### PR TITLE
GSdx-d3d: Add support for Channel Shuffle on Direct3D11

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -174,6 +174,145 @@ void GSRendererDX11::EmulateTextureShuffleAndFbmask()
 	}
 }
 
+void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex)
+{
+	// Uncomment to disable HLE emulation (allow to trace the draw call)
+	// m_channel_shuffle = false;
+
+	// First let's check we really have a channel shuffle effect
+	if (m_channel_shuffle)
+	{
+		if (m_game.title == CRC::Tekken5)
+		{
+			if (m_context->FRAME.FBW == 1)
+			{
+				// Used in stages: Secret Garden, Acid Rain, Moonlit Wilderness
+				// fprintf(stderr, "Tekken5 RGB Channel\n");
+				// m_ps_sel.channel = ChannelFetch_RGB;
+				// m_context->FRAME.FBMSK = 0xFF000000;
+				// 12 pages: 2 calls by channel, 3 channels, 1 blit
+				// Minus current draw call
+				m_skip = 12 * (3 + 3 + 1) - 1;
+				// *rt = tex->m_from_target;
+			}
+			else
+			{
+				// Could skip model drawing if wrongly detected
+				m_channel_shuffle = false;
+			}
+		}
+		else if ((tex->m_texture->GetType() == GSTexture::DepthStencil) && !(tex->m_32_bits_fmt))
+		{
+			// So far 2 games hit this code path. Urban Chaos and Tales of Abyss.
+			// Lacks shader like usual but maybe we can still use it to skip some bad draw calls.
+			// fprintf(stderr, "Tales Of Abyss Crazyness/Urban Chaos channel not supported\n");
+			throw GSDXRecoverableError();
+		}
+		else if (m_index.tail <= 64 && m_context->CLAMP.WMT == 3)
+		{
+			// Blood will tell. I think it is channel effect too but again
+			// implemented in a different way. I don't want to add more CRC stuff. So
+			// let's disable channel when the signature is different.
+			//
+			// Note: Tales Of Abyss and Tekken5 could hit this path too. Those games are
+			// handled above.
+			// fprintf(stderr, "Maybe not a channel!\n");
+			m_channel_shuffle = false;
+		}
+		else if (m_context->CLAMP.WMS == 3 && ((m_context->CLAMP.MAXU & 0x8) == 8))
+		{
+			// Read either blue or Alpha. Let's go for Blue ;)
+			// MGS3/Kill Zone
+			// fprintf(stderr, "Blue channel\n");
+			m_ps_sel.channel = ChannelFetch_BLUE;
+		}
+		else if (m_context->CLAMP.WMS == 3 && ((m_context->CLAMP.MINU & 0x8) == 0))
+		{
+			// Read either Red or Green. Let's check the V coordinate. 0-1 is likely top so
+			// red. 2-3 is likely bottom so green (actually depends on texture base pointer offset)
+			bool green = PRIM->FST && (m_vertex.buff[0].V & 32);
+			if (green && (m_context->FRAME.FBMSK & 0x00FFFFFF) == 0x00FFFFFF)
+			{
+				// Typically used in Terminator 3
+				int blue_mask = m_context->FRAME.FBMSK >> 24;
+				int green_mask = ~blue_mask & 0xFF;
+				int blue_shift = -1;
+
+				// Note: potentially we could also check the value of the clut
+				switch (m_context->FRAME.FBMSK >> 24)
+				{
+					case 0xFF: ASSERT(0);      break;
+					case 0xFE: blue_shift = 1; break;
+					case 0xFC: blue_shift = 2; break;
+					case 0xF8: blue_shift = 3; break;
+					case 0xF0: blue_shift = 4; break;
+					case 0xE0: blue_shift = 5; break;
+					case 0xC0: blue_shift = 6; break;
+					case 0x80: blue_shift = 7; break;
+					default:   ASSERT(0);      break;
+				}
+
+				int green_shift = 8 - blue_shift;
+				ps_cb.ChannelShuffle = GSVector4i(blue_mask, blue_shift, green_mask, green_shift);
+
+				if (blue_shift >= 0)
+				{
+					// fprintf(stderr, "Green/Blue channel (%d, %d)\n", blue_shift, green_shift);
+					m_ps_sel.channel = ChannelFetch_GXBY;
+					m_context->FRAME.FBMSK = 0x00FFFFFF;
+				}
+				else
+				{
+					// fprintf(stderr, "Green channel (wrong mask) (fbmask %x)\n", m_context->FRAME.FBMSK >> 24);
+					m_ps_sel.channel = ChannelFetch_GREEN;
+				}
+
+			}
+			else if (green)
+			{
+				// fprintf(stderr, "Green channel\n");
+				m_ps_sel.channel = ChannelFetch_GREEN;
+			}
+			else
+			{
+				// Pop
+				// fprintf(stderr, "Red channel\n");
+				m_ps_sel.channel = ChannelFetch_RED;
+			}
+		}
+		else
+		{
+			// fprintf(stderr, "Channel not supported\n");
+			m_channel_shuffle = false;
+		}
+	}
+
+	// Effect is really a channel shuffle effect so let's cheat a little
+	if (m_channel_shuffle)
+	{
+		dev->PSSetShaderResource(4, tex->m_from_target);
+		// Replace current draw with a fullscreen sprite
+		//
+		// Performance GPU note: it could be wise to reduce the size to
+		// the rendered size of the framebuffer
+
+		GSVertex* s = &m_vertex.buff[0];
+		s[0].XYZ.X = (uint16)(m_context->XYOFFSET.OFX + 0);
+		s[1].XYZ.X = (uint16)(m_context->XYOFFSET.OFX + 16384);
+		s[0].XYZ.Y = (uint16)(m_context->XYOFFSET.OFY + 0);
+		s[1].XYZ.Y = (uint16)(m_context->XYOFFSET.OFY + 16384);
+
+		m_vertex.head = m_vertex.tail = m_vertex.next = 2;
+		m_index.tail = 2;
+	}
+	else
+	{
+#ifdef _DEBUG
+		dev->PSSetShaderResource(4, NULL);
+#endif
+	}
+}
+
 void GSRendererDX11::SetupIA(const float& sx, const float& sy)
 {
 	GSDevice11* dev = (GSDevice11*)m_dev;

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -290,6 +290,7 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 	// Effect is really a channel shuffle effect so let's cheat a little
 	if (m_channel_shuffle)
 	{
+		// FIXME: Slot 4 - unbind texture when it isn't used.
 		dev->PSSetShaderResource(4, tex->m_from_target);
 		// Replace current draw with a fullscreen sprite
 		//

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.h
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.h
@@ -29,6 +29,7 @@ class GSRendererDX11 : public GSRendererDX
 {
 protected:
 	void EmulateTextureShuffleAndFbmask();
+	void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
 	void SetupIA(const float& sx, const float& sy);
 
 public:

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -209,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[23];
+		std::string str[24];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -232,8 +232,9 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[18] = format("%d", sel.shuffle);
 		str[19] = format("%d", sel.read_ba);
 		str[20] = format("%d", sel.channel);
-		str[21] = format("%d", sel.fmt >> 2);
-		str[22] = format("%d", m_upscale_multiplier);
+		str[21] = format("%d", sel.depth_fmt);
+		str[22] = format("%d", sel.fmt >> 2);
+		str[23] = format("%d", m_upscale_multiplier);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -258,8 +259,9 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_SHUFFLE", str[18].c_str() },
 			{"PS_READ_BA", str[19].c_str() },
 			{"PS_CHANNEL_FETCH", str[20].c_str() },
-			{"PS_PAL_FMT", str[21].c_str() },
-			{"PS_SCALE_FACTOR", str[22].c_str() },
+			{"PS_DEPTH_FMT", str[21].c_str() },
+			{"PS_PAL_FMT", str[22].c_str() },
+			{"PS_SCALE_FACTOR", str[23].c_str() },
 			{NULL, NULL},
 		};
 

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -209,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[22];
+		std::string str[23];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -231,8 +231,9 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[17] = format("%d", sel.point_sampler);
 		str[18] = format("%d", sel.shuffle);
 		str[19] = format("%d", sel.read_ba);
-		str[20] = format("%d", sel.fmt >> 2);
-		str[21] = format("%d", m_upscale_multiplier);
+		str[20] = format("%d", sel.channel);
+		str[21] = format("%d", sel.fmt >> 2);
+		str[22] = format("%d", m_upscale_multiplier);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -256,8 +257,9 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_POINT_SAMPLER", str[17].c_str()},
 			{"PS_SHUFFLE", str[18].c_str() },
 			{"PS_READ_BA", str[19].c_str() },
-			{"PS_PAL_FMT", str[20].c_str() },
-			{"PS_SCALE_FACTOR", str[21].c_str() },
+			{"PS_CHANNEL_FETCH", str[20].c_str() },
+			{"PS_PAL_FMT", str[21].c_str() },
+			{"PS_SCALE_FACTOR", str[22].c_str() },
 			{NULL, NULL},
 		};
 

--- a/plugins/GSdx/Renderers/DX9/GSRendererDX9.h
+++ b/plugins/GSdx/Renderers/DX9/GSRendererDX9.h
@@ -35,6 +35,7 @@ protected:
 	} m_fba;
 
 	void EmulateTextureShuffleAndFbmask();
+	void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
 	void SetupIA(const float& sx, const float& sy);
 	void UpdateFBA(GSTexture* rt);
 

--- a/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
@@ -94,6 +94,7 @@ public:
 		GSVector4 MinMax;
 		GSVector4 MinF_TA;
 		GSVector4i MskFix;
+		GSVector4i ChannelShuffle;
 
 		GSVector4 TC_OffsetHack;
 
@@ -105,6 +106,7 @@ public:
 			MinMax = GSVector4::zero();
 			MinF_TA = GSVector4::zero();
 			MskFix = GSVector4i::zero();
+			ChannelShuffle = GSVector4i::zero();
 		}
 
 		__forceinline bool Update(const PSConstantBuffer* cb)
@@ -112,7 +114,7 @@ public:
 			GSVector4i* a = (GSVector4i*)this;
 			GSVector4i* b = (GSVector4i*)cb;
 
-			if(!((a[0] == b[0]) /*& (a[1] == b1)*/ & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4]) & (a[5] == b[5])).alltrue()) // if WH matches HalfTexel does too
+			if(!((a[0] == b[0]) /*& (a[1] == b1)*/ & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4]) & (a[5] == b[5]) & (a[6] == b[6])).alltrue()) // if WH matches HalfTexel does too
 			{
 				a[0] = b[0];
 				a[1] = b[1];
@@ -120,6 +122,7 @@ public:
 				a[3] = b[3];
 				a[4] = b[4];
 				a[5] = b[5];
+				a[6] = b[6];
 
 				return true;
 			}

--- a/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
@@ -201,13 +201,16 @@ public:
 				uint32 rt:1;
 				uint32 colclip:2;
 
+				// Others ways to fetch the texture
+				uint32 channel:3;
+
 				// Hack
 				uint32 aout:1;
 				uint32 spritehack:1;
 				uint32 tcoffsethack:1;
 				uint32 point_sampler:1;
 
-				uint32 _free:30;
+				uint32 _free:27;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
@@ -179,6 +179,7 @@ public:
 				// Format
 				uint32 fmt:4;
 				uint32 dfmt:2;
+				uint32 depth_fmt:2;
 				// Alpha extension/Correction
 				uint32 aem:1;
 				uint32 fba:1;
@@ -213,7 +214,7 @@ public:
 				uint32 tcoffsethack:1;
 				uint32 point_sampler:1;
 
-				uint32 _free:27;
+				uint32 _free:25;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
@@ -240,6 +240,17 @@ void GSRendererDX::EmulateTextureSampler(const GSTextureCache::Source* tex)
 			bilinear &= m_vt.IsLinear();
 		}
 
+		// Depth format
+		if (tex->m_texture->GetType() == GSTexture::DepthStencil)
+		{
+			// Require a float conversion if the texure is a depth format
+			m_ps_sel.depth_fmt = (psm.bpp == 16) ? 2 : 1;
+			// m_vs_sel.int_fst = !PRIM->FST; // select float/int coordinate
+
+			// Don't force interpolation on depth format
+			bilinear &= m_vt.IsLinear();
+		}
+
 		GSVector4 half_offset = RealignTargetTextureCoordinate(tex);
 		vs_cb.Texture_Scale_Offset.z = half_offset.x;
 		vs_cb.Texture_Scale_Offset.w = half_offset.y;

--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.h
@@ -37,10 +37,10 @@ protected:
 	void ResetStates();
 	void EmulateAtst(const int pass, const GSTextureCache::Source* tex);
 	void EmulateZbuffer();
-	void EmulateChannelShuffle(const GSTextureCache::Source* tex);
 	void EmulateTextureSampler(const GSTextureCache::Source* tex);
 	virtual void DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* tex);
 	virtual void EmulateTextureShuffleAndFbmask() = 0;
+	virtual void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex) = 0;
 	virtual void SetupIA(const float& sx, const float& sy) = 0;
 	virtual void UpdateFBA(GSTexture* rt) {}
 

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -105,6 +105,7 @@ cbuffer cb1
 	float2 MinF;
 	float2 TA;
 	uint4 MskFix;
+	int4 ChannelShuffle;
 	float4 TC_OffsetHack;
 };
 

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -40,6 +40,7 @@
 #define PS_SHUFFLE 0
 #define PS_READ_BA 0
 #define PS_PAL_FMT 0
+#define PS_CHANNEL_FETCH 0
 #endif
 
 struct VS_INPUT
@@ -82,6 +83,7 @@ struct PS_OUTPUT
 Texture2D<float4> Texture : register(t0);
 Texture2D<float4> Palette : register(t1);
 Texture2D<float4> RTCopy : register(t2);
+Texture2D<float4> RawTexture : register(t4);
 SamplerState TextureSampler : register(s0);
 SamplerState PaletteSampler : register(s1);
 SamplerState RTCopySampler : register(s2);
@@ -134,6 +136,50 @@ float4 sample_p(float u)
 float4 sample_rt(float2 uv)
 {
 	return RTCopy.Sample(RTCopySampler, uv);
+}
+
+float4 fetch_raw_color(int2 xy)
+{
+	return RawTexture.Load(int3(xy, 0));
+}
+
+float4 fetch_red(int2 xy)
+{
+	float4 rt = fetch_raw_color(xy);
+	return sample_p(rt.r);
+}
+
+float4 fetch_blue(int2 xy)
+{
+	float4 rt = fetch_raw_color(xy);
+	return sample_p(rt.b);
+}
+
+float4 fetch_green(int2 xy)
+{
+	float4 rt = fetch_raw_color(xy);
+	return sample_p(rt.g);
+}
+
+float4 fetch_alpha(int2 xy)
+{
+	float4 rt = fetch_raw_color(xy);
+	return sample_p(rt.a);
+}
+
+float4 fetch_rgb(int2 xy)
+{
+	float4 rt = fetch_raw_color(xy);
+	float4 c = float4(sample_p(rt.r).r, sample_p(rt.g).g, sample_p(rt.b).b, 1.0);
+	return c;
+}
+
+float4 fetch_gXbY(int2 xy)
+{
+	int4 rt = (int4)(fetch_raw_color(xy) * 255.0);
+	int green = (rt.g >> ChannelShuffle.w) & ChannelShuffle.z;
+	int blue = (rt.b << ChannelShuffle.y) & ChannelShuffle.x;
+	return (float4)(green | blue) / 255.0;
 }
 
 #elif SHADER_MODEL <= 0x300
@@ -594,7 +640,21 @@ float4 ps_color(PS_INPUT input)
 {
 	datst(input);
 
+#if PS_CHANNEL_FETCH == 1
+	float4 t = fetch_red(int2(input.p.xy));
+#elif PS_CHANNEL_FETCH == 2
+	float4 t = fetch_green(int2(input.p.xy));
+#elif PS_CHANNEL_FETCH == 3
+	float4 t = fetch_blue(int2(input.p.xy));
+#elif PS_CHANNEL_FETCH == 4
+	float4 t = fetch_alpha(int2(input.p.xy));
+#elif PS_CHANNEL_FETCH == 5
+	float4 t = fetch_rgb(int2(input.p.xy));
+#elif PS_CHANNEL_FETCH == 6
+	float4 t = fetch_gXbY(int2(input.p.xy));
+#else
 	float4 t = sample(input.t.xy, input.t.w);
+#endif
 
 	float4 c = tfx(t, input.c);
 


### PR DESCRIPTION
Note the feature is still not yet complete, copy function needs to be
implemented (suggested by Gregory) but it can be done at a later date,
this still fixes a bunch of issues on various games even in it's current state.

Related: https://github.com/PCSX2/pcsx2/issues/1318