### PR TITLE
gsdx: port X11 GLX/EGL to XCB/X11 GLX/EGL

### DIFF
--- a/plugins/GSdx/GSWnd.cpp
+++ b/plugins/GSdx/GSWnd.cpp
@@ -23,6 +23,11 @@
 #include "stdafx.h"
 #include "GSWnd.h"
 
+#if defined(__unix__)
+#include <X11/Xlib-xcb.h>
+#include <X11/Xlib.h>
+#endif
+
 void GSWndGL::PopulateGlFunction()
 {
 	*(void**)&(gl_BlendColor) = GetProcAddress("glBlendColor");
@@ -187,3 +192,17 @@ void GSWndGL::PopulateGlFunction()
 	if (!GLLoader::check_gl_supported_extension())
 		throw GSDXRecoverableError();
 }
+
+#if defined(__unix__)
+
+xcb_connection_t *GSWndGL::GetConnection_XCB()
+{
+	return m_xcb_connection;
+}
+
+void GSWndGL::SetConnection_XCB(void* display)
+{
+	m_xcb_connection = XGetXCBConnection((Display *)display);
+}
+
+#endif

--- a/plugins/GSdx/GSWnd.h
+++ b/plugins/GSdx/GSWnd.h
@@ -25,6 +25,10 @@
 #include "GSdx.h"
 #include "GSVector.h"
 
+#if defined(__unix__)
+#include <xcb/xcb.h>
+#endif
+
 class GSWnd
 {
 protected:
@@ -63,8 +67,19 @@ protected:
 
 	bool IsContextAttached() const { return m_ctx_attached; }
 
+#if defined(__unix__)
+	xcb_connection_t *m_xcb_connection;
+
+	xcb_connection_t *GetConnection_XCB();
+	void SetConnection_XCB(void* display);
+#endif
+
 public:
-	GSWndGL() : m_ctx_attached(false) {};
+	GSWndGL() : m_ctx_attached(false) {
+#if defined(__unix__)
+		m_xcb_connection = nullptr;
+#endif
+	}
 	virtual ~GSWndGL() {};
 
 	virtual bool Create(const string& title, int w, int h) = 0;

--- a/plugins/GSdx/GSWndEGL.cpp
+++ b/plugins/GSdx/GSWndEGL.cpp
@@ -132,6 +132,7 @@ bool GSWndEGL::Attach(void* handle, bool managed)
 	m_managed = managed;
 
 	m_NativeDisplay = XOpenDisplay(NULL);
+	SetConnection_XCB(m_NativeDisplay);
 	OpenEGLDisplay();
 
 	CreateContext(3, 3);
@@ -165,30 +166,41 @@ bool GSWndEGL::Create(const string& title, int w, int h)
 	if(m_NativeWindow)
 		throw GSDXRecoverableError();
 
+	const int depth = 0, x = 0, y = 0, border_width = 1;
+	m_managed = true;
+
 	if(w <= 0 || h <= 0) {
 		w = theApp.GetConfigI("ModeWidth");
 		h = theApp.GetConfigI("ModeHeight");
 	}
 
-	m_managed = true;
-
-	// note this part must be only executed when replaying .gs debug file
 	m_NativeDisplay = XOpenDisplay(NULL);
+	SetConnection_XCB(m_NativeDisplay);
 	OpenEGLDisplay();
 
-	m_NativeWindow = XCreateSimpleWindow(m_NativeDisplay, DefaultRootWindow(m_NativeDisplay), 0, 0, w, h, 0, 0, 0);
-	XMapWindow (m_NativeDisplay, m_NativeWindow);
+	auto c = GetConnection_XCB();
+
+	const xcb_setup_t *setup = xcb_get_setup(c);
+
+	xcb_screen_t *screen = (xcb_setup_roots_iterator (setup)).data;
+
+	m_NativeWindow = xcb_generate_id(c);
+
+	xcb_create_window (c, depth, m_NativeWindow, screen->root, x, y, w, h,
+			border_width, InputOutput, screen->root_visual, 0, nullptr);
+
+	xcb_map_window (c, m_NativeWindow);
+
+	xcb_flush(c);
+
+	if (m_NativeWindow == 0)
+		throw GSDXRecoverableError();
 
 	CreateContext(3, 3);
 
 	AttachContext();
 
-	CheckContext();
-
 	PopulateGlFunction();
-
-	if (m_NativeWindow == 0)
-		throw GSDXRecoverableError();
 
 	return true;
 }
@@ -212,17 +224,14 @@ void* GSWndEGL::GetDisplay()
 
 GSVector4i GSWndEGL::GetClientRect()
 {
-	unsigned int h = 480;
-	unsigned int w = 640;
+	auto c = GetConnection_XCB();
 
-	unsigned int borderDummy;
-	unsigned int depthDummy;
-	Window winDummy;
-    int xDummy;
-    int yDummy;
+	xcb_get_geometry_reply_t *g = xcb_get_geometry_reply(c, xcb_get_geometry(c, m_NativeWindow), nullptr);
 
-	if (!m_NativeDisplay) m_NativeDisplay = XOpenDisplay(NULL);
-	XGetGeometry(m_NativeDisplay, m_NativeWindow, &winDummy, &xDummy, &yDummy, &w, &h, &borderDummy, &depthDummy);
+	uint16_t h = g->height;
+	uint16_t w = g->width;
+
+	free(g);
 
 	return GSVector4i(0, 0, (int)w, (int)h);
 }
@@ -234,17 +243,13 @@ bool GSWndEGL::SetWindowText(const char* title)
 {
 	if (!m_managed) return true;
 
-	XTextProperty prop;
+	auto c = GetConnection_XCB();
 
-	memset(&prop, 0, sizeof(prop));
+	xcb_change_property(c, XCB_PROP_MODE_REPLACE, m_NativeWindow,
+                       XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8,
+                       strlen (title), title);
 
-	char* ptitle = (char*)title;
-	if (XStringListToTextProperty(&ptitle, 1, &prop)) {
-		XSetWMName(m_NativeDisplay, m_NativeWindow, &prop);
-	}
-
-	XFree(prop.value);
-	XFlush(m_NativeDisplay);
+	xcb_flush(c);
 
 	return true;
 }
@@ -263,14 +268,10 @@ void GSWndEGL::Flip()
 
 void GSWndEGL::Show()
 {
-	XMapRaised(m_NativeDisplay, m_NativeWindow);
-	XFlush(m_NativeDisplay);
 }
 
 void GSWndEGL::Hide()
 {
-	XUnmapWindow(m_NativeDisplay, m_NativeWindow);
-	XFlush(m_NativeDisplay);
 }
 
 void GSWndEGL::HideFrame()

--- a/plugins/GSdx/GSWndOGL.h
+++ b/plugins/GSdx/GSWndOGL.h
@@ -23,6 +23,7 @@
 
 #if defined(__unix__)
 #include <X11/Xlib.h>
+#include <X11/Xlib-xcb.h>
 #include <GL/glx.h>
 
 class GSWndOGL final : public GSWndGL


### PR DESCRIPTION
Unfortunately there is a strong connection between GLX and X11
so only half the code is ported to XCB

At least the ported stuff is thread safe (which is better for MT driver)

After the 1.6 release, we will drop GLX in favor of EGL.
Then it will be easier to port the remaining code.

Edit: oups I forget to remove the old XInitThread commented code