### PR TITLE
GSDX: Remove redundant "Null" string from GS Frame title bar

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -299,7 +299,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 				break;
 			case GSRendererType::Null:
 				s_gs = new GSRendererNull();
-				s_renderer_type = " Null";
+				s_renderer_type = "";
 				break;
 			case GSRendererType::DX9_OpenCL:
 			case GSRendererType::DX1011_OpenCL:

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -32,7 +32,7 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_double_downscale(false)
 {
 	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
-	m_large_framebuffer  = theApp.GetConfigI("large_framebuffer");
+	m_large_framebuffer  = theApp.GetConfigB("large_framebuffer");
 	if (theApp.GetConfigB("UserHacks")) {
 		m_userhacks_align_sprite_X       = theApp.GetConfigB("UserHacks_align_sprite_X");
 		m_userhacks_round_sprite_offset  = theApp.GetConfigI("UserHacks_round_sprite_offset");


### PR DESCRIPTION
**Summary of changes**:

* Remove redundant ``Null`` string present on the GS Frame title bar. (Err.. Ignore those other details on the GS Frame, it's just for easy debugging of video mode)
![image](http://ultraimg.com/images/null.png)

* Fix Improper usage of ``GetConfigI``