### PR TITLE
SPU2-X: Handle INI changes to variable on Conlog 

### DIFF
--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -309,7 +309,7 @@ void V_Voice::QueueStart()
 	if (Cycles - PlayCycle < delayCycles)
 	{
 		// Required by The Legend of Spyro: The Eternal Night (probably the other two legend games too)
-		ConLog(" *** KeyOn after less than 4 T disregarded.\n");
+		ConLog(" *** KeyOn after less than %d T disregarded.\n", delayCycles);
 		return;
 	}
 	PlayCycle = Cycles;


### PR DESCRIPTION
delayCycles value can be changed through the INI files, use the current INI value for the Console message instead of the default value on all cases. should have been handled on #953 

