### PR TITLE
Corrections of GameIndex Regions

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1043,15 +1043,15 @@ vuClampMode = 2 // Text in GT mode works
 ---------------------------------------------
 Serial = SCAJ-30010
 Name   = God of War
-Region = NTSC-E
+Region = NTSC-UK
 ---------------------------------------------
 Serial = SCAJ-30011
 Name   = God of War II
-Region = NTSC-E
+Region = NTSC-UK
 ---------------------------------------------
 Serial = SCED-50041
 Name   = Tekken Tag Tournament [Demo]
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCED-50163
 Name   = PlayStation 2 Greatest Hits Vol.3 [Demo]
@@ -1071,12 +1071,12 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCED-50642
 Name   = Final Fantasy X [Demo] [Final Fantasy VI PS1 - Bonus Disc]
-Region = PAL-E
+Region = PAL-UK
 IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCED-50748
 Name   = Official PlayStation 2 Magazine Demo 26
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-50907
 Name   = Final Fantasy X [Bonus Disc - Beyond Final Fantasy]
@@ -1085,11 +1085,11 @@ IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCED-51531
 Name   = Official PlayStation 2 Magazine Demo 33
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-51537
 Name   = Official PlayStation 2 Magazine Demo 37
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-52436
 Name   = Playstation2 UK Demo 7-2004
@@ -1102,7 +1102,7 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SCED-52970
 Name   = SCEE Hits Demo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-53163
 Name   = Official PlayStation 2 Magazine Demo 60
@@ -1140,7 +1140,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50005
 Name   = Wipeout Fusion
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50006
@@ -1148,10 +1148,8 @@ Name   = Drakan - The Ancients' Gates	// aka "Drakan 2"
 Region = PAL-M5
 Compat = 5
 EETimingHack = 1	// flickery textures
-[patches]
-	comment=- This gamedisc supports multiple languages through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-	// =====
+// Language selection via BIOS settings (requires Full boot).
+[patches = 04F9D87F]
 	// Fix by pgert against displaycrap which arises with HD
 	//  when using GSdx (in HW-mode) around the Health & Mana bars.
 	patch=1,EE,001C2274,word,3C013F7F // 3C013F80
@@ -1164,12 +1162,12 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50034
 Name   = MotoGP
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50105
 Name   = Sky Odyssey
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50139
 Name   = World Rally Championship
@@ -1178,7 +1176,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50240
 Name   = Extermination
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50241
 Name   = Bouncer, The
@@ -1187,16 +1185,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50244
 Name   = This is Football 2002
-Region = PAL-E
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-50246
 Name   = AirBlade
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50293
 Name   = ATV Off-Road
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50294
 Name   = Gran Turismo 3 A-Spec
@@ -1205,17 +1203,17 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50295
 Name   = Dark Cloud
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50300
 Name   = Time Crisis 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50354
 Name   = Klonoa 2 - Lunatea's Veil
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 eeClampMode = 3		//Objects needed appear in wrong places without it
 [patches = 7EBEEBBD]
@@ -1229,41 +1227,41 @@ eeClampMode = 3		//Objects needed appear in wrong places without it
 ---------------------------------------------
 Serial = SCES-50360
 Name   = Twisted Metal - Black
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50361
 Name   = Jak and Daxter - The Precursor Legacy
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50408
 Name   = PaRappa the Rapper 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50409
 Name   = MotoGP 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50410
 Name   = Ace Combat - Distant Thunder
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50411
 Name   = Vampire Night
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SCES-50459
 Name   = Dropship - United Peace Force
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SCES-50490
 Name   = Final Fantasy X
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 IPUWaitHack = 1
 ---------------------------------------------
@@ -1285,63 +1283,63 @@ IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCES-50494
 Name   = Final Fantasy X
-Region = PAL-S
+Region = PAL-E
 IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCES-50499
 Name   = Ecco the Dolphin - Defender of the Future
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SCES-50500
 Name   = Headhunter
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50501
 Name   = Rez
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50522
 Name   = Disney's Peter Pan - Adventures in Neverland
-Region = PAL-E
+Region = PAL-M2	// UK & ES
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50526
 Name   = Peter Pan
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50531
 Name   = Peter Pan - Legenden om Onskeoen
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SCES-50595
 Name   = Disney-Pixar's Monsters Inc.
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-50596
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-DA
 ---------------------------------------------
 Serial = SCES-50597
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SCES-50598
 Name   = Monsterit Oy
-Region = PAL-Unk
+Region = PAL-FI
 ---------------------------------------------
 Serial = SCES-50599
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-50600
 Name   = Disney's Monster Inc. - Scare Island
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-50601
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-50602
 Name   = Monsters Inc.
@@ -1349,11 +1347,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50603
 Name   = Monstruos S.A - La Isla de los Sustos
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-50604
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-50605
 Name   = Monsters Inc.
@@ -1361,11 +1359,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50611
 Name   = Space Channel 5
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50612
 Name   = Space Channel 5 - Part 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50614
 Name   = Jak & Daxter - The Precursor Legacy
@@ -1373,7 +1371,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50759
 Name   = Virtua Fighter 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50760
@@ -1385,17 +1383,17 @@ vuClampMode = 1	// Otherwise camera gets stuck off the player in various spots.
 ---------------------------------------------
 Serial = SCES-50781
 Name   = Destruction Derby Arena [Beta, Promo, & Full Retail]
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50791
 Name   = Frequency
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50810
 Name   = Smash Court Tennis - Pro Tournament
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50850
 Name   = Gran Turismo - Concept 2002 Tokyo-Geneva
@@ -1408,7 +1406,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50878
 Name   = Tekken 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 [patches = 2251E14D]
 
@@ -1429,20 +1427,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50885
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-50887
 Name   = Alpine Racer 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50888
 Name   = Pac-Man World 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50889
 Name   = Ninja Assault
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50916
@@ -1452,7 +1450,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50917
 Name   = Sly Racoon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50928
 Name   = SOCOM - U.S. Navy SEALs [Beta & Full Release]
@@ -1460,7 +1458,7 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-50934
 Name   = World Rally Championship II Extreme
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-50935
 Name   = World Rally Championship II Extreme
@@ -1468,26 +1466,26 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50956
 Name   = Ferrari F355 Challenge
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50960
 Name   = Disney's Stitch: Experiment 626
-Region = PAL-E
+Region = PAL-M2	// FR & GE
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50966
 Name   = Disney's Stitch - Experiment 626
-Region = PAL-Unk
+Region = PAL-M2	// UK & SE
 ---------------------------------------------
 Serial = SCES-50967
 Name   = Kingdom Hearts
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50968
 Name   = Kingdom Hearts
-Region = PAL-Unk
+Region = PAL-F
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50969
@@ -1501,12 +1499,12 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SCES-50971
 Name   = Kingdom Hearts
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50982
 Name   = Moto GP 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50987
@@ -1515,15 +1513,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-51004
 Name   = Formula One 2002
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-51039
 Name   = This is Football 2003
-Region = PAL-E
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-51040
 Name   = Le Monde des Bleus 2003
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-51041
 Name   = This is Football 2003
@@ -1531,19 +1529,19 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-51102
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-51103
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-51104
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-51105
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-51135
 Name   = Primal
@@ -1569,15 +1567,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-51164
 Name   = Mark of Kri, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51176
 Name   = Disney's Treasure Planet
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51179
 Name   = This is Football 2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-51190
 Name   = Dark Chronicle
@@ -1586,24 +1584,24 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-51224
 Name   = War of the Monsters
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51248
 Name   = Dog's Life
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-51426
 Name   = Getaway, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51428
 Name   = Shinobi
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51463
 Name   = Ghosthunter
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51480
@@ -1612,7 +1610,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51513
 Name   = EyeToy - Play
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-51533
 Name   = God of War
@@ -1634,32 +1632,32 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51607
 Name   = Ratchet & Clank 2 - Locked & Loaded
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51608
 Name   = Jak & Daxter 2 - Renegade
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-51610
 Name   = This is Football 2004 (Red Devils 2004)
-Region = PAL-Unk
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SCES-51611
 Name   = This is Football 2004
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51612
 Name   = This is Football 5
-Region = PAL-Unk
+Region = PAL-M2	// UK & NO
 ---------------------------------------------
 Serial = SCES-51613
 Name   = This is Football 2004
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51614
 Name   = Monde des Bleus 2004, Le - Nouvelle Generation
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-51618
 Name   = SOCOM
@@ -1667,19 +1665,19 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-51635
 Name   = Brave - The Search for Spirit Dancer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51648
 Name   = Everquest - Online Adventures
-Region = PAL-E-I
+Region = PAL-M2	// UK & IT
 ---------------------------------------------
 Serial = SCES-51677
 Name   = My Street
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51684
 Name   = World Rally Championship 3
-Region = PAL-Unk
+Region = PAL-M8
 [patches = 80802EA9]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -1689,16 +1687,16 @@ patch=1,EE,002aa574,word,00000000
 ---------------------------------------------
 Serial = SCES-51685
 Name   = Primal
-Region = PAL-R
+Region = PAL-M2	// UK & RU - Russian Edition.
 ---------------------------------------------
 Serial = SCES-51706
 Name   = Amplitude
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51719
 Name   = Gran Turismo 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
@@ -1716,11 +1714,11 @@ Compat = 3
 ---------------------------------------------
 Serial = SCES-51844
 Name   = Time Crisis 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51895
 Name   = EyeToy - Groove
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-51904
 Name   = SOCOM II - U.S. Navy SEALs
@@ -1731,17 +1729,17 @@ VIF1StallHack = 1		//HUD
 ---------------------------------------------
 Serial = SCES-51910
 Name   = Arc the Lad - Twilight of the Spirits
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51920
 Name   = Forbidden Siren
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51971
 Name   = Rise to Honor
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-51977
 Name   = Hardware Online Arena
@@ -1769,7 +1767,7 @@ EETimingHack = 1		//random hangs in US version, code is the same.
 ---------------------------------------------
 Serial = SCES-52042
 Name   = Formula One 2004
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52065
 Name   = Flipnic
@@ -1777,7 +1775,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52099
 Name   = I-Ninja
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52124
 Name   = kill.switch
@@ -1789,15 +1787,15 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-52156
 Name   = Ghosthunter - Hunter on the spectres
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-52268
 Name   = Sing-Star
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-52299
 Name   = SingStar
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-52306
 Name   = SOCOM II - U.S. Navy SEALs
@@ -1808,7 +1806,7 @@ VIF1StallHack = 1		//HUD
 ---------------------------------------------
 Serial = SCES-52327
 Name   = Forbidden Siren
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52328
 Name   = Forbidden Siren
@@ -1817,15 +1815,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52329
 Name   = Forbidden Siren
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-52330
 Name   = Forbidden Siren - Viviendo la Pesadilla
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-52389
 Name   = World Rally Championship 4
-Region = PAL-Unk
+Region = PAL-M8
 Compat = 1
 ---------------------------------------------
 Serial = SCES-52405
@@ -1835,15 +1833,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52410
 Name   = Athens 2004
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52411
 Name   = Athens 2004 [Platinum]
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52412
 Name   = Jackie Chan Adventures
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-52423
 Name   = Smash Court Tennis - Pro Tournament 2
@@ -1851,7 +1849,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52424
 Name   = Ace Combat - Squadron Leader
-Region = PAL-E
+Region = PAL-M5
 [patches = 1D54FEA9]
 	patch=0,EE,001A3154,word,48498800
 	patch=0,EE,001A3158,word,4B00682C
@@ -1865,19 +1863,19 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52426
 Name   = This is Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-52427
 Name   = This is Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-52429
 Name   = This is Football 2005
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SCES-52430
 Name   = Le Monde des Bleus 2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52431
 Name   = This is Football 2005
@@ -1889,19 +1887,19 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52438
 Name   = Gran Turismo 4 - Prologue
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
 ---------------------------------------------
 Serial = SCES-52456
 Name   = Ratchet & Clank 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52460
 Name   = Jak 3
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52529
@@ -1911,15 +1909,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52530
 Name   = Crisis Zone
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52564
 Name   = Sing-Star
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52565
 Name   = Sing-Star
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-52566
 Name   = SingStar
@@ -1927,11 +1925,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52582
 Name   = Everybody's Golf
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52586
 Name   = Death by Degrees
-Region = PAL-Unk
+Region = PAL-M2	// UK & ES
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52596
@@ -1940,13 +1938,10 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52677
 Name   = Network Access Disc & Hardware - Online Arena
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M7
 Compat = 5
+// Language selection & Widescreen mode via BIOS settings (requires Full boot).
 [patches]
-	comment=- This gamedisc supports multiple languages and widescreen.
-	comment=- Language & widescreen selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-	comment=-  *  *  *  *  *  *
 	comment=- Using GSdx, this gamedisc crashes in gamemenu with SW-mode, 
 	comment=-  and has no 3D display with HW-mode.
 	comment=- Playable by toggling between HW-mode (in menu) and SW-mode (in game).
@@ -1954,7 +1949,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52748
 Name   = EyeToy - Play 2
-Region = PAL-Unk
+Region = PAL-M12	// SpyToy - M11
 Compat = 2
 ---------------------------------------------
 Serial = SCES-52756
@@ -1963,7 +1958,7 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SCES-52758
 Name   = Getaway, The - Black Monday
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52762
 Name   = DJ Decks & FX
@@ -1971,11 +1966,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52763
 Name   = DJ Decks & FX Vol.1
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-52826
 Name   = Sing-Star Party
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-52827
 Name   = SingStar Party
@@ -1987,47 +1982,47 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52829
 Name   = Sing-Star Party
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-52830
 Name   = SingStar Party
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-52883
 Name   = EyeToy - Kinetic
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 2
 ---------------------------------------------
 Serial = SCES-52892
 Name   = Moto GP 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52893
 Name   = Killzone
-Region = PAL-E-Gr-R
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-52930
 Name   = EyeToy - Monkey Mania
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SCES-52948
 Name   = Getaway, The - Black Monday
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-53033
 Name   = Formula One 2005
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53053
 Name   = Death by Degrees
-Region = PAL-Unk
+Region = PAL-M2	// FR & IT
 ---------------------------------------------
 Serial = SCES-53054
 Name   = Death by Degrees
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53055
@@ -2036,50 +2031,50 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-53133
 Name   = God of War
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53178
 Name   = SingStar Pop
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53179
 Name   = SingStar Pop
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-53180
 Name   = Sing-Star - The Dome
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53181
 Name   = SingStar
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53182
 Name   = Sing-Star Pop
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53183
 Name   = SingStar Pop
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53184
 Name   = SingStar Norske Hits
-Region = PAL-Unk
+Region = PAL-NO
 ---------------------------------------------
 Serial = SCES-53185
 Name   = SingStar Svenska Hits
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-53202
 Name   = Tekken 5
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 eeClampMode = 1
 ---------------------------------------------
 Serial = SCES-53247
 Name   = WRC - World Rally Championship - Rally Evolved
-Region = PAL-Unk
+Region = PAL-M8
 Compat = 5
 XgKickHack = 1			//SPS.
 [patches = cbbc2e7f]
@@ -2101,12 +2096,12 @@ XgKickHack = 1			//SPS.
 ---------------------------------------------
 Serial = SCES-53285
 Name   = Ratchet - Gladiator
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53286
 Name   = Jak X - Combat Racing
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-53300
 Name   = SOCOM 3 - U.S. Navy SEALs
@@ -2114,28 +2109,28 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-53304
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53305
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-53307
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SCES-53308
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SCES-53310
 Name   = Roland Garros 2005
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53312
 Name   = Soul Calibur 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 vuRoundMode = 3
 ---------------------------------------------
@@ -2145,29 +2140,29 @@ Region = PAL-M12
 ---------------------------------------------
 Serial = SCES-53323
 Name   = SingStar Pop World
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53326
 Name   = Shadow of the Colossus
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53328
 Name   = Genji
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53347
 Name   = SpyToy
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-53358
 Name   = 24 - The Game
-Region = PAL-Unk
+Region = PAL-M9
 ---------------------------------------------
 Serial = SCES-53372
 Name   = Tourist Trophy - The Real Riding Simulator
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-53397
 Name   = SingStar Pop - World Events Code
@@ -2184,11 +2179,11 @@ Region = PAL-M9
 ---------------------------------------------
 Serial = SCES-53449
 Name   = AFL Premiership 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53450
 Name   = Gaelic Football 2005
-Region = PAL-Unk
+Region = PAL-M2	// UK & Gaelic
 ---------------------------------------------
 Serial = SCES-53565
 Name   = SingStar Pop
@@ -2196,7 +2191,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-53602
 Name   = Sing-Star '80s
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53603
 Name   = Sing-Star '80s
@@ -2208,19 +2203,19 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53605
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53606
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53607
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SCES-53609
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-53610
 Name   = Sing-Star '80s
@@ -2228,16 +2223,16 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-53642
 Name   = Ape Escape 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53663
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-53669
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53688
 Name   = Urban Reign
@@ -2261,52 +2256,52 @@ XgKickHack = 1			//SPS.
 ---------------------------------------------
 Serial = SCES-53879
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53880
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53881
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-53882
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53883
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53884
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-E
 Compat = 2
 ---------------------------------------------
 Serial = SCES-53889
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53890
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-53891
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53893
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SCES-53894
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-HR
 ---------------------------------------------
 Serial = SCES-53895
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53897
 Name   = Sing-Star Rocks!
@@ -2314,16 +2309,16 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SCES-53898
 Name   = Sing-Star Rocks!
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53925
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53926
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SCES-53927
 Name   = Buzz! The Big Quiz
@@ -2335,17 +2330,17 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-53931
 Name   = Shinobido - Way of the Ninja
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53950
 Name   = F1 '06
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53960
 Name   = B-Boy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-54025
 Name   = SingStar Rocks!
@@ -2353,7 +2348,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54041
 Name   = Ace Combat - The Belkan War
-Region = PAL-E
+Region = PAL-M5
 [patches = 194C9F38]
 	patch=0,EE,00131EB4,word,48498800
 	patch=0,EE,00131EB8,word,4B00682C
@@ -2375,37 +2370,38 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SCES-54078
 Name   = SingStar Norsk pa Norsk
-Region = PAL-Unk
+	// Norsk på Norsk
+Region = PAL-NO
 ---------------------------------------------
 Serial = SCES-54128
 Name   = Deutsch Rock-Pop
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54129
 Name   = SingStar
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54131
 Name   = Sing-Star Anthems
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 3
 ---------------------------------------------
 Serial = SCES-54145
 Name   = Lemmings
-Region = PAL-Unk
+Region = PAL-M10
 Compat = 5
 ---------------------------------------------
 Serial = SCES-54191
 Name   = Sing-Star Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54197
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-54198
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54206
 Name   = God of War II
@@ -2414,35 +2410,35 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-54219
 Name   = Buzz! Junior - Jungle Party
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-54220
 Name   = Buzz! Junior - Jungle Party
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SCES-54257
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54258
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54259
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54260
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-54261
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-54262
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54263
 Name   = Buzz! The Sports Quiz
@@ -2450,15 +2446,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54264
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54265
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-54266
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SCES-54267
 Name   = Buzz! The Sports Quiz
@@ -2474,23 +2470,23 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54325
 Name   = SingStar Legendat
-Region = PAL-Unk
+Region = PAL-FI
 ---------------------------------------------
 Serial = SCES-54329
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-54330
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54353
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-DA
 ---------------------------------------------
 Serial = SCES-54477
 Name   = Socom US Navy Seals - Combined Assault
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-54497
@@ -2503,7 +2499,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54500
 Name   = Buzz! El Mega Concurso
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54507
 Name   = Buzz! The Mega Quiz
@@ -2515,7 +2511,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54535
 Name   = Everybody's Tennis
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-54538
 Name   = Eyetoy - Play Astro Zoo
@@ -2535,11 +2531,11 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-54598
 Name   = SingStar - Svenska Hits Schlager
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-54599
 Name   = SingStar - '90s
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54600
 Name   = SingStar - Die Toten Hosen
@@ -2555,7 +2551,7 @@ Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-54638
 Name   = Gaelic Games - Football 2
-Region = PAL-E
+Region = PAL-M2	// UK & Gaelic
 ---------------------------------------------
 Serial = SCES-54676
 Name   = Buzz! Junior - RoboJam
@@ -2583,11 +2579,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-54823
 Name   = SingStar Bollywood
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54844
 Name   = Buzz! The Hollywood Quiz
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-54845
 Name   = Buzz! The Hollywood Quiz
@@ -2595,7 +2591,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54848
 Name   = Buzz! Hollywood
-Region = PAL-M2
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SCES-54851
 Name   = Buzz! The Hollywood Quiz
@@ -2603,7 +2599,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-55093
 Name   = Buzz! The Pop Quiz
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-55094
 Name   = Buzz! The Pop Quiz
@@ -2615,7 +2611,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55183
 Name   = SingStar Turkish Party
-Region = PAL-Unk
+Region = PAL-TU	// Turkish
 ---------------------------------------------
 Serial = SCES-55210
 Name   = Buzz! Junior - Ace Racers
@@ -2623,7 +2619,7 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-55213
 Name   = Buzz! Escuela de Talentos
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-55361
 Name   = SingStar Boy Bands vs Girl Bands
@@ -2635,7 +2631,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55385
 Name   = Buzz! Brain of the UK
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SCES-55387
 Name   = Buzz! Deutschlands Superquiz
@@ -2651,7 +2647,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55464
 Name   = Hanuman: Boy Warrior
-Region = PAL-Unk
+Region = PAL-M2	// UK & Hindi
 Compat = 5
 ---------------------------------------------
 Serial = SCES-55510
@@ -2660,7 +2656,7 @@ Region = PAL-M12
 ---------------------------------------------
 Serial = SCES-55535
 Name   = Desi Adda : Games of India
-Region = PAL-Unk
+Region = PAL-M4	// UK, Hindi, Punjabi & Tamil
 Compat = 5
 ---------------------------------------------
 Serial = SCES-55538
@@ -2690,16 +2686,16 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55661
 Name   = RA.ONE: The Game
-Region = PAL-Unk
+Region = PAL-UK	// India
 Compat = 5
 ---------------------------------------------
 Serial = SCES-82034
 Name   = Xenosaga II - Jenseits von Gut und Bose [Disc 1]
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-82035
 Name   = Xenosaga II - Jenseits von Gut und Bose [Disc 2]
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCKA-10006
 Name   = Come on Baby
@@ -6254,11 +6250,11 @@ Region = NTSC-Unk
 ---------------------------------------------
 Serial = SLED-50117
 Name   = Metal Gear Solid 2 - Sons of Liberty [Demo] [Zone of the Enders Bonus Disc]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-50359
 Name   = Devil May Cry [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-50478
 Name   = WWF Smackdown! - Just Bring It [Demo]
@@ -6270,7 +6266,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLED-50884
 Name   = TimeSplitters 2 [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-51211
 Name   = Burnout 2 - Point of Impact [Demo]
@@ -6278,27 +6274,27 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLED-51281
 Name   = Haven - Call of the King [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-51901
 Name   = Soul Calibur II [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-52375
 Name   = Fight Night 2004 [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-52441
 Name   = Transformers [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-52473
 Name   = Transformers - Optimus Prime [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-52474
 Name   = Transformers - Red Alert [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-52476
 Name   = UEFA Euro 2004 - Portugal [Demo]
@@ -6306,7 +6302,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLED-52488
 Name   = The Suffering [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-52929
 Name   = Prince of Persia - Warrior Within [Demo]
@@ -6322,15 +6318,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLED-53673
 Name   = 007 - From Russia with Love [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-53719
 Name   = Pro Evolution Soccer 5 [Demo]
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLED-53723
 Name   = Peter Jackson's king Kong [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-53745
 Name   = Total Overdose [Demo]
@@ -6338,7 +6334,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLED-53845
 Name   = Matrix - Path of Neo [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-53937
 Name   = Black [Demo]
@@ -6346,11 +6342,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLED-53951
 Name   = Honda Demo [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-53953
 Name   = FIFA Street 2 [Demo]
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLED-54035
 Name   = Play the Best Demos from Atari [Demo]
@@ -6366,20 +6362,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50009
 Name   = Action Replay MAX
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50010
 Name   = Ready 2 Rumble - Round 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50011
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50012
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50013
 Name   = FIFA 2001
@@ -6391,11 +6387,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50015
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50016
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50017
 Name   = F1 Championship Season 2000
@@ -6404,43 +6400,43 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50018
 Name   = Kessen
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50019
 Name   = Kessen
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50020
 Name   = Kessen
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50021
 Name   = Madden NFL 2001
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50022
 Name   = NBA Live 2001
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50023
 Name   = NBA Live 2001
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50024
 Name   = NBA Live 2001
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50025
 Name   = NBA 2001
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50026
 Name   = NBA 2001
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50027
 Name   = NHL 2001
-Region = PAL-Unk
+Region = PAL-M3	// UK, FI & SE
 ---------------------------------------------
 Serial = SLES-50028
 Name   = NHL 2001
@@ -6452,17 +6448,17 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50031
 Name   = X-Squad
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50032
 Name   = Theme Park World
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50033
 Name   = Swing Away Golf
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50035
 Name   = Winter X-games Snowboarding
@@ -6470,41 +6466,41 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50036
 Name   = ESPN International Track & Field
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50037
 Name   = Silent Scope
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50038
 Name   = Gradius III & IV
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50039
 Name   = International Superstar Soccer
-Region = PAL-E-G
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-50042
 Name   = Disney's Dinosaur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50043
 Name   = Disney's Dinosaur
-Region = PAL-Unk
+Region = PAL-M5	// UK & Nordic
 ---------------------------------------------
 Serial = SLES-50044
 Name   = Rayman Revolution
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50045
 Name   = Disney's Jungle Book - Groove Party
-Region = PAL-Unk
+Region = PAL-M12
 ---------------------------------------------
 Serial = SLES-50046
 Name   = F1 Racing Championship
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 Compat = 2
 [patches = EDD7E0FF]
 	
@@ -6517,11 +6513,11 @@ Compat = 2
 ---------------------------------------------
 Serial = SLES-50047
 Name   = F1 Racing Championship
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50048
 Name   = Donald Duck - Quack Attack
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50050
@@ -6531,42 +6527,42 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50051
 Name   = Eternal Ring
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50052
 Name   = Pool Master
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50053
 Name   = Aqua Aqua - Wetrix 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50054
 Name   = Midnight Club
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50055
 Name   = Smuggler's Run
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50056
 Name   = Surfing H3O
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50057
 Name   = Dynasty Warriors 2
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50059
 Name   = Dynasty Warriors 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50060
 Name   = International Superstar Soccer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50061
 Name   = Smuggler's Run
@@ -6575,47 +6571,47 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50062
 Name   = Orphen - Scion of Sorcery
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50064
 Name   = Stunt GP
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-50068
 Name   = Top Gear Daredevil
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50069
 Name   = Top Gear Daredevil
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50071
 Name   = Midnight Club - Street Racing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 3
 ---------------------------------------------
 Serial = SLES-50072
 Name   = Street Fighter EX3
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50073
 Name   = Driving Emotion Type-S
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50074
 Name   = Unreal Tournament
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50075
 Name   = ESPN NBA 2Night
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50076
 Name   = Super Bust-A-Move
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50077
@@ -6625,29 +6621,29 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50078
 Name   = TimeSplitters
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50079
 Name   = Armored Core 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50080
 Name   = NBA Hoopz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50106
 Name   = Fur Fighters - Viggo's Revenge
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50107
 Name   = Legends of Wrestling
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50109
 Name   = 7 Blades
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50110
 Name   = Ephemeral Fantasia
@@ -6660,7 +6656,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50112
 Name   = Shadow of Memories
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50113
 Name   = Ring of Red
@@ -6669,51 +6665,51 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50114
 Name   = Kengo - Master of Bushido
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50115
 Name   = Tokyo Xtreme Racer
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50118
 Name   = Tiger Woods PGA Tour 2001
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50120
 Name   = Rumble Racing
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50126
 Name   = Quake III - Revolution
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50127
 Name   = Quake III - Revolution
-Region = PAL-Unk
+Region = PAL-UK	// German Edition.
 ---------------------------------------------
 Serial = SLES-50128
 Name   = Knockout Kings 2001
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50130
 Name   = Knockout Kings 2001
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50131
 Name   = Le Mans 24 Hours
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50132
 Name   = MX Rider
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50134
 Name   = Oni
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 [patches = 22E85E68]
 
@@ -6726,7 +6722,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50136
 Name   = Robot Warlords
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50137
 Name   = Robot Warlords
@@ -6744,47 +6740,47 @@ vuClampMode = 3		//For full textures showing.
 ---------------------------------------------
 Serial = SLES-50158
 Name   = Gungriffon Blaze
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50159
 Name   = Gungriffon Blaze
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50160
 Name   = Gungriffon Blaze
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50165
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50166
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50167
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50168
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50169
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50170
 Name   = World Destruction League - Thunder Tanks
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50171
 Name   = ESPN National Hockey Night
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50176
 Name   = Oni
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50177
 Name   = Oni
@@ -6805,7 +6801,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50183
 Name   = Wacky Races
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50185
@@ -6815,16 +6811,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50186
 Name   = Heroes of Might and Magic
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50187
 Name   = Warriors of Might and Magic
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50191
 Name   = Army Men - Green Rogue
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50192
 Name   = Army Men - Sarges Heroes 2
@@ -6833,25 +6829,25 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50193
 Name   = Silpheed - The Lost Planet
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50194
 Name   = 4x4 Evolution
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50195
 Name   = UEFA Challenge
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-50196
 Name   = Soul Reaver 2 - Legacy of Kain
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50201
 Name   = Evil Twin - Cyprien's Chronicles
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50202
@@ -6861,20 +6857,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50203
 Name   = Bloody Roar 3
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50204
 Name   = Star Wars - Super Bombad Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50206
 Name   = Star Wars - Super Bombad Racing
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50209
 Name   = Jeremy McGrath Supercross World
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50210
 Name   = XG3 - Extreme-G Racing
@@ -6883,27 +6879,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50211
 Name   = Gauntlet - Dark Legacy
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M3
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-50212
 Name   = Paris-Dakar Rally
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 SkipMPEGPatch = 1
 ---------------------------------------------
 Serial = SLES-50213
 Name   = NFL Quarterback Club 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50214
 Name   = 18 Wheeler
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50215
@@ -6925,19 +6917,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50217
 Name   = Dave Mirra Freestyle BMX 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50218
 Name   = All-Star Baseball 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50219
 Name   = NBA Street
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-50220
 Name   = EA Sports Rugby
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50221
 Name   = Conflict Zone
@@ -6945,16 +6937,16 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50224
 Name   = Kuri Kuri Mix
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50225
 Name   = Escape from Monkey Island
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50226
 Name   = Escape from Monkey Island 4
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50227
 Name   = Escape from Monkey Island (Flucht von Monkey Island)
@@ -6963,11 +6955,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50228
 Name   = Escape from Monkey Island 4
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50229
 Name   = Monkey Island 4
-Region = PAL-Unk
+	// La Fuga de Monkey Island
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50230
 Name   = Lotus Challenge
@@ -6977,90 +6970,90 @@ XgKickHack = 1			//SPS.
 ---------------------------------------------
 Serial = SLES-50231
 Name   = International League Soccer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50232
 Name   = Off-Road Wide Open
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50233
 Name   = Army Men - Air Attack - Blade's Revenge
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50243
 Name   = David Beckham Soccer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50247
 Name   = Onimusha - Warlords
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50248
 Name   = MDK 2 - Armageddon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50252
 Name   = Penny Racers
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50253
 Name   = Modern Groove - Ministry of Sound Edition
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50259
 Name   = Flintstones - Viva Rock Vegas
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50260
 Name   = Hidden Invasion
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50261
 Name   = Sky Surfer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50262
 Name   = World Destruction League - War Jets
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50263
 Name   = Portal Runner
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50266
 Name   = Playmobil - Hype - The Time Quest
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50267
 Name   = CART Fury Championship Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50268
 Name   = SpyHunter
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50273
 Name   = Legion - The Legend of Excalibur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50274
 Name   = Arctic Thunder
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50275
 Name   = EA Sports Rugby
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50276
 Name   = Gift, The
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50277
 Name   = Red Faction
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50278
 Name   = Red Faction
@@ -7073,7 +7066,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50280
 Name   = Victorious Boxers
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50282
 Name   = Age of Empires II: The Age of Kings
@@ -7082,15 +7075,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50283
 Name   = WTA Tour Tennis
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50284
 Name   = Silent Scope 2
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50285
 Name   = Police 24-7
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50288
@@ -7100,7 +7093,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50296
 Name   = Gift
-Region = PAL-Unk
+Region = PAL-F
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50297
@@ -7114,46 +7107,46 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50310
 Name   = Freak Out
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50314
 Name   = Giants - Citizen Kabuto
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50325
 Name   = Max Payne
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50326
 Name   = Max Payne
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50330
 Name   = Grand Theft Auto III
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50335
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50336
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50337
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50338
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50339
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50341
 Name   = Smuggler's Run 2 - Hostile Territory
@@ -7161,7 +7154,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50350
 Name   = Disney's Tarzan - Freeride
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50351
 Name   = Lake Masters EX
@@ -7170,7 +7163,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50355
 Name   = Batman Vengeance
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50356
 Name   = ESPN International Winter Sports
@@ -7178,40 +7171,40 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50358
 Name   = Devil May Cry
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50362
 Name   = Jonny Moseley Mad Trix
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50364
 Name   = City Crisis
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50366
 Name   = Star Wars - Racer Revenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50371
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50372
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50373
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50374
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50375
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50382
 Name   = Silent Hill 2
@@ -7224,12 +7217,12 @@ Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50384
-Name   = Project Zero II
-Region = PAL-Unk
+Name   = Metal Gear Solid 2 - Sons of Liberty
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50385
 Name   = Metal Gear Solid 2 - Sons of Liberty
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50386
 Name   = Crash Bandicoot - Wrath of Cortex
@@ -7238,36 +7231,36 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50390
 Name   = Driven
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50395
 Name   = World Championship Snooker 2002
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50396
 Name   = Mike Tyson Heavyweight Boxing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50397
 Name   = Prisoner of War
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50398
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50400
 Name   = Shaun Palmer's Pro Snowboarder
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50401
 Name   = Shaun Palmer's Pro Snowboarder
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50402
 Name   = Shaun Palmer's Pro Snowboarder
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50412
 Name   = Pro Evolution Soccer
@@ -7275,11 +7268,11 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50421
 Name   = Supercar Street Challenge
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50422
 Name   = Madden NFL 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50423
 Name   = F1 2001
@@ -7296,36 +7289,36 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50424
 Name   = Cricket 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50425
 Name   = NHL 2002
-Region = PAL-Unk
+Region = PAL-M3	// UK, FI & SE
 ---------------------------------------------
 Serial = SLES-50426
 Name   = NHL 2002
-Region = PAL-Unk
+Region = PAL-M2	// Czech & FR
 ---------------------------------------------
 Serial = SLES-50427
 Name   = NHL 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50428
 Name   = MX 2002 featuring Ricky Carmichael
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50429
 Name   = Alex Ferguson Player Manager 2002
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 3
 ---------------------------------------------
 Serial = SLES-50430
 Name   = ESPN X-Games Skateboarding
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50431
 Name   = F1 2001
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50432
 Name   = Tony Hawk Pro Skater 3
@@ -7333,54 +7326,54 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50433
 Name   = GoDai - Elemental Force
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50434
 Name   = Army Men - Real Time Strategy
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50435
 Name   = Tony Hawk's Pro Skater 3
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50436
 Name   = Tony Hawk Pro Skater 3
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50437
 Name   = Tony Hawk's Pro Skater 3
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50438
 Name   = Motor Mayhem
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50443
 Name   = LEGO Racers 2
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-50444
 Name   = Portal Runner
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50445
 Name   = Burnout
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50446
 Name   = Shadow Man - 2econd Coming
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50447
 Name   = All-Star Baseball 2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50451
 Name   = NHL Hitz 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50457
 Name   = Rayman M
@@ -7393,7 +7386,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50462
 Name   = Pro Evolution Soccer
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-50464
 Name   = FIFA 2002
@@ -7405,7 +7398,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50466
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50467
 Name   = FIFA 2002
@@ -7413,15 +7406,15 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50469
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-GR	// Greek
 ---------------------------------------------
 Serial = SLES-50470
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50471
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50472
 Name   = GTC Africa
@@ -7430,7 +7423,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50477
 Name   = WWF Smackdown! - Just Bring It
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50479
 Name   = Turok Evolution
@@ -7439,7 +7432,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50480
 Name   = Aggressive Inline Skating
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50481
@@ -7453,20 +7446,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50486
 Name   = Splashdown
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50487
 Name   = Space Race
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50495
 Name   = Who Wants to be a Millionaire - 2nd Edition
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50496
 Name   = Qui Veut Gagner des Millions
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50497
 Name   = Who Wants to be a Millionaire 2 (Wer wird Millionar 2)
@@ -7474,16 +7467,16 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50498
 Name   = Grandia II
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50503
 Name   = Weakest Link
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50504
 Name   = Half-Life
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50505
@@ -7497,15 +7490,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50507
 Name   = Half-Life
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50508
 Name   = Half-Life
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50509
 Name   = Half-Life
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50510
 Name   = Mummy Returns, The
@@ -7515,84 +7508,84 @@ EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-50511
 Name   = G-Surfers
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50512
 Name   = Bass Strike
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50533
 Name   = Sunny Garcia Surfing
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50534
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50535
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50536
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50537
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50538
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50539
 Name   = James Bond 007 - Agent Under Fire
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50540
 Name   = Simpsons Road Rage
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50541
 Name   = Capcom vs. SNK 2 - Mark of the Millennium
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50544
 Name   = Jet Ion GP
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50545
 Name   = SSX Tricky
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50546
 Name   = LMA Manager 2002
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50547
 Name   = Roger Lemerre - La Selection des Champions 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50548
 Name   = BDFL Manager 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50549
 Name   = Football Manager Campionato 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50550
 Name   = Manager de Liga 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50551
 Name   = Tetris Worlds
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50552
 Name   = Jet Ski Riders
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50553
 Name   = Project Eden
@@ -7601,11 +7594,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50554
 Name   = Thunderhawk - Operation Pheonix
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50556
 Name   = New York Race
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50558
 Name   = DSF Futball Manager 2002
@@ -7613,32 +7606,32 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50559
 Name   = Guy Roux Manager 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50562
 Name   = Super Bust-A-Move 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50568
 Name   = Top Gun - Combat Zones
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50570
 Name   = Tour de France, Le
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50572
 Name   = Robot Wars - Arenas of Destruction
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50575
 Name   = Dark Summit
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50578
 Name   = Kessen II
-Region = PAL-Unk
+Region = PAL-UK
 [patches = 9FAC4FF3]
 	comment=COP2 flag instance patch by refraction
 	// a mac flag check just after a vsub which gets in the way, rearranging
@@ -7650,27 +7643,27 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50579
 Name   = Kessen II
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50580
 Name   = Kessen II
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50584
 Name   = G1 Jockey
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50586
 Name   = ESPN Winter Sports 2002
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50589
 Name   = Worms Blast
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50590
 Name   = Music Maker
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-50591
 Name   = Guilty Gear X
@@ -7678,7 +7671,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50592
 Name   = No One Lives Forever
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50606
 Name   = State of Emergency
@@ -7686,7 +7679,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50608
 Name   = Shadow Man - 2econd Coming
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50613
 Name   = Woody Woodpecker
@@ -7695,27 +7688,27 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50619
 Name   = Jonny Moseley Mad Trix
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-50620
 Name   = Micro Machines
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-50628
 Name   = Simpsons Road Rage
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50630
 Name   = Dragon Rage
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50631
 Name   = Dragon Rage
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-50632
 Name   = Dragon Rage
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-50633
 Name   = Gitaroo Man
@@ -7732,67 +7725,67 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50638
 Name   = High Heat Major League Baseball 2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50639
 Name   = Everblue
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50640
 Name   = Salt Lake City 2002 Olympic Winter Games
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50641
 Name   = Dynasty Warriors 3
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50643
 Name   = Shifters
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-50644
 Name   = Shifters
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50645
 Name   = Shifters
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-50647
 Name   = Casper - Spirit Dimensions
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50649
 Name   = Taz Wanted
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50650
 Name   = Resident Evil Gun Survivor 2 - Code Veronica
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50653
 Name   = Gitaroo Man
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50654
 Name   = Dune, Frank Herbert's
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50661
 Name   = Atlantis III
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50662
 Name   = Shadow of Zorro, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50670
 Name   = ESPN Winter X-Games Snowboarding 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50672
 Name   = Baldur's Gate: Dark Alliance
@@ -7801,16 +7794,16 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-50677
 Name   = Shadow Hearts
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50679
 Name   = Tenchu 3 - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50680
 Name   = Pirates - The Legend of Black Kat
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50683
@@ -7819,25 +7812,25 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50684
 Name   = Medal of Honor - Frontline
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50686
 Name   = Iron Aces 2 - Birds of Prey
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50703
 Name   = Maximo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50704
 Name   = Godai - Elemental Force
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50706
 Name   = Army Men - Real Time Strategy
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50709
 Name   = Weakest Link (Le Maillon Fable)
@@ -7845,70 +7838,70 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50710
 Name   = Dr. Muto
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50711
 Name   = Red Card Football
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50713
 Name   = Freaky Flyers
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50714
 Name   = Defender
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50715
 Name   = Gravity Games Bike Street - Vertical Dirt
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50716
 Name   = Fireblade
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50717
 Name   = Mortal Kombat - Deadly Alliance
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50720
 Name   = FMX - Freestyle Metal X
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50721
 Name   = Pryzm - Dark Unicorn
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50722
 Name   = Premier Manager 2002-2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50723
 Name   = TOCA Race Driver
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50725
 Name   = V-Rally 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50726
 Name   = Myst III - Exile
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50727
 Name   = Knockout Kings 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50728
 Name   = Tiger Woods PGA Tour 2002
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50730
 Name   = VIP
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50731
 Name   = Need for Speed - Hot Pursuit 2
@@ -7918,50 +7911,50 @@ vuClampMode = 2			//white textures
 ---------------------------------------------
 Serial = SLES-50735
 Name   = Jade Cocoon 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50738
 Name   = Star Trek Voyager - Elite Force
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50739
 Name   = Soldier of Fortune - Gold Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50751
 Name   = Herdy Gerdy
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50752
 Name   = Pro Tennis WTA Tour
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50753
 Name   = Freekstyle
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50754
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50755
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50757
 Name   = Atlantis III
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-50758
 Name   = Eve of Extinction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50763
 Name   = Rally Championship
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50765
@@ -7970,7 +7963,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50767
 Name   = V8 Supercars Australia - Race Driver
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50768
 Name   = Rally Championship
@@ -7978,20 +7971,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50769
 Name   = Mr. Moskeeto
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50770
 Name   = Mad Maestro!
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50771
 Name   = Blood Omen 2 - Legend of Kain
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50772
 Name   = Blood Omen 2 - Legend of Kain
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50773
 Name   = Donald Duck Phantomias Platyrhynchos Kineticus
@@ -8000,63 +7993,63 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50777
 Name   = Battle Engine Aquila
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50778
 Name   = TD Overdrive - The Brotherhood of Speed
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SLES-50779
 Name   = ESPN NBA 2Night 2002
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50787
 Name   = International Superstar Soccer 2
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-50788
 Name   = Frogger - The Great Quest
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50790
 Name   = International Superstar Soccer 2002
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50793
 Name   = Grand Theft Auto III
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50794
 Name   = Sven-Goran Eriksson's World Manager 2002
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50795
 Name   = Superman - Shadow of Apokolips
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50796
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-M2	// UK & SE
 ---------------------------------------------
 Serial = SLES-50797
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50798
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-50799
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50800
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50801
 Name   = FIFA World Cup 2002
@@ -8064,48 +8057,48 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50802
 Name   = Knockout Kings 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50804
 Name   = Deus Ex
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50805
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50806
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50807
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50808
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50809
 Name   = Next Generation Tennis 2003
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50812
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50813
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50814
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50815
 Name   = Blood Omen 2 - Legend of Kain
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50816
 Name   = DTM Race Driver
@@ -8114,11 +8107,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50818
 Name   = Pro Race Driver
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50820
 Name   = Micro Machines
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50821
 Name   = Project Zero
@@ -8133,11 +8126,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50822
 Name   = Shadow Hearts
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50826
 Name   = Star Wars - Clone Wars
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50829
 Name   = Commandos 2 - Men of Courage
@@ -8145,48 +8138,52 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50831
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50832
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50833
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50834
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50835
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50836
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+Region = PAL-UK
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50837
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+	// Indiana Jones et le Tombeau de L'Empereur
+Region = PAL-F
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50838
 Name   = Indiana Jones and The Emperor's Tomb
+	// Indiana Jones und die Legende der Kaisergruft
 Region = PAL-G
 Compat = 5
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50839
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+	// Indiana Jones e la Tomba dell'Imperatore
+Region = PAL-I
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50840
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+	// Indiana Jones y la Tumba del Emperador
+Region = PAL-E
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50841
@@ -8196,97 +8193,100 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50842
 Name   = Downforce
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50843
 Name   = Crashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50845
 Name   = Medal of Honour - Frontline
-Region = PAL-Unk
+	// En Première Ligne
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50846
 Name   = Medal of Honor - Frontline
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50848
 Name   = Speed Kings
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50849
 Name   = Urban Freestyle Soccer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50850
 Name   = ATV Off-Road 2
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot),
+//  and in Options menu if you have Dutch or Portuguese.
 ---------------------------------------------
 Serial = SLES-50852
 Name   = Sven-Goran Eriksson's World Challenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50853
 Name   = Marcel DeSaily Pro Football
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50854
 Name   = WM Nationalspieler
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50859
 Name   = Commandos 2 - Men of Courage
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50860
 Name   = Commandos 2 - Men of Courage
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50861
 Name   = Top Angler
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50862
 Name   = Street Hoops
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50870
 Name   = Mat Hoffman's Pro BMX 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50871
 Name   = Mat Hoffman's Pro BMX 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50872
 Name   = Mat Hoffman's Pro BMX 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50873
 Name   = Reign of Fire
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50874
 Name   = F1 2002
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50875
 Name   = F1 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50876
 Name   = Driv3r
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50877
 Name   = TimeSplitters 2
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50879
 Name   = Paris-Dakar 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 FPUNegDivHack = 1		//Fixes sky being shown over the 3d.
 EETimingHack = 1		//Flickery videos without it.
@@ -8309,82 +8309,82 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50882
 Name   = Mary-Kate and Ashley - Sweet 16
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50886
 Name   = Transworld Surf
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50891
 Name   = Legaia 2 - Duel Saga
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50892
 Name   = Lethal Skies Elite Pilot - Team SW
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50897
 Name   = Super Trucks
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50898
 Name   = X-Men - The Next Dimension
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50899
 Name   = X-Men - The Next Dimension
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50900
 Name   = X-Men - The Next Dimension
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50902
 Name   = Conflict - Desert Storm
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50905
 Name   = Armored Core 2 - Another Age
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50906
 Name   = Master Rally
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50908
 Name   = Monster Jam - Maximum Destruction
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50914
 Name   = International Cue Club
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50919
 Name   = Akira Psycho Ball
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50920
 Name   = King's Field IV
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50921
 Name   = Way of the Samurai
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50922
 Name   = Terminator, The - Dawn of Fate
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50927
 Name   = Commandos 2 - Men of Courage
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50930
 Name   = Dino Stalker
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50932
 Name   = Smash Court Tennis - Pro Tournament
@@ -8392,24 +8392,24 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50933
 Name   = eJay Clubworld
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50935
 Name   = Circus Maximus - Chariot Wars
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50936
 Name   = Endgame
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50937
 Name   = LEGO Football Mania
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-50939
 Name   = USA Racer
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50946
 Name   = Britney's Dance Beat
@@ -8417,50 +8417,51 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50947
 Name   = Britney's Dance Beat
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50948
 Name   = Britney's Dance Beat
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50953
 Name   = Air Rescue Ranger
-Region = PAL-Unk
+	// Air Ranger - Rescue from Sky
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50954
 Name   = Tokyo Road Race
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50955
 Name   = London Racer 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50958
 Name   = Warhammer 40,000 - Firewarrior
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50963
 Name   = Riding Spirits
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50964
 Name   = Antz Extreme Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50965
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50972
 Name   = Barbarian
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50974
 Name   = Zapper - One Wicked Cricket!
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50975
 Name   = Thing, The
@@ -8474,21 +8475,21 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50978
 Name   = Onimusha 2 - Samurai's Destiny
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50981
 Name   = RC Sports Copter Challenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50984
 Name   = Gumball 3000
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50985
 Name   = Gumball 3000
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50986
@@ -8498,36 +8499,37 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50987
 Name   = Scorpion King, The - Rise of an Akkadian
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50988
-Name   = Lord of the Rings, The - The Fellowship of the Ring (Der Herr der Ringe - Die Gefahrten)
-Region = PAL-G
+Name   = Lord of the Rings, The - The Fellowship of the Ring
+	// Der Herr der Ringe - Die Gefährten
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50992
 Name   = Hitman 2 - Silent Assassin
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50994
 Name   = Paris-Marseille Racing II
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50995
 Name   = Fireblade
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50997
 Name   = Rally Fusion - Race of Champions
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50998
 Name   = Xtreme Express - World Grand Prix
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-50999
 Name   = UFC Throwdown
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51009
 Name   = Autobahn Raser IV
@@ -8535,36 +8537,38 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51011
 Name   = Knight Rider - The Game
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51013
 Name   = Blade 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51014
 Name   = Blade 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51017
 Name   = Scooby-Doo! and The Night of 100 Frights
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51018
 Name   = Scooby-Doo! and The Night of 100 Frights
-Region = PAL-Unk
+	// La Nuit des 100 Frissons
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51019
 Name   = Scooby-Doo! and The Night of 100 Frights
-Region = PAL-Unk
+	// Nacht der 100 Schrecken
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51022
 Name   = Virtual Racer - Jaques Villeneuve
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-51023
 Name   = LMA Manager 2003
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 [patches = 5C313124]
 	comment=patches by Shadow Lady
@@ -8576,19 +8580,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51025
 Name   = BDFL Manager 2003
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51038
 Name   = MX Superfly featuring Ricky Carmichael
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51042
 Name   = Disney Golf
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51043
 Name   = Spyro - Enter the Dragonfly
-Region = PAL-Unk
+Region = PAL-M6
 [patches = 0EF1D4BA]
 	comment=Spyro PAL startup fix
 	patch=1,EE,001E763C,word,24020001
@@ -8601,157 +8605,160 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51045
 Name   = Legends of Wrestling II
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51046
 Name   = State of Emergency
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51053
 Name   = Tom & Jerry's War of the Wiskers
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51054
 Name   = Midnight Club 2
-Region = PAL-Unk
+Region = PAL-M5	// Voices and Movies are in English.
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51055
 Name   = Go Go Golf
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51056
 Name   = Fighting Fury
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51057
 Name   = Hard Hitter 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51058
 Name   = Maken Shao - Demon Sword
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51060
 Name   = Butt Ugly Martians
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51061
 Name   = Grand Theft Auto - Vice City
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51064
 Name   = Gladius
-Region = PAL-Unk
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-51065
 Name   = Gladius
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51066
 Name   = Gladius
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51069
 Name   = RTX - Red Rock
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51070
 Name   = RTX Red Rock
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51071
 Name   = RTX - Red Rock
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51072
 Name   = RTX - Red Rock
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51073
 Name   = RTX Red Rock
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51076
 Name   = Liverpool FC - Club Football
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51077
 Name   = Club Football Real Madrid
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51078
 Name   = FC Barcelona - Club Football
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51079
 Name   = Ajax Club Football
-Region = PAL-Unk
+Region = PAL-M4
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 ---------------------------------------------
 Serial = SLES-51080
 Name   = AC Milan Club Football
-Region = PAL-Unk
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 ---------------------------------------------
 Serial = SLES-51081
 Name   = Club Football - Juventus 2003-2004 Season
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51082
 Name   = Hamburger SV Club Football - Saison 2003-2004
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51083
 Name   = Borussia Dortmund Club Football - Saison 2003-2004
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51084
 Name   = BDFL Manager 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51085
 Name   = Aston Villa - Club Football
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51086
 Name   = Club Football - Chelsea
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51087
 Name   = Leeds United - Club Football
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51088
 Name   = Club Football - Rangers
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51089
 Name   = Club Football - Arsenal
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51090
 Name   = Club Football - Manchester United
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51093
 Name   = Largo Winch - Empire Under Threat
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51094
 Name   = FC Internazionale - Club Football
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51095
 Name   = Dino Stalker
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51096
 Name   = Dino Stalker
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51100
 Name   = Club Football - Liverpool - 2003-2004 Season
@@ -8788,11 +8795,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51117
 Name   = Colin McRae Rally 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51118
 Name   = Wizardry - Tales of the Forsaken Land
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51124
@@ -8802,11 +8809,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51125
 Name   = Sega Soccer Slam
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51126
 Name   = Whirl Tour
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51128
 Name   = Total Immersion Racing
@@ -8815,28 +8822,28 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51130
 Name   = Tony Hawk's Pro Skater 4
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51132
 Name   = Tony Hawk's Pro Skater 4
-Region = PAL-Unk
+Region = PAL-G
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51133
 Name   = Red Faction 2
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51134
 Name   = Powerpuff Girls - Relish Rampage
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51141
 Name   = Summoner 2
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51142
@@ -8846,7 +8853,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51143
 Name   = Summoner 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51144
 Name   = Shox - Rally Reinvented
@@ -8855,7 +8862,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51145
 Name   = Monopoly Party
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51150
 Name   = Scrabble Interactive - 2003 Edition
@@ -8863,16 +8870,16 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51151
 Name   = NHL 2003
-Region = PAL-Unk
+Region = PAL-M6
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-51153
 Name   = LEGO Island - Extreme Stunts
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-51154
 Name   = Madden NFL 2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51156
 Name   = Silent Hill 2 - Director's Cut
@@ -8881,24 +8888,24 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51157
 Name   = Silent Scope 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51160
 Name   = Sub Rebellion
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51162
 Name   = Metropolismania
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51168
 Name   = AFL Live 2004 - Aussie Rules Football
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51174
 Name   = Marvel vs. Capcom 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51180
@@ -8908,38 +8915,39 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51181
 Name   = Tom Clancy's Ghost Recon
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51182
 Name   = Tom Clancy's Ghost Recon
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51188
 Name   = Rocket Power - Beach Bandits
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51189
 Name   = MTV's Celebrity Deathmatch
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51191
 Name   = Auto Modellista
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51192
 Name   = Harry Potter and the Chamber of Secrets
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51194
-Name   = Harry Potter - Kammer D Schreckens
-Region = PAL-Unk
+Name   = Harry Potter und die Kammer des Schreckens
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51195
 Name   = Harry Potter y La Camara Secreta
-Region = PAL-S
+	// Harry Potter y la Cámara Secreta
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51196
 Name   = Harry Potter e La Camera dei Secreti
@@ -8953,23 +8961,24 @@ vuClampMode = 2			//missing geometry with microVU
 ---------------------------------------------
 Serial = SLES-51198
 Name   = NBA Live 2003
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51199
 Name   = 4x4 Evolution II
-Region = PAL-Unk
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-51200
 Name   = Kelly Slater's Pro Surfer
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51201
 Name   = Kelly Slater's Pro Surfer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51202
 Name   = Wreckless - The Yakuza Missions
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51203
 Name   = Enter the Matrix
@@ -8979,11 +8988,11 @@ EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-51208
 Name   = Rocky
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51209
 Name   = Haven - Call of the King
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51214
@@ -8992,33 +9001,30 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51220
 Name   = Ty - The Tazmanian Tiger
-Region = PAL-5
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51222
 Name   = Rayman 3 - Hoodlum Havoc
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51223
 Name   = Runabout 3 - Neo Age
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51226
 Name   = Twin Caliber
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
+// German Censored Edition.
 ---------------------------------------------
 Serial = SLES-51227
 Name   = Tomb Raider - Angel of Darkness	// aka "TRAOD"
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M10
 Compat = 5
 //OPHFlagHack = 1 // 08.09.2014 not needed anymore and actually causes a hang
-[patches]
-	comment=- This gamedisc supports multiple languages and widescreen.
-	comment=- Language & widescreen selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-	comment=- Full boot is recommended anyway for this gamedisc to avoid textproblems.
-[/patches]
+// Language selection & Widescreen mode via BIOS settings (requires Full boot).
+// Full boot is recommended anyway for this gamedisc to avoid textdisplay-problems.
 ---------------------------------------------
 Serial = SLES-51229
 Name   = Virtua Cop - Elite Edition
@@ -9027,11 +9033,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51230
 Name   = Minority Report
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51232
 Name   = Virtua Tennis 2
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51233
@@ -9041,12 +9047,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51235
 Name   = Raging Blades
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51236
 Name   = Gungrave
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51244
 Name   = XIII
@@ -9055,26 +9061,26 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51247
 Name   = Inspector Gadget - Mad Robots Invasion
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51249
 Name   = Castleween
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51250
 Name   = Shox - Rally Reinvented
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51251
 Name   = Shox - Rally Reinvented
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51252
 Name   = Lord of the Rings, The - The Two Towers
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51253
@@ -9086,12 +9092,12 @@ Name   = Lord of the Rings, The - The Two Towers (Der Herr der Ringe - Die Zwei 
 Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51255
-Name   = Lord of the Rings, The - The Two Towers
-Region = PAL-Unk
+Name   = Lord of the Rings, The - The Two Towers (Il Signore degli Anelli - Le Due Torri)
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51256
 Name   = Lord of the Rings, The - The Two Towers (El Senor de Los Anillos - Las Dos Torres)
-Region = PAL-S
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51257
@@ -9101,70 +9107,71 @@ Compat = 3
 ---------------------------------------------
 Serial = SLES-51258
 Name   = James Bond 007 - Nightfire
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51260
 Name   = James Bond 007 - Nightfire
-Region = PAL-Unk
+Region = PAL-M2	// ES & GE
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51265
 Name   = Dynasty Warriors Tactics
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51266
 Name   = Dynasty Tactics
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51267
 Name   = Dynasty Tactics
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51271
 Name   = Mobile Suit Gundam - Federation vs. Zeon
-Region = PAL-Unk
+Region = PAL-M5	// Voices are in English.
 ---------------------------------------------
 Serial = SLES-51272
-Name   = Wakeboarding Unleashed
-Region = PAL-Unk
+Name   = Wakeboarding Unleashed featuring Shaun Murray
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51273
-Name   = Wakeboarding Unleashed
-Region = PAL-Unk
+Name   = Wakeboarding Unleashed featuring Shaun Murray
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51282
 Name   = Tiger Woods PGA Tour 2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51283
 Name   = WWE Smackdown! 4 - Shut Your Mouth
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51284
 Name   = Contra - Shattered Soldier
 Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51285
-Name   = Spongebob Squarepants - Revenge of the Flying Dutchman
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - Revenge of the Flying Dutchman
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51286
 Name   = X-Men 2 - Wolverine's Revenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51287
 Name   = X-Men 2 - Wolverine's Revenge
-Region = PAL-Unk
+	// La Vengeance de Wolverine
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51289
 Name   = Gunfighter 2 - Legend of Jesse James
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51290
 Name   = Sword of the Samurai
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51294
@@ -9173,46 +9180,47 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51296
 Name   = Grand Prix Challenge
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-51298
 Name   = Jimmy Neutron - Boy Genius
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51301
 Name   = SOS - The Final Escape
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51302
 Name   = Bomberman Kart
-Region = PAL-Unk
+Region = PAL-M3
 compat = 5
 ---------------------------------------------
 Serial = SLES-51303
 Name   = LEGO Dome Racers
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-51307
 Name   = Wild Arms 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51308
 Name   = Reel Fishing 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51311
 Name   = Rugrats Royal Ransom
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51312
 Name   = Rugrats Royal Ransom
-Region = PAL-Unk
+	// Nickelodeon Les Razmoket - La Rançon Royale
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51313
 Name   = Activision Anthology
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51315
 Name   = Great Escape, The
@@ -9221,48 +9229,49 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51316
 Name   = Grand Theft Auto - Vice City
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51317
 Name   = Minority Report
-Region = PAL-Unk
+	// Le Futur vous Rattrape
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51318
-Name   = Minority Report
-Region = PAL-Unk
+Name   = Minority Report - Everybody Runs
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51322
 Name   = Robotech Battlecry
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51333
 Name   = Dark Angel
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51339
 Name   = NFL 2K3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51340
 Name   = NBA 2K3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51341
 Name   = NHL 2K3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51343
 Name   = Galerians - Ash
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51344
 Name   = Guilty Gear X2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51345
 Name   = Run Like Hell
-Region = PAL-Unk
+Region = PAL-M5
 [patches = 945301BE]
 	comment=swapping a COP2 op into place to make the flags work without delays
 	patch=0,EE,001D4534,word,4A0002FF
@@ -9274,30 +9283,30 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51347
 Name   = Die Hard - Vendetta
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51348
 Name   = Die Hard - Vendetta
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51349
 Name   = Evolution Skateboarding
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51350
 Name   = Ben Hur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51354
 Name   = Jurassic Park - Operation Genesis
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51355
 Name   = Big Mutha Truckers
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51356
@@ -9307,54 +9316,55 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51357
 Name   = G1 Jockey 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51358
 Name   = Mystic Heroes
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51360
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51361
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51362
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51363
 Name   = Music 3000
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51365
 Name   = BMX XXX
-Region = PAL-Unk
+Region = PAL-M4
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 ---------------------------------------------
 Serial = SLES-51371
 Name   = Pride FC
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51372
 Name   = Wallace & Gromit in Project Zoo
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51374
 Name   = RoboCop
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51381
 Name   = Everblue 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51382
 Name   = Shrek - Super Party
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51383
 Name   = Beach King Stunt Racer
@@ -9363,78 +9373,81 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51385
 Name   = Rugrats Rescate Real
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51387
 Name   = World Racing
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51388
 Name   = Sega Bass Fishing Duel
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-51390
 Name   = Fightbox
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51391
 Name   = RTL Skispringen 2003
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-51392
 Name   = Evolution Snowboarding
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51393
 Name   = Syberia
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51397
 Name   = IndyCar Series
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51398
 Name   = World Championship Snooker 2003
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51399
 Name   = Armored Core 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51400
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+	// La Ira del Cielo
+Region = PAL-E	// Voices: English & Japanese (Videos)
 ---------------------------------------------
 Serial = SLES-51401
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-I	// Selection of Japanese Audio possible.
 ---------------------------------------------
 Serial = SLES-51402
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51403
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+	// La Colère Divine
+Region = PAL-F	// Voices: English & Japanese (Option menu)
 ---------------------------------------------
 Serial = SLES-51409
 Name   = Frogger Beyond
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51418
 Name   = Fisherman's Challenge
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51423
 Name   = Celtic - Club Football
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51433
 Name   = Ghost Vibration
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51434
 Name   = Silent Hill 3
@@ -9443,27 +9456,27 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51435
 Name   = International Superstar Soccer 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51436
 Name   = Chessmaster 9000
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51439
 Name   = Mortal Kombat - Deadly Alliance
-Region = PAL-G
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51441
 Name   = Dynasty Warriors 3 - Extreme Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51442
 Name   = Dynasty Warriors 3 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51443
 Name   = Dynasty Warriors 3 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51445
 Name   = Rygar - The Legendary Adventure
@@ -9471,32 +9484,32 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51448
 Name   = Resident Evil - Dead Aim
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51449
 Name   = Return to Castle Wolfenstein - Operation Resurrection
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51451
 Name   = Whiteout
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51456
 Name   = LMA Manager 2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51458
 Name   = BDFL Manager 2004
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51460
 Name   = Football Manager 2004
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51462
 Name   = Shrek Super Party
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51466
 Name   = Tom Clancy's Splinter Cell
@@ -9505,15 +9518,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51467
 Name   = Freedom Fighters
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51469
 Name   = Freedom Fighters
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51470
 Name   = Freedom Fighters
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51473
 Name   = Kya - Dark Lineage
@@ -9521,43 +9534,43 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51474
 Name   = Blood Rayne
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51476
 Name   = Mystic Heroes
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51477
 Name   = Mystic Heroes
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51479
 Name   = Def Jam Vendetta
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51481
 Name   = NBA Street 2
-Region = PAL-M2
+Region = PAL-M2	// UK & FR
 Compat = 5
 vuClampMode = 2		//missing environment with microVU
 ---------------------------------------------
 Serial = SLES-51482
 Name   = Downtown Run
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51488
 Name   = Tour de France, Le - Centenary Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51492
 Name   = Pro Beach Soccer
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51493
 Name   = Mr. Golf
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51495
 Name   = SX Superstar
@@ -9579,11 +9592,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51503
 Name   = Ace Lightning
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51504
 Name   = Chessmaster
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51507
 Name   = Futurama
@@ -9591,11 +9604,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51508
 Name   = Hulk, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51509
 Name   = World of Outlaws - Sprint Cars
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51510
 Name   = Dancing Stage Fever MegaMix
@@ -9604,20 +9617,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51511
 Name   = Crash Nitro Kart
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51523
 Name   = Conflict - Desert Storm II
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51525
 Name   = Fallout - Brotherhood of Steel
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51526
 Name   = Fallout - Brotherhood of Steel
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51541
 Name   = Grand Theft Auto - San Andreas
@@ -9625,38 +9638,41 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51547
 Name   = Next Generation Tennis 2003
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51548
 Name   = This is Football
-Region = PAL-I-S
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51553
 Name   = Chaos Legion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51554
 Name   = Cell Damage Overdrive
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51555
 Name   = Play It Pinball
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51557
 Name   = Broken Sword - The Sleeping Dragon
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51579
 Name   = Yu-Gi-Oh! - The Duelists of the Roses
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51580
-Name   = London Racer World Challenge
-Region = PAL-Unk
+Name   = London Racer - World Challenge
+	// France: Paris - Marseille Racing - Edition Tour du Monde
+	// Germany: Autobahn Raser - World Challenge
+	// Netherlands: A2 Racer - World Challenge
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51581
 Name   = Dead to Rights
@@ -9665,12 +9681,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51584
 Name   = F1 Career Challenge
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51588
 Name   = Evil Dead - A Fistful of Boomstick (with Bonus DVD Movie)
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51589
 Name   = Resident Evil - Outbreak
@@ -9678,53 +9694,55 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51590
 Name   = Cabela's Big Game Hunter
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51594
 Name   = Disney's Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51595
 Name   = Grand Theft Auto - Vice City
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot).
+// German Censored Edition.
 ---------------------------------------------
 Serial = SLES-51600
 Name   = WWE Crush Hour
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51602
 Name   = All-Stars Baseball 2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51603
 Name   = Seek & Destroy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51605
 Name   = Motorsiege - Warriors of Prime Time
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51606
 Name   = Unlimited Saga
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51615
 Name   = King of Route 66, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51616
-Name   = Virtua Fighter 4 Evolution
-Region = PAL-Unk
+Name   = Virtua Fighter 4 - Evolution
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51617
 Name   = Starsky & Hutch
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51618
 Name   = Starsky & Hutch
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-51619
 Name   = Clock Tower 3
@@ -9733,37 +9751,37 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51620
 Name   = Black and Bruised
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51621
 Name   = Dirt Track Devils
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51622
 Name   = Maxxed Out Racing
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51623
 Name   = Sniper 2, The
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51624
 Name   = Eternal Quest
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51625
 Name   = Ultimate Mindgames
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51629
 Name   = International Pool Championship
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51630
 Name   = Play It Chess Challenger
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51633
@@ -9772,24 +9790,24 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51636
 Name   = XGRA - Extreme G Racing Association
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51646
 Name   = Energy Airforce
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51649
 Name   = Judge Dredd vs. Judge Death
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51650
 Name   = Judge Dredd - Dredd vs. Death
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-51653
 Name   = Mace Griffin - Bounty Hunter
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51654
 Name   = Mace Griffin - Bounty Hunter
@@ -9797,23 +9815,23 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51658
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51659
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51660
 Name   = Risk - Global Domination
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51661
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51662
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51663
 Name   = Dynasty Warriors 4
@@ -9821,80 +9839,80 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51664
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51665
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51666
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51667
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51668
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-51670
 Name   = Alter Echo
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51671
 Name   = Alter Echo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51675
 Name   = Psyvariar
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51678
 Name   = Super Farm
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51680
 Name   = Splashdown 2 - Rides Gone Wild
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51681
 Name   = Splashdown 2 - Rides Gone Wild
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51682
 Name   = Headhunter - Redemption
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51686
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51687
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51688
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51689
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51690
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51693
 Name   = Suffering, The
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51696
 Name   = Dragon's Lair 3D - Special Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51697
 Name   = SSX 3
@@ -9907,78 +9925,78 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51699
 Name   = Virtua Fighter - 10th Anniversary Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51702
 Name   = Battlestar Galactica - Apostasy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51704
 Name   = XII Stag
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51705
 Name   = Ford Racing 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51707
 Name   = Secret Weapons Over Normandy
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51708
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51709
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51710
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51711
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51712
 Name   = Snowboard Racer 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51713
 Name   = Bust-A-Bloc
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51714
 Name   = BCV - Battle Construction Vehicles
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51715
 Name   = Seed, The - War Zone
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51716
 Name   = A-Train 6
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51717
 Name   = Boxing Champions
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51718
 Name   = League Series Baseball 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51720
 Name   = Disney's Extreme Skate Adventure
-Region = PAL-Unk
+Region = PAL-UK
 vuRoundMode = 0
 ---------------------------------------------
 Serial = SLES-51723
 Name   = Hobbit, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51731
 Name   = Bust-A-Block
@@ -9986,11 +10004,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51732
 Name   = EA Sports Rugby 2004
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51733
 Name   = EA SPORTS RUGBY 2004
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51735
 Name   = Perfect Ace - Pro Tournament Tennis
@@ -9998,16 +10016,16 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51741
 Name   = 1945 I & II - The Arcade Games
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51746
 Name   = Space Invaders - Invasion Day
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51749
 Name   = Mark Davis Pro Bass Challenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51750
 Name   = Charlie's Angels
@@ -10021,51 +10039,51 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51753
 Name   = True Crime - Streets of L.A.
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51754
 Name   = True Crime - Streets of L.A.
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51755
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51756
 Name   = Batman 2 - The Rise of Sin Tsu
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51757
 Name   = Dancing Stage Fever
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51758
 Name   = Metal Arms - Glitch in the System
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51759
 Name   = Maximo vs. Army of Zin
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51761
 Name   = Italian Job, The - L.A. Heist
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51765
 Name   = Volleyball Xciting
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51766
 Name   = Gladiator - Sword of Vengeance
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51772
 Name   = Bad Boys II
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51778
 Name   = Summer Heat Beach Volleyball
@@ -10078,21 +10096,21 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51783
 Name   = Starsky & Hutch
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51785
 Name   = Cool Shot
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51787
 Name   = Harry Potter - Quidditch World Cup
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-51792
 Name   = Aliens vs. Predator - Extinction
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51794
 Name   = Looney Toons - Back in Action
@@ -10101,11 +10119,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51797
 Name   = Madden NFL 2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51798
 Name   = NHL 2004
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51799
 Name   = Soul Calibur II
@@ -10114,27 +10132,27 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51800
 Name   = Smash Cars Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51806
 Name   = Evil Dead - A Fistful of Boomstick
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51812
 Name   = Homerun
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51813
 Name   = European Tennis Pro
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51814
 Name   = ATV Off-Road Fury 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51815
 Name   = Final Fantasy X-2
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51816
@@ -10152,20 +10170,20 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51819
 Name   = Final Fantasy X-2
-Region = PAL-S
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51821
 Name   = Alias
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51822
 Name   = Alias
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51823
 Name   = Hunter - The Reckoning Wayward
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51824
 Name   = Colin McRae Rally '04
@@ -10173,58 +10191,58 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51825
 Name   = Pop Idol
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51826
 Name   = AFL Live 2004
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51828
 Name   = Gladiator - Sword of Vengeance
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51831
 Name   = Sphinx and The Cursed Mummy
-Region = PAL-Unk
+Region = PAL-M5
 OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLES-51833
 Name   = Premier Manager 2003-2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51834
 Name   = Premier Manager 2003-2004
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51838
 Name   = Asterix & Obelix XXL2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51839
 Name   = DragonBall Z - Budokai 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51840
 Name   = NHL Hitz Pro
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51841
 Name   = SpyHunter 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51842
 Name   = Road Kill
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51843
 Name   = Worms 3D
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51845
-Name   = Barbie - Horse Adventure
-Region = PAL-Unk
+Name   = Barbie Horse Adventures - Wild Horse Rescue
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51846
 Name   = Deutschland sucht den Superstar
@@ -10232,13 +10250,13 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51848
 Name   = Tony Hawk's Underground
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51850
 Name   = Basketball Xciting
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51851
 Name   = Tony Hawk's Underground
@@ -10247,7 +10265,7 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51852
 Name   = Thug MOTX [Demo]
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51853
@@ -10257,74 +10275,74 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51854
 Name   = Tony Hawk Underground
-Region = PAL-Unk
+Region = PAL-E
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51855
 Name   = Tank Elite
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51856
 Name   = Monster Attack
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51859
 Name   = Billiards Xciting
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51860
 Name   = Tennis Court Smash
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51861
 Name   = Bowling Xciting
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51862
 Name   = Bass Master Fishing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51863
 Name   = Maze Action
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51864
 Name   = Police Chase Down
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51865
 Name   = Heartbeat Boxing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51867
 Name   = Dynasty Tactics 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51868
 Name   = Dynasty Tactics 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51869
 Name   = Dynasty Tactics 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51870
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-
+Region = PAL-M2	// ES & FI
 ---------------------------------------------
 Serial = SLES-51871
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-51872
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SLES-51873
 Name   = Medal of Honor - Rising Sun
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51874
@@ -10333,7 +10351,7 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51875
 Name   = Medal of Honor - Rising Sun
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51876
 Name   = Medal of Honor - Rising Sun
@@ -10341,20 +10359,20 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51877
 Name   = Bloody Roar 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51879
 Name   = Hot Wheels World Race
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51881
 Name   = Mercedes Bens World Racing
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-51883
 Name   = Scooby Doo! Mystery Mayhem
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51885
 Name   = MegaMan X7
@@ -10364,72 +10382,72 @@ eeClampMode = 3			//For camera issues in some scenes.
 ---------------------------------------------
 Serial = SLES-51886
 Name   = Lethal Skies 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51887
 Name   = Tiger Woods PGA Tour 2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51888
 Name   = RTL Skiijumping 2004
-Region = PAL-M2
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-51890
 Name   = Buffy the Vampire Slayer - Chaos Bleeds
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLES-51893
 Name   = Naval Ops - Warship Gunner
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51896
 Name   = Gallop Racer
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51897
 Name   = Simpsons, The - Hit & Run
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51903
 Name   = AFL Live 2004 - Aussie Rules Football
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51906
 Name   = Rolling
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51908
 Name   = Van Helsing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51911
 Name   = Gadget Racers
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51912
 Name   = Pro Evolution Soccer 3
 Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51913
-Name   = Onimusha Blade Warrior
-Region = PAL-Unk
+Name   = Onimusha - Blade Warriors
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51914
 Name   = Onimusha 3 - Demon Siege
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51915
 Name   = Pro Evolution Soccer 3
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51916
 Name   = Crouching Tiger, Hidden Dragon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51917
 Name   = Beyond Good and Evil
@@ -10442,7 +10460,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51924
 Name   = World War Zero - Ironstorm
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51925
@@ -10451,103 +10469,103 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51926
 Name   = Outlaw Golf
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51927
 Name   = Midway Arcade Treasures
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51930
 Name   = Road Rage 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51931
 Name   = Teenage Mutant Ninja Turtles
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51932
 Name   = Jimmy Neutron - Jet Fusion
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51933
 Name   = Gregory Horror Show
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 1
 ---------------------------------------------
 Serial = SLES-51934
 Name   = Curse - The Eye of Isis
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51946
 Name   = Robin Hood - Defender of the Crown
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-51947
 Name   = ESPN NFL 2K4
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51948
 Name   = ESPN NHL Hockey 2K4
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51949
 Name   = NBA 2K4
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51950
 Name   = Sonic Heroes
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51951
 Name   = Puyo Pop Fever
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51952
 Name   = R-Type Final
-Region = PAL-E
+Region = PAL-M3
 Compat = 5
 EETimingHack = 1 // Else serious slowdown due to VIF timing. Can be disabled once timing voodoo is fixed ;)
 ---------------------------------------------
 Serial = SLES-51953
 Name   = FIFA 2004
-Region = PAL-E-Sw
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51954
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-UK
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-51956
 Name   = Bionicle - The Game
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51957
 Name   = Terminator 3 - Rise of the Machines
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51958
 Name   = Whiplash
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51959
 Name   = Football Generation
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51963
 Name   = FIFA 2004
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-51964
 Name   = FIFA 2004
-Region = PAL-Unk
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-51966
 Name   = Bombastic
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51967
@@ -10557,25 +10575,25 @@ Compat = 5
 EETimingHack = 1	//broken textures
 ---------------------------------------------
 Serial = SLES-51968
-Name   = Spongebob Squarepants - Battle for Bikini Bottom
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - Battle for Bikini Bottom
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51970
-Name   = Spongebob Schwammkopf - Schlacht um Bikini Bottom
+Name   = SpongeBob Schwammkopf - Schlacht um Bikini Bottom
 Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51972
 Name   = NBA Jam 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51973
 Name   = War Chess
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51974
 Name   = XS Junior League Soccer
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51976
 Name   = Tom Clancy's Ghost Recon - Jungle Storm
@@ -10588,28 +10606,28 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51980
 Name   = TT Superbikes
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51981
 Name   = ShellShock - Nam '67
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51982
 Name   = ShellShock - Nam '67
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51986
 Name   = Backyard Wrestling - Don't Try This At Home
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51989
 Name   = Wallace & Gromit in Project Zoo
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51991
 Name   = Dance UK
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-51996
 Name   = International Snooker Championship
@@ -10617,76 +10635,80 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51997
 Name   = SWAT - Global Strike Team
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 eeClampMode = 3			//For grey screen ingame.
 ---------------------------------------------
 Serial = SLES-51998
 Name   = Kao the Kangaroo - Round 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51999
 Name   = GrooveRider Slot Car Thunder
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52001
 Name   = Mission Impossible - Operation Surma
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52002
 Name   = Rogue Ops
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52005
 Name   = James Bond 007 - Everything or Nothing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52008
 Name   = NBA Live 2004
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52011
 Name   = Tak and The Power of Juju
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52015
-Name   = Les Chevaliers de Baphomet
-Region = PAL-Unk
+Name   = Les Chevaliers de Baphomet - Le Manuscrit de Voynich
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52017
 Name   = Lord of the Rings, The - Return of the King
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52018
-Name   = Lord of the Rings, The - Return of the King (Der Herr der Ringe, Die Ruckkehr des Konigs)
+Name   = Lord of the Rings, The - Return of the King
+	// Der Herr der Ringe, Die Ruckkehr des Konigs
 Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52019
 Name   = Lord of the Rings, The - Return of the King
-Region = PAL-Unk
+	// Le Seigneur des Anneaux - Le Retour du Roi
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52020
 Name   = Lord of the Rings, The - The Return of the King
-Region = PAL-Unk
+	// El Señor de los Anillos - El Retorno del Rey
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52021
 Name   = Lord of the Rings, The - The Return of the King
-Region = PAL-Unk
+	// Il Signore degli Anelli - Il ritorno del Re
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52022
 Name   = Total Club Manager 2004
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52023
 Name   = Manhunt
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52025
 Name   = NFL Street
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52026
 Name   = Wallace & Gromit in Project Zoo
@@ -10703,36 +10725,36 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52028
 Name   = Junior Sports Basketball
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52034
 Name   = Dr. Seuss' Cat in the Hat
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52036
 Name   = WWE SmackDown! - Here Comes the Pain!
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52038
 Name   = Terminator 3 - Rise of the Machines
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52041
 Name   = Detonator
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52043
 Name   = MX Unleashed Migrated
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52044
 Name   = Crescent Suzuki Racing - Superbikes and Super Sidecars
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52045
 Name   = GTR 400
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52046
@@ -10742,74 +10764,74 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52047
 Name   = Sims, The - Bustin' Out
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52048
 Name   = Sims, The - Bustin' Out
-Region = PAL-Unk
+Region = PAL-M5	// UK & Nordic
 ---------------------------------------------
 Serial = SLES-52055
 Name   = Harry Potter and the Philosopher's Stone
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52056
 Name   = Harry Potter and The Philosopher's Stone
-Region = PAL-Unk
+Region = PAL-M11
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52058
 Name   = Groove Rider - Slot Car Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52060
 Name   = Fame Academy
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52061
 Name   = Star Academy
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52062
 Name   = Pop Star Academy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52063
 Name   = Alarm for Cobra 11 Autobahn
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-52065
 Name   = Flipnic
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52095
 Name   = Gradius V
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52096
 Name   = Firefighter F.D. 18
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52097
 Name   = SWAT - Global Strike Force
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 Compat = 5
 eeClampMode = 3			//For grey screen ingame.
 ---------------------------------------------
 Serial = SLES-52100
 Name   = NRL Rugby League
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52101
 Name   = Wrath Unleashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52102
 Name   = Hugo Bukkazoom!
-Region = PAL-Unk
+Region = PAL-M12
 ---------------------------------------------
 Serial = SLES-52103
 Name   = Tak & Le Pouvoir de Juju
@@ -10817,36 +10839,36 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52104
 Name   = Tak and the Power of JuJu
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52106
 Name   = Cabela's Dangerous Hunts
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52107
 Name   = Dance Europe
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52108
 Name   = Underworld - The Eternal War
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52109
 Name   = Underworld - The Eternal War
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52111
 Name   = Mojo!
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52116
 Name   = Sitting Duck
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52117
 Name   = Go Go Copter
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52118
 Name   = Castlevania - Lament of Innocence
@@ -10855,106 +10877,102 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52122
 Name   = Crime Life - Gang Wars
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52123
 Name   = EA Sports Cricket 2004
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52124
 Name   = Kill Switch
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52125
 Name   = Agassi Tennis Generation
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52132
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52133
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52134
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-I
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52135
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52136
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52143
 Name   = Carmen Sandiego - The Secret of the Stolen Drums
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-52149
 Name   = Tom Clancy's Splinter Cell - Pandora Tomorrow
 Region = PAL-M5
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-52150
 Name   = Legacy of Kain - Defiance
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52151
 Name   = Terminator 3 - Le Macchine Ribelli
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52152
 Name   = Terminator 3 - Rise of the Machines
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52153
 Name   = Driver 3
-Region = PAL-Unk
+Region = PAL-M2	// UK & ES
 ---------------------------------------------
 Serial = SLES-52159
 Name   = Myth Makers Super Kart GP
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52171
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52172
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52173
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52174
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52175
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52178
 Name   = Casino Challenge
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52179
 Name   = Kaan Barbarian Blade
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52187
@@ -10969,7 +10987,7 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52190
 Name   = RPM Tuning
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52202
@@ -10979,32 +10997,32 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52203
 Name   = Armored Core - Silent Line
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52204
 Name   = UFC Sudden Impact
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52209
 Name   = Star Trek - Shattered Universe
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52214
 Name   = Disney's The Haunted Mansion
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52216
 Name   = Disney's The Haunted Mansion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52219
 Name   = Corvette
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52230
 Name   = Muppets Party Cruise
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 EETimingHack = 1		//Path 3 masking errors
 ---------------------------------------------
 Serial = SLES-52237
@@ -11022,20 +11040,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52241
 Name   = Myth Makers - Orbs of Doom
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52242
 Name   = Dalmatians 3
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52243
 Name   = Dinosaur Adventure
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52244
 Name   = Legend of Herkules
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-52246
 Name   = Pool Paradise
@@ -11044,49 +11062,49 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52247
 Name   = Hobbit, The
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-52249
 Name   = Premier Manager 2003-2004
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52256
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-M2	// UK & ES
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52257
 Name   = P.T.O. IV - Pacific Theater of Operations IV
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52258
 Name   = Romance of the Three Kingdoms VIII
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52259
 Name   = Outlaw Volleyball
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52265
 Name   = Energy Airforce - Aim Strike!
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52266
 Name   = Energy Airforce - Aim Strike!
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52267
 Name   = Energy Airforce - Aim Strike!
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52275
 Name   = Way of the Samurai 2
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52276
 Name   = 187 - Ride or Die
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52277
@@ -11096,130 +11114,130 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52278
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-UK
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52279
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-G
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52280
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-F
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52282
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52283
 Name   = Terminator 3 - The Redemption
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52284
-Name   = Deadly Skies II
-Region = PAL-Unk
+Name   = Deadly Skies III
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52286
 Name   = Tak and The Poer of JuJu
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52287
 Name   = Tak and The Poer of JuJu
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52288
 Name   = Tom Clancy's Rainbow Six 3
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52289
 Name   = MTX Mototrax
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52290
 Name   = MTX Mototrax
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52291
 Name   = Countryside Bears
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52292
 Name   = Disney's Mighty Mulan
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52293
 Name   = Disney's Son of the Lion King
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52294
 Name   = Toys Room, The
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52295
 Name   = Master Chess
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52298
 Name   = IndyCar Series 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52308
 Name   = Karaoke Stage
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52309
 Name   = R - Racing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-52312
 Name   = World Championship Rugby
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-52313
 Name   = Space Invaders Anniversary
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52314
 Name   = Hugo - Bukkazoom
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-52322
 Name   = Drakengard
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 eeClampMode = 3			//characters are visible in-game.
 ---------------------------------------------
 Serial = SLES-52323
 Name   = Richard Burns Rally
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52325
 Name   = Champions of Norrath - Realms of EverQuest
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52326
 Name   = Spawn - Armageddon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52336
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 Compat = 5
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52337
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52338
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-M2	// UK & IT
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52339
@@ -11229,36 +11247,36 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52340
 Name   = Rollercoaster World
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52341
 Name   = X-Files - Resist or Serve
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52342
 Name   = Worms - Forts Under Seige
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52343
 Name   = Midway Arcade Treasures
-Region = PAL-Unk
+Region = PAL-UK	// German Censored Edition (does not include Smash T.V.).
 ---------------------------------------------
 Serial = SLES-52348
 Name   = Seven Samurai 20XX
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52349
 Name   = International Golf Pro
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52350
 Name   = International Golf Pro
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52358
 Name   = Glass Rose
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52362
@@ -11271,77 +11289,77 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52366
 Name   = America's 10 Most Wanted
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52367
 Name   = America's 10 Most Wanted
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52368
 Name   = AFL Live - Premiership Edition
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52369
 Name   = Empires of Atlantis
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52370
 Name   = Mouse Police, The
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52371
 Name   = Animal Soccer World
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52372
 Name   = Spider-Man 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52374
 Name   = Fight Night 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52378
 Name   = Euro Rally Champion
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1		//For dmac errors and so 3d is visible and steady.
 ---------------------------------------------
 Serial = SLES-52379
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52380
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52381
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52382
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52383
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52384
 Name   = Project Zero 2 - Crimson Butterfly
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52385
 Name   = England International Football
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52386
 Name   = World Championship Snooker 2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52387
 Name   = SpyHunter 2
@@ -11349,45 +11367,45 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52388
 Name   = Transformers Armada - Prelude to Energon [Special Edition]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-52393
 Name   = Pinball Fun
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52394
 Name   = UFEA Euro 2004
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52395
 Name   = UFEA Euro 2004
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-52396
 Name   = Euro 2004
-Region = PAL-Unk
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-52397
 Name   = Euro 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52398
 Name   = Euro 2004
-Region = PAL-Unk
+Region = PAL-M3	// UK, DA & SE
 ---------------------------------------------
 Serial = SLES-52402
 Name   = Perfect Ace 2 - The Championships
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52403
 Name   = Formula Challenge
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52404
 Name   = MTV Music Generator 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52413
 Name   = Malice
@@ -11396,7 +11414,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52418
 Name   = Powerdrome
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52423
 Name   = Smash Court Tennis - Pro Tournament 2
@@ -11404,21 +11422,21 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52433
 Name   = Goblin Commander - Unleash The Horde
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52439
 Name   = Suffering, The
-Region = PAL-E
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52440
 Name   = Harry Potter and the Prisoner of Azkaban
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 3
 ---------------------------------------------
 Serial = SLES-52444
 Name   = Hyper Street Fighter II - The Anniversary Edition
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52445
 Name   = Silent Hill 4 - The Room
@@ -11427,33 +11445,33 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52446
 Name   = Mashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52448
 Name   = Knights of the Temple
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52449
 Name   = Kidz Sports Basketball
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52450
 Name   = Serious Sam - Next Encounter
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52451
 Name   = Conan - The Dark Axe
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52457
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-52458
 Name   = Disgaea: Hour of Darkness
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52459
 Name   = Autobahn Raser - Das Spiel zum Film
@@ -11461,7 +11479,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52466
 Name   = Ribbit King
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52467
 Name   = dot Hack - Part 2 - Mutation
@@ -11480,15 +11498,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52471
 Name   = Naval Ops - Commander
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52472
 Name   = Project Minerva
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52477
 Name   = Vegas Casino II
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52478
 Name   = Red Dead Revolver
@@ -11497,52 +11515,52 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52479
 Name   = Samurai Jack - The Shadow of Aku
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52480
 Name   = Yu-Gi-Oh! - The Duelists of the Roses
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52481
 Name   = Hot Wheels - Stunt Track Challenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52482
 Name   = Steel Dragon EX
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52483
 Name   = World Championship Pool 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52486
 Name   = Astroboy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52490
 Name   = Dance UK - Extra Trax
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52493
 Name   = Spider-Man 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52495
 Name   = Bujingai - Swordmaster
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52504
 Name   = Trivial Pursuit Unhinged
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52505
 Name   = Spy Fiction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52507
 Name   = Def Jam - Fight for New York
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52508
@@ -11551,11 +11569,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52509
 Name   = Tiger Woods PGA Tour Golf 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52510
 Name   = Neo Contra
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 4
 [patches = EEE2F6A3]
 	//comment=Patches By Nachbrenner and Prafull
@@ -11572,68 +11590,70 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52511
 Name   = Headhunter - Redemption (EX)
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52512
 Name   = Headhunter - Redemption
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52515
 Name   = Ultimate Casino
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52516
 Name   = World Fighting
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52517
 Name   = Radio Helicopter
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52518
 Name   = Motorbike King
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-52519
 Name   = Pink Pong
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52520
 Name   = Volleyball Challenge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52521
 Name   = Adibou & Les Voleurs d'Energie
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52523
 Name   = Cocoto - Platform Jumper
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52525
 Name   = Mouse Trophy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52527
-Name   = Harry Potter og Fangen fra Azkaban
-Region = PAL-Unk
+Name   = Harry Potter and the Prisoner of Azkaban
+	// Harry Potter og Fangen fra Azkaban
+	// Harry Potter och Fången från Azkaban
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SLES-52531
 Name   = Suffering, The
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52532
 Name   = Aces of War
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52533
 Name   = Zoo Puzzle
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52534
 Name   = Crimson Tears
@@ -11646,16 +11666,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52536
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 2
 ---------------------------------------------
 Serial = SLES-52537
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52539
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52541
 Name   = Grand Theft Auto - San Andreas
@@ -11664,48 +11684,48 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52544
 Name   = Trivial Pursuit Unhinged
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52545
 Name   = Star Wars Battlefront
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52546
 Name   = Star Wars Battlefront
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52547
 Name   = Star Wars Battlefront
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52551
 Name   = Samurai Warriors
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52553
 Name   = Samurai Warriors
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52555
 Name   = Samurai Warriors
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52556
 Name   = Crimson Sea 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52557
 Name   = Crimson Sea 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52558
 Name   = Crimson Sea 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52559
 Name   = FIFA 2005
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52560
 Name   = FIFA 2005
@@ -11713,60 +11733,60 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52561
 Name   = FIFA 2005
-Region = PAL-Unk
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-52562
 Name   = FIFA 2005
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52563
 Name   = FIFA Football 2005
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52567
 Name   = Catwoman
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-52568
 Name   = Crash Twinsanity
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 XgKickHack = 1 //Fixes bad Geometry
 ---------------------------------------------
 Serial = SLES-52569
 Name   = Spyro - A Hero's Tail
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52570
 Name   = Area 51
-Region = PAL-R
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52571
 Name   = Pacific Air Warriors 2 - Dogfight
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52572
 Name   = Operation Air Assault
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52573
 Name   = Conflict - Global Storm
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52576
 Name   = Yu-Gi-Oh! - Capsule Monster Colisee
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52579
 Name   = Legends of Wrestling - Showdown
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52581
 Name   = Madden NFL 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52584
 Name   = Burnout 3 - Takedown
@@ -11775,40 +11795,40 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52585
 Name   = Burnout 3 - Takedown
-Region = PAL-F-G-I
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52587
 Name   = Army Men - Sarge's War
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52588
 Name   = Mercenaries
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52590
 Name   = Mercenaries
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52591
 Name   = Dynasty Warriors 4 - Empires
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52592
 Name   = Dynasty Warriors 4 - Empires
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52593
 Name   = Dynasty Warriors 4 - Empires
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52594
 Name   = U-Move SuperSports
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52598
 Name   = Dancing Stage Fusion
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52599
@@ -11821,7 +11841,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52601
 Name   = Ex Zeus
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52602
 Name   = GT Racers
@@ -11830,7 +11850,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52603
 Name   = Room Zoom - Race for Impact
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52605
 Name   = Polar Express, The
@@ -11838,71 +11858,71 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52616
 Name   = Video Poker & Blackjack
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52617
 Name   = Stock Car Speedway
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52620
 Name   = Guncom 2
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52621
 Name   = Tony Hawk's Underground 2
-Region = PAL-Unk
+Region = PAL-UK
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-52622
 Name   = Tony Hawk's Underground 2
-Region = PAL-Unk
+Region = PAL-M4
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-52624
 Name   = X-Men Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52625
 Name   = X-Men Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52628
 Name   = NBA Ballers
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52630
 Name   = Conflict - Vietnam
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52631
 Name   = Digimon Rumble Arena 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 FpuCompareHack = 1
 ---------------------------------------------
 Serial = SLES-52636
 Name   = Colin McRae Rally 2005
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52637
 Name   = TOCA Racer Driver 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52638
 Name   = DTM Race Driver 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52639
 Name   = V8 Supercars 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52641
 Name   = Leisure Suit Larry: Magna Cum Laude (Uncut)
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52642
 Name   = Leisure Suit Larry: Magna cum Laude
@@ -11914,7 +11934,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52644
 Name   = Leisure Suit Larry: Magna Cum Laude
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52645
 Name   = Leisure Suit Larry: Magna cum Laude
@@ -11922,95 +11942,95 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52646
 Name   = Tom Clancy's Ghost Recon 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52647
-Name   = Club Football - Manchester United 2005
-Region = PAL-Unk
+Name   = Club Football 2005 - Manchester United
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52648
 Name   = BVB 09 - Club Football 2005 - Borussia Dortmund
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52649
-Name   = Om Droit au Bit - Club Football 2005
-Region = PAL-Unk
+Name   = Om Droit au Bit - Club Football 2005 - Olympique de Marseille
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-52650
 Name   = Juventus - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52651
 Name   = FC Barcelona - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52652
 Name   = Liverpool FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52653
 Name   = Liverpool FC - Club Football 2005
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52654
-Name   = Club Football - Real Madri 2005
-Region = PAL-Unk
+Name   = Club Football 2005 - Real Madrid
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52655
 Name   = FC Bayern Munich - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52656
-Name   = AC Milan Club Football 2005
-Region = PAL-Unk
+Name   = AC Milan - Club Football 2005
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52657
 Name   = Arsenal FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-52658
 Name   = Hamburg SV - Club Football 2005
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52659
-Name   = Paris Saint-Germain Club Football 2005
-Region = PAL-Unk
+Name   = Paris Saint-Germain - Club Football 2005
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-52660
 Name   = Inter - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52661
-Name   = Ajax Club Football 2005
-Region = PAL-Unk
+Name   = Ajax Amsterdam - Club Football 2005
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52662
 Name   = Newcastle United - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52663
 Name   = Chelsea FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52664
 Name   = Rangers FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52665
 Name   = Celtic FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52666
 Name   = Tottenham Hotspur - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52667
 Name   = Birmingham City - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52668
 Name   = Aston Villa FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52669
 Name   = Forgotten Realms - Demon Stone
@@ -12023,16 +12043,16 @@ Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52671
-Name   = Ghostmaster
-Region = PAL-Unk
+Name   = Ghost Master - The Gravenville Chronicles
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52673
 Name   = NHL 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52674
 Name   = Fussball Manager 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52675
 Name   = Hugo Cannon Cruise
@@ -12044,7 +12064,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52680
 Name   = Intellivision Lives - The History of Video Gaming
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52684
 Name   = Cyclone Circus - Power Sail Racing
@@ -12053,15 +12073,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52685
 Name   = Polar Express, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52686
 Name   = Backyard Wrestling - There Goes the Neighborhood
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52693
 Name   = LMA Manager 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52694
 Name   = BDFL Manager 2005
@@ -12073,102 +12093,104 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52697
 Name   = Manager de la Liga 2005
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52700
 Name   = Jimmy Neutron - Attack of the Twonkies
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52701
 Name   = Future Tactics - The Uprising
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52702
 Name   = Psi-Ops - The Mindgate Conspiracy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52703
 Name   = Psi-Ops - The Mindgate Conspiracy
-Region = PAL-Unk
+Region = PAL-M5	// German Censored Edition.
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-52705
 Name   = Mortal Kombat - Deception
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52706
 Name   = Mortal Kombat - Deception
-Region = PAL-Unk
+Region = PAL-M5	// German Edition.
 ---------------------------------------------
 Serial = SLES-52707
 Name   = Monster Hunter
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52709
 Name   = Ty the Tazmanian Tiger 2 - Bush Rescue
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-52710
 Name   = McFarlane's Evil Prophecy
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52711
 Name   = Titeuf Mega Compet
-Region = PAL-Unk
+	// Titeuf Méga-compet'
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52713
 Name   = NBA Live 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52714
 Name   = Board Games Gallery
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52716
 Name   = Energy Thieves, The
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52717
 Name   = Brian Lara Cricket 2005
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52718
 Name   = Fight Club
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52719
 Name   = Under the Skin
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52720
 Name   = Ford Racing 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52725
 Name   = Need for Speed - Underground 2
-Region = PAL-E
+Region = PAL-M8
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52726
 Name   = NBA Live 2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52727
 Name   = NBA Live 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52729
 Name   = Animaniacs - The Great Edgar Hunt
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52730
 Name   = DragonBall Z - Budokai 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52731
@@ -12177,19 +12199,19 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52733
 Name   = Driven to Destruction
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52734
 Name   = Worms Forts - Under Siege
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52737
 Name   = Obscure
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52738
 Name   = Obscure
-Region = PAL-Unk
+Region = PAL-M2	// FR & IT
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52745
@@ -12198,51 +12220,52 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52747
 Name   = Dukes of Hazzard, The - The Return of General Lee
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52749
 Name   = Habitrail - Hamster Ball
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52750
 Name   = Monster Trux Extreme
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52751
 Name   = Offroad Extreme!
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52752
 Name   = Playboy - The Mansion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52753
 Name   = Flatout
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52754
 Name   = FlatOut
-Region = PAL-Unk
+Region = PAL-G
+// Censored version.
 ---------------------------------------------
 Serial = SLES-52755
 Name   = Blood Will Tell
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52760
 Name   = Pro Evolution Soccer 4
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52761
 Name   = Rocky - Legends
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52766
 Name   = Godzilla - Save The Earth
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52767
@@ -12251,15 +12274,15 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52768
 Name   = Commandos - Strike Force
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52773
 Name   = Pool Shark 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52774
 Name   = Sprint Car Challenge
-Region = PAL-E
+Region = PAL-M6
 Compat = 2
 ---------------------------------------------
 Serial = SLES-52776
@@ -12269,7 +12292,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52778
 Name   = Arcade, The
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52779
@@ -12278,11 +12301,11 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52781
 Name   = WWE SmackDown! vs. RAW
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52782
 Name   = Call of Duty - Finest Hour
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52783
 Name   = Call of Duty - Le Jour de Glorie
@@ -12294,11 +12317,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52798
 Name   = Vietcong - Purple Haze
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52799
 Name   = Vietcong - Purple Haze
-Region = PAL-Unk
+Region = PAL-M2	// UK & IT
 ---------------------------------------------
 Serial = SLES-52800
 Name   = Pro Evolution Soccer 4
@@ -12310,43 +12333,55 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52802
 Name   = Lord of the Rings, The - The Third Age
+	// Le Seigneur des Anneaux - Le Tiers Age
 Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52803
-Name   = Lord of the Rings, The - The Third Age (Der Herr der Ringe - Das dritte Zeitalter)
+Name   = Lord of the Rings, The - The Third Age
+	// Der Herr der Ringe - Das dritte Zeitalter
 Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52804
 Name   = Lord of the Rings, The - The Third Age
-Region = PAL-Unk
+	// Il Signore degli Anelli - La Terza Era
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52805
 Name   = Lord of the Rings, The - The Third Age
-Region = PAL-S
+	// El Señor de los Anillos - La Tercera Edad
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52807
 Name   = Lemony Snicket's A Series of Unfortunate Events
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52808
 Name   = Lemony Snicket's A Series of Unfortunate Events
-Region = PAL-Unk
+	// Les Désastreuses Aventures des Orphelins Baudelaire - D'Apres Lemony Snicket
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52809
-Name   = Lemony Snicket - Schauriger Schlamassel
-Region = PAL-Unk
+Name   = Lemony Snicket's A Series of Unfortunate Events
+	// Rätselhafte Ereignisse
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52810
-Name   = Lemony Snicket's Una Serie Disfortunati Eventi
-Region = PAL-Unk
+Name   = Lemony Snicket's A Series of Unfortunate Events
+	// Una Serie Disfortunati Eventi
+Region = PAL-I
+---------------------------------------------
+Serial = SLES-52825
+Name   = Lemony Snicket's A Series of Unfortunate Events
+	// Una Serie de Catastróficas Desdichas de Lemony Snicket
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52811
 Name   = Get on da Mic
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52812
 Name   = Disney-Pixar's The Incredibles
-Region = PAL-Unk
+Region = PAL-UK
 [patches = EBDB6E4B]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12355,19 +12390,19 @@ patch=1,EE,0010ec20,word,00000000
 ---------------------------------------------
 Serial = SLES-52813
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SLES-52814
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52815
 Name   = Disney-Pixar's The Incredibles
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52816
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-E
 [patches = 197641AA]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12376,11 +12411,12 @@ patch=1,EE,0010ec20,word,00000000
 ---------------------------------------------
 Serial = SLES-52820
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SLES-52821
 Name   = Incredibles, The
-Region = PAL-Unk
+	// Os Super-Heróis
+Region = PAL-PO
 ---------------------------------------------
 Serial = SLES-52822
 Name   = Prince of Persia - Warrior Within
@@ -12389,11 +12425,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52824
 Name   = Furry Tales
-Region = PAL-Unk
----------------------------------------------
-Serial = SLES-52825
-Name   = Lemony Snicket's A Series of Unfortunate Events
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-52831
 Name   = Syberia 2
@@ -12402,33 +12434,33 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52832
 Name   = MegaMan X - Command Mission
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52834
 Name   = Sega Superstars Eyetoy Bundle
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 1
 ---------------------------------------------
 Serial = SLES-52835
 Name   = Mummy, The
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52836
 Name   = Knight Rider 2
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52843
 Name   = Garfield
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52844
 Name   = Midway Arcade Treasures 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52845
 Name   = Gadget and the Gadgetinis
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52852
 Name   = Capcom Fighting Jam
@@ -12436,58 +12468,58 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52853
 Name   = Miami Vice
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52854
 Name   = Capcom Fighting Jam
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52857
 Name   = Fairly Odd Parents, The - Shadow Showdown
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52858
 Name   = Cocoto Kart Racer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52859
 Name   = Project - Snowblind
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52861
 Name   = King Arthur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52863
 Name   = Pinball Hall of Fame
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52864
 Name   = MX World Tour
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52867
 Name   = Spindrive Ping Pong
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52868
 Name   = Viewtiful Joe 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52872
 Name   = Constantine
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52874
-Name   = Dark Wind (with Gametrak)
-Region = PAL-Unk
+Name   = Dark Wind
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52876
 Name   = King of Fighters 2000-2001
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52877
 Name   = Haunting Ground
@@ -12501,19 +12533,19 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52884
 Name   = Duel Masters
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52885
 Name   = Sega Superstars
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52886
 Name   = Power Rangers Dino Thunder
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52887
 Name   = Power Rangers Dino Thunder
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52888
 Name   = Brothers in Arms: Road to Hill 30
@@ -12521,11 +12553,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52889
 Name   = Disney's Winnie the Pooh Rumbly Tumbly Adventure
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52895
-Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - The Movie
+Region = PAL-UK
 Compat = 2
 [patches = 536FEB77]
 comment= Patch By Prafull
@@ -12534,75 +12566,76 @@ patch=1,EE,0010f3e0,word,00000000
 [/patches]
 ---------------------------------------------
 Serial = SLES-52896
-Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - The Movie
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SLES-52898
 Name   = King of Fighters - Maximum Impact
-Region = PAL-Unk
+Region = PAL-M2	// UK & JP
 ---------------------------------------------
 Serial = SLES-52900
 Name   = Rapala Pro Fishing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52902
 Name   = Arcade Classics Vol.1
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52906
-Name   = Spongebob and Friends - Movin'
-Region = PAL-Unk
+Name   = SpongeBob and Friends - Movin'
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52908
 Name   = Urbz, The - Sims in the City
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52909
 Name   = UEFA Champions League 2004-2005
-Region = PAL-E-G
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52910
 Name   = UEFA Champions League 2005
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-52911
 Name   = UEFA Champions League 2005
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-52912
 Name   = UEFA Champions League 2005
-Region = PAL-Unk
+Region = PAL-M2	// UK & DU
 ---------------------------------------------
 Serial = SLES-52913
 Name   = Suikoden IV
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52915
 Name   = Shark Tale
-Region = PAL-Unk
+	// Hajar som Hajar
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-52917
 Name   = Scaler
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52918
 Name   = Scaler
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52919
 Name   = NRL Rugby League 2
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52921
 Name   = Rogue Trooper
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52922
 Name   = EyeToy - Disney Move
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52927
 Name   = Grand Theft Auto - San Andreas
@@ -12615,31 +12648,31 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52939
 Name   = Airborne Troops - Countdown to D-Day
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52940
 Name   = S.L.A.I. Steel Lancer Arena International
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52941
 Name   = Gungrave - Overdose
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52942
 Name   = Midnight Club 3 - DUB Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52943
 Name   = ESPN NFL 2K5
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52944
 Name   = Robotech - Invasion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52949
 Name   = Arcade Action - 30 Games
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52950
 Name   = Shadow of Rome
@@ -12648,41 +12681,41 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52951
 Name   = Phantom Brave
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52954
 Name   = WWII - Tank Battles
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52955
 Name   = Deadly Strike
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52956
 Name   = Action Girlz Racing
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52957
 Name   = Urban Extreme
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52958
 Name   = Premier Manager 2004-2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52960
 Name   = Premier Manager 2004-2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52961
 Name   = Premier Manager 2004-2005
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52963
 Name   = Cold Winter
-Region = PAL-Unk
+Region = PAL-M4
 vuClampMode = 2 //fixes rainbow graphics
 ---------------------------------------------
 Serial = SLES-52964
@@ -12692,16 +12725,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52965
 Name   = Outlaw Golf 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52966
 Name   = ESPN NHL 2K5
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52967
 Name   = Guilty Gear X2 Reloaded
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52968
@@ -12711,47 +12744,48 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52973
 Name   = Ski Racing 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52974
 Name   = GoldenEye - Rogue Agent
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52975
 Name   = GoldenEye - Au Service du Mal
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52976
 Name   = GoldenEye - Rogue Agent
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52977
-Name   = GoldenEye - Rogue Agent
-Region = PAL-Unk
+Name   = GoldenEye - Agente Corrupto
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52978
-Name   = La Pucelle Tactics
-Region = PAL-Unk
+Name   = La Pucelle - Tactics
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52980
-Name   = Big Mutha Truckers 2
-Region = PAL-Unk
+Name   = Big Mutha Truckers 2 - Truck Me Harder
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52982
 Name   = NFL Street 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52983
 Name   = Fitness Fun
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52984
-Name   = Panzer Front Ausf B
-Region = PAL-Unk
+Name   = Panzer Front Ausf.B
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52985
-Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - The Movie
+	// SpongeBob Schwammkopf - Der Film
+Region = PAL-G
 [patches = B3C11E2D]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12759,8 +12793,9 @@ patch=1,EE,0010f3e0,word,00000000
 [/patches]
 ---------------------------------------------
 Serial = SLES-52986
-Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - The Movie
+	// Bob Esponja - La Película
+Region = PAL-E
 [patches = 34DA05D2]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12769,91 +12804,87 @@ patch=1,EE,0010f3e0,word,00000000
 ---------------------------------------------
 Serial = SLES-52988
 Name   = MegaMan X8
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52989
 Name   = Blowout
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-52993
 Name   = TimeSplitters - Future Perfect
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52998
 Name   = Sonic Mega Collection Plus
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52999
 Name   = RC Toy Machines
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53000
 Name   = Crazy Golf
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53001
 Name   = NBA Street 3
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53002
 Name   = Samurai Warriors Xtreme Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53003
 Name   = Samurai Warriors Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53004
 Name   = Samurai Warriors Xtreme Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53005
 Name   = Monster Trux - Off-Road Edition
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53006
 Name   = Hamster Heroes
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53007
 Name   = Tom Clancy's Splinter Cell - Chaos Theory
 Region = PAL-M5
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53011
 Name   = Gallop Racer 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53012
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53013
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53014
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53015
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53016
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53017
 Name   = Teenage Mutant Ninja Turtles 2 - Battle Nexus
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53020
 Name   = Ghost in the Shell - Stand Alone Complex
@@ -12893,36 +12924,37 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53022
 Name   = ESPN NBA 2K5
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53023
 Name   = RTL Ski Jump 2005
-Region = PAL-Unk
+	// RTL Skispringen 2005
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53024
 Name   = Altered Beast
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53025
 Name   = Red Ninja - End of Honor
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53026
 Name   = Red Ninja - End of Honor
-Region = PAL-Unk
+Region = PAL-UK	// German Censored Edition.
 ---------------------------------------------
 Serial = SLES-53027
 Name   = Championship Manager 5
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SLES-53028
 Name   = Hitman - Blood Money
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53029
 Name   = Hitman - Blood Money
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53030
 Name   = Hitman - Blood Money
@@ -12930,20 +12962,20 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53031
 Name   = Hitman - Blood Money
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53032
 Name   = Hitman - Blood Money
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53035
 Name   = Masters of the Universe - He-Man - Defender of Greyskull
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53036
 Name   = Tak 2 - The Stuff of Dreams
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53037
 Name   = Super Monkey Ball Deluxe
@@ -12952,128 +12984,129 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53038
 Name   = Devil May Cry 3 - Dante's Awakening
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 eeRoundMode = 0
 ---------------------------------------------
 Serial = SLES-53039
 Name   = Champions - Return to Arms	// aka "Champions of Norrath 2"
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-53041
 Name   = RTL Ski Alpine 2005
-Region = PAL-Unk
+	// Alpine Skiing 2005
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53044
 Name   = Juiced
-Region = PAL-R
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53045
 Name   = Street Racing Syndicate
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53046
 Name   = CT Special Forces - Fire for Effect
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53047
 Name   = Punisher, The
-Region = PAL-M2
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-53049
 Name   = Punisher, The
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-53052
 Name   = Robots
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53058
 Name   = Ricky Ponting International Cricket
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53059
 Name   = Samurai Showdown V
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53060
 Name   = Asterix & Obelix XXL 2 - Mission Las Vegum
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53061
 Name   = Atari Anthology
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53062
 Name   = Yu Yu Hakuhso - Dark Tournament
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53064
 Name   = FIFA Street
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53065
 Name   = SNK vs. Capcom - SVC Chaos
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53073
 Name   = Michigan : Report from Hell
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53074
 Name   = Soccer Life
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53075
 Name   = Area 51
-Region = PAL-Unk
+Region = PAL-M5	// German Censored Edition.
 ---------------------------------------------
 Serial = SLES-53076
 Name   = Triggerman
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53078
 Name   = Spy vs. Spy
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53079
 Name   = Ys - The Ark of Napishtim
-Region = PAL-Unk
+Region = PAL-M5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53080
 Name   = Extreme Sprint 3010
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53082
 Name   = World Championship Snooker 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53084
 Name   = Fight Night Round 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53087
 Name   = TOCA Race Driver 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53088
 Name   = DTM Race Driver 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53089
 Name   = V8 Supercars 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53090
 Name   = Circuit Blasters
@@ -13081,185 +13114,190 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53091
 Name   = Predator - Concrete Jungle
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53092
 Name   = Motocross Mania 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53093
 Name   = Cold Winter
-Region = PAL-Unk
+Region = PAL-G	// German Censored Edition.
 vuClampMode = 2 //fixes rainbow graphics
 ---------------------------------------------
 Serial = SLES-53094
 Name   = Rugby 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53095
 Name   = Rugby 2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53096
 Name   = Worms 4 - Mayhem
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53098
 Name   = Conspiracy - Weapons of Mass Destruction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53099
 Name   = Pilot Down - Behind Enemy Lines
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53100
 Name   = Scooby Doo! Unmasked
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53104
 Name   = Tom Clancy's Rainbow Six - Lockdown
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53106
 Name   = MX vs. ATV Unleashed
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53107
 Name   = Cabela's Big Game Hunter 2005 Adventures
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53108
 Name   = American Chopper
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53114
 Name   = Full Spectrum Warrior
-Region = PAL-Unk
+Region = PAL-M5
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53119
 Name   = Kessen III
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53120
 Name   = Kessen III
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53121
 Name   = Kessen III
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53124
 Name   = Project Snowblind
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53125
 Name   = Enthusia - Professional Racing
-Region = PAL-Unk
+Region = PAL-M5
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-53127
 Name   = Teenage Mutant Ninja Turtles - Mutant Melee
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53129
 Name   = Tak 2 - The Staff of Dreams
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53130
 Name   = World Championship Poker
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 ---------------------------------------------
 Serial = SLES-53131
 Name   = Full Spectrum Warrior
-Region = PAL-R
+Region = PAL-UK
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53138
 Name   = Outlaw Volleyball - Remixed
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53139
 Name   = Alien Humanoid
-Region = PAL-Unk
+Region = PAL-M6
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53140
 Name   = Choro Q
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53141
 Name   = X-Treme Quads
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53142
 Name   = Doomsday Racers
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53143
 Name   = Fantastic Four
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53144
-Name   = Four Fantastiques, Les
-Region = PAL-Unk
+Name   = Quatre Fantastiques, Les
+	// Fantastic Four
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53145
 Name   = Fantastic Four
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53146
 Name   = I Fantastici Quattro
-Region = PAL-Unk
+	// Fantastic Four
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53147
-Name   = Four Fantasticos, Los
-Region = PAL-Unk
+Name   = Cuatro Fantasticos, Los
+	// Fantastic Four
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53148
 Name   = Fruitfall
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53150
 Name   = 10 Pin - Champions' Alley
-Region = PAL-Unk
+Region = PAL-M6
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 ---------------------------------------------
 Serial = SLES-53151
 Name   = Juiced
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53152
 Name   = Mashed Fully Loaded
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53154
 Name   = The Bard's Tale
-Region = PAL-M4	// Multiple languages
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+Region = PAL-M8
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53155
 Name   = Star Wars - Episode III - Revenge of the Sith
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53156
 Name   = Star Wars - Episode III - La Revanche des Sith
-Region = PAL-Unk
+	// Revenge of the Sith
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53157
 Name   = Star Wars - Episode III - Die Rache der Sith
-Region = PAL-Unk
+	// Revenge of the Sith
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53158
 Name   = Cold Fear
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53172
@@ -13268,55 +13306,55 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53174
 Name   = Golden Age of Racing
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53175
 Name   = Top Spin
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53186
 Name   = International Super Karts
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53190
 Name   = Girl Zone
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53191
 Name   = Kaido Racer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53192
 Name   = Nightmare Before Christmas, The - Tim Burton's
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53194
 Name   = LEGO Star Wars
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53195
 Name   = Punisher, The
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53196
 Name   = Destroy All Humans!
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53197
 Name   = Destroy All Humans!
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53199
 Name   = 25 to Life
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53200
 Name   = DragonBall Z - Budokai Tenkaichi
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53201
@@ -13326,48 +13364,50 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53203
 Name   = Punisher, The
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53218
 Name   = Dancing Stage MAX
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53219
 Name   = Winx Club
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53221
-Name   = l'Entraineur 5
-Region = PAL-Unk
+Name   = L'Entraineur 5
+	// L'Entraîneur 5 - Saison 04/05
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53222
 Name   = Scudetto 5
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53223
 Name   = Championship Manager 5
-Region = PAL-Unk
+Region = PAL-PO
 ---------------------------------------------
 Serial = SLES-53224
 Name   = Championship Manager 5
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53225
 Name   = Dreamworks' Madagascar
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53226
 Name   = Dreamworks' Madagascar
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53227
 Name   = Madagascar
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53233
 Name   = Assault Suits Valken
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53234
 Name   = Samurai Western
@@ -13376,20 +13416,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53235
 Name   = Syberia II
-Region = PAL-Unk
+Region = PAL-R
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53236
 Name   = Buzzrod Fishing Fantasy
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53237
 Name   = Fire Heroes
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53238
 Name   = Premier Manager 2005-2006
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53242
 Name   = Madagascar
@@ -13397,7 +13437,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53246
 Name   = Madagascar
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53280
 Name   = 7 Sins
@@ -13406,16 +13446,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53281
 Name   = Fantastic Four
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53282
 Name   = Harvest Fishing
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53284
 Name   = Guilty Gear Isuka
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53287
@@ -13424,17 +13464,17 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53296
 Name   = Ford Mustang - The Legend Lives
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53297
 Name   = 7 Sins
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53299
 Name   = Delta Force - Black Hawk Down
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53300
 Name   = SOCOM 3 - U.S. Navy SEALs
@@ -13442,12 +13482,13 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53301
 Name   = Bomberman Hardball
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53303
 Name   = Skijumping 2006
-Region = PAL-Unk
+	// RTL Skispringen 2006
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53309
 Name   = Transformers
@@ -13456,11 +13497,11 @@ VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-53311
 Name   = Graffiti Kingdom
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53317
 Name   = Black Market Bowling
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53318
 Name   = Crazy Golf - World Tour
@@ -13468,44 +13509,44 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53319
 Name   = Resident Evil Outbreak - File #2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53320
 Name   = S.C.A.R. - Squadra Corse Alfa Romeo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53322
 Name   = Obscure
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53332
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53333
 Name   = Medal of Honor - Les Faucons de Guerre
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53334
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53335
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53336
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53338
 Name   = Victorious Boxers 2 - Fighting Spirit
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53339
 Name   = Dynasty Warriors 5
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53341
 Name   = Dynasty Warriors 5
@@ -13514,50 +13555,50 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53342
 Name   = EA Sports Cricket 2005
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53344
 Name   = Gerrilla Strike
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53346
 Name   = DragonBall Z - Budokai 3 [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53350
 Name   = Sonic Gems Collection
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53351
 Name   = SSX On Tour
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53354
 Name   = Superbike GP
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53356
 Name   = Colosseum - Road to Freedom
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53357
 Name   = Colosseum - Road to Freedom
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53360
 Name   = Alarm for Cobra 11 Vol.2 - Hot Pursuit
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53361
 Name   = Stealth Force - The War on Terror
-Region = PAL-E
+Region = PAL-M2	// UK & ES
 ---------------------------------------------
 Serial = SLES-53362
 Name   = Alpine Skiing 2005
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53363
 Name   = Shin Megami Tensei: Lucifer's Call
@@ -13571,29 +13612,29 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53367
 Name   = Dodgeball
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53368
 Name   = Splatter Master
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53369
 Name   = Twenty-2 Party
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53370
-Name   = Real World Golf [with Gametrak]
-Region = PAL-Unk
+Name   = Real World Golf
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53371
-Name   = Real World Golf [with Gametrak]
-Region = PAL-Unk
+Name   = Real World Golf
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53373
 Name   = Madagascar
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53374
 Name   = X-Men Legends II - Rise of Apocalypse
@@ -13601,106 +13642,106 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53377
 Name   = X-Men Legends II - Rise of Apocalypse
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-53380
 Name   = Metal Slug 4
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53381
 Name   = King of Fighters 2002
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53382
 Name   = King of Fighters 2003
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53383
 Name   = Metal Slug 5
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53386
 Name   = Charlie and the Chocolate Factory
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53387
 Name   = Batman Begins
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53390
 Name   = Ultimate Spider-Man
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53391
 Name   = Ultimate Spider-Man
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53393
-Name   = Spartan Total Warrior
-Region = PAL-Unk
+Name   = Spartan - Total Warrior
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53398
 Name   = Zombie Zone
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53399
 Name   = Yakuza Fury
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53402
 Name   = Taxi Rider
-Region = PAL-E
+Region = PAL-UK
 Compat = 4
 ---------------------------------------------
 Serial = SLES-53403
 Name   = Demolition Girl
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53405
 Name   = Digimon World 4
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53406
 Name   = Party Girls
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53407
 Name   = Street Boyz
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53408
 Name   = Fighting Angels
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53411
 Name   = Kuon
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53414
 Name   = Echo Night - Beyond
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53415
 Name   = Call of Duty 2 - Big Red One
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53416
 Name   = Call of Duty 2 - Big Red One
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53417
 Name   = Call of Duty 2 - Big Red One
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53418
 Name   = Tak - The Great JuJu Challenge
@@ -13708,32 +13749,33 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53419
 Name   = LA Rush
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53424
 Name   = Dead to Rights 2
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53430
 Name   = Incredible Hulk 2, The - Ultimate Destruction
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53433
 Name   = NHL '06
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53434
 Name   = WWI - Red Baron
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53435
 Name   = SAS Anti-Terror Force
-Region = PAL-Unk
+	// GSG9 Anti-Terror Force
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53436
 Name   = YetiSports Arctic Adventures
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53438
 Name   = Taito Legends
@@ -13742,46 +13784,46 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53439
 Name   = Crash Tag Team Racing
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53441
 Name   = Heroes of the Pacific
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53443
 Name   = Warriors, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53444
-Name   = Pro Evolution Soccer 5
-Region = PAL-Unk
+Name   = Panzer Elite Action - Fields of Glory
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53446
 Name   = Arcade USA
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53452
 Name   = Trixie in Toyland
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53457
 Name   = Evil Dead - Regeneration
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53458
 Name   = Shin Megami Tensei: Digital Devil Saga
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53459
 Name   = Marc Ecko's Getting Up - Contents Under Pressure
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53461
 Name   = Sega Classics Collection
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53462
@@ -13790,7 +13832,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53463
 Name   = NHL '06
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53466
 Name   = Il Grande Quiz sul Calcio Italiano
@@ -13806,75 +13848,80 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53473
 Name   = Incredibles, The - Rise of the Underminer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53474
 Name   = Incredibles, The - Rise of the Underminer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53480
 Name   = Harvest Moon - A Wonderful Life [Special Edition]
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53481
 Name   = 10,000 Bullets
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53483
 Name   = Magna Carta: Tears of Blood
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53484
 Name   = Eagle Eye Golf
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53487
 Name   = Forty 4 Party
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53488
 Name   = Puzzlemaniacs
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53489
 Name   = Paparazzi
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53490
 Name   = Outlaw Tennis
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53492
 Name   = Total Overdose
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53494
-Name   = Spongebob Squarepants - Lights, Camera, PANTS!
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - Lights, Camera, PANTS!
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53496
-Name   = Spongebob Squarepants - Lights, Camera, PANTS!
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - Lights, Camera, PANTS!
+	// Ciak si Gira!
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53501
 Name   = Star Wars - Battlefront II
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53502
 Name   = Star Wars - Battlefront II
-Region = PAL-Unk
+Region = PAL-F
+---------------------------------------------
+Serial = SLES-53503
+Name   = Star Wars - Battlefront II
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53504
 Name   = Agent Hugo
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-53505
 Name   = Beat Down - Fists of Vengeance
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53506
 Name   = Burnout Revenge
@@ -13883,25 +13930,25 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53507
 Name   = Burnout Revenge
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53508
 Name   = Ultimate Pro-Pinball
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53509
 Name   = Hello Kitty - Roller Rescue
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53510
 Name   = Madden NFL 2006
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53518
 Name   = Castle Shikigami II
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53521
 Name   = Musashi - Samurai Legend
@@ -13909,11 +13956,11 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53523
 Name   = Gun
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53524
 Name   = Mortal Kombat - Shaolin Monks
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53525
 Name   = Mortal Kombat - Shaolin Monks
@@ -13921,7 +13968,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53527
 Name   = Suffering, The - Ties that Bind
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53528
 Name   = Suffering, The - Ties that Bind
@@ -13929,36 +13976,36 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53529
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53530
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53531
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-53532
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-53533
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-53534
 Name   = Tony Hawk's American Wasteland
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53535
 Name   = Tony Hawk's American Wasteland
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53536
 Name   = London Racer - Police Madness
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53539
@@ -13973,113 +14020,113 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53541
 Name   = Tiger Woods PGA Tour '06
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53542
 Name   = Shadow the Hedgehog
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53544
 Name   = Pro Evolution Soccer 5
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53545
 Name   = Pro Evolution Soccer 5
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53546
 Name   = NBA Live 2006
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53547
 Name   = NBA Live '06
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53548
 Name   = Yokushin - Giga Wing Generations
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53551
 Name   = SSX On Tour
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53552
 Name   = SSX On Tour
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-53553
 Name   = James Bond 007 - From Russia with Love
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53557
 Name   = Need for Speed - Most Wanted
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53558
 Name   = Need for Speed - Most Wanted
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-53559
 Name   = Need for Speed - Most Wanted
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53560
 Name   = Sonic Riders
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53561
 Name   = Canis Canem Edit
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53563
-Name   = Spongebob Squarepants and Friends - Untie!
-Region = PAL-Unk
+Name   = SpongeBob Squarepants and Friends - Untie!
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53564
 Name   = Darkwatch
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53566
 Name   = London Taxi - Rushour
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53569
 Name   = Mini Mini Desktop Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53570
 Name   = Ninjabread Man
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53571
 Name   = Anubis II
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53572
 Name   = Rig Racer 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 4
 ---------------------------------------------
 Serial = SLES-53574
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53575
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53576
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53577
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53578
 Name   = Bratz - Rock Angelz
@@ -14087,40 +14134,40 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53579
 Name   = One Piece - Grand Battle
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53580
 Name   = NBA Live '06
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53581
 Name   = NBA Live '06
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53582
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-53583
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53585
 Name   = Marvel Nemesis - Rise of the Imperfects
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 3
 ---------------------------------------------
 Serial = SLES-53587
 Name   = Garfield - Saving Arlene
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53592
 Name   = Zombie Attack
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53594
 Name   = Living World Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53595
 Name   = Wild Water Adrenaline featuring Salomon
@@ -14136,37 +14183,39 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53614
 Name   = Classic British Motor Racing
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53616
 Name   = True Crime - New York City
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53618
 Name   = True Crime - New York City
-Region = PAL-Unk
+Region = PAL-E
+// Voices in English, text and subtitles in Spanish.
 ---------------------------------------------
 Serial = SLES-53621
 Name   = Wallace & Grommit - The Curse of the Were Rabbit
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53623
-Name   = Spongebob Squarepants - Battle for Bikini Bottom
-Region = PAL-Unk
+Name   = SpongeBob Squarepants - Battle for Bikini Bottom
+	// Bob L'éponge - La Bataille de Bikini Bottom
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53624
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53626
 Name   = Suffering, The - Ties that Bind
-Region = PAL-M2
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53635
 Name   = NASCAR '06 - Total Team Control
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53639
 Name   = Ford Street Racing
@@ -14174,47 +14223,49 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53641
 Name   = Destroy All Humans!
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53645
 Name   = Knights of the Temple II
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53646
 Name   = World Racing 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53647
 Name   = Gun
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53651
 Name   = WWII - Soldier
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53652
 Name   = Daemon Summoner
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53654
 Name   = London Racer - Destruction Madness
-Region = PAL-Unk
+	// Paris-Marseille Racing - Destruction Madness
+	// Autobahn Raser - Destruction Madness
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53656
 Name   = Full Spectrum Warrior - Ten Hammers
-Region = PAL-Unk
+Region = PAL-M4
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53657
 Name   = Shrek - Super Slam
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53658
 Name   = Disney-Pixar's The Incredibles - Rise of the Underminer
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53659
 Name   = Brothers in Arms: Earned in Blood
@@ -14222,69 +14273,66 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53661
 Name   = Capcom Classics Collection
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53666
 Name   = Midway Arcade Treasures 3
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53667
 Name   = Gauntlet - Seven Sorrows
 Region = PAL-M5
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53668
 Name   = Micro Machines v4
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53676
 Name   = WWE SmackDown! vs. RAW 2006
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53677
 Name   = WWE SmackDown! vs. RAW 2006
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53682
 Name   = James Pond - Codename Robocod
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53685
 Name   = Codename: Kids Next Door - Operation V.I.D.E.O.G.A.M.E
-Region = PAL-E
+Region = PAL-M2	// UK & GE
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53686
 Name   = NHL Hockey 2K6
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53689
 Name   = World Poker Tour 2K6
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53690
 Name   = Makai Kingdon - Chronicle of the Sacred Stone
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53695
 Name   = Tak - The Great Juju Challenge
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53696
 Name   = Zathura
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53697
-Name   = Dora the Explorer
-Region = PAL-Unk
+Name   = Dora the Explorer - Journey to the Purple Planet
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53699
 Name   = Swords of Destiny
@@ -14293,18 +14341,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53701
 Name   = Super Monkey Ball Adventure
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53702
 Name   = Resident Evil 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53703
 Name   = King Kong, Peter Jackson's - The Official Game of the Movie
-Region = PAL-Unk
+Region = PAL-M10
 Compat = 5
+// Limited Collector's Edition, includes the bonus disc "Making of Peter Jackson's King Kong".
 ---------------------------------------------
 Serial = SLES-53704
 Name   = King Kong, Peter Jackson's - The Official Game of the Movie
@@ -14316,28 +14365,31 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53706
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53707
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+	// Die Chroniken von Narnia - Der König von Narnia
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53708
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+	// Le Cronache di Narnia - Il leone, la strega e l'armadio
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53709
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SLES-53710
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+	// Las Crónicas de Narnia - El León, la Bruja y el Armario
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53712
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SLES-53713
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
@@ -14345,108 +14397,111 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53715
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53716
 Name   = Without Warning
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53717
 Name   = Midnight Club 3 - DUB Edition Remix
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53718
 Name   = Sims 2, The
-Region = PAL-Unk
+Region = PAL-M10
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53722
 Name   = Call of Duty 2 - Big Red One [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53724
 Name   = World Series of Poker
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53725
 Name   = Asterix & Obelix XXL2
-Region = PAL-Unk
+	// Astérix & Obélix XXL 2: Mission: Las Vegum
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53726
 Name   = Harry Potter and The Goblet of Fire
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53727
 Name   = Harry Potter and The Goblet of Fire
-Region = PAL-Unk
+	// Harry Potter och den Flammande Bägaren
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53728
 Name   = Harry Potter and The Goblet of Fire
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53729
 Name   = Battlefield 2 - Modern Combat
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53730
 Name   = Battlefield 2 - Modern Combat
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53734
 Name   = 50cent - Bulletproof
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53736
 Name   = Billy the Wizard - Rocket Broomstick Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53738
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SLES-53739
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-M2	// FR & ES
 ---------------------------------------------
 Serial = SLES-53740
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+	// Disneys Himmel und Huhn
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53741
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53743
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SLES-53744
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53746
 Name   = Superman Returns
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53747
-Name   = Ed, Edd, 'n Eddy - The Misadventure
-Region = PAL-Unk
+Name   = Ed, Edd n Eddy - The Mis-Edventures
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53748
 Name   = Quest for Sleeping Beauty
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53751
 Name   = Shrek Superslam
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53754
 Name   = ATV Off-Road Fury 3
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53755
 Name   = Castlevania - Curse of Darkness
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 vuClampMode = 0		//SPS with microVU
 ---------------------------------------------
@@ -14460,23 +14515,23 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53760
 Name   = Rugby Challenge 2006
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53761
 Name   = Friends - The One with All the Trivia
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53763
 Name   = Tom Clancy's Ghost Recon - Advanced Warfighter
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53764
 Name   = Atelier Iris: Eternal Mana
-Region = PAL-Unk
+Region = PAL-UK	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-53765
 Name   = Stella Deus: The Gate of Eternity
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53767
 Name   = Magna Carta: Les Larmes de Sang
@@ -14489,15 +14544,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53769
 Name   = Suikoden Tactics
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53772
 Name   = Air Raid 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53775
 Name   = Reservoir Dogs
-Region = PAL-Unk
+Region = PAL-M4
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53777
@@ -14507,119 +14562,116 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53778
 Name   = Jacked
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53779
 Name   = American Chopper 2 - Full Throttle
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53794
 Name   = Drakengard 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53796
 Name   = FIFA Street 2
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53797
 Name   = FIFA Street 2
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53799
 Name   = Matrix, The - Path of Neo
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53800
 Name   = Rampage - Total Destruction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53803
 Name   = Friends - Das Trivia Game
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53804
 Name   = Shamu's Deep Sea Adventures
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53810
 Name   = Sensible Soccer 2006
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53813
 Name   = Friends - Celui qui Repond a Toutes les Questions
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53819
 Name   = Armored Core - Nine Breaker
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53820
 Name   = Armored Core - Last Raven
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53824
 Name   = Trapt
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53825
 Name   = Project Zero 3 - The Tormented
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53826
 Name   = Tom Clancy's Splinter Cell - Double Agent
 Region = PAL-M5
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53827
 Name   = Tom Clancy's Splinter Cell - Double Agent
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53828
 Name   = We Love Katamari
-Region = PAL-Unk
+Region = PAL-M4
 vuClampMode = 3
 mvuFlagSpeedHack = 0
 ---------------------------------------------
 Serial = SLES-53829
 Name   = Raiden III
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53830
 Name   = Psychonauts
-Region = PAL-Unk
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53831
 Name   = BloodRayne 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53832
 Name   = BloodRayne 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53846
 Name   = Soccer Life II
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53847
 Name   = Street Golfer
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53848
 Name   = Flow - Urban Dance Uprising
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53849
@@ -14628,7 +14680,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53850
 Name   = Teenage Mutant Ninja Turtles 3 - Mutant Nightmare
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53852
 Name   = Taito Legends 2
@@ -14637,19 +14689,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53855
 Name   = Heracles - Battle with the Gods
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53857
 Name   = Need for Speed - Most Wanted [Black Edition]
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53860
 Name   = Dynasty Warriors 5 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53861
 Name   = Dynasty Warriors 5 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53862
 Name   = Dynasty Warriors 5 - Xtreme Legends
@@ -14662,97 +14714,94 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53866
 Name   = Over the Hedge
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53867
 Name   = Ski Alpin 2006
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-53869
 Name   = Crazy Frog Racer
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53870
 Name   = Devil Kings
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53871
 Name   = Tengai
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53872
 Name   = Samurai Aces
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53873
 Name   = Sol Divide
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53874
 Name   = Dragon Blaze
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53877
 Name   = Premier Manager 2006-2007
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53886
 Name   = Black
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 vuClampMode = 0
 ---------------------------------------------
 Serial = SLES-53897
 Name   = Dreamworks Vecinos Invasores
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53899
 Name   = Pro Evolution Soccer Management
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53900
 Name   = Kaido Racer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53901
 Name   = Torino 2006
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 vuClampMode = 2			//for SPS with microVU.
 ---------------------------------------------
 Serial = SLES-53902
 Name   = Leaderboard Golf
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53903
 Name   = Franklin the Turtle
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-53904
 Name   = DT Racer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53906
 Name   = 50cent - Bulletproof
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53908
 Name   = Tomb Raider - Legend
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M8
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53909
 Name   = Full Spectrum Warrior - Ten Hammers
-Region = PAL-Unk
+Region = PAL-G
+// German Censored Edition.
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53910
@@ -14761,64 +14810,65 @@ Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53913
 Name   = Plan, The
-Region = PAL-Unk
+Region = PAL-M2	// FR & IT
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-53914
 Name   = Plan, The
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53915
 Name   = Space War Attack
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53917
 Name   = G1 Jockey 4
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53920
 Name   = Speed Machines 3
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53921
 Name   = Sim Chemist
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53922
 Name   = Car Wash Tycoon
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53923
 Name   = London Cab Challenge
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53924
 Name   = Combat Ace
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53934
 Name   = G-Force
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53935
 Name   = Dynamite
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53936
 Name   = Snow Rider
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53940
-Name   = Smarties Meltdown
-Region = PAL-Unk
+Name   = Smarties - Meltdown
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53945
 Name   = Championship Manager 2006
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53948
 Name   = Winter Sports
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53949
 Name   = Magna Carta: Lacrime di Sangue
@@ -14830,101 +14880,101 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53955
 Name   = Friends - The One with All the Trivia
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53956
 Name   = Aeon Flux
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53959
 Name   = Pac-Man World 3
-Region = PAL-Unk
+Region = PAL-M5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53963
 Name   = Downhill Slalom
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53964
 Name   = Homura
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53965
 Name   = Plan, The
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53966
 Name   = Taito Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53967
 Name   = Godfather, The
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53968
-Name   = Godfather, The (Le Parrain)
-Region = PAL-Unk
+Name   = Godfather, The - Le Parrain
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53970
-Name   = Godfather, The
-Region = PAL-Unk
+Name   = Godfather, The - Il Padrino
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53971
-Name   = Godfather, The
-Region = PAL-Unk
+Name   = Godfather, The - El Padrino
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53972
 Name   = Stock Car Crash
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53974
 Name   = Dragon Quest VIII - Journey of the Cursed King
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53976
 Name   = Evolution GT
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53979
 Name   = Torrente 3 - El Protector
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53982
 Name   = Fight Night Round 3
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-53984
 Name   = Ice Age 2 - The Meltdown
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53987
-Name   = Over the Hedge
-Region = PAL-Unk
+Name   = Over the Hedge - Vecinos Invasores
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53988
 Name   = Over the Hedge
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-53989
-Name   = Over the Hedge
-Region = PAL-Unk
+Name   = Over the Hedge - Beestenboel Bij De Buren
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53991
 Name   = Urban Chaos - Riot Response
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53994
 Name   = 50cent - Bulletproof
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-53996
 Name   = Army Men - Major Malfunction
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53998
@@ -14934,7 +14984,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53999
 Name   = King of Fighters, The - Neo Wave
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54002
 Name   = FlatOut 2
@@ -14943,110 +14993,112 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54003
 Name   = Flatout 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54004
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-M2	// DU & PO
 ---------------------------------------------
 Serial = SLES-54006
-Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Name   = Disney-Pixar's Cars - Quatre Roues
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54007
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54010
-Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Name   = Disney-Pixar's Cars - Motori Ruggenti
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54011
-Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Name   = Disney-Pixar's Cars - Bilar
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-54012
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+	// Disney Präsentiert einen Pixar Film - Cars
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54013
 Name   = World Snooker Championship 2007
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54015
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-M3	// DA, FI & NO
 ---------------------------------------------
 Serial = SLES-54016
 Name   = AND 1 Streetball
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54021
 Name   = Ruff Trigger
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54023
 Name   = Bible Game, The
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54027
 Name   = Driver - Parallel Lines
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54030
 Name   = Black
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 vuClampMode = 0
 ---------------------------------------------
 Serial = SLES-54031
 Name   = Da Vinci Code, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54033
 Name   = Search and Destroy
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54060
 Name   = Fruit Machine Mania
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54061
 Name   = FIFA World Cup - Germany '06
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54062
 Name   = FIFA World Cup - Germany '06
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-54063
 Name   = FIFA World Cup 2006
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54064
 Name   = FIFA World Cup 2006
-Region = PAL-Unk
+	// FIFA Fotbolls-VM 2006
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54066
 Name   = X-Men - The Official Game
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54068
 Name   = AFL Premiership 2006
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54074
 Name   = Speedboat GP
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54075
 Name   = ProStroke Golf - World Tour 2007
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54080
 Name   = World Super Police
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54081
 Name   = FIFA World Cup 2006
@@ -15054,7 +15106,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54083
 Name   = Pirates of the Caribbean - The Legend of Jack Sparrow
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54084
 Name   = PowerShot Pinball
@@ -15063,7 +15115,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54085
 Name   = Street Fighter Alpha Anthology
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54087
 Name   = Suikoden V
@@ -15072,23 +15124,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54089
 Name   = State of Emergency 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54093
 Name   = Guitar Hero
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54095
 Name   = Dynasty Warriors 5 - Empires
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54096
 Name   = Dynasty Warriors 5 - Empires
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54097
 Name   = Dynasty Warriors 5 - Empires
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54106
 Name   = Kidz Sports - Ice Hockey
@@ -15104,7 +15156,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54109
 Name   = Off-Road Extreme! [Special Edition]
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54110
 Name   = Monster Trux Arenas [Special Edition]
@@ -15124,26 +15176,26 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54114
 Name   = Kingdom Hearts II
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54115
 Name   = Delta Force - Black Hawk Down - Team Sabre
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1	//missing text
 ---------------------------------------------
 Serial = SLES-54116
 Name   = Operation Winback 2 - Project Poseidon
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54117
-Name   = Torrente 3 - El Protector
-Region = PAL-E
+Name   = Torrente 3 - The Protector
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54118
 Name   = Da Vinci Code, The
-Region = PAL-Unk
+Region = PAL-M2	// UK & DU
 ---------------------------------------------
 Serial = SLES-54120
 Name   = The Snow Queen Quest
@@ -15151,19 +15203,19 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54123
 Name   = Marvel - Ultimate Alliance
-Region = PAL-Unk
+Region = PAL-M2	// UK & IT
 ---------------------------------------------
 Serial = SLES-54126
 Name   = Family Guy - The Video Game
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54130
 Name   = Spy Hunter - Nowhere to Run
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54132
 Name   = Guitar Hero
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54135
@@ -15173,23 +15225,24 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54136
 Name   = Grand Theft Auto - Liberty City Stories
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-54137
 Name   = Just Cause
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54138
 Name   = Steambot Chronicles
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54139
 Name   = Earache - Extreme Metal Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54140
 Name   = Playwize Poker & Casino
-Region = PAL-Unk
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-54143
 Name   = Hard Rock Casino
@@ -15201,47 +15254,47 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54150
 Name   = Bionicle Heroes
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54151
 Name   = Let's Make a Soccer Team!
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54152
 Name   = Ant Bully, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54153
 Name   = Virtua Pro Football
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54154
 Name   = D-Unit Drift Racing
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54155
 Name   = Drag Racer USA
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54156
 Name   = Mortal Kombat - Armageddon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54158
 Name   = Hummer Badlands
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54159
 Name   = Eragon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54160
 Name   = Eragon
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54161
 Name   = Super DragonBall Z
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54162
 Name   = Saint Seiya - The Hades
@@ -15254,53 +15307,53 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54164
 Name   = DragonBall Z Budokai - Tenkaichi 2
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54165
 Name   = One Piece - Grand Adventure
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54166
 Name   = Call of Duty 3
-Region = PAL-Unk
+Region = PAL-UK
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-54167
 Name   = Call of Duty 3
-Region = PAL-S
+Region = PAL-M3
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-54168
 Name   = Call of Duty 3
-Region = PAL-Unk
+Region = PAL-G
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-54169
 Name   = Aeon Flux
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54170
 Name   = Jaws Unleashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54171
 Name   = Yakuza
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54172
 Name   = Garfield 2 - Tale of Two Kitties
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54174
 Name   = Zoocube
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54178
 Name   = Ant Bully, The
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-54179
 Name   = Pirates of the Caribbean - At World's End
@@ -15326,13 +15379,10 @@ Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54185
 Name   = Dirge of Cerberus - Final Fantasy VII
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
+// Language selection via BIOS settings (requires Full boot).
 [patches = 33F7D21A]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-	//
 	// Override sceScfGetLanguage patches by nachbrenner:
 	//  patch=0,EE,002486d8,word,24020000 // japanese
 	//  patch=0,EE,002486d8,word,24020001 // english
@@ -15341,12 +15391,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54186
 Name   = Devil May Cry 3 - Dante's Awakening [Special Edition]
-Region = PAL-E
+Region = PAL-M5
 eeRoundMode = 0
 ---------------------------------------------
 Serial = SLES-54187
 Name   = Real World Golf 2007
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54188
 Name   = Nickelodeon Avatar - The Legend of Aang
@@ -15354,47 +15404,47 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54193
 Name   = Sudoku, Carol Vonderman's
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54194
 Name   = Sudoku, Carol Vonderman's
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54195
 Name   = Turbo Trucks
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54199
 Name   = Who Wants to be a Millionaire - Party Edition
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54200
 Name   = Just Cause
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-54203
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54204
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-M2	// IT & PL
 ---------------------------------------------
 Serial = SLES-54205
 Name   = WWI - Aces of the Sky
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54209
 Name   = Sopranos, The - Road to Respect
-Region = PAL-Unk
+Region = PAL-M2	// UK & ES
 ---------------------------------------------
 Serial = SLES-54210
 Name   = NBA 2K7
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54211
 Name   = NHL 2K7
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54212
 Name   = Agent Hugo - RoboRumble
@@ -15406,16 +15456,16 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54215
 Name   = Monster House
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54216
 Name   = Monster House
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54217
 Name   = Monster House
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54218
 Name   = Rule of Rose
@@ -15423,27 +15473,27 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54221
 Name   = LEGO Star Wars II - The Original Trilogy
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54222
 Name   = SuperBikes Riding Challenge
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54223
 Name   = NASCAR '07
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54224
 Name   = Australian Idol Sing
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54225
 Name   = LMA Manager 2007
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54230
 Name   = Brian Lara International Cricket 2007
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54232
@@ -15456,65 +15506,65 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54234
 Name   = Kingdom Hearts II
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54235
 Name   = Kingdom Hearts II
-Region = PAL-S
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54237
 Name   = Pirates of the Caribbean - The Legend of Jack Sparrow
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54239
 Name   = Wild ARMs 4
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54240
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54241
 Name   = FIFA '07
-Region = PAL-F-G-I
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54243
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-54244
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-M5	// DU & Nordic
 ---------------------------------------------
 Serial = SLES-54245
 Name   = NHL '07
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54246
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54248
 Name   = Madden NFL '07
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54250
 Name   = NBA Live '07
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54251
 Name   = NBA Live '07
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54252
 Name   = NBA Live '07
-Region = PAL-E-G-I
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54253
 Name   = Tiger Woods PGA Tour '07
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54254
 Name   = Evolution GT
@@ -15527,11 +15577,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54256
 Name   = WWII - Battle Over the Pacific
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54271
 Name   = Scarface - The World is Yours
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54305
 Name   = Demon Chaos
@@ -15540,30 +15590,31 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54306
 Name   = Cartoon Network Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54307
 Name   = Rayman - Raving Rabbids
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54308
 Name   = Phantasy Star Universe
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 eeRoundMode = 0
 ---------------------------------------------
 Serial = SLES-54309
 Name   = Strawberry Shortcake - The Sweet Dreams Game
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54310
 Name   = Open Season
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54311
 Name   = Noddy and The Magic Book
-Region = PAL-Unk
+	// Noddy e o livro mágico
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54316
 Name   = Open Season - Rebelles de la Foret
@@ -15571,7 +15622,7 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54317
 Name   = Ghost Rider
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54319
@@ -15580,49 +15631,49 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54320
 Name   = Championship Manager 2007
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54321
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54322
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-54323
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-54324
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54331
 Name   = Street Dance
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-54332
 Name   = Dance Fest
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54333
 Name   = Sega MegaDrive Collection
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54336
 Name   = Lumines Plus
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54339
 Name   = Realm of the Dead
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54340
 Name   = Samurai Warriors 2
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54341
 Name   = Dancing Stage SuperNOVA
@@ -15630,15 +15681,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54342
 Name   = Bratz - Forever Diamondz
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-54343
 Name   = Bratz - Forever Diamondz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54344
 Name   = Bratz - Forever Diamondz
-Region = PAL-Unk
+Region = PAL-M3	// UK, DA & SE
 ---------------------------------------------
 Serial = SLES-54346
 Name   = Heatseeker
@@ -15646,21 +15697,21 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54347
 Name   = Sims 2, The - Pets
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54350
-Name   = Superman Returns
+Name   = Superman Returns - Das Spiel
 Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54354
 Name   = Final Fantasy XII
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54355
 Name   = Final Fantasy XII
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54356
 Name   = Final Fantasy XII
@@ -15672,28 +15723,28 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54358
 Name   = Final Fantasy XII
-Region = PAL-S
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54359
 Name   = Legend of Spyro, The - A New Beginning
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54360
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54361
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54362
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54364
 Name   = Curious George
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54365
 Name   = AMF Xtreme bowling 2006
@@ -15701,27 +15752,28 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54366
 Name   = David Douillet Judo
-Region = PAL-Unk
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SLES-54368
 Name   = RTL Ski Jumping 2007
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 ---------------------------------------------
 Serial = SLES-54370
 Name   = Alpine Ski Racing
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-54374
 Name   = RTL Wintergames 2007
-Region = PAL-Unk
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-54376
 Name   = Barnyard
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54379
 Name   = NFL Street 3
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54380
 Name   = Babe
@@ -15729,58 +15781,59 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54381
 Name   = Dr. Dolittle
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54382
 Name   = Jumanji
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54383
 Name   = Casper and The Ghostly Trio
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54384
 Name   = Destroy All Humans 2 - Make War not Love
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54385
 Name   = Atelier Iris 2: The Azoth of Destiny
-Region = PAL-Unk
+Region = PAL-UK	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-54388
 Name   = Kim Possible - What's the Switch
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54389
 Name   = Tony Hawk's Project 8
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54393
 Name   = Pippa Funnell - Take the Reins
-Region = PAL-Unk
+	// Australia: Horsez
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54394
 Name   = Family Guy - The Video Game
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54395
 Name   = NeoGeo Battle Coliseum
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54396
 Name   = Cricket 07
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54400
 Name   = SpongeBob Squarepants - Creature from the Krusty Krab
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54402
 Name   = Need for Speed - Carbon [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54418
 Name   = Powerdrome
@@ -15788,11 +15841,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54420
 Name   = Arthus & The Minimoys
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54421
 Name   = Happy Feet
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54423
@@ -15801,132 +15854,138 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54424
 Name   = Dr. Dolittle
-Region = PAL-Unk
+Region = PAL-M7	// PL, PO & Nordic
 ---------------------------------------------
 Serial = SLES-54426
 Name   = Casper and The Ghostly Trio
-Region = PAL-Unk
+Region = PAL-M7	// PL, PO & Nordic
 ---------------------------------------------
 Serial = SLES-54427
 Name   = Jumanji
-Region = PAL-Unk
+Region = PAL-M6	// UK, PO & Nordic
 ---------------------------------------------
 Serial = SLES-54430
 Name   = Teen Titans
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-54431
 Name   = Teen Titans
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54432
 Name   = Mercury Meltdown Remix
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54437
 Name   = King of Fighters XI
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54439
 Name   = Okami
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54440
 Name   = GT-R Touring
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54441
 Name   = Hawk Kawasaki Racing
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54442
 Name   = Guitar Hero II
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54444
 Name   = Made Man
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54448
 Name   = World Series of Poker - Tournament of Champions
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54449
 Name   = Chicken Little - Ace in Action
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54450
-Name   = Chicken Little - Aventures Intergalactiques
-Region = PAL-Unk
+Name   = Chicken Little - Ace in Action
+	// Aventures Intergalactiques
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54451
-Name   = Himmel und Huhn - Ace in Action
-Region = PAL-Unk
+Name   = Chicken Little - Ace in Action
+	// Himmel und Huhn
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54452
-Name   = Chicken Little - 'As' en Accion
+Name   = Chicken Little - Ace in Action
+	// As en Acción
 Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54453
 Name   = Chicken Little - Ace in Action
-Region = PAL-Unk
+	// Asso Spaziale!
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54454
 Name   = Disgaea 2: Cursed Memories
-Region = PAL-Unk
+Region = PAL-UK
+// Voices can be switched between Japanese and English via Options menu.
 ---------------------------------------------
 Serial = SLES-54456
 Name   = Beverly Hills Cop
-Region = PAL-E
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54459
 Name   = All Star Fighters
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54460
 Name   = Dragon Sisters
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54461
 Name   = Zombie Hunters
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54462
 Name   = Zombie Virus
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54464
 Name   = Global Defence Force
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54465
 Name   = CSI 3 - Dimensions of Murder
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54466
 Name   = Test Drive Unlimited
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-54467
 Name   = Final Armada
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54468
 Name   = Crazy Chicken X
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54469
 Name   = Home Alone
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-54471
 Name   = Captain Scarlet
@@ -15934,15 +15993,15 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54473
 Name   = Flintstones, The - Bedrock Racing
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-54474
 Name   = Curious George
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54476
 Name   = Buccaneer
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54478
 Name   = TMNT
@@ -15951,7 +16010,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54483
 Name   = The Fast and the Furious
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54486
 Name   = Xiaolin Showdown
@@ -15963,29 +16022,29 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54488
 Name   = WWE SmackDown! vs. RAW 2007
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54489
 Name   = WWE SmackDown! vs. RAW 2007
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54490
 Name   = God Hand
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54492
 Name   = Need for Speed - Carbon [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54493
 Name   = Need for Speed - Carbon [Collector's Edition]
-Region = PAL-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-54494
 Name   = Little Britain - The Video Game
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54510
 Name   = Disney's Meet the Robinsons
@@ -15993,19 +16052,20 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54511
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54512
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-54513
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-54518
 Name   = Clumsy Shumsy
-Region = PAL-Unk
+Region = PAL-UK
+// EyeToy USB Camera Needed.
 ---------------------------------------------
 Serial = SLES-54521
 Name   = Nickelodeon SpongeBob and Friends - Battle for Volcano Island
@@ -16013,53 +16073,58 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54527
 Name   = Flushed Away
-Region = PAL-Unk
+	// French: Souris City
+	// Spanish: Ratónpolis
+	// German: Flutsch und Weg
+	// Italian: Giù peril Tubo
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54541
 Name   = Xena - Warrior Princess
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54542
 Name   = Xena - Warrior Princess
-Region = PAL-Unk
+Region = PAL-M6	// UK, PO & Nordic
 ---------------------------------------------
 Serial = SLES-54544
 Name   = Gun Club
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54545
 Name   = Maxxed Out Racing Nitro
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54546
-Name   = Horsez
-Region = PAL-Unk
+Name   = Pippa Funnell - Take the Reins
+	// German: Horsez - Abenteuer auf dem Reiterhof - Die Meisterschule
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54548
 Name   = Cocoto Fishing Master
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54549
 Name   = Crazy Frog Racer 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54551
 Name   = Premier Manager 2006-2007
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54553
 Name   = Shrek - Smash 'n Crash Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54554
 Name   = Star Trek - Encounters
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54555
 Name   = Shin Megami Tensei: Digital Devil Saga 2
-Region = PAL-E
+Region = PAL-UK
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-54560
@@ -16068,15 +16133,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54561
 Name   = Capcom Classics Collection Vol. 2
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54566
 Name   = Barbie in The 12 Dancing Princesses
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54569
 Name   = Zombie Hunters 2
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54579
@@ -16089,7 +16154,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54582
 Name   = International Tennis Pro
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54583
 Name   = Surf's Up
@@ -16097,36 +16162,37 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54584
 Name   = Pac-Man Rally
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54586
 Name   = Ar tonelico: Melody of Elemia
-Region = PAL-Unk
+Region = PAL-UK	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-54588
 Name   = Brunswick Pro Bowling
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54589
 Name   = Global Defense Force Tactics
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54590
 Name   = Hard Knock High
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54604
-Name   = 'Que pasa Neng! El Videojuego
-Region = PAL-S
+Name   = Que pasa Neng! El Videojuego
+	// ¡Qué Pasa Neng! El Videojuego
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54606
 Name   = Harley-Davidson - Race to the Rally
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54608
 Name   = Barbie in The 12 Dancing Princesses
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54611
 Name   = TT Superbikes - Real Road Racing Championship
@@ -16134,7 +16200,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54615
 Name   = Code of the Samurai
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54617
@@ -16152,7 +16218,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54624
 Name   = Samurai Warriors 2 - Empires
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54626
 Name   = An American Tail
@@ -16160,16 +16226,16 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-54627
 Name   = Burnout Dominator
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54629
 Name   = Shin Megami Tensei - Devil Summoner
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54631
 Name   = Harley-Davidson - Race to the Rally
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54633
 Name   = Premier Manager 08
@@ -16185,15 +16251,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54639
 Name   = AFL Premiership 2007
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54641
 Name   = International Cricket Captain III
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54644
 Name   = Valkyrie Profile 2 - Silmeria
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 VuAddSubHack = 1
 ---------------------------------------------
@@ -16216,12 +16282,12 @@ VuAddSubHack = 1
 ---------------------------------------------
 Serial = SLES-54648
 Name   = Valkyrie Profile 2 - Silmeria
-Region = PAL-S
+Region = PAL-E
 VuAddSubHack = 1
 ---------------------------------------------
 Serial = SLES-54657
 Name   = Charlotte's Web
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54659
 Name   = Star Wars - The Force Unleashed
@@ -16234,7 +16300,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54666
 Name   = Mr. Bean
-Region = PAL-E
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54670
@@ -16243,26 +16309,22 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-54674
 Name   = Lara Croft Tomb Raider - Anniversary
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M10
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-54675
 Name   = Street Warrior
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54677
 Name   = Metal Slug - Anthology
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54681
 Name   = Burnout Dominator
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54683
 Name   = Medal of Honor - Vanguard
@@ -16270,16 +16332,16 @@ Region = PAL-M9
 ---------------------------------------------
 Serial = SLES-54686
 Name   = Impossible Mission
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54687
 Name   = Spectral vs. Generation
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54695
 Name   = Azur & Asmar
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54705
@@ -16288,20 +16350,20 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54711
 Name   = Shadow Hearts - From the New World
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54717
 Name   = Power Volleyball
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54719
 Name   = Charlotte's Web
-Region = PAL-11
+Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-54723
 Name   = Spiderman 3
-Region = PAL-E
+Region = PAL-UK
 Compat = 4
 ---------------------------------------------
 Serial = SLES-54727
@@ -16315,7 +16377,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54733
 Name   = Disney-Pixar Ratatouille
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54735
 Name   = Disney-Pixar Ratatouille
@@ -16323,20 +16385,20 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54747
 Name   = Disney-Pixar Ratatouille
-Region = PAL-M2
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-54755
 Name   = Transformers - The Game
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54756
 Name   = Transformers - The Game
-Region = PAL-M2
+Region = PAL-M2	// FR & ES
 ---------------------------------------------
 Serial = SLES-54770
 Name   = DreamWorks Shrek the Third
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54771
 Name   = DreamWorks Shrek the Third
@@ -16344,7 +16406,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54776
 Name   = Fantastic Four - Rise of the Silver Surfer
-Region = PAL-I
+Region = PAL-M2	// UK & IT
 ---------------------------------------------
 Serial = SLES-54779
 Name   = Harry Potter and the Order of the Phoenix
@@ -16352,7 +16414,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54782
 Name   = Obscure 2
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54784
@@ -16361,19 +16423,19 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54788
 Name   = Aqua Teen Hunger Force - Zombie Ninja Pro-Am
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54790
 Name   = Art of Fighting Anthology
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54793
 Name   = WWE SmackDown vs. Raw 2008
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54804
 Name   = Operation Air Assault 2
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54805
@@ -16382,7 +16444,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54810
 Name   = Rugby 08
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54811
 Name   = Rugby 08
@@ -16390,7 +16452,7 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54812
 Name   = Madden NFL 08
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54815
 Name   = Spyro - The Eternal Night
@@ -16404,13 +16466,13 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54820
 Name   = Stuntman Ignition
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-54822
 Name   = Atelier Iris 3: Grand Phantasm
-Region = PAL-Unk
+Region = PAL-UK	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-54825
 Name   = Bob the Builder
@@ -16418,7 +16480,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54834
 Name   = Juiced 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54836
@@ -16447,7 +16509,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54859
 Name   = Guitar Hero - Rocks The 80's
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54861
@@ -16456,23 +16518,23 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54870
 Name   = FIFA 08
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54871
 Name   = FIFA 2008
-Region = PAL-F-G-I
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54872
 Name   = FIFA 08
-Region = PAL-P-S
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-54873
 Name   = FIFA 2008
-Region = PAL-E-N-Sw
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54875
 Name   = Warriors Orochi
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54877
 Name   = Warriors Orochi
@@ -16492,12 +16554,12 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54884
 Name   = Alone in the Dark
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54885
 Name   = Moto X Maniac
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54891
 Name   = Clever Kids - Pony World
@@ -16513,12 +16575,12 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54897
 Name   = GrimGrimoire
-Region = PAL-E
+Region = PAL-M2	// UK & JP
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54898
 Name   = Metropolismania 2
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54899
 Name   = Bob the Builder
@@ -16535,16 +16597,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54906
 Name   = The Simpsons Game
-Region = PAL-I-S
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-54913
 Name   = Pro Evolution Soccer 2008
-Region = PAL-E
+Region = PAL-M2	// UK & ES
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54914
 Name   = Pro Evolution Soccer 2008
-Region = PAL-I-P
+Region = PAL-M2	// IT & PO
 ---------------------------------------------
 Serial = SLES-54915
 Name   = Sonic Riders - Zero Gravity
@@ -16572,11 +16634,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54942
 Name   = Disney Princess - Enchanted Journey
-Region = PAL-D-F-I
+Region = PAL-M3	// ES, GE & IT
 ---------------------------------------------
 Serial = SLES-54945
 Name   = Dragonball Z Budokai Tenkaichi 3
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54946
@@ -16594,11 +16656,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54953
 Name   = Totally Spies! Totally Party
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54955
 Name   = Finkles World
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54957
 Name   = Cheggers Party Quiz
@@ -16610,11 +16672,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54962
 Name   = Guitar Hero III - Legends of Rock
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-54963
 Name   = Tony Hawks - Proving Ground
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54964
@@ -16623,16 +16685,16 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54975
 Name   = George Of The Jungle
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54981
 Name   = Bob the Builder - Festival of Fun
-Region = PAL-I-F-G
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54986
 Name   = Bratz - The Movie
-Region = PAL-E-I
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-54988
 Name   = Bratz - The Movie
@@ -16656,7 +16718,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54997
 Name   = Mercenaries 2 - World in Flames
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
@@ -16671,16 +16733,16 @@ EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-55001
 Name   = Mercenaries 2 - World in Flames
-Region = PAL-S
+Region = PAL-E
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-55002
 Name   = Need for Speed - ProStreet
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55003
 Name   = Need for Speed - ProStreet
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55005
 Name   = Need for Speed - ProStreet
@@ -16688,7 +16750,7 @@ Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-55007
 Name   = Boogie
-Region = PAL-E
+Region = PAL-M7
 Compat = 4
 ---------------------------------------------
 Serial = SLES-55013
@@ -16705,7 +16767,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55018
 Name   = Shin Megami Tensei: Persona 3
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 VuClipFlagHack = 1
 ---------------------------------------------
@@ -16719,7 +16781,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-55021
 Name   = Pro Evolution Soccer 2008
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55024
 Name   = Nickelodeon SpongeBob's Atlantis SquarePantis
@@ -16739,7 +16801,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55050
 Name   = MX vs. ATV - Untamed
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55052
 Name   = Alvin and the Chipmunks
@@ -16768,7 +16830,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55081
 Name   = Jackass - The Game
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55090
 Name   = Naruto - Uzumaki Chronicles 2
@@ -16781,7 +16843,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55108
 Name   = Samurai Warriors 2 - Xtreme Legends
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55110
 Name   = Odin Sphere
@@ -16818,7 +16880,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55150
 Name   = TNA Impact
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
@@ -16836,11 +16898,11 @@ Region = PAL-R
 ---------------------------------------------
 Serial = SLES-55187
 Name   = Disney-Pixar WALL-E
-Region = PAL-D-F
+Region = PAL-M2	// DU & FR
 ---------------------------------------------
 Serial = SLES-55191
 Name   = Guitar Hero - Aerosmith
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55197
 Name   = Dancing Stage SuperNOVA 2
@@ -16848,7 +16910,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55198
 Name   = Iron Man
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55204
@@ -16861,15 +16923,15 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55208
 Name   = The Incredible Hulk
-Region = PAL-E-F-G
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-55215
 Name   = Growlanser - Heritage of War
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55216
 Name   = Baroque
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55220
 Name   = Summer Athletics
@@ -16877,15 +16939,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55231
 Name   = Fatal Fury - Battle Archives Volume 1
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55232
 Name   = SNK Arcade Classics Vol. 1
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55233
 Name   = World Heroes Anthology
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55237
 Name   = Naruto - Ultimate Ninja 3
@@ -16898,15 +16960,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55242
 Name   = Yakuza 2
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55243
 Name   = FIFA 09
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55244
 Name   = FIFA 09
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55245
 Name   = FIFA 09
@@ -16923,7 +16985,7 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55249
 Name   = Harry Potter and the Half-Blood Prince
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-55251
 Name   = WWE SmackDown vs. Raw 2009
@@ -16940,7 +17002,7 @@ Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-55266
 Name   = MotoGP 08
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55274
@@ -16949,23 +17011,23 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55280
 Name   = King of Fighters '98 - Ultimate Match
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55292
 Name   = Samurai Shodown Anthology
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55328
 Name   = The Millenium European Paintball Series - Championship Paintball 2009
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55329
 Name   = Shrek's Carnival Craze
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-55331
 Name   = Cabela's Dangerous Adventures
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55341
 Name   = Hasbro Family Game Night
@@ -16981,30 +17043,31 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55345
 Name   = James Bond: Quantum of Solace
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot).
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55347
 Name   = Dragonball Z Infinite World
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55349
 Name   = Need For Speed - Undercover
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55350
 Name   = Need for Speed - Undercover
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55352
 Name   = Need For Speed - Undercover
-Region = PAL-Unk
+Region = PAL-R
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55354
 Name   = Shin Megami Tensei: Persona 3 FES
-Region = PAL-E
+Region = PAL-UK
 VuClipFlagHack = 1
 ---------------------------------------------
 Serial = SLES-55355
@@ -17029,12 +17092,12 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55372
 Name   = Spiderman: Web of Shadows
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55373
 Name   = The King of Fighters Collection: The Orochi Saga
-Region = PAL-Unk
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55374
 Name   = DreamWorks Madagascar 2 - Escape 2 Africa
@@ -17043,7 +17106,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55376
 Name   = Nickelodeon Tak and the Guardians of Gross
-Region = PAL-E-G
+Region = PAL-M2	// UK & GE
 ---------------------------------------------
 Serial = SLES-55380
 Name   = Sonic Unleashed
@@ -17052,7 +17115,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55382
 Name   = Warriors Orochi 2
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55384
@@ -17065,11 +17128,15 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55394
 Name   = Disney TH!NK Fast
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55395
 Name   = Disney TH!NK Fast
-Region = PAL-D-F-G
+Region = PAL-M3
+---------------------------------------------
+Serial = SLES-55415
+Name   = Disney TH!NK Fast
+Region = PAL-M2	// ES & IT
 ---------------------------------------------
 Serial = SLES-55398
 Name   = Disney High School Musical 3 - Senior Year Dance!
@@ -17077,11 +17144,11 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55405
 Name   = Pro Evolution Soccer 2009
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55406
 Name   = Pro Evolution Soccer 2009
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55409
 Name   = TT SuperBikes - Legends
@@ -17089,11 +17156,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55430
 Name   = Disney Bolt
-Region = PAL-D-F-G
+Region = PAL-M3	// DU, FR & GE
 ---------------------------------------------
 Serial = SLES-55431
 Name   = Disney Vol't
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-55440
 Name   = Ben 10: Alien Force
@@ -17102,23 +17169,19 @@ compat = 5
 ---------------------------------------------
 Serial = SLES-55442
 Name   = Tomb Raider Underworld
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M8
 Compat = 5
-[patches]
-	comment=- This gamedisc supports multiple languages.
-	comment=- Language selection is done through the BIOS configuration.
-	comment=- Implementation requires Full boot - "Boot CDVD (full)".
-[/patches]
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-55443
 Name   = Mana Khemia - Alchemists of Al-Revis
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 DMABusyHack = 1
 ---------------------------------------------
 Serial = SLES-55444
 Name   = Ar tonelico II: Melody of Metafalica
-Region = PAL-Unk
+Region = PAL-UK	// Voices: English & Japanese
 Compat = 5
 eeRoundMode = 0 // Fixes "Fall through floor" bug when aproaching chests
 ---------------------------------------------
@@ -17128,15 +17191,16 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55453
 Name   = Singstar Queen
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-55457
 Name   = AC/DC LIVE: Rock Band Track Pack
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-55459
 Name   = Jelly Belly: Ballistic Beans
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55467
 Name   = Trivial Pursuit
@@ -17144,7 +17208,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55470
 Name   = Coraline
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55472
@@ -17153,7 +17217,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55474
 Name   = Shin Megami Tensei: Persona 4
-Region = PAL-E
+Region = PAL-UK
 VuClipFlagHack = 1
 ---------------------------------------------
 Serial = SLES-55476
@@ -17162,7 +17226,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55482
 Name   = Naruto Shipuuden - Ultimate Ninja 4
-Region = PAL-G-I-S
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-55486
 Name   = DreamWorks Monsters vs. Aliens
@@ -17178,12 +17242,13 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55494
 Name   = X-Men Origins - Wolverine
-Region = PAL-Unk
+Region = PAL-M2	// UK & FR
+// Language selection via BIOS settings (requires Full boot).
 FpuCompareHack = 1		//flickering objects, sound loop
 ---------------------------------------------
 Serial = SLES-55495
 Name   = X-Men Origins - Wolverine
-Region = PAL-G-F-S
+Region = PAL-M3	// FR, ES & GE
 FpuCompareHack = 1		//flickering objects, sound loop
 ---------------------------------------------
 Serial = SLES-55496
@@ -17192,11 +17257,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-55500
 Name   = Disney G-Force
-Region = PAL-G-I
+Region = PAL-M2	// GE & IT
 ---------------------------------------------
 Serial = SLES-55509
 Name   = Music Maker - Rockstar
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55511
@@ -17241,7 +17306,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55571
 Name   = Ghostbusters
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55572
@@ -17251,11 +17316,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55573
 Name   = MotorStorm Arctic Edge
-Region = PAL-Unk
+Region = PAL-M14
 OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLES-55574
-Name   = the Lord of the Rings - Aragorn's Quest
+Name   = The Lord of the Rings - Aragorn's Quest
 Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55578
@@ -17268,11 +17333,11 @@ Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-55582
 Name   = FIFA 10
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55583
 Name   = FIFA 10
-Region = PAL-Unk
+Region = PAL-M4	// UK & Scandinavia
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55584
@@ -17281,15 +17346,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55585
 Name   = FIFA 10
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-55588
 Name   = Pro Evolution Soccer 2010
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55589
 Name   = Pro Evolution Soccer 2010
-Region = PAL-I-P-S
+Region = PAL-M3	// ES, IT & PO
 ---------------------------------------------
 Serial = SLES-55592
 Name   = Ben 10: Alien Force - Vilgax Attacks
@@ -17320,12 +17385,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55636
 Name   = Pro Evolution Soccer 2011
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55637
 Name   = Pro Evolution Soccer 2011
-Region = PAL-F-G
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55638
 Name   = Pro Evolution Soccer 2011
@@ -17333,7 +17398,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55642
 Name   = FIFA 11
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55644
@@ -17347,17 +17412,18 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55653
 Name   = FIFA 12
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55664
 Name   = FIFA 13
-Region = PAL-Unk
+Region = PAL-M5
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55665
 Name   = FIFA 13
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55671
 Name   = FIFA 14
@@ -17365,31 +17431,31 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55672
 Name   = FIFA 14
-Region = PAL
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55673
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55674
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-M2	// FR & GE
 ---------------------------------------------
 Serial = SLES-55675
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-M2	// GR & IT
 ---------------------------------------------
 Serial = SLES-55676
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-M2	// ES & PO
 ---------------------------------------------
 Serial = SLES-82001
 Name   = Summoner
-Region = PAL-E
+Region = PAL-UK
 ---------------------------------------------
 Serial = SLES-82005
 Name   = Summoner
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82009
@@ -17399,35 +17465,38 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-82010
 Name   = Metal Gear Solid 2, Document of
-Region = PAL-Unk
+Region = PAL-UK
 Compat = 5
+// Bundled with Metal Gear Solid 2 - Substance [SLES-82009]
 ---------------------------------------------
 Serial = SLES-82011
 Name   = Devil May Cry 2 [Dante Disc]
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82012
 Name   = Devil May Cry 2 [Lucia Disc]
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82013
 Name   = Metal Gear Solid 3 - Snake Eater
-Region = PAL-E-F
+Region = PAL-M2	// UK & FR
+// Language selection via BIOS settings (requires Full boot), and in Options menu.
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82018
 Name   = Cy Girls
-Region = PAL-Unk
+Region = PAL-M3
+// Language selection via BIOS settings (requires Full boot).
 ---------------------------------------------
 Serial = SLES-82020
 Name   = Cy Girls [Disc 1]
-Region = PAL-E-G-I
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82021
 Name   = Cy Girls [Disc 2]
-Region = PAL-E-G-I
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82024
 Name   = Metal Gear Solid 3 - Snake Eater
@@ -17435,27 +17504,27 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-82026
 Name   = Metal Gear Solid 3 - Snake Eater
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-82028
 Name   = Star Ocean 3 - Till the End of Time [Disc1of2]
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 VuAddSubHack = 1
 ---------------------------------------------
 Serial = SLES-82029
 Name   = Star Ocean 3 - Till the End of Time [Disc2of2]
-Region = PAL-E
+Region = PAL-UK
 Compat = 5
 VuAddSubHack = 1
 ---------------------------------------------
 Serial = SLES-82030
 Name   = Shadow Hearts - Covenant [Disc1of2]
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82031
 Name   = Shadow Hearts - Covenant [Disc2of2]
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82032
 Name   = Metal Gear Solid 3 - Snake Eater
@@ -17463,11 +17532,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-82034
 Name   = Xenosaga Episode II [Disc1of2]
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82035
 Name   = Xenosaga Episode II [Disc2of2]
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82036
 Name   = Armored Core - Nexus [Evolution Disc]
@@ -17479,7 +17548,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-82038
 Name   = Onimusha - Dawn of Dreams [Disc1]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 [patches = 812C5A96]
 	comment= patch by Shadow Lady
@@ -17488,7 +17557,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-82039
 Name   = Onimusha - Dawn of Dreams [Disc2]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 [patches = 812C5A96]
 	comment= patch by Shadow Lady
@@ -17496,52 +17565,64 @@ Compat = 5
 [/patches]
 ---------------------------------------------
 Serial = SLES-82042
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 1 of 3 - Subsistance Disc
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-82043
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 2 of 3 - Persistence Disc
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-82044
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 1 of 3 - Subsistance Disc
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-82045
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 2 of 3 - Persistence Disc
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-82046
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 1 of 3 - Subsistance Disc
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-82047
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 2 of 3 - Persistence Disc
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-82048
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 1 of 3 - Subsistance Disc
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-82049
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 2 of 3 - Persistence Disc
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-82050
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 3 of 3 - Existence Disc
+Region = PAL-M2	// UK & FR
 ---------------------------------------------
 Serial = SLES-82051
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 3 of 3 - Existence Disc
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-82052
-Name   = Metal Gear Solid 3 - Subsistance [Disc1of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 3 of 3 - Existence Disc
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-82053
-Name   = Metal Gear Solid 3 - Subsistance [Disc2of2]
-Region = PAL-Unk
+Name   = Metal Gear Solid 3 - Subsistance
+	// Disc 3 of 3 - Existence Disc
+Region = PAL-E
 ---------------------------------------------
 Serial = SLKA-15003
 Name   = Shikigami no Shiro II
@@ -17564,7 +17645,7 @@ OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLKA-15008
 Name   = Choro Q HG2
-Region = NTSC-E-F-G
+Region = NTSC-M3	// UK, FR & GE
 ---------------------------------------------
 Serial = SLKA-15021
 Name   = GrowLanser3
@@ -26866,7 +26947,7 @@ Name   = Princess Maker 4 [Best Version]
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66694
-Name   = Spongebob
+Name   = SpongeBob
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-66695
@@ -35133,7 +35214,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-20425
-Name   = Spongebob Squarepants - Revenge of the Flying Dutchman
+Name   = SpongeBob Squarepants - Revenge of the Flying Dutchman
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -35301,7 +35382,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-20466
-Name   = Gravenville - Ghost Master
+Name   = Ghost Master - The Gravenville Chronicles
 Region = NTSC-U
 ---------------------------------------------
 Serial = SLUS-20467
@@ -41435,7 +41516,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21818
-Name   = Spongebob Squarepants Featuring Nicktoons - Globs Of Doom
+Name   = SpongeBob Squarepants Featuring Nicktoons - Globs Of Doom
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
@@ -42670,7 +42751,7 @@ Compat = 5
 ---------------------------------------------
 Serial = TCES-51613
 Name   = This Is Football 2004 [Beta]
-Region = PAL-E-S
+Region = PAL-M2	// UK & ES
 ---------------------------------------------
 Serial = TCES-51904
 Name   = SOCOM II - U.S. Navy SEALs [Beta]

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1043,11 +1043,11 @@ vuClampMode = 2 // Text in GT mode works
 ---------------------------------------------
 Serial = SCAJ-30010
 Name   = God of War
-Region = NTSC-UK
+Region = NTSC-EN
 ---------------------------------------------
 Serial = SCAJ-30011
 Name   = God of War II
-Region = NTSC-UK
+Region = NTSC-EN
 ---------------------------------------------
 Serial = SCED-50041
 Name   = Tekken Tag Tournament [Demo]
@@ -1059,7 +1059,8 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCED-50254
 Name   = Official Review of the 2000 FIA Formula 1 World Championship [Formula One 2001 Bonus Disc]
-Region = PAL-E
+Region = PAL-Unk
+// Bundled with Formula One 2001 Limited Edition Pack
 ---------------------------------------------
 Serial = SCED-50286
 Name   = Red Faction [Demo]


### PR DESCRIPTION
Specifications & Corrections of PAL-regions, mainly extracted from:
http://redump.org/discs/system/ps2/
http://ns348841.ip-91-121-109.eu/psxdata/psx2/pal_list2.html
http://wiki.redump.org/index.php?title=Sony_Playstation_2_PAL_Missing_Dumps
