### PR TITLE
GSdx: Add hidden option to disable Nvidia hack

### DIFF
--- a/plugins/GSdx/GSDevice11.cpp
+++ b/plugins/GSdx/GSDevice11.cpp
@@ -41,8 +41,10 @@ GSDevice11::GSDevice11()
 
 	if (theApp.GetConfigB("UserHacks")) {
 		UserHacks_unscale_pt_ln = theApp.GetConfigB("UserHacks_unscale_point_line");
+		UserHacks_disable_NV_hack = theApp.GetConfigB("UserHacks_DisableNVhack");
 	} else {
 		UserHacks_unscale_pt_ln = false;
+		UserHacks_disable_NV_hack = false;
 	}
 }
 
@@ -1296,8 +1298,8 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector
 		D3D11_VIEWPORT vp;
 		memset(&vp, 0, sizeof(vp));
 
-		vp.TopLeftX = (spritehack > 0 || isNative) ? 0.0f : -0.01f;
-		vp.TopLeftY = (spritehack > 0 || isNative) ? 0.0f : -0.01f;
+		vp.TopLeftX = (UserHacks_disable_NV_hack || spritehack > 0 || isNative) ? 0.0f : -0.01f;
+		vp.TopLeftY = (UserHacks_disable_NV_hack || spritehack > 0 || isNative) ? 0.0f : -0.01f;
 		vp.Width = (float)size.x;
 		vp.Height = (float)size.y;
 		vp.MinDepth = 0.0f;

--- a/plugins/GSdx/GSDevice11.h
+++ b/plugins/GSdx/GSDevice11.h
@@ -58,6 +58,7 @@ class GSDevice11 : public GSDeviceDX
 	bool isNative;
 
 	bool UserHacks_unscale_pt_ln;
+	bool UserHacks_disable_NV_hack;
 
 	struct
 	{

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -434,6 +434,7 @@ void GSdxApp::Init()
 	m_default_configuration["UserHacks_DisableDepthSupport"]              = "0";
 	m_default_configuration["UserHacks_CPU_FB_Conversion"]                = "0";
 	m_default_configuration["UserHacks_DisableGsMemClear"]                = "0";
+	m_default_configuration["UserHacks_DisableNVhack"]                    = "0";
 	m_default_configuration["UserHacks_DisablePartialInvalidation"]       = "0";
 	m_default_configuration["UserHacks_HalfPixelOffset"]                  = "0";
 	m_default_configuration["UserHacks_merge_pp_sprite"]                  = "0";


### PR DESCRIPTION
Add hidden option "UserHacks_DisableNVhack" to disable
the Nvidia hack on Direct3D which added black lines on the right
and bottom of the screen. Could be useful for Intel and AMD GPUs.

A better solution would be to add Vendor Id detection instead,
but this will do for now.

To disable the Nvidia hack add UserHacks_DisableNVhack=1 in GSdx.ini

Issue #1026