### PR TITLE
onepad: add a first time wizard to notify that plugin auto-map the Gamepad

### DIFF
--- a/plugins/onepad/Linux/dialog.cpp
+++ b/plugins/onepad/Linux/dialog.cpp
@@ -477,6 +477,18 @@ void Dialog::repopulate()
 // Main
 void DisplayDialog()
 {
+    if (g_conf.ftw) {
+        wxString info("The OnePad GUI is provided to map the keyboard/mouse to the virtual PS2 pad.\n\n"
+                      "Gamepads/Joysticks are plug and play. The active gamepad can be selected in the 'Gamepad Configuration' panel.\n\n"
+                      "If you prefer to manually map your gamepad, you should use the 'onepad-legacy' plugin instead.");
+
+        wxMessageDialog ftw(nullptr, info);
+        ftw.ShowModal();
+
+        g_conf.ftw = 0;
+        SaveConfig();
+    }
+
     Dialog dialog;
 
     dialog.InitDialog();

--- a/plugins/onepad/Linux/ini.cpp
+++ b/plugins/onepad/Linux/ini.cpp
@@ -56,6 +56,7 @@ void SaveConfig()
         return;
     }
 
+    fprintf(f, "first_time_wizard = %d\n", g_conf.ftw);
     fprintf(f, "log = %d\n", g_conf.log);
     fprintf(f, "options = %d\n", g_conf.packed_options);
     fprintf(f, "mouse_sensibility = %d\n", g_conf.get_sensibility());
@@ -89,6 +90,10 @@ void LoadConfig()
     }
 
     u32 value;
+
+    if (fscanf(f, "first_time_wizard = %u\n", &value) == 1)
+        g_conf.ftw = value;
+
     if (fscanf(f, "log = %u\n", &value) == 1)
         g_conf.log = value;
 

--- a/plugins/onepad/controller.h
+++ b/plugins/onepad/controller.h
@@ -50,6 +50,7 @@ public:
     };
 
     u32 log;
+    u32 ftw;
     std::map<u32, u32> keysym_map[GAMEPAD_NUMBER];
     std::array<size_t, GAMEPAD_NUMBER> unique_id;
     std::vector<std::string> sdl2_mapping;
@@ -58,7 +59,9 @@ public:
 
     void init()
     {
-        log = packed_options = 0;
+        log = 0;
+        ftw = 1;
+        packed_options = 0;
         ff_intensity = 0x7FFF; // set it at max value by default
         sensibility = 500;
         for (int pad = 0; pad < GAMEPAD_NUMBER; pad++) {


### PR DESCRIPTION
It should avoid some bug reports of not-working-as-expected GUI

Please review the wizard user string.