### PR TITLE
Fix build error with wxWidgets 2.8.

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -308,8 +308,6 @@ public:
 		SysAutoRun				= false;
 		SysAutoRunElf			= false;
 		CdvdSource				= CDVDsrc_NoDisc;
-		IsoFile					= "";
-		ElfFile					= "";
 	}
 };
 


### PR DESCRIPTION
Regression introduced in 81891ac1097f28fc97c0bd4226b0b72394c2ef69; assigning "" to a wxString results in an ambiguity error when building with wxWidgets 2.8 (this could well be a bug in wxWidgets). The default wxString constructor creates an empty string anyway, so these assignments are unnecessary.