### PR TITLE
Beyond good and evil fix for SPS

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -10638,6 +10638,7 @@ Region = PAL-M5
 Serial = SLES-51917
 Name   = Beyond Good and Evil
 Region = PAL-M6
+eeRoundMode = 2 // fix SPS with water in some places
 ---------------------------------------------
 Serial = SLES-51918
 Name   = Prince of Persia - The Sands of Time
@@ -37291,6 +37292,7 @@ Serial = SLUS-20763
 Name   = Beyond Good and Evil
 Region = NTSC-U
 Compat = 5
+eeRoundMode = 2 // fix SPS with water in some places
 ---------------------------------------------
 Serial = SLUS-20764
 Name   = Bombastic
@@ -43160,6 +43162,7 @@ Region = NTSC-U
 Serial = SLUS-29082
 Name   = Beyond Good and Evil [Demo]
 Region = NTSC-U
+eeRoundMode = 2 // fix SPS with water in some places
 ---------------------------------------------
 Serial = SLUS-29083
 Name   = Maximo vs. The Army of Zin [Demo]


### PR DESCRIPTION
A separate PR only for Beyond good and evil, this game throw SPS in some water places if EE round mode is not on positive or nearest.

With EE Round mode to Chop/zero:
![capture](https://user-images.githubusercontent.com/26351275/33804527-34f8fb18-dda7-11e7-8dbd-b534e3b9dfa5.PNG)

With EE Round mode to positive/nearest:
![capture](https://user-images.githubusercontent.com/26351275/33804553-c589e9f8-dda7-11e7-99c3-0d4d2e8a707c.PNG)

Note: this is only for SPS, the game still have some issues.

It is ready to merge.

[skip ci]