### PR TITLE
Windows: Fix bot

### DIFF
--- a/common/build/x86emitter/x86emitter.vcxproj
+++ b/common/build/x86emitter/x86emitter.vcxproj
@@ -150,6 +150,12 @@
     <ClInclude Include="..\..\include\x86emitter\implement\simd_moremovs.h" />
     <ClInclude Include="..\..\include\x86emitter\implement\simd_shufflepack.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\3rdparty\wxwidgets3.0\build\msw\wx30_config.vcxproj">
+      <Project>{01f4ce10-2cfb-41a8-b41f-e54337868a1d}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
Build wx30config before x86emitter.

I tested 29/29 of the projects in the main solution.
I tested 7/7 of the unique projects in the old plugin solution.

Hopefully nothing else is wrong.