### PR TITLE
FolderMemoryCard: Don't load files in the root dir when filtering.

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -316,6 +316,11 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 			bool isFile = wxFile::Exists( fileInfo.GetFullPath() );
 
 			if ( isFile ) {
+				// don't load files in the root dir if we're filtering; no official software stores files there
+				if ( enableFiltering && parent == nullptr ) {
+					hasNext = dir.GetNext( &fileName );
+					continue;
+				}
 				if ( AddFile( dirEntry, dirPath, fileName, parent ) ) {
 					++entryNumber;
 				}


### PR DESCRIPTION
No official game stores files there. You can easily check this by putting any file in the root dir and loading the PS2 BIOS, which will show it as corrupted data with an unknown filesize.

See also comments on #757.