### PR TITLE
psxmode: Correct exe name for several PSX titles

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -406,7 +406,7 @@ void cdvdReloadElfInfo(wxString elfoverride)
 			// PCSX2 currently only recognizes *.elf executables in proper PS2 format.
 			// To support different PSX titles in the console title and for savestates, this code bypasses all the detection,
 			// simply using the exe name, stripped of problematic characters.
-			wxString fname = elfpath.AfterLast('\\');
+			wxString fname = elfpath.AfterLast('\\').AfterLast(':'); // Also catch elf paths which lack a backslash, and only have a colon.
 			wxString fname2 = fname.BeforeFirst(';');
 			DiscSerial = fname2;
 			Console.SetTitle(DiscSerial);


### PR DESCRIPTION
Several PSX titles lack a backslash in the elf path, which made the disc
serial contain 'cdrom:'. This caused savestate issues in those games.

Solves: https://github.com/PCSX2/pcsx2/issues/1692