### PR TITLE
GameDB: Default to Positive round mode for Ed, Edd, 'n Eddy & 	GameDB: SLES-52895 and SLUS-20904 are same, and patch works.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -14619,6 +14619,7 @@ Region = PAL-E
 Serial = SLES-53747
 Name   = Ed, Edd, 'n Eddy - The Misadventure
 Region = PAL-E
+eeRoundMode = 2
 ---------------------------------------------
 Serial = SLES-53748
 Name   = Quest for Sleeping Beauty
@@ -39471,6 +39472,7 @@ Serial = SLUS-21260
 Name   = Ed, Edd, 'n Eddy - The Mis-Edventures
 Region = NTSC-U
 Compat = 5
+eeRoundMode = 2
 ---------------------------------------------
 Serial = SLUS-21261
 Name   = Shadow the Hedgehog

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -37693,6 +37693,12 @@ Serial = SLUS-20904
 Name   = SpongeBob Squarepants - The Movie
 Region = NTSC-U
 Compat = 5
+[patches = 536FEB77]
+comment= Patch By Prafull
+// fix hang at loading screen
+patch=1,EE,0010f3e0,word,00000000
+comment= this disc has the same crc as SLES-52895.
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20905
 Name   = Incredibles, The

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -14619,7 +14619,7 @@ Region = PAL-E
 Serial = SLES-53747
 Name   = Ed, Edd, 'n Eddy - The Misadventure
 Region = PAL-E
-eeRoundMode = 2
+eeRoundMode = 2		//fixes missing text
 ---------------------------------------------
 Serial = SLES-53748
 Name   = Quest for Sleeping Beauty
@@ -39478,7 +39478,7 @@ Serial = SLUS-21260
 Name   = Ed, Edd, 'n Eddy - The Mis-Edventures
 Region = NTSC-U
 Compat = 5
-eeRoundMode = 2
+eeRoundMode = 2		//fixes missing text
 ---------------------------------------------
 Serial = SLUS-21261
 Name   = Shadow the Hedgehog


### PR DESCRIPTION
before:
![default](https://cloud.githubusercontent.com/assets/3949282/13247245/d08674f8-da5b-11e5-9b3e-00813ad8b4b3.png)

after:
![2](https://cloud.githubusercontent.com/assets/3949282/13247252/d81f51bc-da5b-11e5-804f-0463f279311b.png)

Serial = SLES-53747
Name   = Ed, Edd, 'n Eddy - The Misadventure
Region = PAL-E

Serial = SLUS-21260
Name   = Ed, Edd, 'n Eddy - The Mis-Edventures
Region = NTSC-U

setting eeRoundMode = 2 fixes missing text.