### PR TITLE
gsdx:linux: Add GSDrawingContext.cpp to CMakeLists.txt

### DIFF
--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -80,6 +80,7 @@ set(GSdxSources
     GSDeviceSW.cpp
     GSDeviceNull.cpp
     GSDirtyRect.cpp
+    GSDrawingContext.cpp
     GSDrawScanline.cpp
     GSDrawScanlineCodeGenerator.cpp
     GSDrawScanlineCodeGenerator.x86.avx.cpp


### PR DESCRIPTION
Fixes the missing symbol error since 49b3acea72a4c2a37811a4616cb2d940355b6952