### PR TITLE
pcsx2: Fix some issues on FMV Aspect Ratio Override

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -882,9 +882,9 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 
 	static const wxChar* FMVAspectRatioSwitchNames[] =
 	{
+		L"Off",
 		L"4:3",
 		L"16:9",
-		L"Off",
 		// WARNING: array must be NULL terminated to compute it size
 		NULL
 	};

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -98,9 +98,9 @@ enum AspectRatioType
 
 enum FMVAspectRatioSwitchType
 {
+	FMV_AspectRatio_Switch_Off,
 	FMV_AspectRatio_Switch_4_3,
 	FMV_AspectRatio_Switch_16_9,
-	FMV_AspectRatio_Switch_Off,
 	FMV_AspectRatio_Switch_MaxCount
 };
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -167,19 +167,21 @@ void GSPanel::DoResize()
 		switchAR = false;
 	}
 
-	if (!switchAR) {
-		if (g_Conf->GSWindow.AspectRatio == AspectRatio_4_3)
+	if (switchAR) {
+		if (g_Conf->GSWindow.FMVAspectRatioSwitch == FMV_AspectRatio_Switch_4_3) {
 			targetAr = 4.0 / 3.0;
-		else if (g_Conf->GSWindow.AspectRatio == AspectRatio_16_9)
+		} else if (g_Conf->GSWindow.FMVAspectRatioSwitch == FMV_AspectRatio_Switch_16_9) {
 			targetAr = 16.0 / 9.0;
-	} else if (switchAR) {
-		if (g_Conf->GSWindow.FMVAspectRatioSwitch == FMV_AspectRatio_Switch_4_3 && g_Conf->GSWindow.AspectRatio != AspectRatio_4_3) {
+		} else {
+			// Allows for better real time toggling, returns to the non fmv override aspect ratio.
+			switchAR = false;
+		}
+	} else if (!switchAR) {
+		if (g_Conf->GSWindow.AspectRatio == AspectRatio_4_3) {
 			targetAr = 4.0 / 3.0;
-		} else if (g_Conf->GSWindow.FMVAspectRatioSwitch == FMV_AspectRatio_Switch_16_9 && g_Conf->GSWindow.AspectRatio != AspectRatio_16_9) {
+		} else if (g_Conf->GSWindow.AspectRatio == AspectRatio_16_9) {
 			targetAr = 16.0 / 9.0;
 		}
-	} else {
-		targetAr = 4.0 / 3.0;
 	}
 
 	double arr = targetAr / clientAr;

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -34,9 +34,9 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 
 	const wxString fmv_aspect_ratio_switch_labels[] =
 	{
+		_("Off (Default)"),
 		_("Standard (4:3)"),
-		_("Widescreen (16:9)"),
-		_("Off (Default)")
+		_("Widescreen (16:9)")
 	};
 
 	// Warning must match the order of the VsyncMode Enum
@@ -71,9 +71,9 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel( wxWindow* parent )
 	m_check_DclickFullscreen = new pxCheckBox( this, _("Double-click toggles fullscreen mode") );
 	//m_check_ExclusiveFS = new pxCheckBox( this, _("Use exclusive fullscreen mode (if available)") );
 
-	m_combo_FMVAspectRatioSwitch->SetToolTip( pxEt( L"4:3: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display an 4:3 FMV.\n\n"
-		L"16:9: Temporarily switch to a 16:9 aspect ratio while an FMV plays to correctly display a widescreen 16:9 FMV.\n\n"
-		L"Off: Disables temporary aspect ratio switch.") );
+	m_combo_FMVAspectRatioSwitch->SetToolTip( pxEt( L"Off: Disables temporary aspect ratio switch.\n\n"
+		L"4:3: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display an 4:3 FMV.\n\n"
+		L"16:9: Temporarily switch to a 16:9 aspect ratio while an FMV plays to correctly display a widescreen 16:9 FMV.") );
 
 	m_text_Zoom->SetToolTip( pxEt( L"Zoom = 100: Fit the entire image to the window without any cropping.\nAbove/Below 100: Zoom In/Out\n0: Automatic-Zoom-In untill the black-bars are gone (Aspect ratio is kept, some of the image goes out of screen).\n  NOTE: Some games draw their own black-bars, which will not be removed with '0'.\n\nKeyboard: CTRL + NUMPAD-PLUS: Zoom-In, CTRL + NUMPAD-MINUS: Zoom-Out, CTRL + NUMPAD-*: Toggle 100/0"
 	) );


### PR DESCRIPTION
gui: Move the Off option to the top instead of bottom for FMV Aspect Ratio Override.

It's not ideal for it to be at the bottom.

Adjust the logic how the button works, there was an issue if both aspect ratios
were the same the aspect ratio chosen was selected to Fill.
Also adjust the code so the button better responds to realtime toggling.

If disabling the button realtime during a fmv then the normal aspect ratio
should be chosen.

There's still an issue left where if the fmv button is changed first and then
the aspect ratio button the button would would not work in realtime. Switching it off
seems to reset and make it work again.

Note: even the old 4:3 option had these same issues with realtime toggling.