### PR TITLE
PCSX2: Save/load slot improvements

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -343,6 +343,7 @@ set(pcsx2GuiHeaders
 	gui/Panels/MemoryCardPanels.h
 	gui/pxEventThread.h
 	gui/RecentIsoList.h
+	gui/Saveslots.h
 	)
 
 # Warning: the declaration of the .h are mandatory in case of resources files. It will ensure the creation

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -236,6 +236,7 @@ void SysCoreThread::GameStartingInThread()
 	sApp.PostAppMethod(&Pcsx2App::resetDebugger);
 
 	ApplyLoadedPatches(PPT_ONCE_ON_LOAD);
+	UI_UpdateSysControls();
 }
 
 bool SysCoreThread::StateCheckInThread()

--- a/pcsx2/gui/AppSaveStates.h
+++ b/pcsx2/gui/AppSaveStates.h
@@ -17,6 +17,7 @@
 
 #include "App.h"
 #include "SaveState.h"
+#include "Saveslots.h"
 
 // --------------------------------------------------------------------------------------
 //  SysExecEvent_SaveSinglePlugin
@@ -60,15 +61,3 @@ extern void StateCopy_SaveToFile( const wxString& file );
 extern void StateCopy_LoadFromFile( const wxString& file );
 extern void StateCopy_SaveToSlot( uint num );
 extern void StateCopy_LoadFromSlot( uint slot, bool isFromBackup = false );
-
-extern void States_registerLoadBackupMenuItem( wxMenuItem* loadBackupMenuItem );
-
-extern bool States_isSlotUsed(int num);
-extern void States_DefrostCurrentSlotBackup();
-extern void States_DefrostCurrentSlot();
-extern void States_FreezeCurrentSlot();
-extern void States_CycleSlotForward();
-extern void States_CycleSlotBackward();
-
-extern void States_SetCurrentSlot( int slot );
-extern int  States_GetCurrentSlot();

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -28,6 +28,7 @@
 #include "AppAccelerators.h"
 
 #include "svnrev.h"
+#include "Saveslots.h"
 
 // ------------------------------------------------------------------------
 wxMenu* MainEmuFrame::MakeStatesSubMenu( int baseid, int loadBackupId ) const
@@ -36,18 +37,18 @@ wxMenu* MainEmuFrame::MakeStatesSubMenu( int baseid, int loadBackupId ) const
 
 	for (int i = 0; i < 10; i++)
 	{
-		mnuSubstates->Append( baseid+i+1, wxsFormat(_("Slot %d"), i) );
+		// Will be changed once an iso is loaded.
+		mnuSubstates->Append(baseid + i + 1, wxsFormat(_("Slot %d"), i));
 	}
-	if( loadBackupId>=0 )
+
+	if (loadBackupId >= 0)
 	{
 		mnuSubstates->AppendSeparator();
 
-		wxMenuItem* m = mnuSubstates->Append( loadBackupId,	_("Backup") );
+		wxMenuItem* m = mnuSubstates->Append(loadBackupId, _("Backup"));
 		m->Enable( false );
-		States_registerLoadBackupMenuItem( m );
 	}
 
-	//mnuSubstates->Append( baseid - 1,	_("Other...") );
 	return mnuSubstates;
 }
 
@@ -787,4 +788,3 @@ void PerPluginMenuInfo::OnLoaded()
 	);
 	MyMenu.Enable( GetPluginMenuId_Settings(PluginId), true );
 }
-

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -137,6 +137,7 @@ public:
 	void UpdateIsoSrcSelection();
 	void RemoveCdvdMenu();
 	void EnableMenuItem( int id, bool enable );
+	void SetMenuItemLabel(int id, wxString str);
 	void EnableCdvdPluginSubmenu(bool isEnable = true);
 	
 	bool Destroy();

--- a/pcsx2/gui/Saveslots.h
+++ b/pcsx2/gui/Saveslots.h
@@ -1,0 +1,100 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2018  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "PS2Edefs.h"
+#include "System.h"
+#include "Elfheader.h"
+
+class Saveslot
+{
+public:
+	u32 slot_num;
+	bool empty;
+	wxDateTime updated;
+	u32 crc;
+
+	Saveslot()
+	{
+		slot_num = 0;
+		empty = true;
+		updated = wxInvalidDateTime;
+		crc = ElfCRC;
+	}
+
+	Saveslot(int i)
+	{
+		slot_num = i;
+		empty = true;
+		updated = wxInvalidDateTime;
+		crc = ElfCRC;
+	}
+
+	bool isUsed()
+	{
+		return wxFileExists(SaveStateBase::GetFilename(slot_num));
+	}
+
+	wxDateTime GetTimestamp()
+	{
+		if (!isUsed()) return wxInvalidDateTime;
+
+		return wxDateTime(wxFileModificationTime(SaveStateBase::GetFilename(slot_num)));
+	}
+
+	void UpdateCache()
+	{
+		empty = !isUsed();
+		updated = GetTimestamp();
+		crc = ElfCRC;
+	}
+
+	wxString SlotName()
+	{
+		if (empty) return wxsFormat(_("Slot %d - Empty"), slot_num);
+
+		if (updated != wxInvalidDateTime) return wxsFormat(_("Slot %d - %s %s"), slot_num, updated.FormatDate(), updated.FormatTime());
+
+		return wxsFormat(_("Slot %d - Unknown Time"), slot_num);
+	}
+
+	void ConsoleDump()
+	{
+		Console.WriteLn("Slot %i information:", slot_num);
+		Console.WriteLn("Internal CRC = %i; Current CRC = %i.", crc, ElfCRC);
+		if (empty)
+			Console.WriteLn("Slot cache says it is empty.");
+		else
+			Console.WriteLn("Slot cache says it is used.");
+
+		if (updated != wxInvalidDateTime)
+			Console.WriteLn(wxsFormat(_("Write time is %s %s."), updated.FormatDate(), updated.FormatTime()));
+
+		if (isUsed())
+			Console.WriteLn(wxsFormat(_("The disk has a file on it dated %s %s."), GetTimestamp().FormatDate(), GetTimestamp().FormatTime()));
+	}
+};
+
+extern Saveslot saveslot_cache[10];
+extern void States_DefrostCurrentSlotBackup();
+extern void States_DefrostCurrentSlot();
+extern void States_FreezeCurrentSlot();
+extern void States_CycleSlotForward();
+extern void States_CycleSlotBackward();
+extern void States_SetCurrentSlot(int slot);
+extern int States_GetCurrentSlot();
+extern void Sstates_updateLoadBackupMenuItem(bool isBeforeSave);

--- a/pcsx2/gui/SysState.cpp
+++ b/pcsx2/gui/SysState.cpp
@@ -476,6 +476,7 @@ protected:
 
 	void CleanupEvent()
 	{
+		UI_UpdateSysControls();
 	}
 };
 
@@ -674,6 +675,7 @@ void StateCopy_SaveToSlot( uint num )
 	Console.Indent().WriteLn( Color_StrongGreen, L"filename: %s", WX_STR(file) );
 
 	StateCopy_SaveToFile( file );
+	UI_UpdateSysControls();
 }
 
 void StateCopy_LoadFromSlot( uint slot, bool isFromBackup )
@@ -690,4 +692,5 @@ void StateCopy_LoadFromSlot( uint slot, bool isFromBackup )
 	Console.Indent().WriteLn( Color_StrongGreen, L"filename: %s", WX_STR(file) );
 
 	StateCopy_LoadFromFile( file );
+	UI_UpdateSysControls();
 }

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -19,84 +19,119 @@
 
 // General Notes:
 //  * It's very important that we re-discover menu items by ID every time we change them,
-//    because the modern era of configurable GUIs means that we can't be assured the IDs
-//    exist anymore.
+//	because the modern era of configurable GUIs means that we can't be assured the IDs
+//	exist anymore.
 
 
 // This is necessary because this stupid wxWidgets thing has implicit debug errors
 // in the FindItem call that asserts if the menu options are missing.  This is bad
 // mojo for configurable/dynamic menus. >_<
-void MainEmuFrame::EnableMenuItem( int id, bool enable )
+void MainEmuFrame::EnableMenuItem(int id, bool enable)
 {
-	if( wxMenuItem* item = m_menubar.FindItem(id) )
-		item->Enable( enable );
+	if (wxMenuItem *item = m_menubar.FindItem(id))
+		item->Enable(enable);
 }
 
-static void _SaveLoadStuff( bool enabled )
+void MainEmuFrame::SetMenuItemLabel(int id, wxString str)
 {
-	sMainFrame.EnableMenuItem( MenuId_Sys_LoadStates, enabled );
-	sMainFrame.EnableMenuItem( MenuId_Sys_SaveStates, enabled );
+	if (wxMenuItem *item = m_menubar.FindItem(id))
+		item->SetItemLabel(str);
+}
+
+static void _SaveLoadStuff(bool enabled)
+{
+	sMainFrame.EnableMenuItem(MenuId_Sys_LoadStates, enabled);
+	sMainFrame.EnableMenuItem(MenuId_Sys_SaveStates, enabled);
+
+	for (int i = 0; i < 10; i++)
+	{
+		int load_menu_item = MenuId_State_Load01 + i + 1;
+		int save_menu_item = MenuId_State_Save01 + i + 1;
+
+		// If the cache is out of sync with the actual files, we need to update things. First update, the cache'll be blank, and this will populate everything.
+		if (saveslot_cache[i].empty == saveslot_cache[i].isUsed())
+		{
+			// If there is actually a file there, or the cache was for a different game, we force an update.
+			// If the cache says there's a saveslot for the current game that there isn't a file for, writing it is done in a different thread,
+			// so it might not be written yet. Which is why I cache to begin with. 
+			if (saveslot_cache[i].isUsed() || (saveslot_cache[i].crc != ElfCRC)) 
+			{
+				saveslot_cache[i].UpdateCache();
+			}
+		}
+
+		sMainFrame.EnableMenuItem(load_menu_item, !saveslot_cache[i].empty);
+		sMainFrame.SetMenuItemLabel(load_menu_item, saveslot_cache[i].SlotName());
+		sMainFrame.SetMenuItemLabel(save_menu_item, saveslot_cache[i].SlotName());
+	}
+	Sstates_updateLoadBackupMenuItem(false);
 }
 
 // Updates the enable/disable status of all System related controls: menus, toolbars,
 // etc.  Typically called by SysEvtHandler whenever the message pump becomes idle.
 void UI_UpdateSysControls()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_UpdateSysControls ) ) return;
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_UpdateSysControls))
+		return;
 
-	sApp.PostAction( CoreThreadStatusEvent( CoreThread_Indeterminate ) );
+	sApp.PostAction(CoreThreadStatusEvent(CoreThread_Indeterminate));
 
-	//_SaveLoadStuff( true );
-	_SaveLoadStuff( SysHasValidState() );
+	_SaveLoadStuff(SysHasValidState());
 }
 
 void UI_DisableSysShutdown()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_DisableSysShutdown ) ) return;
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_DisableSysShutdown))
+		return;
 
-	sMainFrame.EnableMenuItem( MenuId_Sys_Shutdown, false );
+	sMainFrame.EnableMenuItem(MenuId_Sys_Shutdown, false);
 	sMainFrame.EnableMenuItem(MenuId_IsoBrowse, !g_Conf->AskOnBoot);
 	wxGetApp().GetRecentIsoManager().EnableItems(!g_Conf->AskOnBoot);
 }
 
 void UI_EnableSysShutdown()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_EnableSysShutdown ) ) return;
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_EnableSysShutdown))
+		return;
 
-	sMainFrame.EnableMenuItem( MenuId_Sys_Shutdown, true );
+	sMainFrame.EnableMenuItem(MenuId_Sys_Shutdown, true);
 }
 
 
 void UI_DisableSysActions()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_DisableSysActions ) ) return;
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_DisableSysActions))
+		return;
 
-	sMainFrame.EnableMenuItem( MenuId_Sys_Shutdown, false );
-	
-	_SaveLoadStuff( false );
+	sMainFrame.EnableMenuItem(MenuId_Sys_Shutdown, false);
+
+	_SaveLoadStuff(false);
 }
 
 void UI_EnableSysActions()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_EnableSysActions ) ) return;
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_EnableSysActions))
+		return;
 
-	sMainFrame.EnableMenuItem( MenuId_Sys_Shutdown, true );
+	sMainFrame.EnableMenuItem(MenuId_Sys_Shutdown, true);
 	sMainFrame.EnableMenuItem(MenuId_IsoBrowse, true);
 	wxGetApp().GetRecentIsoManager().EnableItems(true);
-	
-	_SaveLoadStuff( true );
+
+	_SaveLoadStuff(true);
 }
 
 void UI_DisableStateActions()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_DisableStateActions ) ) return;
-	_SaveLoadStuff( false );
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_DisableStateActions))
+		return;
+
+	_SaveLoadStuff(false);
 }
 
 void UI_EnableStateActions()
 {
-	if( wxGetApp().Rpc_TryInvokeAsync( &UI_EnableStateActions ) ) return;
-	_SaveLoadStuff( true );
+	if (wxGetApp().Rpc_TryInvokeAsync(&UI_EnableStateActions))
+		return;
+
+	_SaveLoadStuff(true);
 }
-
-

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -427,6 +427,7 @@
     <ClInclude Include="..\..\GameDatabase.h" />
     <ClInclude Include="..\..\Gif_Unit.h" />
     <ClInclude Include="..\..\gui\AppGameDatabase.h" />
+    <ClInclude Include="..\..\gui\Saveslots.h" />
     <ClInclude Include="..\..\gui\Debugger\BreakpointWindow.h" />
     <ClInclude Include="..\..\gui\Debugger\CtrlDisassemblyView.h" />
     <ClInclude Include="..\..\gui\Debugger\CtrlMemView.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -1197,6 +1197,9 @@
     <ClInclude Include="..\..\gui\RecentIsoList.h">
       <Filter>AppHost\Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\gui\Saveslots.h">
+      <Filter>AppHost\Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\cheats\cheats.h">
       <Filter>AppHost\Cheats</Filter>
     </ClInclude>


### PR DESCRIPTION
I figured this one was enough to do a PR request on rather than committing.

With these changes, saveslots will be labeled as either empty or with the date that the file was last updated on. The menu items for loading them are also disabled if the slot is empty.

It's possible if you are very fast to access the menu before the slots change. It updates when the crc changes. When you save a saveslot, the menu item also changes to show the time you told it to save until the file is actually done saving.

Finding times for it to update the ui was a bit tricky. This was tested with Linux, but not Windows, and was tested with Isos, but not actual disks (no dvd drive on the computer I was testing with).

Testing, fixes and improvements are welcome, and if there's anything I should do differently next time I do a PR, let me know...

Close #2073