### PR TITLE
Check delay breakpoint conditions

### DIFF
--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -602,17 +602,19 @@ inline bool isBranchOrJump(u32 addr)
 
 // The next two functions return 0 if no breakpoint is needed,
 // 1 if it's needed on the current pc, 2 if it's needed in the delay slot
+// 3 if needed in both
 
 int isBreakpointNeeded(u32 addr)
 {
+	int bpFlags = 0;
 	if (CBreakPoints::IsAddressBreakPoint(addr))
-		return 1;
+		bpFlags += 1;
 
 	// there may be a breakpoint in the delay slot
 	if (isBranchOrJump(addr) && CBreakPoints::IsAddressBreakPoint(addr+4))
-		return 2;
+		bpFlags += 2;
 
-	return 0;
+	return bpFlags;
 }
 
 int isMemcheckNeeded(u32 pc)

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1088,8 +1088,23 @@ void dynarecCheckBreakpoint()
  	if (CBreakPoints::CheckSkipFirst(pc) != 0)
 		return;
 
-	auto cond = CBreakPoints::GetBreakPointCondition(pc);
-	if (cond && !cond->Evaluate())
+	int bpFlags = isBreakpointNeeded(pc);
+	bool hit = false;
+	//check breakpoint at current pc
+	if (bpFlags & 1) {
+		auto cond = CBreakPoints::GetBreakPointCondition(pc);
+		if (cond == NULL || cond->Evaluate()) {
+			hit = true;
+		}
+	}
+	//check breakpoint in delay slot
+	if (bpFlags & 2) {
+		auto cond = CBreakPoints::GetBreakPointCondition(pc + 4);
+		if (cond == NULL || cond->Evaluate())
+			hit = true;
+	}
+
+	if (!hit)
 		return;
 
 	CBreakPoints::SetBreakpointTriggered(true);


### PR DESCRIPTION
Fixes #1204 

isBreakpointNeeded returns if breakpoints are needed for any combination
of the current pc and delay slot.
dynarecCheckBreakpoint checks conditions for each breakpoint slot.
