### PR TITLE
Debugger: Make memory view row size configurable

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -413,12 +413,15 @@ struct Pcsx2Config
 		BITFIELD32()
 			bool
 				ShowDebuggerOnStart	:1;
+			bool
+				AlignMemoryWindowStart :1;
 		BITFIELD_END
 
 		u8 FontWidth;
 		u8 FontHeight;
 		u32 WindowWidth;
 		u32 WindowHeight;
+		u32 MemoryViewBytesPerRow;
 
 		DebugOptions();
 		void LoadSave( IniInterface& conf );
@@ -426,7 +429,7 @@ struct Pcsx2Config
 		bool operator ==( const DebugOptions& right ) const
 		{
 			return OpEqu( bitset ) && OpEqu( FontWidth ) && OpEqu( FontHeight )
-				&& OpEqu( WindowWidth ) && OpEqu( WindowHeight );
+				&& OpEqu( WindowWidth ) && OpEqu( WindowHeight ) && OpEqu( MemoryViewBytesPerRow );
 		}
 
 		bool operator !=( const DebugOptions& right ) const

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -374,10 +374,12 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 Pcsx2Config::DebugOptions::DebugOptions()
 {
 	ShowDebuggerOnStart = false;
+	AlignMemoryWindowStart = true;
 	FontWidth = 8;
 	FontHeight = 12;
 	WindowWidth = 0;
 	WindowHeight = 0;
+	MemoryViewBytesPerRow = 16;
 }
 
 void Pcsx2Config::DebugOptions::LoadSave( IniInterface& ini )
@@ -385,10 +387,12 @@ void Pcsx2Config::DebugOptions::LoadSave( IniInterface& ini )
 	ScopedIniGroup path( ini, L"Debugger" );
 
 	IniBitBool( ShowDebuggerOnStart );
-	IniBitfield(FontWidth);
-	IniBitfield(FontHeight);
-	IniBitfield(WindowWidth);
-	IniBitfield(WindowHeight);
+	IniBitBool( AlignMemoryWindowStart );
+	IniBitfield( FontWidth );
+	IniBitfield( FontHeight );
+	IniBitfield( WindowWidth );
+	IniBitfield( WindowHeight );
+	IniBitfield( MemoryViewBytesPerRow );
 }
 
 

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -74,9 +74,8 @@ CtrlMemView::CtrlMemView(wxWindow* parent, DebugInterface* _cpu)
 	selectedNibble = 0;
 	addressStart = charWidth;
 	hexStart = addressStart + 9*charWidth;
-	alignWindowStart = true;
 
-	setRowSize(32);
+	setRowSize(g_Conf->EmuOptions.Debugger.MemoryViewBytesPerRow);
 
 	font = pxGetFixedFont(8);
 	underlineFont = pxGetFixedFont(8, wxFONTWEIGHT_NORMAL, true);
@@ -103,7 +102,7 @@ CtrlMemView::CtrlMemView(wxWindow* parent, DebugInterface* _cpu)
 	menu.Enable(ID_MEMVIEW_DUMP,false);
 	menu.AppendSeparator();
 	menu.AppendCheckItem(ID_MEMVIEW_ALIGNWINDOW, L"Align window to row size");
-	menu.Check(ID_MEMVIEW_ALIGNWINDOW, alignWindowStart);
+	menu.Check(ID_MEMVIEW_ALIGNWINDOW, g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart);
 	menu.Bind(wxEVT_MENU, &CtrlMemView::onPopupClick, this);
 
 	SetScrollbar(wxVERTICAL,100,1,201,true);
@@ -397,7 +396,8 @@ void CtrlMemView::onPopupClick(wxCommandEvent& evt)
 		}
 		break;
 	case ID_MEMVIEW_ALIGNWINDOW:
-		if (alignWindowStart = evt.IsChecked()) {
+		g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart = evt.IsChecked();
+		if (g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart) {
 			windowStart -= windowStart % rowSize;
 			redraw();
 		}
@@ -431,7 +431,7 @@ void CtrlMemView::mouseEvent(wxMouseEvent& evt)
 		menu.Enable(ID_MEMVIEW_COPYVALUE_32,(curAddress & 3) == 0);
 		menu.Enable(ID_MEMVIEW_COPYVALUE_16,(curAddress & 1) == 0);
 
-		menu.Check(ID_MEMVIEW_ALIGNWINDOW, alignWindowStart);
+		menu.Check(ID_MEMVIEW_ALIGNWINDOW, g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart);
 
 		PopupMenu(&menu);
 		return;
@@ -659,7 +659,7 @@ void CtrlMemView::gotoAddress(u32 addr, bool pushInHistory)
 	curAddress = addr;
 	selectedNibble = 0;
 
-	if (alignWindowStart) {
+	if (g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart) {
 		int visibleRows = GetClientSize().y / rowHeight;
 		u32 windowEnd = windowStart + visibleRows*rowSize;
 

--- a/pcsx2/gui/Debugger/CtrlMemView.h
+++ b/pcsx2/gui/Debugger/CtrlMemView.h
@@ -51,7 +51,6 @@ private:
 	int rowHeight;
 	int charWidth;
 	u32 windowStart;
-	bool alignWindowStart;
 	u32 curAddress; // current selected address
 	u32 referencedAddress; // refrenced by register
 	u32 byteGroupSize;


### PR DESCRIPTION
This makes the row size of the memory view configurable. Previously it was hard coded to 32 by #1663, which required you to have a very wide debug window if you wanted to actually see the ASCII part of the memory view. The value is read from the ini file. Another setting added by that pull request is also permanently remembered now.