### PR TITLE
x86emitter: gcc 6 compilation fix

### DIFF
--- a/common/src/x86emitter/cpudetect.cpp
+++ b/common/src/x86emitter/cpudetect.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "cpudetect_internal.h"
 #include "internal.h"
+#include "x86_intrin.h"
 
 using namespace x86Emitter;
 


### PR DESCRIPTION
Fix #1297