### PR TITLE
pcsx2-ee: disable memory write protection for the first kernel page

### DIFF
--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -931,6 +931,12 @@ int mmap_GetRamPageInfo( u32 paddr )
 	if (rampage >= Ps2MemSize::MainRam)
 		return -1; //not in ram, no tracking done ...
 
+	// EE Kernel is static (but uses a static zone in the
+	// middle to save the register context. Let's keep the
+	// first two pages as unchecked
+	if (rampage < 0x2000)
+		return -1;
+
 	rampage >>= 12;
 	return ( m_PageProtectInfo[rampage].Mode == ProtMode_Manual ) ? 1 : 0;
 }

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -2078,6 +2078,14 @@ StartRecomp:
 			break;
 
         default:
+			if (startpc == 0x81fc0)
+			{
+				// Idle loop (i.e. an empty while(1))
+				// Thread data are stored in 0x81000 so there is always write in this page.
+				// Just take a short-cut
+				break;
+			}
+
 			xMOV( ecx, inpage_ptr );
 			xMOV( edx, pgsz / 4 );
 			//xMOV( eax, startpc );		// uncomment this to access startpc (as eax) in dyna_block_discard
@@ -2102,7 +2110,7 @@ StartRecomp:
 
 			// (ideally, perhaps, manual_counter should be reset to 0 every few minutes?)
 
-			if (startpc != 0x81fc0 && manual_counter[inpage_ptr >> 12] <= 3)
+			if (manual_counter[inpage_ptr >> 12] <= 3)
 			{
 				// Counted blocks add a weighted (by block size) value into manual_page each time they're
 				// run.  If the block gets run a lot, it resets and re-protects itself in the hope


### PR DESCRIPTION
The EE kernel saves register context in a static area (0x80001100-0x80001300).
Therefore it triggers the protection mechanism.

Game can't access the kernel memory area, and the kernel doesn't
morph itself. So it is safe to leave the first page of memory as
unprotected.

It might have a positive impact on performance.