### PR TITLE
GSdx-OGL: Extend ICO workaround to PAL videomode

### DIFF
--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -1312,8 +1312,10 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 	if (m_game.title == CRC::ICO) {
 		GSVertex* v = &m_vertex.buff[0];
+		const GSVideoMode mode = GetVideoMode();
 		if (tex && m_vt.m_primclass == GS_SPRITE_CLASS && m_vertex.next == 2 && PRIM->ABE && // Blend texture
-				v[1].U == 8200 && v[1].V == 7176 && // at display resolution 512x448
+				((v[1].U == 8200 && v[1].V == 7176 && mode == GSVideoMode::NTSC) || // at display resolution 512x448
+				(v[1].U == 8200 && v[1].V == 8200 && mode == GSVideoMode::PAL)) && // at display resolution 512x512
 				tex->m_TEX0.PSM == PSM_PSMT8H) {  // i.e. read the alpha channel of a 32 bits texture
 			// Note potentially we can limit to TBP0:0x2800
 


### PR DESCRIPTION
**Summary of changes**:

* Extend ICO hack to also remove white lines when using PAL video mode. (For more details regarding the issue, refer here: http://forums.pcsx2.net/Thread-ICO-graphic-issues-with-1-4-1-5)