### PR TITLE
GameDB: Scarface

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -15659,16 +15659,6 @@ Name   = Scarface - The World is Yours
 Region = PAL-R
 ScarfaceIbitHack = 1
 ---------------------------------------------
-Serial = SLES-54271
-Name   = Scarface - The World is Yours
-Region = PAL-E
-ScarfaceIbitHack = 1
----------------------------------------------
-Serial = SLES-54534
-Name   = Scarface - The World is Yours [Collector's Edition]
-Region = PAL-E
-ScarfaceIbitHack = 1
----------------------------------------------
 Serial = SLES-54185
 Name   = Dirge of Cerberus - Final Fantasy VII
 Region = PAL-M5
@@ -15877,6 +15867,11 @@ Compat = 5
 Serial = SLES-54256
 Name   = WWII - Battle Over the Pacific
 Region = PAL-E
+---------------------------------------------
+Serial = SLES-54271
+Name   = Scarface - The World is Yours
+Region = PAL-E
+ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLES-54305
 Name   = Demon Chaos
@@ -16370,6 +16365,11 @@ Region = PAL-M5
 Serial = SLES-54527
 Name   = Flushed Away
 Region = PAL-M5
+---------------------------------------------
+Serial = SLES-54534
+Name   = Scarface - The World is Yours [Collector's Edition]
+Region = PAL-E
+ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLES-54541
 Name   = Xena - Warrior Princess

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -15644,15 +15644,6 @@ Name   = Gottlieb Pinball Classics
 Region = PAL-M5
 Compat = 5
 ---------------------------------------------
-Serial = SLUS-21111
-Name   = Scarface - The World is Yours
-Region = NTSC-U
-Compat = 4
----------------------------------------------
-Serial = SLUS-21492
-Name   = Scarface - The World is Yours [Collector's Edition]
-Region = NTSC-U
----------------------------------------------
 Serial = SLES-54182
 Name   = Scarface - The World is Yours
 Region = PAL-M4
@@ -39103,6 +39094,11 @@ Name   = Pirates of the Caribbean - The Legend of Jack Sparrow
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
+Serial = SLUS-21111
+Name   = Scarface - The World is Yours
+Region = NTSC-U
+Compat = 4
+---------------------------------------------
 Serial = SLUS-21112
 Name   = L.A. Rush
 Region = NTSC-U
@@ -41003,6 +40999,10 @@ Serial = SLUS-21491
 Name   = World Series of Poker - Tournament of Champions
 Region = NTSC-U
 Compat = 5
+---------------------------------------------
+Serial = SLUS-21492
+Name   = Scarface - The World is Yours [Collector's Edition]
+Region = NTSC-U
 ---------------------------------------------
 Serial = SLUS-21493
 Name   = Need for Speed - Carbon

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -69,7 +69,7 @@
 -- VIFFIFOHack       = 1 // Transformers Armada, Test Drive Unlimited. Fixes slow booting issue.
 -- VIF1StallHack     = 1 // SOCOM II HUD and Spy Hunter loading hang.
 -- FMVinSoftwareHack = 1 // Silent Hill 2-3. Fixes FMVs that are obscured when using hardware rendering by switching to software rendering while an FMV plays.
--- ScarfaceIbitHack  = 1 // VU I bit Hack avoid constant recompilation. ( Scarface The World Is Yours)
+-- ScarfaceIbitHack  = 1 // VU I bit Hack avoid constant recompilation (Scarface The World Is Yours).
 
 ---------------------------------------------
 -- Speed Hacks (SpeedHackName = <value>)
@@ -15644,9 +15644,18 @@ Name   = Gottlieb Pinball Classics
 Region = PAL-M5
 Compat = 5
 ---------------------------------------------
+Serial = SLUS-21111
+Name   = Scarface - The World is Yours
+Region = NTSC-U
+Compat = 4
+---------------------------------------------
+Serial = SLUS-21492
+Name   = Scarface - The World is Yours [Collector's Edition]
+Region = NTSC-U
+---------------------------------------------
 Serial = SLES-54182
 Name   = Scarface - The World is Yours
-Region = PAL-F
+Region = PAL-M4
 ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLES-54183
@@ -15657,6 +15666,16 @@ ScarfaceIbitHack = 1
 Serial = SLES-54184
 Name   = Scarface - The World is Yours
 Region = PAL-R
+ScarfaceIbitHack = 1
+---------------------------------------------
+Serial = SLES-54271
+Name   = Scarface - The World is Yours
+Region = PAL-E
+ScarfaceIbitHack = 1
+---------------------------------------------
+Serial = SLES-54534
+Name   = Scarface - The World is Yours [Collector's Edition]
+Region = PAL-E
 ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLES-54185
@@ -15867,11 +15886,6 @@ Compat = 5
 Serial = SLES-54256
 Name   = WWII - Battle Over the Pacific
 Region = PAL-E
----------------------------------------------
-Serial = SLES-54271
-Name   = Scarface - The World is Yours
-Region = PAL-E
-ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLES-54305
 Name   = Demon Chaos
@@ -39089,11 +39103,6 @@ Name   = Pirates of the Caribbean - The Legend of Jack Sparrow
 Region = NTSC-U
 Compat = 5
 ---------------------------------------------
-Serial = SLUS-21111
-Name   = Scarface - The World is Yours
-Region = NTSC-U
-Compat = 4
----------------------------------------------
 Serial = SLUS-21112
 Name   = L.A. Rush
 Region = NTSC-U
@@ -40994,10 +41003,6 @@ Serial = SLUS-21491
 Name   = World Series of Poker - Tournament of Champions
 Region = NTSC-U
 Compat = 5
----------------------------------------------
-Serial = SLUS-21492
-Name   = Scarface [Collector's Edition]
-Region = NTSC-U
 ---------------------------------------------
 Serial = SLUS-21493
 Name   = Need for Speed - Carbon


### PR DESCRIPTION
 • Corrected typo errors in the description of the ScarfaceIbitHack fix.
 • Added SLES-54534, and applied the ScarfaceIbitHack fix to it since the other PAL discs have it.
 • Corrected the regioncode for SLES-54182 from PAL-F to PAL-M4.
 • Corrected the name for SLUS-21492 into its full name.