### PR TITLE
Memory Card as folder instead of a big raw file.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -75,6 +75,19 @@
 -- mvuFlagSpeedHack = 1 or 0 // Katamari Damacy have weird speed bug when this speed hack is enabled (and it is by default)
 
 ---------------------------------------------
+-- Memory Card Filter Override (MemCardFilter = s)
+---------------------------------------------
+-- By default, the FolderMemoryCard filters save games based on the
+-- game's serial, which means that only saves whose folder names contain
+-- the game's serial are loaded. This works fine for the vast majority
+-- of games, but fails in some cases, for which this override is for.
+-- Examples include multi-disc games, where later games often reuse the
+-- serial of the previous disc(s), and games that allow transfer of save
+-- data between different games, such as importing data from a prequel.
+-- To allow multiple serials separate them with slashes, like this:
+-- MemCardFilter = SLUS-12345/SLUS-12346/SLUS-12347
+
+---------------------------------------------
 -- Patches ([patches] or [patches = crc])
 ---------------------------------------------
 -- Patches must be specified in blocks.
@@ -221,6 +234,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20004
 Name   = dot Hack Vol.3
 Region = NTSC-Unk
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SCAJ-20005
 Name   = Guilty Gear XX
@@ -301,6 +315,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20024
 Name   = dot Hack Vol.4
 Region = NTSC-Unk
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SCAJ-20025
 Name   = Grand Prix Challenge
@@ -440,6 +455,7 @@ Region = NTSC-Unk
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCAJ-20067
 Name   = GunGrave O.D.
@@ -514,10 +530,12 @@ Region = NTSC-Unk
 Serial = SCAJ-20086
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [Disc1of2]
 Region = NTSC-Unk
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SCAJ-20087
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [Disc2of2]
 Region = NTSC-Unk
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SCAJ-20088
 Name   = UO Nanatsu no Mizu to Densetsu no Nushi
@@ -644,6 +662,7 @@ Serial = SCAJ-20120
 Name   = Digital Devil Saga: Avatar Tuner 2
 Region = NTSC-Unk
 EETimingHack = 1
+MemCardFilter = SCAJ-20120/SLPM-65795/SLPM-66373/SCAJ-20095/SLPM-65597/SLPM-66372
 ---------------------------------------------
 Serial = SCAJ-20121
 Name   = Armored Core - Formula Front
@@ -656,6 +675,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20123
 Name   = Wild ARMs - The 4th Detonator
 Region = NTSC-Unk
+MemCardFilter = SCAJ-20123/SCPS-15091/SCPS-15092/SCPS-19313/SCPS-19322/SCPS-19323/SCAJ-30002/SCPS-17002/SCPS-19251/SCPS-19253
 ---------------------------------------------
 Serial = SCAJ-20124
 Name   = Romancing Saga - Minstrel Song
@@ -708,6 +728,7 @@ Name   = Minna Daisuki Katamari Damacy
 Region = NTSC-Unk
 vuClampMode = 3
 mvuFlagSpeedHack = 0
+MemCardFilter = SCAJ-20135/SLPS-25467/SLPS-73241/SCAJ-20079/SLPS-25360/SLPS-73210/SLPS-73240
 ---------------------------------------------
 Serial = SCAJ-20136
 Name   = Ace Combat 5 - The Unsung War [PlayStation 2 The Best]
@@ -749,6 +770,7 @@ Serial = SCAJ-20146
 Name   = Shadow of the Colossus
 Region = NTSC-Ch-E-J
 Compat = 5
+MemCardFilter = SCAJ-20146/SCAJ-20196/SCAJ-20099/SCPS-11003/SCPS-19103/SCPS-19151/SCPS-55001
 ---------------------------------------------
 Serial = SCAJ-20147
 Name   = Heavy Metal Thunder
@@ -860,6 +882,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20173
 Name   = Ace Combat Zero - The Belkan War
 Region = NTSC-Unk
+MemCardFilter = SCAJ-20173/SLPS-25629/SLPS-73250/SLPS-25052/SLPS-73205/SLPS-73410/SCAJ-20104/SCAJ-20136/SLPS-25418/SLPS-73218
 ---------------------------------------------
 Serial = SCAJ-20175
 Name   = Dragon Quest - Shonen Yangus to Fushigi no Dungeon
@@ -941,6 +964,7 @@ Region = NTSC-Ch
 Serial = SCAJ-20196
 Name   = Shadow of the Colossus [PlayStation 2 The Best]
 Region = NTSC-Ch
+MemCardFilter = SCAJ-20146/SCAJ-20196/SCAJ-20099/SCPS-11003/SCPS-19103/SCPS-19151/SCPS-55001
 ---------------------------------------------
 Serial = SCAJ-20197
 Name   = Valkyrie Profile 2 - Silmeria [Ultimate Hits]
@@ -1019,6 +1043,7 @@ Name   = Gran Turismo 4
 Region = NTSC-Unk
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCAJ-30007
 Name   = Gran Turismo 4
@@ -1026,6 +1051,7 @@ Region = NTSC-Unk
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 //[patches = 7ABDBB5E]
 //	
 //	comment=patches by nachbrenner
@@ -1040,6 +1066,7 @@ Name   = Gran Turismo 4 [PlayStation 2 The Best]
 Region = NTSC-Unk
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCAJ-30010
 Name   = God of War
@@ -1636,6 +1663,8 @@ Serial = SCES-51607
 Name   = Ratchet & Clank 2 - Locked & Loaded
 Region = PAL-Unk
 Compat = 5
+// reads Ratchet 1 data
+MemCardFilter = SCES-51607/SCES-50916
 ---------------------------------------------
 Serial = SCES-51608
 Name   = Jak & Daxter 2 - Renegade
@@ -1702,6 +1731,7 @@ Region = PAL-Unk
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCES-51719/SCES-52438/SCES-50294
 ---------------------------------------------
 Serial = SCES-51725
 Name   = Everquest Online Adventures
@@ -1893,11 +1923,14 @@ Region = PAL-Unk
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCES-51719/SCES-52438/SCES-50294
 ---------------------------------------------
 Serial = SCES-52456
 Name   = Ratchet & Clank 3
 Region = PAL-Unk
 Compat = 5
+// reads Ratchet 1 & 2 data
+MemCardFilter = SCES-52456/SCES-51607/SCES-50916
 ---------------------------------------------
 Serial = SCES-52460
 Name   = Jak 3
@@ -2107,6 +2140,8 @@ Compat = 5
 Serial = SCES-53286
 Name   = Jak X - Combat Racing
 Region = PAL-Unk
+// reads Ratchet Gladiator data
+MemCardFilter = SCES-53286/SCES-53285
 ---------------------------------------------
 Serial = SCES-53300
 Name   = SOCOM 3 - U.S. Navy SEALs
@@ -2151,6 +2186,7 @@ Serial = SCES-53326
 Name   = Shadow of the Colossus
 Region = PAL-Unk
 Compat = 5
+MemCardFilter = SCES-53326/SCES-50760
 ---------------------------------------------
 Serial = SCES-53328
 Name   = Genji
@@ -2354,6 +2390,8 @@ Region = PAL-Unk
 Serial = SCES-54041
 Name   = Ace Combat - The Belkan War
 Region = PAL-E
+// reads AC4 and 5 saves for bonus unlockables
+MemCardFilter = SCES-54041/SCES-50410/SCES-52424
 [patches = 194C9F38]
 	patch=0,EE,00131EB4,word,48498800
 	patch=0,EE,00131EB8,word,4B00682C
@@ -2696,10 +2734,12 @@ Compat = 5
 Serial = SCES-82034
 Name   = Xenosaga II - Jenseits von Gut und Bose [Disc 1]
 Region = PAL-Unk
+MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SCES-82035
 Name   = Xenosaga II - Jenseits von Gut und Bose [Disc 2]
 Region = PAL-Unk
+MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SCKA-10006
 Name   = Come on Baby
@@ -2728,6 +2768,7 @@ Region = NTSC-K
 Serial = SCKA-20011
 Name   = Ratchet & Clank 2
 Region = NTSC-K
+MemCardFilter = SCKA-20011/SCKA-20120
 ---------------------------------------------
 Serial = SCKA-20012
 Name   = Ark the Lad - jeongryeongui Hwanghon
@@ -2819,6 +2860,7 @@ Region = NTSC-K
 Serial = SCKA-20037
 Name   = Ratchet & Clank 3
 Region = NTSC-K
+MemCardFilter = SCKA-20037/SCKA-20011/SCKA-20120
 ---------------------------------------------
 Serial = SCKA-20038
 Name   = Time Crisis - Crisis Zone
@@ -2864,6 +2906,7 @@ Name   = Minna Daisuki Katamari Damacy
 Region = NTSC-K
 vuClampMode = 3
 mvuFlagSpeedHack = 0
+MemCardFilter = SCKA-20051/SCKA-20025
 ---------------------------------------------
 Serial = SCKA-20052
 Name   = Genji
@@ -2906,6 +2949,7 @@ Serial = SCKA-20061
 Name   = Wanda to Kyozou (Shadow of the Colossus)
 Region = NTSC-K
 Compat = 5
+MemCardFilter = SCKA-20061/SCPS-15097/SCPS-19320/SCKA-20028/SCPS-56001
 ---------------------------------------------
 Serial = SCKA-20062
 Name   = Ape Escape 3
@@ -2963,6 +3007,7 @@ Region = NTSC-K
 Serial = SCKA-20087
 Name   = Shin Onimusha - Dawn of Dreams [Disc2of2]
 Region = NTSC-K
+MemCardFilter = SCKA-20086
 ---------------------------------------------
 Serial = SCKA-20090
 Name   = God Hand
@@ -2995,6 +3040,7 @@ Serial = SCKA-20109
 Name   = Persona 3 FES [Independent Starting Version]
 Region = NTSC-K
 VuClipFlagHack = 1
+MemCardFilter = SCKA-20109/SCKA-20099
 ---------------------------------------------
 Serial = SCKA-20114
 Name   = Obscure II - The Aftermath
@@ -3129,10 +3175,12 @@ Region = NTSC-J
 Serial = SCPS-11019
 Name   = Bravo Music - Chou-Meikyokuban [Limited Edition] [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SCPS-11023/SCPS-11019/SCPS-11020
 ---------------------------------------------
 Serial = SCPS-11020
 Name   = Bravo Music - Chou-Meikyokuban [Limited Edition] [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SCPS-11023/SCPS-11019/SCPS-11020
 ---------------------------------------------
 Serial = SCPS-11021
 Name   = Yoake no Mariko 2nd Act
@@ -3145,6 +3193,7 @@ Region = NTSC-J
 Serial = SCPS-11023
 Name   = Bravo Music - Chou-Meikyokuban
 Region = NTSC-J
+MemCardFilter = SCPS-11023/SCPS-11019/SCPS-11020
 ---------------------------------------------
 Serial = SCPS-11024
 Name   = Otostaz
@@ -3439,10 +3488,12 @@ Name   = Gran Turismo 4 - Prologue
 Region = NTSC-J
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCPS-15056
 Name   = Ratchet & Clank 2
 Region = NTSC-J
+MemCardFilter = SCPS-15056/SCPS-15037
 ---------------------------------------------
 Serial = SCPS-15057
 Name   = Jak & Daxter 2
@@ -3560,6 +3611,7 @@ Region = NTSC-J
 Serial = SCPS-15084
 Name   = Ratchet & Clank 3
 Region = NTSC-J
+MemCardFilter = SCPS-15084/SCPS-15056/SCPS-15037
 ---------------------------------------------
 Serial = SCPS-15085
 Name   = Kenran Butousai
@@ -3589,10 +3641,12 @@ Region = NTSC-J
 Serial = SCPS-15091
 Name   = Wild ARMs - The 4th Detonator
 Region = NTSC-J
+MemCardFilter = SCAJ-20123/SCPS-15091/SCPS-15092/SCPS-19313/SCPS-19322/SCPS-19323/SCAJ-30002/SCPS-17002/SCPS-19251/SCPS-19253
 ---------------------------------------------
 Serial = SCPS-15092
 Name   = Wild ARMs - The 4th Detonator
 Region = NTSC-J
+MemCardFilter = SCAJ-20123/SCPS-15091/SCPS-15092/SCPS-19313/SCPS-19322/SCPS-19323/SCAJ-30002/SCPS-17002/SCPS-19251/SCPS-19253
 ---------------------------------------------
 Serial = SCPS-15093
 Name   = Rule of Rose
@@ -3616,6 +3670,7 @@ Serial = SCPS-15097
 Name   = Wanda to Kyozou (Shadow of the Colossus)
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SCAJ-20146/SCAJ-20196/SCAJ-20099/SCPS-11003/SCPS-19103/SCPS-19151/SCPS-55001
 ---------------------------------------------
 Serial = SCPS-15098
 Name   = Formula One 2005
@@ -3727,6 +3782,7 @@ Region = NTSC-J
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCPS-17002
 Name   = Wild ARMs - Alter Code F
@@ -3855,6 +3911,7 @@ Name   = Gran Turismo 4 [PlayStation 2 The Best]
 Region = NTSC-J
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCPS-19253
 Name   = Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]
@@ -3877,6 +3934,7 @@ Name   = Gran Turismo 4 - Prologue [PlayStation 2 The Best]
 Region = NTSC-J
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-17001/SCPS-19252/SCPS-19304/SCPS-15009/SCPS-55007
 ---------------------------------------------
 Serial = SCPS-19305
 Name   = Siren [PlayStation 2 The Best]
@@ -3913,6 +3971,7 @@ Region = NTSC-J
 Serial = SCPS-19313
 Name   = Wild ARMs - The 4th Detonator [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SCAJ-20123/SCPS-15091/SCPS-15092/SCPS-19313/SCPS-19322/SCPS-19323/SCAJ-30002/SCPS-17002/SCPS-19251/SCPS-19253
 ---------------------------------------------
 Serial = SCPS-19315
 Name   = EyeToy - Play [PlayStation 2 The Best]
@@ -3937,6 +3996,7 @@ Region = NTSC-J
 Serial = SCPS-19320
 Name   = Wanda to Kyozou (Shadow of the Colossus) [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SCAJ-20146/SCAJ-20196/SCAJ-20099/SCPS-11003/SCPS-19103/SCPS-19151/SCPS-55001
 ---------------------------------------------
 Serial = SCPS-19321
 Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]
@@ -3945,10 +4005,12 @@ Region = NTSC-J
 Serial = SCPS-19322
 Name   = Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]
 Region = NTSC-J
+MemCardFilter = SCAJ-20123/SCPS-15091/SCPS-15092/SCPS-19313/SCPS-19322/SCPS-19323/SCAJ-30002/SCPS-17002/SCPS-19251/SCPS-19253
 ---------------------------------------------
 Serial = SCPS-19323
 Name   = Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]
 Region = NTSC-J
+MemCardFilter = SCAJ-20123/SCPS-15091/SCPS-15092/SCPS-19313/SCPS-19322/SCPS-19323/SCAJ-30002/SCPS-17002/SCPS-19251/SCPS-19253
 ---------------------------------------------
 Serial = SCPS-19324
 Name   = Tourist Trophy - The Real Riding Simulator [PlayStation 2 The Best]
@@ -4158,6 +4220,7 @@ Region = NTSC-J
 Serial = SCPS-55029
 Name   = dot Hack - Vol.1
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SCPS-55030
 Name   = First Step Victorious Boxers [PlayStation 2 The Best]
@@ -4186,6 +4249,7 @@ Region = NTSC-J
 Serial = SCPS-55042
 Name   = dot Hack - Vol.2
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SCPS-55043
 Name   = Fatal Frame
@@ -4955,6 +5019,7 @@ Serial = SCUS-97268
 Name   = Ratchet & Clank - Going Commando
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SCUS-97268/SCUS-97199
 ---------------------------------------------
 Serial = SCUS-97269
 Name   = Final Fantasy XI [Disc2of2]
@@ -5086,6 +5151,8 @@ Region = NTSC-U
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+// allows car imports from GT3 or something
+MemCardFilter = SCUS-97328/SCUS-97436/SCUS-97102/SCUS-97219/SCUS-97512
 ---------------------------------------------
 Serial = SCUS-97329
 Name   = Downhill Domination [Demo]
@@ -5161,6 +5228,7 @@ Serial = SCUS-97353
 Name   = Ratchet & Clank - Up Your Arsenal
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SCUS-97353/SCUS-97268/SCUS-97199
 ---------------------------------------------
 Serial = SCUS-97355
 Name   = Siren
@@ -5397,6 +5465,7 @@ Serial = SCUS-97429
 Name   = Jak X - Combat Racing
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SCUS-97429/SCUS-97465
 ---------------------------------------------
 Serial = SCUS-97430
 Name   = Hot Shots Golf FORE! [Regular Demo]
@@ -5415,6 +5484,7 @@ Name   = Gran Turismo 4 [Online Public Beta]
 Region = NTSC-U
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
+MemCardFilter = SCUS-97328/SCUS-97436/SCUS-97102/SCUS-97219/SCUS-97512
 ---------------------------------------------
 Serial = SCUS-97437
 Name   = ATV Off-Road Fury 3 [Demo]
@@ -5546,6 +5616,7 @@ Serial = SCUS-97472
 Name   = Shadow of the Colossus
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SCUS-97472/SCUS-97113
 ---------------------------------------------
 Serial = SCUS-97473
 Name   = World Tour Soccer 2006 [Demo]
@@ -6162,6 +6233,7 @@ Region = NTSC-Unk
 Serial = SLAJ-25066
 Name   = Burnout Revenge - Battle Racing Ignited
 Region = NTSC-Unk
+MemCardFilter = SLAJ-25066/SLPM-66108/SLPM-66652/SLPM-65719/SLPM-65958/SLPM-66962/SLAJ-25053/SLPM-66204
 ---------------------------------------------
 Serial = SLAJ-25068
 Name   = Shin Sangoku Musou 4 - Moushouden
@@ -6178,6 +6250,7 @@ Region = NTSC-Unk
 Serial = SLAJ-25075
 Name   = Need for Speed - Most Wanted [Black Edition]
 Region = NTSC-Unk
+MemCardFilter = SLAJ-25075/SLPM-66232/SLPM-66562/SLPM-65766/SLPM-66051/SLPM-66960
 ---------------------------------------------
 Serial = SLAJ-25076
 Name   = Harry Potter and the Goblet of Fire
@@ -6186,6 +6259,7 @@ Region = NTSC-Unk
 Serial = SLAJ-25077
 Name   = Sengoku Musou 2
 Region = NTSC-Unk
+MemCardFilter = SLAJ-25077/SLPM-55122/SLPM-66307/SLPM-74247/SLAJ-25035/SLPM-65517/SLPM-74212/SLPM-74235/SLAJ-25048/SLPM-65718/SLPM-74224/SLPM-74249
 ---------------------------------------------
 Serial = SLAJ-25078
 Name   = Black
@@ -6550,6 +6624,8 @@ Compat = 5
 Serial = SLES-50054
 Name   = Midnight Club
 Region = PAL-Unk
+// reads Smuggler's Run for bonus unlockable
+MemCardFilter = SLES-50054/SLES-50071/SLES-50055/SLES-50061
 ---------------------------------------------
 Serial = SLES-50055
 Name   = Smuggler's Run
@@ -6597,6 +6673,7 @@ Serial = SLES-50071
 Name   = Midnight Club - Street Racing
 Region = PAL-Unk
 Compat = 3
+MemCardFilter = SLES-50054/SLES-50071/SLES-50055/SLES-50061
 ---------------------------------------------
 Serial = SLES-50072
 Name   = Street Fighter EX3
@@ -9444,6 +9521,7 @@ Serial = SLES-51434
 Name   = Silent Hill 3
 Region = PAL-M5
 Compat = 5
+MemCardFilter = SLES-51434/SLES-50382/SLES-51156
 ---------------------------------------------
 Serial = SLES-51435
 Name   = International Superstar Soccer 3
@@ -10421,11 +10499,13 @@ Region = PAL-M4
 Serial = SLES-51913
 Name   = Onimusha Blade Warrior
 Region = PAL-Unk
+MemCardFilter = SLES-51913/SLES-51914
 ---------------------------------------------
 Serial = SLES-51914
 Name   = Onimusha 3 - Demon Siege
 Region = PAL-Unk
 Compat = 5
+MemCardFilter = SLES-51913/SLES-51914
 ---------------------------------------------
 Serial = SLES-51915
 Name   = Pro Evolution Soccer 3
@@ -11014,6 +11094,7 @@ EETimingHack = 1		//Path 3 masking errors
 Serial = SLES-52237
 Name   = dot Hack - Part 1 - Infection
 Region = PAL-M5
+MemCardFilter = SLES-52237/SLES-52467/SLES-52468/SLES-52469
 ---------------------------------------------
 Serial = SLES-52238
 Name   = Nightshade
@@ -11471,16 +11552,19 @@ Serial = SLES-52467
 Name   = dot Hack - Part 2 - Mutation
 Region = PAL-M5
 Compat = 5
+MemCardFilter = SLES-52237/SLES-52467/SLES-52468/SLES-52469
 ---------------------------------------------
 Serial = SLES-52468
 Name   = dot Hack - Part 4 - Quarantine
 Region = PAL-M5
 Compat = 5
+MemCardFilter = SLES-52237/SLES-52467/SLES-52468/SLES-52469
 ---------------------------------------------
 Serial = SLES-52469
 Name   = dot Hack - Part 3 - Outbreak
 Region = PAL-M5
 Compat = 5
+MemCardFilter = SLES-52237/SLES-52467/SLES-52468/SLES-52469
 ---------------------------------------------
 Serial = SLES-52471
 Name   = Naval Ops - Commander
@@ -12782,6 +12866,8 @@ patch=1,EE,0010f3e0,word,00000000
 Serial = SLES-52988
 Name   = MegaMan X8
 Region = PAL-Unk
+// reads Command Mission save for bonus boss
+MemCardFilter = SLES-52988/SLES-52832
 ---------------------------------------------
 Serial = SLES-52989
 Name   = Blowout
@@ -12795,6 +12881,8 @@ Serial = SLES-52998
 Name   = Sonic Mega Collection Plus
 Region = PAL-Unk
 Compat = 5
+// two games unlock by having a Sonic Heroes save
+MemCardFilter = SLES-52998/SLES-51950
 ---------------------------------------------
 Serial = SLES-52999
 Name   = RC Toy Machines
@@ -12972,6 +13060,8 @@ Serial = SLES-53039
 Name   = Champions - Return to Arms	// aka "Champions of Norrath 2"
 Region = PAL-Unk
 Compat = 4
+// allows import of characters from first game
+MemCardFilter = SLES-53039/SLES-52325
 ---------------------------------------------
 Serial = SLES-53041
 Name   = RTL Ski Alpine 2005
@@ -13481,6 +13571,8 @@ Region = PAL-M6
 Serial = SLES-53319
 Name   = Resident Evil Outbreak - File #2
 Region = PAL-Unk
+// reads and writes to Outbreak File #1
+MemCardFilter = SLES-53319/SCES-50987/SLES-51589
 ---------------------------------------------
 Serial = SLES-53320
 Name   = S.C.A.R. - Squadra Corse Alfa Romeo
@@ -13541,6 +13633,8 @@ Serial = SLES-53350
 Name   = Sonic Gems Collection
 Region = PAL-E
 Compat = 5
+// Vectorman unlocks by having a Mega Collection or Heroes save
+MemCardFilter = SLES-53350/SLES-52998/SLES-51950
 ---------------------------------------------
 Serial = SLES-53351
 Name   = SSX On Tour
@@ -13892,11 +13986,13 @@ Serial = SLES-53506
 Name   = Burnout Revenge
 Region = PAL-M5
 Compat = 5
+MemCardFilter = SLES-53506/SLES-53507/SLES-52584/SLES-52585/SLES-53510
 ---------------------------------------------
 Serial = SLES-53507
 Name   = Burnout Revenge
 Region = PAL-Unk
 Compat = 5
+MemCardFilter = SLES-53506/SLES-53507/SLES-52584/SLES-52585/SLES-53510
 ---------------------------------------------
 Serial = SLES-53508
 Name   = Ultimate Pro-Pinball
@@ -13934,14 +14030,17 @@ Region = PAL-G
 Serial = SLES-53526
 Name   = Suffering, The - Ties that Bind
 Region = PAL-E-F
+MemCardFilter = SLES-53526/SLES-53527/SLES-53528/SLES-53626/SLES-51693/SLES-52439/SLES-52531
 ---------------------------------------------
 Serial = SLES-53527
 Name   = Suffering, The - Ties that Bind
 Region = PAL-E-I-S
+MemCardFilter = SLES-53526/SLES-53527/SLES-53528/SLES-53626/SLES-51693/SLES-52439/SLES-52531
 ---------------------------------------------
 Serial = SLES-53528
 Name   = Suffering, The - Ties that Bind
 Region = PAL-G
+MemCardFilter = SLES-53526/SLES-53527/SLES-53528/SLES-53626/SLES-51693/SLES-52439/SLES-52531
 ---------------------------------------------
 Serial = SLES-53529
 Name   = FIFA '06
@@ -14032,14 +14131,18 @@ Serial = SLES-53557
 Name   = Need for Speed - Most Wanted
 Region = PAL-E
 Compat = 5
+// reads Underground 2 save for extra money
+MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53558
 Name   = Need for Speed - Most Wanted
 Region = PAL-Unk
+MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53559
 Name   = Need for Speed - Most Wanted
 Region = PAL-Unk
+MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53560
 Name   = Sonic Riders
@@ -14179,6 +14282,7 @@ Compat = 5
 Serial = SLES-53626
 Name   = Suffering, The - Ties that Bind
 Region = PAL-M2
+MemCardFilter = SLES-53526/SLES-53527/SLES-53528/SLES-53626/SLES-51693/SLES-52439/SLES-52531
 ---------------------------------------------
 Serial = SLES-53635
 Name   = NASCAR '06 - Total Team Control
@@ -14465,6 +14569,8 @@ Name   = Castlevania - Curse of Darkness
 Region = PAL-Unk
 Compat = 5
 vuClampMode = 0		//SPS with microVU
+// reads Lament of Innocence save for easter egg
+MemCardFilter = SLES-53755/SLES-52118
 ---------------------------------------------
 Serial = SLES-53756
 Name   = Resident Evil 4
@@ -14506,6 +14612,7 @@ Compat = 5
 Serial = SLES-53769
 Name   = Suikoden Tactics
 Region = PAL-Unk
+MemCardFilter = SLES-53769/SLES-52913
 ---------------------------------------------
 Serial = SLES-53772
 Name   = Air Raid 3
@@ -14658,6 +14765,7 @@ Region = PAL-Unk
 Serial = SLES-53857
 Name   = Need for Speed - Most Wanted [Black Edition]
 Region = PAL-E
+MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53860
 Name   = Dynasty Warriors 5 - Xtreme Legends
@@ -15440,6 +15548,8 @@ Region = PAL-F
 Serial = SLES-54221
 Name   = LEGO Star Wars II - The Original Trilogy
 Region = PAL-Unk
+// allows import of characters from Lego Star Wars 1
+MemCardFilter = SLES-54221/SLES-53194
 ---------------------------------------------
 Serial = SLES-54222
 Name   = SuperBikes Riding Challenge
@@ -15639,6 +15749,8 @@ Region = PAL-E
 Serial = SLES-54340
 Name   = Samurai Warriors 2
 Region = PAL-Unk
+// reads Samurai Warriors and Samurai Warriors Xtreme Legends saves for unlockables
+MemCardFilter = SLES-54340/SLES-52551/SLES-52552/SLES-52553/SLES-52554/SLES-52555/SLES-53002/SLES-53003/SLES-53004
 ---------------------------------------------
 Serial = SLES-54341
 Name   = Dancing Stage SuperNOVA
@@ -16077,6 +16189,8 @@ Serial = SLES-54555
 Name   = Shin Megami Tensei: Digital Devil Saga 2
 Region = PAL-E
 EETimingHack = 1
+// reads data from DDS1
+MemCardFilter = SLES-54555/SLES-53458
 ---------------------------------------------
 Serial = SLES-54560
 Name   = Alpine Ski Racing 2007
@@ -16915,6 +17029,8 @@ Region = PAL-M5
 Serial = SLES-55242
 Name   = Yakuza 2
 Region = PAL-E
+// allows import of Yakuza 1 data
+MemCardFilter = SLES-55242/SLES-54171
 ---------------------------------------------
 Serial = SLES-55243
 Name   = FIFA 09
@@ -17022,6 +17138,7 @@ Serial = SLES-55354
 Name   = Shin Megami Tensei: Persona 3 FES
 Region = PAL-E
 VuClipFlagHack = 1
+MemCardFilter = SLES-55354/SLES-55018
 ---------------------------------------------
 Serial = SLES-55355
 Name   = Guitar Hero - World Tour
@@ -17427,6 +17544,7 @@ Serial = SLES-82012
 Name   = Devil May Cry 2 [Lucia Disc]
 Region = PAL-E
 Compat = 5
+MemCardFilter = SLES-82011
 ---------------------------------------------
 Serial = SLES-82013
 Name   = Metal Gear Solid 3 - Snake Eater
@@ -17440,6 +17558,7 @@ Region = PAL-E-F-S
 Serial = SLES-82019
 Name   = Cy Girls [Disc 2]
 Region = PAL-E-F-S
+MemCardFilter = SLES-82018
 ---------------------------------------------
 Serial = SLES-82020
 Name   = Cy Girls [Disc 1]
@@ -17448,6 +17567,7 @@ Region = PAL-E-G-I
 Serial = SLES-82021
 Name   = Cy Girls [Disc 2]
 Region = PAL-E-G-I
+MemCardFilter = SLES-82020
 ---------------------------------------------
 Serial = SLES-82024
 Name   = Metal Gear Solid 3 - Snake Eater
@@ -17468,6 +17588,7 @@ Name   = Star Ocean 3 - Till the End of Time [Disc2of2]
 Region = PAL-E
 Compat = 5
 VuAddSubHack = 1
+MemCardFilter = SLES-82028
 ---------------------------------------------
 Serial = SLES-82030
 Name   = Shadow Hearts - Covenant [Disc1of2]
@@ -17476,6 +17597,7 @@ Region = PAL-Unk
 Serial = SLES-82031
 Name   = Shadow Hearts - Covenant [Disc2of2]
 Region = PAL-Unk
+MemCardFilter = SLES-82030
 ---------------------------------------------
 Serial = SLES-82032
 Name   = Metal Gear Solid 3 - Snake Eater
@@ -17484,10 +17606,12 @@ Region = PAL-G
 Serial = SLES-82034
 Name   = Xenosaga Episode II [Disc1of2]
 Region = PAL-E
+MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SLES-82035
 Name   = Xenosaga Episode II [Disc2of2]
 Region = PAL-E
+MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SLES-82036
 Name   = Armored Core - Nexus [Evolution Disc]
@@ -17510,6 +17634,7 @@ Serial = SLES-82039
 Name   = Onimusha - Dawn of Dreams [Disc2]
 Region = PAL-Unk
 Compat = 5
+MemCardFilter = SLES-82038
 [patches = 812C5A96]
 	comment= patch by Shadow Lady
 	patch=0,EE,00104170,word,00000000
@@ -17522,6 +17647,7 @@ Region = PAL-Unk
 Serial = SLES-82043
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82042
 ---------------------------------------------
 Serial = SLES-82044
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
@@ -17530,6 +17656,7 @@ Region = PAL-Unk
 Serial = SLES-82045
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82044
 ---------------------------------------------
 Serial = SLES-82046
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
@@ -17538,6 +17665,7 @@ Region = PAL-Unk
 Serial = SLES-82047
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82046
 ---------------------------------------------
 Serial = SLES-82048
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
@@ -17546,22 +17674,27 @@ Region = PAL-Unk
 Serial = SLES-82049
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82048
 ---------------------------------------------
 Serial = SLES-82050
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82042
 ---------------------------------------------
 Serial = SLES-82051
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82044
 ---------------------------------------------
 Serial = SLES-82052
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82046
 ---------------------------------------------
 Serial = SLES-82053
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
+MemCardFilter = SLES-82048
 ---------------------------------------------
 Serial = SLKA-15003
 Name   = Shikigami no Shiro II
@@ -17606,6 +17739,7 @@ Serial = SLKA-25013
 Name   = Devil May Cry 2 Lucia
 Region = NTSC-K
 Compat = 5
+MemCardFilter = SLKA-25012
 ---------------------------------------------
 Serial = SLKA-25015
 Name   = Evolution Skateboarding
@@ -17733,10 +17867,12 @@ Region = NTSC-K
 Serial = SLKA-25092
 Name   = Onimusha Buraiden
 Region = NTSC-K
+MemCardFilter = SLKA-25092/SLKA-25093
 ---------------------------------------------
 Serial = SLKA-25093
 Name   = Onimusha 3 Demon Siege
 Region = NTSC-K
+MemCardFilter = SLKA-25092/SLKA-25093
 ---------------------------------------------
 Serial = SLKA-25100
 Name   = Dragon Quest V Dragon Quarter
@@ -18049,10 +18185,12 @@ Region = NTSC-K
 Serial = SLKA-25280
 Name   = Ryu ga Gotoku 2 [Disc1of2]
 Region = NTSC-K
+MemCardFilter = SLKA-25280/SLKA-25342
 ---------------------------------------------
 Serial = SLKA-25281
 Name   = Ryu ga Gotoku 2 [Disc2of2]
 Region = NTSC-K
+MemCardFilter = SLKA-25280/SLKA-25342
 ---------------------------------------------
 Serial = SLKA-25284
 Name   = Sakura Taisen 3
@@ -18102,6 +18240,7 @@ Name   = Digital Devil Saga: Avatar Tuner 2
 Region = NTSC-K
 Compat = 5
 EETimingHack = 1
+MemCardFilter = SLKA-25301/SLKA-25300
 ---------------------------------------------
 Serial = SLKA-25307
 Name   = Dragonball Z Sparking
@@ -18144,6 +18283,7 @@ Name   = Castlevania - Curse of Darkness
 Region = NTSC-K
 Compat = 5
 vuClampMode = 0		//SPS with microVU
+MemCardFilter = SLKA-25328/SLKA-25082
 ---------------------------------------------
 Serial = SLKA-25329
 Name   = Shin Sangoku Musou 4 - Moushouden
@@ -18182,6 +18322,7 @@ Serial = SLKA-25354
 Name   = Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc2of2]
 Region = NTSC-K
 Compat = 5
+MemCardFilter = SLKA-25353
 ---------------------------------------------
 Serial = SLKA-25359
 Name   = Winning Eleven 9 - Liveware Edition
@@ -18344,6 +18485,7 @@ Region = NTSC-J
 Serial = SLPM-55122
 Name   = Sengoku Musou 2
 Region = NTSC-J
+MemCardFilter = SLAJ-25077/SLPM-55122/SLPM-66307/SLPM-74247/SLAJ-25035/SLPM-65517/SLPM-74212/SLPM-74235/SLAJ-25048/SLPM-65718/SLPM-74224/SLPM-74249
 ---------------------------------------------
 Serial = SLPM-55127
 Name   = Need for Speed - Undercover
@@ -21058,19 +21200,23 @@ Region = NTSC-J
 Serial = SLPM-65040
 Name   = Fear, The [Disc1of4]
 Region = NTSC-J
+MemCardFilter = SLPM-65040/SLPM-65041/SLPM-65042/SLPM-65043
 ---------------------------------------------
 Serial = SLPM-65041
 Name   = Fear, The [Disc2of4]
 Region = NTSC-J
+MemCardFilter = SLPM-65040/SLPM-65041/SLPM-65042/SLPM-65043
 ---------------------------------------------
 Serial = SLPM-65042
 Name   = Fear, The [Disc3of4]
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-65040/SLPM-65041/SLPM-65042/SLPM-65043
 ---------------------------------------------
 Serial = SLPM-65043
 Name   = Fear, The [Disc4of4]
 Region = NTSC-J
+MemCardFilter = SLPM-65040/SLPM-65041/SLPM-65042/SLPM-65043
 ---------------------------------------------
 Serial = SLPM-65044
 Name   = Aizouban Angelique Trois [Koei The Best]
@@ -21151,10 +21297,13 @@ Region = NTSC-J
 Serial = SLPM-65073
 Name   = Genso Suikoden III
 Region = NTSC-J
+// This looks like a mess because it includes all serials for Suikoden 3, Suikoden 2, Suikogaiden 1, and Suikogaiden 2. A lot of these probably aren't actually required but it's not really hurting anything to have them here.
+MemCardFilter = SLPM-65073/SLPM-65074/SLPM-65305/SLPM-65694/SLPM-86168/SLPM-86389/SLPM-87100/SLPM-86637/SLPM-86883/SLPM-87261/SLPM-86663/SLPM-86953/SLPM-87262
 ---------------------------------------------
 Serial = SLPM-65074
 Name   = Genso Suikoden III
 Region = NTSC-J
+MemCardFilter = SLPM-65073/SLPM-65074/SLPM-65305/SLPM-65694/SLPM-86168/SLPM-86389/SLPM-87100/SLPM-86637/SLPM-86883/SLPM-87261/SLPM-86663/SLPM-86953/SLPM-87262
 ---------------------------------------------
 Serial = SLPM-65075
 Name   = K-1 World Grand Prix 2001
@@ -21193,11 +21342,13 @@ Serial = SLPM-65086
 Name   = Ayumi Hamasaki Dome Tour 2001 - A Visual Mix [Disc1of2]
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPS-25071/SLPS-25072/SLPM-65086/SLPM-65087
 ---------------------------------------------
 Serial = SLPM-65087
 Name   = Ayumi Hamasaki Dome Tour 2001 - A Visual Mix [Disc2of2]
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPS-25071/SLPS-25072/SLPM-65086/SLPM-65087
 ---------------------------------------------
 Serial = SLPM-65089
 Name   = Grandia Extreme
@@ -21634,6 +21785,7 @@ Serial = SLPM-65233
 Name   = Devil May Cry 2 [Lucia Disc]
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-65232
 ---------------------------------------------
 Serial = SLPM-65234
 Name   = Gregory Horror Show - Soul Collector
@@ -21715,6 +21867,7 @@ Serial = SLPM-65257
 Name   = Silent Hill 3
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-65257/SLPM-65622/SLPM-66018/SLPM-65051/SLPM-65098/SLPM-65341/SLPM-65631
 ---------------------------------------------
 Serial = SLPM-65260
 Name   = Air Land Force
@@ -21879,6 +22032,7 @@ Region = NTSC-J
 Serial = SLPM-65305
 Name   = Genso Suikoden 3
 Region = NTSC-J
+MemCardFilter = SLPM-65073/SLPM-65074/SLPM-65305/SLPM-65694/SLPM-86168/SLPM-86389/SLPM-87100/SLPM-86637/SLPM-86883/SLPM-87261/SLPM-86663/SLPM-86953/SLPM-87262
 ---------------------------------------------
 Serial = SLPM-65306
 Name   = Sakura Yuki Gekka [Limited Edition]
@@ -22263,6 +22417,7 @@ Serial = SLPM-65411
 Name   = Onimusha Buraiden
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-65411/SLPM-65413
 ---------------------------------------------
 Serial = SLPM-65412
 Name   = War of the Monsters
@@ -22271,6 +22426,7 @@ Region = NTSC-J
 Serial = SLPM-65413
 Name   = Onimusha 3
 Region = NTSC-J
+MemCardFilter = SLPM-65411/SLPM-65413
 ---------------------------------------------
 Serial = SLPM-65414
 Name   = Simple 2000 Series Vol.45 - The Love and Tears and Memory
@@ -22365,6 +22521,7 @@ Name   = Star Ocean 3 [Director's Cut] [Disc2of2]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+MemCardFilter = SLPM-65438
 ---------------------------------------------
 Serial = SLPM-65441
 Name   = Ashita no Joe: Masshiro ni Moetsukuru
@@ -22595,14 +22752,17 @@ Compat = 5
 Serial = SLPM-65504
 Name   = Cool Girl [Limited Edition] [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPM-65504/SLPM-65505/SLPM-65506/SLPM-65742
 ---------------------------------------------
 Serial = SLPM-65505
 Name   = Cool Girl [Limited Edition] [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPM-65504/SLPM-65505/SLPM-65506/SLPM-65742
 ---------------------------------------------
 Serial = SLPM-65506
 Name   = Cool Girl
 Region = NTSC-J
+MemCardFilter = SLPM-65504/SLPM-65505/SLPM-65506/SLPM-65742
 ---------------------------------------------
 Serial = SLPM-65508
 Name   = Pop'n Music 9
@@ -23029,6 +23189,7 @@ Compat = 5
 Serial = SLPM-65622
 Name   = Silent Hill 3 [Konami The Best]
 Region = NTSC-J
+MemCardFilter = SLPM-65257/SLPM-65622/SLPM-66018/SLPM-65051/SLPM-65098/SLPM-65341/SLPM-65631
 ---------------------------------------------
 Serial = SLPM-65623
 Name   = Tantei Gakuen Q: Kiokan no Satsui [Konami The Best]
@@ -23274,6 +23435,7 @@ Serial = SLPM-65692
 Name   = BioHazard Outbreak - File #2
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-65692/SLPM-65428/SLPM-74201
 ---------------------------------------------
 Serial = SLPM-65693
 Name   = Tokimeki Memorial 3 [Konami Palace Selection]
@@ -23282,6 +23444,7 @@ Region = NTSC-J
 Serial = SLPM-65694
 Name   = Genso Suikoden 3 [Konami Dendou Collection]
 Region = NTSC-J
+MemCardFilter = SLPM-65073/SLPM-65074/SLPM-65305/SLPM-65694/SLPM-86168/SLPM-86389/SLPM-87100/SLPM-86637/SLPM-86883/SLPM-87261/SLPM-86663/SLPM-86953/SLPM-87262
 ---------------------------------------------
 Serial = SLPM-65695
 Name   = Hard Luck - Return of the Heroes
@@ -23408,6 +23571,7 @@ Region = NTSC-J
 Serial = SLPM-65730
 Name   = RockMan X8
 Region = NTSC-J
+MemCardFilter = SLPM-65730/SLPM-65643
 ---------------------------------------------
 Serial = SLPM-65731
 Name   = Tom Clancy's Rainbow Six 3
@@ -23454,6 +23618,7 @@ Region = NTSC-J
 Serial = SLPM-65742
 Name   = Cool Girl [Konami the Best]
 Region = NTSC-J
+MemCardFilter = SLPM-65504/SLPM-65505/SLPM-65506/SLPM-65742
 ---------------------------------------------
 Serial = SLPM-65744
 Name   = Firefighter F.D. 18 [Konami The Best]
@@ -23510,6 +23675,7 @@ Region = NTSC-J
 Serial = SLPM-65758
 Name   = Sonic Mega Collection Plus
 Region = NTSC-J
+MemCardFilter = SLPM-65758/SLAJ-25027/SLPM-65431
 ---------------------------------------------
 Serial = SLPM-65759
 Name   = Mr. Incredible
@@ -23645,6 +23811,7 @@ Serial = SLPM-65795
 Name   = Digital Devil Saga: Avatar Tuner 2
 Region = NTSC-J
 EETimingHack = 1
+MemCardFilter = SCAJ-20120/SLPM-65795/SLPM-66373/SCAJ-20095/SLPM-65597/SLPM-66372
 ---------------------------------------------
 Serial = SLPM-65796
 Name   = Project Altered Beast
@@ -24346,6 +24513,7 @@ Serial = SLPM-65977
 Name   = Grandia III [Disc2of2]
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-65976
 ---------------------------------------------
 Serial = SLPM-65978
 Name   = Kurogane no Houkou 2 - Warship Gunner [Koei The Best]
@@ -24481,6 +24649,7 @@ Region = NTSC-J
 Serial = SLPM-66018
 Name   = Silent Hill 3 [Konami Dendou Collection]
 Region = NTSC-J
+MemCardFilter = SLPM-65257/SLPM-65622/SLPM-66018/SLPM-65051/SLPM-65098/SLPM-65341/SLPM-65631
 ---------------------------------------------
 Serial = SLPM-66019
 Name   = Stuntman
@@ -24693,6 +24862,7 @@ Serial = SLPM-66074
 Name   = Sonic Gems Collection
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-66074/SLPM-65758/SLAJ-25027/SLPM-65431
 ---------------------------------------------
 Serial = SLPM-66076
 Name   = Meine Liebe - Yuubinaru kioku [Konami the Best]
@@ -24795,6 +24965,8 @@ Region = NTSC-J
 Serial = SLPM-66105
 Name   = Rhapsodia
 Region = NTSC-J
+// this is the JP Suikoden Tactics
+MemCardFilter = SLPM-66105/SLPM-66594/SLPM-65599/SLPM-65600
 ---------------------------------------------
 Serial = SLPM-66106
 Name   = Hoshi no Furu Koku [Limited Edition]
@@ -24807,6 +24979,7 @@ Region = NTSC-J
 Serial = SLPM-66108
 Name   = Burnout Revenge
 Region = NTSC-J
+MemCardFilter = SLAJ-25066/SLPM-66108/SLPM-66652/SLPM-65719/SLPM-65958/SLPM-66962/SLAJ-25053/SLPM-66204
 ---------------------------------------------
 Serial = SLPM-66109
 Name   = Code Age Commanders
@@ -25021,6 +25194,7 @@ Name   = Akumajo Dracula - Yami no Juin
 Region = NTSC-J
 Compat = 5
 vuClampMode = 0		//SPS with microVU
+MemCardFilter = SLPM-66175/SLPM-66668/SLPM-65406/SLPM-65444/SLPM-66325
 ---------------------------------------------
 Serial = SLPM-66176
 Name   = Chaos Field - New Order
@@ -25186,22 +25360,27 @@ Region = NTSC-J
 Serial = SLPM-66220
 Name   = Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc1of3]
 Region = NTSC-J
+MemCardFilter = SLPM-66117
 ---------------------------------------------
 Serial = SLPM-66221
 Name   = Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc2of3]
 Region = NTSC-J
+MemCardFilter = SLPM-66117
 ---------------------------------------------
 Serial = SLPM-66222
 Name   = Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc3of3]
 Region = NTSC-J
+MemCardFilter = SLPM-66117
 ---------------------------------------------
 Serial = SLPM-66223
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPM-66117
 ---------------------------------------------
 Serial = SLPM-66224
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPM-66117
 ---------------------------------------------
 Serial = SLPM-66225
 Name   = Da Capo Four Seasons [Deluxe Pack]
@@ -25230,6 +25409,7 @@ Region = NTSC-J
 Serial = SLPM-66232
 Name   = Need for Speed - Most Wanted
 Region = NTSC-J
+MemCardFilter = SLAJ-25075/SLPM-66232/SLPM-66562/SLPM-65766/SLPM-66051/SLPM-66960
 ---------------------------------------------
 Serial = SLPM-66233
 Name   = Kingdom Hearts II
@@ -25407,6 +25587,7 @@ Serial = SLPM-66276
 Name   = Shin Onimusha - Dawn of Dreams [Disc2of2]
 Region = NTSC-J
 Compat = 2
+MemCardFilter = SLPM-66275
 [patches = BD17248E]
 	comment= patch by Shadow Lady
 	patch=0,EE,00104170,word,00000000
@@ -25521,6 +25702,7 @@ Region = NTSC-J
 Serial = SLPM-66307
 Name   = Sengoku Musou 2
 Region = NTSC-J
+MemCardFilter = SLAJ-25077/SLPM-55122/SLPM-66307/SLPM-74247/SLAJ-25035/SLPM-65517/SLPM-74212/SLPM-74235/SLAJ-25048/SLPM-65718/SLPM-74224/SLPM-74249
 ---------------------------------------------
 Serial = SLPM-66308
 Name   = Harukanaru Toki no Naka Premium Boxset
@@ -25718,6 +25900,7 @@ Serial = SLPM-66373
 Name   = Digital Devil Saga: Avatar Tuner 2 [Atlus Best Collection]
 Region = NTSC-J
 EETimingHack = 1
+MemCardFilter = SCAJ-20120/SLPM-65795/SLPM-66373/SCAJ-20095/SLPM-65597/SLPM-66372
 ---------------------------------------------
 Serial = SLPM-66374
 Name   = World Soccer Winning Eleven 10
@@ -26114,6 +26297,7 @@ Name   = Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc2of2]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+MemCardFilter = SLPM-66478
 ---------------------------------------------
 Serial = SLPM-66480
 Name   = Dragon Quest V - Bride of the Sky [Ultimate Hits]
@@ -26423,6 +26607,7 @@ Region = NTSC-J
 Serial = SLPM-66562
 Name   = Need for Speed - Most Wanted [EA Best Hits]
 Region = NTSC-J
+MemCardFilter = SLAJ-25075/SLPM-66232/SLPM-66562/SLPM-65766/SLPM-66051/SLPM-66960
 ---------------------------------------------
 Serial = SLPM-66563
 Name   = Nizu no Senritsu [2800 Collection]
@@ -26463,6 +26648,7 @@ Region = NTSC-J
 Serial = SLPM-66572
 Name   = LEGO Star Wars II - The Original Trilogy
 Region = NTSC-J
+MemCardFilter = SLPM-66572/SLPS-20423
 ---------------------------------------------
 Serial = SLPM-66573
 Name   = Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]
@@ -26538,6 +26724,7 @@ Compat = 5
 Serial = SLPM-66594
 Name   = Rhapsodia [Konami the Best]
 Region = NTSC-J
+MemCardFilter = SLPM-66105/SLPM-66594/SLPM-65599/SLPM-65600
 ---------------------------------------------
 Serial = SLPM-66595
 Name   = J-League Winning Eleven 10 - Europa League '06-'07
@@ -26562,10 +26749,12 @@ Region = NTSC-J
 Serial = SLPM-66602
 Name   = Ryu ga Gotoku 2 [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPM-66602/SLPM-74301/SLPM-66168/SLPM-74234/SLPM-74253
 ---------------------------------------------
 Serial = SLPM-66603
 Name   = Ryu ga Gotoku 2 [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPM-66602/SLPM-74301/SLPM-66168/SLPM-74234/SLPM-74253
 ---------------------------------------------
 Serial = SLPM-66604
 Name   = Galaxy Angel - Moonlit Lovers [Banpresido the Best]
@@ -26744,6 +26933,7 @@ Region = NTSC-J
 Serial = SLPM-66652
 Name   = Burnout Revenge [EA Best Hits]
 Region = NTSC-J
+MemCardFilter = SLAJ-25066/SLPM-66108/SLPM-66652/SLPM-65719/SLPM-65958/SLPM-66962/SLAJ-25053/SLPM-66204
 ---------------------------------------------
 Serial = SLPM-66653
 Name   = Akudaikan 3
@@ -26803,6 +26993,7 @@ Serial = SLPM-66668
 Name   = Akumajo Dracula - Yami no Juin [Konami the Best]
 Region = NTSC-J
 vuClampMode = 0		//SPS with microVU
+MemCardFilter = SLPM-66175/SLPM-66668/SLPM-65406/SLPM-65444/SLPM-66325
 ---------------------------------------------
 Serial = SLPM-66669
 Name   = Prince of Tennis, The - Card Hunter [First Print Limited Edition]
@@ -26832,11 +27023,14 @@ Serial = SLPM-66675
 Name   = Kingdom Hearts II - Final Mix +
 Region = NTSC-J
 Compat = 5
+// reads Re:Chain data and vice-versa
+MemCardFilter = SLPM-66675/SLPM-66676
 ---------------------------------------------
 Serial = SLPM-66676
 Name   = Kingdom Hearts Re: Chain of Memories
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPM-66675/SLPM-66676
 ---------------------------------------------
 Serial = SLPM-66677
 Name   = Final Fantasy X - International [Ultimate Hits]
@@ -26850,10 +27044,12 @@ Region = NTSC-J
 Serial = SLPM-66679
 Name   = Devil Summoner: Kuzunoha Raidou tai Abaddon Ou [Plus]
 Region = NTSC-J
+MemCardFilter = SLPM-66679/SLPM-66683/SLPM-66246/SLPM-66634
 ---------------------------------------------
 Serial = SLPM-66683
 Name   = Devil Summoner: Kuzunoha Raidou tai Abaddon Ou
 Region = NTSC-J
+MemCardFilter = SLPM-66679/SLPM-66683/SLPM-66246/SLPM-66634
 ---------------------------------------------
 Serial = SLPM-66685
 Name   = Seaman 2 - Peking Genjin Ikusei Kit
@@ -26876,11 +27072,13 @@ Serial = SLPM-66689
 Name   = Persona 3 FES [Append Edition]
 Region = NTSC-J
 VuClipFlagHack = 1
+MemCardFilter = SLPM-66445/SLPM-66689/SLPM-66690
 ---------------------------------------------
 Serial = SLPM-66690
 Name   = Persona 3 FES [Independent Starting Version]
 Region = NTSC-J
 VuClipFlagHack = 1
+MemCardFilter = SLPM-66445/SLPM-66689/SLPM-66690
 ---------------------------------------------
 Serial = SLPM-66691
 Name   = Sengoku Basara 2 [CapKore]
@@ -28344,6 +28542,7 @@ Region = NTSC-J
 Serial = SLPM-74247
 Name   = Sengoku Musou 2 [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SLAJ-25077/SLPM-55122/SLPM-66307/SLPM-74247/SLAJ-25035/SLPM-65517/SLPM-74212/SLPM-74235/SLAJ-25048/SLPM-65718/SLPM-74224/SLPM-74249
 ---------------------------------------------
 Serial = SLPM-74248
 Name   = Monster Hunter G [PlayStation 2 The Best]
@@ -28402,6 +28601,7 @@ Region = NTSC-J
 Serial = SLPM-74301
 Name   = Ryu ga Gotoku 2 [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SLPM-66602/SLPM-74301/SLPM-66168/SLPM-74234/SLPM-74253
 ---------------------------------------------
 Serial = SLPM-74402
 Name   = Capcom vs. SNK 2 [PlayStation 2 The Best]
@@ -28532,10 +28732,12 @@ Region = NTSC-J
 Serial = SLPS-20018
 Name   = Stepping Selection [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPS-20018/SLPS-20019
 ---------------------------------------------
 Serial = SLPS-20019
 Name   = Stepping Selection [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPS-20018/SLPS-20019
 ---------------------------------------------
 Serial = SLPS-20020
 Name   = FIFA 2000 World Championship
@@ -28694,6 +28896,7 @@ Region = NTSC-J
 Serial = SLPS-20068
 Name   = Midnight Club - Street Racing
 Region = NTSC-J
+MemCardFilter = SLPS-20068/SLPS-20067
 ---------------------------------------------
 Serial = SLPS-20071
 Name   = Game Select 5
@@ -28722,10 +28925,12 @@ Region = NTSC-J
 Serial = SLPS-20084
 Name   = Basic Studio [Disc 1]
 Region = NTSC-J
+MemCardFilter = SLPS-20084/SLPS-20085
 ---------------------------------------------
 Serial = SLPS-20085
 Name   = Basic Studio [Disc 2]
 Region = NTSC-J
+MemCardFilter = SLPS-20084/SLPS-20085
 ---------------------------------------------
 Serial = SLPS-20086
 Name   = Generation of Chaos [Limited Edition]
@@ -30009,10 +30214,12 @@ Region = NTSC-J
 Serial = SLPS-25071
 Name   = Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPS-25071/SLPS-25072/SLPM-65086/SLPM-65087
 ---------------------------------------------
 Serial = SLPS-25072
 Name   = Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPS-25071/SLPS-25072/SLPM-65086/SLPM-65087
 ---------------------------------------------
 Serial = SLPS-25074
 Name   = Project Zero
@@ -30174,6 +30381,7 @@ Region = NTSC-J
 Serial = SLPS-25121
 Name   = dot Hack Vol.1
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-25122
 Name   = Mobile Suit Gundam - Lost War Chronicles [Limited Edition]
@@ -30235,6 +30443,7 @@ Region = NTSC-J
 Serial = SLPS-25143
 Name   = dot Hack Vol.2 - Mutation
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-25144
 Name   = Memorial Song
@@ -30275,6 +30484,7 @@ Region = NTSC-J
 Serial = SLPS-25158
 Name   = dot Hack - Vol.3 - Erosion Pollution
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-25159
 Name   = Technic Beat
@@ -30417,6 +30627,7 @@ Region = NTSC-J
 Serial = SLPS-25202
 Name   = dot Hack - Vol.4 - Zettai Houi
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-25204
 Name   = Moto GP3
@@ -30850,6 +31061,7 @@ Region = NTSC-J
 Serial = SLPS-25335
 Name   = Shadow Hearts 2 [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPS-25334
 ---------------------------------------------
 Serial = SLPS-25336
 Name   = Bass Landing 3 [with TsuriCon2+] [Sammy Best]
@@ -30975,18 +31187,23 @@ Region = NTSC-J
 Serial = SLPS-25366
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SLPS-25367
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SLPS-25368
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [Disc1of2]
 Region = NTSC-J
+// allows import of Xenosaga I, Xenosaga I Reloaded, and Xenosaga Freaks data
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SLPS-25369
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SLPS-25370
 Name   = Spawn - Armageddon
@@ -31363,6 +31580,7 @@ Region = NTSC-J
 Compat = 5
 vuClampMode = 3
 mvuFlagSpeedHack = 0
+MemCardFilter = SCAJ-20135/SLPS-25467/SLPS-73241/SCAJ-20079/SLPS-25360/SLPS-73210/SLPS-73240
 ---------------------------------------------
 Serial = SLPS-25468
 Name   = Eternal Aselia - The Spirit of Eternity Sword
@@ -31989,6 +32207,7 @@ Region = NTSC-J
 Serial = SLPS-25629
 Name   = Ace Combat Zero - The Belkan War
 Region = NTSC-J
+MemCardFilter = SCAJ-20173/SLPS-25629/SLPS-73250/SLPS-25052/SLPS-73205/SLPS-73410/SCAJ-20104/SCAJ-20136/SLPS-25418/SLPS-73218
 ---------------------------------------------
 Serial = SLPS-25630
 Name   = Pro Yakyuu Netsu Star 2006
@@ -32030,11 +32249,14 @@ Serial = SLPS-25640
 Name   = Xenosaga Episode III - Also Sprach Zarathustra [Disc1of2]
 Region = NTSC-J
 Compat = 5
+// allows import of Xenosaga II save data
+MemCardFilter = SLPS-25640/SLPS-25368
 ---------------------------------------------
 Serial = SLPS-25641
 Name   = Xenosaga Episode III - Also Sprach Zarathustra [Disc2of2]
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SLPS-25640/SLPS-25368
 ---------------------------------------------
 Serial = SLPS-25642
 Name   = Super DragonBall Z
@@ -32077,6 +32299,7 @@ Compat = 5
 Serial = SLPS-25651
 Name   = dot Hack G.U. Vol.1 - Saitan
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233/SLPS-25651/SLPS-25655/SLPS-25656/SLPS-25756
 ---------------------------------------------
 Serial = SLPS-25653
 Name   = Cluster Edge [Limited Edition]
@@ -32089,10 +32312,12 @@ Region = NTSC-J
 Serial = SLPS-25655
 Name   = dot Hack G.U. Vol.2 - Kimi Omou Koe
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233/SLPS-25651/SLPS-25655/SLPS-25656/SLPS-25756
 ---------------------------------------------
 Serial = SLPS-25656
 Name   = dot Hack - G.U. Vol.3 - Aruku Youna Hayasa de
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233/SLPS-25651/SLPS-25655/SLPS-25656/SLPS-25756
 ---------------------------------------------
 Serial = SLPS-25657
 Name   = Fighting Beauty Wulong
@@ -32478,6 +32703,7 @@ Region = NTSC-J
 Serial = SLPS-25756
 Name   = dot Hack G.U. Vol.1 - Saitan [Bandai the Best]
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233/SLPS-25651/SLPS-25655/SLPS-25656/SLPS-25756
 ---------------------------------------------
 Serial = SLPS-25757
 Name   = Nanatsu Iro - Drops Pure!! [First Print Limited Edition]
@@ -32812,12 +33038,15 @@ Serial = SLPS-25841
 Name   = Tales of Destiny [Director's Cut] [Premium Box]
 Region = NTSC-J
 FpuMulHack = 1
+// allows import of non-DC Tales of Destiny data
+MemCardFilter = SLPS-25841/SLPS-25842/SLPS-25715
 ---------------------------------------------
 Serial = SLPS-25842
 Name   = Tales of Destiny [Director's Cut]
 Region = NTSC-J
 Compat = 5
 FpuMulHack = 1
+MemCardFilter = SLPS-25841/SLPS-25842/SLPS-25715
 ---------------------------------------------
 Serial = SLPS-25843
 Name   = Tir-Na-Nog
@@ -33158,10 +33387,12 @@ eeClampMode = 1
 Serial = SLPS-73224
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc1of2]
 Region = NTSC-J
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SLPS-73225
 Name   = Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc2of2]
 Region = NTSC-J
+MemCardFilter = SLPS-29001/SLPS-29002/SLPS-29005/SLPS-25368/SLPS-25353/SLPS-73224
 ---------------------------------------------
 Serial = SLPS-73226
 Name   = Tenchu Kurenai [PlayStation 2 The Best]
@@ -33182,18 +33413,22 @@ Region = NTSC-J
 Serial = SLPS-73230
 Name   = dot Hack - Vol.1 & Vol.2 [PlayStation 2 The Best] [Vol.1 Disc]
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-73231
 Name   = dot Hack - Vol.1 & Vol.2 [PlayStation 2 The Best] [Vol.2 Disc]
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-73232
 Name   = dot Hack - Vol.3 & Vol.4 [PlayStation 2 The Best] [Vol.3 Disc]
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-73233
 Name   = dot Hack - Vol.3 & Vol.4 [PlayStation 2 The Best] [Vol.4 Disc]
 Region = NTSC-J
+MemCardFilter = SCPS-55029/SCPS-55042/SCAJ-20004/SCAJ-20024/SLPS-25121/SLPS-25143/SLPS-25158/SLPS-25202/SLPS-73230/SLPS-73231/SLPS-73232/SLPS-73233
 ---------------------------------------------
 Serial = SLPS-73234
 Name   = Kidou Senshi Z-Gundam - AEUG vs. Titans [PlayStation 2 The Best]
@@ -33229,6 +33464,7 @@ Name   = Minna Daisuki Katamari Damacy [PlayStation 2 The Best]
 Region = NTSC-J
 vuClampMode = 3
 mvuFlagSpeedHack = 0
+MemCardFilter = SCAJ-20135/SLPS-25467/SLPS-73241/SCAJ-20079/SLPS-25360/SLPS-73210/SLPS-73240
 ---------------------------------------------
 Serial = SLPS-73242
 Name   = Tales of Legendia [PlayStation 2 The Best]
@@ -33267,6 +33503,7 @@ Region = NTSC-J
 Serial = SLPS-73250
 Name   = Ace Combat Zero - The Belkan War [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SCAJ-20173/SLPS-25629/SLPS-73250/SLPS-25052/SLPS-73205/SLPS-73410/SCAJ-20104/SCAJ-20136/SLPS-25418/SLPS-73218
 ---------------------------------------------
 Serial = SLPS-73251
 Name   = Naruto - Narutimett Hero 3 [PlayStation 2 The Best]
@@ -33601,6 +33838,7 @@ Serial = SLUS-20063
 Name   = Midnight Club - Street Racing
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20063/SLUS-20065
 ---------------------------------------------
 Serial = SLUS-20064
 Name   = Oni
@@ -34464,6 +34702,7 @@ Serial = SLUS-20267
 Name   = dot Hack - Part 1 - Infection
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564
 ---------------------------------------------
 Serial = SLUS-20268
 Name   = Star Wars - Racer Revenge
@@ -35014,6 +35253,8 @@ Serial = SLUS-20387
 Name   = Suikoden III
 Region = NTSC-U
 Compat = 5
+// allows import of Suikoden II clear data
+MemCardFilter = SLUS-20387/SLUS-00958
 ---------------------------------------------
 Serial = SLUS-20388
 Name   = Fatal Frame
@@ -35782,16 +36023,19 @@ Serial = SLUS-20562
 Name   = dot Hack - Part 2 - Mutation
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564
 ---------------------------------------------
 Serial = SLUS-20563
 Name   = dot Hack - Part 3 - Outbreak
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564
 ---------------------------------------------
 Serial = SLUS-20564
 Name   = dot Hack - Part 4 - Quarantine
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564
 ---------------------------------------------
 Serial = SLUS-20565
 Name   = Champions of Norrath
@@ -36041,6 +36285,8 @@ Serial = SLUS-20622
 Name   = Silent Hill 3
 Region = NTSC-U
 Compat = 5
+// reads Silent Hill 2 for easter egg
+MemCardFilter = SLUS-20622/SLUS-20228
 ---------------------------------------------
 Serial = SLUS-20623
 Name   = Winning Eleven 6
@@ -36063,6 +36309,7 @@ Serial = SLUS-20627
 Name   = Devil May Cry 2 [Disc2of2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20484
 ---------------------------------------------
 Serial = SLUS-20628
 Name   = Disney's Finding Nemo
@@ -36364,6 +36611,7 @@ Serial = SLUS-20694
 Name   = Onimusha 3 - Demon Siege
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20694/SLUS-20710
 ---------------------------------------------
 Serial = SLUS-20695
 Name   = Chaos Legion
@@ -36432,6 +36680,7 @@ Serial = SLUS-20710
 Name   = Onimusha - Blade Warriors
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20694/SLUS-20710
 ---------------------------------------------
 Serial = SLUS-20711
 Name   = Dance Dance Revolution MAX 2
@@ -37071,6 +37320,7 @@ Serial = SLUS-20854
 Name   = Cy Girls [Disc2of2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20697
 ---------------------------------------------
 Serial = SLUS-20855
 Name   = Destruction Derby Arenas
@@ -37124,6 +37374,8 @@ Compat = 5
 Serial = SLUS-20865
 Name   = Backyard Baseball
 Region = NTSC-U
+// reads Backyard Basketball for bonus unlockable
+MemCardFilter = SLUS-20865/SLUS-20704
 ---------------------------------------------
 Serial = SLUS-20866
 Name   = Asterix & Obelix XXL - Kick Buttix
@@ -37251,11 +37503,14 @@ Name   = Star Ocean 3 - Till the End of Time [Disc2of2]
 Region = NTSC-U
 Compat = 5
 VuAddSubHack = 1
+MemCardFilter = SLUS-20488
 ---------------------------------------------
 Serial = SLUS-20892
 Name   = Xenosaga - Episode II - Jenseits von Gut und Bose [Disc1of2]
 Region = NTSC-U
 Compat = 5
+// allows import of Xenosaga I data
+MemCardFilter = SLUS-20469/SLUS-20892
 ---------------------------------------------
 Serial = SLUS-20893
 Name   = Way of the Samurai 2
@@ -37370,6 +37625,7 @@ Serial = SLUS-20917
 Name   = Sonic Mega Collection Plus
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20917/SLUS-20718
 ---------------------------------------------
 Serial = SLUS-20918
 Name   = Super Monkey Ball Deluxe
@@ -37581,6 +37837,7 @@ Serial = SLUS-20960
 Name   = MegaMan X8
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20960/SLUS-20903
 ---------------------------------------------
 Serial = SLUS-20961
 Name   = Neo Contra
@@ -37660,6 +37917,7 @@ Serial = SLUS-20973
 Name   = Champions - Return to Arms	// aka "Champions of Norrath 2"
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20973/SLUS-20565
 ---------------------------------------------
 Serial = SLUS-20974
 Name   = Shin Megami Tensei: Digital Devil Saga
@@ -37716,6 +37974,7 @@ Serial = SLUS-20984
 Name   = Resident Evil Outbreak - File #2
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20984/SLUS-20765
 ---------------------------------------------
 Serial = SLUS-20985
 Name   = Under the Skin
@@ -38024,6 +38283,7 @@ Serial = SLUS-21044
 Name   = Shadow Hearts - Covenant [Disc2of2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21041
 ---------------------------------------------
 Serial = SLUS-21045
 Name   = Conflict Vietnam
@@ -38428,6 +38688,7 @@ Serial = SLUS-21133
 Name   = Xenosaga - Episode II - Jenseits von Gut und Bose [Disc2of2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20469/SLUS-20892
 ---------------------------------------------
 Serial = SLUS-21134
 Name   = Resident Evil 4
@@ -38517,6 +38778,7 @@ Name   = Shin Megami Tensei: Digital Devil Saga 2
 Region = NTSC-U
 Compat = 5
 EETimingHack = 1
+MemCardFilter = SLUS-21152/SLUS-20974
 ---------------------------------------------
 Serial = SLUS-21153
 Name   = Dynasty Warriors 5
@@ -38590,6 +38852,7 @@ Name   = Castlevania - Curse of Darkness
 Region = NTSC-U
 Compat = 5
 vuClampMode = 0		//SPS with microVU
+MemCardFilter = SLUS-21168/SLUS-20733
 ---------------------------------------------
 Serial = SLUS-21169
 Name   = Rollercoaster Tycoon - The Peeps
@@ -38690,6 +38953,7 @@ Serial = SLUS-21189
 Name   = Suffering, The - Ties That Bind
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21189/SLUS-20636
 ---------------------------------------------
 Serial = SLUS-21190
 Name   = Outlaw Tennis
@@ -38891,6 +39155,8 @@ Region = NTSC-U
 Compat = 5
 vuClampMode = 3
 mvuFlagSpeedHack = 0
+// allows import of constellations from Katamari Damacy
+MemCardFilter = SLUS-21230/SLUS-21008
 ---------------------------------------------
 Serial = SLUS-21231
 Name   = Sniper Elite
@@ -38949,11 +39215,14 @@ Serial = SLUS-21242
 Name   = Burnout Revenge
 Region = NTSC-U
 Compat = 5
+// reads Burnout 3 and NFL 06 saves for unlockables
+MemCardFilter = SLUS-21242/SLUS-21050/SLUS-21213
 ---------------------------------------------
 Serial = SLUS-21243
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21359
 ---------------------------------------------
 Serial = SLUS-21244
 Name   = Fatal Frame 3 - The Tormented
@@ -38964,6 +39233,8 @@ Serial = SLUS-21245
 Name   = Suikoden Tactics
 Region = NTSC-U
 Compat = 5
+// allows import of Suikoden 4 clear data
+MemCardFilter = SLUS-21245/SLUS-20979
 ---------------------------------------------
 Serial = SLUS-21246
 Name   = Charlie and the Chocolate Factory
@@ -39024,6 +39295,7 @@ Serial = SLUS-21258
 Name   = dot Hack - G.U. Vol.1 - Rebirth
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564/SLUS-21258/SLUS-21488/SLUS-21489/SLUS-21480
 ---------------------------------------------
 Serial = SLUS-21259
 Name   = Stacked with Daniel Negreanu
@@ -39069,6 +39341,7 @@ Serial = SLUS-21267
 Name   = Need for Speed - Most Wanted
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21267/SLUS-21351/SLUS-21065
 ---------------------------------------------
 Serial = SLUS-21268
 Name   = 24 - The Game
@@ -39189,6 +39462,8 @@ Serial = SLUS-21292
 Name   = Wild ARMs 4
 Region = NTSC-U
 Compat = 5
+// allows import of Alter Code F clear data
+MemCardFilter = SLUS-21292/SLUS-20937
 ---------------------------------------------
 Serial = SLUS-21293
 Name   = Metal Saga
@@ -39390,6 +39665,7 @@ Serial = SLUS-21335
 Name   = Hustle, The - Detroit Streets - Kat's Story
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21334
 ---------------------------------------------
 Serial = SLUS-21336
 Name   = Zathura
@@ -39445,6 +39721,7 @@ Serial = SLUS-21346
 Name   = Ace Combat Zero - The Belkan War
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21346/SLUS-20152/SLUS-20851
 [patches = 65729657]
 	patch=0,EE,00131EBC,word,48498800
 	patch=0,EE,00131EC0,word,4B00682C
@@ -39475,6 +39752,7 @@ Serial = SLUS-21351
 Name   = Need for Speed - Most Wanted [Black Edition]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21267/SLUS-21351/SLUS-21065
 ---------------------------------------------
 Serial = SLUS-21352
 Name   = Dai Senryaku VII Exceed
@@ -39518,6 +39796,7 @@ Compat = 5
 Serial = SLUS-21360
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = NTSC-U
+MemCardFilter = SLUS-21359
 ---------------------------------------------
 Serial = SLUS-21361
 Name   = Devil May Cry 3 - Dante's Awakening [Special Edition]
@@ -39529,6 +39808,7 @@ Serial = SLUS-21362
 Name   = Onimusha - Dawn of Dreams [Disc2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21180
 [patches = FFDE85E9]
 	comment= patch by Shadow Lady
 	patch=0,EE,00104170,word,00000000
@@ -39663,6 +39943,8 @@ Serial = SLUS-21389
 Name   = Xenosaga - Episode III - Also Sprach Zarathustra [Disc1of2]
 Region = NTSC-U
 Compat = 5
+// allows import of Xenosaga II save data
+MemCardFilter = SLUS-21389/SLUS-20892
 ---------------------------------------------
 Serial = SLUS-21390
 Name   = Urban Chaos - Riot Response
@@ -39758,6 +40040,7 @@ Compat = 5
 Serial = SLUS-21409
 Name   = LEGO Star Wars II - The Original Trilogy
 Region = NTSC-U
+MemCardFilter = SLUS-21409/SLUS-21083
 ---------------------------------------------
 Serial = SLUS-21410
 Name   = Mortal Kombat - Armageddon
@@ -39797,6 +40080,7 @@ Serial = SLUS-21417
 Name   = Xenosaga - Episode III - Also Sprach Zarathustra [Disc2of2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21389/SLUS-20892
 ---------------------------------------------
 Serial = SLUS-21418
 Name   = Sprint Cars - Road to Knoxville
@@ -40011,6 +40295,7 @@ Serial = SLUS-21462
 Name   = Samurai Warriors 2
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21462/SLUS-20878/SLUS-21080
 ---------------------------------------------
 Serial = SLUS-21463
 Name   = Tom Clancy's Ghost Recon 2
@@ -40097,6 +40382,7 @@ Serial = SLUS-21480
 Name   = Dot Hack GU Volume 1 - Rebirth - Terminal Disc
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564/SLUS-21258/SLUS-21488/SLUS-21489/SLUS-21480
 ---------------------------------------------
 Serial = SLUS-21481
 Name   = NCAA March Madness '07
@@ -40135,11 +40421,13 @@ Serial = SLUS-21488
 Name   = dot Hack - G.U. Vol.2 - Reminisce
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564/SLUS-21258/SLUS-21488/SLUS-21489/SLUS-21480
 ---------------------------------------------
 Serial = SLUS-21489
 Name   = dot Hack - G.U. Vol.3 - Redemption
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20267/SLUS-20562/SLUS-20563/SLUS-20564/SLUS-21258/SLUS-21488/SLUS-21489/SLUS-21480
 ---------------------------------------------
 Serial = SLUS-21490
 Name   = Test Drive Unlimited
@@ -40600,6 +40888,7 @@ Name   = Shin Megami Tensei: Persona 3 FES
 Region = NTSC-U
 Compat = 5
 VuClipFlagHack = 1
+MemCardFilter = SLUS-21621/SLUS-21569
 ---------------------------------------------
 Serial = SLUS-21622
 Name   = Bee Movie Game
@@ -41266,6 +41555,8 @@ Serial = SLUS-21769
 Name   = Yakuza 2
 Region = NTSC-U
 Compat = 5
+// allows import of Yakuza 1 data
+MemCardFilter = SLUS-21769/SLUS-21348
 ---------------------------------------------
 Serial = SLUS-21770
 Name   = Madden NFL '09
@@ -41579,6 +41870,8 @@ Serial = SLUS-21845
 Name   = Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon
 Region = NTSC-U
 Compat = 5
+// allows import of save from Devil Summoner 1
+MemCardFilter = SLUS-21845/SLUS-21431
 ---------------------------------------------
 Serial = SLUS-21846
 Name   = Sonic Unleashed

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -207,7 +207,7 @@ Name   = Taiko No Tatsujin Doka! To Omori 7Daime
 Region = NTSC-Unk
 ---------------------------------------------
 Serial = SCAJ-20001
-Name   = Ratchet and Clank
+Name   = Ratchet & Clank
 Region = NTSC-Unk
 ---------------------------------------------
 Serial = SCAJ-20002
@@ -2726,7 +2726,7 @@ Name   = Jak II
 Region = NTSC-K
 ---------------------------------------------
 Serial = SCKA-20011
-Name   = Ratchet and Clank 2
+Name   = Ratchet & Clank 2
 Region = NTSC-K
 ---------------------------------------------
 Serial = SCKA-20012
@@ -2814,6 +2814,10 @@ Region = NTSC-K
 ---------------------------------------------
 Serial = SCKA-20035
 Name   = Hot Shots Golf 3 [PlayStation 2 Big Hit Series]
+Region = NTSC-K
+---------------------------------------------
+Serial = SCKA-20037
+Name   = Ratchet & Clank 3
 Region = NTSC-K
 ---------------------------------------------
 Serial = SCKA-20038
@@ -3001,7 +3005,7 @@ Name   = Super Robot Taisen OG - Original Generations Gaiden
 Region = NTSC-K
 ---------------------------------------------
 Serial = SCKA-20120
-Name   = Ratchet and Clank
+Name   = Ratchet & Clank
 Region = NTSC-K
 ---------------------------------------------
 Serial = SCKA-20132
@@ -3618,7 +3622,7 @@ Name   = Formula One 2005
 Region = NTSC-J
 ---------------------------------------------
 Serial = SCPS-15099
-Name   = Ratchet & Clank - Giga Battle
+Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle
 Region = NTSC-J
 ---------------------------------------------
 Serial = SCPS-15100
@@ -3935,7 +3939,7 @@ Name   = Wanda to Kyozou (Shadow of the Colossus) [PlayStation 2 The Best]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SCPS-19321
-Name   = Ratchet & Clank 4th - GiriGiri Gingano Giga-Battle [PlayStation 2 The Best]
+Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SCPS-19322
@@ -3964,7 +3968,7 @@ Name   = Ape Escape 3 [PlayStation 2 the Best - Reprint]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SCPS-19328
-Name   = Ratchet & Clank 4th Girigiri Gingano Giga-battle [PlayStation 2 the Best - Reprint]
+Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SCPS-19329
@@ -5154,7 +5158,7 @@ Name   = NBA '06
 Region = NTSC-U
 ---------------------------------------------
 Serial = SCUS-97353
-Name   = Ratchet and Clank - Up Your Arsenal
+Name   = Ratchet & Clank - Up Your Arsenal
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -5705,7 +5709,7 @@ Name   = Killzone [Greatest Hits]
 Region = NTSC-U
 ---------------------------------------------
 Serial = SCUS-97518
-Name   = Ratchet and Clank - Up Your Arsenal [Greatest Hits]
+Name   = Ratchet & Clank - Up Your Arsenal [Greatest Hits]
 Region = NTSC-U
 ---------------------------------------------
 Serial = SCUS-97519
@@ -9890,7 +9894,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51693
 Name   = Suffering, The
-Region = PAL-E
+Region = PAL-E-F-G
 ---------------------------------------------
 Serial = SLES-51696
 Name   = Dragon's Lair 3D - Special Edition
@@ -11408,7 +11412,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52439
 Name   = Suffering, The
-Region = PAL-E
+Region = PAL-E-I-S
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52440
@@ -11625,7 +11629,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52531
 Name   = Suffering, The
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52532
 Name   = Aces of War
@@ -11681,15 +11685,23 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52551
 Name   = Samurai Warriors
-Region = PAL-Unk
+Region = PAL-E
+---------------------------------------------
+Serial = SLES-52552
+Name   = Samurai Warriors
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52553
 Name   = Samurai Warriors
-Region = PAL-Unk
+Region = PAL-G
+---------------------------------------------
+Serial = SLES-52554
+Name   = Samurai Warriors
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52555
 Name   = Samurai Warriors
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52556
 Name   = Crimson Sea 2
@@ -13919,9 +13931,13 @@ Serial = SLES-53525
 Name   = Mortal Kombat - Shaolin Monks
 Region = PAL-G
 ---------------------------------------------
+Serial = SLES-53526
+Name   = Suffering, The - Ties that Bind
+Region = PAL-E-F
+---------------------------------------------
 Serial = SLES-53527
 Name   = Suffering, The - Ties that Bind
-Region = PAL-Unk
+Region = PAL-E-I-S
 ---------------------------------------------
 Serial = SLES-53528
 Name   = Suffering, The - Ties that Bind
@@ -16164,7 +16180,7 @@ Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54629
-Name   = Shin Megami Tensei - Devil Summoner
+Name   = Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs. the Soulless Army
 Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54631
@@ -17418,8 +17434,12 @@ Region = PAL-E-F
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82018
-Name   = Cy Girls
-Region = PAL-Unk
+Name   = Cy Girls [Disc 1]
+Region = PAL-E-F-S
+---------------------------------------------
+Serial = SLES-82019
+Name   = Cy Girls [Disc 2]
+Region = PAL-E-F-S
 ---------------------------------------------
 Serial = SLES-82020
 Name   = Cy Girls [Disc 1]
@@ -17496,51 +17516,51 @@ Compat = 5
 [/patches]
 ---------------------------------------------
 Serial = SLES-82042
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82043
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82044
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82045
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82046
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82047
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82048
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82049
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82050
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82051
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82052
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-82053
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLKA-15003
@@ -17697,7 +17717,7 @@ Name   = SD Gundam G Generation Neo
 Region = NTSC-K
 ---------------------------------------------
 Serial = SLKA-25082
-Name   = Castlevania Lament of Innocence
+Name   = Castlevania - Lament of Innocence
 Region = NTSC-K
 Compat = 5
 ---------------------------------------------
@@ -18120,7 +18140,7 @@ Name   = SSX On Tour
 Region = NTSC-J-K
 ---------------------------------------------
 Serial = SLKA-25328
-Name   = Castlevania - Curse of Dakness
+Name   = Castlevania - Curse of Darkness
 Region = NTSC-K
 Compat = 5
 vuClampMode = 0		//SPS with microVU
@@ -18154,12 +18174,12 @@ Name   = Full Metal Alchemist - Dream Carnival
 Region = NTSC-K
 ---------------------------------------------
 Serial = SLKA-25353
-Name   = Metal Gear Solid 3 - Subsistance [Limited Edition] [Disc1of2]
+Name   = Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc1of2]
 Region = NTSC-K
 Compat = 5
 ---------------------------------------------
 Serial = SLKA-25354
-Name   = Metal Gear Solid 3 - Subsistance [Limited Edition] [Disc2of2]
+Name   = Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc2of2]
 Region = NTSC-K
 Compat = 5
 ---------------------------------------------
@@ -23251,7 +23271,7 @@ Name   = Ever 17 - Out of Infinity [SuperLite 2000 Series]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-65692
-Name   = BioHazard Outbreak - File 2
+Name   = BioHazard Outbreak - File #2
 Region = NTSC-J
 Compat = 5
 ---------------------------------------------
@@ -24318,7 +24338,12 @@ Name   = World Rally Championship 4
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-65976
-Name   = Grandia III
+Name   = Grandia III [Disc1of2]
+Region = NTSC-J
+Compat = 5
+---------------------------------------------
+Serial = SLPM-65977
+Name   = Grandia III [Disc2of2]
 Region = NTSC-J
 Compat = 5
 ---------------------------------------------
@@ -25258,7 +25283,7 @@ Name   = Jewels Ocean - Star of Sierra Leone
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66246
-Name   = Shin Megami Tensei - Devil Summoner - Kuzunoha Raidou
+Name   = Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan
 Region = NTSC-J
 Compat = 5
 ---------------------------------------------
@@ -26535,7 +26560,11 @@ Name   = SSX On Tour [EA Best Hits]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66602
-Name   = Ryu ga Gotoku 2
+Name   = Ryu ga Gotoku 2 [Disc1of2]
+Region = NTSC-J
+---------------------------------------------
+Serial = SLPM-66603
+Name   = Ryu ga Gotoku 2 [Disc2of2]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66604
@@ -26652,7 +26681,7 @@ Name   = Shoujo Mahou Gaku Little Witch Romanesque
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66634
-Name   = Devil Summoner - Kuzunoha Raidou [Atlus Best Collection]
+Name   = Devil Summoner - Kuzunoha Raidou tai Chouriki Heidan [Atlus Best Collection]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66635
@@ -29978,7 +30007,11 @@ Name   = Tales of the Sunrise Heroes 2
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25071
-Name   = Visual Mix - Ayumi Hamasaki Dome Tour 2001
+Name   = Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc1of2]
+Region = NTSC-J
+---------------------------------------------
+Serial = SLPS-25072
+Name   = Visual Mix - Ayumi Hamasaki Dome Tour 2001 [Disc2of2]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25074
@@ -30762,7 +30795,11 @@ Region = NTSC-J
 Compat = 5
 ---------------------------------------------
 Serial = SLPS-25317
-Name   = Shadow Hearts 2 [Deluxe Pack]
+Name   = Shadow Hearts 2 [Deluxe Pack] [Disc1of2]
+Region = NTSC-J
+---------------------------------------------
+Serial = SLPS-25318
+Name   = Shadow Hearts 2 [Deluxe Pack] [Disc2of2]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25319
@@ -30807,7 +30844,11 @@ Name   = Gallop Racer Lucky 7
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25334
-Name   = Shadow Hearts 2
+Name   = Shadow Hearts 2 [Disc1of2]
+Region = NTSC-J
+---------------------------------------------
+Serial = SLPS-25335
+Name   = Shadow Hearts 2 [Disc1of2]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25336
@@ -31317,9 +31358,11 @@ Name   = Eternal Aselia - The Spirit of Eternity Sword [Limited Edition]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25467
-Name   = Minna Daisuki Katamaki Damacy
+Name   = Minna Daisuki Katamari Damacy
 Region = NTSC-J
 Compat = 5
+vuClampMode = 3
+mvuFlagSpeedHack = 0
 ---------------------------------------------
 Serial = SLPS-25468
 Name   = Eternal Aselia - The Spirit of Eternity Sword
@@ -37670,7 +37713,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-20984
-Name   = Resident Evil - Outbreak File #2
+Name   = Resident Evil Outbreak - File #2
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -37963,7 +38006,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21041
-Name   = Shadow Hearts 2 - Covenant [Disc1of2]
+Name   = Shadow Hearts - Covenant [Disc1of2]
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -37978,7 +38021,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21044
-Name   = Shadow Hearts 2 - Covenant [Disc2of2]
+Name   = Shadow Hearts - Covenant [Disc2of2]
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -38543,7 +38586,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21168
-Name   = Castlevania - Curse of Dakness
+Name   = Castlevania - Curse of Darkness
 Region = NTSC-U
 Compat = 5
 vuClampMode = 0		//SPS with microVU
@@ -38908,7 +38951,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21243
-Name   = Metal Gear Solid 3 - Subsistence
+Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -39468,12 +39511,12 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21359
-Name   = Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc2of3]
+Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21360
-Name   = Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc3of3]
+Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
 Region = NTSC-U
 ---------------------------------------------
 Serial = SLUS-21361

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -263,6 +263,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20011
 Name   = Armored Core 3 - Silent Line
 Region = NTSC-Unk
+MemCardFilter = SCAJ-20011/SCPS-55014/SLPS-25112/SLPS-25169/SLPS-73417/SLPS-73420
 ---------------------------------------------
 Serial = SCAJ-20012
 Name   = Venus & Braves
@@ -491,8 +492,14 @@ Name   = Dragon Quest V - Bride of the Sky
 Region = NTSC-Unk
 ---------------------------------------------
 Serial = SCAJ-20076
-Name   = Armored Core - Nexus
+Name   = Armored Core - Nexus [Disc 1]
 Region = NTSC-Unk
+MemCardFilter = SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
+---------------------------------------------
+Serial = SCAJ-20077
+Name   = Armored Core - Nexus [Disc 2]
+Region = NTSC-Unk
+MemCardFilter = SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
 ---------------------------------------------
 Serial = SCAJ-20078
 Name   = Kuon
@@ -2886,6 +2893,7 @@ Compat = 5
 Serial = SCKA-20047
 Name   = Armored Core Nine Breaker
 Region = NTSC-K
+MemCardFilter = SCKA-20047/SLKA-25201/SLKA-25202
 ---------------------------------------------
 Serial = SCKA-20048
 Name   = Killzone
@@ -4200,6 +4208,7 @@ Region = NTSC-J
 Serial = SCPS-55024
 Name   = Armored Core 2 - Another Age
 Region = NTSC-J
+MemCardFilter = SCPS-55024/SLPS-25007/SLPS-25040/SLPS-73403/SLPS-73411
 ---------------------------------------------
 Serial = SCPS-55025
 Name   = Eve of Extinction
@@ -8428,6 +8437,7 @@ Region = PAL-Unk
 Serial = SLES-50905
 Name   = Armored Core 2 - Another Age
 Region = PAL-Unk
+// save import option was removed from PAL release
 ---------------------------------------------
 Serial = SLES-50906
 Name   = Master Rally
@@ -11065,6 +11075,7 @@ Serial = SLES-52203
 Name   = Armored Core - Silent Line
 Region = PAL-Unk
 Compat = 5
+MemCardFilter = SLES-51399/SLES-52203
 ---------------------------------------------
 Serial = SLES-52204
 Name   = UFC Sudden Impact
@@ -14679,6 +14690,7 @@ Region = PAL-Unk
 Serial = SLES-53819
 Name   = Armored Core - Nine Breaker
 Region = PAL-Unk
+MemCardFilter = SLES-53819/SLES-82036/SLES-82037
 ---------------------------------------------
 Serial = SLES-53820
 Name   = Armored Core - Last Raven
@@ -17616,10 +17628,12 @@ MemCardFilter = SLES-82034/SCES-82034
 Serial = SLES-82036
 Name   = Armored Core - Nexus [Evolution Disc]
 Region = PAL-M5
+MemCardFilter = SLES-82036/SLES-82037
 ---------------------------------------------
 Serial = SLES-82037
 Name   = Armored Core - Nexus [Revolution Disc]
 Region = PAL-M5
+MemCardFilter = SLES-82036/SLES-82037
 ---------------------------------------------
 Serial = SLES-82038
 Name   = Onimusha - Dawn of Dreams [Disc1]
@@ -17774,6 +17788,7 @@ Region = NTSC-K
 Serial = SLKA-25041
 Name   = Armored Core 3 Silent Line
 Region = NTSC-K
+MemCardFilter = SLKA-25041/SLPM-67524
 ---------------------------------------------
 Serial = SLKA-25042
 Name   = Tamamayu Monogatari 2 Horobi no Mushi
@@ -18016,10 +18031,12 @@ Region = NTSC-K
 Serial = SLKA-25201
 Name   = Armored Core Nexus Evolution DISC1
 Region = NTSC-K
+MemCardFilter = SLKA-25201/SLKA-25202
 ---------------------------------------------
 Serial = SLKA-25202
 Name   = Armored Core Nexus Revolution DISC2
 Region = NTSC-K
+MemCardFilter = SLKA-25201/SLKA-25202
 ---------------------------------------------
 Serial = SLKA-25204
 Name   = Showdown - Legends of Wrestling
@@ -30127,6 +30144,7 @@ Serial = SLPS-25040
 Name   = Armored Core 2 - Another Age
 Region = NTSC-J
 Compat = 5
+MemCardFilter = SCPS-55024/SLPS-25007/SLPS-25040/SLPS-73403/SLPS-73411
 ---------------------------------------------
 Serial = SLPS-25041
 Name   = Shadow Hearts
@@ -30517,6 +30535,7 @@ Region = NTSC-J
 Serial = SLPS-25169
 Name   = Armored Core 3 - Silent Line
 Region = NTSC-J
+MemCardFilter = SCAJ-20011/SCPS-55014/SLPS-25112/SLPS-25169/SLPS-73417/SLPS-73420
 ---------------------------------------------
 Serial = SLPS-25170
 Name   = SD Gundam G Generation Neo
@@ -31072,8 +31091,14 @@ Name   = Bass Landing 3 [Sammy Best]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-25338
-Name   = Armored Core - Nexus
+Name   = Armored Core - Nexus [Disc 1]
 Region = NTSC-J
+MemCardFilter = SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
+---------------------------------------------
+Serial = SLPS-25339
+Name   = Armored Core - Nexus [Disc 2]
+Region = NTSC-J
+MemCardFilter = SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
 ---------------------------------------------
 Serial = SLPS-25340
 Name   = Missing Parts - Side B
@@ -31358,6 +31383,7 @@ Region = NTSC-J
 Serial = SLPS-25408
 Name   = Armored Core - Nine Breaker
 Region = NTSC-J
+MemCardFilter = SLPS-25408/SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
 ---------------------------------------------
 Serial = SLPS-25409
 Name   = Futakoi [Limited Edition]
@@ -33307,8 +33333,14 @@ Name   = Fatal Frame 2 - Crimson Butterfly [PlayStation 2 The Best]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPS-73202
-Name   = Armored Core - Nexus [PlayStation 2 The Best]
+Name   = Armored Core - Nexus [PlayStation 2 The Best] [Disc 1]
 Region = NTSC-J
+MemCardFilter = SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
+---------------------------------------------
+Serial = SLPS-73203
+Name   = Armored Core - Nexus [PlayStation 2 The Best] [Disc 2]
+Region = NTSC-J
+MemCardFilter = SCAJ-20076/SCAJ-20077/SLPS-25338/SLPS-25339/SLPS-73202/SLPS-73203
 ---------------------------------------------
 Serial = SLPS-73204
 Name   = Zettai Zetsumi Toshi [PlayStation 2 The Best]
@@ -33578,6 +33610,7 @@ Region = NTSC-J
 Serial = SLPS-73411
 Name   = Armored Core 2 - Another Age [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SCPS-55024/SLPS-25007/SLPS-25040/SLPS-73403/SLPS-73411
 ---------------------------------------------
 Serial = SLPS-73412
 Name   = Vampire Night [PlayStation 2 The Best]
@@ -33607,6 +33640,7 @@ Region = NTSC-J
 Serial = SLPS-73420
 Name   = Armored Core 3 - Silent Line [PlayStation 2 The Best]
 Region = NTSC-J
+MemCardFilter = SCAJ-20011/SCPS-55014/SLPS-25112/SLPS-25169/SLPS-73417/SLPS-73420
 ---------------------------------------------
 Serial = SLPS-73421
 Name   = Tenchu 3 [PlayStation 2 The Best]
@@ -34636,6 +34670,8 @@ Compat = 5
 Serial = SLUS-20249
 Name   = Armored Core 2 - Another Age
 Region = NTSC-U
+// can import data from regular Armored Core 2
+MemCardFilter = SLUS-20249/SLUS-20014
 ---------------------------------------------
 Serial = SLUS-20250
 Name   = Stuntman
@@ -36394,6 +36430,8 @@ Compat = 5
 Serial = SLUS-20644
 Name   = Armored Core - Silent Line
 Region = NTSC-U
+// can import data from AC3
+MemCardFilter = SLUS-20435/SLUS-20644
 ---------------------------------------------
 Serial = SLUS-20645
 Name   = Time Crisis 3 [with Guncon]
@@ -37984,6 +38022,7 @@ Serial = SLUS-20986
 Name   = Armored Core Nexus [Evolution Disc]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-20986/SLUS-21079
 ---------------------------------------------
 Serial = SLUS-20987
 Name   = Pool Paradise
@@ -38440,6 +38479,7 @@ Compat = 5
 Serial = SLUS-21079
 Name   = Armored Core Nexus [Revolution Disc]
 Region = NTSC-U
+MemCardFilter = SLUS-20986/SLUS-21079
 ---------------------------------------------
 Serial = SLUS-21080
 Name   = Samurai Warriors - Xtreme Legends
@@ -39010,6 +39050,8 @@ Serial = SLUS-21200
 Name   = Armored Core - Nine Breaker
 Region = NTSC-U
 Compat = 5
+// can import data from AC:Nexus
+MemCardFilter = SLUS-21200/SLUS-20986/SLUS-21079
 ---------------------------------------------
 Serial = SLUS-21201
 Name   = Tales of Legendia

--- a/common/include/PluginCallbacks.h
+++ b/common/include/PluginCallbacks.h
@@ -1109,7 +1109,9 @@ typedef struct _PS2E_ComponentAPI_Mcd
 	// Used by the FolderMemoryCard to find a good time to flush written data to the host file system.
 	void (PS2E_CALLBACK* McdNextFrame)( PS2E_THISPTR thisptr, uint port, uint slot );
 
-	void* reserved[7];
+	void (PS2E_CALLBACK* McdReIndex)( PS2E_THISPTR thisptr, uint port, uint slot, const wxString& filter );
+
+	void* reserved[6];
 
 } PS2E_ComponentAPI_Mcd;
 

--- a/common/include/PluginCallbacks.h
+++ b/common/include/PluginCallbacks.h
@@ -1104,7 +1104,12 @@ typedef struct _PS2E_ComponentAPI_Mcd
 
 	u64 (PS2E_CALLBACK* McdGetCRC)( PS2E_THISPTR thisptr, uint port, uint slot );
 
-	void* reserved[8];
+	// McdNextFrame
+	// Inform the memory card that a frame of emulation time has passed.
+	// Used by the FolderMemoryCard to find a good time to flush written data to the host file system.
+	void (PS2E_CALLBACK* McdNextFrame)( PS2E_THISPTR thisptr, uint port, uint slot );
+
+	void* reserved[7];
 
 } PS2E_ComponentAPI_Mcd;
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -272,6 +272,7 @@ set(pcsx2GuiSources
 	gui/Panels/ThemeSelectorPanel.cpp
 	gui/Dialogs/BaseConfigurationDialog.cpp
 	gui/Dialogs/ConfirmationDialogs.cpp
+	gui/Dialogs/ConvertMemoryCardDialog.cpp
 	gui/Dialogs/CreateMemoryCardDialog.cpp
 	gui/Dialogs/FirstTimeWizard.cpp
 	gui/Dialogs/GameDatabaseDialog.cpp

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -296,6 +296,7 @@ set(pcsx2GuiSources
 	gui/MainFrame.cpp
 	gui/MainMenuClicks.cpp
 	gui/MemoryCardFile.cpp
+	gui/MemoryCardFolder.cpp
 	gui/Panels/BaseApplicableConfigPanel.cpp
 	gui/Panels/MemoryCardListPanel.cpp
 	gui/MessageBoxes.cpp
@@ -348,6 +349,7 @@ set(pcsx2GuiHeaders
 	gui/IsoDropTarget.h
 	gui/MainFrame.h
 	gui/MemoryCardFile.h
+	gui/MemoryCardFolder.h
 	gui/MSWstuff.h
 	gui/Panels/ConfigurationPanels.h
 	gui/Panels/LogOptionsPanels.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -441,6 +441,7 @@ struct Pcsx2Config
 			BackupSavestate		:1,
 		// enables simulated ejection of memory cards when loading savestates
 			McdEnableEjection	:1,
+			McdFolderAutoManage	:1,
 
 			MultitapPort0_Enabled:1,
 			MultitapPort1_Enabled:1,

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -431,10 +431,8 @@ static __fi void VSyncEnd(u32 sCycle)
 	psxVBlankEnd(); // psxCounters vBlank End
 	if (gates) rcntEndGate(true, sCycle); // Counters End Gate Code
 
-#ifdef MEMORYCARD_USE_FOLDER
 	// FolderMemoryCard needs information on how much time has passed since the last write
 	sioNextFrame();
-#endif
 
 	frameLimit(); // limit FPS
 

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -29,6 +29,8 @@
 
 #include "ps2/HwInternal.h"
 
+#include "Sio.h"
+
 using namespace Threading;
 
 extern u8 psxhblankgate;
@@ -428,6 +430,12 @@ static __fi void VSyncEnd(u32 sCycle)
 	hwIntcIrq(INTC_VBLANK_E);  // HW Irq
 	psxVBlankEnd(); // psxCounters vBlank End
 	if (gates) rcntEndGate(true, sCycle); // Counters End Gate Code
+
+#ifdef MEMORYCARD_USE_FOLDER
+	// FolderMemoryCard needs information on how much time has passed since the last write
+	sioNextFrame();
+#endif
+
 	frameLimit(); // limit FPS
 
 	//Do this here, breaks Dynasty Warriors otherwise.

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -398,6 +398,7 @@ Pcsx2Config::Pcsx2Config()
 	bitset = 0;
 	// Set defaults for fresh installs / reset settings
 	McdEnableEjection = true;
+	McdFolderAutoManage = true;
 	EnablePatches = true;
 	BackupSavestate = true;
 }
@@ -417,6 +418,7 @@ void Pcsx2Config::LoadSave( IniInterface& ini )
 
 	IniBitBool( BackupSavestate );
 	IniBitBool( McdEnableEjection );
+	IniBitBool( McdFolderAutoManage );
 	IniBitBool( MultitapPort0_Enabled );
 	IniBitBool( MultitapPort1_Enabled );
 

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -66,6 +66,9 @@ u64 SysPluginBindings::McdGetCRC( uint port, uint slot )
 	return Mcd->McdGetCRC( (PS2E_THISPTR) Mcd, port, slot );
 }
 
+void SysPluginBindings::McdNextFrame( uint port, uint slot ) {
+	Mcd->McdNextFrame( (PS2E_THISPTR) Mcd, port, slot );
+}
 
 // ----------------------------------------------------------------------------
 // Yay, order of this array shouldn't be important. :)

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -70,6 +70,10 @@ void SysPluginBindings::McdNextFrame( uint port, uint slot ) {
 	Mcd->McdNextFrame( (PS2E_THISPTR) Mcd, port, slot );
 }
 
+void SysPluginBindings::McdReIndex( uint port, uint slot, const wxString& filter ) {
+	Mcd->McdReIndex( (PS2E_THISPTR) Mcd, port, slot, filter );
+}
+
 // ----------------------------------------------------------------------------
 // Yay, order of this array shouldn't be important. :)
 //

--- a/pcsx2/Plugins.h
+++ b/pcsx2/Plugins.h
@@ -242,6 +242,7 @@ public:
 	void McdEraseBlock( uint port, uint slot, u32 adr );
 	u64  McdGetCRC( uint port, uint slot );
 	void McdNextFrame( uint port, uint slot );
+	void McdReIndex( uint port, uint slot, const wxString& filter );
 
 	friend class SysCorePlugins;
 };

--- a/pcsx2/Plugins.h
+++ b/pcsx2/Plugins.h
@@ -241,6 +241,7 @@ public:
 	void McdSave( uint port, uint slot, const u8 *src, u32 adr, int size );
 	void McdEraseBlock( uint port, uint slot, u32 adr );
 	u64  McdGetCRC( uint port, uint slot );
+	void McdNextFrame( uint port, uint slot );
 
 	friend class SysCorePlugins;
 };

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -871,6 +871,14 @@ void SIODMAWrite(u8 value)
 	sioWrite8inl(value);
 }
 
+void sioNextFrame() {
+	for ( uint port = 0; port < 2; ++port ) {
+		for ( uint slot = 0; slot < 4; ++slot ) {
+			mcds[port][slot].NextFrame();
+		}
+	}
+}
+
 void SaveStateBase::sioFreeze()
 {
 	// CRCs for memory cards.

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -879,6 +879,20 @@ void sioNextFrame() {
 	}
 }
 
+// Used to figure out when a new game boots, so that memory cards can re-index themselves and only load data relevant to that game.
+wxString SioCurrentGameSerial = L"";
+void sioSetGameSerial( const wxString& serial ) {
+	if ( serial == SioCurrentGameSerial ) { return; }
+	SioCurrentGameSerial = serial;
+
+	for ( uint port = 0; port < 2; ++port ) {
+		for ( uint slot = 0; slot < 4; ++slot ) {
+			mcds[port][slot].ReIndex( serial );
+		}
+	}
+	SetForceMcdEjectTimeoutNow();
+}
+
 void SaveStateBase::sioFreeze()
 {
 	// CRCs for memory cards.

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -60,6 +60,13 @@ void SetForceMcdEjectTimeoutNow()
 				mcds[port][slot].ForceEjection_Timeout = FORCED_MCD_EJECTION_MAX_TRIES;
 }
 
+void ClearMcdEjectTimeoutNow()
+{
+	for( u8 port=0; port<2; ++port ) 
+			for( u8 slot=0; slot<4; ++slot )
+				mcds[port][slot].ForceEjection_Timeout = 0;
+}
+
 // SIO Inline'd IRQs : Calls the SIO interrupt handlers directly instead of
 // feeding them through the IOP's branch test. (see SIO.H for details)
 

--- a/pcsx2/Sio.h
+++ b/pcsx2/Sio.h
@@ -19,6 +19,8 @@
 // Games are highly unlikely to need timed IRQ's for PAD and MemoryCard handling anyway (rama).
 #define SIO_INLINE_IRQS
 
+#include "MemoryCardFile.h"
+
 struct _mcd
 {
 	u8 term; // terminator value;
@@ -80,6 +82,10 @@ struct _mcd
 	{
 		return SysPlugins.McdGetCRC(port, slot);
 	}
+
+	void NextFrame() {
+		SysPlugins.McdNextFrame( port, slot );
+	}
 };
 
 struct _sio
@@ -117,3 +123,4 @@ extern void sioWriteCtrl16(u16 value);
 extern void sioInterrupt();
 extern void InitializeSIO(u8 value);
 extern void SetForceMcdEjectTimeoutNow();
+extern void sioNextFrame();

--- a/pcsx2/Sio.h
+++ b/pcsx2/Sio.h
@@ -127,5 +127,6 @@ extern void sioWriteCtrl16(u16 value);
 extern void sioInterrupt();
 extern void InitializeSIO(u8 value);
 extern void SetForceMcdEjectTimeoutNow();
+extern void ClearMcdEjectTimeoutNow();
 extern void sioNextFrame();
 extern void sioSetGameSerial(const wxString& serial);

--- a/pcsx2/Sio.h
+++ b/pcsx2/Sio.h
@@ -86,6 +86,10 @@ struct _mcd
 	void NextFrame() {
 		SysPlugins.McdNextFrame( port, slot );
 	}
+
+	void ReIndex(const wxString& filter = L"") {
+		SysPlugins.McdReIndex( port, slot, filter );
+	}
 };
 
 struct _sio
@@ -124,3 +128,4 @@ extern void sioInterrupt();
 extern void InitializeSIO(u8 value);
 extern void SetForceMcdEjectTimeoutNow();
 extern void sioNextFrame();
+extern void sioSetGameSerial(const wxString& serial);

--- a/pcsx2/Utilities/FileUtils.cpp
+++ b/pcsx2/Utilities/FileUtils.cpp
@@ -16,6 +16,9 @@
 #include "PrecompiledHeader.h"
 #include "AsciiFile.h"
 
+#include <wx/dir.h>
+#include <wx/string.h>
+
 void AsciiFile::Printf( const char* fmt, ... )
 {
 	va_list list;
@@ -24,4 +27,71 @@ void AsciiFile::Printf( const char* fmt, ... )
 	ascii.WriteV(fmt,list);
 	va_end( list );
 	Write( ascii, strlen(ascii) );
+}
+
+bool CopyDirectory( const wxString& from, const wxString& to ) {
+	wxDir src( from );
+	if ( !src.IsOpened() ) {
+		return false;
+	}
+
+	wxMkdir( to );
+	wxDir dst( to );
+	if ( !dst.IsOpened() ) {
+		return false;
+	}
+
+	wxString filename;
+
+	// copy directories
+	if ( src.GetFirst( &filename, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN ) ) {
+		do {
+			if ( !CopyDirectory( wxFileName( from, filename ).GetFullPath(), wxFileName( to, filename ).GetFullPath() ) ) {
+				return false;
+			}
+		} while ( src.GetNext( &filename ) );
+	}
+
+	// copy files
+	if ( src.GetFirst( &filename, wxEmptyString, wxDIR_FILES | wxDIR_HIDDEN ) ) {
+		do {
+			if ( !wxCopyFile( wxFileName( from, filename ).GetFullPath(), wxFileName( to, filename ).GetFullPath() ) ) {
+				return false;
+			}
+		} while ( src.GetNext( &filename ) );
+	}
+
+	return true;
+}
+
+bool RemoveDirectory( const wxString& dirname ) {
+		{
+			wxDir dir( dirname );
+			if ( !dir.IsOpened() ) {
+				return false;
+			}
+
+			wxString filename;
+
+			// delete subdirs recursively
+			if ( dir.GetFirst( &filename, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN ) ) {
+				do {
+					if ( !RemoveDirectory( wxFileName( dirname, filename ).GetFullPath() ) ) {
+						return false;
+					}
+				} while ( dir.GetNext( &filename ) );
+			}
+
+			// delete files
+			if ( dir.GetFirst( &filename, wxEmptyString, wxDIR_FILES | wxDIR_HIDDEN ) ) {
+				do {
+					if ( !wxRemoveFile( wxFileName( dirname, filename ).GetFullPath() ) ) {
+						return false;
+					}
+				} while ( dir.GetNext( &filename ) );
+			}
+		}
+
+	// oddly enough this has different results compared to the more sensible dirname.Rmdir(), don't change!
+	return wxFileName::Rmdir( dirname );
 }

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -611,6 +611,10 @@ void AppConfig::LoadSaveMemcards( IniInterface& ini )
 			Mcd[slot].Enabled, Mcd[slot].Enabled );
 		ini.Entry( pxsFmt( L"Slot%u_Filename", slot+1 ),
 			Mcd[slot].Filename, Mcd[slot].Filename );
+		int type = (int)Mcd[slot].Type;
+		ini.Entry( pxsFmt( L"Slot%u_Type", slot + 1 ),
+			type, (int)MemoryCardType::MemoryCard_File );
+		Mcd[slot].Type = (MemoryCardType)type;
 	}
 
 	for( uint slot=2; slot<8; ++slot )
@@ -622,6 +626,10 @@ void AppConfig::LoadSaveMemcards( IniInterface& ini )
 			Mcd[slot].Enabled, Mcd[slot].Enabled );
 		ini.Entry( pxsFmt( L"Multitap%u_Slot%u_Filename", mtport, mtslot ),
 			Mcd[slot].Filename, Mcd[slot].Filename );
+		int type = (int)Mcd[slot].Type;
+		ini.Entry( pxsFmt( L"Multitap%u_Slot%u_Type", mtport, mtslot ),
+			type, (int)MemoryCardType::MemoryCard_File );
+		Mcd[slot].Type = (MemoryCardType)type;
 	}
 }
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -98,6 +98,14 @@ enum AspectRatioType
 	AspectRatio_MaxCount
 };
 
+enum MemoryCardType
+{
+	MemoryCard_None,
+	MemoryCard_File,
+	MemoryCard_Folder,
+	MemoryCard_MaxCount
+};
+
 // =====================================================================================================
 //  Pcsx2 Application Configuration. 
 // =====================================================================================================
@@ -182,6 +190,7 @@ public:
 	{
 		wxFileName	Filename;	// user-configured location of this memory card
 		bool		Enabled;	// memory card enabled (if false, memcard will not show up in-game)
+		MemoryCardType Type;	// the memory card implementation that should be used
 	};
 
 	// ------------------------------------------------------------------------

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -522,6 +522,7 @@ void AppCoreThread::GameStartingInThread()
 	m_ExecMode = ExecMode_Paused;
 	OnResumeReady();
 	_reset_stuff_as_needed();
+	ClearMcdEjectTimeoutNow(); // probably safe to do this when a game boots, eliminates annoying prompts
 	m_ExecMode = ExecMode_Opened;
 	
 	_parent::GameStartingInThread();

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -345,6 +345,7 @@ void AppCoreThread::ApplySettings( const Pcsx2Config& src )
 
 	wxString gameName;
 	wxString gameCompat;
+	wxString gameMemCardFilter;
 
 	int numberLoadedCheats;
 	int numberLoadedWideScreenPatches;
@@ -369,6 +370,7 @@ void AppCoreThread::ApplySettings( const Pcsx2Config& src )
 				gameName   = game.getString("Name");
 				gameName  += L" (" + game.getString("Region") + L")";
 				gameCompat = L" [Status = "+compatToStringWX(compat)+L"]";
+				gameMemCardFilter = game.getString("MemCardFilter");
 			}
 
 			if (EmuConfig.EnablePatches) {
@@ -383,7 +385,11 @@ void AppCoreThread::ApplySettings( const Pcsx2Config& src )
 		}
 	}
 
-	sioSetGameSerial( curGameKey );
+	if (!gameMemCardFilter.IsEmpty()) {
+		sioSetGameSerial(gameMemCardFilter);
+	} else {
+		sioSetGameSerial(curGameKey);
+	}
 
 	if (gameName.IsEmpty() && gameSerial.IsEmpty() && gameCRC.IsEmpty())
 	{

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -31,6 +31,7 @@
 #include "Elfheader.h"
 #include "Patch.h"
 #include "R5900Exceptions.h"
+#include "Sio.h"
 
 __aligned16 SysMtgsThread mtgsThread;
 __aligned16 AppCoreThread CoreThread;
@@ -381,6 +382,8 @@ void AppCoreThread::ApplySettings( const Pcsx2Config& src )
 			}
 		}
 	}
+
+	sioSetGameSerial( curGameKey );
 
 	if (gameName.IsEmpty() && gameSerial.IsEmpty() && gameCRC.IsEmpty())
 	{

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -237,4 +237,26 @@ namespace Dialogs
 		void CreateControls();
 		void OnOk_Click( wxCommandEvent& evt );
 	};
+
+	// --------------------------------------------------------------------------------------
+	//  ConvertMemoryCardDialog
+	// --------------------------------------------------------------------------------------
+	class ConvertMemoryCardDialog : public wxDialogWithHelpers
+	{
+	protected:
+		wxDirName     m_mcdPath;
+		wxString      m_mcdSourceFilename;
+		wxTextCtrl*   m_text_filenameInput;
+		pxRadioPanel* m_radio_CardType;
+
+	public:
+		virtual ~ConvertMemoryCardDialog()  throw() {}
+		ConvertMemoryCardDialog( wxWindow* parent, const wxDirName& mcdPath, const AppConfig::McdOptions& mcdSourceConfig );
+	
+	protected:
+		void CreateControls( const MemoryCardType sourceType );
+		void OnOk_Click( wxCommandEvent& evt );
+		bool ConvertToFile( const wxFileName& sourcePath, const wxFileName& targetPath );
+		bool ConvertToFolder( const wxFileName& sourcePath, const wxFileName& targetPath );
+	};
 }

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -256,7 +256,7 @@ namespace Dialogs
 	protected:
 		void CreateControls( const MemoryCardType sourceType );
 		void OnOk_Click( wxCommandEvent& evt );
-		bool ConvertToFile( const wxFileName& sourcePath, const wxFileName& targetPath );
+		bool ConvertToFile( const wxFileName& sourcePath, const wxFileName& targetPath, const u32 sizeInMB );
 		bool ConvertToFolder( const wxFileName& sourcePath, const wxFileName& targetPath );
 	};
 }

--- a/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
@@ -1,0 +1,197 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2015  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "ConfigurationDialog.h"
+#include "System.h"
+
+#include "MemoryCardFile.h"
+#include "MemoryCardFolder.h"
+#include <wx/ffile.h>
+
+Dialogs::ConvertMemoryCardDialog::ConvertMemoryCardDialog( wxWindow* parent, const wxDirName& mcdPath, const AppConfig::McdOptions& mcdSourceConfig )
+	: wxDialogWithHelpers( parent, _( "Convert a memory card to a different format" ) )
+	, m_mcdPath( mcdPath )
+	, m_mcdSourceFilename( mcdSourceConfig.Filename.GetFullName() )
+{
+	SetMinWidth( 472 );
+
+	CreateControls( mcdSourceConfig.Type );
+
+	if ( m_radio_CardType ) m_radio_CardType->Realize();
+
+	wxBoxSizer& s_buttons( *new wxBoxSizer( wxHORIZONTAL ) );
+	s_buttons += new wxButton( this, wxID_OK, _( "Convert" ) ) | pxProportion( 2 );
+	s_buttons += pxStretchSpacer( 3 );
+	s_buttons += new wxButton( this, wxID_CANCEL ) | pxProportion( 2 );
+
+	wxBoxSizer& s_padding( *new wxBoxSizer( wxVERTICAL ) );
+
+	s_padding += Heading( wxString( _( "Convert: " ) ) + ( mcdPath + m_mcdSourceFilename ).GetFullPath() ).Unwrapped() | pxSizerFlags::StdExpand();
+
+	wxBoxSizer& s_filename( *new wxBoxSizer( wxHORIZONTAL ) );
+	s_filename += Heading( _( "To: " ) ).SetMinWidth( 50 );
+	m_text_filenameInput->SetMinSize( wxSize( 250, 20 ) );
+	m_text_filenameInput->SetValue( wxFileName( m_mcdSourceFilename ).GetName() + L"_converted" );
+	s_filename += m_text_filenameInput;
+	s_filename += Heading( L".ps2" );
+
+	s_padding += s_filename | wxALIGN_LEFT;
+
+	s_padding += m_radio_CardType | pxSizerFlags::StdExpand();
+
+	s_padding += Heading( pxE( L"WARNING: Converting a memory card may take several minutes! Please do not close the emulator during the conversion process, even if the emulator is no longer responding to input." ) );
+
+	s_padding += 12;
+	s_padding += s_buttons | pxSizerFlags::StdCenter();
+
+	*this += s_padding | pxSizerFlags::StdExpand();
+
+	Connect( wxID_OK, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ConvertMemoryCardDialog::OnOk_Click ) );
+	Connect( m_text_filenameInput->GetId(), wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( ConvertMemoryCardDialog::OnOk_Click ) );
+
+	m_text_filenameInput->SetFocus();
+	m_text_filenameInput->SelectAll();
+}
+
+void Dialogs::ConvertMemoryCardDialog::CreateControls( const MemoryCardType sourceType ) {
+	m_text_filenameInput = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
+
+	RadioPanelItem toFile = RadioPanelItem( _( "File" ), pxE( L"Convert this memory card to a regular 8 MB .ps2 file. Please note that the resulting file may not actually contain all saves, depending on how many are in the source memory card." ) )
+		.SetInt( MemoryCardType::MemoryCard_File );
+	RadioPanelItem toFolder = RadioPanelItem( _( "Folder" ), _( "Convert this memory card to a folder of individual saves." ) )
+		.SetInt( MemoryCardType::MemoryCard_Folder );
+
+	const RadioPanelItem tblForFile[] = { toFolder };
+	const RadioPanelItem tblForFolder[] = { toFile };
+
+	switch ( sourceType ) {
+		case MemoryCardType::MemoryCard_File:
+			m_radio_CardType = new pxRadioPanel( this, tblForFile );
+			break;
+		case MemoryCardType::MemoryCard_Folder:
+			m_radio_CardType = new pxRadioPanel( this, tblForFolder );
+			break;
+		default:
+			Console.Error( L"Memory Card Conversion: Invalid source type!" );
+			return;
+	}
+
+	m_radio_CardType->SetDefaultItem( 0 );
+}
+
+void Dialogs::ConvertMemoryCardDialog::OnOk_Click( wxCommandEvent& evt ) {
+	wxString composedName = m_text_filenameInput->GetValue().Trim() + L".ps2";
+
+	wxString errMsg;
+	if ( !isValidNewFilename( composedName, m_mcdPath, errMsg, 5 ) ) {
+		wxString message;
+		message.Printf( _( "Error (%s)" ), errMsg.c_str() );
+		Msgbox::Alert( message, _( "Convert memory card" ) );
+		m_text_filenameInput->SetFocus();
+		m_text_filenameInput->SelectAll();
+		return;
+	}
+
+	bool success = false;
+
+	wxFileName sourcePath = ( m_mcdPath + m_mcdSourceFilename );
+	wxFileName targetPath = ( m_mcdPath + composedName );
+	if ( m_radio_CardType ) {
+		MemoryCardType targetType = (MemoryCardType)m_radio_CardType->SelectedItem().SomeInt;
+
+		switch ( targetType ) {
+		case MemoryCardType::MemoryCard_File:
+			success = ConvertToFile( sourcePath, targetPath );
+			break;
+		case MemoryCardType::MemoryCard_Folder:
+			success = ConvertToFolder( sourcePath, targetPath );
+			break;
+		}
+	}
+
+	if ( !success ) {
+		Msgbox::Alert( _( "Memory Card conversion failed for unknown reasons." ), _( "Convert memory card" ) );
+		return;
+	}
+
+	EndModal( wxID_OK );
+}
+
+bool Dialogs::ConvertMemoryCardDialog::ConvertToFile( const wxFileName& sourcePath, const wxFileName& targetPath ) {
+	// Conversion method: Open FolderMcd as usual, then read the raw data from it and write it to a file stream
+
+	wxFFile targetFile( targetPath.GetFullPath(), L"wb" );
+	if ( !targetFile.IsOpened() ) {
+		return false;
+	}
+
+	FolderMemoryCard sourceFolderMemoryCard;
+	AppConfig::McdOptions config;
+	config.Enabled = true;
+	config.Type = MemoryCardType::MemoryCard_Folder;
+	sourceFolderMemoryCard.Open( sourcePath.GetFullPath(), config, false, L"" );
+
+	u8 buffer[FolderMemoryCard::PageSizeRaw];
+	u32 adr = 0;
+	while ( adr < FolderMemoryCard::TotalSizeRaw ) {
+		sourceFolderMemoryCard.Read( buffer, adr, FolderMemoryCard::PageSizeRaw );
+		targetFile.Write( buffer, FolderMemoryCard::PageSizeRaw );
+		adr += FolderMemoryCard::PageSizeRaw;
+	}
+
+	targetFile.Close();
+	sourceFolderMemoryCard.Close();
+
+	return true;
+}
+
+bool Dialogs::ConvertMemoryCardDialog::ConvertToFolder( const wxFileName& sourcePath, const wxFileName& targetPath ) {
+	// Conversion method: Read all pages of the FileMcd into a FolderMcd, then just write that out with the regular methods
+	// TODO: Test if >8MB files don't super fuck up something
+
+	wxFFile sourceFile( sourcePath.GetFullPath(), L"rb" );
+	if ( !sourceFile.IsOpened() ) {
+		return false;
+	}
+
+	u8 buffer[FolderMemoryCard::PageSizeRaw];
+	FolderMemoryCard targetFolderMemoryCard;
+	AppConfig::McdOptions config;
+	config.Enabled = true;
+	config.Type = MemoryCardType::MemoryCard_Folder;
+	targetFolderMemoryCard.Open( targetPath.GetFullPath(), config, false, L"" );
+
+	u32 adr = 0;
+	while ( !sourceFile.Eof() ) {
+		int size = sourceFile.Read( buffer, FolderMemoryCard::PageSizeRaw );
+		if ( size > 0 ) {
+			targetFolderMemoryCard.Save( buffer, adr, size );
+			adr += size;
+		}
+	}
+
+	sourceFile.Close();
+	targetFolderMemoryCard.Close();
+
+	if ( adr != FolderMemoryCard::TotalSizeRaw ) {
+		// reset memory card metrics in superblock to the default 8MB, since the converted card was different
+		targetFolderMemoryCard.Open( targetPath.GetFullPath(), config, true, L"" );
+		targetFolderMemoryCard.SetSizeInMB( 8 );
+		targetFolderMemoryCard.Close();
+	}
+
+	return true;
+}

--- a/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
@@ -119,6 +119,9 @@ void Dialogs::ConvertMemoryCardDialog::OnOk_Click( wxCommandEvent& evt ) {
 		case MemoryCardType::MemoryCard_Folder:
 			success = ConvertToFolder( sourcePath, targetPath );
 			break;
+		default:
+			Msgbox::Alert( _( "This target type is not supported!" ), _( "Convert memory card" ) );
+			return;
 		}
 	}
 

--- a/pcsx2/gui/Dialogs/McdConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/McdConfigDialog.cpp
@@ -40,6 +40,12 @@ Panels::McdConfigPanel_Toggles::McdConfigPanel_Toggles(wxWindow *parent)
 		)
 	);
 
+	m_folderAutoIndex = new pxCheckBox( this,
+		_( "Automatically manage saves based on running game" ),
+		pxE( L"(Folder type only) Re-index memory card content every time the running software changes. This prevents the memory card from running out of space for saves."
+		)
+	);
+
 	//m_check_SavestateBackup = new pxCheckBox( this, pxsFmt(_("Backup existing Savestate when creating a new one")) );
 /*
 	for( uint i=0; i<2; ++i )
@@ -64,6 +70,7 @@ Panels::McdConfigPanel_Toggles::McdConfigPanel_Toggles(wxWindow *parent)
 	*this	+= new wxStaticLine( this )	| StdExpand();
 
 	*this += m_check_Ejection;	
+	*this += m_folderAutoIndex;
 }
 
 void Panels::McdConfigPanel_Toggles::Apply()
@@ -73,6 +80,7 @@ void Panels::McdConfigPanel_Toggles::Apply()
 
 	//g_Conf->EmuOptions.BackupSavestate			= m_check_SavestateBackup->GetValue();
 	g_Conf->EmuOptions.McdEnableEjection		= m_check_Ejection->GetValue();
+	g_Conf->EmuOptions.McdFolderAutoManage		= m_folderAutoIndex->GetValue();
 }
 
 void Panels::McdConfigPanel_Toggles::AppStatusEvent_OnSettingsApplied()
@@ -82,6 +90,7 @@ void Panels::McdConfigPanel_Toggles::AppStatusEvent_OnSettingsApplied()
 
 	//m_check_SavestateBackup ->SetValue( g_Conf->EmuOptions.BackupSavestate );
 	m_check_Ejection		->SetValue( g_Conf->EmuOptions.McdEnableEjection );
+	m_folderAutoIndex		->SetValue( g_Conf->EmuOptions.McdFolderAutoManage );
 }
 
 

--- a/pcsx2/gui/MemoryCardFile.cpp
+++ b/pcsx2/gui/MemoryCardFile.cpp
@@ -552,6 +552,20 @@ static void PS2E_CALLBACK FileMcd_NextFrame( PS2E_THISPTR thisptr, uint port, ui
 	}
 }
 
+static void PS2E_CALLBACK FileMcd_ReIndex( PS2E_THISPTR thisptr, uint port, uint slot, const wxString& filter ) {
+	const uint combinedSlot = FileMcd_ConvertToSlot( port, slot );
+	switch ( g_Conf->Mcd[combinedSlot].Type ) {
+	//case MemoryCardType::MemoryCard_File:
+	//	thisptr->impl.ReIndex( combinedSlot, filter );
+	//	break;
+	case MemoryCardType::MemoryCard_Folder:
+		thisptr->implFolder.ReIndex( combinedSlot, filter );
+		break;
+	default:
+		return;
+	}
+}
+
 Component_FileMcd::Component_FileMcd()
 {
 	memzero( api );
@@ -567,6 +581,7 @@ Component_FileMcd::Component_FileMcd()
 	api.McdEraseBlock	= FileMcd_EraseBlock;
 	api.McdGetCRC		= FileMcd_GetCRC;
 	api.McdNextFrame    = FileMcd_NextFrame;
+	api.McdReIndex      = FileMcd_ReIndex;
 }
 
 

--- a/pcsx2/gui/MemoryCardFile.cpp
+++ b/pcsx2/gui/MemoryCardFile.cpp
@@ -436,6 +436,7 @@ uint FileMcd_ConvertToSlot( uint port, uint slot )
 static void PS2E_CALLBACK FileMcd_EmuOpen( PS2E_THISPTR thisptr, const PS2E_SessionInfo *session )
 {
 	thisptr->impl.Open();
+	thisptr->implFolder.SetFiltering( g_Conf->EmuOptions.McdFolderAutoManage );
 	thisptr->implFolder.Open();
 }
 
@@ -559,7 +560,7 @@ static void PS2E_CALLBACK FileMcd_ReIndex( PS2E_THISPTR thisptr, uint port, uint
 	//	thisptr->impl.ReIndex( combinedSlot, filter );
 	//	break;
 	case MemoryCardType::MemoryCard_Folder:
-		thisptr->implFolder.ReIndex( combinedSlot, filter );
+		thisptr->implFolder.ReIndex( combinedSlot, g_Conf->EmuOptions.McdFolderAutoManage, filter );
 		break;
 	default:
 		return;

--- a/pcsx2/gui/MemoryCardFile.cpp
+++ b/pcsx2/gui/MemoryCardFile.cpp
@@ -75,8 +75,6 @@ public:
 	s32  EraseBlock	( uint slot, u32 adr );
 	u64  GetCRC		( uint slot );
 	
-	void NextFrame( uint slot );
-
 protected:
 	bool Seek( wxFFile& f, u32 adr );
 	bool Create( const wxString& mcdFile, uint sizeInMB );
@@ -408,11 +406,6 @@ u64 FileMemoryCard::GetCRC( uint slot )
 	return retval;
 }
 
-void FileMemoryCard::NextFrame( uint slot )
-{
-
-}
-
 // --------------------------------------------------------------------------------------
 //  MemoryCard Component API Bindings
 // --------------------------------------------------------------------------------------
@@ -542,9 +535,9 @@ static u64 PS2E_CALLBACK FileMcd_GetCRC( PS2E_THISPTR thisptr, uint port, uint s
 static void PS2E_CALLBACK FileMcd_NextFrame( PS2E_THISPTR thisptr, uint port, uint slot ) {
 	const uint combinedSlot = FileMcd_ConvertToSlot( port, slot );
 	switch ( g_Conf->Mcd[combinedSlot].Type ) {
-	case MemoryCardType::MemoryCard_File:
-		thisptr->impl.NextFrame( combinedSlot );
-		break;
+	//case MemoryCardType::MemoryCard_File:
+	//	thisptr->impl.NextFrame( combinedSlot );
+	//	break;
 	case MemoryCardType::MemoryCard_Folder:
 		thisptr->implFolder.NextFrame( combinedSlot );
 		break;

--- a/pcsx2/gui/MemoryCardFile.h
+++ b/pcsx2/gui/MemoryCardFile.h
@@ -15,6 +15,9 @@
 
 #pragma once
 
+// define this to use the FolderMemoryCard implementation instead of the regular FileMemoryCard one
+//#define MEMORYCARD_USE_FOLDER
+
 // NOTICE!  This file is intended as a temporary placebo only, until such time that the
 // memorycard system is properly extracted into a plugin system (which would make it a
 // separate project file).

--- a/pcsx2/gui/MemoryCardFile.h
+++ b/pcsx2/gui/MemoryCardFile.h
@@ -15,9 +15,6 @@
 
 #pragma once
 
-// define this to use the FolderMemoryCard implementation instead of the regular FileMemoryCard one
-//#define MEMORYCARD_USE_FOLDER
-
 // NOTICE!  This file is intended as a temporary placebo only, until such time that the
 // memorycard system is properly extracted into a plugin system (which would make it a
 // separate project file).

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -520,7 +520,7 @@ u8* FolderMemoryCard::GetFileEntryPointer( const u32 currentCluster, const u32 s
 	// check subdirectories
 	for ( int i = 0; i < 2; ++i ) {
 		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
-		if ( entry->IsUsed() && entry->IsDir() && entry->entry.data.cluster != 0 ) {
+		if ( entry->IsValid() && entry->IsUsed() && entry->IsDir() && entry->entry.data.cluster != 0 ) {
 			u8* ptr = GetFileEntryPointer( entry->entry.data.cluster, searchCluster, entryNumber, offset );
 			if ( ptr != nullptr ) { return ptr; }
 		}
@@ -533,7 +533,7 @@ MemoryCardFileEntry* FolderMemoryCard::GetFileEntryFromFileDataCluster( const u3
 	// check both entries of the current cluster if they're the file we're searching for, and if yes return it
 	for ( int i = 0; i < 2; ++i ) {
 		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
-		if ( entry->IsUsed() && entry->IsFile() ) {
+		if ( entry->IsValid() && entry->IsUsed() && entry->IsFile() ) {
 			u32 fileCluster = entry->entry.data.cluster;
 			u32 clusterNumber = 0;
 			do {
@@ -563,7 +563,7 @@ MemoryCardFileEntry* FolderMemoryCard::GetFileEntryFromFileDataCluster( const u3
 	// check subdirectories
 	for ( int i = 0; i < 2; ++i ) {
 		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
-		if ( entry->IsUsed() && entry->IsDir() && entry->entry.data.cluster != 0 ) {
+		if ( entry->IsValid() && entry->IsUsed() && entry->IsDir() && entry->entry.data.cluster != 0 ) {
 			MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster( entry->entry.data.cluster, searchCluster, fileName, originalDirCount, outClusterNumber );
 			if ( ptr != nullptr ) {
 				fileName->InsertDir( originalDirCount, wxString::FromAscii( (const char*)entry->entry.data.name ) );

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1,0 +1,961 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "Utilities/SafeArray.inl"
+
+#include "MemoryCardFile.h"
+#include "MemoryCardFolder.h"
+
+#include "System.h"
+#include "AppConfig.h"
+
+#include "svnrev.h"
+
+FolderMemoryCard::FolderMemoryCard() {
+	m_slot = 0;
+	m_isEnabled = false;
+}
+
+void FolderMemoryCard::InitializeInternalData() {
+	memset( &m_superBlock, 0xFF, sizeof( m_superBlock ) );
+	memset( &m_indirectFat, 0xFF, sizeof( m_indirectFat ) );
+	memset( &m_fat, 0xFF, sizeof( m_fat ) );
+	memset( &m_backupBlock1, 0xFF, sizeof( m_backupBlock1 ) );
+	memset( &m_backupBlock2, 0xFF, sizeof( m_backupBlock2 ) );
+	m_cache.clear();
+	m_timeLastWritten = 0;
+	m_isEnabled = false;
+	m_framesUntilFlush = 0;
+}
+
+bool FolderMemoryCard::IsFormatted() {
+	// this should be a good enough arbitrary check, if someone can think of a case where this doesn't work feel free to change
+	return m_superBlock.raw[0x16] == 0x6F;
+}
+
+void FolderMemoryCard::Open() {
+	InitializeInternalData();
+
+	wxFileName configuredFileName( g_Conf->FullpathToMcd( m_slot ) );
+	folderName = wxFileName( configuredFileName.GetFullPath() + L"/" );
+	wxString str( configuredFileName.GetFullPath() );
+	bool disabled = false;
+
+	if ( g_Conf->Mcd[m_slot].Enabled && g_Conf->Mcd[m_slot].Type == MemoryCardType::MemoryCard_Folder ) {
+		if ( configuredFileName.GetFullName().IsEmpty() ) {
+			str = L"[empty filename]";
+			disabled = true;
+		}
+		if ( !disabled && configuredFileName.FileExists() ) {
+			str = L"[is file, should be folder]";
+			disabled = true;
+		}
+
+		// if nothing exists at a valid location, create a directory for the memory card
+		if ( !disabled && !folderName.DirExists() ) {
+			if ( !folderName.Mkdir() ) {
+				str = L"[couldn't create folder]";
+				disabled = true;
+			}
+		}
+	} else {
+		str = L"[disabled]";
+		disabled = true;
+	}
+
+	Console.WriteLn( disabled ? Color_Gray : Color_Green, L"McdSlot %u: [Folder] " + str, m_slot );
+	if ( disabled ) return;
+
+	m_isEnabled = true;
+	LoadMemoryCardData();
+
+	SetTimeLastWrittenToNow();
+	m_framesUntilFlush = 0;
+}
+
+void FolderMemoryCard::Close() {
+	if ( !m_isEnabled ) { return; }
+
+	Flush();
+
+	wxFileName superBlockFileName( folderName.GetPath(), L"_pcsx2_superblock" );
+	wxFFile superBlockFile( superBlockFileName.GetFullPath().c_str(), L"wb" );
+	if ( superBlockFile.IsOpened() ) {
+		superBlockFile.Write( &m_superBlock.raw, sizeof( m_superBlock.raw ) );
+	}
+}
+
+void FolderMemoryCard::LoadMemoryCardData() {
+	bool formatted = false;
+
+	// read superblock if it exists
+	wxFileName superBlockFileName( folderName.GetPath(), L"_pcsx2_superblock" );
+	if ( superBlockFileName.FileExists() ) {
+		wxFFile superBlockFile( superBlockFileName.GetFullPath().c_str(), L"rb" );
+		if ( superBlockFile.IsOpened() && superBlockFile.Read( &m_superBlock.raw, sizeof( m_superBlock.raw ) ) >= sizeof( m_superBlock.data ) ) {
+			formatted = IsFormatted();
+		}
+	}
+
+	// if superblock was valid, load folders and files
+	if ( formatted ) {
+		CreateFat();
+		CreateRootDir();
+		MemoryCardFileEntry* const rootDirEntry = &m_fileEntryDict[m_superBlock.data.rootdir_cluster].entries[0];
+		AddFolder( rootDirEntry, folderName.GetPath() );
+	}
+}
+
+void FolderMemoryCard::CreateFat() {
+	const u32 totalClusters = m_superBlock.data.clusters_per_card;
+	const u32 clusterSize = m_superBlock.data.page_len * m_superBlock.data.pages_per_cluster;
+	const u32 fatEntriesPerCluster = clusterSize / 4;
+	const u32 countFatClusters = ( totalClusters % fatEntriesPerCluster ) != 0 ? ( totalClusters / fatEntriesPerCluster + 1 ) : ( totalClusters / fatEntriesPerCluster );
+	const u32 countDataClusters = m_superBlock.data.alloc_end;
+
+	// create indirect FAT
+	for ( unsigned int i = 0; i < countFatClusters; ++i ) {
+		m_indirectFat.data[0][i] = GetFreeSystemCluster();
+	}
+
+	// fill FAT with default values
+	for ( unsigned int i = 0; i < countDataClusters; ++i ) {
+		m_fat.data[0][0][i] = 0x7FFFFFFFu;
+	}
+}
+
+void FolderMemoryCard::CreateRootDir() {
+	MemoryCardFileEntryCluster* const rootCluster = &m_fileEntryDict[m_superBlock.data.rootdir_cluster];
+	memset( &rootCluster->entries[0].entry.raw[0], 0x00, 0x200 );
+	rootCluster->entries[0].entry.data.mode = 0x8427;
+	rootCluster->entries[0].entry.data.length = 2;
+	rootCluster->entries[0].entry.data.name[0] = '.';
+
+	memset( &rootCluster->entries[1].entry.raw[0], 0x00, 0x200 );
+	rootCluster->entries[1].entry.data.mode = 0xA426;
+	rootCluster->entries[1].entry.data.name[0] = '.';
+	rootCluster->entries[1].entry.data.name[1] = '.';
+
+	// mark root dir cluster as used
+	m_fat.data[0][0][m_superBlock.data.rootdir_cluster] = 0xFFFFFFFFu;
+}
+
+u32 FolderMemoryCard::GetFreeSystemCluster() {
+	// first block is reserved for superblock
+	u32 highestUsedCluster = ( m_superBlock.data.pages_per_block / m_superBlock.data.pages_per_cluster ) - 1;
+
+	// can't use any of the indirect fat clusters
+	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+		highestUsedCluster = std::max( highestUsedCluster, m_superBlock.data.ifc_list[i] );
+	}
+
+	// or fat clusters
+	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+		for ( int j = 0; j < ClusterSize / 4; ++j ) {
+			if ( m_indirectFat.data[i][j] != 0xFFFFFFFFu ) {
+				highestUsedCluster = std::max( highestUsedCluster, m_indirectFat.data[i][j] );
+			}
+		}
+	}
+
+	return highestUsedCluster + 1;
+}
+
+u32 FolderMemoryCard::GetFreeDataCluster() {
+	// BIOS reports different cluster values than what the memory card actually has, match that when adding files
+	//  8mb card -> BIOS:  7999 clusters / Superblock:  8135 clusters
+	// 16mb card -> BIOS: 15999 clusters / Superblock: 16295 clusters
+	// 32mb card -> BIOS: 31999 clusters / Superblock: 32615 clusters
+	// 64mb card -> BIOS: 64999 clusters / Superblock: 65255 clusters
+	const u32 countDataClusters = ( m_superBlock.data.alloc_end / 1000 ) * 1000 - 1;
+
+	for ( unsigned int i = 0; i < countDataClusters; ++i ) {
+		const u32 cluster = m_fat.data[0][0][i];
+
+		if ( ( cluster & 0x80000000 ) == 0 ) {
+			return i;
+		}
+	}
+
+	return 0xFFFFFFFF;
+}
+
+u32 FolderMemoryCard::GetAmountFreeDataClusters() {
+	const u32 countDataClusters = ( m_superBlock.data.alloc_end / 1000 ) * 1000 - 1;
+	u32 countFreeDataClusters = 0;
+
+	for ( unsigned int i = 0; i < countDataClusters; ++i ) {
+		const u32 cluster = m_fat.data[0][0][i];
+
+		if ( ( cluster & 0x80000000 ) == 0 ) {
+			++countFreeDataClusters;
+		}
+	}
+
+	return countFreeDataClusters;
+}
+
+u32 FolderMemoryCard::GetLastClusterOfData( const u32 cluster ) {
+	u32 entryCluster;
+	u32 nextCluster = cluster;
+	do {
+		entryCluster = nextCluster;
+		nextCluster = m_fat.data[0][0][entryCluster] & 0x7FFFFFFF;
+	} while ( nextCluster != 0x7FFFFFFF );
+	return entryCluster;
+}
+
+u64 FolderMemoryCard::ConvertToMemoryCardTimestamp( const wxDateTime& time ) {
+	if ( !time.IsValid() ) {
+		return 0;
+	}
+
+	union {
+		MemoryCardFileEntryDateTime data;
+		u64 value;
+	} t;
+
+	wxDateTime::Tm tm = time.GetTm( wxDateTime::GMT9 );
+
+	t.data.unused = 0;
+	t.data.second = tm.sec;
+	t.data.minute = tm.min;
+	t.data.hour = tm.hour;
+	t.data.day = tm.mday;
+	t.data.month = tm.mon + 1;
+	t.data.year = tm.year;
+
+	return t.value;
+}
+
+MemoryCardFileEntry* FolderMemoryCard::AppendFileEntryToDir( MemoryCardFileEntry* const dirEntry ) {
+	u32 entryCluster = GetLastClusterOfData( dirEntry->entry.data.cluster );
+
+	MemoryCardFileEntry* newFileEntry;
+	if ( dirEntry->entry.data.length % 2 == 0 ) {
+		// need new cluster
+		u32 newCluster = GetFreeDataCluster();
+		if ( newCluster == 0xFFFFFFFFu ) { return nullptr; }
+		m_fat.data[0][0][entryCluster] = newCluster | 0x80000000;
+		m_fat.data[0][0][newCluster] = 0xFFFFFFFF;
+		newFileEntry = &m_fileEntryDict[newCluster].entries[0];
+	} else {
+		// can use last page of existing clusters
+		newFileEntry = &m_fileEntryDict[entryCluster].entries[1];
+	}
+
+	return newFileEntry;
+}
+
+bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath ) {
+	wxDir dir( dirPath );
+	if ( dir.IsOpened() ) {
+		Console.WriteLn( L"(FolderMcd) Adding folder: %s", WX_STR( dirPath ) );
+
+		const u32 dirStartCluster = dirEntry->entry.data.cluster;
+
+		wxString fileName;
+		bool hasNext;
+
+		int entryNumber = 2; // include . and ..
+		hasNext = dir.GetFirst( &fileName );
+		while ( hasNext ) {
+			wxFileName fileInfo( dirPath, fileName );
+			bool isFile = wxFile::Exists( fileInfo.GetFullPath() );
+
+			if ( isFile ) {
+				if ( !fileName.StartsWith( L"_pcsx2_" ) ) {
+					if ( AddFile( dirEntry, dirPath, fileName ) ) {
+						++entryNumber;
+					}
+				}
+			} else {
+				// make sure we have enough space on the memcard for the directory
+				const u32 newNeededClusters = ( dirEntry->entry.data.length % 2 ) == 0 ? 2 : 1;
+				if ( newNeededClusters > GetAmountFreeDataClusters() ) {
+					Console.Warning( GetCardFullMessage( fileName ) );
+					hasNext = dir.GetNext( &fileName );
+					continue;
+				}
+
+				// is a subdirectory
+				wxDateTime creationTime, modificationTime;
+				fileInfo.AppendDir( fileInfo.GetFullName() );
+				fileInfo.SetName( L"" );
+				fileInfo.ClearExt();
+				fileInfo.GetTimes( NULL, &modificationTime, &creationTime );
+
+				// add entry for subdir in parent dir
+				MemoryCardFileEntry* newDirEntry = AppendFileEntryToDir( dirEntry );
+				dirEntry->entry.data.length++;
+				newDirEntry->entry.data.mode = 0x8427;
+				newDirEntry->entry.data.length = 2;
+				newDirEntry->entry.data.timeCreated.value = ConvertToMemoryCardTimestamp( creationTime );
+				newDirEntry->entry.data.timeModified.value = ConvertToMemoryCardTimestamp( modificationTime );
+				strcpy( (char*)&newDirEntry->entry.data.name[0], fileName.mbc_str() );
+
+				// create new cluster for . and .. entries
+				u32 newCluster = GetFreeDataCluster();
+				m_fat.data[0][0][newCluster] = 0xFFFFFFFF;
+				newDirEntry->entry.data.cluster = newCluster;
+
+				MemoryCardFileEntryCluster* const subDirCluster = &m_fileEntryDict[newCluster];
+				memset( &subDirCluster->entries[0].entry.raw[0], 0x00, 0x200 );
+				subDirCluster->entries[0].entry.data.mode = 0x8427;
+				subDirCluster->entries[0].entry.data.dirEntry = entryNumber;
+				subDirCluster->entries[0].entry.data.name[0] = '.';
+
+				memset( &subDirCluster->entries[1].entry.raw[0], 0x00, 0x200 );
+				subDirCluster->entries[1].entry.data.mode = 0x8427;
+				subDirCluster->entries[1].entry.data.name[0] = '.';
+				subDirCluster->entries[1].entry.data.name[1] = '.';
+
+				++entryNumber;
+
+				// and add all files in subdir
+				AddFolder( newDirEntry, fileInfo.GetFullPath() );
+			}
+
+			hasNext = dir.GetNext( &fileName );
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+bool FolderMemoryCard::AddFile( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const wxString& fileName ) {
+	wxFileName relativeFilePath( dirPath, fileName );
+	relativeFilePath.MakeRelativeTo( folderName.GetPath() );
+	Console.WriteLn( L"(FolderMcd) Adding file: %s", WX_STR( relativeFilePath.GetFullPath() ) );
+
+	wxFileName fileInfo( dirPath, fileName );
+	wxFFile file( fileInfo.GetFullPath(), L"rb" );
+	if ( file.IsOpened() ) {
+		// make sure we have enough space on the memcard to hold the data
+		const u32 clusterSize = m_superBlock.data.pages_per_cluster * m_superBlock.data.page_len;
+		const u32 filesize = file.Length();
+		const u32 countClusters = ( filesize % clusterSize ) != 0 ? ( filesize / clusterSize + 1 ) : ( filesize / clusterSize );
+		const u32 newNeededClusters = ( dirEntry->entry.data.length % 2 ) == 0 ? countClusters + 1 : countClusters;
+		if ( newNeededClusters > GetAmountFreeDataClusters() ) {
+			Console.Warning( GetCardFullMessage( relativeFilePath.GetFullPath() ) );
+			file.Close();
+			return false;
+		}
+
+		MemoryCardFileEntry* newFileEntry = AppendFileEntryToDir( dirEntry );
+		wxDateTime creationTime, modificationTime;
+		fileInfo.GetTimes( NULL, &modificationTime, &creationTime );
+
+		// set file entry data
+		memset( &newFileEntry->entry.raw[0], 0x00, 0x200 );
+		newFileEntry->entry.data.mode = 0x8497;
+		newFileEntry->entry.data.length = filesize;
+		newFileEntry->entry.data.timeCreated.value = ConvertToMemoryCardTimestamp( creationTime );
+		newFileEntry->entry.data.timeModified.value = ConvertToMemoryCardTimestamp( modificationTime );
+		u32 fileDataStartingCluster = GetFreeDataCluster();
+		newFileEntry->entry.data.cluster = fileDataStartingCluster;
+		strcpy( (char*)&newFileEntry->entry.data.name[0], fileName.mbc_str() );
+
+		// mark the appropriate amount of clusters as used
+		u32 dataCluster = fileDataStartingCluster;
+		m_fat.data[0][0][dataCluster] = 0xFFFFFFFF;
+		for ( unsigned int i = 0; i < countClusters - 1; ++i ) {
+			u32 newCluster = GetFreeDataCluster();
+			m_fat.data[0][0][dataCluster] = newCluster | 0x80000000;
+			m_fat.data[0][0][newCluster] = 0xFFFFFFFF;
+			dataCluster = newCluster;
+		}
+
+		file.Close();
+	} else {
+		Console.WriteLn( L"(FolderMcd) Could not open file: %s", WX_STR( relativeFilePath.GetFullPath() ) );
+		return false;
+	}
+
+	// and finally, increase file count in the directory entry
+	dirEntry->entry.data.length++;
+
+	return true;
+}
+
+s32 FolderMemoryCard::IsPresent() {
+	return m_isEnabled;
+}
+
+void FolderMemoryCard::GetSizeInfo( PS2E_McdSizeInfo& outways ) {
+	outways.SectorSize = PageSize;
+	outways.EraseBlockSizeInSectors = BlockSize / PageSize;
+	outways.McdSizeInSectors = TotalPages;
+
+	u8 *pdata = (u8*)&outways.McdSizeInSectors;
+	outways.Xor = 18;
+	outways.Xor ^= pdata[0] ^ pdata[1] ^ pdata[2] ^ pdata[3];
+}
+
+bool FolderMemoryCard::IsPSX() {
+	return false;
+}
+
+u8* FolderMemoryCard::GetSystemBlockPointer( const u32 adr ) {
+	const u32 block = adr / BlockSizeRaw;
+	const u32 page = adr / PageSizeRaw;
+	const u32 offset = adr % PageSizeRaw;
+	const u32 cluster = adr / ClusterSizeRaw;
+
+	const u32 startDataCluster = m_superBlock.data.alloc_offset;
+	const u32 endDataCluster = startDataCluster + m_superBlock.data.alloc_end;
+	if ( cluster >= startDataCluster && cluster < endDataCluster ) {
+		// trying to access a file entry?
+		const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
+		return GetFileEntryPointer( m_superBlock.data.rootdir_cluster, fatCluster, page % 2, offset );
+	}
+
+	u8* src = nullptr;
+	if ( block == 0 ) {
+		src = &m_superBlock.raw[page * PageSize + offset];
+	} else if ( block == m_superBlock.data.backup_block1 ) {
+		src = &m_backupBlock1[( page % 16 ) * PageSize + offset];
+	} else if ( block == m_superBlock.data.backup_block2 ) {
+		src = &m_backupBlock2[( page % 16 ) * PageSize + offset];
+	} else {
+		// trying to access indirect FAT?
+		for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+			if ( cluster == m_superBlock.data.ifc_list[i] ) {
+				src = &m_indirectFat.raw[i][( page % 2 ) * PageSize + offset];
+				return src;
+			}
+		}
+		// trying to access FAT?
+		for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+			for ( int j = 0; j < ClusterSize / 4; ++j ) {
+				const u32 fatCluster = m_indirectFat.data[i][j];
+				if ( fatCluster != 0xFFFFFFFFu && fatCluster == cluster ) {
+					src = &m_fat.raw[i][j][( page % 2 ) * PageSize + offset];
+					return src;
+				}
+			}
+		}
+	}
+
+	return src;
+}
+
+u8* FolderMemoryCard::GetFileEntryPointer( const u32 currentCluster, const u32 searchCluster, const u32 entryNumber, const u32 offset ) {
+	// we found the correct cluster, return pointer to it
+	if ( currentCluster == searchCluster ) {
+		return &m_fileEntryDict[currentCluster].entries[entryNumber].entry.raw[offset];
+	}
+
+	// check other clusters of this directory
+	const u32 nextCluster = m_fat.data[0][0][currentCluster] & 0x7FFFFFFF;
+	if ( nextCluster != 0x7FFFFFFF ) {
+		u8* ptr = GetFileEntryPointer( nextCluster, searchCluster, entryNumber, offset );
+		if ( ptr != nullptr ) { return ptr; }
+	}
+
+	// check subdirectories
+	for ( int i = 0; i < 2; ++i ) {
+		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
+		if ( entry->IsUsed() && entry->IsDir() && entry->entry.data.cluster != 0 ) {
+			u8* ptr = GetFileEntryPointer( entry->entry.data.cluster, searchCluster, entryNumber, offset );
+			if ( ptr != nullptr ) { return ptr; }
+		}
+	}
+
+	return nullptr;
+}
+
+MemoryCardFileEntry* FolderMemoryCard::GetFileEntryFromFileDataCluster( const u32 currentCluster, const u32 searchCluster, wxFileName* fileName, const size_t originalDirCount, u32* outClusterNumber ) {
+	// check both entries of the current cluster if they're the file we're searching for, and if yes return it
+	for ( int i = 0; i < 2; ++i ) {
+		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
+		if ( entry->IsUsed() && entry->IsFile() ) {
+			u32 fileCluster = entry->entry.data.cluster;
+			u32 clusterNumber = 0;
+			do {
+				if ( fileCluster == searchCluster ) {
+					fileName->SetName( wxString::FromAscii( (const char*)entry->entry.data.name ) );
+					*outClusterNumber = clusterNumber;
+					return entry;
+				}
+				++clusterNumber;
+			} while ( ( fileCluster = m_fat.data[0][0][fileCluster] & 0x7FFFFFFF ) != 0x7FFFFFFF );
+			// There's a lot of optimization work that can be done here, looping through all clusters of every single file
+			// is not very efficient, especially since files are going to be accessed from the start and in-order the vast
+			// majority of the time. You can probably cut a lot of the work by remembering the state of the last access
+			// and only checking if the current access is either the same or the next cluster according to the FAT.
+			//} while ( false );
+		}
+	}
+
+	// check other clusters of this directory
+	// this can probably be solved more efficiently by looping through nextClusters instead of recursively calling
+	const u32 nextCluster = m_fat.data[0][0][currentCluster] & 0x7FFFFFFF;
+	if ( nextCluster != 0x7FFFFFFF ) {
+		MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster( nextCluster, searchCluster, fileName, originalDirCount, outClusterNumber );
+		if ( ptr != nullptr ) { return ptr; }
+	}
+
+	// check subdirectories
+	for ( int i = 0; i < 2; ++i ) {
+		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
+		if ( entry->IsUsed() && entry->IsDir() && entry->entry.data.cluster != 0 ) {
+			MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster( entry->entry.data.cluster, searchCluster, fileName, originalDirCount, outClusterNumber );
+			if ( ptr != nullptr ) {
+				fileName->InsertDir( originalDirCount, wxString::FromAscii( (const char*)entry->entry.data.name ) );
+				return ptr;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+bool FolderMemoryCard::ReadFromFile( u8 *dest, u32 adr, u32 dataLength ) {
+	const u32 page = adr / PageSizeRaw;
+	const u32 offset = adr % PageSizeRaw;
+	const u32 cluster = adr / ClusterSizeRaw;
+	const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
+
+	// figure out which file to read from
+	wxFileName fileName( folderName );
+	u32 clusterNumber;
+	const MemoryCardFileEntry* const entry = GetFileEntryFromFileDataCluster( m_superBlock.data.rootdir_cluster, fatCluster, &fileName, fileName.GetDirCount(), &clusterNumber );
+	if ( entry != nullptr ) {
+		if ( !fileName.DirExists() ) {
+			fileName.Mkdir();
+		}
+		wxFFile file( fileName.GetFullPath(), L"rb" );
+		if ( file.IsOpened() ) {
+			const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
+			const u32 fileOffset = clusterNumber * ClusterSize + clusterOffset;
+
+			file.Seek( fileOffset );
+			size_t bytesRead = file.Read( dest, dataLength );
+
+			// if more bytes were requested than actually exist, fill the rest with 0xFF
+			if ( bytesRead < dataLength ) {
+				memset( &dest[bytesRead], 0xFF, dataLength - bytesRead );
+			}
+
+			file.Close();
+
+			return bytesRead > 0;
+		}
+	}
+
+	return false;
+}
+
+s32 FolderMemoryCard::Read( u8 *dest, u32 adr, int size ) {
+	const u32 block = adr / BlockSizeRaw;
+	const u32 page = adr / PageSizeRaw;
+	const u32 offset = adr % PageSizeRaw;
+	const u32 cluster = adr / ClusterSizeRaw;
+	const u32 end = offset + size;
+
+	if ( end > PageSizeRaw ) {
+		// is trying to read more than one page at a time
+		// do this recursively so that each function call only has to care about one page
+		const u32 toNextPage = PageSizeRaw - offset;
+		Read( dest + toNextPage, adr + toNextPage, size - toNextPage );
+		size = toNextPage;
+	}
+
+	if ( offset < PageSize ) {
+		// is trying to read (part of) an actual data block
+		const u32 dataOffset = 0;
+		const u32 dataLength = std::min( (u32)size, (u32)( PageSize - offset ) );
+
+		// if we have a cache for this page, just load from that
+		auto it = m_cache.find( page );
+		if ( it != m_cache.end() ) {
+			memcpy( dest, &it->second.raw[offset], dataLength );
+		} else {
+			u8* src = GetSystemBlockPointer( adr );
+			if ( src != nullptr ) {
+				memcpy( dest, src, dataLength );
+			} else {
+				if ( !ReadFromFile( dest, adr, dataLength ) ) {
+					memset( dest, 0xFF, dataLength );
+				}
+			}
+		}
+	}
+
+	if ( end > PageSize ) {
+		// is trying to (partially) read the ECC
+		const u32 eccOffset = PageSize - offset;
+		const u32 eccLength = std::min( (u32)( size - offset ), (u32)EccSize );
+		const u32 adrStart = page * 0x210u;
+
+		u8 data[PageSize];
+		Read( data, adrStart, PageSize );
+
+		u8 ecc[EccSize];
+		memset( ecc, 0xFF, EccSize );
+
+		for ( int i = 0; i < PageSize / 0x80; ++i ) {
+			FolderMemoryCard::CalculateECC( ecc + ( i * 3 ), &data[i * 0x80] );
+		}
+
+		memcpy( dest + eccOffset, ecc, eccLength );
+	}
+
+	// return 0 on fail, 1 on success?
+	return 1;
+}
+
+s32 FolderMemoryCard::Save( const u8 *src, u32 adr, int size ) {
+	const u32 block = adr / BlockSizeRaw;
+	const u32 cluster = adr / ClusterSizeRaw;
+	const u32 page = adr / PageSizeRaw;
+	const u32 offset = adr % PageSizeRaw;
+	const u32 end = offset + size;
+
+	if ( end > PageSizeRaw ) {
+		// is trying to store more than one page at a time
+		// do this recursively so that each function call only has to care about one page
+		const u32 toNextPage = PageSizeRaw - offset;
+		Save( src + toNextPage, adr + toNextPage, size - toNextPage );
+		size = toNextPage;
+	}
+
+	if ( offset < PageSize ) {
+		// is trying to store (part of) an actual data block
+		const u32 dataLength = std::min( (u32)size, PageSize - offset );
+
+		// if cache page has not yet been touched, fill it with the data from our memory card
+		auto it = m_cache.find( page );
+		MemoryCardPage* cachePage;
+		if ( it == m_cache.end() ) {
+			cachePage = &m_cache[page];
+			const u32 adrLoad = page * PageSizeRaw;
+			Read( &cachePage->raw[0], adrLoad, PageSize );
+		} else {
+			cachePage = &it->second;
+		}
+
+		// then just write to the cache
+		memcpy( &cachePage->raw[offset], src, dataLength );
+
+		SetTimeLastWrittenToNow();
+	}
+
+	return 1;
+}
+
+void FolderMemoryCard::NextFrame() {
+	if ( m_framesUntilFlush > 0 && --m_framesUntilFlush == 0 ) {
+		Flush();
+	}
+}
+
+void FolderMemoryCard::Flush() {
+	Console.WriteLn( L"(FolderMcd) Writing data for slot %u to file system.", m_slot );
+
+	// first write the superblock if necessary
+	Flush( 0 );
+
+	if ( !IsFormatted() ) { return; }
+
+	// then write the indirect FAT
+	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+		const u32 cluster = m_superBlock.data.ifc_list[i];
+		if ( cluster > 0 && cluster < TotalClusters ) {
+			const u32 page = cluster * 2;
+			Flush( page );
+			Flush( page + 1 );
+		}
+	}
+
+	// and the FAT
+	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+		for ( int j = 0; j < ClusterSize / 4; ++j ) {
+			const u32 cluster = m_indirectFat.data[i][j];
+			if ( cluster > 0 && cluster < TotalClusters ) {
+				const u32 page = cluster * 2;
+				Flush( page );
+				Flush( page + 1 );
+			}
+		}
+	}
+
+	// then all directory and file entries
+	const u32 rootDirCluster = m_superBlock.data.rootdir_cluster;
+	const u32 rootDirPage = ( rootDirCluster + m_superBlock.data.alloc_offset ) * 2;
+	Flush( rootDirPage );
+	MemoryCardFileEntryCluster* rootEntries = &m_fileEntryDict[rootDirCluster];
+	if ( rootEntries->entries[0].IsValid() && rootEntries->entries[0].IsUsed() ) {
+		FlushFileEntries( rootDirCluster, rootEntries->entries[0].entry.data.length );
+	}
+
+	// and finally, flush everything that hasn't been flushed yet
+	for ( int i = 0; i < TotalPages; ++i ) {
+		Flush( i );
+	}
+
+}
+
+void FolderMemoryCard::Flush( const u32 page ) {
+	if ( page >= TotalPages ) { return; }
+	auto it = m_cache.find( page );
+	if ( it != m_cache.end() ) {
+		WriteWithoutCache( &it->second.raw[0], page * PageSizeRaw, PageSize );
+		m_cache.erase( it );
+	}
+}
+
+void FolderMemoryCard::FlushFileEntries( const u32 dirCluster, const u32 remainingFiles ) {
+	// flush the current cluster
+	const u32 page = ( dirCluster + m_superBlock.data.alloc_offset ) * 2;
+	Flush( page );
+	Flush( page + 1 );
+
+	// if either of the current entries is a subdir, flush that too
+	MemoryCardFileEntryCluster* entries = &m_fileEntryDict[dirCluster];
+	const u32 filesInThisCluster = std::min( remainingFiles, 2u );
+	for ( unsigned int i = 0; i < filesInThisCluster; ++i ) {
+		MemoryCardFileEntry* entry = &entries->entries[i];
+		if ( entry->IsValid() && entry->IsUsed() && entry->IsDir() ) {
+			const u32 cluster = entry->entry.data.cluster;
+			if ( cluster > 0 ) {
+				FlushFileEntries( cluster, entry->entry.data.length );
+			}
+		}
+	}
+
+	// continue to the next cluster of this directory
+	const u32 nextCluster = m_fat.data[0][0][dirCluster];
+	if ( nextCluster != 0xFFFFFFFF ) {
+		FlushFileEntries( nextCluster & 0x7FFFFFFF, remainingFiles - 2 );
+	}
+}
+
+s32 FolderMemoryCard::WriteWithoutCache( const u8 *src, u32 adr, int size ) {
+	const u32 block = adr / BlockSizeRaw;
+	const u32 cluster = adr / ClusterSizeRaw;
+	const u32 page = adr / PageSizeRaw;
+	const u32 offset = adr % PageSizeRaw;
+	const u32 end = offset + size;
+
+	if ( end > PageSizeRaw ) {
+		// is trying to store more than one page at a time
+		// do this recursively so that each function call only has to care about one page
+		const u32 toNextPage = PageSizeRaw - offset;
+		Save( src + toNextPage, adr + toNextPage, size - toNextPage );
+		size = toNextPage;
+	}
+
+	if ( offset < PageSize ) {
+		// is trying to store (part of) an actual data block
+		const u32 dataLength = std::min( (u32)size, PageSize - offset );
+
+		u8* dest = GetSystemBlockPointer( adr );
+		if ( dest != nullptr ) {
+			memcpy( dest, src, dataLength );
+		} else {
+			WriteToFile( src, adr, dataLength );
+		}
+	}
+
+	if ( end > PageSize ) {
+		// is trying to store ECC
+		// simply ignore this, is automatically generated when reading
+	}
+
+	// return 0 on fail, 1 on success?
+	return 1;
+}
+
+bool FolderMemoryCard::WriteToFile( const u8* src, u32 adr, u32 dataLength ) {
+	const u32 cluster = adr / ClusterSizeRaw;
+	const u32 page = adr / PageSizeRaw;
+	const u32 offset = adr % PageSizeRaw;
+	const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
+
+	// figure out which file to write to
+	wxFileName fileName( folderName );
+	u32 clusterNumber;
+	const MemoryCardFileEntry* const entry = GetFileEntryFromFileDataCluster( m_superBlock.data.rootdir_cluster, fatCluster, &fileName, fileName.GetDirCount(), &clusterNumber );
+	if ( entry != nullptr ) {
+		if ( !fileName.DirExists() ) {
+			fileName.Mkdir();
+		}
+		if ( !fileName.FileExists() ) {
+			wxFFile createEmptyFile( fileName.GetFullPath(), L"wb" );
+			createEmptyFile.Close();
+		}
+		wxFFile file( fileName.GetFullPath(), L"r+b" );
+		if ( file.IsOpened() ) {
+			const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
+			const u32 fileSize = entry->entry.data.length;
+			const u32 fileOffsetStart = std::min( clusterNumber * ClusterSize + clusterOffset, fileSize );;
+			const u32 fileOffsetEnd = std::min( fileOffsetStart + dataLength, fileSize );
+			const u32 bytesToWrite = fileOffsetEnd - fileOffsetStart;
+
+			wxFileOffset actualFileSize = file.Length();
+			if ( actualFileSize < fileOffsetStart ) {
+				const u32 diff = fileOffsetStart - actualFileSize;
+				u8 temp = 0xFF;
+				for ( u32 i = 0; i < diff; ++i ) {
+					file.Write( &temp, 1 );
+				}
+			}
+
+			file.Seek( fileOffsetStart );
+			if ( bytesToWrite > 0 ) {
+				file.Write( src, bytesToWrite );
+			}
+
+			file.Close();
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+s32 FolderMemoryCard::EraseBlock( u32 adr ) {
+	const u32 block = adr / BlockSizeRaw;
+
+	u8 eraseData[PageSize];
+	memset( eraseData, 0xFF, PageSize );
+	for ( int page = 0; page < 16; ++page ) {
+		const u32 adr = block * BlockSizeRaw + page * PageSizeRaw;
+		Save( eraseData, adr, PageSize );
+	}
+
+	// return 0 on fail, 1 on success?
+	return 1;
+}
+
+u64 FolderMemoryCard::GetCRC() {
+	// Since this is just used as integrity check for savestate loading,
+	// give a timestamp of the last time the memory card was written to
+	return m_timeLastWritten;
+}
+
+void FolderMemoryCard::SetSlot( uint slot ) {
+	pxAssert( slot < 8 );
+	m_slot = slot;
+}
+
+void FolderMemoryCard::SetTimeLastWrittenToNow() {
+	m_timeLastWritten = wxGetLocalTimeMillis().GetValue();
+	m_framesUntilFlush = FramesAfterWriteUntilFlush;
+}
+
+// from http://www.oocities.org/siliconvalley/station/8269/sma02/sma02.html#ECC
+void FolderMemoryCard::CalculateECC( u8* ecc, const u8* data ) {
+	static const u8 Table[] = {
+		0x00, 0x87, 0x96, 0x11, 0xa5, 0x22, 0x33, 0xb4, 0xb4, 0x33, 0x22, 0xa5, 0x11, 0x96, 0x87, 0x00,
+		0xc3, 0x44, 0x55, 0xd2, 0x66, 0xe1, 0xf0, 0x77, 0x77, 0xf0, 0xe1, 0x66, 0xd2, 0x55, 0x44, 0xc3,
+		0xd2, 0x55, 0x44, 0xc3, 0x77, 0xf0, 0xe1, 0x66, 0x66, 0xe1, 0xf0, 0x77, 0xc3, 0x44, 0x55, 0xd2,
+		0x11, 0x96, 0x87, 0x00, 0xb4, 0x33, 0x22, 0xa5, 0xa5, 0x22, 0x33, 0xb4, 0x00, 0x87, 0x96, 0x11,
+		0xe1, 0x66, 0x77, 0xf0, 0x44, 0xc3, 0xd2, 0x55, 0x55, 0xd2, 0xc3, 0x44, 0xf0, 0x77, 0x66, 0xe1,
+		0x22, 0xa5, 0xb4, 0x33, 0x87, 0x00, 0x11, 0x96, 0x96, 0x11, 0x00, 0x87, 0x33, 0xb4, 0xa5, 0x22,
+		0x33, 0xb4, 0xa5, 0x22, 0x96, 0x11, 0x00, 0x87, 0x87, 0x00, 0x11, 0x96, 0x22, 0xa5, 0xb4, 0x33,
+		0xf0, 0x77, 0x66, 0xe1, 0x55, 0xd2, 0xc3, 0x44, 0x44, 0xc3, 0xd2, 0x55, 0xe1, 0x66, 0x77, 0xf0,
+		0xf0, 0x77, 0x66, 0xe1, 0x55, 0xd2, 0xc3, 0x44, 0x44, 0xc3, 0xd2, 0x55, 0xe1, 0x66, 0x77, 0xf0,
+		0x33, 0xb4, 0xa5, 0x22, 0x96, 0x11, 0x00, 0x87, 0x87, 0x00, 0x11, 0x96, 0x22, 0xa5, 0xb4, 0x33,
+		0x22, 0xa5, 0xb4, 0x33, 0x87, 0x00, 0x11, 0x96, 0x96, 0x11, 0x00, 0x87, 0x33, 0xb4, 0xa5, 0x22,
+		0xe1, 0x66, 0x77, 0xf0, 0x44, 0xc3, 0xd2, 0x55, 0x55, 0xd2, 0xc3, 0x44, 0xf0, 0x77, 0x66, 0xe1,
+		0x11, 0x96, 0x87, 0x00, 0xb4, 0x33, 0x22, 0xa5, 0xa5, 0x22, 0x33, 0xb4, 0x00, 0x87, 0x96, 0x11,
+		0xd2, 0x55, 0x44, 0xc3, 0x77, 0xf0, 0xe1, 0x66, 0x66, 0xe1, 0xf0, 0x77, 0xc3, 0x44, 0x55, 0xd2,
+		0xc3, 0x44, 0x55, 0xd2, 0x66, 0xe1, 0xf0, 0x77, 0x77, 0xf0, 0xe1, 0x66, 0xd2, 0x55, 0x44, 0xc3,
+		0x00, 0x87, 0x96, 0x11, 0xa5, 0x22, 0x33, 0xb4, 0xb4, 0x33, 0x22, 0xa5, 0x11, 0x96, 0x87, 0x00
+	};
+
+	int i, c;
+
+	ecc[0] = ecc[1] = ecc[2] = 0;
+
+	for ( i = 0; i < 0x80; i++ ) {
+		c = Table[data[i]];
+
+		ecc[0] ^= c;
+		if ( c & 0x80 ) {
+			ecc[1] ^= ~i;
+			ecc[2] ^= i;
+		}
+	}
+	ecc[0] = ~ecc[0];
+	ecc[0] &= 0x77;
+
+	ecc[1] = ~ecc[1];
+	ecc[1] &= 0x7f;
+
+	ecc[2] = ~ecc[2];
+	ecc[2] &= 0x7f;
+
+	return;
+}
+
+FolderMemoryCardAggregator::FolderMemoryCardAggregator() {
+	for ( uint i = 0; i < totalCardSlots; ++i ) {
+		m_cards[i].SetSlot( i );
+	}
+}
+
+void FolderMemoryCardAggregator::Open() {
+	for ( int i = 0; i < totalCardSlots; ++i ) {
+		m_cards[i].Open();
+	}
+}
+
+void FolderMemoryCardAggregator::Close() {
+	for ( int i = 0; i < totalCardSlots; ++i ) {
+		m_cards[i].Close();
+	}
+}
+
+s32 FolderMemoryCardAggregator::IsPresent( uint slot ) {
+	return m_cards[slot].IsPresent();
+}
+
+void FolderMemoryCardAggregator::GetSizeInfo( uint slot, PS2E_McdSizeInfo& outways ) {
+	m_cards[slot].GetSizeInfo( outways );
+}
+
+bool FolderMemoryCardAggregator::IsPSX( uint slot ) {
+	return m_cards[slot].IsPSX();
+}
+
+s32 FolderMemoryCardAggregator::Read( uint slot, u8 *dest, u32 adr, int size ) {
+	return m_cards[slot].Read( dest, adr, size );
+}
+
+s32 FolderMemoryCardAggregator::Save( uint slot, const u8 *src, u32 adr, int size ) {
+	return m_cards[slot].Save( src, adr, size );
+}
+
+s32 FolderMemoryCardAggregator::EraseBlock( uint slot, u32 adr ) {
+	return m_cards[slot].EraseBlock( adr );
+}
+
+u64 FolderMemoryCardAggregator::GetCRC( uint slot ) {
+	return m_cards[slot].GetCRC();
+}
+
+void FolderMemoryCardAggregator::NextFrame( uint slot ) {
+	m_cards[slot].NextFrame();
+}
+
+

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -78,8 +78,8 @@ void FolderMemoryCard::Open( const wxString& fullPath, const AppConfig::McdOptio
 			}
 		}
 	} else {
-		str = L"[disabled]";
-		disabled = true;
+		// if the user has disabled this slot or is using a different memory card type, just return without a console log
+		return;
 	}
 
 	Console.WriteLn( disabled ? Color_Gray : Color_Green, L"McdSlot %u: [Folder] " + str, m_slot );
@@ -276,8 +276,6 @@ bool FilterMatches( const wxString& fileName, const wxString& filter ) {
 bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, MemoryCardFileMetadataReference* parent, const bool enableFiltering, const wxString& filter ) {
 	wxDir dir( dirPath );
 	if ( dir.IsOpened() ) {
-		Console.WriteLn( L"(FolderMcd) Adding folder: %s", WX_STR( dirPath ) );
-
 		const u32 dirStartCluster = dirEntry->entry.data.cluster;
 
 		wxString fileName;
@@ -388,7 +386,6 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 bool FolderMemoryCard::AddFile( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const wxString& fileName, MemoryCardFileMetadataReference* parent ) {
 	wxFileName relativeFilePath( dirPath, fileName );
 	relativeFilePath.MakeRelativeTo( m_folderName.GetPath() );
-	Console.WriteLn( L"(FolderMcd) Adding file: %s", WX_STR( relativeFilePath.GetFullPath() ) );
 
 	wxFileName fileInfo( dirPath, fileName );
 	wxFFile file( fileInfo.GetFullPath(), L"rb" );

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -287,9 +287,9 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 		if ( enableFiltering ) {
 			bool hasFilter = !filter.IsEmpty();
 			if ( hasFilter ) {
-				localFilter = L"DATA-SYSTEM/" + filter;
+				localFilter = L"DATA-SYSTEM/BWNETCNF/" + filter;
 			} else {
-				localFilter = L"DATA-SYSTEM";
+				localFilter = L"DATA-SYSTEM/BWNETCNF";
 			}
 		}
 

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1172,9 +1172,9 @@ bool FileAccessHelper::CleanMemcardFilename( char* name ) {
 	const char illegalChars[] = { '\\', '%', ':', '|', '"', '<', '>' };
 	bool cleaned = false;
 
-	for ( int i = 0; i < sizeof( illegalChars ); ++i ) {
+	for ( size_t i = 0; i < sizeof( illegalChars ); ++i ) {
 		// this sizeof looks really odd but I couldn't get MemoryCardFileEntry::entry.data.name (or variants) working, feel free to replace with something equivalent but nicer looking
-		for ( int j = 0; j < sizeof( ( (MemoryCardFileEntry*)0 )->entry.data.name ); ++j ) {
+		for ( size_t j = 0; j < sizeof( ( (MemoryCardFileEntry*)0 )->entry.data.name ); ++j ) {
 			if ( name[j] == illegalChars[i] ) {
 				name[j] = '_';
 				cleaned = true;

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1025,7 +1025,7 @@ FolderMemoryCardAggregator::FolderMemoryCardAggregator() {
 
 void FolderMemoryCardAggregator::Open() {
 	for ( int i = 0; i < totalCardSlots; ++i ) {
-		m_cards[i].Open();
+		m_cards[i].Open( m_lastKnownFilter );
 	}
 }
 
@@ -1071,5 +1071,6 @@ void FolderMemoryCardAggregator::ReIndex( uint slot, const wxString& filter ) {
 	m_cards[slot].Close();
 	Console.WriteLn( Color_Green, L"(FolderMcd) Re-Indexing slot %u with filter \"%s\"", slot, WX_STR( filter ) );
 	m_cards[slot].Open( filter );
+	m_lastKnownFilter = filter;
 }
 

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -729,14 +729,7 @@ s32 FolderMemoryCard::Read( u8 *dest, u32 adr, int size ) {
 		if ( it != m_cache.end() ) {
 			memcpy( dest, &it->second.raw[offset], dataLength );
 		} else {
-			u8* src = GetSystemBlockPointer( adr );
-			if ( src != nullptr ) {
-				memcpy( dest, src, dataLength );
-			} else {
-				if ( !ReadFromFile( dest, adr, dataLength ) ) {
-					memset( dest, 0xFF, dataLength );
-				}
-			}
+			ReadDataWithoutCache( dest, adr, dataLength );
 		}
 	}
 
@@ -765,6 +758,17 @@ s32 FolderMemoryCard::Read( u8 *dest, u32 adr, int size ) {
 	return 1;
 }
 
+void FolderMemoryCard::ReadDataWithoutCache( u8* const dest, const u32 adr, const u32 dataLength ) {
+	u8* src = GetSystemBlockPointer( adr );
+	if ( src != nullptr ) {
+		memcpy( dest, src, dataLength );
+	} else {
+		if ( !ReadFromFile( dest, adr, dataLength ) ) {
+			memset( dest, 0xFF, dataLength );
+		}
+	}
+}
+
 s32 FolderMemoryCard::Save( const u8 *src, u32 adr, int size ) {
 	const u32 block = adr / BlockSizeRaw;
 	const u32 cluster = adr / ClusterSizeRaw;
@@ -790,7 +794,7 @@ s32 FolderMemoryCard::Save( const u8 *src, u32 adr, int size ) {
 		if ( it == m_cache.end() ) {
 			cachePage = &m_cache[page];
 			const u32 adrLoad = page * PageSizeRaw;
-			Read( &cachePage->raw[0], adrLoad, PageSize );
+			ReadDataWithoutCache( &cachePage->raw[0], adrLoad, PageSize );
 		} else {
 			cachePage = &it->second;
 		}

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -298,6 +298,8 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 		bool hasFilter = !filter.IsEmpty();
 		if ( hasFilter ) {
 			localFilter = L"DATA-SYSTEM/" + filter;
+		} else {
+			localFilter = L"DATA-SYSTEM";
 		}
 
 		int entryNumber = 2; // include . and ..
@@ -319,7 +321,7 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 				// if possible filter added directories by game serial
 				// this has the effective result of only files relevant to the current game being loaded into the memory card
 				// which means every game essentially sees the memory card as if no other files exist
-				if ( hasFilter && !FilterMatches( fileName, localFilter ) ) {
+				if ( !FilterMatches( fileName, localFilter ) ) {
 					hasNext = dir.GetNext( &fileName );
 					continue;
 				}

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -589,9 +589,6 @@ bool FolderMemoryCard::ReadFromFile( u8 *dest, u32 adr, u32 dataLength ) {
 	u32 clusterNumber;
 	const MemoryCardFileEntry* const entry = GetFileEntryFromFileDataCluster( m_superBlock.data.rootdir_cluster, fatCluster, &fileName, fileName.GetDirCount(), &clusterNumber );
 	if ( entry != nullptr ) {
-		if ( !fileName.DirExists() ) {
-			fileName.Mkdir();
-		}
 		wxFFile* file = m_lastAccessedFile.ReOpen( fileName.GetFullPath(), L"rb" );
 		if ( file->IsOpened() ) {
 			const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
@@ -879,13 +876,6 @@ bool FolderMemoryCard::WriteToFile( const u8* src, u32 adr, u32 dataLength ) {
 	u32 clusterNumber;
 	const MemoryCardFileEntry* const entry = GetFileEntryFromFileDataCluster( m_superBlock.data.rootdir_cluster, fatCluster, &fileName, fileName.GetDirCount(), &clusterNumber );
 	if ( entry != nullptr ) {
-		if ( !fileName.DirExists() ) {
-			fileName.Mkdir();
-		}
-		if ( !fileName.FileExists() ) {
-			wxFFile createEmptyFile( fileName.GetFullPath(), L"wb" );
-			createEmptyFile.Close();
-		}
 		wxFFile* file = m_lastAccessedFile.ReOpen( fileName.GetFullPath(), L"r+b" );
 		if ( file->IsOpened() ) {
 			const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
@@ -1061,6 +1051,16 @@ FileAccessHelper::~FileAccessHelper() {
 
 wxFFile* FileAccessHelper::Open( const wxString& filename, const wxString& mode ) {
 	this->Close();
+
+	wxFileName fn( filename );
+	if ( !fn.FileExists() ) {
+		if ( !fn.DirExists() ) {
+			fn.Mkdir();
+		}
+		wxFFile createEmptyFile( filename, L"wb" );
+		createEmptyFile.Close();
+	}
+
 	m_file = new wxFFile( filename, mode );
 	m_filename = filename;
 	m_mode = mode;

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1111,7 +1111,7 @@ wxFFile* FileAccessHelper::Open( const wxFileName& folderName, MemoryCardFileMet
 
 	if ( !fn.FileExists() ) {
 		if ( !fn.DirExists() ) {
-			fn.Mkdir();
+			fn.Mkdir( 0777, wxPATH_MKDIR_FULL );
 		}
 		wxFFile createEmptyFile( filename, L"wb" );
 		createEmptyFile.Close();

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1012,7 +1012,7 @@ void FolderMemoryCard::SetSlot( uint slot ) {
 
 u32 FolderMemoryCard::GetSizeInClusters() {
 	const u32 clusters = m_superBlock.data.clusters_per_card;
-	if ( clusters > 0 && clusters < UINT32_MAX ) {
+	if ( clusters > 0 && clusters < 0xFFFFFFFFu ) {
 		return clusters;
 	} else {
 		return TotalClusters;

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -813,12 +813,7 @@ void FolderMemoryCard::Flush() {
 	}
 
 	// then all directory and file entries
-	const u32 rootDirCluster = m_superBlock.data.rootdir_cluster;
-	FlushCluster( rootDirCluster + m_superBlock.data.alloc_offset );
-	MemoryCardFileEntryCluster* rootEntries = &m_fileEntryDict[rootDirCluster];
-	if ( rootEntries->entries[0].IsValid() && rootEntries->entries[0].IsUsed() ) {
-		FlushFileEntries( rootDirCluster, rootEntries->entries[0].entry.data.length );
-	}
+	FlushFileEntries();
 
 	// and finally, flush everything that hasn't been flushed yet
 	for ( uint i = 0; i < pageCount; ++i ) {
@@ -849,6 +844,16 @@ void FolderMemoryCard::FlushBlock( const u32 block ) {
 	const u32 page = block * 16;
 	for ( int i = 0; i < 16; ++i ) {
 		FlushPage( page + i );
+	}
+}
+
+void FolderMemoryCard::FlushFileEntries() {
+	// Flush all file entry data from the cache into m_fileEntryDict.
+	const u32 rootDirCluster = m_superBlock.data.rootdir_cluster;
+	FlushCluster( rootDirCluster + m_superBlock.data.alloc_offset );
+	MemoryCardFileEntryCluster* rootEntries = &m_fileEntryDict[rootDirCluster];
+	if ( rootEntries->entries[0].IsValid() && rootEntries->entries[0].IsUsed() ) {
+		FlushFileEntries( rootDirCluster, rootEntries->entries[0].entry.data.length );
 	}
 }
 

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -169,6 +169,7 @@ public:
 	void Unlock();
 
 	void Open();
+	void Open( const wxString& filter );
 	void Close();
 
 	s32  IsPresent();
@@ -219,7 +220,7 @@ protected:
 
 
 	// loads files and folders from the host file system if a superblock exists in the root directory
-	void LoadMemoryCardData();
+	void LoadMemoryCardData( const wxString& filter );
 
 	// creates the FAT and indirect FAT
 	void CreateFat();
@@ -252,7 +253,7 @@ protected:
 	// adds a folder in the host file system to the memory card, including all files and subdirectories
 	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
 	// - dirPath: the full path to the directory in the host file system
-	bool AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath );
+	bool AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const wxString& filter = L"" );
 
 	// adds a file in the host file sytem to the memory card
 	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
@@ -313,4 +314,5 @@ public:
 	s32  EraseBlock( uint slot, u32 adr );
 	u64  GetCRC( uint slot );
 	void NextFrame( uint slot );
+	void ReIndex( uint slot, const wxString& filter );
 };

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -112,6 +112,8 @@ struct MemoryCardFileEntry {
 	bool IsDir()  { return !!( entry.data.mode & 0x0020 ); }
 	bool IsUsed() { return !!( entry.data.mode & 0x8000 ); }
 	bool IsValid() { return entry.data.mode != 0xFFFFFFFF; }
+	// checks if we're either "." or ".."
+	bool IsDotDir() { return entry.data.name[0] == '.' && ( entry.data.name[1] == '\0' || ( entry.data.name[1] == '.' && entry.data.name[2] == '\0' ) ); }
 
 	static const u32 DefaultDirMode = 0x8427;
 	static const u32 DefaultFileMode = 0x8497;

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -150,7 +150,7 @@ struct MemoryCardFileMetadataReference {
 class FileAccessHelper {
 protected:
 	wxFFile* m_file;
-	wxString m_filename;
+	const MemoryCardFileEntry* m_entry;
 	wxString m_mode;
 
 public:
@@ -158,13 +158,13 @@ public:
 	~FileAccessHelper();
 
 	// Get an already opened file if possible, or open a new one and remember it
-	wxFFile* ReOpen( const wxString& filename, const wxString& mode );
+	wxFFile* ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata = false );
 	// Close an open file, if any
 	void Close();
 
 protected:
 	// Open a new file and remember it for later
-	wxFFile* Open( const wxString& filename, const wxString& mode );
+	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata = false );
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -293,8 +293,9 @@ public:
 	// Initialize & Load Memory Card with values configured in the Memory Card Manager
 	void Open( const bool enableFiltering, const wxString& filter );
 	// Initialize & Load Memory Card with provided custom values
-	void Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const bool enableFiltering, const wxString& filter );
-	void Close();
+	void Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter );
+	// Close the memory card and flush changes to the file system. Set flush to false to not store changes.
+	void Close( bool flush = true );
 
 	s32  IsPresent() const;
 	void GetSizeInfo( PS2E_McdSizeInfo& outways ) const;
@@ -357,9 +358,10 @@ protected:
 
 
 	// loads files and folders from the host file system if a superblock exists in the root directory
+	// - sizeInClusters: total memory card size in clusters, 0 for default
 	// - enableFiltering: if set to true, only folders whose name contain the filter string are loaded
 	// - filter: can include multiple filters by separating them with "/"
-	void LoadMemoryCardData( const bool enableFiltering, const wxString& filter );
+	void LoadMemoryCardData( const u32 sizeInClusters, const bool enableFiltering, const wxString& filter );
 
 	// creates the FAT and indirect FAT
 	void CreateFat();

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -168,8 +168,7 @@ public:
 	void Lock();
 	void Unlock();
 
-	void Open();
-	void Open( const wxString& filter );
+	void Open( const bool enableFiltering, const wxString& filter );
 	void Close();
 
 	s32  IsPresent();
@@ -220,7 +219,9 @@ protected:
 
 
 	// loads files and folders from the host file system if a superblock exists in the root directory
-	void LoadMemoryCardData( const wxString& filter );
+	// if enableFiltering is set to true, only folders whose name contain the filter string are loaded
+	// filter string can include multiple filters by separating them with "/"
+	void LoadMemoryCardData( const bool enableFiltering, const wxString& filter );
 
 	// creates the FAT and indirect FAT
 	void CreateFat();
@@ -253,7 +254,8 @@ protected:
 	// adds a folder in the host file system to the memory card, including all files and subdirectories
 	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
 	// - dirPath: the full path to the directory in the host file system
-	bool AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const wxString& filter = L"" );
+	// - enableFiltering and filter: filter loaded contents, see LoadMemoryCardData()
+	bool AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const bool enableFiltering = false, const wxString& filter = L"" );
 
 	// adds a file in the host file sytem to the memory card
 	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
@@ -298,6 +300,7 @@ class FolderMemoryCardAggregator {
 protected:
 	static const int totalCardSlots = 8;
 	FolderMemoryCard m_cards[totalCardSlots];
+	bool m_enableFiltering = true;
 	wxString m_lastKnownFilter = L"";
 
 public:
@@ -307,6 +310,8 @@ public:
 	void Open();
 	void Close();
 
+	void SetFiltering( const bool enableFiltering );
+
 	s32  IsPresent( uint slot );
 	void GetSizeInfo( uint slot, PS2E_McdSizeInfo& outways );
 	bool IsPSX( uint slot );
@@ -315,5 +320,5 @@ public:
 	s32  EraseBlock( uint slot, u32 adr );
 	u64  GetCRC( uint slot );
 	void NextFrame( uint slot );
-	void ReIndex( uint slot, const wxString& filter );
+	void ReIndex( uint slot, const bool enableFiltering, const wxString& filter );
 };

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -94,6 +94,9 @@ struct MemoryCardFileEntry {
 	bool IsDir()  { return !!( entry.data.mode & 0x0020 ); }
 	bool IsUsed() { return !!( entry.data.mode & 0x8000 ); }
 	bool IsValid() { return entry.data.mode != 0xFFFFFFFF; }
+
+	static const u32 DefaultDirMode = 0x8427;
+	static const u32 DefaultFileMode = 0x8497;
 };
 #pragma pack(pop)
 
@@ -269,7 +272,7 @@ protected:
 	void Flush( const u32 page );
 
 	// flush a directory's file entries and all its subdirectories to the internal data
-	void FlushFileEntries( const u32 dirCluster, const u32 remainingFiles );
+	void FlushFileEntries( const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath = L"" );
 
 	// write data as Save() normally would, but ignore the cache; used for flushing
 	s32 WriteWithoutCache( const u8 *src, u32 adr, int size );

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -280,12 +280,17 @@ protected:
 
 	// returns in-memory address of file or directory metadata searchCluster corresponds to
 	// returns nullptr if searchCluster contains something else
-	// originally call by passing:
-	// - currentCluster: the root directory cluster as indicated in the superblock
 	// - searchCluster: the cluster that is being accessed, relative to alloc_offset in the superblock
 	// - entryNumber: page of cluster
 	// - offset: offset of page
-	u8* GetFileEntryPointer( const u32 currentCluster, const u32 searchCluster, const u32 entryNumber, const u32 offset );
+	u8* GetFileEntryPointer( const u32 searchCluster, const u32 entryNumber, const u32 offset );
+
+	// used by GetFileEntryPointer to find the correct cluster
+	// returns nullptr if searchCluster is not a file or directory metadata cluster
+	// - currentCluster: the cluster we're currently traversing
+	// - searchCluster: the cluster we want
+	// - fileCount: the number of files left in the directory currently traversed
+	MemoryCardFileEntryCluster* GetFileEntryCluster( const u32 currentCluster, const u32 searchCluster, const u32 fileCount );
 
 	// returns file entry of the file at the given searchCluster
 	// the passed fileName will be filled with a path to the file being accessed

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -140,7 +140,8 @@ struct MemoryCardFileMetadataReference {
 	MemoryCardFileEntry* entry;
 	u32 consecutiveCluster;
 
-	void GetPath( wxFileName* fileName );
+	// returns true if filename was modified and metadata containing the actual filename should be written
+	bool GetPath( wxFileName* fileName );
 };
 
 // --------------------------------------------------------------------------------------
@@ -161,6 +162,10 @@ public:
 	wxFFile* ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata = false );
 	// Close an open file, if any
 	void Close();
+
+	// removes characters from a PS2 file name that would be illegal in a Windows file system
+	// returns true if any changes were made
+	static bool CleanMemcardFilename( char* name );
 
 protected:
 	// Open a new file and remember it for later

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -298,6 +298,7 @@ class FolderMemoryCardAggregator {
 protected:
 	static const int totalCardSlots = 8;
 	FolderMemoryCard m_cards[totalCardSlots];
+	wxString m_lastKnownFilter = L"";
 
 public:
 	FolderMemoryCardAggregator();

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -402,6 +402,11 @@ protected:
 	// creates a reference to a directory entry, so it can be passed as parent to other files/directories
 	MemoryCardFileMetadataReference* AddDirEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
 
+	
+	// read data from the memory card, ignoring the cache
+	// do NOT attempt to read ECC with this method, it will not work
+	void ReadDataWithoutCache( u8* const dest, const u32 adr, const u32 dataLength );
+
 
 	bool ReadFromFile( u8 *dest, u32 adr, u32 dataLength );
 	bool WriteToFile( const u8* src, u32 adr, u32 dataLength );

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -357,6 +357,9 @@ protected:
 	// - parent: pointer to the parent dir's quick-access reference element
 	bool AddFile( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const wxString& fileName, MemoryCardFileMetadataReference* parent = nullptr );
 
+	// calculates the amount of clusters a directory would use up if put into a memory card
+	u32 CalculateRequiredClustersOfDirectory( const wxString& dirPath );
+
 
 	// adds a file to the quick-access dictionary, so it can be accessed more efficiently (ie, without searching through the entire file system) later
 	void AddFileEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -416,13 +416,16 @@ protected:
 	void Flush();
 
 	// flush a single page of the cache to the internal data and/or host file system
-	void FlushPage( const u32 page );
+	bool FlushPage( const u32 page );
 
 	// flush a memory card cluster of the cache to the internal data and/or host file system
-	void FlushCluster( const u32 cluster );
+	bool FlushCluster( const u32 cluster );
 
 	// flush a whole memory card block of the cache to the internal data and/or host file system
-	void FlushBlock( const u32 block );
+	bool FlushBlock( const u32 block );
+
+	// flush the superblock to the internal data and/or host file system
+	void FlushSuperBlock();
 
 	// flush all directory and file entries to the internal data
 	void FlushFileEntries();

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -211,6 +211,14 @@ public:
 
 	void SetSlot( uint slot );
 
+	u32 GetSizeInClusters();
+
+	// WARNING: The intended use-case for this is resetting back to 8MB if a differently-sized superblock was loaded
+	// setting to a different size is untested and will probably not work correctly
+	void SetSizeInClusters( u32 clusters );
+	// see SetSizeInClusters()
+	void SetSizeInMB( u32 megaBytes );
+
 	// called once per frame, used for flushing data after FramesAfterWriteUntilFlush frames of no writes
 	void NextFrame();
 

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -1,0 +1,313 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wx/file.h>
+#include <wx/dir.h>
+#include <wx/stopwatch.h>
+#include <wx/ffile.h>
+#include <map>
+
+#include "PluginCallbacks.h"
+
+// --------------------------------------------------------------------------------------
+//  Superblock Header Struct
+// --------------------------------------------------------------------------------------
+#pragma pack(push, 1)
+struct superblock {
+	char magic[28]; 			// 0x00
+	char version[12]; 			// 0x1c
+	u16 page_len; 				// 0x28
+	u16 pages_per_cluster;	 	// 0x2a
+	u16 pages_per_block;		// 0x2c
+	u16 unused; 				// 0x2e
+	u32 clusters_per_card;	 	// 0x30
+	u32 alloc_offset; 			// 0x34
+	u32 alloc_end; 				// 0x38
+	u32 rootdir_cluster;		// 0x3c
+	u32 backup_block1;			// 0x40
+	u32 backup_block2;			// 0x44
+	u64 padding0x48;			// 0x48
+	u32 ifc_list[32]; 			// 0x50
+	u32 bad_block_list[32]; 	// 0xd0
+	u8 card_type; 				// 0x150
+	u8 card_flags; 				// 0x151
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct MemoryCardFileEntryDateTime {
+	u8 unused;
+	u8 second;
+	u8 minute;
+	u8 hour;
+	u8 day;
+	u8 month;
+	u16 year;
+};
+#pragma pack(pop)
+
+// --------------------------------------------------------------------------------------
+//  MemoryCardFileEntry
+// --------------------------------------------------------------------------------------
+// Structure for directory and file relationships as stored on memory cards
+#pragma pack(push, 1)
+struct MemoryCardFileEntry {
+	union {
+		struct MemoryCardFileEntryData {
+			u32 mode;
+			u32 length; // number of bytes for file, number of files for dir
+			union {
+				MemoryCardFileEntryDateTime data;
+				u64 value;
+				u8 raw[8];
+			} timeCreated;
+			u32 cluster; // cluster the start of referred file or folder can be found in
+			u32 dirEntry; // parent directory entry number, only used if "." entry of subdir
+			union {
+				MemoryCardFileEntryDateTime data;
+				u64 value;
+				u8 raw[8];
+			} timeModified;
+			u32 attr;
+			u8 padding[0x1C];
+			u8 name[0x20];
+			u8 unused[0x1A0];
+		} data;
+		u8 raw[0x200];
+	} entry;
+
+	bool IsFile() { return !!( entry.data.mode & 0x0010 ); }
+	bool IsDir()  { return !!( entry.data.mode & 0x0020 ); }
+	bool IsUsed() { return !!( entry.data.mode & 0x8000 ); }
+	bool IsValid() { return entry.data.mode != 0xFFFFFFFF; }
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct MemoryCardFileEntryCluster {
+	MemoryCardFileEntry entries[2];
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct MemoryCardPage {
+	static const int PageSize = 0x200;
+	u8 raw[PageSize];
+};
+#pragma pack(pop)
+
+// --------------------------------------------------------------------------------------
+//  FolderMemoryCard
+// --------------------------------------------------------------------------------------
+// Fakes a memory card using a regular folder/file structure in the host file system
+class FolderMemoryCard {
+protected:
+	wxFileName folderName;
+
+	// a few constants so we could in theory change the memory card size without too much effort
+	static const int IndirectFatClusterCount = 1; // should be 32 but only 1 is ever used
+	static const int PageSize = MemoryCardPage::PageSize;
+	static const int ClusterSize = PageSize * 2;
+	static const int BlockSize = ClusterSize * 8;
+	static const int EccSize = 0x10;
+	static const int PageSizeRaw = PageSize + EccSize;
+	static const int ClusterSizeRaw = PageSizeRaw * 2;
+	static const int BlockSizeRaw = ClusterSizeRaw * 8;
+	static const int TotalPages = 0x4000;
+	static const int TotalClusters = TotalPages / 2;
+	static const int TotalBlocks = TotalClusters / 8;
+
+	static const int FramesAfterWriteUntilFlush = 60;
+
+	union superBlockUnion {
+		superblock data;
+		u8 raw[BlockSize];
+	} m_superBlock;
+	union indirectFatUnion {
+		u32 data[IndirectFatClusterCount][ClusterSize / 4];
+		u8 raw[IndirectFatClusterCount][ClusterSize];
+	} m_indirectFat;
+	union fatUnion {
+		u32 data[IndirectFatClusterCount][ClusterSize / 4][ClusterSize / 4];
+		u8 raw[IndirectFatClusterCount][ClusterSize / 4][ClusterSize];
+	} m_fat;
+	u8 m_backupBlock1[BlockSize];
+	u8 m_backupBlock2[BlockSize];
+
+	std::map<u32, MemoryCardFileEntryCluster> m_fileEntryDict;
+
+	// holds a copy of modified areas of the memory card, in page-sized chunks
+	std::map<u32, MemoryCardPage> m_cache;
+
+	uint m_slot;
+	bool m_isEnabled;
+	u64 m_timeLastWritten;
+	int m_framesUntilFlush;
+
+public:
+	FolderMemoryCard();
+	virtual ~FolderMemoryCard() throw() {}
+
+	void Lock();
+	void Unlock();
+
+	void Open();
+	void Close();
+
+	s32  IsPresent();
+	void GetSizeInfo( PS2E_McdSizeInfo& outways );
+	bool IsPSX();
+	s32  Read( u8 *dest, u32 adr, int size );
+	s32  Save( const u8 *src, u32 adr, int size );
+	s32  EraseBlock( u32 adr );
+	u64  GetCRC();
+
+	void SetSlot( uint slot );
+
+	// called once per frame, used for flushing data after FramesAfterWriteUntilFlush frames of no writes
+	void NextFrame();
+
+	static void CalculateECC( u8* ecc, const u8* data );
+
+protected:
+	// initializes memory card data, as if it was fresh from the factory
+	void InitializeInternalData();
+
+	bool IsFormatted();
+
+	// returns the in-memory address of data the given memory card adr corresponds to
+	// returns nullptr if adr corresponds to a folder or file entry
+	u8* GetSystemBlockPointer( const u32 adr );
+
+	// returns in-memory address of file or directory metadata searchCluster corresponds to
+	// returns nullptr if searchCluster contains something else
+	// originally call by passing:
+	// - currentCluster: the root directory cluster as indicated in the superblock
+	// - searchCluster: the cluster that is being accessed, relative to alloc_offset in the superblock
+	// - entryNumber: page of cluster
+	// - offset: offset of page
+	u8* GetFileEntryPointer( const u32 currentCluster, const u32 searchCluster, const u32 entryNumber, const u32 offset );
+
+	// returns file entry of the file at the given searchCluster
+	// the passed fileName will be filled with a path to the file being accessed
+	// returns nullptr if searchCluster contains no file
+	// call by passing:
+	// - currentCluster: the root directory cluster as indicated in the superblock
+	// - searchCluster: the cluster that is being accessed, relative to alloc_offset in the superblock
+	// - fileName: wxFileName of the root directory of the memory card folder in the host file system (filename part doesn't matter)
+	// - originalDirCount: the point in fileName where to insert the found folder path, usually fileName->GetDirCount()
+	// - outClusterNumber: the cluster's sequential number of the file will be written to this pointer,
+	//                     which can be used to calculate the in-file offset of the address being accessed
+	MemoryCardFileEntry* GetFileEntryFromFileDataCluster( const u32 currentCluster, const u32 searchCluster, wxFileName* fileName, const size_t originalDirCount, u32* outClusterNumber );
+
+
+	// loads files and folders from the host file system if a superblock exists in the root directory
+	void LoadMemoryCardData();
+
+	// creates the FAT and indirect FAT
+	void CreateFat();
+
+	// creates file entries for the root directory
+	void CreateRootDir();
+
+
+	// returns the system cluster past the highest used one (will be the lowest free one under normal use)
+	// this is used for creating the FAT, don't call otherwise unless you know exactly what you're doing
+	u32 GetFreeSystemCluster();
+
+	// returns the lowest unused data cluster, relative to alloc_offset in the superblock
+	// returns 0xFFFFFFFFu when the memory card is full
+	u32 GetFreeDataCluster();
+
+	// returns the amount of unused data clusters
+	u32 GetAmountFreeDataClusters();
+
+	// returns the final cluster of the file or directory which is (partially) stored in the given cluster
+	u32 GetLastClusterOfData( const u32 cluster );
+
+	u64 ConvertToMemoryCardTimestamp( const wxDateTime& time );
+
+
+	// creates and returns a new file entry in the given directory entry, ready to be filled
+	// returns nullptr when the memory card is full
+	MemoryCardFileEntry* AppendFileEntryToDir( MemoryCardFileEntry* const dirEntry );
+
+	// adds a folder in the host file system to the memory card, including all files and subdirectories
+	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
+	// - dirPath: the full path to the directory in the host file system
+	bool AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath );
+
+	// adds a file in the host file sytem to the memory card
+	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
+	// - dirPath: the full path to the directory containing the file in the host file system
+	// - fileName: the name of the file, without path
+	bool AddFile( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const wxString& fileName );
+
+
+	bool ReadFromFile( u8 *dest, u32 adr, u32 dataLength );
+	bool WriteToFile( const u8* src, u32 adr, u32 dataLength );
+
+
+	// flush the whole cache to the internal data and/or host file system
+	void Flush();
+
+	// flush a single page of the cache to the internal data and/or host file system
+	void Flush( const u32 page );
+
+	// flush a directory's file entries and all its subdirectories to the internal data
+	void FlushFileEntries( const u32 dirCluster, const u32 remainingFiles );
+
+	// write data as Save() normally would, but ignore the cache; used for flushing
+	s32 WriteWithoutCache( const u8 *src, u32 adr, int size );
+
+	void SetTimeLastWrittenToNow();
+
+	wxString GetDisabledMessage( uint slot ) const {
+		return wxsFormat( pxE( L"The PS2-slot %d has been automatically disabled.  You can correct the problem\nand re-enable it at any time using Config:Memory cards from the main menu."
+			), slot//TODO: translate internal slot index to human-readable slot description
+			);
+	}
+	wxString GetCardFullMessage( const wxString& filePath ) const {
+		return wxsFormat( pxE( L"(FolderMcd) Memory Card is full, could not add: %s" ), WX_STR( filePath ) );
+	}
+};
+
+// --------------------------------------------------------------------------------------
+//  FolderMemoryCardAggregator
+// --------------------------------------------------------------------------------------
+// Forwards the API's requests for specific memory card slots to the correct FolderMemoryCard.
+class FolderMemoryCardAggregator {
+protected:
+	static const int totalCardSlots = 8;
+	FolderMemoryCard m_cards[totalCardSlots];
+
+public:
+	FolderMemoryCardAggregator();
+	virtual ~FolderMemoryCardAggregator() throw( ) {}
+
+	void Open();
+	void Close();
+
+	s32  IsPresent( uint slot );
+	void GetSizeInfo( uint slot, PS2E_McdSizeInfo& outways );
+	bool IsPSX( uint slot );
+	s32  Read( uint slot, u8 *dest, u32 adr, int size );
+	s32  Save( uint slot, const u8 *src, u32 adr, int size );
+	s32  EraseBlock( uint slot, u32 adr );
+	u64  GetCRC( uint slot );
+	void NextFrame( uint slot );
+};

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -381,6 +381,9 @@ protected:
 	// flush a whole memory card block of the cache to the internal data and/or host file system
 	void FlushBlock( const u32 block );
 
+	// flush all directory and file entries to the internal data
+	void FlushFileEntries();
+
 	// flush a directory's file entries and all its subdirectories to the internal data
 	void FlushFileEntries( const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath = L"", MemoryCardFileMetadataReference* parent = nullptr );
 

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -191,7 +191,10 @@ protected:
 		u8 raw[IndirectFatClusterCount][ClusterSize / 4][ClusterSize];
 	} m_fat;
 	u8 m_backupBlock1[BlockSize];
-	u8 m_backupBlock2[BlockSize];
+	union backupBlock2Union {
+		u32 programmedBlock;
+		u8 raw[BlockSize];
+	} m_backupBlock2;
 
 	// stores directory and file metadata
 	std::map<u32, MemoryCardFileEntryCluster> m_fileEntryDict;

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -132,6 +132,30 @@ struct MemoryCardPage {
 #pragma pack(pop)
 
 // --------------------------------------------------------------------------------------
+//  FileAccessHelper
+// --------------------------------------------------------------------------------------
+// Small helper class to keep memory card files opened between calls to Read()/Save() 
+class FileAccessHelper {
+protected:
+	wxFFile* m_file;
+	wxString m_filename;
+	wxString m_mode;
+
+public:
+	FileAccessHelper();
+	~FileAccessHelper();
+
+	// Get an already opened file if possible, or open a new one and remember it
+	wxFFile* ReOpen( const wxString& filename, const wxString& mode );
+	// Close an open file, if any
+	void Close();
+
+protected:
+	// Open a new file and remember it for later
+	wxFFile* Open( const wxString& filename, const wxString& mode );
+};
+
+// --------------------------------------------------------------------------------------
 //  FolderMemoryCard
 // --------------------------------------------------------------------------------------
 // Fakes a memory card using a regular folder/file structure in the host file system
@@ -179,6 +203,9 @@ protected:
 	int m_framesUntilFlush;
 	// used to figure out if contents were changed for savestate-related purposes, see GetCRC()
 	u64 m_timeLastWritten;
+
+	// remembers and keeps the last accessed file open for further access
+	FileAccessHelper m_lastAccessedFile;
 
 	// path to the folder that contains the files of this memory card
 	wxFileName m_folderName;
@@ -316,6 +343,7 @@ protected:
 	// write data as Save() normally would, but ignore the cache; used for flushing
 	s32 WriteWithoutCache( const u8 *src, u32 adr, int size );
 
+	void SetTimeLastReadToNow();
 	void SetTimeLastWrittenToNow();
 
 	

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -283,6 +283,9 @@ protected:
 
 	bool m_isEnabled;
 
+	// if set to false, nothing is actually written to the file system while flushing, and data is discarded instead
+	bool m_performFileWrites;
+
 public:
 	FolderMemoryCard();
 	virtual ~FolderMemoryCard() throw() {}
@@ -293,7 +296,7 @@ public:
 	// Initialize & Load Memory Card with values configured in the Memory Card Manager
 	void Open( const bool enableFiltering, const wxString& filter );
 	// Initialize & Load Memory Card with provided custom values
-	void Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter );
+	void Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter, bool simulateFileWrites = false );
 	// Close the memory card and flush changes to the file system. Set flush to false to not store changes.
 	void Close( bool flush = true );
 

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -335,7 +335,13 @@ protected:
 	void Flush();
 
 	// flush a single page of the cache to the internal data and/or host file system
-	void Flush( const u32 page );
+	void FlushPage( const u32 page );
+
+	// flush a memory card cluster of the cache to the internal data and/or host file system
+	void FlushCluster( const u32 cluster );
+
+	// flush a whole memory card block of the cache to the internal data and/or host file system
+	void FlushBlock( const u32 block );
 
 	// flush a directory's file entries and all its subdirectories to the internal data
 	void FlushFileEntries( const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath = L"" );

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -30,6 +30,9 @@
 #include <wx/dir.h>
 
 
+bool CopyDirectory( const wxString& from, const wxString& to );
+bool RemoveDirectory( const wxString& dirname );
+
 using namespace pxSizerFlags;
 using namespace Panels;
 
@@ -777,73 +780,6 @@ void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card ) {
 	}
 
 	closed_core.AllowResume();
-}
-
-bool CopyDirectory( const wxString& from, const wxString& to ) {
-	wxDir src( from );
-	if ( !src.IsOpened() ) {
-		return false;
-	}
-
-	wxMkdir( to );
-	wxDir dst( to );
-	if ( !dst.IsOpened() ) {
-		return false;
-	}
-
-	wxString filename;
-
-	// copy directories
-	if ( src.GetFirst( &filename, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN ) ) {
-		do {
-			if ( !CopyDirectory( wxFileName( from, filename ).GetFullPath(), wxFileName( to, filename ).GetFullPath() ) ) {
-				return false;
-			}
-		} while ( src.GetNext( &filename ) );
-	}
-
-	// copy files
-	if ( src.GetFirst( &filename, wxEmptyString, wxDIR_FILES | wxDIR_HIDDEN ) ) {
-		do {
-			if ( !wxCopyFile( wxFileName( from, filename ).GetFullPath(), wxFileName( to, filename ).GetFullPath() ) ) {
-				return false;
-			}
-		} while ( src.GetNext( &filename ) );
-	}
-
-	return true;
-}
-
-bool RemoveDirectory( const wxString& dirname ) {
-	{
-		wxDir dir( dirname );
-		if ( !dir.IsOpened() ) {
-			return false;
-		}
-
-		wxString filename;
-
-		// delete subdirs recursively
-		if ( dir.GetFirst( &filename, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN ) ) {
-			do {
-				if ( !RemoveDirectory( wxFileName( dirname, filename ).GetFullPath() ) ) {
-					return false;
-				}
-			} while ( dir.GetNext( &filename ) );
-		}
-
-		// delete files
-		if ( dir.GetFirst( &filename, wxEmptyString, wxDIR_FILES | wxDIR_HIDDEN ) ) {
-			do {
-				if ( !wxRemoveFile( wxFileName( dirname, filename ).GetFullPath() ) ) {
-					return false;
-				}
-			} while ( dir.GetNext( &filename ) );
-		}
-	}
-
-	// oddly enough this has different results compared to the more sensible dirname.Rmdir(), don't change!
-	return wxFileName::Rmdir( dirname );
 }
 
 void Panels::MemoryCardListPanel_Simple::UiDeleteCard( McdSlotItem& card )

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -54,6 +54,7 @@ bool EnumerateMemoryCard( McdSlotItem& dest, const wxFileName& filename, const w
 {
 	dest.IsFormatted	= false;
 	dest.IsPresent		= false;
+	dest.IsPSX			= false;
 	dest.Type			= MemoryCardType::MemoryCard_None;
 
 	const wxString fullpath( filename.GetFullPath() );

--- a/pcsx2/gui/Panels/MemoryCardListView.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListView.cpp
@@ -156,7 +156,7 @@ wxString MemoryCardListView_Simple::OnGetItemText(long item, long column) const
 			return prefix + res;
 		}
 */		
-		case McdColS_Size:			return prefix + ( !it.IsPresent ? L"" : (it.IsPSX? pxsFmt( L"%u MBit", it.SizeInMB ) : pxsFmt( L"%u MiB", it.SizeInMB )) );
+		case McdColS_Size:			return prefix + ( !it.IsPresent ? L"" : (it.IsPSX? pxsFmt( L"%u MBit", it.SizeInMB ) : ( it.SizeInMB > 0 ? pxsFmt( L"%u MiB", it.SizeInMB ) : L"Auto" ) ) );
 		case McdColS_Formatted:		return prefix + ( !it.IsPresent ? L"" : ( it.IsFormatted ? _("Yes") : _("No")) );
 		case McdColS_Type:			return prefix + ( !it.IsPresent ? L"" : ( it.IsPSX? _("PSX") : _("PS2")) );
 		case McdColS_DateModified:	return prefix + ( !it.IsPresent ? L"" : it.DateModified.FormatDate() );

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -212,6 +212,8 @@ namespace Panels
 		
 		// Doubles as Create and Delete buttons
 		wxButton*		m_button_Create;
+
+		wxButton*		m_button_Convert;
 		
 		// Doubles as Mount and Unmount buttons ("Enable"/"Disable" port)
 //		wxButton*		m_button_Mount;
@@ -237,6 +239,7 @@ namespace Panels
 
 	protected:
 		void OnCreateOrDeleteCard(wxCommandEvent& evt);
+		void OnConvertCard(wxCommandEvent& evt);
 		void OnMountCard(wxCommandEvent& evt);
 //		void OnRelocateCard(wxCommandEvent& evt);
 		void OnRenameFile(wxCommandEvent& evt);
@@ -270,6 +273,7 @@ namespace Panels
 
 		virtual void UiRenameCard( McdSlotItem& card );
 		virtual void UiCreateNewCard( McdSlotItem& card );
+		virtual void UiConvertCard( McdSlotItem& card );
 		virtual void UiDeleteCard( McdSlotItem& card );
 		virtual void UiAssignUnassignFile( McdSlotItem& card );
 		

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -40,6 +40,7 @@ struct McdSlotItem
 {
 	int			Slot;			//0-7: internal slot. -1: unrelated to an internal slot (the rest of the files at the folder).
 	bool		IsPresent;		//Whether or not a file is associated with this item (true/false when 0<=Slot<=7. Always true when Slot==-1)
+	MemoryCardType Type;		//The implementation used for this memory card
 	
 	//Only meaningful when IsPresent==true (a file exists for this item):
 	wxFileName	Filename;		// full pathname

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -285,6 +285,7 @@ namespace Panels
 	protected:
 		//pxCheckBox*		m_check_Multitap[2];
 		pxCheckBox*		m_check_Ejection;
+		pxCheckBox*		m_folderAutoIndex;
 
 		//moved to the system menu, just below "Save State"
 		//pxCheckBox*		m_check_SavestateBackup;

--- a/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj
@@ -636,6 +636,7 @@
     <ClCompile Include="..\..\gui\MainFrame.cpp" />
     <ClCompile Include="..\..\gui\MainMenuClicks.cpp" />
     <ClCompile Include="..\..\gui\MemoryCardFile.cpp" />
+    <ClCompile Include="..\..\gui\MemoryCardFolder.cpp" />
     <ClCompile Include="..\..\gui\MessageBoxes.cpp" />
     <ClCompile Include="..\..\gui\MSWstuff.cpp" />
     <ClCompile Include="..\..\gui\pxLogTextCtrl.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj
@@ -646,6 +646,7 @@
     <ClCompile Include="..\..\gui\Dialogs\AssertionDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\BaseConfigurationDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\ConfirmationDialogs.cpp" />
+    <ClCompile Include="..\..\gui\Dialogs\ConvertMemoryCardDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\CreateMemoryCardDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\FirstTimeWizard.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\ImportSettingsDialog.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj.filters
@@ -635,6 +635,9 @@
     <ClCompile Include="..\..\gui\MemoryCardFile.cpp">
       <Filter>AppHost</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gui\MemoryCardFolder.cpp">
+      <Filter>AppHost</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\gui\MessageBoxes.cpp">
       <Filter>AppHost</Filter>
     </ClCompile>

--- a/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2012.vcxproj.filters
@@ -665,6 +665,9 @@
     <ClCompile Include="..\..\gui\Dialogs\ConfirmationDialogs.cpp">
       <Filter>AppHost\Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gui\Dialogs\ConvertMemoryCardDialog.cpp">
+      <Filter>AppHost\Dialogs</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\gui\Dialogs\CreateMemoryCardDialog.cpp">
       <Filter>AppHost\Dialogs</Filter>
     </ClCompile>

--- a/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj
@@ -636,6 +636,7 @@
     <ClCompile Include="..\..\gui\MainFrame.cpp" />
     <ClCompile Include="..\..\gui\MainMenuClicks.cpp" />
     <ClCompile Include="..\..\gui\MemoryCardFile.cpp" />
+    <ClCompile Include="..\..\gui\MemoryCardFolder.cpp" />
     <ClCompile Include="..\..\gui\MessageBoxes.cpp" />
     <ClCompile Include="..\..\gui\MSWstuff.cpp" />
     <ClCompile Include="..\..\gui\pxLogTextCtrl.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj
@@ -646,6 +646,7 @@
     <ClCompile Include="..\..\gui\Dialogs\AssertionDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\BaseConfigurationDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\ConfirmationDialogs.cpp" />
+    <ClCompile Include="..\..\gui\Dialogs\ConvertMemoryCardDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\CreateMemoryCardDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\FirstTimeWizard.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\ImportSettingsDialog.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj.filters
@@ -635,6 +635,9 @@
     <ClCompile Include="..\..\gui\MemoryCardFile.cpp">
       <Filter>AppHost</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gui\MemoryCardFolder.cpp">
+      <Filter>AppHost</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\gui\MessageBoxes.cpp">
       <Filter>AppHost</Filter>
     </ClCompile>

--- a/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2_vs2013.vcxproj.filters
@@ -665,6 +665,9 @@
     <ClCompile Include="..\..\gui\Dialogs\ConfirmationDialogs.cpp">
       <Filter>AppHost\Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gui\Dialogs\ConvertMemoryCardDialog.cpp">
+      <Filter>AppHost\Dialogs</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\gui\Dialogs\CreateMemoryCardDialog.cpp">
       <Filter>AppHost\Dialogs</Filter>
     </ClCompile>


### PR DESCRIPTION
This adds a class (and some helper structures) that implements memory card reads and writes into the host file system instead of a raw memory card file.

I was mostly doing this because I was curious if it was possible to implement the same sort of thing Dolphin added recently for the PS2 as well, and it kinda is, although the way and order the PS2 writes FAT data make it quite difficult at times. I ended up caching all modified pages of data in memory and only flushing to disk when the emulator is shutting down, which isn't great but at least works consistently. Memory Card FAT is recreated whenever it's opened, so you can freely add and remove files from the folder.

It's probably far from perfect and could use some optimization, especially when it comes to finding a good time to flush the in-memory data, but it works quite well for regular use of creating and overwriting saves. Deleting isn't implemented yet. I imagine that savestates could mess with it quite a bit, but that's probably the case with the raw files as well.

Here's a picture of it running in the PS2 file browser: https://cloud.githubusercontent.com/assets/4522237/5193663/b7cb128e-7503-11e4-8cbe-8fade86e678d.png

To test it out, comment out the FileMemoryCard impl in Component_FileMcd and comment in the FolderMemoryCardAggregator instead. Ideally, there should be an option to allow the user to switch between the two modes. A few other small GUI changes would also be needed so you can select folders instead of files as memory cards.

Tell me what you think and if this could be a good addition to the emulator with a bit more polish.