### PR TITLE
gsdx: value was wrongly overwritten

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -362,7 +362,7 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* o, const GSVector4i& rect, boo
 
 					s->m_complete = false;
 
-					found = b;
+					found |= b;
 				}
 				else
 				{


### PR DESCRIPTION
Need a lots of tests to ensure at least no regression on cache behavior

Issue #332