### PR TITLE
Automatic CRC hack level

### DIFF
--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -338,7 +338,7 @@ namespace GLLoader {
 		}
 
 		bool status = true;
-		bool mandatory_hw = static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW;
+		bool mandatory_hw = (theApp.GetConfigT<GSRendererType>("Renderer") == GSRendererType::OGL_HW);
 
 		// Bonus
 		status &= status_and_override(found_GL_EXT_texture_filter_anisotropic, "GL_EXT_texture_filter_anisotropic");

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -506,6 +506,8 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	static bool stored_toggle_state = false;
 	bool toggle_state = !!(flags & 4);
 
+	theApp.ClearTempConfig();
+
 	GSRendererType renderer = s_renderer;
 	// Fresh start up or config file changed
 	if (renderer == GSRendererType::Undefined)

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -212,7 +212,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 
 	if(renderer == GSRendererType::Undefined)
 	{
-		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+		renderer = theApp.GetTempConfig<GSRendererType>();
 	}
 
 	if(threads == -1)
@@ -512,11 +512,7 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	// Fresh start up or config file changed
 	if (renderer == GSRendererType::Undefined)
 	{
-		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
-#ifdef _WIN32
-		if (renderer == GSRendererType::Default)
-			renderer = GSUtil::GetBestRenderer();
-#endif
+		renderer = theApp.GetTempConfig<GSRendererType>();
 	}
 	else if (stored_toggle_state != toggle_state)
 	{
@@ -545,6 +541,7 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 		default: renderer = GSRendererType::OGL_SW; break; // fallback to OGL SW
 		}
 #endif
+		theApp.SetTempConfig<GSRendererType>(renderer);
 	}
 	stored_toggle_state = toggle_state;
 
@@ -590,7 +587,7 @@ EXPORT_C_(int) GSopen(void** dsp, const char* title, int mt)
 	{
 		// normal init
 
-		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+		renderer = theApp.GetTempConfig<GSRendererType>();
 	}
 
 	*dsp = NULL;
@@ -1566,7 +1563,7 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 
 	GSRendererType m_renderer;
 	// Allow to easyly switch between SW/HW renderer -> this effectively removes the ability to select the renderer by function args
-	m_renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
+	m_renderer = theApp.GetTempConfig<GSRendererType>();
 
 	if (m_renderer != GSRendererType::OGL_HW && m_renderer != GSRendererType::OGL_SW)
 	{

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1429,6 +1429,7 @@ enum class Filtering : uint8
 //Enum order matters! Don't change it!
 enum class CRCHackLevel : int8
 {
+	Automatic = -1,
 	None,
 	Minimum,
 	Partial,

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1425,3 +1425,13 @@ enum class Filtering : uint8
 	Trilinear_Bilinear_Forced,
 	Trilinear_Always
 };
+
+//Enum order matters! Don't change it!
+enum class CRCHackLevel : int8
+{
+	None,
+	Minimum,
+	Partial,
+	Full,
+	Aggressive
+};

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -79,7 +79,7 @@ GSDeviceOGL::GSDeviceOGL()
 
 	// Reset the debug file
 	#ifdef ENABLE_OGL_DEBUG
-	if (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_SW)
+	if (theApp.GetConfigT<GSRendererType>("Renderer") == GSRendererType::OGL_SW)
 		m_debug_gl_file = fopen("GSdx_opengl_debug_sw.txt","w");
 	else
 		m_debug_gl_file = fopen("GSdx_opengl_debug_hw.txt","w");

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -2433,7 +2433,7 @@ void GSState::SetupCrcHack()
 {
 	GetSkipCount lut[CRC::TitleCount];
 
-	s_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
+	s_crc_hack_level = theApp.GetTempConfig<CRCHackLevel>();
 
 	memset(lut, 0, sizeof(lut));
 

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -23,11 +23,12 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-int s_crc_hack_level = 3;
+CRCHackLevel s_crc_hack_level = CRCHackLevel::Full;
 
 // hacks
-#define Aggresive (s_crc_hack_level > 3)
-#define Dx_only   (s_crc_hack_level > 2)
+#define Aggresive  (s_crc_hack_level >= CRCHackLevel::Aggressive)
+#define Dx_only    (s_crc_hack_level >= CRCHackLevel::Full)
+#define Dx_and_OGL (s_crc_hack_level >= CRCHackLevel::Partial)
 
 CRC::Region g_crc_region = CRC::NoRegion;
 
@@ -2432,11 +2433,11 @@ void GSState::SetupCrcHack()
 {
 	GetSkipCount lut[CRC::TitleCount];
 
-	s_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	s_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
 
 	memset(lut, 0, sizeof(lut));
 
-	if (s_crc_hack_level > 1) {
+	if (Dx_and_OGL) {
 		lut[CRC::AceCombat4] = GSC_AceCombat4;
 		lut[CRC::AlpineRacer3] = GSC_AlpineRacer3;
 		lut[CRC::BlackHawkDown] = GSC_BlackHawkDown;

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -299,7 +299,7 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 
 	// Gregory: code is not yet ready so let's only enable it when
 	// CRC is below the FULL level
-	if (m_texture_shuffle && (m_crc_hack_level < 3)) {
+	if (m_texture_shuffle && (m_crc_hack_level < CRCHackLevel::Full)) {
 		ps_sel.shuffle = 1;
 		ps_sel.fmt = 0;
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -851,7 +851,7 @@ GSRendererHW::Hacks::Hacks()
 	, m_oo(NULL)
 	, m_cu(NULL)
 {
-	bool is_opengl = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW);
+	bool is_opengl = (theApp.GetConfigT<GSRendererType>("Renderer") == GSRendererType::OGL_HW);
 	bool can_handle_depth = (!theApp.GetConfigB("UserHacks") || !theApp.GetConfigB("UserHacks_DisableDepthSupport")) && is_opengl;
 
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::FFXII, CRC::EU, &GSRendererHW::OI_FFXII));

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -40,6 +40,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"Trilinear Ultra:\nAlways enable full trilinear interpolation. Warning Slow!\n\n";
 		case IDC_CRC_LEVEL:
 			return "Control the number of Auto-CRC hacks applied to games.\n\n"
+				"Automatic:\nAutomatically select 'Partial' or 'Full' level based on whether you are using OpenGL or Direct3D.\n\n"
 				"None:\nRemove nearly all CRC hacks (debug only).\n\n"
 				"Minimum:\nEnable a couple of CRC hacks (23).\n\n"
 				"Partial:\nEnable most of the CRC hacks.\nRecommended OpenGL setting (Accurate/depth options may be required).\n\n"

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -355,8 +355,7 @@ void GSSettingsDlg::UpdateRenderers()
 	}
 	else
 	{
-		GSRendererType ini_renderer = GSRendererType(theApp.GetConfigI("Renderer"));
-		renderer_setting = (ini_renderer == GSRendererType::Undefined) ? GSUtil::GetBestRenderer() : ini_renderer;
+		renderer_setting = theApp.GetConfigT<GSRendererType>("Renderer");
 	}
 
 	GSRendererType renderer_sel = GSRendererType::Default;

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -23,8 +23,6 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-extern CRCHackLevel g_crc_hack_level;
-
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
 int GSState::s_n = 0;

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -23,7 +23,7 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-extern int g_crc_hack_level;
+extern CRCHackLevel g_crc_hack_level;
 
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
@@ -79,7 +79,7 @@ GSState::GSState()
 	//s_savel = 0;
 
 	UserHacks_WildHack = theApp.GetConfigB("UserHacks") ? theApp.GetConfigI("UserHacks_WildHack") : 0;
-	m_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	m_crc_hack_level = theApp.GetTempConfig<CRCHackLevel>();
 
 	memset(&m_v, 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));
@@ -2494,7 +2494,7 @@ void GSState::SetGameCRC(uint32 crc, int options)
 {
 	m_crc = crc;
 	m_options = options;
-	m_game = CRC::Lookup(m_crc_hack_level ? crc : 0);
+	m_game = CRC::Lookup(m_crc_hack_level > CRCHackLevel::None ? crc : 0);
 	SetupCrcHack();
 
 	// Until we find a solution that work for all games.

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -160,7 +160,7 @@ protected:
 
 	int UserHacks_WildHack;
 	bool isPackedUV_HackFlag;
-	int m_crc_hack_level;
+	CRCHackLevel m_crc_hack_level;
 	GetSkipCount m_gsc;
 	int m_skip;
 	int m_userhacks_skipdraw;

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -48,7 +48,7 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	m_paltex = theApp.GetConfigB("paltex");
 	m_can_convert_depth &= s_IS_OPENGL; // only supported by openGL so far
-	m_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	m_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
 
 	// In theory 4MB is enough but 9MB is safer for overflow (8MB
 	// isn't enough in custom resolution)
@@ -271,7 +271,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 
 						// Gregory: to avoid a massive slow down for nothing, let's only enable
 						// this code when CRC is below the FULL level
-						if (m_crc_hack_level < 3)
+						if (m_crc_hack_level < CRCHackLevel::Full)
 							Read(t, t->m_valid);
 						else
 							dst = t;

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -28,7 +28,7 @@ bool GSTextureCache::m_disable_partial_invalidation = false;
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
 {
-	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW);
+	s_IS_OPENGL = (theApp.GetConfigT<GSRendererType>("Renderer") == GSRendererType::OGL_HW);
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_spritehack                   = theApp.GetConfigI("UserHacks_SpriteHack");
@@ -48,7 +48,7 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	m_paltex = theApp.GetConfigB("paltex");
 	m_can_convert_depth &= s_IS_OPENGL; // only supported by openGL so far
-	m_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
+	m_crc_hack_level = theApp.GetTempConfig<CRCHackLevel>();
 
 	// In theory 4MB is enough but 9MB is safer for overflow (8MB
 	// isn't enough in custom resolution)

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -129,7 +129,7 @@ protected:
 	bool m_preload_frame;
 	uint8* m_temp;
 	bool m_can_convert_depth;
-	int m_crc_hack_level;
+	CRCHackLevel m_crc_hack_level;
 	static bool m_disable_partial_invalidation;
 	bool m_texture_inside_rt;
 

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -523,5 +523,6 @@ template<> GSRendererType GSdxApp::GetTempConfig<GSRendererType>()
 	return iniValue;
 }
 
+// throw if somebody wants to access a settings that is not cached
 template<typename T> T GSdxApp::GetTempConfig() {throw GSDXError();}
 template<typename T> void GSdxApp::SetTempConfig(T value) {throw GSDXError();}

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -523,3 +523,5 @@ template<> GSRendererType GSdxApp::GetTempConfig<GSRendererType>()
 	return iniValue;
 }
 
+template<typename T> T GSdxApp::GetTempConfig() {throw GSDXError();}
+template<typename T> void GSdxApp::SetTempConfig(T value) {throw GSDXError();}

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -218,6 +218,7 @@ void GSdxApp::Init()
 	m_gs_hw_mipmapping.push_back(GSSetting(1, "Basic", "Fast"));
 	m_gs_hw_mipmapping.push_back(GSSetting(2, "Full", "Slow"));
 
+	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Automatic, "Automatic", "Default"));
 	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::None , "None", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Minimum, "Minimum", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Partial, "Partial", "OpenGL Recommended"));

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -218,11 +218,11 @@ void GSdxApp::Init()
 	m_gs_hw_mipmapping.push_back(GSSetting(1, "Basic", "Fast"));
 	m_gs_hw_mipmapping.push_back(GSSetting(2, "Full", "Slow"));
 
-	m_gs_crc_level.push_back(GSSetting(0 , "None", "Debug"));
-	m_gs_crc_level.push_back(GSSetting(1 , "Minimum", "Debug"));
-	m_gs_crc_level.push_back(GSSetting(2 , "Partial", "OpenGL Recommended"));
-	m_gs_crc_level.push_back(GSSetting(3 , "Full", "Safest"));
-	m_gs_crc_level.push_back(GSSetting(4 , "Aggressive", ""));
+	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::None , "None", "Debug"));
+	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Minimum, "Minimum", "Debug"));
+	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Partial, "Partial", "OpenGL Recommended"));
+	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Full, "Full", "Safest"));
+	m_gs_crc_level.push_back(GSSetting(CRCHackLevel::Aggressive, "Aggressive", ""));
 
 	m_gs_acc_blend_level.push_back(GSSetting(0, "None", "Fastest"));
 	m_gs_acc_blend_level.push_back(GSSetting(1, "Basic", "Recommended low-end PC"));
@@ -292,7 +292,7 @@ void GSdxApp::Init()
 	m_default_configuration["CaptureHeight"]                              = "480";
 	m_default_configuration["CaptureWidth"]                               = "640";
 	m_default_configuration["clut_load_before_draw"]                      = "0";
-	m_default_configuration["crc_hack_level"]                             = "3";
+	m_default_configuration["crc_hack_level"]                             = to_string(static_cast<int8>(CRCHackLevel::Automatic));
 	m_default_configuration["CrcHacksExclusions"]                         = "";
 	m_default_configuration["debug_glsl_shader"]                          = "0";
 	m_default_configuration["debug_opengl"]                               = "0";

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -66,7 +66,9 @@ bool GSdxApp::LoadResource(int id, vector<unsigned char>& buff, const char* type
 	return false;
 }
 
-size_t GSdxApp::GetPrivateProfileString(const char* lpAppName, const char* lpKeyName, const char* lpDefault, char* lpReturnedString, size_t nSize, const char* lpFileName)
+#endif
+
+size_t GSdxApp::GetIniEntryString(const char* lpAppName, const char* lpKeyName, const char* lpDefault, char* lpReturnedString, size_t nSize, const char* lpFileName)
 {
 	BuildConfigurationMap(lpFileName);
 
@@ -82,7 +84,7 @@ size_t GSdxApp::GetPrivateProfileString(const char* lpAppName, const char* lpKey
     return 0;
 }
 
-bool GSdxApp::WritePrivateProfileString(const char* lpAppName, const char* lpKeyName, const char* pString, const char* lpFileName)
+bool GSdxApp::WriteIniEntryString(const char* lpAppName, const char* lpKeyName, const char* pString, const char* lpFileName)
 {
 	BuildConfigurationMap(lpFileName);
 
@@ -109,7 +111,7 @@ bool GSdxApp::WritePrivateProfileString(const char* lpAppName, const char* lpKey
 	return false;
 }
 
-int GSdxApp::GetPrivateProfileInt(const char* lpAppName, const char* lpKeyName, int nDefault, const char* lpFileName)
+int GSdxApp::GetIniEntryInt(const char* lpAppName, const char* lpKeyName, int nDefault, const char* lpFileName)
 {
 	BuildConfigurationMap(lpFileName);
 
@@ -121,7 +123,7 @@ int GSdxApp::GetPrivateProfileInt(const char* lpAppName, const char* lpKeyName, 
 	} else
 		return atoi(value.c_str());
 }
-#endif
+
 
 GSdxApp theApp;
 
@@ -366,7 +368,6 @@ void GSdxApp::Init()
 	m_default_configuration["vsync"]                                      = "0";
 }
 
-#if defined(__unix__)
 void GSdxApp::ReloadConfig()
 {
 	if (m_configuration_map.empty()) return;
@@ -404,7 +405,6 @@ void GSdxApp::BuildConfigurationMap(const char* lpFileName)
 
 	fclose(f);
 }
-#endif
 
 void* GSdxApp::GetModuleHandlePtr()
 {
@@ -442,10 +442,10 @@ string GSdxApp::GetConfigS(const char* entry)
 	auto def = m_default_configuration.find(entry);
 
 	if (def != m_default_configuration.end()) {
-		GetPrivateProfileString(m_section.c_str(), entry, def->second.c_str(), buff, countof(buff), m_ini.c_str());
+		GetIniEntryString(m_section.c_str(), entry, def->second.c_str(), buff, countof(buff), m_ini.c_str());
 	} else {
 		fprintf(stderr, "Option %s doesn't have a default value\n", entry);
-		GetPrivateProfileString(m_section.c_str(), entry, "", buff, countof(buff), m_ini.c_str());
+		GetIniEntryString(m_section.c_str(), entry, "", buff, countof(buff), m_ini.c_str());
 	}
 
 	return string(buff);
@@ -453,7 +453,7 @@ string GSdxApp::GetConfigS(const char* entry)
 
 void GSdxApp::SetConfig(const char* entry, const char* value)
 {
-	WritePrivateProfileString(m_section.c_str(), entry, value, m_ini.c_str());
+	WriteIniEntryString(m_section.c_str(), entry, value, m_ini.c_str());
 }
 
 int GSdxApp::GetConfigI(const char* entry)
@@ -461,10 +461,10 @@ int GSdxApp::GetConfigI(const char* entry)
 	auto def = m_default_configuration.find(entry);
 
 	if (def != m_default_configuration.end()) {
-		return GetPrivateProfileInt(m_section.c_str(), entry, std::stoi(def->second), m_ini.c_str());
+		return GetIniEntryInt(m_section.c_str(), entry, std::stoi(def->second), m_ini.c_str());
 	} else {
 		fprintf(stderr, "Option %s doesn't have a default value\n", entry);
-		return GetPrivateProfileInt(m_section.c_str(), entry, 0, m_ini.c_str());
+		return GetIniEntryInt(m_section.c_str(), entry, 0, m_ini.c_str());
 	}
 }
 

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -29,9 +29,12 @@ class GSdxApp
 	std::string m_ini;
 	std::string m_section;
 	std::map< std::string, std::string > m_default_configuration;
-#if defined(__unix__)
 	std::map< std::string, std::string > m_configuration_map;
-#endif
+
+	void BuildConfigurationMap(const char* lpFileName);
+	size_t GetIniEntryString(const char* lpAppName, const char* lpKeyName, const char* lpDefault, char* lpReturnedString, size_t nSize, const char* lpFileName);
+	bool WriteIniEntryString(const char* lpAppName, const char* lpKeyName, const char* pString, const char* lpFileName);
+	int GetIniEntryInt(const char* lpAppName, const char* lpKeyName, int nDefault, const char* lpFileName);
 
 public:
 	GSdxApp();
@@ -41,15 +44,6 @@ public:
 
 #ifdef _WIN32
  	HMODULE GetModuleHandle() {return (HMODULE)GetModuleHandlePtr();}
-#endif
-
-#if defined(__unix__)
-	void BuildConfigurationMap(const char* lpFileName);
-	void ReloadConfig();
-
-	size_t GetPrivateProfileString(const char* lpAppName, const char* lpKeyName, const char* lpDefault, char* lpReturnedString, size_t nSize, const char* lpFileName);
-	bool WritePrivateProfileString(const char* lpAppName, const char* lpKeyName, const char* pString, const char* lpFileName);
-	int GetPrivateProfileInt(const char* lpAppName, const char* lpKeyName, int nDefault, const char* lpFileName);
 #endif
 
 	bool LoadResource(int id, vector<unsigned char>& buff, const char* type = NULL);
@@ -67,6 +61,7 @@ public:
 	template<typename T> void SetTempConfig(T value);
 	void ClearTempConfig();
 	void SetConfigDir(const char* dir);
+	void ReloadConfig();
 
 	vector<GSSetting> m_gs_renderers;
 	vector<GSSetting> m_gs_interlace;

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -63,18 +63,9 @@ public:
 	bool   GetConfigB(const char* entry);
 	string GetConfigS(const char* entry);
 
-	template<typename T>
-	T GetTempConfig() {
-		throw GSDXError();
-	}
-
-	template<typename T>
-	void SetTempConfig(T value) {
-		throw GSDXError();
-	}
-
+	template<typename T> T GetTempConfig();
+	template<typename T> void SetTempConfig(T value);
 	void ClearTempConfig();
-	
 	void SetConfigDir(const char* dir);
 
 	vector<GSSetting> m_gs_renderers;
@@ -106,10 +97,7 @@ template<> void GSdxApp::SetTempConfig<CRCHackLevel>(CRCHackLevel value);
 template<> void GSdxApp::SetTempConfig<GSRendererType>(GSRendererType value);
 
 
-template<typename T>
-void TempOverwriteConfig() {
-	printf("GSdx: Was not able to find a cached version of type '%s' to write.\n", typeid(type).name());
-}
+
 
 struct GSDXError {};
 struct GSDXRecoverableError : GSDXError {};

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -56,6 +56,8 @@ public:
 	void SetConfig(const char* entry, const char* value);
 	void SetConfig(const char* entry, int value);
 	// Avoid issue with overloading
+	template<typename T>
+	T      GetConfigT(const char* entry) { return static_cast<T>(GetConfigI(entry)); }
 	int    GetConfigI(const char* entry);
 	bool   GetConfigB(const char* entry);
 	string GetConfigS(const char* entry);

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -30,6 +30,8 @@ class GSdxApp
 	std::string m_section;
 	std::map< std::string, std::string > m_default_configuration;
 	std::map< std::string, std::string > m_configuration_map;
+	GSRendererType m_cached_GSRendererType = GSRendererType::Undefined;
+	CRCHackLevel m_cached_CRCHackLevel = CRCHackLevel::Automatic;
 
 	void BuildConfigurationMap(const char* lpFileName);
 	size_t GetIniEntryString(const char* lpAppName, const char* lpKeyName, const char* lpDefault, char* lpReturnedString, size_t nSize, const char* lpFileName);
@@ -81,9 +83,6 @@ public:
 	vector<GSSetting> m_gpu_dithering;
 	vector<GSSetting> m_gpu_aspectratio;
 	vector<GSSetting> m_gpu_scale;
-
-	GSRendererType m_cached_GSRendererType = GSRendererType::Undefined;
-	CRCHackLevel m_cached_CRCHackLevel = CRCHackLevel::Automatic;
 };
 
 template<> CRCHackLevel GSdxApp::GetTempConfig<CRCHackLevel>();

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "GSSetting.h"
+#include "GSUtil.h"
 
 class GSdxApp
 {
@@ -62,7 +63,18 @@ public:
 	bool   GetConfigB(const char* entry);
 	string GetConfigS(const char* entry);
 
+	template<typename T>
+	T GetTempConfig() {
+		throw GSDXError();
+	}
 
+	template<typename T>
+	void SetTempConfig(T value) {
+		throw GSDXError();
+	}
+
+	void ClearTempConfig();
+	
 	void SetConfigDir(const char* dir);
 
 	vector<GSSetting> m_gs_renderers;
@@ -83,7 +95,21 @@ public:
 	vector<GSSetting> m_gpu_dithering;
 	vector<GSSetting> m_gpu_aspectratio;
 	vector<GSSetting> m_gpu_scale;
+
+	GSRendererType m_cached_GSRendererType = GSRendererType::Undefined;
+	CRCHackLevel m_cached_CRCHackLevel = CRCHackLevel::Automatic;
 };
+
+template<> CRCHackLevel GSdxApp::GetTempConfig<CRCHackLevel>();
+template<> GSRendererType GSdxApp::GetTempConfig<GSRendererType>();
+template<> void GSdxApp::SetTempConfig<CRCHackLevel>(CRCHackLevel value);
+template<> void GSdxApp::SetTempConfig<GSRendererType>(GSRendererType value);
+
+
+template<typename T>
+void TempOverwriteConfig() {
+	printf("GSdx: Was not able to find a cached version of type '%s' to write.\n", typeid(type).name());
+}
 
 struct GSDXError {};
 struct GSDXRecoverableError : GSDXError {};


### PR DESCRIPTION
Adds an automatic CRC Hack level to the GUI. The value will be interpreted as either 'Partial' or 'Full' depending on the renderer. Was already discussed in #1582, #904, and #882. It's basically the same as FlatOut's approach.

Additionally added an enum class for the CRCHackLevel. Although the usage is not completely consequently done in consumer code. The CRC hack section largely depends on the ordering of the enum as CRC hacks on the partial level are as well applied on the full level. Reordering of the enum values would break the code. But that would as well break the backwards compatibility of the ini-File. A more strict approach to use an enum (maybe as flag) would need a larger non-functional rewrite.

Additionally added a template-version of GetConfig (GetConfigT) to avoid the casts in the consumer code and possibly improve readability.