### PR TITLE
Make settings dialog usable with 1024x768 resolution

### DIFF
--- a/common/include/Utilities/wxGuiTools.h
+++ b/common/include/Utilities/wxGuiTools.h
@@ -553,7 +553,7 @@ protected:
 //    matically adjusts the width based on the sizer type (groupsizers get truncated to
 //    account for borders).
 //
-class wxPanelWithHelpers : public wxPanel
+class wxPanelWithHelpers : public wxScrolled<wxPanel>
 {
 	DECLARE_DYNAMIC_CLASS_NO_COPY(wxPanelWithHelpers)
 

--- a/common/src/Utilities/wxHelpers.cpp
+++ b/common/src/Utilities/wxHelpers.cpp
@@ -434,27 +434,27 @@ pxStaticText& wxPanelWithHelpers::Heading( const wxString& label )
 }
 
 wxPanelWithHelpers::wxPanelWithHelpers( wxWindow* parent, wxOrientation orient, const wxString& staticBoxLabel )
-	: wxPanel( parent )
+	: wxScrolled<wxPanel>( parent )
 {
 	SetSizer( new wxStaticBoxSizer( orient, this, staticBoxLabel ) );
 	Init();
 }
 
 wxPanelWithHelpers::wxPanelWithHelpers( wxWindow* parent, wxOrientation orient )
-	: wxPanel( parent )
+	: wxScrolled<wxPanel>( parent )
 {
 	SetSizer( new wxBoxSizer( orient ) );
 	Init();
 }
 
 wxPanelWithHelpers::wxPanelWithHelpers( wxWindow* parent )
-	: wxPanel( parent )
+	: wxScrolled<wxPanel>( parent )
 {
 	Init();
 }
 
 wxPanelWithHelpers::wxPanelWithHelpers( wxWindow* parent, const wxPoint& pos, const wxSize& size )
-	: wxPanel( parent, wxID_ANY, pos, size )
+	: wxScrolled<wxPanel>( parent, wxID_ANY, pos, size )
 {
 	Init();
 }

--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -229,6 +229,21 @@ Dialogs::SysConfigDialog::SysConfigDialog(wxWindow* parent)
 	AddOkCancel();
 	AddPresetsControl();
 
+	// Add scrollbars to Speedhacks and Gamefixes panels if dialog size
+	// exceed desktop size.
+	// Assume user have panels with 50px size in total.
+	if(GetBestSize().GetWidth() >= (wxSystemSettings::GetMetric(wxSYS_SCREEN_X) - 50) ||
+		GetBestSize().GetHeight() >= (wxSystemSettings::GetMetric(wxSYS_SCREEN_Y) - 50))
+	{
+		for(int i = 4; i <= 5; i++)
+		{
+			wxPanelWithHelpers* panel = (wxPanelWithHelpers*) m_listbook->GetPage(i);
+			panel->InvalidateBestSize();
+			panel->FitInside();
+			panel->SetScrollRate(10, 10);
+		}
+	}
+
 	SetSizerAndFit(GetSizer());
 
 	if( wxGetApp().Overrides.HasCustomHacks() )


### PR DESCRIPTION
Hi,

Currently PCSX2 settings dialog is not usable with 1024x768 resolution because Speedhacks and Gamefixes panels exceed 768 pixels height.

While Gamefixes can be split in 2 columns, it's hard to pack Speedhacks panel properly to fit both 1024 pixel width and 768 pixel height.

This PR:
1. Removes redundant vertical line and whitespace of slider messages from Speedhacks panel.
2. Makes pxCheckboxes height smaller to remove redundant whitespace from Speedhacks and Gamefixes panels.
3. Adds scrollbars to Speedhacks and Gamefixes panels.

This issue was originally [reported at Gentoo bugzilla](https://bugs.gentoo.org/show_bug.cgi?id=591316).
