### PR TITLE
Greg/modernize use default

### DIFF
--- a/common/include/Utilities/Console.h
+++ b/common/include/Utilities/Console.h
@@ -189,7 +189,7 @@ public:
     // Constructor: The specified number of tabs will be appended to the current indentation
     // setting.  The tabs will be unrolled when the object leaves scope or is destroyed.
     ConsoleIndentScope(int tabs = 1);
-    virtual ~ConsoleIndentScope() throw();
+    virtual ~ConsoleIndentScope();
     void EnterScope();
     void LeaveScope();
 };
@@ -208,7 +208,7 @@ protected:
 
 public:
     ConsoleColorScope(ConsoleColors newcolor);
-    virtual ~ConsoleColorScope() throw();
+    virtual ~ConsoleColorScope();
     void EnterScope();
     void LeaveScope();
 };
@@ -228,7 +228,7 @@ protected:
 
 public:
     ConsoleAttrScope(ConsoleColors newcolor, int indent = 0);
-    virtual ~ConsoleAttrScope() throw();
+    virtual ~ConsoleAttrScope();
 };
 
 extern IConsoleWriter Console;

--- a/common/include/Utilities/Dependencies.h
+++ b/common/include/Utilities/Dependencies.h
@@ -153,7 +153,7 @@ public:
         m_boolme = &boolme;
     }
 
-    ~ScopedBool() throw()
+    ~ScopedBool()
     {
         *m_boolme = false;
     }

--- a/common/include/Utilities/EventSource.h
+++ b/common/include/Utilities/EventSource.h
@@ -49,7 +49,7 @@ public:
         m_cache_valid = false;
     }
 
-    virtual ~EventSource() throw() {}
+    virtual ~EventSource() = default;
 
     virtual ListenerIterator Add(ListenerType &listener);
     virtual void Remove(ListenerType &listener);
@@ -89,6 +89,6 @@ protected:
     IEventDispatcher() {}
 
 public:
-    virtual ~IEventDispatcher() throw() {}
+    virtual ~IEventDispatcher() = default;
     virtual void DispatchEvent(const EvtParams &params) = 0;
 };

--- a/common/include/Utilities/Exceptions.h
+++ b/common/include/Utilities/Exceptions.h
@@ -128,7 +128,7 @@ protected:
     wxString m_message; // a "detailed" message of what disastrous thing has occurred!
 
 public:
-    virtual ~Ps2Generic() throw() {}
+    virtual ~Ps2Generic() = default;
 
     virtual u32 GetPc() const = 0;
     virtual bool IsDelaySlot() const = 0;
@@ -157,7 +157,7 @@ private:                                             \
     typedef parent _parent;                          \
                                                      \
 public:                                              \
-    virtual ~classname() throw() {}                  \
+    virtual ~classname() = default;                  \
     virtual void Rethrow() const { throw * this; }   \
     virtual classname *Clone() const { return new classname(*this); }
 

--- a/common/include/Utilities/Exceptions.h
+++ b/common/include/Utilities/Exceptions.h
@@ -85,7 +85,7 @@ protected:
     wxString m_message_user; // (translated) a "detailed" message of what disastrous thing has occurred!
 
 public:
-    virtual ~BaseException() throw() = 0; // the =0; syntax forces this class into "abstract" mode.
+    virtual ~BaseException() = default;
 
     const wxString &DiagMsg() const { return m_message_diag; }
     const wxString &UserMsg() const { return m_message_user; }

--- a/common/include/Utilities/General.h
+++ b/common/include/Utilities/General.h
@@ -70,7 +70,7 @@ public:
 class IActionInvocation
 {
 public:
-    virtual ~IActionInvocation() throw() {}
+    virtual ~IActionInvocation() = default;
     virtual void InvokeAction() = 0;
 };
 
@@ -83,7 +83,7 @@ public:
 class IDeletableObject
 {
 public:
-    virtual ~IDeletableObject() throw() {}
+    virtual ~IDeletableObject() = default;
 
     virtual void DeleteSelf() = 0;
     virtual bool IsBeingDeleted() = 0;

--- a/common/include/Utilities/General.h
+++ b/common/include/Utilities/General.h
@@ -56,7 +56,7 @@ public:
         ++Counter;
     }
 
-    virtual ~RecursionGuard() throw()
+    virtual ~RecursionGuard()
     {
         --Counter;
     }
@@ -126,7 +126,7 @@ protected:
 
 public:
     BaseDeletableObject();
-    virtual ~BaseDeletableObject() throw();
+    virtual ~BaseDeletableObject();
 
     void DeleteSelf();
     bool IsBeingDeleted() { return !!m_IsBeingDeleted; }

--- a/common/include/Utilities/IniInterface.h
+++ b/common/include/Utilities/IniInterface.h
@@ -110,7 +110,7 @@ public:
 class IniLoader : public IniInterface
 {
 public:
-    virtual ~IniLoader() throw();
+    virtual ~IniLoader() = default;
     explicit IniLoader();
     explicit IniLoader(wxConfigBase &config);
     explicit IniLoader(wxConfigBase *config);
@@ -148,7 +148,7 @@ protected:
 class IniSaver : public IniInterface
 {
 public:
-    virtual ~IniSaver();
+    virtual ~IniSaver() = default;
     explicit IniSaver();
     explicit IniSaver(wxConfigBase &config);
     explicit IniSaver(wxConfigBase *config);

--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -67,7 +67,7 @@ class EventListener_PageFault : public IEventListener_PageFault
 {
 public:
     EventListener_PageFault();
-    virtual ~EventListener_PageFault() throw();
+    virtual ~EventListener_PageFault();
 };
 
 template <typename TypeToDispatchTo>
@@ -157,7 +157,7 @@ protected:
 
 public:
     VirtualMemoryReserve(const wxString &name = wxEmptyString, size_t size = 0);
-    virtual ~VirtualMemoryReserve() throw()
+    virtual ~VirtualMemoryReserve()
     {
         Release();
     }

--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -45,7 +45,7 @@ public:
     typedef PageFaultInfo EvtParams;
 
 public:
-    virtual ~IEventListener_PageFault() throw() {}
+    virtual ~IEventListener_PageFault() = default;
 
     virtual void DispatchEvent(const PageFaultInfo &evtinfo, bool &handled)
     {
@@ -87,7 +87,7 @@ public:
         Owner = dispatchTo;
     }
 
-    virtual ~EventListenerHelper_PageFault() throw() {}
+    virtual ~EventListenerHelper_PageFault() = default;
 
 protected:
     virtual void OnPageFaultEvent(const PageFaultInfo &info, bool &handled)
@@ -112,7 +112,7 @@ public:
         : m_handled(false)
     {
     }
-    virtual ~SrcType_PageFault() throw() {}
+    virtual ~SrcType_PageFault() = default;
 
     bool WasHandled() const { return m_handled; }
     virtual void Dispatch(const PageFaultInfo &params);

--- a/common/include/Utilities/PersistentThread.h
+++ b/common/include/Utilities/PersistentThread.h
@@ -39,7 +39,7 @@ public:
         m_thread = NULL;
     }
 
-    virtual ~EventListener_Thread() throw() {}
+    virtual ~EventListener_Thread() = default;
 
     void SetThread(pxThread &thr) { m_thread = &thr; }
     void SetThread(pxThread *thr) { m_thread = thr; }
@@ -250,7 +250,7 @@ protected:
     Mutex m_lock_TaskComplete;
 
 public:
-    virtual ~BaseTaskThread() throw() {}
+    virtual ~BaseTaskThread() = default;
     BaseTaskThread()
         : m_Done(false)
         , m_TaskPending(false)

--- a/common/include/Utilities/PersistentThread.h
+++ b/common/include/Utilities/PersistentThread.h
@@ -114,7 +114,7 @@ protected:
 
 
 public:
-    virtual ~pxThread() throw();
+    virtual ~pxThread();
     pxThread(const wxString &name = L"pxThread");
 
     pthread_t GetId() const { return m_thread; }

--- a/common/include/Utilities/RwMutex.h
+++ b/common/include/Utilities/RwMutex.h
@@ -31,7 +31,7 @@ protected:
 
 public:
     RwMutex();
-    virtual ~RwMutex() throw();
+    virtual ~RwMutex();
 
     virtual void AcquireRead();
     virtual void AcquireWrite();
@@ -58,7 +58,7 @@ public:
     {
     }
 
-    virtual ~BaseScopedReadWriteLock() throw();
+    virtual ~BaseScopedReadWriteLock();
 
     void Release();
     bool IsLocked() const { return m_IsLocked; }

--- a/common/include/Utilities/RwMutex.h
+++ b/common/include/Utilities/RwMutex.h
@@ -71,7 +71,7 @@ class ScopedReadLock : public BaseScopedReadWriteLock
 {
 public:
     ScopedReadLock(RwMutex &locker);
-    virtual ~ScopedReadLock() throw() {}
+    virtual ~ScopedReadLock() = default;
 
     void Acquire();
 };
@@ -80,7 +80,7 @@ class ScopedWriteLock : public BaseScopedReadWriteLock
 {
 public:
     ScopedWriteLock(RwMutex &locker);
-    virtual ~ScopedWriteLock() throw() {}
+    virtual ~ScopedWriteLock() = default;
 
     void Acquire();
 

--- a/common/include/Utilities/SafeArray.h
+++ b/common/include/Utilities/SafeArray.h
@@ -57,7 +57,7 @@ protected:
     T *_getPtr(uint i) const;
 
 public:
-    virtual ~SafeArray() throw();
+    virtual ~SafeArray();
 
     explicit SafeArray(const wxChar *name = L"Unnamed");
     explicit SafeArray(int initialSize, const wxChar *name = L"Unnamed");
@@ -137,7 +137,7 @@ protected:
     T *_getPtr(uint i) const;
 
 public:
-    virtual ~SafeList() throw();
+    virtual ~SafeList();
     explicit SafeList(const wxChar *name = L"Unnamed");
     explicit SafeList(int initialSize, const wxChar *name = L"Unnamed");
     virtual SafeList<T> *Clone() const;
@@ -203,7 +203,7 @@ protected:
 public:
     using _parent::operator[];
 
-    virtual ~SafeAlignedArray() throw();
+    virtual ~SafeAlignedArray();
 
     explicit SafeAlignedArray(const wxChar *name = L"Unnamed")
         : SafeArray<T>::SafeArray(name)

--- a/common/include/Utilities/SafeArray.inl
+++ b/common/include/Utilities/SafeArray.inl
@@ -55,7 +55,7 @@ T *SafeArray<T>::_virtual_realloc(int newsize)
 }
 
 template <typename T>
-SafeArray<T>::~SafeArray() throw()
+SafeArray<T>::~SafeArray()
 {
     safe_free(m_ptr);
 }
@@ -138,7 +138,7 @@ T *SafeAlignedArray<T, Alignment>::_virtual_realloc(int newsize)
 // Maybe useful,maybe not... no harm in attaching it. :D
 
 template <typename T, uint Alignment>
-SafeAlignedArray<T, Alignment>::~SafeAlignedArray() throw()
+SafeAlignedArray<T, Alignment>::~SafeAlignedArray()
 {
     safe_aligned_free(this->m_ptr);
     // mptr is set to null, so the parent class's destructor won't re-free it.
@@ -172,7 +172,7 @@ T *SafeList<T>::_virtual_realloc(int newsize)
 }
 
 template <typename T>
-SafeList<T>::~SafeList() throw()
+SafeList<T>::~SafeList()
 {
     safe_free(m_ptr);
 }

--- a/common/include/Utilities/ScopedAlloc.h
+++ b/common/include/Utilities/ScopedAlloc.h
@@ -103,7 +103,7 @@ public:
         m_size = 0;
     }
 
-    virtual ~BaseScopedAlloc() throw()
+    virtual ~BaseScopedAlloc()
     {
         //pxAssert(m_buffer==NULL);
     }
@@ -184,7 +184,7 @@ public:
         Alloc(size);
     }
 
-    virtual ~ScopedAlloc() throw()
+    virtual ~ScopedAlloc()
     {
         safe_free(this->m_buffer);
     }
@@ -234,7 +234,7 @@ public:
         Alloc(size);
     }
 
-    virtual ~ScopedAlignedAlloc() throw()
+    virtual ~ScopedAlignedAlloc()
     {
         safe_aligned_free(this->m_buffer);
     }

--- a/common/include/Utilities/ScopedPtrMT.h
+++ b/common/include/Utilities/ScopedPtrMT.h
@@ -39,7 +39,7 @@ public:
         m_ptr = ptr;
     }
 
-    ~ScopedPtrMT() throw() { _Delete_unlocked(); }
+    ~ScopedPtrMT() { _Delete_unlocked(); }
 
     ScopedPtrMT &Reassign(T *ptr = nullptr)
     {

--- a/common/include/Utilities/ScopedPtrMT.h
+++ b/common/include/Utilities/ScopedPtrMT.h
@@ -49,7 +49,7 @@ public:
         return *this;
     }
 
-    ScopedPtrMT &Delete() throw()
+    ScopedPtrMT &Delete() noexcept
     {
         ScopedLock lock(m_mtx);
         _Delete_unlocked();
@@ -87,19 +87,19 @@ public:
     // the wx/boost approach (which uses some bizarre member method pointer crap, and can't
     // allow the T* implicit casting.
 
-    bool operator!() const throw()
+    bool operator!() const noexcept
     {
         return m_ptr.load() == nullptr;
     }
 
     // Equality
-    bool operator==(T *pT) const throw()
+    bool operator==(T *pT) const noexcept
     {
         return m_ptr == pT;
     }
 
     // Inequality
-    bool operator!=(T *pT) const throw()
+    bool operator!=(T *pT) const noexcept
     {
         return !operator==(pT);
     }
@@ -133,7 +133,7 @@ public:
 #endif
 
 protected:
-    void _Delete_unlocked() throw()
+    void _Delete_unlocked() noexcept
     {
         delete m_ptr.exchange(nullptr);
     }

--- a/common/include/Utilities/StringHelpers.h
+++ b/common/include/Utilities/StringHelpers.h
@@ -144,7 +144,7 @@ protected:
 
 public:
     FastFormatAscii();
-    ~FastFormatAscii() throw();
+    ~FastFormatAscii() = default;
     FastFormatAscii &Write(const char *fmt, ...);
     FastFormatAscii &WriteV(const char *fmt, va_list argptr);
 
@@ -187,7 +187,7 @@ protected:
 
 public:
     FastFormatUnicode();
-    ~FastFormatUnicode() throw();
+    ~FastFormatUnicode() = default;
 
     FastFormatUnicode &Write(const char *fmt, ...);
     FastFormatUnicode &Write(const wxChar *fmt, ...);

--- a/common/include/Utilities/Threading.h
+++ b/common/include/Utilities/Threading.h
@@ -186,7 +186,7 @@ extern void Sleep(int ms);
 		pthread_mutex_t mutex;
 
 		WaitEvent();
-		~WaitEvent() throw();
+		~WaitEvent();
 
 		void Set();
 		void Wait();
@@ -243,7 +243,7 @@ protected:
 
 public:
     Semaphore();
-    virtual ~Semaphore() throw();
+    virtual ~Semaphore();
 
     void Reset();
     void Post();
@@ -266,7 +266,7 @@ protected:
 
 public:
     Mutex();
-    virtual ~Mutex() throw();
+    virtual ~Mutex();
     virtual bool IsRecursive() const { return false; }
 
     void Recreate();
@@ -295,7 +295,7 @@ class MutexRecursive : public Mutex
 {
 public:
     MutexRecursive();
-    virtual ~MutexRecursive() throw();
+    virtual ~MutexRecursive();
     virtual bool IsRecursive() const { return true; }
 };
 
@@ -327,7 +327,7 @@ protected:
     bool m_IsLocked;
 
 public:
-    virtual ~ScopedLock() throw();
+    virtual ~ScopedLock();
     explicit ScopedLock(const Mutex *locker = NULL);
     explicit ScopedLock(const Mutex &locker);
     void AssignAndLock(const Mutex &locker);
@@ -377,7 +377,7 @@ public:
     {
     }
 
-    virtual ~ScopedNonblockingLock() throw()
+    virtual ~ScopedNonblockingLock()
     {
         if (m_IsLocked)
             m_lock.Release();
@@ -404,7 +404,7 @@ struct ScopedLockBool
     {
         m_bool.store(m_lock.IsLocked(), std::memory_order_relaxed);
     }
-    virtual ~ScopedLockBool() throw()
+    virtual ~ScopedLockBool()
     {
         m_bool.store(false, std::memory_order_relaxed);
     }

--- a/common/include/Utilities/Threading.h
+++ b/common/include/Utilities/Threading.h
@@ -213,7 +213,7 @@ public:
     NonblockingMutex() { val.clear(); }
     virtual ~NonblockingMutex() = default;
 
-    bool TryAcquire() throw()
+    bool TryAcquire() noexcept
     {
         return !val.test_and_set();
     }

--- a/common/include/Utilities/Threading.h
+++ b/common/include/Utilities/Threading.h
@@ -211,7 +211,7 @@ protected:
 
 public:
     NonblockingMutex() { val.clear(); }
-    virtual ~NonblockingMutex() throw() {}
+    virtual ~NonblockingMutex() = default;
 
     bool TryAcquire() throw()
     {
@@ -353,7 +353,7 @@ public:
         : ScopedLock(locker, true)
     {
     }
-    virtual ~ScopedTryLock() throw() {}
+    virtual ~ScopedTryLock() = default;
     bool Failed() const { return !m_IsLocked; }
 };
 

--- a/common/include/Utilities/ThreadingDialogs.h
+++ b/common/include/Utilities/ThreadingDialogs.h
@@ -42,7 +42,7 @@ protected:
 
 public:
     WaitForTaskDialog(const wxString &title = wxEmptyString, const wxString &heading = wxEmptyString);
-    virtual ~WaitForTaskDialog() throw() {}
+    virtual ~WaitForTaskDialog() = default;
     virtual int ShowModal();
 
 protected:

--- a/common/include/Utilities/pxCheckBox.h
+++ b/common/include/Utilities/pxCheckBox.h
@@ -40,7 +40,7 @@ protected:
 public:
     pxCheckBox(wxWindow *parent, const wxString &label, const wxString &subtext = wxEmptyString, int flags = wxCHK_2STATE);
     pxCheckBox(wxWindow *parent, const wxString &label, int flags);
-    virtual ~pxCheckBox() throw() {}
+    virtual ~pxCheckBox() = default;
 
     bool HasSubText() const { return m_subtext != NULL; }
     const pxStaticText *GetSubText() const { return m_subtext; }

--- a/common/include/Utilities/pxEvents.h
+++ b/common/include/Utilities/pxEvents.h
@@ -42,7 +42,7 @@ public:
         return_value = 0;
     }
 
-    virtual ~SynchronousActionState() throw() {}
+    virtual ~SynchronousActionState() = default;
 
     void SetException(const BaseException &ex);
     void SetException(BaseException *ex);
@@ -99,7 +99,7 @@ protected:
     SynchronousActionState *m_state;
 
 public:
-    virtual ~pxActionEvent() throw() {}
+    virtual ~pxActionEvent() = default;
     virtual pxActionEvent *Clone() const { return new pxActionEvent(*this); }
 
     explicit pxActionEvent(SynchronousActionState *sema = NULL, int msgtype = pxEvt_InvokeAction);
@@ -172,7 +172,7 @@ protected:
     wxEventType m_realEvent;
 
 public:
-    virtual ~pxSynchronousCommandEvent() throw() {}
+    virtual ~pxSynchronousCommandEvent() = default;
     virtual pxSynchronousCommandEvent *Clone() const { return new pxSynchronousCommandEvent(*this); }
 
     pxSynchronousCommandEvent(SynchronousActionState *sema = NULL, wxEventType commandType = wxEVT_NULL, int winid = 0);
@@ -204,7 +204,7 @@ protected:
     wxString m_Content;
 
 public:
-    virtual ~BaseMessageBoxEvent() throw() {}
+    virtual ~BaseMessageBoxEvent() = default;
     virtual BaseMessageBoxEvent *Clone() const { return new BaseMessageBoxEvent(*this); }
 
     explicit BaseMessageBoxEvent(const wxString &content = wxEmptyString, SynchronousActionState *instdata = NULL);

--- a/common/include/Utilities/pxEvents.h
+++ b/common/include/Utilities/pxEvents.h
@@ -149,7 +149,7 @@ public:
 
     pxExceptionEvent(const BaseException &ex);
 
-    virtual ~pxExceptionEvent() throw()
+    virtual ~pxExceptionEvent()
     {
     }
 

--- a/common/include/Utilities/pxEvents.h
+++ b/common/include/Utilities/pxEvents.h
@@ -386,7 +386,7 @@ public:
     pxMessageBoxEvent() {}
     pxMessageBoxEvent(const wxString &title, const wxString &content, const MsgButtons &buttons, SynchronousActionState &instdata);
     pxMessageBoxEvent(const wxString &title, const wxString &content, const MsgButtons &buttons, SynchronousActionState *instdata = NULL);
-    pxMessageBoxEvent(const pxMessageBoxEvent &event);
+    pxMessageBoxEvent(const pxMessageBoxEvent &event) = default;
 
 protected:
     int _DoDialog() const;
@@ -409,7 +409,7 @@ public:
 
     pxAssertionEvent(const wxString &content = wxEmptyString, const wxString &trace = wxEmptyString, SynchronousActionState *instdata = NULL);
     pxAssertionEvent(const wxString &content, const wxString &trace, SynchronousActionState &instdata);
-    pxAssertionEvent(const pxAssertionEvent &event);
+    pxAssertionEvent(const pxAssertionEvent &event) = default;
 
     pxAssertionEvent &SetStacktrace(const wxString &trace);
 

--- a/common/include/Utilities/pxEvents.h
+++ b/common/include/Utilities/pxEvents.h
@@ -380,7 +380,7 @@ protected:
     MsgButtons m_Buttons;
 
 public:
-    virtual ~pxMessageBoxEvent() throw() {}
+    virtual ~pxMessageBoxEvent() = default;
     virtual pxMessageBoxEvent *Clone() const { return new pxMessageBoxEvent(*this); }
 
     pxMessageBoxEvent() {}
@@ -404,7 +404,7 @@ protected:
     wxString m_Stacktrace;
 
 public:
-    virtual ~pxAssertionEvent() throw() {}
+    virtual ~pxAssertionEvent() = default;
     virtual pxAssertionEvent *Clone() const { return new pxAssertionEvent(*this); }
 
     pxAssertionEvent(const wxString &content = wxEmptyString, const wxString &trace = wxEmptyString, SynchronousActionState *instdata = NULL);

--- a/common/include/Utilities/pxRadioPanel.h
+++ b/common/include/Utilities/pxRadioPanel.h
@@ -117,7 +117,7 @@ public:
         Init();
     }
 
-    virtual ~pxRadioPanel() throw() {}
+    virtual ~pxRadioPanel() = default;
 
     void Reset();
     void Realize();

--- a/common/include/Utilities/pxStaticText.h
+++ b/common/include/Utilities/pxStaticText.h
@@ -60,7 +60,7 @@ protected:
 public:
     pxStaticText(wxWindow *parent, const wxString &label, wxAlignment align = wxALIGN_CENTRE_HORIZONTAL);
     pxStaticText(wxWindow *parent, int heightInLines, const wxString &label, wxAlignment align = wxALIGN_CENTRE_HORIZONTAL);
-    virtual ~pxStaticText() throw() {}
+    virtual ~pxStaticText() = default;
 
     wxFont GetFontOk() const;
     bool Enable(bool enabled = true);
@@ -109,7 +109,7 @@ class pxStaticHeading : public pxStaticText
 public:
     pxStaticHeading(wxWindow *parent = NULL, const wxString &label = wxEmptyString);
     pxStaticHeading(wxWindow *parent, int heightInLines, const wxString &label = wxEmptyString);
-    virtual ~pxStaticHeading() throw() {}
+    virtual ~pxStaticHeading() = default;
 
 protected:
     void SetPaddingDefaults();

--- a/common/include/Utilities/pxStreams.h
+++ b/common/include/Utilities/pxStreams.h
@@ -33,7 +33,7 @@ protected:
 
 public:
     pxStreamBase(const wxString &filename);
-    virtual ~pxStreamBase() throw() {}
+    virtual ~pxStreamBase() = default;
 
     // Implementing classes should return the base wxStream object (usually either a wxInputStream
     // or wxOputStream derivative).
@@ -62,7 +62,7 @@ public:
     pxOutputStream(const wxString &filename, std::unique_ptr<wxOutputStream> &output);
     pxOutputStream(const wxString &filename, wxOutputStream *output);
 
-    virtual ~pxOutputStream() throw() {}
+    virtual ~pxOutputStream() = default;
     virtual void Write(const void *data, size_t size);
 
     void SetStream(const wxString &filename, std::unique_ptr<wxOutputStream> &stream);
@@ -96,7 +96,7 @@ public:
     pxInputStream(const wxString &filename, std::unique_ptr<wxInputStream> &input);
     pxInputStream(const wxString &filename, wxInputStream *input);
 
-    virtual ~pxInputStream() throw() {}
+    virtual ~pxInputStream() = default;
     virtual void Read(void *dest, size_t size);
 
     void SetStream(const wxString &filename, std::unique_ptr<wxInputStream> &stream);

--- a/common/include/Utilities/wxAppWithHelpers.h
+++ b/common/include/Utilities/wxAppWithHelpers.h
@@ -50,7 +50,7 @@ class ModalButtonPanel : public wxPanelWithHelpers
 {
 public:
     ModalButtonPanel(wxWindow *window, const MsgButtons &buttons);
-    virtual ~ModalButtonPanel() throw() {}
+    virtual ~ModalButtonPanel() = default;
 
     virtual void AddActionButton(wxWindowID id);
     virtual void AddCustomButton(wxWindowID id, const wxString &label);

--- a/common/include/Utilities/wxBaseTools.h
+++ b/common/include/Utilities/wxBaseTools.h
@@ -55,7 +55,7 @@ public:
         m_prev = wxLog::EnableLogging(false);
     }
 
-    virtual ~wxDoNotLogInThisScope() throw()
+    virtual ~wxDoNotLogInThisScope()
     {
         wxLog::EnableLogging(m_prev);
     }

--- a/common/include/Utilities/wxGuiTools.h
+++ b/common/include/Utilities/wxGuiTools.h
@@ -292,7 +292,7 @@ public:
     bool hasCloseBox;
 
 public:
-    virtual ~pxDialogCreationFlags() throw() {}
+    virtual ~pxDialogCreationFlags() = default;
 
     pxDialogCreationFlags()
     {
@@ -605,7 +605,7 @@ protected:
     wxString m_indent;
 
 public:
-    virtual ~pxTextWrapperBase() throw() {}
+    virtual ~pxTextWrapperBase() = default;
 
     pxTextWrapperBase(const wxString &indent = wxEmptyString)
         : m_indent(indent)
@@ -653,7 +653,7 @@ public:
     {
     }
 
-    virtual ~pxTextWrapper() throw() {}
+    virtual ~pxTextWrapper() = default;
 
     const wxString &GetResult() const
     {
@@ -686,7 +686,7 @@ protected:
 
 public:
     pxWindowTextWriter(wxDC &dc);
-    virtual ~pxWindowTextWriter() throw() {}
+    virtual ~pxWindowTextWriter() = default;
 
     virtual void OnFontChanged();
 
@@ -746,7 +746,7 @@ protected:
 
 public:
     MoreStockCursors() {}
-    virtual ~MoreStockCursors() throw() {}
+    virtual ~MoreStockCursors() = default;
     const wxCursor &GetArrowWait();
 };
 

--- a/common/include/Utilities/wxGuiTools.h
+++ b/common/include/Utilities/wxGuiTools.h
@@ -511,7 +511,7 @@ protected:
 public:
     wxDialogWithHelpers();
     wxDialogWithHelpers(wxWindow *parent, const wxString &title, const pxDialogCreationFlags &cflags = pxDialogCreationFlags());
-    virtual ~wxDialogWithHelpers() throw();
+    virtual ~wxDialogWithHelpers() = default;
 
     void Init(const pxDialogCreationFlags &cflags);
     void AddOkCancel(wxSizer &sizer, bool hasApply = false);

--- a/common/include/Utilities/wxGuiTools.h
+++ b/common/include/Utilities/wxGuiTools.h
@@ -772,7 +772,7 @@ protected:
 
 public:
     ScopedBusyCursor(BusyCursorType busytype);
-    virtual ~ScopedBusyCursor() throw();
+    virtual ~ScopedBusyCursor();
 
     static void SetDefault(BusyCursorType busytype);
     static void SetManualBusyCursor(BusyCursorType busytype);

--- a/common/src/Utilities/Console.cpp
+++ b/common/src/Utilities/Console.cpp
@@ -465,7 +465,7 @@ ConsoleColorScope::ConsoleColorScope(ConsoleColors newcolor)
     EnterScope();
 }
 
-ConsoleColorScope::~ConsoleColorScope() throw()
+ConsoleColorScope::~ConsoleColorScope()
 {
     LeaveScope();
 }
@@ -491,7 +491,7 @@ ConsoleIndentScope::ConsoleIndentScope(int tabs)
     EnterScope();
 }
 
-ConsoleIndentScope::~ConsoleIndentScope() throw()
+ConsoleIndentScope::~ConsoleIndentScope()
 {
     try {
         LeaveScope();
@@ -517,7 +517,7 @@ ConsoleAttrScope::ConsoleAttrScope(ConsoleColors newcolor, int indent)
     Console.SetColor(newcolor);
 }
 
-ConsoleAttrScope::~ConsoleAttrScope() throw()
+ConsoleAttrScope::~ConsoleAttrScope()
 {
     try {
         Console.SetColor(m_old_color);

--- a/common/src/Utilities/Darwin/DarwinSemaphore.cpp
+++ b/common/src/Utilities/Darwin/DarwinSemaphore.cpp
@@ -64,7 +64,7 @@ Threading::Semaphore::Semaphore()
     __atomic_store_n(&m_counter, 0, __ATOMIC_SEQ_CST);
 }
 
-Threading::Semaphore::~Semaphore() throw()
+Threading::Semaphore::~Semaphore()
 {
     MACH_CHECK(semaphore_destroy(mach_task_self(), (semaphore_t)m_sema));
     __atomic_store_n(&m_counter, 0, __ATOMIC_SEQ_CST);

--- a/common/src/Utilities/Exceptions.cpp
+++ b/common/src/Utilities/Exceptions.cpp
@@ -143,8 +143,6 @@ __fi void pxOnAssert(const DiagnosticOrigin &origin, const FastFormatUnicode &ms
 //  BaseException  (implementations)
 // --------------------------------------------------------------------------------------
 
-BaseException::~BaseException() throw() {}
-
 BaseException &BaseException::SetBothMsgs(const wxChar *msg_diag)
 {
     m_message_user = msg_diag ? wxString(wxGetTranslation(msg_diag)) : wxString("");

--- a/common/src/Utilities/FastFormatString.cpp
+++ b/common/src/Utilities/FastFormatString.cpp
@@ -132,10 +132,6 @@ FastFormatUnicode::FastFormatUnicode()
     Clear();
 }
 
-FastFormatUnicode::~FastFormatUnicode() throw()
-{
-}
-
 void FastFormatUnicode::Clear()
 {
     m_Length = 0;
@@ -259,10 +255,6 @@ FastFormatAscii::FastFormatAscii()
     : m_dest(2048)
 {
     Clear();
-}
-
-FastFormatAscii::~FastFormatAscii() throw()
-{
 }
 
 void FastFormatAscii::Clear()

--- a/common/src/Utilities/IniInterface.cpp
+++ b/common/src/Utilities/IniInterface.cpp
@@ -98,6 +98,7 @@ IniLoader::IniLoader(wxConfigBase &config)
     : IniInterface(config)
 {
 }
+
 IniLoader::IniLoader(wxConfigBase *config)
     : IniInterface(config)
 {
@@ -107,8 +108,6 @@ IniLoader::IniLoader()
     : IniInterface()
 {
 }
-IniLoader::~IniLoader() throw() {}
-
 
 void IniLoader::Entry(const wxString &var, wxString &value, const wxString defvalue)
 {
@@ -117,7 +116,6 @@ void IniLoader::Entry(const wxString &var, wxString &value, const wxString defva
     else
         value = defvalue;
 }
-
 
 void IniLoader::Entry(const wxString &var, wxDirName &value, const wxDirName defvalue, bool isAllowRelative)
 {
@@ -271,17 +269,16 @@ IniSaver::IniSaver(wxConfigBase &config)
     : IniInterface(config)
 {
 }
+
 IniSaver::IniSaver(wxConfigBase *config)
     : IniInterface(config)
 {
 }
 
-
 IniSaver::IniSaver()
     : IniInterface()
 {
 }
-IniSaver::~IniSaver() {}
 
 void IniSaver::Entry(const wxString &var, wxString &value, const wxString defvalue)
 {

--- a/common/src/Utilities/Mutex.cpp
+++ b/common/src/Utilities/Mutex.cpp
@@ -114,7 +114,7 @@ void Threading::Mutex::Detach()
         Console.Error("(Thread Log) Mutex cleanup failed due to possible deadlock.");
 }
 
-Threading::Mutex::~Mutex() throw()
+Threading::Mutex::~Mutex()
 {
     try {
         Mutex::Detach();
@@ -136,7 +136,7 @@ Threading::MutexRecursive::MutexRecursive()
         Console.Error("(Thread Log) Failed to initialize mutex.");
 }
 
-Threading::MutexRecursive::~MutexRecursive() throw()
+Threading::MutexRecursive::~MutexRecursive()
 {
     if (--_attr_refcount == 0)
         pthread_mutexattr_destroy(&_attr_recursive);
@@ -288,7 +288,7 @@ bool Threading::Mutex::WaitWithoutYield(const wxTimeSpan &timeout)
 //  ScopedLock Implementations
 // --------------------------------------------------------------------------------------
 
-Threading::ScopedLock::~ScopedLock() throw()
+Threading::ScopedLock::~ScopedLock()
 {
     if (m_IsLocked && m_lock)
         m_lock->Release();

--- a/common/src/Utilities/RwMutex.cpp
+++ b/common/src/Utilities/RwMutex.cpp
@@ -24,7 +24,7 @@ Threading::RwMutex::RwMutex()
     pthread_rwlock_init(&m_rwlock, NULL);
 }
 
-Threading::RwMutex::~RwMutex() throw()
+Threading::RwMutex::~RwMutex()
 {
     pthread_rwlock_destroy(&m_rwlock);
 }
@@ -57,7 +57,7 @@ void Threading::RwMutex::Release()
 // --------------------------------------------------------------------------------------
 //
 // --------------------------------------------------------------------------------------
-Threading::BaseScopedReadWriteLock::~BaseScopedReadWriteLock() throw()
+Threading::BaseScopedReadWriteLock::~BaseScopedReadWriteLock()
 {
     if (m_IsLocked)
         m_lock.Release();

--- a/common/src/Utilities/Semaphore.cpp
+++ b/common/src/Utilities/Semaphore.cpp
@@ -30,7 +30,7 @@ Threading::Semaphore::Semaphore()
     sem_init(&m_sema, false, 0);
 }
 
-Threading::Semaphore::~Semaphore() throw()
+Threading::Semaphore::~Semaphore()
 {
     sem_destroy(&m_sema);
 }

--- a/common/src/Utilities/ThreadTools.cpp
+++ b/common/src/Utilities/ThreadTools.cpp
@@ -57,7 +57,7 @@ public:
     {
     }
 
-    virtual ~StaticMutex() throw()
+    virtual ~StaticMutex()
     {
         m_DeletedFlag = true;
     }
@@ -184,7 +184,7 @@ Threading::pxThread::pxThread(const wxString &name)
 //
 // Thread safety: This class must not be deleted from its own thread.  That would be
 // like marrying your sister, and then cheating on her with your daughter.
-Threading::pxThread::~pxThread() throw()
+Threading::pxThread::~pxThread()
 {
     try {
         pxThreadLog.Write(GetName(), L"Executing default destructor!");
@@ -758,7 +758,7 @@ Threading::WaitEvent::WaitEvent()
 	err = pthread_mutex_init(&mutex, NULL);
 }
 
-Threading::WaitEvent::~WaitEvent() throw()
+Threading::WaitEvent::~WaitEvent()
 {
 	pthread_cond_destroy( &cond );
 	pthread_mutex_destroy( &mutex );

--- a/common/src/Utilities/VirtualMemory.cpp
+++ b/common/src/Utilities/VirtualMemory.cpp
@@ -48,7 +48,7 @@ EventListener_PageFault::EventListener_PageFault()
     Source_PageFault->Add(*this);
 }
 
-EventListener_PageFault::~EventListener_PageFault() throw()
+EventListener_PageFault::~EventListener_PageFault()
 {
     if (Source_PageFault)
         Source_PageFault->Remove(*this);

--- a/common/src/Utilities/wxAppWithHelpers.cpp
+++ b/common/src/Utilities/wxAppWithHelpers.cpp
@@ -229,7 +229,7 @@ protected:
     void (*m_Method)();
 
 public:
-    virtual ~pxRpcEvent() throw() {}
+    virtual ~pxRpcEvent() = default;
     virtual pxRpcEvent *Clone() const { return new pxRpcEvent(*this); }
 
     explicit pxRpcEvent(void (*method)() = NULL, SynchronousActionState *sema = NULL)

--- a/common/src/Utilities/wxGuiTools.cpp
+++ b/common/src/Utilities/wxGuiTools.cpp
@@ -529,7 +529,7 @@ ScopedBusyCursor::ScopedBusyCursor(BusyCursorType busytype)
     m_cursorStack.push(curtype);
 }
 
-ScopedBusyCursor::~ScopedBusyCursor() throw()
+ScopedBusyCursor::~ScopedBusyCursor()
 {
     if (!pxAssert(wxTheApp != NULL))
         return;

--- a/common/src/Utilities/wxHelpers.cpp
+++ b/common/src/Utilities/wxHelpers.cpp
@@ -132,10 +132,6 @@ wxDialogWithHelpers::wxDialogWithHelpers(wxWindow *parent, const wxString &title
     SetMinSize(cflags.MinimumSize);
 }
 
-wxDialogWithHelpers::~wxDialogWithHelpers() throw()
-{
-}
-
 void wxDialogWithHelpers::Init(const pxDialogCreationFlags &cflags)
 {
 // Note to self: if any comments indicate platform specific behaviour then

--- a/common/src/Utilities/wxHelpers.cpp
+++ b/common/src/Utilities/wxHelpers.cpp
@@ -59,7 +59,7 @@ BaseDeletableObject::BaseDeletableObject()
     m_IsBeingDeleted.store(false, std::memory_order_relaxed);
 }
 
-BaseDeletableObject::~BaseDeletableObject() throw()
+BaseDeletableObject::~BaseDeletableObject()
 {
     AffinityAssert_AllowFrom_MainUI();
 }

--- a/common/src/x86emitter/LnxCpuDetect.cpp
+++ b/common/src/x86emitter/LnxCpuDetect.cpp
@@ -30,4 +30,4 @@ void x86capabilities::CountLogicalCores()
 
 // Not implemented yet for linux (see cpudetect_internal.h for details)
 SingleCoreAffinity::SingleCoreAffinity() = default;
-SingleCoreAffinity::~SingleCoreAffinity() throw() = default;
+SingleCoreAffinity::~SingleCoreAffinity() = default;

--- a/common/src/x86emitter/LnxCpuDetect.cpp
+++ b/common/src/x86emitter/LnxCpuDetect.cpp
@@ -29,5 +29,5 @@ void x86capabilities::CountLogicalCores()
 }
 
 // Not implemented yet for linux (see cpudetect_internal.h for details)
-SingleCoreAffinity::SingleCoreAffinity() {}
-SingleCoreAffinity::~SingleCoreAffinity() throw() {}
+SingleCoreAffinity::SingleCoreAffinity() = default;
+SingleCoreAffinity::~SingleCoreAffinity() throw() = default;

--- a/common/src/x86emitter/WinCpuDetect.cpp
+++ b/common/src/x86emitter/WinCpuDetect.cpp
@@ -75,7 +75,7 @@ SingleCoreAffinity::SingleCoreAffinity()
     // the thread during the cpuSpeed test instead, causing totally wacky results.
 };
 
-SingleCoreAffinity::~SingleCoreAffinity() throw()
+SingleCoreAffinity::~SingleCoreAffinity()
 {
     if (s_oldmask != ERROR_INVALID_PARAMETER)
         SetThreadAffinityMask(s_threadId, s_oldmask);

--- a/common/src/x86emitter/cpudetect_internal.h
+++ b/common/src/x86emitter/cpudetect_internal.h
@@ -34,5 +34,5 @@ protected:
 
 public:
     SingleCoreAffinity();
-    virtual ~SingleCoreAffinity() throw();
+    virtual ~SingleCoreAffinity();
 };

--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -162,7 +162,7 @@ InputIsoFile::InputIsoFile()
 	_init();
 }
 
-InputIsoFile::~InputIsoFile() throw()
+InputIsoFile::~InputIsoFile()
 {
 	Close();
 }

--- a/pcsx2/CDVD/IsoFS/IsoDirectory.h
+++ b/pcsx2/CDVD/IsoFS/IsoDirectory.h
@@ -31,7 +31,7 @@ public:
 public:
 	IsoDirectory(SectorSource& r);
 	IsoDirectory(SectorSource& r, IsoFileDescriptor directoryEntry);
-	virtual ~IsoDirectory() throw();
+	virtual ~IsoDirectory() = default;
 
 	wxString FStype_ToString() const;
 	SectorSource& GetReader() const { return internalReader; }

--- a/pcsx2/CDVD/IsoFS/IsoFS.cpp
+++ b/pcsx2/CDVD/IsoFS/IsoFS.cpp
@@ -110,10 +110,6 @@ IsoDirectory::IsoDirectory(SectorSource& r, IsoFileDescriptor directoryEntry)
 	Init(directoryEntry);
 }
 
-IsoDirectory::~IsoDirectory() throw()
-{
-}
-
 void IsoDirectory::Init(const IsoFileDescriptor& directoryEntry)
 {
 	// parse directory sector

--- a/pcsx2/CDVD/IsoFS/IsoFSCDVD.cpp
+++ b/pcsx2/CDVD/IsoFS/IsoFSCDVD.cpp
@@ -35,7 +35,3 @@ int IsoFSCDVD::getNumSectors()
 
 	return td.lsn;
 }
-
-IsoFSCDVD::~IsoFSCDVD() throw()
-{
-}

--- a/pcsx2/CDVD/IsoFS/IsoFSCDVD.h
+++ b/pcsx2/CDVD/IsoFS/IsoFSCDVD.h
@@ -23,7 +23,7 @@ class IsoFSCDVD: public SectorSource
 {
 public:
 	IsoFSCDVD();
-	virtual ~IsoFSCDVD() throw();
+	virtual ~IsoFSCDVD() = default;
 
 	virtual bool readSector(unsigned char* buffer, int lba);
 

--- a/pcsx2/CDVD/IsoFS/IsoFile.cpp
+++ b/pcsx2/CDVD/IsoFS/IsoFile.cpp
@@ -53,10 +53,6 @@ void IsoFile::Init()
 		internalReader.readSector(currentSector, currentSectorNumber);
 }
 
-IsoFile::~IsoFile() throw()
-{
-}
-
 u32 IsoFile::seek(u32 absoffset)
 {
 	u32 endOffset = absoffset;

--- a/pcsx2/CDVD/IsoFS/IsoFile.h
+++ b/pcsx2/CDVD/IsoFS/IsoFile.h
@@ -38,7 +38,7 @@ public:
 	IsoFile(const IsoDirectory& dir, const wxString& filename);
 	IsoFile(SectorSource& reader, const wxString& filename);
 	IsoFile(SectorSource& reader, const IsoFileDescriptor& fileEntry);
-	virtual ~IsoFile() throw();
+	virtual ~IsoFile() = default;
 
 	u32 seek(u32 absoffset);
 	u32 seek(s64 offset, wxSeekMode ref_position);

--- a/pcsx2/CDVD/IsoFS/SectorSource.h
+++ b/pcsx2/CDVD/IsoFS/SectorSource.h
@@ -20,5 +20,5 @@ class SectorSource
 public:
 	virtual int  getNumSectors()=0;
 	virtual bool readSector(unsigned char* buffer, int lba)=0;
-	virtual ~SectorSource() throw() {}
+	virtual ~SectorSource() = default;
 };

--- a/pcsx2/CDVD/IsoFileFormats.h
+++ b/pcsx2/CDVD/IsoFileFormats.h
@@ -67,7 +67,7 @@ protected:
 	
 public:	
 	InputIsoFile();
-	virtual ~InputIsoFile() throw();
+	virtual ~InputIsoFile();
 
 	bool IsOpened() const;
 	
@@ -121,7 +121,7 @@ protected:
 		
 public:	
 	OutputIsoFile();
-	virtual ~OutputIsoFile() throw();
+	virtual ~OutputIsoFile();
 
 	bool IsOpened() const;
 	

--- a/pcsx2/CDVD/OutputIsoFile.cpp
+++ b/pcsx2/CDVD/OutputIsoFile.cpp
@@ -34,7 +34,7 @@ OutputIsoFile::OutputIsoFile()
 	_init();
 }
 
-OutputIsoFile::~OutputIsoFile() throw()
+OutputIsoFile::~OutputIsoFile()
 {
 	Close();
 }

--- a/pcsx2/Elfheader.h
+++ b/pcsx2/Elfheader.h
@@ -142,7 +142,7 @@ class ElfObject
 
 		// Destructor!
 		// C++ does all the cleanup automagically for us.
-		virtual ~ElfObject() throw() { }
+		virtual ~ElfObject() = default;
 
 		ElfObject(const wxString& srcfile, IsoFile& isofile);
 		ElfObject( const wxString& srcfile, uint hdrsize );

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -354,7 +354,7 @@ public:
 
 public:
 	SysMtgsThread();
-	virtual ~SysMtgsThread() throw();
+	virtual ~SysMtgsThread();
 
 	// Waits for the GS to empty out the entire ring buffer contents.
 	void WaitGS(bool syncRegs=true, bool weakWait=false, bool isMTVU=false);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -30,7 +30,7 @@ BaseGameDatabaseImpl::BaseGameDatabaseImpl()
 	m_BlockTable.push_back(NULL);
 }
 
-BaseGameDatabaseImpl::~BaseGameDatabaseImpl() throw()
+BaseGameDatabaseImpl::~BaseGameDatabaseImpl()
 {
 	for(uint blockidx=0; blockidx<=m_BlockTableWritePos; ++blockidx)
 	{

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -178,7 +178,7 @@ struct Game_Data
 class IGameDatabase
 {
 public:
-	virtual ~IGameDatabase() throw() {}
+	virtual ~IGameDatabase() = default;
 
 	virtual wxString getBaseKey() const=0;
 	virtual bool findGame(Game_Data& dest, const wxString& id)=0;

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -206,7 +206,7 @@ protected:
 
 public:
 	BaseGameDatabaseImpl();
-	virtual ~BaseGameDatabaseImpl() throw();
+	virtual ~BaseGameDatabaseImpl();
 
 	wxString getBaseKey() const { return m_baseKey; }
 	void setBaseKey( const wxString& key ) { m_baseKey = key; }

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -143,7 +143,7 @@ public:
 		fd = hostfd;
 	}
 
-	virtual ~HostFile() {}
+	virtual ~HostFile() = default;
 
 	static __fi int translate_error(int err)
 	{

--- a/pcsx2/Linux/LnxConsolePipe.cpp
+++ b/pcsx2/Linux/LnxConsolePipe.cpp
@@ -137,7 +137,7 @@ protected:
 
 public:
 	LinuxPipeRedirection(FILE* stdstream);
-	virtual ~LinuxPipeRedirection() noexcept;
+	virtual ~LinuxPipeRedirection() = default;
 };
 
 LinuxPipeRedirection::LinuxPipeRedirection(FILE* stdstream)
@@ -152,10 +152,6 @@ LinuxPipeRedirection::LinuxPipeRedirection(FILE* stdstream)
 		// the constructor, so re-pack a new exception:
 		throw Exception::RuntimeError().SetDiagMsg(ex.FormatDiagnosticMessage());
 	}
-}
-
-LinuxPipeRedirection::~LinuxPipeRedirection() noexcept
-{
 }
 
 PipeRedirectionBase* NewPipeRedir(FILE* stdstream)

--- a/pcsx2/Linux/LnxConsolePipe.cpp
+++ b/pcsx2/Linux/LnxConsolePipe.cpp
@@ -36,7 +36,7 @@ protected:
 	void ExecuteTaskInThread();
 public:
 	LinuxPipeThread(FILE* stdstream);
-	virtual ~LinuxPipeThread() noexcept;
+	virtual ~LinuxPipeThread();
 };
 
 LinuxPipeThread::LinuxPipeThread(FILE* stdstream)
@@ -69,7 +69,7 @@ LinuxPipeThread::LinuxPipeThread(FILE* stdstream)
 	}
 }
 
-LinuxPipeThread::~LinuxPipeThread() noexcept
+LinuxPipeThread::~LinuxPipeThread()
 {
 	// Close write end of the pipe first so the redirection thread starts
 	// finishing up and restore the original stdout/stderr file descriptor so

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -80,7 +80,7 @@ void SysMtgsThread::OnStart()
 	_parent::OnStart();
 }
 
-SysMtgsThread::~SysMtgsThread() throw()
+SysMtgsThread::~SysMtgsThread()
 {
 	try {
 		_parent::Cancel();
@@ -250,7 +250,7 @@ class RingBufferLock {
 		  m_mtgs(mtgs) {
 		m_mtgs.m_RingBufferIsBusy.store(true, std::memory_order_relaxed);
 	}
-	virtual ~RingBufferLock() throw() {
+	virtual ~RingBufferLock() {
 		m_mtgs.m_RingBufferIsBusy.store(false, std::memory_order_relaxed);
 	}
 	void Acquire() {

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -67,7 +67,7 @@ VU_Thread::VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs) :
 	Reset();
 }
 
-VU_Thread::~VU_Thread() throw()
+VU_Thread::~VU_Thread()
 {
 	try {
 		pxThread::Cancel();

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -49,7 +49,7 @@ public:
 	__aligned(4) u32 vuCycleIdx;  // Used for VU cycle stealing hack
 
 	VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs);
-	virtual ~VU_Thread() throw();
+	virtual ~VU_Thread();
 
 	void Reset();
 

--- a/pcsx2/OutputIsoFile.cpp
+++ b/pcsx2/OutputIsoFile.cpp
@@ -35,7 +35,7 @@ OutputIsoFile::OutputIsoFile()
 	_init();
 }
 
-OutputIsoFile::~OutputIsoFile() throw()
+OutputIsoFile::~OutputIsoFile()
 {
 	Close();
 }

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -1111,7 +1111,7 @@ void SysCorePlugins::PluginStatus_t::BindOptional( PluginsEnum_t pid )
 //  SysCorePlugins Implementations
 // =====================================================================================
 
-SysCorePlugins::~SysCorePlugins() throw()
+SysCorePlugins::~SysCorePlugins()
 {
 	try
 	{

--- a/pcsx2/Plugins.h
+++ b/pcsx2/Plugins.h
@@ -324,7 +324,7 @@ protected:
 		}
 
 		PluginStatus_t( PluginsEnum_t _pid, const wxString& srcfile );
-		virtual ~PluginStatus_t() throw() { delete Lib; }
+		virtual ~PluginStatus_t() { delete Lib; }
 
 	protected:
 		void BindCommon( PluginsEnum_t pid );
@@ -345,7 +345,7 @@ public:		// hack until we unsuck plugins...
 
 public:
 	SysCorePlugins();
-	virtual ~SysCorePlugins() throw();
+	virtual ~SysCorePlugins();
 
 	virtual void Load( PluginsEnum_t pid, const wxString& srcfile );
 	virtual void Load( const wxString (&folders)[PluginId_Count] );

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -315,8 +315,6 @@ memLoadingState::memLoadingState( const SafeArray<u8>* load_from )
 {
 }
 
-memLoadingState::~memLoadingState() throw() { }
-
 // Loading of state data from a memory buffer...
 void memLoadingState::FreezeMem( void* data, int size )
 {

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -247,7 +247,7 @@ public:
 class memLoadingState : public SaveStateBase
 {
 public:
-	virtual ~memLoadingState() throw();
+	virtual ~memLoadingState() = default;
 
 	memLoadingState( const VmStateBuffer& load_from );
 	memLoadingState( const VmStateBuffer* load_from );

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -232,7 +232,7 @@ protected:
 	static const int MemoryBaseAllocSize	= _8mb;			// 8 meg base alloc when PS2 main memory is excluded
 
 public:
-	virtual ~memSavingState() throw() { }
+	virtual ~memSavingState() = default;
 	memSavingState( VmStateBuffer& save_to );
 	memSavingState( VmStateBuffer* save_to );
 

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -344,7 +344,7 @@ public:
 
 public:
 	CpuInitializerSet() {}
-	virtual ~CpuInitializerSet() throw() {}
+	virtual ~CpuInitializerSet() = default;
 };
 
 

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -505,7 +505,7 @@ BaseException* SysCpuProviderPack::GetException_SuperVU1() const { return CpuPro
 #endif
 
 
-void SysCpuProviderPack::CleanupMess() throw()
+void SysCpuProviderPack::CleanupMess() noexcept
 {
 	try
 	{

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -41,7 +41,7 @@ RecompiledCodeReserve::RecompiledCodeReserve( const wxString& name, uint defComm
 	m_prot_mode		= PageAccess_Any();
 }
 
-RecompiledCodeReserve::~RecompiledCodeReserve() throw()
+RecompiledCodeReserve::~RecompiledCodeReserve()
 {
 	_termProfiler();
 }
@@ -274,7 +274,7 @@ public:
 	ScopedExcept ExThrown;
 
 	CpuInitializer();
-	virtual ~CpuInitializer() throw();
+	virtual ~CpuInitializer();
 
 	bool IsAvailable() const
 	{
@@ -315,7 +315,7 @@ CpuInitializer< CpuType >::CpuInitializer()
 }
 
 template< typename CpuType >
-CpuInitializer< CpuType >::~CpuInitializer() throw()
+CpuInitializer< CpuType >::~CpuInitializer()
 {
 	try {
 		if (MyCpu)
@@ -362,7 +362,7 @@ SysMainMemory::SysMainMemory()
 {
 }
 
-SysMainMemory::~SysMainMemory() throw()
+SysMainMemory::~SysMainMemory()
 {
 	try {
 		ReleaseAll();
@@ -521,7 +521,7 @@ void SysCpuProviderPack::CleanupMess() throw()
 	DESTRUCTOR_CATCHALL
 }
 
-SysCpuProviderPack::~SysCpuProviderPack() throw()
+SysCpuProviderPack::~SysCpuProviderPack()
 {
 	CleanupMess();
 }

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -103,7 +103,7 @@ protected:
 
 public:
 	SysMainMemory();
-	virtual ~SysMainMemory() throw();
+	virtual ~SysMainMemory();
 
 	virtual void ReserveAll();
 	virtual void CommitAll();
@@ -119,7 +119,7 @@ class SysAllocVM
 {
 public:
 	SysAllocVM();
-	virtual ~SysAllocVM() throw();
+	virtual ~SysAllocVM();
 
 protected:
 	void CleanupMess() throw();
@@ -138,7 +138,7 @@ public:
 	std::unique_ptr<CpuInitializerSet> CpuProviders;
 
 	SysCpuProviderPack();
-	virtual ~SysCpuProviderPack() throw();
+	virtual ~SysCpuProviderPack();
 
 	void ApplyConfig() const;
 #ifndef DISABLE_SVU

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -122,7 +122,7 @@ public:
 	virtual ~SysAllocVM();
 
 protected:
-	void CleanupMess() throw();
+	void CleanupMess() noexcept;
 };
 
 // --------------------------------------------------------------------------------------
@@ -164,7 +164,7 @@ public:
 	BaseException* GetException_SuperVU1() const;
 
 protected:
-	void CleanupMess() throw();
+	void CleanupMess() noexcept;
 };
 
 // GetCpuProviders - this function is not implemented by PCSX2 core -- it must be

--- a/pcsx2/System/RecTypes.h
+++ b/pcsx2/System/RecTypes.h
@@ -32,7 +32,7 @@ protected:
 
 public:
 	RecompiledCodeReserve( const wxString& name=wxEmptyString, uint defCommit = 0 );
-	virtual ~RecompiledCodeReserve() throw();
+	virtual ~RecompiledCodeReserve();
 
 	virtual void* Reserve( size_t size, uptr base=0, uptr upper_bounds=0 );
 	virtual void Reset();

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -53,7 +53,7 @@ SysCoreThread::SysCoreThread()
 	m_hasActiveMachine		= false;
 }
 
-SysCoreThread::~SysCoreThread() throw()
+SysCoreThread::~SysCoreThread()
 {
 	try {
 		SysCoreThread::Cancel();

--- a/pcsx2/System/SysThreadBase.cpp
+++ b/pcsx2/System/SysThreadBase.cpp
@@ -29,10 +29,6 @@ SysThreadBase::SysThreadBase() :
 {
 }
 
-SysThreadBase::~SysThreadBase() throw()
-{
-}
-
 void SysThreadBase::Start()
 {
 	_parent::Start();

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -82,7 +82,7 @@ protected:
 
 public:
 	explicit SysThreadBase();
-	virtual ~SysThreadBase() throw();
+	virtual ~SysThreadBase() = default;
 
 	// Thread safety for IsOpen / IsClosed: The execution mode can change at any time on
 	// any thread, so the actual status may have already changed by the time this function

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -234,7 +234,7 @@ public:
 
 public:
 	IEventListener_SysState() {}
-	virtual ~IEventListener_SysState() throw() {}
+	virtual ~IEventListener_SysState() = default;
 
 	virtual void DispatchEvent( const SysStateUnlockedParams& status )
 	{

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -180,7 +180,7 @@ protected:
 
 public:
 	explicit SysCoreThread();
-	virtual ~SysCoreThread() throw();
+	virtual ~SysCoreThread();
 
 	bool HasPendingStateChangeRequest() const;
 

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -198,7 +198,7 @@ void InterpVU1::Reset() {
 	vu1Thread.WaitVU();
 }
 
-void InterpVU1::Shutdown() throw() {
+void InterpVU1::Shutdown() noexcept {
 	vu1Thread.WaitVU();
 }
 

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -64,7 +64,7 @@ public:
 		IsInterpreter = false;
 	}
 
-	virtual ~BaseCpuProvider() throw()
+	virtual ~BaseCpuProvider()
 	{
 		try {
 			if( m_Reserved != 0 )
@@ -170,7 +170,7 @@ class InterpVU0 : public BaseVUmicroCPU
 {
 public:
 	InterpVU0();
-	virtual ~InterpVU0() throw() { Shutdown(); }
+	virtual ~InterpVU0() { Shutdown(); }
 
 	const char* GetShortName() const	{ return "intVU0"; }
 	wxString GetLongName() const		{ return L"VU0 Interpreter"; }
@@ -191,7 +191,7 @@ class InterpVU1 : public BaseVUmicroCPU
 {
 public:
 	InterpVU1();
-	virtual ~InterpVU1() throw() { Shutdown(); }
+	virtual ~InterpVU1() { Shutdown(); }
 
 	const char* GetShortName() const	{ return "intVU1"; }
 	wxString GetLongName() const		{ return L"VU1 Interpreter"; }
@@ -216,7 +216,7 @@ class recMicroVU0 : public BaseVUmicroCPU
 {
 public:
 	recMicroVU0();
-	virtual ~recMicroVU0() throw()  { Shutdown(); }
+	virtual ~recMicroVU0() { Shutdown(); }
 
 	const char* GetShortName() const	{ return "mVU0"; }
 	wxString GetLongName() const		{ return L"microVU0 Recompiler"; }
@@ -237,7 +237,7 @@ class recMicroVU1 : public BaseVUmicroCPU
 {
 public:
 	recMicroVU1();
-	virtual ~recMicroVU1() throw() { Shutdown(); }
+	virtual ~recMicroVU1() { Shutdown(); }
 
 	const char* GetShortName() const	{ return "mVU1"; }
 	wxString GetLongName() const		{ return L"microVU1 Recompiler"; }

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -139,7 +139,7 @@ public:
 	//   Called from the EEcore thread.  No locking is performed, so any necessary locks must
 	//   be implemented by the CPU provider manually.
 	//
-	virtual void Vsync() throw() { }
+	virtual void Vsync() noexcept { }
 
 	virtual void Step() {
 		// Ideally this would fall back on interpretation for executing single instructions
@@ -176,7 +176,7 @@ public:
 	wxString GetLongName() const		{ return L"VU0 Interpreter"; }
 
 	void Reserve() { }
-	void Shutdown() throw() { }
+	void Shutdown() noexcept { }
 	void Reset() { }
 
 	void Step();
@@ -197,7 +197,7 @@ public:
 	wxString GetLongName() const		{ return L"VU1 Interpreter"; }
 
 	void Reserve() { }
-	void Shutdown() throw();
+	void Shutdown() noexcept;
 	void Reset();
 
 	void Step();
@@ -222,12 +222,12 @@ public:
 	wxString GetLongName() const		{ return L"microVU0 Recompiler"; }
 
 	void Reserve();
-	void Shutdown() throw();
+	void Shutdown() noexcept;
 
 	void Reset();
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size);
-	void Vsync() throw();
+	void Vsync() noexcept;
 
 	uint GetCacheReserve() const;
 	void SetCacheReserve( uint reserveInMegs ) const;
@@ -243,11 +243,11 @@ public:
 	wxString GetLongName() const		{ return L"microVU1 Recompiler"; }
 
 	void Reserve();
-	void Shutdown() throw();
+	void Shutdown() noexcept;
 	void Reset();
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size);
-	void Vsync() throw();
+	void Vsync() noexcept;
 	void ResumeXGkick();
 
 	uint GetCacheReserve() const;
@@ -267,7 +267,7 @@ public:
 	wxString GetLongName() const		{ return L"SuperVU0 Recompiler"; }
 
 	void Reserve();
-	void Shutdown() throw();
+	void Shutdown() noexcept;
 	void Reset();
 	void Execute(u32 cycles);
 	void Clear(u32 Addr, u32 Size);
@@ -285,7 +285,7 @@ public:
 	wxString GetLongName() const		{ return L"SuperVU1 Recompiler"; }
 
 	void Reserve();
-	void Shutdown() throw();
+	void Shutdown() noexcept;
 	void Reset();
 	void Execute(u32 cycles);
 	void Clear(u32 Addr, u32 Size);

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -126,7 +126,7 @@ public:
 		m_Idx		   = 0;
 		m_lastEEcycles = 0;
 	}
-	virtual ~BaseVUmicroCPU() throw() {}
+	virtual ~BaseVUmicroCPU() = default;
 
 	// Called by the PS2 VM's event manager for every internal vertical sync (occurs at either
 	// 50hz (pal) or 59.94hz (NTSC).

--- a/pcsx2/ZipTools/ThreadedZipTools.h
+++ b/pcsx2/ZipTools/ThreadedZipTools.h
@@ -39,7 +39,7 @@ public:
 		m_datasize	= 0;
 	}
 
-	virtual ~ArchiveEntry() throw() {}
+	virtual ~ArchiveEntry() = default;
 
 	ArchiveEntry& SetDataIndex( uptr idx )
 	{
@@ -83,7 +83,7 @@ protected:
 	std::unique_ptr<ArchiveDataBuffer> m_data;
 
 public:
-	virtual ~ArchiveEntryList() throw() {}
+	virtual ~ArchiveEntryList() = default;
 
 	ArchiveEntryList() {}
 

--- a/pcsx2/ZipTools/ThreadedZipTools.h
+++ b/pcsx2/ZipTools/ThreadedZipTools.h
@@ -155,7 +155,7 @@ protected:
 	wxString						m_final_filename;
 
 public:
-	virtual ~BaseCompressThread() throw();
+	virtual ~BaseCompressThread();
 
 	BaseCompressThread& SetSource( ArchiveEntryList* srcdata )
 	{

--- a/pcsx2/ZipTools/thread_gzip.cpp
+++ b/pcsx2/ZipTools/thread_gzip.cpp
@@ -22,7 +22,7 @@
 #include "wx/wfstream.h"
 
 
-BaseCompressThread::~BaseCompressThread() throw()
+BaseCompressThread::~BaseCompressThread()
 {
 	try {
 		_parent::Cancel();

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -242,7 +242,7 @@ public:
 	std::unique_ptr<AppGameDatabase>	GameDB;
 
 	pxAppResources();
-	virtual ~pxAppResources() throw();
+	virtual ~pxAppResources();
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -260,7 +260,7 @@ protected:
 
 public:
 	FramerateManager() { Reset(); }
-	virtual ~FramerateManager() throw() {}
+	virtual ~FramerateManager() = default;
 
 	void Reset();
 	void Resume();

--- a/pcsx2/gui/AppAccelerators.h
+++ b/pcsx2/gui/AppAccelerators.h
@@ -113,7 +113,7 @@ protected:
 
 public:
 	using _parent::operator[];
-	virtual ~CommandDictionary() throw();
+	virtual ~CommandDictionary() = default;
 };
 
 // --------------------------------------------------------------------------------------
@@ -128,6 +128,6 @@ protected:
 public:
 	using _parent::operator[];
 
-	virtual ~AcceleratorDictionary() throw();
+	virtual ~AcceleratorDictionary() = default;
 	void Map( const KeyAcceleratorCode& acode, const char *searchfor );
 };

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1175,7 +1175,7 @@ protected:
 	wxString	m_empty;
 
 public:
-	virtual ~pxDudConfig() {}
+	virtual ~pxDudConfig() = default;
 
 	virtual void SetPath(const wxString& ) {}
 	virtual const wxString& GetPath() const { return m_empty; }
@@ -1222,14 +1222,14 @@ class AppIniSaver : public IniSaver
 {
 public:
 	AppIniSaver();
-	virtual ~AppIniSaver() throw() {}
+	virtual ~AppIniSaver() = default;
 };
 
 class AppIniLoader : public IniLoader
 {
 public:
 	AppIniLoader();
-	virtual ~AppIniLoader() throw() {}
+	virtual ~AppIniLoader() = default;
 };
 
 AppIniSaver::AppIniSaver()

--- a/pcsx2/gui/AppCorePlugins.cpp
+++ b/pcsx2/gui/AppCorePlugins.cpp
@@ -50,7 +50,7 @@ protected:
 	PluginEventType		m_evt;
 
 public:
-	virtual ~CorePluginsEvent() throw() {}
+	virtual ~CorePluginsEvent() = default;
 	CorePluginsEvent* Clone() const { return new CorePluginsEvent( *this ); }
 
 	explicit CorePluginsEvent( PluginEventType evt, SynchronousActionState* sema=NULL )
@@ -107,17 +107,17 @@ class SysExecEvent_AppPluginManager : public SysExecEvent
 {
 protected:
 	FnPtr_AppPluginManager	m_method;
-	
+
 public:
 	wxString GetEventName() const { return L"CorePluginsMethod"; }
-	virtual ~SysExecEvent_AppPluginManager() throw() {}
+	virtual ~SysExecEvent_AppPluginManager() = default;
 	SysExecEvent_AppPluginManager* Clone() const { return new SysExecEvent_AppPluginManager( *this ); }
 
 	SysExecEvent_AppPluginManager( FnPtr_AppPluginManager method )
 	{
 		m_method = method;
 	}
-	
+
 protected:
 	void InvokeEvent()
 	{
@@ -138,9 +138,9 @@ protected:
 	PluginsEnum_t	m_pid;
 
 public:
-	virtual ~LoadSinglePluginEvent() throw() { }
+	virtual ~LoadSinglePluginEvent() = default;
 	virtual LoadSinglePluginEvent *Clone() const { return new LoadSinglePluginEvent(*this); }
-	
+
 	LoadSinglePluginEvent( PluginsEnum_t pid = PluginId_GS, const wxString& filename=wxEmptyString )
 		: m_filename( filename )
 	{
@@ -167,15 +167,15 @@ protected:
 	FnPtr_AppPluginPid		m_method;
 
 public:
-	virtual ~SinglePluginMethodEvent() throw() { }
+	virtual ~SinglePluginMethodEvent() = default;
 	virtual SinglePluginMethodEvent *Clone() const { return new SinglePluginMethodEvent(*this); }
-	
+
 	SinglePluginMethodEvent( FnPtr_AppPluginPid method=NULL,  PluginsEnum_t pid = PluginId_GS )
 	{
 		m_pid		= pid;
 		m_method	= method;
 	}
-	
+
 protected:
 	void InvokeEvent()
 	{
@@ -203,13 +203,6 @@ IMPLEMENT_DYNAMIC_CLASS( SinglePluginMethodEvent, pxActionEvent );
 //  the main thread from being completely busy while plugins are loaded and initialized.
 //  (responsiveness is bliss!!) -- air
 //
-AppCorePlugins::AppCorePlugins()
-{
-}
-
-AppCorePlugins::~AppCorePlugins() throw()
-{
-}
 
 static void _SetSettingsFolder()
 {
@@ -409,7 +402,7 @@ protected:
 	{
 		CorePlugins.Load( m_folders );
 	}
-	~LoadCorePluginsEvent() throw() {}
+	~LoadCorePluginsEvent() = default;
 };
 
 // --------------------------------------------------------------------------------------
@@ -507,7 +500,7 @@ class SysExecEvent_UnloadPlugins : public SysExecEvent
 public:
 	wxString GetEventName() const { return L"UnloadPlugins"; }
 
-	virtual ~SysExecEvent_UnloadPlugins() throw() {}
+	virtual ~SysExecEvent_UnloadPlugins() = default;
 	SysExecEvent_UnloadPlugins* Clone() const { return new SysExecEvent_UnloadPlugins(*this); }
 
 	virtual bool AllowCancelOnExit() const { return false; }
@@ -525,7 +518,7 @@ class SysExecEvent_ShutdownPlugins : public SysExecEvent
 public:
 	wxString GetEventName() const { return L"ShutdownPlugins"; }
 
-	virtual ~SysExecEvent_ShutdownPlugins() throw() {}
+	virtual ~SysExecEvent_ShutdownPlugins() = default;
 	SysExecEvent_ShutdownPlugins* Clone() const { return new SysExecEvent_ShutdownPlugins(*this); }
 
 	virtual bool AllowCancelOnExit() const { return false; }

--- a/pcsx2/gui/AppCorePlugins.h
+++ b/pcsx2/gui/AppCorePlugins.h
@@ -31,8 +31,8 @@ class AppCorePlugins : public SysCorePlugins
 	typedef SysCorePlugins _parent;
 
 public:
-	AppCorePlugins();
-	virtual ~AppCorePlugins() throw();
+	AppCorePlugins() = default;
+	virtual ~AppCorePlugins() = default;
 
 	void Load( const wxString (&folders)[PluginId_Count] );
 	void Load( PluginsEnum_t pid, const wxString& srcfile );
@@ -43,7 +43,7 @@ public:
 	void Init( PluginsEnum_t pid );
 	void Shutdown( PluginsEnum_t pid );
 	bool Shutdown();
-	void Close();	
+	void Close();
 	void Open();
 
 protected:

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -49,7 +49,7 @@ protected:
 
 public:
 	wxString GetEventName() const { return L"CoreThreadMethod"; }
-	virtual ~SysExecEvent_InvokeCoreThreadMethod() throw() {}
+	virtual ~SysExecEvent_InvokeCoreThreadMethod() = default;
 	SysExecEvent_InvokeCoreThreadMethod* Clone() const { return new SysExecEvent_InvokeCoreThreadMethod(*this); }
 
 	bool AllowCancelOnExit() const { return false; }
@@ -708,9 +708,7 @@ BaseScopedCoreThread::BaseScopedCoreThread()
 	m_alreadyScoped		= false;
 }
 
-BaseScopedCoreThread::~BaseScopedCoreThread() throw()
-{
-}
+BaseScopedCoreThread::~BaseScopedCoreThread() throw() = default;
 
 // Allows the object to resume execution upon object destruction.  Typically called as the last thing
 // in the object's scope.  Any code prior to this call that causes exceptions will not resume the emulator,

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -87,7 +87,7 @@ AppCoreThread::AppCoreThread() : SysCoreThread()
 	m_resetCdvd = false;
 }
 
-AppCoreThread::~AppCoreThread() throw()
+AppCoreThread::~AppCoreThread()
 {
 	try {
 		_parent::Cancel();		// use parent's, skips thread affinity check.
@@ -708,7 +708,7 @@ BaseScopedCoreThread::BaseScopedCoreThread()
 	m_alreadyScoped		= false;
 }
 
-BaseScopedCoreThread::~BaseScopedCoreThread() throw() = default;
+BaseScopedCoreThread::~BaseScopedCoreThread() = default;
 
 // Allows the object to resume execution upon object destruction.  Typically called as the last thing
 // in the object's scope.  Any code prior to this call that causes exceptions will not resume the emulator,
@@ -773,7 +773,7 @@ ScopedCoreThreadClose::ScopedCoreThreadClose()
 	ScopedCore_IsFullyClosed = true;
 }
 
-ScopedCoreThreadClose::~ScopedCoreThreadClose() throw()
+ScopedCoreThreadClose::~ScopedCoreThreadClose()
 {
 	if( m_alreadyScoped ) return;
 	try {
@@ -803,7 +803,7 @@ ScopedCoreThreadPause::ScopedCoreThreadPause( BaseSysExecEvent_ScopedCore* abuse
 	ScopedCore_IsPaused = true;
 }
 
-ScopedCoreThreadPause::~ScopedCoreThreadPause() throw()
+ScopedCoreThreadPause::~ScopedCoreThreadPause()
 {
 	if( m_alreadyScoped ) return;
 	try {

--- a/pcsx2/gui/AppCoreThread.h
+++ b/pcsx2/gui/AppCoreThread.h
@@ -49,7 +49,7 @@ protected:
 	Threading::Mutex*			m_mtx_resume;
 
 public:
-	virtual ~BaseSysExecEvent_ScopedCore() throw() {}
+	virtual ~BaseSysExecEvent_ScopedCore() = default;
 
 	BaseSysExecEvent_ScopedCore& SetResumeStates( SynchronousActionState* sync, Threading::Mutex* mutex )
 	{
@@ -87,7 +87,7 @@ class SysExecEvent_CoreThreadClose : public BaseSysExecEvent_ScopedCore
 public:
 	wxString GetEventName() const { return L"CloseCoreThread"; }
 
-	virtual ~SysExecEvent_CoreThreadClose() throw() {}
+	virtual ~SysExecEvent_CoreThreadClose() = default;
 	SysExecEvent_CoreThreadClose* Clone() const { return new SysExecEvent_CoreThreadClose( *this ); }
 	
 	SysExecEvent_CoreThreadClose( SynchronousActionState* sync=NULL, SynchronousActionState* resume_sync=NULL, Threading::Mutex* mtx_resume=NULL )
@@ -105,7 +105,7 @@ class SysExecEvent_CoreThreadPause : public BaseSysExecEvent_ScopedCore
 public:
 	wxString GetEventName() const { return L"PauseCoreThread"; }
 
-	virtual ~SysExecEvent_CoreThreadPause() throw() {}
+	virtual ~SysExecEvent_CoreThreadPause() = default;
 	SysExecEvent_CoreThreadPause* Clone() const { return new SysExecEvent_CoreThreadPause( *this ); }
 	
 	SysExecEvent_CoreThreadPause( SynchronousActionState* sync=NULL, SynchronousActionState* resume_sync=NULL, Threading::Mutex* mtx_resume=NULL )
@@ -165,7 +165,7 @@ protected:
 	IScopedCoreThread() {}
 
 public:
-	virtual ~IScopedCoreThread() throw() {};
+	virtual ~IScopedCoreThread() = default;;
 	virtual void AllowResume()=0;
 	virtual void DisallowResume()=0;
 };
@@ -241,7 +241,7 @@ protected:
 
 public:
 	ScopedCoreThreadPopup();
-	virtual ~ScopedCoreThreadPopup() throw() {}
+	virtual ~ScopedCoreThreadPopup() = default;
 
 	virtual void AllowResume();
 	virtual void DisallowResume();

--- a/pcsx2/gui/AppCoreThread.h
+++ b/pcsx2/gui/AppCoreThread.h
@@ -127,7 +127,7 @@ protected:
 
 public:
 	AppCoreThread();
-	virtual ~AppCoreThread() throw();
+	virtual ~AppCoreThread();
 
 	void ResetCdvd() { m_resetCdvd = true; }
 
@@ -185,7 +185,7 @@ protected:
 	BaseScopedCoreThread();
 
 public:
-	virtual ~BaseScopedCoreThread() throw()=0;
+	virtual ~BaseScopedCoreThread() =0;
 	virtual void AllowResume();
 	virtual void DisallowResume();
 
@@ -220,7 +220,7 @@ class ScopedCoreThreadClose : public BaseScopedCoreThread
 
 public:
 	ScopedCoreThreadClose();
-	virtual ~ScopedCoreThreadClose() throw();
+	virtual ~ScopedCoreThreadClose();
 
 	void LoadPlugins();
 };
@@ -231,7 +231,7 @@ struct ScopedCoreThreadPause : public BaseScopedCoreThread
 
 public:
 	ScopedCoreThreadPause( BaseSysExecEvent_ScopedCore* abuse_me=NULL );
-	virtual ~ScopedCoreThreadPause() throw();
+	virtual ~ScopedCoreThreadPause();
 };
 
 struct ScopedCoreThreadPopup : public IScopedCoreThread

--- a/pcsx2/gui/AppEventListeners.h
+++ b/pcsx2/gui/AppEventListeners.h
@@ -82,7 +82,7 @@ public:
 	typedef CoreThreadStatus EvtParams;
 
 public:
-	virtual ~IEventListener_CoreThread() throw() {}
+	virtual ~IEventListener_CoreThread() = default;
 
 	virtual void DispatchEvent( const CoreThreadStatus& status );
 
@@ -110,7 +110,7 @@ public:
 	typedef PluginEventType EvtParams;
 
 public:
-	virtual ~IEventListener_Plugins() throw() {}
+	virtual ~IEventListener_Plugins() = default;
 
 	virtual void DispatchEvent( const PluginEventType& pevt );
 
@@ -141,7 +141,7 @@ public:
 	typedef AppEventInfo EvtParams;
 
 public:
-	virtual ~IEventListener_AppStatus() throw() {}
+	virtual ~IEventListener_AppStatus() = default;
 
 	virtual void DispatchEvent( const AppEventInfo& evtinfo );
 
@@ -191,7 +191,7 @@ public:
 		pxAssert(dispatchTo != NULL);
 	}
 
-	virtual ~EventListenerHelper_CoreThread() throw() {}
+	virtual ~EventListenerHelper_CoreThread() = default;
 
 protected:
 	void CoreThread_OnIndeterminate()	{ Owner.OnCoreThread_Indeterminate(); }
@@ -218,7 +218,7 @@ public:
 		pxAssert(dispatchTo != NULL);
 	}
 
-	virtual ~EventListenerHelper_Plugins() throw() {}
+	virtual ~EventListenerHelper_Plugins() = default;
 
 protected:
 	void CorePlugins_OnLoaded()		{ Owner.OnCorePlugins_Loaded(); }
@@ -247,7 +247,7 @@ public:
 		pxAssert(dispatchTo != NULL);
 	}
 
-	virtual ~EventListenerHelper_AppStatus() throw() {}
+	virtual ~EventListenerHelper_AppStatus() = default;
 
 protected:
 	virtual void AppStatusEvent_OnUiSettingsLoadSave( const AppSettingsEventInfo& evtinfo ) { Owner.AppStatusEvent_OnUiSettingsLoadSave( evtinfo ); }
@@ -268,7 +268,7 @@ protected:
 	CoreThreadStatus		m_evt;
 
 public:
-	virtual ~CoreThreadStatusEvent() throw() {}
+	virtual ~CoreThreadStatusEvent() = default;
 	CoreThreadStatusEvent* Clone() const { return new CoreThreadStatusEvent( *this ); }
 
 	explicit CoreThreadStatusEvent( CoreThreadStatus evt, SynchronousActionState* sema=NULL );

--- a/pcsx2/gui/AppEventListeners.h
+++ b/pcsx2/gui/AppEventListeners.h
@@ -98,7 +98,7 @@ class EventListener_CoreThread : public IEventListener_CoreThread
 {
 public:
 	EventListener_CoreThread();
-	virtual ~EventListener_CoreThread() throw();
+	virtual ~EventListener_CoreThread();
 };
 
 // --------------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ class EventListener_Plugins : public IEventListener_Plugins
 {
 public:
 	EventListener_Plugins();
-	virtual ~EventListener_Plugins() throw();
+	virtual ~EventListener_Plugins();
 };
 
 // --------------------------------------------------------------------------------------
@@ -157,7 +157,7 @@ class EventListener_AppStatus : public IEventListener_AppStatus
 {
 public:
 	EventListener_AppStatus();
-	virtual ~EventListener_AppStatus() throw();
+	virtual ~EventListener_AppStatus();
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/AppEventSources.cpp
+++ b/pcsx2/gui/AppEventSources.cpp
@@ -33,7 +33,7 @@ EventListener_CoreThread::EventListener_CoreThread()
 	wxGetApp().AddListener( this );
 }
 
-EventListener_CoreThread::~EventListener_CoreThread() throw()
+EventListener_CoreThread::~EventListener_CoreThread()
 {
 	wxGetApp().RemoveListener( this );
 }
@@ -59,7 +59,7 @@ EventListener_Plugins::EventListener_Plugins()
 	wxGetApp().AddListener( this );
 }
 
-EventListener_Plugins::~EventListener_Plugins() throw()
+EventListener_Plugins::~EventListener_Plugins()
 {
 	wxGetApp().RemoveListener( this );
 }
@@ -86,7 +86,7 @@ EventListener_AppStatus::EventListener_AppStatus()
 	wxGetApp().AddListener( this );
 }
 
-EventListener_AppStatus::~EventListener_AppStatus() throw()
+EventListener_AppStatus::~EventListener_AppStatus()
 {
 	wxGetApp().RemoveListener( this );
 }

--- a/pcsx2/gui/AppGameDatabase.h
+++ b/pcsx2/gui/AppGameDatabase.h
@@ -47,7 +47,7 @@ protected:
 
 public:
 	AppGameDatabase() {}
-	virtual ~AppGameDatabase() throw() {
+	virtual ~AppGameDatabase() {
 		try {
 			Console.WriteLn( "(GameDB) Unloading..." );
 		}

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -397,7 +397,7 @@ public:
 	{
 	}
 
-	virtual ~GameDatabaseLoaderThread() throw()
+	virtual ~GameDatabaseLoaderThread()
 	{
 		try {
 			_parent::Cancel();

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -95,7 +95,7 @@ public:
 	PluginErrorEvent( BaseException* ex=NULL ) : _parent( ex ) {}
 	PluginErrorEvent( const BaseException& ex ) : _parent( ex ) {}
 
-	virtual ~PluginErrorEvent() throw() { }
+	virtual ~PluginErrorEvent() = default;
 	virtual PluginErrorEvent *Clone() const { return new PluginErrorEvent(*this); }
 
 protected:
@@ -110,7 +110,7 @@ public:
 	PluginInitErrorEvent( BaseException* ex=NULL ) : _parent( ex ) {}
 	PluginInitErrorEvent( const BaseException& ex ) : _parent( ex ) {}
 
-	virtual ~PluginInitErrorEvent() throw() { }
+	virtual ~PluginInitErrorEvent() = default;
 	virtual PluginInitErrorEvent *Clone() const { return new PluginInitErrorEvent(*this); }
 
 protected:
@@ -163,7 +163,7 @@ public:
 	BIOSLoadErrorEvent(BaseException* ex = NULL) : _parent(ex) {}
 	BIOSLoadErrorEvent(const BaseException& ex) : _parent(ex) {}
 
-	virtual ~BIOSLoadErrorEvent() throw() { }
+	virtual ~BIOSLoadErrorEvent() = default;
 	virtual BIOSLoadErrorEvent *Clone() const { return new BIOSLoadErrorEvent(*this); }
 
 protected:
@@ -233,7 +233,7 @@ protected:
 	FnPtr_Pcsx2App	m_Method;
 
 public:
-	virtual ~Pcsx2AppMethodEvent() throw() { }
+	virtual ~Pcsx2AppMethodEvent() = default;
 	virtual Pcsx2AppMethodEvent *Clone() const { return new Pcsx2AppMethodEvent(*this); }
 
 	explicit Pcsx2AppMethodEvent( FnPtr_Pcsx2App method=NULL, SynchronousActionState* sema=NULL )
@@ -1048,7 +1048,7 @@ protected:
 	wxString			m_elf_override;
 
 public:
-	virtual ~SysExecEvent_Execute() throw() {}
+	virtual ~SysExecEvent_Execute() = default;
 	SysExecEvent_Execute* Clone() const { return new SysExecEvent_Execute(*this); }
 
 	wxString GetEventName() const

--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -71,7 +71,7 @@ pxAppResources::pxAppResources()
 {
 }
 
-pxAppResources::~pxAppResources() throw() = default;
+pxAppResources::~pxAppResources() = default;
 
 wxMenu& Pcsx2App::GetRecentIsoMenu()
 {

--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -71,7 +71,7 @@ pxAppResources::pxAppResources()
 {
 }
 
-pxAppResources::~pxAppResources() throw() {}
+pxAppResources::~pxAppResources() throw() = default;
 
 wxMenu& Pcsx2App::GetRecentIsoMenu()
 {

--- a/pcsx2/gui/AppSaveStates.h
+++ b/pcsx2/gui/AppSaveStates.h
@@ -36,7 +36,7 @@ protected:
 public:
 	wxString GetEventName() const { return L"SaveSinglePlugin"; }
 
-	virtual ~SysExecEvent_SaveSinglePlugin() throw() {}
+	virtual ~SysExecEvent_SaveSinglePlugin() = default;
 	SysExecEvent_SaveSinglePlugin* Clone() const { return new SysExecEvent_SaveSinglePlugin( *this ); }
 
 	SysExecEvent_SaveSinglePlugin( PluginsEnum_t pid=PluginId_GS )

--- a/pcsx2/gui/ApplyState.h
+++ b/pcsx2/gui/ApplyState.h
@@ -118,7 +118,7 @@ class BaseApplicableDialog
 
 public:
 	BaseApplicableDialog() {}
-	virtual ~BaseApplicableDialog() throw();
+	virtual ~BaseApplicableDialog();
 
 	// Must return the same thing as GetNameStatic; a name ideal for use in uniquely
 	// identifying dialogs.  (this version is the 'instance' version, which is called
@@ -161,7 +161,7 @@ protected:
 	EventListenerHelper_AppStatus<BaseApplicableConfigPanel>	m_AppStatusHelper;
 
 public:
-	virtual ~BaseApplicableConfigPanel() throw();
+	virtual ~BaseApplicableConfigPanel();
 
 	BaseApplicableConfigPanel( wxWindow* parent, wxOrientation orient=wxVERTICAL );
 	BaseApplicableConfigPanel( wxWindow* parent, wxOrientation orient, const wxString& staticLabel );
@@ -236,7 +236,7 @@ public:
 		const wxBitmap& bitmap = wxNullBitmap
 	);
 
-	virtual ~ApplicableWizardPage() throw() { m_ApplyState.DoCleanup(); }
+	virtual ~ApplicableWizardPage() { m_ApplyState.DoCleanup(); }
 	
 	virtual bool PrepForApply();
 };

--- a/pcsx2/gui/ApplyState.h
+++ b/pcsx2/gui/ApplyState.h
@@ -95,7 +95,7 @@ struct ApplyStateStruct
 	void StartWizard();
 	bool ApplyAll();
 	bool ApplyPage( int pageid );
-	void DoCleanup() throw();
+	void DoCleanup() noexcept;
 };
 
 class IApplyState

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -33,7 +33,7 @@ wxDEFINE_EVENT(pxEvt_SetTitleText, wxCommandEvent);
 wxDEFINE_EVENT(pxEvt_FlushQueue, wxCommandEvent);
 
 // C++ requires abstract destructors to exist, even though they're abstract.
-PipeRedirectionBase::~PipeRedirectionBase() throw() = default;
+PipeRedirectionBase::~PipeRedirectionBase() = default;
 
 // ----------------------------------------------------------------------------
 //

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -33,7 +33,7 @@ wxDEFINE_EVENT(pxEvt_SetTitleText, wxCommandEvent);
 wxDEFINE_EVENT(pxEvt_FlushQueue, wxCommandEvent);
 
 // C++ requires abstract destructors to exist, even though they're abstract.
-PipeRedirectionBase::~PipeRedirectionBase() throw() {}
+PipeRedirectionBase::~PipeRedirectionBase() throw() = default;
 
 // ----------------------------------------------------------------------------
 //
@@ -147,10 +147,6 @@ static bool OpenLogFile(wxFile& file, wxString& filename, wxWindow *parent)
 ConsoleLogFrame::ColorArray::ColorArray( int fontsize )
 {
 	SetFont( fontsize );
-}
-
-ConsoleLogFrame::ColorArray::~ColorArray() throw()
-{
 }
 
 void ConsoleLogFrame::ColorArray::SetFont( int fontsize )
@@ -274,7 +270,7 @@ public:
 		WindowPtr = pxTheApp.m_ptr_ProgramLog;
 	}
 
-	virtual ~ScopedLogLock() throw() {}
+	virtual ~ScopedLogLock() = default;
 
 	bool HasWindow() const
 	{

--- a/pcsx2/gui/ConsoleLogger.h
+++ b/pcsx2/gui/ConsoleLogger.h
@@ -35,7 +35,7 @@ class PipeRedirectionBase
 	DeclareNoncopyableObject( PipeRedirectionBase );
 
 public:
-	virtual ~PipeRedirectionBase() throw()=0;	// abstract destructor, forces abstract class behavior
+	virtual ~PipeRedirectionBase() =0;	// abstract destructor, forces abstract class behavior
 
 protected:
 	PipeRedirectionBase() {}
@@ -79,7 +79,7 @@ public:
 	{
 	}
 
-	~ConsoleTestThread() throw()
+	~ConsoleTestThread()
 	{
 		m_done = true;
 	}

--- a/pcsx2/gui/ConsoleLogger.h
+++ b/pcsx2/gui/ConsoleLogger.h
@@ -104,7 +104,7 @@ protected:
 		std::array<wxTextAttr, ConsoleColors_Count> m_table;
 
 	public:
-		virtual ~ColorArray() throw();
+		virtual ~ColorArray() = default;
 		ColorArray( int fontsize=8 );
 
 		void SetFont( const wxFont& font );

--- a/pcsx2/gui/CpuUsageProvider.h
+++ b/pcsx2/gui/CpuUsageProvider.h
@@ -40,7 +40,7 @@ protected:
 
 public:
 	CpuUsageProvider();
-	virtual ~CpuUsageProvider() throw();
+	virtual ~CpuUsageProvider();
 
 	virtual bool IsImplemented() const	{ return m_Implementation->IsImplemented(); }
 	virtual void UpdateStats()			{ m_Implementation->UpdateStats(); }

--- a/pcsx2/gui/CpuUsageProvider.h
+++ b/pcsx2/gui/CpuUsageProvider.h
@@ -22,7 +22,7 @@ class BaseCpuUsageProvider
 {
 public:
 	BaseCpuUsageProvider() {}
-	virtual ~BaseCpuUsageProvider() throw() {}
+	virtual ~BaseCpuUsageProvider() = default;
 
 	virtual bool IsImplemented() const=0;
 	virtual void UpdateStats()=0;
@@ -77,7 +77,7 @@ protected:
 
 public:
 	DefaultCpuUsageProvider();
-	virtual ~DefaultCpuUsageProvider() throw() {}
+	virtual ~DefaultCpuUsageProvider() = default;
 
 	bool IsImplemented() const;
 	void Reset();

--- a/pcsx2/gui/CpuUsageProviderLnx.cpp
+++ b/pcsx2/gui/CpuUsageProviderLnx.cpp
@@ -28,4 +28,4 @@ CpuUsageProvider::CpuUsageProvider() :
 {
 }
 
-CpuUsageProvider::~CpuUsageProvider() throw() = default;
+CpuUsageProvider::~CpuUsageProvider() = default;

--- a/pcsx2/gui/CpuUsageProviderLnx.cpp
+++ b/pcsx2/gui/CpuUsageProviderLnx.cpp
@@ -28,6 +28,4 @@ CpuUsageProvider::CpuUsageProvider() :
 {
 }
 
-CpuUsageProvider::~CpuUsageProvider() throw()
-{
-}
+CpuUsageProvider::~CpuUsageProvider() throw() = default;

--- a/pcsx2/gui/CpuUsageProviderMSW.cpp
+++ b/pcsx2/gui/CpuUsageProviderMSW.cpp
@@ -49,7 +49,7 @@ protected:
 
 public:
 	CpuUsageProviderMSW();
-	virtual ~CpuUsageProviderMSW() throw();
+	virtual ~CpuUsageProviderMSW();
 
 	bool IsImplemented() const;
 	void UpdateStats();
@@ -156,7 +156,7 @@ CpuUsageProviderMSW::CpuUsageProviderMSW()
 	}*/
 }
 
-CpuUsageProviderMSW::~CpuUsageProviderMSW() throw()
+CpuUsageProviderMSW::~CpuUsageProviderMSW()
 {
 	//CoUninitialize();
 }
@@ -282,6 +282,6 @@ CpuUsageProvider::CpuUsageProvider() :
 {
 }
 
-CpuUsageProvider::~CpuUsageProvider() throw()
+CpuUsageProvider::~CpuUsageProvider()
 {
 }

--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -80,7 +80,7 @@ class DisassemblyDialog : public wxFrame
 {
 public:
 	DisassemblyDialog( wxWindow* parent=NULL );
-	virtual ~DisassemblyDialog() throw() {}
+	virtual ~DisassemblyDialog() = default;
 
 	static wxString GetNameStatic() { return L"DisassemblyDialog"; }
 	wxString GetDialogName() const { return GetNameStatic(); }

--- a/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
+++ b/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
@@ -73,7 +73,7 @@ public:
 		m_apply = m_ok = m_cancel = NULL;
 	}
 
-	virtual ~ScopedOkButtonDisabler() throw()
+	virtual ~ScopedOkButtonDisabler()
 	{
 		if (m_apply)	m_apply	->Enable();
 		if (m_ok)		m_ok	->Enable();
@@ -94,7 +94,7 @@ BaseApplicableDialog::BaseApplicableDialog( wxWindow* parent, const wxString& ti
 	Init();
 }
 
-BaseApplicableDialog::~BaseApplicableDialog() throw()
+BaseApplicableDialog::~BaseApplicableDialog()
 {
 	m_ApplyState.DoCleanup();
 }

--- a/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
+++ b/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
@@ -187,10 +187,6 @@ void Dialogs::BaseConfigurationDialog::AddOkCancel( wxSizer* sizer )
 	*m_extraButtonSizer += screenshotButton|pxMiddle;
 }
 
-Dialogs::BaseConfigurationDialog::~BaseConfigurationDialog() throw()
-{
-}
-
 void Dialogs::BaseConfigurationDialog::OnSetSettingsPage( wxCommandEvent& evt )
 {
 	if( !m_listbook ) return;

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -46,7 +46,7 @@ namespace Dialogs
 		bool				m_allowApplyActivation;
 
 	public:
-		virtual ~BaseConfigurationDialog() throw();
+		virtual ~BaseConfigurationDialog() = default;
 		BaseConfigurationDialog(wxWindow* parent, const wxString& title, int idealWidth);
 
 	public:

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -87,7 +87,7 @@ namespace Dialogs
 	class SysConfigDialog : public BaseConfigurationDialog
 	{
 	public:
-		virtual ~SysConfigDialog() throw() {}
+		virtual ~SysConfigDialog() = default;
 		SysConfigDialog(wxWindow* parent=NULL);
 		static wxString GetNameStatic() { return L"CoreSettings"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
@@ -119,7 +119,7 @@ namespace Dialogs
 	{
 	public:
 		InterfaceLanguageDialog(wxWindow* parent = NULL);
-		virtual ~InterfaceLanguageDialog() throw() { }
+		virtual ~InterfaceLanguageDialog() = default;
 
 		static wxString GetNameStatic() { return L"InterfaceLanguage"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
@@ -140,7 +140,7 @@ namespace Dialogs
 		Panels::BaseMcdListPanel*	m_panel_mcdlist;
 
 	public:
-		virtual ~McdConfigDialog() throw() {}
+		virtual ~McdConfigDialog() = default;
 		McdConfigDialog(wxWindow* parent=NULL);
 		static wxString GetNameStatic() { return L"McdConfig"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
@@ -156,7 +156,7 @@ namespace Dialogs
 	class GameDatabaseDialog : public BaseConfigurationDialog
 	{
 	public:
-		virtual ~GameDatabaseDialog() throw() {}
+		virtual ~GameDatabaseDialog() = default;
 		GameDatabaseDialog(wxWindow* parent=NULL);
 		static wxString GetNameStatic() { return L"GameDatabase"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
@@ -173,7 +173,7 @@ namespace Dialogs
 	protected:
 
 	public:
-		virtual ~ComponentsConfigDialog() throw() {}
+		virtual ~ComponentsConfigDialog() = default;
 		ComponentsConfigDialog(wxWindow* parent=NULL);
 		static wxString GetNameStatic() { return L"AppSettings"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
@@ -200,7 +200,7 @@ namespace Dialogs
 	#endif
 
 	public:
-		virtual ~CreateMemoryCardDialog()  throw() {}
+		virtual ~CreateMemoryCardDialog()  = default;
 		CreateMemoryCardDialog( wxWindow* parent, const wxDirName& mcdpath, const wxString& suggested_mcdfileName);
 	
 		//duplicate of MemoryCardFile::Create. Don't know why the existing method isn't used. - avih
@@ -226,7 +226,7 @@ namespace Dialogs
 		pxRadioPanel* m_radio_CardType;
 
 	public:
-		virtual ~ConvertMemoryCardDialog()  throw() {}
+		virtual ~ConvertMemoryCardDialog()  = default;
 		ConvertMemoryCardDialog( wxWindow* parent, const wxDirName& mcdPath, const AppConfig::McdOptions& mcdSourceConfig );
 	
 	protected:

--- a/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
+++ b/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
@@ -60,7 +60,7 @@ namespace Panels
 	{
 	public:
 		FirstTimeIntroPanel( wxWindow* parent );
-		virtual ~FirstTimeIntroPanel() throw() {}
+		virtual ~FirstTimeIntroPanel() = default;
 	};
 }
 
@@ -161,11 +161,6 @@ FirstTimeWizard::FirstTimeWizard( wxWindow* parent )
 	Bind(wxEVT_LISTBOX_DCLICK, &FirstTimeWizard::OnDoubleClicked, this);
 
 	Bind(wxEVT_BUTTON, &FirstTimeWizard::OnRestartWizard, this, pxID_RestartWizard);
-}
-
-FirstTimeWizard::~FirstTimeWizard() throw()
-{
-
 }
 
 void FirstTimeWizard::OnRestartWizard( wxCommandEvent& evt )

--- a/pcsx2/gui/Dialogs/LogOptionsDialog.h
+++ b/pcsx2/gui/Dialogs/LogOptionsDialog.h
@@ -27,7 +27,7 @@ class LogOptionsDialog : public BaseConfigurationDialog
 {
 public:
 	LogOptionsDialog( wxWindow* parent=NULL );
-	virtual ~LogOptionsDialog() throw() { }
+	virtual ~LogOptionsDialog() = default;
 
 	static wxString GetNameStatic() { return L"TraceLogSettings"; }
 	wxString GetDialogName() const { return GetNameStatic(); }

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -65,7 +65,7 @@ namespace Dialogs
 
 	public:
 		AboutBoxDialog( wxWindow* parent=NULL );
-		virtual ~AboutBoxDialog() throw() {}
+		virtual ~AboutBoxDialog() = default;
 
 		static wxString GetNameStatic() { return L"AboutBox"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
@@ -80,7 +80,7 @@ namespace Dialogs
 
 	public:
 		PickUserModeDialog( wxWindow* parent );
-		virtual ~PickUserModeDialog() throw() {}
+		virtual ~PickUserModeDialog() = default;
 
 	protected:
 		void OnOk_Click( wxCommandEvent& evt );
@@ -91,7 +91,7 @@ namespace Dialogs
 	{
 	public:
 		ImportSettingsDialog( wxWindow* parent );
-		virtual ~ImportSettingsDialog() throw() {}
+		virtual ~ImportSettingsDialog() = default;
 
 	protected:
 		void OnImport_Click( wxCommandEvent& evt );
@@ -102,7 +102,7 @@ namespace Dialogs
 	{
 	public:
 		AssertionDialog( const wxString& text, const wxString& stacktrace );
-		virtual ~AssertionDialog() throw() {}
+		virtual ~AssertionDialog() = default;
 	};
 }
 

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -36,7 +36,7 @@ protected:
 
 public:
 	FirstTimeWizard( wxWindow* parent );
-	virtual ~FirstTimeWizard() throw();
+	virtual ~FirstTimeWizard() = default;
 
 	wxWizardPage *GetFirstPage() const { return &m_page_intro; }
 

--- a/pcsx2/gui/ExecutorThread.cpp
+++ b/pcsx2/gui/ExecutorThread.cpp
@@ -182,7 +182,7 @@ struct ScopedThreadCancelDisable
 		pthread_setcancelstate( PTHREAD_CANCEL_DISABLE, &oldstate );
 	}
 	
-	~ScopedThreadCancelDisable() throw()
+	~ScopedThreadCancelDisable()
 	{
 		int oldstate;
 		pthread_setcancelstate( PTHREAD_CANCEL_ENABLE, &oldstate );

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -131,7 +131,7 @@ GSPanel::GSPanel( wxWindow* parent )
 	Bind(wxEVT_LEFT_DCLICK, &GSPanel::OnLeftDclick, this);
 }
 
-GSPanel::~GSPanel() throw()
+GSPanel::~GSPanel()
 {
 	//CoreThread.Suspend( false );		// Just in case...!
 }

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -468,10 +468,6 @@ GSFrame::GSFrame( const wxString& title)
 	Bind(wxEVT_TIMER, &GSFrame::OnUpdateTitle, this, m_timer_UpdateTitle.GetId());
 }
 
-GSFrame::~GSFrame() throw()
-{
-}
-
 void GSFrame::OnCloseWindow(wxCloseEvent& evt)
 {
 	sApp.OnGsFrameClosed( GetId() );

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -97,7 +97,7 @@ protected:
 
 public:
 	GSFrame( const wxString& title);
-	virtual ~GSFrame() throw();
+	virtual ~GSFrame() = default;
 
 	GSPanel* GetViewport();
 	void SetFocus();

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -49,7 +49,7 @@ protected:
 
 public:
 	GSPanel( wxWindow* parent );
-	virtual ~GSPanel() throw();
+	virtual ~GSPanel();
 
 	void DoResize();
 	void DoShowMouse();

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -625,10 +625,6 @@ static const GlobalCommandDescriptor CommandDeclarations[] =
 	{ NULL }
 };
 
-CommandDictionary::~CommandDictionary() throw() {}
-
-AcceleratorDictionary::~AcceleratorDictionary() throw() {}
-
 void AcceleratorDictionary::Map( const KeyAcceleratorCode& _acode, const char *searchfor )
 {
 	// Search override mapping at ini file

--- a/pcsx2/gui/IsoDropTarget.cpp
+++ b/pcsx2/gui/IsoDropTarget.cpp
@@ -44,7 +44,7 @@ public:
 		m_ownerid = window->GetId();
 	}
 
-	virtual ~DroppedTooManyFiles() throw() { }
+	virtual ~DroppedTooManyFiles() = default;
 	virtual DroppedTooManyFiles *Clone() const { return new DroppedTooManyFiles(*this); }
 
 protected:
@@ -73,7 +73,7 @@ public:
 		m_ownerid = window->GetId();
 	}
 
-	virtual ~DroppedElf() throw() { }
+	virtual ~DroppedElf() = default;
 	virtual DroppedElf *Clone() const { return new DroppedElf(*this); }
 
 protected:
@@ -122,7 +122,7 @@ public:
 		m_ownerid = window->GetId();
 	}
 
-	virtual ~DroppedIso() throw() { }
+	virtual ~DroppedIso() = default;
 	virtual DroppedIso *Clone() const { return new DroppedIso(*this); }
 
 protected:

--- a/pcsx2/gui/IsoDropTarget.h
+++ b/pcsx2/gui/IsoDropTarget.h
@@ -27,7 +27,7 @@ protected:
 	wxWindow* m_WindowBound;
 
 public:
-	virtual ~IsoDropTarget() throw() { }
+	virtual ~IsoDropTarget() = default;
 	IsoDropTarget( wxWindow* parent ) : wxFileDropTarget()
 	{
 		m_WindowBound = parent;

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -734,10 +734,6 @@ void MainEmuFrame::AppendKeycodeNamesToMenuOptions() {
 //   "Extensible" Plugin Menus
 // ------------------------------------------------------------------------
 
-PerPluginMenuInfo::~PerPluginMenuInfo() throw()
-{
-}
-
 void PerPluginMenuInfo::Populate( PluginsEnum_t pid )
 {
 	if( !pxAssert(pid < PluginId_Count) ) return;

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -533,7 +533,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	AppendKeycodeNamesToMenuOptions();
 }
 
-MainEmuFrame::~MainEmuFrame() throw()
+MainEmuFrame::~MainEmuFrame()
 {
 	try {
 		if( m_RestartEmuOnDelete )

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -54,7 +54,7 @@ public:
 public:
 	PerPluginMenuInfo() : MyMenu(*new wxMenu()), PluginId (PluginId_Count) {}
 
-	virtual ~PerPluginMenuInfo() throw();
+	virtual ~PerPluginMenuInfo() = default;
 
 	void Populate( PluginsEnum_t pid );
 	void OnUnloaded();

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -80,7 +80,7 @@ public:
 		m_menu_cmd = menu_command;
 	}
 	
-	virtual ~InvokeMenuCommand_OnSysStateUnlocked() throw() {}
+	virtual ~InvokeMenuCommand_OnSysStateUnlocked() = default;
 
 	virtual void SaveStateAction_OnCreateFinished()
 	{

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -129,7 +129,7 @@ protected:
 
 public:
 	MainEmuFrame(wxWindow* parent, const wxString& title);
-	virtual ~MainEmuFrame() throw();
+	virtual ~MainEmuFrame();
 
 	void OnLogBoxHidden();
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -518,7 +518,7 @@ void MainEmuFrame::Menu_Exit_Click(wxCommandEvent &event)
 class SysExecEvent_ToggleSuspend : public SysExecEvent
 {
 public:
-	virtual ~SysExecEvent_ToggleSuspend() throw() {}
+	virtual ~SysExecEvent_ToggleSuspend() = default;
 
 	wxString GetEventName() const { return L"ToggleSuspendResume"; }
 

--- a/pcsx2/gui/MemoryCardFile.cpp
+++ b/pcsx2/gui/MemoryCardFile.cpp
@@ -63,7 +63,7 @@ protected:
 
 public:
 	FileMemoryCard();
-	virtual ~FileMemoryCard() throw() {}
+	virtual ~FileMemoryCard() = default;
 
 	void Lock();
 	void Unlock();

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -333,7 +333,7 @@ protected:
 
 public:
 	FolderMemoryCard();
-	virtual ~FolderMemoryCard() throw() {}
+	virtual ~FolderMemoryCard() = default;
 
 	void Lock();
 	void Unlock();
@@ -556,7 +556,7 @@ protected:
 
 public:
 	FolderMemoryCardAggregator();
-	virtual ~FolderMemoryCardAggregator() throw( ) {}
+	virtual ~FolderMemoryCardAggregator() = default;
 
 	void Open();
 	void Close();

--- a/pcsx2/gui/MessageBoxes.cpp
+++ b/pcsx2/gui/MessageBoxes.cpp
@@ -97,13 +97,6 @@ pxMessageBoxEvent::pxMessageBoxEvent( const wxString& title, const wxString& con
 {
 }
 
-pxMessageBoxEvent::pxMessageBoxEvent( const pxMessageBoxEvent& event )
-	: BaseMessageBoxEvent( event )
-	, m_Title( event.m_Title )
-	, m_Buttons( event.m_Buttons )
-{
-}
-
 int pxMessageBoxEvent::_DoDialog() const
 {
 	return pxMessageDialog( m_Title, m_Content, m_Buttons );
@@ -123,12 +116,6 @@ pxAssertionEvent::pxAssertionEvent( const wxString& content, const wxString& tra
 pxAssertionEvent::pxAssertionEvent( const wxString& content, const wxString& trace, SynchronousActionState* instdata )
 	: BaseMessageBoxEvent( content, instdata )
 	, m_Stacktrace( trace )
-{
-}
-
-pxAssertionEvent::pxAssertionEvent( const pxAssertionEvent& event )
-	: BaseMessageBoxEvent( event )
-	, m_Stacktrace( event.m_Stacktrace )
 {
 }
 

--- a/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
+++ b/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
@@ -28,7 +28,7 @@ using namespace Dialogs;
 // on dialog destruction.  It asserts if the ApplyList hasn't been cleaned up
 // and then cleans it up forcefully.
 //
-void ApplyStateStruct::DoCleanup() throw()
+void ApplyStateStruct::DoCleanup() noexcept
 {
 	pxAssertMsg( !PanelList.empty(), L"PanelList list hasn't been cleaned up." );
 	PanelList.clear();

--- a/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
+++ b/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
@@ -147,7 +147,7 @@ IApplyState* BaseApplicableConfigPanel::FindApplyStateManager() const
 	return NULL;
 }
 
-BaseApplicableConfigPanel::~BaseApplicableConfigPanel() throw()
+BaseApplicableConfigPanel::~BaseApplicableConfigPanel()
 {
 	if( IApplyState* iapp = FindApplyStateManager() )
 		iapp->GetApplyState().PanelList.remove( this );

--- a/pcsx2/gui/Panels/BiosSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/BiosSelectorPanel.cpp
@@ -48,10 +48,6 @@ Panels::BaseSelectorPanel::BaseSelectorPanel( wxWindow* parent )
 	Bind(wxEVT_SHOW, &BaseSelectorPanel::OnShow, this);
 }
 
-Panels::BaseSelectorPanel::~BaseSelectorPanel() throw()
-{
-}
-
 void Panels::BaseSelectorPanel::OnShow(wxShowEvent& evt)
 {
 	evt.Skip();
@@ -120,10 +116,6 @@ Panels::BiosSelectorPanel::BiosSelectorPanel( wxWindow* parent )
 	*this	+= m_FolderPicker	| StdExpand();
 
 	Bind(wxEVT_BUTTON, &BiosSelectorPanel::OnRefreshSelections, this, refreshButton->GetId());
-}
-
-Panels::BiosSelectorPanel::~BiosSelectorPanel() throw ()
-{
 }
 
 void Panels::BiosSelectorPanel::Apply()

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -490,7 +490,7 @@ namespace Panels
 		DirPickerPanel* m_FolderPicker;
 
 	public:
-		virtual ~ThemeSelectorPanel() throw();
+		virtual ~ThemeSelectorPanel();
 		ThemeSelectorPanel( wxWindow* parent );
 
 	protected:
@@ -554,7 +554,7 @@ namespace Panels
 			PluginSelectorPanel&	m_master;
 			ScopedBusyCursor		m_hourglass;
 		public:
-			virtual ~EnumThread() throw()
+			virtual ~EnumThread()
 			{
 				try {
 					pxThread::Cancel();
@@ -617,7 +617,7 @@ namespace Panels
 		std::unique_ptr<EnumThread>		m_EnumeratorThread;
 
 	public:
-		virtual ~PluginSelectorPanel() throw();
+		virtual ~PluginSelectorPanel();
 		PluginSelectorPanel( wxWindow* parent );
 
 		void CancelRefresh();		// used from destructor, stays non-virtual

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -447,7 +447,7 @@ namespace Panels
 		typedef BaseApplicableConfigPanel _parent;
 
 	public:
-		virtual ~BaseSelectorPanel() throw();
+		virtual ~BaseSelectorPanel() = default;
 		BaseSelectorPanel( wxWindow* parent );
 
 		virtual void RefreshSelections();
@@ -512,7 +512,7 @@ namespace Panels
 
 	public:
 		BiosSelectorPanel( wxWindow* parent );
-		virtual ~BiosSelectorPanel() throw();
+		virtual ~BiosSelectorPanel() = default;
 
 	protected:
 		virtual void Apply();

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -51,7 +51,7 @@ namespace Panels
 	public:
 		DirPickerPanel( wxWindow* parent, FoldersEnum_t folderid, const wxString& label, const wxString& dialogLabel );
 		DirPickerPanel( wxWindow* parent, FoldersEnum_t folderid, const wxString& dialogLabel );
-		virtual ~DirPickerPanel() throw() { }
+		virtual ~DirPickerPanel() = default;
 
 		void Reset();
 		wxDirName GetPath() const;
@@ -89,7 +89,7 @@ namespace Panels
 		DirPickerPanel*	m_dirpicker_custom;
 
 	public:
-		virtual ~DocsFolderPickerPanel() throw() { }
+		virtual ~DocsFolderPickerPanel() = default;
 		DocsFolderPickerPanel( wxWindow* parent, bool isFirstTime = true );
 
 		void Apply();
@@ -109,7 +109,7 @@ namespace Panels
 		wxComboBox*		m_picker;
 
 	public:
-		virtual ~LanguageSelectionPanel() throw() { }
+		virtual ~LanguageSelectionPanel() = default;
 		LanguageSelectionPanel( wxWindow* parent, bool showApply = true );
 
 		void Apply();
@@ -135,7 +135,7 @@ namespace Panels
 
 	public:
 		BaseAdvancedCpuOptions( wxWindow* parent );
-		virtual ~BaseAdvancedCpuOptions() throw() { }
+		virtual ~BaseAdvancedCpuOptions() = default;
 
 		void RestoreDefaults();
 
@@ -151,7 +151,7 @@ namespace Panels
 	{
 	public:
 		AdvancedOptionsFPU( wxWindow* parent );
-		virtual ~AdvancedOptionsFPU() throw() { }
+		virtual ~AdvancedOptionsFPU() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
@@ -161,7 +161,7 @@ namespace Panels
 	{
 	public:
 		AdvancedOptionsVU( wxWindow* parent );
-		virtual ~AdvancedOptionsVU() throw() { }
+		virtual ~AdvancedOptionsVU() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
@@ -182,7 +182,7 @@ namespace Panels
 
 	public:
 		CpuPanelEE( wxWindow* parent );
-		virtual ~CpuPanelEE() throw() {}
+		virtual ~CpuPanelEE() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
@@ -203,7 +203,7 @@ namespace Panels
 
 	public:
 		CpuPanelVU( wxWindow* parent );
-		virtual ~CpuPanelVU() throw() {}
+		virtual ~CpuPanelVU() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
@@ -226,7 +226,7 @@ namespace Panels
 
 	public:
 		FrameSkipPanel( wxWindow* parent );
-		virtual	~FrameSkipPanel() throw() {}
+		virtual	~FrameSkipPanel() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
@@ -253,7 +253,7 @@ namespace Panels
 
 	public:
 		FramelimiterPanel( wxWindow* parent );
-		virtual ~FramelimiterPanel() throw() {}
+		virtual ~FramelimiterPanel() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
@@ -293,7 +293,7 @@ namespace Panels
 
 	public:
 		GSWindowSettingsPanel( wxWindow* parent );
-		virtual ~GSWindowSettingsPanel() throw() {}
+		virtual ~GSWindowSettingsPanel() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
@@ -309,7 +309,7 @@ namespace Panels
 
 	public:
 		VideoPanel( wxWindow* parent );
-		virtual ~VideoPanel() throw() {}
+		virtual ~VideoPanel() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
@@ -343,7 +343,7 @@ namespace Panels
 		pxCheckBox*		m_check_vuThread;
 
 	public:
-		virtual ~SpeedHacksPanel() throw() {}
+		virtual ~SpeedHacksPanel() = default;
 		SpeedHacksPanel( wxWindow* parent );
 		void Apply();
 		void EnableStuff( AppConfig* configToUse=NULL );
@@ -374,7 +374,7 @@ namespace Panels
 
 	public:
 		GameFixesPanel( wxWindow* parent );
-		virtual ~GameFixesPanel() throw() { }
+		virtual ~GameFixesPanel() = default;
 		void EnableStuff( AppConfig* configToUse=NULL );
 		void OnEnable_Toggled( wxCommandEvent& evt );
 		void Apply();
@@ -402,7 +402,7 @@ namespace Panels
 
 	public:
 		GameDatabasePanel( wxWindow* parent );
-		virtual ~GameDatabasePanel() throw() { }
+		virtual ~GameDatabasePanel() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 

--- a/pcsx2/gui/Panels/GameDatabasePanel.cpp
+++ b/pcsx2/gui/Panels/GameDatabasePanel.cpp
@@ -55,7 +55,7 @@ protected:
 	wxArrayString	m_GamesInView;
 
 public:
-	virtual ~GameDatabaseListView() throw() { }
+	virtual ~GameDatabaseListView() = default;
 	GameDatabaseListView( wxWindow* parent );
 
 	void CreateColumns();
@@ -141,7 +141,7 @@ public:
 		m_descending = descend;
 	}
 
-	virtual ~BaseGameListSort() throw() {}
+	virtual ~BaseGameListSort() = default;
 
 	// Note: Return TRUE if the first value is less than the second value.
 	bool operator()(const wxString& i1, const wxString& i2)

--- a/pcsx2/gui/Panels/LogOptionsPanels.h
+++ b/pcsx2/gui/Panels/LogOptionsPanels.h
@@ -45,7 +45,7 @@ namespace Panels
 
 	public:
 		eeLogOptionsPanel( LogOptionsPanel* parent );
-		virtual ~eeLogOptionsPanel() throw() {}
+		virtual ~eeLogOptionsPanel() = default;
 
 		CheckedStaticBox* GetStaticBox( const wxString& subgroup ) const;
 
@@ -63,7 +63,7 @@ namespace Panels
 
 	public:
 		iopLogOptionsPanel( LogOptionsPanel* parent );
-		virtual ~iopLogOptionsPanel() throw() {}
+		virtual ~iopLogOptionsPanel() = default;
 
 		CheckedStaticBox* GetStaticBox( const wxString& subgroup ) const;
 
@@ -84,7 +84,7 @@ namespace Panels
 
 	public:
 		LogOptionsPanel( wxWindow* parent );
-		virtual ~LogOptionsPanel() throw() {}
+		virtual ~LogOptionsPanel() = default;
 
 		void AppStatusEvent_OnSettingsApplied();
 		void OnUpdateEnableAll();

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -370,7 +370,7 @@ enum McdMenuId
 Panels::MemoryCardListPanel_Simple* g_uglyPanel=NULL;
 void g_uglyFunc(){if (g_uglyPanel) g_uglyPanel->OnChangedListSelection();}
 
-Panels::MemoryCardListPanel_Simple::~MemoryCardListPanel_Simple() throw(){g_uglyPanel=NULL;}
+Panels::MemoryCardListPanel_Simple::~MemoryCardListPanel_Simple() {g_uglyPanel=NULL;}
 
 Panels::MemoryCardListPanel_Simple::MemoryCardListPanel_Simple( wxWindow* parent )
 	: _parent( parent )

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -107,7 +107,7 @@ public:
 	void setExternHandler(void (*f)(void)){m_externHandler=f;};
 	void OnChanged(wxEvent& evt){if (m_externHandler) m_externHandler(); evt.Skip();}
 
-	virtual ~BaseMcdListView() throw() { }
+	virtual ~BaseMcdListView() = default;
 	BaseMcdListView( wxWindow* parent )
 		: _parent( parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_VIRTUAL )
 	{
@@ -134,7 +134,7 @@ class MemoryCardListView_Simple : public BaseMcdListView
 	typedef BaseMcdListView _parent;
 
 public:
-	virtual ~MemoryCardListView_Simple() throw() { }
+	virtual ~MemoryCardListView_Simple() = default;
 	MemoryCardListView_Simple( wxWindow* parent );
 
 	void CreateColumns();
@@ -182,7 +182,7 @@ namespace Panels
 		}
 
 	public:
-		virtual ~BaseMcdListPanel() throw() {}
+		virtual ~BaseMcdListPanel() = default;
 		BaseMcdListPanel( wxWindow* parent );
 
 		void CreateLayout();
@@ -295,7 +295,7 @@ namespace Panels
 
 	public:
 		McdConfigPanel_Toggles( wxWindow* parent );
-		virtual ~McdConfigPanel_Toggles() throw() { }
+		virtual ~McdConfigPanel_Toggles() = default;
 		void Apply();
 
 	protected:

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -222,7 +222,7 @@ namespace Panels
 
 
 	public:
-		virtual ~MemoryCardListPanel_Simple() throw();
+		virtual ~MemoryCardListPanel_Simple();
 		MemoryCardListPanel_Simple( wxWindow* parent );
 
 		void UpdateUI();

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -159,7 +159,7 @@ protected:
 
 public:
 	ApplyPluginsDialog( BaseApplicableConfigPanel* panel=NULL );
-	virtual ~ApplyPluginsDialog() throw() {}
+	virtual ~ApplyPluginsDialog() = default;
 
 	BaseApplicableConfigPanel* GetApplicableConfigPanel() const { return m_panel; }
 };
@@ -182,7 +182,7 @@ public:
 		m_owner = owner;
 	}
 
-	virtual ~ApplyOverValidStateEvent() throw() { }
+	virtual ~ApplyOverValidStateEvent() = default;
 	virtual ApplyOverValidStateEvent *Clone() const { return new ApplyOverValidStateEvent(*this); }
 
 protected:
@@ -203,7 +203,7 @@ protected:
 public:
 	wxString GetEventName() const { return L"PluginSelectorPanel::ApplyPlugins"; }
 
-	virtual ~SysExecEvent_ApplyPlugins() throw() {}
+	virtual ~SysExecEvent_ApplyPlugins() = default;
 	SysExecEvent_ApplyPlugins* Clone() const { return new SysExecEvent_ApplyPlugins( *this ); }
 
 	SysExecEvent_ApplyPlugins( ApplyPluginsDialog* parent, SynchronousActionState& sync )

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -437,7 +437,7 @@ Panels::PluginSelectorPanel::PluginSelectorPanel( wxWindow* parent )
 	Bind(wxEVT_BUTTON, &PluginSelectorPanel::OnConfigure_Clicked, this, ButtonId_Configure);
 }
 
-Panels::PluginSelectorPanel::~PluginSelectorPanel() throw()
+Panels::PluginSelectorPanel::~PluginSelectorPanel()
 {
 	CancelRefresh();		// in case the enumeration thread is currently refreshing...
 }

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -42,7 +42,7 @@ RecentIsoManager::RecentIsoManager( wxMenu* menu, int firstIdForMenuItems_or_wxI
 	Bind(wxEVT_MENU, &RecentIsoManager::OnChangedSelection, this);
 }
 
-RecentIsoManager::~RecentIsoManager() throw()
+RecentIsoManager::~RecentIsoManager()
 {
 	Unbind(wxEVT_MENU, &RecentIsoManager::OnChangedSelection, this);
 }

--- a/pcsx2/gui/RecentIsoList.h
+++ b/pcsx2/gui/RecentIsoList.h
@@ -50,7 +50,7 @@ protected:
 
 public:
 	RecentIsoManager( wxMenu* menu , int firstIdForMenuItems_or_wxID_ANY );
-	virtual ~RecentIsoManager() throw();
+	virtual ~RecentIsoManager();
 
 	void RemoveAllFromMenu();
 	void Repopulate();

--- a/pcsx2/gui/RecentIsoList.h
+++ b/pcsx2/gui/RecentIsoList.h
@@ -76,6 +76,6 @@ struct RecentIsoList
 	std::unique_ptr<wxMenu>				Menu;
 
 	RecentIsoList(int firstIdForMenuItems_or_wxID_ANY);
-	virtual ~RecentIsoList() throw() { }
+	virtual ~RecentIsoList() = default;
 };
 

--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -48,13 +48,13 @@ class SysExecEvent_ClearSavingLoadingFlag : public SysExecEvent
 public:
 	wxString GetEventName() const { return L"ClearSavingLoadingFlag"; }
 
-	virtual ~SysExecEvent_ClearSavingLoadingFlag() throw() { }
+	virtual ~SysExecEvent_ClearSavingLoadingFlag() = default;
 	SysExecEvent_ClearSavingLoadingFlag()
 	{
 	}
-	
+
 	SysExecEvent_ClearSavingLoadingFlag* Clone() const { return new SysExecEvent_ClearSavingLoadingFlag(); }
-	
+
 protected:
 	void InvokeEvent()
 	{

--- a/pcsx2/gui/SysState.cpp
+++ b/pcsx2/gui/SysState.cpp
@@ -45,10 +45,10 @@ static const wxChar* EntryFilename_InternalStructures	= L"PCSX2 Internal Structu
 class BaseSavestateEntry
 {
 protected:
-	BaseSavestateEntry() {}
+	BaseSavestateEntry() = default;
 
 public:
-	virtual ~BaseSavestateEntry() throw() {}
+	virtual ~BaseSavestateEntry() = default;
 
 	virtual wxString GetFilename() const=0;
 	virtual void FreezeIn( pxInputStream& reader ) const=0;
@@ -60,7 +60,7 @@ class MemorySavestateEntry : public BaseSavestateEntry
 {
 protected:
 	MemorySavestateEntry() {}
-	virtual ~MemorySavestateEntry() throw() {}
+	virtual ~MemorySavestateEntry() = default;
 
 public:
 	virtual void FreezeIn( pxInputStream& reader ) const;
@@ -83,7 +83,7 @@ public:
 		m_pid = pid;
 	}
 
-	virtual ~PluginSavestateEntry() throw() {}
+	virtual ~PluginSavestateEntry() = default;
 
 	virtual wxString GetFilename() const;
 	virtual void FreezeIn( pxInputStream& reader ) const;
@@ -147,7 +147,7 @@ void PluginSavestateEntry::FreezeOut( SaveStateBase& writer ) const
 class SavestateEntry_EmotionMemory : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_EmotionMemory() throw() {}
+	virtual ~SavestateEntry_EmotionMemory() = default;
 
 	wxString GetFilename() const		{ return L"eeMemory.bin"; }
 	u8* GetDataPtr() const				{ return eeMem->Main; }
@@ -163,7 +163,7 @@ public:
 class SavestateEntry_IopMemory : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_IopMemory() throw() {}
+	virtual ~SavestateEntry_IopMemory() = default;
 
 	wxString GetFilename() const		{ return L"iopMemory.bin"; }
 	u8* GetDataPtr() const				{ return iopMem->Main; }
@@ -173,7 +173,7 @@ public:
 class SavestateEntry_HwRegs : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_HwRegs() throw() {}
+	virtual ~SavestateEntry_HwRegs() = default;
 
 	wxString GetFilename() const		{ return L"eeHwRegs.bin"; }
 	u8* GetDataPtr() const				{ return eeHw; }
@@ -183,7 +183,7 @@ public:
 class SavestateEntry_IopHwRegs : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_IopHwRegs() throw() {}
+	virtual ~SavestateEntry_IopHwRegs() = default;
 
 	wxString GetFilename() const		{ return L"iopHwRegs.bin"; }
 	u8* GetDataPtr() const				{ return iopHw; }
@@ -193,7 +193,7 @@ public:
 class SavestateEntry_Scratchpad : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_Scratchpad() throw() {}
+	virtual ~SavestateEntry_Scratchpad() = default;
 
 	wxString GetFilename() const		{ return L"Scratchpad.bin"; }
 	u8* GetDataPtr() const				{ return eeMem->Scratch; }
@@ -203,7 +203,7 @@ public:
 class SavestateEntry_VU0mem : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_VU0mem() throw() {}
+	virtual ~SavestateEntry_VU0mem() = default;
 
 	wxString GetFilename() const		{ return L"vu0Memory.bin"; }
 	u8* GetDataPtr() const				{ return vuRegs[0].Mem; }
@@ -213,7 +213,7 @@ public:
 class SavestateEntry_VU1mem : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_VU1mem() throw() {}
+	virtual ~SavestateEntry_VU1mem() = default;
 
 	wxString GetFilename() const		{ return L"vu1Memory.bin"; }
 	u8* GetDataPtr() const				{ return vuRegs[1].Mem; }
@@ -223,7 +223,7 @@ public:
 class SavestateEntry_VU0prog : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_VU0prog() throw() {}
+	virtual ~SavestateEntry_VU0prog() = default;
 
 	wxString GetFilename() const		{ return L"vu0MicroMem.bin"; }
 	u8* GetDataPtr() const				{ return vuRegs[0].Micro; }
@@ -233,7 +233,7 @@ public:
 class SavestateEntry_VU1prog : public MemorySavestateEntry
 {
 public:
-	virtual ~SavestateEntry_VU1prog() throw() {}
+	virtual ~SavestateEntry_VU1prog() = default;
 
 	wxString GetFilename() const		{ return L"vu1MicroMem.bin"; }
 	u8* GetDataPtr() const				{ return vuRegs[1].Micro; }
@@ -313,7 +313,7 @@ protected:
 public:
 	wxString GetEventName() const { return L"VM_Download"; }
 
-	virtual ~SysExecEvent_DownloadState() throw() {}
+	virtual ~SysExecEvent_DownloadState() = default;
 	SysExecEvent_DownloadState* Clone() const { return new SysExecEvent_DownloadState( *this ); }
 	SysExecEvent_DownloadState( ArchiveEntryList* dest_list=NULL )
 	{
@@ -375,9 +375,7 @@ public:
 		m_lock_Compress.Assign(mtx_CompressToDisk);
 	}
 
-	virtual ~VmStateCompressThread() throw()
-	{
-	}
+	virtual ~VmStateCompressThread() = default;
 
 protected:
 	void OnStartInThread()
@@ -405,9 +403,7 @@ protected:
 public:
 	wxString GetEventName() const { return L"VM_ZipToDisk"; }
 
-	virtual ~SysExecEvent_ZipToDisk() throw()
-	{
-	}
+	virtual ~SysExecEvent_ZipToDisk() = default;
 
 	SysExecEvent_ZipToDisk* Clone() const { return new SysExecEvent_ZipToDisk( *this ); }
 
@@ -498,7 +494,7 @@ protected:
 public:
 	wxString GetEventName() const { return L"VM_UnzipFromDisk"; }
 
-	virtual ~SysExecEvent_UnzipFromDisk() throw() {}
+	virtual ~SysExecEvent_UnzipFromDisk() = default;
 	SysExecEvent_UnzipFromDisk* Clone() const { return new SysExecEvent_UnzipFromDisk( *this ); }
 	SysExecEvent_UnzipFromDisk( const wxString& filename )
 		: m_filename( filename )

--- a/pcsx2/gui/pxEventThread.h
+++ b/pcsx2/gui/pxEventThread.h
@@ -79,7 +79,7 @@ protected:
 	SynchronousActionState*		m_sync;
 
 public:
-	virtual ~SysExecEvent() throw() {}
+	virtual ~SysExecEvent() = default;
 	SysExecEvent* Clone() const { return new SysExecEvent( *this ); }
 
 	SysExecEvent( SynchronousActionState* sync=NULL )
@@ -145,7 +145,7 @@ protected:
 public:
 	wxString GetEventName() const { return m_TraceName; }
 
-	virtual ~SysExecEvent_MethodVoid() throw() {}
+	virtual ~SysExecEvent_MethodVoid() = default;
 	SysExecEvent_MethodVoid* Clone() const { return new SysExecEvent_MethodVoid( *this ); }
 
 	bool AllowCancelOnExit() const { return !m_IsCritical; }
@@ -214,7 +214,7 @@ protected:
 
 public:
 	pxEvtQueue();
-	virtual ~pxEvtQueue() throw() {}
+	virtual ~pxEvtQueue() = default;
 
 	virtual wxString GetEventHandlerName() const { return L"pxEvtQueue"; }
 
@@ -273,7 +273,7 @@ protected:
 
 public:
 	ExecutorThread( pxEvtQueue* evtandler = NULL );
-	virtual ~ExecutorThread() throw() { }
+	virtual ~ExecutorThread() = default;
 
 	virtual void ShutdownQueue();
 	bool IsRunning() const;

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -100,7 +100,7 @@ protected:
 
 public:
 	VtlbMemoryReserve( const wxString& name, size_t size );
-	virtual ~VtlbMemoryReserve() throw()
+	virtual ~VtlbMemoryReserve()
 	{
 		m_reserve.Release();
 	}
@@ -124,7 +124,7 @@ class eeMemoryReserve : public VtlbMemoryReserve
 
 public:
 	eeMemoryReserve();
-	virtual ~eeMemoryReserve() throw()
+	virtual ~eeMemoryReserve()
 	{
 		Release();
 	}
@@ -145,7 +145,7 @@ class iopMemoryReserve : public VtlbMemoryReserve
 
 public:
 	iopMemoryReserve();
-	virtual ~iopMemoryReserve() throw()
+	virtual ~iopMemoryReserve()
 	{
 		Release();
 	}
@@ -166,7 +166,7 @@ class vuMemoryReserve : public VtlbMemoryReserve
 
 public:
 	vuMemoryReserve();
-	virtual ~vuMemoryReserve() throw()
+	virtual ~vuMemoryReserve()
 	{
 		Release();
 	}

--- a/pcsx2/windows/WinConsolePipe.cpp
+++ b/pcsx2/windows/WinConsolePipe.cpp
@@ -140,7 +140,7 @@ public:
 	WinPipeRedirection( FILE* stdstream );
 	virtual ~WinPipeRedirection();
 
-	void Cleanup() throw();
+	void Cleanup() noexcept;
 };
 
 WinPipeRedirection::WinPipeRedirection( FILE* stdstream )
@@ -200,7 +200,7 @@ WinPipeRedirection::~WinPipeRedirection()
 	Cleanup();
 }
 
-void WinPipeRedirection::Cleanup() throw()
+void WinPipeRedirection::Cleanup() noexcept
 {
 	// Cleanup Order Notes:
 	//  * The redirection thread is most likely blocking on ReadFile(), so we can't Cancel yet, lest we deadlock --

--- a/pcsx2/windows/WinConsolePipe.cpp
+++ b/pcsx2/windows/WinConsolePipe.cpp
@@ -45,7 +45,7 @@ public:
 		m_name = (m_color == Color_Red) ? L"Redirect_Stderr" : L"Redirect_Stdout";
 	}
 
-	virtual ~WinPipeThread() throw()
+	virtual ~WinPipeThread()
 	{
 		_parent::Cancel();
 	}
@@ -138,7 +138,7 @@ protected:
 
 public:
 	WinPipeRedirection( FILE* stdstream );
-	virtual ~WinPipeRedirection() throw();
+	virtual ~WinPipeRedirection();
 
 	void Cleanup() throw();
 };

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -302,8 +302,8 @@ _mVUt __fi void* mVUsearchProg(u32 startPC, uptr pState) {
 //------------------------------------------------------------------
 recMicroVU0::recMicroVU0()		  { m_Idx = 0; IsInterpreter = false; }
 recMicroVU1::recMicroVU1()		  { m_Idx = 1; IsInterpreter = false; }
-void recMicroVU0::Vsync() throw() { mVUvsyncUpdate(microVU0); }
-void recMicroVU1::Vsync() throw() { mVUvsyncUpdate(microVU1); }
+void recMicroVU0::Vsync() noexcept { mVUvsyncUpdate(microVU0); }
+void recMicroVU1::Vsync() noexcept { mVUvsyncUpdate(microVU1); }
 
 void recMicroVU0::Reserve() {
 	if (m_Reserved.exchange(1) == 0)
@@ -316,11 +316,11 @@ void recMicroVU1::Reserve() {
 	}
 }
 
-void recMicroVU0::Shutdown() throw() {
+void recMicroVU0::Shutdown() noexcept {
 	if (m_Reserved.exchange(0) == 1)
 		mVUclose(microVU0);
 }
-void recMicroVU1::Shutdown() throw() {
+void recMicroVU1::Shutdown() noexcept {
 	if (m_Reserved.exchange(0) == 1) {
 		vu1Thread.WaitVU();
 		mVUclose(microVU1);

--- a/pcsx2/x86/newVif_HashBucket.h
+++ b/pcsx2/x86/newVif_HashBucket.h
@@ -63,7 +63,7 @@ public:
 		m_bucket.fill(nullptr);
 	}
 
-	~HashBucket() throw() { clear(); }
+	~HashBucket() { clear(); }
 
 	__fi nVifBlock* find(const nVifBlock& dataPtr) {
 		nVifBlock* chainpos = m_bucket[dataPtr.hash_key];

--- a/pcsx2/x86/newVif_UnpackSSE.h
+++ b/pcsx2/x86/newVif_UnpackSSE.h
@@ -46,7 +46,7 @@ protected:
 
 public:
 	VifUnpackSSE_Base();
-	virtual ~VifUnpackSSE_Base() throw() {}
+	virtual ~VifUnpackSSE_Base() = default;
 
 	virtual void xUnpack( int upktype ) const;
 	virtual bool IsUnmaskedOp() const=0;
@@ -90,7 +90,7 @@ public:
 
 public:
 	VifUnpackSSE_Simple(bool usn_, bool domask_, int curCycle_);
-	virtual ~VifUnpackSSE_Simple() throw() {}
+	virtual ~VifUnpackSSE_Simple() = default;
 
 	virtual bool IsUnmaskedOp() const{ return !doMask; }
 
@@ -125,7 +125,7 @@ public:
 		vCL		= src.vCL;
 	}
 
-	virtual ~VifUnpackSSE_Dynarec() throw() {}
+	virtual ~VifUnpackSSE_Dynarec() = default;
 
 	virtual bool IsUnmaskedOp() const{ return !doMode && !doMask; }
 

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -4592,7 +4592,7 @@ void recSuperVU0::Reserve()
 	SuperVUAlloc(0);
 }
 
-void recSuperVU0::Shutdown() throw()
+void recSuperVU0::Shutdown() noexcept
 {
 	SuperVUDestroy( 0 );
 }
@@ -4639,7 +4639,7 @@ void recSuperVU1::Reserve()
 	SuperVUAlloc(1);
 }
 
-void recSuperVU1::Shutdown() throw()
+void recSuperVU1::Shutdown() noexcept
 {
 	vu1Thread.WaitVU();
 	SuperVUDestroy( 1 );

--- a/plugins/GSdx/GSDrawScanline.cpp
+++ b/plugins/GSdx/GSDrawScanline.cpp
@@ -35,10 +35,6 @@ GSDrawScanline::GSDrawScanline()
 	m_local.gd = &m_global;
 }
 
-GSDrawScanline::~GSDrawScanline()
-{
-}
-
 void GSDrawScanline::BeginDraw(const GSRasterizerData* data)
 {
 	memcpy(&m_global, &((const SharedData*)data)->global, sizeof(m_global));

--- a/plugins/GSdx/GSDrawScanline.h
+++ b/plugins/GSdx/GSDrawScanline.h
@@ -63,7 +63,7 @@ protected:
 
 public:
 	GSDrawScanline();
-	virtual ~GSDrawScanline();
+	virtual ~GSDrawScanline() = default;
 
 	// IDrawScanline
 

--- a/plugins/GSdx/GSLzma.cpp
+++ b/plugins/GSdx/GSLzma.cpp
@@ -158,9 +158,6 @@ GSDumpRaw::GSDumpRaw(char* filename, const char* repack_filename) : GSDumpFile(f
 	m_start     = 0;
 }
 
-GSDumpRaw::~GSDumpRaw() {
-}
-
 bool GSDumpRaw::IsEof() {
 	return feof(m_fp);
 }

--- a/plugins/GSdx/GSLzma.h
+++ b/plugins/GSdx/GSLzma.h
@@ -78,7 +78,7 @@ class GSDumpRaw : public GSDumpFile {
 	public:
 
 	GSDumpRaw(char* filename, const char* repack_filename);
-	virtual ~GSDumpRaw();
+	virtual ~GSDumpRaw() = default;
 
 	bool IsEof();
 	void Read(void* ptr, size_t size);

--- a/plugins/GSdx/PSX/GPUDrawScanline.cpp
+++ b/plugins/GSdx/PSX/GPUDrawScanline.cpp
@@ -31,10 +31,6 @@ GPUDrawScanline::GPUDrawScanline()
 	m_local.gd = &m_global;
 }
 
-GPUDrawScanline::~GPUDrawScanline()
-{
-}
-
 void GPUDrawScanline::BeginDraw(const GSRasterizerData* data)
 {
 	memcpy(&m_global, &((const SharedData*)data)->global, sizeof(m_global));

--- a/plugins/GSdx/PSX/GPUDrawScanline.h
+++ b/plugins/GSdx/PSX/GPUDrawScanline.h
@@ -56,7 +56,7 @@ protected:
 
 public:
 	GPUDrawScanline();
-	virtual ~GPUDrawScanline();
+	virtual ~GPUDrawScanline() = default;
 
 	// IDrawScanline
 

--- a/plugins/GSdx/PSX/GPUState.cpp
+++ b/plugins/GSdx/PSX/GPUState.cpp
@@ -55,10 +55,6 @@ GPUState::GPUState()
 	Reset();
 }
 
-GPUState::~GPUState()
-{
-}
-
 void GPUState::Reset()
 {
 	m_env.Reset();

--- a/plugins/GSdx/PSX/GPUState.h
+++ b/plugins/GSdx/PSX/GPUState.h
@@ -124,7 +124,7 @@ public:
 
 public:
 	GPUState();
-	virtual ~GPUState();
+	virtual ~GPUState() = default;
 
 	virtual void Reset();
 	virtual void Flush();


### PR DESCRIPTION
Initial goal was to replace constructor/destructor code reported by clang-tidy.

But I learn in the process that destructors are noexcept by default. So `throw()` => /dev/null

And I found plenty of case of trivial destructor not reported by clang-tidy but that I feel could be `= default` too.

Finally, I replaced the few remaining `throw()` by `noexcept`.