### PR TITLE
gsdx ogl: allow to read the depth buffer

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -719,6 +719,14 @@ void GSTextureCache::InvalidateLocalMem(GSOffset* off, const GSVector4i& r)
 	// No depth handling please.
 	if (psm == PSM_PSMZ32 || psm == PSM_PSMZ24 || psm == PSM_PSMZ16 || psm == PSM_PSMZ16S) {
 		GL_INS("ERROR: InvalidateLocalMem depth format isn't supported");
+		if (m_can_convert_depth) {
+			for(auto t : m_dst[DepthStencil]) {
+				if(GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM)) {
+					// Read the full depth buffer for easy testing
+					Read(t, t->m_valid);
+				}
+			}
+		}
 		return;
 	}
 


### PR DESCRIPTION
Unfortunately can't be tested on gs dump

Ought to impact #1276 (Incognito/Eat Sleep Play's games, Nocturne too)

Tests are welcome