### PR TITLE
pcsx2|common|gsdx: use empty() instead of .size() ==/!= 0 check

### DIFF
--- a/common/src/Utilities/wxAppWithHelpers.cpp
+++ b/common/src/Utilities/wxAppWithHelpers.cpp
@@ -482,7 +482,7 @@ void wxAppWithHelpers::OnSynchronousCommand( pxSynchronousCommandEvent& evt )
 void wxAppWithHelpers::AddIdleEvent( const wxEvent& evt )
 {
 	ScopedLock lock( m_IdleEventMutex );
-	if( m_IdleEventQueue.size() == 0 )
+	if( m_IdleEventQueue.empty() )
 		PostEvent(wxCommandEvent(pxEvt_StartIdleEventTimer));
 
 	m_IdleEventQueue.push_back( evt.Clone() );
@@ -491,7 +491,7 @@ void wxAppWithHelpers::AddIdleEvent( const wxEvent& evt )
 void wxAppWithHelpers::OnStartIdleEventTimer( wxCommandEvent& evt )
 {
 	ScopedLock lock( m_IdleEventMutex );
-	if( m_IdleEventQueue.size() != 0 )
+	if( !m_IdleEventQueue.empty() )
 		m_IdleEventTimer.Start( 100, true );
 }
 
@@ -535,7 +535,7 @@ void wxAppWithHelpers::IdleEventDispatcher( const wxChar* action )
 	}
 
 	m_IdleEventQueue = postponed;
-	if( m_IdleEventQueue.size() > 0 )
+	if( !m_IdleEventQueue.empty() )
 		pxAppLog.Write( L"(AppIdleQueue%s) %d events postponed due to dependencies.", action, m_IdleEventQueue.size() );
 }
 

--- a/pcsx2/CDVD/ChunksCache.cpp
+++ b/pcsx2/CDVD/ChunksCache.cpp
@@ -23,7 +23,7 @@ void ChunksCache::SetLimit(uint megabytes) {
 
 void ChunksCache::MatchLimit(bool removeAll) {
 	std::list<CacheEntry*>::reverse_iterator rit;
-	while (m_entries.size() && (removeAll || m_size > m_limit)) {
+	while (!m_entries.empty() && (removeAll || m_size > m_limit)) {
 		rit = m_entries.rbegin();
 		m_size -= (*rit)->size;
 		delete(*rit);

--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -108,7 +108,7 @@ std::map<u32,DisassemblyEntry*>::iterator findDisassemblyEntry(std::map<u32,Disa
 	if (exact)
 		return entries.find(address);
 
-	if (entries.size() == 0)
+	if (entries.empty())
 		return entries.end();
 
 	// find first elem that's >= address

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -502,7 +502,7 @@ void CtrlMemView::keydownEvent(wxKeyEvent& evt)
 		scrollWindow(GetClientSize().y/rowHeight);
 		break;
 	case WXK_ESCAPE:
-		if (history.size()) {
+		if (!history.empty()) {
 			gotoAddress(history.top());
 			history.pop();
 		}

--- a/pcsx2/gui/ExecutorThread.cpp
+++ b/pcsx2/gui/ExecutorThread.cpp
@@ -300,7 +300,7 @@ void pxEvtQueue::PostIdleEvent( SysExecEvent* evt )
 
 	pxEvtLog.Write( this, evt, pxsFmt(L"Posting event! (pending=%d, idle=%d) [idle]", m_pendingEvents.size(), m_idleEvents.size()) );
 
-	if( m_pendingEvents.size() == 0)
+	if( m_pendingEvents.empty() )
 	{
 		m_pendingEvents.push_back( evt );
 		m_wakeup.Post();

--- a/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
+++ b/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
@@ -30,7 +30,7 @@ using namespace Dialogs;
 //
 void ApplyStateStruct::DoCleanup() throw()
 {
-	pxAssertMsg( PanelList.size() != 0, L"PanelList list hasn't been cleaned up." );
+	pxAssertMsg( !PanelList.empty(), L"PanelList list hasn't been cleaned up." );
 	PanelList.clear();
 	ParentBook = NULL;
 }

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -1049,7 +1049,7 @@ void Panels::MemoryCardListPanel_Simple::OnOpenItemContextMenu(wxListEvent& evt)
 
 void Panels::MemoryCardListPanel_Simple::ReadFilesAtMcdFolder(){
 	//Dir enumeration/iteration code courtesy of cotton. - avih.
-	while( m_allFilesystemCards.size() )
+	while( !m_allFilesystemCards.empty() )
 		m_allFilesystemCards.pop_back();
 
 	m_filesystemPlaceholderCard.Slot=-1;

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -810,7 +810,7 @@ void VuBaseBlock::GetInstsAtPc(int instpc, std::list<VuInstruction*>& listinsts)
 		}
 	}
 
-	pxAssert(listinsts.size() > 0);
+	pxAssert(!listinsts.empty());
 }
 
 static VuFunctionHeader* SuperVURecompileProgram(u32 startpc, int vuindex)
@@ -1382,7 +1382,7 @@ static VuBaseBlock* SuperVUBuildBlocks(VuBaseBlock* parent, u32 startpc, const V
 #endif
 	{
 		// flush writebacks
-		if (listWritebacks.size() > 0)
+		if (!listWritebacks.empty())
 		{
 			listWritebacks.sort(WRITEBACK::SortWritebacks);
 			for (itwriteback = listWritebacks.begin(); itwriteback != listWritebacks.end(); ++itwriteback)
@@ -1428,7 +1428,7 @@ static VuBaseBlock* SuperVUBuildBlocks(VuBaseBlock* parent, u32 startpc, const V
 	newpipes.efu.sCycle -= vucycle;
 	for (i = 0; i < 8; ++i) newpipes.ialu[i].sCycle -= vucycle;
 
-	if (listWritebacks.size() > 0)
+	if (!listWritebacks.empty())
 	{
 		// flush all when jumping, send down the pipe when in branching
 		bool bFlushWritebacks = (vucode >> 25) == 0x24 || (vucode >> 25) == 0x25;//||(vucode>>25)==0x20||(vucode>>25)==0x21;
@@ -1455,7 +1455,7 @@ static VuBaseBlock* SuperVUBuildBlocks(VuBaseBlock* parent, u32 startpc, const V
 		}
 	}
 
-	if (newpipes.listWritebacks.size() > 0)  // other blocks might read the mac flags
+	if (!newpipes.listWritebacks.empty())  // other blocks might read the mac flags
 		pblock->type |= BLOCKTYPE_MACFLAGS;
 
 	u32 firstbranch = vucode >> 25;
@@ -1622,7 +1622,7 @@ static void SuperVUInitLiveness(VuBaseBlock* pblock)
 {
 	std::list<VuInstruction>::iterator itinst, itnext;
 
-	pxAssert(pblock->insts.size() > 0);
+	pxAssert(!pblock->insts.empty());
 
 	for (itinst = pblock->insts.begin(); itinst != pblock->insts.end(); ++itinst)
 	{
@@ -1721,7 +1721,7 @@ static void SuperVULivenessAnalysis()
 			// the last inst relies on the neighbor's insts
 			itinst = --pb->insts.end();
 
-			if (pb->blocks.size() > 0)
+			if (!pb->blocks.empty())
 			{
 				livevars[0] = 0;
 				livevars[1] = 0;
@@ -2326,13 +2326,13 @@ void VuBaseBlock::AssignVIRegs(int parent)
 	_x86regs* pregs = &s_vecRegArray[allocX86Regs];
 	memset(pregs, 0, sizeof(_x86regs)*iREGCNT_GPR);
 
-	pxAssert(parents.size() > 0);
+	pxAssert(!parents.empty());
 
 	std::list<VuBaseBlock*>::iterator itparent;
 	u32 usedvars = insts.front().usedvars[0];
 	u32 livevars = insts.front().livevars[0];
 
-	if (parents.size() > 0)
+	if (!parents.empty())
 	{
 		u32 usedvars2 = 0xffffffff;
 
@@ -2714,7 +2714,7 @@ static void SuperVURecompile()
 
 				if (pchild->type & BLOCKTYPE_HASEOP)
 				{
-					pxAssert(pchild->blocks.size() == 0);
+					pxAssert(pchild->blocks.empty());
 
 					xAND(ptr32[&VU0.VI[ REG_VPU_STAT ].UL], s_vu ? ~0x100 : ~0x001); // E flag
 					//xAND(ptr32[(&VU->GetVifRegs().stat)], ~VIF1_STAT_VEW);
@@ -3012,7 +3012,7 @@ void VuBaseBlock::Recompile()
 		else
 		{
 			// take from children
-			if (blocks.size() > 0)
+			if (!blocks.empty())
 			{
 				LISTBLOCKS::iterator itchild;
 				for(itchild = blocks.begin(); itchild != blocks.end(); itchild++)

--- a/plugins/GSdx/GSDevice.cpp
+++ b/plugins/GSdx/GSDevice.cpp
@@ -203,7 +203,7 @@ void GSDevice::AgePool()
 void GSDevice::PurgePool()
 {
 	// OOM emergency. Let's free this useless pool
-	while(m_pool.size() > 0)
+	while(!m_pool.empty())
 	{
 		delete m_pool.back();
 


### PR DESCRIPTION
Enhance readability reported by clang tidy