### PR TITLE
Add PGO support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,9 @@ for ARG in "$@"; do
         --extra             ) flags="$flags -DEXTRA_PLUGINS=TRUE" ;;
         --asan              ) flags="$flags -DUSE_ASAN=TRUE" ;;
         --gtk3              ) flags="$flags -DGTK3_API=TRUE" ;;
+        --lto               ) flags="$flags -DUSE_LTO=TRUE" ;;
+        --pgo-optimize      ) flags="$flags -DUSE_PGO_OPTIMIZE=TRUE" ;;
+        --pgo-generate      ) flags="$flags -DUSE_PGO_GENERATE=TRUE" ;;
         --no-simd           ) flags="$flags -DDISABLE_ADVANCE_SIMD=TRUE" ;;
         --cross-multilib    ) flags="$flags -DCMAKE_TOOLCHAIN_FILE=$toolfile"; useCross=1; ;;
         --no-cross-multilib ) useCross=0; ;;
@@ -108,6 +111,9 @@ for ARG in "$@"; do
             echo "--no-cross-multilib: Build a native PCSX2"
             echo "--clang         : Build with Clang/llvm"
             echo "--intel         : Build with ICC (Intel compiler)"
+            echo "--lto           : Use Link Time Optimization"
+            echo "--pgo-generate  : Executable will generate profiling information when run"
+            echo "--pgo-optimize  : Use previously generated profiling information"
             echo
             echo "** Quality & Assurance (Please install the external tool) **"
             echo "--asan          : Enable Address sanitizer"

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -296,6 +296,8 @@ endif()
 # Set some default compiler flags
 #-------------------------------------------------------------------------------
 option(USE_LTO "Enable LTO optimization (will likely break the build)")
+option(USE_PGO_GENERATE "Enable PGO optimization (generate profile)")
+option(USE_PGO_OPTIMIZE "Enable PGO optimization (use profile)")
 
 # Note1: Builtin strcmp/memcmp was proved to be slower on Mesa than stdlib version.
 # Note2: float operation SSE is impacted by the PCSX2 SSE configuration. In particular, flush to zero denormal.
@@ -349,6 +351,18 @@ else()
     set(LTO_FLAGS "")
 endif()
 
+set(PGO_FLAGS "-fprofile-dir=${CMAKE_SOURCE_DIR}/profile")
+
+if (USE_PGO_GENERATE)
+    message(WARNING "PGO has not been thoroughly tested. A bug is not impossible.")
+    set(PGO_FLAGS "${PGO_FLAGS} -fprofile-generate")
+endif()
+
+if(USE_PGO_OPTIMIZE)
+    message(WARNING "PGO has not been thoroughly tested. A bug is not impossible.")
+    set(PGO_FLAGS "${PGO_FLAGS} -fprofile-use")
+endif()
+
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
     set(DEBUG_FLAG "${DBG} -DPCSX2_DEVBUILD -DPCSX2_DEBUG -D_DEBUG")
 elseif(CMAKE_BUILD_TYPE MATCHES "Devel")
@@ -386,7 +400,7 @@ else()
 endif()
 
 # Note: -DGTK_DISABLE_DEPRECATED can be used to test a build without gtk deprecated feature. It could be useful to port to a newer API
-set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS} ${PLUGIN_SUPPORT}")
+set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS} ${PGO_FLAGS} ${PLUGIN_SUPPORT}")
 # c++ only flags
 set(DEFAULT_CPP_FLAG "${DEFAULT_GCC_FLAG} -std=c++11 -Wno-invalid-offsetof")
 


### PR DESCRIPTION
Adds PGO support. Profile data is stored in a folder called profilein the top-level source directory. The build folder should NOT be transferred between computers when PGO is used, though I don't
see why anyone would be doing so anyway.