### PR TITLE
PCSX2-WX: Add more granularity to EE cycle rate slider

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -390,7 +390,7 @@ struct Pcsx2Config
 				vuThread        :1;		// Enable Threaded VU1
 		BITFIELD_END
 
-		s8	EECycleRate;		// EE cycle rate selector (1.0, 1.5, 2.0)
+		u16	EECycleRate;
 		u8	VUCycleSteal;		// VU Cycle Stealer factor (0, 1, 2, or 3)
 
 		SpeedhackOptions();
@@ -509,7 +509,7 @@ TraceLogFilters&				SetTraceConfig();
 
 
 /////////////////////////////////////////////////////////////////////////////////////////
-// Helper Macros for Reading Emu Configurations.
+// Helper Macros/Functions for Reading Emu Configurations.
 //
 
 // ------------ CPU / Recompiler Options ---------------
@@ -520,6 +520,12 @@ TraceLogFilters&				SetTraceConfig();
 #define CHECK_EEREC					(EmuConfig.Cpu.Recompiler.EnableEE && GetCpuProviders().IsRecAvailable_EE())
 #define CHECK_CACHE					(EmuConfig.Cpu.Recompiler.EnableEECache)
 #define CHECK_IOPREC				(EmuConfig.Cpu.Recompiler.EnableIOP && GetCpuProviders().IsRecAvailable_IOP())
+
+// ------------ Speed Hacks!!! ---------------
+#define EESlider_MaxValue (300)
+#define EESlider_MinValue (50)
+#define EESlider_DefaultValue (100)
+const auto EESliderValueCheck = [](int x) { if (x > EESlider_MaxValue || x < EESlider_MinValue) return EESlider_DefaultValue; else return x; };
 
 //------------ SPECIAL GAME FIXES!!! ---------------
 #define CHECK_VUADDSUBHACK			(EmuConfig.Gamefixes.VuAddSubHack)	 // Special Fix for Tri-ace games, they use an encryption algorithm that requires VU addi opcode to be bit-accurate.

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -47,7 +47,7 @@ Pcsx2Config::SpeedhackOptions::SpeedhackOptions()
 Pcsx2Config::SpeedhackOptions& Pcsx2Config::SpeedhackOptions::DisableAll()
 {
 	bitset			= 0;
-	EECycleRate		= 0;
+	EECycleRate		= 100;
 	VUCycleSteal	= 0;
 	
 	return *this;

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1056,8 +1056,8 @@ bool AppConfig::IsOkApplyPreset(int n)
 		case 5 :	//Set VU cycle steal to 2 clicks (maximum-1)
 					vuUsed?0:(vuUsed=true, EmuOptions.Speedhacks.VUCycleSteal = 2);
 		
-		case 4 :	//set EE cyclerate to 2 clicks (maximum)
-					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = -2);
+		case 4 :
+					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = 60);
 
 		case 3 :	//Set VU cycle steal to 1 click, set VU clamp mode to 'none'
 					vuUsed?0:(vuUsed=true, EmuOptions.Speedhacks.VUCycleSteal = 1);
@@ -1066,8 +1066,8 @@ bool AppConfig::IsOkApplyPreset(int n)
 					EmuOptions.Cpu.Recompiler.vuSignOverflow = false; //VU Clamp mode to 'none'
 
 		//best balanced hacks combo?
-		case 2 :	//set EE cyclerate to 1 click.
-					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = -1);
+		case 2 :
+					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = 80);
 					// EE timing hack appears to break the BIOS text and cause slowdowns in a few titles.
 					//EnableGameFixes = true;
 					//EmuOptions.Gamefixes.EETimingHack = true;

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -351,7 +351,7 @@ namespace Panels
 		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
 
 	protected:
-		const wxChar* GetEEcycleSliderMsg( int val );
+		std::string GetEEcycleSliderMsg( int val );
 		const wxChar* GetVUcycleSliderMsg( int val );
 		void SetEEcycleSliderMsg();
 		void SetVUcycleSliderMsg();
@@ -359,7 +359,7 @@ namespace Panels
 
 		void OnEnable_Toggled( wxCommandEvent& evt );
 		void Defaults_Click( wxCommandEvent& evt );
-		void EECycleRate_Scroll(wxScrollEvent &event);
+		void EECycleRate_Scroll(wxCommandEvent &event);
 		void VUCycleRate_Scroll(wxScrollEvent &event);
 	};
 

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -19,51 +19,43 @@
 
 using namespace pxSizerFlags;
 
-const wxChar* Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
+std::string Panels::SpeedHacksPanel::GetEEcycleSliderMsg( int val )
 {
-	switch( val )
+	int clockspeed = static_cast<float>(294) * val / 100;
+	wxColour color = wxColour(0, 0, 0);
+
+	switch (val / 10)
 	{
-		case -3:
-		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"-3 - Reduces the EE's cyclerate to about 50%.  Big speedup, but *will* cause stuttering audio on many FMVs.");
-		}
-		case -2:
-		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"-2 - Reduces the EE's cyclerate to about 60%.  Moderate speedup, but may cause stuttering audio on many FMVs.");
-		}
-		case -1:
-		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"-1 - Reduces the EE's cyclerate to about 75%.  Mild speedup for most games with high compatibility.");
-		}
-		case 0:
-		{
-			const wxColour DarkSeaGreen = wxColour(14, 158, 19);
-			m_msg_eecycle->SetForegroundColour(DarkSeaGreen);
-			return pxEt(L"0 - Default cyclerate (100%). This closely matches the actual speed of a real PS2 EmotionEngine.");
-		}
-		case 1:
-		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"1 - Increases the EE's cyclerate to about 130%. Mildly increases hardware requirements, may increase in-game FPS.");
-		}
-		case 2:
-		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"2 - Increases the EE's cyclerate to about 180%. Increases hardware requirements, may noticeably increase in-game FPS.");
-		}
-		case 3:
-		{
-			m_msg_eecycle->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"3 - Increases the EE's cyclerate to about 300%. Greatly increases hardware requirements, may noticeably increase in-game FPS.\nThis setting can cause games to FAIL TO BOOT.");
-		}
-		default:
-			break;
+	case 5: case 6:
+		color = wxColour(L"Red");
+		break;
+	case 7:
+		color = wxColour(255, 69, 0); // Orange Red
+		break;
+	case 8:
+		color = wxColour(0, 100, 0); // Forest Green
+		break;
+	case 9: case 10: case 11:
+		if (val == 100)
+			color = wxColour(14, 158, 19); // Dark Sea Green
+		else
+			color = wxColour(0, 128, 0); // Just Green
+		break;
+	case 12: case 13: case 14: case 15: case 16:
+		color = wxColour(0, 100, 0); // Forest Green
+		break;
+	case 17: case 18: case 19: case 20: case 21: case 22: case 23: case 24:
+		color = wxColour(255, 69, 0); // Orange Red
+		break;
+	case 25: case 26: case 27: case 28: case 29: case 30:
+		color = wxColour(L"Red");
+		break;
+	default:
+		pxAssert(false);
 	}
 
-	return L"Unreachable Warning Suppressor!!";
+	m_msg_eecycle->SetForegroundColour(color);
+	return std::to_string(val) + "% (" + std::to_string(clockspeed) + (" MHz)");
 }
 
 const wxChar* Panels::SpeedHacksPanel::GetVUcycleSliderMsg( int val )
@@ -137,9 +129,11 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 
 	m_eeSliderPanel = new wxPanelWithHelpers( left, wxVERTICAL, _("EE Cyclerate [Not Recommended]") );
 
-	m_slider_eecycle = new wxSlider( m_eeSliderPanel, wxID_ANY, 0, -3, 3,
-		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
+	m_slider_eecycle = new wxSlider( m_eeSliderPanel, wxID_ANY, EESlider_DefaultValue, EESlider_MinValue, EESlider_MaxValue,
+		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL | wxSL_AUTOTICKS);
 
+	m_slider_eecycle->ClearTicks();
+	m_slider_eecycle->SetTick(100);
 	m_msg_eecycle = new pxStaticHeading( m_eeSliderPanel );
 
 	const wxChar* ee_tooltip = pxEt( L"Setting lower values on this slider effectively reduces the clock speed of the EmotionEngine's R5900 core cpu, and typically brings big speedups to games that fail to utilize the full potential of the real PS2 hardware. Conversely, higher values effectively increase the clock speed which may bring about an increase in in-game FPS while also making games more demanding and possibly causing glitches."
@@ -251,7 +245,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 
 	// ------------------------------------------------------------------------
 
-	Bind(wxEVT_SCROLL_CHANGED, &SpeedHacksPanel::EECycleRate_Scroll, this, m_slider_eecycle->GetId());
+	Bind(wxEVT_SLIDER, &SpeedHacksPanel::EECycleRate_Scroll, this, m_slider_eecycle->GetId());
 	Bind(wxEVT_SCROLL_CHANGED, &SpeedHacksPanel::VUCycleRate_Scroll, this, m_slider_vustealer->GetId());
 	Bind(wxEVT_CHECKBOX, &SpeedHacksPanel::OnEnable_Toggled, this, m_check_Enable->GetId());
 	Bind(wxEVT_BUTTON, &SpeedHacksPanel::Defaults_Click, this, wxID_DEFAULT);
@@ -302,7 +296,7 @@ void Panels::SpeedHacksPanel::ApplyConfigToGui( AppConfig& configToApply, int fl
 	// First, set the values of the widgets (checked/unchecked etc).
 	m_check_Enable->SetValue(configToApply.EnableSpeedHacks);
 
-	m_slider_eecycle	->SetValue( opts.EECycleRate );
+	m_slider_eecycle	->SetValue( EESliderValueCheck(opts.EECycleRate) );
 	m_slider_vustealer	->SetValue( opts.VUCycleSteal );
 
 	SetEEcycleSliderMsg();
@@ -363,12 +357,9 @@ void Panels::SpeedHacksPanel::Defaults_Click( wxCommandEvent& evt )
 	evt.Skip();
 }
 
-void Panels::SpeedHacksPanel::EECycleRate_Scroll(wxScrollEvent &event)
+void Panels::SpeedHacksPanel::EECycleRate_Scroll(wxCommandEvent &event)
 {
 	SetEEcycleSliderMsg();
-
-	TrigLayout();
-
 	event.Skip();
 }
 


### PR DESCRIPTION
**Summary of changes**:

* Added more granularity to the slider, 251 different options to select from! (ranging from 50% to 300% clockspeed)

![slider](https://snag.gy/aQDc5e.jpg)
![gifslider](https://media.giphy.com/media/l0IymG9aVownE97LG/giphy.gif)
Some other things to discuss about,
* Maybe ``EE Cyclerate`` in the slider should be renamed to something different?

 It's something technical, we increment the cycles before an event by a higher value in underclock and increment it to a lower value in overclock, so it seems sort of confusing to me as people might think that right side increments the cycle rate even higher? Well, normal users might not know much about it, so maybe not worth worrying about and just keep the name as it is?

For those who don't understand, in order to manage the number of instructions executed per second, in most emulators, the following method of cycle clock timing is used:

```c++
cycle_clock += instructions_executed;
while(cycle_clock > next_event_time)
{
  execute_event();
  setup_next_event();
}
```

The bigger the value of ``instructions_executed``, the fewer the instructions which can be executed by the game before the next vsync event occurs. In case of underclock, we're having the value of ``instructions_executed`` as a very high value which causes the EE to actually do less amount of work, it's the opposite for overclock. The manipulation is done by modifying the IPC rate, the system still counts in the units of EE's 294MHz clock. I think we're modifying the scale of cycles per instruction instead of directly modifying the clock speed due to potential problems in timing of the event scheduler which is closely linked to the clock speed of EE. (Maybe?)

* Added colors for different levels of selection in the slider.

I've added various text colors for different levels in the slider ranging from Red, Orange Red, Forest Green, Dark Green, Green. Please test it out and provide your opinion on them - Is it too much/unnecessary (or) actually something useful which might hint the compatibility of the slider level selection to the end user?

* Need tons of testing!

Previously, there was a safe limit on the code which prevented the scaling of blocks when the current amount of blocks recompiling is too low. I removed that limit for overclock values to provide proper scaling of blocks in overclock values. (While making the overclock a bit more effective, it might also introduce some new issues, so please do tons of tests for glitches/crashes/explosions on your games compared to previous overclock behavior)

**Build download link**: [[**Appveyor**]](https://ci.appveyor.com/api/buildjobs/5j0e8pabdr76y52t/artifacts/pcsx2-v1.5.0-dev-2122-g98dacdde3-3100-vs2015-Win32-AppVeyor.7z)