### PR TITLE
GSDX-Windows: Automatic initial CRC hack level selection

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -523,7 +523,11 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
 #ifdef _WIN32
 		if (renderer == GSRendererType::Default)
+		{
 			renderer = GSUtil::GetBestRenderer();
+			if (renderer == GSRendererType::OGL_HW)
+				theApp.SetConfig("crc_hack_level", static_cast<int>(CRCHackLevel::Partial));
+		}
 #endif
 	}
 	else if (stored_toggle_state != toggle_state)

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1425,3 +1425,12 @@ enum class Filtering : uint8
 	Trilinear_Bilinear_Forced,
 	Trilinear_Always
 };
+
+enum class CRCHackLevel : uint8
+{
+	None,
+	Minimum,
+	Partial,
+	Full,
+	Aggressive
+};

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -23,11 +23,11 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-int s_crc_hack_level = 3;
+CRCHackLevel s_crc_hack_level = CRCHackLevel::Full;
 
 // hacks
-#define Aggresive (s_crc_hack_level > 3)
-#define Dx_only   (s_crc_hack_level > 2)
+#define Aggresive (s_crc_hack_level >= CRCHackLevel::Aggressive)
+#define Dx_only   (s_crc_hack_level >= CRCHackLevel::Full)
 
 CRC::Region g_crc_region = CRC::NoRegion;
 
@@ -2419,11 +2419,11 @@ void GSState::SetupCrcHack()
 {
 	GetSkipCount lut[CRC::TitleCount];
 
-	s_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	s_crc_hack_level = static_cast<CRCHackLevel>(theApp.GetConfigI("crc_hack_level"));
 
 	memset(lut, 0, sizeof(lut));
 
-	if (s_crc_hack_level > 1) {
+	if (s_crc_hack_level > CRCHackLevel::Minimum) {
 		lut[CRC::AceCombat4] = GSC_AceCombat4;
 		lut[CRC::BlackHawkDown] = GSC_BlackHawkDown;
 		lut[CRC::BleachBladeBattlers] = GSC_BleachBladeBattlers;

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -299,7 +299,7 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 
 	// Gregory: code is not yet ready so let's only enable it when
 	// CRC is below the FULL level
-	if (m_texture_shuffle && (m_crc_hack_level < 3)) {
+	if (m_texture_shuffle && (m_crc_hack_level < CRCHackLevel::Full)) {
 		ps_sel.shuffle = 1;
 		ps_sel.fmt = 0;
 

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -360,7 +360,18 @@ void GSSettingsDlg::UpdateRenderers()
 	else
 	{
 		GSRendererType ini_renderer = GSRendererType(theApp.GetConfigI("Renderer"));
-		renderer_setting = (ini_renderer == GSRendererType::Undefined) ? GSUtil::GetBestRenderer() : ini_renderer;
+
+		if (ini_renderer == GSRendererType::Undefined)
+		{
+			renderer_setting = GSUtil::GetBestRenderer();
+
+			if(renderer_setting == GSRendererType::OGL_HW)
+				theApp.SetConfig("crc_hack_level", static_cast<int>(CRCHackLevel::Partial));
+		}
+		else
+		{
+			renderer_setting = ini_renderer;
+		}
 	}
 
 	GSRendererType renderer_sel = GSRendererType::Default;

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -23,7 +23,6 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-extern int g_crc_hack_level;
 
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
@@ -79,7 +78,7 @@ GSState::GSState()
 	//s_savel = 0;
 
 	UserHacks_WildHack = theApp.GetConfigB("UserHacks") ? theApp.GetConfigI("UserHacks_WildHack") : 0;
-	m_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	m_crc_hack_level = static_cast<CRCHackLevel>(theApp.GetConfigI("crc_hack_level"));
 
 	memset(&m_v, 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));
@@ -2519,7 +2518,7 @@ void GSState::SetGameCRC(uint32 crc, int options)
 {
 	m_crc = crc;
 	m_options = options;
-	m_game = CRC::Lookup(m_crc_hack_level ? crc : 0);
+	m_game = CRC::Lookup(m_crc_hack_level != CRCHackLevel::None ? crc : 0);
 	SetupCrcHack();
 
 	// Until we find a solution that work for all games.

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -160,7 +160,7 @@ protected:
 
 	int UserHacks_WildHack;
 	bool isPackedUV_HackFlag;
-	int m_crc_hack_level;
+	CRCHackLevel m_crc_hack_level;
 	GetSkipCount m_gsc;
 	int m_skip;
 	int m_userhacks_skipdraw;

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -51,7 +51,7 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	m_paltex = theApp.GetConfigB("paltex");
 	m_can_convert_depth &= s_IS_OPENGL; // only supported by openGL so far
-	m_crc_hack_level = theApp.GetConfigI("crc_hack_level");
+	m_crc_hack_level = static_cast<CRCHackLevel>(theApp.GetConfigI("crc_hack_level"));
 
 	// In theory 4MB is enough but 9MB is safer for overflow (8MB
 	// isn't enough in custom resolution)
@@ -281,7 +281,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 
 						// Gregory: to avoid a massive slow down for nothing, let's only enable
 						// this code when CRC is below the FULL level
-						if (m_crc_hack_level < 3)
+						if (m_crc_hack_level < CRCHackLevel::Full)
 							Read(t, t->m_valid);
 						else
 							dst = t;

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -129,7 +129,7 @@ protected:
 	bool m_preload_frame;
 	uint8* m_temp;
 	bool m_can_convert_depth;
-	int m_crc_hack_level;
+	CRCHackLevel m_crc_hack_level;
 	static bool m_disable_partial_invalidation;
 	bool m_texture_inside_rt;
 	static bool m_wrap_gs_mem;

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -294,7 +294,7 @@ void GSdxApp::Init()
 	m_default_configuration["CaptureHeight"]                              = "480";
 	m_default_configuration["CaptureWidth"]                               = "640";
 	m_default_configuration["clut_load_before_draw"]                      = "0";
-	m_default_configuration["crc_hack_level"]                             = "3";
+	m_default_configuration["crc_hack_level"]                             = to_string(static_cast<int8>(CRCHackLevel::Full));
 	m_default_configuration["CrcHacksExclusions"]                         = "";
 	m_default_configuration["debug_glsl_shader"]                          = "0";
 	m_default_configuration["debug_opengl"]                               = "0";


### PR DESCRIPTION
**Summary of changes**:

* Add an enum class for ``CRC hack level``.
* Default to ``Partial`` level on a fresh startup if the best renderer is detected as OpenGL. Closes #1722.