### PR TITLE
GameDB: Fix Grandia III MemCardFilter

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -40004,7 +40004,6 @@ Serial = SLUS-21335
 Name   = Hustle, The - Detroit Streets - Kat's Story
 Region = NTSC-U
 Compat = 5
-MemCardFilter = SLUS-21334
 ---------------------------------------------
 Serial = SLUS-21336
 Name   = Zathura
@@ -40055,6 +40054,7 @@ Serial = SLUS-21345
 Name   = Grandia III [Disc2of2]
 Region = NTSC-U
 Compat = 5
+MemCardFilter = SLUS-21334
 ---------------------------------------------
 Serial = SLUS-21346
 Name   = Ace Combat Zero - The Belkan War


### PR DESCRIPTION
MemCardFilter for Grandia III NTSC-U Disc 2 was applied to the wrong
game. The serials for Disc 1 and 2 are SLUS-21334 and SLUS-21345,
respectively - I assume someone fatfingered when issuing the serials.