### PR TITLE
Case Mapping & GitHub instead of GoogleCode.

### DIFF
--- a/bin/docs/pcsx2.1
+++ b/bin/docs/pcsx2.1
@@ -1,10 +1,10 @@
 .TH "pcsx2" "1"
 
 .SH NAME
-PCSX2 - PlayStation®2 console emulator
+PCSX2 - PlayStation(R)2 console emulator
 
 .SH DESCRIPTION
-PCSX2 is an emulator for the PlayStation®2 video game console. It is written mostly in C++, some part are in C and x86 assembly.
+PCSX2 is an emulator for the PlayStation(R)2 video game console. It is written mostly in C++, some part are in C and x86 assembly.
 There is still lot of on going work to improve compatibility & speed.
 
 Visit http://pcsx2.net & https://github.com/PCSX2/pcsx2 for the latest updates.

--- a/bin/docs/pcsx2.1
+++ b/bin/docs/pcsx2.1
@@ -1,13 +1,13 @@
 .TH "pcsx2" "1"
 
 .SH NAME
-PCSX2 - Playstation 2 console emulator
+PCSX2 - PlayStation®2 console emulator
 
 .SH DESCRIPTION
-PCSX2 is an emulator for the playstation 2 video game console. It is written mostly in C++, some part are in C and x86 assembly.
+PCSX2 is an emulator for the PlayStation®2 video game console. It is written mostly in C++, some part are in C and x86 assembly.
 There is still lot of on going work to improve compatibility & speed.
 
-Visit http://pcsx2.net & http://code.google.com/p/pcsx2 for the latest updates.
+Visit http://pcsx2.net & https://github.com/PCSX2/pcsx2 for the latest updates.
 
 .SH Options
 Note: all options can also be updated in the GUI.
@@ -46,7 +46,7 @@ Disables display of the gui on exit (program auto-exits).
 .TP
 
 .B --nodisc
-Boots with an empty dvd tray. Use this to boot into the PS2 system menu.
+Boots with an empty DVD tray. Use this to boot into the PS2 system menu.
 .TP
 
 .B --usecd

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -225,7 +225,7 @@ void Pcsx2App::OnInitCmdLine( wxCmdLineParser& parser )
 	parser.AddSwitch( wxEmptyString,L"noguiprompt",	_("when nogui - prompt before exiting on suspend") );
 
 	parser.AddOption( wxEmptyString,L"elf",			_("executes an ELF image"), wxCMD_LINE_VAL_STRING );
-	parser.AddSwitch( wxEmptyString,L"nodisc",		_("boots an empty dvd tray; use to enter the PS2 system menu") );
+	parser.AddSwitch( wxEmptyString,L"nodisc",		_("boots an empty DVD tray; use to enter the PS2 system menu") );
 	parser.AddSwitch( wxEmptyString,L"usecd",		_("boots from the CDVD plugin (overrides IsoFile parameter)") );
 
 	parser.AddSwitch( wxEmptyString,L"nohacks",		_("disables all speedhacks") );

--- a/plugins/CDVDpeops/Cfg.c
+++ b/plugins/CDVDpeops/Cfg.c
@@ -348,7 +348,7 @@ BOOL OnInitCDRDialog(HWND hW)
  ComboBox_AddString(hWC,"Read ahead - fast, reads more sectors at once");
  ComboBox_AddString(hWC,"Async read - faster, additional asynchronous reads");
  ComboBox_AddString(hWC,"Thread read - fast with IOCTL, always async reads");
- ComboBox_AddString(hWC,"Smooth read - for drives with ps2 cd/dvd reading troubles");
+ ComboBox_AddString(hWC,"Smooth read - for drives with PS2 CD/DVD reading troubles");
  ComboBox_SetCurSel(hWC,iUseCaching);
 
  if(iUseDataCache)


### PR DESCRIPTION
A couple of case-mapping adjustments,
 "PlayStation®2" instead of "playstation 2" or "Playstation 2",
 and correction of a weblink.
