### PR TITLE
sVU_zerorec: Get rid of a memset call on VUInstruction's this pointer

### DIFF
--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -177,10 +177,11 @@ class VuInstruction
 {
 	public:
 		VuInstruction()
+		    : nParentPc(-1), info(), regs(), livevars(), addvars(), usedvars(), keepvars(),
+		      pqcycles(0), type(0), pClipWrite(0), pMACWrite(0), pStatusWrite(0),
+		      vffree(), vfwrite(), vfread0(), vfread1(), vfacc(), vfflush(), vicached(-1),
+		      pPrevInst(NULL)
 		{
-			memzero(*this);
-			nParentPc = -1;
-			vicached = -1;
 		}
 
 		int nParentPc; // used for syncing with flag writes, -1 for no parent


### PR DESCRIPTION
This can trample the class's internal data, so we initialize within the initializer list instead.
