### PR TITLE
Fix Cg find for Gentoo amd64

### DIFF
--- a/cmake/FindCg.cmake
+++ b/cmake/FindCg.cmake
@@ -52,6 +52,7 @@ else(WIN32) # Unix based OS
 				 /usr/include
 				 /usr/local/lib
 				 /opt/nvidia-cg-toolkit/lib	
+				 /opt/nvidia-cg-toolkit/lib32
 				 DOC "Path to the Cg library.")
 
 	# Cg GL library
@@ -59,6 +60,7 @@ else(WIN32) # Unix based OS
 				 /usr/include
 				 /usr/local/lib
 				 /opt/nvidia-cg-toolkit/lib
+				 /opt/nvidia-cg-toolkit/lib32
 				 DOC "Path to the CgGL library.")
 
 	set(CG_LIBRARIES ${CG_LIBRARY} ${CG_GL_LIBRARY})


### PR DESCRIPTION
Gentoo amd64 installs 32 bit Cg libraries to /opt/nvidia-cg-toolkit/lib32
This trivial change allow cmake to find 32 bit Cg libs
