### PR TITLE
GSdx: Partial port of format destination (dfmt)

### DIFF
--- a/plugins/GSdx/GSDeviceDX.h
+++ b/plugins/GSdx/GSDeviceDX.h
@@ -190,8 +190,9 @@ public:
 				uint32 point_sampler:1;
 				uint32 shuffle:1;
 				uint32 read_ba:1;
+				uint32 dfmt:2;
 
-				uint32 _free:32;
+				uint32 _free:30;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/GSDeviceDX.h
+++ b/plugins/GSdx/GSDeviceDX.h
@@ -169,28 +169,40 @@ public:
 		{
 			struct
 			{
-				uint32 fst:1;
-				uint32 wms:2;
-				uint32 wmt:2;
+				// *** Word 1
+				// Format
 				uint32 fmt:4;
+				uint32 dfmt:2;
+				// Alpha extension/Correction
 				uint32 aem:1;
+				uint32 fba:1;
+				// Fog
+				uint32 fog:1;
+				// Pixel test
+				uint32 date:2;
+				uint32 atst:3;
+				// Color sampling
+				uint32 fst:1;
 				uint32 tfx:3;
 				uint32 tcc:1;
-				uint32 atst:3;
-				uint32 fog:1;
-				uint32 clr1:1;
-				uint32 fba:1;
-				uint32 aout:1;
-				uint32 rt:1;
+				uint32 wms:2;
+				uint32 wmt:2;
 				uint32 ltf:1;
+				// Shuffle and fbmask effect
+				uint32 shuffle:1;
+				uint32 read_ba:1;
+
+				// *** Word 2
+				// Blend and Colclip
 				uint32 colclip:2;
-				uint32 date:2;
+				uint32 clr1:1;
+				uint32 rt:1;
+
+				// Hack
+				uint32 aout:1;
 				uint32 spritehack:1;
 				uint32 tcoffsethack:1;
 				uint32 point_sampler:1;
-				uint32 shuffle:1;
-				uint32 read_ba:1;
-				uint32 dfmt:2;
 
 				uint32 _free:30;
 			};

--- a/plugins/GSdx/GSRendererDX11.cpp
+++ b/plugins/GSdx/GSRendererDX11.cpp
@@ -50,7 +50,7 @@ void GSRendererDX11::EmulateTextureShuffleAndFbmask()
 	// Note: D3D1011 is limited and can't read the current framebuffer so we can't have PS_FBMASK and PS_WRITE_RG shaders ported and working.
 	if (m_texture_shuffle) {
 		m_ps_sel.shuffle = 1;
-		m_ps_sel.fmt = 0;
+		m_ps_sel.dfmt = 0;
 
 		const GIFRegXYOFFSET& o = m_context->XYOFFSET;
 
@@ -154,7 +154,7 @@ void GSRendererDX11::EmulateTextureShuffleAndFbmask()
 		}
 
 	} else {
-		//m_ps_sel.fmt = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt;
+		m_ps_sel.dfmt = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt;
 
 		om_bsel.wrgba = ~GSVector4i::load((int)m_context->FRAME.FBMSK).eq8(GSVector4i::xffffffff()).mask();
 	}

--- a/plugins/GSdx/GSTextureFX11.cpp
+++ b/plugins/GSdx/GSTextureFX11.cpp
@@ -209,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[21];
+		std::string str[22];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -232,6 +232,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[18] = format("%d", sel.shuffle);
 		str[19] = format("%d", sel.read_ba);
 		str[20] = format("%d", sel.fmt >> 2);
+		str[21] = format("%d", sel.dfmt);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -256,6 +257,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_SHUFFLE", str[18].c_str() },
 			{"PS_READ_BA", str[19].c_str() },
 			{"PS_PAL_FMT", str[20].c_str() },
+			{"PS_DFMT", str[21].c_str() },
 			{NULL, NULL},
 		};
 

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -43,6 +43,7 @@
 #define PS_SHUFFLE 0
 #define PS_READ_BA 0
 #define PS_PAL_FMT 0
+#define PS_DFMT 0
 #endif
 
 struct VS_INPUT
@@ -852,15 +853,15 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 	output.c1 = c.a * 2; // used for alpha blending
 
-	if(PS_AOUT) // 16 bit output
+	if ((PS_DFMT == FMT_16) || PS_AOUT) // 16 bit output
 	{
 		float a = 128.0f / 255; // alpha output will be 0x80
 		
 		c.a = PS_FBA ? a : step(0.5, c.a) * a;
 	}
-	else if(PS_FBA)
+	else if ((PS_DFMT == FMT_32) && (PS_FBA != 0))
 	{
-		if(c.a < 0.5) c.a += 0.5;
+		if (c.a < 0.5) c.a += 0.5;
 	}
 
 	output.c0 = c;


### PR DESCRIPTION
Port dfmt partially from GL to D3D10/11.
Use dfmt instead of fmt on d3d texture shuffle just
like on gl. It should be more accurate.

Update dfmt shader to recent gl code.


GSdx: Reformat PSselector shader list in GSDeviceDX.h.
Match it with gl code, easier to read and to know
what the shaders do.