### PR TITLE
Log window: bug fixes and some minor changes.

### DIFF
--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -510,6 +510,8 @@ void ConsoleLogFrame::OnEnableAllLogging(wxCommandEvent& evt)
 		if (ConsoleLogSource* log = ConLogSources[i])
 			log->Enabled = true;
 	}
+	DevConWriterEnabled = true;
+	g_Conf->EmuOptions.CdvdVerboseReads = true;
 
 	OnLoggingChanged();
 	evt.Skip();
@@ -523,6 +525,8 @@ void ConsoleLogFrame::OnDisableAllLogging(wxCommandEvent& evt)
 		if (ConsoleLogSource* log = ConLogSources[i])
 			log->Enabled = false;
 	}
+	DevConWriterEnabled = false;
+	g_Conf->EmuOptions.CdvdVerboseReads = false;
 
 	OnLoggingChanged();
 	evt.Skip();
@@ -536,6 +540,8 @@ void ConsoleLogFrame::OnSetDefaultLogging(wxCommandEvent& evt)
 		if (ConsoleLogSource* log = ConLogSources[i])
 			log->Enabled = ConLogDefaults[i];
 	}
+	DevConWriterEnabled = false;
+	g_Conf->EmuOptions.CdvdVerboseReads = false;
 
 	OnLoggingChanged();
 	evt.Skip();

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -691,7 +691,8 @@ void ConsoleLogFrame::OnMoveAround( wxMoveEvent& evt )
 
 void ConsoleLogFrame::OnResize( wxSizeEvent& evt )
 {
-	m_conf.DisplaySize = GetSize();
+	if (!ConsoleLogFrame::IsMaximized())
+		m_conf.DisplaySize = GetSize();
 	evt.Skip();
 }
 


### PR DESCRIPTION
**Summary of changes:**

* Fixes Issue #1092 , don't remember the display size when the log window is maximized since the display size gets too big and the next time you open PCSX2 you'll see a gigantic log window ;)

* Previously the Enable all / Disable all / Restore defaults menu options ignored the status of Dev/verbose and CDVD reads. The following commit makes them to also impact the other two menu items.