### PR TITLE
Removed FreezeGS from  PCSX2_keys.ini.default

### DIFF
--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -57,7 +57,6 @@ Sys_Suspend                       = ESC
 Sys_RenderswitchToggle            = F9
 
 Sys_LoggingToggle                 = F10
-Sys_FreezeGS                      = F11
 Sys_RecordingToggle               = F12
 
 GSwindow_CycleAspectRatio         = F6


### PR DESCRIPTION
FreezeGS is a deprecated function and is no longer in use. If you check
on GlobalCommands.cpp you will see that it is ifdef'ed out. Apparently it
was used to freeze states when STGS was a thing. Removing this hotkey from the default list of hotkeys will avoid user confusion when the user is checking out what F11 is supposed to do.