### PR TITLE
Avoid leaking `romdir` file handle

### DIFF
--- a/fps2bios/romdir.c
+++ b/fps2bios/romdir.c
@@ -38,6 +38,8 @@ int main(int argc, char *argv[]) {
 
 	extinfo = fopen("EXTINFO", "wb");
 	if (extinfo == NULL) {
+		/* Don't leak the opened romdir */
+		fclose(romdir);
 		printf("failed to create EXTINFO\n");
 		return 1;
 	}


### PR DESCRIPTION
If there is an error opening `extinfo`, the `rominfo` file handle isn't closed.
