### PR TITLE
Remove a depencency on float constants from the SuperVU core.

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -181,6 +181,7 @@ set(pcsx2Headers
 	Dump.h
 	GameDatabase.h
 	Elfheader.h
+	FP_Consts.h
 	Gif.h
 	Gif_Unit.h
 	GS.h

--- a/pcsx2/FP_Consts.h
+++ b/pcsx2/FP_Consts.h
@@ -1,0 +1,66 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "Pcsx2Defs.h"
+
+static const __aligned16 float g_fones[8]  = {1.0f, 1.0f, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
+static const __aligned16 u32 g_mask[4]     = {0x007fffff, 0x007fffff, 0x007fffff, 0x007fffff};
+static const __aligned16 u32 g_minvals[4]  = {0xff7fffff, 0xff7fffff, 0xff7fffff, 0xff7fffff};
+static const __aligned16 u32 g_maxvals[4]  = {0x7f7fffff, 0x7f7fffff, 0x7f7fffff, 0x7f7fffff};
+static const __aligned16 u32 g_clip[8]     = {0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff,
+                                              0x80000000, 0x80000000, 0x80000000, 0x80000000};
+
+static const __aligned(64) u32 g_ones[4]   = {0x00000001, 0x00000001, 0x00000001, 0x00000001};
+
+static const __aligned16 u32 g_minvals_XYZW[16][4] =
+{
+	{ 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff }, //0000
+	{ 0xffffffff, 0xffffffff, 0xffffffff, 0xff7fffff }, //0001
+	{ 0xffffffff, 0xffffffff, 0xff7fffff, 0xffffffff }, //0010
+	{ 0xffffffff, 0xffffffff, 0xff7fffff, 0xff7fffff }, //0011
+	{ 0xffffffff, 0xff7fffff, 0xffffffff, 0xffffffff }, //0100
+	{ 0xffffffff, 0xff7fffff, 0xffffffff, 0xff7fffff }, //0101
+	{ 0xffffffff, 0xff7fffff, 0xff7fffff, 0xffffffff }, //0110
+	{ 0xffffffff, 0xff7fffff, 0xff7fffff, 0xff7fffff }, //0111
+	{ 0xff7fffff, 0xffffffff, 0xffffffff, 0xffffffff }, //1000
+	{ 0xff7fffff, 0xffffffff, 0xffffffff, 0xff7fffff }, //1001
+	{ 0xff7fffff, 0xffffffff, 0xff7fffff, 0xffffffff }, //1010
+	{ 0xff7fffff, 0xffffffff, 0xff7fffff, 0xff7fffff }, //1011
+	{ 0xff7fffff, 0xff7fffff, 0xffffffff, 0xffffffff }, //1100
+	{ 0xff7fffff, 0xff7fffff, 0xffffffff, 0xff7fffff }, //1101
+	{ 0xff7fffff, 0xff7fffff, 0xff7fffff, 0xffffffff }, //1110
+	{ 0xff7fffff, 0xff7fffff, 0xff7fffff, 0xff7fffff }, //1111
+};
+
+static const __aligned16 u32 g_maxvals_XYZW[16][4] =
+{
+	{ 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff }, //0000
+	{ 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7f7fffff }, //0001
+	{ 0x7fffffff, 0x7fffffff, 0x7f7fffff, 0x7fffffff }, //0010
+	{ 0x7fffffff, 0x7fffffff, 0x7f7fffff, 0x7f7fffff }, //0011
+	{ 0x7fffffff, 0x7f7fffff, 0x7fffffff, 0x7fffffff }, //0100
+	{ 0x7fffffff, 0x7f7fffff, 0x7fffffff, 0x7f7fffff }, //0101
+	{ 0x7fffffff, 0x7f7fffff, 0x7f7fffff, 0x7fffffff }, //0110
+	{ 0x7fffffff, 0x7f7fffff, 0x7f7fffff, 0x7f7fffff }, //0111
+	{ 0x7f7fffff, 0x7fffffff, 0x7fffffff, 0x7fffffff }, //1000
+	{ 0x7f7fffff, 0x7fffffff, 0x7fffffff, 0x7f7fffff }, //1001
+	{ 0x7f7fffff, 0x7fffffff, 0x7f7fffff, 0x7fffffff }, //1010
+	{ 0x7f7fffff, 0x7fffffff, 0x7f7fffff, 0x7f7fffff }, //1011
+	{ 0x7f7fffff, 0x7f7fffff, 0x7fffffff, 0x7fffffff }, //1100
+	{ 0x7f7fffff, 0x7f7fffff, 0x7fffffff, 0x7f7fffff }, //1101
+	{ 0x7f7fffff, 0x7f7fffff, 0x7f7fffff, 0x7fffffff }, //1110
+	{ 0x7f7fffff, 0x7f7fffff, 0x7f7fffff, 0x7f7fffff }, //1111
+};

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -736,6 +736,7 @@
     <ClInclude Include="..\..\Common.h" />
     <ClInclude Include="..\..\Config.h" />
     <ClInclude Include="..\..\Dump.h" />
+    <ClInclude Include="..\..\FP_Consts.h" />
     <ClInclude Include="..\..\IopCommon.h" />
     <ClInclude Include="..\..\NakedAsm.h" />
     <ClInclude Include="..\..\Plugins.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -879,6 +879,9 @@
     <ClInclude Include="..\..\Dump.h">
       <Filter>System\Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\FP_Consts.h">
+      <Filter>System\Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\IopCommon.h">
       <Filter>System\Include</Filter>
     </ClInclude>

--- a/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj
@@ -723,6 +723,7 @@
     <ClInclude Include="..\..\Common.h" />
     <ClInclude Include="..\..\Config.h" />
     <ClInclude Include="..\..\Dump.h" />
+    <ClInclude Include="..\..\FP_Consts.h" />
     <ClInclude Include="..\..\IopCommon.h" />
     <ClInclude Include="..\..\NakedAsm.h" />
     <ClInclude Include="..\..\Plugins.h" />

--- a/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj.filters
@@ -876,6 +876,9 @@
     <ClInclude Include="..\..\Dump.h">
       <Filter>System\Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\FP_Consts.h">
+      <Filter>System\Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\IopCommon.h">
       <Filter>System\Include</Filter>
     </ClInclude>

--- a/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj
@@ -723,6 +723,7 @@
     <ClInclude Include="..\..\Common.h" />
     <ClInclude Include="..\..\Config.h" />
     <ClInclude Include="..\..\Dump.h" />
+    <ClInclude Include="..\..\FP_Consts.h" />
     <ClInclude Include="..\..\IopCommon.h" />
     <ClInclude Include="..\..\NakedAsm.h" />
     <ClInclude Include="..\..\Plugins.h" />

--- a/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj.filters
@@ -876,6 +876,9 @@
     <ClInclude Include="..\..\Dump.h">
       <Filter>System\Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\FP_Consts.h">
+      <Filter>System\Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\IopCommon.h">
       <Filter>System\Include</Filter>
     </ClInclude>

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -20,7 +20,7 @@
 #include "R5900OpcodeTables.h"
 #include "iR5900.h"
 #include "iFPU.h"
-#include "sVU_Micro.h"
+#include "FP_Consts.h"
 
 using namespace x86Emitter;
 

--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -21,7 +21,7 @@
 #include "x86emitter/x86emitter.h"
 #include "iR5900.h"
 #include "iFPU.h"
-#include "sVU_Micro.h"
+#include "FP_Consts.h"
 
 /* This is a version of the FPU that emulates an exponent of 0xff and overflow/underflow flags */
 

--- a/pcsx2/x86/sVU_Lower.cpp
+++ b/pcsx2/x86/sVU_Lower.cpp
@@ -122,7 +122,7 @@ void recVUMI_DIV(VURegs *VU, int info)
 		SSE_XORPS_XMM_to_XMM(EEREC_TEMP, EEREC_T);
 		_vuFlipRegSS_xyzw(EEREC_T, _Ftf_);
 
-		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 		SSE_ORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_maxvals[0]); // If division by zero, then EEREC_TEMP = +/- fmax
 
 		bjmp32 = JMP32(0);
@@ -167,7 +167,7 @@ void recVUMI_SQRT( VURegs *VU, int info )
 		OR32ItoM(VU_VI_ADDR(REG_STATUS_FLAG, 2), 0x410); // Invalid Flag - Negative number sqrt
 	x86SetJ8(pjmp);
 
-	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)const_clip); // Do a cardinal sqrt
+	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)g_clip); // Do a cardinal sqrt
 	if (CHECK_VU_OVERFLOW) SSE_MINSS_M32_to_XMM(EEREC_TEMP, (uptr)g_maxvals); // Clamp infinities (only need to do positive clamp since EEREC_TEMP is positive)
 	SSE_SQRTSS_XMM_to_XMM(EEREC_TEMP, EEREC_TEMP);
 	SSE_MOVSS_XMM_to_M32(VU_VI_ADDR(REG_Q, 0), EEREC_TEMP);
@@ -196,7 +196,7 @@ void recVUMI_RSQRT(VURegs *VU, int info)
 		OR32ItoM(VU_VI_ADDR(REG_STATUS_FLAG, 2), 0x410); // Invalid Flag - Negative number sqrt
 	x86SetJ8(ajmp8);
 
-	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)const_clip); // Do a cardinal sqrt
+	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)g_clip); // Do a cardinal sqrt
 	if (CHECK_VU_OVERFLOW) SSE_MINSS_M32_to_XMM(EEREC_TEMP, (uptr)g_maxvals); // Clamp Infinities to Fmax
 	SSE_SQRTSS_XMM_to_XMM(EEREC_TEMP, EEREC_TEMP);
 
@@ -233,7 +233,7 @@ void recVUMI_RSQRT(VURegs *VU, int info)
 			OR32ItoM( VU_VI_ADDR(REG_STATUS_FLAG, 2), 0x820 ); // Zero divide (only when not 0/0)
 		x86SetJ8(qjmp2);
 
-		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 		SSE_ORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_maxvals[0]); // If division by zero, then EEREC_TEMP = +/- fmax
 		SSE_MOVSS_XMM_to_M32(VU_VI_ADDR(REG_Q, 0), EEREC_TEMP);
 		bjmp8 = JMP8(0);
@@ -1125,7 +1125,7 @@ void recVUMI_RINIT(VURegs *VU, int info)
 		_deleteX86reg(X86TYPE_VI|(VU==&VU1?X86TYPE_VU1:0), REG_R, 2);
 		_unpackVFSS_xyzw(EEREC_TEMP, EEREC_S, _Fsf_);
 
-		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)s_mask);
+		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)g_mask);
 		SSE_ORPS_M128_to_XMM(EEREC_TEMP, (uptr)VU_ONE);
 		SSE_MOVSS_XMM_to_M32(VU_REGR_ADDR, EEREC_TEMP);
 	}
@@ -1223,8 +1223,8 @@ void recVUMI_RXOR( VURegs *VU, int info )
 		_unpackVFSS_xyzw(EEREC_TEMP, EEREC_S, _Fsf_);
 
 		SSE_XORPS_M128_to_XMM(EEREC_TEMP, VU_REGR_ADDR);
-		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)s_mask);
-		SSE_ORPS_M128_to_XMM(EEREC_TEMP, (uptr)s_fones);
+		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)g_mask);
+		SSE_ORPS_M128_to_XMM(EEREC_TEMP, (uptr)g_fones);
 		SSE_MOVSS_XMM_to_M32(VU_REGR_ADDR, EEREC_TEMP);
 	}
 	else {
@@ -1793,7 +1793,7 @@ void recVUMI_ESQRT( VURegs *VU, int info )
 
 	//Console.WriteLn("VU1: ESQRT");
 	_unpackVFSS_xyzw(EEREC_TEMP, EEREC_S, _Fsf_);
-	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)const_clip); // abs(x)
+	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)g_clip); // abs(x)
 	if (CHECK_VU_OVERFLOW) SSE_MINSS_M32_to_XMM(EEREC_TEMP, (uptr)g_maxvals); // Only need to do positive clamp
 	SSE_SQRTSS_XMM_to_XMM(EEREC_TEMP, EEREC_TEMP);
 
@@ -1813,7 +1813,7 @@ void recVUMI_ERSQRT( VURegs *VU, int info )
 	//Console.WriteLn("VU1: ERSQRT");
 
 	_unpackVFSS_xyzw(EEREC_TEMP, EEREC_S, _Fsf_);
-	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)const_clip); // abs(x)
+	SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)g_clip); // abs(x)
 	SSE_MINSS_M32_to_XMM(EEREC_TEMP, (uptr)g_maxvals); // Clamp Infinities to Fmax
 	SSE_SQRTSS_XMM_to_XMM(EEREC_TEMP, EEREC_TEMP); // SQRT(abs(x))
 

--- a/pcsx2/x86/sVU_Micro.cpp
+++ b/pcsx2/x86/sVU_Micro.cpp
@@ -85,54 +85,6 @@
 //------------------------------------------------------------------
 int vucycle;
 
-const __aligned16 float s_fones[8]	= {1.0f, 1.0f, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
-const __aligned16 u32 s_mask[4]		= {0x007fffff, 0x007fffff, 0x007fffff, 0x007fffff};
-const __aligned16 u32 s_expmask[4]	= {0x7f800000, 0x7f800000, 0x7f800000, 0x7f800000};
-const __aligned16 u32 g_minvals[4]	= {0xff7fffff, 0xff7fffff, 0xff7fffff, 0xff7fffff};
-const __aligned16 u32 g_maxvals[4]	= {0x7f7fffff, 0x7f7fffff, 0x7f7fffff, 0x7f7fffff};
-const __aligned16 u32 const_clip[8]	= {0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff,
-									   0x80000000, 0x80000000, 0x80000000, 0x80000000};
-
-const __aligned(64) u32 g_ones[4]	= {0x00000001, 0x00000001, 0x00000001, 0x00000001};
-
-const __aligned16 u32 g_minvals_XYZW[16][4] =
-{
-   { 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff }, //0000
-   { 0xffffffff, 0xffffffff, 0xffffffff, 0xff7fffff }, //0001
-   { 0xffffffff, 0xffffffff, 0xff7fffff, 0xffffffff }, //0010
-   { 0xffffffff, 0xffffffff, 0xff7fffff, 0xff7fffff }, //0011
-   { 0xffffffff, 0xff7fffff, 0xffffffff, 0xffffffff }, //0100
-   { 0xffffffff, 0xff7fffff, 0xffffffff, 0xff7fffff }, //0101
-   { 0xffffffff, 0xff7fffff, 0xff7fffff, 0xffffffff }, //0110
-   { 0xffffffff, 0xff7fffff, 0xff7fffff, 0xff7fffff }, //0111
-   { 0xff7fffff, 0xffffffff, 0xffffffff, 0xffffffff }, //1000
-   { 0xff7fffff, 0xffffffff, 0xffffffff, 0xff7fffff }, //1001
-   { 0xff7fffff, 0xffffffff, 0xff7fffff, 0xffffffff }, //1010
-   { 0xff7fffff, 0xffffffff, 0xff7fffff, 0xff7fffff }, //1011
-   { 0xff7fffff, 0xff7fffff, 0xffffffff, 0xffffffff }, //1100
-   { 0xff7fffff, 0xff7fffff, 0xffffffff, 0xff7fffff }, //1101
-   { 0xff7fffff, 0xff7fffff, 0xff7fffff, 0xffffffff }, //1110
-   { 0xff7fffff, 0xff7fffff, 0xff7fffff, 0xff7fffff }, //1111
-};
-const __aligned16 u32 g_maxvals_XYZW[16][4] =
-{
-   { 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff }, //0000
-   { 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7f7fffff }, //0001
-   { 0x7fffffff, 0x7fffffff, 0x7f7fffff, 0x7fffffff }, //0010
-   { 0x7fffffff, 0x7fffffff, 0x7f7fffff, 0x7f7fffff }, //0011
-   { 0x7fffffff, 0x7f7fffff, 0x7fffffff, 0x7fffffff }, //0100
-   { 0x7fffffff, 0x7f7fffff, 0x7fffffff, 0x7f7fffff }, //0101
-   { 0x7fffffff, 0x7f7fffff, 0x7f7fffff, 0x7fffffff }, //0110
-   { 0x7fffffff, 0x7f7fffff, 0x7f7fffff, 0x7f7fffff }, //0111
-   { 0x7f7fffff, 0x7fffffff, 0x7fffffff, 0x7fffffff }, //1000
-   { 0x7f7fffff, 0x7fffffff, 0x7fffffff, 0x7f7fffff }, //1001
-   { 0x7f7fffff, 0x7fffffff, 0x7f7fffff, 0x7fffffff }, //1010
-   { 0x7f7fffff, 0x7fffffff, 0x7f7fffff, 0x7f7fffff }, //1011
-   { 0x7f7fffff, 0x7f7fffff, 0x7fffffff, 0x7fffffff }, //1100
-   { 0x7f7fffff, 0x7f7fffff, 0x7fffffff, 0x7f7fffff }, //1101
-   { 0x7f7fffff, 0x7f7fffff, 0x7f7fffff, 0x7fffffff }, //1110
-   { 0x7f7fffff, 0x7f7fffff, 0x7f7fffff, 0x7f7fffff }, //1111
-};
 //------------------------------------------------------------------
 
 //------------------------------------------------------------------
@@ -1008,7 +960,7 @@ void vFloat1c(int regd, int regTemp) { //1000
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_SHUFPS_XMM_to_XMM(regd, regd, 0x27);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1028,7 +980,7 @@ void vFloat2c(int regd, int regTemp) { //0100
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_SHUFPS_XMM_to_XMM(regd, regd, 0xc6);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1057,7 +1009,7 @@ void vFloat3c(int regd, int regTemp) { //1100
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_SHUFPS_XMM_to_XMM(regd, regd, 0xc6);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1080,7 +1032,7 @@ void vFloat4c(int regd, int regTemp) { //0010
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1117,7 +1069,7 @@ void vFloat5c(int regd, int regTemp) { //1010
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1157,7 +1109,7 @@ void vFloat6c(int regd, int regTemp) { //0110
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1204,7 +1156,7 @@ void vFloat7c(int regd, int regTemp) { //1110
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
@@ -1225,7 +1177,7 @@ void vFloat7c_useEAX(int regd, int regTemp) { //1110 //EAX is Modified
 	else {
 		SSE2_MOVD_XMM_to_R(EAX, regd);
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINPS_M128_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXPS_M128_to_XMM(regd, (uptr)g_minvals);
 		SSE_ORPS_XMM_to_XMM(regd, regTemp);
@@ -1243,7 +1195,7 @@ void vFloat8c(int regd, int regTemp) { //0001
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE_ORPS_XMM_to_XMM(regd, regTemp);
@@ -1276,7 +1228,7 @@ void vFloat9c(int regd, int regTemp) { //1001
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE_SHUFPS_XMM_to_XMM(regd, regd, 0x27);
@@ -1313,7 +1265,7 @@ void vFloat10c(int regd, int regTemp) { //0101
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE_SHUFPS_XMM_to_XMM(regd, regd, 0xc6);
@@ -1361,7 +1313,7 @@ void vFloat11c(int regd, int regTemp) { //1101
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE_SHUFPS_XMM_to_XMM(regd, regd, 0xc6);
@@ -1382,7 +1334,7 @@ void vFloat11c_useEAX(int regd, int regTemp) { //1101 // EAX is modified
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
 		SSE2_MOVD_XMM_to_R(EAX, regd);
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINPS_M128_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXPS_M128_to_XMM(regd, (uptr)g_minvals);
 		SSE_ORPS_XMM_to_XMM(regd, regTemp);
@@ -1411,7 +1363,7 @@ void vFloat12c(int regd, int regTemp) { //0011
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
@@ -1459,7 +1411,7 @@ void vFloat13c(int regd, int regTemp) { //1011
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
@@ -1480,7 +1432,7 @@ void vFloat13c_useEAX(int regd, int regTemp) { //1011 // EAX is modified
 		SSE2_PSHUFD_XMM_to_XMM(regd, regd, 0xc6);
 		SSE2_MOVD_XMM_to_R(EAX, regd);
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINPS_M128_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXPS_M128_to_XMM(regd, (uptr)g_minvals);
 		SSE_ORPS_XMM_to_XMM(regd, regTemp);
@@ -1527,7 +1479,7 @@ void vFloat14c(int regd, int regTemp) { //0111
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINSS_M32_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXSS_M32_to_XMM(regd, (uptr)g_minvals);
 		SSE2_PSHUFLW_XMM_to_XMM(regd, regd, 0x4e);
@@ -1548,7 +1500,7 @@ void vFloat14c_useEAX(int regd, int regTemp) { //0111 // EAX is modified
 		SSE2_PSHUFD_XMM_to_XMM(regd, regd, 0x27);
 		SSE2_MOVD_XMM_to_R(EAX, regd);
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINPS_M128_to_XMM(regd, (uptr)g_maxvals);
 		SSE_MAXPS_M128_to_XMM(regd, (uptr)g_minvals);
 		SSE_ORPS_XMM_to_XMM(regd, regTemp);
@@ -1567,7 +1519,7 @@ void vFloat15c(int regd, int regTemp) { //1111
 	}
 	else {
 		SSE_MOVAPS_XMM_to_XMM(regTemp, regd);
-		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&const_clip[4]);
+		SSE_ANDPS_M128_to_XMM(regTemp, (uptr)&g_clip[4]);
 		SSE_MINPS_M128_to_XMM(regd, (uptr)&g_maxvals[0]);
 		SSE_MAXPS_M128_to_XMM(regd, (uptr)&g_minvals[0]);
 		SSE_ORPS_XMM_to_XMM(regd, regTemp);

--- a/pcsx2/x86/sVU_Micro.h
+++ b/pcsx2/x86/sVU_Micro.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "VUmicro.h"
+#include "FP_Consts.h"
 
 extern u32 vudump;
 
@@ -56,12 +57,6 @@ extern vFloat vFloats1_useEAX[16];
 extern vFloat vFloats2[16];
 extern vFloat vFloats4[16];
 extern vFloat vFloats4_useEAX[16];
-extern const __aligned16 float s_fones[8];
-extern const __aligned16 u32 s_mask[4];
-extern const __aligned16 u32 s_expmask[4];
-extern const __aligned16 u32 g_minvals[4];
-extern const __aligned16 u32 g_maxvals[4];
-extern const __aligned16 u32 const_clip[8];
 
 u32 GetVIAddr(VURegs * VU, int reg, int read, int info);
 int _vuGetTempXMMreg(int info);

--- a/pcsx2/x86/sVU_Upper.cpp
+++ b/pcsx2/x86/sVU_Upper.cpp
@@ -1052,14 +1052,14 @@ void recVUMI_SUB_iq(VURegs *VU, uptr addr, int info)
 			}
 			else {
 				// negate
-				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 				SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_S);
 				VU_MERGE_REGS(EEREC_D, EEREC_TEMP);
 			}
 		}
 		else {
 			if( EEREC_D == EEREC_TEMP ) {
-				SSE_XORPS_M128_to_XMM(EEREC_D, (uptr)&const_clip[4]);
+				SSE_XORPS_M128_to_XMM(EEREC_D, (uptr)&g_clip[4]);
 				SSE_ADDPS_XMM_to_XMM(EEREC_D, EEREC_S);
 			}
 			else {
@@ -1118,14 +1118,14 @@ void recVUMI_SUB_xyzw(VURegs *VU, int xyzw, int info)
 			}
 			else {
 				// negate
-				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 				SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_S);
 				VU_MERGE_REGS(EEREC_D, EEREC_TEMP);
 			}
 		}
 		else {
 			if( EEREC_D == EEREC_TEMP ) {
-				SSE_XORPS_M128_to_XMM(EEREC_D, (uptr)&const_clip[4]);
+				SSE_XORPS_M128_to_XMM(EEREC_D, (uptr)&g_clip[4]);
 				SSE_ADDPS_XMM_to_XMM(EEREC_D, EEREC_S);
 			}
 			else {
@@ -1241,7 +1241,7 @@ void recVUMI_SUBA_iq(VURegs *VU, uptr addr, int info)
 			}
 			else {
 				// negate
-				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 				SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_S);
 				VU_MERGE_REGS(EEREC_ACC, EEREC_TEMP);
 			}
@@ -1288,7 +1288,7 @@ void recVUMI_SUBA_xyzw(VURegs *VU, int xyzw, int info)
 			}
 			else {
 				// negate
-				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+				SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 				SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_S);
 				VU_MERGE_REGS(EEREC_ACC, EEREC_TEMP);
 			}
@@ -1942,7 +1942,7 @@ void recVUMI_MSUB_toD(VURegs *VU, int regd, int info)
 			_freeXMMreg(t1reg);
 		}
 		else {
-			SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 			SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_ACC);
 			VU_MERGE_REGS(regd, EEREC_TEMP);
 		}
@@ -1953,21 +1953,21 @@ void recVUMI_MSUB_toD(VURegs *VU, int regd, int info)
 			SSE_MULPS_XMM_to_XMM(regd, EEREC_T);
 			if (CHECK_VU_EXTRA_OVERFLOW) { vuFloat_useEAX( info, regd, _X_Y_Z_W ); }
 			SSE_SUBPS_XMM_to_XMM(regd, EEREC_ACC);
-			SSE_XORPS_M128_to_XMM(regd, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(regd, (uptr)&g_clip[4]);
 		}
 		else if( regd == EEREC_T ) {
 			assert( regd != EEREC_ACC );
 			SSE_MULPS_XMM_to_XMM(regd, EEREC_S);
 			if (CHECK_VU_EXTRA_OVERFLOW) { vuFloat_useEAX( info, regd, _X_Y_Z_W ); }
 			SSE_SUBPS_XMM_to_XMM(regd, EEREC_ACC);
-			SSE_XORPS_M128_to_XMM(regd, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(regd, (uptr)&g_clip[4]);
 		}
 		else if( regd == EEREC_TEMP ) {
 			SSE_MOVAPS_XMM_to_XMM(regd, EEREC_S);
 			SSE_MULPS_XMM_to_XMM(regd, EEREC_T);
 			if (CHECK_VU_EXTRA_OVERFLOW) { vuFloat_useEAX( info, regd, _X_Y_Z_W ); }
 			SSE_SUBPS_XMM_to_XMM(regd, EEREC_ACC);
-			SSE_XORPS_M128_to_XMM(regd, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(regd, (uptr)&g_clip[4]);
 		}
 		else {
 			SSE_MOVAPS_XMM_to_XMM(EEREC_TEMP, EEREC_S);
@@ -1999,7 +1999,7 @@ void recVUMI_MSUB_temp_toD(VURegs *VU, int regd, int info)
 			_freeXMMreg(t1reg);
 		}
 		else {
-			SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 			SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_ACC);
 			VU_MERGE_REGS(regd, EEREC_TEMP);
 		}
@@ -2014,13 +2014,13 @@ void recVUMI_MSUB_temp_toD(VURegs *VU, int regd, int info)
 			SSE_MULPS_XMM_to_XMM(regd, EEREC_TEMP);
 			if (CHECK_VU_EXTRA_OVERFLOW) { vuFloat_useEAX( info, regd, _X_Y_Z_W ); }
 			SSE_SUBPS_XMM_to_XMM(regd, EEREC_ACC);
-			SSE_XORPS_M128_to_XMM(regd, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(regd, (uptr)&g_clip[4]);
 		}
 		else if( regd == EEREC_TEMP ) {
 			SSE_MULPS_XMM_to_XMM(regd, EEREC_S);
 			if (CHECK_VU_EXTRA_OVERFLOW) { vuFloat_useEAX( info, regd, _X_Y_Z_W ); }
 			SSE_SUBPS_XMM_to_XMM(regd, EEREC_ACC);
-			SSE_XORPS_M128_to_XMM(regd, (uptr)&const_clip[4]);
+			SSE_XORPS_M128_to_XMM(regd, (uptr)&g_clip[4]);
 		}
 		else {
 			SSE_MOVAPS_XMM_to_XMM(regd, EEREC_ACC);
@@ -2382,7 +2382,7 @@ void recVUMI_MAX_xyzw(VURegs *VU, int xyzw, int info)
 				SSE_MOVSS_XMM_to_XMM(EEREC_D, EEREC_TEMP);
 			}
 			else {
-				SSE_MOVSS_M32_to_XMM(EEREC_TEMP, (uptr)s_fones);
+				SSE_MOVSS_M32_to_XMM(EEREC_TEMP, (uptr)g_fones);
 				SSE_MOVSS_XMM_to_XMM(EEREC_D, EEREC_TEMP);
 			}
 		}
@@ -2391,13 +2391,13 @@ void recVUMI_MAX_xyzw(VURegs *VU, int xyzw, int info)
 				if( _X_Y_Z_W & 1 ) SSE_MOVAPS_M128_to_XMM(EEREC_TEMP, (uptr)&VU->VF[0].UL[0]); // w included, so insert the whole reg
 				else SSE_XORPS_XMM_to_XMM(EEREC_TEMP, EEREC_TEMP); // w not included, can zero out
 			}
-			else SSE_MOVAPS_M128_to_XMM(EEREC_TEMP, (uptr)s_fones);
+			else SSE_MOVAPS_M128_to_XMM(EEREC_TEMP, (uptr)g_fones);
 			VU_MERGE_REGS(EEREC_D, EEREC_TEMP);
 		}
 		else {
 			//If VF0.w isnt chosen as the constant, then its going to be MAX( 0, VF0 ), so the result is VF0
 			if( xyzw < 3 ) { SSE_MOVAPS_M128_to_XMM(EEREC_D, (uptr)&VU->VF[0].UL[0]); }
-			else SSE_MOVAPS_M128_to_XMM(EEREC_D, (uptr)s_fones);
+			else SSE_MOVAPS_M128_to_XMM(EEREC_D, (uptr)g_fones);
 		}
 		return;
 	}
@@ -2676,7 +2676,7 @@ void recVUMI_OPMSUB( VURegs *VU, int info )
 	SSE_MULPS_XMM_to_XMM(EEREC_TEMP, EEREC_T);
 
 	// negate and add
-	SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[4]);
+	SSE_XORPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[4]);
 	SSE_ADDPS_XMM_to_XMM(EEREC_TEMP, EEREC_ACC);
 	VU_MERGE_REGS_CUSTOM(EEREC_D, EEREC_TEMP, 14);
 
@@ -2711,12 +2711,12 @@ void recVUMI_FTOI_Saturate(int rec_s, int rec_t, int rec_tmp1, int rec_tmp2)
 	//Duplicate the xor'd sign bit to the whole value
 	//FFFF FFFF for positive,  0 for negative
 	SSE_MOVAPS_XMM_to_XMM(rec_tmp1, rec_s);
-	SSE2_PXOR_M128_to_XMM(rec_tmp1, (uptr)&const_clip[4]);
+	SSE2_PXOR_M128_to_XMM(rec_tmp1, (uptr)&g_clip[4]);
 	SSE2_PSRAD_I8_to_XMM(rec_tmp1, 31);
 
 	//Create mask: 0 where !=8000 0000
 	SSE_MOVAPS_XMM_to_XMM(rec_tmp2, rec_t);
-	SSE2_PCMPEQD_M128_to_XMM(rec_tmp2, (uptr)&const_clip[4]);
+	SSE2_PCMPEQD_M128_to_XMM(rec_tmp2, (uptr)&g_clip[4]);
 
 	//AND the mask w/ the edit values
 	SSE_ANDPS_XMM_to_XMM(rec_tmp1, rec_tmp2);
@@ -3027,14 +3027,14 @@ void recVUMI_CLIP(VURegs *VU, int info)
 	_freeXMMreg(t2reg); // but if they've been used since then, then free them. (just doing this incase :p (cottonvibes))
 
 	if( _Ft_ == 0 ) {
-		SSE_MOVAPS_M128_to_XMM(EEREC_TEMP, (uptr)&s_fones[0]); // all 1s
-		SSE_MOVAPS_M128_to_XMM(t1reg, (uptr)&s_fones[4]);
+		SSE_MOVAPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_fones[0]); // all 1s
+		SSE_MOVAPS_M128_to_XMM(t1reg, (uptr)&g_fones[4]);
 	}
 	else {
 		_unpackVF_xyzw(EEREC_TEMP, EEREC_T, 3);
-		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)&const_clip[0]);
+		SSE_ANDPS_M128_to_XMM(EEREC_TEMP, (uptr)&g_clip[0]);
 		SSE_MOVAPS_XMM_to_XMM(t1reg, EEREC_TEMP);
-		SSE_ORPS_M128_to_XMM(t1reg, (uptr)&const_clip[4]);
+		SSE_ORPS_M128_to_XMM(t1reg, (uptr)&g_clip[4]);
 	}
 
 	MOV32MtoR(EAX, prevclipaddr);


### PR DESCRIPTION
iFPU.cpp and iFPUd.cpp depended on float arrays that were provided in sVU_Micro.cpp.
In the case that x86_64 will be not compiling SuperVU this will cause issues.
Remove the dependency early.
Moves the lot of float arrays that SuperVU provides to a header.
That way when other sources are cleaned later they can also use these constants
