### PR TITLE
PCSX2-GS: Use interrupt mask register bitfields

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -450,10 +450,8 @@ static __fi void VSyncStart(u32 sCycle)
 	if (!CSRreg.VSINT)
 	{
 		CSRreg.VSINT = true;
-		if (!(GSIMR&0x800))
-		{
+		if (!GSIMR.VSMSK)
 			gsIrq();
-		}
 	}
 
 	hwIntcIrq(INTC_VBLANK_S);
@@ -532,10 +530,8 @@ __fi void rcntUpdate_hScanline()
 		if (!CSRreg.HSINT)
 		{
 			CSRreg.HSINT = true;
-			if (!(GSIMR&0x400))
-			{
+			if (!GSIMR.HSMSK)
 				gsIrq();
-			}
 		}
 		if (gates) rcntEndGate(false, hsyncCounter.sCycle);
 		if (psxhblankgate) psxCheckEndGate16(0);

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -55,7 +55,7 @@ void gsReset()
 	memzero(g_RealGSMem);
 
 	CSRreg.Reset();
-	GSIMR = 0x7f00;
+	GSIMR.reset();
 }
 
 static __fi void gsCSRwrite( const tGS_CSR& csr )
@@ -68,7 +68,7 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 		GetMTGS().SendSimplePacket(GS_RINGTYPE_RESET, 0, 0, 0);
 
 		CSRreg.Reset();
-		GSIMR = 0x7F00;			//This is bits 14-8 thats all that should be 1
+		GSIMR.reset();
 	}
 
 	if(csr.FLUSH)
@@ -87,7 +87,7 @@ static __fi void gsCSRwrite( const tGS_CSR& csr )
 			GSSIGLBLID.SIGID = (GSSIGLBLID.SIGID & ~gifUnit.gsSIGNAL.data[1])
 				        | (gifUnit.gsSIGNAL.data[0]&gifUnit.gsSIGNAL.data[1]);
 
-			if (!(GSIMR&0x100)) gsIrq();
+			if (!GSIMR.SIGMSK) gsIrq();
 			CSRreg.SIGNAL  = true; // Just to be sure :p
 		}
 		else CSRreg.SIGNAL = false;
@@ -108,10 +108,10 @@ static __fi void IMRwrite(u32 value)
 {
 	GUNIT_LOG("IMRwrite()");
 
-	if (CSRreg.GetInterruptMask() & (~value & GSIMR) >> 8)
+	if (CSRreg.GetInterruptMask() & (~value & GSIMR._u32) >> 8)
 		gsIrq();
 
-	GSIMR = (value & 0x1f00)|0x6000;
+	GSIMR._u32 = (value & 0x1f00)|0x6000;
 }
 
 __fi void gsWrite8(u32 mem, u8 value)

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -173,12 +173,12 @@ union tGS_IMR
     struct
     {
         u32 _reserved1	: 8;
-        u32 SIGMSK		: 1;
-        u32 FINISHMSK	: 1;
-        u32 HSMSK		: 1;
-        u32 VSMSK		: 1;
-        u32 EDWMSK		: 1;
-        u32 _undefined	: 2; // Should both be set to 1.
+        u32 SIGMSK		: 1; // Signal evevnt interrupt mask
+        u32 FINISHMSK	: 1; // Finish event interrupt mask
+        u32 HSMSK		: 1; // HSync interrupt mask
+        u32 VSMSK		: 1; // VSync interrupt mask
+        u32 EDWMSK		: 1; // Rectangle write termination interrupt mask
+        u32 _undefined	: 2; // undefined bits should be set to 1.
         u32 _reserved2	: 17;
     };
     u32 _u32;
@@ -246,10 +246,9 @@ struct GSRegSIGBLID
 #define PS2GS_BASE(mem) (PS2MEM_GS+(mem&0x13ff))
 
 #define CSRreg		((tGS_CSR&)*(PS2MEM_GS+0x1000))
-#define GSIMRregs	((tGS_IMR&)*(PS2MEM_GS+0x1010))
 
 #define GSCSRr		((u32&)*(PS2MEM_GS+0x1000))
-#define GSIMR		((u32&)*(PS2MEM_GS+0x1010))
+#define GSIMR		((tGS_IMR&)*(PS2MEM_GS+0x1010))
 #define GSSIGLBLID	((GSRegSIGBLID&)*(PS2MEM_GS+0x1080))
 
 enum class GS_VideoMode : int

--- a/pcsx2/Gif_Unit.cpp
+++ b/pcsx2/Gif_Unit.cpp
@@ -63,7 +63,7 @@ bool Gif_HandlerAD(u8* pMem) {
 		else {
 			GUNIT_WARN("GIF Handler - SIGNAL");
 			GSSIGLBLID.SIGID = (GSSIGLBLID.SIGID&~data[1])|(data[0]&data[1]);
-			if (!(GSIMR&0x100)) gsIrq();
+			if (!GSIMR.SIGMSK) gsIrq();
 			CSRreg.SIGNAL = true;
 		}
 	}
@@ -97,7 +97,7 @@ bool Gif_HandlerAD_Debug(u8* pMem) {
 }
 
 void Gif_FinishIRQ() {
-	if (CSRreg.FINISH && !(GSIMR & 0x200) && !gifUnit.gsFINISH.gsFINISHFired) {
+	if (CSRreg.FINISH && !GSIMR.FINISHMSK && !gifUnit.gsFINISH.gsFINISHFired) {
 		gsIrq();
 		gifUnit.gsFINISH.gsFINISHFired = true;
 	}

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -133,7 +133,7 @@ void SysMtgsThread::PostVsyncStart()
 
 	u32* remainder = (u32*)GetDataPacketPtr();
 	remainder[0] = GSCSRr;
-	remainder[1] = GSIMR;
+	remainder[1] = GSIMR._u32;
 	(GSRegSIGBLID&)remainder[2] = GSSIGLBLID;
 	m_packet_writepos = (m_packet_writepos + 1) & RingBufferMask;
 


### PR DESCRIPTION
**Summary of changes**:

* Use the IMR register union to get mask interrupt value of specific bit-fields of the register instead of using multiple bitwise operations all over the place to get the required field.

 I assume this was actually needed to be done but never got done for some reason? As the union was left there without any purpose before this commit.