### PR TITLE
cdvdgigaherz: Fix race condition and other stuff

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -437,7 +437,7 @@ void CALLBACK CDVDnewDiskCB(void (*callback)());
 // new funcs
 
 // read a track directly
-s32 CALLBACK CDVDreadSector(u8 *buffer, s32 lsn, int mode);
+s32 CALLBACK CDVDreadSector(u8 *buffer, u32 lsn, int mode);
 
 // improved getBuffer
 s32 CALLBACK CDVDgetBuffer2(u8 *buffer);

--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -238,7 +238,7 @@ EXPORT s32 CALLBACK CDVDgetDualInfo(s32 *dualType, u32 *_layer1start)
 int lastReadInNewDiskCB = 0;
 char directReadSectorBuffer[2448];
 
-EXPORT s32 CALLBACK CDVDreadSector(u8 *buffer, s32 lsn, int mode)
+EXPORT s32 CALLBACK CDVDreadSector(u8 *buffer, u32 lsn, int mode)
 {
     return cdvdDirectReadSector(lsn, mode, (char *)buffer);
 }

--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -113,7 +113,6 @@ bool weAreInNewDiskCB = false;
 
 std::unique_ptr<IOCtlSrc> src;
 
-char throwaway[2352];
 extern s32 prefetch_last_lba;
 extern s32 prefetch_last_mode;
 
@@ -122,6 +121,8 @@ extern s32 prefetch_last_mode;
 
 void keepAliveThread()
 {
+    u8 throwaway[2352];
+
     printf(" * CDVD: KeepAlive thread started...\n");
     std::unique_lock<std::mutex> guard(s_keepalive_lock);
 
@@ -236,11 +237,11 @@ EXPORT s32 CALLBACK CDVDgetDualInfo(s32 *dualType, u32 *_layer1start)
 }
 
 int lastReadInNewDiskCB = 0;
-char directReadSectorBuffer[2448];
+u8 directReadSectorBuffer[2448];
 
 EXPORT s32 CALLBACK CDVDreadSector(u8 *buffer, u32 lsn, int mode)
 {
-    return cdvdDirectReadSector(lsn, mode, (char *)buffer);
+    return cdvdDirectReadSector(lsn, mode, buffer);
 }
 
 EXPORT s32 CALLBACK CDVDreadTrack(u32 lsn, int mode)
@@ -263,12 +264,10 @@ EXPORT u8 *CALLBACK CDVDgetBuffer()
 {
     if (lastReadInNewDiskCB) {
         lastReadInNewDiskCB = 0;
-        return (u8 *)directReadSectorBuffer;
+        return directReadSectorBuffer;
     }
 
-    u8 *s = (u8 *)cdvdGetSector(csector, cmode);
-
-    return s;
+    return cdvdGetSector(csector, cmode);
 }
 
 // return can be NULL (for async modes)

--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -130,10 +130,10 @@ void keepAliveThread()
                                     []() { return !s_keepalive_is_open; })) {
 
         //printf(" * keepAliveThread: polling drive.\n");
-        //if (prefetch_last_mode == CDVD_MODE_2048)
-        src->ReadSectors2048(prefetch_last_lba, 1, throwaway);
-        //else
-        //	src->ReadSectors2352(prefetch_last_lba, 1, throwaway);
+        if (prefetch_last_mode == CDVD_MODE_2048)
+            src->ReadSectors2048(prefetch_last_lba, 1, throwaway);
+        else
+            src->ReadSectors2352(prefetch_last_lba, 1, throwaway);
     }
 
     printf(" * CDVD: KeepAlive thread finished.\n");

--- a/plugins/cdvdGigaherz/src/CDVD.h
+++ b/plugins/cdvdGigaherz/src/CDVD.h
@@ -24,6 +24,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -83,8 +84,8 @@ public:
 
     u32 GetSectorCount() const;
     const std::vector<toc_entry> &ReadTOC() const;
-    bool ReadSectors2048(u32 sector, u32 count, char *buffer) const;
-    bool ReadSectors2352(u32 sector, u32 count, char *buffer) const;
+    bool ReadSectors2048(u32 sector, u32 count, u8 *buffer) const;
+    bool ReadSectors2352(u32 sector, u32 count, u8 *buffer) const;
     u32 GetLayerBreakAddress() const;
     s32 GetMediaType() const;
     void SetSpindleSpeed(bool restore_defaults) const;
@@ -114,8 +115,8 @@ bool cdvdStartThread();
 void cdvdStopThread();
 s32 cdvdRequestSector(u32 sector, s32 mode);
 s32 cdvdRequestComplete();
-char *cdvdGetSector(s32 sector, s32 mode);
-s32 cdvdDirectReadSector(s32 first, s32 mode, char *buffer);
+u8 *cdvdGetSector(u32 sector, s32 mode);
+s32 cdvdDirectReadSector(u32 first, s32 mode, u8 *buffer);
 s32 cdvdGetMediaType();
 s32 cdvdRefreshData();
 void cdvdParseTOC();

--- a/plugins/cdvdGigaherz/src/CDVD.h
+++ b/plugins/cdvdGigaherz/src/CDVD.h
@@ -114,7 +114,6 @@ extern void (*newDiscCB)();
 bool cdvdStartThread();
 void cdvdStopThread();
 s32 cdvdRequestSector(u32 sector, s32 mode);
-s32 cdvdRequestComplete();
 u8 *cdvdGetSector(u32 sector, s32 mode);
 s32 cdvdDirectReadSector(u32 first, s32 mode, u8 *buffer);
 s32 cdvdGetMediaType();

--- a/plugins/cdvdGigaherz/src/ReadThread.cpp
+++ b/plugins/cdvdGigaherz/src/ReadThread.cpp
@@ -176,7 +176,7 @@ void cdvdThread()
     while (cdvd_is_open) {
         if (cdvdUpdateDiscStatus()) {
             // Need to sleep some to avoid an aggressive spin that sucks the cpu dry.
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            s_notify_cv.wait_for(guard, std::chrono::milliseconds(10));
             continue;
         }
 

--- a/plugins/cdvdGigaherz/src/ReadThread.cpp
+++ b/plugins/cdvdGigaherz/src/ReadThread.cpp
@@ -77,6 +77,14 @@ void cdvdCacheUpdate(u32 lsn, s32 mode, u8 *data)
     Cache[entry].mode = mode;
 }
 
+bool cdvdCacheCheck(u32 lsn, s32 mode)
+{
+    std::lock_guard<std::mutex> guard(s_cache_lock);
+    u32 entry = cdvdSectorHash(lsn, mode);
+
+    return Cache[entry].lsn == lsn && Cache[entry].mode == mode;
+}
+
 bool cdvdCacheFetch(u32 lsn, s32 mode, u8 *data)
 {
     std::lock_guard<std::mutex> guard(s_cache_lock);

--- a/plugins/cdvdGigaherz/src/Unix/LinuxIOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Unix/LinuxIOCtlSrc.cpp
@@ -84,7 +84,7 @@ const std::vector<toc_entry> &IOCtlSrc::ReadTOC() const
     return m_toc;
 }
 
-bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, char *buffer) const
+bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, u8 *buffer) const
 {
     std::lock_guard<std::mutex> guard(m_lock);
 
@@ -108,7 +108,7 @@ bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, char *buffer) const
     return false;
 }
 
-bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, char *buffer) const
+bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8 *buffer) const
 {
     union
     {

--- a/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
@@ -111,7 +111,7 @@ const std::vector<toc_entry> &IOCtlSrc::ReadTOC() const
     return m_toc;
 }
 
-bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, char *buffer) const
+bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, u8 *buffer) const
 {
     std::lock_guard<std::mutex> guard(m_lock);
     LARGE_INTEGER offset;
@@ -138,7 +138,7 @@ bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, char *buffer) const
     return false;
 }
 
-bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, char *buffer) const
+bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8 *buffer) const
 {
     struct sptdinfo
     {


### PR DESCRIPTION
Changes:
 * Fixes a race condition where the wrong data could be sent to PCSX2.
 * Fixes a data race.
 * Fixes a sign mismatch in the CDVD plugin API.
 * Change variable/parameter types to reduce casting.
 * Fixes the cdvdgigaherz Coverity issue.

The plugin will probably have slightly worse performance in some cases, but it might be unavoidable (and it's better than random crashing).