### PR TITLE
GSVector4i: Fix compare64 function

### DIFF
--- a/plugins/GSdx/GSVector4i.h
+++ b/plugins/GSdx/GSVector4i.h
@@ -1945,7 +1945,7 @@ public:
 	{
 		ASSERT((size & 63) == 0);
 
-		size >>= 6;
+		size >>= 4;
 
 		GSVector4i* s = (GSVector4i*)src;
 		GSVector4i* d = (GSVector4i*)dst;


### PR DESCRIPTION
Fix `GSVector4i::compare64` function by adjusting the number of iterations needed to cover the comparison of all the elements of the input arrays, where the number of bytes to compare is indicated in the `size` parameter of the function. 
The function is used only in GSdx-TC to compare CLUT arrays.
On one hand this fix closes the recent #2706 and possibly the color regressions indicated in #2702 (which were both introduced with the new `PaletteMap` mechanism, which partially replaced the `GSVector4i::update` logic with the bugged `GSVector4i::compare64`).
On the other hand this might impact long standing wrong texture cache lookup when palette was involved with 8-bit palette disabled (to be verified which ones).
