### PR TITLE
Dev9 plugin - prevent null dereference if no device is set

### DIFF
--- a/plugins/dev9ghzdrk/Win32/Win32.cpp
+++ b/plugins/dev9ghzdrk/Win32/Win32.cpp
@@ -171,8 +171,13 @@ s32  _DEV9open()
 	//ResumeThread (handleDEV9Thread);
 	NetAdapter* na=GetNetAdapter();
 	if (!na)
+	{
 		emu_printf("Failed to GetNetAdapter()\n");
-	InitNet( na);
+	}
+	else
+	{
+		InitNet(na);
+	}
 	return 0;
 }
 

--- a/plugins/dev9ghzdrk/Win32/net.cpp
+++ b/plugins/dev9ghzdrk/Win32/net.cpp
@@ -57,10 +57,13 @@ void InitNet(NetAdapter* ad)
 }
 void TermNet()
 {
-	RxRunning=false;
-	emu_printf("Waiting for RX-net thread to terminate..");
-	WaitForSingleObject(rx_thread,-1);
-	emu_printf(".done\n");
+	if(RxRunning)
+	{
+		RxRunning = false;
+		emu_printf("Waiting for RX-net thread to terminate..");
+		WaitForSingleObject(rx_thread, -1);
+		emu_printf(".done\n");
 
-	delete nif;
+		delete nif;
+	}
 }


### PR DESCRIPTION
The out of the box settings for pcsx2 is to enable the Ghz Dev9 plugin. This by itself isn't an issue but if you don't manually go into the settings dialog and select a network device then the whole emulator crashes when starting a game (`0` is passed to `InitNet` and then `NetAdapter* nif` is set to 0 which is dereferenced in `NetRxThread`)
