### PR TITLE
PCSX2: Fix a bunch of coverity defects

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -335,14 +335,13 @@ u32 UpdateVSyncRate()
 		scanlines = SCANLINES_TOTAL_NTSC;
 		break;
 
-	// Falls through to unknown when unidentified mode parameter of SetGsCrt is detected.
 	case GS_VideoMode::Unknown:
+	default:
+		// Falls through to default when unidentified mode parameter of SetGsCrt is detected.
 		// For Release builds, keep using the NTSC timing values when unknown video mode is detected.
 		// Assert will be triggered for debug/dev builds.
 		scanlines = SCANLINES_TOTAL_NTSC;
 		Console.Error("PCSX2-Counters: Unknown video mode detected");
-
-	default:
 		pxAssertDev(false , "Unknown video mode detected via SetGsCrt");
 	}
 

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -304,13 +304,17 @@ VuBaseBlock::VuBaseBlock()
 	type = 0;
 	endpc = 0;
 	cycles = 0;
-	pcode = NULL;
 	id = 0;
 	memzero(pChildJumps);
 	memzero(startregs);
 	memzero(endregs);
 	allocX86Regs = nStartx86 = nEndx86 = -1;
 	prevFlagsOutOfBlock = 0;
+	startpc = 0;
+	vuxy = 0;
+	vuxyz = 0;
+	pendcode = nullptr;
+	pcode = nullptr;
 }
 
 #define SUPERVU_STACKSIZE 0x1000

--- a/plugins/LilyPad/InputManager.cpp
+++ b/plugins/LilyPad/InputManager.cpp
@@ -433,7 +433,6 @@ Device *InputDeviceManager::GetActiveDevice(InitInfo *info, unsigned int *uid, i
 							  (devices[i]->oldVirtualControlState[j] > 31*FULLY_DOWN/32 && devices[i]->virtualControlState[j] < 7*FULLY_DOWN/8))) {
 									continue;
 						}
-						devices[i]->virtualControls[j].uid = devices[i]->virtualControls[j].uid;
 					}
 					else if ((((devices[i]->virtualControls[j].uid>>16)&0xFF) == ABSAXIS)) {
 						if (devices[i]->oldVirtualControlState[j] > 15*FULLY_DOWN/16)


### PR DESCRIPTION
**Summary of changes**:

* EE-Counters : the defect coverity found was not actually an issue but apparently someone marked it as ``fix required`` so FWIW I made the code behavior more explicit by moving the unknown video mode handling to default case.

* LilyPad : Remove useless self assignment.

* PCSX2-Core : Initialize class members on GIF/VIF/SuperVU


Initially I was planning on only fixing the defect which I had introduced (counters code) though that would make the PR too small and pointless so made a bunch of random defect fixes along with it.