### PR TITLE
Remove some unused code such as data moves and tags in iCore.

### DIFF
--- a/pcsx2/x86/iCore.h
+++ b/pcsx2/x86/iCore.h
@@ -35,7 +35,6 @@
 #define MODE_NOFRAME	0x40	// when allocating x86regs, don't use ebp reg
 #define MODE_8BITREG	0x80	// when allocating x86regs, use only eax, ecx, edx, and ebx
 
-//#define PROCESS_EE_MMX 0x01 // removed
 #define PROCESS_EE_XMM 0x02
 
 // currently only used in FPU
@@ -191,9 +190,6 @@ void _signExtendSFtoM(u32 mem);
 // a negative shift is for sign extension
 int _signExtendXMMtoM(u32 to, x86SSERegType from, int candestroy); // returns true if reg destroyed
 
-static const int MEM_MMXTAG = 0x0800;	// mmreg is mmxreg
-static const int MEM_XMMTAG = 0x8000;	// mmreg is xmmreg
-
 //////////////////////
 // Instruction Info //
 //////////////////////
@@ -318,9 +314,6 @@ int _signExtendMtoMMX(x86MMXRegType to, u32 mem);
 int _signExtendGPRMMXtoMMX(x86MMXRegType to, u32 gprreg, x86MMXRegType from, u32 gprfromreg);
 int _allocCheckGPRtoMMX(EEINST* pinst, int reg, int mode);
 
-void _recMove128RmOffsettoM(u32 to, u32 offset);
-void _recMove128MtoRmOffset(u32 offset, u32 from);
-
 // returns new index of reg, lower 32 bits already in mmx
 // shift is used when the data is in the top bits of the mmx reg to begin with
 // a negative shift is for sign extension
@@ -372,9 +365,6 @@ extern u16 x86FpuState;
 
 //////////////////////////////////////////////////////////////////////////
 // Utility Functions -- that should probably be part of the Emitter.
-
-// Moves 128 bits of data using EAX/EDX (used by iCOP2 only currently)
-extern void _recMove128MtoM(u32 to, u32 from);
 
 // op = 0, and
 // op = 1, or

--- a/pcsx2/x86/ix86-32/iCore-32.cpp
+++ b/pcsx2/x86/ix86-32/iCore-32.cpp
@@ -923,46 +923,6 @@ int _allocCheckGPRtoMMX(EEINST* pinst, int reg, int mode)
 	return _checkMMXreg(MMX_GPR+reg, mode);
 }
 
-// fixme - yay stupid?  This sucks, and is used from iCOP2.cpp only.
-// Surely there is a better way!
-void _recMove128MtoM(u32 to, u32 from)
-{
-	MOV32MtoR(EAX, from);
-	MOV32MtoR(EDX, from+4);
-	MOV32RtoM(to, EAX);
-	MOV32RtoM(to+4, EDX);
-	MOV32MtoR(EAX, from+8);
-	MOV32MtoR(EDX, from+12);
-	MOV32RtoM(to+8, EAX);
-	MOV32RtoM(to+12, EDX);
-}
-
-// fixme - see above function!
-void _recMove128RmOffsettoM(u32 to, u32 offset)
-{
-	MOV32RmtoR(EAX, ECX, offset);
-	MOV32RmtoR(EDX, ECX, offset+4);
-	MOV32RtoM(to, EAX);
-	MOV32RtoM(to+4, EDX);
-	MOV32RmtoR(EAX, ECX, offset+8);
-	MOV32RmtoR(EDX, ECX, offset+12);
-	MOV32RtoM(to+8, EAX);
-	MOV32RtoM(to+12, EDX);
-}
-
-// fixme - see above function again!
-void _recMove128MtoRmOffset(u32 offset, u32 from)
-{
-	MOV32MtoR(EAX, from);
-	MOV32MtoR(EDX, from+4);
-	MOV32RtoRm(ECX, EAX, offset);
-	MOV32RtoRm(ECX, EDX, offset+4);
-	MOV32MtoR(EAX, from+8);
-	MOV32MtoR(EDX, from+12);
-	MOV32RtoRm(ECX, EAX, offset+8);
-	MOV32RtoRm(ECX, EDX, offset+12);
-}
-
 static const __aligned16 u32 s_ones[2] = {0xffffffff, 0xffffffff};
 
 void LogicalOpRtoR(x86MMXRegType to, x86MMXRegType from, int op)

--- a/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
+++ b/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
@@ -91,7 +91,6 @@ void recWritebackHILO(int info, int writed, int upper)
 				regd = _checkXMMreg(XMMTYPE_GPRREG, _Rd_, MODE_WRITE|MODE_READ);
 				if( regd >= 0 ) {
 					SSE_MOVLPS_M64_to_XMM(regd, loaddr);
-					regd |= MEM_XMMTAG;
 				}
 			}
 		}


### PR DESCRIPTION
The code was sitting there only serving to confuse people. The tags were a way of setting an 'isXMMreg' inside a function and the values actually didn't mean anything.
