### PR TITLE
Don't assume .git exists just because git is installed.

### DIFF
--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -37,9 +37,8 @@ function(detectOperatingSystem)
 endfunction()
 
 function(write_svnrev_h)
-    find_package(Git)
     set(PCSX2_WC_TIME 0)
-    if (GIT_FOUND)
+    if (GIT_FOUND AND EXISTS ${PROJECT_SOURCE_DIR}/.git)
         EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} show -s --format=%ci HEAD
             OUTPUT_VARIABLE PCSX2_WC_TIME
             OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
If .git does not exists and you have git installed you get:
fatal: Not a git repository (or any of the parent directories): .git

I also removed the extra find_package(Git) since it's done in SearchforStuff.
To confirm it was really found I did:

```
    message("f=${GIT_FOUND}, c=${CMAKE_SOURCE_DIR}, p=${PROJECT_SOURCE_DIR}")
    find_package(Git)
    message("f=${GIT_FOUND}, c=${CMAKE_SOURCE_DIR}, p=${PROJECT_SOURCE_DIR}")
```
and got

```
f=TRUE, c=/tmp/buildd/pcsx2-1.2.1-850-ge0add80+dfsg, p=/tmp/buildd/pcsx2-1.2.1-850-ge0add80+dfsg
f=TRUE, c=/tmp/buildd/pcsx2-1.2.1-850-ge0add80+dfsg, p=/tmp/buildd/pcsx2-1.2.1-850-ge0add80+dfsg
fatal: Not a git repository (or any of the parent directories): .git
```
This shows that it was found and since it was found find_package is not triggered.
If it was not found it told me twice that it was not found.

I used ${PROJECT_SOURCE_DIR}/.git since using ${CMAKE_SOURCE_DIR} probably breaks build.sh.