### PR TITLE
gsdx tc: revert 87fc4c1e44cfa7215cf1b327e0c0f93cadfb5bda

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -175,10 +175,10 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		// The game tries to emulate a texture shuffle with an old depth buffer
 		// (don't exists yet for us due to the cache)
 		// Rendering is nicer (less garbage) if we skip the draw call.
-		throw GSDXRecoverableError();
+		//throw GSDXRecoverableError();
 
 		//ASSERT(0);
-		//return LookupSource(TEX0, TEXA, r);
+		return LookupSource(TEX0, TEXA, r);
 	}
 
 	return src;


### PR DESCRIPTION
At least 2 regressions
* SVC Chaos #1862
* Jackie Chan #1838

I don't see any difference on Full Spectrum Warrior gsdump (#1757). Both return
and throw flicker. And none has the original vertical line issue. I suspect
it is linked to the behavior of depth miss.

The correct fix would be to trace all textures writes to be sure of the source.
But it is a much bigger work.

@FlatOutPS2 @ssakash 
Could you test those 3 games
* [ ] SVC Chaos
* [ ] Jackie Chan
* [ ] Full Spectrum Warrior