### PR TITLE
EE SYSCALL: Add missing video modes at SYSCALL 2

### DIFF
--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -912,9 +912,11 @@ void SYSCALL()
 
 						case 0x50: mode = "HDTV   720x480 @ 59.94"; break;
 						case 0x51: mode = "HDTV 1920x1080 @ 60.00"; break;
-						case 0x52: mode = "HDTV  1280x720 @ ?????"; break;
+						case 0x52: mode = "HDTV  1280x720 @ ??.???"; break;
+						// TODO: Videomodetest.ELF reported 0x53 and 0x54 for two video modes. however no info on the docs.
 
-						case 0x72: mode = "DVD NTSC 640x448 @ ????"; break;
+						case 0x72: mode = "DVD NTSC 640x448 @ ??.???"; break;
+						case 0x73: mode = "DVD PAL/480P 720x480 @ ??.???"; break;
 
 						default: DevCon.Error("Mode %x is not supported. Report me upstream", cpuRegs.GPR.n.a1.UC[0]);
 					}


### PR DESCRIPTION
**summary of changes**:
* Add missing video modes at EE SYSCALL 2

Build download link: https://ci.appveyor.com/api/buildjobs/jc5g83x435sfk8as/artifacts/pcsx2-v1.3.1-1576-gff780b9-master-65-vs2015-Win32-ReleaseAll.7z
