### PR TITLE
PSX-mode: Detect video mode via colorburst

### DIFF
--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -199,6 +199,41 @@ union tGS_IMR
 };
 
 // --------------------------------------------------------------------------------------
+//  GSRegSMODE1
+// --------------------------------------------------------------------------------------
+// Currently it's only used to get the CMOD bit from the SMODE1 register value.
+union GSRegSMODE1
+{
+	struct
+	{
+		u32 RC : 3;
+		u32 LC : 7;
+		u32 T1248 : 2;
+		u32 SLCK : 1;
+		u32 CMOD : 2;
+		u32 EX : 1;
+		u32 PRST : 1;
+		u32 SINT : 1;
+		u32 XPCK : 1;
+		u32 PCK2 : 2;
+		u32 SPML : 4;
+		u32 GCONT : 1;
+		u32 PHS : 1;
+		u32 PVS : 1;
+		u32 PEHS : 1;
+		u32 PEVS : 1;
+		u32 CLKSEL : 2;
+		u32 NVCK : 1;
+		u32 SLCK2 : 1;
+		u32 VCKSEL : 2;
+		u32 VHP : 1;
+		u32 _PAD1 : 27;
+	};
+
+	u64 SMODE1;
+};
+
+// --------------------------------------------------------------------------------------
 //  GSRegSIGBLID
 // --------------------------------------------------------------------------------------
 struct GSRegSIGBLID


### PR DESCRIPTION
**Summary of changes**:
- Improve PSX video mode detection by using info from colorburst at certain cases. `( Might help some scenarios on PSX games where PAL/NTSC video mode was improperly set to a wrong limit instead of it's actual vertical frequency limit.)`

@FlatOutPS2 

IIRC you had mentioned some PSX games didn't have a proper limit of 50fps when using PAL video mode, could you check the behavior of this patch with such games? Thank you :)
