### PR TITLE
SPU2-X: Updates

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -72,6 +72,12 @@
 -- ScarfaceIbitHack  = 1 // VU I bit Hack avoid constant recompilation. ( Scarface The World Is Yours)
 
 ---------------------------------------------
+-- SPU2-X Delay Cycles (DelayCycles = n):
+---------------------------------------------
+-- 1 = Fixes a number of games like Unreal Tournament.
+-- 4 = Default setting, good for most games.
+
+---------------------------------------------
 -- Speed Hacks (SpeedHackName = <value>)
 ---------------------------------------------
 -- mvuFlagSpeedHack = 1 or 0 // Katamari Damacy have weird speed bug when this speed hack is enabled (and it is by default)
@@ -6745,6 +6751,7 @@ Serial = SLES-50074
 Name   = Unreal Tournament
 Region = PAL-M5
 Compat = 5
+DelayCycles = 1 // Fixes infinitely looping audio
 ---------------------------------------------
 Serial = SLES-50075
 Name   = ESPN NBA 2Night
@@ -6769,6 +6776,7 @@ Compat = 5
 Serial = SLES-50079
 Name   = Armored Core 2
 Region = PAL-E
+DelayCycles = 1 // Fixes infinitely looping audio
 ---------------------------------------------
 Serial = SLES-50080
 Name   = NBA Hoopz
@@ -8251,22 +8259,27 @@ Region = PAL-G
 Serial = SLES-50804
 Name   = Deus Ex
 Region = PAL-E
+DelayCycles = 1 // Fixes skipping audio
 ---------------------------------------------
 Serial = SLES-50805
 Name   = Deus Ex
 Region = PAL-G
+DelayCycles = 1 // Fixes skipping audio
 ---------------------------------------------
 Serial = SLES-50806
 Name   = Deus Ex
 Region = PAL-F
+DelayCycles = 1 // Fixes skipping audio
 ---------------------------------------------
 Serial = SLES-50807
 Name   = Deus Ex
 Region = PAL-I
+DelayCycles = 1 // Fixes skipping audio
 ---------------------------------------------
 Serial = SLES-50808
 Name   = Deus Ex
 Region = PAL-S
+DelayCycles = 1 // Fixes skipping audio
 ---------------------------------------------
 Serial = SLES-50809
 Name   = Next Generation Tennis 2003
@@ -27162,6 +27175,7 @@ Region = NTSC-J
 Serial = SLPM-66620
 Name   = Higurashi no Naku Koro ni Matsuri
 Region = NTSC-J
+DelayCycles = 1
 ---------------------------------------------
 Serial = SLPM-66621
 Name   = Beatmania IIDX 12 - Happy Sky
@@ -28271,10 +28285,12 @@ Region = NTSC-J
 Serial = SLPM-66912
 Name   = Higurashi no Naku Koro ni Matsuri - Kakera Asobi [Append Version]
 Region = NTSC-J
+DelayCycles = 1
 ---------------------------------------------
 Serial = SLPM-66913
 Name   = Higurashi no Naku Koro ni Matsuri - Kakera Asobi
 Region = NTSC-J
+DelayCycles = 1 // Some voices don't play.
 ---------------------------------------------
 Serial = SLPM-66914
 Name   = Houkago wa Hakugin no Shirabe
@@ -30377,6 +30393,7 @@ Region = NTSC-J
 Serial = SLPS-25007
 Name   = Armored Core 2
 Region = NTSC-J
+DelayCycles = 1 // Fixes infinitely looping audio
 ---------------------------------------------
 Serial = SLPS-25008
 Name   = Sorcerous Stabber Orphen
@@ -33968,6 +33985,7 @@ Region = NTSC-J
 Serial = SLPS-73403
 Name   = Armored Core 2 [PlayStation 2 The Best]
 Region = NTSC-J
+DelayCycles = 1 // Fixes infinitely looping audio
 ---------------------------------------------
 Serial = SLPS-73404
 Name   = Klonoa 2 [PlayStation 2 The Best]
@@ -34108,6 +34126,7 @@ Serial = SLUS-20014
 Name   = Armored Core 2
 Region = NTSC-U
 Compat = 5
+DelayCycles = 1 // Fixes infinitely looping audio
 ---------------------------------------------
 Serial = SLUS-20015
 Name   = Eternal Ring
@@ -34158,6 +34177,7 @@ Serial = SLUS-20034
 Name   = Unreal Tournament
 Region = NTSC-U
 Compat = 5
+DelayCycles = 1 // Fixes infinitely looping audio
 ---------------------------------------------
 Serial = SLUS-20035
 Name   = Baldur's Gate: Dark Alliance
@@ -34479,6 +34499,7 @@ Serial = SLUS-20111
 Name   = Deus Ex - The Conspiracy
 Region = NTSC-U
 Compat = 5
+DelayCycles = 1 // Fixes skipping audio
 ---------------------------------------------
 Serial = SLUS-20112
 Name   = Star Trek - Shattered Universe

--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -394,6 +394,8 @@ s32 CALLBACK SPU2freeze(int mode, freezeData *data);
 void CALLBACK SPU2configure();
 s32 CALLBACK SPU2test();
 
+void CALLBACK SPU2DelayCycles(int DelayCyclese);
+
 #endif
 
 /* CDVD plugin API */
@@ -643,6 +645,7 @@ typedef void(CALLBACK *_SPU2setTimeStretcher)(short int enable);
 
 typedef void(CALLBACK *_SPU2async)(u32 cycles);
 
+typedef void(CALLBACK *_SPU2DelayCycles)(int DelayCycles);
 
 // CDVD
 // NOTE: The read/write functions CANNOT use XMM/MMX regs
@@ -803,6 +806,8 @@ extern _SPU2setClockPtr SPU2setClockPtr;
 extern _SPU2setTimeStretcher SPU2setTimeStretcher;
 
 extern _SPU2async SPU2async;
+
+extern _SPU2DelayCycles SPU2DelayCycles;
 #endif
 
 // DEV9

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -303,6 +303,7 @@ _SPU2irqCallback   SPU2irqCallback;
 
 _SPU2setClockPtr   SPU2setClockPtr;
 _SPU2async         SPU2async;
+_SPU2DelayCycles   SPU2DelayCycles;
 #endif
 
 
@@ -610,6 +611,7 @@ static const LegacyApi_OptMethod s_MethMessOpt_SPU2[] =
 	{	"SPU2setDMABaseAddr",	(vMeth**)&SPU2setDMABaseAddr},
 #endif
 	{	"SPU2setupRecording",	(vMeth**)&SPU2setupRecording},
+	{	"SPU2DelayCycles",		(vMeth**)&SPU2DelayCycles	},
 
 	{ NULL }
 };

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -262,11 +262,16 @@ static int loadGameSettings(Pcsx2Config& dest, const Game_Data& game) {
 		gf++;
 	}
 
-
 	if (game.keyExists("mvuFlagSpeedHack")) {
 		bool vuFlagHack = game.getInt("mvuFlagSpeedHack") ? 1 : 0;
 		PatchesCon->WriteLn("(GameDB) Changing mVU flag speed hack [mode=%d]", vuFlagHack);
 		dest.Speedhacks.vuFlagHack = vuFlagHack;
+		gf++;
+	}
+
+	if (game.keyExists("DelayCycles")) {
+		int delayCycles = game.getInt("DelayCycles");
+		SPU2DelayCycles(delayCycles);
 		gf++;
 	}
 

--- a/plugins/spu2-x/src/DplIIdecoder.cpp
+++ b/plugins/spu2-x/src/DplIIdecoder.cpp
@@ -101,10 +101,10 @@ void ProcessDplIISample32(const StereoOut32 &src, Stereo51Out32DplII *s)
     float VL = L / (1 - B); // if B>0, it means R>L, so increase L, else decrease L
     float VR = R / (1 + B); // vice-versa
 
-    // 1.73+1.22 = 2.94; 2.94 = 0.34 = 0.9996; Close enough.
+    // 1.73+1.22 = 2.94; 2.94 * 0.34 = 0.9996; Close enough.
     // The range for VL/VR is approximately 0..1,
     // But in the cases where VL/VR are > 0.5, Rearness is 0 so it should never overflow.
-    const float RearScale = 0.34f * 2;
+    const float RearScale = 0.34f; // *2; Let's remove the times 2 and enjoy the rear audo sans the horrible static noise.
 
     float SL = (VR * 1.73f - VL * 1.22f) * RearScale * Rearness;
     float SR = (VR * 1.22f - VL * 1.73f) * RearScale * Rearness;

--- a/plugins/spu2-x/src/Global.h
+++ b/plugins/spu2-x/src/Global.h
@@ -48,7 +48,7 @@ class SoundTouch;
 namespace VersionInfo
 {
 static const u8 Release = 2;
-static const u8 Revision = 0; // increase that with each version
+static const u8 Revision = 1; // increase that with each version
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -66,6 +66,7 @@ float VolumeAdjustSL;
 float VolumeAdjustSR;
 float VolumeAdjustLFE;
 unsigned int delayCycles;
+unsigned int delayCycles_override;
 
 bool postprocess_filter_enabled = true;
 bool postprocess_filter_dealias = false;
@@ -116,7 +117,7 @@ void ReadSettings()
     VolumeAdjustSR = powf(10, VolumeAdjustSRdb / 10);
     VolumeAdjustLFE = powf(10, VolumeAdjustLFEdb / 10);
     delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 4);
-
+    delayCycles_override = 0;
 
     wxString temp;
     CfgReadStr(L"OUTPUT", L"Output_Module", temp, PortaudioOut->GetIdent());

--- a/plugins/spu2-x/src/Linux/Dialogs.h
+++ b/plugins/spu2-x/src/Linux/Dialogs.h
@@ -28,6 +28,13 @@ extern void WriteSettings();
 extern void DisplayDialog();
 }
 
+namespace AdvancedVolumeConfig
+{
+extern void ReadSettings();
+extern void WriteSettings();
+extern void DisplayDialog();
+}
+
 extern void CfgSetSettingsDir(const char *dir);
 extern void CfgSetLogDir(const char *dir);
 

--- a/plugins/spu2-x/src/PS2E-spu2.cpp
+++ b/plugins/spu2-x/src/PS2E-spu2.cpp
@@ -328,11 +328,20 @@ CALLBACK SPU2writeDMA7Mem(u16 *pMem, u32 size)
 EXPORT_C_(void)
 SPU2reset()
 {
+    delayCycles_override = 0;
     memset(spu2regs, 0, 0x010000);
     memset(_spu2mem, 0, 0x200000);
     memset(_spu2mem + 0x2800, 7, 0x10); // from BIOS reversal. Locks the voices so they don't run free.
     Cores[0].Init(0);
     Cores[1].Init(1);
+}
+EXPORT_C_(void)
+SPU2DelayCycles(int cyclesnr = 0)
+{
+    if (cyclesnr != delayCycles_override) {
+        delayCycles_override = cyclesnr;
+        printf("(GameDB) Changing SPU2-X delay cycles to %u\n", delayCycles_override);
+    }
 }
 
 EXPORT_C_(s32)

--- a/plugins/spu2-x/src/PS2E-spu2.h
+++ b/plugins/spu2-x/src/PS2E-spu2.h
@@ -37,6 +37,8 @@ EXPORT_C_(s32)
 SPU2init();
 EXPORT_C_(void)
 SPU2reset();
+EXPORT_C_(void)
+SPU2DelayCycles(int DelayCycles);
 EXPORT_C_(s32)
 SPU2open(void *pDsp);
 EXPORT_C_(void)

--- a/plugins/spu2-x/src/SndOut.h
+++ b/plugins/spu2-x/src/SndOut.h
@@ -46,6 +46,7 @@ extern float VolumeAdjustSL;
 extern float VolumeAdjustSR;
 extern float VolumeAdjustLFE;
 extern unsigned int delayCycles;
+extern unsigned int delayCycles_override;
 
 struct Stereo51Out16DplII;
 struct Stereo51Out32DplII;

--- a/plugins/spu2-x/src/Windows/Config.cpp
+++ b/plugins/spu2-x/src/Windows/Config.cpp
@@ -215,6 +215,7 @@ void CheckOutputModule(HWND window)
 
     const bool AudioExpansion =
         mods[OutputModule] == XAudio2Out ||
+        mods[OutputModule] == XAudio2_27_Out ||
         mods[OutputModule] == PortaudioOut;
 
     EnableWindow(GetDlgItem(window, IDC_OUTCONF), IsConfigurable);

--- a/plugins/spu2-x/src/Windows/Config.cpp
+++ b/plugins/spu2-x/src/Windows/Config.cpp
@@ -59,6 +59,7 @@ float VolumeAdjustSL;
 float VolumeAdjustSR;
 float VolumeAdjustLFE;
 unsigned int delayCycles;
+unsigned int delayCycles_override;
 
 bool postprocess_filter_enabled = 1;
 bool postprocess_filter_dealias = false;
@@ -103,6 +104,7 @@ void ReadSettings()
     VolumeAdjustSRdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSR(dB)", 0);
     VolumeAdjustLFEdb = CfgReadFloat(L"MIXING", L"VolumeAdjustLFE(dB)", 0);
     delayCycles = CfgReadInt(L"DEBUG", L"DelayCycles", 4);
+    delayCycles_override = 0;
     VolumeAdjustC = powf(10, VolumeAdjustCdb / 10);
     VolumeAdjustFL = powf(10, VolumeAdjustFLdb / 10);
     VolumeAdjustFR = powf(10, VolumeAdjustFRdb / 10);

--- a/plugins/spu2-x/src/Windows/ConfigAdvancedVolume.cpp
+++ b/plugins/spu2-x/src/Windows/ConfigAdvancedVolume.cpp
@@ -1,0 +1,232 @@
+/* SPU2-X, A plugin for Emulating the Sound Processing Unit of the Playstation 2
+ * Developed and maintained by the Pcsx2 Development Team.
+ *
+ * SPU2-X is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * SPU2-X is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SPU2-X.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Global.h"
+#include "Dialogs.h"
+
+bool AdvancedVolumeControl = false;
+
+float VolumeAdjustFLdb; // Decibels settings, cos audiophiles love that.
+float VolumeAdjustCdb;
+float VolumeAdjustFRdb;
+float VolumeAdjustBLdb;
+float VolumeAdjustBRdb;
+float VolumeAdjustSLdb;
+float VolumeAdjustSRdb;
+float VolumeAdjustLFEdb;
+float VolumeAdjustFL; // Linear coefs calculated from decibels.
+float VolumeAdjustC;
+float VolumeAdjustFR;
+float VolumeAdjustBL;
+float VolumeAdjustBR;
+float VolumeAdjustSL;
+float VolumeAdjustSR;
+float VolumeAdjustLFE;
+
+void AdvancedVolumeConfig::ReadSettings()
+{
+    AdvancedVolumeControl = CfgReadBool(L"MIXING", L"AdvancedVolumeControl", false);
+
+    VolumeAdjustCdb = CfgReadFloat(L"MIXING", L"VolumeAdjustC(dB)", 0);
+    VolumeAdjustFLdb = CfgReadFloat(L"MIXING", L"VolumeAdjustFL(dB)", 0);
+    VolumeAdjustFRdb = CfgReadFloat(L"MIXING", L"VolumeAdjustFR(dB)", 0);
+    VolumeAdjustBLdb = CfgReadFloat(L"MIXING", L"VolumeAdjustBL(dB)", 0);
+    VolumeAdjustBRdb = CfgReadFloat(L"MIXING", L"VolumeAdjustBR(dB)", 0);
+    VolumeAdjustSLdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSL(dB)", 0);
+    VolumeAdjustSRdb = CfgReadFloat(L"MIXING", L"VolumeAdjustSR(dB)", 0);
+    VolumeAdjustLFEdb = CfgReadFloat(L"MIXING", L"VolumeAdjustLFE(dB)", 0);
+
+    VolumeAdjustC = powf(10, VolumeAdjustCdb / 10);
+    VolumeAdjustFL = powf(10, VolumeAdjustFLdb / 10);
+    VolumeAdjustFR = powf(10, VolumeAdjustFRdb / 10);
+    VolumeAdjustBL = powf(10, VolumeAdjustBLdb / 10);
+    VolumeAdjustBR = powf(10, VolumeAdjustBRdb / 10);
+    VolumeAdjustSL = powf(10, VolumeAdjustSLdb / 10);
+    VolumeAdjustSR = powf(10, VolumeAdjustSRdb / 10);
+    VolumeAdjustLFE = powf(10, VolumeAdjustLFEdb / 10);
+}
+
+void AdvancedVolumeConfig::WriteSettings()
+{
+    CfgWriteBool(L"MIXING", L"AdvancedVolumeControl", AdvancedVolumeControl);
+
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustC(dB)", VolumeAdjustCdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustFL(dB)", VolumeAdjustFLdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustFR(dB)", VolumeAdjustFRdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustBL(dB)", VolumeAdjustBLdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustBR(dB)", VolumeAdjustBRdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustSL(dB)", VolumeAdjustSLdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustSR(dB)", VolumeAdjustSRdb);
+    CfgWriteFloat(L"MIXING", L"VolumeAdjustLFE(dB)", VolumeAdjustLFEdb);
+}
+
+static BOOL CALLBACK DialogProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    int wmId;
+    wchar_t temp[384] = {0};
+
+    switch (uMsg) {
+        case WM_PAINT:
+            return FALSE;
+
+        case WM_INITDIALOG: {
+            INIT_SLIDER(IDC_VOLADJ_CDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_CDB, TBM_SETPOS, TRUE, VolumeAdjustCdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustCdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_C_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_FLDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_FLDB, TBM_SETPOS, TRUE, VolumeAdjustFLdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustFLdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_FL_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_FRDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_FRDB, TBM_SETPOS, TRUE, VolumeAdjustFRdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustFRdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_FR_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_BLDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_BLDB, TBM_SETPOS, TRUE, VolumeAdjustBLdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustBLdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_BL_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_BRDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_BRDB, TBM_SETPOS, TRUE, VolumeAdjustBRdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustBRdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_BR_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_SLDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_SLDB, TBM_SETPOS, TRUE, VolumeAdjustSLdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustSLdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_SL_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_SRDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_SRDB, TBM_SETPOS, TRUE, VolumeAdjustSRdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustSRdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_SR_LABEL), temp);
+
+            INIT_SLIDER(IDC_VOLADJ_LFEDB, 0, 50, 5, 5, 1);
+            SendDialogMsg(hWnd, IDC_VOLADJ_LFEDB, TBM_SETPOS, TRUE, VolumeAdjustLFEdb + 25.0f);
+            swprintf_s(temp, L"%d dB", (int)VolumeAdjustLFEdb);
+            SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_LFE_LABEL), temp);
+        }
+
+        case WM_COMMAND:
+            wmId = LOWORD(wParam);
+            if (wmId == IDOK) {
+                VolumeAdjustCdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_CDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustFLdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_FLDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustFRdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_FRDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustBLdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_BLDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustBRdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_BRDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustSLdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_SLDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustSRdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_SRDB, TBM_GETPOS, 0, 0) - 25.0f);
+                VolumeAdjustLFEdb = ((float)SendDialogMsg(hWnd, IDC_VOLADJ_LFEDB, TBM_GETPOS, 0, 0) - 25.0f);
+
+                WriteSettings();
+                EndDialog(hWnd, 0);
+            } else if (wmId == IDC_RESET_DEFAULTS) {
+                SendDialogMsg(hWnd, IDC_VOLADJ_CDB, TBM_SETPOS, TRUE, 25.0f);
+                swprintf_s(temp, L"%d dB", 0);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_C_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_FLDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_FL_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_FRDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_FR_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_BLDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_BL_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_BRDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_BR_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_SLDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_SL_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_SRDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_SR_LABEL), temp);
+                SendDialogMsg(hWnd, IDC_VOLADJ_LFEDB, TBM_SETPOS, TRUE, 25.0f);
+                SetWindowText(GetDlgItem(hWnd, IDC_ADV_VOL_LFE_LABEL), temp);
+            } else if (wmId == IDCANCEL) {
+                EndDialog(hWnd, 0);
+            }
+            break;
+
+        case WM_HSCROLL: {
+            wmId = LOWORD(wParam);
+            HWND hwndDlg = (HWND)lParam;
+
+            int curpos = HIWORD(wParam);
+
+            switch (wmId) {
+                case TB_LINEUP:
+                case TB_LINEDOWN:
+                case TB_PAGEUP:
+                case TB_PAGEDOWN:
+                case TB_TOP:
+                case TB_BOTTOM:
+                    curpos = (int)SendMessage(hwndDlg, TBM_GETPOS, 0, 0);
+
+                case TB_THUMBPOSITION:
+                case TB_THUMBTRACK:
+                    Clampify(curpos,
+                             (int)SendMessage(hwndDlg, TBM_GETRANGEMIN, 0, 0),
+                             (int)SendMessage(hwndDlg, TBM_GETRANGEMAX, 0, 0));
+
+                    SendMessage((HWND)lParam, TBM_SETPOS, TRUE, curpos);
+
+                    if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_CDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_C_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_FLDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_FL_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_FRDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_FR_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_BLDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_BL_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_BRDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_BR_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_SLDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_SL_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_SRDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_SR_LABEL, temp);
+                    } else if (hwndDlg == GetDlgItem(hWnd, IDC_VOLADJ_LFEDB)) {
+                        swprintf_s(temp, L"%d dB", curpos - 25);
+                        SetDlgItemText(hWnd, IDC_ADV_VOL_LFE_LABEL, temp);
+                    }
+                    break;
+
+                default:
+                    return FALSE;
+            }
+        } break;
+
+        default:
+            return FALSE;
+    }
+    return TRUE;
+}
+
+void AdvancedVolumeConfig::OpenDialog()
+{
+    INT_PTR ret = DialogBox(hInstance, MAKEINTRESOURCE(IDD_CONFIG_ADVANCEDVOLUME), GetActiveWindow(), (DLGPROC)DialogProc);
+    if (ret == -1) {
+        MessageBox(GetActiveWindow(), L"Error Opening the Advanced Volume Control configuration dialog.", L"OMG ERROR!", MB_OK | MB_SETFOREGROUND);
+        return;
+    }
+    ReadSettings();
+}

--- a/plugins/spu2-x/src/Windows/Dialogs.h
+++ b/plugins/spu2-x/src/Windows/Dialogs.h
@@ -31,6 +31,13 @@ extern void OpenDialog();
 extern void EnableControls(HWND hWnd);
 }
 
+namespace AdvancedVolumeConfig
+{
+extern void ReadSettings();
+extern void WriteSettings();
+extern void OpenDialog();
+}
+
 namespace SoundtouchCfg
 {
 extern void ReadSettings();

--- a/plugins/spu2-x/src/Windows/Spu2-X.def
+++ b/plugins/spu2-x/src/Windows/Spu2-X.def
@@ -62,3 +62,4 @@ EXPORTS
 	SPU2replay = s2r_replay	@33
 
 	SPU2reset			@34
+	SPU2DelayCycles		@35

--- a/plugins/spu2-x/src/Windows/Spu2-X.rc
+++ b/plugins/spu2-x/src/Windows/Spu2-X.rc
@@ -31,34 +31,42 @@ FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     PUSHBUTTON      "OK",IDOK,200,276,54,15,NOT WS_TABSTOP
     PUSHBUTTON      "Cancel",IDCANCEL,259,276,54,15,NOT WS_TABSTOP
-    GROUPBOX        "Mixing Settings",IDC_STATIC,6,5,130,115
+    // Mixing Settings:
+    GROUPBOX        "Mixing Settings",IDC_STATIC,6,5,130,145
+    LTEXT           "Interpolation:",IDC_STATIC,12,16,55,10,NOT WS_GROUP
+    COMBOBOX        IDC_INTERPOLATE,14,26,114,84,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CHECKBOX        "Disable Effects Processing",IDC_EFFECTS_DISABLE,14,47,112,10
+    LTEXT           "(speedup!) Skips reverb effects processing, but won't sound as good in most games.",IDC_STATIC,26,60,104,36
+    CONTROL         "Use the de-alias filter",IDC_DEALIASFILTER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,92,112,10
+    LTEXT           "(overemphasizes the highs)",IDC_STATIC,26,104,100,12,NOT WS_GROUP
+    CHECKBOX        "Advanced Volume Control",IDC_ADVANCED_VOL_ENABLE,14,118,112,10
+    PUSHBUTTON      "Configure...",IDC_OPEN_CONFIG_ADVANCED_VOL,64,132,54,12
+    // Output Settings:
     GROUPBOX        "Output Settings",IDC_STATIC,142,0,172,268
+    LTEXT           "Module:",IDC_STATIC,161,16,50,9,NOT WS_GROUP
     COMBOBOX        IDC_OUTPUT,154,26,126,120,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "Configure...",IDC_OUTCONF,236,40,54,12
-    COMBOBOX        IDC_INTERPOLATE,14,26,114,84,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "Slider2",IDC_LATENCY_SLIDER,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,166,94,116,10
-    CONTROL         "Use a Winamp DSP plugin",IDC_DSP_ENABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,149,223,126,11
-    CHECKBOX        "Disable Effects Processing",IDC_EFFECTS_DISABLE,14,47,112,10
-    LTEXT           "Latency:",IDC_STATIC,189,84,29,8,NOT WS_GROUP
-    LTEXT           "Interpolation:",IDC_STATIC,12,16,55,10,NOT WS_GROUP
-    LTEXT           "Module:",IDC_STATIC,161,16,50,9,NOT WS_GROUP
-    LTEXT           "(speedup!) Skips reverb effects processing, but won't sound as good in most games.",IDC_STATIC,26,60,104,36
-    LTEXT           "(currently requires manual configuration via the ini file)",IDC_STATIC,162,236,146,20
-    CTEXT           "100 ms (avg)",IDC_LATENCY_LABEL,224,84,58,9
-    CONTROL         116,IDC_STATIC,"Static",SS_BITMAP | SS_REALSIZECONTROL,6,213,119,55,WS_EX_CLIENTEDGE
-    PUSHBUTTON      "Advanced...",IDC_OPEN_CONFIG_SOUNDTOUCH,219,149,84,12
-    PUSHBUTTON      "Configure Debug Options...",IDC_OPEN_CONFIG_DEBUG,14,167,108,14
-    CHECKBOX        "Enable Debug Options",IDC_DEBUG_ENABLE,14,153,104,10,NOT WS_TABSTOP
-    GROUPBOX        "",IDC_STATIC,6,143,129,46
-    LTEXT           "Audio Expansion Mode:",IDC_STATIC,161,176,135,9,NOT WS_GROUP
-    COMBOBOX        IDC_SPEAKERS,163,185,135,84,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "Synchronizing Mode:",IDC_STATIC,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,161,116,131,8
-    COMBOBOX        IDC_SYNCHMODE,163,125,134,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Volume:",IDC_STATIC,192,59,26,8,NOT WS_GROUP
     CTEXT           "100%",IDC_VOLUME_LABEL,224,59,58,9
     CONTROL         "",IDC_VOLUME_SLIDER,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,166,69,116,10
-    CONTROL         "Use the de-alias filter",IDC_DEALIASFILTER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,92,112,10
-    LTEXT           "(overemphasizes the highs)",IDC_STATIC,26,104,100,12,NOT WS_GROUP
+    LTEXT           "Latency:",IDC_STATIC,189,84,29,8,NOT WS_GROUP
+    CTEXT           "100 ms (avg)",IDC_LATENCY_LABEL,224,84,58,9
+    CONTROL         "Slider2",IDC_LATENCY_SLIDER,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,166,94,116,10
+    CONTROL         "Synchronizing Mode:",IDC_STATIC,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,161,116,131,8
+    COMBOBOX        IDC_SYNCHMODE,163,125,134,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "Advanced...",IDC_OPEN_CONFIG_SOUNDTOUCH,219,144,84,12
+    LTEXT           "Audio Expansion Mode:",IDC_STATIC,161,166,135,9,NOT WS_GROUP
+    COMBOBOX        IDC_SPEAKERS,163,175,135,84,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Dolby Pro Logic Level:",IDC_STATIC,161,196,135,9,NOT WS_GROUP
+    COMBOBOX        IDC_DPLDECODE,163,205,135,84,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Use a Winamp DSP plugin",IDC_DSP_ENABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,149,228,126,11
+    LTEXT           "(currently requires manual configuration via the ini file)",IDC_STATIC,162,241,146,20
+    // Debug Settings:
+    GROUPBOX        "",IDC_STATIC,6,158,129,46
+    CHECKBOX        "Enable Debug Options",IDC_DEBUG_ENABLE,14,168,104,10,NOT WS_TABSTOP
+    PUSHBUTTON      "Configure Debug Options...",IDC_OPEN_CONFIG_DEBUG,14,182,108,14
+    // Logo
+    CONTROL         116,IDC_STATIC,"Static",SS_BITMAP | SS_REALSIZECONTROL,6,213,119,55,WS_EX_CLIENTEDGE
 END
 
 IDD_DEBUG DIALOGEX 0, 0, 303, 473
@@ -166,6 +174,40 @@ BEGIN
     LTEXT           "Note: This is a non-devel build.  For performance reasons, some logging options are disabled; and only available in devel/debug builds.",IDC_MSG_PUBLIC_BUILD,9,187,174,30
     GROUPBOX        "Others",IDC_DEBUG_OTHERS,5,104,135,68
     CONTROL         "Show Core Activity",IDC_DEBUG_VISUAL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,116,90,11
+END
+
+IDD_CONFIG_ADVANCEDVOLUME DIALOGEX 0, 0, 206, 230
+STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Advanced Volume Control - SPU2-X"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "OK",IDOK,14,210,50,14
+    PUSHBUTTON      "Restore Defaults",IDC_RESET_DEFAULTS,68,210,70,14
+    PUSHBUTTON      "Cancel",IDCANCEL,142,210,50,14
+    LTEXT           "Center Volume:",IDC_STATIC,47,5,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_C_LABEL,125,5,58,9
+    CONTROL         "",IDC_VOLADJ_CDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,15,116,10
+    LTEXT           "Front Left Volume:",IDC_STATIC,47,30,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_FL_LABEL,125,30,58,9
+    CONTROL         "",IDC_VOLADJ_FLDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,40,116,10
+    LTEXT           "Front Right Volume:",IDC_STATIC,47,55,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_FR_LABEL,125,55,58,9
+    CONTROL         "",IDC_VOLADJ_FRDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,65,116,10
+    LTEXT           "Back Left Volume:",IDC_STATIC,47,80,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_BL_LABEL,125,80,58,9
+    CONTROL         "",IDC_VOLADJ_BLDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,90,116,10
+    LTEXT           "Back Right Volume:",IDC_STATIC,47,105,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_BR_LABEL,125,105,58,9
+    CONTROL         "",IDC_VOLADJ_BRDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,115,116,10
+    LTEXT           "Side Left Volume:",IDC_STATIC,47,130,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_SL_LABEL,125,130,58,9
+    CONTROL         "",IDC_VOLADJ_SLDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,140,116,10
+    LTEXT           "Side Right Volume:",IDC_STATIC,47,155,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_SR_LABEL,125,155,58,9
+    CONTROL         "",IDC_VOLADJ_SRDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,165,116,10
+    LTEXT           "Low-Frequency Volume:",IDC_STATIC,47,180,80,8,NOT WS_GROUP
+    CTEXT           "0%",IDC_ADV_VOL_LFE_LABEL,125,180,58,9
+    CONTROL         "",IDC_VOLADJ_LFEDB,"msctls_trackbar32",TBS_AUTOTICKS | WS_TABSTOP,47,190,116,10
 END
 
 

--- a/plugins/spu2-x/src/Windows/Spu2-X.vcxproj
+++ b/plugins/spu2-x/src/Windows/Spu2-X.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="ConfigDebug.cpp" />
     <ClCompile Include="ConfigSoundtouch.cpp" />
     <ClCompile Include="RealtimeDebugger.cpp" />
+    <ClCompile Include="ConfigAdvancedVolume.cpp" />
     <ClCompile Include="UIHelpers.cpp" />
     <ClCompile Include="..\PS2E-spu2.cpp" />
   </ItemGroup>

--- a/plugins/spu2-x/src/Windows/Spu2-X.vcxproj.filters
+++ b/plugins/spu2-x/src/Windows/Spu2-X.vcxproj.filters
@@ -213,6 +213,9 @@
     <ClCompile Include="SndOut_XAudio2.cpp">
       <Filter>Source Files\Sound Output\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="ConfigAdvancedVolume.cpp">
+      <Filter>Source Files\GUI\Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LGPL.txt">

--- a/plugins/spu2-x/src/Windows/resource.h
+++ b/plugins/spu2-x/src/Windows/resource.h
@@ -61,6 +61,26 @@
 #define IDC_PA_HOSTAPI                  1071
 #define IDC_LATENCY                     1072
 #define IDC_EXCLUSIVE                   1073
+#define IDC_DPLDECODE                   1074
+#define IDC_ADVANCED_VOL_ENABLE         1075
+#define IDC_OPEN_CONFIG_ADVANCED_VOL    1076
+#define IDC_VOLADJ_CDB                  1077
+#define IDC_VOLADJ_FLDB                 1078
+#define IDC_VOLADJ_FRDB                 1079
+#define IDC_VOLADJ_BLDB                 1080
+#define IDC_VOLADJ_BRDB                 1081
+#define IDC_VOLADJ_SLDB                 1082
+#define IDC_VOLADJ_SRDB                 1083
+#define IDC_VOLADJ_LFEDB                1084
+#define IDC_ADV_VOL_C_LABEL             1085
+#define IDC_ADV_VOL_FL_LABEL            1086
+#define IDC_ADV_VOL_FR_LABEL            1087
+#define IDC_ADV_VOL_BL_LABEL            1088
+#define IDC_ADV_VOL_BR_LABEL            1089
+#define IDC_ADV_VOL_SL_LABEL            1090
+#define IDC_ADV_VOL_SR_LABEL            1091
+#define IDC_ADV_VOL_LFE_LABEL           1092
+#define IDD_CONFIG_ADVANCEDVOLUME       1093
 
 // Next default values for new objects
 // 
@@ -68,7 +88,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        120
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1074
+#define _APS_NEXT_CONTROL_VALUE         1094
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -1025,19 +1025,20 @@ static void __fastcall RegWrite_VoiceParams(u16 value)
 
         // REG_VP_ENVX, REG_VP_VOLXL and REG_VP_VOLXR have been confirmed to not be allowed to be written to, so code has been commented out.
         // Colin McRae Rally 2005 triggers case 5 (ADSR), but it doesn't produce issues enabled or disabled.
+        // Enabled cases again due a regression in Wallace And Gromit: Curse Of The Were-Rabbit.
 
         case 5:
             // [Air] : Mysterious ADSR set code.  Too bad none of my games ever use it.
             //      (as usual... )
-            //thisvoice.ADSR.Value = (value << 16) | value;
-            //ConLog("* SPU2: Mysterious ADSR Volume Set to 0x%x\n", value);
+            thisvoice.ADSR.Value = (value << 16) | value;
+            ConLog("* SPU2: Mysterious ADSR Volume Set to 0x%x\n", value);
             break;
 
         case 6:
-            //thisvoice.Volume.Left.RegSet(value);
+            thisvoice.Volume.Left.RegSet(value);
             break;
         case 7:
-            //thisvoice.Volume.Right.RegSet(value);
+            thisvoice.Volume.Right.RegSet(value);
             break;
 
             jNO_DEFAULT;
@@ -1082,15 +1083,16 @@ static void __fastcall RegWrite_VoiceAddr(u16 value)
 
         // NextA has been confirmed to not be allowed to be written to, so code has been commented out.
         // FlatOut & Soul Reaver 2 trigger these cases, but don't produce issues enabled or disabled.
+        // Enabled cases again due a regression in Wallace And Gromit: Curse Of The Were-Rabbit.
 
         case 4:
-            //thisvoice.NextA = ((value & 0x0F) << 16) | (thisvoice.NextA & 0xFFF8) | 1;
-            //thisvoice.SCurrent = 28;
+            thisvoice.NextA = ((value & 0x0F) << 16) | (thisvoice.NextA & 0xFFF8) | 1;
+            thisvoice.SCurrent = 28;
             break;
 
         case 5:
-            //thisvoice.NextA = (thisvoice.NextA & 0x0F0000) | (value & 0xFFF8) | 1;
-            //thisvoice.SCurrent = 28;
+            thisvoice.NextA = (thisvoice.NextA & 0x0F0000) | (value & 0xFFF8) | 1;
+            thisvoice.SCurrent = 28;
             break;
     }
 }

--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -302,9 +302,10 @@ void V_Core::UpdateEffectsBufferSize()
 
 void V_Voice::QueueStart()
 {
-    if (Cycles - PlayCycle < delayCycles) {
+    unsigned int temp_delayCycle = delayCycles_override > 0 ? delayCycles_override : delayCycles;
+    if (Cycles - PlayCycle < temp_delayCycle) {
         // Required by The Legend of Spyro: The Eternal Night (probably the other two legend games too)
-        ConLog(" *** KeyOn after less than %d T disregarded.\n", delayCycles);
+        ConLog(" *** KeyOn after less than %d T disregarded.\n", temp_delayCycle);
         return;
     }
     PlayCycle = Cycles;
@@ -312,7 +313,8 @@ void V_Voice::QueueStart()
 
 bool V_Voice::Start()
 {
-    if ((Cycles - PlayCycle) >= delayCycles) {
+    unsigned int temp_delayCycle = delayCycles_override > 0 ? delayCycles_override : delayCycles;
+    if ((Cycles - PlayCycle) >= temp_delayCycle) {
         if (StartA & 7) {
             fprintf(stderr, " *** Misaligned StartA %05x!\n", StartA);
             StartA = (StartA + 0xFFFF8) + 0x8;


### PR DESCRIPTION
Fixes 2 regressions:
- Audio cutting out in Wallace And Gromit: Curse of the Were-Rabbit
- AudioExpansion Mode not available for XAudio2 when using a Windows version before 8.

New features:
- Adds automatic fix for SPU2-X delay cycles
- Windows UI options for advanced volume controls and Dolby Pro Logic settings.