### PR TITLE
Get host mac correctly on Windows

### DIFF
--- a/plugins/dev9ghzdrk/Linux/Linux.cpp
+++ b/plugins/dev9ghzdrk/Linux/Linux.cpp
@@ -143,11 +143,6 @@ DEV9configure() {
 
 }
 
-void __attribute__((constructor)) DllMain() {
-    //gtk_builder_add_from_file(builder, "dev9ghzdrk.ui", NULL);
-    //builder = gtk_build_new_from_resource( "/net/pcsx2/dev9ghzdrk/dev9ghzdrk.ui" );
-}
-
 NetAdapter* GetNetAdapter()
 {
     NetAdapter* na;

--- a/plugins/dev9ghzdrk/Linux/dev9ghzdrk.ui
+++ b/plugins/dev9ghzdrk/Linux/dev9ghzdrk.ui
@@ -69,6 +69,7 @@
         </child>
         <child>
           <object class="GtkComboBoxText" id="IDC_BAYTYPE">
+         <property name="sensitive">False</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="has_entry">True</property>
@@ -129,7 +130,7 @@
               <object class="GtkComboBoxText" id="IDC_ETHDEV">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="has_entry">True</property>
+            <property name="has_entry">False</property>
             <property name="entry_text_column">0</property>
               </object>
               <packing>
@@ -172,6 +173,7 @@
         <child>
           <object class="GtkCheckButton" id="IDC_HDDENABLED">
             <property name="label" translatable="yes">ENABLED</property>
+            <property name="sensitive">False</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -201,6 +203,7 @@
             </child>
             <child>
               <object class="GtkEntry" id="IDC_HDDFILE">
+            <property name="sensitive">False</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
               </object>
@@ -223,7 +226,7 @@
           <object class="GtkLabel" id="label2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Hard Disk Drive (not yet properly implemented</property>
+        <property name="label" translatable="yes">Hard Disk Drive (not yet properly implemented)</property>
           </object>
         </child>
       </object>

--- a/plugins/dev9ghzdrk/Win32/Config.cpp
+++ b/plugins/dev9ghzdrk/Win32/Config.cpp
@@ -19,19 +19,6 @@
 #include <winsock2.h>
 #include "..\DEV9.h"
 
-#define GetKeyV(name, var, s, t) \
-	size = s; type = t; \
-	RegQueryValueEx(myKey, name, 0, &type, (LPBYTE) var, &size);
-
-#define GetKeyVdw(name, var) \
-	GetKeyV(name, var, 4, REG_DWORD);
-
-//#define SetKeyV(name, var, s, t) \
-//	RegSetValueEx(myKey, name, 0, t, (LPBYTE) var, s);
-
-//#define SetKeyVdw(name, var) \
-//	SetKeyV(name, var, 4, REG_DWORD);
-
 BOOL WritePrivateProfileInt(LPCSTR lpAppName, LPCSTR lpKeyName, int intvar, LPCSTR lpFileName)
 {
 	return WritePrivateProfileString(lpAppName, lpKeyName, std::to_string(intvar).c_str(), lpFileName);
@@ -44,7 +31,7 @@ bool FileExists(std::string szPath)
 }
 
 void SaveConf() {
-	const std::string file(s_strIniPath + "/dev9ghz.ini");
+	const std::string file(s_strIniPath + "dev9ghz.ini");
 	DeleteFile(file.c_str());
 
 	WritePrivateProfileString("DEV9", "Eth", config.Eth, file.c_str());
@@ -54,84 +41,14 @@ void SaveConf() {
 	WritePrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
 }
 
-void DeleteRegConf() {
-	HKEY myKey;
-	//DWORD type, size;
+void LoadConf() {
+	const std::string file(s_strIniPath + "dev9ghz.ini");
+	if (FileExists(file.c_str()) == false)
+		return;
 
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9\\DEV9linuz", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
-		return;
-	}
-	RegDeleteKey(myKey, "Eth");
-	RegDeleteKey(myKey, "Hdd");
-	RegDeleteKey(myKey, "HddSize");
-	RegDeleteKey(myKey, "ethEnable");
-	RegDeleteKey(myKey, "hddEnable");
-	RegCloseKey(myKey);
-	//Delete Key Software\PS2Eplugin\DEV9\DEV9linuz
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
-		emu_printf("Error Opening Key DEV9\n");
-		return;
-	}
-	if (RegDeleteKey(myKey, "DEV9linuz") != ERROR_SUCCESS) {
-		emu_printf("Error Removing Key DEV9linuz\n");
-		RegCloseKey(myKey);
-		return;
-	}
-	RegCloseKey(myKey);
-	//Delete Key Software\PS2Eplugin\DEV9
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin", 0, KEY_ALL_ACCESS, &myKey) != ERROR_SUCCESS) {
-		emu_printf("Error Opening Key PS2Eplugin\n");
-		return;
-	}
-	if (RegDeleteKey(myKey, "DEV9") != ERROR_SUCCESS) {
-		emu_printf("Error Removing Key DEV9\n");
-		RegCloseKey(myKey);
-		return;
-	}
-	RegCloseKey(myKey);
-}
-
-void LoadIniConf() {
-	//memset(&config, 0, sizeof(config));
-	//strcpy(config.Hdd, HDD_DEF);
-	//config.HddSize = 8 * 1024;
-	//strcpy(config.Eth, ETH_DEF);
-
-	const std::string file(s_strIniPath + "/dev9ghz.ini");
-	if (FileExists(file.c_str()) == false) {
-		SaveConf();
-		return;
-	}
 	GetPrivateProfileString("DEV9", "Eth", ETH_DEF, config.Eth, sizeof(config.Eth), file.c_str());
 	GetPrivateProfileString("DEV9", "Hdd", HDD_DEF, config.Hdd, sizeof(config.Hdd), file.c_str());
 	config.HddSize = GetPrivateProfileInt("DEV9", "HddSize", config.HddSize, file.c_str());
 	config.ethEnable = GetPrivateProfileInt("DEV9", "ethEnable", config.ethEnable, file.c_str());
 	config.hddEnable = GetPrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
 }
-
-void LoadConf() {
-	HKEY myKey;
-	DWORD type, size;
-
-	memset(&config, 0, sizeof(config));
-	strcpy(config.Hdd, HDD_DEF);
-	config.HddSize = 8 * 1024;
-	strcpy(config.Eth, ETH_DEF);
-
-	if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\PS2Eplugin\\DEV9\\DEV9linuz", 0, KEY_ALL_ACCESS, &myKey)!=ERROR_SUCCESS) {
-		LoadIniConf();
-		return;
-	}
-	printf("Importing Settings\n");
-	//Import old settings if user has upgraded this plugin
-	GetKeyV("Eth", config.Eth, sizeof(config.Eth), REG_SZ);
-	GetKeyV("Hdd", config.Hdd, sizeof(config.Hdd), REG_SZ);
-	GetKeyVdw("HddSize", &config.HddSize);
-	GetKeyVdw("ethEnable", &config.ethEnable);
-	GetKeyVdw("hddEnable", &config.hddEnable);
-
-	RegCloseKey(myKey);
-	SaveConf();
-	DeleteRegConf();
-}
-

--- a/plugins/dev9ghzdrk/Win32/Win32.cpp
+++ b/plugins/dev9ghzdrk/Win32/Win32.cpp
@@ -51,16 +51,15 @@ void OnInitDialog(HWND hW) {
 	for (int i=0; i<pcap_io_get_dev_num(); i++) {
 		dev = pcap_io_get_dev_desc(i);
 		int itm=ComboBox_AddString(GetDlgItem(hW, IDC_ETHDEV), dev);
-		ComboBox_SetItemData(GetDlgItem(hW, IDC_ETHDEV),itm,strdup(pcap_io_get_dev_name(i)));
+		ComboBox_SetItemData(GetDlgItem(hW, IDC_ETHDEV),itm,_strdup(pcap_io_get_dev_name(i)));
 		if (strcmp(pcap_io_get_dev_name(i), config.Eth) == 0) {
 			ComboBox_SetCurSel(GetDlgItem(hW, IDC_ETHDEV), itm);
 		}
 	}
 	vector<tap_adapter> * al=GetTapAdapters();
 	for (size_t i=0; i<al->size(); i++) {
-		
 		int itm=ComboBox_AddString(GetDlgItem(hW, IDC_ETHDEV), al[0][i].name.c_str());
-		ComboBox_SetItemData(GetDlgItem(hW, IDC_ETHDEV),itm,strdup( al[0][i].guid.c_str()));
+		ComboBox_SetItemData(GetDlgItem(hW, IDC_ETHDEV),itm,_strdup( al[0][i].guid.c_str()));
 		if (strcmp(al[0][i].guid.c_str(), config.Eth) == 0) {
 			ComboBox_SetCurSel(GetDlgItem(hW, IDC_ETHDEV), itm);
 		}
@@ -77,27 +76,27 @@ void OnOk(HWND hW) {
 	if (i == -1)
 	{
 		//adapter not selected
-		if (Button_GetCheck(GetDlgItem(hW, IDC_ETHENABLED)))
+		if ( Button_GetCheck(GetDlgItem(hW, IDC_ETHENABLED)))
 		{
 			//Trying to use an ethernet without
 			//selected adapter, we can't have that
 			SysMessage("Please select an ethernet adapter");
 			return;
 		}
-		else 
+		else
 		{
 			//user not planning on using
 			//ethernet anyway
 			strcpy(config.Eth, ETH_DEF);
 		}
 	}
-	else 
+	else
 	{
 		//adapter is selected
 		char* ptr = (char*)ComboBox_GetItemData(GetDlgItem(hW, IDC_ETHDEV), i);
 		strcpy(config.Eth, ptr);
 	}
-	
+
 	Edit_GetText(GetDlgItem(hW, IDC_HDDFILE), config.Hdd, 256);
 
 	config.ethEnable = Button_GetCheck(GetDlgItem(hW, IDC_ETHENABLED));
@@ -109,7 +108,7 @@ void OnOk(HWND hW) {
 }
 
 BOOL CALLBACK ConfigureDlgProc(HWND hW, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-	
+
 	switch(uMsg) {
 		case WM_INITDIALOG:
 			OnInitDialog(hW);
@@ -147,8 +146,8 @@ EXPORT_C_(void)
 DEV9configure() {
     DialogBox(hInst,
               MAKEINTRESOURCE(IDD_CONFIG),
-              GetActiveWindow(),  
-             (DLGPROC)ConfigureDlgProc); 
+              GetActiveWindow(),
+             (DLGPROC)ConfigureDlgProc);
 		//SysMessage("Nothing to Configure");
 }
 
@@ -156,12 +155,12 @@ EXPORT_C_(void)
 DEV9about() {
     DialogBox(hInst,
               MAKEINTRESOURCE(IDD_ABOUT),
-              GetActiveWindow(),  
+              GetActiveWindow(),
               (DLGPROC)AboutDlgProc);
 }
 
 BOOL APIENTRY DllMain(HANDLE hModule,                  // DLL INIT
-                      DWORD  dwReason, 
+                      DWORD  dwReason,
                       LPVOID lpReserved) {
 	hInst = (HINSTANCE)hModule;
 	return TRUE;                                          // very quick :)
@@ -184,7 +183,7 @@ NetAdapter* GetNetAdapter()
 	}
 	return na;
 }
-s32  _DEV9open() 
+s32  _DEV9open()
 {
 	//handleDEV9Thread = CreateThread (NULL, 0, (LPTHREAD_START_ROUTINE) DEV9ThreadProc, &dwThrdParam, CREATE_SUSPENDED, &dwThreadId);
 	//SetThreadPriority(handleDEV9Thread,THREAD_PRIORITY_HIGHEST);

--- a/plugins/dev9ghzdrk/smap.cpp
+++ b/plugins/dev9ghzdrk/smap.cpp
@@ -344,14 +344,14 @@ smap_read8(u32 addr)
 EXPORT_C_(u16)
 smap_read16(u32 addr)
 {
-	if (addr >= SMAP_BD_TX_BASE && addr < (SMAP_BD_TX_BASE + SMAP_BD_SIZE)) 
+	int rv = dev9Ru16(addr);
+	if (addr >= SMAP_BD_TX_BASE && addr < (SMAP_BD_TX_BASE + SMAP_BD_SIZE))
 	{
-		int rv = dev9Ru16(addr);
-		if(dev9.bd_swap)
-				return (rv<<8)|(rv>>8);
+		if (dev9.bd_swap)
+			return (rv << 8) | (rv >> 8);
 		return rv;
 		/*
-		switch (addr & 0x7) 
+		switch (addr & 0x7)
 		{
 		case 0: // ctrl_stat
 			hard = dev9Ru16(addr);
@@ -380,14 +380,13 @@ smap_read16(u32 addr)
 		}
 		*/
 	}
-	else if (addr >= SMAP_BD_RX_BASE && addr < (SMAP_BD_RX_BASE + SMAP_BD_SIZE)) 
+	else if (addr >= SMAP_BD_RX_BASE && addr < (SMAP_BD_RX_BASE + SMAP_BD_SIZE))
 	{
-		int rv = dev9Ru16(addr);
-		if(dev9.bd_swap)
-				return (rv<<8)|(rv>>8);
+		if (dev9.bd_swap)
+			return (rv << 8) | (rv >> 8);
 		return rv;
 		/*
-		switch (addr & 0x7) 
+		switch (addr & 0x7)
 		{
 		case 0: // ctrl_stat
 			hard = dev9Ru16(addr);
@@ -416,10 +415,9 @@ smap_read16(u32 addr)
 		}
 		*/
 	}
-
+#ifdef DEV9_LOG_ENABLE
 	switch(addr)
 	{
-#ifdef DEV9_LOG_ENABLE
 		case SMAP_R_TXFIFO_FRAME_CNT:
 			printf("SMAP_R_TXFIFO_FRAME_CNT read 16\n");
 			return dev9Ru16(addr);
@@ -489,12 +487,14 @@ smap_read16(u32 addr)
 		case SMAP_R_EMAC3_STA_CTRL_H:
 			DEV9_LOG("SMAP_R_EMAC3_STA_CTRL_H 16bit read %x\n", dev9Ru16(addr));
 			return dev9Ru16(addr);
-#endif
 		default:
 			DEV9_LOG("SMAP : Unknown 16 bit read @ %X,v=%X\n",addr,dev9Ru16(addr));
 			return dev9Ru16(addr);
 	}
+#endif
+	return rv;
 }
+
 EXPORT_C_(u32)
 smap_read32(u32 addr)
 {


### PR DESCRIPTION
Follow on to #2586 which ensures that MAC address is unique on Xlink Kai when using Windows. Apparently the old GetAdapterInfo() API is deprecated after Windows XP. Previous build was returning last two bytes as 00:00 rather than last two bytes of host adapter's MAC as highlighted below
![capture](https://user-images.githubusercontent.com/13685818/46511595-8e314300-c81d-11e8-9bbc-9d9984e9787c.PNG)
