### PR TITLE
GSdx: Adjust Naruto series crc hacks

### DIFF
--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -358,11 +358,7 @@ bool GSC_NarutimateAccel(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
-		if(fi.TME && fi.FBP == 0x3800 && fi.TBP0 == 0 && (fi.FPSM | fi.TPSM) == 0)
-			{
-				skip = 105;
-			}
-		else if(!fi.TME && fi.FBP == 0x3800 && fi.TBP0 == 0x1E00 && fi.FPSM == 0 && fi.TPSM == 49 && fi.FBMSK == 0xFF000000)
+		if(!fi.TME && fi.FBP == 0x3800 && fi.TBP0 == 0x1E00 && fi.FPSM == 0 && fi.TPSM == 49 && fi.FBMSK == 0xFF000000)
 			{
 				skip = 1;
 			}
@@ -382,11 +378,7 @@ bool GSC_Naruto(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
-		if(fi.TME && fi.FBP == 0x3800 && fi.TBP0 == 0 && (fi.FPSM | fi.TPSM) == 0)
-			{
-				skip = 105;
-			}
-		else if(!fi.TME && fi.FBP == 0x3800 && fi.TBP0 == 0x1E00 && fi.FPSM == 0 && fi.TPSM == 49 && fi.FBMSK == 0xFF000000)
+		if(!fi.TME && fi.FBP == 0x3800 && fi.TBP0 == 0x1E00 && fi.FPSM == 0 && fi.TPSM == 49 && fi.FBMSK == 0xFF000000)
 			{
 				skip = 0;
 			}


### PR DESCRIPTION
Purge CRC hacks that removed lighting on maps.
Games: Naruto - Narutimate Hero 3,
Naruto Shippuuden: Narutimate Accel.

I don't know what the other crc hacks do so I left them there given that the games also make use of Hw Depth they might be needed for some issue.

GS dumps for future use if needed.
[Naruto_Accel.gs.zip](https://github.com/PCSX2/pcsx2/files/1871791/Naruto_Accel.gs.zip)
[Naruto_accel2.gs.zip](https://github.com/PCSX2/pcsx2/files/1871792/Naruto_accel2.gs.zip)
[Naruto_hero3.gs.zip](https://github.com/PCSX2/pcsx2/files/1871793/Naruto_hero3.gs.zip)
[Naruto_1.gs.zip](https://github.com/PCSX2/pcsx2/files/1871794/Naruto_1.gs.zip)
