### PR TITLE
wxWidgets 3.0 fixes

### DIFF
--- a/3rdparty/wxwidgets3.0/build/msw/wx30_core_vs2013.vcxproj
+++ b/3rdparty/wxwidgets3.0/build/msw/wx30_core_vs2013.vcxproj
@@ -979,7 +979,7 @@
     <ClInclude Include="..\..\include\wx\msw\progdlg.h" />
     <ClInclude Include="..\..\include\wx\msw\radiobox.h" />
     <ClInclude Include="..\..\include\wx\msw\radiobut.h" />
-    <ClInclude Include="..\..\include\wx\msw\rcdefs.h" />
+    <ClInclude Include="..\..\$(PlatformName)\wx\msw\rcdefs.h" />
     <ClInclude Include="..\..\include\wx\msw\region.h" />
     <ClInclude Include="..\..\include\wx\msw\richmsgdlg.h" />
     <ClInclude Include="..\..\include\wx\msw\scrolbar.h" />

--- a/3rdparty/wxwidgets3.0/build/msw/wx30_core_vs2013.vcxproj.filters
+++ b/3rdparty/wxwidgets3.0/build/msw/wx30_core_vs2013.vcxproj.filters
@@ -1171,7 +1171,7 @@
     <ClInclude Include="..\..\include\wx\msw\radiobut.h">
       <Filter>MSW Headers</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\wx\msw\rcdefs.h">
+    <ClInclude Include="..\..\$(PlatformName)\wx\msw\rcdefs.h">
       <Filter>MSW Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\msw\region.h">

--- a/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
+++ b/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
@@ -301,7 +301,17 @@ void Dialogs::BaseConfigurationDialog::OnScreenshot_Click( wxCommandEvent& evt )
 	if( !filename.IsEmpty() )
 	{
 		ScopedBusyCursor busy( Cursor_ReallyBusy );
+#ifdef __WXMSW__
+		// FIXME: Ideally the alpha channel information should be dealt with
+		// at the window level. This will do until I have a comprehensive fix
+		// ready.
+		wxImage image = memBmp.ConvertToImage();
+		if (image.HasAlpha())
+			image.ClearAlpha();
+		image.SaveFile( filename, wxBITMAP_TYPE_PNG );
+#else
 		memBmp.SaveFile( filename, wxBITMAP_TYPE_PNG );
+#endif
 	}
 }
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -92,6 +92,7 @@ GSPanel::GSPanel( wxWindow* parent )
 
 	InitDefaultAccelerators();
 
+	SetBackgroundColour(wxColour((unsigned long)0));
 	if( g_Conf->GSWindow.AlwaysHideMouse )
 	{
 		SetCursor( wxCursor(wxCURSOR_BLANK) );

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -353,7 +353,6 @@ namespace Panels
 
 		void OnEnable_Toggled( wxCommandEvent& evt );
 		void Defaults_Click( wxCommandEvent& evt );
-		void Slider_Click(wxScrollEvent &event);
 		void EECycleRate_Scroll(wxScrollEvent &event);
 		void VUCycleRate_Scroll(wxScrollEvent &event);
 	};

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -197,13 +197,13 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	*m_vuSliderPanel += m_slider_vustealer | sliderFlags;
 	*m_vuSliderPanel += m_msg_vustealer | sliderFlags;
 
-	*vuHacksPanel	+= m_check_vuFlagHack;
-	*vuHacksPanel	+= m_check_vuThread;
+	*vuHacksPanel += m_check_vuFlagHack | StdExpand();
+	*vuHacksPanel += m_check_vuThread | StdExpand();
 	//*vuHacksPanel	+= 57; // Aligns left and right boxes in default language and font size
 
-	*miscHacksPanel	+= m_check_intc;
-	*miscHacksPanel	+= m_check_waitloop;
-	*miscHacksPanel	+= m_check_fastCDVD;
+	*miscHacksPanel	+= m_check_intc | StdExpand();
+	*miscHacksPanel	+= m_check_waitloop | StdExpand();
+	*miscHacksPanel	+= m_check_fastCDVD | StdExpand();
 
 	*left	+= m_eeSliderPanel | StdExpand();
 	*left	+= miscHacksPanel	| StdExpand();

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -226,13 +226,6 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 
 	// ------------------------------------------------------------------------
 
-	Connect( wxEVT_SCROLL_PAGEUP,	wxScrollEventHandler( SpeedHacksPanel::Slider_Click ) );
-	Connect( wxEVT_SCROLL_PAGEDOWN,	wxScrollEventHandler( SpeedHacksPanel::Slider_Click ) );
-	Connect( wxEVT_SCROLL_LINEUP,	wxScrollEventHandler( SpeedHacksPanel::Slider_Click ) );
-	Connect( wxEVT_SCROLL_LINEDOWN,	wxScrollEventHandler( SpeedHacksPanel::Slider_Click ) );
-	Connect( wxEVT_SCROLL_TOP,		wxScrollEventHandler( SpeedHacksPanel::Slider_Click ) );
-	Connect( wxEVT_SCROLL_BOTTOM,	wxScrollEventHandler( SpeedHacksPanel::Slider_Click ) );
-
 	Connect( m_slider_eecycle->GetId(),		wxEVT_SCROLL_CHANGED, wxScrollEventHandler( SpeedHacksPanel::EECycleRate_Scroll ) );
 	Connect( m_slider_vustealer->GetId(),	wxEVT_SCROLL_CHANGED, wxScrollEventHandler( SpeedHacksPanel::VUCycleRate_Scroll ) );
 	Connect( m_check_Enable->GetId(),		wxEVT_COMMAND_CHECKBOX_CLICKED,	wxCommandEventHandler( SpeedHacksPanel::OnEnable_Toggled ) );
@@ -341,30 +334,6 @@ void Panels::SpeedHacksPanel::Defaults_Click( wxCommandEvent& evt )
 	currentConfigWithHacksReset.EnablePresets=false;//speed hacks gui depends on preset, apply it as if presets are disabled
 	ApplyConfigToGui( currentConfigWithHacksReset );
 	evt.Skip();
-}
-
-void Panels::SpeedHacksPanel::Slider_Click(wxScrollEvent &event) {
-	wxSlider* slider = (wxSlider*) event.GetEventObject();
-	int value = slider->GetValue();
-	int eventType = event.GetEventType();
-	if (eventType == wxEVT_SCROLL_PAGEUP || eventType == wxEVT_SCROLL_LINEUP) {
-		if (value > slider->GetMin()) {
-			slider->SetValue(value-1);
-		}
-	}
-	else if (eventType == wxEVT_SCROLL_TOP) {
-		slider->SetValue(slider->GetMin());
-	}
-	else if (eventType == wxEVT_SCROLL_PAGEDOWN || eventType == wxEVT_SCROLL_LINEDOWN) {
-		if (value < slider->GetMax()) {
-			slider->SetValue(value+1);
-		}
-	}
-	else if (eventType == wxEVT_SCROLL_BOTTOM) {
-		slider->SetValue(slider->GetMax());
-	}
-
-	event.Skip();
 }
 
 void Panels::SpeedHacksPanel::EECycleRate_Scroll(wxScrollEvent &event)


### PR DESCRIPTION
Regressions fixed:
 * EE and VU Slider click handling - pcsx2 uses a custom event handler to handle click events, and then passes the event to the default wxWidgets click handler. So click events are processed twice. Remove the custom event handler - it's designed for Windows yet only breaks Windows.
 * GSPanel colour - Now it's black instead of the default grey.
 * wxCore30 rcdefs.h location - wxCore30 continually reports that it's out of date because it can't find rcdefs.h. The pathname is now fixed for the VS2013 file.

Regressions partially fixed:
 * Screenshot function - The default alpha channel settings of wx3.0 on Windows seem different from wx2.8. For now I've removed the alpha channel information from the image on Windows which degrades the screenshots slightly. The proper fix should be to set the transparency of all the UI elements correctly, but that'll probably take quite a while to do correctly.

Other fixes:
 * Speedhacks description - The "Other Hacks" and "microVU Hacks" checkbox descriptions are truncated. This problem actually existed on Windows wx2.8 as well, but was less obvious. Use sizer flags so that the checkbox descriptions are shown in full. (Or should be, only tested a few languages)

Tested on Windows VS2013, Linux wx2.8/wx3.0.

Question: Why does the EE slider start from 1 and the VU slider start from 0? It makes no sense to me.