### PR TITLE
Gs renderer enum & default renderer handling

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -62,7 +62,7 @@ extern bool RunLinuxDialog();
 static GSRenderer* s_gs = NULL;
 static void (*s_irq)() = NULL;
 static uint8* s_basemem = NULL;
-static int s_renderer = -1;
+static GSRendererType s_renderer = GSRendererType::Undefined;
 static bool s_framelimit = true;
 static bool s_vsync = false;
 static bool s_exclusive = true;
@@ -146,7 +146,7 @@ EXPORT_C GSshutdown()
 
 	s_gs = NULL;
 
-	s_renderer = -1;
+	s_renderer = GSRendererType::Undefined;
 
 #ifdef _WINDOWS
 
@@ -180,13 +180,13 @@ EXPORT_C GSclose()
 	}
 }
 
-static int _GSopen(void** dsp, char* title, int renderer, int threads = -1)
+static int _GSopen(void** dsp, char* title, GSRendererType renderer, int threads = -1)
 {
 	GSDevice* dev = NULL;
 
-	if(renderer == -1)
+	if(renderer == GSRendererType::Undefined)
 	{
-		renderer = theApp.GetConfig("Renderer", 0);
+		renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
 	}
 
 	if(threads == -1)
@@ -211,13 +211,21 @@ static int _GSopen(void** dsp, char* title, int renderer, int threads = -1)
 
 		switch (renderer)
 		{		
-		case 1: case 4: case 10: case 13:
+		case GSRendererType::DX9_SW:
+		case GSRendererType::DX1011_SW:
+		case GSRendererType::Null_SW:
+		case GSRendererType::OGL_SW:
 			s_type_log = "(Software mode)";
 			break;
-		case 2: case 5: case 11:
+		case GSRendererType::DX9_Null:
+		case GSRendererType::DX1011_Null:
+		case GSRendererType::Null_Null:
 			s_type_log = "(Null mode)";
 			break;
-		case 14: case 15: case 16: case 17:
+		case GSRendererType::DX9_OpenCL:
+		case GSRendererType::DX1011_OpenCL:
+		case GSRendererType::Null_OpenCL:
+		case GSRendererType::OGL_OpenCL:
 			s_type_log = "(OpenCL)";
 			break;
 		default:
@@ -229,21 +237,32 @@ static int _GSopen(void** dsp, char* title, int renderer, int threads = -1)
 		{
 		default:
 #ifdef _WINDOWS
-		case 0: case 1: case 2: case 14:
+		case GSRendererType::DX9_HW:
+		case GSRendererType::DX9_SW:
+		case GSRendererType::DX9_Null:
+		case GSRendererType::DX9_OpenCL:
 			dev = new GSDevice9();
 			s_renderer_name = " D3D9";
 			printf("\n Current Renderer: Direct3D9%s \n", s_type_log);
 			break;
-		case 3: case 4: case 5: case 15:
+		case GSRendererType::DX1011_HW:
+		case GSRendererType::DX1011_SW:
+		case GSRendererType::DX1011_Null:
+		case GSRendererType::DX1011_OpenCL:
 			dev = new GSDevice11();
 			s_renderer_name = " D3D11";
 			printf("\n Current Renderer: Direct3D11%s \n", s_type_log);
 			break;
 #endif
-		case 9: case 10: case 11: case 16:
+		case GSRendererType::Null_HW:
+		case GSRendererType::Null_SW:
+		case GSRendererType::Null_Null:
+		case GSRendererType::Null_OpenCL:
 			dev = new GSDeviceNull();
 			break;
-		case 12: case 13: case 17:
+		case GSRendererType::OGL_HW:
+		case GSRendererType::OGL_SW:
+		case GSRendererType::OGL_OpenCL:
 			dev = new GSDeviceOGL();
 			s_renderer_name = " OGL";
 			printf("\n Current Renderer: OpenGL%s \n", s_type_log);
@@ -261,28 +280,36 @@ static int _GSopen(void** dsp, char* title, int renderer, int threads = -1)
 			{
 			default:
 #ifdef _WINDOWS
-			case 0:
+			case GSRendererType::DX9_HW:
 				s_gs = (GSRenderer*)new GSRendererDX9();
 				s_renderer_type = " HW";
 				break;
-			case 3:
+			case GSRendererType::DX1011_HW:
 				s_gs = (GSRenderer*)new GSRendererDX11();
 				s_renderer_type = " HW";
 				break;
 #endif
-			case 12:
+			case GSRendererType::OGL_HW:
 				s_gs = (GSRenderer*)new GSRendererOGL();
 				s_renderer_type = " HW";
 				break;
-			case 1: case 4: case 10: case 13:
+			case GSRendererType::DX9_SW:
+			case GSRendererType::DX1011_SW:
+			case GSRendererType::Null_SW:
+			case GSRendererType::OGL_SW:
 				s_gs = new GSRendererSW(threads);
 				s_renderer_type = " SW";
 				break;
-			case 2: case 5: case 11:
+			case GSRendererType::DX9_Null:
+			case GSRendererType::DX1011_Null:
+			case GSRendererType::Null_Null:
 				s_gs = new GSRendererNull();
 					s_renderer_type = " Null";
 				break;
-			case 14: case 15: case 16: case 17:
+			case GSRendererType::DX9_OpenCL:
+			case GSRendererType::DX1011_OpenCL:
+			case GSRendererType::Null_OpenCL:
+			case GSRendererType::OGL_OpenCL:
 #ifdef ENABLE_OPENCL
 				s_gs = new GSRendererCL();
 				s_renderer_type = " OCL";
@@ -302,7 +329,9 @@ static int _GSopen(void** dsp, char* title, int renderer, int threads = -1)
 #ifdef _WINDOWS
 			switch (renderer)
 			{
-			case 12: case 13: case 17:
+			case GSRendererType::OGL_HW:
+			case GSRendererType::OGL_SW:
+			case GSRendererType::OGL_OpenCL:
 				s_gs->m_wnd = new GSWndWGL();
 				break;
 			default:
@@ -442,7 +471,7 @@ static int _GSopen(void** dsp, char* title, int renderer, int threads = -1)
 		return -1;
 	}
 
-	if (renderer == 12 && theApp.GetConfig("debug_glsl_shader", 0) == 2) {
+	if (renderer == GSRendererType::OGL_HW && theApp.GetConfig("debug_glsl_shader", 0) == 2) {
 		printf("GSdx: test OpenGL shader. Please wait...\n\n");
 		static_cast<GSDeviceOGL*>(s_gs->m_dev)->SelfShaderTest();
 		printf("\nGSdx: test OpenGL shader done. It will now exit\n");
@@ -457,39 +486,37 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	static bool stored_toggle_state = false;
 	bool toggle_state = !!(flags & 4);
 
-	int renderer = s_renderer;
+	GSRendererType renderer = s_renderer;
 	// Fresh start up or config file changed
-	if (renderer == -1)
+	if (renderer == GSRendererType::Undefined)
 	{
-#ifdef __linux__
-		// Use ogl renderer as default otherwise it crash at startup
-		// GSRenderOGL only GSDeviceOGL (not GSDeviceNULL)
-		renderer = theApp.GetConfig("Renderer", 12);
-#else
-		renderer = theApp.GetConfig("Renderer", 0);
-#endif
+		renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
 	}
 	else if (stored_toggle_state != toggle_state)
 	{
 #ifdef _WIN32
-		int best_sw_renderer = GSUtil::CheckDirect3D11Level() >= D3D_FEATURE_LEVEL_10_0 ? 4 : 1; // dx11 / dx9 sw
+		GSRendererType best_sw_renderer = GSUtil::CheckDirect3D11Level() >= D3D_FEATURE_LEVEL_10_0 ? GSRendererType::DX1011_SW : GSRendererType::DX9_SW;
 
-		switch(renderer){
-			// Use alternative renderer (SW if currently using HW renderer, and vice versa, keeping the same DX level)
-			case 1: renderer = 0; break; // DX9:  SW to HW
-			case 0: renderer = 1; break; // DX9:  HW to SW
-			case 4: renderer = 3; break; // DX11: SW to HW
-			case 3: renderer = 4; break; // DX11: HW to SW
-			case 13: renderer = 12; break; // OGL: SW to HW
-			case 12: renderer = 13; break; // OGL: HW to SW
-			default: renderer = best_sw_renderer; // If wasn't using DX (e.g. SDL), use best SW renderer.
+
+		switch (renderer) {
+			// Use alternative renderer (SW if currently using HW renderer, and vice versa, keeping the same API and API version)
+		case GSRendererType::DX9_SW: renderer = GSRendererType::DX9_HW; break;
+		case GSRendererType::DX9_HW: renderer = GSRendererType::DX9_SW; break;
+		case GSRendererType::DX1011_SW: renderer = GSRendererType::DX1011_HW; break;
+		case GSRendererType::DX1011_HW: renderer = GSRendererType::DX1011_SW; break;
+		case GSRendererType::OGL_SW: renderer = GSRendererType::OGL_HW; break;
+		case GSRendererType::OGL_HW: renderer = GSRendererType::OGL_SW; break;
+		default: renderer = best_sw_renderer; break;// If wasn't using one of the above mentioned ones, use best SW renderer.
+
 		}
 
 #endif
 #ifdef __linux__
 		switch(renderer) {
-			case 13: renderer = 12; break; // OGL: SW to HW
-			case 12: renderer = 13; break; // OGL: HW to SW
+			// Use alternative renderer (SW if currently using HW renderer, and vice versa)
+		case GSRendererType::OGL_SW: renderer = GSRendererType::OGL_HW; break;
+		case GSRendererType::OGL_HW: renderer = GSRendererType::OGL_SW; break;
+		default: renderer = GSRendererType::OGL_SW; break; // fallback to OGL SW
 		}
 #endif
 	}
@@ -515,7 +542,7 @@ EXPORT_C_(int) GSopen(void** dsp, char* title, int mt)
 	XCloseDisplay(display);
 	*/
 
-	int renderer = 0;
+	GSRendererType renderer = GSRendererType::Default;
 
 	// Legacy GUI expects to acquire vsync from the configuration files.
 
@@ -527,7 +554,7 @@ EXPORT_C_(int) GSopen(void** dsp, char* title, int mt)
 
 #ifdef _WINDOWS
 
-		renderer = GSUtil::CheckDirect3D11Level() >= D3D_FEATURE_LEVEL_10_0 ? 4 : 1; // dx11 / dx9 sw
+		renderer = GSUtil::CheckDirect3D11Level() >= D3D_FEATURE_LEVEL_10_0 ? GSRendererType::DX1011_SW : GSRendererType::DX9_SW;
 
 #endif
 
@@ -537,7 +564,7 @@ EXPORT_C_(int) GSopen(void** dsp, char* title, int mt)
 	{
 		// normal init
 
-		renderer = theApp.GetConfig("Renderer", 0);
+		renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
 	}
 
 	*dsp = NULL;
@@ -779,7 +806,7 @@ EXPORT_C GSconfigure()
 				GSshutdown();
 			}
 			// Force a reload of the gs state
-			s_renderer = -1;
+			s_renderer = GSRendererType::Undefined;
 		}
 
 #else
@@ -787,7 +814,7 @@ EXPORT_C GSconfigure()
 		if (RunLinuxDialog()) {
 			theApp.ReloadConfig();
 			// Force a reload of the gs state
-			s_renderer = -1;
+			s_renderer = GSRendererType::Undefined;
 		}
 
 #endif
@@ -1030,13 +1057,13 @@ public:
 
 EXPORT_C GSReplay(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int nCmdShow)
 {
-	int renderer = -1;
+	GSRendererType renderer = GSRendererType::Undefined;
 
 	{
 		char* start = lpszCmdLine;
 		char* end = NULL;
 		long n = strtol(lpszCmdLine, &end, 10);
-		if(end > start) {renderer = n; lpszCmdLine = end;}
+		if(end > start) {renderer = static_cast<GSRendererType>(n); lpszCmdLine = end;}
 	}
 
 	while(*lpszCmdLine == ' ') lpszCmdLine++;
@@ -1496,11 +1523,15 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 {
 	GLLoader::in_replayer = true;
 
-	// Allow to easyly switch between SW/HW renderer
-	renderer = theApp.GetConfig("Renderer", 12);
-	if (renderer != 12 && renderer != 13)
+	GSRendererType m_renderer;
+	// Allow to easyly switch between SW/HW renderer -> this effectively removes the ability to select the renderer by function args
+	m_renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+	// alternatively:
+	// m_renderer = static_cast<GSRendererType>(renderer);
+
+	if (m_renderer != GSRendererType::OGL_HW && m_renderer != GSRendererType::OGL_SW)
 	{
-		fprintf(stderr, "wrong renderer selected %d\n", renderer);
+		fprintf(stderr, "wrong renderer selected %d\n", static_cast<int>(m_renderer));
 		return;
 	}
 
@@ -1520,7 +1551,7 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 
 	void* hWnd = NULL;
 
-	int err = _GSopen((void**)&hWnd, "", renderer);
+	int err = _GSopen((void**)&hWnd, "", m_renderer);
 	if (err != 0) {
 		fprintf(stderr, "Error failed to GSopen\n");
 		return;

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -216,6 +216,40 @@ enum GS_AFAIL
 	AFAIL_RGB_ONLY	= 3,
 };
 
+enum class GSRendererType : int8_t
+{
+	Undefined = -1,
+
+	DX9_HW = 0,
+	DX9_SW = 1,
+	DX9_OpenCL = 14,
+	DX9_Null = 2,
+
+	DX1011_HW = 3,
+	DX1011_SW = 4,
+	DX1011_OpenCL = 15,
+	DX1011_Null = 5,
+
+	Null_HW = 9,
+	Null_SW = 10,
+	Null_OpenCL = 16,
+	Null_Null = 11,
+
+	OGL_HW = 12,
+	OGL_SW = 13,
+	OGL_OpenCL = 17,
+
+#ifdef _WINDOWS
+	Default = DX9_HW
+#else
+	// Use ogl renderer as default otherwise it crash at startup
+	// GSRenderOGL only GSDeviceOGL (not GSDeviceNULL)
+	Default = OGL_HW
+#endif
+
+};
+
+
 #define REG32(name) \
 union name			\
 {					\

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -21,6 +21,7 @@
 
 #include "stdafx.h"
 #include <gtk/gtk.h>
+#include "GS.h"
 #include "GSdx.h"
 #include "GSLinuxLogo.h"
 #include "GSSetting.h"
@@ -38,17 +39,16 @@ void CB_ChangedRenderComboBox(GtkComboBox *combo, gpointer user_data)
 {
 	if (gtk_combo_box_get_active(combo) == -1) return;
 
-	// Note the value are based on m_gs_renderers vector on GSdx.cpp
 	switch (gtk_combo_box_get_active(combo)) {
-		case 0: theApp.SetConfig("Renderer", 10); break;
-		case 1: theApp.SetConfig("Renderer", 16); break;
-		case 2: theApp.SetConfig("Renderer", 11); break;
-		case 3: theApp.SetConfig("Renderer", 12); break;
-		case 4: theApp.SetConfig("Renderer", 13); break;
-		case 5: theApp.SetConfig("Renderer", 17); break;
+	case 0: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::Null_SW)); break;
+	case 1: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::Null_OpenCL)); break;
+	case 2: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::Null_Null)); break;
+	case 3: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_HW)); break;
+	case 4: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_SW)); break;
+	case 5: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_OpenCL)); break;
 
 				// Fallback to SW opengl
-		default: theApp.SetConfig("Renderer", 13); break;
+	default: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_SW)); break;
 	}
 }
 
@@ -64,38 +64,37 @@ GtkWidget* CreateRenderComboBox()
 		if(!s->note.empty()) label += format(" (%s)", s->note.c_str());
 
 		// Add some tags to ease users selection
-		switch (s->id) {
+		switch (static_cast<GSRendererType>(s->id)) {
 			// Supported opengl
-			case 12:
-			case 13:
-			case 17:
-				break;
+		case GSRendererType::OGL_HW:
+		case GSRendererType::OGL_SW:
+		case GSRendererType::OGL_OpenCL:
+			break;
 
 			// (dev only) for any NULL stuff
-			case 10:
-			case 11:
-			case 16:
-				label += " (debug only)";
-				break;
+		case GSRendererType::Null_SW:
+		case GSRendererType::Null_OpenCL:
+		case GSRendererType::Null_Null:
+			label += " (debug only)";
+			break;
 
-			default:
-				continue;
+		default:
+			continue;
 		}
 
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(render_combo_box), label.c_str());
 	}
 
-	switch (theApp.GetConfig("Renderer", 0)) {
-		// Note the value are based on m_gs_renderers vector on GSdx.cpp
-		case 10: renderer_box_position = 0; break;
-		case 16: renderer_box_position = 1; break;
-		case 11: renderer_box_position = 2; break;
-		case 12: renderer_box_position = 3; break;
-		case 13: renderer_box_position = 4; break;
-		case 17: renderer_box_position = 5; break;
+	switch (static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)))) {
+	case GSRendererType::Null_SW:		renderer_box_position = 0; break;
+	case GSRendererType::Null_OpenCL:	renderer_box_position = 1; break;
+	case GSRendererType::Null_Null:		renderer_box_position = 2; break;
+	case GSRendererType::OGL_HW:		renderer_box_position = 3; break;
+	case GSRendererType::OGL_SW:		renderer_box_position = 4; break;
+	case GSRendererType::OGL_OpenCL:	renderer_box_position = 5; break;
 
-		// Fallback to openGL SW
-		default: renderer_box_position = 4; break;
+	// Fallback to openGL SW
+	default: renderer_box_position = 4; break;
 	}
 	gtk_combo_box_set_active(GTK_COMBO_BOX(render_combo_box), renderer_box_position);
 

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -356,14 +356,16 @@ void GSSettingsDlg::UpdateRenderers()
 
 	vector<GSSetting> renderers;
 
-	unsigned renderer_setting = theApp.GetConfig("Renderer", 0);
-	unsigned renderer_sel = 0;
+	GSRendererType renderer_setting = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+	GSRendererType renderer_sel = GSRendererType::Default;
 
 	for(size_t i = 0; i < theApp.m_gs_renderers.size(); i++)
 	{
 		GSSetting r = theApp.m_gs_renderers[i];
 
-		if(r.id >= 3 && r.id <= 5 || r.id == 15)
+		GSRendererType renderer = static_cast<GSRendererType>(r.id);
+
+		if(renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::DX1011_Null || renderer == GSRendererType::DX1011_OpenCL)
 		{
 			if(level < D3D_FEATURE_LEVEL_10_0) continue;
 
@@ -372,13 +374,13 @@ void GSSettingsDlg::UpdateRenderers()
 
 		renderers.push_back(r);
 
-		if(r.id == renderer_setting)
+		if (static_cast<GSRendererType>(r.id) == renderer_setting)
 		{
 			renderer_sel = renderer_setting;
 		}
 	}
 
-	ComboBoxInit(IDC_RENDERER, renderers, renderer_sel);
+	ComboBoxInit(IDC_RENDERER, renderers, static_cast<uint32>(renderer_sel));
 }
 
 void GSSettingsDlg::UpdateControls()
@@ -394,13 +396,15 @@ void GSSettingsDlg::UpdateControls()
 
 	if(ComboBoxGetSelData(IDC_RENDERER, i))
 	{
-		bool dx9 = i >= 0 && i <= 2 || i == 14;
-		bool dx11 = i >= 3 && i <= 5 || i == 15;
-		bool ogl = i >= 12 && i <= 13 || i == 17;
-		bool hw = i == 0 || i == 3 || i == 12;
-		//bool sw = i == 1 || i == 4 || i == 10 || i == 13;
-		bool ocl = i >= 14 && i <= 17;
+		GSRendererType renderer = static_cast<GSRendererType>(i);
 
+		bool dx9 = renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX9_SW || renderer == GSRendererType::DX9_Null || renderer == GSRendererType::DX9_OpenCL;
+		bool dx11 = renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::DX1011_Null || renderer == GSRendererType::DX1011_OpenCL;
+		bool ogl = renderer == GSRendererType::OGL_HW || renderer == GSRendererType::OGL_SW || renderer == GSRendererType::OGL_OpenCL;
+
+		bool hw = renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::OGL_HW || renderer == GSRendererType::Null_HW;
+		//bool sw = renderer == GSRendererType::DX9_SW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::OGL_SW  || renderer == GSRendererType::Null_SW
+		bool ocl = renderer == GSRendererType::DX9_OpenCL || renderer == GSRendererType::DX1011_OpenCL || renderer == GSRendererType::Null_OpenCL || renderer == GSRendererType::OGL_OpenCL;
 
 		ShowWindow(GetDlgItem(m_hWnd, IDC_LOGO9), dx9 ? SW_SHOW : SW_HIDE);
 		ShowWindow(GetDlgItem(m_hWnd, IDC_LOGO11), dx11 ? SW_SHOW : SW_HIDE);
@@ -580,11 +584,11 @@ GSHacksDlg::GSHacksDlg() :
 void GSHacksDlg::OnInit()
 {
 	HWND hwnd_renderer = GetDlgItem(GetParent(m_hWnd), IDC_RENDERER);
-	int renderer = SendMessage(hwnd_renderer, CB_GETITEMDATA, SendMessage(hwnd_renderer, CB_GETCURSEL, 0, 0), 0);
+	GSRendererType renderer = static_cast<GSRendererType>(SendMessage(hwnd_renderer, CB_GETITEMDATA, SendMessage(hwnd_renderer, CB_GETCURSEL, 0, 0), 0));
 	// It can only be accessed with a HW renderer, so this is sufficient.
-	bool dx9 = renderer == 0;
-	// bool dx11 = renderer == 3;
-	bool ogl = renderer == 12;
+	bool dx9 = renderer == GSRendererType::DX9_HW;
+	// bool dx11 = renderer == GSRendererType::DX1011_HW;
+	bool ogl = renderer == GSRendererType::OGL_HW;
 	unsigned short cb = 0;
 
 	if(dx9) for(unsigned short i = 0; i < 17; i++)

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -27,14 +27,14 @@ bool s_IS_OPENGL = false;
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
 {
-	s_IS_OPENGL = (theApp.GetConfig("Renderer", 12) == 12);
+	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default))) == GSRendererType::OGL_HW);
 
 	m_spritehack = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_SpriteHack", 0) : 0;
 	UserHacks_HalfPixelOffset = !!theApp.GetConfig("UserHacks", 0) && !!theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
 
 	m_paltex = !!theApp.GetConfig("paltex", 0);
 	m_preload_frame = theApp.GetConfig("preload_frame_with_gs_data", 0);
-	m_can_convert_depth = theApp.GetConfig("Renderer", 12) == 12 ? theApp.GetConfig("texture_cache_depth", 1) : 0;
+	m_can_convert_depth = s_IS_OPENGL ? theApp.GetConfig("texture_cache_depth", 1) : 0;
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
 	
 	m_temp = (uint8*)_aligned_malloc(1024 * 1024 * sizeof(uint32), 32);

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -21,6 +21,7 @@
 
 #include "stdafx.h"
 #include "GSdx.h"
+#include "GS.h"
 
 static void* s_hModule;
 
@@ -127,20 +128,20 @@ GSdxApp::GSdxApp()
 	m_ini = "inis/GSdx.ini";
 	m_section = "Settings";
 
-	m_gs_renderers.push_back(GSSetting(0, "Direct3D9", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(1, "Direct3D9", "Software"));
-	m_gs_renderers.push_back(GSSetting(14, "Direct3D9", "OpenCL"));
-	m_gs_renderers.push_back(GSSetting(2, "Direct3D9", "Null"));
-	m_gs_renderers.push_back(GSSetting(3, "Direct3D", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(4, "Direct3D", "Software"));
-	m_gs_renderers.push_back(GSSetting(15, "Direct3D", "OpenCL"));
-	m_gs_renderers.push_back(GSSetting(5, "Direct3D", "Null"));
-	m_gs_renderers.push_back(GSSetting(10, "Null", "Software"));
-	m_gs_renderers.push_back(GSSetting(16, "Null", "OpenCL"));
-	m_gs_renderers.push_back(GSSetting(11, "Null", "Null"));
-	m_gs_renderers.push_back(GSSetting(12, "OpenGL", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(13, "OpenGL", "Software"));
-	m_gs_renderers.push_back(GSSetting(17, "OpenGL", "OpenCL"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_HW),			"Direct3D9",	"Hardware"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_SW),			"Direct3D9",	"Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_OpenCL),		"Direct3D9",	"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_Null),		"Direct3D9",	"Null"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_HW),		"Direct3D",		"Hardware"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_SW),		"Direct3D",		"Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_OpenCL),	"Direct3D",		"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_Null),	"Direct3D",		"Null"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null_SW),		"Null",			"Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null_OpenCL),	"Null",			"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null_Null),		"Null",			"Null"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW),			"OpenGL",		"Hardware"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW),			"OpenGL",		"Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_OpenCL),		"OpenGL",		"OpenCL"));
 
 	m_gs_interlace.push_back(GSSetting(0, "None", ""));
 	m_gs_interlace.push_back(GSSetting(1, "Weave tff", "saw-tooth"));


### PR DESCRIPTION
1. Add a strongly typed enum representing possible renderers.
2. Replace all instances of int/unit usage by this enum
3. Define a default renderer to prevent misuse of default values

All changes should only appear as code cosmetics considering current implementation and not change the behavior of the code itsself.