### PR TITLE
Folder Memory Card: Detect and handle filenames that end in dots and/or spaces.

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1530,9 +1530,9 @@ bool FileAccessHelper::CleanMemcardFilename( char* name ) {
 	const char illegalChars[] = { '\\', '%', ':', '|', '"', '<', '>' };
 	bool cleaned = false;
 
+	const size_t filenameLength = strlen( name );
 	for ( size_t i = 0; i < sizeof( illegalChars ); ++i ) {
-		// this sizeof looks really odd but I couldn't get MemoryCardFileEntry::entry.data.name (or variants) working, feel free to replace with something equivalent but nicer looking
-		for ( size_t j = 0; j < sizeof( ( (MemoryCardFileEntry*)0 )->entry.data.name ); ++j ) {
+		for ( size_t j = 0; j < filenameLength; ++j ) {
 			if ( name[j] == illegalChars[i] ) {
 				name[j] = '_';
 				cleaned = true;
@@ -1540,9 +1540,28 @@ bool FileAccessHelper::CleanMemcardFilename( char* name ) {
 		}
 	}
 
+	cleaned = CleanMemcardFilenameEndDotOrSpace( name, filenameLength ) || cleaned;
+
 	return cleaned;
 }
 
+bool FileAccessHelper::CleanMemcardFilenameEndDotOrSpace( char* name, size_t length ) {
+	// Windows truncates dots and spaces at the end of filenames, so make sure that doesn't happen
+	bool cleaned = false;
+	for ( size_t j = length; j > 0; --j ) {
+		switch ( name[j - 1] ) {
+		case ' ':
+		case '.':
+			name[j - 1] = '_';
+			cleaned = true;
+			break;
+		default:
+			return cleaned;
+		}
+	}
+
+	return cleaned;
+}
 
 bool MemoryCardFileMetadataReference::GetPath( wxFileName* fileName ) const {
 	bool parentCleaned = false;

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -237,6 +237,9 @@ public:
 	static bool CleanMemcardFilename( char* name );
 
 protected:
+	// helper function for CleanMemcardFilename()
+	static bool CleanMemcardFilenameEndDotOrSpace( char* name, size_t length );
+
 	// Open a new file and remember it for later
 	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
 	// Close a file and delete its handle


### PR DESCRIPTION
Windows truncates filenames that end in dots or spaces by removing them until a non-space/dot is encountered. This commit makes sure that filenames with that property get modified and saved along with a metadata file that has the actual filename, similar to how we clean characters that are illegal in filenames on Windows.

This may or may not fix the cause of #1136, hard to say since I don't own the GTA games.