### PR TITLE
FolderMemoryCard: Fix Linux compile error.

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1415,7 +1415,9 @@ void FileAccessHelper::CloseFileHandle( wxFFile* file, const MemoryCardFileEntry
 
 	if ( entry != nullptr ) {
 		wxFileName fn( file->GetName() );
-		fn.SetTimes( nullptr, &entry->entry.data.timeModified.ToWxDateTime(), &entry->entry.data.timeCreated.ToWxDateTime() );
+		wxDateTime modified = entry->entry.data.timeModified.ToWxDateTime();
+		wxDateTime created = entry->entry.data.timeCreated.ToWxDateTime();
+		fn.SetTimes( nullptr, &modified, &created );
 	}
 
 	delete file;


### PR DESCRIPTION
See the comments on f9e6a023463a5139a89367286310c6520dc6836a.