### PR TITLE
Rename the "FMV in software mode" game fix to "FMV Fix" and make it set the EE cyclerate to 100% in addition to it switching the rendering mode

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -56,7 +56,7 @@ enum GamefixId
 	Fix_VIFFIFO,
 	Fix_VIF1Stall,
 	Fix_GIFFIFO,
-	Fix_FMVinSoftware,
+	Fix_FMVFix,
 	Fix_GoemonTlbMiss,
 	Fix_ScarfaceIbit,
 
@@ -353,15 +353,15 @@ struct Pcsx2Config
 				XgKickHack		:1,		// Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
 				IPUWaitHack     :1,		// FFX FMV, makes GIF flush before doing IPU work. Fixes bad graphics overlay.
 				EETimingHack	:1,		// General purpose timing hack.
-				SkipMPEGHack	:1,		// Skips MPEG videos (Katamari and other games need this)
+				SkipMPEGHack	:1,		// Skips MPEG videos (Katamari and other games need this).
 				OPHFlagHack		:1,		// Bleach Blade Battlers
 				DMABusyHack		:1,		// Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.
 				VIFFIFOHack		:1,     // Pretends to fill the non-existant VIF FIFO Buffer.
 				VIF1StallHack   :1,     // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
-				GIFFIFOHack		:1,		// Enabled the GIF FIFO (more correct but slower)
-				FMVinSoftwareHack:1,	// Toggle in and out of software rendering when an FMV runs.
-				GoemonTlbHack	:1,		// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
-				ScarfaceIbit 	:1;		// Scarface I bit hack. Needed to stop constant VU recompilation
+				GIFFIFOHack		:1,		// Enabled the GIF FIFO (more correct but slower).
+				FMVFix			:1,		// Use GSdx software rendering & regular EE cyclerate for FMVs.
+				GoemonTlbHack	:1,		// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup.
+				ScarfaceIbit 	:1;		// Scarface I bit hack. Needed to stop constant VU recompilation.
 		BITFIELD_END
 
 		GamefixOptions();
@@ -536,15 +536,15 @@ TraceLogFilters&				SetTraceConfig();
 #define CHECK_FPUMULHACK			(EmuConfig.Gamefixes.FpuMulHack)	 // Special Fix for Tales of Destiny hangs.
 #define CHECK_FPUNEGDIVHACK			(EmuConfig.Gamefixes.FpuNegDivHack)	 // Special Fix for Gundam games messed up camera-view.
 #define CHECK_XGKICKHACK			(EmuConfig.Gamefixes.XgKickHack)	 // Special Fix for Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics.
-#define CHECK_IPUWAITHACK			(EmuConfig.Gamefixes.IPUWaitHack)	 // Special Fix For FFX
+#define CHECK_IPUWAITHACK			(EmuConfig.Gamefixes.IPUWaitHack)	 // Special Fix For FFX.
 #define CHECK_EETIMINGHACK			(EmuConfig.Gamefixes.EETimingHack)	 // Fix all scheduled events to happen in 1 cycle.
-#define CHECK_SKIPMPEGHACK			(EmuConfig.Gamefixes.SkipMPEGHack)	 // Finds sceMpegIsEnd pattern to tell the game the mpeg is finished (Katamari and a lot of games need this)
+#define CHECK_SKIPMPEGHACK			(EmuConfig.Gamefixes.SkipMPEGHack)	 // Finds sceMpegIsEnd pattern to tell the game the mpeg is finished (Katamari and a lot of games need this).
 #define CHECK_OPHFLAGHACK			(EmuConfig.Gamefixes.OPHFlagHack)	 // Bleach Blade Battlers
 #define CHECK_DMABUSYHACK			(EmuConfig.Gamefixes.DMABusyHack)    // Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.
 #define CHECK_VIFFIFOHACK			(EmuConfig.Gamefixes.VIFFIFOHack)    // Pretends to fill the non-existant VIF FIFO Buffer.
 #define CHECK_VIF1STALLHACK			(EmuConfig.Gamefixes.VIF1StallHack)  // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
-#define CHECK_GIFFIFOHACK			(EmuConfig.Gamefixes.GIFFIFOHack)	 // Enabled the GIF FIFO (more correct but slower)
-#define CHECK_FMVINSOFTWAREHACK	 	(EmuConfig.Gamefixes.FMVinSoftwareHack) // Toggle in and out of software rendering when an FMV runs.
+#define CHECK_GIFFIFOHACK			(EmuConfig.Gamefixes.GIFFIFOHack)	 // Enabled the GIF FIFO (more correct but slower).
+#define CHECK_FMVFIX				(EmuConfig.Gamefixes.FMVFix)		 // Use GSdx software rendering & regular EE cyclerate for FMVs.
 //------------ Advanced Options!!! ---------------
 #define CHECK_VU_OVERFLOW			(EmuConfig.Cpu.Recompiler.vuOverflow)
 #define CHECK_VU_EXTRA_OVERFLOW		(EmuConfig.Cpu.Recompiler.vuExtraOverflow) // If enabled, Operands are clamped before being used in the VU recs

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -409,7 +409,7 @@ static __ri void ipuBDEC(tIPU_CMD_BDEC bdec)
 
 static __fi bool ipuVDEC(u32 val)
 {
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if (EmuConfig.Gamefixes.FMVFix || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
 		static int count = 0;
 		if (count++ > 5) {
 			if (!FMVstarted) {

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -265,7 +265,7 @@ const wxChar *const tbl_GamefixNames[] =
 	L"VIFFIFO",
 	L"VIF1Stall",
 	L"GIFFIFO",
-	L"FMVinSoftware",
+	L"FMVFix",
 	L"GoemonTlb",
 	L"ScarfaceIbit"
 };
@@ -323,14 +323,14 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_IpuWait:		IPUWaitHack			= enabled;	break;
 		case Fix_EETiming:		EETimingHack		= enabled;	break;
 		case Fix_SkipMpeg:		SkipMPEGHack		= enabled;	break;
-		case Fix_OPHFlag:		OPHFlagHack			= enabled;  break;
-		case Fix_DMABusy:		DMABusyHack			= enabled;  break;
-		case Fix_VIFFIFO:		VIFFIFOHack			= enabled;  break;
-		case Fix_VIF1Stall:		VIF1StallHack		= enabled;  break;
-		case Fix_GIFFIFO:		GIFFIFOHack			= enabled;  break;
-		case Fix_FMVinSoftware:	FMVinSoftwareHack	= enabled;  break;
-		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;  break;
-		case Fix_ScarfaceIbit:  ScarfaceIbit        = enabled;  break;
+		case Fix_OPHFlag:		OPHFlagHack			= enabled;	break;
+		case Fix_DMABusy:		DMABusyHack			= enabled;	break;
+		case Fix_VIFFIFO:		VIFFIFOHack			= enabled;	break;
+		case Fix_VIF1Stall:		VIF1StallHack		= enabled;	break;
+		case Fix_GIFFIFO:		GIFFIFOHack			= enabled;	break;
+		case Fix_FMVFix:		FMVFix				= enabled;	break;
+		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;	break;
+		case Fix_ScarfaceIbit:  ScarfaceIbit        = enabled;	break;
 		jNO_DEFAULT;
 	}
 }
@@ -354,7 +354,7 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_VIFFIFO:		return VIFFIFOHack;
 		case Fix_VIF1Stall:		return VIF1StallHack;
 		case Fix_GIFFIFO:		return GIFFIFOHack;
-		case Fix_FMVinSoftware:	return FMVinSoftwareHack;
+		case Fix_FMVFix:		return FMVFix;
 		case Fix_GoemonTlbMiss: return GoemonTlbHack;
 		case Fix_ScarfaceIbit:  return ScarfaceIbit;
 		jNO_DEFAULT;
@@ -380,7 +380,7 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( VIFFIFOHack );
 	IniBitBool( VIF1StallHack );
 	IniBitBool( GIFFIFOHack );
-	IniBitBool( FMVinSoftwareHack );
+	IniBitBool( FMVFix );
 	IniBitBool( GoemonTlbHack );
 	IniBitBool( ScarfaceIbit );
 }

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -514,6 +514,7 @@ extern uint eecount_on_last_vdec;
 extern bool FMVstarted;
 extern bool renderswitch;
 extern bool EnableFMV;
+s8 eecycle_backup;
 
 void DoFmvSwitch(bool on)
 {
@@ -529,8 +530,9 @@ void DoFmvSwitch(bool on)
 				viewport->DoResize();
 	}
 
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack) {
+	if (EmuConfig.Gamefixes.FMVFix) {
 		ScopedCoreThreadPause paused_core(new SysExecEvent_SaveSinglePlugin(PluginId_GS));
+		g_Conf->EmuOptions.Speedhacks.EECycleRate = 0;
 		renderswitch = !renderswitch;
 		paused_core.AllowResume();
 	}
@@ -546,8 +548,9 @@ void Pcsx2App::LogicalVsync()
 
 	FpsManager.DoFrame();
 	
-	if (EmuConfig.Gamefixes.FMVinSoftwareHack || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
+	if (EmuConfig.Gamefixes.FMVFix || g_Conf->GSWindow.IsToggleAspectRatioSwitch) {
 		if (EnableFMV) {
+			eecycle_backup = g_Conf->EmuOptions.Speedhacks.EECycleRate;
 			DevCon.Warning("FMV on");
 			DoFmvSwitch(true);
 			EnableFMV = false;
@@ -559,6 +562,9 @@ void Pcsx2App::LogicalVsync()
 				DevCon.Warning("FMV off");
 				DoFmvSwitch(false);
 				FMVstarted = false;
+				ScopedCoreThreadPause paused_core(new SysExecEvent_SaveSinglePlugin(PluginId_GS));
+				g_Conf->EmuOptions.Speedhacks.EECycleRate = eecycle_backup;
+				paused_core.AllowResume();
 			}
 		}
 	}

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -188,7 +188,7 @@ void GSPanel::DoResize()
 		zoom = std::max( (float)arr, (float)(1.0/arr) );
 
 	viewport.Scale(zoom, zoom*g_Conf->GSWindow.StretchY.ToFloat()/100.0 );
-	if (viewport == client && EmuConfig.Gamefixes.FMVinSoftwareHack && g_Conf->GSWindow.IsFullscreen)
+	if (viewport == client && EmuConfig.Gamefixes.FMVFix && g_Conf->GSWindow.IsFullscreen)
 		viewport.x += 1; //avoids crash on some systems switching HW><SW in fullscreen aspect ratio's with FMV Software switch.
 	SetSize( viewport );
 	CenterOnParent();

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -97,7 +97,7 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("Switch to GSdx software rendering when an FMV plays"),
+			_("Use GSdx software rendering & regular EE cyclerate for FMVs"),
 			wxEmptyString
 		},
 		{


### PR DESCRIPTION
This is an alternative of #2426 with its functionality merged with the FMV in Software Mode fix, as suggested by various contributors. I'm leaving both up so the contributors can decide which one to merge if that happens.

This fixes FMV cutscenes being played at a slower speed than usual when the EE cyclerate is set to high values on some games, notably the Ratchet & Clank series.