### PR TITLE
pcsx2: forbid negative index of array in case of register allocation failure

### DIFF
--- a/pcsx2/x86/iCore.cpp
+++ b/pcsx2/x86/iCore.cpp
@@ -144,6 +144,9 @@ int _allocTempXMMreg(XMMSSEType type, int xmmreg) {
 	else
 		_freeXMMreg(xmmreg);
 
+	if (xmmreg == -1)
+		return -1;
+
 	xmmregs[xmmreg].inuse = 1;
 	xmmregs[xmmreg].type = XMMTYPE_TEMP;
 	xmmregs[xmmreg].needed = 1;
@@ -190,6 +193,9 @@ int _allocVFtoXMMreg(VURegs *VU, int xmmreg, int vfreg, int mode) {
 		xmmreg = _getFreeXMMreg();
 	else
 		_freeXMMreg(xmmreg);
+
+	if (xmmreg == -1)
+		return -1;
 
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;
@@ -273,6 +279,9 @@ int _allocACCtoXMMreg(VURegs *VU, int xmmreg, int mode) {
 	else
 		_freeXMMreg(xmmreg);
 
+	if (xmmreg == -1)
+		return -1;
+
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;
 	xmmregs[xmmreg].type = XMMTYPE_ACC;
@@ -314,6 +323,7 @@ int _allocFPtoXMMreg(int xmmreg, int fpreg, int mode) {
 	}
 
 	if (xmmreg == -1) xmmreg = _getFreeXMMreg();
+	if (xmmreg == -1) return -1;
 
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;
@@ -379,6 +389,7 @@ int _allocGPRtoXMMreg(int xmmreg, int gprreg, int mode)
 	}
 
 	if (xmmreg == -1) xmmreg = _getFreeXMMreg();
+	if (xmmreg == -1) return -1;
 
 	g_xmmtypes[xmmreg] = XMMT_INT;
 	xmmregs[xmmreg].inuse = 1;
@@ -455,9 +466,10 @@ int _allocFPACCtoXMMreg(int xmmreg, int mode)
 		return i;
 	}
 
-	if (xmmreg == -1) {
+	if (xmmreg == -1)
 		xmmreg = _getFreeXMMreg();
-	}
+	if (xmmreg == -1)
+		return -1;
 
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;

--- a/pcsx2/x86/iCore.cpp
+++ b/pcsx2/x86/iCore.cpp
@@ -133,7 +133,7 @@ int  _getFreeXMMreg()
 		_freeXMMreg(tempi);
 		return tempi;
 	}
-	Console.Error("*PCSX2*: XMM Reg Allocation Error in _getFreeXMMreg()!");
+	pxFailDev("*PCSX2*: XMM Reg Allocation Error in _getFreeXMMreg()!");
 
 	return -1;
 }

--- a/pcsx2/x86/ix86-32/iCore-32.cpp
+++ b/pcsx2/x86/ix86-32/iCore-32.cpp
@@ -311,6 +311,9 @@ int _allocX86reg(int x86reg, int type, int reg, int mode)
 	else
 		_freeX86reg(x86reg);
 
+	if (x86reg == -1)
+		return -1;
+
 	x86regs[x86reg].type = type;
 	x86regs[x86reg].reg = reg;
 	x86regs[x86reg].mode = mode;
@@ -584,6 +587,7 @@ int _allocMMXreg(int mmxreg, int reg, int mode)
 	}
 
 	if (mmxreg == -1) mmxreg = _getFreeMMXreg();
+	if (mmxreg == -1) return -1;
 
 	mmxregs[mmxreg].inuse = 1;
 	mmxregs[mmxreg].reg = reg;


### PR DESCRIPTION
CID 146870 (#1 of 1): Negative array index write (NEGATIVE_RETURNS)
5. negative_returns: Using variable xmmreg as an index to array ...

Open discussion: how to handle correctly bad register allocation?
    Currently negative index is returned and a message printed. It means
    we need to propagate the index check everywhere in order to not use it.

    I suspect that Instruction Generation is more or less corrupted so
    potentially we could just fire an exception.