### PR TITLE
dev9ghz: Use .ini for saving settings

### DIFF
--- a/plugins/dev9ghzdrk/DEV9.cpp
+++ b/plugins/dev9ghzdrk/DEV9.cpp
@@ -81,7 +81,7 @@ u32 CALLBACK PS2EgetLibVersion2(u32 type) {
 }
 
 
-//string s_strIniPath = "inis";
+std::string s_strIniPath = "inis";
 std::string s_strLogPath = "logs";
 // Warning: The below log function is SLOW. Better fix it before attempting to use it.
 #ifdef _DEBUG
@@ -627,7 +627,7 @@ void CALLBACK DEV9setSettingsDir(const char* dir)
 {
 	// Grab the ini directory.
 	// TODO: Use
-    // s_strIniPath = (dir == NULL) ? "inis" : dir;
+    s_strIniPath = (dir == NULL) ? "inis" : dir;
 }
 
 void CALLBACK DEV9setLogDir(const char* dir)

--- a/plugins/dev9ghzdrk/DEV9.h
+++ b/plugins/dev9ghzdrk/DEV9.h
@@ -128,7 +128,8 @@ EXTERN  DEV9callback DEV9irq;
 //void DEV9thread();
 
 EXTERN  PluginLog DEV9Log;
-//Yes this is meant to be a lowercase extern
+//Yes these are meant to be a lowercase extern
+extern  std::string s_strIniPath;
 extern  std::string s_strLogPath;
 void __Log(char *fmt, ...);
 

--- a/plugins/dev9ghzdrk/Win32/Config.cpp
+++ b/plugins/dev9ghzdrk/Win32/Config.cpp
@@ -91,6 +91,6 @@ void LoadConf() {
 	GetPrivateProfileString("DEV9", "Hdd", HDD_DEF, config.Hdd, sizeof(config.Hdd), file.c_str());
 	config.HddSize = GetPrivateProfileInt("DEV9", "HddSize", config.HddSize, file.c_str());
 	config.ethEnable = GetPrivateProfileInt("DEV9", "ethEnable", config.ethEnable, file.c_str());
-	config.ethEnable = GetPrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
+	config.hddEnable = GetPrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
 }
 

--- a/plugins/dev9ghzdrk/Win32/Config.cpp
+++ b/plugins/dev9ghzdrk/Win32/Config.cpp
@@ -54,6 +54,29 @@ void SaveConf() {
 	WritePrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
 }
 
+void DeleteRegConf() {
+	HKEY myKey;
+	//DWORD type, size;
+
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9\\DEV9linuz", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
+		return;
+	}
+	RegDeleteKey(myKey, "Eth");
+	RegDeleteKey(myKey, "Hdd");
+	RegDeleteKey(myKey, "HddSize");
+	RegDeleteKey(myKey, "ethEnable");
+	RegDeleteKey(myKey, "hddEnable");
+	RegCloseKey(myKey);
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
+		emu_printf("Error Opening Key DEV9linuz");
+		return;
+	}
+	if (RegDeleteKey(myKey, "DEV9linuz") != ERROR_SUCCESS) {
+		emu_printf("Error Deleting Key DEV9linuz");
+		return;
+	}
+}
+
 void LoadRegConf() {
 	HKEY myKey;
 	DWORD type, size;
@@ -74,6 +97,7 @@ void LoadRegConf() {
 	GetKeyVdw("hddEnable", &config.hddEnable);
 
 	RegCloseKey(myKey);
+	DeleteRegConf();
 }
 void LoadConf() {
 	memset(&config, 0, sizeof(config));

--- a/plugins/dev9ghzdrk/Win32/Config.cpp
+++ b/plugins/dev9ghzdrk/Win32/Config.cpp
@@ -67,47 +67,38 @@ void DeleteRegConf() {
 	RegDeleteKey(myKey, "ethEnable");
 	RegDeleteKey(myKey, "hddEnable");
 	RegCloseKey(myKey);
+	//Delete Key Software\PS2Eplugin\DEV9\DEV9linuz
 	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
-		emu_printf("Error Opening Key DEV9linuz");
+		emu_printf("Error Opening Key DEV9\n");
 		return;
 	}
 	if (RegDeleteKey(myKey, "DEV9linuz") != ERROR_SUCCESS) {
-		emu_printf("Error Deleting Key DEV9linuz");
+		emu_printf("Error Removing Key DEV9linuz\n");
+		RegCloseKey(myKey);
 		return;
 	}
+	RegCloseKey(myKey);
+	//Delete Key Software\PS2Eplugin\DEV9
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
+		emu_printf("Error Opening Key PS2Eplugin\n");
+		return;
+	}
+	if (RegDeleteKey(myKey, "DEV9") != ERROR_SUCCESS) {
+		emu_printf("Error Removing Key DEV9\n");
+		RegCloseKey(myKey);
+		return;
+	}
+	RegCloseKey(myKey);
 }
 
-void LoadRegConf() {
-	HKEY myKey;
-	DWORD type, size;
-
+void LoadIniConf() {
 	//memset(&config, 0, sizeof(config));
 	//strcpy(config.Hdd, HDD_DEF);
-	//config.HddSize=8*1024;
+	//config.HddSize = 8 * 1024;
 	//strcpy(config.Eth, ETH_DEF);
-
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9\\DEV9linuz", 0, KEY_ALL_ACCESS, &myKey)!=ERROR_SUCCESS) {
-		//SaveConf();
-		return;
-	}
-	GetKeyV("Eth", config.Eth, sizeof(config.Eth), REG_SZ);
-	GetKeyV("Hdd", config.Hdd, sizeof(config.Hdd), REG_SZ);
-	GetKeyVdw("HddSize", &config.HddSize);
-	GetKeyVdw("ethEnable", &config.ethEnable);
-	GetKeyVdw("hddEnable", &config.hddEnable);
-
-	RegCloseKey(myKey);
-	DeleteRegConf();
-}
-void LoadConf() {
-	memset(&config, 0, sizeof(config));
-	strcpy(config.Hdd, HDD_DEF);
-	config.HddSize = 8 * 1024;
-	strcpy(config.Eth, ETH_DEF);
 
 	const std::string file(s_strIniPath + "/dev9ghz.ini");
 	if (FileExists(file.c_str()) == false) {
-		LoadRegConf(); //Import old settings if user has upgraded this plugin
 		SaveConf();
 		return;
 	}
@@ -116,5 +107,31 @@ void LoadConf() {
 	config.HddSize = GetPrivateProfileInt("DEV9", "HddSize", config.HddSize, file.c_str());
 	config.ethEnable = GetPrivateProfileInt("DEV9", "ethEnable", config.ethEnable, file.c_str());
 	config.hddEnable = GetPrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
+}
+
+void LoadConf() {
+	HKEY myKey;
+	DWORD type, size;
+
+	memset(&config, 0, sizeof(config));
+	strcpy(config.Hdd, HDD_DEF);
+	config.HddSize = 8 * 1024;
+	strcpy(config.Eth, ETH_DEF);
+
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9\\DEV9linuz", 0, KEY_ALL_ACCESS, &myKey)!=ERROR_SUCCESS) {
+		LoadIniConf();
+		return;
+	}
+	printf("Importing Settings\n");
+	//Import old settings if user has upgraded this plugin
+	GetKeyV("Eth", config.Eth, sizeof(config.Eth), REG_SZ);
+	GetKeyV("Hdd", config.Hdd, sizeof(config.Hdd), REG_SZ);
+	GetKeyVdw("HddSize", &config.HddSize);
+	GetKeyVdw("ethEnable", &config.ethEnable);
+	GetKeyVdw("hddEnable", &config.hddEnable);
+
+	RegCloseKey(myKey);
+	SaveConf();
+	DeleteRegConf();
 }
 


### PR DESCRIPTION
Use .ini for saving settings.

This seems to be how other plugins save their settings.

Also import settings from the registry (where it was previously saved) if needed.

