### PR TITLE
Stdcall for plugin

### DIFF
--- a/common/include/PS2Eext.h
+++ b/common/include/PS2Eext.h
@@ -30,7 +30,7 @@
 #include <gtk/gtk.h>
 #include <cstring>
 
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 //#include "PS2Edefs.h"

--- a/plugins/CDVDiso/src/CDVDiso.h
+++ b/plugins/CDVDiso/src/CDVDiso.h
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" __declspec(dllexport) type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 #else
@@ -39,7 +39,7 @@
 #ifdef _MSC_VER
 #define EXPORT_C_(type) __declspec(dllexport) type __stdcall
 #else
-#define EXPORT_C_(type) __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 #endif

--- a/plugins/CDVDnull/CDVD.h
+++ b/plugins/CDVDnull/CDVD.h
@@ -39,7 +39,7 @@
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 extern const unsigned char version;

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -52,8 +52,6 @@ const char* GSUtil::GetLibName()
 
 		list<string> sl;
 
-		// TODO: linux (gcc)
-
 		#ifdef __INTEL_COMPILER
 		sl.push_back(format("Intel C++ %d.%02d", __INTEL_COMPILER / 100, __INTEL_COMPILER % 100));
 		#elif _MSC_VER

--- a/plugins/GSnull/GS.h
+++ b/plugins/GSnull/GS.h
@@ -40,7 +40,7 @@ typedef struct _keyEvent keyEvent;
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 //#define GS_LOG GSLog::Log

--- a/plugins/LilyPad/Global.h
+++ b/plugins/LilyPad/Global.h
@@ -110,7 +110,7 @@ inline void * realloc(void *mem, size_t size);
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" __declspec(dllexport) type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type CALLBACK
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type CALLBACK
 #endif
 
 #ifdef _MSC_VER

--- a/plugins/PadNull/Pad.h
+++ b/plugins/PadNull/Pad.h
@@ -37,7 +37,7 @@
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 #define PAD_LOG __Log

--- a/plugins/SPU2null/SPU2.h
+++ b/plugins/SPU2null/SPU2.h
@@ -39,7 +39,7 @@ extern "C"
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" __declspec(dllexport) type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 extern FILE *spu2Log;

--- a/plugins/onepad/onepad.cpp
+++ b/plugins/onepad/onepad.cpp
@@ -36,7 +36,7 @@
 #endif
 
 PADconf* conf;
-char libraryName[256];
+static char libraryName[256];
 
 keyEvent event;
 

--- a/plugins/onepad/onepad.h
+++ b/plugins/onepad/onepad.h
@@ -57,7 +57,7 @@ using namespace std;
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" __declspec(dllexport) type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 enum PadOptions

--- a/plugins/onepad/onepad.h
+++ b/plugins/onepad/onepad.h
@@ -60,8 +60,6 @@ using namespace std;
 #define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
 #endif
 
-extern char libraryName[256];
-
 enum PadOptions
 {
 	PADOPTION_FORCEFEEDBACK = 0x1,

--- a/plugins/spu2-x/src/PS2E-spu2.h
+++ b/plugins/spu2-x/src/PS2E-spu2.h
@@ -28,7 +28,7 @@
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" __declspec(dllexport) type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 // We have our own versions that have the DLLExport attribute configured:

--- a/plugins/zzogl-pg/opengl/GS.h
+++ b/plugins/zzogl-pg/opengl/GS.h
@@ -35,7 +35,7 @@ extern float fFPS;
 #ifdef _MSC_VER
 #define EXPORT_C_(type) extern "C" type CALLBACK
 #else
-#define EXPORT_C_(type) extern "C" __attribute__((externally_visible,visibility("default"))) type
+#define EXPORT_C_(type) extern "C" __attribute__((stdcall,externally_visible,visibility("default"))) type
 #endif
 
 extern int g_LastCRC;


### PR DESCRIPTION
Those updates enforce the calling convention for all plugins to stdcall (as it used to be).

A stack overflow was highlighted by asan on spu2x.

I split the commit to ease bisection, update is very sensible.