### PR TITLE
GSDX: Fix output texture height calculation

### DIFF
--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -169,7 +169,7 @@ GSTexture* GSRendererCL::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFrameRect(i).bottom;
+	int h = GetFrameRect(i).height();
 
 	// TODO: round up bottom
 

--- a/plugins/GSdx/GSRendererCS.cpp
+++ b/plugins/GSdx/GSRendererCS.cpp
@@ -345,7 +345,7 @@ GSTexture* GSRendererCS::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFrameRect(i).bottom;
+	int h = GetFrameRect(i).height();
 
 	// TODO: round up bottom
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -219,7 +219,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 
 	GSTexture* t = NULL;
 
-	if(GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, m_width, m_height, GetFrameRect(i).bottom))
+	if(GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, m_width, m_height, GetFrameRect(i).height()))
 	{
 		t = rt->m_texture;
 

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -165,7 +165,7 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFrameRect(i).bottom;
+	int h = GetFrameRect(i).height();
 
 	// TODO: round up bottom
 


### PR DESCRIPTION
**Summary of changes**:

* Properly calculate the texture height on ``GetOutput()``, the bug was shared by all the renderers.

Previously, the value of the frame offset was also considered for the total height of the texture which was obviously wrong as the portion before the offset value isn't part of the frame memory. _Might_ help on fixing some GSdx bugs.