### PR TITLE
Autoselect CRC Hack by renderer

### DIFF
--- a/plugins/GSdx/GPU.cpp
+++ b/plugins/GSdx/GPU.cpp
@@ -107,17 +107,17 @@ EXPORT_C_(int32) GPUopen(void* hWnd)
 
 #endif
 
-	int renderer = theApp.GetConfig("Renderer", 1);
+	GS_RENDERER renderer = static_cast<GS_RENDERER>(theApp.GetConfig("Renderer", GS_DEFAULT_RENDERER));
 	int threads = theApp.GetConfig("extrathreads", 0);
 
 	switch(renderer)
 	{
 	default:
 	#ifdef _WINDOWS
-	case 0: s_gpu = new GPURendererSW(new GSDevice9(), threads); break;
-	case 1: s_gpu = new GPURendererSW(new GSDevice11(), threads); break;
+	case REND_D3D9_HW: s_gpu = new GPURendererSW(new GSDevice9(), threads); break;
+	case REND_D3D1011_SW: s_gpu = new GPURendererSW(new GSDevice11(), threads); break;
 	#endif
-	case 3: s_gpu = new GPURendererSW(new GSDeviceNull(), threads); break;
+	case REND_NULL_SW: s_gpu = new GPURendererSW(new GSDeviceNull(), threads); break;
 	//case 4: s_gpu = new GPURendererNull(new GSDeviceNull()); break;
 	}
 

--- a/plugins/GSdx/GPUSettingsDlg.cpp
+++ b/plugins/GSdx/GPUSettingsDlg.cpp
@@ -65,7 +65,7 @@ void GPUSettingsDlg::OnInit()
 		}
 	}
 
-	ComboBoxInit(IDC_RENDERER, theApp.m_gpu_renderers, theApp.GetConfig("Renderer", 0));
+	ComboBoxInit(IDC_RENDERER, theApp.m_gpu_renderers, theApp.GetConfig("Renderer", GS_DEFAULT_RENDERER));
 	ComboBoxInit(IDC_FILTER, theApp.m_gpu_filter, theApp.GetConfig("filter", 0));
 	ComboBoxInit(IDC_DITHERING, theApp.m_gpu_dithering, theApp.GetConfig("dithering", 1));
 	ComboBoxInit(IDC_ASPECTRATIO, theApp.m_gpu_aspectratio, theApp.GetConfig("AspectRatio", 1));

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1246,3 +1246,18 @@ enum {FREEZE_LOAD=0, FREEZE_SAVE=1, FREEZE_SIZE=2};
 struct GSFreezeData {int size; uint8* data;};
 
 enum stateType {ST_WRITE, ST_TRANSFER, ST_VSYNC};
+
+static inline int AutoselectCRCHackLevel(int renderer)
+{
+	switch (renderer)
+	{
+	case 0: // D3D9_HW
+	case 3: // D3D1011_HW
+	case 9: // NULL_HW
+		return 3; //CRC Hack Level Full
+	case 12: // OGL_HW
+		return 2; //CRC Hack Level Partial
+	default:
+		return 3; // Not sure if warning or default is more appropriate.
+	}
+}

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -373,6 +373,8 @@ bool GSRendererOGL::EmulateBlending(GSDeviceOGL::PSSelector& ps_sel, bool DATE_G
 			// The fastest algo that requires a single pass
 			GL_INS("COLCLIP Free mode ENABLED");
 			ps_sel.colclip = 1;
+			ASSERT(sw_blending);
+			accumulation_blend = false; // disable the HDR algo
 		} else if (accumulation_blend) {
 			// A fast algo that requires 2 passes
 			GL_INS("COLCLIP Fast HDR mode ENABLED");

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -37,6 +37,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"Forced:\nAlways enable interpolation. Rendering is smoother but it could generate some glitches.";
 		case IDC_CRC_LEVEL:
 			return "Control the number of Auto-CRC hacks applied to games.\n\n"
+				"Automatic:\nAutomatically selects recommended CRC hack level according to the renderer\n(Accurate/depth options may be required for OpenGL).\n\n"
 				"None:\nRemove nearly all CRC hacks (debug only).\n\n"
 				"Minimum:\nEnable a couple of CRC hacks (23).\n\n"
 				"Partial:\nEnable most of the CRC hacks.\nRecommended OpenGL setting (Accurate/depth options may be required).\n\n"

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -153,7 +153,7 @@ void GSSettingsDlg::OnInit()
 	ComboBoxInit(IDC_AFCOMBO, theApp.m_gs_max_anisotropy, theApp.GetConfig("MaxAnisotropy", 0));
 	ComboBoxInit(IDC_FILTER, theApp.m_gs_filter, theApp.GetConfig("filter", 2));
 	ComboBoxInit(IDC_ACCURATE_BLEND_UNIT, theApp.m_gs_acc_blend_level, theApp.GetConfig("accurate_blending_unit", 1));
-	ComboBoxInit(IDC_CRC_LEVEL, theApp.m_gs_crc_level, theApp.GetConfig("crc_hack_level", 3));
+	ComboBoxInit(IDC_CRC_LEVEL, theApp.m_gs_crc_level, theApp.GetConfig("crc_hack_level", -1));
 
 	CheckDlgButton(m_hWnd, IDC_PALTEX, theApp.GetConfig("paltex", 0));
 	CheckDlgButton(m_hWnd, IDC_LOGZ, theApp.GetConfig("logz", 1));

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -353,18 +353,24 @@ void GSSettingsDlg::UpdateRenderers()
 
 	vector<GSSetting> renderers;
 
-	unsigned renderer_setting = theApp.GetConfig("Renderer", 0);
+	GS_RENDERER renderer_setting = static_cast<GS_RENDERER>(theApp.GetConfig("Renderer", GS_DEFAULT_RENDERER));
 	unsigned renderer_sel = 0;
 
 	for(size_t i = 0; i < theApp.m_gs_renderers.size(); i++)
 	{
 		GSSetting r = theApp.m_gs_renderers[i];
 
-		if(r.id >= 3 && r.id <= 5 || r.id == 15)
+		switch(r.id)
 		{
-			if(level < D3D_FEATURE_LEVEL_10_0) continue;
+			case REND_D3D1011_HW:
+			case REND_D3D1011_NULL:
+			case REND_D3D1011_OCL:
+			case REND_D3D1011_SW:
+				if (level < D3D_FEATURE_LEVEL_10_0)
+					continue;
 
-			r.name += (level >= D3D_FEATURE_LEVEL_11_0 ? "11" : "10");
+				r.name += (level >= D3D_FEATURE_LEVEL_11_0 ? "11" : "10");
+			break;
 		}
 
 		renderers.push_back(r);
@@ -391,12 +397,14 @@ void GSSettingsDlg::UpdateControls()
 
 	if(ComboBoxGetSelData(IDC_RENDERER, i))
 	{
-		bool dx9 = i >= 0 && i <= 2 || i == 14;
-		bool dx11 = i >= 3 && i <= 5 || i == 15;
-		bool ogl = i >= 12 && i <= 13 || i == 17;
-		bool hw = i == 0 || i == 3 || i == 12;
-		//bool sw = i == 1 || i == 4 || i == 10 || i == 13;
-		bool ocl = i >= 14 && i <= 17;
+		
+
+		bool dx9 = i == REND_D3D9_HW || i == REND_D3D9_NULL || i == REND_D3D9_OCL || i == REND_D3D9_SW;
+		bool dx11 = i == REND_D3D1011_HW || i == REND_D3D1011_NULL || i == REND_D3D1011_OCL || i == REND_D3D1011_SW;
+		bool ogl = i == REND_OGL_HW || i == REND_OGL_OCL || i == REND_OGL_SW;
+		bool hw = i == REND_D3D9_HW || i == REND_D3D1011_HW || i == REND_OGL_HW;
+		//bool sw = REND_D3D9_SW || i == REND_D3D1011_SW || i == REND_OGL_SW;;
+		bool ocl = i == REND_D3D9_OCL || i == REND_D3D1011_OCL || i == REND_OGL_OCL;
 
 
 		ShowWindow(GetDlgItem(m_hWnd, IDC_LOGO9), dx9 ? SW_SHOW : SW_HIDE);
@@ -577,11 +585,11 @@ GSHacksDlg::GSHacksDlg() :
 void GSHacksDlg::OnInit()
 {
 	HWND hwnd_renderer = GetDlgItem(GetParent(m_hWnd), IDC_RENDERER);
-	int renderer = SendMessage(hwnd_renderer, CB_GETITEMDATA, SendMessage(hwnd_renderer, CB_GETCURSEL, 0, 0), 0);
+	GS_RENDERER renderer = static_cast<GS_RENDERER>(SendMessage(hwnd_renderer, CB_GETITEMDATA, SendMessage(hwnd_renderer, CB_GETCURSEL, 0, 0), 0));
 	// It can only be accessed with a HW renderer, so this is sufficient.
-	bool dx9 = renderer == 0;
-	// bool dx11 = renderer == 3;
-	bool ogl = renderer == 12;
+	bool dx9 = renderer == REND_D3D9_HW;
+	// bool dx11 = renderer ==  REND_D3D1011_HW;
+	bool ogl = renderer == REND_OGL_HW;
 	unsigned short cb = 0;
 
 	if(dx9) for(unsigned short i = 0; i < 17; i++)

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -25,7 +25,7 @@
 
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
-static int s_crc_hack_level = 3;
+static int s_crc_hack_level = -1;
 
 GSState::GSState()
 	: m_version(6)
@@ -69,7 +69,12 @@ GSState::GSState()
 	//s_savel = 0;
 
 	UserHacks_WildHack = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_WildHack", 0) : 0;
-	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
+	m_crc_hack_level = theApp.GetConfig("crc_hack_level", -1);
+	
+	m_crc_hack_level = m_crc_hack_level == -1 ?
+		AutoselectCRCHackLevel(theApp.GetConfig("Renderer", 12)) :
+		m_crc_hack_level;
+	
 	s_crc_hack_level = m_crc_hack_level;
 
 	memset(&m_v, 0, sizeof(m_v));

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -37,6 +37,10 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 	m_can_convert_depth = theApp.GetConfig("Renderer", 12) == 12 ? theApp.GetConfig("texture_cache_depth", 1) : 0;
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
 	
+	m_crc_hack_level = m_crc_hack_level == -1 ?
+		AutoselectCRCHackLevel(theApp.GetConfig("Renderer", 12)) :
+		m_crc_hack_level;
+
 	m_temp = (uint8*)_aligned_malloc(1024 * 1024 * sizeof(uint32), 32);
 }
 

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -21,6 +21,7 @@
 
 #include "stdafx.h"
 #include "GSdx.h"
+#include "GS.h"
 
 static void* s_hModule;
 
@@ -127,20 +128,20 @@ GSdxApp::GSdxApp()
 	m_ini = "inis/GSdx.ini";
 	m_section = "Settings";
 
-	m_gs_renderers.push_back(GSSetting(0, "Direct3D9", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(1, "Direct3D9", "Software"));
-	m_gs_renderers.push_back(GSSetting(14, "Direct3D9", "OpenCL"));
-	m_gs_renderers.push_back(GSSetting(2, "Direct3D9", "Null"));
-	m_gs_renderers.push_back(GSSetting(3, "Direct3D", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(4, "Direct3D", "Software"));
-	m_gs_renderers.push_back(GSSetting(15, "Direct3D", "OpenCL"));
-	m_gs_renderers.push_back(GSSetting(5, "Direct3D", "Null"));
-	m_gs_renderers.push_back(GSSetting(10, "Null", "Software"));
-	m_gs_renderers.push_back(GSSetting(16, "Null", "OpenCL"));
-	m_gs_renderers.push_back(GSSetting(11, "Null", "Null"));
-	m_gs_renderers.push_back(GSSetting(12, "OpenGL", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(13, "OpenGL", "Software"));
-	m_gs_renderers.push_back(GSSetting(17, "OpenGL", "OpenCL"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D9_HW, "Direct3D9", "Hardware"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D9_SW, "Direct3D9", "Software"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D9_OCL, "Direct3D9", "OpenCL"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D9_NULL, "Direct3D9", "Null"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D1011_HW, "Direct3D", "Hardware"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D1011_SW, "Direct3D", "Software"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D1011_OCL, "Direct3D", "OpenCL"));
+	m_gs_renderers.push_back(GSSetting(REND_D3D1011_NULL, "Direct3D", "Null"));
+	m_gs_renderers.push_back(GSSetting(REND_NULL_SW, "Null", "Software"));
+	m_gs_renderers.push_back(GSSetting(REND_NULL_OCL, "Null", "OpenCL"));
+	m_gs_renderers.push_back(GSSetting(REND_NULL_NULL, "Null", "Null"));
+	m_gs_renderers.push_back(GSSetting(REND_OGL_HW, "OpenGL", "Hardware"));
+	m_gs_renderers.push_back(GSSetting(REND_OGL_SW, "OpenGL", "Software"));
+	m_gs_renderers.push_back(GSSetting(REND_OGL_OCL, "OpenGL", "OpenCL"));
 
 	m_gs_interlace.push_back(GSSetting(0, "None", ""));
 	m_gs_interlace.push_back(GSSetting(1, "Weave tff", "saw-tooth"));

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -182,6 +182,7 @@ GSdxApp::GSdxApp()
 	m_gs_hack.push_back(GSSetting(1,  "Half", ""));
 	m_gs_hack.push_back(GSSetting(2,  "Full", ""));
 
+	m_gs_crc_level.push_back(GSSetting(-1, "Automatic", "Recommended"));
 	m_gs_crc_level.push_back(GSSetting(0 , "None", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(1 , "Minimum", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(2 , "Partial", "OpenGL Recommended"));


### PR DESCRIPTION
Inline function to select the appropriate crc level by renderer.
Accordingly new Combobox Element 'Automatic'

Added as well a (at least to me) nice renderer enum and replaced all
renderer int's by the enum.

Defined default renderer device according to OS.