### PR TITLE
GSdx-TC: JackieChanAdv run invalidate video memory

### DIFF
--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -669,7 +669,10 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 // must invalidate the Target/Depth respectively
 void GSTextureCache::InvalidateVideoMemType(int type, uint32 bp)
 {
-	if (!CanConvertDepth())
+	if (!CanConvertDepth() && m_renderer->m_game.title != CRC::JackieChanAdv)
+		// JackieChanAdv shouldn't hit this code path even if depth is not supported,
+		// otherwise it causes a regression on D3D/OGL on the main menu where the background image is back instead of yellow, and it also fixes texture flickering ingame.
+		// Note: The game also doesn't like Depth Emulation as it causes half right screen issue so this is the best workaround we have atm.
 		return;
 
 	auto& list = m_dst[type];


### PR DESCRIPTION
Run invalidate video memory on JackieChanAdv when depth is disabled to
avoid regressions, fixes black/grey background on D3D/OGL and textures
flickering ingame.

The game also doesn't play well with depth emulation on OGL as it causes
a half right screen issue so this is the best workaround we have atm.

Regression PR: #1776
Related issue: #1838

D3D test comparisons:
Master (first boot)
![pcsx2 2018-04-25 03-37-50-74](https://user-images.githubusercontent.com/18107717/39222105-1bcfe7ce-483b-11e8-8c8a-bf462099b716.png)

Master (render paused/resumed/restarted)
![pcsx2 2018-04-25 03-37-24-64](https://user-images.githubusercontent.com/18107717/39222113-2fe82c12-483b-11e8-8998-a4078f03987e.png)

PR
![pcsx2 2018-04-25 03-38-19-82](https://user-images.githubusercontent.com/18107717/39222120-3668b548-483b-11e8-88d8-c60514af4b6b.png)

Close #1838 