### PR TITLE
Coverity: Prevent NULL dereferences and other stuffs. 

### DIFF
--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -392,6 +392,7 @@ void CBreakPoints::Update(u32 addr)
 	
 	if (resume)
 		r5900Debug.resumeCpu();
-
-	wxGetApp().GetDisassemblyPtr()->update();
+	auto disassembly_window = wxGetApp().GetDisassemblyPtr();
+	if (disassembly_window) // make sure that valid pointer is recieved to prevent potential NULL dereference.
+		disassembly_window->update();
 }

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -514,7 +514,7 @@ public:
 
 	GSFrame*			GetGsFramePtr() const		{ return (GSFrame*)wxWindow::FindWindowById( m_id_GsFrame ); }
 	MainEmuFrame*		GetMainFramePtr() const		{ return (MainEmuFrame*)wxWindow::FindWindowById( m_id_MainFrame ); }
-	DisassemblyDialog*	GetDisassemblyPtr() const	{ return m_id_Disassembler ? (DisassemblyDialog*)wxWindow::FindWindowById( m_id_Disassembler ) : NULL; }
+	DisassemblyDialog*	GetDisassemblyPtr() const	{ return (DisassemblyDialog*)wxWindow::FindWindowById(m_id_Disassembler); }
 	
 	void enterDebugMode();
 	void leaveDebugMode();

--- a/plugins/GSdx/GSFunctionMap.h
+++ b/plugins/GSdx/GSFunctionMap.h
@@ -125,7 +125,7 @@ public:
 			KEY key = i->first;
 			ActivePtr* p = i->second;
 
-			if(p->frames > 0)
+			if(p->frames && ttpf)
 			{
 				uint64 tpp = p->actual > 0 ? p->ticks / p->actual : 0;
 				uint64 tpf = p->frames > 0 ? p->ticks / p->frames : 0;

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -1572,12 +1572,12 @@ void GSRendererSW::SharedData::UsePages(const uint32* fb_pages, int fpsm, const 
 	{
 		//TransactionScope scope(s_lock);
 
-		if(global.sel.fb)
+		if(global.sel.fb && fb_pages != NULL)
 		{
 			m_parent->UsePages(fb_pages, 0);
 		}
 
-		if(global.sel.zb)
+		if(global.sel.zb && zb_pages != NULL)
 		{
 			m_parent->UsePages(zb_pages, 1);
 		}


### PR DESCRIPTION
***Fixes the following coverity Issues :-***

- CID 146839 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)11. var_deref_model: Passing null pointer fb_pages to UsePages, which dereferences it.

- CID 146840 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)11. var_deref_model: Passing null pointer zb_pages to UsePages, which dereferences it.

- CID 146834 (#2-1 of 2): Division or modulo by zero (DIVIDE_BY_ZERO)9. divide_by_zero: In expression tpf * 10000ULL / ttpf, division by expression ttpf which may be zero has undefined behavior.

- CID 146889 (#1 of 1): Dereference null return value (NULL_RETURNS)4. dereference: Dereferencing a pointer that might be null wxGetApp()->GetDisassemblyPtr() when calling update