### PR TITLE
GSdx: Adjust Kunoichi crc hack

### DIFF
--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -750,13 +750,13 @@ bool GSC_TalesOfLegendia(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-// Removes depth effects(shadows) not rendered correctly on all renders.
 bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
 		if(!fi.TME && (fi.FBP == 0x0 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0x00FFFFFF)
 		{
+			// Removes depth effects(shadows) not rendered correctly on all renders.
 			skip = 3;
 		}
 	}

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -750,6 +750,7 @@ bool GSC_TalesOfLegendia(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
+//Shadows don't appear or cause darkness issues in different levels.
 bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -757,27 +758,6 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		if(!fi.TME && (fi.FBP == 0x0 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0x00FFFFFF)
 		{
 			skip = 3;
-		}
-		if(fi.TME && (fi.FBP ==0x0700 || fi.FBP==0) && fi.TBP0==0x0e00 && fi.TPSM ==0  && fi.FBMSK == 0)
-		{
-			skip = 1;
-		}
-		if(fi.TME)
-		{
-			// depth textures (bully, mgs3s1 intro, Front Mission 5)
-			if( (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
-				// General, often problematic post processing
-				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
-			{
-				skip = 1;
-			}
-		}
-	}
-	else
-	{
-		if(fi.TME && (fi.FBP == 0x0e00) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0xFF000000)
-		{
-			skip = 0;
 		}
 	}
 

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -766,7 +766,7 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		if(fi.TME)
 		{
 			// Removes burning air effect, the effect causes major slowdowns.
-			if( (Aggressive && (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+			if(Aggressive && (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
 				// General, often problematic post processing
 				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
 			{

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -762,6 +762,16 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		{
 			skip = 1;
 		}
+		if(fi.TME)
+		{
+			// depth textures (bully, mgs3s1 intro, Front Mission 5)
+			if( (Aggressive && fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+				// General, often problematic post processing
+				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
+			{
+				skip = 1;
+			}
+		}
 	}
 	else
 	{
@@ -770,19 +780,7 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 			skip = 0;
 		}
 	}
-	else(Aggressive && skip == 0)
-	{
-		if(fi.TME)
-		{
-			// depth textures (bully, mgs3s1 intro, Front Mission 5)
-			if( (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
-				// General, often problematic post processing
-				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
-			{
-				skip = 1;
-			}
-		}
-	}
+
 	return true;
 }
 

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -760,6 +760,13 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 			skip = 3;
 		}
 	}
+	else
+	{
+		if(fi.TME && (fi.FBP == 0x0e00) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0xFF000000)
+		{
+			skip = 0;
+		}
+	}
 
 	return true;
 }

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -761,7 +761,6 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		}
 		if(fi.TME && (fi.FBP ==0x0700 || fi.FBP==0) && fi.TBP0==0x0e00 && fi.TPSM ==0  && fi.FBMSK == 0)
 		{
-			// Removes depth effects(shadows) not rendered correctly on all renders.
 			skip = 1;
 		}
 		if(Aggressive && fi.TME)

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -756,8 +756,11 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 	{
 		if(!fi.TME && (fi.FBP == 0x0 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0x00FFFFFF)
 		{
-			// Removes depth effects(shadows) not rendered correctly on all renders.
 			skip = 3;
+		}
+		if(fi.TME && (fi.FBP ==0x0700 || fi.FBP==0) && fi.TBP0==0x0e00 && fi.TPSM ==0  && fi.FBMSK == 0)
+		{
+			skip = 1;
 		}
 	}
 	else

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -752,7 +752,6 @@ bool GSC_TalesOfLegendia(const GSFrameInfo& fi, int& skip)
 
 bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 {
-	// Removes depth effects(shadows) not rendered correctly on all renders.
 	if(skip == 0)
 	{
 		if(!fi.TME && (fi.FBP == 0x0 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0x00FFFFFF)

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -757,10 +757,12 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 	{
 		if(!fi.TME && (fi.FBP == 0x0 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0x00FFFFFF)
 		{
+			// Removes depth effects(shadows) not rendered correctly on all renders.
 			skip = 3;
 		}
 		if(fi.TME && (fi.FBP ==0x0700 || fi.FBP==0) && fi.TBP0==0x0e00 && fi.TPSM ==0  && fi.FBMSK == 0)
 		{
+			// Removes depth effects(shadows) not rendered correctly on all renders.
 			skip = 1;
 		}
 		if(Aggressive && fi.TME)

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -752,6 +752,7 @@ bool GSC_TalesOfLegendia(const GSFrameInfo& fi, int& skip)
 
 bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 {
+	// Removes depth effects(shadows) not rendered correctly on all renders.
 	if(skip == 0)
 	{
 		if(!fi.TME && (fi.FBP == 0x0 || fi.FBP == 0x00700 || fi.FBP == 0x00800) && fi.FPSM == PSM_PSMCT32 && fi.FBMSK == 0x00FFFFFF)
@@ -764,8 +765,8 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		}
 		if(fi.TME)
 		{
-			// depth textures (bully, mgs3s1 intro, Front Mission 5)
-			if( (Aggressive && fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+			// Removes burning air effect, the effect causes major slowdowns.
+			if( (Aggressive && (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
 				// General, often problematic post processing
 				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
 			{

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -750,7 +750,7 @@ bool GSC_TalesOfLegendia(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-//Shadows don't appear or cause darkness issues in different levels.
+// Removes depth effects(shadows) not rendered correctly on all renders.
 bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -763,10 +763,10 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		{
 			skip = 1;
 		}
-		if(fi.TME)
+		if(Aggressive && fi.TME)
 		{
 			// Removes burning air effect, the effect causes major slowdowns.
-			if(Aggressive && (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+			if((fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
 				// General, often problematic post processing
 				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
 			{

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -763,13 +763,14 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		{
 			skip = 1;
 		}
-		// Removes burning air effect, the effect causes major slowdowns.
 		if(Aggressive && fi.TME)
 		{
+			// depth textures (bully, mgs3s1 intro, Front Mission 5)
 			if((fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
 				// General, often problematic post processing
 				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
 			{
+				// Removes burning air effect, the effect causes major slowdowns.
 				skip = 1;
 			}
 		}

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -770,7 +770,19 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 			skip = 0;
 		}
 	}
-
+	else(Aggressive && skip == 0)
+	{
+		if(fi.TME)
+		{
+			// depth textures (bully, mgs3s1 intro, Front Mission 5)
+			if( (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+				// General, often problematic post processing
+				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
+			{
+				skip = 1;
+			}
+		}
+	}
 	return true;
 }
 

--- a/plugins/GSdx/GSHwHack.cpp
+++ b/plugins/GSdx/GSHwHack.cpp
@@ -763,9 +763,9 @@ bool GSC_Kunoichi(const GSFrameInfo& fi, int& skip)
 		{
 			skip = 1;
 		}
+		// Removes burning air effect, the effect causes major slowdowns.
 		if(Aggressive && fi.TME)
 		{
-			// Removes burning air effect, the effect causes major slowdowns.
 			if((fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
 				// General, often problematic post processing
 				(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )


### PR DESCRIPTION
Removes only depth effects(shadows) not rendered correctly on all renders, without touching burning air effect. Move it to an aggressive hack, and added description of the problem.