### PR TITLE
windows: Fix detection of Ctrl and Shift key presses

### DIFF
--- a/pcsx2/windows/WinKeyCodes.cpp
+++ b/pcsx2/windows/WinKeyCodes.cpp
@@ -25,9 +25,11 @@ int TranslateVKToWXK(u32 keysym)
 	switch (keysym)
 	{
 	// Shift, Control, Alt and Menu
+	case VK_SHIFT:
 	case VK_LSHIFT:
 	case VK_RSHIFT: key_code = WXK_SHIFT; break;
 
+	case VK_CONTROL:
 	case VK_LCONTROL:
 	case VK_RCONTROL: key_code = WXK_CONTROL; break;
 


### PR DESCRIPTION
Fixes #674, where VK_CONTROL and VK_SHIFT were not detected properly. Credit for this fix goes to @poodle111

The regression was introduced in commit 760de9915bb54d1243f8afc95f7d630ca3eb54ec.