### PR TITLE
GSdx: Integrate software renderers

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -267,12 +267,26 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 			break;
 		case GSRendererType::Software:
 #ifdef _WIN32
-			dev = new GSDevice9();
+			switch (GSUtil::GetBestRenderer(RenderingMode::Software))
+			{
+			case GSRendererType::OGL:
+				dev = new GSDeviceOGL();
+				renderer_fullname = "Software mode (OpenGL API)";
+				break;
+			case GSRendererType::DX1011:
+				dev = new GSDevice11();
+				renderer_fullname = "Software mode (D3D11 API)";
+				break;
+			case GSRendererType::DX9:
+				dev = new GSDevice9();
+				renderer_fullname = "Software mode (D3D9 API)";
+				break;
+			}
 #else
 			dev = new GSDeviceOGL();
+			renderer_fullname = "Software mode";
 #endif
 			s_renderer_name = " SW";
-			renderer_fullname = "Software mode";
 			break;
 		}
 
@@ -335,6 +349,10 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 			case GSRendererType::OGL:
 			case GSRendererType::OGL_OpenCL:
 				s_gs->m_wnd = new GSWndWGL();
+				break;
+			case GSRendererType::Software:
+				if(GSUtil::GetBestRenderer(RenderingMode::Software) == GSRendererType::OGL)
+					s_gs->m_wnd = new GSWndWGL();
 				break;
 			default:
 				s_gs->m_wnd = new GSWndDX();
@@ -509,13 +527,13 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
 #ifdef _WIN32
 		if (renderer == GSRendererType::Default)
-			renderer = GSUtil::GetBestRenderer();
+			renderer = GSUtil::GetBestRenderer(RenderingMode::Hardware);
 #endif
 	}
 	else if (stored_toggle_state != toggle_state)
 	{
 #ifdef _WIN32
-		GSRendererType best_renderer = GSUtil::GetBestRenderer();
+		GSRendererType best_renderer = GSUtil::GetBestRenderer(RenderingMode::Hardware);
 
 		switch (renderer)
 		{

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -231,13 +231,11 @@ enum class GS_MIN_FILTER : uint8_t
 enum class GSRendererType : int8_t
 {
 	Undefined = -1,
-	DX9_HW,
-	DX9_SW,
-	DX1011_HW = 3,
-	DX1011_SW,
+	DX9,
+	DX1011 = 3,
 	Null = 11,
-	OGL_HW,
-	OGL_SW,
+	OGL,
+	Software,
 	DX9_OpenCL,
 	DX1011_OpenCL,
 	OGL_OpenCL = 17,
@@ -247,7 +245,7 @@ enum class GSRendererType : int8_t
 #else
 	// Use ogl renderer as default otherwise it crash at startup
 	// GSRenderOGL only GSDeviceOGL (not GSDeviceNULL)
-	Default = OGL_HW
+	Default = OGL
 #endif
 
 };

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -81,7 +81,7 @@ GSDeviceOGL::GSDeviceOGL()
 
 	// Reset the debug file
 	#ifdef ENABLE_OGL_DEBUG
-	if (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_SW)
+	if (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::Software)
 		m_debug_gl_file = fopen("GSdx_opengl_debug_sw.txt","w");
 	else
 		m_debug_gl_file = fopen("GSdx_opengl_debug_hw.txt","w");

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -851,7 +851,7 @@ GSRendererHW::Hacks::Hacks()
 	, m_oo(NULL)
 	, m_cu(NULL)
 {
-	bool is_opengl = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW);
+	bool is_opengl = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL);
 	bool can_handle_depth = (!theApp.GetConfigB("UserHacks") || !theApp.GetConfigB("UserHacks_DisableDepthSupport")) && is_opengl;
 
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::FFXII, CRC::EU, &GSRendererHW::OI_FFXII));

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -198,8 +198,8 @@ void GSSettingsDlg::UpdateFilteringCombobox()
 {
 	INT_PTR i;
 	ComboBoxGetSelData(IDC_RENDERER, i);
-	bool opengl = static_cast<GSRendererType>(i) == GSRendererType::OGL_HW;
-	bool hw_mode = opengl || static_cast<GSRendererType>(i) == GSRendererType::DX1011_HW || static_cast<GSRendererType>(i) == GSRendererType::DX9_HW;
+	bool opengl = static_cast<GSRendererType>(i) == GSRendererType::OGL;
+	bool hw_mode = opengl || static_cast<GSRendererType>(i) == GSRendererType::DX1011 || static_cast<GSRendererType>(i) == GSRendererType::DX9;
 	if (!hw_mode)
 		return;
 
@@ -371,7 +371,7 @@ void GSSettingsDlg::UpdateRenderers()
 
 		GSRendererType renderer = static_cast<GSRendererType>(r.value);
 
-		if(renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::DX1011_OpenCL)
+		if(renderer == GSRendererType::DX1011 || renderer == GSRendererType::DX1011_OpenCL)
 		{
 			if(level < D3D_FEATURE_LEVEL_10_0) continue;
 			r.name += (level >= D3D_FEATURE_LEVEL_11_0 ? "11" : "10");
@@ -404,12 +404,12 @@ void GSSettingsDlg::UpdateControls()
 		GSRendererType renderer = static_cast<GSRendererType>(i);
 		D3D_FEATURE_LEVEL level = GSUtil::CheckDirect3D11Level();
 
-		bool dx9 = renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX9_SW || renderer == GSRendererType::DX9_OpenCL;
-		bool dx11 = renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::DX1011_OpenCL;
-		bool ogl = renderer == GSRendererType::OGL_HW || renderer == GSRendererType::OGL_SW || renderer == GSRendererType::OGL_OpenCL;
+		bool dx9 = renderer == GSRendererType::DX9 || renderer == GSRendererType::DX9_OpenCL;
+		bool dx11 = renderer == GSRendererType::DX1011 || renderer == GSRendererType::DX1011_OpenCL;
+		bool ogl = renderer == GSRendererType::OGL || renderer == GSRendererType::OGL_OpenCL;
 
-		bool hw = renderer == GSRendererType::DX9_HW || renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::OGL_HW;
-		bool sw = renderer == GSRendererType::DX9_SW || renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::OGL_SW;
+		bool hw = renderer == GSRendererType::DX9 || renderer == GSRendererType::DX1011 || renderer == GSRendererType::OGL;
+		bool sw = renderer == GSRendererType::Software;
 		bool ocl = renderer == GSRendererType::DX9_OpenCL || renderer == GSRendererType::DX1011_OpenCL || renderer == GSRendererType::OGL_OpenCL;
 		bool null = renderer == GSRendererType::Null;
 
@@ -666,8 +666,8 @@ void GSHacksDlg::OnInit()
 	unsigned short cb = 0;
 
 	// It can only be accessed with a HW renderer, so this is sufficient.
-	bool dx9 = renderer == GSRendererType::DX9_HW;
-	bool ogl = renderer == GSRendererType::OGL_HW;
+	bool dx9 = renderer == GSRendererType::DX9;
+	bool ogl = renderer == GSRendererType::OGL;
 	bool native = upscaling_multiplier == 1;
 
 	if(dx9) for(unsigned short i = 0; i < 17; i++)

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -360,7 +360,7 @@ void GSSettingsDlg::UpdateRenderers()
 	else
 	{
 		GSRendererType ini_renderer = GSRendererType(theApp.GetConfigI("Renderer"));
-		renderer_setting = (ini_renderer == GSRendererType::Undefined) ? GSUtil::GetBestRenderer() : ini_renderer;
+		renderer_setting = (ini_renderer == GSRendererType::Undefined) ? GSUtil::GetBestRenderer(RenderingMode::Hardware) : ini_renderer;
 	}
 
 	GSRendererType renderer_sel = GSRendererType::Default;

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -29,7 +29,7 @@ bool GSTextureCache::m_wrap_gs_mem = false;
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
 {
-	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW);
+	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL);
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_spritehack                   = theApp.GetConfigI("UserHacks_SpriteHack");

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -414,7 +414,7 @@ D3D_FEATURE_LEVEL GSUtil::CheckDirect3D11Level(IDXGIAdapter *adapter, D3D_DRIVER
 	return SUCCEEDED(hr) ? level : (D3D_FEATURE_LEVEL)0;
 }
 
-GSRendererType GSUtil::GetBestRenderer()
+GSRendererType GSUtil::GetBestRenderer(RenderingMode mode)
 {
 	CComPtr<IDXGIFactory1> dxgi_factory;
 	if (SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&dxgi_factory))))
@@ -425,16 +425,22 @@ GSRendererType GSUtil::GetBestRenderer()
 			DXGI_ADAPTER_DESC1 desc;
 			if (SUCCEEDED(adapter->GetDesc1(&desc)))
 			{
-				D3D_FEATURE_LEVEL level = GSUtil::CheckDirect3D11Level();
-				// Check for Nvidia VendorID. Latest OpenGL features need at least DX11 level GPU
-				if (desc.VendorId == 0x10DE && level >= D3D_FEATURE_LEVEL_11_0)
-					return GSRendererType::OGL;
-				if (level >= D3D_FEATURE_LEVEL_10_0)
-					return GSRendererType::DX1011;
+				const D3D_FEATURE_LEVEL level = GSUtil::CheckDirect3D11Level();
+				const GSRendererType best_dx_renderer = (level >= D3D_FEATURE_LEVEL_10_0) ? GSRendererType::DX1011 : GSRendererType::DX9;
+
+				if (level >= D3D_FEATURE_LEVEL_11_0)
+				{
+					if (mode == RenderingMode::Software && desc.VendorId != _INTEL_VENDOR_ID ||
+						mode == RenderingMode::Hardware && desc.VendorId == _NVIDIA_VENDOR_ID)
+					{
+						return GSRendererType::OGL;
+					}
+				}
+				return best_dx_renderer;
 			}
 		}
 	}
-	return GSRendererType::DX9;
+	return GSRendererType::Default;
 }
 
 #else

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -428,13 +428,13 @@ GSRendererType GSUtil::GetBestRenderer()
 				D3D_FEATURE_LEVEL level = GSUtil::CheckDirect3D11Level();
 				// Check for Nvidia VendorID. Latest OpenGL features need at least DX11 level GPU
 				if (desc.VendorId == 0x10DE && level >= D3D_FEATURE_LEVEL_11_0)
-					return GSRendererType::OGL_HW;
+					return GSRendererType::OGL;
 				if (level >= D3D_FEATURE_LEVEL_10_0)
-					return GSRendererType::DX1011_HW;
+					return GSRendererType::DX1011;
 			}
 		}
 	}
-	return GSRendererType::DX9_HW;
+	return GSRendererType::DX9;
 }
 
 #else

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -24,6 +24,16 @@
 #include "GS.h"
 #include "xbyak/xbyak_util.h"
 
+#define _AMD_VENDOR_ID		0x1002
+#define _INTEL_VENDOR_ID	0x8086
+#define _NVIDIA_VENDOR_ID	0x10DE
+
+enum class RenderingMode : uint8
+{
+	Hardware,
+	Software
+};
+
 struct OCLDeviceDesc
 {
 #ifdef ENABLE_OPENCL
@@ -61,7 +71,7 @@ public:
 	static bool CheckDirectX();
 	static bool CheckDXGI();
 	static bool CheckD3D11();
-	static GSRendererType GetBestRenderer();
+	static GSRendererType GetBestRenderer(RenderingMode);
 	static D3D_FEATURE_LEVEL CheckDirect3D11Level(IDXGIAdapter *adapter = NULL, D3D_DRIVER_TYPE type = D3D_DRIVER_TYPE_HARDWARE);
 
 #endif

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -147,18 +147,11 @@ void GSdxApp::Init()
 	m_section = "Settings";
 
 #ifdef _WIN32
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_HW), "Direct3D9", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_HW), "Direct3D", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW), "OpenGL", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9_SW), "Direct3D9", "Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_SW), "Direct3D", "Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW), "OpenGL", "Software"));
-#else // Linux
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW), "OpenGL", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW), "OpenGL", "Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX9), "Direct3D9", ""));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011), "Direct3D", ""));
 #endif
-
-	// The null renderer goes third, it has use for benchmarking purposes in a release build
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL), "OpenGL", ""));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Software), "Software Renderer", ""));
 	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null), "None", "Core Benchmark"));
 
 #ifdef ENABLE_OPENCL


### PR DESCRIPTION
**Summary of changes**:

* Integrate all the software renderers into a single item in renderer combobox.
* Slightly modify the F9 toggle behavior to make it suitable with the new integration of software renderers.
* I've update the enumeration values in GSRendererType, I prefer to keep the code clean in cost of temporarily breaking the INI compatibility.

**TODO**:

* Missing logo for software renderer?
* Maybe ``DX1011_HW``, ``DX9_HW``... could be converted to ``DX1011``, ``DX9`` respectively as there's only one software renderer right now? (I mean the enumeration in code, _nothing to see here for end users_)

I remember having a discussion with Gregory on IRC before and the consensus was to use D3D9 for SW rendering on Windows and OpenGL for Linux if there was a plan to integrate the software renderers. I did that approach on this PR, actually I was planning on making this change [**last year**](https://github.com/PCSX2/pcsx2/pull/1284#issuecomment-207447845) but I only got the time to do it now. :P


_**Master branch**_:

![Before](http://i.imgur.com/GETEWPk.png)

_**Pull request branch**_:

![Now](http://i.imgur.com/zzE4i71.png)