### PR TITLE
GSdx: Linux: Fix build failure on AVX2 processor with disabled TSX, enable SSE4.2, SSE4.1, SSSE3 builds

### DIFF
--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -1519,7 +1519,7 @@ GSRendererSW::SharedData::~SharedData()
 	fflush(s_fp);}
 }
 
-static TransactionScope::Lock s_lock;
+//static TransactionScope::Lock s_lock;
 
 void GSRendererSW::SharedData::UsePages(const uint32* fb_pages, int fpsm, const uint32* zb_pages, int zpsm)
 {

--- a/plugins/GSdx/GSThread.h
+++ b/plugins/GSdx/GSThread.h
@@ -485,7 +485,7 @@ public:
 	TransactionScope(Lock& fallBackLock_, int max_retries = 3) 
 		: fallBackLock(fallBackLock_)
 	{
-		#if _M_SSE >= 0x501
+		#if (_M_SSE >= 0x501 && !defined(__GNUC__)) || defined(__RTM__)
 
 		int nretries = 0;
 		
@@ -528,7 +528,7 @@ public:
 		{
 			fallBackLock.unlock();
 		}
-		#if _M_SSE >= 0x501
+		#if (_M_SSE >= 0x501 && !defined(__GNUC__)) || defined(__RTM__)
 		else
 		{
 			_xend();

--- a/plugins/GSdx/GSThread.h
+++ b/plugins/GSdx/GSThread.h
@@ -485,6 +485,11 @@ public:
 	TransactionScope(Lock& fallBackLock_, int max_retries = 3) 
 		: fallBackLock(fallBackLock_)
 	{
+		// The TSX (RTM/HLE) instructions on Intel AVX2 CPUs may either be
+		// absent or disabled (see errata HSD136 and specification change at
+		// http://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/4th-gen-core-family-desktop-specification-update.pdf)
+		// This can cause builds for AVX2 CPUs to fail with GCC/Clang on Linux,
+		// so check that the RTM instructions are actually available.
 		#if (_M_SSE >= 0x501 && !defined(__GNUC__)) || defined(__RTM__)
 
 		int nretries = 0;

--- a/plugins/GSdx/GSThread.h
+++ b/plugins/GSdx/GSThread.h
@@ -443,7 +443,7 @@ public:
 };
 
 // http://software.intel.com/en-us/blogs/2012/11/06/exploring-intel-transactional-synchronization-extensions-with-intel-software
-
+#if 0
 class TransactionScope
 {
 public:
@@ -541,4 +541,4 @@ public:
 		#endif
 	}
 };
-
+#endif

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -279,6 +279,16 @@ struct aligned_free_second {template<class T> void operator()(T& p) {_aligned_fr
 	#define _M_SSE 0x501
 #elif defined(__AVX__)
 	#define _M_SSE 0x500
+#elif defined(__SSE4_2__)
+	#define _M_SSE 0x402
+#elif defined(__SSE4_1__)
+	#define _M_SSE 0x401
+#elif defined(__SSSE3__)
+	#define _M_SSE 0x301
+#elif defined(__SSE2__)
+	#define _M_SSE 0x200
+#elif defined(__SSE__)
+	#define _M_SSE 0x100
 #endif
 #endif
 


### PR DESCRIPTION
Version: 1.3.1 GIT f2657ae
Relevant PC Specifications:
CPU: Intel Core i5-4590 @ 3.3Ghz with updated microcode(revision 0x1c, 2014-07-03)
OS: Slackware Linux 14.1, 64-bit with 32-bit chroot, GCC 4.8.2

Issue: On Linux, CPUs with AVX2 instruction sets that have TSX disabled (by microcode update or otherwise) fail to build GSdx. The \__RTM__ macro is undefined, and the TSX RTM instruction set (_xbegin, _xend, _xabort, etc.) is unavailable. Without the microcode update (TSX enabled), the build works fine. Issue #440 may also be related to this, where the vmware build had to use the --nosimd option due to compile errors.

Fix: I've modified the preprocessor check so that the RTM instructions are only used if available. This fixes the build on Linux, I haven't tested it on Windows.
