### PR TITLE
Fixing DEV9 Adapter Detection

### DIFF
--- a/plugins/dev9ghzdrk/DEV9.cpp
+++ b/plugins/dev9ghzdrk/DEV9.cpp
@@ -183,7 +183,6 @@ void CALLBACK DEV9shutdown() {
 #endif
 }
 
-bool tx_p_first;
 s32 CALLBACK DEV9open(void *pDsp) 
 {
 	DEV9_LOG("DEV9open\n");
@@ -191,8 +190,6 @@ s32 CALLBACK DEV9open(void *pDsp)
 	DEV9_LOG("open r+: %s\n", config.Hdd);
 	config.HddSize = 8*1024;
 	
-	tx_p_first=false; // reset stack init hack so it works on game reboots 
-
 	iopPC = (u32*)pDsp;
 	
 #ifdef ENABLE_ATA


### PR DESCRIPTION
Fixes DEV9 adapter detection on ELF reload and makes dirty workarounds like the GT4 fix unnecessary.
Other games I can confirm working properly online thanks to this patch are: .hack//frägment (although it requires to be hooked up to my private server at coldbird.net because the real server went offline 2007).
