### PR TITLE
Zero out the skip bp

### DIFF
--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -619,6 +619,7 @@ void DisassemblyDialog::setDebugMode(bool debugMode, bool switchPC)
 				if (currentCpu != NULL)
 					currentCpu->getDisassembly()->SetFocus();
 				CBreakPoints::SetBreakpointTriggered(false);
+				CBreakPoints::SetSkipFirst(0);
 			}
 
 			if (currentCpu != NULL)


### PR DESCRIPTION
Fixes #1453
Reset skip bp on breakpoint hit as it is invalid otherwise