### PR TITLE
Texture-cache: check userhacks value for preload data frame

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -27,14 +27,15 @@ bool s_IS_OPENGL = false;
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
 {
+	bool userhacks = !!theApp.GetConfig("UserHacks", 0);
 	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfig("Renderer", static_cast<int>(GSRendererType::Default))) == GSRendererType::OGL_HW);
 
-	m_spritehack = !!theApp.GetConfig("UserHacks", 0) ? theApp.GetConfig("UserHacks_SpriteHack", 0) : 0;
-	UserHacks_HalfPixelOffset = !!theApp.GetConfig("UserHacks", 0) && !!theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
+	m_spritehack = userhacks ? theApp.GetConfig("UserHacks_SpriteHack", 0) : 0;
+	UserHacks_HalfPixelOffset = userhacks && theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
 
 	m_paltex = !!theApp.GetConfig("paltex", 0);
-	m_preload_frame = theApp.GetConfig("preload_frame_with_gs_data", 0);
-	m_can_convert_depth = s_IS_OPENGL ? theApp.GetConfig("texture_cache_depth", 1) : 0;
+	m_preload_frame = userhacks && theApp.GetConfig("preload_frame_with_gs_data", 0);
+	m_can_convert_depth = s_IS_OPENGL && theApp.GetConfig("texture_cache_depth", 1);
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
 	
 	m_temp = (uint8*)_aligned_malloc(1024 * 1024 * sizeof(uint32), 32);


### PR DESCRIPTION
Previously the Preload data frame option got used without the consideration of the user hacks checkbox value, the following patch fixes the behavior. also removed some ``!!`` operators where it was not necessary and changed the user hacks check to a local variable.

Fix for the GUI issue addressed in #987  