### PR TITLE
Fix renderer toggling behaviour and other related stuff

### DIFF
--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -179,6 +179,8 @@ static void dummyIrqCallback()
 
 void SysMtgsThread::OpenPlugin()
 {
+	static bool stored_renderswitch = false;
+
 	if( m_PluginOpened ) return;
 
 	memcpy( RingBuffer.Regs, PS2MEM_GS, sizeof(PS2MEM_GS) );
@@ -192,8 +194,9 @@ void SysMtgsThread::OpenPlugin()
 	else
 		result = GSopen( (void*)pDsp, "PCSX2", renderswitch ? 2 : 1 );
 
-	if( renderswitch )
+	if( stored_renderswitch != renderswitch )
 	{
+		stored_renderswitch = renderswitch;
 		Console.Indent(2).WriteLn( "Toggling GSdx Hardware/Software renderer" );
 	}
 

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -192,24 +192,12 @@ void SysMtgsThread::OpenPlugin()
 	else
 		result = GSopen( (void*)pDsp, "PCSX2", renderswitch ? 2 : 1 );
 
-	// Vsync on / off ?
 	if( renderswitch )
 	{
 		Console.Indent(2).WriteLn( "Toggling GSdx Hardware/Software renderer" );
-		if ( EmuConfig.GS.VsyncEnable )
-		{
-			// Better turn Vsync off now, as in most cases sw rendering is not fast enough to support a steady 60fps.
-			// Having Vsync still enabled then means a big cut in speed and sloppy rendering.
-			// It's possible though that some users have very fast machines, and rather kept Vsync enabled,
-			// but let's assume this is the minority. At least for now ;)
-			GSsetVsync( false );
-			Console.Indent(2).WriteLn( "Vsync temporarily disabled" );
-		}
 	}
-	else
-	{
-		GSsetVsync( EmuConfig.GS.FrameLimitEnable && EmuConfig.GS.VsyncEnable );
-	}
+
+	GSsetVsync(EmuConfig.GS.FrameLimitEnable && EmuConfig.GS.VsyncEnable);
 
 	if( result != 0 )
 	{


### PR DESCRIPTION
Changes:
 * Removes code that disables vsync in "software" rendering mode, or what PCSX2 believes to be software rendering mode. It doesn't actually know, so the code is broken.
 * The toggling renderer message only appears after F9 is pressed (a pause and resume doesn't tell you it's toggling anymore). The message has also been changed slightly - GSdx might not be the renderer in use.
 * The renderer should be changed correctly after using the config panel, so it should fix #584. But maybe I've missed a test case so do test carefully.

This is for temporary F9 toggling. (Permanent F9 toggling is one extra line I think, I don't really have a preference for either).