### PR TITLE
FolderMemoryCard: Fix issue #976: Corrupted FF12 saves when overwriting data.

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -904,6 +904,7 @@ void FolderMemoryCard::Flush() {
 	}
 
 	m_lastAccessedFile.FlushAll();
+	m_lastAccessedFile.ClearMetadataWriteState();
 	m_oldDataCache.clear();
 
 	const u64 timeFlushEnd = wxGetLocalTimeMillis().GetValue();
@@ -1516,6 +1517,10 @@ void FileAccessHelper::FlushAll() {
 	for ( auto it = m_files.begin(); it != m_files.end(); ++it ) {
 		it->second.fileHandle->Flush();
 	}
+}
+
+void FileAccessHelper::ClearMetadataWriteState() {
+	m_lastWrittenFileRef = nullptr;
 }
 
 bool FileAccessHelper::CleanMemcardFilename( char* name ) {

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -202,13 +202,18 @@ struct MemoryCardFileMetadataReference {
 	void GetInternalPath( std::string* fileName ) const;
 };
 
+struct MemoryCardFileHandleStructure {
+	MemoryCardFileMetadataReference* fileRef;
+	wxFFile* fileHandle;
+};
+
 // --------------------------------------------------------------------------------------
 //  FileAccessHelper
 // --------------------------------------------------------------------------------------
 // Small helper class to keep memory card files opened between calls to Read()/Save() 
 class FileAccessHelper {
 protected:
-	std::map<std::string, wxFFile*> m_files;
+	std::map<std::string, MemoryCardFileHandleStructure> m_files;
 	MemoryCardFileMetadataReference* m_lastWrittenFileRef; // we remember this to reduce redundant metadata checks/writes
 
 public:

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -24,6 +24,8 @@
 #include "PluginCallbacks.h"
 #include "AppConfig.h"
 
+//#define DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
+
 // --------------------------------------------------------------------------------------
 //  Superblock Header Struct
 // --------------------------------------------------------------------------------------
@@ -347,6 +349,8 @@ public:
 	void NextFrame();
 
 	static void CalculateECC( u8* ecc, const u8* data );
+
+	void WriteToFile( const wxString& filename );
 
 protected:
 	// initializes memory card data, as if it was fresh from the factory

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -229,6 +229,9 @@ public:
 	// Flush the written data of all open files to the file system
 	void FlushAll();
 
+	// Force metadata to be written on next file access, not sure if this is necessary but it can't hurt.
+	void ClearMetadataWriteState();
+
 	// removes characters from a PS2 file name that would be illegal in a Windows file system
 	// returns true if any changes were made
 	static bool CleanMemcardFilename( char* name );

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -197,6 +197,9 @@ struct MemoryCardFileMetadataReference {
 
 	// returns true if filename was modified and metadata containing the actual filename should be written
 	bool GetPath( wxFileName* fileName ) const;
+
+	// gives the internal memory card file system path, not to be used for writes to the host file system
+	void GetInternalPath( std::string* fileName ) const;
 };
 
 // --------------------------------------------------------------------------------------
@@ -205,7 +208,7 @@ struct MemoryCardFileMetadataReference {
 // Small helper class to keep memory card files opened between calls to Read()/Save() 
 class FileAccessHelper {
 protected:
-	std::map<const MemoryCardFileEntry* const, wxFFile*> m_files;
+	std::map<std::string, wxFFile*> m_files;
 	MemoryCardFileMetadataReference* m_lastWrittenFileRef; // we remember this to reduce redundant metadata checks/writes
 
 public:


### PR DESCRIPTION
This fixes a bug introduced in 879d0c601f9baf4539d142a22907cee3d74f2a2d that allowed the folder memory card to write data to the wrong host file system file when metadata to a file gets written to the memory location where metadata for a different file existed before.

There's also a commit (186d58af019575ebf2cbd9b34b76a43096835f36) with debugging functionality in here that writes out the internal memory card on load and flush for comparison purposes. It's #defined out, so if you don't mind, I'd like to leave that in so I can just quickly enable that when other issues pop up.

I haven't tested this extensively, just a few games and the BIOS, so if someone wants to run this on a couple games before merging that's probably not a bad idea. This definitely fixes the cause of #976, though.