### PR TITLE
Linux: Don't use O2 in the Debug Build.

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -272,7 +272,11 @@ else()
 endif()
 
 if(NOT DEFINED OPTIMIZATION_FLAG)
-    set(OPTIMIZATION_FLAG -O2)
+    if (CMAKE_BUILD_TYPE STREQUAL Debug)
+        set(OPTIMIZATION_FLAG -O0)
+    else()
+        set(OPTIMIZATION_FLAG -O2)
+    endif()
 endif()
 
 # Note: -DGTK_DISABLE_DEPRECATED can be used to test a build without gtk deprecated feature. It could be useful to port to a newer API


### PR DESCRIPTION
IF
   - DEFINED OPTIMIZATION_FLAG => assume the user knows what it's doing
   - NOT DEFINED OPTIMIZATION_FLAG AND (DEVEL OR RELEASE) => -O2
   - NOT DEFINED OPTIMIZATION_FLAG AND DEBUG => blank = -O0

I had a commit like this in the cmake PR but removed it. There was an oversight in the one merged.

Edit: Add the explicit -O0 to Debug to override any -O in USER_CMAKE_CXX_FLAGS or USER_CMAKE_C_FLAGS.