### PR TITLE
EditorConfig: Enforce Indent size for specific files on project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Should always be specified at the top of the file outside of any sections
+root = true
+
+# TODO: Add one for resource script file and other Linux specific files ?
+
+[*.{cpp,h}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
**Summary of changes:**

* Enforce Indent style to ~~Tab~~ Space and Indent size to 4 for all .cpp/.h files as that works nice with code alignment.

* Natively works on the Github online editor so you don't need to change indent size to 4 on GitHub online editor to view the code properly all the time.

* Remove any whitespace characters preceding newline characters for .cpp/.h ( saves some poor souls :P )

* I've explicitly set ``trim_trailing_whitespace = false`` for .md files to avoid any potential issues with the syntax.


Feel free to make any changes to specific types of files , just avoid using the global format ``[*]`` as some files need different indentation levels. Thanks to @gregory38 for the suggestion.