### PR TITLE
Improve texshuffle detection

### DIFF
--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -401,11 +401,15 @@ void GSRendererHW::Draw()
 			m_mem.m_clut.Read32(context->TEX0, env.TEXA);
 		}
 
+		bool not_really_16_bits;
 		if (rt) {
 			rt->m_32_bits_fmt |= tex->m_32_bits_fmt;
+			not_really_16_bits = rt->m_32_bits_fmt;
+		} else {
+			not_really_16_bits = tex->m_32_bits_fmt;
 		}
-		// Both input and output are 16 bits but texture was initially 32 bits!
-		m_texture_shuffle = ((context->FRAME.PSM & 0x2) && ((context->TEX0.PSM & 3) == 2) && (m_vt.m_primclass == GS_SPRITE_CLASS) && tex->m_32_bits_fmt);
+		// Both input and output are 16 bits but either texture or RT was initially 32 bits!
+		m_texture_shuffle = (context->FRAME.PSM & 0x2) && ((context->TEX0.PSM & 3) == 2) && (m_vt.m_primclass == GS_SPRITE_CLASS) && not_really_16_bits;
 		ASSERT(!m_texture_shuffle || (context->CLAMP.WMS < 3 && context->CLAMP.WMT < 3));
 	}
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -401,15 +401,19 @@ void GSRendererHW::Draw()
 			m_mem.m_clut.Read32(context->TEX0, env.TEXA);
 		}
 
-		bool not_really_16_bits;
+		bool not_really_16_bits = tex->m_32_bits_fmt;
 		if (rt) {
-			rt->m_32_bits_fmt |= tex->m_32_bits_fmt;
-			not_really_16_bits = rt->m_32_bits_fmt;
-		} else {
-			not_really_16_bits = tex->m_32_bits_fmt;
+			not_really_16_bits |= rt->m_32_bits_fmt;
 		}
 		// Both input and output are 16 bits but either texture or RT was initially 32 bits!
 		m_texture_shuffle = (context->FRAME.PSM & 0x2) && ((context->TEX0.PSM & 3) == 2) && (m_vt.m_primclass == GS_SPRITE_CLASS) && not_really_16_bits;
+
+		// Be sure texture shuffle detection is properly propagated
+		if (m_texture_shuffle && rt) {
+			rt->m_32_bits_fmt |= tex->m_32_bits_fmt;
+		}
+
+		// Texture shuffle is not yet supported with strange clamp mode
 		ASSERT(!m_texture_shuffle || (context->CLAMP.WMS < 3 && context->CLAMP.WMT < 3));
 	}
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -432,9 +432,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 	}
 
 	dst->m_used = true;
-	// Frame is always 32 bits. However target could be reused for standard RT. If the
-	// game uses a 16 bits RT (ricky cricket), you will be screwed
-	dst->m_32_bits_fmt = false;
 
 	return dst;
 }
@@ -788,6 +785,12 @@ void GSTextureCache::IncAge()
 
 			Target* t = *j;
 
+			// This variable is used to detect the texture shuffle effect. There is a high
+			// probability that game will do it on the current RT.
+			// Variable is cleared here to avoid issue with game that uses a 16 bits
+			// render target
+			t->m_32_bits_fmt = false;
+
 			if(++t->m_age > maxage)
 			{
 				m_dst[type].erase(j);
@@ -843,8 +846,9 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		}
 #endif
 
-		if (TEX0.PSM < PSM_PSMT8 || TEX0.PSM > PSM_PSMT4HH)
+		if (TEX0.PSM < PSM_PSMT8 || TEX0.PSM > PSM_PSMT4HH) {
 			src->m_32_bits_fmt = dst->m_32_bits_fmt;
+		}
 		src->m_target = true;
 
 		dst->Update();


### PR DESCRIPTION
This code improve the detection of texture shuffle effect. It seems to be fine on my limited testcase.

Could you do a quick test on your side too.

@refractionpcsx2 could you share a build to @prafullpcsx2