### PR TITLE
Core|Common: restore old interlocked add/sub behavior

### DIFF
--- a/common/src/Utilities/Mutex.cpp
+++ b/common/src/Utilities/Mutex.cpp
@@ -120,7 +120,7 @@ Threading::Mutex::~Mutex() throw()
 
 Threading::MutexRecursive::MutexRecursive() : Mutex( false )
 {
-	if( _attr_refcount.fetch_add(1) == 1 )
+	if( ++_attr_refcount == 1 )
 	{
 		if( 0 != pthread_mutexattr_init( &_attr_recursive ) )
 			throw Exception::OutOfMemory(L"Recursive mutexing attributes");
@@ -134,7 +134,7 @@ Threading::MutexRecursive::MutexRecursive() : Mutex( false )
 
 Threading::MutexRecursive::~MutexRecursive() throw()
 {
-	if( _attr_refcount.fetch_sub(1) == 0 )
+	if( --_attr_refcount == 0 )
 		pthread_mutexattr_destroy( &_attr_recursive );
 }
 


### PR DESCRIPTION
interlocked* returns the new value whereas fetch_add/sub returns the old value.