### PR TITLE
gsdx: set the new renderer in ini file after a F9 switch

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -751,6 +751,10 @@ EXPORT_C GSconfigure()
 	{
 		if(!GSUtil::CheckSSE()) return;
 
+		// Be sure config is aligned after F9 toggling
+		if (s_renderer != -1)
+			theApp.SetConfig("renderer", s_renderer);
+
 #ifdef _WINDOWS
 
 		if(GSSettingsDlg(s_isgsopen2).DoModal() == IDOK)


### PR DESCRIPTION
Tentative fix for #584 