### PR TITLE
Rumble onepad

### DIFF
--- a/plugins/onepad/CMakeLists.txt
+++ b/plugins/onepad/CMakeLists.txt
@@ -9,11 +9,11 @@ endif()
 # plugin name
 set(Output onepad-1.1.0)
 set(onepadFinalFlags "")
-
 # onepad sources
 set(onepadSources
 	controller.cpp
-	joystick.cpp
+	SDL/joystick.cpp
+    GamePad.cpp
 	keyboard.cpp
     KeyStatus.cpp
 	onepad.cpp)
@@ -22,7 +22,8 @@ set(onepadSources
 set(onepadHeaders
 	bitwise.h
 	controller.h
-	joystick.h
+	SDL/joystick.h
+    GamePad.h
 	keyboard.h
     KeyStatus.h
 	onepad.h)
@@ -37,22 +38,16 @@ set(onepadLinuxSources
 set(onepadLinuxHeaders
 	Linux/linux.h)
 
-# onepad Windows sources
-set(onepadWindowsSources
-	)
-
-# onepad Windows headers
-set(onepadWindowsHeaders
-	)
-
 if (SDL2_API)
 	set(onepadFinalLibs
 		${SDL2_LIBRARIES}
-	)
+        )
+    add_definitions(-DSDL_BUILD -DSDL2_BUILD)
 else()
 	set(onepadFinalLibs
 		${SDL_LIBRARY}
-	)
+        )
+    add_definitions(-DSDL_BUILD -DSDL2_BUILD)
 endif()
 
 set(onepadFinalLibs

--- a/plugins/onepad/GamePad.cpp
+++ b/plugins/onepad/GamePad.cpp
@@ -1,0 +1,54 @@
+/*  OnePAD - author: arcum42(@gmail.com)
+ *  Copyright (C) 2009
+ *
+ *  Based on ZeroPAD, author zerofrog@gmail.com
+ *  Copyright (C) 2006-2007
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#include "GamePad.h"
+#ifdef  SDL_BUILD
+#include "SDL/joystick.h"
+#define HAT_UP SDL_HAT_UP
+#define HAT_DOWN SDL_HAT_DOWN
+#define HAT_RIGHT SDL_HAT_RIGHT
+#define HAT_LEFT SDL_HAT_LEFT
+#endif
+vector<GamePad*> s_vjoysticks;
+/**
+ * Just forward the statics to the correct backend
+ **/
+void GamePad::EnumerateGamePads(vector<GamePad*>& vGamePad)
+{
+#ifdef  SDL_BUILD
+    JoystickInfo::EnumerateJoysticks(vGamePad);
+#else
+#error YOU STILL NEED SDL for now, evdev coming soon hopefully
+#endif
+}
+
+
+/**
+ * Just forward the statics to the correct backend
+ **/
+void GamePad::UpdateReleaseState()
+{
+#ifdef  SDL_BUILD
+    JoystickInfo::UpdateReleaseState();
+#else
+#error YOU STILL NEED SDL for now, evdev coming soon hopefully
+#endif
+}

--- a/plugins/onepad/GamePad.h
+++ b/plugins/onepad/GamePad.h
@@ -1,0 +1,210 @@
+/*  OnePAD - author: arcum42(@gmail.com)
+ *  Copyright (C) 2009
+ *
+ *  Based on ZeroPAD, author zerofrog@gmail.com
+ *  Copyright (C) 2006-2007
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#pragma once
+
+#include "onepad.h"
+#include "controller.h"
+#ifdef  SDL_BUILD
+#include <SDL.h>
+#define HAT_UP SDL_HAT_UP
+#define HAT_DOWN SDL_HAT_DOWN
+#define HAT_RIGHT SDL_HAT_RIGHT
+#define HAT_LEFT SDL_HAT_LEFT
+#endif
+
+// generic class for GamePad backends(e.g. SDL2 or, hopefully soon, evdev.
+class GamePad
+{
+	public:
+
+		/**
+         * Search for connected GamePads and create corresponding classes for each of them
+         * Need to be generic as it may either be sdl's joystick or evdev or whatever else
+         **/
+		static void EnumerateGamePads(vector<GamePad*>& vGamePad);
+        static void UpdateReleaseState();
+
+
+
+
+        /*************************************************************************/
+        // Everything after this point is meant to be overiden by correct backend!
+        /*************************************************************************/
+       
+        virtual void UpdateGamePadState()
+        {
+            return;// Need to be done by backend. At least for SDL --3kinox
+        }
+        /**
+         * In first call, create effects and upload them to device
+         * For every call:
+         * According to effect type(int type), an effect is uploaded and ran on this GamePad
+         **/
+        virtual void DoHapticEffect(int type)
+        {
+            return; // Obviously does nothing here, no backend!    
+        }
+
+        virtual bool Init(int i)
+        {
+            return false;
+        }
+
+		GamePad()
+        {// Leave blank for child classes to handle however they wish
+	    vbuttonstate.clear();
+        vaxisstate.clear();
+        vhatstate.clear();
+        devname = ""; // pretty device name
+		_id = -1;
+		numbuttons = numaxes = numhats = 0;
+		deadzone =1500;
+		pad= -1;	    
+        }
+
+		virtual ~GamePad()
+		{
+		}
+
+		virtual void Destroy()
+        {
+            return;
+        }
+
+        /**
+         * method to test whether pad is able to rumble or not
+         **/
+		virtual void TestForce()
+        {
+            return;
+        }
+
+		virtual bool PollButtons(u32 &pkey)
+        {
+            return false;
+        }
+		virtual bool PollAxes(u32 &pkey)
+		{
+            return false;
+        }
+        virtual bool PollHats(u32 &pkey)
+ 		{
+            return false;
+        }     
+
+        virtual int GetHat(int key_to_axis)
+        {
+            return 0;
+        }
+
+        virtual int GetButton(int key_to_button)
+        {
+            return 0;
+        }
+
+		virtual const string& GetName()
+		{
+			return devname;
+		}
+
+		virtual int GetNumButtons()
+		{
+			return numbuttons;
+		}
+
+		virtual int GetNumAxes()
+		{
+			return numaxes;
+		}
+
+		virtual int GetNumHats()
+		{
+			return numhats;
+		}
+
+		virtual int GetPAD()
+		{
+			return pad;
+		}
+
+		virtual int GetDeadzone()
+		{
+			return deadzone;
+		}
+
+		virtual void SaveState()
+        {
+            return;
+        }
+
+		virtual int GetButtonState(int i)
+		{
+			return vbuttonstate[i];
+		}
+
+		virtual int GetAxisState(int i)
+		{
+			return vaxisstate[i];
+		}
+
+		virtual int GetHatState(int i)
+		{
+			//PAD_LOG("Getting POV State of %d.\n", i);
+			return vhatstate[i];
+		}
+
+		virtual void SetButtonState(int i, int state)
+		{
+			vbuttonstate[i] = state;
+		}
+
+		virtual void SetAxisState(int i, int value)
+		{
+			vaxisstate[i] = value;
+		}
+
+		virtual void SetHatState(int i, int value)
+		{
+			//PAD_LOG("We should set %d to %d.\n", i, value);
+			vhatstate[i] = value;
+		}
+
+		virtual int GetAxisFromKey(int pad, int index)
+        {
+            return -1;
+        }
+
+		
+
+// protected should be enough, child classes should have access to this
+	    protected:
+        vector<int> vbuttonstate, vaxisstate, vhatstate;
+        string devname; // pretty device name
+		int _id;
+		int numbuttons, numaxes, numhats;
+		int deadzone;
+		int pad;
+};
+
+extern vector<GamePad*> s_vjoysticks;
+extern int s_selectedpad;
+extern bool JoystickIdWithinBounds(int joyid);

--- a/plugins/onepad/KeyStatus.cpp
+++ b/plugins/onepad/KeyStatus.cpp
@@ -123,19 +123,19 @@ bool KeyStatus::analog_is_reversed(u32 index)
 	{
 		case PAD_L_RIGHT:
 		case PAD_L_LEFT:
-			return ((conf->options & PADOPTION_REVERSELX) != 0);
+			return ((conf->pad.PADOPTION_REVERSELX) != 0);
 
 		case PAD_R_LEFT:
 		case PAD_R_RIGHT:
-			return ((conf->options & PADOPTION_REVERSERX) != 0);
+			return ((conf->pad.PADOPTION_REVERSERX) != 0);
 
 		case PAD_L_UP:
 		case PAD_L_DOWN:
-			return ((conf->options & PADOPTION_REVERSELY) != 0);
+			return ((conf->pad.PADOPTION_REVERSELY) != 0);
 
 		case PAD_R_DOWN:
 		case PAD_R_UP:
-			return ((conf->options & PADOPTION_REVERSERY) != 0);
+			return ((conf->pad.PADOPTION_REVERSERY) != 0);
 
 		default: return false;
 	}

--- a/plugins/onepad/Linux/dialog.cpp
+++ b/plugins/onepad/Linux/dialog.cpp
@@ -294,7 +294,34 @@ typedef struct
 		mask = mask_value;
 
 		gtk_fixed_put(GTK_FIXED(area), widget, x, y);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), mask & conf->options);
+        switch(mask){
+            case PADOPTION_FORCEFEEDBACK :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_FORCEFEEDBACK);
+            break;
+            case PADOPTION_REVERSELX :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_REVERSELX);
+            break;
+            case PADOPTION_REVERSELY :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_REVERSELY);
+            break;
+            case PADOPTION_REVERSERX :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_REVERSERX);
+            break;
+            case PADOPTION_REVERSERY :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_REVERSERY);
+            break;
+            case PADOPTION_MOUSE_L :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_MOUSE_L);
+            break;
+            case PADOPTION_MOUSE_R :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_MOUSE_R);
+            break;
+            case PADOPTION_SIXAXIS_USB :
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), conf->pad.PADOPTION_SIXAXIS_USB);
+            break;
+        }
+
+		
 		g_signal_connect(widget, "toggled", G_CALLBACK(on_toggle_option), this);
 	}
 } dialog_checkbox;
@@ -393,9 +420,66 @@ void on_toggle_option(GtkToggleButton *togglebutton, gpointer user_data)
 	dialog_checkbox *checkbox = (dialog_checkbox*)user_data;
 
 	if (gtk_toggle_button_get_active(togglebutton))
-		conf->options |= checkbox->mask;
-	else
-		conf->options &= ~checkbox->mask;
+	{
+        switch(checkbox->mask)
+        {
+            case PADOPTION_FORCEFEEDBACK :
+                conf->pad.PADOPTION_FORCEFEEDBACK = 1;
+                s_vjoysticks[conf->get_joyid(current_pad)]->TestForce();
+                break;
+            case PADOPTION_REVERSELX :
+                conf->pad.PADOPTION_REVERSELX = 1;
+                break;
+            case PADOPTION_REVERSELY :
+                conf->pad.PADOPTION_REVERSELY = 1;
+                break;
+            case PADOPTION_REVERSERX :
+                conf->pad.PADOPTION_REVERSERX = 1;
+                break;
+            case PADOPTION_REVERSERY :
+                conf->pad.PADOPTION_REVERSERY = 1;
+                break;
+            case PADOPTION_MOUSE_L :
+                conf->pad.PADOPTION_MOUSE_L = 1;
+                break;
+            case PADOPTION_MOUSE_R :
+                conf->pad.PADOPTION_MOUSE_R = 1;
+                break;
+            case PADOPTION_SIXAXIS_USB :
+                conf->pad.PADOPTION_SIXAXIS_USB = 1;
+                break;
+        }
+    }
+    else
+    {
+        switch(checkbox->mask)
+        {
+            case PADOPTION_FORCEFEEDBACK :
+                conf->pad.PADOPTION_FORCEFEEDBACK = 0;
+                break;
+            case PADOPTION_REVERSELX :
+                conf->pad.PADOPTION_REVERSELX = 0;
+                break;
+            case PADOPTION_REVERSELY :
+                conf->pad.PADOPTION_REVERSELY = 0;
+                break;
+            case PADOPTION_REVERSERX :
+                conf->pad.PADOPTION_REVERSERX = 0;
+                break;
+            case PADOPTION_REVERSERY :
+                conf->pad.PADOPTION_REVERSERY = 0;
+                break;
+            case PADOPTION_MOUSE_L :
+                conf->pad.PADOPTION_MOUSE_L = 0;
+                break;
+            case PADOPTION_MOUSE_R :
+                conf->pad.PADOPTION_MOUSE_R = 0;
+                break;
+            case PADOPTION_SIXAXIS_USB :
+                conf->pad.PADOPTION_SIXAXIS_USB = 0;
+                break;
+        }
+    }
 }
 
 void joy_changed(GtkComboBoxText *box, gpointer user_data)

--- a/plugins/onepad/Linux/dialog.cpp
+++ b/plugins/onepad/Linux/dialog.cpp
@@ -426,24 +426,29 @@ void pad_changed(GtkNotebook *notebook, void *notebook_page, int page, void *dat
 	// update joy
 	set_current_joy();
 }
+#if 0
+void on_forcefeedback_toggled(GtkToggleButton *togglebutton, gpointer user_data)
+{
+	int mask = PADOPTION_REVERSELX << (16 * current_pad);
+    fprintf(stderr,"We enter forcefeedback_toggled\n");
+	if (gtk_toggle_button_get_active(togglebutton))
+	{
+        fprintf(stderr,"Button is now active!\n");
+		conf->options |= mask;
 
-//void on_forcefeedback_toggled(GtkToggleButton *togglebutton, gpointer user_data)
-//{
-//	int mask = PADOPTION_REVERSELX << (16 * s_selectedpad);
-//
-//	if (gtk_toggle_button_get_active(togglebutton))
-//	{
-//		conf->options |= mask;
-//
-//		u32 joyid = conf->get_joyid(current_pad);
-//		if (JoystickIdWithinBounds(joyid)) s_vjoysticks[joyid]->TestForce();
-//	}
-//	else
-//	{
-//		conf->options &= ~mask;
-//	}
-//}
-
+		u32 joyid = conf->get_joyid(current_pad);
+		if (JoystickIdWithinBounds(joyid))
+        {
+            fprintf(stderr,"Button actually had effect!\n");
+            s_vjoysticks[joyid]->TestForce();
+        }
+    }
+	else
+	{
+		conf->options &= ~mask;
+	}
+}
+#endif
 struct button_positions
 {
 	const char* label;
@@ -505,7 +510,7 @@ GtkWidget *create_notebook_page_dialog(int page, dialog_buttons btn[MAX_KEYS], d
 {
     GtkWidget *main_box;
     GtkWidget *joy_choose_frame, *joy_choose_box;
-    
+
     GtkWidget *keys_frame, *keys_box;
     
     GtkWidget *keys_tree_box, *keys_tree_scroll;
@@ -546,6 +551,12 @@ GtkWidget *create_notebook_page_dialog(int page, dialog_buttons btn[MAX_KEYS], d
 	g_signal_connect(keys_tree_show_key_btn, "toggled", G_CALLBACK(on_view_key_clicked), NULL);
     gtk_widget_set_size_request(keys_tree_show_key_btn, 100, 24);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(keys_tree_show_key_btn), true);
+
+	// REACTIVATE FORCE FEEDBACK!
+    //keys_tree_show_key_btn = gtk_check_button_new_with_label("Enable force feedback");
+	//g_signal_connect(keys_tree_show_key_btn, "toggled", G_CALLBACK(on_forcefeedback_toggled), NULL);
+    //gtk_widget_set_size_request(keys_tree_show_key_btn, 40, 400);
+	//gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(keys_tree_show_key_btn), true);
 
     joy_choose_box = gtk_hbox_new(false, 5);
     joy_choose_frame = gtk_frame_new ("Joystick to use for this pad");

--- a/plugins/onepad/Linux/dialog.cpp
+++ b/plugins/onepad/Linux/dialog.cpp
@@ -554,7 +554,7 @@ GtkWidget *create_notebook_page_dialog(int page, dialog_buttons btn[MAX_KEYS], d
 
 	// REACTIVATE FORCE FEEDBACK!
     //keys_tree_show_key_btn = gtk_check_button_new_with_label("Enable force feedback");
-	//g_signal_connect(keys_tree_show_key_btn, "toggled", G_CALLBACK(on_forcefeedback_toggled), NULL);
+	//g_signal_connect(keys_tree_show_key_btn, "toggled", G_CALLBACK(on_toggle_option), NULL);
     //gtk_widget_set_size_request(keys_tree_show_key_btn, 40, 400);
 	//gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(keys_tree_show_key_btn), true);
 

--- a/plugins/onepad/Linux/ini.cpp
+++ b/plugins/onepad/Linux/ini.cpp
@@ -130,9 +130,9 @@ void SaveConfig()
 
 	fprintf(f, "log = %d\n", conf->log);
 	fprintf(f, "options = %d\n", conf->options);
-	fprintf(f, "mouse_sensibility = %d\n", conf->sensibility);
+	fprintf(f, "mouse_sensibility = %d\n", conf->get_sensibility());
 	fprintf(f, "joy_pad_map = %d\n", conf->joyid_map);
-	fprintf(f, "ff_intensity = %d\n", conf->ff_intensity);
+	fprintf(f, "ff_intensity = %d\n", conf->get_ff_intensity());
 
 	for (int pad = 0; pad < 2; pad++)
 	{
@@ -176,11 +176,11 @@ void LoadConfig()
 	if (fscanf(f, "options = %d\n", &value) == 0) goto error;
 	conf->options = value;
 	if (fscanf(f, "mouse_sensibility = %d\n", &value) == 0) goto error;
-	conf->sensibility = value;
+	conf->set_sensibility(value);
 	if (fscanf(f, "joy_pad_map = %d\n", &value) == 0) goto error;
 	conf->joyid_map = value;
 	if (fscanf(f, "ff_intensity = %d\n", &value) == 0) goto error;
-	conf->ff_intensity = value;
+	conf->set_ff_intensity(value);
 
 	for (int pad = 0; pad < 2; pad++)
 	{

--- a/plugins/onepad/Linux/ini.cpp
+++ b/plugins/onepad/Linux/ini.cpp
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <gtk/gtk.h>
 
-#include "joystick.h"
+#include "GamePad.h"
 #include "keyboard.h"
 #include "onepad.h"
 #include "linux.h"
@@ -73,19 +73,19 @@ string KeyName(int pad, int key, int keysym)
 					int axis = key_to_axis(pad, key);
 					switch(key_to_hat_dir(pad, key))
 					{
-						case SDL_HAT_UP:
+						case HAT_UP:
 							sprintf(&tmp[0], "JPOVU-%d", axis);
 							break;
 
-						case SDL_HAT_RIGHT:
+						case HAT_RIGHT:
 							sprintf(&tmp[0], "JPOVR-%d", axis);
 							break;
 
-						case SDL_HAT_DOWN:
+						case HAT_DOWN:
 							sprintf(&tmp[0], "JPOVD-%d", axis);
 							break;
 
-						case SDL_HAT_LEFT:
+						case HAT_LEFT:
 							sprintf(&tmp[0], "JPOVL-%d", axis);
 							break;
 					}
@@ -129,14 +129,7 @@ void SaveConfig()
 	}
 
 	fprintf(f, "log = %d\n", conf->log);
-    fprintf(f, "PADOPTION_FORCEFEEDBACK = %d\n", conf->pad.PADOPTION_FORCEFEEDBACK);
-    fprintf(f, "PADOPTION_REVERSELX = %d\n", conf->pad.PADOPTION_REVERSELX);
-    fprintf(f, "PADOPTION_REVERSELY = %d\n", conf->pad.PADOPTION_REVERSELY);
-    fprintf(f, "PADOPTION_REVERSERX = %d\n", conf->pad.PADOPTION_REVERSERX);
-    fprintf(f, "PADOPTION_REVERSERY = %d\n", conf->pad.PADOPTION_REVERSERY);
-    fprintf(f, "PADOPTION_MOUSE_L = %d\n", conf->pad.PADOPTION_MOUSE_L);
-    fprintf(f, "PADOPTION_MOUSE_R = %d\n", conf->pad.PADOPTION_MOUSE_R);
-    fprintf(f, "PADOPTION_SIXAXIS_USB = %d\n", conf->pad.PADOPTION_SIXAXIS_USB);
+    fprintf(f, "PADOPTION = %d\n", conf->pad.packed_opt);
     fprintf(f, "mouse_sensibility = %d\n", conf->get_sensibility());
 	fprintf(f, "joy_pad_map = %d\n", conf->joyid_map);
 	fprintf(f, "ff_intensity = %d\n", conf->get_ff_intensity());
@@ -180,22 +173,8 @@ void LoadConfig()
 	u32 value;
 	if (fscanf(f, "log = %d\n", &value) == 0) goto error;
 	conf->log = value;
-	if (fscanf(f, "PADOPTION_FORCEFEEDBACK = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_FORCEFEEDBACK = value;
-    if (fscanf(f, "PADOPTION_REVERSELX = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_REVERSELX = value;
-    if (fscanf(f, "PADOPTION_REVERSELY = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_REVERSELY = value;
-    if (fscanf(f, "PADOPTION_REVERSERX = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_REVERSERX = value;
-    if (fscanf(f, "PADOPTION_REVERSERY = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_REVERSERY = value;
-    if (fscanf(f, "PADOPTION_MOUSE_L = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_MOUSE_L = value;
-    if (fscanf(f, "PADOPTION_MOUSE_R = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_MOUSE_R = value;
-    if (fscanf(f, "PADOPTION_SIXAXIS_USB = %d\n", &value) == 0) goto error;
-    conf->pad.PADOPTION_SIXAXIS_USB = value;
+	if (fscanf(f, "PADOPTION = %d\n", &value) == 0) goto error;
+    conf->pad.packed_opt = value;
     if (fscanf(f, "mouse_sensibility = %d\n", &value) == 0) goto error;
 	conf->set_sensibility(value);
 	if (fscanf(f, "joy_pad_map = %d\n", &value) == 0) goto error;

--- a/plugins/onepad/Linux/ini.cpp
+++ b/plugins/onepad/Linux/ini.cpp
@@ -129,8 +129,15 @@ void SaveConfig()
 	}
 
 	fprintf(f, "log = %d\n", conf->log);
-	fprintf(f, "options = %d\n", conf->options);
-	fprintf(f, "mouse_sensibility = %d\n", conf->get_sensibility());
+    fprintf(f, "PADOPTION_FORCEFEEDBACK = %d\n", conf->pad.PADOPTION_FORCEFEEDBACK);
+    fprintf(f, "PADOPTION_REVERSELX = %d\n", conf->pad.PADOPTION_REVERSELX);
+    fprintf(f, "PADOPTION_REVERSELY = %d\n", conf->pad.PADOPTION_REVERSELY);
+    fprintf(f, "PADOPTION_REVERSERX = %d\n", conf->pad.PADOPTION_REVERSERX);
+    fprintf(f, "PADOPTION_REVERSERY = %d\n", conf->pad.PADOPTION_REVERSERY);
+    fprintf(f, "PADOPTION_MOUSE_L = %d\n", conf->pad.PADOPTION_MOUSE_L);
+    fprintf(f, "PADOPTION_MOUSE_R = %d\n", conf->pad.PADOPTION_MOUSE_R);
+    fprintf(f, "PADOPTION_SIXAXIS_USB = %d\n", conf->pad.PADOPTION_SIXAXIS_USB);
+    fprintf(f, "mouse_sensibility = %d\n", conf->get_sensibility());
 	fprintf(f, "joy_pad_map = %d\n", conf->joyid_map);
 	fprintf(f, "ff_intensity = %d\n", conf->get_ff_intensity());
 
@@ -173,9 +180,23 @@ void LoadConfig()
 	u32 value;
 	if (fscanf(f, "log = %d\n", &value) == 0) goto error;
 	conf->log = value;
-	if (fscanf(f, "options = %d\n", &value) == 0) goto error;
-	conf->options = value;
-	if (fscanf(f, "mouse_sensibility = %d\n", &value) == 0) goto error;
+	if (fscanf(f, "PADOPTION_FORCEFEEDBACK = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_FORCEFEEDBACK = value;
+    if (fscanf(f, "PADOPTION_REVERSELX = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_REVERSELX = value;
+    if (fscanf(f, "PADOPTION_REVERSELY = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_REVERSELY = value;
+    if (fscanf(f, "PADOPTION_REVERSERX = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_REVERSERX = value;
+    if (fscanf(f, "PADOPTION_REVERSERY = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_REVERSERY = value;
+    if (fscanf(f, "PADOPTION_MOUSE_L = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_MOUSE_L = value;
+    if (fscanf(f, "PADOPTION_MOUSE_R = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_MOUSE_R = value;
+    if (fscanf(f, "PADOPTION_SIXAXIS_USB = %d\n", &value) == 0) goto error;
+    conf->pad.PADOPTION_SIXAXIS_USB = value;
+    if (fscanf(f, "mouse_sensibility = %d\n", &value) == 0) goto error;
 	conf->set_sensibility(value);
 	if (fscanf(f, "joy_pad_map = %d\n", &value) == 0) goto error;
 	conf->joyid_map = value;

--- a/plugins/onepad/Linux/linux.cpp
+++ b/plugins/onepad/Linux/linux.cpp
@@ -19,7 +19,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  */
 
-#include "joystick.h"
+#include "GamePad.h"
 #include "onepad.h"
 #include "keyboard.h"
 
@@ -74,7 +74,7 @@ void _PADclose()
 {
 	SetAutoRepeat(true);
 
-	vector<JoystickInfo*>::iterator it = s_vjoysticks.begin();
+	vector<GamePad*>::iterator it = s_vjoysticks.begin();
 
 	// Delete everything in the vector vjoysticks.
 	while (it != s_vjoysticks.end())
@@ -91,18 +91,16 @@ void PollForJoystickInput(int cpad)
 	int joyid = conf->get_joyid(cpad);
 	if (!JoystickIdWithinBounds(joyid)) return;
 
-	SDL_JoystickUpdate();
+ 	GamePad* pjoy = s_vjoysticks[joyid];  
+    pjoy->UpdateGamePadState();
 	for (int i = 0; i < MAX_KEYS; i++)
 	{
-		JoystickInfo* pjoy = s_vjoysticks[joyid];
-
 		switch (type_of_joykey(cpad, i))
 		{
 			case PAD_JOYBUTTONS:
 				{
-
-					int value = SDL_JoystickGetButton((pjoy)->GetJoy(), key_to_button(cpad, i));
-					if (value)
+					int value = pjoy->GetButton( key_to_axis(cpad, i));
+                    if (value)
 						key_status->press(cpad, i);
 					else
 						key_status->release(cpad, i);
@@ -111,8 +109,7 @@ void PollForJoystickInput(int cpad)
 				}
 			case PAD_HAT:
 				{
-					int value = SDL_JoystickGetHat((pjoy)->GetJoy(), key_to_axis(cpad, i));
-
+                    int value = pjoy->GetHat( key_to_axis(cpad, i));
 					// key_to_hat_dir and SDL_JoystickGetHat are a 4 bits bitmap, one for each directions. Only 1 bit can be high for
 					// key_to_hat_dir. SDL_JoystickGetHat handles diagonal too (2 bits) so you must check the intersection
 					// '&' not only equality '=='. -- Gregory

--- a/plugins/onepad/SDL/joystick.cpp
+++ b/plugins/onepad/SDL/joystick.cpp
@@ -25,12 +25,11 @@
 // Joystick definitions //
 //////////////////////////
 
-vector<JoystickInfo*> s_vjoysticks;
 static u32 s_bSDLInit = false;
 
 void JoystickInfo::UpdateReleaseState()
 {
-	vector<JoystickInfo*>::iterator itjoy = s_vjoysticks.begin();
+	vector<GamePad*>::iterator itjoy = s_vjoysticks.begin();
 
 	SDL_JoystickUpdate();
 
@@ -47,8 +46,8 @@ bool JoystickIdWithinBounds(int joyid)
 	return ((joyid >= 0) && (joyid < (int)s_vjoysticks.size()));
 }
 
-// opens handles to all possible joysticks
-void JoystickInfo::EnumerateJoysticks(vector<JoystickInfo*>& vjoysticks)
+// opens handles to all possible joystick
+void JoystickInfo::EnumerateJoysticks(vector<GamePad*>& vjoysticks)
 {
 
 	if (!s_bSDLInit)
@@ -67,7 +66,7 @@ void JoystickInfo::EnumerateJoysticks(vector<JoystickInfo*>& vjoysticks)
 		s_bSDLInit = true;
 	}
 
-	vector<JoystickInfo*>::iterator it = vjoysticks.begin();
+	vector<GamePad*>::iterator it = vjoysticks.begin();
 
 	// Delete everything in the vector vjoysticks.
 	while (it != vjoysticks.end())

--- a/plugins/onepad/SDL/joystick.h
+++ b/plugins/onepad/SDL/joystick.h
@@ -19,20 +19,21 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  */
 
-#ifndef __JOYSTICK_H__
-#define __JOYSTICK_H__
+#pragma once
 
 #include <SDL.h>
 #if SDL_MAJOR_VERSION >= 2
 #include <SDL_haptic.h>
+#else
+#warning Compiling SDL backend of onepad with sdl1.x is deprecated, rumble will not be disponible, and bugs are bound to happen!
 #endif
 
 
 #include "onepad.h"
 #include "controller.h"
-
+#include "GamePad.h"
 // holds all joystick info
-class JoystickInfo
+class JoystickInfo : virtual GamePad
 {
 	public:
 		JoystickInfo() : devname(""), _id(-1), numbuttons(0), numaxes(0), numhats(0),
@@ -58,7 +59,7 @@ class JoystickInfo
     
 		void Destroy();
 		// opens handles to all possible joysticks
-		static void EnumerateJoysticks(vector<JoystickInfo*>& vjoysticks);
+		static void EnumerateJoysticks(vector<GamePad*>& vjoysticks);
         
         /**
          * (Re)Initialize first, Triangle_id and Sine_id
@@ -79,6 +80,21 @@ class JoystickInfo
 		bool PollButtons(u32 &pkey);
 		bool PollAxes(u32 &pkey);
 		bool PollHats(u32 &pkey);
+
+        void UpdateGamePadState()
+        {
+            SDL_JoystickUpdate();
+        }
+
+        int GetHat(int key_to_axis)
+        {
+            return SDL_JoystickGetHat(joy, key_to_axis);
+        }
+
+        int GetButton(int key_to_button)
+        {
+            return SDL_JoystickGetButton(joy, key_to_button);
+        }
 
 		const string& GetName()
 		{
@@ -171,9 +187,3 @@ class JoystickInfo
         int Triangle_id, Sine_id;
 #endif
 };
-
-
-extern int s_selectedpad;
-extern vector<JoystickInfo*> s_vjoysticks;
-extern bool JoystickIdWithinBounds(int joyid);
-#endif

--- a/plugins/onepad/controller.h
+++ b/plugins/onepad/controller.h
@@ -28,6 +28,7 @@
 #define MAX_KEYS 20
 #endif
 
+#include <string.h>
 enum KeyType
 {
 	PAD_JOYBUTTONS = 0,
@@ -55,7 +56,9 @@ extern int hat_to_key(int dir, int axis_id);
 
 extern int PadEnum[2][2];
 
-typedef struct{
+
+union PADOption {
+    struct {
     signed PADOPTION_FORCEFEEDBACK :1;
 	signed PADOPTION_REVERSELX :1;
 	signed PADOPTION_REVERSELY :1;
@@ -63,8 +66,10 @@ typedef struct{
 	signed PADOPTION_REVERSERY :1;
 	signed PADOPTION_MOUSE_L :1;
 	signed PADOPTION_MOUSE_R :1;
-	signed PADOPTION_SIXAXIS_USB :1;
-}PADOption; // One pad is 8 bit now. And much much more readable  --3kinox
+	signed PADOPTION_SIXAXIS_USB :1;                    
+    };
+    uint32_t packed_opt;//8 bit is enough, like in good ol'times :)
+};
 
 class PADconf
 {

--- a/plugins/onepad/controller.h
+++ b/plugins/onepad/controller.h
@@ -55,23 +55,40 @@ extern int hat_to_key(int dir, int axis_id);
 
 extern int PadEnum[2][2];
 
-struct PADconf
+typedef struct{
+    signed PADOPTION_FORCEFEEDBACK :1;
+	signed PADOPTION_REVERSELX :1;
+	signed PADOPTION_REVERSELY :1;
+	signed PADOPTION_REVERSERX :1;
+	signed PADOPTION_REVERSERY :1;
+	signed PADOPTION_MOUSE_L :1;
+	signed PADOPTION_MOUSE_R :1;
+	signed PADOPTION_SIXAXIS_USB :1;
+}PADOption; // One pad is 8 bit now. And much much more readable  --3kinox
+
+class PADconf
 {
-	public:
-	u32 keys[2][MAX_KEYS];
-	u32 log;
-	u32 options;  // upper 16 bits are for pad2
 	u32 sensibility;
-	u32 joyid_map;
 	u32 ff_intensity;
-	map<u32,u32> keysym_map[2];
+    public:
+
+    /** 
+     * These two bitfields will replace the "option" variables 
+     * It stays public for ease of use 
+     **/
+    PADOption pad1;
+    PADOption pad2; // Options separated for each pads usig bit fields
 
 	PADconf() { init(); }
-
+	u32 joyid_map;
+    u32 options;  // upper 16 bits are for pad2
+    u32 keys[2][MAX_KEYS];
+	u32 log;
+	map<u32,u32> keysym_map[2];
 	void init() {
 		memset(&keys, 0, sizeof(keys));
 		log = options = joyid_map = 0;
-		ff_intensity = 100;
+		ff_intensity = 0x7FFF;
 		sensibility = 500;
 		for (int pad = 0; pad < 2 ; pad++)
 			keysym_map[pad].clear();
@@ -87,6 +104,37 @@ struct PADconf
 		int shift = 8 * pad;
 		return ((joyid_map >> shift) & 0xFF);
 	}
+
+	u32 get_sensibility()
+    {
+        return sensibility;
+    }
+	
+    void set_sensibility(u32 new_sensibility)
+    {
+        /**
+         * Add some checks here!
+         * Dunno variable range there
+         **/
+        sensibility = new_sensibility;
+    }
+	
+    u32 get_ff_intensity()
+    {
+        return ff_intensity;
+    }
+
+    /**
+     * Check intensity while checking that the new value is within
+     * valid range
+     **/
+    void set_ff_intensity(u32 new_intensity)
+    {
+        if(new_intensity < 0x7FFF && new_intensity >= 0)
+        {
+            ff_intensity = new_intensity;
+        }
+    }
 };
 extern PADconf *conf;
 #endif

--- a/plugins/onepad/controller.h
+++ b/plugins/onepad/controller.h
@@ -76,18 +76,18 @@ class PADconf
      * These two bitfields will replace the "option" variables 
      * It stays public for ease of use 
      **/
-    PADOption pad1;
-    PADOption pad2; // Options separated for each pads usig bit fields
+    PADOption pad;
+    //PADOption pad2; // Options separated for each pads usig bit fields
 
 	PADconf() { init(); }
 	u32 joyid_map;
-    u32 options;  // upper 16 bits are for pad2
+    //u32 options;  // upper 16 bits are for pad2
     u32 keys[2][MAX_KEYS];
 	u32 log;
 	map<u32,u32> keysym_map[2];
 	void init() {
 		memset(&keys, 0, sizeof(keys));
-		log = options = joyid_map = 0;
+		log = joyid_map = 0;
 		ff_intensity = 0x7FFF;
 		sensibility = 500;
 		for (int pad = 0; pad < 2 ; pad++)

--- a/plugins/onepad/joystick.h
+++ b/plugins/onepad/joystick.h
@@ -157,6 +157,10 @@ class JoystickInfo
 		SDL_Haptic*   		haptic;
 		SDL_HapticEffect	haptic_effect_data[2];
 		int   				haptic_effect_id[2];
+        int first;
+        SDL_HapticEffect Triangle_effect;
+        SDL_HapticEffect Sine_effect;
+        int Triangle_id, Sine_id;
 #endif
 };
 

--- a/plugins/onepad/joystick.h
+++ b/plugins/onepad/joystick.h
@@ -42,8 +42,6 @@ class JoystickInfo
 			 vhatstate.clear();
 #if SDL_MAJOR_VERSION >= 2
 			 haptic = NULL;
-			 for (int i = 0 ; i < 2 ; i++)
-				 haptic_effect_id[i] = -1;
 #endif
 		 }
 
@@ -58,9 +56,18 @@ class JoystickInfo
 		void Destroy();
 		// opens handles to all possible joysticks
 		static void EnumerateJoysticks(vector<JoystickInfo*>& vjoysticks);
-
+        
+        /**
+         * (Re)Initialize first, Triangle_id and Sine_id
+         **/
 		void InitHapticEffect();
-		static void DoHapticEffect(int type, int pad, int force);
+		
+        /**
+         * In first call, create effects and upload them to device
+         * For every call:
+         * According to effect type(int type), an effect is uploaded and ran on this pad/joystick
+         **/
+        void DoHapticEffect(int type);
 
 		bool Init(int id); // opens a handle and gets information
 
@@ -155,9 +162,7 @@ class JoystickInfo
 		SDL_Joystick*		joy;
 #if SDL_MAJOR_VERSION >= 2
 		SDL_Haptic*   		haptic;
-		SDL_HapticEffect	haptic_effect_data[2];
-		int   				haptic_effect_id[2];
-        int first;
+        bool first;
         SDL_HapticEffect Triangle_effect;
         SDL_HapticEffect Sine_effect;
         int Triangle_id, Sine_id;

--- a/plugins/onepad/joystick.h
+++ b/plugins/onepad/joystick.h
@@ -41,7 +41,10 @@ class JoystickInfo
 			 vaxisstate.clear();
 			 vhatstate.clear();
 #if SDL_MAJOR_VERSION >= 2
-			 haptic = NULL;
+			haptic = NULL;
+            first = 1;
+            Triangle_id = -1;
+            Sine_id = -1;
 #endif
 		 }
 

--- a/plugins/onepad/keyboard.cpp
+++ b/plugins/onepad/keyboard.cpp
@@ -142,11 +142,11 @@ void AnalyzeKeyEvent(int pad, keyEvent &evt)
 			// 1/ small move == no move. Cons : can not do small movement
 			// 2/ use a watchdog timer thread
 			// 3/ ??? idea welcome ;)
-			if (conf->options & ((PADOPTION_MOUSE_L|PADOPTION_MOUSE_R) << 16 * pad )) {
+			if (conf->pad.PADOPTION_MOUSE_L || conf->pad.PADOPTION_MOUSE_R){
 				unsigned int pad_x;
 				unsigned int pad_y;
 				// Note when both PADOPTION_MOUSE_R and PADOPTION_MOUSE_L are set, take only the right one
-				if (conf->options & (PADOPTION_MOUSE_R << 16 * pad)) {
+				if (conf->pad.PADOPTION_MOUSE_R) {
 					pad_x = PAD_R_RIGHT;
 					pad_y = PAD_R_UP;
 				} else {

--- a/plugins/onepad/keyboard.cpp
+++ b/plugins/onepad/keyboard.cpp
@@ -156,7 +156,7 @@ void AnalyzeKeyEvent(int pad, keyEvent &evt)
 
 				unsigned x = evt.key & 0xFFFF;
 				unsigned int value = (s_previous_mouse_x > x) ? s_previous_mouse_x - x : x - s_previous_mouse_x;
-				value *= conf->sensibility;
+				value *= conf->get_sensibility();
 
 				if (x == 0)
 					key_status->press(pad, pad_x, -MAX_ANALOG_VALUE);
@@ -172,7 +172,7 @@ void AnalyzeKeyEvent(int pad, keyEvent &evt)
 
 				unsigned y = evt.key >> 16;
 				value = (s_previous_mouse_y > y) ? s_previous_mouse_y - y : y - s_previous_mouse_y;
-				value *= conf->sensibility;
+				value *= conf->get_sensibility();
 
 				if (y == 0)
 					key_status->press(pad, pad_y, -MAX_ANALOG_VALUE);

--- a/plugins/onepad/onepad.cpp
+++ b/plugins/onepad/onepad.cpp
@@ -263,7 +263,7 @@ EXPORT_C_(s32) PADopen(void *pDsp)
 	mutex_WasInit = true;
 
 #ifdef __linux__
-	JoystickInfo::EnumerateJoysticks(s_vjoysticks);
+	GamePad::EnumerateGamePads(s_vjoysticks);
 #endif
 	return _PADopen(pDsp);
 }
@@ -418,7 +418,7 @@ u8  _PADpoll(u8 value)
                 vib_small = padVibF[curPad][0] ? 2000 : 0;
 				if (padVibF[curPad][2] != vib_small)
 				{
-                    JoystickInfo* pjoy = s_vjoysticks[conf->get_joyid(curPad)];
+                    GamePad* pjoy = s_vjoysticks[conf->get_joyid(curPad)];
 					padVibF[curPad][2] = vib_small;
                     pjoy->DoHapticEffect(0);
 
@@ -427,7 +427,7 @@ u8  _PADpoll(u8 value)
 				vib_big = padVibF[curPad][1] ? 500 + 37*padVibF[curPad][1] : 0;
 				if (padVibF[curPad][3] != vib_big)
 				{
-                    JoystickInfo* pjoy = s_vjoysticks[conf->get_joyid(curPad)];
+                    GamePad* pjoy = s_vjoysticks[conf->get_joyid(curPad)];
 					padVibF[curPad][3] = vib_big;
                     pjoy->DoHapticEffect(1);
 				}

--- a/plugins/onepad/onepad.cpp
+++ b/plugins/onepad/onepad.cpp
@@ -413,25 +413,23 @@ u8  _PADpoll(u8 value)
 
 				buf = stdpar[curPad];
 
-				// FIXME FEEDBACK. Set effect here
-				/* Small Motor */
-				vib_small = padVibF[curPad][0] ? 2000 : 0;
-				// if ((padVibF[curPad][2] != vib_small) && (padVibC[curPad] >= 0))
+				// FIXED FEEDBACK
+                /* Small Motor */
+                vib_small = padVibF[curPad][0] ? 2000 : 0;
 				if (padVibF[curPad][2] != vib_small)
 				{
+                    JoystickInfo* pjoy = s_vjoysticks[conf->get_joyid(curPad)];
 					padVibF[curPad][2] = vib_small;
-					// SetDeviceForceS (padVibC[curPad], vib_small);
-					JoystickInfo::DoHapticEffect(0, curPad, vib_small);
-				}
+                    pjoy->DoHapticEffect(0);
 
+				}
 				/* Big Motor */
 				vib_big = padVibF[curPad][1] ? 500 + 37*padVibF[curPad][1] : 0;
-				// if ((padVibF[curPad][3] != vib_big) && (padVibC[curPad] >= 0))
 				if (padVibF[curPad][3] != vib_big)
 				{
+                    JoystickInfo* pjoy = s_vjoysticks[conf->get_joyid(curPad)];
 					padVibF[curPad][3] = vib_big;
-					// SetDeviceForceB (padVibC[curPad], vib_big);
-					JoystickInfo::DoHapticEffect(1, curPad, vib_big);
+                    pjoy->DoHapticEffect(1);
 				}
 
 				return padID[curPad];

--- a/plugins/onepad/onepad.h
+++ b/plugins/onepad/onepad.h
@@ -48,7 +48,7 @@ using namespace std;
 #include "PS2Edefs.h"
 
 #ifdef __linux__
-#include "joystick.h"
+#include "GamePad.h"
 #endif
 #include "bitwise.h"
 #include "controller.h"


### PR DESCRIPTION
+ Add rumble to onepad when using SDL2 backend.
+ Fix a crash when calling SDL_joystickclose by.. not calling it. Function is bugged as a matter of fact.
But it does not cause leak as I retrieve same pointer whenver plugin is relaunched.
+ Isolate every SDL specific stuff so that an evdev backend can be done.
+ Make some code look more like cpp, replace some shifts by bitfields as it is much more clean and make the force feedback checkbox actually do something.
+ Some Options such as intensity and sensibility are still not responsive but it will come, just that I will not fix this interface, it will be replaced by a wxwidget new and shiny version which will allow me to handle that in a better way(with sliders and such).