### PR TITLE
PCSX2-WX: Add a dialog for title bar customization

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -250,6 +250,7 @@ set(pcsx2GuiSources
 	gui/CpuUsageProvider.cpp
 	gui/CpuUsageProviderLnx.cpp
 	gui/Dialogs/AboutBoxDialog.cpp
+	gui/Dialogs/GSFrameConfiguration.cpp
 	gui/Dialogs/AppConfigDialog.cpp
 	gui/Dialogs/AssertionDialog.cpp
 	gui/Panels/BaseApplicableConfigPanel.cpp

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -253,7 +253,7 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, Fixed100 framesPerSecond, u32 s
 	// is thus not worth the effort at this time.
 }
 
-static const char* ReportVideoMode()
+const char* ReportVideoMode()
 {
 	switch (gsVideoMode)
 	{

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -124,6 +124,7 @@ struct SyncCounter
 
 
 extern Fixed100 GetVerticalFrequency();
+extern const char *ReportVideoMode();
 extern Counter counters[4];
 extern SyncCounter hsyncCounter;
 extern SyncCounter vsyncCounter;

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -148,6 +148,7 @@ enum MenuIdentifiers
 	MenuId_Video_WindowSettings,
 
 	// Miscellaneous Menu!  (Misc)
+	MenuId_GSFrame,
 	MenuId_Website,				// Visit our awesome website!
 	MenuId_Profiler,			// Enable profiler
 	MenuId_Console,				// Enable console

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -947,7 +947,11 @@ AppConfig::UiTemplateOptions::UiTemplateOptions()
 	OutputProgressive	= L"Progressive";
 	OutputInterlaced	= L"Interlaced";
 	Paused				= L"<PAUSED> ";
-	TitleTemplate		= L"Slot: ${slot} | Speed: ${speed} (${vfps}) | Limiter: ${limiter} | ${gsdx} | ${omodei} | ${cpuusage}";
+	TitleTemplate		= DefaultTitleTemplate;
+	ShowLimiter			= true;
+	ShowSaveSlot		= true;
+	ShowThreadUsage		= true;
+	ShowVideoMode		= false;
 }
 
 void AppConfig::UiTemplateOptions::LoadSave(IniInterface& ini)
@@ -963,6 +967,10 @@ void AppConfig::UiTemplateOptions::LoadSave(IniInterface& ini)
 	IniEntry(OutputProgressive);
 	IniEntry(OutputInterlaced);
 	IniEntry(Paused);
+	IniEntry(ShowVideoMode);
+	IniEntry(ShowSaveSlot);
+	IniEntry(ShowLimiter);
+	IniEntry(ShowThreadUsage);
 	IniEntry(TitleTemplate);
 }
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -20,6 +20,8 @@
 #include "CDVD/CDVDaccess.h"
 #include <memory>
 
+const wxString DefaultTitleTemplate = L"Slot: ${slot} | Speed: ${speed} (${vfps}) | Limiter: ${limiter} | ${videomode} | ${gsdx} | ${omodei} | ${cpuusage}";
+
 enum DocsModeType
 {
 	// uses /home/user or /cwd for the program data.  This is the default mode and is the most
@@ -243,7 +245,8 @@ public:
 		void SanityCheck();
 	};
 
-	struct UiTemplateOptions {
+	struct UiTemplateOptions
+	{
 		UiTemplateOptions();
 		void LoadSave(IniInterface& conf);
 
@@ -257,6 +260,10 @@ public:
 		wxString OutputInterlaced;
 		wxString Paused;
 		wxString TitleTemplate;
+		bool ShowVideoMode;
+		bool ShowSaveSlot;
+		bool ShowLimiter;
+		bool ShowThreadUsage;
 	};
 
 public:

--- a/pcsx2/gui/Dialogs/GSFrameConfiguration.cpp
+++ b/pcsx2/gui/Dialogs/GSFrameConfiguration.cpp
@@ -1,0 +1,77 @@
+/*  PCSX2 - PS2 Emulator for PCs
+*  Copyright (C) 2002-2010  PCSX2 Dev Team
+*
+*  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+*  of the GNU Lesser General Public License as published by the Free Software Found-
+*  ation, either version 3 of the License, or (at your option) any later version.
+*
+*  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+*  PURPOSE.  See the GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along with PCSX2.
+*  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PrecompiledHeader.h"
+#include "App.h"
+#include "AppCommon.h"
+#include "Dialogs/ModalPopups.h"
+
+Dialogs::GSFrameConfigurationDialog::GSFrameConfigurationDialog(wxWindow* parent)
+	: wxDialogWithHelpers(parent, AddAppName(_("Titlebar Customization")), pxDialogFlags())
+{
+	const int spacer_size = 10;
+	wxBoxSizer *Y_axis = new wxBoxSizer(wxVERTICAL);
+	wxBoxSizer *X_axis = new wxBoxSizer(wxHORIZONTAL);
+	wxButton *CancelButton = new wxButton(this, wxID_CANCEL, _("Cancel"));
+	wxButton *OkButton = new wxButton(this, wxID_OK, _("OK"));
+
+	m_show_limiter = new wxCheckBox(this, wxID_ANY, _("Show frame limiter status"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
+	m_show_videomode = new wxCheckBox(this, wxID_ANY, _("Show current video mode"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
+	m_show_saveslot = new wxCheckBox(this, wxID_ANY, _("Show current save slot"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
+	m_show_threadusage_percentage = new wxCheckBox(this, wxID_ANY, _("Show thread usage"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
+
+	Y_axis->Add(m_show_limiter, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(spacer_size);
+
+	Y_axis->Add(m_show_videomode, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(spacer_size);
+
+	Y_axis->Add(m_show_saveslot, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(spacer_size);
+
+	Y_axis->Add(m_show_threadusage_percentage, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(spacer_size);
+
+	X_axis->Add(OkButton, wxSizerFlags().HorzBorder());
+	X_axis->Add(CancelButton, wxSizerFlags().HorzBorder());
+
+	*this += Y_axis;
+	*this += X_axis | pxSizerFlags::StdButton();
+
+	Bind(wxEVT_BUTTON, &Dialogs::GSFrameConfigurationDialog::ApplySettings, this, OkButton->GetId());
+
+	InitValues();
+	OkButton->SetFocus();
+	SetSizerAndFit(GetSizer());
+}
+
+void Dialogs::GSFrameConfigurationDialog::ApplySettings(wxCommandEvent& evt)
+{
+	AppConfig::UiTemplateOptions& Options = g_Conf->Templates;
+	Options.ShowLimiter = m_show_limiter->GetValue();
+	Options.ShowSaveSlot = m_show_saveslot->GetValue();
+	Options.ShowVideoMode = m_show_videomode->GetValue();
+	Options.ShowThreadUsage = m_show_threadusage_percentage->GetValue();
+	evt.Skip();
+}
+
+void Dialogs::GSFrameConfigurationDialog::InitValues()
+{
+	AppConfig::UiTemplateOptions& Options = g_Conf->Templates;
+	m_show_limiter->SetValue(Options.ShowLimiter);
+	m_show_saveslot->SetValue(Options.ShowSaveSlot);
+	m_show_videomode->SetValue(Options.ShowVideoMode);
+	m_show_threadusage_percentage->SetValue(Options.ShowThreadUsage);
+}

--- a/pcsx2/gui/Dialogs/GSFrameConfiguration.cpp
+++ b/pcsx2/gui/Dialogs/GSFrameConfiguration.cpp
@@ -22,15 +22,28 @@ Dialogs::GSFrameConfigurationDialog::GSFrameConfigurationDialog(wxWindow* parent
 	: wxDialogWithHelpers(parent, AddAppName(_("Titlebar Customization")), pxDialogFlags())
 {
 	const int spacer_size = 10;
+	const wxSize textctrl_size(400, 40);
 	wxBoxSizer *Y_axis = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer *X_axis = new wxBoxSizer(wxHORIZONTAL);
 	wxButton *CancelButton = new wxButton(this, wxID_CANCEL, _("Cancel"));
 	wxButton *OkButton = new wxButton(this, wxID_OK, _("OK"));
+	wxStaticText *AutomaticText = new wxStaticText(this, wxID_ANY, _("Automatic Configuration"));
+	wxStaticText *ManualText = new wxStaticText(this, wxID_ANY , _("Manual Configuration"));
 
+	//Apply bold font style to the Automatic/Manual Configuration headers.
+	SetBold(AutomaticText);
+	SetBold(ManualText);
+
+
+	m_template_text = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, textctrl_size, wxTE_PROCESS_ENTER, wxDefaultValidator);
 	m_show_limiter = new wxCheckBox(this, wxID_ANY, _("Show frame limiter status"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
 	m_show_videomode = new wxCheckBox(this, wxID_ANY, _("Show current video mode"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
 	m_show_saveslot = new wxCheckBox(this, wxID_ANY, _("Show current save slot"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
 	m_show_threadusage_percentage = new wxCheckBox(this, wxID_ANY, _("Show thread usage"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE, wxDefaultValidator);
+	m_restore_defaults = new wxButton(this, wxID_DEFAULT, _("Restore Defaults"));
+
+	Y_axis->Add(AutomaticText, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(spacer_size);
 
 	Y_axis->Add(m_show_limiter, wxSizerFlags().DoubleHorzBorder());
 	Y_axis->AddSpacer(spacer_size);
@@ -42,6 +55,13 @@ Dialogs::GSFrameConfigurationDialog::GSFrameConfigurationDialog(wxWindow* parent
 	Y_axis->AddSpacer(spacer_size);
 
 	Y_axis->Add(m_show_threadusage_percentage, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(2 * spacer_size);
+
+	Y_axis->Add(ManualText, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->AddSpacer(spacer_size);
+
+	Y_axis->Add(m_template_text, wxSizerFlags().DoubleHorzBorder());
+	Y_axis->Add(m_restore_defaults, wxSizerFlags().DoubleHorzBorder());
 	Y_axis->AddSpacer(spacer_size);
 
 	X_axis->Add(OkButton, wxSizerFlags().HorzBorder());
@@ -51,6 +71,8 @@ Dialogs::GSFrameConfigurationDialog::GSFrameConfigurationDialog(wxWindow* parent
 	*this += X_axis | pxSizerFlags::StdButton();
 
 	Bind(wxEVT_BUTTON, &Dialogs::GSFrameConfigurationDialog::ApplySettings, this, OkButton->GetId());
+	Bind(wxEVT_TEXT, &Dialogs::GSFrameConfigurationDialog::GrayOut, this, m_template_text->GetId());
+	Bind(wxEVT_BUTTON, &Dialogs::GSFrameConfigurationDialog::RestoreDefaults, this, m_restore_defaults->GetId());
 
 	InitValues();
 	OkButton->SetFocus();
@@ -60,6 +82,7 @@ Dialogs::GSFrameConfigurationDialog::GSFrameConfigurationDialog(wxWindow* parent
 void Dialogs::GSFrameConfigurationDialog::ApplySettings(wxCommandEvent& evt)
 {
 	AppConfig::UiTemplateOptions& Options = g_Conf->Templates;
+	Options.TitleTemplate = m_template_text->GetLineText(m_template_text->GetNumberOfLines());
 	Options.ShowLimiter = m_show_limiter->GetValue();
 	Options.ShowSaveSlot = m_show_saveslot->GetValue();
 	Options.ShowVideoMode = m_show_videomode->GetValue();
@@ -67,9 +90,43 @@ void Dialogs::GSFrameConfigurationDialog::ApplySettings(wxCommandEvent& evt)
 	evt.Skip();
 }
 
+void Dialogs::GSFrameConfigurationDialog::SetBold(wxStaticText* Text)
+{
+	wxFont Font = Text->GetFont();
+	Font.SetWeight(wxFONTWEIGHT_BOLD);
+	Text->SetFont(Font);
+}
+
+void Dialogs::GSFrameConfigurationDialog::GrayOutCheckboxes()
+{
+	bool show = m_template_text->GetValue() == DefaultTitleTemplate;
+	m_show_limiter->Enable(show);
+	m_show_saveslot->Enable(show);
+	m_show_threadusage_percentage->Enable(show);
+	m_show_videomode->Enable(show);
+}
+
+void Dialogs::GSFrameConfigurationDialog::GrayOut(wxCommandEvent& evt)
+{
+	GrayOutCheckboxes();
+	evt.Skip();
+}
+
+void Dialogs::GSFrameConfigurationDialog::RestoreDefaults(wxCommandEvent& evt)
+{
+	m_template_text->SetValue(DefaultTitleTemplate);
+	m_show_limiter->SetValue(true);
+	m_show_saveslot->SetValue(true);
+	m_show_videomode->SetValue(false);
+	m_show_threadusage_percentage->SetValue(true);
+	GrayOutCheckboxes();
+	evt.Skip();
+}
+
 void Dialogs::GSFrameConfigurationDialog::InitValues()
 {
 	AppConfig::UiTemplateOptions& Options = g_Conf->Templates;
+	m_template_text->SetValue(Options.TitleTemplate);
 	m_show_limiter->SetValue(Options.ShowLimiter);
 	m_show_saveslot->SetValue(Options.ShowSaveSlot);
 	m_show_videomode->SetValue(Options.ShowVideoMode);

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -71,6 +71,23 @@ namespace Dialogs
 		wxString GetDialogName() const { return GetNameStatic(); }
 	};
 
+	class GSFrameConfigurationDialog : public wxDialogWithHelpers
+	{
+	protected:
+		wxCheckBox* m_show_videomode;
+		wxCheckBox* m_show_saveslot;
+		wxCheckBox* m_show_limiter;
+		wxCheckBox* m_show_threadusage_percentage;
+
+	public:
+		GSFrameConfigurationDialog(wxWindow* parent = NULL);
+		virtual ~GSFrameConfigurationDialog() throw() {}
+
+		static wxString GetNameStatic() { return L"Title bar customization"; }
+		wxString GetDialogName() const { return GetNameStatic(); }
+		void InitValues();
+		void ApplySettings(wxCommandEvent& evt);
+	};
 
 	class PickUserModeDialog : public BaseApplicableDialog
 	{

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -78,6 +78,8 @@ namespace Dialogs
 		wxCheckBox* m_show_saveslot;
 		wxCheckBox* m_show_limiter;
 		wxCheckBox* m_show_threadusage_percentage;
+		wxTextCtrl* m_template_text;
+		wxButton*   m_restore_defaults;
 
 	public:
 		GSFrameConfigurationDialog(wxWindow* parent = NULL);
@@ -86,7 +88,11 @@ namespace Dialogs
 		static wxString GetNameStatic() { return L"Title bar customization"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
 		void InitValues();
+		void SetBold(wxStaticText* text);
+		void GrayOut(wxCommandEvent& evt);
 		void ApplySettings(wxCommandEvent& evt);
+		void RestoreDefaults(wxCommandEvent& evt);
+		void GrayOutCheckboxes();
 	};
 
 	class PickUserModeDialog : public BaseApplicableDialog

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -625,8 +625,20 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 	const u64& smode2 = *(u64*)PS2GS_BASE(GS_SMODE2);
 	wxString omodef = (smode2 & 2) ? templates.OutputFrame : templates.OutputField;
 	wxString omodei = (smode2 & 1) ? templates.OutputInterlaced : templates.OutputProgressive;
-
 	wxString title = templates.TitleTemplate;
+
+	if (title == DefaultTitleTemplate)
+	{
+		if (!templates.ShowSaveSlot)
+			title.Replace(L"Slot: ${slot} | ", L"");
+		if (!templates.ShowLimiter)
+			title.Replace(L" Limiter: ${limiter} |", L"");
+		if (!templates.ShowThreadUsage)
+			title.Replace(L"| ${cpuusage}", L"");
+		if (!templates.ShowVideoMode)
+			title.Replace(L"| ${videomode} ", L"");
+	}
+
 	title.Replace(L"${slot}",		pxsFmt(L"%d", States_GetCurrentSlot()));
 	title.Replace(L"${limiter}",	limiterStr);
 	title.Replace(L"${speed}",		pxsFmt(L"%3d%%", lround(percentage)));
@@ -635,6 +647,7 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 	title.Replace(L"${omodef}",		omodef);
 	title.Replace(L"${omodei}",		omodei);
 	title.Replace(L"${gsdx}",		fromUTF8(gsDest));
+	title.Replace(L"${videomode}",	ReportVideoMode());
 	if (CoreThread.IsPaused())
 		title = templates.Paused + title;
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -234,6 +234,7 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ShowConsole, this, MenuId_Console);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ShowConsole_Stdio, this, MenuId_Console_Stdio);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ShowAboutBox, this, MenuId_About);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ShowTitlebarConfiguration, this, MenuId_GSFrame);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ChangeLang, this, MenuId_ChangeLang);
 
 	// Debug
@@ -514,13 +515,16 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	//There's a great working "open website" in the about panel. Less clutter by just using that.
 	//m_menuMisc.Append(MenuId_Website,			_("Visit Website..."),
 	//	_("Opens your web-browser to our favorite website."));
-	m_menuMisc.Append(MenuId_About,				_("&About...") );
-
+	m_menuMisc.Append(MenuId_GSFrame, _("&Titlebar Customization"));
 	m_menuMisc.AppendSeparator();
+
+	m_menuMisc.Append(MenuId_About,				_("&About...") );
+	m_menuMisc.AppendSeparator();
+
 	m_menuMisc.Append( MenuId_ChangeLang,		L"Change &Language" ); // Always in English
 
+	// Debug Menu
 	m_menuDebug.Append(MenuId_Debug_Open,		_("&Open Debug Window..."),	wxEmptyString);
-
 #ifdef PCSX2_DEVBUILD
 	m_menuDebug.Append(MenuId_Debug_Logging,	_("&Logging..."),			wxEmptyString);
 #endif

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -197,6 +197,7 @@ protected:
 	void Menu_ShowConsole(wxCommandEvent &event);
 	void Menu_ChangeLang(wxCommandEvent &event);
 	void Menu_ShowConsole_Stdio(wxCommandEvent &event);
+	void Menu_ShowTitlebarConfiguration(wxCommandEvent &event);
 	void Menu_ShowAboutBox(wxCommandEvent &event);
 
 	void _DoBootCdvd();

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -603,3 +603,8 @@ void MainEmuFrame::Menu_ShowAboutBox(wxCommandEvent &event)
 {
 	AppOpenDialog<AboutBoxDialog>( this );
 }
+
+void MainEmuFrame::Menu_ShowTitlebarConfiguration(wxCommandEvent &event)
+{
+	AppOpenDialog<GSFrameConfigurationDialog>(this);
+}

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="..\..\gui\Debugger\DebuggerLists.cpp" />
     <ClCompile Include="..\..\gui\Debugger\DisassemblyDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\GameDatabaseDialog.cpp" />
+    <ClCompile Include="..\..\gui\Dialogs\GSFrameConfiguration.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\McdConfigDialog.cpp" />
     <ClCompile Include="..\..\gui\Panels\GameDatabasePanel.cpp" />
     <ClCompile Include="..\..\gui\Panels\MemoryCardListView.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -877,6 +877,9 @@
     <ClCompile Include="..\..\IopGte.cpp">
       <Filter>System\Ps2\Iop</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gui\Dialogs\GSFrameConfiguration.cpp">
+      <Filter>AppHost\Dialogs</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Patch.h">


### PR DESCRIPTION
**Summary of changes**:

* Adds a new ``Titlebar customization dialog`` which enables you to remove/display some title bar elements.
* Allows optional display of current video mode on title bar.

![image1](http://i.imgur.com/ycOuXLJ.png)

![Image2](http://i.imgur.com/O5woIbh.png)

![Image3](http://i.imgur.com/iV4amdN.png)