### PR TITLE
Check for alignment when accessing memory with the debugger

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -206,22 +206,31 @@ bool DebugInterface::parseExpression(PostfixExpression& exp, u64& dest)
 
 u32 R5900DebugInterface::read8(u32 address)
 {
+	if (!isValidAddress(address))
+		return -1;
+
 	return memRead8(address);
 }
 
 u32 R5900DebugInterface::read16(u32 address)
 {
+	if (!isValidAddress(address) || address % 2)
+		return -1;
+
 	return memRead16(address);
 }
 
 u32 R5900DebugInterface::read32(u32 address)
 {
+	if (!isValidAddress(address) || address % 4)
+		return -1;
+
 	return memRead32(address);
 }
 
 u64 R5900DebugInterface::read64(u32 address)
 {
-	if (!isValidAddress(address))
+	if (!isValidAddress(address) || address % 8)
 		return -1;
 
 	u64 result;
@@ -231,10 +240,13 @@ u64 R5900DebugInterface::read64(u32 address)
 
 u128 R5900DebugInterface::read128(u32 address)
 {
-	if (!isValidAddress(address))
-		return u128::From32(-1);
-
 	__aligned16 u128 result;
+	if (!isValidAddress(address) || address % 16)
+	{
+		result.hi = result.lo = -1;
+		return result;
+	}
+
 	memRead128(address,result);
 	return result;
 }

--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -317,26 +317,35 @@ namespace MIPSAnalyst
 			size = 2;
 			break;
 		case 0x23:		// lw
-		case 0x26:		// lwr
 		case 0x2B:		// sw
+			size = 4;
+			break;
+		case 0x26:		// lwr
 		case 0x2E:		// swr
 			size = 4;
+			info.lrType = LOADSTORE_RIGHT; 
 			break;
 		case 0x22:		// lwl
 		case 0x2A:		// swl
 			size = 4;
 			off = -3;
+			info.lrType = LOADSTORE_LEFT; 
 			break;
 		case 0x37:		// ld
-		case 0x1B:		// ldr
 		case 0x3F:		// sd
+			size = 8;
+			break;
+		case 0x1B:		// ldr
 		case 0x2D:		// sdr
 			size = 8;
+			info.lrType = LOADSTORE_RIGHT; 
 			break;
 		case 0x1A:		// ldl
 		case 0x2C:		// sdl
 			size = 8;
 			off = -7;
+			info.lrType = LOADSTORE_LEFT;
+			break;
 		case 0x1E:		// lq
 		case 0x1F:		// sq
 			size = 16;

--- a/pcsx2/DebugTools/MIPSAnalyst.h
+++ b/pcsx2/DebugTools/MIPSAnalyst.h
@@ -41,6 +41,8 @@ namespace MIPSAnalyst
 
 	void ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols);
 
+	enum LoadStoreLRType { LOADSTORE_NORMAL, LOADSTORE_LEFT, LOADSTORE_RIGHT };
+
 	typedef struct {
 		DebugInterface* cpu;
 		u32 opcodeAddress;
@@ -61,6 +63,7 @@ namespace MIPSAnalyst
 
 		// data access
 		bool isDataAccess;
+		LoadStoreLRType lrType;
 		int dataSize;
 		u32 dataAddress;
 


### PR DESCRIPTION
Re-adds the valid address checks I accidently removed, too.
