### PR TITLE
GSdx: Move/add GT4 CRC

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -137,6 +137,7 @@ CRC::Game CRC::m_games[] =
 	{0x29C28734, ICO, CH, 0},
 	{0xAEAD1CA3, GT4, JP, 0},
 	{0x30E41D93, GT4, KO, 0},
+	{0x715CF2EC, GT4, EU, 0},
 	{0x44A61C8F, GT4, EU, 0},
 	{0x0086E35B, GT4, EU, 0},
 	{0x77E61C8A, GT4, US, 0},

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -1370,13 +1370,18 @@ bool GSC_GT4(const GSFrameInfo& fi, int& skip)
 	// Game requires to extract source from RT (block boundary) (texture cache limitation)
 	if(skip == 0)
 	{
-		if(fi.TME && fi.FBP >= 0x02f00 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01180 /*|| fi.TBP0 == 0x01a40*/) && fi.TPSM == PSM_PSMT8) //TBP0 0x1a40 progressive
+		if(Aggressive)
 		{
-			skip = 770;	//ntsc, progressive 1540
-		}
-		if(g_crc_region == CRC::EU && fi.TME && fi.FBP >= 0x03400 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01400 ) && fi.TPSM == PSM_PSMT8)
-		{
-			skip = 880;	//pal
+			// Removes layer obscuring the screen when the in-game brightness or contrast setting is set to any value but 0.
+			// The hack can cause VRAM/RAM spikes when both brightness and contrast settings are set to 0.
+			if(fi.TME && fi.FBP >= 0x02f00 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01180 /*|| fi.TBP0 == 0x01a40*/) && fi.TPSM == PSM_PSMT8) //TBP0 0x1a40 progressive
+			{
+			skip = 770;	// ntsc, progressive 1540
+			}
+			if(g_crc_region == CRC::EU && fi.TME && fi.FBP >= 0x03400 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01400 ) && fi.TPSM == PSM_PSMT8)
+			{
+			skip = 880;	// pal
+			}
 		}
 		else if(fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x01400) && fi.FPSM == PSM_PSMCT24 && fi.TBP0 >= 0x03420 && fi.TPSM == PSM_PSMT8)
 		{
@@ -2561,8 +2566,8 @@ void GSState::SetupCrcHack()
 		lut[CRC::StarWarsBattlefront] = GSC_StarWarsBattlefront;
 		// Dedicated shader for channel effect
 		lut[CRC::TouristTrophy] = GSC_TouristTrophy;
-		lut[CRC::GT3] = GSC_GT3;
 		lut[CRC::GT4] = GSC_GT4;
+		lut[CRC::GT3] = GSC_GT3;
 		lut[CRC::GTConcept] = GSC_GTConcept;
 		lut[CRC::TalesOfAbyss] = GSC_TalesOfAbyss;
 		lut[CRC::Tekken5] = GSC_Tekken5;


### PR DESCRIPTION
Removed a crc hw hack that caused vram spikes on GT4 when using the Full
CRC hack level. Vram spikes should be greatly reduced now when using
Full hack level (Recomended for Direct3D).
Testing is welcomed for the vram spikes.

Added missing CRC game version for GT4 pal.

Note: The issue might be the same on GT3 and GTConcept , the code might
need to be removed for those games as well. Needs to be tested.