### PR TITLE
GSDX: Apply saturation only to interlaced video mode

### DIFF
--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -423,7 +423,7 @@ GSVector4i GSState::GetDisplayRect(int i)
 	//  Limit games to standard NTSC resolutions. games with 512X512 (PAL resolution) on NTSC video mode produces black border on the bottom.
 	//  512 X 448 is the resolution generally used by NTSC, saturating the height value seems to get rid of the black borders.
 	//  Though it's quite a bad hack as it affects binaries which are patched to run on a non-native video mode.
-	if (videomode == GSVideoMode::NTSC && height > 448 && width < 640 && m_NTSC_Saturation)
+	if (m_NTSC_Saturation && isinterlaced() && videomode == GSVideoMode::NTSC && height > 448 && width < 640)
 		height = 448;
 
 	// Set up the display rectangle based on the values obtained from DISPLAY registers


### PR DESCRIPTION
**Summary of changes**:

* Apply saturation only to interlaced video modes of NTSC, progressive scan variant of NTSC seems to allow usage of higher value.

JMMT uses a bigger display height on NTSC progressive scan mode, which is not really unusual hence the saturation hack has been adjusted to only take effect on interlaced NTSC mode.

However, the whole double screen issue on FMV still exists. As a bit of information, this game has the second output disabled but seems to have some valid data inside of it, maybe the second output data is leaked into the first one? most likely a bug in the frambuffer data management rather than a CRTC issue (needs to be investigated)