### PR TITLE
pcsx2: Fix commandline options

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -495,11 +495,8 @@ bool Pcsx2App::OnInit()
 
 		if( Startup.SysAutoRun )
 		{
-			// Notes: Saving/remembering the Iso file is probably fine and desired, so using
-			// SysUpdateIsoSrcFile is good(ish).
-			// Saving the cdvd plugin override isn't desirable, so we don't assign it into g_Conf.
-
 			g_Conf->EmuOptions.UseBOOT2Injection = !Startup.NoFastBoot;
+			g_Conf->CdvdSource = Startup.CdvdSource;
 			SysUpdateIsoSrcFile( Startup.IsoFile );
 			sApp.SysExecute( Startup.CdvdSource );
 		}

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -370,6 +370,12 @@ bool Pcsx2App::OnCmdLineParsed( wxCmdLineParser& parser )
 		Startup.SysAutoRun	= true;
 	}
 
+	if (parser.Found(L"nodisc"))
+	{
+		Startup.CdvdSource = CDVD_SourceType::NoDisc;
+		Startup.SysAutoRun = true;
+	}
+
 	return true;
 }
 

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -503,7 +503,8 @@ bool Pcsx2App::OnInit()
 		{
 			g_Conf->EmuOptions.UseBOOT2Injection = !Startup.NoFastBoot;
 			g_Conf->CdvdSource = Startup.CdvdSource;
-			SysUpdateIsoSrcFile( Startup.IsoFile );
+			if (Startup.CdvdSource == CDVD_SourceType::Iso)
+				SysUpdateIsoSrcFile( Startup.IsoFile );
 			sApp.SysExecute( Startup.CdvdSource );
 		}
 		else if ( Startup.SysAutoRunElf )


### PR DESCRIPTION
Changes:
 * Fixes #1099
 * Fixes the --nodisc commandline option
 * EDIT: Prevent the current ISO from being cleared if not autorunning an ISO from the command line