### PR TITLE
gsdx sw: add extrathreads_height to control the quantity of pixels pr…

### DIFF
--- a/plugins/GSdx/GSRasterizer.h
+++ b/plugins/GSdx/GSRasterizer.h
@@ -129,6 +129,7 @@ protected:
 	IDrawScanline* m_ds;
 	int m_id;
 	int m_threads;
+	int m_thread_height;
 	uint8* m_scanline;
 	GSVector4i m_scissor;
 	GSVector4 m_fscissor_x;
@@ -138,7 +139,7 @@ protected:
 
 	typedef void (GSRasterizer::*DrawPrimPtr)(const GSVertexSW* v, int count);
 
-	template<bool scissor_test> 
+	template<bool scissor_test>
 	void DrawPoint(const GSVertexSW* vertex, int vertex_count, const uint32* index, int index_count);
 	void DrawLine(const GSVertexSW* vertex, const uint32* index);
 	void DrawTriangle(const GSVertexSW* vertex, const uint32* index);
@@ -198,6 +199,7 @@ protected:
 	GSPerfMon* m_perfmon;
 	vector<GSWorker*> m_workers;
 	uint8* m_scanline;
+	int m_thread_height;
 
 	GSRasterizerList(int threads, GSPerfMon* perfmon);
 

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -274,6 +274,7 @@ GSdxApp::GSdxApp()
 	m_default_configuration["debug_opengl"]                               = "0";
 	m_default_configuration["dump"]                                       = "0";
 	m_default_configuration["extrathreads"]                               = "2";
+	m_default_configuration["extrathreads_height"]                        = "4";
 	m_default_configuration["filter"]                                     = "2";
 	m_default_configuration["force_texture_clear"]                        = "0";
 	m_default_configuration["fxaa"]                                       = "0";


### PR DESCRIPTION
Value could range from 1 to 9. Default is 4 and it is potentially the
best option.  Feel free to test some values on your system, behavior
might depends on the core number and thread number

Value is exponential so 4 is 2 times more pixels than 3.

Small value increased thread overhead, big value increase wait/sync latency