### PR TITLE
Cleanup of Sif{0,1,2}.cpp

### DIFF
--- a/pcsx2/Sif.h
+++ b/pcsx2/Sif.h
@@ -18,9 +18,6 @@
 
 static const int FIFO_SIF_W = 128;
 
-// psxdev: was here on the initial psx merge
-//static u32 sif2fifostat = (u32&)eeHw[0xf380];
-
 // Despite its name, this is actually the IOP's DMAtag, which itself also contains
 // the EE's DMAtag in its upper 64 bits.  Note that only the lower 24 bits of 'data' is
 // the IOP's chain transfer address (loaded into MADR).  Bits 30 and 31 are transfer stop

--- a/pcsx2/Sif0.cpp
+++ b/pcsx2/Sif0.cpp
@@ -22,161 +22,6 @@
 
 _sif sif0;
 
-static bool done = false;
-
-static __fi void Sif0Init()
-{
-	SIF_LOG("SIF0 DMA start...");
-	done = false;
-	sif0.ee.cycles = 0;
-	sif0.iop.cycles = 0;
-}
-
-// Write from Fifo to EE.
-static __fi bool WriteFifoToEE()
-{
-	const int readSize = std::min((s32)sif0ch.qwc, sif0.fifo.size >> 2);
-
-	tDMA_TAG *ptag;
-
-	//SIF_LOG(" EE SIF doing transfer %04Xqw to %08X", readSize, sif0ch.madr);
-	SIF_LOG("Write Fifo to EE: ----------- %lX of %lX", readSize << 2, sif0ch.qwc << 2);
-
-	ptag = sif0ch.getAddr(sif0ch.madr, DMAC_SIF0, true);
-	if (ptag == NULL)
-	{
-		DevCon.Warning("Write Fifo to EE: ptag == NULL");
-		return false;
-	}
-
-	sif0.fifo.read((u32*)ptag, readSize << 2);
-
-	// Clearing handled by vtlb memory protection and manual blocks.
-	//Cpu->Clear(sif0ch.madr, readSize*4);
-
-	sif0ch.madr += readSize << 4;
-	sif0.ee.cycles += readSize;	// fixme : BIAS is factored in above
-	sif0ch.qwc -= readSize;
-
-	return true;
-}
-
-// Write IOP to Fifo.
-static __fi bool WriteIOPtoFifo()
-{
-	// There's some data ready to transfer into the fifo..
-	const int writeSize = std::min(sif0.iop.counter, sif0.fifo.sif_free());
-
-	SIF_LOG("Write IOP to Fifo: +++++++++++ %lX of %lX", writeSize, sif0.iop.counter);
-
-	sif0.fifo.write((u32*)iopPhysMem(hw_dma9.madr), writeSize);
-	hw_dma9.madr += writeSize << 2;
-
-	// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords).
-	sif0.iop.cycles += (writeSize >> 2)/* * BIAS*/;		// fixme : should be >> 4
-	sif0.iop.counter -= writeSize;
-
-	return true;
-}
-
-// Read Fifo into an ee tag, transfer it to sif0ch, and process it.
-static __fi bool ProcessEETag()
-{
-	static __aligned16 u32 tag[4];
-	tDMA_TAG& ptag(*(tDMA_TAG*)tag);
-
-	sif0.fifo.read((u32*)&tag[0], 4); // Tag
-	SIF_LOG("SIF0 EE read tag: %x %x %x %x", tag[0], tag[1], tag[2], tag[3]);
-
-	sif0ch.unsafeTransfer(&ptag);
-	sif0ch.madr = tag[1];
-
-	SIF_LOG("SIF0 EE dest chain tag madr:%08X qwc:%04X id:%X irq:%d(%08X_%08X)",
-		sif0ch.madr, sif0ch.qwc, ptag.ID, ptag.IRQ, tag[1], tag[0]);
-
-	if (sif0ch.chcr.TIE && ptag.IRQ)
-	{
-		//Console.WriteLn("SIF0 TIE");
-		sif0.ee.end = true;
-	}
-
-	switch (ptag.ID)
-	{
-		case TAG_CNT:	break;
-
-		case TAG_CNTS:
-			if (dmacRegs.ctrl.STS == STS_SIF0)
-				dmacRegs.stadr.ADDR = sif0ch.madr + (sif0ch.qwc * 16);
-			break;
-
-		case TAG_END:
-			sif0.ee.end = true;
-			break;
-	}
-	return true;
-}
-
-// Read Fifo into an iop tag, and transfer it to hw_dma9. And presumably process it.
-static __fi bool ProcessIOPTag()
-{
-	// Process DMA tag at hw_dma9.tadr
-	sif0.iop.data = *(sifData *)iopPhysMem(hw_dma9.tadr);
-	sif0.iop.data.words = (sif0.iop.data.words + 3) & 0xfffffffc; // Round up to nearest 4.
-
-	// send the EE's side of the DMAtag.  The tag is only 64 bits, with the upper 64 bits
-	// ignored by the EE.
-
-	sif0.fifo.write((u32*)iopPhysMem(hw_dma9.tadr + 8), 2);
-	sif0.fifo.writePos = (sif0.fifo.writePos + 2) & (FIFO_SIF_W - 1);		// iggy on the upper 64.
-	sif0.fifo.size += 2;
-
-	hw_dma9.tadr += 16; ///hw_dma9.madr + 16 + sif0.sifData.words << 2;
-
-	// We're only copying the first 24 bits.  Bits 30 and 31 (checked below) are Stop/IRQ bits.
-	hw_dma9.madr = sif0data & 0xFFFFFF;
-	sif0.iop.counter = sif0words;
-
-	// IOP tags have an IRQ bit and an End of Transfer bit:
-	if (sif0tag.IRQ  || (sif0tag.ID & 4)) sif0.iop.end = true;
-	SIF_LOG("SIF0 IOP Tag: madr=%lx, tadr=%lx, counter=%lx (%08X_%08X)", hw_dma9.madr, hw_dma9.tadr, sif0.iop.counter, sif0words, sif0data);
-
-	return true;
-}
-
-// Stop transferring ee, and signal an interrupt.
-static __fi void EndEE()
-{
-	SIF_LOG("Sif0: End EE");
-	sif0.ee.end = false;
-	sif0.ee.busy = false;
-	if (sif0.ee.cycles == 0)
-	{
-		SIF_LOG("SIF0 EE: cycles = 0");
-		sif0.ee.cycles = 1;
-	}
-
-	CPU_INT(DMAC_SIF0, sif0.ee.cycles*BIAS);
-}
-
-// Stop transferring iop, and signal an interrupt.
-static __fi void EndIOP()
-{
-	SIF_LOG("Sif0: End IOP");
-	sif0data = 0;
-	sif0.iop.end = false;
-	sif0.iop.busy = false;
-
-	if (sif0.iop.cycles == 0)
-	{
-		DevCon.Warning("SIF0 IOP: cycles = 0");
-		sif0.iop.cycles = 1;
-	}
-	// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords)
-	// So when we're all done, the equation looks like thus:
-	//PSX_INT(IopEvt_SIF0, ( ( sif0.iop.cycles*BIAS ) / 4 ) / 8);
-	PSX_INT(IopEvt_SIF0, sif0.iop.cycles);
-}
-
 // Handle the EE transfer.
 static __fi void HandleEETransfer()
 {
@@ -193,37 +38,71 @@ static __fi void HandleEETransfer()
 		DevCon.Warning("SIF0 stall control not properly implemented");
 	}
 
-	/*if (sif0ch.qwc == 0)
-		if (sif0ch.chcr.MOD == NORMAL_MODE)
-			if (!sif0.ee.end){
-				DevCon.Warning("sif0 irq prevented");
-				done = true;
-				return;
-			}*/
-
 	if (sif0ch.qwc <= 0)
 	{
 		if ((sif0ch.chcr.MOD == NORMAL_MODE) || sif0.ee.end)
 		{
-			// Stop transferring ee, and signal an interrupt.
-			done = true;
-			EndEE();
+			// Stop transferring EE and signal an interrupt.
+			SIF_LOG("Sif0: End EE");
+			sif0.ee.end = false;
+			sif0.ee.busy = false;
+			if (sif0.ee.cycles == 0)
+			{
+				SIF_LOG("SIF0 EE: cycles = 0");
+				sif0.ee.cycles = 1;
+			}
+
+			CPU_INT(DMAC_SIF0, sif0.ee.cycles*BIAS);
 		}
-		else if (sif0.fifo.size >= 4) // Read a tag
+		else if (sif0.fifo.size >= 4)
 		{
-			// Read Fifo into an ee tag, transfer it to sif0ch
-			// and process it.
-			ProcessEETag();
+			// Read Fifo into an EE tag, transfer it to sif0ch and process it.
+			static __aligned16 u32 tag[4];
+			tDMA_TAG& ptag(*(tDMA_TAG*)tag); // Read a tag
+
+			sif0.fifo.read((u32*)&tag[0], 4); // Tag
+			SIF_LOG("SIF0 EE read tag: %x %x %x %x", tag[0], tag[1], tag[2], tag[3]);
+
+			sif0ch.unsafeTransfer(&ptag);
+			sif0ch.madr = tag[1];
+
+			SIF_LOG("SIF0 EE dest chain tag madr:%08X qwc:%04X id:%X irq:%d(%08X_%08X)",
+				sif0ch.madr, sif0ch.qwc, ptag.ID, ptag.IRQ, tag[1], tag[0]);
+
+			if (ptag.ID == TAG_END || (sif0ch.chcr.TIE && ptag.IRQ))
+			{
+				sif0.ee.end = true;
+			}
+
+			if (ptag.ID == TAG_CNTS && dmacRegs.ctrl.STS == STS_SIF0)
+			{
+				dmacRegs.stadr.ADDR = sif0ch.madr + (sif0ch.qwc * 16);
+			}
 		}
 	}
 
-	if (sif0ch.qwc > 0) // If we're writing something, continue to do so.
+	// If we're writing something, continue to do so.
+	if (sif0ch.qwc > 0 && sif0.fifo.size > 0)
 	{
-		// Write from Fifo to EE.
-		if (sif0.fifo.size > 0)
+		const int readSize = std::min((s32)sif0ch.qwc, sif0.fifo.size >> 2);
+
+		//SIF_LOG(" EE SIF doing transfer %04Xqw to %08X", readSize, sif0ch.madr);
+		SIF_LOG("Write Fifo to EE: ----------- %lX of %lX", readSize << 2, sif0ch.qwc << 2);
+
+		tDMA_TAG *ptag = sif0ch.getAddr(sif0ch.madr, DMAC_SIF0, true);
+		if (ptag == NULL)
 		{
-			WriteFifoToEE();
+			DevCon.Warning("Write Fifo to EE: ptag == NULL");
+			return;
 		}
+
+		sif0.fifo.read((u32*)ptag, readSize << 2);
+
+		// Clearing madr is handled by vtlb memory protection and manual blocks.
+
+		sif0ch.madr += readSize << 4;
+		sif0.ee.cycles += readSize;	// fixme : BIAS is factored in above
+		sif0ch.qwc -= readSize;
 	}
 }
 
@@ -262,65 +141,91 @@ static __fi void HandleIOPTransfer()
 	{
 		if (sif0.iop.end)
 		{
-			// Stop transferring iop, and signal an interrupt.
-			done = true;
-			EndIOP();
+			// Stop transferring iop and signal an interrupt.
+			SIF_LOG("Sif0: End IOP");
+			sif0data = 0;
+			sif0.iop.end = false;
+			sif0.iop.busy = false;
+
+			if (sif0.iop.cycles == 0)
+			{
+				DevCon.Warning("SIF0 IOP: cycles = 0");
+				sif0.iop.cycles = 1;
+			}
+			// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords)
+			// So when we're all done, the equation looks like: ( ( sif0.iop.cycles*BIAS ) / 4 ) / 8
+			PSX_INT(IopEvt_SIF0, sif0.iop.cycles); 
 		}
 		else
 		{
-			// Read Fifo into an iop tag, and transfer it to hw_dma9.
-			// And presumably process it.
-			ProcessIOPTag();
+			// Read Fifo into an iop tag, transfer it to hw_dma9 and presumably process it.
+			sif0.iop.data = *(sifData *)iopPhysMem(hw_dma9.tadr); // DMA tag
+			sif0.iop.data.words = (sif0.iop.data.words + 3) & 0xfffffffc; // Round up to nearest 4.
+
+			// send the EE's DMAtag.  The tag is only 64 bits, with the upper 64 bits ignored by the EE.
+
+			sif0.fifo.write((u32*)iopPhysMem(hw_dma9.tadr + 8), 2);
+			sif0.fifo.writePos = (sif0.fifo.writePos + 2) & (FIFO_SIF_W - 1);		// ignore upper 64.
+			sif0.fifo.size += 2;
+
+			hw_dma9.tadr += 16; ///hw_dma9.madr + 16 + sif0.sifData.words << 2;
+
+			// We're only copying the first 24 bits.  Bits 30 and 31 (checked below) are Stop/IRQ bits.
+			hw_dma9.madr = sif0data & 0xFFFFFF;
+			sif0.iop.counter = sif0words;
+
+			// IOP tags have an IRQ bit and an End of Transfer bit:
+			if (sif0tag.IRQ  || (sif0tag.ID & 4))
+				sif0.iop.end = true;
+			SIF_LOG("SIF0 IOP Tag: madr=%lx, tadr=%lx, counter=%lx (%08X_%08X)", hw_dma9.madr, hw_dma9.tadr, sif0.iop.counter, sif0words, sif0data);
 		}
 	}
-	else
+	else if (sif0.fifo.sif_free() > 0)
 	{
-		// Write IOP to Fifo.
-		if (sif0.fifo.sif_free() > 0)
-		{
-			WriteIOPtoFifo();
-		}
+		// There's some data ready to transfer into the fifo..
+		const int writeSize = std::min(sif0.iop.counter, sif0.fifo.sif_free());
+
+		SIF_LOG("Write IOP to Fifo: +++++++++++ %lX of %lX", writeSize, sif0.iop.counter);
+
+		sif0.fifo.write((u32*)iopPhysMem(hw_dma9.madr), writeSize);
+		hw_dma9.madr += writeSize << 2;
+
+		// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords).
+		sif0.iop.cycles += (writeSize >> 2)/* * BIAS*/;		// fixme : should be >> 4
+		sif0.iop.counter -= writeSize;
 	}
-}
-
-static __fi void Sif0End()
-{
-	psHu32(SBUS_F240) &= ~0x20;
-	psHu32(SBUS_F240) &= ~0x2000;
-
-	DMA_LOG("SIF0 DMA End");
 }
 
 // Transfer IOP to EE, putting data in the fifo as an intermediate step.
 __fi void SIF0Dma()
 {
-	int BusyCheck = 0;
-	Sif0Init();
+	SIF_LOG("SIF0 DMA start...");
+	sif0.ee.cycles = 0;
+	sif0.iop.cycles = 0;
 
-	do
+	while (true)
 	{
-		//I realise this is very hacky in a way but its an easy way of checking if both are doing something
-		BusyCheck = 0;
+		// I realise this is very hacky in a way but its an easy way of checking if both are doing something
+		bool busyCheck = false;
 
-		if (sif0.iop.busy)
+		if (sif0.iop.busy && (sif0.fifo.sif_free() > 0 || (sif0.iop.end == true && sif0.iop.counter == 0)))
 		{
-			if(sif0.fifo.sif_free() > 0 || (sif0.iop.end == true && sif0.iop.counter == 0)) 
-			{
-				BusyCheck++;
-				HandleIOPTransfer();
-			}
+			busyCheck = true;
+			HandleIOPTransfer();
 		}
-		if (sif0.ee.busy)
+		if (sif0.ee.busy && (sif0.fifo.size >= 4 || (sif0.ee.end == true && sif0ch.qwc == 0)))
 		{
-			if(sif0.fifo.size >= 4 || (sif0.ee.end == true && sif0ch.qwc == 0)) 
-			{
-				BusyCheck++;
-				HandleEETransfer();
-			}
+			busyCheck = true;
+			HandleEETransfer();
 		}
-	} while (/*!done && */BusyCheck > 0); // Substituting (sif0.ee.busy || sif0.iop.busy) breaks things.
+		if (!busyCheck)
+			break;
+	}
 
-	Sif0End();
+	psHu32(SBUS_F240) &= ~0x20;
+	psHu32(SBUS_F240) &= ~0x2000;
+
+	SIF_LOG("SIF0 DMA End");
 }
 
 __fi void  sif0Interrupt()

--- a/pcsx2/Sif1.cpp
+++ b/pcsx2/Sif1.cpp
@@ -22,156 +22,6 @@
 
 _sif sif1;
 
-static bool done = false;
-
-static __fi void Sif1Init()
-{
-	SIF_LOG("SIF1 DMA start...");
-	done = false;
-	sif1.ee.cycles = 0;
-	sif1.iop.cycles = 0;
-}
-
-// Write from the EE to Fifo.
-static __fi bool WriteEEtoFifo()
-{
-	// There's some data ready to transfer into the fifo..
-
-	SIF_LOG("Sif 1: Write EE to Fifo");
-	const int writeSize = std::min((s32)sif1ch.qwc, sif1.fifo.sif_free() >> 2);
-
-	tDMA_TAG *ptag;
-
-	ptag = sif1ch.getAddr(sif1ch.madr, DMAC_SIF1, false);
-	if (ptag == NULL)
-	{
-		DevCon.Warning("Write EE to Fifo: ptag == NULL");
-		return false;
-	}
-
-	sif1.fifo.write((u32*)ptag, writeSize << 2);
-
-	sif1ch.madr += writeSize << 4;
-	hwDmacSrcTadrInc(sif1ch);
-	sif1.ee.cycles += writeSize;		// fixme : BIAS is factored in above
-	sif1ch.qwc -= writeSize;
-
-	return true;
-}
-
-// Read from the fifo and write to IOP
-static __fi bool WriteFifoToIOP()
-{
-	// If we're reading something, continue to do so.
-
-	SIF_LOG("Sif1: Write Fifo to IOP");
-	const int readSize = std::min(sif1.iop.counter, sif1.fifo.size);
-
-	SIF_LOG("Sif 1 IOP doing transfer %04X to %08X", readSize, HW_DMA10_MADR);
-
-	sif1.fifo.read((u32*)iopPhysMem(hw_dma10.madr), readSize);
-	psxCpu->Clear(hw_dma10.madr, readSize);
-	hw_dma10.madr += readSize << 2;
-	sif1.iop.cycles += readSize >> 2;		// fixme: should be >> 4
-	sif1.iop.counter -= readSize;
-
-	return true;
-}
-
-// Get a tag and process it.
-static __fi bool ProcessEETag()
-{
-	// Chain mode
-	tDMA_TAG *ptag;
-	SIF_LOG("Sif1: ProcessEETag");
-
-	// Process DMA tag at sif1ch.tadr
-	ptag = sif1ch.DMAtransfer(sif1ch.tadr, DMAC_SIF1);
-	if (ptag == NULL)
-	{
-		Console.WriteLn("Sif1 ProcessEETag: ptag = NULL");
-		return false;
-	}
-
-	if (sif1ch.chcr.TTE)
-	{
-		Console.WriteLn("SIF1 TTE");
-		sif1.fifo.write((u32*)ptag + 2, 2);
-	}
-
-	if (sif1ch.chcr.TIE && ptag->IRQ)
-	{
-		Console.WriteLn("SIF1 TIE");
-		sif1.ee.end = true;
-	}
-
-	SIF_LOG(wxString(ptag->tag_to_str()).To8BitData());
-	sif1ch.madr = ptag[1]._u32;
-
-	sif1.ee.end = hwDmacSrcChain(sif1ch, ptag->ID);
-
-	return true;
-}
-
-// Write fifo to data, and put it in IOP.
-static __fi bool SIFIOPReadTag()
-{
-	// Read a tag.
-	sif1.fifo.read((u32*)&sif1.iop.data, 4);
-	//sif1words = (sif1words + 3) & 0xfffffffc; // Round up to nearest 4.
-	SIF_LOG("SIF 1 IOP: dest chain tag madr:%08X wc:%04X id:%X irq:%d",
-		sif1data & 0xffffff, sif1words, sif1tag.ID, sif1tag.IRQ);
-
-	// Only use the first 24 bits.
-	hw_dma10.madr = sif1data & 0xffffff;
-
-	sif1.iop.counter = sif1words;
-	if (sif1tag.IRQ  || (sif1tag.ID & 4)) sif1.iop.end = true;
-
-	return true;
-}
-
-// Stop processing EE, and signal an interrupt.
-static __fi void EndEE()
-{
-	sif1.ee.end = false;
-	sif1.ee.busy = false;
-	SIF_LOG("Sif 1: End EE");
-
-	// Voodoocycles : Okami wants around 100 cycles when booting up
-	// Other games reach like 50k cycles here, but the EE will long have given up by then and just retry.
-	// (Cause of double interrupts on the EE)
-	if (sif1.ee.cycles == 0)
-	{
-		SIF_LOG("SIF1 EE: cycles = 0");
-		sif1.ee.cycles = 1;
-	}
-
-
-	CPU_INT(DMAC_SIF1, /*std::min((int)(*/sif1.ee.cycles*BIAS/*), 384)*/);
-}
-
-// Stop processing IOP, and signal an interrupt.
-static __fi void EndIOP()
-{
-	sif1data = 0;
-	sif1.iop.end = false;
-	sif1.iop.busy = false;
-	SIF_LOG("Sif 1: End IOP");
-
-	//Fixme ( voodoocycles ):
-	//The *24 are needed for ecco the dolphin (CDVD hangs) and silver surfer (Pad not detected)
-	//Greater than *35 break rebooting when trying to play Tekken5 arcade history
-	//Total cycles over 1024 makes SIF too slow to keep up the sound stream in so3...
-	if (sif1.iop.cycles == 0)
-	{
-		DevCon.Warning("SIF1 IOP: cycles = 0");
-		sif1.iop.cycles = 1;
-	}
-	// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords)
-	PSX_INT(IopEvt_SIF1, /*std::min((*/sif1.iop.cycles/* * 26*//*), 1024)*/);
-}
-
 // Handle the EE transfer.
 static __fi void HandleEETransfer()
 {
@@ -187,105 +37,169 @@ static __fi void HandleEETransfer()
 		DevCon.Warning("SIF1 stall control Not Implemented"); // STD == fromSIF1
 	}
 
-	/*if (sif1ch.qwc == 0)
-		if (sif1ch.chcr.MOD == NORMAL_MODE)
-			if (!sif1.ee.end){
-				DevCon.Warning("sif1 irq prevented CHCR %x QWC %x", sif1ch.chcr, sif1ch.qwc);
-				done = true;
-				return;
-			}*/
-
 	// If there's no more to transfer.
 	if (sif1ch.qwc <= 0)
 	{
 		// If NORMAL mode or end of CHAIN then stop DMA.
 		if ((sif1ch.chcr.MOD == NORMAL_MODE) || sif1.ee.end)
 		{
-			done = true;
-			EndEE();
+			// Stop processing EE and signal an interrupt.
+			sif1.ee.end = false;
+			sif1.ee.busy = false;
+			SIF_LOG("Sif 1: End EE");
+
+			// Voodoocycles : Okami wants ~100 cycles when booting up but other games reach 50k cycles here.
+			// However, the EE will long have given up by then and just retry due to double interrupts on the EE.
+			if (sif1.ee.cycles == 0)
+			{
+				SIF_LOG("SIF1 EE: cycles = 0");
+				sif1.ee.cycles = 1;
+			}
+
+			CPU_INT(DMAC_SIF1,  sif1.ee.cycles*BIAS); // Old: std::min(sif1.ee.cycles*BIAS, 384)
 		}
 		else
 		{
-			done = false;
-			if (!ProcessEETag()) return;
+			// Chain mode. Process DMA tag at sif1ch.tadr
+			SIF_LOG("Sif1: ProcessEETag");
+
+			tDMA_TAG *ptag = sif1ch.DMAtransfer(sif1ch.tadr, DMAC_SIF1);
+			if (ptag == NULL)
+			{
+				Console.WriteLn("Sif1 ProcessEETag: ptag = NULL");
+				return;
+			}
+
+			if (sif1ch.chcr.TTE)
+			{
+				Console.WriteLn("SIF1 TTE");
+				sif1.fifo.write((u32*)ptag + 2, 2);
+			}
+
+			if (sif1ch.chcr.TIE && ptag->IRQ)
+			{
+				Console.WriteLn("SIF1 TIE");
+				sif1.ee.end = true;
+			}
+
+			SIF_LOG(wxString(ptag->tag_to_str()).To8BitData());
+			sif1ch.madr = ptag[1]._u32;
+
+			sif1.ee.end = hwDmacSrcChain(sif1ch, ptag->ID);
 		}
 	}
-	else
+	else if (sif1.fifo.sif_free() > 0)
 	{
-		if (sif1.fifo.sif_free() > 0)
+		// There's data ready to transfer in to the fifo
+		SIF_LOG("Sif 1: Write EE to Fifo");
+		const int writeSize = std::min((s32)sif1ch.qwc, sif1.fifo.sif_free() >> 2);
+
+		tDMA_TAG *ptag = sif1ch.getAddr(sif1ch.madr, DMAC_SIF1, false);
+		if (ptag == NULL)
 		{
-			WriteEEtoFifo();
+			DevCon.Warning("Write EE to Fifo: ptag == NULL");
+			return;
 		}
+
+		sif1.fifo.write((u32*)ptag, writeSize << 2);
+
+		sif1ch.madr += writeSize << 4;
+		hwDmacSrcTadrInc(sif1ch);
+		sif1.ee.cycles += writeSize;		// fixme : BIAS is factored in above
+		sif1ch.qwc -= writeSize;
 	}
 }
 
 // Handle the IOP transfer.
 static __fi void HandleIOPTransfer()
 {
-	if (sif1.iop.counter > 0)
+	if (sif1.iop.counter > 0 && sif1.fifo.size > 0)
 	{
-		if (sif1.fifo.size > 0)
-		{
-			WriteFifoToIOP();
-		}
+		// If we are reading from fifo, continue to do so.
+		SIF_LOG("Sif1: Write Fifo to IOP");
+		const int readSize = std::min(sif1.iop.counter, sif1.fifo.size);
+
+		SIF_LOG("Sif 1 IOP doing transfer %04X to %08X", readSize, HW_DMA10_MADR);
+
+		sif1.fifo.read((u32*)iopPhysMem(hw_dma10.madr), readSize);
+		psxCpu->Clear(hw_dma10.madr, readSize);
+		hw_dma10.madr += readSize << 2;
+		sif1.iop.cycles += readSize >> 2;		// fixme: should be >> 4
+		sif1.iop.counter -= readSize;
 	}
 
 	if (sif1.iop.counter <= 0)
 	{
 		if (sif1.iop.end)
 		{
-			done = true;
-			EndIOP();
+			// Stop processing IOP and signal an interrupt.
+
+			sif1data = 0;
+			sif1.iop.end = false;
+			sif1.iop.busy = false;
+			SIF_LOG("Sif 1: End IOP");
+
+			// FIXME (Voodoocycles): Cycles * 24 needed for ecco the dolphin (CDVD hangs) and silver surfer (no Pad).
+			// Cycles * 35 or more breaks rebooting for Tekken5 arcade history.
+			// Total cycles over 1024 makes SIF too slow to keep up the sound stream in so3.
+			if (sif1.iop.cycles == 0)
+			{
+				DevCon.Warning("SIF1 IOP: cycles = 0");
+				sif1.iop.cycles = 1;
+			}
+			// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords)
+			PSX_INT(IopEvt_SIF1, sif1.iop.cycles); // Old: std::min(sif1.iop.cycles*26, 1024)
 		}
 		else if (sif1.fifo.size >= 4)
 		{
+			// Write fifo to data, and put it in IOP.
 
-			done = false;
-			SIFIOPReadTag();
+			sif1.fifo.read((u32*)&sif1.iop.data, 4); // Reading a tag
+
+			SIF_LOG("SIF 1 IOP: dest chain tag madr:%08X wc:%04X id:%X irq:%d",
+				sif1data & 0xffffff, sif1words, sif1tag.ID, sif1tag.IRQ);
+
+			// Only use the first 24 bits.
+			hw_dma10.madr = sif1data & 0xffffff;
+
+			sif1.iop.counter = sif1words;
+			if (sif1tag.IRQ  || (sif1tag.ID & 4))
+				sif1.iop.end = true;
 		}
 	}
-}
-
-static __fi void Sif1End()
-{
-	psHu32(SBUS_F240) &= ~0x40;
-	psHu32(SBUS_F240) &= ~0x4000;
-
-	DMA_LOG("SIF1 DMA End");
 }
 
 // Transfer EE to IOP, putting data in the fifo as an intermediate step.
 __fi void SIF1Dma()
 {
-	int BusyCheck = 0;
-	Sif1Init();
+	SIF_LOG("SIF1 DMA start...");
+	sif1.ee.cycles = 0;
+	sif1.iop.cycles = 0;
 
-	do
+	while (true)
 	{
-		//I realise this is very hacky in a way but its an easy way of checking if both are doing something
-		BusyCheck = 0;
+		// I realise this is very hacky in a way but its an easy way of checking if both are doing something
+		bool busyCheck = false;
 
-		if (sif1.ee.busy)
+		if (sif1.ee.busy && (sif1.fifo.sif_free() > 0 || (sif1.ee.end == true && sif1ch.qwc == 0)))
 		{
-			if(sif1.fifo.sif_free() > 0 || (sif1.ee.end == true && sif1ch.qwc == 0)) 
-			{
-				BusyCheck++;
-				HandleEETransfer();
-			}
+			busyCheck = true;
+			HandleEETransfer();
 		}
 
-		if (sif1.iop.busy)
+		if (sif1.iop.busy && (sif1.fifo.size >= 4 || (sif1.iop.end == true && sif1.iop.counter == 0)))
 		{
-			if(sif1.fifo.size >= 4 || (sif1.iop.end == true && sif1.iop.counter == 0)) 
-			{
-				BusyCheck++;
-				HandleIOPTransfer();
-			}
+			busyCheck = true;
+			HandleIOPTransfer();
 		}
+		if (!busyCheck)
+			break;
+	}
 
-	} while (/*!done &&*/ BusyCheck > 0);
+	psHu32(SBUS_F240) &= ~0x40;
+	psHu32(SBUS_F240) &= ~0x4000;
 
-	Sif1End();
+	SIF_LOG("SIF1 DMA End");
 }
 
 __fi void  sif1Interrupt()
@@ -314,7 +228,6 @@ __fi void dmaSIF1()
 	psHu32(SBUS_F240) |= 0x4000;
 	sif1.ee.busy = true;
 
-
 	// Okay, this here is needed currently (r3644). 
 	// FFX battles in the thunder plains map die otherwise, Phantasy Star 4 as well
 	// These 2 games could be made playable again by increasing the time the EE or the IOP run,
@@ -336,5 +249,4 @@ __fi void dmaSIF1()
 	}	
 
 	SIF1Dma();
-
 }

--- a/pcsx2/sif2.cpp
+++ b/pcsx2/sif2.cpp
@@ -15,31 +15,22 @@
 
 #include "PrecompiledHeader.h"
 
-#define _PC_	// disables MIPS opcode macros.
+#define _PC_ // disables MIPS opcode macros.
 
 #include "IopCommon.h"
 #include "Sif.h"
 
 _sif sif2;
 
-static bool done = false;
-
-static __fi void Sif2Init()
-{
-	SIF_LOG("SIF2 DMA start... free %x iop busy %x", sif2.fifo.sif_free(), sif2.iop.busy);
-	done = false;
-	sif2.ee.cycles = 0;
-	sif2.iop.cycles = 0;
-}
-
 __fi bool WriteFifoSingleWord()
 {
 	// There's some data ready to transfer into the fifo..
 
 	SIF_LOG("Write Single word to SIF2 Fifo");
-	
+
 	sif2.fifo.write((u32*)&psxHu32(HW_PS1_GPU_DATA), 1);
-	if (sif2.fifo.size > 0) psxHu32(0x1000f300) &= ~0x4000000;
+	if (sif2.fifo.size > 0)
+		psxHu32(0x1000f300) &= ~0x4000000;
 	return true;
 }
 
@@ -47,162 +38,15 @@ __fi bool ReadFifoSingleWord()
 {
 	u32 ptag[4];
 
-	//SIF_LOG(" EE SIF doing transfer %04Xqw to %08X", readSize, sif2dma.madr);
 	SIF_LOG("Read Fifo SIF2 Single Word IOP Busy %x Fifo Size %x SIF2 CHCR %x", sif2.iop.busy, sif2.fifo.size, HW_DMA2_CHCR);
-
 
 	sif2.fifo.read((u32*)&ptag[0], 1);
 	psHu32(0x1000f3e0) = ptag[0];
-	if (sif2.fifo.size == 0) psxHu32(0x1000f300) |= 0x4000000;
-	if (sif2.iop.busy && sif2.fifo.size <= 8)SIF2Dma();
+	if (sif2.fifo.size == 0)
+		psxHu32(0x1000f300) |= 0x4000000;
+	if (sif2.iop.busy && sif2.fifo.size <= 8)
+		SIF2Dma();
 	return true;
-}
-
-// Write from Fifo to EE.
-static __fi bool WriteFifoToEE()
-{
-	const int readSize = std::min((s32)sif2dma.qwc, sif2.fifo.size >> 2);
-
-	tDMA_TAG *ptag;
-
-	//SIF_LOG(" EE SIF doing transfer %04Xqw to %08X", readSize, sif2dma.madr);
-	SIF_LOG("Write Fifo to EE: ----------- %lX of %lX", readSize << 2, sif2dma.qwc << 2);
-
-	ptag = sif2dma.getAddr(sif2dma.madr, DMAC_SIF2, true);
-	if (ptag == NULL)
-	{
-		DevCon.Warning("Write Fifo to EE: ptag == NULL");
-		return false;
-	}
-
-	sif2.fifo.read((u32*)ptag, readSize << 2);
-
-	// Clearing handled by vtlb memory protection and manual blocks.
-	//Cpu->Clear(sif2dma.madr, readSize*4);
-
-	sif2dma.madr += readSize << 4;
-	sif2.ee.cycles += readSize;	// fixme : BIAS is factored in above
-	sif2dma.qwc -= readSize;
-	
-	return true;
-}
-
-// Write IOP to Fifo.
-static __fi bool WriteIOPtoFifo()
-{
-	// There's some data ready to transfer into the fifo..
-	const int writeSize = std::min(sif2.iop.counter, sif2.fifo.sif_free());
-
-	SIF_LOG("Write IOP to Fifo: +++++++++++ %lX of %lX", writeSize, sif2.iop.counter);
-	
-	sif2.fifo.write((u32*)iopPhysMem(hw_dma2.madr), writeSize);
-	hw_dma2.madr += writeSize << 2;
-
-	// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords).
-	sif2.iop.cycles += (writeSize >> 2)/* * BIAS*/;		// fixme : should be >> 4
-	sif2.iop.counter -= writeSize;
-	//PSX_INT(IopEvt_SIF2, sif2.iop.cycles);
-	if (sif2.iop.counter == 0) hw_dma2.madr = sif2data & 0xffffff;
-	if (sif2.fifo.size > 0) psxHu32(0x1000f300) &= ~0x4000000;
-	return true;
-}
-
-// Read Fifo into an ee tag, transfer it to sif2dma, and process it.
-static __fi bool ProcessEETag()
-{
-	static __aligned16 u32 tag[4];
-	tDMA_TAG& ptag(*(tDMA_TAG*)tag);
-
-	sif2.fifo.read((u32*)&tag[0], 4); // Tag
-	SIF_LOG("SIF2 EE read tag: %x %x %x %x", tag[0], tag[1], tag[2], tag[3]);
-
-	sif2dma.unsafeTransfer(&ptag);
-	sif2dma.madr = tag[1];
-
-	SIF_LOG("SIF2 EE dest chain tag madr:%08X qwc:%04X id:%X irq:%d(%08X_%08X)",
-		sif2dma.madr, sif2dma.qwc, ptag.ID, ptag.IRQ, tag[1], tag[0]);
-
-	if (sif2dma.chcr.TIE && ptag.IRQ)
-	{
-		//Console.WriteLn("SIF2 TIE");
-		sif2.ee.end = true;
-	}
-
-	switch (ptag.ID)
-	{
-	case TAG_CNT:	break;
-
-	case TAG_CNTS:
-		break;
-
-	case TAG_END:
-		sif2.ee.end = true;
-		break;
-	}
-	return true;
-}
-
-// Read Fifo into an iop tag, and transfer it to hw_dma9. And presumably process it.
-static __fi bool ProcessIOPTag()
-{
-	//sif2.iop.data = *(sifData *)iopPhysMem(hw_dma2.madr); //comment this out and replace words below
-	// Process DMA tag at hw_dma9.tadr
-	if (HW_DMA2_CHCR & 0x400) DevCon.Warning("First bit %x", sif2.iop.data.data);
-	
-	sif2.iop.data.words = sif2.iop.data.data >> 24; // Round up to nearest 4.
-
-	// send the EE's side of the DMAtag.  The tag is only 64 bits, with the upper 64 bits
-	// ignored by the EE.
-	
-	// We're only copying the first 24 bits.  Bits 30 and 31 (checked below) are Stop/IRQ bits.
-	
-	//psxHu32(HW_PS1_GPU_DATA) += 4;
-	sif2.iop.counter =  (HW_DMA2_BCR_H16 * HW_DMA2_BCR_L16); //makes it do more stuff?? //sif2words;
-	/*if (HW_DMA2_CHCR & 0x400)
-	{
-		if (sif2.iop.counter == 0) hw_dma2.madr = sif2data & 0xFFFFFF;
-		else hw_dma2.madr += 2;
-	}
-	else hw_dma2.madr += 2;
-	// IOP tags have an IRQ bit and an End of Transfer bit:
-	if ((sif2data & 0xFFFFFF) == 0xFFFFFF || (HW_DMA2_CHCR & 0x200)) */sif2.iop.end = true;
-	DevCon.Warning("SIF2 IOP Tag: madr=%lx, counter=%lx (%08X_%08X)", hw_dma2.madr, sif2.iop.counter, sif2words, sif2data);
-
-	return true;
-}
-
-// Stop transferring ee, and signal an interrupt.
-static __fi void EndEE()
-{
-	SIF_LOG("Sif2: End EE");
-	sif2.ee.end = false;
-	sif2.ee.busy = false;
-	if (sif2.ee.cycles == 0)
-	{
-		SIF_LOG("SIF2 EE: cycles = 0");
-		sif2.ee.cycles = 1;
-	}
-
-	CPU_INT(DMAC_SIF2, sif2.ee.cycles*BIAS);
-}
-
-// Stop transferring iop, and signal an interrupt.
-static __fi void EndIOP()
-{
-	SIF_LOG("Sif2: End IOP");
-	sif2data = 0;
-	//sif2.iop.end = false;
-	sif2.iop.busy = false;
-
-	if (sif2.iop.cycles == 0)
-	{
-		DevCon.Warning("SIF2 IOP: cycles = 0");
-		sif2.iop.cycles = 1;
-	}
-	// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords)
-	// So when we're all done, the equation looks like thus:
-	//PSX_INT(IopEvt_SIF2, ( ( sif2.iop.cycles*BIAS ) / 4 ) / 8);
-	PSX_INT(IopEvt_SIF2, sif2.iop.cycles);
 }
 
 // Handle the EE transfer.
@@ -215,39 +59,67 @@ static __fi void HandleEETransfer()
 		sif2.ee.busy = false;
 		return;
 	}
-	
-	/*if (sif2dma.qwc == 0)
-	if (sif2dma.chcr.MOD == NORMAL_MODE)
-	if (!sif2.ee.end){
-	DevCon.Warning("sif2 irq prevented");
-	done = true;
-	return;
-	}*/
 
 	if (sif2dma.qwc <= 0)
 	{
 		if ((sif2dma.chcr.MOD == NORMAL_MODE) || sif2.ee.end)
 		{
-			// Stop transferring ee, and signal an interrupt.
-			done = true;
-			EndEE();
+			// Stop transferring ee and signal an interrupt.
+			SIF_LOG("Sif2: End EE");
+			sif2.ee.end = false;
+			sif2.ee.busy = false;
+			if (sif2.ee.cycles == 0)
+			{
+				SIF_LOG("SIF2 EE: cycles = 0");
+				sif2.ee.cycles = 1;
+			}
+
+			CPU_INT(DMAC_SIF2, sif2.ee.cycles*BIAS);
 		}
 		else if (sif2.fifo.size >= 4) // Read a tag
 		{
-			// Read Fifo into an ee tag, transfer it to sif2dma
-			// and process it.
+			// Read Fifo into an ee tag, transfer it to sif2dma and process it.
 			DevCon.Warning("SIF2 EE Chain?!");
-			ProcessEETag();
+
+			static __aligned16 u32 tag[4];
+			tDMA_TAG& ptag(*(tDMA_TAG*)tag);
+
+			sif2.fifo.read((u32*)&tag[0], 4); // Tag
+			SIF_LOG("SIF2 EE read tag: %x %x %x %x", tag[0], tag[1], tag[2], tag[3]);
+
+			sif2dma.unsafeTransfer(&ptag);
+			sif2dma.madr = tag[1];
+
+			SIF_LOG("SIF2 EE dest chain tag madr:%08X qwc:%04X id:%X irq:%d(%08X_%08X)",
+				sif2dma.madr, sif2dma.qwc, ptag.ID, ptag.IRQ, tag[1], tag[0]);
+
+			if (ptag.ID == TAG_END || (sif2dma.chcr.TIE && ptag.IRQ))
+			{
+				sif2.ee.end = true;
+			}
 		}
 	}
 
-	if (sif2dma.qwc > 0) // If we're writing something, continue to do so.
+	// If we're writing something, continue to do so.
+	if (sif2dma.qwc > 0 && sif2.fifo.size > 0) 
 	{
-		// Write from Fifo to EE.
-		if (sif2.fifo.size > 0)
+		const int readSize = std::min((s32)sif2dma.qwc, sif2.fifo.size >> 2);
+		SIF_LOG("Write Fifo to EE: ----------- %lX of %lX", readSize << 2, sif2dma.qwc << 2);
+
+		tDMA_TAG *ptag = sif2dma.getAddr(sif2dma.madr, DMAC_SIF2, true);
+		if (ptag == NULL)
 		{
-			WriteFifoToEE();
+			DevCon.Warning("Write Fifo to EE: ptag == NULL");
+			return;
 		}
+
+		sif2.fifo.read((u32*)ptag, readSize << 2);
+
+		// Clearing madr is handled by vtlb memory protection and manual blocks.
+
+		sif2dma.madr += readSize << 4;
+		sif2.ee.cycles += readSize;	// fixme : BIAS is factored in above
+		sif2dma.qwc -= readSize;
 	}
 }
 
@@ -286,15 +158,33 @@ static __fi void HandleIOPTransfer()
 	{
 		if (sif2.iop.end)
 		{
-			// Stop transferring iop, and signal an interrupt.
-			done = true;
-			EndIOP();
+			// Stop transferring iop and signal an interrupt.
+			SIF_LOG("Sif2: End IOP");
+			sif2data = 0;
+			//sif2.iop.end = false;
+			sif2.iop.busy = false;
+
+			if (sif2.iop.cycles == 0)
+			{
+				DevCon.Warning("SIF2 IOP: cycles = 0");
+				sif2.iop.cycles = 1;
+			}
+			// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords)
+			// So when we're all done, the equation looks like: ( ( sif2.iop.cycles*BIAS ) / 4 ) / 8)
+			PSX_INT(IopEvt_SIF2, sif2.iop.cycles);
 		}
 		else
 		{
-			// Read Fifo into an iop tag, and transfer it to hw_dma9.
-			// And presumably process it.
-			ProcessIOPTag();
+			// Read Fifo into an iop tag, transfer it to hw_dma9 and presumably process it.
+			// Process DMA tag at hw_dma9.tadr
+			if (HW_DMA2_CHCR & 0x400)
+				DevCon.Warning("First bit %x", sif2.iop.data.data);
+
+			sif2.iop.data.words = sif2.iop.data.data >> 24; // Round up to nearest 4.
+
+			sif2.iop.counter =  (HW_DMA2_BCR_H16 * HW_DMA2_BCR_L16); //makes it do more stuff?? //sif2words;
+			sif2.iop.end = true;
+			DevCon.Warning("SIF2 IOP Tag: madr=%lx, counter=%lx (%08X_%08X)", hw_dma2.madr, sif2.iop.counter, sif2words, sif2data);
 		}
 	}
 	else
@@ -302,36 +192,45 @@ static __fi void HandleIOPTransfer()
 		// Write IOP to Fifo.
 		if (sif2.fifo.sif_free() > 0)
 		{
-			WriteIOPtoFifo();
+			// There's some data ready to transfer into the fifo..
+			const int writeSize = std::min(sif2.iop.counter, sif2.fifo.sif_free());
+
+			SIF_LOG("Write IOP to Fifo: +++++++++++ %lX of %lX", writeSize, sif2.iop.counter);
+
+			sif2.fifo.write((u32*)iopPhysMem(hw_dma2.madr), writeSize);
+			hw_dma2.madr += writeSize << 2;
+
+			// iop is 1/8th the clock rate of the EE and psxcycles is in words (not quadwords).
+			sif2.iop.cycles += (writeSize >> 2)/* * BIAS*/;    // fixme : should be >> 4
+			sif2.iop.counter -= writeSize;
+			//PSX_INT(IopEvt_SIF2, sif2.iop.cycles);
+			if (sif2.iop.counter == 0)
+				hw_dma2.madr = sif2data & 0xffffff;
+			if (sif2.fifo.size > 0)
+				psxHu32(0x1000f300) &= ~0x4000000;
 		}
-		else DevCon.Warning("Nothing free!");
+		else
+			DevCon.Warning("Nothing free!");
 	}
-}
-
-static __fi void Sif2End()
-{
-	psHu32(SBUS_F240) &= ~0x80;
-	psHu32(SBUS_F240) &= ~0x8000;
-
-	DMA_LOG("SIF2 DMA End");
 }
 
 // Transfer IOP to EE, putting data in the fifo as an intermediate step.
 __fi void SIF2Dma()
 {
-	int BusyCheck = 0;
-	Sif2Init();
+	SIF_LOG("SIF2 DMA start... free %x iop busy %x", sif2.fifo.sif_free(), sif2.iop.busy);
+	sif2.ee.cycles = 0;
+	sif2.iop.cycles = 0;
 
-	do
+	while (true)
 	{
 		//I realise this is very hacky in a way but its an easy way of checking if both are doing something
-		BusyCheck = 0;
+		bool busyCheck = false;
 
 		if (sif2.iop.busy)
 		{
 			if (sif2.fifo.sif_free() > 0 || (sif2.iop.end == true && sif2.iop.counter == 0))
 			{
-				BusyCheck++;
+				busyCheck = true;
 				HandleIOPTransfer();
 			}
 		}
@@ -339,13 +238,18 @@ __fi void SIF2Dma()
 		{
 			if (sif2.fifo.size >= 4 || (sif2.ee.end == true && sif2dma.qwc == 0))
 			{
-				BusyCheck++;
+				busyCheck = true;
 				HandleEETransfer();
 			}
 		}
-	} while (/*!done && */BusyCheck > 0); // Substituting (sif2.ee.busy || sif2.iop.busy) breaks things.
+		if (!busyCheck)
+			break;
+	}
 
-	Sif2End();
+	psHu32(SBUS_F240) &= ~0x80;
+	psHu32(SBUS_F240) &= ~0x8000;
+
+	SIF_LOG("SIF2 DMA End");
 }
 
 __fi void  sif2Interrupt()
@@ -355,7 +259,7 @@ __fi void  sif2Interrupt()
 		SIF2Dma();
 		return;
 	}
-	
+
 	SIF_LOG("SIF2 IOP Intr end");
 	HW_DMA2_CHCR &= ~0x01000000;
 	psxDmaInterrupt2(2);


### PR DESCRIPTION
Some unused functions.
Local variable 'done' wasn't being used.
Collapse it in to main functions so that it is easier to (re)move.

Functionality is unchanged, although it appears most of it isn't used or is only ever used once.