### PR TITLE
Gsdx: Adjust crc ids and purge crc hacks for Captain Tsubasa

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -163,7 +163,7 @@ CRC::Game CRC::m_games[] =
 	{0xC1640D2C, WildArms5, US, 0},
 	{0x0FCF8FE4, WildArms5, EU, 0},
 	{0x2294D322, WildArms5, JP, 0},
-	{0x565B6170, WildArms5, JP, 0},
+	{0x565B6170, WildArms4, JP, 0}, // Wild Arms: The 4th Detonator
 	{0xBBC3EFFA, WildArms4, US, 0},
 	{0xBBC396EC, WildArms4, US, 0}, // hmm such a small diff in the CRC..
 	{0x7B2DE9CC, WildArms4, EU, 0},
@@ -356,6 +356,7 @@ CRC::Game CRC::m_games[] =
 	{0x73C560BA, FinalFightStreetwise, EU, 0},
 	{0xCBB87BF9, EvangelionJo, JP, 0}, // cutie comment
 	{0x278A91FD, CaptainTsubasa, JP, 0}, // cutie comment
+	{0x2CF3EFF3, CaptainTsubasa, JP, 0},
 	{0xC5B75C7C, Oneechanbara2Special, JP, 0}, // cutie comment
 	{0xC0659AD1, NarutimateAccel, JP, 0}, // cutie comment
 	{0xF3D9DFBE, NarutimateAccel, JP, 0},

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -329,18 +329,6 @@ bool GSC_EvangelionJo(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_CaptainTsubasa(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(fi.TME && fi.FBP == 0x1C00 && !fi.FBMSK)
-		{
-			skip = 1;
-		}
-	}
-	return true;
-}
-
 bool GSC_Oneechanbara2Special(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -2221,7 +2209,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::BurnoutDominator] = GSC_Burnout;
 		lut[CRC::BurnoutRevenge] = GSC_Burnout;
 		lut[CRC::BurnoutTakedown] = GSC_Burnout;
-		lut[CRC::CaptainTsubasa] = GSC_CaptainTsubasa;
 		lut[CRC::CrashBandicootWoC] = GSC_CrashBandicootWoC;
 		lut[CRC::DevilMayCry3] = GSC_DevilMayCry3;
 		lut[CRC::EvangelionJo] = GSC_EvangelionJo;
@@ -2233,7 +2220,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::IkkiTousen] = GSC_IkkiTousen;
 		lut[CRC::KnightsOfTheTemple2] = GSC_KnightsOfTheTemple2;
 		lut[CRC::Kunoichi] = GSC_Kunoichi;
-		lut[CRC::LordOfTheRingsThirdAge] = GSC_LordOfTheRingsThirdAge;
 		lut[CRC::Manhunt2] = GSC_Manhunt2;
 		lut[CRC::MidnightClub3] = GSC_MidnightClub3;
 		lut[CRC::NarutimateAccel] = GSC_NarutimateAccel;
@@ -2267,6 +2253,9 @@ void GSState::SetupCrcHack()
 		// Channel Effect
 		lut[CRC::GiTS] = GSC_GiTS;
 		lut[CRC::SteambotChronicles] = GSC_SteambotChronicles;
+
+		// Colclip not supported
+		lut[CRC::LordOfTheRingsThirdAge] = GSC_LordOfTheRingsThirdAge;
 
 		// Half Screen bottom issue
 		lut[CRC::DBZBT2] = GSC_DBZBT2;


### PR DESCRIPTION
GSdx: Adjust crc ids.
Add a missing crc id for Captain Tsubasa-JP.
Rename WildArms5 to WildArms4 for crc 565B6170 Jap,
it was incorrect.

Gsdx: Remove Captain Tsubasa crc hacks.
The crc hack broke graphics ingame, causing flickering/transparent
textures and other similar issues.

On a side note the game experiences upscaling issues that can be fixed
with Half Pixel offset hack.