### PR TITLE
PrecompiledHeader.h: Removed WTF-redefines

### DIFF
--- a/pcsx2/PrecompiledHeader.h
+++ b/pcsx2/PrecompiledHeader.h
@@ -58,10 +58,12 @@
 using std::min;
 using std::max;
 
-typedef int BOOL;
 
-#undef TRUE
-#undef FALSE
+// As plugins which use C have to be used with PCSX2, the BOOL type is redefined
+// to prevent any C/C++ compatibility issues.
+typedef int BOOL;
+#undef  TRUE
+#undef  FALSE
 #define TRUE  1
 #define FALSE 0
 


### PR DESCRIPTION
Removed redefinition of TRUE and FALSE, and removed typedef of int to BOOL

If there's an actual reason for this, though, I'd really like to know (and a comment should explain).
