### PR TITLE
glsl: reduce geometry shader complexity

### DIFF
--- a/plugins/GSdx/res/glsl/tfx_vgs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_vgs.glsl
@@ -93,7 +93,7 @@ struct vertex
     vec4 c;
 };
 
-void out_vertex(in vertex v)
+void out_vertex(in vec4 position, in vertex v)
 {
     GSout.t_float  = v.t_float;
     GSout.t_int    = v.t_int;
@@ -104,6 +104,7 @@ void out_vertex(in vertex v)
 #else
     GSout.fc       = GSin[1].fc;
 #endif
+    gl_Position = position;
     gl_PrimitiveID = gl_PrimitiveIDIn;
     EmitVertex();
 }
@@ -113,7 +114,7 @@ layout(points) in;
 #else
 layout(lines) in;
 #endif
-layout(triangle_strip, max_vertices = 6) out;
+layout(triangle_strip, max_vertices = 4) out;
 
 #if GS_POINT == 1
 
@@ -130,26 +131,14 @@ void gs_main()
     lb_p.x    = lt_p.x;
     rt_p.y    = lt_p.y;
 
-    // Triangle 1
-    gl_Position = lt_p;
-    out_vertex(point);
+    out_vertex(lt_p, point);
 
-    gl_Position = lb_p;
-    out_vertex(point);
+    out_vertex(lb_p, point);
 
-    gl_Position = rt_p;
-    out_vertex(point);
-    EndPrimitive();
+    out_vertex(rt_p, point);
 
-    // Triangle 2
-    gl_Position = lb_p;
-    out_vertex(point);
+    out_vertex(rb_p, point);
 
-    gl_Position = rt_p;
-    out_vertex(point);
-
-    gl_Position = rb_p;
-    out_vertex(point);
     EndPrimitive();
 }
 
@@ -171,26 +160,14 @@ void gs_main()
     vec4 lb_p = gl_in[0].gl_Position + vec4(line_width, 0.0f, 0.0f);
     vec4 rb_p = gl_in[1].gl_Position + vec4(line_width, 0.0f, 0.0f);
 
-    // Triangle 1
-    gl_Position = lt_p;
-    out_vertex(left);
+    out_vertex(lt_p, left);
 
-    gl_Position = lb_p;
-    out_vertex(left);
+    out_vertex(lb_p, left);
 
-    gl_Position = rt_p;
-    out_vertex(right);
-    EndPrimitive();
+    out_vertex(rt_p, right);
 
-    // Triangle 2
-    gl_Position = lb_p;
-    out_vertex(left);
+    out_vertex(rb_p, right);
 
-    gl_Position = rt_p;
-    out_vertex(right);
-
-    gl_Position = rb_p;
-    out_vertex(right);
     EndPrimitive();
 }
 
@@ -228,26 +205,14 @@ void gs_main()
     rt.t_int.y   = lt.t_int.y;
     rt.t_int.w   = lt.t_int.w;
 
-    // Triangle 1
-    gl_Position = lt_p;
-    out_vertex(lt);
+    out_vertex(lt_p, lt);
 
-    gl_Position = lb_p;
-    out_vertex(lb);
+    out_vertex(lb_p, lb);
 
-    gl_Position = rt_p;
-    out_vertex(rt);
-    EndPrimitive();
+    out_vertex(rt_p, rt);
 
-    // Triangle 2
-    gl_Position = lb_p;
-    out_vertex(lb);
+    out_vertex(rb_p, rb);
 
-    gl_Position = rt_p;
-    out_vertex(rt);
-
-    gl_Position = rb_p;
-    out_vertex(rb);
     EndPrimitive();
 }
 


### PR DESCRIPTION
output 1 strip of 2 triangles instead of 2 strips of 1 triangle.

Potentially it would reduce the geometry shader overhead. And it
might avoid a middle line in sprite in some AMD GPU/driver/OS
bad combination

Need a quick test on various driver, AMD, Nvidia, Intel.