### PR TITLE
GameDB: Remove CRC check for Forbidden Siren 2 patch

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -2305,7 +2305,7 @@ Name   = Forbidden Siren 2
 Region = PAL-M5
 Compat = 5
 XgKickHack = 1 // SPS.
-[patches = C040B6AB]
+[patches]
 	comment=swapping a COP2 op into place to make the flags work without delays
 	patch=0,EE,002E2B44,word,48449000
 	patch=0,EE,002E2B4C,word,4BC949FF


### PR DESCRIPTION
Removing this CRC check allows the patch to work with another version containing the same serial but a different CRC (as noted in https://forums.pcsx2.net/Thread-bug-report-Forbidden-Siren-2-Pal?page=2)