### PR TITLE
GSdx: Remove/adjust crc hacks, add some crc ids

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -283,6 +283,7 @@ CRC::Game CRC::m_games[] =
 	{0x1CC39DBD, SuikodenTactics, US, 0},
 	{0x3E205556, SuikodenTactics, EU, 0},
 	{0xB808413B, SuikodenTactics, JP, 0},
+	{0xA33AF77A, TenchuFS, US, 0},
 	{0x64C58FB4, TenchuFS, US, 0},
 	{0xE7CCCB1E, TenchuFS, EU, 0},
 	{0x1969B19A, TenchuFS, ES, 0}, // PAL Spanish
@@ -465,7 +466,9 @@ CRC::Game CRC::m_games[] =
 	{0xFE44479E, ShinOnimusha, US, 0},
 	{0xFFDE85E9, ShinOnimusha, US, 0},
 	{0xE21404E2, GetaWay, US, 0},
+	{0x458485EF, GetaWay, EU, 0},
 	{0xE78971DF, GetaWayBlackMonday, US, 0},
+	{0x09C3DF79, GetaWayBlackMonday, EU, 0},
 	{0x1130BF23, SakuraTaisen, CH, 0}, // cutie comment
 	{0x4FAE8B83, SakuraTaisen, KO, 0},
 	{0xEF06DBD6, SakuraWarsSoLongMyLove, JP, 0}, // cutie comment
@@ -487,6 +490,7 @@ CRC::Game CRC::m_games[] =
 	{0xAEDAEE99, GodHand, JP, 0},
 	{0x6FB69282, GodHand, US, 0},
 	{0x924C4AA6, GodHand, KO, 0},
+	{0xDE9722A5, GodHand, EU, 0},
 	{0x9637D496, KnightsOfTheTemple2, JP, 0}, // cutie comment
 	{0x4E811100, UltramanFightingEvolution, JP, 0}, // cutie comment
 	{0xF7F181C3, DeathByDegreesTekkenNinaWilliams, CH, 0}, // cutie comment

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -91,8 +91,7 @@ bool GSC_DBZBT3(const GSFrameInfo& fi, int& skip)
 		}
 		else if(fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x00e00 || fi.FBP == 0x01000) && fi.FPSM == PSM_PSMCT16 && fi.TPSM == PSM_PSMZ16)
 		{
-			// Texture shuffling works on OpenGL only for the NTSC version. The PAL version still has some issues.
-			// Sky texture (depth related). On Direct3D the blue sky texture is shown on the whole screen in front of the player if hack is disabled.
+			// Sky texture (Depth) is properly rendered on OpenGL only for the NTSC version. The PAL version still has some issues (half screen bottom issue).
 			if(g_crc_region == CRC::EU || Dx_only)
 			{
 				skip = 5;
@@ -107,6 +106,27 @@ bool GSC_DBZBT3(const GSFrameInfo& fi, int& skip)
 	}
 
     return true;
+}
+
+bool GSC_DemonStone(const GSFrameInfo& fi, int& skip)
+{
+	if(skip == 0)
+	{
+		if(fi.TME && fi.FBP == 0x01400 && fi.FPSM == fi.TPSM && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01000) && fi.TPSM == PSM_PSMCT16)
+		{
+			// Texture shuffle half screen bottom issue.
+			skip = 1000;
+		}
+	}
+	else
+	{
+		if(Dx_only && fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x01000) && fi.FPSM == PSM_PSMCT32)
+		{
+			skip = 2;
+		}
+	}
+
+	return true;
 }
 
 bool GSC_WildArmsGames(const GSFrameInfo& fi, int& skip)
@@ -382,19 +402,6 @@ bool GSC_Naruto(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_EternalPoison(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		// Texture shuffle ???
-		if(fi.TPSM == PSM_PSMCT16S && fi.TBP0 == 0x3200)
-		{
-			skip = 1;
-		}
-	}
-	return true;
-}
-
 bool GSC_SakuraTaisen(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -433,10 +440,13 @@ bool GSC_ShadowofRome(const GSFrameInfo& fi, int& skip)
 	{
 		if(fi.FBP && fi.TPSM == PSM_PSMT8H && ( fi.FBMSK ==0x00FFFFFF))
 		{
-			skip =1;
+			// Depth issues on all renders, white wall and white duplicate characters.
+			skip = 1;
 		}
 		else if(fi.TME ==0x0001 && (fi.TBP0==0x1300 || fi.TBP0==0x0f00) && fi.FBMSK>=0xFFFFFF)
 		{
+			// Cause a grey transparent wall (D3D) and a transparent vertical grey line (all renders) on the left side of the screen.
+			// Blur effect maybe ?
 			skip = 1;
 		}
 		else if(fi.TME && fi.FPSM == PSM_PSMCT32 && (fi.TBP0 ==0x0160 ||fi.TBP0==0x01e0 || fi.TBP0<=0x0800) && fi.TPSM == PSM_PSMT8)
@@ -1034,19 +1044,6 @@ bool GSC_HummerBadlands(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_SengokuBasara(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(fi.TME  && (fi.TBP0==0x1800 ) && fi.FBMSK==0xFF000000)
-		{
-			skip = 1;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_TalesofSymphonia(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1122,6 +1119,21 @@ bool GSC_SteambotChronicles(const GSFrameInfo& fi, int& skip)
 // Correctly emulated on OpenGL but can be used as potential speed hack
 ////////////////////////////////////////////////////////////////////////////////
 
+bool GSC_EternalPoison(const GSFrameInfo& fi, int& skip)
+{
+	if(skip == 0)
+	{
+		// Texture shuffle or hdr colclip ???
+		if(fi.TPSM == PSM_PSMCT16S && fi.TBP0 == 0x3200)
+		{
+			// Removes shadows.
+			skip = 1;
+		}
+	}
+
+	return true;
+}
+
 bool GSC_FinalFightStreetwise(const GSFrameInfo& fi, int& skip)
 {
 	if (skip == 0)
@@ -1178,11 +1190,11 @@ bool GSC_HauntingGround(const GSFrameInfo& fi, int& skip)
 
 bool GSC_GetaWay(const GSFrameInfo& fi, int& skip)
 {
-	if (skip == 0)
+	if(skip == 0)
 	{
-		if ((fi.FBP == 0 || fi.FBP == 0x1180) && fi.TPSM == PSM_PSMT8H && fi.FBMSK == 0)
+		if((fi.FBP == 0 || fi.FBP == 0x1180 || fi.FBP == 0x1400) && fi.TPSM == PSM_PSMT8H && fi.FBMSK == 0)
 		{
-			skip = 1; // US version only. Removes fog wall.
+			skip = 1; // Removes fog wall.
 		}
 	}
 
@@ -1664,6 +1676,7 @@ bool GSC_Tenchu(const GSFrameInfo& fi, int& skip)
 	{
 		if(fi.TME && fi.TPSM == PSM_PSMZ16 && fi.FPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
 		{
+			// Depth issues. D3D only.
 			skip = 3;
 		}
 	}
@@ -1705,26 +1718,6 @@ bool GSC_Sly2(const GSFrameInfo& fi, int& skip)
 		if(fi.TME && fi.FPSM == fi.TPSM && fi.TPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
 		{
 			skip = 3;
-		}
-	}
-
-	return true;
-}
-
-bool GSC_DemonStone(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(fi.TME && fi.FBP == 0x01400 && fi.FPSM == fi.TPSM && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01000) && fi.TPSM == PSM_PSMCT16)
-		{
-			skip = 1000;
-		}
-	}
-	else
-	{
-		if(fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x01000) && fi.FPSM == PSM_PSMCT32)
-		{
-			skip = 2;
 		}
 	}
 
@@ -2234,15 +2227,11 @@ void GSState::SetupCrcHack()
 		lut[CRC::BurnoutTakedown] = GSC_Burnout;
 		lut[CRC::CaptainTsubasa] = GSC_CaptainTsubasa;
 		lut[CRC::CrashBandicootWoC] = GSC_CrashBandicootWoC;
-		lut[CRC::DBZBT2] = GSC_DBZBT2;
-		lut[CRC::DBZBT3] = GSC_DBZBT3;
 		lut[CRC::DevilMayCry3] = GSC_DevilMayCry3;
-		lut[CRC::EternalPoison] = GSC_EternalPoison;
 		lut[CRC::EvangelionJo] = GSC_EvangelionJo;
 		lut[CRC::FightingBeautyWulong] = GSC_FightingBeautyWulong;
 		lut[CRC::FrontMission5] = GSC_FrontMission5;
 		lut[CRC::Genji] = GSC_Genji;
-		lut[CRC::GiTS] = GSC_GiTS;
 		lut[CRC::GodHand] = GSC_GodHand;
 		lut[CRC::HeavyMetalThunder] = GSC_HeavyMetalThunder;
 		lut[CRC::HummerBadlands] = GSC_HummerBadlands;
@@ -2260,17 +2249,14 @@ void GSState::SetupCrcHack()
 		lut[CRC::SacredBlaze] = GSC_SacredBlaze;
 		lut[CRC::SakuraTaisen] = GSC_SakuraTaisen;
 		lut[CRC::SakuraWarsSoLongMyLove] = GSC_SakuraWarsSoLongMyLove;
-		lut[CRC::SengokuBasara] = GSC_SengokuBasara;
 		lut[CRC::ShadowofRome] = GSC_ShadowofRome;
 		lut[CRC::ShinOnimusha] = GSC_ShinOnimusha;
 		lut[CRC::Simple2000Vol114] = GSC_Simple2000Vol114;
 		lut[CRC::Spartan] = GSC_Spartan;
 		lut[CRC::StarWarsForceUnleashed] = GSC_StarWarsForceUnleashed;
-		lut[CRC::SteambotChronicles] = GSC_SteambotChronicles;
 		lut[CRC::SFEX3] = GSC_SFEX3;
 		lut[CRC::TalesOfLegendia] = GSC_TalesOfLegendia;
 		lut[CRC::TalesofSymphonia] = GSC_TalesofSymphonia;
-		lut[CRC::Tekken5] = GSC_Tekken5;
 		lut[CRC::TimeSplitters2] = GSC_TimeSplitters2;
 		lut[CRC::TombRaiderAnniversary] = GSC_TombRaider;
 		lut[CRC::TombRaiderLegend] = GSC_TombRaiderLegend;
@@ -2282,10 +2268,22 @@ void GSState::SetupCrcHack()
 		lut[CRC::Yakuza2] = GSC_Yakuza2;
 		lut[CRC::Yakuza] = GSC_Yakuza;
 		lut[CRC::ZettaiZetsumeiToshi2] = GSC_ZettaiZetsumeiToshi2;
+
+		// Channel Effect
+		lut[CRC::GiTS] = GSC_GiTS;
+		lut[CRC::SteambotChronicles] = GSC_SteambotChronicles;
+
+		// Half Screen bottom issue
+		lut[CRC::DBZBT2] = GSC_DBZBT2;
+		lut[CRC::DBZBT3] = GSC_DBZBT3;
+		lut[CRC::DemonStone] = GSC_DemonStone;
+		lut[CRC::Tekken5] = GSC_Tekken5;
+
 		// These games emulate a stencil buffer with the alpha channel of the RT (too slow to move to DX only)
 		lut[CRC::RadiataStories] = GSC_RadiataStories;
 		lut[CRC::StarOcean3] = GSC_StarOcean3;
 		lut[CRC::ValkyrieProfile2] = GSC_ValkyrieProfile2;
+
 		// Only Aggressive
 		lut[CRC::BleachBladeBattlers] = GSC_BleachBladeBattlers;
 		lut[CRC::FFX2] = GSC_FFXGames;
@@ -2304,7 +2302,7 @@ void GSState::SetupCrcHack()
 		// Depth
 		lut[CRC::Bully] = GSC_Bully;
 		lut[CRC::BullyCC] = GSC_BullyCC;
-		lut[CRC::FinalFightStreetwise] = GSC_FinalFightStreetwise;
+		lut[CRC::FinalFightStreetwise] = GSC_FinalFightStreetwise; // + blending
 		lut[CRC::GodOfWar2] = GSC_GodOfWar2;
 		lut[CRC::ICO] = GSC_ICO;
 		lut[CRC::LordOfTheRingsTwoTowers] = GSC_LordOfTheRingsTwoTowers;
@@ -2312,6 +2310,8 @@ void GSState::SetupCrcHack()
 		lut[CRC::SoulCalibur2] = GSC_SoulCaliburGames;
 		lut[CRC::SoulCalibur3] = GSC_SoulCaliburGames;
 		lut[CRC::SuikodenTactics] = GSC_SuikodenTactics;
+		lut[CRC::TenchuFS] = GSC_Tenchu;
+		lut[CRC::TenchuWoH] = GSC_Tenchu;
 		lut[CRC::XE3] = GSC_XE3;
 
 		// Depth + Texture cache issue + Date (AKA a real mess)
@@ -2319,16 +2319,14 @@ void GSState::SetupCrcHack()
 
 		// Not tested but must be fixed with texture shuffle
 		lut[CRC::BigMuthaTruckers] = GSC_BigMuthaTruckers;
-		lut[CRC::DemonStone] = GSC_DemonStone;
 		lut[CRC::CrashNburn] = GSC_CrashNburn; // seem to be a basic depth effect
+		lut[CRC::EternalPoison] = GSC_EternalPoison;
 		lut[CRC::LegoBatman] = GSC_LegoBatman;
 		lut[CRC::OnePieceGrandAdventure] = GSC_OnePieceGrandAdventure;
 		lut[CRC::OnePieceGrandBattle] = GSC_OnePieceGrandBattle;
 		lut[CRC::SpyroEternalNight] = GSC_SpyroEternalNight;
 		lut[CRC::SpyroNewBeginning] = GSC_SpyroNewBeginning;
 		lut[CRC::SonicUnleashed] = GSC_SonicUnleashed;
-		lut[CRC::TenchuFS] = GSC_Tenchu;
-		lut[CRC::TenchuWoH] = GSC_Tenchu;
 
 		// Those games might requires accurate fbmask
 		lut[CRC::Sly2] = GSC_Sly2;
@@ -2352,6 +2350,7 @@ void GSState::SetupCrcHack()
 		lut[CRC::SkyGunner] = GSC_SkyGunner;
 		lut[CRC::StarWarsBattlefront2] = GSC_StarWarsBattlefront2;
 		lut[CRC::StarWarsBattlefront] = GSC_StarWarsBattlefront;
+
 		// Dedicated shader for channel effect
 		lut[CRC::TalesOfAbyss] = GSC_TalesOfAbyss;
 


### PR DESCRIPTION
GSdx: Adjust CRC hacks.
Purge Sengoku Basara crc hacks. Texture shuffle is emulated correctly on
d3d/ogl. d3d9 skips the bad draw call.

Move Eternal Poison crc hack to d3d level. Not needed on ogl since it's
emulated properly.

Move hack that removes texture shuffle for Demon Stoneback back to ogl level,
half screen bottom issue remains.

Extent CRC hack for The Getaway and The Getaway Black Monday to work on
EU regions.

Gsdx: Add some missing crc ids.
Tenchu Fatal Shadows US,
God Hand EU,
The Getaway EU,
The Getaway Black Monday EU.