### PR TITLE
GameDB: Add vuClampMode hack to Katamari/SkipMPEGHack to Arctic Thunder.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -34956,6 +34956,7 @@ Serial = SLUS-20217
 Name   = Arctic Thunder
 Region = NTSC-U
 Compat = 5
+SkipMPEGHack = 1
 ---------------------------------------------
 Serial = SLUS-20218
 Name   = Stunt GP
@@ -38681,6 +38682,7 @@ Serial = SLUS-21008
 Name   = Katamari Damacy
 Region = NTSC-U
 Compat = 5
+vuClampMode = 3
 mvuFlagSpeedHack = 0
 ---------------------------------------------
 Serial = SLUS-21009


### PR DESCRIPTION
- Adds the vuClampMode hack to the NTSC-U release of Katamari Damacy. Closes #2386 
- Adds the SkipMPEGHack to the NTSC-U release of Arctic Thunder. Closes #2385 