### PR TITLE
Small optimization to CSO support, add notes

### DIFF
--- a/pcsx2/CDVD/CsoFileReader.cpp
+++ b/pcsx2/CDVD/CsoFileReader.cpp
@@ -183,6 +183,9 @@ int CsoFileReader::ReadSync(void* pBuffer, uint sector, uint count) {
 		return 0;
 	}
 
+	// Note that, in practice, count will always be 1.  It seems one sector is read
+	// per interrupt, even if multiple are requested by the application.
+
 	u8* dest = (u8*)pBuffer;
 	// We do it this way in case m_blocksize is not well aligned to our frame size.
 	u64 pos = (u64)sector * (u64)m_blocksize;

--- a/pcsx2/CDVD/CsoFileReader.h
+++ b/pcsx2/CDVD/CsoFileReader.h
@@ -18,6 +18,7 @@
 #include "AsyncFileReader.h"
 
 struct CsoHeader;
+typedef struct z_stream_s z_stream;
 
 class CsoFileReader : public AsyncFileReader
 {
@@ -28,7 +29,9 @@ public:
 		m_zlibBuffer(0),
 		m_index(0),
 		m_totalSize(0),
-		m_src(0) {
+		m_src(0),
+		m_z_stream(0),
+		m_bytesRead(0) {
 		m_blocksize = 2048;
 	};
 
@@ -69,6 +72,7 @@ private:
 	u64 m_totalSize;
 	// The actual source cso file handle.
 	FILE* m_src;
+	z_stream* m_z_stream;
 	// The result of a read is stored here between BeginRead() and FinishRead().
-	int mBytesRead;
+	int m_bytesRead;
 };

--- a/pcsx2/CDVD/CsoFileReader.h
+++ b/pcsx2/CDVD/CsoFileReader.h
@@ -15,10 +15,22 @@
 
 #pragma once
 
+// Based on testing, the overhead of using this cache is high.
+//
+// The test was done with CSO files using a block size of 16KB.
+// Cache hit rates were observed in the range of 25%.
+// Cache overhead added 35% to the overall read time.
+//
+// For this reason, it's currently disabled.
+#define CSO_USE_CHUNKSCACHE 0
+
 #include "AsyncFileReader.h"
+#include "ChunksCache.h"
 
 struct CsoHeader;
 typedef struct z_stream_s z_stream;
+
+static const uint CSO_CHUNKCACHE_SIZE_MB = 200;
 
 class CsoFileReader : public AsyncFileReader
 {
@@ -31,6 +43,9 @@ public:
 		m_totalSize(0),
 		m_src(0),
 		m_z_stream(0),
+#if CSO_USE_CHUNKSCACHE
+		m_cache(CSO_CHUNKCACHE_SIZE_MB),
+#endif
 		m_bytesRead(0) {
 		m_blocksize = 2048;
 	};
@@ -59,7 +74,7 @@ private:
 	static bool ValidateHeader(const CsoHeader& hdr);
 	bool ReadFileHeader();
 	bool InitializeBuffers();
-	int ReadFromFrame(u8 *dest, u64 pos, u64 maxBytes);
+	int ReadFromFrame(u8 *dest, u64 pos, int maxBytes);
 	bool DecompressFrame(u32 frame, u32 readBufferSize);
 
 	u32 m_frameSize;
@@ -73,6 +88,11 @@ private:
 	// The actual source cso file handle.
 	FILE* m_src;
 	z_stream* m_z_stream;
+
+#if CSO_USE_CHUNKSCACHE
+	ChunksCache m_cache;
+#endif
+
 	// The result of a read is stored here between BeginRead() and FinishRead().
 	int m_bytesRead;
 };


### PR DESCRIPTION
This caches the z_stream between decompressions (not a big deal, reduces runtime allocations), and adds disabled code for using the ChunksCache.

There's also a small tweak to handle a failure case slightly better.

See here for more notes on the cache and its timings:
https://github.com/PCSX2/pcsx2/pull/504#issuecomment-93491422

-[Unknown]