### PR TITLE
Gsdx alpha test improvement DX

### DIFF
--- a/plugins/GSdx/GSRendererDX.h
+++ b/plugins/GSdx/GSRendererDX.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "GSRendererHW.h"
+#include "GSDeviceDX.h"
 
 class GSRendererDX : public GSRendererHW
 {
@@ -33,12 +34,28 @@ class GSRendererDX : public GSRendererHW
 	bool UserHacks_AlphaStencil;
 
 protected:
+	void EmulateAtst(const int pass, const GSTextureCache::Source* tex);
+	void EmulateZbuffer();
 	virtual void DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* tex);
 	virtual void SetupIA() = 0;
 	virtual void UpdateFBA(GSTexture* rt) {}
 
 	unsigned int UserHacks_TCOffset;
 	float UserHacks_TCO_x, UserHacks_TCO_y;
+
+	bool DATE;
+
+	GSDrawingContext* context;
+	GSDrawingEnvironment env;
+
+	GSDeviceDX* dev;
+
+	GSDeviceDX::OMDepthStencilSelector om_dssel;
+	GSDeviceDX::OMBlendSelector om_bsel;
+
+	GSDeviceDX::PSSelector ps_sel;
+	GSDeviceDX::PSSamplerSelector ps_ssel;
+	GSDeviceDX::PSConstantBuffer ps_cb;
 
 public:
 	GSRendererDX(GSTextureCache* tc, const GSVector2& pixelcenter = GSVector2(0, 0));

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -515,40 +515,50 @@ void atst(float4 c)
 {
 	float a = trunc(c.a * 255 + 0.01);
 	
-	if(PS_ATST == 0) // never
-	{
-		discard;
-	}
-	else if(PS_ATST == 1) // always
+#if 0
+    switch(Uber_ATST) {
+        case 0:
+            break;
+        case 1:
+            if (a > AREF) discard;
+            break;
+        case 2:
+            if (a < AREF) discard;
+            break;
+        case 3:
+            if (abs(a - AREF) > 0.5f) discard;
+            break;
+        case 4:
+            if (abs(a - AREF) < 0.5f) discard;
+            break;
+    }
+
+#endif
+
+#if 1
+	if(PS_ATST == 0)
 	{
 		// nothing to do
 	}
-	else if(PS_ATST == 2) // l
+	else if(PS_ATST == 1)
 	{
 		#if PS_SPRITEHACK == 0
-		clip(AREF - a - 0.5f);
-		#endif				
+		if (a > AREF) discard;
+		#endif		
 	}
-	else if(PS_ATST == 3) // le
+	else if(PS_ATST == 2)
 	{
-		clip(AREF - a + 0.5f);
+		if (a < AREF) discard;	
 	}
-	else if(PS_ATST == 4) // e
+	else if(PS_ATST == 3)
 	{
-		clip(0.5f - abs(a - AREF));
+		 if (abs(a - AREF) > 0.5f) discard;
 	}
-	else if(PS_ATST == 5) // ge
+	else if(PS_ATST == 4)
 	{
-		clip(a - AREF + 0.5f);
+		if (abs(a - AREF) < 0.5f) discard;
 	}
-	else if(PS_ATST == 6) // g
-	{
-		clip(a - AREF - 0.5f);
-	}
-	else if(PS_ATST == 7) // ne
-	{
-		clip(abs(a - AREF) - 0.5f);
-	}
+#endif
 }
 
 float4 fog(float4 c, float f)


### PR DESCRIPTION
Port for the DX renderers of the alpha test improvement PR for OGL(#1514) created
by gregory38.

Tested and confirmed to work the same as OGL with both DX9 and DX11, fixing text issues for the Burnout games, Kengo and Ridge Racer V.