### PR TITLE
Silence -Wclass-memaccess warnings.

### DIFF
--- a/common/include/Utilities/MemcpyFast.h
+++ b/common/include/Utilities/MemcpyFast.h
@@ -29,7 +29,7 @@ extern u8 memcmp_mmx(const void *src1, const void *src2, int cmpsize);
 template <typename T>
 static __fi void memzero(T &object)
 {
-    memset(&object, 0, sizeof(T));
+    memset(static_cast<void *>(&object), 0, sizeof(T));
 }
 
 // This method clears an object with the given 8 bit value.

--- a/pcsx2/x86/sVU_zerorec.cpp
+++ b/pcsx2/x86/sVU_zerorec.cpp
@@ -1346,7 +1346,7 @@ static VuBaseBlock* SuperVUBuildBlocks(VuBaseBlock* parent, u32 startpc, const V
 		{
 			pinst->pqcycles = QWaitTimes[pinst->info.pqinst] + 1;
 
-			memset(&w, 0, sizeof(w));
+			memset(static_cast<void *>(&w), 0, sizeof(w));
 			w.nParentPc = pc - 8;
 			w.cycle = pinst->info.cycle + pinst->pqcycles;
 			w.viwrite[0] = 1 << REG_Q;

--- a/plugins/GSdx/GSDrawScanline.cpp
+++ b/plugins/GSdx/GSDrawScanline.cpp
@@ -30,14 +30,14 @@ GSDrawScanline::GSDrawScanline()
 	: m_sp_map("GSSetupPrim", &m_local)
 	, m_ds_map("GSDrawScanline", &m_local)
 {
-	memset(&m_local, 0, sizeof(m_local));
+	memset(static_cast<void *>(&m_local), 0, sizeof(m_local));
 
 	m_local.gd = &m_global;
 }
 
 void GSDrawScanline::BeginDraw(const GSRasterizerData* data)
 {
-	memcpy(&m_global, &((const SharedData*)data)->global, sizeof(m_global));
+	memcpy(static_cast<void *>(&m_global), &((const SharedData*)data)->global, sizeof(m_global));
 
 	if(m_global.sel.mmin && m_global.sel.lcm)
 	{

--- a/plugins/GSdx/GSRendererSW.cpp
+++ b/plugins/GSdx/GSRendererSW.cpp
@@ -1317,7 +1317,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 			gd.dimx = (GSVector4i*)_aligned_malloc(sizeof(env.dimx), 32);
 
-			memcpy(gd.dimx, env.dimx, sizeof(env.dimx));
+			memcpy(static_cast<void *>(gd.dimx), env.dimx, sizeof(env.dimx));
 		}
 	}
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -82,7 +82,7 @@ GSState::GSState()
 	if (m_crc_hack_level == CRCHackLevel::Automatic)
 		m_crc_hack_level = GSUtil::GetRecommendedCRCHackLevel(theApp.GetCurrentRendererType());
 
-	memset(&m_v, 0, sizeof(m_v));
+	memset(static_cast<void *>(&m_v), 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));
 	memset(&m_index, 0, sizeof(m_index));
 
@@ -222,8 +222,8 @@ void GSState::Reset()
 	//printf("GSdx info: GS reset\n");
 
 	// FIXME: memset(m_mem.m_vm8, 0, m_mem.m_vmsize); // bios logo not shown cut in half after reset, missing graphics in GoW after first FMV
-	memset(&m_path[0], 0, sizeof(m_path[0]) * countof(m_path));
-	memset(&m_v, 0, sizeof(m_v));
+	memset(static_cast<void *>(&m_path[0]), 0, sizeof(m_path[0]) * countof(m_path));
+	memset(static_cast<void *>(&m_v), 0, sizeof(m_v));
 
 //	PRIM = &m_env.PRIM;
 //	m_env.PRMODECONT.AC = 1;
@@ -1665,7 +1665,7 @@ void GSState::FlushPrim()
 
 		if(unused > 0)
 		{
-			memcpy(m_vertex.buff, buff, sizeof(GSVertex) * unused);
+			memcpy(static_cast<void *>(m_vertex.buff), buff, sizeof(GSVertex) * unused);
 
 			m_vertex.tail = unused;
 			m_vertex.next = next > head ? next - head : 0;
@@ -2056,12 +2056,12 @@ void GSState::SoftReset(uint32 mask)
 {
 	if(mask & 1)
 	{
-		memset(&m_path[0], 0, sizeof(GIFPath));
-		memset(&m_path[3], 0, sizeof(GIFPath));
+		memset(static_cast<void *>(&m_path[0]), 0, sizeof(GIFPath));
+		memset(static_cast<void *>(&m_path[3]), 0, sizeof(GIFPath));
 	}
 
-	if(mask & 2) memset(&m_path[1], 0, sizeof(GIFPath));
-	if(mask & 4) memset(&m_path[2], 0, sizeof(GIFPath));
+	if(mask & 2) memset(static_cast<void *>(&m_path[1]), 0, sizeof(GIFPath));
+	if(mask & 4) memset(static_cast<void *>(&m_path[2]), 0, sizeof(GIFPath));
 
 	m_env.TRXDIR.XDIR = 3; //-1 ; set it to invalid value
 
@@ -2613,7 +2613,7 @@ void GSState::GrowVertexBuffer()
 
 	if(m_vertex.buff != NULL)
 	{
-		memcpy(vertex, m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
+		memcpy(static_cast<void *>(vertex), m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
 
 		_aligned_free(m_vertex.buff);
 	}

--- a/plugins/GSdx/GSTextureCache.cpp
+++ b/plugins/GSdx/GSTextureCache.cpp
@@ -1823,7 +1823,7 @@ void GSTextureCache::Source::Flush(uint32 count, int layer)
 	if(count < m_write.count)
 	{
 		// Warning src and destination overlap. Memmove must be used instead of memcpy
-		memmove(&m_write.rect[0], &m_write.rect[count], (m_write.count - count) * sizeof(m_write.rect[0]));
+		memmove(static_cast<void *>(&m_write.rect[0]), &m_write.rect[count], (m_write.count - count) * sizeof(m_write.rect[0]));
 	}
 
 	m_write.count -= count;

--- a/plugins/GSdx/GSVector4i.h
+++ b/plugins/GSdx/GSVector4i.h
@@ -1826,7 +1826,7 @@ public:
 
 		if(size == 0) return;
 
-		memcpy(d, s, size);
+		memcpy(static_cast<void *>(d), s, size);
 	}
 
 	__forceinline static void transpose(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d)

--- a/plugins/GSdx/GSVector8i.h
+++ b/plugins/GSdx/GSVector8i.h
@@ -1179,7 +1179,7 @@ public:
 
 		if(size == 0) return;
 
-		memcpy(d, s, size);
+		memcpy(static_cast<void *>(d), s, size);
 	}
 
 	// TODO: swizzling

--- a/plugins/GSdx/PSX/GPUDrawScanline.cpp
+++ b/plugins/GSdx/PSX/GPUDrawScanline.cpp
@@ -26,14 +26,14 @@ GPUDrawScanline::GPUDrawScanline()
 	: m_sp_map("GPUSetupPrim", &m_local)
 	, m_ds_map("GPUDrawScanline", &m_local)
 {
-	memset(&m_local, 0, sizeof(m_local));
+	memset(static_cast<void *>(&m_local), 0, sizeof(m_local));
 
 	m_local.gd = &m_global;
 }
 
 void GPUDrawScanline::BeginDraw(const GSRasterizerData* data)
 {
-	memcpy(&m_global, &((const SharedData*)data)->global, sizeof(m_global));
+	memcpy(static_cast<void *>(&m_global), &((const SharedData*)data)->global, sizeof(m_global));
 
 	if(m_global.sel.tme && m_global.sel.twin)
 	{

--- a/plugins/GSdx/PSX/GPURenderer.h
+++ b/plugins/GSdx/PSX/GPURenderer.h
@@ -131,7 +131,7 @@ protected:
 
 		if(m_vertices != NULL)
 		{
-			memcpy(vertices, m_vertices, sizeof(Vertex) * m_maxcount);
+			memcpy(static_cast<void *>(vertices), m_vertices, sizeof(Vertex) * m_maxcount);
 			_aligned_free(m_vertices);
 		}
 

--- a/plugins/GSdx/PSX/GPURendererSW.cpp
+++ b/plugins/GSdx/PSX/GPURendererSW.cpp
@@ -125,7 +125,7 @@ void GPURendererSW::Draw()
 	data->vertex = (GSVertexSW*)data->buff;
 	data->vertex_count = m_count;
 
-	memcpy(data->vertex, m_vertices, sizeof(GSVertexSW) * m_count);
+	memcpy(static_cast<void *>(data->vertex), m_vertices, sizeof(GSVertexSW) * m_count);
 	
 	data->frame = m_perfmon.GetFrame();
 

--- a/plugins/GSdx/PSX/GPUState.cpp
+++ b/plugins/GSdx/PSX/GPUState.cpp
@@ -61,7 +61,7 @@ void GPUState::Reset()
 
 	m_mem.Invalidate(GSVector4i(0, 0, 1024, 512));
 
-	memset(&m_v, 0, sizeof(m_v));
+	memset(static_cast<void *>(&m_v), 0, sizeof(m_v));
 }
 
 void GPUState::Flush()

--- a/plugins/GSdx_legacy/GPUDrawScanline.cpp
+++ b/plugins/GSdx_legacy/GPUDrawScanline.cpp
@@ -26,7 +26,7 @@ GPUDrawScanline::GPUDrawScanline()
 	: m_sp_map("GPUSetupPrim", &m_local)
 	, m_ds_map("GPUDrawScanline", &m_local)
 {
-	memset(&m_local, 0, sizeof(m_local));
+	memset(static_cast<void *>(&m_local), 0, sizeof(m_local));
 
 	m_local.gd = &m_global;
 }
@@ -37,7 +37,7 @@ GPUDrawScanline::~GPUDrawScanline()
 
 void GPUDrawScanline::BeginDraw(const GSRasterizerData* data)
 {
-	memcpy(&m_global, &((const SharedData*)data)->global, sizeof(m_global));
+	memcpy(static_cast<void *>(&m_global), &((const SharedData*)data)->global, sizeof(m_global));
 
 	if(m_global.sel.tme && m_global.sel.twin)
 	{

--- a/plugins/GSdx_legacy/GPURenderer.h
+++ b/plugins/GSdx_legacy/GPURenderer.h
@@ -131,7 +131,7 @@ protected:
 
 		if(m_vertices != NULL)
 		{
-			memcpy(vertices, m_vertices, sizeof(Vertex) * m_maxcount);
+			memcpy(static_cast<void *>(vertices), m_vertices, sizeof(Vertex) * m_maxcount);
 			_aligned_free(m_vertices);
 		}
 

--- a/plugins/GSdx_legacy/GPURendererSW.cpp
+++ b/plugins/GSdx_legacy/GPURendererSW.cpp
@@ -125,7 +125,7 @@ void GPURendererSW::Draw()
 	data->vertex = (GSVertexSW*)data->buff;
 	data->vertex_count = m_count;
 
-	memcpy(data->vertex, m_vertices, sizeof(GSVertexSW) * m_count);
+	memcpy(static_cast<void *>(data->vertex), m_vertices, sizeof(GSVertexSW) * m_count);
 	
 	data->frame = m_perfmon.GetFrame();
 

--- a/plugins/GSdx_legacy/GPUState.cpp
+++ b/plugins/GSdx_legacy/GPUState.cpp
@@ -65,7 +65,7 @@ void GPUState::Reset()
 
 	m_mem.Invalidate(GSVector4i(0, 0, 1024, 512));
 
-	memset(&m_v, 0, sizeof(m_v));
+	memset(static_cast<void *>(&m_v), 0, sizeof(m_v));
 }
 
 void GPUState::Flush()

--- a/plugins/GSdx_legacy/GSDrawScanline.cpp
+++ b/plugins/GSdx_legacy/GSDrawScanline.cpp
@@ -27,7 +27,7 @@ GSDrawScanline::GSDrawScanline()
 	: m_sp_map("GSSetupPrim", &m_local)
 	, m_ds_map("GSDrawScanline", &m_local)
 {
-	memset(&m_local, 0, sizeof(m_local));
+	memset(static_cast<void *>(&m_local), 0, sizeof(m_local));
 
 	m_local.gd = &m_global;
 }
@@ -38,7 +38,7 @@ GSDrawScanline::~GSDrawScanline()
 
 void GSDrawScanline::BeginDraw(const GSRasterizerData* data)
 {
-	memcpy(&m_global, &((const SharedData*)data)->global, sizeof(m_global));
+	memcpy(static_cast<void *>(&m_global), &((const SharedData*)data)->global, sizeof(m_global));
 
 	if(m_global.sel.mmin && m_global.sel.lcm)
 	{

--- a/plugins/GSdx_legacy/GSRendererSW.cpp
+++ b/plugins/GSdx_legacy/GSRendererSW.cpp
@@ -1425,7 +1425,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 			gd.dimx = (GSVector4i*)_aligned_malloc(sizeof(env.dimx), 32);
 
-			memcpy(gd.dimx, env.dimx, sizeof(env.dimx));
+			memcpy(static_cast<void *>(gd.dimx), env.dimx, sizeof(env.dimx));
 		}
 	}
 

--- a/plugins/GSdx_legacy/GSState.cpp
+++ b/plugins/GSdx_legacy/GSState.cpp
@@ -72,7 +72,7 @@ GSState::GSState()
 	m_crc_hack_level = theApp.GetConfig("crc_hack_level", 3);
 	s_crc_hack_level = m_crc_hack_level;
 
-	memset(&m_v, 0, sizeof(m_v));
+	memset(static_cast<void *>(&m_v), 0, sizeof(m_v));
 	memset(&m_vertex, 0, sizeof(m_vertex));
 	memset(&m_index, 0, sizeof(m_index));
 
@@ -212,8 +212,8 @@ void GSState::Reset()
 	//printf("GSdx info: GS reset\n");
 
 	// FIXME: memset(m_mem.m_vm8, 0, m_mem.m_vmsize); // bios logo not shown cut in half after reset, missing graphics in GoW after first FMV
-	memset(&m_path[0], 0, sizeof(m_path[0]) * countof(m_path));
-	memset(&m_v, 0, sizeof(m_v));
+	memset(static_cast<void *>(&m_path[0]), 0, sizeof(m_path[0]) * countof(m_path));
+	memset(static_cast<void *>(&m_v), 0, sizeof(m_v));
 
 //	PRIM = &m_env.PRIM;
 //	m_env.PRMODECONT.AC = 1;
@@ -1505,7 +1505,7 @@ void GSState::FlushPrim()
 
 		if(unused > 0)
 		{
-			memcpy(m_vertex.buff, buff, sizeof(GSVertex) * unused);
+			memcpy(static_cast<void *>(m_vertex.buff), buff, sizeof(GSVertex) * unused);
 
 			m_vertex.tail = unused;
 			m_vertex.next = next > head ? next - head : 0;
@@ -1861,12 +1861,12 @@ void GSState::SoftReset(uint32 mask)
 {
 	if(mask & 1)
 	{
-		memset(&m_path[0], 0, sizeof(GIFPath));
-		memset(&m_path[3], 0, sizeof(GIFPath));
+		memset(static_cast<void *>(&m_path[0]), 0, sizeof(GIFPath));
+		memset(static_cast<void *>(&m_path[3]), 0, sizeof(GIFPath));
 	}
 
-	if(mask & 2) memset(&m_path[1], 0, sizeof(GIFPath));
-	if(mask & 4) memset(&m_path[2], 0, sizeof(GIFPath));
+	if(mask & 2) memset(static_cast<void *>(&m_path[1]), 0, sizeof(GIFPath));
+	if(mask & 4) memset(static_cast<void *>(&m_path[2]), 0, sizeof(GIFPath));
 
 	m_env.TRXDIR.XDIR = 3; //-1 ; set it to invalid value
 
@@ -2400,7 +2400,7 @@ void GSState::GrowVertexBuffer()
 
 	if(m_vertex.buff != NULL)
 	{
-		memcpy(vertex, m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
+		memcpy(static_cast<void *>(vertex), m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
 
 		_aligned_free(m_vertex.buff);
 	}

--- a/plugins/GSdx_legacy/GSTextureCache.cpp
+++ b/plugins/GSdx_legacy/GSTextureCache.cpp
@@ -1525,7 +1525,7 @@ void GSTextureCache::Source::Flush(uint32 count)
 	if(count < m_write.count)
 	{
 		// Warning src and destination overlap. Memmove must be used instead of memcpy
-		memmove(&m_write.rect[0], &m_write.rect[count], (m_write.count - count) * sizeof(m_write.rect[0]));
+		memmove(static_cast<void *>(&m_write.rect[0]), &m_write.rect[count], (m_write.count - count) * sizeof(m_write.rect[0]));
 	}
 
 	m_write.count -= count;

--- a/plugins/GSdx_legacy/GSVector.h
+++ b/plugins/GSdx_legacy/GSVector.h
@@ -1876,7 +1876,7 @@ public:
 
 		if(size == 0) return;
 
-		memcpy(d, s, size);
+		memcpy(static_cast<void *>(d), s, size);
 	}
 
 	__forceinline static void transpose(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d)

--- a/plugins/spu2-x/src/SndOut.cpp
+++ b/plugins/spu2-x/src/SndOut.cpp
@@ -282,7 +282,7 @@ void SndBuffer::ReadSamples(T *bData)
     // If quietSamples != 0 it means we have an underrun...
     // Let's just dull out some silence, because that's usually the least
     // painful way of dealing with underruns:
-    memset(bData, 0, quietSamples * sizeof(T));
+    memset(static_cast<void *>(bData), 0, quietSamples * sizeof(T));
 }
 
 template void SndBuffer::ReadSamples(StereoOut16 *);
@@ -390,8 +390,8 @@ void SndBuffer::Init()
 
     // clear buffers!
     // Fixes loopy sounds on emu resets.
-    memset(sndTempBuffer, 0, sizeof(StereoOut32) * SndOutPacketSize);
-    memset(sndTempBuffer16, 0, sizeof(StereoOut16) * SndOutPacketSize);
+    memset(static_cast<void *>(sndTempBuffer), 0, sizeof(StereoOut32) * SndOutPacketSize);
+    memset(static_cast<void *>(sndTempBuffer16), 0, sizeof(StereoOut16) * SndOutPacketSize);
 
     sndTempProgress = 0;
 
@@ -445,7 +445,7 @@ void SndBuffer::Write(const StereoOut32 &Sample)
     //Don't play anything directly after loading a savestate, avoids static killing your speakers.
     if (ssFreeze > 0) {
         ssFreeze--;
-        memset(sndTempBuffer, 0, sizeof(StereoOut32) * SndOutPacketSize); // Play silence
+        memset(static_cast<void *>(sndTempBuffer), 0, sizeof(StereoOut32) * SndOutPacketSize); // Play silence
     }
 #ifndef __POSIX__
     if (dspPluginEnabled) {

--- a/plugins/spu2-x/src/spu2sys.cpp
+++ b/plugins/spu2-x/src/spu2sys.cpp
@@ -118,7 +118,7 @@ V_Core::~V_Core() throw()
 void V_Core::Init(int index)
 {
     ConLog("* SPU2-X: Init SPU2 core %d \n", index);
-    memset(this, 0, sizeof(V_Core));
+    memset(static_cast<void *>(this), 0, sizeof(V_Core));
     psxmode = false;
 
     const int c = Index = index;


### PR DESCRIPTION
gcc-8.2.0 prints this warning many times over making it hard to read the compile output.
```
[ 99%] Building CXX object pcsx2/CMakeFiles/PCSX2.dir/x86/newVif_UnpackSSE.cpp.o
In file included from /tmp/SBo/pcsx2/pcsx2/./PrecompiledHeader.h:80,
                 from /tmp/SBo/pcsx2/pcsx2/x86/ix86-32/iR5900Shift.cpp:17:
/tmp/SBo/pcsx2/common/include/Utilities/MemcpyFast.h: In instantiation of ‘void memzero(T&) [with T = LegacyPluginAPI_Common]’:
/tmp/SBo/pcsx2/pcsx2/./Plugins.h:212:18:   required from here
/tmp/SBo/pcsx2/common/include/Utilities/MemcpyFast.h:32:11: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct LegacyPluginAPI_Common’; use assignment or value-initialization instead [-Wclass-memaccess]
     memset(&object, 0, sizeof(T));
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
In file included from /tmp/SBo/pcsx2/pcsx2/./CDVD/CDVDaccess.h:18,
                 from /tmp/SBo/pcsx2/pcsx2/./System.h:22,
                 from /tmp/SBo/pcsx2/pcsx2/./Common.h:25,
                 from /tmp/SBo/pcsx2/pcsx2/x86/ix86-32/iR5900Shift.cpp:19:
/tmp/SBo/pcsx2/pcsx2/./Plugins.h:194:8: note: ‘struct LegacyPluginAPI_Common’ declared here
 struct LegacyPluginAPI_Common
        ^~~~~~~~~~~~~~~~~~~~~~
```
I tested this locally and it seems to work, but I'm not sure this is the best way to solve this so please review to make sure its right, thanks!

For reference here is the build log.

Before - http://0x0.st/sJgp.log
After - http://0x0.st/sJgf.log

To get a good idea of how verbose these warnings are...
```
$ du -h pcsx2.*
1.1M	pcsx2.1.log
372K	pcsx2.2.log
```