### PR TITLE
Add System Out as a logging source.

### DIFF
--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -318,6 +318,7 @@ struct SysConsoleLogPack
 {
 	ConsoleLogSource		ELF;
 	ConsoleLogSource		eeRecPerf;
+	ConsoleLogSource		sysoutConsole;
 
 	ConsoleLogFromVM<Color_Cyan>		eeConsole;
 	ConsoleLogFromVM<Color_Yellow>		iopConsole;
@@ -387,8 +388,9 @@ extern void __Log( const char* fmt, ... );
 #define MDEC_LOG		macTrace(IOP.MDEC)
 
 
-#define ELF_LOG			SysConsole.ELF.IsActive()		&& SysConsole.ELF.Write
-#define eeRecPerfLog	SysConsole.eeRecPerf.IsActive()	&& SysConsole.eeRecPerf
-#define eeConLog		SysConsole.eeConsole.IsActive()	&& SysConsole.eeConsole.Write
-#define eeDeci2Log		SysConsole.deci2.IsActive()		&& SysConsole.deci2.Write
-#define iopConLog		SysConsole.iopConsole.IsActive()&& SysConsole.iopConsole.Write
+#define ELF_LOG			SysConsole.ELF.IsActive()			&& SysConsole.ELF.Write
+#define eeRecPerfLog	SysConsole.eeRecPerf.IsActive()		&& SysConsole.eeRecPerf
+#define eeConLog		SysConsole.eeConsole.IsActive()		&& SysConsole.eeConsole.Write
+#define eeDeci2Log		SysConsole.deci2.IsActive()			&& SysConsole.deci2.Write
+#define iopConLog		SysConsole.iopConsole.IsActive()	&& SysConsole.iopConsole.Write
+#define sysConLog		SysConsole.sysoutConsole.IsActive()	&& SysConsole.sysoutConsole.Write

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -982,6 +982,8 @@ void SYSCALL()
 			}
 			else
 				__Deci2Call(cpuRegs.GPR.n.a0.UL[0], (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
+
+			break;
 		}
 		case Syscall::sysPrintOut:
 		{

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -983,14 +983,27 @@ void SYSCALL()
 			else
 				__Deci2Call(cpuRegs.GPR.n.a0.UL[0], (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
 		}
-		break;
 		case Syscall::sysPrintOut:
 		{
-			if (cpuRegs.GPR.n.a0.UL[0] != 0)
+			if (memRead32(cpuRegs.GPR.n.a0.UL[0]) != 0)
 			{
-				sysConLog(ShiftJIS_ConvertString((char*)PSM(cpuRegs.GPR.n.a0.UL[0])));
+				// TODO: Only supports 7 format arguments. Need to read from the stack for more.
+				// Is there a function which collects PS2 arguments?
+				sysConLog(
+					ShiftJIS_ConvertString((char*)PSM(cpuRegs.GPR.n.a0.UL[0])),
+					cpuRegs.GPR.n.a1.UL[0],
+					cpuRegs.GPR.n.a2.UL[0],
+					cpuRegs.GPR.n.a3.UL[0],
+					cpuRegs.GPR.n.t0.UL[0],
+					cpuRegs.GPR.n.t1.UL[0],
+					cpuRegs.GPR.n.t2.UL[0],
+					cpuRegs.GPR.n.t3.UL[0]
+				);
 			}
+			break;
 		}
+		
+
 		default:
 			break;
 	}

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -984,7 +984,13 @@ void SYSCALL()
 				__Deci2Call(cpuRegs.GPR.n.a0.UL[0], (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
 		}
 		break;
-
+		case Syscall::sysPrintOut:
+		{
+			if (cpuRegs.GPR.n.a0.UL[0] != 0)
+			{
+				sysConLog(ShiftJIS_ConvertString((char*)PSM(cpuRegs.GPR.n.a0.UL[0])));
+			}
+		}
 		default:
 			break;
 	}

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -987,7 +987,7 @@ void SYSCALL()
 		}
 		case Syscall::sysPrintOut:
 		{
-			if (memRead32(cpuRegs.GPR.n.a0.UL[0]) != 0)
+			if (cpuRegs.GPR.n.a0.UL[0] != 0)
 			{
 				// TODO: Only supports 7 format arguments. Need to read from the stack for more.
 				// Is there a function which collects PS2 arguments?

--- a/pcsx2/R5900OpcodeTables.h
+++ b/pcsx2/R5900OpcodeTables.h
@@ -21,6 +21,7 @@ enum Syscall : u8
 {
 	SetGsCrt = 2,
 	SetVTLBRefillHandler = 13,
+	sysPrintOut = 117,
 	sceSifSetDma = 119,
 	Deci2Call = 124
 };

--- a/pcsx2/SourceLog.cpp
+++ b/pcsx2/SourceLog.cpp
@@ -114,14 +114,20 @@ TLD_iopConsole = {
 TLD_deci2 = {
 	L"DECI2",		L"DECI&2 Console",
 	pxDt("Shows DECI2 debugging logs (EE processor)")
+},
+
+TLD_sysoutConsole = {
+	L"SYSout",		L"System Out",
+	pxDt("Shows strings printed to the system output stream.")
 };
 
 SysConsoleLogPack::SysConsoleLogPack()
-	: ELF		(&TLD_ELF, Color_Gray)
-	, eeRecPerf	(&TLD_eeRecPerf, Color_Gray)
-	, eeConsole	(&TLD_eeConsole)
-	, iopConsole(&TLD_iopConsole)
-	, deci2		(&TLD_deci2)
+	: ELF		   (&TLD_ELF, Color_Gray)
+	, eeRecPerf	   (&TLD_eeRecPerf, Color_Gray)
+	, sysoutConsole(&TLD_sysoutConsole, Color_Gray)
+	, eeConsole	   (&TLD_eeConsole)
+	, iopConsole   (&TLD_iopConsole)
+	, deci2		   (&TLD_deci2)
 {
 }
 

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -294,6 +294,7 @@ static ConsoleLogSource* const ConLogSources[] =
 	NULL,
 	(ConsoleLogSource*)&pxConLog_Event,
 	(ConsoleLogSource*)&pxConLog_Thread,
+	(ConsoleLogSource*)&SysConsole.sysoutConsole
 };
 
 // WARNING ConsoleLogSources & ConLogDefaults must have the same size
@@ -303,6 +304,7 @@ static const bool ConLogDefaults[] =
 	true,
 	false,
 	true,
+	false,
 	false,
 	false,
 	false,


### PR DESCRIPTION
Implements system out logging in PCSX2 console. The basic concept is explained in [this issue](https://github.com/PCSX2/pcsx2/issues/2558).

Example video:
https://gfycat.com/ThornyUnfinishedAplomadofalcon

In addition, this solution supports `printf` formatting, forgoing the need for the user to format the string in-game. By calling SYSCALL 0x75 with an unformatted string and arguments, PCSX2 will format the string.

This PR still needs a bit of polish. PCSX2 doesn't pull arguments from the stack to print them in this current implementation, meaning only up to 7 format arguments are used. If there is already a function that aggregates PS2 arguments it might be better utilized here as well. Additionally, another concern is that ConsoleLogSource always appends a newline character when writing text, and it's not necessarily something that may be preferable, though adding a method to write with ConsoleLogSource without a newline would be a lot of work and not necessarily within the scope of this PR. However, if you're pulling development/homebrew messages, these tend to already have newlines at the end of the message and thus you end up with having a lot of empty lines.


EDIT: To clarify on the newline thing, I think we can assume that if the user is a game developer and printing their own strings, or is a user that is restoring console functionality in a PS2 game that those strings already properly have a newline if necessary anyways. Thus I believe that the optimal solution probably would be a IConsoleWriter implementation that does not force newlines, and also provides formatting capabilities, though I would like to hear the opinions of others.