### PR TITLE
Linux GUI: Fix invalid cast from 'wxPizza' to 'GtkBin'.

### DIFF
--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -973,7 +973,7 @@ void Pcsx2App::OpenGsPanel()
 #if wxMAJOR_VERSION < 3
 	GtkWidget *child_window = gtk_bin_get_child(GTK_BIN(gsFrame->GetViewport()->GetHandle()));
 #else
-	GtkWidget *child_window = (GtkWidget*)GTK_BIN(gsFrame->GetViewport()->GetHandle());
+	GtkWidget *child_window = GTK_WIDGET(gsFrame->GetViewport()->GetHandle());
 #endif
 
 	gtk_widget_realize(child_window); // create the widget to allow to use GDK_WINDOW_* macro


### PR DESCRIPTION
(PCSX2:32189): GLib-GObject-WARNING **: invalid cast from 'wxPizza' to 'GtkBin'
.
Cast the wxPizza directly to a GtkWidget. Looking at the wx3.0 source code the pizza
constructor returns a GtkWidget. Also GetHandle() returns a GtkWidget:
http://docs.wxwidgets.org/trunk/classwx_window.html#a185e6cd7065367b552748cb722651b27

Alternatively it could be like this which should handle 2.8 & 3.0:

```
GtkWidget *child_window = null;
if(GTK_IS_BIN(gsFrame->GetViewport()->GetHandle())) {
    *child_window = gtk_bin_get_child(GTK_BIN(gsFrame->GetViewport()->GetHandle()));
}
else {
    *child_window = GTK_WIDGET(gsFrame->GetViewport()->GetHandle());
}
