### PR TITLE
gsdx-ogl: only enable aniso when sampling from the HW texture unit

### DIFF
--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -562,10 +562,10 @@ void GSDeviceOGL::ClearStencil(GSTexture* t, uint8 c)
 
 GLuint GSDeviceOGL::CreateSampler(PSSamplerSelector sel)
 {
-	return CreateSampler(sel.ltf, sel.tau, sel.tav);
+	return CreateSampler(sel.ltf, sel.tau, sel.tav, sel.aniso);
 }
 
-GLuint GSDeviceOGL::CreateSampler(bool bilinear, bool tau, bool tav)
+GLuint GSDeviceOGL::CreateSampler(bool bilinear, bool tau, bool tav, bool aniso)
 {
 	GL_PUSH("Create Sampler");
 
@@ -594,7 +594,7 @@ GLuint GSDeviceOGL::CreateSampler(bool bilinear, bool tau, bool tav)
 	glSamplerParameterf(sampler, GL_TEXTURE_MAX_LOD, 6);
 
 	int anisotropy = theApp.GetConfig("MaxAnisotropy", 0);
-	if (GLLoader::found_GL_EXT_texture_filter_anisotropic && anisotropy && !theApp.GetConfig("paltex", 0))
+	if (GLLoader::found_GL_EXT_texture_filter_anisotropic && anisotropy && aniso)
 		glSamplerParameterf(sampler, GL_TEXTURE_MAX_ANISOTROPY_EXT, (float)anisotropy);
 
 	GL_POP();

--- a/plugins/GSdx/GSDeviceOGL.h
+++ b/plugins/GSdx/GSDeviceOGL.h
@@ -312,8 +312,9 @@ class GSDeviceOGL : public GSDevice
 				uint32 tau:1;
 				uint32 tav:1;
 				uint32 ltf:1;
+				uint32 aniso:1;
 
-				uint32 _free:29;
+				uint32 _free:28;
 			};
 
 			uint32 key;
@@ -439,7 +440,7 @@ class GSDeviceOGL : public GSDevice
 
 	GLuint m_vs[1<<5];
 	GLuint m_gs[1<<2];
-	GLuint m_ps_ss[1<<3];
+	GLuint m_ps_ss[1<<4];
 	GSDepthStencilOGL* m_om_dss[1<<4];
 	hash_map<uint64, GLuint > m_ps;
 	GLuint m_apitrace;
@@ -533,7 +534,7 @@ class GSDeviceOGL : public GSDevice
 	GLuint CompileVS(VSSelector sel, int logz);
 	GLuint CompileGS(GSSelector sel);
 	GLuint CompilePS(PSSelector sel);
-	GLuint CreateSampler(bool bilinear, bool tau, bool tav);
+	GLuint CreateSampler(bool bilinear, bool tau, bool tav, bool aniso = false);
 	GLuint CreateSampler(PSSamplerSelector sel);
 	GSDepthStencilOGL* CreateDepthStencil(OMDepthStencilSelector dssel);
 

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -897,9 +897,10 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 
 		// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader
-		ps_ssel.tau = (m_context->CLAMP.WMS != CLAMP_CLAMP);
-		ps_ssel.tav = (m_context->CLAMP.WMT != CLAMP_CLAMP);
-		ps_ssel.ltf = bilinear && simple_sample;
+		ps_ssel.tau   = (m_context->CLAMP.WMS != CLAMP_CLAMP);
+		ps_ssel.tav   = (m_context->CLAMP.WMT != CLAMP_CLAMP);
+		ps_ssel.ltf   = bilinear && simple_sample;
+		ps_ssel.aniso = simple_sample;
 
 		// Setup Texture ressources
 		dev->SetupSampler(ps_ssel);


### PR DESCRIPTION
Potentially help issue #884 