### PR TITLE
Enhance "Assemble Opcode" to be pre-populated by existing instruction.

### DIFF
--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -779,7 +779,7 @@ void CtrlDisassemblyView::onPopupClick(wxCommandEvent& evt)
 			break;
 		}
 	case ID_DISASM_ASSEMBLE:
-		assembleOpcode(curAddress,"");
+		assembleOpcode(curAddress, disassembleCurAddress());
 		break;
 	default:
 		wxMessageBox( L"Unimplemented.",  L"Unimplemented.", wxICON_INFORMATION);
@@ -1204,6 +1204,13 @@ std::string CtrlDisassemblyView::disassembleRange(u32 start, u32 size)
 	}
 
 	return result;
+}
+
+std::string CtrlDisassemblyView::disassembleCurAddress()
+{
+	DisassemblyLineInfo line = DisassemblyLineInfo();
+	manager.getLine(curAddress, displaySymbols, line);
+	return line.name + (line.params.length() > 0 ? " " + line.params : "");
 }
 
 void CtrlDisassemblyView::copyInstructions(u32 startAddr, u32 endAddr, bool withDisasm)

--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.h
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.h
@@ -61,6 +61,7 @@ private:
 	void toggleBreakpoint(bool toggleEnabled);
 	void updateStatusBarText();
 	std::string disassembleRange(u32 start, u32 size);
+	std::string disassembleCurAddress();
 	void copyInstructions(u32 startAddr, u32 endAddr, bool withDisasm);
 	void disassembleToFile();
 	void editBreakpoint();


### PR DESCRIPTION
A primary use case for the "Assemble Opcode" function from the context menu is to modify an existing instruction. This commit populates the text entry with the existing opcode. This is quicker than trying to do a copy/paste, or rewrite the entire opcode if just one parameter is changing.
For the use cases where an entirely new opcode is written, it is just as easy to delete the populated opcode from the text entry.
One downside is this potentially shines more light on existing discrepancies between the assembler and disassembler. For example, when the disassembler displays "b 0x00001234" (short-hand of "beq zero, zero, 0x00001234"), if that short-hand is re-entered without change to "Assemble Opcode," then it is actually assembled as "j 0x00001234" - essentially changing it from a relative branch to an absolute jump. The user must know to write out the long-hand opcode for it to assemble as expected. This is also seen in some "load immediate" opcodes, where the disassembler shows it as the "li" short-hand, rather than the "ori" long-hand. However, the assembler cannot understand the "li" short-hand - the user must know to write out the long-hand.