### PR TITLE
gsdx: use old size of target if ds and rt is null

### DIFF
--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -1411,7 +1411,7 @@ void GSDeviceOGL::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVecto
 	}
 
 
-	GSVector2i size = rt ? rt->GetSize() : ds->GetSize();
+	GSVector2i size = rt ? rt->GetSize() : ds ? ds->GetSize() : GLState::viewport;
 	if(GLState::viewport != size)
 	{
 		GLState::viewport = size;


### PR DESCRIPTION
* CID 146843 (#1 of 1): Dereference after null check (FORWARD_NULL) 6. var_deref_model: Passing null pointer ds to GetSize, which dereferences it.


