### PR TITLE
pcsx2: Remove == true/false for boolean logic

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -59,10 +59,7 @@ static void rcntWhold(int index, u32 value);
 
 static bool IsAnalogVideoMode()
 {
-	if (gsVideoMode == GS_VideoMode::PAL || gsVideoMode == GS_VideoMode::NTSC)
-		return true;
-
-	return false;
+	return (gsVideoMode == GS_VideoMode::PAL || gsVideoMode == GS_VideoMode::NTSC);
 }
 
 void rcntReset(int index) {

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -388,17 +388,17 @@ const std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
 void CBreakPoints::Update(u32 addr)
 {
 	bool resume = false;
-	if (r5900Debug.isCpuPaused() == false)
+	if (!r5900Debug.isCpuPaused())
 	{
 		r5900Debug.pauseCpu();
 		resume = true;
 	}
-	
+
 //	if (addr != 0)
 //		Cpu->Clear(addr-4,8);
 //	else
 		SysClearExecutionCache();
-	
+
 	if (resume)
 		r5900Debug.resumeCpu();
 	auto disassembly_window = wxGetApp().GetDisassemblyPtr();

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -36,7 +36,7 @@ struct BreakPointCond
 	u32 Evaluate()
 	{
 		u64 result;
-		if (debug->parseExpression(expression,result) == false || result == 0) return 0;
+		if (!debug->parseExpression(expression,result) || result == 0) return 0;
 		return 1;
 	}
 };

--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -141,7 +141,7 @@ std::map<u32,DisassemblyEntry*>::iterator findDisassemblyEntry(std::map<u32,Disa
 
 void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 {
-	if (cpu->isAlive() == false)
+	if (!cpu->isAlive())
 		return;
 
 	u32 end = address+size;
@@ -486,7 +486,7 @@ void DisassemblyFunction::generateBranchLines()
 		int lane = -1;
 		for (int l = 0; l < NUM_LANES; l++)
 		{
-			if (lanes[l].used == false)
+			if (!lanes[l].used)
 			{
 				lane = l;
 				break;
@@ -899,7 +899,7 @@ void DisassemblyData::createLines()
 			{
 				if (currentLine.size()+1 >= maxChars)
 				{
-					if (inString == true)
+					if (inString)
 						currentLine += "\"";
 
 					DataEntry entry = {currentLine,pos-1-currentLineStart,lineCount++};
@@ -911,7 +911,7 @@ void DisassemblyData::createLines()
 					inString = false;
 				}
 
-				if (inString == false)
+				if (!inString)
 					currentLine += "\"";
 				currentLine += (char)b;
 				inString = true;
@@ -924,7 +924,7 @@ void DisassemblyData::createLines()
 
 				if (currentLine.size()+strlen(buffer) >= maxChars)
 				{
-					if (inString == true)
+					if (inString)
 						currentLine += "\"";
 					
 					DataEntry entry = {currentLine,pos-1-currentLineStart,lineCount++};
@@ -951,7 +951,7 @@ void DisassemblyData::createLines()
 			}
 		}
 
-		if (inString == true)
+		if (inString)
 			currentLine += "\"";
 
 		if (currentLine.size() != 0)

--- a/pcsx2/DebugTools/ExpressionParser.cpp
+++ b/pcsx2/DebugTools/ExpressionParser.cpp
@@ -193,7 +193,7 @@ ExpressionOpcodeType getExpressionOpcode(const char* str, int& ReturnLen, Expres
 
 	for (int i = 0; i < EXOP_NUMBER; i++)
 	{
-		if (ExpressionOpcodes[i].sign == true &&
+		if (ExpressionOpcodes[i].sign &&
 			(LastOpcode == EXOP_NUMBER || LastOpcode == EXOP_BRACKETR)) continue;
 
 		int len = ExpressionOpcodes[i].len;
@@ -213,15 +213,10 @@ ExpressionOpcodeType getExpressionOpcode(const char* str, int& ReturnLen, Expres
 
 bool isAlphaNum(char c)
 {
-	if ((c >= '0' && c <= '9') ||
+	return ((c >= '0' && c <= '9') ||
 		(c >= 'A' && c <= 'Z') ||
 		(c >= 'a' && c <= 'z') ||
-		c == '@' || c == '_' || c == '$' || c == '.')
-	{
-		return true;
-	} else {
-		return false;
-	}
+		c == '@' || c == '_' || c == '$' || c == '.');
 }
 
 bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, PostfixExpression& dest)
@@ -256,9 +251,9 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 
 			u64 value;
 			bool isFloat = false;
-			if (parseFloat(subStr,subPos,value) == true)
+			if (parseFloat(subStr,subPos,value))
 				isFloat = true;
-			else if (parseNumber(subStr,16,subPos,value) == false)
+			else if (!parseNumber(subStr,16,subPos,value))
 			{
 				sprintf(expressionError,"Invalid number \"%s\"",subStr);
 				return false;
@@ -275,14 +270,14 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 			subStr[subPos] = 0;
 
 			u64 value;
-			if (funcs->parseReference(subStr,value) == true)
+			if (funcs->parseReference(subStr,value))
 			{
 				dest.push_back(ExpressionPair(EXCOMM_REF,value));
 				lastOpcode = EXOP_NUMBER;
 				continue;
 			}
 
-			if (funcs->parseSymbol(subStr,value) == true)
+			if (funcs->parseSymbol(subStr,value))
 			{
 				dest.push_back(ExpressionPair(EXCOMM_CONST,value));
 				lastOpcode = EXOP_NUMBER;
@@ -340,7 +335,7 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 				type = EXOP_NUMBER;
 				break;
 			default:
-				if (opcodeStack.empty() == false)
+				if (!opcodeStack.empty())
 				{
 					int CurrentPriority = ExpressionOpcodes[type].Priority;
 					while (!opcodeStack.empty())
@@ -457,7 +452,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 				}
 
 				u64 val;
-				if(funcs->getMemoryValue(arg[1],arg[0],val,expressionError) == false)
+				if(!funcs->getMemoryValue(arg[1],arg[0],val,expressionError))
 				{
 					return false;
 				}
@@ -466,7 +461,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			case EXOP_MEM:
 				{
 					u64 val;
-					if (funcs->getMemoryValue(arg[0],4,val,expressionError) == false)
+					if (!funcs->getMemoryValue(arg[0],4,val,expressionError))
 					{
 						return false;
 					}
@@ -598,7 +593,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 bool parseExpression(char* exp, IExpressionFunctions* funcs, u64& dest)
 {
 	PostfixExpression postfix;
-	if (initPostfixExpression(exp,funcs,postfix) == false) return false;
+	if (!initPostfixExpression(exp,funcs,postfix)) return false;
 	return parsePostfixExpression(postfix,funcs,dest);
 }
 

--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -326,7 +326,7 @@ namespace MIPSAnalyst
 		MipsOpcodeInfo info;
 		memset(&info, 0, sizeof(info));
 
-		if (cpu->isValidAddress(address) == false)
+		if (!cpu->isValidAddress(address))
 			return info;
 
 		info.cpu = cpu;

--- a/pcsx2/DebugTools/MipsAssembler.cpp
+++ b/pcsx2/DebugTools/MipsAssembler.cpp
@@ -183,13 +183,13 @@ bool MipsAssembleOpcode(const char* line, DebugInterface* cpu, u32 address, u32&
 	SplitLine(line,name,args);
 
 	CMipsInstruction opcode(cpu);
-	if (cpu == NULL || opcode.Load(name,args,(int)address) == false)
+	if (cpu == NULL || !opcode.Load(name,args,(int)address))
 	{
 		errorText = opcode.getErrorMessage();
 		return false;
 	}
 
-	if (opcode.Validate() == false)
+	if (!opcode.Validate())
 	{
 		errorText = "Parameter failure.";
 		return false;
@@ -356,11 +356,11 @@ bool MipsCheckImmediate(const char* Source, DebugInterface* cpu, int& dest, int&
 	RetLen = SourceLen;
 
 	PostfixExpression postfix;
-	if (cpu->initExpression(Buffer,postfix) == false)
+	if (!cpu->initExpression(Buffer,postfix))
 		return false;
 
 	u64 value;
-	if (cpu->parseExpression(postfix,value) == false)
+	if (!cpu->parseExpression(postfix,value))
 		return false;
 
 	dest = (int) value;
@@ -394,9 +394,9 @@ bool CMipsInstruction::Load(const char* Name, const char* Params, int RamPos)
 		if ((MipsOpcodes[z].flags & MO_FPU) && !(arch.flags & MO_FPU))
 			continue;
 
-		if (parseOpcode(MipsOpcodes[z],Name) == true)
+		if (parseOpcode(MipsOpcodes[z],Name))
 		{
-			if (LoadEncoding(MipsOpcodes[z],Params) == true)
+			if (LoadEncoding(MipsOpcodes[z],Params))
 			{
 				Loaded = true;
 				return true;
@@ -405,9 +405,9 @@ bool CMipsInstruction::Load(const char* Name, const char* Params, int RamPos)
 		}
 	}
 
-	if (NoCheckError == false)
+	if (!NoCheckError)
 	{
-		if (paramfail == true)
+		if (paramfail)
 		{
 			error = "Parameter failure.";
 		} else {
@@ -455,9 +455,9 @@ bool CMipsInstruction::parseOpcode(const tMipsOpcode& SourceOpcode, const char* 
 			break;
 		}
 	}
-	
-	if (*Line != 0)	return false;	// there's something else, bad
-	return true;
+
+	// there's something else, bad
+	return (*Line == 0);
 }
 
 bool CMipsInstruction::LoadEncoding(const tMipsOpcode& SourceOpcode, const char* Line)
@@ -491,32 +491,32 @@ bool CMipsInstruction::LoadEncoding(const tMipsOpcode& SourceOpcode, const char*
 			switch (*SourceEncoding)
 			{
 			case 'T':	// float reg
-				if (MipsGetFloatRegister(Line,RetLen,registers.frt) == false) return false;
+				if (!MipsGetFloatRegister(Line,RetLen,registers.frt)) return false;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 'D':	// float reg
-				if (MipsGetFloatRegister(Line,RetLen,registers.frd) == false) return false;
+				if (!MipsGetFloatRegister(Line,RetLen,registers.frd)) return false;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 'S':	// float reg
-				if (MipsGetFloatRegister(Line,RetLen,registers.frs) == false) return false;
+				if (!MipsGetFloatRegister(Line,RetLen,registers.frs)) return false;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 't':
-				if (MipsGetRegister(Line,RetLen,registers.grt) == false) return false;
+				if (!MipsGetRegister(Line,RetLen,registers.grt)) return false;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 'd':
-				if (MipsGetRegister(Line,RetLen,registers.grd) == false) return false;
+				if (!MipsGetRegister(Line,RetLen,registers.grd)) return false;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 's':
-				if (MipsGetRegister(Line,RetLen,registers.grs) == false) return false;
+				if (!MipsGetRegister(Line,RetLen,registers.grs)) return false;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
@@ -524,15 +524,15 @@ bool CMipsInstruction::LoadEncoding(const tMipsOpcode& SourceOpcode, const char*
 				switch (*(SourceEncoding+1))
 				{
 				case 's':
-					if (MipsGetPs2VectorRegister(Line,RetLen,registers.ps2vrs) == false) return false;
+					if (!MipsGetPs2VectorRegister(Line,RetLen,registers.ps2vrs)) return false;
 					Line += RetLen;
 					break;
 				case 't':
-					if (MipsGetPs2VectorRegister(Line,RetLen,registers.ps2vrt) == false) return false;
+					if (!MipsGetPs2VectorRegister(Line,RetLen,registers.ps2vrt)) return false;
 					Line += RetLen;
 					break;
 				case 'd':
-					if (MipsGetPs2VectorRegister(Line,RetLen,registers.ps2vrd) == false) return false;
+					if (!MipsGetPs2VectorRegister(Line,RetLen,registers.ps2vrd)) return false;
 					Line += RetLen;
 					break;
 				default:
@@ -541,25 +541,25 @@ bool CMipsInstruction::LoadEncoding(const tMipsOpcode& SourceOpcode, const char*
 				SourceEncoding += 2;
 				break;
 			case 'a':	// 5 bit immediate
-				if (MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen) == false) return false;
+				if (!MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen)) return false;
 				immediateType = MIPS_IMMEDIATE5;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 'i':	// 16 bit immediate
-				if (MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen) == false) return false;
+				if (!MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen)) return false;
 				immediateType = MIPS_IMMEDIATE16;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 'b':	// 20 bit immediate
-				if (MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen) == false) return false;
+				if (!MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen)) return false;
 				immediateType = MIPS_IMMEDIATE20;
 				Line += RetLen;
 				SourceEncoding++;
 				break;
 			case 'I':	// 32 bit immediate
-				if (MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen) == false) return false;
+				if (!MipsCheckImmediate(Line,cpu,immediate.originalValue,RetLen)) return false;
 				immediateType = MIPS_IMMEDIATE26;
 				Line += RetLen;
 				SourceEncoding++;

--- a/pcsx2/DebugTools/MipsStackWalk.cpp
+++ b/pcsx2/DebugTools/MipsStackWalk.cpp
@@ -162,11 +162,7 @@ namespace MipsStackWalk {
 		// Okay, we failed to get one.  Our possibleEntry could be wrong, it often is.
 		// Let's just scan upward.
 		u32 newPossibleEntry = frame.pc > threadEntry ? threadEntry : frame.pc - MAX_FUNC_SIZE;
-		if (ScanForEntry(cpu, frame, newPossibleEntry, ra)) {
-			return true;
-		} else {
-			return false;
-		}
+		return ScanForEntry(cpu, frame, newPossibleEntry, ra);
 	}
 
 	std::vector<StackFrame> Walk(DebugInterface* cpu, u32 pc, u32 ra, u32 sp, u32 threadEntry, u32 threadStackTop) {

--- a/pcsx2/FiFo.cpp
+++ b/pcsx2/FiFo.cpp
@@ -75,7 +75,7 @@ void __fastcall WriteFIFO_VIF0(const mem128_t *value)
 	VIF_LOG("WriteFIFO/VIF0 <- %ls", WX_STR(value->ToString()));
 
 	vif0ch.qwc += 1;
-	if(vif0.irqoffset.value != 0 && vif0.vifstalled.enabled == true) DevCon.Warning("Offset on VIF0 FIFO start!");
+	if(vif0.irqoffset.value != 0 && vif0.vifstalled.enabled) DevCon.Warning("Offset on VIF0 FIFO start!");
 	bool ret = VIF0transfer((u32*)value, 4);
 
 	if (vif0.cmd) 
@@ -100,7 +100,7 @@ void __fastcall WriteFIFO_VIF1(const mem128_t *value)
 	if (vif1Regs.stat.test(VIF1_STAT_INT | VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS) ) {
 		DevCon.Warning("writing to vif1 fifo when stalled");
 	}
-	if (vif1.irqoffset.value != 0 && vif1.vifstalled.enabled == true) {
+	if (vif1.irqoffset.value != 0 && vif1.vifstalled.enabled) {
 		DevCon.Warning("Offset on VIF1 FIFO start!");
 	}
 

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -278,12 +278,12 @@ void GIFdma()
 	{
 		gifRegs.stat.FQC = std::min((u16)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
 
-		if (CheckPaths(DMAC_GIF) == false) return;
+		if (!CheckPaths(DMAC_GIF)) return;
 
 		GIFchain();	//Transfers the data set by the switch
 		CPU_INT(DMAC_GIF, gscycles);
 		return;
-	} else if(gspath3done == false) GIFdma(); //Loop round if there was a blank tag, causes hell otherwise with P3 masking games.
+	} else if(!gspath3done) GIFdma(); //Loop round if there was a blank tag, causes hell otherwise with P3 masking games.
 
 	prevcycles = 0;
 	CPU_INT(DMAC_GIF, gscycles);
@@ -440,7 +440,7 @@ void mfifoGIFtransfer(int qwc)
 
 	if (qwc > 0 ) {
 		if ((gifstate & GIF_STATE_EMPTY)) {
-			if(gifch.chcr.STR == true && !(cpuRegs.interrupt & (1<<DMAC_MFIFO_GIF)))
+			if(gifch.chcr.STR && !(cpuRegs.interrupt & (1<<DMAC_MFIFO_GIF)))
 				CPU_INT(DMAC_MFIFO_GIF, 4);
 			gifstate &= ~GIF_STATE_EMPTY;			
 		}
@@ -473,7 +473,7 @@ void mfifoGIFtransfer(int qwc)
 		}
 		mfifoGifMaskMem(ptag->ID);
 
-		if(gspath3done == true) gifstate = GIF_STATE_DONE;
+		if(gspath3done) gifstate = GIF_STATE_DONE;
 		else gifstate = GIF_STATE_READY;
 
 		if ((gifch.chcr.TIE) && (ptag->IRQ)) {
@@ -559,7 +559,7 @@ void gifMFIFOInterrupt()
 		if(!(gifstate & GIF_STATE_STALL)) return;
 	}
 
-	if (CheckPaths(DMAC_MFIFO_GIF) == false) return;
+	if (!CheckPaths(DMAC_MFIFO_GIF)) return;
 
 	if(!gifch.chcr.STR) {
 		Console.WriteLn("WTF GIFMFIFO");

--- a/pcsx2/Gif_Unit.cpp
+++ b/pcsx2/Gif_Unit.cpp
@@ -97,7 +97,7 @@ bool Gif_HandlerAD_Debug(u8* pMem) {
 }
 
 void Gif_FinishIRQ() {
-	if (CSRreg.FINISH && !(GSIMR & 0x200) && gifUnit.gsFINISH.gsFINISHFired == false) {
+	if (CSRreg.FINISH && !(GSIMR & 0x200) && !gifUnit.gsFINISH.gsFINISHFired) {
 		gsIrq();
 		gifUnit.gsFINISH.gsFINISHFired = true;
 	}

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -83,9 +83,9 @@ void intMemcheck(u32 op, u32 bits, bool store)
 
 		if (check.result == 0)
 			continue;
-		if ((check.cond & MEMCHECK_WRITE) == 0 && store == true)
+		if ((check.cond & MEMCHECK_WRITE) == 0 && store)
 			continue;
-		if ((check.cond & MEMCHECK_READ) == 0 && store == false)
+		if ((check.cond & MEMCHECK_READ) == 0 && !store)
 			continue;
 
 		if (start < check.end && check.start < end)

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -171,7 +171,7 @@ static bool __fastcall _rcntFireInterrupt(int i, bool isOverflow) {
 	bool ret;
 
 	if ((psxCounters[i].mode & 0x400)) { //IRQ fired
-		//DevCon.Warning("Counter %d %s IRQ Fired count %x", i, isOverflow == true ? "Overflow" : "Target", psxCounters[i].count);
+		//DevCon.Warning("Counter %d %s IRQ Fired count %x", i, isOverflow ? "Overflow" : "Target", psxCounters[i].count);
 		psxHu32(0x1070) |= psxCounters[i].interrupt;
 		iopTestIntc();
 		ret = true;

--- a/pcsx2/SPR.cpp
+++ b/pcsx2/SPR.cpp
@@ -34,7 +34,7 @@ static void TestClearVUs(u32 madr, u32 qwc, bool isWrite)
 	{
 		if (madr < 0x11004000)
 		{
-			if(isWrite == true)
+			if(isWrite)
 			{
 				DbgCon.Warning("scratch pad clearing vu0");
 
@@ -48,7 +48,7 @@ static void TestClearVUs(u32 madr, u32 qwc, bool isWrite)
 		}
 		else if (madr >= 0x11008000 && madr < 0x1100c000)
 		{
-			if(isWrite == true)
+			if(isWrite)
 			{
 				DbgCon.Warning("scratch pad clearing vu1");
 

--- a/pcsx2/Sif0.cpp
+++ b/pcsx2/Sif0.cpp
@@ -182,7 +182,7 @@ static __fi void EndIOP()
 // Handle the EE transfer.
 static __fi void HandleEETransfer()
 {
-	if(sif0ch.chcr.STR == false)
+	if(!sif0ch.chcr.STR)
 	{
 		//DevCon.Warning("Replacement for irq prevention hack EE SIF0");
 		sif0.ee.end = false;
@@ -306,7 +306,7 @@ __fi void SIF0Dma()
 
 		if (sif0.iop.busy)
 		{
-			if(sif0.fifo.sif_free() > 0 || (sif0.iop.end == true && sif0.iop.counter == 0)) 
+			if(sif0.fifo.sif_free() > 0 || (sif0.iop.end && sif0.iop.counter == 0))
 			{
 				BusyCheck++;
 				HandleIOPTransfer();
@@ -314,7 +314,7 @@ __fi void SIF0Dma()
 		}
 		if (sif0.ee.busy)
 		{
-			if(sif0.fifo.size >= 4 || (sif0.ee.end == true && sif0ch.qwc == 0)) 
+			if(sif0.fifo.size >= 4 || (sif0.ee.end && sif0ch.qwc == 0))
 			{
 				BusyCheck++;
 				HandleEETransfer();

--- a/pcsx2/Sif1.cpp
+++ b/pcsx2/Sif1.cpp
@@ -179,7 +179,7 @@ static __fi void EndIOP()
 // Handle the EE transfer.
 static __fi void HandleEETransfer()
 {
-	if(sif1ch.chcr.STR == false)
+	if(!sif1ch.chcr.STR)
 	{
 		//DevCon.Warning("Replacement for irq prevention hack EE SIF1");
 		sif1.ee.end = false;
@@ -271,7 +271,7 @@ __fi void SIF1Dma()
 
 		if (sif1.ee.busy)
 		{
-			if(sif1.fifo.sif_free() > 0 || (sif1.ee.end == true && sif1ch.qwc == 0)) 
+			if(sif1.fifo.sif_free() > 0 || (sif1.ee.end && sif1ch.qwc == 0))
 			{
 				BusyCheck++;
 				HandleEETransfer();
@@ -280,7 +280,7 @@ __fi void SIF1Dma()
 
 		if (sif1.iop.busy)
 		{
-			if(sif1.fifo.size >= 4 || (sif1.iop.end == true && sif1.iop.counter == 0)) 
+			if(sif1.fifo.size >= 4 || (sif1.iop.end && sif1.iop.counter == 0))
 			{
 				BusyCheck++;
 				HandleIOPTransfer();

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -70,10 +70,7 @@ void SysCoreThread::Cancel( bool isBlocking )
 bool SysCoreThread::Cancel( const wxTimeSpan& span )
 {
 	m_hasActiveMachine = false;
-	if( _parent::Cancel( span ) )
-		return true;
-
-	return false;
+	return _parent::Cancel( span );
 }
 
 void SysCoreThread::OnStart()

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -155,7 +155,7 @@ static void _vu0Exec(VURegs* VU)
 		if (VU->branch-- == 1) {
 			VU->VI[REG_TPC].UL = VU->branchpc;
 
-			if(VU->takedelaybranch == true)
+			if(VU->takedelaybranch)
 			{				
 				VU->branch = 2;
 				DevCon.Warning("VU0 - Branch/Jump in Delay Slot");			

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -155,7 +155,7 @@ static void _vu1Exec(VURegs* VU)
 		if (VU->branch-- == 1) {
 			VU->VI[REG_TPC].UL = VU->branchpc;
 
-			if(VU->takedelaybranch == true)
+			if(VU->takedelaybranch)
 			{				
 				VU->branch = 2;
 				//DevCon.Warning("VU1 - Branch/Jump in Delay Slot");			

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -83,7 +83,7 @@ __fi void vif0FBRST(u32 value) {
 		u128 SaveCol;
 		u128 SaveRow;
 
-	//	if(vif0ch.chcr.STR == true) DevCon.Warning("FBRST While Vif0 active");
+	//	if(vif0ch.chcr.STR) DevCon.Warning("FBRST While Vif0 active");
 		//Must Preserve Row/Col registers! (Downhill Domination for testing)
 		SaveCol._u64[0] = vif0.MaskCol._u64[0];
 		SaveCol._u64[1] = vif0.MaskCol._u64[1];
@@ -160,7 +160,7 @@ __fi void vif1FBRST(u32 value) {
 	{
 		u128 SaveCol;
 		u128 SaveRow;
-		//if(vif1ch.chcr.STR == true) DevCon.Warning("FBRST While Vif1 active");
+		//if(vif1ch.chcr.STR) DevCon.Warning("FBRST While Vif1 active");
 		//Must Preserve Row/Col registers! (Downhill Domination for testing) - Really shouldnt be part of the vifstruct.
 		SaveCol._u64[0] = vif1.MaskCol._u64[0];
 		SaveCol._u64[1] = vif1.MaskCol._u64[1];
@@ -202,7 +202,7 @@ __fi void vif1FBRST(u32 value) {
 		}
 		
 #if USE_OLD_GIF == 1 // ...
-		if(vif1Regs.mskpath3 == 1 && GSTransferStatus.PTH3 == STOPPED_MODE && gifch.chcr.STR == true) {
+		if(vif1Regs.mskpath3 == 1 && GSTransferStatus.PTH3 == STOPPED_MODE && gifch.chcr.STR) {
 			DevCon.Warning("VIF Path3 Resume on FBRST MSK = %x", vif1Regs.mskpath3);
 			gifInterrupt();
 			vif1Regs.mskpath3 = false;
@@ -271,14 +271,14 @@ __fi void vif1FBRST(u32 value) {
 				    case MFD_VIF1:
                         //Console.WriteLn("MFIFO Stall");
 						//MFIFO active and not empty
-                        if(vif1ch.chcr.STR == true) CPU_INT(DMAC_MFIFO_VIF, 0);
+                        if(vif1ch.chcr.STR) CPU_INT(DMAC_MFIFO_VIF, 0);
                         break;
 
                     case NO_MFD:
                     case MFD_RESERVED:
                     case MFD_GIF: // Wonder if this should be with VIF?
                         // Gets the timing right - Flatout
-                        if(vif1ch.chcr.STR == true) CPU_INT(DMAC_VIF1, 0);
+                        if(vif1ch.chcr.STR) CPU_INT(DMAC_VIF1, 0);
                         break;
 				}
 

--- a/pcsx2/Vif.h
+++ b/pcsx2/Vif.h
@@ -241,7 +241,7 @@ static VIFregisters& vif1Regs = (VIFregisters&)eeHw[0x3C00];
 #define  MTVU_VifX     (idx ? ((THREAD_VU1) ? vu1Thread.vif     : vif1)     : (vif0))
 #define  MTVU_VifXRegs (idx ? ((THREAD_VU1) ? vu1Thread.vifRegs : vif1Regs) : (vif0Regs))
 
-#define VifStallEnable(vif) vif.chcr.STR ? true : false;
+#define VifStallEnable(vif) (vif.chcr.STR);
 
 extern void dmaVIF0();
 extern void dmaVIF1();

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -25,7 +25,7 @@ u32 g_vif0Cycles = 0;
 // because its vif stalling not the EE core...
 __fi void vif0FLUSH()
 {
-	if(vif0Regs.stat.VEW == true)
+	if(vif0Regs.stat.VEW)
 	{
 		vif0.waitforvu = true;
 		vif0.vifstalled.enabled = VifStallEnable(vif0ch);
@@ -146,12 +146,12 @@ __fi void vif0VUFinish()
 	}
 	vif0Regs.stat.VEW = false;
 	VIF_LOG("VU0 finished");
-	if(vif0.waitforvu == true)
+	if(vif0.waitforvu)
 	{
 		vif0.waitforvu = false;
 		ExecuteVU(0);
 		//Make sure VIF0 isnt already scheduled to spin.
-		if(!(cpuRegs.interrupt & 0x1) && vif0ch.chcr.STR == true && !vif0Regs.stat.INT)
+		if(!(cpuRegs.interrupt & 0x1) && vif0ch.chcr.STR && !vif0Regs.stat.INT)
 			vif0Interrupt();
 	}
 	//DevCon.Warning("VU0 state cleared");
@@ -194,7 +194,7 @@ __fi void vif0Interrupt()
 		}
 	}
 
-	if(vif0.waitforvu == true)
+	if(vif0.waitforvu)
 	{
 		//DevCon.Warning("Waiting on VU0");
 		//CPU_INT(DMAC_VIF0, 16);
@@ -206,7 +206,7 @@ __fi void vif0Interrupt()
 	//Must go after the Stall, incase it's still in progress, GTC africa likes to see it still transferring.
 	if (vif0.cmd) 
 	{
-		if(vif0.done == true && vif0ch.qwc == 0)	vif0Regs.stat.VPS = VPS_WAITING;
+		if(vif0.done && vif0ch.qwc == 0)	vif0Regs.stat.VPS = VPS_WAITING;
 	}
 	else		 
 	{
@@ -251,7 +251,7 @@ __fi void vif0Interrupt()
 	vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
 	vif0.vifstalled.enabled = false;
 	vif0.irqoffset.enabled = false;
-	if(vif0.queued_program == true) vifExecQueue(0);
+	if(vif0.queued_program) vifExecQueue(0);
 	g_vif0Cycles = 0;
 	hwDmacIrq(DMAC_VIF0);
 	vif0Regs.stat.FQC = 0;
@@ -286,7 +286,7 @@ void dmaVIF0()
 		{
 			vif0.dmamode = VIF_NORMAL_FROM_MEM_MODE;
 
-			if (vif0.irqoffset.enabled == true && vif0.done == false) DevCon.Warning("Warning! VIF0 starting a Normal transfer with vif offset set (Possible force stop?)");
+			if (vif0.irqoffset.enabled && !vif0.done) DevCon.Warning("Warning! VIF0 starting a Normal transfer with vif offset set (Possible force stop?)");
 			vif0.done = true;
 		}
 
@@ -294,7 +294,7 @@ void dmaVIF0()
 	}
 	else
 	{
-		if (vif0.irqoffset.enabled == true && vif0.done == false) DevCon.Warning("Warning! VIF0 starting a new Chain transfer with vif offset set (Possible force stop?)");
+		if (vif0.irqoffset.enabled && !vif0.done) DevCon.Warning("Warning! VIF0 starting a new Chain transfer with vif offset set (Possible force stop?)");
 		vif0.dmamode = VIF_CHAIN_MODE;
 		vif0.done = false;
 		vif0.inprogress &= ~0x1;

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -25,7 +25,7 @@ u32 g_vif1Cycles = 0;
 
 __fi void vif1FLUSH()
 {
-	if(vif1Regs.stat.VEW == true)
+	if(vif1Regs.stat.VEW)
 	{
 		vif1.waitforvu = true;
 		vif1.vifstalled.enabled = VifStallEnable(vif1ch);
@@ -255,12 +255,12 @@ __fi void vif1VUFinish()
 		}
 
 	}
-	if(vif1.waitforvu == true)
+	if(vif1.waitforvu)
 	{
 		vif1.waitforvu = false;
 		ExecuteVU(1);
 		//Check if VIF is already scheduled to interrupt, if it's waiting, kick it :P
-		if((cpuRegs.interrupt & (1<<DMAC_VIF1 | 1 << DMAC_MFIFO_VIF)) == 0 && vif1ch.chcr.STR == true && !vif1Regs.stat.INT)
+		if((cpuRegs.interrupt & (1<<DMAC_VIF1 | 1 << DMAC_MFIFO_VIF)) == 0 && vif1ch.chcr.STR && !vif1Regs.stat.INT)
 		{
 			if(dmacRegs.ctrl.MFD == MFD_VIF1)
 				vifMFIFOInterrupt();
@@ -313,7 +313,7 @@ __fi void vif1Interrupt()
 		//Simulated GS transfer time done, clear the flags
 	}
 	
-	if(vif1.waitforvu == true)
+	if(vif1.waitforvu)
 	{
 		//DevCon.Warning("Waiting on VU1");
 		//CPU_INT(DMAC_VIF1, 16);
@@ -412,7 +412,7 @@ __fi void vif1Interrupt()
 	vif1ch.chcr.STR = false;
 	vif1.vifstalled.enabled = false;
 	vif1.irqoffset.enabled = false;
-	if(vif1.queued_program == true) vifExecQueue(1);
+	if(vif1.queued_program) vifExecQueue(1);
 	g_vif1Cycles = 0;
 	DMA_LOG("VIF1 DMA End");
 	hwDmacIrq(DMAC_VIF1);
@@ -463,7 +463,7 @@ void dmaVIF1()
 			else
 				vif1.dmamode = VIF_NORMAL_TO_MEM_MODE;
 
-			if(vif1.irqoffset.enabled == true && vif1.done == false) DevCon.Warning("Warning! VIF1 starting a Normal transfer with vif offset set (Possible force stop?)");
+			if(vif1.irqoffset.enabled && !vif1.done) DevCon.Warning("Warning! VIF1 starting a Normal transfer with vif offset set (Possible force stop?)");
 			vif1.done = true;
 		}
 
@@ -471,7 +471,7 @@ void dmaVIF1()
 	}
 	else
 	{
-		if(vif1.irqoffset.enabled == true && vif1.done == false) DevCon.Warning("Warning! VIF1 starting a new Chain transfer with vif offset set (Possible force stop?)");
+		if(vif1.irqoffset.enabled && !vif1.done) DevCon.Warning("Warning! VIF1 starting a new Chain transfer with vif offset set (Possible force stop?)");
 		vif1.dmamode = VIF_CHAIN_MODE;
 		vif1.done = false;
 		vif1.inprogress &= ~0x1;

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -184,7 +184,7 @@ void mfifoVIF1transfer(int qwc)
 		if (vif1.inprogress & 0x10)
 		{
 			//Don't resume if stalled or already looping
-			if(vif1ch.chcr.STR == true && !(cpuRegs.interrupt & (1<<DMAC_MFIFO_VIF)) && !vif1Regs.stat.INT)
+			if(vif1ch.chcr.STR && !(cpuRegs.interrupt & (1<<DMAC_MFIFO_VIF)) && !vif1Regs.stat.INT)
 			{
 				SPR_LOG("Data Added, Resuming");
 				//Need to simulate the time it takes to copy here, if the VIF resumes before the SPR has finished, it isn't happy.
@@ -308,7 +308,7 @@ void vifMFIFOInterrupt()
 			return;
 		}
 	}
-	if(vif1.waitforvu == true)
+	if(vif1.waitforvu)
 	{
 	//	DevCon.Warning("Waiting on VU1 MFIFO");
 		//CPU_INT(DMAC_MFIFO_VIF, 16);
@@ -359,7 +359,7 @@ void vifMFIFOInterrupt()
 
 	vif1.vifstalled.enabled = false;
 
-	if (vif1.done == false || vif1ch.qwc) {
+	if (!vif1.done || vif1ch.qwc) {
 		switch(vif1.inprogress & 1) {
 			case 0: //Set up transfer
 				if (QWCinVIFMFIFO(vif1ch.tadr) == 0) {

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -327,7 +327,7 @@ vifOp(vifCode_MPG) {
 		vifX.tag.size = vifNum ? (vifNum*2) : 512;
 		vifFlush(idx);
 
-		if(vifX.vifstalled.enabled == true) return 0;
+		if(vifX.vifstalled.enabled) return 0;
 		else
 		{
 			vifX.pass = 1;
@@ -364,7 +364,7 @@ vifOp(vifCode_MSCAL) {
 	pass1 { 
 		vifFlush(idx); 
 
-		if(vifX.waitforvu == false)
+		if(!vifX.waitforvu)
 		{
 			vuExecMicro(idx, (u16)(vifXRegs.code) << 3); 
 			vifX.cmd = 0;
@@ -395,7 +395,7 @@ vifOp(vifCode_MSCALF) {
 			vifX.vifstalled.enabled   = VifStallEnable(vifXch);
 			vifX.vifstalled.value = VIF_TIMING_BREAK;
 		}
-		if(vifX.waitforvu == false)
+		if(!vifX.waitforvu)
 		{
 			vuExecMicro(idx, (u16)(vifXRegs.code) << 3);
 			vifX.cmd = 0;
@@ -411,7 +411,7 @@ vifOp(vifCode_MSCNT) {
 	vifStruct& vifX = GetVifX;
 	pass1 { 
 		vifFlush(idx); 
-		if(vifX.waitforvu == false)
+		if(!vifX.waitforvu)
 		{
 			vuExecMicro(idx, -1);
 			vifX.cmd = 0;

--- a/pcsx2/gui/Debugger/BreakpointWindow.cpp
+++ b/pcsx2/gui/Debugger/BreakpointWindow.cpp
@@ -245,7 +245,7 @@ bool BreakpointWindow::fetchDialogData()
 
 	// parse address
 	wxCharBuffer addressText = editAddress->GetValue().ToUTF8();
-	if (cpu->initExpression(addressText,exp) == false)
+	if (!cpu->initExpression(addressText,exp))
 	{
 		swprintf(errorMessage,512,L"Invalid expression \"%s\".",editAddress->GetValue().wchar_str().data());
 		wxMessageBox(errorMessage,L"Error",wxICON_ERROR);
@@ -253,7 +253,7 @@ bool BreakpointWindow::fetchDialogData()
 	}
 
 	u64 value;
-	if (cpu->parseExpression(exp,value) == false)
+	if (!cpu->parseExpression(exp,value))
 	{
 		swprintf(errorMessage,512,L"Invalid expression \"%s\".",editAddress->GetValue().wchar_str().data());
 		wxMessageBox(errorMessage,L"Error",wxICON_ERROR);
@@ -265,14 +265,14 @@ bool BreakpointWindow::fetchDialogData()
 	{
 		// parse size
 		wxCharBuffer sizeText = editSize->GetValue().ToUTF8();
-		if (cpu->initExpression(sizeText,exp) == false)
+		if (!cpu->initExpression(sizeText,exp))
 		{
 			swprintf(errorMessage,512,L"Invalid expression \"%s\".",editSize->GetValue().wchar_str().data());
 			wxMessageBox(errorMessage,L"Error",wxICON_ERROR);
 			return false;
 		}
 
-		if (cpu->parseExpression(exp,value) == false)
+		if (!cpu->parseExpression(exp,value))
 		{
 			swprintf(errorMessage,512,L"Invalid expression \"%s\".",editSize->GetValue().wchar_str().data());
 			wxMessageBox(errorMessage,L"Error",wxICON_ERROR);
@@ -289,7 +289,7 @@ bool BreakpointWindow::fetchDialogData()
 	compiledCondition.clear();
 	if (condition[0] != 0)
 	{
-		if (cpu->initExpression(condition,compiledCondition) == false)
+		if (!cpu->initExpression(condition,compiledCondition))
 		{
 			swprintf(errorMessage,512,L"Invalid expression \"%s\".",editCondition->GetValue().wchar_str().data());
 			wxMessageBox(errorMessage,L"Error",wxICON_ERROR);
@@ -302,7 +302,7 @@ bool BreakpointWindow::fetchDialogData()
 
 void BreakpointWindow::onButtonOk(wxCommandEvent& evt)
 {
-	if (fetchDialogData() == true)
+	if (fetchDialogData())
 		evt.Skip();
 }
 
@@ -339,7 +339,7 @@ void BreakpointWindow::addBreakpoint()
 			CBreakPoints::ChangeBreakPointAddCond(address,cond);
 		}
 
-		if (enabled == false)
+		if (!enabled)
 		{
 			CBreakPoints::ChangeBreakPoint(address,false);
 		}

--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -201,7 +201,7 @@ WXLRESULT CtrlDisassemblyView::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPA
 
 void CtrlDisassemblyView::scanFunctions()
 {
-	if (cpu->isAlive() == false)
+	if (!cpu->isAlive())
 		return;
 
 	manager.analyze(windowStart,manager.getNthNextAddress(windowStart,visibleRows)-windowStart);
@@ -628,7 +628,7 @@ void CtrlDisassemblyView::assembleOpcode(u32 address, std::string defaultText)
 {
 	u32 encoded;
 
-	if (cpu->isCpuPaused() == false)
+	if (!cpu->isCpuPaused())
 	{
 		wxMessageBox( L"Cannot change code while the core is running",  L"Error.", wxICON_ERROR);
 		return;
@@ -643,7 +643,7 @@ void CtrlDisassemblyView::assembleOpcode(u32 address, std::string defaultText)
 	wxString op = entry.getText();
 	std::string errorText;
 	bool result = MipsAssembleOpcode(op.To8BitData(),cpu,address,encoded,errorText);
-	if (result == true)
+	if (result)
 	{
 		SysClearExecutionCache();
 		cpu->write32(address,encoded);
@@ -824,7 +824,7 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 		case 'G':
 			{
 				u64 addr;
-				if (executeExpressionWindow(this,cpu,addr) == false)
+				if (!executeExpressionWindow(this,cpu,addr))
 					return;
 				gotoAddress(addr);
 			}
@@ -1220,7 +1220,7 @@ void CtrlDisassemblyView::copyInstructions(u32 startAddr, u32 endAddr, bool with
 		return;
 	}
 
-	if (withDisasm == false)
+	if (!withDisasm)
 	{
 		int instructionSize = 4;
 		int count = (endAddr - startAddr) / instructionSize;

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -457,9 +457,9 @@ void CtrlMemView::keydownEvent(wxKeyEvent& evt)
 		case 'G':
 			{
 				u64 addr;
-				if (executeExpressionWindow(this,cpu,addr) == false)
+				if (!executeExpressionWindow(this,cpu,addr))
 					return;
-				
+
 				gotoAddress(addr, true);
 			}
 			break;

--- a/pcsx2/gui/Debugger/DebugEvents.cpp
+++ b/pcsx2/gui/Debugger/DebugEvents.cpp
@@ -31,7 +31,7 @@ wxDEFINE_EVENT(debEVT_BREAKPOINTWINDOW, wxCommandEvent);
 bool parseExpression(const char* exp, DebugInterface* cpu, u64& dest)
 {
 	PostfixExpression postfix;
-	if (cpu->initExpression(exp,postfix) == false) return false;
+	if (!cpu->initExpression(exp,postfix)) return false;
 	return cpu->parseExpression(postfix,dest);
 }
 
@@ -47,7 +47,7 @@ bool executeExpressionWindow(wxWindow* parent, DebugInterface* cpu, u64& dest, c
 		return false;
 
 	wxCharBuffer expression = result.ToUTF8();
-	if (parseExpression(expression, cpu, dest) == false)
+	if (!parseExpression(expression, cpu, dest))
 	{
 		displayExpressionError(parent);
 		return false;

--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -275,7 +275,7 @@ wxString BreakpointList::getColumnText(int item, int col) const
 		break;
 	case BPL_CONDITION:
 		{
-			if (isMemory || displayedBreakPoints_[index].hasCond == false) {
+			if (isMemory || !displayedBreakPoints_[index].hasCond) {
 				dest.Write("-");
 			} else {
 				dest.Write("%s",displayedBreakPoints_[index].cond.expressionString);

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -386,7 +386,7 @@ void DisassemblyDialog::stepOver()
 	u32 breakpointAddress = currentPc+disassembly->getInstructionSizeAt(currentPc);
 	if (info.isBranch)
 	{
-		if (info.isConditional == false)
+		if (!info.isConditional)
 		{
 			if (info.isLinkedBranch)	// jal, jalr
 			{
@@ -433,7 +433,7 @@ void DisassemblyDialog::stepInto()
 	u32 breakpointAddress = currentPc+disassembly->getInstructionSizeAt(currentPc);
 	if (info.isBranch)
 	{
-		if (info.isConditional == false)
+		if (!info.isConditional)
 		{
 			breakpointAddress = info.branchTarget;
 		} else {

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -79,25 +79,22 @@ namespace Implementations
 	void Framelimiter_TurboToggle()
 	{
 		ScopedCoreThreadPause pauser;
-		
+
 		if( !g_Conf->EmuOptions.GS.FrameLimitEnable )
 		{
 			g_Conf->EmuOptions.GS.FrameLimitEnable = true;
 			g_LimiterMode = Limit_Turbo;
 			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.TurboScalar;
 			Console.WriteLn("(FrameLimiter) Turbo + FrameLimit ENABLED." );
-			if ( g_Conf->Framerate.SkipOnTurbo == true) 
-				g_Conf->EmuOptions.GS.FrameSkipEnable = true;
-			else
-				g_Conf->EmuOptions.GS.FrameSkipEnable = false;
+			g_Conf->EmuOptions.GS.FrameSkipEnable = !!g_Conf->Framerate.SkipOnTurbo;
 		}
 		else if( g_LimiterMode == Limit_Turbo )
 		{
 			GSsetVsync( g_Conf->EmuOptions.GS.VsyncEnable );
 			g_LimiterMode = Limit_Nominal;
 			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
-			
-			if ( g_Conf->Framerate.SkipOnLimit == true) 
+
+			if ( g_Conf->Framerate.SkipOnLimit)
 			{
 				Console.WriteLn("(FrameLimiter) Turbo DISABLED. Frameskip ENABLED" );
 				g_Conf->EmuOptions.GS.FrameSkipEnable = true;
@@ -113,8 +110,8 @@ namespace Implementations
 			GSsetVsync( false );
 			g_LimiterMode = Limit_Turbo;
 			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.TurboScalar;
-			
-			if ( g_Conf->Framerate.SkipOnTurbo == true)
+
+			if ( g_Conf->Framerate.SkipOnTurbo)
 			{
 				Console.WriteLn("(FrameLimiter) Turbo + Frameskip ENABLED." );
 				g_Conf->EmuOptions.GS.FrameSkipEnable = true;

--- a/pcsx2/sif2.cpp
+++ b/pcsx2/sif2.cpp
@@ -208,7 +208,7 @@ static __fi void EndIOP()
 // Handle the EE transfer.
 static __fi void HandleEETransfer()
 {
-	if (sif2dma.chcr.STR == false)
+	if (!sif2dma.chcr.STR)
 	{
 		//DevCon.Warning("Replacement for irq prevention hack EE SIF2");
 		sif2.ee.end = false;
@@ -329,7 +329,7 @@ __fi void SIF2Dma()
 
 		if (sif2.iop.busy)
 		{
-			if (sif2.fifo.sif_free() > 0 || (sif2.iop.end == true && sif2.iop.counter == 0))
+			if (sif2.fifo.sif_free() > 0 || (sif2.iop.end && sif2.iop.counter == 0))
 			{
 				BusyCheck++;
 				HandleIOPTransfer();
@@ -337,7 +337,7 @@ __fi void SIF2Dma()
 		}
 		if (sif2.ee.busy)
 		{
-			if (sif2.fifo.size >= 4 || (sif2.ee.end == true && sif2dma.qwc == 0))
+			if (sif2.fifo.size >= 4 || (sif2.ee.end && sif2dma.qwc == 0))
 			{
 				BusyCheck++;
 				HandleEETransfer();
@@ -350,7 +350,7 @@ __fi void SIF2Dma()
 
 __fi void  sif2Interrupt()
 {
-	if (sif2.iop.end == false || sif2.iop.counter > 0)
+	if (!sif2.iop.end || sif2.iop.counter > 0)
 	{
 		SIF2Dma();
 		return;

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1192,9 +1192,9 @@ void recMemcheck(u32 op, u32 bits, bool store)
 	{
 		if (checks[i].result == 0)
 			continue;
-		if ((checks[i].cond & MEMCHECK_WRITE) == 0 && store == true)
+		if ((checks[i].cond & MEMCHECK_WRITE) == 0 && store)
 			continue;
-		if ((checks[i].cond & MEMCHECK_READ) == 0 && store == false)
+		if ((checks[i].cond & MEMCHECK_READ) == 0 && !store)
 			continue;
 
 		// logic: memAddress < bpEnd && bpStart < memAddress+memSize

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -174,16 +174,16 @@ void VifUnpackSSE_Dynarec::ModUnpack( int upknum, bool PostOp )
 	
 	switch( upknum )
 	{
-		case 0:	
-		case 1: 
-		case 2: if(PostOp == true) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x3; } break;
+		case 0:
+		case 1:
+		case 2: if(PostOp) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x3; } break;
 
-		case 4:  
+		case 4:
 		case 5:
-		case 6: if(PostOp == true) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x1; } break;
+		case 6: if(PostOp) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x1; } break;
 
-		case 8: if(PostOp == true) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x1; } break;
-		case 9:	if (PostOp == false) { UnpkLoopIteration++; } break;
+		case 8: if(PostOp) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x1; } break;
+		case 9:	if (!PostOp) { UnpkLoopIteration++; } break;
 		case 10: 	break;
 
 		case 12: 	break;

--- a/plugins/GSdx/GSDeviceNull.cpp
+++ b/plugins/GSdx/GSDeviceNull.cpp
@@ -34,10 +34,7 @@ bool GSDeviceNull::Create(GSWnd* wnd)
 
 bool GSDeviceNull::Reset(int w, int h)
 {
-	if(!GSDevice::Reset(w, h))
-		return false;
-
-	return true;
+	return GSDevice::Reset(w, h);
 }
 
 GSTexture* GSDeviceNull::CreateSurface(int type, int w, int h, bool msaa, int format)

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -56,10 +56,7 @@ GSRendererOGL::GSRendererOGL()
 
 bool GSRendererOGL::CreateDevice(GSDevice* dev)
 {
-	if (!GSRenderer::CreateDevice(dev))
-		return false;
-
-	return true;
+	return GSRenderer::CreateDevice(dev);
 }
 
 void GSRendererOGL::Lines2Sprites()

--- a/plugins/onepad/SDL/joystick.cpp
+++ b/plugins/onepad/SDL/joystick.cpp
@@ -306,7 +306,7 @@ bool JoystickInfo::PollAxes(u32 &pkey)
             const s32 half_axis_ceil = 0x1FFF;
 
             // Normally, old_value contains the release state so it can be used to detect the types of axis.
-            bool is_full_axis = (old_value < full_axis_ceil) ? true : false;
+            bool is_full_axis = (old_value < full_axis_ceil);
 
             if ((!is_full_axis && abs(value) <= half_axis_ceil) || (is_full_axis && value <= full_axis_ceil))  // we don't want this
             {


### PR DESCRIPTION
As discussed in #1553

Clang Tidy reports goes from 156 to 9.

Remain some macro in spu2x + a deadcode line