### PR TITLE
GameDB: Nerversoft Games Engine Fix & Burnout 2 NTSC Fix to PAL Release

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -40405,6 +40405,7 @@ Serial = SLUS-21444
 Name   = Tony Hawk's Project 8
 Region = NTSC-U
 Compat = 5
+vuRoundMode = 0
 ---------------------------------------------
 Serial = SLUS-21445
 Name   = Ar tonelico: Melody of Elemia

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -10110,6 +10110,11 @@ Name   = Disney's Extreme Skate Adventure
 Region = PAL-E
 vuRoundMode = 0
 ---------------------------------------------
+Serial = SLES-51721
+Name   = Disney's Extreme Skate Adventure
+Region = PAL-E
+vuRoundMode = 0
+---------------------------------------------
 Serial = SLES-51723
 Name   = Hobbit, The
 Region = PAL-M5

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -8731,6 +8731,7 @@ Serial = SLES-51044
 Name   = Burnout 2 - Point of Impact
 Region = PAL-M5
 Compat = 5
+vuRoundMode = 1 //bright lights in cars
 ---------------------------------------------
 Serial = SLES-51045
 Name   = Legends of Wrestling II

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -41065,6 +41065,7 @@ Serial = SLUS-21616
 Name   = Tony Hawk's Proving Ground
 Region = NTSC-U
 Compat = 5
+vuRoundMode = 0
 ---------------------------------------------
 Serial = SLUS-21618
 Name   = Plan, The

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -40465,6 +40465,7 @@ Serial = SLUS-21456
 Name   = Tony Hawk's Downhill Jam
 Region = NTSC-U
 Compat = 5
+vuRoundMode = 0
 ---------------------------------------------
 Serial = SLUS-21457
 Name   = World Championship Paintball

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -14143,10 +14143,12 @@ Serial = SLES-53534
 Name   = Tony Hawk's American Wasteland
 Region = PAL-E
 Compat = 5
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-53535
 Name   = Tony Hawk's American Wasteland
 Region = PAL-M4
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-53536
 Name   = London Racer - Police Madness


### PR DESCRIPTION
Disney Extreme Skate Adventure (SLES-51721) release is not fixed by default on GameDB.
Same vuRoundMode from SLES-51720 used in order to fix the issue.