### PR TITLE
PCSX2-WX: Display boot medium, fix shutdown menu behavior and some string updates

### DIFF
--- a/common/include/Utilities/IniInterface.h
+++ b/common/include/Utilities/IniInterface.h
@@ -74,10 +74,11 @@ public:
     void EnumEntry(const wxString &var, T &value, const wxChar *const *enumArray = NULL, const T defvalue = (T)0)
     {
         int tstore = (int)value;
+        auto defaultvalue = enum_cast(defvalue);
         if (enumArray == NULL)
-            Entry(var, tstore, defvalue);
+            Entry(var, tstore, defaultvalue);
         else
-            _EnumEntry(var, tstore, enumArray, defvalue);
+            _EnumEntry(var, tstore, enumArray, defaultvalue);
         value = (T)tstore;
     }
 

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -38,7 +38,7 @@
 
 const wxChar* CDVD_SourceLabels[] =
 {
-	L"Iso",
+	L"ISO",
 	L"Plugin",
 	L"NoDisc",
 	NULL

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -285,11 +285,11 @@ static void DetectDiskType()
 }
 
 static wxString			m_SourceFilename[3];
-static CDVD_SourceType	m_CurrentSourceType = CDVDsrc_NoDisc;
+static CDVD_SourceType	m_CurrentSourceType = CDVD_SourceType::NoDisc;
 
 void CDVDsys_SetFile( CDVD_SourceType srctype, const wxString& newfile )
 {
-	m_SourceFilename[srctype] = newfile;
+	m_SourceFilename[enum_cast(srctype)] = newfile;
 
 	// look for symbol file
 	if (symbolMap.IsEmpty())
@@ -309,7 +309,7 @@ void CDVDsys_SetFile( CDVD_SourceType srctype, const wxString& newfile )
 
 const wxString& CDVDsys_GetFile( CDVD_SourceType srctype )
 {
-	return m_SourceFilename[srctype];
+	return m_SourceFilename[enum_cast(srctype)];
 }
 
 CDVD_SourceType CDVDsys_GetSourceType()
@@ -323,15 +323,15 @@ void CDVDsys_ChangeSource( CDVD_SourceType type )
 	
 	switch( m_CurrentSourceType = type )
 	{
-		case CDVDsrc_Iso:
+		case CDVD_SourceType::Iso:
 			CDVD = &CDVDapi_Iso;
 		break;
 
-		case CDVDsrc_NoDisc:
+		case CDVD_SourceType::NoDisc:
 			CDVD = &CDVDapi_NoDisc;
 		break;
 
-		case CDVDsrc_Plugin:
+		case CDVD_SourceType::Plugin:
 			CDVD = &CDVDapi_Plugin;
 		break;
 
@@ -354,8 +354,9 @@ bool DoCDVDopen()
 	// question marks if the filename is another language.
 	// Likely Fix: Force new versions of CDVD plugins to expect UTF8 instead.
 
-	int ret = CDVD->open( !m_SourceFilename[m_CurrentSourceType].IsEmpty() ?
-		static_cast<const char*>(m_SourceFilename[m_CurrentSourceType].ToUTF8()) : (char*)NULL
+	auto CurrentSourceType = enum_cast(m_CurrentSourceType);
+	int ret = CDVD->open( !m_SourceFilename[CurrentSourceType].IsEmpty() ?
+		static_cast<const char*>(m_SourceFilename[CurrentSourceType].ToUTF8()) : (char*)NULL
 	);
 
 	if( ret == -1 ) return false;	// error! (handled by caller)
@@ -374,7 +375,7 @@ bool DoCDVDopen()
 	// TODO: "Untitled" should use pnach/slus name resolution, slus if no patch,
 	// and finally an "Untitled-[ElfCRC]" if no slus.
 
-	wxString somepick( Path::GetFilenameWithoutExt( m_SourceFilename[m_CurrentSourceType] ) );
+	wxString somepick( Path::GetFilenameWithoutExt( m_SourceFilename[CurrentSourceType] ) );
 	if( somepick.IsEmpty() )
 		somepick = L"Untitled";
 

--- a/pcsx2/CDVD/CDVDaccess.h
+++ b/pcsx2/CDVD/CDVDaccess.h
@@ -17,11 +17,11 @@
 
 #include "Plugins.h"
 
-enum CDVD_SourceType
+enum class CDVD_SourceType : uint8_t
 {
-	CDVDsrc_Iso = 0,	// use built in ISO api
-	CDVDsrc_Plugin,		// use external plugin
-	CDVDsrc_NoDisc,		// use built in CDVDnull
+	Iso,		// use built in ISO api
+	Plugin,		// use external plugin
+	NoDisc,		// use built in CDVDnull
 };
 
 struct CDVD_API

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -63,6 +63,13 @@ enum GamefixId
 	GamefixId_COUNT
 };
 
+// Template function for casting enumerations to their underlying type
+template <typename Enumeration>
+typename std::underlying_type<Enumeration>::type enum_cast(Enumeration E)
+{
+	return static_cast<typename std::underlying_type<Enumeration>::type>(E);
+}
+
 ImplementEnumOperators( GamefixId );
 
 //------------ DEFAULT sseMXCSR VALUES ---------------

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -305,7 +305,7 @@ public:
 		SysAutoRun				= false;
 		SysAutoRunElf			= false;
 		SysAutoRunIrx			= false;
-		CdvdSource				= CDVDsrc_NoDisc;
+		CdvdSource				= CDVD_SourceType::NoDisc;
 	}
 };
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -549,7 +549,7 @@ AppConfig::AppConfig()
 	EnablePresets		= true;
 	PresetIndex			= 1;
 
-	CdvdSource			= CDVDsrc_Iso;
+	CdvdSource			= CDVD_SourceType::Iso;
 
 	// To be moved to FileMemoryCard pluign (someday)
 	for( uint slot=0; slot<8; ++slot )

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -191,12 +191,12 @@ void Pcsx2App::SysApplySettings()
 	CoreThread.ApplySettings( g_Conf->EmuOptions );
 
 	CDVD_SourceType cdvdsrc( g_Conf->CdvdSource );
-	if( cdvdsrc != CDVDsys_GetSourceType() || (cdvdsrc==CDVDsrc_Iso && (CDVDsys_GetFile(cdvdsrc) != g_Conf->CurrentIso)) )
+	if( cdvdsrc != CDVDsys_GetSourceType() || (cdvdsrc == CDVD_SourceType::Iso && (CDVDsys_GetFile(cdvdsrc) != g_Conf->CurrentIso)) )
 	{
 		CoreThread.ResetCdvd();
 	}
 
-	CDVDsys_SetFile( CDVDsrc_Iso, g_Conf->CurrentIso );
+	CDVDsys_SetFile(CDVD_SourceType::Iso, g_Conf->CurrentIso );
 }
 
 void AppCoreThread::OnResumeReady()

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -362,7 +362,7 @@ bool Pcsx2App::OnCmdLineParsed( wxCmdLineParser& parser )
 
 	if( parser.Found(L"usecd") )
 	{
-		Startup.CdvdSource	= CDVDsrc_Plugin;
+		Startup.CdvdSource	= CDVD_SourceType::Plugin;
 		Startup.SysAutoRun	= true;
 	}
 

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1064,7 +1064,7 @@ public:
 	SysExecEvent_Execute()
 		: m_UseCDVDsrc(false)
 		, m_UseELFOverride(false)
-		, m_cdvdsrc_type(CDVDsrc_Iso)
+		, m_cdvdsrc_type(CDVD_SourceType::Iso)
 	{
 	}
 
@@ -1090,11 +1090,11 @@ protected:
 		CoreThread.ResetQuick();
 		symbolMap.Clear();
 
-		CDVDsys_SetFile( CDVDsrc_Iso, g_Conf->CurrentIso );
+		CDVDsys_SetFile(CDVD_SourceType::Iso, g_Conf->CurrentIso );
 		if( m_UseCDVDsrc )
 			CDVDsys_ChangeSource( m_cdvdsrc_type );
 		else if( CDVD == NULL )
-			CDVDsys_ChangeSource( CDVDsrc_NoDisc );
+			CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
 
 		if( m_UseELFOverride && !CoreThread.HasActiveMachine() )
 			CoreThread.SetElfOverride( m_elf_override );

--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -63,7 +63,7 @@ const wxImage& LoadImageAny(
 RecentIsoList::RecentIsoList(int firstIdForMenuItems_or_wxID_ANY)
 {
 	Menu = std::unique_ptr<wxMenu>(new wxMenu());
-	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an Iso that is not in your recent history.") );
+	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history.") );
 	Manager = std::unique_ptr<RecentIsoManager>(new RecentIsoManager( Menu.get(), firstIdForMenuItems_or_wxID_ANY ));
 }
 

--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -275,13 +275,13 @@ Dialogs::InterfaceConfigDialog::InterfaceConfigDialog(wxWindow *parent)
 }
 
 Dialogs::InterfaceLanguageDialog::InterfaceLanguageDialog(wxWindow* parent)
-	: BaseConfigurationDialog(parent, _("Language selector"), 400)
+	: BaseConfigurationDialog(parent, _("Language Selector"), 400)
 {
 	*this += 5;
 
 	// Keep this in English - same as the menu item.
-	*this += Heading(L"New language will affect newly opened windows.\n");
-	*this += Heading(L"Full change will happen after restarting PCSX2.");
+	*this += Heading(L"Language switch will only affect newly opened windows.\n");
+	*this += Heading(L"Full change will not apply until PCSX2 is restarted.");
 	*this += new Panels::LanguageSelectionPanel(this, false) | StdCenter();
 
 	AddOkCancel();

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -448,6 +448,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 
 	m_menuSys.Append(MenuId_Sys_Shutdown,	_("Shut&down"),
 		_("Wipes all internal VM states and shuts down plugins."));
+	m_menuSys.FindItem(MenuId_Sys_Shutdown)->Enable(false);
 
 	m_menuSys.Append(MenuId_Exit,			_("E&xit"),
 		AddAppName(_("Closing %s may be hazardous to your health")));
@@ -671,8 +672,6 @@ void MainEmuFrame::ApplyCoreStatus()
 			cdvd2->SetHelp(_("Use fast boot to skip PS2 startup and splash screens"));
 		}
 	}
-
-	menubar.Enable( MenuId_Sys_Shutdown, SysHasValidState() || CorePlugins.AreAnyInitialized() );
 }
 
 //Apply a config to the menu such that the menu reflects it properly

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -57,14 +57,14 @@ void MainEmuFrame::UpdateIsoSrcSelection()
 
 	switch( g_Conf->CdvdSource )
 	{
-		case CDVDsrc_Iso:		cdsrc = MenuId_Src_Iso;		break;
-		case CDVDsrc_Plugin:	cdsrc = MenuId_Src_Plugin;	break;
-		case CDVDsrc_NoDisc:	cdsrc = MenuId_Src_NoDisc;	break;
+		case CDVD_SourceType::Iso:		cdsrc = MenuId_Src_Iso;		break;
+		case CDVD_SourceType::Plugin:	cdsrc = MenuId_Src_Plugin;	break;
+		case CDVD_SourceType::NoDisc:	cdsrc = MenuId_Src_NoDisc;	break;
 
 		jNO_DEFAULT
 	}
 	sMenuBar.Check( cdsrc, true );
-	m_statusbar.SetStatusText( CDVD_SourceLabels[g_Conf->CdvdSource], 1 );
+	m_statusbar.SetStatusText( CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], 1 );
 
 	EnableCdvdPluginSubmenu( cdsrc == MenuId_Src_Plugin );
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -440,8 +440,9 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	m_menuSys.Append(MenuId_EnableWideScreenPatches,	_("Enable &Widescreen Patches"),
 		wxEmptyString, wxITEM_CHECK);
 
-	m_menuSys.Append(MenuId_EnableHostFs,	_("Enable &Host Filesystem"),
-		wxEmptyString, wxITEM_CHECK);
+	if(IsDebugBuild || IsDevBuild)
+		m_menuSys.Append(MenuId_EnableHostFs,	_("Enable &Host Filesystem"),
+			wxEmptyString, wxITEM_CHECK);
 
 	m_menuSys.AppendSeparator();
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -133,7 +133,7 @@ wxWindowID SwapOrReset_Iso( wxWindow* owner, IScopedCoreThread& core_control, co
 {
 	wxWindowID result = wxID_CANCEL;
 
-	if( (g_Conf->CdvdSource == CDVDsrc_Iso) && (isoFilename == g_Conf->CurrentIso) )
+	if( (g_Conf->CdvdSource == CDVD_SourceType::Iso) && (isoFilename == g_Conf->CurrentIso) )
 	{
 		core_control.AllowResume();
 		return result;
@@ -158,12 +158,12 @@ wxWindowID SwapOrReset_Iso( wxWindow* owner, IScopedCoreThread& core_control, co
 		}
 	}
 
-	g_Conf->CdvdSource = CDVDsrc_Iso;
+	g_Conf->CdvdSource = CDVD_SourceType::Iso;
 	SysUpdateIsoSrcFile( isoFilename );
 	if( result == wxID_RESET )
 	{
 		core_control.DisallowResume();
-		sApp.SysExecute( CDVDsrc_Iso );
+		sApp.SysExecute(CDVD_SourceType::Iso);
 	}
 	else
 	{
@@ -173,7 +173,7 @@ wxWindowID SwapOrReset_Iso( wxWindow* owner, IScopedCoreThread& core_control, co
 		core_control.AllowResume();
 	}
 
-	GetMainFrame().EnableCdvdPluginSubmenu( g_Conf->CdvdSource == CDVDsrc_Plugin );
+	GetMainFrame().EnableCdvdPluginSubmenu( g_Conf->CdvdSource == CDVD_SourceType::Plugin);
 
 	return result;
 }
@@ -190,7 +190,7 @@ wxWindowID SwapOrReset_CdvdSrc( wxWindow* owner, CDVD_SourceType newsrc )
 
 		wxString changeMsg;
 		changeMsg.Printf(_("You've selected to switch the CDVD source from %s to %s."),
-			CDVD_SourceLabels[g_Conf->CdvdSource], CDVD_SourceLabels[newsrc] );
+			CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], CDVD_SourceLabels[enum_cast(newsrc)] );
 
 		dialog += dialog.Heading(changeMsg + L"\n\n" +
 			_("Do you want to swap discs or boot the new image (system reset)?")
@@ -212,7 +212,8 @@ wxWindowID SwapOrReset_CdvdSrc( wxWindow* owner, CDVD_SourceType newsrc )
 	if( result != wxID_RESET )
 	{
 		Console.Indent().WriteLn(L"(CdvdSource) HotSwapping CDVD source types from %s to %s.",
-			WX_STR(wxString(CDVD_SourceLabels[oldsrc])), WX_STR(wxString(CDVD_SourceLabels[newsrc])));
+			WX_STR(wxString(CDVD_SourceLabels[enum_cast(oldsrc)])),
+			WX_STR(wxString(CDVD_SourceLabels[enum_cast(newsrc)])));
 		//CoreThread.ChangeCdvdSource();
 		sMainFrame.UpdateIsoSrcSelection();
 		core.AllowResume();
@@ -223,7 +224,7 @@ wxWindowID SwapOrReset_CdvdSrc( wxWindow* owner, CDVD_SourceType newsrc )
 		sApp.SysExecute( g_Conf->CdvdSource );
 	}
 
-	GetMainFrame().EnableCdvdPluginSubmenu( g_Conf->CdvdSource == CDVDsrc_Plugin );
+	GetMainFrame().EnableCdvdPluginSubmenu( g_Conf->CdvdSource == CDVD_SourceType::Plugin );
 
 	return result;
 }
@@ -313,7 +314,7 @@ void MainEmuFrame::_DoBootCdvd()
 {
 	ScopedCoreThreadPause paused_core;
 
-	if( g_Conf->CdvdSource == CDVDsrc_Iso )
+	if( g_Conf->CdvdSource == CDVD_SourceType::Iso )
 	{
 		bool selector = g_Conf->CurrentIso.IsEmpty();
 
@@ -369,13 +370,13 @@ void MainEmuFrame::EnableCdvdPluginSubmenu(bool isEnable)
 
 void MainEmuFrame::Menu_CdvdSource_Click( wxCommandEvent &event )
 {
-	CDVD_SourceType newsrc = CDVDsrc_NoDisc;
+	CDVD_SourceType newsrc = CDVD_SourceType::NoDisc;
 
 	switch( event.GetId() )
 	{
-		case MenuId_Src_Iso:	newsrc = CDVDsrc_Iso;		break;
-		case MenuId_Src_Plugin:	newsrc = CDVDsrc_Plugin;	break;
-		case MenuId_Src_NoDisc: newsrc = CDVDsrc_NoDisc;	break;
+		case MenuId_Src_Iso:	newsrc = CDVD_SourceType::Iso;		break;
+		case MenuId_Src_Plugin:	newsrc = CDVD_SourceType::Plugin;	break;
+		case MenuId_Src_NoDisc: newsrc = CDVD_SourceType::NoDisc;	break;
 		jNO_DEFAULT
 	}
 

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -65,7 +65,7 @@ void RecentIsoManager::OnChangedSelection( wxCommandEvent& evt )
 	// Actually there is no change on the selection so the event can be skip
 	// Note: It also avoids a deadlock which appears when the core thread is already paused
 	// and ScopedCoreThreadPopup try to stop the thread (GSOpen1 code path)
-	if( (g_Conf->CdvdSource == CDVDsrc_Iso) && (m_Items[i].Filename == g_Conf->CurrentIso) )
+	if( (g_Conf->CdvdSource == CDVD_SourceType::Iso) && (m_Items[i].Filename == g_Conf->CurrentIso) )
 	{
 		evt.Skip();
 		return;


### PR DESCRIPTION
**Summary of changes**:

* Fix shutdown menu item behavior (Thanks to @MrCK1 for looking into it)
* Disable Host Filesystem menu item for release builds as it isn't generally useful for endusers.
* Display proper boot medium on the menu items.
* Some string updates, here and there.

~~``[WIP]`` I still need to update https://github.com/PCSX2/pcsx2/commit/80ed0c367f8d46c30aa89fdefd8c93fd0c130bfd at a later time, other than that code is complete.~~ **Done**

Gregory suggested refraction to reduce the gamefix panel help string size, so #1620 could probably be closed after that I guess.