### PR TITLE
MicroVU: Fix a logically dead code for XGKick Instruction

### DIFF
--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -54,7 +54,7 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 		}
 		//Run any pending XGKick, providing we've got to it.
 		if (mVUinfo.doXGKICK && xPC >= mVUinfo.XGKICKPC) {
-			mVU_XGKICK_DELAY(mVU, true);
+			mVU_XGKICK_DELAY(mVU);
 		}
 		if (doEarlyExit(mVU)) {
 			if (!isVU1) xCALL(mVU0clearlpStateJIT);
@@ -113,7 +113,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 			mVUdivSet(mVU);
 		}
 		if (mVUinfo.doXGKICK) {
-			mVU_XGKICK_DELAY(mVU, true);
+			mVU_XGKICK_DELAY(mVU);
 		}
 		if (doEarlyExit(mVU)) {
 			if (!isVU1)

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -499,7 +499,7 @@ void* mVUcompileSingleInstruction(microVU& mVU, u32 startPC, uptr pState, microF
 
 	mVUincCycles(mVU, 1); //Just incase the is XGKick
 	if (mVUinfo.doXGKICK) {
-		mVU_XGKICK_DELAY(mVU, true);
+		mVU_XGKICK_DELAY(mVU);
 	}
 
 	return thisPtr;
@@ -624,7 +624,7 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState) {
 		}
 
 		if (mVUinfo.doXGKICK) {
-			mVU_XGKICK_DELAY(mVU, true);
+			mVU_XGKICK_DELAY(mVU);
 		}
 
 		if (isEvilBlock) {

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -1212,15 +1212,14 @@ void __fastcall mVU_XGKICK_(u32 addr) {
 	}
 }
 
-static __fi void mVU_XGKICK_DELAY(mV, bool memVI) {
+static __fi void mVU_XGKICK_DELAY(mV) {
 	mVUbackupRegs(mVU);
 #if 0 // XGkick Break - ToDo: Change "SomeGifPathValue" to w/e needs to be tested
 	xTEST (ptr32[&SomeGifPathValue], 1); // If '1', breaks execution
 	xMOV  (ptr32[&mVU.resumePtrXG], (uptr)xGetPtr() + 10 + 6);
 	xJcc32(Jcc_NotZero, (uptr)mVU.exitFunctXG - ((uptr)xGetPtr()+6));
 #endif
-	if (memVI)	xMOV(gprT2, ptr32[&mVU.VIxgkick]);
-	else		mVUallocVIa(mVU, gprT2, _Is_);
+	xMOV(gprT2, ptr32[&mVU.VIxgkick]);
 	xCALL(mVU_XGKICK_);
 	mVUrestoreRegs(mVU);
 }
@@ -1228,12 +1227,8 @@ static __fi void mVU_XGKICK_DELAY(mV, bool memVI) {
 mVUop(mVU_XGKICK) {
 	pass1 { mVUanalyzeXGkick(mVU, _Is_, mVU_XGKICK_CYCLES); }
 	pass2 {
-		if (!mVU_XGKICK_CYCLES) {
-			mVU_XGKICK_DELAY(mVU, false);
-			return;
-		}
-		else if (mVUinfo.doXGKICK) {
-			mVU_XGKICK_DELAY(mVU, true);
+		if (mVUinfo.doXGKICK) { // check for XGkick Transfer
+			mVU_XGKICK_DELAY(mVU);
 			mVUinfo.doXGKICK = false;
 		}
 


### PR DESCRIPTION
mVU_XGKICK_CYCLES can only take delay cycle values 1 and 6, it can't take NULL value. the conditional check was probably intended to check for the default cycle delay (which is 1 in our case). 

Requesting @sudonim1 and @refractionpcsx2 to review this, 