### PR TITLE
GSdx-d3d: Port max_layer mipmap calculation from opengl, update nvidia d3d hack

### DIFF
--- a/plugins/GSdx/GSDevice11.h
+++ b/plugins/GSdx/GSDevice11.h
@@ -54,11 +54,8 @@ class GSDevice11 : public GSDeviceDX
 	CComPtr<ID3D11Buffer> m_ib_old;
 
 	bool m_srv_changed, m_ss_changed;
-	int spritehack;
-	bool isNative;
-
 	bool UserHacks_unscale_pt_ln;
-	bool UserHacks_disable_NV_hack;
+	float m_hack_topleft_offset;
 
 	int m_mipmap;
 

--- a/plugins/GSdx/GSDevice11.h
+++ b/plugins/GSdx/GSDevice11.h
@@ -60,6 +60,8 @@ class GSDevice11 : public GSDeviceDX
 	bool UserHacks_unscale_pt_ln;
 	bool UserHacks_disable_NV_hack;
 
+	int m_mipmap;
+
 	struct
 	{
 		ID3D11Buffer* vb;

--- a/plugins/GSdx/GSDevice9.h
+++ b/plugins/GSdx/GSDevice9.h
@@ -97,6 +97,8 @@ class GSDevice9 : public GSDeviceDX
 	bool m_lost;
 	D3DFORMAT m_depth_format;
 
+	int m_mipmap;
+
 	struct
 	{
 		IDirect3DVertexBuffer9* vb;

--- a/plugins/GSdx/GSTexture11.h
+++ b/plugins/GSdx/GSTexture11.h
@@ -34,6 +34,9 @@ class GSTexture11 : public GSTexture
 	CComPtr<ID3D11RenderTargetView> m_rtv;
 	CComPtr<ID3D11DepthStencilView> m_dsv;
 
+	int m_layer;
+	int m_max_layer;
+
 public:
 	explicit GSTexture11(ID3D11Texture2D* texture);
 

--- a/plugins/GSdx/GSTexture9.h
+++ b/plugins/GSdx/GSTexture9.h
@@ -30,6 +30,11 @@ class GSTexture9 : public GSTexture
 	CComPtr<IDirect3DTexture9> m_texture;
 	D3DSURFACE_DESC m_desc;
 
+	bool m_generate_mipmap;
+
+	int m_layer;
+	int m_max_layer;
+
 public:
 	explicit GSTexture9(IDirect3DSurface9* surface);
 	explicit GSTexture9(IDirect3DTexture9* texture);

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -434,7 +434,6 @@ void GSdxApp::Init()
 	m_default_configuration["UserHacks_DisableDepthSupport"]              = "0";
 	m_default_configuration["UserHacks_CPU_FB_Conversion"]                = "0";
 	m_default_configuration["UserHacks_DisableGsMemClear"]                = "0";
-	m_default_configuration["UserHacks_DisableNVhack"]                    = "0";
 	m_default_configuration["UserHacks_DisablePartialInvalidation"]       = "0";
 	m_default_configuration["UserHacks_HalfPixelOffset"]                  = "0";
 	m_default_configuration["UserHacks_merge_pp_sprite"]                  = "0";


### PR DESCRIPTION
Fixues issue with full mipmapping on D3D11 with textures appearing broken.
Some code still remains to be ported but at least the broken textures issue has been resolved.
Issue #2150 

GSdx-d3d: Update nvidia hack with vendor id detection.
Hack will no longer be active on Intel or AMD gpus.
Close #1026

Commits by: @KrossX 