### PR TITLE
Digimon Battle chronicle Gsdx crc hack.

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -115,6 +115,7 @@ CRC::Game CRC::m_games[] =
 	{0x877F3436, SoTC, JP, 0},
 	{0xA17D6AAA, SoTC, KO, 0},
 	{0x877B3D35, SoTC, CH, 0},
+	{0x7F995E8D, DigimonBattleChronicle ,JP , 0},
 	{0x3122B508, OnePieceGrandAdventure, US, 0},
 	{0x8DF14A24, OnePieceGrandAdventure, EU, 0},
 	{0xE446C9F9, OnePieceGrandAdventure, KO, 0},

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -31,6 +31,7 @@ public:
 		TomoyoAfter,
 		Clannad,
 		Lamune,
+		DigimonBattleChronicle,
 		KyuuketsuKitanMoonties,
 		PiaCarroteYoukosoGPGakuenPrincess,
 		KazokuKeikakuKokoroNoKizuna,


### PR DESCRIPTION
the current patch fixes the graphical glitches in the game during battle at the RubberTree Falls Stadium,