### PR TITLE
Corrected MGS3 comment, because OCD also new CRC

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -82,14 +82,14 @@ CRC::Game CRC::m_games[] =
 	{0x79ED26AD, MetalGearSolid3, EU, 0},
 	{0x5E31EA42, MetalGearSolid3, EU, 0},
 	{0xD7ED797D, MetalGearSolid3, EU, 0},
-	{0x053D2239, MetalGearSolid3, US, 0}, //Metal Gear Solid 3 Subsistence  disc1
-	{0x01B2FA7F, MetalGearSolid3, US  0}, //Metal Gear Solid 3 Subsistence  disc1
+	{0x053D2239, MetalGearSolid3, US, 0}, //Metal Gear Solid 3 Subsistence disc1
+	{0x01B2FA7F, MetalGearSolid3, US  0}, //Metal Gear Solid 3 Subsistence disc2
 	{0xAA31B5BF, MetalGearSolid3, US, 0},
-	{0x86BC3040, MetalGearSolid3, US, 0}, //Metal Gear Solid 3 Subsistence  disc1
+	{0x86BC3040, MetalGearSolid3, US, 0}, //Metal Gear Solid 3 Subsistence disc1
 	{0x0481AD8A, MetalGearSolid3, JP, 0},
 	{0xC69ACB6F, MetalGearSolid3, KO, 0}, //Metal Gear Solid 3 Snake Eater
-	{0xB0D195EF, MetalGearSolid3, KO, 0}, //Metal Gear Solid 3 Subsistence  disc1
-	{0x3EBABC9C, MetalGearSolid3, KO, 0}, //Metal Gear Solid 3 Subsistence  disc2
+	{0xB0D195EF, MetalGearSolid3, KO, 0}, //Metal Gear Solid 3 Subsistence disc1
+	{0x3EBABC9C, MetalGearSolid3, KO, 0}, //Metal Gear Solid 3 Subsistence disc2
 	{0x8A5C25A7, MetalGearSolid3, ES, 0}, //Metal Gear Solid 3 Subsistence Spanish version
 	{0x278722BF, DBZBT2, US, 0},
 	{0xFE961D28, DBZBT2, US, 0},


### PR DESCRIPTION
There is no such thing as MGS3 Substance only Subsistence. Substance is MGS2 :P
Also this new CRC is US Disc 2 of Subsistence. The blue stripes should be fixed now I guess.
