### PR TITLE
Rename regs (remove .r and .n suffix for reg types). [Not for merging]

### DIFF
--- a/pcsx2/COP0.cpp
+++ b/pcsx2/COP0.cpp
@@ -25,7 +25,7 @@ u32 s_iLastPERFCycle[2] = { 0, 0 };
 // Given this function is called so much, it's commented out for now. (rama)
 __ri void cpuUpdateOperationMode() {
 
-	//u32 value = cpuRegs.CP0.n.Status.val;
+	//u32 value = cpuRegs.Status.val;
 
 	//if (value & 0x06 ||
 	//	(value & 0x18) == 0) { // Kernel Mode (KSU = 0 | EXL = 1 | ERL = 1)*/
@@ -39,7 +39,7 @@ void __fastcall WriteCP0Status(u32 value) {
 
 	//DMA_LOG("COP0 Status write = 0x%08x", value);
 
-	cpuRegs.CP0.n.Status.val = value;
+	cpuRegs.Status.val = value;
     cpuUpdateOperationMode();
     cpuSetNextEventDelta(4);
 }
@@ -118,7 +118,7 @@ void COP0_DiagnosticPCCR()
 extern int branch;
 __fi void COP0_UpdatePCCR()
 {
-	//if( cpuRegs.CP0.n.Status.b.ERL || !cpuRegs.PERF.n.pccr.b.CTE ) return;
+	//if( cpuRegs.Status.b.ERL || !cpuRegs.PERF.n.pccr.b.CTE ) return;
 
 	// TODO : Implement memory mode checks here (kernel/super/user)
 	// For now we just assume kernel mode.
@@ -141,7 +141,7 @@ __fi void COP0_UpdatePCCR()
 
 			//prev ^= (1UL<<31);		// XOR is fun!
 			//if( (prev & cpuRegs.PERF.n.pcr0) & (1UL<<31) )
-			if( (cpuRegs.PERF.n.pcr0 & 0x80000000) && (cpuRegs.CP0.n.Status.b.ERL == 1) && cpuRegs.PERF.n.pccr.b.CTE)
+			if( (cpuRegs.PERF.n.pcr0 & 0x80000000) && (cpuRegs.Status.b.ERL == 1) && cpuRegs.PERF.n.pccr.b.CTE)
 			{
 				// TODO: Vector to the appropriate exception here.
 				// This code *should* be correct, but is untested (and other parts of the emu are
@@ -150,16 +150,16 @@ __fi void COP0_UpdatePCCR()
 				//branch == 1 is probably not the best way to check for the delay slot, but it beats nothing! (Refraction)
 			/*	if( branch == 1 )
 				{
-					cpuRegs.CP0.n.ErrorEPC = cpuRegs.pc - 4;
-					cpuRegs.CP0.n.Cause |= 0x40000000;
+					cpuRegs.ErrorEPC = cpuRegs.pc - 4;
+					cpuRegs.Cause |= 0x40000000;
 				}
 				else
 				{
-					cpuRegs.CP0.n.ErrorEPC = cpuRegs.pc;
-					cpuRegs.CP0.n.Cause &= ~0x40000000;
+					cpuRegs.ErrorEPC = cpuRegs.pc;
+					cpuRegs.Cause &= ~0x40000000;
 				}
 
-				if( cpuRegs.CP0.n.Status.b.DEV )
+				if( cpuRegs.Status.b.DEV )
 				{
 					// Bootstrap vector
 					cpuRegs.pc = 0xbfc00280;
@@ -168,8 +168,8 @@ __fi void COP0_UpdatePCCR()
 				{
 					cpuRegs.pc = 0x80000080;
 				}
-				cpuRegs.CP0.n.Status.b.ERL = 1;
-				cpuRegs.CP0.n.Cause |= 0x20000;*/
+				cpuRegs.Status.b.ERL = 1;
+				cpuRegs.Cause |= 0x20000;*/
 			}
 		}
 	}
@@ -188,7 +188,7 @@ __fi void COP0_UpdatePCCR()
 			cpuRegs.PERF.n.pcr1 += incr;
 			s_iLastPERFCycle[1] = cpuRegs.cycle;
 
-			if( (cpuRegs.PERF.n.pcr1 & 0x80000000) && (cpuRegs.CP0.n.Status.b.ERL == 1) && cpuRegs.PERF.n.pccr.b.CTE)
+			if( (cpuRegs.PERF.n.pcr1 & 0x80000000) && (cpuRegs.Status.b.ERL == 1) && cpuRegs.PERF.n.pccr.b.CTE)
 			{
 				// TODO: Vector to the appropriate exception here.
 				// This code *should* be correct, but is untested (and other parts of the emu are
@@ -198,16 +198,16 @@ __fi void COP0_UpdatePCCR()
 
 				/*if( branch == 1 )
 				{
-					cpuRegs.CP0.n.ErrorEPC = cpuRegs.pc - 4;
-					cpuRegs.CP0.n.Cause |= 0x40000000;
+					cpuRegs.ErrorEPC = cpuRegs.pc - 4;
+					cpuRegs.Cause |= 0x40000000;
 				}
 				else
 				{
-					cpuRegs.CP0.n.ErrorEPC = cpuRegs.pc;
-					cpuRegs.CP0.n.Cause &= ~0x40000000;
+					cpuRegs.ErrorEPC = cpuRegs.pc;
+					cpuRegs.Cause &= ~0x40000000;
 				}
 
-				if( cpuRegs.CP0.n.Status.b.DEV )
+				if( cpuRegs.Status.b.DEV )
 				{
 					// Bootstrap vector
 					cpuRegs.pc = 0xbfc00280;
@@ -216,8 +216,8 @@ __fi void COP0_UpdatePCCR()
 				{
 					cpuRegs.pc = 0x80000080;
 				}
-				cpuRegs.CP0.n.Status.b.ERL = 1;
-				cpuRegs.CP0.n.Cause |= 0x20000;*/
+				cpuRegs.Status.b.ERL = 1;
+				cpuRegs.Cause |= 0x20000;*/
 			}
 		}
 	}
@@ -310,19 +310,19 @@ void UnmapTLB(int i)
 
 void WriteTLB(int i)
 {
-	tlb[i].PageMask = cpuRegs.CP0.n.PageMask;
-	tlb[i].EntryHi = cpuRegs.CP0.n.EntryHi;
-	tlb[i].EntryLo0 = cpuRegs.CP0.n.EntryLo0;
-	tlb[i].EntryLo1 = cpuRegs.CP0.n.EntryLo1;
+	tlb[i].PageMask = cpuRegs.PageMask;
+	tlb[i].EntryHi = cpuRegs.EntryHi;
+	tlb[i].EntryLo0 = cpuRegs.EntryLo0;
+	tlb[i].EntryLo1 = cpuRegs.EntryLo1;
 
-	tlb[i].Mask = (cpuRegs.CP0.n.PageMask >> 13) & 0xfff;
+	tlb[i].Mask = (cpuRegs.PageMask >> 13) & 0xfff;
 	tlb[i].nMask = (~tlb[i].Mask) & 0xfff;
-	tlb[i].VPN2 = ((cpuRegs.CP0.n.EntryHi >> 13) & (~tlb[i].Mask)) << 13;
-	tlb[i].ASID = cpuRegs.CP0.n.EntryHi & 0xfff;
-	tlb[i].G = cpuRegs.CP0.n.EntryLo0 & cpuRegs.CP0.n.EntryLo1 & 0x1;
-	tlb[i].PFN0 = (((cpuRegs.CP0.n.EntryLo0 >> 6) & 0xFFFFF) & (~tlb[i].Mask)) << 12;
-	tlb[i].PFN1 = (((cpuRegs.CP0.n.EntryLo1 >> 6) & 0xFFFFF) & (~tlb[i].Mask)) << 12;
-	tlb[i].S = cpuRegs.CP0.n.EntryLo0&0x80000000;
+	tlb[i].VPN2 = ((cpuRegs.EntryHi >> 13) & (~tlb[i].Mask)) << 13;
+	tlb[i].ASID = cpuRegs.EntryHi & 0xfff;
+	tlb[i].G = cpuRegs.EntryLo0 & cpuRegs.EntryLo1 & 0x1;
+	tlb[i].PFN0 = (((cpuRegs.EntryLo0 >> 6) & 0xFFFFF) & (~tlb[i].Mask)) << 12;
+	tlb[i].PFN1 = (((cpuRegs.EntryLo1 >> 6) & 0xFFFFF) & (~tlb[i].Mask)) << 12;
+	tlb[i].S = cpuRegs.EntryLo0&0x80000000;
 
 	MapTLB(i);
 }
@@ -334,50 +334,50 @@ namespace COP0 {
 
 void TLBR() {
 	DevCon.Warning("COP0_TLBR %d:%x,%x,%x,%x\n",
-			cpuRegs.CP0.n.Index,   cpuRegs.CP0.n.PageMask, cpuRegs.CP0.n.EntryHi,
-			cpuRegs.CP0.n.EntryLo0, cpuRegs.CP0.n.EntryLo1);
+			cpuRegs.Index,   cpuRegs.PageMask, cpuRegs.EntryHi,
+			cpuRegs.EntryLo0, cpuRegs.EntryLo1);
 
-	int i = cpuRegs.CP0.n.Index & 0x3f;
+	int i = cpuRegs.Index & 0x3f;
 
-	cpuRegs.CP0.n.PageMask = tlb[i].PageMask;
-	cpuRegs.CP0.n.EntryHi = tlb[i].EntryHi&~(tlb[i].PageMask|0x1f00);
-	cpuRegs.CP0.n.EntryLo0 = (tlb[i].EntryLo0&~1)|((tlb[i].EntryHi>>12)&1);
-	cpuRegs.CP0.n.EntryLo1 =(tlb[i].EntryLo1&~1)|((tlb[i].EntryHi>>12)&1);
+	cpuRegs.PageMask = tlb[i].PageMask;
+	cpuRegs.EntryHi = tlb[i].EntryHi&~(tlb[i].PageMask|0x1f00);
+	cpuRegs.EntryLo0 = (tlb[i].EntryLo0&~1)|((tlb[i].EntryHi>>12)&1);
+	cpuRegs.EntryLo1 =(tlb[i].EntryLo1&~1)|((tlb[i].EntryHi>>12)&1);
 }
 
 void TLBWI() {
-	int j = cpuRegs.CP0.n.Index & 0x3f;
+	int j = cpuRegs.Index & 0x3f;
 
 	//if (j > 48) return;
 
 DbgCon.Warning("COP0_TLBWI %d:%x,%x,%x,%x\n",
-			cpuRegs.CP0.n.Index,    cpuRegs.CP0.n.PageMask, cpuRegs.CP0.n.EntryHi,
-			cpuRegs.CP0.n.EntryLo0, cpuRegs.CP0.n.EntryLo1);
+			cpuRegs.Index,    cpuRegs.PageMask, cpuRegs.EntryHi,
+			cpuRegs.EntryLo0, cpuRegs.EntryLo1);
 
 	UnmapTLB(j);
-	tlb[j].PageMask = cpuRegs.CP0.n.PageMask;
-	tlb[j].EntryHi = cpuRegs.CP0.n.EntryHi;
-	tlb[j].EntryLo0 = cpuRegs.CP0.n.EntryLo0;
-	tlb[j].EntryLo1 = cpuRegs.CP0.n.EntryLo1;
+	tlb[j].PageMask = cpuRegs.PageMask;
+	tlb[j].EntryHi = cpuRegs.EntryHi;
+	tlb[j].EntryLo0 = cpuRegs.EntryLo0;
+	tlb[j].EntryLo1 = cpuRegs.EntryLo1;
 	WriteTLB(j);
 }
 
 void TLBWR() {
-	int j = cpuRegs.CP0.n.Random & 0x3f;
+	int j = cpuRegs.Random & 0x3f;
 
 	//if (j > 48) return;
 
 DevCon.Warning("COP0_TLBWR %d:%x,%x,%x,%x\n",
-			cpuRegs.CP0.n.Random,   cpuRegs.CP0.n.PageMask, cpuRegs.CP0.n.EntryHi,
-			cpuRegs.CP0.n.EntryLo0, cpuRegs.CP0.n.EntryLo1);
+			cpuRegs.Random,   cpuRegs.PageMask, cpuRegs.EntryHi,
+			cpuRegs.EntryLo0, cpuRegs.EntryLo1);
 
 	//if (j > 48) return;
 
 	UnmapTLB(j);
-	tlb[j].PageMask = cpuRegs.CP0.n.PageMask;
-	tlb[j].EntryHi = cpuRegs.CP0.n.EntryHi;
-	tlb[j].EntryLo0 = cpuRegs.CP0.n.EntryLo0;
-	tlb[j].EntryLo1 = cpuRegs.CP0.n.EntryLo1;
+	tlb[j].PageMask = cpuRegs.PageMask;
+	tlb[j].EntryHi = cpuRegs.EntryHi;
+	tlb[j].EntryLo0 = cpuRegs.EntryLo0;
+	tlb[j].EntryLo1 = cpuRegs.EntryLo1;
 	WriteTLB(j);
 }
 
@@ -394,17 +394,17 @@ void TLBP() {
 		u32 u;
 	} EntryHi32;
 
-	EntryHi32.u = cpuRegs.CP0.n.EntryHi;
+	EntryHi32.u = cpuRegs.EntryHi;
 
-	cpuRegs.CP0.n.Index=0xFFFFFFFF;
+	cpuRegs.Index=0xFFFFFFFF;
 	for(i=0;i<48;i++){
 		if (tlb[i].VPN2 == ((~tlb[i].Mask) & (EntryHi32.s.VPN2))
 		&& ((tlb[i].G&1) || ((tlb[i].ASID & 0xff) == EntryHi32.s.ASID))) {
-			cpuRegs.CP0.n.Index = i;
+			cpuRegs.Index = i;
 			break;
 		}
 	}
-	 if(cpuRegs.CP0.n.Index == 0xFFFFFFFF) cpuRegs.CP0.n.Index = 0x80000000;
+	 if(cpuRegs.Index == 0xFFFFFFFF) cpuRegs.Index = 0x80000000;
 }
 
 void MFC0()
@@ -413,28 +413,28 @@ void MFC0()
 	if ((_Rd_ != 9) && !_Rt_ ) return;
 	if (_Rd_ != 9) { COP0_LOG("%s", disR5900Current.getCString() ); }
 
-	//if(bExecBIOS == FALSE && _Rd_ == 25) Console.WriteLn("MFC0 _Rd_ %x = %x", _Rd_, cpuRegs.CP0.r[_Rd_]);
+	//if(bExecBIOS == FALSE && _Rd_ == 25) Console.WriteLn("MFC0 _Rd_ %x = %x", _Rd_, cpuRegs.CP0[_Rd_]);
 	switch (_Rd_)
 	{
 		case 12:
-			cpuRegs.GPR.r[_Rt_].SD[0] = (s32)(cpuRegs.CP0.r[_Rd_] & 0xf0c79c1f);
+			cpuRegs.GPR[_Rt_].SD[0] = (s32)(cpuRegs.CP0[_Rd_] & 0xf0c79c1f);
 		break;
 
 		case 25:
 		    switch(_Imm_ & 0x3F)
 		    {
 			    case 0:		// MFPS  [LSB is clear]
-					cpuRegs.GPR.r[_Rt_].SD[0] = (s32)cpuRegs.PERF.n.pccr.val;
+					cpuRegs.GPR[_Rt_].SD[0] = (s32)cpuRegs.PERF.n.pccr.val;
 				break;
 
 			    case 1:		// MFPC [LSB is set] - read PCR0
 					COP0_UpdatePCCR();
-                    cpuRegs.GPR.r[_Rt_].SD[0] = (s32)cpuRegs.PERF.n.pcr0;
+                    cpuRegs.GPR[_Rt_].SD[0] = (s32)cpuRegs.PERF.n.pcr0;
 				break;
 
 			    case 3:		// MFPC [LSB is set] - read PCR1
 					COP0_UpdatePCCR();
-					cpuRegs.GPR.r[_Rt_].SD[0] = (s32)cpuRegs.PERF.n.pcr1;
+					cpuRegs.GPR[_Rt_].SD[0] = (s32)cpuRegs.PERF.n.pcr1;
 				break;
 		    }
 		    /*Console.WriteLn("MFC0 PCCR = %x PCR0 = %x PCR1 = %x IMM= %x",  params
@@ -449,29 +449,29 @@ void MFC0()
 		{
 			u32 incr = cpuRegs.cycle-s_iLastCOP0Cycle;
 			if( incr == 0 ) incr++;
-			cpuRegs.CP0.n.Count += incr;
+			cpuRegs.Count += incr;
 			s_iLastCOP0Cycle = cpuRegs.cycle;
 			if( !_Rt_ ) break;
 		}
 
 		default:
-			cpuRegs.GPR.r[_Rt_].UD[0] = (s64)cpuRegs.CP0.r[_Rd_];
+			cpuRegs.GPR[_Rt_].UD[0] = (s64)cpuRegs.CP0[_Rd_];
 	}
 }
 
 void MTC0()
 {
 	COP0_LOG("%s\n", disR5900Current.getCString());
-	//if(bExecBIOS == FALSE && _Rd_ == 25) Console.WriteLn("MTC0 _Rd_ %x = %x", _Rd_, cpuRegs.CP0.r[_Rd_]);
+	//if(bExecBIOS == FALSE && _Rd_ == 25) Console.WriteLn("MTC0 _Rd_ %x = %x", _Rd_, cpuRegs.CP0[_Rd_]);
 	switch (_Rd_)
 	{
 		case 9:
 			s_iLastCOP0Cycle = cpuRegs.cycle;
-			cpuRegs.CP0.r[9] = cpuRegs.GPR.r[_Rt_].UL[0];
+			cpuRegs.CP0[9] = cpuRegs.GPR[_Rt_].UL[0];
 		break;
 
 		case 12:
-			WriteCP0Status(cpuRegs.GPR.r[_Rt_].UL[0]);
+			WriteCP0Status(cpuRegs.GPR[_Rt_].UL[0]);
 		break;
 
 		case 24:
@@ -486,24 +486,24 @@ void MTC0()
 				case 0:		// MTPS  [LSB is clear]
 					// Updates PCRs and sets the PCCR.
 					COP0_UpdatePCCR();
-					cpuRegs.PERF.n.pccr.val = cpuRegs.GPR.r[_Rt_].UL[0];
+					cpuRegs.PERF.n.pccr.val = cpuRegs.GPR[_Rt_].UL[0];
 					COP0_DiagnosticPCCR();
 				break;
 
 				case 1:		// MTPC [LSB is set] - set PCR0
-					cpuRegs.PERF.n.pcr0 = cpuRegs.GPR.r[_Rt_].UL[0];
+					cpuRegs.PERF.n.pcr0 = cpuRegs.GPR[_Rt_].UL[0];
 					s_iLastPERFCycle[0] = cpuRegs.cycle;
 				break;
 
 				case 3:		// MTPC [LSB is set] - set PCR0
-					cpuRegs.PERF.n.pcr1 = cpuRegs.GPR.r[_Rt_].UL[0];
+					cpuRegs.PERF.n.pcr1 = cpuRegs.GPR[_Rt_].UL[0];
 					s_iLastPERFCycle[1] = cpuRegs.cycle;
 				break;
 			}
 		break;
 
 		default:
-			cpuRegs.CP0.r[_Rd_] = cpuRegs.GPR.r[_Rt_].UL[0];
+			cpuRegs.CP0[_Rd_] = cpuRegs.GPR[_Rt_].UL[0];
 		break;
 	}
 }
@@ -538,12 +538,12 @@ void BC0TL() {
 }
 
 void ERET() {
-	if (cpuRegs.CP0.n.Status.b.ERL) {
-		cpuRegs.pc = cpuRegs.CP0.n.ErrorEPC;
-		cpuRegs.CP0.n.Status.b.ERL = 0;
+	if (cpuRegs.Status.b.ERL) {
+		cpuRegs.pc = cpuRegs.ErrorEPC;
+		cpuRegs.Status.b.ERL = 0;
 	} else {
-		cpuRegs.pc = cpuRegs.CP0.n.EPC;
-		cpuRegs.CP0.n.Status.b.EXL = 0;
+		cpuRegs.pc = cpuRegs.EPC;
+		cpuRegs.Status.b.EXL = 0;
 	}
 	cpuUpdateOperationMode();
 	cpuSetNextEventDelta(4);
@@ -551,18 +551,18 @@ void ERET() {
 }
 
 void DI() {
-	if (cpuRegs.CP0.n.Status.b._EDI || cpuRegs.CP0.n.Status.b.EXL ||
-		cpuRegs.CP0.n.Status.b.ERL || (cpuRegs.CP0.n.Status.b.KSU == 0)) {
-		cpuRegs.CP0.n.Status.b.EIE = 0;
+	if (cpuRegs.Status.b._EDI || cpuRegs.Status.b.EXL ||
+		cpuRegs.Status.b.ERL || (cpuRegs.Status.b.KSU == 0)) {
+		cpuRegs.Status.b.EIE = 0;
 		// IRQs are disabled so no need to do a cpu exception/event test...
 		//cpuSetNextEventDelta();
 	}
 }
 
 void EI() {
-	if (cpuRegs.CP0.n.Status.b._EDI || cpuRegs.CP0.n.Status.b.EXL ||
-		cpuRegs.CP0.n.Status.b.ERL || (cpuRegs.CP0.n.Status.b.KSU == 0)) {
-		cpuRegs.CP0.n.Status.b.EIE = 1;
+	if (cpuRegs.Status.b._EDI || cpuRegs.Status.b.EXL ||
+		cpuRegs.Status.b.ERL || (cpuRegs.Status.b.KSU == 0)) {
+		cpuRegs.Status.b.EIE = 1;
 		// schedule an event test, which will check for and raise pending IRQs.
 		cpuSetNextEventDelta(4);
 	}

--- a/pcsx2/Cache.cpp
+++ b/pcsx2/Cache.cpp
@@ -39,7 +39,7 @@ int getFreeCache(u32 mem, int mode, int * way ) {
 	u32 hand=(u8)vmv;
 	u32 paddr=ppf-hand+0x80000000;
 
-	if((cpuRegs.CP0.n.Config & 0x10000)  == 0) CACHE_LOG("Cache off!");
+	if((cpuRegs.Config & 0x10000)  == 0) CACHE_LOG("Cache off!");
 	
 	if ((pCache[i].tag[0] & ~0xFFF) == (paddr & ~0xFFF) && (pCache[i].tag[0] & VALID_FLAG))
 	{
@@ -248,8 +248,8 @@ extern int Dcache;
 void CACHE() {
     u32 addr;
 
-   addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
-  // CACHE_LOG("cpuRegs.GPR.r[_Rs_].UL[0] = %x, IMM = %x RT = %x", cpuRegs.GPR.r[_Rs_].UL[0], _Imm_, _Rt_);
+   addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
+  // CACHE_LOG("cpuRegs.GPR[_Rs_].UL[0] = %x, IMM = %x RT = %x", cpuRegs.GPR[_Rs_].UL[0], _Imm_, _Rt_);
 	switch (_Rt_) 
 	{
 		case 0x1a: //DHIN (Data Cache Hit Invalidate)
@@ -412,9 +412,9 @@ void CACHE() {
 			int index = (addr >> 6) & 0x3F;
 			int way = addr & 0x1;
 
-			cpuRegs.CP0.n.TagLo = pCache[index].data[way][(addr>>4) & 0x3].b8._u32[(addr&0xf)>>2];
+			cpuRegs.TagLo = pCache[index].data[way][(addr>>4) & 0x3].b8._u32[(addr&0xf)>>2];
 
-			CACHE_LOG("CACHE DXLDT addr %x, index %d, way %d, DATA %x OP %x",addr,index,way,cpuRegs.CP0.r[28], cpuRegs.code);
+			CACHE_LOG("CACHE DXLDT addr %x, index %d, way %d, DATA %x OP %x",addr,index,way,cpuRegs.CP0[28], cpuRegs.code);
 
 			break;
 		}
@@ -423,9 +423,9 @@ void CACHE() {
 			int index = (addr >> 6) & 0x3F;
 			int way = addr & 0x1;
 			
-			cpuRegs.CP0.n.TagLo = pCache[index].tag[way];
+			cpuRegs.TagLo = pCache[index].tag[way];
 
-			CACHE_LOG("CACHE DXLTG addr %x, index %d, way %d, DATA %x OP %x ",addr,index,way,cpuRegs.CP0.r[28], cpuRegs.code);
+			CACHE_LOG("CACHE DXLTG addr %x, index %d, way %d, DATA %x OP %x ",addr,index,way,cpuRegs.CP0[28], cpuRegs.code);
 
 			break;
 		}
@@ -434,9 +434,9 @@ void CACHE() {
 			int index = (addr >> 6) & 0x3F;
 			int way = addr & 0x1;
 
-			pCache[index].data[way][(addr>>4) & 0x3].b8._u32[(addr&0xf)>>2] = cpuRegs.CP0.n.TagLo;
+			pCache[index].data[way][(addr>>4) & 0x3].b8._u32[(addr&0xf)>>2] = cpuRegs.TagLo;
 
-			CACHE_LOG("CACHE DXSDT addr %x, index %d, way %d, DATA %x OP %x",addr,index,way,cpuRegs.CP0.r[28], cpuRegs.code);
+			CACHE_LOG("CACHE DXSDT addr %x, index %d, way %d, DATA %x OP %x",addr,index,way,cpuRegs.CP0[28], cpuRegs.code);
 
 			break;
 		}
@@ -444,9 +444,9 @@ void CACHE() {
 		{
 			int index = (addr >> 6) & 0x3F;
 			int way = addr & 0x1;
-			pCache[index].tag[way] = cpuRegs.CP0.n.TagLo; 
+			pCache[index].tag[way] = cpuRegs.TagLo; 
 
-			CACHE_LOG("CACHE DXSTG addr %x, index %d, way %d, DATA %x OP %x",addr,index,way,cpuRegs.CP0.r[28] & 0x6F, cpuRegs.code);
+			CACHE_LOG("CACHE DXSTG addr %x, index %d, way %d, DATA %x OP %x",addr,index,way,cpuRegs.CP0[28] & 0x6F, cpuRegs.code);
 
 			break;
 		}

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -386,12 +386,12 @@ u128 R5900DebugInterface::getRegister(int cat, int num)
 			result = cpuRegs.LO.UQ;
 			break;
 		default:
-			result = cpuRegs.GPR.r[num].UQ;
+			result = cpuRegs.GPR[num].UQ;
 			break;
 		}
 		break;
 	case EECAT_CP0:
-		result = u128::From32(cpuRegs.CP0.r[num]);
+		result = u128::From32(cpuRegs.CP0[num]);
 		break;
 	case EECAT_CP1:
 		result = u128::From32(fpuRegs.fpr[num].UL);
@@ -466,12 +466,12 @@ void R5900DebugInterface::setRegister(int cat, int num, u128 newValue)
 			cpuRegs.LO.UQ = newValue;
 			break;
 		default:
-			cpuRegs.GPR.r[num].UQ = newValue;
+			cpuRegs.GPR[num].UQ = newValue;
 			break;
 		}
 		break;
 	case EECAT_CP0:
-		cpuRegs.CP0.r[num] = newValue._u32[0];
+		cpuRegs.CP0[num] = newValue._u32[0];
 		break;
 	case EECAT_CP1:
 		fpuRegs.fpr[num].UL = newValue._u32[0];
@@ -664,13 +664,13 @@ u128 R3000DebugInterface::getRegister(int cat, int num)
 			value = psxRegs.pc;
 			break;
 		case 33:	// hi
-			value = psxRegs.GPR.n.hi;
+			value = psxRegs.hi;
 			break;
 		case 34:	// lo
-			value = psxRegs.GPR.n.lo;
+			value = psxRegs.lo;
 			break;
 		default:
-			value = psxRegs.GPR.r[num];
+			value = psxRegs.GPR[num];
 			break;
 		}
 		break;
@@ -695,12 +695,12 @@ wxString R3000DebugInterface::getRegisterString(int cat, int num)
 
 u128 R3000DebugInterface::getHI()
 {
-	return u128::From32(psxRegs.GPR.n.hi);
+	return u128::From32(psxRegs.hi);
 }
 
 u128 R3000DebugInterface::getLO()
 {
-	return u128::From32(psxRegs.GPR.n.lo);
+	return u128::From32(psxRegs.lo);
 }
 
 u32 R3000DebugInterface::getPC()
@@ -724,13 +724,13 @@ void R3000DebugInterface::setRegister(int cat, int num, u128 newValue)
 			psxRegs.pc = newValue._u32[0];
 			break;
 		case 33:	// hi
-			psxRegs.GPR.n.hi = newValue._u32[0];
+			psxRegs.hi = newValue._u32[0];
 			break;
 		case 34:	// lo
-			psxRegs.GPR.n.lo = newValue._u32[0];
+			psxRegs.lo = newValue._u32[0];
 			break;
 		default:
-			psxRegs.GPR.r[num] = newValue._u32[0];
+			psxRegs.GPR[num] = newValue._u32[0];
 			break;
 		}
 		break;

--- a/pcsx2/DebugTools/DisR3000A.cpp
+++ b/pcsx2/DebugTools/DisR3000A.cpp
@@ -69,14 +69,14 @@ typedef char* (*TdisR3000AF)(u32 code, u32 pc);
 #define _OfB_     _Im_, _nRs_
 
 #define dName(i)	sprintf(ostr + strlen(ostr), " %-7s,", i)
-#define dGPR(i)		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR.r[i], disRNameGPR[i])
-#define dCP0(i)		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.CP0.r[i], disRNameCP0[i])
-#define dHI()		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR.n.hi, "hi")
-#define dLO()		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR.n.lo, "lo")
+#define dGPR(i)		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.GPR[i], disRNameGPR[i])
+#define dCP0(i)		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.CP0[i], disRNameCP0[i])
+#define dHI()		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.hi, "hi")
+#define dLO()		sprintf(ostr + strlen(ostr), " %8.8x (%s),", psxRegs.lo, "lo")
 #define dImm()		sprintf(ostr + strlen(ostr), " %4.4x (%d),", _Im_, _Im_)
 #define dTarget()	sprintf(ostr + strlen(ostr), " %8.8x,", _Target_)
 #define dSa()		sprintf(ostr + strlen(ostr), " %2.2x (%d),", _Sa_, _Sa_)
-#define dOfB()		sprintf(ostr + strlen(ostr), " %4.4x (%8.8x (%s)),", _Im_, psxRegs.GPR.r[_Rs_], disRNameGPR[_Rs_])
+#define dOfB()		sprintf(ostr + strlen(ostr), " %4.4x (%8.8x (%s)),", _Im_, psxRegs.GPR[_Rs_], disRNameGPR[_Rs_])
 #define dOffset()	sprintf(ostr + strlen(ostr), " %8.8x,", _Branch_)
 #define dCode()		sprintf(ostr + strlen(ostr), " %8.8x,", (code >> 6) & 0xffffff)
 

--- a/pcsx2/DebugTools/DisR5900.cpp
+++ b/pcsx2/DebugTools/DisR5900.cpp
@@ -93,17 +93,17 @@ typedef void (*TdisR5900F)DisFInterface;
 #define _Im_     ( code & 0xFFFF)      // The immediate part of the instruction register
 
 
-#define _rRs_   cpuRegs.GPR.r[_Rs_].UL[1], cpuRegs.GPR.r[_Rs_].UL[0]   // Rs register
-#define _rRt_   cpuRegs.GPR.r[_Rt_].UL[1], cpuRegs.GPR.r[_Rt_].UL[0]   // Rt register
-#define _rRd_   cpuRegs.GPR.r[_Rd_].UL[1], cpuRegs.GPR.r[_Rd_].UL[0]   // Rd register
-#define _rSa_   cpuRegs.GPR.r[_Sa_].UL[1], cpuRegs.GPR.r[_Sa_].UL[0]   // Sa register
+#define _rRs_   cpuRegs.GPR[_Rs_].UL[1], cpuRegs.GPR[_Rs_].UL[0]   // Rs register
+#define _rRt_   cpuRegs.GPR[_Rt_].UL[1], cpuRegs.GPR[_Rt_].UL[0]   // Rt register
+#define _rRd_   cpuRegs.GPR[_Rd_].UL[1], cpuRegs.GPR[_Rd_].UL[0]   // Rd register
+#define _rSa_   cpuRegs.GPR[_Sa_].UL[1], cpuRegs.GPR[_Sa_].UL[0]   // Sa register
 
-#define _rFs_   cpuRegs.CP0.r[_Rd_]   // Fs register
+#define _rFs_   cpuRegs.CP0[_Rd_]   // Fs register
 
-#define _rRs32_   cpuRegs.GPR.r[_Rs_].UL[0]   // Rs register
-#define _rRt32_   cpuRegs.GPR.r[_Rt_].UL[0]   // Rt register
-#define _rRd32_   cpuRegs.GPR.r[_Rd_].UL[0]   // Rd register
-#define _rSa32_   cpuRegs.GPR.r[_Sa_].UL[0]   // Sa register
+#define _rRs32_   cpuRegs.GPR[_Rs_].UL[0]   // Rs register
+#define _rRt32_   cpuRegs.GPR[_Rt_].UL[0]   // Rt register
+#define _rRd32_   cpuRegs.GPR[_Rd_].UL[0]   // Rd register
+#define _rSa32_   cpuRegs.GPR[_Sa_].UL[0]   // Sa register
 
 
 #define _nRs_ _rRs_, disRNameGPR[_Rs_]
@@ -130,12 +130,12 @@ typedef void (*TdisR5900F)DisFInterface;
 #define _sap( str ) ssappendf( output, str,
 
 #define dName(i)	_sap("%-7s\t") i);
-#define dGPR128(i)	_sap("%8.8x_%8.8x_%8.8x_%8.8x (%s),") cpuRegs.GPR.r[i].UL[3], cpuRegs.GPR.r[i].UL[2], cpuRegs.GPR.r[i].UL[1], cpuRegs.GPR.r[i].UL[0], disRNameGPR[i])
-#define dGPR64(i)	_sap("%8.8x_%8.8x (%s),") cpuRegs.GPR.r[i].UL[1], cpuRegs.GPR.r[i].UL[0], disRNameGPR[i])
-#define dGPR64U(i)	_sap("%8.8x_%8.8x (%s),") cpuRegs.GPR.r[i].UL[3], cpuRegs.GPR.r[i].UL[2], disRNameGPR[i])
-#define dGPR32(i)	_sap("%8.8x (%s),") cpuRegs.GPR.r[i].UL[0], disRNameGPR[i])
+#define dGPR128(i)	_sap("%8.8x_%8.8x_%8.8x_%8.8x (%s),") cpuRegs.GPR[i].UL[3], cpuRegs.GPR[i].UL[2], cpuRegs.GPR[i].UL[1], cpuRegs.GPR[i].UL[0], disRNameGPR[i])
+#define dGPR64(i)	_sap("%8.8x_%8.8x (%s),") cpuRegs.GPR[i].UL[1], cpuRegs.GPR[i].UL[0], disRNameGPR[i])
+#define dGPR64U(i)	_sap("%8.8x_%8.8x (%s),") cpuRegs.GPR[i].UL[3], cpuRegs.GPR[i].UL[2], disRNameGPR[i])
+#define dGPR32(i)	_sap("%8.8x (%s),") cpuRegs.GPR[i].UL[0], disRNameGPR[i])
 
-#define dCP032(i)	_sap("%8.8x (%s),") cpuRegs.CP0.r[i], disRNameCP0[i])
+#define dCP032(i)	_sap("%8.8x (%s),") cpuRegs.CP0[i], disRNameCP0[i])
 
 #define dCP132(i)	_sap("%f (%s),") fpuRegs.fpr[i].f, disRNameCP1[i])
 #define dCP1c32(i)	_sap("%8.8x (%s),") fpuRegs.fprc[i], disRNameCP1c[i])
@@ -157,7 +157,7 @@ typedef void (*TdisR5900F)DisFInterface;
 #define dTarget()	_sap("%8.8x,") _Target_)
 #define dSa()		_sap("%2.2x (%d),") _Sa_, _Sa_)
 #define dSa32()		_sap("%2.2x (%d),") _Sa_+32, _Sa_+32)
-#define dOfB()		_sap("%4.4x (%8.8x (%s)),") _Im_, cpuRegs.GPR.r[_Rs_].UL[0], disRNameGPR[_Rs_])
+#define dOfB()		_sap("%4.4x (%8.8x (%s)),") _Im_, cpuRegs.GPR[_Rs_].UL[0], disRNameGPR[_Rs_])
 #define dOffset()	_sap("%8.8x,") _Branch_)
 #define dCode()		_sap("%8.8x,") (code >> 6) & 0xffffff)
 #define dSaR()		_sap("%8.8x,") cpuRegs.sa)
@@ -274,8 +274,8 @@ MakeDisF(disJAL,		dName("JAL"); dTarget(); dGPR32(31); dAppendSym(_Target_);)
 * Register jump                                          *
 * Format:  OP rs, rd                                     *
 *********************************************************/
-MakeDisF(disJR,			dName("JR");   dGPR32(_Rs_); dAppendSym(cpuRegs.GPR.r[_Rs_].UL[0]);)
-MakeDisF(disJALR,		dName("JALR"); dGPR32(_Rs_); dGPR32(_Rd_); dAppendSym(cpuRegs.GPR.r[_Rs_].UL[0]);)
+MakeDisF(disJR,			dName("JR");   dGPR32(_Rs_); dAppendSym(cpuRegs.GPR[_Rs_].UL[0]);)
+MakeDisF(disJALR,		dName("JALR"); dGPR32(_Rs_); dGPR32(_Rd_); dAppendSym(cpuRegs.GPR[_Rs_].UL[0]);)
 
 /*********************************************************
 * Register mult/div & Register trap logic                *

--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -423,10 +423,10 @@ namespace MIPSAnalyst
 					info.isConditional = false;
 
 					// probably shouldn't be hard coded like this...
-					if (cpuRegs.CP0.n.Status.b.ERL) {
-						info.branchTarget = cpuRegs.CP0.n.ErrorEPC;
+					if (cpuRegs.Status.b.ERL) {
+						info.branchTarget = cpuRegs.ErrorEPC;
 					} else {
-						info.branchTarget = cpuRegs.CP0.n.EPC;
+						info.branchTarget = cpuRegs.EPC;
 					}
 					break;
 				}

--- a/pcsx2/Dump.cpp
+++ b/pcsx2/Dump.cpp
@@ -50,9 +50,9 @@ void iDumpPsxRegisters(u32 startpc, u32 temp)
 	const char* pstr = temp ? "t" : "";
 
 	// fixme: PSXM doesn't exist any more.
-	//__Log("%spsxreg: %x %x ra:%x k0: %x %x", pstr, startpc, psxRegs.cycle, psxRegs.GPR.n.ra, psxRegs.GPR.n.k0, *(int*)PSXM(0x13c128));
+	//__Log("%spsxreg: %x %x ra:%x k0: %x %x", pstr, startpc, psxRegs.cycle, psxRegs.ra, psxRegs.k0, *(int*)PSXM(0x13c128));
 
-	for(i = 0; i < 34; i+=2) __Log("%spsx%s: %x %x", pstr, disRNameGPR[i], psxRegs.GPR.r[i], psxRegs.GPR.r[i+1]);
+	for(i = 0; i < 34; i+=2) __Log("%spsx%s: %x %x", pstr, disRNameGPR[i], psxRegs.GPR[i], psxRegs.GPR[i+1]);
 
 	DbgCon.WriteLn("%scycle: %x %x %x; counters %x %x", pstr, psxRegs.cycle, g_iopNextEventCycle, EEsCycle,
 		psxNextsCounter, psxNextCounter);
@@ -96,9 +96,9 @@ void iDumpRegisters(u32 startpc, u32 temp)
 	else
 		__Log("%sreg: %x %x c:%x", pstr, startpc, cpuRegs.interrupt, cpuRegs.cycle);
 
-	for(i = 1; i < 32; ++i) __Log("%s: %x_%x_%x_%x", disRNameGPR[i], cpuRegs.GPR.r[i].UL[3], cpuRegs.GPR.r[i].UL[2], cpuRegs.GPR.r[i].UL[1], cpuRegs.GPR.r[i].UL[0]);
+	for(i = 1; i < 32; ++i) __Log("%s: %x_%x_%x_%x", disRNameGPR[i], cpuRegs.GPR[i].UL[3], cpuRegs.GPR[i].UL[2], cpuRegs.GPR[i].UL[1], cpuRegs.GPR[i].UL[0]);
 
-	//for(i = 0; i < 32; i+=4) __Log("cp%d: %x_%x_%x_%x", i, cpuRegs.CP0.r[i], cpuRegs.CP0.r[i+1], cpuRegs.CP0.r[i+2], cpuRegs.CP0.r[i+3]);
+	//for(i = 0; i < 32; i+=4) __Log("cp%d: %x_%x_%x_%x", i, cpuRegs.CP0[i], cpuRegs.CP0[i+1], cpuRegs.CP0[i+2], cpuRegs.CP0[i+3]);
 	//for(i = 0; i < 32; ++i) __Log("%sf%d: %f %x", pstr, i, fpuRegs.fpr[i].f, fpuRegs.fprc[i]);
 	//for(i = 1; i < 32; ++i) __Log("%svf%d: %f %f %f %f, vi: %x", pstr, i, VU0.VF[i].F[3], VU0.VF[i].F[2], VU0.VF[i].F[1], VU0.VF[i].F[0], VU0.VI[i].UL);
 
@@ -108,7 +108,7 @@ void iDumpRegisters(u32 startpc, u32 temp)
 	__Log("%svfACC: %x %x %x %x", pstr, VU0.ACC.UL[3], VU0.ACC.UL[2], VU0.ACC.UL[1], VU0.ACC.UL[0]);
 	__Log("%sLO: %x_%x_%x_%x, HI: %x_%x_%x_%x", pstr, cpuRegs.LO.UL[3], cpuRegs.LO.UL[2], cpuRegs.LO.UL[1], cpuRegs.LO.UL[0],
 	cpuRegs.HI.UL[3], cpuRegs.HI.UL[2], cpuRegs.HI.UL[1], cpuRegs.HI.UL[0]);
-	__Log("%sCycle: %x %x, Count: %x", pstr, cpuRegs.cycle, g_nextEventCycle, cpuRegs.CP0.n.Count);
+	__Log("%sCycle: %x %x, Count: %x", pstr, cpuRegs.cycle, g_nextEventCycle, cpuRegs.Count);
 
 	iDumpPsxRegisters(psxRegs.pc, temp);
 

--- a/pcsx2/FPU.cpp
+++ b/pcsx2/FPU.cpp
@@ -224,12 +224,12 @@ void C_LT() {
 
 void CFC1() {
 	if ( !_Rt_ || ( (_Fs_ != 0) && (_Fs_ != 31) ) ) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = (s32)fpuRegs.fprc[_Fs_];	// force sign extension to 64 bit
+	cpuRegs.GPR[_Rt_].SD[0] = (s32)fpuRegs.fprc[_Fs_];	// force sign extension to 64 bit
 }
 
 void CTC1() {
 	if ( _Fs_ != 31 ) return;
-	fpuRegs.fprc[_Fs_] = cpuRegs.GPR.r[_Rt_].UL[0];
+	fpuRegs.fprc[_Fs_] = cpuRegs.GPR[_Rt_].UL[0];
 }
 
 void CVT_S() {
@@ -275,7 +275,7 @@ void MAX_S() {
 
 void MFC1() {
 	if ( !_Rt_ ) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = _FsValSl_;		// sign extension into 64bit
+	cpuRegs.GPR[_Rt_].SD[0] = _FsValSl_;		// sign extension into 64bit
 }
 
 void MIN_S() {
@@ -302,7 +302,7 @@ void MSUBA_S() {
 }
 
 void MTC1() {
-	_FsValUl_ = cpuRegs.GPR.r[_Rt_].UL[0];
+	_FsValUl_ = cpuRegs.GPR[_Rt_].UL[0];
 }
 
 void MUL_S() {
@@ -372,14 +372,14 @@ void SUBA_S() {
 
 void LWC1() {
 	u32 addr;
-	addr = cpuRegs.GPR.r[_Rs_].UL[0] + (s16)(cpuRegs.code & 0xffff);	// force sign extension to 32bit
+	addr = cpuRegs.GPR[_Rs_].UL[0] + (s16)(cpuRegs.code & 0xffff);	// force sign extension to 32bit
 	if (addr & 0x00000003) { Console.Error( "FPU (LWC1 Opcode): Invalid Unaligned Memory Address" ); return; }  // Should signal an exception?
 	fpuRegs.fpr[_Rt_].UL = memRead32(addr);
 }
 
 void SWC1() {
 	u32 addr;
-	addr = cpuRegs.GPR.r[_Rs_].UL[0] + (s16)(cpuRegs.code & 0xffff);	// force sign extension to 32bit
+	addr = cpuRegs.GPR[_Rs_].UL[0] + (s16)(cpuRegs.code & 0xffff);	// force sign extension to 32bit
 	if (addr & 0x00000003) { Console.Error( "FPU (SWC1 Opcode): Invalid Unaligned Memory Address" ); return; }  // Should signal an exception?
 	memWrite32(addr, fpuRegs.fpr[_Rt_].UL);
 }

--- a/pcsx2/Gte.cpp
+++ b/pcsx2/Gte.cpp
@@ -22,10 +22,10 @@
 #include "IopCommon.h"
 #ifdef GTE_DUMP
 #define G_OP(name,delay) fprintf(gteLog, "* : %08X : %02d : %s\n", psxRegs.code, delay, name);
-#define G_SD(reg)  fprintf(gteLog, "+D%02d : %08X\n", reg, psxRegs.CP2D.r[reg]);
-#define G_SC(reg)  fprintf(gteLog, "+C%02d : %08X\n", reg, psxRegs.CP2C.r[reg]);
-#define G_GD(reg)  fprintf(gteLog, "-D%02d : %08X\n", reg, psxRegs.CP2D.r[reg]);
-#define G_GC(reg)  fprintf(gteLog, "-C%02d : %08X\n", reg, psxRegs.CP2C.r[reg]);
+#define G_SD(reg)  fprintf(gteLog, "+D%02d : %08X\n", reg, psxRegs.CP2D[reg]);
+#define G_SC(reg)  fprintf(gteLog, "+C%02d : %08X\n", reg, psxRegs.CP2C[reg]);
+#define G_GD(reg)  fprintf(gteLog, "-D%02d : %08X\n", reg, psxRegs.CP2D[reg]);
+#define G_GC(reg)  fprintf(gteLog, "-C%02d : %08X\n", reg, psxRegs.CP2C[reg]);
 #else
 #define G_OP(name,delay)
 #define G_SD(reg)
@@ -41,119 +41,119 @@
 #pragma warning(disable:4761)
 #endif
 
-#define gteVX0     ((s16*)psxRegs.CP2D.r)[0]
-#define gteVY0     ((s16*)psxRegs.CP2D.r)[1]
-#define gteVZ0     ((s16*)psxRegs.CP2D.r)[2]
-#define gteVX1     ((s16*)psxRegs.CP2D.r)[4]
-#define gteVY1     ((s16*)psxRegs.CP2D.r)[5]
-#define gteVZ1     ((s16*)psxRegs.CP2D.r)[6]
-#define gteVX2     ((s16*)psxRegs.CP2D.r)[8]
-#define gteVY2     ((s16*)psxRegs.CP2D.r)[9]
-#define gteVZ2     ((s16*)psxRegs.CP2D.r)[10]
-#define gteRGB     psxRegs.CP2D.r[6]
-#define gteOTZ     ((s16*)psxRegs.CP2D.r)[7*2]
-#define gteIR0     ((s32*)psxRegs.CP2D.r)[8]
-#define gteIR1     ((s32*)psxRegs.CP2D.r)[9]
-#define gteIR2     ((s32*)psxRegs.CP2D.r)[10]
-#define gteIR3     ((s32*)psxRegs.CP2D.r)[11]
-#define gteSXY0    ((s32*)psxRegs.CP2D.r)[12]
-#define gteSXY1    ((s32*)psxRegs.CP2D.r)[13]
-#define gteSXY2    ((s32*)psxRegs.CP2D.r)[14]
-#define gteSXYP    ((s32*)psxRegs.CP2D.r)[15]
-#define gteSX0     ((s16*)psxRegs.CP2D.r)[12*2]
-#define gteSY0     ((s16*)psxRegs.CP2D.r)[12*2+1]
-#define gteSX1     ((s16*)psxRegs.CP2D.r)[13*2]
-#define gteSY1     ((s16*)psxRegs.CP2D.r)[13*2+1]
-#define gteSX2     ((s16*)psxRegs.CP2D.r)[14*2]
-#define gteSY2     ((s16*)psxRegs.CP2D.r)[14*2+1]
-#define gteSXP     ((s16*)psxRegs.CP2D.r)[15*2]
-#define gteSYP     ((s16*)psxRegs.CP2D.r)[15*2+1]
-#define gteSZx     ((u16*)psxRegs.CP2D.r)[16*2]
-#define gteSZ0     ((u16*)psxRegs.CP2D.r)[17*2]
-#define gteSZ1     ((u16*)psxRegs.CP2D.r)[18*2]
-#define gteSZ2     ((u16*)psxRegs.CP2D.r)[19*2]
-#define gteRGB0    psxRegs.CP2D.r[20]
-#define gteRGB1    psxRegs.CP2D.r[21]
-#define gteRGB2    psxRegs.CP2D.r[22]
-#define gteMAC0    psxRegs.CP2D.r[24]
-#define gteMAC1    ((s32*)psxRegs.CP2D.r)[25]
-#define gteMAC2    ((s32*)psxRegs.CP2D.r)[26]
-#define gteMAC3    ((s32*)psxRegs.CP2D.r)[27]
-#define gteIRGB    psxRegs.CP2D.r[28]
-#define gteORGB    psxRegs.CP2D.r[29]
-#define gteLZCS    psxRegs.CP2D.r[30]
-#define gteLZCR    psxRegs.CP2D.r[31]
+#define gteVX0     ((s16*)psxRegs.CP2D)[0]
+#define gteVY0     ((s16*)psxRegs.CP2D)[1]
+#define gteVZ0     ((s16*)psxRegs.CP2D)[2]
+#define gteVX1     ((s16*)psxRegs.CP2D)[4]
+#define gteVY1     ((s16*)psxRegs.CP2D)[5]
+#define gteVZ1     ((s16*)psxRegs.CP2D)[6]
+#define gteVX2     ((s16*)psxRegs.CP2D)[8]
+#define gteVY2     ((s16*)psxRegs.CP2D)[9]
+#define gteVZ2     ((s16*)psxRegs.CP2D)[10]
+#define gteRGB     psxRegs.CP2D[6]
+#define gteOTZ     ((s16*)psxRegs.CP2D)[7*2]
+#define gteIR0     ((s32*)psxRegs.CP2D)[8]
+#define gteIR1     ((s32*)psxRegs.CP2D)[9]
+#define gteIR2     ((s32*)psxRegs.CP2D)[10]
+#define gteIR3     ((s32*)psxRegs.CP2D)[11]
+#define gteSXY0    ((s32*)psxRegs.CP2D)[12]
+#define gteSXY1    ((s32*)psxRegs.CP2D)[13]
+#define gteSXY2    ((s32*)psxRegs.CP2D)[14]
+#define gteSXYP    ((s32*)psxRegs.CP2D)[15]
+#define gteSX0     ((s16*)psxRegs.CP2D)[12*2]
+#define gteSY0     ((s16*)psxRegs.CP2D)[12*2+1]
+#define gteSX1     ((s16*)psxRegs.CP2D)[13*2]
+#define gteSY1     ((s16*)psxRegs.CP2D)[13*2+1]
+#define gteSX2     ((s16*)psxRegs.CP2D)[14*2]
+#define gteSY2     ((s16*)psxRegs.CP2D)[14*2+1]
+#define gteSXP     ((s16*)psxRegs.CP2D)[15*2]
+#define gteSYP     ((s16*)psxRegs.CP2D)[15*2+1]
+#define gteSZx     ((u16*)psxRegs.CP2D)[16*2]
+#define gteSZ0     ((u16*)psxRegs.CP2D)[17*2]
+#define gteSZ1     ((u16*)psxRegs.CP2D)[18*2]
+#define gteSZ2     ((u16*)psxRegs.CP2D)[19*2]
+#define gteRGB0    psxRegs.CP2D[20]
+#define gteRGB1    psxRegs.CP2D[21]
+#define gteRGB2    psxRegs.CP2D[22]
+#define gteMAC0    psxRegs.CP2D[24]
+#define gteMAC1    ((s32*)psxRegs.CP2D)[25]
+#define gteMAC2    ((s32*)psxRegs.CP2D)[26]
+#define gteMAC3    ((s32*)psxRegs.CP2D)[27]
+#define gteIRGB    psxRegs.CP2D[28]
+#define gteORGB    psxRegs.CP2D[29]
+#define gteLZCS    psxRegs.CP2D[30]
+#define gteLZCR    psxRegs.CP2D[31]
 
-#define gteR       ((u8 *)psxRegs.CP2D.r)[6*4]
-#define gteG       ((u8 *)psxRegs.CP2D.r)[6*4+1]
-#define gteB       ((u8 *)psxRegs.CP2D.r)[6*4+2]
-#define gteCODE    ((u8 *)psxRegs.CP2D.r)[6*4+3]
+#define gteR       ((u8 *)psxRegs.CP2D)[6*4]
+#define gteG       ((u8 *)psxRegs.CP2D)[6*4+1]
+#define gteB       ((u8 *)psxRegs.CP2D)[6*4+2]
+#define gteCODE    ((u8 *)psxRegs.CP2D)[6*4+3]
 #define gteC       gteCODE
 
-#define gteR0      ((u8 *)psxRegs.CP2D.r)[20*4]
-#define gteG0      ((u8 *)psxRegs.CP2D.r)[20*4+1]
-#define gteB0      ((u8 *)psxRegs.CP2D.r)[20*4+2]
-#define gteCODE0   ((u8 *)psxRegs.CP2D.r)[20*4+3]
+#define gteR0      ((u8 *)psxRegs.CP2D)[20*4]
+#define gteG0      ((u8 *)psxRegs.CP2D)[20*4+1]
+#define gteB0      ((u8 *)psxRegs.CP2D)[20*4+2]
+#define gteCODE0   ((u8 *)psxRegs.CP2D)[20*4+3]
 #define gteC0      gteCODE0
 
-#define gteR1      ((u8 *)psxRegs.CP2D.r)[21*4]
-#define gteG1      ((u8 *)psxRegs.CP2D.r)[21*4+1]
-#define gteB1      ((u8 *)psxRegs.CP2D.r)[21*4+2]
-#define gteCODE1   ((u8 *)psxRegs.CP2D.r)[21*4+3]
+#define gteR1      ((u8 *)psxRegs.CP2D)[21*4]
+#define gteG1      ((u8 *)psxRegs.CP2D)[21*4+1]
+#define gteB1      ((u8 *)psxRegs.CP2D)[21*4+2]
+#define gteCODE1   ((u8 *)psxRegs.CP2D)[21*4+3]
 #define gteC1      gteCODE1
 
-#define gteR2      ((u8 *)psxRegs.CP2D.r)[22*4]
-#define gteG2      ((u8 *)psxRegs.CP2D.r)[22*4+1]
-#define gteB2      ((u8 *)psxRegs.CP2D.r)[22*4+2]
-#define gteCODE2   ((u8 *)psxRegs.CP2D.r)[22*4+3]
+#define gteR2      ((u8 *)psxRegs.CP2D)[22*4]
+#define gteG2      ((u8 *)psxRegs.CP2D)[22*4+1]
+#define gteB2      ((u8 *)psxRegs.CP2D)[22*4+2]
+#define gteCODE2   ((u8 *)psxRegs.CP2D)[22*4+3]
 #define gteC2      gteCODE2
 
 
 
-#define gteR11  ((s16*)psxRegs.CP2C.r)[0]
-#define gteR12  ((s16*)psxRegs.CP2C.r)[1]
-#define gteR13  ((s16*)psxRegs.CP2C.r)[2]
-#define gteR21  ((s16*)psxRegs.CP2C.r)[3]
-#define gteR22  ((s16*)psxRegs.CP2C.r)[4]
-#define gteR23  ((s16*)psxRegs.CP2C.r)[5]
-#define gteR31  ((s16*)psxRegs.CP2C.r)[6]
-#define gteR32  ((s16*)psxRegs.CP2C.r)[7]
-#define gteR33  ((s16*)psxRegs.CP2C.r)[8]
-#define gteTRX  ((s32*)psxRegs.CP2C.r)[5]
-#define gteTRY  ((s32*)psxRegs.CP2C.r)[6]
-#define gteTRZ  ((s32*)psxRegs.CP2C.r)[7]
-#define gteL11  ((s16*)psxRegs.CP2C.r)[16]
-#define gteL12  ((s16*)psxRegs.CP2C.r)[17]
-#define gteL13  ((s16*)psxRegs.CP2C.r)[18]
-#define gteL21  ((s16*)psxRegs.CP2C.r)[19]
-#define gteL22  ((s16*)psxRegs.CP2C.r)[20]
-#define gteL23  ((s16*)psxRegs.CP2C.r)[21]
-#define gteL31  ((s16*)psxRegs.CP2C.r)[22]
-#define gteL32  ((s16*)psxRegs.CP2C.r)[23]
-#define gteL33  ((s16*)psxRegs.CP2C.r)[24]
-#define gteRBK  ((s32*)psxRegs.CP2C.r)[13]
-#define gteGBK  ((s32*)psxRegs.CP2C.r)[14]
-#define gteBBK  ((s32*)psxRegs.CP2C.r)[15]
-#define gteLR1  ((s16*)psxRegs.CP2C.r)[32]
-#define gteLR2  ((s16*)psxRegs.CP2C.r)[33]
-#define gteLR3  ((s16*)psxRegs.CP2C.r)[34]
-#define gteLG1  ((s16*)psxRegs.CP2C.r)[35]
-#define gteLG2  ((s16*)psxRegs.CP2C.r)[36]
-#define gteLG3  ((s16*)psxRegs.CP2C.r)[37]
-#define gteLB1  ((s16*)psxRegs.CP2C.r)[38]
-#define gteLB2  ((s16*)psxRegs.CP2C.r)[39]
-#define gteLB3  ((s16*)psxRegs.CP2C.r)[40]
-#define gteRFC  ((s32*)psxRegs.CP2C.r)[21]
-#define gteGFC  ((s32*)psxRegs.CP2C.r)[22]
-#define gteBFC  ((s32*)psxRegs.CP2C.r)[23]
-#define gteOFX  ((s32*)psxRegs.CP2C.r)[24]
-#define gteOFY  ((s32*)psxRegs.CP2C.r)[25]
-#define gteH    ((u16*)psxRegs.CP2C.r)[52]
-#define gteDQA  ((s16*)psxRegs.CP2C.r)[54]
-#define gteDQB  ((s32*)psxRegs.CP2C.r)[28]
-#define gteZSF3 ((s16*)psxRegs.CP2C.r)[58]
-#define gteZSF4 ((s16*)psxRegs.CP2C.r)[60]
-#define gteFLAG psxRegs.CP2C.r[31]
+#define gteR11  ((s16*)psxRegs.CP2C)[0]
+#define gteR12  ((s16*)psxRegs.CP2C)[1]
+#define gteR13  ((s16*)psxRegs.CP2C)[2]
+#define gteR21  ((s16*)psxRegs.CP2C)[3]
+#define gteR22  ((s16*)psxRegs.CP2C)[4]
+#define gteR23  ((s16*)psxRegs.CP2C)[5]
+#define gteR31  ((s16*)psxRegs.CP2C)[6]
+#define gteR32  ((s16*)psxRegs.CP2C)[7]
+#define gteR33  ((s16*)psxRegs.CP2C)[8]
+#define gteTRX  ((s32*)psxRegs.CP2C)[5]
+#define gteTRY  ((s32*)psxRegs.CP2C)[6]
+#define gteTRZ  ((s32*)psxRegs.CP2C)[7]
+#define gteL11  ((s16*)psxRegs.CP2C)[16]
+#define gteL12  ((s16*)psxRegs.CP2C)[17]
+#define gteL13  ((s16*)psxRegs.CP2C)[18]
+#define gteL21  ((s16*)psxRegs.CP2C)[19]
+#define gteL22  ((s16*)psxRegs.CP2C)[20]
+#define gteL23  ((s16*)psxRegs.CP2C)[21]
+#define gteL31  ((s16*)psxRegs.CP2C)[22]
+#define gteL32  ((s16*)psxRegs.CP2C)[23]
+#define gteL33  ((s16*)psxRegs.CP2C)[24]
+#define gteRBK  ((s32*)psxRegs.CP2C)[13]
+#define gteGBK  ((s32*)psxRegs.CP2C)[14]
+#define gteBBK  ((s32*)psxRegs.CP2C)[15]
+#define gteLR1  ((s16*)psxRegs.CP2C)[32]
+#define gteLR2  ((s16*)psxRegs.CP2C)[33]
+#define gteLR3  ((s16*)psxRegs.CP2C)[34]
+#define gteLG1  ((s16*)psxRegs.CP2C)[35]
+#define gteLG2  ((s16*)psxRegs.CP2C)[36]
+#define gteLG3  ((s16*)psxRegs.CP2C)[37]
+#define gteLB1  ((s16*)psxRegs.CP2C)[38]
+#define gteLB2  ((s16*)psxRegs.CP2C)[39]
+#define gteLB3  ((s16*)psxRegs.CP2C)[40]
+#define gteRFC  ((s32*)psxRegs.CP2C)[21]
+#define gteGFC  ((s32*)psxRegs.CP2C)[22]
+#define gteBFC  ((s32*)psxRegs.CP2C)[23]
+#define gteOFX  ((s32*)psxRegs.CP2C)[24]
+#define gteOFY  ((s32*)psxRegs.CP2C)[25]
+#define gteH    ((u16*)psxRegs.CP2C)[52]
+#define gteDQA  ((s16*)psxRegs.CP2C)[54]
+#define gteDQB  ((s32*)psxRegs.CP2C)[28]
+#define gteZSF3 ((s16*)psxRegs.CP2C)[58]
+#define gteZSF4 ((s16*)psxRegs.CP2C)[60]
+#define gteFLAG psxRegs.CP2C[31]
 
 __inline unsigned long MFC2(int reg) {
 	switch (reg) {
@@ -170,7 +170,7 @@ __inline unsigned long MFC2(int reg) {
 		return gteORGB;
 
 	default:
-		return psxRegs.CP2D.r[reg];
+		return psxRegs.CP2D[reg];
 	}
 }
 
@@ -179,7 +179,7 @@ __inline void MTC2(unsigned long value, int reg) {
 
 	switch (reg) {
 	case 8: case 9: case 10: case 11:
-		psxRegs.CP2D.r[reg] = (short)value;
+		psxRegs.CP2D[reg] = (short)value;
 		break;
 
 	case 15:
@@ -190,11 +190,11 @@ __inline void MTC2(unsigned long value, int reg) {
 		break;
 
 	case 16: case 17: case 18: case 19:
-		psxRegs.CP2D.r[reg] = (value & 0xffff);
+		psxRegs.CP2D[reg] = (value & 0xffff);
 		break;
 
 	case 28:
-		psxRegs.CP2D.r[28] = value;
+		psxRegs.CP2D[28] = value;
 		gteIR1 = ((value)& 0x1f) << 7;
 		gteIR2 = ((value >> 5) & 0x1f) << 7;
 		gteIR3 = ((value >> 10) & 0x1f) << 7;
@@ -207,9 +207,9 @@ __inline void MTC2(unsigned long value, int reg) {
 		break;
 
 	case 30:
-		psxRegs.CP2D.r[30] = value;
+		psxRegs.CP2D[30] = value;
 
-		a = psxRegs.CP2D.r[30];
+		a = psxRegs.CP2D[30];
 #if defined(_MSC_VER_)
 		if (a > 0) {
 			__asm {
@@ -217,7 +217,7 @@ __inline void MTC2(unsigned long value, int reg) {
 				bsr eax, eax;
 				mov a, eax;
 			}
-			psxRegs.CP2D.r[31] = 31 - a;
+			psxRegs.CP2D[31] = 31 - a;
 		} else if (a < 0) {
 			__asm {
 				mov eax, a;
@@ -225,63 +225,63 @@ __inline void MTC2(unsigned long value, int reg) {
 				bsr eax, eax;
 				mov a, eax;
 			}
-			psxRegs.CP2D.r[31] = 31 - a;
+			psxRegs.CP2D[31] = 31 - a;
 		} else {
-			psxRegs.CP2D.r[31] = 32;
+			psxRegs.CP2D[31] = 32;
 		}
 #elif defined(__linux__) || defined(__MINGW32__)
 		if (a > 0) {
 			__asm__ ("bsrl %1, %0\n" : "=r"(a) : "r"(a) );
-			psxRegs.CP2D.r[31] = 31 - a;
+			psxRegs.CP2D[31] = 31 - a;
 		} else if (a < 0) {
 			a^= 0xffffffff;
 			__asm__ ("bsrl %1, %0\n" : "=r"(a) : "r"(a) );
-			psxRegs.CP2D.r[31] = 31 - a;
+			psxRegs.CP2D[31] = 31 - a;
 		} else {
-			psxRegs.CP2D.r[31] = 32;
+			psxRegs.CP2D[31] = 32;
 		}
 #else
 		if (a > 0) {
 			int i;
 			for (i = 31; (a & (1 << i)) == 0 && i >= 0; i--);
-			psxRegs.CP2D.r[31] = 31 - i;
+			psxRegs.CP2D[31] = 31 - i;
 		}
 		else if (a < 0) {
 			int i;
 			a ^= 0xffffffff;
 			for (i = 31; (a & (1 << i)) == 0 && i >= 0; i--);
-			psxRegs.CP2D.r[31] = 31 - i;
+			psxRegs.CP2D[31] = 31 - i;
 		}
 		else {
-			psxRegs.CP2D.r[31] = 32;
+			psxRegs.CP2D[31] = 32;
 		}
 #endif
 		break;
 
 	default:
-		psxRegs.CP2D.r[reg] = value;
+		psxRegs.CP2D[reg] = value;
 	}
 }
 
 void gteMFC2() {
 	if (!_Rt_) return;
-	psxRegs.GPR.r[_Rt_] = MFC2(_Rd_);
+	psxRegs.GPR[_Rt_] = MFC2(_Rd_);
 }
 
 void gteCFC2() {
 	if (!_Rt_) return;
-	psxRegs.GPR.r[_Rt_] = psxRegs.CP2C.r[_Rd_];
+	psxRegs.GPR[_Rt_] = psxRegs.CP2C[_Rd_];
 }
 
 void gteMTC2() {
-	MTC2(psxRegs.GPR.r[_Rt_], _Rd_);
+	MTC2(psxRegs.GPR[_Rt_], _Rd_);
 }
 
 void gteCTC2() {
-	psxRegs.CP2C.r[_Rd_] = psxRegs.GPR.r[_Rt_];
+	psxRegs.CP2C[_Rd_] = psxRegs.GPR[_Rt_];
 }
 
-#define _oB_ (psxRegs.GPR.r[_Rs_] + _Imm_)
+#define _oB_ (psxRegs.GPR[_Rs_] + _Imm_)
 
 void gteLWC2() {
 	MTC2(iopMemRead32(_oB_), _Rt_);
@@ -699,8 +699,8 @@ void gteRTPS() {
 		gteSZ2  = gteSZx;
 		gteSZx  = (unsigned short)float2int(SZ);
 
-		psxRegs.CP2D.r[12]= psxRegs.CP2D.r[13];
-		psxRegs.CP2D.r[13]= psxRegs.CP2D.r[14];
+		psxRegs.CP2D[12]= psxRegs.CP2D[13];
+		psxRegs.CP2D[13]= psxRegs.CP2D[14];
 
 		gteSX2  = (signed short)float2int(LIMIT((double)(gteOFX)/65536.0f + (LimitAS(SSX0,24)*DSZ),(double)-1024,(double)1024,14));
 		gteSY2  = (signed short)float2int(LIMIT((double)(gteOFY)/65536.0f + (LimitAS(SSY0,23)*DSZ),(double)-1024,(double)1024,13));
@@ -1142,13 +1142,13 @@ void gteAVSZ3() {
 
 	/*	gteFLAG = 0;
 
-		SS = psxRegs.CP2D.r[17] & 0xffff; SZ1  = (double)SS;
-		SS = psxRegs.CP2D.r[18] & 0xffff; SZ2  = (double)SS;
-		SS = psxRegs.CP2D.r[19] & 0xffff; SZ3  = (double)SS;
-		SS = psxRegs.CP2C.r[29] & 0xffff; ZSF3 = (double)SS/(double)4096;
+		SS = psxRegs.CP2D[17] & 0xffff; SZ1  = (double)SS;
+		SS = psxRegs.CP2D[18] & 0xffff; SZ2  = (double)SS;
+		SS = psxRegs.CP2D[19] & 0xffff; SZ3  = (double)SS;
+		SS = psxRegs.CP2C[29] & 0xffff; ZSF3 = (double)SS/(double)4096;
 
-		psxRegs.CP2D.r[24] = (signed long)float2int(EDETEC4(((SZ1+SZ2+SZ3)*ZSF3)));
-		psxRegs.CP2D.r[7]  = (unsigned short)float2int(LimitC(((SZ1+SZ2+SZ3)*ZSF3),18));
+		psxRegs.CP2D[24] = (signed long)float2int(EDETEC4(((SZ1+SZ2+SZ3)*ZSF3)));
+		psxRegs.CP2D[7]  = (unsigned short)float2int(LimitC(((SZ1+SZ2+SZ3)*ZSF3),18));
 
 		if (gteFLAG & 0x7f87e000) gteFLAG|=0x80000000;*/
 
@@ -1207,14 +1207,14 @@ void gteAVSZ4() {
 
 	/*	gteFLAG = 0;
 
-		SS = psxRegs.CP2D.r[16] & 0xffff; SZ0  = (double)SS;
-		SS = psxRegs.CP2D.r[17] & 0xffff; SZ1  = (double)SS;
-		SS = psxRegs.CP2D.r[18] & 0xffff; SZ2  = (double)SS;
-		SS = psxRegs.CP2D.r[19] & 0xffff; SZ3  = (double)SS;
-		SS = psxRegs.CP2C.r[30] & 0xffff; ZSF4 = (double)SS/(double)4096;
+		SS = psxRegs.CP2D[16] & 0xffff; SZ0  = (double)SS;
+		SS = psxRegs.CP2D[17] & 0xffff; SZ1  = (double)SS;
+		SS = psxRegs.CP2D[18] & 0xffff; SZ2  = (double)SS;
+		SS = psxRegs.CP2D[19] & 0xffff; SZ3  = (double)SS;
+		SS = psxRegs.CP2C[30] & 0xffff; ZSF4 = (double)SS/(double)4096;
 
-		psxRegs.CP2D.r[24] = (signed long)float2int(EDETEC4(((SZ0+SZ1+SZ2+SZ3)*ZSF4)));
-		psxRegs.CP2D.r[7]  = (unsigned short)float2int(LimitC(((SZ0+SZ1+SZ2+SZ3)*ZSF4),18));
+		psxRegs.CP2D[24] = (signed long)float2int(EDETEC4(((SZ0+SZ1+SZ2+SZ3)*ZSF4)));
+		psxRegs.CP2D[7]  = (unsigned short)float2int(LimitC(((SZ0+SZ1+SZ2+SZ3)*ZSF4),18));
 
 		if (gteFLAG & 0x7f87e000) gteFLAG|=0x80000000;*/
 	gteFLAG = 0;

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -40,7 +40,7 @@ static void intEventTest();
 static void debugI()
 {
 	if( !IsDevBuild ) return;
-	if( cpuRegs.GPR.n.r0.UD[0] || cpuRegs.GPR.n.r0.UD[1] ) Console.Error("R0 is not zero!!!!");
+	if( cpuRegs.r0.UD[0] || cpuRegs.r0.UD[1] ) Console.Error("R0 is not zero!!!!");
 }
 
 //long int runs=0;
@@ -155,7 +155,7 @@ void JAL()
 
 void BEQ()  // Branch if Rs == Rt
 {
-	if (cpuRegs.GPR.r[_Rs_].SD[0] == cpuRegs.GPR.r[_Rt_].SD[0])
+	if (cpuRegs.GPR[_Rs_].SD[0] == cpuRegs.GPR[_Rt_].SD[0])
 		doBranch(_BranchTarget_);
 	else
 		intEventTest();
@@ -163,7 +163,7 @@ void BEQ()  // Branch if Rs == Rt
 
 void BNE()  // Branch if Rs != Rt
 {
-	if (cpuRegs.GPR.r[_Rs_].SD[0] != cpuRegs.GPR.r[_Rt_].SD[0])
+	if (cpuRegs.GPR[_Rs_].SD[0] != cpuRegs.GPR[_Rt_].SD[0])
 		doBranch(_BranchTarget_);
 	else
 		intEventTest();
@@ -176,7 +176,7 @@ void BNE()  // Branch if Rs != Rt
 
 void BGEZ()    // Branch if Rs >= 0
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] >= 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -185,7 +185,7 @@ void BGEZ()    // Branch if Rs >= 0
 void BGEZAL() // Branch if Rs >= 0 and link
 {
 
-	if (cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
+	if (cpuRegs.GPR[_Rs_].SD[0] >= 0)
 	{
 		_SetLink(31);
 		doBranch(_BranchTarget_);
@@ -194,7 +194,7 @@ void BGEZAL() // Branch if Rs >= 0 and link
 
 void BGTZ()    // Branch if Rs >  0
 {
-	if (cpuRegs.GPR.r[_Rs_].SD[0] > 0)
+	if (cpuRegs.GPR[_Rs_].SD[0] > 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -202,7 +202,7 @@ void BGTZ()    // Branch if Rs >  0
 
 void BLEZ()   // Branch if Rs <= 0
 {
-	if (cpuRegs.GPR.r[_Rs_].SD[0] <= 0)
+	if (cpuRegs.GPR[_Rs_].SD[0] <= 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -210,7 +210,7 @@ void BLEZ()   // Branch if Rs <= 0
 
 void BLTZ()    // Branch if Rs <  0
 {
-	if (cpuRegs.GPR.r[_Rs_].SD[0] < 0)
+	if (cpuRegs.GPR[_Rs_].SD[0] < 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -218,7 +218,7 @@ void BLTZ()    // Branch if Rs <  0
 
 void BLTZAL()  // Branch if Rs <  0 and link
 {
-	if (cpuRegs.GPR.r[_Rs_].SD[0] < 0)
+	if (cpuRegs.GPR[_Rs_].SD[0] < 0)
 	{
 		_SetLink(31);
 		doBranch(_BranchTarget_);
@@ -233,7 +233,7 @@ void BLTZAL()  // Branch if Rs <  0 and link
 
 void BEQL()    // Branch if Rs == Rt
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] == cpuRegs.GPR.r[_Rt_].SD[0])
+	if(cpuRegs.GPR[_Rs_].SD[0] == cpuRegs.GPR[_Rt_].SD[0])
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -246,7 +246,7 @@ void BEQL()    // Branch if Rs == Rt
 
 void BNEL()     // Branch if Rs != Rt
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] != cpuRegs.GPR.r[_Rt_].SD[0])
+	if(cpuRegs.GPR[_Rs_].SD[0] != cpuRegs.GPR[_Rt_].SD[0])
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -259,7 +259,7 @@ void BNEL()     // Branch if Rs != Rt
 
 void BLEZL()    // Branch if Rs <= 0
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] <= 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] <= 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -272,7 +272,7 @@ void BLEZL()    // Branch if Rs <= 0
 
 void BGTZL()     // Branch if Rs >  0
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] > 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] > 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -285,7 +285,7 @@ void BGTZL()     // Branch if Rs >  0
 
 void BLTZL()     // Branch if Rs <  0
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] < 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] < 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -298,7 +298,7 @@ void BLTZL()     // Branch if Rs <  0
 
 void BGEZL()     // Branch if Rs >= 0
 {
-	if(cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] >= 0)
 	{
 		doBranch(_BranchTarget_);
 	}
@@ -312,7 +312,7 @@ void BGEZL()     // Branch if Rs >= 0
 void BLTZALL()   // Branch if Rs <  0 and link
 {
 
-	if(cpuRegs.GPR.r[_Rs_].SD[0] < 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] < 0)
 	{
 		_SetLink(31);
 		doBranch(_BranchTarget_);
@@ -327,7 +327,7 @@ void BLTZALL()   // Branch if Rs <  0 and link
 void BGEZALL()   // Branch if Rs >= 0 and link
 {
 
-	if(cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
+	if(cpuRegs.GPR[_Rs_].SD[0] >= 0)
 	{
 		_SetLink(31);
 		doBranch(_BranchTarget_);
@@ -346,15 +346,15 @@ void BGEZALL()   // Branch if Rs >= 0 and link
 void JR()
 {
 	// 0x33ad48 is the return address of the function that populate the TLB cache
-	if (cpuRegs.GPR.r[_Rs_].UL[0] == 0x33ad48 && EmuConfig.Gamefixes.GoemonTlbHack) {
+	if (cpuRegs.GPR[_Rs_].UL[0] == 0x33ad48 && EmuConfig.Gamefixes.GoemonTlbHack) {
 		GoemonPreloadTlb();
 	}
-	doBranch(cpuRegs.GPR.r[_Rs_].UL[0]);
+	doBranch(cpuRegs.GPR[_Rs_].UL[0]);
 }
 
 void JALR()
 {
-	u32 temp = cpuRegs.GPR.r[_Rs_].UL[0];
+	u32 temp = cpuRegs.GPR[_Rs_].UL[0];
 
 	if (_Rd_)  _SetLink(_Rd_);
 

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -82,13 +82,13 @@ void Hle_SetElfPath(const char* elfFileName)
 
 namespace R3000A {
 
-#define v0 (psxRegs.GPR.n.v0)
-#define a0 (psxRegs.GPR.n.a0)
-#define a1 (psxRegs.GPR.n.a1)
-#define a2 (psxRegs.GPR.n.a2)
-#define a3 (psxRegs.GPR.n.a3)
-#define sp (psxRegs.GPR.n.sp)
-#define ra (psxRegs.GPR.n.ra)
+#define v0 (psxRegs.v0)
+#define a0 (psxRegs.a0)
+#define a1 (psxRegs.a1)
+#define a2 (psxRegs.a2)
+#define a3 (psxRegs.a3)
+#define sp (psxRegs.sp)
+#define ra (psxRegs.ra)
 #define pc (psxRegs.pc)
 
 #define Ra0 (iopVirtMemR<char>(a0))

--- a/pcsx2/IopHw.cpp
+++ b/pcsx2/IopHw.cpp
@@ -57,7 +57,7 @@ void psxDmaInterrupt(int n)
 	if (HW_DMA_ICR & (1 << (16 + n)))
 	{
 		HW_DMA_ICR|= (1 << (24 + n));
-		psxRegs.CP0.n.Cause |= 1 << (9 + n);
+		psxRegs.Cause |= 1 << (9 + n);
 		iopIntcIrq( 3 );
 	}
 }
@@ -73,7 +73,7 @@ void psxDmaInterrupt2(int n)
 			Console.WriteLn("*PCSX2*: psxHu32(0x1070) 8 already set (n=%d)", n);
 		}*/
 		HW_DMA_ICR2|= (1 << (24 + n));
-		psxRegs.CP0.n.Cause |= 1 << (16 + n);
+		psxRegs.Cause |= 1 << (16 + n);
 		iopIntcIrq( 3 );
 	}
 }

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -307,7 +307,7 @@ void __fastcall iopMemWrite8(u32 mem, u8 value)
 	else
 	{
 		u8* p = (u8 *)(psxMemWLUT[mem >> 16]);
-		if (p != NULL && !(psxRegs.CP0.n.Status & 0x10000) )
+		if (p != NULL && !(psxRegs.Status & 0x10000) )
 		{
 			*(u8  *)(p + (mem & 0xffff)) = value;
 			psxCpu->Clear(mem&~3, 1);
@@ -349,7 +349,7 @@ void __fastcall iopMemWrite16(u32 mem, u16 value)
 	} else
 	{
 		u8* p = (u8 *)(psxMemWLUT[mem >> 16]);
-		if (p != NULL && !(psxRegs.CP0.n.Status & 0x10000) )
+		if (p != NULL && !(psxRegs.Status & 0x10000) )
 		{
 			if( t==0x1D00 ) Console.WriteLn("sw16 [0x%08X]=0x%08X", mem, value);
 			*(u16 *)(p + (mem & 0xffff)) = value;
@@ -423,7 +423,7 @@ void __fastcall iopMemWrite32(u32 mem, u32 value)
 	{
 		//see also Hw.c
 		u8* p = (u8 *)(psxMemWLUT[mem >> 16]);
-		if( p != NULL && !(psxRegs.CP0.n.Status & 0x10000) )
+		if( p != NULL && !(psxRegs.Status & 0x10000) )
 		{
 			*(u32 *)(p + (mem & 0xffff)) = value;
 			psxCpu->Clear(mem&~3, 1);

--- a/pcsx2/MMI.cpp
+++ b/pcsx2/MMI.cpp
@@ -31,113 +31,113 @@ namespace OpcodeImpl {
 
 	void MADD() {
 		s64 temp = (s64)((u64)cpuRegs.LO.UL[0] | ((u64)cpuRegs.HI.UL[0] << 32)) +
-				  ((s64)cpuRegs.GPR.r[_Rs_].SL[0] * (s64)cpuRegs.GPR.r[_Rt_].SL[0]);
+				  ((s64)cpuRegs.GPR[_Rs_].SL[0] * (s64)cpuRegs.GPR[_Rt_].SL[0]);
 
 		cpuRegs.LO.SD[0] = (s32)(temp & 0xffffffff);
 		cpuRegs.HI.SD[0] = (s32)(temp >> 32);
 
-		if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[0] = cpuRegs.LO.SD[0];
+		if (_Rd_) cpuRegs.GPR[_Rd_].SD[0] = cpuRegs.LO.SD[0];
 	}
 
 	void MADDU() {
 		u64 tempu =	(u64)((u64)cpuRegs.LO.UL[0] | ((u64)cpuRegs.HI.UL[0] << 32)) +
-				   ((u64)cpuRegs.GPR.r[_Rs_].UL[0] * (u64)cpuRegs.GPR.r[_Rt_].UL[0]);
+				   ((u64)cpuRegs.GPR[_Rs_].UL[0] * (u64)cpuRegs.GPR[_Rt_].UL[0]);
 
 		cpuRegs.LO.SD[0] = (s32)(tempu & 0xffffffff);
 		cpuRegs.HI.SD[0] = (s32)(tempu >> 32);
 
-		if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[0] = cpuRegs.LO.SD[0];
+		if (_Rd_) cpuRegs.GPR[_Rd_].SD[0] = cpuRegs.LO.SD[0];
 	}
 
 	void MADD1() {
 		s64 temp = (s64)((u64)cpuRegs.LO.UL[2] | ((u64)cpuRegs.HI.UL[2] << 32)) +
-				  ((s64)cpuRegs.GPR.r[_Rs_].SL[0] * (s64)cpuRegs.GPR.r[_Rt_].SL[0]);
+				  ((s64)cpuRegs.GPR[_Rs_].SL[0] * (s64)cpuRegs.GPR[_Rt_].SL[0]);
 
 		cpuRegs.LO.SD[1] = (s32)(temp & 0xffffffff);
 		cpuRegs.HI.SD[1] = (s32)(temp >> 32);
 
-		if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[0] = cpuRegs.LO.SD[1];
+		if (_Rd_) cpuRegs.GPR[_Rd_].SD[0] = cpuRegs.LO.SD[1];
 	}
 
 	void MADDU1() {
 		u64 tempu = (u64)((u64)cpuRegs.LO.UL[2] | ((u64)cpuRegs.HI.UL[2] << 32)) +
-				   ((u64)cpuRegs.GPR.r[_Rs_].UL[0] * (u64)cpuRegs.GPR.r[_Rt_].UL[0]);
+				   ((u64)cpuRegs.GPR[_Rs_].UL[0] * (u64)cpuRegs.GPR[_Rt_].UL[0]);
 
 		cpuRegs.LO.SD[1] = (s32)(tempu & 0xffffffff);
 		cpuRegs.HI.SD[1] = (s32)(tempu >> 32);
 
-		if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[0] = cpuRegs.LO.SD[1];
+		if (_Rd_) cpuRegs.GPR[_Rd_].SD[0] = cpuRegs.LO.SD[1];
 	}
 
 	void MFHI1() {
 		if (!_Rd_) return;
-		cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.HI.UD[1];
+		cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.HI.UD[1];
 	}
 
 	void MFLO1() {
 		if (!_Rd_) return;
-		cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[1];
+		cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[1];
 	}
 
 	void MTHI1() {
-		cpuRegs.HI.UD[1] = cpuRegs.GPR.r[_Rs_].UD[0];
+		cpuRegs.HI.UD[1] = cpuRegs.GPR[_Rs_].UD[0];
 	}
 
 	void MTLO1() {
-		cpuRegs.LO.UD[1] = cpuRegs.GPR.r[_Rs_].UD[0];
+		cpuRegs.LO.UD[1] = cpuRegs.GPR[_Rs_].UD[0];
 	}
 
 	void MULT1() {
-		s64 temp = (s64)cpuRegs.GPR.r[_Rs_].SL[0] * cpuRegs.GPR.r[_Rt_].SL[0];
+		s64 temp = (s64)cpuRegs.GPR[_Rs_].SL[0] * cpuRegs.GPR[_Rt_].SL[0];
 
 		// Sign-extend into 64 bits:
 		cpuRegs.LO.SD[1] = (s32)(temp & 0xffffffff);
 		cpuRegs.HI.SD[1] = (s32)(temp >> 32);
 
-		if (_Rd_) cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[1];
+		if (_Rd_) cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[1];
 	}
 
 	void MULTU1() {
-		u64 tempu = (u64)cpuRegs.GPR.r[_Rs_].UL[0] * cpuRegs.GPR.r[_Rt_].UL[0];
+		u64 tempu = (u64)cpuRegs.GPR[_Rs_].UL[0] * cpuRegs.GPR[_Rt_].UL[0];
 
 		// According to docs, sign-extend into 64 bits even though it's an unsigned mult.
 		cpuRegs.LO.SD[1] = (s32)(tempu & 0xffffffff);
 		cpuRegs.HI.SD[1] = (s32)(tempu >> 32);
 
-		if (_Rd_) cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[1];
+		if (_Rd_) cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[1];
 	}
 
 	void DIV1() {
-		if (cpuRegs.GPR.r[_Rs_].UL[0] == 0x80000000 && cpuRegs.GPR.r[_Rt_].UL[0] == 0xffffffff)
+		if (cpuRegs.GPR[_Rs_].UL[0] == 0x80000000 && cpuRegs.GPR[_Rt_].UL[0] == 0xffffffff)
 		{
 				cpuRegs.LO.SD[1] = (s32)0x80000000;
 				cpuRegs.HI.SD[1] = (s32)0x0;
 		}
-		else if (cpuRegs.GPR.r[_Rt_].SL[0] != 0)
+		else if (cpuRegs.GPR[_Rt_].SL[0] != 0)
 		{
-			cpuRegs.LO.SD[1] = cpuRegs.GPR.r[_Rs_].SL[0] / cpuRegs.GPR.r[_Rt_].SL[0];
-			cpuRegs.HI.SD[1] = cpuRegs.GPR.r[_Rs_].SL[0] % cpuRegs.GPR.r[_Rt_].SL[0];
+			cpuRegs.LO.SD[1] = cpuRegs.GPR[_Rs_].SL[0] / cpuRegs.GPR[_Rt_].SL[0];
+			cpuRegs.HI.SD[1] = cpuRegs.GPR[_Rs_].SL[0] % cpuRegs.GPR[_Rt_].SL[0];
 		}
 		else
 		{
-			cpuRegs.LO.SD[1] = (cpuRegs.GPR.r[_Rs_].SL[0] < 0) ? 1 : -1;
-			cpuRegs.HI.SD[1] = cpuRegs.GPR.r[_Rs_].SL[0];
+			cpuRegs.LO.SD[1] = (cpuRegs.GPR[_Rs_].SL[0] < 0) ? 1 : -1;
+			cpuRegs.HI.SD[1] = cpuRegs.GPR[_Rs_].SL[0];
 		}
 	}
 
 	void DIVU1()
 	{
-		if (cpuRegs.GPR.r[_Rt_].UL[0] != 0)
+		if (cpuRegs.GPR[_Rt_].UL[0] != 0)
 		{
 			// note: DIVU has no sign extension when assigning back to 64 bits
 			// note 2: reference material strongly disagrees. (air)
-			cpuRegs.LO.SD[1] = (s32)(cpuRegs.GPR.r[_Rs_].UL[0] / cpuRegs.GPR.r[_Rt_].UL[0]);
-			cpuRegs.HI.SD[1] = (s32)(cpuRegs.GPR.r[_Rs_].UL[0] % cpuRegs.GPR.r[_Rt_].UL[0]);
+			cpuRegs.LO.SD[1] = (s32)(cpuRegs.GPR[_Rs_].UL[0] / cpuRegs.GPR[_Rt_].UL[0]);
+			cpuRegs.HI.SD[1] = (s32)(cpuRegs.GPR[_Rs_].UL[0] % cpuRegs.GPR[_Rt_].UL[0]);
 		}
 		else
 		{
 			cpuRegs.LO.SD[1] = -1;
-			cpuRegs.HI.SD[1] = cpuRegs.GPR.r[_Rs_].SL[0];
+			cpuRegs.HI.SD[1] = cpuRegs.GPR[_Rs_].SL[0];
 		}
 	}
 
@@ -152,7 +152,7 @@ static __fi void _PLZCW(int n)
 	// So 0xff00 would return 7, not 8.
 
 	int c = 0;
-	s32 i = cpuRegs.GPR.r[_Rs_].SL[n];
+	s32 i = cpuRegs.GPR[_Rs_].SL[n];
 
 	// Negate the source based on the sign bit.  This allows us to use a simple
 	// unified bit test of the MSB for either condition.
@@ -161,7 +161,7 @@ static __fi void _PLZCW(int n)
 	// shift first, compare, then increment.  This excludes the sign bit from our final count.
 	while( i <<= 1, i < 0 ) c++;
 
-	cpuRegs.GPR.r[_Rd_].UL[n] = c;
+	cpuRegs.GPR[_Rd_].UL[n] = c;
 }
 
 void PLZCW() {
@@ -183,61 +183,61 @@ void PMFHL() {
 
 	switch (_Sa_) {
 		case 0x00: // LW
-			cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[0];
-			cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[0];
-			cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[2];
-			cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[2];
+			cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[0];
+			cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[0];
+			cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[2];
+			cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[2];
 			break;
 
 		case 0x01: // UW
-			cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[1];
-			cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[1];
-			cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[3];
-			cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[3];
+			cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[1];
+			cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[1];
+			cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[3];
+			cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[3];
 			break;
 
 		case 0x02: // SLW
 			{
 				s64 TempS64 = ((u64)cpuRegs.HI.UL[0] << 32) | (u64)cpuRegs.LO.UL[0];
 				if (TempS64 >= 0x000000007fffffffLL) {
-					cpuRegs.GPR.r[_Rd_].UD[0] = 0x000000007fffffffLL;
+					cpuRegs.GPR[_Rd_].UD[0] = 0x000000007fffffffLL;
 				} else if (TempS64 <= 0xffffffff80000000LL) {
-					cpuRegs.GPR.r[_Rd_].UD[0] = 0xffffffff80000000LL;
+					cpuRegs.GPR[_Rd_].UD[0] = 0xffffffff80000000LL;
 				} else {
-					cpuRegs.GPR.r[_Rd_].UD[0] = (s64)cpuRegs.LO.SL[0];
+					cpuRegs.GPR[_Rd_].UD[0] = (s64)cpuRegs.LO.SL[0];
 				}
 
 				TempS64 = ((u64)cpuRegs.HI.UL[2] << 32) | (u64)cpuRegs.LO.UL[2];
 				if (TempS64 >= 0x000000007fffffffLL) {
-					cpuRegs.GPR.r[_Rd_].UD[1] = 0x000000007fffffffLL;
+					cpuRegs.GPR[_Rd_].UD[1] = 0x000000007fffffffLL;
 				} else if (TempS64 <= 0xffffffff80000000LL) {
-					cpuRegs.GPR.r[_Rd_].UD[1] = 0xffffffff80000000LL;
+					cpuRegs.GPR[_Rd_].UD[1] = 0xffffffff80000000LL;
 				} else {
-					cpuRegs.GPR.r[_Rd_].UD[1] = (s64)cpuRegs.LO.SL[2];
+					cpuRegs.GPR[_Rd_].UD[1] = (s64)cpuRegs.LO.SL[2];
 				}
 			}
 			break;
 
 		case 0x03: // LH
-			cpuRegs.GPR.r[_Rd_].US[0] = cpuRegs.LO.US[0];
-			cpuRegs.GPR.r[_Rd_].US[1] = cpuRegs.LO.US[2];
-			cpuRegs.GPR.r[_Rd_].US[2] = cpuRegs.HI.US[0];
-			cpuRegs.GPR.r[_Rd_].US[3] = cpuRegs.HI.US[2];
-			cpuRegs.GPR.r[_Rd_].US[4] = cpuRegs.LO.US[4];
-			cpuRegs.GPR.r[_Rd_].US[5] = cpuRegs.LO.US[6];
-			cpuRegs.GPR.r[_Rd_].US[6] = cpuRegs.HI.US[4];
-			cpuRegs.GPR.r[_Rd_].US[7] = cpuRegs.HI.US[6];
+			cpuRegs.GPR[_Rd_].US[0] = cpuRegs.LO.US[0];
+			cpuRegs.GPR[_Rd_].US[1] = cpuRegs.LO.US[2];
+			cpuRegs.GPR[_Rd_].US[2] = cpuRegs.HI.US[0];
+			cpuRegs.GPR[_Rd_].US[3] = cpuRegs.HI.US[2];
+			cpuRegs.GPR[_Rd_].US[4] = cpuRegs.LO.US[4];
+			cpuRegs.GPR[_Rd_].US[5] = cpuRegs.LO.US[6];
+			cpuRegs.GPR[_Rd_].US[6] = cpuRegs.HI.US[4];
+			cpuRegs.GPR[_Rd_].US[7] = cpuRegs.HI.US[6];
 			break;
 
 		case 0x04: // SH
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[0], cpuRegs.LO.UL[0]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[1], cpuRegs.LO.UL[1]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[2], cpuRegs.HI.UL[0]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[3], cpuRegs.HI.UL[1]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[4], cpuRegs.LO.UL[2]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[5], cpuRegs.LO.UL[3]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[6], cpuRegs.HI.UL[2]);
-			PMFHL_CLAMP(cpuRegs.GPR.r[_Rd_].US[7], cpuRegs.HI.UL[3]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[0], cpuRegs.LO.UL[0]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[1], cpuRegs.LO.UL[1]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[2], cpuRegs.HI.UL[0]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[3], cpuRegs.HI.UL[1]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[4], cpuRegs.LO.UL[2]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[5], cpuRegs.LO.UL[3]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[6], cpuRegs.HI.UL[2]);
+			PMFHL_CLAMP(cpuRegs.GPR[_Rd_].US[7], cpuRegs.HI.UL[3]);
 			break;
 	}
 }
@@ -245,15 +245,15 @@ void PMFHL() {
 void PMTHL() {
 	if (_Sa_ != 0) return;
 
-	cpuRegs.LO.UL[0] = cpuRegs.GPR.r[_Rs_].UL[0];
-	cpuRegs.HI.UL[0] = cpuRegs.GPR.r[_Rs_].UL[1];
-	cpuRegs.LO.UL[2] = cpuRegs.GPR.r[_Rs_].UL[2];
-	cpuRegs.HI.UL[2] = cpuRegs.GPR.r[_Rs_].UL[3];
+	cpuRegs.LO.UL[0] = cpuRegs.GPR[_Rs_].UL[0];
+	cpuRegs.HI.UL[0] = cpuRegs.GPR[_Rs_].UL[1];
+	cpuRegs.LO.UL[2] = cpuRegs.GPR[_Rs_].UL[2];
+	cpuRegs.HI.UL[2] = cpuRegs.GPR[_Rs_].UL[3];
 }
 
 static __fi void _PSLLH(int n)
 {
-	cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rt_].US[n] << ( _Sa_ & 0xf );
+	cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rt_].US[n] << ( _Sa_ & 0xf );
 }
 
 void PSLLH() {
@@ -265,7 +265,7 @@ void PSLLH() {
 
 static __fi void _PSRLH(int n)
 {
-	cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rt_].US[n] >> ( _Sa_ & 0xf );
+	cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rt_].US[n] >> ( _Sa_ & 0xf );
 }
 
 void PSRLH () {
@@ -277,7 +277,7 @@ void PSRLH () {
 
 static __fi void _PSRAH(int n)
 {
-	cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rt_].SS[n] >> ( _Sa_ & 0xf );
+	cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rt_].SS[n] >> ( _Sa_ & 0xf );
 }
 
 void PSRAH() {
@@ -289,7 +289,7 @@ void PSRAH() {
 
 static __fi void _PSLLW(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rt_].UL[n] << _Sa_;
+	cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rt_].UL[n] << _Sa_;
 }
 
 void PSLLW() {
@@ -300,7 +300,7 @@ void PSLLW() {
 
 static __fi void _PSRLW(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rt_].UL[n] >> _Sa_;
+	cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rt_].UL[n] >> _Sa_;
 }
 
 void PSRLW() {
@@ -311,7 +311,7 @@ void PSRLW() {
 
 static __fi void _PSRAW(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rt_].SL[n] >> _Sa_;
+	cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rt_].SL[n] >> _Sa_;
 }
 
 void PSRAW() {
@@ -325,7 +325,7 @@ void PSRAW() {
 
 static __fi void _PADDW(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rs_].UL[n] + cpuRegs.GPR.r[_Rt_].UL[n];
+	cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rs_].UL[n] + cpuRegs.GPR[_Rt_].UL[n];
 }
 
 void PADDW() {
@@ -336,7 +336,7 @@ void PADDW() {
 
 static __fi void _PSUBW(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rs_].UL[n] - cpuRegs.GPR.r[_Rt_].UL[n];
+	cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rs_].UL[n] - cpuRegs.GPR[_Rt_].UL[n];
 }
 
 void PSUBW() {
@@ -347,10 +347,10 @@ void PSUBW() {
 
 static __fi void _PCGTW(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].SL[n] > cpuRegs.GPR.r[_Rt_].SL[n])
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0xFFFFFFFF;
+	if (cpuRegs.GPR[_Rs_].SL[n] > cpuRegs.GPR[_Rt_].SL[n])
+		cpuRegs.GPR[_Rd_].UL[n] = 0xFFFFFFFF;
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x00000000;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x00000000;
 }
 
 void PCGTW() {
@@ -361,10 +361,10 @@ void PCGTW() {
 
 static __fi void _PMAXW(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].SL[n] > cpuRegs.GPR.r[_Rt_].SL[n])
-		cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rs_].UL[n];
+	if (cpuRegs.GPR[_Rs_].SL[n] > cpuRegs.GPR[_Rt_].SL[n])
+		cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rs_].UL[n];
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rt_].UL[n];
+		cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rt_].UL[n];
 }
 
 void PMAXW() {
@@ -375,7 +375,7 @@ void PMAXW() {
 
 static __fi void _PADDH(int n)
 {
-	cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rs_].US[n] + cpuRegs.GPR.r[_Rt_].US[n];
+	cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rs_].US[n] + cpuRegs.GPR[_Rt_].US[n];
 }
 
 void PADDH() {
@@ -387,7 +387,7 @@ void PADDH() {
 
 static __fi void _PSUBH(int n)
 {
-	cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rs_].US[n] - cpuRegs.GPR.r[_Rt_].US[n];
+	cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rs_].US[n] - cpuRegs.GPR[_Rt_].US[n];
 }
 
 void PSUBH() {
@@ -399,10 +399,10 @@ void PSUBH() {
 
 static __fi void _PCGTH(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].SS[n] > cpuRegs.GPR.r[_Rt_].SS[n])
-		cpuRegs.GPR.r[_Rd_].US[n] = 0xFFFF;
+	if (cpuRegs.GPR[_Rs_].SS[n] > cpuRegs.GPR[_Rt_].SS[n])
+		cpuRegs.GPR[_Rd_].US[n] = 0xFFFF;
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x0000;
+		cpuRegs.GPR[_Rd_].US[n] = 0x0000;
 }
 
 void PCGTH() {
@@ -414,10 +414,10 @@ void PCGTH() {
 
 static __fi void _PMAXH(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].SS[n] > cpuRegs.GPR.r[_Rt_].SS[n])
-		cpuRegs.GPR.r[_Rd_].US[n] =  cpuRegs.GPR.r[_Rs_].US[n];
+	if (cpuRegs.GPR[_Rs_].SS[n] > cpuRegs.GPR[_Rt_].SS[n])
+		cpuRegs.GPR[_Rd_].US[n] =  cpuRegs.GPR[_Rs_].US[n];
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rt_].US[n];
+		cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rt_].US[n];
 }
 
 void PMAXH() {
@@ -429,7 +429,7 @@ void PMAXH() {
 
 static __fi void _PADDB(int n)
 {
-	cpuRegs.GPR.r[_Rd_].SC[n] = cpuRegs.GPR.r[_Rs_].SC[n] + cpuRegs.GPR.r[_Rt_].SC[n];
+	cpuRegs.GPR[_Rd_].SC[n] = cpuRegs.GPR[_Rs_].SC[n] + cpuRegs.GPR[_Rt_].SC[n];
 }
 
 void PADDB() {
@@ -442,7 +442,7 @@ void PADDB() {
 
 static __fi void _PSUBB(int n)
 {
-	cpuRegs.GPR.r[_Rd_].SC[n] = cpuRegs.GPR.r[_Rs_].SC[n] - cpuRegs.GPR.r[_Rt_].SC[n];
+	cpuRegs.GPR[_Rd_].SC[n] = cpuRegs.GPR[_Rs_].SC[n] - cpuRegs.GPR[_Rt_].SC[n];
 }
 
 void PSUBB() {
@@ -455,10 +455,10 @@ void PSUBB() {
 
 static __fi void _PCGTB(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].SC[n] > cpuRegs.GPR.r[_Rt_].SC[n])
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0xFF;
+	if (cpuRegs.GPR[_Rs_].SC[n] > cpuRegs.GPR[_Rt_].SC[n])
+		cpuRegs.GPR[_Rd_].UC[n] = 0xFF;
 	else
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x00;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x00;
 }
 
 void PCGTB() {
@@ -473,13 +473,13 @@ static __fi void _PADDSW(int n)
 {
 	s64 sTemp64;
 
-	sTemp64 = (s64)cpuRegs.GPR.r[_Rs_].SL[n] + (s64)cpuRegs.GPR.r[_Rt_].SL[n];
+	sTemp64 = (s64)cpuRegs.GPR[_Rs_].SL[n] + (s64)cpuRegs.GPR[_Rt_].SL[n];
 	if (sTemp64 > 0x7FFFFFFF)
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x7FFFFFFF;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x7FFFFFFF;
 	else if ((sTemp64 < (s32)0x80000000) )
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x80000000LL;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x80000000LL;
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = (s32)sTemp64;
+		cpuRegs.GPR[_Rd_].UL[n] = (s32)sTemp64;
 }
 
 void PADDSW() {
@@ -492,14 +492,14 @@ static __fi void _PSUBSW(int n)
 {
 	s64 sTemp64;
 
-	sTemp64 = (s64)cpuRegs.GPR.r[_Rs_].SL[n] - (s64)cpuRegs.GPR.r[_Rt_].SL[n];
+	sTemp64 = (s64)cpuRegs.GPR[_Rs_].SL[n] - (s64)cpuRegs.GPR[_Rt_].SL[n];
 
 	if (sTemp64 >= 0x7FFFFFFF)
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x7FFFFFFF;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x7FFFFFFF;
 	else if ((sTemp64 < (s32)0x80000000))
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x80000000;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x80000000;
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = (s32)sTemp64;
+		cpuRegs.GPR[_Rd_].UL[n] = (s32)sTemp64;
 }
 
 void PSUBSW() {
@@ -516,11 +516,11 @@ void PEXTLW() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UL[0] = Rt.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[1] = Rs.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[2] = Rt.UL[1];
-	cpuRegs.GPR.r[_Rd_].UL[3] = Rs.UL[1];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UL[0] = Rt.UL[0];
+	cpuRegs.GPR[_Rd_].UL[1] = Rs.UL[0];
+	cpuRegs.GPR[_Rd_].UL[2] = Rt.UL[1];
+	cpuRegs.GPR[_Rd_].UL[3] = Rs.UL[1];
 }
 
 void PPACW() {
@@ -528,24 +528,24 @@ void PPACW() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UL[0] = Rt.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[1] = Rt.UL[2];
-	cpuRegs.GPR.r[_Rd_].UL[2] = Rs.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[3] = Rs.UL[2];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UL[0] = Rt.UL[0];
+	cpuRegs.GPR[_Rd_].UL[1] = Rt.UL[2];
+	cpuRegs.GPR[_Rd_].UL[2] = Rs.UL[0];
+	cpuRegs.GPR[_Rd_].UL[3] = Rs.UL[2];
 }
 
 __fi void  _PADDSH(int n)
 {
 	s32 sTemp32;
-	sTemp32 = (s32)cpuRegs.GPR.r[_Rs_].SS[n] + (s32)cpuRegs.GPR.r[_Rt_].SS[n];
+	sTemp32 = (s32)cpuRegs.GPR[_Rs_].SS[n] + (s32)cpuRegs.GPR[_Rt_].SS[n];
 
 	if (sTemp32 > 0x7FFF)
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x7FFF;
+		cpuRegs.GPR[_Rd_].US[n] = 0x7FFF;
 	else if ((sTemp32 < (s32)0xffff8000) )
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x8000;
+		cpuRegs.GPR[_Rd_].US[n] = 0x8000;
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = (s16)sTemp32;
+		cpuRegs.GPR[_Rd_].US[n] = (s16)sTemp32;
 }
 
 void PADDSH() {
@@ -558,14 +558,14 @@ void PADDSH() {
 __fi void  _PSUBSH(int n)
 {
 	s32 sTemp32;
-	sTemp32 = (s32)cpuRegs.GPR.r[_Rs_].SS[n] - (s32)cpuRegs.GPR.r[_Rt_].SS[n];
+	sTemp32 = (s32)cpuRegs.GPR[_Rs_].SS[n] - (s32)cpuRegs.GPR[_Rt_].SS[n];
 
 	if (sTemp32 >= 0x7FFF)
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x7FFF;
+		cpuRegs.GPR[_Rd_].US[n] = 0x7FFF;
 	else if ((sTemp32 < (s32)0xffff8000) )
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x8000;
+		cpuRegs.GPR[_Rd_].US[n] = 0x8000;
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = (s16)sTemp32;
+		cpuRegs.GPR[_Rd_].US[n] = (s16)sTemp32;
 }
 
 void PSUBSH() {
@@ -580,15 +580,15 @@ void PEXTLH() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rs.US[0];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[1];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rs.US[1];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rs.US[2];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[3];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rs.US[3];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[1] = Rs.US[0];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[1];
+	cpuRegs.GPR[_Rd_].US[3] = Rs.US[1];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[5] = Rs.US[2];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[3];
+	cpuRegs.GPR[_Rd_].US[7] = Rs.US[3];
 }
 
 void PPACH() {
@@ -596,28 +596,28 @@ void PPACH() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rt.US[6];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rs.US[0];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rs.US[2];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rs.US[4];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rs.US[6];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[1] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[3] = Rt.US[6];
+	cpuRegs.GPR[_Rd_].US[4] = Rs.US[0];
+	cpuRegs.GPR[_Rd_].US[5] = Rs.US[2];
+	cpuRegs.GPR[_Rd_].US[6] = Rs.US[4];
+	cpuRegs.GPR[_Rd_].US[7] = Rs.US[6];
 }
 
 __fi void  _PADDSB(int n)
 {
 	s16 sTemp16;
-	sTemp16 = (s16)cpuRegs.GPR.r[_Rs_].SC[n] + (s16)cpuRegs.GPR.r[_Rt_].SC[n];
+	sTemp16 = (s16)cpuRegs.GPR[_Rs_].SC[n] + (s16)cpuRegs.GPR[_Rt_].SC[n];
 
 	if (sTemp16 > 0x7F)
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x7F;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x7F;
 	else if (sTemp16 < /*(s16)0xff80*/(s16)-128) // be sure
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x80;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x80;
 	else
-		cpuRegs.GPR.r[_Rd_].UC[n] = (s8)sTemp16;
+		cpuRegs.GPR[_Rd_].UC[n] = (s8)sTemp16;
 }
 
 void PADDSB() {
@@ -631,14 +631,14 @@ void PADDSB() {
 static __fi void _PSUBSB( u8 n )
 {
 	s16 sTemp16;
-	sTemp16 = (s16)cpuRegs.GPR.r[_Rs_].SC[n] - (s16)cpuRegs.GPR.r[_Rt_].SC[n];
+	sTemp16 = (s16)cpuRegs.GPR[_Rs_].SC[n] - (s16)cpuRegs.GPR[_Rt_].SC[n];
 
 	if (sTemp16 >= 0x7F)
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x7F;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x7F;
 	else if (sTemp16 < /*(s16)0xff80*/(s16)-128) // be sure
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x80;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x80;
 	else
-		cpuRegs.GPR.r[_Rd_].UC[n] = (s8)sTemp16;
+		cpuRegs.GPR[_Rd_].UC[n] = (s8)sTemp16;
 }
 
 void PSUBSB() {
@@ -654,26 +654,26 @@ void PEXTLB() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UC[0]  = Rt.UC[0];
-	cpuRegs.GPR.r[_Rd_].UC[1]  = Rs.UC[0];
-	cpuRegs.GPR.r[_Rd_].UC[2]  = Rt.UC[1];
-	cpuRegs.GPR.r[_Rd_].UC[3]  = Rs.UC[1];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UC[0]  = Rt.UC[0];
+	cpuRegs.GPR[_Rd_].UC[1]  = Rs.UC[0];
+	cpuRegs.GPR[_Rd_].UC[2]  = Rt.UC[1];
+	cpuRegs.GPR[_Rd_].UC[3]  = Rs.UC[1];
 
-	cpuRegs.GPR.r[_Rd_].UC[4]  = Rt.UC[2];
-	cpuRegs.GPR.r[_Rd_].UC[5]  = Rs.UC[2];
-	cpuRegs.GPR.r[_Rd_].UC[6]  = Rt.UC[3];
-	cpuRegs.GPR.r[_Rd_].UC[7]  = Rs.UC[3];
+	cpuRegs.GPR[_Rd_].UC[4]  = Rt.UC[2];
+	cpuRegs.GPR[_Rd_].UC[5]  = Rs.UC[2];
+	cpuRegs.GPR[_Rd_].UC[6]  = Rt.UC[3];
+	cpuRegs.GPR[_Rd_].UC[7]  = Rs.UC[3];
 
-	cpuRegs.GPR.r[_Rd_].UC[8]  = Rt.UC[4];
-	cpuRegs.GPR.r[_Rd_].UC[9]  = Rs.UC[4];
-	cpuRegs.GPR.r[_Rd_].UC[10] = Rt.UC[5];
-	cpuRegs.GPR.r[_Rd_].UC[11] = Rs.UC[5];
+	cpuRegs.GPR[_Rd_].UC[8]  = Rt.UC[4];
+	cpuRegs.GPR[_Rd_].UC[9]  = Rs.UC[4];
+	cpuRegs.GPR[_Rd_].UC[10] = Rt.UC[5];
+	cpuRegs.GPR[_Rd_].UC[11] = Rs.UC[5];
 
-	cpuRegs.GPR.r[_Rd_].UC[12] = Rt.UC[6];
-	cpuRegs.GPR.r[_Rd_].UC[13] = Rs.UC[6];
-	cpuRegs.GPR.r[_Rd_].UC[14] = Rt.UC[7];
-	cpuRegs.GPR.r[_Rd_].UC[15] = Rs.UC[7];
+	cpuRegs.GPR[_Rd_].UC[12] = Rt.UC[6];
+	cpuRegs.GPR[_Rd_].UC[13] = Rs.UC[6];
+	cpuRegs.GPR[_Rd_].UC[14] = Rt.UC[7];
+	cpuRegs.GPR[_Rd_].UC[15] = Rs.UC[7];
 }
 
 void PPACB() {
@@ -681,35 +681,35 @@ void PPACB() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UC[0]  = Rt.UC[0];
-	cpuRegs.GPR.r[_Rd_].UC[1]  = Rt.UC[2];
-	cpuRegs.GPR.r[_Rd_].UC[2]  = Rt.UC[4];
-	cpuRegs.GPR.r[_Rd_].UC[3]  = Rt.UC[6];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UC[0]  = Rt.UC[0];
+	cpuRegs.GPR[_Rd_].UC[1]  = Rt.UC[2];
+	cpuRegs.GPR[_Rd_].UC[2]  = Rt.UC[4];
+	cpuRegs.GPR[_Rd_].UC[3]  = Rt.UC[6];
 
-	cpuRegs.GPR.r[_Rd_].UC[4]  = Rt.UC[8];
-	cpuRegs.GPR.r[_Rd_].UC[5]  = Rt.UC[10];
-	cpuRegs.GPR.r[_Rd_].UC[6]  = Rt.UC[12];
-	cpuRegs.GPR.r[_Rd_].UC[7]  = Rt.UC[14];
+	cpuRegs.GPR[_Rd_].UC[4]  = Rt.UC[8];
+	cpuRegs.GPR[_Rd_].UC[5]  = Rt.UC[10];
+	cpuRegs.GPR[_Rd_].UC[6]  = Rt.UC[12];
+	cpuRegs.GPR[_Rd_].UC[7]  = Rt.UC[14];
 
-	cpuRegs.GPR.r[_Rd_].UC[8]  = Rs.UC[0];
-	cpuRegs.GPR.r[_Rd_].UC[9]  = Rs.UC[2];
-	cpuRegs.GPR.r[_Rd_].UC[10] = Rs.UC[4];
-	cpuRegs.GPR.r[_Rd_].UC[11] = Rs.UC[6];
+	cpuRegs.GPR[_Rd_].UC[8]  = Rs.UC[0];
+	cpuRegs.GPR[_Rd_].UC[9]  = Rs.UC[2];
+	cpuRegs.GPR[_Rd_].UC[10] = Rs.UC[4];
+	cpuRegs.GPR[_Rd_].UC[11] = Rs.UC[6];
 
-	cpuRegs.GPR.r[_Rd_].UC[12] = Rs.UC[8];
-	cpuRegs.GPR.r[_Rd_].UC[13] = Rs.UC[10];
-	cpuRegs.GPR.r[_Rd_].UC[14] = Rs.UC[12];
-	cpuRegs.GPR.r[_Rd_].UC[15] = Rs.UC[14];
+	cpuRegs.GPR[_Rd_].UC[12] = Rs.UC[8];
+	cpuRegs.GPR[_Rd_].UC[13] = Rs.UC[10];
+	cpuRegs.GPR[_Rd_].UC[14] = Rs.UC[12];
+	cpuRegs.GPR[_Rd_].UC[15] = Rs.UC[14];
 }
 
 __fi void  _PEXT5(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] =
-		((cpuRegs.GPR.r[_Rt_].UL[n] & 0x0000001F) <<  3) |
-		((cpuRegs.GPR.r[_Rt_].UL[n] & 0x000003E0) <<  6) |
-		((cpuRegs.GPR.r[_Rt_].UL[n] & 0x00007C00) <<  9) |
-		((cpuRegs.GPR.r[_Rt_].UL[n] & 0x00008000) << 16);
+	cpuRegs.GPR[_Rd_].UL[n] =
+		((cpuRegs.GPR[_Rt_].UL[n] & 0x0000001F) <<  3) |
+		((cpuRegs.GPR[_Rt_].UL[n] & 0x000003E0) <<  6) |
+		((cpuRegs.GPR[_Rt_].UL[n] & 0x00007C00) <<  9) |
+		((cpuRegs.GPR[_Rt_].UL[n] & 0x00008000) << 16);
 }
 
 void PEXT5() {
@@ -720,11 +720,11 @@ void PEXT5() {
 
 __fi void  _PPAC5(int n)
 {
-	cpuRegs.GPR.r[_Rd_].UL[n] =
-		((cpuRegs.GPR.r[_Rt_].UL[n] >>  3) & 0x0000001F) |
-		((cpuRegs.GPR.r[_Rt_].UL[n] >>  6) & 0x000003E0) |
-		((cpuRegs.GPR.r[_Rt_].UL[n] >>  9) & 0x00007C00) |
-		((cpuRegs.GPR.r[_Rt_].UL[n] >> 16) & 0x00008000);
+	cpuRegs.GPR[_Rd_].UL[n] =
+		((cpuRegs.GPR[_Rt_].UL[n] >>  3) & 0x0000001F) |
+		((cpuRegs.GPR[_Rt_].UL[n] >>  6) & 0x000003E0) |
+		((cpuRegs.GPR[_Rt_].UL[n] >>  9) & 0x00007C00) |
+		((cpuRegs.GPR[_Rt_].UL[n] >> 16) & 0x00008000);
 }
 
 void PPAC5() {
@@ -738,12 +738,12 @@ void PPAC5() {
 
 static __fi void _PABSW(int n)
 {
-	if (cpuRegs.GPR.r[_Rt_].UL[n] == 0x80000000)
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x7fffffff; //clamp
-	else if (cpuRegs.GPR.r[_Rt_].SL[n] < 0)
-		cpuRegs.GPR.r[_Rd_].UL[n] = - cpuRegs.GPR.r[_Rt_].SL[n];
+	if (cpuRegs.GPR[_Rt_].UL[n] == 0x80000000)
+		cpuRegs.GPR[_Rd_].UL[n] = 0x7fffffff; //clamp
+	else if (cpuRegs.GPR[_Rt_].SL[n] < 0)
+		cpuRegs.GPR[_Rd_].UL[n] = - cpuRegs.GPR[_Rt_].SL[n];
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = cpuRegs.GPR.r[_Rt_].SL[n];
+		cpuRegs.GPR[_Rd_].UL[n] = cpuRegs.GPR[_Rt_].SL[n];
 }
 
 void PABSW() {
@@ -754,10 +754,10 @@ void PABSW() {
 
 static __fi void _PCEQW(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].UL[n] == cpuRegs.GPR.r[_Rt_].UL[n])
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0xFFFFFFFF;
+	if (cpuRegs.GPR[_Rs_].UL[n] == cpuRegs.GPR[_Rt_].UL[n])
+		cpuRegs.GPR[_Rd_].UL[n] = 0xFFFFFFFF;
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x00000000;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x00000000;
 }
 
 void PCEQW() {
@@ -768,10 +768,10 @@ void PCEQW() {
 
 static __fi void _PMINW( u8 n )
 {
-	if (cpuRegs.GPR.r[_Rs_].SL[n] < cpuRegs.GPR.r[_Rt_].SL[n])
-		cpuRegs.GPR.r[_Rd_].SL[n] = cpuRegs.GPR.r[_Rs_].SL[n];
+	if (cpuRegs.GPR[_Rs_].SL[n] < cpuRegs.GPR[_Rt_].SL[n])
+		cpuRegs.GPR[_Rd_].SL[n] = cpuRegs.GPR[_Rs_].SL[n];
 	else
-		cpuRegs.GPR.r[_Rd_].SL[n] = cpuRegs.GPR.r[_Rt_].SL[n];
+		cpuRegs.GPR[_Rd_].SL[n] = cpuRegs.GPR[_Rt_].SL[n];
 }
 
 void PMINW() {
@@ -789,12 +789,12 @@ void PADSBH() {
 
 static __fi void _PABSH(int n)
 {
-	if (cpuRegs.GPR.r[_Rt_].US[n] == 0x8000)
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x7fff; //clamp
-	else if (cpuRegs.GPR.r[_Rt_].SS[n] < 0)
-		cpuRegs.GPR.r[_Rd_].US[n] = - cpuRegs.GPR.r[_Rt_].SS[n];
+	if (cpuRegs.GPR[_Rt_].US[n] == 0x8000)
+		cpuRegs.GPR[_Rd_].US[n] = 0x7fff; //clamp
+	else if (cpuRegs.GPR[_Rt_].SS[n] < 0)
+		cpuRegs.GPR[_Rd_].US[n] = - cpuRegs.GPR[_Rt_].SS[n];
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rt_].SS[n];
+		cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rt_].SS[n];
 }
 
 void PABSH() {
@@ -806,10 +806,10 @@ void PABSH() {
 
 static __fi void  _PCEQH( u8 n )
 {
-	if (cpuRegs.GPR.r[_Rs_].US[n] == cpuRegs.GPR.r[_Rt_].US[n])
-		cpuRegs.GPR.r[_Rd_].US[n] = 0xFFFF;
+	if (cpuRegs.GPR[_Rs_].US[n] == cpuRegs.GPR[_Rt_].US[n])
+		cpuRegs.GPR[_Rd_].US[n] = 0xFFFF;
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x0000;
+		cpuRegs.GPR[_Rd_].US[n] = 0x0000;
 }
 
 void PCEQH() {
@@ -821,10 +821,10 @@ void PCEQH() {
 
 static __fi void  _PMINH( u8 n )
 {
-	if (cpuRegs.GPR.r[_Rs_].SS[n] < cpuRegs.GPR.r[_Rt_].SS[n])
-		cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rs_].US[n];
+	if (cpuRegs.GPR[_Rs_].SS[n] < cpuRegs.GPR[_Rt_].SS[n])
+		cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rs_].US[n];
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = cpuRegs.GPR.r[_Rt_].US[n];
+		cpuRegs.GPR[_Rd_].US[n] = cpuRegs.GPR[_Rt_].US[n];
 }
 
 void PMINH() {
@@ -836,10 +836,10 @@ void PMINH() {
 
 __fi void  _PCEQB(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].UC[n] == cpuRegs.GPR.r[_Rt_].UC[n])
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0xFF;
+	if (cpuRegs.GPR[_Rs_].UC[n] == cpuRegs.GPR[_Rt_].UC[n])
+		cpuRegs.GPR[_Rd_].UC[n] = 0xFF;
 	else
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x00;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x00;
 }
 
 void PCEQB() {
@@ -853,12 +853,12 @@ void PCEQB() {
 __fi void  _PADDUW(int n)
 {
 	s64 tmp;
-	tmp = (s64)cpuRegs.GPR.r[_Rs_].UL[n] + (s64)cpuRegs.GPR.r[_Rt_].UL[n];
+	tmp = (s64)cpuRegs.GPR[_Rs_].UL[n] + (s64)cpuRegs.GPR[_Rt_].UL[n];
 
 	if (tmp > 0xffffffff)
-		 cpuRegs.GPR.r[_Rd_].UL[n] = 0xffffffff;
+		 cpuRegs.GPR[_Rd_].UL[n] = 0xffffffff;
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = (u32)tmp;
+		cpuRegs.GPR[_Rd_].UL[n] = (u32)tmp;
 }
 
 void PADDUW () {
@@ -870,12 +870,12 @@ void PADDUW () {
 __fi void  _PSUBUW(int n)
 {
 	s64 sTemp64;
-	sTemp64 = (s64)cpuRegs.GPR.r[_Rs_].UL[n] - (s64)cpuRegs.GPR.r[_Rt_].UL[n];
+	sTemp64 = (s64)cpuRegs.GPR[_Rs_].UL[n] - (s64)cpuRegs.GPR[_Rt_].UL[n];
 
 	if (sTemp64 <= 0x0)
-		cpuRegs.GPR.r[_Rd_].UL[n] = 0x0;
+		cpuRegs.GPR[_Rd_].UL[n] = 0x0;
 	else
-		cpuRegs.GPR.r[_Rd_].UL[n] = (u32)sTemp64;
+		cpuRegs.GPR[_Rd_].UL[n] = (u32)sTemp64;
 }
 
 void PSUBUW() {
@@ -889,22 +889,22 @@ void PEXTUW() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UL[0] = Rt.UL[2];
-	cpuRegs.GPR.r[_Rd_].UL[1] = Rs.UL[2];
-	cpuRegs.GPR.r[_Rd_].UL[2] = Rt.UL[3];
-	cpuRegs.GPR.r[_Rd_].UL[3] = Rs.UL[3];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UL[0] = Rt.UL[2];
+	cpuRegs.GPR[_Rd_].UL[1] = Rs.UL[2];
+	cpuRegs.GPR[_Rd_].UL[2] = Rt.UL[3];
+	cpuRegs.GPR[_Rd_].UL[3] = Rs.UL[3];
 }
 
 __fi void  _PADDUH(int n)
 {
 	s32 sTemp32;
-	sTemp32 = (s32)cpuRegs.GPR.r[_Rs_].US[n] + (s32)cpuRegs.GPR.r[_Rt_].US[n];
+	sTemp32 = (s32)cpuRegs.GPR[_Rs_].US[n] + (s32)cpuRegs.GPR[_Rt_].US[n];
 
 	if (sTemp32 > 0xFFFF)
-		cpuRegs.GPR.r[_Rd_].US[n] = 0xFFFF;
+		cpuRegs.GPR[_Rd_].US[n] = 0xFFFF;
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = (u16)sTemp32;
+		cpuRegs.GPR[_Rd_].US[n] = (u16)sTemp32;
 }
 
 void PADDUH() {
@@ -917,12 +917,12 @@ void PADDUH() {
 __fi void  _PSUBUH(int n)
 {
 	s32 sTemp32;
-	sTemp32 = (s32)cpuRegs.GPR.r[_Rs_].US[n] - (s32)cpuRegs.GPR.r[_Rt_].US[n];
+	sTemp32 = (s32)cpuRegs.GPR[_Rs_].US[n] - (s32)cpuRegs.GPR[_Rt_].US[n];
 
 	if (sTemp32 <= 0x0)
-		cpuRegs.GPR.r[_Rd_].US[n] = 0x0;
+		cpuRegs.GPR[_Rd_].US[n] = 0x0;
 	else
-		cpuRegs.GPR.r[_Rd_].US[n] = (u16)sTemp32;
+		cpuRegs.GPR[_Rd_].US[n] = (u16)sTemp32;
 }
 
 void PSUBUH() {
@@ -937,27 +937,27 @@ void PEXTUH() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rs.US[4];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[5];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rs.US[5];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[1] = Rs.US[4];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[5];
+	cpuRegs.GPR[_Rd_].US[3] = Rs.US[5];
 
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[6];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rs.US[6];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[7];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rs.US[7];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[6];
+	cpuRegs.GPR[_Rd_].US[5] = Rs.US[6];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[7];
+	cpuRegs.GPR[_Rd_].US[7] = Rs.US[7];
 }
 
 __fi void  _PADDUB(int n)
 {
 	u16 Temp16;
-	Temp16 = (u16)cpuRegs.GPR.r[_Rs_].UC[n] + (u16)cpuRegs.GPR.r[_Rt_].UC[n];
+	Temp16 = (u16)cpuRegs.GPR[_Rs_].UC[n] + (u16)cpuRegs.GPR[_Rt_].UC[n];
 
 	if (Temp16 > 0xFF)
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0xFF;
+		cpuRegs.GPR[_Rd_].UC[n] = 0xFF;
 	else
-		cpuRegs.GPR.r[_Rd_].UC[n] = (u8)Temp16;
+		cpuRegs.GPR[_Rd_].UC[n] = (u8)Temp16;
 }
 
 void PADDUB() {
@@ -970,12 +970,12 @@ void PADDUB() {
 
 __fi void  _PSUBUB(int n) {
 	s16 sTemp16;
-	sTemp16 = (s16)cpuRegs.GPR.r[_Rs_].UC[n] - (s16)cpuRegs.GPR.r[_Rt_].UC[n];
+	sTemp16 = (s16)cpuRegs.GPR[_Rs_].UC[n] - (s16)cpuRegs.GPR[_Rt_].UC[n];
 
 	if (sTemp16 <= 0x0)
-		cpuRegs.GPR.r[_Rd_].UC[n] = 0x0;
+		cpuRegs.GPR[_Rd_].UC[n] = 0x0;
 	else
-		cpuRegs.GPR.r[_Rd_].UC[n] = (u8)sTemp16;
+		cpuRegs.GPR[_Rd_].UC[n] = (u8)sTemp16;
 }
 
 void PSUBUB() {
@@ -991,23 +991,23 @@ void PEXTUB() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UC[0]  = Rt.UC[8];
-	cpuRegs.GPR.r[_Rd_].UC[1]  = Rs.UC[8];
-	cpuRegs.GPR.r[_Rd_].UC[2]  = Rt.UC[9];
-	cpuRegs.GPR.r[_Rd_].UC[3]  = Rs.UC[9];
-	cpuRegs.GPR.r[_Rd_].UC[4]  = Rt.UC[10];
-	cpuRegs.GPR.r[_Rd_].UC[5]  = Rs.UC[10];
-	cpuRegs.GPR.r[_Rd_].UC[6]  = Rt.UC[11];
-	cpuRegs.GPR.r[_Rd_].UC[7]  = Rs.UC[11];
-	cpuRegs.GPR.r[_Rd_].UC[8]  = Rt.UC[12];
-	cpuRegs.GPR.r[_Rd_].UC[9]  = Rs.UC[12];
-	cpuRegs.GPR.r[_Rd_].UC[10] = Rt.UC[13];
-	cpuRegs.GPR.r[_Rd_].UC[11] = Rs.UC[13];
-	cpuRegs.GPR.r[_Rd_].UC[12] = Rt.UC[14];
-	cpuRegs.GPR.r[_Rd_].UC[13] = Rs.UC[14];
-	cpuRegs.GPR.r[_Rd_].UC[14] = Rt.UC[15];
-	cpuRegs.GPR.r[_Rd_].UC[15] = Rs.UC[15];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UC[0]  = Rt.UC[8];
+	cpuRegs.GPR[_Rd_].UC[1]  = Rs.UC[8];
+	cpuRegs.GPR[_Rd_].UC[2]  = Rt.UC[9];
+	cpuRegs.GPR[_Rd_].UC[3]  = Rs.UC[9];
+	cpuRegs.GPR[_Rd_].UC[4]  = Rt.UC[10];
+	cpuRegs.GPR[_Rd_].UC[5]  = Rs.UC[10];
+	cpuRegs.GPR[_Rd_].UC[6]  = Rt.UC[11];
+	cpuRegs.GPR[_Rd_].UC[7]  = Rs.UC[11];
+	cpuRegs.GPR[_Rd_].UC[8]  = Rt.UC[12];
+	cpuRegs.GPR[_Rd_].UC[9]  = Rs.UC[12];
+	cpuRegs.GPR[_Rd_].UC[10] = Rt.UC[13];
+	cpuRegs.GPR[_Rd_].UC[11] = Rs.UC[13];
+	cpuRegs.GPR[_Rd_].UC[12] = Rt.UC[14];
+	cpuRegs.GPR[_Rd_].UC[13] = Rs.UC[14];
+	cpuRegs.GPR[_Rd_].UC[14] = Rt.UC[15];
+	cpuRegs.GPR[_Rd_].UC[15] = Rs.UC[15];
 }
 
 //int saZero = 0;
@@ -1017,8 +1017,8 @@ void QFSRV() {				// JayteeMaster: changed a bit to avoid screw up
 
 	u32 sa_amt = cpuRegs.sa << 3;
 	if (sa_amt == 0) {
-		cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0];
-		cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rt_].UD[1];
+		cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rt_].UD[0];
+		cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rt_].UD[1];
 		//saZero++;
 		//if( saZero >= 388800 )
 			//Console.WriteLn( "SA Is Zero, Bitch: %d zeros and counting.", saZero );
@@ -1027,28 +1027,28 @@ void QFSRV() {				// JayteeMaster: changed a bit to avoid screw up
 		//saZero = 0;
 		if (sa_amt < 64) {
 			/*
-			cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0] >> sa_amt;
-			cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rt_].UD[1] >> sa_amt;
-			cpuRegs.GPR.r[_Rd_].UD[0]|= cpuRegs.GPR.r[_Rt_].UD[1] << (64 - sa_amt);
-			cpuRegs.GPR.r[_Rd_].UD[1]|= cpuRegs.GPR.r[_Rs_].UD[0] << (64 - sa_amt);
+			cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rt_].UD[0] >> sa_amt;
+			cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rt_].UD[1] >> sa_amt;
+			cpuRegs.GPR[_Rd_].UD[0]|= cpuRegs.GPR[_Rt_].UD[1] << (64 - sa_amt);
+			cpuRegs.GPR[_Rd_].UD[1]|= cpuRegs.GPR[_Rs_].UD[0] << (64 - sa_amt);
 			*/
-			Rd.UD[0] = cpuRegs.GPR.r[_Rt_].UD[0] >> sa_amt;
-			Rd.UD[1] = cpuRegs.GPR.r[_Rt_].UD[1] >> sa_amt;
-			Rd.UD[0]|= cpuRegs.GPR.r[_Rt_].UD[1] << (64 - sa_amt);
-			Rd.UD[1]|= cpuRegs.GPR.r[_Rs_].UD[0] << (64 - sa_amt);
-			cpuRegs.GPR.r[_Rd_] = Rd;
+			Rd.UD[0] = cpuRegs.GPR[_Rt_].UD[0] >> sa_amt;
+			Rd.UD[1] = cpuRegs.GPR[_Rt_].UD[1] >> sa_amt;
+			Rd.UD[0]|= cpuRegs.GPR[_Rt_].UD[1] << (64 - sa_amt);
+			Rd.UD[1]|= cpuRegs.GPR[_Rs_].UD[0] << (64 - sa_amt);
+			cpuRegs.GPR[_Rd_] = Rd;
 		} else {
 			/*
-			cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[1] >> (sa_amt - 64);
-			cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rs_].UD[0] >> (sa_amt - 64);
-			cpuRegs.GPR.r[_Rd_].UD[0]|= cpuRegs.GPR.r[_Rs_].UD[0] << (128 - sa_amt);
-			cpuRegs.GPR.r[_Rd_].UD[1]|= cpuRegs.GPR.r[_Rs_].UD[1] << (128 - sa_amt);
+			cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rt_].UD[1] >> (sa_amt - 64);
+			cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rs_].UD[0] >> (sa_amt - 64);
+			cpuRegs.GPR[_Rd_].UD[0]|= cpuRegs.GPR[_Rs_].UD[0] << (128 - sa_amt);
+			cpuRegs.GPR[_Rd_].UD[1]|= cpuRegs.GPR[_Rs_].UD[1] << (128 - sa_amt);
 			*/
-			Rd.UD[0] = cpuRegs.GPR.r[_Rt_].UD[1] >> (sa_amt - 64);
-			Rd.UD[1] = cpuRegs.GPR.r[_Rs_].UD[0] >> (sa_amt - 64);
-			Rd.UD[0]|= cpuRegs.GPR.r[_Rs_].UD[0] << (128 - sa_amt);
-			Rd.UD[1]|= cpuRegs.GPR.r[_Rs_].UD[1] << (128 - sa_amt);
-			cpuRegs.GPR.r[_Rd_] = Rd;
+			Rd.UD[0] = cpuRegs.GPR[_Rt_].UD[1] >> (sa_amt - 64);
+			Rd.UD[1] = cpuRegs.GPR[_Rs_].UD[0] >> (sa_amt - 64);
+			Rd.UD[0]|= cpuRegs.GPR[_Rs_].UD[0] << (128 - sa_amt);
+			Rd.UD[1]|= cpuRegs.GPR[_Rs_].UD[1] << (128 - sa_amt);
+			cpuRegs.GPR[_Rd_] = Rd;
 		}
 	}
 }
@@ -1060,12 +1060,12 @@ void QFSRV() {				// JayteeMaster: changed a bit to avoid screw up
 static __fi void _PMADDW(int dd, int ss)
 {
 	s64 temp = (s64)((s64)cpuRegs.LO.SL[ss] | ((s64)cpuRegs.HI.SL[ss] << 32)) +
-			   ((s64)cpuRegs.GPR.r[_Rs_].SL[ss] * (s64)cpuRegs.GPR.r[_Rt_].SL[ss]);
+			   ((s64)cpuRegs.GPR[_Rs_].SL[ss] * (s64)cpuRegs.GPR[_Rt_].SL[ss]);
 
 	cpuRegs.LO.SD[dd] = (s32)(temp & 0xffffffff);
 	cpuRegs.HI.SD[dd] = (s32)(temp >> 32);
 
-	if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[dd] = temp;
+	if (_Rd_) cpuRegs.GPR[_Rd_].SD[dd] = temp;
 }
 
 void PMADDW() {
@@ -1076,30 +1076,30 @@ void PMADDW() {
 void PSLLVW() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].SD[0] = (s64)(s32)(cpuRegs.GPR.r[_Rt_].UL[0] <<
-										  (cpuRegs.GPR.r[_Rs_].UL[0] & 0x1F));
-	cpuRegs.GPR.r[_Rd_].SD[1] = (s64)(s32)(cpuRegs.GPR.r[_Rt_].UL[2] <<
-										  (cpuRegs.GPR.r[_Rs_].UL[2] & 0x1F));
+	cpuRegs.GPR[_Rd_].SD[0] = (s64)(s32)(cpuRegs.GPR[_Rt_].UL[0] <<
+										  (cpuRegs.GPR[_Rs_].UL[0] & 0x1F));
+	cpuRegs.GPR[_Rd_].SD[1] = (s64)(s32)(cpuRegs.GPR[_Rt_].UL[2] <<
+										  (cpuRegs.GPR[_Rs_].UL[2] & 0x1F));
 }
 
 void PSRLVW() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].SD[0] = (s64)(s32)(cpuRegs.GPR.r[_Rt_].UL[0] >>
-										  (cpuRegs.GPR.r[_Rs_].UL[0] & 0x1F));
-	cpuRegs.GPR.r[_Rd_].SD[1] = (s64)(s32)(cpuRegs.GPR.r[_Rt_].UL[2] >>
-										  (cpuRegs.GPR.r[_Rs_].UL[2] & 0x1F));
+	cpuRegs.GPR[_Rd_].SD[0] = (s64)(s32)(cpuRegs.GPR[_Rt_].UL[0] >>
+										  (cpuRegs.GPR[_Rs_].UL[0] & 0x1F));
+	cpuRegs.GPR[_Rd_].SD[1] = (s64)(s32)(cpuRegs.GPR[_Rt_].UL[2] >>
+										  (cpuRegs.GPR[_Rs_].UL[2] & 0x1F));
 }
 
 __fi void  _PMSUBW(int dd, int ss)
 {
 	s64 temp = (s64)((s64)cpuRegs.LO.SL[ss] | ((s64)cpuRegs.HI.SL[ss] << 32)) -
-			   ((s64)cpuRegs.GPR.r[_Rs_].SL[ss] * (s64)cpuRegs.GPR.r[_Rt_].SL[ss]);
+			   ((s64)cpuRegs.GPR[_Rs_].SL[ss] * (s64)cpuRegs.GPR[_Rt_].SL[ss]);
 
 	cpuRegs.LO.SD[dd] = (s32)(temp & 0xffffffff);
 	cpuRegs.HI.SD[dd] = (s32)(temp >> 32);
 
-	if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[dd] = temp;
+	if (_Rd_) cpuRegs.GPR[_Rd_].SD[dd] = temp;
 }
 
 void PMSUBW() {
@@ -1110,15 +1110,15 @@ void PMSUBW() {
 void PMFHI() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.HI.UD[0];
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.HI.UD[1];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.HI.UD[0];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.HI.UD[1];
 }
 
 void PMFLO() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[0];
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.LO.UD[1];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[0];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.LO.UD[1];
 }
 
 void PINTH() {
@@ -1126,25 +1126,25 @@ void PINTH() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rs.US[4];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[1];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rs.US[5];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rs.US[6];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[3];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rs.US[7];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[1] = Rs.US[4];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[1];
+	cpuRegs.GPR[_Rd_].US[3] = Rs.US[5];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[5] = Rs.US[6];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[3];
+	cpuRegs.GPR[_Rd_].US[7] = Rs.US[7];
 }
 
 __fi void  _PMULTW(int dd, int ss)
 {
-	s64 temp = (s64)cpuRegs.GPR.r[_Rs_].SL[ss] * (s64)cpuRegs.GPR.r[_Rt_].SL[ss];
+	s64 temp = (s64)cpuRegs.GPR[_Rs_].SL[ss] * (s64)cpuRegs.GPR[_Rt_].SL[ss];
 
 	cpuRegs.LO.UD[dd] = (s32)(temp & 0xffffffff);
 	cpuRegs.HI.UD[dd] = (s32)(temp >> 32);
 
-	if (_Rd_) cpuRegs.GPR.r[_Rd_].SD[dd] = temp;
+	if (_Rd_) cpuRegs.GPR[_Rd_].SD[dd] = temp;
 }
 
 void PMULTW() {
@@ -1154,20 +1154,20 @@ void PMULTW() {
 
 __fi void  _PDIVW(int dd, int ss)
 {
-	if (cpuRegs.GPR.r[_Rs_].UL[ss] == 0x80000000 && cpuRegs.GPR.r[_Rt_].UL[ss] == 0xffffffff)
+	if (cpuRegs.GPR[_Rs_].UL[ss] == 0x80000000 && cpuRegs.GPR[_Rt_].UL[ss] == 0xffffffff)
 	{
 		cpuRegs.LO.SD[dd] = (s32)0x80000000;
 		cpuRegs.HI.SD[dd] = (s32)0;
 	}
-	else if (cpuRegs.GPR.r[_Rt_].SL[ss] != 0)
+	else if (cpuRegs.GPR[_Rt_].SL[ss] != 0)
 	{
-		cpuRegs.LO.SD[dd] = cpuRegs.GPR.r[_Rs_].SL[ss] / cpuRegs.GPR.r[_Rt_].SL[ss];
-		cpuRegs.HI.SD[dd] = cpuRegs.GPR.r[_Rs_].SL[ss] % cpuRegs.GPR.r[_Rt_].SL[ss];
+		cpuRegs.LO.SD[dd] = cpuRegs.GPR[_Rs_].SL[ss] / cpuRegs.GPR[_Rt_].SL[ss];
+		cpuRegs.HI.SD[dd] = cpuRegs.GPR[_Rs_].SL[ss] % cpuRegs.GPR[_Rt_].SL[ss];
 	}
 	else
 	{
-		cpuRegs.LO.SD[dd] = (cpuRegs.GPR.r[_Rs_].SL[ss] < 0) ? 1 : -1;
-		cpuRegs.HI.SD[dd] = cpuRegs.GPR.r[_Rs_].SL[ss];
+		cpuRegs.LO.SD[dd] = (cpuRegs.GPR[_Rs_].SL[ss] < 0) ? 1 : -1;
+		cpuRegs.HI.SD[dd] = cpuRegs.GPR[_Rs_].SL[ss];
 	}
 }
 
@@ -1181,46 +1181,46 @@ void PCPYLD() {
 
 	// note: first _Rs_, since the other way when _Rd_ equals
 	// _Rs_ or _Rt_ this would screw up
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rs_].UD[0];
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rs_].UD[0];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rt_].UD[0];
 }
 
 void PMADDH() {			// JayteeMaster: changed a bit to avoid screw up
 	s32 temp;
 
-    temp = cpuRegs.LO.UL[0] + (s32)cpuRegs.GPR.r[_Rs_].SS[0] * (s32)cpuRegs.GPR.r[_Rt_].SS[0];
+    temp = cpuRegs.LO.UL[0] + (s32)cpuRegs.GPR[_Rs_].SS[0] * (s32)cpuRegs.GPR[_Rt_].SS[0];
     cpuRegs.LO.UL[0] = temp;
-    /* if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[0] = temp; */
+    /* if (_Rd_) cpuRegs.GPR[_Rd_].UL[0] = temp; */
 
-    temp = cpuRegs.LO.UL[1] + (s32)cpuRegs.GPR.r[_Rs_].SS[1] * (s32)cpuRegs.GPR.r[_Rt_].SS[1];
+    temp = cpuRegs.LO.UL[1] + (s32)cpuRegs.GPR[_Rs_].SS[1] * (s32)cpuRegs.GPR[_Rt_].SS[1];
     cpuRegs.LO.UL[1] = temp;
 
-    temp = cpuRegs.HI.UL[0] + (s32)cpuRegs.GPR.r[_Rs_].SS[2] * (s32)cpuRegs.GPR.r[_Rt_].SS[2];
+    temp = cpuRegs.HI.UL[0] + (s32)cpuRegs.GPR[_Rs_].SS[2] * (s32)cpuRegs.GPR[_Rt_].SS[2];
     cpuRegs.HI.UL[0] = temp;
-    /* if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[1] = temp; */
+    /* if (_Rd_) cpuRegs.GPR[_Rd_].UL[1] = temp; */
 
-    temp = cpuRegs.HI.UL[1] + (s32)cpuRegs.GPR.r[_Rs_].SS[3] * (s32)cpuRegs.GPR.r[_Rt_].SS[3];
+    temp = cpuRegs.HI.UL[1] + (s32)cpuRegs.GPR[_Rs_].SS[3] * (s32)cpuRegs.GPR[_Rt_].SS[3];
     cpuRegs.HI.UL[1] = temp;
 
-    temp = cpuRegs.LO.UL[2] + (s32)cpuRegs.GPR.r[_Rs_].SS[4] * (s32)cpuRegs.GPR.r[_Rt_].SS[4];
+    temp = cpuRegs.LO.UL[2] + (s32)cpuRegs.GPR[_Rs_].SS[4] * (s32)cpuRegs.GPR[_Rt_].SS[4];
     cpuRegs.LO.UL[2] = temp;
-    /* if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[2] = temp; */
+    /* if (_Rd_) cpuRegs.GPR[_Rd_].UL[2] = temp; */
 
-    temp = cpuRegs.LO.UL[3] + (s32)cpuRegs.GPR.r[_Rs_].SS[5] * (s32)cpuRegs.GPR.r[_Rt_].SS[5];
+    temp = cpuRegs.LO.UL[3] + (s32)cpuRegs.GPR[_Rs_].SS[5] * (s32)cpuRegs.GPR[_Rt_].SS[5];
     cpuRegs.LO.UL[3] = temp;
 
-    temp = cpuRegs.HI.UL[2] + (s32)cpuRegs.GPR.r[_Rs_].SS[6] * (s32)cpuRegs.GPR.r[_Rt_].SS[6];
+    temp = cpuRegs.HI.UL[2] + (s32)cpuRegs.GPR[_Rs_].SS[6] * (s32)cpuRegs.GPR[_Rt_].SS[6];
     cpuRegs.HI.UL[2] = temp;
-    /* if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[3] = temp; */
+    /* if (_Rd_) cpuRegs.GPR[_Rd_].UL[3] = temp; */
 
-    temp = cpuRegs.HI.UL[3] + (s32)cpuRegs.GPR.r[_Rs_].SS[7] * (s32)cpuRegs.GPR.r[_Rt_].SS[7];
+    temp = cpuRegs.HI.UL[3] + (s32)cpuRegs.GPR[_Rs_].SS[7] * (s32)cpuRegs.GPR[_Rt_].SS[7];
     cpuRegs.HI.UL[3] = temp;
 
 	if (_Rd_) {
-		cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[2];
-		cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[2];
+		cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[0];
+		cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[0];
+		cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[2];
+		cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[2];
 	}
 
 }
@@ -1228,8 +1228,8 @@ void PMADDH() {			// JayteeMaster: changed a bit to avoid screw up
 // JayteeMaster: changed a bit to avoid screw up
 __fi void  _PHMADH_LO(int dd, int n)
 {
-	s32 firsttemp =		   (s32)cpuRegs.GPR.r[_Rs_].SS[n+1] * (s32)cpuRegs.GPR.r[_Rt_].SS[n+1];
-	s32 temp = firsttemp + (s32)cpuRegs.GPR.r[_Rs_].SS[n]   * (s32)cpuRegs.GPR.r[_Rt_].SS[n];
+	s32 firsttemp =		   (s32)cpuRegs.GPR[_Rs_].SS[n+1] * (s32)cpuRegs.GPR[_Rt_].SS[n+1];
+	s32 temp = firsttemp + (s32)cpuRegs.GPR[_Rs_].SS[n]   * (s32)cpuRegs.GPR[_Rt_].SS[n];
 
 	cpuRegs.LO.UL[dd] = temp;
 	cpuRegs.LO.UL[dd+1] = firsttemp;
@@ -1237,8 +1237,8 @@ __fi void  _PHMADH_LO(int dd, int n)
 
 __fi void  _PHMADH_HI(int dd, int n)
 {
-	s32 firsttemp =		   (s32)cpuRegs.GPR.r[_Rs_].SS[n+1] * (s32)cpuRegs.GPR.r[_Rt_].SS[n+1];
-	s32 temp = firsttemp + (s32)cpuRegs.GPR.r[_Rs_].SS[n]   * (s32)cpuRegs.GPR.r[_Rt_].SS[n];
+	s32 firsttemp =		   (s32)cpuRegs.GPR[_Rs_].SS[n+1] * (s32)cpuRegs.GPR[_Rt_].SS[n+1];
+	s32 temp = firsttemp + (s32)cpuRegs.GPR[_Rs_].SS[n]   * (s32)cpuRegs.GPR[_Rt_].SS[n];
 
 	cpuRegs.HI.UL[dd] = temp;
 	cpuRegs.HI.UL[dd+1] = firsttemp;
@@ -1250,79 +1250,79 @@ void PHMADH() {				// JayteeMaster: changed a bit to avoid screw up. Also used 0
 	_PHMADH_LO(2, 4);
 	_PHMADH_HI(2, 6);
 	if (_Rd_) {
-		cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[2];
-		cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[2];
+		cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[0];
+		cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[0];
+		cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[2];
+		cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[2];
 	}
 }
 
 void PAND() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0] & cpuRegs.GPR.r[_Rt_].UD[0];
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rs_].UD[1] & cpuRegs.GPR.r[_Rt_].UD[1];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0] & cpuRegs.GPR[_Rt_].UD[0];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rs_].UD[1] & cpuRegs.GPR[_Rt_].UD[1];
 }
 
 void PXOR() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0] ^ cpuRegs.GPR.r[_Rt_].UD[0];
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rs_].UD[1] ^ cpuRegs.GPR.r[_Rt_].UD[1];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0] ^ cpuRegs.GPR[_Rt_].UD[0];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rs_].UD[1] ^ cpuRegs.GPR[_Rt_].UD[1];
 }
 
 void PMSUBH() {			// JayteeMaster: changed a bit to avoid screw up
 	s32 temp;
 
-    temp = cpuRegs.LO.UL[0] - (s32)cpuRegs.GPR.r[_Rs_].SS[0] * (s32)cpuRegs.GPR.r[_Rt_].SS[0];
+    temp = cpuRegs.LO.UL[0] - (s32)cpuRegs.GPR[_Rs_].SS[0] * (s32)cpuRegs.GPR[_Rt_].SS[0];
     cpuRegs.LO.UL[0] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[0] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[0] = temp;*/
 
-    temp = cpuRegs.LO.UL[1] - (s32)cpuRegs.GPR.r[_Rs_].SS[1] * (s32)cpuRegs.GPR.r[_Rt_].SS[1];
+    temp = cpuRegs.LO.UL[1] - (s32)cpuRegs.GPR[_Rs_].SS[1] * (s32)cpuRegs.GPR[_Rt_].SS[1];
     cpuRegs.LO.UL[1] = temp;
 
-    temp = cpuRegs.HI.UL[0] - (s32)cpuRegs.GPR.r[_Rs_].SS[2] * (s32)cpuRegs.GPR.r[_Rt_].SS[2];
+    temp = cpuRegs.HI.UL[0] - (s32)cpuRegs.GPR[_Rs_].SS[2] * (s32)cpuRegs.GPR[_Rt_].SS[2];
     cpuRegs.HI.UL[0] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[1] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[1] = temp;*/
 
-    temp = cpuRegs.HI.UL[1] - (s32)cpuRegs.GPR.r[_Rs_].SS[3] * (s32)cpuRegs.GPR.r[_Rt_].SS[3];
+    temp = cpuRegs.HI.UL[1] - (s32)cpuRegs.GPR[_Rs_].SS[3] * (s32)cpuRegs.GPR[_Rt_].SS[3];
     cpuRegs.HI.UL[1] = temp;
 
-    temp = cpuRegs.LO.UL[2] - (s32)cpuRegs.GPR.r[_Rs_].SS[4] * (s32)cpuRegs.GPR.r[_Rt_].SS[4];
+    temp = cpuRegs.LO.UL[2] - (s32)cpuRegs.GPR[_Rs_].SS[4] * (s32)cpuRegs.GPR[_Rt_].SS[4];
     cpuRegs.LO.UL[2] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[2] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[2] = temp;*/
 
-    temp = cpuRegs.LO.UL[3] - (s32)cpuRegs.GPR.r[_Rs_].SS[5] * (s32)cpuRegs.GPR.r[_Rt_].SS[5];
+    temp = cpuRegs.LO.UL[3] - (s32)cpuRegs.GPR[_Rs_].SS[5] * (s32)cpuRegs.GPR[_Rt_].SS[5];
     cpuRegs.LO.UL[3] = temp;
 
-    temp = cpuRegs.HI.UL[2] - (s32)cpuRegs.GPR.r[_Rs_].SS[6] * (s32)cpuRegs.GPR.r[_Rt_].SS[6];
+    temp = cpuRegs.HI.UL[2] - (s32)cpuRegs.GPR[_Rs_].SS[6] * (s32)cpuRegs.GPR[_Rt_].SS[6];
     cpuRegs.HI.UL[2] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[3] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[3] = temp;*/
 
-    temp = cpuRegs.HI.UL[3] - (s32)cpuRegs.GPR.r[_Rs_].SS[7] * (s32)cpuRegs.GPR.r[_Rt_].SS[7];
+    temp = cpuRegs.HI.UL[3] - (s32)cpuRegs.GPR[_Rs_].SS[7] * (s32)cpuRegs.GPR[_Rt_].SS[7];
     cpuRegs.HI.UL[3] = temp;
 
 	if (_Rd_) {
-		cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[2];
-		cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[2];
+		cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[0];
+		cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[0];
+		cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[2];
+		cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[2];
 	}
 }
 
 // JayteeMaster: changed a bit to avoid screw up
 static __fi void _PHMSBH_LO(int dd, int n, int rdd)
 {
-	s32 firsttemp =        (s32)cpuRegs.GPR.r[_Rs_].SS[n+1] * (s32)cpuRegs.GPR.r[_Rt_].SS[n+1];
-	s32 temp = firsttemp - (s32)cpuRegs.GPR.r[_Rs_].SS[n]   * (s32)cpuRegs.GPR.r[_Rt_].SS[n];
+	s32 firsttemp =        (s32)cpuRegs.GPR[_Rs_].SS[n+1] * (s32)cpuRegs.GPR[_Rt_].SS[n+1];
+	s32 temp = firsttemp - (s32)cpuRegs.GPR[_Rs_].SS[n]   * (s32)cpuRegs.GPR[_Rt_].SS[n];
 
 	cpuRegs.LO.UL[dd] = temp;
 	cpuRegs.LO.UL[dd+1] = ~firsttemp;
 }
 static __fi void _PHMSBH_HI(int dd, int n, int rdd)
 {
-	s32 firsttemp =        (s32)cpuRegs.GPR.r[_Rs_].SS[n+1] * (s32)cpuRegs.GPR.r[_Rt_].SS[n+1];
-	s32 temp = firsttemp - (s32)cpuRegs.GPR.r[_Rs_].SS[n]   * (s32)cpuRegs.GPR.r[_Rt_].SS[n];
+	s32 firsttemp =        (s32)cpuRegs.GPR[_Rs_].SS[n+1] * (s32)cpuRegs.GPR[_Rt_].SS[n+1];
+	s32 temp = firsttemp - (s32)cpuRegs.GPR[_Rs_].SS[n]   * (s32)cpuRegs.GPR[_Rt_].SS[n];
 
 	cpuRegs.HI.UL[dd] = temp;
 	cpuRegs.HI.UL[dd+1] = ~firsttemp;
@@ -1334,10 +1334,10 @@ void PHMSBH() {		// JayteeMaster: changed a bit to avoid screw up
 	_PHMSBH_LO(2, 4, 2);
 	_PHMSBH_HI(2, 6, 3);
 	if (_Rd_) {
-		cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[2];
-		cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[2];
+		cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[0];
+		cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[0];
+		cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[2];
+		cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[2];
 	}
 }
 
@@ -1346,15 +1346,15 @@ void PEXEH() {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rt.US[1];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rt.US[3];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[6];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rt.US[5];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rt.US[7];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[1] = Rt.US[1];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[3] = Rt.US[3];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[6];
+	cpuRegs.GPR[_Rd_].US[5] = Rt.US[5];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[7] = Rt.US[7];
 }
 
 void PREVH () {
@@ -1362,72 +1362,72 @@ void PREVH () {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[3];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[1];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[7];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rt.US[6];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[5];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rt.US[4];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[3];
+	cpuRegs.GPR[_Rd_].US[1] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[1];
+	cpuRegs.GPR[_Rd_].US[3] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[7];
+	cpuRegs.GPR[_Rd_].US[5] = Rt.US[6];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[5];
+	cpuRegs.GPR[_Rd_].US[7] = Rt.US[4];
 }
 
 void PMULTH() {			// JayteeMaster: changed a bit to avoid screw up
 	s32 temp;
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[0] * (s32)cpuRegs.GPR.r[_Rt_].SS[0];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[0] * (s32)cpuRegs.GPR[_Rt_].SS[0];
     cpuRegs.LO.UL[0] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[0] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[0] = temp;*/
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[1] * (s32)cpuRegs.GPR.r[_Rt_].SS[1];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[1] * (s32)cpuRegs.GPR[_Rt_].SS[1];
     cpuRegs.LO.UL[1] = temp;
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[2] * (s32)cpuRegs.GPR.r[_Rt_].SS[2];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[2] * (s32)cpuRegs.GPR[_Rt_].SS[2];
     cpuRegs.HI.UL[0] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[1] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[1] = temp;*/
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[3] * (s32)cpuRegs.GPR.r[_Rt_].SS[3];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[3] * (s32)cpuRegs.GPR[_Rt_].SS[3];
     cpuRegs.HI.UL[1] = temp;
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[4] * (s32)cpuRegs.GPR.r[_Rt_].SS[4];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[4] * (s32)cpuRegs.GPR[_Rt_].SS[4];
     cpuRegs.LO.UL[2] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[2] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[2] = temp;*/
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[5] * (s32)cpuRegs.GPR.r[_Rt_].SS[5];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[5] * (s32)cpuRegs.GPR[_Rt_].SS[5];
     cpuRegs.LO.UL[3] = temp;
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[6] * (s32)cpuRegs.GPR.r[_Rt_].SS[6];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[6] * (s32)cpuRegs.GPR[_Rt_].SS[6];
     cpuRegs.HI.UL[2] = temp;
-    /*if (_Rd_) cpuRegs.GPR.r[_Rd_].UL[3] = temp;*/
+    /*if (_Rd_) cpuRegs.GPR[_Rd_].UL[3] = temp;*/
 
-    temp = (s32)cpuRegs.GPR.r[_Rs_].SS[7] * (s32)cpuRegs.GPR.r[_Rt_].SS[7];
+    temp = (s32)cpuRegs.GPR[_Rs_].SS[7] * (s32)cpuRegs.GPR[_Rt_].SS[7];
     cpuRegs.HI.UL[3] = temp;
 
 	if (_Rd_) {
-		cpuRegs.GPR.r[_Rd_].UL[0] = cpuRegs.LO.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[1] = cpuRegs.HI.UL[0];
-		cpuRegs.GPR.r[_Rd_].UL[2] = cpuRegs.LO.UL[2];
-		cpuRegs.GPR.r[_Rd_].UL[3] = cpuRegs.HI.UL[2];
+		cpuRegs.GPR[_Rd_].UL[0] = cpuRegs.LO.UL[0];
+		cpuRegs.GPR[_Rd_].UL[1] = cpuRegs.HI.UL[0];
+		cpuRegs.GPR[_Rd_].UL[2] = cpuRegs.LO.UL[2];
+		cpuRegs.GPR[_Rd_].UL[3] = cpuRegs.HI.UL[2];
 	}
 }
 
 __fi void  _PDIVBW(int n)
 {
-	if (cpuRegs.GPR.r[_Rs_].UL[n] == 0x80000000 && cpuRegs.GPR.r[_Rt_].US[0] == 0xffff)
+	if (cpuRegs.GPR[_Rs_].UL[n] == 0x80000000 && cpuRegs.GPR[_Rt_].US[0] == 0xffff)
 	{
 		cpuRegs.LO.SL[n] = (s32)0x80000000;
 		cpuRegs.HI.SL[n] = (s32)0x0;
 	}
-    else if (cpuRegs.GPR.r[_Rt_].US[0] != 0)
+    else if (cpuRegs.GPR[_Rt_].US[0] != 0)
     {
-        cpuRegs.LO.SL[n] = cpuRegs.GPR.r[_Rs_].SL[n] / cpuRegs.GPR.r[_Rt_].SS[0];
-        cpuRegs.HI.SL[n] = cpuRegs.GPR.r[_Rs_].SL[n] % cpuRegs.GPR.r[_Rt_].SS[0];
+        cpuRegs.LO.SL[n] = cpuRegs.GPR[_Rs_].SL[n] / cpuRegs.GPR[_Rt_].SS[0];
+        cpuRegs.HI.SL[n] = cpuRegs.GPR[_Rs_].SL[n] % cpuRegs.GPR[_Rt_].SS[0];
     }
 	else
 	{
-		cpuRegs.LO.SL[n] = (cpuRegs.GPR.r[_Rs_].SL[n] < 0) ? 1 : -1;
-		cpuRegs.HI.SL[n] = cpuRegs.GPR.r[_Rs_].SL[n];
+		cpuRegs.LO.SL[n] = (cpuRegs.GPR[_Rs_].SL[n] < 0) ? 1 : -1;
+		cpuRegs.HI.SL[n] = cpuRegs.GPR[_Rs_].SL[n];
 	}
 }
 
@@ -1440,11 +1440,11 @@ void PEXEW() {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UL[0] = Rt.UL[2];
-	cpuRegs.GPR.r[_Rd_].UL[1] = Rt.UL[1];
-	cpuRegs.GPR.r[_Rd_].UL[2] = Rt.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[3] = Rt.UL[3];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UL[0] = Rt.UL[2];
+	cpuRegs.GPR[_Rd_].UL[1] = Rt.UL[1];
+	cpuRegs.GPR[_Rd_].UL[2] = Rt.UL[0];
+	cpuRegs.GPR[_Rd_].UL[3] = Rt.UL[3];
 }
 
 void PROT3W() {
@@ -1452,11 +1452,11 @@ void PROT3W() {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UL[0] = Rt.UL[1];
-	cpuRegs.GPR.r[_Rd_].UL[1] = Rt.UL[2];
-	cpuRegs.GPR.r[_Rd_].UL[2] = Rt.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[3] = Rt.UL[3];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UL[0] = Rt.UL[1];
+	cpuRegs.GPR[_Rd_].UL[1] = Rt.UL[2];
+	cpuRegs.GPR[_Rd_].UL[2] = Rt.UL[0];
+	cpuRegs.GPR[_Rd_].UL[3] = Rt.UL[3];
 }
 
 //*****END OF MMI2 OPCODES***********************************
@@ -1466,12 +1466,12 @@ void PROT3W() {
 static __fi void _PMADDUW(int dd, int ss)
 {
 	u64 tempu =	(u64)((u64)cpuRegs.LO.UL[ss] | ((u64)cpuRegs.HI.UL[ss] << 32)) + \
-			   ((u64)cpuRegs.GPR.r[_Rs_].UL[ss] * (u64)cpuRegs.GPR.r[_Rt_].UL[ss]);
+			   ((u64)cpuRegs.GPR[_Rs_].UL[ss] * (u64)cpuRegs.GPR[_Rt_].UL[ss]);
 
 	cpuRegs.LO.SD[dd] = (s32)(tempu & 0xffffffff);
 	cpuRegs.HI.SD[dd] = (s32)(tempu >> 32);
 
-	if (_Rd_) cpuRegs.GPR.r[_Rd_].UD[dd] = tempu;
+	if (_Rd_) cpuRegs.GPR[_Rd_].UD[dd] = tempu;
 }
 
 void PMADDUW() {
@@ -1482,20 +1482,20 @@ void PMADDUW() {
 void PSRAVW() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].SD[0] = (s64)(cpuRegs.GPR.r[_Rt_].SL[0] >>
-									 (cpuRegs.GPR.r[_Rs_].UL[0] & 0x1F));
-	cpuRegs.GPR.r[_Rd_].SD[1] = (s64)(cpuRegs.GPR.r[_Rt_].SL[2] >>
-									 (cpuRegs.GPR.r[_Rs_].UL[2] & 0x1F));
+	cpuRegs.GPR[_Rd_].SD[0] = (s64)(cpuRegs.GPR[_Rt_].SL[0] >>
+									 (cpuRegs.GPR[_Rs_].UL[0] & 0x1F));
+	cpuRegs.GPR[_Rd_].SD[1] = (s64)(cpuRegs.GPR[_Rt_].SL[2] >>
+									 (cpuRegs.GPR[_Rs_].UL[2] & 0x1F));
 }
 
 void PMTHI() {
-	cpuRegs.HI.UD[0] = cpuRegs.GPR.r[_Rs_].UD[0];
-	cpuRegs.HI.UD[1] = cpuRegs.GPR.r[_Rs_].UD[1];
+	cpuRegs.HI.UD[0] = cpuRegs.GPR[_Rs_].UD[0];
+	cpuRegs.HI.UD[1] = cpuRegs.GPR[_Rs_].UD[1];
 }
 
 void PMTLO() {
-	cpuRegs.LO.UD[0] = cpuRegs.GPR.r[_Rs_].UD[0];
-	cpuRegs.LO.UD[1] = cpuRegs.GPR.r[_Rs_].UD[1];
+	cpuRegs.LO.UD[0] = cpuRegs.GPR[_Rs_].UD[0];
+	cpuRegs.LO.UD[1] = cpuRegs.GPR[_Rs_].UD[1];
 }
 
 void PINTEH() {
@@ -1503,25 +1503,25 @@ void PINTEH() {
 
 	if (!_Rd_) return;
 
-	Rs = cpuRegs.GPR.r[_Rs_]; Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rs.US[0];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rs.US[2];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rs.US[4];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[6];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rs.US[6];
+	Rs = cpuRegs.GPR[_Rs_]; Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[1] = Rs.US[0];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[3] = Rs.US[2];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[5] = Rs.US[4];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[6];
+	cpuRegs.GPR[_Rd_].US[7] = Rs.US[6];
 }
 
 __fi void  _PMULTUW(int dd, int ss)
 {
-   u64 tempu = (u64)cpuRegs.GPR.r[_Rs_].UL[ss] * (u64)cpuRegs.GPR.r[_Rt_].UL[ss];
+   u64 tempu = (u64)cpuRegs.GPR[_Rs_].UL[ss] * (u64)cpuRegs.GPR[_Rt_].UL[ss];
 
    cpuRegs.LO.UD[dd] = (s32)(tempu & 0xffffffff);
    cpuRegs.HI.UD[dd] = (s32)(tempu >> 32);
 
-   if (_Rd_) cpuRegs.GPR.r[_Rd_].UD[dd] = tempu;
+   if (_Rd_) cpuRegs.GPR[_Rd_].UD[dd] = tempu;
 }
 
 
@@ -1532,14 +1532,14 @@ void PMULTUW() {
 
 __fi void  _PDIVUW(int dd, int ss)
 {
-	if (cpuRegs.GPR.r[_Rt_].UL[ss] != 0) {
-		cpuRegs.LO.SD[dd] = (s32)(cpuRegs.GPR.r[_Rs_].UL[ss] / cpuRegs.GPR.r[_Rt_].UL[ss]);
-		cpuRegs.HI.SD[dd] = (s32)(cpuRegs.GPR.r[_Rs_].UL[ss] % cpuRegs.GPR.r[_Rt_].UL[ss]);
+	if (cpuRegs.GPR[_Rt_].UL[ss] != 0) {
+		cpuRegs.LO.SD[dd] = (s32)(cpuRegs.GPR[_Rs_].UL[ss] / cpuRegs.GPR[_Rt_].UL[ss]);
+		cpuRegs.HI.SD[dd] = (s32)(cpuRegs.GPR[_Rs_].UL[ss] % cpuRegs.GPR[_Rt_].UL[ss]);
 	}
 	else
 	{
 		cpuRegs.LO.SD[dd] = -1;
-		cpuRegs.HI.SD[dd] = cpuRegs.GPR.r[_Rs_].SL[ss];
+		cpuRegs.HI.SD[dd] = cpuRegs.GPR[_Rs_].SL[ss];
 	}
 }
 
@@ -1553,22 +1553,22 @@ void PCPYUD() {
 
 	// note: first _Rs_, since the other way when _Rd_ equals
 	// _Rs_ or _Rt_ this would screw up
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[1];
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rt_].UD[1];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[1];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rt_].UD[1];
 }
 
 void POR() {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0] | cpuRegs.GPR.r[_Rt_].UD[0];
-	cpuRegs.GPR.r[_Rd_].UD[1] = cpuRegs.GPR.r[_Rs_].UD[1] | cpuRegs.GPR.r[_Rt_].UD[1];
+	cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0] | cpuRegs.GPR[_Rt_].UD[0];
+	cpuRegs.GPR[_Rd_].UD[1] = cpuRegs.GPR[_Rs_].UD[1] | cpuRegs.GPR[_Rt_].UD[1];
 }
 
 void PNOR () {
 	if (!_Rd_) return;
 
-	cpuRegs.GPR.r[_Rd_].UD[0] = ~(cpuRegs.GPR.r[_Rs_].UD[0] | cpuRegs.GPR.r[_Rt_].UD[0]);
-	cpuRegs.GPR.r[_Rd_].UD[1] = ~(cpuRegs.GPR.r[_Rs_].UD[1] | cpuRegs.GPR.r[_Rt_].UD[1]);
+	cpuRegs.GPR[_Rd_].UD[0] = ~(cpuRegs.GPR[_Rs_].UD[0] | cpuRegs.GPR[_Rt_].UD[0]);
+	cpuRegs.GPR[_Rd_].UD[1] = ~(cpuRegs.GPR[_Rs_].UD[1] | cpuRegs.GPR[_Rt_].UD[1]);
 }
 
 void PEXCH() {
@@ -1576,15 +1576,15 @@ void PEXCH() {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rt.US[2];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[1];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rt.US[3];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rt.US[6];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[5];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rt.US[7];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[1] = Rt.US[2];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[1];
+	cpuRegs.GPR[_Rd_].US[3] = Rt.US[3];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[5] = Rt.US[6];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[5];
+	cpuRegs.GPR[_Rd_].US[7] = Rt.US[7];
 }
 
 void PCPYH() {
@@ -1592,15 +1592,15 @@ void PCPYH() {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].US[0] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[1] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[2] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[3] = Rt.US[0];
-	cpuRegs.GPR.r[_Rd_].US[4] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[5] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[6] = Rt.US[4];
-	cpuRegs.GPR.r[_Rd_].US[7] = Rt.US[4];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].US[0] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[1] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[2] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[3] = Rt.US[0];
+	cpuRegs.GPR[_Rd_].US[4] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[5] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[6] = Rt.US[4];
+	cpuRegs.GPR[_Rd_].US[7] = Rt.US[4];
 }
 
 void PEXCW() {
@@ -1608,11 +1608,11 @@ void PEXCW() {
 
 	if (!_Rd_) return;
 
-	Rt = cpuRegs.GPR.r[_Rt_];
-	cpuRegs.GPR.r[_Rd_].UL[0] = Rt.UL[0];
-	cpuRegs.GPR.r[_Rd_].UL[1] = Rt.UL[2];
-	cpuRegs.GPR.r[_Rd_].UL[2] = Rt.UL[1];
-	cpuRegs.GPR.r[_Rd_].UL[3] = Rt.UL[3];
+	Rt = cpuRegs.GPR[_Rt_];
+	cpuRegs.GPR[_Rd_].UL[0] = Rt.UL[0];
+	cpuRegs.GPR[_Rd_].UL[1] = Rt.UL[2];
+	cpuRegs.GPR[_Rd_].UL[2] = Rt.UL[1];
+	cpuRegs.GPR[_Rd_].UL[3] = Rt.UL[3];
 }
 
 //**********************END OF MMI3 OPCODES********************

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -316,7 +316,7 @@ static mem32_t __fastcall _ext_memRead32(u32 mem)
 		default: break;
 	}
 
-	MEM_LOG("Unknown Memory read32  from address %8.8x (Status=%8.8x)", mem, cpuRegs.CP0.n.Status.val);
+	MEM_LOG("Unknown Memory read32  from address %8.8x (Status=%8.8x)", mem, cpuRegs.Status.val);
 	cpuTlbMissR(mem, cpuRegs.branch);
 	return 0;
 }

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -55,8 +55,8 @@ void psxReset()
 	memzero(psxRegs);
 
 	psxRegs.pc = 0xbfc00000; // Start in bootstrap
-	psxRegs.CP0.n.Status = 0x10900000; // COP0 enabled | BEV = 1 | TS = 1
-	psxRegs.CP0.n.PRid   = 0x0000001f; // PRevID = Revision ID, same as the IOP R3000A
+	psxRegs.Status = 0x10900000; // COP0 enabled | BEV = 1 | TS = 1
+	psxRegs.PRid   = 0x0000001f; // PRevID = Revision ID, same as the IOP R3000A
 
 	iopBreak = 0;
 	iopCycleEE = -1;
@@ -76,34 +76,34 @@ void __fastcall psxException(u32 code, u32 bd)
 //	PSXCPU_LOG("psxException %x: %x, %x", code, psxHu32(0x1070), psxHu32(0x1074));
 	//Console.WriteLn("!! psxException %x: %x, %x", code, psxHu32(0x1070), psxHu32(0x1074));
 	// Set the Cause
-	psxRegs.CP0.n.Cause &= ~0x7f;
-	psxRegs.CP0.n.Cause |= code;
+	psxRegs.Cause &= ~0x7f;
+	psxRegs.Cause |= code;
 
 	// Set the EPC & PC
 	if (bd)
 	{
 		PSXCPU_LOG("bd set");
-		psxRegs.CP0.n.Cause|= 0x80000000;
-		psxRegs.CP0.n.EPC = (psxRegs.pc - 4);
+		psxRegs.Cause|= 0x80000000;
+		psxRegs.EPC = (psxRegs.pc - 4);
 	}
 	else
-		psxRegs.CP0.n.EPC = (psxRegs.pc);
+		psxRegs.EPC = (psxRegs.pc);
 
-	if (psxRegs.CP0.n.Status & 0x400000)
+	if (psxRegs.Status & 0x400000)
 		psxRegs.pc = 0xbfc00180;
 	else
 		psxRegs.pc = 0x80000080;
 
 	// Set the Status
-	psxRegs.CP0.n.Status = (psxRegs.CP0.n.Status &~0x3f) |
-						  ((psxRegs.CP0.n.Status & 0xf) << 2);
+	psxRegs.Status = (psxRegs.Status &~0x3f) |
+						  ((psxRegs.Status & 0xf) << 2);
 
-	/*if ((((PSXMu32(psxRegs.CP0.n.EPC) >> 24) & 0xfe) == 0x4a)) {
+	/*if ((((PSXMu32(psxRegs.EPC) >> 24) & 0xfe) == 0x4a)) {
 		// "hokuto no ken" / "Crash Bandicot 2" ... fix
-		PSXMu32(psxRegs.CP0.n.EPC)&= ~0x02000000;
+		PSXMu32(psxRegs.EPC)&= ~0x02000000;
 	}*/
 
-	/*if (psxRegs.CP0.n.Cause == 0x400 && (!(psxHu32(0x1450) & 0x8))) {
+	/*if (psxRegs.Cause == 0x400 && (!(psxHu32(0x1450) & 0x8))) {
 		hwIntcIrq(INTC_SBUS);
 	}*/
 }
@@ -216,7 +216,7 @@ __ri void iopEventTest()
 
 	if( (psxHu32(0x1078) != 0) && ((psxHu32(0x1070) & psxHu32(0x1074)) != 0) )
 	{
-		if( (psxRegs.CP0.n.Status & 0xFE01) >= 0x401 )
+		if( (psxRegs.Status & 0xFE01) >= 0x401 )
 		{
 			PSXCPU_LOG("Interrupt: %x  %x", psxHu32(0x1070), psxHu32(0x1074));
 			psxException(0, 0);

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -18,30 +18,6 @@
 
 #include <stdio.h>
 
-union GPRRegs {
-	struct {
-		u32 r0, at, v0, v1, a0, a1, a2, a3,
-			t0, t1, t2, t3, t4, t5, t6, t7,
-			s0, s1, s2, s3, s4, s5, s6, s7,
-			t8, t9, k0, k1, gp, sp, s8, ra, hi, lo; // hi needs to be at index 32! don't change
-	} n;
-	u32 r[34]; /* Lo, Hi in r[33] and r[32] */
-};
-
-union CP0Regs {
-	struct {
-		u32 Index,     Random,    EntryLo0,  EntryLo1,
-			Context,   PageMask,  Wired,     Reserved0,
-			BadVAddr,  Count,     EntryHi,   Compare,
-			Status,    Cause,     EPC,       PRid,
-			Config,    LLAddr,    WatchLO,   WatchHI,
-			XContext,  Reserved1, Reserved2, Reserved3,
-			Reserved4, Reserved5, ECC,       CacheErr,
-			TagLo,     TagHi,     ErrorEPC,  Reserved6;
-	} n;
-	u32 r[32];
-};
-
 struct SVector2D {
 	short x, y;
 };
@@ -66,45 +42,71 @@ struct SMatrix3D {
 	short m11, m12, m13, m21, m22, m23, m31, m32, m33, pad;
 };
 
-union CP2Data {
-	struct {
-		SVector3D     v0, v1, v2;
-		CBGR          rgb;
-		s32          otz;
-		s32          ir0, ir1, ir2, ir3;
-		SVector2D     sxy0, sxy1, sxy2, sxyp;
-		SVector2Dz    sz0, sz1, sz2, sz3;
-		CBGR          rgb0, rgb1, rgb2;
-		s32          reserved;
-		s32          mac0, mac1, mac2, mac3;
-		u32 irgb, orgb;
-		s32          lzcs, lzcr;
-	} n;
-	u32 r[32];
-};
-
-union CP2Ctrl {
-	struct {
-		SMatrix3D rMatrix;
-		s32      trX, trY, trZ;
-		SMatrix3D lMatrix;
-		s32      rbk, gbk, bbk;
-		SMatrix3D cMatrix;
-		s32      rfc, gfc, bfc;
-		s32      ofx, ofy;
-		s32      h;
-		s32      dqa, dqb;
-		s32      zsf3, zsf4;
-		s32      flag;
-	} n;
-	u32 r[32];
-};
-
 struct psxRegisters {
-	GPRRegs GPR;		/* General Purpose Registers */
-	CP0Regs CP0;		/* Coprocessor0 Registers */
-	CP2Data CP2D; 		/* Cop2 data registers */
-	CP2Ctrl CP2C; 		/* Cop2 control registers */
+	/* General Purpose Registers */
+	union {
+		struct {
+			u32 r0, at, v0, v1, a0, a1, a2, a3,
+				t0, t1, t2, t3, t4, t5, t6, t7,
+				s0, s1, s2, s3, s4, s5, s6, s7,
+				t8, t9, k0, k1, gp, sp, s8, ra, hi, lo; // hi needs to be at index 32! don't change
+		};
+		u32 GPR[34]; /* Lo, Hi in GPR[33] and GPR[32] */
+	};
+
+	/* Coprocessor0 Registers */
+	union CP0Regs {
+		struct {
+			u32 Index,     Random,    EntryLo0,  EntryLo1,
+				Context,   PageMask,  Wired,     Reserved0,
+				BadVAddr,  Count,     EntryHi,   Compare,
+				Status,    Cause,     EPC,       PRid,
+				Config,    LLAddr,    WatchLO,   WatchHI,
+				XContext,  Reserved1, Reserved2, Reserved3,
+				Reserved4, Reserved5, ECC,       CacheErr,
+				TagLo,     TagHi,     ErrorEPC,  Reserved6;
+		};
+		u32 CP0[32];
+	};
+
+	/* Cop2 data registers */
+	union CP2Data {
+		// Note: This struct is currently unused
+		struct {
+			SVector3D     v0, v1, v2;
+			CBGR          rgb;
+			s32          otz;
+			s32          ir0, ir1, ir2, ir3;
+			SVector2D     sxy0, sxy1, sxy2, sxyp;
+			SVector2Dz    sz0, sz1, sz2, sz3;
+			CBGR          rgb0, rgb1, rgb2;
+			s32          reserved;
+			s32          mac0, mac1, mac2, mac3;
+			u32 irgb, orgb;
+			s32          lzcs, lzcr;
+		};
+		u32 CP2D[32];
+	};
+
+	/* Cop2 control registers */
+	union {
+		// Note: This struct is currently unused
+		struct {
+			SMatrix3D rMatrix;
+			s32      trX, trY, trZ;
+			SMatrix3D lMatrix;
+			s32      rbk, gbk, bbk;
+			SMatrix3D cMatrix;
+			s32      rfc, gfc, bfc;
+			s32      ofx, ofy;
+			s32      h;
+			s32      dqa, dqb;
+			s32      zsf3, zsf4;
+			s32      flag;
+		};
+		u32 CP2C[32];
+	};
+
 	u32 pc;				/* Program counter */
 	u32 code;			/* The instruction */
 	u32 cycle;

--- a/pcsx2/R3000AOpcodeTables.cpp
+++ b/pcsx2/R3000AOpcodeTables.cpp
@@ -87,15 +87,15 @@ void psxDIVU() {
 void psxMULT() {
 	u64 res = (s64)((s64)_i32(_rRs_) * (s64)_i32(_rRt_));
 
-	psxRegs.GPR.n.lo = (u32)(res & 0xffffffff);
-	psxRegs.GPR.n.hi = (u32)((res >> 32) & 0xffffffff);
+	psxRegs.lo = (u32)(res & 0xffffffff);
+	psxRegs.hi = (u32)((res >> 32) & 0xffffffff);
 }
 
 void psxMULTU() {
 	u64 res = (u64)((u64)_u32(_rRs_) * (u64)_u32(_rRt_));
 
-	psxRegs.GPR.n.lo = (u32)(res & 0xffffffff);
-	psxRegs.GPR.n.hi = (u32)((res >> 32) & 0xffffffff);
+	psxRegs.lo = (u32)(res & 0xffffffff);
+	psxRegs.hi = (u32)((res >> 32) & 0xffffffff);
 }
 
 /*********************************************************
@@ -152,8 +152,8 @@ void psxSYSCALL() {
 
 void psxRFE() {
 //	Console.WriteLn("RFE\n");
-	psxRegs.CP0.n.Status = (psxRegs.CP0.n.Status & 0xfffffff0) |
-						  ((psxRegs.CP0.n.Status & 0x3c) >> 2);
+	psxRegs.Status = (psxRegs.Status & 0xfffffff0) |
+						  ((psxRegs.Status & 0x3c) >> 2);
 //	Log=0;
 }
 

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -236,7 +236,7 @@ struct tlbs
 #define _BranchTarget_   (((s32)(s16)_Im_ * 4) + _PC_)                 // Calculates the target during a branch instruction
 #define _TrapCode_       ((u16)cpuRegs.code >> 6)	// error code for non-immediate trap instructions.
 
-#define _SetLink(x)     (cpuRegs.GPR.r[x].UD[0] = _PC_ + 4)       // Sets the return address in the link register
+#define _SetLink(x)     (cpuRegs.GPR[x].UD[0] = _PC_ + 4)       // Sets the return address in the link register
 
 #endif
 

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -284,9 +284,9 @@ void COP1_Unknown() { Console.Warning("Unknown FPU/COP1 opcode called"); }
 void ADDI()
 {
 	s64 result;
-	bool overflow = _add32_Overflow( cpuRegs.GPR.r[_Rs_].SD[0], _Imm_, result );
+	bool overflow = _add32_Overflow( cpuRegs.GPR[_Rs_].SD[0], _Imm_, result );
 	if (overflow || !_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = result;
+	cpuRegs.GPR[_Rt_].SD[0] = result;
 }
 
 // Rt = Rs + Im signed !!! [overflow ignored]
@@ -295,7 +295,7 @@ void ADDI()
 void ADDIU()
 {
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = cpuRegs.GPR.r[_Rs_].SL[0] + _Imm_;
+	cpuRegs.GPR[_Rt_].SD[0] = cpuRegs.GPR[_Rs_].SL[0] + _Imm_;
 }
 
 // Rt = Rs + Im [exception on overflow]
@@ -304,9 +304,9 @@ void ADDIU()
 void DADDI()
 {
 	s64 result;
-	bool overflow = _add64_Overflow( cpuRegs.GPR.r[_Rs_].SD[0], _Imm_, result );
+	bool overflow = _add64_Overflow( cpuRegs.GPR[_Rs_].SD[0], _Imm_, result );
 	if (overflow || !_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = result;
+	cpuRegs.GPR[_Rt_].SD[0] = result;
 }
 
 // Rt = Rs + Im [overflow ignored]
@@ -315,13 +315,13 @@ void DADDI()
 void DADDIU()
 {
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] = cpuRegs.GPR.r[_Rs_].SD[0] + _Imm_;
+	cpuRegs.GPR[_Rt_].UD[0] = cpuRegs.GPR[_Rs_].SD[0] + _Imm_;
 }
-void ANDI() 	{ if (!_Rt_) return; cpuRegs.GPR.r[_Rt_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0] & (u64)_ImmU_; } // Rt = Rs And Im (zero-extended)
-void ORI() 	    { if (!_Rt_) return; cpuRegs.GPR.r[_Rt_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0] | (u64)_ImmU_; } // Rt = Rs Or  Im (zero-extended)
-void XORI() 	{ if (!_Rt_) return; cpuRegs.GPR.r[_Rt_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0] ^ (u64)_ImmU_; } // Rt = Rs Xor Im (zero-extended)
-void SLTI()     { if (!_Rt_) return; cpuRegs.GPR.r[_Rt_].UD[0] = (cpuRegs.GPR.r[_Rs_].SD[0] < (s64)(_Imm_)) ? 1 : 0; } // Rt = Rs < Im (signed)
-void SLTIU()    { if (!_Rt_) return; cpuRegs.GPR.r[_Rt_].UD[0] = (cpuRegs.GPR.r[_Rs_].UD[0] < (u64)(_Imm_)) ? 1 : 0; } // Rt = Rs < Im (unsigned)
+void ANDI() 	{ if (!_Rt_) return; cpuRegs.GPR[_Rt_].UD[0] = cpuRegs.GPR[_Rs_].UD[0] & (u64)_ImmU_; } // Rt = Rs And Im (zero-extended)
+void ORI() 	    { if (!_Rt_) return; cpuRegs.GPR[_Rt_].UD[0] = cpuRegs.GPR[_Rs_].UD[0] | (u64)_ImmU_; } // Rt = Rs Or  Im (zero-extended)
+void XORI() 	{ if (!_Rt_) return; cpuRegs.GPR[_Rt_].UD[0] = cpuRegs.GPR[_Rs_].UD[0] ^ (u64)_ImmU_; } // Rt = Rs Xor Im (zero-extended)
+void SLTI()     { if (!_Rt_) return; cpuRegs.GPR[_Rt_].UD[0] = (cpuRegs.GPR[_Rs_].SD[0] < (s64)(_Imm_)) ? 1 : 0; } // Rt = Rs < Im (signed)
+void SLTIU()    { if (!_Rt_) return; cpuRegs.GPR[_Rt_].UD[0] = (cpuRegs.GPR[_Rs_].UD[0] < (u64)(_Imm_)) ? 1 : 0; } // Rt = Rs < Im (unsigned)
 
 /*********************************************************
 * Register arithmetic                                    *
@@ -332,47 +332,47 @@ void SLTIU()    { if (!_Rt_) return; cpuRegs.GPR.r[_Rt_].UD[0] = (cpuRegs.GPR.r[
 void ADD()
 {
 	s64 result;
-	bool overflow = _add32_Overflow( cpuRegs.GPR.r[_Rs_].SD[0], cpuRegs.GPR.r[_Rt_].SD[0], result );
+	bool overflow = _add32_Overflow( cpuRegs.GPR[_Rs_].SD[0], cpuRegs.GPR[_Rt_].SD[0], result );
 	if (overflow || !_Rd_) return;
-	cpuRegs.GPR.r[_Rd_].SD[0] = result;
+	cpuRegs.GPR[_Rd_].SD[0] = result;
 }
 
 void DADD()
 {
 	s64 result;
-	bool overflow = _add64_Overflow( cpuRegs.GPR.r[_Rs_].SD[0], cpuRegs.GPR.r[_Rt_].SD[0], result );
+	bool overflow = _add64_Overflow( cpuRegs.GPR[_Rs_].SD[0], cpuRegs.GPR[_Rt_].SD[0], result );
 	if (overflow || !_Rd_) return;
-	cpuRegs.GPR.r[_Rd_].SD[0] = result;
+	cpuRegs.GPR[_Rd_].SD[0] = result;
 }
 
 // Rd = Rs - Rt		(Exception on Integer Overflow)
 void SUB()
 {
 	s64 result;
-	bool overflow = _add32_Overflow( cpuRegs.GPR.r[_Rs_].SD[0], -cpuRegs.GPR.r[_Rt_].SD[0], result );
+	bool overflow = _add32_Overflow( cpuRegs.GPR[_Rs_].SD[0], -cpuRegs.GPR[_Rt_].SD[0], result );
 	if (overflow || !_Rd_) return;
-	cpuRegs.GPR.r[_Rd_].SD[0] = result;
+	cpuRegs.GPR[_Rd_].SD[0] = result;
 }
 
 // Rd = Rs - Rt		(Exception on Integer Overflow)
 void DSUB()
 {
 	s64 result;
-	bool overflow = _add64_Overflow( cpuRegs.GPR.r[_Rs_].SD[0], -cpuRegs.GPR.r[_Rt_].SD[0], result );
+	bool overflow = _add64_Overflow( cpuRegs.GPR[_Rs_].SD[0], -cpuRegs.GPR[_Rt_].SD[0], result );
 	if (overflow || !_Rd_) return;
-	cpuRegs.GPR.r[_Rd_].SD[0] = result;
+	cpuRegs.GPR[_Rd_].SD[0] = result;
 }
 
-void ADDU() 	{ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].SL[0]  + cpuRegs.GPR.r[_Rt_].SL[0];}	// Rd = Rs + Rt
-void DADDU()    { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].SD[0]  + cpuRegs.GPR.r[_Rt_].SD[0]; }
-void SUBU() 	{ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].SL[0]  - cpuRegs.GPR.r[_Rt_].SL[0]; }	// Rd = Rs - Rt
-void DSUBU() 	{ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].SD[0]  - cpuRegs.GPR.r[_Rt_].SD[0]; }
-void AND() 	    { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0]  & cpuRegs.GPR.r[_Rt_].UD[0]; }	// Rd = Rs And Rt
-void OR() 	    { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0]  | cpuRegs.GPR.r[_Rt_].UD[0]; }	// Rd = Rs Or  Rt
-void XOR() 	    { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0]  ^ cpuRegs.GPR.r[_Rt_].UD[0]; }	// Rd = Rs Xor Rt
-void NOR() 	    { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] =~(cpuRegs.GPR.r[_Rs_].UD[0] | cpuRegs.GPR.r[_Rt_].UD[0]); }// Rd = Rs Nor Rt
-void SLT()		{ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (cpuRegs.GPR.r[_Rs_].SD[0] < cpuRegs.GPR.r[_Rt_].SD[0]) ? 1 : 0; }	// Rd = Rs < Rt (signed)
-void SLTU()		{ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (cpuRegs.GPR.r[_Rs_].UD[0] < cpuRegs.GPR.r[_Rt_].UD[0]) ? 1 : 0; }	// Rd = Rs < Rt (unsigned)
+void ADDU() 	{ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].SL[0]  + cpuRegs.GPR[_Rt_].SL[0];}	// Rd = Rs + Rt
+void DADDU()    { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].SD[0]  + cpuRegs.GPR[_Rt_].SD[0]; }
+void SUBU() 	{ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].SL[0]  - cpuRegs.GPR[_Rt_].SL[0]; }	// Rd = Rs - Rt
+void DSUBU() 	{ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].SD[0]  - cpuRegs.GPR[_Rt_].SD[0]; }
+void AND() 	    { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0]  & cpuRegs.GPR[_Rt_].UD[0]; }	// Rd = Rs And Rt
+void OR() 	    { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0]  | cpuRegs.GPR[_Rt_].UD[0]; }	// Rd = Rs Or  Rt
+void XOR() 	    { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0]  ^ cpuRegs.GPR[_Rt_].UD[0]; }	// Rd = Rs Xor Rt
+void NOR() 	    { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] =~(cpuRegs.GPR[_Rs_].UD[0] | cpuRegs.GPR[_Rt_].UD[0]); }// Rd = Rs Nor Rt
+void SLT()		{ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = (cpuRegs.GPR[_Rs_].SD[0] < cpuRegs.GPR[_Rt_].SD[0]) ? 1 : 0; }	// Rd = Rs < Rt (signed)
+void SLTU()		{ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = (cpuRegs.GPR[_Rs_].UD[0] < cpuRegs.GPR[_Rt_].UD[0]) ? 1 : 0; }	// Rd = Rs < Rt (unsigned)
 
 /*********************************************************
 * Register mult/div & Register trap logic                *
@@ -387,62 +387,62 @@ void SLTU()		{ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (cpuRegs.GPR.r[_Rs
 // Result is stored in HI/LO [no arithmetic exceptions]
 void DIV()
 {
-	if (cpuRegs.GPR.r[_Rs_].UL[0] == 0x80000000 && cpuRegs.GPR.r[_Rt_].UL[0] == 0xffffffff)
+	if (cpuRegs.GPR[_Rs_].UL[0] == 0x80000000 && cpuRegs.GPR[_Rt_].UL[0] == 0xffffffff)
 	{
 		cpuRegs.LO.SD[0] = (s32)0x80000000;
 		cpuRegs.HI.SD[0] = (s32)0x0;
 	}
-    else if (cpuRegs.GPR.r[_Rt_].SL[0] != 0)
+    else if (cpuRegs.GPR[_Rt_].SL[0] != 0)
     {
-        cpuRegs.LO.SD[0] = cpuRegs.GPR.r[_Rs_].SL[0] / cpuRegs.GPR.r[_Rt_].SL[0];
-        cpuRegs.HI.SD[0] = cpuRegs.GPR.r[_Rs_].SL[0] % cpuRegs.GPR.r[_Rt_].SL[0];
+        cpuRegs.LO.SD[0] = cpuRegs.GPR[_Rs_].SL[0] / cpuRegs.GPR[_Rt_].SL[0];
+        cpuRegs.HI.SD[0] = cpuRegs.GPR[_Rs_].SL[0] % cpuRegs.GPR[_Rt_].SL[0];
     }
 	else
 	{
-		cpuRegs.LO.SD[0] = (cpuRegs.GPR.r[_Rs_].SL[0] < 0) ? 1 : -1;
-		cpuRegs.HI.SD[0] = cpuRegs.GPR.r[_Rs_].SL[0];
+		cpuRegs.LO.SD[0] = (cpuRegs.GPR[_Rs_].SL[0] < 0) ? 1 : -1;
+		cpuRegs.HI.SD[0] = cpuRegs.GPR[_Rs_].SL[0];
 	}
 }
 
 // Result is stored in HI/LO [no arithmetic exceptions]
 void DIVU()
 {
-	if (cpuRegs.GPR.r[_Rt_].UL[0] != 0)
+	if (cpuRegs.GPR[_Rt_].UL[0] != 0)
 	{
 		// note: DIVU has no sign extension when assigning back to 64 bits
 		// note 2: reference material strongly disagrees. (air)
-		cpuRegs.LO.SD[0] = (s32)(cpuRegs.GPR.r[_Rs_].UL[0] / cpuRegs.GPR.r[_Rt_].UL[0]);
-		cpuRegs.HI.SD[0] = (s32)(cpuRegs.GPR.r[_Rs_].UL[0] % cpuRegs.GPR.r[_Rt_].UL[0]);
+		cpuRegs.LO.SD[0] = (s32)(cpuRegs.GPR[_Rs_].UL[0] / cpuRegs.GPR[_Rt_].UL[0]);
+		cpuRegs.HI.SD[0] = (s32)(cpuRegs.GPR[_Rs_].UL[0] % cpuRegs.GPR[_Rt_].UL[0]);
 	}
 	else
 	{
 		cpuRegs.LO.SD[0] = -1;
-		cpuRegs.HI.SD[0] = cpuRegs.GPR.r[_Rs_].SL[0];
+		cpuRegs.HI.SD[0] = cpuRegs.GPR[_Rs_].SL[0];
 	}
 }
 
 // Result is written to both HI/LO and to the _Rd_ (Lo only)
 void MULT()
 {
-	s64 res = (s64)cpuRegs.GPR.r[_Rs_].SL[0] * cpuRegs.GPR.r[_Rt_].SL[0];
+	s64 res = (s64)cpuRegs.GPR[_Rs_].SL[0] * cpuRegs.GPR[_Rt_].SL[0];
 
 	// Sign-extend into 64 bits:
 	cpuRegs.LO.SD[0] = (s32)(res & 0xffffffff);
 	cpuRegs.HI.SD[0] = (s32)(res >> 32);
 
-	if( _Rd_ ) cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[0];
+	if( _Rd_ ) cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[0];
 }
 
 // Result is written to both HI/LO and to the _Rd_ (Lo only)
 void MULTU()
 {
-	u64 res = (u64)cpuRegs.GPR.r[_Rs_].UL[0] * cpuRegs.GPR.r[_Rt_].UL[0];
+	u64 res = (u64)cpuRegs.GPR[_Rs_].UL[0] * cpuRegs.GPR[_Rt_].UL[0];
 
 	// Note: sign-extend into 64 bits even though it's an unsigned mult.
 	cpuRegs.LO.SD[0] = (s32)(res & 0xffffffff);
 	cpuRegs.HI.SD[0] = (s32)(res >> 32);
 
-	if( _Rd_ ) cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[0];
+	if( _Rd_ ) cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[0];
 }
 
 /*********************************************************
@@ -451,48 +451,48 @@ void MULTU()
 *********************************************************/
 void LUI() {
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] = (s32)(cpuRegs.code << 16);
+	cpuRegs.GPR[_Rt_].UD[0] = (s32)(cpuRegs.code << 16);
 }
 
 /*********************************************************
 * Move from HI/LO to GPR                                 *
 * Format:  OP rd                                         *
 *********************************************************/
-void MFHI() { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.HI.UD[0]; } // Rd = Hi
-void MFLO() { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.LO.UD[0]; } // Rd = Lo
+void MFHI() { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.HI.UD[0]; } // Rd = Hi
+void MFLO() { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.LO.UD[0]; } // Rd = Lo
 
 /*********************************************************
 * Move to GPR to HI/LO & Register jump                   *
 * Format:  OP rs                                         *
 *********************************************************/
-void MTHI() { cpuRegs.HI.UD[0] = cpuRegs.GPR.r[_Rs_].UD[0]; } // Hi = Rs
-void MTLO() { cpuRegs.LO.UD[0] = cpuRegs.GPR.r[_Rs_].UD[0]; } // Lo = Rs
+void MTHI() { cpuRegs.HI.UD[0] = cpuRegs.GPR[_Rs_].UD[0]; } // Hi = Rs
+void MTLO() { cpuRegs.LO.UD[0] = cpuRegs.GPR[_Rs_].UD[0]; } // Lo = Rs
 
 
 /*********************************************************
 * Shift arithmetic with constant shift                   *
 * Format:  OP rd, rt, sa                                 *
 *********************************************************/
-void SRA()   { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s32)(cpuRegs.GPR.r[_Rt_].SL[0] >> _Sa_); } // Rd = Rt >> sa (arithmetic)
-void SRL()   { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s32)(cpuRegs.GPR.r[_Rt_].UL[0] >> _Sa_); } // Rd = Rt >> sa (logical) [sign extend!!]
-void SLL()   { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s32)(cpuRegs.GPR.r[_Rt_].UL[0] << _Sa_); } // Rd = Rt << sa
-void DSLL()  { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (u64)(cpuRegs.GPR.r[_Rt_].UD[0] << _Sa_); }
-void DSLL32(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (u64)(cpuRegs.GPR.r[_Rt_].UD[0] << (_Sa_+32));}
-void DSRA()  { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = cpuRegs.GPR.r[_Rt_].SD[0] >> _Sa_; }
-void DSRA32(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = cpuRegs.GPR.r[_Rt_].SD[0] >> (_Sa_+32);}
-void DSRL()  { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0] >> _Sa_; }
-void DSRL32(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0] >> (_Sa_+32);}
+void SRA()   { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s32)(cpuRegs.GPR[_Rt_].SL[0] >> _Sa_); } // Rd = Rt >> sa (arithmetic)
+void SRL()   { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s32)(cpuRegs.GPR[_Rt_].UL[0] >> _Sa_); } // Rd = Rt >> sa (logical) [sign extend!!]
+void SLL()   { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s32)(cpuRegs.GPR[_Rt_].UL[0] << _Sa_); } // Rd = Rt << sa
+void DSLL()  { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = (u64)(cpuRegs.GPR[_Rt_].UD[0] << _Sa_); }
+void DSLL32(){ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = (u64)(cpuRegs.GPR[_Rt_].UD[0] << (_Sa_+32));}
+void DSRA()  { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = cpuRegs.GPR[_Rt_].SD[0] >> _Sa_; }
+void DSRA32(){ if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = cpuRegs.GPR[_Rt_].SD[0] >> (_Sa_+32);}
+void DSRL()  { if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rt_].UD[0] >> _Sa_; }
+void DSRL32(){ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rt_].UD[0] >> (_Sa_+32);}
 
 /*********************************************************
 * Shift arithmetic with variant register shift           *
 * Format:  OP rd, rt, rs                                 *
 *********************************************************/
-void SLLV() { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s32)(cpuRegs.GPR.r[_Rt_].UL[0] << (cpuRegs.GPR.r[_Rs_].UL[0] &0x1f));} // Rd = Rt << rs
-void SRAV() { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s32)(cpuRegs.GPR.r[_Rt_].SL[0] >> (cpuRegs.GPR.r[_Rs_].UL[0] &0x1f));} // Rd = Rt >> rs (arithmetic)
-void SRLV() { if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s32)(cpuRegs.GPR.r[_Rt_].UL[0] >> (cpuRegs.GPR.r[_Rs_].UL[0] &0x1f));} // Rd = Rt >> rs (logical)
-void DSLLV(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (u64)(cpuRegs.GPR.r[_Rt_].UD[0] << (cpuRegs.GPR.r[_Rs_].UL[0] &0x3f));}
-void DSRAV(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].SD[0] = (s64)(cpuRegs.GPR.r[_Rt_].SD[0] >> (cpuRegs.GPR.r[_Rs_].UL[0] &0x3f));}
-void DSRLV(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (u64)(cpuRegs.GPR.r[_Rt_].UD[0] >> (cpuRegs.GPR.r[_Rs_].UL[0] &0x3f));}
+void SLLV() { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s32)(cpuRegs.GPR[_Rt_].UL[0] << (cpuRegs.GPR[_Rs_].UL[0] &0x1f));} // Rd = Rt << rs
+void SRAV() { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s32)(cpuRegs.GPR[_Rt_].SL[0] >> (cpuRegs.GPR[_Rs_].UL[0] &0x1f));} // Rd = Rt >> rs (arithmetic)
+void SRLV() { if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s32)(cpuRegs.GPR[_Rt_].UL[0] >> (cpuRegs.GPR[_Rs_].UL[0] &0x1f));} // Rd = Rt >> rs (logical)
+void DSLLV(){ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = (u64)(cpuRegs.GPR[_Rt_].UD[0] << (cpuRegs.GPR[_Rs_].UL[0] &0x3f));}
+void DSRAV(){ if (!_Rd_) return; cpuRegs.GPR[_Rd_].SD[0] = (s64)(cpuRegs.GPR[_Rt_].SD[0] >> (cpuRegs.GPR[_Rs_].UL[0] &0x3f));}
+void DSRLV(){ if (!_Rd_) return; cpuRegs.GPR[_Rd_].UD[0] = (u64)(cpuRegs.GPR[_Rt_].UD[0] >> (cpuRegs.GPR[_Rs_].UL[0] &0x3f));}
 
 /*********************************************************
 * Load and store for GPR                                 *
@@ -512,25 +512,25 @@ void DSRLV(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (u64)(cpuRegs.GPR.r
 
 void LB()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	s8 temp = memRead8(addr);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = temp;
+	cpuRegs.GPR[_Rt_].SD[0] = temp;
 }
 
 void LBU()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u8 temp = memRead8(addr);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] = temp;
+	cpuRegs.GPR[_Rt_].UD[0] = temp;
 }
 
 void LH()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 1 )
 		throw R5900Exception::AddressError( addr, false );
@@ -538,12 +538,12 @@ void LH()
 	s16 temp = memRead16(addr);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = temp;
+	cpuRegs.GPR[_Rt_].SD[0] = temp;
 }
 
 void LHU()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 1 )
 		throw R5900Exception::AddressError( addr, false );
@@ -551,12 +551,12 @@ void LHU()
 	u16 temp = memRead16(addr);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] = temp;
+	cpuRegs.GPR[_Rt_].UD[0] = temp;
 }
 
 void LW()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 3 )
 		throw R5900Exception::AddressError( addr, false );
@@ -564,12 +564,12 @@ void LW()
 	u32 temp = memRead32(addr);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].SD[0] = (s32)temp;
+	cpuRegs.GPR[_Rt_].SD[0] = (s32)temp;
 }
 
 void LWU()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 3 )
 		throw R5900Exception::AddressError( addr, false );
@@ -577,7 +577,7 @@ void LWU()
 	u32 temp = memRead32(addr);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] = temp;
+	cpuRegs.GPR[_Rt_].UD[0] = temp;
 }
 
 static const u32 LWL_MASK[4] = { 0xffffff, 0x0000ffff, 0x000000ff, 0x00000000 };
@@ -587,7 +587,7 @@ static const u8 LWR_SHIFT[4] = { 0, 8, 16, 24 };
 
 void LWL()
 {
-	s32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	s32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 3;
 
 	// ensure the compiler does correct sign extension into 64 bits by using s32
@@ -595,7 +595,7 @@ void LWL()
 
 	if (!_Rt_) return;
 
-	cpuRegs.GPR.r[_Rt_].SD[0] =	(cpuRegs.GPR.r[_Rt_].SL[0] & LWL_MASK[shift]) |
+	cpuRegs.GPR[_Rt_].SD[0] =	(cpuRegs.GPR[_Rt_].SL[0] & LWL_MASK[shift]) |
 								(mem << LWL_SHIFT[shift]);
 
 	/*
@@ -611,7 +611,7 @@ void LWL()
 
 void LWR()
 {
-	s32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	s32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 3;
 
 	u32 mem = memRead32(addr & ~3);
@@ -619,18 +619,18 @@ void LWR()
 	if (!_Rt_) return;
 
 	// Use unsigned math here, and conditionally sign extend below, when needed.
-	mem = (cpuRegs.GPR.r[_Rt_].UL[0] & LWR_MASK[shift]) | (mem >> LWR_SHIFT[shift]);
+	mem = (cpuRegs.GPR[_Rt_].UL[0] & LWR_MASK[shift]) | (mem >> LWR_SHIFT[shift]);
 
 	if( shift == 0 )
 	{
 		// This special case requires sign extension into the full 64 bit dest.
-		cpuRegs.GPR.r[_Rt_].SD[0] =	(s32)mem;
+		cpuRegs.GPR[_Rt_].SD[0] =	(s32)mem;
 	}
 	else
 	{
 		// This case sets the lower 32 bits of the target register.  Upper
 		// 32 bits are always preserved.
-		cpuRegs.GPR.r[_Rt_].UL[0] =	mem;
+		cpuRegs.GPR[_Rt_].UL[0] =	mem;
 	}
 
 	/*
@@ -652,12 +652,12 @@ static __aligned16 GPR_reg m_dummy_gpr_zero;
 // always preserved)
 static GPR_reg* gpr_GetWritePtr( uint gpr )
 {
-	return (( gpr == 0 ) ? &m_dummy_gpr_zero : &cpuRegs.GPR.r[gpr]);
+	return (( gpr == 0 ) ? &m_dummy_gpr_zero : &cpuRegs.GPR[gpr]);
 }
 
 void LD()
 {
-    s32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+    s32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 7 )
 		throw R5900Exception::AddressError( addr, false );
@@ -680,27 +680,27 @@ static const u8 LDL_SHIFT[8] = { 56, 48, 40, 32, 24, 16, 8, 0 };
 
 void LDL()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 7;
 
 	u64 mem;
 	memRead64(addr & ~7, &mem);
 
 	if( !_Rt_ ) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] =	(cpuRegs.GPR.r[_Rt_].UD[0] & LDL_MASK[shift]) |
+	cpuRegs.GPR[_Rt_].UD[0] =	(cpuRegs.GPR[_Rt_].UD[0] & LDL_MASK[shift]) |
 								(mem << LDL_SHIFT[shift]);
 }
 
 void LDR()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 7;
 
 	u64 mem;
 	memRead64(addr & ~7, &mem);
 
 	if (!_Rt_) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] =	(cpuRegs.GPR.r[_Rt_].UD[0] & LDR_MASK[shift]) |
+	cpuRegs.GPR[_Rt_].UD[0] =	(cpuRegs.GPR[_Rt_].UD[0] & LDR_MASK[shift]) |
 								(mem >> LDR_SHIFT[shift]);
 }
 
@@ -709,34 +709,34 @@ void LQ()
 	// MIPS Note: LQ and SQ are special and "silently" align memory addresses, thus
 	// an address error due to unaligned access isn't possible like it is on other loads/stores.
 
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	memRead128(addr & ~0xf, (u128*)gpr_GetWritePtr(_Rt_));
 }
 
 void SB()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
-	memWrite8(addr, cpuRegs.GPR.r[_Rt_].UC[0]);
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
+	memWrite8(addr, cpuRegs.GPR[_Rt_].UC[0]);
 }
 
 void SH()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 1 )
 		throw R5900Exception::AddressError( addr, true );
 
-	memWrite16(addr, cpuRegs.GPR.r[_Rt_].US[0]);
+	memWrite16(addr, cpuRegs.GPR[_Rt_].US[0]);
 }
 
 void SW()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 3 )
 		throw R5900Exception::AddressError( addr, true );
 
-    memWrite32(addr, cpuRegs.GPR.r[_Rt_].UL[0]);
+    memWrite32(addr, cpuRegs.GPR[_Rt_].UL[0]);
 }
 
 static const u32 SWL_MASK[4] = { 0xffffff00, 0xffff0000, 0xff000000, 0x00000000 };
@@ -747,12 +747,12 @@ static const u8 SWL_SHIFT[4] = { 24, 16, 8, 0 };
 
 void SWL()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 3;
 	u32 mem = memRead32( addr & ~3 );
 
 	memWrite32( addr & ~3,
-		(cpuRegs.GPR.r[_Rt_].UL[0] >> SWL_SHIFT[shift]) |
+		(cpuRegs.GPR[_Rt_].UL[0] >> SWL_SHIFT[shift]) |
 		(mem & SWL_MASK[shift])
 	);
 
@@ -767,12 +767,12 @@ void SWL()
 }
 
 void SWR() {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 3;
 	u32 mem = memRead32(addr & ~3);
 
 	memWrite32( addr & ~3,
-		(cpuRegs.GPR.r[_Rt_].UL[0] << SWR_SHIFT[shift]) |
+		(cpuRegs.GPR[_Rt_].UL[0] << SWR_SHIFT[shift]) |
 		(mem & SWR_MASK[shift])
 	);
 
@@ -788,12 +788,12 @@ void SWR() {
 
 void SD()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 
 	if( addr & 7 )
 		throw R5900Exception::AddressError( addr, true );
 
-    memWrite64(addr,&cpuRegs.GPR.r[_Rt_].UD[0]);
+    memWrite64(addr,&cpuRegs.GPR[_Rt_].UD[0]);
 }
 
 static const u64 SDL_MASK[8] =
@@ -810,12 +810,12 @@ static const u8 SDR_SHIFT[8] = { 0, 8, 16, 24, 32, 40, 48, 56 };
 
 void SDL()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 7;
 	u64 mem;
 
 	memRead64(addr & ~7, &mem);
-	mem = (cpuRegs.GPR.r[_Rt_].UD[0] >> SDL_SHIFT[shift]) |
+	mem = (cpuRegs.GPR[_Rt_].UD[0] >> SDL_SHIFT[shift]) |
 		  (mem & SDL_MASK[shift]);
 	memWrite64(addr & ~7, &mem);
 }
@@ -823,12 +823,12 @@ void SDL()
 
 void SDR()
 {
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
 	u32 shift = addr & 7;
 	u64 mem;
 
 	memRead64(addr & ~7, &mem);
-	mem = (cpuRegs.GPR.r[_Rt_].UD[0] << SDR_SHIFT[shift]) |
+	mem = (cpuRegs.GPR[_Rt_].UD[0] << SDR_SHIFT[shift]) |
 		  (mem & SDR_MASK[shift]);
 	memWrite64(addr & ~7, &mem );
 }
@@ -838,8 +838,8 @@ void SQ()
 	// MIPS Note: LQ and SQ are special and "silently" align memory addresses, thus
 	// an address error due to unaligned access isn't possible like it is on other loads/stores.
 
-	u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
-	memWrite128(addr & ~0xf, cpuRegs.GPR.r[_Rt_].UQ);
+	u32 addr = cpuRegs.GPR[_Rs_].UL[0] + _Imm_;
+	memWrite128(addr & ~0xf, cpuRegs.GPR[_Rt_].UQ);
 }
 
 /*********************************************************
@@ -849,14 +849,14 @@ void SQ()
 
 void MOVZ() {
 	if (!_Rd_) return;
-	if (cpuRegs.GPR.r[_Rt_].UD[0] == 0) {
-		cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0];
+	if (cpuRegs.GPR[_Rt_].UD[0] == 0) {
+		cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0];
 	}
 }
 void MOVN() {
 	if (!_Rd_) return;
-	if (cpuRegs.GPR.r[_Rt_].UD[0] != 0) {
-		cpuRegs.GPR.r[_Rd_].UD[0] = cpuRegs.GPR.r[_Rs_].UD[0];
+	if (cpuRegs.GPR[_Rt_].UD[0] != 0) {
+		cpuRegs.GPR[_Rd_].UD[0] = cpuRegs.GPR[_Rs_].UD[0];
 	}
 }
 
@@ -873,24 +873,24 @@ void SYSCALL()
 {
 	u8 call;
 
-	if (cpuRegs.GPR.n.v1.SL[0] < 0)
-		call = (u8)(-cpuRegs.GPR.n.v1.SL[0]);
+	if (cpuRegs.v1.SL[0] < 0)
+		call = (u8)(-cpuRegs.v1.SL[0]);
 	else
-		call = cpuRegs.GPR.n.v1.UC[0];
+		call = cpuRegs.v1.UC[0];
 
 	BIOS_LOG("Bios call: %s (%x)", R5900::bios[call], call);
 	if (call == 13) {
-		DevCon.Warning("A tlb refill handler is set. New handler %x", (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
+		DevCon.Warning("A tlb refill handler is set. New handler %x", (u32*)PSM(cpuRegs.a1.UL[0]));
 	}
 
 	if (call == 0x7c)
 	{
-		if(cpuRegs.GPR.n.a0.UL[0] == 0x10)
+		if(cpuRegs.a0.UL[0] == 0x10)
 		{
-			eeConLog( ShiftJIS_ConvertString((char*)PSM(memRead32(cpuRegs.GPR.n.a1.UL[0]))) );
+			eeConLog( ShiftJIS_ConvertString((char*)PSM(memRead32(cpuRegs.a1.UL[0]))) );
 		}
 		else
-			__Deci2Call( cpuRegs.GPR.n.a0.UL[0], (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]) );
+			__Deci2Call( cpuRegs.a0.UL[0], (u32*)PSM(cpuRegs.a1.UL[0]) );
 	}
 
 	// The only thing this code is used for is the one log message, so don't execute it if we aren't logging bios messages.
@@ -904,14 +904,14 @@ void SYSCALL()
 		u32 addr;
 		//int sid;
 
-		n_transfer = cpuRegs.GPR.n.a1.UL[0] - 1;
+		n_transfer = cpuRegs.a1.UL[0] - 1;
 		if (n_transfer >= 0)
 		{
-			addr = cpuRegs.GPR.n.a0.UL[0] + n_transfer * sizeof(t_sif_dma_transfer);
+			addr = cpuRegs.a0.UL[0] + n_transfer * sizeof(t_sif_dma_transfer);
 			dmat = (t_sif_dma_transfer*)PSM(addr);
 
 			BIOS_LOG("bios_%s: n_transfer=%d, size=%x, attr=%x, dest=%x, src=%x",
-				R5900::bios[cpuRegs.GPR.n.v1.UC[0]], n_transfer,
+				R5900::bios[cpuRegs.v1.UC[0]], n_transfer,
 				dmat->size, dmat->attr,
 				dmat->dest, dmat->src);
 		}
@@ -928,11 +928,11 @@ void BREAK() {
 
 void MFSA() {
 	if (!_Rd_) return;
-	cpuRegs.GPR.r[_Rd_].SD[0] = (s64)cpuRegs.sa;
+	cpuRegs.GPR[_Rd_].SD[0] = (s64)cpuRegs.sa;
 }
 
 void MTSA() {
-	cpuRegs.sa = (s32)cpuRegs.GPR.r[_Rs_].SD[0] & 0xf;
+	cpuRegs.sa = (s32)cpuRegs.GPR[_Rs_].SD[0] & 0xf;
 }
 
 // SNY supports three basic modes, two which synchronize memory accesses (related
@@ -964,23 +964,23 @@ static void trap(u16 code=0)
 * Register trap                                          *
 * Format:  OP rs, rt                                     *
 *********************************************************/
-void TGE()  { if (cpuRegs.GPR.r[_Rs_].SD[0] >= cpuRegs.GPR.r[_Rt_].SD[0]) trap(_TrapCode_); }
-void TGEU() { if (cpuRegs.GPR.r[_Rs_].UD[0] >= cpuRegs.GPR.r[_Rt_].UD[0]) trap(_TrapCode_); }
-void TLT()  { if (cpuRegs.GPR.r[_Rs_].SD[0] <  cpuRegs.GPR.r[_Rt_].SD[0]) trap(_TrapCode_); }
-void TLTU() { if (cpuRegs.GPR.r[_Rs_].UD[0] <  cpuRegs.GPR.r[_Rt_].UD[0]) trap(_TrapCode_); }
-void TEQ()  { if (cpuRegs.GPR.r[_Rs_].SD[0] == cpuRegs.GPR.r[_Rt_].SD[0]) trap(_TrapCode_); }
-void TNE()  { if (cpuRegs.GPR.r[_Rs_].SD[0] != cpuRegs.GPR.r[_Rt_].SD[0]) trap(_TrapCode_); }
+void TGE()  { if (cpuRegs.GPR[_Rs_].SD[0] >= cpuRegs.GPR[_Rt_].SD[0]) trap(_TrapCode_); }
+void TGEU() { if (cpuRegs.GPR[_Rs_].UD[0] >= cpuRegs.GPR[_Rt_].UD[0]) trap(_TrapCode_); }
+void TLT()  { if (cpuRegs.GPR[_Rs_].SD[0] <  cpuRegs.GPR[_Rt_].SD[0]) trap(_TrapCode_); }
+void TLTU() { if (cpuRegs.GPR[_Rs_].UD[0] <  cpuRegs.GPR[_Rt_].UD[0]) trap(_TrapCode_); }
+void TEQ()  { if (cpuRegs.GPR[_Rs_].SD[0] == cpuRegs.GPR[_Rt_].SD[0]) trap(_TrapCode_); }
+void TNE()  { if (cpuRegs.GPR[_Rs_].SD[0] != cpuRegs.GPR[_Rt_].SD[0]) trap(_TrapCode_); }
 
 /*********************************************************
 * Trap with immediate operand                            *
 * Format:  OP rs, rt                                     *
 *********************************************************/
-void TGEI()  { if (cpuRegs.GPR.r[_Rs_].SD[0] >= _Imm_) trap(); }
-void TLTI()  { if (cpuRegs.GPR.r[_Rs_].SD[0] <  _Imm_) trap(); }
-void TEQI()  { if (cpuRegs.GPR.r[_Rs_].SD[0] == _Imm_) trap(); }
-void TNEI()  { if (cpuRegs.GPR.r[_Rs_].SD[0] != _Imm_) trap(); }
-void TGEIU() { if (cpuRegs.GPR.r[_Rs_].UD[0] >= (u64)_Imm_) trap(); }
-void TLTIU() { if (cpuRegs.GPR.r[_Rs_].UD[0] <  (u64)_Imm_) trap(); }
+void TGEI()  { if (cpuRegs.GPR[_Rs_].SD[0] >= _Imm_) trap(); }
+void TLTI()  { if (cpuRegs.GPR[_Rs_].SD[0] <  _Imm_) trap(); }
+void TEQI()  { if (cpuRegs.GPR[_Rs_].SD[0] == _Imm_) trap(); }
+void TNEI()  { if (cpuRegs.GPR[_Rs_].SD[0] != _Imm_) trap(); }
+void TGEIU() { if (cpuRegs.GPR[_Rs_].UD[0] >= (u64)_Imm_) trap(); }
+void TLTIU() { if (cpuRegs.GPR[_Rs_].UD[0] <  (u64)_Imm_) trap(); }
 
 /*********************************************************
 * Sa intructions                                         *
@@ -988,11 +988,11 @@ void TLTIU() { if (cpuRegs.GPR.r[_Rs_].UD[0] <  (u64)_Imm_) trap(); }
 *********************************************************/
 
 void MTSAB() {
- 	cpuRegs.sa = ((cpuRegs.GPR.r[_Rs_].UL[0] & 0xF) ^ (_Imm_ & 0xF));
+ 	cpuRegs.sa = ((cpuRegs.GPR[_Rs_].UL[0] & 0xF) ^ (_Imm_ & 0xF));
 }
 
 void MTSAH() {
-    cpuRegs.sa = ((cpuRegs.GPR.r[_Rs_].UL[0] & 0x7) ^ (_Imm_ & 0x7)) << 1;
+    cpuRegs.sa = ((cpuRegs.GPR[_Rs_].UL[0] & 0x7) ^ (_Imm_ & 0x7)) << 1;
 }
 
 } }	} // end namespace R5900::Interpreter::OpcodeImpl

--- a/pcsx2/RDebug/deci2_dbgp.cpp
+++ b/pcsx2/RDebug/deci2_dbgp.cpp
@@ -134,24 +134,24 @@ void D2_DBGP(const u8 *inbuffer, u8 *outbuffer, char *message, char *eepc, char 
 				for (i=0; i<in->count; i++)
 					switch (iregs[i].kind){
 					case 1:switch (iregs[i].number){
-							case 0:iregs[i].value=psxRegs.GPR.n.lo;break;
-							case 1:iregs[i].value=psxRegs.GPR.n.hi;break;
+							case 0:iregs[i].value=psxRegs.lo;break;
+							case 1:iregs[i].value=psxRegs.hi;break;
 						   }
 						   break;
-					case 2:iregs[i].value=psxRegs.GPR.r[iregs[i].number]; break;
+					case 2:iregs[i].value=psxRegs.GPR[iregs[i].number]; break;
 					case 3:
-						if (iregs[i].number==14) psxRegs.CP0.n.EPC=psxRegs.pc;
-						iregs[i].value=psxRegs.CP0.r[iregs[i].number];
+						if (iregs[i].number==14) psxRegs.EPC=psxRegs.pc;
+						iregs[i].value=psxRegs.CP0[iregs[i].number];
 						break;
-					case 6:iregs[i].value=psxRegs.CP2D.r[iregs[i].number]; break;
-					case 7:iregs[i].value=psxRegs.CP2C.r[iregs[i].number]; break;
+					case 6:iregs[i].value=psxRegs.CP2D[iregs[i].number]; break;
+					case 7:iregs[i].value=psxRegs.CP2C[iregs[i].number]; break;
 					default:
 						iregs[0].value++;//dummy; might be assert(0)
 					}
 			}else
 				for (i=0; i<in->count; i++)
 					switch (eregs[i].kind){
-					case  0:memcpy(eregs[i].value, &cpuRegs.GPR.r[eregs[i].number], 16);break;
+					case  0:memcpy(eregs[i].value, &cpuRegs.GPR[eregs[i].number], 16);break;
 					case  1:
 						switch(eregs[i].number){
 						case 0:memcpy(eregs[i].value, &cpuRegs.HI.UD[0], 8);break;
@@ -161,8 +161,8 @@ void D2_DBGP(const u8 *inbuffer, u8 *outbuffer, char *message, char *eepc, char 
 						case 4:memcpy(eregs[i].value, &cpuRegs.sa, 4);		break;
 						}
 					case  2:
-						if (eregs[i].number==14) cpuRegs.CP0.n.EPC=cpuRegs.pc;
-						memcpy(eregs[i].value, &cpuRegs.CP0.r[eregs[i].number], 4);
+						if (eregs[i].number==14) cpuRegs.EPC=cpuRegs.pc;
+						memcpy(eregs[i].value, &cpuRegs.CP0[eregs[i].number], 4);
 						break;
 					case  3:break;//performance counter 32x3
 					case  4:break;//hw debug reg 32x8
@@ -183,24 +183,24 @@ void D2_DBGP(const u8 *inbuffer, u8 *outbuffer, char *message, char *eepc, char 
 				for (i=0; i<in->count; i++)
 					switch (iregs[i].kind){
 					case 1:switch (iregs[i].number){
-							case 0:psxRegs.GPR.n.lo=iregs[i].value;break;
-							case 1:psxRegs.GPR.n.hi=iregs[i].value;break;
+							case 0:psxRegs.lo=iregs[i].value;break;
+							case 1:psxRegs.hi=iregs[i].value;break;
 						   }
 						   break;
-					case 2:psxRegs.GPR.r[iregs[i].number]=iregs[i].value; break;
+					case 2:psxRegs.GPR[iregs[i].number]=iregs[i].value; break;
 					case 3:
-						psxRegs.CP0.r[iregs[i].number]=iregs[i].value;
-						if (iregs[i].number==14) psxRegs.pc=psxRegs.CP0.n.EPC;
+						psxRegs.CP0[iregs[i].number]=iregs[i].value;
+						if (iregs[i].number==14) psxRegs.pc=psxRegs.EPC;
 						break;
-					case 6:psxRegs.CP2D.r[iregs[i].number]=iregs[i].value; break;
-					case 7:psxRegs.CP2C.r[iregs[i].number]=iregs[i].value; break;
+					case 6:psxRegs.CP2D[iregs[i].number]=iregs[i].value; break;
+					case 7:psxRegs.CP2C[iregs[i].number]=iregs[i].value; break;
 					default:
 						;//dummy; might be assert(0)
 					}
 			}else
 				for (i=0; i<in->count; i++)
 					switch (eregs[i].kind){
-					case  0:memcpy(&cpuRegs.GPR.r[eregs[i].number], eregs[i].value, 16);break;
+					case  0:memcpy(&cpuRegs.GPR[eregs[i].number], eregs[i].value, 16);break;
 					case  1:
 						switch(eregs[i].number){
 						case 0:memcpy(&cpuRegs.HI.UD[0], eregs[i].value, 8);break;
@@ -211,8 +211,8 @@ void D2_DBGP(const u8 *inbuffer, u8 *outbuffer, char *message, char *eepc, char 
 						}
 						break;
 					case  2:
-						memcpy(&cpuRegs.CP0.r[eregs[i].number], eregs[i].value, 4);
-						if (eregs[i].number==14) cpuRegs.pc=cpuRegs.CP0.n.EPC;
+						memcpy(&cpuRegs.CP0[eregs[i].number], eregs[i].value, 4);
+						if (eregs[i].number==14) cpuRegs.pc=cpuRegs.EPC;
 						break;
 					case  3:break;//performance counter 32x3
 					case  4:break;//hw debug reg 32x8
@@ -383,8 +383,8 @@ void D2_DBGP(const u8 *inbuffer, u8 *outbuffer, char *message, char *eepc, char 
 			sprintf(line, "%s/RUN code=%d count=%d entry=0x%08X gp=0x%08X argc=%d",
 				in->id==0?"CPU":in->id==1?"VU0":"VU1", in->code, in->count,
 				run->entry, run->gp, run->argc);
-			cpuRegs.CP0.n.EPC=cpuRegs.pc=run->entry;
-			cpuRegs.GPR.n.gp.UL[0]=run->gp;
+			cpuRegs.EPC=cpuRegs.pc=run->entry;
+			cpuRegs.gp.UL[0]=run->gp;
 //			threads_array[0].argc = run->argc;
 			u32* argv = (u32*)&run[1];
 			for (i=0, s=0; i<(int)run->argc; i++, argv++)	s+=argv[i];

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -41,7 +41,7 @@ static void PreLoadPrep()
 static void PostLoadPrep()
 {
 	memzero(pCache);
-//	WriteCP0Status(cpuRegs.CP0.n.Status.val);
+//	WriteCP0Status(cpuRegs.Status.val);
 	for(int i=0; i<48; i++) MapTLB(i);
 	if (EmuConfig.Gamefixes.GoemonTlbHack) GoemonPreloadTlb();
 

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -85,7 +85,7 @@ namespace Interpreter{
 namespace OpcodeImpl
 {
 	void LQC2() {
-		u32 addr = cpuRegs.GPR.r[_Rs_].UL[0] + (s16)cpuRegs.code;
+		u32 addr = cpuRegs.GPR[_Rs_].UL[0] + (s16)cpuRegs.code;
 		if (_Ft_) {
 			memRead128(addr, VU0.VF[_Ft_].UQ);
 		} else {
@@ -98,7 +98,7 @@ namespace OpcodeImpl
 	//TODO: check this
 	// HUH why ? doesn't make any sense ...
 	void SQC2() {
-		u32 addr = _Imm_ + cpuRegs.GPR.r[_Rs_].UL[0];
+		u32 addr = _Imm_ + cpuRegs.GPR[_Rs_].UL[0];
 		memWrite128(addr, VU0.VF[_Ft_].UQ);
 	}
 }}}
@@ -109,8 +109,8 @@ void QMFC2() {
 		_vu0WaitMicro();
 	}
 	if (_Rt_ == 0) return;
-	cpuRegs.GPR.r[_Rt_].UD[0] = VU0.VF[_Fs_].UD[0];
-	cpuRegs.GPR.r[_Rt_].UD[1] = VU0.VF[_Fs_].UD[1];
+	cpuRegs.GPR[_Rt_].UD[0] = VU0.VF[_Fs_].UD[0];
+	cpuRegs.GPR[_Rt_].UD[1] = VU0.VF[_Fs_].UD[1];
 }
 
 void QMTC2() {
@@ -118,8 +118,8 @@ void QMTC2() {
 		_vu0WaitMicro();
 	}
 	if (_Fs_ == 0) return;
-	VU0.VF[_Fs_].UD[0] = cpuRegs.GPR.r[_Rt_].UD[0];
-	VU0.VF[_Fs_].UD[1] = cpuRegs.GPR.r[_Rt_].UD[1];
+	VU0.VF[_Fs_].UD[0] = cpuRegs.GPR[_Rt_].UD[0];
+	VU0.VF[_Fs_].UD[1] = cpuRegs.GPR[_Rt_].UD[1];
 }
 
 void CFC2() {
@@ -127,11 +127,11 @@ void CFC2() {
 		_vu0WaitMicro();
 	}
 	if (_Rt_ == 0) return;
-	cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[_Fs_].UL;
+	cpuRegs.GPR[_Rt_].UL[0] = VU0.VI[_Fs_].UL;
 	if(VU0.VI[_Fs_].UL & 0x80000000)
-		cpuRegs.GPR.r[_Rt_].UL[1] = 0xffffffff;
+		cpuRegs.GPR[_Rt_].UL[1] = 0xffffffff;
 	else
-		cpuRegs.GPR.r[_Rt_].UL[1] = 0;
+		cpuRegs.GPR[_Rt_].UL[1] = 0;
 }
 
 void CTC2() {
@@ -146,30 +146,30 @@ void CTC2() {
 		case REG_VPU_STAT: // read-only
 			break;
 		case REG_FBRST:
-			VU0.VI[REG_FBRST].UL = cpuRegs.GPR.r[_Rt_].UL[0] & 0x0C0C;
-			if (cpuRegs.GPR.r[_Rt_].UL[0] & 0x1) { // VU0 Force Break
+			VU0.VI[REG_FBRST].UL = cpuRegs.GPR[_Rt_].UL[0] & 0x0C0C;
+			if (cpuRegs.GPR[_Rt_].UL[0] & 0x1) { // VU0 Force Break
 				Console.Error("fixme: VU0 Force Break");
 			}
-			if (cpuRegs.GPR.r[_Rt_].UL[0] & 0x2) { // VU0 Reset
+			if (cpuRegs.GPR[_Rt_].UL[0] & 0x2) { // VU0 Reset
 				//Console.WriteLn("fixme: VU0 Reset");
 				vu0ResetRegs();
 			}
-			if (cpuRegs.GPR.r[_Rt_].UL[0] & 0x100) { // VU1 Force Break
+			if (cpuRegs.GPR[_Rt_].UL[0] & 0x100) { // VU1 Force Break
 				Console.Error("fixme: VU1 Force Break");
 			}
-			if (cpuRegs.GPR.r[_Rt_].UL[0] & 0x200) { // VU1 Reset
+			if (cpuRegs.GPR[_Rt_].UL[0] & 0x200) { // VU1 Reset
 //				Console.WriteLn("fixme: VU1 Reset");
 				vu1ResetRegs();
 			}
 			break;
 		case REG_CMSAR1: // REG_CMSAR1
 			if (!(VU0.VI[REG_VPU_STAT].UL & 0x100) ) {
-				vu1ExecMicro(cpuRegs.GPR.r[_Rt_].US[0]);	// Execute VU1 Micro SubRoutine
+				vu1ExecMicro(cpuRegs.GPR[_Rt_].US[0]);	// Execute VU1 Micro SubRoutine
 				vif1VUFinish();
 			}
 			break;
 		default:
-			VU0.VI[_Fs_].UL = cpuRegs.GPR.r[_Rt_].UL[0];
+			VU0.VI[_Fs_].UL = cpuRegs.GPR[_Rt_].UL[0];
 			break;
 	}
 }

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -60,9 +60,9 @@ __inline int CheckCache(u32 addr)
 {
 	u32 mask;
 
-	if(((cpuRegs.CP0.n.Config >> 16) & 0x1) == 0) 
+	if(((cpuRegs.Config >> 16) & 0x1) == 0) 
 	{
-		//DevCon.Warning("Data Cache Disabled! %x", cpuRegs.CP0.n.Config);
+		//DevCon.Warning("Data Cache Disabled! %x", cpuRegs.Config);
 		return false;//
 	}
 

--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -114,14 +114,14 @@ void recDI()
 
 	//CALLFunc( (uptr)Interp::DI );
 
-	xMOV(eax, ptr[&cpuRegs.CP0.n.Status]);
+	xMOV(eax, ptr[&cpuRegs.Status]);
 	xTEST(eax, 0x20006); // EXL | ERL | EDI
 	xForwardJNZ8 iHaveNoIdea;
 	xTEST(eax, 0x18); // KSU
 	xForwardJNZ8 inUserMode;
 	iHaveNoIdea.SetTarget();
 	xAND(eax, ~(u32)0x10000); // EIE
-	xMOV(ptr[&cpuRegs.CP0.n.Status], eax);
+	xMOV(ptr[&cpuRegs.Status], eax);
 	inUserMode.SetTarget();
 }
 
@@ -144,17 +144,17 @@ void recMFC0()
 		u8* skipInc = JNZ8( 0 );
 		INC32R(EAX);
 		x86SetJ8( skipInc );
-        ADD32RtoM((uptr)&cpuRegs.CP0.n.Count, EAX);
+        ADD32RtoM((uptr)&cpuRegs.Count, EAX);
 		MOV32RtoM((uptr)&s_iLastCOP0Cycle, ECX);
-        MOV32MtoR( EAX, (uptr)&cpuRegs.CP0.r[ _Rd_ ] );
+        MOV32MtoR( EAX, (uptr)&cpuRegs.CP0[ _Rd_ ] );
 
 		if( !_Rt_ ) return;
 
 		_deleteEEreg(_Rt_, 0);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[0],EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[0],EAX);
 
 		CDQ();
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[1], EDX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[1], EDX);
 		return;
 	}
 
@@ -180,10 +180,10 @@ void recMFC0()
 			break;
 		}
 		_deleteEEreg(_Rt_, 0);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[0],EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[0],EAX);
 
 		CDQ();
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[1], EDX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[1], EDX);
 
 		return;
 	}
@@ -193,10 +193,10 @@ void recMFC0()
 	}
 	_eeOnWriteReg(_Rt_, 1);
 	_deleteEEreg(_Rt_, 0);
-	MOV32MtoR(EAX, (uptr)&cpuRegs.CP0.r[ _Rd_ ]);
+	MOV32MtoR(EAX, (uptr)&cpuRegs.CP0[ _Rd_ ]);
 	CDQ();
-	MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[0], EAX);
-	MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[1], EDX);
+	MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[0], EAX);
+	MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[1], EDX);
 }
 
 void recMTC0()
@@ -214,7 +214,7 @@ void recMTC0()
 			case 9:
 				MOV32MtoR(ECX, (uptr)&cpuRegs.cycle);
 				MOV32RtoM((uptr)&s_iLastCOP0Cycle, ECX);
-				MOV32ItoM((uptr)&cpuRegs.CP0.r[9], g_cpuConstRegs[_Rt_].UL[0]);
+				MOV32ItoM((uptr)&cpuRegs.CP0[9], g_cpuConstRegs[_Rt_].UL[0]);
 			break;
 
 			case 25:
@@ -246,7 +246,7 @@ void recMTC0()
 			break;
 
 			default:
-				MOV32ItoM((uptr)&cpuRegs.CP0.r[_Rd_], g_cpuConstRegs[_Rt_].UL[0]);
+				MOV32ItoM((uptr)&cpuRegs.CP0[_Rd_], g_cpuConstRegs[_Rt_].UL[0]);
 			break;
 		}
 	}
@@ -262,7 +262,7 @@ void recMTC0()
 
 			case 9:
 				MOV32MtoR(ECX, (uptr)&cpuRegs.cycle);
-				_eeMoveGPRtoM((uptr)&cpuRegs.CP0.r[9], _Rt_);
+				_eeMoveGPRtoM((uptr)&cpuRegs.CP0[9], _Rt_);
 				MOV32RtoM((uptr)&s_iLastCOP0Cycle, ECX);
 			break;
 
@@ -295,7 +295,7 @@ void recMTC0()
 			break;
 
 			default:
-				_eeMoveGPRtoM((uptr)&cpuRegs.CP0.r[_Rd_], _Rt_);
+				_eeMoveGPRtoM((uptr)&cpuRegs.CP0[_Rd_], _Rt_);
 			break;
 		}
 	}

--- a/pcsx2/x86/iCore.cpp
+++ b/pcsx2/x86/iCore.cpp
@@ -63,7 +63,7 @@ __fi void* _XMMGetAddr(int type, int reg, VURegs *VU)
 		case XMMTYPE_GPRREG:
 			if( reg < 32 )
 				pxAssert( !(g_cpuHasConstReg & (1<<reg)) || (g_cpuFlushedConstReg & (1<<reg)) );
-			return &cpuRegs.GPR.r[reg].UL[0];
+			return &cpuRegs.GPR[reg].UL[0];
 
 		case XMMTYPE_FPREG:
 			return &fpuRegs.fpr[reg];
@@ -353,7 +353,7 @@ int _allocGPRtoXMMreg(int xmmreg, int gprreg, int mode)
 			{
 				//pxAssert( !(g_cpuHasConstReg & (1<<gprreg)) || (g_cpuFlushedConstReg & (1<<gprreg)) );
 				_flushConstReg(gprreg);
-				SSEX_MOVDQA_M128_to_XMM(i, (uptr)&cpuRegs.GPR.r[gprreg].UL[0]);
+				SSEX_MOVDQA_M128_to_XMM(i, (uptr)&cpuRegs.GPR[gprreg].UL[0]);
 			}
 			xmmregs[i].mode |= MODE_READ;
 		}
@@ -409,7 +409,7 @@ int _allocGPRtoXMMreg(int xmmreg, int gprreg, int mode)
 				SetMMXstate();
 				SSE2_MOVQ2DQ_MM_to_XMM(xmmreg, mmxreg);
 				SSE2_PUNPCKLQDQ_XMM_to_XMM(xmmreg, xmmreg);
-				SSE2_PUNPCKHQDQ_M128_to_XMM(xmmreg, (uptr)&cpuRegs.GPR.r[gprreg].UL[0]);
+				SSE2_PUNPCKHQDQ_M128_to_XMM(xmmreg, (uptr)&cpuRegs.GPR[gprreg].UL[0]);
 
 				if (mmxregs[mmxreg].mode & MODE_WRITE )
 				{
@@ -417,7 +417,7 @@ int _allocGPRtoXMMreg(int xmmreg, int gprreg, int mode)
 					if  (!(mode & MODE_WRITE))
 					{
 						SetMMXstate();
-						MOVQRtoM((uptr)&cpuRegs.GPR.r[gprreg].UL[0], mmxreg);
+						MOVQRtoM((uptr)&cpuRegs.GPR[gprreg].UL[0], mmxreg);
 					}
 					//xmmregs[xmmreg].mode |= MODE_WRITE;
 				}
@@ -426,7 +426,7 @@ int _allocGPRtoXMMreg(int xmmreg, int gprreg, int mode)
 				mmxregs[mmxreg].inuse = 0;
 			}
 			else
-				SSEX_MOVDQA_M128_to_XMM(xmmreg, (uptr)&cpuRegs.GPR.r[gprreg].UL[0]);
+				SSEX_MOVDQA_M128_to_XMM(xmmreg, (uptr)&cpuRegs.GPR[gprreg].UL[0]);
 		}
 	}
 	else
@@ -711,7 +711,7 @@ void _deleteGPRtoXMMreg(int reg, int flush)
 						pxAssert( reg != 0 );
 
 						//pxAssert( g_xmmtypes[i] == XMMT_INT );
-						SSEX_MOVDQA_XMM_to_M128((uptr)&cpuRegs.GPR.r[reg].UL[0], i);
+						SSEX_MOVDQA_XMM_to_M128((uptr)&cpuRegs.GPR[reg].UL[0], i);
 
 						// get rid of MODE_WRITE since don't want to flush again
 						xmmregs[i].mode &= ~MODE_WRITE;
@@ -849,7 +849,7 @@ void _freeXMMreg(u32 xmmreg)
 		case XMMTYPE_GPRREG:
 			pxAssert( xmmregs[xmmreg].reg != 0 );
 			//pxAssert( g_xmmtypes[xmmreg] == XMMT_INT );
-			SSEX_MOVDQA_XMM_to_M128((uptr)&cpuRegs.GPR.r[xmmregs[xmmreg].reg].UL[0], xmmreg);
+			SSEX_MOVDQA_XMM_to_M128((uptr)&cpuRegs.GPR[xmmregs[xmmreg].reg].UL[0], xmmreg);
 			break;
 
 		case XMMTYPE_FPREG:

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -122,8 +122,8 @@ void recCFC1(void)
 	}
 
 	CDQ( );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], EDX );
 }
 
 void recCTC1()
@@ -157,7 +157,7 @@ void recCTC1()
 				_deleteGPRtoXMMreg(_Rt_, 1);
 				_deleteMMXreg(MMX_GPR+_Rt_, 1);
 
-				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 				MOV32RtoM( (uptr)&fpuRegs.fprc[ _Fs_ ], EAX );
 			}
 		}
@@ -191,7 +191,7 @@ void recMFC1()
 		}
 		else
 		{
-			_signExtendXMMtoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], regs, 0);
+			_signExtendXMMtoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], regs, 0);
 		}
 	}
 	else
@@ -213,7 +213,7 @@ void recMFC1()
 			{
 				if( xmmregs[regt].mode & MODE_WRITE )
 				{
-					SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[_Rt_].UL[2], regt);
+					SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[_Rt_].UL[2], regt);
 				}
 				xmmregs[regt].inuse = 0;
 			}
@@ -222,8 +222,8 @@ void recMFC1()
 			MOV32MtoR( EAX, (uptr)&fpuRegs.fpr[ _Fs_ ].UL );
 
 			CDQ( );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], EDX );
 		}
 	}
 }
@@ -288,11 +288,11 @@ void recMTC1()
 			{
 				if( mmreg2 >= 0 )
 				{
-					SSE_MOVSS_M32_to_XMM(mmreg2, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ]);
+					SSE_MOVSS_M32_to_XMM(mmreg2, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ]);
 				}
 				else
 				{
-					MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ]);
+					MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ]);
 					MOV32RtoM((uptr)&fpuRegs.fpr[ _Fs_ ].UL, EAX);
 				}
 			}

--- a/pcsx2/x86/iMMI.cpp
+++ b/pcsx2/x86/iMMI.cpp
@@ -98,7 +98,7 @@ void recPLZCW()
 		regs |= MEM_MMXTAG;
 	}
 	else {
-		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
+		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
 		regs = 0;
 	}
 
@@ -126,7 +126,7 @@ void recPLZCW()
 	DEC32R(ECX);			// PS2 doesn't count the first bit
 
 	x86SetJ8(label_Zeroed);
-	MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], ECX);
+	MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], ECX);
 
 	// second word
 
@@ -141,7 +141,7 @@ void recPLZCW()
 		PSHUFWRtoR(regs&0xf, regs&0xf, 0x4e);
 		SetMMXstate();
 	}
-	else MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
+	else MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
 
 	MOV32ItoR(ECX, 31);
 	TEST32RtoR(EAX, EAX);		// TEST sets the sign flag accordingly.
@@ -155,7 +155,7 @@ void recPLZCW()
 	DEC32R(ECX);			// PS2 doesn't count the first bit
 
 	x86SetJ8(label_Zeroed);
-	MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], ECX);
+	MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], ECX);
 
 	GPR_DEL_CONST(_Rd_);
 }
@@ -1477,7 +1477,7 @@ void recQFSRV()
 		int info = eeRecompileCodeXMM(XMMINFO_WRITED);
 
 		xMOV(eax, ptr32[&cpuRegs.sa]);
-		xMOVDQU(xRegisterSSE(EEREC_D), ptr32[eax + &cpuRegs.GPR.r[_Rt_]]);
+		xMOVDQU(xRegisterSSE(EEREC_D), ptr32[eax + &cpuRegs.GPR[_Rt_]]);
 		return;
 	}
 		

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -485,7 +485,7 @@ int _psxFlushUnusedConstReg()
 			!_recIsRegWritten(g_pCurInstInfo+1, (s_nEndBlock-psxpc)/4, XMMTYPE_GPRREG, i) ) {
 
 			// check if will be written in the future
-			MOV32ItoM((uptr)&psxRegs.GPR.r[i], g_psxConstRegs[i]);
+			MOV32ItoM((uptr)&psxRegs.GPR[i], g_psxConstRegs[i]);
 			g_psxFlushedConstReg |= 1<<i;
 			return 1;
 		}
@@ -502,7 +502,7 @@ void _psxFlushCachedRegs()
 void _psxFlushConstReg(int reg)
 {
 	if( PSX_IS_CONST1( reg ) && !(g_psxFlushedConstReg&(1<<reg)) ) {
-		MOV32ItoM((uptr)&psxRegs.GPR.r[reg], g_psxConstRegs[reg]);
+		MOV32ItoM((uptr)&psxRegs.GPR[reg], g_psxConstRegs[reg]);
 		g_psxFlushedConstReg |= (1<<reg);
 	}
 }
@@ -518,7 +518,7 @@ void _psxFlushConstRegs()
 		if( g_psxHasConstReg & (1<<i) ) {
 
 			if( !(g_psxFlushedConstReg&(1<<i)) ) {
-				MOV32ItoM((uptr)&psxRegs.GPR.r[i], g_psxConstRegs[i]);
+				MOV32ItoM((uptr)&psxRegs.GPR[i], g_psxConstRegs[i]);
 				g_psxFlushedConstReg |= 1<<i;
 			}
 
@@ -545,7 +545,7 @@ void _psxMoveGPRtoR(x86IntRegType to, int fromgpr)
 		MOV32ItoR( to, g_psxConstRegs[fromgpr] );
 	else {
 		// check x86
-		MOV32MtoR(to, (uptr)&psxRegs.GPR.r[ fromgpr ] );
+		MOV32MtoR(to, (uptr)&psxRegs.GPR[ fromgpr ] );
 	}
 }
 
@@ -555,7 +555,7 @@ void _psxMoveGPRtoM(u32 to, int fromgpr)
 		MOV32ItoM( to, g_psxConstRegs[fromgpr] );
 	else {
 		// check x86
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[ fromgpr ] );
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[ fromgpr ] );
 		MOV32RtoM(to, EAX );
 	}
 }
@@ -566,7 +566,7 @@ void _psxMoveGPRtoRm(x86IntRegType to, int fromgpr)
 		MOV32ItoRm( to, g_psxConstRegs[fromgpr] );
 	else {
 		// check x86
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[ fromgpr ] );
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[ fromgpr ] );
 		MOV32RtoRm(to, EAX );
 	}
 }

--- a/pcsx2/x86/iR3000Atables.cpp
+++ b/pcsx2/x86/iR3000Atables.cpp
@@ -53,15 +53,15 @@ void rpsxADDconst(int dreg, int sreg, u32 off, int info)
 {
 	if (sreg) {
 		if (sreg == dreg) {
-			ADD32ItoM((uptr)&psxRegs.GPR.r[dreg], off);
+			ADD32ItoM((uptr)&psxRegs.GPR[dreg], off);
 		} else {
-			MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(EAX, (uptr)&psxRegs.GPR[sreg]);
 			if (off) ADD32ItoR(EAX, off);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], EAX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], EAX);
 		}
 	}
 	else {
-		MOV32ItoM((uptr)&psxRegs.GPR.r[dreg], off);
+		MOV32ItoM((uptr)&psxRegs.GPR[dreg], off);
 	}
 }
 
@@ -85,9 +85,9 @@ void rpsxSLTI_const()
 void rpsxSLTconst(int info, int dreg, int sreg, int imm)
 {
 	XOR32RtoR(EAX, EAX);
-    CMP32ItoM((uptr)&psxRegs.GPR.r[sreg], imm);
+    CMP32ItoM((uptr)&psxRegs.GPR[sreg], imm);
     SETL8R(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[dreg], EAX);
 }
 
 void rpsxSLTI_(int info) { rpsxSLTconst(info, _Rt_, _Rs_, _Imm_); }
@@ -103,9 +103,9 @@ void rpsxSLTIU_const()
 void rpsxSLTUconst(int info, int dreg, int sreg, int imm)
 {
 	XOR32RtoR(EAX, EAX);
-	CMP32ItoM((uptr)&psxRegs.GPR.r[sreg], imm);
+	CMP32ItoM((uptr)&psxRegs.GPR[sreg], imm);
     SETB8R(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[dreg], EAX);
 }
 
 void rpsxSLTIU_(int info) { rpsxSLTUconst(info, _Rt_, _Rs_, (s32)_Imm_); }
@@ -122,14 +122,14 @@ void rpsxANDconst(int info, int dreg, int sreg, u32 imm)
 {
 	if (imm) {
 		if (sreg == dreg) {
-			AND32ItoM((uptr)&psxRegs.GPR.r[dreg], imm);
+			AND32ItoM((uptr)&psxRegs.GPR[dreg], imm);
 		} else {
-			MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(EAX, (uptr)&psxRegs.GPR[sreg]);
 			AND32ItoR(EAX, imm);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], EAX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], EAX);
 		}
 	} else {
-		MOV32ItoM((uptr)&psxRegs.GPR.r[dreg], 0);
+		MOV32ItoM((uptr)&psxRegs.GPR[dreg], 0);
 	}
 }
 
@@ -147,18 +147,18 @@ void rpsxORconst(int info, int dreg, int sreg, u32 imm)
 {
 	if (imm) {
 		if (sreg == dreg) {
-			OR32ItoM((uptr)&psxRegs.GPR.r[dreg], imm);
+			OR32ItoM((uptr)&psxRegs.GPR[dreg], imm);
 		}
 		else {
-			MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(EAX, (uptr)&psxRegs.GPR[sreg]);
 			OR32ItoR (EAX, imm);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], EAX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], EAX);
 		}
 	}
 	else {
 		if( dreg != sreg ) {
-			MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[sreg]);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], ECX);
+			MOV32MtoR(ECX, (uptr)&psxRegs.GPR[sreg]);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], ECX);
 		}
 	}
 }
@@ -176,29 +176,29 @@ void rpsxXORconst(int info, int dreg, int sreg, u32 imm)
 {
 	if( imm == 0xffffffff ) {
 		if( dreg == sreg ) {
-			NOT32M((uptr)&psxRegs.GPR.r[dreg]);
+			NOT32M((uptr)&psxRegs.GPR[dreg]);
 		}
 		else {
-			MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(ECX, (uptr)&psxRegs.GPR[sreg]);
 			NOT32R(ECX);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], ECX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], ECX);
 		}
 	}
 	else if (imm) {
 
 		if (sreg == dreg) {
-			XOR32ItoM((uptr)&psxRegs.GPR.r[dreg], imm);
+			XOR32ItoM((uptr)&psxRegs.GPR[dreg], imm);
 		}
 		else {
-			MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(EAX, (uptr)&psxRegs.GPR[sreg]);
 			XOR32ItoR(EAX, imm);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], EAX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], EAX);
 		}
 	}
 	else {
 		if( dreg != sreg ) {
-			MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[sreg]);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], ECX);
+			MOV32MtoR(ECX, (uptr)&psxRegs.GPR[sreg]);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], ECX);
 		}
 	}
 }
@@ -231,16 +231,16 @@ void rpsxADDU_constt(int info)
 void rpsxADDU_(int info)
 {
 	if (_Rs_ && _Rt_) {
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-		ADD32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+		ADD32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
 	} else if (_Rs_) {
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
 	} else if (_Rt_) {
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
 	} else {
 		XOR32RtoR(EAX, EAX);
 	}
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 PSXRECOMPILE_CONSTCODE0(ADDU);
@@ -256,8 +256,8 @@ void rpsxSUBU_const()
 void rpsxSUBU_consts(int info)
 {
 	MOV32ItoR(EAX, g_psxConstRegs[_Rs_]);
-	SUB32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	SUB32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 void rpsxSUBU_constt(int info) { rpsxADDconst(_Rd_, _Rs_, -(int)g_psxConstRegs[_Rt_], info); }
@@ -268,13 +268,13 @@ void rpsxSUBU_(int info)
 	if (!_Rd_) return;
 
 	if( _Rd_ == _Rs_ ) {
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-		SUB32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+		SUB32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 	}
 	else {
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-		SUB32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+		SUB32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 	}
 }
 
@@ -286,17 +286,17 @@ void rpsxLogicalOp(int info, int op)
 {
 	if( _Rd_ == _Rs_ || _Rd_ == _Rt_ ) {
 		int vreg = _Rd_ == _Rs_ ? _Rt_ : _Rs_;
-		MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[vreg]);
-		LogicalOp32RtoM((uptr)&psxRegs.GPR.r[_Rd_], ECX, op);
+		MOV32MtoR(ECX, (uptr)&psxRegs.GPR[vreg]);
+		LogicalOp32RtoM((uptr)&psxRegs.GPR[_Rd_], ECX, op);
 		if( op == 3 )
-			NOT32M((uptr)&psxRegs.GPR.r[_Rd_]);
+			NOT32M((uptr)&psxRegs.GPR[_Rd_]);
 	}
 	else {
-		MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
-		LogicalOp32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rt_], op);
+		MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
+		LogicalOp32MtoR(ECX, (uptr)&psxRegs.GPR[_Rt_], op);
 		if( op == 3 )
 			NOT32R(ECX);
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], ECX);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], ECX);
 	}
 }
 
@@ -344,24 +344,24 @@ void rpsxNORconst(int info, int dreg, int sreg, u32 imm)
 {
 	if( imm ) {
 		if( dreg == sreg ) {
-			OR32ItoM((uptr)&psxRegs.GPR.r[dreg], imm);
-			NOT32M((uptr)&psxRegs.GPR.r[dreg]);
+			OR32ItoM((uptr)&psxRegs.GPR[dreg], imm);
+			NOT32M((uptr)&psxRegs.GPR[dreg]);
 		}
 		else {
-			MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(ECX, (uptr)&psxRegs.GPR[sreg]);
 			OR32ItoR(ECX, imm);
 			NOT32R(ECX);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], ECX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], ECX);
 		}
 	}
 	else {
 		if( dreg == sreg ) {
-			NOT32M((uptr)&psxRegs.GPR.r[dreg]);
+			NOT32M((uptr)&psxRegs.GPR[dreg]);
 		}
 		else {
-			MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[sreg]);
+			MOV32MtoR(ECX, (uptr)&psxRegs.GPR[sreg]);
 			NOT32R(ECX);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[dreg], ECX);
+			MOV32RtoM((uptr)&psxRegs.GPR[dreg], ECX);
 		}
 	}
 }
@@ -381,19 +381,19 @@ void rpsxSLT_const()
 void rpsxSLT_consts(int info)
 {
 	XOR32RtoR(EAX, EAX);
-    CMP32ItoM((uptr)&psxRegs.GPR.r[_Rt_], g_psxConstRegs[_Rs_]);
+    CMP32ItoM((uptr)&psxRegs.GPR[_Rt_], g_psxConstRegs[_Rs_]);
     SETG8R(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 void rpsxSLT_constt(int info) { rpsxSLTconst(info, _Rd_, _Rs_, g_psxConstRegs[_Rt_]); }
 void rpsxSLT_(int info)
 {
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-    CMP32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+    CMP32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
     SETL8R   (EAX);
     AND32ItoR(EAX, 0xff);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 PSXRECOMPILE_CONSTCODE0(SLT);
@@ -407,9 +407,9 @@ void rpsxSLTU_const()
 void rpsxSLTU_consts(int info)
 {
 	XOR32RtoR(EAX, EAX);
-    CMP32ItoM((uptr)&psxRegs.GPR.r[_Rt_], g_psxConstRegs[_Rs_]);
+    CMP32ItoM((uptr)&psxRegs.GPR[_Rt_], g_psxConstRegs[_Rs_]);
     SETA8R(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 void rpsxSLTU_constt(int info) { rpsxSLTUconst(info, _Rd_, _Rs_, g_psxConstRegs[_Rt_]); }
@@ -418,11 +418,11 @@ void rpsxSLTU_(int info)
 	// Rd = Rs < Rt (unsigned)
 	if (!_Rd_) return;
 
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-    CMP32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+    CMP32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
 	SBB32RtoR(EAX, EAX);
 	NEG32R   (EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 PSXRECOMPILE_CONSTCODE0(SLTU);
@@ -432,28 +432,28 @@ void rpsxMULT_const()
 {
 	u64 res = (s64)((s64)*(int*)&g_psxConstRegs[_Rs_] * (s64)*(int*)&g_psxConstRegs[_Rt_]);
 
-	MOV32ItoM((uptr)&psxRegs.GPR.n.hi, (u32)((res >> 32) & 0xffffffff));
-	MOV32ItoM((uptr)&psxRegs.GPR.n.lo, (u32)(res & 0xffffffff));
+	MOV32ItoM((uptr)&psxRegs.hi, (u32)((res >> 32) & 0xffffffff));
+	MOV32ItoM((uptr)&psxRegs.lo, (u32)(res & 0xffffffff));
 }
 
 void rpsxMULTsuperconst(int info, int sreg, int imm, int sign)
 {
 	// Lo/Hi = Rs * Rt (signed)
 	MOV32ItoR(EAX, imm);
-	if( sign ) IMUL32M  ((uptr)&psxRegs.GPR.r[sreg]);
-	else MUL32M  ((uptr)&psxRegs.GPR.r[sreg]);
-	MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EDX);
+	if( sign ) IMUL32M  ((uptr)&psxRegs.GPR[sreg]);
+	else MUL32M  ((uptr)&psxRegs.GPR[sreg]);
+	MOV32RtoM((uptr)&psxRegs.lo, EAX);
+	MOV32RtoM((uptr)&psxRegs.hi, EDX);
 }
 
 void rpsxMULTsuper(int info, int sign)
 {
 	// Lo/Hi = Rs * Rt (signed)
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-	if( sign ) IMUL32M  ((uptr)&psxRegs.GPR.r[_Rt_]);
-	else MUL32M  ((uptr)&psxRegs.GPR.r[_Rt_]);
-	MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EDX);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+	if( sign ) IMUL32M  ((uptr)&psxRegs.GPR[_Rt_]);
+	else MUL32M  ((uptr)&psxRegs.GPR[_Rt_]);
+	MOV32RtoM((uptr)&psxRegs.lo, EAX);
+	MOV32RtoM((uptr)&psxRegs.hi, EDX);
 }
 
 void rpsxMULT_consts(int info) { rpsxMULTsuperconst(info, _Rt_, g_psxConstRegs[_Rs_], 1); }
@@ -467,8 +467,8 @@ void rpsxMULTU_const()
 {
 	u64 res = (u64)((u64)g_psxConstRegs[_Rs_] * (u64)g_psxConstRegs[_Rt_]);
 
-	MOV32ItoM((uptr)&psxRegs.GPR.n.hi, (u32)((res >> 32) & 0xffffffff));
-	MOV32ItoM((uptr)&psxRegs.GPR.n.lo, (u32)(res & 0xffffffff));
+	MOV32ItoM((uptr)&psxRegs.hi, (u32)((res >> 32) & 0xffffffff));
+	MOV32ItoM((uptr)&psxRegs.lo, (u32)(res & 0xffffffff));
 }
 
 void rpsxMULTU_consts(int info) { rpsxMULTsuperconst(info, _Rt_, g_psxConstRegs[_Rs_], 0); }
@@ -485,8 +485,8 @@ void rpsxDIV_const()
 	if (g_psxConstRegs[_Rt_] != 0) {
 		lo = *(int*)&g_psxConstRegs[_Rs_] / *(int*)&g_psxConstRegs[_Rt_];
 		hi = *(int*)&g_psxConstRegs[_Rs_] % *(int*)&g_psxConstRegs[_Rt_];
-		MOV32ItoM((uptr)&psxRegs.GPR.n.hi, hi);
-		MOV32ItoM((uptr)&psxRegs.GPR.n.lo, lo);
+		MOV32ItoM((uptr)&psxRegs.hi, hi);
+		MOV32ItoM((uptr)&psxRegs.lo, lo);
 	}
 }
 
@@ -496,7 +496,7 @@ void rpsxDIVsuperconsts(int info, int sign)
 
 	if( imm ) {
 		// Lo/Hi = Rs / Rt (signed)
-		MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rt_]);
+		MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rt_]);
 		CMP32ItoR(ECX, 0);
 		j8Ptr[0] = JE8(0);
 		MOV32ItoR(EAX, imm);
@@ -512,14 +512,14 @@ void rpsxDIVsuperconsts(int info, int sign)
 		}
 
 
-		MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EDX);
+		MOV32RtoM((uptr)&psxRegs.lo, EAX);
+		MOV32RtoM((uptr)&psxRegs.hi, EDX);
 		x86SetJ8(j8Ptr[0]);
 	}
 	else {
 		XOR32RtoR(EAX, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
+		MOV32RtoM((uptr)&psxRegs.hi, EAX);
+		MOV32RtoM((uptr)&psxRegs.lo, EAX);
 	}
 }
 
@@ -528,7 +528,7 @@ void rpsxDIVsuperconstt(int info, int sign)
 	u32 imm = g_psxConstRegs[_Rt_];
 
 	if( imm ) {
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
 		MOV32ItoR(ECX, imm);
 		//CDQ();
 
@@ -542,18 +542,18 @@ void rpsxDIVsuperconstt(int info, int sign)
 		}
 
 
-		MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EDX);
+		MOV32RtoM((uptr)&psxRegs.lo, EAX);
+		MOV32RtoM((uptr)&psxRegs.hi, EDX);
 	}
 }
 
 void rpsxDIVsuper(int info, int sign)
 {
 	// Lo/Hi = Rs / Rt (signed)
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rt_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rt_]);
 	CMP32ItoR(ECX, 0);
 	j8Ptr[0] = JE8(0);
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
 
 	if( sign ) {
 		CDQ();
@@ -564,8 +564,8 @@ void rpsxDIVsuper(int info, int sign)
 		DIV32R(ECX);
 	}
 
-	MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EDX);
+	MOV32RtoM((uptr)&psxRegs.lo, EAX);
+	MOV32RtoM((uptr)&psxRegs.hi, EDX);
 	x86SetJ8(j8Ptr[0]);
 }
 
@@ -583,8 +583,8 @@ void rpsxDIVU_const()
 	if (g_psxConstRegs[_Rt_] != 0) {
 		lo = g_psxConstRegs[_Rs_] / g_psxConstRegs[_Rt_];
 		hi = g_psxConstRegs[_Rs_] % g_psxConstRegs[_Rt_];
-		MOV32ItoM((uptr)&psxRegs.GPR.n.hi, hi);
-		MOV32ItoM((uptr)&psxRegs.GPR.n.lo, lo);
+		MOV32ItoM((uptr)&psxRegs.hi, hi);
+		MOV32ItoM((uptr)&psxRegs.lo, lo);
 	}
 }
 
@@ -608,12 +608,12 @@ static void rpsxLB()
 	_psxOnWriteReg(_Rt_);
 	_psxDeleteReg(_Rt_, 0);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
 	xCALL( iopMemRead8 );		// returns value in EAX
 	if (_Rt_) {
 		MOVSX32R8toR(EAX, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 	}
 	PSX_DEL_CONST(_Rt_);
 }
@@ -624,12 +624,12 @@ static void rpsxLBU()
 	_psxOnWriteReg(_Rt_);
 	_psxDeleteReg(_Rt_, 0);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
 	xCALL( iopMemRead8 );		// returns value in EAX
 	if (_Rt_) {
 		MOVZX32R8toR(EAX, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 	}
 	PSX_DEL_CONST(_Rt_);
 }
@@ -640,12 +640,12 @@ static void rpsxLH()
 	_psxOnWriteReg(_Rt_);
 	_psxDeleteReg(_Rt_, 0);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
 	xCALL( iopMemRead16 );		// returns value in EAX
 	if (_Rt_) {
 		MOVSX32R16toR(EAX, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 	}
 	PSX_DEL_CONST(_Rt_);
 }
@@ -656,12 +656,12 @@ static void rpsxLHU()
 	_psxOnWriteReg(_Rt_);
 	_psxDeleteReg(_Rt_, 0);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
 	xCALL( iopMemRead16 );		// returns value in EAX
 	if (_Rt_) {
 		MOVZX32R16toR(EAX, EAX);
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 	}
 	PSX_DEL_CONST(_Rt_);
 }
@@ -673,7 +673,7 @@ static void rpsxLW()
 	_psxDeleteReg(_Rt_, 0);
 
 	_psxFlushCall(FLUSH_EVERYTHING);
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
 
 	TEST32ItoR(ECX, 0x10000000);
@@ -681,7 +681,7 @@ static void rpsxLW()
 
 	xCALL( iopMemRead32 );		// returns value in EAX
 	if (_Rt_) {
-		MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+		MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 	}
 	j8Ptr[1] = JMP8(0);
 	x86SetJ8(j8Ptr[0]);
@@ -691,7 +691,7 @@ static void rpsxLW()
 	ADD32ItoR(ECX, (uptr)iopMem->Main);
 
 	MOV32RmtoR( ECX, ECX );
-	MOV32RtoM( (uptr)&psxRegs.GPR.r[_Rt_], ECX);
+	MOV32RtoM( (uptr)&psxRegs.GPR[_Rt_], ECX);
 
 	x86SetJ8(j8Ptr[1]);
 	PSX_DEL_CONST(_Rt_);
@@ -702,9 +702,9 @@ static void rpsxSB()
 	_psxDeleteReg(_Rs_, 1);
 	_psxDeleteReg(_Rt_, 1);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
-	xMOV( edx, ptr[&psxRegs.GPR.r[_Rt_]] );
+	xMOV( edx, ptr[&psxRegs.GPR[_Rt_]] );
 	xCALL( iopMemWrite8 );
 }
 
@@ -713,9 +713,9 @@ static void rpsxSH()
 	_psxDeleteReg(_Rs_, 1);
 	_psxDeleteReg(_Rt_, 1);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
-	xMOV( edx, ptr[&psxRegs.GPR.r[_Rt_]] );
+	xMOV( edx, ptr[&psxRegs.GPR[_Rt_]] );
 	xCALL( iopMemWrite16 );
 }
 
@@ -724,9 +724,9 @@ static void rpsxSW()
 	_psxDeleteReg(_Rs_, 1);
 	_psxDeleteReg(_Rt_, 1);
 
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	if (_Imm_) ADD32ItoR(ECX, _Imm_);
-	xMOV( edx, ptr[&psxRegs.GPR.r[_Rt_]] );
+	xMOV( edx, ptr[&psxRegs.GPR[_Rt_]] );
 	xCALL( iopMemWrite32 );
 }
 
@@ -743,25 +743,25 @@ void rpsxShiftConst(int info, int rdreg, int rtreg, int imm, int shifttype)
 	if (imm) {
 		if( rdreg == rtreg ) {
 			switch(shifttype) {
-				case 0: SHL32ItoM((uptr)&psxRegs.GPR.r[rdreg], imm); break;
-				case 1: SHR32ItoM((uptr)&psxRegs.GPR.r[rdreg], imm); break;
-				case 2: SAR32ItoM((uptr)&psxRegs.GPR.r[rdreg], imm); break;
+				case 0: SHL32ItoM((uptr)&psxRegs.GPR[rdreg], imm); break;
+				case 1: SHR32ItoM((uptr)&psxRegs.GPR[rdreg], imm); break;
+				case 2: SAR32ItoM((uptr)&psxRegs.GPR[rdreg], imm); break;
 			}
 		}
 		else {
-			MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[rtreg]);
+			MOV32MtoR(EAX, (uptr)&psxRegs.GPR[rtreg]);
 			switch(shifttype) {
 				case 0: SHL32ItoR(EAX, imm); break;
 				case 1: SHR32ItoR(EAX, imm); break;
 				case 2: SAR32ItoR(EAX, imm); break;
 			}
-			MOV32RtoM((uptr)&psxRegs.GPR.r[rdreg], EAX);
+			MOV32RtoM((uptr)&psxRegs.GPR[rdreg], EAX);
 		}
 	}
 	else {
 		if( rdreg != rtreg ) {
-			MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[rtreg]);
-			MOV32RtoM((uptr)&psxRegs.GPR.r[rdreg], EAX);
+			MOV32MtoR(EAX, (uptr)&psxRegs.GPR[rtreg]);
+			MOV32RtoM((uptr)&psxRegs.GPR[rdreg], EAX);
 		}
 	}
 }
@@ -801,23 +801,23 @@ void rpsxShiftVconsts(int info, int shifttype)
 void rpsxShiftVconstt(int info, int shifttype)
 {
 	MOV32ItoR(EAX, g_psxConstRegs[_Rt_]);
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	switch(shifttype) {
 		case 0: SHL32CLtoR(EAX); break;
 		case 1: SHR32CLtoR(EAX); break;
 		case 2: SAR32CLtoR(EAX); break;
 	}
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 void rpsxSLLV_consts(int info) { rpsxShiftVconsts(info, 0); }
 void rpsxSLLV_constt(int info) { rpsxShiftVconstt(info, 0); }
 void rpsxSLLV_(int info)
 {
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	SHL32CLtoR(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 PSXRECOMPILE_CONSTCODE0(SLLV);
@@ -832,10 +832,10 @@ void rpsxSRLV_consts(int info) { rpsxShiftVconsts(info, 1); }
 void rpsxSRLV_constt(int info) { rpsxShiftVconstt(info, 1); }
 void rpsxSRLV_(int info)
 {
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	SHR32CLtoR(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 PSXRECOMPILE_CONSTCODE0(SRLV);
@@ -850,10 +850,10 @@ void rpsxSRAV_consts(int info) { rpsxShiftVconsts(info, 2); }
 void rpsxSRAV_constt(int info) { rpsxShiftVconstt(info, 2); }
 void rpsxSRAV_(int info)
 {
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-	MOV32MtoR(ECX, (uptr)&psxRegs.GPR.r[_Rs_]);
+	MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+	MOV32MtoR(ECX, (uptr)&psxRegs.GPR[_Rs_]);
 	SAR32CLtoR(EAX);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 PSXRECOMPILE_CONSTCODE0(SRAV);
@@ -867,19 +867,19 @@ void rpsxMFHI()
 
 	_psxOnWriteReg(_Rd_);
 	_psxDeleteReg(_Rd_, 0);
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.n.hi);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32MtoR(EAX, (uptr)&psxRegs.hi);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 void rpsxMTHI()
 {
 	if( PSX_IS_CONST1(_Rs_) ) {
-		MOV32ItoM((uptr)&psxRegs.GPR.n.hi, g_psxConstRegs[_Rs_]);
+		MOV32ItoM((uptr)&psxRegs.hi, g_psxConstRegs[_Rs_]);
 	}
 	else {
 		_psxDeleteReg(_Rs_, 1);
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-		MOV32RtoM((uptr)&psxRegs.GPR.n.hi, EAX);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+		MOV32RtoM((uptr)&psxRegs.hi, EAX);
 	}
 }
 
@@ -889,19 +889,19 @@ void rpsxMFLO()
 
 	_psxOnWriteReg(_Rd_);
 	_psxDeleteReg(_Rd_, 0);
-	MOV32MtoR(EAX, (uptr)&psxRegs.GPR.n.lo);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rd_], EAX);
+	MOV32MtoR(EAX, (uptr)&psxRegs.lo);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rd_], EAX);
 }
 
 void rpsxMTLO()
 {
 	if( PSX_IS_CONST1(_Rs_) ) {
-		MOV32ItoM((uptr)&psxRegs.GPR.n.hi, g_psxConstRegs[_Rs_]);
+		MOV32ItoM((uptr)&psxRegs.hi, g_psxConstRegs[_Rs_]);
 	}
 	else {
 		_psxDeleteReg(_Rs_, 1);
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rs_]);
-		MOV32RtoM((uptr)&psxRegs.GPR.n.lo, EAX);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rs_]);
+		MOV32RtoM((uptr)&psxRegs.lo, EAX);
 	}
 }
 
@@ -975,16 +975,16 @@ static u32* s_pbranchjmp;
 void rpsxSetBranchEQ(int info, int process)
 {
 	if( process & PROCESS_CONSTS ) {
-		CMP32ItoM( (uptr)&psxRegs.GPR.r[ _Rt_ ], g_psxConstRegs[_Rs_] );
+		CMP32ItoM( (uptr)&psxRegs.GPR[ _Rt_ ], g_psxConstRegs[_Rs_] );
 		s_pbranchjmp = JNE32( 0 );
 	}
 	else if( process & PROCESS_CONSTT ) {
-		CMP32ItoM( (uptr)&psxRegs.GPR.r[ _Rs_ ], g_psxConstRegs[_Rt_] );
+		CMP32ItoM( (uptr)&psxRegs.GPR[ _Rs_ ], g_psxConstRegs[_Rt_] );
 		s_pbranchjmp = JNE32( 0 );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&psxRegs.GPR.r[ _Rs_ ] );
-		CMP32MtoR( EAX, (uptr)&psxRegs.GPR.r[ _Rt_ ] );
+		MOV32MtoR( EAX, (uptr)&psxRegs.GPR[ _Rs_ ] );
+		CMP32MtoR( EAX, (uptr)&psxRegs.GPR[ _Rt_ ] );
 		s_pbranchjmp = JNE32( 0 );
 	}
 }
@@ -1101,7 +1101,7 @@ void rpsxBLTZ()
 		return;
 	}
 
-	CMP32ItoM((uptr)&psxRegs.GPR.r[_Rs_], 0);
+	CMP32ItoM((uptr)&psxRegs.GPR[_Rs_], 0);
 	u32* pjmp = JL32(0);
 
 	psxSaveBranchState();
@@ -1135,7 +1135,7 @@ void rpsxBGEZ()
 		return;
 	}
 
-	CMP32ItoM((uptr)&psxRegs.GPR.r[_Rs_], 0);
+	CMP32ItoM((uptr)&psxRegs.GPR[_Rs_], 0);
 	u32* pjmp = JGE32(0);
 
 	psxSaveBranchState();
@@ -1176,12 +1176,12 @@ void rpsxBLTZAL()
 		return;
 	}
 
-	CMP32ItoM((uptr)&psxRegs.GPR.r[_Rs_], 0);
+	CMP32ItoM((uptr)&psxRegs.GPR[_Rs_], 0);
 	u32* pjmp = JL32(0);
 
 	psxSaveBranchState();
 
-	MOV32ItoM((uptr)&psxRegs.GPR.r[31], psxpc+4);
+	MOV32ItoM((uptr)&psxRegs.GPR[31], psxpc+4);
 	psxRecompileNextInstruction(1);
 
 	psxSetBranchImm(psxpc);
@@ -1209,17 +1209,17 @@ void rpsxBGEZAL()
 		if( (int)g_psxConstRegs[_Rs_] < 0 )
 			branchTo = psxpc+4;
 		else
-			MOV32ItoM((uptr)&psxRegs.GPR.r[31], psxpc+4);
+			MOV32ItoM((uptr)&psxRegs.GPR[31], psxpc+4);
 
 		psxRecompileNextInstruction(1);
 		psxSetBranchImm( branchTo );
 		return;
 	}
 
-	CMP32ItoM((uptr)&psxRegs.GPR.r[_Rs_], 0);
+	CMP32ItoM((uptr)&psxRegs.GPR[_Rs_], 0);
 	u32* pjmp = JGE32(0);
 
-	MOV32ItoM((uptr)&psxRegs.GPR.r[31], psxpc+4);
+	MOV32ItoM((uptr)&psxRegs.GPR[31], psxpc+4);
 
 	psxSaveBranchState();
 	psxRecompileNextInstruction(1);
@@ -1256,7 +1256,7 @@ void rpsxBLEZ()
 	_psxDeleteReg(_Rs_, 1);
 	_clearNeededX86regs();
 
-	CMP32ItoM((uptr)&psxRegs.GPR.r[_Rs_], 0);
+	CMP32ItoM((uptr)&psxRegs.GPR[_Rs_], 0);
 	u32* pjmp = JLE32(0);
 
 	psxSaveBranchState();
@@ -1291,7 +1291,7 @@ void rpsxBGTZ()
 	_psxDeleteReg(_Rs_, 1);
 	_clearNeededX86regs();
 
-	CMP32ItoM((uptr)&psxRegs.GPR.r[_Rs_], 0);
+	CMP32ItoM((uptr)&psxRegs.GPR[_Rs_], 0);
 	u32* pjmp = JG32(0);
 
 	psxSaveBranchState();
@@ -1312,8 +1312,8 @@ void rpsxMFC0()
 	if (!_Rt_) return;
 
 	_psxOnWriteReg(_Rt_);
-	MOV32MtoR(EAX, (uptr)&psxRegs.CP0.r[_Rd_]);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+	MOV32MtoR(EAX, (uptr)&psxRegs.CP0[_Rd_]);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 }
 
 void rpsxCFC0()
@@ -1322,20 +1322,20 @@ void rpsxCFC0()
 	if (!_Rt_) return;
 
 	_psxOnWriteReg(_Rt_);
-	MOV32MtoR(EAX, (uptr)&psxRegs.CP0.r[_Rd_]);
-	MOV32RtoM((uptr)&psxRegs.GPR.r[_Rt_], EAX);
+	MOV32MtoR(EAX, (uptr)&psxRegs.CP0[_Rd_]);
+	MOV32RtoM((uptr)&psxRegs.GPR[_Rt_], EAX);
 }
 
 void rpsxMTC0()
 {
 	// Cop0->Rd = Rt
 	if( PSX_IS_CONST1(_Rt_) ) {
-		MOV32ItoM((uptr)&psxRegs.CP0.r[_Rd_], g_psxConstRegs[_Rt_]);
+		MOV32ItoM((uptr)&psxRegs.CP0[_Rd_], g_psxConstRegs[_Rt_]);
 	}
 	else {
 		_psxDeleteReg(_Rt_, 1);
-		MOV32MtoR(EAX, (uptr)&psxRegs.GPR.r[_Rt_]);
-		MOV32RtoM((uptr)&psxRegs.CP0.r[_Rd_], EAX);
+		MOV32MtoR(EAX, (uptr)&psxRegs.GPR[_Rt_]);
+		MOV32RtoM((uptr)&psxRegs.CP0[_Rd_], EAX);
 	}
 }
 
@@ -1347,13 +1347,13 @@ void rpsxCTC0()
 
 void rpsxRFE()
 {
-	MOV32MtoR(EAX, (uptr)&psxRegs.CP0.n.Status);
+	MOV32MtoR(EAX, (uptr)&psxRegs.Status);
 	MOV32RtoR(ECX, EAX);
 	AND32ItoR(EAX, 0xfffffff0);
 	AND32ItoR(ECX, 0x3c);
 	SHR32ItoR(ECX, 2);
 	OR32RtoR (EAX, ECX);
-	MOV32RtoM((uptr)&psxRegs.CP0.n.Status, EAX);
+	MOV32RtoM((uptr)&psxRegs.Status, EAX);
 
 	// Test the IOP's INTC status, so that any pending ints get raised.
 

--- a/pcsx2/x86/iR5900Misc.cpp
+++ b/pcsx2/x86/iR5900Misc.cpp
@@ -104,8 +104,8 @@ void recMFSA()
 	else {
 		MOV32MtoR(EAX, (uptr)&cpuRegs.sa);
 		_deleteEEreg(_Rd_, 0);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rd_].UL[0], EAX);
-		MOV32ItoM((uptr)&cpuRegs.GPR.r[_Rd_].UL[1], 0);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rd_].UL[0], EAX);
+		MOV32ItoM((uptr)&cpuRegs.GPR[_Rd_].UL[1], 0);
 	}
 }
 
@@ -126,7 +126,7 @@ void recMTSA()
 			SetMMXstate();
 		}
 		else {
-			MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[_Rs_].UL[0]);
+			MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[_Rs_].UL[0]);
 			MOV32RtoM((uptr)&cpuRegs.sa, EAX);
 		}
 		AND32ItoM((uptr)&cpuRegs.sa, 0xf);

--- a/pcsx2/x86/ix86-32/iCore-32.cpp
+++ b/pcsx2/x86/ix86-32/iCore-32.cpp
@@ -48,7 +48,7 @@ uptr _x86GetAddr(int type, int reg)
 	switch(type&~X86TYPE_VU1)
 	{
 		case X86TYPE_GPR:
-			ret = (uptr)&cpuRegs.GPR.r[reg];
+			ret = (uptr)&cpuRegs.GPR[reg];
 			break;
 
 		case X86TYPE_VI:
@@ -95,7 +95,7 @@ uptr _x86GetAddr(int type, int reg)
 			break;
 
 		case X86TYPE_PSX:
-			ret = (uptr)&psxRegs.GPR.r[reg];
+			ret = (uptr)&psxRegs.GPR[reg];
 			break;
 
 		case X86TYPE_PCWRITEBACK:
@@ -169,8 +169,8 @@ void _flushCachedRegs()
 void _flushConstReg(int reg)
 {
 	if( GPR_IS_CONST1( reg ) && !(g_cpuFlushedConstReg&(1<<reg)) ) {
-		MOV32ItoM((uptr)&cpuRegs.GPR.r[reg].UL[0], g_cpuConstRegs[reg].UL[0]);
-		MOV32ItoM((uptr)&cpuRegs.GPR.r[reg].UL[1], g_cpuConstRegs[reg].UL[1]);
+		MOV32ItoM((uptr)&cpuRegs.GPR[reg].UL[0], g_cpuConstRegs[reg].UL[0]);
+		MOV32ItoM((uptr)&cpuRegs.GPR[reg].UL[1], g_cpuConstRegs[reg].UL[1]);
 		g_cpuFlushedConstReg |= (1<<reg);
 		if (reg == 0) DevCon.Warning("Flushing r0!");
 	}
@@ -193,7 +193,7 @@ void _flushConstRegs()
 
 		if (eaxval != 0) XOR32RtoR(EAX, EAX), eaxval = 0;
 
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[i].SL[j], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[i].SL[j], EAX);
 		done[j] |= 1<<i;
 		zero_cnt++;
 	}
@@ -207,7 +207,7 @@ void _flushConstRegs()
 		if (eaxval > 0) XOR32RtoR(EAX, EAX), eaxval = 0;
 		if (eaxval == 0) NOT32R(EAX), eaxval = -1;
 
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[i].SL[j], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[i].SL[j], EAX);
 		done[j + 2] |= 1<<i;
 		minusone_cnt++;
 	}
@@ -223,9 +223,9 @@ void _flushConstRegs()
 		if (GPR_IS_CONST1(i)) {
 			if (!(g_cpuFlushedConstReg&(1<<i))) {
 				if (!(done[0] & (1<<i)))
-					MOV32ItoM((uptr)&cpuRegs.GPR.r[i].UL[0], g_cpuConstRegs[i].UL[0]);
+					MOV32ItoM((uptr)&cpuRegs.GPR[i].UL[0], g_cpuConstRegs[i].UL[0]);
 				if (!(done[1] & (1<<i)))
-					MOV32ItoM((uptr)&cpuRegs.GPR.r[i].UL[1], g_cpuConstRegs[i].UL[1]);
+					MOV32ItoM((uptr)&cpuRegs.GPR[i].UL[1], g_cpuConstRegs[i].UL[1]);
 
 				g_cpuFlushedConstReg |= 1<<i;
 			}
@@ -475,9 +475,9 @@ __fi void* _MMXGetAddr(int reg)
 	if( reg == MMX_HI ) return &cpuRegs.HI;
 	if( reg == MMX_FPUACC ) return &fpuRegs.ACC;
 
-	if( reg >= MMX_GPR && reg < MMX_GPR+32 ) return &cpuRegs.GPR.r[reg&31];
+	if( reg >= MMX_GPR && reg < MMX_GPR+32 ) return &cpuRegs.GPR[reg&31];
 	if( reg >= MMX_FPU && reg < MMX_FPU+32 ) return &fpuRegs.fpr[reg&31];
-	if( reg >= MMX_COP0 && reg < MMX_COP0+32 ) return &cpuRegs.CP0.r[reg&31];
+	if( reg >= MMX_COP0 && reg < MMX_COP0+32 ) return &cpuRegs.CP0[reg&31];
 
 	pxAssume( false );
 	return NULL;
@@ -895,9 +895,9 @@ int _signExtendGPRMMXtoMMX(x86MMXRegType to, u32 gprreg, x86MMXRegType from, u32
 	SetMMXstate();
 
 	MOVQRtoR(to, from);
-	MOVDMMXtoM((uptr)&cpuRegs.GPR.r[gprreg].UL[0], from);
+	MOVDMMXtoM((uptr)&cpuRegs.GPR[gprreg].UL[0], from);
 	PSRADItoR(from, 31);
-	MOVDMMXtoM((uptr)&cpuRegs.GPR.r[gprreg].UL[1], from);
+	MOVDMMXtoM((uptr)&cpuRegs.GPR[gprreg].UL[1], from);
 	mmxregs[to].inuse = 0;
 
 	return -1;
@@ -910,9 +910,9 @@ int _signExtendGPRtoMMX(x86MMXRegType to, u32 gprreg, int shift)
 	SetMMXstate();
 
 	if( shift > 0 ) PSRADItoR(to, shift);
-	MOVDMMXtoM((uptr)&cpuRegs.GPR.r[gprreg].UL[0], to);
+	MOVDMMXtoM((uptr)&cpuRegs.GPR[gprreg].UL[0], to);
 	PSRADItoR(to, 31);
-	MOVDMMXtoM((uptr)&cpuRegs.GPR.r[gprreg].UL[1], to);
+	MOVDMMXtoM((uptr)&cpuRegs.GPR[gprreg].UL[1], to);
 	mmxregs[to].inuse = 0;
 
 	return -1;

--- a/pcsx2/x86/ix86-32/iR5900Arit.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Arit.cpp
@@ -67,7 +67,7 @@ void recADD_constv(int info, int creg, u32 vreg)
 
 	s32 cval = g_cpuConstRegs[creg].SL[0];
 
-	xMOV(eax, ptr32[&cpuRegs.GPR.r[vreg].SL[0]]);
+	xMOV(eax, ptr32[&cpuRegs.GPR[vreg].SL[0]]);
 	if (cval)
 		xADD(eax, cval);
 	eeSignExtendTo(_Rd_, _Rd_ == vreg && !cval);
@@ -90,11 +90,11 @@ void recADD_(int info)
 {
 	pxAssert( !(info&PROCESS_EE_XMM) );
 
-	xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rs_].SL[0]]);
+	xMOV(eax, ptr32[&cpuRegs.GPR[_Rs_].SL[0]]);
 	if (_Rs_ == _Rt_)
 		xADD(eax, eax);
 	else
-		xADD(eax, ptr32[&cpuRegs.GPR.r[_Rt_].SL[0]]);
+		xADD(eax, ptr32[&cpuRegs.GPR[_Rt_].SL[0]]);
 	eeSignExtendTo(_Rd_);
 }
 
@@ -121,17 +121,17 @@ void recDADD_constv(int info, int creg, u32 vreg)
 	if (_Rd_ == vreg) {
 		if (!cval.SD[0])
 			return; // no-op
-		xADD(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], cval.SL[0]);
-		xADC(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], cval.SL[1]);
+		xADD(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], cval.SL[0]);
+		xADC(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], cval.SL[1]);
 	} else {
-		xMOV(eax, ptr32[&cpuRegs.GPR.r[vreg].SL[0]]);
-		xMOV(edx, ptr32[&cpuRegs.GPR.r[vreg].SL[1]]);
+		xMOV(eax, ptr32[&cpuRegs.GPR[vreg].SL[0]]);
+		xMOV(edx, ptr32[&cpuRegs.GPR[vreg].SL[1]]);
 		if (cval.SD[0]) {
 			xADD(eax, cval.SL[0]);
 			xADC(edx, cval.SL[1]);
 		}
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 	}
 }
 
@@ -153,30 +153,30 @@ void recDADD_(int info)
 	if (_Rd_ == _Rt_)
 		rs = _Rt_, rt = _Rs_;
 
-	xMOV(eax, ptr32[&cpuRegs.GPR.r[rt].SL[0]]);
+	xMOV(eax, ptr32[&cpuRegs.GPR[rt].SL[0]]);
 
 	if (_Rd_ == _Rs_ && _Rs_ == _Rt_) {
-		xSHLD(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], eax, 1);
-		xSHL(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], 1);
+		xSHLD(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], eax, 1);
+		xSHL(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], 1);
 		return;
 	}
 
-	xMOV(edx, ptr32[&cpuRegs.GPR.r[rt].SL[1]]);
+	xMOV(edx, ptr32[&cpuRegs.GPR[rt].SL[1]]);
 
 	if (_Rd_ == rs) {
-		xADD(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-		xADC(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+		xADD(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+		xADC(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 		return;
 	} else if (rs == rt) {
 		xADD(eax, eax);
 		xADC(edx, edx);
 	} else {
-		xADD(eax, ptr32[&cpuRegs.GPR.r[rs].SL[0]]);
-		xADC(edx, ptr32[&cpuRegs.GPR.r[rs].SL[1]]);
+		xADD(eax, ptr32[&cpuRegs.GPR[rs].SL[0]]);
+		xADC(edx, ptr32[&cpuRegs.GPR[rs].SL[1]]);
 	}
 
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 }
 
 EERECOMPILE_CODE0(DADD, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);
@@ -201,7 +201,7 @@ void recSUB_consts(int info)
 	s32 sval = g_cpuConstRegs[_Rs_].SL[0];
 
 	xMOV(eax, sval);
-	xSUB(eax, ptr32[&cpuRegs.GPR.r[_Rt_].SL[0]]);
+	xSUB(eax, ptr32[&cpuRegs.GPR[_Rt_].SL[0]]);
 	eeSignExtendTo(_Rd_);
 }
 
@@ -211,7 +211,7 @@ void recSUB_constt(int info)
 
 	s32 tval = g_cpuConstRegs[_Rt_].SL[0];
 
-	xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rs_].SL[0]]);
+	xMOV(eax, ptr32[&cpuRegs.GPR[_Rs_].SL[0]]);
 	if (tval)
 		xSUB(eax, tval);
 	eeSignExtendTo(_Rd_, _Rd_ == _Rs_ && !tval);
@@ -222,13 +222,13 @@ void recSUB_(int info)
 	pxAssert( !(info&PROCESS_EE_XMM) );
 
 	if (_Rs_ == _Rt_) {
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], 0);
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], 0);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], 0);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], 0);
 		return;
 	}
 
-	xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rs_].SL[0]]);
-	xSUB(eax, ptr32[&cpuRegs.GPR.r[_Rt_].SL[0]]);
+	xMOV(eax, ptr32[&cpuRegs.GPR[_Rs_].SL[0]]);
+	xSUB(eax, ptr32[&cpuRegs.GPR[_Rt_].SL[0]]);
 	eeSignExtendTo(_Rd_);
 }
 
@@ -259,19 +259,19 @@ void recDSUB_consts(int info)
 		 * Incrementing before a NEG is the same as a NOT and the carry flag is set for
 		 * a non-zero lower word.
 		 */
-		xNEG(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]]);
-		xADC(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], 0);
-		xNEG(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]]);
+		xNEG(ptr32[&cpuRegs.GPR[_Rd_].SL[0]]);
+		xADC(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], 0);
+		xNEG(ptr32[&cpuRegs.GPR[_Rd_].SL[1]]);
 		return;
 	} else {
 		xMOV(eax, sval.SL[0]);
 		xMOV(edx, sval.SL[1]);
 	}
 
-	xSUB(eax, ptr32[&cpuRegs.GPR.r[_Rt_].SL[0]]);
-	xSBB(edx, ptr32[&cpuRegs.GPR.r[_Rt_].SL[1]]);
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+	xSUB(eax, ptr32[&cpuRegs.GPR[_Rt_].SL[0]]);
+	xSBB(edx, ptr32[&cpuRegs.GPR[_Rt_].SL[1]]);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 }
 
 void recDSUB_constt(int info)
@@ -281,17 +281,17 @@ void recDSUB_constt(int info)
 	GPR_reg64 tval = g_cpuConstRegs[_Rt_];
 
 	if (_Rd_ == _Rs_) {
-		xSUB(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], tval.SL[0]);
-		xSBB(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], tval.SL[1]);
+		xSUB(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], tval.SL[0]);
+		xSBB(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], tval.SL[1]);
 	} else {
-		xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rs_].SL[0]]);
-		xMOV(edx, ptr32[&cpuRegs.GPR.r[_Rs_].SL[1]]);
+		xMOV(eax, ptr32[&cpuRegs.GPR[_Rs_].SL[0]]);
+		xMOV(edx, ptr32[&cpuRegs.GPR[_Rs_].SL[1]]);
 		if (tval.SD[0]) {
 			xSUB(eax, tval.SL[0]);
 			xSBB(edx, tval.SL[1]);
 		}
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 	}
 }
 
@@ -300,20 +300,20 @@ void recDSUB_(int info)
 	pxAssert( !(info&PROCESS_EE_XMM) );
 
 	if (_Rs_ == _Rt_) {
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], 0);
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], 0);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], 0);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], 0);
 	} else if (_Rd_ == _Rs_) {
-		xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rt_].SL[0]]);
-		xMOV(edx, ptr32[&cpuRegs.GPR.r[_Rt_].SL[1]]);
-		xSUB(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-		xSBB(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+		xMOV(eax, ptr32[&cpuRegs.GPR[_Rt_].SL[0]]);
+		xMOV(edx, ptr32[&cpuRegs.GPR[_Rt_].SL[1]]);
+		xSUB(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+		xSBB(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 	} else {
-		xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rs_].SL[0]]);
-		xMOV(edx, ptr32[&cpuRegs.GPR.r[_Rs_].SL[1]]);
-		xSUB(eax, ptr32[&cpuRegs.GPR.r[_Rt_].SL[0]]);
-		xSBB(edx, ptr32[&cpuRegs.GPR.r[_Rt_].SL[1]]);
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[0]], eax);
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].SL[1]], edx);
+		xMOV(eax, ptr32[&cpuRegs.GPR[_Rs_].SL[0]]);
+		xMOV(edx, ptr32[&cpuRegs.GPR[_Rs_].SL[1]]);
+		xSUB(eax, ptr32[&cpuRegs.GPR[_Rt_].SL[0]]);
+		xSBB(edx, ptr32[&cpuRegs.GPR[_Rt_].SL[1]]);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[0]], eax);
+		xMOV(ptr32[&cpuRegs.GPR[_Rd_].SL[1]], edx);
 	}
 }
 
@@ -339,15 +339,15 @@ void recAND_constv(int info, int creg, u32 vreg)
 
 	for (int i = 0; i < 2; i++) {
 		if (!cval.UL[i]) {
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], 0);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], 0);
 		} else if (_Rd_ == vreg) {
 			if (cval.SL[i] != -1)
-				xAND(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], cval.UL[i]);
+				xAND(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], cval.UL[i]);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[vreg].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[vreg].UL[i]]);
 			if (cval.SL[i] != -1)
 				xAND(eax, cval.UL[i]);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -374,13 +374,13 @@ void recAND_(int info)
 		if (_Rd_ == rs) {
 			if (rs == rt)
 				continue;
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xAND(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xAND(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rs].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rs].UL[i]]);
 			if (rs != rt)
-				xAND(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+				xAND(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -401,15 +401,15 @@ void recOR_constv(int info, int creg, u32 vreg)
 
 	for (int i = 0; i < 2; i++) {
 		if (cval.SL[i] == -1) {
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], -1);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], -1);
 		} else if (_Rd_ == vreg) {
 			if (cval.UL[i])
-				xOR(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], cval.UL[i]);
+				xOR(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], cval.UL[i]);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[vreg].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[vreg].UL[i]]);
 			if (cval.UL[i])
 				xOR(eax, cval.UL[i]);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -436,13 +436,13 @@ void recOR_(int info)
 		if (_Rd_ == rs) {
 			if (rs == rt)
 				continue;
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xOR(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xOR(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rs].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rs].UL[i]]);
 			if (rs != rt)
-				xOR(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+				xOR(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -464,12 +464,12 @@ void recXOR_constv(int info, int creg, u32 vreg)
 	for (int i = 0; i < 2; i++) {
 		if (_Rd_ == vreg) {
 			if (cval.UL[i])
-				xXOR(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], cval.UL[i]);
+				xXOR(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], cval.UL[i]);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[vreg].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[vreg].UL[i]]);
 			if (cval.UL[i])
 				xXOR(eax, cval.UL[i]);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -494,14 +494,14 @@ void recXOR_(int info)
 
 	for (int i = 0; i < 2; i++) {
 		if (rs == rt) {
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], 0);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], 0);
 		} else if (_Rd_ == rs) {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xXOR(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xXOR(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rs].UL[i]]);
-			xXOR(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rs].UL[i]]);
+			xXOR(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -523,14 +523,14 @@ void recNOR_constv(int info, int creg, u32 vreg)
 	for (int i = 0; i < 2; i++) {
 		if (_Rd_ == vreg) {
 			if (cval.UL[i])
-				xOR(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], cval.UL[i]);
-			xNOT(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]]);
+				xOR(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], cval.UL[i]);
+			xNOT(ptr32[&cpuRegs.GPR[_Rd_].UL[i]]);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[vreg].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[vreg].UL[i]]);
 			if (cval.UL[i])
 				xOR(eax, cval.UL[i]);
 			xNOT(eax);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -556,18 +556,18 @@ void recNOR_(int info)
 	for (int i = 0; i < 2; i++) {
 		if (_Rd_ == rs) {
 			if (rs == rt) {
-				xNOT(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]]);
+				xNOT(ptr32[&cpuRegs.GPR[_Rd_].UL[i]]);
 				continue;
 			}
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
-			xOR(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
-			xNOT(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
+			xOR(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
+			xNOT(ptr32[&cpuRegs.GPR[_Rd_].UL[i]]);
 		} else {
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[rs].UL[i]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[rs].UL[i]]);
 			if (rs != rt)
-				xOR(eax, ptr32[&cpuRegs.GPR.r[rt].UL[i]]);
+				xOR(eax, ptr32[&cpuRegs.GPR[rt].UL[i]]);
 			xNOT(eax);
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[i]], eax);
+			xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[i]], eax);
 		}
 	}
 }
@@ -588,11 +588,11 @@ void recSLTs_const(int info, int sign, int st)
 
 	xMOV(eax, 1);
 
-	xCMP(ptr32[&cpuRegs.GPR.r[st ? _Rs_ : _Rt_].UL[1]], cval.UL[1]);
+	xCMP(ptr32[&cpuRegs.GPR[st ? _Rs_ : _Rt_].UL[1]], cval.UL[1]);
 	xForwardJump8 pass1(st ? (sign ? Jcc_Less : Jcc_Below) : (sign ? Jcc_Greater : Jcc_Above));
 	xForwardJump8 fail(st ? (sign ? Jcc_Greater : Jcc_Above) : (sign ? Jcc_Less : Jcc_Below));
 	{
-		xCMP(ptr32[&cpuRegs.GPR.r[st ? _Rs_ : _Rt_].UL[0]], cval.UL[0]);
+		xCMP(ptr32[&cpuRegs.GPR[st ? _Rs_ : _Rt_].UL[0]], cval.UL[0]);
 		xForwardJump8 pass2(st ? Jcc_Below : Jcc_Above);
 
 		fail.SetTarget();
@@ -601,8 +601,8 @@ void recSLTs_const(int info, int sign, int st)
 	}
 	pass1.SetTarget();
 
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[0]], eax);
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[1]], 0);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[0]], eax);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[1]], 0);
 }
 
 void recSLTs_(int info, int sign)
@@ -611,13 +611,13 @@ void recSLTs_(int info, int sign)
 
 	xMOV(eax, 1);
 
-	xMOV(edx, ptr32[&cpuRegs.GPR.r[_Rs_].UL[1]]);
-	xCMP(edx, ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]]);
+	xMOV(edx, ptr32[&cpuRegs.GPR[_Rs_].UL[1]]);
+	xCMP(edx, ptr32[&cpuRegs.GPR[_Rt_].UL[1]]);
 	xForwardJump8 pass1(sign ? Jcc_Less : Jcc_Below);
 	xForwardJump8 fail(sign ? Jcc_Greater : Jcc_Above);
 	{
-		xMOV(edx, ptr32[&cpuRegs.GPR.r[_Rs_].UL[0]]);
-		xCMP(edx, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+		xMOV(edx, ptr32[&cpuRegs.GPR[_Rs_].UL[0]]);
+		xCMP(edx, ptr32[&cpuRegs.GPR[_Rt_].UL[0]]);
 		xForwardJump8 pass2(Jcc_Below);
 
 		fail.SetTarget();
@@ -626,8 +626,8 @@ void recSLTs_(int info, int sign)
 	}
 	pass1.SetTarget();
 
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[0]], eax);
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rd_].UL[1]], 0);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[0]], eax);
+	xMOV(ptr32[&cpuRegs.GPR[_Rd_].UL[1]], 0);
 }
 
 void recSLT_consts(int info)

--- a/pcsx2/x86/ix86-32/iR5900AritImm.cpp
+++ b/pcsx2/x86/ix86-32/iR5900AritImm.cpp
@@ -59,17 +59,17 @@ void recADDI_(int info)
 
 	if ( _Rt_ == _Rs_ ) {
 		// must perform the ADD unconditionally, to maintain flags status:
-		ADD32ItoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], _Imm_);
-		_signExtendSFtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ]);
+		ADD32ItoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], _Imm_);
+		_signExtendSFtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ]);
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 
 		if ( _Imm_ != 0 ) ADD32ItoR( EAX, _Imm_ );
 
 		CDQ( );
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], EDX );
 	}
 }
 
@@ -92,13 +92,13 @@ void recDADDI_(int info)
 	pxAssert( !(info&PROCESS_EE_XMM) );
 
 	if( _Rt_ == _Rs_ ) {
-		ADD32ItoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], _Imm_);
-		ADC32ItoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], _Imm_<0?0xffffffff:0);
+		ADD32ItoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], _Imm_);
+		ADC32ItoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], _Imm_<0?0xffffffff:0);
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 
-		MOV32MtoR( EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ] );
+		MOV32MtoR( EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ] );
 
 		if ( _Imm_ != 0 )
 		{
@@ -106,9 +106,9 @@ void recDADDI_(int info)
 			ADC32ItoR( EDX, _Imm_ < 0?0xffffffff:0);
 		}
 
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
 
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], EDX );
 	}
 }
 
@@ -133,11 +133,11 @@ void recSLTIU_(int info)
 {
 	MOV32ItoR(EAX, 1);
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], _Imm_ >= 0 ? 0 : 0xffffffff);
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], _Imm_ >= 0 ? 0 : 0xffffffff);
 	j8Ptr[0] = JB8( 0 );
 	j8Ptr[2] = JA8( 0 );
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], (s32)_Imm_ );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], (s32)_Imm_ );
 	j8Ptr[1] = JB8(0);
 
 	x86SetJ8(j8Ptr[2]);
@@ -146,8 +146,8 @@ void recSLTIU_(int info)
 	x86SetJ8(j8Ptr[0]);
 	x86SetJ8(j8Ptr[1]);
 
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], 0 );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], 0 );
 }
 
 EERECOMPILE_CODEX(eeRecompileCode1, SLTIU);
@@ -163,11 +163,11 @@ void recSLTI_(int info)
 	// test silent hill if modding
 	MOV32ItoR(EAX, 1);
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], _Imm_ >= 0 ? 0 : 0xffffffff);
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], _Imm_ >= 0 ? 0 : 0xffffffff);
 	j8Ptr[0] = JL8( 0 );
 	j8Ptr[2] = JG8( 0 );
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], (s32)_Imm_ );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], (s32)_Imm_ );
 	j8Ptr[1] = JB8(0);
 
 	x86SetJ8(j8Ptr[2]);
@@ -176,8 +176,8 @@ void recSLTI_(int info)
 	x86SetJ8(j8Ptr[0]);
 	x86SetJ8(j8Ptr[1]);
 
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], 0 );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], 0 );
 }
 
 EERECOMPILE_CODEX(eeRecompileCode1, SLTI);
@@ -193,34 +193,34 @@ void recLogicalOpI(int info, int op)
 	if ( _ImmU_ != 0 )
 	{
 		if( _Rt_ == _Rs_ ) {
-			LogicalOp32ItoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], _ImmU_, op);
+			LogicalOp32ItoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], _ImmU_, op);
 		}
 		else {
-			MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+			MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 			if( op != 0 )
-				MOV32MtoR( EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ] );
+				MOV32MtoR( EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ] );
 			LogicalOp32ItoR( EAX, _ImmU_, op);
 			if( op != 0 )
-				MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
+				MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
 		}
 
 		if( op == 0 ) {
-			MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], 0 );
+			MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], 0 );
 		}
 	}
 	else
 	{
 		if( op == 0 ) {
-			MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], 0 );
-			MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], 0 );
+			MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], 0 );
+			MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], 0 );
 		}
 		else {
 			if( _Rt_ != _Rs_ ) {
-				MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-				MOV32MtoR(EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ] );
-				MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], EAX );
-				MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], EDX );
+				MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+				MOV32MtoR(EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ] );
+				MOV32RtoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], EAX );
+				MOV32RtoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], EDX );
 			}
 		}
 	}

--- a/pcsx2/x86/ix86-32/iR5900Branch.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Branch.cpp
@@ -71,7 +71,7 @@ void recSetBranchEQ(int info, int bne, int process)
 			}
 
 			_flushConstReg(_Rs_);
-			SSE2_PCMPEQD_M128_to_XMM(t0reg, (uptr)&cpuRegs.GPR.r[_Rs_].UL[0]);
+			SSE2_PCMPEQD_M128_to_XMM(t0reg, (uptr)&cpuRegs.GPR[_Rs_].UL[0]);
 
 
 			if( t0reg != EEREC_T ) _freeXMMreg(t0reg);
@@ -88,7 +88,7 @@ void recSetBranchEQ(int info, int bne, int process)
 			}
 
 			_flushConstReg(_Rt_);
-			SSE2_PCMPEQD_M128_to_XMM(t0reg, (uptr)&cpuRegs.GPR.r[_Rt_].UL[0]);
+			SSE2_PCMPEQD_M128_to_XMM(t0reg, (uptr)&cpuRegs.GPR[_Rt_].UL[0]);
 
 			if( t0reg != EEREC_S ) _freeXMMreg(t0reg);
 		}
@@ -131,26 +131,26 @@ void recSetBranchEQ(int info, int bne, int process)
 
 		if( bne ) {
 			if( process & PROCESS_CONSTS ) {
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
 				j8Ptr[ 0 ] = JNE8( 0 );
 
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
 				j32Ptr[ 1 ] = JE32( 0 );
 			}
 			else if( process & PROCESS_CONSTT ) {
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], g_cpuConstRegs[_Rt_].UL[0] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], g_cpuConstRegs[_Rt_].UL[0] );
 				j8Ptr[ 0 ] = JNE8( 0 );
 
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], g_cpuConstRegs[_Rt_].UL[1] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], g_cpuConstRegs[_Rt_].UL[1] );
 				j32Ptr[ 1 ] = JE32( 0 );
 			}
 			else {
-				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 				j8Ptr[ 0 ] = JNE8( 0 );
 
-				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ] );
-				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ] );
+				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 				j32Ptr[ 1 ] = JE32( 0 );
 			}
 
@@ -159,26 +159,26 @@ void recSetBranchEQ(int info, int bne, int process)
 		else {
 			// beq
 			if( process & PROCESS_CONSTS ) {
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
 				j32Ptr[ 0 ] = JNE32( 0 );
 
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
 				j32Ptr[ 1 ] = JNE32( 0 );
 			}
 			else if( process & PROCESS_CONSTT ) {
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], g_cpuConstRegs[_Rt_].UL[0] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], g_cpuConstRegs[_Rt_].UL[0] );
 				j32Ptr[ 0 ] = JNE32( 0 );
 
-				CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], g_cpuConstRegs[_Rt_].UL[1] );
+				CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], g_cpuConstRegs[_Rt_].UL[1] );
 				j32Ptr[ 1 ] = JNE32( 0 );
 			}
 			else {
-				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 				j32Ptr[ 0 ] = JNE32( 0 );
 
-				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ] );
-				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+				MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ] );
+				CMP32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 				j32Ptr[ 1 ] = JNE32( 0 );
 			}
 		}
@@ -205,7 +205,7 @@ void recSetBranchL(int ltz)
 		return;
 	}
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], 0 );
 	if( ltz ) j32Ptr[ 0 ] = JGE32( 0 );
 	else j32Ptr[ 0 ] = JL32( 0 );
 
@@ -409,8 +409,8 @@ void recBLTZAL()
 	_eeFlushAllUnused();
 
 	_deleteEEreg(31, 0);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[0], pc+4);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[1], 0);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[0], pc+4);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[1], 0);
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		if( !(g_cpuConstRegs[_Rs_].SD[0] < 0) )
@@ -448,8 +448,8 @@ void recBGEZAL()
 	_eeFlushAllUnused();
 
 	_deleteEEreg(31, 0);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[0], pc+4);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[1], 0);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[0], pc+4);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[1], 0);
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		if( !(g_cpuConstRegs[_Rs_].SD[0] >= 0) )
@@ -487,8 +487,8 @@ void recBLTZALL()
 	_eeFlushAllUnused();
 
 	_deleteEEreg(31, 0);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[0], pc+4);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[1], 0);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[0], pc+4);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[1], 0);
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		if( !(g_cpuConstRegs[_Rs_].SD[0] < 0) )
@@ -521,8 +521,8 @@ void recBGEZALL()
 	_eeFlushAllUnused();
 
 	_deleteEEreg(31, 0);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[0], pc+4);
-	MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[1], 0);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[0], pc+4);
+	MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[1], 0);
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		if( !(g_cpuConstRegs[_Rs_].SD[0] >= 0) )
@@ -565,11 +565,11 @@ void recBLEZ()
 
 	_flushEEreg(_Rs_);
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], 0 );
 	j8Ptr[ 0 ] = JL8( 0 );
 	j32Ptr[ 1 ] = JG32( 0 );
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], 0 );
 	j32Ptr[ 2 ] = JNZ32( 0 );
 
 	x86SetJ8( j8Ptr[ 0 ] );
@@ -611,11 +611,11 @@ void recBGTZ()
 
 	_flushEEreg(_Rs_);
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], 0 );
 	j8Ptr[ 0 ] = JG8( 0 );
 	j32Ptr[ 1 ] = JL32( 0 );
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], 0 );
 	j32Ptr[ 2 ] = JZ32( 0 );
 
 	x86SetJ8( j8Ptr[ 0 ] );
@@ -793,11 +793,11 @@ void recBLEZL()
 
 	_flushEEreg(_Rs_);
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], 0 );
 	j32Ptr[ 0 ] = JL32( 0 );
 	j32Ptr[ 1 ] = JG32( 0 );
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], 0 );
 	j32Ptr[ 2 ] = JNZ32( 0 );
 
 	x86SetJ32( j32Ptr[ 0 ] );
@@ -837,11 +837,11 @@ void recBGTZL()
 
 	_flushEEreg(_Rs_);
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], 0 );
 	j32Ptr[ 0 ] = JG32( 0 );
 	j32Ptr[ 1 ] = JL32( 0 );
 
-	CMP32ItoM( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], 0 );
+	CMP32ItoM( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], 0 );
 	j32Ptr[ 2 ] = JZ32( 0 );
 
 	x86SetJ32( j32Ptr[ 0 ] );

--- a/pcsx2/x86/ix86-32/iR5900Jump.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Jump.cpp
@@ -69,8 +69,8 @@ void recJAL()
 	}
 	else
 	{
-		MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[0], pc + 4);
-		MOV32ItoM((uptr)&cpuRegs.GPR.r[31].UL[1], 0);
+		MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[0], pc + 4);
+		MOV32ItoM((uptr)&cpuRegs.GPR[31].UL[1], 0);
 	}
 
 	recompileNextInstruction(1);
@@ -118,7 +118,7 @@ void recJALR()
 //			SetMMXstate();
 //		}
 //		else {
-//			MOV32MtoR(EAX, (int)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+//			MOV32MtoR(EAX, (int)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 //			MOV32RtoM((u32)&cpuRegs.pc, EAX);
 //		}
 //	}
@@ -135,8 +135,8 @@ void recJALR()
 		}
 		else
 		{
-			MOV32ItoM((uptr)&cpuRegs.GPR.r[_Rd_].UL[0], newpc);
-			MOV32ItoM((uptr)&cpuRegs.GPR.r[_Rd_].UL[1], 0);
+			MOV32ItoM((uptr)&cpuRegs.GPR[_Rd_].UL[0], newpc);
+			MOV32ItoM((uptr)&cpuRegs.GPR[_Rd_].UL[1], 0);
 		}
 	}
 

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -84,9 +84,9 @@ void _eeOnLoadWrite(u32 reg)
 		if( xmmregs[regt].mode & MODE_WRITE ) {
 			if( reg != _Rs_ ) {
 				SSE2_PUNPCKHQDQ_XMM_to_XMM(regt, regt);
-				SSE2_MOVQ_XMM_to_M64((uptr)&cpuRegs.GPR.r[reg].UL[2], regt);
+				SSE2_MOVQ_XMM_to_M64((uptr)&cpuRegs.GPR[reg].UL[2], regt);
 			}
-			else SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[reg].UL[2], regt);
+			else SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[reg].UL[2], regt);
 		}
 		xmmregs[regt].inuse = 0;
 	}
@@ -111,7 +111,7 @@ void recLoad64( u32 bits, bool sign )
 	// 64/128 bit modes load the result directly into the cpuRegs.GPR struct.
 
 	if (_Rt_)
-		xMOV(edx, (uptr)&cpuRegs.GPR.r[_Rt_].UL[0]);
+		xMOV(edx, (uptr)&cpuRegs.GPR[_Rt_].UL[0]);
 	else
 		xMOV(edx, (uptr)&dummyValue[0]);
 
@@ -180,11 +180,11 @@ void recLoad32( u32 bits, bool sign )
 		if (sign)
 			xCDQ();
 
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]], eax);
+		xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[0]], eax);
 		if (sign)
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]], edx);
+			xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[1]], edx);
 		else
-			xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]], 0);
+			xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[1]], 0);
 	}
 }
 
@@ -207,7 +207,7 @@ void recStore(u32 bits)
         else if (bits == 128 || bits == 64)
         {
                 _flushEEreg(_Rt_);          // flush register to mem
-                xMOV(edx, (uptr)&cpuRegs.GPR.r[_Rt_].UL[0]);
+                xMOV(edx, (uptr)&cpuRegs.GPR[_Rt_].UL[0]);
         }
 
         // Load ECX with the destination address, or issue a direct optimized write
@@ -280,17 +280,17 @@ void recLWL()
 	xMOV(ecx, edi);
 	xMOV(edx, 0xffffff);
 	xSHR(edx, cl);
-	xAND(ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]], edx);
+	xAND(ptr32[&cpuRegs.GPR[_Rt_].UL[0]], edx);
 
 	// OR in bytes loaded
 	xMOV(ecx, 24);
 	xSUB(ecx, edi);
 	xSHL(eax, cl);
-	xOR(ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]], eax);
+	xOR(ptr32[&cpuRegs.GPR[_Rt_].UL[0]], eax);
 
 	// eax will always have the sign bit
 	xCDQ();
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]], edx);
+	xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[1]], edx);
 #else
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -327,18 +327,18 @@ void recLWR()
 	xSUB(ecx, edi);
 	xMOV(edx, 0xffffff00);
 	xSHL(edx, cl);
-	xAND(ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]], edx);
+	xAND(ptr32[&cpuRegs.GPR[_Rt_].UL[0]], edx);
 
 	// OR in bytes loaded
 	xMOV(ecx, edi);
 	xSHR(eax, cl);
-	xOR(ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]], eax);
+	xOR(ptr32[&cpuRegs.GPR[_Rt_].UL[0]], eax);
 
 	xCMP(edi, 0);
 	xForwardJump8 nosignextend(Jcc_NotEqual);
 	// if ((addr & 3) == 0)
 	xCDQ();
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]], edx);
+	xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[1]], edx);
 	nosignextend.SetTarget();
 #else
 	iFlushCall(FLUSH_INTERPRETER);

--- a/pcsx2/x86/ix86-32/iR5900Move.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Move.cpp
@@ -65,7 +65,7 @@ void recLUI()
 
 	if( (mmreg = _checkXMMreg(XMMTYPE_GPRREG, _Rt_, MODE_WRITE)) >= 0 ) {
 		if( xmmregs[mmreg].mode & MODE_WRITE ) {
-			SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[_Rt_].UL[2], mmreg);
+			SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[_Rt_].UL[2], mmreg);
 		}
 		xmmregs[mmreg].inuse = 0;
 	}
@@ -81,8 +81,8 @@ void recLUI()
 	{
 		MOV32ItoR(EAX, (s32)(cpuRegs.code << 16));
 		CDQ();
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[0], EAX);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[_Rt_].UL[1], EDX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[0], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[_Rt_].UL[1], EDX);
 	}	
 }
 
@@ -106,10 +106,10 @@ void recMFHILO(int hi)
 
 			xmmregs[regd].inuse = 0;
 
-			SSE2_MOVQ_XMM_to_M64((uptr)&cpuRegs.GPR.r[_Rd_].UL[0], reghi);
+			SSE2_MOVQ_XMM_to_M64((uptr)&cpuRegs.GPR[_Rd_].UL[0], reghi);
 
 			if( xmmregs[regd].mode & MODE_WRITE ) {
-				SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[_Rd_].UL[2], regd);
+				SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[_Rd_].UL[2], regd);
 			}
 		}
 		else {
@@ -120,7 +120,7 @@ void recMFHILO(int hi)
 			}
 			else {
 				_deleteEEreg(_Rd_, 0);
-				SSE2_MOVQ_XMM_to_M64((uptr)&cpuRegs.GPR.r[ _Rd_ ].UD[ 0 ], reghi);
+				SSE2_MOVQ_XMM_to_M64((uptr)&cpuRegs.GPR[ _Rd_ ].UD[ 0 ], reghi);
 			}
 		}
 	}
@@ -132,10 +132,10 @@ void recMFHILO(int hi)
 			if( regd >= 0 ) {
 				if( EEINST_ISLIVE2(_Rd_) ) {
 					if( xmmregs[regd].mode & MODE_WRITE ) {
-						SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 2 ], regd);
+						SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 2 ], regd);
 					}
 					xmmregs[regd].inuse = 0;
-					MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UD[ 0 ], reghi);
+					MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UD[ 0 ], reghi);
 				}
 				else {
 					SetMMXstate();
@@ -152,7 +152,7 @@ void recMFHILO(int hi)
 				}
 				else {
 					_deleteEEreg(_Rd_, 0);
-					MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UD[ 0 ], reghi);
+					MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UD[ 0 ], reghi);
 				}
 			}
 		}
@@ -172,8 +172,8 @@ void recMFHILO(int hi)
 					_deleteEEreg(_Rd_, 0);
 					MOV32MtoR( EAX, hi ? (uptr)&cpuRegs.HI.UL[ 0 ] : (uptr)&cpuRegs.LO.UL[ 0 ]);
 					MOV32MtoR( EDX, hi ? (uptr)&cpuRegs.HI.UL[ 1 ] : (uptr)&cpuRegs.LO.UL[ 1 ]);
-					MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-					MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+					MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+					MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 				}
 			}
 		}
@@ -225,7 +225,7 @@ void recMTHILO(int hi)
 			}
 			else {
 				_flushConstReg(_Rs_);
-				SSE_MOVLPS_M64_to_XMM(reghi, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UD[ 0 ]);
+				SSE_MOVLPS_M64_to_XMM(reghi, (uptr)&cpuRegs.GPR[ _Rs_ ].UD[ 0 ]);
 				xmmregs[reghi].mode |= MODE_WRITE;
 			}
 		}
@@ -247,7 +247,7 @@ void recMTHILO(int hi)
 				}
 				else {
 					_flushConstReg(_Rs_);
-					MOVQMtoR(reghi, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UD[ 0 ]);
+					MOVQMtoR(reghi, (uptr)&cpuRegs.GPR[ _Rs_ ].UD[ 0 ]);
 				}
 			}
 		}
@@ -270,8 +270,8 @@ void recMTHILO(int hi)
 					else {
 						_eeMoveGPRtoR(ECX, _Rs_);
 						_flushEEreg(_Rs_);
-						MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-						MOV32MtoR( EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
+						MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+						MOV32MtoR( EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
 						MOV32RtoM( addrhilo, EAX );
 						MOV32RtoM( addrhilo+4, EDX );
 					}
@@ -322,7 +322,7 @@ void recMFHILO1(int hi)
 		}
 		else {
 			_deleteEEreg(_Rd_, 0);
-			SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[ _Rd_ ].UD[ 0 ], reghi);
+			SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[ _Rd_ ].UD[ 0 ], reghi);
 		}
 	}
 	else {
@@ -348,8 +348,8 @@ void recMFHILO1(int hi)
 				_deleteEEreg(_Rd_, 0);
 				MOV32MtoR( EAX, hi ? (uptr)&cpuRegs.HI.UL[ 2 ] : (uptr)&cpuRegs.LO.UL[ 2 ]);
 				MOV32MtoR( EDX, hi ? (uptr)&cpuRegs.HI.UL[ 3 ] : (uptr)&cpuRegs.LO.UL[ 3 ]);
-				MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-				MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+				MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+				MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 			}
 		}
 	}
@@ -372,7 +372,7 @@ void recMTHILO1(int hi)
 		}
 		else {
 			_flushEEreg(_Rs_);
-			SSE2_PUNPCKLQDQ_M128_to_XMM(reghi, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UD[ 0 ]);
+			SSE2_PUNPCKLQDQ_M128_to_XMM(reghi, (uptr)&cpuRegs.GPR[ _Rs_ ].UD[ 0 ]);
 		}
 	}
 	else {
@@ -393,8 +393,8 @@ void recMTHILO1(int hi)
 				}
 				else {
 					_flushEEreg(_Rs_);
-					MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-					MOV32MtoR( EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
+					MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+					MOV32MtoR( EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
 					MOV32RtoM( addrhilo+8, EAX );
 					MOV32RtoM( addrhilo+12, EDX );
 				}
@@ -433,12 +433,12 @@ void recMOVZtemp_const()
 
 void recMOVZtemp_consts(int info)
 {
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
-	OR32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
+	OR32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 	j8Ptr[ 0 ] = JNZ8( 0 );
 
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
 
 	x86SetJ8( j8Ptr[ 0 ] );
 }
@@ -448,15 +448,15 @@ void recMOVZtemp_constt(int info)
 	// Fixme: MMX problem
 	if(0/* _hasFreeXMMreg() */) {
 		int t0reg = _allocMMXreg(-1, MMX_TEMP, 0);
-		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], t0reg);
+		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], t0reg);
 		_freeMMXreg(t0reg);
 	}
 	else {
-		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX);
+		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX);
 	}
 }
 
@@ -468,20 +468,20 @@ void recMOVZtemp_(int info)
 	if(0/* _hasFreeXMMreg() */)
 		t0reg = _allocMMXreg(-1, MMX_TEMP, 0);
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
-	OR32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
+	OR32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 	j8Ptr[ 0 ] = JNZ8( 0 );
 
 	if( t0reg >= 0 ) {
-		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], t0reg);
+		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], t0reg);
 		_freeMMXreg(t0reg);
 	}
 	else {
-		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX);
+		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX);
 	}
 
 	x86SetJ8( j8Ptr[ 0 ] );
@@ -512,12 +512,12 @@ void recMOVNtemp_const()
 
 void recMOVNtemp_consts(int info)
 {
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
-	OR32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
+	OR32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 	j8Ptr[ 0 ] = JZ8( 0 );
 
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0] );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1] );
 
 	x86SetJ8( j8Ptr[ 0 ] );
 }
@@ -527,15 +527,15 @@ void recMOVNtemp_constt(int info)
 	// Fixme: MMX problem
 	if(0/* _hasFreeXMMreg() */) {
 		int t0reg = _allocMMXreg(-1, MMX_TEMP, 0);
-		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], t0reg);
+		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], t0reg);
 		_freeMMXreg(t0reg);
 	}
 	else {
-		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX);
+		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX);
 	}
 }
 
@@ -547,20 +547,20 @@ void recMOVNtemp_(int info)
 	if(0/* _hasFreeXMMreg() */)
 		t0reg = _allocMMXreg(-1, MMX_TEMP, 0);
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
-	OR32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
+	OR32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 	j8Ptr[ 0 ] = JZ8( 0 );
 
 	if( t0reg >= 0 ) {
-		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], t0reg);
+		MOVQMtoR(t0reg, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], t0reg);
 		_freeMMXreg(t0reg);
 	}
 	else {
-		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ]);
-		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ]);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX);
-		MOV32RtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX);
+		MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ]);
+		MOV32MtoR(EDX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ]);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX);
+		MOV32RtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX);
 	}
 
 	x86SetJ8( j8Ptr[ 0 ] );

--- a/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
+++ b/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
@@ -100,8 +100,8 @@ void recWritebackHILO(int info, int writed, int upper)
 			_deleteEEreg(_Rd_, 0);
 
 			if( !savedlo ) CDQ();
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 		}
 	}
 
@@ -190,17 +190,17 @@ void recWritebackHILOMMX(int info, int regsource, int writed, int upper)
 					xmmregs[regd].mode |= MODE_WRITE;
 				}
 				else {
-					MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], regsource);
+					MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], regsource);
 
 					if( xmmregs[regd].mode & MODE_WRITE ) {
-						SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR.r[_Rd_].UL[2], regd);
+						SSE_MOVHPS_XMM_to_M64((uptr)&cpuRegs.GPR[_Rd_].UL[2], regd);
 					}
 
 					xmmregs[regd].inuse = 0;
 				}
 			}
 			else {
-				MOVQRtoM((uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], regsource);
+				MOVQRtoM((uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], regsource);
 			}
 		}
 	}
@@ -308,15 +308,15 @@ void recMULTsuper(int info, int upper, int process)
 {
 	if( process & PROCESS_CONSTS ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 	else if( process & PROCESS_CONSTT) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 
 	recWritebackHILO(info, 1, upper);
@@ -397,15 +397,15 @@ void recMULTUsuper(int info, int upper, int process)
 {
 	if( process & PROCESS_CONSTS ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 	else if( process & PROCESS_CONSTT) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 
 	recWritebackHILO(info, 1, upper);
@@ -512,12 +512,12 @@ void recDIVsuper(int info, int sign, int upper, int process)
 	if( process & PROCESS_CONSTT )
 		MOV32ItoR( ECX, g_cpuConstRegs[_Rt_].UL[0] );
 	else
-		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 
 	if( process & PROCESS_CONSTS )
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
 	else
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 
 	u8 *end1;
 	if (sign)  //test for overflow (x86 will just throw an exception)
@@ -681,8 +681,8 @@ void recMADD()
 		if( _Rd_) {
 			_eeOnWriteReg(_Rd_, 1);
 			_deleteEEreg(_Rd_, 0);
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 		}
 
 		MOV32RtoM( (uptr)&cpuRegs.LO.UL[0], EAX );
@@ -704,15 +704,15 @@ void recMADD()
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 	else if ( GPR_IS_CONST1(_Rt_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 
 	MOV32RtoR( ECX, EDX );
@@ -722,8 +722,8 @@ void recMADD()
 	if( _Rd_ ) {
 		_eeOnWriteReg(_Rd_, 1);
 		_deleteEEreg(_Rd_, 0);
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 	}
 
 	MOV32RtoM( (uptr)&cpuRegs.LO.UL[0], EAX );
@@ -753,8 +753,8 @@ void recMADDU()
 		if( _Rd_) {
 			_eeOnWriteReg(_Rd_, 1);
 			_deleteEEreg(_Rd_, 0);
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 		}
 
 		MOV32RtoM( (uptr)&cpuRegs.LO.UL[0], EAX );
@@ -776,15 +776,15 @@ void recMADDU()
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 	else if ( GPR_IS_CONST1(_Rt_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 
 	MOV32RtoR( ECX, EDX );
@@ -794,8 +794,8 @@ void recMADDU()
 	if( _Rd_ ) {
 		_eeOnWriteReg(_Rd_, 1);
 		_deleteEEreg(_Rd_, 0);
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 	}
 
 	MOV32RtoM( (uptr)&cpuRegs.LO.UL[0], EAX );
@@ -823,8 +823,8 @@ void recMADD1()
 		if( _Rd_) {
 			_eeOnWriteReg(_Rd_, 1);
 			_deleteEEreg(_Rd_, 0);
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 		}
 
 		MOV32RtoM( (uptr)&cpuRegs.LO.UL[2], EAX );
@@ -846,15 +846,15 @@ void recMADD1()
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 	else if ( GPR_IS_CONST1(_Rt_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-		IMUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+		IMUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 
 	MOV32RtoR( ECX, EDX );
@@ -864,8 +864,8 @@ void recMADD1()
 	if( _Rd_ ) {
 		_eeOnWriteReg(_Rd_, 1);
 		_deleteEEreg(_Rd_, 0);
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 	}
 
 	MOV32RtoM( (uptr)&cpuRegs.LO.UL[2], EAX );
@@ -895,8 +895,8 @@ void recMADDU1()
 		if( _Rd_) {
 			_eeOnWriteReg(_Rd_, 1);
 			_deleteEEreg(_Rd_, 0);
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-			MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+			MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 		}
 
 		MOV32RtoM( (uptr)&cpuRegs.LO.UL[2], EAX );
@@ -918,15 +918,15 @@ void recMADDU1()
 
 	if( GPR_IS_CONST1(_Rs_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rs_].UL[0] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 	else if ( GPR_IS_CONST1(_Rt_) ) {
 		MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 	}
 	else {
-		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
-		MUL32M( (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+		MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
+		MUL32M( (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	}
 
 	MOV32RtoR( ECX, EDX );
@@ -936,8 +936,8 @@ void recMADDU1()
 	if( _Rd_ ) {
 		_eeOnWriteReg(_Rd_, 1);
 		_deleteEEreg(_Rd_, 0);
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-		MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+		MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 	}
 
 	MOV32RtoM( (uptr)&cpuRegs.LO.UL[2], EAX );

--- a/pcsx2/x86/ix86-32/iR5900Shift.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Shift.cpp
@@ -63,15 +63,15 @@ void recSLLs_(int info, int sa)
 {
 	pxAssert( !(info & PROCESS_EE_XMM) );
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( sa != 0 )
 	{
 		SHL32ItoR( EAX, sa );
 	}
 
 	CDQ( );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 }
 
 void recSLL_(int info)
@@ -91,12 +91,12 @@ void recSRLs_(int info, int sa)
 {
 	pxAssert( !(info & PROCESS_EE_XMM) );
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( sa != 0 ) SHR32ItoR( EAX, sa);
 
 	CDQ( );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 }
 
 void recSRL_(int info)
@@ -116,12 +116,12 @@ void recSRAs_(int info, int sa)
 {
 	pxAssert( !(info & PROCESS_EE_XMM) );
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( sa != 0 ) SAR32ItoR( EAX, sa);
 
 	CDQ();
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 }
 
 void recSRA_(int info)
@@ -239,13 +239,13 @@ void recDSLL32s_(int info, int sa)
 {
 	pxAssert( !(info & PROCESS_EE_XMM) );
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( sa != 0 )
 	{
 		SHL32ItoR( EAX, sa );
 	}
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], 0 );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EAX );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], 0 );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EAX );
 
 }
 
@@ -266,11 +266,11 @@ void recDSRL32s_(int info, int sa)
 {
 	pxAssert( !(info & PROCESS_EE_XMM) );
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 	if ( sa != 0 ) SHR32ItoR( EAX, sa );
 
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32ItoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], 0 );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32ItoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], 0 );
 }
 
 void recDSRL32_(int info)
@@ -290,12 +290,12 @@ void recDSRA32s_(int info, int sa)
 {
 	pxAssert( !(info & PROCESS_EE_XMM) );
 
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ] );
 	CDQ( );
 	if ( sa != 0 ) SAR32ItoR( EAX, sa );
 
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 
 }
 
@@ -324,7 +324,7 @@ int recSetShiftV(int info, int* rsreg, int* rtreg, int* rdreg, int* rstemp, int 
 	SetMMXstate();
 
 	*rstemp = _allocMMXreg(-1, MMX_TEMP, 0);
-	MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[_Rs_].UL[0]);
+	MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[_Rs_].UL[0]);
 	AND32ItoR(EAX, shift64?0x3f:0x1f);
 	MOVD32RtoMMX(*rstemp, EAX);
 	*rsreg = *rstemp;
@@ -340,7 +340,7 @@ void recSetConstShiftV(int info, int* rsreg, int* rdreg, int* rstemp, int shift6
 	SetMMXstate();
 
 	*rstemp = _allocMMXreg(-1, MMX_TEMP, 0);
-	MOV32MtoR(EAX, (uptr)&cpuRegs.GPR.r[_Rs_].UL[0]);
+	MOV32MtoR(EAX, (uptr)&cpuRegs.GPR[_Rs_].UL[0]);
 	AND32ItoR(EAX, shift64?0x3f:0x1f);
 	MOVD32RtoMMX(*rstemp, EAX);
 	*rsreg = *rstemp;
@@ -361,7 +361,7 @@ void recSLLV_consts(int info)
 
 void recSLLV_constt(int info)
 {
-	MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+	MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 
 	MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
 	AND32ItoR( ECX, 0x1f );
@@ -372,16 +372,16 @@ void recSLLV_constt(int info)
 
 void recSLLV_(int info)
 {
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( _Rs_ != 0 )
 	{
-		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 		AND32ItoR( ECX, 0x1f );
 		SHL32CLtoR( EAX );
 	}
 	CDQ();
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 }
 
 EERECOMPILE_CODE0(SLLV, XMMINFO_READS|XMMINFO_READT|XMMINFO_WRITED);
@@ -399,7 +399,7 @@ void recSRLV_consts(int info)
 
 void recSRLV_constt(int info)
 {
-	MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+	MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 
 	MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
 	AND32ItoR( ECX, 0x1f );
@@ -410,16 +410,16 @@ void recSRLV_constt(int info)
 
 void recSRLV_(int info)
 {
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( _Rs_ != 0 )
 	{
-		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 		AND32ItoR( ECX, 0x1f );
 		SHR32CLtoR( EAX );
 	}
 	CDQ( );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 }
 
 EERECOMPILE_CODE0(SRLV, XMMINFO_READS|XMMINFO_READT|XMMINFO_WRITED);
@@ -437,7 +437,7 @@ void recSRAV_consts(int info)
 
 void recSRAV_constt(int info)
 {
-	MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+	MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 
 	MOV32ItoR( EAX, g_cpuConstRegs[_Rt_].UL[0] );
 	AND32ItoR( ECX, 0x1f );
@@ -448,16 +448,16 @@ void recSRAV_constt(int info)
 
 void recSRAV_(int info)
 {
-	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ] );
+	MOV32MtoR( EAX, (uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ] );
 	if ( _Rs_ != 0 )
 	{
-		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ] );
+		MOV32MtoR( ECX, (uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ] );
 		AND32ItoR( ECX, 0x1f );
 		SAR32CLtoR( EAX );
 	}
 	CDQ( );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 0 ], EAX );
-	MOV32RtoM( (uptr)&cpuRegs.GPR.r[ _Rd_ ].UL[ 1 ], EDX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 0 ], EAX );
+	MOV32RtoM( (uptr)&cpuRegs.GPR[ _Rd_ ].UL[ 1 ], EDX );
 }
 
 EERECOMPILE_CODE0(SRAV, XMMINFO_READS|XMMINFO_READT|XMMINFO_WRITED);
@@ -480,7 +480,7 @@ void recDSLLV_constt(int info)
 	int rsreg, rdreg, rstemp = -1;
 	recSetConstShiftV(info, &rsreg, &rdreg, &rstemp, 1);
 
-	MOVQMtoR(rdreg, (uptr)&cpuRegs.GPR.r[_Rt_]);
+	MOVQMtoR(rdreg, (uptr)&cpuRegs.GPR[_Rt_]);
 	PSLLQRtoR(rdreg, rsreg);
 	if( rstemp != -1 ) _freeMMXreg(rstemp);
 }
@@ -514,7 +514,7 @@ void recDSRLV_constt(int info)
 	int rsreg, rdreg, rstemp = -1;
 	recSetConstShiftV(info, &rsreg, &rdreg, &rstemp, 1);
 
-	MOVQMtoR(rdreg, (uptr)&cpuRegs.GPR.r[_Rt_]);
+	MOVQMtoR(rdreg, (uptr)&cpuRegs.GPR[_Rt_]);
 	PSRLQRtoR(rdreg, rsreg);
 	if( rstemp != -1 ) _freeMMXreg(rstemp);
 }
@@ -551,7 +551,7 @@ void recDSRAV_constt(int info)
 
 	recSetConstShiftV(info, &rsreg, &rdreg, &rstemp, 1);
 
-	MOVQMtoR(rdreg, (uptr)&cpuRegs.GPR.r[_Rt_]);
+	MOVQMtoR(rdreg, (uptr)&cpuRegs.GPR[_Rt_]);
 	PXORRtoR(t0reg, t0reg);
 
 	// calc high bit

--- a/pcsx2/x86/ix86-32/iR5900Templates.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Templates.cpp
@@ -523,15 +523,15 @@ int eeRecompileCodeXMM(int xmminfo)
 	// flush consts
 	if( xmminfo & XMMINFO_READT ) {
 		if( GPR_IS_CONST1( _Rt_ ) && !(g_cpuFlushedConstReg&(1<<_Rt_)) ) {
-			MOV32ItoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 0 ], g_cpuConstRegs[_Rt_].UL[0]);
-			MOV32ItoM((uptr)&cpuRegs.GPR.r[ _Rt_ ].UL[ 1 ], g_cpuConstRegs[_Rt_].UL[1]);
+			MOV32ItoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 0 ], g_cpuConstRegs[_Rt_].UL[0]);
+			MOV32ItoM((uptr)&cpuRegs.GPR[ _Rt_ ].UL[ 1 ], g_cpuConstRegs[_Rt_].UL[1]);
 			g_cpuFlushedConstReg |= (1<<_Rt_);
 		}
 	}
 	if( xmminfo & XMMINFO_READS) {
 		if( GPR_IS_CONST1( _Rs_ ) && !(g_cpuFlushedConstReg&(1<<_Rs_)) ) {
-			MOV32ItoM((uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0]);
-			MOV32ItoM((uptr)&cpuRegs.GPR.r[ _Rs_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1]);
+			MOV32ItoM((uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 0 ], g_cpuConstRegs[_Rs_].UL[0]);
+			MOV32ItoM((uptr)&cpuRegs.GPR[ _Rs_ ].UL[ 1 ], g_cpuConstRegs[_Rs_].UL[1]);
 			g_cpuFlushedConstReg |= (1<<_Rs_);
 		}
 	}

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -258,7 +258,7 @@ void TEST_FBRST_RESET(FnType_Void* resetFunct, int vuIndex) {
 	xTEST(eax, (vuIndex) ? 0x200 : 0x002);
 	xForwardJZ8 skip;
 		xCALL(resetFunct);
-		xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+		xMOV(eax, ptr32[&cpuRegs.GPR[_Rt_].UL[0]]);
 	skip.SetTarget();
 }
 
@@ -277,13 +277,13 @@ static void recCFC2() {
 	else xMOV(eax, ptr32[&vu0Regs.VI[_Rd_].UL]);
 
 	// FixMe: Should R-Reg have upper 9 bits 0?
-	xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]], eax);
+	xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[0]], eax);
 
 	if (_Rd_ >= 16) {
 		xCDQ(); // Sign Extend
-		xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]], edx);
+		xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[1]], edx);
 	}
-	else xMOV(ptr32[&cpuRegs.GPR.r[_Rt_].UL[1]], 0);
+	else xMOV(ptr32[&cpuRegs.GPR[_Rt_].UL[1]], 0);
 
 	// FixMe: I think this is needed, but not sure how it works
 	_eeOnWriteReg(_Rt_, 1);
@@ -300,20 +300,20 @@ static void recCTC2() {
 		case REG_MAC_FLAG: case REG_TPC:
 		case REG_VPU_STAT: break; // Read Only Regs
 		case REG_R:
-			xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+			xMOV(eax, ptr32[&cpuRegs.GPR[_Rt_].UL[0]]);
 			xOR (eax, 0x3f800000);
 			xMOV(ptr32[&vu0Regs.VI[REG_R].UL], eax);
 			break;
 		case REG_STATUS_FLAG:
 			if (_Rt_) { // Denormalizes flag into eax (gprT1)
-				mVUallocSFLAGd(&cpuRegs.GPR.r[_Rt_].UL[0]);
+				mVUallocSFLAGd(&cpuRegs.GPR[_Rt_].UL[0]);
 				xMOV(ptr32[&vu0Regs.VI[_Rd_].UL], eax);
 			}
 			else xMOV(ptr32[&vu0Regs.VI[_Rd_].UL], 0);
 			break;
 		case REG_CMSAR1:	// Execute VU1 Micro SubRoutine
 			if (_Rt_) {
-				xMOV(ecx, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+				xMOV(ecx, ptr32[&cpuRegs.GPR[_Rt_].UL[0]]);
 			}
 			else xXOR(ecx, ecx);
 			xCALL(vu1ExecMicro);
@@ -324,7 +324,7 @@ static void recCTC2() {
 				xMOV(ptr32[&vu0Regs.VI[REG_FBRST].UL], 0); 
 				return;
 			}
-			else xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+			else xMOV(eax, ptr32[&cpuRegs.GPR[_Rt_].UL[0]]);
 
 			TEST_FBRST_RESET(vu0ResetRegs, 0);
 			TEST_FBRST_RESET(vu1ResetRegs, 1);
@@ -353,7 +353,7 @@ static void recQMFC2() {
 	_eeOnWriteReg(_Rt_, 0);
 
 	xMOVAPS(xmmT1, ptr128[&vu0Regs.VF[_Rd_]]);
-	xMOVAPS(ptr128[&cpuRegs.GPR.r[_Rt_]], xmmT1);
+	xMOVAPS(ptr128[&cpuRegs.GPR[_Rt_]], xmmT1);
 }
 
 static void recQMTC2() {
@@ -363,7 +363,7 @@ static void recQMTC2() {
 	if (!_Rd_) return;
 	iFlushCall(FLUSH_EVERYTHING);
 
-	xMOVAPS(xmmT1, ptr128[&cpuRegs.GPR.r[_Rt_]]);
+	xMOVAPS(xmmT1, ptr128[&cpuRegs.GPR[_Rt_]]);
 	xMOVAPS(ptr128[&vu0Regs.VF[_Rd_]], xmmT1);
 }
 


### PR DESCRIPTION
Regs can now be accessed directly by name or by array index when specifying the reg type.
This removes a lot of the 'fluff'.

Any discussion on renaming of regs is welcome.

Only GPR and CP0 use named entries. The names are quite different and relate to actual reg functions, so hard to be confused. Even so, perhaps the names should be changed in some instances.
It would likely be better as an enum.