### PR TITLE
Fix git version detection

### DIFF
--- a/common/vsprops/preBuild.cmd
+++ b/common/vsprops/preBuild.cmd
@@ -13,23 +13,20 @@
 
 SETLOCAL ENABLEEXTENSIONS
 
-set mydir=%~dp0
+IF EXIST "%ProgramFiles(x86)%\Git\bin\git.exe" SET "GITPATH=%ProgramFiles(x86)%\Git\bin"
+IF EXIST "%ProgramFiles%\Git\bin\git.exe" SET "GITPATH=%ProgramFiles%\Git\bin"
+IF EXIST "%ProgramW6432%\Git\bin\git.exe" SET "GITPATH=%ProgramW6432%\Git\bin"
+IF DEFINED GITPATH SET "PATH=%PATH%;%GITPATH%"
 
-IF "%PROGRAMFILES(x86)%" == "" do (
-  set PROGRAMFILES(x86)=%PROGRAMFILES%
-)
-
-set PATH=%PATH%;"%PROGRAMFILES(x86)%\Git\bin"
-
-FOR /F "delims=+" %%i IN ('"git show -s --format=%%%ci HEAD"') do (
-  set REV3=%%i
+FOR /F "tokens=1-2" %%i IN ('"git show -s --format=%%%ci HEAD 2> NUL"') do (
+  set REV3=%%i%%j
 )
 
 set REV2=%REV3: =%
 set REV1=%REV2:-=%
 set REV=%REV1::=%
 
-git show -s
+git show -s > NUL 2>&1
 if %ERRORLEVEL% NEQ 0 (
   echo Automatic version detection unavailable.
   echo If you want to have the version string print correctly,


### PR DESCRIPTION
> It currently fails to detect a 64bit git.

More info: https://msdn.microsoft.com/en-us/library/windows/desktop/aa384274(v=vs.85).aspx

VS is a 32bit process and on a 64bit OS the variables get diverted:
ProgramFiles=%ProgramFiles(x86)%

There is no 64bit VS (yet)  therefore check ProgramW6432.

I tried to make it work for all cases:
```
32bit VS and 32bit OS
  - N/A
  - 32bit git
  - N/A
32bit VS and 64bit OS
  - 32bit git
  - 32bit git
  - 64bit git
64bit VS and 64bit OS
  - 32bit git
  - 64bit git
  - 64bit git
```

The order of the checks is important to ensure that if we find a 32bit/64bit git we always pick the native 64bit git.

> It currently breaks with a TZ left of the Greenwich meridian.

The delimiter in the for loop is "+" which assumes a positive UTC offset. My offset is the rare negative which breaks the intended format. To fix this use the default delimiter and picks the 1st two tokens since the third token is the time zone.
> The output of git show -s can cause compilation errors pipe to NUL.

If a commit message contains a line like
```
error C2871: 'stdext' : a namespace with this name does not exist.
```
It will break all compilation until a new commit with a different message is done. 

> Pipe the two can't find the git command error messages to NUL too.

The custom message is enough to get the idea that git is not installed. Silence the other error messages.