### PR TITLE
GSDX-TextureCache: Fix corner cases on custom resolution scaling

### DIFF
--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -405,7 +405,7 @@ GSVideoMode GSState::GetVideoMode()
 	return videomode;
 }
 
-GSVector4i GSState::GetDisplayRect(int i)
+GSVector4i GSState::GetDisplayRect(int i, bool merged_rect)
 {
 	if(i < 0) i = IsEnabled(1) ? 1 : 0;
 
@@ -433,8 +433,16 @@ GSVector4i GSState::GetDisplayRect(int i)
 	rectangle.right = rectangle.left + width;
 	rectangle.bottom = rectangle.top + height;
 
-	// Useful for debugging games:
-	//printf("DW: %d , DH: %d , left: %d , right: %d , top: %d , down: %d , MAGH: %d , MAGV: %d\n", m_regs->DISP[i].DISPLAY.DW, m_regs->DISP[i].DISPLAY.DH, r.left, r.right, r.top, r.bottom , m_regs->DISP[i].DISPLAY.MAGH,m_regs->DISP[i].DISPLAY.MAGV);
+	if ((m_regs->PMODE.EN1 & m_regs->PMODE.EN2) && merged_rect)
+	{
+		GSVector4i opposite_output = GetDisplayRect(!i);
+		GSVector4i r_intersect = opposite_output.rintersect(rectangle);
+		GSVector4i r_union = opposite_output.runion_ordered(rectangle);
+
+		if(!(r_intersect.width() && r_intersect.height()) ||
+			r_intersect.xyxy().eq(r_union.xyxy()))
+			return r_union;
+	}
 
 	return rectangle;
 }

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -242,7 +242,7 @@ public:
 
 	void ResetHandlers();
 
-	GSVector4i GetDisplayRect(int i = -1);
+	GSVector4i GetDisplayRect(int i = -1, bool merged_rect = false);
 	GSVector4i GetFrameRect(int i = -1);
 	GSVideoMode GetVideoMode();
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -414,8 +414,8 @@ void GSTextureCache::ScaleTexture(GSTexture* texture)
 
 	if (custom_resolution)
 	{
-		int width = m_renderer->GetDisplayRect().width();
-		int height = m_renderer->GetDisplayRect().height();
+		int width = m_renderer->GetDisplayRect(-1, true).width();
+		int height = m_renderer->GetDisplayRect(-1, true).height();
 		int real_height = static_cast<int>(round(m_renderer->GetInternalResolution().y / texture->GetScale().y));
 
 		// Fixes offset issues on Persona 3 (512x511) where real value of height is 512

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -416,11 +416,6 @@ void GSTextureCache::ScaleTexture(GSTexture* texture)
 	{
 		int width = m_renderer->GetDisplayRect(-1, true).width();
 		int height = m_renderer->GetDisplayRect(-1, true).height();
-		int real_height = static_cast<int>(round(m_renderer->GetInternalResolution().y / texture->GetScale().y));
-
-		// Fixes offset issues on Persona 3 (512x511) where real value of height is 512
-		if (real_height % height == 1)
-			height = real_height;
 
 		GSVector2i requested_resolution = m_renderer->GetCustomResolution();
 		scale_factor.x = static_cast<float>(requested_resolution.x) / width;


### PR DESCRIPTION
**Summary of changes**:

* Scale the textures based on the total size of both the output circuits combined, fixes a regression on ``Time Crisis 2``.
* Remove an older hack as it's no longer necessary.

Potentially there are still some bugs in the code as I'm not too confident with it for some reason,