### PR TITLE
Console: Reset the titlebar when the VM is shutdown.

### DIFF
--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -577,6 +577,7 @@ void MainEmuFrame::Menu_SysShutdown_Click(wxCommandEvent &event)
 	//if( !SysHasValidState() && !CorePlugins.AreAnyInitialized() ) return;
 
 	UI_DisableSysShutdown();
+	Console.SetTitle("PCSX2 Program Log");
 	CoreThread.Reset();
 }
 


### PR DESCRIPTION
This is sort of a nitpick of mine that's bugged me for a bit. After the VM is shutdown, the game that was last played remains in the console. The new behavior will revert the console text back to `PCSX2 Program Log` after being shutdown.