### PR TITLE
pcsx2: auto_ptr is deprecated in favor of auto_ptr

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -222,7 +222,7 @@ int LoadCheatsFromZip(wxString gameCRC, const wxString& cheatsArchiveFilename) {
 
   int before = cheatnumber;
 
-  std::auto_ptr<wxZipEntry> entry;
+  std::unique_ptr<wxZipEntry> entry;
   wxFFileInputStream in(cheatsArchiveFilename);
   wxZipInputStream zip(in);
   while (entry.reset(zip.GetNextEntry()), entry.get() != NULL)


### PR DESCRIPTION
Might need a windows compilation test.