### PR TITLE
Dump.cpp: Fix Linux build.

### DIFF
--- a/pcsx2/Dump.cpp
+++ b/pcsx2/Dump.cpp
@@ -253,8 +253,8 @@ void iDumpBlock(u32 ee_pc, u32 ee_size, uptr x86_pc, u32 x86_size)
 	objdump.Close();
 
 	std::system(
-			wxsFormat("objdump -D -b binary -mi386 --disassembler-options=intel --no-show-raw-insn --adjust-vma=%d %s >> %s",
-				(u32) x86_pc, WX_STR(obj_filename), WX_STR(dump_filename))
+			wxsFormat( L"objdump -D -b binary -mi386 --disassembler-options=intel --no-show-raw-insn --adjust-vma=%d %s >> %s",
+				   (u32) x86_pc, WX_STR(obj_filename), WX_STR(dump_filename)).mb_str()
 			);
 #endif
 }

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -281,8 +281,8 @@ static void iIopDumpBlock( int startpc, u8 * ptr )
 		f2.Write( ptr, (uptr)x86Ptr - (uptr)ptr );
 	}
 
-	std::system( wxsFormat("objdump -D -b binary -mi386 -M intel --no-show-raw-insn %s >> %s; rm %s",
-				"mydump1", WX_STR(filename), "mydump1") );
+	std::system( wxsFormat( L"objdump -D -b binary -mi386 -M intel --no-show-raw-insn %s >> %s; rm %s",
+				"mydump1", WX_STR(filename), "mydump1").mb_str() );
 #endif
 }
 


### PR DESCRIPTION
pcsx2/Dump.cpp: In function 'void iDumpBlock(u32, u32, uptr, u32)':
pcsx2/Dump.cpp:258:4: error: cannot convert 'wxString' to 'const char*' for argument '1' to 'int system(const char*)'