### PR TITLE
Move icons (Emulation Settings, Plugin BIOS selector) to the left

### DIFF
--- a/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
+++ b/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
@@ -37,12 +37,9 @@ DEFINE_EVENT_TYPE( pxEvt_SomethingChanged )
 using namespace Panels;
 
 // configure the orientation of the listbox based on the platform
+// For now, they're all on the left.
+static const int s_orient = wxLB_LEFT;
 
-#if defined(__WXMAC__) || defined(__WXMSW__)
-	static const int s_orient = wxBK_TOP;
-#else
-	static const int s_orient = wxBK_LEFT;
-#endif
 
 class ScopedOkButtonDisabler
 {
@@ -314,10 +311,4 @@ void Dialogs::BaseConfigurationDialog::OnScreenshot_Click( wxCommandEvent& evt )
 		memBmp.SaveFile( filename, wxBITMAP_TYPE_PNG );
 #endif
 	}
-}
-
-void Dialogs::BaseConfigurationDialog::OnSettingsApplied( wxCommandEvent& evt )
-{
-	evt.Skip();
-	MSW_ListView_SetIconSpacing( m_listbook, GetClientSize().GetWidth() );
 }

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -70,8 +70,6 @@ namespace Dialogs
 		}
 
 	protected:
-		void OnSettingsApplied( wxCommandEvent& evt );
-
 		void OnOk_Click( wxCommandEvent& evt );
 		void OnCancel_Click( wxCommandEvent& evt );
 		void OnApply_Click( wxCommandEvent& evt );

--- a/pcsx2/gui/MSWstuff.cpp
+++ b/pcsx2/gui/MSWstuff.cpp
@@ -14,15 +14,11 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "GSFrame.h"
 
 #include "MSWstuff.h"
-#include <wx/listbook.h>
-#include <wx/listctrl.h>
 
 #ifdef __WXMSW__
 #	include <wx/msw/wrapwin.h>		// needed for OutputDebugString
-#	include <commctrl.h>
 #endif
 
 void MSW_SetWindowAfter( WXWidget hwnd, WXWidget hwndAfter )
@@ -30,28 +26,6 @@ void MSW_SetWindowAfter( WXWidget hwnd, WXWidget hwndAfter )
 #ifdef __WXMSW__
 	SetWindowPos( (HWND)hwnd, (HWND)hwndAfter, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOSIZE | SWP_NOMOVE );
 #endif
-}
-
-void MSW_ListView_SetIconSpacing( wxListbook& listbook, int width )
-{
-#ifdef __WXMSW__
-	// Depending on Windows version and user appearance settings, the default icon spacing can be
-	// way over generous.  This little bit of Win32-specific code ensures proper icon spacing, scaled
-	// to the size of the frame's ideal width.
-
-	if (listbook.GetPageCount())
-	{
-		ListView_SetIconSpacing( (HWND)listbook.GetListView()->GetHWND(),
-			(width / listbook.GetPageCount()) - 4, g_Conf->Listbook_ImageSize+32		// y component appears to be ignored
-		);
-	}
-#endif
-}
-
-void MSW_ListView_SetIconSpacing( wxListbook* listbook, int width )
-{
-	if( listbook == NULL ) return;
-	MSW_ListView_SetIconSpacing( *listbook, width );
 }
 
 float MSW_GetDPIScale()

--- a/pcsx2/gui/MSWstuff.h
+++ b/pcsx2/gui/MSWstuff.h
@@ -15,12 +15,9 @@
 
 #pragma once
 
-class wxListbook;
-
+// FIXME: Missing some includes.
 extern void MSW_SetWindowAfter( WXWidget hwnd, WXWidget hwndAfter );
 extern void MSW_OutputDebugString( const wxString& text );
-extern void MSW_ListView_SetIconSpacing( wxListbook& listbook, int width );
-extern void MSW_ListView_SetIconSpacing( wxListbook* listbook, int width );
 extern float MSW_GetDPIScale();
 
 extern void pxDwm_Load();

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -29,8 +29,6 @@ using namespace pxSizerFlags;
 Panels::FramelimiterPanel::FramelimiterPanel( wxWindow* parent )
 	: BaseApplicableConfigPanel_SpecificConfig( parent )
 {
-	SetMinWidth( 280 );
-
 	m_check_LimiterDisable = new pxCheckBox( this, _("Disable Framelimiting"),
 		_("Useful for running benchmarks. Toggle this option in-game by pressing F4.") );
 
@@ -169,8 +167,6 @@ void Panels::FramelimiterPanel::Apply()
 Panels::FrameSkipPanel::FrameSkipPanel( wxWindow* parent )
 	: BaseApplicableConfigPanel_SpecificConfig( parent )
 {
-	SetMinWidth( 350 );
-
 	const RadioPanelItem FrameskipOptions[] =
 	{
 		RadioPanelItem(


### PR DESCRIPTION
Benefits:
 * Fixes the minimise then restore dialog bug on the Emulation Settings and Plugin/BIOS selector, where the bottom GUI elements become misplaced.
 * Fixes a bug on 200% DPI (and maybe 175% DPI) where it's difficult to use GUI elements near the top (i.e. GS Plugin selector, Enable Speedhacks, etc.) since part of it becomes unclickable.
 * Makes Windows and Linux look more similar.
 * Makes it easier for me to work on the GUI stuff - currently I cannot see the whole Emulation Settings dialog when I use 200% dpi with my monitor, so it makes testing rather annoying. After the change, I can.

Does anyone object to this?

Before:
![before](https://cloud.githubusercontent.com/assets/10976277/9701541/6b0216e8-5426-11e5-93d8-42c9fcbea670.png)
After:
![after](https://cloud.githubusercontent.com/assets/10976277/9701542/70e2def8-5426-11e5-9000-360aa136c135.png)
