### PR TITLE
Allow building the replayer with the legacy GSdx.

### DIFF
--- a/plugins/GSdx_legacy/CMakeLists.txt
+++ b/plugins/GSdx_legacy/CMakeLists.txt
@@ -218,11 +218,11 @@ else()
 endif()
 
 ################################### Replay Loader
-if(BUILD_REPLAY_LOADERS)
+if(BUILD_REPLAY_LOADERS AND NOT GSdx)
     set(Replay pcsx2_GSReplayLoader)
     set(GSdxReplayLoaderFinalSources
         ${GSdxFinalSources}
         linux_replay.cpp
     )
     add_pcsx2_executable(${Replay} "${GSdxReplayLoaderFinalSources}" "${GSdxFinalLibs}" "${GSdxFinalFlags}")
-endif(BUILD_REPLAY_LOADERS)
+endif()


### PR DESCRIPTION
It can be useful to build with `-DGSDX_LEGACY=ON` as the gsdx plugin can be switched in the gui configuration with ease and not everyone has the same hardware, however if PCSX2 is also built with `-DBUILD_REPLAY_LOADERS=TRUE` it will fail to configure the build.
```
CMake Error at cmake/Pcsx2Utils.cmake:130 (add_executable):
  add_executable cannot create target "pcsx2_GSReplayLoader" because another
  target with the same name already exists.  The existing target is an
  executable created in source directory "/tmp/SBo/pcsx2/plugins/GSdx".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  plugins/GSdx_legacy/CMakeLists.txt:227 (add_pcsx2_executable)


-- Configuring incomplete, errors occurred!
See also "/tmp/SBo/pcsx2/build/CMakeFiles/CMakeOutput.log".
```
The reason for this is because its trying to add `pcsx2_GSReplayLoader` from the cmake files for both the regular GSdx and the legacy GSdx.
```
$ grep -r pcsx2_GSReplayLoader
plugins/GSdx/CMakeLists.txt:    set(Replay pcsx2_GSReplayLoader)
plugins/GSdx_legacy/CMakeLists.txt:    set(Replay pcsx2_GSReplayLoader
```
Looking at `plugins/CMakeLists.txt` it looks like there will be no time that someone will build the legacy GSdx without the regular GSdx meaning that setting these targets for replayer seem largely redundant. I guess the check can be removed from the legacy cmake file, but in the even someone does build the legacy GSdx without the regular one it might be useful to just skip the check if `GSdx` is defined as will most likely be the case.

At the very least this allows the build to proceed normally and I was able to replay gs dumps with the replayer. Unless anyone has a better idea?