### PR TITLE
pcsx2: generate an exception when recompilation failed

### DIFF
--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -43,6 +43,12 @@ namespace Exception
 	public:
 		explicit CancelInstruction() { }
 	};
+
+	class FailedToAllocateRegister
+	{
+	public:
+		explicit FailedToAllocateRegister() { }
+	};
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/x86/iCore.cpp
+++ b/pcsx2/x86/iCore.cpp
@@ -133,9 +133,9 @@ int  _getFreeXMMreg()
 		_freeXMMreg(tempi);
 		return tempi;
 	}
-	pxFailDev("*PCSX2*: XMM Reg Allocation Error in _getFreeXMMreg()!");
 
-	return -1;
+	pxFailDev("*PCSX2*: XMM Reg Allocation Error in _getFreeXMMreg()!");
+	throw Exception::FailedToAllocateRegister();
 }
 
 int _allocTempXMMreg(XMMSSEType type, int xmmreg) {
@@ -143,9 +143,6 @@ int _allocTempXMMreg(XMMSSEType type, int xmmreg) {
 		xmmreg = _getFreeXMMreg();
 	else
 		_freeXMMreg(xmmreg);
-
-	if (xmmreg == -1)
-		return -1;
 
 	xmmregs[xmmreg].inuse = 1;
 	xmmregs[xmmreg].type = XMMTYPE_TEMP;
@@ -193,9 +190,6 @@ int _allocVFtoXMMreg(VURegs *VU, int xmmreg, int vfreg, int mode) {
 		xmmreg = _getFreeXMMreg();
 	else
 		_freeXMMreg(xmmreg);
-
-	if (xmmreg == -1)
-		return -1;
 
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;
@@ -279,9 +273,6 @@ int _allocACCtoXMMreg(VURegs *VU, int xmmreg, int mode) {
 	else
 		_freeXMMreg(xmmreg);
 
-	if (xmmreg == -1)
-		return -1;
-
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;
 	xmmregs[xmmreg].type = XMMTYPE_ACC;
@@ -322,8 +313,8 @@ int _allocFPtoXMMreg(int xmmreg, int fpreg, int mode) {
 		return i;
 	}
 
-	if (xmmreg == -1) xmmreg = _getFreeXMMreg();
-	if (xmmreg == -1) return -1;
+	if (xmmreg == -1)
+		xmmreg = _getFreeXMMreg();
 
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;
@@ -388,8 +379,8 @@ int _allocGPRtoXMMreg(int xmmreg, int gprreg, int mode)
 		g_cpuHasConstReg &= ~(1<<gprreg);
 	}
 
-	if (xmmreg == -1) xmmreg = _getFreeXMMreg();
-	if (xmmreg == -1) return -1;
+	if (xmmreg == -1)
+		xmmreg = _getFreeXMMreg();
 
 	g_xmmtypes[xmmreg] = XMMT_INT;
 	xmmregs[xmmreg].inuse = 1;
@@ -468,8 +459,6 @@ int _allocFPACCtoXMMreg(int xmmreg, int mode)
 
 	if (xmmreg == -1)
 		xmmreg = _getFreeXMMreg();
-	if (xmmreg == -1)
-		return -1;
 
 	g_xmmtypes[xmmreg] = XMMT_FPS;
 	xmmregs[xmmreg].inuse = 1;

--- a/pcsx2/x86/ix86-32/iCore-32.cpp
+++ b/pcsx2/x86/ix86-32/iCore-32.cpp
@@ -155,8 +155,7 @@ int _getFreeX86reg(int mode)
 	}
 
 	pxFailDev( "x86 register allocation error" );
-
-	return -1;
+	throw Exception::FailedToAllocateRegister();
 }
 
 void _flushCachedRegs()
@@ -310,9 +309,6 @@ int _allocX86reg(int x86reg, int type, int reg, int mode)
 		x86reg = _getFreeX86reg(oldmode);
 	else
 		_freeX86reg(x86reg);
-
-	if (x86reg == -1)
-		return -1;
 
 	x86regs[x86reg].type = type;
 	x86regs[x86reg].reg = reg;
@@ -545,7 +541,7 @@ int  _getFreeMMXreg()
 	}
 
 	pxFailDev( "mmx register allocation error" );
-	return -1;
+	throw Exception::FailedToAllocateRegister();
 }
 
 int _allocMMXreg(int mmxreg, int reg, int mode)
@@ -586,8 +582,8 @@ int _allocMMXreg(int mmxreg, int reg, int mode)
 		}
 	}
 
-	if (mmxreg == -1) mmxreg = _getFreeMMXreg();
-	if (mmxreg == -1) return -1;
+	if (mmxreg == -1)
+		mmxreg = _getFreeMMXreg();
 
 	mmxregs[mmxreg].inuse = 1;
 	mmxregs[mmxreg].reg = reg;

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1476,7 +1476,20 @@ void recompileNextInstruction(int delayslot)
 	else {
 		//If the COP0 DIE bit is disabled, cycles should be doubled.
 		s_nBlockCycles += opcode.cycles * (2 - ((cpuRegs.CP0.n.Config >> 18) & 0x1));
-		opcode.recompile();
+		try {
+			opcode.recompile();
+		} catch (Exception::FailedToAllocateRegister&) {
+			// TODO: fallback to interpreter
+#if 0
+			iFlushCall(FLUSH_INTERPRETER);
+			CALLFunc( (uptr)R5900::Interpreter::OpcodeImpl::MMI::PMFHL );
+#endif
+			// TODO: Free register ?
+#if 0
+			//	_freeXMMregs();
+			//	_freeMMXregs();
+#endif
+		}
 	}
 
 	if( !delayslot ) {

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1479,13 +1479,10 @@ void recompileNextInstruction(int delayslot)
 		try {
 			opcode.recompile();
 		} catch (Exception::FailedToAllocateRegister&) {
-			// TODO: fallback to interpreter
+			// Fall back to the interpreter
+			recCall(opcode.interpret);
 #if 0
-			iFlushCall(FLUSH_INTERPRETER);
-			CALLFunc( (uptr)R5900::Interpreter::OpcodeImpl::MMI::PMFHL );
-#endif
 			// TODO: Free register ?
-#if 0
 			//	_freeXMMregs();
 			//	_freeMMXregs();
 #endif


### PR DESCRIPTION
Avoid the cost of checking -1 for a very rare case.

It misses currently a good fallback

@refractionpcsx2, 
What do you think about it? Maybe we can just call opcode.interpret but I'm not sure.