### PR TITLE
cdvdgigaherz: Improve sector prefetch, fix past end of buffer read

### DIFF
--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -113,8 +113,7 @@ bool weAreInNewDiskCB = false;
 
 std::unique_ptr<IOCtlSrc> src;
 
-extern s32 prefetch_last_lba;
-extern s32 prefetch_last_mode;
+extern CacheRequest g_last_sector_block;
 
 ///////////////////////////////////////////////////////////////////////////////
 // keepAliveThread throws a read event regularly to prevent drive spin down  //
@@ -130,10 +129,10 @@ void keepAliveThread()
                                     []() { return !s_keepalive_is_open; })) {
 
         //printf(" * keepAliveThread: polling drive.\n");
-        if (prefetch_last_mode == CDVD_MODE_2048)
-            src->ReadSectors2048(prefetch_last_lba, 1, throwaway);
+        if (g_last_sector_block.mode == CDVD_MODE_2048)
+            src->ReadSectors2048(g_last_sector_block.lsn, 1, throwaway);
         else
-            src->ReadSectors2352(prefetch_last_lba, 1, throwaway);
+            src->ReadSectors2352(g_last_sector_block.lsn, 1, throwaway);
     }
 
     printf(" * CDVD: KeepAlive thread finished.\n");

--- a/plugins/cdvdGigaherz/src/CDVD.h
+++ b/plugins/cdvdGigaherz/src/CDVD.h
@@ -115,7 +115,7 @@ bool cdvdStartThread();
 void cdvdStopThread();
 s32 cdvdRequestSector(u32 sector, s32 mode);
 u8 *cdvdGetSector(u32 sector, s32 mode);
-s32 cdvdDirectReadSector(u32 first, s32 mode, u8 *buffer);
+s32 cdvdDirectReadSector(u32 sector, s32 mode, u8 *buffer);
 s32 cdvdGetMediaType();
 s32 cdvdRefreshData();
 void cdvdParseTOC();

--- a/plugins/cdvdGigaherz/src/CDVD.h
+++ b/plugins/cdvdGigaherz/src/CDVD.h
@@ -47,6 +47,12 @@ extern track tracks[100];
 extern int curDiskType;
 extern int curTrayStatus;
 
+struct CacheRequest
+{
+    u32 lsn;
+    s32 mode;
+};
+
 struct toc_entry
 {
     u32 lba;

--- a/plugins/cdvdGigaherz/src/ReadThread.cpp
+++ b/plugins/cdvdGigaherz/src/ReadThread.cpp
@@ -341,7 +341,7 @@ s32 cdvdDirectReadSector(u32 sector, s32 mode, u8 *buffer)
             memcpy(buffer, bfr + 12, 2340);
             return 0;
         default:
-            memcpy(buffer, bfr + 12, 2352);
+            memcpy(buffer, bfr, 2352);
             return 0;
     }
 }

--- a/plugins/cdvdGigaherz/src/ReadThread.cpp
+++ b/plugins/cdvdGigaherz/src/ReadThread.cpp
@@ -297,28 +297,28 @@ u8 *cdvdGetSector(u32 sector, s32 mode)
     return data;
 }
 
-s32 cdvdDirectReadSector(u32 first, s32 mode, u8 *buffer)
+s32 cdvdDirectReadSector(u32 sector, s32 mode, u8 *buffer)
 {
     static u8 data[2352 * sectors_per_read];
 
-    if (first >= src->GetSectorCount())
+    if (sector >= src->GetSectorCount())
         return -1;
 
     // Align to cache block
-    u32 sector = first & ~(sectors_per_read - 1);
+    u32 sector_block = sector & ~(sectors_per_read - 1);
 
-    if (!cdvdCacheFetch(sector, mode, data)) {
-        if (cdvdReadBlockOfSectors(sector, mode, data))
-            cdvdCacheUpdate(sector, mode, data);
+    if (!cdvdCacheFetch(sector_block, mode, data)) {
+        if (cdvdReadBlockOfSectors(sector_block, mode, data))
+            cdvdCacheUpdate(sector_block, mode, data);
     }
 
     if (mode == CDVD_MODE_2048) {
-        u32 offset = 2048 * (first - sector);
+        u32 offset = 2048 * (sector - sector_block);
         memcpy(buffer, data + offset, 2048);
         return 0;
     }
 
-    u32 offset = 2352 * (first - sector);
+    u32 offset = 2352 * (sector - sector_block);
     u8 *bfr = data + offset;
 
     switch (mode) {


### PR DESCRIPTION
First 2 commits are refactoring.

3rd commit should fix the read past the end of the disk prefetch issue. It also improves the prefetch logic a bit (see commit message).

4th commit fixes a read past the end of the buffer.