### PR TITLE
GSdx: Add CRC ids, adjust CRC hacks for Final Fight Streetwise

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -301,6 +301,8 @@ CRC::Game CRC::m_games[] =
 	{0xA8CC1583, Sly3, KO, 0},
 	{0x518DD841, Sly2, KO, 0},
 	{0x07652DD9, Sly2, US, 0},
+	{0x5B93397F, Sly2, US, 0}, // E3 Demo
+	{0x615EA2DB, Sly2, JP, 0}, // Kaitou Sly Cooper 2
 	{0xFDA1CBF6, Sly2, EU, 0},
 	{0x15DD1F6F, Sly2, NoRegion, 0},
 	{0xA9C82AB9, DemonStone, US, 0},

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -1047,19 +1047,6 @@ bool GSC_SengokuBasara(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_FinalFightStreetwise(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(!fi.TME && (fi.FBP == 0 || fi.FBP == 0x08c0) && fi.FPSM == PSM_PSMCT32 && (fi.TPSM == PSM_PSMT8 || fi.TPSM == PSM_PSMT4) && fi.FBMSK == 0x00FFFFFF)
-		{
-			skip = 3;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_TalesofSymphonia(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1083,10 +1070,12 @@ bool GSC_Simple2000Vol114(const GSFrameInfo& fi, int& skip)
 	{
 		if(fi.TME==0 && (fi.FBP==0x1500) && (fi.TBP0==0x2c97 || fi.TBP0==0x2ace || fi.TBP0==0x03d0 || fi.TBP0==0x2448) && (fi.FBMSK == 0x0000))
 		{
+			// Upscaling issues, removes glow/blur effect which fixes ghosting.
 			skip = 1;
 		}
 		if(fi.TME && (fi.FBP==0x0e00) && (fi.TBP0==0x1000) && (fi.FBMSK == 0x0000))
 		{
+			// Depth shadows, they don't work properly on OpenGL as well.
 			skip = 1;
 		}
 	}
@@ -1132,6 +1121,25 @@ bool GSC_SteambotChronicles(const GSFrameInfo& fi, int& skip)
 ////////////////////////////////////////////////////////////////////////////////
 // Correctly emulated on OpenGL but can be used as potential speed hack
 ////////////////////////////////////////////////////////////////////////////////
+
+bool GSC_FinalFightStreetwise(const GSFrameInfo& fi, int& skip)
+{
+	if (skip == 0)
+	{
+		if(fi.TME)
+		{
+			// depth textures (bully, mgs3s1 intro, Front Mission 5)
+			if( (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+				// General, often problematic post processing
+				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
+			{
+				skip = 1;
+			}
+		}
+	}
+
+	return true;
+}
 
 bool GSC_HauntingGround(const GSFrameInfo& fi, int& skip)
 {
@@ -2239,7 +2247,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::EternalPoison] = GSC_EternalPoison;
 		lut[CRC::EvangelionJo] = GSC_EvangelionJo;
 		lut[CRC::FightingBeautyWulong] = GSC_FightingBeautyWulong;
-		lut[CRC::FinalFightStreetwise] = GSC_FinalFightStreetwise;
 		lut[CRC::FrontMission5] = GSC_FrontMission5;
 		lut[CRC::Genji] = GSC_Genji;
 		lut[CRC::GiTS] = GSC_GiTS;
@@ -2304,6 +2311,7 @@ void GSState::SetupCrcHack()
 		// Depth
 		lut[CRC::Bully] = GSC_Bully;
 		lut[CRC::BullyCC] = GSC_BullyCC;
+		lut[CRC::FinalFightStreetwise] = GSC_FinalFightStreetwise;
 		lut[CRC::GodOfWar2] = GSC_GodOfWar2;
 		lut[CRC::ICO] = GSC_ICO;
 		lut[CRC::LordOfTheRingsTwoTowers] = GSC_LordOfTheRingsTwoTowers;


### PR DESCRIPTION
GSdx: Add some missing crc ids.
Sly 2 E3 Demo US, Sly 2 JP.

GSdx Adjust/Replace crc hack for Final Fight Streetwise.
Replace/remove an old crc hack that was used to fix the red vertical
lines issue, the hack is no longer needed. The new hack removes depth
effects on D3D only.
Note: The game has another vertical lines issue that can be fixed with
texture shuffle on D3D.

Add comments to Simple2000Vol114 explaining what the hacks do.