### PR TITLE
cdvdgigaherz: Use SPTI to read raw CD sectors

### DIFF
--- a/plugins/cdvdGigaherz/src/CDVD.h
+++ b/plugins/cdvdGigaherz/src/CDVD.h
@@ -90,7 +90,7 @@ class IOCtlSrc: public Source
 	IOCtlSrc(IOCtlSrc&);
 
 	HANDLE device;
-
+	bool m_can_use_spti;
 	bool OpenOK;
 
 	s32 last_read_mode;


### PR DESCRIPTION
IOCTL_CDROM_RAW_READ apparently does not work for some read modes on some optical drives, which makes some CD-ROM games unplayable from the disc.

Work around the issue by using SPTI to retrieve the raw sector data. The old reading method has been retained in case SPTI cannot be used (if the device could not be opened with write access).

Note: While I have tested the SPTI code, I haven't tested it within cdvdGigaherz (I don't own any PS2 CD-ROM games).

Should fix #648