### PR TITLE
onepad legacy: avoid null pointer in devname

### DIFF
--- a/plugins/onepad_legacy/SDL/joystick.cpp
+++ b/plugins/onepad_legacy/SDL/joystick.cpp
@@ -162,7 +162,7 @@ void JoystickInfo::Destroy()
             SDL_JoystickClose(joy);
 #endif
 #else
-        if (SDL_JoystickOpened(_id))
+        if (joy)
             SDL_JoystickClose(joy);
 #endif
         joy = NULL;
@@ -180,14 +180,21 @@ bool JoystickInfo::Init(int id)
         return false;
     }
 
+#if SDL_MAJOR_VERSION >= 2
+    const char* sdl_devname = SDL_JoystickName(joy);
+#else
+    const char* sdl_devname = SDL_JoystickName(id);
+#endif
+    if (sdl_devname) {
+        devname = sdl_devname;
+    } else {
+        fprintf(stderr, "ERROR: failed to get joystick (%d) devname\n", id);
+        devname = "";
+    }
+
     numaxes = SDL_JoystickNumAxes(joy);
     numbuttons = SDL_JoystickNumButtons(joy);
     numhats = SDL_JoystickNumHats(joy);
-#if SDL_MAJOR_VERSION >= 2
-    devname = SDL_JoystickName(joy);
-#else
-    devname = SDL_JoystickName(id);
-#endif
 
     vaxisstate.resize(numaxes);
     vbuttonstate.resize(numbuttons);


### PR DESCRIPTION
In case something goes wrong in the kernel, SDL_JoystickName can return
a null pointer

Avoid to use SDL_JoystickOpened which can crash on SDL1 instead just check
if joy pointer isn't null

I hope that it will fix #2157