### PR TITLE
Correct faulty behaviour of std thread by using native posix handle.

### DIFF
--- a/plugins/GSdx/GSThread.cpp
+++ b/plugins/GSdx/GSThread.cpp
@@ -144,13 +144,27 @@ void GSThread::CloseThread()
 	}
 
     #else
-    
+    // Should be tested on windows too one day, native handle should be disabled there though, or adapted to windows thread
     #ifdef _STD_THREAD_
+    
+    #define _NATIVE_HANDLE_ // Using std::thread native handle, allows to just use posix stuff.
+    #ifdef _NATIVE_HANDLE_ // std::thread join seems to be bugged, have to test it again every now and then, it did work at some point(gcc 5), seems there is bug in system lib...
+    pthread_t m_thread = t->native_handle();
+    void *ret = NULL;
+    pthread_join(m_thread, &ret);
+    /* We are sure thread is dead, not so bad.
+     * Still no way to to delete that crap though... Really, wtf is this standard??
+     * I guess we will have to wait that someone debug either the implementation or change standard.
+     * There should be a moderate memory leak for now, I am trying to find a way to fix it.
+     * 3kinox
+     */
+    #else
     if(t->joinable())
     {
         t->join();
     }
     delete(t);
+    #endif
     #else
     void* ret = NULL;
 

--- a/plugins/GSdx/GSThread.h
+++ b/plugins/GSdx/GSThread.h
@@ -143,7 +143,7 @@ public:
 
 #else
 // let us use std::thread for now, comment out the definition to go back to pthread
-//#define _STD_THREAD_
+#define _STD_THREAD_
 #ifdef _STD_THREAD_
 #include <thread>
 #include <mutex>


### PR DESCRIPTION
@gregory38 Here is, a "fix" for std::thread
 This is not yet perfect. Really, this standard seems like a load of crap to me in fact...
At least it works now. Should test again when gcc 5 & new c++ libs gets out.. Until then, it will do.
Someone should try pthread on windows maybe... It may be even simpler;).
There should be a moderate memory leak(unless you use f9 switch 10000 times it should be more than OK).