### PR TITLE
Travis CI and Appveyor continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+
+sudo: required
+dist: trusty
+
+matrix:
+  include:
+# Version 5 seems to be whatever is latest - for now it's 5.2
+    - env: VERSION=5
+      compiler: gcc
+      os: linux
+    - env: VERSION=4.9
+      compiler: gcc
+      os: linux
+    - env: VERSION=3.7
+      compiler: clang
+      os: linux
+
+before_install:
+  - ./travis.sh before_install
+
+script:
+  - ./travis.sh script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+# Static build version - changing the version dynamically means you can't
+# just click from github to see how things are progressing until the build has
+# finished, which could be a bit annoying.
+version: 1.{build}-{branch}
+
+environment:
+  matrix:
+  - platform: Win32
+    target: ReleaseAll
+    visualstudio_string: vs2015
+  - platform: Win32
+    VisualStudioVersion: 12.0
+    target: ReleaseAll
+    visualstudio_string: vs2013
+
+init:
+# Use CRLF line endings on Windows so users can just use Notepad.
+  - git config --global core.autocrlf true
+
+build_script:
+  - msbuild buildbot.xml /m /t:%target% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+  - ps: $env:gitrev = git describe --tags
+  - ps: $env:my_version = "$env:gitrev-$env:appveyor_repo_branch-$env:appveyor_build_number"
+  - type NUL > bin\portable.ini
+  - set folder_name=pcsx2-%my_version%-%visualstudio_string%-%platform%-%target%
+  - rename bin %folder_name%
+  - 7z a -mx9 %folder_name%.7z %folder_name%
+
+test: off
+
+artifacts:
+  - path: $(folder_name).7z
+    name: $(visualstudio_string)-$(target)

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+set -ex
+
+linux_before_install() {
+	# Build worker is 64-bit only by default it seems.
+	sudo dpkg --add-architecture i386
+
+	# Compilers
+	if [ "${CXX}" = "clang++" ]; then
+		sudo apt-key adv --fetch-keys http://llvm.org/apt/llvm-snapshot.gpg.key
+		sudo add-apt-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-${VERSION} main"
+		# g++-4.8-multilib is necessary for compiler dependencies. Well, I think
+		# the specific dependency is probably lib32gcc-4.8-dev.
+		COMPILER_PACKAGE="clang-${VERSION} g++-4.8-multilib"
+	fi
+	if [ "${CXX}" = "g++" ]; then
+		sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+		COMPILER_PACKAGE="g++-${VERSION}-multilib"
+	fi
+
+	sudo apt-get -qq update
+
+	# The 64-bit versions of the first 7 dependencies are part of the initial
+	# build image. libgtk2.0-dev:i386 and libsdl2-dev:i386 require the 32-bit
+	# versions of the dependencies, and the 2 versions conflict. So those
+	# dependencies must be explicitly installed.
+	sudo apt-get -qq -y install \
+		gir1.2-freedesktop:i386 \
+		gir1.2-gdkpixbuf-2.0:i386 \
+		gir1.2-glib-2.0:i386 \
+		libcairo2-dev:i386 \
+		libgdk-pixbuf2.0-dev:i386 \
+		libgirepository-1.0-1:i386 \
+		libglib2.0-dev:i386 \
+		libaio-dev:i386 \
+		libasound2-dev:i386 \
+		libgl1-mesa-dev:i386 \
+		libgtk2.0-dev:i386 \
+		liblzma-dev:i386 \
+		libpng12-dev:i386 \
+		libsdl2-dev:i386 \
+		libsoundtouch-dev:i386 \
+		libwxgtk3.0-dev:i386 \
+		libxext-dev:i386 \
+		portaudio19-dev:i386 \
+		zlib1g-dev:i386 \
+		${COMPILER_PACKAGE}
+
+	# libpng++-dev is noarch but doesn't install nicely.
+	apt-get download libpng++-dev
+	sudo dpkg --force-all -i $(ls | grep 'libpng++-dev')
+}
+
+linux_script() {
+	mkdir build
+	cd build
+
+	export CC=${CC}-${VERSION} CXX=${CXX}-${VERSION}
+	cmake \
+		-DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_REPLAY_LOADERS=TRUE \
+		-DCMAKE_BUILD_PO=FALSE \
+		..
+
+	# Documentation says 1.5 cores, so 2 or 3 threads should work ok.
+	make -j3 install
+}
+
+# Just in case I do manual testing and accidentally insert "rm -rf /"
+case "${1}" in
+before_install|script)
+	${TRAVIS_OS_NAME}_${1}
+	;;
+*)
+	echo "Unknown command" && false
+	;;
+esac


### PR DESCRIPTION
I probably should have done this a lot earlier.

I've added yml files for setting up Travis CI and Appveyor. What they currently do:
 - Travis CI - compile tests with gcc-4.9 and clang-3.7. gcc 5.1 and 5.2 spam errors and Travis CI terminates after logs reach 4mb, so they're unusable.
 - AppVeyor - compile tests and creates downloadable release builds with VS2013 and VS2015, which should help with having PRs tested.

This can be changed to cover more/less configurations, or to include/exclude specific branches (I've left it generic enough so other contributors can test their work compiles if they have Travis CI/AppVeyor setup before sending a PR).

Both provide build logs so if compilation fails, you know what the error is.

Someone will still need to do the final setup, which I can't do since I don't have admin level access (necessary for adding repository hooks).