### PR TITLE
gsdx OGL:  add CRC hack for Ratchet & Clank to use Jak shadow shader

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -521,6 +521,9 @@ CRC::Game CRC::m_games[] =
 	{0x12804727, Jak3, EU, 0},
 	{0x644CFD03, Jak3, US, 0},
 	{0xDF659E77, JakX, EU, 0},
+	{0x76F724A3, RatchetAndClank, EU, 0},
+	{0x17125698, RatchetAndClank3, EU, 0},
+	{0xD697D204, RatchetGladiator, EU, 0},
 };
 
 map<uint32, CRC::Game*> CRC::m_map;

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -179,6 +179,9 @@ public:
 		Jak2,
 		Jak3,
 		JakX,
+		RatchetAndClank,
+		RatchetAndClank3,
+		RatchetGladiator,
 		TitleCount,
 	};
 

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -1155,7 +1155,7 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	// Always check if primitive overlap. The function will return PRIM_OVERLAP_UNKNOW for non sprite primitive
 	m_prim_overlap = PrimitiveOverlap();
 	if ((m_context->FRAME.Block() == m_context->TEX0.TBP0) && PRIM->TME && m_sw_blending && (m_prim_overlap != PRIM_OVERLAP_NO) && (m_vertex.next > 2)) {
-		if (m_game.title == CRC::Jak1 || m_game.title == CRC::Jak2 || m_game.title == CRC::Jak3 || m_game.title == CRC::JakX) {
+		if (m_game.title == CRC::Jak1 || m_game.title == CRC::Jak2 || m_game.title == CRC::Jak3 || m_game.title == CRC::JakX || m_game.title == CRC::RatchetAndClank || m_game.title == CRC::RatchetAndClank3 || m_game.title == CRC::RatchetGladiator) {
 			GL_INS("ERROR: Source and Target are the same! Let's sample the framebuffer");
 			m_ps_sel.tex_is_fb = 1;
 			m_require_full_barrier = true;


### PR DESCRIPTION
* 0x76F724A3, RatchetAndClank, EU
* 0x17125698, RatchetAndClank3, EU
* 0xD697D204, RatchetGladiator, EU

Ratchet & Clank games use the same shadow technique as the Jak and Daxter series, and benefit from the alternate shader added for them in c2b67cc .
(Ratchet & Clank 2 not added as my PC can't read the disc currently - can't test it)

No hacks: ![before](http://i.imgur.com/tSpRsFw.jpg)
Auto Flush hack: ![autoflush](http://i.imgur.com/jBSBIPW.jpg)
Shader: ![after](http://i.imgur.com/Jvqo3Oi.jpg)

(sorry for broken texture screenshots gregory)