### PR TITLE
ci: Update Travis CI and AppVeyor configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: cpp
 
 sudo: required
-dist: trusty
 
 cache: ccache
 
 matrix:
   include:
-    - env: VERSION=6 BITS=32
+    - env: VERSION=7 BITS=64
       compiler: gcc
       os: linux
-    - env: VERSION=5 BITS=32
+    - env: VERSION=7 BITS=32
+      compiler: gcc
+      os: linux
+    - env: VERSION=6 BITS=32
       compiler: gcc
       os: linux
     - env: VERSION=4.9 BITS=32
@@ -18,9 +20,6 @@ matrix:
       os: linux
     - env: VERSION=3.8 BITS=32
       compiler: clang
-      os: linux
-    - env: VERSION=4.9 BITS=64
-      compiler: gcc
       os: linux
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,18 @@
 # finished, which could be a bit annoying.
 version: 1.{build}-{branch}
 
+image: Visual Studio 2017
+
 environment:
   matrix:
   - platform: Win32
     target: AppVeyor
+    visualstudio_string: vs2017
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - platform: Win32
+    target: AppVeyor
     visualstudio_string: vs2015
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
AppVeyor:
* Add VS2017 build job.

Travis CI:
* Replace GCC4.9 64-bit with GCC7 64-bit.
* Replace GCC5 32-bit with GCC7 32-bit.
* Move 64-bit build to top of matrix so it gets built first since it takes the longest to build (only really useful when there are multiple builds in queue)