### PR TITLE
Fix NOT32M function declaration.

### DIFF
--- a/common/include/x86emitter/legacy_instructions.h
+++ b/common/include/x86emitter/legacy_instructions.h
@@ -442,7 +442,7 @@ extern void AND8RtoR( x86IntRegType to, x86IntRegType from );
 // not r32
 extern void NOT32R( x86IntRegType from );
 // not m32
-extern void NOT32M( u32 from );
+extern void NOT32M( uptr from );
 // neg r32
 extern void NEG32R( x86IntRegType from );
 // neg m32


### PR DESCRIPTION
Use uptr as the argument since it is either u32 or u64 depending on architecture.
