### PR TITLE
gsdx: cmake: don't display "unused parameters" warnings on release bu…

### DIFF
--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -25,7 +25,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL Devel)
     set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} -D_DEVEL)
 
 elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-    set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} -W)
+    set(GSdxFinalFlags ${GSdxFinalFlags} ${CommonFlags} -W -Wno-unused-parameter)
 
 endif()
 


### PR DESCRIPTION
This PR remove all the "unused-parameter" thrown during a release build of the GSdx plugin with Clang.

Tested on Clang 3.7.0