### PR TITLE
Cache strings for "Next>" or "Finish" buttons in wxWizard

### DIFF
--- a/3rdparty/wxwidgets3.0/include/wx/generic/wizard.h
+++ b/3rdparty/wxwidgets3.0/include/wx/generic/wizard.h
@@ -131,6 +131,10 @@ protected:
                 *m_btnNext;     // the "Next>" or "Finish" button
     wxStaticBitmap *m_statbmp;  // the control for the bitmap
 
+    // cached labels so their locale stays consistent
+    wxString m_nextLabel,
+             m_finishLabel;
+
     // Border around page area sizer requested using SetBorder()
     int m_border;
 

--- a/3rdparty/wxwidgets3.0/src/generic/wizard.cpp
+++ b/3rdparty/wxwidgets3.0/src/generic/wizard.cpp
@@ -428,7 +428,10 @@ void wxWizard::AddButtonRow(wxBoxSizer *mainColumn)
         btnHelp=new wxButton(this, wxID_HELP, wxEmptyString, wxDefaultPosition, wxDefaultSize, buttonStyle);
 #endif
 
-    m_btnNext = new wxButton(this, wxID_FORWARD, _("&Next >"));
+    m_nextLabel = _("&Next >");
+    m_finishLabel = _("&Finish");
+
+    m_btnNext = new wxButton(this, wxID_FORWARD, m_nextLabel);
     wxButton *btnCancel=new wxButton(this, wxID_CANCEL, _("&Cancel"), wxDefaultPosition, wxDefaultSize, buttonStyle);
 #ifndef __WXMAC__
     if (GetExtraStyle() & wxWIZARD_EX_HELPBUTTON)
@@ -623,7 +626,7 @@ bool wxWizard::ShowPage(wxWizardPage *page, bool goingForward)
     m_btnPrev->Enable(HasPrevPage(m_page));
 
     const bool hasNext = HasNextPage(m_page);
-    const wxString label = hasNext ? _("&Next >") : _("&Finish");
+    const wxString& label = hasNext ? m_nextLabel : m_finishLabel;
     if ( label != m_btnNext->GetLabel() )
         m_btnNext->SetLabel(label);
 


### PR DESCRIPTION
This is a partial fix for #1207, as described in "Bug no. 1".

Back/Cancel buttons were initialized only once when wizard was constructed, so translations were also applied only once at that time. However, Next/Finish buttons had its string replaced when switching pages (so Next can become Finish when appropriate), and that triggered retranslation every time. If translation changed between those two events, you'd end up with a frankenstein navigation bar in two languages:

![lang-mix](https://user-images.githubusercontent.com/7947461/47682204-faf4ee80-dbcb-11e8-9fe9-a5186d1227fe.png)

This PR caches translated strings for Next and Finish at the time of initial creation of those buttons. This has two added benefits:
- Not triggering retranslation every time string changes.
- "Next>" and "Finish" strings are not duplicated in the code anymore - and they could be considered "magic values".

#1207 also triages an issue of selected language being ignored at a point - however, correct behaviour has not been fully agreed upon yet, so for now I am only including a fix for the part everyone can agree on that it's a bug.