### PR TITLE
GSdx: Windows gui updates

### DIFF
--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -367,7 +367,7 @@ namespace GLLoader {
 #ifdef _WIN32
 		if (status) {
 			if (fglrx_buggy_driver) {
-				fprintf(stderr, "The \"OpenGL (Hardware)\" renderer is slow on AMD GPU's due to an inefficient driver. Check out the links below for further information.\n"
+				fprintf(stderr, "The \"OpenGL Hardware\" renderer is slow on AMD GPUs due to an inefficient driver. Check out the links below for further information.\n"
 					"https://community.amd.com/message/2756964\n"
 					"https://community.amd.com/thread/205702\n"
 					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause an application or system crash.\n"

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -367,11 +367,11 @@ namespace GLLoader {
 #ifdef _WIN32
 		if (status) {
 			if (fglrx_buggy_driver) {
-				fprintf(stderr, "The \"OpenGL Hardware\" renderer is slow on AMD GPUs due to an inefficient driver. Check out the links below for further information.\n"
+				fprintf(stderr, "The OpenGL hardware renderer is slow on AMD GPUs due to an inefficient driver. Check out the links below for further information.\n"
 					"https://community.amd.com/message/2756964\n"
 					"https://community.amd.com/thread/205702\n"
-					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause an application or system crash.\n"
-					"Keep Blending Unit Accuracy set to at least the default \"Basic\".\n"
+					"Note: Due to an AMD OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause an application or system crash.\n"
+					"Keep Blending Unit Accuracy set to at least the default \"Basic\" level.\n"
 					"AMD has a fix for the issue that will be released in the coming months. The issue does not affect AMD GPUs on legacy drivers.\n");
 			}
 		}

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -370,8 +370,8 @@ namespace GLLoader {
 				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver.Please check the links below.\n"
 					"https://community.amd.com/message/2756964\n"
 					"https://community.amd.com/thread/205702\n"
-					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to "None" can cause a application or system crash.\n"
-					"Keep Blending Unit Accuracy set to at least the default "Basic".\n"
+					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause a application or system crash.\n"
+					"Keep Blending Unit Accuracy set to at least the default \"Basic\".\n"
 					"AMD have a fix for the issue that will be released in the coming months. The issue does not affect AMD GPU's on legacy drivers.\n");
 			}
 		}

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -367,7 +367,11 @@ namespace GLLoader {
 #ifdef _WIN32
 		if (status) {
 			if (fglrx_buggy_driver) {
-				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver. Please check the links below.\nhttps://community.amd.com/thread/205702\nhttps://community.amd.com/message/2756964\n");
+				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver.Please check the links below.\n"
+					"https://community.amd.com/message/2756964\n"
+					"https://community.amd.com/thread/205702\n"
+					"Note: When running OpenGL on AMD cards make sure Blending Unit Accuracy is set to at least Basic.\n"
+					"Having it set to None will cause a BSOD and crash the system.\n");
 			}
 		}
 #endif

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -367,12 +367,12 @@ namespace GLLoader {
 #ifdef _WIN32
 		if (status) {
 			if (fglrx_buggy_driver) {
-				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver.Please check the links below.\n"
+				fprintf(stderr, "The \"OpenGL (Hardware)\" renderer is slow on AMD GPU's due to an inefficient driver. Check out the links below for further information.\n"
 					"https://community.amd.com/message/2756964\n"
 					"https://community.amd.com/thread/205702\n"
-					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause a application or system crash.\n"
+					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause an application or system crash.\n"
 					"Keep Blending Unit Accuracy set to at least the default \"Basic\".\n"
-					"AMD have a fix for the issue that will be released in the coming months. The issue does not affect AMD GPU's on legacy drivers.\n");
+					"AMD has a fix for the issue that will be released in the coming months. The issue does not affect AMD GPU's on legacy drivers.\n");
 			}
 		}
 #endif

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -370,8 +370,9 @@ namespace GLLoader {
 				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver.Please check the links below.\n"
 					"https://community.amd.com/message/2756964\n"
 					"https://community.amd.com/thread/205702\n"
-					"Note: When running OpenGL on AMD cards make sure Blending Unit Accuracy is set to at least Basic.\n"
-					"Having it set to None will cause a BSOD and crash the system.\n");
+					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to "None" can cause a application or system crash.\n"
+					"Keep Blending Unit Accuracy set to at least the default "Basic".\n"
+					"AMD have a fix for the issue that will be released in the coming months. The issue does not affect AMD GPU's on legacy drivers.\n");
 			}
 		}
 #endif

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -367,7 +367,7 @@ namespace GLLoader {
 #ifdef _WIN32
 		if (status) {
 			if (fglrx_buggy_driver) {
-				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver. Sorry.\n");
+				fprintf(stderr, "OpenGL renderer is slow on AMD GPU due to inefficient driver. Please check the links below.\nhttps://community.amd.com/thread/205702\nhttps://community.amd.com/message/2756964\n");
 			}
 		}
 #endif

--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -372,7 +372,7 @@ namespace GLLoader {
 					"https://community.amd.com/thread/205702\n"
 					"Note: Due to an AMD GPU OpenGL driver issue, setting Blending Unit Accuracy to \"None\" can cause an application or system crash.\n"
 					"Keep Blending Unit Accuracy set to at least the default \"Basic\".\n"
-					"AMD has a fix for the issue that will be released in the coming months. The issue does not affect AMD GPU's on legacy drivers.\n");
+					"AMD has a fix for the issue that will be released in the coming months. The issue does not affect AMD GPUs on legacy drivers.\n");
 			}
 		}
 #endif

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -103,7 +103,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"It could be slower when the effects are used.";
 		case IDC_ACCURATE_BLEND_UNIT:
 			return "Control the accuracy level of the GS blending unit emulation.\n\n"
-				"None:\nFast but introduce various rendering issues. It is intended for slow computer.\n\n"
+				"None:\nFast but introduce various rendering issues. It is intended for slow computer.\nNot recommended for AMD cards due to buggy driver as it will cause a BSOD and crash the system.\n\n"
 				"Basic:\nEmulate correctly most of the effects with a limited speed penalty. It is the recommended setting.\n\n"
 				"Medium:\nExtend it to all sprites. Performance impact remains reasonable in 3D game.\n\n"
 				"High:\nExtend it to destination alpha blending and color wrapping. (help shadow and fog effect). A good CPU is required.\n\n"

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -103,7 +103,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"It could be slower when the effects are used.";
 		case IDC_ACCURATE_BLEND_UNIT:
 			return "Control the accuracy level of the GS blending unit emulation.\n\n"
-				"None:\nFast but introduce various rendering issues. It is intended for slow computer.\nNot recommended for AMD cards due to buggy driver as it will cause a BSOD and crash the system.\n\n"
+				"None:\nFast but introduce various rendering issues. It is intended for slow computer.\n\n"
 				"Basic:\nEmulate correctly most of the effects with a limited speed penalty. It is the recommended setting.\n\n"
 				"Medium:\nExtend it to all sprites. Performance impact remains reasonable in 3D game.\n\n"
 				"High:\nExtend it to destination alpha blending and color wrapping. (help shadow and fog effect). A good CPU is required.\n\n"

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -221,7 +221,7 @@ void GSdxApp::Init()
 	m_gs_crc_level.push_back(GSSetting(0 , "None", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(1 , "Minimum", "Debug"));
 	m_gs_crc_level.push_back(GSSetting(2 , "Partial", "OpenGL Recommended"));
-	m_gs_crc_level.push_back(GSSetting(3 , "Full", "Safest"));
+	m_gs_crc_level.push_back(GSSetting(3 , "Full", "Direct3D Recommended"));
 	m_gs_crc_level.push_back(GSSetting(4 , "Aggressive", ""));
 
 	m_gs_acc_blend_level.push_back(GSSetting(0, "None", "Fastest"));


### PR DESCRIPTION
Rename CRC Hack Level "Full (Safest)" to "Full (Direct3D Recommended)"

Add tooltip info for Blending Accuracy None that it doesn't work with
AMD cards.