### PR TITLE
GSdx: Automatically set default CRC Hack Level

### DIFF
--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -23,7 +23,7 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-int s_crc_hack_level = 3;
+int s_crc_hack_level = -1;
 
 // hacks
 #define Aggresive (s_crc_hack_level > 3)
@@ -2435,7 +2435,19 @@ void GSState::SetupCrcHack()
 {
 	GetSkipCount lut[CRC::TitleCount];
 
-	s_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	GSRendererType renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+	int selected_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	if (selected_crc_hack_level == -1) {
+		if (renderer == GSRendererType::OGL_HW) {
+			printf("Automatic crc hack level set to Partial\n");
+			s_crc_hack_level = 2;
+		} else if (renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX1011_HW) {
+			printf("Automatic crc hack level set to Full\n");
+			s_crc_hack_level = 3;
+		}
+	} else {
+		s_crc_hack_level = selected_crc_hack_level;
+	}
 
 	memset(lut, 0, sizeof(lut));
 

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -42,6 +42,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"Partial:\nEnable most of the CRC hacks.\nRecommended OpenGL setting (Accurate/depth options may be required).\n\n"
 				"Full:\nEnable all CRC hacks.\nRecommended Direct3D setting.\n\n"
 				"Aggressive:\nUse more aggressive CRC hacks. Only affects a few games, removing some effects which might make the image sharper/clearer.\n"
+				"Automatic:\nAutomatically select Partial or Full level based on wether you're using an OpenGL or Direct3D renderer.\n"
 				"Affected games: FFX, FFX2, FFXII, GOW2, ICO, SoTC, SSX3, SMT3, SMTDDS1, SMTDDS2.\n"
 				"Works as a speedhack for: Steambot Chronicles.";
 		case IDC_SKIPDRAWHACK:

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -23,8 +23,6 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-extern int g_crc_hack_level;
-
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
 int GSState::s_n = 0;
@@ -77,7 +75,18 @@ GSState::GSState()
 	//s_savel = 0;
 
 	UserHacks_WildHack = theApp.GetConfigB("UserHacks") ? theApp.GetConfigI("UserHacks_WildHack") : 0;
-	m_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+
+	GSRendererType renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+	int selected_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	if (selected_crc_hack_level == -1) {
+		if (renderer == GSRendererType::OGL_HW) {
+			m_crc_hack_level = 2;
+		} else if (renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX1011_HW) {
+			m_crc_hack_level = 3;
+		}
+	} else {
+		m_crc_hack_level = selected_crc_hack_level;
+	}
 
 	memset(&m_v, 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -48,7 +48,18 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	m_paltex = theApp.GetConfigB("paltex");
 	m_can_convert_depth &= s_IS_OPENGL; // only supported by openGL so far
-	m_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+
+	GSRendererType renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+	int selected_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	if (selected_crc_hack_level == -1) {
+		if (renderer == GSRendererType::OGL_HW) {
+			m_crc_hack_level = 2;
+		} else if (renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX1011_HW) {
+			m_crc_hack_level = 3;
+		}
+	} else {
+		m_crc_hack_level = selected_crc_hack_level;
+	}
 
 	// In theory 4MB is enough but 9MB is safer for overflow (8MB
 	// isn't enough in custom resolution)

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -211,6 +211,7 @@ void GSdxApp::Init()
 	m_gs_hack.push_back(GSSetting(1,  "Half", ""));
 	m_gs_hack.push_back(GSSetting(2,  "Full", ""));
 
+	m_gs_crc_level.push_back(GSSetting(-1, "Automatic", ""));
 	m_gs_crc_level.push_back(GSSetting(0 , "None", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(1 , "Minimum", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(2 , "Partial", "OpenGL Recommended"));
@@ -285,7 +286,7 @@ void GSdxApp::Init()
 	m_default_configuration["CaptureHeight"]                              = "480";
 	m_default_configuration["CaptureWidth"]                               = "640";
 	m_default_configuration["clut_load_before_draw"]                      = "0";
-	m_default_configuration["crc_hack_level"]                             = "3";
+	m_default_configuration["crc_hack_level"]                             = "-1";
 	m_default_configuration["CrcHacksExclusions"]                         = "";
 	m_default_configuration["debug_glsl_shader"]                          = "0";
 	m_default_configuration["debug_opengl"]                               = "0";


### PR DESCRIPTION
Automatically switches the default CRC Hack Level from Full in D3D to
Partial in OGL and vice versa.

Does not change CRC Hack Level when it is set to a non-default
setting.