### PR TITLE
(Minor) Mainframe: Fixed shutdown UI function to properly disable itself afte…

### DIFF
--- a/nsis/nsis_instructions.txt
+++ b/nsis/nsis_instructions.txt
@@ -2,12 +2,12 @@
   PCSX2 NSIS Installer Instructions
 -------------------------------------
 
- * Install NSIS (tested with 3.00), make sure to include the "Modern User Interface"
+ * Install NSIS (tested with 2.46), make sure to include the "Modern User Interface"
  * Install NSIS Script: Advanced Uninstall Log (you can find it on NSIS wiki)
    ( Currently at http://nsis.sourceforge.net/Advanced_Uninstall_Log_NSIS_Header )
 
   * Download the Visual C++ 2015 Redistributable and save it to this nsis/ folder.
-   ( https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe )
+   ( https://www.microsoft.com/en-us/download/details.aspx?id=49984 )
    Rename the download to "vcredist_2015_Update_1_x86".
    
  * Download the DirectX Web Installer (dxwebsetup.exe) from Microsoft's website and save it to
@@ -29,7 +29,6 @@
  * Compile script (pcsx2_full_install.nsi)!
    Output executables will be generated to the output/ folder.
  
- *Compiler may abort if output/ folder is not already created in Explorer!
  
 --------------------------------------------
   Compilation Targets and Plugin Inclusion

--- a/nsis/nsis_instructions.txt
+++ b/nsis/nsis_instructions.txt
@@ -2,12 +2,12 @@
   PCSX2 NSIS Installer Instructions
 -------------------------------------
 
- * Install NSIS (tested with 2.46), make sure to include the "Modern User Interface"
+ * Install NSIS (tested with 3.00), make sure to include the "Modern User Interface"
  * Install NSIS Script: Advanced Uninstall Log (you can find it on NSIS wiki)
    ( Currently at http://nsis.sourceforge.net/Advanced_Uninstall_Log_NSIS_Header )
 
   * Download the Visual C++ 2015 Redistributable and save it to this nsis/ folder.
-   ( https://www.microsoft.com/en-us/download/details.aspx?id=49984 )
+   ( https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe )
    Rename the download to "vcredist_2015_Update_1_x86".
    
  * Download the DirectX Web Installer (dxwebsetup.exe) from Microsoft's website and save it to
@@ -29,6 +29,7 @@
  * Compile script (pcsx2_full_install.nsi)!
    Output executables will be generated to the output/ folder.
  
+ *Compiler may abort if output/ folder is not already created in Explorer!
  
 --------------------------------------------
   Compilation Targets and Plugin Inclusion

--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -275,13 +275,13 @@ Dialogs::InterfaceConfigDialog::InterfaceConfigDialog(wxWindow *parent)
 }
 
 Dialogs::InterfaceLanguageDialog::InterfaceLanguageDialog(wxWindow* parent)
-	: BaseConfigurationDialog(parent, _("Language selector"), 400)
+	: BaseConfigurationDialog(parent, _("Language Selector"), 400)
 {
 	*this += 5;
 
 	// Keep this in English - same as the menu item.
-	*this += Heading(L"New language will affect newly opened windows.\n");
-	*this += Heading(L"Full change will happen after restarting PCSX2.");
+	*this += Heading(L"Some menu items may not change until PCSX2 is restarted\n");
+	*this += 2;
 	*this += new Panels::LanguageSelectionPanel(this, false) | StdCenter();
 
 	AddOkCancel();

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -665,7 +665,7 @@ void MainEmuFrame::ApplyCoreStatus()
 		}
 	}
 
-	menubar.Enable( MenuId_Sys_Shutdown, SysHasValidState() || CorePlugins.AreAnyInitialized() );
+	menubar.Check( MenuId_Sys_Shutdown, SysHasValidState() || CorePlugins.AreAnyInitialized() );
 }
 
 //Apply a config to the menu such that the menu reflects it properly

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -665,7 +665,7 @@ void MainEmuFrame::ApplyCoreStatus()
 		}
 	}
 
-	menubar.Check( MenuId_Sys_Shutdown, SysHasValidState() || CorePlugins.AreAnyInitialized() );
+	menubar.Enable( MenuId_Sys_Shutdown, SysHasValidState());
 }
 
 //Apply a config to the menu such that the menu reflects it properly

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -109,7 +109,7 @@ Panels::AdvancedOptionsVU::AdvancedOptionsVU( wxWindow* parent )
 Panels::CpuPanelEE::CpuPanelEE( wxWindow* parent )
 	: BaseApplicableConfigPanel_SpecificConfig( parent )
 {
-	*this	+= Text( pxE( L"Notice: Most games are fine with the default options. ")
+	*this	+= Text( pxE( L"Notice: Most games are fine with the default options.")
 	) | StdExpand();
 
 	const RadioPanelItem tbl_CpuTypes_EE[] =


### PR DESCRIPTION
- The shutdown function no longer stays enabled after the VM has been wiped, ect. Previously, the button would not disable itself after a shutdown and could confuse the user
- I also made a small changes to a the top line in the EE/VU panels (pet-peeve :P) and rewrote the language dialog to sound more fluent.
