### PR TITLE
core: use memcpy and reserve function

### DIFF
--- a/pcsx2/x86/BaseblockEx.h
+++ b/pcsx2/x86/BaseblockEx.h
@@ -53,7 +53,7 @@ class BaseBlockArray {
 		pxAssert(size > 0);
 		BASEBLOCKEX *newMem = new BASEBLOCKEX[size];
 		if(blocks) {
-			memmove(newMem, blocks, _Reserved * sizeof(BASEBLOCKEX));
+			memcpy(newMem, blocks, _Reserved * sizeof(BASEBLOCKEX));
 			delete[] blocks;
 		}
 		blocks = newMem;
@@ -84,8 +84,7 @@ public:
 	BASEBLOCKEX *insert(u32 startpc, uptr fnptr)
 	{
 		if(_Size + 1 >= _Reserved) {
-			resize(_Reserved + 0x2000);
-			_Reserved += 0x2000;		// some games requires even more!
+			reserve(_Reserved + 0x2000); // some games requires even more!
 		}
 
 		int imin = 0, imax = _Size, imid;


### PR DESCRIPTION
newMem is a new memory allocated by "new". There is no way that is
overlap with previous allocation. Therefore the faster memcpy can be used safely.