### PR TITLE
man: Minor fixes

### DIFF
--- a/bin/docs/PCSX2.1
+++ b/bin/docs/PCSX2.1
@@ -62,7 +62,7 @@ This allows you to play PS2 games on your PC, with many additional features and
 benefits.
 .Sh GENERAL OPTIONS
 .Bl -tag -width Ds
-.It Fl h, Fl \-help
+.It Fl h,\& Fl \-help
 Displays the list of available command line options.
 .It Fl \-cfg Ns = Ns Ar file
 Uses
@@ -116,7 +116,7 @@ Boots with an empty DVD tray.
 Use this to boot into the PS2 system menu.
 .It Fl \-usecd
 Boots using the configured CDVD plugin instead of booting
-.Ar iso Ns .
+.Ar iso .
 .It Fl \-fullscreen
 Runs the game in fullscreen mode.
 .It Fl \-windowed
@@ -177,7 +177,7 @@ User configuration and data directory.
 .An PCSX2 Dev Team and many other contributors
 .Sh BUGS
 Bugs can be reported by submitting an issue at the
-.Lk https://github.com/PCSX2/pcsx2/issues "PCSX2 Github issue tracker" Ns .
+.Lk https://github.com/PCSX2/pcsx2/issues "PCSX2 Github issue tracker"
 .Sh PCSX2 RELATED WEBSITES
 .Bl -bullet
 .It


### PR DESCRIPTION
This adds two commits.

1. This moves `PCSX2.1` to `PCSX2.6` and install its to man section `6` instead of `1`. The reason for this is according the man manual page games should be in section `6` where section `1` is used for general tools. I think we can agree PCSX2 is more a game than a general tool?

2. This silences some warnings for the PCSX2 man page found with the lint feature from `mandoc(1)`.

Any suggestions are of course welcome.
```
Only select manuals from the specified section.  The currently available sections are:

      1         General commands (tools and utilities).
      2         System calls and error numbers.
      3         Library functions.
      3p        perl(1) programmer's reference guide.
      4         Device drivers.
      5         File formats.
      6         Games.
      7         Miscellaneous information.
      8         System maintenance and operation commands.
      9         Kernel internals.
```
```
man -Tlint PCSX2
```
```
no blank before trailing delimiter
  (mdoc) The last argument of a macro that supports trailing
  delimiter arguments is longer than one byte and ends with a
  trailing delimiter. Consider inserting a blank such that the
  delimiter becomes a separate argument, thus moving it out of
  the scope of the macro.
```
```
skipping no-space macro
  (mdoc) An input line begins with an Ns macro, or the next argument
  after an Ns macro is an isolated closing delimiter. The macro is
  ignored.
```
https://man.openbsd.org/mandoc.1
```
man: PCSX2.6:65:9: STYLE: no blank before trailing delimiter: Fl h,
man: PCSX2.6:119:9: WARNING: skipping no-space macro
man: PCSX2.6:180:72: WARNING: skipping no-space macro
```
1. This is fixed by adding a zero-width space (\&) so that the trailing delimiter character is no longer at the end.
2. Removes the ignored no-space macros. This has the side effect of removing a lone period.

See the following diff of the rendered man page.
```
--- PCSX2.1.orig        2018-04-08 16:02:09.300643308 -0700
+++ PCSX2.6     2018-04-08 16:03:47.677587114 -0700
@@ -1,4 +1,4 @@
-PCSX2(1)                    General Commands Manual                   PCSX2(1)
+PCSX2(6)                         Games Manual                         PCSX2(6)
 
 NAME
      PCSX2 – PlayStation(R)2 Console Emulator
@@ -121,7 +121,6 @@
      Bugs can be reported by submitting an issue at the PCSX2 Github issue
      tracker:
            https://github.com/PCSX2/pcsx2/issues
-     .
 
 PCSX2 RELATED WEBSITES
      •   PCSX2 git repository:
```