### PR TITLE
PCSX2: Add configurable Cheats folder to Components Selectors

### DIFF
--- a/pcsx2/gui/Panels/PathsPanel.cpp
+++ b/pcsx2/gui/Panels/PathsPanel.cpp
@@ -34,6 +34,14 @@ Panels::StandardPathsPanel::StandardPathsPanel( wxWindow* parent )
 	: BasePathsPanel( parent )
 {
 	*this += BetweenFolderSpace;
+	*this += (new DirPickerPanel( this, FolderId_Cheats,
+		_("Cheats:"),
+		_("Select folder for Cheats") ))->
+		SetToolTip( pxEt( L"This folder is where PCSX2 loads cheats from."
+		)
+	) | SubGroup();
+
+	*this += BetweenFolderSpace;
 	*this += (new DirPickerPanel( this, FolderId_Savestates,
 		_("Savestates:"),
 		_("Select folder for Savestates") ))->


### PR DESCRIPTION
Add GUI option in the Plugins Component Selector to change the default "Cheats" folder location.
Similar to savestates/logs/..etc

This has been bugging me. I have no idea how many times I deleted my cheats folder by mistake when updating to newer dev builds. This should solve all those issues for many people.

![image](https://user-images.githubusercontent.com/18107717/35260731-4796a242-000d-11e8-9b0f-7b66efd9484a.png)

Close #1584