### PR TITLE
VU0: fix for Street Fighter EX3 and R: Racing Evolution

### DIFF
--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -122,7 +122,15 @@ void CFC2() {
 		_vu0WaitMicro();
 	}
 	if (_Rt_ == 0) return;
-	cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[_Fs_].UL;
+	
+	if (_Fs_ == REG_TPC) {
+		// For explanation why this is needed here please refer to 
+		// recCFC2() definded in microVU_Macro.inl
+		cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[_Fs_].UL >> 3;
+	} else {
+		cpuRegs.GPR.r[_Rt_].UL[0] = VU0.VI[_Fs_].UL;
+	}
+
 	if(VU0.VI[_Fs_].UL & 0x80000000)
 		cpuRegs.GPR.r[_Rt_].UL[1] = 0xffffffff;
 	else


### PR DESCRIPTION
Hi guys!

Remember the *Street Fighter EX3* clothing issue #954 and this thread *http://forums.pcsx2.net/Thread-R-Racing-Evolution-invisible-cars* describing the lack of the cars on the race track in R Racing Evolution?
Well, the dark days for these games seem finally to be over as there is a fix for them!

![sfex3](https://cloud.githubusercontent.com/assets/3531289/23243194/f9733366-f985-11e6-85e4-233bc919d568.png)
![rri](https://cloud.githubusercontent.com/assets/3531289/23243198/fb43e488-f985-11e6-8466-f8ee785930a6.png)

In short, there is something peculiar about the CFC2 instruction (VU0 Macro) when it copies the value from the TPC register.
These two mentioned games use the code like below for running the VU0 micro subroutine:

...
cfc2	t4, TPC
ctc2	t4, CMSAR0
callmsr
...

The official VU coding manual requires the value in the CMSAR0 to be divided by 8 before running the VCALLMSR instruction.
Apparently CFC2 divides the value by 8 itself because all the other games I have found also using the VCALLMSR instruction (24: The Game, GTA LCS, GTA VCS and FFXII) indeed divide the value by 8 in code before running the micro subroutine:

(From the FFXII game)

...
lw		v0, 0x14(v1)
sra		v0, 0x03
ctc2	v0, CMSAR0
...
callmsr	
...

The only difference is that they never fetch the value from the TPC directly.

I have also run some homebrew tests on my PS2 and discovered that the CFC2 instruction really ends up with the value already divided by 8.
There are basically two possibilities: either CFC2 also divides by 8 while fetching from the TPC register or the TPC register always works with the values already divided by 8.
The latter seems unlikely because TPC is the Program Counter register that should hold the memory address of the instruction.
Sadly there seems to be no way to see what is really inside the TPC register before fetching from it by CFC2 because CFC2 is the only way to retrieve its value (so says the manual).
In any case PCSX2 already implements TPC as the instruction address pointer so sticking to CFC2 dividing by 8 looks like the correct way for the fix.

(I left a descriptive comment directly in code describing the same, fixed for both the EE Interpreter and the Recompiler)

It was possible for me to test some games apart from all of the mentioned above and there _seem_ to be no regression.
However this needs to be tested on a bigger amount of games as obviously the impact may be pretty significant.
Who knows, it might even fix some issues related to VU0 in other games! :)

Please take a look at your earliest convenience.