### PR TITLE
Use global compiler optimization flags instead of defining them for every plugin/binary

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -124,14 +124,17 @@ if(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386")
     #     - Only plugins. No package will link to them.
     set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
 
-    if (DISABLE_ADVANCE_SIMD)
-        set(ARCH_FLAG "-msse -msse2 -march=i686")
-    else()
-        # AVX requires some fix of the ABI (mangling) (default 2)
-        # Note: V6 requires GCC 4.7
-        #set(ARCH_FLAG "-march=native -fabi-version=6")
-        set(ARCH_FLAG "-march=native")
+    if(NOT DEFINED ARCH_FLAG)
+        if (DISABLE_ADVANCE_SIMD)
+            set(ARCH_FLAG "-msse -msse2 -march=i686")
+        else()
+            # AVX requires some fix of the ABI (mangling) (default 2)
+            # Note: V6 requires GCC 4.7
+            #set(ARCH_FLAG "-march=native -fabi-version=6")
+            set(ARCH_FLAG "-march=native")
+        endif()
     endif()
+
     add_definitions(-D_ARCH_32=1 -D_M_X86=1 -D_M_X86_32=1)
     set(_ARCH_32 1)
     set(_M_X86 1)
@@ -143,11 +146,13 @@ elseif(${PCSX2_TARGET_ARCHITECTURES} MATCHES "x86_64")
     # SuperVU will not be ported
     set(DISABLE_SVU TRUE)
 
-    if (DISABLE_ADVANCE_SIMD)
-        set(ARCH_FLAG "-msse -msse2")
-    else()
-        #set(ARCH_FLAG "-march=native -fabi-version=6")
-        set(ARCH_FLAG "-march=native")
+    if(NOT DEFINED ARCH_FLAG)
+        if (DISABLE_ADVANCE_SIMD)
+            set(ARCH_FLAG "-msse -msse2")
+        else()
+            #set(ARCH_FLAG "-march=native -fabi-version=6")
+            set(ARCH_FLAG "-march=native")
+        endif()
     endif()
     add_definitions(-D_ARCH_64=1 -D_M_X86=1 -D_M_X86_64=1)
     set(_ARCH_64 1)
@@ -266,8 +271,12 @@ else()
     set(ASAN_FLAG "")
 endif()
 
+if(NOT DEFINED OPTIMIZATION_FLAG)
+    set(OPTIMIZATION_FLAG -O2)
+endif()
+
 # Note: -DGTK_DISABLE_DEPRECATED can be used to test a build without gtk deprecated feature. It could be useful to port to a newer API
-set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG}")
+set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG}")
 # c++ only flags
 set(DEFAULT_CPP_FLAG "${DEFAULT_GCC_FLAG} -Wno-invalid-offsetof")
 

--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CommonFlags
 	-fno-strict-aliasing
     )
 
-set(OptimizationFlags -O2)
-
 #Clang doesn't support a few common flags that GCC does.
 if(NOT USE_CLANG)
 	set(UtilitiesFinalFlags
@@ -38,7 +36,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Devel)
 	# add defines
 	set(UtilitiesFinalFlags
 		${UtilitiesFinalFlags}
-		${CommonFlags} ${OptimizationFlags} -DPCSX2_DEVBUILD
+		${CommonFlags} -DPCSX2_DEVBUILD
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Devel)
 
@@ -48,7 +46,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Release)
 	# add defines
 	set(UtilitiesFinalFlags
 		${UtilitiesFinalFlags}
-		${CommonFlags} ${OptimizationFlags}
+		${CommonFlags}
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Release)
 

--- a/common/src/x86emitter/CMakeLists.txt
+++ b/common/src/x86emitter/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CommonFlags
 	-fno-strict-aliasing
     )
 
-set(OptimizationFlags -O2)
-
 #Clang doesn't support a few common flags that GCC does.
 if(NOT USE_CLANG)
 	set(x86emitterFinalFlags
@@ -36,7 +34,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Devel)
 	# add defines
 	set(x86emitterFinalFlags
 		${x86emitterFinalFlags}
-		${CommonFlags} ${OptimizationFlags} -DPCSX2_DEVBUILD
+		${CommonFlags} -DPCSX2_DEVBUILD
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Devel)
 
@@ -46,7 +44,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Release)
 	# add defines
 	set(x86emitterFinalFlags
 		${x86emitterFinalFlags}
-		${CommonFlags} ${OptimizationFlags}
+		${CommonFlags}
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Release)
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -26,8 +26,6 @@ set(CommonFlags
     -DWX_PRECOMP
 	)
 
-set(OptimizationFlags -O2)
-
 #Clang doesn't support a few common flags that GCC does.
 if(NOT USE_CLANG)
 	set(pcsx2FinalFlags ${CommonFlags} -fno-guess-branch-probability -fno-dse -fno-tree-dse)
@@ -38,10 +36,10 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
 	set(pcsx2FinalFlags ${pcsx2FinalFlags} ${CommonFlags} -DPCSX2_DEVBUILD -DPCSX2_DEBUG)
 
 elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(pcsx2FinalFlags ${pcsx2FinalFlags} ${CommonFlags} ${OptimizationFlags} -DPCSX2_DEVBUILD)
+	set(pcsx2FinalFlags ${pcsx2FinalFlags} ${CommonFlags} -DPCSX2_DEVBUILD)
 
 elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(pcsx2FinalFlags ${pcsx2FinalFlags} ${CommonFlags} ${OptimizationFlags})
+	set(pcsx2FinalFlags ${pcsx2FinalFlags} ${CommonFlags})
 
 endif()
 

--- a/plugins/CDVDiso/src/CMakeLists.txt
+++ b/plugins/CDVDiso/src/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output CDVDiso)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(CDVDisoFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(CDVDisoFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(CDVDisoFinalFlags ${OptimizationFlags})
-
-endif()
+set(CDVDisoFinalFlags "")
 
 # CDVDiso sources
 set(CDVDisoSources

--- a/plugins/CDVDlinuz/Src/CMakeLists.txt
+++ b/plugins/CDVDlinuz/Src/CMakeLists.txt
@@ -2,26 +2,7 @@
 
 # plugin name
 set(Output CDVDlinuz)
-
-set(CommonFlags
-    -D_LARGEFILE64_SOURCE
-    )
-
-set(OptimizationFlags
-    -O2
-    -fomit-frame-pointer
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(CDVDlinuzFinalFlags ${CommonFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(CDVDlinuzFinalFlags ${CommonFlags} ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(CDVDlinuzFinalFlags ${CommonFlags} ${OptimizationFlags})
-
-endif()
+set(CDVDlinuzFinalFlags -D_LARGEFILE64_SOURCE)
 
 # CDVDlinuz sources
 set(CDVDlinuzSources

--- a/plugins/CDVDnull/CMakeLists.txt
+++ b/plugins/CDVDnull/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output CDVDnull)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(CDVDnullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(CDVDnullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(CDVDnullFinalFlags ${OptimizationFlags})
-
-endif()
+set(CDVDnullFinalFlags "")
 
 # CDVDnull sources
 set(CDVDnullSources

--- a/plugins/FWnull/CMakeLists.txt
+++ b/plugins/FWnull/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output FWnull-0.7.0)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(FWnullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(FWnullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(FWnullFinalFlags ${OptimizationFlags})
-
-endif()
+set(FWnullFinalFlags "")
 
 # FWnull sources
 set(FWnullSources

--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -18,17 +18,14 @@ set(CommonFlags
     -Wunused-variable # __dummy variable need to be investigated
     )
 
-set(OptimizationFlags -O2)
-
-
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} -D_DEBUG)
 
 elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-    set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} ${OptimizationFlags} -D_DEVEL)
+    set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} -D_DEVEL)
 
 elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-    set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} ${OptimizationFlags} -W)
+    set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} -W)
 
 endif()
 

--- a/plugins/GSnull/CMakeLists.txt
+++ b/plugins/GSnull/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output GSnull)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(GSnullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(GSnullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(GSnullFinalFlags ${OptimizationFlags})
-
-endif()
+set(GSnullFinalFlags "")
 
 # GSnull sources
 set(GSnullSources

--- a/plugins/LilyPad/CMakeLists.txt
+++ b/plugins/LilyPad/CMakeLists.txt
@@ -9,19 +9,10 @@ endif()
 # plugin name
 set(Output LilyPad-0.11.0)
 
-set(OptimizationFlags
-    -O2
-    )
-
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     set(lilypadFinalFlags "-DPCSX2_DEBUG")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(lilypadFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(lilypadFinalFlags ${OptimizationFlags})
-
+else()
+    set(lilypadFinalFlags "")
 endif()
 
 # lilypad sources

--- a/plugins/PadNull/CMakeLists.txt
+++ b/plugins/PadNull/CMakeLists.txt
@@ -7,21 +7,7 @@ endif()
 
 # plugin name
 set(Output PADnull)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(PadNullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(PadNullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(PadNullFinalFlags ${OptimizationFlags})
-
-endif()
+set(PadNullFinalFlags "")
 
 # PadNull sources
 set(PadNullSources

--- a/plugins/SPU2null/CMakeLists.txt
+++ b/plugins/SPU2null/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output SPU2null)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(SPU2nullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(SPU2nullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(SPU2nullFinalFlags ${OptimizationFlags})
-
-endif()
+set(SPU2nullFinalFlags "")
 
 # SPU2null sources
 set(SPU2nullSources

--- a/plugins/USBnull/CMakeLists.txt
+++ b/plugins/USBnull/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output USBnull-0.7.0)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-	set(USBnullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(USBnullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(USBnullFinalFlags ${OptimizationFlags})
-
-endif()
+set(USBnullFinalFlags "")
 
 # USBnull sources
 set(USBnullSources

--- a/plugins/dev9null/CMakeLists.txt
+++ b/plugins/dev9null/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output dev9null-0.5.0)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(dev9nullFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(dev9nullFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(dev9nullFinalFlags ${OptimizationFlags})
-
-endif()
+set(dev9nullFinalFlags "")
 
 # dev9null sources
 set(dev9nullSources

--- a/plugins/onepad/CMakeLists.txt
+++ b/plugins/onepad/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output onepad-1.1.0)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(onepadFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(onepadFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(onepadFinalFlags ${OptimizationFlags})
-
-endif()
+set(onepadFinalFlags "")
 
 # onepad sources
 set(onepadSources

--- a/plugins/spu2-x/src/CMakeLists.txt
+++ b/plugins/spu2-x/src/CMakeLists.txt
@@ -14,21 +14,7 @@ endif()
 
 # plugin name
 set(Output spu2x-2.0.0)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(spu2xFinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(spu2xFinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(spu2xFinalFlags ${OptimizationFlags})
-
-endif()
+set(spu2xFinalFlags "")
 
 # spu2x sources
 set(spu2xSources

--- a/plugins/zerogs/opengl/CMakeLists.txt
+++ b/plugins/zerogs/opengl/CMakeLists.txt
@@ -7,10 +7,6 @@ set(CommonFlags
     -Wall
     )
 
-set(OptimizationFlags
-    -O2
-    )
-
 # Debug - Build
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
 	# add defines
@@ -20,13 +16,13 @@ endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 # Devel - Build
 if(CMAKE_BUILD_TYPE STREQUAL Devel)
 	# add defines
-	add_definitions(${CommonFlags} ${OptimizationFlags})
+	add_definitions(${CommonFlags})
 endif(CMAKE_BUILD_TYPE STREQUAL Devel)
 
 # Release - Build
 if(CMAKE_BUILD_TYPE STREQUAL Release)
 	# add defines
-	add_definitions(${CommonFlags} ${OptimizationFlags})
+	add_definitions(${CommonFlags})
 endif(CMAKE_BUILD_TYPE STREQUAL Release)
 
 # zerogs sources

--- a/plugins/zerospu2/CMakeLists.txt
+++ b/plugins/zerospu2/CMakeLists.txt
@@ -8,21 +8,7 @@ endif()
 
 # plugin name
 set(Output zerospu2)
-
-set(OptimizationFlags
-    -O2
-    )
-
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(zerospu2FinalFlags "")
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
-	set(zerospu2FinalFlags ${OptimizationFlags})
-
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-	set(zerospu2FinalFlags ${OptimizationFlags})
-
-endif(CMAKE_BUILD_TYPE STREQUAL Release)
+set(zerospu2FinalFlags "")
 
 # zerospu2 sources
 set(zerospu2Sources

--- a/plugins/zzogl-pg/opengl/CMakeLists.txt
+++ b/plugins/zzogl-pg/opengl/CMakeLists.txt
@@ -26,10 +26,6 @@ set(CommonFlags
     -Wunused-variable
     )
 
-set(OptimizationFlags
-    -O2
-    )
-
 #Clang doesn't support a few common flags that GCC does.
 if(NOT USE_CLANG)
 	set(zzoglFinalFlags
@@ -46,12 +42,12 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
 elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
     set(zzoglFinalFlags
         ${zzoglFinalFlags}
-        ${CommonFlags} ${OptimizationFlags} -g -W -DZEROGS_DEVBUILD
+        ${CommonFlags} -g -W -DZEROGS_DEVBUILD
     )
 elseif(CMAKE_BUILD_TYPE STREQUAL Release)
     set(zzoglFinalFlags
         ${zzoglFinalFlags}
-        ${CommonFlags} ${OptimizationFlags} -W
+        ${CommonFlags} -W
     )
 endif()
 

--- a/plugins/zzogl-pg/opengl/ZeroGSShaders/CMakeLists.txt
+++ b/plugins/zzogl-pg/opengl/ZeroGSShaders/CMakeLists.txt
@@ -17,21 +17,17 @@ set(CommonFlags
     -DNVIDIA_CG_API
     )
 
-set(OptimizationFlags
-    -O2
-    )
-
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     set(zerogsshadersFinalFlags
         ${CommonFlags} -D_DEBUG
     )
 elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
     set(zerogsshadersFinalFlags
-        ${CommonFlags} ${OptimizationFlags} -g -W -DZEROGS_DEVBUILD
+        ${CommonFlags} -g -W -DZEROGS_DEVBUILD
     )
 elseif(CMAKE_BUILD_TYPE STREQUAL Release)
     set(zerogsshadersFinalFlags
-        ${CommonFlags} ${OptimizationFlags} -W
+        ${CommonFlags} -W
     )
 endif(CMAKE_BUILD_TYPE STREQUAL Release)
 

--- a/tools/bin2cpp/CMakeLists.txt
+++ b/tools/bin2cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ set(bin2cppName bin2cpp)
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
 	# add defines
 	set(bin2cppFinalFlags
-		-O2 -s -Wall -fexceptions
+		-s -Wall -fexceptions
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 
@@ -15,7 +15,7 @@ endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 if(CMAKE_BUILD_TYPE STREQUAL Devel)
 	# add defines
 	set(bin2cppFinalFlags
-		-O2 -s -Wall -fexceptions
+		-s -Wall -fexceptions
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Devel)
 
@@ -23,7 +23,7 @@ endif(CMAKE_BUILD_TYPE STREQUAL Devel)
 if(CMAKE_BUILD_TYPE STREQUAL Release)
 	# add defines
 	set(bin2cppFinalFlags
-		-O2 -s -Wall -fexceptions
+		-s -Wall -fexceptions
 	)
 endif(CMAKE_BUILD_TYPE STREQUAL Release)
 


### PR DESCRIPTION
In Gentoo Linux every user defines compiler flags that best suits his system.
It's usually set to recommended "-O2 -match=native", but some can try another optimizations (or even other compilers with other flags).

Currently, pcsx2 build system force "-O2" flag for most plugins. That patch allow to disable all extra CFLAGS by providing DISABLE_OPTIMIZATION cmake option.