### PR TITLE
use GameDB editor also on the normal builds.

### DIFF
--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -465,7 +465,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	m_menuConfig.Append(MenuId_Config_SysSettings,	_("Emulation &Settings") );
 	m_menuConfig.Append(MenuId_Config_McdSettings,	_("&Memory cards") );
 	m_menuConfig.Append(MenuId_Config_BIOS,			_("&Plugin/BIOS Selector") );
-	if (IsDebugBuild) m_menuConfig.Append(MenuId_Config_GameDatabase,	_("Game Database Editor") );
+	m_menuConfig.Append(MenuId_Config_GameDatabase,	_("Game Database Editor") );
 	// Empty menu
 	// m_menuConfig.Append(MenuId_Config_Language,		_("Appearance...") );
 


### PR DESCRIPTION
I personally don't feel it to be only limited to the debug builds, it works fine also on the release builds. This would give users easier way of customizing the GameDB through PCSX2 itself instead of customizing through the DBF file.