### PR TITLE
Alternative fix for old GSDX config GUI showing during 1st time config.

### DIFF
--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -865,7 +865,7 @@ SysCorePlugins::PluginStatus_t::PluginStatus_t( PluginsEnum_t _pid, const wxStri
 			.SetUserMsg(_( "The configured %s plugin is not a PCSX2 plugin, or is for an older unsupported version of PCSX2."));
 
 	if( SetEmuVersion != NULL )
-		SetEmuVersion( "PCSX2", (0ul << 24) | (9ul<<16) | (7ul<<8) | 0 );
+		SetEmuVersion("PCSX2", (PCSX2_VersionHi << 24) | (PCSX2_VersionMid << 16) | (PCSX2_VersionLo << 8) | 0);
 
 	Name = fromUTF8( GetLibName() );
 	int version = GetLibVersion2( tbl_PluginInfo[pid].typemask );

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -653,6 +653,17 @@ void Panels::PluginSelectorPanel::OnConfigure_Clicked( wxCommandEvent& evt )
 			{
 				func( GetLogFolder().ToString().mb_str(wxConvFile) );
 			}
+
+			//FIX for GSDX loading old config GUI, Code taken from PluginManager.cpp
+#ifdef __linux__
+			_PS2EsetEmuVersion	SetEmuVersion = NULL;
+#else
+            _PS2EsetEmuVersion	SetEmuVersion = (_PS2EsetEmuVersion)dynlib.GetSymbol(L"PS2EsetEmuVersion");
+#endif
+
+			if (SetEmuVersion != NULL)
+				SetEmuVersion("PCSX2", (0ul << 24) | (9ul << 16) | (7ul << 8) | 0);
+
 		}
 
 		configfunc();

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -642,31 +642,16 @@ void Panels::PluginSelectorPanel::OnConfigure_Clicked( wxCommandEvent& evt )
 		ScopedCoreThreadPause paused_core( new SysExecEvent_SaveSinglePlugin(pid) );
 		if (!CorePlugins.AreLoaded())
 		{
-			typedef void	(CALLBACK* SetDirFnptr)( const char* dir );
-
-			if( SetDirFnptr func = (SetDirFnptr)dynlib.GetSymbol( tbl_PluginInfo[pid].GetShortname() + L"setSettingsDir" ) )
-			{
-				func( GetSettingsFolder().ToString().mb_str(wxConvFile) );
-			}
-
-			if( SetDirFnptr func = (SetDirFnptr)dynlib.GetSymbol( tbl_PluginInfo[pid].GetShortname() + L"setLogDir" ) )
-			{
-				func( GetLogFolder().ToString().mb_str(wxConvFile) );
-			}
-
-			//FIX for GSDX loading old config GUI, Code taken from PluginManager.cpp
-#ifdef __linux__
-			_PS2EsetEmuVersion	SetEmuVersion = NULL;
-#else
-            _PS2EsetEmuVersion	SetEmuVersion = (_PS2EsetEmuVersion)dynlib.GetSymbol(L"PS2EsetEmuVersion");
-#endif
-
-			if (SetEmuVersion != NULL)
-				SetEmuVersion("PCSX2", (PCSX2_VersionHi << 24) | (PCSX2_VersionMid << 16) | (PCSX2_VersionLo << 8) | 0);
-
+			CorePlugins.Load(pid, filename);
+			CorePlugins.SendLogFolder();
+			CorePlugins.SendSettingsFolder();
+			configfunc();
+			CorePlugins.Unload(pid);
 		}
-
-		configfunc();
+		else
+		{
+			configfunc();
+		}
 	}
 }
 

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -662,7 +662,7 @@ void Panels::PluginSelectorPanel::OnConfigure_Clicked( wxCommandEvent& evt )
 #endif
 
 			if (SetEmuVersion != NULL)
-				SetEmuVersion("PCSX2", (0ul << 24) | (9ul << 16) | (7ul << 8) | 0);
+				SetEmuVersion("PCSX2", (PCSX2_VersionHi << 24) | (PCSX2_VersionMid << 16) | (PCSX2_VersionLo << 8) | 0);
 
 		}
 


### PR DESCRIPTION
GSDX expects the emulator to call PS2EsetEmuVersion before it will show the new GUI.

This PR takes the code present here https://github.com/PCSX2/pcsx2/blob/98d22f8b2e7c7084d41dc06cf31af7ea8fc7c771/pcsx2/PluginManager.cpp#L856 and reuses it in OnConfigure_Clicked, causing GSDX to recognise that we are a relatively modern version of PCSX2 and show the newer GUI.

This is an alternative to PR https://github.com/PCSX2/pcsx2/pull/567 that performs the fix on the core side, instead of in GSDX.