### PR TITLE
utilities: Restrict pxWindowAndFlag templates to wxObject derived classes

### DIFF
--- a/common/include/Utilities/wxGuiTools.h
+++ b/common/include/Utilities/wxGuiTools.h
@@ -199,14 +199,14 @@ struct pxWindowAndFlags
 
 extern wxSizerFlags operator&(const wxSizerFlags &_flgs, const wxSizerFlags &_flgs2);
 
-template <typename WinType>
+template <typename WinType, typename = typename std::enable_if<std::is_base_of<wxObject, WinType>::value>::type>
 pxWindowAndFlags<WinType> operator|(WinType *_win, const wxSizerFlags &_flgs)
 {
     pxWindowAndFlags<WinType> result = {_win, _flgs};
     return result;
 }
 
-template <typename WinType>
+template <typename WinType, typename = typename std::enable_if<std::is_base_of<wxObject, WinType>::value>::type>
 pxWindowAndFlags<WinType> operator|(WinType &_win, const wxSizerFlags &_flgs)
 {
     pxWindowAndFlags<WinType> result = {&_win, _flgs};


### PR DESCRIPTION
Fixes a compile error (C2666) on VS2017 15.8 due to the template causing ambiguity issues (It was affecting the std::ostringstream ~~constructor~~, will add this info to the commit message later).