### PR TITLE
PS1 mode: Adjustments to processor clock speed and CD read speed. 

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <wx/datetime.h>
 
+#include "CdRom.h"
 #include "CDVD.h"
 #include "CDVD_internal.h"
 #include "CDVDisoReader.h"
@@ -1415,6 +1416,9 @@ static __fi void cdvdWrite0F(u8 rt) { // TYPE
 
 static __fi void cdvdWrite14(u8 rt) { // PS1 MODE?? // This should be done in the SBUS_F240 bit 19 write in HwWrite.cpp
 	u32 cycle = psxRegs.cycle;
+
+	PSXCLK =  33868800;
+	setPsxSpeed();
 
 	if (rt == 0xFE)
 		Console.Warning("*PCSX2*: go PS1 mode DISC SPEED = FAST");

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -39,6 +39,9 @@ wxString DiscSerial;
 
 static cdvdStruct cdvd;
 
+s64 PSXCLK = 36864000;
+
+
 static __fi void SetResultSize(u8 size)
 {
 	cdvd.ResultC = size;

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -82,7 +82,10 @@ u8 Test20[] = { 0x98, 0x06, 0x10, 0xC3 };
 u8 Test22[] = { 0x66, 0x6F, 0x72, 0x20, 0x45, 0x75, 0x72, 0x6F };
 u8 Test23[] = { 0x43, 0x58, 0x44, 0x32, 0x39 ,0x34, 0x30, 0x51 };
 
-u32 cdReadTime;
+// 1x = 75 sectors per second
+// PSXCLK = 1 sec in the ps
+// so (PSXCLK / 75) / BIAS = cdr read time (linuzappz)
+u32 cdReadTime;// = ((PSXCLK / 75) / BIAS);
 
 #define CDR_INT(eCycle)    PSX_INT(IopEvt_Cdrom, eCycle)
 #define CDREAD_INT(eCycle) PSX_INT(IopEvt_CdromRead, eCycle)
@@ -602,9 +605,6 @@ void cdrWrite0(u8 rt) {
 
 void setPsxSpeed()
 {
-	// 1x = 75 sectors per second
-	// PSXCLK = 1 sec in the ps
-	// so (PSXCLK / 75) / BIAS = cdr read time (linuzappz)
 	 cdReadTime = ((PSXCLK / 75) / BIAS);
 }
 

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -82,11 +82,7 @@ u8 Test20[] = { 0x98, 0x06, 0x10, 0xC3 };
 u8 Test22[] = { 0x66, 0x6F, 0x72, 0x20, 0x45, 0x75, 0x72, 0x6F };
 u8 Test23[] = { 0x43, 0x58, 0x44, 0x32, 0x39 ,0x34, 0x30, 0x51 };
 
-// 1x = 75 sectors per second
-// PSXCLK = 1 sec in the ps
-// so (PSXCLK / 75) / BIAS = cdr read time (linuzappz)
-//#define cdReadTime ((PSXCLK / 75) / BIAS)
-u32 cdReadTime;// = ((PSXCLK / 75) / BIAS);
+u32 cdReadTime;
 
 #define CDR_INT(eCycle)    PSX_INT(IopEvt_Cdrom, eCycle)
 #define CDREAD_INT(eCycle) PSX_INT(IopEvt_CdromRead, eCycle)
@@ -602,6 +598,14 @@ void cdrWrite0(u8 rt) {
 		cdr.ParamC = 0;
 		cdr.ResultReady = 0;
 	}
+}
+
+void setPsxSpeed()
+{
+	// 1x = 75 sectors per second
+	// PSXCLK = 1 sec in the ps
+	// so (PSXCLK / 75) / BIAS = cdr read time (linuzappz)
+	 cdReadTime = ((PSXCLK / 75) / BIAS);
 }
 
 u8 cdrRead1(void) {

--- a/pcsx2/CDVD/CdRom.h
+++ b/pcsx2/CDVD/CdRom.h
@@ -93,6 +93,7 @@ u8   cdrRead0(void);
 u8   cdrRead1(void);
 u8   cdrRead2(void);
 u8   cdrRead3(void);
+void setPsxSpeed();
 void cdrWrite0(u8 rt);
 void cdrWrite1(u8 rt);
 void cdrWrite2(u8 rt);

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -19,7 +19,7 @@
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
 static const u32 PS2CLK = 294912000;	//hz	/* 294.912 mhz */
-static s64 PSXCLK = 36864000;	/* 36.864 Mhz */
+extern s64 PSXCLK;	/* 36.864 Mhz */
 
 
 #include "System.h"

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -19,6 +19,8 @@
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
 static const u32 PS2CLK = 294912000;	//hz	/* 294.912 mhz */
+static s64 PSXCLK = 36864000;	/* 36.864 Mhz */
+
 
 #include "System.h"
 #include "Memory.h"

--- a/pcsx2/IopCommon.h
+++ b/pcsx2/IopCommon.h
@@ -28,7 +28,6 @@
 #include "IopCounters.h"
 #include "IopSio2.h"
 #include "IopGte.h"
-static const s64 PSXCLK = 36864000;	/* 36.864 Mhz */
 //#define PSXCLK	 9216000	/* 36.864 Mhz */
 //#define PSXCLK	186864000	/* 36.864 Mhz */
 

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -63,7 +63,7 @@ void psxReset()
 	g_iopNextEventCycle = psxRegs.cycle + 4;
 
 	psxHwReset();
-
+	PSXCLK = 36864000;
 	ioman::reset();
 	psxBiosReset();
 }

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -142,14 +142,16 @@ static __fi void execI()
 
 	psxRegs.pc+= 4;
 	psxRegs.cycle++;
-	iopCycleEE-=8;
-
+	
 	if ((psxHu32(HW_ICFG) & (1 << 3)))
 	{
 		//One of the Iop to EE delta clocks to be set in PS1 mode.
 		iopCycleEE-=9;
 	}
-
+	else
+	{   //default ps2 mode value
+		iopCycleEE-=8;
+	}
 	psxBSC[psxRegs.code >> 26]();
 }
 

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -144,6 +144,12 @@ static __fi void execI()
 	psxRegs.cycle++;
 	iopCycleEE-=8;
 
+	if ((psxHu32(HW_ICFG) & (1 << 3)))
+	{
+		//One of the Iop to EE delta clocks to be set in PS1 mode.
+		iopCycleEE-=9;
+	}
+
 	psxBSC[psxRegs.code >> 26]();
 }
 


### PR DESCRIPTION
This is a simple PR that focused on making the core changes to pcsx2's ps1 mode to make games run at proper speeds. By adjusting the PSXCLK or IOP that represents the main ps1 processor to proper ps1 clock speeds and setting the cdreadspeed and EE to IOP delta timers. This PR fixes games like klonoa that had issues with disk and game speed causing glitches with memory cards or other various issues whilst this commit also add's issues with games like metal gear solid that won't get past the main logo's and do do do do da do part anymore