### PR TITLE
GSdx: Add missing CRC for Tomb Raider Underworld

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -357,6 +357,7 @@ CRC::Game CRC::m_games[] =
 	{0xF21EE6E0, CrashNburn, US, 0},
 	{0x694A998E, TombRaiderUnderworld, JP, 0}, // cutie comment
 	{0x8E214549, TombRaiderUnderworld, EU, 0},
+	{0x618769D6, TombRaiderUnderworld, US, 0},
 	{0xB639EB17, TombRaiderAnniversary, US, 0},
 	{0xB05805B6, TombRaiderAnniversary, JP, 0}, // cutie comment
 	{0xA629A376, TombRaiderAnniversary, EU, 0},


### PR DESCRIPTION
NTSC-U version.

Issue #2027