### PR TITLE
Link Unconditionally

### DIFF
--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -299,10 +299,10 @@ void BGEZ()    // Branch if Rs >= 0
 
 void BGEZAL() // Branch if Rs >= 0 and link
 {
-
+	_SetLink(31);
 	if (cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
 	{
-		_SetLink(31);
+		
 		doBranch(_BranchTarget_);
 	}
 }
@@ -333,9 +333,10 @@ void BLTZ()    // Branch if Rs <  0
 
 void BLTZAL()  // Branch if Rs <  0 and link
 {
+	_SetLink(31);
 	if (cpuRegs.GPR.r[_Rs_].SD[0] < 0)
 	{
-		_SetLink(31);
+		
 		doBranch(_BranchTarget_);
 	}
 }
@@ -426,10 +427,10 @@ void BGEZL()     // Branch if Rs >= 0
 
 void BLTZALL()   // Branch if Rs <  0 and link
 {
-
+	_SetLink(31);
 	if(cpuRegs.GPR.r[_Rs_].SD[0] < 0)
 	{
-		_SetLink(31);
+		
 		doBranch(_BranchTarget_);
 	}
 	else
@@ -441,10 +442,10 @@ void BLTZALL()   // Branch if Rs <  0 and link
 
 void BGEZALL()   // Branch if Rs >= 0 and link
 {
-
+	_SetLink(31);
 	if(cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
 	{
-		_SetLink(31);
+		
 		doBranch(_BranchTarget_);
 	}
 	else

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -302,7 +302,6 @@ void BGEZAL() // Branch if Rs >= 0 and link
 	_SetLink(31);
 	if (cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
 	{
-		
 		doBranch(_BranchTarget_);
 	}
 }
@@ -336,7 +335,6 @@ void BLTZAL()  // Branch if Rs <  0 and link
 	_SetLink(31);
 	if (cpuRegs.GPR.r[_Rs_].SD[0] < 0)
 	{
-		
 		doBranch(_BranchTarget_);
 	}
 }
@@ -430,7 +428,6 @@ void BLTZALL()   // Branch if Rs <  0 and link
 	_SetLink(31);
 	if(cpuRegs.GPR.r[_Rs_].SD[0] < 0)
 	{
-		
 		doBranch(_BranchTarget_);
 	}
 	else
@@ -445,7 +442,6 @@ void BGEZALL()   // Branch if Rs >= 0 and link
 	_SetLink(31);
 	if(cpuRegs.GPR.r[_Rs_].SD[0] >= 0)
 	{
-		
 		doBranch(_BranchTarget_);
 	}
 	else


### PR DESCRIPTION
Link instructions used to store the return address if the branch was
taken, but the correct behavior is to store the return address whether
or not the branch is taken.