### PR TITLE
Switch to using the current cmake policies, not depreciated ones.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,44 +2,9 @@
 project(Pcsx2)
 
 # Debian-based distributions require at least 2.8.5 due to multiarch.
-cmake_minimum_required(VERSION 2.8.5)
-
-# Keep OLD policy. Code was updated to support the new one but wasn't tested
-# Well, no time like the present to test it!
-#
-# cmake version 2.8.9
-#   CMP0018
-#        Ignore CMAKE_SHARED_LIBRARY_<Lang>_FLAGS variable.
-# 
-#        CMake 2.8.8 and lower compiled sources in SHARED and MODULE libraries
-#        using the value of the undocumented CMAKE_SHARED_LIBRARY_<Lang>_FLAGS
-#        platform variable.  The variable contained platform-specific flags
-#        needed to compile objects for shared libraries.  Typically it included
-#        a flag such as -fPIC for position independent code but also included
-#        other flags needed on certain platforms.  CMake 2.8.9 and higher
-#        prefer instead to use the POSITION_INDEPENDENT_CODE target property to
-#        determine what targets should be position independent, and new
-#        undocumented platform variables to select flags while ignoring
-#        CMAKE_SHARED_LIBRARY_<Lang>_FLAGS completely.
-# 
-#        The default for either approach produces identical compilation flags,
-#        but if a project modifies CMAKE_SHARED_LIBRARY_<Lang>_FLAGS from its
-#        original value this policy determines which approach to use.
-# 
-#        The OLD behavior for this policy is to ignore the
-#        POSITION_INDEPENDENT_CODE property for all targets and use the
-#        modified value of CMAKE_SHARED_LIBRARY_<Lang>_FLAGS for SHARED and
-#        MODULE libraries.
-# 
-#        The NEW behavior for this policy is to ignore
-#        CMAKE_SHARED_LIBRARY_<Lang>_FLAGS whether it is modified or not and
-#        honor the POSITION_INDEPENDENT_CODE target property.
-if(POLICY CMP0018)
-    cmake_policy(SET CMP0018 NEW)
-endif()
-if(POLICY CMP0022)
-    cmake_policy(SET CMP0022 NEW)
-endif()
+# Bumping up to 3.0 seems reasonable at this point, and will let us modernize
+# things a bit.
+cmake_minimum_required(VERSION 3.0.2)
 
 # Variable to check that people use the good file
 set(TOP_CMAKE_WAS_SOURCED TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(Pcsx2)
 cmake_minimum_required(VERSION 2.8.5)
 
 # Keep OLD policy. Code was updated to support the new one but wasn't tested
+# Well, no time like the present to test it!
 #
 # cmake version 2.8.9
 #   CMP0018
@@ -34,10 +35,10 @@ cmake_minimum_required(VERSION 2.8.5)
 #        CMAKE_SHARED_LIBRARY_<Lang>_FLAGS whether it is modified or not and
 #        honor the POSITION_INDEPENDENT_CODE target property.
 if(POLICY CMP0018)
-    cmake_policy(SET CMP0018 OLD)
+    cmake_policy(SET CMP0018 NEW)
 endif()
 if(POLICY CMP0022)
-    cmake_policy(SET CMP0022 OLD)
+    cmake_policy(SET CMP0022 NEW)
 endif()
 
 # Variable to check that people use the good file


### PR DESCRIPTION
In the comments in the cmake file, it said that it had already been changed to support the new policies, but it hadn't been tested. Eventually, those depreciated policies will no longer be there, so switching is something that should be done at some point.

I switched both on, and built with all the extra plugins and with gtk 2 and gtk 3. It seemed to work both times. Doing as a PR request do it can get a bit of testing before being turned on in the main system. (And so I can see a travis cl build before committing.)