### PR TITLE
cmake: Add external shader, PCSX2_key.ini.default in package mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ if(PACKAGE_MODE)
         INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/cheats_ws.zip" DESTINATION "${GAMEINDEX_DIR}")
     endif()
     INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/GameIndex.dbf" DESTINATION "${GAMEINDEX_DIR}")
+    INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/PCSX2_keys.ini.default" DESTINATION "${GAMEINDEX_DIR}")
+    INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/shaders/GSdx.fx" DESTINATION "${GAMEINDEX_DIR}/shaders")
+    INSTALL(FILES     "${CMAKE_SOURCE_DIR}/bin/shaders/GSdx_FX_Settings.ini" DESTINATION "${GAMEINDEX_DIR}/shaders")
 
     # set categories depending on system/distribution in pcsx2.desktop
     if(openSUSE)


### PR DESCRIPTION
A few files seem to be missing when package mode is used - the external shader files and PCSX2_keys.ini.default. This adds the files.

I PR'd this to check the locations are ok. The files will be added to the same place as GameIndex.dbf, with the shaders going in a subfolder.

The sample cheat is missing as well, but I don't know what to do with that.