### PR TITLE
gsdx-ogl: Improve accurate blend sprite draw speed

### DIFF
--- a/plugins/GSdx/GSRendererOGL.h
+++ b/plugins/GSdx/GSRendererOGL.h
@@ -49,6 +49,7 @@ class GSRendererOGL : public GSRendererHW
 		int m_sw_blending;
 		PRIM_OVERLAP m_prim_overlap;
 		bool m_unsafe_fbmask;
+		vector<size_t> m_drawlist;
 
 		unsigned int UserHacks_TCOffset;
 		float UserHacks_TCO_x, UserHacks_TCO_y;

--- a/plugins/GSdx/GSVector.h
+++ b/plugins/GSdx/GSVector.h
@@ -239,15 +239,7 @@ public:
 
 		if(i == 0xffff)
 		{
-			#if _M_SSE >= 0x401
-
-			return min_i32(a).upl64(max_i32(a).srl<8>());
-
-			#else
-
-			return GSVector4i(min(x, a.x), min(y, a.y), max(z, a.z), max(w, a.w));
-
-			#endif
+			return runion_ordered(a);
 		}
 
 		if((i & 0x00ff) == 0x00ff)
@@ -261,6 +253,19 @@ public:
 		}
 
 		return GSVector4i::zero();
+	}
+
+	__forceinline GSVector4i runion_ordered(const GSVector4i& a) const
+	{
+		#if _M_SSE >= 0x401
+
+		return min_i32(a).upl64(max_i32(a).srl<8>());
+
+		#else
+
+		return GSVector4i(min(x, a.x), min(y, a.y), max(z, a.z), max(w, a.w));
+
+		#endif
 	}
 
 	__forceinline GSVector4i rintersect(const GSVector4i& a) const


### PR DESCRIPTION
Needs testing - AppVeyor builds for Windows users available when checks complete.

Changes:
 * List of number of non-overlapping consecutive sprite draw calls is generated
 * Non-overlapping consecutive sprite draw calls are now drawn together
 * Plus debug messages to make life easier

Improves performance for accurate blend >= 2 (Medium and above) - See #1093

Note: An initial attempt to use SSE to replace the ifs seemed to slow things down - I lost a few fps on Windows (AVX2 build). Code used (maybe someone has better ideas):
```
GSVector4i all(v[0].XYZ.X, v[0].XYZ.Y, v[1].XYZ.X, v[1].XYZ.Y);
all = all.xyxy().blend(all.zwzw(), all > all.zwxy());
```
