### PR TITLE
GSDX: Add proper detection of internal resolution

### DIFF
--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -37,6 +37,7 @@ GSRenderer::GSRenderer()
 	, m_texture_shuffle(false)
 	, m_wnd(NULL)
 	, m_dev(NULL)
+	, m_real_size(0,0)
 {
 	m_GStitleInfoBuffer[0] = 0;
 
@@ -248,6 +249,7 @@ bool GSRenderer::Merge(int field)
 	{
 		ds.y *= 2;
 	}
+	m_real_size = ds;
 
 	bool slbg = m_regs->PMODE.SLBG;
 	bool mmod = m_regs->PMODE.MMOD;
@@ -298,6 +300,11 @@ bool GSRenderer::Merge(int field)
 	}
 
 	return true;
+}
+
+GSVector2i GSRenderer::GetInternalResolution()
+{
+	return m_real_size;
 }
 
 void GSRenderer::SetFrameLimit(bool limit)

--- a/plugins/GSdx/GSRenderer.h
+++ b/plugins/GSdx/GSRenderer.h
@@ -49,6 +49,7 @@ protected:
 	bool m_fxaa;
 	bool m_shadeboost;
 	bool m_texture_shuffle;
+	GSVector2i m_real_size;
 
 	virtual GSTexture* GetOutput(int i, int& y_offset) = 0;
 
@@ -68,9 +69,7 @@ public:
 	virtual void KeyEvent(GSKeyEventData* e);
 	virtual bool CanUpscale() {return false;}
 	virtual int GetUpscaleMultiplier() {return 1;}
-	virtual GSVector2i GetInternalResolution() {
-		return GetOutputRect();
-	}
+	GSVector2i GetInternalResolution();
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(bool enabled);
 	void SetFrameLimit(bool limit);

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -143,15 +143,6 @@ int GSRendererHW::GetUpscaleMultiplier()
 	return m_upscale_multiplier ? m_upscale_multiplier : 1;
 }
 
-GSVector2i GSRendererHW::GetInternalResolution() {
-	GSVector2i dr = GetOutputRect();
-
-	if (m_upscale_multiplier)
-		return GSVector2i(dr.x * m_upscale_multiplier, dr.y * m_upscale_multiplier);
-	else
-		return GSVector2i(m_width, m_height);
-}
-
 void GSRendererHW::Reset()
 {
 	// TODO: GSreset can come from the main thread too => crash

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -162,7 +162,6 @@ public:
 	void SetGameCRC(uint32 crc, int options);
 	bool CanUpscale();
 	int GetUpscaleMultiplier();
-	virtual GSVector2i GetInternalResolution();
 	void SetScaling();
 
 	void Reset();

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -467,28 +467,6 @@ GSVector2i GSState::GetDeviceSize(int i)
 	return DeviceSize;
 }
 
-GSVector2i GSState::GetOutputRect()
-{
-	GSVector2i Merged_Rectangle(GetDisplayRect().width(), GetDisplayRect().height());
-	GSVector4i Rectangle[2] = { GetDisplayRect(0) , GetDisplayRect(1) };
-	int width[2] = { Rectangle[0].width() , Rectangle[1].width() };
-	int height[2] = { Rectangle[0].height() , Rectangle[1].height() };
-	int x_offset[2] = { Rectangle[0].left , Rectangle[1].left };
-	int y_offset[2] = { Rectangle[0].top , Rectangle[1].top };
-
-	if (!(IsEnabled(0) && IsEnabled(1)))
-		return Merged_Rectangle;
-
-	if (width[0] == width[1] && width[0] == std::max(x_offset[0], x_offset[1]) - std::min(x_offset[0], x_offset[1]))
-		Merged_Rectangle.x <<= 1;
-
-	if (height[0] == height[1] && height[0] == std::max(y_offset[0], y_offset[1]) - std::min(y_offset[0], y_offset[1]))
-		Merged_Rectangle.y <<= 1;
-
-	return Merged_Rectangle;
-
-}
-
 bool GSState::IsEnabled(int i)
 {
 	ASSERT(i >= 0 && i < 2);

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -239,7 +239,6 @@ public:
 	GSVector4i GetDisplayRect(int i = -1);
 	GSVector4i GetFrameRect(int i = -1);
 	GSVector2i GetDeviceSize(int i = -1);
-	GSVector2i GetOutputRect(); //Final Output rectangle after passing through merge circuit.
 	GSVideoMode GetVideoMode();
 
 	bool IsEnabled(int i);


### PR DESCRIPTION
**Summary of changes**:

* Remove old hacky detection of the internal resolution and properly detect it based on data from ``Merge()``. Now it'll display the same resolution as the captured screenshot. It also eases up my future works required to fix custom resolution on few games.

**Master branch**:

* Persona 3 - ``640x511``

**Pull request branch**:

* Persona 3 - ``640x512`` (Thanks to FlatOut for the GS dump)