### PR TITLE
EE: Minor changes to syscall function

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -34,7 +34,6 @@
 using namespace Threading;
 
 extern u8 psxhblankgate;
-extern bool gsIsInterlaced;
 static const uint EECNT_FUTURE_TARGET = 0x10000000;
 static int gates = 0;
 

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -32,8 +32,6 @@ void gsOnModeChanged( Fixed100 framerate, u32 newTickrate )
 	GetMTGS().SendSimplePacket( GS_RINGTYPE_MODECHANGE, framerate.Raw, newTickrate, 0 );
 }
 
-bool gsIsInterlaced	= false;
-
 
 void gsSetVideoMode(GS_VideoMode mode )
 {
@@ -154,20 +152,12 @@ __fi void gsWrite8(u32 mem, u8 value)
 	GIF_LOG("GS write 8 at %8.8lx with data %8.8lx", mem, value);
 }
 
-static void _gsSMODEwrite( u32 mem, u32 value )
-{
-	if(mem == GS_SMODE2)
-		gsIsInterlaced = (value & 0x1);
-}
-
 //////////////////////////////////////////////////////////////////////////
 // GS Write 16 bit
 
 __fi void gsWrite16(u32 mem, u16 value)
 {
 	GIF_LOG("GS write 16 at %8.8lx with data %8.8lx", mem, value);
-
-	_gsSMODEwrite( mem, value );
 
 	switch (mem)
 	{
@@ -198,8 +188,6 @@ __fi void gsWrite32(u32 mem, u32 value)
 	pxAssume( (mem & 3) == 0 );
 	GIF_LOG("GS write 32 at %8.8lx with data %8.8lx", mem, value);
 
-	_gsSMODEwrite( mem, value );
-
 	switch (mem)
 	{
 		case GS_CSR:
@@ -228,7 +216,6 @@ void __fastcall gsWrite64_generic( u32 mem, const mem64_t* value )
 void __fastcall gsWrite64_page_00( u32 mem, const mem64_t* value )
 {
 	gsWrite64_generic( mem, value );
-	_gsSMODEwrite( mem, (u32)value[0] );
 }
 
 void __fastcall gsWrite64_page_01( u32 mem, const mem64_t* value )
@@ -280,7 +267,6 @@ void __fastcall gsWrite64_page_01( u32 mem, const mem64_t* value )
 void __fastcall gsWrite128_page_00( u32 mem, const mem128_t* value )
 {
 	gsWrite128_generic( mem, value );
-	_gsSMODEwrite( mem, (u32)value[0] );
 }
 
 void __fastcall gsWrite128_page_01( u32 mem, const mem128_t* value )

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -233,6 +233,7 @@ enum class GS_VideoMode : int
 };
 
 extern GS_VideoMode gsVideoMode;
+extern bool gsIsInterlaced;
 
 /////////////////////////////////////////////////////////////////////////////
 // MTGS Threaded Class Declaration

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -25,6 +25,7 @@
 #include "GS.h"
 
 GS_VideoMode gsVideoMode = GS_VideoMode::Uninitialized;
+bool gsIsInterlaced = false;
 
 static __fi bool _add64_Overflow( s64 x, s64 y, s64 &ret )
 {
@@ -884,8 +885,13 @@ void SYSCALL()
 
 	switch (call) {
 		case 2: {
-					const char* inter = (cpuRegs.GPR.n.a0.UL[0] & 1) ? "Interlaced" : "Progressive";
-					const char* field = (cpuRegs.GPR.n.a2.UL[0] & 1) ? "FRAME" : "FIELD";
+					//Function "SetGsCrt(Interlace, Mode, Field)"
+					//Useful for fetching information of interlace/video/field display parameters of the Graphics Synthesizer
+
+					gsIsInterlaced = cpuRegs.GPR.n.a0.UL[0] & 1;
+					bool gsIsFrameMode = cpuRegs.GPR.n.a2.UL[0] & 1;
+					const char* inter = (gsIsInterlaced) ? "Interlaced" : "Progressive";
+					const char* field = (gsIsFrameMode) ? "FRAME" : "FIELD";
 					std::string mode;
 					// Warning info might be incorrect!
 					switch (cpuRegs.GPR.n.a1.UC[0])

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -883,8 +883,11 @@ void SYSCALL()
 
 	BIOS_LOG("Bios call: %s (%x)", R5900::bios[call], call);
 
-	switch (call) {
-		case 2: {
+
+	switch (static_cast<Syscall>(call))
+	{
+		case Syscall::SetGsCrt:
+		{
 					//Function "SetGsCrt(Interlace, Mode, Field)"
 					//Useful for fetching information of interlace/video/field display parameters of the Graphics Synthesizer
 
@@ -940,22 +943,12 @@ void SYSCALL()
 				}
 				break;
 
-		case 13:
+		case Syscall::SetVTLBRefillHandler:
 			DevCon.Warning("A tlb refill handler is set. New handler %x", (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
 			break;
 
-		case 0x7c:
-			{
-				if(cpuRegs.GPR.n.a0.UL[0] == 0x10)
-				{
-					eeConLog( ShiftJIS_ConvertString((char*)PSM(memRead32(cpuRegs.GPR.n.a1.UL[0]))) );
-				}
-				else
-					__Deci2Call( cpuRegs.GPR.n.a0.UL[0], (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]) );
-			}
-			break;
 
-		case 0x77:
+		case Syscall::sceSifSetDma:
 			// The only thing this code is used for is the one log message, so don't execute it if we aren't logging bios messages.
 			if (SysTraceActive(EE.Bios))
 			{
@@ -980,6 +973,17 @@ void SYSCALL()
 				}
 			}
 			break;
+
+		case Syscall::Deci2Call:
+		{
+			if (cpuRegs.GPR.n.a0.UL[0] == 0x10)
+			{
+				eeConLog(ShiftJIS_ConvertString((char*)PSM(memRead32(cpuRegs.GPR.n.a1.UL[0]))));
+			}
+			else
+				__Deci2Call(cpuRegs.GPR.n.a0.UL[0], (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
+		}
+		break;
 
 		default:
 			break;

--- a/pcsx2/R5900OpcodeTables.h
+++ b/pcsx2/R5900OpcodeTables.h
@@ -17,6 +17,14 @@
 
 #include "Pcsx2Defs.h"
 
+enum Syscall : u8
+{
+	SetGsCrt = 2,
+	SetVTLBRefillHandler = 13,
+	sceSifSetDma = 119,
+	Deci2Call = 124
+};
+
 // TODO : Move these into the OpcodeTables namespace
 extern  void (*Int_COP2PrintTable[32])();
 extern  void (*Int_COP2BC2PrintTable[32])();


### PR DESCRIPTION
**Summary of changes**:

* Move interlace/progressive & Frame/Field detection code to ``SetGsCrt()`` instead of relying on SMODE2 registers.
* Add some nice enums to improve code readability on ``SYSCALL()``.