### PR TITLE
PCSX2-Counters: Improve video mode detection

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -25,7 +25,7 @@
 #include "CDVD_internal.h"
 #include "CDVDisoReader.h"
 
-#include "GS.h"			// for gsRegionMode
+#include "GS.h"			// for gsVideoMode
 #include "Elfheader.h"
 #include "ps2/BiosTools.h"
 #include "GameDatabase.h"
@@ -958,7 +958,7 @@ u8 monthmap[13] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 void cdvdVsync() {
 	cdvd.RTCcount++;
-	if (cdvd.RTCcount < ((gsRegionMode == Region_NTSC) ? 60 : 50)) return;
+	if (cdvd.RTCcount < ((gsVideoMode == GS_VideoMode::NTSC) ? 60 : 50)) return;
 	cdvd.RTCcount = 0;
 
 	if ( cdvd.Status == CDVD_STATUS_TRAY_OPEN )

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -288,11 +288,6 @@ struct Pcsx2Config
 		bool	FrameSkipEnable;
 		bool	VsyncEnable;
 
-		// The region mode controls the default Maximum/Minimum FPS settings and also
-		// regulates the vsync rates (which in turn control the IOP's SPU2 tick sync and ensure
-		// proper audio playback speed).
-		int		DefaultVideoMode;	// 0=NTSC and 1=PAL
-
 		int		FramesToDraw;	// number of consecutive frames (fields) to render
 		int		FramesToSkip;	// number of consecutive frames (fields) to skip
 
@@ -318,7 +313,6 @@ struct Pcsx2Config
 				OpEqu( FramerateNTSC )			&&
 				OpEqu( FrameratePAL )			&&
 
-				OpEqu( DefaultVideoMode )		&&
 				OpEqu( FramesToDraw )			&&
 				OpEqu( FramesToSkip );
 		}

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -291,7 +291,7 @@ struct Pcsx2Config
 		// The region mode controls the default Maximum/Minimum FPS settings and also
 		// regulates the vsync rates (which in turn control the IOP's SPU2 tick sync and ensure
 		// proper audio playback speed).
-		int		DefaultRegionMode;	// 0=NTSC and 1=PAL
+		int		DefaultVideoMode;	// 0=NTSC and 1=PAL
 
 		int		FramesToDraw;	// number of consecutive frames (fields) to render
 		int		FramesToSkip;	// number of consecutive frames (fields) to skip
@@ -318,7 +318,7 @@ struct Pcsx2Config
 				OpEqu( FramerateNTSC )			&&
 				OpEqu( FrameratePAL )			&&
 
-				OpEqu( DefaultRegionMode )		&&
+				OpEqu( DefaultVideoMode )		&&
 				OpEqu( FramesToDraw )			&&
 				OpEqu( FramesToSkip );
 		}

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -155,9 +155,6 @@ void rcntInit()
 	vsyncCounter.Mode = MODE_VRENDER;
 	vsyncCounter.sCycle = cpuRegs.cycle;
 
-	// Set the video mode to user's default request:
-	gsSetVideoMode( (GS_VideoMode)EmuConfig.GS.DefaultVideoMode );
-
 	for (i=0; i<4; i++) rcntReset(i);
 	cpuRcntSet();
 }

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -156,7 +156,7 @@ void rcntInit()
 	vsyncCounter.sCycle = cpuRegs.cycle;
 
 	// Set the video mode to user's default request:
-	gsSetRegionMode( (GS_RegionMode)EmuConfig.GS.DefaultRegionMode );
+	gsSetVideoMode( (GS_VideoMode)EmuConfig.GS.DefaultVideoMode );
 
 	for (i=0; i<4; i++) rcntReset(i);
 	cpuRcntSet();
@@ -173,7 +173,7 @@ static u64 m_iStart=0;
 struct vSyncTimingInfo
 {
 	Fixed100 Framerate;		// frames per second (8 bit fixed)
-	GS_RegionMode RegionMode; // used to detect change (interlaced/progressive)
+	GS_VideoMode VideoMode; // used to detect change (interlaced/progressive)
 	u32 Render;				// time from vblank end to vblank start (cycles)
 	u32 Blank;				// time from vblank start to vblank end (cycles)
 
@@ -214,7 +214,7 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, Fixed100 framesPerSecond, u32 s
 	u64 hBlank = Scanline / 2;
 	u64 hRender = Scanline - hBlank;
 
-	if (gsRegionMode == Region_NTSC_PROGRESSIVE)
+	if (gsVideoMode == GS_VideoMode::PROGRESSIVE)
 	{
 		hBlank /= 2;
 		hRender /= 2;
@@ -236,7 +236,7 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, Fixed100 framesPerSecond, u32 s
 	else if ((hBlank - info->hBlank) >= 5000) info->hBlank++;
 
 	// Calculate accumulative hSync rounding error per half-frame:
-	if (gsRegionMode != Region_NTSC_PROGRESSIVE) // gets off the chart in that mode
+	if (gsVideoMode != GS_VideoMode::PROGRESSIVE) // gets off the chart in that mode
 	{
 		u32 hSyncCycles = ((info->hRender + info->hBlank) * scansPerFrame) / 2;
 		u32 vSyncCycles = (info->Render + info->Blank);
@@ -262,33 +262,33 @@ u32 UpdateVSyncRate()
 	u32			scanlines = 0;
 	bool		isCustom  = false;
 
-	if( gsRegionMode == Region_PAL )
+	if(gsVideoMode == GS_VideoMode::PAL )
 	{
 		isCustom = (EmuConfig.GS.FrameratePAL != 50.0);
 		framerate = EmuConfig.GS.FrameratePAL / 2;
 		scanlines = SCANLINES_TOTAL_PAL;
 		if (!gsIsInterlaced) scanlines += 3;
 	}
-	else if ( gsRegionMode == Region_NTSC )
+	else if (gsVideoMode == GS_VideoMode::NTSC )
 	{
 		isCustom = (EmuConfig.GS.FramerateNTSC != 59.94);
 		framerate = EmuConfig.GS.FramerateNTSC / 2;
 		scanlines = SCANLINES_TOTAL_NTSC;
 		if (!gsIsInterlaced) scanlines += 1;
 	}
-	else if ( gsRegionMode == Region_NTSC_PROGRESSIVE )
+	else if (gsVideoMode == GS_VideoMode::PROGRESSIVE )
 	{
 		isCustom = (EmuConfig.GS.FramerateNTSC != 59.94);
 		framerate = EmuConfig.GS.FramerateNTSC / 2;
 		scanlines = SCANLINES_TOTAL_NTSC;
 	}
 
-	if (vSyncInfo.Framerate != framerate || vSyncInfo.RegionMode != gsRegionMode)
+	if (vSyncInfo.Framerate != framerate || vSyncInfo.VideoMode != gsVideoMode)
 	{
-		vSyncInfo.RegionMode = gsRegionMode;
+		vSyncInfo.VideoMode = gsVideoMode;
 		vSyncInfoCalc( &vSyncInfo, framerate, scanlines );
-		Console.WriteLn( Color_Green, "(UpdateVSyncRate) Mode Changed to %s.", ( gsRegionMode == Region_PAL ) ? "PAL" : 
-			( gsRegionMode == Region_NTSC ) ? "NTSC" : "NTSC Progressive Scan" );
+		Console.WriteLn( Color_Green, "(UpdateVSyncRate) Mode Changed to %s.", (gsVideoMode == GS_VideoMode::PAL ) ? "PAL" :
+			(gsVideoMode == GS_VideoMode::NTSC ) ? "NTSC" : "NTSC Progressive Scan" );
 		
 		if( isCustom )
 			Console.Indent().WriteLn( Color_StrongGreen, "... with user configured refresh rate: %.02f Hz", 2 * framerate.ToFloat() );

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -33,7 +33,6 @@ void gsOnModeChanged( Fixed100 framerate, u32 newTickrate )
 }
 
 bool gsIsInterlaced	= false;
-GS_VideoMode gsVideoMode = GS_VideoMode::NTSC;
 
 
 void gsSetVideoMode(GS_VideoMode mode )
@@ -157,21 +156,8 @@ __fi void gsWrite8(u32 mem, u8 value)
 
 static void _gsSMODEwrite( u32 mem, u32 value )
 {
-	switch (mem)
-	{
-	case GS_SMODE1:
-		if ( (value & 0x6000) == 0x6000 ) 
-			gsSetVideoMode( GS_VideoMode::PAL );
-		else if (value & 0x400000 || value & 0x200000) 
-			gsSetVideoMode( GS_VideoMode::PROGRESSIVE );
-		else
-			gsSetVideoMode( GS_VideoMode::NTSC );
-		break;
-
-	case GS_SMODE2:
+	if(mem == GS_SMODE2)
 		gsIsInterlaced = (value & 0x1);
-		break;
-	}
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -32,15 +32,15 @@ void gsOnModeChanged( Fixed100 framerate, u32 newTickrate )
 	GetMTGS().SendSimplePacket( GS_RINGTYPE_MODECHANGE, framerate.Raw, newTickrate, 0 );
 }
 
-bool			gsIsInterlaced	= false;
-GS_RegionMode	gsRegionMode	= Region_NTSC;
+bool gsIsInterlaced	= false;
+GS_VideoMode gsVideoMode = GS_VideoMode::NTSC;
 
 
-void gsSetRegionMode( GS_RegionMode region )
+void gsSetVideoMode(GS_VideoMode mode )
 {
-	if( gsRegionMode == region ) return;
+	if( gsVideoMode == mode ) return;
 
-	gsRegionMode = region;
+	gsVideoMode = mode;
 	UpdateVSyncRate();
 }
 
@@ -161,11 +161,11 @@ static void _gsSMODEwrite( u32 mem, u32 value )
 	{
 	case GS_SMODE1:
 		if ( (value & 0x6000) == 0x6000 ) 
-			gsSetRegionMode( Region_PAL );
+			gsSetVideoMode( GS_VideoMode::PAL );
 		else if (value & 0x400000 || value & 0x200000) 
-			gsSetRegionMode( Region_NTSC_PROGRESSIVE );
+			gsSetVideoMode( GS_VideoMode::PROGRESSIVE );
 		else
-			gsSetRegionMode( Region_NTSC );
+			gsSetVideoMode( GS_VideoMode::NTSC );
 		break;
 
 	case GS_SMODE2:
@@ -436,5 +436,5 @@ void gsResetFrameSkip()
 void SaveStateBase::gsFreeze()
 {
 	FreezeMem(PS2MEM_GS, 0x2000);
-	Freeze(gsRegionMode);
+	Freeze(gsVideoMode);
 }

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -219,9 +219,17 @@ struct GSRegSIGBLID
 
 enum class GS_VideoMode : int
 {
+	Uninitialized,
+	Unknown,
 	NTSC,
 	PAL,
-	PROGRESSIVE
+	VESA,
+	HDTV_480P,
+	HDTV_576P,
+	HDTV_720P,
+	HDTV_1080I,
+	HDTV_1080P,
+	BIOS
 };
 
 extern GS_VideoMode gsVideoMode;

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -217,14 +217,14 @@ struct GSRegSIGBLID
 #define GSIMR		((u32&)*(PS2MEM_GS+0x1010))
 #define GSSIGLBLID	((GSRegSIGBLID&)*(PS2MEM_GS+0x1080))
 
-enum GS_RegionMode
+enum class GS_VideoMode : int
 {
-	Region_NTSC,
-	Region_PAL,
-	Region_NTSC_PROGRESSIVE
+	NTSC,
+	PAL,
+	PROGRESSIVE
 };
 
-extern GS_RegionMode gsRegionMode;
+extern GS_VideoMode gsVideoMode;
 
 /////////////////////////////////////////////////////////////////////////////
 // MTGS Threaded Class Declaration
@@ -363,7 +363,7 @@ extern s32 gsOpen();
 extern void gsClose();
 extern void gsReset();
 extern void gsOnModeChanged( Fixed100 framerate, u32 newTickrate );
-extern void gsSetRegionMode( GS_RegionMode isPal );
+extern void gsSetVideoMode( GS_VideoMode mode );
 extern void gsResetFrameSkip();
 extern void gsPostVsyncStart();
 extern void gsFrameSkip();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -206,7 +206,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	DisableOutput			= false;
 	VsyncQueueSize			= 2;
 
-	DefaultRegionMode		= Region_NTSC;
+	DefaultVideoMode		= NTSC;
 	FramesToDraw			= 2;
 	FramesToSkip			= 2;
 
@@ -233,7 +233,7 @@ void Pcsx2Config::GSOptions::LoadSave( IniInterface& ini )
 
 	// WARNING: array must be NULL terminated to compute it size
 	static const wxChar * const ntsc_pal_str[3] =  { L"ntsc", L"pal", NULL };
-	ini.EnumEntry( L"DefaultRegionMode", DefaultRegionMode, ntsc_pal_str, DefaultRegionMode );
+	ini.EnumEntry( L"DefaultRegionMode", DefaultVideoMode, ntsc_pal_str, DefaultVideoMode );
 
 	IniEntry( FramesToDraw );
 	IniEntry( FramesToSkip );

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -206,7 +206,6 @@ Pcsx2Config::GSOptions::GSOptions()
 	DisableOutput			= false;
 	VsyncQueueSize			= 2;
 
-	DefaultVideoMode		= NTSC;
 	FramesToDraw			= 2;
 	FramesToSkip			= 2;
 
@@ -230,10 +229,6 @@ void Pcsx2Config::GSOptions::LoadSave( IniInterface& ini )
 	IniEntry( LimitScalar );
 	IniEntry( FramerateNTSC );
 	IniEntry( FrameratePAL );
-
-	// WARNING: array must be NULL terminated to compute it size
-	static const wxChar * const ntsc_pal_str[3] =  { L"ntsc", L"pal", NULL };
-	ini.EnumEntry( L"DefaultRegionMode", DefaultVideoMode, ntsc_pal_str, DefaultVideoMode );
 
 	IniEntry( FramesToDraw );
 	IniEntry( FramesToSkip );

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -22,7 +22,9 @@
 #include "R5900.h"
 #include "R5900OpcodeTables.h"
 #include "R5900Exceptions.h"
+#include "GS.h"
 
+GS_VideoMode gsVideoMode = GS_VideoMode::Uninitialized;
 
 static __fi bool _add64_Overflow( s64 x, s64 y, s64 &ret )
 {
@@ -886,40 +888,47 @@ void SYSCALL()
 					const char* field = (cpuRegs.GPR.n.a2.UL[0] & 1) ? "FRAME" : "FIELD";
 					std::string mode;
 					// Warning info might be incorrect!
-					switch (cpuRegs.GPR.n.a1.UC[0]) {
-						case 0x2:  mode = "NTSC 640x448 @ 59.940 (59.82)"; break;
+					switch (cpuRegs.GPR.n.a1.UC[0])
+					{
+						case 0x0:
+						case 0x2:
+							mode = "NTSC 640x448 @ 59.940 (59.82)"; gsSetVideoMode(GS_VideoMode::NTSC); break;
 
-						case 0x3:  mode = "PAL  640x512 @ 50.000 (49.76)"; break;
+						case 0x1:
+						case 0x3:
+							mode = "PAL  640x512 @ 50.000 (49.76)"; gsSetVideoMode(GS_VideoMode::PAL); break;
 
-						case 0x1A: mode = "VESA 640x480 @ 59.940"; break;
-						case 0x1B: mode = "VESA 640x480 @ 72.809"; break;
-						case 0x1C: mode = "VESA 640x480 @ 75.000"; break;
-						case 0x1D: mode = "VESA 640x480 @ 85.008"; break;
+						case 0x1A: mode = "VESA 640x480 @ 59.940"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x1B: mode = "VESA 640x480 @ 72.809"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x1C: mode = "VESA 640x480 @ 75.000"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x1D: mode = "VESA 640x480 @ 85.008"; gsSetVideoMode(GS_VideoMode::VESA); break;
 
-						case 0x2A: mode = "VESA 800x600 @ 56.250"; break;
-						case 0x2B: mode = "VESA 800x600 @ 60.317"; break;
-						case 0x2C: mode = "VESA 800x600 @ 72.188"; break;
-						case 0x2D: mode = "VESA 800x600 @ 75.000"; break;
-						case 0x2E: mode = "VESA 800x600 @ 85.061"; break;
+						case 0x2A: mode = "VESA 800x600 @ 56.250"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x2B: mode = "VESA 800x600 @ 60.317"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x2C: mode = "VESA 800x600 @ 72.188"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x2D: mode = "VESA 800x600 @ 75.000"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x2E: mode = "VESA 800x600 @ 85.061"; gsSetVideoMode(GS_VideoMode::VESA); break;
 
-						case 0x3B: mode = "VESA 1024x768 @ 60.004"; break;
-						case 0x3C: mode = "VESA 1024x768 @ 70.069"; break;
-						case 0x3D: mode = "VESA 1024x768 @ 75.029"; break;
-						case 0x3E: mode = "VESA 1024x768 @ 84.997"; break;
+						case 0x3B: mode = "VESA 1024x768 @ 60.004"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x3C: mode = "VESA 1024x768 @ 70.069"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x3D: mode = "VESA 1024x768 @ 75.029"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x3E: mode = "VESA 1024x768 @ 84.997"; gsSetVideoMode(GS_VideoMode::VESA); break;
 
-						case 0x4A: mode = "VESA 1280x1024 @ 63.981"; break;
-						case 0x4B: mode = "VESA 1280x1024 @ 79.976"; break;
+						case 0x4A: mode = "VESA 1280x1024 @ 63.981"; gsSetVideoMode(GS_VideoMode::VESA); break;
+						case 0x4B: mode = "VESA 1280x1024 @ 79.976"; gsSetVideoMode(GS_VideoMode::VESA); break;
 
-						case 0x50: mode = "HDTV   720x480 @ 59.94"; break;
-						case 0x51: mode = "HDTV 1920x1080 @ 60.00"; break;
-						case 0x52: mode = "HDTV  1280x720 @ ??.???"; break;
-						case 0x53: mode = "HDTV   768x576 @ ??.???"; break;
-						case 0x54: mode = "HDTV 1920x1080 @ ??.???"; break;
+						case 0x50: mode = "HDTV   720x480 @ 59.94"; gsSetVideoMode(GS_VideoMode::HDTV_480P); break;
+						case 0x51: mode = "HDTV 1920x1080 @ 60.00"; gsSetVideoMode(GS_VideoMode::HDTV_1080I); break;
+						case 0x52: mode = "HDTV  1280x720 @ ??.???"; gsSetVideoMode(GS_VideoMode::HDTV_720P); break;
+						case 0x53: mode = "HDTV   768x576 @ ??.???"; gsSetVideoMode(GS_VideoMode::HDTV_576P); break;
+						case 0x54: mode = "HDTV 1920x1080 @ ??.???"; gsSetVideoMode(GS_VideoMode::HDTV_1080P); break;
 
-						case 0x72: mode = "DVD NTSC 640x448 @ ??.???"; break;
-						case 0x73: mode = "DVD PAL/480P 720x480 @ ??.???"; break;
+						case 0x72: mode = "DVD NTSC 640x448 @ ??.???"; gsSetVideoMode(GS_VideoMode::BIOS); break;
+						case 0x73: mode = "DVD PAL 720x480 @ ??.???"; gsSetVideoMode(GS_VideoMode::BIOS); break;
 
-						default: Console.Error("Mode %x is not supported. Report me upstream", cpuRegs.GPR.n.a1.UC[0]);
+						default:
+							Console.Error("Mode %x is not supported. Report me upstream", cpuRegs.GPR.n.a1.UC[0]);
+							gsSetVideoMode(GS_VideoMode::Unknown);
 					}
 					Console.Warning("Set GS CRTC configuration. Interlace %s. Field Type %s. Mode %s", inter, field, mode.c_str());
 				}

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -927,10 +927,10 @@ void SYSCALL()
 						case 0x73: mode = "DVD PAL 720x480 @ ??.???"; gsSetVideoMode(GS_VideoMode::BIOS); break;
 
 						default:
-							Console.Error("Mode %x is not supported. Report me upstream", cpuRegs.GPR.n.a1.UC[0]);
+							DevCon.Error("Mode %x is not supported. Report me upstream", cpuRegs.GPR.n.a1.UC[0]);
 							gsSetVideoMode(GS_VideoMode::Unknown);
 					}
-					Console.Warning("Set GS CRTC configuration. Interlace %s. Field Type %s. Mode %s", inter, field, mode.c_str());
+					DevCon.Warning("Set GS CRTC configuration. Interlace %s. Field Type %s. Mode %s", inter, field, mode.c_str());
 				}
 				break;
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -591,8 +591,8 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 	AppConfig::UiTemplateOptions& templates = g_Conf->Templates;
 
 	double fps = wxGetApp().FpsManager.GetFramerate();
-	// The "not PAL" case covers both Region_NTSC and Region_NTSC_PROGRESSIVE
-	float per = gsRegionMode == Region_PAL ? (fps * 100) / EmuConfig.GS.FrameratePAL.ToFloat() : (fps * 100) / EmuConfig.GS.FramerateNTSC.ToFloat();
+	// The "not PAL" case covers both NTSC and Progressive
+	float per = gsVideoMode == GS_VideoMode::PAL ? (fps * 100) / EmuConfig.GS.FrameratePAL.ToFloat() : (fps * 100) / EmuConfig.GS.FramerateNTSC.ToFloat();
 
 	char gsDest[128];
 	gsDest[0] = 0; // No need to set whole array to NULL.


### PR DESCRIPTION
**Summary of Changes**:

*  The detected values using the SMODE registers were for the video modes and not the region of the game, changed the variable naming to video modes to prevent any confusions.
* Convert GS_VideMode into an enum class
* Move VideoMode init code from _gsSMODEwrite to SYSCALL
* Fix a bug where 1080I was reported as progressive
* Fix a bug where NTSC VideoMode was automatically used when videomode is uninitialized. the bug was only temporary till the SMODE register was written (or) till the SYSCALL was executed for the new code.
* EE-SYSCALL: Move messages back to dev/verbose level