### PR TITLE
Update manual game fix panel text

### DIFF
--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -113,7 +113,7 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 	}
 
 	m_check_Enable = new pxCheckBox( this, _("Enable manual game fixes [Not recommended]"),
-		pxE( L"It's better to enable 'Automatic game fixes' at the main menu instead, and leave this page empty. ('Automatic' means: selectively use specific tested fixes for specific games)"
+		pxE( L"It's better to enable 'Automatic game fixes' at the main menu instead, and leave this page empty. ('Automatic' means: selectively use specific tested fixes for specific games). Manual game fixes will NOT increase your performance. In fact they may decrease it."
 		)
 	);
 


### PR DESCRIPTION
Add some text telling users that the game fixes do not speed up games. We have many users who have followed a Youtube guide enabling all these and breaking their games. Hopefully this will mitigate that.


![1](https://cloud.githubusercontent.com/assets/7574269/7824870/63b4572a-03cc-11e5-9d18-a5498321b049.png)