### PR TITLE
GSDX: Improve scaling of custom resolution

### DIFF
--- a/plugins/GSdx/GSRenderer.h
+++ b/plugins/GSdx/GSRenderer.h
@@ -69,6 +69,7 @@ public:
 	virtual void KeyEvent(GSKeyEventData* e);
 	virtual bool CanUpscale() {return false;}
 	virtual int GetUpscaleMultiplier() {return 1;}
+	virtual GSVector2i GetCustomResolution() {return GSVector2i(0,0);}
 	GSVector2i GetInternalResolution();
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(bool enabled);

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -114,7 +114,8 @@ void GSRendererHW::SetScaling()
 			ratio = round(ratio + buffer_scale_offset);
 
 			m_tc->RemovePartial();
-			m_height = crtc_size.y * ratio;
+			m_width = max(m_width, 1280);
+			m_height = max(static_cast<int>(crtc_size.y * ratio) , 1024);
 		}
 	}
 

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -32,6 +32,8 @@ class GSRendererHW : public GSRenderer
 private:
 	int m_width;
 	int m_height;
+	int m_custom_width;
+	int m_custom_height;
 	bool m_reset;
 	int m_upscale_multiplier;
 
@@ -162,6 +164,7 @@ public:
 	void SetGameCRC(uint32 crc, int options);
 	bool CanUpscale();
 	int GetUpscaleMultiplier();
+	GSVector2i GetCustomResolution();
 	void SetScaling();
 
 	void Reset();

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -389,7 +389,7 @@ void GSSettingsDlg::UpdateControls()
 		ShowWindow(GetDlgItem(m_hWnd, IDC_TC_DEPTH), ogl ? SW_SHOW : SW_HIDE);
 
 		EnableWindow(GetDlgItem(m_hWnd, IDC_CRC_LEVEL), hw);
-		EnableWindow(GetDlgItem(m_hWnd, IDC_LARGE_FB), integer_scaling > 1 && hw);
+		EnableWindow(GetDlgItem(m_hWnd, IDC_LARGE_FB), integer_scaling != 1 && hw);
 		EnableWindow(GetDlgItem(m_hWnd, IDC_CRC_LEVEL_TEXT), hw);
 		EnableWindow(GetDlgItem(m_hWnd, IDC_OPENCL_DEVICE), ocl);
 		EnableWindow(GetDlgItem(m_hWnd, IDC_RESX), hw && !integer_scaling);

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -472,21 +472,8 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 		}
 		else  // Custom resolution hack
 		{
-			GSVector4i fr = m_renderer->GetFrameRect();
-
-			int ww = (int)(fr.left + m_renderer->GetDisplayRect().width());
-			int hh = (int)(fr.top + m_renderer->GetDisplayRect().height());
-
-			// Gregory: I'm sure this sillyness is related to the usage of a 32bits
-			// buffer as a 16 bits format. In this case the height of the buffer is
-			// multiplyed by 2 (Hence a scissor bigger than the RT)
-
-			// This vp2 fix doesn't work most of the time
-
-			if(hh < 512 && m_renderer->m_context->SCISSOR.SCAY1 == 511) // vp2
-			{
-				hh = 512;
-			}
+			int ww = m_renderer->GetDisplayRect().width();
+			int hh = m_renderer->GetDisplayRect().height();
 
 			if(ww && hh)
 			{


### PR DESCRIPTION
**Summary of changes**:

* Remove scaling hack which limited scaling size based on the scissor value.
* Ignore Frame memory offsets for calculating dimensions value of display rectangle.
* Improve frame buffer height management on custom resolution.

**ICO 60Hz mode** ( ``master branch`` )

![ICObefore.png](http://ultraimg.com/images/2016/06/27/ICObefore.png)

**ICO 60Hz mode** ( ``Pull request branch with large frame buffer enabled`` )

![ICOafter.png](http://ultraimg.com/images/2016/06/27/ICOafter.png)

**Silent Hill 2** (``master branch``)

![sh2_before.png](http://ultraimg.com/images/2016/06/27/sh2_before.png)

**Note**:
```
 Outputs a scaled image of size 1024x672 when 1024x768 is set on custom resolution.
```

**Silent Hill 2** (``Pull request branch``)

![SH2_after.png](http://ultraimg.com/images/2016/06/27/SH2_after.png)

**Note**:
```
 Properly outputs a scaled image of size 1024x768 when custom resolution is set to 1024x768.
```

Fixes the Silent Hill 2 bug [reported on the forum](http://forums.pcsx2.net/Thread-GSDX-Texture-Cache-Bug-Report-Silent-Hill-2-GSdx-Screenshots-have-wrong-height).