### PR TITLE
Fix a couple issues in the x86emitter on x86_64.

### DIFF
--- a/common/include/x86emitter/x86types.h
+++ b/common/include/x86emitter/x86types.h
@@ -675,10 +675,10 @@ template< typename T > void xWrite( T val );
 	class xIndirectVoid : public OperandSizedObject
 	{
 	public:
-		xAddressReg		Base;			// base register (no scale)
-		xAddressReg		Index;			// index reg gets multiplied by the scale
-		uint			Scale;			// scale applied to the index register, in scale/shift form
-		s32				Displacement;	// offset applied to the Base/Index registers.
+		xAddressReg Base;         // base register (no scale)
+		xAddressReg Index;        // index reg gets multiplied by the scale
+		uint        Scale;        // scale applied to the index register, in scale/shift form
+		sptr        Displacement; // offset applied to the Base/Index registers.
 
 	public:
 		explicit xIndirectVoid( s32 disp );


### PR DESCRIPTION
This won't fix the billions of errors that will happen at runtime of using the x86 emitter, but chooses to make some better coding practice choices
that enables it to compile on x86_64.

in the xIndirectVoid class, instead of using s32 for the offset, use sptr which will be 32bit or 64bit depending on architecture.
This also fixes a few alignment issues in xAddressVoid's constructors.

In EmitSibMagic we are casting a void\* to s32, which won't work on x86_64, so first do a cast from sptr to s32.
Won't work on x86_64, but gets us compiling.
