### PR TITLE
Added missing CRC for Grand Theft Auto San Andreas.

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -459,6 +459,7 @@ CRC::Game CRC::m_games[] =
 	{0xFF9C0E93, TouristTrophy, US, 0},
 	{0xCA9AA903, TouristTrophy, EU, 0}, //crc hack not fully working on PAL, still needs brightness =0
 	{0xA1B3F232, GTASanAndreas, EU, 0}, // cutie comment
+	{0xB440A8FE, GTASanAndreas, EU, 0},
 	{0x399A49CA, GTASanAndreas, US, 0}, 
 	{0x2C6BE434, GTASanAndreas, US, 0},
 	{0x60FE139C, GTASanAndreas, JP, 0}, 


### PR DESCRIPTION
Could not get this to work [[SOLVED] GTA SA skip draw hack without losing orange sky effect](http://forums.pcsx2.net/Thread-SOLVED-GTA-SA-skip-draw-hack-without-losing-orange-sky-effect). Did some digging and realized my DVD CRC for Grand Theft Auto was not added in this file.