### PR TITLE
Fix memorycard dialog close event behavior

### DIFF
--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -156,7 +156,7 @@ namespace Dialogs
 
 	protected:
 		Panels::BaseMcdListPanel*	m_panel_mcdlist;
-		bool m_needs_suspending;
+		bool m_needs_resume;
 
 	public:
 		virtual ~McdConfigDialog() throw() {}

--- a/pcsx2/gui/Dialogs/McdConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/McdConfigDialog.cpp
@@ -101,7 +101,7 @@ Dialogs::McdConfigDialog::McdConfigDialog( wxWindow* parent )
 	: BaseConfigurationDialog( parent, _("MemoryCard Manager"), 600 )
 {
 	m_panel_mcdlist	= new MemoryCardListPanel_Simple( this );
-	m_needs_suspending = false;
+	m_needs_resume = false;
 
 	wxFlexGridSizer* s_flex=new wxFlexGridSizer(3,1, 0, 0);
 	s_flex->AddGrowableCol(0);
@@ -155,14 +155,14 @@ void Dialogs::McdConfigDialog::OnMultitapClicked( wxCommandEvent& evt )
 bool Dialogs::McdConfigDialog::Show( bool show )
 {
 	// Suspend the emulation before any file operations on the memory cards can be done.
-	if( show && CoreThread.IsRunning() )
+	if( show && SysHasValidState() )
 	{
-		m_needs_suspending = true;
+		m_needs_resume = true;
 		CoreThread.Suspend();
 	}
-	else if( !show && m_needs_suspending == true )
+	else if( !show && SysHasValidState() && m_needs_resume )
 	{
-		m_needs_suspending = false;
+		m_needs_resume = false;
 		CoreThread.Resume();
 	}
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -438,7 +438,7 @@ GSFrame::~GSFrame() throw()
 void GSFrame::OnCloseWindow(wxCloseEvent& evt)
 {
 	sApp.OnGsFrameClosed( GetId() );
-	Hide();		// and don't close it.
+	CoreThread.Reset(); // reset thread to avoid suspend status on close event.
 }
 
 bool GSFrame::ShowFullScreen(bool show, long style)


### PR DESCRIPTION
Fixes #868 

previous behavior: GS Frame opens after a previous close event of the GS Frame and a close event of the Memory card dialog. (this was due it's suspend status)

current PR behavior:  It just closes the memory card dialog (similar to the emulation settings and plugin settings)