### PR TITLE
GSDX-Windows: Changes to Texture filtering option on GUI

### DIFF
--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1414,3 +1414,13 @@ enum class GSVideoMode : uint8
 	DTV_720P,
 	DTV_1080I
 };
+
+enum class Filtering : uint8
+{
+	Nearest,
+	Bilinear_Forced,
+	Bilinear_PS2,
+	Trilinear,
+	Trilinear_Bilinear_Forced,
+	Trilinear_Always
+};

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -75,7 +75,7 @@ GSDeviceOGL::GSDeviceOGL()
 	GLState::Clear();
 
 	m_mipmap = theApp.GetConfigI("mipmap");
-	m_filter = theApp.GetConfigI("filter");
+	m_filter = static_cast<Filtering>(theApp.GetConfigI("filter"));
 
 	// Reset the debug file
 	#ifdef ENABLE_OGL_DEBUG
@@ -228,8 +228,9 @@ GSTexture* GSDeviceOGL::CreateSurface(int type, int w, int h, bool msaa, int fmt
 {
 	GL_PUSH("Create surface");
 
+	bool trilinear = m_filter == Filtering::Trilinear || m_filter == Filtering::Trilinear_Bilinear_Forced || m_filter == Filtering::Trilinear_Always;
 	// A wrapper to call GSTextureOGL, with the different kind of parameter
-	GSTextureOGL* t = new GSTextureOGL(type, w, h, fmt, m_fbo_read, m_mipmap > 1 || m_filter > 2);
+	GSTextureOGL* t = new GSTextureOGL(type, w, h, fmt, m_fbo_read, m_mipmap > 1 || trilinear);
 
 	// NOTE: I'm not sure RenderTarget always need to be cleared. It could be costly for big upscale.
 	// FIXME: it will be more logical to do it in FetchSurface. This code is only called at first creation

--- a/plugins/GSdx/GSDeviceOGL.h
+++ b/plugins/GSdx/GSDeviceOGL.h
@@ -405,7 +405,7 @@ public:
 	uint32 m_msaa;				// Level of Msaa
 	int m_force_texture_clear;
 	int m_mipmap;
-	int m_filter;
+	Filtering m_filter;
 
 	static bool m_debug_gl_call;
 	static FILE* m_debug_gl_file;

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -44,7 +44,7 @@ GSRenderer::GSRenderer()
 	m_interlace   = theApp.GetConfigI("interlace") % s_interlace_nb;
 	m_aspectratio = theApp.GetConfigI("AspectRatio") % s_aspect_ratio_nb;
 	m_shader      = theApp.GetConfigI("TVShader") % s_post_shader_nb;
-	m_filter      = theApp.GetConfigI("filter");
+	m_filter      = static_cast<Filtering>(theApp.GetConfigI("filter"));
 	m_vsync       = theApp.GetConfigB("vsync");
 	m_aa1         = theApp.GetConfigB("aa1");
 	m_fxaa        = theApp.GetConfigB("fxaa");

--- a/plugins/GSdx/GSRenderer.h
+++ b/plugins/GSdx/GSRenderer.h
@@ -41,7 +41,6 @@ class GSRenderer : public GSState
 protected:
 	int m_interlace;
 	int m_aspectratio;
-	int m_filter;
 	bool m_vsync;
 	bool m_aa1;
 	bool m_framelimit;
@@ -49,6 +48,7 @@ protected:
 	bool m_fxaa;
 	bool m_shadeboost;
 	bool m_texture_shuffle;
+	Filtering m_filter;
 	GSVector2i m_real_size;
 
 	virtual GSTexture* GetOutput(int i, int& y_offset) = 0;

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -478,7 +478,7 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		// After the conversion the texture will be RGBA8 (aka 32 bits) hence the 0 below
 		int gpu_tex_fmt = (tex->m_target) ? cpsm.fmt : 0;
 
-		bool bilinear = m_filter == 2 || m_filter == 4 ? m_vt.IsLinear() : m_filter != 0;
+		bool bilinear = m_filter == Filtering::Bilinear_PS2 || m_filter == Filtering::Trilinear ? m_vt.IsLinear() : m_filter != Filtering::Nearest;
 		bool simple_sample = !tex->m_palette && gpu_tex_fmt == 0 && m_context->CLAMP.WMS < 2 && m_context->CLAMP.WMT < 2;
 		// Don't force extra filtering on sprite (it creates various upscaling issue)
 		bilinear &= !((m_vt.m_primclass == GS_SPRITE_CLASS) && m_userhacks_round_sprite_offset && !m_vt.IsLinear());

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -754,29 +754,35 @@ void GSRendererOGL::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	bool bilinear = false;
 	int trilinear = 0;
 	bool trilinear_auto = false;
-	switch (m_filter) {
-		case 0: // Nearest
+	switch (m_filter)
+	{
+		case Filtering::Nearest:
 			bilinear = false;
 			break;
-		case 1: // Forced Bilinear
+
+		case Filtering::Bilinear_Forced:
 			bilinear = true;
 			break;
-		case 2: // Bilinear PS2
+
+		case Filtering::Bilinear_PS2:
 			bilinear = m_vt.IsLinear();
 			break;
-		case 3: // Trilinear Forced
+
+		case Filtering::Trilinear_Always:
 			bilinear = true;
 			trilinear = static_cast<uint8>(GS_MIN_FILTER::Linear_Mipmap_Linear);
 			trilinear_auto = m_mipmap != 2;
 			break;
-		case 4: // Trilinear
+
+		case Filtering::Trilinear:
 			bilinear = m_vt.IsLinear();
 			if (need_mipmap && m_mipmap != 2) {
 				trilinear = m_context->TEX1.MMIN;
 				trilinear_auto = true;
 			}
 			break;
-		case 5: // Trilinear (forced on linear)
+
+		case Filtering::Trilinear_Bilinear_Forced:
 			bilinear = true;
 			if (need_mipmap && m_mipmap != 2) {
 				trilinear = (m_context->TEX1.MMIN | 4) & 0x5;

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -33,8 +33,8 @@ const char* dialog_message(int ID, bool* updateText) {
 		case IDC_FILTER:
 			return "Control the texture filtering of the emulation.\n\n"
 				"Nearest:\nAlways disable interpolation, rendering will be blocky.\n\n"
-				"Bilinear PS2:\nUse same mode as the PS2. It is the more accurate option.\n\n"
 				"Bilinear Forced:\nAlways enable interpolation. Rendering is smoother but it could generate some glitches.\n\n"
+				"Bilinear PS2:\nUse same mode as the PS2. It is the more accurate option.\n\n"
 				"Trilinear:\nUse OpenGL trilinear interpolation when PS2 uses mipmaps.\n\n"
 				"Trilinear Forced Bilinear:\nSame as above but always enable bilinear interpolation.\n\n"
 				"Trilinear Ultra:\nAlways enable full trilinear interpolation. Warning Slow!\n\n";

--- a/plugins/GSdx/GSSettingsDlg.h
+++ b/plugins/GSdx/GSSettingsDlg.h
@@ -82,6 +82,7 @@ class GSSettingsDlg : public GSDialog
 
 	void UpdateRenderers();
 	void UpdateControls();
+	void UpdateFilteringCombobox();
 
 protected:
 	void OnInit();

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -199,12 +199,12 @@ void GSdxApp::Init()
 	m_gs_max_anisotropy.push_back(GSSetting(8, "8x", ""));
 	m_gs_max_anisotropy.push_back(GSSetting(16, "16x", ""));
 
-	m_gs_filter.push_back(GSSetting(0, "Nearest", ""));
-	m_gs_filter.push_back(GSSetting(1, "Bilinear", "Forced"));
-	m_gs_filter.push_back(GSSetting(2, "Bilinear", "PS2"));
-	m_gs_filter.push_back(GSSetting(3, "Trilinear", "Ultra/Slow"));
-	m_gs_filter.push_back(GSSetting(4, "Trilinear", ""));
-	m_gs_filter.push_back(GSSetting(5, "Trilinear", "Forced Bilinear"));
+	m_gs_filter.push_back(GSSetting(static_cast<uint32>(Filtering::Nearest), "Nearest", ""));
+	m_gs_filter.push_back(GSSetting(static_cast<uint32>(Filtering::Bilinear_Forced), "Bilinear", "Forced"));
+	m_gs_filter.push_back(GSSetting(static_cast<uint32>(Filtering::Bilinear_PS2), "Bilinear", "PS2"));
+	m_gs_filter.push_back(GSSetting(static_cast<uint32>(Filtering::Trilinear), "Trilinear", ""));
+	m_gs_filter.push_back(GSSetting(static_cast<uint32>(Filtering::Trilinear_Bilinear_Forced), "Trilinear", "Forced Bilinear"));
+	m_gs_filter.push_back(GSSetting(static_cast<uint32>(Filtering::Trilinear_Always), "Trilinear", "Ultra/Slow"));
 
 	m_gs_gl_ext.push_back(GSSetting(-1, "Auto", ""));
 	m_gs_gl_ext.push_back(GSSetting(0,  "Force-Disabled", ""));


### PR DESCRIPTION
**Summary of changes**:

* Add a nice enum for texture filtering options.
* Show Trilinear combobox items only when OpenGL (hardware mode) is used.