### PR TITLE
GSDX: Cleanup warnings on MSVC

### DIFF
--- a/plugins/GSdx/GSDrawScanlineCodeGenerator.x64.avx.cpp
+++ b/plugins/GSdx/GSDrawScanlineCodeGenerator.x64.avx.cpp
@@ -693,8 +693,8 @@ void GSDrawScanlineCodeGenerator::TestZ_AVX(const Xmm& temp1, const Xmm& temp2)
 
 		if(m_sel.zpsm)
 		{
-			vpslld(xmm1, m_sel.zpsm * 8);
-			vpsrld(xmm1, m_sel.zpsm * 8);
+			vpslld(xmm1, static_cast<uint8>(m_sel.zpsm * 8));
+			vpsrld(xmm1, static_cast<uint8>(m_sel.zpsm * 8));
 		}
 
 		if(m_sel.zoverflow || m_sel.zpsm == 0)
@@ -824,7 +824,7 @@ void GSDrawScanlineCodeGenerator::SampleTexture_AVX()
 
 	vpunpcklwd(xmm2, xmm4, xmm0);
 	vpunpckhwd(xmm3, xmm4, xmm0);
-	vpslld(xmm3, m_sel.tw + 3);
+	vpslld(xmm3, static_cast<uint8>(m_sel.tw + 3));
 
 	// xmm0 = 0
 	// xmm2 = x0
@@ -840,7 +840,7 @@ void GSDrawScanlineCodeGenerator::SampleTexture_AVX()
 
 		vpunpcklwd(xmm4, xmm5, xmm0);
 		vpunpckhwd(xmm5, xmm5, xmm0);
-		vpslld(xmm5, m_sel.tw + 3);
+		vpslld(xmm5, static_cast<uint8>(m_sel.tw + 3));
 
 		// xmm2 = x0
 		// xmm3 = y0
@@ -2019,7 +2019,7 @@ void GSDrawScanlineCodeGenerator::ReadTexel_AVX(int pixels, int mip_offset)
 
 	for(int i = 0; i < pixels; i++)
 	{
-		for(int j = 0; j < 4; j++)
+		for(uint8 j = 0; j < 4; j++)
 		{
 			ReadTexel_AVX(Xmm(out[i]), Xmm(in[i]), j);
 		}

--- a/plugins/GSdx/GSDrawScanlineCodeGenerator.x86.avx.cpp
+++ b/plugins/GSdx/GSDrawScanlineCodeGenerator.x86.avx.cpp
@@ -654,8 +654,8 @@ void GSDrawScanlineCodeGenerator::TestZ_AVX(const Xmm& temp1, const Xmm& temp2)
 
 		if(m_sel.zpsm)
 		{
-			vpslld(xmm1, m_sel.zpsm * 8);
-			vpsrld(xmm1, m_sel.zpsm * 8);
+			vpslld(xmm1, static_cast<uint8>(m_sel.zpsm * 8));
+			vpsrld(xmm1, static_cast<uint8>(m_sel.zpsm * 8));
 		}
 
 		if(m_sel.zoverflow || m_sel.zpsm == 0)
@@ -795,7 +795,7 @@ void GSDrawScanlineCodeGenerator::SampleTexture_AVX()
 
 	vpunpcklwd(xmm4, xmm2, xmm0);
 	vpunpckhwd(xmm2, xmm2, xmm0);
-	vpslld(xmm2, m_sel.tw + 3);
+	vpslld(xmm2, static_cast<uint8>(m_sel.tw + 3));
 
 	// xmm0 = 0
 	// xmm2 = y0
@@ -811,7 +811,7 @@ void GSDrawScanlineCodeGenerator::SampleTexture_AVX()
 
 		vpunpcklwd(xmm6, xmm3, xmm0);
 		vpunpckhwd(xmm3, xmm3, xmm0);
-		vpslld(xmm3, m_sel.tw + 3);
+		vpslld(xmm3, static_cast<uint8>(m_sel.tw + 3));
 
 		// xmm2 = y0
 		// xmm3 = y1
@@ -1380,7 +1380,7 @@ return;
 
 	vpunpcklwd(xmm4, xmm2, xmm0);
 	vpunpckhwd(xmm2, xmm2, xmm0);
-	vpslld(xmm2, m_sel.tw + 3);
+	vpslld(xmm2, static_cast<uint8>(m_sel.tw + 3));
 
 	// xmm0 = 0
 	// xmm2 = y0
@@ -1396,7 +1396,7 @@ return;
 
 		vpunpcklwd(xmm6, xmm3, xmm0);
 		vpunpckhwd(xmm3, xmm3, xmm0);
-		vpslld(xmm3, m_sel.tw + 3);
+		vpslld(xmm3, static_cast<uint8>(m_sel.tw + 3));
 
 		// xmm2 = y0
 		// xmm3 = y1
@@ -1611,7 +1611,7 @@ return;
 
 		vpunpcklwd(xmm4, xmm2, xmm0);
 		vpunpckhwd(xmm2, xmm2, xmm0);
-		vpslld(xmm2, m_sel.tw + 3);
+		vpslld(xmm2, static_cast<uint8>(m_sel.tw + 3));
 
 		// xmm0 = 0
 		// xmm2 = y0
@@ -1627,7 +1627,7 @@ return;
 
 			vpunpcklwd(xmm6, xmm3, xmm0);
 			vpunpckhwd(xmm3, xmm3, xmm0);
-			vpslld(xmm3, m_sel.tw + 3);
+			vpslld(xmm3, static_cast<uint8>(m_sel.tw + 3));
 
 			// xmm2 = y0
 			// xmm3 = y1

--- a/plugins/GSdx/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/GSDrawScanlineCodeGenerator.x86.cpp
@@ -2889,7 +2889,7 @@ void GSDrawScanlineCodeGenerator::ReadTexel_SSE(int pixels, int mip_offset)
 				movdqa(ptr[&m_local.temp.test], xmm7);
 			}
 
-			for(int j = 0; j < 4; j++)
+			for(uint8 j = 0; j < 4; j++)
 			{
 				mov(ebx, ptr[&lod_i->u32[j]]);
 				mov(ebx, ptr[ebp + ebx * sizeof(void*) + mip_offset]);
@@ -3042,7 +3042,7 @@ void GSDrawScanlineCodeGenerator::ReadTexel_SSE(int pixels, int mip_offset)
 		{
 			for(int i = 0; i < pixels; i++)
 			{
-				for(int j = 0; j < 4; j++)
+				for(uint8 j = 0; j < 4; j++)
 				{
 					ReadTexel_SSE(Xmm(r[i * 2 + 1]), Xmm(r[i * 2 + 0]), j);
 				}


### PR DESCRIPTION
**Summary of changes**:

* Explicitly cast some bitfields/local loop variables to uint8 as certain functions seem to have uint8 as the parameter datatype.

Though to be honest, I don't really care about these warnings. They were just annoying as they keep popping up all the time I rebuild GSdx.