### PR TITLE
spu2x: correctly apply the volume to the external source

### DIFF
--- a/plugins/spu2-x/src/Mixer.cpp
+++ b/plugins/spu2-x/src/Mixer.cpp
@@ -860,7 +860,7 @@ void Mix()
 	spu2M_WriteFast( 0xA00 + OutPos, Ext.Right );
 	WaveDump::WriteCore( 0, CoreSrc_External, Ext );
 
-	ApplyVolume( Ext, Cores[1].ExtVol );
+	Ext = ApplyVolume( Ext, Cores[1].ExtVol );
 	StereoOut32 Out( Cores[1].Mix( VoiceData[1], InputData[1], Ext ) );
 
 	if( PlayMode & 8 )


### PR DESCRIPTION
CID 147046 (#1 of 1): Useless call (USELESS_CALL)
side_effect_free: Calling ApplyVolume(Ext, Cores[1].ExtVol) is only useful for its return value, which is ignored.