### PR TITLE
GSDX: Clean up warnings on MSVC

### DIFF
--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -926,8 +926,8 @@ void GSRendererHW::OI_DoubleHalfClear(GSTexture* rt, GSTexture* ds)
 		//	return;
 
 		// Size of the current draw
-		uint32 w_pages = roundf(m_vt.m_max.p.x / frame_psm.pgs.x);
-		uint32 h_pages = roundf(m_vt.m_max.p.y / frame_psm.pgs.y);
+		uint32 w_pages = static_cast<uint32>(roundf(m_vt.m_max.p.x / frame_psm.pgs.x));
+		uint32 h_pages = static_cast<uint32>(roundf(m_vt.m_max.p.y / frame_psm.pgs.y));
 		uint32 written_pages = w_pages * h_pages;
 
 		// Frame and depth pointer can be inverted

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -3200,7 +3200,7 @@ bool GSState::IsMipMapActive()
 	return m_mipmap && IsMipMapDraw();
 }
 
-GIFRegTEX0 GSState::GetTex0Layer(int lod)
+GIFRegTEX0 GSState::GetTex0Layer(uint32 lod)
 {
 	// Shortcut
 	if (lod == 0) {

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -206,7 +206,7 @@ protected:
 	bool IsOpaque();
 	bool IsMipMapDraw();
 	bool IsMipMapActive();
-	GIFRegTEX0 GetTex0Layer(int lod);
+	GIFRegTEX0 GetTex0Layer(uint32 lod);
 
 public:
 	GIFPath m_path[4];


### PR DESCRIPTION
**Summary of changes**:
* Explicitly cast w_pages and h_pages into uint32.
* Prevent signed/unsigned comparison by converting lod into unsigned integer, honestly how coud a mipmapping level be negative?

On the other hand, don't really care much about the warnings. They were just annoying as they kept popping up all the time I rebuild GSdx.