### PR TITLE
SPU2-X: New INI variable for cycle delay

### DIFF
--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -60,6 +60,7 @@ float VolumeAdjustBR;
 float VolumeAdjustSL;
 float VolumeAdjustSR;
 float VolumeAdjustLFE;
+int delayCycles;
 
 bool postprocess_filter_enabled = true;
 bool postprocess_filter_dealias = false;
@@ -108,6 +109,7 @@ void ReadSettings()
 	VolumeAdjustSL = powf(10, VolumeAdjustSLdb / 10);
 	VolumeAdjustSR = powf(10, VolumeAdjustSRdb / 10);
 	VolumeAdjustLFE = powf(10, VolumeAdjustLFEdb / 10);
+	delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 4);
 
 
 	wxString temp;
@@ -165,6 +167,7 @@ void WriteSettings()
 	CfgWriteStr(L"OUTPUT",L"Output_Module", mods[OutputModule]->GetIdent() );
 	CfgWriteInt(L"OUTPUT",L"Latency", SndOutLatencyMS);
 	CfgWriteInt(L"OUTPUT",L"Synch_Mode", SynchMode);
+	CfgWriteInt(L"DEBUG", L"DelayCycles", delayCycles);
 
 	PortaudioOut->WriteSettings();
 	SoundtouchCfg::WriteSettings();

--- a/plugins/spu2-x/src/SndOut.h
+++ b/plugins/spu2-x/src/SndOut.h
@@ -45,6 +45,7 @@ extern float VolumeAdjustBR;
 extern float VolumeAdjustSL;
 extern float VolumeAdjustSR;
 extern float VolumeAdjustLFE;
+extern int delayCycles;
 
 struct Stereo51Out16DplII;
 struct Stereo51Out32DplII;

--- a/plugins/spu2-x/src/Windows/Config.cpp
+++ b/plugins/spu2-x/src/Windows/Config.cpp
@@ -58,6 +58,7 @@ float VolumeAdjustBR;
 float VolumeAdjustSL;
 float VolumeAdjustSR;
 float VolumeAdjustLFE;
+int delayCycles;
 
 bool postprocess_filter_enabled = 1;
 bool postprocess_filter_dealias = false;
@@ -114,6 +115,7 @@ void ReadSettings()
 	VolumeAdjustSLdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSL(dB)", 0);
 	VolumeAdjustSRdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSR(dB)", 0);
 	VolumeAdjustLFEdb = CfgReadFloat(L"MIXING", L"VolumeAdjustLFE(dB)", 0);
+	delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 4);
 	VolumeAdjustC = powf(10, VolumeAdjustCdb / 10);
 	VolumeAdjustFL = powf(10, VolumeAdjustFLdb / 10);
 	VolumeAdjustFR = powf(10, VolumeAdjustFRdb / 10);
@@ -198,6 +200,7 @@ void WriteSettings()
 	CfgWriteInt(L"OUTPUT",L"Synch_Mode", SynchMode);
 	CfgWriteInt(L"OUTPUT",L"SpeakerConfiguration", numSpeakers);
 	CfgWriteInt( L"OUTPUT", L"DplDecodingLevel", dplLevel);
+	CfgWriteInt(L"DEBUG", L"DelayCycles", delayCycles);
 
 	if( Config_WaveOut.Device.empty() ) Config_WaveOut.Device = L"default";
 	CfgWriteStr(L"WAVEOUT",L"Device",Config_WaveOut.Device);

--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -306,7 +306,7 @@ void V_Core::UpdateEffectsBufferSize()
 
 void V_Voice::QueueStart()
 {
-	if (Cycles - PlayCycle < 4)
+	if (Cycles - PlayCycle < delayCycles)
 	{
 		// Required by The Legend of Spyro: The Eternal Night (probably the other two legend games too)
 		ConLog(" *** KeyOn after less than 4 T disregarded.\n");
@@ -317,7 +317,7 @@ void V_Voice::QueueStart()
 
 bool V_Voice::Start()
 {
-	if((Cycles-PlayCycle)>=4)
+	if((Cycles-PlayCycle)>= delayCycles)
 	{
 		if(StartA&7)
 		{


### PR DESCRIPTION
Allows manipulation of the delays after Key-on through the INI files , some non-default values seem to fix voice playback on games like ``Higurashi no Naku Koro ni Matsuri Kakera Asobi (SPLM-66913)`` hence allow wider range of values to debug games and find a more suitable approach to the cycle delays.

Related to #918 