### PR TITLE
PCSX2: Replace FPS with Game speed.

### DIFF
--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -557,6 +557,8 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 #endif
 
 	double fps = wxGetApp().FpsManager.GetFramerate();
+	// The "not PAL" case covers both Region_NTSC and Region_NTSC_PROGRESSIVE
+	float per = gsRegionMode == Region_PAL ? (fps * 100) / EmuConfig.GS.FrameratePAL.ToFloat() : (fps * 100) / EmuConfig.GS.FramerateNTSC.ToFloat();
 
 	char gsDest[128];
 	gsDest[0] = 0; // No need to set whole array to NULL.
@@ -591,11 +593,11 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 
 	const u64& smode2 = *(u64*)PS2GS_BASE(GS_SMODE2);
 
-	SetTitle( pxsFmt( L"%s | %ls (%ls) | Limiter: %ls | fps: %6.02f%ls | State %d",
+	SetTitle( pxsFmt( L"%s | %ls (%ls) | Limiter: %ls | Speed: %3d%% (%6.02f)%ls | State %d",
 		WX_STR(fromUTF8(gsDest)),
 		(smode2 & 1) ? L"Interlaced" : L"Progressive",
 		(smode2 & 2) ? L"frame" : L"field",
-		limiterStr, fps, cpuUsage.c_str(), States_GetCurrentSlot() )
+		limiterStr, lround(per), fps, cpuUsage.c_str(), States_GetCurrentSlot() )
 	);
 
 	//States_GetCurrentSlot()


### PR DESCRIPTION
Game speed would provide the percentage values based on the FPS limit for NTSC, PAL games. (50, 59.94).

Fixes #822 