### PR TITLE
Change Playstation to PlayStation in the About dialog and the CLI dialog.

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -213,7 +213,7 @@ void Pcsx2App::AllocateCoreStuffs()
 
 void Pcsx2App::OnInitCmdLine( wxCmdLineParser& parser )
 {
-	parser.SetLogo( AddAppName(" >>  %s  --  A Playstation2 Emulator for the PC  <<") + L"\n\n" +
+	parser.SetLogo( AddAppName(" >>  %s  --  A PlayStation2 Emulator for the PC  <<") + L"\n\n" +
 		_("All options are for the current session only and will not be saved.\n")
 	);
 

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -213,7 +213,7 @@ void Pcsx2App::AllocateCoreStuffs()
 
 void Pcsx2App::OnInitCmdLine( wxCmdLineParser& parser )
 {
-	parser.SetLogo( AddAppName(" >>  %s  --  A PlayStation2 Emulator for the PC  <<") + L"\n\n" +
+	parser.SetLogo( AddAppName(" >>  %s  --  A PlayStation 2 Emulator for the PC  <<") + L"\n\n" +
 		_("All options are for the current session only and will not be saved.\n")
 	);
 

--- a/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
+++ b/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
@@ -95,7 +95,7 @@ Dialogs::AboutBoxDialog::AboutBoxDialog( wxWindow* parent )
 
 	*this	+= StdPadding;
 	*this	+= Text(wxGetApp().GetAppName()).Bold();
-	*this	+= Text(_("A Playstation 2 Emulator"));
+	*this	+= Text(_("A PlayStation 2 Emulator"));
 	*this	+= AuthLogoSizer						| StdExpand();
 
 	*this	+= new wxHyperlinkCtrl( this, wxID_ANY,


### PR DESCRIPTION
Changed the word "Playstation" to the proper "PlayStation" in the About
dialog and the Command Line Options dialog. Thanks to @ssakash for finding the proper files for me!