### PR TITLE
IOP: Convert most IOP memory access in the IRX HLE and debugging modu…

### DIFF
--- a/pcsx2/IopBios.h
+++ b/pcsx2/IopBios.h
@@ -20,6 +20,7 @@
 #define IOP_EIO		5
 #define IOP_ENOMEM	12
 #define IOP_EACCES	13
+#define IOP_ENODEV	19
 #define IOP_EISDIR	21
 #define IOP_EMFILE	24
 #define IOP_EROFS	30
@@ -38,7 +39,10 @@
 
 class IOManFile {
 public:
-	// int open(IOManFile **file, char *name, s32 flags, u16 mode);
+	static int open(IOManFile **file, const std::string &path, s32 flags, u16 mode)
+	{
+		return -IOP_ENODEV;
+	}
 
 	virtual void close() = 0;
 
@@ -59,12 +63,13 @@ typedef void (*irxDEBUG)();
 
 namespace R3000A
 {
-	const char* irxImportLibname(u32 entrypc);
-	const char* irxImportFuncname(const char libname[8], u16 index);
-	irxHLE irxImportHLE(const char libname[8], u16 index);
-	irxDEBUG irxImportDebug(const char libname[8], u16 index);
-	void __fastcall irxImportLog(const char libname[8], u16 index, const char *funcname);
-	int __fastcall irxImportExec(const char libname[8], u16 index);
+	const u32 irxImportTableAddr(u32 entrypc);
+	const char* irxImportFuncname(const std::string &libname, u16 index);
+	irxHLE irxImportHLE(const std::string &libnam, u16 index);
+	irxDEBUG irxImportDebug(const std::string & libname, u16 index);
+	void irxImportLog(const std::string &libnameptr, u16 index, const char *funcname);
+	void __fastcall irxImportLog_rec(u32 import_table, u16 index, const char *funcname);
+	int irxImportExec(u32 import_table, u16 index);
 
 	namespace ioman
 	{

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -490,3 +490,14 @@ void __fastcall iopMemWrite32(u32 mem, u32 value)
 		}
 	}
 }
+
+std::string iopMemReadString(u32 mem, int maxlen)
+{
+    std::string ret;
+    char c;
+
+    while ((c = iopMemRead8(mem++)) && maxlen--)
+        ret.push_back(c);
+
+	return ret;
+}

--- a/pcsx2/IopMem.h
+++ b/pcsx2/IopMem.h
@@ -83,6 +83,8 @@ extern void __fastcall iopMemWrite8 (u32 mem, u8 value);
 extern void __fastcall iopMemWrite16(u32 mem, u16 value);
 extern void __fastcall iopMemWrite32(u32 mem, u32 value);
 
+std::string iopMemReadString(u32 mem, int maxlen = 65536);
+
 namespace IopMemory
 {
 	// Sif functions not made yet (will for future Iop improvements):

--- a/pcsx2/IopModuleNames.cpp
+++ b/pcsx2/IopModuleNames.cpp
@@ -13,7 +13,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define MODULE(n) if (!strncmp(libname, #n, 8)) switch (index) {
+#define MODULE(n) if (#n == libname) switch (index) {
 #define END_MODULE }
 #define EXPORT(i, n) case (i): return #n;
 

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -93,7 +93,7 @@ void psxJ()
 {
 	// check for iop module import table magic
 	u32 delayslot = iopMemRead32(psxRegs.pc);
-	if (delayslot >> 16 == 0x2400 && irxImportExec(irxImportLibname(psxRegs.pc), delayslot & 0xffff))
+	if (delayslot >> 16 == 0x2400 && irxImportExec(irxImportTableAddr(psxRegs.pc), delayslot & 0xffff))
 		return;
 
 	doBranch(_JumpTarget_);


### PR DESCRIPTION
…le to safe access through iopMem* functions.

Also made a minor change to allow passing module version numbers to our function implementations, which I'll make part of the extended ioman functionality pull request since it needs that.

Kprintf requires special attention so I didn't tackle it here, I don't even think it has the same features as the actual Sony IOP printf (e.g. no * for field width).