### PR TITLE
GSdx-ogl: Drop AMD's SSO workarounds

### DIFF
--- a/plugins/GSdx/Renderers/OpenGL/GLLoader.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GLLoader.cpp
@@ -332,26 +332,14 @@ namespace GLLoader {
 			fprintf(stderr, "Error: GLLoader failed to get GL version\n");
 			return false;
 		}
-		GLuint v = 1;
-		while (s[v] != '\0' && s[v-1] != ' ') v++;
-
 		const char* vendor = (const char*)glGetString(GL_VENDOR);
 		if (s_first_load)
-			fprintf(stdout, "OpenGL information. GPU: %s. Vendor: %s. Driver: %s\n", glGetString(GL_RENDERER), vendor, &s[v]);
+			fprintf(stdout, "OpenGL information. GPU: %s. Vendor: %s. Driver: %s\n", glGetString(GL_RENDERER), vendor, &s[0]);
 
-		// Name changed but driver is still bad!
-		if (strstr(vendor, "Advanced Micro Devices") || strstr(vendor, "ATI Technologies Inc.") || strstr(vendor, "ATI"))
+		// 32-bit driver should always actually just report the former
+		if (strstr(vendor, "ATI Technologies Inc.") || strstr(vendor, "Advanced Micro Devices") || strstr(vendor, "ATI"))
 			vendor_id_amd = true;
-		/*if (vendor_id_amd && (
-				strstr((const char*)&s[v], " 10.") || // Blacklist all 2010 AMD drivers.
-				strstr((const char*)&s[v], " 11.") || // Blacklist all 2011 AMD drivers.
-				strstr((const char*)&s[v], " 12.") || // Blacklist all 2012 AMD drivers.
-				strstr((const char*)&s[v], " 13.") || // Blacklist all 2013 AMD drivers.
-				strstr((const char*)&s[v], " 14.") || // Blacklist all 2014 AMD drivers.
-				strstr((const char*)&s[v], " 15.") || // Blacklist all 2015 AMD drivers.
-				strstr((const char*)&s[v], " 16.") || // Blacklist all 2016 AMD drivers.
-				strstr((const char*)&s[v], " 17.") // Blacklist all 2017 AMD drivers for now.
-				))
+		/*if (vendor_id_amd)
 			amd_legacy_buggy_driver = true;
 		*/
 		if (strstr(vendor, "NVIDIA Corporation"))

--- a/plugins/GSdx/Renderers/OpenGL/GLLoader.h
+++ b/plugins/GSdx/Renderers/OpenGL/GLLoader.h
@@ -362,6 +362,7 @@ namespace GLLoader {
 	extern bool vendor_id_nvidia;
 	extern bool vendor_id_intel;
 	extern bool amd_legacy_buggy_driver;
+	extern bool amd_buggy_driver;
 	extern bool mesa_driver;
 	extern bool buggy_sso_dual_src;
 	extern bool in_replayer;


### PR DESCRIPTION
Details on the otherwise random-looking values I used at https://github.com/PCSX2/pcsx2/issues/1552#issuecomment-439735770

I have some reserve on whether it's me to be stupid, Wx, or both, considering the time I needed to find the right code (for as much ugly) that worked in every case. 

And yes, @lightningterror, `amd_legacy_buggy_driver` is just there waiting for your June <~15.11 hack to land ^^