### PR TITLE
GameDB: Tony Hawk's Games Crash & Graphics Fix + Jak X PAL Black Screen Fix

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -2168,12 +2168,12 @@ Compat = 5
 Serial = SCES-53286
 Name   = Jak X - Combat Racing
 Region = PAL-M7
+// reads Ratchet Gladiator data
+MemCardFilter = SCES-53286/SCES-53285
 [patches = df659e77]
 	comment=patched by Ge-Force
 	patch=1,EE,00275CF7,word,00000000
 [/patches]
-// reads Ratchet Gladiator data
-MemCardFilter = SCES-53286/SCES-53285
 ---------------------------------------------
 Serial = SCES-53300
 Name   = SOCOM 3 - U.S. Navy SEALs

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -5498,6 +5498,10 @@ Name   = Jak X - Combat Racing
 Region = NTSC-U
 Compat = 5
 MemCardFilter = SCUS-97429/SCUS-97465
+[patches = 3091e6fb]
+	comment=patched by Ge-Force
+	patch=1,EE,00275C67,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SCUS-97430
 Name   = Hot Shots Golf FORE! [Regular Demo]

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -10381,9 +10381,10 @@ Region = PAL-F
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51852
-Name   = Thug MOTX [Demo]
+Name   = Tony Hawk's Underground
 Region = PAL-G
 Compat = 5
+vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLES-51853
 Name   = Tony Hawk's Underground

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -2170,7 +2170,6 @@ Name   = Jak X - Combat Racing
 Region = PAL-M7
 [patches = df659e77]
 	comment=patched by Ge-Force
-	//fix delay slot violation
 	patch=1,EE,00275CF7,word,00000000
 [/patches]
 // reads Ratchet Gladiator data

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -2168,6 +2168,11 @@ Compat = 5
 Serial = SCES-53286
 Name   = Jak X - Combat Racing
 Region = PAL-M7
+[patches = df659e77]
+	comment=patched by Ge-Force
+	//fix delay slot violation
+	patch=1,EE,00275CF7,word,00000000
+[/patches]
 // reads Ratchet Gladiator data
 MemCardFilter = SCES-53286/SCES-53285
 ---------------------------------------------

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -39242,6 +39242,7 @@ Serial = SLUS-21208
 Name   = Tony Hawk's American Wasteland
 Region = NTSC-U
 Compat = 5
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLUS-21209
 Name   = Urban Reign

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -8953,6 +8953,11 @@ Region = PAL-E
 Compat = 5
 vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
+Serial = SLES-51131
+Name   = Tony Hawk's Pro Skater 4
+Region = PAL-F
+vuRoundMode = 0		//Crashes without.
+---------------------------------------------
 Serial = SLES-51132
 Name   = Tony Hawk's Pro Skater 4
 Region = PAL-G

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -4374,11 +4374,6 @@ Serial = SCPS-56015
 Name   = Ninja Assault
 Region = NTSC-J
 ---------------------------------------------
-Serial = SCUS-21295
-Name   = Tony Hawk's American Wasteland Collector's Edition
-Region = NTSC-U
-Compat = 5
----------------------------------------------
 Serial = SCUS-21494
 Name   = Need for Speed Carbon Collector's Edition
 Region = NTSC-U
@@ -39686,6 +39681,8 @@ Region = NTSC-U
 Serial = SLUS-21295
 Name   = Tony Hawk's American Wasteland [Collector's Edition]
 Region = NTSC-U
+Compat = 5
+vuRoundMode = 0		//Crashes without.
 ---------------------------------------------
 Serial = SLUS-21296
 Name   = Dance Factory

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16512,6 +16512,16 @@ Name   = Shadow Hearts - From the New World
 Region = PAL-E
 Compat = 5
 ---------------------------------------------
+Serial = SLES-54714
+Name   = Tony Hawk's Downhill Jam
+Region = PAL-E
+vuRoundMode = 0 //Crashes without.
+---------------------------------------------
+Serial = SLES-54715
+Name   = Tony Hawk's Downhill Jam
+Region = PAL-M4
+vuRoundMode = 0 //Crashes without.
+---------------------------------------------
 Serial = SLES-54717
 Name   = Power Volleyball
 Region = PAL-E


### PR DESCRIPTION
Set VU0/1 to Nearest by default in order to fix the graphics and avoid a PCSX2 crash (like others Tony Hawk's episodes using the Neversoft engine)