### PR TITLE
Lilypad: Fix Local Volume control CB function and few other stuffs

### DIFF
--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -927,7 +927,7 @@ void Pcsx2App::OpenGsPanel()
 	GSFrame* gsFrame = GetGsFramePtr();
 	if( gsFrame == NULL )
 	{
-		gsFrame = new GSFrame( GetMainFramePtr(), GetAppName() );
+		gsFrame = new GSFrame(GetAppName() );
 		m_id_GsFrame = gsFrame->GetId();
 
 		switch( wxGetApp().Overrides.GsWindowMode )

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -401,8 +401,8 @@ void GSPanel::OnLeftDclick(wxMouseEvent& evt)
 static const uint TitleBarUpdateMs = 333;
 
 
-GSFrame::GSFrame(wxWindow* parent, const wxString& title)
-	: wxFrame(parent, wxID_ANY, title, g_Conf->GSWindow.WindowPos)
+GSFrame::GSFrame( const wxString& title)
+	: wxFrame(NULL, wxID_ANY, title, g_Conf->GSWindow.WindowPos)
 	, m_timer_UpdateTitle( this )
 {
 	SetIcons( wxGetApp().GetIconBundle() );

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -95,7 +95,7 @@ protected:
 	CpuUsageProvider		m_CpuUsage;
 
 public:
-	GSFrame(wxWindow* parent, const wxString& title);
+	GSFrame( const wxString& title);
 	virtual ~GSFrame() throw();
 
 	GSPanel* GetViewport();

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -207,7 +207,7 @@ __ri void branchWarning(mV) {
 	incPC(-2);
 	if (mVUup.eBit && mVUbranch) {
 		incPC(2);
-		Console.Error("microVU%d Warning: Branch in E-bit delay slot! [%04x]", mVU.index, xPC);
+		DevCon.Warning("microVU%d Warning: Branch in E-bit delay slot! [%04x]", mVU.index, xPC);
 		mVUlow.isNOP = true;
 	}
 	else incPC(2);

--- a/plugins/LilyPad/Config.cpp
+++ b/plugins/LilyPad/Config.cpp
@@ -1925,7 +1925,6 @@ INT_PTR CALLBACK GeneralDialogProc(HWND hWnd, unsigned int msg, WPARAM wParam, L
 					// sound plugin plays with it.
 					SetVolume(100);
 				}
-				config.vistaVolume = 100;
 			}
 
 			for (i=0; i<4; i++) {


### PR DESCRIPTION
There was a wrong value change for vistaVolume in condition for when it is disabled, it sets 100 to the variable. hence when the checkbox gets unchecked, it eventually leads the Local volume control checkbox to be force enabled even when a user disables it at the dialog. the following patch corrects the behavior.

Partial fix for #629 