### PR TITLE
pcsx2: manually cast function pointer to void*

### DIFF
--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -169,13 +169,13 @@ void recMFC0()
 		else if (0 == (_Imm_ & 2)) // MFPC 0, only LSB of register matters
 		{
 			iFlushCall(FLUSH_INTERPRETER);
-			xFastCall(COP0_UpdatePCCR);
+			xFastCall((void*)COP0_UpdatePCCR);
 			xMOV(eax, ptr[&cpuRegs.PERF.n.pcr0]);
 		}
 		else // MFPC 1
 		{
 			iFlushCall(FLUSH_INTERPRETER);
-			xFastCall(COP0_UpdatePCCR);
+			xFastCall((void*)COP0_UpdatePCCR);
 			xMOV(eax, ptr[&cpuRegs.PERF.n.pcr1]);
 		}
 		_deleteEEreg(_Rt_, 0);
@@ -206,7 +206,7 @@ void recMTC0()
 		{
 			case 12:
 				iFlushCall(FLUSH_INTERPRETER);
-				xFastCall(WriteCP0Status, g_cpuConstRegs[_Rt_].UL[0] );
+				xFastCall((void*)WriteCP0Status, g_cpuConstRegs[_Rt_].UL[0] );
 			break;
 
 			case 9:
@@ -222,9 +222,9 @@ void recMTC0()
 						break;
 					// Updates PCRs and sets the PCCR.
 					iFlushCall(FLUSH_INTERPRETER);
-					xFastCall(COP0_UpdatePCCR);
+					xFastCall((void*)COP0_UpdatePCCR);
 					xMOV(ptr32[&cpuRegs.PERF.n.pccr], g_cpuConstRegs[_Rt_].UL[0]);
-					xFastCall(COP0_DiagnosticPCCR);
+					xFastCall((void*)COP0_DiagnosticPCCR);
 				}
 				else if (0 == (_Imm_ & 2)) // MTPC 0, only LSB of register matters
 				{
@@ -256,7 +256,7 @@ void recMTC0()
 			case 12:
 				iFlushCall(FLUSH_INTERPRETER);
 				_eeMoveGPRtoR(ecx, _Rt_);
-				xFastCall(WriteCP0Status, ecx );
+				xFastCall((void*)WriteCP0Status, ecx );
 			break;
 
 			case 9:
@@ -271,9 +271,9 @@ void recMTC0()
 					if (0 != (_Imm_ & 0x3E)) // only effective when the register is 0
 						break;
 					iFlushCall(FLUSH_INTERPRETER);
-					xFastCall(COP0_UpdatePCCR);
+					xFastCall((void*)COP0_UpdatePCCR);
 					_eeMoveGPRtoM((uptr)&cpuRegs.PERF.n.pccr, _Rt_);
-					xFastCall(COP0_DiagnosticPCCR);
+					xFastCall((void*)COP0_DiagnosticPCCR);
 				}
 				else if (0 == (_Imm_ & 2)) // MTPC 0, only LSB of register matters
 				{

--- a/pcsx2/x86/iR3000Atables.cpp
+++ b/pcsx2/x86/iR3000Atables.cpp
@@ -631,7 +631,7 @@ static void rpsxLB()
 
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
-	xFastCall(iopMemRead8, ecx );		// returns value in EAX
+	xFastCall((void*)iopMemRead8, ecx );		// returns value in EAX
 	if (_Rt_) {
 		xMOVSX(eax, al);
 		xMOV(ptr[&psxRegs.GPR.r[_Rt_]], eax);
@@ -647,7 +647,7 @@ static void rpsxLBU()
 
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
-	xFastCall(iopMemRead8, ecx );		// returns value in EAX
+	xFastCall((void*)iopMemRead8, ecx );		// returns value in EAX
 	if (_Rt_) {
 		xMOVZX(eax, al);
 		xMOV(ptr[&psxRegs.GPR.r[_Rt_]], eax);
@@ -663,7 +663,7 @@ static void rpsxLH()
 
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
-	xFastCall(iopMemRead16, ecx );		// returns value in EAX
+	xFastCall((void*)iopMemRead16, ecx );		// returns value in EAX
 	if (_Rt_) {
 		xMOVSX(eax, ax);
 		xMOV(ptr[&psxRegs.GPR.r[_Rt_]], eax);
@@ -679,7 +679,7 @@ static void rpsxLHU()
 
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
-	xFastCall(iopMemRead16, ecx );		// returns value in EAX
+	xFastCall((void*)iopMemRead16, ecx );		// returns value in EAX
 	if (_Rt_) {
 		xMOVZX(eax, ax);
 		xMOV(ptr[&psxRegs.GPR.r[_Rt_]], eax);
@@ -700,7 +700,7 @@ static void rpsxLW()
 	xTEST(ecx, 0x10000000);
 	j8Ptr[0] = JZ8(0);
 
-	xFastCall(iopMemRead32, ecx );		// returns value in EAX
+	xFastCall((void*)iopMemRead32, ecx );		// returns value in EAX
 	if (_Rt_) {
 		xMOV(ptr[&psxRegs.GPR.r[_Rt_]], eax);
 	}
@@ -728,7 +728,7 @@ static void rpsxSB()
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
 	xMOV( edx, ptr[&psxRegs.GPR.r[_Rt_]] );
-	xFastCall(iopMemWrite8, ecx, edx );
+	xFastCall((void*)iopMemWrite8, ecx, edx );
 }
 
 static void rpsxSH()
@@ -739,7 +739,7 @@ static void rpsxSH()
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
 	xMOV( edx, ptr[&psxRegs.GPR.r[_Rt_]] );
-	xFastCall(iopMemWrite16, ecx, edx );
+	xFastCall((void*)iopMemWrite16, ecx, edx );
 }
 
 static void rpsxSW()
@@ -750,7 +750,7 @@ static void rpsxSW()
 	xMOV(ecx, ptr[&psxRegs.GPR.r[_Rs_]]);
 	if (_Imm_) xADD(ecx, _Imm_);
 	xMOV( edx, ptr[&psxRegs.GPR.r[_Rt_]] );
-	xFastCall(iopMemWrite32, ecx, edx );
+	xFastCall((void*)iopMemWrite32, ecx, edx );
 }
 
 //// SLL

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -57,8 +57,8 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 			mVU_XGKICK_DELAY(mVU);
 		}
 		if (doEarlyExit(mVU)) {
-			if (!isVU1) xFastCall(mVU0clearlpStateJIT);
-			else		xFastCall(mVU1clearlpStateJIT);
+			if (!isVU1) xFastCall((void*)mVU0clearlpStateJIT);
+			else		xFastCall((void*)mVU1clearlpStateJIT);
 		}
 	}
 
@@ -117,9 +117,9 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 		}
 		if (doEarlyExit(mVU)) {
 			if (!isVU1)
-				xFastCall(mVU0clearlpStateJIT);
+				xFastCall((void*)mVU0clearlpStateJIT);
 			else
-				xFastCall(mVU1clearlpStateJIT);
+				xFastCall((void*)mVU1clearlpStateJIT);
 		}
 	}
 
@@ -192,8 +192,8 @@ void normJumpCompile(mV, microFlagCycles& mFC, bool isEvilJump) {
 		xJMP(mVU.exitFunct);
 	}
 	
-	if (!mVU.index) xFastCall(mVUcompileJIT<0>, gprT2, gprT3); //(u32 startPC, uptr pState)
-	else			xFastCall(mVUcompileJIT<1>, gprT2, gprT3);
+	if (!mVU.index) xFastCall((void*)(void(*)())mVUcompileJIT<0>, gprT2, gprT3); //(u32 startPC, uptr pState)
+	else			xFastCall((void*)(void(*)())mVUcompileJIT<1>, gprT2, gprT3);
 
 	mVUrestoreRegs(mVU);
 	xJMP(gprT1);  // Jump to rec-code address

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -27,8 +27,8 @@ void mVUdispatcherAB(mV) {
 		xScopedStackFrame frame(false, true);
 
 		// __fastcall = The caller has already put the needed parameters in ecx/edx:
-		if (!isVU1)	{ xFastCall(mVUexecuteVU0, ecx, edx); }
-		else		{ xFastCall(mVUexecuteVU1, ecx, edx); }
+		if (!isVU1)	{ xFastCall((void*)mVUexecuteVU0, ecx, edx); }
+		else		{ xFastCall((void*)mVUexecuteVU1, ecx, edx); }
 
 		// Load VU's MXCSR state
 		xLDMXCSR(g_sseVUMXCSR);
@@ -61,8 +61,8 @@ void mVUdispatcherAB(mV) {
 
 		// __fastcall = The first two DWORD or smaller arguments are passed in ECX and EDX registers;
 		//              all other arguments are passed right to left.
-		if (!isVU1) { xFastCall(mVUcleanUpVU0); }
-		else		{ xFastCall(mVUcleanUpVU1); }
+		if (!isVU1) { xFastCall((void*)mVUcleanUpVU0); }
+		else		{ xFastCall((void*)mVUcleanUpVU1); }
 	}
 
 	xRET();

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -249,15 +249,15 @@ void recBC2TL() { _setupBranchTest(JZ32,  true);  }
 void COP2_Interlock(bool mBitSync) {
 	if (cpuRegs.code & 1) {
 		iFlushCall(FLUSH_EVERYTHING | FLUSH_PC);
-		if (mBitSync) xFastCall(_vu0WaitMicro);
-		else		  xFastCall(_vu0FinishMicro);
+		if (mBitSync) xFastCall((void*)_vu0WaitMicro);
+		else		  xFastCall((void*)_vu0FinishMicro);
 	}
 }
 
 void TEST_FBRST_RESET(FnType_Void* resetFunct, int vuIndex) {
 	xTEST(eax, (vuIndex) ? 0x200 : 0x002);
 	xForwardJZ8 skip;
-		xFastCall(resetFunct);
+		xFastCall((void*)resetFunct);
 		xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
 	skip.SetTarget();
 }
@@ -316,8 +316,8 @@ static void recCTC2() {
 				xMOV(ecx, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
 			}
 			else xXOR(ecx, ecx);
-			xFastCall(vu1ExecMicro, ecx);
-			xFastCall(vif1VUFinish);
+			xFastCall((void*)vu1ExecMicro, ecx);
+			xFastCall((void*)vif1VUFinish);
 			break;
 		case REG_FBRST:
 			if (!_Rt_) { 
@@ -336,7 +336,7 @@ static void recCTC2() {
 			// Executing vu0 block here fixes the intro of Ratchet and Clank
 			// sVU's COP2 has a comment that "Donald Duck" needs this too...
 			if (_Rd_) _eeMoveGPRtoM((uptr)&vu0Regs.VI[_Rd_].UL, _Rt_);
-			xFastCall(BaseVUmicroCPU::ExecuteBlockJIT, (uptr)CpuVU0);
+			xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, (uptr)CpuVU0);
 			break;
 	}
 }

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -298,9 +298,9 @@ __fi void mVUaddrFix(mV, const x32& gprReg)
 				if (IsDevBuild && !isCOP2) {         // Lets see which games do this!
 					xMOV(gprT2, mVU.prog.cur->idx); // Note: Kernel does it via COP2 to initialize VU1!
 					xMOV(gprT3, xPC);               // So we don't spam console, we'll only check micro-mode...
-					xCALL(mVUwarningRegAccess);
+					xCALL((void*)mVUwarningRegAccess);
 				}
-				xCALL(mVUwaitMTVU);
+				xCALL((void*)mVUwaitMTVU);
 #ifdef __GNUC__
 				xADD(esp, 4);
 #endif

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -2890,7 +2890,7 @@ void VuBaseBlock::Recompile()
 	if (itparent == parents.end()) xMOV(ptr32[&skipparent], -1);
 
 	xMOV( ecx, s_vu );
-	xCALL( svudispfn );
+	xCALL( (void*)svudispfn );
 #endif
 
 	s_pCurBlock = this;
@@ -3599,7 +3599,7 @@ void VuInstruction::Recompile(std::list<VuInstruction>::iterator& itinst, u32 vu
 		u8* jptr = JZ8(0);
 		xOR(ptr32[&VU0.VI[REG_VPU_STAT].UL], s_vu ? 0x200 : 0x002);
 		xMOV( ecx, s_vu ? INTC_VU1 : INTC_VU0 );
-		xCALL( hwIntcIrq );
+		xCALL( (void*)hwIntcIrq );
 		x86SetJ8(jptr);
 	}
 	if (code_ptr[1] & 0x08000000)   // T flag
@@ -3608,7 +3608,7 @@ void VuInstruction::Recompile(std::list<VuInstruction>::iterator& itinst, u32 vu
 		u8* jptr = JZ8(0);
 		xOR(ptr32[&VU0.VI[REG_VPU_STAT].UL], s_vu ? 0x400 : 0x004);
 		xMOV( ecx, s_vu ? INTC_VU1 : INTC_VU0 );
-		xCALL( hwIntcIrq );
+		xCALL( (void*)hwIntcIrq );
 		x86SetJ8(jptr);
 	}
 
@@ -4311,7 +4311,7 @@ void recVUMI_XGKICK_(VURegs *VU)
 	_freeXMMregs();
 
 	xMOV(ecx, xRegister32(s_XGKICKReg));
-	xCALL(VU1XGKICK_MTGSTransfer);
+	xCALL((void*)VU1XGKICK_MTGSTransfer);
 
 	s_ScheduleXGKICK = 0;
 }


### PR DESCRIPTION
Templace is nicer but give a hard time to compiler.

New version compile in both gcc&clang without hack

=> #1488 