### PR TITLE
spu2x:zzogl: disable TLS

### DIFF
--- a/common/include/Utilities/Threading.h
+++ b/common/include/Utilities/Threading.h
@@ -63,7 +63,7 @@ extern ConsoleLogSource_Threading pxConLog_Thread;
 // For complimentary support for TLS, include Utilities/TlsVariable.inl, and use the
 // DeclareTls macro in the place of __threadlocal.
 //
-//#define PCSX2_THREAD_LOCAL 0		// uncomment this line to force-disable native TLS (useful for testing TlsVariabel on windows/linux)
+//#define PCSX2_THREAD_LOCAL 0		// uncomment this line to force-disable native TLS (useful for testing TlsVariable on windows/linux)
 
 #ifndef PCSX2_THREAD_LOCAL
 #	ifdef __WXMAC__

--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -176,3 +176,4 @@ set(UtilitiesFinalLibs
 )
 
 add_pcsx2_lib(${Output} "${UtilitiesFinalSources}" "${UtilitiesFinalLibs}" "${UtilitiesFinalFlags}")
+add_pcsx2_lib(${Output}_NO_TLS "${UtilitiesFinalSources}" "${UtilitiesFinalLibs}" "${UtilitiesFinalFlags} -DPCSX2_THREAD_LOCAL=0")

--- a/plugins/spu2-x/src/CMakeLists.txt
+++ b/plugins/spu2-x/src/CMakeLists.txt
@@ -120,7 +120,7 @@ set(spu2xFinalSources
 )
 
 set(spu2xFinalLibs
-    Utilities
+    Utilities_NO_TLS
     ${ALSA_LIBRARIES}
     ${PORTAUDIO_LIBRARIES}
     ${GTK2_LIBRARIES}

--- a/plugins/zzogl-pg/opengl/CMakeLists.txt
+++ b/plugins/zzogl-pg/opengl/CMakeLists.txt
@@ -190,7 +190,7 @@ set(zzoglFinalSources
 )
 
 set(zzoglFinalLibs
-    Utilities
+    Utilities_NO_TLS
     ${OPENGL_LIBRARIES}
 )
 


### PR DESCRIPTION
builds an Utilies_NO_TLS.a archive of the common Utilities code. It replaces native TLS by a slower reimplementation

Rational: number of TLS slot is very limited by the GLIBc on linux. I hope it doesn't impact performance.
- Zzogl don't requires TLS AFAIK
- spu2x will likely use it for assertions only.

TLS exhaustion creates issue to dlopen plugins
    issue #384 : https://github.com/PCSX2/pcsx2/issues/384

But also for profiled build (-fprofile-generate)
    http://forums.pcsx2.net/Thread-WORKAROUND-build-with-fprofile-generate

If someone have a better idea, please raise your hand!
