### PR TITLE
GameDB: Add XgKickHack for Crash Twinsanity (NTSC-U)

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -38133,9 +38133,10 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-20909
-Name   = Crash Bandicoot Twinsanity
+Name   = Crash Twinsanity
 Region = NTSC-U
 Compat = 5
+XgKickHack = 1 // Fixes bad geometry.
 ---------------------------------------------
 Serial = SLUS-20910
 Name   = Test Drive - Eve of Destruction


### PR DESCRIPTION
Add the XgKickHack to the NTSC-U release of Crash Twinsanity. Fixes #2365.