### PR TITLE
Disable superVU entry and exit on !x86_32.

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -606,9 +606,11 @@ set(pcsx2AsmFiles
 	IPU/yuv2rgb.asm
 	x86/ix86-32/aVif_proc-32.asm)
 
-# collect .S files
-set(pcsx2SSources
-	x86/aVUzerorec.S)
+if (_M_X86_32)
+	# collect .S files
+	set(pcsx2SSources
+	    x86/aVUzerorec.S)
+endif()
 
 # change language of .S-files to c++
 set_source_files_properties(${pcsx2SSources} PROPERTIES LANGUAGE CXX)

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -2550,6 +2550,7 @@ void SuperVUCleanupProgram(u32 startpc, int vuindex)
 	// _initX86regs();
 }
 
+#ifdef _M_X86_32
 #if defined(_MSC_VER)
 
 // entry point of all vu programs from emulator calls
@@ -2607,6 +2608,19 @@ __declspec(naked) static void SuperVUEndProgram()
 		jmp s_callstack // so returns correctly
 	}
 }
+#endif
+
+#else
+// entry point of all vu programs from emulator calls
+void SuperVUExecuteProgram(u32 startpc, int vuindex)
+{
+}
+
+// exit point of all vu programs
+void SuperVUEndProgram()
+{
+}
+
 
 #endif
 


### PR DESCRIPTION
The assembly for this is x86_32 only so it won't work on anything else.
Disable it forcefully for now, in the future there should be a generic interpreter style fallback in place.
That will require some restructuring that isn't yet possible to do.

This requires the architecture defines to be working fully, so this can't be merged until it is fixed on the Windows side of things.
