### PR TITLE
GSdx: Improve GSJobQueue behaviour

### DIFF
--- a/plugins/GSdx/GSThread_CXX11.h
+++ b/plugins/GSdx/GSThread_CXX11.h
@@ -44,10 +44,9 @@ private:
 		while (true) {
 
 			while (m_count == 0) {
-				if (m_exit.load(memory_order_relaxed)) {
-					m_exit = false;
+				if (m_exit.load(memory_order_relaxed))
 					return;
-				}
+
 				m_notempty.wait(l);
 			}
 
@@ -87,10 +86,11 @@ public:
 
 	~GSJobQueue()
 	{
-		m_exit = true;
-		do {
-			m_notempty.notify_one();
-		} while (m_exit);
+		{
+			std::lock_guard<std::mutex> l(m_lock);
+			m_exit = true;
+		}
+		m_notempty.notify_one();
 
 		m_thread.join();
 	}

--- a/plugins/GSdx/GSThread_CXX11.h
+++ b/plugins/GSdx/GSThread_CXX11.h
@@ -29,7 +29,7 @@ template<class T, int CAPACITY> class GSJobQueue final
 private:
 	std::thread m_thread;
 	std::function<void(T&)> m_func;
-	std::atomic<bool> m_exit;
+	bool m_exit;
 	ringbuffer_base<T, CAPACITY> m_queue;
 
 	std::mutex m_lock;
@@ -43,7 +43,7 @@ private:
 		while (true) {
 
 			while (m_queue.empty()) {
-				if (m_exit.load(memory_order_relaxed))
+				if (m_exit)
 					return;
 
 				m_notempty.wait(l);


### PR DESCRIPTION
Changes:
 * Don't use a separate counter to count queue items. Seems to fix #998.
 * Use a separate mutex for waiting - should reduce context switches.
 * Change the exit flag within a lock and make it non-atomic.