### PR TITLE
GSdx: Rename HW hacks drop list options

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -259,19 +259,19 @@ void GSdxApp::Init()
 	m_gs_bifilter.push_back(GSSetting(static_cast<uint32>(BiFiltering::Forced), "Bilinear", "Forced"));
 	m_gs_bifilter.push_back(GSSetting(static_cast<uint32>(BiFiltering::PS2), "Bilinear", "PS2"));
 
-	m_gs_trifilter.push_back(GSSetting(static_cast<uint32>(TriFiltering::None), "None", ""));
+	m_gs_trifilter.push_back(GSSetting(static_cast<uint32>(TriFiltering::None), "None", "Default"));
 	m_gs_trifilter.push_back(GSSetting(static_cast<uint32>(TriFiltering::PS2), "Trilinear", ""));
 	m_gs_trifilter.push_back(GSSetting(static_cast<uint32>(TriFiltering::Forced), "Trilinear", "Ultra/Slow"));
 
-	m_gs_gl_ext.push_back(GSSetting(-1, "Auto", ""));
+	m_gs_gl_ext.push_back(GSSetting(-1, "Auto", "Default"));
 	m_gs_gl_ext.push_back(GSSetting(0,  "Force-Disabled", ""));
 	m_gs_gl_ext.push_back(GSSetting(1,  "Force-Enabled", ""));
 
-	m_gs_hack.push_back(GSSetting(0,  "Off", ""));
+	m_gs_hack.push_back(GSSetting(0,  "Off", "Default"));
 	m_gs_hack.push_back(GSSetting(1,  "Half", ""));
 	m_gs_hack.push_back(GSSetting(2,  "Full", ""));
 
-	m_gs_offset_hack.push_back(GSSetting(0,  "Off", ""));
+	m_gs_offset_hack.push_back(GSSetting(0,  "Off", "Default"));
 	m_gs_offset_hack.push_back(GSSetting(1,  "Normal", "Vertex"));
 	m_gs_offset_hack.push_back(GSSetting(2,  "Special", "Texture"));
 	m_gs_offset_hack.push_back(GSSetting(3,  "Special", "Texture - aggressive"));


### PR DESCRIPTION
Add "Default" nametag for default list options for the hacks: Sprite,
Round Sprite, GL Advanced settings, HPO.

Should help users know which options are the default ones with less
confusion.

OCD goodness.
![image](https://user-images.githubusercontent.com/18107717/36814220-2cb49600-1cd7-11e8-9b89-608729d98824.png)
