### PR TITLE
x86emitter: remove instruction when imm is 0

### DIFF
--- a/common/src/x86emitter/groups.cpp
+++ b/common/src/x86emitter/groups.cpp
@@ -85,6 +85,19 @@ static void _g1_EmitOp( G1Type InstType, const xRegisterInt& to, const xIndirect
 
 static void _g1_EmitOp( G1Type InstType, const xRegisterInt& to, int imm )
 {
+	// If immediate is 0, we can take a shortcut.
+	if (imm == 0) {
+		switch (InstType) {
+			case G1Type_OR:
+			case G1Type_XOR:
+			case G1Type_ADD:
+			case G1Type_SUB:
+				return;
+			default:
+				break;
+		}
+	}
+
 	to.prefix16();
 	if( !to.Is8BitOp() && is_s8( imm ) )
 	{


### PR DESCRIPTION
ADD/SUB/OR/XOR are a nop if immediate is 0

Avoid to cluter the code each time you call those basic instruction