### PR TITLE
pcsx2: Fix copy byte patch command

### DIFF
--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -74,11 +74,11 @@ void handle_extended_t(IniPatch *p)
 		PrevCheatType = 0;
 		break;
 
-	case 0x5000: // dddddddd iiiiiiii
+	case 0x5000: // bbbbbbbb 00000000
 		for (u32 i = 0; i < IterationCount; i++)
 		{
 			u8 mem = memRead8(PrevCheatAddr + i);
-			memWrite8(((u32)p->data) + i, mem);
+			memWrite8((p->addr + i) & 0x0FFFFFFF, mem);
 		}
 		PrevCheatType = 0;
 		break;


### PR DESCRIPTION
This adjusts the copy bytes command format from
5aaaaaaa nnnnnnnn
00000000 bbbbbbbb
to
5aaaaaaa nnnnnnnn
bbbbbbbb 00000000
so that it matches the copy bytes command format used by PS2 cheat
devices (GS/CB/XP/AR2).

**Note**: This isn't really my PR. A user emailed me this, and I think it makes sense. A portion of the email is below:
> I was trying to create a copy code for a ps2 game on pcsx2 emulator and it wasn't working, so I tested it on my old PS2 console with codebreaker and my code worked just as I intended.
That made me curious what pcsx2 was doing differently, so I looked into the source and found the "problem". later I found a topic where the same problem was addressed some years ago and nicely summarized: https://forums.pcsx2.net/Thread-About-the-implementation-of-type-5-cheat-code?highlight=5aaaaaaa
> pcsx2 src@Jan2018   vs   Codemasters Project Description (  
http://www.codemasters-project.net/portal-english/apportal/cmp_plugins/content/content.php?content.23  
)
(commit:ab44ebd)    vs   (Standard Formats (CB/GS/XP/AR2) / CB7+)
5aaaaaaa nnnnnnnn   vs   5aaaaaaa nnnnnnnn
00000000 bbbbbbbb   vs   bbbbbbbb 00000000
a = Address to copy from
b = Address to copy to
n = Number of bytes to copy