### PR TITLE
Core: Get rid of C void parameter carryovers

### DIFF
--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -921,17 +921,17 @@ void SYSCALL()
 	cpuException(0x20, cpuRegs.branch);
 }
 
-void BREAK(void) {
+void BREAK() {
 	cpuRegs.pc -= 4;
 	cpuException(0x24, cpuRegs.branch);
 }
 
-void MFSA( void ) {
+void MFSA() {
 	if (!_Rd_) return;
 	cpuRegs.GPR.r[_Rd_].SD[0] = (s64)cpuRegs.sa;
 }
 
-void MTSA( void ) {
+void MTSA() {
 	cpuRegs.sa = (s32)cpuRegs.GPR.r[_Rs_].SD[0] & 0xf;
 }
 
@@ -939,14 +939,14 @@ void MTSA( void ) {
 // to the cache) and one which synchronizes the instruction pipeline (effectively
 // a stall in either case).  Our emulation model does not track EE-side pipeline
 // status or stalls, nor does it implement the CACHE.  Thus SYNC need do nothing.
-void SYNC( void )
+void SYNC()
 {
 }
 
 // Used to prefetch data into the EE's cache, or schedule a dirty write-back.
 // CACHE is not emulated at this time (nor is there any need to emulate it), so
 // this function does nothing in the context of our emulator.
-void PREF( void )
+void PREF()
 {
 }
 

--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -133,7 +133,7 @@ REC_SYS( MTC0 );
 
 #else
 
-void recMFC0( void )
+void recMFC0()
 {
 	if( _Rd_ == 9 )
 	{

--- a/pcsx2/x86/iCOP0.h
+++ b/pcsx2/x86/iCOP0.h
@@ -28,19 +28,19 @@ namespace Dynarec {
 namespace OpcodeImpl {
 namespace COP0
 {
-	void recMFC0( void );
-	void recMTC0( void );
-	void recBC0F( void );
-	void recBC0T( void );
-	void recBC0FL( void );
-	void recBC0TL( void );
-	void recTLBR( void );
-	void recTLBWI( void );
-	void recTLBWR( void );
-	void recTLBP( void );
-	void recERET( void );
-	void recDI( void );
-	void recEI( void );
+	void recMFC0();
+	void recMTC0();
+	void recBC0F();
+	void recBC0T();
+	void recBC0FL();
+	void recBC0TL();
+	void recTLBR();
+	void recTLBWI();
+	void recTLBWR();
+	void recTLBP();
+	void recERET();
+	void recDI();
+	void recEI();
 
 }}}}
 #endif

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -126,7 +126,7 @@ void recCFC1(void)
 	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
 }
 
-void recCTC1( void )
+void recCTC1()
 {
 	if ( _Fs_ != 31 ) return;
 
@@ -170,7 +170,7 @@ void recCTC1( void )
 // MFC1
 //------------------------------------------------------------------
 
-void recMFC1(void)
+void recMFC1()
 {
 	int regt, regs;
 	if ( ! _Rt_ ) return;
@@ -234,7 +234,7 @@ void recMFC1(void)
 //------------------------------------------------------------------
 // MTC1
 //------------------------------------------------------------------
-void recMTC1(void)
+void recMTC1()
 {
 	if( GPR_IS_CONST1(_Rt_) )
 	{
@@ -670,25 +670,25 @@ static void _setupBranchTest()
 	TEST32ItoR(EAX, FPUflagC);
 }
 
-void recBC1F( void )
+void recBC1F()
 {
 	_setupBranchTest();
 	recDoBranchImm(JNZ32(0));
 }
 
-void recBC1T( void )
+void recBC1T()
 {
 	_setupBranchTest();
 	recDoBranchImm(JZ32(0));
 }
 
-void recBC1FL( void )
+void recBC1FL()
 {
 	_setupBranchTest();
 	recDoBranchImm_Likely(JNZ32(0));
 }
 
-void recBC1TL( void )
+void recBC1TL()
 {
 	_setupBranchTest();
 	recDoBranchImm_Likely(JZ32(0));

--- a/pcsx2/x86/iFPU.h
+++ b/pcsx2/x86/iFPU.h
@@ -22,41 +22,41 @@ namespace Dynarec {
 	namespace OpcodeImpl {
 	namespace COP1
 	{
-		void recMFC1( void );
-		void recCFC1( void );
-		void recMTC1( void );
-		void recCTC1( void );
-		void recCOP1_BC1( void );
-		void recCOP1_S( void );
-		void recCOP1_W( void );
-		void recC_EQ( void );
-		void recC_F( void );
-		void recC_LT( void );
-		void recC_LE( void );
-		void recADD_S( void );
-		void recSUB_S( void );
-		void recMUL_S( void );
-		void recDIV_S( void );
-		void recSQRT_S( void );
-		void recABS_S( void );
-		void recMOV_S( void );
-		void recNEG_S( void );
-		void recRSQRT_S( void );
-		void recADDA_S( void );
-		void recSUBA_S( void );
-		void recMULA_S( void );
-		void recMADD_S( void );
-		void recMSUB_S( void );
-		void recMADDA_S( void );
-		void recMSUBA_S( void );
-		void recCVT_S( void );
-		void recCVT_W( void );
-		void recMAX_S( void );
-		void recMIN_S( void );
-		void recBC1F( void );
-		void recBC1T( void );
-		void recBC1FL( void );
-		void recBC1TL( void );
+		void recMFC1();
+		void recCFC1();
+		void recMTC1();
+		void recCTC1();
+		void recCOP1_BC1();
+		void recCOP1_S();
+		void recCOP1_W();
+		void recC_EQ();
+		void recC_F();
+		void recC_LT();
+		void recC_LE();
+		void recADD_S();
+		void recSUB_S();
+		void recMUL_S();
+		void recDIV_S();
+		void recSQRT_S();
+		void recABS_S();
+		void recMOV_S();
+		void recNEG_S();
+		void recRSQRT_S();
+		void recADDA_S();
+		void recSUBA_S();
+		void recMULA_S();
+		void recMADD_S();
+		void recMSUB_S();
+		void recMADDA_S();
+		void recMSUBA_S();
+		void recCVT_S();
+		void recCVT_W();
+		void recMAX_S();
+		void recMIN_S();
+		void recBC1F();
+		void recBC1T();
+		void recBC1FL();
+		void recBC1TL();
 	} }
 } }
 

--- a/pcsx2/x86/iMMI.cpp
+++ b/pcsx2/x86/iMMI.cpp
@@ -290,7 +290,7 @@ void recPMTHL()
 } \*/
 
 ////////////////////////////////////////////////////
-void recPSRLH( void )
+void recPSRLH()
 {
 	if ( !_Rd_ ) return;
 
@@ -306,7 +306,7 @@ void recPSRLH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSRLW( void )
+void recPSRLW()
 {
 	if( !_Rd_ ) return;
 
@@ -322,7 +322,7 @@ void recPSRLW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSRAH( void )
+void recPSRAH()
 {
 	if ( !_Rd_ ) return;
 
@@ -338,7 +338,7 @@ void recPSRAH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSRAW( void )
+void recPSRAW()
 {
 	if ( !_Rd_ ) return;
 
@@ -354,7 +354,7 @@ void recPSRAW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSLLH( void )
+void recPSLLH()
 {
 	if ( !_Rd_ ) return;
 
@@ -370,7 +370,7 @@ void recPSLLH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSLLW( void )
+void recPSLLW()
 {
 	if ( !_Rd_ ) return;
 
@@ -386,15 +386,15 @@ void recPSLLW( void )
 }
 
 /*
-void recMADD( void )
+void recMADD()
 {
 }
 
-void recMADDU( void )
+void recMADDU()
 {
 }
 
-void recPLZCW( void )
+void recPLZCW()
 {
 }
 */
@@ -523,7 +523,7 @@ void recPPACW()
 	_clearNeededXMMregs();
 }
 
-void recPPACH( void )
+void recPPACH()
 {
 	if (!_Rd_) return;
 
@@ -665,7 +665,7 @@ void recPPAC5()
 }
 
 ////////////////////////////////////////////////////
-void recPMAXH( void )
+void recPMAXH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -680,7 +680,7 @@ void recPMAXH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCGTB( void )
+void recPCGTB()
 {
 	if ( ! _Rd_ ) return;
 
@@ -700,7 +700,7 @@ void recPCGTB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCGTH( void )
+void recPCGTH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -720,7 +720,7 @@ void recPCGTH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCGTW( void )
+void recPCGTW()
 {
 	//TODO:optimize RS | RT== 0
 	if ( ! _Rd_ ) return;
@@ -741,7 +741,7 @@ void recPCGTW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDSB( void )
+void recPADDSB()
 {
 	if ( ! _Rd_ ) return;
 
@@ -756,7 +756,7 @@ void recPADDSB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDSH( void )
+void recPADDSH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -772,7 +772,7 @@ void recPADDSH( void )
 
 ////////////////////////////////////////////////////
 //NOTE: check kh2 movies if changing this
-void recPADDSW( void )
+void recPADDSW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -822,7 +822,7 @@ void recPADDSW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSUBSB( void )
+void recPSUBSB()
 {
    if ( ! _Rd_ ) return;
 
@@ -843,7 +843,7 @@ void recPSUBSB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSUBSH( void )
+void recPSUBSH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -865,7 +865,7 @@ void recPSUBSH( void )
 
 ////////////////////////////////////////////////////
 //NOTE: check kh2 movies if changing this
-void recPSUBSW( void )
+void recPSUBSW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -920,7 +920,7 @@ void recPSUBSW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDB( void )
+void recPADDB()
 {
 	if ( ! _Rd_ ) return;
 
@@ -935,7 +935,7 @@ void recPADDB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDH( void )
+void recPADDH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -959,7 +959,7 @@ void recPADDH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDW( void )
+void recPADDW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -983,7 +983,7 @@ void recPADDW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSUBB( void )
+void recPSUBB()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1004,7 +1004,7 @@ void recPSUBB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSUBH( void )
+void recPSUBH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1025,7 +1025,7 @@ void recPSUBH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPSUBW( void )
+void recPSUBW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1046,7 +1046,7 @@ void recPSUBW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPEXTLW( void )
+void recPEXTLW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1072,7 +1072,7 @@ void recPEXTLW( void )
 	_clearNeededXMMregs();
 }
 
-void recPEXTLB( void )
+void recPEXTLB()
 {
 	if (!_Rd_) return;
 
@@ -1098,7 +1098,7 @@ void recPEXTLB( void )
 	_clearNeededXMMregs();
 }
 
-void recPEXTLH( void )
+void recPEXTLH()
 {
 	if (!_Rd_) return;
 
@@ -1492,7 +1492,7 @@ void recQFSRV()
 }
 
 
-void recPEXTUB( void )
+void recPEXTUB()
 {
 	if (!_Rd_) return;
 
@@ -1520,7 +1520,7 @@ void recPEXTUB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPEXTUW( void )
+void recPEXTUW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1547,7 +1547,7 @@ void recPEXTUW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPMINH( void )
+void recPMINH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1562,7 +1562,7 @@ void recPMINH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCEQB( void )
+void recPCEQB()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1577,7 +1577,7 @@ void recPCEQB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCEQH( void )
+void recPCEQH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1592,7 +1592,7 @@ void recPCEQH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCEQW( void )
+void recPCEQW()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1607,7 +1607,7 @@ void recPCEQW( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDUB( void )
+void recPADDUB()
 {
 	if ( ! _Rd_ ) return;
 
@@ -1625,7 +1625,7 @@ void recPADDUB( void )
 }
 
 ////////////////////////////////////////////////////
-void recPADDUH( void )
+void recPADDUH()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2098,7 +2098,7 @@ void recPHMSBH()
 }
 
 ////////////////////////////////////////////////////
-void recPEXEH( void )
+void recPEXEH()
 {
 	if (!_Rd_) return;
 
@@ -2109,7 +2109,7 @@ void recPEXEH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPREVH( void )
+void recPREVH()
 {
 	if (!_Rd_) return;
 
@@ -2121,7 +2121,7 @@ void recPREVH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPINTH( void )
+void recPINTH()
 {
 	if (!_Rd_) return;
 
@@ -2140,7 +2140,7 @@ void recPINTH( void )
 	_clearNeededXMMregs();
 }
 
-void recPEXEW( void )
+void recPEXEW()
 {
 	if (!_Rd_) return;
 
@@ -2149,7 +2149,7 @@ void recPEXEW( void )
 	_clearNeededXMMregs();
 }
 
-void recPROT3W( void )
+void recPROT3W()
 {
 	if (!_Rd_) return;
 
@@ -2158,7 +2158,7 @@ void recPROT3W( void )
 	_clearNeededXMMregs();
 }
 
-void recPMULTH( void )
+void recPMULTH()
 {
 	int info = eeRecompileCodeXMM( XMMINFO_READS|XMMINFO_READT|(_Rd_?XMMINFO_WRITED:0)|XMMINFO_WRITELO|XMMINFO_WRITEHI );
 	int t0reg = _allocTempXMMreg(XMMT_INT, -1);
@@ -2193,7 +2193,7 @@ void recPMULTH( void )
 	_clearNeededXMMregs();
 }
 
-void recPMFHI( void )
+void recPMFHI()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2203,7 +2203,7 @@ void recPMFHI( void )
 }
 
 ////////////////////////////////////////////////////
-void recPMFLO( void )
+void recPMFLO()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2213,7 +2213,7 @@ void recPMFLO( void )
 }
 
 ////////////////////////////////////////////////////
-void recPAND( void )
+void recPAND()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2232,7 +2232,7 @@ void recPAND( void )
 }
 
 ////////////////////////////////////////////////////
-void recPXOR( void )
+void recPXOR()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2251,7 +2251,7 @@ void recPXOR( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCPYLD( void )
+void recPCPYLD()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2274,7 +2274,7 @@ void recPCPYLD( void )
 	_clearNeededXMMregs();
 }
 
-void recPMADDH( void )
+void recPMADDH()
 {
 	int info = eeRecompileCodeXMM( (_Rd_?XMMINFO_WRITED:0)|XMMINFO_READS|XMMINFO_READT|XMMINFO_READLO|XMMINFO_READHI|XMMINFO_WRITELO|XMMINFO_WRITEHI );
 	int t0reg = _allocTempXMMreg(XMMT_INT, -1);
@@ -2594,7 +2594,7 @@ void recPEXCW()
 }
 
 ////////////////////////////////////////////////////
-void recPEXCH( void )
+void recPEXCH()
 {
 	if (!_Rd_) return;
 
@@ -2605,7 +2605,7 @@ void recPEXCH( void )
 }
 
 ////////////////////////////////////////////////////
-void recPNOR( void )
+void recPNOR()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2658,7 +2658,7 @@ void recPNOR( void )
 }
 
 ////////////////////////////////////////////////////
-void recPMTHI( void )
+void recPMTHI()
 {
 	int info = eeRecompileCodeXMM( XMMINFO_READS|XMMINFO_WRITEHI );
 	SSEX_MOVDQA_XMM_to_XMM(EEREC_HI, EEREC_S);
@@ -2666,7 +2666,7 @@ void recPMTHI( void )
 }
 
 ////////////////////////////////////////////////////
-void recPMTLO( void )
+void recPMTLO()
 {
 	int info = eeRecompileCodeXMM( XMMINFO_READS|XMMINFO_WRITELO );
 	SSEX_MOVDQA_XMM_to_XMM(EEREC_LO, EEREC_S);
@@ -2674,7 +2674,7 @@ void recPMTLO( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCPYUD( void )
+void recPCPYUD()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2711,7 +2711,7 @@ void recPCPYUD( void )
 }
 
 ////////////////////////////////////////////////////
-void recPOR( void )
+void recPOR()
 {
 	if ( ! _Rd_ ) return;
 
@@ -2744,7 +2744,7 @@ void recPOR( void )
 }
 
 ////////////////////////////////////////////////////
-void recPCPYH( void )
+void recPCPYH()
 {
 	if ( ! _Rd_ ) return;
 

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -35,26 +35,26 @@ extern u32 s_nBlockCycles;		// cycles of current block recompiling
 //
 
 #define REC_FUNC( f ) \
-   void rec##f( void ) \
+   void rec##f() \
    { \
 	   recCall(Interp::f); \
    }
 
 #define REC_FUNC_DEL( f, delreg ) \
-	void rec##f( void ) \
+	void rec##f() \
 { \
 	if( (delreg) > 0 ) _deleteEEreg(delreg, 1); \
 	recCall(Interp::f); \
 }
 
 #define REC_SYS( f ) \
-   void rec##f( void ) \
+   void rec##f() \
    { \
 	   recBranchCall(Interp::f); \
    }
 
 #define REC_SYS_DEL( f, delreg ) \
-   void rec##f( void ) \
+   void rec##f() \
    { \
 	   if( (delreg) > 0 ) _deleteEEreg(delreg, 1); \
 	   recBranchCall(Interp::f); \

--- a/pcsx2/x86/iR5900Arit.h
+++ b/pcsx2/x86/iR5900Arit.h
@@ -25,19 +25,19 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl
 {
-	void recADD( void );
-	void recADDU( void );
-	void recDADD( void );
-	void recDADDU( void );
-	void recSUB( void );
-	void recSUBU( void );
-	void recDSUB( void );
-	void recDSUBU( void );
-	void recAND( void );
-	void recOR( void );
-	void recXOR( void );
-	void recNOR( void );
-	void recSLT( void );
-	void recSLTU( void );
+	void recADD();
+	void recADDU();
+	void recDADD();
+	void recDADDU();
+	void recSUB();
+	void recSUBU();
+	void recDSUB();
+	void recDSUBU();
+	void recAND();
+	void recOR();
+	void recXOR();
+	void recNOR();
+	void recSLT();
+	void recSLTU();
 } } }
 #endif

--- a/pcsx2/x86/iR5900AritImm.h
+++ b/pcsx2/x86/iR5900AritImm.h
@@ -24,16 +24,16 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recADDI( void );
-	void recADDIU( void );
-	void recDADDI( void );
-	void recDADDIU( void );
-	void recANDI( void );
-	void recORI( void );
-	void recXORI( void );
+	void recADDI();
+	void recADDIU();
+	void recDADDI();
+	void recDADDIU();
+	void recANDI();
+	void recORI();
+	void recXORI();
 
-	void recSLTI( void );
-	void recSLTIU( void );
+	void recSLTI();
+	void recSLTIU();
 } } }
 
 #endif

--- a/pcsx2/x86/iR5900Branch.h
+++ b/pcsx2/x86/iR5900Branch.h
@@ -25,22 +25,22 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recBEQ( void );
-	void recBEQL( void );
-	void recBNE( void );
-	void recBNEL( void );
-	void recBLTZ( void );
-	void recBLTZL( void );
-	void recBLTZAL( void );
-	void recBLTZALL( void );
-	void recBGTZ( void );
-	void recBGTZL( void );
-	void recBLEZ( void );
-	void recBLEZL( void );
-	void recBGEZ( void );
-	void recBGEZL( void );
-	void recBGEZAL( void );
-	void recBGEZALL( void );
+	void recBEQ();
+	void recBEQL();
+	void recBNE();
+	void recBNEL();
+	void recBLTZ();
+	void recBLTZL();
+	void recBLTZAL();
+	void recBLTZALL();
+	void recBGTZ();
+	void recBGTZL();
+	void recBLEZ();
+	void recBLEZL();
+	void recBGEZ();
+	void recBGEZL();
+	void recBGEZAL();
+	void recBGEZALL();
 } } }
 
 #endif

--- a/pcsx2/x86/iR5900Jump.h
+++ b/pcsx2/x86/iR5900Jump.h
@@ -25,10 +25,10 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recJ( void );
-	void recJAL( void );
-	void recJR( void );
-	void recJALR( void );
+	void recJ();
+	void recJAL();
+	void recJR();
+	void recJALR();
 } } }
 
 #endif

--- a/pcsx2/x86/iR5900LoadStore.h
+++ b/pcsx2/x86/iR5900LoadStore.h
@@ -24,31 +24,31 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recLB( void );
-	void recLBU( void );
-	void recLH( void );
-	void recLHU( void );
-	void recLW( void );
-	void recLWU( void );
-	void recLWL( void );
-	void recLWR( void );
-	void recLD( void );
-	void recLDR( void );
-	void recLDL( void );
-	void recLQ( void );
-	void recSB( void );
-	void recSH( void );
-	void recSW( void );
-	void recSWL( void );
-	void recSWR( void );
-	void recSD( void );
-	void recSDL( void );
-	void recSDR( void );
-	void recSQ( void );
-	void recLWC1( void );
-	void recSWC1( void );
-	void recLQC2( void );
-	void recSQC2( void );
+	void recLB();
+	void recLBU();
+	void recLH();
+	void recLHU();
+	void recLW();
+	void recLWU();
+	void recLWL();
+	void recLWR();
+	void recLD();
+	void recLDR();
+	void recLDL();
+	void recLQ();
+	void recSB();
+	void recSH();
+	void recSW();
+	void recSWL();
+	void recSWR();
+	void recSD();
+	void recSDL();
+	void recSDR();
+	void recSQ();
+	void recLWC1();
+	void recSWC1();
+	void recLQC2();
+	void recSQC2();
 
 } } }
 

--- a/pcsx2/x86/iR5900Misc.cpp
+++ b/pcsx2/x86/iR5900Misc.cpp
@@ -66,7 +66,7 @@ void recDoBranchImm_Likely( u32* jmpSkip )
 namespace OpcodeImpl {
 
 ////////////////////////////////////////////////////
-//static void recCACHE( void ) {
+//static void recCACHE() {
 //	MOV32ItoM( (uptr)&cpuRegs.code, cpuRegs.code );
 //	MOV32ItoM( (uptr)&cpuRegs.pc, pc );
 //	iFlushCall(FLUSH_EVERYTHING);
@@ -80,15 +80,15 @@ namespace OpcodeImpl {
 //}
 
 
-void recPREF( void )
+void recPREF()
 {
 }
 
-void recSYNC( void )
+void recSYNC()
 {
 }
 
-void recMFSA( void )
+void recMFSA()
 {
 	int mmreg;
 	if (!_Rd_) return;
@@ -110,7 +110,7 @@ void recMFSA( void )
 }
 
 // SA is 4-bit and contains the amount of bytes to shift
-void recMTSA( void )
+void recMTSA()
 {
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoM((uptr)&cpuRegs.sa, g_cpuConstRegs[_Rs_].UL[0] & 0xf );
@@ -133,7 +133,7 @@ void recMTSA( void )
 	}
 }
 
-void recMTSAB( void )
+void recMTSAB()
 {
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoM((uptr)&cpuRegs.sa, ((g_cpuConstRegs[_Rs_].UL[0] & 0xF) ^ (_Imm_ & 0xF)) );
@@ -146,7 +146,7 @@ void recMTSAB( void )
 	}
 }
 
-void recMTSAH( void )
+void recMTSAH()
 {
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoM((uptr)&cpuRegs.sa, ((g_cpuConstRegs[_Rs_].UL[0] & 0x7) ^ (_Imm_ & 0x7)) << 1);
@@ -161,7 +161,7 @@ void recMTSAH( void )
 }
 
 	////////////////////////////////////////////////////
-	void recNULL( void )
+	void recNULL()
 	{
 		Console.Error("EE: Unimplemented op %x", cpuRegs.code);
 	}
@@ -206,62 +206,62 @@ void recMTSAH( void )
 	   //branch = 2;
 	}
 
-	void recTGE( void )
+	void recTGE()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TGE );
 	}
 
-	void recTGEU( void )
+	void recTGEU()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TGEU );
 	}
 
-	void recTLT( void )
+	void recTLT()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TLT );
 	}
 
-	void recTLTU( void )
+	void recTLTU()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TLTU );
 	}
 
-	void recTEQ( void )
+	void recTEQ()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TEQ );
 	}
 
-	void recTNE( void )
+	void recTNE()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TNE );
 	}
 
-	void recTGEI( void )
+	void recTGEI()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TGEI );
 	}
 
-	void recTGEIU( void )
+	void recTGEIU()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TGEIU );
 	}
 
-	void recTLTI( void )
+	void recTLTI()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TLTI );
 	}
 
-	void recTLTIU( void )
+	void recTLTIU()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TLTIU );
 	}
 
-	void recTEQI( void )
+	void recTEQI()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TEQI );
 	}
 
-	void recTNEI( void )
+	void recTNEI()
 	{
 		recBranchCall( R5900::Interpreter::OpcodeImpl::TNEI );
 	}

--- a/pcsx2/x86/iR5900Move.h
+++ b/pcsx2/x86/iR5900Move.h
@@ -20,13 +20,13 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recLUI( void );
-	void recMFLO( void );
-	void recMFHI( void );
-	void recMTLO( void );
-	void recMTHI( void );
-	void recMOVN( void );
-	void recMOVZ( void );
+	void recLUI();
+	void recMFLO();
+	void recMFHI();
+	void recMTLO();
+	void recMTHI();
+	void recMOVN();
+	void recMOVZ();
 } } }
 
 #endif

--- a/pcsx2/x86/iR5900MultDiv.h
+++ b/pcsx2/x86/iR5900MultDiv.h
@@ -25,10 +25,10 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recMULT( void );
-	void recMULTU( void );
-	void recDIV( void );
-	void recDIVU( void );
+	void recMULT();
+	void recMULTU();
+	void recDIV();
+	void recDIVU();
 } } }
 
 #endif

--- a/pcsx2/x86/iR5900Shift.h
+++ b/pcsx2/x86/iR5900Shift.h
@@ -25,22 +25,22 @@ namespace R5900 {
 namespace Dynarec {
 namespace OpcodeImpl {
 
-	void recSLL( void );
-	void recSRL( void );
-	void recSRA( void );
-	void recDSLL( void );
-	void recDSRL( void );
-	void recDSRA( void );
-	void recDSLL32( void );
-	void recDSRL32( void );
-	void recDSRA32( void );
+	void recSLL();
+	void recSRL();
+	void recSRA();
+	void recDSLL();
+	void recDSRL();
+	void recDSRA();
+	void recDSLL32();
+	void recDSRL32();
+	void recDSRA32();
 
-	void recSLLV( void );
-	void recSRLV( void );
-	void recSRAV( void );
-	void recDSLLV( void );
-	void recDSRLV( void );
-	void recDSRAV( void );
+	void recSLLV();
+	void recSRLV();
+	void recSRAV();
+	void recDSLLV();
+	void recDSRLV();
+	void recDSRAV();
 } } }
 
 #endif

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -759,7 +759,7 @@ static void recResetEE()
 	recResetRaw();
 }
 
-void recStep( void )
+void recStep()
 {
 }
 
@@ -842,7 +842,7 @@ static void recExecute()
 }
 
 ////////////////////////////////////////////////////
-void R5900::Dynarec::OpcodeImpl::recSYSCALL( void )
+void R5900::Dynarec::OpcodeImpl::recSYSCALL()
 {
 	recCall(R5900::Interpreter::OpcodeImpl::SYSCALL);
 
@@ -855,7 +855,7 @@ void R5900::Dynarec::OpcodeImpl::recSYSCALL( void )
 }
 
 ////////////////////////////////////////////////////
-void R5900::Dynarec::OpcodeImpl::recBREAK( void )
+void R5900::Dynarec::OpcodeImpl::recBREAK()
 {
 	recCall(R5900::Interpreter::OpcodeImpl::BREAK);
 

--- a/pcsx2/x86/ix86-32/iR5900AritImm.cpp
+++ b/pcsx2/x86/ix86-32/iR5900AritImm.cpp
@@ -76,13 +76,13 @@ void recADDI_(int info)
 EERECOMPILE_CODEX(eeRecompileCode1, ADDI);
 
 ////////////////////////////////////////////////////
-void recADDIU( void )
+void recADDIU()
 {
-	recADDI( );
+	recADDI();
 }
 
 ////////////////////////////////////////////////////
-void recDADDI_const( void )
+void recDADDI_const()
 {
 	g_cpuConstRegs[_Rt_].SD[0] = g_cpuConstRegs[_Rs_].SD[0] + (s64)_Imm_;
 }
@@ -115,9 +115,9 @@ void recDADDI_(int info)
 EERECOMPILE_CODEX(eeRecompileCode1, DADDI);
 
 //// DADDIU
-void recDADDIU( void )
+void recDADDIU()
 {
-	recDADDI( );
+	recDADDI();
 }
 
 //// SLTIU

--- a/pcsx2/x86/ix86-32/iR5900Branch.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Branch.cpp
@@ -389,7 +389,7 @@ EERECOMPILE_CODE0(BNEL, XMMINFO_READS|XMMINFO_READT);
 *********************************************************/
 
 ////////////////////////////////////////////////////
-//void recBLTZAL( void )
+//void recBLTZAL()
 //{
 //	Console.WriteLn("BLTZAL");
 //	_eeFlushAllUnused();
@@ -440,7 +440,7 @@ void recBLTZAL()
 }
 
 ////////////////////////////////////////////////////
-void recBGEZAL( void )
+void recBGEZAL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -479,7 +479,7 @@ void recBGEZAL( void )
 }
 
 ////////////////////////////////////////////////////
-void recBLTZALL( void )
+void recBLTZALL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -513,7 +513,7 @@ void recBLTZALL( void )
 }
 
 ////////////////////////////////////////////////////
-void recBGEZALL( void )
+void recBGEZALL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -548,7 +548,7 @@ void recBGEZALL( void )
 
 
 //// BLEZ
-void recBLEZ( void )
+void recBLEZ()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -594,7 +594,7 @@ void recBLEZ( void )
 }
 
 //// BGTZ
-void recBGTZ( void )
+void recBGTZ()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -673,7 +673,7 @@ void recBLTZ()
 }
 
 ////////////////////////////////////////////////////
-void recBGEZ( void )
+void recBGEZ()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -706,7 +706,7 @@ void recBGEZ( void )
 }
 
 ////////////////////////////////////////////////////
-void recBLTZL( void )
+void recBLTZL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -736,7 +736,7 @@ void recBLTZL( void )
 
 
 ////////////////////////////////////////////////////
-void recBGEZL( void )
+void recBGEZL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -773,7 +773,7 @@ void recBGEZL( void )
 *********************************************************/
 
 ////////////////////////////////////////////////////
-void recBLEZL( void )
+void recBLEZL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 
@@ -817,7 +817,7 @@ void recBLEZL( void )
 }
 
 ////////////////////////////////////////////////////
-void recBGTZL( void )
+void recBGTZL()
 {
 	u32 branchTo = ((s32)_Imm_ * 4) + pc;
 

--- a/pcsx2/x86/ix86-32/iR5900Jump.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Jump.cpp
@@ -45,7 +45,7 @@ REC_SYS_DEL(JALR, _Rd_);
 #else
 
 ////////////////////////////////////////////////////
-void recJ( void )
+void recJ()
 {
 	// SET_FPUSTATE;
 	u32 newpc = (_Target_ << 2) + ( pc & 0xf0000000 );
@@ -57,7 +57,7 @@ void recJ( void )
 }
 
 ////////////////////////////////////////////////////
-void recJAL( void )
+void recJAL()
 {
 	u32 newpc = (_Target_ << 2) + ( pc & 0xf0000000 );
 	_deleteEEreg(31, 0);
@@ -86,13 +86,13 @@ void recJAL( void )
 *********************************************************/
 
 ////////////////////////////////////////////////////
-void recJR( void )
+void recJR()
 {
 	SetBranchReg( _Rs_);
 }
 
 ////////////////////////////////////////////////////
-void recJALR( void )
+void recJALR()
 {
 	int newpc = pc + 4;
 	_allocX86reg(ESI, X86TYPE_PCWRITEBACK, 0, MODE_WRITE);

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -238,24 +238,24 @@ void recStore(u32 bits)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-void recLB( void )  { recLoad32(8,true); }
-void recLBU( void ) { recLoad32(8,false); }
-void recLH( void )  { recLoad32(16,true); }
-void recLHU( void ) { recLoad32(16,false); }
-void recLW( void )  { recLoad32(32,true); }
-void recLWU( void ) { recLoad32(32,false); }
-void recLD( void )  { recLoad64(64,false); }
-void recLQ( void )  { recLoad64(128,false); }
+void recLB()  { recLoad32(8,true); }
+void recLBU() { recLoad32(8,false); }
+void recLH()  { recLoad32(16,true); }
+void recLHU() { recLoad32(16,false); }
+void recLW()  { recLoad32(32,true); }
+void recLWU() { recLoad32(32,false); }
+void recLD()  { recLoad64(64,false); }
+void recLQ()  { recLoad64(128,false); }
 
-void recSB( void )  { recStore(8); }
-void recSH( void )  { recStore(16); }
-void recSW( void )  { recStore(32); }
-void recSQ( void )  { recStore(128); }
-void recSD( void )  { recStore(64); }
+void recSB()  { recStore(8); }
+void recSH()  { recStore(16); }
+void recSW()  { recStore(32); }
+void recSQ()  { recStore(128); }
+void recSD()  { recStore(64); }
 
 ////////////////////////////////////////////////////
 
-void recLWL( void )
+void recLWL()
 {
 #ifdef REC_LOADS
 	iFlushCall(FLUSH_FULLVTLB);
@@ -301,7 +301,7 @@ void recLWL( void )
 }
 
 ////////////////////////////////////////////////////
-void recLWR(void)
+void recLWR()
 {
 #ifdef REC_LOADS
 	iFlushCall(FLUSH_FULLVTLB);
@@ -350,7 +350,7 @@ void recLWR(void)
 }
 
 ////////////////////////////////////////////////////
-void recSWL(void)
+void recSWL()
 {
 #ifdef REC_STORES
 	iFlushCall(FLUSH_FULLVTLB);
@@ -398,7 +398,7 @@ void recSWL(void)
 }
 
 ////////////////////////////////////////////////////
-void recSWR(void)
+void recSWR()
 {
 #ifdef REC_STORES
 	iFlushCall(FLUSH_FULLVTLB);
@@ -446,7 +446,7 @@ void recSWR(void)
 }
 
 ////////////////////////////////////////////////////
-void recLDL( void )
+void recLDL()
 {
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -455,7 +455,7 @@ void recLDL( void )
 }
 
 ////////////////////////////////////////////////////
-void recLDR( void )
+void recLDR()
 {
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -465,7 +465,7 @@ void recLDR( void )
 
 ////////////////////////////////////////////////////
 
-void recSDL( void )
+void recSDL()
 {
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -474,7 +474,7 @@ void recSDL( void )
 }
 
 ////////////////////////////////////////////////////
-void recSDR( void )
+void recSDR()
 {
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -490,7 +490,7 @@ void recSDR( void )
 
 ////////////////////////////////////////////////////
 
-void recLWC1( void )
+void recLWC1()
 {
 	_deleteFPtoXMMreg(_Rt_, 2);
 
@@ -515,7 +515,7 @@ void recLWC1( void )
 
 ////////////////////////////////////////////////////
 
-void recSWC1( void )
+void recSWC1()
 {
 	_deleteFPtoXMMreg(_Rt_, 1);
 
@@ -551,7 +551,7 @@ void recSWC1( void )
 
 
 
-void recLQC2( void )
+void recLQC2()
 {
 	_deleteVFtoXMMreg(_Ft_, 0, 2);
 
@@ -580,7 +580,7 @@ void recLQC2( void )
 
 ////////////////////////////////////////////////////
 
-void recSQC2( void )
+void recSQC2()
 {
 	_deleteVFtoXMMreg(_Ft_, 0, 1); //Want to flush it but not clear it
 

--- a/pcsx2/x86/ix86-32/iR5900Move.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Move.cpp
@@ -281,22 +281,22 @@ void recMTHILO(int hi)
 	}
 }
 
-void recMFHI( void )
+void recMFHI()
 {
 	recMFHILO(1);
 }
 
-void recMFLO( void )
+void recMFLO()
 {
 	recMFHILO(0);
 }
 
-void recMTHI( void )
+void recMTHI()
 {
 	recMTHILO(1);
 }
 
-void recMTLO( void )
+void recMTLO()
 {
 	recMTHILO(0);
 }
@@ -403,22 +403,22 @@ void recMTHILO1(int hi)
 	}
 }
 
-void recMFHI1( void )
+void recMFHI1()
 {
 	recMFHILO1(1);
 }
 
-void recMFLO1( void )
+void recMFLO1()
 {
 	recMFHILO1(0);
 }
 
-void recMTHI1( void )
+void recMTHI1()
 {
 	recMTHILO1(1);
 }
 
-void recMTLO1( void )
+void recMTLO1()
 {
 	recMTHILO1(0);
 }


### PR DESCRIPTION
Some functions in these files had the void specifier while others didn't. To make it more consistent, just remove them.
