### PR TITLE
PSX: Mode adjustments, fixed PSXCLK and adjusted EE clock speed 

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -22,6 +22,7 @@
 #include <wx/datetime.h>
 
 #include "CDVD.h"
+#include "CdRom.h"
 #include "CDVD_internal.h"
 #include "CDVDisoReader.h"
 
@@ -1416,6 +1417,10 @@ static __fi void cdvdWrite0F(u8 rt) { // TYPE
 static __fi void cdvdWrite14(u8 rt) { // PS1 MODE?? // This should be done in the SBUS_F240 bit 19 write in HwWrite.cpp
 	u32 cycle = psxRegs.cycle;
 
+	PSXCLK = 33868800;      //33.8688 Mhz Playstation 1 speed.
+    psxEEmultiplier = 8.71; //proper EE to iop cycle freaquency.
+    setPsxSpeed();          //this sets the cd speed for ps1 mode.
+	
 	if (rt == 0xFE)
 		Console.Warning("*PCSX2*: go PS1 mode DISC SPEED = FAST");
 	else

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -82,15 +82,10 @@ u8 Test20[] = { 0x98, 0x06, 0x10, 0xC3 };
 u8 Test22[] = { 0x66, 0x6F, 0x72, 0x20, 0x45, 0x75, 0x72, 0x6F };
 u8 Test23[] = { 0x43, 0x58, 0x44, 0x32, 0x39 ,0x34, 0x30, 0x51 };
 
-// 1x = 75 sectors per second
-// PSXCLK = 1 sec in the ps
-// so (PSXCLK / 75) / BIAS = cdr read time (linuzappz)
-//#define cdReadTime ((PSXCLK / 75) / BIAS)
-u32 cdReadTime;// = ((PSXCLK / 75) / BIAS);
+u32 cdReadTime;
 
 #define CDR_INT(eCycle)    PSX_INT(IopEvt_Cdrom, eCycle)
 #define CDREAD_INT(eCycle) PSX_INT(IopEvt_CdromRead, eCycle)
-
 
 static void AddIrqQueue(u8 irq, u32 ecycle);
 
@@ -938,6 +933,15 @@ void psxDma3(u32 madr, u32 bcr, u32 chcr) {
 	HW_DMA3_CHCR &= ~0x01000000;
 	psxDmaInterrupt(3);
 }
+
+void setPsxSpeed()
+{
+    // 1x = 75 sectors per second
+    // PSXCLK = 1 sec in the ps
+    // so (PSXCLK / 75) / BIAS = cdr read time (linuzappz)
+    cdReadTime = ((PSXCLK / 75) / BIAS);
+}
+
 
 #ifdef ENABLE_NEW_IOPDMA
 s32 CALLBACK cdvdDmaRead(s32 channel, u32* data, u32 bytesLeft, u32* bytesProcessed)

--- a/pcsx2/CDVD/CdRom.h
+++ b/pcsx2/CDVD/CdRom.h
@@ -89,6 +89,7 @@ extern cdrStruct cdr;
 void cdrReset();
 void  cdrInterrupt();
 void  cdrReadInterrupt();
+void setPsxSpeed();
 u8   cdrRead0(void);
 u8   cdrRead1(void);
 u8   cdrRead2(void);

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -19,6 +19,14 @@
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
 static const u32 PS2CLK = 294912000;	//hz	/* 294.912 mhz */
+extern s64 PSXCLK; // The Iop cycle clock or the PS1's main processor this variable determins and set's the freaquency of the processor. 	
+
+
+// This variable controls and set's the Multiplier value for the EE to Iop cycle clock,                     
+// This is the thing that controls the freaquency of Iop to EE interaction and vice versa                       
+// This changes between PS2 and PS1 mode's to account for the clock difference in                            
+// The Iop or ps1 processor's speed between the two modes.
+extern int psxEEmultiplier; 
 
 #include "System.h"
 #include "Memory.h"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -305,9 +305,9 @@ struct Pcsx2Config
 		int		FramesToDraw;	// number of consecutive frames (fields) to render
 		int		FramesToSkip;	// number of consecutive frames (fields) to skip
 
-		Fixed100	LimitScalar;
-		Fixed100	FramerateNTSC;
-		Fixed100	FrameratePAL;
+		Fixed100 LimitScalar;
+		Fixed100 FramerateNTSC;
+		Fixed100 FrameratePAL;
 
 		GSOptions();
 		void LoadSave( IniInterface& conf );

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -93,8 +93,8 @@ struct SyncCounter
 //------------------------------------------------------------------
 #define FRAMERATE_NTSC			29.97 // frames per second
 
-#define SCANLINES_TOTAL_NTSC	525 // total number of scanlines
-#define SCANLINES_VSYNC_NTSC	3   // scanlines that are used for syncing every half-frame
+#define SCANLINES_TOTAL_NTSC 525    // total number of scanlines
+#define SCANLINES_VSYNC_NTSC 3     // scanlines that are used for syncing every half-frame
 #define SCANLINES_VRENDER_NTSC	240 // scanlines in a half-frame (because of interlacing)
 #define SCANLINES_VBLANK1_NTSC	19  // scanlines used for vblank1 (even interlace)
 #define SCANLINES_VBLANK2_NTSC	20  // scanlines used for vblank2 (odd interlace)

--- a/pcsx2/IopCommon.h
+++ b/pcsx2/IopCommon.h
@@ -28,7 +28,6 @@
 #include "IopCounters.h"
 #include "IopSio2.h"
 #include "IopGte.h"
-static const s64 PSXCLK = 36864000;	/* 36.864 Mhz */
 //#define PSXCLK	 9216000	/* 36.864 Mhz */
 //#define PSXCLK	186864000	/* 36.864 Mhz */
 

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -32,9 +32,11 @@
 	 VBlank non-interlaced	59.82 Hz
 	 HBlank					15.73426573 KHz */
 
+s64 PSXCLK; //This is the definition of the Processor Clock for the PS1 externally declared in IopCommon.h
+
 // Misc IOP Clocks
-#define PSXPIXEL        ((int)(PSXCLK / 13500000))
-#define PSXSOUNDCLK		((int)(48000))
+#define PSXPIXEL          ((int)(PSXCLK / 13500000))
+#define PSXSOUNDCLK		  ((int)(48000))
 
 psxCounter psxCounters[NUM_COUNTERS];
 s32 psxNextCounter;

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -63,7 +63,8 @@ void psxReset()
 	g_iopNextEventCycle = psxRegs.cycle + 4;
 
 	psxHwReset();
-
+	psxEEmultiplier = 8; /*Base EE to Iop Clock speed for the Playstation 2*/
+	PSXCLK = 36864000; /* 36.864 Mhz Playstation 2 speed*/
 	ioman::reset();
 	psxBiosReset();
 }
@@ -149,7 +150,7 @@ __fi void PSX_INT( IopEventId n, s32 ecycle )
 		// The EE called this int, so inform it to branch as needed:
 		// fixme - this doesn't take into account EE/IOP sync (the IOP may be running
 		// ahead or behind the EE as per the EEsCycles value)
-		s32 iopDelta = (g_iopNextEventCycle-psxRegs.cycle)*8;
+		s32 iopDelta = (s32)((g_iopNextEventCycle-psxRegs.cycle)*psxEEmultiplier);
 		cpuSetNextEventDelta( iopDelta );
 	}
 }

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -144,7 +144,15 @@ static __fi void execI()
 	psxRegs.cycle++;
 	iopCycleEE-=8;
 
-	psxBSC[psxRegs.code >> 26]();
+    if ((psxHu32(HW_ICFG) & (1 << 3)))    
+	{
+        //this get's set to 9 because in the EE's half of this equation	                 
+		//Were trunacating the value 8.71 to a 9 instead due to casting
+		//setting this causes Iop to stay correctly synced to EE in ps1 mode
+		//Whilst before Iop was running ahead of EE.
+		iopCycleEE -= 9; 
+	}
+    psxBSC[psxRegs.code >> 26]();
 }
 
 static void doBranch(s32 tar) {

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -59,6 +59,9 @@ u32 eeloadMain = 0;
 
 extern SysMainMemory& GetVmMemory();
 
+int psxEEmultiplier; //to fixed the unresolved external symbol. 
+
+
 void cpuReset()
 {
 	vu1Thread.WaitVU();
@@ -438,7 +441,10 @@ __fi void _cpuEventTest_Shared()
 
 	// The IOP could be running ahead/behind of us, so adjust the iop's next branch by its
 	// relative position to the EE (via EEsCycle)
-	cpuSetNextEventDelta( ((g_iopNextEventCycle-psxRegs.cycle)*8) - EEsCycle );
+
+	// One of two parts of an equation that determines the EE to Iop clock speed, note the value is trunacated.		                                                                                           
+	// due to the freaquency in PS1 mode being 8.71 that get's rounded up to 9. 
+	cpuSetNextEventDelta((s32)((g_iopNextEventCycle - psxRegs.cycle) * psxEEmultiplier) - EEsCycle); 
 
 	// Apply the hsync counter's nextCycle
 	cpuSetNextEvent( hsyncCounter.sCycle, hsyncCounter.CycleT );

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -942,7 +942,10 @@ static void iPsxBranchTest(u32 newpc, u32 cpuBranch)
 		xMOV(ptr32[&psxRegs.cycle], eax); // update cycles
 
 		// jump if iopCycleEE <= 0  (iop's timeslice timed out, so time to return control to the EE)
-		xSUB(ptr32[&iopCycleEE], blockCycles*8);
+		// One of two parts of an equation that determins the EE to Iop clock speed, note the value is trunacated.		                                                                      
+		// due to the freaquency in PS1 mode being 8.71 that get's rounded up to 9. 
+		xSUB(ptr32[&iopCycleEE], (s32)(round(blockCycles * psxEEmultiplier)));
+
 		xJLE(iopExitRecompiledCode);
 
 		// check if an event is pending
@@ -992,7 +995,7 @@ void rpsxSYSCALL()
 	j8Ptr[0] = JE8(0);
 
 	xADD(ptr32[&psxRegs.cycle], psxScaleBlockCycles() );
-	xSUB(ptr32[&iopCycleEE], psxScaleBlockCycles()*8 );
+    xSUB(ptr32[&iopCycleEE], (s32)(psxScaleBlockCycles() * psxEEmultiplier));
 	JMP32((uptr)iopDispatcherReg - ( (uptr)x86Ptr + 5 ));
 
 	// jump target for skipping blockCycle updates
@@ -1014,7 +1017,7 @@ void rpsxBREAK()
 	xCMP(ptr32[&psxRegs.pc], psxpc-4);
 	j8Ptr[0] = JE8(0);
 	xADD(ptr32[&psxRegs.cycle], psxScaleBlockCycles() );
-	xSUB(ptr32[&iopCycleEE], psxScaleBlockCycles()*8 );
+	xSUB(ptr32[&iopCycleEE], (s32)(psxScaleBlockCycles()*psxEEmultiplier));
 	JMP32((uptr)iopDispatcherReg - ( (uptr)x86Ptr + 5 ));
 	x86SetJ8(j8Ptr[0]);
 
@@ -1284,7 +1287,7 @@ StartRecomp:
 		else
 		{
 			xADD(ptr32[&psxRegs.cycle], psxScaleBlockCycles() );
-			xSUB(ptr32[&iopCycleEE], psxScaleBlockCycles()*8 );
+            xSUB(ptr32[&iopCycleEE], (s32)(psxScaleBlockCycles() * psxEEmultiplier));
 		}
 
 		if (willbranch3 || !psxbranch) {


### PR DESCRIPTION
The point / goal of this pr is to adjust pcsx2's clock speed in ps1 mode to avoid ps1 game's running faster then intended, most of this commit is focused on adjusting the PSXCLK EE and IOP multipliers and CD speed all centered around IOP speed and it's dependencies.  