### PR TITLE
PCSX2: Console log update

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1688,8 +1688,9 @@ Compat = 5
 MemCardFilter = SCES-51607/SCES-50916
 ---------------------------------------------
 Serial = SCES-51608
-Name   = Jak & Daxter 2 - Renegade
+Name   = Jak II: Renegade
 Region = PAL-M7
+Compat = 5
 ---------------------------------------------
 Serial = SCES-51610
 Name   = This is Football 2004 (Red Devils 2004)
@@ -7972,6 +7973,7 @@ Compat = 5
 Serial = SLES-50683
 Name   = Sled Storm
 Region = PAL-M3
+vuClampMode = 2 // Missing polygons at the bottom of the screen.
 ---------------------------------------------
 Serial = SLES-50684
 Name   = Medal of Honor - Frontline
@@ -8442,6 +8444,7 @@ Region = PAL-I
 Serial = SLES-50876
 Name   = Driv3r
 Region = PAL-M5
+Compat = 4
 ---------------------------------------------
 Serial = SLES-50877
 Name   = TimeSplitters 2
@@ -14993,7 +14996,7 @@ Name   = Pro Evolution Soccer Management
 Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53900
-Name   = Kaido Racer
+Name   = Kaido Racer 2
 Region = PAL-M3
 ---------------------------------------------
 Serial = SLES-53901
@@ -35454,6 +35457,7 @@ Serial = SLUS-20363
 Name   = Sled Storm
 Region = NTSC-U
 Compat = 5
+vuClampMode = 2 // Missing polygons at the bottom of the screen.
 ---------------------------------------------
 Serial = SLUS-20364
 Name   = Tiger Woods PGA Tour 2002
@@ -40380,7 +40384,7 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21394
-Name   = TXR Drift 2
+Name   = Tokyo Xtreme Racer Drift 2
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -1126,8 +1126,11 @@ void SysCorePlugins::Load( PluginsEnum_t pid, const wxString& srcfile )
 {
 	ScopedLock lock( m_mtx_PluginStatus );
 	pxAssert( (uint)pid < PluginId_Count );
-	Console.Indent().WriteLn( L"Binding %4s: %s ", WX_STR(tbl_PluginInfo[pid].GetShortname()), WX_STR(srcfile) );
+
 	m_info[pid] = std::unique_ptr<PluginStatus_t>(new PluginStatus_t(pid, srcfile));
+
+	Console.Indent().WriteLn(L"Bound %4s: %s [%s %s]", WX_STR(tbl_PluginInfo[pid].GetShortname()), 
+		WX_STR(wxFileName(srcfile).GetFullName()), WX_STR(m_info[pid]->Name), WX_STR(m_info[pid]->Version));
 }
 
 void SysCorePlugins::Load( const wxString (&folders)[PluginId_Count] )
@@ -1135,8 +1138,8 @@ void SysCorePlugins::Load( const wxString (&folders)[PluginId_Count] )
 	if( !NeedsLoad() ) return;
 
 	wxDoNotLogInThisScope please;
-	
-	Console.WriteLn( Color_StrongBlue, "\nLoading plugins..." );
+
+	Console.WriteLn(Color_StrongBlue, L"\nLoading plugins from %s...", WX_STR(g_Conf->Folders[FolderId_Plugins].ToString()));
 
 	ConsoleIndentScope indent;
 	const PluginInfo* pi = tbl_PluginInfo; do
@@ -1510,7 +1513,7 @@ bool SysCorePlugins::Init()
 {
 	if( !NeedsInit() ) return false;
 
-	Console.WriteLn( Color_StrongBlue, "\nInitializing plugins..." );
+	Console.WriteLn( Color_StrongBlue, "Initializing plugins..." );
 	const PluginInfo* pi = tbl_PluginInfo; do {
 		Init( pi->id );
 	} while( ++pi, pi->shortname != NULL );

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -446,7 +446,7 @@ static void _ApplySettings( const Pcsx2Config& src, Pcsx2Config& fixup )
 		if (int numberLoadedWideScreenPatches = LoadPatchesFromDir(gameCRC, GetCheatsWsFolder(), L"Widescreen hacks"))
 		{
 			gameWsHacks.Printf(L" [%d widescreen hacks]", numberLoadedWideScreenPatches);
-			Console.WriteLn(Color_Gray, "Found ws patches at cheats_ws --> skipping cheats_ws.zip");
+			Console.WriteLn(Color_Gray, "Found widescreen patches in the cheats_ws folder --> skipping cheats_ws.zip");
 		}
 		else
 		{


### PR DESCRIPTION
Remove full path from every plugin binding and only add it to the preceding "Loading Plugins..." line.
Instead the revision date and version number are printed for each plugin to make it easier to identify issues with plugin versions.

And improve the widescreen patch message when loading from the cheats_ws folder instead of the archive.

And add a very minor compatibility info update in the GameIndex file for 2 games bassed on compatibility reports I made earlier.

EDIT: And adds fix for Sled Storm(confirmed to be required for both the PAL(SLES-50683) and NTSC-U(SLUS-20363) versions).