### PR TITLE
R5900: Add Overclock function for EE cycle rate.

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -387,7 +387,7 @@ struct Pcsx2Config
 				vuThread        :1;		// Enable Threaded VU1
 		BITFIELD_END
 
-		u8	EECycleRate;		// EE cycle rate selector (1.0, 1.5, 2.0)
+		s8	EECycleRate;		// EE cycle rate selector (1.0, 1.5, 2.0)
 		u8	VUCycleSteal;		// VU Cycle Stealer factor (0, 1, 2, or 3)
 
 		SpeedhackOptions();

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -23,16 +23,24 @@ const wxChar* Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
 {
 	switch( val )
 	{
+		case -2:
+			return pxEt( L"-2 - Increases the EE's cyclerate by about 50%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT."
+			);
+
+		case -1:
+			return pxEt( L"-1 - Increases the EE's cyclerate by about 33%. Increases hardware requirements, may increase in-game FPS."
+			);
+
+		case 0:
+			return pxEt( L"0 - Default cyclerate. This closely matches the actual speed of a real PS2 EmotionEngine."
+			);
+
 		case 1:
-			return pxEt( L"1 - Default cyclerate. This closely matches the actual speed of a real PS2 EmotionEngine."
+			return pxEt( L"1 - Reduces the EE's cyclerate by about 33%.  Mild speedup for most games with high compatibility."
 			);
 
 		case 2:
-			return pxEt( L"2 - Reduces the EE's cyclerate by about 33%.  Mild speedup for most games with high compatibility."
-			);
-
-		case 3:
-			return pxEt( L"3 - Reduces the EE's cyclerate by about 50%.  Moderate speedup, but *will* cause stuttering audio on many FMVs."
+			return pxEt( L"2 - Reduces the EE's cyclerate by about 50%.  Moderate speedup, but *will* cause stuttering audio on many FMVs."
 			);
 
 		default:
@@ -108,14 +116,14 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 
 	m_eeSliderPanel = new wxPanelWithHelpers( left, wxVERTICAL, _("EE Cyclerate [Not Recommended]") );
 
-	m_slider_eecycle = new wxSlider( m_eeSliderPanel, wxID_ANY, 1, 1, 3,
+	m_slider_eecycle = new wxSlider( m_eeSliderPanel, wxID_ANY, 0, -2, 2,
 		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
 
 	m_msg_eecycle = new pxStaticHeading( m_eeSliderPanel );
 	m_msg_eecycle->SetForegroundColour( wxColour( L"Red" ) );
-	m_msg_eecycle->SetHeight(3);
+	m_msg_eecycle->SetHeight(5);
 
-	const wxChar* ee_tooltip = pxEt( L"Setting higher values on this slider effectively reduces the clock speed of the EmotionEngine's R5900 core cpu, and typically brings big speedups to games that fail to utilize the full potential of the real PS2 hardware."
+	const wxChar* ee_tooltip = pxEt( L"Setting higher values on this slider effectively reduces the clock speed of the EmotionEngine's R5900 core cpu, and typically brings big speedups to games that fail to utilize the full potential of the real PS2 hardware. Conversely, lower values effectively increase the clock speed which may bring about an increase in in-game FPS while also making games more demanding and possibly causing glitches."
 	);
 
 	pxSetToolTip( m_slider_eecycle, ee_tooltip );
@@ -131,7 +139,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 
 	m_msg_vustealer = new pxStaticHeading(m_vuSliderPanel);
 	m_msg_vustealer->SetForegroundColour( wxColour( L"Red" ) );
-	m_msg_vustealer->SetHeight(3);
+	m_msg_vustealer->SetHeight(5);
 
 	const wxChar* vu_tooltip = pxEt( L"This slider controls the amount of cycles the VU unit steals from the EmotionEngine.  Higher values increase the number of cycles stolen from the EE for each VU microprogram the game runs."
 	);
@@ -272,7 +280,7 @@ void Panels::SpeedHacksPanel::ApplyConfigToGui( AppConfig& configToApply, int fl
 	// First, set the values of the widgets (checked/unchecked etc).
 	m_check_Enable->SetValue(configToApply.EnableSpeedHacks);
 
-	m_slider_eecycle	->SetValue( opts.EECycleRate + 1 );
+	m_slider_eecycle	->SetValue( opts.EECycleRate );
 	m_slider_vustealer	->SetValue( opts.VUCycleSteal );
 
 	SetEEcycleSliderMsg();
@@ -302,7 +310,7 @@ void Panels::SpeedHacksPanel::Apply()
 
 	Pcsx2Config::SpeedhackOptions& opts( g_Conf->EmuOptions.Speedhacks );
 
-	opts.EECycleRate		= m_slider_eecycle->GetValue()-1;
+	opts.EECycleRate		= m_slider_eecycle->GetValue();
 	opts.VUCycleSteal		= m_slider_vustealer->GetValue();
 
 	opts.WaitLoop			= m_check_waitloop->GetValue();

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1111,31 +1111,40 @@ static u32 scaleBlockCycles_helper()
 
 	switch( EmuConfig.Speedhacks.EECycleRate )
 	{
-		case 0:	return s_nBlockCycles >> 3;
+		case -2:
+			scalarLow = 1;
+			scalarMid = 1;
+			scalarHigh = 1;
+		break;
 
-		case 1:		// Sync hack x1.5!
+		case -1:
+			scalarLow = 2;
+			scalarMid = 2;
+			scalarHigh = 1;
+		break;
+
+		case 0:
+			return s_nBlockCycles >> 3; // Default cyclerate
+
+		case 1:
 			scalarLow = 5;
 			scalarMid = 7;
 			scalarHigh = 5;
 		break;
 
-		case 2:		// Sync hack x2
+		case 2:
 			scalarLow = 7;
 			scalarMid = 9;
 			scalarHigh = 7;
 		break;
 
 		// Added insane rates on popular request (rama)
-		//jNO_DEFAULT
+		// This allows higher values to be set at INI, higher values follows same series as case 0 and case 1.
 		default:
-			scalarLow = 2;
-			scalarMid = 3;
-			scalarHigh = 2;
-			
 			if (EmuConfig.Speedhacks.EECycleRate > 2 && EmuConfig.Speedhacks.EECycleRate < 100) {
-				scalarLow *= EmuConfig.Speedhacks.EECycleRate;
-				scalarMid *= EmuConfig.Speedhacks.EECycleRate;
-				scalarHigh *= EmuConfig.Speedhacks.EECycleRate;
+				scalarLow = 3 + (2*EmuConfig.Speedhacks.EECycleRate);
+				scalarMid = 5 + (2*EmuConfig.Speedhacks.EECycleRate);
+				scalarHigh = 3 + (2*EmuConfig.Speedhacks.EECycleRate);
 			}
 	}
 


### PR DESCRIPTION
List of changes made on the Pull Request:

* Change default EE cycle rate from 1 to 0.
* Values 1 & 2 will effectively reduce the clock speed of R5900 due to higher delays whereas, values -1 & -2 will increase the clock speed by lower delays.
* Presets and Restore defaults obey the new EE cycle rate.
* values greater than 2 (Set through INI) will follow the same scalar value series as the value 1,2. previously it wasn't correctly made relevant to the the scaling of values.


**Don't merge this PR yet** , I'd have to make sure whether the users are contempt with the current way it has been placed. that's why I have made this PR to encourage further discussions.

also @Sarania  was the one who did most of the works, I basically made it obey preset and restore defaults and simplified the equations a little further. 

Fixes #153 