### PR TITLE
GSdx-d3d: Move Selector reset states in to a separate function.

### DIFF
--- a/plugins/GSdx/GSRendererDX.h
+++ b/plugins/GSdx/GSRendererDX.h
@@ -34,6 +34,7 @@ class GSRendererDX : public GSRendererHW
 	bool UserHacks_AlphaStencil;
 
 protected:
+	void ResetStates();
 	void EmulateAtst(const int pass, const GSTextureCache::Source* tex);
 	void EmulateZbuffer();
 	void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
@@ -54,12 +55,13 @@ protected:
 
 	GSDeviceDX* dev;
 
-	GSDeviceDX::OMDepthStencilSelector om_dssel;
-	GSDeviceDX::OMBlendSelector om_bsel;
-
-	GSDeviceDX::PSSelector m_ps_sel;
-	GSDeviceDX::PSSamplerSelector m_ps_ssel;
+	GSDeviceDX::VSSelector m_vs_sel;
 	GSDeviceDX::GSSelector m_gs_sel;
+	GSDeviceDX::PSSelector m_ps_sel;
+
+	GSDeviceDX::PSSamplerSelector m_ps_ssel;
+	GSDeviceDX::OMBlendSelector	om_bsel;
+	GSDeviceDX::OMDepthStencilSelector om_dssel;
 
 	GSDeviceDX::PSConstantBuffer ps_cb;
 	GSDeviceDX::VSConstantBuffer vs_cb;


### PR DESCRIPTION
Also move vs_sel def in header file and rename it using the member name.

Code is easier to read/move/adjust similar to GL.