### PR TITLE
Minor changes to cdvdGigaherz

### DIFF
--- a/plugins/cdvdGigaherz/src/TocStuff.cpp
+++ b/plugins/cdvdGigaherz/src/TocStuff.cpp
@@ -136,7 +136,7 @@ s32 cdvdParseTOC()
 
 					if((cdtoc.Descriptors[i].Control&4)==0)
 					{
-						tracks[tn].type = 1;
+						tracks[tn].type = CDVD_AUDIO_TRACK;
 					}
 					else if((cdtoc.Descriptors[i].Control&0xE)==4)
 					{


### PR DESCRIPTION
Just some minor changes for readability.

Also, I'd like to point out line 143 and 147 of TocStuff.cpp. They both assign `CDVD_MODE1_TRACK`. I believe one of them should have originally been `CDVD_MODE2_TRACK`. Though I'm not sure which one, which is why I have left it for now.
