### PR TITLE
pcsx2|utilities: Remove potentially ambiguous wxString-related overloads

### DIFF
--- a/common/include/Utilities/Assertions.h
+++ b/common/include/Utilities/Assertions.h
@@ -185,9 +185,6 @@ extern pxDoAssertFnType *pxDoAssert;
 #define IndexBoundsAssumeDev(objname, idx, sze) pxAssumeDev((uint)(idx) < (uint)(sze), \
                                                             pxsFmt(L"Array index out of bounds accessing object '%s' (index=%d, size=%d)", objname, (idx), (sze)))
 
-
-extern void pxOnAssert(const DiagnosticOrigin &origin, const wxChar *msg = NULL);
-extern void pxOnAssert(const DiagnosticOrigin &origin, const char *msg);
 extern void pxOnAssert(const DiagnosticOrigin &origin, const wxString &msg);
 extern void pxOnAssert(const DiagnosticOrigin &origin, const FastFormatUnicode &msg);
 

--- a/common/include/Utilities/wxGuiTools.h
+++ b/common/include/Utilities/wxGuiTools.h
@@ -680,8 +680,7 @@ protected:
     wxPoint m_curpos;
     int m_leading;
 
-    virtual void _DoWriteLn(const wxChar *msg);
-    void _DoWriteLn(const wxString msg);
+    virtual void _DoWriteLn(const wxString &msg);
     void _DoWrite(const wxChar *msg);
 
 public:

--- a/common/src/Utilities/Exceptions.cpp
+++ b/common/src/Utilities/Exceptions.cpp
@@ -95,7 +95,7 @@ bool pxAssertImpl_LogIt(const DiagnosticOrigin &origin, const wxChar *msg)
 }
 
 
-DEVASSERT_INLINE void pxOnAssert(const DiagnosticOrigin &origin, const wxChar *msg)
+DEVASSERT_INLINE void pxOnAssert(const DiagnosticOrigin &origin, const wxString &msg)
 {
     // Recursion guard: Allow at least one recursive call.  This is useful because sometimes
     // we get meaningless assertions while unwinding stack traces after exceptions have occurred.
@@ -122,16 +122,6 @@ DEVASSERT_INLINE void pxOnAssert(const DiagnosticOrigin &origin, const wxChar *m
     if (trapit) {
         pxTrap();
     }
-}
-
-__fi void pxOnAssert(const DiagnosticOrigin &origin, const char *msg)
-{
-    pxOnAssert(origin, fromUTF8(msg));
-}
-
-__fi void pxOnAssert(const DiagnosticOrigin &origin, const wxString &msg)
-{
-    pxOnAssert(origin, msg.wc_str());
 }
 
 __fi void pxOnAssert(const DiagnosticOrigin &origin, const FastFormatUnicode &msg)

--- a/common/src/Utilities/pxWindowTextWriter.cpp
+++ b/common/src/Utilities/pxWindowTextWriter.cpp
@@ -84,7 +84,7 @@ pxWindowTextWriter &pxWindowTextWriter::MoveY(int ydelta)
     return *this;
 }
 
-void pxWindowTextWriter::_DoWriteLn(const wxChar *msg)
+void pxWindowTextWriter::_DoWriteLn(const wxString &msg)
 {
     pxAssert(msg);
 
@@ -101,11 +101,6 @@ void pxWindowTextWriter::_DoWriteLn(const wxChar *msg)
 
     m_dc.DrawText(msg, dispos);
     m_curpos.y += tHeight + m_leading;
-}
-
-void pxWindowTextWriter::_DoWriteLn(const wxString msg)
-{
-    _DoWriteLn(msg.wc_str());
 }
 
 // Splits incoming multi-line strings into pieces, and dispatches each line individually

--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -227,7 +227,7 @@ public:
 
 	ConsoleLogFromVM( const TraceLogDescriptor* desc ) : _parent( desc ) {}
 
-	bool Write( const wxChar* msg ) const
+	bool Write( const wxString &msg ) const
 	{
 		ConsoleColorScope cs(conColor);
 		Console.WriteRaw( msg );
@@ -239,12 +239,6 @@ public:
 
 		return false;
 	}
-
-	bool Write( const wxString msg ) const
-	{
-		return Write(msg.wc_str());
-	}
-
 };
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Avoid some function overloads that can accept char*, wxChar* and wxString as a parameter. wxString can be constructed with either of those parameters, so the function overloads may actually result in ambiguity errors. Keep the wxString parameter versions and remove the rest.

Fixes some compile errors on FreeBSD.