### PR TITLE
Gcc warning

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -241,7 +241,7 @@ extern "C" {
 // basic funcs
 
 s32  CALLBACK GSinit();
-s32  CALLBACK GSopen(void *pDsp, char *Title, int multithread);
+s32  CALLBACK GSopen(void *pDsp, const char *Title, int multithread);
 void CALLBACK GSclose();
 void CALLBACK GSshutdown();
 void CALLBACK GSsetSettingsDir( const char* dir );
@@ -572,7 +572,7 @@ typedef void (CALLBACK* _PS2EsetEmuVersion)(const char* emuId, u32 version);		//
 // GS
 // NOTE: GSreadFIFOX/GSwriteCSR functions CANNOT use XMM/MMX regs
 // If you want to use them, need to save and restore current ones
-typedef s32  (CALLBACK* _GSopen)(void *pDsp, char *Title, int multithread);
+typedef s32  (CALLBACK* _GSopen)(void *pDsp, const char *Title, int multithread);
 typedef s32  (CALLBACK* _GSopen2)( void *pDsp, u32 flags );
 typedef void (CALLBACK* _GSvsync)(int field);
 typedef void (CALLBACK* _GSgifTransfer)(const u32 *pMem, u32 size);

--- a/common/src/x86emitter/cpudetect.cpp
+++ b/common/src/x86emitter/cpudetect.cpp
@@ -197,8 +197,10 @@ void x86capabilities::Identify()
 	u32 cmds;
 
 	//AMD 64 STUFF
+#ifdef __x86_64__
 	u32 x86_64_8BITBRANDID;
 	u32 x86_64_12BITBRANDID;
+#endif
 
 	memzero( VendorName );
 	__cpuid( regs, 0 );
@@ -227,7 +229,9 @@ void x86capabilities::Identify()
 		Model		= (regs[ 0 ] >>  4) & 0xf;
 		FamilyID	= (regs[ 0 ] >>  8) & 0xf;
 		TypeID		= (regs[ 0 ] >> 12) & 0x3;
+#ifdef __x86_64__
 		x86_64_8BITBRANDID	=  regs[ 1 ] & 0xff;
+#endif
 		Flags		=  regs[ 3 ];
 		Flags2		=  regs[ 2 ];
 	}
@@ -238,7 +242,9 @@ void x86capabilities::Identify()
 	{
 		__cpuid( regs, 0x80000001 );
 
+#ifdef __x86_64__
 		x86_64_12BITBRANDID = regs[1] & 0xfff;
+#endif
 		EFlags2 = regs[ 2 ];
 		EFlags = regs[ 3 ];
 	}

--- a/debian-packager/create_built_tarball.sh
+++ b/debian-packager/create_built_tarball.sh
@@ -100,12 +100,10 @@ remove_not_yet_free_plugin()
 remove_remaining_non_free_file()
 {
     echo "Remove remaining non free file. TODO UPSTREAM"
+    rm -fr $LOCAL_REPO/unfree
     rm -fr $LOCAL_REPO/plugins/GSdx/baseclasses
     rm -f  $LOCAL_REPO/plugins/zzogl-pg/opengl/Win32/aviUtil.h
-    rm -f  $LOCAL_REPO/plugins/spu2-x/src/Windows/Hyperlinks.h
-    rm -f  $LOCAL_REPO/plugins/spu2-x/src/Windows/Hyperlinks.cpp
     rm -f  $LOCAL_REPO/common/src/Utilities/x86/MemcpyFast.cpp
-    rm -f  $LOCAL_REPO/common/include/comptr.h
 }
 remove_dot_git()
 {

--- a/pcsx2/DebugTools/MipsAssembler.cpp
+++ b/pcsx2/DebugTools/MipsAssembler.cpp
@@ -691,6 +691,8 @@ void CMipsInstruction::encodeNormal()
 
 	switch (immediateType)
 	{
+	case MIPS_NOIMMEDIATE:
+		break;
 	case MIPS_IMMEDIATE5:
 	case MIPS_IMMEDIATE20:
 		encoding |= immediate.value << 6;

--- a/pcsx2/System/SysThreadBase.cpp
+++ b/pcsx2/System/SysThreadBase.cpp
@@ -93,9 +93,8 @@ void SysThreadBase::Suspend( bool isBlocking )
 
 		switch( m_ExecMode )
 		{
-			// FIXME what to do for this case
-			// case ExecMode_NoThreadYet:
-
+			// Invalid thread state, nothing to suspend
+			case ExecMode_NoThreadYet:
 			// Check again -- status could have changed since above.
 			case ExecMode_Closed: return;
 

--- a/pcsx2/x86/ix86-32/iCore-32.cpp
+++ b/pcsx2/x86/ix86-32/iCore-32.cpp
@@ -279,7 +279,7 @@ int _allocX86reg(int x86reg, int type, int reg, int mode)
 
 			if( x86reg >= 0 ) {
 				// requested specific reg, so return that instead
-				if( i != x86reg ) {
+				if( i != (uint)x86reg ) {
 					if( x86regs[i].mode & MODE_READ ) readfromreg = i;
 					mode |= x86regs[i].mode&MODE_WRITE;
 					x86regs[i].inuse = 0;

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -179,7 +179,7 @@ EXPORT_C GSclose()
 	}
 }
 
-static int _GSopen(void** dsp, char* title, GSRendererType renderer, int threads = -1)
+static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int threads = -1)
 {
 	GSDevice* dev = NULL;
 
@@ -528,7 +528,7 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	}
 	stored_toggle_state = toggle_state;
 
-	int retval = _GSopen(dsp, NULL, renderer);
+	int retval = _GSopen(dsp, "", renderer);
 
 	if (s_gs != NULL)
 		s_gs->SetAspectRatio(0);	 // PCSX2 manages the aspect ratios
@@ -538,7 +538,7 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	return retval;
 }
 
-EXPORT_C_(int) GSopen(void** dsp, char* title, int mt)
+EXPORT_C_(int) GSopen(void** dsp, const char* title, int mt)
 {
 	/*
 	if(!XInitThreads()) return -1;

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -1449,7 +1449,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 	{
 		gd.sel.zpsm = GSLocalMemory::m_psm[context->ZBUF.PSM].fmt;
 		gd.sel.ztst = ztest ? context->TEST.ZTST : ZTST_ALWAYS;
-		gd.sel.zoverflow = GSVector4i(m_vt.m_max.p).z == 0x80000000;
+		gd.sel.zoverflow = (uint32)GSVector4i(m_vt.m_max.p).z == 0x80000000U;
 	}
 
 	#if _M_SSE >= 0x501

--- a/plugins/GSnull/GS.cpp
+++ b/plugins/GSnull/GS.cpp
@@ -121,7 +121,7 @@ EXPORT_C_(void) GSshutdown()
 	GSLog::Close();
 }
 
-EXPORT_C_(s32) GSopen(void *pDsp, char *Title, int multithread)
+EXPORT_C_(s32) GSopen(void *pDsp, const char *Title, int multithread)
 {
 	int err = 0;
 	GSLog::WriteLn("GS open.");

--- a/plugins/GSnull/Linux/GSLinux.cpp
+++ b/plugins/GSnull/Linux/GSLinux.cpp
@@ -20,7 +20,7 @@ Display *display;
 int screen;
 GtkScrolledWindow *win;
 
-int GSOpenWindow(void *pDsp, char *Title)
+int GSOpenWindow(void *pDsp, const char *Title)
 {
 	display = XOpenDisplay(0);
 	screen = DefaultScreen(display);

--- a/plugins/GSnull/Linux/GSLinux.h
+++ b/plugins/GSnull/Linux/GSLinux.h
@@ -20,7 +20,7 @@
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 
-extern int GSOpenWindow(void *pDsp, char *Title);
+extern int GSOpenWindow(void *pDsp, const char *Title);
 extern int GSOpenWindow2(void *pDsp, u32 flags);
 extern void GSCloseWindow();
 extern void GSProcessMessages();

--- a/plugins/GSnull/Windows/GSwin.cpp
+++ b/plugins/GSnull/Windows/GSwin.cpp
@@ -34,7 +34,7 @@ LRESULT CALLBACK MsgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     return 0;
 }
 
-int GSOpenWindow(void *pDsp, char *Title)
+int GSOpenWindow(void *pDsp, const char *Title)
 {
 	WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, MsgProc, 0L, 0L,
 					GetModuleHandle(NULL), NULL, NULL, NULL, NULL,

--- a/plugins/GSnull/Windows/GSwin.h
+++ b/plugins/GSnull/Windows/GSwin.h
@@ -18,7 +18,7 @@
 #include <windows.h>
 #include <windowsx.h>
 
-extern int GSOpenWindow(void *pDsp, char *Title);
+extern int GSOpenWindow(void *pDsp, const char *Title);
 extern void GSCloseWindow();
 extern void GSProcessMessages();
 extern void HandleKeyEvent(keyEvent *ev);

--- a/plugins/LilyPad/LilyPad.cpp
+++ b/plugins/LilyPad/LilyPad.cpp
@@ -77,7 +77,7 @@ int windowThreadId = 0;
 int updateQueued = 0;
 #endif
 
-int bufSize = 0;
+u32 bufSize = 0;
 unsigned char outBuf[50];
 unsigned char inBuf[50];
 
@@ -126,7 +126,7 @@ void DEBUG_NEW_SET() {
 	if (config.debug && bufSize>1) {
 		HANDLE hFile = CreateFileA("logs\\padLog.txt", FILE_APPEND_DATA, FILE_SHARE_READ, 0, OPEN_ALWAYS, 0, 0);
 		if (hFile != INVALID_HANDLE_VALUE) {
-			int i;
+			u32 i;
 			char temp[1500];
 			char *end = temp;
 			sprintf(end, "%02X (%02X) ", inBuf[0], inBuf[1]);

--- a/plugins/LilyPad/Linux/Config.cpp
+++ b/plugins/LilyPad/Linux/Config.cpp
@@ -168,7 +168,7 @@ int BindCommand(Device *dev, unsigned int uid, unsigned int port, unsigned int s
 	if (!config.multipleBinding) {
 		for (int port2=0; port2<2; port2++) {
 			for (int slot2=0; slot2<4; slot2++) {
-				if (port2==port && slot2 == slot) continue;
+				if (port2==(int)port && slot2 == (int)slot) continue;
 				PadBindings *p = dev->pads[port2]+slot2;
 				for (int i=0; i < p->numBindings; i++) {
 					Binding *b = p->bindings+i;
@@ -220,7 +220,7 @@ void CALLBACK PADsetSettingsDir( const char *dir )
 int SaveSettings(wchar_t *file=0) {
 	CfgHelper cfg;
 
-	for (int i=0; i<sizeof(BoolOptionsInfo)/sizeof(BoolOptionsInfo[0]); i++) {
+	for (size_t i=0; i<sizeof(BoolOptionsInfo)/sizeof(BoolOptionsInfo[0]); i++) {
 		 cfg.WriteBool(L"General Settings", BoolOptionsInfo[i].name, config.bools[i]);
 	}
 	cfg.WriteInt(L"General Settings", L"Close Hacks", config.closeHacks);
@@ -305,7 +305,7 @@ int LoadSettings(int force, wchar_t *file) {
 
 	CfgHelper cfg;
 
-	for (int i=0; i<sizeof(BoolOptionsInfo)/sizeof(BoolOptionsInfo[0]); i++) {
+	for (size_t i=0; i<sizeof(BoolOptionsInfo)/sizeof(BoolOptionsInfo[0]); i++) {
 		config.bools[i] = cfg.ReadBool(L"General Settings", BoolOptionsInfo[i].name, BoolOptionsInfo[i].defaultValue);
 	}
 

--- a/plugins/spu2-x/src/Linux/Alsa.cpp
+++ b/plugins/spu2-x/src/Linux/Alsa.cpp
@@ -47,7 +47,7 @@ protected:
 		fprintf(stderr,"* SPU2-X:Iz in your internal callback.\n");
 
 		avail = snd_pcm_avail_update( handle );
-		while (avail >= period_time )
+		while (avail >= (int)period_time )
 		{
 			StereoOut16 buff[PacketsPerBuffer * SndOutPacketSize];
 			StereoOut16* p1 = buff;

--- a/plugins/zerogs/dx/GSmain.cpp
+++ b/plugins/zerogs/dx/GSmain.cpp
@@ -358,7 +358,7 @@ LRESULT WINAPI MsgProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 	return DefWindowProc( hWnd, msg, wParam, lParam );
 }
 
-s32 CALLBACK GSopen(void *pDsp, char *Title, int multithread) {
+s32 CALLBACK GSopen(void *pDsp, const char *Title, int multithread) {
 
 	g_GSMultiThreaded = multithread;
 

--- a/plugins/zzogl-pg/opengl/GSmain.cpp
+++ b/plugins/zzogl-pg/opengl/GSmain.cpp
@@ -282,7 +282,7 @@ __forceinline void InitMisc()
 	ResetRegs();
 }
 
-EXPORT_C_(s32) GSopen(void *pDsp, char *Title, int multithread)
+EXPORT_C_(s32) GSopen(void *pDsp, const char *Title, int multithread)
 {
 	FUNCLOG
 


### PR DESCRIPTION
The ususal gcc warning fixes.

On debug build it remains a couples of them :)
```
Total: 11
$VAR1 = {
          'LilyPad' => {
                         'write-strings' => 2,
                         'sign-compare' => 1
                       },
          'pcsx2' => {
                       'sign-compare' => 7,
                       'switch' => 1
                     }
        };
```