### PR TITLE
debugger:windows: Fix vanishing breakpoints when scrollbar disappears

### DIFF
--- a/pcsx2/gui/Debugger/DebuggerLists.h
+++ b/pcsx2/gui/Debugger/DebuggerLists.h
@@ -65,6 +65,7 @@ private:
 
 	GenericListViewColumn* columns;
 	wxPoint clickPos;
+	bool dontResizeColumnsInSizeEventHandler;
 };
 
 class BreakpointList: public GenericListView


### PR DESCRIPTION
On Windows, it seems that if you resize the columns in the size event handler when the scrollbar disappears, the listview contents may decide to disappear as well. So let's avoid the resize for this case.

Should fix #1198

@Aced14 Please test :)