### PR TITLE
pcsx2: Fix trace logging behaviour and dialog

### DIFF
--- a/common/src/Utilities/CheckedStaticBox.cpp
+++ b/common/src/Utilities/CheckedStaticBox.cpp
@@ -35,6 +35,7 @@ CheckedStaticBox::CheckedStaticBox(wxWindow *parent, int orientation, const wxSt
 void CheckedStaticBox::MainToggle_Click(wxCommandEvent &evt)
 {
     SetValue(evt.IsChecked());
+    evt.Skip();
 }
 
 // Sets the main checkbox status, and enables/disables all child controls
@@ -46,7 +47,7 @@ void CheckedStaticBox::SetValue(bool val)
     for (wxWindowList::iterator iter = list.begin(); iter != list.end(); ++iter) {
         wxWindow *current = *iter;
         if (current != &ThisToggle)
-            current->Enable(val);
+            current->Enable(IsEnabled() && val);
     }
     ThisToggle.SetValue(val);
 }

--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -72,7 +72,10 @@ public:
 		: TextFileTraceLog( &desc->base ) {}
 
 	void DoWrite( const char *fmt ) const;
-
+	bool IsActive() const override
+	{
+		return EmuConfig.Trace.Enabled && Enabled;
+	}
 };
 
 class SysTraceLog_EE : public SysTraceLog
@@ -85,7 +88,7 @@ public:
 	void ApplyPrefix( FastFormatAscii& ascii ) const;
 	bool IsActive() const
 	{
-		return EmuConfig.Trace.Enabled && Enabled && EmuConfig.Trace.EE.m_EnableAll;
+		return SysTraceLog::IsActive() && EmuConfig.Trace.EE.m_EnableAll;
 	}
 	
 	wxString GetCategory() const { return L"EE"; }
@@ -157,7 +160,7 @@ public:
 	void ApplyPrefix( FastFormatAscii& ascii ) const;
 	bool IsActive() const
 	{
-		return EmuConfig.Trace.Enabled && Enabled && EmuConfig.Trace.IOP.m_EnableAll;
+		return SysTraceLog::IsActive() && EmuConfig.Trace.IOP.m_EnableAll;
 	}
 
 	wxString GetCategory() const { return L"IOP"; }

--- a/pcsx2/gui/Panels/LogOptionsPanels.cpp
+++ b/pcsx2/gui/Panels/LogOptionsPanels.cpp
@@ -265,7 +265,7 @@ Panels::LogOptionsPanel::LogOptionsPanel(wxWindow* parent )
 	*this		+= topSizer						| StdExpand();
 	*this		+= s_misc						| StdSpace().Centre();
 
-	Bind(wxEVT_CHECKBOX, &LogOptionsPanel::OnCheckBoxClicked, this);
+	Bind(wxEVT_CHECKBOX, &LogOptionsPanel::OnCheckBoxClicked, this, m_masterEnabler->GetWxPtr()->GetId());
 }
 
 Panels::BaseCpuLogOptionsPanel* Panels::LogOptionsPanel::GetCpuPanel( const wxString& token ) const
@@ -303,21 +303,16 @@ void Panels::LogOptionsPanel::OnUpdateEnableAll()
 
 void Panels::LogOptionsPanel::OnCheckBoxClicked(wxCommandEvent &evt)
 {
-	m_IsDirty = true;
-	if( evt.GetId() == m_masterEnabler->GetWxPtr()->GetId() )
-		OnUpdateEnableAll();
+	OnUpdateEnableAll();
+	evt.Skip();
 }
 
 void Panels::LogOptionsPanel::Apply()
 {
-	if( !m_IsDirty ) return;
-
 	g_Conf->EmuOptions.Trace.Enabled	= m_masterEnabler->GetValue();
 
 	m_eeSection->Apply();
 	m_iopSection->Apply();
-
-	m_IsDirty = false;
 
 	for( uint i = 0; i<traceLogCount; ++i )
 	{

--- a/pcsx2/gui/Panels/LogOptionsPanels.cpp
+++ b/pcsx2/gui/Panels/LogOptionsPanels.cpp
@@ -206,7 +206,7 @@ Panels::LogOptionsPanel::LogOptionsPanel(wxWindow* parent )
 	: BaseApplicableConfigPanel( parent )
 	, m_checks( new pxCheckBox*[traceLogCount] )
 {
-	wxStaticBoxSizer&	s_misc		= *new wxStaticBoxSizer( wxHORIZONTAL, this, L"Misc" );
+	m_miscSection = new wxStaticBoxSizer( wxHORIZONTAL, this, L"Misc" );
 
 	m_eeSection		= new eeLogOptionsPanel( this );
 	m_iopSection	= new iopLogOptionsPanel( this );
@@ -238,8 +238,8 @@ Panels::LogOptionsPanel::LogOptionsPanel(wxWindow* parent )
 		}
 		else
 		{
-			addsizer = &s_misc;
-			addparent = this;
+			addsizer = m_miscSection;
+			addparent = m_miscSection->GetStaticBox();
 		}
 
 		*addsizer += m_checks[i] = new pxCheckBox( addparent, item.GetName() );
@@ -263,7 +263,7 @@ Panels::LogOptionsPanel::LogOptionsPanel(wxWindow* parent )
 	*this		+= new wxStaticLine( this )		| StdExpand().Border(wxLEFT | wxRIGHT, 20);
 	*this		+= 5;
 	*this		+= topSizer						| StdExpand();
-	*this		+= s_misc						| StdSpace().Centre();
+	*this		+= m_miscSection				| StdSpace().Centre();
 
 	Bind(wxEVT_CHECKBOX, &LogOptionsPanel::OnCheckBoxClicked, this, m_masterEnabler->GetWxPtr()->GetId());
 }
@@ -299,6 +299,7 @@ void Panels::LogOptionsPanel::OnUpdateEnableAll()
 
 	m_eeSection->Enable( enabled );
 	m_iopSection->Enable( enabled );
+	m_miscSection->GetStaticBox()->Enable( enabled );
 }
 
 void Panels::LogOptionsPanel::OnCheckBoxClicked(wxCommandEvent &evt)

--- a/pcsx2/gui/Panels/LogOptionsPanels.h
+++ b/pcsx2/gui/Panels/LogOptionsPanels.h
@@ -76,7 +76,6 @@ namespace Panels
 	protected:
 		eeLogOptionsPanel*	m_eeSection;
 		iopLogOptionsPanel*	m_iopSection;
-		bool				m_IsDirty;		// any settings modified since last apply will flag this "true"
 
 		pxCheckBox*			m_masterEnabler;
 

--- a/pcsx2/gui/Panels/LogOptionsPanels.h
+++ b/pcsx2/gui/Panels/LogOptionsPanels.h
@@ -76,6 +76,7 @@ namespace Panels
 	protected:
 		eeLogOptionsPanel*	m_eeSection;
 		iopLogOptionsPanel*	m_iopSection;
+		wxStaticBoxSizer*	m_miscSection;
 
 		pxCheckBox*			m_masterEnabler;
 


### PR DESCRIPTION
Fixes the following issues in the Trace Logging dialog:
 * The apply button does not enable when something has changed.
 * The checkboxes may appear to be incorrectly enabled.
 * The misc section is not disabled if the master trace logging checkbox is unchecked.

Fixes the following trace logging behaviour:
 * SIF logging is not disabled if the master trace logging switch is disabled.

Note: Only testable with devel/debug builds.