### PR TITLE
Debugger: Fix various memory view issues

### DIFF
--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -612,11 +612,11 @@ void CtrlMemView::scrollCursor(int bytes)
 
 	if (curAddress < windowStart)
 	{
-		windowStart = (curAddress / rowSize) * curAddress;
+		windowStart = (curAddress / rowSize) * rowSize;
 	} else if (curAddress >= windowEnd)
 	{
 		windowStart = curAddress - (visibleRows - 1)*rowSize;
-		windowStart = (windowStart / rowSize) * windowStart;
+		windowStart = (windowStart / rowSize) * rowSize;
 	}
 	
 	updateStatusBarText();
@@ -642,7 +642,12 @@ void CtrlMemView::gotoAddress(u32 addr, bool pushInHistory)
 
 	curAddress = addr;
 	selectedNibble = 0;
-	windowStart = curAddress;
+
+	int visibleRows = GetClientSize().y/rowHeight;
+	u32 windowEnd = windowStart+visibleRows*rowSize;
+
+	if (curAddress < windowStart || curAddress >= windowEnd)
+		windowStart = (curAddress / rowSize) * rowSize;
 
 	updateStatusBarText();
 	redraw();

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -502,9 +502,8 @@ void DisassemblyDialog::onDebuggerEvent(wxCommandEvent& evt)
 		{
 			currentCpu->showMemoryView();
 
-			CtrlMemView *memview = currentCpu->getMemoryView();
-			memview->gotoAddress(evt.GetInt(), true);
-			memview->SetFocus();
+			currentCpu->getMemoryView()->gotoAddress(evt.GetInt(), true);
+			currentCpu->getDisassembly()->SetFocus();
 		}
 	} else if (type == debEVT_RUNTOPOS)
 	{


### PR DESCRIPTION
* scrolling the window with the keyboard was broken
* window wasn't getting aligned to row size when using goto
* pressing right on a memory opcode positions the memory view to the address accessed. The focus was set to the memory view, which is rather disruptive and not the common use case where you just want to see what is there, not actually edit it. Changed to set the focus back to the disassembly