### PR TITLE
Debugger: Fix mouse click focus in debugger near functions ending in a branch.

### DIFF
--- a/pcsx2/DebugTools/DisassemblyManager.cpp
+++ b/pcsx2/DebugTools/DisassemblyManager.cpp
@@ -575,7 +575,7 @@ void DisassemblyFunction::load()
 		// skip branches and their delay slots
 		if (opInfo.isBranch)
 		{
-			funcPos += 4;
+			if (funcPos < funcEnd) funcPos += 4; // only include delay slots within the function bounds
 			continue;
 		}
 		


### PR DESCRIPTION
This code updates the DisassemblyFunction objects to only include Delay Slots when they are within the bounds of the function.

This is to resolve issue #2076.

Close #2076