### PR TITLE
GSDX: Silence an implicit conversion warning

### DIFF
--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -567,7 +567,7 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 
 		if (accumulation_blend) {
 			// Keep HW blending to do the addition/subtraction
-			dev->OMSetBlendState(blend_index, 0.0f, false, true);
+			dev->OMSetBlendState(blend_index, 0, false, true);
 			if (ALPHA.A == 2) {
 				// The blend unit does a reverse subtraction so it means
 				// the shader must output a positive value.


### PR DESCRIPTION
**Summary of changes**

* Don't explicitly cast 0 to float as ``OMSetBlendState()`` doesn't accept a float argument.

Don't really care much about the warning, it was just annoying me as it kept popping up all the time I rebuild GSdx plugin.