### PR TITLE
GameDB: Add EERoundMode gamefix to restore missing text in Teen Titans.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16194,10 +16194,12 @@ Region = PAL-M6	// Eng, P & Nordic
 Serial = SLES-54430
 Name   = Teen Titans
 Region = PAL-E-F
+eeRoundMode = 2 // Restores missing text in pause menu/load game screen.
 ---------------------------------------------
 Serial = SLES-54431
 Name   = Teen Titans
 Region = PAL-E
+eeRoundMode = 2 // Restores missing text in pause menu/load game screen.
 ---------------------------------------------
 Serial = SLES-54432
 Name   = Mercury Meltdown Remix
@@ -39610,6 +39612,7 @@ Serial = SLUS-21183
 Name   = Teen Titans
 Region = NTSC-U
 Compat = 5
+eeRoundMode = 2 // Restores missing text in pause menu/load game screen.
 ---------------------------------------------
 Serial = SLUS-21184
 Name   = Teenage Mutant Ninja Turtles 3 - Mutant Nightmare


### PR DESCRIPTION
This PR restores missing text in the pause menu/load game screen as reported here: https://forums.pcsx2.net/Thread-Bug-Report-Teen-Titans-Load-Game-menu-not-displaying-text-where-it-should