### PR TITLE
GSDX-TextureCache: Port Half pixel offset hack for custom resolutions

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1329,6 +1329,14 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		{
 			switch(m_renderer->GetUpscaleMultiplier())
 			{
+			case 0: //Custom Resolution
+			{
+				const float offset = 0.2f;
+				modx = dst->m_texture->GetScale().x + offset;
+				mody = dst->m_texture->GetScale().y + offset;
+				dst->m_texture->LikelyOffset = true;
+				break;
+			}
 			case 2:  modx = 2.2f; mody = 2.2f; dst->m_texture->LikelyOffset = true;  break;
 			case 3:  modx = 3.1f; mody = 3.1f; dst->m_texture->LikelyOffset = true;  break;
 			case 4:  modx = 4.2f; mody = 4.2f; dst->m_texture->LikelyOffset = true;  break;


### PR DESCRIPTION
**Summary of changes**:

* Add Half-Pixel Offset for custom resolutions, seems to help with blurring issue on ICO.

**Master Branch**: ``Custom resolution (3096x3096) with Half pixel offset enabled``

![blur_my_eyes](http://i.imgur.com/4ZnpWUA.jpg)

**Pull Request Branch**: ``Custom resolution (3096x3096) with Half pixel offset enabled``

![Try_to_avoid_blur](http://i.imgur.com/aKkGZEI.jpg)

@FlatOutPS2 
Could you check whether it works as good as HPO on native scaling resolutions ?