### PR TITLE
Allow to share writing to the ISO through an ini option

### DIFF
--- a/pcsx2/AsyncFileReader.h
+++ b/pcsx2/AsyncFileReader.h
@@ -75,8 +75,10 @@ class FlatFileReader : public AsyncFileReader
 	io_context_t m_aio_context;
 #endif
 
+	bool shareWrite;
+
 public:
-	FlatFileReader(void);
+	FlatFileReader(bool shareWrite = false);
 	virtual ~FlatFileReader(void);
 
 	virtual bool Open(const wxString& fileName);

--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -201,7 +201,10 @@ bool InputIsoFile::Open( const wxString& srcfile, bool testOnly )
 	Close();
 	m_filename = srcfile;
 	
-	m_reader = new FlatFileReader();
+	// Allow write sharing of the iso based on the ini settings.
+	// Mostly useful for romhacking, where the disc is frequently
+	// changed and the emulator would block modifications
+	m_reader = new FlatFileReader(EmuConfig.CdvdShareWrite);
 	m_reader->Open(m_filename);
 
 	bool isBlockdump, isCompressed = false;

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -433,6 +433,7 @@ struct Pcsx2Config
 		bool
 			CdvdVerboseReads	:1,		// enables cdvd read activity verbosely dumped to the console
 			CdvdDumpBlocks		:1,		// enables cdvd block dumping
+			CdvdShareWrite		:1,		// allows the iso to be modified while it's loaded
 			EnablePatches		:1,		// enables patch detection and application
 			EnableCheats		:1,		// enables cheat detection and application
 			EnableWideScreenPatches		:1,

--- a/pcsx2/Linux/LnxFlatFileReader.cpp
+++ b/pcsx2/Linux/LnxFlatFileReader.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "AsyncFileReader.h"
 
-FlatFileReader::FlatFileReader(void)
+FlatFileReader::FlatFileReader(bool shareWrite) : shareWrite(shareWrite)
 {
 	m_blocksize = 2048;
 	m_fd = 0;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -410,6 +410,7 @@ void Pcsx2Config::LoadSave( IniInterface& ini )
 
 	IniBitBool( CdvdVerboseReads );
 	IniBitBool( CdvdDumpBlocks );
+	IniBitBool( CdvdShareWrite );
 	IniBitBool( EnablePatches );
 	IniBitBool( EnableCheats );
 	IniBitBool( EnableWideScreenPatches );

--- a/pcsx2/windows/FlatFileReaderWindows.cpp
+++ b/pcsx2/windows/FlatFileReaderWindows.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "AsyncFileReader.h"
 
-FlatFileReader::FlatFileReader(void)
+FlatFileReader::FlatFileReader(bool shareWrite) : shareWrite(shareWrite)
 {
 	m_blocksize = 2048;
 	hOverlappedFile = INVALID_HANDLE_VALUE;
@@ -35,10 +35,14 @@ bool FlatFileReader::Open(const wxString& fileName)
 
 	hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 
+	DWORD shareMode = FILE_SHARE_READ;
+	if (shareWrite)
+		shareMode |= FILE_SHARE_WRITE;
+
 	hOverlappedFile = CreateFile(
 		fileName,
 		GENERIC_READ,
-		FILE_SHARE_READ,
+		shareMode,
 		NULL,
 		OPEN_EXISTING,
 		FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED,


### PR DESCRIPTION
This helps for romhacking, because you would otherwise need to pause the emulation to do any changes. It's an ini setting and disabled by default. Anyone using it needs to manually enable it on their own risk.

The license change is due to inconsistent line endings in the file. I have no idea how to implement i on Linux, unfortunately.
