### PR TITLE
PCSX2: Update VU I bit gamefix tooltip

### DIFF
--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -105,9 +105,8 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("VU I bit Hack avoid constant recompilation. Fixes memory leak slowdowns/stalls."),
-			pxEt( L"Try this when \"microVU1: Program cache limit\" is printed in the log.\nKnown to affect following games:\n * Scarface The World Is Yours\n * Crash Tag Team Racing"
-			)
+			_("VU I bit Hack avoid constant recompilation (Scarface The World Is Yours)"),
+			wxEmptyString
 		}
 	};
 


### PR DESCRIPTION
Remove mention of Crash Tag Team Racing from VU I bit gamefix tooltip.
Not needed since the gamefix has been removed for the game as it causes
more issues.

Related #2368