### PR TITLE
Call eeGameStarting sooner

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1740,7 +1740,7 @@ static void __fastcall recRecompile( const u32 startpc )
 
 	// this is the only way patches get applied, doesn't depend on a hack
 	if (HWADDR(startpc) == ElfEntry)
-		xCALL(eeGameStarting);
+		eeGameStarting();
 
 	g_branch = 0;
 


### PR DESCRIPTION
I'm not sure it is 100% valid. Otherwise, we need to call it twice. At compilation and I run time.