### PR TITLE
Use generic memcpy from now on. Tests show generics are good enough now.

### DIFF
--- a/common/include/Utilities/MemcpyFast.h
+++ b/common/include/Utilities/MemcpyFast.h
@@ -42,12 +42,9 @@ void _memset16_unaligned( void* dest, u16 data, size_t size );
 extern void memcpy_vibes(void * dest, const void * src, int size);
 extern void gen_memcpy_vibes();
 
-#define memcpy_fast				memcpy_amd_  // Fast memcpy
-#define memcpy_aligned(d,s,c)	memcpy_amd_(d,s,c)	// Memcpy with 16-byte Aligned addresses
-#define memcpy_const			memcpy_amd_	 // Memcpy with constant size
-#define memcpy_constA			memcpy_amd_  // Memcpy with constant size and 16-byte aligned
-#define memcpy_qwc_				memcpy_vibes // Memcpy in aligned qwc increments, with 0x400 qwc or less
-#define memcpy_qwc(d,s,c)		memcpy_amd_qwc(d,s,c)
-
-// Useful alternative if we think memcpy_amd_qwc is buggy
-//#define memcpy_qwc(d,s,c)		memcpy_amd_(d,s,c*16)
+#define memcpy_fast					memcpy
+#define memcpy_aligned(d,s,c)		memcpy(d,s,c)
+#define memcpy_const					memcpy
+#define memcpy_constA				memcpy
+#define memcpy_qwc_					memcpy
+#define memcpy_qwc(d,s,c)			memcpy(d,s,c*16)


### PR DESCRIPTION
It should be a speedup even on modern CPUs.
