### PR TITLE
Specifications & Corrections of PAL languages in GameIndex.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1085,7 +1085,7 @@ Region = NTSC-E
 ---------------------------------------------
 Serial = SCED-50041
 Name   = Tekken Tag Tournament [Demo]
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCED-50163
 Name   = PlayStation 2 Greatest Hits Vol.3 [Demo]
@@ -1093,7 +1093,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCED-50254
 Name   = Official Review of the 2000 FIA Formula 1 World Championship [Formula One 2001 Bonus Disc]
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SCED-50286
 Name   = Red Faction [Demo]
@@ -1110,7 +1110,7 @@ IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCED-50748
 Name   = Official PlayStation 2 Magazine Demo 26
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-50907
 Name   = Final Fantasy X [Bonus Disc - Beyond Final Fantasy]
@@ -1119,11 +1119,11 @@ IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCED-51531
 Name   = Official PlayStation 2 Magazine Demo 33
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-51537
 Name   = Official PlayStation 2 Magazine Demo 37
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-52436
 Name   = Playstation2 UK Demo 7-2004
@@ -1136,7 +1136,7 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SCED-52970
 Name   = SCEE Hits Demo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCED-53163
 Name   = Official PlayStation 2 Magazine Demo 60
@@ -1174,7 +1174,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50005
 Name   = Wipeout Fusion
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50006
@@ -1198,12 +1198,12 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50034
 Name   = MotoGP
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50105
 Name   = Sky Odyssey
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50139
 Name   = World Rally Championship
@@ -1212,7 +1212,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50240
 Name   = Extermination
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50241
 Name   = Bouncer, The
@@ -1221,16 +1221,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50244
 Name   = This is Football 2002
-Region = PAL-E
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-50246
 Name   = AirBlade
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50293
 Name   = ATV Off-Road
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50294
 Name   = Gran Turismo 3 A-Spec
@@ -1239,17 +1239,17 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50295
 Name   = Dark Cloud
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50300
 Name   = Time Crisis 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50354
 Name   = Klonoa 2 - Lunatea's Veil
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 eeClampMode = 3		//Objects needed appear in wrong places without it
 [patches = 7EBEEBBD]
@@ -1263,36 +1263,36 @@ eeClampMode = 3		//Objects needed appear in wrong places without it
 ---------------------------------------------
 Serial = SCES-50360
 Name   = Twisted Metal - Black
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50361
 Name   = Jak and Daxter - The Precursor Legacy
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50408
 Name   = PaRappa the Rapper 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50409
 Name   = MotoGP 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50410
 Name   = Ace Combat - Distant Thunder
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50411
 Name   = Vampire Night
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SCES-50459
 Name   = Dropship - United Peace Force
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SCES-50490
@@ -1324,58 +1324,58 @@ IPUWaitHack = 1
 ---------------------------------------------
 Serial = SCES-50499
 Name   = Ecco the Dolphin - Defender of the Future
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SCES-50500
 Name   = Headhunter
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50501
 Name   = Rez
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50522
 Name   = Disney's Peter Pan - Adventures in Neverland
-Region = PAL-E
+Region = PAL-E-S
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50526
 Name   = Peter Pan
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50531
 Name   = Peter Pan - Legenden om Onskeoen
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SCES-50595
 Name   = Disney-Pixar's Monsters Inc.
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-50596
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-DA
 ---------------------------------------------
 Serial = SCES-50597
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SCES-50598
 Name   = Monsterit Oy
-Region = PAL-Unk
+Region = PAL-FI
 ---------------------------------------------
 Serial = SCES-50599
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-50600
 Name   = Disney's Monster Inc. - Scare Island
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-50601
 Name   = Monsters Inc.
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-50602
 Name   = Monsters Inc.
@@ -1383,7 +1383,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50603
 Name   = Monstruos S.A - La Isla de los Sustos
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-50604
 Name   = Monsters Inc.
@@ -1395,11 +1395,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50611
 Name   = Space Channel 5
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50612
 Name   = Space Channel 5 - Part 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50614
 Name   = Jak & Daxter - The Precursor Legacy
@@ -1407,7 +1407,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50759
 Name   = Virtua Fighter 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50760
@@ -1419,17 +1419,17 @@ vuClampMode = 1	// Otherwise camera gets stuck off the player in various spots.
 ---------------------------------------------
 Serial = SCES-50781
 Name   = Destruction Derby Arena [Beta, Promo, & Full Retail]
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50791
 Name   = Frequency
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50810
 Name   = Smash Court Tennis - Pro Tournament
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50850
 Name   = Gran Turismo - Concept 2002 Tokyo-Geneva
@@ -1442,7 +1442,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50878
 Name   = Tekken 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 [patches = 2251E14D]
 
@@ -1463,20 +1463,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50885
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-50887
 Name   = Alpine Racer 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50888
 Name   = Pac-Man World 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50889
 Name   = Ninja Assault
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50916
@@ -1486,7 +1486,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-50917
 Name   = Sly Racoon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-50928
 Name   = SOCOM - U.S. Navy SEALs [Beta & Full Release]
@@ -1494,7 +1494,7 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-50934
 Name   = World Rally Championship II Extreme
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-50935
 Name   = World Rally Championship II Extreme
@@ -1502,26 +1502,26 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-50956
 Name   = Ferrari F355 Challenge
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50960
 Name   = Disney's Stitch: Experiment 626
-Region = PAL-E
+Region = PAL-F-G
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50966
 Name   = Disney's Stitch - Experiment 626
-Region = PAL-Unk
+Region = PAL-E-SE
 ---------------------------------------------
 Serial = SCES-50967
 Name   = Kingdom Hearts
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50968
 Name   = Kingdom Hearts
-Region = PAL-Unk
+Region = PAL-F
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50969
@@ -1535,12 +1535,12 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SCES-50971
 Name   = Kingdom Hearts
-Region = PAL-Unk
+Region = PAL-S
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50982
 Name   = Moto GP 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-50987
@@ -1549,15 +1549,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-51004
 Name   = Formula One 2002
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-51039
 Name   = This is Football 2003
-Region = PAL-E
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-51040
 Name   = Le Monde des Bleus 2003
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-51041
 Name   = This is Football 2003
@@ -1565,19 +1565,19 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-51102
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-51103
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-51104
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-51105
 Name   = Ape Escape 2
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-51135
 Name   = Primal
@@ -1603,15 +1603,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-51164
 Name   = Mark of Kri, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51176
 Name   = Disney's Treasure Planet
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51179
 Name   = This is Football 2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-51190
 Name   = Dark Chronicle
@@ -1620,24 +1620,24 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-51224
 Name   = War of the Monsters
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-51248
 Name   = Dog's Life
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-51426
 Name   = Getaway, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51428
 Name   = Shinobi
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51463
 Name   = Ghosthunter
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51480
@@ -1646,7 +1646,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51513
 Name   = EyeToy - Play
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-51533
 Name   = God of War
@@ -1668,34 +1668,34 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51607
 Name   = Ratchet & Clank 2 - Locked & Loaded
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 // reads Ratchet 1 data
 MemCardFilter = SCES-51607/SCES-50916
 ---------------------------------------------
 Serial = SCES-51608
 Name   = Jak & Daxter 2 - Renegade
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-51610
 Name   = This is Football 2004 (Red Devils 2004)
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SCES-51611
 Name   = This is Football 2004
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51612
 Name   = This is Football 5
-Region = PAL-Unk
+Region = PAL-E-NO
 ---------------------------------------------
 Serial = SCES-51613
 Name   = This is Football 2004
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-51614
 Name   = Monde des Bleus 2004, Le - Nouvelle Generation
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-51618
 Name   = SOCOM
@@ -1703,7 +1703,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-51635
 Name   = Brave - The Search for Spirit Dancer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51648
 Name   = Everquest - Online Adventures
@@ -1711,11 +1711,11 @@ Region = PAL-E-I
 ---------------------------------------------
 Serial = SCES-51677
 Name   = My Street
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51684
 Name   = World Rally Championship 3
-Region = PAL-Unk
+Region = PAL-M8
 XgKickHack = 1
 [patches = 80802EA9]
 comment= Patch By Prafull
@@ -1726,16 +1726,16 @@ patch=1,EE,002aa574,word,00000000
 ---------------------------------------------
 Serial = SCES-51685
 Name   = Primal
-Region = PAL-R
+Region = PAL-E-R
 ---------------------------------------------
 Serial = SCES-51706
 Name   = Amplitude
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51719
 Name   = Gran Turismo 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
@@ -1743,7 +1743,7 @@ MemCardFilter = SCES-51719/SCES-52438/SCES-50294
 ---------------------------------------------
 Serial = SCES-51725
 Name   = Everquest Online Adventures
-Region = PAL-E
+Region = PAL-M3
 Compat = 3
 [patches = 555019B2]
 	
@@ -1754,11 +1754,11 @@ Compat = 3
 ---------------------------------------------
 Serial = SCES-51844
 Name   = Time Crisis 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-51895
 Name   = EyeToy - Groove
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-51904
 Name   = SOCOM II - U.S. Navy SEALs
@@ -1769,17 +1769,17 @@ VIF1StallHack = 1		//HUD
 ---------------------------------------------
 Serial = SCES-51910
 Name   = Arc the Lad - Twilight of the Spirits
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51920
 Name   = Forbidden Siren
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SCES-51971
 Name   = Rise to Honor
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-51977
 Name   = Hardware Online Arena
@@ -1807,7 +1807,7 @@ EETimingHack = 1		//random hangs in US version, code is the same.
 ---------------------------------------------
 Serial = SCES-52042
 Name   = Formula One 2004
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52065
 Name   = Flipnic
@@ -1815,7 +1815,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52099
 Name   = I-Ninja
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52124
 Name   = kill.switch
@@ -1827,15 +1827,15 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-52156
 Name   = Ghosthunter - Hunter on the spectres
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-52268
 Name   = Sing-Star
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-52299
 Name   = SingStar
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-52306
 Name   = SOCOM II - U.S. Navy SEALs
@@ -1846,7 +1846,7 @@ VIF1StallHack = 1		//HUD
 ---------------------------------------------
 Serial = SCES-52327
 Name   = Forbidden Siren
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52328
 Name   = Forbidden Siren
@@ -1855,7 +1855,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52329
 Name   = Forbidden Siren
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-52330
 Name   = Forbidden Siren - Viviendo la Pesadilla
@@ -1863,7 +1863,7 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SCES-52389
 Name   = World Rally Championship 4
-Region = PAL-Unk
+Region = PAL-M8
 Compat = 1
 ---------------------------------------------
 Serial = SCES-52405
@@ -1873,15 +1873,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52410
 Name   = Athens 2004
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52411
 Name   = Athens 2004 [Platinum]
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52412
 Name   = Jackie Chan Adventures
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-52423
 Name   = Smash Court Tennis - Pro Tournament 2
@@ -1889,7 +1889,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52424
 Name   = Ace Combat - Squadron Leader
-Region = PAL-E
+Region = PAL-M5
 [patches = 1D54FEA9]
 	patch=0,EE,001A3154,word,48498800
 	patch=0,EE,001A3158,word,4B00682C
@@ -1903,19 +1903,19 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52426
 Name   = This is Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-52427
 Name   = This is Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-52429
 Name   = This is Football 2005
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SCES-52430
 Name   = Le Monde des Bleus 2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52431
 Name   = This is Football 2005
@@ -1927,7 +1927,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52438
 Name   = Gran Turismo 4 - Prologue
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 //eeClampMode = 3 // Text in races works
 vuClampMode = 2 // Text in GT mode works
@@ -1935,14 +1935,14 @@ MemCardFilter = SCES-51719/SCES-52438/SCES-50294
 ---------------------------------------------
 Serial = SCES-52456
 Name   = Ratchet & Clank 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 // reads Ratchet 1 & 2 data
 MemCardFilter = SCES-52456/SCES-51607/SCES-50916
 ---------------------------------------------
 Serial = SCES-52460
 Name   = Jak 3
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52529
@@ -1952,15 +1952,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52530
 Name   = Crisis Zone
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52564
 Name   = Sing-Star
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52565
 Name   = Sing-Star
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-52566
 Name   = SingStar
@@ -1968,11 +1968,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52582
 Name   = Everybody's Golf
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-52586
 Name   = Death by Degrees
-Region = PAL-Unk
+Region = PAL-E-S
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52596
@@ -1981,7 +1981,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52677
 Name   = Network Access Disc & Hardware - Online Arena
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M7
 Compat = 5
 [patches]
 	comment=- This gamedisc supports multiple languages and widescreen.
@@ -1995,7 +1995,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-52748
 Name   = EyeToy - Play 2
-Region = PAL-Unk
+Region = PAL-M12	// SpyToy - M11
 Compat = 2
 ---------------------------------------------
 Serial = SCES-52756
@@ -2004,7 +2004,7 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SCES-52758
 Name   = Getaway, The - Black Monday
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SCES-52762
 Name   = DJ Decks & FX
@@ -2012,11 +2012,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-52763
 Name   = DJ Decks & FX Vol.1
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-52826
 Name   = Sing-Star Party
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-52827
 Name   = SingStar Party
@@ -2028,47 +2028,47 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SCES-52829
 Name   = Sing-Star Party
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-52830
 Name   = SingStar Party
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-52883
 Name   = EyeToy - Kinetic
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 2
 ---------------------------------------------
 Serial = SCES-52892
 Name   = Moto GP 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-52893
 Name   = Killzone
-Region = PAL-E-Gr-R
+Region = PAL-E-GR-R
 ---------------------------------------------
 Serial = SCES-52930
 Name   = EyeToy - Monkey Mania
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SCES-52948
 Name   = Getaway, The - Black Monday
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-53033
 Name   = Formula One 2005
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53053
 Name   = Death by Degrees
-Region = PAL-Unk
+Region = PAL-F-I
 ---------------------------------------------
 Serial = SCES-53054
 Name   = Death by Degrees
-Region = PAL-Unk
+Region = PAL-E-G
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53055
@@ -2077,24 +2077,24 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-53133
 Name   = God of War
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53178
 Name   = SingStar Pop
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53179
 Name   = SingStar Pop
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-53180
 Name   = Sing-Star - The Dome
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53181
 Name   = SingStar
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53182
 Name   = Sing-Star Pop
@@ -2102,25 +2102,25 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SCES-53183
 Name   = SingStar Pop
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53184
 Name   = SingStar Norske Hits
-Region = PAL-Unk
+Region = PAL-NO
 ---------------------------------------------
 Serial = SCES-53185
 Name   = SingStar Svenska Hits
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-53202
 Name   = Tekken 5
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 eeClampMode = 1
 ---------------------------------------------
 Serial = SCES-53247
 Name   = WRC - World Rally Championship - Rally Evolved
-Region = PAL-Unk
+Region = PAL-M8
 Compat = 5
 XgKickHack = 1			//SPS.
 [patches = cbbc2e7f]
@@ -2142,12 +2142,12 @@ XgKickHack = 1			//SPS.
 ---------------------------------------------
 Serial = SCES-53285
 Name   = Ratchet - Gladiator
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53286
 Name   = Jak X - Combat Racing
-Region = PAL-Unk
+Region = PAL-M7
 // reads Ratchet Gladiator data
 MemCardFilter = SCES-53286/SCES-53285
 ---------------------------------------------
@@ -2157,28 +2157,28 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-53304
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53305
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SCES-53307
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SCES-53308
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SCES-53310
 Name   = Roland Garros 2005
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53312
 Name   = Soul Calibur 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 vuRoundMode = 3
 ---------------------------------------------
@@ -2188,30 +2188,30 @@ Region = PAL-M12
 ---------------------------------------------
 Serial = SCES-53323
 Name   = SingStar Pop World
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53326
 Name   = Shadow of the Colossus
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 MemCardFilter = SCES-53326/SCES-50760
 ---------------------------------------------
 Serial = SCES-53328
 Name   = Genji
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53347
 Name   = SpyToy
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-53358
 Name   = 24 - The Game
-Region = PAL-Unk
+Region = PAL-M9
 ---------------------------------------------
 Serial = SCES-53372
 Name   = Tourist Trophy - The Real Riding Simulator
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-53397
 Name   = SingStar Pop - World Events Code
@@ -2228,11 +2228,11 @@ Region = PAL-M9
 ---------------------------------------------
 Serial = SCES-53449
 Name   = AFL Premiership 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53450
 Name   = Gaelic Football 2005
-Region = PAL-Unk
+Region = PAL-E-GA	// Eng & Gaelic
 ---------------------------------------------
 Serial = SCES-53565
 Name   = SingStar Pop
@@ -2252,19 +2252,19 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53605
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53606
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-53607
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SCES-53609
 Name   = Sing-Star '80s
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-53610
 Name   = Sing-Star '80s
@@ -2272,16 +2272,16 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-53642
 Name   = Ape Escape 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53663
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-53669
 Name   = Buzz! The Music Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53688
 Name   = Urban Reign
@@ -2305,52 +2305,52 @@ XgKickHack = 1			//SPS.
 ---------------------------------------------
 Serial = SCES-53879
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53880
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53881
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-53882
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53883
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53884
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-S
 Compat = 2
 ---------------------------------------------
 Serial = SCES-53889
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53890
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-53891
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-53893
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SCES-53894
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-HR	// Croatian
 ---------------------------------------------
 Serial = SCES-53895
 Name   = SingStar Rocks!
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-53897
 Name   = Sing-Star Rocks!
@@ -2358,16 +2358,16 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SCES-53898
 Name   = Sing-Star Rocks!
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-53925
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53926
 Name   = Buzz! The Big Quiz
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SCES-53927
 Name   = Buzz! The Big Quiz
@@ -2379,17 +2379,17 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-53931
 Name   = Shinobido - Way of the Ninja
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53950
 Name   = F1 '06
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SCES-53960
 Name   = B-Boy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SCES-54025
 Name   = SingStar Rocks!
@@ -2397,7 +2397,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54041
 Name   = Ace Combat - The Belkan War
-Region = PAL-E
+Region = PAL-M5
 // reads AC4 and 5 saves for bonus unlockables
 MemCardFilter = SCES-54041/SCES-50410/SCES-52424
 [patches = 194C9F38]
@@ -2421,37 +2421,37 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SCES-54078
 Name   = SingStar Norsk pa Norsk
-Region = PAL-Unk
+Region = PAL-NO
 ---------------------------------------------
 Serial = SCES-54128
 Name   = Deutsch Rock-Pop
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54129
 Name   = SingStar
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-54131
 Name   = Sing-Star Anthems
-Region = PAL-Unk
+Region = PAL-E
 Compat = 3
 ---------------------------------------------
 Serial = SCES-54145
 Name   = Lemmings
-Region = PAL-Unk
+Region = PAL-M10
 Compat = 5
 ---------------------------------------------
 Serial = SCES-54191
 Name   = Sing-Star Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54197
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-54198
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54206
 Name   = God of War II
@@ -2460,35 +2460,35 @@ Compat = 5
 ---------------------------------------------
 Serial = SCES-54219
 Name   = Buzz! Junior - Jungle Party
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-54220
 Name   = Buzz! Junior - Jungle Party
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SCES-54257
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-54258
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54259
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54260
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SCES-54261
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-54262
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SCES-54263
 Name   = Buzz! The Sports Quiz
@@ -2496,15 +2496,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54264
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54265
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-54266
 Name   = Buzz! The Sports Quiz
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SCES-54267
 Name   = Buzz! The Sports Quiz
@@ -2520,23 +2520,23 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54325
 Name   = SingStar Legendat
-Region = PAL-Unk
+Region = PAL-FI
 ---------------------------------------------
 Serial = SCES-54329
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SCES-54330
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SCES-54353
 Name   = SingStar Legends
-Region = PAL-Unk
+Region = PAL-DA
 ---------------------------------------------
 Serial = SCES-54477
 Name   = Socom US Navy Seals - Combined Assault
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SCES-54497
@@ -2561,7 +2561,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SCES-54535
 Name   = Everybody's Tennis
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SCES-54538
 Name   = Eyetoy - Play Astro Zoo
@@ -2581,7 +2581,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SCES-54598
 Name   = SingStar - Svenska Hits Schlager
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SCES-54599
 Name   = SingStar - '90s
@@ -2601,7 +2601,7 @@ Region = PAL-M7
 ---------------------------------------------
 Serial = SCES-54638
 Name   = Gaelic Games - Football 2
-Region = PAL-E
+Region = PAL-E-GA	// Eng & Gaelic
 ---------------------------------------------
 Serial = SCES-54676
 Name   = Buzz! Junior - RoboJam
@@ -2641,7 +2641,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-54848
 Name   = Buzz! Hollywood
-Region = PAL-M2
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SCES-54851
 Name   = Buzz! The Hollywood Quiz
@@ -2661,7 +2661,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55183
 Name   = SingStar Turkish Party
-Region = PAL-Unk
+Region = PAL-TU
 ---------------------------------------------
 Serial = SCES-55210
 Name   = Buzz! Junior - Ace Racers
@@ -2697,7 +2697,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55464
 Name   = Hanuman: Boy Warrior
-Region = PAL-Unk
+Region = PAL-E-HI	// Eng & Hindi
 Compat = 5
 ---------------------------------------------
 Serial = SCES-55510
@@ -2706,7 +2706,7 @@ Region = PAL-M12
 ---------------------------------------------
 Serial = SCES-55535
 Name   = Desi Adda : Games of India
-Region = PAL-Unk
+Region = PAL-M4	// Eng, Hindi, Punjabi & Tamil
 Compat = 5
 ---------------------------------------------
 Serial = SCES-55538
@@ -2736,17 +2736,17 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SCES-55661
 Name   = RA.ONE: The Game
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SCES-82034
 Name   = Xenosaga II - Jenseits von Gut und Bose [Disc 1]
-Region = PAL-Unk
+Region = PAL-M3
 MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SCES-82035
 Name   = Xenosaga II - Jenseits von Gut und Bose [Disc 2]
-Region = PAL-Unk
+Region = PAL-M3
 MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SCKA-10006
@@ -6454,20 +6454,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50009
 Name   = Action Replay MAX
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50010
 Name   = Ready 2 Rumble - Round 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50011
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50012
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50013
 Name   = FIFA 2001
@@ -6479,11 +6479,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50015
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50016
 Name   = FIFA 2001
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50017
 Name   = F1 Championship Season 2000
@@ -6492,15 +6492,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50018
 Name   = Kessen
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50019
 Name   = Kessen
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50020
 Name   = Kessen
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50021
 Name   = Madden NFL 2001
@@ -6508,27 +6508,27 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50022
 Name   = NBA Live 2001
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50023
 Name   = NBA Live 2001
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50024
 Name   = NBA Live 2001
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50025
 Name   = NBA 2001
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50026
 Name   = NBA 2001
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50027
 Name   = NHL 2001
-Region = PAL-Unk
+Region = PAL-M3	// Eng, FI & SE
 ---------------------------------------------
 Serial = SLES-50028
 Name   = NHL 2001
@@ -6540,17 +6540,17 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50031
 Name   = X-Squad
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50032
 Name   = Theme Park World
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50033
 Name   = Swing Away Golf
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50035
 Name   = Winter X-games Snowboarding
@@ -6558,16 +6558,16 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50036
 Name   = ESPN International Track & Field
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50037
 Name   = Silent Scope
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50038
 Name   = Gradius III & IV
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50039
@@ -6576,23 +6576,23 @@ Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-50042
 Name   = Disney's Dinosaur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50043
 Name   = Disney's Dinosaur
-Region = PAL-Unk
+Region = PAL-M5	// Eng & Nordic
 ---------------------------------------------
 Serial = SLES-50044
 Name   = Rayman Revolution
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50045
 Name   = Disney's Jungle Book - Groove Party
-Region = PAL-Unk
+Region = PAL-M12
 ---------------------------------------------
 Serial = SLES-50046
 Name   = F1 Racing Championship
-Region = PAL-Unk
+Region = PAL-F-G
 Compat = 2
 [patches = EDD7E0FF]
 	
@@ -6605,11 +6605,11 @@ Compat = 2
 ---------------------------------------------
 Serial = SLES-50047
 Name   = F1 Racing Championship
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50048
 Name   = Donald Duck - Quack Attack
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50050
@@ -6619,32 +6619,32 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50051
 Name   = Eternal Ring
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50052
 Name   = Pool Master
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50053
 Name   = Aqua Aqua - Wetrix 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50054
 Name   = Midnight Club
-Region = PAL-Unk
+Region = PAL-E
 // reads Smuggler's Run for bonus unlockable
 MemCardFilter = SLES-50054/SLES-50071/SLES-50055/SLES-50061
 ---------------------------------------------
 Serial = SLES-50055
 Name   = Smuggler's Run
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50056
 Name   = Surfing H3O
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50057
 Name   = Dynasty Warriors 2
@@ -6652,11 +6652,11 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50059
 Name   = Dynasty Warriors 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50060
 Name   = International Superstar Soccer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50061
 Name   = Smuggler's Run
@@ -6665,11 +6665,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50062
 Name   = Orphen - Scion of Sorcery
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50064
 Name   = Stunt GP
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-50068
 Name   = Top Gear Daredevil
@@ -6677,36 +6677,36 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50069
 Name   = Top Gear Daredevil
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50071
 Name   = Midnight Club - Street Racing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 3
 MemCardFilter = SLES-50054/SLES-50071/SLES-50055/SLES-50061
 ---------------------------------------------
 Serial = SLES-50072
 Name   = Street Fighter EX3
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50073
 Name   = Driving Emotion Type-S
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50074
 Name   = Unreal Tournament
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50075
 Name   = ESPN NBA 2Night
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50076
 Name   = Super Bust-A-Move
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50077
@@ -6716,29 +6716,29 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50078
 Name   = TimeSplitters
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50079
 Name   = Armored Core 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50080
 Name   = NBA Hoopz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50106
 Name   = Fur Fighters - Viggo's Revenge
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50107
 Name   = Legends of Wrestling
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50109
 Name   = 7 Blades
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50110
 Name   = Ephemeral Fantasia
@@ -6751,7 +6751,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50112
 Name   = Shadow of Memories
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50113
 Name   = Ring of Red
@@ -6760,7 +6760,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50114
 Name   = Kengo - Master of Bushido
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50115
@@ -6769,38 +6769,38 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50118
 Name   = Tiger Woods PGA Tour 2001
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50120
 Name   = Rumble Racing
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50126
 Name   = Quake III - Revolution
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50127
 Name   = Quake III - Revolution
-Region = PAL-Unk
+Region = PAL-E // German Edition
 ---------------------------------------------
 Serial = SLES-50128
 Name   = Knockout Kings 2001
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50130
 Name   = Knockout Kings 2001
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50131
 Name   = Le Mans 24 Hours
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50132
 Name   = MX Rider
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50134
 Name   = Oni
@@ -6835,47 +6835,47 @@ vuClampMode = 3		//For full textures showing.
 ---------------------------------------------
 Serial = SLES-50158
 Name   = Gungriffon Blaze
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50159
 Name   = Gungriffon Blaze
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50160
 Name   = Gungriffon Blaze
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50165
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50166
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50167
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50168
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50169
 Name   = Star Wars - Starfighter
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50170
 Name   = World Destruction League - Thunder Tanks
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50171
 Name   = ESPN National Hockey Night
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50176
 Name   = Oni
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50177
 Name   = Oni
@@ -6896,7 +6896,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50183
 Name   = Wacky Races
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50185
@@ -6906,16 +6906,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50186
 Name   = Heroes of Might and Magic
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50187
 Name   = Warriors of Might and Magic
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50191
 Name   = Army Men - Green Rogue
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50192
 Name   = Army Men - Sarges Heroes 2
@@ -6924,25 +6924,25 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50193
 Name   = Silpheed - The Lost Planet
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50194
 Name   = 4x4 Evolution
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50195
 Name   = UEFA Challenge
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-50196
 Name   = Soul Reaver 2 - Legacy of Kain
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50201
 Name   = Evil Twin - Cyprien's Chronicles
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50202
@@ -6952,20 +6952,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50203
 Name   = Bloody Roar 3
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50204
 Name   = Star Wars - Super Bombad Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50206
 Name   = Star Wars - Super Bombad Racing
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50209
 Name   = Jeremy McGrath Supercross World
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50210
 Name   = XG3 - Extreme-G Racing
@@ -6974,7 +6974,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50211
 Name   = Gauntlet - Dark Legacy
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M3
 Compat = 5
 [patches]
 	comment=- This gamedisc supports multiple languages.
@@ -6984,17 +6984,17 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50212
 Name   = Paris-Dakar Rally
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 SkipMPEGPatch = 1
 ---------------------------------------------
 Serial = SLES-50213
 Name   = NFL Quarterback Club 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50214
 Name   = 18 Wheeler
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50215
@@ -7016,15 +7016,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50217
 Name   = Dave Mirra Freestyle BMX 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50218
 Name   = All-Star Baseball 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50219
 Name   = NBA Street
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-50220
 Name   = EA Sports Rugby
@@ -7036,16 +7036,16 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50224
 Name   = Kuri Kuri Mix
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50225
 Name   = Escape from Monkey Island
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50226
 Name   = Escape from Monkey Island 4
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50227
 Name   = Escape from Monkey Island (Flucht von Monkey Island)
@@ -7054,11 +7054,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50228
 Name   = Escape from Monkey Island 4
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50229
 Name   = Monkey Island 4
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50230
 Name   = Lotus Challenge
@@ -7068,33 +7068,33 @@ XgKickHack = 1			//SPS.
 ---------------------------------------------
 Serial = SLES-50231
 Name   = International League Soccer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50232
 Name   = Off-Road Wide Open
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50233
 Name   = Army Men - Air Attack - Blade's Revenge
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50243
 Name   = David Beckham Soccer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50247
 Name   = Onimusha - Warlords
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50248
 Name   = MDK 2 - Armageddon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50252
 Name   = Penny Racers
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50253
 Name   = Modern Groove - Ministry of Sound Edition
@@ -7102,52 +7102,52 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50259
 Name   = Flintstones - Viva Rock Vegas
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50260
 Name   = Hidden Invasion
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50261
 Name   = Sky Surfer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50262
 Name   = World Destruction League - War Jets
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50263
 Name   = Portal Runner
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50266
 Name   = Playmobil - Hype - The Time Quest
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50267
 Name   = CART Fury Championship Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50268
 Name   = SpyHunter
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50273
 Name   = Legion - The Legend of Excalibur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50274
 Name   = Arctic Thunder
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50275
 Name   = EA Sports Rugby
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50276
 Name   = Gift, The
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50277
 Name   = Red Faction
@@ -7173,15 +7173,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50283
 Name   = WTA Tour Tennis
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50284
 Name   = Silent Scope 2
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50285
 Name   = Police 24-7
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50288
@@ -7191,7 +7191,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50296
 Name   = Gift
-Region = PAL-Unk
+Region = PAL-F
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50297
@@ -7205,12 +7205,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50310
 Name   = Freak Out
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50314
 Name   = Giants - Citizen Kabuto
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50325
 Name   = Max Payne
@@ -7219,32 +7219,32 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50326
 Name   = Max Payne
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50330
 Name   = Grand Theft Auto III
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50335
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50336
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50337
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50338
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50339
 Name   = Rune - Viking Warlord
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50341
 Name   = Smuggler's Run 2 - Hostile Territory
@@ -7252,7 +7252,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50350
 Name   = Disney's Tarzan - Freeride
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50351
 Name   = Lake Masters EX
@@ -7261,7 +7261,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50355
 Name   = Batman Vengeance
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50356
 Name   = ESPN International Winter Sports
@@ -7269,40 +7269,40 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50358
 Name   = Devil May Cry
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50362
 Name   = Jonny Moseley Mad Trix
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50364
 Name   = City Crisis
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50366
 Name   = Star Wars - Racer Revenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50371
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50372
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50373
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50374
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50375
 Name   = Star Wars - Jedi Starfighter
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50382
 Name   = Silent Hill 2
@@ -7320,7 +7320,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50385
 Name   = Metal Gear Solid 2 - Sons of Liberty
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50386
 Name   = Crash Bandicoot - Wrath of Cortex
@@ -7329,24 +7329,24 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50390
 Name   = Driven
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50395
 Name   = World Championship Snooker 2002
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50396
 Name   = Mike Tyson Heavyweight Boxing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50397
 Name   = Prisoner of War
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50398
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50400
 Name   = Shaun Palmer's Pro Snowboarder
@@ -7354,11 +7354,11 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50401
 Name   = Shaun Palmer's Pro Snowboarder
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50402
 Name   = Shaun Palmer's Pro Snowboarder
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50412
 Name   = Pro Evolution Soccer
@@ -7366,11 +7366,11 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50421
 Name   = Supercar Street Challenge
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50422
 Name   = Madden NFL 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50423
 Name   = F1 2001
@@ -7387,36 +7387,36 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50424
 Name   = Cricket 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50425
 Name   = NHL 2002
-Region = PAL-Unk
+Region = PAL-M3	// Eng, FI & SE
 ---------------------------------------------
 Serial = SLES-50426
 Name   = NHL 2002
-Region = PAL-Unk
+Region = PAL-CZ-F
 ---------------------------------------------
 Serial = SLES-50427
 Name   = NHL 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50428
 Name   = MX 2002 featuring Ricky Carmichael
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50429
 Name   = Alex Ferguson Player Manager 2002
-Region = PAL-Unk
+Region = PAL-E
 Compat = 3
 ---------------------------------------------
 Serial = SLES-50430
 Name   = ESPN X-Games Skateboarding
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50431
 Name   = F1 2001
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50432
 Name   = Tony Hawk Pro Skater 3
@@ -7424,11 +7424,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50433
 Name   = GoDai - Elemental Force
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50434
 Name   = Army Men - Real Time Strategy
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50435
 Name   = Tony Hawk's Pro Skater 3
@@ -7437,41 +7437,41 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50436
 Name   = Tony Hawk Pro Skater 3
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50437
 Name   = Tony Hawk's Pro Skater 3
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50438
 Name   = Motor Mayhem
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50443
 Name   = LEGO Racers 2
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-50444
 Name   = Portal Runner
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50445
 Name   = Burnout
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50446
 Name   = Shadow Man - 2econd Coming
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50447
 Name   = All-Star Baseball 2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50451
 Name   = NHL Hitz 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50457
 Name   = Rayman M
@@ -7484,7 +7484,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50462
 Name   = Pro Evolution Soccer
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-50464
 Name   = FIFA 2002
@@ -7496,7 +7496,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50466
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50467
 Name   = FIFA 2002
@@ -7504,15 +7504,15 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50469
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-GR
 ---------------------------------------------
 Serial = SLES-50470
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50471
 Name   = FIFA 2002
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50472
 Name   = GTC Africa
@@ -7530,7 +7530,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50480
 Name   = Aggressive Inline Skating
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50481
@@ -7544,20 +7544,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50486
 Name   = Splashdown
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50487
 Name   = Space Race
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50495
 Name   = Who Wants to be a Millionaire - 2nd Edition
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50496
 Name   = Qui Veut Gagner des Millions
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50497
 Name   = Who Wants to be a Millionaire 2 (Wer wird Millionar 2)
@@ -7570,7 +7570,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50503
 Name   = Weakest Link
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50504
 Name   = Half-Life
@@ -7588,15 +7588,15 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50507
 Name   = Half-Life
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50508
 Name   = Half-Life
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50509
 Name   = Half-Life
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50510
 Name   = Mummy Returns, The
@@ -7606,47 +7606,47 @@ EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-50511
 Name   = G-Surfers
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50512
 Name   = Bass Strike
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50533
 Name   = Sunny Garcia Surfing
-Region = PAL-E
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50534
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50535
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50536
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50537
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50538
 Name   = NBA Live 2002
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50539
 Name   = James Bond 007 - Agent Under Fire
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50540
 Name   = Simpsons Road Rage
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50541
 Name   = Capcom vs. SNK 2 - Mark of the Millennium
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50544
 Name   = Jet Ion GP
@@ -7655,7 +7655,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50545
 Name   = SSX Tricky
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50546
 Name   = LMA Manager 2002
@@ -7663,27 +7663,27 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50547
 Name   = Roger Lemerre - La Selection des Champions 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50548
 Name   = BDFL Manager 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50549
 Name   = Football Manager Campionato 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50550
 Name   = Manager de Liga 2002
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50551
 Name   = Tetris Worlds
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50552
 Name   = Jet Ski Riders
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50553
 Name   = Project Eden
@@ -7692,11 +7692,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50554
 Name   = Thunderhawk - Operation Pheonix
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50556
 Name   = New York Race
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50558
 Name   = DSF Futball Manager 2002
@@ -7704,32 +7704,32 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50559
 Name   = Guy Roux Manager 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50562
 Name   = Super Bust-A-Move 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50568
 Name   = Top Gun - Combat Zones
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50570
 Name   = Tour de France, Le
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50572
 Name   = Robot Wars - Arenas of Destruction
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50575
 Name   = Dark Summit
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50578
 Name   = Kessen II
-Region = PAL-Unk
+Region = PAL-E
 [patches = 9FAC4FF3]
 	comment=COP2 flag instance patch by refraction
 	// a mac flag check just after a vsub which gets in the way, rearranging
@@ -7741,27 +7741,27 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50579
 Name   = Kessen II
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50580
 Name   = Kessen II
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50584
 Name   = G1 Jockey
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50586
 Name   = ESPN Winter Sports 2002
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50589
 Name   = Worms Blast
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50590
 Name   = Music Maker
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-50591
 Name   = Guilty Gear X
@@ -7769,7 +7769,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50592
 Name   = No One Lives Forever
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50606
 Name   = State of Emergency
@@ -7777,7 +7777,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50608
 Name   = Shadow Man - 2econd Coming
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50613
 Name   = Woody Woodpecker
@@ -7786,27 +7786,27 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50619
 Name   = Jonny Moseley Mad Trix
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-50620
 Name   = Micro Machines
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-50628
 Name   = Simpsons Road Rage
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50630
 Name   = Dragon Rage
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50631
 Name   = Dragon Rage
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-50632
 Name   = Dragon Rage
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-50633
 Name   = Gitaroo Man
@@ -7823,7 +7823,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50638
 Name   = High Heat Major League Baseball 2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50639
 Name   = Everblue
@@ -7832,58 +7832,58 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50640
 Name   = Salt Lake City 2002 Olympic Winter Games
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50641
 Name   = Dynasty Warriors 3
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50643
 Name   = Shifters
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-50644
 Name   = Shifters
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50645
 Name   = Shifters
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-50647
 Name   = Casper - Spirit Dimensions
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50649
 Name   = Taz Wanted
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50650
 Name   = Resident Evil Gun Survivor 2 - Code Veronica
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50653
 Name   = Gitaroo Man
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50654
 Name   = Dune, Frank Herbert's
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50661
 Name   = Atlantis III
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50662
 Name   = Shadow of Zorro, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50670
 Name   = ESPN Winter X-Games Snowboarding 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50672
 Name   = Baldur's Gate: Dark Alliance
@@ -7892,16 +7892,16 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-50677
 Name   = Shadow Hearts
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50679
 Name   = Tenchu 3 - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50680
 Name   = Pirates - The Legend of Black Kat
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50683
@@ -7910,16 +7910,16 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50684
 Name   = Medal of Honor - Frontline
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50686
 Name   = Iron Aces 2 - Birds of Prey
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50703
 Name   = Maximo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50704
 Name   = Godai - Elemental Force
@@ -7928,7 +7928,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50706
 Name   = Army Men - Real Time Strategy
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50709
 Name   = Weakest Link (Le Maillon Fable)
@@ -7936,70 +7936,70 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50710
 Name   = Dr. Muto
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50711
 Name   = Red Card Football
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50713
 Name   = Freaky Flyers
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50714
 Name   = Defender
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50715
 Name   = Gravity Games Bike Street - Vertical Dirt
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50716
 Name   = Fireblade
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50717
 Name   = Mortal Kombat - Deadly Alliance
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50720
 Name   = FMX - Freestyle Metal X
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50721
 Name   = Pryzm - Dark Unicorn
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50722
 Name   = Premier Manager 2002-2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50723
 Name   = TOCA Race Driver
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50725
 Name   = V-Rally 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50726
 Name   = Myst III - Exile
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50727
 Name   = Knockout Kings 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50728
 Name   = Tiger Woods PGA Tour 2002
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50730
 Name   = VIP
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50731
 Name   = Need for Speed - Hot Pursuit 2
@@ -8009,50 +8009,50 @@ vuClampMode = 2			//white textures
 ---------------------------------------------
 Serial = SLES-50735
 Name   = Jade Cocoon 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50738
 Name   = Star Trek Voyager - Elite Force
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50739
 Name   = Soldier of Fortune - Gold Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50751
 Name   = Herdy Gerdy
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50752
 Name   = Pro Tennis WTA Tour
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50753
 Name   = Freekstyle
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50754
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50755
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50757
 Name   = Atlantis III
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-50758
 Name   = Eve of Extinction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50763
 Name   = Rally Championship
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50765
@@ -8061,7 +8061,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50767
 Name   = V8 Supercars Australia - Race Driver
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50768
 Name   = Rally Championship
@@ -8069,20 +8069,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50769
 Name   = Mr. Moskeeto
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50770
 Name   = Mad Maestro!
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50771
 Name   = Blood Omen 2 - Legend of Kain
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50772
 Name   = Blood Omen 2 - Legend of Kain
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50773
 Name   = Donald Duck Phantomias Platyrhynchos Kineticus
@@ -8091,63 +8091,63 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50777
 Name   = Battle Engine Aquila
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50778
 Name   = TD Overdrive - The Brotherhood of Speed
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 2
 ---------------------------------------------
 Serial = SLES-50779
 Name   = ESPN NBA 2Night 2002
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50787
 Name   = International Superstar Soccer 2
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-50788
 Name   = Frogger - The Great Quest
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50790
 Name   = International Superstar Soccer 2002
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50793
 Name   = Grand Theft Auto III
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50794
 Name   = Sven-Goran Eriksson's World Manager 2002
-Region = PAL-Unk
+Region = PAL-E
 Compat = 4
 ---------------------------------------------
 Serial = SLES-50795
 Name   = Superman - Shadow of Apokolips
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50796
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-E-SE
 ---------------------------------------------
 Serial = SLES-50797
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50798
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-50799
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50800
 Name   = FIFA World Cup 2002
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50801
 Name   = FIFA World Cup 2002
@@ -8155,7 +8155,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50802
 Name   = Knockout Kings 2002
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50804
 Name   = Deus Ex
@@ -8163,40 +8163,40 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50805
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50806
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50807
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50808
 Name   = Deus Ex
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50809
 Name   = Next Generation Tennis 2003
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50812
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50813
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50814
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50815
 Name   = Blood Omen 2 - Legend of Kain
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50816
 Name   = DTM Race Driver
@@ -8205,11 +8205,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50818
 Name   = Pro Race Driver
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50820
 Name   = Micro Machines
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50821
 Name   = Project Zero
@@ -8224,11 +8224,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50822
 Name   = Shadow Hearts
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50826
 Name   = Star Wars - Clone Wars
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50829
 Name   = Commandos 2 - Men of Courage
@@ -8236,32 +8236,32 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50831
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50832
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50833
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50834
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50835
 Name   = Star Wars - Bounty Hunter
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50836
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+Region = PAL-E
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50837
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+Region = PAL-F
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50838
@@ -8272,12 +8272,12 @@ EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50839
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+Region = PAL-I
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50840
 Name   = Indiana Jones and The Emperor's Tomb
-Region = PAL-Unk
+Region = PAL-S
 EETimingHack = 1		//For texture flicker.
 ---------------------------------------------
 Serial = SLES-50841
@@ -8287,28 +8287,28 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50842
 Name   = Downforce
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50843
 Name   = Crashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50845
 Name   = Medal of Honour - Frontline
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50846
 Name   = Medal of Honor - Frontline
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50848
 Name   = Speed Kings
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50849
 Name   = Urban Freestyle Soccer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50850
 Name   = ATV Off-Road 2
@@ -8316,68 +8316,68 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50852
 Name   = Sven-Goran Eriksson's World Challenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50853
 Name   = Marcel DeSaily Pro Football
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50854
 Name   = WM Nationalspieler
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50859
 Name   = Commandos 2 - Men of Courage
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50860
 Name   = Commandos 2 - Men of Courage
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50861
 Name   = Top Angler
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50862
 Name   = Street Hoops
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50870
 Name   = Mat Hoffman's Pro BMX 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50871
 Name   = Mat Hoffman's Pro BMX 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50872
 Name   = Mat Hoffman's Pro BMX 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50873
 Name   = Reign of Fire
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50874
 Name   = F1 2002
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50875
 Name   = F1 2002
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-50876
 Name   = Driv3r
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50877
 Name   = TimeSplitters 2
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50879
 Name   = Paris-Dakar 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 FPUNegDivHack = 1		//Fixes sky being shown over the 3d.
 EETimingHack = 1		//Flickery videos without it.
@@ -8400,83 +8400,83 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50882
 Name   = Mary-Kate and Ashley - Sweet 16
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50886
 Name   = Transworld Surf
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50891
 Name   = Legaia 2 - Duel Saga
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50892
 Name   = Lethal Skies Elite Pilot - Team SW
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50897
 Name   = Super Trucks
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50898
 Name   = X-Men - The Next Dimension
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50899
 Name   = X-Men - The Next Dimension
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-50900
 Name   = X-Men - The Next Dimension
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50902
 Name   = Conflict - Desert Storm
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50905
 Name   = Armored Core 2 - Another Age
-Region = PAL-Unk
+Region = PAL-E
 // save import option was removed from PAL release
 ---------------------------------------------
 Serial = SLES-50906
 Name   = Master Rally
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50908
 Name   = Monster Jam - Maximum Destruction
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50914
 Name   = International Cue Club
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50919
 Name   = Akira Psycho Ball
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50920
 Name   = King's Field IV
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50921
 Name   = Way of the Samurai
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50922
 Name   = Terminator, The - Dawn of Fate
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50927
 Name   = Commandos 2 - Men of Courage
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50930
 Name   = Dino Stalker
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50932
 Name   = Smash Court Tennis - Pro Tournament
@@ -8484,24 +8484,24 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50933
 Name   = eJay Clubworld
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50935
 Name   = Circus Maximus - Chariot Wars
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50936
 Name   = Endgame
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50937
 Name   = LEGO Football Mania
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-50939
 Name   = USA Racer
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50946
 Name   = Britney's Dance Beat
@@ -8509,50 +8509,50 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-50947
 Name   = Britney's Dance Beat
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50948
 Name   = Britney's Dance Beat
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50953
 Name   = Air Rescue Ranger
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50954
 Name   = Tokyo Road Race
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50955
 Name   = London Racer 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50958
 Name   = Warhammer 40,000 - Firewarrior
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-50963
 Name   = Riding Spirits
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50964
 Name   = Antz Extreme Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50965
 Name   = Spider-Man
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-50972
 Name   = Barbarian
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50974
 Name   = Zapper - One Wicked Cricket!
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-50975
 Name   = Thing, The
@@ -8566,21 +8566,21 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50978
 Name   = Onimusha 2 - Samurai's Destiny
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50981
 Name   = RC Sports Copter Challenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50984
 Name   = Gumball 3000
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50985
 Name   = Gumball 3000
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50986
@@ -8590,36 +8590,36 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-50987
 Name   = Scorpion King, The - Rise of an Akkadian
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50988
 Name   = Lord of the Rings, The - The Fellowship of the Ring (Der Herr der Ringe - Die Gefahrten)
-Region = PAL-G
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50992
 Name   = Hitman 2 - Silent Assassin
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-50994
 Name   = Paris-Marseille Racing II
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-50995
 Name   = Fireblade
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-50997
 Name   = Rally Fusion - Race of Champions
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-50998
 Name   = Xtreme Express - World Grand Prix
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-50999
 Name   = UFC Throwdown
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51009
 Name   = Autobahn Raser IV
@@ -8627,32 +8627,32 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51011
 Name   = Knight Rider - The Game
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51013
 Name   = Blade 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51014
 Name   = Blade 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51017
 Name   = Scooby-Doo! and The Night of 100 Frights
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51018
 Name   = Scooby-Doo! and The Night of 100 Frights
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51019
 Name   = Scooby-Doo! and The Night of 100 Frights
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51022
 Name   = Virtual Racer - Jaques Villeneuve
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-51023
 Name   = LMA Manager 2003
@@ -8668,19 +8668,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51025
 Name   = BDFL Manager 2003
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51038
 Name   = MX Superfly featuring Ricky Carmichael
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51042
 Name   = Disney Golf
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51043
 Name   = Spyro - Enter the Dragonfly
-Region = PAL-Unk
+Region = PAL-M6
 [patches = 0EF1D4BA]
 	comment=Spyro PAL startup fix
 	patch=1,EE,001E763C,word,24020001
@@ -8693,19 +8693,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51045
 Name   = Legends of Wrestling II
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51046
 Name   = State of Emergency
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51053
 Name   = Tom & Jerry's War of the Wiskers
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51054
 Name   = Midnight Club 2
-Region = PAL-Unk
+Region = PAL-M5	// Voices and Movies are in English.
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51055
@@ -8719,131 +8719,131 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51057
 Name   = Hard Hitter 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51058
 Name   = Maken Shao - Demon Sword
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51060
 Name   = Butt Ugly Martians
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51061
 Name   = Grand Theft Auto - Vice City
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51064
 Name   = Gladius
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51065
 Name   = Gladius
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51066
 Name   = Gladius
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51069
 Name   = RTX - Red Rock
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51070
 Name   = RTX Red Rock
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51071
 Name   = RTX - Red Rock
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51072
 Name   = RTX - Red Rock
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51073
 Name   = RTX Red Rock
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51076
 Name   = Liverpool FC - Club Football
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51077
 Name   = Club Football Real Madrid
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51078
 Name   = FC Barcelona - Club Football
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51079
 Name   = Ajax Club Football
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51080
 Name   = AC Milan Club Football
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51081
 Name   = Club Football - Juventus 2003-2004 Season
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51082
 Name   = Hamburger SV Club Football - Saison 2003-2004
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51083
 Name   = Borussia Dortmund Club Football - Saison 2003-2004
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51084
 Name   = BDFL Manager 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51085
 Name   = Aston Villa - Club Football
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51086
 Name   = Club Football - Chelsea
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51087
 Name   = Leeds United - Club Football
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51088
 Name   = Club Football - Rangers
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51089
 Name   = Club Football - Arsenal
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51090
 Name   = Club Football - Manchester United
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51093
 Name   = Largo Winch - Empire Under Threat
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51094
 Name   = FC Internazionale - Club Football
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51095
 Name   = Dino Stalker
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51096
 Name   = Dino Stalker
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51100
 Name   = Club Football - Liverpool - 2003-2004 Season
@@ -8880,11 +8880,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51117
 Name   = Colin McRae Rally 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51118
 Name   = Wizardry - Tales of the Forsaken Land
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51124
@@ -8894,11 +8894,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51125
 Name   = Sega Soccer Slam
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51126
 Name   = Whirl Tour
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51128
 Name   = Total Immersion Racing
@@ -8907,23 +8907,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51130
 Name   = Tony Hawk's Pro Skater 4
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51132
 Name   = Tony Hawk's Pro Skater 4
-Region = PAL-Unk
+Region = PAL-G
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51133
 Name   = Red Faction 2
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51134
 Name   = Powerpuff Girls - Relish Rampage
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51141
@@ -8938,7 +8938,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51143
 Name   = Summoner 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51144
 Name   = Shox - Rally Reinvented
@@ -8947,7 +8947,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51145
 Name   = Monopoly Party
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51150
 Name   = Scrabble Interactive - 2003 Edition
@@ -8955,16 +8955,16 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51151
 Name   = NHL 2003
-Region = PAL-Unk
+Region = PAL-M6
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-51153
 Name   = LEGO Island - Extreme Stunts
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-51154
 Name   = Madden NFL 2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51156
 Name   = Silent Hill 2 - Director's Cut
@@ -8973,24 +8973,24 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51157
 Name   = Silent Scope 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51160
 Name   = Sub Rebellion
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51162
 Name   = Metropolismania
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51168
 Name   = AFL Live 2004 - Aussie Rules Football
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51174
 Name   = Marvel vs. Capcom 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51180
@@ -9000,34 +9000,34 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51181
 Name   = Tom Clancy's Ghost Recon
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51182
 Name   = Tom Clancy's Ghost Recon
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51188
 Name   = Rocket Power - Beach Bandits
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51189
 Name   = MTV's Celebrity Deathmatch
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51191
 Name   = Auto Modellista
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51192
 Name   = Harry Potter and the Chamber of Secrets
-Region = PAL-Unk
+Region = PAL-E
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51194
 Name   = Harry Potter - Kammer D Schreckens
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51195
 Name   = Harry Potter y La Camara Secreta
@@ -9045,23 +9045,23 @@ vuClampMode = 2			//missing geometry with microVU
 ---------------------------------------------
 Serial = SLES-51198
 Name   = NBA Live 2003
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51199
 Name   = 4x4 Evolution II
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51200
 Name   = Kelly Slater's Pro Surfer
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51201
 Name   = Kelly Slater's Pro Surfer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51202
 Name   = Wreckless - The Yakuza Missions
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51203
 Name   = Enter the Matrix
@@ -9071,11 +9071,11 @@ EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-51208
 Name   = Rocky
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51209
 Name   = Haven - Call of the King
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51214
@@ -9084,12 +9084,12 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51220
 Name   = Ty - The Tazmanian Tiger
-Region = PAL-5
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51222
 Name   = Rayman 3 - Hoodlum Havoc
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51223
 Name   = Runabout 3 - Neo Age
@@ -9097,12 +9097,12 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51226
 Name   = Twin Caliber
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51227
 Name   = Tomb Raider - Angel of Darkness	// aka "TRAOD"
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M10
 Compat = 5
 //OPHFlagHack = 1 // 08.09.2014 not needed anymore and actually causes a hang
 [patches]
@@ -9119,11 +9119,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51230
 Name   = Minority Report
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51232
 Name   = Virtua Tennis 2
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51233
@@ -9133,12 +9133,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51235
 Name   = Raging Blades
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51236
 Name   = Gungrave
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51244
 Name   = XIII
@@ -9147,12 +9147,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51247
 Name   = Inspector Gadget - Mad Robots Invasion
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51249
 Name   = Castleween
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51250
@@ -9162,11 +9162,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51251
 Name   = Shox - Rally Reinvented
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51252
 Name   = Lord of the Rings, The - The Two Towers
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51253
@@ -9179,7 +9179,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51255
 Name   = Lord of the Rings, The - The Two Towers
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51256
 Name   = Lord of the Rings, The - The Two Towers (El Senor de Los Anillos - Las Dos Torres)
@@ -9193,44 +9193,44 @@ Compat = 3
 ---------------------------------------------
 Serial = SLES-51258
 Name   = James Bond 007 - Nightfire
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51260
 Name   = James Bond 007 - Nightfire
-Region = PAL-Unk
+Region = PAL-G-S
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51265
 Name   = Dynasty Warriors Tactics
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51266
 Name   = Dynasty Tactics
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51267
 Name   = Dynasty Tactics
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51271
 Name   = Mobile Suit Gundam - Federation vs. Zeon
-Region = PAL-Unk
+Region = PAL-M5	// Voices are in English.
 ---------------------------------------------
 Serial = SLES-51272
 Name   = Wakeboarding Unleashed
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51273
 Name   = Wakeboarding Unleashed
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51282
 Name   = Tiger Woods PGA Tour 2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51283
 Name   = WWE Smackdown! 4 - Shut Your Mouth
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51284
 Name   = Contra - Shattered Soldier
@@ -9238,25 +9238,25 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51285
 Name   = Spongebob Squarepants - Revenge of the Flying Dutchman
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51286
 Name   = X-Men 2 - Wolverine's Revenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51287
 Name   = X-Men 2 - Wolverine's Revenge
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51289
 Name   = Gunfighter 2 - Legend of Jesse James
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51290
 Name   = Sword of the Samurai
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51294
@@ -9265,46 +9265,46 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51296
 Name   = Grand Prix Challenge
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-51298
 Name   = Jimmy Neutron - Boy Genius
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51301
 Name   = SOS - The Final Escape
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51302
 Name   = Bomberman Kart
-Region = PAL-Unk
+Region = PAL-M3
 compat = 5
 ---------------------------------------------
 Serial = SLES-51303
 Name   = LEGO Dome Racers
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-51307
 Name   = Wild Arms 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51308
 Name   = Reel Fishing 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51311
 Name   = Rugrats Royal Ransom
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51312
 Name   = Rugrats Royal Ransom
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51313
 Name   = Activision Anthology
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51315
 Name   = Great Escape, The
@@ -9313,48 +9313,48 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51316
 Name   = Grand Theft Auto - Vice City
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51317
 Name   = Minority Report
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51318
 Name   = Minority Report
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51322
 Name   = Robotech Battlecry
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51333
 Name   = Dark Angel
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51339
 Name   = NFL 2K3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51340
 Name   = NBA 2K3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51341
 Name   = NHL 2K3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51343
 Name   = Galerians - Ash
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51344
 Name   = Guilty Gear X2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51345
 Name   = Run Like Hell
-Region = PAL-Unk
+Region = PAL-M5
 [patches = 945301BE]
 	comment=swapping a COP2 op into place to make the flags work without delays
 	patch=0,EE,001D4534,word,4A0002FF
@@ -9366,30 +9366,30 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51347
 Name   = Die Hard - Vendetta
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51348
 Name   = Die Hard - Vendetta
-Region = PAL-Unk
+Region = PAL-E-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51349
 Name   = Evolution Skateboarding
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51350
 Name   = Ben Hur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51354
 Name   = Jurassic Park - Operation Genesis
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51355
 Name   = Big Mutha Truckers
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51356
@@ -9399,54 +9399,54 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51357
 Name   = G1 Jockey 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51358
 Name   = Mystic Heroes
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51360
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51361
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51362
 Name   = Simpsons Skateboarding
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51363
 Name   = Music 3000
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51365
 Name   = BMX XXX
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51371
 Name   = Pride FC
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51372
 Name   = Wallace & Gromit in Project Zoo
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51374
 Name   = RoboCop
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51381
 Name   = Everblue 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51382
 Name   = Shrek - Super Party
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51383
 Name   = Beach King Stunt Racer
@@ -9455,15 +9455,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51385
 Name   = Rugrats Rescate Real
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51387
 Name   = World Racing
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51388
 Name   = Sega Bass Fishing Duel
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51390
 Name   = Fightbox
@@ -9471,62 +9471,62 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51391
 Name   = RTL Skispringen 2003
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-51392
 Name   = Evolution Snowboarding
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51393
 Name   = Syberia
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51397
 Name   = IndyCar Series
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51398
 Name   = World Championship Snooker 2003
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51399
 Name   = Armored Core 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51400
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-S	// Voices: English & Japanese (Videos)
 ---------------------------------------------
 Serial = SLES-51401
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-I	// Selection of Japanese Audio possible.
 ---------------------------------------------
 Serial = SLES-51402
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51403
 Name   = Tenchu - Wrath of Heaven
-Region = PAL-Unk
+Region = PAL-F	// Voices: English & Japanese (Option menu)
 ---------------------------------------------
 Serial = SLES-51409
 Name   = Frogger Beyond
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51418
 Name   = Fisherman's Challenge
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51423
 Name   = Celtic - Club Football
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51433
 Name   = Ghost Vibration
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51434
 Name   = Silent Hill 3
@@ -9536,27 +9536,27 @@ MemCardFilter = SLES-51434/SLES-50382/SLES-51156
 ---------------------------------------------
 Serial = SLES-51435
 Name   = International Superstar Soccer 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51436
 Name   = Chessmaster 9000
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51439
 Name   = Mortal Kombat - Deadly Alliance
-Region = PAL-G
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51441
 Name   = Dynasty Warriors 3 - Extreme Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51442
 Name   = Dynasty Warriors 3 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51443
 Name   = Dynasty Warriors 3 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51445
 Name   = Rygar - The Legendary Adventure
@@ -9564,32 +9564,32 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51448
 Name   = Resident Evil - Dead Aim
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51449
 Name   = Return to Castle Wolfenstein - Operation Resurrection
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51451
 Name   = Whiteout
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51456
 Name   = LMA Manager 2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51458
 Name   = BDFL Manager 2004
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51460
 Name   = Football Manager 2004
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51462
 Name   = Shrek Super Party
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51466
 Name   = Tom Clancy's Splinter Cell
@@ -9598,15 +9598,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51467
 Name   = Freedom Fighters
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51469
 Name   = Freedom Fighters
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51470
 Name   = Freedom Fighters
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51473
 Name   = Kya - Dark Lineage
@@ -9614,43 +9614,43 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51474
 Name   = Blood Rayne
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51476
 Name   = Mystic Heroes
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51477
 Name   = Mystic Heroes
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51479
 Name   = Def Jam Vendetta
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51481
 Name   = NBA Street 2
-Region = PAL-M2
+Region = PAL-E-F
 Compat = 5
 vuClampMode = 2		//missing environment with microVU
 ---------------------------------------------
 Serial = SLES-51482
 Name   = Downtown Run
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51488
 Name   = Tour de France, Le - Centenary Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51492
 Name   = Pro Beach Soccer
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51493
 Name   = Mr. Golf
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51495
 Name   = SX Superstar
@@ -9672,11 +9672,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51503
 Name   = Ace Lightning
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51504
 Name   = Chessmaster
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51507
 Name   = Futurama
@@ -9684,11 +9684,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51508
 Name   = Hulk, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51509
 Name   = World of Outlaws - Sprint Cars
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51510
 Name   = Dancing Stage Fever MegaMix
@@ -9697,20 +9697,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51511
 Name   = Crash Nitro Kart
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51523
 Name   = Conflict - Desert Storm II
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51525
 Name   = Fallout - Brotherhood of Steel
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51526
 Name   = Fallout - Brotherhood of Steel
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51541
 Name   = Grand Theft Auto - San Andreas
@@ -9718,38 +9718,38 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51547
 Name   = Next Generation Tennis 2003
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51548
 Name   = This is Football
-Region = PAL-I-S
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51553
 Name   = Chaos Legion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51554
 Name   = Cell Damage Overdrive
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51555
 Name   = Play It Pinball
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51557
 Name   = Broken Sword - The Sleeping Dragon
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51579
 Name   = Yu-Gi-Oh! - The Duelists of the Roses
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51580
 Name   = London Racer World Challenge
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51581
 Name   = Dead to Rights
@@ -9758,12 +9758,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51584
 Name   = F1 Career Challenge
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51588
 Name   = Evil Dead - A Fistful of Boomstick (with Bonus DVD Movie)
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51589
 Name   = Resident Evil - Outbreak
@@ -9771,31 +9771,31 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51590
 Name   = Cabela's Big Game Hunter
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51594
 Name   = Disney's Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51595
 Name   = Grand Theft Auto - Vice City
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51600
 Name   = WWE Crush Hour
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51602
 Name   = All-Stars Baseball 2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51603
 Name   = Seek & Destroy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51605
 Name   = Motorsiege - Warriors of Prime Time
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51606
 Name   = Unlimited Saga
@@ -9803,21 +9803,21 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51615
 Name   = King of Route 66, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51616
 Name   = Virtua Fighter 4 Evolution
-Region = PAL-Unk
+Region = PAL-UM5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51617
 Name   = Starsky & Hutch
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51618
 Name   = Starsky & Hutch
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-51619
 Name   = Clock Tower 3
@@ -9826,11 +9826,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51620
 Name   = Black and Bruised
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51621
 Name   = Dirt Track Devils
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51622
 Name   = Maxxed Out Racing
@@ -9848,15 +9848,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51625
 Name   = Ultimate Mindgames
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51629
 Name   = International Pool Championship
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51630
 Name   = Play It Chess Challenger
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51633
@@ -9865,24 +9865,24 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51636
 Name   = XGRA - Extreme G Racing Association
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51646
 Name   = Energy Airforce
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51649
 Name   = Judge Dredd vs. Judge Death
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51650
 Name   = Judge Dredd - Dredd vs. Death
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-51653
 Name   = Mace Griffin - Bounty Hunter
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51654
 Name   = Mace Griffin - Bounty Hunter
@@ -9890,23 +9890,23 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51658
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51659
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51660
 Name   = Risk - Global Domination
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51661
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51662
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51663
 Name   = Dynasty Warriors 4
@@ -9914,23 +9914,23 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51664
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51665
 Name   = Dynasty Warriors 4
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51666
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51667
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51668
 Name   = Piglet's Big Game
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-51670
 Name   = Alter Echo
@@ -9938,48 +9938,48 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51671
 Name   = Alter Echo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51675
 Name   = Psyvariar
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51678
 Name   = Super Farm
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51680
 Name   = Splashdown 2 - Rides Gone Wild
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51681
 Name   = Splashdown 2 - Rides Gone Wild
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51682
 Name   = Headhunter - Redemption
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51686
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-E
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51687
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51688
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51689
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51690
 Name   = Pitfall - The Lost Expedition
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51693
 Name   = Suffering, The
@@ -9987,7 +9987,7 @@ Region = PAL-E-F-G
 ---------------------------------------------
 Serial = SLES-51696
 Name   = Dragon's Lair 3D - Special Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51697
 Name   = SSX 3
@@ -10000,52 +10000,52 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51699
 Name   = Virtua Fighter - 10th Anniversary Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51702
 Name   = Battlestar Galactica - Apostasy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51704
 Name   = XII Stag
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51705
 Name   = Ford Racing 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51707
 Name   = Secret Weapons Over Normandy
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51708
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51709
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51710
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51711
 Name   = Secret Weapons over Normandy
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-51712
 Name   = Snowboard Racer 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51713
 Name   = Bust-A-Bloc
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51714
 Name   = BCV - Battle Construction Vehicles
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51715
 Name   = Seed, The - War Zone
@@ -10053,25 +10053,25 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51716
 Name   = A-Train 6
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51717
 Name   = Boxing Champions
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51718
 Name   = League Series Baseball 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51720
 Name   = Disney's Extreme Skate Adventure
-Region = PAL-Unk
+Region = PAL-E
 vuRoundMode = 0
 ---------------------------------------------
 Serial = SLES-51723
 Name   = Hobbit, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51731
 Name   = Bust-A-Block
@@ -10083,7 +10083,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51733
 Name   = EA SPORTS RUGBY 2004
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51735
 Name   = Perfect Ace - Pro Tournament Tennis
@@ -10091,16 +10091,16 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51741
 Name   = 1945 I & II - The Arcade Games
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51746
 Name   = Space Invaders - Invasion Day
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51749
 Name   = Mark Davis Pro Bass Challenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51750
 Name   = Charlie's Angels
@@ -10114,47 +10114,47 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51753
 Name   = True Crime - Streets of L.A.
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51754
 Name   = True Crime - Streets of L.A.
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51755
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51756
 Name   = Batman 2 - The Rise of Sin Tsu
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51757
 Name   = Dancing Stage Fever
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51758
 Name   = Metal Arms - Glitch in the System
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51759
 Name   = Maximo vs. Army of Zin
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51761
 Name   = Italian Job, The - L.A. Heist
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51765
 Name   = Volleyball Xciting
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51766
 Name   = Gladiator - Sword of Vengeance
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51772
 Name   = Bad Boys II
@@ -10171,21 +10171,21 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51783
 Name   = Starsky & Hutch
-Region = PAL-Unk
+Region = PAL-F-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51785
 Name   = Cool Shot
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51787
 Name   = Harry Potter - Quidditch World Cup
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-51792
 Name   = Aliens vs. Predator - Extinction
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51794
 Name   = Looney Toons - Back in Action
@@ -10194,11 +10194,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51797
 Name   = Madden NFL 2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51798
 Name   = NHL 2004
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51799
 Name   = Soul Calibur II
@@ -10207,23 +10207,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51800
 Name   = Smash Cars Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51806
 Name   = Evil Dead - A Fistful of Boomstick
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51812
 Name   = Homerun
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51813
 Name   = European Tennis Pro
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51814
 Name   = ATV Off-Road Fury 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51815
 Name   = Final Fantasy X-2
@@ -10250,15 +10250,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51821
 Name   = Alias
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51822
 Name   = Alias
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51823
 Name   = Hunter - The Reckoning Wayward
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51824
 Name   = Colin McRae Rally '04
@@ -10266,7 +10266,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51825
 Name   = Pop Idol
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51826
 Name   = AFL Live 2004
@@ -10274,50 +10274,50 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51828
 Name   = Gladiator - Sword of Vengeance
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51831
 Name   = Sphinx and The Cursed Mummy
-Region = PAL-Unk
+Region = PAL-M5
 OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLES-51833
 Name   = Premier Manager 2003-2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51834
 Name   = Premier Manager 2003-2004
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51838
 Name   = Asterix & Obelix XXL2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51839
 Name   = DragonBall Z - Budokai 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51840
 Name   = NHL Hitz Pro
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51841
 Name   = SpyHunter 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51842
 Name   = Road Kill
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51843
 Name   = Worms 3D
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51845
 Name   = Barbie - Horse Adventure
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51846
 Name   = Deutschland sucht den Superstar
@@ -10331,7 +10331,7 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51850
 Name   = Basketball Xciting
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51851
 Name   = Tony Hawk's Underground
@@ -10340,7 +10340,7 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51852
 Name   = Thug MOTX [Demo]
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51853
@@ -10350,74 +10350,74 @@ vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51854
 Name   = Tony Hawk Underground
-Region = PAL-Unk
+Region = PAL-S
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51855
 Name   = Tank Elite
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51856
 Name   = Monster Attack
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51859
 Name   = Billiards Xciting
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51860
 Name   = Tennis Court Smash
-Region = PAL-Unk
+Region = PAL-E
 Compat = 3
 ---------------------------------------------
 Serial = SLES-51861
 Name   = Bowling Xciting
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51862
 Name   = Bass Master Fishing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51863
 Name   = Maze Action
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51864
 Name   = Police Chase Down
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51865
 Name   = Heartbeat Boxing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51867
 Name   = Dynasty Tactics 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51868
 Name   = Dynasty Tactics 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51869
 Name   = Dynasty Tactics 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51870
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-
+Region = PAL-FI-S
 ---------------------------------------------
 Serial = SLES-51871
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-51872
 Name   = Disney-Pixar's Finding Nemo
-Region = PAL-unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SLES-51873
 Name   = Medal of Honor - Rising Sun
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51874
@@ -10426,7 +10426,7 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51875
 Name   = Medal of Honor - Rising Sun
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-51876
 Name   = Medal of Honor - Rising Sun
@@ -10434,20 +10434,20 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51877
 Name   = Bloody Roar 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51879
 Name   = Hot Wheels World Race
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51881
 Name   = Mercedes Bens World Racing
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-51883
 Name   = Scooby Doo! Mystery Mayhem
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51885
 Name   = MegaMan X7
@@ -10457,51 +10457,51 @@ eeClampMode = 3			//For camera issues in some scenes.
 ---------------------------------------------
 Serial = SLES-51886
 Name   = Lethal Skies 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51887
 Name   = Tiger Woods PGA Tour 2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51888
 Name   = RTL Skiijumping 2004
-Region = PAL-M2
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-51890
 Name   = Buffy the Vampire Slayer - Chaos Bleeds
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLES-51893
 Name   = Naval Ops - Warship Gunner
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51896
 Name   = Gallop Racer
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51897
 Name   = Simpsons, The - Hit & Run
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51903
 Name   = AFL Live 2004 - Aussie Rules Football
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51906
 Name   = Rolling
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51908
 Name   = Van Helsing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51911
 Name   = Gadget Racers
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51912
 Name   = Pro Evolution Soccer 3
@@ -10509,22 +10509,22 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51913
 Name   = Onimusha Blade Warrior
-Region = PAL-Unk
+Region = PAL-M3
 MemCardFilter = SLES-51913/SLES-51914
 ---------------------------------------------
 Serial = SLES-51914
 Name   = Onimusha 3 - Demon Siege
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 MemCardFilter = SLES-51913/SLES-51914
 ---------------------------------------------
 Serial = SLES-51915
 Name   = Pro Evolution Soccer 3
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-51916
 Name   = Crouching Tiger, Hidden Dragon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51917
 Name   = Beyond Good and Evil
@@ -10537,7 +10537,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51924
 Name   = World War Zero - Ironstorm
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51925
@@ -10546,103 +10546,103 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-51926
 Name   = Outlaw Golf
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51927
 Name   = Midway Arcade Treasures
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51930
 Name   = Road Rage 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51931
 Name   = Teenage Mutant Ninja Turtles
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51932
 Name   = Jimmy Neutron - Jet Fusion
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51933
 Name   = Gregory Horror Show
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 1
 ---------------------------------------------
 Serial = SLES-51934
 Name   = Curse - The Eye of Isis
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51946
 Name   = Robin Hood - Defender of the Crown
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-51947
 Name   = ESPN NFL 2K4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51948
 Name   = ESPN NHL Hockey 2K4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51949
 Name   = NBA 2K4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51950
 Name   = Sonic Heroes
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51951
 Name   = Puyo Pop Fever
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51952
 Name   = R-Type Final
-Region = PAL-E
+Region = PAL-M3
 Compat = 5
 EETimingHack = 1 // Else serious slowdown due to VIF timing. Can be disabled once timing voodoo is fixed ;)
 ---------------------------------------------
 Serial = SLES-51953
 Name   = FIFA 2004
-Region = PAL-E-Sw
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-51954
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-E
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-51956
 Name   = Bionicle - The Game
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-51957
 Name   = Terminator 3 - Rise of the Machines
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-51958
 Name   = Whiplash
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51959
 Name   = Football Generation
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51963
 Name   = FIFA 2004
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-51964
 Name   = FIFA 2004
-Region = PAL-Unk
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-51966
 Name   = Bombastic
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51967
@@ -10653,7 +10653,7 @@ EETimingHack = 1	//broken textures
 ---------------------------------------------
 Serial = SLES-51968
 Name   = Spongebob Squarepants - Battle for Bikini Bottom
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51970
 Name   = Spongebob Schwammkopf - Schlacht um Bikini Bottom
@@ -10662,15 +10662,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51972
 Name   = NBA Jam 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51973
 Name   = War Chess
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51974
 Name   = XS Junior League Soccer
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51976
 Name   = Tom Clancy's Ghost Recon - Jungle Storm
@@ -10683,28 +10683,28 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-51980
 Name   = TT Superbikes
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51981
 Name   = ShellShock - Nam '67
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51982
 Name   = ShellShock - Nam '67
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-51986
 Name   = Backyard Wrestling - Don't Try This At Home
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51989
 Name   = Wallace & Gromit in Project Zoo
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-51991
 Name   = Dance UK
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-51996
 Name   = International Snooker Championship
@@ -10712,47 +10712,47 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51997
 Name   = SWAT - Global Strike Team
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 eeClampMode = 3			//For grey screen ingame.
 ---------------------------------------------
 Serial = SLES-51998
 Name   = Kao the Kangaroo - Round 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-51999
 Name   = GrooveRider Slot Car Thunder
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52001
 Name   = Mission Impossible - Operation Surma
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52002
 Name   = Rogue Ops
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52005
 Name   = James Bond 007 - Everything or Nothing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52008
 Name   = NBA Live 2004
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52011
 Name   = Tak and The Power of Juju
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52015
 Name   = Les Chevaliers de Baphomet
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52017
 Name   = Lord of the Rings, The - Return of the King
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52018
@@ -10761,27 +10761,27 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52019
 Name   = Lord of the Rings, The - Return of the King
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52020
 Name   = Lord of the Rings, The - The Return of the King
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52021
 Name   = Lord of the Rings, The - The Return of the King
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52022
 Name   = Total Club Manager 2004
-Region = PAL-E
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52023
 Name   = Manhunt
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52025
 Name   = NFL Street
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52026
 Name   = Wallace & Gromit in Project Zoo
@@ -10798,19 +10798,19 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52028
 Name   = Junior Sports Basketball
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52034
 Name   = Dr. Seuss' Cat in the Hat
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52036
 Name   = WWE SmackDown! - Here Comes the Pain!
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52038
 Name   = Terminator 3 - Rise of the Machines
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52041
 Name   = Detonator
@@ -10819,7 +10819,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52043
 Name   = MX Unleashed Migrated
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52044
 Name   = Crescent Suzuki Racing - Superbikes and Super Sidecars
@@ -10827,7 +10827,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52045
 Name   = GTR 400
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52046
@@ -10837,60 +10837,60 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52047
 Name   = Sims, The - Bustin' Out
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52048
 Name   = Sims, The - Bustin' Out
-Region = PAL-Unk
+Region = PAL-M5	// Eng & Nordic
 ---------------------------------------------
 Serial = SLES-52055
 Name   = Harry Potter and the Philosopher's Stone
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52056
 Name   = Harry Potter and The Philosopher's Stone
-Region = PAL-Unk
+Region = PAL-M11
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52058
 Name   = Groove Rider - Slot Car Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52060
 Name   = Fame Academy
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52061
 Name   = Star Academy
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52062
 Name   = Pop Star Academy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52063
 Name   = Alarm for Cobra 11 Autobahn
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-52065
 Name   = Flipnic
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52095
 Name   = Gradius V
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52096
 Name   = Firefighter F.D. 18
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52097
 Name   = SWAT - Global Strike Force
-Region = PAL-Unk
+Region = PAL-E-G
 Compat = 5
 eeClampMode = 3			//For grey screen ingame.
 ---------------------------------------------
@@ -10900,11 +10900,11 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52101
 Name   = Wrath Unleashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52102
 Name   = Hugo Bukkazoom!
-Region = PAL-Unk
+Region = PAL-M12
 ---------------------------------------------
 Serial = SLES-52103
 Name   = Tak & Le Pouvoir de Juju
@@ -10912,36 +10912,36 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52104
 Name   = Tak and the Power of JuJu
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52106
 Name   = Cabela's Dangerous Hunts
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52107
 Name   = Dance Europe
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52108
 Name   = Underworld - The Eternal War
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52109
 Name   = Underworld - The Eternal War
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52111
 Name   = Mojo!
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52116
 Name   = Sitting Duck
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52117
 Name   = Go Go Copter
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52118
 Name   = Castlevania - Lament of Innocence
@@ -10950,45 +10950,45 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52122
 Name   = Crime Life - Gang Wars
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52123
 Name   = EA Sports Cricket 2004
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52124
 Name   = Kill Switch
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52125
 Name   = Agassi Tennis Generation
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52132
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52133
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52134
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-I
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52135
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52136
 Name   = Hitman - Contracts
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52143
 Name   = Carmen Sandiego - The Secret of the Stolen Drums
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 ---------------------------------------------
 Serial = SLES-52149
@@ -11003,53 +11003,53 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52150
 Name   = Legacy of Kain - Defiance
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52151
 Name   = Terminator 3 - Le Macchine Ribelli
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52152
 Name   = Terminator 3 - Rise of the Machines
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52153
 Name   = Driver 3
-Region = PAL-Unk
+Region = PAL-E-S
 ---------------------------------------------
 Serial = SLES-52159
 Name   = Myth Makers Super Kart GP
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52171
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52172
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52173
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52174
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52175
 Name   = Dynasty Warriors 4 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52178
 Name   = Casino Challenge
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52179
 Name   = Kaan Barbarian Blade
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52187
@@ -11064,7 +11064,7 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52190
 Name   = RPM Tuning
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52202
@@ -11074,29 +11074,29 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52203
 Name   = Armored Core - Silent Line
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 MemCardFilter = SLES-51399/SLES-52203
 ---------------------------------------------
 Serial = SLES-52204
 Name   = UFC Sudden Impact
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52209
 Name   = Star Trek - Shattered Universe
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52214
 Name   = Disney's The Haunted Mansion
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52216
 Name   = Disney's The Haunted Mansion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52219
 Name   = Corvette
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52230
 Name   = Muppets Party Cruise
@@ -11119,20 +11119,20 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52241
 Name   = Myth Makers - Orbs of Doom
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52242
 Name   = Dalmatians 3
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52243
 Name   = Dinosaur Adventure
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52244
 Name   = Legend of Herkules
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-52246
 Name   = Pool Paradise
@@ -11141,49 +11141,49 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52247
 Name   = Hobbit, The
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-52249
 Name   = Premier Manager 2003-2004
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52256
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-E-S
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52257
 Name   = P.T.O. IV - Pacific Theater of Operations IV
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52258
 Name   = Romance of the Three Kingdoms VIII
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52259
 Name   = Outlaw Volleyball
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52265
 Name   = Energy Airforce - Aim Strike!
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52266
 Name   = Energy Airforce - Aim Strike!
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52267
 Name   = Energy Airforce - Aim Strike!
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52275
 Name   = Way of the Samurai 2
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52276
 Name   = 187 - Ride or Die
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52277
@@ -11193,130 +11193,130 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52278
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-E
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52279
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-G
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52280
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-F
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-52282
 Name   = Mafia
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52283
 Name   = Terminator 3 - The Redemption
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52284
 Name   = Deadly Skies II
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52286
 Name   = Tak and The Poer of JuJu
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52287
 Name   = Tak and The Poer of JuJu
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52288
 Name   = Tom Clancy's Rainbow Six 3
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52289
 Name   = MTX Mototrax
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52290
 Name   = MTX Mototrax
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52291
 Name   = Countryside Bears
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52292
 Name   = Disney's Mighty Mulan
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52293
 Name   = Disney's Son of the Lion King
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52294
 Name   = Toys Room, The
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52295
 Name   = Master Chess
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52298
 Name   = IndyCar Series 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52308
 Name   = Karaoke Stage
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52309
 Name   = R - Racing
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 4
 ---------------------------------------------
 Serial = SLES-52312
 Name   = World Championship Rugby
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-52313
 Name   = Space Invaders Anniversary
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52314
 Name   = Hugo - Bukkazoom
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-52322
 Name   = Drakengard
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 eeClampMode = 3			//characters are visible in-game.
 ---------------------------------------------
 Serial = SLES-52323
 Name   = Richard Burns Rally
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52325
 Name   = Champions of Norrath - Realms of EverQuest
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52326
 Name   = Spawn - Armageddon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52336
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-E-G
 Compat = 5
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52337
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-E-F
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52338
 Name   = Max Payne 2 - The Fall of Max Payne
-Region = PAL-Unk
+Region = PAL-E-I
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-52339
@@ -11326,32 +11326,32 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52340
 Name   = Rollercoaster World
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52341
 Name   = X-Files - Resist or Serve
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52342
 Name   = Worms - Forts Under Seige
-Region = PAL-Unk
+Region = PAL-E-F
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52343
 Name   = Midway Arcade Treasures
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52348
 Name   = Seven Samurai 20XX
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52349
 Name   = International Golf Pro
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52350
 Name   = International Golf Pro
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52358
 Name   = Glass Rose
@@ -11368,11 +11368,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52366
 Name   = America's 10 Most Wanted
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52367
 Name   = America's 10 Most Wanted
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52368
 Name   = AFL Live - Premiership Edition
@@ -11380,65 +11380,65 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52369
 Name   = Empires of Atlantis
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52370
 Name   = Mouse Police, The
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52371
 Name   = Animal Soccer World
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52372
 Name   = Spider-Man 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52374
 Name   = Fight Night 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52378
 Name   = Euro Rally Champion
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1		//For dmac errors and so 3d is visible and steady.
 ---------------------------------------------
 Serial = SLES-52379
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52380
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52381
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52382
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52383
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52384
 Name   = Project Zero 2 - Crimson Butterfly
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52385
 Name   = England International Football
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52386
 Name   = World Championship Snooker 2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52387
 Name   = SpyHunter 2
@@ -11446,45 +11446,45 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52388
 Name   = Transformers Armada - Prelude to Energon [Special Edition]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-52393
 Name   = Pinball Fun
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52394
 Name   = UFEA Euro 2004
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52395
 Name   = UFEA Euro 2004
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-52396
 Name   = Euro 2004
-Region = PAL-Unk
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-52397
 Name   = Euro 2004
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52398
 Name   = Euro 2004
-Region = PAL-Unk
+Region = PAL-M3	// Eng, DA & SE
 ---------------------------------------------
 Serial = SLES-52402
 Name   = Perfect Ace 2 - The Championships
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52403
 Name   = Formula Challenge
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52404
 Name   = MTV Music Generator 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52413
 Name   = Malice
@@ -11493,7 +11493,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52418
 Name   = Powerdrome
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52423
 Name   = Smash Court Tennis - Pro Tournament 2
@@ -11501,7 +11501,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52433
 Name   = Goblin Commander - Unleash The Horde
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52439
 Name   = Suffering, The
@@ -11510,12 +11510,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52440
 Name   = Harry Potter and the Prisoner of Azkaban
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 3
 ---------------------------------------------
 Serial = SLES-52444
 Name   = Hyper Street Fighter II - The Anniversary Edition
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52445
 Name   = Silent Hill 4 - The Room
@@ -11524,29 +11524,29 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52446
 Name   = Mashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52448
 Name   = Knights of the Temple
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52449
 Name   = Kidz Sports Basketball
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52450
 Name   = Serious Sam - Next Encounter
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52451
 Name   = Conan - The Dark Axe
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52457
 Name   = Shrek 2
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-52458
 Name   = Disgaea: Hour of Darkness
@@ -11558,7 +11558,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52466
 Name   = Ribbit King
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52467
 Name   = dot Hack - Part 2 - Mutation
@@ -11580,15 +11580,15 @@ MemCardFilter = SLES-52237/SLES-52467/SLES-52468/SLES-52469
 ---------------------------------------------
 Serial = SLES-52471
 Name   = Naval Ops - Commander
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52472
 Name   = Project Minerva
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52477
 Name   = Vegas Casino II
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52478
 Name   = Red Dead Revolver
@@ -11597,52 +11597,52 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52479
 Name   = Samurai Jack - The Shadow of Aku
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52480
 Name   = Yu-Gi-Oh! - The Duelists of the Roses
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52481
 Name   = Hot Wheels - Stunt Track Challenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52482
 Name   = Steel Dragon EX
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52483
 Name   = World Championship Pool 2004
-Region = PAL-Unk
+Region = PAL-UM3
 ---------------------------------------------
 Serial = SLES-52486
 Name   = Astroboy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52490
 Name   = Dance UK - Extra Trax
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52493
 Name   = Spider-Man 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52495
 Name   = Bujingai - Swordmaster
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52504
 Name   = Trivial Pursuit Unhinged
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52505
 Name   = Spy Fiction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52507
 Name   = Def Jam - Fight for New York
-Region = PAL-Unk
+Region = PAL-E-F
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52508
@@ -11651,11 +11651,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52509
 Name   = Tiger Woods PGA Tour Golf 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52510
 Name   = Neo Contra
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 4
 [patches = EEE2F6A3]
 	//comment=Patches By Nachbrenner and Prafull
@@ -11672,56 +11672,56 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52511
 Name   = Headhunter - Redemption (EX)
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52512
 Name   = Headhunter - Redemption
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52515
 Name   = Ultimate Casino
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52516
 Name   = World Fighting
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52517
 Name   = Radio Helicopter
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52518
 Name   = Motorbike King
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-52519
 Name   = Pink Pong
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52520
 Name   = Volleyball Challenge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52521
 Name   = Adibou & Les Voleurs d'Energie
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52523
 Name   = Cocoto - Platform Jumper
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52525
 Name   = Mouse Trophy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52527
 Name   = Harry Potter og Fangen fra Azkaban
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SLES-52531
 Name   = Suffering, The
@@ -11729,11 +11729,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52532
 Name   = Aces of War
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52533
 Name   = Zoo Puzzle
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52534
 Name   = Crimson Tears
@@ -11746,16 +11746,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52536
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-E
 Compat = 2
 ---------------------------------------------
 Serial = SLES-52537
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52539
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52541
 Name   = Grand Theft Auto - San Andreas
@@ -11764,20 +11764,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52544
 Name   = Trivial Pursuit Unhinged
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52545
 Name   = Star Wars Battlefront
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52546
 Name   = Star Wars Battlefront
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52547
 Name   = Star Wars Battlefront
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52551
 Name   = Samurai Warriors
@@ -11801,15 +11801,15 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52556
 Name   = Crimson Sea 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52557
 Name   = Crimson Sea 2
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52558
 Name   = Crimson Sea 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52559
 Name   = FIFA 2005
@@ -11821,60 +11821,60 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52561
 Name   = FIFA 2005
-Region = PAL-Unk
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-52562
 Name   = FIFA 2005
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52563
 Name   = FIFA Football 2005
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52567
 Name   = Catwoman
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-52568
 Name   = Crash Twinsanity
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 XgKickHack = 1 //Fixes bad Geometry
 ---------------------------------------------
 Serial = SLES-52569
 Name   = Spyro - A Hero's Tail
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52570
 Name   = Area 51
-Region = PAL-R
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52571
 Name   = Pacific Air Warriors 2 - Dogfight
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52572
 Name   = Operation Air Assault
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52573
 Name   = Conflict - Global Storm
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52576
 Name   = Yu-Gi-Oh! - Capsule Monster Colisee
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52579
 Name   = Legends of Wrestling - Showdown
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52581
 Name   = Madden NFL 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52584
 Name   = Burnout 3 - Takedown
@@ -11887,36 +11887,36 @@ Region = PAL-F-G-I
 ---------------------------------------------
 Serial = SLES-52587
 Name   = Army Men - Sarge's War
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52588
 Name   = Mercenaries
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52590
 Name   = Mercenaries
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52591
 Name   = Dynasty Warriors 4 - Empires
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52592
 Name   = Dynasty Warriors 4 - Empires
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52593
 Name   = Dynasty Warriors 4 - Empires
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52594
 Name   = U-Move SuperSports
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52598
 Name   = Dancing Stage Fusion
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52599
@@ -11929,7 +11929,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52601
 Name   = Ex Zeus
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52602
 Name   = GT Racers
@@ -11938,7 +11938,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52603
 Name   = Room Zoom - Race for Impact
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52605
 Name   = Polar Express, The
@@ -11946,67 +11946,67 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52616
 Name   = Video Poker & Blackjack
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52617
 Name   = Stock Car Speedway
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52620
 Name   = Guncom 2
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52621
 Name   = Tony Hawk's Underground 2
-Region = PAL-Unk
+Region = PAL-E
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-52622
 Name   = Tony Hawk's Underground 2
-Region = PAL-Unk
+Region = PAL-M4
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-52624
 Name   = X-Men Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52625
 Name   = X-Men Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52628
 Name   = NBA Ballers
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52630
 Name   = Conflict - Vietnam
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52631
 Name   = Digimon Rumble Arena 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 FpuCompareHack = 1
 ---------------------------------------------
 Serial = SLES-52636
 Name   = Colin McRae Rally 2005
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52637
 Name   = TOCA Racer Driver 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52638
 Name   = DTM Race Driver 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52639
 Name   = V8 Supercars 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52641
 Name   = Leisure Suit Larry: Magna Cum Laude (Uncut)
@@ -12030,31 +12030,31 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52646
 Name   = Tom Clancy's Ghost Recon 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52647
 Name   = Club Football - Manchester United 2005
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52648
 Name   = BVB 09 - Club Football 2005 - Borussia Dortmund
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52649
 Name   = Om Droit au Bit - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-52650
 Name   = Juventus - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52651
 Name   = FC Barcelona - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52652
 Name   = Liverpool FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52653
 Name   = Liverpool FC - Club Football 2005
@@ -12062,63 +12062,63 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52654
 Name   = Club Football - Real Madri 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52655
 Name   = FC Bayern Munich - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52656
 Name   = AC Milan Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52657
 Name   = Arsenal FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-52658
 Name   = Hamburg SV - Club Football 2005
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52659
 Name   = Paris Saint-Germain Club Football 2005
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-52660
 Name   = Inter - Club Football 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52661
 Name   = Ajax Club Football 2005
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52662
 Name   = Newcastle United - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52663
 Name   = Chelsea FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52664
 Name   = Rangers FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52665
 Name   = Celtic FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52666
 Name   = Tottenham Hotspur - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52667
 Name   = Birmingham City - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52668
 Name   = Aston Villa FC - Club Football 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52669
 Name   = Forgotten Realms - Demon Stone
@@ -12132,15 +12132,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52671
 Name   = Ghostmaster
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52673
 Name   = NHL 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52674
 Name   = Fussball Manager 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52675
 Name   = Hugo Cannon Cruise
@@ -12152,7 +12152,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52680
 Name   = Intellivision Lives - The History of Video Gaming
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52684
 Name   = Cyclone Circus - Power Sail Racing
@@ -12161,15 +12161,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52685
 Name   = Polar Express, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52686
 Name   = Backyard Wrestling - There Goes the Neighborhood
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52693
 Name   = LMA Manager 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52694
 Name   = BDFL Manager 2005
@@ -12185,50 +12185,50 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52700
 Name   = Jimmy Neutron - Attack of the Twonkies
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52701
 Name   = Future Tactics - The Uprising
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52702
 Name   = Psi-Ops - The Mindgate Conspiracy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52703
 Name   = Psi-Ops - The Mindgate Conspiracy
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52705
 Name   = Mortal Kombat - Deception
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52706
 Name   = Mortal Kombat - Deception
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52707
 Name   = Monster Hunter
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52709
 Name   = Ty the Tazmanian Tiger 2 - Bush Rescue
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-52710
 Name   = McFarlane's Evil Prophecy
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52711
 Name   = Titeuf Mega Compet
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52713
 Name   = NBA Live 2005
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52714
 Name   = Board Games Gallery
@@ -12236,47 +12236,47 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52716
 Name   = Energy Thieves, The
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52717
 Name   = Brian Lara Cricket 2005
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52718
 Name   = Fight Club
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52719
 Name   = Under the Skin
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52720
 Name   = Ford Racing 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52725
 Name   = Need for Speed - Underground 2
-Region = PAL-E
+Region = PAL-M8
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52726
 Name   = NBA Live 2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52727
 Name   = NBA Live 2005
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52729
 Name   = Animaniacs - The Great Edgar Hunt
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52730
 Name   = DragonBall Z - Budokai 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52731
@@ -12285,19 +12285,19 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52733
 Name   = Driven to Destruction
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52734
 Name   = Worms Forts - Under Siege
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52737
 Name   = Obscure
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52738
 Name   = Obscure
-Region = PAL-Unk
+Region = PAL-F-I
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52745
@@ -12306,16 +12306,16 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52747
 Name   = Dukes of Hazzard, The - The Return of General Lee
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52749
 Name   = Habitrail - Hamster Ball
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52750
 Name   = Monster Trux Extreme
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52751
@@ -12324,33 +12324,33 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52752
 Name   = Playboy - The Mansion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52753
 Name   = Flatout
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52754
 Name   = FlatOut
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52755
 Name   = Blood Will Tell
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52760
 Name   = Pro Evolution Soccer 4
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52761
 Name   = Rocky - Legends
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52766
 Name   = Godzilla - Save The Earth
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52767
@@ -12359,15 +12359,15 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52768
 Name   = Commandos - Strike Force
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52773
 Name   = Pool Shark 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52774
 Name   = Sprint Car Challenge
-Region = PAL-E
+Region = PAL-M6
 Compat = 2
 ---------------------------------------------
 Serial = SLES-52776
@@ -12377,7 +12377,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52778
 Name   = Arcade, The
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52779
@@ -12386,11 +12386,11 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52781
 Name   = WWE SmackDown! vs. RAW
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52782
 Name   = Call of Duty - Finest Hour
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52783
 Name   = Call of Duty - Le Jour de Glorie
@@ -12402,11 +12402,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52798
 Name   = Vietcong - Purple Haze
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52799
 Name   = Vietcong - Purple Haze
-Region = PAL-Unk
+Region = PAL-E-I
 ---------------------------------------------
 Serial = SLES-52800
 Name   = Pro Evolution Soccer 4
@@ -12426,7 +12426,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52804
 Name   = Lord of the Rings, The - The Third Age
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52805
 Name   = Lord of the Rings, The - The Third Age
@@ -12434,27 +12434,27 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52807
 Name   = Lemony Snicket's A Series of Unfortunate Events
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52808
 Name   = Lemony Snicket's A Series of Unfortunate Events
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52809
 Name   = Lemony Snicket - Schauriger Schlamassel
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52810
 Name   = Lemony Snicket's Una Serie Disfortunati Eventi
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52811
 Name   = Get on da Mic
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52812
 Name   = Disney-Pixar's The Incredibles
-Region = PAL-Unk
+Region = PAL-E
 [patches = EBDB6E4B]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12463,19 +12463,19 @@ patch=1,EE,0010ec20,word,00000000
 ---------------------------------------------
 Serial = SLES-52813
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-DU-F
 ---------------------------------------------
 Serial = SLES-52814
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52815
 Name   = Disney-Pixar's The Incredibles
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52816
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-S
 [patches = 197641AA]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12484,11 +12484,11 @@ patch=1,EE,0010ec20,word,00000000
 ---------------------------------------------
 Serial = SLES-52820
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SLES-52821
 Name   = Incredibles, The
-Region = PAL-Unk
+Region = PAL-P
 ---------------------------------------------
 Serial = SLES-52822
 Name   = Prince of Persia - Warrior Within
@@ -12497,11 +12497,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52824
 Name   = Furry Tales
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-52825
 Name   = Lemony Snicket's A Series of Unfortunate Events
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52831
 Name   = Syberia 2
@@ -12510,33 +12510,33 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52832
 Name   = MegaMan X - Command Mission
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52834
 Name   = Sega Superstars Eyetoy Bundle
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 1
 ---------------------------------------------
 Serial = SLES-52835
 Name   = Mummy, The
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52836
 Name   = Knight Rider 2
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52843
 Name   = Garfield
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52844
 Name   = Midway Arcade Treasures 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52845
 Name   = Gadget and the Gadgetinis
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52852
 Name   = Capcom Fighting Jam
@@ -12544,21 +12544,21 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-52853
 Name   = Miami Vice
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52854
 Name   = Capcom Fighting Jam
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52857
 Name   = Fairly Odd Parents, The - Shadow Showdown
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52858
 Name   = Cocoto Kart Racer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52859
 Name   = Project - Snowblind
@@ -12566,36 +12566,36 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52861
 Name   = King Arthur
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52863
 Name   = Pinball Hall of Fame
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52864
 Name   = MX World Tour
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52867
 Name   = Spindrive Ping Pong
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52868
 Name   = Viewtiful Joe 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52872
 Name   = Constantine
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52874
 Name   = Dark Wind (with Gametrak)
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52876
 Name   = King of Fighters 2000-2001
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52877
 Name   = Haunting Ground
@@ -12609,19 +12609,19 @@ Compat = 4
 ---------------------------------------------
 Serial = SLES-52884
 Name   = Duel Masters
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52885
 Name   = Sega Superstars
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52886
 Name   = Power Rangers Dino Thunder
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52887
 Name   = Power Rangers Dino Thunder
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52888
 Name   = Brothers in Arms: Road to Hill 30
@@ -12629,11 +12629,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52889
 Name   = Disney's Winnie the Pooh Rumbly Tumbly Adventure
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-52895
 Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Region = PAL-E
 Compat = 2
 [patches = 536FEB77]
 comment= Patch By Prafull
@@ -12643,27 +12643,27 @@ patch=1,EE,0010f3e0,word,00000000
 ---------------------------------------------
 Serial = SLES-52896
 Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-52898
 Name   = King of Fighters - Maximum Impact
-Region = PAL-Unk
+Region = PAL-E-JP
 ---------------------------------------------
 Serial = SLES-52900
 Name   = Rapala Pro Fishing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52902
 Name   = Arcade Classics Vol.1
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52906
 Name   = Spongebob and Friends - Movin'
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52908
 Name   = Urbz, The - Sims in the City
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52909
@@ -12672,33 +12672,33 @@ Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-52910
 Name   = UEFA Champions League 2005
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-52911
 Name   = UEFA Champions League 2005
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-52912
 Name   = UEFA Champions League 2005
-Region = PAL-Unk
+Region = PAL-E-DU
 ---------------------------------------------
 Serial = SLES-52913
 Name   = Suikoden IV
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52915
 Name   = Shark Tale
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-52917
 Name   = Scaler
-Region = PAL-Unk
+Region = PAL-E-F
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52918
 Name   = Scaler
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52919
 Name   = NRL Rugby League 2
@@ -12706,11 +12706,11 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52921
 Name   = Rogue Trooper
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52922
 Name   = EyeToy - Disney Move
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52927
 Name   = Grand Theft Auto - San Andreas
@@ -12723,31 +12723,31 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52939
 Name   = Airborne Troops - Countdown to D-Day
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52940
 Name   = S.L.A.I. Steel Lancer Arena International
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52941
 Name   = Gungrave - Overdose
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-52942
 Name   = Midnight Club 3 - DUB Edition
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52943
 Name   = ESPN NFL 2K5
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52944
 Name   = Robotech - Invasion
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52949
 Name   = Arcade Action - 30 Games
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52950
 Name   = Shadow of Rome
@@ -12756,41 +12756,41 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52951
 Name   = Phantom Brave
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52954
 Name   = WWII - Tank Battles
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52955
 Name   = Deadly Strike
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52956
 Name   = Action Girlz Racing
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52957
 Name   = Urban Extreme
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52958
 Name   = Premier Manager 2004-2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52960
 Name   = Premier Manager 2004-2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52961
 Name   = Premier Manager 2004-2005
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-52963
 Name   = Cold Winter
-Region = PAL-Unk
+Region = PAL-M4
 vuClampMode = 2 //fixes rainbow graphics
 ---------------------------------------------
 Serial = SLES-52964
@@ -12800,16 +12800,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52965
 Name   = Outlaw Golf 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52966
 Name   = ESPN NHL 2K5
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52967
 Name   = Guilty Gear X2 Reloaded
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-52968
@@ -12819,47 +12819,47 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-52973
 Name   = Ski Racing 2005
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52974
 Name   = GoldenEye - Rogue Agent
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-52975
 Name   = GoldenEye - Au Service du Mal
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-52976
 Name   = GoldenEye - Rogue Agent
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-52977
 Name   = GoldenEye - Rogue Agent
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-52978
 Name   = La Pucelle Tactics
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52980
 Name   = Big Mutha Truckers 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52982
 Name   = NFL Street 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52983
 Name   = Fitness Fun
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52984
 Name   = Panzer Front Ausf B
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52985
 Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Region = PAL-G
 [patches = B3C11E2D]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12868,7 +12868,7 @@ patch=1,EE,0010f3e0,word,00000000
 ---------------------------------------------
 Serial = SLES-52986
 Name   = Spongebob Squarepants - The Movie
-Region = PAL-Unk
+Region = PAL-S
 [patches = 34DA05D2]
 comment= Patch By Prafull
 // fix hang at loading screen
@@ -12877,56 +12877,56 @@ patch=1,EE,0010f3e0,word,00000000
 ---------------------------------------------
 Serial = SLES-52988
 Name   = MegaMan X8
-Region = PAL-Unk
+Region = PAL-M5
 // reads Command Mission save for bonus boss
 MemCardFilter = SLES-52988/SLES-52832
 ---------------------------------------------
 Serial = SLES-52989
 Name   = Blowout
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-52993
 Name   = TimeSplitters - Future Perfect
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-52998
 Name   = Sonic Mega Collection Plus
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 // two games unlock by having a Sonic Heroes save
 MemCardFilter = SLES-52998/SLES-51950
 ---------------------------------------------
 Serial = SLES-52999
 Name   = RC Toy Machines
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53000
 Name   = Crazy Golf
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53001
 Name   = NBA Street 3
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53002
 Name   = Samurai Warriors Xtreme Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53003
 Name   = Samurai Warriors Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53004
 Name   = Samurai Warriors Xtreme Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53005
 Name   = Monster Trux - Off-Road Edition
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53006
 Name   = Hamster Heroes
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53007
 Name   = Tom Clancy's Splinter Cell - Chaos Theory
@@ -12940,32 +12940,32 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53011
 Name   = Gallop Racer 2
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53012
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53013
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53014
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53015
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53016
 Name   = Tenchu - Fatal Shadows
-Region = PAL-Unk
+Region = PAL-S
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53017
 Name   = Teenage Mutant Ninja Turtles 2 - Battle Nexus
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53020
 Name   = Ghost in the Shell - Stand Alone Complex
@@ -13005,28 +13005,28 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53022
 Name   = ESPN NBA 2K5
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53023
 Name   = RTL Ski Jump 2005
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-53024
 Name   = Altered Beast
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53025
 Name   = Red Ninja - End of Honor
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53026
 Name   = Red Ninja - End of Honor
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53027
 Name   = Championship Manager 5
-Region = PAL-Unk
+Region = PAL-M4	// Nordic
 ---------------------------------------------
 Serial = SLES-53028
 Name   = Hitman - Blood Money
@@ -13034,7 +13034,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53029
 Name   = Hitman - Blood Money
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53030
 Name   = Hitman - Blood Money
@@ -13042,7 +13042,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53031
 Name   = Hitman - Blood Money
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53032
 Name   = Hitman - Blood Money
@@ -13050,12 +13050,12 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53035
 Name   = Masters of the Universe - He-Man - Defender of Greyskull
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53036
 Name   = Tak 2 - The Stuff of Dreams
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53037
 Name   = Super Monkey Ball Deluxe
@@ -13064,130 +13064,130 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53038
 Name   = Devil May Cry 3 - Dante's Awakening
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 eeRoundMode = 0
 ---------------------------------------------
 Serial = SLES-53039
 Name   = Champions - Return to Arms	// aka "Champions of Norrath 2"
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 4
 // allows import of characters from first game
 MemCardFilter = SLES-53039/SLES-52325
 ---------------------------------------------
 Serial = SLES-53041
 Name   = RTL Ski Alpine 2005
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-53044
 Name   = Juiced
-Region = PAL-R
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53045
 Name   = Street Racing Syndicate
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53046
 Name   = CT Special Forces - Fire for Effect
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53047
 Name   = Punisher, The
-Region = PAL-M2
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-53049
 Name   = Punisher, The
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-53052
 Name   = Robots
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53058
 Name   = Ricky Ponting International Cricket
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53059
 Name   = Samurai Showdown V
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53060
 Name   = Asterix & Obelix XXL 2 - Mission Las Vegum
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53061
 Name   = Atari Anthology
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53062
 Name   = Yu Yu Hakuhso - Dark Tournament
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53064
 Name   = FIFA Street
-Region = PAL-Unk
+Region = PAL-M7
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53065
 Name   = SNK vs. Capcom - SVC Chaos
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53073
 Name   = Michigan : Report from Hell
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53074
 Name   = Soccer Life
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53075
 Name   = Area 51
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53076
 Name   = Triggerman
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53078
 Name   = Spy vs. Spy
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53079
 Name   = Ys - The Ark of Napishtim
-Region = PAL-Unk
+Region = PAL-M5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53080
 Name   = Extreme Sprint 3010
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53082
 Name   = World Championship Snooker 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53084
 Name   = Fight Night Round 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53087
 Name   = TOCA Race Driver 3
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53088
 Name   = DTM Race Driver 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53089
 Name   = V8 Supercars 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53090
 Name   = Circuit Blasters
@@ -13195,49 +13195,49 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53091
 Name   = Predator - Concrete Jungle
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53092
 Name   = Motocross Mania 3
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53093
 Name   = Cold Winter
-Region = PAL-Unk
+Region = PAL-G
 vuClampMode = 2 //fixes rainbow graphics
 ---------------------------------------------
 Serial = SLES-53094
 Name   = Rugby 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53095
 Name   = Rugby 2005
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53096
 Name   = Worms 4 - Mayhem
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53098
 Name   = Conspiracy - Weapons of Mass Destruction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53099
 Name   = Pilot Down - Behind Enemy Lines
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53100
 Name   = Scooby Doo! Unmasked
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53104
 Name   = Tom Clancy's Rainbow Six - Lockdown
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53106
 Name   = MX vs. ATV Unleashed
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53107
 Name   = Cabela's Big Game Hunter 2005 Adventures
@@ -13245,59 +13245,59 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53108
 Name   = American Chopper
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53114
 Name   = Full Spectrum Warrior
-Region = PAL-Unk
+Region = PAL-M5
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53119
 Name   = Kessen III
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53120
 Name   = Kessen III
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53121
 Name   = Kessen III
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53124
 Name   = Project Snowblind
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53125
 Name   = Enthusia - Professional Racing
-Region = PAL-Unk
+Region = PAL-M5
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-53127
 Name   = Teenage Mutant Ninja Turtles - Mutant Melee
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53129
 Name   = Tak 2 - The Staff of Dreams
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-53130
 Name   = World Championship Poker
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53131
 Name   = Full Spectrum Warrior
-Region = PAL-R
+Region = PAL-E
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53138
 Name   = Outlaw Volleyball - Remixed
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53139
 Name   = Alien Humanoid
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53140
@@ -13306,52 +13306,52 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53141
 Name   = X-Treme Quads
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53142
 Name   = Doomsday Racers
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53143
 Name   = Fantastic Four
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53144
 Name   = Four Fantastiques, Les
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53145
 Name   = Fantastic Four
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53146
 Name   = I Fantastici Quattro
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53147
 Name   = Four Fantasticos, Los
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53148
 Name   = Fruitfall
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53150
 Name   = 10 Pin - Champions' Alley
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53151
 Name   = Juiced
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53152
 Name   = Mashed Fully Loaded
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53154
 Name   = The Bard's Tale
-Region = PAL-M4	// Multiple languages
+Region = PAL-M8
 [patches]
 	comment=- This gamedisc supports multiple languages.
 	comment=- Language selection is done through the BIOS configuration.
@@ -13360,20 +13360,20 @@ Region = PAL-M4	// Multiple languages
 ---------------------------------------------
 Serial = SLES-53155
 Name   = Star Wars - Episode III - Revenge of the Sith
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53156
 Name   = Star Wars - Episode III - La Revanche des Sith
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53157
 Name   = Star Wars - Episode III - Die Rache der Sith
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53158
 Name   = Cold Fear
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53172
@@ -13382,55 +13382,55 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53174
 Name   = Golden Age of Racing
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53175
 Name   = Top Spin
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53186
 Name   = International Super Karts
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53190
 Name   = Girl Zone
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53191
 Name   = Kaido Racer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53192
 Name   = Nightmare Before Christmas, The - Tim Burton's
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53194
 Name   = LEGO Star Wars
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53195
 Name   = Punisher, The
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53196
 Name   = Destroy All Humans!
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53197
 Name   = Destroy All Humans!
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53199
 Name   = 25 to Life
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53200
 Name   = DragonBall Z - Budokai Tenkaichi
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53201
@@ -13440,44 +13440,44 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53203
 Name   = Punisher, The
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53218
 Name   = Dancing Stage MAX
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53219
 Name   = Winx Club
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53221
 Name   = l'Entraineur 5
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53222
 Name   = Scudetto 5
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53223
 Name   = Championship Manager 5
-Region = PAL-Unk
+Region = PAL-P
 ---------------------------------------------
 Serial = SLES-53224
 Name   = Championship Manager 5
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53225
 Name   = Dreamworks' Madagascar
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53226
 Name   = Dreamworks' Madagascar
-Region = PAL-Unk
+Region = PAL-F-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53227
 Name   = Madagascar
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53233
 Name   = Assault Suits Valken
@@ -13490,7 +13490,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53235
 Name   = Syberia II
-Region = PAL-Unk
+Region = PAL-R
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53236
@@ -13499,11 +13499,11 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53237
 Name   = Fire Heroes
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53238
 Name   = Premier Manager 2005-2006
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53242
 Name   = Madagascar
@@ -13511,7 +13511,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53246
 Name   = Madagascar
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53280
 Name   = 7 Sins
@@ -13520,16 +13520,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53281
 Name   = Fantastic Four
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53282
 Name   = Harvest Fishing
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53284
 Name   = Guilty Gear Isuka
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53287
@@ -13538,17 +13538,17 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53296
 Name   = Ford Mustang - The Legend Lives
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53297
 Name   = 7 Sins
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53299
 Name   = Delta Force - Black Hawk Down
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53300
 Name   = SOCOM 3 - U.S. Navy SEALs
@@ -13556,12 +13556,12 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53301
 Name   = Bomberman Hardball
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53303
 Name   = Skijumping 2006
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-53309
 Name   = Transformers
@@ -13570,11 +13570,11 @@ VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-53311
 Name   = Graffiti Kingdom
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53317
 Name   = Black Market Bowling
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53318
 Name   = Crazy Golf - World Tour
@@ -13582,42 +13582,42 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53319
 Name   = Resident Evil Outbreak - File #2
-Region = PAL-Unk
+Region = PAL-M5
 // reads and writes to Outbreak File #1
 MemCardFilter = SLES-53319/SCES-50987/SLES-51589
 ---------------------------------------------
 Serial = SLES-53320
 Name   = S.C.A.R. - Squadra Corse Alfa Romeo
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53322
 Name   = Obscure
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53332
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53333
 Name   = Medal of Honor - Les Faucons de Guerre
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53334
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53335
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53336
 Name   = Medal of Honor - European Assault
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53338
 Name   = Victorious Boxers 2 - Fighting Spirit
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53339
 Name   = Dynasty Warriors 5
@@ -13630,7 +13630,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53342
 Name   = EA Sports Cricket 2005
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53344
 Name   = Gerrilla Strike
@@ -13638,12 +13638,12 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53346
 Name   = DragonBall Z - Budokai 3 [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53350
 Name   = Sonic Gems Collection
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 // Vectorman unlocks by having a Mega Collection or Heroes save
 MemCardFilter = SLES-53350/SLES-52998/SLES-51950
@@ -13654,24 +13654,24 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53354
 Name   = Superbike GP
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53356
 Name   = Colosseum - Road to Freedom
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53357
 Name   = Colosseum - Road to Freedom
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53360
 Name   = Alarm for Cobra 11 Vol.2 - Hot Pursuit
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53361
 Name   = Stealth Force - The War on Terror
-Region = PAL-E
+Region = PAL-E-S
 ---------------------------------------------
 Serial = SLES-53362
 Name   = Alpine Skiing 2005
@@ -13689,7 +13689,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53367
 Name   = Dodgeball
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53368
@@ -13698,20 +13698,20 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53369
 Name   = Twenty-2 Party
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53370
 Name   = Real World Golf [with Gametrak]
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53371
 Name   = Real World Golf [with Gametrak]
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53373
 Name   = Madagascar
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53374
 Name   = X-Men Legends II - Rise of Apocalypse
@@ -13719,7 +13719,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53377
 Name   = X-Men Legends II - Rise of Apocalypse
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-53380
 Name   = Metal Slug 4
@@ -13740,25 +13740,25 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53386
 Name   = Charlie and the Chocolate Factory
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53387
 Name   = Batman Begins
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53390
 Name   = Ultimate Spider-Man
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53391
 Name   = Ultimate Spider-Man
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53393
 Name   = Spartan Total Warrior
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53398
@@ -13768,7 +13768,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53399
 Name   = Yakuza Fury
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53402
 Name   = Taxi Rider
@@ -13782,11 +13782,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53405
 Name   = Digimon World 4
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53406
 Name   = Party Girls
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53407
@@ -13795,30 +13795,30 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53408
 Name   = Fighting Angels
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53411
 Name   = Kuon
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53414
 Name   = Echo Night - Beyond
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53415
 Name   = Call of Duty 2 - Big Red One
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53416
 Name   = Call of Duty 2 - Big Red One
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53417
 Name   = Call of Duty 2 - Big Red One
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53418
 Name   = Tak - The Great JuJu Challenge
@@ -13826,32 +13826,32 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53419
 Name   = LA Rush
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53424
 Name   = Dead to Rights 2
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53430
 Name   = Incredible Hulk 2, The - Ultimate Destruction
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53433
 Name   = NHL '06
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53434
 Name   = WWI - Red Baron
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53435
 Name   = SAS Anti-Terror Force
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53436
 Name   = YetiSports Arctic Adventures
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53438
 Name   = Taito Legends
@@ -13860,15 +13860,15 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53439
 Name   = Crash Tag Team Racing
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53441
 Name   = Heroes of the Pacific
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53443
 Name   = Warriors, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53444
 Name   = Pro Evolution Soccer 5
@@ -13881,11 +13881,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53452
 Name   = Trixie in Toyland
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53457
 Name   = Evil Dead - Regeneration
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53458
 Name   = Shin Megami Tensei: Digital Devil Saga
@@ -13895,11 +13895,11 @@ EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53459
 Name   = Marc Ecko's Getting Up - Contents Under Pressure
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53461
 Name   = Sega Classics Collection
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53462
@@ -13908,7 +13908,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53463
 Name   = NHL '06
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53466
 Name   = Il Grande Quiz sul Calcio Italiano
@@ -13924,11 +13924,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53473
 Name   = Incredibles, The - Rise of the Underminer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53474
 Name   = Incredibles, The - Rise of the Underminer
-Region = PAL-Unk
+Region = PAL-M3
 [patches = F3AE68FC]
 	//Patch By Prafull
 	//fix hang at loading screen
@@ -13937,11 +13937,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53480
 Name   = Harvest Moon - A Wonderful Life [Special Edition]
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53481
 Name   = 10,000 Bullets
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53483
@@ -13951,53 +13951,57 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53484
 Name   = Eagle Eye Golf
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53487
 Name   = Forty 4 Party
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53488
 Name   = Puzzlemaniacs
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53489
 Name   = Paparazzi
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53490
 Name   = Outlaw Tennis
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53492
 Name   = Total Overdose
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53494
 Name   = Spongebob Squarepants - Lights, Camera, PANTS!
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53496
 Name   = Spongebob Squarepants - Lights, Camera, PANTS!
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53501
 Name   = Star Wars - Battlefront II
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53502
 Name   = Star Wars - Battlefront II
-Region = PAL-Unk
+Region = PAL-F
+---------------------------------------------
+Serial = SLES-53503
+Name   = Star Wars - Battlefront II
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53504
 Name   = Agent Hugo
-Region = PAL-Unk
+Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-53505
 Name   = Beat Down - Fists of Vengeance
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53506
 Name   = Burnout Revenge
@@ -14007,26 +14011,26 @@ MemCardFilter = SLES-53506/SLES-53507/SLES-52584/SLES-52585/SLES-53510
 ---------------------------------------------
 Serial = SLES-53507
 Name   = Burnout Revenge
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 MemCardFilter = SLES-53506/SLES-53507/SLES-52584/SLES-52585/SLES-53510
 ---------------------------------------------
 Serial = SLES-53508
 Name   = Ultimate Pro-Pinball
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53509
 Name   = Hello Kitty - Roller Rescue
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53510
 Name   = Madden NFL 2006
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53518
 Name   = Castle Shikigami II
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53521
 Name   = Musashi - Samurai Legend
@@ -14034,11 +14038,11 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53523
 Name   = Gun
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53524
 Name   = Mortal Kombat - Shaolin Monks
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53525
 Name   = Mortal Kombat - Shaolin Monks
@@ -14061,36 +14065,36 @@ MemCardFilter = SLES-53526/SLES-53527/SLES-53528/SLES-53626/SLES-51693/SLES-5243
 ---------------------------------------------
 Serial = SLES-53529
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53530
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53531
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-53532
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-53533
 Name   = FIFA '06
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-53534
 Name   = Tony Hawk's American Wasteland
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53535
 Name   = Tony Hawk's American Wasteland
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53536
 Name   = London Racer - Police Madness
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53539
@@ -14105,44 +14109,44 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53541
 Name   = Tiger Woods PGA Tour '06
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53542
 Name   = Shadow the Hedgehog
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53544
 Name   = Pro Evolution Soccer 5
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53545
 Name   = Pro Evolution Soccer 5
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53546
 Name   = NBA Live 2006
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53547
 Name   = NBA Live '06
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53548
 Name   = Yokushin - Giga Wing Generations
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53551
 Name   = SSX On Tour
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53552
 Name   = SSX On Tour
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-53553
 Name   = James Bond 007 - From Russia with Love
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53557
 Name   = Need for Speed - Most Wanted
@@ -14153,69 +14157,69 @@ MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53558
 Name   = Need for Speed - Most Wanted
-Region = PAL-Unk
+Region = PAL-M8
 MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53559
 Name   = Need for Speed - Most Wanted
-Region = PAL-Unk
+Region = PAL-M3
 MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53560
 Name   = Sonic Riders
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53561
 Name   = Canis Canem Edit
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53563
 Name   = Spongebob Squarepants and Friends - Untie!
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53564
 Name   = Darkwatch
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53566
 Name   = London Taxi - Rushour
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53569
 Name   = Mini Mini Desktop Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53570
 Name   = Ninjabread Man
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53571
 Name   = Anubis II
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53572
 Name   = Rig Racer 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 4
 ---------------------------------------------
 Serial = SLES-53574
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53575
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53576
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53577
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53578
 Name   = Bratz - Rock Angelz
@@ -14223,32 +14227,32 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53579
 Name   = One Piece - Grand Battle
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53580
 Name   = NBA Live '06
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53581
 Name   = NBA Live '06
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53582
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-53583
 Name   = Bratz - Rock Angelz
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53585
 Name   = Marvel Nemesis - Rise of the Imperfects
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 3
 ---------------------------------------------
 Serial = SLES-53587
 Name   = Garfield - Saving Arlene
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53592
 Name   = Zombie Attack
@@ -14256,7 +14260,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53594
 Name   = Living World Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53595
 Name   = Wild Water Adrenaline featuring Salomon
@@ -14272,38 +14276,38 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53614
 Name   = Classic British Motor Racing
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53616
 Name   = True Crime - New York City
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53618
 Name   = True Crime - New York City
-Region = PAL-Unk
+Region = PAL-S // Voices in English, text and subtitles in Spanish.
 ---------------------------------------------
 Serial = SLES-53621
 Name   = Wallace & Grommit - The Curse of the Were Rabbit
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53623
 Name   = Spongebob Squarepants - Battle for Bikini Bottom
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53624
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53626
 Name   = Suffering, The - Ties that Bind
-Region = PAL-M2
+Region = PAL-E-G
 MemCardFilter = SLES-53526/SLES-53527/SLES-53528/SLES-53626/SLES-51693/SLES-52439/SLES-52531
 ---------------------------------------------
 Serial = SLES-53635
 Name   = NASCAR '06 - Total Team Control
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53639
 Name   = Ford Street Racing
@@ -14311,24 +14315,24 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53641
 Name   = Destroy All Humans!
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53645
 Name   = Knights of the Temple II
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53646
 Name   = World Racing 2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53647
 Name   = Gun
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53651
 Name   = WWII - Soldier
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53652
 Name   = Daemon Summoner
@@ -14337,21 +14341,21 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53654
 Name   = London Racer - Destruction Madness
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53656
 Name   = Full Spectrum Warrior - Ten Hammers
-Region = PAL-Unk
+Region = PAL-M4
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53657
 Name   = Shrek - Super Slam
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53658
 Name   = Disney-Pixar's The Incredibles - Rise of the Underminer
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53659
 Name   = Brothers in Arms: Earned in Blood
@@ -14359,7 +14363,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53661
 Name   = Capcom Classics Collection
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53666
 Name   = Midway Arcade Treasures 3
@@ -14377,51 +14381,51 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53668
 Name   = Micro Machines v4
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53676
 Name   = WWE SmackDown! vs. RAW 2006
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53677
 Name   = WWE SmackDown! vs. RAW 2006
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53682
 Name   = James Pond - Codename Robocod
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53685
 Name   = Codename: Kids Next Door - Operation V.I.D.E.O.G.A.M.E
-Region = PAL-E
+Region = PAL-E-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53686
 Name   = NHL Hockey 2K6
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53689
 Name   = World Poker Tour 2K6
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53690
 Name   = Makai Kingdon - Chronicle of the Sacred Stone
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53695
 Name   = Tak - The Great Juju Challenge
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-53696
 Name   = Zathura
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53697
 Name   = Dora the Explorer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53699
 Name   = Swords of Destiny
@@ -14430,17 +14434,17 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53701
 Name   = Super Monkey Ball Adventure
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53702
 Name   = Resident Evil 4
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53703
 Name   = King Kong, Peter Jackson's - The Official Game of the Movie
-Region = PAL-Unk
+Region = PAL-M10
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53704
@@ -14453,28 +14457,28 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53706
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53707
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53708
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53709
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-DU-F
 ---------------------------------------------
 Serial = SLES-53710
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53712
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SLES-53713
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
@@ -14482,84 +14486,84 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53715
 Name   = Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53716
 Name   = Without Warning
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53717
 Name   = Midnight Club 3 - DUB Edition Remix
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53718
 Name   = Sims 2, The
-Region = PAL-Unk
+Region = PAL-M10
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53722
 Name   = Call of Duty 2 - Big Red One [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53724
 Name   = World Series of Poker
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53725
 Name   = Asterix & Obelix XXL2
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53726
 Name   = Harry Potter and The Goblet of Fire
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53727
 Name   = Harry Potter and The Goblet of Fire
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53728
 Name   = Harry Potter and The Goblet of Fire
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53729
 Name   = Battlefield 2 - Modern Combat
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-53730
 Name   = Battlefield 2 - Modern Combat
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53734
 Name   = 50cent - Bulletproof
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53736
 Name   = Billy the Wizard - Rocket Broomstick Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53738
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-DU-F
 ---------------------------------------------
 Serial = SLES-53739
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-F-S
 ---------------------------------------------
 Serial = SLES-53740
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53741
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53743
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-M3	// Scandinavia
 ---------------------------------------------
 Serial = SLES-53744
 Name   = Disney's Chicken Little
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53746
 Name   = Superman Returns
@@ -14567,23 +14571,23 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53747
 Name   = Ed, Edd, 'n Eddy - The Misadventure
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53748
 Name   = Quest for Sleeping Beauty
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-53751
 Name   = Shrek Superslam
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53754
 Name   = ATV Off-Road Fury 3
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53755
 Name   = Castlevania - Curse of Darkness
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 vuClampMode = 0		//SPS with microVU
 // reads Lament of Innocence save for easter egg
@@ -14599,23 +14603,23 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53760
 Name   = Rugby Challenge 2006
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53761
 Name   = Friends - The One with All the Trivia
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53763
 Name   = Tom Clancy's Ghost Recon - Advanced Warfighter
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53764
 Name   = Atelier Iris: Eternal Mana
-Region = PAL-Unk
+Region = PAL-E	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-53765
 Name   = Stella Deus: The Gate of Eternity
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53767
 Name   = Magna Carta: Les Larmes de Sang
@@ -14628,16 +14632,16 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53769
 Name   = Suikoden Tactics
-Region = PAL-Unk
+Region = PAL-M5
 MemCardFilter = SLES-53769/SLES-52913
 ---------------------------------------------
 Serial = SLES-53772
 Name   = Air Raid 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53775
 Name   = Reservoir Dogs
-Region = PAL-Unk
+Region = PAL-M4
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53777
@@ -14647,7 +14651,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53778
 Name   = Jacked
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53779
@@ -14656,60 +14660,60 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53794
 Name   = Drakengard 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53796
 Name   = FIFA Street 2
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53797
 Name   = FIFA Street 2
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53799
 Name   = Matrix, The - Path of Neo
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53800
 Name   = Rampage - Total Destruction
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53803
 Name   = Friends - Das Trivia Game
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53804
 Name   = Shamu's Deep Sea Adventures
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53810
 Name   = Sensible Soccer 2006
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53813
 Name   = Friends - Celui qui Repond a Toutes les Questions
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53819
 Name   = Armored Core - Nine Breaker
-Region = PAL-Unk
+Region = PAL-E
 MemCardFilter = SLES-53819/SLES-82036/SLES-82037
 ---------------------------------------------
 Serial = SLES-53820
 Name   = Armored Core - Last Raven
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53824
 Name   = Trapt
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53825
 Name   = Project Zero 3 - The Tormented
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53826
@@ -14724,43 +14728,43 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53827
 Name   = Tom Clancy's Splinter Cell - Double Agent
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53828
 Name   = We Love Katamari
-Region = PAL-Unk
+Region = PAL-M4
 vuClampMode = 3
 mvuFlagSpeedHack = 0
 ---------------------------------------------
 Serial = SLES-53829
 Name   = Raiden III
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53830
 Name   = Psychonauts
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53831
 Name   = BloodRayne 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53832
 Name   = BloodRayne 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53846
 Name   = Soccer Life II
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53847
 Name   = Street Golfer
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53848
 Name   = Flow - Urban Dance Uprising
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53849
@@ -14769,7 +14773,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-53850
 Name   = Teenage Mutant Ninja Turtles 3 - Mutant Nightmare
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53852
 Name   = Taito Legends 2
@@ -14778,20 +14782,20 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53855
 Name   = Heracles - Battle with the Gods
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53857
 Name   = Need for Speed - Most Wanted [Black Edition]
-Region = PAL-E
+Region = PAL-M3
 MemCardFilter = SLES-53557/SLES-53558/SLES-53559/SLES-53857/SLES-52725
 ---------------------------------------------
 Serial = SLES-53860
 Name   = Dynasty Warriors 5 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53861
 Name   = Dynasty Warriors 5 - Xtreme Legends
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53862
 Name   = Dynasty Warriors 5 - Xtreme Legends
@@ -14804,47 +14808,47 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53866
 Name   = Over the Hedge
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53867
 Name   = Ski Alpin 2006
-Region = PAL-Unk
+Region = PAL-E-G
 vuClampMode = 2
 ---------------------------------------------
 Serial = SLES-53869
 Name   = Crazy Frog Racer
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53870
 Name   = Devil Kings
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53871
 Name   = Tengai
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53872
 Name   = Samurai Aces
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53873
 Name   = Sol Divide
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53874
 Name   = Dragon Blaze
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53877
 Name   = Premier Manager 2006-2007
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53886
 Name   = Black
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 vuClampMode = 0
 ---------------------------------------------
@@ -14854,37 +14858,37 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53899
 Name   = Pro Evolution Soccer Management
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53900
 Name   = Kaido Racer
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53901
 Name   = Torino 2006
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 vuClampMode = 2			//for SPS with microVU.
 ---------------------------------------------
 Serial = SLES-53902
 Name   = Leaderboard Golf
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53903
 Name   = Franklin the Turtle
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-53904
 Name   = DT Racer
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53906
 Name   = 50cent - Bulletproof
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53908
 Name   = Tomb Raider - Legend
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M8
 Compat = 5
 [patches]
 	comment=- This gamedisc supports multiple languages.
@@ -14894,7 +14898,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-53909
 Name   = Full Spectrum Warrior - Ten Hammers
-Region = PAL-Unk
+Region = PAL-G
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
 Serial = SLES-53910
@@ -14903,64 +14907,64 @@ Region = PAL-R
 ---------------------------------------------
 Serial = SLES-53913
 Name   = Plan, The
-Region = PAL-Unk
+Region = PAL-F-I
 ---------------------------------------------
 Serial = SLES-53914
 Name   = Plan, The
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53915
 Name   = Space War Attack
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53917
 Name   = G1 Jockey 4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53920
 Name   = Speed Machines 3
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53921
 Name   = Sim Chemist
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53922
 Name   = Car Wash Tycoon
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53923
 Name   = London Cab Challenge
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53924
 Name   = Combat Ace
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53934
 Name   = G-Force
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53935
 Name   = Dynamite
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53936
 Name   = Snow Rider
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53940
 Name   = Smarties Meltdown
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53945
 Name   = Championship Manager 2006
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53948
 Name   = Winter Sports
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53949
 Name   = Magna Carta: Lacrime di Sangue
@@ -14972,101 +14976,101 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53955
 Name   = Friends - The One with All the Trivia
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53956
 Name   = Aeon Flux
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53959
 Name   = Pac-Man World 3
-Region = PAL-Unk
+Region = PAL-M5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53963
 Name   = Downhill Slalom
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53964
 Name   = Homura
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53965
 Name   = Plan, The
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-53966
 Name   = Taito Legends
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-53967
 Name   = Godfather, The
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53968
 Name   = Godfather, The (Le Parrain)
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-53970
 Name   = Godfather, The
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-53971
 Name   = Godfather, The
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53972
 Name   = Stock Car Crash
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
 Serial = SLES-53974
 Name   = Dragon Quest VIII - Journey of the Cursed King
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53976
 Name   = Evolution GT
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53979
 Name   = Torrente 3 - El Protector
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53982
 Name   = Fight Night Round 3
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-53984
 Name   = Ice Age 2 - The Meltdown
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-53987
 Name   = Over the Hedge
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-53988
 Name   = Over the Hedge
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-53989
 Name   = Over the Hedge
-Region = PAL-Unk
+Region = PAL-DU
 ---------------------------------------------
 Serial = SLES-53991
 Name   = Urban Chaos - Riot Response
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53994
 Name   = 50cent - Bulletproof
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-53996
 Name   = Army Men - Major Malfunction
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-53998
@@ -15085,110 +15089,110 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54003
 Name   = Flatout 2
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54004
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-DU-P
 ---------------------------------------------
 Serial = SLES-54006
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54007
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-54010
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54011
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-SE
 ---------------------------------------------
 Serial = SLES-54012
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54013
 Name   = World Snooker Championship 2007
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54015
 Name   = Disney-Pixar's Cars
-Region = PAL-Unk
+Region = PAL-M3	// DA, FI & NO
 ---------------------------------------------
 Serial = SLES-54016
 Name   = AND 1 Streetball
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54021
 Name   = Ruff Trigger
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54023
 Name   = Bible Game, The
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54027
 Name   = Driver - Parallel Lines
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54030
 Name   = Black
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 vuClampMode = 0
 ---------------------------------------------
 Serial = SLES-54031
 Name   = Da Vinci Code, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54033
 Name   = Search and Destroy
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54060
 Name   = Fruit Machine Mania
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54061
 Name   = FIFA World Cup - Germany '06
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54062
 Name   = FIFA World Cup - Germany '06
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-54063
 Name   = FIFA World Cup 2006
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54064
 Name   = FIFA World Cup 2006
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54066
 Name   = X-Men - The Official Game
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54068
 Name   = AFL Premiership 2006
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54074
 Name   = Speedboat GP
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54075
 Name   = ProStroke Golf - World Tour 2007
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54080
 Name   = World Super Police
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54081
 Name   = FIFA World Cup 2006
@@ -15196,7 +15200,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54083
 Name   = Pirates of the Caribbean - The Legend of Jack Sparrow
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54084
 Name   = PowerShot Pinball
@@ -15205,7 +15209,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54085
 Name   = Street Fighter Alpha Anthology
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54087
 Name   = Suikoden V
@@ -15214,23 +15218,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54089
 Name   = State of Emergency 2
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54093
 Name   = Guitar Hero
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54095
 Name   = Dynasty Warriors 5 - Empires
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54096
 Name   = Dynasty Warriors 5 - Empires
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54097
 Name   = Dynasty Warriors 5 - Empires
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54106
 Name   = Kidz Sports - Ice Hockey
@@ -15246,7 +15250,7 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54109
 Name   = Off-Road Extreme! [Special Edition]
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54110
 Name   = Monster Trux Arenas [Special Edition]
@@ -15266,12 +15270,12 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54114
 Name   = Kingdom Hearts II
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54115
 Name   = Delta Force - Black Hawk Down - Team Sabre
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1	//missing text
 ---------------------------------------------
@@ -15280,12 +15284,12 @@ Name   = Operation Winback 2 - Project Poseidon
 Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54117
-Name   = Torrente 3 - El Protector
+Name   = Torrente 3 - The Protector
 Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54118
 Name   = Da Vinci Code, The
-Region = PAL-Unk
+Region = PAL-E-DU
 ---------------------------------------------
 Serial = SLES-54120
 Name   = The Snow Queen Quest
@@ -15293,19 +15297,19 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54123
 Name   = Marvel - Ultimate Alliance
-Region = PAL-Unk
+Region = PAL-E-I
 ---------------------------------------------
 Serial = SLES-54126
 Name   = Family Guy - The Video Game
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54130
 Name   = Spy Hunter - Nowhere to Run
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54132
 Name   = Guitar Hero
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54135
@@ -15315,23 +15319,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54136
 Name   = Grand Theft Auto - Liberty City Stories
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-54137
 Name   = Just Cause
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54138
 Name   = Steambot Chronicles
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54139
 Name   = Earache - Extreme Metal Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54140
 Name   = Playwize Poker & Casino
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54143
 Name   = Hard Rock Casino
@@ -15343,19 +15347,19 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54150
 Name   = Bionicle Heroes
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54151
 Name   = Let's Make a Soccer Team!
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54152
 Name   = Ant Bully, The
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54153
 Name   = Virtua Pro Football
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54154
 Name   = D-Unit Drift Racing
@@ -15367,23 +15371,23 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54156
 Name   = Mortal Kombat - Armageddon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54158
 Name   = Hummer Badlands
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54159
 Name   = Eragon
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54160
 Name   = Eragon
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54161
 Name   = Super DragonBall Z
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54162
 Name   = Saint Seiya - The Hades
@@ -15396,53 +15400,53 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54164
 Name   = DragonBall Z Budokai - Tenkaichi 2
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54165
 Name   = One Piece - Grand Adventure
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54166
 Name   = Call of Duty 3
-Region = PAL-Unk
+Region = PAL-E
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-54167
 Name   = Call of Duty 3
-Region = PAL-S
+Region = PAL-M3
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-54168
 Name   = Call of Duty 3
-Region = PAL-Unk
+Region = PAL-G
 eeClampMode = 3
 ---------------------------------------------
 Serial = SLES-54169
 Name   = Aeon Flux
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54170
 Name   = Jaws Unleashed
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54171
 Name   = Yakuza
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54172
 Name   = Garfield 2 - Tale of Two Kitties
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54174
 Name   = Zoocube
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54178
 Name   = Ant Bully, The
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-54179
 Name   = Pirates of the Caribbean - At World's End
@@ -15468,7 +15472,7 @@ Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54185
 Name   = Dirge of Cerberus - Final Fantasy VII
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 [patches = 33F7D21A]
 	comment=- This gamedisc supports multiple languages.
@@ -15483,12 +15487,12 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54186
 Name   = Devil May Cry 3 - Dante's Awakening [Special Edition]
-Region = PAL-E
+Region = PAL-M5
 eeRoundMode = 0
 ---------------------------------------------
 Serial = SLES-54187
 Name   = Real World Golf 2007
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54188
 Name   = Nickelodeon Avatar - The Legend of Aang
@@ -15496,11 +15500,11 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54193
 Name   = Sudoku, Carol Vonderman's
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54194
 Name   = Sudoku, Carol Vonderman's
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54195
 Name   = Turbo Trucks
@@ -15508,7 +15512,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54199
 Name   = Who Wants to be a Millionaire - Party Edition
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54200
 Name   = Just Cause
@@ -15516,27 +15520,27 @@ Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-54203
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54204
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-I-PL
 ---------------------------------------------
 Serial = SLES-54205
 Name   = WWI - Aces of the Sky
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54209
 Name   = Sopranos, The - Road to Respect
-Region = PAL-Unk
+Region = PAL-E-S
 ---------------------------------------------
 Serial = SLES-54210
 Name   = NBA 2K7
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54211
 Name   = NHL 2K7
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54212
 Name   = Agent Hugo - RoboRumble
@@ -15548,16 +15552,16 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54215
 Name   = Monster House
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54216
 Name   = Monster House
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54217
 Name   = Monster House
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54218
 Name   = Rule of Rose
@@ -15565,17 +15569,17 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54221
 Name   = LEGO Star Wars II - The Original Trilogy
-Region = PAL-Unk
+Region = PAL-M6
 // allows import of characters from Lego Star Wars 1
 MemCardFilter = SLES-54221/SLES-53194
 ---------------------------------------------
 Serial = SLES-54222
 Name   = SuperBikes Riding Challenge
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54223
 Name   = NASCAR '07
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54224
 Name   = Australian Idol Sing
@@ -15583,7 +15587,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54225
 Name   = LMA Manager 2007
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54230
 Name   = Brian Lara International Cricket 2007
@@ -15600,7 +15604,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54234
 Name   = Kingdom Hearts II
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54235
 Name   = Kingdom Hearts II
@@ -15608,16 +15612,16 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-54237
 Name   = Pirates of the Caribbean - The Legend of Jack Sparrow
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54239
 Name   = Wild ARMs 4
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54240
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54241
@@ -15626,31 +15630,31 @@ Region = PAL-F-G-I
 ---------------------------------------------
 Serial = SLES-54243
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-54244
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-M5	// DU & Nordic
 ---------------------------------------------
 Serial = SLES-54245
 Name   = NHL '07
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54246
 Name   = FIFA '07
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54248
 Name   = Madden NFL '07
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54250
 Name   = NBA Live '07
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54251
 Name   = NBA Live '07
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-54252
 Name   = NBA Live '07
@@ -15658,7 +15662,7 @@ Region = PAL-E-G-I
 ---------------------------------------------
 Serial = SLES-54253
 Name   = Tiger Woods PGA Tour '07
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54254
 Name   = Evolution GT
@@ -15671,11 +15675,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54256
 Name   = WWII - Battle Over the Pacific
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54271
 Name   = Scarface - The World is Yours
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54305
 Name   = Demon Chaos
@@ -15684,30 +15688,30 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54306
 Name   = Cartoon Network Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54307
 Name   = Rayman - Raving Rabbids
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54308
 Name   = Phantasy Star Universe
-Region = PAL-Unk
+Region = PAL-M3
 Compat = 5
 eeRoundMode = 0
 ---------------------------------------------
 Serial = SLES-54309
 Name   = Strawberry Shortcake - The Sweet Dreams Game
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54310
 Name   = Open Season
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54311
 Name   = Noddy and The Magic Book
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54316
 Name   = Open Season - Rebelles de la Foret
@@ -15715,7 +15719,7 @@ Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54317
 Name   = Ghost Rider
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54319
@@ -15724,40 +15728,40 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54320
 Name   = Championship Manager 2007
-Region = PAL-E
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54321
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54322
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-54323
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-54324
 Name   = Need for Speed - Carbon
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-54331
 Name   = Street Dance
-Region = PAL-Unk
+Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-54332
 Name   = Dance Fest
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54333
 Name   = Sega MegaDrive Collection
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54336
 Name   = Lumines Plus
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54339
@@ -15766,7 +15770,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54340
 Name   = Samurai Warriors 2
-Region = PAL-Unk
+Region = PAL-E
 // reads Samurai Warriors and Samurai Warriors Xtreme Legends saves for unlockables
 MemCardFilter = SLES-54340/SLES-52551/SLES-52552/SLES-52553/SLES-52554/SLES-52555/SLES-53002/SLES-53003/SLES-53004
 ---------------------------------------------
@@ -15776,15 +15780,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54342
 Name   = Bratz - Forever Diamondz
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-54343
 Name   = Bratz - Forever Diamondz
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54344
 Name   = Bratz - Forever Diamondz
-Region = PAL-Unk
+Region = PAL-M3	// Eng, DA & SE
 ---------------------------------------------
 Serial = SLES-54346
 Name   = Heatseeker
@@ -15792,7 +15796,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54347
 Name   = Sims 2, The - Pets
-Region = PAL-Unk
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54350
@@ -15806,7 +15810,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54355
 Name   = Final Fantasy XII
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54356
 Name   = Final Fantasy XII
@@ -15823,23 +15827,23 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54359
 Name   = Legend of Spyro, The - A New Beginning
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54360
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54361
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54362
 Name   = Pro Evolution Soccer 6
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-54364
 Name   = Curious George
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54365
 Name   = AMF Xtreme bowling 2006
@@ -15847,23 +15851,23 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54366
 Name   = David Douillet Judo
-Region = PAL-Unk
+Region = PAL-DU-F
 ---------------------------------------------
 Serial = SLES-54368
 Name   = RTL Ski Jumping 2007
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-54370
 Name   = Alpine Ski Racing
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-54374
 Name   = RTL Wintergames 2007
-Region = PAL-Unk
+Region = PAL-E-G
 ---------------------------------------------
 Serial = SLES-54376
 Name   = Barnyard
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54379
 Name   = NFL Street 3
@@ -15875,45 +15879,45 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54381
 Name   = Dr. Dolittle
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54382
 Name   = Jumanji
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54383
 Name   = Casper and The Ghostly Trio
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54384
 Name   = Destroy All Humans 2 - Make War not Love
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54385
 Name   = Atelier Iris 2: The Azoth of Destiny
-Region = PAL-Unk
+Region = PAL-E	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-54388
 Name   = Kim Possible - What's the Switch
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54389
 Name   = Tony Hawk's Project 8
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54393
 Name   = Pippa Funnell - Take the Reins
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54394
 Name   = Family Guy - The Video Game
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54395
 Name   = NeoGeo Battle Coliseum
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54396
 Name   = Cricket 07
@@ -15922,11 +15926,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54400
 Name   = SpongeBob Squarepants - Creature from the Krusty Krab
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54402
 Name   = Need for Speed - Carbon [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54418
 Name   = Powerdrome
@@ -15934,11 +15938,11 @@ Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54420
 Name   = Arthus & The Minimoys
-Region = PAL-Unk
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54421
 Name   = Happy Feet
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54423
@@ -15947,27 +15951,27 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54424
 Name   = Dr. Dolittle
-Region = PAL-Unk
+Region = PAL-M7	// P, PL & Nordic
 ---------------------------------------------
 Serial = SLES-54426
 Name   = Casper and The Ghostly Trio
-Region = PAL-Unk
+Region = PAL-M7	// P, PL & Nordic
 ---------------------------------------------
 Serial = SLES-54427
 Name   = Jumanji
-Region = PAL-Unk
+Region = PAL-M6	// Eng, P & Nordic
 ---------------------------------------------
 Serial = SLES-54430
 Name   = Teen Titans
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-54431
 Name   = Teen Titans
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54432
 Name   = Mercury Meltdown Remix
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54437
@@ -15976,7 +15980,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54439
 Name   = Okami
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54440
 Name   = GT-R Touring
@@ -15984,49 +15988,50 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54441
 Name   = Hawk Kawasaki Racing
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54442
 Name   = Guitar Hero II
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54444
 Name   = Made Man
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54448
 Name   = World Series of Poker - Tournament of Champions
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54449
 Name   = Chicken Little - Ace in Action
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54450
 Name   = Chicken Little - Aventures Intergalactiques
-Region = PAL-Unk
+Region = PAL-F
 ---------------------------------------------
 Serial = SLES-54451
 Name   = Himmel und Huhn - Ace in Action
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54452
 Name   = Chicken Little - 'As' en Accion
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-54453
 Name   = Chicken Little - Ace in Action
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54454
 Name   = Disgaea 2: Cursed Memories
-Region = PAL-Unk
+Region = PAL-E
+// Voices can be switched between Japanese and English via Options menu.
 ---------------------------------------------
 Serial = SLES-54456
 Name   = Beverly Hills Cop
-Region = PAL-E
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54459
@@ -16054,25 +16059,25 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54465
 Name   = CSI 3 - Dimensions of Murder
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54466
 Name   = Test Drive Unlimited
-Region = PAL-E
+Region = PAL-M4
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-54467
 Name   = Final Armada
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54468
 Name   = Crazy Chicken X
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54469
 Name   = Home Alone
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-54471
 Name   = Captain Scarlet
@@ -16080,11 +16085,11 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54473
 Name   = Flintstones, The - Bedrock Racing
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-54474
 Name   = Curious George
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54476
 Name   = Buccaneer
@@ -16109,25 +16114,25 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54488
 Name   = WWE SmackDown! vs. RAW 2007
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-54489
 Name   = WWE SmackDown! vs. RAW 2007
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54490
 Name   = God Hand
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54492
 Name   = Need for Speed - Carbon [Collector's Edition]
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54493
 Name   = Need for Speed - Carbon [Collector's Edition]
-Region = PAL-G
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-54494
 Name   = Little Britain - The Video Game
@@ -16139,19 +16144,19 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54511
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54512
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-54513
 Name   = UEFA Champions League
-Region = PAL-Unk
+Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-54518
 Name   = Clumsy Shumsy
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54521
 Name   = Nickelodeon SpongeBob and Friends - Battle for Volcano Island
@@ -16159,20 +16164,20 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54527
 Name   = Flushed Away
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54541
 Name   = Xena - Warrior Princess
-Region = PAL-Unk
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54542
 Name   = Xena - Warrior Princess
-Region = PAL-Unk
+Region = PAL-M6	// Eng, P & Nordic
 ---------------------------------------------
 Serial = SLES-54544
 Name   = Gun Club
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54545
 Name   = Maxxed Out Racing Nitro
@@ -16180,28 +16185,28 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54546
 Name   = Horsez
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54548
 Name   = Cocoto Fishing Master
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54549
 Name   = Crazy Frog Racer 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54551
 Name   = Premier Manager 2006-2007
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54553
 Name   = Shrek - Smash 'n Crash Racing
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54554
 Name   = Star Trek - Encounters
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54555
 Name   = Shin Megami Tensei: Digital Devil Saga 2
@@ -16220,7 +16225,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54566
 Name   = Barbie in The 12 Dancing Princesses
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54569
 Name   = Zombie Hunters 2
@@ -16245,11 +16250,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54584
 Name   = Pac-Man Rally
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54586
 Name   = Ar tonelico: Melody of Elemia
-Region = PAL-Unk
+Region = PAL-E	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-54588
 Name   = Brunswick Pro Bowling
@@ -16261,7 +16266,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54590
 Name   = Hard Knock High
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54604
@@ -16270,11 +16275,11 @@ Region = PAL-S
 ---------------------------------------------
 Serial = SLES-54606
 Name   = Harley-Davidson - Race to the Rally
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54608
 Name   = Barbie in The 12 Dancing Princesses
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54611
 Name   = TT Superbikes - Real Road Racing Championship
@@ -16282,7 +16287,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54615
 Name   = Code of the Samurai
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54617
@@ -16308,7 +16313,7 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-54627
 Name   = Burnout Dominator
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54629
@@ -16317,7 +16322,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54631
 Name   = Harley-Davidson - Race to the Rally
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-54633
 Name   = Premier Manager 08
@@ -16333,7 +16338,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54639
 Name   = AFL Premiership 2007
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-54641
 Name   = International Cricket Captain III
@@ -16382,7 +16387,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54666
 Name   = Mr. Bean
-Region = PAL-E
+Region = PAL-M11
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54670
@@ -16391,7 +16396,7 @@ Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-54674
 Name   = Lara Croft Tomb Raider - Anniversary
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M10
 Compat = 5
 [patches]
 	comment=- This gamedisc supports multiple languages.
@@ -16427,7 +16432,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54695
 Name   = Azur & Asmar
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54705
@@ -16445,7 +16450,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54719
 Name   = Charlotte's Web
-Region = PAL-11
+Region = PAL-M11
 ---------------------------------------------
 Serial = SLES-54723
 Name   = Spiderman 3
@@ -16471,7 +16476,7 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54747
 Name   = Disney-Pixar Ratatouille
-Region = PAL-M2
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-54755
 Name   = Transformers - The Game
@@ -16480,7 +16485,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54756
 Name   = Transformers - The Game
-Region = PAL-M2
+Region = PAL-F-S
 ---------------------------------------------
 Serial = SLES-54770
 Name   = DreamWorks Shrek the Third
@@ -16492,7 +16497,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54776
 Name   = Fantastic Four - Rise of the Silver Surfer
-Region = PAL-I
+Region = PAL-E-I
 ---------------------------------------------
 Serial = SLES-54779
 Name   = Harry Potter and the Order of the Phoenix
@@ -16500,7 +16505,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54782
 Name   = Obscure 2
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54784
@@ -16552,13 +16557,13 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54820
 Name   = Stuntman Ignition
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 VIFFIFOHack = 1
 ---------------------------------------------
 Serial = SLES-54822
 Name   = Atelier Iris 3: Grand Phantasm
-Region = PAL-Unk
+Region = PAL-E	// Voices: English & Japanese
 ---------------------------------------------
 Serial = SLES-54825
 Name   = Bob the Builder
@@ -16566,7 +16571,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54834
 Name   = Juiced 2
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54836
@@ -16616,7 +16621,7 @@ Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-54873
 Name   = FIFA 2008
-Region = PAL-E-N-Sw
+Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-54875
 Name   = Warriors Orochi
@@ -16661,7 +16666,7 @@ Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-54897
 Name   = GrimGrimoire
-Region = PAL-E
+Region = PAL-E-JP
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54898
@@ -16687,7 +16692,7 @@ Region = PAL-I-S
 ---------------------------------------------
 Serial = SLES-54913
 Name   = Pro Evolution Soccer 2008
-Region = PAL-E
+Region = PAL-E-S
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54914
@@ -16720,11 +16725,11 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-54942
 Name   = Disney Princess - Enchanted Journey
-Region = PAL-D-F-I
+Region = PAL-F-G-I
 ---------------------------------------------
 Serial = SLES-54945
 Name   = Dragonball Z Budokai Tenkaichi 3
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54946
@@ -16742,7 +16747,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54953
 Name   = Totally Spies! Totally Party
-Region = PAL-Unk
+Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-54955
 Name   = Finkles World
@@ -16762,7 +16767,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-54963
 Name   = Tony Hawks - Proving Ground
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54964
@@ -16776,11 +16781,11 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-54981
 Name   = Bob the Builder - Festival of Fun
-Region = PAL-I-F-G
+Region = PAL-F-G-I
 ---------------------------------------------
 Serial = SLES-54986
 Name   = Bratz - The Movie
-Region = PAL-E-I
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-54988
 Name   = Bratz - The Movie
@@ -16804,7 +16809,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-54997
 Name   = Mercenaries 2 - World in Flames
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 EETimingHack = 1	//flickery textures
 ---------------------------------------------
@@ -16836,7 +16841,7 @@ Region = PAL-M8
 ---------------------------------------------
 Serial = SLES-55007
 Name   = Boogie
-Region = PAL-E
+Region = PAL-M7
 Compat = 4
 ---------------------------------------------
 Serial = SLES-55013
@@ -16966,7 +16971,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55150
 Name   = TNA Impact
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 EETimingHack = 1
 ---------------------------------------------
@@ -16984,7 +16989,7 @@ Region = PAL-R
 ---------------------------------------------
 Serial = SLES-55187
 Name   = Disney-Pixar WALL-E
-Region = PAL-D-F
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-55191
 Name   = Guitar Hero - Aerosmith
@@ -16996,7 +17001,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55198
 Name   = Iron Man
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55204
@@ -17073,7 +17078,7 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55249
 Name   = Harry Potter and the Half-Blood Prince
-Region = PAL-Unk
+Region = PAL-M10
 ---------------------------------------------
 Serial = SLES-55251
 Name   = WWE SmackDown vs. Raw 2009
@@ -17090,7 +17095,7 @@ Region = PAL-M7
 ---------------------------------------------
 Serial = SLES-55266
 Name   = MotoGP 08
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55274
@@ -17111,7 +17116,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-55329
 Name   = Shrek's Carnival Craze
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-55331
 Name   = Cabela's Dangerous Adventures
@@ -17131,17 +17136,17 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55345
 Name   = James Bond: Quantum of Solace
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55347
 Name   = Dragonball Z Infinite World
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55349
 Name   = Need For Speed - Undercover
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-55350
 Name   = Need for Speed - Undercover
@@ -17149,7 +17154,7 @@ Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-55352
 Name   = Need For Speed - Undercover
-Region = PAL-Unk
+Region = PAL-R
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55354
@@ -17180,12 +17185,12 @@ Region = PAL-M6
 ---------------------------------------------
 Serial = SLES-55372
 Name   = Spiderman: Web of Shadows
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55373
 Name   = The King of Fighters Collection: The Orochi Saga
-Region = PAL-Unk
+Region = PAL-E
 ---------------------------------------------
 Serial = SLES-55374
 Name   = DreamWorks Madagascar 2 - Escape 2 Africa
@@ -17220,7 +17225,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-55395
 Name   = Disney TH!NK Fast
-Region = PAL-D-F-G
+Region = PAL-M3	// DU, FR & GE
 ---------------------------------------------
 Serial = SLES-55398
 Name   = Disney High School Musical 3 - Senior Year Dance!
@@ -17232,7 +17237,7 @@ Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-55406
 Name   = Pro Evolution Soccer 2009
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55409
 Name   = TT SuperBikes - Legends
@@ -17240,11 +17245,11 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55430
 Name   = Disney Bolt
-Region = PAL-D-F-G
+Region = PAL-M3	// DU, FR & GE
 ---------------------------------------------
 Serial = SLES-55431
 Name   = Disney Vol't
-Region = PAL-Unk
+Region = PAL-R
 ---------------------------------------------
 Serial = SLES-55440
 Name   = Ben 10: Alien Force
@@ -17253,7 +17258,7 @@ compat = 5
 ---------------------------------------------
 Serial = SLES-55442
 Name   = Tomb Raider Underworld
-Region = PAL-Unk	// Multiple languages
+Region = PAL-M8
 Compat = 5
 [patches]
 	comment=- This gamedisc supports multiple languages.
@@ -17269,7 +17274,7 @@ DMABusyHack = 1
 ---------------------------------------------
 Serial = SLES-55444
 Name   = Ar tonelico II: Melody of Metafalica
-Region = PAL-Unk
+Region = PAL-E	// Voices: English & Japanese
 Compat = 5
 eeRoundMode = 0 // Fixes "Fall through floor" bug when aproaching chests
 ---------------------------------------------
@@ -17279,15 +17284,15 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55453
 Name   = Singstar Queen
-Region = PAL-E
+Region = PAL-Unk
 ---------------------------------------------
 Serial = SLES-55457
 Name   = AC/DC LIVE: Rock Band Track Pack
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55459
 Name   = Jelly Belly: Ballistic Beans
-Region = PAL-Unk
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55467
 Name   = Trivial Pursuit
@@ -17295,7 +17300,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55470
 Name   = Coraline
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55472
@@ -17329,7 +17334,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55494
 Name   = X-Men Origins - Wolverine
-Region = PAL-Unk
+Region = PAL-E-F
 FpuCompareHack = 1		//flickering objects, sound loop
 ---------------------------------------------
 Serial = SLES-55495
@@ -17347,7 +17352,7 @@ Region = PAL-G-I
 ---------------------------------------------
 Serial = SLES-55509
 Name   = Music Maker - Rockstar
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55511
@@ -17392,7 +17397,7 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55571
 Name   = Ghostbusters
-Region = PAL-E
+Region = PAL-M6
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55572
@@ -17402,7 +17407,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55573
 Name   = MotorStorm Arctic Edge
-Region = PAL-Unk
+Region = PAL-M14
 OPHFLagHack = 1
 ---------------------------------------------
 Serial = SLES-55574
@@ -17423,7 +17428,7 @@ Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-55583
 Name   = FIFA 10
-Region = PAL-Unk
+Region = PAL-M4	// Eng & Scandinavia
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55584
@@ -17471,7 +17476,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55636
 Name   = Pro Evolution Soccer 2011
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55637
@@ -17484,7 +17489,7 @@ Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55642
 Name   = FIFA 11
-Region = PAL-Unk
+Region = PAL-M4
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55644
@@ -17498,17 +17503,17 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-55653
 Name   = FIFA 12
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55664
 Name   = FIFA 13
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-55665
 Name   = FIFA 13
-Region = PAL-Unk
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55671
 Name   = FIFA 14
@@ -17516,23 +17521,23 @@ Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55672
 Name   = FIFA 14
-Region = PAL
+Region = PAL-M4
 ---------------------------------------------
 Serial = SLES-55673
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55674
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-F-G
 ---------------------------------------------
 Serial = SLES-55675
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-G-I
 ---------------------------------------------
 Serial = SLES-55676
 Name   = Pro Evolution Soccer 2014
-Region = PAL
+Region = PAL-P-S
 ---------------------------------------------
 Serial = SLES-82001
 Name   = Summoner
@@ -17540,7 +17545,7 @@ Region = PAL-E
 ---------------------------------------------
 Serial = SLES-82005
 Name   = Summoner
-Region = PAL-Unk
+Region = PAL-G
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82009
@@ -17550,17 +17555,17 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-82010
 Name   = Metal Gear Solid 2, Document of
-Region = PAL-Unk
+Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82011
 Name   = Devil May Cry 2 [Dante Disc]
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 ---------------------------------------------
 Serial = SLES-82012
 Name   = Devil May Cry 2 [Lucia Disc]
-Region = PAL-E
+Region = PAL-M5
 Compat = 5
 MemCardFilter = SLES-82011
 ---------------------------------------------
@@ -17593,7 +17598,7 @@ Region = PAL-I
 ---------------------------------------------
 Serial = SLES-82026
 Name   = Metal Gear Solid 3 - Snake Eater
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-82028
 Name   = Star Ocean 3 - Till the End of Time [Disc1of2]
@@ -17610,11 +17615,11 @@ MemCardFilter = SLES-82028
 ---------------------------------------------
 Serial = SLES-82030
 Name   = Shadow Hearts - Covenant [Disc1of2]
-Region = PAL-Unk
+Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-82031
 Name   = Shadow Hearts - Covenant [Disc2of2]
-Region = PAL-Unk
+Region = PAL-M3
 MemCardFilter = SLES-82030
 ---------------------------------------------
 Serial = SLES-82032
@@ -17623,12 +17628,12 @@ Region = PAL-G
 ---------------------------------------------
 Serial = SLES-82034
 Name   = Xenosaga Episode II [Disc1of2]
-Region = PAL-E
+Region = PAL-M3
 MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SLES-82035
 Name   = Xenosaga Episode II [Disc2of2]
-Region = PAL-E
+Region = PAL-M3
 MemCardFilter = SLES-82034/SCES-82034
 ---------------------------------------------
 Serial = SLES-82036
@@ -17643,7 +17648,7 @@ MemCardFilter = SLES-82036/SLES-82037
 ---------------------------------------------
 Serial = SLES-82038
 Name   = Onimusha - Dawn of Dreams [Disc1]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 [patches = 812C5A96]
 	comment= patch by Shadow Lady
@@ -17652,7 +17657,7 @@ Compat = 5
 ---------------------------------------------
 Serial = SLES-82039
 Name   = Onimusha - Dawn of Dreams [Disc2]
-Region = PAL-Unk
+Region = PAL-M5
 Compat = 5
 MemCardFilter = SLES-82038
 [patches = 812C5A96]
@@ -17662,58 +17667,58 @@ MemCardFilter = SLES-82038
 ---------------------------------------------
 Serial = SLES-82042
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
-Region = PAL-Unk
+Region = PAL-E-F
 ---------------------------------------------
 Serial = SLES-82043
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
-Region = PAL-Unk
+Region = PAL-E-F
 MemCardFilter = SLES-82042
 ---------------------------------------------
 Serial = SLES-82044
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
-Region = PAL-Unk
+Region = PAL-I
 ---------------------------------------------
 Serial = SLES-82045
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
-Region = PAL-Unk
+Region = PAL-I
 MemCardFilter = SLES-82044
 ---------------------------------------------
 Serial = SLES-82046
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
-Region = PAL-Unk
+Region = PAL-G
 ---------------------------------------------
 Serial = SLES-82047
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
-Region = PAL-Unk
+Region = PAL-G
 MemCardFilter = SLES-82046
 ---------------------------------------------
 Serial = SLES-82048
 Name   = Metal Gear Solid 3 - Subsistence [Disc1of3]
-Region = PAL-Unk
+Region = PAL-S
 ---------------------------------------------
 Serial = SLES-82049
 Name   = Metal Gear Solid 3 - Subsistence [Disc2of3]
-Region = PAL-Unk
+Region = PAL-S
 MemCardFilter = SLES-82048
 ---------------------------------------------
 Serial = SLES-82050
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
-Region = PAL-Unk
+Region = PAL-E-F
 MemCardFilter = SLES-82042
 ---------------------------------------------
 Serial = SLES-82051
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
-Region = PAL-Unk
+Region = PAL-I
 MemCardFilter = SLES-82044
 ---------------------------------------------
 Serial = SLES-82052
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
-Region = PAL-Unk
+Region = PAL-G
 MemCardFilter = SLES-82046
 ---------------------------------------------
 Serial = SLES-82053
 Name   = Metal Gear Solid 3 - Subsistence [Disc3of3]
-Region = PAL-Unk
+Region = PAL-S
 MemCardFilter = SLES-82048
 ---------------------------------------------
 Serial = SLKA-15003


### PR DESCRIPTION
What this PR primarily does is to sort out the PAL-E mess.
Some have used PAL-E for Englsh, others for Europa (PAL-M5), and others still for España.
With this PR all PAL-E should refer to English, while the ones referring to Europa have PAL-M5 or something as a code, and the ones referring to España have PAL-S as a code.

Generally only one letter is used for the more common languages; English etc.
So is the case in this PR.

For some PAL-M2 entries in particular, though maybe also for some PAL-M3 entries, there can be 2 or more discs of the same game having this code; it's not necessarily a disc specific code - it only tells how many languages the disc supports.
So is the case in this PR.

Language codes used:
E - English
G - German
I - Italian
S - Spanish
F - French
P - Portuguese
R - Russian
DU - Dutch
NO - Norwegian
SE - Swedish
DA - Danish
FI - Finnish
CZ - Czech
PL - Polish
HR - Croatian
HI - Hindu