### PR TITLE
GSdx-d3d: Keep fract in [0;1] range port from OpenGL.

### DIFF
--- a/plugins/GSdx/res/glsl/tfx_fs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_fs.glsl
@@ -428,7 +428,7 @@ vec4 sample_color(vec2 st)
         // Background in Shin Megami Tensei Lucifers
         // I suspect that uv isn't a standard number, so fract is outside of the [0;1] range
         // Note: it is free on GPU but let's do it only for float coordinate
-        // Strangely Dx doesn't suffer from this issue.
+        // Strangely DX9 doesn't suffer from this issue.
         dd = clamp(dd, vec2(0.0f), vec2(1.0f));
 #endif
     }

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -403,6 +403,12 @@ float4 sample(float2 st, float q)
 		{
 			uv = st.xyxy + HalfTexel;
 			dd = frac(uv.xy * WH.zw);
+			#if SHADER_MODEL >= 0x400
+			if(PS_FST == 0)
+			{
+				dd = clamp(dd, (float2)0.0, (float2)0.9999999);
+			}
+			#endif
 		}
 		else
 		{


### PR DESCRIPTION
Another commit from @KrossX oh nice.

Follow up on issue #2057 

Commit:
https://github.com/PCSX2/pcsx2/commit/a8968257db0b3cfaeafa872cdeddd455280802c8

Related PR ?
https://github.com/PCSX2/pcsx2/pull/782

Fixes texture flickering in Oni on d3d11.

Close ##2057