### PR TITLE
GSdx: Remove GT4/Tourist Trophy CRC hacks

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -147,14 +147,14 @@ CRC::Game CRC::m_games[] =
 	{0x7ABDBB5E, GT3, CH, 0}, // cutie comment
 	{0x3E9D448A, GT3, CH, 0}, // cutie comment
 	{0xAD66643C, GT3, CH, 0}, // cutie comment
-	{0x6810C3BC, GT3, CH, 0}, //GRAN TURISMO Concept 2002 Tokyo-Geneva
+	{0x6810C3BC, GT3, CH, 0}, // Gran Turismo Concept 2002 Tokyo-Geneva
 	{0x85AE91B3, GT3, US, 0},
 	{0x8AA991B0, GT3, US, 0},
 	{0xC220951A, GT3, JP, 0},
 	{0x9DE5CF65, GT3, JP, 0}, //Gran Turismo 3: A-spec
 	{0x60013EBD, GTConcept, EU, 0},
 	{0xB590CE04, GTConcept, EU, 0},
-	{0x0EEF32A3, GTConcept, KO, 0}, //Gran Turismo Concept 2002 Tokyo-Seoul
+	{0x0EEF32A3, GTConcept, KO, 0}, // Gran Turismo Concept 2002 Tokyo-Seoul
 	{0xC164550A, WildArms5, JPUNDUB, 0},
 	{0xC1640D2C, WildArms5, US, 0},
 	{0x0FCF8FE4, WildArms5, EU, 0},
@@ -463,7 +463,7 @@ CRC::Game CRC::m_games[] =
 	{0x4A4B623A, FightingBeautyWulong, JP,0}, // cutie comment
 	{0x5AC7E79C, TouristTrophy, CH, 0}, // cutie comment
 	{0xFF9C0E93, TouristTrophy, US, 0},
-	{0xCA9AA903, TouristTrophy, EU, 0}, //crc hack not fully working on PAL, still needs brightness =0
+	{0xCA9AA903, TouristTrophy, EU, 0},
 	{0xA1B3F232, GTASanAndreas, EU, 0}, // cutie comment
 	{0xB440A8FE, GTASanAndreas, EU, 0},
 	{0x399A49CA, GTASanAndreas, US, 0},

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -1272,37 +1272,9 @@ bool GSC_ICO(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_GT4(const GSFrameInfo& fi, int& skip)
-{
-	// Game requires to extract source from RT (block boundary) (texture cache limitation)
-	if(skip == 0)
-	{
-		if(Aggressive)
-		{
-			// Removes layer obscuring the screen when the in-game brightness or contrast setting is set to any value but 0.
-			// The hack can cause VRAM/RAM spikes when both brightness and contrast settings are set to 0.
-			if(fi.TME && fi.FBP >= 0x02f00 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01180 /*|| fi.TBP0 == 0x01a40*/) && fi.TPSM == PSM_PSMT8) //TBP0 0x1a40 progressive
-			{
-			skip = 770;	// ntsc, progressive 1540
-			}
-			if(g_crc_region == CRC::EU && fi.TME && fi.FBP >= 0x03400 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01400 ) && fi.TPSM == PSM_PSMT8)
-			{
-			skip = 880;	// pal
-			}
-		}
-		else if(fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x01400) && fi.FPSM == PSM_PSMCT24 && fi.TBP0 >= 0x03420 && fi.TPSM == PSM_PSMT8)
-		{
-			// TODO: removes gfx from where it is not supposed to (garage)
-			// skip = 58;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_GT3(const GSFrameInfo& fi, int& skip)
 {
-	// Same issue as GSC_GT4 ???
+	// Same issue as GT4??? The GT4 hack removed layer obscuring the screen when the in-game brightness or contrast setting is set to any value but 0.
 	if(skip == 0)
 	{
 		if(fi.TME && fi.FBP >= 0x02de0 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01180) && fi.TPSM == PSM_PSMT8)
@@ -1316,29 +1288,12 @@ bool GSC_GT3(const GSFrameInfo& fi, int& skip)
 
 bool GSC_GTConcept(const GSFrameInfo& fi, int& skip)
 {
-	// Same issue as GSC_GT4 ???
+	// Same issue as GSC_GT3/GT4 ???
 	if(skip == 0)
 	{
 		if(fi.TME && fi.FBP >= 0x03420 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01400) && fi.TPSM == PSM_PSMT8)
 		{
 			skip = 880;
-		}
-	}
-
-	return true;
-}
-
-bool GSC_TouristTrophy(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(fi.TME && fi.FBP >= 0x02f00 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01180) && fi.TPSM == PSM_PSMT8)
-		{
-			skip = 770;
-		}
-		if(fi.TME && fi.FBP >= 0x02de0 && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 ==0 || fi.TBP0==0x1a40 ||fi.TBP0 ==0x2300) && fi.TPSM == PSM_PSMT8)
-		{
-			skip = 770; //480P
 		}
 	}
 
@@ -2428,8 +2383,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::StarWarsBattlefront2] = GSC_StarWarsBattlefront2;
 		lut[CRC::StarWarsBattlefront] = GSC_StarWarsBattlefront;
 		// Dedicated shader for channel effect
-		lut[CRC::TouristTrophy] = GSC_TouristTrophy;
-		lut[CRC::GT4] = GSC_GT4;
 		lut[CRC::GT3] = GSC_GT3;
 		lut[CRC::GTConcept] = GSC_GTConcept;
 		lut[CRC::TalesOfAbyss] = GSC_TalesOfAbyss;


### PR DESCRIPTION
Removes GT4/Tourist Trophy CRC hacks. The hack had already been moved to
aggressive due to VRAM spike issues, but is no longer necessary at all
due to the in-game brightness/contrast setting issue being moved to
behind the frame buffer conversion hack for Direct3D and being resolved for OpenGL.