### PR TITLE
gsdx: Clean up some warning under windows

### DIFF
--- a/plugins/GSdx/GPUState.h
+++ b/plugins/GSdx/GPUState.h
@@ -87,12 +87,14 @@ class GPUState : public GSAlignedClass<32>
 protected:
 
 	int s_n;
+	bool dump_enable = false;
 
 	void Dump(const string& s, uint32 TP, const GSVector4i& r, int inc = true)
 	{
 		//if(m_perfmon.GetFrame() < 1000)
 		//if((m_env.TWIN.u32 & 0xfffff) == 0)
 		//if(!m_env.STATUS.ME && !m_env.STATUS.MD)
+		if(!dump_enable)
 			return;
 
 		if(inc) s_n++;

--- a/plugins/GSdx/GSClut.cpp
+++ b/plugins/GSdx/GSClut.cpp
@@ -331,7 +331,7 @@ void GSClut::Read32(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA)
 	}
 }
 
-void GSClut::GetAlphaMinMax32(int& amin, int& amax)
+void GSClut::GetAlphaMinMax32(int& amin_out, int& amax_out)
 {
 	// call only after Read32
 
@@ -394,8 +394,8 @@ void GSClut::GetAlphaMinMax32(int& amin, int& amax)
 		}
 	}
 
-	amin = m_read.amin;
-	amax = m_read.amax;
+	amin_out = m_read.amin;
+	amax_out = m_read.amax;
 }
 
 //

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -622,7 +622,7 @@ void GSDevice11::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r)
 		return;
 	}
 
-	D3D11_BOX box = {r.left, r.top, 0, r.right, r.bottom, 1};
+	D3D11_BOX box = {(UINT)r.left, (UINT)r.top, 0U, (UINT)r.right, (UINT)r.bottom, 1U};
 
 	m_ctx->CopySubresourceRegion(*(GSTexture11*)dTex, 0, 0, 0, 0, *(GSTexture11*)sTex, 0, &box);
 }
@@ -793,8 +793,8 @@ void GSDevice11::DoExternalFX(GSTexture* sTex, GSTexture* dTex)
 
 	InitExternalFX();
 
-	cb.xyFrame = GSVector2(s.x, s.y);
-	cb.rcpFrame = GSVector4(1.0f / s.x, 1.0f / s.y, 0.0f, 0.0f);
+	cb.xyFrame = GSVector2((float)s.x, (float)s.y);
+	cb.rcpFrame = GSVector4(1.0f / (float)s.x, 1.0f / (float)s.y, 0.0f, 0.0f);
 	cb.rcpFrameOpt = GSVector4::zero();
 
 	m_ctx->UpdateSubresource(m_shaderfx.cb, 0, NULL, &cb, 0, 0);

--- a/plugins/GSdx/GSDevice9.cpp
+++ b/plugins/GSdx/GSDevice9.cpp
@@ -977,7 +977,7 @@ void GSDevice9::DoExternalFX(GSTexture* sTex, GSTexture* dTex)
 	
 	InitExternalFX();
 
-	cb.xyFrame = GSVector2(s.x, s.y);
+	cb.xyFrame = GSVector2((float)s.x, (float)s.y);
 	cb.rcpFrame = GSVector4(1.0f / s.x, 1.0f / s.y, 0.0f, 0.0f);
 	cb.rcpFrameOpt = GSVector4::zero();
 

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -72,7 +72,7 @@ GSDeviceOGL::GSDeviceOGL()
 	m_debug_gl_file = fopen("GSdx_opengl_debug.txt","w");
 	#endif
 
-	m_debug_gl_call =  theApp.GetConfig("debug_opengl", 0);
+	m_debug_gl_call =  !!theApp.GetConfig("debug_opengl", 0);
 }
 
 GSDeviceOGL::~GSDeviceOGL()
@@ -1039,7 +1039,7 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	else
 		OMSetRenderTargets(dTex, NULL);
 
-	OMSetBlendState(bs);
+	OMSetBlendState((uint8)bs);
 	OMSetColorMaskState();
 
 	// ************************************
@@ -1219,7 +1219,7 @@ void GSDeviceOGL::DoExternalFX(GSTexture* sTex, GSTexture* dTex)
 
 	ExternalFXConstantBuffer cb;
 
-	cb.xyFrame = GSVector2(s.x, s.y);
+	cb.xyFrame = GSVector2((float)s.x, (float)s.y);
 	cb.rcpFrame = GSVector4(1.0f / s.x, 1.0f / s.y, 0.0f, 0.0f);
 	cb.rcpFrameOpt = GSVector4::zero();
 

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -41,7 +41,7 @@
 		for(int x = _r.left; x < _r.right; x += w >> 3) \
 		{ \
 			const uint8* src = BlockPtr(_base + off->block.col[x]); \
-			uint8* dst = &_dst[x * bpp]; \
+			uint8* read_dst = &_dst[x * bpp]; \
 
 #define FOREACH_BLOCK_END }}
 
@@ -1612,7 +1612,7 @@ void GSLocalMemory::ReadTexture32(const GSOffset* RESTRICT off, const GSVector4i
 {
 	FOREACH_BLOCK_START(r, 8, 8, 32)
 	{
-		GSBlock::ReadBlock32(src, dst, dstpitch);
+		GSBlock::ReadBlock32(src, read_dst, dstpitch);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1623,7 +1623,7 @@ void GSLocalMemory::ReadTexture24(const GSOffset* RESTRICT off, const GSVector4i
 	{
 		FOREACH_BLOCK_START(r, 8, 8, 32)
 		{
-			GSBlock::ReadAndExpandBlock24<true>(src, dst, dstpitch, TEXA);
+			GSBlock::ReadAndExpandBlock24<true>(src, read_dst, dstpitch, TEXA);
 		}
 		FOREACH_BLOCK_END
 	}
@@ -1631,7 +1631,7 @@ void GSLocalMemory::ReadTexture24(const GSOffset* RESTRICT off, const GSVector4i
 	{
 		FOREACH_BLOCK_START(r, 8, 8, 32)
 		{
-			GSBlock::ReadAndExpandBlock24<false>(src, dst, dstpitch, TEXA);
+			GSBlock::ReadAndExpandBlock24<false>(src, read_dst, dstpitch, TEXA);
 		}
 		FOREACH_BLOCK_END
 	}
@@ -1643,7 +1643,7 @@ void GSLocalMemory::ReadTexture16(const GSOffset* RESTRICT off, const GSVector4i
 	{
 		FOREACH_BLOCK_START(r, 16, 8, 32)
 		{
-			GSBlock::ReadAndExpandBlock16<true>(src, dst, dstpitch, TEXA);
+			GSBlock::ReadAndExpandBlock16<true>(src, read_dst, dstpitch, TEXA);
 		}
 		FOREACH_BLOCK_END
 	}
@@ -1651,7 +1651,7 @@ void GSLocalMemory::ReadTexture16(const GSOffset* RESTRICT off, const GSVector4i
 	{
 		FOREACH_BLOCK_START(r, 16, 8, 32)
 		{
-			GSBlock::ReadAndExpandBlock16<false>(src, dst, dstpitch, TEXA);
+			GSBlock::ReadAndExpandBlock16<false>(src, read_dst, dstpitch, TEXA);
 		}
 		FOREACH_BLOCK_END
 	}
@@ -1663,7 +1663,7 @@ void GSLocalMemory::ReadTexture8(const GSOffset* RESTRICT off, const GSVector4i&
 
 	FOREACH_BLOCK_START(r, 16, 16, 32)
 	{
-		GSBlock::ReadAndExpandBlock8_32(src, dst, dstpitch, pal);
+		GSBlock::ReadAndExpandBlock8_32(src, read_dst, dstpitch, pal);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1674,7 +1674,7 @@ void GSLocalMemory::ReadTexture4(const GSOffset* RESTRICT off, const GSVector4i&
 
 	FOREACH_BLOCK_START(r, 32, 16, 32)
 	{
-		GSBlock::ReadAndExpandBlock4_32(src, dst, dstpitch, pal);
+		GSBlock::ReadAndExpandBlock4_32(src, read_dst, dstpitch, pal);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1685,7 +1685,7 @@ void GSLocalMemory::ReadTexture8H(const GSOffset* RESTRICT off, const GSVector4i
 
 	FOREACH_BLOCK_START(r, 8, 8, 32)
 	{
-		GSBlock::ReadAndExpandBlock8H_32(src, dst, dstpitch, pal);
+		GSBlock::ReadAndExpandBlock8H_32(src, read_dst, dstpitch, pal);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1696,7 +1696,7 @@ void GSLocalMemory::ReadTexture4HL(const GSOffset* RESTRICT off, const GSVector4
 
 	FOREACH_BLOCK_START(r, 8, 8, 32)
 	{
-		GSBlock::ReadAndExpandBlock4HL_32(src, dst, dstpitch, pal);
+		GSBlock::ReadAndExpandBlock4HL_32(src, read_dst, dstpitch, pal);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1707,7 +1707,7 @@ void GSLocalMemory::ReadTexture4HH(const GSOffset* RESTRICT off, const GSVector4
 
 	FOREACH_BLOCK_START(r, 8, 8, 32)
 	{
-		GSBlock::ReadAndExpandBlock4HH_32(src, dst, dstpitch, pal);
+		GSBlock::ReadAndExpandBlock4HH_32(src, read_dst, dstpitch, pal);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1870,7 +1870,7 @@ void GSLocalMemory::ReadTexture8P(const GSOffset* RESTRICT off, const GSVector4i
 {
 	FOREACH_BLOCK_START(r, 16, 16, 8)
 	{
-		GSBlock::ReadBlock8(src, dst, dstpitch);
+		GSBlock::ReadBlock8(src, read_dst, dstpitch);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1879,7 +1879,7 @@ void GSLocalMemory::ReadTexture4P(const GSOffset* RESTRICT off, const GSVector4i
 {
 	FOREACH_BLOCK_START(r, 32, 16, 8)
 	{
-		GSBlock::ReadBlock4P(src, dst, dstpitch);
+		GSBlock::ReadBlock4P(src, read_dst, dstpitch);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1888,7 +1888,7 @@ void GSLocalMemory::ReadTexture8HP(const GSOffset* RESTRICT off, const GSVector4
 {
 	FOREACH_BLOCK_START(r, 8, 8, 8)
 	{
-		GSBlock::ReadBlock8HP(src, dst, dstpitch);
+		GSBlock::ReadBlock8HP(src, read_dst, dstpitch);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1897,7 +1897,7 @@ void GSLocalMemory::ReadTexture4HLP(const GSOffset* RESTRICT off, const GSVector
 {
 	FOREACH_BLOCK_START(r, 8, 8, 8)
 	{
-		GSBlock::ReadBlock4HLP(src, dst, dstpitch);
+		GSBlock::ReadBlock4HLP(src, read_dst, dstpitch);
 	}
 	FOREACH_BLOCK_END
 }
@@ -1906,7 +1906,7 @@ void GSLocalMemory::ReadTexture4HHP(const GSOffset* RESTRICT off, const GSVector
 {
 	FOREACH_BLOCK_START(r, 8, 8, 8)
 	{
-		GSBlock::ReadBlock4HHP(src, dst, dstpitch);
+		GSBlock::ReadBlock4HHP(src, read_dst, dstpitch);
 	}
 	FOREACH_BLOCK_END
 }

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -263,10 +263,10 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 			GSVector4i tmp(v[i].XYZ.Y, v[i].V, v[i + 1].XYZ.Y, v[i + 1].V);
 			tmp = GSVector4i(tmp - offset).srl32(1) + offset;
 
-			v[i].XYZ.Y = tmp.x;
-			v[i].V = tmp.y;
-			v[i + 1].XYZ.Y = tmp.z;
-			v[i + 1].V = tmp.w;
+			v[i].XYZ.Y = (uint16)tmp.x;
+			v[i].V = (uint16)tmp.y;
+			v[i + 1].XYZ.Y = (uint16)tmp.z;
+			v[i + 1].V = (uint16)tmp.w;
 		}
 
 		// Please bang my head against the wall!

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -138,7 +138,7 @@ private:
 
 	#pragma endregion
 
-	int Interpolate_UV(float alpha, int t0, int t1);
+	uint16 Interpolate_UV(float alpha, int t0, int t1);
 	float alpha0(int L, int X0, int X1);
 	float alpha1(int L, int X0, int X1);
 

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -232,7 +232,7 @@ bool GSSettingsDlg::OnCommand(HWND hWnd, UINT id, UINT code)
 
 			if(ComboBoxGetSelData(IDC_OPENCL_DEVICE, data))
 			{
-				if ((int)data < m_ocl_devs.size()) {
+				if ((UINT)data < m_ocl_devs.size()) {
 					theApp.SetConfig("ocldev", m_ocl_devs[(int)data].name.c_str());
 				}
 			}

--- a/plugins/GSdx/GSTexture11.cpp
+++ b/plugins/GSdx/GSTexture11.cpp
@@ -50,7 +50,7 @@ bool GSTexture11::Update(const GSVector4i& r, const void* data, int pitch)
 {
 	if(m_dev && m_texture)
 	{
-		D3D11_BOX box = {r.left, r.top, 0, r.right, r.bottom, 1};
+		D3D11_BOX box = { (UINT)r.left, (UINT)r.top, 0U, (UINT)r.right, (UINT)r.bottom, 1U };
 
 		m_ctx->UpdateSubresource(m_texture, 0, &box, data, pitch, 0);
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -32,9 +32,9 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	if (theApp.GetConfig("UserHacks", 0)) {
 		m_spritehack                   = theApp.GetConfig("UserHacks_SpriteHack", 0);
-		UserHacks_HalfPixelOffset      = theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
-		m_preload_frame                = theApp.GetConfig("preload_frame_with_gs_data", 0);
-		m_disable_partial_invalidation = theApp.GetConfig("UserHacks_DisablePartialInvalidation", 0);
+		UserHacks_HalfPixelOffset      = !!theApp.GetConfig("UserHacks_HalfPixelOffset", 0);
+		m_preload_frame                = !!theApp.GetConfig("preload_frame_with_gs_data", 0);
+		m_disable_partial_invalidation = !!theApp.GetConfig("UserHacks_DisablePartialInvalidation", 0);
 		m_can_convert_depth            = !theApp.GetConfig("UserHacks_DisableDepthSupport", 0);
 	} else {
 		m_spritehack                   = 0;
@@ -299,7 +299,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 	} else if (CanConvertDepth()) {
 
 		int rev_type = (type == DepthStencil) ? RenderTarget : DepthStencil;
-		GSVector4 sRect(0, 0, 1.0, 1.0);
+		GSVector4 sRect(0, 0, 1, 1);
 		GSVector4 dRect(0, 0, w, h);
 
 		// Depth stencil/RT can be an older RT/DS but only check recent RT/DS to avoid to pick
@@ -1123,7 +1123,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 				// which is arbitrary set to 1280 (biggest RT used by GS). h/w are based on the input texture
 				// so the only reliable way to find the real size of the target is to use the TBW value.
 				float real_width = dst->m_TEX0.TBW * 64u * dst->m_texture->GetScale().x;
-				m_renderer->m_dev->CopyRect(sTex, dTex, GSVector4i(real_width/2.0f, 0, real_width, h));
+				m_renderer->m_dev->CopyRect(sTex, dTex, GSVector4i((int)(real_width/2.0f), 0, (int)real_width, h));
 			} else {
 				m_renderer->m_dev->CopyRect(sTex, dTex, GSVector4i(0, 0, w, h)); // <= likely wrong dstsize.x could be bigger than w
 			}


### PR DESCRIPTION
Just some changes to clean up warnings in windows, they were annoying me.

Also there's a possible bug/unused variable passed in GSRendererHW.cpp for alpha0, just commented it as I wasn't sure.

Some warnings still exist, but they are either outside of GSDX or they are to do with potentially not being reliable under other compilers inside try/catch blocks, which I'm unsure what to do with.

Feel free to mock me and suggest any changes :p
