### PR TITLE
GSDX-Windows: Better detection of default renderer

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -485,6 +485,10 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	if (renderer == GSRendererType::Undefined)
 	{
 		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+#ifdef _WIN32
+		if (renderer == GSRendererType::Default)
+			renderer = GSUtil::GetBestRenderer();
+#endif
 	}
 	else if (stored_toggle_state != toggle_state)
 	{

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -231,7 +231,7 @@ enum class GSRendererType : int8_t
 	OGL_OpenCL = 17,
 
 #ifdef _WIN32
-	Default = DX1011_HW
+	Default = Undefined
 #else
 	// Use ogl renderer as default otherwise it crash at startup
 	// GSRenderOGL only GSDeviceOGL (not GSDeviceNULL)

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -685,6 +685,7 @@ void GSHacksDlg::OnInit()
 	ShowWindow(GetDlgItem(m_hWnd, IDC_ALPHASTENCIL), ogl ? SW_HIDE : SW_SHOW);
 	ShowWindow(GetDlgItem(m_hWnd, IDC_ALPHAHACK), ogl ? SW_HIDE : SW_SHOW);
 	ShowWindow(GetDlgItem(m_hWnd, IDC_SAFE_FBMASK), ogl ? SW_SHOW : SW_HIDE);
+	EnableWindow(GetDlgItem(m_hWnd, IDC_TC_DEPTH), ogl);
 	EnableWindow(GetDlgItem(m_hWnd, IDC_MSAACB), !ogl);
 	EnableWindow(GetDlgItem(m_hWnd, IDC_MSAA_TEXT), !ogl);
 	EnableWindow(GetDlgItem(m_hWnd, IDC_SPRITEHACK), !native);

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -316,8 +316,8 @@ void GSSettingsDlg::UpdateRenderers()
 	}
 	else
 	{
-		//GSRendererType best_renderer = (level >= D3D_FEATURE_LEVEL_10_0) ? GSRendererType::DX1011_HW : GSRendererType::DX9_HW;
-		renderer_setting = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+		GSRendererType ini_renderer = GSRendererType(theApp.GetConfigI("Renderer"));
+		renderer_setting = (ini_renderer == GSRendererType::Undefined) ? GSUtil::GetBestRenderer() : ini_renderer;
 	}
 
 	GSRendererType renderer_sel = GSRendererType::Default;

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -396,6 +396,29 @@ D3D_FEATURE_LEVEL GSUtil::CheckDirect3D11Level(IDXGIAdapter *adapter, D3D_DRIVER
 	return SUCCEEDED(hr) ? level : (D3D_FEATURE_LEVEL)0;
 }
 
+GSRendererType GSUtil::GetBestRenderer()
+{
+	CComPtr<IDXGIFactory1> dxgi_factory;
+	if (SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&dxgi_factory))))
+	{
+		CComPtr<IDXGIAdapter1> adapter;
+		if (SUCCEEDED(dxgi_factory->EnumAdapters1(0, &adapter)))
+		{
+			DXGI_ADAPTER_DESC1 desc;
+			if (SUCCEEDED(adapter->GetDesc1(&desc)))
+			{
+				D3D_FEATURE_LEVEL level = GSUtil::CheckDirect3D11Level();
+				// Check for Nvidia VendorID. Latest OpenGL features need at least DX11 level GPU
+				if (desc.VendorId == 0x10DE && level >= D3D_FEATURE_LEVEL_11_0)
+					return GSRendererType::OGL_HW;
+				if (level >= D3D_FEATURE_LEVEL_10_0)
+					return GSRendererType::DX1011_HW;
+			}
+		}
+	}
+	return GSRendererType::DX9_HW;
+}
+
 #else
 
 void GSmkdir(const char* dir)

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -60,6 +60,7 @@ public:
 	static bool CheckDirectX();
 	static bool CheckDXGI();
 	static bool CheckD3D11();
+	static GSRendererType GetBestRenderer();
 	static D3D_FEATURE_LEVEL CheckDirect3D11Level(IDXGIAdapter *adapter = NULL, D3D_DRIVER_TYPE type = D3D_DRIVER_TYPE_HARDWARE);
 
 #endif

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -295,7 +295,7 @@ GSdxApp::GSdxApp()
 	m_default_configuration["paltex"]                                     = "0";
 	m_default_configuration["png_compression_level"]                      = to_string(Z_BEST_SPEED);
 	m_default_configuration["preload_frame_with_gs_data"]                 = "0";
-	m_default_configuration["Renderer"]                                   = to_string(static_cast<int>(GSRendererType::Default)); // FIXME
+	m_default_configuration["Renderer"]                                   = to_string(static_cast<int>(GSRendererType::Default));
 	m_default_configuration["resx"]                                       = "1024";
 	m_default_configuration["resy"]                                       = "1024";
 	m_default_configuration["save"]                                       = "0";


### PR DESCRIPTION
**Summary of Changes**:

*  Better detection of default renderer based on the vendor ID ( Nvidia, AMD , Intel) [(Thanks to mirh)](https://github.com/PCSX2/pcsx2/pull/1370#issuecomment-222302060)
*  Gray out ``Disable Depth Emulation`` for renderers other than OpenGL.

Closes #1039 

**Testing Required**:
- [x] Nvidia (Tested myself , works fine)
- [x] AMD (**Flatout** tested it and seems to be fine)
- [x] Intel IGPU (**Bositman** and **Flatout** tested it, seems to be fine)
