### PR TITLE
Add a game fix to set EE Cyclerate at 100% while FMVs are playing

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -59,6 +59,7 @@ enum GamefixId
 	Fix_FMVinSoftware,
 	Fix_GoemonTlbMiss,
 	Fix_ScarfaceIbit,
+	Fix_FMVEECycle,
 
 	GamefixId_COUNT
 };
@@ -361,7 +362,8 @@ struct Pcsx2Config
 				GIFFIFOHack		:1,		// Enabled the GIF FIFO (more correct but slower)
 				FMVinSoftwareHack:1,	// Toggle in and out of software rendering when an FMV runs.
 				GoemonTlbHack	:1,		// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
-				ScarfaceIbit 	:1;		// Scarface I bit hack. Needed to stop constant VU recompilation
+				ScarfaceIbit 	:1,		// Scarface I bit hack. Needed to stop constant VU recompilation
+				FMVEECycleHack  :1;     // Set the EE Cycle to 100% while playing a FMV cutscene
 		BITFIELD_END
 
 		GamefixOptions();
@@ -545,6 +547,7 @@ TraceLogFilters&				SetTraceConfig();
 #define CHECK_VIF1STALLHACK			(EmuConfig.Gamefixes.VIF1StallHack)  // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
 #define CHECK_GIFFIFOHACK			(EmuConfig.Gamefixes.GIFFIFOHack)	 // Enabled the GIF FIFO (more correct but slower)
 #define CHECK_FMVINSOFTWAREHACK	 	(EmuConfig.Gamefixes.FMVinSoftwareHack) // Toggle in and out of software rendering when an FMV runs.
+#define CHECK_FMVEECYCCLEHACK       (EmuConfig.Gamefixes.FMVEECycleHack) // Set the EE Cycle to 100% while playing a FMV cutscene
 //------------ Advanced Options!!! ---------------
 #define CHECK_VU_OVERFLOW			(EmuConfig.Cpu.Recompiler.vuOverflow)
 #define CHECK_VU_EXTRA_OVERFLOW		(EmuConfig.Cpu.Recompiler.vuExtraOverflow) // If enabled, Operands are clamped before being used in the VU recs

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -409,7 +409,7 @@ static __ri void ipuBDEC(tIPU_CMD_BDEC bdec)
 
 static __fi bool ipuVDEC(u32 val)
 {
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if ((EmuConfig.Gamefixes.FMVinSoftwareHack || EmuConfig.Gamefixes.FMVEECycleHack) || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
 		static int count = 0;
 		if (count++ > 5) {
 			if (!FMVstarted) {

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -267,7 +267,8 @@ const wxChar *const tbl_GamefixNames[] =
 	L"GIFFIFO",
 	L"FMVinSoftware",
 	L"GoemonTlb",
-	L"ScarfaceIbit"
+	L"ScarfaceIbit",
+	L"FMVEECycle"
 };
 
 const __fi wxChar* EnumToString( GamefixId id )
@@ -323,14 +324,15 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_IpuWait:		IPUWaitHack			= enabled;	break;
 		case Fix_EETiming:		EETimingHack		= enabled;	break;
 		case Fix_SkipMpeg:		SkipMPEGHack		= enabled;	break;
-		case Fix_OPHFlag:		OPHFlagHack			= enabled;  break;
-		case Fix_DMABusy:		DMABusyHack			= enabled;  break;
-		case Fix_VIFFIFO:		VIFFIFOHack			= enabled;  break;
-		case Fix_VIF1Stall:		VIF1StallHack		= enabled;  break;
-		case Fix_GIFFIFO:		GIFFIFOHack			= enabled;  break;
-		case Fix_FMVinSoftware:	FMVinSoftwareHack	= enabled;  break;
-		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;  break;
-		case Fix_ScarfaceIbit:  ScarfaceIbit        = enabled;  break;
+		case Fix_OPHFlag:		OPHFlagHack			= enabled;	break;
+		case Fix_DMABusy:		DMABusyHack			= enabled;	break;
+		case Fix_VIFFIFO:		VIFFIFOHack			= enabled;	break;
+		case Fix_VIF1Stall:		VIF1StallHack		= enabled;	break;
+		case Fix_GIFFIFO:		GIFFIFOHack			= enabled;	break;
+		case Fix_FMVinSoftware:	FMVinSoftwareHack	= enabled;	break;
+		case Fix_GoemonTlbMiss:	GoemonTlbHack		= enabled;	break;
+		case Fix_ScarfaceIbit:	ScarfaceIbit		= enabled;	break;
+		case Fix_FMVEECycle:	FMVEECycleHack		= enabled;	break;
 		jNO_DEFAULT;
 	}
 }
@@ -357,6 +359,7 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_FMVinSoftware:	return FMVinSoftwareHack;
 		case Fix_GoemonTlbMiss: return GoemonTlbHack;
 		case Fix_ScarfaceIbit:  return ScarfaceIbit;
+		case Fix_FMVEECycle:    return FMVEECycleHack;
 		jNO_DEFAULT;
 	}
 	return false;		// unreachable, but we still need to suppress warnings >_<
@@ -383,6 +386,7 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( FMVinSoftwareHack );
 	IniBitBool( GoemonTlbHack );
 	IniBitBool( ScarfaceIbit );
+  IniBitBool( FMVEECycleHack );
 }
 
 

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -514,6 +514,7 @@ extern uint eecount_on_last_vdec;
 extern bool FMVstarted;
 extern bool renderswitch;
 extern bool EnableFMV;
+s8 eecycle_backup;
 
 void DoFmvSwitch(bool on)
 {
@@ -534,6 +535,12 @@ void DoFmvSwitch(bool on)
 		renderswitch = !renderswitch;
 		paused_core.AllowResume();
 	}
+
+	if (EmuConfig.Gamefixes.FMVEECycleHack && on) {
+		ScopedCoreThreadPause paused_core(new SysExecEvent_SaveSinglePlugin(PluginId_GS));
+		g_Conf->EmuOptions.Speedhacks.EECycleRate = 0;
+		paused_core.AllowResume();
+	 }
 }
 
 void Pcsx2App::LogicalVsync()
@@ -545,9 +552,9 @@ void Pcsx2App::LogicalVsync()
 	// Update / Calculate framerate!
 
 	FpsManager.DoFrame();
-	
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if ((EmuConfig.Gamefixes.FMVinSoftwareHack || EmuConfig.Gamefixes.FMVEECycleHack) || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
 		if (EnableFMV) {
+			eecycle_backup = g_Conf->EmuOptions.Speedhacks.EECycleRate;
 			DevCon.Warning("FMV on");
 			DoFmvSwitch(true);
 			EnableFMV = false;
@@ -559,6 +566,9 @@ void Pcsx2App::LogicalVsync()
 				DevCon.Warning("FMV off");
 				DoFmvSwitch(false);
 				FMVstarted = false;
+				ScopedCoreThreadPause paused_core(new SysExecEvent_SaveSinglePlugin(PluginId_GS));
+				g_Conf->EmuOptions.Speedhacks.EECycleRate = eecycle_backup;
+				paused_core.AllowResume();
 			}
 		}
 	}

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -107,6 +107,10 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 		{
 			_("VU I bit Hack avoid constant recompilation (Scarface The World Is Yours)"),
 			wxEmptyString
+		},
+		{
+			_("Set the EE Cycle rate to 100% when a FMV plays"),
+			wxEmptyString
 		}
 	};
 


### PR DESCRIPTION
This fixes FMVs being slowed down when EE Cyclerate is set at high values

(Edit on 05/12)
This fixes FMV cutscenes being played at a slower speed than usual when the EE cyclerate is set to high values on some games, notably the Ratchet & Clank series.

Another option would be to merge this functionality in the "FMV in Software Mode" fix and rename it to "FMV Safe Mode". I opened a pull request for that: #2435