### PR TITLE
EE: Rework overclock and underclock function

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1048,7 +1048,7 @@ bool AppConfig::IsOkApplyPreset(int n)
 					vuUsed?0:(vuUsed=true, EmuOptions.Speedhacks.VUCycleSteal = 2);
 		
 		case 4 :	//set EE cyclerate to 2 clicks (maximum)
-					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = 2);
+					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = -2);
 
 		case 3 :	//Set VU cycle steal to 1 click, set VU clamp mode to 'none'
 					vuUsed?0:(vuUsed=true, EmuOptions.Speedhacks.VUCycleSteal = 1);
@@ -1058,7 +1058,7 @@ bool AppConfig::IsOkApplyPreset(int n)
 
 		//best balanced hacks combo?
 		case 2 :	//set EE cyclerate to 1 click.
-					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = 1);
+					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = -1);
 					// EE timing hack appears to break the BIOS text and cause slowdowns in a few titles.
 					//EnableGameFixes = true;
 					//EmuOptions.Gamefixes.EETimingHack = true;

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -24,24 +24,30 @@ const wxChar* Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
 	switch( val )
 	{
 		case -2:
-			return pxEt(L"-2 - Reduces the EE's cyclerate by about 50%.  Moderate speedup, but *will* cause stuttering audio on many FMVs."
-			);
-
+		{
+			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"-2 - Reduces the EE's cyclerate by about 50%.  Moderate speedup, but *will* cause stuttering audio on many FMVs.");
+		}
 		case -1:
-			return pxEt(L"-1 - Reduces the EE's cyclerate by about 33%.  Mild speedup for most games with high compatibility."
-			);
-
+		{
+			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"-1 - Reduces the EE's cyclerate by about 33%.  Mild speedup for most games with high compatibility.");
+		}
 		case 0:
-			return pxEt(L"0 - Default cyclerate. This closely matches the actual speed of a real PS2 EmotionEngine."
-			);
-
+		{
+			m_msg_eecycle->SetForegroundColour(wxColour(14,158,19)); // Dark Green
+			return pxEt(L"0 - Default cyclerate. This closely matches the actual speed of a real PS2 EmotionEngine.");
+		}
 		case 1:
-			return pxEt( L"1 - Increases the EE's cyclerate by about 33%. Increases hardware requirements, may increase in-game FPS."
-			);
-
+		{
+			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"1 - Increases the EE's cyclerate by about 33%. Increases hardware requirements, may increase in-game FPS.");
+		}
 		case 2:
-			return pxEt(L"2 - Increases the EE's cyclerate by about 50%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT."
-			);
+		{
+			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"2 - Increases the EE's cyclerate by about 50%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT.");
+		}
 		default:
 			break;
 	}
@@ -54,21 +60,26 @@ const wxChar* Panels::SpeedHacksPanel::GetVUcycleSliderMsg( int val )
 	switch( val )
 	{
 		case 0:
-			return pxEt( L"0 - Disables VU Cycle Stealing.  Most compatible setting!"
-			);
-
+		{
+			m_msg_vustealer->SetForegroundColour(wxColour(14,158,19)); // Dark Green
+			return pxEt(L"0 - Disables VU Cycle Stealing.  Most compatible setting!");
+		}
 		case 1:
-			return pxEt( L"1 - Mild VU Cycle Stealing.  Lower compatibility, but some speedup for most games."
-			);
-
+		{
+			m_msg_vustealer->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"1 - Mild VU Cycle Stealing.  Lower compatibility, but some speedup for most games.");
+		}
 		case 2:
-			return pxEt( L"2 - Moderate VU Cycle Stealing.  Even lower compatibility, but significant speedups in some games."
-			);
-
+		{
+			m_msg_vustealer->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"2 - Moderate VU Cycle Stealing.  Even lower compatibility, but significant speedups in some games.");
+		}
 		case 3:
+		{
 			// TODO: Mention specific games that benefit from this setting here.
-			return pxEt( L"3 - Maximum VU Cycle Stealing.  Usefulness is limited, as this will cause flickering visuals or slowdown in most games."
-			);
+			m_msg_vustealer->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"3 - Maximum VU Cycle Stealing.  Usefulness is limited, as this will cause flickering visuals or slowdown in most games.");
+		}
 		default:
 			break;
 	}
@@ -119,7 +130,6 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
 
 	m_msg_eecycle = new pxStaticHeading( m_eeSliderPanel );
-	m_msg_eecycle->SetForegroundColour( wxColour( L"Red" ) );
 	m_msg_eecycle->SetHeight(5);
 
 	const wxChar* ee_tooltip = pxEt( L"Setting lower values on this slider effectively reduces the clock speed of the EmotionEngine's R5900 core cpu, and typically brings big speedups to games that fail to utilize the full potential of the real PS2 hardware. Conversely, higher values effectively increase the clock speed which may bring about an increase in in-game FPS while also making games more demanding and possibly causing glitches."
@@ -137,7 +147,6 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 		wxHORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
 
 	m_msg_vustealer = new pxStaticHeading(m_vuSliderPanel);
-	m_msg_vustealer->SetForegroundColour( wxColour( L"Red" ) );
 	m_msg_vustealer->SetHeight(5);
 
 	const wxChar* vu_tooltip = pxEt( L"This slider controls the amount of cycles the VU unit steals from the EmotionEngine.  Higher values increase the number of cycles stolen from the EE for each VU microprogram the game runs."

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -24,25 +24,24 @@ const wxChar* Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
 	switch( val )
 	{
 		case -2:
-			return pxEt( L"-2 - Increases the EE's cyclerate by about 50%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT."
+			return pxEt(L"-2 - Reduces the EE's cyclerate by about 50%.  Moderate speedup, but *will* cause stuttering audio on many FMVs."
 			);
 
 		case -1:
-			return pxEt( L"-1 - Increases the EE's cyclerate by about 33%. Increases hardware requirements, may increase in-game FPS."
+			return pxEt(L"-1 - Reduces the EE's cyclerate by about 33%.  Mild speedup for most games with high compatibility."
 			);
 
 		case 0:
-			return pxEt( L"0 - Default cyclerate. This closely matches the actual speed of a real PS2 EmotionEngine."
+			return pxEt(L"0 - Default cyclerate. This closely matches the actual speed of a real PS2 EmotionEngine."
 			);
 
 		case 1:
-			return pxEt( L"1 - Reduces the EE's cyclerate by about 33%.  Mild speedup for most games with high compatibility."
+			return pxEt( L"1 - Increases the EE's cyclerate by about 33%. Increases hardware requirements, may increase in-game FPS."
 			);
 
 		case 2:
-			return pxEt( L"2 - Reduces the EE's cyclerate by about 50%.  Moderate speedup, but *will* cause stuttering audio on many FMVs."
+			return pxEt(L"2 - Increases the EE's cyclerate by about 50%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT."
 			);
-
 		default:
 			break;
 	}
@@ -123,7 +122,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	m_msg_eecycle->SetForegroundColour( wxColour( L"Red" ) );
 	m_msg_eecycle->SetHeight(5);
 
-	const wxChar* ee_tooltip = pxEt( L"Setting higher values on this slider effectively reduces the clock speed of the EmotionEngine's R5900 core cpu, and typically brings big speedups to games that fail to utilize the full potential of the real PS2 hardware. Conversely, lower values effectively increase the clock speed which may bring about an increase in in-game FPS while also making games more demanding and possibly causing glitches."
+	const wxChar* ee_tooltip = pxEt( L"Setting lower values on this slider effectively reduces the clock speed of the EmotionEngine's R5900 core cpu, and typically brings big speedups to games that fail to utilize the full potential of the real PS2 hardware. Conversely, higher values effectively increase the clock speed which may bring about an increase in in-game FPS while also making games more demanding and possibly causing glitches."
 	);
 
 	pxSetToolTip( m_slider_eecycle, ee_tooltip );

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -125,7 +125,7 @@ static u32 dumplog = 0;
 
 static void iBranchTest(u32 newpc = 0xffffffff);
 static void ClearRecLUT(BASEBLOCK* base, int count);
-static u32 eeScaleBlockCycles();
+static u32 scaleblockcycles();
 
 void _eeFlushAllUnused()
 {
@@ -860,7 +860,7 @@ void R5900::Dynarec::OpcodeImpl::recSYSCALL()
 
 	CMP32ItoM((uptr)&cpuRegs.pc, pc);
 	j8Ptr[0] = JE8(0);
-	ADD32ItoM((uptr)&cpuRegs.cycle, eeScaleBlockCycles());
+	ADD32ItoM((uptr)&cpuRegs.cycle, scaleblockcycles());
 	// Note: technically the address is 0x8000_0180 (or 0x180)
 	// (if CPU is booted)
 	xJMP( DispatcherReg );
@@ -875,7 +875,7 @@ void R5900::Dynarec::OpcodeImpl::recBREAK()
 
 	CMP32ItoM((uptr)&cpuRegs.pc, pc);
 	j8Ptr[0] = JE8(0);
-	ADD32ItoM((uptr)&cpuRegs.cycle, eeScaleBlockCycles());
+	ADD32ItoM((uptr)&cpuRegs.cycle, scaleblockcycles());
 	xJMP( DispatcherEvent );
 	x86SetJ8(j8Ptr[0]);
 	//g_branch = 2;
@@ -1113,76 +1113,23 @@ void iFlushCall(int flushtype)
 //	}
 //}
 
-
-static u32 scaleBlockCycles_helper()
+static u32 scaleblockcycles()
 {
-	// Note: s_nBlockCycles is 3 bit fixed point.  Divide by 8 when done!
+	bool lowcycles = (s_nBlockCycles <= 40);
+	s8 cyclerate = EmuConfig.Speedhacks.EECycleRate;
+	u32 scale_cycles = 0;
 
-	// Let's not scale blocks under 5-ish cycles.  This fixes countless "problems"
-	// caused by sync hacks and such, since games seem to care a lot more about
-	// these small blocks having accurate cycle counts.
+	if (cyclerate == 0 || lowcycles || cyclerate > 99 || cyclerate < -2)
+		scale_cycles = s_nBlockCycles >> 3; // Default cycle rate
 
-	if( s_nBlockCycles <= (5<<3) || (EmuConfig.Speedhacks.EECycleRate > 99) ) // use default cycle rate if users set more than 99 in INI file.
-		return s_nBlockCycles >> 3;
+	else if (cyclerate < 0)
+		scale_cycles = s_nBlockCycles >> (3 - cyclerate);
 
-	uint scalarLow = 0, scalarMid = 0, scalarHigh = 0;
+	else if (cyclerate > 0)
+		scale_cycles = ((5 + (2 * cyclerate)) * s_nBlockCycles) >> 5;
 
-	// Note: larger blocks get a smaller scalar, to help keep
-	// them from becoming "too fat" and delaying branch tests.
-
-	switch( EmuConfig.Speedhacks.EECycleRate )
-	{
-		case -2:
-			scalarLow = 1;
-			scalarMid = 1;
-			scalarHigh = 1;
-		break;
-
-		case -1:
-			scalarLow = 2;
-			scalarMid = 2;
-			scalarHigh = 1;
-		break;
-
-		case 0:
-			return s_nBlockCycles >> 3; // Default cyclerate
-
-		case 1:
-			scalarLow = 5;
-			scalarMid = 7;
-			scalarHigh = 5;
-		break;
-
-		case 2:
-			scalarLow = 7;
-			scalarMid = 9;
-			scalarHigh = 7;
-		break;
-
-		// Added insane rates on popular request (rama)
-		// This allows higher values to be set at INI, Scalar values follow Arithmetic progression on increment to cyclerate.
-		default:
-			if (EmuConfig.Speedhacks.EECycleRate > 2)
-			{
-				scalarLow = 3 + (2*EmuConfig.Speedhacks.EECycleRate);
-				scalarMid = 5 + (2*EmuConfig.Speedhacks.EECycleRate);
-				scalarHigh = 3 + (2*EmuConfig.Speedhacks.EECycleRate);
-			}
-	}
-
-	const u32 temp = s_nBlockCycles * (
-		(s_nBlockCycles <= (10<<3)) ? scalarLow :
-		((s_nBlockCycles > (21<<3)) ? scalarHigh : scalarMid )
-	);
-
-	return temp >> (3+2);
-}
-
-static u32 eeScaleBlockCycles()
-{
-	// Ensures block cycles count is never less than 1:
-	u32 retval = scaleBlockCycles_helper();
-	return (retval < 1) ? 1 : retval;
+	// Ensure block cycle count is never less than 1.
+	return (scale_cycles < 1) ? 1 : scale_cycles;
 }
 
 
@@ -1208,7 +1155,7 @@ static void iBranchTest(u32 newpc)
 	if (EmuConfig.Speedhacks.WaitLoop && s_nBlockFF && newpc == s_branchTo)
 	{
 		xMOV(eax, ptr32[&g_nextEventCycle]);
-		xADD(ptr32[&cpuRegs.cycle], eeScaleBlockCycles());
+		xADD(ptr32[&cpuRegs.cycle], scaleblockcycles());
 		xCMP(eax, ptr32[&cpuRegs.cycle]);
 		xCMOVS(eax, ptr32[&cpuRegs.cycle]);
 		xMOV(ptr32[&cpuRegs.cycle], eax);
@@ -1218,7 +1165,7 @@ static void iBranchTest(u32 newpc)
 	else
 	{
 		xMOV(eax, ptr[&cpuRegs.cycle]);
-		xADD(eax, eeScaleBlockCycles());
+		xADD(eax, scaleblockcycles());
 		xMOV(ptr[&cpuRegs.cycle], eax); // update cycles
 		xSUB(eax, ptr[&g_nextEventCycle]);
 
@@ -2223,7 +2170,7 @@ StartRecomp:
 			else
 			{
 				xMOV( ptr32[&cpuRegs.pc], pc );
-				xADD( ptr32[&cpuRegs.cycle], eeScaleBlockCycles() );
+				xADD( ptr32[&cpuRegs.cycle], scaleblockcycles() );
 				recBlocks.Link( HWADDR(pc), xJcc32() );
 			}
 		}

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1113,6 +1113,10 @@ void iFlushCall(int flushtype)
 //	}
 //}
 
+// Note: scaleblockcycles() scales s_nBlockCycles respective to the EECycleRate value for manipulating the cycles of current block recompiling.
+// s_nBlockCycles is 3 bit fixed point.  Divide by 8 when done!
+// Scaling blocks under 40 cycles seems to produce countless problem, so let's try to avoid them.
+
 static u32 scaleblockcycles()
 {
 	bool lowcycles = (s_nBlockCycles <= 40);

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1122,11 +1122,11 @@ static u32 scaleblockcycles()
 	if (cyclerate == 0 || lowcycles || cyclerate > 99 || cyclerate < -2)
 		scale_cycles = s_nBlockCycles >> 3; // Default cycle rate
 
-	else if (cyclerate < 0)
-		scale_cycles = s_nBlockCycles >> (3 - cyclerate);
-
 	else if (cyclerate > 0)
-		scale_cycles = ((5 + (2 * cyclerate)) * s_nBlockCycles) >> 5;
+		scale_cycles = s_nBlockCycles >> (3 + cyclerate);
+
+	else if (cyclerate < 0)
+		scale_cycles = ((5 + (-2 * cyclerate)) * s_nBlockCycles) >> 5;
 
 	// Ensure block cycle count is never less than 1.
 	return (scale_cycles < 1) ? 1 : scale_cycles;


### PR DESCRIPTION
**Summary of changes :-**

- don't classify blocks and use different scaled block cycles for each specific range, rather use a constant value for all the range (having lower blocks as an exception since they're very sensitive on these stuffs)

-  decrease the complexity on the code ( 71 lines -> 18 lines )

- Integrate ``eeScaleBlockCycles()`` and ``scaleBlockCycles_helper()`` to a single function

The first mentioned change actually seems to make the games run a lot better on overclock and underclock scenarios thanks to the removed classification of scalar_mid & scalar_ high stuffs. which probably caused some quirks due to dynamic scalar variable toggles (maybe ? )

The following code change needs reviews from @ramapcsx2  and @refractionpcsx2 

also for future plans,

- maybe move the cycle rate manipulation to some place rather than  ``iBranchTest()`` to have higher overclock range. ( higher underclock range is already possible )

* ~~invert the slider to have overclock on right side and underclock on left, lots of users were complaining about it. ( Need more users opinion before proceeding on this one)~~ Done :heavy_check_mark: 
