### PR TITLE
cdvd: Fix blockdump writing issues

### DIFF
--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -394,7 +394,7 @@ bool DoCDVDopen()
 	cdvdTD td;
 	CDVD->getTD(0, &td);
 
-	blockDumpFile.Create(temp, 3);
+	blockDumpFile.Create(temp, 2);
 
 	if( blockDumpFile.IsOpened() )
 	{

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -439,7 +439,16 @@ s32 DoCDVDreadSector(u8* buffer, u32 lsn, int mode)
 
 	if (ret == 0 && blockDumpFile.IsOpened())
 	{
-		blockDumpFile.WriteSector(buffer, lsn);
+		if (blockDumpFile.GetBlockSize() == CD_FRAMESIZE_RAW && mode != CDVD_MODE_2352)
+		{
+			u8 blockDumpBuffer[CD_FRAMESIZE_RAW];
+			if (CDVD->readSector(blockDumpBuffer, lsn, CDVD_MODE_2352) == 0)
+				blockDumpFile.WriteSector(blockDumpBuffer, lsn);
+		}
+		else
+		{
+			blockDumpFile.WriteSector(buffer, lsn);
+		}
 	}
 
 	return ret;
@@ -478,7 +487,16 @@ s32 DoCDVDgetBuffer(u8* buffer)
 
 	if (ret == 0 && blockDumpFile.IsOpened())
 	{
-		blockDumpFile.WriteSector(buffer, lastLSN);
+		if (blockDumpFile.GetBlockSize() == CD_FRAMESIZE_RAW && lastReadSize != 2352)
+		{
+			u8 blockDumpBuffer[CD_FRAMESIZE_RAW];
+			if (CDVD->readSector(blockDumpBuffer, lastLSN, CDVD_MODE_2352) == 0)
+				blockDumpFile.WriteSector(blockDumpBuffer, lastLSN);
+		}
+		else
+		{
+			blockDumpFile.WriteSector(buffer, lastLSN);
+		}
 	}
 
 	return ret;

--- a/pcsx2/CDVD/IsoFileFormats.h
+++ b/pcsx2/CDVD/IsoFileFormats.h
@@ -123,7 +123,7 @@ public:
 	virtual ~OutputIsoFile();
 
 	bool IsOpened() const;
-	
+	u32 GetBlockSize() const;
 	
 	const wxString& GetFilename() const
 	{

--- a/pcsx2/CDVD/IsoFileFormats.h
+++ b/pcsx2/CDVD/IsoFileFormats.h
@@ -113,9 +113,8 @@ protected:
 	// total number of blocks in the ISO image (including all parts)
 	u32			m_blocks;
 
-	// dtable / dtablesize are used when reading blockdumps
-	std::unique_ptr<u32[]> m_dtable;
-	int m_dtablesize;
+	// dtable is used when reading blockdumps
+	std::vector<u32> m_dtable;
 
 	std::unique_ptr<wxFileOutputStream>	m_outstream;
 		

--- a/pcsx2/CDVD/OutputIsoFile.cpp
+++ b/pcsx2/CDVD/OutputIsoFile.cpp
@@ -47,9 +47,6 @@ void OutputIsoFile::_init()
 	m_blockofs		= 0;
 	m_blocksize		= 0;
 	m_blocks		= 0;
-
-	m_dtable		= 0;
-	m_dtablesize	= 0;
 }
 
 void OutputIsoFile::Create(const wxString& filename, int version)
@@ -93,12 +90,10 @@ void OutputIsoFile::WriteSector(const u8* src, uint lsn)
 	if (m_version == 2)
 	{	
 		// Find and ignore blocks that have already been dumped:
-		for (int i=0; i<m_dtablesize; ++i)
-		{
-			if (m_dtable[i] == lsn) return;
-		}
+		if (std::any_of(std::begin(m_dtable), std::end(m_dtable), [=](const u32 entry) {return entry == lsn;}))
+			return;
 
-		m_dtable[m_dtablesize++] = lsn;
+		m_dtable.push_back(lsn);
 
 		WriteValue<u32>( lsn );
 	}
@@ -114,7 +109,7 @@ void OutputIsoFile::WriteSector(const u8* src, uint lsn)
 
 void OutputIsoFile::Close()
 {
-	m_dtable.reset(nullptr);
+	m_dtable.clear();
 
 	_init();
 }

--- a/pcsx2/CDVD/OutputIsoFile.cpp
+++ b/pcsx2/CDVD/OutputIsoFile.cpp
@@ -133,3 +133,8 @@ bool OutputIsoFile::IsOpened() const
 {
 	return m_outstream && m_outstream->IsOk();
 }
+
+u32 OutputIsoFile::GetBlockSize() const
+{
+	return m_blocksize;
+}


### PR DESCRIPTION
Changes:
 * Fixes writing to V2 block dumps.
 * Switches to writing V2 block dumps.
 * Fixes CD blockdumps.

Fixes #2266.