### PR TITLE
build.sh: get number of CPUs on OSX too

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,13 @@ else
     cmake "${flags[@]}" $root 2>&1 | tee -a $log
 fi
 
-make -j "$(grep -w -c processor /proc/cpuinfo)" 2>&1 | tee -a $log
+if [[ $(uname -s) == 'Darwin' ]]; then
+    ncpu=$(sysctl -n hw.ncpu)
+else
+    ncpu=$(grep -w -c processor /proc/cpuinfo)
+fi
+
+make -j"$ncpu" 2>&1 | tee -a $log
 make install 2>&1 | tee -a $log
 
 exit 0


### PR DESCRIPTION
Just a small fix for something that's way of, but every little bit helps I suppose.

The linux way (reading /proc/cpuinfo) doesn't work on OSX.
