### PR TITLE
PCSX2: Vsync Timing gamefix

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -70,6 +70,7 @@
 -- VIF1StallHack     = 1 // SOCOM II HUD and Spy Hunter loading hang.
 -- FMVinSoftwareHack = 1 // Silent Hill 2-3. Fixes FMVs that are obscured when using hardware rendering by switching to software rendering while an FMV plays.
 -- ScarfaceIbitHack  = 1 // VU I bit Hack avoid constant recompilation. ( Scarface The World Is Yours)
+-- VsyncTimingHack   = 1 // Alternate Vsync timing. Fixing timing issues in Jak II, Fatal Fury Battle Archives 1, Shadow Of Rome.
 
 ---------------------------------------------
 -- Speed Hacks (SpeedHackName = <value>)
@@ -485,6 +486,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20073
 Name   = Jak and Daxter II
 Region = NTSC-Unk
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCAJ-20074
 Name   = King of Fighters 2002, The
@@ -1697,6 +1699,7 @@ Serial = SCES-51608
 Name   = Jak II: Renegade
 Region = PAL-M7
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCES-51610
 Name   = This is Football 2004 (Red Devils 2004)
@@ -2800,6 +2803,7 @@ EETimingHack = 1 // Else serious slowdown due to VIF timing. Can be disabled onc
 Serial = SCKA-20010
 Name   = Jak II
 Region = NTSC-K
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCKA-20011
 Name   = Ratchet & Clank 2
@@ -3377,6 +3381,7 @@ Region = NTSC-J
 Serial = SCPS-15021
 Name   = Jak & Daxter 2
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCPS-15022
 Name   = Dual Hearts
@@ -3542,6 +3547,7 @@ MemCardFilter = SCPS-15056/SCPS-15037
 Serial = SCPS-15057
 Name   = Jak & Daxter 2
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCPS-15058
 Name   = Arc the Lad - Generation
@@ -5055,6 +5061,7 @@ Serial = SCUS-97265
 Name   = Jak II
 Region = NTSC-U
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCUS-97266
 Name   = Final Fantasy XI [Disc1of2]
@@ -5087,10 +5094,12 @@ Region = NTSC-U
 Serial = SCUS-97273
 Name   = Jak II [Demo]
 Region = NTSC-U
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCUS-97274
 Name   = Jak II [Video Demo]
 Region = NTSC-U
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCUS-97275
 Name   = SOCOM II - U.S. Navy SEALs
@@ -5793,6 +5802,7 @@ Region = NTSC-U
 Serial = SCUS-97509
 Name   = Jak II [Greatest Hits]
 Region = NTSC-U
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SCUS-97510
 Name   = ATV Off-Road Fury 2 [Greatest Hits]
@@ -12924,6 +12934,7 @@ Serial = SLES-52950
 Name   = Shadow of Rome
 Region = PAL-M5
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLES-52951
 Name   = Phantom Brave
@@ -16738,6 +16749,7 @@ Region = PAL-E
 Serial = SLES-54790
 Name   = Art of Fighting Anthology
 Region = PAL-E
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLES-54793
 Name   = WWE SmackDown vs. Raw 2008
@@ -17288,8 +17300,9 @@ Name   = Summer Athletics
 Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-55231
-Name   = Fatal Fury - Battle Archives Volume 1
+Name   = Fatal Fury Battle Archives Volume 1
 Region = PAL-E
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLES-55232
 Name   = SNK Arcade Classics Vol. 1
@@ -17298,6 +17311,7 @@ Region = PAL-E
 Serial = SLES-55233
 Name   = World Heroes Anthology
 Region = PAL-E
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLES-55237
 Name   = Naruto - Ultimate Ninja 3
@@ -24485,6 +24499,7 @@ Region = NTSC-J
 Serial = SLPM-65883
 Name   = Shadow of Rome
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPM-65884
 Name   = Remote Control Dandy SF
@@ -27641,6 +27656,7 @@ Region = NTSC-J
 Serial = SLPM-66745
 Name   = Shadow of Rome [CapKore]
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPM-66746
 Name   = Guilty Gear XX - Accent Core
@@ -32524,6 +32540,7 @@ Region = NTSC-J
 Serial = SLPS-25610
 Name   = Ryuuko no Ken - Ten-Chi-Jin (Art of Fighting Collection)
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPS-25611
 Name   = Strawberry Panic [Limited Edition]
@@ -32743,6 +32760,7 @@ Serial = SLPS-25664
 Name   = NeoGeo Online Collection - Garou Densetsu Battle Archives Vol.1
 Region = NTSC-J
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPS-25665
 Name   = Pachitte Chonmage Tatsujin 10
@@ -33199,6 +33217,7 @@ Compat = 5
 Serial = SLPS-25782
 Name   = World Heroes - Gorgeous
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPS-25783
 Name   = King of Fighters '98, The - Ultimate Match
@@ -33228,6 +33247,7 @@ Region = NTSC-J
 Serial = SLPS-25790
 Name   = Art of Fighting Collection [NeoGeo Online Collection the Best]
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPS-25791
 Name   = King of Fighters, The - Orochi Collection [NeoGeo Online Collection the Best]
@@ -33517,6 +33537,7 @@ Region = NTSC-J
 Serial = SLPS-25863
 Name   = Fatal Fury - Battle Archives 1 [SNK the Best]
 Region = NTSC-J
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLPS-25864
 Name   = Fatal Fury - Battle Archives 2 [SNK the Best]
@@ -38029,6 +38050,7 @@ Serial = SLUS-20902
 Name   = Shadow of Rome
 Region = NTSC-U
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLUS-20903
 Name   = MegaMan X - Command Mission
@@ -40967,6 +40989,7 @@ Serial = SLUS-21487
 Name   = Art of Fighting Anthology
 Region = NTSC-U
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLUS-21488
 Name   = dot Hack - G.U. Vol.2 - Reminisce
@@ -41049,9 +41072,10 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21537
-Name   = NeoGeo Fatal Fury Collection
+Name   = Fatal Fury Battle Archives Volume 1
 Region = NTSC-U
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLUS-21538
 Name   = Eureka Seven - Vol.2 - The New Vision
@@ -41919,6 +41943,7 @@ Serial = SLUS-21725
 Name   = World Heroes Anthology
 Region = NTSC-U
 Compat = 5
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLUS-21726
 Name   = Samurai Warriors 2 - Xtreme Legends
@@ -43417,6 +43442,7 @@ Region = NTSC-U
 Serial = SLUS-29139
 Name   = Shadow of Rome [Demo]
 Region = NTSC-U
+VsyncTimingHack = 1
 ---------------------------------------------
 Serial = SLUS-29140
 Name   = MX vs. ATV Unleashed [Demo]

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -59,6 +59,7 @@ enum GamefixId
 	Fix_FMVinSoftware,
 	Fix_GoemonTlbMiss,
 	Fix_ScarfaceIbit,
+	Fix_VsyncTiming,
 
 	GamefixId_COUNT
 };
@@ -362,7 +363,8 @@ struct Pcsx2Config
 				GIFFIFOHack		:1,		// Enabled the GIF FIFO (more correct but slower)
 				FMVinSoftwareHack:1,	// Toggle in and out of software rendering when an FMV runs.
 				GoemonTlbHack	:1,		// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
-				ScarfaceIbit 	:1;		// Scarface I bit hack. Needed to stop constant VU recompilation
+				ScarfaceIbit 	:1,		// Scarface I bit hack. Needed to stop constant VU recompilation
+				VsyncTimingHack:1;	// Fixes Vsync timing issues. Needed for Jak II, Fatal Fury Battle Archives, Shadow of Rome.
 		BITFIELD_END
 
 		GamefixOptions();
@@ -546,6 +548,7 @@ TraceLogFilters&				SetTraceConfig();
 #define CHECK_VIF1STALLHACK			(EmuConfig.Gamefixes.VIF1StallHack)  // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
 #define CHECK_GIFFIFOHACK			(EmuConfig.Gamefixes.GIFFIFOHack)	 // Enabled the GIF FIFO (more correct but slower)
 #define CHECK_FMVINSOFTWAREHACK	 	(EmuConfig.Gamefixes.FMVinSoftwareHack) // Toggle in and out of software rendering when an FMV runs.
+#define CHECK_VSYNCTIMINGHACK	 	(EmuConfig.Gamefixes.VsyncTiminghack) // Fixes vsync timing issues in a number of games.
 //------------ Advanced Options!!! ---------------
 #define CHECK_VU_OVERFLOW			(EmuConfig.Cpu.Recompiler.vuOverflow)
 #define CHECK_VU_EXTRA_OVERFLOW		(EmuConfig.Cpu.Recompiler.vuExtraOverflow) // If enabled, Operands are clamped before being used in the VU recs

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -198,9 +198,13 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, Fixed100 framesPerSecond, u32 s
 	u64 HalfFrame = Frame / 2;
 
 	// One test we have shows that VBlank lasts for ~22 HBlanks, another we have show that is the time it's off.
-	// There exists a game (Legendz Gekitou! Saga Battle) Which runs REALLY slowly if VBlank is ~22 HBlanks, so the other test wins.
+	// There's a game (Legendz Gekitou! Saga Battle) which runs REALLY slowly if VBlank is ~22 HBlanks, so the other test wins.
 
 	u64 Blank = HalfFrame / 2; // PAL VBlank Period is off for roughly 22 HSyncs
+
+	if (EmuConfig.Gamefixes.VsyncTimingHack)
+		// This fixes timing issues Jak II, Fatal Fury Battle Archives (1) and Shadow Of Rome
+		Blank = (Frame / scansPerFrame) * (gsVideoMode == GS_VideoMode::NTSC ? 26 : 22);
 
 	//I would have suspected this to be Frame - Blank, but that seems to completely freak it out
 	//and the test results are completely wrong. It seems 100% the same as the PS2 test on this,
@@ -346,8 +350,10 @@ u32 UpdateVSyncRate()
 	}
 
 	bool ActiveVideoMode = gsVideoMode != GS_VideoMode::Uninitialized;
-	if (vSyncInfo.Framerate != framerate || vSyncInfo.VideoMode != gsVideoMode)
+	static bool vSyncHack = EmuConfig.Gamefixes.VsyncTimingHack;
+	if (vSyncInfo.Framerate != framerate || vSyncInfo.VideoMode != gsVideoMode || vSyncHack != EmuConfig.Gamefixes.VsyncTimingHack)
 	{
+		vSyncHack = EmuConfig.Gamefixes.VsyncTimingHack;
 		vSyncInfo.VideoMode = gsVideoMode;
 		vSyncInfoCalc( &vSyncInfo, framerate, scanlines );
 		if(ActiveVideoMode)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -269,7 +269,8 @@ const wxChar *const tbl_GamefixNames[] =
 	L"GIFFIFO",
 	L"FMVinSoftware",
 	L"GoemonTlb",
-	L"ScarfaceIbit"
+	L"ScarfaceIbit",
+	L"VsyncTiming"
 };
 
 const __fi wxChar* EnumToString( GamefixId id )
@@ -333,6 +334,7 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_FMVinSoftware:	FMVinSoftwareHack	= enabled;  break;
 		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;  break;
 		case Fix_ScarfaceIbit:  ScarfaceIbit        = enabled;  break;
+		case Fix_VsyncTiming:   VsyncTimingHack     = enabled;  break;
 		jNO_DEFAULT;
 	}
 }
@@ -359,6 +361,7 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_FMVinSoftware:	return FMVinSoftwareHack;
 		case Fix_GoemonTlbMiss: return GoemonTlbHack;
 		case Fix_ScarfaceIbit:  return ScarfaceIbit;
+		case Fix_VsyncTiming:   return VsyncTimingHack;
 		jNO_DEFAULT;
 	}
 	return false;		// unreachable, but we still need to suppress warnings >_<
@@ -385,6 +388,7 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( FMVinSoftwareHack );
 	IniBitBool( GoemonTlbHack );
 	IniBitBool( ScarfaceIbit );
+	IniBitBool( VsyncTimingHack );
 }
 
 

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -147,7 +147,7 @@ void SysCoreThread::ApplySettings( const Pcsx2Config& src )
 
 	m_resetRecompilers		= ( src.Cpu != EmuConfig.Cpu ) || ( src.Gamefixes != EmuConfig.Gamefixes ) || ( src.Speedhacks != EmuConfig.Speedhacks );
 	m_resetProfilers		= ( src.Profiler != EmuConfig.Profiler );
-	m_resetVsyncTimers		= ( src.GS != EmuConfig.GS );
+	m_resetVsyncTimers		= ( src.GS != EmuConfig.GS ) || ( src.Gamefixes.VsyncTimingHack != EmuConfig.Gamefixes.VsyncTimingHack );
 
 	const_cast<Pcsx2Config&>(EmuConfig) = src;
 }

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -107,6 +107,10 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 		{
 			_("VU I bit Hack avoid constant recompilation (Scarface The World Is Yours)"),
 			wxEmptyString
+		},
+		{
+			_("Alternate Vsync timing. Fixing timing issues in Jak II, Fatal Fury Battle Archives, Shadow Of Rome."),
+			wxEmptyString
 		}
 	};
 


### PR DESCRIPTION
Adds Vsync timing gamefix to Gamefixes panel of the UI. Fixes timing issues in Jak II (randomly runs too fast), Fatal Fury Battle Archives Volume 1 (runs at half-speed) and Shadow Of Rome (FMV timing issues).

Close: #360
Close: #1712