### PR TITLE
GameDB: Revert Crash Tag Team Racing gamefix

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -14105,7 +14105,6 @@ Compat = 5
 Serial = SLES-53439
 Name   = Crash Tag Team Racing
 Region = PAL-M6
-ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLES-53441
 Name   = Heroes of the Pacific
@@ -25368,7 +25367,6 @@ Region = NTSC-J
 Serial = SLPM-66090
 Name   = Crash Bandicoot: Gacchanko World
 Region = NTSC-J
-ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLPM-66091
 Name   = Shinobido Imashime
@@ -39672,7 +39670,6 @@ Serial = SLUS-21191
 Name   = Crash Tag Team Racing
 Region = NTSC-U
 Compat = 5
-ScarfaceIbitHack = 1
 ---------------------------------------------
 Serial = SLUS-21192
 Name   = Cabela's Outdoor Adventures 2006


### PR DESCRIPTION
Revert ScarfaceIbitHack Gamefix.
Regression was introduced in #2326.
Caused hard freezes making the game unplayable and required an emulator
restart without gamefixes enabled.
Without the fix the game experiences short freezes but the game is still
playable.

Close #2366