### PR TITLE
gsdx: Remove DirectX SDK dependency

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -132,6 +132,10 @@ EXPORT_C_(int) GSinit()
 		return -1;
 	}
 
+	if (!GSDeviceDX::LoadD3DCompiler())
+	{
+		return -1;
+	}
 #endif
 
 	return 0;
@@ -155,6 +159,8 @@ EXPORT_C GSshutdown()
 
 		s_hr = E_FAIL;
 	}
+
+	GSDeviceDX::FreeD3DCompiler();
 
 #endif
 }

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -127,11 +127,6 @@ EXPORT_C_(int) GSinit()
 
 	s_hr = ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
 
-	if(!GSUtil::CheckDirectX())
-	{
-		return -1;
-	}
-
 	if (!GSDeviceDX::LoadD3DCompiler())
 	{
 		return -1;

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -175,11 +175,11 @@ bool GSDevice11::Create(GSWnd* wnd)
 
 	vector<unsigned char> shader;
 	theApp.LoadResource(IDR_CONVERT_FX, shader);
-	CompileShader((const char *)shader.data(), shader.size(), "convert.fx", "vs_main", NULL, &m_convert.vs, il_convert, countof(il_convert), &m_convert.il);
+	CompileShader((const char *)shader.data(), shader.size(), "convert.fx", nullptr, "vs_main", nullptr, &m_convert.vs, il_convert, countof(il_convert), &m_convert.il);
 
 	for(size_t i = 0; i < countof(m_convert.ps); i++)
 	{
-		CompileShader((const char *)shader.data(), shader.size(), "convert.fx", format("ps_main%d", i).c_str(), NULL, &m_convert.ps[i]);
+		CompileShader((const char *)shader.data(), shader.size(), "convert.fx", nullptr, format("ps_main%d", i).c_str(), nullptr, &m_convert.ps[i]);
 	}
 
 	memset(&dsd, 0, sizeof(dsd));
@@ -208,7 +208,7 @@ bool GSDevice11::Create(GSWnd* wnd)
 	theApp.LoadResource(IDR_MERGE_FX, shader);
 	for(size_t i = 0; i < countof(m_merge.ps); i++)
 	{
-		CompileShader((const char *)shader.data(), shader.size(), "merge.fx", format("ps_main%d", i).c_str(), NULL, &m_merge.ps[i]);
+		CompileShader((const char *)shader.data(), shader.size(), "merge.fx", nullptr, format("ps_main%d", i).c_str(), nullptr, &m_merge.ps[i]);
 	}
 
 	memset(&bsd, 0, sizeof(bsd));
@@ -237,7 +237,7 @@ bool GSDevice11::Create(GSWnd* wnd)
 	theApp.LoadResource(IDR_INTERLACE_FX, shader);
 	for(size_t i = 0; i < countof(m_interlace.ps); i++)
 	{
-		CompileShader((const char *)shader.data(), shader.size(), "interlace.fx", format("ps_main%d", i).c_str(), NULL, &m_interlace.ps[i]);
+		CompileShader((const char *)shader.data(), shader.size(), "interlace.fx", nullptr, format("ps_main%d", i).c_str(), nullptr, &m_interlace.ps[i]);
 	}
 
 	// Shade Boost	
@@ -252,7 +252,7 @@ bool GSDevice11::Create(GSWnd* wnd)
 	str[1] = format("%d", ShadeBoost_Brightness);
 	str[2] = format("%d", ShadeBoost_Contrast);
 
-	D3D11_SHADER_MACRO macro[] =
+	D3D_SHADER_MACRO macro[] =
 	{			
 		{"SB_SATURATION", str[0].c_str()},
 		{"SB_BRIGHTNESS", str[1].c_str()},
@@ -269,7 +269,7 @@ bool GSDevice11::Create(GSWnd* wnd)
 	hr = m_dev->CreateBuffer(&bd, NULL, &m_shadeboost.cb);
 
 	theApp.LoadResource(IDR_SHADEBOOST_FX, shader);
-	CompileShader((const char *)shader.data(), shader.size(), "shadeboost.fx", "ps_main", macro, &m_shadeboost.ps);
+	CompileShader((const char *)shader.data(), shader.size(), "shadeboost.fx", nullptr, "ps_main", macro, &m_shadeboost.ps);
 
 	// External fx shader
 
@@ -768,7 +768,7 @@ void GSDevice11::InitExternalFX()
 			if (fshader.good())
 			{
 				shader << fshader.rdbuf();
-				CompileShader(shader.str().c_str(), shader.str().length(), shader_name.c_str(), "ps_main", NULL, &m_shaderfx.ps);
+				CompileShader(shader.str().c_str(), shader.str().length(), shader_name.c_str(), D3D_COMPILE_STANDARD_FILE_INCLUDE, "ps_main", nullptr, &m_shaderfx.ps);
 			}
 			else
 			{
@@ -811,7 +811,7 @@ void GSDevice11::InitFXAA()
 		try {
 			vector<unsigned char> shader;
 			theApp.LoadResource(IDR_FXAA_FX, shader);
-			CompileShader((const char *)shader.data(), shader.size(), "fxaa.fx", "ps_main", NULL, &m_fxaa.ps);
+			CompileShader((const char *)shader.data(), shader.size(), "fxaa.fx", nullptr, "ps_main", nullptr, &m_fxaa.ps);
 		}
 		catch (GSDXRecoverableError) {
 			printf("GSdx: failed to compile fxaa shader.\n");
@@ -1324,17 +1324,17 @@ void GSDevice11::OMSetRenderTargets(const GSVector2i& rtsize, int count, ID3D11U
 	}
 }
 
-void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11VertexShader** vs, D3D11_INPUT_ELEMENT_DESC* layout, int count, ID3D11InputLayout** il)
+void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11VertexShader** vs, D3D11_INPUT_ELEMENT_DESC* layout, int count, ID3D11InputLayout** il)
 {
 	HRESULT hr;
 
-	vector<D3D11_SHADER_MACRO> m;
+	vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
-	CComPtr<ID3D11Blob> shader, error;
+	CComPtr<ID3DBlob> shader, error;
 
-	hr = D3DX11CompileFromMemory(source, size, fn, &m[0], NULL, entry, m_shader.vs.c_str(), 0, 0, NULL, &shader, &error, NULL);
+	hr = s_pD3DCompile(source, size, fn, &m[0], s_old_d3d_compiler_dll? nullptr : include, entry, m_shader.vs.c_str(), 0, 0, &shader, &error);
 
 	if(error)
 	{
@@ -1361,17 +1361,17 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 	}
 }
 
-void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11GeometryShader** gs)
+void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11GeometryShader** gs)
 {
 	HRESULT hr;
 
-	vector<D3D11_SHADER_MACRO> m;
+	vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
-	CComPtr<ID3D11Blob> shader, error;
+	CComPtr<ID3DBlob> shader, error;
 
-	hr = D3DX11CompileFromMemory(source, size, fn, &m[0], NULL, entry, m_shader.gs.c_str(), 0, 0, NULL, &shader, &error, NULL);
+	hr = s_pD3DCompile(source, size, fn, &m[0], s_old_d3d_compiler_dll ? nullptr : include, entry, m_shader.gs.c_str(), 0, 0, &shader, &error);
 
 	if(error)
 	{
@@ -1391,17 +1391,17 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 	}
 }
 
-void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11GeometryShader** gs, D3D11_SO_DECLARATION_ENTRY* layout, int count)
+void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11GeometryShader** gs, D3D11_SO_DECLARATION_ENTRY* layout, int count)
 {
 	HRESULT hr;
 
-	vector<D3D11_SHADER_MACRO> m;
+	vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
-	CComPtr<ID3D11Blob> shader, error;
+	CComPtr<ID3DBlob> shader, error;
 
-	hr = D3DX11CompileFromMemory(source, size, fn, &m[0], NULL, entry, m_shader.gs.c_str(), 0, 0, NULL, &shader, &error, NULL);
+	hr = s_pD3DCompile(source, size, fn, &m[0], s_old_d3d_compiler_dll ? nullptr : include, entry, m_shader.gs.c_str(), 0, 0, &shader, &error);
 
 	if(error)
 	{
@@ -1421,17 +1421,17 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 	}
 }
 
-void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11PixelShader** ps)
+void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11PixelShader** ps)
 {
 	HRESULT hr;
 
-	vector<D3D11_SHADER_MACRO> m;
+	vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
-	CComPtr<ID3D11Blob> shader, error;
+	CComPtr<ID3DBlob> shader, error;
 
-	hr = D3DX11CompileFromMemory(source, size, fn, &m[0], NULL, entry, m_shader.ps.c_str(), 0, 0, NULL, &shader, &error, NULL);
+	hr = s_pD3DCompile(source, size, fn, &m[0], s_old_d3d_compiler_dll ? nullptr : include, entry, m_shader.ps.c_str(), 0, 0, &shader, &error);
 
 	if(error)
 	{
@@ -1451,17 +1451,17 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 	}
 }
 
-void GSDevice11::CompileShader(const char* source, size_t size, const char *fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11ComputeShader** cs)
+void GSDevice11::CompileShader(const char* source, size_t size, const char *fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11ComputeShader** cs)
 {
 	HRESULT hr;
 
-	vector<D3D11_SHADER_MACRO> m;
+	vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
-	CComPtr<ID3D11Blob> shader, error;
+	CComPtr<ID3DBlob> shader, error;
 
-	hr = D3DX11CompileFromMemory(source, size, fn, &m[0], NULL, entry, m_shader.cs.c_str(), 0, 0, NULL, &shader, &error, NULL);
+	hr = s_pD3DCompile(source, size, fn, &m[0], s_old_d3d_compiler_dll ? nullptr : include, entry, m_shader.cs.c_str(), 0, 0, &shader, &error);
 
 	if(error)
 	{
@@ -1480,4 +1480,3 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char *fn, 
 		throw GSDXRecoverableError();
 	}
 }
-

--- a/plugins/GSdx/GSDevice11.h
+++ b/plugins/GSdx/GSDevice11.h
@@ -227,10 +227,10 @@ public:
 	operator ID3D11Device*() {return m_dev;}
 	operator ID3D11DeviceContext*() {return m_ctx;}
 
-	void CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11VertexShader** vs, D3D11_INPUT_ELEMENT_DESC* layout, int count, ID3D11InputLayout** il);
-	void CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11GeometryShader** gs);
-	void CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11GeometryShader** gs, D3D11_SO_DECLARATION_ENTRY* layout, int count);
-	void CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11PixelShader** ps);
-	void CompileShader(const char* source, size_t size, const char* fn, const char* entry, D3D11_SHADER_MACRO* macro, ID3D11ComputeShader** cs);
+	void CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11VertexShader** vs, D3D11_INPUT_ELEMENT_DESC* layout, int count, ID3D11InputLayout** il);
+	void CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11GeometryShader** gs);
+	void CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11GeometryShader** gs, D3D11_SO_DECLARATION_ENTRY* layout, int count);
+	void CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11PixelShader** ps);
+	void CompileShader(const char* source, size_t size, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3D11ComputeShader** cs);
 };
 

--- a/plugins/GSdx/GSDevice9.h
+++ b/plugins/GSdx/GSDevice9.h
@@ -237,8 +237,8 @@ public:
 	IDirect3DDevice9* operator->() {return m_dev;}
 	operator IDirect3DDevice9*() {return m_dev;}
 
-	void CompileShader(const char *source, size_t size, const string& entry, const D3DXMACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il);
-	void CompileShader(const char *source, size_t size, const string& entry, const D3DXMACRO* macro, IDirect3DPixelShader9** ps);
+	void CompileShader(const char *source, size_t size, const char *filename, const string& entry, const D3D_SHADER_MACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il);
+	void CompileShader(const char *source, size_t size, const char *filename, const string& entry, const D3D_SHADER_MACRO* macro, IDirect3DPixelShader9** ps);
 
 	void SetupVS(VSSelector sel, const VSConstantBuffer* cb);
 	void SetupGS(GSSelector sel) {}

--- a/plugins/GSdx/GSDeviceDX.h
+++ b/plugins/GSdx/GSDeviceDX.h
@@ -278,6 +278,12 @@ protected:
 	uint32 m_msaa;
 	DXGI_SAMPLE_DESC m_msaa_desc;
 
+	static HMODULE s_d3d_compiler_dll;
+	static decltype(&D3DCompile) s_pD3DCompile;
+	// Older version doesn't support D3D_COMPILE_STANDARD_FILE_INCLUDE, which
+	// could be useful for external shaders.
+	static bool s_old_d3d_compiler_dll;
+
 	GSTexture* FetchSurface(int type, int w, int h, bool msaa, int format);
 
 public:
@@ -296,6 +302,9 @@ public:
 
 	virtual bool HasStencil() = 0;
 	virtual bool HasDepth32() = 0;
+
+	static bool LoadD3DCompiler();
+	static void FreeD3DCompiler();
 
 	template<class T> void PrepareShaderMacro(vector<T>& dst, const T* src)
 	{

--- a/plugins/GSdx/GSRendererCS.cpp
+++ b/plugins/GSdx/GSRendererCS.cpp
@@ -288,7 +288,7 @@ bool GSRendererCS::CreateDevice(GSDevice* dev_unk)
 
 	// PS
 
-	D3D11_SHADER_MACRO macro[] =
+	D3D_SHADER_MACRO macro[] =
 	{
 		{NULL, NULL},
 	};
@@ -297,7 +297,7 @@ bool GSRendererCS::CreateDevice(GSDevice* dev_unk)
 	{
 		vector<unsigned char> shader;
 		theApp.LoadResource(IDR_CS_FX, shader);
-		dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", "ps_main0", macro, &m_ps0);
+		dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", nullptr, "ps_main0", macro, &m_ps0);
 	}
 	catch (GSDXRecoverableError)
 	{
@@ -514,7 +514,7 @@ void GSRendererCS::Draw()
 			str[0] = format("%d", vs_sel.tme);
 			str[1] = format("%d", vs_sel.fst);
 
-			D3D11_SHADER_MACRO macro[] =
+			D3D_SHADER_MACRO macro[] =
 			{
 				{"VS_TME", str[0].c_str()},
 				{"VS_FST", str[1].c_str()},
@@ -534,7 +534,7 @@ void GSRendererCS::Draw()
 
 			vector<unsigned char> shader;
 			theApp.LoadResource(IDR_CS_FX, shader);
-			dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", "vs_main", macro, &vs.vs, layout, countof(layout), &vs.il);
+			dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", nullptr, "vs_main", macro, &vs.vs, layout, countof(layout), &vs.il);
 
 			m_vs[vs_sel] = vs;
 		}
@@ -571,7 +571,7 @@ void GSRendererCS::Draw()
 			str[0] = format("%d", gs_sel.iip);
 			str[1] = format("%d", j == 0 ? gs_sel.prim : GS_SPRITE_CLASS);
 
-			D3D11_SHADER_MACRO macro[] =
+			D3D_SHADER_MACRO macro[] =
 			{
 				{"GS_IIP", str[0].c_str()},
 				{"GS_PRIM", str[1].c_str()},
@@ -580,7 +580,7 @@ void GSRendererCS::Draw()
 
 			vector<unsigned char> shader;
 			theApp.LoadResource(IDR_CS_FX, shader);
-			dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", "gs_main", macro, &gs[j]);
+			dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", nullptr, "gs_main", macro, &gs[j]);
 
 			m_gs[gs_sel] = gs[j];
 		}
@@ -611,7 +611,7 @@ void GSRendererCS::Draw()
 		str[1] = format("%d", context->FRAME.PSM);
 		str[2] = format("%d", context->ZBUF.PSM);
 
-		D3D11_SHADER_MACRO macro[] =
+		D3D_SHADER_MACRO macro[] =
 		{
 			{"PS_BATCH_SIZE", str[0].c_str()},
 			{"PS_FPSM", str[1].c_str()},
@@ -621,7 +621,7 @@ void GSRendererCS::Draw()
 
 		vector<unsigned char> shader;
 		theApp.LoadResource(IDR_CS_FX, shader);
-		dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", "ps_main1", macro, &ps[1]);
+		dev->CompileShader((const char *)shader.data(), shader.size(), "cs.fx", nullptr, "ps_main1", macro, &ps[1]);
 
 		m_ps1[ps_sel] = ps[1];
 	}

--- a/plugins/GSdx/GSTextureFX11.cpp
+++ b/plugins/GSdx/GSTextureFX11.cpp
@@ -96,7 +96,7 @@ void GSDevice11::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 		str[2] = format("%d", sel.fst);
 		str[3] = format("%d", sel.rtcopy);
 
-		D3D11_SHADER_MACRO macro[] =
+		D3D_SHADER_MACRO macro[] =
 		{
 			{"VS_BPPZ", str[0].c_str()},
 			{"VS_TME", str[1].c_str()},
@@ -120,7 +120,7 @@ void GSDevice11::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 
 		vector<unsigned char> shader;
 		theApp.LoadResource(IDR_TFX_FX, shader);
-		CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", "vs_main", macro, &vs.vs, layout, countof(layout), &vs.il);
+		CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", nullptr, "vs_main", macro, &vs.vs, layout, countof(layout), &vs.il);
 
 		m_vs[sel] = vs;
 
@@ -158,7 +158,7 @@ void GSDevice11::SetupGS(GSSelector sel)
 			str[0] = format("%d", sel.iip);
 			str[1] = format("%d", sel.prim);
 
-			D3D11_SHADER_MACRO macro[] =
+			D3D_SHADER_MACRO macro[] =
 			{
 				{"GS_IIP", str[0].c_str()},
 				{"GS_PRIM", str[1].c_str()},
@@ -167,7 +167,7 @@ void GSDevice11::SetupGS(GSSelector sel)
 
 			vector<unsigned char> shader;
 			theApp.LoadResource(IDR_TFX_FX, shader);
-			CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", "gs_main", macro, &gs);
+			CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", nullptr, "gs_main", macro, &gs);
 
 			m_gs[sel] = gs;
 		}
@@ -205,7 +205,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[18] = format("%d", sel.shuffle);
 		str[19] = format("%d", sel.read_ba);
 
-		D3D11_SHADER_MACRO macro[] =
+		D3D_SHADER_MACRO macro[] =
 		{
 			{"PS_FST", str[0].c_str()},
 			{"PS_WMS", str[1].c_str()},
@@ -234,7 +234,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 		vector<unsigned char> shader;
 		theApp.LoadResource(IDR_TFX_FX, shader);
-		CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", "ps_main", macro, &ps);
+		CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", nullptr, "ps_main", macro, &ps);
 
 		m_ps[sel] = ps;
 

--- a/plugins/GSdx/GSTextureFX9.cpp
+++ b/plugins/GSdx/GSTextureFX9.cpp
@@ -75,7 +75,7 @@ void GSDevice9::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 		str[3] = format("%d", sel.logz);
 		str[4] = format("%d", sel.rtcopy);
 
-		D3DXMACRO macro[] =
+		D3D_SHADER_MACRO macro[] =
 		{
 			{"VS_BPPZ", str[0].c_str()},
 			{"VS_TME", str[1].c_str()},
@@ -98,7 +98,7 @@ void GSDevice9::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 
 		vector<unsigned char> shader;
 		theApp.LoadResource(IDR_TFX_FX, shader);
-		CompileShader((const char *)shader.data(), shader.size(), "vs_main", macro, &vs.vs, layout, countof(layout), &vs.il);
+		CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", "vs_main", macro, &vs.vs, layout, countof(layout), &vs.il);
 
 		m_vs[sel] = vs;
 
@@ -157,7 +157,7 @@ void GSDevice9::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSel
 		str[15] = format("%d", sel.tcoffsethack);
 		str[16] = format("%d", sel.point_sampler);
 
-		D3DXMACRO macro[] =
+		D3D_SHADER_MACRO macro[] =
 		{
 			{"PS_FST", str[0].c_str()},
 			{"PS_WMS", str[1].c_str()},
@@ -183,7 +183,7 @@ void GSDevice9::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSel
 
 		vector<unsigned char> shader;
 		theApp.LoadResource(IDR_TFX_FX, shader);
-		CompileShader((const char *)shader.data(), shader.size(), "ps_main", macro, &ps);
+		CompileShader((const char *)shader.data(), shader.size(), "tfx.fx", "ps_main", macro, &ps);
 
 		m_ps[sel] = ps;
 

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -37,6 +37,7 @@
 #include <commctrl.h>
 #include <commdlg.h>
 #include <shellapi.h>
+#include <d3dcompiler.h>
 #include <d3d11.h>
 #include <d3dx11.h>
 #include <d3d9.h>

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -40,7 +40,6 @@
 #include <d3dcompiler.h>
 #include <d3d11.h>
 #include <d3d9.h>
-#include <d3dx9.h>
 #include <comutil.h>
 #include <atlcomcli.h>
 

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -39,15 +39,12 @@
 #include <shellapi.h>
 #include <d3dcompiler.h>
 #include <d3d11.h>
-#include <d3dx11.h>
 #include <d3d9.h>
 #include <d3dx9.h>
 #include <comutil.h>
 #include <atlcomcli.h>
 
 #define D3DCOLORWRITEENABLE_RGBA (D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN | D3DCOLORWRITEENABLE_BLUE | D3DCOLORWRITEENABLE_ALPHA)
-#define D3D11_SHADER_MACRO D3D10_SHADER_MACRO
-#define ID3D11Blob ID3D10Blob
 
 #endif
 

--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -4,7 +4,6 @@
     <_ProjectFileVersion>10.0.30128.1</_ProjectFileVersion>
     <OutDir>$(SolutionDir)bin\$(PcsxSubsection)\</OutDir>
     <IntDir>$(PlatformName)\$(Configuration)\</IntDir>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -18,8 +18,8 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>d3d11.lib;d3d10_1.lib;d3d9.lib;d3dx9.lib;dxgi.lib;dxguid.lib;winmm.lib;strmiids.lib;xinput.lib;opengl32.lib;opencl.lib;comsuppw.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>d3d9.dll;d3dx9_43.dll;d3d11.dll;dxgi.dll;opengl32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>d3d11.lib;d3d10_1.lib;d3d9.lib;dxgi.lib;dxguid.lib;winmm.lib;strmiids.lib;opengl32.lib;opencl.lib;comsuppw.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>d3d9.dll;d3d11.dll;dxgi.dll;opengl32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -4,6 +4,7 @@
     <_ProjectFileVersion>10.0.30128.1</_ProjectFileVersion>
     <OutDir>$(SolutionDir)bin\$(PcsxSubsection)\</OutDir>
     <IntDir>$(PlatformName)\$(Configuration)\</IntDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -14,12 +14,12 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4456;4458;4996;4995;4324;4100;4101;4201;4556;4127;4512;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(DXSDK_DIR)include;$(VTUNE_AMPLIFIER_XE_2015_DIR)include;$(SolutionDir)3rdparty;$(SolutionDir)3rdparty\libpng;$(SolutionDir)3rdparty\opencl;$(SolutionDir)3rdparty\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VTUNE_AMPLIFIER_XE_2015_DIR)include;$(SolutionDir)3rdparty;$(SolutionDir)3rdparty\libpng;$(SolutionDir)3rdparty\opencl;$(SolutionDir)3rdparty\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>d3d11.lib;d3dx11.lib;d3d10_1.lib;d3dx10.lib;d3d9.lib;d3dx9.lib;dxgi.lib;dxguid.lib;winmm.lib;strmiids.lib;xinput.lib;opengl32.lib;opencl.lib;comsuppw.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>d3d9.dll;d3dx9_43.dll;d3d11.dll;d3dx11_43.dll;dxgi.dll;opengl32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>d3d11.lib;d3d10_1.lib;d3d9.lib;d3dx9.lib;dxgi.lib;dxguid.lib;winmm.lib;strmiids.lib;xinput.lib;opengl32.lib;opencl.lib;comsuppw.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>d3d9.dll;d3dx9_43.dll;d3d11.dll;dxgi.dll;opengl32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>

--- a/plugins/GSdx/vsprops/x64.props
+++ b/plugins/GSdx/vsprops/x64.props
@@ -2,10 +2,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(DXSDK_DIR)Lib\x64;</LibraryPath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories>$(DXSDK_DIR)Lib\x64;$(ProjectDir)vtune\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)vtune\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/plugins/GSdx/vsprops/x64.props
+++ b/plugins/GSdx/vsprops/x64.props
@@ -1,17 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(DXSDK_DIR)Lib\x64;</LibraryPath>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(ProjectDir)vtune\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <ClCompile>
-      <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup />
 </Project>

--- a/plugins/GSdx/vsprops/x86.props
+++ b/plugins/GSdx/vsprops/x86.props
@@ -1,18 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(DXSDK_DIR)Lib\x86;</LibraryPath>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(ProjectDir)vtune\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <ClCompile />
-    <ClCompile>
-      <PreprocessorDefinitions>_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup />
 </Project>

--- a/plugins/GSdx/vsprops/x86.props
+++ b/plugins/GSdx/vsprops/x86.props
@@ -2,10 +2,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(DXSDK_DIR)Lib\x86;</LibraryPath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories>$(DXSDK_DIR)Lib\x86;$(ProjectDir)vtune\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)vtune\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile />
     <ClCompile>


### PR DESCRIPTION
Changes:
 * Removes DirectX SDK dependency from GSdx by using D3DCompile to compile the shaders instead of the D3DX equivalents
 * Bundles d3dcompiler_47.dll with PCSX2 - this is only of use to Windows Vista and 7 (EDIT: and 8) users - Windows 8.1+ users can delete the file to use the version that comes with their OS.