### PR TITLE
VideoPanel: Some changes to element greyout behavior

### DIFF
--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -231,10 +231,12 @@ void Panels::FrameSkipPanel::ApplyConfigToGui( AppConfig& configToApply, int fla
 	const AppConfig::FramerateOptions& appfps( configToApply.Framerate );
 	const Pcsx2Config::GSOptions& gsconf( configToApply.EmuOptions.GS );
 
-	m_radio_SkipMode	->SetSelection( appfps.SkipOnLimit ? 2 : (appfps.SkipOnTurbo ? 1 : 0) );
+	m_radio_SkipMode->SetSelection( appfps.SkipOnLimit ? 2 : (appfps.SkipOnTurbo ? 1 : 0) );
 
-	m_spin_FramesToDraw	->SetValue( gsconf.FramesToDraw );
-	m_spin_FramesToSkip	->SetValue( gsconf.FramesToSkip );
+	m_spin_FramesToDraw->SetValue( gsconf.FramesToDraw );
+	m_spin_FramesToDraw->Enable(!configToApply.EnablePresets);
+	m_spin_FramesToSkip->SetValue( gsconf.FramesToSkip );
+	m_spin_FramesToSkip->Enable(!configToApply.EnablePresets);
 
 	this->Enable(!configToApply.EnablePresets);
 }


### PR DESCRIPTION
**Summary of changes:**

~~* Don't grey out NTSC/PAL Framerate as it'd be valuable for users to directly edit through the GUi. (editing through the INI was already possible)~~

* Previously the text box for "Frames to Draw" and "Frames to Skip" got failed to grey out properly and only the text and arrows got greyed out, The following patch properly greys out the elements.

First commit needs opinions from @avih and @turtleli 