### PR TITLE
Require SSE2 instead of SSE+MMX. SSE2 implies SSE+MMX is supported, so a...

### DIFF
--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -240,8 +240,6 @@ void SysLogMachineCaps()
 
 	wxArrayString features[2];	// 2 lines, for readability!
 
-	if( x86caps.hasMultimediaExtensions )			features[0].Add( L"MMX" );
-	if( x86caps.hasStreamingSIMDExtensions )		features[0].Add( L"SSE" );
 	if( x86caps.hasStreamingSIMD2Extensions )		features[0].Add( L"SSE2" );
 	if( x86caps.hasStreamingSIMD3Extensions )		features[0].Add( L"SSE3" );
 	if( x86caps.hasSupplementalStreamingSIMD3Extensions ) features[0].Add( L"SSSE3" );

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -237,10 +237,7 @@ void Panels::CpuPanelEE::AppStatusEvent_OnSettingsApplied()
 }
 
 void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags ){
-	m_panel_RecEE->Enable( x86caps.hasStreamingSIMD2Extensions );
-
-	// IOP rec should work fine on any CPU. :D
-	//m_panel_RecIOP->Enable( x86caps.hasStreamingSIMD2Extensions );
+	m_panel_RecEE->Enable(true);
 
 	const Pcsx2Config::RecompilerOptions& recOps( configToApply.EmuOptions.Cpu.Recompiler );
 	m_panel_RecEE->SetSelection( (int)recOps.EnableEE );
@@ -288,14 +285,14 @@ void Panels::CpuPanelVU::AppStatusEvent_OnSettingsApplied()
 
 void Panels::CpuPanelVU::ApplyConfigToGui( AppConfig& configToApply, int flags )
 {
-	m_panel_VU0->Enable( x86caps.hasStreamingSIMD2Extensions );
-	m_panel_VU1->Enable( x86caps.hasStreamingSIMD2Extensions );
+	m_panel_VU0->Enable(true);
+	m_panel_VU1->Enable(true);
 
-	m_panel_VU0->EnableItem( 1, x86caps.hasStreamingSIMD2Extensions );
-	m_panel_VU0->EnableItem( 2, x86caps.hasStreamingSIMD2Extensions );
+	m_panel_VU0->EnableItem( 1, true);
+	m_panel_VU0->EnableItem( 2, true);
 
-	m_panel_VU1->EnableItem( 1, x86caps.hasStreamingSIMD2Extensions );
-	m_panel_VU1->EnableItem( 2, x86caps.hasStreamingSIMD2Extensions );
+	m_panel_VU1->EnableItem( 1, true);
+	m_panel_VU1->EnableItem( 2, true);
 
 	Pcsx2Config::RecompilerOptions& recOps( configToApply.EmuOptions.Cpu.Recompiler );
 	if( recOps.UseMicroVU0 )

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -577,7 +577,7 @@ static void recThrowHardwareDeficiency( const wxChar* extFail )
 {
 	throw Exception::HardwareDeficiency()
 		.SetDiagMsg(pxsFmt( L"R5900-32 recompiler init failed: %s is not available.", extFail))
-		.SetUserMsg(pxsFmt(_("%s Extensions not found.  The R5900-32 recompiler requires a host CPU with MMX, SSE, and SSE2 extensions."), extFail ));
+		.SetUserMsg(pxsFmt(_("%s Extensions not found.  The R5900-32 recompiler requires a host CPU with SSE2 extensions."), extFail ));
 }
 
 static void recReserveCache()
@@ -600,12 +600,6 @@ static void recReserveCache()
 static void recReserve()
 {
 	// Hardware Requirements Check...
-
-	if ( !x86caps.hasMultimediaExtensions )
-		recThrowHardwareDeficiency( L"MMX" );
-
-	if ( !x86caps.hasStreamingSIMDExtensions )
-		recThrowHardwareDeficiency( L"SSE" );
 
 	if ( !x86caps.hasStreamingSIMD2Extensions )
 		recThrowHardwareDeficiency( L"SSE2" );

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -25,7 +25,7 @@
 static __fi void mVUthrowHardwareDeficiency(const wxChar* extFail, int vuIndex) {
 	throw Exception::HardwareDeficiency()
 		.SetDiagMsg(pxsFmt(L"microVU%d recompiler init failed: %s is not available.", vuIndex, extFail))
-		.SetUserMsg(pxsFmt(_("%s Extensions not found.  microVU requires a host CPU with MMX, SSE, and SSE2 extensions."), extFail));
+		.SetUserMsg(pxsFmt(_("%s Extensions not found.  microVU requires a host CPU with SSE2 extensions."), extFail));
 }
 
 void mVUreserveCache(microVU& mVU) {
@@ -43,8 +43,6 @@ void mVUreserveCache(microVU& mVU) {
 // Only run this once per VU! ;)
 void mVUinit(microVU& mVU, uint vuIndex) {
 
-	if(!x86caps.hasMultimediaExtensions)	 mVUthrowHardwareDeficiency( L"MMX",  vuIndex );
-	if(!x86caps.hasStreamingSIMDExtensions)	 mVUthrowHardwareDeficiency( L"SSE",  vuIndex );
 	if(!x86caps.hasStreamingSIMD2Extensions) mVUthrowHardwareDeficiency( L"SSE2", vuIndex );
 
 	memzero(mVU.prog);


### PR DESCRIPTION
...ll checks of of 'SSE' and 'MMX' can be removed.

SSE2 is supported on more than decade-old x86 CPUs. Almost(?) every x86 CPU since PS2 was released.
Certainly running the existing code on a non-SSE2 computer resulted in most of the code being disabled anyway and the emulator being incredibly slow.
This removal will hopefully allow the removal of MMX/3DNow code as it has been superceded.
