### PR TITLE
pcsx2:wx3: fix filter selection of iso

### DIFF
--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -228,12 +228,12 @@ static wxString JoinFiletypes( const wxChar** src )
 		if( !dest.IsEmpty() )
 			dest += L";";
 
-		dest += pxsFmt(L"*.%s", *src);
+		dest += pxsFmt(L"*.%ls", *src);
 
 		if (wxFileName::IsCaseSensitive())
 		{
 			// omgosh!  the filesystem is CaSE SeNSiTiVE!!
-			dest += pxsFmt(L";*.%s", *src).ToUpper();
+			dest += pxsFmt(L";*.%ls", *src).ToUpper();
 		}
 
 		++src;


### PR DESCRIPTION
On linux, wxChar requires a %ls

It must be tested on windows:
1/ >CDVD>Iso selector>Browse...
2/ try the different filter
