### PR TITLE
GSdx-ogl: Add AMD SSO workaround for older drivers/gpus

### DIFF
--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -266,13 +266,13 @@ namespace GLLoader {
 
 	bool s_first_load = true;
 
-	bool legacy_fglrx_buggy_driver = false;
-	bool fglrx_buggy_driver    = false;
-	bool mesa_buggy_driver     = false;
-	bool nvidia_buggy_driver   = false;
-	bool intel_buggy_driver    = false;
-	bool in_replayer           = false;
-	bool buggy_sso_dual_src    = false;
+	bool amd_legacy_buggy_driver = false;
+	bool vendor_id_amd      = false;
+	bool vendor_id_nvidia   = false;
+	bool vendor_id_intel    = false;
+	bool mesa_driver        = false;
+	bool in_replayer        = false;
+	bool buggy_sso_dual_src = false;
 
 
 	bool found_geometry_shader = true; // we require GL3.3 so geometry must be supported by default
@@ -341,26 +341,31 @@ namespace GLLoader {
 
 		// Name changed but driver is still bad!
 		if (strstr(vendor, "Advanced Micro Devices") || strstr(vendor, "ATI Technologies Inc.") || strstr(vendor, "ATI"))
-			fglrx_buggy_driver = true;
-		if (fglrx_buggy_driver && (
-					strstr((const char*)&s[v], " 15.") || // Blacklist all 2015 AMD drivers.
-					strstr((const char*)&s[v], " 16.") || // Blacklist all 2016 AMD drivers.
-					strstr((const char*)&s[v], " 17.") // Blacklist all 2017 AMD drivers for now.
-					))
-			legacy_fglrx_buggy_driver = true;
-
+			vendor_id_amd = true;
+		/*if (vendor_id_amd && (
+				strstr((const char*)&s[v], " 10.") || // Blacklist all 2010 AMD drivers.
+				strstr((const char*)&s[v], " 11.") || // Blacklist all 2011 AMD drivers.
+				strstr((const char*)&s[v], " 12.") || // Blacklist all 2012 AMD drivers.
+				strstr((const char*)&s[v], " 13.") || // Blacklist all 2013 AMD drivers.
+				strstr((const char*)&s[v], " 14.") || // Blacklist all 2014 AMD drivers.
+				strstr((const char*)&s[v], " 15.") || // Blacklist all 2015 AMD drivers.
+				strstr((const char*)&s[v], " 16.") || // Blacklist all 2016 AMD drivers.
+				strstr((const char*)&s[v], " 17.") // Blacklist all 2017 AMD drivers for now.
+				))
+			amd_legacy_buggy_driver = true;
+		*/
 		if (strstr(vendor, "NVIDIA Corporation"))
-			nvidia_buggy_driver = true;
+			vendor_id_nvidia = true;
 
 #ifdef _WIN32
 		if (strstr(vendor, "Intel"))
-			intel_buggy_driver = true;
+			vendor_id_intel = true;
 #else
 		// On linux assumes the free driver if it isn't nvidia or amd pro driver
-		mesa_buggy_driver = !nvidia_buggy_driver && !fglrx_buggy_driver;
+		mesa_driver = !vendor_id_nvidia && !vendor_id_amd;
 #endif
 
-		buggy_sso_dual_src = intel_buggy_driver || fglrx_buggy_driver || legacy_fglrx_buggy_driver;
+		buggy_sso_dual_src = vendor_id_intel || vendor_id_amd /*|| amd_legacy_buggy_driver*/;
 
 		if (theApp.GetConfigI("override_geometry_shader") != -1) {
 			found_geometry_shader = theApp.GetConfigB("override_geometry_shader");
@@ -443,13 +448,13 @@ namespace GLLoader {
 		status &= status_and_override(found_GL_ARB_get_texture_sub_image, "GL_ARB_get_texture_sub_image");
 
 		if (s_first_load) {
-			if (fglrx_buggy_driver) {
+			if (vendor_id_amd) {
 				fprintf(stderr, "The OpenGL hardware renderer is slow on AMD GPUs due to an inefficient driver.\n"
 					"Check out the link below for further information.\n"
 					"https://github.com/PCSX2/pcsx2/wiki/OpenGL-and-AMD-GPUs---All-you-need-to-know\n");
 			}
 
-			if (intel_buggy_driver) {
+			if (vendor_id_intel) {
 				fprintf(stderr, "The OpenGL renderer is inefficient on Intel GPUs due to an inefficient driver.\n"
 					"Check out the link below for further information.\n"
 					"https://github.com/PCSX2/pcsx2/wiki/OpenGL-and-Intel-GPUs-All-you-need-to-know\n");

--- a/plugins/GSdx/GLLoader.h
+++ b/plugins/GSdx/GLLoader.h
@@ -358,11 +358,11 @@ extern PFNGLGENERATEMIPMAPPROC                  glGenerateMipmap;
 namespace GLLoader {
 	void check_gl_requirements();
 
-	extern bool fglrx_buggy_driver;
-	extern bool legacy_fglrx_buggy_driver;
-	extern bool mesa_buggy_driver;
-	extern bool nvidia_buggy_driver;
-	extern bool intel_buggy_driver;
+	extern bool vendor_id_amd;
+	extern bool vendor_id_nvidia;
+	extern bool vendor_id_intel;
+	extern bool amd_legacy_buggy_driver;
+	extern bool mesa_driver;
 	extern bool buggy_sso_dual_src;
 	extern bool in_replayer;
 

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -528,7 +528,7 @@ bool GSDeviceOGL::Create(const std::shared_ptr<GSWnd> &wnd)
 	// Get Available Memory
 	// ****************************************************************
 	GLint vram[4] = {0};
-	if (GLLoader::fglrx_buggy_driver) {
+	if (GLLoader::vendor_id_amd) {
 		// Full vram, remove a small margin for others buffer
 		glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, vram);
 	} else if (GLLoader::found_GL_NVX_gpu_memory_info) {
@@ -998,7 +998,7 @@ void GSDeviceOGL::SelfShaderTestRun(const string& dir, const string& file, const
 
 #ifdef __linux__
 	// Nouveau actually
-	if (GLLoader::mesa_buggy_driver) {
+	if (GLLoader::mesa_driver) {
 		if (freopen(out.c_str(), "w", stderr) == NULL)
 			fprintf(stderr, "Failed to redirect stderr\n");
 	}
@@ -1010,7 +1010,7 @@ void GSDeviceOGL::SelfShaderTestRun(const string& dir, const string& file, const
 
 #ifdef __linux__
 	// Nouveau actually
-	if (GLLoader::mesa_buggy_driver) {
+	if (GLLoader::mesa_driver) {
 		if (freopen("/dev/tty", "w", stderr) == NULL)
 			fprintf(stderr, "Failed to restore stderr\n");
 	}

--- a/plugins/GSdx/GSShaderOGL.cpp
+++ b/plugins/GSdx/GSShaderOGL.cpp
@@ -224,7 +224,7 @@ std::string GSShaderOGL::GenGlslHeader(const std::string& entry, GLenum type, co
 	} else {
 		header += "#define DISABLE_GL42_image\n";
 	}
-	if (GLLoader::fglrx_buggy_driver || GLLoader::intel_buggy_driver)
+	if (GLLoader::vendor_id_amd || GLLoader::vendor_id_intel)
 		header += "#define BROKEN_DRIVER as_usual\n";
 
 	// Stupid GL implementation (can't use GL_ES)
@@ -331,7 +331,7 @@ GLuint GSShaderOGL::CompileShader(const std::string& glsl_file, const std::strin
 // GLSL improvement (unfortunately).
 int GSShaderOGL::DumpAsm(const std::string& file, GLuint p)
 {
-	if (!GLLoader::nvidia_buggy_driver) return 0;
+	if (!GLLoader::vendor_id_nvidia) return 0;
 
 	GLint   binaryLength;
 	glGetProgramiv(p, GL_PROGRAM_BINARY_LENGTH, &binaryLength);


### PR DESCRIPTION
Add older drivers to amd's buggy driver list. Fixes the broken driver on
older gpus using older drivers.
http://forums.pcsx2.net/Thread-OpenGL-GS-plugin-failed-to-open?pid=567330#pid567330

fglrx_buggy_driver and legacy_fglrx_buggy_driver renamed to amd_buggy_driver and legacy_amd_buggy_driver.