### PR TITLE
PCSX2-WX: Add Manual ISO selection option

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -86,6 +86,7 @@ enum MenuIdentifiers
 	MenuId_Boot_Iso,			// Opens submenu with Iso browser, and recent isos.
 	MenuId_RecentIsos_reservedStart,
 	MenuId_IsoBrowse = MenuId_RecentIsos_reservedStart + 100,			// Open dialog, runs selected iso.
+	MenuId_Ask_On_Booting,
 	MenuId_Boot_CDVD,
 	MenuId_Boot_CDVD2,
 	MenuId_Boot_ELF,

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -670,6 +670,7 @@ void AppConfig::LoadSaveRootItems( IniInterface& ini )
 
 	IniEntry( EnablePresets );
 	IniEntry( PresetIndex );
+	IniEntry( AskOnBoot );
 	
 	#ifdef __WXMSW__
 	IniEntry( McdCompressNTFS );

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -535,7 +535,7 @@ AppConfig::AppConfig()
 {
 	LanguageId			= wxLANGUAGE_DEFAULT;
 	LanguageCode		= L"default";
-	RecentIsoCount		= 12;
+	RecentIsoCount		= 20;
 	Listbook_ImageSize	= 32;
 	Toolbar_ImageSize	= 24;
 	Toolbar_ShowLabels	= true;

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -315,6 +315,8 @@ public:
 	bool		EnablePresets;
 	int			PresetIndex;
 
+	bool		AskOnBoot;
+
 	wxString				CurrentIso;
 	wxString				CurrentELF;
 	wxString				CurrentIRX;

--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -63,7 +63,10 @@ const wxImage& LoadImageAny(
 RecentIsoList::RecentIsoList(int firstIdForMenuItems_or_wxID_ANY)
 {
 	Menu = std::unique_ptr<wxMenu>(new wxMenu());
-	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history.") );
+	Menu->AppendCheckItem( MenuId_Ask_On_Booting, _("Always ask when booting"), _("Manually select an ISO upon boot ignoring the selection from recent ISO list.") );
+	Menu->AppendSeparator();
+	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history."))->Enable(!g_Conf->AskOnBoot);
+	Menu->Check( MenuId_Ask_On_Booting, g_Conf->AskOnBoot );
 	Manager = std::unique_ptr<RecentIsoManager>(new RecentIsoManager( Menu.get(), firstIdForMenuItems_or_wxID_ANY ));
 }
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -209,6 +209,7 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_Iso);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_Plugin);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_NoDisc);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Ask_On_Boot_Click, this, MenuId_Ask_On_Booting);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Debug_CreateBlockdump_Click, this, MenuId_Debug_CreateBlockdump);
 
 	// Config

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -195,6 +195,7 @@ protected:
 	void Menu_Debug_MemoryDump_Click(wxCommandEvent &event);
 	void Menu_Debug_Logging_Click(wxCommandEvent &event);
 	void Menu_Debug_CreateBlockdump_Click(wxCommandEvent &event);
+	void Menu_Ask_On_Boot_Click(wxCommandEvent &event);
 
 	void Menu_ShowConsole(wxCommandEvent &event);
 	void Menu_ChangeLang(wxCommandEvent &event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -331,7 +331,7 @@ void MainEmuFrame::_DoBootCdvd()
 			selector = true;
 		}
 
-		if( selector )
+		if( selector || g_Conf->AskOnBoot)
 		{
 			wxString result;
 			if( !_DoSelectIsoBrowser( result ) )
@@ -410,6 +410,17 @@ void MainEmuFrame::Menu_IsoBrowse_Click( wxCommandEvent &event )
 	
 	SwapOrReset_Iso(this, core, isofile, GetMsg_IsoImageChanged());
 	AppSaveSettings();		// save the new iso selection; update menus!
+}
+
+void MainEmuFrame::Menu_Ask_On_Boot_Click(wxCommandEvent &event)
+{
+	g_Conf->AskOnBoot = event.IsChecked();
+
+	if (SysHasValidState())
+		return;
+
+	wxGetApp().GetRecentIsoManager().EnableItems(!event.IsChecked());
+	FindItemInMenuBar(MenuId_IsoBrowse)->Enable(!event.IsChecked());
 }
 
 void MainEmuFrame::Menu_Debug_CreateBlockdump_Click(wxCommandEvent &event)

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -171,13 +171,16 @@ void RecentIsoManager::InsertIntoMenu( int id )
 		wxid = this->m_firstIdForMenuItems_or_wxID_ANY + id;
 
 	curitem.ItemPtr = m_Menu->AppendRadioItem( wxid, Path::GetFilename(curitem.Filename), curitem.Filename );
-	bool exists = wxFileExists( curitem.Filename );
+	curitem.ItemPtr->Enable(wxFileExists(curitem.Filename) && !g_Conf->AskOnBoot);
+}
 
-	if( m_cursel == id && exists )
-		curitem.ItemPtr->Check();
-
-	if ( !exists )
-		curitem.ItemPtr->Enable( false );
+void RecentIsoManager::EnableItems(bool display)
+{
+	for (const auto& list : m_Items)
+	{
+		// Files which don't exist still need to be grayed out.
+		list.ItemPtr->Enable(display && wxFileExists(list.Filename));
+	}
 }
 
 void RecentIsoManager::LoadListFrom( IniInterface& ini )

--- a/pcsx2/gui/RecentIsoList.h
+++ b/pcsx2/gui/RecentIsoList.h
@@ -53,6 +53,7 @@ public:
 	virtual ~RecentIsoManager() throw();
 
 	void RemoveAllFromMenu();
+	void EnableItems(bool display);
 	void Repopulate();
 	void Clear();
 	void Add( const wxString& src );

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -55,6 +55,8 @@ void UI_DisableSysShutdown()
 	if( wxGetApp().Rpc_TryInvokeAsync( &UI_DisableSysShutdown ) ) return;
 
 	sMainFrame.EnableMenuItem( MenuId_Sys_Shutdown, false );
+	sMainFrame.EnableMenuItem(MenuId_IsoBrowse, !g_Conf->AskOnBoot);
+	wxGetApp().GetRecentIsoManager().EnableItems(!g_Conf->AskOnBoot);
 }
 
 void UI_EnableSysShutdown()
@@ -79,6 +81,8 @@ void UI_EnableSysActions()
 	if( wxGetApp().Rpc_TryInvokeAsync( &UI_EnableSysActions ) ) return;
 
 	sMainFrame.EnableMenuItem( MenuId_Sys_Shutdown, true );
+	sMainFrame.EnableMenuItem(MenuId_IsoBrowse, true);
+	wxGetApp().GetRecentIsoManager().EnableItems(true);
 	
 	_SaveLoadStuff( true );
 }


### PR DESCRIPTION
**Summary of changes**:

* Add a ``Manual ISO selection`` option which allows you to select your ISO via the file explorer each time whenever you ``full/fast boot``. This one is for you @vsub ❤️ 

![newoption](https://snag.gy/VuxFBK.jpg)

PCSX2 by default only allows you to hold 12 ISOs in the recent ISO list and when you try to add anymore, the previous ones will replaced by your newer ISO selection. The only way to modify the total limit of ISOs capable of being stored in the recent ISO list is to change the value of an INI variable, obviously no end user would be aware of it.

Hence for people with large amount of ISOs in their storage devices, it would be ideal if they could just directly look for their ISOs instead of looking through the recent ISO list which is not capable of storing all of their games.

Another alternative would be to increase the default maximum no.of ISOs allowed in the recent ISO list but that would just make the list a bit larger and at one point it would even grow big enough to touch your taskbar! there's no possible way that the recent ISO list would be able to accommodate all the ISOs of say someone who has a collection of over 50+ games. Also it's not desirable behavior to go to ``CDVD`` -> ``ISO Selector`` -> ``Browse..`` to add individual ISOs each and ever single time. -_-

To avoid such issues, I'm proposing to add this option which would directly take you to the file explorer when you're doing a full/fast boot. Any opinion, guys?