### PR TITLE
GSdx: OpenGL console messages

### DIFF
--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -306,8 +306,6 @@ namespace GLLoader {
 
 		if (!found) {
 			fprintf(stdout, "INFO: %s is NOT SUPPORTED\n", name.c_str());
-		} else {
-			fprintf(stdout, "INFO: %s is available\n", name.c_str());
 		}
 
 		std::string opt("override_");


### PR DESCRIPTION
Disable/remove show available extensions messages.
Only unavailable extensions will show messages.