### PR TITLE
Dev9ghz: Respect user Log dir setting, use PluginLog

### DIFF
--- a/plugins/dev9ghzdrk/DEV9.h
+++ b/plugins/dev9ghzdrk/DEV9.h
@@ -17,6 +17,7 @@
 #define __DEV9_H__
 
 #include <stdio.h>
+#include <string>
 #ifndef EXTERN 
 #define EXTERN  extern
 #endif
@@ -25,6 +26,7 @@
 //#define _WIN32_WINNT 0x0500
 
 #include "PS2Edefs.h"
+#include "PS2Eext.h"
 #include "net.h"
 
 #ifdef __WIN32__
@@ -125,7 +127,9 @@ void _DEV9close();
 EXTERN  DEV9callback DEV9irq;
 //void DEV9thread();
 
-EXTERN  FILE *dev9Log;
+EXTERN  PluginLog DEV9Log;
+//Yes this is meant to be a lowercase extern
+extern  std::string s_strLogPath;
 void __Log(char *fmt, ...);
 
 void SysMessage(char *fmt, ...);

--- a/plugins/dev9ghzdrk/Win32/DEV9ghzdrk.def
+++ b/plugins/dev9ghzdrk/Win32/DEV9ghzdrk.def
@@ -27,3 +27,4 @@ EXPORTS
 	DEV9async           @22
 	
 	DEV9setSettingsDir
+	DEV9setLogDir

--- a/plugins/dev9ghzdrk/pcap_io.cpp
+++ b/plugins/dev9ghzdrk/pcap_io.cpp
@@ -123,9 +123,13 @@ int pcap_io_init(char *adapter)
 		fprintf(stderr,"WARNING: Error setting non-blocking mode. Default mode will be used.\n");
 	}
 
-	packet_log=fopen("logs/packet.log","w");
+	//Changing the LogSetting might not affect logging
+	//directory of winPcap logs if done after Open()
+	const std::string pfile(s_strLogPath + "/packet.log");
+	packet_log = fopen(pfile.c_str(), "w");
 
-	dump_pcap = pcap_dump_open(adhandle,"logs/pkt_log.pcap");
+	const std::string plfile(s_strLogPath + "/pkt_log.pcap");
+	dump_pcap = pcap_dump_open(adhandle, plfile.c_str());
 
 	pcap_io_running=1;
 	emu_printf("Ok.\n");


### PR DESCRIPTION
Respect user Log directory setting, use PluginLog for main logging as it checks if log file was created/opened successfully. 
The winpcap logging code already check if file creation/opening was successful, so they where largely left as is, only adjusting the file paths as needed.

Also enable full logging in debug builds.

Note: Dev9ghz also ignores the user settings directory setting, opting instead to save in the registry. but at least it won't crash.

Edit: Should fix https://github.com/PCSX2/pcsx2/issues/586