### PR TITLE
Auto-detect memory card types instead of trusting the config ini.

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -611,10 +611,6 @@ void AppConfig::LoadSaveMemcards( IniInterface& ini )
 			Mcd[slot].Enabled, Mcd[slot].Enabled );
 		ini.Entry( pxsFmt( L"Slot%u_Filename", slot+1 ),
 			Mcd[slot].Filename, Mcd[slot].Filename );
-		int type = (int)Mcd[slot].Type;
-		ini.Entry( pxsFmt( L"Slot%u_Type", slot + 1 ),
-			type, (int)MemoryCardType::MemoryCard_File );
-		Mcd[slot].Type = (MemoryCardType)type;
 	}
 
 	for( uint slot=2; slot<8; ++slot )
@@ -626,10 +622,6 @@ void AppConfig::LoadSaveMemcards( IniInterface& ini )
 			Mcd[slot].Enabled, Mcd[slot].Enabled );
 		ini.Entry( pxsFmt( L"Multitap%u_Slot%u_Filename", mtport, mtslot ),
 			Mcd[slot].Filename, Mcd[slot].Filename );
-		int type = (int)Mcd[slot].Type;
-		ini.Entry( pxsFmt( L"Multitap%u_Slot%u_Type", mtport, mtslot ),
-			type, (int)MemoryCardType::MemoryCard_File );
-		Mcd[slot].Type = (MemoryCardType)type;
 	}
 }
 

--- a/pcsx2/gui/MemoryCardFile.cpp
+++ b/pcsx2/gui/MemoryCardFile.cpp
@@ -428,6 +428,22 @@ uint FileMcd_ConvertToSlot( uint port, uint slot )
 
 static void PS2E_CALLBACK FileMcd_EmuOpen( PS2E_THISPTR thisptr, const PS2E_SessionInfo *session )
 {
+	// detect inserted memory card types
+	for ( uint slot = 0; slot < 8; ++slot ) {
+		if ( g_Conf->Mcd[slot].Enabled ) {
+			MemoryCardType type = MemoryCardType::MemoryCard_File; // default to file if we can't find anything at the path so it gets auto-generated
+
+			const wxString path = g_Conf->FullpathToMcd( slot );
+			if ( wxFileExists( path ) ) {
+				type = MemoryCardType::MemoryCard_File;
+			} else if ( wxDirExists( path ) ) {
+				type = MemoryCardType::MemoryCard_Folder;
+			}
+
+			g_Conf->Mcd[slot].Type = type;
+		}
+	}
+
 	thisptr->impl.Open();
 	thisptr->implFolder.SetFiltering( g_Conf->EmuOptions.McdFolderAutoManage );
 	thisptr->implFolder.Open();


### PR DESCRIPTION
This should fix the issue discussed here:
http://forums.pcsx2.net/Thread-Memory-cards-not-showing
http://forums.pcsx2.net/Thread-Memory-Card-bug-in-latest-revisions

I can't figure out what exactly triggers the issue in the first place, though. It's most likely related to using a pre-folder-mcd config file in a newer version, but I can't get it to reproduce reliably.