### PR TITLE
utilities: Split thread internal callback function

### DIFF
--- a/common/include/Utilities/PersistentThread.h
+++ b/common/include/Utilities/PersistentThread.h
@@ -200,6 +200,7 @@ protected:
     void _ThreadCleanup();
 
     static void *_internal_callback(void *func);
+    static void internal_callback_helper(void *func);
     static void _pt_callback_cleanup(void *handle);
 };
 

--- a/common/src/Utilities/Exceptions.cpp
+++ b/common/src/Utilities/Exceptions.cpp
@@ -114,9 +114,9 @@ DEVASSERT_INLINE void pxOnAssert(const DiagnosticOrigin &origin, const wxString 
 
     if (pxDoAssert == NULL) {
         // Note: Format uses MSVC's syntax for output window hotlinking.
-        trapit = pxAssertImpl_LogIt(origin, msg);
+        trapit = pxAssertImpl_LogIt(origin, msg.wc_str());
     } else {
-        trapit = pxDoAssert(origin, msg);
+        trapit = pxDoAssert(origin, msg.wc_str());
     }
 
     if (trapit) {

--- a/common/src/Utilities/ThreadTools.cpp
+++ b/common/src/Utilities/ThreadTools.cpp
@@ -685,12 +685,21 @@ void *Threading::pxThread::_internal_callback(void *itsme)
 {
     if (!pxAssertDev(itsme != NULL, wxNullChar))
         return NULL;
-    pxThread &owner = *((pxThread *)itsme);
+
+    internal_callback_helper(itsme);
+    return NULL;
+}
+
+// __try is used in pthread_cleanup_push when CLEANUP_SEH is used as the cleanup model.
+// That can't be used in a function that has objects that require unwinding (compile
+// error C2712), so move it into a separate function.
+void Threading::pxThread::internal_callback_helper(void *itsme)
+{
+    pxThread &owner = *static_cast<pxThread *>(itsme);
 
     pthread_cleanup_push(_pt_callback_cleanup, itsme);
     owner._internal_execute();
     pthread_cleanup_pop(true);
-    return NULL;
 }
 
 void Threading::pxThread::_DoSetThreadName(const wxString &name)


### PR DESCRIPTION
__try is used in pthread_cleanup_push when CLEANUP_SEH is used as the pthread cleanup model. That can't be used in functions with objects that have destructors, so move it into a separate function.

Fixes a non-release build compile error on Windows. Regression was introduced in 93d5b52df34c03a2ed859bba6e06fead3b875e70.