### PR TITLE
EE: Add COP1 Instructions to profiler

### DIFF
--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -307,6 +307,7 @@ void SetMaxValue(int regd)
 //------------------------------------------------------------------
 void recABS_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::ABS_F);
 	GET_S(EEREC_D);
 
 	CLEAR_OU_FLAGS;
@@ -450,6 +451,7 @@ void recFPUOp(int info, int regd, int op, bool acc)
 //------------------------------------------------------------------
 void recADD_S_xmm(int info)
 {
+    EE::Profiler.EmitOp(eeOpcode::ADD_F);
     recFPUOp(info, EEREC_D, 0, false);
 }
 
@@ -457,6 +459,7 @@ FPURECOMPILE_CONSTCODE(ADD_S, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);
 
 void recADDA_S_xmm(int info)
 {
+    EE::Profiler.EmitOp(eeOpcode::ADDA_F);
     recFPUOp(info, EEREC_ACC, 0, true);
 }
 
@@ -479,6 +482,7 @@ void recCMP(int info)
 //------------------------------------------------------------------
 void recC_EQ_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::CEQ_F);
 	recCMP(info);
 
 	j8Ptr[0] = JZ8(0);
@@ -493,6 +497,7 @@ FPURECOMPILE_CONSTCODE(C_EQ, XMMINFO_READS|XMMINFO_READT);
 
 void recC_LE_xmm(int info )
 {
+	EE::Profiler.EmitOp(eeOpcode::CLE_F);
 	recCMP(info);
 
 	j8Ptr[0] = JBE8(0);
@@ -507,6 +512,7 @@ FPURECOMPILE_CONSTCODE(C_LE, XMMINFO_READS|XMMINFO_READT);
 
 void recC_LT_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::CLT_F);
 	recCMP(info);
 
 	j8Ptr[0] = JB8(0);
@@ -526,6 +532,7 @@ FPURECOMPILE_CONSTCODE(C_LT, XMMINFO_READS|XMMINFO_READT);
 //------------------------------------------------------------------
 void recCVT_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::CVTS_F);
 	if( !(info&PROCESS_EE_S) || (EEREC_D != EEREC_S && !(info&PROCESS_EE_MODEWRITES)) ) {
 		xCVTSI2SS(xRegisterSSE(EEREC_D), ptr32[&fpuRegs.fpr[_Fs_]]);
 	}
@@ -538,6 +545,7 @@ FPURECOMPILE_CONSTCODE(CVT_S, XMMINFO_WRITED|XMMINFO_READS);
 
 void recCVT_W() //called from iFPU.cpp's recCVT_W
 {
+	EE::Profiler.EmitOp(eeOpcode::CVTW);
 	int regs = _checkXMMreg(XMMTYPE_FPREG, _Fs_, MODE_READ);
 
 	if( regs >= 0 )
@@ -631,6 +639,7 @@ static __aligned16 SSE_MXCSR roundmode_nearest, roundmode_neg;
 
 void recDIV_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::DIV_F);
 	bool roundmodeFlag = false;
     //Console.WriteLn("DIV");
 
@@ -745,6 +754,7 @@ void recMaddsub(int info, int regd, int op, bool acc)
 
 void recMADD_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MADD_F);
 	recMaddsub(info, EEREC_D, 0, false);
 }
 
@@ -752,6 +762,7 @@ FPURECOMPILE_CONSTCODE(MADD_S, XMMINFO_WRITED|XMMINFO_READACC|XMMINFO_READS|XMMI
 
 void recMADDA_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MADDA_F);
 	recMaddsub(info, EEREC_ACC, 0, true);
 }
 
@@ -794,6 +805,7 @@ void recMINMAX(int info, bool ismin)
 
 void recMAX_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MAX_F);
 	recMINMAX(info, false);
 }
 
@@ -801,6 +813,7 @@ FPURECOMPILE_CONSTCODE(MAX_S, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);
 
 void recMIN_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MIN_F);
 	recMINMAX(info, true);
 }
 
@@ -813,6 +826,7 @@ FPURECOMPILE_CONSTCODE(MIN_S, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);
 //------------------------------------------------------------------
 void recMOV_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MOV_F);
 	GET_S(EEREC_D);
 }
 
@@ -826,6 +840,7 @@ FPURECOMPILE_CONSTCODE(MOV_S, XMMINFO_WRITED|XMMINFO_READS);
 
 void recMSUB_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MSUB_F);
 	recMaddsub(info, EEREC_D, 1, false);
 }
 
@@ -833,6 +848,7 @@ FPURECOMPILE_CONSTCODE(MSUB_S, XMMINFO_WRITED|XMMINFO_READACC|XMMINFO_READS|XMMI
 
 void recMSUBA_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MSUBA_F);
 	recMaddsub(info, EEREC_ACC, 1, true);
 }
 
@@ -844,6 +860,7 @@ FPURECOMPILE_CONSTCODE(MSUBA_S, XMMINFO_WRITEACC|XMMINFO_READACC|XMMINFO_READS|X
 //------------------------------------------------------------------
 void recMUL_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MUL_F);
 	int sreg, treg;
 	ALLOC_S(sreg); ALLOC_T(treg);
 
@@ -855,6 +872,7 @@ FPURECOMPILE_CONSTCODE(MUL_S, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);
 
 void recMULA_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::MULA_F);
 	int sreg, treg;
 	ALLOC_S(sreg); ALLOC_T(treg);
 
@@ -869,8 +887,9 @@ FPURECOMPILE_CONSTCODE(MULA_S, XMMINFO_WRITEACC|XMMINFO_READS|XMMINFO_READT);
 //------------------------------------------------------------------
 // NEG XMM
 //------------------------------------------------------------------
-void recNEG_S_xmm(int info) {
-
+void recNEG_S_xmm(int info)
+{
+	EE::Profiler.EmitOp(eeOpcode::NEG_F);
 	GET_S(EEREC_D);
 
 	CLEAR_OU_FLAGS;
@@ -888,6 +907,7 @@ FPURECOMPILE_CONSTCODE(NEG_S, XMMINFO_WRITED|XMMINFO_READS);
 
 void recSUB_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::SUB_F);
 	recFPUOp(info, EEREC_D, 1, false);
 }
 
@@ -896,6 +916,7 @@ FPURECOMPILE_CONSTCODE(SUB_S, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);
 
 void recSUBA_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::SUBA_F);
 	recFPUOp(info, EEREC_ACC, 1, true);
 }
 
@@ -908,6 +929,7 @@ FPURECOMPILE_CONSTCODE(SUBA_S, XMMINFO_WRITEACC|XMMINFO_READS|XMMINFO_READT);
 //------------------------------------------------------------------
 void recSQRT_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::SQRT_F);
 	u8 *pjmp;
 	int roundmodeFlag = 0;
 	int tempReg = _allocX86reg(xEmptyReg, X86TYPE_TEMP, 0, 0);
@@ -1031,6 +1053,7 @@ void recRSQRThelper2(int regd, int regt) // Preforms the RSQRT function when reg
 
 void recRSQRT_S_xmm(int info)
 {
+	EE::Profiler.EmitOp(eeOpcode::RSQRT_F);
 	int sreg, treg;
 
 	// iFPU (regular FPU) doesn't touch roundmode for rSQRT.


### PR DESCRIPTION
**Summary of changes:**

* Implement COP1 Instructions for EE profiler
* align a comment , brace before willkuer / turtleli complains.

Thanks to @gregory38 for providing the idea of preventing a possibility of NOP being profiled. Also thanks to rama and refraction for reviewing the change :)