### PR TITLE
Ensure selected rows are visible in debugger

### DIFF
--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -467,6 +467,7 @@ void CtrlRegisterList::setCurrentRow(int row)
 
 	currentRows[category] = row;
 	postEvent(debEVT_SETSTATUSBARTEXT,text);
+	ensureVisible(currentRows[category] + 1); //offset due to header at scroll position 0
 	Refresh();
 }
 
@@ -546,12 +547,29 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 	}
 }
 
+void CtrlRegisterList::ensureVisible(int index) {
+	//scroll vertically to keep a logical position visible
+	int x, y;
+	GetViewStart(&x, &y);
+	int visibleOffset = floor(float(GetClientSize().y) / rowHeight) - 1;
+	if (index < y)
+		Scroll(x, index);
+	else if (index > y + visibleOffset)
+		Scroll(x, index - visibleOffset);
+}
+
 void CtrlRegisterList::keydownEvent(wxKeyEvent& evt)
 {
 	switch (evt.GetKeyCode())
 	{
 	case WXK_UP:
-		setCurrentRow(std::max<int>(currentRows[category]-1,0));
+		int x, y;
+		GetViewStart(&x, &y);
+		//If at top of rows allow scrolling an extra time to show tab header
+		if (currentRows[category] == 0 && y == 1)
+			Scroll(x, 0);
+		else
+			setCurrentRow(std::max<int>(currentRows[category]-1,0));
 		break;
 	case WXK_DOWN:
 		setCurrentRow(std::min<int>(currentRows[category]+1,cpu->getRegisterCount(category)-1));

--- a/pcsx2/gui/Debugger/CtrlRegisterList.h
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.h
@@ -50,6 +50,7 @@ private:
 	void OnDraw(wxDC& dc);
 	void refreshChangedRegs();
 	void setCurrentRow(int row);
+	void ensureVisible(int index);
 	void changeValue(RegisterChangeMode mode);
 	wxSize getOptimalSize() const;
 

--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -88,12 +88,16 @@ void GenericListView::keydownEvent(wxKeyEvent& evt)
 	switch (evt.GetKeyCode())
 	{
 	case WXK_UP:
-		if (sel > 0)
+		if (sel > 0) {
 			Select(sel-1);
+			Focus(sel-1);
+		}
 		break;
 	case WXK_DOWN:
-		if (sel+1 < GetItemCount())
+		if (sel+1 < GetItemCount()) {
 			Select(sel+1);
+			Focus(sel+1);
+		}
 		break;
 	}
 


### PR DESCRIPTION
Fixes #1353
DebuggerLists:
Select does not ensure the item is visible if selecting
Went with existing convention of calling Select and then Focus.

CtrlRegisterList:
Added ensureVisible, called whenever the current row selection is
changed