### PR TITLE
PCSX2-Counters: Fix rounding of blank and render

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -229,11 +229,12 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, Fixed100 framesPerSecond, u32 s
 	info->hScanlinesPerFrame = scansPerFrame;
 
 	// Apply rounding:
-	if ((Render - info->Render) >= 5000) info->Render++;
-	else if ((Blank - info->Blank) >= 5000) info->Blank++;
+	// To investigate: Why is render rounding prioritized over blank? why skip the latter?
+	if ((Render % 10000) >= 5000) info->Render++;
+	else if ((Blank % 10000) >= 5000) info->Blank++;
 
-	if ((hRender - info->hRender) >= 5000) info->hRender++;
-	else if ((hBlank - info->hBlank) >= 5000) info->hBlank++;
+	if ((hRender % 10000) >= 5000) info->hRender++;
+	else if ((hBlank % 10000) >= 5000) info->hBlank++;
 
 	// Calculate accumulative hSync rounding error per half-frame:
 	if (IsAnalogVideoMode()) // gets off the chart in that mode


### PR DESCRIPTION
**Summary of changes**:

* Fix rounding of horizontal/vertical render and blank, the older rounding logic was totally wrong.

**Note**: I'm not expecting much from this, it's a really small change. If the render was 804 before, it _could_ be 805 now, that's about it. I rather doubt this might lead to any sort of significant changes in a game.