### PR TITLE
GameDB: Add vuClampMode hack/remove eeClampMode hack for Pac-Man World Rally

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16473,6 +16473,7 @@ Region = PAL-M5
 Serial = SLES-54584
 Name   = Pac-Man Rally
 Region = PAL-M5
+vuClampMode=2 // Fixes bad geometry.
 ---------------------------------------------
 Serial = SLES-54586
 Name   = Ar tonelico: Melody of Elemia
@@ -40225,7 +40226,7 @@ Serial = SLUS-21328
 Name   = Pac-Man World Rally
 Region = NTSC-U
 Compat = 5
-eeClampMode = 3
+vuClampMode = 2 // Fixes bad geometry.
 ---------------------------------------------
 Serial = SLUS-21329
 Name   = Karaoke Revolution Country - CMT Presents


### PR DESCRIPTION
Fixes bad geometry. This also replaces the eeClampMode hack in the NTSC-U release which didn't appear to do anything (it was probably a mistake and I can't find any references to it)