### PR TITLE
Don't compile the x86_32 only memcpy/memcmp functions.

### DIFF
--- a/common/include/Utilities/MemcpyFast.h
+++ b/common/include/Utilities/MemcpyFast.h
@@ -15,39 +15,52 @@
 
 #pragma once
 
-#ifdef __linux__
-
-#	include "lnx_memzero.h"
-
-	extern "C" void __fastcall memcpy_amd_(void *dest, const void *src, size_t bytes);
-	extern "C" u8 memcmp_mmx(const void* src1, const void* src2, int cmpsize);
-	extern "C" void memxor_mmx(void* dst, const void* src1, int cmpsize);
-	extern void memcpy_amd_qwc(void *dest, const void *src, size_t bytes);
-
+#ifdef _WIN32
+#include "win_memzero.h"
 #else
-
-#	include "win_memzero.h"
-
-	extern void __fastcall memcpy_amd_(void *dest, const void *src, size_t bytes);
-	extern void memcpy_amd_qwc(void *dest, const void *src, size_t bytes);
-	extern u8 memcmp_mmx(const void* src1, const void* src2, int cmpsize);
-	extern void memxor_mmx(void* dst, const void* src1, int cmpsize);
-
+#include "lnx_memzero.h"
 #endif
 
 // Only used in the Windows version of memzero.h. But it's in Misc.cpp for some reason.
 void _memset16_unaligned( void* dest, u16 data, size_t size );
 
+#ifdef _M_X86_32
+
+#ifdef _WIN32
+	extern void __fastcall memcpy_amd_(void *dest, const void *src, size_t bytes);
+	extern void memcpy_amd_qwc(void *dest, const void *src, size_t bytes);
+	extern u8 memcmp_mmx(const void* src1, const void* src2, int cmpsize);
+	extern void memxor_mmx(void* dst, const void* src1, int cmpsize);
+#else
+	extern "C" void __fastcall memcpy_amd_(void *dest, const void *src, size_t bytes);
+	extern "C" u8 memcmp_mmx(const void* src1, const void* src2, int cmpsize);
+	extern "C" void memxor_mmx(void* dst, const void* src1, int cmpsize);
+	extern void memcpy_amd_qwc(void *dest, const void *src, size_t bytes);
+#endif
+
 // MemcpyVibes.cpp functions
 extern void memcpy_vibes(void * dest, const void * src, int size);
 extern void gen_memcpy_vibes();
 
-#define memcpy_fast				memcpy_amd_  // Fast memcpy
-#define memcpy_aligned(d,s,c)	memcpy_amd_(d,s,c)	// Memcpy with 16-byte Aligned addresses
-#define memcpy_const			memcpy_amd_	 // Memcpy with constant size
-#define memcpy_constA			memcpy_amd_  // Memcpy with constant size and 16-byte aligned
-#define memcpy_qwc_				memcpy_vibes // Memcpy in aligned qwc increments, with 0x400 qwc or less
-#define memcpy_qwc(d,s,c)		memcpy_amd_qwc(d,s,c)
+#define memcpy_fast           memcpy_amd_  // Fast memcpy
+#define memcpy_aligned(d,s,c) memcpy_amd_(d,s,c)	// Memcpy with 16-byte Aligned addresses
+#define memcpy_const          memcpy_amd_	 // Memcpy with constant size
+#define memcpy_constA         memcpy_amd_  // Memcpy with constant size and 16-byte aligned
+#define memcpy_qwc_           memcpy_vibes // Memcpy in aligned qwc increments, with 0x400 qwc or less
+#define memcpy_qwc(d,s,c)     memcpy_amd_qwc(d,s,c)
 
 // Useful alternative if we think memcpy_amd_qwc is buggy
-//#define memcpy_qwc(d,s,c)		memcpy_amd_(d,s,c*16)
+//#define memcpy_qwc(d,s,c)     memcpy_amd_(d,s,c*16)
+#else
+
+#define memcpy_amd_           memcpy
+#define memcmp_mmx            memcmp
+#define memcpy_amd_qwc        memcpy
+
+#define memcpy_fast           memcpy
+#define memcpy_aligned(d,s,c) memcpy(d,s,c)
+#define memcpy_const          memcpy
+#define memcpy_constA         memcpy
+#define memcpy_qwc_           memcpy
+#define memcpy_qwc(d,s,c)     memcpy(d,s,(c)*16)
+#endif

--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -116,13 +116,7 @@ set(UtilitiesSources
 	wxAppWithHelpers.cpp
 	wxGuiTools.cpp
 	wxHelpers.cpp
-	x86/MemcpyVibes.cpp
-#	x86/MemcpyFast.cpp
 	)
-
-# collect .S files
-set(UtilitiesSSources
-	x86/MemcpyFast.S)
 
 # variable with all headers of this library
 set(UtilitiesHeaders
@@ -158,6 +152,15 @@ set(UtilitiesHeaders
 	../../include/Utilities/wxBaseTools.h
 	../../include/Utilities/wxGuiTools.h
 	PrecompiledHeader.h)
+
+if (_M_X86_32)
+	set(UtilitiesSources ${UtilitiesSources}
+	    x86/MemcpyVibes.cpp)
+
+	# collect .S files
+	set(UtilitiesSSources
+	    x86/MemcpyFast.S)
+endif()
 
 include_directories(.)
 


### PR DESCRIPTION
These optimized codepaths only work on x86_32, use the ones provided by the toolchain since it should be good enough.

Re-arranges a #ifdef **LINUX** in MemcpyFast.h since **LINUX** is much more restricting than _WIN32.
__LINUX__ isn't defined when building on FreeBSD for example. Not a supported platform, but make easy decisions now.

This requires PR #109 & #128 to be merged first.
