### PR TITLE
Recompiler memory optimization

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -300,7 +300,7 @@ else()
 endif()
 
 # Note: -DGTK_DISABLE_DEPRECATED can be used to test a build without gtk deprecated feature. It could be useful to port to a newer API
-set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS}")
+set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS} -fno-omit-frame-pointer")
 # c++ only flags
 set(DEFAULT_CPP_FLAG "${DEFAULT_GCC_FLAG} -std=c++11 -Wno-invalid-offsetof")
 

--- a/common/include/Utilities/General.h
+++ b/common/include/Utilities/General.h
@@ -218,13 +218,16 @@ static __fi PageProtectionMode PageAccess_Any()
 // platform prior to wxWidgets .. it should prolly be removed -- air)
 namespace HostSys
 {
-	void* MmapReserve(uptr base, size_t size);
+	void OpenSharedMemory(size_t size);
+	void CloseSharedMemory();
+
+	void* MmapReserve(uptr base, size_t size, u32 offset = ~0u);
 	bool MmapCommit(uptr base, size_t size, const PageProtectionMode& mode);
 	void MmapReset(uptr base, size_t size);
 
-	void* MmapReservePtr(void* base, size_t size);
+	void* MmapReservePtr(void* base, size_t size, u32 offset = ~0u);
 	bool MmapCommitPtr(void* base, size_t size, const PageProtectionMode& mode);
-	void MmapResetPtr(void* base, size_t size);
+	void MmapResetPtr(void* base, size_t size, u32 offset = ~0u);
 
 	// Maps a block of memory for use as a recompiled code buffer.
 	// Returns NULL on allocation failure.

--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -29,10 +29,14 @@
 struct PageFaultInfo
 {
 	uptr	addr;
+	uptr	eip;
+	void*	ctx;
 
-	PageFaultInfo( uptr address )
+	PageFaultInfo( uptr address, uptr eip_reg = 0, void* context = NULL )
 	{
 		addr = address;
+		eip  = eip_reg;
+		ctx  = context;
 	}
 };
 

--- a/common/src/x86emitter/groups.cpp
+++ b/common/src/x86emitter/groups.cpp
@@ -83,6 +83,19 @@ static void _g1_EmitOp( G1Type InstType, const xRegisterInt& to, const xIndirect
 
 static void _g1_EmitOp( G1Type InstType, const xRegisterInt& to, int imm )
 {
+	// If immediate is 0, we can take a shortcut.
+	if (imm == 0) {
+		switch (InstType) {
+			case G1Type_OR:
+			case G1Type_XOR:
+			case G1Type_ADD:
+			case G1Type_SUB:
+				return;
+			default:
+				break;
+		}
+	}
+
 	if( !to.Is8BitOp() && is_s8( imm ) )
 	{
 		xOpWrite( to.GetPrefix16(), 0x83, InstType, to );

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -722,7 +722,7 @@ void eeMemoryReserve::Reserve()
 	const int extra = 10 * _1mb;
 	const int special = 32 * _1kb;
 
-	const int start = HostMemoryMap::EEmem;
+	const int start = HostMemoryMap::EEmem + _32kb;
 
 	const MemoryView ee_views[] {
 		{ 0x00000000 , start + 0 * _32mb           , _32mb   , PageAccess_ReadWrite() } ,
@@ -734,8 +734,9 @@ void eeMemoryReserve::Reserve()
 		{ 0x02000000 , start + 6 * _32mb           , _32mb   , PageAccess_None() }      ,
 		// Scratchpad and ROM and zero stuff
 		{ 0x04000000 , start + 7 * _32mb           , extra   , PageAccess_ReadWrite() } ,
-		// Special Main memory
+		// Special Main memory (+ an extra trick)
 		{ 0x00078000 , start + 8 * _32mb - special , special , PageAccess_ReadWrite() } ,
+		{ 0x00078000 , start - _32kb               , _32kb   , PageAccess_ReadWrite() } ,
 	};
 	for (size_t v = 0; v < sizeof(ee_views) / sizeof(ee_views[0]); v++)
 		m_reserve.Reserve( ee_views[v] );
@@ -1120,7 +1121,7 @@ void direct_PageFaultHandler::OnPageFaultEvent( const PageFaultInfo& info, bool&
 	}
 
 	s32 absolute_offset = *(s32*)(x86 + op_nb + 1);
-	s32 imm_offset = absolute_offset - (s32)(HostMemoryMap::EEmem);
+	s32 imm_offset = absolute_offset - (s32)(HostMemoryMap::EEmem + _32kb);
 
 	// Search the start of the load/store
 	u8* start = x86;

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -62,6 +62,9 @@ typedef u128 mem128_t;
 
 // The order of the components in this struct *matter* -- it has been laid out so that the
 // full breadth of PS2 RAM and ROM mappings are directly supported.
+#ifdef __x86_64__
+
+// A piles of crap that need to be done correctly
 struct EEVM_MemoryAllocMess
 {
 	u8 (&Main)[Ps2MemSize::MainRam];				// Main memory (hard-wired to 32MB)
@@ -78,6 +81,49 @@ struct EEVM_MemoryAllocMess
 	u8 _padding4[0x1fc00000-(0x1e040000+Ps2MemSize::Rom2)];
 	u8 (&ROM)[Ps2MemSize::Rom];				// Boot rom (4MB)
 };
+
+#else
+
+struct EEVM_MemoryAllocMess
+{
+	// 0x0... to 0x1...
+	u8 Main[Ps2MemSize::MainRam];				// Main memory (hard-wired to 32MB)
+
+	// 0x1... to 0x2...
+	u8 _pad_hw_reg[_32mb];
+
+	// 0x2... to 0x4...
+	u8 Main_uncached[Ps2MemSize::MainRam];
+	u8 Main_uncached_acc[Ps2MemSize::MainRam];
+
+	// 0x4... to 0x7...
+	u8 _pad4[_32mb];
+	u8 _pad5[_32mb];
+	u8 _pad6[_32mb];
+
+	// 0x7... to 0x7...
+	u8 Scratch[Ps2MemSize::Scratch];		// Scratchpad!
+
+	// FIXME might need a protection in case of Scratchpad overflow
+
+	// Put garbadge between Spad and iop reg (save bunch of MB)
+	u8 _pad_align_1mb[_1mb - Ps2MemSize::Scratch];
+	u8 ZeroRead[_1mb];
+	u8 ZeroWrite[_1mb];
+
+	u8 ROM1[Ps2MemSize::Rom1];				// DVD player
+	u8 EROM[Ps2MemSize::ERom];				// DVD player extensions
+	u8 ROM2[Ps2MemSize::Rom2];				// Chinese extensions
+	u8 ROM[Ps2MemSize::Rom];				// Boot rom (4MB)
+
+	u8* _pad_unmapped[22*_1mb + 480*_1kb];
+
+	u8* Main_special[32*_1kb];
+
+	//u8 _pad_iop_reg[_32mb - Ps2MemSize::Scratch - Ps2MemSize::Rom - Ps2MemSize::Rom1 - Ps2MemSize::Rom2 - Ps2MemSize::ERom - 2*_1mb];
+};
+
+#endif
 
 #else
 

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -56,7 +56,7 @@ typedef u128 mem128_t;
 // Note that support for this feature may not be doable under x86/32 platforms, due to the
 // 2gb/3gb limit of Windows XP (the 3gb feature will make it slightly more feasible at least).
 //
-#define VTLB_UsePageFaulting 0
+#define VTLB_UsePageFaulting 1
 
 #if VTLB_UsePageFaulting
 

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -86,6 +86,9 @@ struct EEVM_MemoryAllocMess
 
 struct EEVM_MemoryAllocMess
 {
+	// Small trick to do add the immediate offset after the PEXT instruction
+	u8 wrap_4g[_32kb];
+
 	// 0x0... to 0x1...
 	u8 Main[Ps2MemSize::MainRam];				// Main memory (hard-wired to 32MB)
 

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -50,13 +50,17 @@ namespace HostMemoryMap
 	// address sanitizer uses a shadow memory to monitor the state of the memory. Shadow is computed
 	// as S = (M >> 3) + 0x20000000. So PCSX2 can't use 0x20000000 to 0x3FFFFFFF... Just add another
 	// 0x20000000 offset to avoid conflict.
-	static const int asan_offset = 0x20000000;
+	static const int asan_offset = 0x40000000;
 #else
 	static const int asan_offset = 0;
 #endif
 
 	// PS2 main memory, SPR, and ROMs (256 mb)
+#if VTLB_UsePageFaulting
+	static const uptr EEmem		= 0x20000000 - _32kb + asan_offset;
+#else
 	static const uptr EEmem		= 0x20000000 + asan_offset;
+#endif
 
 	// EE recompiler code cache area (64mb)
 	static const uptr EErec		= 0x30000000 + asan_offset;

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -50,57 +50,50 @@ namespace HostMemoryMap
 	// address sanitizer uses a shadow memory to monitor the state of the memory. Shadow is computed
 	// as S = (M >> 3) + 0x20000000. So PCSX2 can't use 0x20000000 to 0x3FFFFFFF... Just add another
 	// 0x20000000 offset to avoid conflict.
-	static const uptr EEmem		= 0x40000000;
-	static const uptr IOPmem	= 0x44000000;
-	static const uptr VUmem		= 0x48000000;
-	static const uptr EErec		= 0x50000000;
-	static const uptr IOPrec	= 0x54000000;
-	static const uptr VIF0rec	= 0x56000000;
-	static const uptr VIF1rec	= 0x58000000;
-	static const uptr mVU0rec	= 0x5C000000;
-	static const uptr mVU1rec	= 0x60000000;
+	static const int asan_offset = 0x20000000;
 #else
-	// PS2 main memory, SPR, and ROMs
-	static const uptr EEmem		= 0x20000000;
+	static const int asan_offset = 0;
+#endif
 
-	// IOP main memory and ROMs
-	static const uptr IOPmem	= 0x24000000;
-
-	// VU0 and VU1 memory.
-	static const uptr VUmem		= 0x28000000;
+	// PS2 main memory, SPR, and ROMs (256 mb)
+	static const uptr EEmem		= 0x20000000 + asan_offset;
 
 	// EE recompiler code cache area (64mb)
-	static const uptr EErec		= 0x30000000;
-
-	// IOP recompiler code cache area (16 or 32mb)
-	static const uptr IOPrec	= 0x34000000;
-
-	// newVif0 recompiler code cache area (16mb)
-	static const uptr VIF0rec	= 0x36000000;
-
-	// newVif1 recompiler code cache area (32mb)
-	static const uptr VIF1rec	= 0x38000000;
+	static const uptr EErec		= 0x30000000 + asan_offset;
 
 	// microVU1 recompiler code cache area (32 or 64mb)
-	static const uptr mVU0rec	= 0x3C000000;
+	static const uptr mVU0rec	= 0x34000000 + asan_offset;
 
 	// microVU0 recompiler code cache area (64mb)
-	static const uptr mVU1rec	= 0x40000000;
-#endif
-	
+	static const uptr mVU1rec	= 0x38000000 + asan_offset;
+
+	// IOP recompiler code cache area (16 or 32mb)
+	static const uptr IOPrec	= 0x3C000000 + asan_offset;
+
+	// newVif0 recompiler code cache area (16mb) (code seem to use 8mb)
+	static const uptr VIF0rec	= 0x3E000000 + asan_offset;
+
+	// newVif1 recompiler code cache area (16mb) (code seem to use 8mb)
+	static const uptr VIF1rec	= 0x3E800000 + asan_offset;
+
+	// IOP main memory and ROMs (~2.1mb)
+	static const uptr IOPmem	= 0x3F000000 + asan_offset;
+
+	// VU0 and VU1 memory. (40 KB)
+	static const uptr VUmem		= 0x3F800000 + asan_offset;
 }
 
 // --------------------------------------------------------------------------------------
 //  SysMainMemory
 // --------------------------------------------------------------------------------------
-// This class provides the main memory for the virtual machines.  
+// This class provides the main memory for the virtual machines.
 class SysMainMemory
 {
 protected:
 	eeMemoryReserve			m_ee;
 	iopMemoryReserve		m_iop;
 	vuMemoryReserve			m_vu;
-	
+
 public:
 	SysMainMemory();
 	virtual ~SysMainMemory() throw();

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -829,13 +829,15 @@ static wxString GetHostVmErrorMsg()
 // --------------------------------------------------------------------------------------
 //  VtlbMemoryReserve  (implementations)
 // --------------------------------------------------------------------------------------
-VtlbMemoryReserve::VtlbMemoryReserve( const wxString& name, size_t size )
+template<class VM>
+VtlbMemoryReserve<VM>::VtlbMemoryReserve( const wxString& name, size_t size )
 	: m_reserve( name, size )
 {
 	m_reserve.SetPageAccessOnCommit( PageAccess_ReadWrite() );
 }
 
-void VtlbMemoryReserve::Reserve( sptr hostptr )
+template<class VM>
+void VtlbMemoryReserve<VM>::Reserve( sptr hostptr )
 {
 	if (!m_reserve.ReserveAt( hostptr ))
 	{
@@ -845,7 +847,8 @@ void VtlbMemoryReserve::Reserve( sptr hostptr )
 	}
 }
 
-void VtlbMemoryReserve::Commit()
+template<class VM>
+void VtlbMemoryReserve<VM>::Commit()
 {
 	if (IsCommitted()) return;
 	if (!m_reserve.Commit())
@@ -856,23 +859,31 @@ void VtlbMemoryReserve::Commit()
 	}
 }
 
-void VtlbMemoryReserve::Reset()
+template<class VM>
+void VtlbMemoryReserve<VM>::Reset()
 {
 	Commit();
 	memzero_sse_a(m_reserve.GetPtr(), m_reserve.GetCommittedBytes());
 }
 
-void VtlbMemoryReserve::Decommit()
+template<class VM>
+void VtlbMemoryReserve<VM>::Decommit()
 {
 	m_reserve.Reset();
 }
 
-void VtlbMemoryReserve::Release()
+template<class VM>
+void VtlbMemoryReserve<VM>::Release()
 {
 	m_reserve.Release();
 }
 
-bool VtlbMemoryReserve::IsCommitted() const
+template<class VM>
+bool VtlbMemoryReserve<VM>::IsCommitted() const
 {
 	return !!m_reserve.GetCommittedPageCount();
 }
+
+// Please Mr compiler generate me the code
+template class VtlbMemoryReserve<VirtualMemoryReserve>;
+template class VtlbMemoryReserve<VirtualSharedMemoryReserve>;

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -82,8 +82,8 @@ extern void __fastcall vtlb_memWrite(u32 mem, DataType value);
 extern void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value);
 extern void __fastcall vtlb_memWrite128(u32 mem, const mem128_t* value);
 
-extern void vtlb_DynGenWrite(u32 likely_address, u32 sz);
-extern void vtlb_DynGenRead(u32 likely_address, u32 bits, bool sign = false);
+extern void vtlb_DynGenWrite(u32 likely_address, s16 imm, u32 sz);
+extern void vtlb_DynGenRead(u32 likely_address, s16 imm, u32 bits, bool sign = false);
 
 extern void vtlb_DynGenWrite_Const( u32 bits, u32 addr_const );
 extern void vtlb_DynGenRead64_Const( u32 bits, u32 addr_const );

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -89,6 +89,8 @@ extern void vtlb_DynGenWrite_Const( u32 bits, u32 addr_const );
 extern void vtlb_DynGenRead64_Const( u32 bits, u32 addr_const );
 extern void vtlb_DynGenRead32_Const( u32 bits, bool sign, u32 addr_const );
 
+extern void vtlb_rewrite_memory_instruction(u8* start, u8* end, int mode, int bits, bool sign, s32 imm_offset);
+
 // --------------------------------------------------------------------------------------
 //  VtlbMemoryReserve
 // --------------------------------------------------------------------------------------

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -82,9 +82,8 @@ extern void __fastcall vtlb_memWrite(u32 mem, DataType value);
 extern void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value);
 extern void __fastcall vtlb_memWrite128(u32 mem, const mem128_t* value);
 
-extern void vtlb_DynGenWrite(u32 sz);
-extern void vtlb_DynGenRead32(u32 bits, bool sign);
-extern void vtlb_DynGenRead64(u32 sz);
+extern void vtlb_DynGenWrite(u32 likely_address, u32 sz);
+extern void vtlb_DynGenRead(u32 likely_address, u32 bits, bool sign = false);
 
 extern void vtlb_DynGenWrite_Const( u32 bits, u32 addr_const );
 extern void vtlb_DynGenRead64_Const( u32 bits, u32 addr_const );

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -92,10 +92,11 @@ extern void vtlb_DynGenRead32_Const( u32 bits, bool sign, u32 addr_const );
 // --------------------------------------------------------------------------------------
 //  VtlbMemoryReserve
 // --------------------------------------------------------------------------------------
+template<class VM>
 class VtlbMemoryReserve
 {
 protected:
-	VirtualMemoryReserve	m_reserve;
+	VM	m_reserve;
 
 public:
 	VtlbMemoryReserve( const wxString& name, size_t size );
@@ -117,9 +118,17 @@ public:
 // --------------------------------------------------------------------------------------
 //  eeMemoryReserve
 // --------------------------------------------------------------------------------------
-class eeMemoryReserve : public VtlbMemoryReserve
+#if VTLB_UsePageFaulting
+class eeMemoryReserve : public VtlbMemoryReserve<VirtualSharedMemoryReserve>
+#else
+class eeMemoryReserve : public VtlbMemoryReserve<VirtualMemoryReserve>
+#endif
 {
-	typedef VtlbMemoryReserve _parent;
+#if VTLB_UsePageFaulting
+	typedef VtlbMemoryReserve<VirtualSharedMemoryReserve> _parent;
+#else
+	typedef VtlbMemoryReserve<VirtualMemoryReserve> _parent;
+#endif
 
 public:
 	eeMemoryReserve();
@@ -138,7 +147,7 @@ public:
 // --------------------------------------------------------------------------------------
 //  iopMemoryReserve
 // --------------------------------------------------------------------------------------
-class iopMemoryReserve : public VtlbMemoryReserve
+class iopMemoryReserve : public VtlbMemoryReserve<VirtualMemoryReserve>
 {
 	typedef VtlbMemoryReserve _parent;
 
@@ -159,7 +168,7 @@ public:
 // --------------------------------------------------------------------------------------
 //  vuMemoryReserve
 // --------------------------------------------------------------------------------------
-class vuMemoryReserve : public VtlbMemoryReserve
+class vuMemoryReserve : public VtlbMemoryReserve<VirtualMemoryReserve>
 {
 	typedef VtlbMemoryReserve _parent;
 

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -29,6 +29,9 @@ extern int g_branch;	         // set for branch (also used by the SuperVU! .. wh
 extern u32 target;		         // branch target
 extern u32 s_nBlockCycles;		// cycles of current block recompiling
 
+extern u8* eeGetRecPtr();
+extern void eeSetRecPtr(u8* ptr);
+
 //////////////////////////////////////////////////////////////////////////////////////////
 //
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -323,6 +323,18 @@ u32* recGetImm64(u32 hi, u32 lo)
 	return imm64;
 }
 
+// Those functions allow to append a new block to handle memory tlb through SIGSEGV
+// FIXME: it would be better to ensure the correctness of the pointer (always point to first
+// free byte) rather to rely on an extra variable.
+void eeSetRecPtr(u8* ptr) {
+	recPtr = ptr;
+}
+
+u8* eeGetRecPtr() {
+	return recPtr;
+}
+
+
 // Use this to call into interpreter functions that require an immediate branchtest
 // to be done afterward (anything that throws an exception or enables interrupts, etc).
 void recBranchCall( void (*func)() )

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -139,7 +139,8 @@ void recLoad64( u32 bits, bool sign )
 		_deleteEEreg(_Rt_, 0);
 		iFlushCall(FLUSH_FULLVTLB);
 
-		vtlb_DynGenRead64(bits);
+		u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+		vtlb_DynGenRead(likely_addr, bits);
 	}
 }
 
@@ -171,7 +172,9 @@ void recLoad32( u32 bits, bool sign )
 		_deleteEEreg(_Rt_, 0);
 
 		iFlushCall(FLUSH_FULLVTLB);
-		vtlb_DynGenRead32(bits, sign);
+
+		u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+		vtlb_DynGenRead(likely_addr, bits, sign);
 	}
 
 	if (_Rt_)
@@ -231,7 +234,8 @@ void recStore(u32 bits)
 
                 iFlushCall(FLUSH_FULLVTLB);
 
-				vtlb_DynGenWrite(bits);
+				u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+				vtlb_DynGenWrite(likely_addr, bits);
         }
 }
 
@@ -258,6 +262,8 @@ void recSD()  { recStore(64);  EE::Profiler.EmitOp(eeOpcode::SD);}
 void recLWL()
 {
 #ifdef REC_LOADS
+	u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+
 	iFlushCall(FLUSH_FULLVTLB);
 	_deleteEEreg(_Rt_, 1);
 
@@ -271,7 +277,7 @@ void recLWL()
 	xSHL(edi, 3);
 
 	xAND(ecx, ~3);
-	vtlb_DynGenRead32(32, false);
+	vtlb_DynGenRead(likely_addr, 32, false);
 
 	if (!_Rt_)
 		return;
@@ -306,6 +312,8 @@ void recLWL()
 void recLWR()
 {
 #ifdef REC_LOADS
+	u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+
 	iFlushCall(FLUSH_FULLVTLB);
 	_deleteEEreg(_Rt_, 1);
 
@@ -319,7 +327,7 @@ void recLWR()
 	xSHL(edi, 3);
 
 	xAND(ecx, ~3);
-	vtlb_DynGenRead32(32, false);
+	vtlb_DynGenRead(likely_addr, 32, false);
 
 	if (!_Rt_)
 		return;
@@ -357,6 +365,8 @@ void recLWR()
 void recSWL()
 {
 #ifdef REC_STORES
+	u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+
 	iFlushCall(FLUSH_FULLVTLB);
 
 	_eeMoveGPRtoR(ecx, _Rs_);
@@ -369,7 +379,7 @@ void recSWL()
 	xSHL(edi, 3);
 
 	xAND(ecx, ~3);
-	vtlb_DynGenRead32(32, false);
+	vtlb_DynGenRead(likely_addr, 32, false);
 
 	// mask read -> edx
 	xMOV(ecx, edi);
@@ -392,7 +402,7 @@ void recSWL()
 		xADD(ecx, _Imm_);
 	xAND(ecx, ~3);
 
-	vtlb_DynGenWrite(32);
+	vtlb_DynGenWrite(likely_addr, 32);
 #else
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -407,6 +417,8 @@ void recSWL()
 void recSWR()
 {
 #ifdef REC_STORES
+	u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+
 	iFlushCall(FLUSH_FULLVTLB);
 
 	_eeMoveGPRtoR(ecx, _Rs_);
@@ -419,7 +431,7 @@ void recSWR()
 	xSHL(edi, 3);
 
 	xAND(ecx, ~3);
-	vtlb_DynGenRead32(32, false);
+	vtlb_DynGenRead(likely_addr, 32, false);
 
 	// mask read -> edx
 	xMOV(ecx, 24);
@@ -442,7 +454,7 @@ void recSWR()
 		xADD(ecx, _Imm_);
 	xAND(ecx, ~3);
 
-	vtlb_DynGenWrite(32);
+	vtlb_DynGenWrite(likely_addr, 32);
 #else
 	iFlushCall(FLUSH_INTERPRETER);
 	_deleteEEreg(_Rs_, 1);
@@ -523,7 +535,8 @@ void recLWC1()
 
 		iFlushCall(FLUSH_FULLVTLB);
 
-		vtlb_DynGenRead32(32, false);
+		u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+		vtlb_DynGenRead(likely_addr, 32, false);
 	}
 
 	xMOV(ptr32[&fpuRegs.fpr[_Rt_].UL], eax);
@@ -552,7 +565,8 @@ void recSWC1()
 
 		iFlushCall(FLUSH_FULLVTLB);
 
-		vtlb_DynGenWrite(32);
+		u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+		vtlb_DynGenWrite(likely_addr, 32);
 	}
 
 	EE::Profiler.EmitOp(eeOpcode::SWC1);
@@ -594,7 +608,8 @@ void recLQC2()
 
 		iFlushCall(FLUSH_FULLVTLB);
 
-		vtlb_DynGenRead64(128);
+		u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+		vtlb_DynGenRead(likely_addr, 128);
 	}
 
 	EE::Profiler.EmitOp(eeOpcode::LQC2);
@@ -621,7 +636,8 @@ void recSQC2()
 
 		iFlushCall(FLUSH_FULLVTLB);
 
-		vtlb_DynGenWrite(128);
+		u32 likely_addr = cpuRegs.GPR.r[_Rs_].UL[0] + _Imm_;
+		vtlb_DynGenWrite(likely_addr, 128);
 	}
 
 	EE::Profiler.EmitOp(eeOpcode::SQC2);

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -25,8 +25,8 @@
 using namespace vtlb_private;
 using namespace x86Emitter;
 
-//#define PLEASE_SIGSEGV
-//#define FASTER_DIRECT_ACCESS
+#define PLEASE_SIGSEGV
+#define FASTER_DIRECT_ACCESS
 
 #ifdef PLEASE_SIGSEGV
 static const bool s_fast_memspace[16] = {

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -673,8 +673,10 @@ void vtlb_FastDynGenRead32(u32 bits, bool sign, u32 likely_addr)
 
 // ------------------------------------------------------------------------
 // Wrapper to the different load implementation
-void vtlb_DynGenRead(u32 likely_address, u32 bits, bool sign)
+void vtlb_DynGenRead(u32 likely_address, s16 imm, u32 bits, bool sign)
 {
+	xADD(ecx, imm);
+
 #ifdef FASTER_DIRECT_ACCESS
 	vtlb_FastDynGenRead32(bits, sign, likely_address);
 #else
@@ -867,8 +869,10 @@ void vtlb_FastDynGenWrite(u32 bits, u32 likely_addr)
 
 // ------------------------------------------------------------------------
 // Wrapper to the different load implementation
-void vtlb_DynGenWrite(u32 likely_address, u32 bits)
+void vtlb_DynGenWrite(u32 likely_address, s16 imm, u32 bits)
 {
+	xADD(ecx, imm);
+
 #ifdef FASTER_DIRECT_ACCESS
 	vtlb_FastDynGenWrite(bits, likely_address);
 #else

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -627,8 +627,11 @@ void vtlb_DynGenReadReg32(u32 bits, bool sign, u32 likely_addr)
 void vtlb_FastDynGenRead32(u32 bits, bool sign, u32 likely_addr)
 {
 	u32 zone = likely_addr >> 28;
+	// Detection isn't perfect and the rom code uses various register
+	// Code is barely executed, let's avoid plenty of SIGSEGV to ease debug
+	bool rom_code = cpuRegs.pc > 0x90000000;
 
-	if (s_fast_memspace[zone]) {
+	if (s_fast_memspace[zone] && !rom_code) {
 		// Shortcut TLB based on the first address
 
 		// Warning dirty ebx (in case someone got the very bad idea to move this code)
@@ -822,8 +825,11 @@ void vtlb_DynGenWrite(u32 sz)
 void vtlb_FastDynGenWrite(u32 bits, u32 likely_addr)
 {
 	u32 zone = likely_addr >> 28;
+	// Detection isn't perfect and the rom code uses various register
+	// Code is barely executed, let's avoid plenty of SIGSEGV to ease debug
+	bool rom_code = cpuRegs.pc > 0x90000000;
 
-	if (s_fast_memspace[zone]) {
+	if (s_fast_memspace[zone] && !rom_code) {
 		// Shortcut TLB based on the first address
 
 		// Warning dirty ebx (in case someone got the very bad idea to move this code)

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -317,6 +317,25 @@ static void DynGen_IndirectDispatch( int mode, int bits, bool sign = false )
 }
 
 // ------------------------------------------------------------------------
+// Generates a JAE instruction that targets the appropriate templated instance of
+// the vtlb full tlb Dispatcher.
+//
+static void DynGen_FullTlbDispatch( int mode, int bits, bool sign = false )
+{
+	int szidx = 0;
+	switch( bits )
+	{
+		case 8:		szidx=0;	break;
+		case 16:	szidx=1;	break;
+		case 32:	szidx=2;	break;
+		case 64:	szidx=3;	break;
+		case 128:	szidx=4;	break;
+		jNO_DEFAULT;
+	}
+	xJAE( GetFullTlbDispatcherPtr( mode, szidx, sign ) );
+}
+
+// ------------------------------------------------------------------------
 // Generates the various instances of the indirect dispatchers
 static void DynGen_IndirectTlbDispatcher( int mode, int bits, bool sign )
 {

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -443,6 +443,17 @@ void vtlb_DynGenRead32(u32 bits, bool sign)
 }
 
 // ------------------------------------------------------------------------
+// Wrapper to the different load implementation
+void vtlb_DynGenRead(u32 likely_address, u32 bits, bool sign)
+{
+	if (bits < 64)
+		vtlb_DynGenRead32(bits, sign);
+	else
+		vtlb_DynGenRead64(bits);
+}
+
+
+// ------------------------------------------------------------------------
 // TLB lookup is performed in const, with the assumption that the COP0/TLB will clear the
 // recompiler if the TLB is changed.
 void vtlb_DynGenRead64_Const( u32 bits, u32 addr_const )
@@ -578,6 +589,12 @@ void vtlb_DynGenWrite(u32 sz)
 	*writeback = (uptr)xGetPtr();
 }
 
+// ------------------------------------------------------------------------
+// Wrapper to the different load implementation
+void vtlb_DynGenWrite(u32 likely_address, u32 bits)
+{
+	vtlb_DynGenWrite(bits);
+}
 
 // ------------------------------------------------------------------------
 // Generates code for a store instruction, where the address is a known constant.


### PR DESCRIPTION
Open PR to open a discussion on direct memory access. It is only a proof of concept. Various issues likely remain. It is related to #1019 

Part that need more work:
- Remove completely lazy allocation on x86 buffer (otherwise it might generate nested SIGSEGV)
- Use a 64KB mirror below the start address instead of 32KB
- Redo (or drop) the x86emitter immediate optimization
- Windows support?
- Requires BMI2 (haswell and later). So far code rely on ifdef.
- Consume 256MB of Memory (large aware allow to us get 4GB).
