### PR TITLE
gsdx ogl: only use geometry shader to convert big enough draw call

### DIFF
--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -175,7 +175,9 @@ void GSRendererOGL::SetupIA(const float& sx, const float& sy)
 
 			// If the draw calls contains few primitives. Geometry Shader gain with be rather small versus
 			// the extra validation cost of the extra stage.
-			if (GLLoader::found_geometry_shader &&  m_vertex.next > 32) { // <=> 16 sprites (based on Shadow Hearts)
+			//
+			// Note: keep Geometry Shader in the replayer to ease debug.
+			if (GLLoader::found_geometry_shader && (m_vertex.next > 32 || GLLoader::in_replayer)) { // <=> 16 sprites (based on Shadow Hearts)
 				m_gs_sel.sprite = 1;
 
 				t = GL_LINES;


### PR DESCRIPTION
The purpose of geometry shader is to reduce bandwidth (72 bytes by sprite)
and CPU load.

Unfortunately it increases CPU load due to extra shader validations.

So geometry shader will only be enabled for draw call with more than
16 sprites (arbitrarily, smallest number before shadow hearts plummet)

I need performances testing @FlatOutPS2 