### PR TITLE
GameDB: Add GIF FIFO hack for Spongebob: Creature From the Krusty Krab

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -68,6 +68,7 @@
 -- DMABusyHack       = 1 // Mana Khemia, Metal Saga. Denies writes to the DMAC when it's busy.
 -- VIFFIFOHack       = 1 // Transformers Armada, Test Drive Unlimited. Fixes slow booting issue.
 -- VIF1StallHack     = 1 // SOCOM II HUD and Spy Hunter loading hang.
+-- GIFFIFOHack       = 1 // Enables the GIF FIFO. Needed for Wallace & Grommit, Hot Wheels, DJ Hero.
 -- FMVinSoftwareHack = 1 // Silent Hill 2-3. Fixes FMVs that are obscured when using hardware rendering by switching to software rendering while an FMV plays.
 -- ScarfaceIbitHack  = 1 // VU I bit Hack avoid constant recompilation (Scarface The World Is Yours).
 
@@ -16139,8 +16140,9 @@ Region = PAL-E
 Compat = 5
 ---------------------------------------------
 Serial = SLES-54400
-Name   = SpongeBob Squarepants - Creature from the Krusty Krab
+Name   = SpongeBob SquarePants - Creature from the Krusty Krab
 Region = PAL-M7
+GIFFIFOHack = 1 // Fixes bad graphics.
 ---------------------------------------------
 Serial = SLES-54402
 Name   = Need for Speed - Carbon [Collector's Edition]
@@ -27489,6 +27491,7 @@ Region = NTSC-J
 Serial = SLPM-66694
 Name   = Spongebob
 Region = NTSC-J
+GIFFIFOHack = 1 // Fixes bad graphics.
 ---------------------------------------------
 Serial = SLPM-66695
 Name   = Kono Aozora ni Yakusoku o - Melody of the Sun and Sea
@@ -40548,6 +40551,7 @@ Compat = 4
 Serial = SLUS-21391
 Name   = SpongeBob SquarePants - Creature from the Krusty Krab
 Region = NTSC-U
+GIFFIFOHack = 1 // Fixes bad graphics.
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21392


### PR DESCRIPTION
This PR adds the GIF FIFO hack for Spongebob Creature From the Krusty Krab to fix bad graphics. 

Before:
![pcsx2_2018_03_04_11_51_22_746](https://user-images.githubusercontent.com/16314399/36948106-94358572-1fa3-11e8-9ac3-fca5705e937b.png)

After:
![pcsx2_2018_03_04_11_51_09_375](https://user-images.githubusercontent.com/16314399/36948123-b610bf7c-1fa3-11e8-82be-f9dadb732c3b.png)
