### PR TITLE
Add crc hack for project metafalica

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -27,6 +27,7 @@ CRC::Game CRC::m_games[] =
 {
 	{0x00000000, NoTitle, NoRegion, 0},
 	{0xF46142D3, ArTonelico2, NoRegion, 0},
+	{0xC38067F4, ArTonelico2, NoRegion, 0}, // project metafalica 1.0
 	{0xF95F37EE, ArTonelico2, US, 0},
 	{0xCE2C1DBF, ArTonelico2, EU, 0},
 	{0x2113EA2E, MetalSlug6, JP, 0},


### PR DESCRIPTION
Closes https://github.com/PCSX2/pcsx2/issues/1762

Given that all three versions of the patch should result in the same iso this should be `NoRegion`, this CRC was tested with an US patch applied to an iso matching the US redump.