### PR TITLE
GameDB: add Prafull's alternative patch for Klonoa 2

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -34770,6 +34770,11 @@ Region = NTSC-U
 Compat = 5
 eeClampMode = 3 // Objects appear in wrong places without it 
 vuClampMode = 2 // Fixes water reflection
+[patches = 2F56CBC9]
+	comment=patch by Prafull
+	// Avoid cave hang at Volk City.
+	patch=1,EE,00305bcc,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20152
 Name   = Ace Combat 4 - Shattered Skies


### PR DESCRIPTION
This adds the necessary patch to avoid a hang in the NTSC-U version of Klonoa 2. Workaround for #2349.