### PR TITLE
GSdx-d3d11: Add Tales of Abyss and Urban Chaos HLE channel workarounds

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -203,10 +203,20 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 		}
 		else if ((tex->m_texture->GetType() == GSTexture::DepthStencil) && !(tex->m_32_bits_fmt))
 		{
-			// So far 2 games hit this code path. Urban Chaos and Tales of Abyss.
-			// Lacks shader like usual but maybe we can still use it to skip some bad draw calls.
-			// fprintf(stderr, "Tales Of Abyss Crazyness/Urban Chaos channel not supported\n");
-			throw GSDXRecoverableError();
+			// So far 2 games hit this code path. Urban Chaos and Tales of Abyss
+			// UC: will copy depth to green channel
+			// ToA: will copy depth to alpha channel
+			if ((m_context->FRAME.FBMSK & 0xFF0000) == 0xFF0000)
+			{
+				// Green channel is masked
+				// fprintf(stderr, "Tales Of Abyss Crazyness (MSB 16b depth to Alpha)\n");
+				m_ps_sel.tales_of_abyss_hle = 1;
+			}
+			else
+			{
+				// fprintf(stderr, "Urban Chaos Crazyness (Green extraction)\n");
+				m_ps_sel.urban_chaos_hle = 1;
+			}
 		}
 		else if (m_index.tail <= 64 && m_context->CLAMP.WMT == 3)
 		{

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -209,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[24];
+		std::string str[26];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -232,9 +232,11 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[18] = format("%d", sel.shuffle);
 		str[19] = format("%d", sel.read_ba);
 		str[20] = format("%d", sel.channel);
-		str[21] = format("%d", sel.depth_fmt);
-		str[22] = format("%d", sel.fmt >> 2);
-		str[23] = format("%d", m_upscale_multiplier);
+		str[21] = format("%d", sel.tales_of_abyss_hle);
+		str[22] = format("%d", sel.urban_chaos_hle);
+		str[23] = format("%d", sel.depth_fmt);
+		str[24] = format("%d", sel.fmt >> 2);
+		str[25] = format("%d", m_upscale_multiplier);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -259,9 +261,11 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_SHUFFLE", str[18].c_str() },
 			{"PS_READ_BA", str[19].c_str() },
 			{"PS_CHANNEL_FETCH", str[20].c_str() },
-			{"PS_DEPTH_FMT", str[21].c_str() },
-			{"PS_PAL_FMT", str[22].c_str() },
-			{"PS_SCALE_FACTOR", str[23].c_str() },
+			{"PS_TALES_OF_ABYSS_HLE", str[21].c_str() },
+			{"PS_URBAN_CHAOS_HLE", str[22].c_str() },
+			{"PS_DEPTH_FMT", str[23].c_str() },
+			{"PS_PAL_FMT", str[24].c_str() },
+			{"PS_SCALE_FACTOR", str[25].c_str() },
 			{NULL, NULL},
 		};
 

--- a/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
@@ -212,9 +212,11 @@ public:
 				uint32 aout:1;
 				uint32 spritehack:1;
 				uint32 tcoffsethack:1;
+				uint32 urban_chaos_hle:1;
+				uint32 tales_of_abyss_hle:1;
 				uint32 point_sampler:1;
 
-				uint32 _free:25;
+				uint32 _free:23;
 			};
 
 			uint64 key;


### PR DESCRIPTION
tfx.tx: Add support for Tales of Abyss and Urban Chaos HLE shader. 
Add sample_depth function, note only Tales of Abyss and Urban Chaos
depth sampling is supported, full depth fmt will need to wait a little
longer.

GSdx-d3d11: Add support for Tales of Abyss and Urban Chaos shader bit  and shader macro.


GSdx-d3d11: Plug the TOA and Urban Chaos code in to channel shuffle.
On Tales of Abyss it fixes blur,
On Urban Chaos it fixes fog/transparent layer.

Note: Depth needs to be enabled on d3d11 to emulate the effect.
No support for d3d9 ofc.