### PR TITLE
Spu sdl api config

### DIFF
--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -130,7 +130,7 @@ void ReadSettings()
 #if SDL_MAJOR_VERSION >= 2
 	// YES It sucks ...
 	for (int i = 0; i < SDL_GetNumAudioDrivers(); ++i) {
-		if (!temp.Cmp(SDL_GetAudioDriver(i)))
+		if (!temp.Cmp(wxString(SDL_GetAudioDriver(i), wxConvUTF8)))
 			SdlOutputAPI = i;
 	}
 #endif
@@ -364,7 +364,7 @@ void DisplayDialog()
 		if (gtk_combo_box_get_active(GTK_COMBO_BOX(sdl_api_box)) != -1) {
 			SdlOutputAPI = gtk_combo_box_get_active(GTK_COMBO_BOX(sdl_api_box));
 			// YES It sucks ...
-			SDLOut->SetApiSettings(wxString(SDL_GetAudioDriver(SdlOutputAPI)));
+			SDLOut->SetApiSettings(wxString(SDL_GetAudioDriver(SdlOutputAPI), wxConvUTF8));
 		}
 #endif
 

--- a/plugins/spu2-x/src/SndOut_SDL.cpp
+++ b/plugins/spu2-x/src/SndOut_SDL.cpp
@@ -27,11 +27,7 @@
  * build wx without sdl support, though) and onepad at the time of writing this. */
 #include <SDL.h>
 #include <SDL_audio.h>
-#if SDL_MAJOR_VERSION >= 2
-typedef StereoOut32 StereoOut_SDL;
-#else
 typedef StereoOut16 StereoOut_SDL;
-#endif
 
 namespace {
 	/* Since spu2 only ever outputs stereo, we don't worry about emitting surround sound
@@ -42,12 +38,7 @@ namespace {
 	 * sample count and SDL may provide otherwise. Pulseaudio will cut this value in half if
 	 * PA_STREAM_ADJUST_LATENCY is set in the backened, for example. */
 	const Uint16 desiredSamples = 1024;
-	const Uint16 format =
-#if SDL_MAJOR_VERSION >= 2
-		AUDIO_S32SYS;
-#else
-		AUDIO_S16SYS;
-#endif
+	const Uint16 format = AUDIO_S16SYS;
 
 	Uint16 samples = desiredSamples;
 

--- a/plugins/spu2-x/src/SndOut_SDL.cpp
+++ b/plugins/spu2-x/src/SndOut_SDL.cpp
@@ -133,19 +133,19 @@ struct SDLAudioMod : public SndOutModule {
 	}
 
 	void WriteSettings() const {
-		CfgWriteStr(L"SDL", L"HostApi", m_api);
+		CfgWriteStr(L"SDL", L"HostApi", wxString(m_api.c_str(), wxConvUTF8));
 	};
 
 	void SetApiSettings(wxString api) {
 #if SDL_MAJOR_VERSION >= 2
 		// Validate the api name
 		bool valid = false;
-		std::string api_name = std::string(api);
+		std::string api_name = std::string(api.utf8_str());
 		for (int i = 0; i < SDL_GetNumAudioDrivers(); ++i) {
 			valid |= (api_name.compare(SDL_GetAudioDriver(i)) == 0);
 		}
 		if (valid) {
-			m_api = api;
+			m_api = api.utf8_str();
 		} else {
 			std::cerr	<< "SDL audio driver configuration is invalid!" << std::endl
 						<< "It will be replaced by pulseaudio!" << std::endl;


### PR DESCRIPTION
With the recent SDL2 migration some users complain of soiund issue with SPU2X.

This quick & dirty PR adds a way to select the API of the SDL module. Hopefully one of them will actually work as expeced.