### PR TITLE
Remove -march argument on x86_64 build option.

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -85,7 +85,7 @@ if(_ARCH_64 AND 64BIT_BUILD)
         set(CMAKE_LIBRARY_ARCHITECTURE "x86_64-linux-gnu")
     endif()
 
-    set(ARCH_FLAG "-m64 -msse -msse2 -march=pentium4")
+    set(ARCH_FLAG "-m64 -msse -msse2")
 	add_definitions(-D_ARCH_64=1)
 else()
     message("Compiling 32bit build on 32/64bit architecture")


### PR DESCRIPTION
GCC doesn't support pentium4 as a arch target for x86_64. It complains that the architecture doesn't support x86_64
Which to be fair the first few models didn't support 64bit.
Just remove the architecture setting since there isn't a need for it.
