### PR TITLE
gsdx-ogl: extend HDR colclip to 32 bits textures

### DIFF
--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -959,7 +959,7 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	}
 
 	if (ps_sel.hdr) {
-		hdr_rt = dev->CreateTexture(rtsize.x, rtsize.y, GL_RGBA16F);
+		hdr_rt = dev->CreateTexture(rtsize.x, rtsize.y, GL_RGBA32F);
 
 		dev->CopyRectConv(rt, hdr_rt, ComputeBoundingBox(rtscale, rtsize), false);
 


### PR DESCRIPTION
To test shadow rendering on castlevania

@prafullpcsx2 could you make a build for @Kein Thanks you.