### PR TITLE
Strict aliasing

### DIFF
--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -9,7 +9,6 @@ endif(NOT TOP_CMAKE_WAS_SOURCED)
 set(Output Utilities)
 
 set(CommonFlags
-	-fno-strict-aliasing
     )
 
 set(UtilitiesFinalFlags ${CommonFlags})

--- a/common/src/x86emitter/CMakeLists.txt
+++ b/common/src/x86emitter/CMakeLists.txt
@@ -9,7 +9,6 @@ endif(NOT TOP_CMAKE_WAS_SOURCED)
 set(Output x86emitter)
 
 set(CommonFlags
-	-fno-strict-aliasing
     )
 
 set(x86emitterFinalFlags ${CommonFlags})

--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -11,7 +11,6 @@ set(Output GSdx)
 
 set(CommonFlags
     -fno-operator-names # because Xbyak uses and()/xor()/or()/not() function
-    -fno-strict-aliasing
     -Wno-unknown-pragmas
     -Wno-parentheses
     -Wunused-variable # __dummy variable need to be investigated

--- a/plugins/GSdx/GSDevice.h
+++ b/plugins/GSdx/GSDevice.h
@@ -152,7 +152,7 @@ public:
 
 	virtual void ClearRenderTarget(GSTexture* t, const GSVector4& c) {}
 	virtual void ClearRenderTarget(GSTexture* t, uint32 c) {}
-	virtual void ClearDepth(GSTexture* t, float c) {}
+	virtual void ClearDepth(GSTexture* t) {}
 	virtual void ClearStencil(GSTexture* t, uint8 c) {}
 
 	virtual GSTexture* CreateRenderTarget(int w, int h, bool msaa, int format = 0);

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -466,10 +466,10 @@ void GSDevice11::ClearRenderTarget(GSTexture* t, uint32 c)
 	m_ctx->ClearRenderTargetView(*(GSTexture11*)t, color.v);
 }
 
-void GSDevice11::ClearDepth(GSTexture* t, float c)
+void GSDevice11::ClearDepth(GSTexture* t)
 {
 	if (!t) return;
-	m_ctx->ClearDepthStencilView(*(GSTexture11*)t, D3D11_CLEAR_DEPTH, c, 0);
+	m_ctx->ClearDepthStencilView(*(GSTexture11*)t, D3D11_CLEAR_DEPTH, 0.0f, 0);
 }
 
 void GSDevice11::ClearStencil(GSTexture* t, uint8 c)
@@ -536,7 +536,7 @@ GSTexture* GSDevice11::CreateSurface(int type, int w, int h, bool msaa, int form
 			ClearRenderTarget(t, 0);
 			break;
 		case GSTexture::DepthStencil:
-			ClearDepth(t, 0);
+			ClearDepth(t);
 			break;
 		}
 	}

--- a/plugins/GSdx/GSDevice11.h
+++ b/plugins/GSdx/GSDevice11.h
@@ -175,7 +175,7 @@ public:
 
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c);
 	void ClearRenderTarget(GSTexture* t, uint32 c);
-	void ClearDepth(GSTexture* t, float c);
+	void ClearDepth(GSTexture* t);
 	void ClearStencil(GSTexture* t, uint8 c);
 
 	GSTexture* CreateRenderTarget(int w, int h, bool msaa, int format = 0);

--- a/plugins/GSdx/GSDevice9.cpp
+++ b/plugins/GSdx/GSDevice9.cpp
@@ -668,13 +668,13 @@ void GSDevice9::ClearRenderTarget(GSTexture* rt, uint32 c)
 	m_dev->SetRenderTarget(0, surface);
 }
 
-void GSDevice9::ClearDepth(GSTexture* t, float c)
+void GSDevice9::ClearDepth(GSTexture* t)
 {
 	if (!t) return;
 	CComPtr<IDirect3DSurface9> dssurface;
 	m_dev->GetDepthStencilSurface(&dssurface);
 	m_dev->SetDepthStencilSurface(*(GSTexture9*)t);
-	m_dev->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, c, 0);
+	m_dev->Clear(0, NULL, D3DCLEAR_ZBUFFER, 0, 0.0f, 0);
 	m_dev->SetDepthStencilSurface(dssurface);
 }
 
@@ -739,7 +739,7 @@ GSTexture* GSDevice9::CreateSurface(int type, int w, int h, bool msaa, int forma
 			ClearRenderTarget(t, 0);
 			break;
 		case GSTexture::DepthStencil:
-			ClearDepth(t, 0);
+			ClearDepth(t);
 			break;
 		}
 	}

--- a/plugins/GSdx/GSDevice9.h
+++ b/plugins/GSdx/GSDevice9.h
@@ -199,7 +199,7 @@ public:
 
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c);
 	void ClearRenderTarget(GSTexture* t, uint32 c);
-	void ClearDepth(GSTexture* t, float c);
+	void ClearDepth(GSTexture* t);
 	void ClearStencil(GSTexture* t, uint8 c);
 
 	GSTexture* CreateRenderTarget(int w, int h, bool msaa, int format = 0);

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -229,7 +229,7 @@ GSTexture* GSDeviceOGL::CreateSurface(int type, int w, int h, bool msaa, int fmt
 				ClearRenderTarget(t, 0);
 				break;
 			case GSTexture::DepthStencil:
-				ClearDepth(t, 0);
+				ClearDepth(t);
 				// No need to clear the stencil now.
 				break;
 		}
@@ -251,7 +251,7 @@ GSTexture* GSDeviceOGL::FetchSurface(int type, int w, int h, bool msaa, int form
 				ClearRenderTarget(t, 0);
 				break;
 			case GSTexture::DepthStencil:
-				ClearDepth(t, 0);
+				ClearDepth(t);
 				// No need to clear the stencil now.
 				break;
 			case GSTexture::Texture:
@@ -733,7 +733,7 @@ void GSDeviceOGL::ClearRenderTarget_i(GSTexture* t, int32 c)
 	}
 }
 
-void GSDeviceOGL::ClearDepth(GSTexture* t, float c)
+void GSDeviceOGL::ClearDepth(GSTexture* t)
 {
 	if (!t) return;
 
@@ -750,7 +750,6 @@ void GSDeviceOGL::ClearDepth(GSTexture* t, float c)
 		// Let's disable this code for the moment.
 
 		// Don't bother with Depth_Stencil insanity
-		ASSERT(c == 0.0f);
 		T->Clear(NULL);
 	} else {
 		OMSetFBO(m_fbo);
@@ -761,6 +760,7 @@ void GSDeviceOGL::ClearDepth(GSTexture* t, float c)
 
 		// TODO: check size of scissor before toggling it
 		glDisable(GL_SCISSOR_TEST);
+		float c = 0.0f;
 		if (GLState::depth_mask) {
 			glClearBufferfv(GL_DEPTH, 0, &c);
 		} else {

--- a/plugins/GSdx/GSDeviceOGL.h
+++ b/plugins/GSdx/GSDeviceOGL.h
@@ -516,7 +516,7 @@ public:
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c) final;
 	void ClearRenderTarget(GSTexture* t, uint32 c) final;
 	void ClearRenderTarget_i(GSTexture* t, int32 c);
-	void ClearDepth(GSTexture* t, float c) final;
+	void ClearDepth(GSTexture* t) final;
 	void ClearStencil(GSTexture* t, uint8 c) final;
 
 	GSTexture* CreateRenderTarget(int w, int h, bool msaa, int format = 0) final;

--- a/plugins/GSdx/GSDeviceSW.cpp
+++ b/plugins/GSdx/GSDeviceSW.cpp
@@ -80,9 +80,9 @@ void GSDeviceSW::ClearRenderTarget(GSTexture* t, uint32 c)
 	Clear(t, c);
 }
 
-void GSDeviceSW::ClearDepth(GSTexture* t, float c)
+void GSDeviceSW::ClearDepth(GSTexture* t)
 {
-	Clear(t, *(uint32*)&c);
+	Clear(t, 0);
 }
 
 void GSDeviceSW::ClearStencil(GSTexture* t, uint8 c)

--- a/plugins/GSdx/GSDeviceSW.h
+++ b/plugins/GSdx/GSDeviceSW.h
@@ -47,7 +47,7 @@ public:
 
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c);
 	void ClearRenderTarget(GSTexture* t, uint32 c);
-	void ClearDepth(GSTexture* t, float c);
+	void ClearDepth(GSTexture* t);
 	void ClearStencil(GSTexture* t, uint8 c);
 
 	GSTexture* CopyOffscreen(GSTexture* src, const GSVector4& sRect, int w, int h, int format = 0, int ps_shader = 0);

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -860,7 +860,7 @@ bool GSRendererHW::OI_DoubleHalfClear(GSTexture* rt, GSTexture* ds, GSTextureCac
 		if (half <= (base + h_pages * m_context->FRAME.FBW)) {
 			//GL_INS("OI_DoubleHalfClear: base %x half %x. h_pages %d fbw %d", base, half, h_pages, m_context->FRAME.FBW);
 			if (m_context->FRAME.FBP > m_context->ZBUF.ZBP) {
-				m_dev->ClearDepth(ds, 0);
+				m_dev->ClearDepth(ds);
 			} else {
 				m_dev->ClearRenderTarget(rt, 0);
 			}
@@ -1095,7 +1095,7 @@ bool GSRendererHW::OI_FFX(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* 
 	{
 		// random battle transition (z buffer written directly, clear it now)
 
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 	}
 
 	return true;
@@ -1144,7 +1144,7 @@ bool GSRendererHW::OI_GodOfWar2(GSTexture* rt, GSTexture* ds, GSTextureCache::So
 
 		if(GSTextureCache::Target* tmp_ds = m_tc->LookupTarget(TEX0, m_width, m_height, GSTextureCache::DepthStencil, true))
 		{
-			m_dev->ClearDepth(tmp_ds->m_texture, 0);
+			m_dev->ClearDepth(tmp_ds->m_texture);
 		}
 
 		return false;
@@ -1166,7 +1166,7 @@ bool GSRendererHW::OI_SimpsonsGame(GSTexture* rt, GSTexture* ds, GSTextureCache:
 
 		// TODO: tony hawk pro skater 4 same problem, the empty half is not visible though, painted over fully
 
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 
 		return false;
 	}
@@ -1210,7 +1210,7 @@ bool GSRendererHW::OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTex
 
 			if(GSTextureCache::Target* tmp_ds = m_tc->LookupTarget(TEX0, m_width, m_height, GSTextureCache::DepthStencil, true))
 			{
-				m_dev->ClearDepth(tmp_ds->m_texture, 0);
+				m_dev->ClearDepth(tmp_ds->m_texture);
 			}
 
 			return false;
@@ -1228,7 +1228,7 @@ bool GSRendererHW::OI_SpidermanWoS(GSTexture* rt, GSTexture* ds, GSTextureCache:
 	if((FBP == 0x025a0 || FBP == 0x02800) && FPSM == PSM_PSMCT32)	//0x2800 pal, 0x25a0 ntsc
 	{
 		//only top half of the screen clears
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 	}
 
 	return true;
@@ -1242,7 +1242,7 @@ bool GSRendererHW::OI_TyTasmanianTiger(GSTexture* rt, GSTexture* ds, GSTextureCa
 	if((FBP == 0x02800 || FBP == 0x02BC0) && FPSM == PSM_PSMCT24)	//0x2800 pal, 0x2bc0 ntsc
 	{
 		//half height buffer clear
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 
 		return false;
 	}
@@ -1260,7 +1260,7 @@ bool GSRendererHW::OI_DigimonRumbleArena2(GSTexture* rt, GSTexture* ds, GSTextur
 		if((FBP == 0x02300 || FBP == 0x03fc0) && FPSM == PSM_PSMCT32)
 		{
 			//half height buffer clear
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 		}
 	}
 
@@ -1275,7 +1275,7 @@ bool GSRendererHW::OI_BlackHawkDown(GSTexture* rt, GSTexture* ds, GSTextureCache
 	if(FBP == 0x02000 && FPSM == PSM_PSMZ24)
 	{
 		//half height buffer clear
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 
 		return false;
 	}
@@ -1292,7 +1292,7 @@ bool GSRendererHW::OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTex
 	{
 		if(FPSM == PSM_PSMCT24 && FBP == 0x2bc0)
 		{
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 
 			return false;
 		}
@@ -1301,7 +1301,7 @@ bool GSRendererHW::OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTex
 	{
 		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_max.p.z == 0))
 		{
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 		}
 	}
 
@@ -1316,7 +1316,7 @@ bool GSRendererHW::OI_XmenOriginsWolverine(GSTexture* rt, GSTexture* ds, GSTextu
 	if(FBP == 0x0 && FPSM == PSM_PSMCT16)
 	{
 		//half height buffer clear
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 	}
 
 	return true;
@@ -1330,7 +1330,7 @@ bool GSRendererHW::OI_CallofDutyFinalFronts(GSTexture* rt, GSTexture* ds, GSText
 	if(FBP == 0x02300 && FPSM == PSM_PSMZ24)
 	{
 		//half height buffer clear
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 
 		return false;
 	}
@@ -1348,7 +1348,7 @@ bool GSRendererHW::OI_SpyroNewBeginning(GSTexture* rt, GSTexture* ds, GSTextureC
 		if(FPSM == PSM_PSMCT24 && (FBP == 0x02800 || FBP == 0x02bc0))	//0x2800 pal, 0x2bc0 ntsc
 		{
 			//half height buffer clear
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 
 			return false;
 		}
@@ -1357,7 +1357,7 @@ bool GSRendererHW::OI_SpyroNewBeginning(GSTexture* rt, GSTexture* ds, GSTextureC
 	{
 		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_min.p.z == 0))
 		{
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 		}
 	}
 
@@ -1374,7 +1374,7 @@ bool GSRendererHW::OI_SpyroEternalNight(GSTexture* rt, GSTexture* ds, GSTextureC
 		if(FPSM == PSM_PSMCT24 && FBP == 0x2bc0)
 		{
 			//half height buffer clear
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 
 			return false;
 		}
@@ -1383,7 +1383,7 @@ bool GSRendererHW::OI_SpyroEternalNight(GSTexture* rt, GSTexture* ds, GSTextureC
 	{
 		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_min.p.z == 0))
 		{
-			m_dev->ClearDepth(ds, 0);
+			m_dev->ClearDepth(ds);
 		}
 	}
 
@@ -1398,7 +1398,7 @@ bool GSRendererHW::OI_TalesOfLegendia(GSTexture* rt, GSTexture* ds, GSTextureCac
 	if (FPSM == PSM_PSMCT32 && FBP == 0x01c00 && !m_context->TEST.ATE && m_vt.m_eq.z)
 	{
 		m_context->TEST.ZTST = ZTST_ALWAYS;
-		//m_dev->ClearDepth(ds, 0);
+		//m_dev->ClearDepth(ds);
 	}
 
 	return true;
@@ -1421,7 +1421,7 @@ bool GSRendererHW::OI_SMTNocturne(GSTexture* rt, GSTexture* ds, GSTextureCache::
 		TEX0.PSM = FPSM;
 		if (GSTextureCache::Target* tmp_ds = m_tc->LookupTarget(TEX0, m_width, m_height, GSTextureCache::DepthStencil, true))
 		{
-			m_dev->ClearDepth(tmp_ds->m_texture, 0);
+			m_dev->ClearDepth(tmp_ds->m_texture);
 		}
 		return false;
 	}
@@ -1540,7 +1540,7 @@ bool GSRendererHW::OI_ArTonelico2(GSTexture* rt, GSTexture* ds, GSTextureCache::
 
 	if (m_vertex.next == 2 && !PRIM->TME && m_context->FRAME.FBW == 10 && v->XYZ.Z == 0 && m_context->TEST.ZTST == ZTST_ALWAYS) {
 		GL_INS("OI_ArTonelico2");
-		m_dev->ClearDepth(ds, 0);
+		m_dev->ClearDepth(ds);
 	}
 
 	return true;

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -463,7 +463,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 #ifdef ENABLE_OGL_DEBUG
 				switch (type) {
 					case RenderTarget: m_renderer->m_dev->ClearRenderTarget(dst->m_texture, 0); break;
-					case DepthStencil: m_renderer->m_dev->ClearDepth(dst->m_texture, 0); break;
+					case DepthStencil: m_renderer->m_dev->ClearDepth(dst->m_texture); break;
 					default:break;
 				}
 #endif
@@ -1771,7 +1771,7 @@ void GSTextureCache::Target::Update()
 		GL_INS("ERROR: Update DepthStencil dummy");
 
 		if((m_renderer->m_game.flags & CRC::ZWriteMustNotClear) == 0)
-			m_renderer->m_dev->ClearDepth(m_texture, 0);
+			m_renderer->m_dev->ClearDepth(m_texture);
 
 		return;
 	} else if (m_type == DepthStencil && m_renderer->m_game.title == CRC::FFX2) {
@@ -1784,7 +1784,7 @@ void GSTextureCache::Target::Update()
 		// could be a gsdx transfer bug too due to unaligned-page transfer.
 		//
 		// So the quick and dirty solution is just to clean the depth buffer.
-		m_renderer->m_dev->ClearDepth(m_texture, 0);
+		m_renderer->m_dev->ClearDepth(m_texture);
 		return;
 	}
 


### PR DESCRIPTION
Severals fixes of the C++ strict aliasing rules.

Allow to enable more GCC optimization on common/x86emitter/GSdx.

Unfortunately the core uses aliasing everywhere.