### PR TITLE
PCSX2-Counters: Fix RTC counting at certain cases

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -975,7 +975,7 @@ u8 monthmap[13] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 void cdvdVsync() {
 	cdvd.RTCcount++;
-	if (cdvd.RTCcount < ((gsVideoMode == GS_VideoMode::NTSC) ? 60 : 50)) return;
+	if (cdvd.RTCcount < (GetVerticalFrequency().ToIntRounded())) return;
 	cdvd.RTCcount = 0;
 
 	if ( cdvd.Status == CDVD_STATUS_TRAY_OPEN )

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -100,6 +100,8 @@ struct cdvdStruct {
 	u8 CReadWrite;
 	u8 CNumBlocks;
 
+	// Calculates the number of Vsyncs and once it reaches a total number of Vsyncs worth a second with respect to
+	// the videomode's vertical frequency, it updates the real time clock.
 	int RTCcount;
 	cdvdRTC RTC;
 

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -123,7 +123,6 @@ struct SyncCounter
 #define MODE_HBLANK		0x1		//Set for the remaining ~1/6 of 1 Scanline
 
 
-extern Fixed100 GetVerticalFrequency();
 extern Counter counters[4];
 extern SyncCounter hsyncCounter;
 extern SyncCounter vsyncCounter;

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -19,6 +19,7 @@
 #include "System/SysThreads.h"
 #include "Gif.h"
 
+extern Fixed100 GetVerticalFrequency();
 extern __aligned16 u8 g_RealGSMem[Ps2MemSize::GSregs];
 
 enum CSR_FifoState


### PR DESCRIPTION
**Summary of changes**:

* Fix a minor bug in counting time for real time clock. (potential improvements _might_ only be exclusive to progressive mode games)

According to some of refraction's older comments, getting the timer wrong might cause some games to not boot, so look out for progressive mode games which refuse to boot! Also needs extensive testing to make sure that no regressions pop up.