### PR TITLE
cdvd: Street Fighter EX3 (NTSC-J) black screen fix

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1048,9 +1048,9 @@ u8 cdvdRead(u8 key)
 			CDVD_LOG("cdvdRead07(Break) %x", 0);
 			return 0;
 
-		case 0x08:  // STATUS
-			CDVD_LOG("cdvdRead08(Status) %x", cdvd.Status);
-			return cdvd.Status;
+		case 0x08:  // INTR_STAT
+			CDVD_LOG("cdvdRead08(IntrReason) %x", cdvd.PwOff);
+			return cdvd.PwOff;
 
 		case 0x0A:  // STATUS
 			CDVD_LOG("cdvdRead0A(Status) %x", cdvd.Status);

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -890,7 +890,9 @@ __fi void cdvdReadInterrupt()
 
 	if (--cdvd.nSectors <= 0)
 	{
-		cdvd.PwOff |= 1<<Irq_CommandComplete;
+		// Setting the data ready flag fixes a black screen loading issue in
+		// Street Fighter Ex3 (NTSC-J version).
+		cdvd.PwOff |= (1 << Irq_DataReady) | (1 << Irq_CommandComplete);
 		psxHu32(0x1070)|= 0x4;
 
 		HW_DMA3_CHCR &= ~0x01000000;


### PR DESCRIPTION
No, I don't know what I'm doing. This might break everything.

@prafullpcsx2 sent me a block dump and found that Street Fighter EX3 (NTSC-J) was broken by this commit - https://sourceforge.net/p/pcsx2/code/347/.

I found an odd change while searching through the history (bc9e0b08adbe4922433a980ee82166ef03d987c2), where `cdvd.PwOff` was somehow replaced with `cdvd.Status` in the `cdvdRead()` code.

Undoing both those changes lets me get past the black screen.

Related forum issue: http://forums.pcsx2.net/Thread-Street-Fighter-EX3-black-screen-only-on-NTSC-J-version