### PR TITLE
Added a comment to PCSX2_keys.ini.default about F11

### DIFF
--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -57,7 +57,8 @@ Sys_Suspend                       = ESC
 Sys_RenderswitchToggle            = F9
 
 Sys_LoggingToggle                 = F10
-Sys_FreezeGS                      = F11
+# The FreezeGS function is currently disabled internally.
+# Sys_FreezeGS                      = F11
 Sys_RecordingToggle               = F12
 
 GSwindow_CycleAspectRatio         = F6

--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -58,7 +58,7 @@ Sys_RenderswitchToggle            = F9
 
 Sys_LoggingToggle                 = F10
 # The FreezeGS function is currently disabled internally.
-# Sys_FreezeGS                      = F11
+Sys_FreezeGS                      = F11
 Sys_RecordingToggle               = F12
 
 GSwindow_CycleAspectRatio         = F6


### PR DESCRIPTION
Added a comment to PCSX2_keys.ini.default about FreezeGS being
deprecated as to avoid user confusion when pressing F11 and nothing
happens.