### PR TITLE
Mkdir() doesn't allow const qualifier [-fpermissive]

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1362,7 +1362,7 @@ void FileAccessHelper::WriteMetadata( const wxFileName& folderName, MemoryCardFi
 	WriteMetadata( metadataIsNonstandard, fn, entry );
 }
 
-void FileAccessHelper::WriteMetadata( bool metadataIsNonstandard, const wxFileName& metadataFilename, const MemoryCardFileEntry* const entry ) {
+void FileAccessHelper::WriteMetadata( bool metadataIsNonstandard, wxFileName& metadataFilename, const MemoryCardFileEntry* const entry ) {
 	if ( metadataIsNonstandard ) {
 		// write metadata of file if it's nonstandard
 		if ( !metadataFilename.DirExists() ) {

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -228,7 +228,7 @@ protected:
 	void CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry = nullptr );
 
 	void WriteMetadata( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef );
-	void WriteMetadata( bool metadataIsNonstandard, const wxFileName& metadataFilename, const MemoryCardFileEntry* const entry );
+	void WriteMetadata( bool metadataIsNonstandard, wxFileName& metadataFilename, const MemoryCardFileEntry* const entry );
 };
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes: error: passing 'const wxFileName' as 'this' argument of 'bool wxFileName::Mkdir(int, int)' discards qualifiers [-fpermissive]