### PR TITLE
FPU has only 2 control registers.

### DIFF
--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -194,7 +194,7 @@ union FPRreg {
 
 struct fpuRegisters {
 	FPRreg fpr[32];		// 32bit floating point registers
-	u32 fprc[32];		// 32bit floating point control registers
+	u32 fprc[2];		// 32bit floating point control registers
 	FPRreg ACC;			// 32 bit accumulator
 	u32 ACCflag;        // an internal accumulator overflow flag
 };


### PR DESCRIPTION
I assumed it was made 32 for a recompiler hack or something, but I tested it with a couple of games, played fine.