### PR TITLE
GSDX: Avoid crash when TBW == 0 - Preload data frame

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -435,7 +435,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 		// From a performance point of view, it might cost a little on big upscaling
 		// but normally few RT are miss so it must remain reasonable.
 		if (s_IS_OPENGL) {
-			if (m_preload_frame) {
+			if (m_preload_frame && TEX0.TBW > 0) {
 				GL_INS("Preloading the RT DATA");
 				// RT doesn't have height but if we use a too big value, we will read outside of the GS memory.
 				int page0 = TEX0.TBP0 >> 5;


### PR DESCRIPTION
Some games seem to hit this if you have the preload frame hack enabled and the TBW of TEX0 is 0, causing a divide by zero error. In these cases this will assume old behaviour.

Tested with KH, still works. 

Fixes Star Wars Battlefront, possibly others that crash in OGL recently if you use this hack.