### PR TITLE
cdvdgigaherz: Fix Q subchannel relative offset calculation

### DIFF
--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -306,7 +306,7 @@ EXPORT s32 CALLBACK CDVDreadSubQ(u32 lsn, cdvdSubQ *subq)
     lsn_to_msf(&subq->discM, &subq->discS, &subq->discF, lsn + 150);
 
     u8 i = strack;
-    while (i < etrack && lsn < tracks[i + 1].start_lba)
+    while (i < etrack && lsn >= tracks[i + 1].start_lba)
         ++i;
 
     lsn -= tracks[i].start_lba;


### PR DESCRIPTION
The wrong comparison was used, so all the relative offsets were completely wrong. Fixes the wrong track issue in the CD player.

Regression introduced in f314c2a4d9a0ab349c0357b692312c137e2e6ac6.