### PR TITLE
Revert "gsdx tc: always clear a new depth buffer"

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -514,12 +514,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 		// From a performance point of view, it might cost a little on big upscaling
 		// but normally few RT are miss so it must remain reasonable.
 		if (s_IS_OPENGL) {
-			if (type == DepthStencil) {
-				// It is safer to always clear a new depth buffer. Core optimization might create some shortcut
-				// on the rendering. Texture cache only search old depth data in RT of current frame. Which
-				// can cause flickering (Jak2 cutscene)
-				m_renderer->m_dev->ClearDepth(dst->m_texture);
-			} else if (m_preload_frame && TEX0.TBW > 0) {
+			if (m_preload_frame && TEX0.TBW > 0) {
 				GL_INS("Preloading the RT DATA");
 				// RT doesn't have height but if we use a too big value, we will read outside of the GS memory.
 				int page0 = TEX0.TBP0 >> 5;
@@ -532,7 +527,11 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 				dst->Update();
 			} else {
 #ifdef ENABLE_OGL_DEBUG
-				m_renderer->m_dev->ClearRenderTarget(dst->m_texture, 0);
+				switch (type) {
+					case RenderTarget: m_renderer->m_dev->ClearRenderTarget(dst->m_texture, 0); break;
+					case DepthStencil: m_renderer->m_dev->ClearDepth(dst->m_texture); break;
+					default:break;
+				}
 #endif
 			}
 		}


### PR DESCRIPTION
This reverts commit f77c1900faf2baa3ffd1ca538f3b444c743b2444.

Conflicts:
	plugins/GSdx/GSTextureCache.cpp

Another fix was done later for Jak cut scene (or FMV). One game got a regression (don't remember which)

@FlatOutPS2 maybe you can help me.