### PR TITLE
Counters: Fix Hblank calculation for DVD videmodes

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -59,7 +59,7 @@ static void rcntWhold(int index, u32 value);
 
 static bool IsAnalogVideoMode()
 {
-	return (gsVideoMode == GS_VideoMode::PAL || gsVideoMode == GS_VideoMode::NTSC);
+	return (gsVideoMode == GS_VideoMode::PAL || gsVideoMode == GS_VideoMode::NTSC || gsVideoMode == GS_VideoMode::DVD_NTSC || gsVideoMode == GS_VideoMode::DVD_PAL);
 }
 
 void rcntReset(int index) {


### PR DESCRIPTION
**Summary of changes**:

- Made the DVD variant video modes to use the timing algorithm used by all the analog video modes, previously it was using the one we had for HD/SDTV modes which was weird. (Refer commit message for more information)

 @PCSX2/bug-squad 
This change would influence PSX games mostly, I don't have any PSX games with me so tests are appreciated. 