### PR TITLE
PCSX2-WX: Add clear list option to ISO Selector

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -86,6 +86,7 @@ enum MenuIdentifiers
 	MenuId_Boot_Iso,			// Opens submenu with Iso browser, and recent isos.
 	MenuId_RecentIsos_reservedStart,
 	MenuId_IsoBrowse = MenuId_RecentIsos_reservedStart + 100,			// Open dialog, runs selected iso.
+	MenuId_IsoClear,
 	MenuId_Ask_On_Booting,
 	MenuId_Boot_CDVD,
 	MenuId_Boot_CDVD2,

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -206,6 +206,7 @@ void MainEmuFrame::ConnectMenus()
 
 	// CDVD
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IsoBrowse_Click, this, MenuId_IsoBrowse);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IsoClear_Click, this, MenuId_IsoClear);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_Iso);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_Plugin);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_NoDisc);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -168,6 +168,7 @@ protected:
 	void Menu_ResetAllSettings_Click(wxCommandEvent &event);
 
 	void Menu_IsoBrowse_Click(wxCommandEvent &event);
+	void Menu_IsoClear_Click(wxCommandEvent &event);
 	void Menu_EnableBackupStates_Click(wxCommandEvent &event);
 	void Menu_EnablePatches_Click(wxCommandEvent &event);
 	void Menu_EnableCheats_Click(wxCommandEvent &event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -412,6 +412,23 @@ void MainEmuFrame::Menu_IsoBrowse_Click( wxCommandEvent &event )
 	AppSaveSettings();		// save the new iso selection; update menus!
 }
 
+void MainEmuFrame::Menu_IsoClear_Click(wxCommandEvent &event)
+{
+	wxDialogWithHelpers dialog(this, _("Confirm clearing ISO list"));
+	dialog += dialog.Heading(_("This will clear the ISO list. If an ISO is running it will remain in the list. Continue?"));
+
+	bool confirmed = pxIssueConfirmation(dialog, MsgButtons().YesNo()) == wxID_YES;
+
+	if (confirmed)
+	{
+		// If the CDVD mode is not ISO, or the system isn't running, wipe the CurrentIso field in INI file
+		if (g_Conf->CdvdSource != CDVD_SourceType::Iso || !SysHasValidState())
+			SysUpdateIsoSrcFile("");
+		wxGetApp().GetRecentIsoManager().Clear();
+		AppSaveSettings();
+	}
+}
+
 void MainEmuFrame::Menu_Ask_On_Boot_Click(wxCommandEvent &event)
 {
 	g_Conf->AskOnBoot = event.IsChecked();

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
+#include "App.h"
 #include "AppCoreThread.h"
 #include "RecentIsoList.h"
 #include "IsoDropTarget.h"
@@ -34,7 +35,9 @@ RecentIsoManager::RecentIsoManager( wxMenu* menu, int firstIdForMenuItems_or_wxI
 	, m_firstIdForMenuItems_or_wxID_ANY ( firstIdForMenuItems_or_wxID_ANY )
 {
 	m_cursel	= 0;
-	m_Separator	= NULL;
+	m_Separator	= nullptr;
+	m_ClearSeparator = nullptr;
+	m_Clear = nullptr;
 
 	IniLoader loader;
 	LoadListFrom(loader);
@@ -94,10 +97,22 @@ void RecentIsoManager::RemoveAllFromMenu()
 		curitem.ItemPtr = NULL;
 	}
 	
-	if( m_Separator != NULL )
+	if( m_Separator != nullptr )
 	{
 		m_Menu->Destroy( m_Separator );
-		m_Separator = NULL;
+		m_Separator = nullptr;
+	}
+
+	if ( m_ClearSeparator != nullptr )
+	{
+		m_Menu->Destroy( m_ClearSeparator );
+		m_ClearSeparator = nullptr;
+	}
+
+	if ( m_Clear != nullptr )
+	{
+		m_Menu->Destroy( m_Clear );
+		m_Clear = nullptr;
 	}
 }
 
@@ -119,6 +134,9 @@ void RecentIsoManager::Repopulate()
 	//  but the menu is composed in reverse order such that the most recent item appears at the top.
 	for( int i=cnt-1; i>=0; --i )
 		InsertIntoMenu( i );
+
+	m_ClearSeparator = m_Menu->AppendSeparator();
+	m_Clear = m_Menu->Append(MenuIdentifiers::MenuId_IsoClear, _("Clear ISO list"));
 }
 
 void RecentIsoManager::Add( const wxString& src )

--- a/pcsx2/gui/RecentIsoList.h
+++ b/pcsx2/gui/RecentIsoList.h
@@ -47,6 +47,8 @@ protected:
 	int m_firstIdForMenuItems_or_wxID_ANY;
 
 	wxMenuItem* m_Separator;
+	wxMenuItem* m_ClearSeparator;
+	wxMenuItem* m_Clear;
 
 public:
 	RecentIsoManager( wxMenu* menu , int firstIdForMenuItems_or_wxID_ANY );


### PR DESCRIPTION
Adds "Clear ISO List" option to ISO Selector (Issue #2071).

A look at the UI before clearing, with all my iso and bin files: https://i.imgur.com/YnPCAXQ.png
I was kind enough to give users an opportunity to change their mind: https://i.imgur.com/VUVo5l0.png
And after clearning: https://i.imgur.com/Wvsdzfn.png

Closes #2071