### PR TITLE
GSdx - dx9: Edit Alpha Correction (FBA) tooltip. 

### DIFF
--- a/plugins/GSdx/GSSetting.cpp
+++ b/plugins/GSdx/GSSetting.cpp
@@ -159,7 +159,7 @@ const char* dialog_message(int ID, bool* updateText) {
 #ifdef _WIN32
 		// DX9 only
 		case IDC_FBA:
-			return "Makes textures partially or fully transparent as required by emulation. May cause unusual slowdowns for some games.";
+			return "Makes textures partially or fully transparent as required by emulation. May cause unusual slowdowns or graphical glitches for some games.";
 		case IDC_LOGZ:
 			return "Treat depth as logarithmic instead of linear. Recommended setting is on unless it causes graphical glitches.";
 #endif


### PR DESCRIPTION
Edit tooltip to FBA. Causes graphical glitches in some games.

Affected games are DBZ BT3.
It makes some textures look cut off or adds a blue texture in front of the screen when enabled but it also fixes the health bars. Otherwise the health bars do not work properly but there are no glitched textures.
BT2 might also be affected as they share the same engine.
I don't know about others , maybe.

