### PR TITLE
gui: kb shortcuts: fix incorrect wx key codes for "plain" keys

### DIFF
--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -15,13 +15,13 @@
 # HOME    - FX shader
 # INSERT  - Software mipmapping
 
-# Note: some "normal" keys may not display correctly at the log console message
-# but still work correctly (e.g. ']').
-
 # -----------------------------------------------------------------------------
 # The KB shortcuts can be a normal key (e.g. f or ] etc) or a combination of
-# ALT/SHIFT/CTRL and a key, separated with a - (e.g. m or alt-m or alt-ctrl-m).
-# Number (key) pad names start with KP_ (e.g. KP_0 to KP_9, KP_ADD, etc)
+# ALT/SHIFT/CTRL and a key, separated with a - or + (e.g. m or alt+ctrl+m or
+# alt-F12). Number (key) pad names start with KP_ (e.g. KP_0 to KP_9, KP_ADD).
+
+# Note: If the Dev console source is enabled, keypresses (including with Alt
+# etc) will be printed to the console and could be copied to PCSX2_keys.ini .
 
 # List of special key names (beyond KP_0 to KP_9 and normal keys):
 # DEL DELETE BACK INS INSERT ENTER RETURN PGUP PGDN LEFT RIGHT UP DOWN HOME END

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -294,6 +294,18 @@ void Pcsx2App::PadKeyDispatch( const keyEvent& ev )
 
 	m_kevt.m_keyCode = vkey? vkey : ev.key;
 
+	if (DevConWriterEnabled && m_kevt.GetEventType() == wxEVT_KEY_DOWN) {
+		wxString strFromCode = wxAcceleratorEntry(
+			(m_kevt.m_shiftDown ? wxACCEL_SHIFT : 0) | (m_kevt.m_controlDown ? wxACCEL_CTRL : 0) | (m_kevt.m_altDown ? wxACCEL_ALT : 0),
+			m_kevt.m_keyCode
+			).ToString();
+
+		if (strFromCode.EndsWith(L"\\"))
+			strFromCode += L"\\"; // If copied into PCSX2_keys.ini, \ needs escaping
+
+		Console.WriteLn(wxString(L"> Key: %s (Code: %ld)"),	WX_STR(strFromCode), m_kevt.m_keyCode);
+	}
+
 	if( m_kevt.GetEventType() == wxEVT_KEY_DOWN )
 	{
 		if( GSFrame* gsFrame = wxGetApp().GetGsFramePtr() )

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -30,8 +30,10 @@ static const KeyAcceleratorCode FULLSCREEN_TOGGLE_ACCELERATOR_GSPANEL=KeyAcceler
 
 void GSPanel::InitDefaultAccelerators()
 {
-	// Note!  These don't really work yet due to some hacks to get things working for
-	// old legacy PAD plugins.  (the global accelerator tables are used instead) --air
+	// Note: these override GlobalAccels ( Pcsx2App::InitDefaultGlobalAccelerators() )
+	// For plain letters or symbols, replace e.g. WXK_F1 with e.g. wxKeyCode('q') or wxKeyCode('-')
+	// For plain letter keys with shift, use e.g. AAC( wxKeyCode('q') ).Shift() and NOT wxKeyCode('Q')
+	// For a symbol with shift (e.g. '_' which is '-' with shift) use AAC( wxKeyCode('-') ).Shift()
 
 	typedef KeyAcceleratorCode AAC;
 

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -610,6 +610,17 @@ void AcceleratorDictionary::Map( const KeyAcceleratorCode& _acode, const char *s
 		{
 			// ini file contains alternative parsable key combination for current 'searchfor'.
 			acode = codeParser;
+			if (acode.keycode >= 'A' && acode.keycode <= 'Z') {
+				// Note that this needs to match the key event codes at Pcsx2App::PadKeyDispatch
+				// Our canonical representation is the char code (at lower case if
+				// applicable) with a separate modifier indicator, including shift.
+				// The parser deviates from this by parsing e.g. `shift-q` as 81 (Q) without shift, instead of 113 (q) with shift.
+				// (For plain `q` it does end up correctly with 113).
+				// The parser works correctly for symbols, e.g. `-` ends up as 45
+				// So we only need to change upper case letters to lower case and add the shift flag.
+				acode.keycode += 'a' - 'A';
+				acode.Shift();
+			}
 			if (_acode.ToString() != acode.ToString()) {
 				Console.WriteLn(Color_StrongGreen, L"Overriding '%s': assigning %s (instead of %s)",
 					WX_STR(fromUTF8(searchfor)), WX_STR(acode.ToString()), WX_STR(_acode.ToString()));
@@ -672,6 +683,9 @@ void Pcsx2App::InitDefaultGlobalAccelerators()
 	typedef KeyAcceleratorCode AAC;
 
 	if( !GlobalAccels ) GlobalAccels = new AcceleratorDictionary;
+
+	// Why do we even have those here? all of them seem to be overridden
+	// by GSPanel::m_Accels ( GSPanel::InitDefaultAccelerators() )
 
 	GlobalAccels->Map( AAC( WXK_F1 ),			"States_FreezeCurrentSlot" );
 	GlobalAccels->Map( AAC( WXK_F3 ),			"States_DefrostCurrentSlot" );

--- a/pcsx2/windows/WinKeyCodes.cpp
+++ b/pcsx2/windows/WinKeyCodes.cpp
@@ -16,8 +16,14 @@
 #include "PrecompiledHeader.h"
 #include <Windows.h>
 
+// VK values without MS constants. see - https://msdn.microsoft.com/en-us/library/windows/desktop/dd375731%28v=vs.85%29.aspx
+#define PX_VK_A 0x41
+#define PX_VK_Z 0x5A
+
+
 // Returns a WXK_* keycode translated from a VK_* virtual key. wxCharCodeMSWToWx was
 // removed from wxWidgets 3, this should work as a replacement.
+// Where an ascii code for a printable char exists, we try to return it
 int TranslateVKToWXK(u32 keysym)
 {
 	int key_code;
@@ -118,7 +124,28 @@ int TranslateVKToWXK(u32 keysym)
 	case VK_EXECUTE: key_code = WXK_EXECUTE; break;
 	case VK_PRINT: key_code = WXK_PRINT; break;
 
-	default: key_code = 0;
+	// symbol-only keys on all keyboards - return ascii
+	case VK_OEM_PERIOD: key_code = '.'; break;
+	case VK_OEM_PLUS: key_code = '='; break;
+	case VK_OEM_MINUS: key_code = '-'; break;
+	case VK_OEM_COMMA: key_code = ','; break;
+
+	// symbol-only keys on US keyboards - return ascii
+	case VK_OEM_1: key_code = ';'; break;
+	case VK_OEM_2: key_code = '/'; break;
+	case VK_OEM_3: key_code = '`'; break;
+	case VK_OEM_4: key_code = '['; break;
+	case VK_OEM_5: key_code = '\\'; break;
+	case VK_OEM_6: key_code = ']'; break;
+	case VK_OEM_7: key_code = '\''; break;
+
+	default:
+		if (keysym >= PX_VK_A && keysym <= PX_VK_Z) {
+			// VK codes for letter keys - return lower case ascii
+			key_code = keysym + 'a' - PX_VK_A;
+		} else {
+			key_code = 0;
+		}
 	}
 
 	return key_code;


### PR DESCRIPTION
This fixes two issues which were observed on windows:
- plain letters: wx passes the capital code (e.g. 81 instead of 113 for 'q')
- symbol-only keys: just incorrect code (e.g. 219 instead of 91 for '[')

For both these cases, holding e.g. shift correctly has the shift flag set, and
the key code remains the same.

This should allow using letters and symbols at PCSX2_keys.ini

Note: this should have supposedly been fixed at r4918 ( 851bfba ), but neither
that build from the buildbot archive, nor the official 1.2.1 release (r5875),
nor the current builds have this working, which is really weird (tested on win8)