### PR TITLE
GSDX: Remove GetDeviceSize()

### DIFF
--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -99,12 +99,10 @@ void GSRendererSW::VSync(int field)
 
 		GSVector4i dr = GetDisplayRect();
 		GSVector4i fr = GetFrameRect();
-		GSVector2i ds = GetDeviceSize();
 
-		fprintf(s_fp, "dr %d %d %d %d, fr %d %d %d %d, ds %d %d\n",
+		fprintf(s_fp, "dr %d %d %d %d, fr %d %d %d %d\n",
 			dr.x, dr.y, dr.z, dr.w,
-			fr.x, fr.y, fr.z, fr.w,
-			ds.x, ds.y);
+			fr.x, fr.y, fr.z, fr.w);
 
 		for(int i = 0; i < 2; i++)
 		{

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -449,25 +449,6 @@ GSVector4i GSState::GetFrameRect(int i)
 	return rectangle;
 }
 
-GSVector2i GSState::GetDeviceSize(int i)
-{
-	// TODO: return (m_regs->SMODE1.CMOD & 1) ? GSVector2i(640, 576) : GSVector2i(640, 480);
-
-	// TODO: other params of SMODE1 should affect the true device display size
-
-	// TODO2: pal games at 60Hz
-
-	if(i < 0) i = IsEnabled(1) ? 1 : 0;
-
-	GSVector4i rectangle = GetDisplayRect(i);
-	GSVector2i DeviceSize(rectangle.width(), rectangle.height());
-
-	if(isinterlaced() && m_regs->SMODE2.FFMD && DeviceSize.y > 1)
-		DeviceSize.y >>= 1;
-
-	return DeviceSize;
-}
-
 bool GSState::IsEnabled(int i)
 {
 	ASSERT(i >= 0 && i < 2);

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -239,7 +239,6 @@ public:
 
 	GSVector4i GetDisplayRect(int i = -1);
 	GSVector4i GetFrameRect(int i = -1);
-	GSVector2i GetDeviceSize(int i = -1);
 	GSVideoMode GetVideoMode();
 
 	bool IsEnabled(int i);


### PR DESCRIPTION
**Summary of changes**:

* Removes ``GetDeviceSize()`` from GSState.cpp as it's unused. (FWIW, It isn't useful anyway)