### PR TITLE
GSdx: Add Shox to Automatic Mipmapping

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -568,6 +568,9 @@ CRC::Game CRC::m_games[] =
 	{0x8661F7BA, RatchetAndClank5, US, 0}, // Size Matters
 	{0xFCB981D5, RatchetAndClank5, EU, 0}, // Size Matters
 	{0x8634861F, RickyPontingInternationalCricket, EU, 0},
+	{0xDDAC3815, Shox, US, 0},
+	{0x78FFA39F, Shox, EU, 0},
+	{0x3DF10389, Shox, EU, 0},
 	{0x2B58234D, TribesAerialAssault, US, 0},
 	{0x4D22DB95, Whiplash, US, 0},
 	{0xB1BE3E51, Whiplash, EU, 0},

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -138,6 +138,7 @@ public:
 		ShadowHearts,
 		ShadowofRome,
 		ShinOnimusha,
+		Shox,
 		SilentHill2,
 		SilentHill3,
 		Simple2000Vol114,

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -201,6 +201,7 @@ void GSRendererHW::SetGameCRC(uint32 crc, int options)
 		case CRC::FIFA03:
 		case CRC::FIFA04:
 		case CRC::FIFA05:
+		case CRC::Shox:
 		case CRC::SoulReaver2:
 		case CRC::LegacyOfKainDefiance:
 		case CRC::RatchetAndClank:


### PR DESCRIPTION
This PR adds Automatic Mipmapping for "Shox" - it fixes corrupted textures in the distance.