### PR TITLE
GameIndex: Add Ace Combat 5 COP2 Patch on NTSC-J.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -32176,11 +32176,11 @@ Name   = Ace Combat 5 - The Unsung War
 Region = NTSC-J
 Compat = 5
 [patches = 86089F31]
-    comment=Rearranging COP2 instructions that use old results
-    patch=0,EE,001A3B94,word,48498800
-    patch=0,EE,001A3B98,word,4B00682C
-    patch=0,EE,001A3BA4,word,484A8800
-    patch=0,EE,001A3BA8,word,4B0C682C
+	comment=Rearranging COP2 instructions that use old results
+	patch=0,EE,001A3B94,word,48498800
+	patch=0,EE,001A3B98,word,4B00682C
+	patch=0,EE,001A3BA4,word,484A8800
+	patch=0,EE,001A3BA8,word,4B0C682C
 [/patches]
 ---------------------------------------------
 Serial = SLPS-25419

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -32174,6 +32174,14 @@ Region = NTSC-J
 Serial = SLPS-25418
 Name   = Ace Combat 5 - The Unsung War
 Region = NTSC-J
+Compat = 5
+[patches = 86089F31]
+    comment=Rearranging COP2 instructions that use old results
+    patch=0,EE,001A3B94,word,48498800
+    patch=0,EE,001A3B98,word,4B00682C
+    patch=0,EE,001A3BA4,word,484A8800
+    patch=0,EE,001A3BA8,word,4B0C682C
+[/patches]
 ---------------------------------------------
 Serial = SLPS-25419
 Name   = Mobile Suit Gundam - Gundam vs. Z-Gundam


### PR DESCRIPTION
This'll potentially fix "Unplayable Bug" caused by COP2. (This patch exists in NTSC-U, but confirmed this patch work on NTSC-J.)