### PR TITLE
PCSX2: IPU end of video freeze fixes

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -64,6 +64,13 @@ __fi void IPUProcessInterrupt()
 {
 	if (ipuRegs.ctrl.BUSY) // && (g_BP.FP || g_BP.IFC || (ipu1ch.chcr.STR && ipu1ch.qwc > 0)))
 		IPUWorker();
+	if (ipuRegs.ctrl.BUSY && ipuRegs.cmd.BUSY && ipuRegs.cmd.DATA == 0x000001B7) {
+		// 0x000001B7 is the MPEG2 sequence end code, signalling the end of a video.
+		// At the end of a video BUSY values should be automatically set to 0. 
+		// This does not happen for Enthusia - Professional Racing, causing it to get stuck in an endless loop.
+		ipuRegs.cmd.BUSY = 0;
+		ipuRegs.ctrl.BUSY = 0;
+	}
 }
 
 /////////////////////////////////////////////////////////
@@ -274,6 +281,7 @@ void ipuSoftReset()
 	ipuRegs.top = 0;
 	ipu_cmd.clear();
 	ipuRegs.cmd.BUSY = 0;
+	ipuRegs.cmd.DATA = NULL; // required for Enthusia - Professional Racing after fix, or will freeze at start of next video.
 
 	memzero(g_BP);
 }

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -293,6 +293,19 @@ __fi void dmaIPU1() // toIPU
 		hwDmacIrq(DMAC_TO_IPU);
 	}
 
+	if (ipu1ch.chcr.MOD == NORMAL_MODE && ipu1ch.qwc == 0) //avoids freeze when IPU1 Normal error is triggered
+	{
+		/*ipu1ch.chcr.STR = false;
+		// Hack to force stop IPU
+		ipuRegs.cmd.BUSY = 0;
+		ipuRegs.ctrl.BUSY = 0;
+		ipuRegs.topbusy = 0;
+		//
+		hwDmacIrq(DMAC_TO_IPU);*/
+		IPU_LOG("IPU1 Normal error fix");
+		ipu1ch.qwc = 1;
+	}
+
 	if (ipu1ch.chcr.MOD == CHAIN_MODE)  //Chain Mode
 	{
 		IPU_LOG("Setting up IPU1 Chain mode");
@@ -322,25 +335,11 @@ __fi void dmaIPU1() // toIPU
 	}
 	else //Normal Mode
 	{
-		if(ipu1ch.qwc == 0)
-		{
-			ipu1ch.chcr.STR = false;
-				// Hack to force stop IPU
-				ipuRegs.cmd.BUSY = 0;
-				ipuRegs.ctrl.BUSY = 0;
-				ipuRegs.topbusy = 0;
-				//
-			hwDmacIrq(DMAC_TO_IPU);
-			Console.Warning("IPU1 Normal error!");
-		}
-		else
-		{
 			IPU_LOG("Setting up IPU1 Normal mode");
 			IPU1Status.InProgress = true;
 			IPU1Status.DMAFinished = true;
 			IPU1Status.DMAMode = DMA_MODE_NORMAL;
 			IPU1dma();
-		}
 	}
 }
 


### PR DESCRIPTION
* Fixes end of video freeze in Enthusia - Professional Racing.
* Fixes end of video freeze with IPU Normal error in games like Enter The Matrix(https://github.com/PCSX2/pcsx2/issues/1494), Rygar, Freestyle Metal X, etc. Also fixes The Incredible Hulk and Bolt (thanks to @prafullpcsx2 for testing).