### PR TITLE
PCSX2-WX: Revert titlebar update behavior on Windows

### DIFF
--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -618,9 +618,11 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 	out << std::fixed << std::setprecision(2) << fps;
 	OSDmonitor(Color_StrongGreen, "FPS:", out.str());
 
+#ifdef __linux__
 	// Important Linux note: When the title is set in fullscreen the window is redrawn. Unfortunately
 	// an intermediate white screen appears too which leads to a very annoying flickering.
 	if (IsFullScreen()) return;
+#endif
 
 	AppConfig::UiTemplateOptions& templates = g_Conf->Templates;
 


### PR DESCRIPTION
**Current behavior** - The tilebar isn't updated when the user enters full screen mode and when the user returns back to windowed mode they have the older title bar values for a brief second, this sort of behavior is undesirable just in the cost of saving some overhead for updating the title. (which is really negligent)

Hence reverting the code to always update the title like it has been for the past 7 years (Yes, I did my research), I'm doing it only for the windows side at the moment as a code comment describes of some sort of Linux specific issue on wxWidgets side

Closes #2002 (Only on Windows side, the title was always static on fullscreen for Linux anyway)