### PR TITLE
linux: onepad: Prevent dereference of deleted pointer

### DIFF
--- a/plugins/onepad/onepad.cpp
+++ b/plugins/onepad/onepad.cpp
@@ -246,9 +246,11 @@ EXPORT_C_(s32) PADinit(u32 flags)
 
 EXPORT_C_(void) PADshutdown()
 {
-    CloseLogging();
-	if (conf) delete conf;
-	if (key_status) delete key_status;
+	CloseLogging();
+	delete conf;
+	conf = nullptr;
+	delete key_status;
+	key_status = nullptr;
 }
 
 EXPORT_C_(s32) PADopen(void *pDsp)


### PR DESCRIPTION
This prevents onepad dereferencing a null pointer when a PADinit, PADshutdown, then PADinit call sequence takes place.

Test case: Trigger a plugin/bios error using Boot CDVD, then try Boot CDVD again. (Maybe Boot, Shutdown, Boot would also work)