### PR TITLE
GSDX-TextureCache: Add proper rounding when unscaling texture size

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1738,8 +1738,11 @@ void GSTextureCache::Target::Update()
 
 	GSVector2i t_size = m_texture->GetSize();
 	GSVector2 t_scale = m_texture->GetScale();
-	t_size.x = (int)((float)t_size.x/max(1.0f, t_scale.x));
-	t_size.y = (int)((float)t_size.y/max(1.0f, t_scale.y));
+
+	//Avoids division by zero when calculating texture size.
+	t_scale = GSVector2(max(1.0f, t_scale.x), max(1.0f, t_scale.y));
+	t_size.x = lround(static_cast<float>(t_size.x) / t_scale.x);
+	t_size.y = lround(static_cast<float>(t_size.y) / t_scale.y);
 
 	// Don't load above the GS memory
 	int max_y_blocks = (MAX_BLOCKS - m_TEX0.TBP0) / max(1u, m_TEX0.TBW);


### PR DESCRIPTION
**Summary of changes**:

* Add proper rounding when unscaling texture size.

**Master Branch**:
[![gsdx_20160726181803.md.png](http://ultraimg.com/images/2016/07/26/gsdx_20160726181803.md.png)](http://ultraimg.com/image/1Acr)

**Pull Request Branch**:
[![gsdx_20160726181937.md.png](http://ultraimg.com/images/2016/07/26/gsdx_20160726181937.md.png)](http://ultraimg.com/image/1AcJ)

Seems to fix flickering/graphical issues at Dragon Ball Z Budokai Tenkaichi FMV's on custom resolution. Might also help prevent some crashes on custom resolution. I couldn't seem to reproduce crashes on ICO with the commit.

@ramapcsx2  @FlatOutPS2 
Could you test whether all the crashing issues are resolved ? I tested the code only for some time.