### PR TITLE
Automatic aspect ratio switch during FMV playback

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -25,6 +25,7 @@
 #include "Gif.h"
 #include "Vif_Dma.h"
 #include <limits.h>
+#include "AppConfig.h"
 
 #include "Utilities/MemsetFast.inl"
 
@@ -50,8 +51,8 @@ int coded_block_pattern = 0;
 u8 indx4[16*16/2];
 
 uint eecount_on_last_vdec = 0;
-bool FMVstarted = 0;
-bool EnableFMV = 0;
+bool FMVstarted = false;
+bool EnableFMV = false;
 
 void tIPU_cmd::clear()
 {
@@ -400,12 +401,12 @@ static __ri void ipuBDEC(tIPU_CMD_BDEC bdec)
 
 static __fi bool ipuVDEC(u32 val)
 {
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack) {
+	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
 		static int count = 0;
 		if (count++ > 5) {
-			if (FMVstarted == 0) {
-				EnableFMV = 1;
-				FMVstarted = 1;
+			if (!FMVstarted) {
+				EnableFMV = true;
+				FMVstarted = true;
 			}
 			count = 0;
 		}

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -845,7 +845,8 @@ AppConfig::GSWindowOptions::GSWindowOptions()
 	IsMaximized				= false;
 	IsFullscreen			= false;
 
-    IsToggleFullscreenOnDoubleClick = true;
+	IsToggleFullscreenOnDoubleClick = true;
+	IsToggleAspectRatioSwitch = false;
 }
 
 void AppConfig::GSWindowOptions::SanityCheck()
@@ -882,7 +883,8 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 	IniEntry( IsMaximized );
 	IniEntry( IsFullscreen );
 
-    IniEntry( IsToggleFullscreenOnDoubleClick );
+	IniEntry( IsToggleFullscreenOnDoubleClick );
+	IniEntry( IsToggleAspectRatioSwitch );
 
 	static const wxChar* AspectRatioNames[] =
 	{

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -220,6 +220,7 @@ public:
 		bool		IsFullscreen;
 
 		bool		IsToggleFullscreenOnDoubleClick;
+		bool		IsToggleAspectRatioSwitch;
 
 		GSWindowOptions();
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -184,6 +184,8 @@ void GSPanel::DoResize()
 		zoom = std::max( (float)arr, (float)(1.0/arr) );
 
 	viewport.Scale(zoom, zoom*g_Conf->GSWindow.StretchY.ToFloat()/100.0 );
+	if (viewport == client && EmuConfig.Gamefixes.FMVinSoftwareHack && g_Conf->GSWindow.IsFullscreen)
+		viewport.x += 1; //avoids crash on some systems switching HW><SW in fullscreen aspect ratio's with FMV Software switch.
 	SetSize( viewport );
 	CenterOnParent();
 	

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -155,11 +155,22 @@ void GSPanel::DoResize()
 
 	double clientAr = (double)client.GetWidth()/(double)client.GetHeight();
 
+	extern AspectRatioType iniAR;
+	extern bool switchAR;
 	double targetAr = clientAr;
-	if( g_Conf->GSWindow.AspectRatio == AspectRatio_4_3 )
-		targetAr = 4.0/3.0;
-	else if( g_Conf->GSWindow.AspectRatio == AspectRatio_16_9 )
-		targetAr = 16.0/9.0;
+
+	if (g_Conf->GSWindow.AspectRatio != iniAR) {
+		switchAR = false;
+	}
+
+	if (!switchAR) {
+		if (g_Conf->GSWindow.AspectRatio == AspectRatio_4_3)
+			targetAr = 4.0 / 3.0;
+		else if (g_Conf->GSWindow.AspectRatio == AspectRatio_16_9)
+			targetAr = 16.0 / 9.0;
+	} else {
+		targetAr = 4.0 / 3.0;
+	}
 
 	double arr = targetAr / clientAr;
 

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -33,6 +33,8 @@
 // renderswitch - tells GSdx to go into dx9 sw if "renderswitch" is set.
 bool renderswitch = false;
 
+extern bool switchAR;
+
 static int g_Pcsx2Recording = 0; // true 1 if recording video and sound
 
 
@@ -175,6 +177,8 @@ namespace Implementations
 	{
 		AspectRatioType& art = g_Conf->GSWindow.AspectRatio;
 		wxString arts(L"Not modified");
+		if (art == AspectRatio_Stretch && switchAR) //avoids a double 4:3 when coming from FMV aspect ratio switch
+			art = AspectRatio_4_3;
 		switch( art )
 		{
 			case AspectRatio_Stretch:	art = AspectRatio_4_3; arts = L"AspectRatio_4_3"; break;

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -286,6 +286,7 @@ namespace Panels
 
 		pxCheckBox*		m_check_HideMouse;
 		pxCheckBox*		m_check_DclickFullscreen;
+		pxCheckBox*		m_check_AspectRatioSwitch;
 
 		wxTextCtrl*		m_text_WindowWidth;
 		wxTextCtrl*		m_text_WindowHeight;

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -49,6 +49,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	m_check_Fullscreen	= new pxCheckBox( this, _("Default to fullscreen mode on open") );
 	m_check_VsyncEnable	= new pxCheckBox( this, _("Wait for Vsync on refresh") );
 	m_check_DclickFullscreen = new pxCheckBox( this, _("Double-click toggles fullscreen mode") );
+	m_check_AspectRatioSwitch = new pxCheckBox(this, _("Switch to 4:3 aspect ratio when an FMV plays"));
 	//m_check_ExclusiveFS = new pxCheckBox( this, _("Use exclusive fullscreen mode (if available)") );
 
 	m_text_Zoom->SetToolTip( pxEt( L"Zoom = 100: Fit the entire image to the window without any cropping.\nAbove/Below 100: Zoom In/Out\n0: Automatic-Zoom-In untill the black-bars are gone (Aspect ratio is kept, some of the image goes out of screen).\n  NOTE: Some games draw their own black-bars, which will not be removed with '0'.\n\nKeyboard: CTRL + NUMPAD-PLUS: Zoom-In, CTRL + NUMPAD-MINUS: Zoom-Out, CTRL + NUMPAD-*: Toggle 100/0"
@@ -99,6 +100,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 
 	*this += m_check_Fullscreen;
 	*this += m_check_DclickFullscreen;
+	*this += m_check_AspectRatioSwitch;
 
 	//*this += m_check_ExclusiveFS;
 	*this += new wxStaticLine( this )	| StdExpand();
@@ -131,7 +133,8 @@ void Panels::GSWindowSettingsPanel::ApplyConfigToGui( AppConfig& configToApply, 
 		m_combo_AspectRatio	->SetSelection( (int)conf.AspectRatio );
 		m_text_Zoom			->ChangeValue( conf.Zoom.ToString() );
 
-		m_check_DclickFullscreen ->SetValue ( conf.IsToggleFullscreenOnDoubleClick );
+		m_check_DclickFullscreen ->SetValue( conf.IsToggleFullscreenOnDoubleClick );
+		m_check_AspectRatioSwitch->SetValue( conf.IsToggleAspectRatioSwitch );
 
 		m_text_WindowWidth	->ChangeValue( wxsFormat( L"%d", conf.WindowSize.GetWidth() ) );
 		m_text_WindowHeight	->ChangeValue( wxsFormat( L"%d", conf.WindowSize.GetHeight() ) );
@@ -157,6 +160,7 @@ void Panels::GSWindowSettingsPanel::Apply()
 	gsconf.VsyncEnable		= m_check_VsyncEnable->GetValue();
 
 	appconf.IsToggleFullscreenOnDoubleClick = m_check_DclickFullscreen->GetValue();
+	appconf.IsToggleAspectRatioSwitch = m_check_AspectRatioSwitch->GetValue();
 
 	long xr, yr = 1;
 


### PR DESCRIPTION
Add option to Emulation Settings - GS Window to for automatically switching to 4:3 aspect ratio when a FMV plays, and back to widescreen/stretch when it's finished.

![aspectswitch](https://cloud.githubusercontent.com/assets/15942346/14832352/1c40903e-0bfa-11e6-9067-34c7b08f2fe5.png)

Code probably requires optimising to follow PCSX2 coding guidelines, as I'm not a PCSX2 code or C++ expert.

Feature-request by trostboot as posted in issues: #1212

Update: latest commit Appveyor build link(April 29th): https://ci.appveyor.com/api/buildjobs/9lu8c562g7cuy52a/artifacts/pcsx2-v1.5.0-dev-678-gf6c11a1-master-933-vs2015-Win32-AppVeyor.7z