### PR TITLE
GSDX: Fix scaling of custom resolution

### DIFF
--- a/plugins/GSdx/GSRenderer.h
+++ b/plugins/GSdx/GSRenderer.h
@@ -67,7 +67,7 @@ public:
 	virtual bool MakeSnapshot(const string& path);
 	virtual void KeyEvent(GSKeyEventData* e);
 	virtual bool CanUpscale() {return false;}
-	virtual int GetUpscaleMultiplier() {return 1;}
+	virtual float GetUpscaleMultiplier() {return 1.0f;}
 	virtual GSVector2i GetInternalResolution() {
 		return GetOutputRect();
 	}

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -34,6 +34,8 @@ private:
 	int m_height;
 	bool m_reset;
 	int m_upscale_multiplier;
+	int m_custom_width;
+	int m_custom_height;
 
 	bool m_large_framebuffer;
 	bool m_userhacks_align_sprite_X;
@@ -161,7 +163,7 @@ public:
 
 	void SetGameCRC(uint32 crc, int options);
 	bool CanUpscale();
-	int GetUpscaleMultiplier();
+	float GetUpscaleMultiplier();
 	virtual GSVector2i GetInternalResolution();
 	void SetScaling();
 


### PR DESCRIPTION
**Summary of Changes:**

* Remove some hacks which limited scaling factor.
* Remove dubious usage of frame memory offsets
* Use a slightly bigger buffer size compared to the rescaled CRTC size.

Fixes a bug from SilentHill 2 mentioned over [here](http://forums.pcsx2.net/Thread-GSDX-Hardware-mode-Bug-Report-Silent-Hill-2-GSdx-Screenshots-have-wrong-height).

**Master Branch:** ``(outputs a 1280 X 1120 resolution when custom resolution is set to 1280 X 1280)``
[![gsdx_20160520075805.png](http://ultraimg.com/images/gsdx_20160520075805.png)](http://ultraimg.com/image/JfWV)

**Pull Request Branch:** ``(Properly outputs a 1280 X 1280 Resolution)``
[![gsdx_20160520075643.png](http://ultraimg.com/images/gsdx_20160520075643.png)](http://ultraimg.com/image/JfaT)

Thanks to @refractionpcsx2 for providing the dump :)

**Dear testers**, please also test custom resolution on various other games for regressions (look out for VP2).

**Build download link**: [here](https://ci.appveyor.com/api/buildjobs/o084x9sc3b10ple1/artifacts/pcsx2-v1.5.0-dev-781-g462de7f-master-1060-vs2015-Win32-AppVeyor.7z)