### PR TITLE
x86_intrin.h: fix build using GCC

### DIFF
--- a/common/include/x86emitter/x86_intrin.h
+++ b/common/include/x86emitter/x86_intrin.h
@@ -16,7 +16,7 @@
 #pragma once
 
 // Because nobody can't agree on a single name !
-#if defined(__GNUG__)
+#if defined(__GNUC__)
 
 // Yes there are several files for the same features!
 // x86intrin.h which is the general include provided by the compiler


### PR DESCRIPTION
```__GNUG__``` is not defined while compiling this file, this causes the build to fail. Replacing this with ```__GNUC__``` fixes this.

Fixes #1467
