### PR TITLE
GSdx-d3d: Add support for Depth Conversion on Direct3D11

### DIFF
--- a/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTextureCache.cpp
@@ -23,8 +23,7 @@
 #include "Renderers/Common/GSTextureCache.h"
 #include "GSUtil.h"
 
-bool s_IS_DIRECT3D11 = false;
-bool s_IS_OPENGL = false;
+bool s_IS_DIRECT3D9 = false;
 bool GSTextureCache::m_disable_partial_invalidation = false;
 bool GSTextureCache::m_wrap_gs_mem = false;
 
@@ -32,8 +31,7 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r),
 	m_palette_map(r)
 {
-	s_IS_DIRECT3D11 = theApp.GetCurrentRendererType() == GSRendererType::DX1011_HW;
-	s_IS_OPENGL = theApp.GetCurrentRendererType() == GSRendererType::OGL_HW;
+	s_IS_DIRECT3D9 = theApp.GetCurrentRendererType() == GSRendererType::DX9_HW;
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_spritehack                   = theApp.GetConfigI("UserHacks_SpriteHack");
@@ -56,7 +54,7 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 	}
 
 	m_paltex = theApp.GetConfigB("paltex");
-	m_can_convert_depth &= s_IS_OPENGL; // only supported by openGL so far
+	m_can_convert_depth &= !s_IS_DIRECT3D9; // not supported on D3D9
 	m_crc_hack_level = theApp.GetConfigT<CRCHackLevel>("crc_hack_level");
 	if (m_crc_hack_level == CRCHackLevel::Automatic)
 		m_crc_hack_level = GSUtil::GetRecommendedCRCHackLevel(theApp.GetCurrentRendererType());
@@ -1178,7 +1176,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// TODO: clean up this mess
 
 		int shader = dst->m_type != RenderTarget ? ShaderConvert_FLOAT32_TO_RGBA8 : ShaderConvert_COPY;
-		bool is_8bits = TEX0.PSM == PSM_PSMT8 && (s_IS_DIRECT3D11 || s_IS_OPENGL);
+		bool is_8bits = TEX0.PSM == PSM_PSMT8 && !s_IS_DIRECT3D9;
 
 		if (is_8bits) {
 			GL_INS("Reading RT as a packed-indexed 8 bits format");

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -552,7 +552,7 @@ GSTexture* GSDevice11::CreateSurface(int type, int w, int h, bool msaa, int form
 		desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 		break;
 	case GSTexture::DepthStencil:
-		desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+		desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
 		break;
 	case GSTexture::Texture:
 		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
@@ -599,7 +599,7 @@ GSTexture* GSDevice11::CreateRenderTarget(int w, int h, bool msaa, int format)
 
 GSTexture* GSDevice11::CreateDepthStencil(int w, int h, bool msaa, int format)
 {
-	return __super::CreateDepthStencil(w, h, msaa, format ? format : DXGI_FORMAT_D32_FLOAT_S8X24_UINT); // DXGI_FORMAT_R32G8X24_TYPELESS
+	return __super::CreateDepthStencil(w, h, msaa, format ? format : DXGI_FORMAT_R32G8X24_TYPELESS);
 }
 
 GSTexture* GSDevice11::CreateTexture(int w, int h, int format)
@@ -637,12 +637,7 @@ GSTexture* GSDevice11::CopyOffscreen(GSTexture* src, const GSVector4& sRect, int
 		format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	}
 
-	if(format != DXGI_FORMAT_R8G8B8A8_UNORM && format != DXGI_FORMAT_R16_UINT && format != DXGI_FORMAT_R32_UINT)
-	{
-		ASSERT(0);
-
-		return false;
-	}
+	ASSERT(format == DXGI_FORMAT_R8G8B8A8_UNORM || format == DXGI_FORMAT_R16_UINT || format == DXGI_FORMAT_R32_UINT);
 
 	if(GSTexture* rt = CreateRenderTarget(w, h, false, format))
 	{

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -97,6 +97,7 @@ public: // TODO
 		CComPtr<ID3D11SamplerState> ln;
 		CComPtr<ID3D11SamplerState> pt;
 		CComPtr<ID3D11DepthStencilState> dss;
+		CComPtr<ID3D11DepthStencilState> dss_write;
 		CComPtr<ID3D11BlendState> bs;
 	} m_convert;
 

--- a/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
@@ -210,7 +210,20 @@ GSTexture11::operator ID3D11ShaderResourceView*()
 	{
 		ASSERT(!m_msaa);
 
-		m_dev->CreateShaderResourceView(m_texture, NULL, &m_srv);
+		if(m_desc.Format == DXGI_FORMAT_R32G8X24_TYPELESS)
+		{
+			D3D11_SHADER_RESOURCE_VIEW_DESC srvd = {};
+
+			srvd.Format = DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
+			srvd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srvd.Texture2D.MipLevels = 1;
+
+			m_dev->CreateShaderResourceView(m_texture, &srvd, &m_srv);
+		}
+		else
+		{
+			m_dev->CreateShaderResourceView(m_texture, NULL, &m_srv);
+		}
 	}
 
 	return m_srv;
@@ -244,7 +257,19 @@ GSTexture11::operator ID3D11DepthStencilView*()
 {
 	if(!m_dsv && m_dev && m_texture)
 	{
-		m_dev->CreateDepthStencilView(m_texture, NULL, &m_dsv);
+		if(m_desc.Format == DXGI_FORMAT_R32G8X24_TYPELESS)
+		{
+			D3D11_DEPTH_STENCIL_VIEW_DESC dsvd = {};
+
+			dsvd.Format = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+			dsvd.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+
+			m_dev->CreateDepthStencilView(m_texture, &dsvd, &m_dsv);
+		}
+		else
+		{
+			m_dev->CreateDepthStencilView(m_texture, NULL, &m_dsv);
+		}
 	}
 
 	return m_dsv;

--- a/plugins/GSdx/Renderers/DX11/GSTextureCache11.h
+++ b/plugins/GSdx/Renderers/DX11/GSTextureCache11.h
@@ -32,7 +32,7 @@ protected:
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
 
-	virtual bool CanConvertDepth() { return false; }
+	virtual bool CanConvertDepth() { return m_can_convert_depth; }
 
 public:
 	GSTextureCache11(GSRenderer* r);

--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
@@ -242,6 +242,12 @@ void GSRendererDX::EmulateTextureSampler(const GSTextureCache::Source* tex)
 
 	GSVector4 WH(tw, th, w, h);
 
+	if (psm.depth)
+	{
+		// Depth fmt not supported yet, ensure draw calls are skipped to make sure convert depth works properly.
+		throw GSDXRecoverableError();
+	}
+
 	// Performance note:
 	// 1/ Don't set 0 as it is the default value
 	// 2/ Only keep aem when it is useful (avoid useless shader permutation)

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1141,8 +1141,8 @@ GSRendererHW::Hacks::Hacks()
 	, m_oo(NULL)
 	, m_cu(NULL)
 {
-	bool is_opengl = theApp.GetCurrentRendererType() == GSRendererType::OGL_HW;
-	bool can_handle_depth = (!theApp.GetConfigB("UserHacks") || !theApp.GetConfigB("UserHacks_DisableDepthSupport")) && is_opengl;
+	bool is_direct3d9 = theApp.GetCurrentRendererType() == GSRendererType::DX9_HW;
+	bool can_handle_depth = (!theApp.GetConfigB("UserHacks") || !theApp.GetConfigB("UserHacks_DisableDepthSupport")) && !is_direct3d9;
 
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::FFXII, CRC::EU, &GSRendererHW::OI_FFXII));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::FFX, CRC::RegionCount, &GSRendererHW::OI_FFX));

--- a/plugins/GSdx/Window/GSSettingsDlg.cpp
+++ b/plugins/GSdx/Window/GSSettingsDlg.cpp
@@ -727,7 +727,7 @@ void GSHacksDlg::OnInit()
 	EnableWindow(GetDlgItem(m_hWnd, IDC_MSAA_TEXT), !ogl);
 
 	// OpenGL-only hacks:
-	EnableWindow(GetDlgItem(m_hWnd, IDC_TC_DEPTH), ogl);
+	EnableWindow(GetDlgItem(m_hWnd, IDC_TC_DEPTH), !dx9);
 	EnableWindow(GetDlgItem(m_hWnd, IDC_TRI_FILTER), ogl);
 	EnableWindow(GetDlgItem(m_hWnd, IDC_TRI_FILTER_TEXT), ogl);
 


### PR DESCRIPTION
Code is ported from OpenGL.
Note: Depth fmt is still not yet supported but after this has been merged it should be a lot easier to do.

Collaborators: @KrossX , @tadanokojin , @gregory38 