### PR TITLE
Debugger: Make EE kernel region accessible to debugger

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -605,7 +605,7 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 	case 0xB:
 		// [ 8000_0000 - BFFF_FFFF ] kernel
 		// We only need to access the EE kernel (which is 1 MB large)
-		if (lopart <= 0x100000)
+		if (lopart < 0x100000)
 			return true;
 		break;
 	case 0xF:

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -604,7 +604,9 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 	case 0xA:
 	case 0xB:
 		// [ 8000_0000 - BFFF_FFFF ] kernel
-		// return true;
+		// We only need to access the EE kernel (which is 1 MB large)
+		if (lopart <= 0x100000)
+			return true;
 		break;
 	case 0xF:
 		// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack


### PR DESCRIPTION
This PR is _not_ tested! I have not looked into how PCSX2 handles memory accesses, so reading from kernel memory (`0x80000000` and above) may cause issues.

Currently, none of the EE kernel is viewable from the debugger, which poses issues for me when debugging code that makes use of syscalls. This PR should allow the memory region `0x80000000 - 0x800FFFFF` to have readable disassembly.