### PR TITLE
lilypad, xpad: Remove DirectX SDK dependency, support both XInput 1.3 and 1.4

### DIFF
--- a/plugins/LilyPad/LilyPad.vcxproj
+++ b/plugins/LilyPad/LilyPad.vcxproj
@@ -99,9 +99,6 @@
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-    <LibraryPath Condition="'$(Platform)'=='Win32'">$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
-    <LibraryPath Condition="'$(Platform)'=='x64'">$(DXSDK_DIR)Lib\x64;$(LibraryPath)</LibraryPath>
-    <IncludePath>$(DXSDK_DIR)include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>

--- a/plugins/xpad/stdafx.h
+++ b/plugins/xpad/stdafx.h
@@ -12,7 +12,6 @@
 #include <commctrl.h>
 #include <commdlg.h>
 #include <shellapi.h>
-#include <xinput.h>
 
 #include <assert.h>
 #include <time.h>

--- a/plugins/xpad/vsprops/common.props
+++ b/plugins/xpad/vsprops/common.props
@@ -12,16 +12,12 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4995;4324;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(DXSDK_DIR)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>d3d10.lib;d3dx10.lib;d3d9.lib;d3dx9.lib;dxguid.lib;winmm.lib;strmiids.lib;xinput.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\..\bin\plugins\$(ProjectName).dll</OutputFile>
-      <DelayLoadDLLs>d3d9.dll;d3dx9_43.dll;d3d10.dll;d3dx10_43.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
-      <AdditionalLibraryDirectories>$(DXSDK_DIR)Lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/plugins/xpad/xpad.cpp
+++ b/plugins/xpad/xpad.cpp
@@ -23,6 +23,10 @@
 #include "xpad.h"
 #include <VersionHelpers.h>
 
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0602 // Required for XInputEnable definition
+#include <xinput.h>
+
 static HMODULE s_hModule;
 static HMODULE s_xInputDll;
 static decltype(&XInputEnable) pXInputEnable;

--- a/plugins/xpad/xpad.cpp
+++ b/plugins/xpad/xpad.cpp
@@ -21,8 +21,13 @@
 
 #include "stdafx.h"
 #include "xpad.h"
+#include <VersionHelpers.h>
 
 static HMODULE s_hModule;
+static HMODULE s_xInputDll;
+static decltype(&XInputEnable) pXInputEnable;
+static decltype(&XInputGetState) pXInputGetState;
+static decltype(&XInputSetState) pXInputSetState;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
@@ -133,7 +138,7 @@ public:
 		{
 			memset(&m_state, 0, sizeof(m_state));
 
-			m_connected = XInputGetState(m_pad, &m_state) == S_OK; // ERROR_DEVICE_NOT_CONNECTED is not an error, SUCCEEDED(...) won't work here
+			m_connected = pXInputGetState(m_pad, &m_state) == S_OK; // ERROR_DEVICE_NOT_CONNECTED is not an error, SUCCEEDED(...) won't work here
 
 			m_lastpoll = now;
 		}
@@ -147,7 +152,7 @@ public:
 	{
 		if(m_vibration.wLeftMotorSpeed != vibration.wLeftMotorSpeed || m_vibration.wRightMotorSpeed != vibration.wRightMotorSpeed)
 		{
-			XInputSetState(m_pad, &vibration);
+			pXInputSetState(m_pad, &vibration);
 
 			m_vibration = vibration;
 		}
@@ -634,16 +639,41 @@ LRESULT WINAPI PADwndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 EXPORT_C_(UINT32) PADinit(UINT32 flags)
 {
+	DWORD loadFlags = LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32;
+
+	s_xInputDll = LoadLibraryEx(L"xinput1_3.dll", nullptr, loadFlags);
+	if (s_xInputDll == nullptr && IsWindows8OrGreater())
+	{
+		s_xInputDll = LoadLibraryEx(L"XInput1_4.dll", nullptr, loadFlags);
+	}
+	if (s_xInputDll == nullptr)
+	{
+		return 1;
+	}
+
+	if (!(pXInputEnable = reinterpret_cast<decltype(&XInputEnable)>(GetProcAddress(s_xInputDll, "XInputEnable")))
+		|| !(pXInputSetState = reinterpret_cast<decltype(&XInputSetState)>(GetProcAddress(s_xInputDll, "XInputSetState")))
+		|| !(pXInputGetState = reinterpret_cast<decltype(&XInputGetState)>(GetProcAddress(s_xInputDll, "XInputGetState"))))
+	{
+		FreeLibrary(s_xInputDll);
+		s_xInputDll = nullptr;
+		return 1;
+	}
 	return 0;
 }
 
 EXPORT_C PADshutdown()
 {
+	if (s_xInputDll)
+	{
+		FreeLibrary(s_xInputDll);
+		s_xInputDll = nullptr;
+	}
 }
 
 EXPORT_C_(UINT32) PADopen(void* pDsp)
 {
-	XInputEnable(TRUE);
+	pXInputEnable(TRUE);
 
 	if(s_nRefs == 0)
 	{
@@ -671,7 +701,7 @@ EXPORT_C PADclose()
 		}
 	}
 
-	XInputEnable(FALSE);
+	pXInputEnable(FALSE);
 }
 
 EXPORT_C_(UINT32) CALLBACK PADquery()


### PR DESCRIPTION
Changes:
 * Removes DirectX SDK dependency from Lilypad and xpad
 * Allow Windows 8 and above to use XInput 1.4 if the DirectX redists aren't installed. If the XInput 1.3 dll is present, it'll choose to use that first - I think SCP only has an XInput 1.3 wrapper at the moment.