### PR TITLE
PCSX2-WX: Force disable MTVU hack on safest preset

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,14 +1,14 @@
 ***PCSX2 version:***
 ``(For example, stable build v1.4.0 (or) development builds v1.5.xxx)``
 
-- **Note**: It's preferred to only report bugs which are present on the [latest development builds](http://pcsx2.net/download/development.html).
-
-- **Note2**: The new backwards compatibility (psx) mode is in active development. Issue reports are too early at this point.
+- **Notes**:
+  - It's preferred to only report bugs which are present on the [latest development builds](http://pcsx2.net/download/development.html).
+  - The PSX backward compatibility mode is still in its early stage of development. Issue reports are too early at this point.
 
 ***PCSX2 options:***
 ``(For example, Clamping/Rounding, Speedhacks, GameFixes)``
 
-- **Note**: Generally it's recommended to have settings as default as possible and use the ``Safest`` preset along with MTVU speed hack disabled. If there's no issue with these settings but there is an issue with some other non-default option, then please state it explicitly.
+- **Note**: Generally it's recommended to have settings as default as possible and use the ``Safest`` preset. If there's no issue with these settings but there is an issue with some other non-default option, then please state it explicitly.
 
 
 ***Plugins used:***

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1047,7 +1047,7 @@ bool AppConfig::IsOkApplyPreset(int n)
 	EmuOptions.Gamefixes			= default_Pcsx2Config.Gamefixes;
 	EmuOptions.Speedhacks			= default_Pcsx2Config.Speedhacks;
 	EmuOptions.Speedhacks.bitset	= 0; //Turn off individual hacks to make it visually clear they're not used.
-	EmuOptions.Speedhacks.vuThread	= original_SpeedHacks.vuThread; // MTVU is not modified by presets
+	EmuOptions.Speedhacks.vuThread	= original_SpeedHacks.vuThread;
 	EnableSpeedHacks = true;
 
 	//Actual application of current preset over the base settings which all presets use (mostly pcsx2's default values).
@@ -1079,11 +1079,13 @@ bool AppConfig::IsOkApplyPreset(int n)
 					EmuOptions.Speedhacks.IntcStat = true;
 					EmuOptions.Speedhacks.WaitLoop = true;
 					EmuOptions.Speedhacks.vuFlagHack = true;
+					break;
 
 		case 0 :	//Base preset: Mostly pcsx2's defaults.
-					
-		
+					//Force disable MTVU hack on safest preset as it has lots of issues (Crashes/Slow downs) on various games.
+					EmuOptions.Speedhacks.vuThread = false;
 					break;
+
 		default:	Console.WriteLn("Developer Warning: Preset #%d is not implemented. (--> Using application default).", n);
 	}
 

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -281,7 +281,8 @@ void Panels::SpeedHacksPanel::EnableStuff( AppConfig* configToUse )
 	m_check_waitloop->Enable(HacksEnabledAndNoPreset);
 	m_check_fastCDVD->Enable(HacksEnabledAndNoPreset);
 
-	m_check_vuThread->Enable(hacksEnabled); // MTVU is unaffected by presets
+	// Grayout MTVU on safest preset
+	m_check_vuThread->Enable(hacksEnabled && (!hasPreset || configToUse->PresetIndex != 0));
 
 	// Layout necessary to ensure changed slider text gets re-aligned properly
 	// and to properly gray/ungray pxStaticText stuff (I suspect it causes a
@@ -309,11 +310,13 @@ void Panels::SpeedHacksPanel::ApplyConfigToGui( AppConfig& configToApply, int fl
 	SetVUcycleSliderMsg();
 
 	m_check_vuFlagHack->SetValue(opts.vuFlagHack);
-	if( !(flags & AppConfig::APPLY_FLAG_FROM_PRESET) )
-		m_check_vuThread	->SetValue(opts.vuThread);
 	m_check_intc->SetValue(opts.IntcStat);
 	m_check_waitloop->SetValue(opts.WaitLoop);
 	m_check_fastCDVD->SetValue(opts.fastCDVD);
+
+	const bool preset_request = flags & AppConfig::APPLY_FLAG_FROM_PRESET;
+	if (!preset_request || configToApply.PresetIndex == 0)
+		m_check_vuThread->SetValue(opts.vuThread);
 
 	// Then, lock(gray out)/unlock the widgets as necessary.
 	EnableStuff( &configToApply );


### PR DESCRIPTION
**Summary of changes**:

* Force disable MTVU hack on safest preset. (Reasons given at commit message)
* Minor modifications to improve the issue template.