### PR TITLE
GameIndex > Added fix for the "The Incredibles" (SLUS-20905) by Prafull.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -12467,6 +12467,7 @@ Compat = 5
 comment= Patch By Prafull
 // fix hang at loading screen
 patch=1,EE,0010ec20,word,00000000
+	comment=- This disc has the same CRC as SLUS-20905, the NTSC-U disc.
 [/patches]
 ---------------------------------------------
 Serial = SLES-52813
@@ -37648,6 +37649,12 @@ Serial = SLUS-20905
 Name   = Incredibles, The
 Region = NTSC-U
 Compat = 5
+[patches = EBDB6E4B]
+comment= Patch By Prafull
+// fix hang at loading screen
+patch=1,EE,0010ec20,word,00000000
+	comment=- This disc has the same CRC as SLES-52812, the PAL-E disc.
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20906
 Name   = Fight Night 2004


### PR DESCRIPTION
According to Prafull, the PAL-E (SLES-52812) & the NTSC-U (SLUS-20905) discs of "The Incredibles" has the same CRC, and consequently it's resonable to assume that the PAL-E fix also should work for the NTSC-U disc.
This is something that has been recognized by Bositman in his Compatibility List, but (for some reason) haven't been applied in GameIndex.

http://forums.pcsx2.net/Thread-Fixing-unplayable-games?highlight=Incredibles
http://forums.pcsx2.net/Thread-Incredibles-The-SLUS-20905-U
