### PR TITLE
gsdx hw ate

### DIFF
--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -474,8 +474,12 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 	{
 		const GSLocalMemory::psm_t &psm = GSLocalMemory::m_psm[m_context->TEX0.PSM];
 		const GSLocalMemory::psm_t &cpsm = psm.pal > 0 ? GSLocalMemory::m_psm[m_context->TEX0.CPSM] : psm;
+		// The texture cache will handle various format conversion internally for non-target texture
+		// After the conversion the texture will be RGBA8 (aka 32 bits) hence the 0 below
+		int gpu_tex_fmt = (tex->m_target) ? cpsm.fmt : 0;
+
 		bool bilinear = m_filter == 2 ? m_vt.IsLinear() : m_filter != 0;
-		bool simple_sample = !tex->m_palette && cpsm.fmt == 0 && m_context->CLAMP.WMS < 3 && m_context->CLAMP.WMT < 3;
+		bool simple_sample = !tex->m_palette && gpu_tex_fmt == 0 && m_context->CLAMP.WMS < 3 && m_context->CLAMP.WMT < 3;
 		// Don't force extra filtering on sprite (it creates various upscaling issue)
 		bilinear &= !((m_vt.m_primclass == GS_SPRITE_CLASS) && m_userhacks_round_sprite_offset && !m_vt.IsLinear());
 
@@ -484,7 +488,7 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		if (ps_sel.shuffle) {
 			ps_sel.fmt = 0;
 		} else {
-			ps_sel.fmt = tex->m_palette ? cpsm.fmt | 4 : cpsm.fmt;
+			ps_sel.fmt = tex->m_palette ? gpu_tex_fmt | 4 : gpu_tex_fmt;
 		}
 		ps_sel.aem = m_env.TEXA.AEM;
 		ps_sel.tfx = m_context->TEX0.TFX;

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -479,7 +479,7 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		int gpu_tex_fmt = (tex->m_target) ? cpsm.fmt : 0;
 
 		bool bilinear = m_filter == 2 ? m_vt.IsLinear() : m_filter != 0;
-		bool simple_sample = !tex->m_palette && gpu_tex_fmt == 0 && m_context->CLAMP.WMS < 3 && m_context->CLAMP.WMT < 3;
+		bool simple_sample = !tex->m_palette && gpu_tex_fmt == 0 && m_context->CLAMP.WMS < 2 && m_context->CLAMP.WMT < 2;
 		// Don't force extra filtering on sprite (it creates various upscaling issue)
 		bilinear &= !((m_vt.m_primclass == GS_SPRITE_CLASS) && m_userhacks_round_sprite_offset && !m_vt.IsLinear());
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -548,28 +548,14 @@ void GSRendererHW::Draw()
 
 		m_context->offset.tex = m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
-		/*
-
-		// m_tc->LookupSource will mess with the palette, should not, but we do this after, until it is sorted out
-
 		if(tex_psm.pal > 0)
-		{
 			m_mem.m_clut.Read32(context->TEX0, env.TEXA);
-		}
-
-		*/
 
 		GSVector4i r;
 
 		GetTextureMinMax(r, TEX0, MIP_CLAMP, m_vt.IsLinear());
 
 		tex = tex_psm.depth ? m_tc->LookupDepthSource(TEX0, env.TEXA, r) : m_tc->LookupSource(TEX0, env.TEXA, r);
-
-		// FIXME: Could be removed on openGL
-		if(tex_psm.pal > 0)
-		{
-			m_mem.m_clut.Read32(TEX0, env.TEXA);
-		}
 
 		// Hypothesis: texture shuffle is used as a postprocessing effect so texture will be an old target.
 		// Initially code also tested the RT but it gives too much false-positive

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -429,17 +429,17 @@ void GSRendererHW::Draw()
 	context->ZBUF.ZMSK = zm != 0;
 
 	// It is allowed to use the depth and rt at the same location. However at least 1 must
-	// be disabled.
+	// be disabled. Or the written value must be the same on both channels.
 	// 1/ GoW uses a Cd blending on a 24 bits buffer (no alpha)
 	// 2/ SuperMan really draws (0,0,0,0) color and a (0) 32-bits depth
 	// 3/ 50cents really draws (0,0,0,128) color and a (0) 24 bits depth
 	// Note: FF DoC has both buffer at same location but disable the depth test (write?) with ZTE = 0
 	const bool no_rt = (context->ALPHA.IsCd() && PRIM->ABE && (context->FRAME.PSM == 1));
 	const bool no_ds = !no_rt && (
-			// Depth is always pass (no read) and write are discarded (tekken 5).  (Note: DATE is currently implemented with a stencil buffer)
-			(context->ZBUF.ZMSK && m_context->TEST.ZTST == ZTST_ALWAYS && !m_context->TEST.DATE) ||
+			// Depth is always pass/fail (no read) and write are discarded (tekken 5).  (Note: DATE is currently implemented with a stencil buffer => a depth/stencil buffer)
+			(zm != 0 && m_context->TEST.ZTST <= ZTST_ALWAYS && !m_context->TEST.DATE) ||
 			// Depth will be written through the RT
-			(context->FRAME.FBP == context->ZBUF.ZBP && !PRIM->TME && !context->ZBUF.ZMSK && !context->FRAME.FBMSK && context->TEST.ZTE)
+			(context->FRAME.FBP == context->ZBUF.ZBP && !PRIM->TME && zm == 0 && fm == 0 && context->TEST.ZTE)
 			);
 
 	const bool draw_sprite_tex = PRIM->TME && (m_vt.m_primclass == GS_SPRITE_CLASS);

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -843,7 +843,9 @@ template<int i> void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 			TEX0.PSM = PSM_PSMT8; // International Star Soccer (menu)
 			break;
 		default:
-			fprintf(stderr, "INVALID PSM !!!\n");
+#ifdef ENABLE_OGL_DEBUG
+			fprintf(stderr, "%d:INVALID PSM 0x%x !!!\n", s_n, TEX0.PSM);
+#endif
 			break;
 	}
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -178,17 +178,8 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 	//const GSLocalMemory::psm_t& cpsm = psm.pal > 0 ? GSLocalMemory::m_psm[TEX0.CPSM] : psm;
 
 	// Until DX is fixed
-	if (s_IS_OPENGL) {
-		if(psm_s.pal > 0)
-			m_renderer->m_mem.m_clut.Read32(TEX0, TEXA);
-	} else {
-		GIFRegTEXA plainTEXA;
-
-		plainTEXA.AEM = 1;
-		plainTEXA.TA0 = 0;
-		plainTEXA.TA1 = 0x80;
-		m_renderer->m_mem.m_clut.Read32(TEX0, plainTEXA);
-	}
+	if(psm_s.pal > 0)
+		m_renderer->m_mem.m_clut.Read32(TEX0, TEXA);
 
 	const uint32* clut = m_renderer->m_mem.m_clut;
 
@@ -1671,17 +1662,6 @@ void GSTextureCache::Source::Flush(uint32 count)
 
 	GSLocalMemory::readTexture rtx = psm.rtx;
 
-	GIFRegTEXA plainTEXA;
-
-	// Until DX is fixed
-	if (s_IS_OPENGL) {
-		plainTEXA = m_TEXA;
-	} else {
-		plainTEXA.AEM = 1;
-		plainTEXA.TA0 = 0;
-		plainTEXA.TA1 = 0x80;
-	}
-
 	if(m_palette)
 	{
 		pitch >>= 2;
@@ -1706,13 +1686,13 @@ void GSTextureCache::Source::Flush(uint32 count)
 
 			if(m_texture->Map(m, &r))
 			{
-				(mem.*rtx)(off, r, m.bits, m.pitch, plainTEXA);
+				(mem.*rtx)(off, r, m.bits, m.pitch, m_TEXA);
 
 				m_texture->Unmap();
 			}
 			else
 			{
-				(mem.*rtx)(off, r, buff, pitch, plainTEXA);
+				(mem.*rtx)(off, r, buff, pitch, m_TEXA);
 
 				m_texture->Update(r, buff, pitch);
 			}


### PR DESCRIPTION
I shuffle a bit the ATE code in order to improve performance. It will avoid various depth look up when the buffer isn't used.

An old TEXA hack was removed too due to various bad interactions.
```
It would be nice to test those games
* Ar Tonelico 2 (line in sprite regression?)
* breath of fire dragon quarter (overlayed user interface in the game)
```