### PR TITLE
GSDX: Generalize the scaling parameters on SetScale() function calls

### DIFF
--- a/plugins/GSdx/GSDeviceOGL.h
+++ b/plugins/GSdx/GSDeviceOGL.h
@@ -126,8 +126,8 @@ public:
 		VSConstantBuffer()
 		{
 			Vertex_Scale_Offset = GSVector4::zero();
-			DepthMask           = GSVector2i(0, 0);
-			PointSize           = GSVector2(0, 0);
+			DepthMask           = GSVector2i(0);
+			PointSize           = GSVector2(0);
 		}
 
 		__forceinline bool Update(const VSConstantBuffer* cb)

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -231,7 +231,7 @@ bool GSRenderer::Merge(int field)
 		src[i] = GSVector4(r) * scale / GSVector4(tex[i]->GetSize()).xyxy();
 		src_hw[i] = (GSVector4(r) + GSVector4 (0, y_offset[i], 0, y_offset[i])) * scale / GSVector4(tex[i]->GetSize()).xyxy();
 
-		GSVector2 off(0, 0);
+		GSVector2 off(0);
 		GSVector2i display_diff(dr[i].left - display_baseline.x, dr[i].top - display_baseline.y);
 		GSVector2i frame_diff(fr[i].left - frame_baseline.x, fr[i].top - frame_baseline.y);
 

--- a/plugins/GSdx/GSRendererDX.h
+++ b/plugins/GSdx/GSRendererDX.h
@@ -58,7 +58,7 @@ protected:
 	GSDeviceDX::PSConstantBuffer ps_cb;
 
 public:
-	GSRendererDX(GSTextureCache* tc, const GSVector2& pixelcenter = GSVector2(0, 0));
+	GSRendererDX(GSTextureCache* tc, const GSVector2& pixelcenter = GSVector2(0));
 	virtual ~GSRendererDX();
 
 };

--- a/plugins/GSdx/GSRendererDX11.cpp
+++ b/plugins/GSdx/GSRendererDX11.cpp
@@ -25,7 +25,7 @@
 #include "resource.h"
 
 GSRendererDX11::GSRendererDX11()
-	: GSRendererDX(new GSTextureCache11(this), GSVector2(-0.5f, -0.5f))
+	: GSRendererDX(new GSTextureCache11(this), GSVector2(-0.5f))
 {
 }
 

--- a/plugins/GSdx/GSRendererDX9.cpp
+++ b/plugins/GSdx/GSRendererDX9.cpp
@@ -253,10 +253,10 @@ void GSRendererDX9::UpdateFBA(GSTexture* rt)
 
 	GSVertexPT1 vertices[] =
 	{
-		{GSVector4(dst.x, -dst.y, 0.5f, 1.0f), GSVector2(0, 0)},
-		{GSVector4(dst.z, -dst.y, 0.5f, 1.0f), GSVector2(0, 0)},
-		{GSVector4(dst.x, -dst.w, 0.5f, 1.0f), GSVector2(0, 0)},
-		{GSVector4(dst.z, -dst.w, 0.5f, 1.0f), GSVector2(0, 0)},
+		{GSVector4(dst.x, -dst.y, 0.5f, 1.0f), GSVector2(0)},
+		{GSVector4(dst.z, -dst.y, 0.5f, 1.0f), GSVector2(0)},
+		{GSVector4(dst.x, -dst.w, 0.5f, 1.0f), GSVector2(0)},
+		{GSVector4(dst.z, -dst.w, 0.5f, 1.0f), GSVector2(0)},
 	};
 
 	dev->IASetVertexBuffer(vertices, sizeof(vertices[0]), countof(vertices));

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -418,6 +418,12 @@ GSVector4i GSState::GetDisplayRect(int i)
 		height /= 2;
 	}
 
+	//  Limit games to standard NTSC resolutions. games with 512X512 (PAL resolution) on NTSC video mode produces black border on the bottom.
+	//  512 X 448 is the resolution generally used by NTSC, saturating the height value seems to get rid of the black borders.
+	//  Though it's quite a bad hack as it affects binaries which are patched to run on a non-native video mode.
+	if (videomode == GSVideoMode::NTSC && height > 448 && width < 640 && m_NTSC_Saturation)
+		height = 448;
+
 	// Set up the display rectangle based on the values obtained from DISPLAY registers
 	GSVector4i rectangle;
 	rectangle.left = m_regs->DISP[i].DISPLAY.DX / magnification.x;
@@ -436,16 +442,9 @@ GSVector4i GSState::GetFrameRect(int i)
 	if (i < 0) i = IsEnabled(1) ? 1 : 0;
 
 	GSVector4i rectangle = GetDisplayRect(i);
-	GSVideoMode videomode = GetVideoMode();
 
 	int w = rectangle.width();
 	int h = rectangle.height();
-
-//  Limit games to standard NTSC resolutions. games with 512X512 (PAL resolution) on NTSC video mode produces black border on the bottom.
-//  512 X 448 is the resolution generally used by NTSC, saturating the height value seems to get rid of the black borders.
-//  Though it's quite a bad hack as it affects binaries which are patched to run on a non-native video mode.
-	if (videomode == GSVideoMode::NTSC && h > 448 && w < 640 && m_NTSC_Saturation)
-		h = 448;
 
 	if (isinterlaced() && m_regs->SMODE2.FFMD && h > 1)
 		h >>= 1;

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -164,6 +164,7 @@ public:
 
 	void IncAge();
 	bool UserHacks_HalfPixelOffset;
+	void ScaleTexture(GSTexture* texture);
 
 	const char* to_string(int type) {
 		return (type == DepthStencil) ? "Depth" : "Color";

--- a/plugins/GSdx/GSVector.h
+++ b/plugins/GSdx/GSVector.h
@@ -55,6 +55,12 @@ public:
 	{
 	}
 
+	GSVector2T(T x)
+	{
+		this->x = x;
+		this->y = x;
+	}
+
 	GSVector2T(T x, T y)
 	{
 		this->x = x;


### PR DESCRIPTION
**Summary of changes**:
- Generalize the calculation of multipliers passed on the two `SetScale()` functions. Might help fixing #694 on custom resolutions. Previous code only considered cases for native scaling resolutions and also potentially had a bug as it didn't check for `m_renderer->CanUpscale()` but probably not critical.
- Add a constructor to dispatch same values on x/y for GSVector2. Might help to save some time in the future :)

@FlatOutPS2 

Could you check whether custom resolution on DMC is fine with this PR? When I tried the dump provided on #694, it only gave the top part of the screen as output. Would be better to check the game directly instead of relying on these dumps :P 
