### PR TITLE
Move folder memcard filter management into the actual folder memcard class to fix #1179 and similar.

### DIFF
--- a/common/include/PluginCallbacks.h
+++ b/common/include/PluginCallbacks.h
@@ -1109,7 +1109,7 @@ typedef struct _PS2E_ComponentAPI_Mcd
 	// Used by the FolderMemoryCard to find a good time to flush written data to the host file system.
 	void (PS2E_CALLBACK* McdNextFrame)( PS2E_THISPTR thisptr, uint port, uint slot );
 
-	void (PS2E_CALLBACK* McdReIndex)( PS2E_THISPTR thisptr, uint port, uint slot, const wxString& filter );
+	bool (PS2E_CALLBACK* McdReIndex)( PS2E_THISPTR thisptr, uint port, uint slot, const wxString& filter );
 
 	void* reserved[6];
 

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -70,8 +70,8 @@ void SysPluginBindings::McdNextFrame( uint port, uint slot ) {
 	Mcd->McdNextFrame( (PS2E_THISPTR) Mcd, port, slot );
 }
 
-void SysPluginBindings::McdReIndex( uint port, uint slot, const wxString& filter ) {
-	Mcd->McdReIndex( (PS2E_THISPTR) Mcd, port, slot, filter );
+bool SysPluginBindings::McdReIndex( uint port, uint slot, const wxString& filter ) {
+	return Mcd->McdReIndex( (PS2E_THISPTR) Mcd, port, slot, filter );
 }
 
 // ----------------------------------------------------------------------------

--- a/pcsx2/Plugins.h
+++ b/pcsx2/Plugins.h
@@ -242,7 +242,7 @@ public:
 	void McdEraseBlock( uint port, uint slot, u32 adr );
 	u64  McdGetCRC( uint port, uint slot );
 	void McdNextFrame( uint port, uint slot );
-	void McdReIndex( uint port, uint slot, const wxString& filter );
+	bool McdReIndex( uint port, uint slot, const wxString& filter );
 
 	friend class SysCorePlugins;
 };

--- a/pcsx2/Sio.h
+++ b/pcsx2/Sio.h
@@ -87,8 +87,8 @@ struct _mcd
 		SysPlugins.McdNextFrame( port, slot );
 	}
 
-	void ReIndex(const wxString& filter = L"") {
-		SysPlugins.McdReIndex( port, slot, filter );
+	bool ReIndex(const wxString& filter = L"") {
+		return SysPlugins.McdReIndex( port, slot, filter );
 	}
 };
 

--- a/pcsx2/gui/MemoryCardFile.cpp
+++ b/pcsx2/gui/MemoryCardFile.cpp
@@ -562,17 +562,17 @@ static void PS2E_CALLBACK FileMcd_NextFrame( PS2E_THISPTR thisptr, uint port, ui
 	}
 }
 
-static void PS2E_CALLBACK FileMcd_ReIndex( PS2E_THISPTR thisptr, uint port, uint slot, const wxString& filter ) {
+static bool PS2E_CALLBACK FileMcd_ReIndex( PS2E_THISPTR thisptr, uint port, uint slot, const wxString& filter ) {
 	const uint combinedSlot = FileMcd_ConvertToSlot( port, slot );
 	switch ( g_Conf->Mcd[combinedSlot].Type ) {
 	//case MemoryCardType::MemoryCard_File:
-	//	thisptr->impl.ReIndex( combinedSlot, filter );
+	//	return thisptr->impl.ReIndex( combinedSlot, filter );
 	//	break;
 	case MemoryCardType::MemoryCard_Folder:
-		thisptr->implFolder.ReIndex( combinedSlot, g_Conf->EmuOptions.McdFolderAutoManage, filter );
+		return thisptr->implFolder.ReIndex( combinedSlot, g_Conf->EmuOptions.McdFolderAutoManage, filter );
 		break;
 	default:
-		return;
+		return false;
 	}
 }
 

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -42,11 +42,11 @@ void FolderMemoryCard::InitializeInternalData() {
 	memset( &m_backupBlock2, 0xFF, sizeof( m_backupBlock2 ) );
 	m_cache.clear();
 	m_oldDataCache.clear();
+	m_lastAccessedFile.CloseAll();
 	m_fileMetadataQuickAccess.clear();
 	m_timeLastWritten = 0;
 	m_isEnabled = false;
 	m_framesUntilFlush = 0;
-	m_lastAccessedFile.CloseAll();
 	m_performFileWrites = true;
 }
 

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -32,6 +32,8 @@ FolderMemoryCard::FolderMemoryCard() {
 	m_performFileWrites = false;
 	m_framesUntilFlush = 0;
 	m_timeLastWritten = 0;
+	m_filteringEnabled = false;
+	m_filteringString = L"";
 }
 
 void FolderMemoryCard::InitializeInternalData() {
@@ -48,6 +50,8 @@ void FolderMemoryCard::InitializeInternalData() {
 	m_isEnabled = false;
 	m_framesUntilFlush = 0;
 	m_performFileWrites = true;
+	m_filteringEnabled = false;
+	m_filteringString = L"";
 }
 
 bool FolderMemoryCard::IsFormatted() const {
@@ -94,6 +98,8 @@ void FolderMemoryCard::Open( const wxString& fullPath, const AppConfig::McdOptio
 	if ( disabled ) return;
 
 	m_isEnabled = true;
+	m_filteringEnabled = enableFiltering;
+	m_filteringString = filter;
 	LoadMemoryCardData( sizeInClusters, enableFiltering, filter );
 
 	SetTimeLastWrittenToNow();
@@ -111,6 +117,18 @@ void FolderMemoryCard::Close( bool flush ) {
 	m_oldDataCache.clear();
 	m_lastAccessedFile.CloseAll();
 	m_fileMetadataQuickAccess.clear();
+}
+
+bool FolderMemoryCard::ReIndex( bool enableFiltering, const wxString& filter ) {
+	if ( !m_isEnabled ) { return false; }
+
+	if ( m_filteringEnabled != enableFiltering || m_filteringString != filter ) {
+		Close();
+		Open( enableFiltering, filter );
+		return true;
+	}
+
+	return false;
 }
 
 void FolderMemoryCard::LoadMemoryCardData( const u32 sizeInClusters, const bool enableFiltering, const wxString& filter ) {
@@ -1648,11 +1666,13 @@ void FolderMemoryCardAggregator::NextFrame( uint slot ) {
 	m_cards[slot].NextFrame();
 }
 
-void FolderMemoryCardAggregator::ReIndex( uint slot, const bool enableFiltering, const wxString& filter ) {
-	m_cards[slot].Close();
-	m_cards[slot].Open( enableFiltering, filter );
+bool FolderMemoryCardAggregator::ReIndex( uint slot, const bool enableFiltering, const wxString& filter ) {
+	if ( m_cards[slot].ReIndex( enableFiltering, filter ) ) {
+		SetFiltering( enableFiltering );
+		m_lastKnownFilter = filter;
+		return true;
+	}
 
-	SetFiltering( enableFiltering );
-	m_lastKnownFilter = filter;
+	return false;
 }
 

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -327,6 +327,10 @@ protected:
 	// if set to false, nothing is actually written to the file system while flushing, and data is discarded instead
 	bool m_performFileWrites;
 
+	// currently active filter settings
+	bool m_filteringEnabled;
+	wxString m_filteringString;
+
 public:
 	FolderMemoryCard();
 	virtual ~FolderMemoryCard() throw() {}
@@ -340,6 +344,11 @@ public:
 	void Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter, bool simulateFileWrites = false );
 	// Close the memory card and flush changes to the file system. Set flush to false to not store changes.
 	void Close( bool flush = true );
+
+	// Closes and reopens card with given filter options if they differ from the current ones (returns true),
+	// or does nothing if they match already (returns false).
+	// Does nothing and returns false when called on a closed memory card.
+	bool ReIndex( bool enableFiltering, const wxString& filter );
 
 	s32  IsPresent() const;
 	void GetSizeInfo( PS2E_McdSizeInfo& outways ) const;
@@ -562,5 +571,5 @@ public:
 	s32  EraseBlock( uint slot, u32 adr );
 	u64  GetCRC( uint slot );
 	void NextFrame( uint slot );
-	void ReIndex( uint slot, const bool enableFiltering, const wxString& filter );
+	bool ReIndex( uint slot, const bool enableFiltering, const wxString& filter );
 };


### PR DESCRIPTION
By storing it in the class it can't go out of sync with what is assumed to be the current filter.

The memory card temporarily ejects when plugins are changed still, but the filter gets set correctly on reload. Not ejecting it at all could get complicated, since memory cards are implemented as a plugin (even though there's no way to switch), so the emulator explicitly closes and reopens them when plugins change.

I also found a memory access of already free'd memory and fixed it.

As always, didn't do any excessive testing.

Fixes #1179.