### PR TITLE
debugger: Reset breakpoint skip on boot

### DIFF
--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1089,6 +1089,7 @@ protected:
 
 		CoreThread.ResetQuick();
 		symbolMap.Clear();
+		CBreakPoints::SetSkipFirst(0);
 
 		CDVDsys_SetFile(CDVD_SourceType::Iso, g_Conf->CurrentIso );
 		if( m_UseCDVDsrc )


### PR DESCRIPTION
Fixes an issue where the first breakpoint after rebooting a game may be skipped if the following sequence takes place:
 - The first breakpoint after booting the game is triggered once.
 - The user hits run to resume the game.
 - The user reboots the game without any other breakpoint being triggered.

Fixes #2306.