### PR TITLE
gsdx tc: potentially fix a regression on mana-khemia

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1844,7 +1844,7 @@ void GSTextureCache::Target::UpdateValidity(const GSVector4i& rect)
 
 bool GSTextureCache::Target::Inside(uint32 bp, uint32 bw, uint32 psm, const GSVector4i& rect)
 {
-	uint32 block = GSLocalMemory::m_psm[psm].bn(rect.x, rect.y, bp, bw);
+	uint32 block = GSLocalMemory::m_psm[psm].bn(rect.width(), rect.height(), bp, bw);
 
 	return bp > m_TEX0.TBP0 && block < m_end_block;
 }


### PR DESCRIPTION
See:
* http://forums.pcsx2.net/Thread-Bug-Report-Mana-Khemia-Alchemists-of-Al-Revis-NTSC-U--55471
* f712c5c6d092b187558b519d6e7b88fa117df997

Previous code use the size of the draw to compute latest block. I
don't know why I use .x/.y which are the origin offset.

Need to be tested thoroughly