### PR TITLE
Improve nVidia Optimus and AMD PowerXpress compatibility

### DIFF
--- a/pcsx2/windows/Optimus.cpp
+++ b/pcsx2/windows/Optimus.cpp
@@ -1,0 +1,32 @@
+/*  PCSX2 - PS2 Emulator for PCs
+*  Copyright (C) 2002-2015  PCSX2 Dev Team
+*
+*  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+*  of the GNU Lesser General Public License as published by the Free Software Found-
+*  ation, either version 3 of the License, or (at your option) any later version.
+*
+*  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+*  PURPOSE.  See the GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along with PCSX2.
+*  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PrecompiledHeader.h"
+
+#ifdef _WIN32
+
+//This ensures that the nVidia graphics card is used for PCSX2 on an Optimus-enabled system.
+//302 or higher driver required.
+extern "C" {
+	_declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
+//This is the equivalent for an AMD system.
+//13.35 or newer driver required.
+extern "C" {
+	_declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
+#endif

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -698,6 +698,7 @@
     <ClCompile Include="..\..\gui\SysState.cpp" />
     <ClCompile Include="..\..\ZipTools\thread_gzip.cpp" />
     <ClCompile Include="..\..\ZipTools\thread_lzma.cpp" />
+    <ClCompile Include="..\Optimus.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\AsyncFileReader.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -871,6 +871,9 @@
     <ClCompile Include="..\WinKeyCodes.cpp">
       <Filter>AppHost\Win32</Filter>
     </ClCompile>
+    <ClCompile Include="..\Optimus.cpp">
+      <Filter>AppHost\Win32</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Patch.h">


### PR DESCRIPTION
Fix for https://github.com/PCSX2/pcsx2/issues/659 - signal to the nVidia drivers that, if it is an "Optimus"-enabled computer, that the high-performance graphics card should be used with PCSX2. This export must be added to the main executable not to the graphics plugin(s) - the nVidia drivers only look at the main executable.

Sorry this simple change is spread over multiple commits!