### PR TITLE
Fix things found by lintian.

### DIFF
--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -415,7 +415,7 @@ void populate_hack_table(GtkWidget* hack_table)
 	AddTooltip(hack_offset_check, IDC_OFFSETHACK);
 	AddTooltip(hack_skipdraw_label, IDC_SKIPDRAWHACK);
 	AddTooltip(hack_skipdraw_spin, IDC_SKIPDRAWHACK);
-	gtk_widget_set_tooltip_text(hack_enble_check, "Allow to use hack below");
+	gtk_widget_set_tooltip_text(hack_enble_check, "Allows the use of the hack below");
 	AddTooltip(hack_wild_check, IDC_WILDHACK);
 	AddTooltip(hack_sprite_label, hack_sprite_box, IDC_SPRITEHACK);
 	AddTooltip(hack_tco_label, IDC_TCOFFSETX);

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -127,7 +127,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"------------------------------------------------------------------\n"
 				"Ultra\t: The blending unit will be completely emulated by the shader. It is ultra slow! It is intended for debug\n";
 		case IDC_TC_DEPTH:
-			return "Allow to convert Depth buffer from/to Color buffer. It is used for blur & depth of field effects";
+			return "Allows the conversion of Depth buffer from/to Color buffer. It is used for blur & depth of field effects";
 		default:
 			if (updateText)
 				*updateText = false;

--- a/plugins/GSdx/res/glsl/tfx_fs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_fs.glsl
@@ -8,7 +8,7 @@
 #define FMT_16 2
 #define FMT_PAL 4 /* flag bit */
 
-// APITRACE_DEBUG allows to force pixel output to easily detect
+// APITRACE_DEBUG enables forced pixel output to easily detect
 // the fragment computed by primitive
 #define APITRACE_DEBUG 0
 // TEX_COORD_DEBUG output the uv coordinate as color. It is useful

--- a/plugins/GSdx/res/glsl_source.h
+++ b/plugins/GSdx/res/glsl_source.h
@@ -867,7 +867,7 @@ static const char* tfx_fs_all_glsl =
 	"#define FMT_16 2\n"
 	"#define FMT_PAL 4 /* flag bit */\n"
 	"\n"
-	"// APITRACE_DEBUG allows to force pixel output to easily detect\n"
+	"// APITRACE_DEBUG enables forced pixel output to easily detect\n"
 	"// the fragment computed by primitive\n"
 	"#define APITRACE_DEBUG 0\n"
 	"// TEX_COORD_DEBUG output the uv coordinate as color. It is useful\n"


### PR DESCRIPTION
I: pcsx2: spelling-error-in-binary usr/lib/i386-linux-gnu/pcsx2/libGSdx-1.0.0.so allows to allows one to
I: pcsx2: spelling-error-in-binary usr/lib/i386-linux-gnu/pcsx2/libGSdx-1.0.0.so Allow to Allow one to
.
Apparently lintian checks grammar too (most common ones).