### PR TITLE
Plugin-Function: Add OSD for incomplete/corrupt savestates

### DIFF
--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -732,6 +732,7 @@ wxString Exception::SaveStateLoadError::FormatDiagnosticMessage() const
 {
 	FastFormatUnicode retval;
 	retval.Write("Savestate is corrupt or incomplete!\n");
+	OSDlog(Color_Red, false, "Error: Savestate is corrupt or incomplete!");
 	_formatDiagMsg(retval);
 	return retval;
 }
@@ -741,6 +742,7 @@ wxString Exception::SaveStateLoadError::FormatDisplayMessage() const
 	FastFormatUnicode retval;
 	retval.Write(_("The savestate cannot be loaded, as it appears to be corrupt or incomplete."));
 	retval.Write("\n");
+	OSDlog(Color_Red, false, "Error: The savestate cannot be loaded, as it appears to be corrupt or incomplete.");
 	_formatUserMsg(retval);
 	return retval;
 }


### PR DESCRIPTION
**Summary of changes**:

* Add OSD log messages for cases where a savestate load fails. (_**Refer commit message for more details**_)