### PR TITLE
Guitar Hero III + Aerosmith : Crash & Graphics Fix

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16878,6 +16878,7 @@ Region = PAL-M5
 Serial = SLES-54962
 Name   = Guitar Hero III - Legends of Rock
 Region = PAL-E
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-54963
 Name   = Tony Hawks - Proving Ground
@@ -16887,6 +16888,11 @@ vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-54964
 Name   = Tony Hawk's Proving Ground
+Region = PAL-M4
+vuRoundMode = 0 //Crashes without.
+---------------------------------------------
+Serial = SLES-54974
+Name   = Guitar Hero III - Legends of Rock
 Region = PAL-M4
 vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
@@ -17116,6 +17122,7 @@ Region = PAL-F-G
 Serial = SLES-55191
 Name   = Guitar Hero - Aerosmith
 Region = PAL-E
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLES-55197
 Name   = Dancing Stage SuperNOVA 2
@@ -17125,6 +17132,11 @@ Serial = SLES-55198
 Name   = Iron Man
 Region = PAL-M5
 Compat = 5
+---------------------------------------------
+Serial = SLES-55200
+Name   = Guitar Hero - Aerosmith
+Region = PAL-M4
+vuRoundMode = 0 //Crashes without
 ---------------------------------------------
 Serial = SLES-55204
 Name   = Crash - Mind Over Mutant
@@ -33196,6 +33208,7 @@ Region = NTSC-J
 Serial = SLPS-25840
 Name   = Guitar Hero III - Legends of Rock [with Guitar]
 Region = NTSC-J
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLPS-25841
 Name   = Tales of Destiny [Director's Cut] [Premium Box]
@@ -33321,6 +33334,16 @@ Compat = 5
 Serial = SLPS-25887
 Name   = Super Robot Taisen Z
 Region = NTSC-J
+---------------------------------------------
+Serial = SLPS-25889
+Name   = Guitar Hero - Aerosmith
+Region = NTSC-J
+vuRoundMode = 0 //Crashes without
+---------------------------------------------
+Serial = SLPS-25890
+Name   = Guitar Hero III - Legends of Rock [with Guitar]
+Region = NTSC-J
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLPS-25892
 Name   = Nogizaka Haruka no Himitsu - Cosplay Hajimemashita
@@ -41393,6 +41416,7 @@ Serial = SLUS-21672
 Name   = Guitar Hero III - Legends of Rock
 Region = NTSC-U
 Compat = 5
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLUS-21673
 Name   = College Hoops 2K8
@@ -41699,6 +41723,7 @@ Serial = SLUS-21740
 Name   = Guitar Hero - Aerosmith
 Region = NTSC-U
 Compat = 5
+vuRoundMode = 0 //Crashes without.
 ---------------------------------------------
 Serial = SLUS-21741
 Name   = Sea Monsters - A Prehistoric Adventure


### PR DESCRIPTION
Force Round Mode to Nearest on Guitar Hero 3 & Aerosmith version by default : Fix the random crash on PCSX2 while playing and fix all graphics issues in Software Mode. 
For all PAL/NTSC/NTSC-J versions.