### PR TITLE
GSdx/GameDB: Remove Spyro NB/EN HW hack fixes, add gamedb fixes.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16048,6 +16048,11 @@ Compat = 5
 Serial = SLES-54359
 Name   = Legend of Spyro, The - A New Beginning
 Region = PAL-M6
+[patches = 0EE5646B]
+	comment=Patch by Kozarovv and Refraction
+	// Fixes HUD and menu display.
+	patch=1,EE,001849b8,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLES-54360
 Name   = Pro Evolution Soccer 6
@@ -16807,6 +16812,11 @@ Serial = SLES-54815
 Name   = Spyro - The Eternal Night
 Region = PAL-M6
 Compat = 5
+[patches = 8AE9536D]
+	comment=Patch by Kozarovv and Refraction
+	// Fixes HUD and menu display.
+	patch=1,EE,00173c38,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLES-54819
 Name   = Manhunt 2
@@ -40587,6 +40597,11 @@ Serial = SLUS-21372
 Name   = Legend of Spyro, The - A New Beginning
 Region = NTSC-U
 Compat = 5
+[patches = D03D4C77]
+	comment=Patch by Kozarovv and Refraction
+	// Fixes HUD and menu display.
+	patch=1,EE,001849b8,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-21373
 Name   = Drakengard 2
@@ -41579,6 +41594,11 @@ Serial = SLUS-21607
 Name   = Legend of Spyro, The - The Eternal Night
 Region = NTSC-U
 Compat = 5
+[patches = B80CE8EC]
+	comment=Patch by Kozarovv and Refraction
+	// Fixes HUD and menu display.
+	patch=1,EE,00173cb8,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-21608
 Name   = Dance Dance Revolution - SuperNOVA 2

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -1140,8 +1140,6 @@ GSRendererHW::Hacks::Hacks()
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::MetalSlug6, CRC::RegionCount, &GSRendererHW::OI_MetalSlug6));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::RozenMaidenGebetGarden, CRC::RegionCount, &GSRendererHW::OI_RozenMaidenGebetGarden));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::StarWarsForceUnleashed, CRC::RegionCount, &GSRendererHW::OI_StarWarsForceUnleashed));
-	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SpyroNewBeginning, CRC::RegionCount, &GSRendererHW::OI_SpyroNewBeginning));
-	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SpyroEternalNight, CRC::RegionCount, &GSRendererHW::OI_SpyroEternalNight));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SuperManReturns, CRC::RegionCount, &GSRendererHW::OI_SuperManReturns));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::TalesOfLegendia, CRC::RegionCount, &GSRendererHW::OI_TalesOfLegendia));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::ArTonelico2, CRC::RegionCount, &GSRendererHW::OI_ArTonelico2));
@@ -1573,44 +1571,6 @@ bool GSRendererHW::OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTex
 	else if(PRIM->TME)
 	{
 		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_max.p.z == 0))
-		{
-			m_dev->ClearDepth(ds);
-		}
-	}
-
-	return true;
-}
-
-bool GSRendererHW::OI_SpyroNewBeginning(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
-{
-	// uint32 FBP = m_context->FRAME.Block();
-	uint32 TBP = m_context->TEX0.TBP0;
-	uint32 FPSM = m_context->FRAME.PSM;
-
-	// Spyro A New Beginning PAL doesn't play well with FBP so let's use TBP to fix the menu/ui flickering.
-	// We can't merge the two hacks OI_SpyroNewBeginning and OI_SpyroEternalNight because Eternal Night PAL flickers with TBP, the opposite of New Beginning.
-
-	if(PRIM->TME)
-	{
-		// Old code (FBP == 0x0 || FBP == 0x01180)
-		// First two TBP PAL, other two NTSC.
-		if((TBP == 0x03020 || TBP == 0x037c0 || TBP == 0x034a0 || TBP == 0x03a00) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_min.p.z == 0))
-		{
-			m_dev->ClearDepth(ds);
-		}
-	}
-
-	return true;
-}
-
-bool GSRendererHW::OI_SpyroEternalNight(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
-{
-	uint32 FBP = m_context->FRAME.Block();
-	uint32 FPSM = m_context->FRAME.PSM;
-
-	if(PRIM->TME)
-	{
-		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_min.p.z == 0))
 		{
 			m_dev->ClearDepth(ds);
 		}

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -59,8 +59,6 @@ private:
 	bool OI_GodOfWar2(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	bool OI_SpyroNewBeginning(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	bool OI_SpyroEternalNight(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_TalesOfLegendia(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_SMTNocturne(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_PointListPalette(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);


### PR DESCRIPTION
GSdx: Purge Spyro NB /EN hw hack fixes.
Purge Hw hack fixes for Spyro New Beginning and Eternal Night that fixed
HUD and menu display.
They will be replaced with EE patches in GameDB that work for both
software and hardware mode. A much better alternative and less GSdx
hacks.


GameDB: Add EE patches for Spyro NB/EN.
Add EE patches for Spyro New Beginning and Eternal Night NTSC/PAL.
Fixes HUD and menu display in hw/sw mode.
Original patches provided by Kozarovv, improved by Refraction.
https://forums.pcsx2.net/Thread-Did-anybody-ever-find-a-fix-for-The-Legend-of-Spyro-A-New-Beginning-s-flickering

Close #1490