### PR TITLE
GSDX: Calculate Framebuffer size using Scissoring test

### DIFF
--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -35,7 +35,6 @@ private:
 	bool m_reset;
 	int m_upscale_multiplier;
 
-	bool m_large_framebuffer;
 	bool m_userhacks_align_sprite_X;
 	bool m_userhacks_disable_gs_mem_clear;
 


### PR DESCRIPTION
**Summary of Changes**:

* Calculate the Framebuffer size using the size obtained from scissor registers.

**Benefits:**
* Code is more beautiful (No hacks ! :D )
* Useful to limit the rescaling of Framebuffer to valid data.

**Note:** Please test for regressions on native upscaled resolutions (2x , 3x .. etc), don't test custom resolution.