### PR TITLE
pcsx2: Improve GameDB parser

### DIFF
--- a/pcsx2/gui/AppGameDatabase.cpp
+++ b/pcsx2/gui/AppGameDatabase.cpp
@@ -77,7 +77,11 @@ bool DBLoaderHelper::extractMultiLine() {
 	// Use Mid() to strip off the left and right side brackets.
 	wxString midLine(m_dest.Mid(1, m_dest.Length()-2));
 	wxString lvalue(midLine.BeforeFirst(L'=').Trim(true).Trim(false));
-	//wxString rvalue(midLine.AfterFirst(L'=').Trim(true).Trim(false));
+	wxString rvalue(midLine.AfterFirst(L'=').Trim(true).Trim(false));
+
+	wxString key = '[' + lvalue + (rvalue.empty() ? "" : " = ") + rvalue + ']';
+	if (key != m_keyPair.key)
+		Console.Warning("GameDB: Badly formatted section start tag.\nActual: " + m_keyPair.key + "\nExpected: " + key);
 
 	wxString endString;
 	endString.Printf( L"[/%s]", lvalue.c_str() );


### PR DESCRIPTION
Changes:
 * Abort multiline section parsing if the entry separator is found - it prevents bad formatting from eating subsequent GameDB entries.
 * Warn if the GameDB multiline section start tag has incorrect whitespace.

I'm not sure on whether to make the parser more whitespace tolerant on the closing tag. I think the errors/warnings will hint to whoever is editing the GameDB that something isn't quite right.