### PR TITLE
GameDB: Fix missing game board in Monopoly Party, add Gene Troopers to db

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -9090,6 +9090,7 @@ Compat = 5
 Serial = SLES-51145
 Name   = Monopoly Party
 Region = PAL-M5
+vuClampMode = 0 // Fixes missing game board.
 ---------------------------------------------
 Serial = SLES-51150
 Name   = Scrabble Interactive - 2003 Edition
@@ -14522,6 +14523,10 @@ Region = PAL-M5
 Serial = SLES-53641
 Name   = Destroy All Humans!
 Region = PAL-R
+---------------------------------------------
+Serial = SLES-53644
+Name   = Gene Troopers
+Region = PAL-M5
 ---------------------------------------------
 Serial = SLES-53645
 Name   = Knights of the Temple II
@@ -29727,6 +29732,11 @@ Serial = SLPS-20280
 Name   = Mahou no Pumpkin
 Region = NTSC-J
 ---------------------------------------------
+Serial = SLPS-20281
+Name   = Monopoly: Mezase!! Daifugou Jinsei!!
+Region = NTSC-J
+vuClampMode = 0 // Fixes missing game board.
+---------------------------------------------
 Serial = SLPS-20282
 Name   = Taiko no Tatsujin
 Region = NTSC-J
@@ -35646,6 +35656,7 @@ Serial = SLUS-20348
 Name   = Monopoly Party
 Region = NTSC-U
 Compat = 4
+vuClampMode = 0 // Fixes missing game board.
 ---------------------------------------------
 Serial = SLUS-20349
 Name   = Scooby Doo! Night of 100 Frights


### PR DESCRIPTION
This PR restores the missing game board in Monopoly Party and removes it from being dependent on SuperVU.