### PR TITLE
Fix a typo in manual gamefixes

### DIFF
--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -97,7 +97,7 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("Switch to GSdx software rendering when a FMV plays"),
+			_("Switch to GSdx software rendering when an FMV plays"),
 			wxEmptyString
 		},
 		{


### PR DESCRIPTION
Change "a FMV" to "an FMV"