### PR TITLE
GSdx: windows: Make GSReplay work with OpenGL renderers

### DIFF
--- a/plugins/GSdx/GSWndWGL.h
+++ b/plugins/GSdx/GSWndWGL.h
@@ -37,6 +37,8 @@ class GSWndWGL : public GSWndGL
 	void CloseWGLDisplay();
 	bool OpenWGLDisplay();
 
+	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
 public:
 	GSWndWGL();
 	virtual ~GSWndWGL() {};


### PR DESCRIPTION
On Windows, the GSReplay function of GSdx does not work with the OpenGL renderers. This makes it work.