### PR TITLE
gsdx: compute device size based on the clock configuration

### DIFF
--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -431,14 +431,17 @@ void populate_hack_table(GtkWidget* hack_table)
 
 void populate_main_table(GtkWidget* main_table)
 {
-	GtkWidget* render_label     = gtk_label_new ("Renderer:");
-	GtkWidget* render_combo_box = CreateRenderComboBox();
+	GtkWidget* render_label        = gtk_label_new ("Renderer:");
+	GtkWidget* render_combo_box    = CreateRenderComboBox();
 	GtkWidget* interlace_label     = gtk_label_new ("Interlacing (F5):");
 	GtkWidget* interlace_combo_box = CreateComboBoxFromVector(theApp.m_gs_interlace, "interlace", 7);
+	GtkWidget* crtc_size_label     = gtk_label_new("CRTC resolution:");
+	GtkWidget* crtc_size_combo_box = CreateComboBoxFromVector(theApp.m_gs_crtc_size, "crtc_size", 0);
 
 	s_table_line = 0;
 	InsertWidgetInTable(main_table, render_label, render_combo_box);
 	InsertWidgetInTable(main_table, interlace_label, interlace_combo_box);
+	InsertWidgetInTable(main_table, crtc_size_label, crtc_size_combo_box);
 }
 
 void populate_debug_table(GtkWidget* debug_table)

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -522,6 +522,9 @@ void GSRenderer::VSync(int field)
 			}
 		}
 	}
+
+	// Clean display cache size
+	m_renderered_size = GSVector4i(0);
 }
 
 bool GSRenderer::MakeSnapshot(const string& path)

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -215,12 +215,16 @@ bool GSRenderer::Merge(int field)
 
 		// overscan hack
 
+#if 0
 		if(dr[i].height() > 512) // hmm
 		{
 			int y = GetDeviceSize(i).y;
 			if(m_regs->SMODE2.INT && m_regs->SMODE2.FFMD) y /= 2;
 			r.bottom = r.top + y;
 		}
+#else
+		r.bottom = r.top + GetDeviceSize(i).y;
+#endif
 
 		GSVector4 scale = GSVector4(tex[i]->GetScale()).xyxy();
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -423,12 +423,19 @@ GSVector2i GSState::GetDeviceSize(int i)
 
 	if (m_renderered_size.height() >= 224) {
 		h = std::min(h, m_renderered_size.height());
-		h &= ~0x1F;
+		// Round to 32 pixels. Round a bit above in case the game
+		// didn't renderer in the few latest lines (GitarooMan)
+		// Warning don't round to much above otherwise it will be bad
+		// on Devil May Cry 3...
+		h = (h+15) & ~0x1F;
 
 	}
 
 	if (m_crtc_size) {
-		if (m_crtc_size < h) {
+		// If h is much bigger than m_crtc_size, it probably means that
+		// some kind of interlacing is enabled. In this case divide
+		// m_crtc_size by 2.
+		if ((m_crtc_size - 32) <= h) {
 			h = m_crtc_size;
 		} else {
 			h = m_crtc_size / 2;

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -379,11 +379,13 @@ GSVector4i GSState::GetFrameRect(int i)
 	int w = r.width();
 	int h = r.height();
 
+#if 0
 	//Fixme: These games have an extra black bar at bottom of screen
 	if((m_game.title == CRC::DevilMayCry3 || m_game.title == CRC::SkyGunner) && (m_game.region == CRC::US || m_game.region == CRC::JP))
 	{
 		h = 448; //
 	}
+#endif
 	
 	if(m_regs->SMODE2.INT && m_regs->SMODE2.FFMD && h > 1) h >>= 1;
 
@@ -417,6 +419,20 @@ GSVector2i GSState::GetDeviceSize(int i)
 	int w = r.width();
 	int h = r.height();
 
+	switch (m_regs->SMODE1.CMOD) {
+		case 0: // VESA
+			break;
+		case 1:
+			ASSERT(0);
+			break;
+		case 2: // NTSC
+			h = 448;
+			break;
+		case 3: // PAL
+			h = 512;
+			break;
+	}
+
 	/*if(h == 2 * 416 || h == 2 * 448 || h == 2 * 512)
 	{
 		h /= 2;
@@ -436,6 +452,7 @@ GSVector2i GSState::GetDeviceSize(int i)
 	}
 
 	//Fixme: These games elude the code above, worked with the old hack
+	// GREG note: Maybe the IsEnabled is a bad idea
 	else if(m_game.title == CRC::SilentHill2 || m_game.title == CRC::SilentHill3)
 	{
 		h /= 2; 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -426,13 +426,24 @@ GSVector2i GSState::GetDeviceSize(int i)
 			ASSERT(0);
 			break;
 		case 2: // NTSC
-			h = 448;
+			if (h < 448)
+				h = 224; // KOF2000. Strangely FFMD is set without INT
+			else if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD)
+				h = 224;
+			else
+				h = 448;
 			break;
 		case 3: // PAL
-			h = 512;
+			if (h < 512)
+				h = 256;
+			else if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD)
+				h = 256;
+			else
+				h = 512;
 			break;
 	}
 
+#if 0
 	/*if(h == 2 * 416 || h == 2 * 448 || h == 2 * 512)
 	{
 		h /= 2;
@@ -457,6 +468,7 @@ GSVector2i GSState::GetDeviceSize(int i)
 	{
 		h /= 2; 
 	}
+#endif
 
 	return GSVector2i(w, h);
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -45,6 +45,7 @@ GSState::GSState()
 {
 	m_nativeres = theApp.GetConfig("upscale_multiplier",1) == 1;
 	m_mipmap = !!theApp.GetConfig("mipmap", 1);
+	m_crtc_size = theApp.GetConfig("crtc_size", 0);
 
 	s_n     = 0;
 	s_dump  = !!theApp.GetConfig("dump", 0);
@@ -425,6 +426,15 @@ GSVector2i GSState::GetDeviceSize(int i)
 		h &= ~0x1F;
 
 	}
+
+	if (m_crtc_size) {
+		if (m_crtc_size < h) {
+			h = m_crtc_size;
+		} else {
+			h = m_crtc_size / 2;
+		}
+	}
+
 #if 0
 	switch (m_regs->SMODE1.CMOD) {
 		case 0: // VESA

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -152,6 +152,7 @@ protected:
 	GSVector4i m_ofxy;
 	bool m_texflush;
 	GSVector4i m_renderered_size;
+	int m_crtc_size;
 	
 	struct 
 	{

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -151,6 +151,7 @@ protected:
 	GSVector4i m_scissor;
 	GSVector4i m_ofxy;
 	bool m_texflush;
+	GSVector4i m_renderered_size;
 	
 	struct 
 	{

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -195,6 +195,10 @@ GSdxApp::GSdxApp()
 	m_gs_acc_blend_level.push_back(GSSetting(4, "Full", "Very Slow"));
 	m_gs_acc_blend_level.push_back(GSSetting(5, "Ultra", "Ultra Slow"));
 
+	m_gs_crtc_size.push_back(GSSetting(0, "Auto", "Recommended"));
+	m_gs_crtc_size.push_back(GSSetting(448, "448", ""));
+	m_gs_crtc_size.push_back(GSSetting(512, "512", ""));
+
 	m_gpu_renderers.push_back(GSSetting(0, "Direct3D9 (Software)", ""));
 	m_gpu_renderers.push_back(GSSetting(1, "Direct3D11 (Software)", ""));
 	m_gpu_renderers.push_back(GSSetting(2, "SDL 1.3 (Software)", ""));

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -68,6 +68,7 @@ public:
 	vector<GSSetting> m_gs_hack;
 	vector<GSSetting> m_gs_crc_level;
 	vector<GSSetting> m_gs_acc_blend_level;
+	vector<GSSetting> m_gs_crtc_size;
 
 	vector<GSSetting> m_gpu_renderers;
 	vector<GSSetting> m_gpu_filter;


### PR DESCRIPTION
You can't infer it from the output area buffer. Game could have a bigger
area than the real display

Fix DMC3 and Gitaroo Man

Need testing of (at least) 2000 games