### PR TITLE
IOP: Fix booting ELF files on a different drive

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -166,7 +166,7 @@ public:
 
 	static int open(IOManFile **file, const std::string &full_path, s32 flags, u16 mode)
 	{
-		const std::string path = full_path.substr(full_path.rfind(':') + 1);
+		const std::string path = full_path.substr(full_path.find(':') + 1);
 
 		// host: actually DOES let you write!
 		//if (flags != IOP_O_RDONLY)


### PR DESCRIPTION
Fixes a regression introduced in b3b1f3ac685da28030993e70ae6433175060d57e, where ELF files on a different drive to PCSX2 would fail to load.

Fixes #1930 
Fixes #2225 