### PR TITLE
PCSX2: Minor memory card fixes

### DIFF
--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -191,6 +191,7 @@ namespace Dialogs
 		wxDirName	m_mcdpath;
 		wxString	m_mcdfile;
 		wxTextCtrl*	m_text_filenameInput;
+		wxStaticText *m_mcd_Extension;
 
 		//wxFilePickerCtrl*	m_filepicker;
 		pxRadioPanel *m_radio_CardType;
@@ -208,10 +209,10 @@ namespace Dialogs
 		wxString result_createdMcdFilename;
 		//wxDirName GetPathToMcds() const;
 
-
 	protected:
 		void CreateControls();
-		void OnOk_Click( wxCommandEvent& evt );
+		void OnRadioChanged(wxCommandEvent &evt);
+		void OnOk_Click(wxCommandEvent &evt);
 	};
 
 	// --------------------------------------------------------------------------------------

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -196,9 +196,9 @@ namespace Dialogs
 		//wxFilePickerCtrl*	m_filepicker;
 		pxRadioPanel *m_radio_CardType;
 
-	#ifdef __WXMSW__
-		pxCheckBox*			m_check_CompressNTFS;
-	#endif
+#ifdef __WXMSW__
+		pxCheckBox *m_check_CompressNTFS;
+#endif
 
 	public:
 		virtual ~CreateMemoryCardDialog()  = default;

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -193,12 +193,11 @@ namespace Dialogs
 		wxTextCtrl*	m_text_filenameInput;
 
 		//wxFilePickerCtrl*	m_filepicker;
-		pxRadioPanel*		m_radio_CardSize;
+		pxRadioPanel *m_radio_CardType;
 
 	#ifdef __WXMSW__
 		pxCheckBox*			m_check_CompressNTFS;
 	#endif
-		pxCheckBox*			m_check_psx;
 
 	public:
 		virtual ~CreateMemoryCardDialog()  = default;
@@ -223,8 +222,8 @@ namespace Dialogs
 	protected:
 		wxDirName     m_mcdPath;
 		wxString      m_mcdSourceFilename;
-		wxTextCtrl*   m_text_filenameInput;
-		pxRadioPanel* m_radio_CardType;
+		wxTextCtrl   *m_text_filenameInput;
+		pxRadioPanel *m_radio_CardType;
 
 	public:
 		virtual ~ConvertMemoryCardDialog()  = default;

--- a/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
@@ -76,10 +76,8 @@ Dialogs::CreateMemoryCardDialog::CreateMemoryCardDialog( wxWindow* parent, const
 		s_filename += Heading( _("Select file name: ")).Unwrapped().Align(wxALIGN_RIGHT) | pxProportion(1);
 		m_text_filenameInput->SetValue ((m_mcdpath + m_mcdfile).GetName());
 		s_filename += m_text_filenameInput | pxProportion(2);
-		s_filename += Heading( L".ps2" ).Align(wxALIGN_LEFT) | pxProportion(1);
-
+		s_filename += m_mcd_Extension | pxProportion(1);
 		s_padding += s_filename | StdExpand();
-
 	}
 
 	#ifdef __WXMSW__
@@ -95,6 +93,7 @@ Dialogs::CreateMemoryCardDialog::CreateMemoryCardDialog( wxWindow* parent, const
 
 	Bind(wxEVT_BUTTON, &CreateMemoryCardDialog::OnOk_Click, this, wxID_OK);
 	Bind(wxEVT_TEXT_ENTER, &CreateMemoryCardDialog::OnOk_Click, this, m_text_filenameInput->GetId());
+	Bind(wxEVT_RADIOBUTTON, &CreateMemoryCardDialog::OnRadioChanged, this);
 
 	// ...Typical solution to everything? Or are we doing something weird?
 	SetSizerAndFit(GetSizer());
@@ -154,6 +153,13 @@ bool Dialogs::CreateMemoryCardDialog::CreateIt( const wxString& mcdFile, uint si
 	return true;
 }
 
+void Dialogs::CreateMemoryCardDialog::OnRadioChanged(wxCommandEvent& evt)
+{
+	evt.Skip();
+
+	m_mcd_Extension->SetLabel(m_radio_CardType->SelectedItem().SomeInt == 1 ? L".mcr" : L".ps2");
+}
+
 void Dialogs::CreateMemoryCardDialog::OnOk_Click( wxCommandEvent& evt )
 {
 	// Save status of the NTFS compress checkbox for future reference.
@@ -163,7 +169,8 @@ void Dialogs::CreateMemoryCardDialog::OnOk_Click( wxCommandEvent& evt )
 	g_Conf->McdCompressNTFS = m_check_CompressNTFS->GetValue();
 #endif
 	result_createdMcdFilename=L"_INVALID_FILE_NAME_";
-	wxString composedName = m_text_filenameInput->GetValue().Trim() + L".ps2";
+
+	wxString composedName = m_text_filenameInput->GetValue().Trim() + (m_radio_CardType->SelectedItem().SomeInt == 1 ? L".mcr" : L".ps2");
 
 	wxString errMsg;
 	if( !isValidNewFilename(composedName, m_mcdpath, errMsg, 5) )
@@ -224,7 +231,8 @@ void Dialogs::CreateMemoryCardDialog::CreateControls()
 	m_check_CompressNTFS->SetValue( g_Conf->McdCompressNTFS );
 	#endif
 
-	m_text_filenameInput = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	m_text_filenameInput = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	m_mcd_Extension = new wxStaticText(this, wxID_ANY, L".ps2");
 
 	const RadioPanelItem tbl_CardTypes[] =
 	{

--- a/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
@@ -53,12 +53,13 @@ Dialogs::CreateMemoryCardDialog::CreateMemoryCardDialog( wxWindow* parent, const
 	//      Sizers and Layout
 	// ----------------------------
 
-	if( m_radio_CardSize ) m_radio_CardSize->Realize();
 
 	wxBoxSizer& s_buttons( *new wxBoxSizer(wxHORIZONTAL) );
 	s_buttons += new wxButton( this, wxID_OK, _("Create") )	| pxProportion(2);
 	s_buttons += pxStretchSpacer(3);
 	s_buttons += new wxButton( this, wxID_CANCEL )			| pxProportion(2);
+	if (m_radio_CardType)
+		m_radio_CardType->Realize();
 
 	wxBoxSizer& s_padding( *new wxBoxSizer(wxVERTICAL) );
 
@@ -81,16 +82,14 @@ Dialogs::CreateMemoryCardDialog::CreateMemoryCardDialog( wxWindow* parent, const
 
 	}
 
-	s_padding += m_radio_CardSize			| StdExpand();
 	#ifdef __WXMSW__
 	if( m_check_CompressNTFS )
 		s_padding += m_check_CompressNTFS	| StdExpand();
 	#endif
+	s_padding += m_radio_CardType | StdExpand();
 
-	s_padding += m_check_psx;
 
-	s_padding += 12;
-	s_padding += s_buttons	| StdCenter();
+	s_padding += s_buttons | StdCenter();
 
 	*this += s_padding | StdExpand();
 
@@ -178,7 +177,7 @@ void Dialogs::CreateMemoryCardDialog::OnOk_Click( wxCommandEvent& evt )
 	}
 
 	wxString fullPath = ( m_mcdpath + composedName ).GetFullPath();
-	if ( m_radio_CardSize && m_radio_CardSize->SelectedItem().SomeInt == 0 ) {
+	if (m_radio_CardType && m_radio_CardType->SelectedItem().SomeInt == 0) {
 		// user selected to create a folder memory card
 		if ( !wxFileName::Mkdir( fullPath ) ) {
 			Msgbox::Alert(
@@ -193,10 +192,9 @@ void Dialogs::CreateMemoryCardDialog::OnOk_Click( wxCommandEvent& evt )
 	} else {
 		// otherwise create a file
 		if (!CreateIt(
-			fullPath,
-			m_radio_CardSize ? m_radio_CardSize->SelectedItem().SomeInt : 8,
-			m_check_psx->GetValue()
-			) ) {
+				fullPath,
+				m_radio_CardType ? m_radio_CardType->SelectedItem().SomeInt : 8,
+				m_radio_CardType->SelectedItem().SomeInt == 1)) {
 			Msgbox::Alert(
 				_( "Error: The memory card could not be created." ),
 				_( "Create memory card" )
@@ -228,7 +226,7 @@ void Dialogs::CreateMemoryCardDialog::CreateControls()
 
 	m_text_filenameInput = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 
-	const RadioPanelItem tbl_CardSizes[] =
+	const RadioPanelItem tbl_CardTypes[] =
 	{
 		RadioPanelItem(_("8 MB [most compatible]"), _("This is the standard Sony-provisioned size, and is supported by all games and BIOS versions."))
 		.	SetToolTip(_t("Always use this option if you want the safest and surest memory card behavior."))
@@ -248,12 +246,14 @@ void Dialogs::CreateMemoryCardDialog::CreateControls()
 
 		RadioPanelItem(_("Folder [experimental]"), _("Store memory card contents in the host filesystem instead of a file."))
 		.	SetToolTip(_t("Automatically manages memory card contents so that the console only sees files related to the currently running software. Allows you to drag-and-drop files in and out of the memory card with your standard file explorer. This is still experimental, so use at your own risk!"))
-		.	SetInt(0)
+		.	SetInt(0),
+
+		RadioPanelItem(_("128 KiB (PSX)"), _("This is the standard Sony-provisioned size PSX memory card, only compatible with PSX games."))
+		.	SetToolTip(_t("This memory card is required by PSX games. It is not compatible with PS2 games."))
+		.	SetInt(1)
 	};
 
-	m_radio_CardSize = new pxRadioPanel( this, tbl_CardSizes );
-	m_radio_CardSize->SetDefaultItem(0);
-
-	m_check_psx = new pxCheckBox(this, "Make this a PSX card (128 KiB only, no folders!)");
+	m_radio_CardType = new pxRadioPanel(this, tbl_CardTypes);
+	m_radio_CardType->SetDefaultItem(0);
 }
 

--- a/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -80,11 +80,11 @@ Dialogs::CreateMemoryCardDialog::CreateMemoryCardDialog( wxWindow* parent, const
 		s_padding += s_filename | StdExpand();
 	}
 
-	#ifdef __WXMSW__
-	if( m_check_CompressNTFS )
-		s_padding += m_check_CompressNTFS	| StdExpand();
-	#endif
 	s_padding += m_radio_CardType | StdExpand();
+#ifdef __WXMSW__
+	if (m_check_CompressNTFS)
+		s_padding += m_check_CompressNTFS | StdExpand();
+#endif
 
 
 	s_padding += s_buttons | StdCenter();
@@ -216,7 +216,7 @@ void Dialogs::CreateMemoryCardDialog::OnOk_Click( wxCommandEvent& evt )
 
 void Dialogs::CreateMemoryCardDialog::CreateControls()
 {
-	#ifdef __WXMSW__
+#ifdef __WXMSW__
 	m_check_CompressNTFS = new pxCheckBox( this,
 		_("Use NTFS compression when creating this card."),
 		GetMsg_McdNtfsCompress()
@@ -229,7 +229,7 @@ void Dialogs::CreateMemoryCardDialog::CreateControls()
 	// Initial value of the checkbox is saved between calls to the dialog box.  If the user checks
 	// the option, it remains checked for future dialog.  If the user unchecks it, ditto.
 	m_check_CompressNTFS->SetValue( g_Conf->McdCompressNTFS );
-	#endif
+#endif
 
 	m_text_filenameInput = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 	m_mcd_Extension = new wxStaticText(this, wxID_ANY, L".ps2");

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -71,9 +71,8 @@ bool EnumerateMemoryCard( McdSlotItem& dest, const wxFileName& filename, const w
 
 		wxFileOffset length = mcdFile.Length();
 
-		if( length < (1024*528) && length != 0x20000 )
-		{
-			Console.Warning( "... MemoryCard appears to be truncated.  Ignoring." );
+		if (length < (1024 * 528) && length != 0x20000) {
+			Console.Warning("... Memory card appears to be truncated. Ignoring.");
 			return false;
 		}
 
@@ -487,6 +486,8 @@ void Panels::MemoryCardListPanel_Simple::UpdateUI()
 	pxSetToolTip( m_button_Duplicate, dupTip );
 
 	m_button_Convert->Enable( card.IsPresent && card.IsFormatted && !card.IsPSX );
+	pxSetToolTip(m_button_Convert, _("Convert this memory card to or from a folder memory card. Creates a duplicate of the current memory card in the new type.\n\n"
+		"Note: Only available when a memory card is formatted. Not available for PSX memory cards."));
 
 	//m_button_Create->Enable( card.Slot>=0 || card.IsPresent);
 	m_button_Create->SetLabel( card.IsPresent ? _("Delete") : _("Create ...") );
@@ -514,9 +515,8 @@ void Panels::MemoryCardListPanel_Simple::Apply()
 	_parent::Apply();
 
 	int used=0;
-	Console.WriteLn( L"Apply Memory cards:" );
-	for( uint slot=0; slot<8; ++slot )
-	{
+	Console.WriteLn(L"Apply memory cards:");
+	for(uint slot=0; slot<8; ++slot) {
 		g_Conf->Mcd[slot].Type = m_Cards[slot].Type;
 		g_Conf->Mcd[slot].Enabled = m_Cards[slot].IsEnabled && m_Cards[slot].IsPresent;
 		if (m_Cards[slot].IsPresent)
@@ -524,14 +524,13 @@ void Panels::MemoryCardListPanel_Simple::Apply()
 		else
 			g_Conf->Mcd[slot].Filename = L"";
 
-		if( g_Conf->Mcd[slot].Enabled )
-		{
+		if (g_Conf->Mcd[slot].Enabled) {
 			used++;
-			Console.WriteLn( L"slot[%d]='%s'", slot, WX_STR(g_Conf->Mcd[slot].Filename.GetFullName()) );
+			Console.WriteLn(L"slot[%d]='%s'", slot, WX_STR(g_Conf->Mcd[slot].Filename.GetFullName()));
 		}
 	}
-	if( !used )
-		Console.WriteLn( L"No active slots" );
+	if (!used)
+		Console.WriteLn(L"No active slots.");
 
 	SetForceMcdEjectTimeoutNow();
 
@@ -539,26 +538,22 @@ void Panels::MemoryCardListPanel_Simple::Apply()
 
 void Panels::MemoryCardListPanel_Simple::AppStatusEvent_OnSettingsApplied()
 {
-	for( uint slot=0; slot<8; ++slot )
-	{
+	for (uint slot=0; slot<8; ++slot) {
 		m_Cards[slot].IsEnabled = g_Conf->Mcd[slot].Enabled;
 		m_Cards[slot].Filename = g_Conf->Mcd[slot].Filename;
 		
-		//automatically create the enabled but non-existing file such that it can be managed (else will get created anyway on boot)
+		// Automatically create the enabled but non-existing file such that it can be managed (else will get created anyway on boot)
 		wxString targetFile = (GetMcdPath() + m_Cards[slot].Filename.GetFullName()).GetFullPath();
-		if ( m_Cards[slot].IsEnabled && !( wxFileExists( targetFile ) || wxDirExists( targetFile ) ) )
-		{
+		if (m_Cards[slot].IsEnabled && !(wxFileExists(targetFile) || wxDirExists(targetFile))) {
 			wxString errMsg;
-			if (isValidNewFilename(m_Cards[slot].Filename.GetFullName(), GetMcdPath(), errMsg, 5))
-			{
-				if ( !Dialogs::CreateMemoryCardDialog::CreateIt(targetFile, 8, false) )
-					Console.Error( L"Automatic createion of MCD '%s' failed. Hope for the best...", WX_STR(targetFile) );
-				else
-					Console.WriteLn( L"memcard created: '%s'.", WX_STR(targetFile) );
-			}
-			else
-			{
-				Console.Error( L"memcard was enabled but had an invalid file name. Aborting automatic creation. Hope for the best... (%s)", WX_STR(errMsg) );
+			if (isValidNewFilename(m_Cards[slot].Filename.GetFullName(), GetMcdPath(), errMsg, 5)) {
+				if (!Dialogs::CreateMemoryCardDialog::CreateIt(targetFile, 8, false)) {
+					Console.Error(L"Automatic creation of memory card '%s' failed. Hope for the best...", WX_STR(targetFile));
+				} else {
+					Console.WriteLn(L"Memory card created: '%s'.", WX_STR(targetFile));
+				}
+			} else {
+				Console.Error(L"Memory card was enabled, but it had an invalid file name. Aborting automatic creation. Hope for the best... (%s)", WX_STR(errMsg));
 			}
 		}
 
@@ -621,36 +616,38 @@ void Panels::MemoryCardListPanel_Simple::DoRefresh()
 // =====================================================================================================
 
 void Panels::MemoryCardListPanel_Simple::UiCreateNewCard( McdSlotItem& card )
-{//card can also be the filesystem placeholder. On that case, the changes
- //  made to it will be reverted on refresh, and we'll just have a new card at the folder.
-	if( card.IsPresent ){
-		Console.WriteLn("Error: Aborted: create mcd invoked but but a file is already associated.");
+{
+	// card can also be the filesystem placeholder. On that case, the changes
+	// made to it will be reverted on refresh, and we'll just have a new card at the folder.
+	if (card.IsPresent) {
+		Console.WriteLn("Error: Aborted: create memory card invoked, but a file is already associated.");
 		return;
 	}
 
-	Dialogs::CreateMemoryCardDialog dialog( this, m_FolderPicker->GetPath(), L"my memory card" );
+	Dialogs::CreateMemoryCardDialog dialog(this, m_FolderPicker->GetPath(), L"my memory card");
 	wxWindowID result = dialog.ShowModal();
 
-	if (result != wxID_CANCEL)
-	{
+	if (result != wxID_CANCEL) {
 		card.IsEnabled = true;
 		card.Filename  = dialog.result_createdMcdFilename;
 		card.IsPresent = true;
-		if ( card.Slot >= 0)
-			Console.WriteLn(L"setting new card to slot %u: '%s'", card.Slot, WX_STR(card.Filename.GetFullName()));
-		else
-			Console.WriteLn(L"Created a new unassigned card file: '%s'", WX_STR(card.Filename.GetFullName()) );
+		if (card.Slot >= 0) {
+			Console.WriteLn(L"Setting new memory card to slot %u: '%s'", card.Slot, WX_STR(card.Filename.GetFullName()));
+		} else {
+			Console.WriteLn(L"Created a new unassigned memory card file: '%s'", WX_STR(card.Filename.GetFullName()));
+		}
+	} else {
+		card.IsEnabled = false;
 	}
-	else
-		card.IsEnabled=false;
 
 	Apply();
 	RefreshSelections();
 }
 
-void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card ) {
-	if ( !card.IsPresent ) {
-		Console.WriteLn( "Error: Aborted: Convert mcd invoked but but a file is not associated." );
+void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card )
+{
+	if (!card.IsPresent) {
+		Console.WriteLn("Error: Aborted: Convert memory card invoked, but a file is not associated.");
 		return;
 	}
 
@@ -669,11 +666,10 @@ void Panels::MemoryCardListPanel_Simple::UiConvertCard( McdSlotItem& card ) {
 
 void Panels::MemoryCardListPanel_Simple::UiDeleteCard( McdSlotItem& card )
 {
-	if( !card.IsPresent ){
-		Console.WriteLn("Error: Aborted: delete mcd invoked but but a file is not associated.");
+	if (!card.IsPresent) {
+		Console.WriteLn("Error: Aborted: delete memory card invoked, but a file is not associated.");
 		return;
 	}
-
 
 	bool result = true;
 	if( card.IsFormatted )
@@ -790,7 +786,7 @@ bool Panels::MemoryCardListPanel_Simple::UiDuplicateCard(McdSlotItem& src, McdSl
 void Panels::MemoryCardListPanel_Simple::UiRenameCard( McdSlotItem& card )
 {
 	if( !card.IsPresent ){
-		Console.WriteLn("Error: Aborted: Rename mcd invoked but no file is associated.");
+		Console.WriteLn("Error: Aborted: Rename memory card invoked, but no file is associated.");
 		return;
 	}
 

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -1016,29 +1016,27 @@ void Panels::MemoryCardListPanel_Simple::OnOpenItemContextMenu(wxListEvent& evt)
 
 	wxMenu* junk = new wxMenu();
 
-	if( idx != wxNOT_FOUND )
-	{
+	if (idx != wxNOT_FOUND) {
 		const McdSlotItem& card( GetCardForViewIndex(idx) );
 
-		if (card.IsPresent){
-			junk->Append( McdMenuId_AssignUnassign,	card.Slot>=0?_("Eject card"):_("Insert card ...") );
-			junk->Append( McdMenuId_Duplicate,	_("Duplicate card ...") );
-			junk->Append( McdMenuId_Rename,		_("Rename card ...") );
-			junk->Append( McdMenuId_Create,		_("Delete card") );
+		if (card.IsPresent) {
+			junk->Append(McdMenuId_AssignUnassign,	card.Slot>=0?_("&Eject card"):_("&Insert card ..."));
+			junk->Append(McdMenuId_Duplicate,	_("D&uplicate card ..."));
+			junk->Append(McdMenuId_Rename,		_("&Rename card ..."));
+			junk->Append(McdMenuId_Create,		_("&Delete card"));
 			if (card.IsFormatted && !card.IsPSX) {
-				junk->Append( McdMenuId_Convert, _("Convert card") );
+				junk->Append(McdMenuId_Convert, _("&Convert card"));
 			}
+		} else {
+			junk->Append(McdMenuId_Create, _("&Create a new card ..."));
 		}
-		else
-			junk->Append( McdMenuId_Create, _("Create a new card ...") );
-
+	} else {
+		junk->Append(McdMenuId_Create, _("&Create a new card ..."));
 	}
-	else
-		junk->Append( McdMenuId_Create, _("Create a new card ...") );
 
 	junk->AppendSeparator();
 
-	junk->Append( McdMenuId_RefreshList, _("Refresh List") );
+	junk->Append(McdMenuId_RefreshList, _("Re&fresh List"));
 
 	PopupMenu( junk );
 	m_listview->RefreshItem( idx );


### PR DESCRIPTION
Fixes a few minor issues in the memory card dialogs.

Notable changes:

Replaces the awkward checkbox for a PSX memory card in the bottom left
of the Create Memory Card dialog with a radio button like the other
memory card types.

Changes the file extension used by PSX memory cards to the common .mcr
instead of using the same (.ps2) extension used by PS2 memory cards.