### PR TITLE
GSDX: Remove some unnecessary/dubious hacks

### DIFF
--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -212,15 +212,6 @@ bool GSRenderer::Merge(int field)
 		if(!en[i] || !tex[i]) continue;
 
 		GSVector4i r = fr[i];
-
-		// overscan hack
-
-		if(dr[i].height() > 512) // hmm
-		{
-			int y = GetDeviceSize(i).y;
-			r.bottom = r.top + y;
-		}
-
 		GSVector4 scale = GSVector4(tex[i]->GetScale()).xyxy();
 
 		src[i] = GSVector4(r) * scale / GSVector4(tex[i]->GetSize()).xyxy();

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -429,21 +429,9 @@ GSVector2i GSState::GetDeviceSize(int i)
 
 	//Fixme : Just slightly better than the hack above
 	if(m_regs->SMODE2.INT && m_regs->SMODE2.FFMD && h > 1)
-	{
-		if (IsEnabled(0) || IsEnabled(1))
-		{
-			h >>= 1;
-		}
-	}
-
-	//Fixme: These games elude the code above, worked with the old hack
-	else if(m_game.title == CRC::SilentHill2 || m_game.title == CRC::SilentHill3)
-	{
-		h /= 2; 
-	}
+		h >>= 1;
 
 	return GSVector2i(w, h);
-
 }
 
 bool GSState::IsEnabled(int i)

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -44,6 +44,7 @@ GSState::GSState()
 {
 	m_nativeres = theApp.GetConfig("upscale_multiplier",1) == 1;
 	m_mipmap = !!theApp.GetConfig("mipmap", 1);
+	m_NTSC_Saturation = !!theApp.GetConfig("NTSC_Saturation", true);
 
 	s_n     = 0;
 	s_dump  = !!theApp.GetConfig("dump", 0);
@@ -379,11 +380,10 @@ GSVector4i GSState::GetFrameRect(int i)
 	int w = r.width();
 	int h = r.height();
 
-//  NTSC: Saturate higher height values for games which have CRTC width lower than 640.
-//  Some NTSC mode games request higher height values for accurate display size / position when width is 640
-//  Testcases : PS logo (640x512) , Resident Evil:CVX (640x480). potentially more test cases...
-
-	if (Vmode_NTSC && h > 448 && w < 640)
+//  Limit games to standard NTSC resolutions. games with 512X512 (PAL resolution) on NTSC video mode produces black border on the bottom.
+//  512 X 448 is the resolution generally used by NTSC, saturating the height value seems to get rid of the black borders.
+//  Though it's quite a bad hack as it affects binaries which are patched to run on a non-native video mode.
+	if (Vmode_NTSC && h > 448 && w < 640 && m_NTSC_Saturation)
 		h = 448;
 
 	if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD && h > 1)

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -195,12 +195,13 @@ public:
 	GSDrawingContext* m_context;
 	GSPerfMon m_perfmon;
 	uint32 m_crc;
+	CRC::Game m_game;
+	GSDump m_dump;
 	int m_options;
 	int m_frameskip;
 	bool m_crcinited;
 	bool m_framelimit;
-	CRC::Game m_game;
-	GSDump m_dump;
+	bool m_NTSC_Saturation;
 	bool m_nativeres;
 	bool m_mipmap;
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -368,7 +368,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 	{
 		int multiplier = m_renderer->GetUpscaleMultiplier();
 
-		if(multiplier > 1) // it's limited to a maximum of 4 on reading the config
+		if(multiplier > 1)
 		{
 			dst->m_texture->SetScale(GSVector2((float)multiplier, (float)multiplier));
 		}
@@ -378,11 +378,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 
 			int ww = (int)(fr.left + m_renderer->GetDisplayRect().width());
 			int hh = (int)(fr.top + m_renderer->GetDisplayRect().height());
-
-			if(hh <= m_renderer->GetDeviceSize().y / 2)
-			{
-				hh *= 2;
-			}
 
 			// Gregory: I'm sure this sillyness is related to the usage of a 32bits
 			// buffer as a 16 bits format. In this case the height of the buffer is
@@ -395,7 +390,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 				hh = 512;
 			}
 
-			if(ww > 0 && hh > 0)
+			if(ww && hh)
 			{
 				dst->m_texture->SetScale(GSVector2((float)w / ww, (float)h / hh));
 			}


### PR DESCRIPTION
**Summary of changes:**

* Add an INI option to disable NTSC height saturation hack.
* Remove some dubious/unnecessary hacks on GSDX.


@Ryudo300 @FlatOutPS2 - could you check whether Silent Hill 2/3 are fine with the change ? (I only did some brief testing). build download link will be generated by Appveyor within some time.

**Build download link:** [here](https://ci.appveyor.com/api/buildjobs/tjlr2r2hdr1u4qew/artifacts/pcsx2-v1.5.0-dev-556-g9a366da-master-808-vs2015-Win32-AppVeyor.7z)