### PR TITLE
Allow hotplugging XInput devices in LilyPad

### DIFF
--- a/plugins/LilyPad/XInput.cpp
+++ b/plugins/LilyPad/XInput.cpp
@@ -212,11 +212,8 @@ void EnumXInputDevices() {
 	}
 	pXInputEnable(1);
 	for (i=0; i<4; i++) {
-		XINPUT_STATE state;
-		if (ERROR_SUCCESS == pXInputGetState(i, &state)) {
-			wsprintfW(temp, L"XInput Pad %i", i);
-			dm->AddDevice(new XInputDevice(i, temp));
-		}
+		wsprintfW(temp, L"XInput Pad %i", i);
+		dm->AddDevice(new XInputDevice(i, temp));
 	}
 	pXInputEnable(0);
 }


### PR DESCRIPTION
It's pretty standard to allow XInput devices to be turned on and off at any time. More or less all games natively supporting it allow that, so it just feels natural to provide a similar experience.
I guess this creates a tiny bit of overhead? It shouldn't be significant though.
