### PR TITLE
Fix AlignedMalloc on Windows

### DIFF
--- a/common/src/Utilities/AlignedMalloc.cpp
+++ b/common/src/Utilities/AlignedMalloc.cpp
@@ -29,8 +29,9 @@ static const uint headsize = sizeof(AlignedMallocHeader);
 void* __fastcall pcsx2_aligned_malloc(size_t size, size_t align)
 {
 	pxAssert( align < 0x10000 );
-
-#if defined(__USE_ISOC11) && !defined(ASAN_WORKAROUND) // not supported yet on gcc 4.9
+#ifdef _WIN32
+	return _aligned_malloc(size, align);
+#elif defined(__USE_ISOC11) && !defined(ASAN_WORKAROUND) // not supported yet on gcc 4.9
 	return aligned_alloc(align, size);
 #else
 	void *result=0;
@@ -48,12 +49,16 @@ void* __fastcall pcsx2_aligned_realloc(void* handle, size_t size, size_t align)
 	if( handle != NULL )
 	{
 		memcpy_fast( newbuf, handle, size );
-		free( handle );
+		pcsx2_aligned_free(handle);
 	}
 	return newbuf;
 }
 
 __fi void pcsx2_aligned_free(void* pmem)
 {
+#ifdef _WIN32
+	_aligned_free(pmem);
+#elif
 	free(pmem);
+#endif
 }


### PR DESCRIPTION
Commit 4feeaac7d108496cf4958c885c018b7c543cc9d0 broke the build on Windows. Fix the build.

Only partly tested, it works on my 'remove pre WIndows-8 stuff' branch (https://github.com/turtleli/pcsx2/tree/win8_vs2013) but I haven't tested it against master (I don't have the DirectX SDK installed). It should work though.

FYI Microsoft don't seem to have plans to support C11 except for the parts that are covered in C++ standards. (http://blogs.msdn.com/b/vcblog/archive/2015/04/29/c-11-14-17-features-in-vs-2015-rc.aspx)