### PR TITLE
Make memory card dialog modal, fix resume on memory card dialog close bug

### DIFF
--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
+#include "App.h"
 #include "MainFrame.h"
 #include "GSFrame.h"
 #include "GS.h"
@@ -58,36 +59,6 @@ DEFINE_EVENT_TYPE( pxEvt_LogicalVsync );
 DEFINE_EVENT_TYPE( pxEvt_ThreadTaskTimeout_SysExec );
 
 ScopedPtr<AppConfig>	g_Conf;
-
-template<typename DialogType>
-int AppOpenModalDialog( wxString panel_name, wxWindow* parent=NULL )
-{
-	if( wxWindow* window = wxFindWindowByName( L"Dialog:" + DialogType::GetNameStatic() ) )
-	{
-		window->SetFocus();
-		if( wxDialog* dialog = wxDynamicCast( window, wxDialog ) )
-		{
-			// Switch to the requested panel.
-			wxCommandEvent evt(pxEvt_SetSettingsPage);
-			evt.SetString(panel_name);
-			dialog->GetEventHandler()->ProcessEvent(evt);
-
-			// It's legal to call ShowModal on a non-modal dialog, therefore making
-			// it modal in nature for the needs of whatever other thread of action wants
-			// to block against it:
-			if( !dialog->IsModal() )
-			{
-				int result = dialog->ShowModal();
-				dialog->Destroy();
-				return result;
-			}
-		}
-		pxFailDev( "Can only show wxDialog class windows as modal!" );
-		return wxID_CANCEL;
-	}
-	else
-		return DialogType( parent ).ShowModal();
-}
 
 static bool HandlePluginError( BaseException& ex )
 {

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -30,7 +30,6 @@ namespace Panels
 }
 
 BEGIN_DECLARE_EVENT_TYPES()
-	DECLARE_EVENT_TYPE( pxEvt_SetSettingsPage, -1 )
 	DECLARE_EVENT_TYPE( pxEvt_SomethingChanged, -1 );
 END_DECLARE_EVENT_TYPES()
 

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -155,16 +155,12 @@ namespace Dialogs
 
 	protected:
 		Panels::BaseMcdListPanel*	m_panel_mcdlist;
-		bool m_needs_suspending;
 
 	public:
 		virtual ~McdConfigDialog() throw() {}
 		McdConfigDialog(wxWindow* parent=NULL);
 		static wxString GetNameStatic() { return L"McdConfig"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
-
-		virtual bool Show( bool show=true );
-		virtual int ShowModal();
 
 	protected:
 		virtual wxString& GetConfSettingsTabName() const { return g_Conf->McdSettingsTabName; }

--- a/pcsx2/gui/Dialogs/McdConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/McdConfigDialog.cpp
@@ -101,7 +101,6 @@ Dialogs::McdConfigDialog::McdConfigDialog( wxWindow* parent )
 	: BaseConfigurationDialog( parent, _("MemoryCard Manager"), 600 )
 {
 	m_panel_mcdlist	= new MemoryCardListPanel_Simple( this );
-	m_needs_suspending = false;
 
 	wxFlexGridSizer* s_flex=new wxFlexGridSizer(3,1, 0, 0);
 	s_flex->AddGrowableCol(0);
@@ -152,30 +151,3 @@ void Dialogs::McdConfigDialog::OnMultitapClicked( wxCommandEvent& evt )
 		m_panel_mcdlist->SetMultitapEnabled( (int)box->GetClientData(), box->IsChecked() );
 }
 */
-bool Dialogs::McdConfigDialog::Show( bool show )
-{
-	// Suspend the emulation before any file operations on the memory cards can be done.
-	if( show && CoreThread.IsRunning() )
-	{
-		m_needs_suspending = true;
-		CoreThread.Suspend();
-	}
-	else if( !show && m_needs_suspending == true )
-	{
-		m_needs_suspending = false;
-		CoreThread.Resume();
-	}
-
-	if( show && m_panel_mcdlist )
-		m_panel_mcdlist->OnShown();
-
-	return _parent::Show( show );
-}
-
-int Dialogs::McdConfigDialog::ShowModal()
-{
-	if( m_panel_mcdlist )
-		m_panel_mcdlist->OnShown();
-
-	return _parent::ShowModal();
-}

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 
+#include "App.h"
 #include "CDVD/CDVD.h"
 #include "GS.h"
 
@@ -37,7 +38,9 @@ void MainEmuFrame::Menu_SysSettings_Click(wxCommandEvent &event)
 
 void MainEmuFrame::Menu_McdSettings_Click(wxCommandEvent &event)
 {
-	AppOpenDialog<McdConfigDialog>( this );
+	ScopedCoreThreadClose closed_core;
+	closed_core.AllowResume();
+	AppOpenModalDialog<McdConfigDialog>(wxEmptyString, this);
 }
 
 void MainEmuFrame::Menu_GameDatabase_Click(wxCommandEvent &event)

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -618,9 +618,6 @@ void Panels::MemoryCardListPanel_Simple::Apply()
 {
 	_parent::Apply();
 
-	ScopedCoreThreadClose closed_core;
-	closed_core.AllowResume();
-
 	int used=0;
 	Console.WriteLn( L"Apply Memory cards:" );
 	for( uint slot=0; slot<8; ++slot )
@@ -736,8 +733,6 @@ void Panels::MemoryCardListPanel_Simple::UiCreateNewCard( McdSlotItem& card )
 		return;
 	}
 
-	ScopedCoreThreadClose closed_core;
-
 	Dialogs::CreateMemoryCardDialog dialog( this, m_FolderPicker->GetPath(), L"my memory card" );
 	wxWindowID result = dialog.ShowModal();
 
@@ -756,7 +751,6 @@ void Panels::MemoryCardListPanel_Simple::UiCreateNewCard( McdSlotItem& card )
 
 	Apply();
 	RefreshSelections();
-	closed_core.AllowResume();
 }
 
 void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card ) {
@@ -764,8 +758,6 @@ void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card ) {
 		Console.WriteLn( "Error: Aborted: Convert mcd invoked but but a file is not associated." );
 		return;
 	}
-
-	ScopedCoreThreadClose closed_core;
 
 	AppConfig::McdOptions config;
 	config.Filename = card.Filename.GetFullName();
@@ -778,8 +770,6 @@ void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card ) {
 		Apply();
 		RefreshSelections();
 	}
-
-	closed_core.AllowResume();
 }
 
 void Panels::MemoryCardListPanel_Simple::UiDeleteCard( McdSlotItem& card )
@@ -804,7 +794,6 @@ void Panels::MemoryCardListPanel_Simple::UiDeleteCard( McdSlotItem& card )
 
 	if( result )
 	{
-		ScopedCoreThreadClose closed_core;
 	
 		wxFileName fullpath( m_FolderPicker->GetPath() + card.Filename.GetFullName());
 
@@ -818,7 +807,6 @@ void Panels::MemoryCardListPanel_Simple::UiDeleteCard( McdSlotItem& card )
 		}
 
 		RefreshSelections();
-		closed_core.AllowResume();
 	}
 
 }
@@ -873,7 +861,6 @@ bool Panels::MemoryCardListPanel_Simple::UiDuplicateCard(McdSlotItem& src, McdSl
 		wxFileName destfile( basepath + dest.Filename);
 
 		ScopedBusyCursor doh( Cursor_ReallyBusy );
-		ScopedCoreThreadClose closed_core;
 
 		if( !(    ( srcfile.FileExists() && wxCopyFile( srcfile.GetFullPath(), destfile.GetFullPath(), true ) )
 			   || ( !srcfile.FileExists() && CopyDirectory( srcfile.GetFullPath(), destfile.GetFullPath() ) ) ) )
@@ -886,8 +873,7 @@ bool Panels::MemoryCardListPanel_Simple::UiDuplicateCard(McdSlotItem& src, McdSl
 			wxString content;
 
 			Msgbox::Alert( heading + L"\n\n" + content, _("Copy failed!") );
-			
-			closed_core.AllowResume();
+
 			return false;
 		}
 
@@ -903,7 +889,6 @@ bool Panels::MemoryCardListPanel_Simple::UiDuplicateCard(McdSlotItem& src, McdSl
 
 		Apply();
 		DoRefresh();
-		closed_core.AllowResume();
 		return true;
 }
 
@@ -940,8 +925,6 @@ void Panels::MemoryCardListPanel_Simple::UiRenameCard( McdSlotItem& card )
 		break;
 	}
 
-	ScopedCoreThreadClose closed_core;
-
 	bool origEnabled=card.IsEnabled;
 	card.IsEnabled=false;
 	Apply();
@@ -950,8 +933,7 @@ void Panels::MemoryCardListPanel_Simple::UiRenameCard( McdSlotItem& card )
 		card.IsEnabled=origEnabled;
 		Apply();
 		Msgbox::Alert( _("Error: Rename could not be completed.\n"), _("Rename memory card") );
-	
-		closed_core.AllowResume();
+
 		return;
 	}
 
@@ -960,7 +942,6 @@ void Panels::MemoryCardListPanel_Simple::UiRenameCard( McdSlotItem& card )
 	Apply();
 
 	RefreshSelections();
-	closed_core.AllowResume();
 }
 
 void Panels::MemoryCardListPanel_Simple::OnCreateOrDeleteCard(wxCommandEvent& evt)


### PR DESCRIPTION
Changes:
 * Memory card dialog is now modal - This prevents access to the rest of the GUI, which should make it impossible to resume emulation while the memory card dialog is opened, therefore preventing possible data loss/corruption.
 * Fixes #868 - Emulation does not resume anymore if it was already paused after the memory card dialog is closed.

Side note: Just an FYI, the solution for the resume bug without making the dialog modal was simply to use `!CoreThread.IsClosed()`.