### PR TITLE
GSdx: TC offset hack related changes

### DIFF
--- a/plugins/GSdx/GSLinuxDialog.cpp
+++ b/plugins/GSdx/GSLinuxDialog.cpp
@@ -436,8 +436,9 @@ void populate_hack_table(GtkWidget* hack_table)
 	GtkWidget* hack_skipdraw_label = left_label("Skipdraw Range:");
 	CreateSkipdrawSpinButtons(0, 10000);
 	GtkWidget* hack_wild_check     = CreateCheckBox("Wild Arms Hack", "UserHacks_WildHack");
-	GtkWidget* hack_tco_label      = left_label("Texture Offset: 0x");
-	GtkWidget* hack_tco_entry      = CreateTextBox("UserHacks_TCOffset");
+	GtkWidget* hack_tco_label      = left_label("Texture Offset:");
+	GtkWidget* hack_tco_x_spin     = CreateSpinButton(0, 10000, "UserHacks_TCOffsetX");
+	GtkWidget* hack_tco_y_spin     = CreateSpinButton(0, 10000, "UserHacks_TCOffsetY");
 	GtkWidget* align_sprite_check  = CreateCheckBox("Align Sprite", "UserHacks_align_sprite_X");
 	GtkWidget* preload_gs_check    = CreateCheckBox("Preload Frame Data", "preload_frame_with_gs_data");
 	GtkWidget* hack_fast_inv       = CreateCheckBox("Fast Texture Invalidation", "UserHacks_DisablePartialInvalidation");
@@ -464,7 +465,8 @@ void populate_hack_table(GtkWidget* hack_table)
 	AddTooltip(hack_wild_check, IDC_WILDHACK);
 	AddTooltip(hack_sprite_label, hack_sprite_box, IDC_SPRITEHACK);
 	AddTooltip(hack_tco_label, IDC_TCOFFSETX);
-	AddTooltip(hack_tco_entry, IDC_TCOFFSETX);
+	AddTooltip(hack_tco_x_spin, IDC_TCOFFSETX);
+	AddTooltip(hack_tco_y_spin, IDC_TCOFFSETX);
 	AddTooltip(align_sprite_check, IDC_ALIGN_SPRITE);
 	AddTooltip(stretch_hack_label, stretch_hack_box, IDC_ROUND_SPRITE);
 	AddTooltip(preload_gs_check, IDC_PRELOAD_GS);
@@ -493,7 +495,7 @@ void populate_hack_table(GtkWidget* hack_table)
 	InsertWidgetInTable(hack_table , hack_sprite_label   , hack_sprite_box );
 	InsertWidgetInTable(hack_table , stretch_hack_label  , stretch_hack_box );
 	InsertWidgetInTable(hack_table , hack_skipdraw_label , s_hack_skipdraw_offset_spin, s_hack_skipdraw_spin);
-	InsertWidgetInTable(hack_table , hack_tco_label      , hack_tco_entry);
+	InsertWidgetInTable(hack_table , hack_tco_label      , hack_tco_x_spin, hack_tco_y_spin);
 }
 
 void populate_main_table(GtkWidget* main_table)

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -33,17 +33,12 @@ GSRendererDX::GSRendererDX(GSTextureCache* tc, const GSVector2& pixelcenter)
 	if (theApp.GetConfigB("UserHacks")) {
 		UserHacks_AlphaHack    = theApp.GetConfigB("UserHacks_AlphaHack");
 		UserHacks_AlphaStencil = theApp.GetConfigB("UserHacks_AlphaStencil");
-		UserHacks_TCOffset     = theApp.GetConfigI("UserHacks_TCOffset");
 		UserHacks_HPO          = theApp.GetConfigI("UserHacks_HalfPixelOffset");
 	} else {
 		UserHacks_AlphaHack    = false;
 		UserHacks_AlphaStencil = false;
-		UserHacks_TCOffset     = 0;
 		UserHacks_HPO          = 0;
 	}
-
-	UserHacks_TCO_x = (UserHacks_TCOffset & 0xFFFF) / -1000.0f;
-	UserHacks_TCO_y = ((UserHacks_TCOffset >> 16) & 0xFFFF) / -1000.0f;
 }
 
 GSRendererDX::~GSRendererDX()
@@ -320,8 +315,8 @@ void GSRendererDX::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	}
 
 	// TC Offset Hack
-	m_ps_sel.tcoffsethack = !!UserHacks_TCOffset;
-	ps_cb.TC_OffsetHack = GSVector4(UserHacks_TCO_x, UserHacks_TCO_y).xyxy() / WH.xyxy();
+	m_ps_sel.tcoffsethack = !!m_userhacks_tcoffset;
+	ps_cb.TC_OffsetHack = GSVector4(m_userhacks_tcoffset_x, m_userhacks_tcoffset_y).xyxy() / WH.xyxy();
 
 	// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader
 	m_ps_ssel.tau = (wms != CLAMP_CLAMP);

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -315,7 +315,7 @@ void GSRendererDX::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	}
 
 	// TC Offset Hack
-	m_ps_sel.tcoffsethack = !!m_userhacks_tcoffset;
+	m_ps_sel.tcoffsethack = m_userhacks_tcoffset;
 	ps_cb.TC_OffsetHack = GSVector4(m_userhacks_tcoffset_x, m_userhacks_tcoffset_y).xyxy() / WH.xyxy();
 
 	// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader

--- a/plugins/GSdx/GSRendererDX.h
+++ b/plugins/GSdx/GSRendererDX.h
@@ -43,8 +43,6 @@ protected:
 	virtual void SetupIA(const float& sx, const float& sy) = 0;
 	virtual void UpdateFBA(GSTexture* rt) {}
 
-	unsigned int UserHacks_TCOffset;
-	float UserHacks_TCO_x, UserHacks_TCO_y;
 	int UserHacks_HPO;
 
 	bool DATE;

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -30,7 +30,7 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_reset(false)
 	, m_upscale_multiplier(1)
 	, m_tc(tc)
-	, m_userhacks_tcoffset(0)
+	, m_userhacks_tcoffset(false)
 	, m_userhacks_tcoffset_x(0)
 	, m_userhacks_tcoffset_y(0)
 	, m_channel_shuffle(false)
@@ -45,9 +45,9 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 		m_userhacks_disable_gs_mem_clear = theApp.GetConfigB("UserHacks_DisableGsMemClear");
 		m_userHacks_HPO                  = theApp.GetConfigI("UserHacks_HalfPixelOffset");
 		m_userHacks_merge_sprite         = theApp.GetConfigB("UserHacks_merge_pp_sprite");
-		m_userhacks_tcoffset             = theApp.GetConfigI("UserHacks_TCOffset");
-		m_userhacks_tcoffset_x           = (m_userhacks_tcoffset & 0xFFFF) / -1000.0f;
-		m_userhacks_tcoffset_y           = ((m_userhacks_tcoffset >> 16) & 0xFFFF) / -1000.0f;
+		m_userhacks_tcoffset_x           = theApp.GetConfigI("UserHacks_TCOffsetX") / -1000.0f;
+		m_userhacks_tcoffset_y           = theApp.GetConfigI("UserHacks_TCOffsetY") / -1000.0f;
+		m_userhacks_tcoffset             = m_userhacks_tcoffset_x < 0.0f || m_userhacks_tcoffset_y < 0.0f;
 	} else {
 		m_userhacks_align_sprite_X       = false;
 		m_userhacks_round_sprite_offset  = 0;

--- a/plugins/GSdx/GSRendererHW.cpp
+++ b/plugins/GSdx/GSRendererHW.cpp
@@ -30,6 +30,9 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_reset(false)
 	, m_upscale_multiplier(1)
 	, m_tc(tc)
+	, m_userhacks_tcoffset(0)
+	, m_userhacks_tcoffset_x(0)
+	, m_userhacks_tcoffset_y(0)
 	, m_channel_shuffle(false)
 	, m_lod(GSVector2i(0,0))
 {
@@ -42,6 +45,9 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 		m_userhacks_disable_gs_mem_clear = theApp.GetConfigB("UserHacks_DisableGsMemClear");
 		m_userHacks_HPO                  = theApp.GetConfigI("UserHacks_HalfPixelOffset");
 		m_userHacks_merge_sprite         = theApp.GetConfigB("UserHacks_merge_pp_sprite");
+		m_userhacks_tcoffset             = theApp.GetConfigI("UserHacks_TCOffset");
+		m_userhacks_tcoffset_x           = (m_userhacks_tcoffset & 0xFFFF) / -1000.0f;
+		m_userhacks_tcoffset_y           = ((m_userhacks_tcoffset >> 16) & 0xFFFF) / -1000.0f;
 	} else {
 		m_userhacks_align_sprite_X       = false;
 		m_userhacks_round_sprite_offset  = 0;

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -150,7 +150,7 @@ protected:
 	int m_userhacks_round_sprite_offset;
 	int m_userHacks_HPO;
 
-	unsigned int m_userhacks_tcoffset;
+	bool m_userhacks_tcoffset;
 	float m_userhacks_tcoffset_x;
 	float m_userhacks_tcoffset_y;
 

--- a/plugins/GSdx/GSRendererHW.h
+++ b/plugins/GSdx/GSRendererHW.h
@@ -150,6 +150,10 @@ protected:
 	int m_userhacks_round_sprite_offset;
 	int m_userHacks_HPO;
 
+	unsigned int m_userhacks_tcoffset;
+	float m_userhacks_tcoffset_x;
+	float m_userhacks_tcoffset_y;
+
 	bool m_channel_shuffle;
 
 	GSVector2i m_lod; // Min & Max level of detail

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -838,7 +838,7 @@ void GSRendererOGL::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	}
 
 	// TC Offset Hack
-	m_ps_sel.tcoffsethack = !!m_userhacks_tcoffset;
+	m_ps_sel.tcoffsethack = m_userhacks_tcoffset;
 	ps_cb.TC_OH_TS = GSVector4(1/16.0f, 1/16.0f, m_userhacks_tcoffset_x, m_userhacks_tcoffset_y) / WH.xyxy();
 
 

--- a/plugins/GSdx/GSRendererOGL.cpp
+++ b/plugins/GSdx/GSRendererOGL.cpp
@@ -34,9 +34,6 @@ GSRendererOGL::GSRendererOGL()
 	// Hope nothing requires too many draw calls.
 	m_drawlist.reserve(2048);
 
-	UserHacks_TCOffset       = theApp.GetConfigI("UserHacks_TCOffset");
-	UserHacks_TCO_x          = (UserHacks_TCOffset & 0xFFFF) / -1000.0f;
-	UserHacks_TCO_y          = ((UserHacks_TCOffset >> 16) & 0xFFFF) / -1000.0f;
 	UserHacks_unscale_pt_ln  = theApp.GetConfigB("UserHacks_unscale_point_line");
 	UserHacks_HPO            = theApp.GetConfigI("UserHacks_HalfPixelOffset");
 	UserHacks_tri_filter     = static_cast<TriFiltering>(theApp.GetConfigI("UserHacks_TriFilter"));
@@ -45,9 +42,6 @@ GSRendererOGL::GSRendererOGL()
 	ResetStates();
 
 	if (!theApp.GetConfigB("UserHacks")) {
-		UserHacks_TCOffset       = 0;
-		UserHacks_TCO_x          = 0;
-		UserHacks_TCO_y          = 0;
 		UserHacks_unscale_pt_ln  = false;
 		UserHacks_HPO            = 0;
 		UserHacks_tri_filter     = TriFiltering::None;
@@ -844,8 +838,8 @@ void GSRendererOGL::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	}
 
 	// TC Offset Hack
-	m_ps_sel.tcoffsethack = !!UserHacks_TCOffset;
-	ps_cb.TC_OH_TS = GSVector4(1/16.0f, 1/16.0f, UserHacks_TCO_x, UserHacks_TCO_y) / WH.xyxy();
+	m_ps_sel.tcoffsethack = !!m_userhacks_tcoffset;
+	ps_cb.TC_OH_TS = GSVector4(1/16.0f, 1/16.0f, m_userhacks_tcoffset_x, m_userhacks_tcoffset_y) / WH.xyxy();
 
 
 	// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader

--- a/plugins/GSdx/GSRendererOGL.h
+++ b/plugins/GSdx/GSRendererOGL.h
@@ -50,8 +50,6 @@ class GSRendererOGL final : public GSRendererHW
 		PRIM_OVERLAP m_prim_overlap;
 		std::vector<size_t> m_drawlist;
 
-		unsigned int UserHacks_TCOffset;
-		float UserHacks_TCO_x, UserHacks_TCO_y;
 		bool UserHacks_unscale_pt_ln;
 		int UserHacks_HPO;
 		TriFiltering UserHacks_tri_filter;

--- a/plugins/GSdx/GSSettingsDlg.cpp
+++ b/plugins/GSdx/GSSettingsDlg.cpp
@@ -712,10 +712,10 @@ void GSHacksDlg::OnInit()
 	SendMessage(GetDlgItem(m_hWnd, IDC_SKIPDRAWHACK), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfigI("UserHacks_SkipDraw"), 0));
 
 	SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETX), UDM_SETRANGE, 0, MAKELPARAM(10000, 0));
-	SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETX), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfigI("UserHacks_TCOffset") & 0xFFFF, 0));
+	SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETX), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfigI("UserHacks_TCOffsetX"), 0));
 
 	SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETY), UDM_SETRANGE, 0, MAKELPARAM(10000, 0));
-	SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETY), UDM_SETPOS, 0, MAKELPARAM((theApp.GetConfigI("UserHacks_TCOffset") >> 16) & 0xFFFF, 0));
+	SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETY), UDM_SETPOS, 0, MAKELPARAM(theApp.GetConfigI("UserHacks_TCOffsetY"), 0));
 
 	// Direct3D-only hacks:
 	EnableWindow(GetDlgItem(m_hWnd, IDC_ALPHASTENCIL), !ogl);
@@ -870,11 +870,8 @@ bool GSHacksDlg::OnMessage(UINT message, WPARAM wParam, LPARAM lParam)
 			theApp.SetConfig("UserHacks_unscale_point_line", (int)IsDlgButtonChecked(m_hWnd, IDC_UNSCALE_POINT_LINE));
 			theApp.SetConfig("wrap_gs_mem", (int)IsDlgButtonChecked(m_hWnd, IDC_MEMORY_WRAPPING));
 			theApp.SetConfig("UserHacks_merge_pp_sprite", (int)IsDlgButtonChecked(m_hWnd, IDC_MERGE_PP_SPRITE));
-
-			unsigned int TCOFFSET  =  SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETX), UDM_GETPOS, 0, 0) & 0xFFFF;
-						 TCOFFSET |= (SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETY), UDM_GETPOS, 0, 0) & 0xFFFF) << 16;
-
-			theApp.SetConfig("UserHacks_TCOffset", TCOFFSET);
+			theApp.SetConfig("UserHacks_TCOffsetX", SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETX), UDM_GETPOS, 0, 0));
+			theApp.SetConfig("UserHacks_TCOffsetY", SendMessage(GetDlgItem(m_hWnd, IDC_TCOFFSETY), UDM_GETPOS, 0, 0));
 
 			EndDialog(m_hWnd, id);
 		} break;

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -444,7 +444,8 @@ void GSdxApp::Init()
 	m_default_configuration["UserHacks_SkipDraw"]                         = "0";
 	m_default_configuration["UserHacks_SkipDraw_Offset"]                  = "0";
 	m_default_configuration["UserHacks_SpriteHack"]                       = "0";
-	m_default_configuration["UserHacks_TCOffset"]                         = "0";
+	m_default_configuration["UserHacks_TCOffsetX"]                        = "0";
+	m_default_configuration["UserHacks_TCOffsetY"]                        = "0";
 	m_default_configuration["UserHacks_TextureInsideRt"]                  = "0";
 	m_default_configuration["UserHacks_TriFilter"]                        = std::to_string(static_cast<int8>(TriFiltering::None));
 	m_default_configuration["UserHacks_WildHack"]                         = "0";


### PR DESCRIPTION
Changes:
 * Move TC offset variables from GSRendererOGL and GSRendererDX to GSRendererHW to avoid some code duplication. Also renames the variables for better consistency.
 * Splits TC offset ini setting into X and Y components - it simplifies loading/saving the TC offset value and also makes it easier to handle in the Linux GSdx GUI (which has been adjusted to use two spin controls instead of one text box). Fixes #2568.