### PR TITLE
Search for wx-config-3.0 and wxrc-3.0.

### DIFF
--- a/cmake/ApiValidation.cmake
+++ b/cmake/ApiValidation.cmake
@@ -6,14 +6,6 @@ set(wx_sdl_c_code "
 #endif
 ")
 
-set(wx_gtk3_c_code "
-#include <wx/setup.h>
-
-#ifdef __WXGTK3__
-#error cmake_WX_GTK3
-#endif
-")
-
 function(WX_vs_SDL)
     file(WRITE "${CMAKE_BINARY_DIR}/wx_sdl.c" "${wx_sdl_c_code}")
     enable_language(C)
@@ -31,42 +23,5 @@ function(WX_vs_SDL)
         message(FATAL_ERROR "WxWidget is linked to SDL (wxUSE_LIBSDL) and it is likely SDL1.2.
         Unfortunately you try to build PCSX2 with SDL2 support which is not compatible
         Please use -DSDL2_API=FALSE")
-    endif()
-
-endfunction()
-
-function(WX_vs_GTK3)
-    file(WRITE "${CMAKE_BINARY_DIR}/wx_gtk3.c" "${wx_gtk3_c_code}")
-    enable_language(C)
-
-    try_run(
-            run_result_unused
-            compile_result_unused
-            "${CMAKE_BINARY_DIR}"
-            "${CMAKE_BINARY_DIR}/wx_gtk3.c"
-            COMPILE_OUTPUT_VARIABLE OUT
-            CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${wxWidgets_INCLUDE_DIRS}"
-        )
-
-    if (${OUT} MATCHES "cmake_WX_GTK3")
-        if (NOT GTK3_API)
-            message(FATAL_ERROR "Your current WxWidget version requires GTK3. Please use -DGTK3_API=TRUE option")
-        endif()
-    else()
-        if (GTK3_API)
-            message(FATAL_ERROR "Your current WxWidget version doesn't support GTK3. Please use -DGTK3_API=FALSE option")
-        endif()
-    endif()
-
-endfunction()
-
-function(WX_version)
-    EXECUTE_PROCESS(COMMAND ${wxWidgets_CONFIG_EXECUTABLE} --version OUTPUT_VARIABLE version)
-    STRING(STRIP ${version} version)
-    if (${version} MATCHES "3.0" AND WX28_API)
-        message(FATAL_ERROR "Mismatch between wx-config version (${version}) and requested WX API (2.8.x)")
-    endif()
-    if (${version} MATCHES "2.8" AND NOT WX28_API)
-        message(FATAL_ERROR "Mismatch between wx-config version (${version}) and requested WX API (3.0.x)")
     endif()
 endfunction()

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -23,15 +23,12 @@ else()
     set(wxWidgets_CONFIG_OPTIONS --unicode=yes)
 endif()
 
-# Temprorary help for Arch-based distros.
-# They have wx2.8, lib32-wx2.8 and wx3.0 but no lib32-wx3.0.
 # wx2.8 => /usr/bin/wx-config-2.8, /usr/bin/wxrc-2.8
 # lib32-wx2.8 => /usr/bin/wx-config32-2.8, /usr/bin/wxrc32-2.8
-# wx3.0 => /usr/bin/wx-config, /usr/bin/wxrc -> /usr/bin/wxrc-3.0
+# wx3.0 => /usr/bin/wx-config-3.0, /usr/bin/wxrc-3.0
 # I'm going to take a wild guess and predict this:
 # lib32-wx3.0 => /usr/bin/wx-config32-3.0, /usr/bin/wxrc32-3.0
-# FindwxWidgets only searches for wxrc and wx-config. Therefore only native
-# wx3.0 works since everything else has non-standard naming.
+# FindwxWidgets only searches for wxrc and wx-config.
 if(CMAKE_CROSSCOMPILING)
     # May need to fix the filenames for lib32-wx3.0.
     if(NOT WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-3.0" AND EXISTS "/usr/bin/wxrc32-3.0")
@@ -42,7 +39,10 @@ if(CMAKE_CROSSCOMPILING)
         set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-2.8")
     endif()
 else()
-    if(WX28_API AND EXISTS "/usr/bin/wx-config-2.8" AND EXISTS "/usr/bin/wxrc-2.8")
+    if(NOT WX28_API AND EXISTS "/usr/bin/wx-config-3.0" AND EXISTS "/usr/bin/wxrc-3.0")
+        set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-3.0")
+        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc-3.0")
+    elseif(WX28_API AND EXISTS "/usr/bin/wx-config-2.8" AND EXISTS "/usr/bin/wxrc-2.8")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-2.8")
         set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc-2.8")
     endif()

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -23,6 +23,18 @@ else()
     set(wxWidgets_CONFIG_OPTIONS --unicode=yes)
 endif()
 
+if(WX28_API)
+    list(APPEND wxWidgets_CONFIG_OPTIONS --version=2.8)
+else()
+    list(APPEND wxWidgets_CONFIG_OPTIONS --version=3.0)
+endif()
+
+if(GTK3_API)
+    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk3)
+else()
+    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk2)
+endif()
+
 # wx2.8 => /usr/bin/wx-config-2.8, /usr/bin/wxrc-2.8
 # lib32-wx2.8 => /usr/bin/wx-config32-2.8, /usr/bin/wxrc32-2.8
 # wx3.0 => /usr/bin/wx-config-3.0, /usr/bin/wxrc-3.0
@@ -157,5 +169,3 @@ include_directories(${CMAKE_SOURCE_DIR}/common/include
 #----------------------------------------
 include(ApiValidation)
 WX_vs_SDL()
-WX_vs_GTK3()
-WX_version()

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -35,28 +35,24 @@ else()
     list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk2)
 endif()
 
-# wx2.8 => /usr/bin/wx-config-2.8, /usr/bin/wxrc-2.8
-# lib32-wx2.8 => /usr/bin/wx-config32-2.8, /usr/bin/wxrc32-2.8
-# wx3.0 => /usr/bin/wx-config-3.0, /usr/bin/wxrc-3.0
+# wx2.8 => /usr/bin/wx-config-2.8
+# lib32-wx2.8 => /usr/bin/wx-config32-2.8
+# wx3.0 => /usr/bin/wx-config-3.0
 # I'm going to take a wild guess and predict this:
-# lib32-wx3.0 => /usr/bin/wx-config32-3.0, /usr/bin/wxrc32-3.0
-# FindwxWidgets only searches for wxrc and wx-config.
+# lib32-wx3.0 => /usr/bin/wx-config32-3.0
+# FindwxWidgets only searches for wx-config.
 if(CMAKE_CROSSCOMPILING)
     # May need to fix the filenames for lib32-wx3.0.
-    if(NOT WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-3.0" AND EXISTS "/usr/bin/wxrc32-3.0")
+    if(NOT WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-3.0")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config32-3.0")
-        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-3.0")
-    elseif(WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-2.8" AND EXISTS "/usr/bin/wxrc32-2.8")
+    elseif(WX28_API AND ${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386" AND EXISTS "/usr/bin/wx-config32-2.8")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config32-2.8")
-        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc32-2.8")
     endif()
 else()
-    if(NOT WX28_API AND EXISTS "/usr/bin/wx-config-3.0" AND EXISTS "/usr/bin/wxrc-3.0")
+    if(NOT WX28_API AND EXISTS "/usr/bin/wx-config-3.0")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-3.0")
-        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc-3.0")
-    elseif(WX28_API AND EXISTS "/usr/bin/wx-config-2.8" AND EXISTS "/usr/bin/wxrc-2.8")
+    elseif(WX28_API AND EXISTS "/usr/bin/wx-config-2.8")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-2.8")
-        set(wxWidgets_wxrc_EXECUTABLE "/usr/bin/wxrc-2.8")
     endif()
 endif()
 


### PR DESCRIPTION
The comment made it look as an arch-only thing which was misleading.
.
Gentoo uses
wx-config-3.0 and wxrc-3.0 which are still masked (~).

The current code ONLY overrides the user input if a valid wxWidgets_CONFIG_EXECUTABLE AND wxWidgets_wxrc_EXECUTABLE is found. This avoids:

WX28_API=TRUE, wxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-3.0
WX28_API=FALSE, wxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-2.8

This ensures we pick a correct version if auto-detected. If nothing is auto-detected it defaults to whatever the user gave and if the user gave nothing then whatever FindwxWidgets.cmake found. A second user input validation is done by APIValidation.cmake which gives a fatal error in the case the IF-block was never triggered or the auto-detection was wrong.

To avoid the 1st level of error detection and correction and allow any input, including this:
WX28_API=TRUE, wxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-3.0
WX28_API=FALSE, wxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-2.8

Then merge PR #422 and let APIValidation.cmake stop the build w/o trying to automatically fix it first.
Note: WX_version() in APIValidation did not exist back then so forcing to use the correct executable was needed at that point.