### PR TITLE
GSDX: "Prince Of Persia: Warrior Within" Hack

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -511,6 +511,7 @@ CRC::Game CRC::m_games[] =
 	{0xFEFCF9DE, SteambotChronicles, JP, 0}, // Ponkotsu Roman Daikatsugeki: Bumpy Trot 
 	{0XE1BF5DCA, SuperManReturns, US, 0},
 	{0x06A7506A, SacredBlaze, JP, 0},
+	{0x6B17B39F, PrinceOfPersiaWarriorWithin, US, 0},
 };
 
 hash_map<uint32, CRC::Game*> CRC::m_map;

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -173,6 +173,7 @@ public:
 		SteambotChronicles,
 		SacredBlaze,
 		SuperManReturns,
+		PrinceOfPersiaWarriorWithin,
 		TitleCount,
 	};
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -658,6 +658,7 @@ GSRendererHW::Hacks::Hacks()
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::TalesOfLegendia, CRC::RegionCount, &GSRendererHW::OI_TalesOfLegendia));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SMTNocturne, CRC::RegionCount, &GSRendererHW::OI_SMTNocturne));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SuperManReturns, CRC::RegionCount, &GSRendererHW::OI_SuperManReturns));
+	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::PrinceOfPersiaWarriorWithin, CRC::RegionCount, &GSRendererHW::OI_POPWW));
 
 	m_oo_list.push_back(HackEntry<OO_Ptr>(CRC::DBZBT2, CRC::RegionCount, &GSRendererHW::OO_DBZBT2));
 	m_oo_list.push_back(HackEntry<OO_Ptr>(CRC::MajokkoALaMode2, CRC::RegionCount, &GSRendererHW::OO_MajokkoALaMode2));
@@ -1246,6 +1247,17 @@ bool GSRendererHW::OI_SuperManReturns(GSTexture* rt, GSTexture* ds, GSTextureCac
 	m_tc->InvalidateVideoMemType(GSTextureCache::DepthStencil, ctx->FRAME.Block());
 
 	return false;
+}
+
+bool GSRendererHW::OI_POPWW(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
+{
+	uint32 FBP = m_context->FRAME.Block();
+	uint32 FBMSK = m_context->FRAME.FBMSK;
+
+	if(FBMSK != 0xff000000 && FBMSK != 0 && FBP < 0x02300)
+		return false;
+
+	return true;
 }
 
 

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -65,6 +65,7 @@ private:
 	bool OI_SMTNocturne(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_PointListPalette(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_SuperManReturns(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	bool OI_POPWW(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	void OO_DBZBT2();
 	void OO_MajokkoALaMode2();
 


### PR DESCRIPTION
Makes things visible in Hardware mode.

Known issues:
* Prince's armor is too shiny bright
* Buggy shadows

NTSC only, PAL version is NOT tested.