### PR TITLE
GSdx TC: Peformance improvement by using custom container. Ported erase iterator trick to SW mode.

### DIFF
--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -142,6 +142,7 @@ set(GSdxHeaders
     GSDump.h
     GSdx.h
     GSdxResources.h
+    GSFastList.h
     GSFunctionMap.h
     GS.h
     GSLocalMemory.h

--- a/plugins/GSdx/GSCodeBuffer.cpp
+++ b/plugins/GSdx/GSCodeBuffer.cpp
@@ -32,9 +32,9 @@ GSCodeBuffer::GSCodeBuffer(size_t blocksize)
 
 GSCodeBuffer::~GSCodeBuffer()
 {
-	for(list<void*>::iterator i = m_buffers.begin(); i != m_buffers.end(); ++i)
+	for(auto buffer : m_buffers)
 	{
-		vmfree(*i, m_blocksize);
+		vmfree(buffer, m_blocksize);
 	}
 }
 

--- a/plugins/GSdx/GSCodeBuffer.h
+++ b/plugins/GSdx/GSCodeBuffer.h
@@ -23,7 +23,7 @@
 
 class GSCodeBuffer
 {
-	list<void*> m_buffers;
+	std::vector<void*> m_buffers;
 	size_t m_blocksize;
 	size_t m_pos, m_reserved;
 	uint8* m_ptr;

--- a/plugins/GSdx/GSDevice.cpp
+++ b/plugins/GSdx/GSDevice.cpp
@@ -45,7 +45,7 @@ GSDevice::GSDevice()
 
 GSDevice::~GSDevice()
 {
-	for(auto &t : m_pool) delete t;
+	for(auto t : m_pool) delete t;
 
 	delete m_backbuffer;
 	delete m_merge;
@@ -66,7 +66,7 @@ bool GSDevice::Create(const std::shared_ptr<GSWnd>& wnd)
 
 bool GSDevice::Reset(int w, int h)
 {
-	for(auto &t : m_pool) delete t;
+	for(auto t : m_pool) delete t;
 
 	m_pool.clear();
 
@@ -133,9 +133,9 @@ void GSDevice::Present(GSTexture* sTex, GSTexture* dTex, const GSVector4& dRect,
 
 GSTexture* GSDevice::FetchSurface(int type, int w, int h, bool msaa, int format)
 {
-	GSVector2i size(w, h);
+	const GSVector2i size(w, h);
 
-	for(list<GSTexture*>::iterator i = m_pool.begin(); i != m_pool.end(); ++i)
+	for(auto i = m_pool.begin(); i != m_pool.end(); ++i)
 	{
 		GSTexture* t = *i;
 
@@ -154,9 +154,8 @@ void GSDevice::PrintMemoryUsage()
 {
 #ifdef ENABLE_OGL_DEBUG
 	uint32 pool = 0;
-	for(list<GSTexture*>::iterator i = m_pool.begin(); i != m_pool.end(); i++)
+	for(auto t : m_pool)
 	{
-		GSTexture* t = *i;
 		if (t)
 			pool += t->GetMemUsage();
 	}

--- a/plugins/GSdx/GSDevice.h
+++ b/plugins/GSdx/GSDevice.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "GSFastList.h"
 #include "GSWnd.h"
 #include "GSTexture.h"
 #include "GSVertex.h"
@@ -103,7 +104,7 @@ public:
 
 class GSDevice : public GSAlignedClass<32>
 {
-	list<GSTexture*> m_pool;
+	FastList<GSTexture*> m_pool;
 
 protected:
 	std::shared_ptr<GSWnd> m_wnd;

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -449,7 +449,7 @@ void GSDevice11::DrawIndexedPrimitive()
 
 void GSDevice11::DrawIndexedPrimitive(int offset, int count)
 {
-	ASSERT(offset + count <= m_index.count);
+	ASSERT(offset + count <= (int)m_index.count);
 
 	m_ctx->DrawIndexed(count, m_index.start + offset, m_vertex.start);
 }

--- a/plugins/GSdx/GSDirtyRect.cpp
+++ b/plugins/GSdx/GSDirtyRect.cpp
@@ -37,15 +37,15 @@ GSDirtyRect::GSDirtyRect(const GSVector4i& r, uint32 psm)
 	bottom = r.bottom;
 }
 
-GSVector4i GSDirtyRect::GetDirtyRect(const GIFRegTEX0& TEX0)
+const GSVector4i GSDirtyRect::GetDirtyRect(const GIFRegTEX0& TEX0) const
 {
 	GSVector4i r;
 
-	GSVector2i src = GSLocalMemory::m_psm[psm].bs;
+	const GSVector2i src = GSLocalMemory::m_psm[psm].bs;
 
 	if(psm != TEX0.PSM)
 	{
-		GSVector2i dst = GSLocalMemory::m_psm[TEX0.PSM].bs;
+		const GSVector2i dst = GSLocalMemory::m_psm[TEX0.PSM].bs;
 
 		r.left = left * dst.x / src.x;
 		r.top = top * dst.y / src.y;
@@ -62,20 +62,20 @@ GSVector4i GSDirtyRect::GetDirtyRect(const GIFRegTEX0& TEX0)
 
 //
 
-GSVector4i GSDirtyRectList::GetDirtyRectAndClear(const GIFRegTEX0& TEX0, const GSVector2i& size)
+const GSVector4i GSDirtyRectList::GetDirtyRectAndClear(const GIFRegTEX0& TEX0, const GSVector2i& size)
 {
 	if(!empty())
 	{
 		GSVector4i r(INT_MAX, INT_MAX, 0, 0);
 
-		for(list<GSDirtyRect>::iterator i = begin(); i != end(); ++i)
+		for(const auto& dirty_rect : *this)
 		{
-			r = r.runion(i->GetDirtyRect(TEX0));
+			r = r.runion(dirty_rect.GetDirtyRect(TEX0));
 		}
 
 		clear();
 
-		GSVector2i bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
+		const GSVector2i bs = GSLocalMemory::m_psm[TEX0.PSM].bs;
 
 		return r.ralign<Align_Outside>(bs).rintersect(GSVector4i(0, 0, size.x, size.y));
 	}

--- a/plugins/GSdx/GSDirtyRect.h
+++ b/plugins/GSdx/GSDirtyRect.h
@@ -35,12 +35,12 @@ class GSDirtyRect
 public:
 	GSDirtyRect();
 	GSDirtyRect(const GSVector4i& r, uint32 psm);
-	GSVector4i GetDirtyRect(const GIFRegTEX0& TEX0);
+	const GSVector4i GetDirtyRect(const GIFRegTEX0& TEX0) const;
 };
 
-class GSDirtyRectList : public list<GSDirtyRect>
+class GSDirtyRectList : public std::vector<GSDirtyRect>
 {
 public:
 	GSDirtyRectList() {}
-	GSVector4i GetDirtyRectAndClear(const GIFRegTEX0& TEX0, const GSVector2i& size);
+	const GSVector4i GetDirtyRectAndClear(const GIFRegTEX0& TEX0, const GSVector2i& size);
 };

--- a/plugins/GSdx/GSFastList.h
+++ b/plugins/GSdx/GSFastList.h
@@ -1,0 +1,277 @@
+/*
+*	Copyright (C) 2017-2017 Alessandro Vetere
+*	Copyright (C) 2007-2009 Gabest
+*	http://www.gabest.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with GNU Make; see the file COPYING.  If not, write to
+*  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#pragma once
+
+template <class T>
+struct Element {
+	T  data;
+	uint16 next_index;
+	uint16 prev_index;
+};
+
+template <class T>
+class FastListIterator;
+
+template <class T>
+class FastList {
+	friend class FastListIterator<T>;
+private:
+	// The index of the first element of the list is m_buffer[0].next_index
+	//     The first Element<T> of the list has prev_index equal to 0
+	// The index of the last element of the list is m_buffer[0].prev_index
+	//     The last Element<T> of the list has next_index equal to 0
+	// All the other Element<T> of the list are chained by next_index and prev_index
+	// m_buffer has dynamic size m_capacity
+	// Due to m_buffer reallocation, the pointers to Element<T> stored into the array
+	//     are invalidated every time Grow() is executed. But FastListIterator<T> is
+	//     index based, not pointer based, and the elements are copied in order on Grow(),
+	//     so there is no iterator invalidation (which is an index invalidation) until 
+	//     the relevant iterator (or the index alone) are erased from the list.
+	// m_buffer[0] is always present as auxiliary Element<T> of the list
+	Element<T>* m_buffer;
+	uint16 m_capacity;
+	uint16 m_free_indexes_stack_top;
+	// m_free_indexes_stack has dynamic size (m_capacity - 1)
+	// m_buffer indexes that are free to be used are stacked here
+	uint16* m_free_indexes_stack;
+
+public:
+	__forceinline FastList() {
+		m_buffer = nullptr;
+		clear();
+	}
+
+	__forceinline ~FastList() {
+		_aligned_free(m_buffer);
+	}
+
+	void clear() {
+		// Initialize m_capacity to 4 so we avoid to Grow() on initial insertions
+		// The code doesn't break if this value is changed with anything from 1 to USHRT_MAX
+		m_capacity = 4;
+
+		// Initialize m_buffer and m_free_indexes_stack as a contiguous block of memory starting at m_buffer
+		// This should increase cache locality and reduce memory fragmentation
+		_aligned_free(m_buffer);
+		m_buffer = (Element<T>*)_aligned_malloc(m_capacity * sizeof(Element<T>) + (m_capacity - 1) * sizeof(uint16), 64);
+		m_free_indexes_stack = (uint16*)&m_buffer[m_capacity];
+
+		// Initialize m_buffer[0], data field is unused but initialized using default T constructor
+		m_buffer[0] = { T(), 0, 0 };
+
+		// m_free_indexes_stack top index is 0, bottom index is m_capacity - 2
+		m_free_indexes_stack_top = 0;
+
+		// m_buffer index 0 is reserved for auxiliary element
+		for (uint16 i = 0; i < m_capacity - 1; i++) {
+			m_free_indexes_stack[i] = i + 1;
+		}
+	}
+
+	// Insert the element in front of the list and return its position in m_buffer
+	__forceinline uint16 InsertFront(const T& data) {
+		if (Full()) {
+			Grow();
+		}
+
+		// Pop a free index from the stack
+		const uint16 free_index = m_free_indexes_stack[m_free_indexes_stack_top++];
+		m_buffer[free_index].data = data;
+		ListInsertFront(free_index);
+		return free_index;
+	}
+
+	__forceinline void push_front(const T& data) {
+		InsertFront(data);
+	}
+
+	__forceinline const T& back() const {
+		return m_buffer[LastIndex()].data;
+	}
+
+	__forceinline void pop_back() {
+		EraseIndex(LastIndex());
+	}
+
+	__forceinline uint16 size() const {
+		return m_free_indexes_stack_top;
+	}
+
+	__forceinline bool empty() const {
+		return size() == 0;
+	}	
+
+	__forceinline void EraseIndex(const uint16 index) {
+		ListRemove(index);
+		m_free_indexes_stack[--m_free_indexes_stack_top] = index;
+	}
+
+	__forceinline void MoveFront(const uint16 index) {
+		if (FirstIndex() != index) {
+			ListRemove(index);
+			ListInsertFront(index);
+		}
+	}
+
+	__forceinline const FastListIterator<T> begin() const {
+		return FastListIterator<T>(this, FirstIndex());
+	}
+
+	__forceinline const FastListIterator<T> end() const {
+		return FastListIterator<T>(this, 0);
+	}
+
+	__forceinline FastListIterator<T> erase(FastListIterator<T> i) {
+		EraseIndex(i.Index());
+		return ++i;
+	}
+
+private:
+	// Accessed by FastListIterator<T> using class friendship
+	__forceinline const T& Data(const uint16 index) const {
+		return m_buffer[index].data;
+	}
+
+	// Accessed by FastListIterator<T> using class friendship
+	__forceinline uint16 NextIndex(const uint16 index) const {
+		return m_buffer[index].next_index;
+	}
+
+	// Accessed by FastListIterator<T> using class friendship
+	__forceinline uint16 PrevIndex(const uint16 index) const {
+		return m_buffer[index].prev_index;
+	}
+
+	__forceinline uint16 FirstIndex() const {
+		return m_buffer[0].next_index;
+	}
+
+	__forceinline uint16 LastIndex() const {
+		return m_buffer[0].prev_index;
+	}
+
+	__forceinline bool Full() const {
+		// The minus one is due to the presence of the auxiliary element
+		return size() == m_capacity - 1;
+	}
+
+	__forceinline void ListInsertFront(const uint16 index) {
+		// Update prev / next indexes to add m_buffer[index] to the chain
+		Element<T>& head = m_buffer[0];
+		m_buffer[index].prev_index = 0;
+		m_buffer[index].next_index = head.next_index;
+		m_buffer[head.next_index].prev_index = index;
+		head.next_index = index;
+	}
+
+	__forceinline void ListRemove(const uint16 index) {
+		// Update prev / next indexes to remove m_buffer[index] from the chain
+		const Element<T>& to_remove = m_buffer[index];
+		m_buffer[to_remove.prev_index].next_index = to_remove.next_index;
+		m_buffer[to_remove.next_index].prev_index = to_remove.prev_index;
+	}
+
+	void Grow() {
+		if (m_capacity == USHRT_MAX) {
+			throw std::runtime_error("FastList size maxed out at USHRT_MAX (65535) elements, cannot grow futhermore.");
+		}
+
+		const uint16 new_capacity = m_capacity <= (USHRT_MAX / 2) ? (m_capacity * 2) : USHRT_MAX;
+
+		Element<T>* new_buffer = (Element<T>*)_aligned_malloc(new_capacity * sizeof(Element<T>) + (new_capacity - 1) * sizeof(uint16), 64);
+		uint16* new_free_indexes_stack = (uint16*)&new_buffer[new_capacity];
+
+		memcpy(new_buffer, m_buffer, m_capacity * sizeof(Element<T>));
+		memcpy(new_free_indexes_stack, m_free_indexes_stack, (m_capacity - 1) * sizeof(uint16));
+		
+		_aligned_free(m_buffer);
+		
+		m_buffer = new_buffer;
+		m_free_indexes_stack = new_free_indexes_stack;
+
+		// Initialize the additional space in the stack
+		for (uint16 i = m_capacity - 1; i < new_capacity - 1; i++) {
+			m_free_indexes_stack[i] = i + 1;
+		}
+
+		m_capacity = new_capacity;
+	}
+};
+
+
+template <class T>
+// This iterator is const_iterator
+class FastListIterator
+{
+private:
+	const FastList<T>* m_fastlist;
+	uint16 m_index;
+
+public:
+	__forceinline FastListIterator(const FastList<T>* fastlist, const uint16 index) {
+		m_fastlist = fastlist;
+		m_index = index;
+	}
+
+	__forceinline bool operator!=(const FastListIterator<T>& other) const {
+		return (m_index != other.m_index);
+	}
+
+	__forceinline bool operator==(const FastListIterator<T>& other) const {
+		return (m_index == other.m_index);
+	}
+
+	// Prefix increment
+	__forceinline const FastListIterator<T>& operator++() {
+		m_index = m_fastlist->NextIndex(m_index);
+		return *this;
+	}
+
+	// Postfix increment
+	__forceinline const FastListIterator<T> operator++(int) {
+		FastListIterator<T> copy(*this);
+		++(*this);
+		return copy;
+	}
+
+	// Prefix decrement
+	__forceinline const FastListIterator<T>& operator--() {
+		m_index = m_fastlist->PrevIndex(m_index);
+		return *this;
+	}
+
+	// Postfix decrement
+	__forceinline const FastListIterator<T> operator--(int) {
+		FastListIterator<T> copy(*this);
+		--(*this);
+		return copy;
+	}
+
+	__forceinline const T& operator*() const {
+		return m_fastlist->Data(m_index);
+	}
+
+	__forceinline uint16 Index() const {
+		return m_index;
+	}
+};

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -699,6 +699,9 @@ vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 			}
 		}
 
+		// Allocate vector with initial size
+		p2t[page].reserve(m.size());
+
 		// sort by x and flip the mask (it will be used to erase a lot of bits in a loop, [x] &= ~y)
 
 		for(hash_map<uint32, uint32>::iterator j = m.begin(); j != m.end(); ++j)

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -75,7 +75,7 @@ void GSTextureCache::RemovePartial()
 
 	for (int type = 0; type < 2; type++)
 	{
-		for (auto &t : m_dst[type]) delete t;
+		for (auto t : m_dst[type]) delete t;
 
 		m_dst[type].clear();
 	}
@@ -87,7 +87,7 @@ void GSTextureCache::RemoveAll()
 
 	for(int type = 0; type < 2; type++)
 	{
-		for (auto &t : m_dst[type]) delete t;
+		for (auto t : m_dst[type]) delete t;
 
 		m_dst[type].clear();
 	}
@@ -200,10 +200,9 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 
 	Source* src = NULL;
 
-	list<Source*>& m = m_src.m_map[TEX0.TBP0 >> 5];
+	auto& m = m_src.m_map[TEX0.TBP0 >> 5];
 
-
-	for(list<Source*>::iterator i = m.begin(); i != m.end(); ++i)
+	for(auto i = m.begin(); i != m.end(); ++i)
 	{
 		Source* s = *i;
 
@@ -225,7 +224,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 				continue;
 		}
 
-		m.splice(m.begin(), m, i);
+		m.MoveFront(i.Index());
 
 		src = s;
 
@@ -257,10 +256,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		// (Simply not doing this code at all makes a lot of previsouly missing stuff show (but breaks pretty much everything
 		// else.)
 
-		for(list<Target*>::iterator i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); ++i)
-		{
-			Target* t = *i;
-
+		for(auto t : m_dst[RenderTarget]) {
 			if(t->m_used && t->m_dirty.empty()) {
 				// Typical bug (MGS3 blue cloud):
 				// 1/ RT used as 32 bits => alpha channel written
@@ -357,9 +353,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 			// Unfortunately, I don't have any Arc the Lad testcase
 			//
 			// 1/ Check only current frame, I guess it is only used as a postprocessing effect
-			for(list<Target*>::iterator i = m_dst[DepthStencil].begin(); i != m_dst[DepthStencil].end(); ++i) {
-				Target* t = *i;
-
+			for(auto t : m_dst[DepthStencil]) {
 				if(!t->m_age && t->m_used && t->m_dirty.empty() && GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
 				{
 					GL_INS("TC: Warning depth format read as color format. Pixels will be scrambled");
@@ -445,13 +439,13 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 
 	Target* dst = NULL;
 
-	for(list<Target*>::iterator i = m_dst[type].begin(); i != m_dst[type].end(); ++i)
-	{
+	auto& list = m_dst[type];
+	for(auto i = list.begin(); i != list.end(); ++i) {
 		Target* t = *i;
 
 		if(bp == t->m_TEX0.TBP0)
 		{
-			m_dst[type].splice(m_dst[type].begin(), m_dst[type], i);
+			list.MoveFront(i.Index());
 
 			dst = t;
 
@@ -476,9 +470,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 		// Depth stencil/RT can be an older RT/DS but only check recent RT/DS to avoid to pick
 		// some bad data.
 		Target* dst_match = nullptr;
-		for(list<Target*>::iterator i = m_dst[rev_type].begin(); i != m_dst[rev_type].end(); ++i) {
-			Target* t = *i;
-
+		for(auto t : m_dst[rev_type]) {
 			if (bp == t->m_TEX0.TBP0) {
 				if (t->m_age == 0) {
 					dst_match = t;
@@ -610,10 +602,8 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 
 
 #if 0
-	for(list<Target*>::iterator i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); i++)
+	for(auto t : m_dst[RenderTarget])
 	{
-		Target* t = *i;
-
 		if(bp == t->m_TEX0.TBP0)
 		{
 			dst = t;
@@ -674,7 +664,8 @@ void GSTextureCache::InvalidateVideoMemType(int type, uint32 bp)
 	if (!CanConvertDepth())
 		return;
 
-	for(list<Target*>::iterator i = m_dst[type].begin(); i != m_dst[type].end(); ++i)
+	auto& list = m_dst[type];
+	for(auto i = list.begin(); i != list.end(); ++i)
 	{
 		Target* t = *i;
 
@@ -684,7 +675,7 @@ void GSTextureCache::InvalidateVideoMemType(int type, uint32 bp)
 					t->m_texture ? t->m_texture->GetID() : 0,
 					t->m_TEX0.TBP0);
 
-			m_dst[type].erase(i);
+			list.erase(i);
 			delete t;
 
 			break;
@@ -707,13 +698,11 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 	{
 		// Remove Source that have same BP as the render target (color&dss)
 		// rendering will dirty the copy
-		const list<Source*>& m = m_src.m_map[bp >> 5];
-
-		for(list<Source*>::const_iterator i = m.begin(); i != m.end(); )
+		auto& list = m_src.m_map[bp >> 5];
+		for(auto i = list.begin(); i != list.end(); )
 		{
-			list<Source*>::const_iterator j = i++;
-
-			Source* s = *j;
+			Source* s = *i;
+			++i;
 
 			if(GSUtil::HasSharedBits(bp, psm, s->m_TEX0.TBP0, s->m_TEX0.PSM))
 			{
@@ -726,14 +715,11 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 			// Detect half of the render target (fix snow engine game)
 			// Target Page (8KB) have always a width of 64 pixels
 			// Half of the Target is TBW/2 pages * 8KB / (1 block * 256B) = 0x10
-
-			const list<Source*>& m = m_src.m_map[bbp >> 5];
-
-			for(list<Source*>::const_iterator i = m.begin(); i != m.end(); )
+			auto& list = m_src.m_map[bbp >> 5];
+			for(auto i = list.begin(); i != list.end(); )
 			{
-				list<Source*>::const_iterator j = i++;
-
-				Source* s = *j;
+				Source* s = *i;
+				++i;
 
 				if(GSUtil::HasSharedBits(bbp, psm, s->m_TEX0.TBP0, s->m_TEX0.PSM))
 				{
@@ -749,11 +735,8 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 			uint32 end_block = GSLocalMemory::m_psm[psm].bn(rect.width(), rect.height(), bp, bw);
 			auto type = RenderTarget;
 
-			for(auto i = m_dst[type].begin(); i != m_dst[type].end(); )
+			for(auto t : m_dst[type])
 			{
-				auto j = i++;
-
-				Target* t = *j;
 				if (t->m_TEX0.TBP0 > bp && t->m_end_block < end_block) {
 					// Haunting ground expect to clean buffer B with a rendering into buffer A.
 					// Situation is quite messy as it would require to extract the data from the buffer A
@@ -784,34 +767,33 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 	{
 		uint32 page = *p;
 
-		const list<Source*>& m = m_src.m_map[page];
-
-		for(list<Source*>::const_iterator i = m.begin(); i != m.end(); )
+		auto& list = m_src.m_map[page];
+		for(auto i = list.begin(); i != list.end(); )
 		{
-			list<Source*>::const_iterator j = i++;
-
-			Source* s = *j;
+			Source* s = *i;
+			++i;
 
 			if(GSUtil::HasSharedBits(psm, s->m_TEX0.PSM))
 			{
-				uint32* RESTRICT valid = s->m_valid;
-
 				bool b = bp == s->m_TEX0.TBP0;
 
 				if(!s->m_target)
 				{
-					if (m_disable_partial_invalidation && s->m_repeating) {
+					if(m_disable_partial_invalidation && s->m_repeating)
+					{
 						m_src.RemoveAt(s);
-					} else {
+					}
+					else
+					{
+						uint32* RESTRICT valid = s->m_valid;
+
 						// Invalidate data of input texture
 						if(s->m_repeating)
 						{
 							// Note: very hot path on snowbling engine game
-							vector<GSVector2i>& l = s->m_p2t[page];
-
-							for(vector<GSVector2i>::iterator k = l.begin(); k != l.end(); ++k)
+							for(const GSVector2i& k : s->m_p2t[page])
 							{
-								valid[k->x] &= k->y;
+								valid[k.x] &= k.y;
 							}
 						}
 						else
@@ -842,10 +824,10 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 
 	for(int type = 0; type < 2; type++)
 	{
-		for(list<Target*>::iterator i = m_dst[type].begin(); i != m_dst[type].end(); )
+		auto& list = m_dst[type];
+		for(auto i = list.begin(); i != list.end(); )
 		{
-			list<Target*>::iterator j = i++;
-
+			auto j = i++;
 			Target* t = *j;
 
 			// GH: (I think) this code is completely broken. Typical issue:
@@ -867,7 +849,7 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 				}
 				else
 				{
-					m_dst[type].erase(j);
+					list.erase(j);
 					GL_CACHE("TC: Remove Target(%s) %d (0x%x)", to_string(type),
 								t->m_texture ? t->m_texture->GetID() : 0,
 								t->m_TEX0.TBP0);
@@ -962,12 +944,8 @@ void GSTextureCache::InvalidateLocalMem(GSOffset* off, const GSVector4i& r)
 	// It works for all the games mentioned below and fixes a couple of other ones as well
 	// (Busen0: Wizardry and Chaos Legion).
 	// Also in a few games the below code ran the Grandia3 case when it shouldn't :p
-	for(list<Target*>::iterator i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); )
+	for(auto t : m_dst[RenderTarget])
 	{
-		list<Target*>::iterator j = i++;
-
-		Target* t = *j;
-
 		if (t->m_TEX0.PSM != PSM_PSMZ32 && t->m_TEX0.PSM != PSM_PSMZ24 && t->m_TEX0.PSM != PSM_PSMZ16 && t->m_TEX0.PSM != PSM_PSMZ16S)
 		{
 			if(GSUtil::HasSharedBits(bp, psm, t->m_TEX0.TBP0, t->m_TEX0.PSM))
@@ -1075,17 +1053,20 @@ void GSTextureCache::InvalidateVideoMemSubTarget(GSTextureCache::Target* rt)
 	if (!rt)
 		return;
 
-	for(list<Target*>::iterator i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); ) {
-		list<Target*>::iterator j = i++;
-		Target* t = *j;
+	auto& list = m_dst[RenderTarget];
 
-		if ((t->m_TEX0.TBP0 > rt->m_TEX0.TBP0) && (t->m_end_block < rt->m_end_block) && (t->m_TEX0.TBW == rt->m_TEX0.TBW)
+	for(auto i = list.begin(); i != list.end(); ) {
+		Target* t = *i;
+
+		if((t->m_TEX0.TBP0 > rt->m_TEX0.TBP0) && (t->m_end_block < rt->m_end_block) && (t->m_TEX0.TBW == rt->m_TEX0.TBW)
 				&& (t->m_TEX0.TBP0 < t->m_end_block)) {
 			GL_INS("InvalidateVideoMemSubTarget: rt 0x%x -> 0x%x, sub rt 0x%x -> 0x%x",
 					rt->m_TEX0.TBP0, rt->m_end_block, t->m_TEX0.TBP0, t->m_end_block);
 
-			m_dst[RenderTarget].erase(j);
+			i = list.erase(i);
 			delete t;
+		} else {
+			++i;
 		}
 	}
 }
@@ -1095,19 +1076,20 @@ void GSTextureCache::IncAge()
 	int maxage = m_src.m_used ? 3 : 30;
 
 	// You can't use m_map[page] because Source* are duplicated on several pages.
-	for(hash_set<Source*>::iterator i = m_src.m_surfaces.begin(); i != m_src.m_surfaces.end(); )
+	for(auto i = m_src.m_surfaces.begin(); i != m_src.m_surfaces.end(); )
 	{
-		hash_set<Source*>::iterator j = i++;
-
-		Source* s = *j;
+		Source* s = *i;
 
 		if(s->m_shared_texture) {
 			// Shared textures are temporary only added in the hash set but not in the texture
 			// cache list therefore you can't use RemoveAt
-			m_src.m_surfaces.erase(s);
+			i = m_src.m_surfaces.erase(i);
 			delete s;
-		} else if(++s->m_age > maxage) {
-			m_src.RemoveAt(s);
+		} else {
+			++i;
+			if (++s->m_age > maxage) {
+				m_src.RemoveAt(s);
+			}
 		}
 	}
 
@@ -1121,11 +1103,10 @@ void GSTextureCache::IncAge()
 
 	for(int type = 0; type < 2; type++)
 	{
-		for(list<Target*>::iterator i = m_dst[type].begin(); i != m_dst[type].end(); )
+		auto& list = m_dst[type];
+		for(auto i = list.begin(); i != list.end(); )
 		{
-			list<Target*>::iterator j = i++;
-
-			Target* t = *j;
+			Target* t = *i;
 
 			// This variable is used to detect the texture shuffle effect. There is a high
 			// probability that game will do it on the current RT.
@@ -1138,12 +1119,14 @@ void GSTextureCache::IncAge()
 
 			if(++t->m_age > maxage)
 			{
-				m_dst[type].erase(j);
+				i = list.erase(i);
 				GL_CACHE("TC: Remove Target(%s): %d (0x%x) due to age", to_string(type),
 							t->m_texture ? t->m_texture->GetID() : 0,
 							t->m_TEX0.TBP0);
 
 				delete t;
+			} else {
+				++i;
 			}
 		}
 	}
@@ -1519,24 +1502,20 @@ void GSTextureCache::PrintMemoryUsage()
 	uint32 tex_rt = 0;
 	uint32 rt     = 0;
 	uint32 dss    = 0;
-	for(hash_set<Source*>::iterator i = m_src.m_surfaces.begin(); i != m_src.m_surfaces.end(); i++) {
-		Source* s = *i;
-		if (s && !s->m_shared_texture) {
-			if (s->m_target)
+	for(auto s : m_src.m_surfaces) {
+		if(s && !s->m_shared_texture) {
+			if(s->m_target)
 				tex_rt += s->m_texture->GetMemUsage();
 			else
 				tex    += s->m_texture->GetMemUsage();
-
 		}
 	}
-	for(list<Target*>::iterator i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); i++) {
-		Target* t = *i;
-		if (t)
+	for(auto t : m_dst[RenderTarget]) {
+		if(t)
 			rt += t->m_texture->GetMemUsage();
 	}
-	for(list<Target*>::iterator i = m_dst[DepthStencil].begin(); i != m_dst[DepthStencil].end(); i++) {
-		Target* t = *i;
-		if (t)
+	for(auto t : m_dst[DepthStencil]) {
+		if(t)
 			dss += t->m_texture->GetMemUsage();
 	}
 
@@ -1992,8 +1971,7 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, GSOffset*
 		// GH: I don't know why but it seems we only consider the first page for a render target
 		size_t page = TEX0.TBP0 >> 5;
 
-		m_map[page].push_front(s);
-		s->m_erase_it[page] = m_map[page].begin();
+		s->m_erase_it[page] = m_map[page].InsertFront(s);
 
 		return;
 	}
@@ -2003,7 +1981,7 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, GSOffset*
 	{
 		if(uint32 p = s->m_pages_as_bit[i])
 		{
-			list<Source*>* m = &m_map[i << 5];
+			auto* m = &m_map[i << 5];
 			auto* e = &s->m_erase_it[i << 5];
 
 			unsigned long j;
@@ -2015,8 +1993,7 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, GSOffset*
 				// Or BLSR (AKA Reset Lowest Set Bit). No dependency but require BMI1 (basically a recent CPU)
 				p ^= 1U << j;
 
-				m[j].push_front(s);
-				e[j] = m[j].begin();
+				e[j] = m[j].InsertFront(s);
 			}
 		}
 	}
@@ -2024,7 +2001,7 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, GSOffset*
 
 void GSTextureCache::SourceMap::RemoveAll()
 {
-	for (auto &t : m_surfaces) delete t;
+	for(auto s : m_surfaces) delete s;
 
 	m_surfaces.clear();
 
@@ -2044,9 +2021,8 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 
 	if (s->m_target)
 	{
-		size_t page = s->m_TEX0.TBP0 >> 5;
-		m_map[page].erase(s->m_erase_it[page]);
-
+		const size_t page = s->m_TEX0.TBP0 >> 5;
+		m_map[page].EraseIndex(s->m_erase_it[page]);
 	}
 	else
 	{
@@ -2054,8 +2030,8 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 		{
 			if(uint32 p = s->m_pages_as_bit[i])
 			{
-				list<Source*>* m = &m_map[i << 5];
-				auto* e = &s->m_erase_it[i << 5];
+				auto* m = &m_map[i << 5];
+				const auto* e = &s->m_erase_it[i << 5];
 
 				unsigned long j;
 
@@ -2066,7 +2042,7 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 					// Or BLSR (AKA Reset Lowest Set Bit). No dependency but require BMI1 (basically a recent CPU)
 					p ^= 1U << j;
 
-					m[j].erase(e[j]);
+					m[j].EraseIndex(e[j]);
 				}
 			}
 		}

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "GSRenderer.h"
+#include "GSFastList.h"
 #include "GSDirtyRect.h"
 
 class GSTextureCache
@@ -66,14 +67,14 @@ public:
 		bool m_complete;
 		bool m_repeating;
 		bool m_spritehack_t;
-		vector<GSVector2i>* m_p2t;
+		std::vector<GSVector2i>* m_p2t;
 		// Keep a trace of the target origin. There is no guarantee that pointer will
 		// still be valid on future. However it ought to be good when the source is created
 		// so it can be used to access un-converted data for the current draw call.
 		GSTexture* m_from_target;
 		GIFRegTEX0 m_layer_TEX0[7]; // Detect already loaded value
-		// Keep an GSTextureCache::m_map iterator to allow fast erase
-		std::array<std::list<Source*>::iterator, MAX_PAGES> m_erase_it;
+		// Keep a GSTextureCache::SourceMap::m_map iterator to allow fast erase
+		std::array<uint16, MAX_PAGES> m_erase_it;
 		uint32* m_pages_as_bit;
 
 	public:
@@ -108,7 +109,7 @@ public:
 	{
 	public:
 		hash_set<Source*> m_surfaces;
-		std::list<Source*> m_map[MAX_PAGES];
+		std::array<FastList<Source*>, MAX_PAGES> m_map;
 		uint32 m_pages[16]; // bitmap of all pages
 		bool m_used;
 
@@ -123,7 +124,7 @@ public:
 protected:
 	GSRenderer* m_renderer;
 	SourceMap m_src;
-	std::list<Target*> m_dst[2];
+	FastList<Target*> m_dst[2];
 	bool m_paltex;
 	int m_spritehack;
 	bool m_preload_frame;

--- a/plugins/GSdx/GSTextureCacheSW.cpp
+++ b/plugins/GSdx/GSTextureCacheSW.cpp
@@ -36,48 +36,42 @@ GSTextureCacheSW::Texture* GSTextureCacheSW::Lookup(const GIFRegTEX0& TEX0, cons
 {
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
 
-	Texture* t = NULL;
+	auto& m = m_map[TEX0.TBP0 >> 5];
 
-	list<Texture*>& m = m_map[TEX0.TBP0 >> 5];
-
-	for(list<Texture*>::iterator i = m.begin(); i != m.end(); ++i)
+	for(auto i = m.begin(); i != m.end(); ++i)
 	{
-		Texture* t2 = *i;
+		Texture* t = *i;
 
-		if(((TEX0.u32[0] ^ t2->m_TEX0.u32[0]) | ((TEX0.u32[1] ^ t2->m_TEX0.u32[1]) & 3)) != 0) // TBP0 TBW PSM TW TH
+		if(((TEX0.u32[0] ^ t->m_TEX0.u32[0]) | ((TEX0.u32[1] ^ t->m_TEX0.u32[1]) & 3)) != 0) // TBP0 TBW PSM TW TH
 		{
 			continue;
 		}
 
-		if((psm.trbpp == 16 || psm.trbpp == 24) && TEX0.TCC && TEXA != t2->m_TEXA)
+		if((psm.trbpp == 16 || psm.trbpp == 24) && TEX0.TCC && TEXA != t->m_TEXA)
 		{
 			continue;
 		}
 
-		if(tw0 != 0 && t2->m_tw != tw0)
+		if(tw0 != 0 && t->m_tw != tw0)
 		{
 			continue;
 		}
 
-		m.splice(m.begin(), m, i);
-
-		t = t2;
-
+		// Lookup hit
+		m.MoveFront(i.Index());
 		t->m_age = 0;
-
-		break;
+		return t;
 	}
 
-	if(t == NULL)
+	// Lookup miss
+	Texture* t = new Texture(m_state, tw0, TEX0, TEXA);
+
+	m_textures.insert(t);
+
+	for(const uint32* p = t->m_pages.n; *p != GSOffset::EOP; p++)
 	{
-		t = new Texture(m_state, tw0, TEX0, TEXA);
-
-		m_textures.insert(t);
-
-		for(const uint32* p = t->m_pages.n; *p != GSOffset::EOP; p++)
-		{
-			m_map[*p].push_front(t);
-		}
+		const uint32 page = *p;
+		t->m_erase_it[page] = m_map[page].InsertFront(t);
 	}
 
 	return t;
@@ -87,25 +81,19 @@ void GSTextureCacheSW::InvalidatePages(const uint32* pages, uint32 psm)
 {
 	for(const uint32* p = pages; *p != GSOffset::EOP; p++)
 	{
-		uint32 page = *p;
-
-		const list<Texture*>& map = m_map[page];
-
-		for(list<Texture*>::const_iterator i = map.begin(); i != map.end(); ++i)
+		const uint32 page = *p;
+		
+		for(Texture* t : m_map[page])
 		{
-			Texture* t = *i;
-
 			if(GSUtil::HasSharedBits(psm, t->m_sharedbits))
 			{
 				uint32* RESTRICT valid = t->m_valid;
 
 				if(t->m_repeating)
 				{
-					vector<GSVector2i>& l = t->m_p2t[page];
-
-					for(vector<GSVector2i>::iterator j = l.begin(); j != l.end(); ++j)
+					for(const GSVector2i& j : t->m_p2t[page])
 					{
-						valid[j->x] &= j->y;
+						valid[j.x] &= j.y;
 					}
 				}
 				else
@@ -121,7 +109,7 @@ void GSTextureCacheSW::InvalidatePages(const uint32* pages, uint32 psm)
 
 void GSTextureCacheSW::RemoveAll()
 {
-	for(auto &i : m_textures) delete i;
+	for(auto i : m_textures) delete i;
 
 	m_textures.clear();
 
@@ -133,29 +121,25 @@ void GSTextureCacheSW::RemoveAll()
 
 void GSTextureCacheSW::IncAge()
 {
-	for(hash_set<Texture*>::iterator i = m_textures.begin(); i != m_textures.end(); )
+	for(auto i = m_textures.begin(); i != m_textures.end(); )
 	{
-		hash_set<Texture*>::iterator j = i++;
-
-		Texture* t = *j;
+		Texture* t = *i;
 
 		if(++t->m_age > 10)
 		{
-			m_textures.erase(j);
+			i = m_textures.erase(i);
 
 			for(const uint32* p = t->m_pages.n; *p != GSOffset::EOP; p++)
 			{
-				list<Texture*>& m = m_map[*p];
-
-				for(list<Texture*>::iterator i = m.begin(); i != m.end(); )
-				{
-					list<Texture*>::iterator j = i++;
-
-					if(*j == t) {m.erase(j); break;}
-				}
+				const uint32 page = *p;
+				m_map[page].EraseIndex(t->m_erase_it[page]);
 			}
 
 			delete t;
+		}
+		else
+		{
+			++i;
 		}
 	}
 }

--- a/plugins/GSdx/GSTextureCacheSW.h
+++ b/plugins/GSdx/GSTextureCacheSW.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "GSRenderer.h"
+#include "GSFastList.h"
 
 class GSTextureCacheSW
 {
@@ -38,8 +39,9 @@ public:
 		uint32 m_age;
 		bool m_complete;
 		bool m_repeating;
-		vector<GSVector2i>* m_p2t;
+		std::vector<GSVector2i>* m_p2t;
 		uint32 m_valid[MAX_PAGES];
+		std::array<uint16, MAX_PAGES> m_erase_it;
 		struct {uint32 bm[16]; const uint32* n;} m_pages;
 		const uint32* RESTRICT m_sharedbits;
 
@@ -57,7 +59,7 @@ public:
 protected:
 	GSState* m_state;
 	hash_set<Texture*> m_textures;
-	std::array<std::list<Texture*>, MAX_PAGES> m_map;
+	std::array<FastList<Texture*>, MAX_PAGES> m_map;
 
 public:
 	GSTextureCacheSW(GSState* state);

--- a/plugins/GSdx/GSdx.vcxproj
+++ b/plugins/GSdx/GSdx.vcxproj
@@ -210,6 +210,7 @@
     <ClInclude Include="GSDrawScanlineCodeGenerator.h" />
     <ClInclude Include="GSDump.h" />
     <ClInclude Include="GSdx.h" />
+    <ClInclude Include="GSFastList.h" />
     <ClInclude Include="GSFunctionMap.h" />
     <ClInclude Include="GSLocalMemory.h" />
     <ClInclude Include="GSLzma.h" />

--- a/plugins/GSdx/GSdx.vcxproj.filters
+++ b/plugins/GSdx/GSdx.vcxproj.filters
@@ -581,6 +581,9 @@
     <ClInclude Include="boost_spsc_queue.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="GSFastList.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="GSThread_CXX11.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
This follows #1756.

06/06/2017: Major edit reflecting current status of PR. I will fix errors and clean the PR as soon as possible.
12/06/2017: PR updated.

Some improvements to the existing texture caching system are done:
- I implemented the template class GSFastList as replacement for std::list in GSdx TC, both HW and SW. In GSdx TC HW (similar applies to SW Texture*), the std::list (double linked list) used for Source* and Target* lists is replaced by the custom GSFastList, double linked list built on top of a compact array, which uses a stack for free indexes and a custom struct as list node (with data, index of previous element and index of next element) to manage list traversal, node insert and node deletion.
The data content of the node is generic T and also the initial size of the list can be declared via template.
The list has max size equal to 2^16-1 = 65535, but the head of the list is always present thus only 2^16-2 elements can be added.
The list automatically resizes by doubling it's size (both the array of nodes and the stack, array, of free indexes are realloc'd) when an insert occurs and the list is full.
No resizing on deletion of nodes, thus the size in memory of the list only grows with time.
This list by being compact is not heavily fragmented into memory and thus much more cache friendly than a std::list.
It should be almost as fast as an std::vector if not faster, and it is optimized for the TC tasks.
Beware there is no bounds checking for indexes passed to GSFastList functions.
- I ported the infamous "erase iterator" trick from GSdx TC hardware to software, with serious FPS improvements in the same games that benefit from the trick in hardware mode.
- I became paranoid and hunted down std::list in other parts of the code, replacing it with the data structure that seemed most stuited for the task.

The performance improvement are measured using standard GSdx-SSE4 32 bit D3D11 without any modification to any config.
My machine is i5-2500k@4.3GHz, GTX770 OC, 16GB DDR3-1600, Win7 64bit

|   HW Mode     | Before | After |
|--------|--------|-------|
| ZoE2 - Anubis | 40     | 42.5    |
| BG:DA - Inn| 25     | 29.5    |

|   SW Mode     | Before | After |
|--------|--------|-------|
| ZoE2 - Anubis | 37 | 38    |
| BG:DA - Inn| 55     | 65    |

OGL performances on my machine seemed to be bottlenecked by other factors in ZoE2, while in BG:DA they showed almost the same results of D3D11, but I didn't include those though.
I would be very happy to receive comments and results of other benchmarks if someone is brave enough.
