### PR TITLE
GSdx-TC: Don't skip depth lookup on Jackie Chan Adv and SVC Chaos

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -182,6 +182,8 @@ CRC::Game CRC::m_games[] =
 	{0x72E1E60E, Spartan, EU, 0},
 	{0x26689C87, Spartan, JP, 0},
 	{0x08277A9E, Spartan, US, 0},
+	{0xAC3C1147, SVCChaos, EU, 0}, // SVC Chaos: SNK vs. Capcom
+	{0xB00FF2ED, SVCChaos, JP, 0},
 	{0xA32F7CD0, AceCombat4, US, 0}, // Also needed for automatic mipmapping
 	{0x5ED8FB53, AceCombat4, JP, 0},
 	{0x1B9B7563, AceCombat4, EU, 0},
@@ -221,6 +223,7 @@ CRC::Game CRC::m_games[] =
 	{0xFA0DF523, GodOfWar2, CH, 0}, // cutie comment
 	{0x9FEE3466, GodOfWar2, CH, 0}, // cutie comment
 	{0x5D482F18, JackieChanAdv, EU, 0},
+	{0xAC4DFD5A, JackieChanAdv, EU, 0},
 	{0xF0A6D880, HarvestMoon, US, 0},
 	{0x9536E111, NamcoXCapcom, JP, 0},
 	{0x75C01A04, NamcoXCapcom, US, 0}, // same CRC as another JP disc

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -167,6 +167,7 @@ public:
 		SteambotChronicles,
 		SuikodenTactics,
 		SuperManReturns,
+		SVCChaos,
 		TalesOfAbyss,
 		TalesofDestiny,
 		TalesOfLegendia,

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -99,7 +99,13 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 {
 	if (!CanConvertDepth()) {
 		GL_CACHE("LookupDepthSource not supported (0x%x, F:0x%x)", TEX0.TBP0, TEX0.PSM);
-		throw GSDXRecoverableError();
+		if (m_renderer->m_game.title == CRC::JackieChanAdv || m_renderer->m_game.title == CRC::SVCChaos) {
+			// JackieChan and SVCChaos cause regressions when skipping the draw calls when depth is disabled/not supported.
+			// This way we make sure there are no regressions on D3D as well.
+			return LookupSource(TEX0, TEXA, r);
+		} else {
+			throw GSDXRecoverableError();
+		}
 	}
 
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
@@ -176,14 +182,18 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		// Note: might worth to check previous frame
 		// Note: otherwise return NULL and skip the draw
 
-		// Full Spectrum Warrior: first draw call of cut-scene rendering
-		// The game tries to emulate a texture shuffle with an old depth buffer
-		// (don't exists yet for us due to the cache)
-		// Rendering is nicer (less garbage) if we skip the draw call.
-		throw GSDXRecoverableError();
+		if (m_renderer->m_game.title == CRC::JackieChanAdv || m_renderer->m_game.title == CRC::SVCChaos) {
+			// JackieChan and SVCChaos cause regressions when skipping the draw calls so we reuse the old code for these two.
+			return LookupSource(TEX0, TEXA, r);
+		} else {
+			// Full Spectrum Warrior: first draw call of cut-scene rendering
+			// The game tries to emulate a texture shuffle with an old depth buffer
+			// (don't exists yet for us due to the cache)
+			// Rendering is nicer (less garbage) if we skip the draw call.
+			throw GSDXRecoverableError();
+		}
 
 		//ASSERT(0);
-		//return LookupSource(TEX0, TEXA, r);
 	}
 
 	return src;


### PR DESCRIPTION
This is a follow up to #1868

Issues:
SVC Chaos #1862
Jackie Chan #1838

Don't skip the draw calls on Jackie Chan Adv and SVC Chaos,
avoids regressions and we can use the old code for now.

Gregory: The correct fix would be to trace all textures writes to
be sure of the source. But it is a much bigger work.

Close #1862 
Close #1838