### PR TITLE
GSdx: Remove ancient ATI point sampler hack for 8-bit textures

### DIFF
--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -36,7 +36,6 @@
 #define PS_DATE 0
 #define PS_SPRITEHACK 0
 #define PS_TCOFFSETHACK 0
-#define PS_POINT_SAMPLER 0
 #define PS_SHUFFLE 0
 #define PS_READ_BA 0
 #define PS_PAL_FMT 0
@@ -113,15 +112,6 @@ cbuffer cb2
 
 float4 sample_c(float2 uv)
 {
-	if (PS_POINT_SAMPLER)
-	{
-		// Weird issue with ATI cards (happens on at least HD 4xxx and 5xxx),
-		// it looks like they add 127/128 of a texel to sampling coordinates
-		// occasionally causing point sampling to erroneously round up.
-		// I'm manually adjusting coordinates to the centre of texels here,
-		// though the centre is just paranoia, the top left corner works fine.
-		uv = (trunc(uv * WH.zw) + float2(0.5, 0.5)) / WH.zw;
-	}
 	return Texture.Sample(TextureSampler, uv);
 }
 


### PR DESCRIPTION
Removes an ancient hack for ATI cards that caused texture alignment/minor warping issues in DX11 HW when 8-bit textures were enabled/used. This was first noticed in Shox, but likely affected other games as well. 

Before and after comparison for those who are curious. Notice the line in the bottom left corner of the ground texture.

![ati_hack](https://user-images.githubusercontent.com/16314399/46651108-f610c200-cb6c-11e8-9671-1afb682ee01b.png)
