### PR TITLE
gsdx: Extra rendering threads ambiguity

### DIFF
--- a/plugins/GSdx/GSRasterizer.h
+++ b/plugins/GSdx/GSRasterizer.h
@@ -214,6 +214,14 @@ public:
 		}
 		else
 		{
+			// 1 ERT means that the rendering is handled by one (async) thread. This is similar to 0 ERT where the
+			// rendering is done by the main (sync) thread. Expected behaviour is that if I increase ERT more threads
+			// will handle the rendering. To meet this expectation the number of threads is automatically increased by
+			// one if extra rendering threads are used.
+			// 1 ERT is additionally never a smart choice. Due to sync overhead it should always be outperformed by
+			//  0 ERT or - at best - be as fast.
+			threads++;
+
 			GSRasterizerList* rl = new GSRasterizerList(threads, perfmon);
 
 			for(int i = 0; i < threads; i++)


### PR DESCRIPTION
This PR adjusts the handling of extra rendering threads (ERT).

1. 0 ERT vs 1 ERT
The 1 ERT setting uses counterintuitively the same amount of rendering threads as 0 ERT. They are just async. Most users would expect an increase of rendering threads if the amount of ERT's increases. This PR adds one more thread per setting if ERT's are used (>0)

~~2. Default GS rendering threads~~
~~After some discussion in the forum we considered the typical sw rendering CPU and which setting should be the default value. 2 ERT's  (3 GS threads) + 1 EE (pcsx2) thread fills exactly one QuadCore. ~~This is not an automatic setting but just a better default value than 0 ERT's. 0 ERT would be the best default value for Single/DualCore-CPU's. However most modern CPU's that can handle sw rendering are quadcores.~~
~~Users still might need to adjust this setting to get the optimum (e.g. hyperthreads, dualcores, hexacores...)~~

~~Outsourced to #1048~~
Again outsourced to #1056