### PR TITLE
PCSX2-Counters: Fix tracking of scalar limit

### DIFF
--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -21,6 +21,7 @@
 #include "GS.h"
 #include "Gif_Unit.h"
 #include "Counters.h"
+#include "GSFrame.h"
 
 using namespace Threading;
 using namespace R5900;
@@ -53,6 +54,25 @@ void gsReset()
 
 	CSRreg.Reset();
 	GSIMR.reset();
+}
+
+void gsUpdateFrequency(Pcsx2Config& config)
+{
+	switch (g_LimiterMode)
+	{
+	case LimiterModeType::Limit_Nominal:
+		config.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
+		break;
+	case LimiterModeType::Limit_Slomo:
+		config.GS.LimitScalar = g_Conf->Framerate.SlomoScalar;
+		break;
+	case LimiterModeType::Limit_Turbo:
+		config.GS.LimitScalar = g_Conf->Framerate.TurboScalar;
+		break;
+	default:
+		pxAssert("Unknown framelimiter mode!");
+	}
+	UpdateVSyncRate();
 }
 
 static __fi void gsCSRwrite( const tGS_CSR& csr )

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -414,6 +414,7 @@ extern void gsSetVideoMode( GS_VideoMode mode );
 extern void gsResetFrameSkip();
 extern void gsPostVsyncStart();
 extern void gsFrameSkip();
+extern void gsUpdateFrequency( Pcsx2Config& config );
 
 // Some functions shared by both the GS and MTGS
 extern void _gs_ResetFrameskip();

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -458,13 +458,15 @@ static void _ApplySettings( const Pcsx2Config& src, Pcsx2Config& fixup )
 		}
 	}
 
+	// When we're booting, the bios loader will set a a title which would be more interesting than this
+	// to most users - with region, version, etc, so don't overwrite it with patch info. That's OK. Those
+	// users which want to know the status of the patches at the bios can check the console content.
 	wxString consoleTitle = gameName + gameSerial;
 	consoleTitle += L" [" + gameCRC.MakeUpper() + L"]" + gameCompat + gameFixes + gamePatch + gameCheats + gameWsHacks;
 	if (ingame)
 		Console.SetTitle(consoleTitle);
-	// When we're booting, the bios loader will set a a title which would be more interesting than this
-	// to most users - with region, version, etc, so don't overwrite it with patch info. That's OK. Those
-	// users which want to know the status of the patches at the bios can check the console content.
+
+	gsUpdateFrequency(fixup);
 }
 
 // FIXME: This function is not for general consumption. Its only consumer (and

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -86,7 +86,6 @@ namespace Implementations
 		{
 			g_Conf->EmuOptions.GS.FrameLimitEnable = true;
 			g_LimiterMode = Limit_Turbo;
-			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.TurboScalar;
 			OSDlog( Color_StrongRed, true, "(FrameLimiter) Turbo + FrameLimit ENABLED." );
 			g_Conf->EmuOptions.GS.FrameSkipEnable = !!g_Conf->Framerate.SkipOnTurbo;
 		}
@@ -94,7 +93,6 @@ namespace Implementations
 		{
 			GSsetVsync( g_Conf->EmuOptions.GS.VsyncEnable );
 			g_LimiterMode = Limit_Nominal;
-			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
 
 			if ( g_Conf->Framerate.SkipOnLimit)
 			{
@@ -111,7 +109,6 @@ namespace Implementations
 		{
 			GSsetVsync( false );
 			g_LimiterMode = Limit_Turbo;
-			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.TurboScalar;
 
 			if ( g_Conf->Framerate.SkipOnTurbo)
 			{
@@ -124,6 +121,7 @@ namespace Implementations
 				g_Conf->EmuOptions.GS.FrameSkipEnable = false;
 			}
 		}
+		gsUpdateFrequency(g_Conf->EmuOptions);
 		pauser.AllowResume();
 	}
 
@@ -140,16 +138,15 @@ namespace Implementations
 		if( g_LimiterMode == Limit_Slomo )
 		{
 			g_LimiterMode = Limit_Nominal;
-			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
 			OSDlog( Color_StrongRed, true, "(FrameLimiter) SlowMotion DISABLED." );
 		}
 		else
 		{
 			g_LimiterMode = Limit_Slomo;
-			g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.SlomoScalar;
 			OSDlog( Color_StrongRed, true, "(FrameLimiter) SlowMotion ENABLED." );
 			g_Conf->EmuOptions.GS.FrameLimitEnable = true;
 		}
+		gsUpdateFrequency(g_Conf->EmuOptions);
 		pauser.AllowResume();
 	}
 


### PR DESCRIPTION
**Summary of changes**

* Properly track the scalar limit value. Fixes the second issue mentioned over here (http://forums.pcsx2.net/Thread-Change-the-normal-speed?pid=566120#pid566120).

**Procedure to reproduce the issue**:
* Toggle to turbo mode
* Enter emulation settings dialog and change the ``Turbo Adjust`` to a different percentage value from the current one.
* Apply the settings

_**Master branch behaviour**_
> The framelimit won't be updated, it will only be updated after you toggle back to normal mode and once again come back to turbo mode.

_**Pull request behaviour**_
> It's updated instantaneously after you press either the ``OK/Apply`` button in the emulation settings dialog.