### PR TITLE
GSDX: Vertical frequency corrections and extra stuffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.bsc
 *.aps
 *.exe
+*.wav
 
 *.trace
 *.dump

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1285,6 +1285,16 @@ enum stateType {ST_WRITE, ST_TRANSFER, ST_VSYNC};
 #define DEFAULT_EXTRA_RENDERING_THREADS 2
 
 // GS Video modes macros
-#define Vmode_VESA (m_regs->SMODE1.CMOD == 0)
-#define Vmode_NTSC (m_regs->SMODE1.CMOD == 2)
-#define Vmode_PAL  (m_regs->SMODE1.CMOD == 3)
+#define Vmode_VESA_DTV			(m_regs->SMODE1.CMOD == 0)
+#define Vmode_NTSC				(m_regs->SMODE1.CMOD == 2)
+#define Vmode_PAL				(m_regs->SMODE1.CMOD == 3)
+#define Vmode_VESA_1A			(m_regs->SMODE1.LC == 15 && Vmode_VESA_DTV)
+#define Vmode_VESA_1C			(m_regs->SMODE1.LC == 28 && Vmode_VESA_DTV)
+#define Vmode_VESA_2B			(m_regs->SMODE1.LC == 71 && Vmode_VESA_DTV)
+#define Vmode_VESA_2D			(m_regs->SMODE1.LC == 44 && Vmode_VESA_DTV)
+#define Vmode_VESA_3B			(m_regs->SMODE1.LC == 58 && Vmode_VESA_DTV)
+#define Vmode_VESA_3D			(m_regs->SMODE1.LC == 35 && Vmode_VESA_DTV)
+#define Vmode_VESA_4A			(m_regs->SMODE1.LC == 8  && Vmode_VESA_DTV)
+#define Vmode_VESA_4B			(m_regs->SMODE1.LC == 10 && Vmode_VESA_DTV)
+#define Vmode_DTV_480P			(m_regs->SMODE1.LC == 32 && Vmode_VESA_DTV)
+#define Vmode_DTV_720P_1080I	(m_regs->SMODE1.LC == 22 && Vmode_VESA_DTV)

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -363,7 +363,7 @@ void GSRenderer::VSync(int field)
 
 			s = format(
 				"%lld | %d x %d | %.2f fps (%d%%) | %s - %s | %s | %d S/%d P/%d D | %d%% CPU | %.2f | %.2f",
-				m_perfmon.GetFrame(), r.width(), r.height(), fps, (int)(100.0 * fps / GetTvRefreshRate()),
+				m_perfmon.GetFrame(), GetInternalResolution().x, GetInternalResolution().y, fps, (int)(100.0 * fps / GetTvRefreshRate()),
 				s2.c_str(),
 				theApp.m_gs_interlace[m_interlace].name.c_str(),
 				theApp.m_gs_aspectratio[m_aspectratio].name.c_str(),
@@ -395,7 +395,7 @@ void GSRenderer::VSync(int field)
 		{
 			// Satisfy PCSX2's request for title info: minimal verbosity due to more external title text
 
-			s = format("%dx%d | %s", r.width(), r.height(), theApp.m_gs_interlace[m_interlace].name.c_str());
+			s = format("%dx%d | %s", GetInternalResolution().x, GetInternalResolution().y, theApp.m_gs_interlace[m_interlace].name.c_str());
 		}
 
 		if(m_capture.IsCapturing())

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -354,7 +354,7 @@ GSVector4i GSState::GetDisplayRect(int i)
 	GSVector4i r;
 
 	//Some games (such as Pool Paradise) use alternate line reading and provide a massive height which is really half.
-	if (height > 640 && !Vmode_VESA)
+	if (height > 640 && !Vmode_VESA_DTV)
 	{
 		height /= 2;
 	}

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -370,8 +370,6 @@ GSVector4i GSState::GetDisplayRect(int i)
 	return r;
 }
 
-// There's a problem when games expand/shrink and relocate the visible area since GSdx doesn't support
-// moving the output area. (Disgaea 2 intro FMV when upscaling is used). 
 GSVector4i GSState::GetFrameRect(int i)
 {
 	if (i < 0) i = IsEnabled(1) ? 1 : 0;
@@ -391,7 +389,6 @@ GSVector4i GSState::GetFrameRect(int i)
 	if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD && h > 1)
 		h >>= 1;
 
-	//watch Disgaea2 FMV borders when changing
 	r.left = m_regs->DISP[i].DISPFB.DBX;
 	r.top = m_regs->DISP[i].DISPFB.DBY;
 	r.right = r.left + w;

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -467,10 +467,33 @@ bool GSState::IsEnabled(int i)
 
 float GSState::GetTvRefreshRate()
 {
-  // TODO: Frequencies for VESA / DTV : http://users.neoscientists.org/~blue/ps2videomodes.txt
-  // SMODE1 PLL Loop divider (LC) could be used for detection of other video modes. CMOD's only useful for NTSC/PAL.(2/3)
+	float vertical_frequency = 0;
 
-	return (Vmode_PAL) ? 50 : (60/1.001f);
+	switch (m_regs->SMODE1.CMOD)
+	{
+		case 0:
+		{
+			if (Vmode_VESA_1A)			vertical_frequency = 59.94f;
+			if (Vmode_VESA_1C)			vertical_frequency = 75;
+			if (Vmode_VESA_2B)			vertical_frequency = 60.317f;
+			if (Vmode_VESA_2D)			vertical_frequency = 75;
+			if (Vmode_VESA_3B)			vertical_frequency = 60.004f;
+			if (Vmode_VESA_3D)			vertical_frequency = 75.029f;
+			if (Vmode_VESA_4A)			vertical_frequency = 60.020f;
+			if (Vmode_VESA_4B)			vertical_frequency = 75.025f;
+			if (Vmode_DTV_480P)			vertical_frequency = 59.94f;
+			if (Vmode_DTV_720P_1080I)	vertical_frequency = 60;
+			break;
+		}
+
+		case 2: vertical_frequency = (60 / 1.001f); //NTSC
+			break;
+		case 3: vertical_frequency = 50;			//PAL
+			break;
+		default: ASSERT(0);
+	}
+
+	return vertical_frequency;
 }
 
 // GIFPackedRegHandler*


### PR DESCRIPTION
**Summary of changes:**

* Extend the macros to include all video modes.
* Add vertical frequencies on ``GetTvRefreshRate()`` for all other video modes.
* display the resolution impacted with upscaling on titlebar. (lots of users requested the following to be implemented. example: native -> 640 X 512 then 2x native should display 1280 X 1024).
* remove wav files from appearing on local diff. (SPU2-X generates wav files after recording using the Inbuilt recorder)