### PR TITLE
GSdx ogl sw: Move GL_ARB_copy_image to optional

### DIFF
--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -424,7 +424,7 @@ namespace GLLoader {
 		status &= status_and_override(found_GL_ARB_shading_language_420pack, "GL_ARB_shading_language_420pack", true);
 		status &= status_and_override(found_GL_ARB_texture_storage, "GL_ARB_texture_storage", true);
 		// GL4.3
-		status &= status_and_override(found_GL_ARB_copy_image, "GL_ARB_copy_image", true);
+		status &= status_and_override(found_GL_ARB_copy_image, "GL_ARB_copy_image", required_for_hw);
 		status &= status_and_override(found_GL_KHR_debug, "GL_KHR_debug", true);
 		// GL4.4
 		status &= status_and_override(found_GL_ARB_buffer_storage,"GL_ARB_buffer_storage", true);

--- a/plugins/GSdx/GLLoader.h
+++ b/plugins/GSdx/GLLoader.h
@@ -370,6 +370,7 @@ namespace GLLoader {
 
 	// GL
 	extern bool found_geometry_shader;
+	extern bool found_GL_ARB_copy_image;
 	extern bool found_GL_ARB_clip_control;
 	extern bool found_GL_ARB_gpu_shader5;
 	extern bool found_GL_ARB_shader_image_load_store;

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -1243,6 +1243,7 @@ void GSDeviceOGL::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r
 	PSSetShaderResource(6, sTex);
 #endif
 
+	ASSERT(GLLoader::found_GL_ARB_copy_image && glCopyImageSubData);
 	glCopyImageSubData( sid, GL_TEXTURE_2D,
 			0, r.x, r.y, 0,
 			did, GL_TEXTURE_2D,

--- a/plugins/GSdx/GSWnd.cpp
+++ b/plugins/GSdx/GSWnd.cpp
@@ -121,7 +121,7 @@ void GSWndGL::PopulateGlFunction()
 	GL_EXT_LOAD_OPT(glBindImageTexture);
 	GL_EXT_LOAD_OPT(glMemoryBarrier);
 	// GL4.3
-	GL_EXT_LOAD(glCopyImageSubData);
+	GL_EXT_LOAD_OPT(glCopyImageSubData);
 	GL_EXT_LOAD_OPT(glInvalidateTexImage);
 	GL_EXT_LOAD(glPushDebugGroup);
 	GL_EXT_LOAD(glPopDebugGroup);

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -340,6 +340,7 @@ void GSdxApp::Init()
 	m_default_configuration["osd_transparency"]                           = "25";
 	m_default_configuration["osd_max_log_messages"]                       = "3";
 	m_default_configuration["override_geometry_shader"]                   = "-1";
+	m_default_configuration["override_GL_ARB_copy_image"]                 = "-1";
 	m_default_configuration["override_GL_ARB_clear_texture"]              = "-1";
 	m_default_configuration["override_GL_ARB_clip_control"]               = "-1";
 	m_default_configuration["override_GL_ARB_direct_state_access"]        = "-1";


### PR DESCRIPTION
Follow up to https://github.com/PCSX2/pcsx2/commit/5b91dc45e0d51647ee45e95161b7e92dcbd53932
Move GL_ARB_copy_image to optional for OpenGL SW render.
It will allow Ivy Bridge to work with OpenGL SW as it's not required.

Sandy Bridge is not yet tested , would be nice if someone could test.

Improves #1716