### PR TITLE
Updated .gitignore to exclude /build and pcsx2 snapshot builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,12 @@
 *.mo
 
 _ReSharper.*
+pcsx2.snapshot_*
 postBuild.inc.cmd
 postBuild.cmd
 svnrev.h
 
+build
 Debug
 Release
 Devel


### PR DESCRIPTION
/build is commonly used for out-of-source builds in linux, and the pcsx2 snapshot builds are generated by the script in /debian-unstable-upstream.
