### PR TITLE
Recognize Win 8, 8.1 and 10.

### DIFF
--- a/common/src/Utilities/Windows/WinMisc.cpp
+++ b/common/src/Utilities/Windows/WinMisc.cpp
@@ -55,6 +55,29 @@ u64 GetPhysicalMemory()
 typedef void (WINAPI *PGNSI)(LPSYSTEM_INFO);
 typedef BOOL (WINAPI *PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
 
+// Win 10 SDK
+#ifndef PRODUCT_CORE_N
+#	define PRODUCT_CORE_N                              0x00000062
+#endif
+#ifndef PRODUCT_CORE
+#	define PRODUCT_CORE                                0x00000065
+#endif
+#ifndef PRODUCT_PROFESSIONAL_WMC
+#	define PRODUCT_PROFESSIONAL_WMC                    0x00000067
+#endif
+#ifndef PRODUCT_EDUCATION
+#	define PRODUCT_EDUCATION                           0x00000079
+#endif
+#ifndef PRODUCT_EDUCATION_N
+#	define PRODUCT_EDUCATION_N                         0x0000007A
+#endif
+#ifndef PRODUCT_ENTERPRISE_S
+#	define PRODUCT_ENTERPRISE_S                        0x0000007D
+#endif
+#ifndef PRODUCT_ENTERPRISE_S_N
+#	define PRODUCT_ENTERPRISE_S_N                      0x0000007E
+#endif
+
 // Calculates the Windows OS Version and install information, and returns it as a
 // human-readable string. :)
 // (Handy function borrowed from Microsoft's MSDN Online, and reformatted to use wxString.)
@@ -92,7 +115,58 @@ wxString GetOSVersionString()
 
 	// Test for the specific product.
 
-	if ( osvi.dwMajorVersion == 6 )
+	if ( osvi.dwMajorVersion == 10 )
+	{
+		if( osvi.dwMinorVersion == 0 )
+			retval += ( osvi.wProductType == VER_NT_WORKSTATION ) ? L"Windows 10 " : L"Windows Server 2016 ";
+
+		pGPI = (PGPI) GetProcAddress( GetModuleHandle(TEXT("kernel32.dll")), "GetProductInfo");
+
+		pGPI( osvi.dwMajorVersion, osvi.dwMinorVersion, 0, 0, &dwType);
+
+		switch( dwType )
+		{
+			case PRODUCT_CORE:							retval += L"Home";							break;
+			case PRODUCT_CORE_N:						retval += L"Home N";						break;
+			case PRODUCT_PROFESSIONAL:					retval += L"Pro";							break;
+			case PRODUCT_PROFESSIONAL_N:				retval += L"Pro N";							break;
+			case PRODUCT_ENTERPRISE:					retval += L"Enterprise";					break;
+			case PRODUCT_ENTERPRISE_N:					retval += L"Enterprise N";					break;
+			case PRODUCT_ENTERPRISE_S:					retval += L"Enterprise 2015 LTSB";			break;
+			case PRODUCT_ENTERPRISE_S_N:				retval += L"Enterprise 2015 LTSB N";		break;
+			case PRODUCT_EDUCATION:						retval += L"Education";						break;
+			case PRODUCT_EDUCATION_N:					retval += L"Education N";					break;
+		}
+	}
+
+	if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 1 )
+	{
+		if ( osvi.dwMinorVersion == 2 )
+			retval += ( osvi.wProductType == VER_NT_WORKSTATION ) ? L"Windows 8 " : L"Windows Server 2012 ";
+
+		if ( osvi.dwMinorVersion == 3 )
+			retval += ( osvi.wProductType == VER_NT_WORKSTATION ) ? L"Windows 8.1 " : L"Windows Server 2012 R2 ";
+
+		pGPI = (PGPI) GetProcAddress( GetModuleHandle(TEXT("kernel32.dll")), "GetProductInfo");
+
+		pGPI( osvi.dwMajorVersion, osvi.dwMinorVersion, 0, 0, &dwType);
+
+		switch( dwType )
+		{
+			case PRODUCT_PROFESSIONAL:					retval += L"Pro";							break;
+			case PRODUCT_PROFESSIONAL_N:				retval += L"Pro N";							break;
+			case PRODUCT_PROFESSIONAL_WMC:				retval += L"Pro with Media Center";			break;
+			case PRODUCT_ENTERPRISE:					retval += L"Enterprise";					break;
+			case PRODUCT_ENTERPRISE_N:					retval += L"Enterprise N";					break;
+			case PRODUCT_SERVER_FOUNDATION:				retval += L"Foundation";					break;
+			case PRODUCT_STANDARD_SERVER:				retval += L"Standard";						break;
+			case PRODUCT_STANDARD_SERVER_CORE:			retval += L"Standard (core)";				break;
+			case PRODUCT_DATACENTER_SERVER:				retval += L"Datacenter";					break;
+			case PRODUCT_DATACENTER_SERVER_CORE:		retval += L"Datacenter (core)";				break;
+		}
+	}
+
+	if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion <= 1 )
 	{
 		if( osvi.dwMinorVersion == 0 )
 			retval += ( osvi.wProductType == VER_NT_WORKSTATION ) ? L"Windows Vista " : L"Windows Server 2008 ";

--- a/common/src/Utilities/Windows/WinMisc.cpp
+++ b/common/src/Utilities/Windows/WinMisc.cpp
@@ -244,7 +244,7 @@ wxString GetOSVersionString()
 	if ( osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 1 )
 	{
 		retval += L"Windows XP ";
-		retval += ( osvi.wSuiteMask & VER_SUITE_PERSONAL ) ? L"Professional" : L"Home Edition";
+		retval += ( osvi.wSuiteMask & VER_SUITE_PERSONAL ) ? L"Home Edition" : L"Professional";
 	}
 
 	if ( osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 0 )

--- a/pcsx2/windows/PCSX2.manifest
+++ b/pcsx2/windows/PCSX2.manifest
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity
+        type="win32"
+        name="PCSX2"
+        version="1.0.0.0"
+    />
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+        </application>
+    </compatibility>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"
+            />
+        </dependentAssembly>
+    </dependency>
+</assembly>

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -942,6 +942,9 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(RootDir)%(Directory)\%(Filename).h</Outputs>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="..\PCSX2.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -1390,4 +1390,9 @@
       <Filter>AppHost\Resources</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="..\PCSX2.manifest">
+      <Filter>AppHost\Resources</Filter>
+    </Manifest>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/windows/desktop/dn481241(v=vs.85).aspx
>In Windows 8.1 and Windows 10, the GetVersion and GetVersionEx APIs have been deprecated and superseded by the Version Helper APIs. While you can still call the deprecated APIs, if your application does not specifically target Windows 8.1 or Windows 10, you will get Windows 8 version (6.2.0.0).
In order to target Windows 8.1 or Windows 10, you need to include the app manifest in the source file. 

Before:
```
Host Machine Init:
	Operating System =  Microsoft  (build 9200), 64-bit
```

After, w/o the manifest:
```
Host Machine Init:
	Operating System =  Microsoft Windows 8 Pro (build 9200), 64-bit
```

After, with manifest:
```
Host Machine Init:
	Operating System =  Microsoft Windows 10 Pro (build 10240), 64-bit
```

Not sure if the manifest breaks the executable in Windows XP but it should work for Vista and up.