### PR TITLE
Fix issues with DOC_DIR_COMPILATION.

### DIFF
--- a/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
+++ b/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
@@ -77,7 +77,7 @@ Panels::FirstTimeIntroPanel::FirstTimeIntroPanel( wxWindow* parent )
 	// change it with compilation flags. -- Gregory
 #define xDOC_str(s) DOC_str(s)
 #define DOC_str(s) #s
-	faqFile.Write( L"file://%s/PCSX2_FAQ.pdf", xDOC_str(DOC_DIR_COMPILATION) );
+	faqFile.Write( L"file://%s/PCSX2_FAQ.pdf", WX_STR(wxDirName(xDOC_str(DOC_DIR_COMPILATION)).ToString()) );
 #endif
 
 	wxStaticBoxSizer& langSel	= *new wxStaticBoxSizer( wxVERTICAL, this, _("Language selector") );


### PR DESCRIPTION
This fixes the remaining issues:
- wx2.8 => apparent utf issue.
- wx3.0 => opens the file twice.

Fixes #402 

Tested both builds can confirm that:
With wx2.8 this does not happen anymore
```
gvfs-open: file://������������������������������/PCSX2_FAQ.pdf: error opening location: Operation not supported
```
With wx3.0 it only opens the file once.

In the original code InstallFolder was of type wxDirName so I did the same thing the windows only code does

Let
InstallFolder = wxDirName(xDOC_str(DOC_DIR_COMPILATION))
and do 
WX_STR(InstallFolder.ToString())

This is what seems to have worked before (well not counting the FHS issue).
