### PR TITLE
Add PSX memory card support

### DIFF
--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -172,9 +172,8 @@ static __fi void _psxTestInterrupts()
 	IopTestEvent(IopEvt_SIF0,		sif0Interrupt);	// SIF0
 	IopTestEvent(IopEvt_SIF1,		sif1Interrupt);	// SIF1
 	IopTestEvent(IopEvt_SIF2,		sif2Interrupt);	// SIF2
-#ifndef SIO_INLINE_IRQS
-	IopTestEvent(IopEvt_SIO,		sioInterrupt);
-#endif
+	// Originally controlled by a preprocessor define, now PSX dependent.
+	if (psxHu32(HW_ICFG) & (1 << 3)) IopTestEvent(IopEvt_SIO, sioInterruptR);
 	IopTestEvent(IopEvt_CdvdRead,	cdvdReadInterrupt);
 
 	// Profile-guided Optimization (sorta)

--- a/pcsx2/Sio.h
+++ b/pcsx2/Sio.h
@@ -15,10 +15,6 @@
 
 #pragma once
 
-// Let's enable this to free the IOP event handler of some considerable load.
-// Games are highly unlikely to need timed IRQ's for PAD and MemoryCard handling anyway (rama).
-#define SIO_INLINE_IRQS
-
 #include "MemoryCardFile.h"
 
 struct _mcd
@@ -125,6 +121,7 @@ extern u8 sioRead8();
 extern void sioWrite8(u8 value);
 extern void sioWriteCtrl16(u16 value);
 extern void sioInterrupt();
+extern void sioInterruptR();
 extern void InitializeSIO(u8 value);
 extern void SetForceMcdEjectTimeoutNow();
 extern void ClearMcdEjectTimeoutNow();

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -198,13 +198,14 @@ namespace Dialogs
 	#ifdef __WXMSW__
 		pxCheckBox*			m_check_CompressNTFS;
 	#endif
+		pxCheckBox*			m_check_psx;
 
 	public:
 		virtual ~CreateMemoryCardDialog()  = default;
 		CreateMemoryCardDialog( wxWindow* parent, const wxDirName& mcdpath, const wxString& suggested_mcdfileName);
 	
 		//duplicate of MemoryCardFile::Create. Don't know why the existing method isn't used. - avih
-		static bool CreateIt( const wxString& mcdFile, uint sizeInMB );
+		static bool CreateIt( const wxString& mcdFile, uint sizeInMB, bool isPSX );
 		wxString result_createdMcdFilename;
 		//wxDirName GetPathToMcds() const;
 

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -551,7 +551,7 @@ void Panels::MemoryCardListPanel_Simple::AppStatusEvent_OnSettingsApplied()
 			wxString errMsg;
 			if (isValidNewFilename(m_Cards[slot].Filename.GetFullName(), GetMcdPath(), errMsg, 5))
 			{
-				if ( !Dialogs::CreateMemoryCardDialog::CreateIt(targetFile, 8) )
+				if ( !Dialogs::CreateMemoryCardDialog::CreateIt(targetFile, 8, false) )
 					Console.Error( L"Automatic createion of MCD '%s' failed. Hope for the best...", WX_STR(targetFile) );
 				else
 					Console.WriteLn( L"memcard created: '%s'.", WX_STR(targetFile) );


### PR DESCRIPTION
The majority of code for PSX memory cards existed with a few exceptions:
- PSX memory card creation was not possible through the emulator
- Games could not see a PSX memory card was inserted

This PR addresses these two issues by doing the following:
- Adds a checkbox to the memory card creation screen allowing PSX cards to be made, as well as the logic for writing the empty card. There is no regard for custom sizes or folder format cards, only the standard 128 KiB size, and file based cards.
- Modifying the existing preprocessor based SIO interrupts to instead work based on the running game's type (PSX/PS2). This allows PS2 games to skip the delays as they were before, but for PSX games to use the delays, which are necessary for memory card interaction.

Edit: I should apologize in advance for the eyesore that is the commit history, learned about the evil that is merging from remote, and had issues that involved forking multiple times and finessing Git locally.