### PR TITLE
Fix opcode text crash in Debugger

### DIFF
--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -256,7 +256,8 @@ wxString BreakpointList::getColumnText(int item, int col) const
 				dest.Write(L"-");
 			} else {
 				char temp[256];
-				disasm->getOpcodeText(displayedBreakPoints_[index].addr, temp);
+				if(cpu->isAlive())
+					disasm->getOpcodeText(displayedBreakPoints_[index].addr, temp);
 				dest.Write("%s",temp);
 			}
 		}
@@ -688,7 +689,8 @@ wxString StackFramesList::getColumnText(int item, int col) const
 	case SF_CUROPCODE:
 		{
 			char temp[512];
-			disassembly->getOpcodeText(frame.pc,temp);
+			if (cpu->isAlive())
+				disassembly->getOpcodeText(frame.pc,temp);
 			dest.Write("%s",temp);
 		}
 		break;

--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -255,9 +255,10 @@ wxString BreakpointList::getColumnText(int item, int col) const
 			if (isMemory) {
 				dest.Write(L"-");
 			} else {
+				if (!cpu->isAlive())
+					break;
 				char temp[256];
-				if(cpu->isAlive())
-					disasm->getOpcodeText(displayedBreakPoints_[index].addr, temp);
+				disasm->getOpcodeText(displayedBreakPoints_[index].addr, temp);
 				dest.Write("%s",temp);
 			}
 		}
@@ -688,9 +689,10 @@ wxString StackFramesList::getColumnText(int item, int col) const
 		break;
 	case SF_CUROPCODE:
 		{
+			if (!cpu->isAlive())
+				break;
 			char temp[512];
-			if (cpu->isAlive())
-				disassembly->getOpcodeText(frame.pc,temp);
+			disassembly->getOpcodeText(frame.pc,temp);
 			dest.Write("%s",temp);
 		}
 		break;


### PR DESCRIPTION
Added a check for if the cpu is alive before trying to read memory to display opcodes in the debugger UI list tabs.
When the cpu thread is dead opcodes column in the Breakpoint and Stack Frame tabs now get rendered blank.
The disassembly pane does the same check.
The check seems overly general, because there is no problem getting the opcodes when the cpu is paused?

Intended to fix #1166 but could be a separate issue so needs testing