### PR TITLE
GameDB: Disney's Extreme Skate Adventure PAL Graphics Fix (SLES-51721)

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -10110,6 +10110,12 @@ Name   = Disney's Extreme Skate Adventure
 Region = PAL-E
 vuRoundMode = 0
 ---------------------------------------------
+---------------------------------------------
+Serial = SLES-51721
+Name   = Disney's Extreme Skate Adventure
+Region = PAL-E
+vuRoundMode = 0
+---------------------------------------------
 Serial = SLES-51723
 Name   = Hobbit, The
 Region = PAL-M5


### PR DESCRIPTION
VU0/1 set to "Nearest" by default to the SLES-51721 release, applying the same fix already used for the SLES-517210 release from GameDB.