### PR TITLE
PCSX2: Avoid enabling VuClipFlag at some scenarios

### DIFF
--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -277,6 +277,10 @@ static int loadGameSettings(Pcsx2Config& dest, const Game_Data& game) {
 
 		if (game.keyExists(key))
 		{
+			// VuClipFlag hack is only used by the SuperVu1 Recompiler.
+			if (id == Fix_VuClipFlag && (!g_Conf->EmuOptions.Cpu.Recompiler.EnableVU1 || g_Conf->EmuOptions.Cpu.Recompiler.UseMicroVU1))
+				continue;
+
 			bool enableIt = game.getBool(key);
 			dest.Gamefixes.Set(id, enableIt);
 			PatchesCon->WriteLn(L"(GameDB) %s Gamefix: " + key, enableIt ? L"Enabled" : L"Disabled");


### PR DESCRIPTION
**Summary of changes**:
- VuClipFlag hack is only used by the SuperVU1 Recompiler, let's avoid enabling it when it's not used.

Previously a console message would be provided stating that `(GameDB) Enabled Gamefix: VuClipFlagHack` even when the user is using the Interpreter (or) MicroVu Recompiler. The following patch prevents such confusions.
