### PR TITLE
Fix Windows Resource file name error

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -483,7 +483,7 @@ set(pcsx2WindowsSources
 	windows/DwmSetup.cpp
 	windows/ini.cpp
 	windows/PatchBrowser.cpp
-	windows/SampleProf.cp
+	windows/SamplProf.cpp
 	windows/WinCompressNTFS.cpp
 	windows/WinConsolePipe.cpp
 	windows/WinSysExec.cpp)


### PR DESCRIPTION
The original file name is given by 

    SampleProf.cp 

However this is not the file we could find in any Code or Directory of PCSX2, rather it should be:

    SamplProf.cpp