### PR TITLE
clang-tidy: use parenthesis around macro parameters

### DIFF
--- a/pcsx2/IPU/mpeg2lib/Idct.cpp
+++ b/pcsx2/IPU/mpeg2lib/Idct.cpp
@@ -38,8 +38,6 @@
 #define W5 1609 /* 2048*sqrt (2)*cos (5*pi/16) */
 #define W6 1108 /* 2048*sqrt (2)*cos (6*pi/16) */
 #define W7 565  /* 2048*sqrt (2)*cos (7*pi/16) */
-#define clp(val,res)	res = (val < 0) ? 0 : ((val > 255) ? 255 : val);
-#define clp2(val,res)	res = (val < -255) ? -255 : ((val > 255) ? 255 : val);
 
 /*
  * In legal streams, the IDCT output should be between -384 and +384.

--- a/pcsx2/IPU/mpeg2lib/Idct.cpp
+++ b/pcsx2/IPU/mpeg2lib/Idct.cpp
@@ -51,20 +51,17 @@ static __aligned16 u8 clip_lut[1024];
 
 #define CLIP(i) ((clip_lut+384)[(i)])
 
+static __fi void BUTTERFLY(int& t0, int& t1, int w0, int w1, int d0, int d1)
+{
 #if 0
-#define BUTTERFLY(t0,t1,W0,W1,d0,d1)	\
-do {					\
-    t0 = W0*d0 + W1*d1;			\
-    t1 = W0*d1 - W1*d0;			\
-} while (0)
+    t0 = w0*d0 + w1*d1;
+    t1 = w0*d1 - w1*d0;
 #else
-#define BUTTERFLY(t0,t1,W0,W1,d0,d1)	\
-do {					\
-    int tmp = W0 * (d0 + d1);		\
-    t0 = tmp + (W1 - W0) * d1;		\
-    t1 = tmp - (W1 + W0) * d0;		\
-} while (0)
+    int tmp = w0 * (d0 + d1);
+    t0 = tmp + (w1 - w0) * d1;
+    t1 = tmp - (w1 + w0) * d0;
 #endif
+}
 
 static __fi void idct_row (s16 * const block)
 {

--- a/pcsx2/IPU/mpeg2lib/Mpeg.cpp
+++ b/pcsx2/IPU/mpeg2lib/Mpeg.cpp
@@ -334,11 +334,11 @@ static __fi int get_chroma_dc_dct_diff()
 	return dc_diff;
 }
 
-#define SATURATE(val)					\
-do {							\
-	 if (((u32)(val + 2048) > 4095))	\
-	val = (((s32)val) >> 31) ^ 2047;			\
-} while (0)
+static __fi void SATURATE(int& val)
+{
+	if ((u32)(val + 2048) > 4095)
+		val = (val >> 31) ^ 2047;
+}
 
 static bool get_intra_block()
 {

--- a/pcsx2/IPU/yuv2rgb.cpp
+++ b/pcsx2/IPU/yuv2rgb.cpp
@@ -28,11 +28,11 @@
 // faster or "more accurate" implementation, but this is the precise documented integer method used by
 // the hardware and is fast enough with SSE2.
 
-#define IPU_Y_BIAS 16
-#define IPU_C_BIAS 128
-#define IPU_Y_COEFF 0x95	//  1.1640625
-#define IPU_GCR_COEFF -0x68	// -0.8125
-#define IPU_GCB_COEFF -0x32	// -0.390625
+#define IPU_Y_BIAS    16
+#define IPU_C_BIAS    128
+#define IPU_Y_COEFF   0x95	//  1.1640625
+#define IPU_GCR_COEFF (-0x68)	// -0.8125
+#define IPU_GCB_COEFF (-0x32)	// -0.390625
 #define IPU_RCR_COEFF 0xcc	//  1.59375
 #define IPU_BCB_COEFF 0x102	//  2.015625
 

--- a/pcsx2/IopGte.cpp
+++ b/pcsx2/IopGte.cpp
@@ -425,8 +425,8 @@ __inline s32 FNC_OVERFLOW4(s64 x) {
 }
 
 #define _LIMX(negv, posv, flagb) { \
-	if (x < (negv)) { x = (negv); gteFLAG |= (1<<flagb); } else \
-	if (x > (posv)) { x = (posv); gteFLAG |= (1<<flagb); } return (x); \
+	if (x < (negv)) { x = (negv); gteFLAG |= (1<<(flagb)); } else \
+	if (x > (posv)) { x = (posv); gteFLAG |= (1<<(flagb)); } return (x); \
 }
 
 __inline double limA1S(double x) { _LIMX(-32768.0, 32767.0, 24); }

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -21,9 +21,11 @@
 
 __aligned16 VU_Thread vu1Thread(CpuVU1, VU1);
 
-#define size_u32(x) (((u32)x+3u)>>2) // Rounds up a size in bytes for size in u32's
 #define MTVU_ALWAYS_KICK 0
 #define MTVU_SYNC_MODE   0
+
+// Rounds up a size in bytes for size in u32's
+static __fi u32 size_u32(u32 x) { return (x + 3) >> 2; }
 
 enum MTVU_EVENT {
 	MTVU_VU_EXECUTE,     // Execute VU program

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -35,11 +35,6 @@
 #define _Fs_ _Rd_
 #define _Fd_ _Sa_
 
-#define _X (cpuRegs.code>>24) & 0x1
-#define _Y (cpuRegs.code>>23) & 0x1
-#define _Z (cpuRegs.code>>22) & 0x1
-#define _W (cpuRegs.code>>21) & 0x1
-
 #define _Fsf_ ((cpuRegs.code >> 21) & 0x03)
 #define _Ftf_ ((cpuRegs.code >> 23) & 0x03)
 

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -26,8 +26,6 @@
 
 using namespace R5900;
 
-#define VF_VAL(x) ((x==0x80000000)?0:(x))
-
 // This is called by the COP2 as per the CTC instruction
 void vu0ResetRegs()
 {

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -27,8 +27,6 @@
 u32 vudump = 0;
 #endif
 
-#define VF_VAL(x) ((x==0x80000000)?0:(x))
-
 // This is called by the COP2 as per the CTC instruction
 void vu1ResetRegs()
 {

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -2240,7 +2240,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFr0xyzw= _XYZW; \
 	VUregsn->VFread1 = 0; \
 	VUregsn->VIwrite = 0; \
-	VUregsn->VIread  = (1 << REG_I)|(ACC?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_); \
+	VUregsn->VIread  = (1 << REG_I)|((ACC)?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_); \
 }
 
 #define VUREGS_FDFSQ(OP, ACC) \
@@ -2252,7 +2252,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFr0xyzw= _XYZW; \
 	VUregsn->VFread1 = 0; \
 	VUregsn->VIwrite = 0; \
-	VUregsn->VIread  = (1 << REG_Q)|(ACC?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_); \
+	VUregsn->VIread  = (1 << REG_Q)|((ACC)?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_); \
 }
 
 #define VUREGS_FDFSFT(OP, ACC) \
@@ -2265,7 +2265,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFread1 = _Ft_; \
 	VUregsn->VFr1xyzw= _XYZW; \
 	VUregsn->VIwrite = 0; \
-	VUregsn->VIread  = (ACC?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_); \
+	VUregsn->VIread  = ((ACC)?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_); \
 }
 
 #define VUREGS_FDFSFTxyzw(OP, xyzw, ACC) \
@@ -2278,7 +2278,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFread1 = _Ft_; \
 	VUregsn->VFr1xyzw= xyzw; \
 	VUregsn->VIwrite = 0; \
-	VUregsn->VIread  = (ACC?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_); \
+	VUregsn->VIread  = ((ACC)?(1<<REG_ACC_FLAG):0)|GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_); \
 }
 
 #define VUREGS_FDFSFTx(OP, ACC) VUREGS_FDFSFTxyzw(OP, 8, ACC)
@@ -2296,7 +2296,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFr0xyzw= _XYZW; \
 	VUregsn->VFread1 = 0; \
 	VUregsn->VIwrite = (1<<REG_ACC_FLAG); \
-	VUregsn->VIread  = (1 << REG_I)|GET_VF0_FLAG(_Fs_)|((readacc||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
+	VUregsn->VIread  = (1 << REG_I)|GET_VF0_FLAG(_Fs_)|(((readacc)||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
 }
 
 #define VUREGS_ACCFSQ(OP, readacc) \
@@ -2308,7 +2308,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFr0xyzw= _XYZW; \
 	VUregsn->VFread1 = 0; \
 	VUregsn->VIwrite = (1<<REG_ACC_FLAG); \
-	VUregsn->VIread  = (1 << REG_Q)|GET_VF0_FLAG(_Fs_)|((readacc||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
+	VUregsn->VIread  = (1 << REG_Q)|GET_VF0_FLAG(_Fs_)|(((readacc)||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
 }
 
 #define VUREGS_ACCFSFT(OP, readacc) \
@@ -2321,7 +2321,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFread1 = _Ft_; \
 	VUregsn->VFr1xyzw= _XYZW; \
 	VUregsn->VIwrite = (1<<REG_ACC_FLAG); \
-	VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_)|((readacc||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
+	VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_)|(((readacc)||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
 }
 
 #define VUREGS_ACCFSFTxyzw(OP, xyzw, readacc) \
@@ -2334,7 +2334,7 @@ static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
 	VUregsn->VFread1 = _Ft_; \
 	VUregsn->VFr1xyzw= xyzw; \
 	VUregsn->VIwrite = (1<<REG_ACC_FLAG); \
-	VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_)|((readacc||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
+	VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_)|(((readacc)||_XYZW!=15)?(1<<REG_ACC_FLAG):0); \
 }
 
 #define VUREGS_ACCFSFTx(OP, readacc) VUREGS_ACCFSFTxyzw(OP, 8, readacc)
@@ -2437,27 +2437,27 @@ VUREGS_ACCFSFTw(SUBAw, 0);
 
 #define VUREGS_FDFSFTxyzw_MUL(OP, ACC, xyzw) \
 static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
-	if( _Ft_ == 0 && xyzw > 1 && _XYZW == 0xf ) { /* resetting to 0 */ \
+	if( _Ft_ == 0 && (xyzw) > 1 && _XYZW == 0xf ) { /* resetting to 0 */ \
 		VUregsn->pipe = VUPIPE_FMAC; \
-		VUregsn->VFwrite = ACC?0:_Fd_; \
+		VUregsn->VFwrite = (ACC)?0:_Fd_; \
 		VUregsn->VFwxyzw = _XYZW; \
 		VUregsn->VFread0 = 0; \
 		VUregsn->VFr0xyzw= _XYZW; \
 		VUregsn->VFread1 = 0; \
 		VUregsn->VFr1xyzw= xyzw; \
-		VUregsn->VIwrite = (ACC?(1<<REG_ACC_FLAG):0); \
-		VUregsn->VIread  = (ACC&&(_XYZW!=15))?(1<<REG_ACC_FLAG):0; \
+		VUregsn->VIwrite = ((ACC)?(1<<REG_ACC_FLAG):0); \
+		VUregsn->VIread  = ((ACC)&&(_XYZW!=15))?(1<<REG_ACC_FLAG):0; \
 	} \
 	else { \
 		VUregsn->pipe = VUPIPE_FMAC; \
-		VUregsn->VFwrite = ACC?0:_Fd_; \
+		VUregsn->VFwrite = (ACC)?0:_Fd_; \
 		VUregsn->VFwxyzw = _XYZW; \
 		VUregsn->VFread0 = _Fs_; \
 		VUregsn->VFr0xyzw= _XYZW; \
 		VUregsn->VFread1 = _Ft_; \
 		VUregsn->VFr1xyzw= xyzw; \
-		VUregsn->VIwrite = (ACC?(1<<REG_ACC_FLAG):0); \
-		VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|((ACC&&(_XYZW!=15))?(1<<REG_ACC_FLAG):0); \
+		VUregsn->VIwrite = ((ACC)?(1<<REG_ACC_FLAG):0); \
+		VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|(((ACC)&&(_XYZW!=15))?(1<<REG_ACC_FLAG):0); \
 	} \
 }
 

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -409,6 +409,10 @@ namespace Panels
 		void PopulateFields( const wxString& serial=wxEmptyString );
 		bool WriteFieldsToDB();
 		void Search_Click( wxCommandEvent& evt );
+
+	private:
+		void placeTextBox(wxFlexGridSizer& sizer1, wxTextCtrl* wxBox, const wxString& txt);
+		void blankLine(wxFlexGridSizer& sizer1);
 	};
 
 	class SettingsDirPickerPanel : public DirPickerPanel

--- a/pcsx2/gui/Panels/GameDatabasePanel.cpp
+++ b/pcsx2/gui/Panels/GameDatabasePanel.cpp
@@ -309,18 +309,6 @@ wxListItemAttr* GameDatabaseListView::OnGetItemAttr(long item) const
 }
 
 
-#define blankLine() {	\
-	sizer1+=5; sizer1+=5; sizer1+=Text(wxEmptyString); sizer1+=5; sizer1+=5;	\
-}
-
-#define placeTextBox(wxBox, txt) {	\
-	sizer1	+= Label(_(txt));		\
-	sizer1	+= 5;					\
-	sizer1	+= wxBox | pxCenter;	\
-	sizer1	+= 5;					\
-	sizer1	+= 5;					\
-}
-
 wxTextCtrl* CreateMultiLineTextCtrl( wxWindow* parent, int digits, long flags = 0 )
 {
 	wxTextCtrl* ctrl = new wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
@@ -350,20 +338,20 @@ Panels::GameDatabasePanel::GameDatabasePanel( wxWindow* parent )
 	wxFlexGridSizer& sizer1(*new wxFlexGridSizer(5, StdPadding, 0));
 	sizer1.AddGrowableCol(0);
 
-	blankLine();
-	sizer1	+= Label(L"Serial: ");	
+	blankLine(sizer1);
+	sizer1	+= Label(L"Serial: ");
 	sizer1	+= 5;
 	sizer1	+= serialBox | pxCenter;
 	sizer1	+= 5;
 	sizer1	+= searchBtn;
 
-	placeTextBox(nameBox,    "Name: ");
-	placeTextBox(regionBox,  "Region: ");
-	placeTextBox(compatBox,  "Compatibility: ");
-	placeTextBox(commentBox, "Comments: ");
-	placeTextBox(patchesBox, "Patches: ");
+	placeTextBox(sizer1, nameBox,    _("Name: "));
+	placeTextBox(sizer1, regionBox,  _("Region: "));
+	placeTextBox(sizer1, compatBox,  _("Compatibility: "));
+	placeTextBox(sizer1, commentBox, _("Comments: "));
+	placeTextBox(sizer1, patchesBox, _("Patches: "));
 
-	blankLine();
+	blankLine(sizer1);
 
 	wxStaticBoxSizer& sizer2 = *new wxStaticBoxSizer(wxVERTICAL, this, _("Gamefixes"));
 	wxFlexGridSizer&  sizer3(*new wxFlexGridSizer(3, 0, StdPadding*4));
@@ -379,6 +367,20 @@ Panels::GameDatabasePanel::GameDatabasePanel( wxWindow* parent )
 	
 	Bind(wxEVT_BUTTON, &GameDatabasePanel::Search_Click, this, searchBtn->GetId());
 	PopulateFields();
+}
+
+void Panels::GameDatabasePanel::blankLine(wxFlexGridSizer& sizer1)
+{
+	sizer1+=5; sizer1+=5; sizer1+=Text(wxEmptyString); sizer1+=5; sizer1+=5;
+}
+
+void Panels::GameDatabasePanel::placeTextBox(wxFlexGridSizer& sizer1, wxTextCtrl* wxBox, const wxString& txt)
+{
+	sizer1	+= Label(txt);
+	sizer1	+= 5;
+	sizer1	+= wxBox | pxCenter;
+	sizer1	+= 5;
+	sizer1	+= 5;
 }
 
 void Panels::GameDatabasePanel::PopulateFields( const wxString& id ) {
@@ -415,11 +417,6 @@ void Panels::GameDatabasePanel::PopulateFields( const wxString& id ) {
 			gameFixes[i]->SetValue(0);
 		}
 	}
-}
-
-#define writeTextBoxToDB(_key, _value) {								\
-	if (_value.IsEmpty()) 	GameDB->deleteKey(wxT(_key));				\
-	else					GameDB->writeString(wxT(_key), _value);		\
 }
 
 // returns True if the database is modified, or FALSE if no changes to save.

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -437,19 +437,29 @@ static __ri void vtlb_BusError(u32 addr,u32 mode)
 		Console.Error( R5900Exception::TLBMiss( addr, !!mode ).FormatMessage() );
 }
 
-#define _tmpl(ret) template<typename OperandType, u32 saddr> ret __fastcall
+template<typename OperandType, u32 saddr>
+OperandType __fastcall vtlbUnmappedVReadSm(u32 addr)					{ vtlb_Miss(addr|saddr,0); return 0; }
 
-_tmpl(OperandType) vtlbUnmappedVReadSm(u32 addr)					{ vtlb_Miss(addr|saddr,0); return 0; }
-_tmpl(void) vtlbUnmappedVReadLg(u32 addr,OperandType* data)			{ vtlb_Miss(addr|saddr,0); }
-_tmpl(void) vtlbUnmappedVWriteSm(u32 addr,OperandType data)			{ vtlb_Miss(addr|saddr,1); }
-_tmpl(void) vtlbUnmappedVWriteLg(u32 addr,const OperandType* data)	{ vtlb_Miss(addr|saddr,1); }
+template<typename OperandType, u32 saddr>
+void __fastcall vtlbUnmappedVReadLg(u32 addr,OperandType* data)			{ vtlb_Miss(addr|saddr,0); }
 
-_tmpl(OperandType) vtlbUnmappedPReadSm(u32 addr)					{ vtlb_BusError(addr|saddr,0); return 0; }
-_tmpl(void) vtlbUnmappedPReadLg(u32 addr,OperandType* data)			{ vtlb_BusError(addr|saddr,0); }
-_tmpl(void) vtlbUnmappedPWriteSm(u32 addr,OperandType data)			{ vtlb_BusError(addr|saddr,1); }
-_tmpl(void) vtlbUnmappedPWriteLg(u32 addr,const OperandType* data)	{ vtlb_BusError(addr|saddr,1); }
+template<typename OperandType, u32 saddr>
+void __fastcall vtlbUnmappedVWriteSm(u32 addr,OperandType data)			{ vtlb_Miss(addr|saddr,1); }
 
-#undef _tmpl
+template<typename OperandType, u32 saddr>
+void __fastcall vtlbUnmappedVWriteLg(u32 addr,const OperandType* data)	{ vtlb_Miss(addr|saddr,1); }
+
+template<typename OperandType, u32 saddr>
+OperandType __fastcall vtlbUnmappedPReadSm(u32 addr)					{ vtlb_BusError(addr|saddr,0); return 0; }
+
+template<typename OperandType, u32 saddr>
+void __fastcall vtlbUnmappedPReadLg(u32 addr,OperandType* data)			{ vtlb_BusError(addr|saddr,0); }
+
+template<typename OperandType, u32 saddr>
+void __fastcall vtlbUnmappedPWriteSm(u32 addr,OperandType data)			{ vtlb_BusError(addr|saddr,1); }
+
+template<typename OperandType, u32 saddr>
+void __fastcall vtlbUnmappedPWriteLg(u32 addr,const OperandType* data)	{ vtlb_BusError(addr|saddr,1); }
 
 // --------------------------------------------------------------------------------------
 //  VTLB mapping errors
@@ -510,7 +520,6 @@ static void __fastcall vtlbDefaultPhyWrite128(u32 addr,const mem128_t* data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write128 to unmapped physical address @ 0x%08X.", addr));
 }
-#undef _tmpl
 
 // ===========================================================================================
 //  VTLB Public API -- Init/Term/RegisterHandler stuff 

--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -285,19 +285,19 @@ void SetMaxValue(int regd)
 	if( info & PROCESS_EE_S ) xMOVSS(xRegisterSSE(sreg), xRegisterSSE(EEREC_S)); \
 	else xMOVSSZX(xRegisterSSE(sreg), ptr[&fpuRegs.fpr[_Fs_]]); }
 
-#define ALLOC_S(sreg) { sreg = _allocTempXMMreg(XMMT_FPS, -1);  GET_S(sreg); }
+#define ALLOC_S(sreg) { (sreg) = _allocTempXMMreg(XMMT_FPS, -1);  GET_S(sreg); }
 
 #define GET_T(treg) { \
 	if( info & PROCESS_EE_T ) xMOVSS(xRegisterSSE(treg), xRegisterSSE(EEREC_T)); \
 	else xMOVSSZX(xRegisterSSE(treg), ptr[&fpuRegs.fpr[_Ft_]]); }
 
-#define ALLOC_T(treg) { treg = _allocTempXMMreg(XMMT_FPS, -1);  GET_T(treg); }
+#define ALLOC_T(treg) { (treg) = _allocTempXMMreg(XMMT_FPS, -1);  GET_T(treg); }
 
 #define GET_ACC(areg) { \
 	if( info & PROCESS_EE_ACC ) xMOVSS(xRegisterSSE(areg), xRegisterSSE(EEREC_ACC)); \
 	else xMOVSSZX(xRegisterSSE(areg), ptr[&fpuRegs.ACC]); }
 
-#define ALLOC_ACC(areg) { areg = _allocTempXMMreg(XMMT_FPS, -1);  GET_ACC(areg); }
+#define ALLOC_ACC(areg) { (areg) = _allocTempXMMreg(XMMT_FPS, -1);  GET_ACC(areg); }
 
 #define CLEAR_OU_FLAGS { xAND(ptr32[&fpuRegs.fprc[31]], ~(FPUflagO | FPUflagU)); }
 

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -49,7 +49,7 @@ u32 s_psxrecblocks[] = {0};
 uptr psxRecLUT[0x10000];
 uptr psxhwLUT[0x10000];
 
-#define HWADDR(mem) (psxhwLUT[mem >> 16] + (mem))
+static __fi u32 HWADDR(u32 mem) { return psxhwLUT[mem >> 16] + mem; }
 
 static RecompiledCodeReserve* recMem = NULL;
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -53,7 +53,7 @@ u32 maxrecmem = 0;
 static __aligned16 uptr recLUT[_64kb];
 static __aligned16 uptr hwLUT[_64kb];
 
-#define HWADDR(mem) (hwLUT[mem >> 16] + (mem))
+static __fi u32 HWADDR(u32 mem) { return hwLUT[mem >> 16] + mem; }
 
 u32 s_nBlockCycles = 0; // cycles of current block recompiling
 

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -68,8 +68,9 @@ VifUnpackSSE_Dynarec::VifUnpackSSE_Dynarec(const nVifStruct& vif_, const nVifBlo
 	vCL			= 0;
 }
 
-#define makeMergeMask(x) {									\
-	x = ((x&0x40)>>6) | ((x&0x10)>>3) | (x&4) | ((x&1)<<3);	\
+__fi void makeMergeMask(u32& x)
+{
+	x = ((x&0x40)>>6) | ((x&0x10)>>3) | (x&4) | ((x&1)<<3);
 }
 
 __fi void VifUnpackSSE_Dynarec::SetMasks(int cS) const {

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -28,20 +28,20 @@
 #include "GSLocalMemory.h"
 
 #define ASSERT_BLOCK(r, w, h) \
-	ASSERT((r).width() >= w && (r).height() >= h && !((r).left & (w - 1)) && !((r).top & (h - 1)) && !((r).right & (w - 1)) && !((r).bottom & (h - 1))); \
+	ASSERT((r).width() >= (w) && (r).height() >= (h) && !((r).left & ((w) - 1)) && !((r).top & ((h) - 1)) && !((r).right & ((w) - 1)) && !((r).bottom & ((h) - 1))); \
 
 #define FOREACH_BLOCK_START(r, w, h, bpp) \
 	ASSERT_BLOCK(r, w, h); \
-	GSVector4i _r = r >> 3; \
-	uint8* _dst = dst - _r.left * bpp; \
-	int _offset = dstpitch * h; \
-	for(int y = _r.top; y < _r.bottom; y += h >> 3, _dst += _offset) \
+	GSVector4i _r = (r) >> 3; \
+	uint8* _dst = dst - _r.left * (bpp); \
+	int _offset = dstpitch * (h); \
+	for(int y = _r.top; y < _r.bottom; y += (h) >> 3, _dst += _offset) \
 	{ \
 		uint32 _base = off->block.row[y]; \
-		for(int x = _r.left; x < _r.right; x += w >> 3) \
+		for(int x = _r.left; x < _r.right; x += (w) >> 3) \
 		{ \
 			const uint8* src = BlockPtr(_base + off->block.col[x]); \
-			uint8* read_dst = &_dst[x * bpp]; \
+			uint8* read_dst = &_dst[x * (bpp)]; \
 
 #define FOREACH_BLOCK_END }}
 

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -1037,8 +1037,10 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const uint8* src, int len, GIFR
 }
 
 
-#define IsTopLeftAligned(dsax, tx, ty, bw, bh) \
-	((((int)dsax) & ((bw)-1)) == 0 && ((tx) & ((bw)-1)) == 0 && ((int)dsax) == (tx) && ((ty) & ((bh)-1)) == 0)
+static bool IsTopLeftAligned(int dsax, int tx, int ty, int bw, int bh)
+{
+	return ((dsax & (bw-1)) == 0 && (tx & (bw-1)) == 0 && dsax == tx && (ty & (bh-1)) == 0);
+}
 
 void GSLocalMemory::WriteImage24(int& tx, int& ty, const uint8* src, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG)
 {

--- a/plugins/spu2-x/src/ADSR.cpp
+++ b/plugins/spu2-x/src/ADSR.cpp
@@ -38,8 +38,6 @@ void InitADSR()                                    // INIT ADSR
 	}
 }
 
-#define VOL(x) (((s32)x)) //24.8 volume
-
 // Returns the linear slide value for AR and SR inputs.
 // (currently not used, it's buggy)
 static int GetLinearSrAr( uint SrAr )

--- a/plugins/spu2-x/src/Spu2replay.cpp
+++ b/plugins/spu2-x/src/Spu2replay.cpp
@@ -35,7 +35,10 @@ void s2r_write32(u32 data)
 	fwrite(&data,4,1,s2rfile);
 }
 
-#define EMITC(i,a) s2r_write32(((u32)(i&0x7)<<29)|(a&0x1FFFFFFF))
+static void EMITC(u32 i, u32 a)
+{
+	s2r_write32(((i&0x7u)<<29u)|(a&0x1FFFFFFFu));
+}
 
 int s2r_open(u32 ticks, char *filename)
 {

--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -990,8 +990,8 @@ static void __fastcall RegWrite_Core( u16 value )
 		SetLoWord( thiscore.Regs.reg_out, value ); \
 	if( result == thiscore.Regs.reg_out ) break; \
 	\
-	const uint start_bit	= hiword ? 16 : 0; \
-	const uint end_bit		= hiword ? 24 : 16; \
+	const uint start_bit	= (hiword) ? 16 : 0; \
+	const uint end_bit		= (hiword) ? 24 : 16; \
 	for (uint vc=start_bit, vx=1; vc<end_bit; ++vc, vx<<=1) \
 		thiscore.VoiceGates[vc].mask_out = (value & vx) ? -1 : 0; \
 }
@@ -1264,10 +1264,10 @@ static void __fastcall RegWrite_Null( u16 value )
 
 
 #define CoreParamsPair( core, omem ) \
-	RegWrite_Core<core, omem>, RegWrite_Core<core, (omem+2)>
+	RegWrite_Core<core, omem>, RegWrite_Core<core, ((omem)+2)>
 
 #define ReverbPair( core, mem ) \
-	RegWrite_Reverb<core, mem>, RegWrite_Core<core, (mem+2)>
+	RegWrite_Reverb<core, mem>, RegWrite_Core<core, ((mem)+2)>
 
 #define REGRAW(addr) RegWrite_Raw<addr>
 


### PR DESCRIPTION
Could avoid misused in the future

Clang Tidy warning misc-macro-parentheses 157 => 66