### PR TITLE
FolderMemcard: Keep open handles on files.

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -687,7 +687,7 @@ bool FolderMemoryCard::ReadFromFile( u8 *dest, u32 adr, u32 dataLength ) {
 	auto it = m_fileMetadataQuickAccess.find( fatCluster );
 	if ( it != m_fileMetadataQuickAccess.end() ) {
 		const u32 clusterNumber = it->second.consecutiveCluster;
-		wxFFile* file = m_lastAccessedFile.ReOpen( m_folderName, &it->second, L"rb" );
+		wxFFile* file = m_lastAccessedFile.ReOpen( m_folderName, &it->second );
 		if ( file->IsOpened() ) {
 			const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
 			const u32 fileOffset = clusterNumber * ClusterSize + clusterOffset;
@@ -1111,7 +1111,7 @@ bool FolderMemoryCard::WriteToFile( const u8* src, u32 adr, u32 dataLength ) {
 		const u32 clusterNumber = it->second.consecutiveCluster;
 		
 		if ( m_performFileWrites ) {
-			wxFFile* file = m_lastAccessedFile.ReOpen( m_folderName, &it->second, L"r+b", true );
+			wxFFile* file = m_lastAccessedFile.ReOpen( m_folderName, &it->second, true );
 			if ( file->IsOpened() ) {
 				const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
 				const u32 fileSize = entry->entry.data.length;
@@ -1316,7 +1316,7 @@ FileAccessHelper::~FileAccessHelper() {
 	this->Close();
 }
 
-wxFFile* FileAccessHelper::Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata ) {
+wxFFile* FileAccessHelper::Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata ) {
 	this->Close();
 
 	wxFileName fn( folderName );
@@ -1331,9 +1331,8 @@ wxFFile* FileAccessHelper::Open( const wxFileName& folderName, MemoryCardFileMet
 		createEmptyFile.Close();
 	}
 
-	m_file = new wxFFile( filename, mode );
+	m_file = new wxFFile( filename, L"r+b" );
 	m_entry = fileRef->entry;
-	m_mode = mode;
 
 	if ( writeMetadata ) {
 		const MemoryCardFileEntry* const entry = fileRef->entry;
@@ -1366,11 +1365,11 @@ wxFFile* FileAccessHelper::Open( const wxFileName& folderName, MemoryCardFileMet
 	return m_file;
 }
 
-wxFFile* FileAccessHelper::ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata ) {
-	if ( m_file && fileRef->entry == m_entry && mode == m_mode ) {
+wxFFile* FileAccessHelper::ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata ) {
+	if ( m_file && fileRef->entry == m_entry ) {
 		return m_file;
 	} else {
-		return this->Open( folderName, fileRef, mode, writeMetadata );
+		return this->Open( folderName, fileRef, writeMetadata );
 	}
 }
 

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1410,6 +1410,17 @@ wxFFile* FileAccessHelper::ReOpen( const wxFileName& folderName, MemoryCardFileM
 	}
 }
 
+void FileAccessHelper::CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry ) {
+	file->Close();
+
+	if ( entry != nullptr ) {
+		wxFileName fn( file->GetName() );
+		fn.SetTimes( nullptr, &entry->entry.data.timeModified.ToWxDateTime(), &entry->entry.data.timeCreated.ToWxDateTime() );
+	}
+
+	delete file;
+}
+
 void FileAccessHelper::CloseMatching( const wxString& path ) {
 	wxFileName fn( path );
 	fn.Normalize();
@@ -1417,8 +1428,7 @@ void FileAccessHelper::CloseMatching( const wxString& path ) {
 	for ( auto it = m_files.begin(); it != m_files.end(); ) {
 		wxString openPath = it->second->GetName();
 		if ( openPath.StartsWith( pathNormalized ) ) {
-			it->second->Close();
-			delete it->second;
+			CloseFileHandle( it->second, it->first );
 			it = m_files.erase( it );
 		} else {
 			++it;
@@ -1428,8 +1438,7 @@ void FileAccessHelper::CloseMatching( const wxString& path ) {
 
 void FileAccessHelper::CloseAll() {
 	for ( auto it = m_files.begin(); it != m_files.end(); ++it ) {
-		it->second->Close();
-		delete it->second;
+		CloseFileHandle( it->second, it->first );
 	}
 	m_files.clear();
 }

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -188,6 +188,7 @@ struct MemoryCardFileMetadataReference {
 class FileAccessHelper {
 protected:
 	std::map<const MemoryCardFileEntry* const, wxFFile*> m_files;
+	MemoryCardFileMetadataReference* m_lastWrittenFileRef; // we remember this to reduce redundant metadata checks/writes
 
 public:
 	FileAccessHelper();
@@ -209,6 +210,9 @@ public:
 protected:
 	// Open a new file and remember it for later
 	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
+
+	void WriteMetadata( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef );
+	void WriteMetadata( bool metadataIsNonstandard, const wxFileName& metadataFilename, const MemoryCardFileEntry* const entry );
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -187,8 +187,7 @@ struct MemoryCardFileMetadataReference {
 // Small helper class to keep memory card files opened between calls to Read()/Save() 
 class FileAccessHelper {
 protected:
-	wxFFile* m_file;
-	const MemoryCardFileEntry* m_entry;
+	std::map<const MemoryCardFileEntry* const, wxFFile*> m_files;
 
 public:
 	FileAccessHelper();
@@ -196,8 +195,12 @@ public:
 
 	// Get an already opened file if possible, or open a new one and remember it
 	wxFFile* ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
-	// Close an open file, if any
-	void Close();
+	// Close all open files that start with the given path, so either a file if a filename is given or all files in a directory and its subdirectories when a directory is given
+	void CloseMatching( const wxString& path );
+	// Close all open files
+	void CloseAll();
+	// Flush the written data of all open files to the file system
+	void FlushAll();
 
 	// removes characters from a PS2 file name that would be illegal in a Windows file system
 	// returns true if any changes were made
@@ -413,7 +416,8 @@ protected:
 
 
 	// adds a file to the quick-access dictionary, so it can be accessed more efficiently (ie, without searching through the entire file system) later
-	void AddFileEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
+	// returns the MemoryCardFileMetadataReference of the first file cluster, or nullptr if the file is zero-length
+	MemoryCardFileMetadataReference* AddFileEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
 
 	// creates a reference to a directory entry, so it can be passed as parent to other files/directories
 	MemoryCardFileMetadataReference* AddDirEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -189,14 +189,13 @@ class FileAccessHelper {
 protected:
 	wxFFile* m_file;
 	const MemoryCardFileEntry* m_entry;
-	wxString m_mode;
 
 public:
 	FileAccessHelper();
 	~FileAccessHelper();
 
 	// Get an already opened file if possible, or open a new one and remember it
-	wxFFile* ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata = false );
+	wxFFile* ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
 	// Close an open file, if any
 	void Close();
 
@@ -206,7 +205,7 @@ public:
 
 protected:
 	// Open a new file and remember it for later
-	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, const wxString& mode, bool writeMetadata = false );
+	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -85,6 +85,19 @@ struct MemoryCardFileEntryDateTime {
 		return t;
 	}
 
+	wxDateTime ToWxDateTime() const {
+		wxDateTime::Tm tm;
+		tm.sec = this->second;
+		tm.min = this->minute;
+		tm.hour = this->hour;
+		tm.mday = this->day;
+		tm.mon = (wxDateTime::Month)(this->month - 1);
+		tm.year = this->year;
+
+		wxDateTime time( tm );
+		return time.FromTimezone( wxDateTime::GMT9 );
+	}
+
 	bool operator==( const MemoryCardFileEntryDateTime& other ) const {
 		return unused == other.unused && second == other.second && minute == other.minute && hour == other.hour
 		    && day == other.day && month == other.month && year == other.year;
@@ -210,6 +223,9 @@ public:
 protected:
 	// Open a new file and remember it for later
 	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
+	// Close a file and delete its handle
+	// If entry is given, it also attempts to set the created and modified timestamps of the file according to the entry
+	void CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry = nullptr );
 
 	void WriteMetadata( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef );
 	void WriteMetadata( bool metadataIsNonstandard, const wxFileName& metadataFilename, const MemoryCardFileEntry* const entry );


### PR DESCRIPTION
Discussed in #666. This keeps all files in the virtual memory card open while the emulator is running, preventing other programs/users from modifying or deleting them. Oddly enough not all programs seem to respect that, somehow; Notepad++ still can edit the file, HxD cannot, Windows Explorer can't delete or rename/move. So this could probably be improved but it's much better than before.

Additionally, since the opportunity presented itself, I now adjust the host file system file timestamps to match the memory card's internal ones.