### PR TITLE
PCSX2-WX: Add restore defaults button to GS panel

### DIFF
--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -303,6 +303,7 @@ namespace Panels
 	{
 	protected:
 		pxCheckBox*			m_check_SynchronousGS;
+		wxButton*			m_restore_defaults;
 		pxCheckBox*			m_check_DisableOutput;
 		FrameSkipPanel*		m_span;
 		FramelimiterPanel*	m_fpan;
@@ -312,6 +313,7 @@ namespace Panels
 		virtual ~VideoPanel() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
+		void Defaults_Click(wxCommandEvent& evt);
 		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
 
 	protected:

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -291,6 +291,8 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 		_t("For troubleshooting potential bugs in the MTGS only, as it is potentially very slow.")
 	);
 
+	m_restore_defaults = new wxButton(right, wxID_DEFAULT, _("Restore Defaults"));
+
 	m_check_DisableOutput = new pxCheckBox( left, _("Disable all GS output"),
 		_t("Completely disables all GS plugin activity; ideal for benchmarking EEcore components.")
 	);
@@ -318,6 +320,7 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 
 	*right		+= m_span		| pxExpand;
 	*right		+= 5;
+	*right		+= m_restore_defaults | StdButton();
 
 	*left		+= m_fpan		| pxExpand;
 	*left		+= 5;
@@ -329,7 +332,19 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 
 	*this		+= s_table	| pxExpand;
 
+	Bind(wxEVT_BUTTON, &VideoPanel::Defaults_Click, this, wxID_DEFAULT);
 	AppStatusEvent_OnSettingsApplied();
+}
+
+void Panels::VideoPanel::Defaults_Click(wxCommandEvent& evt)
+{
+	AppConfig config = *g_Conf;
+	config.EmuOptions.GS = Pcsx2Config::GSOptions();
+	config.Framerate = AppConfig::FramerateOptions();
+	VideoPanel::ApplyConfigToGui(config);
+	m_fpan->ApplyConfigToGui(config);
+	m_span->ApplyConfigToGui(config);
+	evt.Skip();
 }
 
 void Panels::VideoPanel::OnOpenWindowSettings( wxCommandEvent& evt )


### PR DESCRIPTION
**Summary of changes**:

* Added ``Restore Defaults`` button to the GS panel of Emulation settings dialog.

Initially, I was planning on adding it for all the dialogs but it seems pointless to add it to Gamefixes panel as you can just uncheck the ``Enable Manual Gamefixes`` and be done with it and the GS Window panel seems to be under a bit of a work right now ( #1950 & #1918), wouldn't want to cause any conflicts with them, so I'm doing it only for the GS panel at the moment.