### PR TITLE
GameDB: Tony Hawk's Proving Ground PAL Crash & Graphics Fix

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -10113,7 +10113,7 @@ vuRoundMode = 0
 ---------------------------------------------
 Serial = SLES-51721
 Name   = Disney's Extreme Skate Adventure
-Region = PAL-E
+Region = PAL-M4
 vuRoundMode = 0
 ---------------------------------------------
 Serial = SLES-51723

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -15966,6 +15966,13 @@ Serial = SLES-54389
 Name   = Tony Hawk's Project 8
 Region = PAL-E
 Compat = 5
+vuRoundMode = 0		//Crashes without.
+---------------------------------------------
+Serial = SLES-54390
+Name   = Tony Hawk's Project 8
+Region = PAL-M4
+Compat = 5
+vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-54393
 Name   = Pippa Funnell - Take the Reins

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16831,10 +16831,12 @@ Serial = SLES-54963
 Name   = Tony Hawks - Proving Ground
 Region = PAL-E
 Compat = 5
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-54964
 Name   = Tony Hawk's Proving Ground
 Region = PAL-M4
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-54975
 Name   = George Of The Jungle

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -22550,6 +22550,7 @@ Region = NTSC-J
 Serial = SLPM-65419
 Name   = Tony Hawk's Pro Skater 2003
 Region = NTSC-J
+vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLPM-65420
 Name   = Dabitsuku 3 - Let's Become a Derby Owner


### PR DESCRIPTION
Set VU0/1 to Nearest by default in order to fix the graphics and avoid a PCSX2 crash (like other Tony Hawk's episodes made by Neversoft)