### PR TITLE
Removes the usage of __LINUX__ define

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -41,7 +41,7 @@
  * Since this is still beta things may change.
 
  * OSflags:
-	__LINUX__ (linux OS)
+	__linux__ (linux OS)
 	_WIN32 (win32 OS)
 
  * common return values (for ie. GSinit):

--- a/common/include/PS2Eext.h
+++ b/common/include/PS2Eext.h
@@ -161,7 +161,7 @@ struct PluginConf
     }
 };
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 static void SysMessage(const char *fmt, ...)
 {

--- a/common/include/Pcsx2Defs.h
+++ b/common/include/Pcsx2Defs.h
@@ -19,11 +19,8 @@
 // Indicate that this is the wx port to the plugins.
 #define WX_PCSX2
 
-// some distributions are lower case
-#if defined (__linux__) || defined(__CYGWIN__)
-#if !defined(__LINUX__)
-#	define __LINUX__
-#endif
+#ifdef __CYGWIN__
+#define __linux__
 #endif
 
 #include "Pcsx2Types.h"
@@ -77,7 +74,7 @@ extern "C" unsigned __int64 __xgetbv(int);
 //  restaints must be enforced).
 //
 #ifndef C_ASSERT
-	#ifdef __LINUX__
+	#ifdef __linux__
 	#	define C_ASSERT(e) static_assert(e, "this is a nice message to explain the failure ;)")
 	#else
 	#	define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]

--- a/common/include/Pcsx2Types.h
+++ b/common/include/Pcsx2Types.h
@@ -50,7 +50,7 @@ typedef unsigned int uint;
 
 #else // _MSC_VER*/
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #ifdef HAVE_STDINT_H
 #include "stdint.h"
@@ -96,10 +96,10 @@ typedef union _LARGE_INTEGER
 	long long QuadPart;
 } LARGE_INTEGER;
 
-#endif // __LINUX__
+#endif // __linux__
 #endif //_MSC_VER
 
-#if !defined(__LINUX__) || !defined(HAVE_STDINT_H)
+#if !defined(__linux__) || !defined(HAVE_STDINT_H)
 #if defined(__x86_64__)
 typedef u64 uptr;
 typedef s64 sptr;

--- a/common/include/Utilities/MemcpyFast.h
+++ b/common/include/Utilities/MemcpyFast.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #	include "lnx_memzero.h"
 

--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -332,7 +332,7 @@ protected:
 	uint _calcBlockBitArrayLength() const;
 };
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #	define PCSX2_PAGEFAULT_PROTECT
 #	define PCSX2_PAGEFAULT_EXCEPT

--- a/common/include/Utilities/Threading.h
+++ b/common/include/Utilities/Threading.h
@@ -408,7 +408,7 @@ namespace Threading
 		ScopedLock m_lock;
 		volatile __aligned(4) bool& m_bool;
 
-#ifdef __LINUX__
+#ifdef __linux__
 		ScopedLockBool(Mutex& mutexToLock, volatile bool& isLockedBool)
 #else
 		ScopedLockBool(Mutex& mutexToLock, volatile __aligned(4) bool& isLockedBool)

--- a/common/include/intrin_x86.h
+++ b/common/include/intrin_x86.h
@@ -845,7 +845,7 @@ static __inline__ __attribute__((always_inline)) unsigned long long __xgetbv(uns
 
 // gcc 4.8 define __rdtsc but unfortunately the compiler crash...
 // The redefine allow to skip the gcc __rdtsc version -- Gregory
-#ifdef __LINUX__
+#ifdef __linux__
 static __inline__ __attribute__((always_inline)) unsigned long long __pcsx2__rdtsc(void)
 #else
 static __inline__ __attribute__((always_inline)) unsigned long long __rdtsc(void)
@@ -858,7 +858,7 @@ static __inline__ __attribute__((always_inline)) unsigned long long __rdtsc(void
 
 
 /*** Interrupts ***/
-#ifndef __LINUX__
+#ifndef __linux__
 static __inline__ __attribute__((always_inline)) void __debugbreak(void)
 {
 	__asm__("int $3");

--- a/common/src/Utilities/Console.cpp
+++ b/common/src/Utilities/Console.cpp
@@ -104,7 +104,7 @@ const IConsoleWriter ConsoleWriter_Null =
 //  Console_Stdout
 // --------------------------------------------------------------------------------------
 
-#ifdef __LINUX__
+#ifdef __linux__
 static __fi const wxChar* GetLinuxConsoleColor(ConsoleColors color)
 {
     switch(color)
@@ -165,15 +165,15 @@ static void __concall ConsoleStdout_Newline()
 
 static void __concall ConsoleStdout_DoSetColor( ConsoleColors color )
 {
-#ifdef __LINUX__
+#ifdef __linux__
 	wxPrintf(L"\033[0m");
-    wxPrintf(GetLinuxConsoleColor(color));
+	wxPrintf(GetLinuxConsoleColor(color));
 #endif
 }
 
 static void __concall ConsoleStdout_SetTitle( const wxString& title )
 {
-#ifdef __LINUX__
+#ifdef __linux__
 	wxPrintf(L"\033]0;%s\007", title.c_str());
 #endif
 }

--- a/common/src/Utilities/Linux/LnxThreads.cpp
+++ b/common/src/Utilities/Linux/LnxThreads.cpp
@@ -23,7 +23,7 @@
 // to remove an unneeded dependency.
 //#include "x86emitter/tools.h"
 
-#if !defined(__LINUX__) && !defined(__WXMAC__)
+#if !defined(__linux__) && !defined(__WXMAC__)
 
 #	pragma message( "LnxThreads.cpp should only be compiled by projects or makefiles targeted at Linux/Mac distros.")
 

--- a/common/src/Utilities/ThreadTools.cpp
+++ b/common/src/Utilities/ThreadTools.cpp
@@ -16,7 +16,7 @@
 
 #include "PrecompiledHeader.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #	include <signal.h>		// for pthread_kill, which is in pthread.h on w32-pthreads
 #endif
 

--- a/common/src/Utilities/vssprintf.cpp
+++ b/common/src/Utilities/vssprintf.cpp
@@ -51,7 +51,7 @@
 
 #define is_digit(c) ((c) >= '0' && (c) <= '9')
 
-#ifdef __LINUX__
+#ifdef __linux__
 #define _CVTBUFSIZE (309+40)
 #endif
 

--- a/common/src/Utilities/wxHelpers.cpp
+++ b/common/src/Utilities/wxHelpers.cpp
@@ -19,7 +19,7 @@
 #include "Threading.h"
 #include "IniInterface.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 // I do not know if it is a GCC issue or a bug in wxwidget !
 // Anyway the code isn't used (m_hasContextHelp always false) so I remove
 // it for linux. The 'vtable' issue appears with the include of 
@@ -474,7 +474,7 @@ int pxGetCharHeight( const wxWindow* wind, int rows )
 	if( !wind ) return 0;
 	wxClientDC dc(wx_const_cast(wxWindow*, wind));
 	dc.SetFont( wind->GetFont() );
-#ifdef __LINUX__
+#ifdef __linux__
 	// It seems there is a bad detection of the size of the font (non standard dpi ???). Font are cut in top or bottom.
 	// Add a correction factor to leave enough room. Visualy 1.7 seems fine but feel free to tune it -- Gregory
 	return (dc.GetCharHeight() * 1.7 + 1 ) * rows;

--- a/common/src/Utilities/x86/MemcpyVibes.cpp
+++ b/common/src/Utilities/x86/MemcpyVibes.cpp
@@ -159,7 +159,7 @@ __fi void memcpy_vibes(void * dest, const void * src, int size) {
 
 // Since MemcpyVibes is already in the project, I'll just tuck the Linux version of memcpy_amd_qwc here for the moment,
 // to get around compilation issues with having it in the headers.
-#ifdef __LINUX__
+#ifdef __linux__
 
 	// This can be moved later, but Linux doesn't even compile memcpyFast.cpp, so I figured I'd stick it here for now.
 	// Quadword Copy! Count is in QWCs (128 bits).  Neither source nor dest need to be aligned.

--- a/common/src/x86emitter/cpudetect.cpp
+++ b/common/src/x86emitter/cpudetect.cpp
@@ -25,7 +25,7 @@ __aligned16 x86capabilities x86caps;
 static __pagealigned u8 recSSE[__pagesize];
 static __pagealigned u8 targetFXSAVE[512];
 
-#ifdef __LINUX__
+#ifdef __linux__
 #	include <sys/time.h>
 #	include <errno.h>
 #endif
@@ -104,7 +104,7 @@ s64 x86capabilities::_CPUSpeedHz( u64 time ) const
 
 	do {
 		timeStart = GetCPUTicks();
-#ifdef __LINUX__
+#ifdef __linux__
 		startCycle = __pcsx2__rdtsc();
 #else
 		startCycle = __rdtsc();
@@ -113,7 +113,7 @@ s64 x86capabilities::_CPUSpeedHz( u64 time ) const
 
 	do {
 		timeStop = GetCPUTicks();
-#ifdef __LINUX__
+#ifdef __linux__
 		endCycle = __pcsx2__rdtsc();
 #else
 		endCycle = __rdtsc();

--- a/pcsx2/CDVD/zlib_indexed.h
+++ b/pcsx2/CDVD/zlib_indexed.h
@@ -101,7 +101,7 @@ Comments) 1950 to 1952 in the files http://tools.ietf.org/html/rfc1950
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef __LINUX__
+#ifdef __linux__
 #include <zlib.h>
 #else
 #include <zlib/zlib.h>

--- a/pcsx2/DebugTools/DisR5900asm.cpp
+++ b/pcsx2/DebugTools/DisR5900asm.cpp
@@ -16,7 +16,7 @@
 
 #include "PrecompiledHeader.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include <cstdarg>
 #endif
 

--- a/pcsx2/Gte.cpp
+++ b/pcsx2/Gte.cpp
@@ -229,7 +229,7 @@ __inline void MTC2(unsigned long value, int reg) {
 		} else {
 			psxRegs.CP2D.r[31] = 32;
 		}
-#elif defined(__LINUX__) || defined(__MINGW32__)
+#elif defined(__linux__) || defined(__MINGW32__)
 		if (a > 0) {
 			__asm__ ("bsrl %1, %0\n" : "=r"(a) : "r"(a) );
 			psxRegs.CP2D.r[31] = 31 - a;

--- a/pcsx2/Memory.h
+++ b/pcsx2/Memory.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include <signal.h>
 #endif
 

--- a/pcsx2/NakedAsm.h
+++ b/pcsx2/NakedAsm.h
@@ -17,7 +17,7 @@
 #ifndef NAKED_ASM_H
 #define NAKED_ASM_H
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 extern "C"
 {

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -853,7 +853,7 @@ SysCorePlugins::PluginStatus_t::PluginStatus_t( PluginsEnum_t _pid, const wxStri
 
 	_PS2EgetLibName		GetLibName		= (_PS2EgetLibName)		Lib.GetSymbol( L"PS2EgetLibName" );
 	_PS2EgetLibVersion2	GetLibVersion2	= (_PS2EgetLibVersion2)	Lib.GetSymbol( L"PS2EgetLibVersion2" );
-#ifdef __LINUX__
+#ifdef __linux__
 	_PS2EsetEmuVersion	SetEmuVersion	= NULL;
 #else
 	_PS2EsetEmuVersion	SetEmuVersion	= (_PS2EsetEmuVersion)	Lib.GetSymbol( L"PS2EsetEmuVersion" );
@@ -1188,7 +1188,7 @@ void SysCorePlugins::Open()
 		// If GS doesn't support GSopen2, need to wait until call to GSopen
 		// returns to populate pDsp.  If it does, can initialize other plugins
 		// at same time as GS, as long as GSopen2 does not subclass its window.
-#ifdef __LINUX__
+#ifdef __linux__
 		// On linux, application have also a channel (named display) to communicate with the
 		// Xserver. The safe rule is 1 thread, 1 channel. In our case we use the display in
 		// several places. Save yourself of multithread headache. Wait few seconds the end of 

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -353,7 +353,7 @@ public:
 		return Path::Combine( GetDataDir(), L"Langs" );
 	}
 
-#ifdef __LINUX__
+#ifdef __linux__
 	wxString GetUserLocalDataDir() const
 	{
 		// I got memory corruption inside wxGetEnv when I heavily toggle the GS renderer (F9). It seems wxGetEnv

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -1019,11 +1019,11 @@ void Pcsx2App::ProgramLog_PostEvent( wxEvent& evt )
 
 static void __concall ConsoleToFile_Newline()
 {
-#ifdef __LINUX__
+#ifdef __linux__
 	if ((g_Conf) && (g_Conf->EmuOptions.ConsoleToStdio)) ConsoleWriter_Stdout.Newline();
 #endif
 
-#ifdef __LINUX__
+#ifdef __linux__
 	fputc( '\n', emuLog );
 #else
 	fputs( "\r\n", emuLog );
@@ -1032,7 +1032,7 @@ static void __concall ConsoleToFile_Newline()
 
 static void __concall ConsoleToFile_DoWrite( const wxString& fmt )
 {
-#ifdef __LINUX__
+#ifdef __linux__
 	if ((g_Conf) && (g_Conf->EmuOptions.ConsoleToStdio)) ConsoleWriter_Stdout.WriteRaw(fmt);
 #endif
 

--- a/pcsx2/gui/CpuUsageProvider.cpp
+++ b/pcsx2/gui/CpuUsageProvider.cpp
@@ -18,7 +18,7 @@
 #include "CpuUsageProvider.h"
 #include "System.h"
 
-#ifndef __LINUX__
+#ifndef __linux__
 #include "SysThreads.h"
 #endif
 

--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -75,7 +75,7 @@ GenericListViewColumn breakpointColumns[BPL_COLUMNCOUNT] = {
 BreakpointList::BreakpointList(wxWindow* parent, DebugInterface* _cpu, CtrlDisassemblyView* _disassembly)
 	: wxListView(parent,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxLC_VIRTUAL|wxLC_REPORT|wxLC_SINGLE_SEL|wxNO_BORDER), cpu(_cpu), disasm(_disassembly)
 {
-#ifdef __LINUX__
+#ifdef __linux__
 	// On linux wx failed to resize properly the page. I don't know why so for the moment I just create a static size page
 	// Far from ideal but at least I can use the memory window!
 	this->SetSize(wxSize(1000, 200));

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -206,7 +206,7 @@ void GSPanel::OnMouseEvent( wxMouseEvent& evt )
 		DoShowMouse();
 	}
 
-#ifdef __LINUX__
+#ifdef __linux__
 	// HACK2: In gsopen2 there is one event buffer read by both wx/gui and pad plugin. Wx deletes
 	// the event before the pad see it. So you send key event directly to the pad.
 	if( (PADWriteEvent != NULL) && (GSopen2 != NULL) ) {
@@ -269,7 +269,7 @@ void GSPanel::OnKeyDown( wxKeyEvent& evt )
 	// to the APP level message handler, which in turn routes them right back here -- yes it's
 	// silly, but oh well).
 
-#ifdef __LINUX__
+#ifdef __linux__
 	// HACK2: In gsopen2 there is one event buffer read by both wx/gui and pad plugin. Wx deletes
 	// the event before the pad see it. So you send key event directly to the pad.
 	if( (PADWriteEvent != NULL) && (GSopen2 != NULL) ) {
@@ -325,7 +325,7 @@ void GSPanel::OnFocus( wxFocusEvent& evt )
 	else
 		DoShowMouse();
 
-#ifdef __LINUX__
+#ifdef __linux__
 	// HACK2: In gsopen2 there is one event buffer read by both wx/gui and pad plugin. Wx deletes
 	// the event before the pad see it. So you send key event directly to the pad.
 	if( (PADWriteEvent != NULL) && (GSopen2 != NULL) ) {
@@ -341,7 +341,7 @@ void GSPanel::OnFocusLost( wxFocusEvent& evt )
 	evt.Skip();
 	m_HasFocus = false;
 	DoShowMouse();
-#ifdef __LINUX__
+#ifdef __linux__
 	// HACK2: In gsopen2 there is one event buffer read by both wx/gui and pad plugin. Wx deletes
 	// the event before the pad see it. So you send key event directly to the pad.
 	if( (PADWriteEvent != NULL) && (GSopen2 != NULL) ) {
@@ -527,7 +527,7 @@ GSPanel* GSFrame::GetViewport()
 
 void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 {
-#ifdef __LINUX__
+#ifdef __linux__
 	// Important Linux note: When the title is set in fullscreen the window is redrawn. Unfortunately
 	// an intermediate white screen appears too which leads to a very annoying flickering.
 	if (IsFullScreen()) return;

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -490,7 +490,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	// ------------------------------------------------------------------------
 
 	m_menuMisc.Append( &m_MenuItem_Console );
-#ifdef __LINUX__
+#ifdef __linux__
 	m_menuMisc.Append( &m_MenuItem_Console_Stdio );
 #endif
 	//Todo: Though not many people need this one :p
@@ -681,7 +681,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 		menubar.Check( MenuId_EnableCheats,  configToApply.EmuOptions.EnableCheats );
 		menubar.Check( MenuId_EnableWideScreenPatches,  configToApply.EmuOptions.EnableWideScreenPatches );
 		menubar.Check( MenuId_EnableHostFs,  configToApply.EmuOptions.HostFs );
-#ifdef __LINUX__
+#ifdef __linux__
 		menubar.Check( MenuId_Console_Stdio, configToApply.EmuOptions.ConsoleToStdio );
 #endif
 

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -252,7 +252,7 @@ protected:
 
 public:
 	McdDataObject(int viewIndex = -1)
-#ifdef __LINUX__
+#ifdef __linux__
 		// XXX: On linux drag and drop doesn't work. I think wxDF_PRIVATE is a MS extension.
 		// Besides it will raise on assertion on wx3.0.
 		//

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -30,7 +30,7 @@
 
 // Allows us to force-disable threading for debugging/troubleshooting
 static const bool DisableThreading =
-#ifdef __LINUX__
+#ifdef __linux__
 	true;		// linux appears to have threading issues with loadlibrary.
 #else
 	false;

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -76,7 +76,7 @@ void RecentIsoManager::OnChangedSelection( wxCommandEvent& evt )
 
 	ScopedCoreThreadPopup stopped_core;
 
-#ifdef __LINUX__
+#ifdef __linux__
 	// Likely not what was intended, but it compiles for the moment...
 	SwapOrReset_Iso( NULL, stopped_core, m_Items[i].Filename, GetMsg_IsoImageChanged());
 #else
@@ -126,7 +126,7 @@ void RecentIsoManager::Repopulate()
 	// wxwidgets deletes the group, but when you start adding radio menu items again, 
 	// it trys to add them to a group that doesn't exist. Since the group doesn't exist, 
 	// it starts a new group, but it also spews a couple warnings about it in Linux.
-#ifdef __LINUX__
+#ifdef __linux__
 	// FIXME is it still useful on v3
 #if wxMAJOR_VERSION >= 3
 	m_Menu->Remove( m_Menu->Append( -1, "dummy" ) );

--- a/pcsx2/gui/i18n.cpp
+++ b/pcsx2/gui/i18n.cpp
@@ -374,7 +374,7 @@ void i18n_SetLanguagePath()
 	// default location for windows
 	wxLocale::AddCatalogLookupPathPrefix( wxGetCwd() );
 	// additional location for linux
-#ifdef __LINUX__
+#ifdef __linux__
 	wxLocale::AddCatalogLookupPathPrefix( PathDefs::GetLangs().ToString() );
 #endif
 

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -380,7 +380,7 @@ static __ri void vtlb_Miss(u32 addr,u32 mode)
 
 	// The exception terminate the program on linux which is very annoying
 	// Just disable it for the moment
-#ifdef __LINUX__
+#ifdef __linux__
 	if (0)
 #else
 	if( IsDevBuild )
@@ -401,7 +401,7 @@ static __ri void vtlb_BusError(u32 addr,u32 mode)
 {
 	// The exception terminate the program on linux which is very annoying
 	// Just disable it for the moment
-#ifdef __LINUX__
+#ifdef __linux__
 	if (0)
 #else
 	if( IsDevBuild )

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -422,7 +422,7 @@ static void iIopDumpBlock( int startpc, u8 * ptr )
 		f.Printf("\n");
 	}
 
-#ifdef __LINUX__
+#ifdef __linux__
 	char command[256];
 	// dump the asm
 	{

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -184,7 +184,7 @@ typedef Fntype_mVUrecInst* Fnptr_mVUrecInst;
 //------------------------------------------------------------------
 // Define mVUquickSearch
 //------------------------------------------------------------------
-#ifndef __LINUX__
+#ifndef __linux__
 extern __pagealigned u8 mVUsearchXMM[__pagesize];
 typedef u32 (__fastcall *mVUCall)(void*, void*);
 #define mVUquickSearch(dest, src, size) ((((mVUCall)((void*)mVUsearchXMM))(dest, src)) == 0xf)

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -664,7 +664,7 @@ void SuperVUDumpBlock(list<VuBaseBlock*>& blocks, int vuindex)
 		}
 
 //
-#if 0	// __LINUX__
+#if 0	// __linux__
 
 		// dump the asm
 		if ((*itblock)->pcode != NULL)
@@ -904,7 +904,7 @@ static VuFunctionHeader* SuperVURecompileProgram(u32 startpc, int vuindex)
 		s_pFnHeader->ranges.push_back(r);
 	}
 
-#if defined(PCSX2_DEBUG) && defined(__LINUX__)
+#if defined(PCSX2_DEBUG) && defined(__linux__)
 	// dump at the end to capture the actual code
 	if ((s_vu && (vudump&1)) || (!s_vu && (vudump&16))) SuperVUDumpBlock(s_listBlocks, s_vu);
 #endif

--- a/pcsx2/x86/sVU_zerorec.h
+++ b/pcsx2/x86/sVU_zerorec.h
@@ -20,13 +20,13 @@
 #include "sVU_Micro.h"
 
 //Using assembly code from an external file.
-#ifdef __LINUX__
+#ifdef __linux__
 extern "C" {
 #endif
 extern void SuperVUExecuteProgram(u32 startpc, int vuindex);
 extern void SuperVUEndProgram();
 extern void svudispfntemp();
-#ifdef __LINUX__
+#ifdef __linux__
 }
 #endif
 

--- a/plugins/CDVDiso/src/Linux/Makefile
+++ b/plugins/CDVDiso/src/Linux/Makefile
@@ -4,7 +4,7 @@ CC = gcc
 PLUGIN = libCDVDiso.so
 CFG = cfgCDVDiso
 MKISO = mkiso
-CFLAGS = -fPIC -Wall -g  -I.. -I. -D__LINUX__ -D_FILE_OFFSET_BITS=64 -Wextra
+CFLAGS = -fPIC -Wall -g  -I.. -I. -D_FILE_OFFSET_BITS=64 -Wextra
 OBJS = ../CDVDisop.o Config.o Linux.o ../libiso.o
 CFGOBJS = conf.o interface.o support.o ${OBJS}
 LIBS = -lz -lbz2 -lstdc++

--- a/plugins/CDVDisoEFP/src/Linux/CD.h
+++ b/plugins/CDVDisoEFP/src/Linux/CD.h
@@ -20,11 +20,6 @@
 #ifndef __CD_H__
 #define __CD_H__
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "../PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/Linux/CDVDiso.c
+++ b/plugins/CDVDisoEFP/src/Linux/CDVDiso.c
@@ -18,11 +18,6 @@
  *  PCSX2 members can be contacted through their website at www.pcsx2.net.
  */
 #include <stddef.h> // NULL
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "PS2Edefs.h"
 #include "conf.h"

--- a/plugins/CDVDisoEFP/src/Linux/DVD.h
+++ b/plugins/CDVDisoEFP/src/Linux/DVD.h
@@ -20,11 +20,6 @@
 #ifndef __DVD_H__
 #define __DVD_H__
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/Linux/device.h
+++ b/plugins/CDVDisoEFP/src/Linux/device.h
@@ -21,11 +21,6 @@
 #define __DEVICE_H__
 
 #include <time.h> // time_t
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "../PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/Linux/devicebox.c
+++ b/plugins/CDVDisoEFP/src/Linux/devicebox.c
@@ -41,11 +41,6 @@
 #include <gtk/gtkvbox.h> // gtk_vbox_new()
 #include <gtk/gtkwindow.h> // gtk_window_new()
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/PS2Edefs.h
+++ b/plugins/CDVDisoEFP/src/PS2Edefs.h
@@ -14,7 +14,7 @@
  * Since this is still beta things may change.
 
  * OSflags:
-	__LINUX__ (linux OS)
+	__linux__ (linux OS)
 	_WIN32 (win32 OS)
 
  * common return values (for ie. GSinit):
@@ -29,7 +29,7 @@
     GetOpenFileName)
 */
 #include "PS2Etypes.h"
-#ifdef __LINUX__
+#ifdef __linux__
 #define CALLBACK
 #else
 #include <windows.h>

--- a/plugins/CDVDisoEFP/src/PS2Etypes.h
+++ b/plugins/CDVDisoEFP/src/PS2Etypes.h
@@ -5,10 +5,6 @@
 #define ARRAYSIZE(x) (sizeof(x)/sizeof((x)[0]))
 #endif
 
-#if defined (__linux__)  // some distributions are lower case
-#define __LINUX__
-#endif
-
 // Basic types
 #if defined(_MSC_VER)
 typedef __int8  s8;
@@ -39,7 +35,7 @@ typedef u64 uptr;
 #else
 typedef u32 uptr;
 #endif
-#ifdef __LINUX__
+#ifdef __linux__
 typedef union _LARGE_INTEGER
 {
 	long long QuadPart;

--- a/plugins/CDVDisoEFP/src/ecma119.c
+++ b/plugins/CDVDisoEFP/src/ecma119.c
@@ -21,12 +21,6 @@
 
 #include <stddef.h>
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/ecma119.h
+++ b/plugins/CDVDisoEFP/src/ecma119.h
@@ -21,12 +21,6 @@
 #ifndef ECMA119_H
 #define ECMA119_H
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/imagetype.c
+++ b/plugins/CDVDisoEFP/src/imagetype.c
@@ -20,11 +20,6 @@
 
 #include <stddef.h> // NULL
 #include <sys/types.h> // off64_t
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/imagetype.h
+++ b/plugins/CDVDisoEFP/src/imagetype.h
@@ -21,12 +21,6 @@
 #ifndef IMAGETYPE_H
 #define IMAGETYPE_H
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 #include "isofile.h"

--- a/plugins/CDVDisoEFP/src/ini.h
+++ b/plugins/CDVDisoEFP/src/ini.h
@@ -23,12 +23,6 @@
 #define INI_H
 
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/isocompress.c
+++ b/plugins/CDVDisoEFP/src/isocompress.c
@@ -20,12 +20,6 @@
 
 #include <stddef.h> // NULL
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 #include "logfile.h"

--- a/plugins/CDVDisoEFP/src/isofile.c
+++ b/plugins/CDVDisoEFP/src/isofile.c
@@ -22,11 +22,6 @@
 #include <stdlib.h> // malloc()
 #include <sys/types.h> // off64_t
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/multifile.c
+++ b/plugins/CDVDisoEFP/src/multifile.c
@@ -20,11 +20,6 @@
 
 #include <stddef.h> // NULL
 #include <sys/types.h> // off64_t
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/multifile.h
+++ b/plugins/CDVDisoEFP/src/multifile.h
@@ -21,12 +21,6 @@
 #ifndef MULTIFILE_H
 #define MULTIFILE_H
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 #include "isofile.h"

--- a/plugins/CDVDisoEFP/src/toc.c
+++ b/plugins/CDVDisoEFP/src/toc.c
@@ -19,11 +19,6 @@
  */
 #include <stddef.h> // NULL
 #include <sys/types.h> // off64_t
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
 #define CDVDdefs
 #include "PS2Edefs.h"
 #include "logfile.h"

--- a/plugins/CDVDisoEFP/src/toc.h
+++ b/plugins/CDVDisoEFP/src/toc.h
@@ -20,12 +20,6 @@
 #ifndef TOC_H
 #define TOC_H
 
-// #ifndef __LINUX__
-// #ifdef __linux__
-// #define __LINUX__
-// #endif /* __linux__ */
-// #endif /* No __LINUX__ */
-
 // #define CDVDdefs
 // #include "PS2Edefs.h"
 #include "isofile.h"

--- a/plugins/CDVDisoEFP/src/version.c
+++ b/plugins/CDVDisoEFP/src/version.c
@@ -19,12 +19,6 @@
  */
 
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
-
 #define CDVDdefs
 #include "PS2Edefs.h"
 

--- a/plugins/CDVDisoEFP/src/version.h
+++ b/plugins/CDVDisoEFP/src/version.h
@@ -21,12 +21,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
-
 #define CDVDdefs
 #include "PS2Edefs.h"
 

--- a/plugins/CDVDlinuz/Src/Linux/CD.h
+++ b/plugins/CDVDlinuz/Src/Linux/CD.h
@@ -46,18 +46,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
-
-
 #define CDVDdefs
 
 #include "../PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/Linux/CDVDlinuz.c
+++ b/plugins/CDVDlinuz/Src/Linux/CDVDlinuz.c
@@ -28,12 +28,6 @@
 #include <time.h> // time_t, time(), struct timeval
 #include <unistd.h> // stat()
 
-#ifndef __LINUX__
-#ifdef __linux__
-#define __LINUX__
-#endif /* __linux__ */
-#endif /* No __LINUX__ */
-
 #define CDVDdefs
 #include "PS2Edefs.h"
 // #include "PS2Etypes.h"

--- a/plugins/CDVDlinuz/Src/Linux/DVD.h
+++ b/plugins/CDVDlinuz/Src/Linux/DVD.h
@@ -46,18 +46,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
-
-
 #define CDVDdefs
 
 #include "PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/Linux/conf.h
+++ b/plugins/CDVDlinuz/Src/Linux/conf.h
@@ -46,18 +46,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
-
-
 #define CDVDdefs
 
 #include "../PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/Linux/device.h
+++ b/plugins/CDVDlinuz/Src/Linux/device.h
@@ -50,16 +50,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
 #define CDVDdefs
 
 #include "../PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/PS2Edefs.h
+++ b/plugins/CDVDlinuz/Src/PS2Edefs.h
@@ -14,7 +14,7 @@
  * Since this is still beta things may change.
 
  * OSflags:
-	__LINUX__ (linux OS)
+	__linux__ (linux OS)
 	_WIN32 (win32 OS)
 
  * common return values (for ie. GSinit):
@@ -33,7 +33,7 @@
 
 #include "PS2Etypes.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #define CALLBACK
 #else
 #include <windows.h>

--- a/plugins/CDVDlinuz/Src/PS2Etypes.h
+++ b/plugins/CDVDlinuz/Src/PS2Etypes.h
@@ -42,7 +42,7 @@ typedef u32 uptr;
 
 
 
-#elif defined(__LINUX__) || defined(__MINGW32__)
+#elif defined(__linux__) || defined(__MINGW32__)
 
 
 

--- a/plugins/CDVDlinuz/Src/buffer.c
+++ b/plugins/CDVDlinuz/Src/buffer.c
@@ -44,18 +44,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
-
-
 #define CDVDdefs
 
 #include "PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/ini.h
+++ b/plugins/CDVDlinuz/Src/ini.h
@@ -48,18 +48,6 @@
 
 
 
-// #ifndef __LINUX__
-
-// #ifdef __linux__
-
-// #define __LINUX__
-
-// #endif /* __linux__ */
-
-// #endif /* No __LINUX__ */
-
-
-
 // #define CDVDdefs
 
 // #include "PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/version.c
+++ b/plugins/CDVDlinuz/Src/version.c
@@ -40,18 +40,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
-
-
 #define CDVDdefs
 
 #include "PS2Edefs.h"

--- a/plugins/CDVDlinuz/Src/version.h
+++ b/plugins/CDVDlinuz/Src/version.h
@@ -48,18 +48,6 @@
 
 
 
-#ifndef __LINUX__
-
-#ifdef __linux__
-
-#define __LINUX__
-
-#endif /* __linux__ */
-
-#endif /* No __LINUX__ */
-
-
-
 #define CDVDdefs
 
 #include "PS2Edefs.h"

--- a/plugins/CDVDpeops/CDVDiso.c
+++ b/plugins/CDVDpeops/CDVDiso.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#ifdef __LINUX__
+#ifdef __linux__
 #define strnicmp strncasecmp
 #endif
 

--- a/plugins/CDVDpeops/PS2Edefs.h
+++ b/plugins/CDVDpeops/PS2Edefs.h
@@ -14,7 +14,7 @@
  * Since this is still beta things may change.
 
  * OSflags:
-	__LINUX__ (linux OS)
+	__linux__ (linux OS)
 	__WIN32__ (win32 OS)
 
  * common return values (for ie. GSinit):
@@ -33,7 +33,7 @@
 
 #include "PS2Etypes.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #define CALLBACK
 #else
 #include <windows.h>

--- a/plugins/CDVDpeops/PS2Etypes.h
+++ b/plugins/CDVDpeops/PS2Etypes.h
@@ -20,7 +20,7 @@ typedef u64 uptr;
 typedef u32 uptr;
 #endif
 
-#elif defined(__LINUX__) || defined(__MINGW32__)
+#elif defined(__linux__) || defined(__MINGW32__)
 
 typedef char s8;
 typedef short s16;

--- a/plugins/GSnull/GS.cpp
+++ b/plugins/GSnull/GS.cpp
@@ -46,7 +46,7 @@ const char* s_iniFilename = "GSnull.ini";
 GSVars gs;
 
 // Because I haven't bothered to get GSOpen2 working in Windows yet in GSNull.
-#ifdef __LINUX__
+#ifdef __linux__
 #define USE_GSOPEN2
 #endif
 

--- a/plugins/GSnull/GS.h
+++ b/plugins/GSnull/GS.h
@@ -26,7 +26,7 @@ typedef struct _keyEvent keyEvent;
 #	include "Windows/GSwin.h"
 #endif
 
-#ifdef __LINUX__
+#ifdef __linux__
 #	include "Linux/GSLinux.h"
 #endif
 

--- a/plugins/cdvdGigaherz/src/FileStream.cpp
+++ b/plugins/cdvdGigaherz/src/FileStream.cpp
@@ -36,7 +36,7 @@ void FileStream::seek(s64 offset)
 void FileStream::seek(s64 offset, int ref_position)
 {
 	int ret = _fseeki64(handle, offset, ref_position);
-#ifdef __LINUX__
+#ifdef __linux__
 	if (ret) throw "Seek offset out of bounds.";
 #else
 	if (ret)
@@ -76,7 +76,7 @@ int FileStream::read(byte* b, int len)
 {
 	if (b == NULL)
 	{
-#ifdef __LINUX__
+#ifdef __linux__
 		throw "NULL buffer passed.";
 #else
 		throw new exception("NULL buffer passed.");
@@ -85,7 +85,7 @@ int FileStream::read(byte* b, int len)
 
 	if (len < 0)
 	{
-#ifdef __LINUX__
+#ifdef __linux__
 		throw "off<0 or len<0.";
 #else
 		throw new exception("off<0 or len<0.");

--- a/plugins/dev9ghzdrk/PS2Edefs.h
+++ b/plugins/dev9ghzdrk/PS2Edefs.h
@@ -29,7 +29,7 @@
  * Since this is still beta things may change.
 
  * OSflags:
-	__LINUX__ (linux OS)
+	__linux__ (linux OS)
 	__WIN32__ (win32 OS)
 
  * common return values (for ie. GSinit):
@@ -48,7 +48,7 @@
 
 #include "PS2Etypes.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #define CALLBACK
 #else
 #include <windows.h>

--- a/plugins/dev9ghzdrk/PS2Etypes.h
+++ b/plugins/dev9ghzdrk/PS2Etypes.h
@@ -29,7 +29,7 @@ typedef unsigned __int16 u16;
 typedef unsigned __int32 u32;
 typedef unsigned __int64 u64;
 
-#elif defined(__LINUX__)
+#elif defined(__linux__)
 
 typedef char s8;
 typedef short s16;

--- a/plugins/onepad/controller.h
+++ b/plugins/onepad/controller.h
@@ -22,7 +22,7 @@
 #ifndef __CONTROLLER_H__
 #define __CONTROLLER_H__
 
-#ifdef __LINUX__
+#ifdef __linux__
 #define MAX_KEYS 24
 #else
 #define MAX_KEYS 20

--- a/plugins/onepad/keyboard.cpp
+++ b/plugins/onepad/keyboard.cpp
@@ -28,7 +28,7 @@
 #include <gdk/gdkkeysyms.h>
 #include "keyboard.h"
 
-#ifndef __LINUX__
+#ifndef __linux__
 char* KeysymToChar(int keysym)
 {
 	LPWORD temp;
@@ -40,7 +40,7 @@ char* KeysymToChar(int keysym)
 
 void SetAutoRepeat(bool autorep)
 {
- #ifdef __LINUX__
+ #ifdef __linux__
     if (toggleAutoRepeat)
     {
         if (autorep)
@@ -51,7 +51,7 @@ void SetAutoRepeat(bool autorep)
 #endif
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 static bool s_grab_input = false;
 static bool s_Shift = false;
 static unsigned int  s_previous_mouse_x = 0;

--- a/plugins/onepad/keyboard.h
+++ b/plugins/onepad/keyboard.h
@@ -24,7 +24,7 @@
 
 #include "onepad.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #include "Linux/linux.h"
 

--- a/plugins/onepad/onepad.cpp
+++ b/plugins/onepad/onepad.cpp
@@ -28,7 +28,7 @@
 #include "onepad.h"
 #include "svnrev.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include <unistd.h>
 #endif
 #ifdef _MSC_VER
@@ -260,7 +260,7 @@ EXPORT_C_(s32) PADopen(void *pDsp)
 	pthread_spin_init(&mutex_KeyEvent, PTHREAD_PROCESS_PRIVATE);
 	mutex_WasInit = true;
 
-#ifdef __LINUX__
+#ifdef __linux__
 	JoystickInfo::EnumerateJoysticks(s_vjoysticks);
 #endif
 	return _PADopen(pDsp);
@@ -602,7 +602,7 @@ EXPORT_C_(keyEvent*) PADkeyEvent()
 	return &s_event;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 EXPORT_C_(void) PADWriteEvent(keyEvent &evt)
 {
 	// This function call be called before PADopen. Therefore we cann't

--- a/plugins/onepad/onepad.h
+++ b/plugins/onepad/onepad.h
@@ -47,7 +47,7 @@ using namespace std;
 #define PADdefs
 #include "PS2Edefs.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include "joystick.h"
 #endif
 #include "bitwise.h"

--- a/plugins/spu2-x/src/Config.h
+++ b/plugins/spu2-x/src/Config.h
@@ -83,7 +83,7 @@ extern u32 OutputModule;
 extern int SndOutLatencyMS;
 extern int SynchMode;
 
-#ifndef __LINUX__
+#ifndef __linux__
 extern wchar_t dspPlugin[];
 extern int  dspPluginModule;
 

--- a/plugins/spu2-x/src/Global.h
+++ b/plugins/spu2-x/src/Global.h
@@ -39,9 +39,7 @@ namespace soundtouch
 #include <ctime>
 #include <stdexcept>
 
-// This will be brought in later anyways, but if we bring it in now, it'll avoid
-// warnings about redefining __LINUX__.
-#include "Utilities/Dependencies.h" 
+#include "Utilities/Dependencies.h"
 #include "Pcsx2Defs.h"
 #include "Pcsx2Types.h"
 

--- a/plugins/spu2-x/src/Mixer.cpp
+++ b/plugins/spu2-x/src/Mixer.cpp
@@ -819,7 +819,7 @@ static int p_cachestat_counter=0;
 
 // Gcc does not want to inline it when lto is enabled because some functions growth too much.
 // The function is big enought to see any speed impact. -- Gregory
-#ifndef __LINUX__
+#ifndef __linux__
 __forceinline
 #endif
 void Mix()

--- a/plugins/spu2-x/src/PS2E-spu2.cpp
+++ b/plugins/spu2-x/src/PS2E-spu2.cpp
@@ -446,7 +446,7 @@ EXPORT_C_(s32) SPU2open(void *pDsp)
 	{
 		SndBuffer::Init();
 		
-#ifndef __LINUX__
+#ifndef __linux__
 		DspLoadLibrary(dspPlugin,dspPluginModule);
 #endif
 		WaveDump::Open();
@@ -467,7 +467,7 @@ EXPORT_C_(void) SPU2close()
 
 	FileLog("[%10d] SPU2 Close\n",Cycles);
 
-#ifndef __LINUX__
+#ifndef __linux__
 	DspCloseLibrary();
 #endif
 

--- a/plugins/spu2-x/src/PS2E-spu2.h
+++ b/plugins/spu2-x/src/PS2E-spu2.h
@@ -20,7 +20,7 @@
 #include "Pcsx2Defs.h"
 #include "PS2Edefs.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 //Until I get around to putting in Linux svn code, this is an unknown svn version.
 #define SVN_REV_UNKNOWN
 #endif
@@ -51,7 +51,7 @@ EXPORT_C_(void) SPU2irqCallback(void (*SPU2callback)());
 #else
 // These defines are useless and gcc-4.6 complain about redefinition
 // so we remove them on linux
-#ifndef __LINUX__
+#ifndef __linux__
 EXPORT_C_(void) SPU2readDMA4Mem(u16 *pMem, u32 size);
 EXPORT_C_(void) SPU2writeDMA4Mem(u16 *pMem, u32 size);
 EXPORT_C_(void) SPU2interruptDMA4();

--- a/plugins/spu2-x/src/SndOut.cpp
+++ b/plugins/spu2-x/src/SndOut.cpp
@@ -95,7 +95,7 @@ SndOutModule* mods[]=
 #if defined(SPU2X_SDL) || defined(SPU2X_SDL2)
   SDLOut,
 #endif
-#ifdef __LINUX__
+#ifdef __linux__
 	AlsaOut,
 #endif
 	NULL		// signals the end of our list
@@ -467,7 +467,7 @@ void SndBuffer::Write( const StereoOut32& Sample )
 		ssFreeze--;
 		memset( sndTempBuffer, 0, sizeof(StereoOut32) * SndOutPacketSize ); // Play silence
 	}
-#ifndef __LINUX__
+#ifndef __linux__
 	if( dspPluginEnabled )
 	{
 		// Convert in, send to winamp DSP, and convert out.

--- a/plugins/spu2-x/src/SndOut.h
+++ b/plugins/spu2-x/src/SndOut.h
@@ -675,7 +675,7 @@ extern SndOutModule* PortaudioOut;
 #if defined(SPU2X_SDL) || defined(SPU2X_SDL2)
 extern SndOutModule * const SDLOut;
 #endif
-#ifdef __LINUX__
+#ifdef __linux__
 extern SndOutModule* AlsaOut;
 #endif
 

--- a/plugins/spu2-x/src/SndOut_Portaudio.cpp
+++ b/plugins/spu2-x/src/SndOut_Portaudio.cpp
@@ -578,7 +578,7 @@ public:
 	{
 		wxString api( L"EMPTYEMPTYEMPTY" );
 		m_Device = L"EMPTYEMPTYEMPTY";
-#ifdef __LINUX__
+#ifdef __linux__
 		// By default on linux use the ALSA API (+99% users) -- Gregory
 		CfgReadStr( L"PORTAUDIO", L"HostApi", api, L"ALSA" );
 #else

--- a/plugins/spu2-x/src/Wavedump_wav.cpp
+++ b/plugins/spu2-x/src/Wavedump_wav.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "Global.h"
-#ifdef __LINUX__
+#ifdef __linux__
 #include "WavFile.h"
 #else
 #include "soundtouch/WavFile.h"
@@ -53,7 +53,7 @@ namespace WaveDump
 			for( int srcidx=0; srcidx<CoreSrc_Count; srcidx++ )
 			{
 				safe_delete( m_CoreWav[cidx][srcidx] );
-#ifdef __LINUX__
+#ifdef __linux__
 				sprintf( wavfilename, "logs/spu2x-Core%d-%s.wav",
 					cidx, m_tbl_CoreOutputTypeNames[ srcidx ] );
 #else

--- a/plugins/zerogs/opengl/common/PS2Edefs.h
+++ b/plugins/zerogs/opengl/common/PS2Edefs.h
@@ -31,7 +31,7 @@
  * Since this is still beta things may change.
 
  * OSflags:
-	__LINUX__ (linux OS)
+	__linux__ (linux OS)
 	_WIN32 (win32 OS)
 
  * common return values (for ie. GSinit):

--- a/plugins/zerogs/opengl/common/PS2Etypes.h
+++ b/plugins/zerogs/opengl/common/PS2Etypes.h
@@ -18,19 +18,15 @@
 #ifndef __PS2ETYPES_H__
 #define __PS2ETYPES_H__
 
-#if defined (__linux__) && !defined(__LINUX__)  // some distributions are lower case
-#define __LINUX__
-#endif
-
 #ifdef __CYGWIN__
-#define __LINUX__
+#define __linux__
 #endif
 
 #ifndef ArraySize
 #define ArraySize(x) (sizeof(x)/sizeof((x)[0]))
 #endif
 
-#ifdef __LINUX__
+#ifdef __linux__
 #define CALLBACK
 #else
 #define CALLBACK    __stdcall
@@ -91,7 +87,7 @@ typedef unsigned int uint;
 
 #else // _MSC_VER
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #ifdef HAVE_STDINT_H
 #include "stdint.h"
@@ -137,7 +133,7 @@ typedef union _LARGE_INTEGER
 #define __forceinline __attribute__((always_inline,unused))
 #define __naked		// GCC lacks the naked specifier
 
-#endif  // __LINUX__
+#endif  // __linux__
 
 #define PCSX2_ALIGNED(alig,x) x __attribute((aligned(alig)))
 #define PCSX2_ALIGNED16(x) x __attribute((aligned(16)))
@@ -146,7 +142,7 @@ typedef union _LARGE_INTEGER
 
 #endif // _MSC_VER
 
-#if !defined(__LINUX__) || !defined(HAVE_STDINT_H)
+#if !defined(__linux__) || !defined(HAVE_STDINT_H)
 #if defined(__x86_64__)
 typedef u64 uptr;
 typedef s64 sptr;

--- a/plugins/zerospu2/Targets/SoundTargets.cpp
+++ b/plugins/zerospu2/Targets/SoundTargets.cpp
@@ -22,7 +22,7 @@ SoundCallbacks *SoundCmds;
 u32 SOUNDSIZE;
 s32 MaxBuffer;
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include "Linux.h"
 
 #ifdef ZEROSPU2_ALSA

--- a/plugins/zerospu2/Targets/SoundTargets.h
+++ b/plugins/zerospu2/Targets/SoundTargets.h
@@ -39,7 +39,7 @@ extern u32 SOUNDSIZE;
 extern s32 MaxBuffer;
 
 // Target List
-#ifdef __LINUX__
+#ifdef __linux__
 
 #if (!defined(ZEROSPU2_ALSA) && !defined(ZEROSPU2_OSS) && !defined(ZEROSPU2_PORTAUDIO))
 #define ZEROSPU2_ALSA // Comment if Alsa isn't on the system.

--- a/plugins/zerospu2/misc.h
+++ b/plugins/zerospu2/misc.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include <unistd.h>
 #include <gtk/gtk.h>
 #include <sys/timeb.h>	// ftime(), struct timeb

--- a/plugins/zerospu2/zerospu2.cpp
+++ b/plugins/zerospu2/zerospu2.cpp
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 
 #include "soundtouch/SoundTouch.h"
-#ifdef __LINUX__
+#ifdef __linux__
 #include "WavFile.h"
 #else
 #include "soundtouch/WavFile.h"

--- a/plugins/zerospu2/zeroworker.cpp
+++ b/plugins/zerospu2/zeroworker.cpp
@@ -19,7 +19,7 @@
 #include "zerospu2.h"
 #include "zeroworker.h"
 #include "soundtouch/SoundTouch.h"
-#ifdef __LINUX__
+#ifdef __linux__
 #include "WavFile.h"
 #else
 #include "soundtouch/WavFile.h"

--- a/plugins/zzogl-pg-cg/opengl/GSmain.cpp
+++ b/plugins/zzogl-pg-cg/opengl/GSmain.cpp
@@ -623,7 +623,7 @@ s32 CALLBACK GSfreeze(int mode, freezeData *data)
 	return 0;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 struct Packet 
 {

--- a/plugins/zzogl-pg-cg/opengl/Profile.h
+++ b/plugins/zzogl-pg-cg/opengl/Profile.h
@@ -32,7 +32,7 @@ extern u64 luPerfFreq;
 
 
 // Copied from Utilities; remove later.
-#ifdef __LINUX__
+#ifdef __linux__
 
 #include <sys/time.h>
 #include <sys/timeb.h>	// ftime(), struct timeb

--- a/plugins/zzogl-pg-cg/opengl/ZZLog.h
+++ b/plugins/zzogl-pg-cg/opengl/ZZLog.h
@@ -26,7 +26,7 @@
 extern void HandleGLError();
 
 //Logging for errors that are called often should have a time counter.
-#ifdef __LINUX__
+#ifdef __linux__
 static u32 __attribute__((unused)) lasttime = 0;
 static u32 __attribute__((unused)) BigTime = 5000;
 static bool __attribute__((unused)) SPAM_PASS;

--- a/plugins/zzogl-pg-cg/opengl/targets.cpp
+++ b/plugins/zzogl-pg-cg/opengl/targets.cpp
@@ -2741,7 +2741,7 @@ void FlushTransferRanges(const tex0Info* ptex)
 
 #endif
 
-#ifdef __LINUX__
+#ifdef __linux__
 //#define LOG_RESOLVE_PROFILE
 #endif
 

--- a/plugins/zzogl-pg/opengl/GSmain.cpp
+++ b/plugins/zzogl-pg/opengl/GSmain.cpp
@@ -641,7 +641,7 @@ EXPORT_C_(s32) GSfreeze(int mode, freezeData *data)
 	return 0;
 }
 
-#ifdef __LINUX__
+#ifdef __linux__
 void _fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	static uint32 read_cnt = 0;

--- a/plugins/zzogl-pg/opengl/Profile.h
+++ b/plugins/zzogl-pg/opengl/Profile.h
@@ -32,7 +32,7 @@ extern u64 luPerfFreq;
 
 
 // Copied from Utilities; remove later.
-#ifdef __LINUX__
+#ifdef __linux__
 
 #include <sys/time.h>
 #include <sys/timeb.h>	// ftime(), struct timeb

--- a/plugins/zzogl-pg/opengl/ZZLog.h
+++ b/plugins/zzogl-pg/opengl/ZZLog.h
@@ -26,7 +26,7 @@
 extern void HandleGLError();
 
 //Logging for errors that are called often should have a time counter.
-#ifdef __LINUX__
+#ifdef __linux__
 static u32 __attribute__((unused)) lasttime = 0;
 static u32 __attribute__((unused)) BigTime = 5000;
 static bool __attribute__((unused)) SPAM_PASS;

--- a/plugins/zzogl-pg/opengl/targets.cpp
+++ b/plugins/zzogl-pg/opengl/targets.cpp
@@ -511,7 +511,7 @@ void FlushTransferRanges(const tex0Info* ptex)
 
 #endif
 
-#ifdef __LINUX__
+#ifdef __linux__
 //#define LOG_RESOLVE_PROFILE
 #endif
 

--- a/tools/bin2cpp/bin2cpp.cpp
+++ b/tools/bin2cpp/bin2cpp.cpp
@@ -36,10 +36,6 @@
 #include <sys/stat.h>
 #include <string.h>
 
-#if defined (__linux__) && !defined(__LINUX__)  // some distributions are lower case
-#define __LINUX__
-#endif
-
 #if _MSC_VER
 #	pragma warning(disable:4996)	// The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name.
 #endif


### PR DESCRIPTION
This is defined and set it a ton of different places.
It's checked in a whole lot more
Instead just use __linux__ like a real project should
