### PR TITLE
 cdvdgigaherz:windows: Avoid unneeded DVD ioctls

### DIFF
--- a/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
@@ -206,43 +206,42 @@ bool IOCtlSrc::ReadDVDInfo()
     std::array<u8, 22> buffer;
     DVD_READ_STRUCTURE dvdrs{{0}, DvdPhysicalDescriptor, 0, 0};
 
-    BOOL ret = DeviceIoControl(m_device, IOCTL_DVD_READ_STRUCTURE, &dvdrs, sizeof(dvdrs),
-                          buffer.data(), buffer.size(), &unused, nullptr);
-    if (ret) {
-        auto &layer = *reinterpret_cast<DVD_LAYER_DESCRIPTOR *>(
-            reinterpret_cast<DVD_DESCRIPTOR_HEADER *>(buffer.data())->Data);
+    if (!DeviceIoControl(m_device, IOCTL_DVD_READ_STRUCTURE, &dvdrs, sizeof(dvdrs),
+                         buffer.data(), buffer.size(), &unused, nullptr))
+        return false;
 
-        u32 start_sector = _byteswap_ulong(layer.StartingDataSector);
-        u32 end_sector = _byteswap_ulong(layer.EndDataSector);
+    auto &layer = *reinterpret_cast<DVD_LAYER_DESCRIPTOR *>(
+        reinterpret_cast<DVD_DESCRIPTOR_HEADER *>(buffer.data())->Data);
 
-        if (layer.NumberOfLayers == 0) {
-            // Single layer
-            m_media_type = 0;
-            m_layer_break = 0;
-            m_sectors = end_sector - start_sector + 1;
-        } else if (layer.TrackPath == 0) {
-            // Dual layer, Parallel Track Path
-            dvdrs.LayerNumber = 1;
-            ret = DeviceIoControl(m_device, IOCTL_DVD_READ_STRUCTURE, &dvdrs,
-                                  sizeof(dvdrs), buffer.data(), buffer.size(), &unused, nullptr);
-            if (ret) {
-                u32 layer1_start_sector = _byteswap_ulong(layer.StartingDataSector);
-                u32 layer1_end_sector = _byteswap_ulong(layer.EndDataSector);
+    u32 start_sector = _byteswap_ulong(layer.StartingDataSector);
+    u32 end_sector = _byteswap_ulong(layer.EndDataSector);
 
-                m_media_type = 1;
-                m_layer_break = end_sector - start_sector;
-                m_sectors = end_sector - start_sector + 1 + layer1_end_sector - layer1_start_sector + 1;
-            }
-        } else {
-            // Dual layer, Opposite Track Path
-            u32 end_sector_layer0 = _byteswap_ulong(layer.EndLayerZeroSector);
-            m_media_type = 2;
-            m_layer_break = end_sector_layer0 - start_sector;
-            m_sectors = end_sector_layer0 - start_sector + 1 + end_sector - (~end_sector_layer0 & 0xFFFFFFU) + 1;
-        }
+    if (layer.NumberOfLayers == 0) {
+        // Single layer
+        m_media_type = 0;
+        m_layer_break = 0;
+        m_sectors = end_sector - start_sector + 1;
+    } else if (layer.TrackPath == 0) {
+        // Dual layer, Parallel Track Path
+        dvdrs.LayerNumber = 1;
+        if (!DeviceIoControl(m_device, IOCTL_DVD_READ_STRUCTURE, &dvdrs, sizeof(dvdrs),
+                             buffer.data(), buffer.size(), &unused, nullptr))
+            return false;
+        u32 layer1_start_sector = _byteswap_ulong(layer.StartingDataSector);
+        u32 layer1_end_sector = _byteswap_ulong(layer.EndDataSector);
+
+        m_media_type = 1;
+        m_layer_break = end_sector - start_sector;
+        m_sectors = end_sector - start_sector + 1 + layer1_end_sector - layer1_start_sector + 1;
+    } else {
+        // Dual layer, Opposite Track Path
+        u32 end_sector_layer0 = _byteswap_ulong(layer.EndLayerZeroSector);
+        m_media_type = 2;
+        m_layer_break = end_sector_layer0 - start_sector;
+        m_sectors = end_sector_layer0 - start_sector + 1 + end_sector - (~end_sector_layer0 & 0xFFFFFFU) + 1;
     }
 
-    return !!ret;
+    return true;
 }
 
 bool IOCtlSrc::ReadCDInfo()


### PR DESCRIPTION
Avoid using the IOCTL_DVD_START_SESSION and IOCTL_DVD_END_SESSION ioctls - it's not necessary to obtain an Authentication Grant ID (AGID) before requesting the DVD physical format layer descriptor.
