### PR TITLE
Dev9ghz: Fix crash on close when ethernet adapter fails to load in winPcap

### DIFF
--- a/plugins/dev9ghzdrk/DEV9.cpp
+++ b/plugins/dev9ghzdrk/DEV9.cpp
@@ -246,6 +246,9 @@ void _DEV9irq(int cause, int cycles)
 
 
 u8  CALLBACK DEV9read8(u32 addr) {
+	if (!config.ethEnable & !config.hddEnable)
+		return 0;
+
 	u8 hard;
 	if (addr>=ATA_DEV9_HDD_BASE && addr<ATA_DEV9_HDD_END)
 	{
@@ -311,6 +314,9 @@ u8  CALLBACK DEV9read8(u32 addr) {
 
 u16 CALLBACK DEV9read16(u32 addr)
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return 0;
+
 	u16 hard;
 	if (addr>=ATA_DEV9_HDD_BASE && addr<ATA_DEV9_HDD_END)
 	{
@@ -373,6 +379,9 @@ u16 CALLBACK DEV9read16(u32 addr)
 
 u32 CALLBACK DEV9read32(u32 addr)
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return 0;
+
 	u32 hard;
 	if (addr>=ATA_DEV9_HDD_BASE && addr<ATA_DEV9_HDD_END)
 	{
@@ -405,6 +414,9 @@ u32 CALLBACK DEV9read32(u32 addr)
 
 void CALLBACK DEV9write8(u32 addr,  u8 value) 
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return;
+
 	if (addr>=ATA_DEV9_HDD_BASE && addr<ATA_DEV9_HDD_END)
 	{
 #ifdef ENABLE_ATA
@@ -512,6 +524,9 @@ void CALLBACK DEV9write8(u32 addr,  u8 value)
 
 void CALLBACK DEV9write16(u32 addr, u16 value) 
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return;
+
 	if (addr>=ATA_DEV9_HDD_BASE && addr<ATA_DEV9_HDD_END)
 	{
 #ifdef ENABLE_ATA
@@ -552,6 +567,9 @@ void CALLBACK DEV9write16(u32 addr, u16 value)
 
 void CALLBACK DEV9write32(u32 addr, u32 value) 
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return;
+
 	if (addr>=ATA_DEV9_HDD_BASE && addr<ATA_DEV9_HDD_END)
 	{
 #ifdef ENABLE_ATA
@@ -586,6 +604,9 @@ void CALLBACK DEV9write32(u32 addr, u32 value)
 
 void CALLBACK DEV9readDMA8Mem(u32 *pMem, int size) 
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return;
+
 	DEV9_LOG("*DEV9readDMA8Mem: size %x\n", size);
 	emu_printf("rDMA\n");
 	
@@ -597,6 +618,9 @@ void CALLBACK DEV9readDMA8Mem(u32 *pMem, int size)
 
 void CALLBACK DEV9writeDMA8Mem(u32* pMem, int size) 
 {
+	if (!config.ethEnable & !config.hddEnable)
+		return;
+
 	DEV9_LOG("*DEV9writeDMA8Mem: size %x\n", size);
 	emu_printf("wDMA\n");
 	

--- a/plugins/dev9ghzdrk/Win32/Win32.cpp
+++ b/plugins/dev9ghzdrk/Win32/Win32.cpp
@@ -175,16 +175,25 @@ UINT DEV9ThreadProc() {
 }*/
 NetAdapter* GetNetAdapter()
 {
+	NetAdapter* na;
 	if(config.Eth[0]=='p')
 	{
-		return new PCAPAdapter();
+		na = new PCAPAdapter();
 	}
 	else if (config.Eth[0]=='t')
 	{
-		return new TAPAdapter();
+		na = new TAPAdapter();
 	}
 	else
 		return 0;
+
+
+	if (!na->isInitialised())
+	{
+		delete na;
+		return 0;
+	}
+	return na;
 }
 s32  _DEV9open() 
 {

--- a/plugins/dev9ghzdrk/Win32/Win32.cpp
+++ b/plugins/dev9ghzdrk/Win32/Win32.cpp
@@ -204,6 +204,7 @@ s32  _DEV9open()
 	if (!na)
 	{
 		emu_printf("Failed to GetNetAdapter()\n");
+		config.ethEnable = false;
 	}
 	else
 	{

--- a/plugins/dev9ghzdrk/Win32/net.cpp
+++ b/plugins/dev9ghzdrk/Win32/net.cpp
@@ -42,7 +42,8 @@ DWORD WINAPI NetRxThread(LPVOID lpThreadParameter)
 
 void tx_put(NetPacket* pkt)
 {
-	nif->send(pkt);
+	if (nif!=NULL)
+		nif->send(pkt);
 	//pkt must be copied if its not processed by here, since it can be allocated on the callers stack
 }
 void InitNet(NetAdapter* ad)
@@ -65,5 +66,6 @@ void TermNet()
 		emu_printf(".done\n");
 
 		delete nif;
+		nif = NULL;
 	}
 }

--- a/plugins/dev9ghzdrk/Win32/net.h
+++ b/plugins/dev9ghzdrk/Win32/net.h
@@ -34,6 +34,7 @@ class NetAdapter
 {
 public:
 	virtual bool blocks()=0;
+	virtual bool isInitialised() = 0;
 	virtual bool recv(NetPacket* pkt)=0;	//gets a packet
 	virtual bool send(NetPacket* pkt)=0;	//sends the packet and deletes it when done
 	virtual ~NetAdapter(){}

--- a/plugins/dev9ghzdrk/Win32/pcap_io.h
+++ b/plugins/dev9ghzdrk/Win32/pcap_io.h
@@ -168,6 +168,7 @@ class PCAPAdapter : public NetAdapter
 public:
 	PCAPAdapter();
 	virtual bool blocks();
+	virtual bool isInitialised();
 	//gets a packet.rv :true success
 	virtual bool recv(NetPacket* pkt);
 	//sends the packet and deletes it when done (if successful).rv :true success

--- a/plugins/dev9ghzdrk/Win32/tap-win32.cpp
+++ b/plugins/dev9ghzdrk/Win32/tap-win32.cpp
@@ -381,6 +381,10 @@ bool TAPAdapter::blocks()
 {
 	return true;	//we use blocking io
 }
+bool TAPAdapter::isInitialised()
+{
+	return (htap != NULL);
+}
 u8 broadcast_adddrrrr[6]={0xFF,0xFF,0xFF,0xFF,0xFF,0xFF};
 //gets a packet.rv :true success
 bool TAPAdapter::recv(NetPacket* pkt)

--- a/plugins/dev9ghzdrk/Win32/tap.h
+++ b/plugins/dev9ghzdrk/Win32/tap.h
@@ -31,6 +31,7 @@ class TAPAdapter : public NetAdapter
 public:
 	TAPAdapter();
 	virtual bool blocks();
+	virtual bool isInitialised();
 	//gets a packet.rv :true success
 	virtual bool recv(NetPacket* pkt);
 	//sends the packet and deletes it when done (if successful).rv :true success

--- a/plugins/dev9ghzdrk/pcap_io.cpp
+++ b/plugins/dev9ghzdrk/pcap_io.cpp
@@ -117,9 +117,12 @@ int pcap_io_init(char *adapter)
 							 errbuf			// error buffer
 							 )) == NULL)
 	{
+		fprintf(stderr, errbuf);
 		fprintf(stderr,"\nUnable to open the adapter. %s is not supported by WinPcap\n", adapter);
 		return -1;
 	}
+
+	
 
 	dlt = pcap_datalink(adhandle);
 	dlt_name = (char*)pcap_datalink_val_to_name(dlt);
@@ -326,7 +329,8 @@ void pcap_io_close()
 		fclose(packet_log);
 	if(dump_pcap)
 		pcap_dump_close(dump_pcap);
-	pcap_close(adhandle);  
+	if (adhandle)
+		pcap_close(adhandle);  
 	pcap_io_running=0;
 }
 
@@ -428,6 +432,10 @@ PCAPAdapter::PCAPAdapter()
 bool PCAPAdapter::blocks()
 {
 	return false;
+}
+bool PCAPAdapter::isInitialised()
+{
+	return pcap_io_running;
 }
 //gets a packet.rv :true success
 bool PCAPAdapter::recv(NetPacket* pkt)


### PR DESCRIPTION
 Fix crash on close/shutdown when we fail to load the selected Ethernet adapter in WinPcap.

The plugin will now also behave like dev9null when Ethernet is disabled (which will be done when we encounter the above situation).

Should Fix https://github.com/PCSX2/pcsx2/issues/959