### PR TITLE
SPU2-X: Force start voices immediately after KeyOn

### DIFF
--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -115,7 +115,7 @@ void ReadSettings()
 	VolumeAdjustSL = powf(10, VolumeAdjustSLdb / 10);
 	VolumeAdjustSR = powf(10, VolumeAdjustSRdb / 10);
 	VolumeAdjustLFE = powf(10, VolumeAdjustLFEdb / 10);
-	delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 4);
+	delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 1);
 
 
 	wxString temp;

--- a/plugins/spu2-x/src/Windows/Config.cpp
+++ b/plugins/spu2-x/src/Windows/Config.cpp
@@ -101,7 +101,7 @@ void ReadSettings()
 	VolumeAdjustSLdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSL(dB)", 0);
 	VolumeAdjustSRdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSR(dB)", 0);
 	VolumeAdjustLFEdb = CfgReadFloat(L"MIXING", L"VolumeAdjustLFE(dB)", 0);
-	delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 4);
+	delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 1);
 	VolumeAdjustC = powf(10, VolumeAdjustCdb / 10);
 	VolumeAdjustFL = powf(10, VolumeAdjustFLdb / 10);
 	VolumeAdjustFR = powf(10, VolumeAdjustFRdb / 10);


### PR DESCRIPTION
**Summary of Changes**:

* Forces sound generation of voices immediately after KeyOn instead of delaying by ``4Ts``.

I'm lead to believe that the former code is a hack. AFAIK SPU2 operations become indeterminate only when they're written at a time interval less than ``1Ts`` , they don't need a delay of ``4Ts``.

The higher delay caused issues in games like,
*  [**Higurashi no Naku Koro ni Matsuri Kakera Asobi**](http://wiki.pcsx2.net/index.php/Higurashi_no_Naku_Koro_ni_Matsuri:_Kakera_Asobi) (#918)
* [**Deus Ex: The Conspiracy**](http://wiki.pcsx2.net/index.php/Deus_Ex:_The_Conspiracy) (#615)
* [**Armored Core 2**](http://wiki.pcsx2.net/index.php/Armored_Core_2) [(bug report)](http://forums.pcsx2.net/Thread-Resolved-Workaround-Bug-Report-Armored-Core-2-NTSC-U)

Fixes #918 and #615 

_**Regressions testing**_:
- [ ] DQ5 adventure log music
- [ ]  Le Mans 24 Hours
- [ ]  The Legend of Spyro: The Eternal Night

**Note**: Make sure to delete your ``SPU2-X.ini`` file before starting to test your games. (The value gets applied only from a fresh start) 

Feel free to also do some regression checking on other games ;)