### PR TITLE
Trivial fix on wxFont style/weight usage

### DIFF
--- a/common/src/Utilities/pxWindowTextWriter.cpp
+++ b/common/src/Utilities/pxWindowTextWriter.cpp
@@ -53,8 +53,8 @@ pxWindowTextWriter& pxWindowTextWriter::SetStyle( wxFontStyle style )
 pxWindowTextWriter& pxWindowTextWriter::Normal()
 {
 	wxFont curfont( m_dc.GetFont() );
-	curfont.SetStyle( wxFONTWEIGHT_NORMAL );
-	curfont.SetWeight( wxFONTSTYLE_NORMAL );
+	curfont.SetStyle( wxFONTSTYLE_NORMAL );
+	curfont.SetWeight( wxFONTWEIGHT_NORMAL );
 	m_dc.SetFont( curfont );
 
 	return *this;


### PR DESCRIPTION
Just a fix for a typo in dda44519c187ee29c8fd75962352556eaefe654b.