### PR TITLE
gsdx: remove "using namespace std;"

### DIFF
--- a/plugins/GSdx/GLLoader.cpp
+++ b/plugins/GSdx/GLLoader.cpp
@@ -385,7 +385,7 @@ namespace GLLoader {
 
 		if (glGetStringi && max_ext) {
 			for (GLint i = 0; i < max_ext; i++) {
-				string ext((const char*)glGetStringi(GL_EXTENSIONS, i));
+				std::string ext{(const char*)glGetStringi(GL_EXTENSIONS, i)};
 				// Bonus
 				if (ext.compare("GL_EXT_texture_filter_anisotropic") == 0) found_GL_EXT_texture_filter_anisotropic = true;
 				if (ext.compare("GL_NVX_gpu_memory_info") == 0) found_GL_NVX_gpu_memory_info = true;

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -1427,10 +1427,10 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 		return;
 	}
 
-	struct Packet {uint8 type, param; uint32 size, addr; vector<uint8> buff;};
+	struct Packet {uint8 type, param; uint32 size, addr; std::vector<uint8> buff;};
 
 	list<Packet*> packets;
-	vector<uint8> buff;
+	std::vector<uint8> buff;
 	uint8 regs[0x2000];
 
 	GSsetBaseMem(regs);

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -753,7 +753,7 @@ EXPORT_C_(uint32) GSmakeSnapshot(char* path)
 {
 	try
 	{
-		string s(path);
+		std::string s{path};
 
 		if(!s.empty() && s[s.length() - 1] != DIRECTORY_SEPARATOR)
 		{
@@ -941,7 +941,7 @@ EXPORT_C GSgetLastTag(uint32* tag)
 
 EXPORT_C GSgetTitleInfo2(char* dest, size_t length)
 {
-	string s = "GSdx";
+	std::string s{"GSdx"};
 	s.append(s_renderer_name).append(s_renderer_type);
 
 	// TODO: this gets called from a different thread concurrently with GSOpen (on linux)
@@ -993,7 +993,7 @@ EXPORT_C GSsetExclusive(int enabled)
 class Console
 {
 	HANDLE m_console;
-	string m_title;
+	std::string m_title;
 
 public:
 	Console::Console(LPCSTR title, bool open)

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -1429,7 +1429,7 @@ EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
 
 	struct Packet {uint8 type, param; uint32 size, addr; std::vector<uint8> buff;};
 
-	list<Packet*> packets;
+	std::list<Packet*> packets;
 	std::vector<uint8> buff;
 	uint8 regs[0x2000];
 

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -401,7 +401,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	m_size.x = (dlg.m_width + 7) & ~7;
 	m_size.y = (dlg.m_height + 7) & ~7;
 
-	wstring fn(dlg.m_filename.begin(), dlg.m_filename.end());
+	std::wstring fn{dlg.m_filename.begin(), dlg.m_filename.end()};
 
 	//
 
@@ -446,8 +446,8 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	{
 		CFilterInfo fi;
 		pBF->QueryFilterInfo(&fi);
-		wstring s(fi.achName);
-		printf("Filter [%p]: %s\n", pBF.p, string(s.begin(), s.end()).c_str());
+		std::wstring s{fi.achName};
+		printf("Filter [%p]: %s\n", pBF.p, std::string{s.begin(), s.end()}.c_str());
 
 		BeginEnumPins(pBF, pEP, pPin)
 		{
@@ -456,8 +456,8 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 
 			CPinInfo pi;
 			pPin->QueryPinInfo(&pi);
-			wstring s(pi.achName);
-			printf("- Pin [%p - %p]: %s (%s)\n", pPin.p, pPinTo.p, string(s.begin(), s.end()).c_str(), pi.dir ? "out" : "in");
+			std::wstring s{pi.achName};
+			printf("- Pin [%p - %p]: %s (%s)\n", pPin.p, pPinTo.p, std::string{s.begin(), s.end()}.c_str(), pi.dir ? "out" : "in");
 
 			BeginEnumMediaTypes(pPin, pEMT, pmt)
 			{

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -54,7 +54,7 @@ GSSource : public CBaseFilter, private CCritSec, public IGSSource
 	class GSSourceOutputPin : public CBaseOutputPin
 	{
 		GSVector2i m_size;
-		vector<CMediaType> m_mts;
+		std::vector<CMediaType> m_mts;
 
 	public:
 		GSSourceOutputPin(const GSVector2i& size, REFERENCE_TIME atpf, CBaseFilter* pFilter, CCritSec* pLock, HRESULT& hr, int colorspace)
@@ -128,9 +128,9 @@ GSSource : public CBaseFilter, private CCritSec, public IGSSource
 
 	    HRESULT CheckMediaType(const CMediaType* pmt)
 		{
-			for(vector<CMediaType>::iterator i = m_mts.begin(); i != m_mts.end(); i++)
+			for(const auto &mt : m_mts)
 			{
-				if(i->majortype == pmt->majortype && i->subtype == pmt->subtype)
+				if(mt.majortype == pmt->majortype && mt.subtype == pmt->subtype)
 				{
 					return S_OK;
 				}

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -516,7 +516,7 @@ bool GSCapture::DeliverFrame(const void* bits, int pitch, bool rgba)
 
 	std::string out_file = m_out_dir + format("/frame.%010d.png", m_frame);
 	//GSPng::Save(GSPng::RGB_PNG, out_file, (uint8*)bits, m_size.x, m_size.y, pitch, m_compression_level);
-	m_workers[m_frame%m_threads]->Push(shared_ptr<GSPng::Transaction>(new GSPng::Transaction(GSPng::RGB_PNG, out_file, static_cast<const uint8*>(bits), m_size.x, m_size.y, pitch, m_compression_level)));
+	m_workers[m_frame%m_threads]->Push(std::make_shared<GSPng::Transaction>(GSPng::RGB_PNG, out_file, static_cast<const uint8*>(bits), m_size.x, m_size.y, pitch, m_compression_level));
 
 	m_frame++;
 

--- a/plugins/GSdx/GSCaptureDlg.cpp
+++ b/plugins/GSdx/GSCaptureDlg.cpp
@@ -79,7 +79,7 @@ void GSCaptureDlg::OnInit()
 
 		c.moniker = moniker;
 
-		wstring prefix;
+		std::wstring prefix;
 
 		LPOLESTR str = NULL;
 
@@ -108,7 +108,7 @@ void GSCaptureDlg::OnInit()
 
 		m_codecs.push_back(c);
 
-		string s(c.FriendlyName.begin(), c.FriendlyName.end());
+		std::string s{c.FriendlyName.begin(), c.FriendlyName.end()};
 
 		ComboBoxAppend(IDC_CODECS, s.c_str(), (LPARAM)&m_codecs.back(), c.DisplayName == selected);
 	}

--- a/plugins/GSdx/GSCaptureDlg.h
+++ b/plugins/GSdx/GSCaptureDlg.h
@@ -31,7 +31,7 @@ class GSCaptureDlg : public GSDialog
 	{
 		CComPtr<IMoniker> moniker;
 		CComPtr<IBaseFilter> filter;
-		wstring FriendlyName;
+		std::wstring FriendlyName;
 		_bstr_t DisplayName;
 	};
 
@@ -48,7 +48,7 @@ public:
 
 	int m_width;
 	int m_height;
-	string m_filename;
+	std::string m_filename;
 	INT_PTR m_colorspace;
 	CComPtr<IBaseFilter> m_enc;
 };

--- a/plugins/GSdx/GSCaptureDlg.h
+++ b/plugins/GSdx/GSCaptureDlg.h
@@ -35,7 +35,7 @@ class GSCaptureDlg : public GSDialog
 		_bstr_t DisplayName;
 	};
 
-	list<Codec> m_codecs;
+	std::list<Codec> m_codecs;
 
 	int GetSelCodec(Codec& c);
 

--- a/plugins/GSdx/GSClut.cpp
+++ b/plugins/GSdx/GSClut.cpp
@@ -140,8 +140,8 @@ void GSClut::Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 	{
 		int size = TEX0.CPSM < PSM_PSMCT16 ? 512 : 256;
 
-		memcpy(m_clut + 512 + offset, m_clut + offset, sizeof(*m_clut) * min(size, 512 - offset));
-		memcpy(m_clut, m_clut + 512, sizeof(*m_clut) * max(0, size + offset - 512));
+		memcpy(m_clut + 512 + offset, m_clut + offset, sizeof(*m_clut) * std::min(size, 512 - offset));
+		memcpy(m_clut, m_clut + 512, sizeof(*m_clut) * std::max(0, size + offset - 512));
 	}
 	else
 	{

--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -516,7 +516,7 @@ CRC::Game CRC::m_games[] =
 	{0x4653CA3E, HarleyDavidson, NoRegion, 0},
 };
 
-map<uint32, CRC::Game*> CRC::m_map;
+std::map<uint32, CRC::Game*> CRC::m_map;
 
 std::string ToLower( std::string str )
 {

--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -518,7 +518,7 @@ CRC::Game CRC::m_games[] =
 
 map<uint32, CRC::Game*> CRC::m_map;
 
-string ToLower( string str )
+std::string ToLower( std::string str )
 {
 	transform( str.begin(), str.end(), str.begin(), ::tolower);
 	return str;
@@ -528,11 +528,11 @@ string ToLower( string str )
 // The list is case insensitive and order insensitive.
 // E.g. Disable all CRC hacks:          CrcHacksExclusions=all
 // E.g. Disable hacks for these CRCs:   CrcHacksExclusions=0x0F0C4A9C, 0x0EE5646B, 0x7ACF7E03
-bool IsCrcExcluded(string exclusionList, uint32 crc)
+bool IsCrcExcluded(std::string exclusionList, uint32 crc)
 {
-	string target = format( "0x%08x", crc );
-	exclusionList = ToLower( exclusionList );
-	return ( exclusionList.find( target ) != string::npos || exclusionList.find( "all" ) != string::npos );
+	std::string target = format("0x%08x", crc);
+	exclusionList = ToLower(exclusionList);
+	return exclusionList.find(target) != std::string::npos || exclusionList.find("all") != std::string::npos;
 }
 
 CRC::Game CRC::Lookup(uint32 crc)
@@ -540,7 +540,7 @@ CRC::Game CRC::Lookup(uint32 crc)
 	printf("GSdx Lookup CRC:%X\n", crc);
 	if(m_map.empty())
 	{
-		string exclusions = theApp.GetConfigS("CrcHacksExclusions");
+		std::string exclusions = theApp.GetConfigS("CrcHacksExclusions");
 		if (exclusions.length() != 0)
 			printf( "GSdx: CrcHacksExclusions: %s\n", exclusions.c_str() );
 

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -209,7 +209,7 @@ public:
 
 private:
 	static Game m_games[];
-	static map<uint32, Game*> m_map;
+	static std::map<uint32, Game*> m_map;
 
 public:
 	static Game Lookup(uint32 crc);

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -1355,7 +1355,7 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 {
 	HRESULT hr;
 
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
@@ -1392,7 +1392,7 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 {
 	HRESULT hr;
 
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
@@ -1422,7 +1422,7 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 {
 	HRESULT hr;
 
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
@@ -1452,7 +1452,7 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char* fn, 
 {
 	HRESULT hr;
 
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
@@ -1482,7 +1482,7 @@ void GSDevice11::CompileShader(const char* source, size_t size, const char *fn, 
 {
 	HRESULT hr;
 
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 

--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -256,7 +256,7 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 	int ShadeBoost_Brightness = theApp.GetConfigI("ShadeBoost_Brightness");
 	int ShadeBoost_Saturation = theApp.GetConfigI("ShadeBoost_Saturation");
 
-	string str[3];
+	std::string str[3];
 
 	str[0] = format("%d", ShadeBoost_Saturation);
 	str[1] = format("%d", ShadeBoost_Brightness);

--- a/plugins/GSdx/GSDevice11.h
+++ b/plugins/GSdx/GSDevice11.h
@@ -145,17 +145,17 @@ public: // TODO
 
 	// Shaders...
 
-	hash_map<uint32, GSVertexShader11 > m_vs;
+	std::unordered_map<uint32, GSVertexShader11> m_vs;
 	CComPtr<ID3D11Buffer> m_vs_cb;
-	hash_map<uint32, CComPtr<ID3D11GeometryShader> > m_gs;
+	std::unordered_map<uint32, CComPtr<ID3D11GeometryShader>> m_gs;
 	CComPtr<ID3D11Buffer> m_gs_cb;
-	hash_map<uint64, CComPtr<ID3D11PixelShader> > m_ps;
+	std::unordered_map<uint64, CComPtr<ID3D11PixelShader>> m_ps;
 	CComPtr<ID3D11Buffer> m_ps_cb;
-	hash_map<uint32, CComPtr<ID3D11SamplerState> > m_ps_ss;
+	std::unordered_map<uint32, CComPtr<ID3D11SamplerState>> m_ps_ss;
 	CComPtr<ID3D11SamplerState> m_palette_ss;
 	CComPtr<ID3D11SamplerState> m_rt_ss;
-	hash_map<uint32, CComPtr<ID3D11DepthStencilState> > m_om_dss;
-	hash_map<uint32, CComPtr<ID3D11BlendState> > m_om_bs;
+	std::unordered_map<uint32, CComPtr<ID3D11DepthStencilState>> m_om_dss;
+	std::unordered_map<uint32, CComPtr<ID3D11BlendState>> m_om_bs;
 
 	VSConstantBuffer m_vs_cb_cache;
 	GSConstantBuffer m_gs_cb_cache;

--- a/plugins/GSdx/GSDevice9.cpp
+++ b/plugins/GSdx/GSDevice9.cpp
@@ -265,7 +265,7 @@ bool GSDevice9::Create(const std::shared_ptr<GSWnd> &wnd)
 	}
 	else
 	{
-		string s = format(
+		std::string s = format(
 			"Supported pixel shader version is too low!\n\nSupported: %d.%d\nNeeded: 2.0 or higher",
 			D3DSHADER_VERSION_MAJOR(m_d3dcaps.PixelShaderVersion), D3DSHADER_VERSION_MINOR(m_d3dcaps.PixelShaderVersion));
 
@@ -354,7 +354,7 @@ bool GSDevice9::Create(const std::shared_ptr<GSWnd> &wnd)
 	int ShadeBoost_Brightness = theApp.GetConfigI("ShadeBoost_Brightness");
 	int ShadeBoost_Saturation = theApp.GetConfigI("ShadeBoost_Saturation");
 
-	string str[3];
+	std::string str[3];
 
 	str[0] = format("%d", ShadeBoost_Saturation);
 	str[1] = format("%d", ShadeBoost_Brightness);
@@ -1454,7 +1454,7 @@ void GSDevice9::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4
 	}
 }
 
-void GSDevice9::CompileShader(const char *source, size_t size, const char *filename, const string& entry, const D3D_SHADER_MACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il)
+void GSDevice9::CompileShader(const char *source, size_t size, const char *filename, const std::string& entry, const D3D_SHADER_MACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il)
 {
 	vector<D3D_SHADER_MACRO> m;
 
@@ -1490,7 +1490,7 @@ void GSDevice9::CompileShader(const char *source, size_t size, const char *filen
 	}
 }
 
-void GSDevice9::CompileShader(const char *source, size_t size, const char *filename, const string& entry, const D3D_SHADER_MACRO* macro, IDirect3DPixelShader9** ps)
+void GSDevice9::CompileShader(const char *source, size_t size, const char *filename, const std::string& entry, const D3D_SHADER_MACRO* macro, IDirect3DPixelShader9** ps)
 {
 	uint32 flags = 0;
 

--- a/plugins/GSdx/GSDevice9.cpp
+++ b/plugins/GSdx/GSDevice9.cpp
@@ -1456,7 +1456,7 @@ void GSDevice9::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4
 
 void GSDevice9::CompileShader(const char *source, size_t size, const char *filename, const std::string& entry, const D3D_SHADER_MACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il)
 {
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 
@@ -1503,7 +1503,7 @@ void GSDevice9::CompileShader(const char *source, size_t size, const char *filen
 		flags |= D3DCOMPILE_SKIP_VALIDATION;
 	}
 
-	vector<D3D_SHADER_MACRO> m;
+	std::vector<D3D_SHADER_MACRO> m;
 
 	PrepareShaderMacro(m, macro);
 

--- a/plugins/GSdx/GSDevice9.h
+++ b/plugins/GSdx/GSDevice9.h
@@ -172,12 +172,12 @@ public: // TODO
 
 	// Shaders...
 
-	hash_map<uint32, GSVertexShader9 > m_vs;
-	hash_map<uint64, CComPtr<IDirect3DPixelShader9> > m_ps;
-	hash_map<uint32, Direct3DSamplerState9* > m_ps_ss;
-	hash_map<uint32, Direct3DDepthStencilState9* > m_om_dss;
-	hash_map<uint32, Direct3DBlendState9* > m_om_bs;
-	hash_map<uint32, GSTexture*> m_mskfix;
+	std::unordered_map<uint32, GSVertexShader9> m_vs;
+	std::unordered_map<uint64, CComPtr<IDirect3DPixelShader9>> m_ps;
+	std::unordered_map<uint32, Direct3DSamplerState9*> m_ps_ss;
+	std::unordered_map<uint32, Direct3DDepthStencilState9*> m_om_dss;
+	std::unordered_map<uint32, Direct3DBlendState9*> m_om_bs;
+	std::unordered_map<uint32, GSTexture*> m_mskfix;
 
 	GSTexture* CreateMskFix(uint32 size, uint32 msk, uint32 fix);
 

--- a/plugins/GSdx/GSDevice9.h
+++ b/plugins/GSdx/GSDevice9.h
@@ -237,8 +237,8 @@ public:
 	IDirect3DDevice9* operator->() {return m_dev;}
 	operator IDirect3DDevice9*() {return m_dev;}
 
-	void CompileShader(const char *source, size_t size, const char *filename, const string& entry, const D3D_SHADER_MACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il);
-	void CompileShader(const char *source, size_t size, const char *filename, const string& entry, const D3D_SHADER_MACRO* macro, IDirect3DPixelShader9** ps);
+	void CompileShader(const char *source, size_t size, const char *filename, const std::string& entry, const D3D_SHADER_MACRO* macro, IDirect3DVertexShader9** vs, const D3DVERTEXELEMENT9* layout, int count, IDirect3DVertexDeclaration9** il);
+	void CompileShader(const char *source, size_t size, const char *filename, const std::string& entry, const D3D_SHADER_MACRO* macro, IDirect3DPixelShader9** ps);
 
 	void SetupVS(VSSelector sel, const VSConstantBuffer* cb);
 	void SetupGS(GSSelector sel, const GSConstantBuffer* cb) {}

--- a/plugins/GSdx/GSDeviceDX.h
+++ b/plugins/GSdx/GSDeviceDX.h
@@ -286,7 +286,7 @@ public:
 	#pragma pack(pop)
 
 protected:
-	struct {D3D_FEATURE_LEVEL level; string model, vs, gs, ps, cs;} m_shader;
+	struct {D3D_FEATURE_LEVEL level; std::string model, vs, gs, ps, cs;} m_shader;
 	uint32 m_msaa;
 	DXGI_SAMPLE_DESC m_msaa_desc;
 

--- a/plugins/GSdx/GSDeviceDX.h
+++ b/plugins/GSdx/GSDeviceDX.h
@@ -318,7 +318,7 @@ public:
 	static bool LoadD3DCompiler();
 	static void FreeD3DCompiler();
 
-	template<class T> void PrepareShaderMacro(vector<T>& dst, const T* src)
+	template<class T> void PrepareShaderMacro(std::vector<T>& dst, const T* src)
 	{
 		dst.clear();
 

--- a/plugins/GSdx/GSDeviceOGL.cpp
+++ b/plugins/GSdx/GSDeviceOGL.cpp
@@ -393,7 +393,7 @@ bool GSDeviceOGL::Create(const std::shared_ptr<GSWnd> &wnd)
 		m_convert.vs = vs;
 		for(size_t i = 0; i < countof(m_convert.ps); i++) {
 			ps = m_shader->Compile("convert.glsl", format("ps_main%d", i), GL_FRAGMENT_SHADER, shader.data());
-			string pretty_name = "Convert pipe " + to_string(i);
+			std::string pretty_name = "Convert pipe " + std::to_string(i);
 			m_convert.ps[i] = m_shader->LinkPipeline(pretty_name, vs, 0, ps);
 		}
 
@@ -422,7 +422,7 @@ bool GSDeviceOGL::Create(const std::shared_ptr<GSWnd> &wnd)
 
 		for(size_t i = 0; i < countof(m_merge_obj.ps); i++) {
 			ps = m_shader->Compile("merge.glsl", format("ps_main%d", i), GL_FRAGMENT_SHADER, shader.data());
-			string pretty_name = "Merge pipe " + to_string(i);
+			std::string pretty_name = "Merge pipe " + std::to_string(i);
 			m_merge_obj.ps[i] = m_shader->LinkPipeline(pretty_name, vs, 0, ps);
 		}
 	}
@@ -439,7 +439,7 @@ bool GSDeviceOGL::Create(const std::shared_ptr<GSWnd> &wnd)
 
 		for(size_t i = 0; i < countof(m_interlace.ps); i++) {
 			ps = m_shader->Compile("interlace.glsl", format("ps_main%d", i), GL_FRAGMENT_SHADER, shader.data());
-			string pretty_name = "Interlace pipe " + to_string(i);
+			std::string pretty_name = "Interlace pipe " + std::to_string(i);
 			m_interlace.ps[i] = m_shader->LinkPipeline(pretty_name, vs, 0, ps);
 		}
 	}
@@ -982,10 +982,10 @@ GLuint GSDeviceOGL::CompilePS(PSSelector sel)
 		return m_shader->Compile("tfx.glsl", "ps_main", GL_FRAGMENT_SHADER, m_shader_tfx_fs.data(), macro);
 }
 
-void GSDeviceOGL::SelfShaderTestRun(const string& dir, const string& file, const PSSelector& sel, int& nb_shader)
+void GSDeviceOGL::SelfShaderTestRun(const std::string& dir, const std::string& file, const PSSelector& sel, int& nb_shader)
 {
 #ifdef __unix__
-	string out = "/tmp/GSdx_Shader/";
+	std::string out = "/tmp/GSdx_Shader/";
 	GSmkdir(out.c_str());
 
 	out += dir + "/";
@@ -993,7 +993,7 @@ void GSDeviceOGL::SelfShaderTestRun(const string& dir, const string& file, const
 
 	out += file;
 #else
-	string out = file;
+	std::string out = file;
 #endif
 
 #ifdef __linux__
@@ -1017,7 +1017,7 @@ void GSDeviceOGL::SelfShaderTestRun(const string& dir, const string& file, const
 #endif
 }
 
-void GSDeviceOGL::SelfShaderTestPrint(const string& test, int& nb_shader)
+void GSDeviceOGL::SelfShaderTestPrint(const std::string& test, int& nb_shader)
 {
 	fprintf(stderr, "%-25s\t\t%d shaders:\t%d instructions (M %4.2f)\t%d registers (M %4.2f)\n",
 			test.c_str(), nb_shader,
@@ -1031,13 +1031,13 @@ void GSDeviceOGL::SelfShaderTestPrint(const string& test, int& nb_shader)
 
 void GSDeviceOGL::SelfShaderTest()
 {
-	string out = "";
+	std::string out;
 
 #ifdef __unix__
 	setenv("NV50_PROG_DEBUG", "1", 1);
 #endif
 
-	string test;
+	std::string test;
 	m_shader_inst = 0;
 	m_shader_reg  = 0;
 	int nb_shader = 0;

--- a/plugins/GSdx/GSDeviceOGL.h
+++ b/plugins/GSdx/GSDeviceOGL.h
@@ -478,7 +478,7 @@ public:
 	GLuint m_gs[1<<3];
 	GLuint m_ps_ss[1<<7];
 	GSDepthStencilOGL* m_om_dss[1<<5];
-	hash_map<uint64, GLuint > m_ps;
+	std::unordered_map<uint64, GLuint> m_ps;
 	GLuint m_apitrace;
 
 	GLuint m_palette_ss;

--- a/plugins/GSdx/GSDeviceOGL.h
+++ b/plugins/GSdx/GSDeviceOGL.h
@@ -579,8 +579,8 @@ public:
 	GLuint CreateSampler(PSSamplerSelector sel);
 	GSDepthStencilOGL* CreateDepthStencil(OMDepthStencilSelector dssel);
 
-	void SelfShaderTestPrint(const string& test, int& nb_shader);
-	void SelfShaderTestRun(const string& dir, const string& file, const PSSelector& sel, int& nb_shader);
+	void SelfShaderTestPrint(const std::string& test, int& nb_shader);
+	void SelfShaderTestRun(const std::string& dir, const std::string& file, const PSSelector& sel, int& nb_shader);
 	void SelfShaderTest();
 
 	void SetupIA(const void* vertex, int vertex_count, const uint32* index, int index_count, int prim);

--- a/plugins/GSdx/GSDialog.cpp
+++ b/plugins/GSdx/GSDialog.cpp
@@ -125,9 +125,9 @@ bool GSDialog::OnCommand(HWND hWnd, UINT id, UINT code)
 	return false;
 }
 
-string GSDialog::GetText(UINT id)
+std::string GSDialog::GetText(UINT id)
 {
-	string s;
+	std::string s;
 
 	char* buff = NULL;
 
@@ -183,7 +183,7 @@ void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t 
 
 		if(s.value <= maxValue)
 		{
-			string str(s.name);
+			std::string str(s.name);
 
 			if(!s.note.empty())
 			{

--- a/plugins/GSdx/GSDialog.cpp
+++ b/plugins/GSdx/GSDialog.cpp
@@ -164,7 +164,7 @@ void GSDialog::SetTextAsInt(UINT id, int i)
 	SetText(id, buff);
 }
 
-void GSDialog::ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue)
+void GSDialog::ComboBoxInit(UINT id, const std::vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue)
 {
 	if (settings.empty())
 		return;

--- a/plugins/GSdx/GSDialog.h
+++ b/plugins/GSdx/GSDialog.h
@@ -45,7 +45,7 @@ public:
 
 	INT_PTR DoModal();
 
-	string GetText(UINT id);
+	std::string GetText(UINT id);
 	int GetTextAsInt(UINT id);
 
 	void SetText(UINT id, const char* str);

--- a/plugins/GSdx/GSDialog.h
+++ b/plugins/GSdx/GSDialog.h
@@ -51,7 +51,7 @@ public:
 	void SetText(UINT id, const char* str);
 	void SetTextAsInt(UINT id, int i);
 
-	void ComboBoxInit(UINT id, const vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue = INT32_MAX);
+	void ComboBoxInit(UINT id, const std::vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue = INT32_MAX);
 	int ComboBoxAppend(UINT id, const char* str, LPARAM data = 0, bool select = false);
 	bool ComboBoxGetSelData(UINT id, INT_PTR& data);
 	void ComboBoxFixDroppedWidth(UINT id);

--- a/plugins/GSdx/GSFunctionMap.h
+++ b/plugins/GSdx/GSFunctionMap.h
@@ -38,8 +38,8 @@ protected:
 		VALUE f;
 	};
 
-	hash_map<KEY, VALUE> m_map;
-	hash_map<KEY, ActivePtr*> m_map_active;
+	std::unordered_map<KEY, VALUE> m_map;
+	std::unordered_map<KEY, ActivePtr*> m_map_active;
 
 	ActivePtr* m_active;
 
@@ -60,15 +60,15 @@ public:
 	{
 		m_active = NULL;
 
-		typename hash_map<KEY, ActivePtr*>::iterator i = m_map_active.find(key);
+		auto it = m_map_active.find(key);
 
-		if(i != m_map_active.end())
+		if(it != m_map_active.end())
 		{
-			m_active = i->second;
+			m_active = it->second;
 		}
 		else
 		{
-			typename hash_map<KEY, VALUE>::iterator i = m_map.find(key);
+			auto i = m_map.find(key);
 
 			ActivePtr* p = new ActivePtr();
 
@@ -108,11 +108,9 @@ public:
 	{
 		uint64 ttpf = 0;
 
-		typename hash_map<KEY, ActivePtr*>::iterator i;
-
-		for(i = m_map_active.begin(); i != m_map_active.end(); ++i)
+		for(const auto &i : m_map_active)
 		{
-			ActivePtr* p = i->second;
+			ActivePtr* p = i.second;
 
 			if(p->frames)
 			{
@@ -122,10 +120,10 @@ public:
 
 		printf("GS stats\n");
 
-		for(i = m_map_active.begin(); i != m_map_active.end(); ++i)
+		for (const auto &i : m_map_active)
 		{
-			KEY key = i->first;
-			ActivePtr* p = i->second;
+			KEY key = i.first;
+			ActivePtr* p = i.second;
 
 			if(p->frames && ttpf)
 			{
@@ -161,7 +159,7 @@ class GSCodeGeneratorFunctionMap : public GSFunctionMap<KEY, VALUE>
 {
 	std::string m_name;
 	void* m_param;
-	hash_map<uint64, VALUE> m_cgmap;
+	std::unordered_map<uint64, VALUE> m_cgmap;
 	GSCodeBuffer m_cb;
 	size_t m_total_code_size;
 
@@ -186,7 +184,7 @@ public:
 	{
 		VALUE ret = NULL;
 
-		typename hash_map<uint64, VALUE>::iterator i = m_cgmap.find(key);
+		auto i = m_cgmap.find(key);
 
 		if(i != m_cgmap.end())
 		{

--- a/plugins/GSdx/GSFunctionMap.h
+++ b/plugins/GSdx/GSFunctionMap.h
@@ -159,7 +159,7 @@ public:
 template<class CG, class KEY, class VALUE>
 class GSCodeGeneratorFunctionMap : public GSFunctionMap<KEY, VALUE>
 {
-	string m_name;
+	std::string m_name;
 	void* m_param;
 	hash_map<uint64, VALUE> m_cgmap;
 	GSCodeBuffer m_cb;
@@ -219,7 +219,7 @@ public:
 
 			// if(iJIT_IsProfilingActive()) // always > 0
 			{
-				string name = format("%s<%016llx>()", m_name.c_str(), (uint64)key);
+				std::string name = format("%s<%016llx>()", m_name.c_str(), (uint64)key);
 
 				iJIT_Method_Load ml;
 

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -2274,15 +2274,15 @@ bool GSC_SSX3(const GSFrameInfo& fi, int& skip)
 class AutoReloadLibrary
 {
 private:
-	string	m_dllPath, m_loadedDllPath;
+	std::string	m_dllPath, m_loadedDllPath;
 	DWORD	m_minMsBetweenProbes;
 	time_t	m_lastFileModification;
 	DWORD	m_lastProbe;
 	HMODULE	m_library;
 
-	string	GetTempName()
+	std::string	GetTempName()
 	{
-		string result = m_loadedDllPath + ".tmp"; //default name
+		std::string result = m_loadedDllPath + ".tmp"; //default name
 		TCHAR tmpPath[MAX_PATH], tmpName[MAX_PATH];
 		DWORD ret = GetTempPath(MAX_PATH, tmpPath);
 		if(ret && ret <= MAX_PATH && GetTempFileName(tmpPath, TEXT("GSdx"), 0, tmpName))
@@ -2305,7 +2305,7 @@ private:
 	}
 
 public:
-	AutoReloadLibrary( const string dllPath, const int minMsBetweenProbes=100 )
+	AutoReloadLibrary( const std::string dllPath, const int minMsBetweenProbes=100 )
 		: m_minMsBetweenProbes( minMsBetweenProbes )
 		, m_dllPath( dllPath )
 		, m_lastFileModification( 0 )

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -81,7 +81,7 @@ GtkWidget* left_label(const char* lbl)
 void CB_ChangedComboBox(GtkComboBox *combo, gpointer user_data)
 {
 	int p = gtk_combo_box_get_active(combo);
-	vector<GSSetting>* s = (vector<GSSetting>*)g_object_get_data(G_OBJECT(combo), "Settings");
+	auto s = reinterpret_cast<std::vector<GSSetting>*>(g_object_get_data(G_OBJECT(combo), "Settings"));
 
 	try {
 		theApp.SetConfig((char*)user_data, s->at(p).value);
@@ -89,7 +89,7 @@ void CB_ChangedComboBox(GtkComboBox *combo, gpointer user_data)
 	}
 }
 
-GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_name)
+GtkWidget* CreateComboBoxFromVector(const std::vector<GSSetting>& s, const char* opt_name)
 {
 	GtkWidget* combo_box = gtk_combo_box_text_new();
 	int32_t opt_value    = theApp.GetConfigI(opt_name);

--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -97,7 +97,7 @@ GtkWidget* CreateComboBoxFromVector(const vector<GSSetting>& s, const char* opt_
 
 	for(size_t i = 0; i < s.size(); i++)
 	{
-		string label = s[i].name;
+		std::string label = s[i].name;
 
 		if(!s[i].note.empty()) label += format(" (%s)", s[i].note.c_str());
 

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -2012,7 +2012,7 @@ void GSLocalMemory::ReadTextureBlock4HHP(uint32 bp, uint8* dst, int dstpitch, co
 
 #include "GSTextureSW.h"
 
-void GSLocalMemory::SaveBMP(const string& fn, uint32 bp, uint32 bw, uint32 psm, int w, int h)
+void GSLocalMemory::SaveBMP(const std::string& fn, uint32 bp, uint32 bw, uint32 psm, int w, int h)
 {
 	int pitch = w * 4;
 	int size = pitch * h;

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -636,7 +636,7 @@ GSPixelOffset4* GSLocalMemory::GetPixelOffset4(const GIFRegFRAME& FRAME, const G
 
 static bool cmp_vec2x(const GSVector2i& a, const GSVector2i& b) {return a.x < b.x;}
 
-vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
+std::vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 {
 	uint64 hash = TEX0.u64 & 0x3ffffffffull; // TBP0 TBW PSM TW TH
 
@@ -670,7 +670,7 @@ vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 
 	// combine the lower 5 bits of the address into a 9:5 pointer:mask form, so the "valid bits" can be tested against an uint32 array
 
-	vector<GSVector2i>* p2t = new vector<GSVector2i>[MAX_PAGES];
+	auto p2t = new std::vector<GSVector2i>[MAX_PAGES];
 
 	for(const auto &i : tmp)
 	{

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -498,9 +498,9 @@ GSLocalMemory::~GSLocalMemory()
 	for(auto &i : m_pomap) _aligned_free(i.second);
 	for(auto &i : m_po4map) _aligned_free(i.second);
 
-	for(hash_map<uint64, vector<GSVector2i>*>::iterator i = m_p2tmap.begin(); i != m_p2tmap.end(); ++i)
+	for(auto &i : m_p2tmap)
 	{
-		delete [] i->second;
+		delete [] i.second;
 	}
 }
 
@@ -508,7 +508,7 @@ GSOffset* GSLocalMemory::GetOffset(uint32 bp, uint32 bw, uint32 psm)
 {
 	uint32 hash = bp | (bw << 14) | (psm << 20);
 
-	hash_map<uint32, GSOffset*>::iterator i = m_omap.find(hash);
+	auto i = m_omap.find(hash);
 
 	if(i != m_omap.end())
 	{
@@ -539,11 +539,11 @@ GSPixelOffset* GSLocalMemory::GetPixelOffset(const GIFRegFRAME& FRAME, const GIF
 
 	uint32 hash = (FRAME.FBP << 0) | (ZBUF.ZBP << 9) | (bw << 18) | (fpsm_hash << 24) | (zpsm_hash << 28);
 
-	hash_map<uint32, GSPixelOffset*>::iterator i = m_pomap.find(hash);
+	auto it = m_pomap.find(hash);
 
-	if(i != m_pomap.end())
+	if(it != m_pomap.end())
 	{
-		return i->second;
+		return it->second;
 	}
 
 	GSPixelOffset* off = (GSPixelOffset*)_aligned_malloc(sizeof(GSPixelOffset), 32);
@@ -595,11 +595,11 @@ GSPixelOffset4* GSLocalMemory::GetPixelOffset4(const GIFRegFRAME& FRAME, const G
 
 	uint32 hash = (FRAME.FBP << 0) | (ZBUF.ZBP << 9) | (bw << 18) | (fpsm_hash << 24) | (zpsm_hash << 28);
 
-	hash_map<uint32, GSPixelOffset4*>::iterator i = m_po4map.find(hash);
+	auto it = m_po4map.find(hash);
 
-	if(i != m_po4map.end())
+	if(it != m_po4map.end())
 	{
-		return i->second;
+		return it->second;
 	}
 
 	GSPixelOffset4* off = (GSPixelOffset4*)_aligned_malloc(sizeof(GSPixelOffset4), 32);
@@ -640,11 +640,11 @@ vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 {
 	uint64 hash = TEX0.u64 & 0x3ffffffffull; // TBP0 TBW PSM TW TH
 
-	hash_map<uint64, vector<GSVector2i>*>::iterator i = m_p2tmap.find(hash);
+	auto it = m_p2tmap.find(hash);
 
-	if(i != m_p2tmap.end())
+	if(it != m_p2tmap.end())
 	{
-		return i->second;
+		return it->second;
 	}
 
 	GSVector2i bs = m_psm[TEX0.PSM].bs;
@@ -654,7 +654,7 @@ vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 
 	const GSOffset* off = GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
-	hash_map<uint32, hash_set<uint32> > tmp; // key = page, value = y:x, 7 bits each, max 128x128 tiles for the worst case (1024x1024 32bpp 8x8 blocks)
+	std::unordered_map<uint32, std::unordered_set<uint32>> tmp; // key = page, value = y:x, 7 bits each, max 128x128 tiles for the worst case (1024x1024 32bpp 8x8 blocks)
 
 	for(int y = 0; y < th; y += bs.y)
 	{
@@ -672,22 +672,20 @@ vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 
 	vector<GSVector2i>* p2t = new vector<GSVector2i>[MAX_PAGES];
 
-	for(hash_map<uint32, hash_set<uint32> >::iterator i = tmp.begin(); i != tmp.end(); ++i)
+	for(const auto &i : tmp)
 	{
-		uint32 page = i->first;
+		uint32 page = i.first;
 
-		hash_set<uint32>& tiles = i->second;
+		auto& tiles = i.second;
 
-		hash_map<uint32, uint32> m;
+		std::unordered_map<uint32, uint32> m;
 
-		for(hash_set<uint32>::iterator j = tiles.begin(); j != tiles.end(); ++j)
+		for(const auto addr : tiles)
 		{
-			uint32 addr = *j;
-
 			uint32 row = addr >> 5;
 			uint32 col = 1 << (addr & 31);
 
-			hash_map<uint32, uint32>::iterator k = m.find(row);
+			auto k = m.find(row);
 
 			if(k != m.end())
 			{
@@ -704,9 +702,9 @@ vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 
 		// sort by x and flip the mask (it will be used to erase a lot of bits in a loop, [x] &= ~y)
 
-		for(hash_map<uint32, uint32>::iterator j = m.begin(); j != m.end(); ++j)
+		for(const auto &j : m)
 		{
-			p2t[page].push_back(GSVector2i(j->first, ~j->second));
+			p2t[page].push_back(GSVector2i(j.first, ~j.second));
 		}
 
 		std::sort(p2t[page].begin(), p2t[page].end(), cmp_vec2x);

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -816,7 +816,7 @@ void GSLocalMemory::WriteImageTopBottom(int l, int r, int y, int h, const uint8*
 
 	if(y2 > 0)
 	{
-		int h2 = min(h, csy - y2);
+		int h2 = std::min(h, csy - y2);
 
 		for(int x = l; x < r; x += bsx)
 		{
@@ -969,7 +969,7 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const uint8* src, int len, GIFR
 
 	if(tx != l)
 	{
-		int n = min(len, (r - tx) * trbpp >> 3);
+		int n = std::min(len, (r - tx) * trbpp >> 3);
 		WriteImageX(tx, ty, src, n, BITBLTBUF, TRXPOS, TRXREG);
 		src += n;
 		len -= n;
@@ -1008,7 +1008,7 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const uint8* src, int len, GIFR
 			// top part
 
 			{
-				int h2 = min(h, bsy - (ty & (bsy - 1)));
+				int h2 = std::min(h, bsy - (ty & (bsy - 1)));
 
 				if(h2 < bsy)
 				{

--- a/plugins/GSdx/GSLocalMemory.h
+++ b/plugins/GSdx/GSLocalMemory.h
@@ -173,10 +173,10 @@ protected:
 
 	//
 
-	hash_map<uint32, GSOffset*> m_omap;
-	hash_map<uint32, GSPixelOffset*> m_pomap;
-	hash_map<uint32, GSPixelOffset4*> m_po4map;
-	hash_map<uint64, vector<GSVector2i>*> m_p2tmap;
+	std::unordered_map<uint32, GSOffset*> m_omap;
+	std::unordered_map<uint32, GSPixelOffset*> m_pomap;
+	std::unordered_map<uint32, GSPixelOffset4*> m_po4map;
+	std::unordered_map<uint64, std::vector<GSVector2i>*> m_p2tmap;
 
 public:
 	GSLocalMemory();

--- a/plugins/GSdx/GSLocalMemory.h
+++ b/plugins/GSdx/GSLocalMemory.h
@@ -917,6 +917,6 @@ public:
 
 	//
 
-	void SaveBMP(const string& fn, uint32 bp, uint32 bw, uint32 psm, int w, int h);
+	void SaveBMP(const std::string& fn, uint32 bp, uint32 bw, uint32 psm, int w, int h);
 };
 

--- a/plugins/GSdx/GSLocalMemory.h
+++ b/plugins/GSdx/GSLocalMemory.h
@@ -185,7 +185,7 @@ public:
 	GSOffset* GetOffset(uint32 bp, uint32 bw, uint32 psm);
 	GSPixelOffset* GetPixelOffset(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
-	vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
+	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
 
 	// address
 

--- a/plugins/GSdx/GSLzma.cpp
+++ b/plugins/GSdx/GSLzma.cpp
@@ -123,7 +123,7 @@ bool GSDumpLzma::Read(void* ptr, size_t size) {
 			Decompress();
 		}
 
-		size_t l = min(size, m_avail);
+		size_t l = std::min(size, m_avail);
 		memcpy(dst + off, m_area+m_start, l);
 		m_avail -= l;
 		size    -= l;

--- a/plugins/GSdx/GSOsdManager.cpp
+++ b/plugins/GSdx/GSOsdManager.cpp
@@ -178,9 +178,9 @@ void GSOsdManager::Log(const char *utf8, uint32 color) {
 	for(char32_t* c = buffer; *c; ++c) AddGlyph(*c);
 #else
 #if _MSC_VER == 1900
-	std::wstring_convert<codecvt_utf8<unsigned int>, unsigned int> conv;
+	std::wstring_convert<std::codecvt_utf8<unsigned int>, unsigned int> conv;
 #else
-	std::wstring_convert<codecvt_utf8<char32_t>, char32_t> conv;
+	std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
 #endif
 	std::u32string buffer = conv.from_bytes(utf8);
 	for(auto const &c : buffer) AddGlyph(c);
@@ -203,9 +203,9 @@ void GSOsdManager::Monitor(const char *key, const char *value, uint32 color) {
 		for(char32_t* c = vbuffer; *c; ++c) AddGlyph(*c);
 #else
 #if _MSC_VER == 1900
-		std::wstring_convert<codecvt_utf8<unsigned int>, unsigned int> conv;
+		std::wstring_convert<std::codecvt_utf8<unsigned int>, unsigned int> conv;
 #else
-		std::wstring_convert<codecvt_utf8<char32_t>, char32_t> conv;
+		std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
 #endif
 		std::u32string buffer = conv.from_bytes(key);
 		std::u32string vbuffer = conv.from_bytes(value);
@@ -219,9 +219,9 @@ void GSOsdManager::Monitor(const char *key, const char *value, uint32 color) {
 		dumb_utf8_to_utf32(key, buffer, countof(buffer));
 #else
 #if _MSC_VER == 1900
-		std::wstring_convert<codecvt_utf8<unsigned int>, unsigned int> conv;
+		std::wstring_convert<std::codecvt_utf8<unsigned int>, unsigned int> conv;
 #else
-		std::wstring_convert<codecvt_utf8<char32_t>, char32_t> conv;
+		std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
 #endif
 		std::u32string buffer = conv.from_bytes(key);
 #endif

--- a/plugins/GSdx/GSPng.cpp
+++ b/plugins/GSdx/GSPng.cpp
@@ -41,7 +41,7 @@ struct {
 
 namespace GSPng {
 
-    bool SaveFile(const string& file, const Format fmt, const uint8* const image,
+    bool SaveFile(const std::string& file, const Format fmt, const uint8* const image,
         uint8* const row, const int width, const int height, const int pitch,
         const int compression, const bool rb_swapped = false, const bool first_image = false)
     {
@@ -104,7 +104,7 @@ namespace GSPng {
         return success;
     }
 
-    bool Save(GSPng::Format fmt, const string& file, uint8* image, int w, int h, int pitch, int compression, bool rb_swapped)
+    bool Save(GSPng::Format fmt, const std::string& file, uint8* image, int w, int h, int pitch, int compression, bool rb_swapped)
     {
         std::string root = file;
         root.replace(file.length() - 4, 4, "");
@@ -128,7 +128,7 @@ namespace GSPng {
         return SaveFile(filename, fmt, image, row.get(), w, h, pitch, compression);
     }
 
-    Transaction::Transaction(GSPng::Format fmt, const string& file, const uint8* image, int w, int h, int pitch, int compression)
+    Transaction::Transaction(GSPng::Format fmt, const std::string& file, const uint8* image, int w, int h, int pitch, int compression)
         : m_fmt(fmt), m_file(file), m_w(w), m_h(h), m_pitch(pitch), m_compression(compression)
     {
         // Note: yes it would be better to use shared pointer

--- a/plugins/GSdx/GSPng.h
+++ b/plugins/GSdx/GSPng.h
@@ -46,11 +46,11 @@ namespace GSPng {
 			int m_pitch;
 			int m_compression;
 
-			Transaction(GSPng::Format fmt, const string& file, const uint8* image, int w, int h, int pitch, int compression);
+			Transaction(GSPng::Format fmt, const std::string& file, const uint8* image, int w, int h, int pitch, int compression);
 			~Transaction();
 	};
 
-    bool Save(GSPng::Format fmt, const string& file, uint8* image, int w, int h, int pitch, int compression, bool rb_swapped = false);
+    bool Save(GSPng::Format fmt, const std::string& file, uint8* image, int w, int h, int pitch, int compression, bool rb_swapped = false);
 
     void Process(std::shared_ptr<Transaction> &item);
 

--- a/plugins/GSdx/GSRasterizer.cpp
+++ b/plugins/GSdx/GSRasterizer.cpp
@@ -114,7 +114,7 @@ int GSRasterizer::FindMyNextScanline(int top) const
 	return top;
 }
 
-void GSRasterizer::Queue(const shared_ptr<GSRasterizerData>& data)
+void GSRasterizer::Queue(const std::shared_ptr<GSRasterizerData>& data)
 {
 	Draw(data.get());
 }
@@ -1161,7 +1161,7 @@ GSRasterizerList::~GSRasterizerList()
 	_aligned_free(m_scanline);
 }
 
-void GSRasterizerList::Queue(const shared_ptr<GSRasterizerData>& data)
+void GSRasterizerList::Queue(const std::shared_ptr<GSRasterizerData>& data)
 {
 	GSVector4i r = data->bbox.rintersect(data->scissor);
 

--- a/plugins/GSdx/GSRasterizer.h
+++ b/plugins/GSdx/GSRasterizer.h
@@ -115,7 +115,7 @@ class IRasterizer : public GSAlignedClass<32>
 public:
 	virtual ~IRasterizer() {}
 
-	virtual void Queue(const shared_ptr<GSRasterizerData>& data) = 0;
+	virtual void Queue(const std::shared_ptr<GSRasterizerData>& data) = 0;
 	virtual void Sync() = 0;
 	virtual bool IsSynced() const = 0;
 	virtual int GetPixels(bool reset = true) = 0;
@@ -171,7 +171,7 @@ public:
 
 	// IRasterizer
 
-	void Queue(const shared_ptr<GSRasterizerData>& data);
+	void Queue(const std::shared_ptr<GSRasterizerData>& data);
 	void Sync() {}
 	bool IsSynced() const {return true;}
 	int GetPixels(bool reset);
@@ -219,7 +219,7 @@ public:
 
 	// IRasterizer
 
-	void Queue(const shared_ptr<GSRasterizerData>& data);
+	void Queue(const std::shared_ptr<GSRasterizerData>& data);
 	void Sync();
 	bool IsSynced() const;
 	int GetPixels(bool reset);

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -101,10 +101,10 @@ bool GSRenderer::Merge(int field)
 			fr[i] = GetFrameRect(i);
 			dr[i] = GetDisplayRect(i);
 
-			display_baseline.x = min(dr[i].left, display_baseline.x);
-			display_baseline.y = min(dr[i].top, display_baseline.y);
-			frame_baseline.x = min(fr[i].left, frame_baseline.x);
-			frame_baseline.y = min(fr[i].top, frame_baseline.y);
+			display_baseline.x = std::min(dr[i].left, display_baseline.x);
+			display_baseline.y = std::min(dr[i].top, display_baseline.y);
+			frame_baseline.x = std::min(fr[i].left, frame_baseline.x);
+			frame_baseline.y = std::min(fr[i].top, frame_baseline.y);
 
 			//printf("[%d]: %d %d %d %d, %d %d %d %d\n", i, fr[i].x,fr[i].y,fr[i].z,fr[i].w , dr[i].x,dr[i].y,dr[i].z,dr[i].w);
 		}
@@ -160,8 +160,8 @@ bool GSRenderer::Merge(int field)
 			// dr[0] = 127 50 639 494
 			// dr[1] = 127 50 639 494
 
-			int top = min(fr[0].top, fr[1].top);
-			int bottom = min(fr[0].bottom, fr[1].bottom);
+			int top = std::min(fr[0].top, fr[1].top);
+			int bottom = std::min(fr[0].bottom, fr[1].bottom);
 
 			fr[0].top = fr[1].top = top;
 			fr[0].bottom = fr[1].bottom = bottom;
@@ -237,8 +237,8 @@ bool GSRenderer::Merge(int field)
 
 		dst[i] = GSVector4(off).xyxy() + scale * GSVector4(r.rsize());
 
-		fs.x = max(fs.x, (int)(dst[i].z + 0.5f));
-		fs.y = max(fs.y, (int)(dst[i].w + 0.5f));
+		fs.x = std::max(fs.x, (int)(dst[i].z + 0.5f));
+		fs.y = std::max(fs.y, (int)(dst[i].w + 0.5f));
 	}
 
 	ds = fs;
@@ -542,7 +542,7 @@ bool GSRenderer::MakeSnapshot(const std::string& path)
 bool GSRenderer::BeginCapture()
 {
 	GSVector4i disp = m_wnd->GetClientRect().fit(m_aspectratio);
-	float aspect = (float)disp.width() / max(1, disp.height());
+	float aspect = (float)disp.width() / std::max(1, disp.height());
 
 	return m_capture.BeginCapture(GetTvRefreshRate(), GetInternalResolution(), aspect);
 }

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -346,7 +346,7 @@ void GSRenderer::VSync(int field)
 
 		double fps = 1000.0f / m_perfmon.Get(GSPerfMon::Frame);
 
-		string s;
+		std::string s;
 
 #ifdef GSTITLEINFO_API_FORCE_VERBOSE
 		if(1)//force verbose reply
@@ -356,7 +356,7 @@ void GSRenderer::VSync(int field)
 		{
 			//GSdx owns the window's title, be verbose.
 
-			string s2 = m_regs->SMODE2.INT ? (string("Interlaced ") + (m_regs->SMODE2.FFMD ? "(frame)" : "(field)")) : "Progressive";
+			std::string s2 = m_regs->SMODE2.INT ? (std::string("Interlaced ") + (m_regs->SMODE2.FFMD ? "(frame)" : "(field)")) : "Progressive";
 
 			s = format(
 				"%lld | %d x %d | %.2f fps (%d%%) | %s - %s | %s | %d S/%d P/%d D | %d%% CPU | %.2f | %.2f",
@@ -508,7 +508,7 @@ void GSRenderer::VSync(int field)
 	}
 }
 
-bool GSRenderer::MakeSnapshot(const string& path)
+bool GSRenderer::MakeSnapshot(const std::string& path)
 {
 	if(m_snapshot.empty())
 	{

--- a/plugins/GSdx/GSRenderer.h
+++ b/plugins/GSdx/GSRenderer.h
@@ -29,7 +29,7 @@
 class GSRenderer : public GSState
 {
 	GSCapture m_capture;
-	string m_snapshot;
+	std::string m_snapshot;
 	int m_shader;
 
 	bool Merge(int field);
@@ -62,7 +62,7 @@ public:
 	virtual bool CreateDevice(GSDevice* dev);
 	virtual void ResetDevice();
 	virtual void VSync(int field);
-	virtual bool MakeSnapshot(const string& path);
+	virtual bool MakeSnapshot(const std::string& path);
 	virtual void KeyEvent(GSKeyEventData* e);
 	virtual bool CanUpscale() {return false;}
 	virtual int GetUpscaleMultiplier() {return 1;}

--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -1919,7 +1919,7 @@ GSRendererCL::CL::CL()
 		throw new std::runtime_error("OpenCL device not found");
 	}
 
-	vector<cl::Device> tmp;
+	std::vector<cl::Device> tmp;
 
 	for(auto d : devs) tmp.push_back(d.device);
 
@@ -2032,7 +2032,7 @@ cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
 
 			if(binaries.size() == devs.size())
 			{
-				vector<cl::Device> tmp;
+				std::vector<cl::Device> tmp;
 
 				for(auto d : devs) tmp.push_back(d.device);
 
@@ -2087,8 +2087,8 @@ cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
 	{
 		try
 		{
-			vector<size_t> sizes = program.getInfo<CL_PROGRAM_BINARY_SIZES>();
-			vector<char*> binaries = program.getInfo<CL_PROGRAM_BINARIES>();
+			std::vector<size_t> sizes = program.getInfo<CL_PROGRAM_BINARY_SIZES>();
+			std::vector<char*> binaries = program.getInfo<CL_PROGRAM_BINARIES>();
 
 			for(size_t i = 0; i < binaries.size(); i++)
 			{

--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -1997,7 +1997,7 @@ void GSRendererCL::CL::Unmap()
 	pb.mapped_ptr = pb.ptr = NULL;
 }
 
-cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
+cl::Kernel GSRendererCL::CL::Build(const char* entry, std::ostringstream& opt)
 {
 	cl::Program program;
 
@@ -2017,7 +2017,7 @@ cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
 				{
 					fseek(f, 0, SEEK_END);
 					long size = ftell(f);
-					pair<void*, size_t> b(new char[size], size);
+					std::pair<void*, size_t> b(new char[size], size);
 					fseek(f, 0, SEEK_SET);
 					fread(b.first, b.second, 1, f);
 					fclose(f);
@@ -2114,7 +2114,7 @@ cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
 	return cl::Kernel(program, entry);
 }
 
-void GSRendererCL::CL::AddDefs(ostringstream& opt)
+void GSRendererCL::CL::AddDefs(std::ostringstream& opt)
 {
 	if(version == 110) opt << "-cl-std=CL1.1 ";
 	else opt << "-cl-std=CL1.2 ";
@@ -2146,7 +2146,7 @@ cl::Kernel& GSRendererCL::CL::GetPrimKernel(const PrimSelector& sel)
 
 	sprintf(entry, "prim_%02x", sel.key);
 
-	ostringstream opt;
+	std::ostringstream opt;
 
 	opt << "-D KERNEL_PRIM=" << entry << " ";
 	opt << "-D PRIM=" << sel.prim << " ";
@@ -2173,7 +2173,7 @@ cl::Kernel& GSRendererCL::CL::GetTileKernel(const TileSelector& sel)
 
 	sprintf(entry, "tile_%02x", sel.key);
 
-	ostringstream opt;
+	std::ostringstream opt;
 
 	opt << "-D KERNEL_TILE=" << entry << " ";
 	opt << "-D PRIM=" << sel.prim << " ";
@@ -2202,7 +2202,7 @@ cl::Kernel& GSRendererCL::CL::GetTFXKernel(const TFXSelector& sel)
 
 	sprintf(entry, "tfx_%016llx", sel.key);
 
-	ostringstream opt;
+	std::ostringstream opt;
 
 	opt << "-D KERNEL_TFX=" << entry << " ";
 	opt << "-D FPSM=" << sel.fpsm << " ";

--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -1887,7 +1887,7 @@ GSRendererCL::CL::CL()
 	ocldev = "Intel(R) Corporation Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz OpenCL C 1.2 CPU";
 #endif
 
-	list<OCLDeviceDesc> dl;
+	std::list<OCLDeviceDesc> dl;
 
 	GSUtil::GetDeviceDescs(dl);
 

--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -405,7 +405,7 @@ void GSRendererCL::Draw()
 			}
 		}
 
-		shared_ptr<TFXJob> job(new TFXJob());
+		std::shared_ptr<TFXJob> job(new TFXJob());
 
 		if(!SetupParameter(job.get(), pb, vb, m_vertex.next, m_index.buff, m_index.tail))
 		{
@@ -891,7 +891,7 @@ void GSRendererCL::Enqueue()
 						}
 					}
 
-					std::list<shared_ptr<TFXJob>> jobs(head, next);
+					std::list<std::shared_ptr<TFXJob>> jobs(head, next);
 
 					JoinTFX(jobs);
 
@@ -945,7 +945,7 @@ void GSRendererCL::Enqueue()
 	m_cl.Map();
 }
 
-void GSRendererCL::EnqueueTFX(std::list<shared_ptr<TFXJob>>& jobs, uint32 bin_count, const cl_uchar4& bin_dim)
+void GSRendererCL::EnqueueTFX(std::list<std::shared_ptr<TFXJob>>& jobs, uint32 bin_count, const cl_uchar4& bin_dim)
 {
 	cl_kernel tfx_prev = NULL;
 
@@ -995,7 +995,7 @@ void GSRendererCL::EnqueueTFX(std::list<shared_ptr<TFXJob>>& jobs, uint32 bin_co
 	}
 }
 
-void GSRendererCL::JoinTFX(std::list<shared_ptr<TFXJob>>& jobs)
+void GSRendererCL::JoinTFX(std::list<std::shared_ptr<TFXJob>>& jobs)
 {
 	// join tfx kernel calls where the selector and fbp/zbp/bw/fpsm/zpsm are the same and src_pages != prev dst_pages
 

--- a/plugins/GSdx/GSRendererCL.cpp
+++ b/plugins/GSdx/GSRendererCL.cpp
@@ -2009,7 +2009,7 @@ cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
 		{
 			for(auto d : devs)
 			{
-				string path = d.tmppath + "/" + entry;
+				std::string path = d.tmppath + "/" + entry;
 
 				FILE* f = fopen(path.c_str(), "rb");
 
@@ -2092,7 +2092,7 @@ cl::Kernel GSRendererCL::CL::Build(const char* entry, ostringstream& opt)
 
 			for(size_t i = 0; i < binaries.size(); i++)
 			{
-				string path = devs[i].tmppath + "/" + entry;
+				std::string path = devs[i].tmppath + "/" + entry;
 
 				FILE* f = fopen(path.c_str(), "wb");
 

--- a/plugins/GSdx/GSRendererCL.h
+++ b/plugins/GSdx/GSRendererCL.h
@@ -194,8 +194,8 @@ class GSRendererCL : public GSRenderer
 		std::map<uint32, cl::Kernel> tile_map;
 		std::map<uint64, cl::Kernel> tfx_map;
 
-		cl::Kernel Build(const char* entry, ostringstream& opt);
-		void AddDefs(ostringstream& opt);
+		cl::Kernel Build(const char* entry, std::ostringstream& opt);
+		void AddDefs(std::ostringstream& opt);
 
 	public:
 		std::vector<OCLDeviceDesc> devs;

--- a/plugins/GSdx/GSRendererCL.h
+++ b/plugins/GSdx/GSRendererCL.h
@@ -223,7 +223,7 @@ class GSRendererCL : public GSRenderer
 	};
 
 	CL m_cl;
-	std::list<shared_ptr<TFXJob>> m_jobs;
+	std::list<std::shared_ptr<TFXJob>> m_jobs;
 	uint32 m_vb_start;
 	uint32 m_vb_count;
 	uint32 m_pb_start;
@@ -231,8 +231,8 @@ class GSRendererCL : public GSRenderer
 	bool m_synced;
 
 	void Enqueue();
-	void EnqueueTFX(std::list<shared_ptr<TFXJob>>& jobs, uint32 bin_count, const cl_uchar4& bin_dim);
-	void JoinTFX(std::list<shared_ptr<TFXJob>>& jobs);
+	void EnqueueTFX(std::list<std::shared_ptr<TFXJob>>& jobs, uint32 bin_count, const cl_uchar4& bin_dim);
+	void JoinTFX(std::list<std::shared_ptr<TFXJob>>& jobs);
 	bool UpdateTextureCache(TFXJob* job);
 	void InvalidateTextureCache(TFXJob* job);
 	void UsePages(uint32* pages);

--- a/plugins/GSdx/GSRendererCS.cpp
+++ b/plugins/GSdx/GSRendererCS.cpp
@@ -501,7 +501,7 @@ void GSRendererCS::Draw()
 	{
 		GSVertexShader11 vs;
 
-		hash_map<uint32, GSVertexShader11>::const_iterator i = m_vs.find(vs_sel);
+		auto i = std::as_const(m_vs).find(vs_sel);
 
 		if(i != m_vs.end())
 		{
@@ -558,7 +558,7 @@ void GSRendererCS::Draw()
 	{
 		gs_sel.prim = j == 0 ? m_vt.m_primclass : GS_SPRITE_CLASS;
 
-		hash_map<uint32, CComPtr<ID3D11GeometryShader> >::const_iterator i = m_gs.find(gs_sel);
+		auto i = std::as_const(m_gs).find(gs_sel);
 
 		if(i != m_gs.end())
 		{
@@ -597,7 +597,7 @@ void GSRendererCS::Draw()
 
 	CComPtr<ID3D11PixelShader> ps[2] = {m_ps0, NULL};
 
-	hash_map<uint64, CComPtr<ID3D11PixelShader> >::const_iterator i = m_ps1.find(ps_sel);
+	auto i = std::as_const(m_ps1).find(ps_sel);
 
 	if(i != m_ps1.end())
 	{
@@ -825,7 +825,7 @@ bool GSRendererCS::GetOffsetBuffer(OffsetBuffer** fzbo)
 	D3D11_SHADER_RESOURCE_VIEW_DESC srvd;
 	D3D11_SUBRESOURCE_DATA data;
 
-	hash_map<uint32, OffsetBuffer>::iterator i = m_offset.find(m_context->offset.fzb->hash);
+	auto i = m_offset.find(m_context->offset.fzb->hash);
 
 	if(i == m_offset.end())
 	{

--- a/plugins/GSdx/GSRendererCS.cpp
+++ b/plugins/GSdx/GSRendererCS.cpp
@@ -509,7 +509,7 @@ void GSRendererCS::Draw()
 		}
 		else
 		{
-			string str[2];
+			std::string str[2];
 
 			str[0] = format("%d", vs_sel.tme);
 			str[1] = format("%d", vs_sel.fst);
@@ -566,7 +566,7 @@ void GSRendererCS::Draw()
 		}
 		else
 		{
-			string str[2];
+			std::string str[2];
 
 			str[0] = format("%d", gs_sel.iip);
 			str[1] = format("%d", j == 0 ? gs_sel.prim : GS_SPRITE_CLASS);
@@ -605,7 +605,7 @@ void GSRendererCS::Draw()
 	}
 	else
 	{
-		string str[15];
+		std::string str[15];
 
 		str[0] = format("%d", PS_BATCH_SIZE);
 		str[1] = format("%d", context->FRAME.PSM);

--- a/plugins/GSdx/GSRendererCS.h
+++ b/plugins/GSdx/GSRendererCS.h
@@ -107,11 +107,11 @@ class GSRendererCS : public GSRenderer
 	uint32 m_vm_valid[16];
 	CComPtr<ID3D11Buffer> m_pb;
 	//CComPtr<ID3D11Texture2D> m_pb;
-	hash_map<uint32, GSVertexShader11 > m_vs;
+	std::unordered_map<uint32, GSVertexShader11> m_vs;
 	CComPtr<ID3D11Buffer> m_vs_cb;
-	hash_map<uint32, CComPtr<ID3D11GeometryShader> > m_gs;
+	std::unordered_map<uint32, CComPtr<ID3D11GeometryShader>> m_gs;
 	CComPtr<ID3D11PixelShader> m_ps0;
-	hash_map<uint64, CComPtr<ID3D11PixelShader> > m_ps1;
+	std::unordered_map<uint64, CComPtr<ID3D11PixelShader>> m_ps1;
 	CComPtr<ID3D11Buffer> m_ps_cb;
 
 	void Write(GSOffset* off, const GSVector4i& r);
@@ -123,7 +123,7 @@ class GSRendererCS : public GSRenderer
 		CComPtr<ID3D11ShaderResourceView> row_srv, col_srv;
 	};
 
-	hash_map<uint32, OffsetBuffer> m_offset;
+	std::unordered_map<uint32, OffsetBuffer> m_offset;
 
 	bool GetOffsetBuffer(OffsetBuffer** fzbo);
 

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -869,7 +869,7 @@ void GSRendererHW::Draw()
 	{
 		uint64 frame = m_perfmon.GetFrame();
 
-		string s;
+		std::string s;
 
 		if (s_n >= s_saven) {
 			// Dump Register state
@@ -1039,7 +1039,7 @@ void GSRendererHW::Draw()
 	{
 		uint64 frame = m_perfmon.GetFrame();
 
-		string s;
+		std::string s;
 
 		if(s_save && s_n >= s_saven)
 		{

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -94,7 +94,7 @@ void GSRendererHW::SetScaling()
 	// Framebuffer width is always a multiple of 64 so at certain cases it can't cover some weird width values.
 	// 480P , 576P use width as 720 which is not referencable by FBW * 64. so it produces 704 ( the closest value multiple by 64).
 	// In such cases, let's just use the CRTC width.
-	int fb_width = max({ (int)m_context->FRAME.FBW * 64, crtc_size.x , 512 });
+	int fb_width = std::max({ (int)m_context->FRAME.FBW * 64, crtc_size.x , 512 });
 	// GS doesn't have a specific register for the FrameBuffer height. so we get the height
 	// from physical units of the display rectangle in case the game uses a heigher value of height.
 	//
@@ -112,7 +112,7 @@ void GSRendererHW::SetScaling()
 	//
 	// Until performance issue is properly fixed, let's keep an option to reduce the framebuffer size.
 	int fb_height = m_large_framebuffer ? 1280 :
-		(fb_width < 1024) ? max(512, crtc_size.y) : 1024;
+		(fb_width < 1024) ? std::max(512, crtc_size.y) : 1024;
 
 	int upscaled_fb_w = fb_width * m_upscale_multiplier;
 	int upscaled_fb_h = fb_height * m_upscale_multiplier;

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -96,18 +96,18 @@ private:
 
 		template<class T> class FunctionMap : public GSFunctionMap<uint32, T>
 		{
-			list<HackEntry<T> >& m_tbl;
+			std::list<HackEntry<T> >& m_tbl;
 
 			T GetDefaultFunction(uint32 key)
 			{
 				CRC::Title title = (CRC::Title)(key & 0xffffff);
 				CRC::Region region = (CRC::Region)(key >> 24);
 
-				for(typename list<HackEntry<T> >::iterator i = m_tbl.begin(); i != m_tbl.end(); i++)
+				for(const auto &entry : m_tbl)
 				{
-					if(i->title == title && (i->region == CRC::RegionCount || i->region == region))
+					if(entry.title == title && (entry.region == CRC::RegionCount || entry.region == region))
 					{
-						return i->func;
+						return entry.func;
 					}
 				}
 
@@ -115,12 +115,12 @@ private:
 			}
 
 		public:
-			FunctionMap(list<HackEntry<T> >& tbl) : m_tbl(tbl) {}
+			FunctionMap(std::list<HackEntry<T> >& tbl) : m_tbl(tbl) {}
 		};
 
-		list<HackEntry<OI_Ptr> > m_oi_list;
-		list<HackEntry<OO_Ptr> > m_oo_list;
-		list<HackEntry<CU_Ptr> > m_cu_list;
+		std::list<HackEntry<OI_Ptr> > m_oi_list;
+		std::list<HackEntry<OO_Ptr> > m_oo_list;
+		std::list<HackEntry<CU_Ptr> > m_cu_list;
 
 		FunctionMap<OI_Ptr> m_oi_map;
 		FunctionMap<OO_Ptr> m_oo_map;

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -1006,7 +1006,7 @@ void GSRendererOGL::SendDraw()
 
 #if defined(_DEBUG)
 		// Check how draw call is split.
-		map<size_t, size_t> frequency;
+		std::map<size_t, size_t> frequency;
 		for (const auto& it: m_drawlist)
 			++frequency[it];
 

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -1010,9 +1010,9 @@ void GSRendererOGL::SendDraw()
 		for (const auto& it: m_drawlist)
 			++frequency[it];
 
-		string message;
+		std::string message;
 		for (const auto& it: frequency)
-			message += " " + to_string(it.first) + "(" + to_string(it.second) + ")";
+			message += " " + std::to_string(it.first) + "(" + std::to_string(it.second) + ")";
 
 		GL_PERF("Split single draw (%d sprites) into %zu draws: consecutive draws(frequency):%s",
 			m_index.tail / nb_vertex, m_drawlist.size(), message.c_str());

--- a/plugins/GSdx/GSRendererOGL.h
+++ b/plugins/GSdx/GSRendererOGL.h
@@ -48,7 +48,7 @@ class GSRendererOGL final : public GSRendererHW
 		bool m_accurate_date;
 		int m_sw_blending;
 		PRIM_OVERLAP m_prim_overlap;
-		vector<size_t> m_drawlist;
+		std::vector<size_t> m_drawlist;
 
 		unsigned int UserHacks_TCOffset;
 		float UserHacks_TCO_x, UserHacks_TCO_y;

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -378,7 +378,7 @@ void GSRendererSW::Draw()
 
 	SharedData* sd = new SharedData(this);
 
-	shared_ptr<GSRasterizerData> data(sd);
+	std::shared_ptr<GSRasterizerData> data(sd);
 
 	sd->primclass = m_vt.m_primclass;
 	sd->buff = (uint8*)_aligned_malloc(sizeof(GSVertexSW) * ((m_vertex.next + 1) & ~1) + sizeof(uint32) * m_index.tail, 64);
@@ -576,7 +576,7 @@ void GSRendererSW::Draw()
 	*/
 }
 
-void GSRendererSW::Queue(shared_ptr<GSRasterizerData>& item)
+void GSRendererSW::Queue(std::shared_ptr<GSRasterizerData>& item)
 {
 	SharedData* sd = (SharedData*)item.get();
 

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -488,7 +488,7 @@ void GSRendererSW::Draw()
 		// It will breaks the few games that really uses 16 bits RT
 		bool texture_shuffle = ((context->FRAME.PSM & 0x2) && ((context->TEX0.PSM & 3) == 2) && (m_vt.m_primclass == GS_SPRITE_CLASS));
 
-		string s;
+		std::string s;
 
 		if(s_n >= s_saven)
 		{
@@ -1539,7 +1539,7 @@ void GSRendererSW::SharedData::UpdateSource()
 	{
 		uint64 frame = m_parent->m_perfmon.GetFrame();
 
-		string s;
+		std::string s;
 
 		if(m_parent->s_savet && m_parent->s_n >= m_parent->s_saven)
 		{

--- a/plugins/GSdx/GSRendererSW.h
+++ b/plugins/GSdx/GSRendererSW.h
@@ -87,7 +87,7 @@ protected:
 	GSTexture* GetFeedbackOutput();
 
 	void Draw();
-	void Queue(shared_ptr<GSRasterizerData>& item);
+	void Queue(std::shared_ptr<GSRasterizerData>& item);
 	void Sync(int reason);
 	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r);
 	void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false);

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -690,7 +690,7 @@ void GSHacksDlg::OnInit()
 		SendMessage(GetDlgItem(m_hWnd, IDC_MSAACB), CB_ADDSTRING, 0, (LPARAM)text);
 	}
 
-	SendMessage(GetDlgItem(m_hWnd, IDC_MSAACB), CB_SETCURSEL, msaa2cb[min(theApp.GetConfigI("UserHacks_MSAA"), 16)], 0);
+	SendMessage(GetDlgItem(m_hWnd, IDC_MSAACB), CB_SETCURSEL, msaa2cb[std::min(theApp.GetConfigI("UserHacks_MSAA"), 16)], 0);
 
 	CheckDlgButton(m_hWnd, IDC_ALPHAHACK, theApp.GetConfigB("UserHacks_AlphaHack"));
 	CheckDlgButton(m_hWnd, IDC_WILDHACK, theApp.GetConfigI("UserHacks_WildHack"));

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -116,7 +116,7 @@ void GSSettingsDlg::OnInit()
 	}
 
 	std::string adapter_setting = theApp.GetConfigS("Adapter");
-	vector<GSSetting> adapter_settings;
+	std::vector<GSSetting> adapter_settings;
 	unsigned int adapter_sel = 0;
 
 	for(unsigned int i = 0; i < adapters.size(); i++)
@@ -324,7 +324,7 @@ void GSSettingsDlg::UpdateRenderers()
 
 	D3D_FEATURE_LEVEL level = adapters[(int)i].level;
 
-	vector<GSSetting> renderers;
+	std::vector<GSSetting> renderers;
 
 	GSRendererType renderer_setting;
 

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -34,7 +34,7 @@ GSSettingsDlg::GSSettingsDlg()
 
 {
 #ifdef ENABLE_OPENCL
-	list<OCLDeviceDesc> ocldevs;
+	std::list<OCLDeviceDesc> ocldevs;
 
 	GSUtil::GetDeviceDescs(ocldevs);
 

--- a/plugins/GSdx/GSSettingsDlg.h
+++ b/plugins/GSdx/GSSettingsDlg.h
@@ -91,7 +91,7 @@ class GSSettingsDlg : public GSDialog
 
 	std::vector<Adapter> adapters;
 
-	vector<GSSetting> m_ocl_devs;
+	std::vector<GSSetting> m_ocl_devs;
 	uint32 m_lastValidMsaa; // used to revert to previous dialog value if the user changed to invalid one, or lesser one and canceled
 
 	void UpdateRenderers();

--- a/plugins/GSdx/GSShaderOGL.cpp
+++ b/plugins/GSdx/GSShaderOGL.cpp
@@ -50,7 +50,7 @@ GSShaderOGL::~GSShaderOGL()
 	glDeleteProgramPipelines(m_pipe_to_delete.size(), &m_pipe_to_delete[0]);
 }
 
-GLuint GSShaderOGL::LinkPipeline(const string& pretty_print, GLuint vs, GLuint gs, GLuint ps)
+GLuint GSShaderOGL::LinkPipeline(const std::string& pretty_print, GLuint vs, GLuint gs, GLuint ps)
 {
 	GLuint p;
 	glCreateProgramPipelines(1, &p);

--- a/plugins/GSdx/GSShaderOGL.h
+++ b/plugins/GSdx/GSShaderOGL.h
@@ -23,7 +23,7 @@
 
 class GSShaderOGL {
 	GLuint m_pipeline;
-	hash_map<uint32, GLuint> m_program;
+	std::unordered_map<uint32, GLuint> m_program;
 	const bool m_debug_shader;
 
 	std::vector<GLuint> m_shad_to_delete;

--- a/plugins/GSdx/GSShaderOGL.h
+++ b/plugins/GSdx/GSShaderOGL.h
@@ -45,7 +45,7 @@ class GSShaderOGL {
 	void BindPipeline(GLuint pipe);
 
 	GLuint Compile(const std::string& glsl_file, const std::string& entry, GLenum type, const char* glsl_h_code, const std::string& macro_sel = "");
-	GLuint LinkPipeline(const string& pretty_print, GLuint vs, GLuint gs, GLuint ps);
+	GLuint LinkPipeline(const std::string& pretty_print, GLuint vs, GLuint gs, GLuint ps);
 
 	// Same as above but for not separated build
 	void BindProgram(GLuint vs, GLuint gs, GLuint ps);

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -1553,7 +1553,7 @@ void GSState::FlushWrite()
 	*/
 /*
 	static int n = 0;
-	string s;
+	std::string s;
 	s = format("c:\\temp1\\[%04d]_%05x_%d_%d_%d_%d_%d_%d.bmp",
 		n++, (int)m_env.BITBLTBUF.DBP, (int)m_env.BITBLTBUF.DBW, (int)m_env.BITBLTBUF.DPSM,
 		r.left, r.top, r.right, r.bottom);
@@ -1750,7 +1750,7 @@ void GSState::Write(const uint8* mem, int len)
 
 		/*
 		static int n = 0;
-		string s;
+		std::string s;
 		s = format("c:\\temp1\\[%04d]_%05x_%d_%d_%d_%d_%d_%d.bmp",
 			n++, (int)blit.DBP, (int)blit.DBW, (int)blit.DPSM,
 			r.left, r.top, r.right, r.bottom);
@@ -1831,7 +1831,7 @@ void GSState::Read(uint8* mem, int len)
 	m_mem.ReadImageX(m_tr.x, m_tr.y, mem, len, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
 
 	if(s_dump && s_save && s_n >= s_saven) {
-		string s= m_dump_root + format("%05d_read_%05x_%d_%d_%d_%d_%d_%d.bmp",
+		std::string s = m_dump_root + format("%05d_read_%05x_%d_%d_%d_%d_%d_%d.bmp",
 				s_n, (int)m_env.BITBLTBUF.SBP, (int)m_env.BITBLTBUF.SBW, (int)m_env.BITBLTBUF.SPSM,
 				r.left, r.top, r.right, r.bottom);
 		m_mem.SaveBMP(s, m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, m_env.BITBLTBUF.SPSM, r.right, r.bottom);

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -2250,7 +2250,7 @@ template<int index> void GSState::Transfer(const uint8* mem, uint32 size)
 			case GIF_FLG_IMAGE:
 
 				{
-					int len = (int)min(size, path.nloop);
+					int len = (int)std::min(size, path.nloop);
 
 					//ASSERT(!(len&3));
 
@@ -2964,8 +2964,8 @@ void GSState::GetTextureMinMax(GSVector4i& r, const GIFRegTEX0& TEX0, const GIFR
 			// This commented code cannot be used directly because it needs uv before the intersection
 			/*if (uv_.x >> tw == uv_.z >> tw)
 			{
-				vr.x = max(vr.x, (uv_.x & ((1 << tw) - 1)));
-				vr.z = min(vr.z, (uv_.z & ((1 << tw) - 1)) + 1);
+				vr.x = std::max(vr.x, (uv_.x & ((1 << tw) - 1)));
+				vr.z = std::min(vr.z, (uv_.z & ((1 << tw) - 1)) + 1);
 			}*/
 			if(mask & 0x000f) {if(vr.x < u.x) vr.x = u.x; if(vr.z > u.z + 1) vr.z = u.z + 1;}
 			break;
@@ -3057,8 +3057,8 @@ void GSState::GetAlphaMinMax()
 			a.w = env.TEXA.TA0;
 			break;
 		case 2:
-			a.y = env.TEXA.AEM ? 0 : min(env.TEXA.TA0, env.TEXA.TA1);
-			a.w = max(env.TEXA.TA0, env.TEXA.TA1);
+			a.y = env.TEXA.AEM ? 0 : std::min(env.TEXA.TA0, env.TEXA.TA1);
+			a.w = std::max(env.TEXA.TA0, env.TEXA.TA1);
 			break;
 		case 3:
 			m_mem.m_clut.GetAlphaMinMax32(a.y, a.w);

--- a/plugins/GSdx/GSState.h
+++ b/plugins/GSdx/GSState.h
@@ -233,7 +233,7 @@ public:
 	bool s_savef;
 	int s_saven;
 	int s_savel;
-	string m_dump_root;
+	std::string m_dump_root;
 
 public:
 	GSState();

--- a/plugins/GSdx/GSTexture.h
+++ b/plugins/GSdx/GSTexture.h
@@ -47,7 +47,7 @@ public:
 	virtual bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) = 0;
 	virtual void Unmap() = 0;
 	virtual void GenerateMipmap() {}
-	virtual bool Save(const string& fn, bool dds = false) = 0;
+	virtual bool Save(const std::string& fn, bool dds = false) = 0;
 	virtual uint32 GetID() { return 0; }
 
 	GSVector2 GetScale() const {return m_scale;}

--- a/plugins/GSdx/GSTexture11.cpp
+++ b/plugins/GSdx/GSTexture11.cpp
@@ -93,7 +93,7 @@ void GSTexture11::Unmap()
 	}
 }
 
-bool GSTexture11::Save(const string& fn, bool dds)
+bool GSTexture11::Save(const std::string& fn, bool dds)
 {
 	CComPtr<ID3D11Texture2D> res;
 	D3D11_TEXTURE2D_DESC desc;

--- a/plugins/GSdx/GSTexture11.h
+++ b/plugins/GSdx/GSTexture11.h
@@ -40,7 +40,7 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0);
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
 	void Unmap();
-	bool Save(const string& fn, bool dds = false);
+	bool Save(const std::string& fn, bool dds = false);
 
 	operator ID3D11Texture2D*();
 	operator ID3D11ShaderResourceView*();

--- a/plugins/GSdx/GSTexture9.cpp
+++ b/plugins/GSdx/GSTexture9.cpp
@@ -142,7 +142,7 @@ void GSTexture9::Unmap()
 	}
 }
 
-bool GSTexture9::Save(const string& fn, bool dds)
+bool GSTexture9::Save(const std::string& fn, bool dds)
 {
 	bool rb_swapped = true;
 	CComPtr<IDirect3DSurface9> surface;

--- a/plugins/GSdx/GSTexture9.cpp
+++ b/plugins/GSdx/GSTexture9.cpp
@@ -97,8 +97,8 @@ bool GSTexture9::Update(const GSVector4i& r, const void* data, int pitch, int la
 			default: ASSERT(m_desc.Format == D3DFMT_A8R8G8B8); break;
 			}
 
-			bytes = min(bytes, pitch);
-			bytes = min(bytes, lr.Pitch);
+			bytes = std::min(bytes, pitch);
+			bytes = std::min(bytes, lr.Pitch);
 
 			for(int i = 0, j = r.height(); i < j; i++, src += pitch, dst += lr.Pitch)
 			{

--- a/plugins/GSdx/GSTexture9.h
+++ b/plugins/GSdx/GSTexture9.h
@@ -38,7 +38,7 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0);
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
 	void Unmap();
-	bool Save(const string& fn, bool dds = false);
+	bool Save(const std::string& fn, bool dds = false);
 
 	operator IDirect3DSurface9*();
 	operator IDirect3DTexture9*();

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1767,7 +1767,7 @@ void GSTextureCache::Source::Flush(uint32 count, int layer)
 
 	GSVector4i tr(0, 0, tw, th);
 
-	int pitch = max(tw, psm.bs.x) * sizeof(uint32);
+	int pitch = std::max(tw, psm.bs.x) * sizeof(uint32);
 
 	GSLocalMemory& mem = m_renderer->m_mem;
 
@@ -1852,12 +1852,12 @@ void GSTextureCache::Target::Update()
 	GSVector2 t_scale = m_texture->GetScale();
 
 	//Avoids division by zero when calculating texture size.
-	t_scale = GSVector2(max(1.0f, t_scale.x), max(1.0f, t_scale.y));
+	t_scale = GSVector2(std::max(1.0f, t_scale.x), std::max(1.0f, t_scale.y));
 	t_size.x = lround(static_cast<float>(t_size.x) / t_scale.x);
 	t_size.y = lround(static_cast<float>(t_size.y) / t_scale.y);
 
 	// Don't load above the GS memory
-	int max_y_blocks = (MAX_BLOCKS - m_TEX0.TBP0) / max(1u, m_TEX0.TBW);
+	int max_y_blocks = (MAX_BLOCKS - m_TEX0.TBP0) / std::max(1u, m_TEX0.TBW);
 	int max_y = (max_y_blocks >> 5) * GSLocalMemory::m_psm[m_TEX0.PSM].pgs.y;
 	t_size.y = std::min(t_size.y, max_y);
 

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -976,9 +976,9 @@ void GSTextureCache::InvalidateLocalMem(GSOffset* off, const GSVector4i& r)
 
 	//GSTextureCache::Target* rt2 = NULL;
 	//int ymin = INT_MAX;
-	//for(list<Target*>::iterator i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); )
+	//for(auto i = m_dst[RenderTarget].begin(); i != m_dst[RenderTarget].end(); )
 	//{
-	//	list<Target*>::iterator j = i++;
+	//	auto j = i++;
 
 	//	Target* t = *j;
 

--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -108,7 +108,7 @@ public:
 	class SourceMap
 	{
 	public:
-		hash_set<Source*> m_surfaces;
+		std::unordered_set<Source*> m_surfaces;
 		std::array<FastList<Source*>, MAX_PAGES> m_map;
 		uint32 m_pages[16]; // bitmap of all pages
 		bool m_used;

--- a/plugins/GSdx/GSTextureCacheSW.cpp
+++ b/plugins/GSdx/GSTextureCacheSW.cpp
@@ -306,7 +306,7 @@ bool GSTextureCacheSW::Texture::Update(const GSVector4i& rect)
 
 #include "GSTextureSW.h"
 
-bool GSTextureCacheSW::Texture::Save(const string& fn, bool dds) const
+bool GSTextureCacheSW::Texture::Save(const std::string& fn, bool dds) const
 {
 	const uint32* RESTRICT clut = m_state->m_mem.m_clut;
 

--- a/plugins/GSdx/GSTextureCacheSW.h
+++ b/plugins/GSdx/GSTextureCacheSW.h
@@ -58,7 +58,7 @@ public:
 
 protected:
 	GSState* m_state;
-	hash_set<Texture*> m_textures;
+	std::unordered_set<Texture*> m_textures;
 	std::array<FastList<Texture*>, MAX_PAGES> m_map;
 
 public:

--- a/plugins/GSdx/GSTextureCacheSW.h
+++ b/plugins/GSdx/GSTextureCacheSW.h
@@ -53,7 +53,7 @@ public:
 		virtual ~Texture();
 
 		bool Update(const GSVector4i& r);
-		bool Save(const string& fn, bool dds = false) const;
+		bool Save(const std::string& fn, bool dds = false) const;
 	};
 
 protected:

--- a/plugins/GSdx/GSTextureFX11.cpp
+++ b/plugins/GSdx/GSTextureFX11.cpp
@@ -99,7 +99,7 @@ bool GSDevice11::CreateTextureFX()
 
 void GSDevice11::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 {
-	hash_map<uint32, GSVertexShader11 >::const_iterator i = m_vs.find(sel);
+	auto i = std::as_const(m_vs).find(sel);
 
 	if(i == m_vs.end())
 	{
@@ -160,7 +160,7 @@ void GSDevice11::SetupGS(GSSelector sel, const GSConstantBuffer* cb)
 	bool Unscale_GSShader = (sel.point == 1 || sel.line == 1) && UserHacks_unscale_pt_ln;
 	if((sel.prim > 0 && (sel.iip == 0 || sel.prim == 3)) || Unscale_GSShader) // geometry shader works in every case, but not needed
 	{
-		hash_map<uint32, CComPtr<ID3D11GeometryShader> >::const_iterator i = m_gs.find(sel);
+		auto i = std::as_const(m_gs).find(sel);
 
 		if(i != m_gs.end())
 		{
@@ -205,7 +205,7 @@ void GSDevice11::SetupGS(GSSelector sel, const GSConstantBuffer* cb)
 
 void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSelector ssel)
 {
-	hash_map<uint64, CComPtr<ID3D11PixelShader> >::const_iterator i = m_ps.find(sel);
+	auto i = std::as_const(m_ps).find(sel);
 
 	if(i == m_ps.end())
 	{
@@ -286,7 +286,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			ssel.ltf = 0;
 		}
 
-		hash_map<uint32, CComPtr<ID3D11SamplerState> >::const_iterator i = m_ps_ss.find(ssel);
+		auto i = std::as_const(m_ps_ss).find(ssel);
 
 		if(i != m_ps_ss.end())
 		{
@@ -327,7 +327,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix)
 {
-	hash_map<uint32, CComPtr<ID3D11DepthStencilState> >::const_iterator i = m_om_dss.find(dssel);
+	auto i = std::as_const(m_om_dss).find(dssel);
 
 	if(i == m_om_dss.end())
 	{
@@ -376,7 +376,7 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 
 	OMSetDepthStencilState(i->second, 1);
 
-	hash_map<uint32, CComPtr<ID3D11BlendState> >::const_iterator j = m_om_bs.find(bsel);
+	auto j = std::as_const(m_om_bs).find(bsel);
 
 	if(j == m_om_bs.end())
 	{

--- a/plugins/GSdx/GSTextureFX11.cpp
+++ b/plugins/GSdx/GSTextureFX11.cpp
@@ -103,7 +103,7 @@ void GSDevice11::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 
 	if(i == m_vs.end())
 	{
-		string str[4];
+		std::string str[4];
 
 		str[0] = format("%d", sel.bppz);
 		str[1] = format("%d", sel.tme);
@@ -168,7 +168,7 @@ void GSDevice11::SetupGS(GSSelector sel, const GSConstantBuffer* cb)
 		}
 		else
 		{
-			string str[4];
+			std::string str[4];
 
 			str[0] = format("%d", sel.iip);
 			str[1] = format("%d", sel.prim);
@@ -209,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		string str[21];
+		std::string str[21];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -430,7 +430,7 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 			{
 				(bsel.a == 0 ? bd.RenderTarget[0].SrcBlend : bd.RenderTarget[0].DestBlend) = D3D11_BLEND_ONE;
 
-				const string afixstr = format("%d >> 7", afix);
+				const std::string afixstr = format("%d >> 7", afix);
 				const char *col[3] = {"Cs", "Cd", "0"};
 				const char *alpha[3] = {"As", "Ad", afixstr.c_str()};
 				

--- a/plugins/GSdx/GSTextureFX9.cpp
+++ b/plugins/GSdx/GSTextureFX9.cpp
@@ -67,7 +67,7 @@ void GSDevice9::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 
 	if(i == m_vs.end())
 	{
-		string str[5];
+		std::string str[5];
 
 		str[0] = format("%d", sel.bppz);
 		str[1] = format("%d", sel.tme);
@@ -137,7 +137,7 @@ void GSDevice9::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSel
 
 	if(i == m_ps.end())
 	{
-		string str[18];
+		std::string str[18];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -323,7 +323,7 @@ void GSDevice9::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint
 			{
 				(bsel.a == 0 ? bs->SrcBlend : bs->DestBlend) = D3DBLEND_ONE;
 
-				const string afixstr = format("%d >> 7", afix);
+				const std::string afixstr = format("%d >> 7", afix);
 				const char *col[3] = {"Cs", "Cd", "0"};
 				const char *alpha[3] = {"As", "Ad", afixstr.c_str()};
 

--- a/plugins/GSdx/GSTextureFX9.cpp
+++ b/plugins/GSdx/GSTextureFX9.cpp
@@ -30,7 +30,7 @@ GSTexture* GSDevice9::CreateMskFix(uint32 size, uint32 msk, uint32 fix)
 
 	uint32 hash = (size << 20) | (msk << 10) | fix;
 
-	hash_map<uint32, GSTexture*>::iterator i = m_mskfix.find(hash);
+	auto i = m_mskfix.find(hash);
 
 	if(i != m_mskfix.end())
 	{
@@ -63,7 +63,7 @@ GSTexture* GSDevice9::CreateMskFix(uint32 size, uint32 msk, uint32 fix)
 
 void GSDevice9::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 {
-	hash_map<uint32, GSVertexShader9>::const_iterator i = m_vs.find(sel);
+	auto i = std::as_const(m_vs).find(sel);
 
 	if(i == m_vs.end())
 	{
@@ -133,7 +133,7 @@ void GSDevice9::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSel
 		}
 	}
 
-	hash_map<uint64, CComPtr<IDirect3DPixelShader9> >::const_iterator i = m_ps.find(sel);
+	auto i = std::as_const(m_ps).find(sel);
 
 	if(i == m_ps.end())
 	{
@@ -203,7 +203,7 @@ void GSDevice9::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSel
 			ssel.ltf = 0;
 		}
 
-		hash_map<uint32, Direct3DSamplerState9* >::const_iterator i = m_ps_ss.find(ssel);
+		auto i = std::as_const(m_ps_ss).find(ssel);
 
 		if(i != m_ps_ss.end())
 		{
@@ -240,7 +240,7 @@ void GSDevice9::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint
 {
 	Direct3DDepthStencilState9* dss = NULL;
 
-	hash_map<uint32, Direct3DDepthStencilState9*>::const_iterator i = m_om_dss.find(dssel);
+	auto i = std::as_const(m_om_dss).find(dssel);
 
 	if(i == m_om_dss.end())
 	{
@@ -282,7 +282,7 @@ void GSDevice9::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint
 
 	OMSetDepthStencilState(i->second);
 
-	hash_map<uint32, Direct3DBlendState9*>::const_iterator j = m_om_bs.find(bsel);
+	auto j = std::as_const(m_om_bs).find(bsel);
 
 	if(j == m_om_bs.end())
 	{

--- a/plugins/GSdx/GSTextureNull.h
+++ b/plugins/GSdx/GSTextureNull.h
@@ -37,5 +37,5 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0) {return true;}
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) {return false;}
 	void Unmap() {}
-	bool Save(const string& fn, bool dds = false) {return false;}
+	bool Save(const std::string& fn, bool dds = false) {return false;}
 };

--- a/plugins/GSdx/GSTextureOGL.cpp
+++ b/plugins/GSdx/GSTextureOGL.cpp
@@ -463,7 +463,7 @@ void GSTextureOGL::GenerateMipmap()
 	}
 }
 
-bool GSTextureOGL::Save(const string& fn, bool dds)
+bool GSTextureOGL::Save(const std::string& fn, bool dds)
 {
 	// Collect the texture data
 	uint32 pitch = 4 * m_size.x;

--- a/plugins/GSdx/GSTextureOGL.cpp
+++ b/plugins/GSdx/GSTextureOGL.cpp
@@ -151,8 +151,8 @@ GSTextureOGL::GSTextureOGL(int type, int w, int h, int format, GLuint fbo_read, 
 	: m_pbo_size(0), m_clean(false), m_generate_mipmap(true), m_local_buffer(NULL), m_r_x(0), m_r_y(0), m_r_w(0), m_r_h(0), m_layer(0)
 {
 	// OpenGL didn't like dimensions of size 0
-	m_size.x = max(1,w);
-	m_size.y = max(1,h);
+	m_size.x = std::max(1,w);
+	m_size.y = std::max(1,h);
 	m_format = format;
 	m_type   = type;
 	m_fbo_read = fbo_read;
@@ -245,7 +245,7 @@ GSTextureOGL::GSTextureOGL(int type, int w, int h, int format, GLuint fbo_read, 
 	}
 
 	// Only 32 bits input texture will be supported for mipmap
-	m_max_layer = mipmap && (m_type == GSTexture::Texture) && m_format == GL_RGBA8 ? (int)log2(max(w,h)) : 1;
+	m_max_layer = mipmap && (m_type == GSTexture::Texture) && m_format == GL_RGBA8 ? (int)log2(std::max(w,h)) : 1;
 
 	// Generate & Allocate the buffer
 	switch (m_type) {

--- a/plugins/GSdx/GSTextureOGL.h
+++ b/plugins/GSdx/GSTextureOGL.h
@@ -72,7 +72,7 @@ class GSTextureOGL final : public GSTexture
 		bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) final;
 		void Unmap() final;
 		void GenerateMipmap() final;
-		bool Save(const string& fn, bool dds = false) final;
+		bool Save(const std::string& fn, bool dds = false) final;
 
 		bool IsBackbuffer() { return (m_type == GSTexture::Backbuffer); }
 		bool IsDss() { return (m_type == GSTexture::DepthStencil); }

--- a/plugins/GSdx/GSTextureSW.cpp
+++ b/plugins/GSdx/GSTextureSW.cpp
@@ -85,7 +85,7 @@ void GSTextureSW::Unmap()
 	m_mapped.clear(std::memory_order_release);
 }
 
-bool GSTextureSW::Save(const string& fn, bool dds)
+bool GSTextureSW::Save(const std::string& fn, bool dds)
 {
 	if(dds) return false; // not implemented
 

--- a/plugins/GSdx/GSTextureSW.h
+++ b/plugins/GSdx/GSTextureSW.h
@@ -38,5 +38,5 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0);
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
 	void Unmap();
-	bool Save(const string& fn, bool dds = false);
+	bool Save(const std::string& fn, bool dds = false);
 };

--- a/plugins/GSdx/GSUniformBufferOGL.h
+++ b/plugins/GSdx/GSUniformBufferOGL.h
@@ -35,7 +35,7 @@ class GSUniformBufferOGL {
 	uint8* m_cache;       // content of the previous upload
 
 public:
-	GSUniformBufferOGL(const string& pretty_name, GLuint index, uint32 size)
+	GSUniformBufferOGL(const std::string& pretty_name, GLuint index, uint32 size)
 		: m_index(index), m_size(size)
 	{
 		glGenBuffers(1, &m_buffer);

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -275,7 +275,7 @@ void GSUtil::GetDeviceDescs(list<OCLDeviceDesc>& dl)
 
 			for(auto& device : ds)
 			{
-				string type;
+				std::string type;
 
 				switch(device.getInfo<CL_DEVICE_TYPE>())
 				{
@@ -317,13 +317,13 @@ void GSUtil::GetDeviceDescs(list<OCLDeviceDesc>& dl)
 	}
 }
 
-string GSUtil::GetDeviceUniqueName(cl::Device& device)
+std::string GSUtil::GetDeviceUniqueName(cl::Device& device)
 {
 	std::string vendor = device.getInfo<CL_DEVICE_VENDOR>();
 	std::string name = device.getInfo<CL_DEVICE_NAME>();
 	std::string version = device.getInfo<CL_DEVICE_OPENCL_C_VERSION>();
 
-	string type;
+	std::string type;
 
 	switch(device.getInfo<CL_DEVICE_TYPE>())
 	{

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -255,7 +255,7 @@ CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
 #define OCL_PROGRAM_VERSION 3
 
 #ifdef ENABLE_OPENCL
-void GSUtil::GetDeviceDescs(list<OCLDeviceDesc>& dl)
+void GSUtil::GetDeviceDescs(std::list<OCLDeviceDesc>& dl)
 {
 	dl.clear();
 

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -29,9 +29,9 @@ struct OCLDeviceDesc
 #ifdef ENABLE_OPENCL
 	cl::Device device;
 #endif
-	string name;
+	std::string name;
 	int version;
-	string tmppath;
+	std::string tmppath;
 };
 
 class GSUtil
@@ -56,7 +56,7 @@ public:
 
 #ifdef ENABLE_OPENCL
 	static void GetDeviceDescs(list<OCLDeviceDesc>& dl);
-	static string GetDeviceUniqueName(cl::Device& device);
+	static std::string GetDeviceUniqueName(cl::Device& device);
 #endif
 
 #ifdef _WIN32

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -55,7 +55,7 @@ public:
 	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
 
 #ifdef ENABLE_OPENCL
-	static void GetDeviceDescs(list<OCLDeviceDesc>& dl);
+	static void GetDeviceDescs(std::list<OCLDeviceDesc>& dl);
 	static std::string GetDeviceUniqueName(cl::Device& device);
 #endif
 

--- a/plugins/GSdx/GSVector4i.h
+++ b/plugins/GSdx/GSVector4i.h
@@ -199,7 +199,7 @@ public:
 
 		#else
 
-		return GSVector4i(min(x, a.x), min(y, a.y), max(z, a.z), max(w, a.w));
+		return GSVector4i(std::min(x, a.x), std::min(y, a.y), std::max(z, a.z), std::max(w, a.w));
 
 		#endif
 	}
@@ -301,10 +301,10 @@ public:
 	{
 		GSVector4i v;
 
-		v.x = min(max(x, a.x), b.x);
-		v.y = min(max(y, a.y), b.y);
-		v.z = min(max(z, a.z), b.z);
-		v.w = min(max(w, a.w), b.w);
+		v.x = std::min(std::max(x, a.x), b.x);
+		v.y = std::min(std::max(y, a.y), b.y);
+		v.z = std::min(std::max(z, a.z), b.z);
+		v.w = std::min(std::max(w, a.w), b.w);
 
 		return v;
 	}
@@ -313,10 +313,10 @@ public:
 	{
 		GSVector4i v;
 
-		v.x = min(max(x, a.x), a.z);
-		v.y = min(max(y, a.y), a.w);
-		v.z = min(max(z, a.x), a.z);
-		v.w = min(max(w, a.y), a.w);
+		v.x = std::min(std::max(x, a.x), a.z);
+		v.y = std::min(std::max(y, a.y), a.w);
+		v.z = std::min(std::max(z, a.x), a.z);
+		v.w = std::min(std::max(w, a.y), a.w);
 
 		return v;
 	}

--- a/plugins/GSdx/GSWnd.h
+++ b/plugins/GSdx/GSWnd.h
@@ -34,7 +34,7 @@ public:
 	GSWnd() : m_managed(false) {};
 	virtual ~GSWnd() {};
 
-	virtual bool Create(const string& title, int w, int h) = 0;
+	virtual bool Create(const std::string& title, int w, int h) = 0;
 	virtual bool Attach(void* handle, bool managed = true) = 0;
 	virtual void Detach() = 0;
 	bool IsManaged() const {return m_managed;}
@@ -76,7 +76,7 @@ public:
 	GSWndGL() : m_ctx_attached(false), m_vsync_change_requested(false), m_vsync(0) {};
 	virtual ~GSWndGL() {};
 
-	virtual bool Create(const string& title, int w, int h) = 0;
+	virtual bool Create(const std::string& title, int w, int h) = 0;
 	virtual bool Attach(void* handle, bool managed = true) = 0;
 	virtual void Detach() = 0;
 

--- a/plugins/GSdx/GSWndDX.cpp
+++ b/plugins/GSdx/GSWndDX.cpp
@@ -79,7 +79,7 @@ LRESULT GSWndDX::OnMessage(UINT message, WPARAM wParam, LPARAM lParam)
 	return DefWindowProc((HWND)m_hWnd, message, wParam, lParam);
 }
 
-bool GSWndDX::Create(const string& title, int w, int h)
+bool GSWndDX::Create(const std::string& title, int w, int h)
 {
 	if(m_hWnd)
 		throw GSDXRecoverableError();

--- a/plugins/GSdx/GSWndDX.h
+++ b/plugins/GSdx/GSWndDX.h
@@ -36,7 +36,7 @@ public:
 	GSWndDX();
 	virtual ~GSWndDX();
 
-	bool Create(const string& title, int w, int h);
+	bool Create(const std::string& title, int w, int h);
 	bool Attach(void* handle, bool managed = true);
 	void Detach();
 

--- a/plugins/GSdx/GSWndEGL.cpp
+++ b/plugins/GSdx/GSWndEGL.cpp
@@ -196,7 +196,7 @@ void GSWndEGL::Detach()
 	DestroyNativeResources();
 }
 
-bool GSWndEGL::Create(const string& title, int w, int h)
+bool GSWndEGL::Create(const std::string& title, int w, int h)
 {
 	if(w <= 0 || h <= 0) {
 		w = theApp.GetConfigI("ModeWidth");

--- a/plugins/GSdx/GSWndEGL.h
+++ b/plugins/GSdx/GSWndEGL.h
@@ -52,7 +52,7 @@ public:
 	GSWndEGL(int platform);
 	virtual ~GSWndEGL() {};
 
-	bool Create(const string& title, int w, int h) final;
+	bool Create(const std::string& title, int w, int h) final;
 	bool Attach(void* handle, bool managed = true) final;
 	void Detach() final;
 

--- a/plugins/GSdx/GSWndOGL.cpp
+++ b/plugins/GSdx/GSWndOGL.cpp
@@ -156,7 +156,7 @@ void GSWndOGL::Detach()
 	}
 }
 
-bool GSWndOGL::Create(const string& title, int w, int h)
+bool GSWndOGL::Create(const std::string& title, int w, int h)
 {
 	if(m_NativeWindow)
 		throw GSDXRecoverableError();

--- a/plugins/GSdx/GSWndOGL.h
+++ b/plugins/GSdx/GSWndOGL.h
@@ -45,7 +45,7 @@ public:
 	GSWndOGL();
 	virtual ~GSWndOGL() {};
 
-	bool Create(const string& title, int w, int h);
+	bool Create(const std::string& title, int w, int h);
 	bool Attach(void* handle, bool managed = true);
 	void Detach();
 

--- a/plugins/GSdx/GSWndWGL.cpp
+++ b/plugins/GSdx/GSWndWGL.cpp
@@ -237,7 +237,7 @@ void GSWndWGL::CloseWGLDisplay()
 // Used by GSReplay. At least for now.
 // More or less copy pasted from GSWndDX::Create and GSWndWGL::Attach with a few
 // modifications
-bool GSWndWGL::Create(const string& title, int w, int h)
+bool GSWndWGL::Create(const std::string& title, int w, int h)
 {
 	if(m_NativeWindow) return false;
 

--- a/plugins/GSdx/GSWndWGL.h
+++ b/plugins/GSdx/GSWndWGL.h
@@ -47,7 +47,7 @@ public:
 	GSWndWGL();
 	virtual ~GSWndWGL() {};
 
-	bool Create(const string& title, int w, int h);
+	bool Create(const std::string& title, int w, int h);
 	bool Attach(void* handle, bool managed = true);
 	void Detach();
 

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -366,7 +366,7 @@ void GSdxApp::Init()
 	m_default_configuration["dump"]                                       = "0";
 	m_default_configuration["extrathreads"]                               = "2";
 	m_default_configuration["extrathreads_height"]                        = "4";
-	m_default_configuration["filter"]                                     = to_string(static_cast<int8>(BiFiltering::PS2));
+	m_default_configuration["filter"]                                     = std::to_string(static_cast<int8>(BiFiltering::PS2));
 	m_default_configuration["force_texture_clear"]                        = "0";
 	m_default_configuration["fxaa"]                                       = "0";
 	m_default_configuration["interlace"]                                  = "7";
@@ -404,9 +404,9 @@ void GSdxApp::Init()
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
 	m_default_configuration["override_GL_EXT_texture_filter_anisotropic"] = "-1";
 	m_default_configuration["paltex"]                                     = "0";
-	m_default_configuration["png_compression_level"]                      = to_string(Z_BEST_SPEED);
+	m_default_configuration["png_compression_level"]                      = std::to_string(Z_BEST_SPEED);
 	m_default_configuration["preload_frame_with_gs_data"]                 = "0";
-	m_default_configuration["Renderer"]                                   = to_string(static_cast<int>(GSRendererType::Default));
+	m_default_configuration["Renderer"]                                   = std::to_string(static_cast<int>(GSRendererType::Default));
 	m_default_configuration["resx"]                                       = "1024";
 	m_default_configuration["resy"]                                       = "1024";
 	m_default_configuration["save"]                                       = "0";
@@ -441,7 +441,7 @@ void GSdxApp::Init()
 	m_default_configuration["UserHacks_SpriteHack"]                       = "0";
 	m_default_configuration["UserHacks_TCOffset"]                         = "0";
 	m_default_configuration["UserHacks_TextureInsideRt"]                  = "0";
-	m_default_configuration["UserHacks_TriFilter"]                        = to_string(static_cast<int8>(TriFiltering::None));
+	m_default_configuration["UserHacks_TriFilter"]                        = std::to_string(static_cast<int8>(TriFiltering::None));
 	m_default_configuration["UserHacks_WildHack"]                         = "0";
 	m_default_configuration["wrap_gs_mem"]                                = "0";
 	m_default_configuration["vsync"]                                      = "0";
@@ -511,7 +511,7 @@ void GSdxApp::SetConfigDir(const char* dir)
 	}
 }
 
-string GSdxApp::GetConfigS(const char* entry)
+std::string GSdxApp::GetConfigS(const char* entry)
 {
 	char buff[4096] = {0};
 	auto def = m_default_configuration.find(entry);
@@ -523,7 +523,7 @@ string GSdxApp::GetConfigS(const char* entry)
 		GetPrivateProfileString(m_section.c_str(), entry, "", buff, countof(buff), m_ini.c_str());
 	}
 
-	return string(buff);
+	return {buff};
 }
 
 void GSdxApp::SetConfig(const char* entry, const char* value)

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -147,14 +147,13 @@ bool GSdxApp::WritePrivateProfileString(const char* lpAppName, const char* lpKey
 
 	if (f == NULL) return false; // FIXME print a nice message
 
-	map<std::string,std::string>::iterator it;
-	for (it = m_configuration_map.begin(); it != m_configuration_map.end(); ++it) {
+	for (const auto& entry : m_configuration_map) {
 		// Do not save the inifile key which is not an option
-		if (it->first.compare("inifile") == 0) continue;
+		if (entry.first.compare("inifile") == 0) continue;
 
 		// Only keep option that have a default value (allow to purge old option of the GSdx.ini)
-		if (!it->second.empty() && m_default_configuration.find(it->first) != m_default_configuration.end())
-			fprintf(f, "%s = %s\n", it->first.c_str(), it->second.c_str());
+		if (!entry.second.empty() && m_default_configuration.find(entry.first) != m_default_configuration.end())
+			fprintf(f, "%s = %s\n", entry.first.c_str(), entry.second.c_str());
 	}
 	fclose(f);
 

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -62,7 +62,7 @@ public:
 	T      GetConfigT(const char* entry) { return static_cast<T>(GetConfigI(entry)); }
 	int    GetConfigI(const char* entry);
 	bool   GetConfigB(const char* entry);
-	string GetConfigS(const char* entry);
+	std::string GetConfigS(const char* entry);
 
 	void SetCurrentRendererType(GSRendererType type);
 	GSRendererType GetCurrentRendererType();

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -69,26 +69,26 @@ public:
 
 	void SetConfigDir(const char* dir);
 
-	vector<GSSetting> m_gs_renderers;
-	vector<GSSetting> m_gs_interlace;
-	vector<GSSetting> m_gs_aspectratio;
-	vector<GSSetting> m_gs_upscale_multiplier;
-	vector<GSSetting> m_gs_max_anisotropy;
-	vector<GSSetting> m_gs_bifilter;
-	vector<GSSetting> m_gs_trifilter;
-	vector<GSSetting> m_gs_gl_ext;
-	vector<GSSetting> m_gs_hack;
-	vector<GSSetting> m_gs_offset_hack;
-	vector<GSSetting> m_gs_hw_mipmapping;
-	vector<GSSetting> m_gs_crc_level;
-	vector<GSSetting> m_gs_acc_blend_level;
-	vector<GSSetting> m_gs_tv_shaders;
+	std::vector<GSSetting> m_gs_renderers;
+	std::vector<GSSetting> m_gs_interlace;
+	std::vector<GSSetting> m_gs_aspectratio;
+	std::vector<GSSetting> m_gs_upscale_multiplier;
+	std::vector<GSSetting> m_gs_max_anisotropy;
+	std::vector<GSSetting> m_gs_bifilter;
+	std::vector<GSSetting> m_gs_trifilter;
+	std::vector<GSSetting> m_gs_gl_ext;
+	std::vector<GSSetting> m_gs_hack;
+	std::vector<GSSetting> m_gs_offset_hack;
+	std::vector<GSSetting> m_gs_hw_mipmapping;
+	std::vector<GSSetting> m_gs_crc_level;
+	std::vector<GSSetting> m_gs_acc_blend_level;
+	std::vector<GSSetting> m_gs_tv_shaders;
 
-	vector<GSSetting> m_gpu_renderers;
-	vector<GSSetting> m_gpu_filter;
-	vector<GSSetting> m_gpu_dithering;
-	vector<GSSetting> m_gpu_aspectratio;
-	vector<GSSetting> m_gpu_scale;
+	std::vector<GSSetting> m_gpu_renderers;
+	std::vector<GSSetting> m_gpu_filter;
+	std::vector<GSSetting> m_gpu_dithering;
+	std::vector<GSSetting> m_gpu_aspectratio;
+	std::vector<GSSetting> m_gpu_scale;
 };
 
 struct GSDXError {};

--- a/plugins/GSdx/PSX/GPULocalMemory.cpp
+++ b/plugins/GSdx/PSX/GPULocalMemory.cpp
@@ -214,11 +214,11 @@ void GPULocalMemory::Invalidate(const GSVector4i& r)
 		}
 	}
 
-	for(int y = 0, ye = min(r.bottom, 512), j = 0; y < ye; y += 256, j++)
+	for(int y = 0, ye = std::min(r.bottom, 512), j = 0; y < ye; y += 256, j++)
 	{
 		if(r.top >= y + 256) continue;
 
-		for(int x = 0, xe = min(r.right, 1024), i = 0; x < xe; x += 64, i++)
+		for(int x = 0, xe = std::min(r.right, 1024), i = 0; x < xe; x += 64, i++)
 		{
 			uint32 flag = 1 << i;
 

--- a/plugins/GSdx/PSX/GPULocalMemory.cpp
+++ b/plugins/GSdx/PSX/GPULocalMemory.cpp
@@ -583,7 +583,7 @@ void GPULocalMemory::Expand24(const uint16* RESTRICT src, uint32* RESTRICT dst, 
 
 #include "GSTextureSW.h"
 
-void GPULocalMemory::SaveBMP(const string& fn, const GSVector4i& r2, int tp, int cx, int cy)
+void GPULocalMemory::SaveBMP(const std::string& fn, const GSVector4i& r2, int tp, int cx, int cy)
 {
 	GSVector4i r;
 

--- a/plugins/GSdx/PSX/GPULocalMemory.h
+++ b/plugins/GSdx/PSX/GPULocalMemory.h
@@ -82,5 +82,5 @@ public:
 	void Expand16(const uint16* RESTRICT src, uint32* RESTRICT dst, int pixels);
 	void Expand24(const uint16* RESTRICT src, uint32* RESTRICT dst, int pixels);
 
-	void SaveBMP(const string& fn, const GSVector4i& r, int tp, int cx, int cy);
+	void SaveBMP(const std::string& fn, const GSVector4i& r, int tp, int cx, int cy);
 };

--- a/plugins/GSdx/PSX/GPURenderer.cpp
+++ b/plugins/GSdx/PSX/GPURenderer.cpp
@@ -25,7 +25,7 @@
 
 #ifdef _WIN32
 
-map<HWND, GPURenderer*> GPURenderer::m_wnd2gpu;
+std::map<HWND, GPURenderer*> GPURenderer::m_wnd2gpu;
 
 #endif
 
@@ -231,7 +231,7 @@ bool GPURenderer::MakeSnapshot(const std::string& path)
 
 LRESULT CALLBACK GPURenderer::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-	map<HWND, GPURenderer*>::iterator i = m_wnd2gpu.find(hWnd);
+	auto i = m_wnd2gpu.find(hWnd);
 
 	if(i != m_wnd2gpu.end())
 	{

--- a/plugins/GSdx/PSX/GPURenderer.cpp
+++ b/plugins/GSdx/PSX/GPURenderer.cpp
@@ -183,7 +183,7 @@ void GPURenderer::VSync()
 		int w = r.width() << m_scale.x;
 		int h = r.height() << m_scale.y;
 
-		string s = format(
+		std::string s = format(
 			"%lld | %d x %d | %.2f fps (%d%%) | %d/%d | %d%% CPU | %.2f | %.2f",
 			m_perfmon.GetFrame(), w, h, fps, (int)(100.0 * fps / m_env.GetFPS()),
 			(int)m_perfmon.Get(GSPerfMon::Prim),
@@ -208,7 +208,7 @@ void GPURenderer::VSync()
 	m_dev->Present(r.fit(m_aspectratio), 0);
 }
 
-bool GPURenderer::MakeSnapshot(const string& path)
+bool GPURenderer::MakeSnapshot(const std::string& path)
 {
 	time_t t = time(NULL);
 

--- a/plugins/GSdx/PSX/GPURenderer.h
+++ b/plugins/GSdx/PSX/GPURenderer.h
@@ -50,7 +50,7 @@ protected:
 
 	HWND m_hWnd;
 	WNDPROC m_wndproc;
-	static map<HWND, GPURenderer*> m_wnd2gpu;
+	static std::map<HWND, GPURenderer*> m_wnd2gpu;
 
 	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 	LRESULT OnMessage(UINT message, WPARAM wParam, LPARAM lParam);

--- a/plugins/GSdx/PSX/GPURenderer.h
+++ b/plugins/GSdx/PSX/GPURenderer.h
@@ -65,7 +65,7 @@ public:
 
 	virtual bool Create(void* hWnd);
 	virtual void VSync();
-	virtual bool MakeSnapshot(const string& path);
+	virtual bool MakeSnapshot(const std::string& path);
 };
 
 template<class Vertex>

--- a/plugins/GSdx/PSX/GPURendererSW.cpp
+++ b/plugins/GSdx/PSX/GPURendererSW.cpp
@@ -118,8 +118,8 @@ void GPURendererSW::Draw()
 
 	data->scissor.left = (int)m_env.DRAREATL.X << m_scale.x;
 	data->scissor.top = (int)m_env.DRAREATL.Y << m_scale.y;
-	data->scissor.right = min((int)(m_env.DRAREABR.X + 1) << m_scale.x, m_mem.GetWidth());
-	data->scissor.bottom = min((int)(m_env.DRAREABR.Y + 1) << m_scale.y, m_mem.GetHeight());
+	data->scissor.right = std::min((int)(m_env.DRAREABR.X + 1) << m_scale.x, m_mem.GetWidth());
+	data->scissor.bottom = std::min((int)(m_env.DRAREABR.Y + 1) << m_scale.y, m_mem.GetHeight());
 	
 	data->buff = (uint8*)_aligned_malloc(sizeof(GSVertexSW) * m_count, 32);
 	data->vertex = (GSVertexSW*)data->buff;

--- a/plugins/GSdx/PSX/GPURendererSW.cpp
+++ b/plugins/GSdx/PSX/GPURendererSW.cpp
@@ -71,7 +71,7 @@ void GPURendererSW::Draw()
 {
 	GPUDrawScanline::SharedData* sd = new GPUDrawScanline::SharedData();
 
-	shared_ptr<GSRasterizerData> data(sd);
+	std::shared_ptr<GSRasterizerData> data(sd);
 
 	GPUScanlineGlobalData& gd = sd->global;
 

--- a/plugins/GSdx/PSX/GPUSettingsDlg.cpp
+++ b/plugins/GSdx/PSX/GPUSettingsDlg.cpp
@@ -58,7 +58,7 @@ void GPUSettingsDlg::OnInit()
 				{
 					m_modes.push_back(mode);
 
-					string str = format("%dx%d %dHz", mode.Width, mode.Height, mode.RefreshRate);
+					std::string str = format("%dx%d %dHz", mode.Width, mode.Height, mode.RefreshRate);
 
 					ComboBoxAppend(IDC_RESOLUTION, str.c_str(), (LPARAM)&m_modes.back(), w == mode.Width && h == mode.Height && hz == mode.RefreshRate);
 				}

--- a/plugins/GSdx/PSX/GPUSettingsDlg.h
+++ b/plugins/GSdx/PSX/GPUSettingsDlg.h
@@ -26,7 +26,7 @@
 
 class GPUSettingsDlg : public GSDialog
 {
-	list<D3DDISPLAYMODE> m_modes;
+	std::list<D3DDISPLAYMODE> m_modes;
 
 	void UpdateControls();
 

--- a/plugins/GSdx/PSX/GPUState.h
+++ b/plugins/GSdx/PSX/GPUState.h
@@ -89,7 +89,7 @@ protected:
 	int s_n;
 	bool dump_enable = false;
 
-	void Dump(const string& s, uint32 TP, const GSVector4i& r, int inc = true)
+	void Dump(const std::string& s, uint32 TP, const GSVector4i& r, int inc = true)
 	{
 		//if(m_perfmon.GetFrame() < 1000)
 		//if((m_env.TWIN.u32 & 0xfffff) == 0)
@@ -105,12 +105,12 @@ protected:
 #ifdef DEBUG
 		dir = 2;
 #endif
-        string path = format("c:\\temp%d\\%04d_%s.bmp", dir, s_n, s.c_str());
+		std::string path = format("c:\\temp%d\\%04d_%s.bmp", dir, s_n, s.c_str());
 
 		m_mem.SaveBMP(path, r, TP, m_env.CLUT.X, m_env.CLUT.Y);
 	}
 
-	void Dump(const string& s, int inc = true)
+	void Dump(const std::string& s, int inc = true)
 	{
 		Dump(s, 2, GSVector4i(0, 0, 1024, 512), inc);
 	}

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -127,8 +127,6 @@ using namespace std;
 
 #include <unordered_map>
 #include <unordered_set>
-#define hash_map unordered_map
-#define hash_set unordered_set
 
 #ifdef _WIN32
 

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -118,9 +118,6 @@ typedef int64 sint64;
 #include <mutex>
 #include <condition_variable>
 #include <functional>
-
-using namespace std;
-
 #include <memory>
 
 #include <zlib.h>


### PR DESCRIPTION
Changes:
 * Removes use of `using namespace std;` by prefixing `std::` or using `auto` and similar.
 * Removes hash_{set,map} macros.