### PR TITLE
PCSX2: Remove obsolete "DisableOutput" option from core/GUI

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -295,7 +295,7 @@ struct Pcsx2Config
 		// forces the MTGS to execute tags/tasks in fully blocking/synchronous
 		// style.  Useful for debugging potential bugs in the MTGS pipeline.
 		bool	SynchronousMTGS;
-		bool	DisableOutput;
+
 		int		VsyncQueueSize;
 
 		bool		FrameLimitEnable;
@@ -318,7 +318,6 @@ struct Pcsx2Config
 		{
 			return
 				OpEqu( SynchronousMTGS )		&&
-				OpEqu( DisableOutput )			&&
 				OpEqu( VsyncQueueSize )			&&
 				
 				OpEqu( FrameSkipEnable )		&&

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -297,11 +297,6 @@ void SysMtgsThread::ExecuteTaskInThread()
 		// ever be modified by this thread.
 		while( m_ReadPos.load(std::memory_order_relaxed) != m_WritePos.load(std::memory_order_acquire))
 		{
-			if (EmuConfig.GS.DisableOutput) {
-				m_ReadPos = m_WritePos.load();
-				continue;
-			}
-
 			const unsigned int local_ReadPos = m_ReadPos.load(std::memory_order_relaxed);
 
 			pxAssert( local_ReadPos < RingBufferSize );

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -204,7 +204,6 @@ Pcsx2Config::GSOptions::GSOptions()
 	VsyncEnable				= VsyncMode::Off;
 
 	SynchronousMTGS			= false;
-	DisableOutput			= false;
 	VsyncQueueSize			= 2;
 
 	FramesToDraw			= 2;
@@ -220,7 +219,6 @@ void Pcsx2Config::GSOptions::LoadSave( IniInterface& ini )
 	ScopedIniGroup path( ini, L"GS" );
 
 	IniEntry( SynchronousMTGS );
-	IniEntry( DisableOutput );
 	IniEntry( VsyncQueueSize );
 
 	IniEntry( FrameLimitEnable );

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -419,7 +419,6 @@ void GSPanel::AppStatusEvent_OnSettingsApplied()
 	if( IsBeingDeleted() ) return;
 	DoResize();
 	DoShowMouse();
-	Show( !EmuConfig.GS.DisableOutput );
 }
 
 void GSPanel::OnLeftDclick(wxMouseEvent& evt)
@@ -445,15 +444,9 @@ GSFrame::GSFrame( const wxString& title)
 	SetIcons( wxGetApp().GetIconBundle() );
 	SetBackgroundColour( *wxBLACK );
 
-	wxStaticText* label = new wxStaticText( this, wxID_ANY, _("GS Output is Disabled!") );
-	m_id_OutputDisabled = label->GetId();
-	label->SetFont( pxGetFixedFont( 20, wxFONTWEIGHT_BOLD ) );
-	label->SetForegroundColour( *wxWHITE );
-
 	AppStatusEvent_OnSettingsApplied();
 
 	GSPanel* gsPanel = new GSPanel( this );
-	gsPanel->Show( !EmuConfig.GS.DisableOutput );
 	m_id_gspanel = gsPanel->GetId();
 
 	// TODO -- Implement this GS window status window!  Whee.
@@ -502,12 +495,6 @@ bool GSFrame::ShowFullScreen(bool show, bool updateConfig)
 }
 
 
-
-wxStaticText* GSFrame::GetLabel_OutputDisabled() const
-{
-	return (wxStaticText*)FindWindowById( m_id_OutputDisabled );
-}
-
 void GSFrame::CoreThread_OnResumed()
 {
 	m_timer_UpdateTitle.Start( TitleBarUpdateMs );
@@ -542,12 +529,8 @@ bool GSFrame::Show( bool shown )
 			m_id_gspanel = gsPanel->GetId();
 		}
 
-		gsPanel->Show( !EmuConfig.GS.DisableOutput );
 		gsPanel->DoResize();
 		gsPanel->SetFocus();
-
-		if( wxStaticText* label = GetLabel_OutputDisabled() )
-			label->Show( EmuConfig.GS.DisableOutput );
 
 		if( !m_timer_UpdateTitle.IsRunning() )
 			m_timer_UpdateTitle.Start( TitleBarUpdateMs );
@@ -575,9 +558,6 @@ void GSFrame::AppStatusEvent_OnSettingsApplied()
 		if( IsShown() && !CorePlugins.IsOpen(PluginId_GS) )
 			Show( false );
 	}
-
-	if( wxStaticText* label = GetLabel_OutputDisabled() )
-		label->Show( EmuConfig.GS.DisableOutput );
 }
 
 GSPanel* GSFrame::GetViewport()
@@ -713,9 +693,6 @@ void GSFrame::OnResize( wxSizeEvent& evt )
 	{
 		g_Conf->GSWindow.WindowSize	= GetClientSize();
 	}
-
-	if( wxStaticText* label = GetLabel_OutputDisabled() )
-		label->CentreOnParent();
 
 	if( GSPanel* gsPanel = GetViewport() )
 	{

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -89,8 +89,6 @@ class GSFrame : public wxFrame
 protected:
 	wxTimer					m_timer_UpdateTitle;
 	wxWindowID				m_id_gspanel;
-	wxWindowID				m_id_OutputDisabled;
-	wxStaticText*			m_label_Disabled;
 	wxStatusBar*			m_statusbar;
 
 	CpuUsageProvider		m_CpuUsage;
@@ -102,7 +100,6 @@ public:
 	GSPanel* GetViewport();
 	void SetFocus();
 	bool Show( bool shown=true );
-	wxStaticText* GetLabel_OutputDisabled() const;
 
 	bool ShowFullScreen(bool show, bool updateConfig = true);
 

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -305,7 +305,6 @@ namespace Panels
 	protected:
 		pxCheckBox*			m_check_SynchronousGS;
 		wxButton*			m_restore_defaults;
-		pxCheckBox*			m_check_DisableOutput;
 		FrameSkipPanel*		m_span;
 		FramelimiterPanel*	m_fpan;
 

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -293,17 +293,8 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 
 	m_restore_defaults = new wxButton(right, wxID_DEFAULT, _("Restore Defaults"));
 
-	m_check_DisableOutput = new pxCheckBox( left, _("Disable all GS output"),
-		_t("Completely disables all GS plugin activity; ideal for benchmarking EEcore components.")
-	);
-
 	m_check_SynchronousGS->SetToolTip( pxEt( L"Enable this if you think MTGS thread sync is causing crashes or graphical errors.")
 	) ;
-
-	m_check_DisableOutput->SetToolTip( pxEt( L"Removes any benchmark noise caused by the MTGS thread or GPU overhead.  This option is best used in conjunction with savestates: save a state at an ideal scene, enable this option, and re-load the savestate.\n\nWarning: This option can be enabled on-the-fly but typically cannot be disabled on-the-fly (video will typically be garbage)."
-	) );
-
-	m_check_DisableOutput->Hide(); // Band-aid fix since currently broken
 
 	//GSWindowSettingsPanel* winpan = new GSWindowSettingsPanel( left );
 	//winpan->AddFrame(_("Display/Window"));
@@ -325,7 +316,6 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 	*left		+= m_fpan		| pxExpand;
 	*left		+= 5;
 	*left		+= m_check_SynchronousGS | StdExpand();
-	*left		+= m_check_DisableOutput;
 
 	*s_table	+= left		| StdExpand();
 	*s_table	+= right	| StdExpand();
@@ -357,7 +347,6 @@ void Panels::VideoPanel::OnOpenWindowSettings( wxCommandEvent& evt )
 void Panels::VideoPanel::Apply()
 {
 	g_Conf->EmuOptions.GS.SynchronousMTGS	= m_check_SynchronousGS->GetValue();
-	g_Conf->EmuOptions.GS.DisableOutput		= m_check_DisableOutput->GetValue();
 }
 
 void Panels::VideoPanel::AppStatusEvent_OnSettingsApplied()
@@ -368,10 +357,8 @@ void Panels::VideoPanel::AppStatusEvent_OnSettingsApplied()
 void Panels::VideoPanel::ApplyConfigToGui( AppConfig& configToApply, int flags ){
 	
 	m_check_SynchronousGS->SetValue( configToApply.EmuOptions.GS.SynchronousMTGS );
-	m_check_DisableOutput->SetValue( configToApply.EmuOptions.GS.DisableOutput );
 
 	m_check_SynchronousGS->Enable(!configToApply.EnablePresets);
-	m_check_DisableOutput->Enable(!configToApply.EnablePresets);
 
 	if( flags & AppConfig::APPLY_FLAG_MANUALLY_PROPAGATE )
 	{


### PR DESCRIPTION
It's been broken/unused for some time.