### PR TITLE
GSdx-d3d: Mask alpha channel on 24bit format

### DIFF
--- a/plugins/GSdx/GSDeviceDX.h
+++ b/plugins/GSdx/GSDeviceDX.h
@@ -172,6 +172,7 @@ public:
 				// *** Word 1
 				// Format
 				uint32 fmt:4;
+				uint32 dfmt:2;
 				// Alpha extension/Correction
 				uint32 aem:1;
 				uint32 fba:1;
@@ -203,7 +204,7 @@ public:
 				uint32 tcoffsethack:1;
 				uint32 point_sampler:1;
 
-				uint32 _free:32;
+				uint32 _free:30;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/GSRendererDX.cpp
+++ b/plugins/GSdx/GSRendererDX.cpp
@@ -475,6 +475,12 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 
 	EmulateTextureShuffleAndFbmask();
 
+	if(m_ps_sel.dfmt == 1)
+	{
+		// Disable writing of the alpha channel
+		om_bsel.wa = 0;
+	}
+
 	if(DATE)
 	{
 		if(dev->HasStencil())

--- a/plugins/GSdx/GSRendererDX11.cpp
+++ b/plugins/GSdx/GSRendererDX11.cpp
@@ -50,7 +50,7 @@ void GSRendererDX11::EmulateTextureShuffleAndFbmask()
 	// Note: D3D1011 is limited and can't read the current framebuffer so we can't have PS_FBMASK and PS_WRITE_RG shaders ported and working.
 	if (m_texture_shuffle) {
 		m_ps_sel.shuffle = 1;
-		m_ps_sel.fmt = 0;
+		m_ps_sel.dfmt = 0;
 
 		const GIFRegXYOFFSET& o = m_context->XYOFFSET;
 
@@ -154,7 +154,7 @@ void GSRendererDX11::EmulateTextureShuffleAndFbmask()
 		}
 
 	} else {
-		//m_ps_sel.fmt = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt;
+		m_ps_sel.dfmt = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt;
 
 		om_bsel.wrgba = ~GSVector4i::load((int)m_context->FRAME.FBMSK).eq8(GSVector4i::xffffffff()).mask();
 	}

--- a/plugins/GSdx/GSRendererDX9.cpp
+++ b/plugins/GSdx/GSRendererDX9.cpp
@@ -58,11 +58,16 @@ bool GSRendererDX9::CreateDevice(GSDevice* dev)
 
 void GSRendererDX9::EmulateTextureShuffleAndFbmask()
 {
-	if (m_texture_shuffle) {
+	if (m_texture_shuffle)
+	{
 		// We can do a partial port for D3D9 that skips the draw call to give it a slight improvement.
 		// It's still broken but more bearable. Broken effect is on the screen but fully instead of vertical lines.
 		throw GSDXRecoverableError();
-	} else {
+	} 
+	else
+	{
+		m_ps_sel.dfmt = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmt;
+
 		om_bsel.wrgba = ~GSVector4i::load((int)m_context->FRAME.FBMSK).eq8(GSVector4i::xffffffff()).mask();
 	}
 }


### PR DESCRIPTION
Follow up/ish from #2465 maybe

Port from #555

dfmt is not supported but we can use the variable to select the
frame buffer format and later disable writting to the alpha channel.

MGS3 sees an improvement, and possibly other games as well.
So far didn't spot any regressions.

![d3d-alpha24bit](https://user-images.githubusercontent.com/18107717/45543636-479b8a80-b815-11e8-947e-fb421017969f.png)

I had to skip the channel shuffle draw calls for the image to show a proper comparison since d3d doesn't support it.

Anyway looks like d3d misses channel shuffle now to show a proper picture (minus blending).