### PR TITLE
Greg/gsdx boost texturecache

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1597,9 +1597,6 @@ GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFR
 		{
 			m_p2t = r->m_mem.GetPage2TileMap(m_TEX0);
 		}
-
-		// will be useless with texture page coverage
-		m_erase_it.fill(list<Source*>::iterator(0));
 	}
 }
 
@@ -1983,10 +1980,10 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, GSOffset*
 	// Remaining code will compute a list of pages that are dirty (in a similar fashion as GSOffset::GetPages)
 	// (Maybe GetPages could be used instead, perf opt?)
 	// The source pointer will be stored/duplicated in all m_map[array of pages]
-	uint32* pages = GetPagesCoverage(TEX0, off);
+	s->m_pages_ptr = GetPagesCoverage(TEX0, off);
 	for(size_t i = 0; i < countof(m_pages); i++)
 	{
-		if(uint32 p = pages[i])
+		if(uint32 p = s->m_pages_ptr[i])
 		{
 			list<Source*>* m = &m_map[i << 5];
 			auto* e = &s->m_erase_it[i << 5];
@@ -2080,18 +2077,30 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 	if (s->m_target)
 	{
 		size_t page = s->m_TEX0.TBP0 >> 5;
-		ASSERT(*s->m_erase_it[page] == s);
 		m_map[page].erase(s->m_erase_it[page]);
 
 	}
 	else
 	{
-		// Source is duplicated for each page they use.
-		for(size_t page = s->m_TEX0.TBP0 >> 5, end = countof(m_map) - 1; page <= end; page++)
+		// Mirror of GetPagesCoverage
+		for(size_t i = 0; i < countof(m_pages); i++)
 		{
-			if (s->m_erase_it[page] != list<Source*>::iterator(0)) {
-				ASSERT(*s->m_erase_it[page] == s);
-				m_map[page].erase(s->m_erase_it[page]);
+			if(uint32 p = s->m_pages_ptr[i])
+			{
+				list<Source*>* m = &m_map[i << 5];
+				auto* e = &s->m_erase_it[i << 5];
+
+				unsigned long j;
+
+				while(_BitScanForward(&j, p))
+				{
+					// FIXME: this statement could be optimized to a single ASM instruction (instead of 4)
+					// Either BTR (AKA bit test and reset). Depends on the previous instruction.
+					// Or BLSR (AKA Reset Lowest Set Bit). No dependency but require BMI1 (basically a recent CPU)
+					p ^= 1 << j;
+
+					m[j].erase(e[j]);
+				}
 			}
 		}
 	}

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1995,7 +1995,7 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, GSOffset*
 				// FIXME: this statement could be optimized to a single ASM instruction (instead of 4)
 				// Either BTR (AKA bit test and reset). Depends on the previous instruction.
 				// Or BLSR (AKA Reset Lowest Set Bit). No dependency but require BMI1 (basically a recent CPU)
-				p ^= 1 << j;
+				p ^= 1U << j;
 
 				m[j].push_front(s);
 				e[j] = m[j].begin();
@@ -2097,7 +2097,7 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 					// FIXME: this statement could be optimized to a single ASM instruction (instead of 4)
 					// Either BTR (AKA bit test and reset). Depends on the previous instruction.
 					// Or BLSR (AKA Reset Lowest Set Bit). No dependency but require BMI1 (basically a recent CPU)
-					p ^= 1 << j;
+					p ^= 1U << j;
 
 					m[j].erase(e[j]);
 				}

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -72,6 +72,8 @@ public:
 		// so it can be used to access un-converted data for the current draw call.
 		GSTexture* m_from_target;
 		GIFRegTEX0 m_layer_TEX0[7]; // Detect already loaded value
+		// Keep an GSTextureCache::m_map iterator to allow fast erase
+		std::array<std::list<Source*>::iterator, MAX_PAGES> m_erase_it;
 
 	public:
 		Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, uint8* temp, bool dummy_container = false);
@@ -106,7 +108,7 @@ public:
 	public:
 		hash_set<Source*> m_surfaces;
 		hash_map<uint64, uint32*> m_pages_coverage;
-		list<Source*> m_map[MAX_PAGES];
+		std::list<Source*> m_map[MAX_PAGES];
 		uint32 m_pages[16]; // bitmap of all pages
 		bool m_used;
 
@@ -123,7 +125,7 @@ public:
 protected:
 	GSRenderer* m_renderer;
 	SourceMap m_src;
-	list<Target*> m_dst[2];
+	std::list<Target*> m_dst[2];
 	bool m_paltex;
 	int m_spritehack;
 	bool m_preload_frame;

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -74,6 +74,7 @@ public:
 		GIFRegTEX0 m_layer_TEX0[7]; // Detect already loaded value
 		// Keep an GSTextureCache::m_map iterator to allow fast erase
 		std::array<std::list<Source*>::iterator, MAX_PAGES> m_erase_it;
+		uint32* m_pages_ptr;
 
 	public:
 		Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, uint8* temp, bool dummy_container = false);

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -102,6 +102,7 @@ typedef int64 sint64;
 
 #include <complex>
 #include <string>
+#include <array>
 #include <vector>
 #include <list>
 #include <map>


### PR DESCRIPTION
Greatly reduce the texture removal operation overhead. It might help to improve GSdx speed a little.