### PR TITLE
PCSX2-WX: Add a mild overclock option on the slider

### DIFF
--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -46,12 +46,17 @@ const wxChar* Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
 		case 1:
 		{
 			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"1 - Increases the EE's cyclerate to about 180%. Increases hardware requirements, may increase in-game FPS.");
+			return pxEt(L"1 - Increases the EE's cyclerate to about 130%. Mildly increases hardware requirements, may increase in-game FPS.");
 		}
 		case 2:
 		{
 			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"2 - Increases the EE's cyclerate to about 300%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT.");
+			return pxEt(L"2 - Increases the EE's cyclerate to about 180%. Increases hardware requirements, may noticeably increase in-game FPS.");
+		}
+		case 3:
+		{
+			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
+			return pxEt(L"3 - Increases the EE's cyclerate to about 300%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT.");
 		}
 		default:
 			break;
@@ -131,7 +136,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 
 	m_eeSliderPanel = new wxPanelWithHelpers( left, wxVERTICAL, _("EE Cyclerate [Not Recommended]") );
 
-	m_slider_eecycle = new wxSlider( m_eeSliderPanel, wxID_ANY, 0, -3, 2,
+	m_slider_eecycle = new wxSlider( m_eeSliderPanel, wxID_ANY, 0, -3, 3,
 		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
 
 	m_msg_eecycle = new pxStaticHeading( m_eeSliderPanel );

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -35,12 +35,13 @@ const wxChar* Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
 		}
 		case -1:
 		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Dark Green"));
+			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
 			return pxEt(L"-1 - Reduces the EE's cyclerate to about 75%.  Mild speedup for most games with high compatibility.");
 		}
 		case 0:
 		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Forest Green")); // Dark Green
+			const wxColour DarkSeaGreen = wxColour(14, 158, 19);
+			m_msg_eecycle->SetForegroundColour(DarkSeaGreen);
 			return pxEt(L"0 - Default cyclerate (100%). This closely matches the actual speed of a real PS2 EmotionEngine.");
 		}
 		case 1:
@@ -71,7 +72,8 @@ const wxChar* Panels::SpeedHacksPanel::GetVUcycleSliderMsg( int val )
 	{
 		case 0:
 		{
-			m_msg_vustealer->SetForegroundColour(wxColour(14,158,19)); // Dark Green
+			const wxColour DarkSeaGreen = wxColour(14, 158, 19);
+			m_msg_vustealer->SetForegroundColour(DarkSeaGreen);
 			return pxEt(L"0 - Disables VU Cycle Stealing.  Most compatible setting!");
 		}
 		case 1:

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -964,11 +964,14 @@ static u32 scaleblockcycles_calculation()
 	s8 cyclerate = EmuConfig.Speedhacks.EECycleRate;
 	u32 scale_cycles = 0;
 
-	if (cyclerate == 0 || lowcycles || cyclerate < -99 || cyclerate > 2)
+	if (cyclerate == 0 || lowcycles || cyclerate < -99 || cyclerate > 3)
 		scale_cycles = DEFAULT_SCALED_BLOCKS();
 
-	else if (cyclerate > 0)
-		scale_cycles = s_nBlockCycles >> (3 + cyclerate);
+	else if (cyclerate > 1)
+		scale_cycles = s_nBlockCycles >> (2 + cyclerate);
+
+	else if (cyclerate == 1)
+		scale_cycles = DEFAULT_SCALED_BLOCKS() / 1.3f; // Adds a mild 30% increase in clockspeed for value 1.
 
 	else if (cyclerate == -1)  // the mildest value which is also used by the "balanced" preset.
 		// These values were manually tuned to yield mild speedup with high compatibility

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -569,7 +569,7 @@ static __aligned16 u8 manual_counter[Ps2MemSize::MainRam >> 12];
 static std::atomic<bool> eeRecIsReset(false);
 static std::atomic<bool> eeRecNeedsReset(false);
 static bool eeCpuExecuting = false;
-static int g_resetEeScalingStats = 0;
+static bool g_resetEeScalingStats = false;
 static int g_patchesNeedRedo = 0;
 
 ////////////////////////////////////////////////////
@@ -606,8 +606,7 @@ static void recResetRaw()
 	recConstBufPtr = recConstBuf;
 
 	g_branch = 0;
-	g_resetEeScalingStats = 1;
-
+	g_resetEeScalingStats = true;
 	g_patchesNeedRedo = 1;
 }
 
@@ -957,16 +956,16 @@ void iFlushCall(int flushtype)
 // s_nBlockCycles is 3 bit fixed point.  Divide by 8 when done!
 // Scaling blocks under 40 cycles seems to produce countless problem, so let's try to avoid them.
 
-#define DEFAULT_SCALING_UNSANITIZED() (s_nBlockCycles >> 3)  /* unsanitized sinec we don't check if 0 */
+#define DEFAULT_SCALED_BLOCKS() (s_nBlockCycles >> 3)
 
-static u32 scaleblockcycles_calc()
+static u32 scaleblockcycles_calculation()
 {
 	bool lowcycles = (s_nBlockCycles <= 40);
 	s8 cyclerate = EmuConfig.Speedhacks.EECycleRate;
 	u32 scale_cycles = 0;
 
 	if (cyclerate == 0 || lowcycles || cyclerate < -99 || cyclerate > 2)
-		scale_cycles = DEFAULT_SCALING_UNSANITIZED(); // Default cycle rate, could be 0
+		scale_cycles = DEFAULT_SCALED_BLOCKS();
 
 	else if (cyclerate > 0)
 		scale_cycles = s_nBlockCycles >> (3 + cyclerate);
@@ -982,24 +981,26 @@ static u32 scaleblockcycles_calc()
 	return (scale_cycles < 1) ? 1 : scale_cycles;
 }
 
-static u32 scaleblockcycles() {
-	u32 scaled = scaleblockcycles_calc();
+static u32 scaleblockcycles()
+{
+	u32 scaled = scaleblockcycles_calculation();
 
-#if 0 /* Enable this to get some runtime statistics about the scaling result in practuce */
-	static u32 scaled_overal = 0, unscaled_overal = 0;
-	if (g_resetEeScalingStats) {
-		scaled_overal = unscaled_overal = 0;
-		g_resetEeScalingStats = 0;
+#if 0 // Enable this to get some runtime statistics about the scaling result in practice
+	static u32 scaled_overall = 0, unscaled_overall = 0;
+	if (g_resetEeScalingStats)
+	{
+		scaled_overall = unscaled_overall = 0;
+		g_resetEeScalingStats = false;
 	}
-	u32 unscaled = DEFAULT_SCALING_UNSANITIZED();
+	u32 unscaled = DEFAULT_SCALED_BLOCKS();
 	if (!unscaled) unscaled = 1;
 
-	scaled_overal += scaled;
-	unscaled_overal += unscaled;
-	float ratio = (float)unscaled_overal / scaled_overal;
+	scaled_overall += scaled;
+	unscaled_overall += unscaled;
+	float ratio = static_cast<float>(unscaled_overall) / scaled_overall;
 
-	DevCon.WriteLn(L"Unscaled overal: %d,  scaled overal: %d,  relative EE clock speed: %d %%",
-	               unscaled_overal, scaled_overal, (int)(100 * ratio));
+	DevCon.WriteLn(L"Unscaled overall: %d,  scaled overall: %d,  relative EE clock speed: %d %%",
+	               unscaled_overall, scaled_overall, static_cast<int>(100 * ratio));
 #endif
 
 	return scaled;


### PR DESCRIPTION
**Summary of changes**:

* ~~Generalize the calculation formula instead of manually tuning it just to *work* well for specific games.~~
* Revert the EE cycle rate description to the older state.
* Add a mild overclock option to have the 0 at the middle of the slider.
* Rename some variables as the previous names didn't make any sense.
* Convert unnecessary int data types to bool.
* Only use dark green color for the default cycle rate. using a different color just for a single value (previously for -1) might be confusing for users.
