### PR TITLE
cdvdGigaherz: Misc updates

### DIFF
--- a/plugins/cdvdGigaherz/src/CDVD.cpp
+++ b/plugins/cdvdGigaherz/src/CDVD.cpp
@@ -110,7 +110,7 @@ bool weAreInNewDiskCB = false;
 
 std::unique_ptr<IOCtlSrc> src;
 
-extern CacheRequest g_last_sector_block;
+extern u32 g_last_sector_block_lsn;
 
 ///////////////////////////////////////////////////////////////////////////////
 // keepAliveThread throws a read event regularly to prevent drive spin down  //
@@ -127,9 +127,9 @@ void keepAliveThread()
 
         //printf(" * keepAliveThread: polling drive.\n");
         if (src->GetMediaType() >= 0)
-            src->ReadSectors2048(g_last_sector_block.lsn, 1, throwaway);
+            src->ReadSectors2048(g_last_sector_block_lsn, 1, throwaway);
         else
-            src->ReadSectors2352(g_last_sector_block.lsn, 1, throwaway);
+            src->ReadSectors2352(g_last_sector_block_lsn, 1, throwaway);
     }
 
     printf(" * CDVD: KeepAlive thread finished.\n");

--- a/plugins/cdvdGigaherz/src/CDVD.h
+++ b/plugins/cdvdGigaherz/src/CDVD.h
@@ -47,12 +47,6 @@ extern track tracks[100];
 extern int curDiskType;
 extern int curTrayStatus;
 
-struct CacheRequest
-{
-    u32 lsn;
-    s32 mode;
-};
-
 struct toc_entry
 {
     u32 lba;

--- a/plugins/cdvdGigaherz/src/Settings.cpp
+++ b/plugins/cdvdGigaherz/src/Settings.cpp
@@ -16,7 +16,9 @@
 #include "Settings.h"
 
 #if defined(_WIN32)
-#include <codecvt>
+#define NOMINMAX
+#include <windows.h>
+#include <vector>
 #endif
 #include <fstream>
 #include <locale>
@@ -96,8 +98,10 @@ bool Settings::Get(const std::string &key, std::string &data) const
 #if defined(_WIN32)
 void Settings::Set(std::string key, std::wstring value)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    m_data[key] = converter.to_bytes(value);
+    int size = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    std::vector<char> converted_string(size);
+    WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, converted_string.data(), converted_string.size(), nullptr, nullptr);
+    m_data[key] = converted_string.data();
 }
 
 bool Settings::Get(const std::string &key, std::wstring &data) const
@@ -106,8 +110,10 @@ bool Settings::Get(const std::string &key, std::wstring &data) const
     if (it == m_data.end())
         return false;
 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    data = converter.from_bytes(it->second);
+    int size = MultiByteToWideChar(CP_UTF8, 0, it->second.c_str(), -1, nullptr, 0);
+    std::vector<wchar_t> converted_string(size);
+    MultiByteToWideChar(CP_UTF8, 0, it->second.c_str(), -1, converted_string.data(), converted_string.size());
+    data = converted_string.data();
     return true;
 }
 #endif

--- a/plugins/cdvdGigaherz/src/Unix/GtkGui.cpp
+++ b/plugins/cdvdGigaherz/src/Unix/GtkGui.cpp
@@ -18,12 +18,6 @@
 
 std::vector<std::string> GetOpticalDriveList();
 
-static void ComboboxCallback(GtkComboBoxText *combobox, gpointer data)
-{
-    Settings *settings = reinterpret_cast<Settings *>(data);
-    settings->Set("drive", gtk_combo_box_text_get_active_text(combobox));
-}
-
 void configure()
 {
     ReadSettings();
@@ -47,25 +41,16 @@ void configure()
             gtk_combo_box_set_active(GTK_COMBO_BOX(combobox), n);
     }
 
-#if GTK_MAJOR_VERSION >= 3
-    GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-    GtkWidget *box = gtk_vbox_new(0, 10);
-#endif
-    gtk_box_pack_start(GTK_BOX(box), label, 0, 0, 0);
-    gtk_box_pack_start(GTK_BOX(box), combobox, 0, 0, 10);
+    GtkContainer *content_area = GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog)));
+    gtk_container_add(content_area, label);
+    gtk_container_add(content_area, combobox);
 
-    GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-    gtk_container_add(GTK_CONTAINER(content_area), box);
-
-    Settings settings_copy = g_settings;
-    g_signal_connect(combobox, "changed", G_CALLBACK(ComboboxCallback), &settings_copy);
-
-    gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ALWAYS);
     gtk_widget_show_all(dialog);
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-        g_settings = settings_copy;
-        WriteSettings();
+        if (const char *selected_drive = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combobox))) {
+            g_settings.Set("drive", selected_drive);
+            WriteSettings();
+        }
     }
     gtk_widget_destroy(dialog);
 }

--- a/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/IOCtlSrc.cpp
@@ -180,9 +180,8 @@ bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8 *buffer) const
         DWORD unused;
         if (DeviceIoControl(m_device, IOCTL_SCSI_PASS_THROUGH_DIRECT, &sptd,
                             sizeof(sptd), &sptd, sizeof(sptd), &unused, nullptr)) {
-            if (sptd.info.DataTransferLength != 2352)
-                printf(" * CDVD: SPTI short transfer of %u bytes", sptd.info.DataTransferLength);
-            continue;
+            if (sptd.info.DataTransferLength == 2352)
+                continue;
         }
         printf(" * CDVD: SPTI failed reading sector %u; SENSE %u -", current_sector, sptd.info.SenseInfoLength);
         for (const auto &c : sptd.sense_buffer)

--- a/plugins/cdvdGigaherz/src/Windows/config.cpp
+++ b/plugins/cdvdGigaherz/src/Windows/config.cpp
@@ -19,7 +19,6 @@
 #include "../CDVD.h"
 #include <Windows.h>
 #include <commctrl.h>
-#include <codecvt>
 #include "resource.h"
 
 static HINSTANCE s_hinstance;
@@ -107,8 +106,10 @@ std::wstring GetValidDrive()
         drive = drives.front();
     }
 
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    printf(" * CDVD: Opening drive '%s'...\n", converter.to_bytes(drive).c_str());
+    int size = WideCharToMultiByte(CP_UTF8, 0, drive.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    std::vector<char> converted_string(size);
+    WideCharToMultiByte(CP_UTF8, 0, drive.c_str(), -1, converted_string.data(), converted_string.size(), nullptr, nullptr);
+    printf(" * CDVD: Opening drive '%s'...\n", converted_string.data());
 
     // The drive string has the form "X:\", but to open the drive, the string
     // has to be in the form "\\.\X:"


### PR DESCRIPTION
Changes:
 * Removes unused mode parameter/member variables
 * (Windows) Adjusts the CD read success condition - basically the IOCTL returns success even if the read fails so the read should only be considered successful if the read length is correct (2352).
 * (Windows) Replaces wstring_convert with MultiByteToWideChar() and WideCharToMultiByte() - wstring_convert was deprecated in C++17.
 * (GTK+) Simplify GUI - Avoids always setting the dialog to the centre of the screen (GTK+3 documentation advises against it because some window managers will dislike it), avoid GUI callbacks (not exactly necessary in this case, the code is simpler without it), and simplify how the GUI is constructed (it consists of a label and combobox, it doesn't really need to be packed into a box).