### PR TITLE
GSdx: Cleanup MSVC warnings

### DIFF
--- a/plugins/GSdx/GSDump.cpp
+++ b/plugins/GSdx/GSDump.cpp
@@ -51,7 +51,7 @@ void GSDumpBase::Transfer(int index, const uint8* mem, size_t size)
 		return;
 
 	AppendRawData(0);
-	AppendRawData(index);
+	AppendRawData(static_cast<uint8>(index));
 	AppendRawData(&size, 4);
 	AppendRawData(mem, size);
 }
@@ -75,7 +75,7 @@ bool GSDumpBase::VSync(int field, bool last, const GSPrivRegSet* regs)
 	AppendRawData(regs, sizeof(*regs));
 
 	AppendRawData(1);
-	AppendRawData(field);
+	AppendRawData(static_cast<uint8>(field));
 
 	if (last)
 		m_extra_frames--;

--- a/plugins/GSdx/GSLzma.cpp
+++ b/plugins/GSdx/GSLzma.cpp
@@ -159,7 +159,7 @@ GSDumpRaw::GSDumpRaw(char* filename, const char* repack_filename) : GSDumpFile(f
 }
 
 bool GSDumpRaw::IsEof() {
-	return feof(m_fp);
+	return !!feof(m_fp);
 }
 
 bool GSDumpRaw::Read(void* ptr, size_t size) {


### PR DESCRIPTION
**Summary of changes**

* Explicitly cast the variables to the required data type to fix some warnings.
* Omit warnings from liblzma (Too much warnings and not on our side anyway - Any opinion? @turtleli @gregory38 )

Don't really care about the warnings to be honest, they were just annoying as they kept popping up all the time I rebuilt GSdx. -_-

Personally I'd prefer if these warnings from liblzma is ignored for the reasons stated on the commit message. (Same for all the other 3rd party code but I decided to only do for this subproject at the moment as I noticed lots of warnings from this specific one)