### PR TITLE
GSdx: recording: Progressive: make the recorded clip play at full speed

### DIFF
--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -358,7 +358,7 @@ void GSRenderer::VSync(int field)
 
 			s = format(
 				"%lld | %d x %d | %.2f fps (%d%%) | %s - %s | %s | %d S/%d P/%d D | %d%% CPU | %.2f | %.2f",
-				m_perfmon.GetFrame(), r.width(), r.height(), fps, (int)(100.0 * fps / GetFPS()),
+				m_perfmon.GetFrame(), r.width(), r.height(), fps, (int)(100.0 * fps / GetTvRefreshRate()),
 				s2.c_str(),
 				theApp.m_gs_interlace[m_interlace].name.c_str(),
 				theApp.m_gs_aspectratio[m_aspectratio].name.c_str(),
@@ -533,7 +533,7 @@ bool GSRenderer::MakeSnapshot(const string& path)
 
 bool GSRenderer::BeginCapture()
 {
-	return m_capture.BeginCapture(GetFPS());
+	return m_capture.BeginCapture(GetTvRefreshRate());
 }
 
 void GSRenderer::EndCapture()

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -465,11 +465,9 @@ bool GSState::IsEnabled(int i)
 	return false;
 }
 
-float GSState::GetFPS()
+float GSState::GetTvRefreshRate()
 {
-	float base_rate = ((m_regs->SMODE1.CMOD & 1) ? 25 : (30/1.001f));
-
-	return base_rate * (m_regs->SMODE2.INT ? 2 : 1);
+	return (m_regs->SMODE1.CMOD & 1) ? 50 : (60/1.001f);
 }
 
 // GIFPackedRegHandler*

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -225,7 +225,7 @@ public:
 
 	bool IsEnabled(int i);
 
-	float GetFPS();
+	float GetTvRefreshRate();
 
 	virtual void Reset();
 	virtual void Flush();


### PR DESCRIPTION
Before this patch, when recording Progressive (frame) mode, it recorded all
the frames correctly but set the clip's fps property to 25/29.97, so when
played back it played at half the speed (but was fine when played at double speed).

This patch does not affect the number of frames recorded per second, but rather
only sets the resulting clip fps property to the correct one (double than before).