### PR TITLE
GSDX: Replace an FLT_MAX with the appropriate ULONG_MAX

### DIFF
--- a/plugins/GSdx/GSTextureFX9.cpp
+++ b/plugins/GSdx/GSTextureFX9.cpp
@@ -220,7 +220,7 @@ void GSDevice9::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSel
 			ss->AddressU = ssel.tau ? D3DTADDRESS_WRAP : D3DTADDRESS_CLAMP;
 			ss->AddressV = ssel.tav ? D3DTADDRESS_WRAP : D3DTADDRESS_CLAMP;
 			ss->MaxAnisotropy = theApp.GetConfig("MaxAnisotropy", 0);
-			ss->MaxLOD = FLT_MAX;
+			ss->MaxLOD = ULONG_MAX;
 
 
 			m_ps_ss[ssel] = ss;


### PR DESCRIPTION
MaxLOD is a `DWORD` (`unsigned long`) in GSTextureFX9. This should be `ULONG_MAX`, FLT_MAX becomes the same value anyway, but is less indicative.
