### PR TITLE
Improve build system.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ useClang=0
 for ARG in "$@"; do
     case "$ARG" in
         --clean       ) cleanBuild=1 ;;
-        --clang       ) flags+=(-DUSE_CLANG=TRUE); useClang=1; ;;
+        --clang       ) useClang=1; ;;
         --dev|--devel ) flags+=(-DCMAKE_BUILD_TYPE=Devel) ;;
         --dbg|--debug ) flags+=(-DCMAKE_BUILD_TYPE=Debug) ;;
         --strip       ) flags+=(-DCMAKE_BUILD_STRIP=TRUE) ;;

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,6 @@ flags=(-DCMAKE_BUILD_PO=FALSE)
 
 cleanBuild=0
 useClang=0
-Build64=0
 
 for ARG in "$@"; do
     case "$ARG" in
@@ -70,10 +69,6 @@ for ARG in "$@"; do
     esac
 done
 
-if [[ (-f /usr/bin/wx-config32-2.8 && -f /usr/bin/wxrc32-2.8) && "$Build64" -eq 0 ]]; then
-#add flags for archlinux, wx 3 is not yet in main repositories, wx2.8 need to be used for now
-flags+=(-DwxWidgets_CONFIG_EXECUTABLE='/usr/bin/wx-config32-2.8' -DwxWidgets_wxrc_EXECUTABLE='/usr/bin/wxrc32-2.8' -DWX28_API=TRUE)
-fi
 root=$PWD/$(dirname "$0")
 log=$root/install_log.txt
 build=$root/build

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,8 @@ flags=(-DCMAKE_BUILD_PO=FALSE)
 
 cleanBuild=0
 useClang=0
+# 0 => no, 1 => yes, 2 => force yes
+useCross=0
 
 for ARG in "$@"; do
     case "$ARG" in
@@ -38,7 +40,7 @@ for ARG in "$@"; do
         --wx28        ) flags+=(-DWX28_API=TRUE) ;;
         --gtk3        ) flags+=(-DGTK3_API=TRUE) ;;
         --no-simd     ) flags+=(-DDISABLE_ADVANCE_SIMD=TRUE) ;;
-        --cross-multilib ) flags+=(-DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake) ;;
+        --cross-multilib ) flags+=(-DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake); useCross=1; ;;
         -D*           ) flags+=($ARG) ;;
 
         *)
@@ -92,7 +94,11 @@ mkdir -p $build
 cd $build
 
 if [[ "$useClang" -eq 1 ]]; then
-    CC=clang CXX=clang++ cmake "${flags[@]}" $root 2>&1 | tee -a $log
+    if [[ "$useCross" -eq 0 ]]; then
+        CC=clang CXX=clang++ cmake "${flags[@]}" $root 2>&1 | tee -a $log
+    else
+        CC="clang -m32" CXX="clang++ -m32" cmake "${flags[@]}" $root 2>&1 | tee -a $log
+    fi
 else
     cmake "${flags[@]}" $root 2>&1 | tee -a $log
 fi

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ flags=(-DCMAKE_BUILD_PO=FALSE)
 cleanBuild=0
 useClang=0
 # 0 => no, 1 => yes, 2 => force yes
-useCross=0
+useCross=2
 
 for ARG in "$@"; do
     case "$ARG" in
@@ -79,6 +79,13 @@ if [[ "$cleanBuild" -eq 1 ]]; then
     echo "Doing a clean build."
     # allow to keep build as a symlink (for example to a ramdisk)
     rm -fr $build/*
+fi
+
+if [[ "$useCross" -eq 2 ]] && [[ "$(getconf LONG_BIT 2> /dev/null)" != 32 ]]; then
+    echo "Forcing cross compilation."
+    flags+=(-DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake)
+elif [[ "$useCross" -ne 1 ]]; then
+    useCross=0
 fi
 
 echo "Building pcsx2 with ${flags[*]}" | tee $log

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -64,6 +64,7 @@ option(USE_ASAN "Enable address sanitizer")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(USE_CLANG TRUE)
+    message(STATUS "Building with Clang/LLVM.")
 endif()
 
 #-------------------------------------------------------------------------------

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -60,11 +60,9 @@ endif()
 #-------------------------------------------------------------------------------
 # Compiler extra
 #-------------------------------------------------------------------------------
-option(USE_CLANG "Use llvm/clang to build PCSX2 (developer option)")
 option(USE_ASAN "Enable address sanitizer")
 
-# It's probably better to autodetect the USE_CLANG. Remove the option?
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT USE_CLANG)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(USE_CLANG TRUE)
 endif()
 

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -33,19 +33,16 @@ endif()
 # FindwxWidgets only searches for wxrc and wx-config. Therefore only native
 # wx3.0 works since everything else has non-standard naming.
 if(CMAKE_CROSSCOMPILING)
-    # Prefer wx3.0 if available. May need to fix the filenames for lib32-wx3.0.
-    if(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-3.0" AND EXISTS "/usr/bin/wxrc32-3.0")
+    # May need to fix the filenames for lib32-wx3.0.
+    if(NOT WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-3.0" AND EXISTS "/usr/bin/wxrc32-3.0")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config32-3.0")
         set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-3.0")
-    elseif(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-2.8" AND EXISTS "/usr/bin/wxrc32-2.8")
-        set(WX28_API TRUE)
+    elseif(WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-2.8" AND EXISTS "/usr/bin/wxrc32-2.8")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config32-2.8")
         set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-2.8")
     endif()
 else()
-    # Prefer wx3.0 if available.
-    if(EXISTS "/usr/bin/wx-config-2.8" AND EXISTS "/usr/bin/wxrc-2.8" AND (NOT EXISTS "/usr/bin/wx-config" OR NOT EXISTS "/usr/bin/wxrc"))
-        set(WX28_API TRUE)
+    if(WX28_API AND EXISTS "/usr/bin/wx-config-2.8" AND EXISTS "/usr/bin/wxrc-2.8")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-2.8")
         set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc-2.8")
     endif()

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -22,6 +22,35 @@ if(Fedora AND CMAKE_CROSSCOMPILING)
 else()
     set(wxWidgets_CONFIG_OPTIONS --unicode=yes)
 endif()
+
+# Temprorary help for Arch-based distros.
+# They have wx2.8, lib32-wx2.8 and wx3.0 but no lib32-wx3.0.
+# wx2.8 => /usr/bin/wx-config-2.8, /usr/bin/wxrc-2.8
+# lib32-wx2.8 => /usr/bin/wx-config32-2.8, /usr/bin/wxrc32-2.8
+# wx3.0 => /usr/bin/wx-config, /usr/bin/wxrc -> /usr/bin/wxrc-3.0
+# I'm going to take a wild guess and predict this:
+# lib32-wx3.0 => /usr/bin/wx-config32-3.0, /usr/bin/wxrc32-3.0
+# FindwxWidgets only searches for wxrc and wx-config. Therefore only native
+# wx3.0 works since everything else has non-standard naming.
+if(CMAKE_CROSSCOMPILING)
+    # Prefer wx3.0 if available. May need to fix the filenames for lib32-wx3.0.
+    if(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-3.0" AND EXISTS "/usr/bin/wxrc32-3.0")
+        set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config32-3.0")
+        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-3.0")
+    elseif(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-2.8" AND EXISTS "/usr/bin/wxrc32-2.8")
+        set(WX28_API TRUE)
+        set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config32-2.8")
+        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-2.8")
+    endif()
+else()
+    # Prefer wx3.0 if available.
+    if(EXISTS "/usr/bin/wx-config-2.8" AND EXISTS "/usr/bin/wxrc-2.8" AND (NOT EXISTS "/usr/bin/wx-config" OR NOT EXISTS "/usr/bin/wxrc"))
+        set(WX28_API TRUE)
+        set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-2.8")
+        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc-2.8")
+    endif()
+endif()
+
 find_package(wxWidgets COMPONENTS base core adv)
 find_package(ZLIB)
 

--- a/cmake/darwin-compiler-i386-clang.cmake
+++ b/cmake/darwin-compiler-i386-clang.cmake
@@ -8,9 +8,6 @@ set(CMAKE_C_COMPILER_TARGET i686-apple-darwin)
 set(CMAKE_CXX_COMPILER clang++ -m32)
 set(CMAKE_CXX_COMPILER_TARGET i686-apple-darwin)
 
-# Enable clang
-set(USE_CLANG TRUE)
-
 # If given a CMAKE_FIND_ROOT_PATH then
 # FIND_PROGRAM ignores CMAKE_FIND_ROOT_PATH (probably can't run)
 # FIND_{LIBRARY,INCLUDE,PACKAGE} only uses the files in CMAKE_FIND_ROOT_PATH.

--- a/cmake/darwin-compiler-i386-generic.cmake
+++ b/cmake/darwin-compiler-i386-generic.cmake
@@ -3,8 +3,10 @@ set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR i686)
 
 # Leave it generic since it could be clang, gnu, etc.
-set(CMAKE_C_COMPILER cc -m32)
-set(CMAKE_CXX_COMPILER c++ -m32)
+if("$ENV{CC}" STREQUAL "" OR "$ENV{CXX}" STREQUAL "")
+    set(CMAKE_C_COMPILER cc -m32)
+    set(CMAKE_CXX_COMPILER c++ -m32)
+endif()
 
 # If given a CMAKE_FIND_ROOT_PATH then
 # FIND_PROGRAM ignores CMAKE_FIND_ROOT_PATH (probably can't run)

--- a/cmake/linux-compiler-i386-multilib.cmake
+++ b/cmake/linux-compiler-i386-multilib.cmake
@@ -4,8 +4,10 @@ set(CMAKE_SYSTEM_PROCESSOR i686)
 
 # It could be i?86-*linux-gnu, x86_64-*linux-gnu, x86_64-*linux-gnux32, etc.
 # Leave it generic to only support amd64 or x32 to i386 with any compiler.
-set(CMAKE_C_COMPILER cc -m32)
-set(CMAKE_CXX_COMPILER c++ -m32)
+if("$ENV{CC}" STREQUAL "" OR "$ENV{CXX}" STREQUAL "")
+    set(CMAKE_C_COMPILER cc -m32)
+    set(CMAKE_CXX_COMPILER c++ -m32)
+endif()
 
 # cmake 2.8.5 correctly sets CMAKE_LIBRARY_ARCHITECTURE for Debian multiarch.
 # Be really strict about what gets used.


### PR DESCRIPTION
Okay, I'm running out of ideas for titles and branch names hehe.

First commit: 
Rely on clang auto detection but still pass CC/CXX in the build.sh script.

Second commit:
Make the code more generic since it should also work if we are building w/o using the build.sh script. Also arch does have wx3.0 it should have been more like arch has everything but a multilib version of wx3.0. So I made it work for all cases since it was also broken for native i686 builds as shown in
https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/pcsx2

@alucryd Changes to the pcsx2 packaging for archlinux for the next stable version.
They can now drop the:
```
    export CC='gcc -m32'
    export CXX='g++ -m32'
    export PKG_CONFIG_PATH='/usr/lib32/pkgconfig'
```
substitute this
```
   -DwxWidgets_CONFIG_EXECUTABLE='/usr/bin/wx-config32-2.8' -DwxWidgets_wxrc_EXECUTABLE='/usr/bin/wxrc32-2.8' -DCMAKE_LIBRARY_PATH='/usr/lib32'
```
with this
```
-DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake
```
and also drop this from the 32bit case
```
-DwxWidgets_CONFIG_EXECUTABLE='/usr/bin/wx-config-2.8' -DwxWidgets_wxrc_EXECUTABLE='/usr/bin/wxrc-2.8'
```

>I push your changes. It is better this way. There is still 2 opens points
>1/ autodetection of clang
>2/ find a way to use cross-multilib (i386) by default
>3/ --cross-multilib --clang doesn't work as expected.

1/ Should be fixed with commit 1.

2/ Well right now it fails to build if in Release or PACKAGE_MODE the message tells them to add --cross-compile. This is probably enough or we could make it always fail and make them read the message. Forcing cross compile is really messy and it would be cleaner to avoid it. 

If we want to force cross compile then it would only be possible at the build.sh level and we have to avoid cross compiling i386->i386 since there is cross compile specific behavior now. To do this uname -m != i?86 would fail in chroot builds, MacOS, etc and using getconf LONG_BIT != 32 could trigger false positives in some architectures but we really don't care about those just now.

```
if [ "$(getconf LONG_BIT 2> /dev/null)" != 32 ]; then echo do cross compile stuff; fi
```


3/ Yes cross compiling with clang does not work unless  cc/c++ already points to clang/clang++. We could either
- Re add USE_CLANG and use it as a if(USE_CLANG) in the toolchain file. This requires reverting the 1st commit and squashing this pull request.
- Create a toolchain file for clang which basically duplicates the code.


Also what about:
```
Also might as well disable RELWITHDEBINFO|MINSIZEREL since I believe the code does not check for those.

SET (CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Only support Debug and Release." FORCE)
```
This has to be done before the call to Project(Pcsx2) to avoid creating those targets.

