### PR TITLE
DEV9ghzdrk - thread safer calls to DEV9irq

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -702,6 +702,7 @@ typedef void (CALLBACK* _DEV9writeDMA8Mem)(u32 *pMem, int size);
 #endif
 typedef void (CALLBACK* _DEV9irqCallback)(DEV9callback callback);
 typedef DEV9handler (CALLBACK* _DEV9irqHandler)(void);
+typedef void (CALLBACK* _DEV9async)(u32 cycles);
 
 // USB
 // NOTE: The read/write functions CANNOT use XMM/MMX regs
@@ -820,6 +821,7 @@ extern _DEV9writeDMA8Mem  DEV9writeDMA8Mem;
 #endif
 extern _DEV9irqCallback   DEV9irqCallback;
 extern _DEV9irqHandler    DEV9irqHandler;
+extern _DEV9async         DEV9async;
 
 // USB
 extern _USBopen           USBopen;

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -453,7 +453,10 @@ void psxRcntUpdate()
 		else c -= difference;
 		psxNextCounter = c;
 	}
-
+	if (DEV9async)
+	{
+		DEV9async(1);
+	}
 	if(USBasync)
 	{
 		const s32 difference = psxRegs.cycle - psxCounters[7].sCycleT;

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -320,6 +320,7 @@ _DEV9writeDMA8Mem  DEV9writeDMA8Mem;
 #endif
 _DEV9irqCallback   DEV9irqCallback;
 _DEV9irqHandler    DEV9irqHandler;
+_DEV9async         DEV9async;
 
 // USB
 _USBopen           USBopen;
@@ -630,6 +631,7 @@ static const LegacyApi_ReqMethod s_MethMessReq_DEV9[] =
 
 static const LegacyApi_OptMethod s_MethMessOpt_DEV9[] =
 {
+	{ "DEV9async", (vMeth**)&DEV9async },
 	{ NULL }
 };
 

--- a/plugins/dev9ghzdrk/DEV9.cpp
+++ b/plugins/dev9ghzdrk/DEV9.cpp
@@ -600,6 +600,10 @@ void CALLBACK DEV9irqCallback(void (*callback)(int cycles)) {
 	DEV9irq = callback;
 }
 
+void CALLBACK DEV9async(u32 cycles)
+{
+	smap_async(cycles);
+}
 
 // extended funcs
 

--- a/plugins/dev9ghzdrk/Win32/DEV9ghzdrk.def
+++ b/plugins/dev9ghzdrk/Win32/DEV9ghzdrk.def
@@ -24,5 +24,6 @@ EXPORTS
 	DEV9about			@19
 	DEV9irqCallback     @20
 	DEV9irqHandler      @21
+	DEV9async           @22
 	
 	DEV9setSettingsDir

--- a/plugins/dev9ghzdrk/Win32/smap.cpp
+++ b/plugins/dev9ghzdrk/Win32/smap.cpp
@@ -81,7 +81,7 @@ bool rx_fifo_can_rx()
 	//we can recv a packet !
 	return true;
 }
-bool fireIntR = false;
+volatile bool fireIntR = false;
 void rx_process(NetPacket* pk)
 {
 	if (!rx_fifo_can_rx())

--- a/plugins/dev9ghzdrk/Win32/smap.cpp
+++ b/plugins/dev9ghzdrk/Win32/smap.cpp
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <windows.h>
 #include <stdarg.h>
+#include <mutex>
 
 #include "smap.h"
 #include "net.h"
@@ -31,6 +32,9 @@
 #include "tap.h"
 
 bool has_link=true;
+volatile bool fireIntR = false;
+std::mutex frame_counter_mutex;
+std::mutex reset_mutex;
 /*
 #define	SMAP_BASE			0xb0000000
 #define	SMAP_REG8(Offset)		(*(u8 volatile*)(SMAP_BASE+(Offset)))
@@ -81,7 +85,7 @@ bool rx_fifo_can_rx()
 	//we can recv a packet !
 	return true;
 }
-volatile bool fireIntR = false;
+
 void rx_process(NetPacket* pk)
 {
 	if (!rx_fifo_can_rx())
@@ -108,6 +112,7 @@ void rx_process(NetPacket* pk)
 	}
 
 	//increase RXBD
+	std::unique_lock<std::mutex> reset_lock(reset_mutex);
 	dev9.rxbdi++;
 	dev9.rxbdi&=(SMAP_BD_SIZE/8)-1;
 
@@ -117,7 +122,10 @@ void rx_process(NetPacket* pk)
 	pbd->ctrl_stat&= ~SMAP_BD_RX_EMPTY;
 
 	//increase frame count
+	std::unique_lock<std::mutex> counter_lock(frame_counter_mutex);
 	dev9Ru8(SMAP_R_RXFIFO_FRAME_CNT)++;
+	counter_lock.unlock();
+	reset_lock.unlock();
 	//spams// emu_printf("Got packet, %d bytes (%d fifo)\n", pk->size,bytes);
 	fireIntR = true;
 	//_DEV9irq(SMAP_INTR_RXEND,0);//now ? or when the fifo is full ? i guess now atm
@@ -530,6 +538,8 @@ u32 CALLBACK smap_read32(u32 addr)
 }
 void CALLBACK smap_write8(u32 addr, u8 value)
 {
+	std::unique_lock<std::mutex> reset_lock(reset_mutex, std::defer_lock);
+	std::unique_lock<std::mutex> counter_lock(frame_counter_mutex, std::defer_lock);
 	switch(addr)
 	{
 	case SMAP_R_TXFIFO_FRAME_INC:
@@ -541,10 +551,12 @@ void CALLBACK smap_write8(u32 addr, u8 value)
 
 	case SMAP_R_RXFIFO_FRAME_DEC:
 		DEV9_LOG("SMAP_R_RXFIFO_FRAME_DEC 8bit write %x\n", value);
+		counter_lock.lock();
 		dev9Ru8(addr) = value;
 		{
 			dev9Ru8(SMAP_R_RXFIFO_FRAME_CNT)--;
 		}
+		counter_lock.unlock();
 		return;
 
 	case SMAP_R_TXFIFO_CTRL:
@@ -565,11 +577,15 @@ void CALLBACK smap_write8(u32 addr, u8 value)
 		DEV9_LOG("SMAP_R_RXFIFO_CTRL 8bit write %x\n", value);
 		if(value&SMAP_RXFIFO_RESET)
 		{
+			reset_lock.lock(); //lock reset mutex 1st
+			counter_lock.lock();
 			dev9.rxbdi=0;
 			dev9.rxfifo_wr_ptr=0;
 			dev9Ru8(SMAP_R_RXFIFO_FRAME_CNT)=0;
 			dev9Ru32(SMAP_R_RXFIFO_RD_PTR)=0;
 			dev9Ru32(SMAP_R_RXFIFO_SIZE)=16384;
+			reset_lock.unlock();
+			counter_lock.unlock();
 		}
 		value&= ~SMAP_RXFIFO_RESET;
 		dev9Ru8(addr) = value;
@@ -846,8 +862,9 @@ void CALLBACK smap_async(u32 cycles)
 {
 	if (fireIntR)
 	{
-		fireIntR = false; //Thread unsafe?
+		fireIntR = false;
 		//Is this used to signal each individual packet, or just when there are packets in the RX fifo?
+		//I think it just signals when there are packets in the RX fifo
 		_DEV9irq(SMAP_INTR_RXEND, 0); //Make the call to _DEV9irq in a thread safe way
 	}
 }

--- a/plugins/dev9ghzdrk/Win32/smap.h
+++ b/plugins/dev9ghzdrk/Win32/smap.h
@@ -26,3 +26,4 @@ void CALLBACK smap_write32(u32 addr, u32 value);
 
 void CALLBACK smap_readDMA8Mem(u32 *pMem, int size);
 void CALLBACK smap_writeDMA8Mem(u32 *pMem, int size);
+void CALLBACK smap_async(u32 cycles);


### PR DESCRIPTION
Seems to fix #520 and maybe #66 

I've added a new function to the plugin interface called DEV9async,which I'm using to call DEV9irq in a thread safe, but responsive way.

I've based it somewhat off the other async functions (SPUasync and USBasync) however, I'm not sure how to deal with the counters in IopCounters.cpp

The RX thread can still potentially perform thread unsafe operations on the Dev9 regs, It may be idea to resolve this in some-way, but I have little to no experience with multi-threading in C++.