### PR TITLE
GameDB: Beyond good and evil, fix for wrong typo

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -10638,6 +10638,7 @@ Region = PAL-M5
 Serial = SLES-51917
 Name   = Beyond Good and Evil
 Region = PAL-M6
+eeRoundMode = 0 // fix SPS with water in some places
 ---------------------------------------------
 Serial = SLES-51918
 Name   = Prince of Persia - The Sands of Time
@@ -37291,6 +37292,7 @@ Serial = SLUS-20763
 Name   = Beyond Good and Evil
 Region = NTSC-U
 Compat = 5
+eeRoundMode = 0 // fix SPS with water in some places
 ---------------------------------------------
 Serial = SLUS-20764
 Name   = Bombastic
@@ -43160,6 +43162,7 @@ Region = NTSC-U
 Serial = SLUS-29082
 Name   = Beyond Good and Evil [Demo]
 Region = NTSC-U
+eeRoundMode = 0 // fix SPS with water in some places
 ---------------------------------------------
 Serial = SLUS-29083
 Name   = Maximo vs. The Army of Zin [Demo]

--- a/locales/da_DK/pcsx2_Iconized.po
+++ b/locales/da_DK/pcsx2_Iconized.po
@@ -1,0 +1,857 @@
+# Danish translation for pcsx2 (Iconized).
+# Copyright (C) 2017 PCSX2 Dev Team
+# This file is distributed under the same license as the pcsx2 package.
+# Jakob5566 <jakob5566@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PCSX2 1.4.0\n"
+"Report-Msgid-Bugs-To: https://github.com/PCSX2/pcsx2/issues\n"
+"POT-Creation-Date: 2017-05-30 09:58+0200\n"
+"PO-Revision-Date: 2017-06-08 15:30+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-KeywordsList: pxE;pxEt\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Poedit-Basepath: trunk\n"
+"X-Generator: Poedit 2.0.2\n"
+"Last-Translator: Jakob5566 <jakob5566@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: da_DK\n"
+"X-Poedit-SearchPath-0: pcsx2\n"
+"X-Poedit-SearchPath-1: common\n"
+
+#: common/src/Utilities/Exceptions.cpp:268
+msgid ""
+"There is not enough virtual memory available, or necessary virtual memory "
+"mappings have already been reserved by other processes, services, or DLLs."
+msgstr ""
+"Der er ikke nok virtuel hukommelse ledig, ellers er de nødvendige virtuelle "
+"hukommelseskortlægninger allerede reserveret af andre processer, tjenester "
+"eller DLL-filer."
+
+#: pcsx2/CDVD/CDVD.cpp:401
+msgid ""
+"Playstation game discs are not supported by PCSX2.  If you want to emulate "
+"PSX games then you'll have to download a PSX-specific emulator, such as "
+"ePSXe or PCSX."
+msgstr ""
+"Playstation spil understøttes ikke af PCSX2. Hvis du ønsker at emulere PSX-"
+"spil, skal du downloade en emulator, der er specielt lavet til PSX. F.eks "
+"ePSXe eller PCSX."
+
+#: pcsx2/CDVD/CDVD.cpp:2054
+msgid ""
+"Failed to read/write NMV/MEC file. Check your bios setup/permission settings"
+msgstr "Kunne ikke læse/skrive NMV/MEC filen. Undersøg dine BIOS indstillinger"
+
+#: pcsx2/System.cpp:112
+msgid ""
+"This recompiler was unable to reserve contiguous memory required for "
+"internal caches.  This error can be caused by low virtual memory resources, "
+"such as a small or disabled swapfile, or by another program that is hogging "
+"a lot of memory."
+msgstr ""
+"Recompileren kunne ikke reservere sammenhængende hukommelse, der skal bruges "
+"til den indre cache. Fejlen kan skyldes en lav virtuel hukommelse, såsom en "
+"lille eller en afbrudt swap-fil, eller et andet program, der bruger en masse "
+"hukommelse."
+
+#: pcsx2/System.cpp:354
+msgid ""
+"PCSX2 is unable to allocate memory needed for the PS2 virtual machine. Close "
+"out some memory hogging background tasks and try again."
+msgstr ""
+"PCSX2 er ikke i stand til at allokere den nødvendige hukommelse for at den "
+"virtuelle PS2-maskine kan tages i brug. Luk nogle af dine andre programmer "
+"og prøv igen."
+
+#: pcsx2/gui/AppInit.cpp:148
+msgid ""
+"Warning: Some of the configured PS2 recompilers failed to initialize and "
+"have been disabled:"
+msgstr ""
+"Advarsel: Nogle af de konfigurerede PS2 recompilere kunne ikke initialisere "
+"og er blevet deaktiveret:"
+
+#: pcsx2/gui/AppInit.cpp:206
+msgid ""
+"Note: Recompilers are not necessary for PCSX2 to run, however they typically "
+"improve emulation speed substantially. You may have to manually re-enable "
+"the recompilers listed above, if you resolve the errors."
+msgstr ""
+"Bemærk: Recompilere er ikke nødvendige for at PCSX2 virker, men de forbedrer "
+"typisk hastigheden på emuleringen markant. Du skal muligvis manuelt "
+"genaktivere de ovenstående recompilere, hvis du løser fejlene."
+
+#: pcsx2/gui/AppMain.cpp:154
+msgid ""
+"PCSX2 requires a PS2 BIOS in order to run.  For legal reasons, you *must* "
+"obtain a BIOS from an actual PS2 unit that you own (borrowing doesn't "
+"count).  Please consult the FAQs and Guides for further instructions."
+msgstr ""
+"PCSX2 kræver en PS2 BIOS-fil for at kunne køre. Af retsmæssige årsager "
+"*skal* sådan en BIOS-fil erhverves fra en fysisk PS2, som du selv ejer (det "
+"tæller ikke at låne den). Vær venlig at læse FAQ'en og de forskellige guides "
+"for yderligere information."
+
+#: pcsx2/gui/AppMain.cpp:689
+msgid ""
+"'Ignore' to continue waiting for the thread to respond.\n"
+"'Cancel' to attempt to cancel the thread.\n"
+"'Terminate' to quit PCSX2 immediately.\n"
+msgstr ""
+"'Ignorer' for fortsat at vente på at trådende svarer.\n"
+"'Annullér' for at forsøge at afbryde tråden.\n"
+"'Afbryd' for at afslutte PCSX2 med det samme.\n"
+
+#: pcsx2/gui/AppUserMode.cpp:57
+msgid ""
+"Please ensure that these folders are created and that your user account is "
+"granted write permissions to them -- or re-run PCSX2 with elevated "
+"(administrator) rights, which should grant PCSX2 the ability to create the "
+"necessary folders itself.  If you do not have elevated rights on this "
+"computer, then you will need to switch to User Documents mode (click button "
+"below)."
+msgstr ""
+"Sikr dig at disse mapper findes, og at din bruger har skriverettigheder til "
+"disse mapper -- eller prøv at lukke PCSX2 og start programmet op igen med "
+"administratorrettigheder. Det vil give PCSX2 mulighed for selv at danne "
+"disse mapper. Hvis du ikke selv har rettigheder til dette, skal du skifte "
+"til “Brugerdokumenter-modus” ved at klikke på knappen nedenfor."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:66
+msgid ""
+"Please note that the resulting file may not actually contain all saves, "
+"depending on how many are in the source memory card."
+msgstr ""
+"Vær opmærksom på at den følgende fil muligvis ikke indeholder alle gemte "
+"spilfiler. Det afhænger af, hvor mange filer, der er i det originale memory "
+"card."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:68
+msgid ""
+"WARNING: Converting a memory card may take a while! Please do not close the "
+"emulator during the conversion process, even if the emulator is no longer "
+"responding to input."
+msgstr ""
+"ADVARSEL: Det vil tage noget tid at konvertere et memory card! Du må ikke "
+"lukke ned for emulatoren under processen, heller ikke selvom emulatoren ikke "
+"længere reagerer på nogen input."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:87
+msgid "Convert this memory card to a standard 8 MB Memory Card .ps2 file."
+msgstr "Omdan dette memory card til en standard 8 MB memory card .ps2 fil."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:89
+msgid "Convert this memory card to a 16 MB Memory Card .ps2 file."
+msgstr "Omdan dette memory card til en 16 MB memory card .ps2 fil."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:91
+msgid "Convert this memory card to a 32 MB Memory Card .ps2 file."
+msgstr "Omdan dette memory card til en 32 MB memory card .ps2 fil."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:93
+msgid "Convert this memory card to a 64 MB Memory Card .ps2 file."
+msgstr "Omdan dette memory card til en 64 MB memory card .ps2 fil."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:197
+msgid ""
+"NTFS compression can be changed manually at any time by using file "
+"properties from Windows Explorer."
+msgstr ""
+"NTFS-kompression kan altid ændres manuelt ved brug af filegenskaber i "
+"Windows Stifinder."
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:49
+msgid ""
+"This is the folder where PCSX2 saves your settings, including settings "
+"generated by most plugins (some older plugins may not respect this value)."
+msgstr ""
+"I denne mappe gemmer PCSX2 dine indstillinger, deriblandt indstillinger "
+"genereret af de fleste plugins (ældre plugins har muligvis ikke denne "
+"egenskab)."
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:52
+msgid ""
+"You may optionally specify a location for your PCSX2 settings here.  If the "
+"location contains existing PCSX2 settings, you will be given the option to "
+"import or overwrite them."
+msgstr ""
+"Her kan du selv vælge, hvor du vil gemme dine PCSX2-indstillinger. Hvis "
+"placeringen indeholder allerede eksisterende indstillinger, vil du blive "
+"spurgt, om du vil importere eller overskrive indstillingerne."
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:96
+#, c-format
+msgid ""
+"This wizard will help guide you through configuring plugins, memory cards, "
+"and BIOS.  It is recommended if this is your first time installing %s that "
+"you view the readme and configuration guide."
+msgstr ""
+"Guiden vil hjælpe dig med at konfigurere plugins, memory cards og BIOS. Det "
+"anbefales, at du læser readme-filen og konfigurationsguiden, hvis du "
+"installerer %s for første gang."
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:139
+msgid ""
+"PCSX2 requires a *legal* copy of the PS2 BIOS in order to run games.\n"
+"You cannot use a copy obtained from a friend or the Internet.\n"
+"You must dump the BIOS from your *own* Playstation 2 console."
+msgstr ""
+"PCSX2 kræver en lovlig kopi af en PS2 BIOS for at man kan spille.\n"
+"Man kan ikke bruge en kopi fra en ven eller fra internettet.\n"
+"Du skal bruge BIOS'en fra din *egen* Playstation 2 konsol."
+
+#: pcsx2/gui/Dialogs/ImportSettingsDialog.cpp:31
+#, c-format
+msgid ""
+"Existing %s settings have been found in the configured settings folder.  "
+"Would you like to import these settings or overwrite them with %s default "
+"values?\n"
+"\n"
+"(or press Cancel to select a different settings folder)"
+msgstr ""
+"Der er fundet eksisterende %s indstillinger i mappen med indstillinger. Vil "
+"du importere disse indstillinger eller overskrive dem med %s standard "
+"værdier?\n"
+"\n"
+"(eller tryk Annullér for at vælge en anden mappe)"
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:30
+msgid ""
+"NTFS compression is built-in, fast, and completely reliable; and typically "
+"compresses memory cards very well (this option is highly recommended)."
+msgstr ""
+"NTFS-kompression er indbygget, hurtigt og fuldstændig troværdig; og "
+"komprimerer typisk memory cards uden problemer (denne valgmulighed er stærkt "
+"anbefalet)."
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:39
+msgid ""
+"Avoids memory card corruption by forcing games to re-index card contents "
+"after loading from savestates.  May not be compatible with all games (Guitar "
+"Hero)."
+msgstr ""
+"Undgår beskadigelse på memory cards ved at tvinge spillet til at "
+"genindeksere kortindhold, efter det er blevet indlæst fra de gemte "
+"spiltilstande. Virker muligvis ikke til alle spil (Guitar Hero)."
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:45
+msgid ""
+"(Folder type only) Re-index memory card content every time the running "
+"software changes. This prevents the memory card from running out of space "
+"for saves."
+msgstr ""
+"(Virker kun til mapper) Genindekser indholdet på memory cardet hver gang den "
+"igangværende software ændrer sig. Dette forhinder at hukommelseskortet løber "
+"tør for plads."
+
+#: pcsx2/gui/Dialogs/StuckThreadDialog.cpp:33
+#, c-format
+msgid ""
+"The thread '%s' is not responding.  It could be deadlocked, or it might just "
+"be running *really* slowly."
+msgstr ""
+"Tråden '%s' svarer ikke. Den kan være fastlåst eller kører bare *meget* "
+"langsomt."
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:38
+msgid ""
+"Warning!  You are running PCSX2 with command line options that override your "
+"configured settings.  These command line options will not be reflected in "
+"the Settings dialog, and will be disabled if you apply any changes here."
+msgstr ""
+"Advarsel! Du kører PCSX2 med kommandolinje-muligheder, der overskriver dine "
+"konfigurerede indstillinger. Disse kommandolinjeparametre vil ikke vise sig "
+"i indstillingsvinduet og vil ikke længere virke, hvis du ændrer noget her."
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:55
+msgid ""
+"Warning!  You are running PCSX2 with command line options that override your "
+"configured plugin and/or folder settings.  These command line options will "
+"not be reflected in the settings dialog, and will be disabled when you apply "
+"settings changes here."
+msgstr ""
+"Advarsel! Du kører PCSX2 med kommandolinje-muligheder, der overskriver dine "
+"konfigurerede plugin- og/eller mappeindstillinger. Disse "
+"kommandolinjeparametre vil ikke vise sig i indstillingsvinduet og vil ikke "
+"længere virke, hvis du ændrer noget her."
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:129
+msgid ""
+"The Presets apply speed hacks, some recompiler options and some game fixes "
+"known to boost speed.\n"
+"Known important game fixes will be applied automatically.\n"
+"\n"
+"Presets info:\n"
+"1 -     The most accurate emulation but also the slowest.\n"
+"3 --> Tries to balance speed with compatibility.\n"
+"4 -     Some more aggressive hacks.\n"
+"6 -     Too many hacks which will probably slow down most games.\n"
+msgstr ""
+"Forudindstillingerne anvender speedhacks, nogle recompiler-indstillinger og "
+"nogle spilløsninger, der skal øge hastigheden.\n"
+"Allerede kendte og væsentlige spilløsninger vil blive anvendt automatisk.\n"
+"\n"
+"Information om de faste indstillinger:\n"
+"1 -     Den mest præcise emulering, men også den langsomste.\n"
+"3 --> Prøver at balancere hastighed og kompatibilitet.\n"
+"4 -     Mere aggressive hacks.\n"
+"6 -     For mange hacks, som nok gør at de fleste spil bliver langsomme.\n"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:136
+msgid ""
+"The Presets apply speed hacks, some recompiler options and some game fixes "
+"known to boost speed.\n"
+"Known important game fixes will be applied automatically.\n"
+"\n"
+"--> Uncheck to modify settings manually (with current preset as base)"
+msgstr ""
+"Forudindstillingerne anvender speedhacks, nogle recompiler-indstillinger og "
+"nogle spilløsninger, der skal øge hastigheden.\n"
+"Allerede kendte og væsentlige spilløsninger vil blive anvendt automatisk.\n"
+"--> Fjern hakket i boksen for at ændre indstillingerne manuelt (med den "
+"nuværende indstilling som udgangspunkt)"
+
+#: pcsx2/gui/IsoDropTarget.cpp:28
+msgid ""
+"This action will reset the existing PS2 virtual machine state; all current "
+"progress will be lost.  Are you sure?"
+msgstr ""
+"Denne handling vil nulstille den nuværende virtuelle PS2-maskines tilstand; "
+"al nuværende fremskridt vil gå tabt. Er du sikker på, du vil fortsætte?"
+
+#: pcsx2/gui/MainMenuClicks.cpp:118
+#, c-format
+msgid ""
+"This command clears %s settings and allows you to re-run the First-Time "
+"Wizard.  You will need to manually restart %s after this operation.\n"
+"\n"
+"WARNING!!  Click OK to delete *ALL* settings for %s and force-close the app, "
+"losing any current emulation progress.  Are you absolutely sure?\n"
+"\n"
+"(note: settings for plugins are unaffected)"
+msgstr ""
+"Denne kommando sletter %s indstillinger og lader dig køre "
+"installationsguiden forfra. Du skal genstarte %s manuelt efter denne "
+"handling.\n"
+"\n"
+"ADVARSEL!! Tryk på OK for at slette *ALLE* indstillinger for %s og tvinge "
+"programmet til at lukke. Du vil miste al nuværende emuleringsfremskridt. Er "
+"du helt sikker?\n"
+"(bemærk: plugin-indstillinger forbliver upåvirket)"
+
+#: pcsx2/gui/MemoryCardFile.cpp:84 pcsx2/gui/MemoryCardFolder.h:534
+#, c-format
+msgid ""
+"The PS2-slot %d has been automatically disabled.  You can correct the "
+"problem\n"
+"and re-enable it at any time using Config:Memory cards from the main menu."
+msgstr ""
+"PS2-slottet %d er blevet afbrudt automatisk. Du kan løse problemet\n"
+"og genaktivere det ved at vælge Rediger: Memory cards fra hovedmenuen."
+
+#: pcsx2/gui/MemoryCardFolder.h:539
+#, c-format
+msgid "(FolderMcd) Memory Card is full, could not add: %s"
+msgstr "(FolderMcd) Memory card er fyldt op, kunne ikke tilføje: %s"
+
+#: pcsx2/gui/Panels/BiosSelectorPanel.cpp:139
+msgid ""
+"Please select a valid BIOS.  If you are unable to make a valid selection "
+"then press Cancel to close the Configuration panel."
+msgstr ""
+"Vælg venligst en gyldig BIOS-fil. Hvis du ikke kan vælge en, skal du trykke "
+"på Annullér for at lukke konfigurationsguiden."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:112
+msgid "Notice: Most games are fine with the default options. "
+msgstr "Bemærk: De fleste spil kan spilles med standardindstillingerne. "
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:180
+msgid "Notice: Most games are fine with the default options."
+msgstr "Bemærk: De fleste spil kan spilles med standardindstillingerne."
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:69
+msgid ""
+"The specified path/directory does not exist.  Would you like to create it?"
+msgstr "Den angivne sti/mappe findes ikke. Vil du oprette den?"
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:157
+msgid ""
+"When checked this folder will automatically reflect the default associated "
+"with PCSX2's current usermode setting. "
+msgstr ""
+"Når denne boks er krydset af, afspejler denne mappe automatisk den standard, "
+"der er forbundet med PCSX2s aktuelle brugerindstilling. "
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:55
+msgid ""
+"Zoom = 100: Fit the entire image to the window without any cropping.\n"
+"Above/Below 100: Zoom In/Out\n"
+"0: Automatic-Zoom-In untill the black-bars are gone (Aspect ratio is kept, "
+"some of the image goes out of screen).\n"
+"  NOTE: Some games draw their own black-bars, which will not be removed with "
+"'0'.\n"
+"\n"
+"Keyboard: CTRL + NUMPAD-PLUS: Zoom-In, CTRL + NUMPAD-MINUS: Zoom-Out, CTRL + "
+"NUMPAD-*: Toggle 100/0"
+msgstr ""
+"Zoom = 100: Tilpas hele billedet til vinduet uden der bliver skåret noget "
+"væk.\n"
+"Over/Under 100: Zoom ind/ud\n"
+"0: Zoomer automatisk ind, så der ikke længere er nogen sorte kanter. "
+"(Aspektforholdet beholdes, men noget af billedet vil være uden for "
+"skærmområdet).\n"
+"BEMÆRK: Nogle spil har deres egne sorte kanter, som ikke kan fjernes med "
+"'0'.\n"
+"Tastaturgenveje: CTRL+NUMPAD-PLUS: Zoom-ind, CTRL+NUMPAD-MINUS: Zoom-ud, CTRL"
+"+NUMPAD-*: Skift mellem 100/0"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:58
+msgid ""
+"Vsync eliminates screen tearing but typically has a big performance hit. It "
+"usually only applies to fullscreen mode, and may not work with all GS "
+"plugins."
+msgstr ""
+"VSync undgår forvrængning af skærmbilledet, men forværrer dog typisk "
+"ydeevnen. Sædvanligvis bliver VSync kun anvendt i fuldskærmsvisning, og det "
+"virker muligvis ikke sammen med alle GS plugins."
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:61
+msgid ""
+"Check this to force the mouse cursor invisible inside the GS window; useful "
+"if using the mouse as a primary control device for gaming.  By default the "
+"mouse auto-hides after 2 seconds of inactivity."
+msgstr ""
+"Kryds denne boks af for at tvinge musen til at forsvinde fra GS-vinduet; det "
+"er nyttigt, hvis man skal bruge musen til at spille. Musen forsvinder "
+"automatisk fra skærmen efter to sekunder, hvis den ikke er blevet brugt."
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:64
+msgid ""
+"Enables automatic mode switch to fullscreen when starting or resuming "
+"emulation. You can still toggle fullscreen display at any time using alt-"
+"enter."
+msgstr ""
+"Gør så fuldskærmsvisning automatisk starter, når man kører eller genoptager "
+"en emulering. Du kan altid selv skfite til fuldskærmsvisning ved at trykke "
+"på alt+enter."
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:71
+msgid ""
+"Completely closes the often large and bulky GS window when pressing ESC or "
+"pausing the emulator."
+msgstr ""
+"Lukker helt for det store og ressourcekrævende GS-vindue, når man trykker på "
+"ESC eller pauser emulatoren."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:69
+msgid ""
+"Known to affect following games:\n"
+" * Digital Devil Saga (Fixes FMV and crashes)\n"
+" * SSX (Fixes bad graphics and crashes)\n"
+" * Resident Evil: Dead Aim (Causes garbled textures)"
+msgstr ""
+"Kendt for at påvirke følgende spil:\n"
+" * Digital Devil Saga (Ordner FMV og bryder ned)\n"
+" * SSX (Ordner grafikfejl og bryder ned)\n"
+" * Resident Evil: Dead Aim (Danner forkludrede teksturer)"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:78
+msgid ""
+"Known to affect following games:\n"
+" * Bleach Blade Battler\n"
+" * Growlanser II and III\n"
+" * Wizardry"
+msgstr ""
+"Kendt for at påvirke følgende spil:\n"
+" * Bleach Blade Battler\n"
+" * Growlanser II and III\n"
+" * Wizardry"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:83
+msgid ""
+"Known to affect following games:\n"
+" * Mana Khemia 1 (Going \"off campus\")\n"
+msgstr ""
+"Kendt for at påvirke følgende spil:\n"
+" * Mana Khemia 1 (Ryger ud af spilkortet)\n"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:88
+msgid ""
+"Known to affect following games:\n"
+" * Test Drive Unlimited\n"
+" * Transformers"
+msgstr ""
+"Kendt for at påvirke følgende spil:\n"
+" * Test Drive Unlimited\n"
+" * Transformers"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:120
+msgid ""
+"It's better to enable 'Automatic game fixes' at the main menu instead, and "
+"leave this page empty. ('Automatic' means: selectively use specific tested "
+"fixes for specific games). Manual game fixes will NOT increase your "
+"performance. In fact they may decrease it."
+msgstr ""
+"Det fungerer bedre, hvis man aktiverer 'Automatiske spilrettelser' i "
+"hovedmenuen i stedet for. ('Automatisk' betyder: selektivt brug af "
+"specifikke testede rettelser til specifikke spil). Manuelle spilrettelser "
+"forbedre IKKE ydeevnen. Den forværrer den muligvis."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:124
+msgid ""
+"Gamefixes can work around wrong emulation in some titles. \n"
+"They may also cause compatibility or performance issues.\n"
+"\n"
+"The safest way is to make sure that all game fixes are completely disabled."
+msgstr ""
+"Spilrettelser kan i særlige tilfælde forværre emuleringen.\n"
+"De kan også skabe kompatibilitets- eller ydelsesproblemer.\n"
+"\n"
+"Det sikreste er at sørge for, at alle spilrettelser er slået helt fra."
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:683
+#, c-format
+msgid ""
+"You are about to delete the formatted memory card '%s'. All data on this "
+"card will be lost!  Are you absolutely and quite positively sure?"
+msgstr ""
+"Du er ved at slette det formaterede memory card '%s'. Al data på dette kort "
+"vil gå tabt! Er du helt sikker på, du vil fortsætte?"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:722
+msgid ""
+"Failed: Duplicate is only allowed to an empty PS2-Port or to the file system."
+msgstr ""
+"Mislykket: Det er kun muligt at kopiere til en tom PS2-port eller til "
+"filsystemet."
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:764
+#, c-format
+msgid "Failed: Destination memory card '%s' is in use."
+msgstr "Mislykket: Memory card '%s' er allerede i brug."
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:36
+msgid ""
+"Please select your preferred default location for PCSX2 user-level documents "
+"below (includes memory cards, screenshots, settings, and savestates).  These "
+"folder locations can be overridden at any time using the Plugin/BIOS "
+"Selector panel."
+msgstr ""
+"Vælg venligst din foretrukne standardplacering til PCSX2-dokumenter nedenfor "
+"(det inkluderer memory cards, skærmbilleder, indstillinger og gemte "
+"spiltilstande). Disse mappeplaceringer kan overskrives når som helst via "
+"Plugin/BIOS vælger-panelet."
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:39
+msgid ""
+"You can change the preferred default location for PCSX2 user-level documents "
+"here (includes memory cards, screenshots, settings, and savestates).  This "
+"option only affects Standard Paths which are set to use the installation "
+"default value."
+msgstr ""
+"Du kan ændre din foretrukne standardplacering til PCSX2-dokumenter nedenfor "
+"(det inkluderer memory cards, skærmbilleder, indstillinger og gemte "
+"spiltilstande). Denne valgmulighed påvirker kun standardstier, som bruger "
+"installationens normalværdi."
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:40
+msgid ""
+"This folder is where PCSX2 records savestates; which are recorded either by "
+"using menus/toolbars, or by pressing F1/F3 (save/load)."
+msgstr ""
+"I denne mappe gemmer PCSX2 spiltilstande; som bliver gemt enten via menuerne/"
+"værktøjsbjælken, eller ved at trykke F1/F3 (gem/indlæs)."
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:48
+msgid ""
+"This folder is where PCSX2 saves screenshots.  Actual screenshot image "
+"format and style may vary depending on the GS plugin being used."
+msgstr ""
+"I denne mappe gemmer PCSX2 skærmbilleder. Formatet og stilen på "
+"skærmbillederne kan variere afhængig af hvilket GS plugin, der bliver brugt."
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:56
+msgid ""
+"This folder is where PCSX2 saves its logfiles and diagnostic dumps.  Most "
+"plugins will also adhere to this folder, however some older plugins may "
+"ignore it."
+msgstr ""
+"I denne mappe gemmer PCSX2 sine logfiler og diagnostiske dumps. De fleste "
+"plugins vil også holde sig til denne mappe, men nogle ældre plugins kan "
+"ignorere den."
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:242
+msgid ""
+"Warning!  Changing plugins requires a complete shutdown and reset of the PS2 "
+"virtual machine. PCSX2 will attempt to save and restore the state, but if "
+"the newly selected plugins are incompatible the recovery may fail, and "
+"current progress will be lost.\n"
+"\n"
+"Are you sure you want to apply settings now?"
+msgstr ""
+"Advarsel! Det kræver en fuldstændig genstart og nulstilling af den virtuelle "
+"PS2-maskine. PCSX2 vil forsøge at gemme og gendanne tilstanden, men hvis det "
+"nyvalgte plugin er inkompatibelt, kan gendannelsen fejle og de nuværende "
+"fremskridt vil gå tabt.\n"
+"\n"
+"Er du sikker på, du vil anvende disse indstillinger nu?"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:454
+#, c-format
+msgid ""
+"All plugins must have valid selections for %s to run.  If you are unable to "
+"make a valid selection due to missing plugins or an incomplete install of "
+"%s, then press Cancel to close the Configuration panel."
+msgstr ""
+"Der skal være valgt gyldige plugins for at %s kan køre. Hvis du ikke kan "
+"vælge et gyldigt plugin, fordi der mangler et plugin eller installationen af "
+"%s har slået fejl, skal du trykke på Annullér eller lukke "
+"konfigurationsguiden."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:29
+msgid ""
+"-3 - Reduces the EE's cyclerate to about 50%.  Big speedup, but *will* cause "
+"stuttering audio on many FMVs."
+msgstr ""
+"-3 - Reducerer EE’ens cyklusfrekvens til cirka 50%. Markant forbedring af "
+"spilhastigheden, men lyden vil hakke, når man spiller."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:34
+msgid ""
+"-2 - Reduces the EE's cyclerate to about 60%.  Moderate speedup, but may "
+"cause stuttering audio on many FMVs."
+msgstr ""
+"-2 - Reducerer EE’ens cyklusfrekvens til cirka 60%. Moderat forbedering af "
+"spilhastigheden, men lyden vil hakke, når man spiller."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:39
+msgid ""
+"-1 - Reduces the EE's cyclerate to about 75%.  Mild speedup for most games "
+"with high compatibility."
+msgstr ""
+"-1 - Reducerer EE’ens cyklusfrekvens til cirka 75%. Mild forbedring af "
+"spilhastigheden for spil med høj kompatibilitet."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:45
+msgid ""
+"0 - Default cyclerate (100%). This closely matches the actual speed of a "
+"real PS2 EmotionEngine."
+msgstr ""
+"0 - Standard cyklusfrekvens (100%). Matcher næsten den originale PS2-motor."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:50
+msgid ""
+"1 - Increases the EE's cyclerate to about 130%. Mildly increases hardware "
+"requirements, may increase in-game FPS."
+msgstr ""
+"1 - Forøger EE’ens cyklusfrekvens til cirka 130%. Mild forøgelse af "
+"hardwarekravene, kan forøge billeder vist pr. sekund i spillet."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:55
+msgid ""
+"2 - Increases the EE's cyclerate to about 180%. Increases hardware "
+"requirements, may noticeably increase in-game FPS."
+msgstr ""
+"2 - Forøger EE’ens cyklusfrekvens til cirka 180%. Moderat forøgelse af "
+"hardwarekravene, kan mærkbart øge billeder vist pr. sekund i spillet."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:60
+msgid ""
+"3 - Increases the EE's cyclerate to about 300%. Greatly increases hardware "
+"requirements, may noticeably increase in-game FPS.\n"
+"This setting can cause games to FAIL TO BOOT."
+msgstr ""
+"3 - Forøger EE’ens cyklusfrekvens til cirka 300%. Forøger i høj grad "
+"hardwarekravene, kan mærkbart øge billeder vist pr. sekund i spillet.\n"
+"Denne indstilling kan gøre, så spil IKKE KAN STARTE OP."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:77
+msgid "0 - Disables VU Cycle Stealing.  Most compatible setting!"
+msgstr ""
+"0 - Slår VU Cycle Stealing fra. Dette er den mest kompatible indstilling!"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:82
+msgid ""
+"1 - Mild VU Cycle Stealing.  Lower compatibility, but some speedup for most "
+"games."
+msgstr ""
+"1 - Mild VU Cycle Stealing. Lav kompatibilitet, men forbedrer "
+"spilhastigheden i de fleste spil."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:87
+msgid ""
+"2 - Moderate VU Cycle Stealing.  Even lower compatibility, but significant "
+"speedups in some games."
+msgstr ""
+"2 - Moderat VU Cycle Stealing. Endnu lavere kompatibilitet, men forbedrer "
+"spilhastigheden markant i nogle spil."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:93
+msgid ""
+"3 - Maximum VU Cycle Stealing.  Usefulness is limited, as this will cause "
+"flickering visuals or slowdown in most games."
+msgstr ""
+"3 - Maksimalt VU Cycle Stealing. Brugbarheden er begrænset, da denne "
+"indstilling vil skabe flimmer og reducere tempoet i de fleste spil."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:118
+msgid ""
+"Speedhacks usually improve emulation speed, but can cause glitches, broken "
+"audio, and false FPS readings.  When having emulation problems, disable this "
+"panel first."
+msgstr ""
+"Speedhacks forbedrer normalt emuleringshastigheden, men kan forårsage fejl, "
+"ødelagt lyd, og forkerte aflæsninger af billeder pr. sekund. Hvis du har "
+"problemer, skal du slå dette panel fra først."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:145
+msgid ""
+"Setting lower values on this slider effectively reduces the clock speed of "
+"the EmotionEngine's R5900 core cpu, and typically brings big speedups to "
+"games that fail to utilize the full potential of the real PS2 hardware. "
+"Conversely, higher values effectively increase the clock speed which may "
+"bring about an increase in in-game FPS while also making games more "
+"demanding and possibly causing glitches."
+msgstr ""
+"Hvis man placerer glideren på de mindre værdier, reducerer man, med god "
+"virkning, klokfrekvensen på EmotionEnginens R5900 processor, og det giver "
+"typisk en stor hastighedsforøgelse på spil, der ikke kunne udnytte PS2-"
+"hardwarens fulde potentiale. Omvendt, forøger de højere værdier "
+"klokfrekvensen, og det kan forøge billederne pr. sekund, men det gør også "
+"spillene mere krævende og kan skabe fejl i dem."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:161
+msgid ""
+"This slider controls the amount of cycles the VU unit steals from the "
+"EmotionEngine.  Higher values increase the number of cycles stolen from the "
+"EE for each VU microprogram the game runs."
+msgstr ""
+"Denne glider kontrollerer mængden af cyklusser som VU-enheden tager fra "
+"EmotionEnginen. De høje værdier forøger mængden af cyklusser, der bliver "
+"taget fra EE’en for hvert VU mikroprogram, spillet kører."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:178
+msgid ""
+"Updates Status Flags only on blocks which will read them, instead of all the "
+"time. This is safe most of the time, and Super VU does something similar by "
+"default."
+msgstr ""
+"Opdaterer kun statusflaget på datablokke, der vil læse dem, i stedet for "
+"hele tiden. Dette er sikkert det meste af tiden, og SuperVU’en gør normalt "
+"noget lignende af sig selv."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:181
+msgid ""
+"Runs VU1 on its own thread (microVU1-only). Generally a speedup on CPUs with "
+"3 or more cores. This is safe for most games, but a few games are "
+"incompatible and may hang. In the case of GS limited games, it may be a "
+"slowdown (especially on dual core CPUs)."
+msgstr ""
+"Kører VU1 på sin egen procestråd (kun MicroVU1). Giver generelt en forøgelse "
+"af hastigheden på processorer med tre eller flere kerner. Dette fungerer til "
+"de fleste spil, men nogle spil vil kunne gå i stå. Hvis spil er begrænset "
+"til GS, kan det gøre spillene langsommere (især på en to-kernet processor)."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:199
+msgid ""
+"This hack works best for games that use the INTC Status register to wait for "
+"vsyncs, which includes primarily non-3D RPG titles. Games that do not use "
+"this method of vsync will see little or no speedup from this hack."
+msgstr ""
+"Denne hack virker bedst i spil, der bruger INTC statusregisteret til at "
+"vente på lodrette synkroniseringer, primært RPG-titler uden 3D. Spil, der "
+"ikke bruger denne metode, vil kun opleve en lille eller slet ingen "
+"hastighedsforbedring."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:202
+msgid ""
+"Primarily targetting the EE idle loop at address 0x81FC0 in the kernel, this "
+"hack attempts to detect loops whose bodies are guaranteed to result in the "
+"same machine state for every iteration until a scheduled event triggers "
+"emulation of another unit.  After a single iteration of such loops, we "
+"advance to the time of the next event or the end of the processor's "
+"timeslice, whichever comes first."
+msgstr ""
+"Retter sig primært mod EE-idleloop’et på adresse 0x81FC0 i kerneprogrammet. "
+"Dette hack forsøger at opdage sløjfer, hvis samlinger er garanteret at "
+"resultere i den samme maskinstilstand for hver gentagelse, der er, indtil en "
+"planlagt begivenhed udløser emuleringen af en anden enhed. Efter første "
+"gentagelse af en sløjfe, fortsætter vi til næste begivenhed eller til næste "
+"tidsdel."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:205
+msgid ""
+"Check HDLoader compatibility lists for known games that have issues with "
+"this. (Often marked as needing 'mode 1' or 'slow DVD'"
+msgstr ""
+"Undersøg HDLoaders kompatibilitetsliste for spil, der er kendt for at have "
+"problemer med dette. (Ofte markeret som mangler ‘mode1’ eller ‘slow DVD’"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:35
+msgid ""
+"Note that when Framelimiting is disabled, Turbo and SlowMotion modes will "
+"not be available either."
+msgstr ""
+"Bemærk, at når Framelimiting er slået fra, vil Turbo og Slowmotion heller "
+"ikke være tilgængelige."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:219
+msgid ""
+"Notice: Due to PS2 hardware design, precise frame skipping is impossible. "
+"Enabling it will cause severe graphical errors in some games."
+msgstr ""
+"Bemærk: Grundet PS2’s design af hardware, er præcis frameskipping umuligt. "
+"Hvis du aktiverer det, vil det forårsage voldsomme grafiske fejl i nogle "
+"spil."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:298
+msgid ""
+"Enable this if you think MTGS thread sync is causing crashes or graphical "
+"errors."
+msgstr ""
+"Aktivér dette, hvis du mener, at MTGS-trådsynkroniseringen er skyld i "
+"nedbrud og grafikfejl."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:301
+msgid ""
+"Removes any benchmark noise caused by the MTGS thread or GPU overhead.  This "
+"option is best used in conjunction with savestates: save a state at an ideal "
+"scene, enable this option, and re-load the savestate.\n"
+"\n"
+"Warning: This option can be enabled on-the-fly but typically cannot be "
+"disabled on-the-fly (video will typically be garbage)."
+msgstr ""
+"Fjerner alle benchmarklyde skabt af MTGS-procestråde eller overophedning af "
+"GPU’en. Denne valgmulighed virker bedst i forbindelse med gemte "
+"spiltilstande: gem en spiltilstand et ideelt sted, vælg denne valgmulighed "
+"og genindlæs den gemte tilstand.\n"
+"\n"
+"Advarsel: Denne valgmulighed kan aktiveres, mens spillet kører, men kan "
+"typisk ikke deaktiveres imens (video vil typisk se forfærdeligt ud)."
+
+#: pcsx2/vtlb.cpp:835
+msgid ""
+"Your system is too low on virtual resources for PCSX2 to run. This can be "
+"caused by having a small or disabled swapfile, or by other programs that are "
+"hogging resources."
+msgstr ""
+"Dit system har ikke nok virtuelle ressourcer ledige for at PCSX2 kan køre. "
+"Dette kan skyldes, at du har en lille eller en ubrugelig swap-fil, eller at "
+"et andet program bruger al pladsen."
+
+#: pcsx2/x86/sVU_zerorec.cpp:367
+msgid ""
+"Out of Memory (sorta): The SuperVU recompiler was unable to reserve the "
+"specific memory ranges required, and will not be available for use.  This is "
+"not a critical error, since the sVU rec is obsolete, and you should use "
+"microVU instead anyway. :)"
+msgstr ""
+"Ikke mere plads: SuperVU recompileren kunne ikke reservere den nødvendige "
+"hukommelse og vil ikke kunne bruges. Dette er ikke en kritisk fejl, da sVU "
+"rec er forældet, og du skal bruge microVU i stedet for. :)"

--- a/locales/da_DK/pcsx2_Main.po
+++ b/locales/da_DK/pcsx2_Main.po
@@ -1,0 +1,2857 @@
+# Danish translation for pcsx2 (Iconized).
+# Copyright (C) 2017 PCSX2 Dev Team
+# This file is distributed under the same license as the pcsx2 package.
+# Jakob5566 <jakob5566@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PCSX2 1.4.0\n"
+"Report-Msgid-Bugs-To: https://github.com/PCSX2/pcsx2/issues\n"
+"POT-Creation-Date: 2017-06-01 16:52+0200\n"
+"PO-Revision-Date: 2017-06-08 15:48+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-KeywordsList: _;pxL;_d;pxDt;_t;pxLt\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Poedit-Basepath: trunk\n"
+"X-Generator: Poedit 2.0.2\n"
+"Last-Translator: Jakob5566 <jakob5566@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: da_DK\n"
+"X-Poedit-SearchPath-0: pcsx2\n"
+"X-Poedit-SearchPath-1: common\n"
+
+#: common/include/Utilities/Exceptions.h:216
+msgid "No reason given."
+msgstr "Ingen grund givet."
+
+#: common/include/Utilities/Exceptions.h:255
+msgid "Parse error"
+msgstr "Parsefejl"
+
+#: common/include/Utilities/Exceptions.h:279
+msgid "Your machine's hardware is incapable of running PCSX2.  Sorry dood."
+msgstr "Din maskines hardware er ude af stand til at køre PCSX2. Beklager."
+
+#: common/src/Utilities/Exceptions.cpp:233
+msgid "Oh noes! Out of memory!"
+msgstr "Åh nej! Ikke mere hukommelse!"
+
+#: common/src/Utilities/Exceptions.cpp:248
+msgid ""
+"Virtual memory mapping failure!  Your system may have conflicting device "
+"drivers, services, or may simply have insufficient memory or resources to "
+"meet PCSX2's lofty needs."
+msgstr ""
+"Den virtuelle lagerliste slog fejl! Dit system kan have konfliktskabende "
+"enhedsdrivere, tjenester, eller ikke nok hukommelse eller ressourcer til at "
+"dække PCSX2’s overlegene behov."
+
+#: common/src/Utilities/Exceptions.cpp:319
+msgid "Path: "
+msgstr "Sti: "
+
+#: common/src/Utilities/Exceptions.cpp:323
+msgid "[Unnamed or unknown]"
+msgstr "[Unavngiven eller ukendt]"
+
+#: common/src/Utilities/Exceptions.cpp:343
+msgid "A file could not be created."
+msgstr "En fil kunne ikke oprettes."
+
+#: common/src/Utilities/Exceptions.cpp:363
+msgid "File not found."
+msgstr "Filen blev ikke fundet."
+
+#: common/src/Utilities/Exceptions.cpp:383
+msgid ""
+"Permission denied while trying to open file, likely due to insufficient user "
+"account rights."
+msgstr ""
+"Tilladelse nægtet da filen blev forsøgt åbnet. Dette kan skyldes, at "
+"brugeren ikke har de rigtige rettigheder."
+
+#: common/src/Utilities/Exceptions.cpp:403
+msgid ""
+"Unexpected end of file or stream encountered.  File is probably truncated or "
+"corrupted."
+msgstr ""
+"Filen eller strømmen sluttede uventet. Filen er muligvis afkortet eller "
+"korrupt."
+
+#: common/src/Utilities/ThreadTools.cpp:41
+msgid "Threading activity: start, detach, sync, deletion, etc."
+msgstr "Trådningens aktivitet: start, løsrive, synkroniser, sletning, osv."
+
+#: common/src/Utilities/ThreadingDialogs.cpp:30
+msgid "Waiting for tasks..."
+msgstr "Venter på opgaver…"
+
+#: common/src/Utilities/ThreadingDialogs.cpp:42
+msgid "Waiting for task..."
+msgstr "Venter på opgave..."
+
+#: common/src/Utilities/wxAppWithHelpers.cpp:35
+msgid "Includes idle event processing and some other uncommon event usages."
+msgstr ""
+"Inkluderer behandling af hændelser medens ledig og andre usædvanlige brug af "
+"hændelser."
+
+#: pcsx2/CDVD/InputIsoFile.cpp:252
+msgid "Unrecognized ISO image file format"
+msgstr "ISO-billede filformatet blev ikke genkendt"
+
+#: pcsx2/Elfheader.cpp:165
+msgid "Cannot load ELF binary image.  The file may be corrupt or incomplete."
+msgstr ""
+"Kan ikke indlæse det binære ELF-billede. Filen kan være beskadiget eller "
+"ufuldstændig."
+
+#: pcsx2/Elfheader.cpp:167
+msgid ""
+"If loading from an ISO image, this error may be caused by an unsupported ISO "
+"image type or a bug in PCSX2 ISO image support."
+msgstr ""
+"Hvis du indlæser fra et ISO-billede, kan fejlen skyldes, at ISO-filformatet "
+"ikke understøttes, eller at der er en fejl i PCSX2 ISO-understøttelse."
+
+#: pcsx2/MTGS.cpp:882
+msgid ""
+"The MTGS thread has become unresponsive while waiting for the GS plugin to "
+"open."
+msgstr ""
+"MTGS-procestråden er gået i stå, da den skulle vente på, at GS-plugin’et "
+"åbnede."
+
+#: pcsx2/PluginManager.cpp:737
+msgid ""
+"The savestate cannot be loaded, as it appears to be corrupt or incomplete."
+msgstr ""
+"Den gemte spiltilstand kunne ikke indlæses, da den er beskadiget eller "
+"ufuldstændig."
+
+#: pcsx2/PluginManager.cpp:747
+#, c-format
+msgid ""
+"%s plugin failed to open.  Your computer may have insufficient resources, or "
+"incompatible hardware/drivers."
+msgstr ""
+"%s plugin kunne ikke åbnes. Din computer kan have utilstrækkelige "
+"ressourcer, eller inkompatibelt hardware/drivere."
+
+#: pcsx2/PluginManager.cpp:754
+#, c-format
+msgid ""
+"%s plugin failed to initialize.  Your system may have insufficient memory or "
+"resources needed."
+msgstr ""
+"%s plugin kunne ikke initialisere. Dit system har utilstrækkelig hukommelse "
+"eller mangler ressourcer."
+
+#: pcsx2/PluginManager.cpp:982
+#, c-format
+msgid "The configured %s plugin file was not found"
+msgstr "Den konfigurerede %s plugin-fil blev ikke fundet"
+
+#: pcsx2/PluginManager.cpp:986
+#, c-format
+msgid "The configured %s plugin file is not a valid dynamic library"
+msgstr "Den konfigurerede %s plugin-fil er ikke et gyldigt dynamisk bibliotek"
+
+#: pcsx2/PluginManager.cpp:1003
+#, c-format
+msgid ""
+"The configured %s plugin is not a PCSX2 plugin, or is for an older "
+"unsupported version of PCSX2."
+msgstr ""
+"Det konfigurerede %s plugin er ikke et PCSX2 plugin, eller det tilhører en "
+"version af PCSX2, der ikke længere er understøttet."
+
+#: pcsx2/PluginManager.cpp:1037
+msgid ""
+"The plugin reports that your hardware or software/drivers are not supported."
+msgstr ""
+"Plugin’et fortæller, at dit hardware eller software/drivere ikke er "
+"understøttet."
+
+#: pcsx2/PluginManager.cpp:1058
+msgid ""
+"Configured plugin is not a PCSX2 plugin, or is for an older unsupported "
+"version of PCSX2."
+msgstr ""
+"Det konfigurerede plugin er ikke et PCSX2 plugin, eller det tilhører en "
+"version af PCSX2, der ikke længere er understøttet."
+
+#: pcsx2/PluginManager.cpp:1083
+#, c-format
+msgid ""
+"Configured %s plugin is not a valid PCSX2 plugin, or is for an older "
+"unsupported version of PCSX2."
+msgstr ""
+"Det konfigurerede %s plugin er ikke et PCSX2 plugin, eller det tilhører en "
+"version af PCSX2, der ikke længere er understøttet."
+
+#: pcsx2/PluginManager.cpp:1518
+msgid "Internal Memorycard Plugin failed to initialize."
+msgstr "Det interne Memorycard Plugin kunne ikke indlæses."
+
+#: pcsx2/PluginManager.cpp:1915
+msgid "Unloaded Plugin"
+msgstr "Plugin ikke indlæst"
+
+#: pcsx2/SaveState.cpp:343
+msgid "Cannot load savestate.  It is of an unknown or unsupported version."
+msgstr ""
+"Kan ikke indlæse den gemte spiltilstand. Versionen er ukendt eller "
+"understøttes ikke."
+
+#: pcsx2/SourceLog.cpp:96
+msgid "Dumps detailed information for PS2 executables (ELFs)."
+msgstr "Gemmer detaljeret information om PS2 eksekverbare filer (ELF’er)."
+
+#: pcsx2/SourceLog.cpp:101
+msgid ""
+"Logs manual protection, split blocks, and other things that might impact "
+"performance."
+msgstr ""
+"Logger manuel beskyttelse, opdeler blokke og andre ting, der kan påvirke "
+"ydeevnen."
+
+#: pcsx2/SourceLog.cpp:106
+msgid "Shows the game developer's logging text (EE processor)"
+msgstr "Viser spiludviklerens journal (EE processor)"
+
+#: pcsx2/SourceLog.cpp:111
+msgid "Shows the game developer's logging text (IOP processor)"
+msgstr "Viser spiludviklerens journal (IOP processor)"
+
+#: pcsx2/SourceLog.cpp:116
+msgid "Shows DECI2 debugging logs (EE processor)"
+msgstr "Viser DECI2 fejl-journal (EE processor)"
+
+#: pcsx2/SourceLog.cpp:145
+msgid "SYSCALL and DECI2 activity."
+msgstr "SYSCALL og DECI2 aktivitet."
+
+#: pcsx2/SourceLog.cpp:151
+msgid "Direct memory accesses to unknown or unmapped EE memory space."
+msgstr ""
+"Direkte hukommelsesadgang til ukendt eller ikke kortlagt EE-hukommelsesplads."
+
+#: pcsx2/SourceLog.cpp:157 pcsx2/SourceLog.cpp:276
+msgid "Disasm of executing core instructions (excluding COPs and CACHE)."
+msgstr ""
+"Adskillelse af kerneinstruktionernes afvikling (med undtagelse af COP’er og "
+"CACHE)."
+
+#: pcsx2/SourceLog.cpp:163
+msgid "Disasm of COP0 instructions (MMU, cpu and dma status, etc)."
+msgstr "Adskillelse af COP0-instruktioner (MMU, cpu og dma-status, osv)."
+
+#: pcsx2/SourceLog.cpp:169
+msgid "Disasm of the EE's floating point unit (FPU) only."
+msgstr "Udelukkende adskillelse af EE’ens flydende komma enhed (FPU)."
+
+#: pcsx2/SourceLog.cpp:175
+msgid "Disasm of the EE's VU0macro co-processor instructions."
+msgstr "Adskillelse af EE’ens VU0macro co-processorinstruktioner."
+
+#: pcsx2/SourceLog.cpp:181
+msgid "Execution of EE cache instructions."
+msgstr "Afvikling af EE cache-instruktioner."
+
+#: pcsx2/SourceLog.cpp:187
+msgid ""
+"All known hardware register accesses (very slow!); not including sub filter "
+"options below."
+msgstr ""
+"Alle kendte hardware dataregistre (meget langsomt!); det inkluderer ikke "
+"subfilter-muligheden nedenunder."
+
+#: pcsx2/SourceLog.cpp:193 pcsx2/SourceLog.cpp:294
+msgid "Logs only unknown, unmapped, or unimplemented register accesses."
+msgstr ""
+"Logger kun ukendte, ikke kortlagte, eller ikke implementerede dataregistre."
+
+#: pcsx2/SourceLog.cpp:199 pcsx2/SourceLog.cpp:300
+msgid "Logs only DMA-related registers."
+msgstr "Logger kun DMA-relaterede registre."
+
+#: pcsx2/SourceLog.cpp:205
+msgid "IPU activity: hardware registers, decoding operations, DMA status, etc."
+msgstr ""
+"IPU-aktivitet: hardwareregistre, afkodningsoperationer, DMA-status, osv."
+
+#: pcsx2/SourceLog.cpp:211
+msgid "All GIFtag parse activity; path index, tag type, etc."
+msgstr "Al GIFtag analyseaktivitet; sti-katalog, etikettype, osv."
+
+#: pcsx2/SourceLog.cpp:217
+msgid "All VIFcode processing; command, tag style, interrupts."
+msgstr "Al VIFcode-behandling; kommando, tag typografi, afbrydelser."
+
+#: pcsx2/SourceLog.cpp:223
+msgid "All processing involved in Path3 Masking"
+msgstr "Al behandling involveret i Path3 Masking"
+
+#: pcsx2/SourceLog.cpp:229
+msgid "Scratchpad's MFIFO activity."
+msgstr "Mellemlagerets MFIFO-aktivet."
+
+#: pcsx2/SourceLog.cpp:235
+msgid "Actual data transfer logs, bus right arbitration, stalls, etc."
+msgstr "Faktiske dataoverførselslogge, bus-overførsel, stops, osv."
+
+#: pcsx2/SourceLog.cpp:241
+msgid "Tracks all EE counters events and some counter register activity."
+msgstr ""
+"Følger alle EE-tællernes begivenheder og nogle tælleregister-aktiviteter."
+
+#: pcsx2/SourceLog.cpp:247
+msgid "Dumps various VIF and VIFcode processing data."
+msgstr "Gemmer forskelligt VIF og VIFcode procesdata."
+
+#: pcsx2/SourceLog.cpp:253
+msgid "Dumps various GIF and GIFtag parsing data."
+msgstr "Gemmer forskelligt GIF og GIFtag parsing data."
+
+#: pcsx2/SourceLog.cpp:264
+msgid "SYSCALL and IRX activity."
+msgstr "SYSCALL og IRX-aktivitet."
+
+#: pcsx2/SourceLog.cpp:270
+msgid "Direct memory accesses to unknown or unmapped IOP memory space."
+msgstr ""
+"Direkte hukommelsesadgang til ukendt eller ikke kortlagt IOP "
+"hukommelsesplads."
+
+#: pcsx2/SourceLog.cpp:282
+msgid "Disasm of the IOP's GPU co-processor instructions."
+msgstr "Adskillelse af IOP’ens GPU co-processorinstruktioner."
+
+#: pcsx2/SourceLog.cpp:288
+msgid ""
+"All known hardware register accesses, not including the sub-filters below."
+msgstr ""
+"Alle kendte hardware dataregistre, det inkluderer ikke subfilter-muligheden "
+"nedenunder."
+
+#: pcsx2/SourceLog.cpp:306
+msgid "Memorycard reads, writes, erases, terminators, and other processing."
+msgstr "Memory card læser, skriver, sletter, afslutter, og andre behandlinger."
+
+#: pcsx2/SourceLog.cpp:312
+msgid "Gamepad activity on the SIO."
+msgstr "Gamepad-aktivitet på SIO’en."
+
+#: pcsx2/SourceLog.cpp:318
+msgid "Actual DMA event processing and data transfer logs."
+msgstr "Faktisk DMA begivenhedsbehandling og dataoverførselslogge."
+
+#: pcsx2/SourceLog.cpp:324
+msgid "Tracks all IOP counters events and some counter register activity."
+msgstr "Følger alle IOP-tællernes begivenheder og tælleregister-aktiviteter."
+
+#: pcsx2/SourceLog.cpp:330
+msgid "Detailed logging of CDVD hardware."
+msgstr "Detaljeret logning af CDVD hardware."
+
+#: pcsx2/SourceLog.cpp:336
+msgid "Detailed logging of the Motion (FMV) Decoder hardware unit."
+msgstr "Detaljeret logning af bevægelsesafkoderen (FMV)."
+
+#: pcsx2/System.h:224 pcsx2/System.h:225 pcsx2/System.h:226
+msgid "PCSX2 Message"
+msgstr "PCSX2 Besked"
+
+#: pcsx2/ZipTools/thread_gzip.cpp:85
+msgid ""
+"The savestate was not properly saved. The temporary file was created "
+"successfully but could not be moved to its final resting place."
+msgstr ""
+"Spiltilstanden blev ikke gemt ordentligt. Den midlertidige fil blev oprettet "
+"med succes, men kunne ikke flyttes til dens endelige placering."
+
+#: pcsx2/gui/AppConfig.cpp:978
+msgid "Safest"
+msgstr "Sikrest"
+
+#: pcsx2/gui/AppConfig.cpp:979
+msgid "Safe (faster)"
+msgstr "Sikrere (hurtigere)"
+
+#: pcsx2/gui/AppConfig.cpp:980
+msgid "Balanced"
+msgstr "Balanceret"
+
+#: pcsx2/gui/AppConfig.cpp:981
+msgid "Aggressive"
+msgstr "Aggressivt"
+
+#: pcsx2/gui/AppConfig.cpp:982
+msgid "Aggressive plus"
+msgstr "Ekstra aggressivt"
+
+#: pcsx2/gui/AppConfig.cpp:983
+msgid "Mostly Harmful"
+msgstr "Mest skadelig"
+
+#: pcsx2/gui/AppConfig.cpp:1143 pcsx2/gui/AppConfig.cpp:1149
+msgid "Failed to overwrite existing settings file; permission was denied."
+msgstr ""
+"Kunne overskrive den eksisterende indstillingsfil: adgangen blev nægtet."
+
+#: pcsx2/gui/AppCorePlugins.cpp:404
+msgid "Loading PS2 system plugins..."
+msgstr "Indlæser PS2 system plugins…."
+
+#: pcsx2/gui/AppInit.cpp:51
+msgid ""
+"SSE2 extensions are not available.  PCSX2 requires a cpu that supports the "
+"SSE2 instruction set."
+msgstr ""
+"SSE2-udvidelser er ikke tilgængelige. PCSX2 kræver en processor, der "
+"understøtter SSE2 instruktionssæt."
+
+#: pcsx2/gui/AppInit.cpp:140
+msgid "PCSX2 Recompiler Error(s)"
+msgstr "PCSX2 recompiler fejl(ene)"
+
+#: pcsx2/gui/AppInit.cpp:219
+msgid "All options are for the current session only and will not be saved.\n"
+msgstr ""
+"Alle valgmuligheder gælder kun for denne session og vil ikke blive gemt.\n"
+
+#: pcsx2/gui/AppInit.cpp:229 pcsx2/gui/AppMain.cpp:363
+msgid "IsoFile"
+msgstr "ISO-fil"
+
+#: pcsx2/gui/AppInit.cpp:230
+msgid "displays this list of command line options"
+msgstr "viser denne liste af kommandolinjeparametre"
+
+#: pcsx2/gui/AppInit.cpp:231
+msgid "forces the program log/console to be visible"
+msgstr "tvinger programmets log/konsol til at være synlig"
+
+#: pcsx2/gui/AppInit.cpp:232
+msgid "use fullscreen GS mode"
+msgstr "brug fuldskærm GS-tilstand"
+
+#: pcsx2/gui/AppInit.cpp:233
+msgid "use windowed GS mode"
+msgstr "brug vindue GS-tilstand"
+
+#: pcsx2/gui/AppInit.cpp:235
+msgid "disables display of the gui while running games"
+msgstr "slår GUI-visningen fra, når man spiller"
+
+#: pcsx2/gui/AppInit.cpp:236
+msgid "when nogui - prompt before exiting on suspend"
+msgstr "når ingenGUI - forespørg inden programmet lukkes"
+
+#: pcsx2/gui/AppInit.cpp:238
+msgid "executes an ELF image"
+msgstr "eksekverer et ELF-billede"
+
+#: pcsx2/gui/AppInit.cpp:239
+msgid "executes an IRX image"
+msgstr "eksekverer et IRX-billede"
+
+#: pcsx2/gui/AppInit.cpp:240
+msgid "boots an empty DVD tray; use to enter the PS2 system menu"
+msgstr "booter et tomt DVD-drev; bruges til at komme ind i PS2-menuen"
+
+#: pcsx2/gui/AppInit.cpp:241
+msgid "boots from the CDVD plugin (overrides IsoFile parameter)"
+msgstr "booter fra CDVD-plugin’et (tilsidesætter ISO-filens parametre)"
+
+#: pcsx2/gui/AppInit.cpp:243
+msgid "disables all speedhacks"
+msgstr "slår alle speedhacks fra"
+
+#: pcsx2/gui/AppInit.cpp:244
+msgid "use the specified comma or pipe-delimited list of gamefixes."
+msgstr "bruger den givne komma- eller pileseparerede liste af spilløsninger."
+
+#: pcsx2/gui/AppInit.cpp:245
+msgid "disables fast booting"
+msgstr "slår hurtig bootning fra"
+
+#: pcsx2/gui/AppInit.cpp:247
+msgid "changes the configuration file path"
+msgstr "ændrer konfigurationens filplacering"
+
+#: pcsx2/gui/AppInit.cpp:248
+msgid "specifies the PCSX2 configuration file to use"
+msgstr "bestemmer hvilken PCSX2-konfigurationsfil, der skal bruges"
+
+#: pcsx2/gui/AppInit.cpp:249
+#, c-format
+msgid "forces %s to start the First-time Wizard"
+msgstr "tvinger %s til at starte installationsguiden"
+
+#: pcsx2/gui/AppInit.cpp:250
+msgid "enables portable mode operation (requires admin/root access)"
+msgstr "aktiverer transportabel modus (kræver admin/root adgang)"
+
+#: pcsx2/gui/AppInit.cpp:252
+msgid "update options to ease profiling (debug)"
+msgstr "opdater muligheder for at lette profilering (fejlfinding)"
+
+#: pcsx2/gui/AppInit.cpp:256
+#, c-format
+msgid "specify the file to use as the %s plugin"
+msgstr "angiv den fil, der skal bruges som %s plugin"
+
+#: pcsx2/gui/AppInit.cpp:306
+#, c-format
+msgid "Plugin Override Error - %s"
+msgstr "Kunne ikke tilsidesætte plugin - %s"
+
+#: pcsx2/gui/AppInit.cpp:309
+#, c-format
+msgid ""
+"%s Plugin Override Error!  The following file does not exist or is not a "
+"valid %s plugin:\n"
+"\n"
+msgstr ""
+"%s Kunne ikke tilsidesætte plugin! Den følgende fil eksisterer ikke eller er "
+"ikke et gyldigt %s plugin:\n"
+"\n"
+
+#: pcsx2/gui/AppInit.cpp:316
+#, c-format
+msgid "Press OK to use the default configured plugin, or Cancel to close %s."
+msgstr ""
+"Tryk OK for at bruge det standardkonfigurerede plugin eller på Annullér for "
+"at lukke %s."
+
+#: pcsx2/gui/AppInit.cpp:531
+msgid "PCSX2 Error: Hardware Deficiency"
+msgstr "PCSX2-Fejl: Hardware ikke tilstrækkelig"
+
+#: pcsx2/gui/AppInit.cpp:531 pcsx2/gui/AppInit.cpp:543
+#, c-format
+msgid "Press OK to close %s."
+msgstr "Tryk OK for at lukke %s."
+
+#: pcsx2/gui/AppInit.cpp:544
+#, c-format
+msgid "%s Critical Error"
+msgstr "%s Kritisk Fejl"
+
+#: pcsx2/gui/AppInit.cpp:714
+msgid "OK"
+msgstr "OK"
+
+#: pcsx2/gui/AppInit.cpp:715
+msgid "&OK"
+msgstr "OK"
+
+#: pcsx2/gui/AppInit.cpp:716
+msgid "Cancel"
+msgstr "Annullér"
+
+#: pcsx2/gui/AppInit.cpp:717
+msgid "&Cancel"
+msgstr "Annullér"
+
+#: pcsx2/gui/AppInit.cpp:718
+msgid "&Apply"
+msgstr "Anvend"
+
+#: pcsx2/gui/AppInit.cpp:719
+msgid "&Next >"
+msgstr "Næste >"
+
+#: pcsx2/gui/AppInit.cpp:720
+msgid "< &Back"
+msgstr "< Tilbage"
+
+#: pcsx2/gui/AppInit.cpp:721
+msgid "&Back"
+msgstr "Tilbage"
+
+#: pcsx2/gui/AppInit.cpp:722
+msgid "&Finish"
+msgstr "Færdig"
+
+#: pcsx2/gui/AppInit.cpp:723
+msgid "&Yes"
+msgstr "Ja"
+
+#: pcsx2/gui/AppInit.cpp:724
+msgid "&No"
+msgstr "Nej"
+
+#: pcsx2/gui/AppInit.cpp:725
+msgid "Browse"
+msgstr "Søg"
+
+#: pcsx2/gui/AppInit.cpp:726
+msgid "&Save"
+msgstr "Gem"
+
+#: pcsx2/gui/AppInit.cpp:727
+msgid "Save &As..."
+msgstr "Gem som…"
+
+#: pcsx2/gui/AppInit.cpp:728
+msgid "&Help"
+msgstr "Hjælp"
+
+#: pcsx2/gui/AppInit.cpp:729
+msgid "&Home"
+msgstr "Hjem"
+
+#: pcsx2/gui/AppInit.cpp:731
+msgid "Show about dialog"
+msgstr "Om"
+
+#: pcsx2/gui/AppMain.cpp:74
+msgid ""
+"\n"
+"\n"
+"Press Ok to go to the Plugin Configuration Panel."
+msgstr ""
+"\n"
+"\n"
+"Tryk OK for at gå til konfiguration af Plugins."
+
+#: pcsx2/gui/AppMain.cpp:131 pcsx2/gui/AppMain.cpp:145
+msgid ""
+"Warning!  System plugins have not been loaded.  PCSX2 may be inoperable."
+msgstr ""
+"Advarsel! Systemplugins blev ikke indlæst. PCSX2 fungerer muligvis ikke "
+"korrekt."
+
+#: pcsx2/gui/AppMain.cpp:179 pcsx2/gui/AppMain.cpp:184
+msgid "PS2 BIOS Error"
+msgstr "PS2 BIOS-Fejl"
+
+#: pcsx2/gui/AppMain.cpp:179
+msgid "Press Ok to go to the BIOS Configuration Panel."
+msgstr "Tryk OK for at gå til konfiguration af BIOS."
+
+#: pcsx2/gui/AppMain.cpp:202
+msgid "Warning! Valid BIOS has not been selected. PCSX2 may be inoperable."
+msgstr ""
+"Advarsel! Der er ikke valgt en gyldig BIOS. PCSX2 fungerer muligvis ikke "
+"korrekt."
+
+#: pcsx2/gui/AppMain.cpp:375
+#, c-format
+msgid "%s Commandline Options"
+msgstr "%s Kommandolinjeparametre"
+
+#: pcsx2/gui/AppMain.cpp:686
+msgid "PCSX2 Unresponsive Thread"
+msgstr "PCSX2 Tråd svarer ikke"
+
+#: pcsx2/gui/AppMain.cpp:693
+msgid "Terminate"
+msgstr "Afslut"
+
+#: pcsx2/gui/AppMain.cpp:1061
+msgid "Executing PS2 Virtual Machine..."
+msgstr "Afvikler den virtuelle PS2-maskine…"
+
+#: pcsx2/gui/AppRes.cpp:66
+msgid "Browse for an ISO that is not in your recent history."
+msgstr "Søg efter en ISO-fil, der ikke er søgt efter tidligere."
+
+#: pcsx2/gui/AppRes.cpp:66
+msgid "Browse..."
+msgstr "Søg…"
+
+#: pcsx2/gui/AppUserMode.cpp:95
+msgid "The following folders exist, but are not writable:"
+msgstr "De følgende mapper eksisterer, men kan ikke skrives til:"
+
+#: pcsx2/gui/AppUserMode.cpp:100
+msgid "The following folders are missing and cannot be created:"
+msgstr "De følgende mapper mangler eller kan ikke oprettes:"
+
+#: pcsx2/gui/AppUserMode.cpp:140
+#, c-format
+msgid "Portable mode error - %s"
+msgstr "Transportable modus fejl - %s"
+
+#: pcsx2/gui/AppUserMode.cpp:153
+msgid ""
+"PCSX2 has been installed as a portable application but cannot run due to the "
+"following errors:"
+msgstr ""
+"PCSX2 er blevet installeret som et transportabelt program og kan ikke køre "
+"på grund af følgende fejl:"
+
+#: pcsx2/gui/AppUserMode.cpp:161
+msgid "Switch to User Documents Mode"
+msgstr "Skift til Brugerdokumenter-modus"
+
+#: pcsx2/gui/AppUserMode.cpp:174
+#, c-format
+msgid "%s is switching to local install mode."
+msgstr "%s skifter til at installere på det lokale drev."
+
+#: pcsx2/gui/AppUserMode.cpp:175
+msgid ""
+"Try to remove the file called \"portable.ini\" from your installation "
+"directory manually."
+msgstr ""
+"Prøver manuelt at fjerne filen, “portable.ini”, fra installationsmappen."
+
+#: pcsx2/gui/ApplyState.h:53
+msgid "Cannot apply new settings, one of the settings is invalid."
+msgstr "Kan ikke anvende nye indstillinger, en af indstillingerne er ugyldig."
+
+#: pcsx2/gui/ConsoleLogger.cpp:115
+msgid "Save log question"
+msgstr "Gem logspørgsmål"
+
+#: pcsx2/gui/ConsoleLogger.cpp:389
+msgid "&Small"
+msgstr "Lille"
+
+#: pcsx2/gui/ConsoleLogger.cpp:389
+msgid "Fits a lot of log in a microcosmically small area."
+msgstr "Masser af logtekst på et meget lille område."
+
+#: pcsx2/gui/ConsoleLogger.cpp:391
+msgid "&Normal font"
+msgstr "Normal font"
+
+#: pcsx2/gui/ConsoleLogger.cpp:391
+msgid "It's what I use (the programmer guy)."
+msgstr "Den bruger jeg (programmøren)."
+
+#: pcsx2/gui/ConsoleLogger.cpp:393
+msgid "&Large"
+msgstr "Stor"
+
+#: pcsx2/gui/ConsoleLogger.cpp:393
+msgid "Its nice and readable."
+msgstr "Den er pæn og læselig."
+
+#: pcsx2/gui/ConsoleLogger.cpp:395
+msgid "&Huge"
+msgstr "Kæmpe"
+
+#: pcsx2/gui/ConsoleLogger.cpp:395
+msgid "In case you have a really high res display."
+msgstr "I tilfælde af, at din skærmopløsning er ret høj."
+
+#: pcsx2/gui/ConsoleLogger.cpp:399
+msgid "&Light theme"
+msgstr "Lyst tema"
+
+#: pcsx2/gui/ConsoleLogger.cpp:399
+msgid "Default soft-tone color scheme."
+msgstr "Standard farveskema med bløde farver."
+
+#: pcsx2/gui/ConsoleLogger.cpp:400
+msgid "&Dark theme"
+msgstr "Mørkt tema"
+
+#: pcsx2/gui/ConsoleLogger.cpp:400
+msgid ""
+"Classic black color scheme for people who enjoy having text seared into "
+"their optic nerves."
+msgstr ""
+"Klassisk sort farveskema til folk, der gerne vil have tekst brændt ind i "
+"deres optiske nerver."
+
+#: pcsx2/gui/ConsoleLogger.cpp:407
+msgid "&Save..."
+msgstr "Gem..."
+
+#: pcsx2/gui/ConsoleLogger.cpp:407
+msgid "Save log contents to file"
+msgstr "Gem log-indhold til fil"
+
+#: pcsx2/gui/ConsoleLogger.cpp:408
+msgid "C&lear"
+msgstr "Slet"
+
+#: pcsx2/gui/ConsoleLogger.cpp:408
+msgid "Clear the log window contents"
+msgstr "Slet indholdet i logvinduet"
+
+#: pcsx2/gui/ConsoleLogger.cpp:410
+msgid "Auto&dock"
+msgstr "Automatisk sammenkobling"
+
+#: pcsx2/gui/ConsoleLogger.cpp:410
+msgid "Dock log window to main PCSX2 window"
+msgstr "Sammenkobl logvinduet til PCSX2 hovedvinduet"
+
+#: pcsx2/gui/ConsoleLogger.cpp:411
+msgid "&Appearance"
+msgstr "Udseende"
+
+#: pcsx2/gui/ConsoleLogger.cpp:413
+msgid "&Close"
+msgstr "Luk"
+
+#: pcsx2/gui/ConsoleLogger.cpp:413
+msgid "Close this log window; contents are preserved"
+msgstr "Lukke dette logvindue; indholdet bevares"
+
+#: pcsx2/gui/ConsoleLogger.cpp:417
+msgid "Dev/&Verbose"
+msgstr "Udvikler/detaljer"
+
+#: pcsx2/gui/ConsoleLogger.cpp:417
+msgid "Shows PCSX2 developer logs"
+msgstr "Viser PCSX2 udviklerlogge"
+
+#: pcsx2/gui/ConsoleLogger.cpp:418
+msgid "&CDVD reads"
+msgstr "CDVD læser"
+
+#: pcsx2/gui/ConsoleLogger.cpp:418
+msgid "Shows disk read activity"
+msgstr "Viser diskens læseaktivitet"
+
+#: pcsx2/gui/ConsoleLogger.cpp:435
+msgid "&Enable all"
+msgstr "Aktivér alle"
+
+#: pcsx2/gui/ConsoleLogger.cpp:435
+msgid "Enables all log source filters."
+msgstr "Aktiverer alle loggens kildefiltre."
+
+#: pcsx2/gui/ConsoleLogger.cpp:436
+msgid "&Disable all"
+msgstr "Deaktivér alle"
+
+#: pcsx2/gui/ConsoleLogger.cpp:436
+msgid "Disables all log source filters."
+msgstr "Deaktiverer alle loggens kildefiltre."
+
+#: pcsx2/gui/ConsoleLogger.cpp:437
+msgid "&Restore Default"
+msgstr "Gendan til standard"
+
+#: pcsx2/gui/ConsoleLogger.cpp:437
+msgid "Restore default source filters."
+msgstr "Gendanner kildefiltrene til deres standard."
+
+#: pcsx2/gui/ConsoleLogger.cpp:439
+msgid "&Log"
+msgstr "Log"
+
+#: pcsx2/gui/ConsoleLogger.cpp:440
+msgid "&Sources"
+msgstr "Kilder"
+
+#: pcsx2/gui/Debugger/DisassemblyDialog.cpp:227
+msgid "panel"
+msgstr "panel"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:35
+#, c-format
+msgid "About %s"
+msgstr "Om %s"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:54
+msgid "Previous versions"
+msgstr "Tidligere versioner"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:54
+msgid "Webmasters"
+msgstr "Webmastere"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:63
+msgid "Plugin Specialists"
+msgstr "Plugin specialister"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:63
+msgid "Special thanks to"
+msgstr "Et særligt tak til"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:75
+msgid "Developers"
+msgstr "Udivklerne"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:77
+msgid "Contributors"
+msgstr "Bidragende"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:86
+msgid "PlayStation 2 Emulator"
+msgstr "PlayStation 2 Emulator"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:89
+msgid "PCSX2 Official Website and Forums"
+msgstr "PCSX2 Officielle hjemmeside og fora"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:93
+msgid "PCSX2 Official Git Repository at GitHub"
+msgstr "PCSX2 Officielle Git-depot på GitHub"
+
+#: pcsx2/gui/Dialogs/AboutBoxDialog.cpp:98
+msgid "I've seen enough"
+msgstr "Jeg har set nok"
+
+#: pcsx2/gui/Dialogs/AssertionDialog.cpp:23
+msgid "Assertion Failure - "
+msgstr "Assertionsfejl - "
+
+#: pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp:185
+msgid "Saves a snapshot of this settings panel to a PNG file."
+msgstr "Gemmer et snapshot af indstillingspanelet til en .PNG-fil."
+
+#: pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp:291
+msgid "Save dialog screenshots to..."
+msgstr "Gemmer skærmbilleder af dialogen til..."
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:195
+msgid "Do not show this dialog again."
+msgstr "Vis ikke denne dialog igen."
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:201
+msgid ""
+"Disables this popup and whatever response you select here will be "
+"automatically used from now on."
+msgstr ""
+"Afbryder dette vindue. Det, du vælger her, vil blive valgt automatisk "
+"fremover."
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:203
+msgid ""
+"The popup will not be shown again.  This setting can be undone from the "
+"settings panels."
+msgstr ""
+"Dette vindue vil ikke blive vist igen. Denne indstilling kan laves om under "
+"indstillinger."
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:249
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:294
+msgid "Ignore"
+msgstr "Ignorer"
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:267
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:276
+msgid "Retry"
+msgstr "Prøv igen"
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:270
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:273
+msgid "Abort"
+msgstr "Afbryd"
+
+#: pcsx2/gui/Dialogs/ConfirmationDialogs.cpp:280
+msgid "Reset"
+msgstr "Nulstil"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:36
+msgid "Convert a memory card to a different format"
+msgstr "Konverter et memory card til et andet format"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:47
+msgid "Convert"
+msgstr "Konverter"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:53
+msgid "Convert: "
+msgstr "Konverter: "
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:56
+msgid "To: "
+msgstr "Til: "
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:87
+msgid "8MB File"
+msgstr "8MB-fil"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:89
+msgid "16MB File"
+msgstr "16MB-fil"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:91
+msgid "32MB File"
+msgstr "32MB-fil"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:93
+msgid "64MB File"
+msgstr "64MB-fil"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:95
+msgid "Convert this memory card to a folder of individual saves."
+msgstr "Konverter dette memory card til en mappe med særskilte gemte data."
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:95
+msgid "Folder"
+msgstr "Mappe"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:122
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:151
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:815
+#, c-format
+msgid "Error (%s)"
+msgstr "Fejl (%s)"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:123
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:153
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:159
+msgid "Convert memory card"
+msgstr "Konverter memory card"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:153
+msgid "This target type is not supported!"
+msgstr "Denne måltype understøttes ikke!"
+
+#: pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp:159
+msgid "Memory Card conversion failed for unknown reasons."
+msgstr "Memory card konvertering fejlede af ukendte årsager."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:41
+msgid "Create a new memory card"
+msgstr "Opret et nyt memory card"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:59
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:73
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:271
+msgid "Create"
+msgstr "Opret"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:71
+msgid "New memory card:"
+msgstr "Nyt memory card:"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:72
+msgid "At folder:    "
+msgstr "I mappe:    "
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:75
+msgid "Select file name: "
+msgstr "Vælg filnavn: "
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:152
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:164
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:179
+msgid "Create memory card"
+msgstr "Opret memory card"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:163
+msgid "Error: The directory for the memory card could not be created."
+msgstr "Fejl: Mappen til memory cardet kunne ikke oprettes."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:178
+msgid "Error: The memory card could not be created."
+msgstr "Fejl: Memory cardet kunne ikke oprettes."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:193
+msgid "Use NTFS compression when creating this card."
+msgstr "Brug NTFS-kompression ved oprettelse af dette kort."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:210
+msgid "8 MB [most compatible]"
+msgstr "8MB [mest kompatibel]"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:210
+msgid ""
+"This is the standard Sony-provisioned size, and is supported by all games "
+"and BIOS versions."
+msgstr ""
+"Denne størrelse brugte Sony som standard, og den understøttes af alle spil "
+"og BIOS’er."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:211
+msgid ""
+"Always use this option if you want the safest and surest memory card "
+"behavior."
+msgstr ""
+"Brug altid denne valgmulighed, hvis du vil have det hurtigste og pålidelige "
+"memory card."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:214
+msgid "16 MB"
+msgstr "16MB"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:214
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:218
+msgid ""
+"A typical size for 3rd-party memory cards which should work with most games."
+msgstr ""
+"En typisk størrelse for tredjeparts memory cards som bør vike i de fleste "
+"spil."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:215
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:219
+msgid "16 and 32 MB cards have roughly the same compatibility factor."
+msgstr "16MB og 32MB kort har omtrent den samme kompatibilitetsfaktor."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:218
+msgid "32 MB"
+msgstr "32MB"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:222
+msgid "64 MB"
+msgstr "64MB"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:222
+msgid ""
+"Low compatibility warning: Yes it's very big, but may not work with many "
+"games."
+msgstr ""
+"Advarsel om lav kompatibilitet: Kortet er stort, ja, men virker ikke til "
+"mange spil."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:223
+msgid ""
+"Use at your own risk.  Erratic memory card behavior is possible (though "
+"unlikely)."
+msgstr ""
+"Brug på egen risiko. Uregelmæssig memory card adfærd er mulig (dog "
+"usandsynligt)."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:226
+msgid "Folder [experimental]"
+msgstr "Mappe [eksperimentel]"
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:226
+msgid "Store memory card contents in the host filesystem instead of a file."
+msgstr "Gemmer memory card indhold i værtsfilsystemet i stedet for en fil."
+
+#: pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp:227
+msgid ""
+"Automatically manages memory card contents so that the console only sees "
+"files related to the currently running software. Allows you to drag-and-drop "
+"files in and out of the memory card with your standard file explorer. This "
+"is still experimental, so use at your own risk!"
+msgstr ""
+"Tager sig automatisk af memory card indhold, så konsollen kun ser filer "
+"relateret til den software, der i øjeblikket kører. Tillader, at du kan "
+"trække og slippe filer ind og ud af dit memory card med din foretrukne "
+"stifinder. Dette er stadig eksperimentelt, så brug på egen risiko!"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:47
+#, c-format
+msgid "Select a folder for %s settings"
+msgstr "Vælg en mappe til %s indstillinger"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:47
+msgid "Settings"
+msgstr "Indstillinger"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:83
+msgid "Language selector"
+msgstr "Vælg sprog"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:86
+msgid ""
+"Change the language only if you need to.\n"
+"The system default should be fine for most operating systems."
+msgstr ""
+"Ændr kun sproget, hvis nødvendigt.\n"
+"Systemsproget passer fint på de fleste operativsystemer."
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:92
+msgid "Welcome to PCSX2!"
+msgstr "Velkommen til PCSX2!"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:103
+msgid "Configuration Guides (online)"
+msgstr "Konfigurationsguides (online)"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:107
+msgid "Readme / FAQ (Offline/PDF)"
+msgstr "Readme / FAQ (Offline/PDF)"
+
+#: pcsx2/gui/Dialogs/FirstTimeWizard.cpp:116
+#, c-format
+msgid "%s First Time Configuration"
+msgstr "%s Førstegangsopsætning"
+
+#: pcsx2/gui/Dialogs/GameDatabaseDialog.cpp:24
+#, c-format
+msgid "Game database - %s"
+msgstr "Spildatabase - %s"
+
+#: pcsx2/gui/Dialogs/ImportSettingsDialog.cpp:24
+msgid "Import Existing Settings?"
+msgstr "Importer eksisterende indstillinger?"
+
+#: pcsx2/gui/Dialogs/ImportSettingsDialog.cpp:36
+msgid "Import"
+msgstr "Importer"
+
+#: pcsx2/gui/Dialogs/ImportSettingsDialog.cpp:37
+msgid "Overwrite"
+msgstr "Overskriv"
+
+#: pcsx2/gui/Dialogs/LogOptionsDialog.cpp:27
+msgid "Trace Logging"
+msgstr "Sporingslogføring"
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:38
+msgid "Auto-eject memory cards when loading savestates"
+msgstr ""
+"Skub automatisk memory cards ud, når gemte spiltilstande bliver indlæst"
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:44
+msgid "Automatically manage saves based on running game"
+msgstr "Administrer automatisk gemte tilstande baseret på det kørende spil"
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:101
+msgid "MemoryCard Manager"
+msgstr "Memory card manager"
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:116
+msgid "Drag cards to or from PS2-ports"
+msgstr "Træk kort til eller fra PS2-porte"
+
+#: pcsx2/gui/Dialogs/McdConfigDialog.cpp:117
+msgid ""
+"\n"
+"Note: Duplicate/Rename/Create/Delete will NOT be reverted with 'Cancel'."
+msgstr ""
+"\n"
+"Bemærk: Duplikér/Omdøb/Opret/Slet kan IKKE gøres om via ‘Annullér’."
+
+#: pcsx2/gui/Dialogs/PickUserModeDialog.cpp:24
+msgid "PCSX2 First Time configuration"
+msgstr "PCSX2 Førstegangsopsætning"
+
+#: pcsx2/gui/Dialogs/PickUserModeDialog.cpp:29
+#, c-format
+msgid "%s is starting from a new or unknown folder and needs to be configured."
+msgstr "%s starter fra en ny eller ukendt mappe og skal konfigureres."
+
+#: pcsx2/gui/Dialogs/StuckThreadDialog.cpp:28
+msgid "PCSX2 Thread is not responding"
+msgstr "PCSX2 Tråd svarer ikke"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:36
+msgid "Config Overrides Warning"
+msgstr "Advarsel om tilsidesættelse af konfiguration"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:53
+msgid "Components Overrides Warning"
+msgstr "Advarsel om tilsidesættelse af komponenter"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:134
+msgid "Preset:"
+msgstr "Forudindstilling:"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:212
+#, c-format
+msgid "Emulation Settings - %s"
+msgstr "Emuleringsindstillinger - %s"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:221
+msgid "EE/IOP"
+msgstr "EE/IOP"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:222
+msgid "VUs"
+msgstr "VU’er"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:223
+msgid "GS"
+msgstr "GS"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:224
+msgid "GS Window"
+msgstr "GS-vindue"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:225
+msgid "Speedhacks"
+msgstr "Speedhacks"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:226
+msgid "Game Fixes"
+msgstr "Spilløsninger"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:239
+#, c-format
+msgid "Components Selectors - %s"
+msgstr "Vælg komponenter - %s"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:246
+msgid "Plugins"
+msgstr "Plugins"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:247
+msgid "BIOS"
+msgstr "BIOS"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:248
+msgid "Folders"
+msgstr "Mapper"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:261
+#, c-format
+msgid "Appearance/Themes - %s"
+msgstr "Udseende/Temaer - %s"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:268
+msgid "Appearance"
+msgstr "Udseende"
+
+#: pcsx2/gui/Dialogs/SysConfigDialog.cpp:278
+msgid "Language Selector"
+msgstr "Vælg sprog"
+
+#: pcsx2/gui/ExecutorThread.cpp:41
+msgid "Logs events as they are passed to the PS2 virtual machine."
+msgstr ""
+"Logger begivenheder, når de bliver givet videre til den virtuelle PS2-"
+"maskine."
+
+#: pcsx2/gui/ExecutorThread.cpp:430
+msgid "Press Cancel to attempt to cancel the action."
+msgstr "Tryk Annullér for at forsøge at afbryde handlingen."
+
+#: pcsx2/gui/ExecutorThread.cpp:431
+#, c-format
+msgid "Press Terminate to kill %s immediately."
+msgstr "Tryk Afslut for at lukke %s med det samme."
+
+#: pcsx2/gui/ExecutorThread.cpp:434
+msgid "Terminate App"
+msgstr "Afslut program"
+
+#: pcsx2/gui/FrameForGS.cpp:444
+msgid "GS Output is Disabled!"
+msgstr "GS-output er slået fra!"
+
+#: pcsx2/gui/GlobalCommands.cpp:309
+msgid "Exit PCSX2?"
+msgstr "Luk PCSX2?"
+
+#: pcsx2/gui/GlobalCommands.cpp:474
+msgid "Save state"
+msgstr "Gem tilstand"
+
+#: pcsx2/gui/GlobalCommands.cpp:475
+msgid "Saves the virtual machine state to the current slot."
+msgstr "Gemmer den virtuelle maskines tilstand til dets nuværende gemmeplads."
+
+#: pcsx2/gui/GlobalCommands.cpp:481
+msgid "Load state"
+msgstr "Indlæs tilstand"
+
+#: pcsx2/gui/GlobalCommands.cpp:482
+msgid "Loads a virtual machine state from the current slot."
+msgstr ""
+"Indlæser den virtuelle maskines tilstand fra dets nuværende gemmeplads."
+
+#: pcsx2/gui/GlobalCommands.cpp:488
+msgid "Load State Backup"
+msgstr "Indlæs tilstandsbackup"
+
+#: pcsx2/gui/GlobalCommands.cpp:489
+msgid "Loads virtual machine state backup for current slot."
+msgstr ""
+"Indlæser den virtuelle maskines tilstandsbackup fra dets nuværende "
+"gemmeplads."
+
+#: pcsx2/gui/GlobalCommands.cpp:495
+msgid "Cycle to next slot"
+msgstr "Gå videre til næste gemmeplads"
+
+#: pcsx2/gui/GlobalCommands.cpp:496
+msgid "Cycles the current save slot in +1 fashion!"
+msgstr "Vælger den næste gemmeplads i rækken!"
+
+#: pcsx2/gui/GlobalCommands.cpp:502
+msgid "Cycle to prev slot"
+msgstr "Gå tilbage til tidligere gemmeplads"
+
+#: pcsx2/gui/GlobalCommands.cpp:503
+msgid "Cycles the current save slot in -1 fashion!"
+msgstr "Går en gemmeplads tilbage!"
+
+#: pcsx2/gui/IsoDropTarget.cpp:55
+msgid "Drag and Drop Error"
+msgstr "Træk og Slip Fejl"
+
+#: pcsx2/gui/IsoDropTarget.cpp:56
+#, c-format
+msgid ""
+"It is an error to drop multiple files onto a %s window.  One at a time "
+"please, thank you."
+msgstr ""
+"%s melder fejl, hvis man smider flere filer ind på en gang. Kun en ad "
+"gangen, tak."
+
+#: pcsx2/gui/IsoDropTarget.cpp:87 pcsx2/gui/MainMenuClicks.cpp:355
+msgid "Confirm PS2 Reset"
+msgstr "Bekræft nulstilling af PS2"
+
+#: pcsx2/gui/IsoDropTarget.cpp:89
+#, c-format
+msgid ""
+"You have dropped the following ELF binary into %s:\n"
+"\n"
+msgstr ""
+"Du har indlæst følgende ELF-binær i %s:\n"
+"\n"
+"\n"
+
+#: pcsx2/gui/IsoDropTarget.cpp:133
+#, c-format
+msgid "You have dropped the following ISO image into %s:"
+msgstr "Du har indlæst følgende ISO-billede i %s:"
+
+#: pcsx2/gui/MainFrame.cpp:39
+#, c-format
+msgid "Slot %d"
+msgstr "Gemmeplads %d"
+
+#: pcsx2/gui/MainFrame.cpp:45 pcsx2/gui/Saveslots.cpp:150
+msgid "Backup"
+msgstr "Backup"
+
+#: pcsx2/gui/MainFrame.cpp:327
+msgid "&Show Console"
+msgstr "Vis konsol"
+
+#: pcsx2/gui/MainFrame.cpp:329
+msgid "&Console to Stdio"
+msgstr "Konsol til Stdio"
+
+#: pcsx2/gui/MainFrame.cpp:343
+msgid "&System"
+msgstr "System"
+
+#: pcsx2/gui/MainFrame.cpp:344
+msgid "CD&VD"
+msgstr "CDVD"
+
+#: pcsx2/gui/MainFrame.cpp:345
+msgid "&Config"
+msgstr "Redigér"
+
+#: pcsx2/gui/MainFrame.cpp:346
+msgid "&Misc"
+msgstr "Diverse"
+
+#: pcsx2/gui/MainFrame.cpp:347
+msgid "&Debug"
+msgstr "Debug"
+
+#: pcsx2/gui/MainFrame.cpp:411 pcsx2/gui/MainFrame.cpp:413
+#: pcsx2/gui/MainFrame.cpp:419
+msgid "Initializing..."
+msgstr "Initialiserer…"
+
+#: pcsx2/gui/MainFrame.cpp:415
+msgid "&Run ELF..."
+msgstr "Kør ELF…"
+
+#: pcsx2/gui/MainFrame.cpp:416
+msgid "For running raw PS2 binaries directly"
+msgstr "Til at køre rå PS2-binære direkte"
+
+#: pcsx2/gui/MainFrame.cpp:425
+msgid "&Load state"
+msgstr "Indlæs tilstand"
+
+#: pcsx2/gui/MainFrame.cpp:426
+msgid "&Save state"
+msgstr "Gem tilstand"
+
+#: pcsx2/gui/MainFrame.cpp:428
+msgid "&Backup before save"
+msgstr "Backup før gem"
+
+#: pcsx2/gui/MainFrame.cpp:433
+msgid "Automatic &Gamefixes"
+msgstr "Automatiske spilløsninger"
+
+#: pcsx2/gui/MainFrame.cpp:434
+msgid "Automatically applies needed Gamefixes to known problematic games"
+msgstr ""
+"Anvender automatisk nødvendige spilløsninger til spil med kendte spilfejl"
+
+#: pcsx2/gui/MainFrame.cpp:436
+msgid "Enable &Cheats"
+msgstr "Aktivér snyd"
+
+#: pcsx2/gui/MainFrame.cpp:439
+msgid "Enable &Widescreen Patches"
+msgstr "Aktivér bredskærmsløsninger"
+
+#: pcsx2/gui/MainFrame.cpp:443
+msgid "Enable &Host Filesystem"
+msgstr "Aktivér værtsfilsystem"
+
+#: pcsx2/gui/MainFrame.cpp:448
+msgid "Shut&down"
+msgstr "Luk ned"
+
+#: pcsx2/gui/MainFrame.cpp:449
+msgid "Wipes all internal VM states and shuts down plugins."
+msgstr "Sletter all interne VM-tilstande og lukker alle pugins ned."
+
+#: pcsx2/gui/MainFrame.cpp:452
+msgid "E&xit"
+msgstr "Afslut"
+
+#: pcsx2/gui/MainFrame.cpp:453
+#, c-format
+msgid "Closing %s may be hazardous to your health"
+msgstr "Hvis du lukker %s, kan det være farligt for dit helbred"
+
+#: pcsx2/gui/MainFrame.cpp:460
+msgid "ISO &Selector"
+msgstr "Vælg ISO"
+
+#: pcsx2/gui/MainFrame.cpp:461
+msgid "Plugin &Menu"
+msgstr "Plugin menu"
+
+#: pcsx2/gui/MainFrame.cpp:464
+msgid "&ISO"
+msgstr "ISO"
+
+#: pcsx2/gui/MainFrame.cpp:464
+msgid "Makes the specified ISO image the CDVD source."
+msgstr "Gør det valgte ISO-billede til CDVD-kilden."
+
+#: pcsx2/gui/MainFrame.cpp:465
+msgid "&Plugin"
+msgstr "Plugin"
+
+#: pcsx2/gui/MainFrame.cpp:465
+msgid "Uses an external plugin as the CDVD source."
+msgstr "Brug et eksterne plugin som CDVD-kilden."
+
+#: pcsx2/gui/MainFrame.cpp:466
+msgid "&No disc"
+msgstr "Ingen disk"
+
+#: pcsx2/gui/MainFrame.cpp:466
+msgid "Use this to boot into your virtual PS2's BIOS configuration."
+msgstr "Brug denne for at boote din virtuelle PS2’s BIOS-konfiguration."
+
+#: pcsx2/gui/MainFrame.cpp:474
+msgid "Emulation &Settings"
+msgstr "Emuleringsindstillinger"
+
+#: pcsx2/gui/MainFrame.cpp:475
+msgid "&Memory cards"
+msgstr "Memory cards"
+
+#: pcsx2/gui/MainFrame.cpp:476
+msgid "&Plugin/BIOS Selector"
+msgstr "Vælg BIOS/Plugin"
+
+#: pcsx2/gui/MainFrame.cpp:477
+msgid "&Game Database Editor"
+msgstr "Ændr spildatabase"
+
+#: pcsx2/gui/MainFrame.cpp:483
+msgid "&Video (GS)"
+msgstr "Video (GS)"
+
+#: pcsx2/gui/MainFrame.cpp:484
+msgid "&Audio (SPU2)"
+msgstr "Lyd (SPU2)"
+
+#: pcsx2/gui/MainFrame.cpp:485
+msgid "&Controllers (PAD)"
+msgstr "Controllere (PAD)"
+
+#: pcsx2/gui/MainFrame.cpp:486
+msgid "&Dev9"
+msgstr "Dev9"
+
+#: pcsx2/gui/MainFrame.cpp:487
+msgid "&USB"
+msgstr "USB"
+
+#: pcsx2/gui/MainFrame.cpp:488
+msgid "&Firewire"
+msgstr "Firewire"
+
+#: pcsx2/gui/MainFrame.cpp:494
+msgid "Multitap &1"
+msgstr "Multitap 1"
+
+#: pcsx2/gui/MainFrame.cpp:495
+msgid "Multitap &2"
+msgstr "Multitap 2"
+
+#: pcsx2/gui/MainFrame.cpp:498
+msgid "C&lear all settings..."
+msgstr "Slet alle indstillinger…"
+
+#: pcsx2/gui/MainFrame.cpp:499
+#, c-format
+msgid "Clears all %s settings and re-runs the startup wizard."
+msgstr "Sletter alle %s indstillinger og kører installationsguiden igen."
+
+#: pcsx2/gui/MainFrame.cpp:521
+msgid "&About..."
+msgstr "Om…"
+
+#: pcsx2/gui/MainFrame.cpp:526
+msgid "&Open Debug Window..."
+msgstr "Åbn debug-vinduet…"
+
+#: pcsx2/gui/MainFrame.cpp:529
+msgid "&Logging..."
+msgstr "Logning…"
+
+#: pcsx2/gui/MainFrame.cpp:609
+msgid "Paus&e"
+msgstr "Pause"
+
+#: pcsx2/gui/MainFrame.cpp:610
+msgid "Safely pauses emulation and preserves the PS2 state."
+msgstr "Pauser emuleringen og beholder PS2’ens tilstand sikkert."
+
+#: pcsx2/gui/MainFrame.cpp:617
+msgid "R&esume"
+msgstr "Fortsæt"
+
+#: pcsx2/gui/MainFrame.cpp:618
+msgid "Resumes the suspended emulation state."
+msgstr "Fortsætter den afbrudte emuleringstilstand."
+
+#: pcsx2/gui/MainFrame.cpp:622
+msgid "Pause/Resume"
+msgstr "Pause/Fortsæt"
+
+#: pcsx2/gui/MainFrame.cpp:623
+msgid "No emulation state is active; cannot suspend or resume."
+msgstr "Ingen emuleringstilstand er aktiv; kan ikke afbryde eller fortsætte."
+
+#: pcsx2/gui/MainFrame.cpp:632
+msgid "Res&tart"
+msgstr "Genstart"
+
+#: pcsx2/gui/MainFrame.cpp:633
+msgid "Simulates hardware reset of the PS2 virtual machine."
+msgstr "Simulerer hardwaregenstart af den virtuelle PS2-maskine."
+
+#: pcsx2/gui/MainFrame.cpp:638
+msgid "No emulation state is active; boot something first."
+msgstr "Ingen emuleringstilstand er aktiv; du skal først boote noget."
+
+#: pcsx2/gui/MainFrame.cpp:655
+msgid "Use fast boot to skip PS2 startup and splash screens"
+msgstr "Brug hutig-start for at springe PS2 menuer, osv. over"
+
+#: pcsx2/gui/MainFrame.cpp:660
+msgid "Boot ISO (&fast)"
+msgstr "Boot ISO (hurtig)"
+
+#: pcsx2/gui/MainFrame.cpp:663
+msgid "Boot CDVD (&fast)"
+msgstr "Boot CDVD (hurtig)"
+
+#: pcsx2/gui/MainFrame.cpp:687
+msgid "Boo&t ISO (full)"
+msgstr "Boot ISO (fuld)"
+
+#: pcsx2/gui/MainFrame.cpp:688
+msgid "Boot the VM using the current ISO source media"
+msgstr "Boot VM’en med den nuværende ISO-kilde"
+
+#: pcsx2/gui/MainFrame.cpp:691
+msgid "Boo&t CDVD (full)"
+msgstr "Boot CDVD (fuld)"
+
+#: pcsx2/gui/MainFrame.cpp:692
+msgid "Boot the VM using the current CD/DVD source media"
+msgstr "Boot VM’en med den nuværende CD/DVD-kilde"
+
+#: pcsx2/gui/MainFrame.cpp:695
+msgid "Boo&t BIOS"
+msgstr "Boot BIOS"
+
+#: pcsx2/gui/MainFrame.cpp:696
+msgid "Boot the VM without any source media"
+msgstr "Boot VM’en uden nogen mediekilde"
+
+#: pcsx2/gui/MainFrame.cpp:777 pcsx2/gui/MainFrame.cpp:812
+msgid "No plugin loaded"
+msgstr "Ingen plugin indlæst"
+
+#: pcsx2/gui/MainFrame.cpp:782
+msgid "&Core GS Settings..."
+msgstr "Kerne GS Indstillinger…"
+
+#: pcsx2/gui/MainFrame.cpp:783
+msgid ""
+"Modify hardware emulation settings regulated by the PCSX2 core virtual "
+"machine."
+msgstr ""
+"Modificér hardwareemuleringsindstillingerne kontrolleret af PCSX2-kernens "
+"virtuelle maskine."
+
+#: pcsx2/gui/MainFrame.cpp:785
+msgid "&Window Settings..."
+msgstr "Vindueindstillinger…"
+
+#: pcsx2/gui/MainFrame.cpp:786
+msgid "Modify window and appearance options, including aspect ratio."
+msgstr ""
+"Modificér indstillinger for vindue og udseende, det inkluderer billedformat."
+
+#: pcsx2/gui/MainFrame.cpp:793
+msgid "&Plugin Settings..."
+msgstr "Plugin indstillinger…"
+
+#: pcsx2/gui/MainFrame.cpp:794
+#, c-format
+msgid "Opens the %s plugin's advanced settings dialog."
+msgstr "Åbner %s pluginnets avancerede indstillingsdialog."
+
+#: pcsx2/gui/MainMenuClicks.cpp:120
+msgid "Reset all settings?"
+msgstr "Nulstil alle indstillinger?"
+
+#: pcsx2/gui/MainMenuClicks.cpp:148
+msgid "Confirm ISO image change"
+msgstr "Bekræft ændring af ISO-billede"
+
+#: pcsx2/gui/MainMenuClicks.cpp:154
+msgid "Do you want to swap discs or boot the new image (via system reset)?"
+msgstr "Vil du skifte disk eller boote det nye billede (via nulstil system?"
+
+#: pcsx2/gui/MainMenuClicks.cpp:156 pcsx2/gui/MainMenuClicks.cpp:202
+msgid "Swap Disc"
+msgstr "Skift disk"
+
+#: pcsx2/gui/MainMenuClicks.cpp:192
+msgid "Confirm CDVD source change"
+msgstr "Bekræft ændring af CDVD-kilden"
+
+#: pcsx2/gui/MainMenuClicks.cpp:195
+#, c-format
+msgid "You've selected to switch the CDVD source from %s to %s."
+msgstr "Du har valgt at skifte CDVD-kilden fra %s til %s."
+
+#: pcsx2/gui/MainMenuClicks.cpp:199
+msgid "Do you want to swap discs or boot the new image (system reset)?"
+msgstr "Vil du skifte disk eller boote det nye billede (nulstil system)?"
+
+#: pcsx2/gui/MainMenuClicks.cpp:271
+#, c-format
+msgid "All Supported (%s)"
+msgstr "Alle understøttede (%s)"
+
+#: pcsx2/gui/MainMenuClicks.cpp:274
+#, c-format
+msgid "Disc Images (%s)"
+msgstr "Diskbilleder (%s)"
+
+#: pcsx2/gui/MainMenuClicks.cpp:277
+#, c-format
+msgid "Blockdumps (%s)"
+msgstr "Blok dumps (%s)"
+
+#: pcsx2/gui/MainMenuClicks.cpp:280
+#, c-format
+msgid "Compressed (%s)"
+msgstr "Komprimeret (%s)"
+
+#: pcsx2/gui/MainMenuClicks.cpp:283 pcsx2/gui/MainMenuClicks.cpp:304
+msgid "All Files (*.*)"
+msgstr "Alle filer (*.*)"
+
+#: pcsx2/gui/MainMenuClicks.cpp:286
+msgid "Select disc image, compressed disc image, or block-dump..."
+msgstr "Vælg diskbillede, komprimeret diskbillede, eller blokdump…"
+
+#: pcsx2/gui/MainMenuClicks.cpp:303
+msgid "Select ELF file..."
+msgstr "Vælg ELF-fil…"
+
+#: pcsx2/gui/MainMenuClicks.cpp:329
+msgid "ISO file not found!"
+msgstr "ISO-fil ikke fundet!"
+
+#: pcsx2/gui/MainMenuClicks.cpp:331
+msgid "An error occurred while trying to open the file:"
+msgstr "Der skete en fejl, da filen blev forsøgt åbnet:"
+
+#: pcsx2/gui/MainMenuClicks.cpp:332
+msgid ""
+"Error: The configured ISO file does not exist.  Click OK to select a new ISO "
+"source for CDVD."
+msgstr ""
+"Fejl: Den valgt ISO-fil eksisterer ikke. Tryk OK for at vælge en ny ISO-"
+"kilde til CDVD."
+
+#: pcsx2/gui/MainMenuClicks.cpp:403
+msgid ""
+"You have selected the following ISO image into PCSX2:\n"
+"\n"
+msgstr ""
+"Du har valgt følgende ISO-billede i PCSX2:\n"
+"\n"
+
+#: pcsx2/gui/MemoryCardFile.cpp:193
+#, c-format
+msgid ""
+"Could not create a memory card: \n"
+"\n"
+"%s\n"
+"\n"
+msgstr ""
+"Kunne ikke oprette et memory card:\n"
+"\n"
+"%s\n"
+"\n"
+
+#: pcsx2/gui/MemoryCardFile.cpp:211
+#, c-format
+msgid ""
+"Access denied to memory card: \n"
+"\n"
+"%s\n"
+"\n"
+msgstr ""
+"Adgang til memory card nægtet:\n"
+"\n"
+"%s\n"
+"\n"
+
+#: pcsx2/gui/MemoryCardFile.cpp:678
+msgid "File name empty or too short"
+msgstr "Intet filnavn eller filnavnet er for kort"
+
+#: pcsx2/gui/MemoryCardFile.cpp:683
+msgid "File name outside of required directory"
+msgstr "Filnavnet findes ikke på den angivne placering"
+
+#: pcsx2/gui/MemoryCardFile.cpp:689 pcsx2/gui/MemoryCardFile.cpp:694
+msgid "File name already exists"
+msgstr "Filnavnet eksisterer allerede"
+
+#: pcsx2/gui/MemoryCardFile.cpp:701
+msgid "The Operating-System prevents this file from being created"
+msgstr "Operativsystemet forhindrer denne fil i at blive oprettet"
+
+#: pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp:103
+msgid "Cannot apply settings..."
+msgstr "Kan ikke anvende indstillingerne…"
+
+#: pcsx2/gui/Panels/BiosSelectorPanel.cpp:104
+msgid "BIOS Search Path:"
+msgstr "BIOS søgesti:"
+
+#: pcsx2/gui/Panels/BiosSelectorPanel.cpp:105
+msgid "Select folder with PS2 BIOS roms"
+msgstr "Vælg mappe med PS2 BIOS-roms"
+
+#: pcsx2/gui/Panels/BiosSelectorPanel.cpp:112
+msgid ""
+"Click the Browse button to select a different folder where PCSX2 will look "
+"for PS2 BIOS roms."
+msgstr ""
+"Tryk på Søg-knappen for at vælge en anden mappe, hvor PCSX2 skal kigge efter "
+"PS2 BIOS-roms."
+
+#: pcsx2/gui/Panels/BiosSelectorPanel.cpp:114
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:195
+#: pcsx2/gui/Panels/ThemeSelectorPanel.cpp:48
+msgid "Refresh list"
+msgstr "Opdatér listen"
+
+#: pcsx2/gui/Panels/BiosSelectorPanel.cpp:116
+msgid "Select a BIOS rom:"
+msgstr "Vælg en BIOS-rom:"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:24
+msgid "Round Mode"
+msgstr "Afrundingsmodus"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:25
+msgid "Clamping Mode"
+msgstr "Clamping-modus"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:29
+msgid "Nearest"
+msgstr "Nærmeste"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:30
+msgid "Negative"
+msgstr "Negativ"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:31
+msgid "Positive"
+msgstr "Positiv"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:32
+msgid "Chop / Zero"
+msgstr "Hakke / Nul"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:37
+msgid "None"
+msgstr "Ingen"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:38
+msgid "Normal"
+msgstr "Normal"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:86
+msgid "EE/FPU Advanced Recompiler Options"
+msgstr "EE/FPU avancerede recompilerindstillinger"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:88 pcsx2/gui/Panels/CpuPanel.cpp:103
+msgid "Extra + Preserve Sign"
+msgstr "Ekstra + Behold tegn"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:89
+msgid "Full"
+msgstr "Fuld"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:100
+msgid "VU0 / VU1 Advanced Recompiler Options"
+msgstr "VU0 / VU1 avancerede recompilerindstillinger"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:102
+msgid "Extra"
+msgstr "Ekstra"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:117 pcsx2/gui/Panels/CpuPanel.cpp:126
+#: pcsx2/gui/Panels/CpuPanel.cpp:185
+msgid "Interpreter"
+msgstr "Tolkningsprogram"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:118
+msgid "Quite possibly the slowest thing in the universe."
+msgstr "Nok det mest langsomme i universet."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:120 pcsx2/gui/Panels/CpuPanel.cpp:129
+msgid "Recompiler"
+msgstr "Recompiler"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:121
+msgid ""
+"Performs just-in-time binary translation of 64-bit MIPS-IV machine code to "
+"x86."
+msgstr ""
+"Udfører en ’just-in-time’ binæroversættelse af 64-bit MIPS-IV maskinkoden "
+"til x84."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:127
+msgid "Pretty slow; provided for diagnostic purposes only."
+msgstr "Meget langsomt; bruges kun til at diagnosticere."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:130
+msgid ""
+"Performs just-in-time binary translation of 32-bit MIPS-I machine code to "
+"x86."
+msgstr ""
+"Udfører en ‘just-in-time’ binæroversættelse af 32 MIPS-1 maskinkoden til x84."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:154
+msgid "Enable EE Cache (Slower)"
+msgstr "Aktivér EE Cache (langsommere)"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:154
+msgid "Interpreter only; provided for diagnostic"
+msgstr "Kun til tolkningsprogram; bruges til at diagnosticere"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:170 pcsx2/gui/Panels/CpuPanel.cpp:226
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:129
+msgid "Restore Defaults"
+msgstr "Gendan standardindstillinger"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:186
+msgid ""
+"Vector Unit Interpreter. Slow and not very compatible. Only use for "
+"diagnostics."
+msgstr ""
+"Vector Unit tolkningsprogram. Langsomt og ikke særlig kompatibelt. Bruges "
+"kun til diagnosticere."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:188
+msgid "microVU Recompiler"
+msgstr "microVU Recompiler"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:189
+msgid ""
+"New Vector Unit recompiler with much improved compatibility. Recommended."
+msgstr ""
+"Ny Vector Unit recompiler med meget forbedret kompatibilitet. Anbefalet."
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:192
+msgid "superVU Recompiler [legacy]"
+msgstr "superVU Recompiler [forældet]"
+
+#: pcsx2/gui/Panels/CpuPanel.cpp:193
+msgid ""
+"Useful for diagnosing bugs or clamping issues in the new mVU recompiler."
+msgstr ""
+"Nyttigt til at diagnosticere bugs og clamping-problemer i den nye mVU "
+"recompiler."
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:64
+msgid "Path does not exist"
+msgstr "Stien eksisterer ikke"
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:155
+msgid "Use default setting"
+msgstr "Brug standardindstillinger"
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:174
+msgid "Open in Explorer"
+msgstr "Åbn i stifinder"
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:175
+msgid "Open an explorer window to this folder."
+msgstr "Åbn mappen i stifinder."
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:266
+msgid "Create folder?"
+msgstr "Opret mappe?"
+
+#: pcsx2/gui/Panels/DirPickerPanel.cpp:267
+#, c-format
+msgid "A configured folder does not exist.  Should %s try to create it?"
+msgstr ""
+"Der eksisterer ikke en konfigureret mappe. Skal %s prøve at oprette en?"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:30
+msgid "Fit to Window/Screen"
+msgstr "Tilpas til vindue/skærm"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:31
+msgid "Standard (4:3)"
+msgstr "Standard (4:3)"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:32
+msgid "Widescreen (16:9)"
+msgstr "Bredskærmsformat (16:9)"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:46
+msgid "Disable window resize border"
+msgstr "Slå ændring af vindueskanten fra"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:47
+msgid "Always hide mouse cursor"
+msgstr "Skjul altid musemarkøren"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:48
+msgid "Hide window when paused"
+msgstr "Skjul vinduet, når der bliver pauset"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:49
+msgid "Default to fullscreen mode on open"
+msgstr "Automatisk fuldskærmsvisning ved opstart"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:50
+msgid "Wait for Vsync on refresh"
+msgstr "Vent på lodret synkronisering"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:51
+msgid "Double-click toggles fullscreen mode"
+msgstr "Dobbeltklik slår fuldskærmsvisning til"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:52
+msgid "Switch to 4:3 aspect ratio when an FMV plays"
+msgstr "Skift til 4:3 billedformat, når en FMV spiller"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:86
+msgid "Aspect Ratio:"
+msgstr "Billedformat:"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:88
+msgid "Custom Window Size:"
+msgstr "Vælg vinduestørrelse:"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:91
+msgid "Zoom:"
+msgstr "Zoom:"
+
+#: pcsx2/gui/Panels/GSWindowPanel.cpp:170
+msgid ""
+"Invalid window dimensions specified: Size cannot contain non-numeric digits! "
+">_<"
+msgstr ""
+"Ugyldige vinduedimensioner angivet: Størrelsen må ikke indeholder ikke-"
+"numeriske cifre! >_<"
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:322
+msgid "Search"
+msgstr "Søg"
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:334
+msgid "Game Database Editor"
+msgstr "Ændr spildatabase"
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:348
+msgid "Name: "
+msgstr "Navn: "
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:349
+msgid "Region: "
+msgstr "Område: "
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:350
+msgid "Compatibility: "
+msgstr "Kompatibilitet: "
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:351
+msgid "Comments: "
+msgstr "Kommentarer: "
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:352
+msgid "Patches: "
+msgstr "Korrektioner: "
+
+#: pcsx2/gui/Panels/GameDatabasePanel.cpp:356
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:25
+msgid "Gamefixes"
+msgstr "Spilløsninger"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:40
+msgid "VU Add Hack - Fixes Tri-Ace games boot crash."
+msgstr "Tilføj VU-Hack - Løser Tri-Ace-spil crash ved boot."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:41
+msgid ""
+"Games that need this hack to boot:\n"
+" * Star Ocean 3\n"
+" * Radiata Stories\n"
+" * Valkyrie Profile 2"
+msgstr ""
+"Spil, der skal bruge dette hack for at boote:\n"
+" * Star Ocean 3\n"
+" * Radiata Stories\n"
+" *Valkyrie Profile 2"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:44
+msgid "VU Clip Flag Hack - For Persona games (SuperVU recompiler only!)"
+msgstr "VU Clip Flag Hack - til Persona-spil (kun til SuperVU-recompileren!)"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:48
+msgid "FPU Compare Hack - For Digimon Rumble Arena 2."
+msgstr "Sammenlign FPU-Hack - Til Digimon Rumble Arena 2."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:52
+msgid "FPU Multiply Hack - For Tales of Destiny."
+msgstr "Forøg FPU-Hack - Til Tales of Destiny."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:56
+msgid "FPU Negative Div Hack - For Gundam games."
+msgstr "Negativ Div FPU-Hack - Til Gundam-spil."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:60
+msgid "VU XGkick Hack - For Erementar Gerad."
+msgstr "VU XGkick Hack - Til Erementar Gerad."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:64
+msgid "FFX videos fix - Fixes bad graphics overlay in FFX videos."
+msgstr "FFX videoløsning - Løser dårlig grafikoverlay i FFX-videoer."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:68
+msgid "EE timing hack - Multi purpose hack. Try if all else fails."
+msgstr "EE-timing-hack - Gør flere ting. Prøv, hvis alt andet slår fejl."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:73
+msgid ""
+"Skip MPEG hack - Skips videos/FMVs in games to avoid game hanging/freezes."
+msgstr ""
+"Skip MPEG-hack - Hopper videoer/FMV’er i spil over for at undgå, at spillet "
+"går i stå."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:77
+msgid "OPH Flag hack - Try if your game freezes showing the same frame."
+msgstr "OPH Flag-hack - Prøv denne, hvis dit spil går i stå ved samme billede."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:82
+msgid "Ignore DMAC writes when it is busy."
+msgstr "Ignorér DMAC-skriv, når den er optaget."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:87
+msgid "Simulate VIF1 FIFO read ahead. Fixes slow loading games."
+msgstr "Simulér VIF1 FIFO-læsninger på forhånd. Løser langsomme læsetider."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:92
+msgid ""
+"Delay VIF1 Stalls (VIF1 FIFO) - For SOCOM 2 HUD and Spy Hunter loading hang."
+msgstr ""
+"Udsæt VIF1 Stalls (VIF1 FIFO) - Til SOCOM 2 HUD og Spy Hunter "
+"indlæsningsproblemer."
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:96
+msgid ""
+"Enable the GIF FIFO (slower but needed for Hotwheels, Wallace and Gromit, DJ "
+"Hero)"
+msgstr ""
+"Aktivér GIF FIFO’en (langsommere, men nødvendig til Hot Wheels, Wallace and "
+"Gromit, Dj Hero)"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:100
+msgid "Switch to GSdx software rendering when an FMV plays"
+msgstr "Skift til GSdx sofwaregengivelse, når en FMV afspiller"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:104
+msgid "Preload TLB hack to avoid tlb miss on Goemon"
+msgstr "Forbelast TLB-hack for at undgå tlb-kiks på Goemon"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:108
+msgid ""
+"VU I bit Hack avoid constant recompilation (Scarface The World Is Yours)"
+msgstr ""
+"VU I bit Hack undgår konstant recompilering (Scarface The World Is Yours)"
+
+#: pcsx2/gui/Panels/GameFixesPanel.cpp:119
+msgid "Enable manual game fixes [Not recommended]"
+msgstr "Aktivér manuelle spilløsninger [Anbefales ikke]"
+
+#: pcsx2/gui/Panels/LogOptionsPanels.cpp:250
+msgid "Enable Trace Logging"
+msgstr "Aktivér Sporingslogføring"
+
+#: pcsx2/gui/Panels/LogOptionsPanels.cpp:251
+msgid ""
+"Trace logs are all written to emulog.txt.  Toggle trace logging at any time "
+"using F10."
+msgstr ""
+"Sporingslogge bliver skrevet til emulog.txt. Du kan altid skifte til "
+"sporingslogføring ved at trykke F10."
+
+#: pcsx2/gui/Panels/LogOptionsPanels.cpp:252
+msgid ""
+"Warning: Enabling trace logs is typically very slow, and is a leading cause "
+"of 'What happened to my FPS?' problems. :)"
+msgstr ""
+"Advarsel: Det er typisk langsomt at slå sporingslogføring til, og det vil "
+"skabe FPS-problemer. :)"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:188
+msgid "Select folder with PS2 memory cards"
+msgstr "Vælg en mappe til PS2 memory cards"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:389
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:481
+msgid "Eject"
+msgstr "Skub ud"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:390
+msgid "Duplicate ..."
+msgstr "Duplikér…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:391
+msgid "Rename ..."
+msgstr "Omdøb…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:392
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:462
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:492
+msgid "Create ..."
+msgstr "Opret…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:393
+msgid "Convert ..."
+msgstr "Konverter…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:405
+msgid "Card: "
+msgstr "Kort: "
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:463
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:499
+msgid "Create a new memory card."
+msgstr "Opret et nyt memory card."
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:477
+msgid "Rename this memory card ..."
+msgstr "Omdøb dette memory card…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:481
+msgid "Insert ..."
+msgstr "Indsæt…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:482
+msgid "Eject the card from this port"
+msgstr "Skub kortet ud fra denne port"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:482
+msgid "Insert this card to a port ..."
+msgstr "Sæt dette kort i en port…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:486
+msgid "Create a duplicate of this memory card ..."
+msgstr "Duplikér dette memory card…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:492
+msgid "Delete"
+msgstr "Slet"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:495
+msgid "Permanently delete this memory card from disk (all contents are lost)"
+msgstr "Slet dette memory card fra disken permanent (al data vil gå tabt)"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:497
+msgid "Create a new memory card and assign it to this Port."
+msgstr "Opret et nyt memory card og tildel det denne port."
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:687
+msgid "Delete memory file?"
+msgstr "Slet hukommelsesfil?"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:714
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:725
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:732
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:746
+msgid "Duplicate memory card"
+msgstr "Duplikér memory card"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:714
+msgid "Failed: Can only duplicate an existing card."
+msgstr "Mislykket: Kan kun duplikere et eksisterende kort."
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:732
+msgid ""
+"Select a name for the duplicate\n"
+"( '.ps2' will be added automatically)"
+msgstr ""
+"Vælg et navn til duplikeringen\n"
+"(‘.ps2’ bliver tilføjet automatisk)"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:745
+#, c-format
+msgid "Failed: %s"
+msgstr "Mislykket: %s"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:770
+msgid "Copy failed!"
+msgstr "Kunne ikke kopiere!"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:777
+#, c-format
+msgid "Memory card '%s' duplicated to '%s'."
+msgstr "Memory card ‘%s’ blev duplikeret til ‘%s’."
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:781
+msgid "Success"
+msgstr "Succes"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:801
+#, c-format
+msgid ""
+"Select a new name for the memory card '%s'\n"
+"( '.ps2' will be added automatically)"
+msgstr ""
+"Vælg et nyt navn til memory card ‘%s’\n"
+"(‘.ps2’ bliver tilføjet automatisk)"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:804
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:816
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:830
+msgid "Rename memory card"
+msgstr "Omdøb memory card"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:830
+msgid "Error: Rename could not be completed.\n"
+msgstr ""
+"Fejl: Kunne ikke omdøbe.\n"
+"\n"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:930
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:134
+#, c-format
+msgid "Port-%u / Multitap-%u--Port-1"
+msgstr "Port-%u / Multitap-%u—Port-1"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:931
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:135
+#, c-format
+msgid "             Multitap-%u--Port-%u"
+msgstr "             Multitap-%u—Port-%u"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:956
+msgid "Empty"
+msgstr "Tom"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:962
+#, c-format
+msgid "Select a target port for '%s'"
+msgstr "Vælg en port til ‘%s’"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:963
+msgid "Insert card"
+msgstr "Indsæt kort"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1024
+msgid "Eject card"
+msgstr "Skub kort ud"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1024
+msgid "Insert card ..."
+msgstr "Indsæt kort…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1025
+msgid "Duplicate card ..."
+msgstr "Duplikér kort…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1026
+msgid "Rename card ..."
+msgstr "Omdøb kort…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1027
+msgid "Delete card"
+msgstr "Slet kort"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1029
+msgid "Convert card"
+msgstr "Konvertér kort"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1033
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1037
+msgid "Create a new card ..."
+msgstr "Opret et nyt kort…"
+
+#: pcsx2/gui/Panels/MemoryCardListPanel.cpp:1041
+msgid "Refresh List"
+msgstr "Opdatér liste"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:99
+msgid "PS2 Port"
+msgstr "PS2 port"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:101
+msgid "Card (file) name"
+msgstr "Kort (fil) navn"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:102
+msgid "Card size"
+msgstr "Kortstørrelse"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:103
+msgid "Formatted"
+msgstr "Formateret"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:104
+msgid "Type"
+msgstr "Type"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:105
+msgid "Last Modified"
+msgstr "Sidst ændret"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:106
+msgid "Created on"
+msgstr "Oprettet"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:151
+msgid "No"
+msgstr "Nej"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:151
+msgid "Yes"
+msgstr "Ja"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:152
+msgid "PS2"
+msgstr "PS2"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:152
+msgid "PSX"
+msgstr "PSX"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:165
+msgid "[-- Unused cards --]"
+msgstr "[— Ubrugte kort —]"
+
+#: pcsx2/gui/Panels/MemoryCardListView.cpp:167
+msgid "[-- No unused cards --]"
+msgstr "[— Ingen ubrugte kort —]"
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:34
+msgid "Usermode Selection"
+msgstr "Vælg brugertilstand"
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:45
+msgid "User Documents (recommended)"
+msgstr "Brugerdokumenter (anbefalet)"
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:46
+msgid "Location: "
+msgstr "Placering: "
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:50
+msgid "Custom folder:"
+msgstr "Vælg mappe:"
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:52
+msgid ""
+"This setting may require administration privileges from your operating "
+"system, depending on how your system is configured."
+msgstr ""
+"Denne indstilling kan kræve administratorrettigheder fra dit operativsystem, "
+"afhængig af konfigurationen af dit system."
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:61
+#, c-format
+msgid "Select a document root for %s"
+msgstr "Vælg en placering til %s"
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:125
+msgid "Apply"
+msgstr "Anvend"
+
+#: pcsx2/gui/Panels/MiscPanelStuff.cpp:126
+msgid "Make this language my default right now!"
+msgstr "Gør dette sprog til mit standardsprog nu!"
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:38
+msgid "Savestates:"
+msgstr "Spiltilstande:"
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:39
+msgid "Select folder for Savestates"
+msgstr "Vælg en mappe til gemte spiltilstande"
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:46
+msgid "Snapshots:"
+msgstr "Snapshots:"
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:47
+msgid "Select a folder for Snapshots"
+msgstr "Vælg en mappe til snapshots"
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:54
+msgid "Logs/Dumps:"
+msgstr "Logge/dumps:"
+
+#: pcsx2/gui/Panels/PathsPanel.cpp:55
+msgid "Select a folder for logs/dumps"
+msgstr "Vælg en mappe til logge/dumps"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:230
+msgid "Applying settings..."
+msgstr "Anvender indstillinger…"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:240
+msgid "Shutdown PS2 virtual machine?"
+msgstr "Luk ned for den virtuelle PS2-maskine?"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:317
+msgid "I'm givin' her all she's got, Captain!"
+msgstr "Jeg giver hende hele armen, Kaptajn!"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:319
+msgid "Enumerating available plugins..."
+msgstr "Optæller tilgængelige plugins…"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:353
+msgid "Plugins Search Path:"
+msgstr "Søgesti til plugins:"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:354
+msgid "Select a folder with PCSX2 plugins"
+msgstr "Vælg en mappe med PCSX2 plugins"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:367
+msgid "Configure..."
+msgstr "Konfigurér…"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:376
+msgid "Click the Browse button to select a different folder for PCSX2 plugins."
+msgstr "Klik på søg-knappen for at vælge en anden mappe til PCSX2 plugins."
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:475
+#, c-format
+msgid "Please select a valid plugin for the %s."
+msgstr "Vælg venligst et gyldigt plugin til %s."
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:513
+#, c-format
+msgid ""
+"The selected %s plugin failed to load.\n"
+"\n"
+"Reason: %s\n"
+"\n"
+msgstr ""
+"Det valgte %s plugin kunne ikke indlæses.\n"
+"\n"
+"Grund: %s\n"
+"\n"
+
+#: pcsx2/gui/Panels/PluginSelectorPanel.cpp:720
+msgid "Completing tasks..."
+msgstr "Fuldfører opgaver…"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:117
+msgid "Enable speedhacks"
+msgstr "Aktivér speedhacks"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:121
+msgid ""
+"A safe and easy way to make sure that all speedhacks are completely disabled."
+msgstr "En sikker og nem måde til at slå alle speedhacks fuldstændig fra."
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:138
+msgid "EE Cyclerate [Not Recommended]"
+msgstr "EE cyclusfrekvens [Anbefales ikke]"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:154
+msgid "VU Cycle Stealing [Not Recommended]"
+msgstr "VU Cycle Stealing [Anbefales ikke]"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:170
+msgid "microVU Hacks"
+msgstr "microVU Hacks"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:172
+msgid "mVU Flag Hack"
+msgstr "mVU Flag Hack"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:173
+msgid ""
+"Good Speedup and High Compatibility; may cause bad graphics... [Recommended]"
+msgstr ""
+"Forøger hastigheden og har høj kompatibilitet; kan give grafikfejl… "
+"[Anbefalet]"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:175
+msgid "MTVU (Multi-Threaded microVU1)"
+msgstr "MTVU (Multi-Threaded microVU1)"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:176
+msgid ""
+"Good Speedup and High Compatibility; may cause hanging... [Recommended if 3+ "
+"cores]"
+msgstr ""
+"Forøger hastigheden og har høj kompatibilitet; kan gøre, så spillet hænger "
+"[Anbefalet, hvis man har 3+ kerner]"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:187
+msgid "Other Hacks"
+msgstr "Andre hacks"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:189
+msgid "Enable INTC Spin Detection"
+msgstr "Aktivér INTC spin-opdagelse"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:190
+msgid ""
+"Huge speedup for some games, with almost no compatibility side effects. "
+"[Recommended]"
+msgstr ""
+"Forøger hastigheden marken i nogle spil og har ikke nogen sideeffekter. "
+"[Anbefalet]"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:192
+msgid "Enable Wait Loop Detection"
+msgstr "Aktivér Wait Loop Detection"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:193
+msgid ""
+"Moderate speedup for some games, with no known side effects. [Recommended]"
+msgstr ""
+"Forøger moderat hastigheden i nogle spil og har ingen sideeffekter "
+"[Anbefalet]"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:195
+msgid "Enable fast CDVD"
+msgstr "Aktivér hurtig CDVD"
+
+#: pcsx2/gui/Panels/SpeedhacksPanel.cpp:196
+msgid "Fast disc access, less loading times. [Not Recommended]"
+msgstr "Hurtig diskadgang, mindre indlæsningstid. [Anbefales ikke]"
+
+#: pcsx2/gui/Panels/ThemeSelectorPanel.cpp:38
+msgid "Themes Search Path:"
+msgstr "Søgesti til temaer:"
+
+#: pcsx2/gui/Panels/ThemeSelectorPanel.cpp:39
+msgid "Select folder containing PCSX2 visual themes"
+msgstr "Vælg mappen med PCSX2 visuelle temaer"
+
+#: pcsx2/gui/Panels/ThemeSelectorPanel.cpp:46
+msgid ""
+"Click the Browse button to select a different folder containing PCSX2 visual "
+"themes."
+msgstr ""
+"Tryk på søg-knappen for at vælge en anden mappe til PCSX2 visuelle temaer."
+
+#: pcsx2/gui/Panels/ThemeSelectorPanel.cpp:50
+msgid "Select a visual theme:"
+msgstr "Vælg et visuelt tema:"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:32
+msgid "Disable Framelimiting"
+msgstr "Slå framelimimiting fra"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:33
+msgid ""
+"Useful for running benchmarks. Toggle this option in-game by pressing F4."
+msgstr "Nyttigt til benchmarks. Tryk F4 i spillet for at anvende dette."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:57
+msgid "Base Framerate Adjust:"
+msgstr "Justér framerate:"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:63
+msgid "Slow Motion Adjust:"
+msgstr "Justér slowmotion:"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:69
+msgid "Turbo Adjust:"
+msgstr "Justér turbo:"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:78
+msgid "NTSC Framerate:"
+msgstr "NTSC framerate:"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:81 pcsx2/gui/Panels/VideoPanel.cpp:87
+msgid "FPS"
+msgstr "FPS"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:84
+msgid "PAL Framerate:"
+msgstr "PAL framerate:"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:156
+msgid ""
+"Error while parsing either NTSC or PAL framerate settings.  Settings must be "
+"valid floating point numerics."
+msgstr ""
+"Kunne ikke parse enten NTSC eller PAL framerate-indstillinger. "
+"Indstillingerne skal være gyldige flydende kommatal."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:176
+msgid "Disabled [default]"
+msgstr "Slået fra [standard]"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:180
+msgid "Skip when on Turbo only (TAB to enable)"
+msgstr "Spring kun over, når Turbo er slået til (TAB for at slå til)"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:184
+msgid "Constant skipping"
+msgstr "Spring over konstant"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:186
+msgid ""
+"Normal and Turbo limit rates skip frames.  Slow motion mode will still "
+"disable frameskipping."
+msgstr ""
+"Normal- og Turbogrænserne springer billeder over. Slowmotion-funktionen slår "
+"frameskipping fra."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:209
+msgid "Frames to Draw"
+msgstr "Billeder, der skal fremkaldes"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:214
+msgid "Frames to Skip"
+msgstr "Billeder, der skal springes over"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:290
+msgid "Use Synchronized MTGS"
+msgstr "Brug synkroniseret MTGS"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:291
+msgid ""
+"For troubleshooting potential bugs in the MTGS only, as it is potentially "
+"very slow."
+msgstr ""
+"Kun til at fejlfinde potentielle bugs i MTGS’en, da det potentiel er meget "
+"langsomt."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:294
+msgid "Disable all GS output"
+msgstr "Deaktivér alle GS-udgange"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:295
+msgid ""
+"Completely disables all GS plugin activity; ideal for benchmarking EEcore "
+"components."
+msgstr ""
+"Slår alle GS pluginaktiviteter fuldstændig fra; ideelt til benchmarking af "
+"EEcore-komponenter."
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:310
+msgid "Frame Skipping"
+msgstr "Frameskipping"
+
+#: pcsx2/gui/Panels/VideoPanel.cpp:313
+msgid "Framelimiter"
+msgstr "Framelimiter"
+
+#: pcsx2/gui/SysState.cpp:289
+msgid "Cannot load this savestate.  The state is an unsupported version."
+msgstr ""
+"Kan ikke indlæse denne gemte tilstand. Tilstandens version er ikke "
+"understøttet."
+
+#: pcsx2/gui/SysState.cpp:296
+msgid "Cannot load this savestate. The state is an unsupported version."
+msgstr ""
+"Kan ikke indlæse denne gemte tilstand. Tilstandens version er ikke "
+"understøttet."
+
+#: pcsx2/gui/SysState.cpp:332
+msgid "There is no active virtual machine state to download or save."
+msgstr "Der er ingen aktiv virtuel maskinetilstand at downloade eller gemme."
+
+#: pcsx2/gui/SysState.cpp:526
+msgid ""
+"This savestate cannot be loaded because it is not a valid gzip archive.  It "
+"may have been created by an older unsupported version of PCSX2, or it may be "
+"corrupted."
+msgstr ""
+"Den gemte tilstand kan ikke indlæses, da den ikke er et gyldigt gzip-arkiv. "
+"Den kan være oprettet af en ældre og forældet version af PCSX2, eller den er "
+"korrupt."
+
+#: pcsx2/gui/SysState.cpp:585
+msgid "This file is not a valid PCSX2 savestate.  See the logfile for details."
+msgstr ""
+"Den gemte tilstand er ikke en gyldig PCSX2-tilstand. Se logfilen for "
+"detaljer."
+
+#: pcsx2/gui/SysState.cpp:604
+msgid ""
+"This savestate cannot be loaded due to missing critical components.  See the "
+"log file for details."
+msgstr ""
+"Den gemte tilstand kan ikke indlæses, da den mangler kritiske elementer. Se "
+"logfilen for detaljer."
+
+#: pcsx2/gui/i18n.cpp:63
+msgid " (default)"
+msgstr " (standard)"
+
+#: pcsx2/ps2/BiosTools.cpp:89 pcsx2/ps2/BiosTools.cpp:157
+msgid "The selected BIOS file is not a valid PS2 BIOS.  Please re-configure."
+msgstr "Den valgte BIOS-fil er ikke en gyldig PS2 BIOS. Vælg venligst en ny."
+
+#: pcsx2/ps2/BiosTools.cpp:270
+msgid ""
+"The PS2 BIOS could not be loaded.  The BIOS has not been configured, or the "
+"configuration has been corrupted.  Please re-configure."
+msgstr ""
+"PS2 BIOS’en kunne ikke indlæses. BIOS’en er ikke konfigureret, eller der er "
+"sket en fejl i konfigurationen. Vælg venligst en ny."
+
+#: pcsx2/ps2/BiosTools.cpp:277
+msgid "The configured BIOS file does not exist.  Please re-configure."
+msgstr "Den konfigurerede BIOS-fil eksisterer ikke. Vælg venligst en ny."
+
+#: pcsx2/x86/ix86-32/iR5900-32.cpp:472
+#, c-format
+msgid ""
+"%s Extensions not found.  The R5900-32 recompiler requires a host CPU with "
+"SSE2 extensions."
+msgstr ""
+"%s udvidelser ikke fundet. R5900-32 recompileren kræver en værtsprocessor "
+"med SSE2-udvidelser."
+
+#: pcsx2/x86/microVU.cpp:32
+#, c-format
+msgid ""
+"%s Extensions not found.  microVU requires a host CPU with SSE2 extensions."
+msgstr ""
+"%s udvidelse ikke fundet microVU kræver en værtsprocessor med SSE2-"
+"udvidelser."


### PR DESCRIPTION
I put a better version of the fix, round mode to nearest fix some issues with ingame typo as well as SPS.

Can be merge.

[skip ci]