### PR TITLE
gsdx tc: Drop the first vsync if we have a frame miss

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -1636,8 +1636,15 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 	}
 	unsigned long frame_number = 0;
 
-	// Init vsync stuff
+	// Init vsync stuff without any real draw
+	//uint32 old_enable[2] = {s_gs->m_regs->PMODE.EN1, s_gs->m_regs->PMODE.EN2};
+	//s_gs->m_regs->PMODE.EN1 = 0;
+	//s_gs->m_regs->PMODE.EN2 = 0;
+
 	GSvsync(1);
+
+	//s_gs->m_regs->PMODE.EN1 = old_enable[0];
+	//s_gs->m_regs->PMODE.EN2 = old_enable[1];
 
 	while(finished > 0)
 	{

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -349,8 +349,11 @@ void GSRenderer::VSync(int field)
 
 	if(!m_dev->IsLost(true))
 	{
-		if(!Merge(field ? 1 : 0))
-		{
+		try {
+			if(!Merge(field ? 1 : 0))
+				return;
+		} catch (GSDXRecoverableError) {
+			s_n++;
 			return;
 		}
 	}

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -129,6 +129,7 @@ protected:
 	bool m_can_convert_depth;
 	int m_crc_hack_level;
 	static bool m_disable_partial_invalidation;
+	bool m_first_frame;
 
 	virtual Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false);
 	virtual Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type);


### PR DESCRIPTION
The goal is to avoid to generate a buffer with wrong data (if preload data hack isn't used)

Could help to avoid a more stable F9, Load/save state behavior.

Hopefully help dark skin issue in haunting ground