### PR TITLE
gsdx: save the blit buffer register when a transfer is started

### DIFF
--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -143,11 +143,12 @@ class GSState : public GSAlignedClass<32>
 		int start, end, total;
 		bool overflow;
 		uint8* buff;
+		GIFRegBITBLTBUF m_blit;
 
 		GSTransferBuffer();
 		virtual ~GSTransferBuffer();
 
-		void Init(int tx, int ty);
+		void Init(int tx, int ty, const GIFRegBITBLTBUF& blit);
 		bool Update(int tw, int th, int bpp, int& len);
 
 	} m_tr;


### PR DESCRIPTION
Fix motocross mania missing texture. Close #1319

As far as I understand, transfer is initialized in DIR. But the real
write only occured later so the blit buffer could have been overwritten
by a new value.

BLIT 0 13700
TREG 40 40
DIR 0 0
BLIT 0 13f00 <=== the bad guy
Write! ...  => 0x3f00 W:1 F:C_32 (DIR 00), dPos(0 0) size(64 64)