### PR TITLE
FolderMemoryCard: Properly handle empty files.

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -413,11 +413,6 @@ bool FolderMemoryCard::AddFile( MemoryCardFileEntry* const dirEntry, const wxStr
 		// make sure we have enough space on the memcard to hold the data
 		const u32 clusterSize = m_superBlock.data.pages_per_cluster * m_superBlock.data.page_len;
 		const u32 filesize = file.Length();
-		if (!filesize) {
-			Console.Error(L"(MCDF) Empty file. Aborting.");
-			file.Close();
-			return false;
-		}
 		const u32 countClusters = ( filesize % clusterSize ) != 0 ? ( filesize / clusterSize + 1 ) : ( filesize / clusterSize );
 		const u32 newNeededClusters = ( dirEntry->entry.data.length % 2 ) == 0 ? countClusters + 1 : countClusters;
 		if ( newNeededClusters > GetAmountFreeDataClusters() ) {
@@ -450,17 +445,21 @@ bool FolderMemoryCard::AddFile( MemoryCardFileEntry* const dirEntry, const wxStr
 		}
 
 		newFileEntry->entry.data.length = filesize;
-		u32 fileDataStartingCluster = GetFreeDataCluster();
-		newFileEntry->entry.data.cluster = fileDataStartingCluster;
+		if ( filesize != 0 ) {
+			u32 fileDataStartingCluster = GetFreeDataCluster();
+			newFileEntry->entry.data.cluster = fileDataStartingCluster;
 
-		// mark the appropriate amount of clusters as used
-		u32 dataCluster = fileDataStartingCluster;
-		m_fat.data[0][0][dataCluster] = LastDataCluster | DataClusterInUseMask;
-		for ( unsigned int i = 0; i < countClusters - 1; ++i ) {
-			u32 newCluster = GetFreeDataCluster();
-			m_fat.data[0][0][dataCluster] = newCluster | DataClusterInUseMask;
-			m_fat.data[0][0][newCluster] = LastDataCluster | DataClusterInUseMask;
-			dataCluster = newCluster;
+			// mark the appropriate amount of clusters as used
+			u32 dataCluster = fileDataStartingCluster;
+			m_fat.data[0][0][dataCluster] = LastDataCluster | DataClusterInUseMask;
+			for ( unsigned int i = 0; i < countClusters - 1; ++i ) {
+				u32 newCluster = GetFreeDataCluster();
+				m_fat.data[0][0][dataCluster] = newCluster | DataClusterInUseMask;
+				m_fat.data[0][0][newCluster] = LastDataCluster | DataClusterInUseMask;
+				dataCluster = newCluster;
+			}
+		} else {
+			newFileEntry->entry.data.cluster = MemoryCardFileEntry::EmptyFileCluster;
 		}
 
 		file.Close();

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -158,6 +158,9 @@ struct MemoryCardFileEntry {
 
 	static const u32 DefaultDirMode = Mode_Read | Mode_Write | Mode_Execute | Mode_Directory | Mode_Unknown0x0400 | Mode_Used;
 	static const u32 DefaultFileMode = Mode_Read | Mode_Write | Mode_Execute | Mode_File | Mode_Unknown0x0080 | Mode_Unknown0x0400 | Mode_Used;
+
+	// used in the cluster entry of empty files on real memory cards, as far as we know
+	static const u32 EmptyFileCluster = 0xFFFFFFFFu;
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
See #838. This properly handles files with a filesize of zero bytes on both read and write.