### PR TITLE
Recompiler block mgt v2

### DIFF
--- a/pcsx2/x86/BaseblockEx.cpp
+++ b/pcsx2/x86/BaseblockEx.cpp
@@ -70,13 +70,11 @@ BASEBLOCKEX* BaseBlocks::GetByX86(uptr ip)
 }
 #endif
 
-void BaseBlocks::Link(u32 pc, s32* jumpptr)
+void BaseBlocks::Link(u32 pc, BASEBLOCK* dst_block, s32* jumpptr)
 {
-	BASEBLOCKEX *targetblock = Get(pc);
-	if (targetblock && targetblock->startpc == pc)
-		*jumpptr = (s32)(targetblock->fnptr - (sptr)(jumpptr + 1));
-	else
-		*jumpptr = (s32)(recompiler - (sptr)(jumpptr + 1));
-	links.insert(std::pair<u32, uptr>(pc, (uptr)jumpptr));
+	if (dst_block) {
+		*jumpptr = (s32)(dst_block->GetFnptr() - (sptr)(jumpptr + 1));
+		links.insert(std::pair<u32, uptr>(pc, (uptr)jumpptr));
+	}
 }
 

--- a/pcsx2/x86/BaseblockEx.h
+++ b/pcsx2/x86/BaseblockEx.h
@@ -264,35 +264,6 @@ public:
 		return removed;
 	}
 
-	__fi void Remove(int first, int last)
-	{
-		pxAssert(first <= last);
-		int idx = first;
-		do{
-			pxAssert(idx <= last);
-
-			//u32 startpc = blocks[idx].startpc;
-			std::pair<linkiter_t, linkiter_t> range = links.equal_range(blocks[idx].startpc);
-			for (linkiter_t i = range.first; i != range.second; ++i)
-				*(u32*)i->second = recompiler - (i->second + 4);
-
-			if( IsDevBuild )
-			{
-				// Clear the first instruction to 0xcc (breakpoint), as a way to assert if some
-				// static jumps get left behind to this block.  Note: Do not clear more than the
-				// first byte, since this code is called during exception handlers and event handlers
-				// both of which expect to be able to return to the recompiled code.
-
-				BASEBLOCKEX effu( blocks[idx] );
-				memset( (void*)effu.fnptr, 0xcc, 1 );
-			}
-		}
-		while(idx++ < last);
-
-		// TODO: remove links from this block?
-		blocks.erase(first, last + 1);
-	}
-
 	void Link(u32 pc, s32* jumpptr);
 
 	__fi void Reset()

--- a/pcsx2/x86/BaseblockEx.h
+++ b/pcsx2/x86/BaseblockEx.h
@@ -264,7 +264,7 @@ public:
 		return removed;
 	}
 
-	void Link(u32 pc, s32* jumpptr);
+	void Link(u32 pc, BASEBLOCK* dst_block, s32* jumpptr);
 
 	__fi void Reset()
 	{

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1051,10 +1051,12 @@ static void __fastcall iopRecRecompile( const u32 startpc )
 
 	pxAssert(s_pCurBlock->GetFnptr() == (uptr)iopJITCompile);
 
-	s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
+	if (IsDevBuild) {
+		s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
+		pxAssert(!s_pCurBlockEx || s_pCurBlockEx->startpc != HWADDR(startpc));
+	}
 
-	if(!s_pCurBlockEx || s_pCurBlockEx->startpc != HWADDR(startpc))
-		s_pCurBlockEx = recBlocks.New(HWADDR(startpc), (uptr)recPtr);
+	s_pCurBlockEx = recBlocks.New(HWADDR(startpc), (uptr)recPtr);
 
 	psxbranch = 0;
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -767,6 +767,13 @@ void R5900::Dynarec::OpcodeImpl::recBREAK()
 // Size is in dwords (4 bytes)
 void recClear(u32 addr, u32 size)
 {
+#if 1
+
+	addr = HWADDR(addr);
+	u32 end = addr + size * 4 - 4;
+	recBlocks.RemoveRange(end, addr, end, PC_GETBLOCK(addr & ~0xFFF));
+
+#else
 	if ((addr) >= maxrecmem || !(recLUT[(addr) >> 16] + (addr & ~0xFFFFUL)))
 		return;
 	addr = HWADDR(addr);
@@ -832,6 +839,7 @@ void recClear(u32 addr, u32 size)
 
 	if (upperextent > lowerextent)
 		ClearRecLUT(PC_GETBLOCK(lowerextent), upperextent - lowerextent);
+#endif
 }
 
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -103,7 +103,7 @@ static EEINST* s_psaveInstInfo = NULL;
 static u32 s_savenBlockCycles = 0;
 
 #ifdef PCSX2_DEBUG
-static u32 dumplog = 0;
+static const u32 dumplog = 0;
 #else
 #define dumplog 0
 #endif
@@ -1556,15 +1556,19 @@ static void __fastcall recRecompile( const u32 startpc )
 	xSetPtr( recPtr );
 	recPtr = xGetAlignedCallTarget();
 
+#ifdef PCSX2_DEBUG
 	if (0x8000d618 == startpc)
 		DbgCon.WriteLn("Compiling block @ 0x%08x", startpc);
+#endif
 
 	s_pCurBlock = PC_GETBLOCK(startpc);
 
 	pxAssert(s_pCurBlock->GetFnptr() == (uptr)JITCompile);
 
+#ifdef PCSX2_DEBUG
 	s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
 	pxAssert(!s_pCurBlockEx || s_pCurBlockEx->startpc != HWADDR(startpc));
+#endif
 
 	s_pCurBlockEx = recBlocks.New(HWADDR(startpc), (uptr)recPtr);
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -89,7 +89,6 @@ static u32 *recConstBufPtr = NULL;
 EEINST* s_pInstCache = NULL;
 static u32 s_nInstCacheSize = 0;
 
-static BASEBLOCK* s_pCurBlock = NULL;
 static BASEBLOCKEX* s_pCurBlockEx = NULL;
 u32 s_nEndBlock = 0; // what pc the current block ends
 u32 s_branchTo;
@@ -969,7 +968,7 @@ static void iBranchTest(u32 newpc)
 		if (newpc == 0xffffffff)
 			xJS( DispatcherReg );
 		else
-			recBlocks.Link(HWADDR(newpc), xJcc32(Jcc_Signed));
+			recBlocks.Link(HWADDR(newpc), PC_GETBLOCK(HWADDR(newpc)), xJcc32(Jcc_Signed));
 
 		xJMP( (void*)DispatcherEvent );
 	}
@@ -1561,9 +1560,14 @@ static void __fastcall recRecompile( const u32 startpc )
 		DbgCon.WriteLn("Compiling block @ 0x%08x", startpc);
 #endif
 
-	s_pCurBlock = PC_GETBLOCK(startpc);
+	{ // Update the function pointer of the current base block
+		BASEBLOCK* cur_base_block = PC_GETBLOCK(startpc);
 
-	pxAssert(s_pCurBlock->GetFnptr() == (uptr)JITCompile);
+		pxAssert(cur_base_block->GetFnptr() == (uptr)JITCompile);
+
+		cur_base_block->SetFnptr((uptr)recPtr);
+	}
+
 
 #ifdef PCSX2_DEBUG
 	s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
@@ -1956,7 +1960,6 @@ StartRecomp:
 
 	pxAssert( (pc-startpc)>>2 <= 0xffff );
 	s_pCurBlockEx->size = (pc-startpc)>>2;
-	s_pCurBlock->SetFnptr((uptr)recPtr);
 
 	if( !(pc&0x10000000) )
 		maxrecmem = std::max( (pc&~0xa0000000), maxrecmem );
@@ -1994,7 +1997,7 @@ StartRecomp:
 			{
 				xMOV( ptr32[&cpuRegs.pc], pc );
 				xADD( ptr32[&cpuRegs.cycle], scaleblockcycles() );
-				recBlocks.Link( HWADDR(pc), xJcc32() );
+				recBlocks.Link( HWADDR(pc), PC_GETBLOCK(HWADDR(pc)), xJcc32() );
 			}
 		}
 	}
@@ -2017,7 +2020,6 @@ StartRecomp:
 
 	pxAssert( (g_cpuHasConstReg&g_cpuFlushedConstReg) == g_cpuHasConstReg );
 
-	s_pCurBlock = NULL;
 	s_pCurBlockEx = NULL;
 }
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -326,7 +326,6 @@ typedef void DynGenFunc();
 static DynGenFunc* DispatcherEvent		= NULL;
 static DynGenFunc* DispatcherReg		= NULL;
 static DynGenFunc* JITCompile			= NULL;
-static DynGenFunc* JITCompileInBlock	= NULL;
 static DynGenFunc* EnterRecompiledCode	= NULL;
 static DynGenFunc* ExitRecompiledCode	= NULL;
 static DynGenFunc* DispatchBlockDiscard = NULL;
@@ -353,13 +352,6 @@ static DynGenFunc* _DynGen_JITCompile()
 	xMOV( ecx, ptr[recLUT + (eax*4)] );
 	xJMP( ptr32[ecx+ebx] );
 
-	return (DynGenFunc*)retval;
-}
-
-static DynGenFunc* _DynGen_JITCompileInBlock()
-{
-	u8* retval = xGetAlignedCallTarget();
-	xJMP( (void*)JITCompile );
 	return (DynGenFunc*)retval;
 }
 
@@ -442,7 +434,6 @@ static void _DynGen_Dispatchers()
 	DispatcherReg	= _DynGen_DispatcherReg();
 
 	JITCompile           = _DynGen_JITCompile();
-	JITCompileInBlock    = _DynGen_JITCompileInBlock();
 	EnterRecompiledCode  = _DynGen_EnterRecompiledCode();
 	DispatchBlockDiscard = _DynGen_DispatchBlockDiscard();
 	DispatchPageReset    = _DynGen_DispatchPageReset();
@@ -1578,8 +1569,7 @@ static void __fastcall recRecompile( const u32 startpc )
 
 	s_pCurBlock = PC_GETBLOCK(startpc);
 
-	pxAssert(s_pCurBlock->GetFnptr() == (uptr)JITCompile
-		|| s_pCurBlock->GetFnptr() == (uptr)JITCompileInBlock);
+	pxAssert(s_pCurBlock->GetFnptr() == (uptr)JITCompile);
 
 	s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
 	pxAssert(!s_pCurBlockEx || s_pCurBlockEx->startpc != HWADDR(startpc));
@@ -1706,7 +1696,7 @@ static void __fastcall recRecompile( const u32 startpc )
 				break;
 			}
 
-			if (pblock->GetFnptr() != (uptr)JITCompile && pblock->GetFnptr() != (uptr)JITCompileInBlock)
+			if (pblock->GetFnptr() != (uptr)JITCompile)
 			{
 				willbranch3 = 1;
 				s_nEndBlock = i;
@@ -1998,11 +1988,6 @@ StartRecomp:
 	}
 
 	s_pCurBlock->SetFnptr((uptr)recPtr);
-
-	for(i = 1; i < (u32)s_pCurBlockEx->size; i++) {
-		if ((uptr)JITCompile == s_pCurBlock[i].GetFnptr())
-			s_pCurBlock[i].SetFnptr((uptr)JITCompileInBlock);
-	}
 
 	if( !(pc&0x10000000) )
 		maxrecmem = std::max( (pc&~0xa0000000), maxrecmem );


### PR DESCRIPTION
The goals are to
- Factorize clear code between IOP/EE
- Better detection of overlapping
- Remove various overlapping hack (which I'm not sure was useful on the current state of the recompiler)

Remain to find some games that were really relying on those overlap hacks.
