### PR TITLE
lilypad: s/size_t/int/ for numDevices

### DIFF
--- a/plugins/LilyPad/InputManager.cpp
+++ b/plugins/LilyPad/InputManager.cpp
@@ -26,7 +26,7 @@ InputDeviceManager::InputDeviceManager() {
 }
 
 void InputDeviceManager::ClearDevices() {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		delete devices[i];
 	}
 	free(devices);
@@ -380,7 +380,7 @@ void InputDeviceManager::AddDevice(Device *d) {
 }
 
 void InputDeviceManager::Update(InitInfo *info) {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		if (devices[i]->enabled) {
 			if (!devices[i]->active) {
 				if (!devices[i]->Activate(info) || !devices[i]->Update()) continue;
@@ -394,18 +394,18 @@ void InputDeviceManager::Update(InitInfo *info) {
 }
 
 void InputDeviceManager::PostRead() {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		if (devices[i]->active)
 			devices[i]->PostRead();
 	}
 }
 
 Device *InputDeviceManager::GetActiveDevice(InitInfo *info, unsigned int *uid, int *index, int *value) {
-	int i, j;
+	int j;
 	Update(info);
 	int bestDiff = FULLY_DOWN/2;
 	Device *bestDevice = 0;
-	for (i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		if (devices[i]->active) {
 			for (j=0; j<devices[i]->numVirtualControls; j++) {
 				if (devices[i]->virtualControlState[j] == devices[i]->oldVirtualControlState[j]) continue;
@@ -461,13 +461,13 @@ Device *InputDeviceManager::GetActiveDevice(InitInfo *info, unsigned int *uid, i
 }
 
 void InputDeviceManager::ReleaseInput() {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		if (devices[i]->active) devices[i]->Deactivate();
 	}
 }
 
 void InputDeviceManager::EnableDevices(DeviceType type, DeviceAPI api) {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		if (devices[i]->api == api && devices[i]->type == type) {
 			EnableDevice(i);
 		}
@@ -475,7 +475,7 @@ void InputDeviceManager::EnableDevices(DeviceType type, DeviceAPI api) {
 }
 
 void InputDeviceManager::DisableAllDevices() {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		DisableDevice(i);
 	}
 }
@@ -508,7 +508,7 @@ void InputDeviceManager::CopyBindings(int numOldDevices, Device **oldDevices) {
 	int *matches = (int*) malloc(sizeof(int) * numDevices);
 	int i, j, port, slot;
 	Device *old, *dev;
-	for (i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		matches[i] = -1;
 	}
 	for (i=0; i<numOldDevices; i++) {
@@ -527,7 +527,7 @@ void InputDeviceManager::CopyBindings(int numOldDevices, Device **oldDevices) {
 	for (int id=0; id<3; id++) {
 		for (i=0; i<numOldDevices; i++) {
 			if (oldMatches[i] >= 0) continue;
-			for (j=0; j<numDevices; j++) {
+			for (size_t j=0; j<numDevices; j++) {
 				if (matches[j] >= 0) {
 					continue;
 				}
@@ -615,7 +615,7 @@ void InputDeviceManager::CopyBindings(int numOldDevices, Device **oldDevices) {
 }
 
 void InputDeviceManager::SetEffect(unsigned char port, unsigned int slot, unsigned char motor, unsigned char force) {
-	for (int i=0; i<numDevices; i++) {
+	for (size_t i=0; i<numDevices; i++) {
 		Device *dev = devices[i];
 		if (dev->enabled && dev->numFFEffectTypes) {
 			dev->SetEffects(port, slot, motor, force);

--- a/plugins/LilyPad/InputManager.h
+++ b/plugins/LilyPad/InputManager.h
@@ -331,7 +331,7 @@ public:
 class InputDeviceManager {
 public:
 	Device **devices;
-	int numDevices;
+	size_t numDevices;
 
 	void ClearDevices();
 

--- a/plugins/LilyPad/LilyPad.cpp
+++ b/plugins/LilyPad/LilyPad.cpp
@@ -263,7 +263,7 @@ void UpdateEnabledDevices(int updateList = 0) {
 			}
 		}
 	}
-	for (int i=0; i<dm->numDevices; i++) {
+	for (size_t i=0; i<dm->numDevices; i++) {
 		Device *dev = dm->devices[i];
 
 		if (!dev->enabled) continue;
@@ -490,7 +490,7 @@ void Update(unsigned int port, unsigned int slot) {
 
 	LastCheck = t;
 
-	int i;
+	size_t i;
 	ButtonSum s[2][4];
 	u8 lockStateChanged[2][4];
 	memset(lockStateChanged, 0, sizeof(lockStateChanged));

--- a/plugins/LilyPad/Linux/Config.cpp
+++ b/plugins/LilyPad/Linux/Config.cpp
@@ -238,7 +238,7 @@ int SaveSettings(wchar_t *file=0) {
 	if (!dm)
 		return 0;
 
-	for (int i=0; i<dm->numDevices; i++) {
+	for (size_t i=0; i<dm->numDevices; i++) {
 		wchar_t id[50];
 		wchar_t temp[50], temp2[1000];
 		wsprintfW(id, L"Device %i", i);
@@ -463,7 +463,7 @@ void RefreshEnabledDevices(int updateDeviceList) {
 		lastXInputState = config.gameApis.xInput;
 	}
 
-	for (int i=0; i<dm->numDevices; i++) {
+	for (size_t i=0; i<dm->numDevices; i++) {
 		Device *dev = dm->devices[i];
 
 		// XXX windows magic?


### PR DESCRIPTION
Fix gcc warning:

warning: comparison between signed and unsigned integer expressions

Replace less variables than previous commit on master. So hopefully it will work without any issues.