### PR TITLE
GSdx: Palette management refactor and fix (v2)

### DIFF
--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -224,10 +224,9 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		// Target are converted (AEM & palette) on the fly by the GPU. They don't need extra check
 		if (!s->m_target) {
 			// We request a palette texture (psm_s.pal). If the texture was
-			// converted by the CPU (!s->m_should_have_tex_palette), we need to ensure
+			// converted by the CPU (!s->m_palette), we need to ensure
 			// palette content is the same.
-			// Note: content of the palette will be uploaded at the end of the function
-			if (psm_s.pal > 0 && !s->m_should_have_tex_palette && !s->ClutMatch({ clut, psm_s.pal }))
+			if (psm_s.pal > 0 && !s->m_palette && !s->ClutMatch({ clut, psm_s.pal }))
 				continue;
 
 			// We request a 24/16 bit RGBA texture. Alpha expansion was done by
@@ -378,6 +377,8 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		}
 	}
 
+	bool new_source = false;
+
 	if(src == NULL)
 	{
 #ifdef ENABLE_OGL_DEBUG
@@ -390,6 +391,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		}
 #endif
 		src = CreateSource(TEX0, TEXA, dst, half_right, x_offset, y_offset);
+		new_source = true;
 
 	} else {
 		GL_CACHE("TC: src hit: %d (0x%x, 0x%x, %s)",
@@ -398,7 +400,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					psm_str(TEX0.PSM));
 	}
 
-	if (src->m_should_have_tex_palette && (!src->m_clut || !src->ClutMatch({ clut, psm_s.pal }))) {
+	if (src->m_palette && !new_source && !src->ClutMatch({ clut, psm_s.pal })) {
 		AttachPaletteToSource(src, psm_s.pal, true);
 	}
 
@@ -1335,7 +1337,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// However it is different here. We want to reuse a Render Target as a texture.
 		// Because the texture is already on the GPU, CPU can't convert it.
 		if (psm.pal > 0) {
-			src->m_should_have_tex_palette = true;
+			AttachPaletteToSource(src, psm.pal, true);
 		}
 		// Disable linear filtering for various GS post-processing effect
 		// 1/ Palette is used to interpret the alpha channel of the RT as an index.
@@ -1449,11 +1451,13 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		if (m_paltex && psm.pal > 0)
 		{
 			src->m_texture = m_renderer->m_dev->CreateTexture(tw, th, Get8bitFormat());
-			src->m_should_have_tex_palette = true;
+			AttachPaletteToSource(src, psm.pal, true);
 		}
 		else {
 			src->m_texture = m_renderer->m_dev->CreateTexture(tw, th);
-			AttachPaletteToSource(src, psm.pal, false); // Attach only Palette object and clut copy
+			if (psm.pal > 0) {
+				AttachPaletteToSource(src, psm.pal, false);
+			}
 		}
 	}
 
@@ -1549,7 +1553,6 @@ void GSTextureCache::Surface::UpdateAge()
 GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, uint8* temp, bool dummy_container)
 	: Surface(r, temp)
 	, m_palette_obj(nullptr)
-	, m_should_have_tex_palette(false)
 	, m_palette(nullptr)
 	, m_target(false)
 	, m_complete(false)

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -1173,6 +1173,11 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_target = true;
 		src->m_from_target = dst->m_texture;
 		src->m_texture->SetScale(scale);
+
+		if (psm.pal > 0) {
+			// Attach palette for GPU texture conversion
+			AttachPaletteToSource(src, psm.pal, true);
+		}
 	}
 	else if (dst)
 	{

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -224,10 +224,10 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		// Target are converted (AEM & palette) on the fly by the GPU. They don't need extra check
 		if (!s->m_target) {
 			// We request a palette texture (psm_s.pal). If the texture was
-			// converted by the CPU (s->m_palette == NULL), we need to ensure
+			// converted by the CPU (!s->m_should_have_tex_palette), we need to ensure
 			// palette content is the same.
 			// Note: content of the palette will be uploaded at the end of the function
-			if (psm_s.pal > 0 && !s->m_should_have_tex_palette && !GSVector4i::compare64(clut, s->m_clut, psm_s.pal * sizeof(clut[0])))
+			if (psm_s.pal > 0 && !s->m_should_have_tex_palette && !s->ClutMatch({ clut, psm_s.pal }))
 				continue;
 
 			// We request a 24/16 bit RGBA texture. Alpha expansion was done by
@@ -398,7 +398,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					psm_str(TEX0.PSM));
 	}
 
-	if (src->m_should_have_tex_palette && (!src->m_clut || !GSVector4i::compare64(src->m_clut, clut, psm_s.pal * sizeof(uint32)))) {
+	if (src->m_should_have_tex_palette && (!src->m_clut || !src->ClutMatch({ clut, psm_s.pal }))) {
 		AttachPaletteToSource(src, psm_s.pal, true);
 	}
 
@@ -1549,9 +1549,8 @@ void GSTextureCache::Surface::UpdateAge()
 GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, uint8* temp, bool dummy_container)
 	: Surface(r, temp)
 	, m_palette_obj(nullptr)
-	, m_palette(NULL)
 	, m_should_have_tex_palette(false)
-	, m_clut(NULL)
+	, m_palette(nullptr)
 	, m_target(false)
 	, m_complete(false)
 	, m_spritehack_t(false)
@@ -1808,6 +1807,10 @@ void GSTextureCache::Source::Flush(uint32 count, int layer)
 	m_write.count -= count;
 }
 
+bool GSTextureCache::Source::ClutMatch(PaletteKey palette_key) {
+	return PaletteKeyEqual()(palette_key, m_palette_obj->GetPaletteKey());
+}
+
 // GSTextureCache::Target
 
 GSTextureCache::Target::Target(GSRenderer* r, const GIFRegTEX0& TEX0, uint8* temp, bool depth_supported)
@@ -2040,15 +2043,17 @@ void GSTextureCache::AttachPaletteToSource(Source* s, uint16 pal, bool need_gs_t
 	if (need_gs_texture) {
 		s->m_palette = p->GetPaletteGSTexture();
 	}
-	s->m_clut = p->GetClut();
 }
 
 // GSTextureCache::Palette
 
-GSTextureCache::Palette::Palette(const GSRenderer* renderer, uint16 pal, bool need_gs_texture) {
+GSTextureCache::Palette::Palette(const GSRenderer* renderer, uint16 pal, bool need_gs_texture)
+	: m_pal(pal)
+	, m_tex_palette(nullptr)
+	, m_renderer(renderer)
+{
 	uint16 palette_size = pal * sizeof(uint32);
 	m_clut = (uint32*)_aligned_malloc(palette_size, 64);
-	m_renderer = renderer;
 	memcpy(m_clut, (const uint32*)m_renderer->m_mem.m_clut, palette_size);
 	if (need_gs_texture) {
 		m_tex_palette = m_renderer->m_dev->CreateTexture(256, 1);
@@ -2060,18 +2065,16 @@ GSTextureCache::Palette::Palette(const GSRenderer* renderer, uint16 pal, bool ne
 }
 
 GSTextureCache::Palette::~Palette() {
-	if (GetPaletteGSTexture()) {
-		m_renderer->m_dev->Recycle(GetPaletteGSTexture()); // Recycle palette texture, if any
-	}
-	_aligned_free(GetClut()); // Free clut copy
-}
-
-uint32* GSTextureCache::Palette::GetClut() {
-	return m_clut;
+	m_renderer->m_dev->Recycle(m_tex_palette);
+	_aligned_free(m_clut);
 }
 
 GSTexture* GSTextureCache::Palette::GetPaletteGSTexture() {
 	return m_tex_palette;
+}
+
+GSTextureCache::PaletteKey GSTextureCache::Palette::GetPaletteKey() {
+	return { m_clut, m_pal };
 }
 
 // GSTextureCache::PaletteKeyHash
@@ -2188,9 +2191,7 @@ std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalet
 
 	std::shared_ptr<Palette> palette = std::make_shared<Palette>(m_renderer, pal, need_gs_texture);
 	
-	palette_key = { palette->GetClut(), pal };
-
-	map.emplace(palette_key, palette);
+	map.emplace(palette->GetPaletteKey(), palette);
 
 	GL_CACHE("TC, %u-bit PaletteMap (Size %u): Added new palette.", pal * sizeof(uint32), map.size());
 	

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -2061,11 +2061,7 @@ GSTextureCache::Palette::Palette(const GSRenderer* renderer, uint16 pal, bool ne
 	m_clut = (uint32*)_aligned_malloc(palette_size, 64);
 	memcpy(m_clut, (const uint32*)m_renderer->m_mem.m_clut, palette_size);
 	if (need_gs_texture) {
-		m_tex_palette = m_renderer->m_dev->CreateTexture(256, 1);
-		m_tex_palette->Update(GSVector4i(0, 0, pal, 1), m_clut, palette_size);
-	}
-	else {
-		m_tex_palette = nullptr;
+		InitializeTexture();
 	}
 }
 
@@ -2080,6 +2076,18 @@ GSTexture* GSTextureCache::Palette::GetPaletteGSTexture() {
 
 GSTextureCache::PaletteKey GSTextureCache::Palette::GetPaletteKey() {
 	return { m_clut, m_pal };
+}
+
+void GSTextureCache::Palette::InitializeTexture() {
+	if (!m_tex_palette) {
+		// A palette texture is always created with dimensions 256x1 (also in the case that m_pal is 16, thus a 16x1 texture
+		// would be enough to store the CLUT data) because the coordinates that the shader uses for
+		// sampling such texture are always normalized by 255.
+		// This is because indexes are stored as normalized values of an RGBA texture (e.g. index 15 will be read as (15/255),
+		// and therefore will read texel 15/255 * texture size).
+		m_tex_palette = m_renderer->m_dev->CreateTexture(256, 1);
+		m_tex_palette->Update(GSVector4i(0, 0, m_pal, 1), m_clut, m_pal * sizeof(m_clut[0]));
+	}
 }
 
 // GSTextureCache::PaletteKeyHash
@@ -2159,6 +2167,10 @@ std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalet
 
 	if (it1 != map.end()) {
 		// Clut content match, HIT
+		if (need_gs_texture && !it1->second->GetPaletteGSTexture()) {
+			// Generate GSTexture and upload clut content if needed and not done yet
+			it1->second->InitializeTexture();
+		}
 		return it1->second;
 	}
 

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -1595,11 +1595,6 @@ GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFR
 
 GSTextureCache::Source::~Source()
 {
-	if (!m_should_have_tex_palette) {
-		// Eventually valid reference for m_palette is not managed by PaletteMap, so it has to be recycled
-		m_renderer->m_dev->Recycle(m_palette);
-	}
-
 	_aligned_free(m_write.rect);
 }
 

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -2094,6 +2094,8 @@ std::size_t GSTextureCache::PaletteKeyHash::operator()(const PaletteKey &key) co
 	uint16 pal = key.pal;
 	const uint32* clut = key.clut;
 
+	ASSERT((pal & 15) == 0);
+
 	size_t clut_hash = 3831179159;
 	for (uint16 i = 0; i < pal; i += 16) {
 		clut_hash = (clut_hash + 1488000301) ^ (clut[i] + 33644011);
@@ -2142,6 +2144,8 @@ GSTextureCache::PaletteMap::PaletteMap(const GSRenderer* renderer) {
 
 // Retrieves the palette with the desired clut
 std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalette(uint16 pal, bool need_gs_texture) {
+	ASSERT(pal == 16 || pal == 256);
+
 	// Choose which hash map search into:
 	//    pal == 16  : index 0
 	//    pal == 256 : index 1

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -2038,11 +2038,8 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 
 void GSTextureCache::AttachPaletteToSource(Source* s, uint16 pal, bool need_gs_texture)
 {
-	std::shared_ptr<Palette> p = m_palette_map.LookupPalette(pal, need_gs_texture);
-	s->m_palette_obj = p;
-	if (need_gs_texture) {
-		s->m_palette = p->GetPaletteGSTexture();
-	}
+	s->m_palette_obj = m_palette_map.LookupPalette(pal, need_gs_texture);
+	s->m_palette = need_gs_texture ? s->m_palette_obj->GetPaletteGSTexture() : nullptr;
 }
 
 // GSTextureCache::Palette

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -29,8 +29,8 @@ bool GSTextureCache::m_disable_partial_invalidation = false;
 bool GSTextureCache::m_wrap_gs_mem = false;
 
 GSTextureCache::GSTextureCache(GSRenderer* r)
-	: m_renderer(r),
-	m_palette_map(r)
+	: m_renderer(r)
+	, m_palette_map(r)
 {
 	s_IS_DIRECT3D11 = theApp.GetCurrentRendererType() == GSRendererType::DX1011_HW;
 	s_IS_OPENGL = theApp.GetCurrentRendererType() == GSRendererType::OGL_HW;
@@ -168,7 +168,6 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		// If it is too expensive, one could cut memory allocation in Source constructor for this
 		// use case.
 		if (palette) {
-			// Palette is attached (Palette object, clut copy and palette texture) directly because the texture is not going in the texture cache list
 			AttachPaletteToSource(src, psm_s.pal, true);
 		}
 
@@ -1337,7 +1336,6 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// Because the texture is already on the GPU, CPU can't convert it.
 		if (psm.pal > 0) {
 			src->m_should_have_tex_palette = true;
-			// Palette (Palette object, clut copy and palette texture) is going to be attached in Source lookup code exploiting initial condition !src->m_clut
 		}
 		// Disable linear filtering for various GS post-processing effect
 		// 1/ Palette is used to interpret the alpha channel of the RT as an index.
@@ -1452,11 +1450,9 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		{
 			src->m_texture = m_renderer->m_dev->CreateTexture(tw, th, Get8bitFormat());
 			src->m_should_have_tex_palette = true;
-			// Palette (Palette object, clut copy and palette texture) is going to be attached in Source lookup code exploiting initial condition !src->m_clut
 		}
 		else {
 			src->m_texture = m_renderer->m_dev->CreateTexture(tw, th);
-			// by default: src->m_should_have_tex_palette = false;
 			AttachPaletteToSource(src, psm.pal, false); // Attach only Palette object and clut copy
 		}
 	}
@@ -2037,7 +2033,6 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 	delete s;
 }
 
-// Query the PaletteMap for a valid Palette, then assign its reference, CLUT copy pointer and optionally its palette texture pointer to the Source object.
 void GSTextureCache::AttachPaletteToSource(Source* s, uint16 pal, bool need_gs_texture)
 {
 	std::shared_ptr<Palette> p = m_palette_map.LookupPalette(pal, need_gs_texture);
@@ -2050,7 +2045,6 @@ void GSTextureCache::AttachPaletteToSource(Source* s, uint16 pal, bool need_gs_t
 
 // GSTextureCache::Palette
 
-// Creates a copy of the current clut with eventually a new palette texture with its content
 GSTextureCache::Palette::Palette(const GSRenderer* renderer, uint16 pal, bool need_gs_texture) {
 	uint16 palette_size = pal * sizeof(uint32);
 	m_clut = (uint32*)_aligned_malloc(palette_size, 64);
@@ -2065,7 +2059,6 @@ GSTextureCache::Palette::Palette(const GSRenderer* renderer, uint16 pal, bool ne
 	}
 }
 
-// Default destructor, frees clut copy and recycles eventual palette texture 
 GSTextureCache::Palette::~Palette() {
 	if (GetPaletteGSTexture()) {
 		m_renderer->m_dev->Recycle(GetPaletteGSTexture()); // Recycle palette texture, if any
@@ -2098,23 +2091,23 @@ std::size_t GSTextureCache::PaletteKeyHash::operator()(const PaletteKey &key) co
 
 	size_t clut_hash = 3831179159;
 	for (uint16 i = 0; i < pal; i += 16) {
-		clut_hash = (clut_hash + 1488000301) ^ (clut[i] + 33644011);
-		clut_hash = (clut_hash + 3831179159) ^ (clut[i + 1] + 47627467);
-		clut_hash = (clut_hash + 3659574209) ^ (clut[i + 2] + 577038523);
-		clut_hash = (clut_hash + 33644011) ^ (clut[i + 3] + 3491555267);
+		clut_hash = (clut_hash + 1488000301) ^ (clut[i     ] +   33644011);
+		clut_hash = (clut_hash + 3831179159) ^ (clut[i +  1] +   47627467);
+		clut_hash = (clut_hash + 3659574209) ^ (clut[i +  2] +  577038523);
+		clut_hash = (clut_hash +   33644011) ^ (clut[i +  3] + 3491555267);
 
-		clut_hash = (clut_hash + 777771959) ^ (clut[i + 4] + 3301075993);
-		clut_hash = (clut_hash + 4019618579) ^ (clut[i + 5] + 4186992613);
-		clut_hash = (clut_hash + 3465668953) ^ (clut[i + 6] + 3043435883);
-		clut_hash = (clut_hash + 3494478943) ^ (clut[i + 7] + 3441897883);
+		clut_hash = (clut_hash +  777771959) ^ (clut[i +  4] + 3301075993);
+		clut_hash = (clut_hash + 4019618579) ^ (clut[i +  5] + 4186992613);
+		clut_hash = (clut_hash + 3465668953) ^ (clut[i +  6] + 3043435883);
+		clut_hash = (clut_hash + 3494478943) ^ (clut[i +  7] + 3441897883);
 
-		clut_hash = (clut_hash + 3432010979) ^ (clut[i + 8] + 2167922789);
-		clut_hash = (clut_hash + 1570862863) ^ (clut[i + 9] + 3401920591);
+		clut_hash = (clut_hash + 3432010979) ^ (clut[i +  8] + 2167922789);
+		clut_hash = (clut_hash + 1570862863) ^ (clut[i +  9] + 3401920591);
 		clut_hash = (clut_hash + 1002648679) ^ (clut[i + 10] + 1293530519);
-		clut_hash = (clut_hash + 551381741) ^ (clut[i + 11] + 2539834039);
+		clut_hash = (clut_hash +  551381741) ^ (clut[i + 11] + 2539834039);
 
-		clut_hash = (clut_hash + 3768974459) ^ (clut[i + 12] + 169943507);
-		clut_hash = (clut_hash + 862380703) ^ (clut[i + 13] + 2906932549);
+		clut_hash = (clut_hash + 3768974459) ^ (clut[i + 12] +  169943507);
+		clut_hash = (clut_hash +  862380703) ^ (clut[i + 13] + 2906932549);
 		clut_hash = (clut_hash + 3433082137) ^ (clut[i + 14] + 4234384109);
 		clut_hash = (clut_hash + 2679083843) ^ (clut[i + 15] + 2719605247);
 	}
@@ -2123,7 +2116,6 @@ std::size_t GSTextureCache::PaletteKeyHash::operator()(const PaletteKey &key) co
 
 // GSTextureCache::PaletteKeyEqual
 
-// Compare clut contents
 bool GSTextureCache::PaletteKeyEqual::operator()(const PaletteKey &lhs, const PaletteKey &rhs) const {
 	if (lhs.pal != rhs.pal) {
 		return false;
@@ -2134,15 +2126,14 @@ bool GSTextureCache::PaletteKeyEqual::operator()(const PaletteKey &lhs, const Pa
 
 // GSTextureCache::PaletteMap
 
-// Default constructor, stores renderer pointer and reverses space in the maps
-GSTextureCache::PaletteMap::PaletteMap(const GSRenderer* renderer) {
-	this->m_renderer = renderer;
+GSTextureCache::PaletteMap::PaletteMap(const GSRenderer* renderer)
+	: m_renderer(renderer)
+{
 	for (auto& map : m_maps) {
 		map.reserve(MAX_SIZE);
 	}
 }
 
-// Retrieves the palette with the desired clut
 std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalette(uint16 pal, bool need_gs_texture) {
 	ASSERT(pal == 16 || pal == 256);
 
@@ -2163,7 +2154,7 @@ std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalet
 		return it1->second;
 	}
 
-	// No Palette with matching clut content hash, MISS
+	// No palette with matching clut content, MISS
 
 	if (map.size() > MAX_SIZE) {
 		// If the map is too big, try to clean it by disposing and removing unused palettes, before adding the new one
@@ -2195,18 +2186,14 @@ std::shared_ptr<GSTextureCache::Palette> GSTextureCache::PaletteMap::LookupPalet
 		}
 	}
 
-	// Create new Palette using shared pointer
 	std::shared_ptr<Palette> palette = std::make_shared<Palette>(m_renderer, pal, need_gs_texture);
 	
-	// Create key for storing the Palette into the map (use copy of the clut stored into Palette itself as key attribute)
 	palette_key = { palette->GetClut(), pal };
 
-	// Add the new palette to the map
 	map.emplace(palette_key, palette);
 
 	GL_CACHE("TC, %u-bit PaletteMap (Size %u): Added new palette.", pal * sizeof(uint32), map.size());
 	
-	// Return the shared pointer to the newly created Palette
 	return palette;
 }
 

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -2125,11 +2125,11 @@ std::size_t GSTextureCache::PaletteKeyHash::operator()(const PaletteKey &key) co
 
 // Compare clut contents
 bool GSTextureCache::PaletteKeyEqual::operator()(const PaletteKey &lhs, const PaletteKey &rhs) const {
-	ASSERT(lhs.pal == rhs.pal); // By design, each map SHOULD contain only PaletteKey with the same pal value
-	
-	uint16 pal = lhs.pal;
-	uint16 palette_size = pal * sizeof(uint32);
-	return GSVector4i::compare64(lhs.clut, rhs.clut, palette_size);
+	if (lhs.pal != rhs.pal) {
+		return false;
+	}
+
+	return GSVector4i::compare64(lhs.clut, rhs.clut, lhs.pal * sizeof(lhs.clut[0]));
 };
 
 // GSTextureCache::PaletteMap

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.h
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.h
@@ -102,7 +102,6 @@ public:
 	public:
 		std::shared_ptr<Palette> m_palette_obj;
 		GSTexture* m_palette;
-		bool m_should_have_tex_palette; // Enables m_clut (and possibly m_palette) recycling on object destruction
 		uint32 m_valid[MAX_PAGES]; // each uint32 bits map to the 32 blocks of that page
 		bool m_target;
 		bool m_complete;

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.h
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.h
@@ -80,6 +80,7 @@ public:
 
 		PaletteKey GetPaletteKey();
 
+		void InitializeTexture();
 	};
 
 	struct PaletteKeyHash {

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.h
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.h
@@ -54,13 +54,13 @@ public:
 	class Palette
 	{
 	private:
-		uint32* m_clut; // Pointer to a copy of relevant clut
-		GSTexture* m_tex_palette; // Pointer to valid texture with relevant clut as content, if instantiated by the constructor
-		const GSRenderer* m_renderer; // Pointer to the current renderer, needed to recycle the eventually referenced GSTexture on destruction
+		uint32* m_clut;
+		GSTexture* m_tex_palette;
+		const GSRenderer* m_renderer;
 
 	public:
-		Palette(const GSRenderer* renderer, uint16 pal, bool need_gs_texture); // Creates a copy of the current clut and, if needed (need_gs_texture == true), a texture with its content
-		~Palette(); // Default destructor, frees clut copy and eventually recycles palette texture
+		Palette(const GSRenderer* renderer, uint16 pal, bool need_gs_texture);
+		~Palette();
 
 		// Disable copy constructor and copy operator
 		Palette(const Palette&) = delete;
@@ -70,10 +70,8 @@ public:
 		Palette(const Palette&&) = delete;
 		Palette& operator=(const Palette&&) = delete;
 
-		// Getter for clut pointer
 		uint32* GetClut();
 
-		// Getter for palette texture pointer, may be nullptr if object has been instantiated with need_gs_texture == false
 		GSTexture* GetPaletteGSTexture();
 	};
 
@@ -88,7 +86,7 @@ public:
 	};
 
 	struct PaletteKeyEqual {
-		// Compare clut contents
+		// Compare pal value and clut contents
 		bool operator()(const PaletteKey &lhs, const PaletteKey &rhs) const;
 	};
 
@@ -100,7 +98,7 @@ public:
 		void Flush(uint32 count, int layer);
 
 	public:
-		std::shared_ptr<Palette> m_palette_obj; // Shared pointer to the relevant Palette object (if any)
+		std::shared_ptr<Palette> m_palette_obj;
 		GSTexture* m_palette;
 		bool m_should_have_tex_palette; // Enables m_clut (and possibly m_palette) recycling on object destruction
 		uint32 m_valid[MAX_PAGES]; // each uint32 bits map to the 32 blocks of that page
@@ -151,7 +149,7 @@ public:
 	{
 	private:
 		static const uint16 MAX_SIZE = 65535; // Max size of each map.
-		const GSRenderer* m_renderer; // Reference to the current renderer
+		const GSRenderer* m_renderer;
 		
 		// Array of 2 maps, the first for 64B palettes and the second for 1024B palettes.
 		// Each map stores the key PaletteKey (clut copy, pal value) pointing to the relevant shared pointer to Palette object.
@@ -159,7 +157,7 @@ public:
 		std::array<std::unordered_map<PaletteKey, std::shared_ptr<Palette>, PaletteKeyHash, PaletteKeyEqual>, 2> m_maps;
 
 	public:
-		PaletteMap(const GSRenderer* renderer); // Default constructor
+		PaletteMap(const GSRenderer* renderer);
 
 		// Retrieves a shared pointer to a valid Palette from m_maps or creates a new one adding it to the data structure
 		std::shared_ptr<Palette> LookupPalette(uint16 pal, bool need_gs_texture);

--- a/plugins/GSdx/Renderers/Common/GSTextureCache.h
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.h
@@ -51,10 +51,16 @@ public:
 		void UpdateAge();
 	};
 
+	struct PaletteKey {
+		const uint32* clut;
+		uint16 pal;
+	};
+
 	class Palette
 	{
 	private:
 		uint32* m_clut;
+		uint16 m_pal;
 		GSTexture* m_tex_palette;
 		const GSRenderer* m_renderer;
 
@@ -70,14 +76,10 @@ public:
 		Palette(const Palette&&) = delete;
 		Palette& operator=(const Palette&&) = delete;
 
-		uint32* GetClut();
-
 		GSTexture* GetPaletteGSTexture();
-	};
 
-	struct PaletteKey {
-		const uint32* clut;
-		uint16 pal;
+		PaletteKey GetPaletteKey();
+
 	};
 
 	struct PaletteKeyHash {
@@ -102,7 +104,6 @@ public:
 		GSTexture* m_palette;
 		bool m_should_have_tex_palette; // Enables m_clut (and possibly m_palette) recycling on object destruction
 		uint32 m_valid[MAX_PAGES]; // each uint32 bits map to the 32 blocks of that page
-		uint32* m_clut;
 		bool m_target;
 		bool m_complete;
 		bool m_repeating;
@@ -123,6 +124,8 @@ public:
 
 		void Update(const GSVector4i& rect, int layer = 0);
 		void UpdateLayer(const GIFRegTEX0& TEX0, const GSVector4i& rect, int layer = 0);
+
+		bool ClutMatch(PaletteKey palette_key);
 	};
 
 	class Target : public Surface

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -1338,16 +1338,8 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 			// We need the palette to convert the depth to the correct alpha value.
 			if (!tex->m_palette) {
-				// If this asserts fails, the allocated palette texture (tex->m_palette)
-				// is leaked because it is not released on tex destruction
-				ASSERT(!tex->m_should_have_tex_palette); // No 8-bit texture enabled
-
-				tex->m_palette = m_dev->CreateTexture(256, 1);
-
-				const uint32* clut = m_mem.m_clut;
 				uint16 pal = GSLocalMemory::m_psm[tex->m_TEX0.PSM].pal;
-				tex->m_palette->Update(GSVector4i(0, 0, pal, 1), clut, pal * sizeof(clut[0]));
-
+				m_tc->AttachPaletteToSource(tex, pal, true);
 				dev->PSSetShaderResource(1, tex->m_palette);
 			}
 		}


### PR DESCRIPTION
Refactor and fix palette management.

1. Improve ICO hack by using palette cache for depth sampling, removing only point of creation of palette textures outside TC (removes conditional deletion of `Source::m_palette` in `~Source()`),
2. Purge comments,
3. Reformat parts of the code,
4. Centralize CLUT comparison logic in `PaletteKey` equality operator,
5. Fix and rationalize palette texture or clut copy attachment and update with respect to pre-`PaletteMap` behavior,
6. Make `PaletteMap` capable of managing at the same time Palette with and without `GSTexture`,
7. Handle possible case of `Source` lookup hit with `psm.pal` value changed.

Closes #2702 , Closes #2736 and prevents possible similar regressions.