### PR TITLE
GSDX: Pass total height of framebuffer on GetOutput()

### DIFF
--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -169,7 +169,7 @@ GSTexture* GSRendererCL::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFrameRect(i).height();
+	int h = GetFramebufferHeight();
 
 	// TODO: round up bottom
 

--- a/plugins/GSdx/GSRendererCS.cpp
+++ b/plugins/GSdx/GSRendererCS.cpp
@@ -345,7 +345,7 @@ GSTexture* GSRendererCS::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFrameRect(i).height();
+	int h = GetFramebufferHeight();
 
 	// TODO: round up bottom
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -219,7 +219,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 
 	GSTexture* t = NULL;
 
-	if(GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, m_width, m_height, GetFrameRect(i).height()))
+	if(GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, m_width, m_height, GetFramebufferHeight()))
 	{
 		t = rt->m_texture;
 

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -165,7 +165,7 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFrameRect(i).height();
+	int h = GetFramebufferHeight();
 
 	// TODO: round up bottom
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -473,6 +473,20 @@ GSVector4i GSState::GetFrameRect(int i)
 	return rectangle;
 }
 
+int GSState::GetFramebufferHeight()
+{
+	const GSVector4i output[2] = { GetFrameRect(0), GetFrameRect(1) };
+	// Framebuffer height is 11 bits max according to GS user manual
+	const int height_limit = (1 << 11);
+	int max_height = std::max(output[0].height(), output[1].height());
+	int frame_memory_height = std::max(max_height, output[0].runion_ordered(output[1]).height() % height_limit);
+
+	if (frame_memory_height > 1024)
+		GL_PERF("Massive framebuffer height detected! (height:%d)", frame_memory_height);
+
+	return frame_memory_height;
+}
+
 bool GSState::IsEnabled(int i)
 {
 	ASSERT(i >= 0 && i < 2);

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -242,6 +242,7 @@ public:
 
 	void ResetHandlers();
 
+	int GetFramebufferHeight();
 	GSVector4i GetDisplayRect(int i = -1, bool merged_rect = false);
 	GSVector4i GetFrameRect(int i = -1);
 	GSVideoMode GetVideoMode();


### PR DESCRIPTION
**Summary of changes**:

* Pass the full height of the frame memory in ``GetOutput()`` ignoring the baseline offsets as usual. Fixes flickering issues in ``Crash Bash``.

@FlatOutPS2 - I trust you on checking for regressions. 👍 