### PR TITLE
GSdx: Disable Merge Sprite on native resolution

### DIFF
--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -56,8 +56,9 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	}
 
 	if (m_upscale_multiplier == 1) { // hacks are only needed for upscaling issues.
-		m_userhacks_round_sprite_offset = 0;
-		m_userhacks_align_sprite_X      = 0;
+		m_userhacks_round_sprite_offset  = 0;
+		m_userhacks_align_sprite_X       = false;
+		m_userHacks_merge_sprite         = false;
 	}
 
 	m_dump_root = root_hw;


### PR DESCRIPTION
Previously if HW hacks were enabled Merge Sprite was active(if checked) on
native resolution even if the GUI option was disabled, which in result
caused glitches in games on native resolution.

This should address that issue.