### PR TITLE
PSX memcard to Pocketstation hack

### DIFF
--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -685,6 +685,7 @@ SIO_WRITE sioWriteMemcard(u8 data)
 		case 0x52: // PSX 'R'ead
 		case 0x53: // PSX 'S'tate
 		case 0x57: // PSX 'W'rite
+		case 0x58: // PSX Pocketstation
 			siomode = SIO_DUMMY;
 			break;
 
@@ -746,16 +747,18 @@ SIO_WRITE sioWriteMemcardPSX(u8 data)
 
 		case 0x52: // PSX 'R'ead / Probe
 		case 0x57: // PSX 'W'rite
+		case 0x58: // POCKETSTATION!! Grrrr // Lots of love to the PS2DEV/ps2sdk
 			sio.buf[1] = 0x00; //mcd->FLAG;
 			sio.buf[2] = 0x5A; // probe end, success "0x5A"
 			sio.buf[3] = 0x5D;
 			sio.buf[4] = 0x00;
 			break;
-
-		case 0x58: // POCKETSTATION!! Grrrr // Lots of love to the PS2DEV/ps2sdk
-			DEVICE_UNPLUGGED(); // Check is for 0x01000 on stat
-			siomode = SIO_DUMMY;
-			break;
+		// Old handing for Pocketstation, effectively discarded the calls.
+		// Keeping it around for reference.
+		//case 0x58: // POCKETSTATION!! Grrrr // Lots of love to the PS2DEV/ps2sdk
+		//	DEVICE_UNPLUGGED(); // Check is for 0x01000 on stat
+		//	siomode = SIO_DUMMY;
+		//	break;
 
 		default:
 			//printf("%s cmd: %02X??\n", __FUNCTION__, data);


### PR DESCRIPTION
### Context
PSX titles made to be compatible with the Pocketstation peripheral, namely Final Fantasy VIII, send a different hex to SIO, 0x58, that was previously ignored. As a result, these games could not see PSX cards.
### Changes
This hack ~~when enabled~~ makes SIO execute the same payload for 0x58 as for normal PSX calls. ~~A checkbox is added to the main memcards screen to enable/disable. Defaults to enabled.~~
### The effect
The entire system sees PSX cards as Pocketstation devices. Though not "correct", this has no negative consequences, as Pocketstations are supposed to behave as memory cards. Additionally, games that use this Pocketstation value (and do not have other issues elsewhere in SIO) can now read and write the cards. It is confirmed that this works for Final Fantasy VIII (but only if there is not a PS2 card in slot 1, the starvation issue mentioned below) and I suspect this may help others as well, such as Saga Frontier 2, which was reported to completely stop working after the PSX SIO interrupts were introduced.
### A warning about memcard safety
In an attempt to also fix an issue where a PS2 card in slot 1 would starve out a PSX card in slot 2, I somehow managed to make it unformat any PS2 cards in the entire memcard directory. I rolled back these changes and have not been able to reproduce the issue, but it feels wrong to not mention it for safety.