### PR TITLE
Fix off-by-one error in the Game Database Editor.

### DIFF
--- a/pcsx2/gui/AppGameDatabase.cpp
+++ b/pcsx2/gui/AppGameDatabase.cpp
@@ -209,7 +209,7 @@ void AppGameDatabase::SaveToFile(const wxString& file) {
 
 		const uint endidx = (blockidx == m_BlockTableWritePos) ? m_CurBlockWritePos : m_GamesPerBlock;
 
-		for( uint gameidx=0; gameidx<=endidx; ++gameidx )
+		for( uint gameidx=0; gameidx<endidx; ++gameidx )
 		{
 			const Game_Data& game( m_BlockTable[blockidx][gameidx] );
 


### PR DESCRIPTION
Pretty ugly error that could potentially corrupt the GameIndex.dbf by accessing unrelated memory and crashing due to it. I guess no one ever uses this window because it only appears in debug builds so it hasn't been found until now?