### PR TITLE
Remove some horrible old code.

### DIFF
--- a/common/include/Pcsx2Defs.h
+++ b/common/include/Pcsx2Defs.h
@@ -67,21 +67,6 @@ extern "C" unsigned __int64 __xgetbv(int);
 #endif
 
 // --------------------------------------------------------------------------------------
-//  C_ASSERT
-// --------------------------------------------------------------------------------------
-// compile-time assertion; usable at static variable define level.
-// (typically used to confirm the correct sizeof() for struct types where size
-//  restaints must be enforced).
-//
-#ifndef C_ASSERT
-	#ifdef __linux__
-	#	define C_ASSERT(e) static_assert(e, "this is a nice message to explain the failure ;)")
-	#else
-	#	define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
-	#endif
-#endif
-
-// --------------------------------------------------------------------------------------
 // Dev / Debug conditionals - Consts for using if() statements instead of uglier #ifdef.
 // --------------------------------------------------------------------------------------
 // Note: Using if() optimizes nicely in Devel and Release builds, but will generate extra
@@ -204,13 +189,10 @@ static const int __pagesize	= PCSX2_PAGESIZE;
 #	define PCSX2_ALIGNED16(x)			__declspec(align(16)) x
 #	define PCSX2_ALIGNED16_EXTERN(x)	extern __declspec(align(16)) x
 
-#	define __naked			__declspec(naked)
 #	define __noinline		__declspec(noinline)
 #	define __threadlocal	__declspec(thread)
 
 // Don't know if there are Visual C++ equivalents of these.
-#	define __hot
-#	define __cold
 #	define likely(x)		(!!(x))
 #	define unlikely(x)		(!!(x))
 
@@ -234,7 +216,6 @@ static const int __pagesize	= PCSX2_PAGESIZE;
 #	define PCSX2_ALIGNED_EXTERN(alig,x) extern x __attribute((aligned(alig)))
 #	define PCSX2_ALIGNED16_EXTERN(x) extern x __attribute((aligned(16)))
 
-#	define __naked						// GCC lacks the naked specifier
 #	define __assume(cond)	((void)0)	// GCC has no equivalent for __assume
 #	define CALLBACK			__attribute__((stdcall))
 
@@ -250,44 +231,9 @@ static const int __pagesize	= PCSX2_PAGESIZE;
 #		define __forceinline	__attribute__((unused))
 #	endif
 #	define __noinline		__attribute__((noinline))
-#	define __hot			__attribute__((hot))
-#	define __cold			__attribute__((cold))
 #	define __threadlocal	__thread
 #	define likely(x)		__builtin_expect(!!(x), 1)
 #	define unlikely(x)		__builtin_expect(!!(x), 0)
-#endif
-
-// --------------------------------------------------------------------------------------
-//  GNU C/C++ Specific Defines
-// --------------------------------------------------------------------------------------
-#ifdef __GNUC__
-
-// GCC 4.4.0 is a bit nutty, as compilers go. it gets a define to itself.
-#	define GCC_VERSION (	__GNUC__ * 10000 \
-						+	__GNUC_MINOR__ * 100 \
-						+	__GNUC_PATCHLEVEL__)
-
-// Test for GCC > 4.4.0; Should be adjusted when new versions come out
-#	if GCC_VERSION >= 40400
-#		define THE_UNBEARABLE_LIGHTNESS_OF_BEING_GCC_4_4_0
-#		define __nooptimization __attribute__((optimize("O0")))
-#	endif
-
-// This theoretically unoptimizes. Not having much luck so far.
-/*
-#	ifdef THE_UNBEARABLE_LIGHTNESS_OF_BEING_GCC_4_4_0
-#		pragma GCC optimize ("O0")
-#	endif
-
-#	ifdef THE_UNBEARABLE_LIGHTNESS_OF_BEING_GCC_4_4_0
-#		pragma GCC reset_options
-#	endif
-*/
-
-#endif		// end GCC-specific section.
-
-#ifndef THE_UNBEARABLE_LIGHTNESS_OF_BEING_GCC_4_4_0
-#	define __nooptimization		// Pretty sure this is obsolete now, since we fixed __asm contraints and stuff. --air
 #endif
 
 // --------------------------------------------------------------------------------------

--- a/common/include/PluginCallbacks.h
+++ b/common/include/PluginCallbacks.h
@@ -148,7 +148,7 @@
 #else
 	// Ensure the user's defined PS2E_THISPTR retains the correct signature for our
 	// plugin API.
-	C_ASSERT( sizeof(PS2E_THISPTR) == sizeof(void*) );
+	static_assert( sizeof(PS2E_THISPTR) == sizeof(void*), "Incorrect signature for PS2E_THISPTR" );
 #endif
 
 // PS2E_LIB_THISPTR - (library scope version of PS2E_THISPTR)
@@ -157,7 +157,7 @@
 #else
 	// Ensure the user's defined PS2E_THISPTR retains the correct signature for our
 	// plugin API.
-	C_ASSERT( sizeof(PS2E_LIB_THISPTR) == sizeof(void*) );
+	static_assert( sizeof(PS2E_LIB_THISPTR) == sizeof(void*), "Incorrect signature for PS2E_LIB_THISPTR" );
 #endif
 
 // Use fastcall by default, since under most circumstances the object-model approach of the

--- a/common/include/Utilities/MemsetFast.inl
+++ b/common/include/Utilities/MemsetFast.inl
@@ -73,13 +73,13 @@ static __fi void memzero_sse_a( void* dest, const size_t size )
 template< u8 data, typename T >
 __noinline void memset_sse_a( T& dest )
 {
-	C_ASSERT( (sizeof(dest) & 0xf) == 0 );
+	static_assert( (sizeof(dest) & 0xf) == 0, "Bad size for SSE memset" );
 	memset_sse_a<data>( &dest, sizeof(dest) );
 }
 
 template< typename T >
 void memzero_sse_a( T& dest )
 {
-	C_ASSERT( (sizeof(dest) & 0xf) == 0 );
+	static_assert( (sizeof(dest) & 0xf) == 0, "Bad size for SSE memset" );
 	memset_sse_a<0>( &dest, sizeof(dest) );
 }

--- a/pcsx2/PrecompiledHeader.h
+++ b/pcsx2/PrecompiledHeader.h
@@ -16,8 +16,6 @@
 #ifndef PCSX2_PRECOMPILED_HEADER
 #define PCSX2_PRECOMPILED_HEADER
 
-//#pragma once		// no dice, causes problems in GCC PCH (which doesn't really work very well anyway)
-
 // Disable some pointless warnings...
 #ifdef _MSC_VER
 #	pragma warning(disable:4250) //'class' inherits 'method' via dominance
@@ -99,7 +97,7 @@ typedef FnType_Void* Fnptr_Void;
 #	define strnicmp _strnicmp
 #	define stricmp _stricmp
 
-#else	// must be GCC...
+#else	// must be GCC or Clang
 
 #	include <sys/types.h>
 #	include <sys/timeb.h>
@@ -109,6 +107,6 @@ typedef FnType_Void* Fnptr_Void;
 #		define __declspec(x)
 #	endif
 
-#endif		// end GCC/Linux stuff
+#endif
 
 #endif

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -47,7 +47,7 @@ struct romdir
 #	pragma pack()
 #endif
 
-C_ASSERT( sizeof(romdir) == DIRENTRY_SIZE );
+static_assert( sizeof(romdir) == DIRENTRY_SIZE, "romdir struct not packed to 16 bytes" );
 
 u32 BiosVersion;
 u32 BiosChecksum;

--- a/pcsx2/x86/BaseblockEx.h
+++ b/pcsx2/x86/BaseblockEx.h
@@ -262,4 +262,4 @@ static void recLUT_SetPage(uptr reclut[0x10000], uptr hwlut[0x10000],
 		hwlut[page] = 0u - (pagebase << 16);
 }
 
-C_ASSERT( sizeof(BASEBLOCK) == 4 );
+static_assert( sizeof(BASEBLOCK) == 4, "BASEBLOCK is not 4 bytes" );

--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -63,7 +63,7 @@ union __aligned16 microRegInfo {
 	u32  full32[160/sizeof(u32)];
 };
 
-C_ASSERT(sizeof(microRegInfo) == 160);
+static_assert(sizeof(microRegInfo) == 160, "microRegInfo was not 160 bytes");
 
 struct microProgram;
 struct microJumpCache {

--- a/plugins/CDVDisoEFP/src/PS2Edefs.h
+++ b/plugins/CDVDisoEFP/src/PS2Edefs.h
@@ -34,11 +34,8 @@
 #else
 #include <windows.h>
 #endif
-/* common defines */
-#ifndef C_ASSERT
-#define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
-#endif
 
+/* common defines */
 #if defined(GSdefs)   || defined(PADdefs)  || defined(SIOdefs)  || \
     defined(SPU2defs) || defined(CDVDdefs) || defined(DEV9defs) || \
     defined(USBdefs)  || defined(FWdefs)

--- a/plugins/CDVDlinuz/Src/PS2Edefs.h
+++ b/plugins/CDVDlinuz/Src/PS2Edefs.h
@@ -41,10 +41,6 @@
 
 
 /* common defines */
-#ifndef C_ASSERT
-#define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
-#endif
-
 #if defined(GSdefs)   || defined(PADdefs)  || defined(SIOdefs)  || \
     defined(SPU2defs) || defined(CDVDdefs) || defined(DEV9defs) || \
     defined(USBdefs)  || defined(FWdefs)

--- a/plugins/zerogs/dx/Regs.cpp
+++ b/plugins/zerogs/dx/Regs.cpp
@@ -70,7 +70,7 @@ GIFRegHandler g_GIFRegHandlers[] = {
 	GIFRegHandlerNull,		GIFRegHandlerNull,		GIFRegHandlerNull,		GIFRegHandlerNull,
 	GIFRegHandlerSIGNAL,	GIFRegHandlerFINISH,	GIFRegHandlerLABEL,		GIFRegHandlerNull };
 
-C_ASSERT(sizeof(g_GIFRegHandlers)/sizeof(g_GIFRegHandlers[0]) == 100 );
+static_assert(sizeof(g_GIFRegHandlers)/sizeof(g_GIFRegHandlers[0]) == 100, "Regs not equal 100");
 
 // values for keeping track of changes
 u32 s_uTex1Data[2][2] = {0}, s_uClampData[2] = {0};

--- a/plugins/zerogs/opengl/Regs.cpp
+++ b/plugins/zerogs/opengl/Regs.cpp
@@ -68,7 +68,7 @@ GIFRegHandler g_GIFRegHandlers[] = {
 	GIFRegHandlerNull,	  GIFRegHandlerNull,	  GIFRegHandlerNull,	  GIFRegHandlerNull,
 	GIFRegHandlerSIGNAL,	GIFRegHandlerFINISH,	GIFRegHandlerLABEL,	 GIFRegHandlerNull };
 
-C_ASSERT(sizeof(g_GIFRegHandlers)/sizeof(g_GIFRegHandlers[0]) == 100 );
+static_assert(sizeof(g_GIFRegHandlers)/sizeof(g_GIFRegHandlers[0]) == 100, "Regs not equal 100");
 
 // values for keeping track of changes
 u32 s_uTex1Data[2][2] = {0}, s_uClampData[2] = {0};

--- a/plugins/zerogs/opengl/common/PS2Edefs.h
+++ b/plugins/zerogs/opengl/common/PS2Edefs.h
@@ -52,10 +52,6 @@
 
 
 /* common defines */
-#ifndef C_ASSERT
-#define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
-#endif
-
 #if defined(GSdefs)   || defined(PADdefs)  || defined(SIOdefs)  || \
     defined(SPU2defs) || defined(CDVDdefs) || defined(DEV9defs) || \
     defined(USBdefs)  || defined(FWdefs)

--- a/plugins/zerogs/opengl/common/PS2Etypes.h
+++ b/plugins/zerogs/opengl/common/PS2Etypes.h
@@ -83,8 +83,6 @@ typedef unsigned int uint;
 #define PCSX2_ALIGNED16(x) __declspec(align(16)) x
 #define PCSX2_ALIGNED16_DECL(x) __declspec(align(16)) x
 
-#define __naked __declspec(naked)
-
 #else // _MSC_VER
 
 #ifdef __linux__
@@ -131,7 +129,6 @@ typedef union _LARGE_INTEGER
 #define __unused __attribute__((unused))
 #define _inline __inline__ __attribute__((unused))
 #define __forceinline __attribute__((always_inline,unused))
-#define __naked		// GCC lacks the naked specifier
 
 #endif  // __linux__
 
@@ -206,10 +203,5 @@ typedef struct {
 	int size;
 	s8 *data;
 } freezeData;
-
-/* common defines */
-#ifndef C_ASSERT
-#define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
-#endif
 
 #endif /* __PS2ETYPES_H__ */


### PR DESCRIPTION
Removal of C_ASSERT define. It doesn't offer descriptive assert and every supported compiler has static_assert (msvc 2010+, gcc4.6.3+, clang). Also removed it from some plugins that didn't use.
Added some comments to asserts where applicable.

Removal of unused __hot, __cold, __naked.

Removal of horrible gcc4.4 hack that was unused.
