### PR TITLE
EE: Prevent usage of uninitialized scalar variable

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1122,10 +1122,10 @@ static u32 scaleBlockCycles_helper()
 	// caused by sync hacks and such, since games seem to care a lot more about
 	// these small blocks having accurate cycle counts.
 
-	if( s_nBlockCycles <= (5<<3) || (EmuConfig.Speedhacks.EECycleRate == 0) )
+	if( s_nBlockCycles <= (5<<3) || (EmuConfig.Speedhacks.EECycleRate > 99) ) // use default cycle rate if users set more than 99 in INI file.
 		return s_nBlockCycles >> 3;
 
-	uint scalarLow, scalarMid, scalarHigh;
+	uint scalarLow = 0, scalarMid = 0, scalarHigh = 0;
 
 	// Note: larger blocks get a smaller scalar, to help keep
 	// them from becoming "too fat" and delaying branch tests.
@@ -1160,9 +1160,10 @@ static u32 scaleBlockCycles_helper()
 		break;
 
 		// Added insane rates on popular request (rama)
-		// This allows higher values to be set at INI, higher values follows same series as case 0 and case 1.
+		// This allows higher values to be set at INI, Scalar values follow Arithmetic progression on increment to cyclerate.
 		default:
-			if (EmuConfig.Speedhacks.EECycleRate > 2 && EmuConfig.Speedhacks.EECycleRate < 100) {
+			if (EmuConfig.Speedhacks.EECycleRate > 2)
+			{
 				scalarLow = 3 + (2*EmuConfig.Speedhacks.EECycleRate);
 				scalarMid = 5 + (2*EmuConfig.Speedhacks.EECycleRate);
 				scalarHigh = 3 + (2*EmuConfig.Speedhacks.EECycleRate);


### PR DESCRIPTION
Quick fix for the following issues,

* CID 153601 (#1 of 1): Uninitialized scalar variable (UNINIT)7. uninit_use: Using uninitialized value scalarHigh.

* CID 153602 (#1 of 1): Uninitialized scalar variable (UNINIT)7. uninit_use: Using uninitialized value scalarLow.

* CID 153603 (#1 of 1): Uninitialized scalar variable (UNINIT)7. uninit_use: Using uninitialized value scalarMid.

**Summary of changes:-**

-  Remove a duplicated check ``EmuConfig.Speedhacks.EECycleRate == 0`` since the check will eventually be done on the switch case statement. 

- Prevent a chance for uninitialized variable usage when users set more than 100 in INI file. 

actually I thought of fixing these issues at the next update to the overclock function but that would probably take some time so did the fixes now :) , Thanks to @gregory38 for finding the issue. 