### PR TITLE
gsdx: Add an automatic CRC hack level

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -216,11 +216,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
 #ifdef _WIN32
 		if (renderer == GSRendererType::Default)
-		{
 			renderer = GSUtil::GetBestRenderer();
-			if (renderer == GSRendererType::OGL_HW)
-				theApp.SetConfig("crc_hack_level", static_cast<int>(CRCHackLevel::Partial));
-		}
 #endif
 	}
 

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -62,7 +62,6 @@ extern bool RunLinuxDialog();
 static GSRenderer* s_gs = NULL;
 static void (*s_irq)() = NULL;
 static uint8* s_basemem = NULL;
-static GSRendererType s_renderer = GSRendererType::Undefined;
 static bool s_framelimit = true;
 static bool s_vsync = false;
 static bool s_exclusive = true;
@@ -170,7 +169,7 @@ EXPORT_C GSshutdown()
 	delete s_gs;
 	s_gs = nullptr;
 
-	s_renderer = GSRendererType::Undefined;
+	theApp.SetCurrentRendererType(GSRendererType::Undefined);
 
 #ifdef _WIN32
 
@@ -232,7 +231,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 
 	try
 	{
-		if (s_renderer != renderer)
+		if (theApp.GetCurrentRendererType() != renderer)
 		{
 			// Emulator has made a render change request, which requires a completely
 			// new s_gs -- if the emu doesn't save/restore the GS state across this
@@ -241,6 +240,8 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 			delete s_gs;
 
 			s_gs = NULL;
+
+			theApp.SetCurrentRendererType(renderer);
 		}
 
 		std::shared_ptr<GSWnd> window;
@@ -419,8 +420,6 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 			}
 			if (s_gs == NULL)
 				return -1;
-
-			s_renderer = renderer;
 		}
 
 		s_gs->m_wnd = window;
@@ -480,7 +479,7 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 	static bool stored_toggle_state = false;
 	bool toggle_state = !!(flags & 4);
 
-	GSRendererType renderer = s_renderer;
+	GSRendererType renderer = theApp.GetCurrentRendererType();
 
 	if (renderer != GSRendererType::Undefined && stored_toggle_state != toggle_state)
 	{
@@ -811,7 +810,7 @@ EXPORT_C GSconfigure()
 		if(GSSettingsDlg().DoModal() == IDOK)
 		{
 			// Force a reload of the gs state
-			s_renderer = GSRendererType::Undefined;
+			theApp.SetCurrentRendererType(GSRendererType::Undefined);
 		}
 
 #else
@@ -819,7 +818,7 @@ EXPORT_C GSconfigure()
 		if (RunLinuxDialog()) {
 			theApp.ReloadConfig();
 			// Force a reload of the gs state
-			s_renderer = GSRendererType::Undefined;
+			theApp.SetCurrentRendererType(GSRendererType::Undefined);
 		}
 
 #endif

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1432,8 +1432,9 @@ enum class TriFiltering : uint8
 	Forced,
 };
 
-enum class CRCHackLevel : uint8
+enum class CRCHackLevel : int8
 {
+	Automatic = -1,
 	None,
 	Minimum,
 	Partial,

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -82,7 +82,7 @@ GSDeviceOGL::GSDeviceOGL()
 
 	// Reset the debug file
 	#ifdef ENABLE_OGL_DEBUG
-	if (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_SW)
+	if (theApp.GetCurrentRendererType() == GSRendererType::OGL_SW)
 		m_debug_gl_file = fopen("GSdx_opengl_debug_sw.txt","w");
 	else
 		m_debug_gl_file = fopen("GSdx_opengl_debug_hw.txt","w");

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -23,11 +23,12 @@
 #include "GSState.h"
 #include "GSdx.h"
 
-CRCHackLevel s_crc_hack_level = CRCHackLevel::Full;
+static CRCHackLevel s_crc_hack_level = CRCHackLevel::Full;
 
 // hacks
 #define Aggresive (s_crc_hack_level >= CRCHackLevel::Aggressive)
-#define Dx_only   (s_crc_hack_level >= CRCHackLevel::Full)
+#define Dx_only (s_crc_hack_level >= CRCHackLevel::Full)
+#define Dx_and_OGL (s_crc_hack_level >= CRCHackLevel::Partial)
 
 CRC::Region g_crc_region = CRC::NoRegion;
 
@@ -2419,11 +2420,11 @@ void GSState::SetupCrcHack()
 {
 	GetSkipCount lut[CRC::TitleCount];
 
-	s_crc_hack_level = static_cast<CRCHackLevel>(theApp.GetConfigI("crc_hack_level"));
+	s_crc_hack_level = m_crc_hack_level;
 
 	memset(lut, 0, sizeof(lut));
 
-	if (s_crc_hack_level > CRCHackLevel::Minimum) {
+	if (Dx_and_OGL) {
 		lut[CRC::AceCombat4] = GSC_AceCombat4;
 		lut[CRC::BlackHawkDown] = GSC_BlackHawkDown;
 		lut[CRC::BleachBladeBattlers] = GSC_BleachBladeBattlers;

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -851,7 +851,7 @@ GSRendererHW::Hacks::Hacks()
 	, m_oo(NULL)
 	, m_cu(NULL)
 {
-	bool is_opengl = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW);
+	bool is_opengl = theApp.GetCurrentRendererType() == GSRendererType::OGL_HW;
 	bool can_handle_depth = (!theApp.GetConfigB("UserHacks") || !theApp.GetConfigB("UserHacks_DisableDepthSupport")) && is_opengl;
 
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::FFXII, CRC::EU, &GSRendererHW::OI_FFXII));

--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -46,10 +46,14 @@ const char* dialog_message(int ID, bool* updateText) {
 #endif
 		case IDC_CRC_LEVEL:
 			return "Control the number of Auto-CRC hacks applied to games.\n\n"
+				"Automatic:\nAutomatically sets the recommended CRC hack level based on the selected renderer.\n"
+				"This is the recommended setting.\n"
+				"Partial will be selected for OpenGL.\nFull will be selected for Direct3D.\n\n"
 				"None:\nRemove nearly all CRC hacks (debug only).\n\n"
 				"Minimum:\nEnable a couple of CRC hacks (23).\n\n"
-				"Partial:\nEnable most of the CRC hacks.\nRecommended OpenGL setting (Accurate/depth options may be required).\n\n"
-				"Full:\nEnable all CRC hacks.\nRecommended Direct3D setting.\n\n"
+				"Partial:\nEnable most of the CRC hacks.\n"
+				"For an optimal experience with OpenGL, Blending Unit Accuracy/Depth Emulation may need to be enabled.\n\n"
+				"Full:\nEnable all CRC hacks.\n\n"
 				"Aggressive:\nUse more aggressive CRC hacks. Only affects a few games, removing some effects which might make the image sharper/clearer.\n"
 				"Affected games: FFX, FFX2, FFXII, GOW2, ICO, SoTC, SSX3, SMT3, SMTDDS1, SMTDDS2.\n"
 				"Works as a speedhack for: Steambot Chronicles.";

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -334,19 +334,9 @@ void GSSettingsDlg::UpdateRenderers()
 	}
 	else
 	{
-		GSRendererType ini_renderer = GSRendererType(theApp.GetConfigI("Renderer"));
-
-		if (ini_renderer == GSRendererType::Undefined)
-		{
+		renderer_setting = GSRendererType(theApp.GetConfigI("Renderer"));
+		if (renderer_setting == GSRendererType::Undefined)
 			renderer_setting = GSUtil::GetBestRenderer();
-
-			if(renderer_setting == GSRendererType::OGL_HW)
-				theApp.SetConfig("crc_hack_level", static_cast<int>(CRCHackLevel::Partial));
-		}
-		else
-		{
-			renderer_setting = ini_renderer;
-		}
 	}
 
 	GSRendererType renderer_sel = GSRendererType::Default;

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -22,7 +22,7 @@
 #include "stdafx.h"
 #include "GSState.h"
 #include "GSdx.h"
-
+#include "GSUtil.h"
 
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
@@ -78,7 +78,9 @@ GSState::GSState()
 	//s_savel = 0;
 
 	UserHacks_WildHack = theApp.GetConfigB("UserHacks") ? theApp.GetConfigI("UserHacks_WildHack") : 0;
-	m_crc_hack_level = static_cast<CRCHackLevel>(theApp.GetConfigI("crc_hack_level"));
+	m_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
+	if (m_crc_hack_level == CRCHackLevel::Automatic)
+		m_crc_hack_level = GSUtil::GetRecommendedCRCHackLevel(theApp.GetCurrentRendererType());
 
 	memset(&m_v, 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -29,7 +29,7 @@ bool GSTextureCache::m_wrap_gs_mem = false;
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
 {
-	s_IS_OPENGL = (static_cast<GSRendererType>(theApp.GetConfigI("Renderer")) == GSRendererType::OGL_HW);
+	s_IS_OPENGL = theApp.GetCurrentRendererType() == GSRendererType::OGL_HW;
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_spritehack                   = theApp.GetConfigI("UserHacks_SpriteHack");

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -21,6 +21,7 @@
 
 #include "stdafx.h"
 #include "GSTextureCache.h"
+#include "GSUtil.h"
 
 bool s_IS_OPENGL = false;
 bool GSTextureCache::m_disable_partial_invalidation = false;
@@ -51,7 +52,9 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	m_paltex = theApp.GetConfigB("paltex");
 	m_can_convert_depth &= s_IS_OPENGL; // only supported by openGL so far
-	m_crc_hack_level = static_cast<CRCHackLevel>(theApp.GetConfigI("crc_hack_level"));
+	m_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
+	if (m_crc_hack_level == CRCHackLevel::Automatic)
+		m_crc_hack_level = GSUtil::GetRecommendedCRCHackLevel(theApp.GetCurrentRendererType());
 
 	// In theory 4MB is enough but 9MB is safer for overflow (8MB
 	// isn't enough in custom resolution)

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -241,6 +241,11 @@ bool GSUtil::CheckSSE()
 	return status;
 }
 
+CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
+{
+	return type == GSRendererType::OGL_HW ? CRCHackLevel::Partial : CRCHackLevel::Full;
+}
+
 #define OCL_PROGRAM_VERSION 3
 
 #ifdef ENABLE_OPENCL

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -50,6 +50,7 @@ public:
 	static bool HasCompatibleBits(uint32 spsm, uint32 dpsm);
 
 	static bool CheckSSE();
+	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
 
 #ifdef ENABLE_OPENCL
 	static void GetDeviceDescs(list<OCLDeviceDesc>& dl);

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -229,11 +229,14 @@ void GSdxApp::Init()
 	m_gs_hw_mipmapping.push_back(GSSetting(1, "Basic", "Fast"));
 	m_gs_hw_mipmapping.push_back(GSSetting(2, "Full", "Slow"));
 
-	m_gs_crc_level.push_back(GSSetting(0 , "None", "Debug"));
-	m_gs_crc_level.push_back(GSSetting(1 , "Minimum", "Debug"));
-	m_gs_crc_level.push_back(GSSetting(2 , "Partial", "OpenGL Recommended"));
-	m_gs_crc_level.push_back(GSSetting(3 , "Full", "Direct3D Recommended"));
-	m_gs_crc_level.push_back(GSSetting(4 , "Aggressive", ""));
+	m_gs_crc_level = {
+		GSSetting(CRCHackLevel::Automatic, "Automatic", "Default"),
+		GSSetting(CRCHackLevel::None , "None", "Debug"),
+		GSSetting(CRCHackLevel::Minimum, "Minimum", "Debug"),
+		GSSetting(CRCHackLevel::Partial, "Partial", "OpenGL Recommended"),
+		GSSetting(CRCHackLevel::Full, "Full", "Direct3D Recommended"),
+		GSSetting(CRCHackLevel::Aggressive, "Aggressive", ""),
+	};
 
 	m_gs_acc_blend_level.push_back(GSSetting(0, "None", "Fastest"));
 	m_gs_acc_blend_level.push_back(GSSetting(1, "Basic", "Recommended low-end PC"));
@@ -303,7 +306,7 @@ void GSdxApp::Init()
 	m_default_configuration["CaptureHeight"]                              = "480";
 	m_default_configuration["CaptureWidth"]                               = "640";
 	m_default_configuration["clut_load_before_draw"]                      = "0";
-	m_default_configuration["crc_hack_level"]                             = to_string(static_cast<int8>(CRCHackLevel::Full));
+	m_default_configuration["crc_hack_level"]                             = std::to_string(static_cast<int8>(CRCHackLevel::Automatic));
 	m_default_configuration["CrcHacksExclusions"]                         = "";
 	m_default_configuration["debug_glsl_shader"]                          = "0";
 	m_default_configuration["debug_opengl"]                               = "0";

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -142,6 +142,8 @@ void GSdxApp::Init()
 		return;
 	is_initialised = true;
 
+	m_current_renderer_type = GSRendererType::Undefined;
+
 	if (m_ini.empty())
 		m_ini = "inis/GSdx.ini";
 	m_section = "Settings";
@@ -496,4 +498,14 @@ void GSdxApp::SetConfig(const char* entry, int value)
 	sprintf(buff, "%d", value);
 
 	SetConfig(entry, buff);
+}
+
+void GSdxApp::SetCurrentRendererType(GSRendererType type)
+{
+	m_current_renderer_type = type;
+}
+
+GSRendererType GSdxApp::GetCurrentRendererType()
+{
+	return m_current_renderer_type;
 }

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -58,6 +58,8 @@ public:
 	void SetConfig(const char* entry, const char* value);
 	void SetConfig(const char* entry, int value);
 	// Avoid issue with overloading
+	template<typename T>
+	T      GetConfigT(const char* entry) { return static_cast<T>(GetConfigI(entry)); }
 	int    GetConfigI(const char* entry);
 	bool   GetConfigB(const char* entry);
 	string GetConfigS(const char* entry);

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "GSSetting.h"
+#include "GS.h"
 
 class GSdxApp
 {
@@ -31,6 +32,7 @@ class GSdxApp
 #if defined(__unix__)
 	std::map< std::string, std::string > m_configuration_map;
 #endif
+	GSRendererType m_current_renderer_type;
 
 public:
 	GSdxApp();
@@ -60,6 +62,8 @@ public:
 	bool   GetConfigB(const char* entry);
 	string GetConfigS(const char* entry);
 
+	void SetCurrentRendererType(GSRendererType type);
+	GSRendererType GetCurrentRendererType();
 
 	void SetConfigDir(const char* dir);
 


### PR DESCRIPTION
Changes:
* Fixes a bug where depth emulation is disabled if the user starts with the OpenGL software renderer and F9s to the hardware renderer.
* Adds an automatic CRC hack level, which will autoselect the recommended CRC hack level for the selected renderer. I used some stuff from willkuer's PR (#1686).