### PR TITLE
GSdx-HW: Optimize RT buffer size calculation for custom resolutions

### DIFF
--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -156,6 +156,7 @@ protected:
 
 	GSVector2i m_lod; // Min & Max level of detail
 	const GSVector2i native_buffer = GSVector2i(1280, 1024);
+	void CustomResolutionScaling();
 
 public:
 	GSRendererHW(GSTextureCache* tc);

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -155,6 +155,7 @@ protected:
 	bool m_channel_shuffle;
 
 	GSVector2i m_lod; // Min & Max level of detail
+	const GSVector2i native_buffer = GSVector2i(1280, 1024);
 
 public:
 	GSRendererHW(GSTextureCache* tc);


### PR DESCRIPTION
**Summary of changes**:

* Revamped custom resolution buffer scaling code making it more efficient, should provide decent performance boost when large framebuffer is enabled at GS limited scenarios.

* Allow future resizing of the buffer size for custom resolution when the buffer required is increased due to the changes in CRTC/Framebuffer dimensions.

Honestly, string formatting is awful in C++ without any external libraries like Boost, It's so simple in Python. They should really consider providing any easier alternative instead of using ``sprintf/snprintf``, using the streams for formatting is even more worse. I've made the most stupid use of smart pointers ever. :P

Here are some benchmarks of the improvement, (Mostly done at GS limited scenarios)

**Master Branch**:

Game | Resolution | Large Framebuffer disabled | Large framebuffer enabled
------------ | ------------- | ------------ | -------------
ICO | 1024x1024 | 28 fps | 28 fps
ICO | 3840x2160 | 15 fps | 12 fps
Digimon Rumble Arena | 1024x1024 | 46 fps | 46 fps
Digimon Rumble Arena | 3840x2160 | 34 fps | 32 fps
Ben10 Alien Force: Vilgax Attacks | 1024x1024 | 95 fps | 95 fps
Ben10 Alien Force: Vilgax Attacks | 3840x2160 | 26 fps | 2 fps

**Pull Request Branch**:

Game | Resolution | Large Framebuffer disabled | Large framebuffer enabled
------------ | ------------- | ------------ | -------------
ICO | 1024x1024 | 28 fps | 28 fps
ICO | 3840x2160 | 15 fps | 12 fps
Digimon Rumble Arena | 1024x1024 | 46 fps | 46 fps
Digimon Rumble Arena | 3840x2160 | 34 fps | 34 fps
Ben10 Alien Force: Vilgax Attacks | 1024x1024 | 95 fps | 95 fps
Ben10 Alien Force: Vilgax Attacks | 3840x2160 | 26 fps | 26 fps

To be less verbose, the new buffer size calculation algorithm only increases the buffer size when necessary (Like at ICO) and doesn't increase them unnecessarily. (giving performance boost in GS limited games like Ben10 Alien Force: Vilgax Attacks)