### PR TITLE
PCSX2: Scaling Types / 16:9 FMV aspect ratio switch

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -280,6 +280,7 @@ void CALLBACK GSreset();
 //deprecated: GSgetTitleInfo was used in PCSX2 but no plugin supported it prior to r4070:
 //void CALLBACK GSgetTitleInfo( char dest[128] );
 void CALLBACK GSgetTitleInfo2(char *dest, size_t length);
+void CALLBACK GSgetImageSize(int *frame_w, int *frame_h);
 void CALLBACK GSwriteCSR(u32 value);
 s32 CALLBACK GSfreeze(int mode, freezeData *data);
 void CALLBACK GSconfigure();
@@ -585,6 +586,7 @@ typedef void(CALLBACK *_GSinitReadFIFO2)(u64 *pMem, int qwc);
 
 typedef void(CALLBACK *_GSchangeSaveState)(int, const char *filename);
 typedef void(CALLBACK *_GSgetTitleInfo2)(char *dest, size_t length);
+typedef void(CALLBACK *_GSgetImageSize)(int *frame_w, int *frame_h);
 typedef void(CALLBACK *_GSirqCallback)(void (*callback)());
 typedef void(CALLBACK *_GSsetBaseMem)(void *);
 typedef void(CALLBACK *_GSsetGameCRC)(int, int);
@@ -744,6 +746,7 @@ extern _GSinitReadFIFO2 GSinitReadFIFO2;
 
 extern _GSchangeSaveState GSchangeSaveState;
 extern _GSgetTitleInfo2 GSgetTitleInfo2;
+extern _GSgetImageSize GSgetImageSize;
 extern _GSmakeSnapshot GSmakeSnapshot;
 extern _GSmakeSnapshot2 GSmakeSnapshot2;
 extern _GSirqCallback GSirqCallback;

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -409,7 +409,7 @@ static __ri void ipuBDEC(tIPU_CMD_BDEC bdec)
 
 static __fi bool ipuVDEC(u32 val)
 {
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.FMVAspectRatioSwitch != FMV_AspectRatio_Switch_Off) {
 		static int count = 0;
 		if (count++ > 5) {
 			if (!FMVstarted) {

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -171,6 +171,7 @@ _GSinitReadFIFO    GSinitReadFIFO;
 _GSinitReadFIFO2   GSinitReadFIFO2;
 _GSchangeSaveState GSchangeSaveState;
 _GSgetTitleInfo2   GSgetTitleInfo2;
+_GSgetImageSize    GSgetImageSize;
 _GSmakeSnapshot	   GSmakeSnapshot;
 _GSmakeSnapshot2   GSmakeSnapshot2;
 _GSirqCallback 	   GSirqCallback;
@@ -423,6 +424,7 @@ static const LegacyApi_OptMethod s_MethMessOpt_GS[] =
 	{	"GSinitReadFIFO",	(vMeth**)&GSinitReadFIFO	},
 	{	"GSinitReadFIFO2",	(vMeth**)&GSinitReadFIFO2	},
 	{	"GSgifTransfer1",	(vMeth**)&GSgifTransfer1	},
+	{	"GSgetImageSize",	(vMeth**)&GSgetImageSize	},
 	{ NULL }
 };
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -839,6 +839,7 @@ AppConfig::GSWindowOptions::GSWindowOptions()
 	DisableScreenSaver		= true;
 
 	AspectRatio				= AspectRatio_4_3;
+	FMVAspectRatioSwitch	= FMV_AspectRatio_Switch_Off;
 	Zoom					= 100;
 	StretchY				= 100;
 	OffsetX					= 0;
@@ -852,7 +853,6 @@ AppConfig::GSWindowOptions::GSWindowOptions()
 	EnableVsyncWindowFlag	= false;
 
 	IsToggleFullscreenOnDoubleClick = true;
-	IsToggleAspectRatioSwitch = false;
 }
 
 void AppConfig::GSWindowOptions::SanityCheck()
@@ -891,7 +891,6 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 	IniEntry( EnableVsyncWindowFlag );
 
 	IniEntry( IsToggleFullscreenOnDoubleClick );
-	IniEntry( IsToggleAspectRatioSwitch );
 
 	static const wxChar* AspectRatioNames[] =
 	{
@@ -916,6 +915,17 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 	};
 
 	ini.EnumEntry(L"ScalingType", ScalingType, ScalingTypeNames, ScalingType);
+
+	static const wxChar* FMVAspectRatioSwitchNames[] =
+	{
+		L"Off",
+		L"4:3",
+		L"16:9",
+		// WARNING: array must be NULL terminated to compute it size
+		NULL
+	};
+
+	ini.EnumEntry(L"FMVAspectRatioSwitch", FMVAspectRatioSwitch, FMVAspectRatioSwitchNames, FMVAspectRatioSwitch);
 
 	IniEntry(Zoom);
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -835,6 +835,7 @@ AppConfig::GSWindowOptions::GSWindowOptions()
 	CloseOnEsc				= true;
 	DefaultToFullscreen		= false;
 	AlwaysHideMouse			= false;
+	DisableScalingCompensation = false;
 	DisableResizeBorders	= false;
 	DisableScreenSaver		= true;
 
@@ -881,6 +882,7 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 	IniEntry( CloseOnEsc );
 	IniEntry( DefaultToFullscreen );
 	IniEntry( AlwaysHideMouse );
+	IniEntry( DisableScalingCompensation );
 	IniEntry( DisableResizeBorders );
 	IniEntry( DisableScreenSaver );
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -843,6 +843,7 @@ AppConfig::GSWindowOptions::GSWindowOptions()
 	StretchY				= 100;
 	OffsetX					= 0;
 	OffsetY					= 0;
+	ScalingType				= ScalingType_Fit;
 
 	WindowSize				= wxSize( 640, 480 );
 	WindowPos				= wxDefaultPosition;
@@ -897,12 +898,26 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 		L"Stretch",
 		L"4:3",
 		L"16:9",
+		L"Frame",
 		// WARNING: array must be NULL terminated to compute it size
 		NULL
 	};
 
 	ini.EnumEntry( L"AspectRatio", AspectRatio, AspectRatioNames, AspectRatio );
-	IniEntry( Zoom );
+
+	static const wxChar* ScalingTypeNames[] =
+	{
+		L"Fill",
+		L"Fit",
+		L"Integer",
+		L"Centered",
+		// WARNING: array must be NULL terminated to compute its size
+		NULL
+	};
+
+	ini.EnumEntry(L"ScalingType", ScalingType, ScalingTypeNames, ScalingType);
+
+	IniEntry(Zoom);
 
 	if( ini.IsLoading() ) SanityCheck();
 }

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -108,6 +108,14 @@ enum ScalingTypes
 	ScalingType_MaxCount
 };
 
+enum FMVAspectRatioSwitchType
+{
+	FMV_AspectRatio_Switch_4_3,
+	FMV_AspectRatio_Switch_16_9,
+	FMV_AspectRatio_Switch_Off,
+	FMV_AspectRatio_Switch_MaxCount
+};
+
 enum MemoryCardType
 {
 	MemoryCard_None,
@@ -217,6 +225,7 @@ public:
 		bool		DisableScreenSaver;
 
 		AspectRatioType AspectRatio;
+		FMVAspectRatioSwitchType FMVAspectRatioSwitch;
 		Fixed100	Zoom;
 		Fixed100	StretchY;
 		Fixed100	OffsetX;
@@ -231,7 +240,6 @@ public:
 		bool		EnableVsyncWindowFlag;
 
 		bool		IsToggleFullscreenOnDoubleClick;
-		bool		IsToggleAspectRatioSwitch;
 
 		GSWindowOptions();
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -221,6 +221,7 @@ public:
 
 		bool		DefaultToFullscreen;
 		bool		AlwaysHideMouse;
+		bool		DisableScalingCompensation;
 		bool		DisableResizeBorders;
 		bool		DisableScreenSaver;
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -96,7 +96,16 @@ enum AspectRatioType
 	AspectRatio_Stretch,
 	AspectRatio_4_3,
 	AspectRatio_16_9,
+	AspectRatio_Frame,
 	AspectRatio_MaxCount
+};
+
+enum ScalingTypes
+{
+	ScalingType_Fit,
+	ScalingType_Integer,
+	ScalingType_Centered,
+	ScalingType_MaxCount
 };
 
 enum MemoryCardType
@@ -201,7 +210,7 @@ public:
 	{
 		// Closes the GS/Video port on escape (good for fullscreen activity)
 		bool		CloseOnEsc;
-		
+
 		bool		DefaultToFullscreen;
 		bool		AlwaysHideMouse;
 		bool		DisableResizeBorders;
@@ -213,6 +222,7 @@ public:
 		Fixed100	OffsetX;
 		Fixed100	OffsetY;
 
+		ScalingTypes	ScalingType;
 
 		wxSize		WindowSize;
 		wxPoint		WindowPos;

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -517,7 +517,7 @@ extern bool EnableFMV;
 
 void DoFmvSwitch(bool on)
 {
-	if (g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if (g_Conf->GSWindow.FMVAspectRatioSwitch != FMV_AspectRatio_Switch_Off) {
 		if (on) {
 			switchAR = true;
 			iniAR = g_Conf->GSWindow.AspectRatio;
@@ -546,7 +546,7 @@ void Pcsx2App::LogicalVsync()
 
 	FpsManager.DoFrame();
 	
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.FMVAspectRatioSwitch != FMV_AspectRatio_Switch_Off) {
 		if (EnableFMV) {
 			DevCon.Warning("FMV on");
 			DoFmvSwitch(true);

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -180,8 +180,12 @@ void GSPanel::DoResize()
 			targetAr = 16.0 / 9.0;
 		else if (Aspect_Ratio == AspectRatio_Frame)
 			targetAr = acceptedImageSize ? (double)s_image_width / s_image_height : 4.0 / 3.0;
-	} else {
-		targetAr = 4.0 / 3.0;
+	} else if (switchAR) {
+		if (g_Conf->GSWindow.FMVAspectRatioSwitch == FMV_AspectRatio_Switch_16_9 && Aspect_Ratio != AspectRatio_4_3) {
+			targetAr = 16.0 / 9.0;
+		} else {
+			targetAr = 4.0 / 3.0;
+		}
 	}
 
 	double arr = targetAr / clientAr;

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -1,6 +1,5 @@
-
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -177,17 +177,39 @@ namespace Implementations
 	{
 		AspectRatioType& art = g_Conf->GSWindow.AspectRatio;
 		const char *arts = "Not modified";
-		if (art == AspectRatio_Stretch && switchAR) //avoids a double 4:3 when coming from FMV aspect ratio switch
+		if (art == AspectRatio_Stretch && switchAR) // avoids a double 4:3 when coming from FMV aspect ratio switch
 			art = AspectRatio_4_3;
 		switch( art )
 		{
-			case AspectRatio_Stretch:	art = AspectRatio_4_3; arts = "4:3"; break;
-			case AspectRatio_4_3:		art = AspectRatio_16_9; arts = "16:9"; break;
-			case AspectRatio_16_9:		art = AspectRatio_Stretch; arts = "Stretch"; break;
+			case AspectRatio_Stretch:	art = AspectRatio_4_3;		arts = "4:3"; break;
+			case AspectRatio_4_3:		art = AspectRatio_16_9;		arts = "16:9"; break;
+			case AspectRatio_16_9:		art = AspectRatio_Frame;	arts = "Frame"; break;
+			case AspectRatio_Frame:		art = AspectRatio_Stretch;	arts = "Stretch"; break;
 			default: break;
 		}
 
 		OSDlog(Color_StrongBlue, true, "(GSwindow) Aspect ratio: %s", arts);
+		UpdateImagePosition();
+	}
+
+	void GSwindow_CycleScalingType()
+	{
+		if (g_Conf->GSWindow.AspectRatio == AspectRatio_Stretch) {
+			OSDlog(Color_StrongBlue, true, "(GSwindow) Scaling Types are locked under \"Stretch\" aspect ratio");
+			return;
+		}
+
+		ScalingTypes& st = g_Conf->GSWindow.ScalingType;
+		const char *sts = "Not modified";
+		switch (st)
+		{
+			case ScalingType_Fit:		st = ScalingType_Integer;	sts = "Integer"; break;
+			case ScalingType_Integer:	st = ScalingType_Centered;	sts = "Centered"; break;
+			case ScalingType_Centered:	st = ScalingType_Fit;		sts = "Fit"; break;
+			default: break;
+		}
+
+		OSDlog(Color_StrongBlue, true, "(GSwindow) Scaling Type: %s", sts);
 		UpdateImagePosition();
 	}
 
@@ -537,6 +559,13 @@ static const GlobalCommandDescriptor CommandDeclarations[] =
 
 	{	"GSwindow_CycleAspectRatio",
 		Implementations::GSwindow_CycleAspectRatio,
+		NULL,
+		NULL,
+		true,
+	},
+
+	{	"GSwindow_CycleScalingType",
+		Implementations::GSwindow_CycleScalingType,
 		NULL,
 		NULL,
 		true,

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -267,6 +267,7 @@ namespace Panels
 	{
 	protected:
 		wxComboBox*		m_combo_AspectRatio;
+		wxComboBox*		m_combo_ScalingType;
 		wxComboBox*		m_combo_vsync;
 
 		wxTextCtrl*		m_text_Zoom;
@@ -291,6 +292,8 @@ namespace Panels
 
 		wxTextCtrl*		m_text_WindowWidth;
 		wxTextCtrl*		m_text_WindowHeight;
+
+		void ScalingTypeChanged(wxCommandEvent &event);
 
 	public:
 		GSWindowSettingsPanel( wxWindow* parent );

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -288,6 +288,7 @@ namespace Panels
 		//pxCheckBox*		m_check_ExclusiveFS;
 
 		pxCheckBox*		m_check_HideMouse;
+		pxCheckBox*		m_check_ScalingCompensation;
 		pxCheckBox*		m_check_DclickFullscreen;
 
 		wxTextCtrl*		m_text_WindowWidth;

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -268,6 +268,7 @@ namespace Panels
 	protected:
 		wxComboBox*		m_combo_AspectRatio;
 		wxComboBox*		m_combo_ScalingType;
+		wxComboBox*		m_combo_FMVAspectRatioSwitch;
 		wxComboBox*		m_combo_vsync;
 
 		wxTextCtrl*		m_text_Zoom;
@@ -288,7 +289,6 @@ namespace Panels
 
 		pxCheckBox*		m_check_HideMouse;
 		pxCheckBox*		m_check_DclickFullscreen;
-		pxCheckBox*		m_check_AspectRatioSwitch;
 
 		wxTextCtrl*		m_text_WindowWidth;
 		wxTextCtrl*		m_text_WindowHeight;

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -77,6 +77,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 
 	m_check_SizeLock	= new pxCheckBox( this, _("Disable window resize border") );
 	m_check_HideMouse	= new pxCheckBox( this, _("Always hide mouse cursor") );
+	m_check_ScalingCompensation = new pxCheckBox(this, _("Disable Scaling Type height compensation"));
 	m_check_CloseGS		= new pxCheckBox( this, _("Hide window when paused") );
 	m_check_Fullscreen	= new pxCheckBox( this, _("Default to fullscreen mode on open") );
 	m_check_DclickFullscreen = new pxCheckBox( this, _("Double-click toggles fullscreen mode") );
@@ -112,6 +113,10 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	m_check_HideMouse->SetToolTip(pxEt(L"Check this to force the mouse cursor invisible inside the GS window; "
 										L"useful if using the mouse as a primary control device for gaming. "
 										L"By default the mouse auto-hides after 2 seconds of inactivity."));
+
+	m_check_ScalingCompensation->SetToolTip(pxEt(L"Don't let Scaling Types compensate(double) the height for games that put out an image "
+												L"that is half as high as displayed. This will half the height for some games. Only for purists.\n\n"
+												L"NOTE: Only available when \"Frame\" Aspect Ratio or \"Integer\" or \"Centered\" Scaling Type is selected."));
 
 	m_check_Fullscreen->SetToolTip(pxEt(L"Enables automatic mode switch to fullscreen when starting or resuming emulation. "
 										L"You can still toggle fullscreen display at any time using alt-enter."));
@@ -157,6 +162,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	*this += m_check_SizeLock;
 	*this += m_check_HideMouse;
 	*this += m_check_CloseGS;
+	*this += m_check_ScalingCompensation;
 	*this += new wxStaticLine( this )	| StdExpand();
 
 	*this += m_check_Fullscreen;
@@ -198,6 +204,10 @@ void Panels::GSWindowSettingsPanel::ApplyConfigToGui( AppConfig& configToApply, 
 		m_check_SizeLock->SetValue(conf.DisableResizeBorders);
 		m_check_HideMouse->SetValue(conf.AlwaysHideMouse);
 		m_check_CloseGS->SetValue(conf.CloseOnEsc);
+		m_check_ScalingCompensation->SetValue(conf.DisableScalingCompensation);
+		m_check_ScalingCompensation->Enable((conf.AspectRatio != AspectRatio_Stretch &&
+											conf.ScalingType != ScalingType_Fit) ||
+											conf.AspectRatio == AspectRatio_Frame);
 
 		m_check_Fullscreen->SetValue(conf.DefaultToFullscreen);
 		m_check_DclickFullscreen->SetValue(conf.IsToggleFullscreenOnDoubleClick);
@@ -210,6 +220,8 @@ void Panels::GSWindowSettingsPanel::ApplyConfigToGui( AppConfig& configToApply, 
 void Panels::GSWindowSettingsPanel::ScalingTypeChanged(wxCommandEvent &event)
 {
 	m_combo_ScalingType->Enable(m_combo_AspectRatio->GetSelection() != 0);
+	m_check_ScalingCompensation->Enable((m_combo_AspectRatio->GetSelection() != 0 &&
+		m_combo_ScalingType->GetSelection() != 0) || m_combo_AspectRatio->GetSelection() == 3);
 	m_combo_FMVAspectRatioSwitch->Enable(m_combo_AspectRatio->GetSelection() != 1);
 
 	event.Skip();
@@ -228,6 +240,7 @@ void Panels::GSWindowSettingsPanel::Apply()
 	appconf.DisableResizeBorders = m_check_SizeLock->GetValue();
 	appconf.AlwaysHideMouse = m_check_HideMouse->GetValue();
 	appconf.CloseOnEsc = m_check_CloseGS->GetValue();
+	appconf.DisableScalingCompensation = m_check_ScalingCompensation->GetValue();
 
 	appconf.DefaultToFullscreen = m_check_Fullscreen->GetValue();
 	appconf.IsToggleFullscreenOnDoubleClick = m_check_DclickFullscreen->GetValue();

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -27,9 +27,17 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 {
 	const wxString aspect_ratio_labels[] =
 	{
-		_("Fit to Window/Screen"),
+		_("Stretch to Window/Screen"),
 		_("Standard (4:3)"),
-		_("Widescreen (16:9)")
+		_("Widescreen (16:9)"),
+		_("Frame")
+	};
+
+	const wxString scaling_type_labels[] =
+	{
+		_("Fit to Window/Screen"),
+		_("Integer Scaling"),
+		_("Centered")
 	};
 
 	// Warning must match the order of the VsyncMode Enum
@@ -44,6 +52,9 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 
 	m_combo_AspectRatio	= new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
 		ArraySize(aspect_ratio_labels), aspect_ratio_labels, wxCB_READONLY );
+
+	m_combo_ScalingType = new wxComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+		ArraySize(scaling_type_labels), scaling_type_labels, wxCB_READONLY);
 
 	m_combo_vsync = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
 		ArraySize(vsync_label), vsync_label, wxCB_READONLY );
@@ -62,24 +73,40 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	m_check_AspectRatioSwitch = new pxCheckBox(this, _("Switch to 4:3 aspect ratio when an FMV plays"));
 	//m_check_ExclusiveFS = new pxCheckBox( this, _("Use exclusive fullscreen mode (if available)") );
 
-	m_text_Zoom->SetToolTip( pxEt( L"Zoom = 100: Fit the entire image to the window without any cropping.\nAbove/Below 100: Zoom In/Out\n0: Automatic-Zoom-In untill the black-bars are gone (Aspect ratio is kept, some of the image goes out of screen).\n  NOTE: Some games draw their own black-bars, which will not be removed with '0'.\n\nKeyboard: CTRL + NUMPAD-PLUS: Zoom-In, CTRL + NUMPAD-MINUS: Zoom-Out, CTRL + NUMPAD-*: Toggle 100/0"
-	) );
+	m_combo_AspectRatio->SetToolTip(pxEt(L"Stretch: Stretches the image to the window/screen size.\n\n"
+										L"4:3: Keeps the aspect ratio to 4:3, the default aspect ratio used by the PS2.\n\n"
+										L"16:9: Sets the aspect ratio to widescreen 16:9, the ratio used by games when "
+										L"a widescreen option or a normal widescreen patch is enabled.\n\n"
+										L"Frame: Uses the aspect ratio of the frame size of the game, to keep a 1:1 pixel ratio.\n\n"
+										L"NOTE: Using the widescreen 16:9 aspect ratio will result in a stretched image unless "
+										L"widescreen is enabled in-game or through a widescreen patch. "
+										L"Widescreen is not available for all games."));
 
-	m_combo_vsync->SetToolTip( pxEt( L"Vsync eliminates screen tearing but typically has a big performance hit. It usually only applies to fullscreen mode, and may not work with all GS plugins."
-	) );
+	m_combo_ScalingType->SetToolTip(pxEt(L"Fit: Scales the image width and/or height to the window/screen size depending on the selected aspect ratio.\n\n"
+										L"Integer Scaling: Scales the image to the highest integer magnification of the selected aspect ratio that "
+										L"fits within the window/screen.\n\n"
+										L"Centered: Displays the image at the native size used by the game, as long as it fits within the window/screen."));
 
-	m_check_HideMouse->SetToolTip( pxEt( L"Check this to force the mouse cursor invisible inside the GS window; useful if using the mouse as a primary control device for gaming.  By default the mouse auto-hides after 2 seconds of inactivity."
-	) );
+	m_text_Zoom->SetToolTip(pxEt(L"Zoom = 100: Fit the entire image to the window without any cropping.\nZoom above or below 100: Zoom in or out\n\n"
+								L"Zoom = 0: Automatic zoom in until the black bars are gone (aspect ratio is kept, some of the image goes out of screen).\n\n"
+								L"NOTE: Some games draw their own black bars, which will not be removed with '0'.\n\n"
+								L"Keyboard shortcuts: CTRL + NUMPAD-PLUS: Zoom in, CTRL + NUMPAD-MINUS: Zoom out, CTRL + NUMPAD-*: Toggle 100/0"));
 
-	m_check_Fullscreen->SetToolTip( pxEt( L"Enables automatic mode switch to fullscreen when starting or resuming emulation. You can still toggle fullscreen display at any time using alt-enter."
-	) );
+	m_combo_vsync->SetToolTip(pxEt(L"Vsync eliminates screen tearing but typically has a big performance hit. "
+									L"It usually only applies to fullscreen mode, and may not work with all GS plugins."));
+
+	m_check_HideMouse->SetToolTip(pxEt(L"Check this to force the mouse cursor invisible inside the GS window; "
+										L"useful if using the mouse as a primary control device for gaming. "
+										L"By default the mouse auto-hides after 2 seconds of inactivity."));
+
+	m_check_Fullscreen->SetToolTip(pxEt(L"Enables automatic mode switch to fullscreen when starting or resuming emulation. "
+										L"You can still toggle fullscreen display at any time using alt-enter."));
 
 /*
 	m_check_ExclusiveFS->SetToolTip( pxEt( L"Fullscreen Exclusive Mode may look better on older CRTs and might be a little faster on older video cards, but typically can lead to memory leaks or random crashes when entering/leaving fullscreen mode."
 	) );
 */
-	m_check_CloseGS->SetToolTip( pxEt( L"Completely closes the often large and bulky GS window when pressing ESC or pausing the emulator."
-	) );
+	m_check_CloseGS->SetToolTip(pxEt(L"Completely closes the often large and bulky GS window when pressing ESC or pausing the emulator."));
 
 	// ----------------------------------------------------------------------------
 	//  Layout and Positioning
@@ -93,10 +120,12 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	//s_AspectRatio.AddGrowableCol( 0 );
 	s_AspectRatio.AddGrowableCol( 1 );
 
-	s_AspectRatio += Label(_("Aspect Ratio:"))		| pxMiddle;
-	s_AspectRatio += m_combo_AspectRatio			| pxExpand;
-	s_AspectRatio += Label(_("Custom Window Size:"))| pxMiddle;
-	s_AspectRatio += s_customsize					| pxAlignRight;
+	s_AspectRatio += Label(_("Scaling Type:"))				| pxMiddle;
+	s_AspectRatio += m_combo_ScalingType					| pxExpand;
+	s_AspectRatio += Label(_("Aspect Ratio:"))				| pxMiddle;
+	s_AspectRatio += m_combo_AspectRatio					| pxExpand;
+	s_AspectRatio += Label(_("Custom Window Size:"))		| pxMiddle;
+	s_AspectRatio += s_customsize							| pxAlignRight;
 
 	s_AspectRatio	+= Label(_("Zoom:"))			| StdExpand();
 	s_AspectRatio	+= m_text_Zoom;
@@ -108,6 +137,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	s_vsync += m_combo_vsync      			| pxExpand;
 
 	*this += s_AspectRatio				| StdExpand();
+	*this += new wxStaticLine(this)		| StdExpand();
 	*this += m_check_SizeLock;
 	*this += m_check_HideMouse;
 	*this += m_check_CloseGS;
@@ -126,6 +156,8 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	*centerSizer += GetSizer()	| pxCenter;
 	SetSizer( centerSizer, false );
 
+	Bind(wxEVT_COMBOBOX, &Panels::GSWindowSettingsPanel::ScalingTypeChanged, this);
+
 	AppStatusEvent_OnSettingsApplied();
 }
 
@@ -136,27 +168,35 @@ void Panels::GSWindowSettingsPanel::AppStatusEvent_OnSettingsApplied()
 
 void Panels::GSWindowSettingsPanel::ApplyConfigToGui( AppConfig& configToApply, int flags )
 {
-	const AppConfig::GSWindowOptions& conf( configToApply.GSWindow );
+	const AppConfig::GSWindowOptions &conf(configToApply.GSWindow);
 
-	if( !(flags & AppConfig::APPLY_FLAG_FROM_PRESET) )	
-	{//Presets don't control these values
-		m_check_CloseGS		->SetValue( conf.CloseOnEsc );
-		m_check_Fullscreen	->SetValue( conf.DefaultToFullscreen );
-		m_check_HideMouse	->SetValue( conf.AlwaysHideMouse );
-		m_check_SizeLock	->SetValue( conf.DisableResizeBorders );
+	if (!(flags & AppConfig::APPLY_FLAG_FROM_PRESET)) { // Presets don't control these values
+		m_check_CloseGS->SetValue(conf.CloseOnEsc);
+		m_check_Fullscreen->SetValue(conf.DefaultToFullscreen);
+		m_check_HideMouse->SetValue(conf.AlwaysHideMouse);
+		m_check_SizeLock->SetValue(conf.DisableResizeBorders);
 
-		m_combo_AspectRatio	->SetSelection( (int)conf.AspectRatio );
-		m_text_Zoom			->ChangeValue( conf.Zoom.ToString() );
+		m_combo_AspectRatio->SetSelection(enum_cast(conf.AspectRatio));
+		m_text_Zoom->ChangeValue(conf.Zoom.ToString());
+		m_combo_ScalingType->SetSelection(enum_cast(conf.ScalingType));
+		m_combo_ScalingType->Enable(conf.AspectRatio != AspectRatio_Stretch);
 
-		m_check_DclickFullscreen ->SetValue( conf.IsToggleFullscreenOnDoubleClick );
-		m_check_AspectRatioSwitch->SetValue( conf.IsToggleAspectRatioSwitch );
+		m_check_AspectRatioSwitch->SetValue(conf.IsToggleAspectRatioSwitch);
+		m_check_DclickFullscreen->SetValue(conf.IsToggleFullscreenOnDoubleClick);
 
-		m_text_WindowWidth	->ChangeValue( wxsFormat( L"%d", conf.WindowSize.GetWidth() ) );
-		m_text_WindowHeight	->ChangeValue( wxsFormat( L"%d", conf.WindowSize.GetHeight() ) );
+		m_text_WindowWidth->ChangeValue(wxsFormat(L"%d", conf.WindowSize.GetWidth()));
+		m_text_WindowHeight->ChangeValue(wxsFormat(L"%d", conf.WindowSize.GetHeight()));
 	}
 
 	m_combo_vsync->SetSelection(enum_cast(configToApply.EmuOptions.GS.VsyncEnable));
-	m_combo_vsync->Enable( !configToApply.EnablePresets );//grayed-out when presets are enabled
+	m_combo_vsync->Enable(!configToApply.EnablePresets); // grayed-out when presets are enabled
+}
+
+void Panels::GSWindowSettingsPanel::ScalingTypeChanged(wxCommandEvent &event)
+{
+	m_combo_ScalingType->Enable(m_combo_AspectRatio->GetSelection() != 0);
+
+	event.Skip();
 }
 
 void Panels::GSWindowSettingsPanel::Apply()
@@ -164,13 +204,15 @@ void Panels::GSWindowSettingsPanel::Apply()
 	AppConfig::GSWindowOptions& appconf( g_Conf->GSWindow );
 	Pcsx2Config::GSOptions& gsconf( g_Conf->EmuOptions.GS );
 
-	appconf.CloseOnEsc				= m_check_CloseGS	->GetValue();
-	appconf.DefaultToFullscreen		= m_check_Fullscreen->GetValue();
-	appconf.AlwaysHideMouse			= m_check_HideMouse	->GetValue();
-	appconf.DisableResizeBorders	= m_check_SizeLock	->GetValue();
+	appconf.CloseOnEsc = m_check_CloseGS->GetValue();
+	appconf.DefaultToFullscreen = m_check_Fullscreen->GetValue();
+	appconf.AlwaysHideMouse = m_check_HideMouse->GetValue();
+	appconf.DisableResizeBorders = m_check_SizeLock->GetValue();
 
-	appconf.AspectRatio		= (AspectRatioType)m_combo_AspectRatio->GetSelection();
-	appconf.Zoom			= Fixed100::FromString( m_text_Zoom->GetValue() );
+	appconf.AspectRatio = (AspectRatioType)m_combo_AspectRatio->GetSelection();
+	appconf.ScalingType = (ScalingTypes)m_combo_ScalingType->GetSelection();
+
+	appconf.Zoom = Fixed100::FromString(m_text_Zoom->GetValue());
 
 	gsconf.VsyncEnable = static_cast<VsyncMode>(m_combo_vsync->GetSelection());
 

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -1,4 +1,5 @@
 /*
+ *	Copyright (C) 2010-2018 PCSX2 Dev Team
  *	Copyright (C) 2007-2009 Gabest
  *	http://www.gabest.org
  *
@@ -945,7 +946,7 @@ EXPORT_C GSgetTitleInfo2(char* dest, size_t length)
 	s.append(s_renderer_name).append(s_renderer_type);
 
 	// TODO: this gets called from a different thread concurrently with GSOpen (on linux)
-	if (gsopen_done && s_gs != NULL && s_gs->m_GStitleInfoBuffer[0])
+	if (gsopen_done && s_gs != nullptr && s_gs->m_GStitleInfoBuffer[0])
 	{
 		std::lock_guard<std::mutex> lock(s_gs->m_pGSsetTitle_Crit);
 
@@ -958,6 +959,24 @@ EXPORT_C GSgetTitleInfo2(char* dest, size_t length)
 	}
 
 	strcpy(dest, s.c_str());
+}
+
+EXPORT_C GSgetImageSize(int *image_width, int *image_height)
+{
+	if (!gsopen_done || s_gs == nullptr)
+		return;
+
+	int en0 = s_gs->IsEnabled(0);
+	int en1 = s_gs->IsEnabled(1);
+	if (!en0 && !en1)
+		return;
+
+	// Disregard the disabled circuit. With full boot the BIOS will fill the disabled circuit with its own data.
+	// When both circuits are enabled use -1 to get the size of the merged frame rectangle.
+	int i = (en0 ^ en1) ? en1 : -1;
+
+	*image_width = s_gs->GetFrameRect(i).width();
+	*image_height = s_gs->GetFrameRect(i).height();
 }
 
 EXPORT_C GSsetFrameSkip(int frameskip)

--- a/plugins/GSdx/GSdx.def
+++ b/plugins/GSdx/GSdx.def
@@ -43,6 +43,7 @@ EXPORTS
 	GSReplay
 	GSBenchmark
 	GSgetTitleInfo2
+	GSgetImageSize
 	PSEgetLibType
 	PSEgetLibName
 	PSEgetLibVersion


### PR DESCRIPTION
- Adds Scaling Types

And adds a combo box(in Config > Emulation Settings > GS Window tab) to
select the scaling type.

Adds new "Centered" option to scale the image down to a centered image
at the native(1x) resolution used by the game.

And adds "Integer" option to scale to the maximum integer magnification
of the native image set by the game which fits within the window/screen.

Adds new aspect ratio "Frame" which sets the aspect ratio to that of the
native image used by the game.
Closes https://github.com/PCSX2/pcsx2/issues/1916

- Add 16:9 option for FMV aspect ratio switch

Adds combobox option to switch to 16:9 aspect ratio while an FMVs plays to fix
16:9 widescreen FMV's when using custom widescreen patches to play a
game at other aspect ratios than 4:3 or 16:9.

Close: #2114
  