### PR TITLE
cdvdgigaherz: Dual layer DVD fixes

### DIFF
--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -290,18 +290,18 @@ s32  CALLBACK CDVDgetDualInfo(s32* dualType, u32* _layer1start)
 	{
 	case 1:
 		*dualType = 1;
-		*_layer1start = src->GetLayerBreakAddress();
-		return 1;
+		*_layer1start = src->GetLayerBreakAddress() + 1;
+		return 0;
 	case 2:
 		*dualType = 2;
-		*_layer1start = src->GetLayerBreakAddress();
-		return 1;
+		*_layer1start = src->GetLayerBreakAddress() + 1;
+		return 0;
 	case 0:
 		*dualType = 0;
 		*_layer1start = 0;
-		return 1;
+		return 0;
 	}
-	return 0;
+	return -1;
 }
 
 int lastReadInNewDiskCB=0;

--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -428,18 +428,15 @@ s32 CALLBACK CDVDgetTD(u8 Track, cdvdTD *Buffer)
 	return 0;
 }
 
-u32 layer1start=-1;
-
 s32 CALLBACK CDVDgetTOC(u8* tocBuff)
 {
 	//return src->ReadTOC((char*)toc,2048);
 	//that didn't work too well...
 
-	if(curDiskType==CDVD_TYPE_NODISC)
+	if (curDiskType == CDVD_TYPE_NODISC)
 		return -1;
 
-	if((curDiskType == CDVD_TYPE_DVDV) ||
-	   (curDiskType == CDVD_TYPE_PS2DVD))
+	if (curDiskType == CDVD_TYPE_DETCTDVDS || curDiskType == CDVD_TYPE_DETCTDVDD)
 	{
 		memset(tocBuff, 0, 2048);
 
@@ -465,7 +462,7 @@ s32 CALLBACK CDVDgetTOC(u8* tocBuff)
 		}
 		else if(mt==1) //PTP
 		{
-			layer1start = src->GetLayerBreakAddress() + 0x30000;
+			u32 layer1start = src->GetLayerBreakAddress() + 0x30000;
 
 			// dual sided
 			tocBuff[ 0] = 0x24;
@@ -489,7 +486,7 @@ s32 CALLBACK CDVDgetTOC(u8* tocBuff)
 		}
 		else //OTP
 		{
-			layer1start = src->GetLayerBreakAddress() + 0x30000;
+			u32 layer1start = src->GetLayerBreakAddress() + 0x30000;
 
 			// dual sided
 			tocBuff[ 0] = 0x24;
@@ -512,11 +509,7 @@ s32 CALLBACK CDVDgetTOC(u8* tocBuff)
 			tocBuff[27] = (layer1start>> 0)&0xff;
 		}
 	}
-	else if(curDiskType == CDVD_TYPE_CDDA ||
-			curDiskType == CDVD_TYPE_PS2CDDA ||
-			curDiskType == CDVD_TYPE_PS2CD ||
-			curDiskType == CDVD_TYPE_PSCDDA ||
-			curDiskType == CDVD_TYPE_PSCD)
+	else if (curDiskType == CDVD_TYPE_DETCTCD)
 	{
 		// cd toc
 		// (could be replaced by 1 command that reads the full toc)

--- a/plugins/cdvdGigaherz/src/ReadThread.cpp
+++ b/plugins/cdvdGigaherz/src/ReadThread.cpp
@@ -445,8 +445,8 @@ s32 cdvdRefreshData()
 
 	switch(curDiskType)
 	{
-		case CDVD_TYPE_DETCTDVDD: diskTypeName="Single-Layer DVD"; break;
-		case CDVD_TYPE_DETCTDVDS: diskTypeName="Double-Layer DVD"; break;
+		case CDVD_TYPE_DETCTDVDD: diskTypeName="Double-Layer DVD"; break;
+		case CDVD_TYPE_DETCTDVDS: diskTypeName="Single-Layer DVD"; break;
 		case CDVD_TYPE_DETCTCD:   diskTypeName="CD-ROM"; break;
 		case CDVD_TYPE_NODISC:    diskTypeName="No Disc"; break;
 	}

--- a/plugins/cdvdGigaherz/src/TocStuff.cpp
+++ b/plugins/cdvdGigaherz/src/TocStuff.cpp
@@ -19,49 +19,33 @@ toc_data cdtoc;
 
 s32 cdvdParseTOC()
 {
-	memset(&cdtoc,0,sizeof(cdtoc));
+	memset(&cdtoc, 0, sizeof(cdtoc));
 
 	s32 len = src->GetSectorCount();
 
 	tracks[0].length = len;
-	tracks[0].start_lba=0;
-	tracks[0].type=0;
-	tracks[1].start_lba=0;
+	tracks[0].start_lba = 0;
+	tracks[0].type = 0;
+	tracks[1].start_lba = 0;
 
-	if(len<=0)
+	if (len <= 0)
 	{
-		curDiskType=CDVD_TYPE_NODISC;
-		tracks[0].length=0;
-		strack=1;
-		etrack=0;
+		curDiskType = CDVD_TYPE_NODISC;
+		tracks[0].length = 0;
+		strack = 1;
+		etrack = 0;
 		return 0;
 	}
 
-	s32 lastaddr = src->GetLayerBreakAddress();
+	s32 mt = src->GetMediaType();
 
-
-	if(lastaddr>=0)
+	if (mt >= 0)
 	{
-		if((lastaddr > 0)&&(tracks[0].length>lastaddr))
-		{
-			tracks[1].length=lastaddr+1;
-			tracks[1].type=0;
+		tracks[1].length = tracks[0].length;
+		tracks[1].type = 0;
 
-			tracks[2].start_lba = tracks[1].length;
-			tracks[2].length    = tracks[0].length-tracks[1].length;
-			tracks[2].type=0;
-
-			strack=1;
-			etrack=2;
-		}
-		else
-		{
-			tracks[1].length=tracks[0].length;
-			tracks[1].type=0;
-
-			strack=1;
-			etrack=1;
-		}
+		strack = 1;
+		etrack = 1;
 	}
 	else
 	{
@@ -81,8 +65,6 @@ s32 cdvdParseTOC()
 
 			//return 0;
 		}
-
-#define btoi(b) ((b>>4)*10+(b&0xF))
 
 		int length = (cdtoc.Length[0]<<8) | cdtoc.Length[1];
 		int descriptors = length/sizeof(cdtoc.Descriptors[0]);

--- a/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
@@ -24,6 +24,7 @@
 #include "rosddk/ntddscsi.h"
 #pragma warning(default:4200)
 #include <stddef.h>
+#include <intrin.h>
 
 template<class T>
 bool ApiErrorCheck(T t,T okValue,bool cmpEq)
@@ -404,11 +405,11 @@ s32 IOCtlSrc::GetSectorCount()
 	{
 		if(dld.ld.EndLayerZeroSector>0) // OTP?
 		{
-			sectors1 = dld.ld.EndLayerZeroSector - dld.ld.StartingDataSector;
+			sectors1 = _byteswap_ulong(dld.ld.EndLayerZeroSector) - _byteswap_ulong(dld.ld.StartingDataSector);
 		}
 		else //PTP or single layer
 		{
-			sectors1 = dld.ld.EndDataSector - dld.ld.StartingDataSector;
+			sectors1 = _byteswap_ulong(dld.ld.EndDataSector) - _byteswap_ulong(dld.ld.StartingDataSector);
 		}
 		dvdrs.BlockByteOffset.QuadPart=0;
 		dvdrs.Format=DvdPhysicalDescriptor;
@@ -420,11 +421,11 @@ s32 IOCtlSrc::GetSectorCount()
 			//sectors1 += dld.ld.EndDataSector - dld.ld.StartingDataSector;
 			if(dld.ld.EndLayerZeroSector>0) // OTP?
 			{
-				sectors1 += dld.ld.EndLayerZeroSector - dld.ld.StartingDataSector;
+				sectors1 += _byteswap_ulong(dld.ld.EndLayerZeroSector) - _byteswap_ulong(dld.ld.StartingDataSector);
 			}
 			else //PTP
 			{
-				sectors1 += dld.ld.EndDataSector - dld.ld.StartingDataSector;
+				sectors1 += _byteswap_ulong(dld.ld.EndDataSector) - _byteswap_ulong(dld.ld.StartingDataSector);
 			}
 		}
 
@@ -456,12 +457,12 @@ s32 IOCtlSrc::GetLayerBreakAddress()
 		if(dld.ld.EndLayerZeroSector>0) // OTP?
 		{
 			layerBreakCached = true;
-			layerBreak = dld.ld.EndLayerZeroSector - dld.ld.StartingDataSector;
+			layerBreak = _byteswap_ulong(dld.ld.EndLayerZeroSector) - _byteswap_ulong(dld.ld.StartingDataSector);
 			return layerBreak;
 		}
 		else //PTP or single layer
 		{
-			u32 s1 = dld.ld.EndDataSector - dld.ld.StartingDataSector;
+			u32 s1 = _byteswap_ulong(dld.ld.EndDataSector) - _byteswap_ulong(dld.ld.StartingDataSector);
 
 			dvdrs.BlockByteOffset.QuadPart=0;
 			dvdrs.Format=DvdPhysicalDescriptor;
@@ -568,8 +569,6 @@ s32 IOCtlSrc::GetMediaType()
 		}
 		else //PTP or single layer
 		{
-			u32 s1 = dld.ld.EndDataSector - dld.ld.StartingDataSector;
-
 			dvdrs.BlockByteOffset.QuadPart=0;
 			dvdrs.Format=DvdPhysicalDescriptor;
 			dvdrs.SessionId=sessID;

--- a/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
@@ -297,6 +297,8 @@ s32 IOCtlSrc::Reopen()
 		if(device==INVALID_HANDLE_VALUE)
 			return -1;
 	}
+	// Dual layer DVDs cannot read from layer 1 without this ioctl
+	DeviceIoControl(device, FSCTL_ALLOW_EXTENDED_DASD_IO, nullptr, 0, nullptr, 0, &size, nullptr);
 
 	sessID=0;
 	DeviceIoControl(device,IOCTL_DVD_START_SESSION,NULL,0,&sessID,sizeof(DVD_SESSION_ID), &size, NULL);

--- a/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
@@ -579,7 +579,7 @@ s32 IOCtlSrc::GetMediaType()
 			{
 				//PTP
 				mediaTypeCached = true;
-				mediaType = 2;
+				mediaType = 1;
 				return mediaType;
 			}
 


### PR DESCRIPTION
Changes:
 * CDVDgetDualInfo now returns the first layer 1 LSN (logical sector number) instead of the last layer 0 LSN.
 * PTP (Parallel Track Path) DVDs should no longer be recognised as OTP (Opposite Track Path) DVDs.
 * Single layer DVDs are no longer reported as dual layer DVDs and vice versa.

Note: Reading from dual layer DVDs might still be broken (someone please test). However, these changes should be correct if I have correctly understood the internal ISO reader and old CDVD plugin compatibility code in PCSX2.