### PR TITLE
Debugger: Align functions to up to 16 bytes

### DIFF
--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -294,7 +294,7 @@ namespace MIPSAnalyst
 			if (end) {
 				// most functions are aligned to 8 or 16 bytes
 				// add the padding to this one
-				if (((addr+8) % 8)  && r5900Debug.read32(addr+8) == 0)
+				while (((addr+8) % 16)  && r5900Debug.read32(addr+8) == 0)
 					addr += 4;
 
 				currentFunction.end = addr + 4;


### PR DESCRIPTION
Some games actually align their functions to multiples of 16 bytes. This wasn't caught previously, and they would often start with two nops as a result. In that case preexisting label names couldn't be matched with the newly found function either.