### PR TITLE
Fix some pathname issues

### DIFF
--- a/common/include/PS2Eext.h
+++ b/common/include/PS2Eext.h
@@ -43,6 +43,7 @@
 
 #endif
 
+#include <PluginCompatibility.h>
 //#include "PS2Edefs.h"
 
 #if !defined(_MSC_VER) || !defined(UNICODE)
@@ -65,7 +66,7 @@ struct PluginLog
 
     bool Open(std::string logname)
     {
-        LogFile = fopen(logname.c_str(), "w");
+        LogFile = px_fopen(logname, "w");
 
         if (LogFile) {
             setvbuf(LogFile, NULL, _IONBF, 0);
@@ -161,9 +162,9 @@ struct PluginConf
     bool Open(std::string name, FileMode mode = READ_FILE)
     {
         if (mode == READ_FILE) {
-            ConfFile = fopen(name.c_str(), "r");
+            ConfFile = px_fopen(name, "r");
         } else {
-            ConfFile = fopen(name.c_str(), "w");
+            ConfFile = px_fopen(name, "w");
         }
 
         if (ConfFile == NULL)

--- a/common/include/PluginCompatibility.h
+++ b/common/include/PluginCompatibility.h
@@ -1,0 +1,42 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2018 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <string>
+#include <vector>
+#include <cstdio>
+
+#ifdef _WIN32
+inline std::wstring convert_utf8_to_utf16(const std::string &utf8_string)
+{
+    int size = MultiByteToWideChar(CP_UTF8, 0, utf8_string.c_str(), -1, nullptr, 0);
+    std::vector<wchar_t> converted_string(size);
+    MultiByteToWideChar(CP_UTF8, 0, utf8_string.c_str(), -1, converted_string.data(), converted_string.size());
+    return {converted_string.data()};
+}
+#endif
+
+// _wfopen has to be used on Windows for pathnames containing non-ASCII characters.
+inline FILE *px_fopen(const std::string &filename, const std::string &mode)
+{
+#ifdef _WIN32
+    return _wfopen(convert_utf8_to_utf16(filename).c_str(), convert_utf8_to_utf16(mode).c_str());
+#else
+    return fopen(filename.c_str(), mode.c_str());
+#endif
+}

--- a/pcsx2/DebugTools/SymbolMap.cpp
+++ b/pcsx2/DebugTools/SymbolMap.cpp
@@ -46,7 +46,7 @@ void SymbolMap::Clear() {
 
 bool SymbolMap::LoadNocashSym(const char *filename) {
 	std::lock_guard<std::recursive_mutex> guard(m_lock);
-	FILE *f = fopen(filename, "r");
+	FILE *f = wxFopen(filename, "r");
 	if (!f)
 		return false;
 

--- a/pcsx2/Elfheader.cpp
+++ b/pcsx2/Elfheader.cpp
@@ -147,9 +147,7 @@ void ElfObject::readIso(IsoFile& file)
 void ElfObject::readFile()
 {
 	int rsize = 0;
-	FILE *f;
-
-	f = fopen( filename.ToUTF8(), "rb" );
+	FILE *f = wxFopen( filename, "rb" );
 	if (f == NULL) throw Exception::FileNotFound( filename );
 
 	fseek(f, 0, SEEK_SET);

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -1732,10 +1732,8 @@ void SysCorePlugins::SendSettingsFolder()
 	ScopedLock lock( m_mtx_PluginStatus );
 	if( m_SettingsFolder.IsEmpty() ) return;
 
-	wxCharBuffer buffer(m_SettingsFolder.mb_str(wxConvFile));
-
 	const PluginInfo* pi = tbl_PluginInfo; do {
-		if( m_info[pi->id] ) m_info[pi->id]->CommonBindings.SetSettingsDir( buffer );
+		if( m_info[pi->id] ) m_info[pi->id]->CommonBindings.SetSettingsDir( m_SettingsFolder.utf8_str() );
 	} while( ++pi, pi->shortname != NULL );
 }
 
@@ -1758,10 +1756,8 @@ void SysCorePlugins::SendLogFolder()
 	ScopedLock lock( m_mtx_PluginStatus );
 	if( m_LogFolder.IsEmpty() ) return;
 
-	wxCharBuffer buffer(m_LogFolder.mb_str(wxConvFile));
-
 	const PluginInfo* pi = tbl_PluginInfo; do {
-		if( m_info[pi->id] ) m_info[pi->id]->CommonBindings.SetLogDir( buffer );
+		if( m_info[pi->id] ) m_info[pi->id]->CommonBindings.SetLogDir( m_LogFolder.utf8_str() );
 	} while( ++pi, pi->shortname != NULL );
 }
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1098,7 +1098,7 @@ void RelocateLogfile()
 	if( emuLog == NULL )
 	{
 		emuLogName = newlogname;
-		emuLog = fopen( emuLogName.ToUTF8(), "wb" );
+		emuLog = wxFopen( emuLogName, "wb" );
 	}
 
 	wxGetApp().EnableAllLogging();

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -353,7 +353,7 @@ namespace Implementations
 
 	void Sys_TakeSnapshot()
 	{
-		GSmakeSnapshot( g_Conf->Folders.Snapshots.ToAscii() );
+		GSmakeSnapshot( g_Conf->Folders.Snapshots.ToUTF8() );
 	}
 
 	void Sys_RenderToggle()

--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -130,7 +130,7 @@ static void OnSlotChanged()
 	OSDlog( Color_StrongGreen, true, " > Selected savestate slot %d", StatesC );
 
 	if( GSchangeSaveState != NULL )
-		GSchangeSaveState(StatesC, SaveStateBase::GetFilename(StatesC).mb_str());
+		GSchangeSaveState(StatesC, SaveStateBase::GetFilename(StatesC).utf8_str());
 
 	Sstates_updateLoadBackupMenuItem();
 }

--- a/plugins/FWnull/Windows/FireWireNull.def
+++ b/plugins/FWnull/Windows/FireWireNull.def
@@ -18,3 +18,4 @@ EXPORTS
 	FWtest			@18
 	
 	FWsetSettingsDir
+	FWsetLogDir

--- a/plugins/GSdx/GSDump.cpp
+++ b/plugins/GSdx/GSDump.cpp
@@ -26,7 +26,7 @@ GSDumpBase::GSDumpBase(const std::string& fn)
 	: m_frames(0)
 	, m_extra_frames(2)
 {
-	m_gs = fopen(fn.c_str(), "wb");
+	m_gs = px_fopen(fn, "wb");
 	if (!m_gs)
 		fprintf(stderr, "GSDump: Error failed to open %s\n", fn.c_str());
 }

--- a/plugins/GSdx/GSPng.cpp
+++ b/plugins/GSdx/GSPng.cpp
@@ -52,7 +52,7 @@ namespace GSPng {
         const int offset = first_image ? 0 : pixel[fmt].bytes_per_pixel_out;
         const int bytes_per_pixel_out = first_image ? pixel[fmt].bytes_per_pixel_out : bytes_per_pixel_in - offset;
 
-        FILE *fp = fopen(file.c_str(), "wb");
+        FILE *fp = px_fopen(file, "wb");
         if (fp == nullptr)
             return false;
 

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -51,6 +51,7 @@
 
 #endif
 
+#include <PluginCompatibility.h>
 
 #ifdef ENABLE_OPENCL
 

--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -13,7 +13,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4456;4458;4996;4995;4324;4100;4101;4201;4556;4127;4512;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(VTUNE_AMPLIFIER_XE_2015_DIR)include;$(ProjectDir);$(SolutionDir)3rdparty\baseclasses;$(SolutionDir)3rdparty;$(SolutionDir)3rdparty\freetype\include;$(SolutionDir)3rdparty\libpng;$(SolutionDir)3rdparty\opencl;$(SolutionDir)3rdparty\xz\xz\src\liblzma\api;$(SolutionDir)3rdparty\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VTUNE_AMPLIFIER_XE_2015_DIR)include;$(ProjectDir);$(SolutionDir)common\include;$(SolutionDir)3rdparty\baseclasses;$(SolutionDir)3rdparty;$(SolutionDir)3rdparty\freetype\include;$(SolutionDir)3rdparty\libpng;$(SolutionDir)3rdparty\opencl;$(SolutionDir)3rdparty\xz\xz\src\liblzma\api;$(SolutionDir)3rdparty\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>LZMA_API_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/plugins/LilyPad/Config.cpp
+++ b/plugins/LilyPad/Config.cpp
@@ -339,7 +339,7 @@ void CALLBACK PADsetSettingsDir(const char *dir)
     //swprintf_s( iniFile, L"%S", (dir==NULL) ? "inis" : dir );
 
     //uint targlen = MultiByteToWideChar(CP_ACP, 0, dir, -1, NULL, 0);
-    MultiByteToWideChar(CP_ACP, 0, dir, -1, iniFile, MAX_PATH * 2);
+    MultiByteToWideChar(CP_UTF8, 0, dir, -1, iniFile, MAX_PATH * 2);
     wcscat_s(iniFile, L"/LilyPad.ini");
 
     createIniDir = false;

--- a/plugins/USBnull/Windows/USBnull.def
+++ b/plugins/USBnull/Windows/USBnull.def
@@ -26,3 +26,4 @@ EXPORTS
 	USBtest				@19
 	
 	USBsetSettingsDir
+	USBsetLogDir

--- a/plugins/cdvdGigaherz/src/Settings.cpp
+++ b/plugins/cdvdGigaherz/src/Settings.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <locale>
 #include <string>
+#include <PluginCompatibility.h>
 
 Settings::Settings()
 {
@@ -45,7 +46,11 @@ void Settings::TrimWhitespace(std::string &str) const
 
 void Settings::Load(const std::string &filename)
 {
+#ifdef _WIN32
+    std::ifstream file(convert_utf8_to_utf16(filename));
+#else
     std::ifstream file(filename);
+#endif
     if (!file.is_open())
         return;
 
@@ -72,7 +77,11 @@ void Settings::Load(const std::string &filename)
 
 void Settings::Save(const std::string &filename) const
 {
+#ifdef _WIN32
+    std::ofstream file(convert_utf8_to_utf16(filename), std::ios::trunc);
+#else
     std::ofstream file(filename, std::ios::trunc);
+#endif
     if (!file.is_open())
         return;
 

--- a/plugins/dev9null/Windows/dev9null.def
+++ b/plugins/dev9null/Windows/dev9null.def
@@ -33,3 +33,4 @@ EXPORTS
 	DEV9dmaInterrupt
 	
 	DEV9setSettingsDir
+	DEV9setLogDir

--- a/plugins/spu2-x/src/Linux/CfgHelpers.cpp
+++ b/plugins/spu2-x/src/Linux/CfgHelpers.cpp
@@ -37,7 +37,7 @@ void setIni(const wchar_t *Section)
 void CfgSetSettingsDir(const char *dir)
 {
     FileLog("CfgSetSettingsDir(%s)\n", dir);
-    path = wxString::FromAscii(dir) + L"/spu2-x.ini";
+    path = wxString::FromUTF8(dir) + L"/spu2-x.ini";
     pathSet = true;
 }
 

--- a/plugins/spu2-x/src/Windows/CfgHelpers.cpp
+++ b/plugins/spu2-x/src/Windows/CfgHelpers.cpp
@@ -55,7 +55,7 @@ static wxString CfgFile(L"inis/SPU2-X.ini");
 
 void CfgSetSettingsDir(const char *dir)
 {
-    CfgFile = Path::Combine((dir == NULL) ? wxString(L"inis") : wxString(dir, wxConvFile), L"SPU2-X.ini");
+    CfgFile = Path::Combine((dir == NULL) ? wxString(L"inis") : wxString::FromUTF8(dir), L"SPU2-X.ini");
 }
 
 


### PR DESCRIPTION
Changes:
 * Fixes an issue where snapshots/GS dumps fail to open when the pathname contains non-ASCII characters.
 * (Windows) Fixes pathname issues when the pathname contains characters not present in the current codepage - this doesn't currently include DEV9ghzdrk and GSdx (excluding the snapshot/GS dump issue mentioned above) - GSdx would require quite a bit of work, whereas for DEV9ghzdrk I simply don't have winpcap installed.
 * (Windows) Exports the log directory settings functions for DEV9null/FWnull/USBnull so changing the log directory actually works.
 *  (Linux) Fixes an SPU2-X issue with the ini if the pathname contains non-ASCII characters.

See #2478.