### PR TITLE
Linux: Add Cmake Options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,9 @@ endif()
 #-------------------------------------------------------------------------------
 # Install some files to ease package creation
 if(PACKAGE_MODE)
-    INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/cheats_ws.zip" DESTINATION "${GAMEINDEX_DIR}")
+    if(NOT DISABLE_CHEATS_ZIP)
+        INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/cheats_ws.zip" DESTINATION "${GAMEINDEX_DIR}")
+    endif()
     INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/GameIndex.dbf" DESTINATION "${GAMEINDEX_DIR}")
 
     # set categories depending on system/distribution in pcsx2.desktop
@@ -104,5 +106,7 @@ if(PACKAGE_MODE)
     INSTALL(FILES "${CMAKE_SOURCE_DIR}/bin/docs/PCSX2_FAQ.pdf"      DESTINATION "${DOC_DIR}")
     INSTALL(FILES "${CMAKE_SOURCE_DIR}/bin/docs/PCSX2_Readme.pdf"   DESTINATION "${DOC_DIR}")
     INSTALL(FILES "${CMAKE_SOURCE_DIR}/bin/docs/PCSX2.1"            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/man/man1/")
-    INSTALL(FILES "${CMAKE_SOURCE_DIR}/bin/PCSX2-linux.sh"          DESTINATION "${BIN_DIR}")
+    if(NOT DISABLE_PCSX2_WRAPPER)
+        INSTALL(FILES "${CMAKE_SOURCE_DIR}/bin/PCSX2-linux.sh"          DESTINATION "${BIN_DIR}")
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(Pcsx2Utils)
 
 check_no_parenthesis_in_path()
 detectOperatingSystem()
-check_compiler_version("4.7" "4.5")
+check_compiler_version("4.8" "4.8")
 
 #-------------------------------------------------------------------------------
 # Include specific module

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -40,6 +40,8 @@ option(BUILD_REPLAY_LOADERS "Build GS replayer to ease testing (developer option
 # Path and lib option
 #-------------------------------------------------------------------------------
 option(PACKAGE_MODE "Use this option to ease packaging of PCSX2 (developer/distribution option)")
+option(DISABLE_CHEATS_ZIP "Disable including the cheats_ws.zip file")
+option(DISABLE_PCSX2_WRAPPER "Disable including the PCSX2-linux.sh file")
 option(XDG_STD "Use XDG standard path instead of the standard PCSX2 path")
 option(EXTRA_PLUGINS "Build various 'extra' plugins")
 option(SDL2_API "Use SDL2 on spu2x and onepad (experimental/wxWidget mustn't be built with SDL1.2 support")

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -226,7 +226,7 @@ endif()
 #-------------------------------------------------------------------------------
 # Set some default compiler flags
 #-------------------------------------------------------------------------------
-set(COMMON_FLAG "-pipe -std=c++11 -fvisibility=hidden -pthread")
+set(COMMON_FLAG "-pipe -std=c++11 -fvisibility=hidden -pthread -fno-builtin-strcmp -fno-builtin-memcmp")
 if (DISABLE_SVU)
     set(COMMON_FLAG "${COMMON_FLAG} -DDISABLE_SVU")
 endif()

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -226,7 +226,7 @@ endif()
 #-------------------------------------------------------------------------------
 # Set some default compiler flags
 #-------------------------------------------------------------------------------
-set(COMMON_FLAG "-pipe -std=c++0x -fvisibility=hidden -pthread")
+set(COMMON_FLAG "-pipe -std=c++11 -fvisibility=hidden -pthread")
 if (DISABLE_SVU)
     set(COMMON_FLAG "${COMMON_FLAG} -DDISABLE_SVU")
 endif()


### PR DESCRIPTION
Hello:

I was testing the current master branch in Debian and might as well submit the changes I did.

Commit 1: 
Adds some options to not include those files which are fairly optional. I left the defaults to INSTALL since that was the previous behavior.

Commit 2: 
Looking at https://gcc.gnu.org/projects/cxx0x.html it requires 4.8 (not sure about 4.8.1)
It failed to build until I tried gcc 4.8.4. There is stuff like this that might not be needed:
```
    # GCC-4.6 crash pcsx2 during the binding of plugins at startup...
    # Disable this optimization for the moment
    -fno-omit-frame-pointer
    # END GCC-4.6
```

Commit 3:
This is optional. While looking at the windows code I saw the memcmp_mmx function and remembered the gcc bug in memcmp. If the size of the strings are large the hit of performance is fairly big. I have not profiled it for PCSX2 but if it does not help it can be dropped.

More info in
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43052
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59048

The only thing left is maybe move Lilypad to extras plugins but that can wait until just before the 1.4 release to see if someone fixes it by then. If it does not get fixed by then it should probably be removed before the stable release.

This is probably not worth a bug report since it's most likely caused by the transition to gcc-5.2 but i get this with current master
```
(gdb) set pagination 0
(gdb) run
Starting program: /usr/games/PCSX2 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Interface is initializing.  Entering Pcsx2App::OnInit!
Applying operating system default language...
Command line parsing...
Command line parsed!
[New Thread 0xf436ab40 (LWP 8912)]
[New Thread 0xf3751b40 (LWP 8915)]

Program received signal SIGSEGV, Segmentation fault.
0xf7e4a65a in wxFormatString::AsWChar() () from /usr/lib/i386-linux-gnu/libwx_baseu-3.0.so.0
(gdb) bt
#0  0xf7e4a65a in wxFormatString::AsWChar() () from /usr/lib/i386-linux-gnu/libwx_baseu-3.0.so.0
#1  0x08243124 in operator wchar_t const* (this=0xffffc5f8) at /usr/include/wx-3.0/wx/strvararg.h:225
#2  Format<wxCStrData> (a1=<error reading variable: access outside bounds of object referenced via synthetic pointer>, f1=...) at /usr/include/wx-3.0/wx/string.h:2322
#3  PerPluginMenuInfo::Populate (this=this@entry=0xa175870, pid=pid@entry=PluginId_GS) at /tmp/buildd/pcsx2-1.3.1-906-g241367e+dfsg/pcsx2/gui/MainFrame.cpp:753
#4  0x082446a9 in MainEmuFrame::MainEmuFrame (this=0xa175418, parent=0x0, title=...) at /tmp/buildd/pcsx2-1.3.1-906-g241367e+dfsg/pcsx2/gui/MainFrame.cpp:334
#5  0x081b9450 in Pcsx2App::OpenMainFrame (this=this@entry=0xa04d100) at /tmp/buildd/pcsx2-1.3.1-906-g241367e+dfsg/pcsx2/gui/AppInit.cpp:67
#6  0x081c0227 in Pcsx2App::OnInit (this=0xa04d100) at /tmp/buildd/pcsx2-1.3.1-906-g241367e+dfsg/pcsx2/gui/AppInit.cpp:464
#7  0xf7e07146 in wxEntry(int&, wchar_t**) () from /usr/lib/i386-linux-gnu/libwx_baseu-3.0.so.0
#8  0xf7e071e3 in wxEntry(int&, char**) () from /usr/lib/i386-linux-gnu/libwx_baseu-3.0.so.0
#9  0x081c2cdd in main (argc=1, argv=0xffffd434) at /tmp/buildd/pcsx2-1.3.1-906-g241367e+dfsg/pcsx2/gui/AppMain.cpp:53
(gdb) quit
```
I wanted to update to master because of this 87bcb465c6c2238137dbf99890e9032930a5f6cd but the transition broke everything.