### PR TITLE
GSdx: Move CRC hacks

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -331,7 +331,6 @@ CRC::Game CRC::m_games[] =
 	{0x306CDADA, CastlevaniaLoI, EU, 0},
 	{0xA36CFF6C, CastlevaniaLoI, JP, 0},
 	{0x9A93FE5D, CastlevaniaLoI, KO, 0},
-	{0xA79B0491, NanoBreaker, JP, 0},
 	{0x7985D894, FinalFightStreetwise, US, 0}, 
 	{0xED4BF0D3, FinalFightStreetwise, US, 0}, // cutie comment
 	{0x73C560BA, FinalFightStreetwise, EU, 0},
@@ -370,9 +369,6 @@ CRC::Game CRC::m_games[] =
 	{0xB3A9F9ED, Black, JP, 0},
 	{0x7838882F, VF4, JP, 0},
 	{0xEA131B57, VF4, US, 0},
-	{0x44A5FA15, FFVIIDoC, US, 0},
-	{0x33F7D21A, FFVIIDoC, EU, 0},
-	{0xAFAC88EF, FFVIIDoC, JP, 0},
 	{0x879CDA5E, StarWarsForceUnleashed, US, 0},
 	{0x137C792E, StarWarsForceUnleashed, US, 0},
 	{0x503BF9E1, StarWarsBattlefront, NoRegion, 0},  // EU and US versions have the same CRC
@@ -409,6 +405,7 @@ CRC::Game CRC::m_games[] =
 	{0x43AB7214, TalesOfLegendia, US, 0},
 	{0x1F8640E0, TalesOfLegendia, JP, 0},
 	{0xE4F5DA2B, TalesOfLegendia, KO, 0},
+	{0xA79B0491, NanoBreaker, JP, 0},
 	{0x98C7B76D, NanoBreaker, US, 0},
 	{0x7098BE76, NanoBreaker, KO, 0},
 	{0x9B89F425, NanoBreaker, EU, 0},

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -53,7 +53,6 @@ public:
 		DuelSaviorDestiny,
 		EternalPoison,
 		EvangelionJo,
-		FFVIIDoC,
 		FFX,
 		FFX2,
 		FFXII,

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -629,23 +629,6 @@ bool GSC_TombRaiderUnderWorld(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_FFVIIDoC(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(fi.TME && fi.FBP == 0x01c00 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x02c00 && fi.TPSM == PSM_PSMCT24)
-		{
-			skip = 1;
-		}
-		if(!fi.TME && fi.FBP == 0x01c00 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x01c00 && fi.TPSM == PSM_PSMCT24)
-		{
-			//skip = 1;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_DevilMayCry3(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -2443,7 +2426,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::DevilMayCry3] = GSC_DevilMayCry3;
 		lut[CRC::EternalPoison] = GSC_EternalPoison;
 		lut[CRC::EvangelionJo] = GSC_EvangelionJo;
-		lut[CRC::FFVIIDoC] = GSC_FFVIIDoC;
 		lut[CRC::FightingBeautyWulong] = GSC_FightingBeautyWulong;
 		lut[CRC::FinalFightStreetwise] = GSC_FinalFightStreetwise;
 		lut[CRC::FrontMission5] = GSC_FrontMission5;

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -943,19 +943,6 @@ bool GSC_ShinOnimusha(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_GetaWay(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if((fi.FBP ==0 || fi.FBP ==0x1180)&& fi.TPSM == PSM_PSMT8H && fi.FBMSK == 0)
-		{
-			skip = 1;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_SakuraWarsSoLongMyLove(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1235,30 +1222,26 @@ bool GSC_HauntingGround(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_NanoBreaker(const GSFrameInfo& fi, int& skip)
+bool GSC_GetaWay(const GSFrameInfo& fi, int& skip)
 {
-	if(skip == 0)
+	if (skip == 0)
 	{
-		if(fi.TME && fi.FBP == 0x0 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x03800 || fi.TBP0 == 0x03900) && fi.TPSM == PSM_PSMCT16S)
+		if ((fi.FBP == 0 || fi.FBP == 0x1180) && fi.TPSM == PSM_PSMT8H && fi.FBMSK == 0)
 		{
-			skip = 2;
+			skip = 1; // US version only. Removes fog wall.
 		}
 	}
 
 	return true;
 }
 
-bool GSC_ResidentEvil4(const GSFrameInfo& fi, int& skip)
+bool GSC_NanoBreaker(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
-		if(fi.TME && fi.FBP == 0x03100 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x01c00 && fi.TPSM == PSM_PSMZ24)
+		if(fi.TME && fi.FBP == 0x0 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x03800 || fi.TBP0 == 0x03900) && fi.TPSM == PSM_PSMCT16S)
 		{
-			skip = 176;
-		}
-		else if(fi.TME && fi.FBP ==0x03100 && (fi.TBP0==0x2a00 ||fi.TBP0==0x3480) && fi.TPSM == PSM_PSMCT32 && fi.FBMSK == 0)
-		{
-			skip = 1;
+			skip = 2; // Removes shadows
 		}
 	}
 
@@ -2137,7 +2120,7 @@ bool GSC_AceCombat4(const GSFrameInfo& fi, int& skip)
 		}
 		/*else if (fi.TME && fi.FBP == 0x02900 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x00000 && fi.TPSM == PSM_PSMCT24)
 		{
-		skip = 28; // blur, (seems applied by to above hack)
+		skip = 28; // blur (seems applied by the above hack)
 		}*/
 	}
 
@@ -2259,6 +2242,23 @@ bool GSC_FFX(const GSFrameInfo& fi, int& skip)
 			}
 		}
 	}
+	return true;
+}
+
+bool GSC_ResidentEvil4(const GSFrameInfo& fi, int& skip)
+{
+	if (Aggressive && skip == 0)
+	{
+		if (fi.TME && fi.FBP == 0x03100 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x01c00 && fi.TPSM == PSM_PSMZ24)
+		{
+			skip = 176; // Removes fog, but no longer required, does offer a decent speed boost.
+		}
+		else if (fi.TME && fi.FBP == 0x03100 && (fi.TBP0 == 0x2a00 || fi.TBP0 == 0x3480) && fi.TPSM == PSM_PSMCT32 && fi.FBMSK == 0)
+		{
+			//skip = 1; // Disabled as it doesn't seem to fix any issue, doesn't offer a further speed boost, and it creates an offset regression in fire effects.
+		}
+	}
+
 	return true;
 }
 
@@ -2448,8 +2448,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::FinalFightStreetwise] = GSC_FinalFightStreetwise;
 		lut[CRC::FrontMission5] = GSC_FrontMission5;
 		lut[CRC::Genji] = GSC_Genji;
-		lut[CRC::GetaWayBlackMonday] = GSC_GetaWay;
-		lut[CRC::GetaWay] = GSC_GetaWay;
 		lut[CRC::GiTS] = GSC_GiTS;
 		lut[CRC::GodHand] = GSC_GodHand;
 		lut[CRC::HeavyMetalThunder] = GSC_HeavyMetalThunder;
@@ -2495,6 +2493,7 @@ void GSState::SetupCrcHack()
 		lut[CRC::StarOcean3] = GSC_StarOcean3;
 		lut[CRC::ValkyrieProfile2] = GSC_ValkyrieProfile2;
 		// Only Aggressive
+		lut[CRC::ResidentEvil4] = GSC_ResidentEvil4;
 		lut[CRC::FFX2] = GSC_FFX2;
 		lut[CRC::FFX] = GSC_FFX;
 		lut[CRC::FFXII] = GSC_FFXII;
@@ -2514,7 +2513,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::ICO] = GSC_ICO;
 		lut[CRC::LordOfTheRingsTwoTowers] = GSC_LordOfTheRingsTwoTowers;
 		lut[CRC::Okami] = GSC_Okami;
-		lut[CRC::ResidentEvil4] = GSC_ResidentEvil4;
 		lut[CRC::SimpsonsGame] = GSC_SimpsonsGame;
 		lut[CRC::SuikodenTactics] = GSC_SuikodenTactics;
 		lut[CRC::XE3] = GSC_XE3;
@@ -2569,6 +2567,10 @@ void GSState::SetupCrcHack()
 
 		// RW frame buffer. UserHacks_AutoFlush allow to emulate it correctly
 		lut[CRC::GTASanAndreas] = GSC_GTASanAndreas;
+
+		// Can be fixed by setting Blending Unit Accuracy to at least High.
+		lut[CRC::GetaWayBlackMonday] = GSC_GetaWay;
+		lut[CRC::GetaWay] = GSC_GetaWay;
 
 		// Accumulation blend
 		lut[CRC::NanoBreaker] = GSC_NanoBreaker;


### PR DESCRIPTION
Moves Resident Evil 4 hack to Aggressive level as it is no longer required to fix any issues, but does offer a decent speed boost.

Moves The Getaway CRC hack to Full level, as the issue can be resolved when using the OpenGL Hardware renderer.