### PR TITLE
GameDB: Kessen 2 refraction patch (NTSC-J/NTSC-K)

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -21305,6 +21305,14 @@ GoemonTlbHack = 1
 Serial = SLPM-65015
 Name   = Kessen 2
 Region = NTSC-J
+[patches = 7C012435]
+	comment=COP2 flag instance patch by refraction
+	// a mac flag check just after a vsub which gets in the way, rearranging
+	patch=0,EE,00170F20,word,48438800
+	patch=0,EE,00170F24,word,4BE521AC
+	patch=0,EE,00170F28,word,30848000
+	patch=0,EE,00170F2C,word,4BE72B3C
+[/patches]
 ---------------------------------------------
 Serial = SLPM-65016
 Name   = Love Songs [Limited Edition]
@@ -28479,6 +28487,14 @@ Region = NTSC-K
 Serial = SLPM-67531
 Name   = Kessen 2
 Region = NTSC-K
+[patches = 46CFF455]
+	comment=COP2 flag instance patch by refraction
+	// a mac flag check just after a vsub which gets in the way, rearranging
+	patch=0,EE,00170F20,word,48438800
+	patch=0,EE,00170F24,word,4BE521AC
+	patch=0,EE,00170F28,word,30848000
+	patch=0,EE,00170F2C,word,4BE72B3C
+[/patches]
 ---------------------------------------------
 Serial = SLPM-67535
 Name   = Memories Of


### PR DESCRIPTION
Apply the refraction patch for Kessen 2 NTSC-J/NTSC-K releases.