### PR TITLE
SPU2-X: Prevent volume check from altering volume

### DIFF
--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -1021,18 +1021,21 @@ static void __fastcall RegWrite_VoiceParams(u16 value)
             thisvoice.ADSR.regADSR2 = value;
             break;
 
+        // REG_VP_ENVX, REG_VP_VOLXL and REG_VP_VOLXR have been confirmed to not be allowed to be written to, so code has been commented out.
+        // Colin McRae Rally 2005 triggers case 5 (ADSR), but it doesn't produce issues enabled or disabled.
+
         case 5:
             // [Air] : Mysterious ADSR set code.  Too bad none of my games ever use it.
             //      (as usual... )
-            thisvoice.ADSR.Value = (value << 16) | value;
-            ConLog("* SPU2: Mysterious ADSR Volume Set to 0x%x\n", value);
+            //thisvoice.ADSR.Value = (value << 16) | value;
+            //ConLog("* SPU2: Mysterious ADSR Volume Set to 0x%x\n", value);
             break;
 
         case 6:
-            thisvoice.Volume.Left.RegSet(value);
+            //thisvoice.Volume.Left.RegSet(value);
             break;
         case 7:
-            thisvoice.Volume.Right.RegSet(value);
+            //thisvoice.Volume.Right.RegSet(value);
             break;
 
             jNO_DEFAULT;
@@ -1075,14 +1078,17 @@ static void __fastcall RegWrite_VoiceAddr(u16 value)
         // for example).  Tests should be done to find games that write to this
         // reg, and see if they're buggy or not. --air
 
+        // NextA has been confirmed to not be allowed to be written to, so code has been commented out.
+        // FlatOut & Soul Reaver 2 trigger these cases, but don't produce issues enabled or disabled.
+
         case 4:
-            thisvoice.NextA = ((value & 0x0F) << 16) | (thisvoice.NextA & 0xFFF8) | 1;
-            thisvoice.SCurrent = 28;
+            //thisvoice.NextA = ((value & 0x0F) << 16) | (thisvoice.NextA & 0xFFF8) | 1;
+            //thisvoice.SCurrent = 28;
             break;
 
         case 5:
-            thisvoice.NextA = (thisvoice.NextA & 0x0F0000) | (value & 0xFFF8) | 1;
-            thisvoice.SCurrent = 28;
+            //thisvoice.NextA = (thisvoice.NextA & 0x0F0000) | (value & 0xFFF8) | 1;
+            //thisvoice.SCurrent = 28;
             break;
     }
 }
@@ -1428,6 +1434,13 @@ static void __fastcall RegWrite_CoreExt(u16 value)
 
         case REG_P_BVOLR:
             thiscore.InpVol.Right = GetVol32(value);
+            break;
+
+        // MVOLX has been confirmed to not be allowed to be written to, so cases have been added as a no-op.
+        // Tokyo Xtreme Racer Zero triggers this code, caused left side volume to be reduced.
+
+        case REG_P_MVOLXL:
+        case REG_P_MVOLXR:
             break;
 
         default: {


### PR DESCRIPTION
Fixes issue in Tokyo Xtreme Racer Zero where checking the left master volume would alter it.

Replaces closed PR(to push from dedicated branch).