### PR TITLE
More gui fixes

### DIFF
--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -764,10 +764,9 @@ void ConsoleLogFrame::OnCloseWindow(wxCloseEvent& event)
 		// instead of closing just hide the window to be able to Show() it later
 		Show( false );
 
-		// Can't do this via a Connect() on the MainFrame because Close events are not commands,
-		// and thus do not propagate up/down the event chain.
-		if( wxWindow* main = GetParent() )
-			wxStaticCast( main, MainEmuFrame )->OnLogBoxHidden();
+		// In the nogui case there might not be a Main frame window.
+		if (MainEmuFrame* mainframe = GetMainFramePtr())
+			mainframe->OnLogBoxHidden();
 	}
 	else
 	{


### PR DESCRIPTION
Fixes:
 * Console close behaviour - The console now properly registers that its been closed in all cases. Previously, closing the console (except via Misc -> Show Console) meant you had to click Show Console twice to reopen the Console and PCSX2 would reopen the console even if you had it closed on last exit.
 * Plugin/BIOS error dialog handling - If you already have the Plugin/BIOS dialog open and encounter a Plugin/BIOS error, PCSX2 will now change the dialog to show the panel that matches the error. The error message also changes slightly as well under these circumstances (I think this behaviour was how it was originally supposed to be done).