### PR TITLE
gsdx: Generic GSSetting

### DIFF
--- a/plugins/GSdx/GSDialog.cpp
+++ b/plugins/GSdx/GSDialog.cpp
@@ -164,7 +164,7 @@ void GSDialog::SetTextAsInt(UINT id, int i)
 	SetText(id, buff);
 }
 
-void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 selid, uint32 maxid)
+void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue)
 {
 	HWND hWnd = GetDlgItem(m_hWnd, id);
 
@@ -174,7 +174,7 @@ void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 s
 	{
 		const GSSetting& s = settings[i];
 
-		if(s.id <= maxid)
+		if(s.value <= maxValue)
 		{
 			string str(s.name);
 
@@ -183,7 +183,7 @@ void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 s
 				str = str + " (" + s.note + ")";
 			}
 
-			ComboBoxAppend(id, str.c_str(), (LPARAM)s.id, s.id == selid);
+			ComboBoxAppend(id, str.c_str(), (LPARAM)s.value, s.value == selectionValue);
 		}
 	}
 

--- a/plugins/GSdx/GSDialog.h
+++ b/plugins/GSdx/GSDialog.h
@@ -51,7 +51,7 @@ public:
 	void SetText(UINT id, const char* str);
 	void SetTextAsInt(UINT id, int i);
 
-	void ComboBoxInit(UINT id, const vector<GSSetting>& settings, uint32 selid, uint32 maxid = ~0);
+	void ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue = INT32_MAX);
 	int ComboBoxAppend(UINT id, const char* str, LPARAM data = 0, bool select = false);
 	bool ComboBoxGetSelData(UINT id, INT_PTR& data);
 	void ComboBoxFixDroppedWidth(UINT id);

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -54,15 +54,15 @@ void CB_ChangedComboBox(GtkComboBox *combo, gpointer user_data)
 	vector<GSSetting>* s = (vector<GSSetting>*)g_object_get_data(G_OBJECT(combo), "Settings");
 
 	try {
-		theApp.SetConfig((char*)user_data, s->at(p).id);
+		theApp.SetConfig((char*)user_data, s->at(p).value);
 	} catch (...) {
 	}
 }
 
-GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_name, int opt_default = 0)
+GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_name, int32_t opt_default = 0)
 {
 	GtkWidget* combo_box = gtk_combo_box_text_new();
-	int opt_value        = theApp.GetConfig(opt_name, opt_default);
+	int32_t opt_value    = theApp.GetConfig(opt_name, opt_default);
 	int opt_position     = 0;
 
 	for(size_t i = 0; i < s.size(); i++)
@@ -73,7 +73,7 @@ GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_
 
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_box), label.c_str());
 
-		if ((int)s[i].id == opt_value)
+		if (s[i].value == opt_value)
 			opt_position = i;
 	}
 

--- a/plugins/GSdx/GSSetting.h
+++ b/plugins/GSdx/GSSetting.h
@@ -25,16 +25,16 @@
 
 struct GSSetting
 {
-	uint32 id;
+	int32_t value;
 	std::string name;
 	std::string note;
 
-
-	GSSetting(uint32 id, const char* name, const char* note)
+	template< typename T>
+	explicit GSSetting(T value, const char* name, const char* note) :
+		value(static_cast<int32_t>(value)),
+		name(name),
+		note(note)
 	{
-		this->id = id;
-		this->name = name;
-		this->note = note;
 	}
 };
 

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -321,8 +321,8 @@ void GSSettingsDlg::UpdateRenderers()
 	{
 		GSSetting r = theApp.m_gs_renderers[i];
 
-		GSRendererType renderer = static_cast<GSRendererType>(r.id);
-		
+		GSRendererType renderer = static_cast<GSRendererType>(r.value);
+
 		if(renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::DX1011_Null || renderer == GSRendererType::DX1011_OpenCL)
 		{
 			if(level < D3D_FEATURE_LEVEL_10_0) continue;
@@ -335,13 +335,13 @@ void GSSettingsDlg::UpdateRenderers()
 
 		renderers.push_back(r);
 
-		if (static_cast<GSRendererType>(r.id) == renderer_setting)
+		if (static_cast<GSRendererType>(r.value) == renderer_setting)
 		{
 			renderer_sel = renderer_setting;
 		}
 	}
 
-	ComboBoxInit(IDC_RENDERER, renderers, static_cast<uint32>(renderer_sel));
+	ComboBoxInit(IDC_RENDERER, renderers, static_cast<int32_t>(renderer_sel));
 }
 
 void GSSettingsDlg::UpdateControls()


### PR DESCRIPTION
### old implementation
The old implementation saved the current value of a GSSetting as uint in
a field called 'id'. The implementation of GSSettings suggests that
GSSettings could be saved in a database with id as primary key. This
would require a translation look up from id to value but would have all
advantages of a database. However the interface to GSSetting was never
implemented like that.

### new implementation
GSSetting has a 'value' field that stores an int representative value of
the desired state. Additionally the constructor is 'overloaded' as
template to reduce casting in the consumer code. However all consumer
values need to be castable to int.

Accordingly combobox initialization was adjusted.