### PR TITLE
Fixes interlockedbittestandreset/set in intrin_x86.h

### DIFF
--- a/common/include/intrin_x86.h
+++ b/common/include/intrin_x86.h
@@ -435,14 +435,14 @@ static __inline__ __attribute__((always_inline)) long _InterlockedIncrement(vola
 static __inline__ __attribute__((always_inline)) unsigned char _interlockedbittestandreset(volatile long * a, const long b)
 {
 	unsigned char retval;
-	__asm__("lock; btrl %[b], %[a]; setb %b[retval]" : [retval] "=r" (retval), [a] "=m" (a) : [b] "Ir" (b) : "memory");
+	__asm__("lock; btrl %k[b], %[a]; setb %b[retval]" : [retval] "=r" (retval), [a] "+m" (*a) : [b] "Ir" (b) : "memory");
 	return retval;
 }
 
 static __inline__ __attribute__((always_inline)) unsigned char _interlockedbittestandset(volatile long * a, const long b)
 {
 	unsigned char retval;
-	__asm__("lock; btsl %[b], %[a]; setc %b[retval]" : [retval] "=r" (retval), [a] "=m" (a) : [b] "Ir" (b) : "memory");
+	__asm__("lock; btsl %k[b], %[a]; setc %b[retval]" : [retval] "=r" (retval), [a] "+m" (*a) : [b] "Ir" (b) : "memory");
 	return retval;
 }
 

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -371,7 +371,6 @@ struct aligned_free_second {template<class T> void operator()(T& p) {_aligned_fr
 	#endif
 
 	// http://svn.reactos.org/svn/reactos/trunk/reactos/include/crt/mingw32/intrin_x86.h?view=markup
-	// - the other intrin_x86.h of pcsx2 is not up to date, its _interlockedbittestandreset simply does not work.
 
 	__forceinline unsigned char _BitScanForward(unsigned long* const Index, const unsigned long Mask)
 	{
@@ -384,7 +383,7 @@ struct aligned_free_second {template<class T> void operator()(T& p) {_aligned_fr
 	{
 		unsigned char retval;
 		
-		__asm__("lock; btrl %[b], %[a]; setb %b[retval]" : [retval] "=q" (retval), [a] "+m" (*a) : [b] "Ir" (b) : "memory");
+		__asm__("lock; btrl %k[b], %[a]; setb %b[retval]" : [retval] "=q" (retval), [a] "+m" (*a) : [b] "Ir" (b) : "memory");
 		
 		return retval;
 	}
@@ -393,7 +392,7 @@ struct aligned_free_second {template<class T> void operator()(T& p) {_aligned_fr
 	{
 		unsigned char retval;
 		
-		__asm__("lock; btsl %[b], %[a]; setc %b[retval]" : [retval] "=q" (retval), [a] "+m" (*a) : [b] "Ir" (b) : "memory");
+		__asm__("lock; btsl %k[b], %[a]; setc %b[retval]" : [retval] "=q" (retval), [a] "+m" (*a) : [b] "Ir" (b) : "memory");
 		
 		return retval;
 	}


### PR DESCRIPTION
This doesn't update the file to the latest version from mingw32 since this is already a custom header stripped from mingw32.

This also fixes the functions for x86_64(verified that it still works for both architectures) and also updates the version inside of GSdx.
Also removes a comment in the GSdx header saying that these functions are broken since they no longer are.

A question, why does GSdx duplicate all this code when it is already available in the common includes?
