### PR TITLE
Coverity: some clean up stuffs and control flow issues.

### DIFF
--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -401,11 +401,7 @@ s32 CALLBACK ISOreadSector(u8* tempbuffer, u32 lsn, int mode)
 
 	switch (mode)
 	{
-		case CDVD_MODE_2352:
-			// Unreachable due to shortcut above.
-			pxAssume(false);
-			break;
-
+	// CDVD_MODE_2352 is handled before the switch statement
 		case CDVD_MODE_2340:
 			pbuffer += 12;
 			psize = 2340;

--- a/plugins/GSdx/GSSettingsDlg.h
+++ b/plugins/GSdx/GSSettingsDlg.h
@@ -46,7 +46,6 @@ class GSHacksDlg : public GSDialog
 	unsigned short msaa2cb[17];
 	std::string adapter_id;
 	
-	bool isdx9;
 
 	void UpdateControls();
 


### PR DESCRIPTION
CDVD commit: (https://scan3.coverity.com/reports.htm#v10075/p11624/g10075g/fileInstanceId=6857270&defectInstanceId=1703193&mergedDefectId=146818)

* Value of CDVD_MODE_2352 is 0, the code won't enter the switch case statement. either way, this scenario still won't happen because of the early return above in case of CDVD_2352. just remove the the unreachable code to satisfy coverity and clean up the code.

GSDX commit: (I spotted this one, not sure whether it is in coverity (it might be ?) )

* This bool variable isn't used anywhere on the code , @rama added this on :30e538a

The intent was probably to verify the current render which is already being done without this variable for the hacks dialog. (see line 555 of GSSettingsdlg.cpp )