### PR TITLE
GSdx: Wrap negative UV on region repeat wrap mode.

### DIFF
--- a/plugins/GSdx/res/glsl/tfx_fs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_fs.glsl
@@ -127,7 +127,7 @@ vec4 clamp_wrap_uv(vec4 uv)
 #if PS_WMS == 2
     uv_out = clamp(uv, MinMax.xyxy, MinMax.zwzw);
 #elif PS_WMS == 3
-    uv_out = vec4((ivec4(uv * WH.xyxy) & ivec4(MskFix.xyxy)) | ivec4(MskFix.zwzw)) / WH.xyxy;
+    uv_out = vec4((uvec4(fract(uv) * WH.xyxy) & ivec4(MskFix.xyxy)) | ivec4(MskFix.zwzw)) / WH.xyxy;
 #endif
 
 #else // PS_WMS != PS_WMT
@@ -136,7 +136,7 @@ vec4 clamp_wrap_uv(vec4 uv)
     uv_out.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
 
 #elif PS_WMS == 3
-    uv_out.xz = vec2((ivec2(uv.xz * WH.xx) & ivec2(MskFix.xx)) | ivec2(MskFix.zz)) / WH.xx;
+    uv_out.xz = vec2((uvec2(fract(uv.xz) * WH.xx) & ivec2(MskFix.xx)) | ivec2(MskFix.zz)) / WH.xx;
 
 #endif
 
@@ -145,7 +145,7 @@ vec4 clamp_wrap_uv(vec4 uv)
 
 #elif PS_WMT == 3
 
-    uv_out.yw = vec2((ivec2(uv.yw * WH.yy) & ivec2(MskFix.yy)) | ivec2(MskFix.ww)) / WH.yy;
+    uv_out.yw = vec2((uvec2(fract(uv.yw) * WH.yy) & ivec2(MskFix.yy)) | ivec2(MskFix.ww)) / WH.yy;
 #endif
 
 #endif

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -254,7 +254,7 @@ float4 clamp_wrap_uv(float4 uv)
 		else if(PS_WMS == 3)
 		{
 			#if SHADER_MODEL >= 0x400
-			uv = (float4)(((int4)(uv * WH.xyxy) & MskFix.xyxy) | MskFix.zwzw) / WH.xyxy;
+			uv = (float4)(((uint4)(frac(uv) * WH.xyxy) & MskFix.xyxy) | MskFix.zwzw) / WH.xyxy;
 			#elif SHADER_MODEL <= 0x300
 			uv.x = tex1D(UMSKFIX, uv.x);
 			uv.y = tex1D(VMSKFIX, uv.y);
@@ -283,7 +283,7 @@ float4 clamp_wrap_uv(float4 uv)
 		else if(PS_WMS == 3)
 		{
 			#if SHADER_MODEL >= 0x400
-			uv.xz = (float2)(((int2)(uv.xz * WH.xx) & MskFix.xx) | MskFix.zz) / WH.xx;
+			uv.xz = (float2)(((uint2)(frac(uv.xz) * WH.xx) & MskFix.xx) | MskFix.zz) / WH.xx;
 			#elif SHADER_MODEL <= 0x300
 			uv.x = tex1D(UMSKFIX, uv.x);
 			uv.z = tex1D(UMSKFIX, uv.z);
@@ -307,7 +307,7 @@ float4 clamp_wrap_uv(float4 uv)
 		else if(PS_WMT == 3)
 		{
 			#if SHADER_MODEL >= 0x400
-			uv.yw = (float2)(((int2)(uv.yw * WH.yy) & MskFix.yy) | MskFix.ww) / WH.yy;
+			uv.yw = (float2)(((uint2)(frac(uv.yw) * WH.yy) & MskFix.yy) | MskFix.ww) / WH.yy;
 			#elif SHADER_MODEL <= 0x300
 			uv.y = tex1D(VMSKFIX, uv.y);
 			uv.w = tex1D(VMSKFIX, uv.w);


### PR DESCRIPTION
@KrossX showing GSdx some more love.

Makes UV coord be on the range [0, SIZE) before applying mask and
offset. This fixes Xenosaga's hair for example, which has negative UV
coords.

Xenosaga Example

Master HW:
![image](https://user-images.githubusercontent.com/18107717/46226982-3054b500-c35e-11e8-968b-098b1150a8d2.png)

PR:
![image](https://user-images.githubusercontent.com/18107717/46226994-38145980-c35e-11e8-9792-052e2aff7b17.png)

SW:
![image](https://user-images.githubusercontent.com/18107717/46227012-419dc180-c35e-11e8-9e24-663f92a0e477.png)


Needs to be tested for any regressions.
@atomic83GitHub I leave the testing to you.
