### PR TITLE
SPU2-X: Minor changes to dialog and stuffs 

### DIFF
--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -63,7 +63,7 @@ float VolumeAdjustBR;
 float VolumeAdjustSL;
 float VolumeAdjustSR;
 float VolumeAdjustLFE;
-int delayCycles;
+unsigned int delayCycles;
 
 bool postprocess_filter_enabled = true;
 bool postprocess_filter_dealias = false;

--- a/plugins/spu2-x/src/SndOut.h
+++ b/plugins/spu2-x/src/SndOut.h
@@ -45,7 +45,7 @@ extern float VolumeAdjustBR;
 extern float VolumeAdjustSL;
 extern float VolumeAdjustSR;
 extern float VolumeAdjustLFE;
-extern int delayCycles;
+extern unsigned int delayCycles;
 
 struct Stereo51Out16DplII;
 struct Stereo51Out32DplII;

--- a/plugins/spu2-x/src/Windows/Config.cpp
+++ b/plugins/spu2-x/src/Windows/Config.cpp
@@ -58,7 +58,7 @@ float VolumeAdjustBR;
 float VolumeAdjustSL;
 float VolumeAdjustSR;
 float VolumeAdjustLFE;
-int delayCycles;
+unsigned int delayCycles;
 
 bool postprocess_filter_enabled = 1;
 bool postprocess_filter_dealias = false;

--- a/plugins/spu2-x/src/Windows/ConfigSoundtouch.cpp
+++ b/plugins/spu2-x/src/Windows/ConfigSoundtouch.cpp
@@ -98,7 +98,7 @@ BOOL CALLBACK SoundtouchCfg::DialogProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM
 				WriteSettings();
 				EndDialog(hWnd,0);
 			}
-			else if( wmId == IDC_RESET_DEFAULTS ) 
+			else if( wmId == IDC_RESET_DEFAULTS )
 			{
 				SequenceLenMS	= 30;
 				SeekWindowMS	= 20;
@@ -107,6 +107,8 @@ BOOL CALLBACK SoundtouchCfg::DialogProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM
 				SendDialogMsg( hWnd, IDC_SEQLEN_SLIDER, TBM_SETPOS, TRUE, SequenceLenMS );
 				SendDialogMsg( hWnd, IDC_SEEKWIN_SLIDER, TBM_SETPOS, TRUE, SeekWindowMS );
 				SendDialogMsg( hWnd, IDC_OVERLAP_SLIDER, TBM_SETPOS, TRUE, OverlapMS );
+
+				AssignSliderValue((HWND)lParam, hWnd, SequenceLenMS);
 			}
 			else if( wmId == IDCANCEL )
 			{


### PR DESCRIPTION
#### Summary of changes:

* fix some signed/unsigned comparison warnings by changing delayCycles to unsigned similar to the playcycles and current cycles var as negative values are pretty much useless for debug tests.

* better caption text slider value display behavior on Soundtouch configure in case of restore defaults.

