### PR TITLE
gsdx: Fix OpenGL vsync, pcsx2: Apply vsync changes immediately

### DIFF
--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -237,7 +237,7 @@ void Pcsx2Config::GSOptions::LoadSave( IniInterface& ini )
 
 int Pcsx2Config::GSOptions::GetVsync() const
 {
-	if (g_LimiterMode == Limit_Turbo)
+	if (g_LimiterMode == Limit_Turbo || !FrameLimitEnable)
 		return 0;
 
 	// D3D only support a boolean state. OpenGL waits a number of vsync

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -512,7 +512,7 @@ void AppCoreThread::ApplySettings( const Pcsx2Config& src )
 	}
 
 	if (m_ExecMode >= ExecMode_Paused)
-		GSsetVsync(EmuConfig.GS.FrameLimitEnable ? EmuConfig.GS.GetVsync() : 0);
+		GSsetVsync(EmuConfig.GS.GetVsync());
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -510,6 +510,9 @@ void AppCoreThread::ApplySettings( const Pcsx2Config& src )
 	{
 		_parent::ApplySettings( fixup );
 	}
+
+	if (m_ExecMode >= ExecMode_Paused)
+		GSsetVsync(EmuConfig.GS.FrameLimitEnable ? EmuConfig.GS.GetVsync() : 0);
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -122,8 +122,6 @@ namespace Implementations
 
 		gsUpdateFrequency(g_Conf->EmuOptions);
 
-		GSsetVsync(g_Conf->EmuOptions.GS.GetVsync());
-
 		pauser.AllowResume();
 	}
 
@@ -150,8 +148,6 @@ namespace Implementations
 
 		gsUpdateFrequency(g_Conf->EmuOptions);
 
-		GSsetVsync(g_Conf->EmuOptions.GS.GetVsync());
-
 		pauser.AllowResume();
 	}
 
@@ -163,12 +159,6 @@ namespace Implementations
 
 		// Turbo/Slowmo don't make sense when framelimiter is toggled
 		g_LimiterMode = Limit_Nominal;
-
-		// Disable Vsync when frame limited is disabled
-		if( g_Conf->EmuOptions.GS.FrameLimitEnable )
-			GSsetVsync(g_Conf->EmuOptions.GS.GetVsync());
-		else
-			GSsetVsync(0);
 
 		pauser.AllowResume();
 	}

--- a/plugins/GSdx/GSWnd.cpp
+++ b/plugins/GSdx/GSWnd.cpp
@@ -199,5 +199,7 @@ void GSWndGL::SetVSync(int vsync)
 	else
 		m_vsync = vsync;
 
-	SetSwapInterval(m_vsync);
+	// The WGL/GLX/EGL swap interval function must be called on the rendering
+	// thread or else the change won't be properly applied.
+	m_vsync_change_requested = true;
 }

--- a/plugins/GSdx/GSWnd.h
+++ b/plugins/GSdx/GSWnd.h
@@ -60,7 +60,8 @@ class GSWndGL : public GSWnd
 {
 protected:
 	bool m_ctx_attached;
-	int m_vsync;
+	std::atomic<bool> m_vsync_change_requested;
+	std::atomic<int> m_vsync;
 
 	bool IsContextAttached() const { return m_ctx_attached; }
 	void PopulateGlFunction();
@@ -68,11 +69,11 @@ protected:
 	void FullContextInit();
 	virtual void CreateContext(int major, int minor) = 0;
 
-	virtual void SetSwapInterval(int vsync) = 0;
+	virtual void SetSwapInterval() = 0;
 	virtual bool HasLateVsyncSupport() = 0;
 
 public:
-	GSWndGL() : m_ctx_attached(false), m_vsync(0) {};
+	GSWndGL() : m_ctx_attached(false), m_vsync_change_requested(false), m_vsync(0) {};
 	virtual ~GSWndGL() {};
 
 	virtual bool Create(const string& title, int w, int h) = 0;

--- a/plugins/GSdx/GSWndEGL.cpp
+++ b/plugins/GSdx/GSWndEGL.cpp
@@ -235,15 +235,18 @@ GSVector4i GSWndEGL::GetClientRect()
 	return GSVector4i(0, 0, w, h);
 }
 
-void GSWndEGL::SetSwapInterval(int vsync)
+void GSWndEGL::SetSwapInterval()
 {
 	// 0 -> disable vsync
 	// n -> wait n frame
-	eglSwapInterval(m_eglDisplay, vsync);
+	eglSwapInterval(m_eglDisplay, m_vsync);
 }
 
 void GSWndEGL::Flip()
 {
+	if (m_vsync_change_requested.exchange(false))
+		SetSwapInterval();
+
 	eglSwapBuffers(m_eglDisplay, m_eglSurface);
 }
 

--- a/plugins/GSdx/GSWndEGL.h
+++ b/plugins/GSdx/GSWndEGL.h
@@ -42,7 +42,7 @@ class GSWndEGL : public GSWndGL
 	void CreateContext(int major, int minor);
 	void BindAPI();
 
-	void SetSwapInterval(int vsync) final;
+	void SetSwapInterval() final;
 	bool HasLateVsyncSupport() final { return false; }
 
 	void OpenEGLDisplay();

--- a/plugins/GSdx/GSWndOGL.cpp
+++ b/plugins/GSdx/GSWndOGL.cpp
@@ -238,18 +238,21 @@ bool GSWndOGL::SetWindowText(const char* title)
 	return true;
 }
 
-void GSWndOGL::SetSwapInterval(int vsync)
+void GSWndOGL::SetSwapInterval()
 {
 	// m_swapinterval uses an integer as parameter
 	// 0 -> disable vsync
 	// n -> wait n frame
-	if      (m_swapinterval_ext)  m_swapinterval_ext(m_NativeDisplay, m_NativeWindow, vsync);
-	else if (m_swapinterval_mesa) m_swapinterval_mesa(vsync);
+	if      (m_swapinterval_ext)  m_swapinterval_ext(m_NativeDisplay, m_NativeWindow, m_vsync);
+	else if (m_swapinterval_mesa) m_swapinterval_mesa(m_vsync);
 	else						 fprintf(stderr, "Failed to set VSync\n");
 }
 
 void GSWndOGL::Flip()
 {
+	if (m_vsync_change_requested.exchange(false))
+		SetSwapInterval();
+
 	glXSwapBuffers(m_NativeDisplay, m_NativeWindow);
 }
 

--- a/plugins/GSdx/GSWndOGL.h
+++ b/plugins/GSdx/GSWndOGL.h
@@ -38,7 +38,7 @@ class GSWndOGL final : public GSWndGL
 	void PopulateWndGlFunction();
 	void CreateContext(int major, int minor);
 
-	void SetSwapInterval(int vsync);
+	void SetSwapInterval();
 	bool HasLateVsyncSupport() { return m_has_late_vsync; }
 
 public:

--- a/plugins/GSdx/GSWndWGL.cpp
+++ b/plugins/GSdx/GSWndWGL.cpp
@@ -324,16 +324,19 @@ void* GSWndWGL::GetProcAddress(const char* name, bool opt)
 
 //TODO: check extensions supported or not
 //FIXME : extension allocation
-void GSWndWGL::SetSwapInterval(int vsync)
+void GSWndWGL::SetSwapInterval()
 {
 	// m_swapinterval uses an integer as parameter
 	// 0 -> disable vsync
 	// n -> wait n frame
-	if (m_swapinterval) m_swapinterval(vsync);
+	if (m_swapinterval) m_swapinterval(m_vsync);
 }
 
 void GSWndWGL::Flip()
 {
+	if (m_vsync_change_requested.exchange(false))
+		SetSwapInterval();
+
 	SwapBuffers(m_NativeDisplay);
 }
 

--- a/plugins/GSdx/GSWndWGL.h
+++ b/plugins/GSdx/GSWndWGL.h
@@ -38,7 +38,7 @@ class GSWndWGL : public GSWndGL
 	void CloseWGLDisplay();
 	void OpenWGLDisplay();
 
-	void SetSwapInterval(int vsync);
+	void SetSwapInterval();
 	bool HasLateVsyncSupport() { return m_has_late_vsync; }
 
 	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Changes:
 * OpenGL renderer - calls the WGL/EGL/GLX swap interval function on the rendering thread so the turbo/framelimiter hotkeys function properly. Fixes #842.
 * Applies vsync change immediately when the vsync settings are changed. Fixes #1971.