### PR TITLE
PCSX2-WX: Minor changes to core panels/dialog

### DIFF
--- a/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
+++ b/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
@@ -55,7 +55,7 @@ Dialogs::AboutBoxDialog::AboutBoxDialog(wxWindow* parent)
 
 	wxString contribsString = wxsFormat(
 		L"%s: \n"
-		L"ChickenLiver(Lilypad), Gabest (Gsdx, Cdvdolio, Xpad)"
+		L"ChickenLiver(Lilypad), Gabest (GSdx, Cdvdolio, Xpad)"
 		L"\n\n"
 		L"%s: \n"
 		L"Ckemu, Prafull, General Plot, KrossX, Devina, ssakash, turtleli, Blyss Sarania, micove, black_wd, Belmont, BGome,"

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -178,7 +178,7 @@ namespace Panels
 		pxRadioPanel*		m_panel_RecIOP;
 		pxCheckBox*			m_check_EECacheEnable;
 		AdvancedOptionsFPU*	m_advancedOptsFpu;
-		wxButton *m_button_RestoreDefaults;
+		wxButton*			m_button_RestoreDefaults;
 
 	public:
 		CpuPanelEE( wxWindow* parent );
@@ -190,6 +190,7 @@ namespace Panels
 
 	protected:
 		void OnRestoreDefaults( wxCommandEvent& evt );
+		void EECache_Event( wxCommandEvent& evt );
 	};
 
 	class CpuPanelVU : public BaseApplicableConfigPanel_SpecificConfig

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -242,9 +242,8 @@ void Panels::CpuPanelEE::AppStatusEvent_OnSettingsApplied()
 	ApplyConfigToGui( *g_Conf );
 }
 
-void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags ){
-	m_panel_RecEE->Enable(true);
-
+void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
+{
 	const Pcsx2Config::RecompilerOptions& recOps( configToApply.EmuOptions.Cpu.Recompiler );
 	m_panel_RecEE->SetSelection( (int)recOps.EnableEE );
 	m_panel_RecIOP->SetSelection( (int)recOps.EnableIOP );
@@ -295,17 +294,10 @@ void Panels::CpuPanelVU::AppStatusEvent_OnSettingsApplied()
 
 void Panels::CpuPanelVU::ApplyConfigToGui( AppConfig& configToApply, int flags )
 {
-	m_panel_VU0->Enable(true);
-	m_panel_VU1->Enable(true);
 
-	m_panel_VU0->EnableItem( 1, true);
-#ifndef DISABLE_SVU
-	m_panel_VU0->EnableItem( 2, true);
-#endif
-
-	m_panel_VU1->EnableItem( 1, true);
-#ifndef DISABLE_SVU
-	m_panel_VU1->EnableItem( 2, true);
+#ifdef DISABLE_SVU
+	m_panel_VU0->EnableItem( 2, false);
+	m_panel_VU1->EnableItem( 2, false);
 #endif
 
 	Pcsx2Config::RecompilerOptions& recOps( configToApply.EmuOptions.Cpu.Recompiler );

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -171,6 +171,7 @@ Panels::CpuPanelEE::CpuPanelEE( wxWindow* parent )
 	*this += m_button_RestoreDefaults | StdButton();
 
 	Connect( wxID_DEFAULT, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CpuPanelEE::OnRestoreDefaults ) );
+	Bind(wxEVT_COMMAND_RADIOBUTTON_SELECTED, &CpuPanelEE::EECache_Event, this);
 }
 
 Panels::CpuPanelVU::CpuPanelVU( wxWindow* parent )
@@ -233,7 +234,7 @@ void Panels::CpuPanelEE::Apply()
 	Pcsx2Config::RecompilerOptions& recOps( g_Conf->EmuOptions.Cpu.Recompiler );
 	recOps.EnableEE		  = !!m_panel_RecEE->GetSelection();
 	recOps.EnableIOP	  = !!m_panel_RecIOP->GetSelection();
-	recOps.EnableEECache  = m_check_EECacheEnable	->GetValue();
+	recOps.EnableEECache  = m_check_EECacheEnable->GetValue();
 }
 
 void Panels::CpuPanelEE::AppStatusEvent_OnSettingsApplied()
@@ -251,8 +252,9 @@ void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
 	m_panel_RecEE->Enable(!configToApply.EnablePresets);
 	m_panel_RecIOP->Enable(!configToApply.EnablePresets);
 
-	m_check_EECacheEnable ->SetValue(recOps.EnableEECache);
-	m_check_EECacheEnable->Enable(!configToApply.EnablePresets);
+	//EECache option is exclusive to the EE Interpreter.
+	m_check_EECacheEnable->SetValue(recOps.EnableEECache);
+	m_check_EECacheEnable->Enable(!configToApply.EnablePresets && m_panel_RecEE->GetSelection() == 0);
 	m_button_RestoreDefaults->Enable(!configToApply.EnablePresets);
 
 	if( flags & AppConfig::APPLY_FLAG_MANUALLY_PROPAGATE )
@@ -427,4 +429,10 @@ void Panels::AdvancedOptionsVU::ApplyConfigToGui( AppConfig& configToApply, int 
 	else								m_ClampModePanel->SetSelection( 0 );
 
 	this->Enable(!configToApply.EnablePresets);
+}
+
+void Panels::CpuPanelEE::EECache_Event(wxCommandEvent& event)
+{
+	m_check_EECacheEnable->Enable(m_panel_RecEE->GetSelection() == 0);
+	event.Skip();
 }


### PR DESCRIPTION
**Summary of changes:**

* Fix a _minor_ typographical error on the about box dialog. (thanks to @Sarania )
* Add an event handler for graying out EE cache checkbox dynamically when recompiler is used.
* Remove / clean up some stuffs. ( unnecessary explicit enable calls / code consistency)