### PR TITLE
PCSX2: Clean up warnings on MSVC

### DIFF
--- a/common/src/x86emitter/x86emitter.cpp
+++ b/common/src/x86emitter/x86emitter.cpp
@@ -426,10 +426,10 @@ void EmitRex( const xRegisterBase& reg1, const void* src )
 
 void EmitRex( const xRegisterBase& reg1, const xIndirectVoid& sib )
 {
-	u8 w = reg1.IsWide();
-	u8 r = reg1.IsExtended();
-	u8 x = sib.Index.IsExtended();
-	u8 b = sib.Base.IsExtended();
+	bool w = reg1.IsWide();
+	bool r = reg1.IsExtended();
+	bool x = sib.Index.IsExtended();
+	bool b = sib.Base.IsExtended();
 	EmitRex(w, r, x, b);
 }
 

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -666,12 +666,12 @@ void LD()
 }
 
 static const u64 LDL_MASK[8] =
-{	0x00ffffffffffffffLL, 0x0000ffffffffffffLL, 0x000000ffffffffffLL, 0x00000000ffffffffLL,
-	0x0000000000ffffffLL, 0x000000000000ffffLL, 0x00000000000000ffLL, 0x0000000000000000LL
+{	0x00ffffffffffffffULL, 0x0000ffffffffffffULL, 0x000000ffffffffffULL, 0x00000000ffffffffULL,
+	0x0000000000ffffffULL, 0x000000000000ffffULL, 0x00000000000000ffULL, 0x0000000000000000ULL
 };
 static const u64 LDR_MASK[8] =
-{	0x0000000000000000LL, 0xff00000000000000LL, 0xffff000000000000LL, 0xffffff0000000000LL,
-	0xffffffff00000000LL, 0xffffffffff000000LL, 0xffffffffffff0000LL, 0xffffffffffffff00LL
+{	0x0000000000000000ULL, 0xff00000000000000ULL, 0xffff000000000000ULL, 0xffffff0000000000ULL,
+	0xffffffff00000000ULL, 0xffffffffff000000ULL, 0xffffffffffff0000ULL, 0xffffffffffffff00ULL
 };
 
 static const u8 LDR_SHIFT[8] = { 0, 8, 16, 24, 32, 40, 48, 56 };
@@ -797,12 +797,12 @@ void SD()
 }
 
 static const u64 SDL_MASK[8] =
-{	0xffffffffffffff00LL, 0xffffffffffff0000LL, 0xffffffffff000000LL, 0xffffffff00000000LL,
-	0xffffff0000000000LL, 0xffff000000000000LL, 0xff00000000000000LL, 0x0000000000000000LL
+{	0xffffffffffffff00ULL, 0xffffffffffff0000ULL, 0xffffffffff000000ULL, 0xffffffff00000000ULL,
+	0xffffff0000000000ULL, 0xffff000000000000ULL, 0xff00000000000000ULL, 0x0000000000000000ULL
 };
 static const u64 SDR_MASK[8] =
-{	0x0000000000000000LL, 0x00000000000000ffLL, 0x000000000000ffffLL, 0x0000000000ffffffLL,
-	0x00000000ffffffffLL, 0x000000ffffffffffLL, 0x0000ffffffffffffLL, 0x00ffffffffffffffLL
+{	0x0000000000000000ULL, 0x00000000000000ffULL, 0x000000000000ffffULL, 0x0000000000ffffffULL,
+	0x00000000ffffffffULL, 0x000000ffffffffffULL, 0x0000ffffffffffffULL, 0x00ffffffffffffffULL
 };
 
 static const u8 SDL_SHIFT[8] = { 56, 48, 40, 32, 24, 16, 8, 0 };

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -327,7 +327,7 @@ void vtlb_dynarec_init()
 			{
 				xSetPtr( GetIndirectDispatcherPtr( mode, bits, !!sign ) );
 
-				DynGen_IndirectTlbDispatcher( mode, bits, sign );
+				DynGen_IndirectTlbDispatcher( mode, bits, !!sign );
 			}
 		}
 	}

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -184,7 +184,7 @@ namespace ReplaceGL {
 
 	void APIENTRY ViewportIndexedf(GLuint index, GLfloat x, GLfloat y, GLfloat w, GLfloat h)
 	{
-		glViewport(x, y, w, h);
+		glViewport(GLint(x), GLint(y), GLsizei(w), GLsizei(h));
 	}
 }
 

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -163,7 +163,7 @@ void GSDeviceOGL::GenerateProfilerData()
 	double ms       = 0.000001;
 
 	float replay    = (float)(theApp.GetConfigI("linux_replay"));
-	int first_query = (float)m_profiler.last_query / replay;
+	int first_query = static_cast<int>((float)m_profiler.last_query / replay);
 
 	glGetQueryObjectui64v(m_profiler.timer_query[first_query], GL_QUERY_RESULT, &time_start);
 	for (uint32 q = first_query + 1; q < m_profiler.last_query; q++) {
@@ -1658,7 +1658,7 @@ void GSDeviceOGL::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVecto
 	{
 		GLState::viewport = size;
 		// FIXME ViewportIndexedf or ViewportIndexedfv (GL4.1)
-		glViewportIndexedf(0, 0, 0, size.x, size.y);
+		glViewportIndexedf(0, 0, 0, GLfloat(size.x), GLfloat(size.y));
 	}
 
 	GSVector4i r = scissor ? *scissor : GSVector4i(size).zwxy();

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -612,7 +612,7 @@ void GSRendererOGL::EmulateTextureSampler(const GSTextureCache::Source* tex)
 
 	const uint8 wms = m_context->CLAMP.WMS;
 	const uint8 wmt = m_context->CLAMP.WMT;
-	bool complex_wms_wmt = (wms | wmt) & 2;
+	bool complex_wms_wmt = !!((wms | wmt) & 2);
 
 	bool bilinear = m_filter == 2 ? m_vt.IsLinear() : m_filter != 0;
 	bool simple_sample = !tex->m_palette && cpsm.fmt == 0 && !complex_wms_wmt && !psm.depth;
@@ -998,15 +998,15 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 				// Replace all sprite with a single fullscreen sprite.
 				GSVertex* s = &m_vertex.buff[0];
 
-				s[0].XYZ.X = (16.0f * m_vt.m_min.p.x) + m_context->XYOFFSET.OFX;
-				s[1].XYZ.X = (16.0f * m_vt.m_max.p.x) + m_context->XYOFFSET.OFX;
-				s[0].XYZ.Y = (16.0f * m_vt.m_min.p.y) + m_context->XYOFFSET.OFY;
-				s[1].XYZ.Y = (16.0f * m_vt.m_max.p.y) + m_context->XYOFFSET.OFY;
+				s[0].XYZ.X = static_cast<uint16>((16.0f * m_vt.m_min.p.x) + m_context->XYOFFSET.OFX);
+				s[1].XYZ.X = static_cast<uint16>((16.0f * m_vt.m_max.p.x) + m_context->XYOFFSET.OFX);
+				s[0].XYZ.Y = static_cast<uint16>((16.0f * m_vt.m_min.p.y) + m_context->XYOFFSET.OFY);
+				s[1].XYZ.Y = static_cast<uint16>((16.0f * m_vt.m_max.p.y) + m_context->XYOFFSET.OFY);
 
-				s[0].U     = 16.0f * m_vt.m_min.t.x;
-				s[0].V     = 16.0f * m_vt.m_min.t.y;
-				s[1].U     = 16.0f * m_vt.m_max.t.x;
-				s[1].V     = 16.0f * m_vt.m_max.t.y;
+				s[0].U     = static_cast<uint16>(16.0f * m_vt.m_min.t.x);
+				s[0].V     = static_cast<uint16>(16.0f * m_vt.m_min.t.y);
+				s[1].U     = static_cast<uint16>(16.0f * m_vt.m_max.t.x);
+				s[1].V     = static_cast<uint16>(16.0f * m_vt.m_max.t.y);
 
 				m_vertex.head = m_vertex.tail = m_vertex.next = 2;
 				m_index.tail = 2;

--- a/plugins/USBqemu/USB.cpp
+++ b/plugins/USBqemu/USB.cpp
@@ -266,8 +266,8 @@ s32 CALLBACK USBfreeze(int mode, freezeData *data) {
 
 		usbd = *(USBfreezeData*)data->data;
 		usbd.freezeID[9] = 0;
-		usbd.cycles = clocks;
-		usbd.remaining = remaining;
+		usbd.cycles = static_cast<int>(clocks);
+		usbd.remaining = static_cast<int>(remaining);
 		
 		if( strcmp(usbd.freezeID, USBfreezeID) != 0)
 		{

--- a/plugins/USBqemu/qemu-usb/usb-kbd.cpp
+++ b/plugins/USBqemu/qemu-usb/usb-kbd.cpp
@@ -616,7 +616,7 @@ static const uint8_t qemu_keyboard_hid_report_descriptor[] = {
 static int usb_keyboard_poll(USBKeyboardState *s, uint8_t *buf, int len)
 {
 	static unsigned char keys[256];
-    int i,l;
+    int l;
 
     if (!s->keyboard_grabbed) {
 		//qemu_add_keyboard_event_handler(usb_keyboard_event, s, 0);

--- a/plugins/USBqemu/qemu-usb/vl.cpp
+++ b/plugins/USBqemu/qemu-usb/vl.cpp
@@ -25,7 +25,7 @@ uint64_t muldiv64(uint64_t a, uint32_t b, uint32_t c)
     rl = (uint64_t)u.l.low * (uint64_t)b;
     rh = (uint64_t)u.l.high * (uint64_t)b;
     rh += (rl >> 32);
-    res.l.high = rh / c;
+    res.l.high = static_cast<uint32_t>(rh / c);
     res.l.low = (((rh % c) << 32) + (rl & 0xffffffff)) / c;
     return res.ll;
 }

--- a/plugins/cdvdGigaherz/src/SectorConverters.h
+++ b/plugins/cdvdGigaherz/src/SectorConverters.h
@@ -42,11 +42,11 @@ int Convert<2352,2048>(char *dest, const char* psrc, int lsn)
 template<>
 int Convert<2048,2352>(char *dest, const char* psrc, int lsn)
 {
-	int m = lsn / (75*60);
-	int s = (lsn/75) % 60;
-	int f = lsn%75;
-	unsigned char header[16] = {
-		0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,   m,   s,   f,0x02
+	u8 m = lsn / (75*60);
+	u8 s = (lsn/75) % 60;
+	u8 f = lsn%75;
+	u8 header[16] = {
+		0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,m,s,f,0x02
 	};
 
 	memcpy(dest,header,16);

--- a/plugins/dev9ghzdrk/pcap_io.cpp
+++ b/plugins/dev9ghzdrk/pcap_io.cpp
@@ -435,7 +435,7 @@ bool PCAPAdapter::blocks()
 }
 bool PCAPAdapter::isInitialised()
 {
-	return pcap_io_running;
+	return !!pcap_io_running;
 }
 //gets a packet.rv :true success
 bool PCAPAdapter::recv(NetPacket* pkt)


### PR DESCRIPTION
**Summary of changes**:

* Clean up all the implicit conversions , unused variables and narrow conversion warnings on Core and Plugins. Most of the remaining warnings are all on wx side.