### PR TITLE
Fix language panel glitch on Windows

### DIFF
--- a/pcsx2/gui/Panels/MiscPanelStuff.cpp
+++ b/pcsx2/gui/Panels/MiscPanelStuff.cpp
@@ -113,7 +113,7 @@ Panels::LanguageSelectionPanel::LanguageSelectionPanel( wxWindow* parent, bool s
 		compiled[i].Printf( L"%s", m_langs[i].englishName.c_str() );
 
 	m_picker = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
-		size, compiled.GetPtr(), wxCB_READONLY | wxCB_SORT );
+		size, compiled.GetPtr(), wxCB_READONLY);
 
 	*this	+= 5;
 	*this	+= m_picker | pxSizerFlags::StdSpace();

--- a/pcsx2/gui/i18n.cpp
+++ b/pcsx2/gui/i18n.cpp
@@ -59,14 +59,7 @@ LangPackEnumeration::LangPackEnumeration( wxLanguage langId )
 LangPackEnumeration::LangPackEnumeration()
 {
 	wxLangId = wxLANGUAGE_DEFAULT;
-#if wxMAJOR_VERSION < 3
-	englishName = L"_System Default";		// left-side space forces it to sort to the front of the lists
-#else
-	// It seems wx change its sort algo... It seems non alphanumeric character are removed
-	englishName = L"0) System Default";		// left-side 0) forces it to sort to the front of the lists
-	// This one can work too
-	//englishName = L"A default";
-#endif
+	englishName = L"System Default";
 	englishName += _(" (default)");
 	canonicalName = L"default";
 


### PR DESCRIPTION
This bug only affects Windows.

The languages in the dropdown box are not in alphabetical order. This leads to some small glitches when selecting certain languages and clicking Apply.

Example:
Choose Chinese (Simplified) and click Apply. The language will be applied successfully, but Croatian will now appear in the dropbox.

Affected languages and the language that appears after pressing apply:
Croatian -> Chinese (Simplified)
Czech -> Chinese (Traditional)
Chinese (Simplified) -> Croatian
Chinese (Traditional) -> Czech
Turkish-> Thai 
Thai -> Turkish

The culprit is the wxCB_SORT window style. This maps out to a CBS_SORT style on the ComboBox, which has a ridiculous sorting order. Removing the style changes the order in which the languages are displayed in the dropdown box and fixes the glitch.