### PR TITLE
GSdx-TC: Remove useless virtual specifiers

### DIFF
--- a/plugins/GSdx/GSTextureCache.h
+++ b/plugins/GSdx/GSTextureCache.h
@@ -60,7 +60,7 @@ public:
 
 	public:
 		Palette(const GSRenderer* renderer, uint16 pal); // Creates a copy of the current clut and a texture with its content
-		virtual ~Palette(); // Default destructor, recycles palette texture and frees clut copy
+		~Palette(); // Default destructor, recycles palette texture and frees clut copy
 
 		// Disable copy constructor and copy operator
 		Palette(const Palette&) = delete;
@@ -84,12 +84,12 @@ public:
 
 	struct PaletteKeyHash {
 		// Calculate hash
-		virtual std::size_t operator()(const PaletteKey &key) const;
+		std::size_t operator()(const PaletteKey &key) const;
 	};
 
 	struct PaletteKeyEqual {
 		// Compare clut contents
-		virtual bool operator()(const PaletteKey &lhs, const PaletteKey &rhs) const;
+		bool operator()(const PaletteKey &lhs, const PaletteKey &rhs) const;
 	};
 
 	class Source : public Surface


### PR DESCRIPTION
Removed three useless virtual specifier added wrongly to operators and destructor in #2344, as highlighted thanks to @turtleli.
The modifiers presence shouldn't be cause of bugs, but it slows down the accesses to the functions and pollutes the code, so its removal is necessary.