### PR TITLE
Don't buffer the changes to the console colors.

### DIFF
--- a/common/src/Utilities/Console.cpp
+++ b/common/src/Utilities/Console.cpp
@@ -168,6 +168,7 @@ static void __concall ConsoleStdout_DoSetColor( ConsoleColors color )
 #ifdef __linux__
 	wxPrintf(L"\033[0m");
 	wxPrintf(GetLinuxConsoleColor(color));
+	fflush(stdout);
 #endif
 }
 


### PR DESCRIPTION
After a Console.Write/Writeln that uses colors a call to
ConsoleColorScope::LeaveScope() is made to restore m_old_color. This
restoration command stays buffered until a full line is printed. In the
meantime any console message that happens will use the old coloring
and if the program happens to crash the console would keep using the
color of the last colored text that was printed.
