### PR TITLE
gsdx ocl: check size of array before access

### DIFF
--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -269,7 +269,9 @@ bool GSSettingsDlg::OnCommand(HWND hWnd, UINT id, UINT code)
 
 			if(ComboBoxGetSelData(IDC_OPENCL_DEVICE, data))
 			{
-				theApp.SetConfig("ocldev", m_ocl_devs[(int)data].name.c_str());
+				if ((int)data < m_ocl_devs.size()) {
+					theApp.SetConfig("ocldev", m_ocl_devs[(int)data].name.c_str());
+				}
 			}
 
 			if(!m_IsOpen2 && ComboBoxGetSelData(IDC_RESOLUTION, data))


### PR DESCRIPTION
Potential fix for issue #408 ?

Could someone check it on windows. Thanks