### PR TITLE
gsdx: Generic config load

### DIFF
--- a/plugins/GSdx/GPURenderer.cpp
+++ b/plugins/GSdx/GPURenderer.cpp
@@ -35,11 +35,11 @@ GPURenderer::GPURenderer(GSDevice* dev)
 	m_filter = theApp.GetConfig("filter", 0);
 	m_dither = theApp.GetConfig("dithering", 1);
 	m_aspectratio = theApp.GetConfig("AspectRatio", 1);
-	m_vsync = !!theApp.GetConfig("vsync", 0);
-	m_fxaa = !!theApp.GetConfig("fxaa", 0);
-	m_shaderfx = !!theApp.GetConfig("shaderfx", 0);
+	m_vsync = theApp.GetConfig("vsync", false);
+	m_fxaa = theApp.GetConfig("fxaa", false);
+	m_shaderfx = theApp.GetConfig("shaderfx", false);
 	m_scale = m_mem.GetScale();
-	m_shadeboost = !!theApp.GetConfig("ShadeBoost", 0);
+	m_shadeboost = theApp.GetConfig("ShadeBoost", false);
 
 	#ifdef _WINDOWS
 

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -185,7 +185,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 
 	if(renderer == GSRendererType::Undefined)
 	{
-		renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+		renderer = theApp.GetConfig("Renderer", GSRendererType::Default);
 	}
 
 	if(threads == -1)
@@ -496,7 +496,7 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	// Fresh start up or config file changed
 	if (renderer == GSRendererType::Undefined)
 	{
-		renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+		renderer = theApp.GetConfig("Renderer", GSRendererType::Default);
 	}
 	else if (stored_toggle_state != toggle_state)
 	{
@@ -552,7 +552,7 @@ EXPORT_C_(int) GSopen(void** dsp, const char* title, int mt)
 
 	// Legacy GUI expects to acquire vsync from the configuration files.
 
-	s_vsync = !!theApp.GetConfig("vsync", 0);
+	s_vsync = theApp.GetConfig("vsync", false);
 
 	if(mt == 2)
 	{
@@ -570,7 +570,7 @@ EXPORT_C_(int) GSopen(void** dsp, const char* title, int mt)
 	{
 		// normal init
 
-		renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+		renderer = theApp.GetConfig("Renderer", GSRendererType::Default);
 	}
 
 	*dsp = NULL;
@@ -1085,7 +1085,7 @@ EXPORT_C GSReplay(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int nCmdShow)
 		uint8 regs[0x2000];
 		GSsetBaseMem(regs);
 
-		s_vsync = !!theApp.GetConfig("vsync", 0);
+		s_vsync = theApp.GetConfig("vsync", false);
 
 		HWND hWnd = NULL;
 
@@ -1531,7 +1531,7 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 
 	GSRendererType m_renderer;
 	// Allow to easyly switch between SW/HW renderer -> this effectively removes the ability to select the renderer by function args
-	m_renderer = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+	m_renderer = theApp.GetConfig("Renderer", GSRendererType::Default);
 	// alternatively:
 	// m_renderer = static_cast<GSRendererType>(renderer);
 
@@ -1553,7 +1553,7 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 
 	GSsetBaseMem(regs);
 
-	s_vsync = !!theApp.GetConfig("vsync", 0);
+	s_vsync = theApp.GetConfig("vsync", false);
 
 	void* hWnd = NULL;
 

--- a/plugins/GSdx/GSCaptureDlg.cpp
+++ b/plugins/GSdx/GSCaptureDlg.cpp
@@ -64,7 +64,7 @@ void GSCaptureDlg::OnInit()
 
 	m_codecs.clear();
 
-	_bstr_t selected = theApp.GetConfig("CaptureVideoCodecDisplayName", "").c_str();
+	_bstr_t selected = CComBSTR(theApp.GetConfig("CaptureVideoCodecDisplayName", "").c_str()).Detach();
 
 	ComboBoxAppend(IDC_CODECS, "Uncompressed", 0, true);
 
@@ -199,7 +199,9 @@ bool GSCaptureDlg::OnCommand(HWND hWnd, UINT id, UINT code)
 
 		if (ris != 2)
 		{
-			theApp.SetConfig("CaptureVideoCodecDisplayName", c.DisplayName);
+			char* displayName = _com_util::ConvertBSTRToString(c.DisplayName);
+			theApp.SetConfig("CaptureVideoCodecDisplayName", displayName);
+			delete[] displayName;
 		}
 		else
 		{

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -110,7 +110,7 @@ bool GSDevice11::Create(GSWnd* wnd)
 
 	scd.Windowed = TRUE;
 
-	spritehack = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_SpriteHack", 0) : 0;
+	spritehack = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_SpriteHack", false) : false;
 	// NOTE : D3D11_CREATE_DEVICE_SINGLETHREADED
 	//   This flag is safe as long as the DXGI's internal message pump is disabled or is on the
 	//   same thread as the GS window (which the emulator makes sure of, if it utilizes a

--- a/plugins/GSdx/GSDeviceDX.cpp
+++ b/plugins/GSdx/GSDeviceDX.cpp
@@ -25,7 +25,7 @@
 
 GSDeviceDX::GSDeviceDX()
 {
-	m_msaa = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_MSAA", 0) : 0;
+	m_msaa = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_MSAA", 0) : 0;
 
 	m_msaa_desc.Count = 1;
 	m_msaa_desc.Quality = 0;

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -219,7 +219,7 @@ bool GSDeviceOGL::Create(GSWnd* wnd)
 	// ****************************************************************
 	GL_PUSH("GSDeviceOGL::Various");
 
-	m_shader = new GSShaderOGL(!!theApp.GetConfig("debug_glsl_shader", 0));
+	m_shader = new GSShaderOGL(theApp.GetConfig("debug_glsl_shader", false));
 
 	glGenFramebuffers(1, &m_fbo);
 	// Always write to the first buffer

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -72,7 +72,7 @@ GSDeviceOGL::GSDeviceOGL()
 	m_debug_gl_file = fopen("GSdx_opengl_debug.txt","w");
 	#endif
 
-	m_debug_gl_call =  theApp.GetConfig("debug_opengl", 0);
+	m_debug_gl_call =  theApp.GetConfig("debug_opengl", false);
 }
 
 GSDeviceOGL::~GSDeviceOGL()

--- a/plugins/GSdx/GSDialog.cpp
+++ b/plugins/GSdx/GSDialog.cpp
@@ -164,7 +164,7 @@ void GSDialog::SetTextAsInt(UINT id, int i)
 	SetText(id, buff);
 }
 
-void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 selid, uint32 maxid)
+void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue)
 {
 	HWND hWnd = GetDlgItem(m_hWnd, id);
 
@@ -174,7 +174,7 @@ void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 s
 	{
 		const GSSetting& s = settings[i];
 
-		if(s.id <= maxid)
+		if(s.value <= maxValue)
 		{
 			string str(s.name);
 
@@ -183,7 +183,7 @@ void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 s
 				str = str + " (" + s.note + ")";
 			}
 
-			ComboBoxAppend(id, str.c_str(), (LPARAM)s.id, s.id == selid);
+			ComboBoxAppend(id, str.c_str(), (LPARAM)s.value, s.value == selectionValue);
 		}
 	}
 

--- a/plugins/GSdx/GSDialog.h
+++ b/plugins/GSdx/GSDialog.h
@@ -51,7 +51,7 @@ public:
 	void SetText(UINT id, const char* str);
 	void SetTextAsInt(UINT id, int i);
 
-	void ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 selid, uint32 maxid = ~0);
+	void ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue = INT32_MAX);
 	int ComboBoxAppend(UINT id, const char* str, LPARAM data = 0, bool select = false);
 	bool ComboBoxGetSelData(UINT id, INT_PTR& data);
 	void ComboBoxFixDroppedWidth(UINT id);

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -77,7 +77,7 @@ GtkWidget* CreateRenderComboBox()
 		if(!s->note.empty()) label += format(" (%s)", s->note.c_str());
 
 		// Add some tags to ease users selection
-		switch (static_cast<GSRendererType>(s->id)) {
+		switch (static_cast<GSRendererType>(s->value)) {
 			// Supported opengl
 		case GSRendererType::OGL_HW:
 		case GSRendererType::OGL_SW:
@@ -122,15 +122,15 @@ void CB_ChangedComboBox(GtkComboBox *combo, gpointer user_data)
 	vector<GSSetting>* s = (vector<GSSetting>*)g_object_get_data(G_OBJECT(combo), "Settings");
 
 	try {
-		theApp.SetConfig((char*)user_data, s->at(p).id);
+		theApp.SetConfig((char*)user_data, s->at(p).value);
 	} catch (...) {
 	}
 }
 
-GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_name, int opt_default = 0)
+GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_name, int32_t opt_default = 0)
 {
 	GtkWidget* combo_box = gtk_combo_box_text_new();
-	int opt_value        = theApp.GetConfig(opt_name, opt_default);
+	int32_t opt_value    = theApp.GetConfig(opt_name, opt_default);
 	int opt_position     = 0;
 
 	for(size_t i = 0; i < s.size(); i++)
@@ -141,7 +141,7 @@ GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_
 
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_box), label.c_str());
 
-		if ((int)s[i].id == opt_value)
+		if (s[i].value == opt_value)
 			opt_position = i;
 	}
 

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -53,15 +53,15 @@ void CB_ChangedRenderComboBox(GtkComboBox *combo, gpointer user_data)
 	if (gtk_combo_box_get_active(combo) == -1) return;
 
 	switch (gtk_combo_box_get_active(combo)) {
-	case 0: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::Null_SW)); break;
-	case 1: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::Null_OpenCL)); break;
-	case 2: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::Null_Null)); break;
-	case 3: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_HW)); break;
-	case 4: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_SW)); break;
-	case 5: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_OpenCL)); break;
+	case 0: theApp.SetConfig("Renderer", GSRendererType::Null_SW); break;
+	case 1: theApp.SetConfig("Renderer", GSRendererType::Null_OpenCL); break;
+	case 2: theApp.SetConfig("Renderer", GSRendererType::Null_Null); break;
+	case 3: theApp.SetConfig("Renderer", GSRendererType::OGL_HW); break;
+	case 4: theApp.SetConfig("Renderer", GSRendererType::OGL_SW); break;
+	case 5: theApp.SetConfig("Renderer", GSRendererType::OGL_OpenCL); break;
 
 				// Fallback to SW opengl
-	default: theApp.SetConfig("Renderer", static_cast<int>(GSRendererType::OGL_SW)); break;
+	default: theApp.SetConfig("Renderer", GSRendererType::OGL_SW); break;
 	}
 }
 
@@ -98,7 +98,7 @@ GtkWidget* CreateRenderComboBox()
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(render_combo_box), label.c_str());
 	}
 
-	switch (static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)))) {
+	switch (theApp.GetConfig("Renderer", GSRendererType::Default)) {
 	case GSRendererType::Null_SW:		renderer_box_position = 0; break;
 	case GSRendererType::Null_OpenCL:	renderer_box_position = 1; break;
 	case GSRendererType::Null_Null:		renderer_box_position = 2; break;

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -44,11 +44,11 @@ GSRenderer::GSRenderer()
 	m_aspectratio = theApp.GetConfig("aspectratio", 1) % s_aspect_ratio_nb;
 	m_shader = theApp.GetConfig("TVShader", 0) % s_post_shader_nb;
 	m_filter = theApp.GetConfig("filter", 1);
-	m_vsync = !!theApp.GetConfig("vsync", 0);
-	m_aa1 = !!theApp.GetConfig("aa1", 0);
-	m_fxaa = !!theApp.GetConfig("fxaa", 0);
-	m_shaderfx = !!theApp.GetConfig("shaderfx", 0);
-	m_shadeboost = !!theApp.GetConfig("ShadeBoost", 0);
+	m_vsync = theApp.GetConfig("vsync", false);
+	m_aa1 = theApp.GetConfig("aa1", false);
+	m_fxaa = theApp.GetConfig("fxaa", false);
+	m_shaderfx = theApp.GetConfig("shaderfx", false);
+	m_shadeboost = theApp.GetConfig("ShadeBoost", false);
 }
 
 GSRenderer::~GSRenderer()

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -27,13 +27,13 @@ GSRendererDX::GSRendererDX(GSTextureCache* tc, const GSVector2& pixelcenter)
 	: GSRendererHW(tc)
 	, m_pixelcenter(pixelcenter)
 {
-	m_logz = !!theApp.GetConfig("logz", 0);
-	m_fba = !!theApp.GetConfig("fba", 1);
+	m_logz = theApp.GetConfig("logz", false);
+	m_fba = theApp.GetConfig("fba", true);
 
-	UserHacks_AlphaHack = !!theApp.GetConfig("UserHacks_AlphaHack", 0) && !!theApp.GetConfig("UserHacks", 0);
-	UserHacks_AlphaStencil = !!theApp.GetConfig("UserHacks_AlphaStencil", 0) && !!theApp.GetConfig("UserHacks", 0);
+	UserHacks_AlphaHack = theApp.GetConfig("UserHacks_AlphaHack", false) && theApp.GetConfig("UserHacks", false);
+	UserHacks_AlphaStencil = theApp.GetConfig("UserHacks_AlphaStencil", false) && theApp.GetConfig("UserHacks", false);
 
-	UserHacks_TCOffset = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_TCOffset", 0) : 0;
+	UserHacks_TCOffset = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_TCOffset", 0) : 0;
 	UserHacks_TCO_x = (UserHacks_TCOffset & 0xFFFF) / -1000.0f;
 	UserHacks_TCO_y = ((UserHacks_TCOffset >> 16) & 0xFFFF) / -1000.0f;
 }

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -31,9 +31,9 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_tc(tc)
 {
 	m_upscale_multiplier = theApp.GetConfig("upscale_multiplier", 1);
-	m_userhacks_skipdraw = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_SkipDraw", 0) : 0;
-	m_userhacks_align_sprite_X = !!theApp.GetConfig("UserHacks_align_sprite_X", 0) && !!theApp.GetConfig("UserHacks", 0);
-	m_userhacks_round_sprite_offset = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_round_sprite_offset", 0) : 0;
+	m_userhacks_skipdraw = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_SkipDraw", 0) : 0;
+	m_userhacks_align_sprite_X = theApp.GetConfig("UserHacks_align_sprite_X", false) && theApp.GetConfig("UserHacks", false);
+	m_userhacks_round_sprite_offset = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_round_sprite_offset", 0) : 0;
 
 	if (!m_upscale_multiplier) { //Custom Resolution
 		m_width = theApp.GetConfig("resx", m_width);

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -27,7 +27,7 @@
 GSRendererOGL::GSRendererOGL()
 	: GSRendererHW(new GSTextureCacheOGL(this))
 {
-	m_accurate_date   = theApp.GetConfig("accurate_date", 0);
+	m_accurate_date   = theApp.GetConfig("accurate_date", false);
 
 	m_sw_blending = theApp.GetConfig("accurate_blending_unit", 1);
 

--- a/plugins/GSdx/GSSetting.h
+++ b/plugins/GSdx/GSSetting.h
@@ -25,14 +25,22 @@
 
 struct GSSetting
 {
-	uint32 id;
+	int32_t value;
 	std::string name;
 	std::string note;
 
 
-	GSSetting(uint32 id, const char* name, const char* note)
+	GSSetting(int32_t value, const char* name, const char* note)
 	{
-		this->id = id;
+		this->value = value;
+		this->name = name;
+		this->note = note;
+	}
+
+	template< typename T>
+	GSSetting(T value, const char* name, const char* note)
+	{
+		this->value = static_cast<int32_t>(value);
 		this->name = name;
 		this->note = note;
 	}

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -356,7 +356,7 @@ void GSSettingsDlg::UpdateRenderers()
 
 	vector<GSSetting> renderers;
 
-	GSRendererType renderer_setting = static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default)));
+	GSRendererType renderer_setting = theApp.GetConfig("Renderer", GSRendererType::Default);
 	GSRendererType renderer_sel = GSRendererType::Default;
 
 	for(size_t i = 0; i < theApp.m_gs_renderers.size(); i++)

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -363,7 +363,7 @@ void GSSettingsDlg::UpdateRenderers()
 	{
 		GSSetting r = theApp.m_gs_renderers[i];
 
-		GSRendererType renderer = static_cast<GSRendererType>(r.id);
+		GSRendererType renderer = static_cast<GSRendererType>(r.value);
 
 		if(renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::DX1011_Null || renderer == GSRendererType::DX1011_OpenCL)
 		{
@@ -374,13 +374,13 @@ void GSSettingsDlg::UpdateRenderers()
 
 		renderers.push_back(r);
 
-		if (static_cast<GSRendererType>(r.id) == renderer_setting)
+		if (static_cast<GSRendererType>(r.value) == renderer_setting)
 		{
 			renderer_sel = renderer_setting;
 		}
 	}
 
-	ComboBoxInit(IDC_RENDERER, renderers, static_cast<uint32>(renderer_sel));
+	ComboBoxInit(IDC_RENDERER, renderers, static_cast<int32_t>(renderer_sel));
 }
 
 void GSSettingsDlg::UpdateControls()

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -43,14 +43,14 @@ GSState::GSState()
 	, m_crcinited(false)
 {
 	m_nativeres = theApp.GetConfig("upscale_multiplier",1) == 1;
-	m_mipmap = !!theApp.GetConfig("mipmap", 1);
+	m_mipmap = theApp.GetConfig("mipmap", true);
 
 	s_n     = 0;
-	s_dump  = !!theApp.GetConfig("dump", 0);
-	s_save  = !!theApp.GetConfig("save", 0);
-	s_savet = !!theApp.GetConfig("savet", 0);
-	s_savez = !!theApp.GetConfig("savez", 0);
-	s_savef = !!theApp.GetConfig("savef", 0);
+	s_dump  = theApp.GetConfig("dump", false);
+	s_save = theApp.GetConfig("save", false);
+	s_savet = theApp.GetConfig("savet", false);
+	s_savez = theApp.GetConfig("savez", false);
+	s_savef = theApp.GetConfig("savef", false);
 	s_saven = theApp.GetConfig("saven", 0);
 	s_savel = theApp.GetConfig("savel", 5000);
 #ifdef __linux__
@@ -68,7 +68,7 @@ GSState::GSState()
 	//s_saven = 0;
 	//s_savel = 0;
 
-	UserHacks_WildHack = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_WildHack", 0) : 0;
+	UserHacks_WildHack = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_WildHack", 0) : 0;
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
 	s_crc_hack_level = m_crc_hack_level;
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -33,8 +33,8 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 	UserHacks_HalfPixelOffset = !!theApp.GetConfig("UserHacks", 0) && !!theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
 
 	m_paltex = !!theApp.GetConfig("paltex", 0);
-	m_preload_frame = theApp.GetConfig("preload_frame_with_gs_data", 0);
-	m_can_convert_depth = s_IS_OPENGL ? theApp.GetConfig("texture_cache_depth", 1) : 0;
+	m_preload_frame = theApp.GetConfig("preload_frame_with_gs_data", false);
+	m_can_convert_depth = s_IS_OPENGL ? theApp.GetConfig("texture_cache_depth", true) : false;
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
 	
 	m_temp = (uint8*)_aligned_malloc(1024 * 1024 * sizeof(uint32), 32);

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -27,12 +27,12 @@ bool s_IS_OPENGL = false;
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
 {
-	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default))) == GSRendererType::OGL_HW);
+	s_IS_OPENGL = (theApp.GetConfig("Renderer", GSRendererType::Default) == GSRendererType::OGL_HW);
 
-	m_spritehack = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_SpriteHack", 0) : 0;
-	UserHacks_HalfPixelOffset = !!theApp.GetConfig("UserHacks", 0) && !!theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
+	m_spritehack = theApp.GetConfig("UserHacks", false) ? theApp.GetConfig("UserHacks_SpriteHack", 0) : 0;
+	UserHacks_HalfPixelOffset = theApp.GetConfig("UserHacks", false) && theApp.GetConfig("UserHacks_HalfPixelOffset", false);
 
-	m_paltex = !!theApp.GetConfig("paltex", 0);
+	m_paltex = theApp.GetConfig("paltex", false);
 	m_preload_frame = theApp.GetConfig("preload_frame_with_gs_data", false);
 	m_can_convert_depth = s_IS_OPENGL ? theApp.GetConfig("texture_cache_depth", true) : false;
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -290,30 +290,57 @@ void GSdxApp::SetConfigDir(const char* dir)
 	}
 }
 
+template<>
+int GSdxApp::GetConfig<int>(const char* entry, int value)
+{
+	return GetPrivateProfileInt(m_section.c_str(), entry, value, m_ini.c_str());
+}
+
+template<>
+bool GSdxApp::GetConfig<bool>(const char* entry, bool value)
+{
+	return GetConfig(entry, value ? 1 : 0) != 0;
+}
+
+template<>
+string GSdxApp::GetConfig<string>(const char* entry, string value)
+{
+	return GSdxApp::GetConfig(entry, value.c_str());
+}
+
 string GSdxApp::GetConfig(const char* entry, const char* value)
 {
-	char buff[4096] = {0};
+	char buff[4096] = { 0 };
 
 	GetPrivateProfileString(m_section.c_str(), entry, value, buff, countof(buff), m_ini.c_str());
 
 	return string(buff);
 }
 
-void GSdxApp::SetConfig(const char* entry, const char* value)
-{
-	WritePrivateProfileString(m_section.c_str(), entry, value, m_ini.c_str());
-}
-
-int GSdxApp::GetConfig(const char* entry, int value)
-{
-	return GetPrivateProfileInt(m_section.c_str(), entry, value, m_ini.c_str());
-}
-
-void GSdxApp::SetConfig(const char* entry, int value)
+template<>
+void GSdxApp::SetConfig<int>(const char* entry, int value)
 {
 	char buff[32] = {0};
 
 	sprintf(buff, "%d", value);
 
 	SetConfig(entry, buff);
+}
+
+template<>
+void GSdxApp::SetConfig<bool>(const char* entry, bool value)
+{
+	SetConfig(entry, value ? 1 : 0);
+}
+
+template<>
+void GSdxApp::SetConfig<const char*>(const char* entry, const char* value)
+{
+	WritePrivateProfileString(m_section.c_str(), entry, value, m_ini.c_str());
+}
+
+template<>
+void GSdxApp::SetConfig<char*>(const char* entry, char* value)
+{
+	SetConfig(entry, (const char*)value);
 }

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -128,20 +128,20 @@ GSdxApp::GSdxApp()
 	m_ini = "inis/GSdx.ini";
 	m_section = "Settings";
 
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_HW),			"Direct3D9",	"Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_SW),			"Direct3D9",	"Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_OpenCL),		"Direct3D9",	"OpenCL"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_Null),		"Direct3D9",	"Null"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_HW),		"Direct3D",		"Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_SW),		"Direct3D",		"Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_OpenCL),	"Direct3D",		"OpenCL"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_Null),	"Direct3D",		"Null"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null_SW),		"Null",			"Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null_OpenCL),	"Null",			"OpenCL"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null_Null),		"Null",			"Null"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW),			"OpenGL",		"Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW),			"OpenGL",		"Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_OpenCL),		"OpenGL",		"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX9_HW,			"Direct3D9",	"Hardware"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX9_SW,			"Direct3D9",	"Software"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX9_OpenCL,		"Direct3D9",	"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX9_Null,		"Direct3D9",	"Null"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX1011_HW,		"Direct3D",		"Hardware"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX1011_SW,		"Direct3D",		"Software"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX1011_OpenCL,	"Direct3D",		"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::DX1011_Null,		"Direct3D",		"Null"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::Null_SW,			"Null",			"Software"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::Null_OpenCL,		"Null",			"OpenCL"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::Null_Null,		"Null",			"Null"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::OGL_HW,			"OpenGL",		"Hardware"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::OGL_SW,			"OpenGL",		"Software"));
+	m_gs_renderers.push_back(GSSetting(GSRendererType::OGL_OpenCL,		"OpenGL",		"OpenCL"));
 
 	m_gs_interlace.push_back(GSSetting(0, "None", ""));
 	m_gs_interlace.push_back(GSSetting(1, "Weave tff", "saw-tooth"));

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -51,11 +51,9 @@ public:
 
 	bool LoadResource(int id, vector<unsigned char>& buff, const char* type = NULL);
 
+	template<typename T> T GetConfig(const char* entry, T value);
 	string GetConfig(const char* entry, const char* value);
-	void SetConfig(const char* entry, const char* value);
-	int GetConfig(const char* entry, int value);
-	void SetConfig(const char* entry, int value);
-
+	template<typename T> void SetConfig(const char* entry, T value);
 	void SetConfigDir(const char* dir);
 
 	vector<GSSetting> m_gs_renderers;
@@ -76,6 +74,28 @@ public:
 	vector<GSSetting> m_gpu_aspectratio;
 	vector<GSSetting> m_gpu_scale;
 };
+
+// Generic methods need to move to the header to allow definition on demand
+template< typename T >
+T GSdxApp::GetConfig(const char* entry, T value)
+{
+	return static_cast<T>(GetConfig(entry, static_cast<int>(value)));
+}
+
+template<typename T>
+void GSdxApp::SetConfig(const char* entry, T value)
+{
+	SetConfig(entry, static_cast<int>(value));
+}
+
+template<> string GSdxApp::GetConfig<string>(const char* entry, string value);
+template<> int GSdxApp::GetConfig<int>(const char* entry, int value);
+template<> bool GSdxApp::GetConfig<bool>(const char* entry, bool value);
+
+template<> void GSdxApp::SetConfig<const char*>(const char* entry, const char* value);
+template<> void GSdxApp::SetConfig<char*>(const char* entry, char* value);
+template<> void GSdxApp::SetConfig<int>(const char* entry, int value);
+template<> void GSdxApp::SetConfig<bool>(const char* entry, bool value);
 
 struct GSDXError {};
 struct GSDXRecoverableError : GSDXError {};


### PR DESCRIPTION
This commit enables the possibility to load settings in the same datatype as they are expected. This should increase flexability, readability (and possibly uncritical speed).

This is achieved by making GsdxApp::GetConfig generic. The two current implementations are given as specialization. Additionally as third specialization a boolean value can now be read.

The PR consists currently of three commits:
1. making GsdxApp:GetConfig generic as described above
2. Fixing warnings that appear if somebody requests bool = theApp.GetConfig( [ * ], 0/1) as an implicit conversion from int to bool happens.
3. Fixing if somebody requests bool = !!theApp.GetConfig( [ * ], 0/1) as one can now directly get the boolean value by bool = theApp.GetConfig( [*], false/true)



This pr is open for discussion. It is not in mergable state. I just wanted to know if there is general interest in implementing such a system. If you like it this PR is probably the first of three to make GSSettings and config load more flexible and readable. ( the other two are SetConfig and GSSetting uint-issue)