### PR TITLE
cmake: reenable a couple of missing gcc optimization

### DIFF
--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -12,14 +12,6 @@ set(CommonFlags
 	-fno-strict-aliasing
     )
 
-#Clang doesn't support a few common flags that GCC does.
-if(NOT USE_CLANG)
-	set(UtilitiesFinalFlags
-		${UtilitiesFinalFlags}
-		${CommonFlags} -fno-guess-branch-probability -fno-dse -fno-tree-dse
-	)
-endif(NOT USE_CLANG) 
-
 # Debug - Build
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
 	

--- a/common/src/x86emitter/CMakeLists.txt
+++ b/common/src/x86emitter/CMakeLists.txt
@@ -12,14 +12,6 @@ set(CommonFlags
 	-fno-strict-aliasing
     )
 
-#Clang doesn't support a few common flags that GCC does.
-if(NOT USE_CLANG)
-	set(x86emitterFinalFlags
-		${x86emitterFinalFlags}
-		${CommonFlags} -fno-guess-branch-probability -fno-dse -fno-tree-dse
-	)
-endif(NOT USE_CLANG)
-
 # Debug - Build
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
 	# add defines

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -22,15 +22,12 @@ set(CommonFlags
     -DWX_PRECOMP
 	)
 
-#Clang doesn't support a few common flags that GCC does.
-if(NOT USE_CLANG)
-	set(pcsx2FinalFlags ${CommonFlags} -fno-guess-branch-probability -fno-dse -fno-tree-dse)
-endif()
-
 if ("${PGO}" STREQUAL "generate")
-    set(pcsx2FinalFlags ${pcsx2FinalFlags} -fprofile-generate)
+    set(pcsx2FinalFlags -fprofile-generate)
 elseif("${PGO}" STREQUAL "use")
-    set(pcsx2FinalFlags ${pcsx2FinalFlags} -fprofile-use)
+    set(pcsx2FinalFlags -fprofile-use)
+else()
+    set(pcsx2FinalFlags "")
 endif()
 
 # Debug - Build


### PR DESCRIPTION
Require linux testing