### PR TITLE
pcsx2: minor fixes

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -441,7 +441,7 @@ u128 R5900DebugInterface::getRegister(int cat, int num)
 		result = u128::From32(VU1.VI[num].UL);
 		break;
 	default:
-		result.From32(0);
+		result = u128::From32(0);
 		break;
 	}
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -288,7 +288,9 @@ static __fi void _cpuTestInterrupts()
 	// The following ints are rarely called.  Encasing them in a conditional
 	// as follows helps speed up most games.
 
-	if( cpuRegs.interrupt & 0x60F19 ) // Bits 0 3 4 8 9 10 11 17 18( 1100000111100011001 )
+	if (cpuRegs.interrupt & ((1 << DMAC_VIF0) | (1 << DMAC_FROM_IPU) | (1 << DMAC_TO_IPU)
+		| (1 << DMAC_FROM_SPR) | (1 << DMAC_TO_SPR) | (1 << DMAC_MFIFO_VIF) | (1 << DMAC_MFIFO_GIF)
+		| (1 << VIF_VU0_FINISH) | (1 << VIF_VU1_FINISH)))
 	{
 		TESTINT(DMAC_VIF0,		vif0Interrupt);
 


### PR DESCRIPTION
Just 2 small changes:
* Use enums instead of hardcoded integer.
* Avoid potential return of uninitialised value.