### PR TITLE
GSdx: Direct3D Updates

### DIFF
--- a/plugins/GSdx/res/merge.fx
+++ b/plugins/GSdx/res/merge.fx
@@ -18,7 +18,7 @@ struct PS_INPUT
 float4 ps_main0(PS_INPUT input) : SV_Target0
 {
 	float4 c = Texture.Sample(Sampler, input.t);
-	c.a = min(c.a * 2, 1);
+	c.a *= 2.0f;
 	return c;
 }
 

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -333,7 +333,7 @@ float4x4 sample_4c(float4 uv)
 	return c;
 }
 
-float4 sample_4a(float4 uv)
+float4 sample_4_index(float4 uv)
 {
 	float4 c;
 
@@ -415,7 +415,7 @@ float4 sample(float2 st, float q)
 		uv = clamp_wrap_uv(uv);
 
 #if PS_PAL_FMT != 0
-			c = sample_4p(sample_4a(uv));
+			c = sample_4p(sample_4_index(uv));
 #else
 			c = sample_4c(uv);
 #endif


### PR DESCRIPTION
GSdx-d3d: Drop an useless min in FS - port from GL.
Commit: PCSX2@a1957a6
GPU will clamp color anyway. It reduces the number of instruction of 25% (4->3).

GSdx-d3d: Reduce state change - port from GL.
Commit: PCSX2@37f9bcf
Don't dirty aref when a fog color is uploaded.
Only set clamp mode in clamp mode (region clamp is handled in shader).

GSdx-d3d: s/sample_4a/sample_4_index/