### PR TITLE
Show default keyboard shortcuts in the menu next to Save and Load State.

### DIFF
--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -24,6 +24,9 @@
 
 #include <wx/iconbndl.h>
 
+#include <unordered_map>
+#include "AppAccelerators.h"
+
 #include "svnrev.h"
 
 // ------------------------------------------------------------------------
@@ -530,6 +533,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 
 	ApplyCoreStatus();
 	ApplySettings();
+	AppendKeycodeNamesToMenuOptions();
 }
 
 MainEmuFrame::~MainEmuFrame() throw()
@@ -694,6 +698,24 @@ void MainEmuFrame::CommitPreset_noTrigger()
 {
 	wxMenuBar& menubar( *GetMenuBar() );
 	g_Conf->EmuOptions.EnablePatches = menubar.IsChecked( MenuId_EnablePatches );
+}
+
+static void AppendShortcutToMenuOption( wxMenuItem& item, const char* id ) {
+	// this is NOT how a dictionary works but it has like 30 entries so this should still perform okay
+	auto* dict = &wxGetApp().GlobalAccels;
+	for ( auto it = ( *dict )->begin(); it != ( *dict )->end(); ++it ) {
+		if ( strcmp( it->second->Id, id ) == 0 ) {
+			wxString text = item.GetItemLabel();
+			size_t tabPos = text.rfind( L'\t' );
+			KeyAcceleratorCode keycode( (wxKeyCode)it->first );
+			item.SetItemLabel( text.Mid( 0, tabPos ) + L"\t" + keycode.ToString() );
+		}
+	}
+}
+
+void MainEmuFrame::AppendKeycodeNamesToMenuOptions() {
+	AppendShortcutToMenuOption( *m_menuSys.FindChildItem( MenuId_Sys_LoadStates ), "States_DefrostCurrentSlot" );
+	AppendShortcutToMenuOption( *m_menuSys.FindChildItem( MenuId_Sys_SaveStates ), "States_FreezeCurrentSlot" );
 }
 
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -150,6 +150,7 @@ public:
 
 	void ApplyConfigToGui( AppConfig& configToApply, int flags=0 ); //flags are: AppConfig::APPLY_CONFIG_FROM_PRESET and (currently unused) AppConfig::APPLY_CONFIG_MANUALLY PROPAGATE
 	void CommitPreset_noTrigger();
+	void AppendKeycodeNamesToMenuOptions();
 
 protected:
 	void DoGiveHelp(const wxString& text, bool show);


### PR DESCRIPTION
This was actually supposed to be a more generic "display all keyboard shortcuts next to their menu options" but those two seem to be the only ones that are actually accessible in the menu.

This only shows the default F1/F3 because I can't figure out how to get the keycodes that have been modified by PCSX2_keys.ini, but it's written in a way where you'd only need to call AppendKeycodeNamesToMenuOptions again after GlobalAccels has been updated correctly, I believe.