### PR TITLE
Update russian locale

### DIFF
--- a/locales/ru_RU/pcsx2_Main.po
+++ b/locales/ru_RU/pcsx2_Main.po
@@ -705,9 +705,13 @@ msgstr "Мелкий шрифт"
 msgid "It's what I use (the programmer guy)."
 msgstr "Это то что я использую. (Программист)."
 
-#: pcsx2/gui/ConsoleLogger.cpp:419 pcsx2/gui/Panels/CpuPanel.cpp:38
-msgid "Normal"
+#: pcsx2/gui/ConsoleLogger.cpp:419 
+msgid "Normal font"
 msgstr "Средний шрифт"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:38
+msgid "Normal"
+msgstr "Normal"
 
 #: pcsx2/gui/ConsoleLogger.cpp:421
 msgid "Its nice and readable."

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -435,7 +435,7 @@ ConsoleLogFrame::ConsoleLogFrame( MainEmuFrame *parent, const wxString& title, A
 
 	menuFontSizes.Append( MenuId_FontSize_Small,	_("Small"),	_t("Fits a lot of log in a microcosmically small area."),
 		wxITEM_RADIO )->Check( options.FontSize == 7 );
-	menuFontSizes.Append( MenuId_FontSize_Normal,	_("Normal"),_t("It's what I use (the programmer guy)."),
+	menuFontSizes.Append( MenuId_FontSize_Normal,	_("Normal font"),_t("It's what I use (the programmer guy)."),
 		wxITEM_RADIO )->Check( options.FontSize == 8 );
 	menuFontSizes.Append( MenuId_FontSize_Large,	_("Large"),	_t("Its nice and readable."),
 		wxITEM_RADIO )->Check( options.FontSize == 10 );


### PR DESCRIPTION
Russian locale update.
In emulation settings window -> EE/IOP and VU tabs -> Clamping mode box, word "Normal" was translated in context of fonts so it was "Средний шрифт" - medium font. I make it just "Normal" as rest of untranslated options. "Normal" in log window appearance dialog now "Normal font".