### PR TITLE
Let non-x86_32 use the reference yuv2rgb conversion function.

### DIFF
--- a/pcsx2/IPU/yuv2rgb.cpp
+++ b/pcsx2/IPU/yuv2rgb.cpp
@@ -58,6 +58,7 @@ void yuv2rgb_reference(void)
 		}
 }
 
+#ifdef _M_X86_32
 // Everything below is bit accurate to the IPU specification (except maybe rounding).
 // Know the specification before you touch it.
 #define SSE_BYTES(x) {x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x}
@@ -403,3 +404,4 @@ ihatemsvc:
 #	error Unsupported compiler
 #endif
 }
+#endif

--- a/pcsx2/IPU/yuv2rgb.h
+++ b/pcsx2/IPU/yuv2rgb.h
@@ -15,7 +15,10 @@
 
 #pragma once
 
-#define yuv2rgb yuv2rgb_sse2
-
 extern void yuv2rgb_reference();
+#ifdef _M_X86_32
+#define yuv2rgb yuv2rgb_sse2
 extern void yuv2rgb_sse2();
+#else
+#define yuv2rgb yuv2rgb_reference
+#endif


### PR DESCRIPTION
The yuv2rgb_sse2 implementation is x86_32 only, so x86_64 can't take advantage of this optimized code path.

This requires the architecture defines to be working fully, so this can't be merged until it is fixed on the Windows side of things.
