### PR TITLE
Change the x86emitter jmp emitter from using s32 to sptr.

### DIFF
--- a/common/src/x86emitter/jmp.cpp
+++ b/common/src/x86emitter/jmp.cpp
@@ -126,7 +126,12 @@ __emitinline void xJccKnownTarget( JccComparisonType comparison, const void* tar
 	{
 		// Perform a 32 bit jump instead. :(
 		s32* bah = xJcc32( comparison );
-		*bah = (s32)target - (s32)xGetPtr();
+		sptr distance = (sptr)target - (sptr)xGetPtr();
+
+		// This assert won't physically happen on x86 targets
+		pxAssertDev(distance >= -0x80000000LL && distance < 0x80000000LL, "Jump target is too far away, needs an indirect register");
+
+		*bah = (s32)distance;
 	}
 }
 


### PR DESCRIPTION
This doesn't change anything on x86_32, but it is required on x86_64 so we don't lose precision.
Also adds an assert to see if the distance is greater than the maximum 32bit jump, which can't be hit on x86_32, but can be on x86_64.
