### PR TITLE
spu2-x: windows: Fix incorrect sscanf, remove unnecessary unicode to ascii conversion

### DIFF
--- a/plugins/spu2-x/src/Windows/Dialogs.h
+++ b/plugins/spu2-x/src/Windows/Dialogs.h
@@ -40,7 +40,7 @@ namespace SoundtouchCfg
 }
 
 extern int		SendDialogMsg( HWND hwnd, int dlgId, UINT code, WPARAM wParam, LPARAM lParam);
-extern HRESULT	GUIDFromString( const char *str, LPGUID guid );
+extern HRESULT	GUIDFromString( const wchar_t *str, LPGUID guid );
 
 extern void		AssignSliderValue( HWND idcwnd, HWND hwndDisplay, int value );
 extern void		AssignSliderValue( HWND hWnd, int idc, int editbox, int value );

--- a/plugins/spu2-x/src/Windows/SndOut_DSound.cpp
+++ b/plugins/spu2-x/src/Windows/SndOut_DSound.cpp
@@ -117,11 +117,7 @@ public:
 			if( m_Device.empty() )
 				throw std::runtime_error( "screw it" );
 
-			// Convert from unicode to ANSI:
-			char guid[256];
-			sprintf_s( guid, "%S", m_Device.c_str() );
-
-			if( (FAILED(GUIDFromString( guid, &cGuid ))) ||
+			if ((FAILED(GUIDFromString(m_Device, &cGuid))) ||
 				FAILED( DirectSoundCreate8(&cGuid,&dsound,NULL) ) )
 					throw std::runtime_error( "try again?" );
 		}
@@ -286,9 +282,7 @@ private:
 			{
 				wchar_t temp[128];
 
-				char temp2[192];
-				sprintf_s( temp2, "%S", m_Device.c_str() );
-				haveGuid = ! FAILED(GUIDFromString(temp2,&DevGuid));
+				haveGuid = !FAILED(GUIDFromString(m_Device, &DevGuid));
 				SendMessage(GetDlgItem(hWnd,IDC_DS_DEVICE),CB_RESETCONTENT,0,0);
 
 				ndevs=0;

--- a/plugins/spu2-x/src/Windows/UIHelpers.cpp
+++ b/plugins/spu2-x/src/Windows/UIHelpers.cpp
@@ -23,7 +23,7 @@ int SendDialogMsg( HWND hwnd, int dlgId, UINT code, WPARAM wParam, LPARAM lParam
 	return SendMessage( GetDlgItem(hwnd,dlgId), code, wParam, lParam );
 }
 
-HRESULT GUIDFromString(const char *str, LPGUID guid)
+HRESULT GUIDFromString(const wchar_t *str, LPGUID guid)
 {
 	// "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
 
@@ -32,7 +32,7 @@ HRESULT GUIDFromString(const char *str, LPGUID guid)
 		int k; // << not used but still needed as of January 6th, 2011
 	} t;
 
-	int r = sscanf_s(str,"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+	int r = swscanf_s(str,L"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
 		&t.g.Data1,
 		&t.g.Data2,
 		&t.g.Data3,

--- a/plugins/spu2-x/src/Windows/UIHelpers.cpp
+++ b/plugins/spu2-x/src/Windows/UIHelpers.cpp
@@ -27,28 +27,39 @@ HRESULT GUIDFromString(const wchar_t *str, LPGUID guid)
 {
 	// "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
 
-	struct T{	// this is a hack because for some reason sscanf writes too much :/
-		GUID g;
-		int k; // << not used but still needed as of January 6th, 2011
-	} t;
+	// VS2015 supports the hh format specifier (finally). VS2013 doesn't though,
+	// so this will do for now.
+	u32 guid_u32;
+	u16 guid_u16[2];
+	u16 guid_u8[8];
 
-	int r = swscanf_s(str,L"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-		&t.g.Data1,
-		&t.g.Data2,
-		&t.g.Data3,
-		&t.g.Data4[0],
-		&t.g.Data4[1],
-		&t.g.Data4[2],
-		&t.g.Data4[3],
-		&t.g.Data4[4],
-		&t.g.Data4[5],
-		&t.g.Data4[6],
-		&t.g.Data4[7]
+	int r = swscanf_s(str,L"{%08x-%04hx-%04hx-%02hx%02hx-%02hx%02hx%02hx%02hx%02hx%02hx}",
+		&guid_u32,
+		&guid_u16[0],
+		&guid_u16[1],
+		&guid_u8[0],
+		&guid_u8[1],
+		&guid_u8[2],
+		&guid_u8[3],
+		&guid_u8[4],
+		&guid_u8[5],
+		&guid_u8[6],
+		&guid_u8[7]
 	);
 
 	if(r!=11) return -1;
 
-	*guid = t.g;
+	guid->Data1 = guid_u32;
+	guid->Data2 = guid_u16[0];
+	guid->Data3 = guid_u16[1];
+	guid->Data4[0] = (u8)guid_u8[0];
+	guid->Data4[1] = (u8)guid_u8[1];
+	guid->Data4[2] = (u8)guid_u8[2];
+	guid->Data4[3] = (u8)guid_u8[3];
+	guid->Data4[4] = (u8)guid_u8[4];
+	guid->Data4[5] = (u8)guid_u8[5];
+	guid->Data4[6] = (u8)guid_u8[6];
+	guid->Data4[7] = (u8)guid_u8[7];
 	return 0;
 }
 


### PR DESCRIPTION
Changes:
 * Removes an unnecessary unicode to ascii conversion.
 * Fixes the incorrect use of sscanf, where half width ("h", "hh") format specifiers were not used. This was the reason why sscanf "writes too much".