### PR TITLE
GSdx-OSD: Adjust messages/logs

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -386,13 +386,13 @@ void GSdxApp::Init()
 #else
 	m_default_configuration["osd_fontname"]                               = "/usr/share/fonts/truetype/freefont/FreeSerif.ttf";
 #endif
-	m_default_configuration["osd_fontsize"]                               = "32";
+	m_default_configuration["osd_fontsize"]                               = "28";
 	m_default_configuration["osd_indicator_enabled"]                      = "0";
 	m_default_configuration["osd_log_enabled"]                            = "1";
-	m_default_configuration["osd_log_speed"]                              = "6";
+	m_default_configuration["osd_log_speed"]                              = "4";
 	m_default_configuration["osd_monitor_enabled"]                        = "0";
 	m_default_configuration["osd_transparency"]                           = "25";
-	m_default_configuration["osd_max_log_messages"]                       = "3";
+	m_default_configuration["osd_max_log_messages"]                       = "2";
 	m_default_configuration["override_geometry_shader"]                   = "-1";
 	m_default_configuration["override_GL_ARB_copy_image"]                 = "-1";
 	m_default_configuration["override_GL_ARB_clear_texture"]              = "-1";


### PR DESCRIPTION
Change font size from 32 to 28 default.
There's no need to have the font be that big and take up a large portion of the screen.

Change log speed from 6 to 4 default.
Making the scroll speed a bit faster will get the messages out of the screen a bit faster, there's no need for them to stay there and fade that slow.

Change max log messages from 3 to 2 default.
Similar to the other two, there's honestly no need to have 3 messages take up the screen.

The key is finding balance between appeal and usefulness.

Preview:

![pcsx2 2018-05-21 03-09-54-74](https://user-images.githubusercontent.com/18107717/40286234-9be6f492-5ca5-11e8-8a0d-a9a51ce73a39.png)

