### PR TITLE
"!64BIT_BUILD" is a variable name. Changed to "NOT 64BIT_BUILD"

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -121,7 +121,7 @@ if(wxWidgets_FOUND)
     if(Linux)
         # Force the use of 32 bit library configuration on
         # 64 bits machine with 32 bits library in /usr/lib32
-        if(_ARCH_64 AND !64BIT_BUILD)
+        if(_ARCH_64 AND NOT 64BIT_BUILD)
             ## There is no guarantee that wx-config is a link to a 32 bits library. So you need to force the destinity
             # Library can go into 3 path major paths (+ multiarch but you will see that later when implementation is done)
             # 1/ /usr/lib32 (32 bits only)


### PR DESCRIPTION
 "!64BIT_BUILD" is a variable name. Changed to "NOT 64BIT_BUILD" which is the negation of the 64BIT_BUILD variable defined in BuildParameters.cmake. Fixes broken compilation on multilib systems.
