### PR TITLE
gsdx: defaulting extra rendering threads to 3

### DIFF
--- a/plugins/GSdx/GPU.cpp
+++ b/plugins/GSdx/GPU.cpp
@@ -108,7 +108,7 @@ EXPORT_C_(int32) GPUopen(void* hWnd)
 #endif
 
 	int renderer = theApp.GetConfig("Renderer", 1);
-	int threads = theApp.GetConfig("extrathreads", 0);
+	int threads = theApp.GetConfig("extrathreads", DEFAULT_EXTRA_RENDERING_THREADS);
 
 	switch(renderer)
 	{

--- a/plugins/GSdx/GPUSettingsDlg.cpp
+++ b/plugins/GSdx/GPUSettingsDlg.cpp
@@ -74,7 +74,7 @@ void GPUSettingsDlg::OnInit()
 	CheckDlgButton(m_hWnd, IDC_WINDOWED, theApp.GetConfig("windowed", 1));
 
 	SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_SETRANGE, 0, MAKELPARAM(16, 0));
-	SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfig("extrathreads", 0), 0));
+	SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfig("extrathreads", DEFAULT_EXTRA_RENDERING_THREADS), 0));
 
 	UpdateControls();
 }

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -190,7 +190,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 
 	if(threads == -1)
 	{
-		threads = theApp.GetConfig("extrathreads", 0);
+		threads = theApp.GetConfig("extrathreads", DEFAULT_EXTRA_RENDERING_THREADS);
 	}
 
 	GSWnd* wnd[2] = { NULL, NULL };

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1280,3 +1280,7 @@ enum {FREEZE_LOAD=0, FREEZE_SAVE=1, FREEZE_SIZE=2};
 struct GSFreezeData {int size; uint8* data;};
 
 enum stateType {ST_WRITE, ST_TRANSFER, ST_VSYNC};
+
+// default gs config settings
+#define DEFAULT_EXTRA_RENDERING_THREADS 3
+

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -286,7 +286,7 @@ void populate_gl_table(GtkWidget* gl_table)
 void populate_sw_table(GtkWidget* sw_table)
 {
 	GtkWidget* threads_label = left_label("Extra rendering threads:");
-	GtkWidget* threads_spin  = CreateSpinButton(0, 32, "extrathreads", 0);
+	GtkWidget* threads_spin  = CreateSpinButton(0, 32, "extrathreads", DEFAULT_EXTRA_RENDERING_THREADS);
 
 	GtkWidget* aa_check         = CreateCheckBox("Edge anti-aliasing (AA1)", "aa1");
 	GtkWidget* mipmap_check     = CreateCheckBox("Mipmap", "mipmap", true);

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -173,7 +173,7 @@ void GSSettingsDlg::OnInit()
 	SendMessage(GetDlgItem(m_hWnd, IDC_RESY), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfig("resy", 1024), 0));
 
 	SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_SETRANGE, 0, MAKELPARAM(16, 0));
-	SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfig("extrathreads", 0), 0));
+	SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfig("extrathreads", DEFAULT_EXTRA_RENDERING_THREADS), 0));
 
 	AddTooltip(IDC_FILTER);
 	AddTooltip(IDC_CRC_LEVEL);


### PR DESCRIPTION
Most cpu's that can render at reasonable speed in sw rendering have
nowadays four physical cores.

PCSX2 uses by default 2 threads. Therefore a default extra rendering
setting should be at least to use two additional threads to match the amount of
cores. (But the gs thread is idling while rendering threads are working. So one needs to add one)

If the cpu supports hyperthreading or pcsx2 shouldn't use all available
ressources the amount of ERT's should be adjusted accordingly by hand.

In the case of MTVU the EE and VU threads are tightly synchronized which
normally leads to a total cpu usage <2 cores due to synchronization
overhead. Therefore even using MTVU 2 ERT might yield best results on a
QuadCore cpu.

There was a very small benchmark test for a strong DualCore in the forum.
It supports that if synchronization overhead is neglectable (low fps) the performance in average doesn't decrease when going from two to three ERT's.
However the performance gain for QuadCores should be non-neglectable.