### PR TITLE
About Box: Add missing contributors, misc. formatting.

### DIFF
--- a/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
+++ b/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
@@ -45,22 +45,26 @@ Dialogs::AboutBoxDialog::AboutBoxDialog(wxWindow* parent)
 		L"%s: \n"
 		L"Arcum42, Aumatt, drk||raziel, "
 		L"cottonvibes, gigaherz, saqib, "
-		L"Alexey silinov, Aumatt, "
-		L"Florin, goldfinger, Linuzappz, loser, "
+		L"\n"
+		L"Alexey Silinov, Florin, "
+		L"goldfinger, Linuzappz, loser, "
 		L"Nachbrenner, shadow, Zerofrog, tmkk, Jake.Stine"
 		L"\n\n"
 		L"%s:\n"
-		L"Falcon4ever, Bositman",
+		L"Falcon4ever, Bositman, Akasha",
 		_("Previous versions"), _("Webmasters"));
 
 	wxString contribsString = wxsFormat(
-		L"%s: \n"
-		L"ChickenLiver(Lilypad), Gabest (GSdx, Cdvdolio, Xpad)"
+		L"ssakash, FlatOut, CK1, lightningterror, atomic83github, Pandubz, Prafull, Blyss Sarania, Nobbs66, Alessandro Vetere"
 		L"\n\n"
 		L"%s: \n"
-		L"Ckemu, Prafull, General Plot, KrossX, Devina, ssakash, FlatOut, Blyss Sarania, micove, black_wd, Belmont, BGome,"
-		L" _Demo_, Dreamtime, Hiryu and Sjeep, nneeve, Shadow Lady, F|RES, Jake.Stine, MrBrown, razorblade, Seta-san, Skarmeth, feal87, Athos",
-		_("Plugin Specialists"), _("Special thanks to"));
+		L"ChickenLiver (Lilypad), Gabest (GSdx, Cdvdolio, Xpad), Ckemu, "
+		L"General Plot, KrossX, Devina, micove, black_wd, Belmont, "
+		L"\n"
+		L"BGome, _Demo_, Dreamtime, Hiryu and Sjeep, nneeve, F|RES, "
+		L"Shadow Lady, MrBrown, razorblade, Seta-san, Skarmeth, feal87, Athos"
+		L"\n",
+		_("Previous versions"));
 
 	wxFlexGridSizer& boxesContainer = *new wxFlexGridSizer(2, 0, StdPadding);
 	boxesContainer.AddGrowableCol(0, 1);


### PR DESCRIPTION
Add names of missing contributors, and reformat some strings to fit the massive amount of names present ;) - If anybody dislikes the new/old contributors being separated, I'm fine with reverting/adjusting that. Let me know if there's anything else to be modified here.

Preview: 
![aboutbox_new](https://user-images.githubusercontent.com/16314399/38746527-c53e3eca-3f15-11e8-8359-9520041329b7.png)
