### PR TITLE
GSdx: Adjust Fbmask and CRC hacks

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -577,6 +577,8 @@ CRC::Game CRC::m_games[] =
 	{0x8661F7BA, RatchetAndClank5, US, 0}, // Size Matters
 	{0xFCB981D5, RatchetAndClank5, EU, 0}, // Size Matters
 	{0x8634861F, RickyPontingInternationalCricket, EU, 0},
+	{0xA56A0525, Quake3Revolution, US, 0},
+	{0x2064ACE6, Quake3Revolution, EU, 0},
 	{0xDDAC3815, Shox, US, 0},
 	{0x78FFA39F, Shox, EU, 0},
 	{0x3DF10389, Shox, EU, 0},

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -118,6 +118,7 @@ public:
 		OnePieceGrandBattle,
 		Onimusha3,
 		PiaCarroteYoukosoGPGakuenPrincess,
+		Quake3Revolution,
 		RadiataStories,
 		RatchetAndClank,
 		RatchetAndClank2,

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -1253,12 +1253,15 @@ bool GSC_ICO(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
-		if(fi.TME && fi.FBP == 0x00800 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x03d00 && fi.TPSM == PSM_PSMCT32)
+		if(Aggressive && fi.TME && fi.FBP == 0x00800 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x03d00 && fi.TPSM == PSM_PSMCT32)
 		{
+			// Removes shadows, shadows can be a little misaligned when upscaled. HPO fixes the issue.
+			// Can be used as a speed hack.
 			skip = 3;
 		}
 		else if(fi.TME && fi.FBP == 0x00800 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x02800 && fi.TPSM == PSM_PSMT8H)
 		{
+			// Depth effects.
 			skip = 1;
 		}
 		else if(Aggressive && fi.TME && fi.FBP == 0x0800 && (fi.TBP0 == 0x2800 || fi.TBP0 ==0x2c00) && fi.TPSM ==0  && fi.FBMSK == 0)
@@ -1452,6 +1455,8 @@ bool GSC_GodOfWar(const GSFrameInfo& fi, int& skip)
 	{
 		if(fi.TME && fi.FBP == 0x00000 && fi.FPSM == PSM_PSMCT16 && fi.TBP0 == 0x00000 && fi.TPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
 		{
+			// Texture shuffle. Not supported on D3D9.
+			// Can be used as a speed hack.
 			skip = 1000;
 		}
 		else if(fi.TME && fi.FBP == 0x00000 && fi.FPSM == PSM_PSMCT32 && fi.TBP0 == 0x00000 && fi.TPSM == PSM_PSMCT32 && fi.FBMSK == 0xff000000)
@@ -1461,12 +1466,6 @@ bool GSC_GodOfWar(const GSFrameInfo& fi, int& skip)
 		else if(fi.FBP == 0x00000 && fi.FPSM == PSM_PSMCT32 && fi.TPSM == PSM_PSMT8 && ((fi.TZTST == 2 && fi.FBMSK == 0x00FFFFFF) || (fi.TZTST == 1 && fi.FBMSK == 0x00FFFFFF) || (fi.TZTST == 3 && fi.FBMSK == 0xFF000000)))
 		{
 			skip = 1; // wall of fog
-		}
-		else if (fi.TME && (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S))
-		{
-			// Equivalent to the UserHacks_AutoSkipDrawDepth hack but enabled by default
-			// http://forums.pcsx2.net/Thread-God-of-War-Red-line-rendering-explained
-			skip = 1;
 		}
 	}
 	else
@@ -1504,12 +1503,6 @@ bool GSC_GodOfWar2(const GSFrameInfo& fi, int& skip)
 			else if(Aggressive && fi.TPSM == PSM_PSMCT24 && fi.TME && (fi.FBP ==0x0100 ) && (fi.TBP0==0x2b00 || fi.TBP0==0x2e80)) // 480P 2e80
 			{
 				skip = 1; // water effect and water vertical lines
-			}
-			else if (fi.TME && (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S))
-			{
-				// Equivalent to the UserHacks_AutoSkipDrawDepth hack but enabled by default
-				// http://forums.pcsx2.net/Thread-God-of-War-Red-line-rendering-explained
-				skip = 1;
 			}
 		}
 	}
@@ -1702,7 +1695,7 @@ bool GSC_Sly2(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
-		if(fi.TME &&  (fi.FBP == 0x00000 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == fi.TPSM && fi.TPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
+		if(fi.TME &&  (fi.FBP == 0x00000 || fi.FBP == 0x00700 || fi.FBP == 0x00800 || fi.FBP == 0x008c0) && fi.FPSM == fi.TPSM && fi.TPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
 		{
 			skip = 1000;
 		}

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -427,8 +427,6 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		}
 	}
 
-	om_bsel.wrgba = ~GSVector4i::load((int)m_context->FRAME.FBMSK).eq8(GSVector4i::xffffffff()).mask();
-
 	// vs
 
 	GSDeviceDX::VSSelector vs_sel;

--- a/plugins/GSdx/GSRendererDX9.cpp
+++ b/plugins/GSdx/GSRendererDX9.cpp
@@ -63,8 +63,6 @@ void GSRendererDX9::EmulateTextureShuffleAndFbmask()
 		// It's still broken but more bearable. Broken effect is on the screen but fully instead of vertical lines.
 		throw GSDXRecoverableError();
 	} else {
-		//m_ps_sel.fmt = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt;
-
 		om_bsel.wrgba = ~GSVector4i::load((int)m_context->FRAME.FBMSK).eq8(GSVector4i::xffffffff()).mask();
 	}
 }

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -210,6 +210,7 @@ void GSRendererHW::SetGameCRC(uint32 crc, int options)
 		case CRC::RatchetAndClank4:
 		case CRC::RatchetAndClank5:
 		case CRC::RickyPontingInternationalCricket:
+		case CRC::Quake3Revolution:
 		case CRC::TombRaiderAnniversary:
 		case CRC::TribesAerialAssault:
 		case CRC::Whiplash:


### PR DESCRIPTION
GSdx: Remove fbmask handle in GSRendererDX. 
It's already handled in texture shuffle code.

GSdx: Adjust CRC hacks.
Move CRC hack for ICO that removed shadows to Aggressive, shadows are misaligned
when upscaling - can be fixed with HPO. We can use the hack as a speedhack 
for Aggressive state.

Add correct FBP code for Sly 2 E3 Demo. CRC hack should work properly now.

Purge God of War 1/2 CRC hacks that fixed/removed the vertical red lines.
No longer needed since the issue is fixed accross all renders.
Also useless to be kept for speedhacks.

GSdx: Add Quak3 Revolution to Automatic mipmapping.