### PR TITLE
GSdx-d3d11: Detect FB read on Slot 4

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1216,8 +1216,6 @@ void GSDevice11::PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, G
 	{
 		m_state.ps_sr_views[i] = srv;
 		m_state.ps_sr_texture[i] = (GSTexture11*)sr;
-
-		m_srv_changed = true;
 	}
 }
 
@@ -1228,8 +1226,6 @@ void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* 
 		m_state.ps_ss[0] = ss0;
 		m_state.ps_ss[1] = ss1;
 		m_state.ps_ss[2] = ss2;
-
-		m_ss_changed = true;
 	}
 }
 
@@ -1242,26 +1238,20 @@ void GSDevice11::PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb)
 		m_ctx->PSSetShader(ps, NULL, 0);
 	}
 
-	if(m_srv_changed)
-	{
-		m_ctx->PSSetShaderResources(0, m_state.ps_sr_views.size(), m_state.ps_sr_views.data());
-
-		m_srv_changed = false;
-	}
-
-	if(m_ss_changed)
-	{
-		m_ctx->PSSetSamplers(0, countof(m_state.ps_ss), m_state.ps_ss);
-
-		m_ss_changed = false;
-	}
-
 	if(m_state.ps_cb != ps_cb)
 	{
 		m_state.ps_cb = ps_cb;
 
 		m_ctx->PSSetConstantBuffers(0, 1, &ps_cb);
 	}
+
+	PSUpdateShaderState();
+}
+
+void GSDevice11::PSUpdateShaderState()
+{
+	m_ctx->PSSetShaderResources(0, m_state.ps_sr_views.size(), m_state.ps_sr_views.data());
+	m_ctx->PSSetSamplers(0, countof(m_state.ps_ss), m_state.ps_ss);
 }
 
 void GSDevice11::OMSetDepthStencilState(ID3D11DepthStencilState* dss, uint8 sref)

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -676,6 +676,18 @@ void GSDevice11::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r)
 	m_ctx->CopySubresourceRegion(*(GSTexture11*)dTex, 0, 0, 0, 0, *(GSTexture11*)sTex, 0, &box);
 }
 
+GSTexture* GSDevice11::CopyRenderTarget(GSTexture* src)
+{
+	int w = src->GetWidth();
+	int h = src->GetHeight();
+
+	GSTexture* dest = CreateRenderTarget(w, h, false);
+
+	CopyRect(src, dest, GSVector4i(0, 0, w, h));
+
+	return dest;
+}
+
 void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, int shader, bool linear)
 {
 	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[shader], NULL, linear);

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1181,7 +1181,7 @@ void GSDevice11::PSSetShaderResources(GSTexture* sr0, GSTexture* sr1)
 	PSSetShaderResource(0, sr0);
 	PSSetShaderResource(1, sr1);
 
-	for(size_t i = 2; i < countof(m_state.ps_srv); i++)
+	for(size_t i = 2; i < m_state.ps_sr_views.size(); i++)
 	{
 		PSSetShaderResource(i, NULL);
 	}
@@ -1193,16 +1193,17 @@ void GSDevice11::PSSetShaderResource(int i, GSTexture* sr)
 
 	if(sr) srv = *(GSTexture11*)sr;
 
-	PSSetShaderResourceView(i, srv);
+	PSSetShaderResourceView(i, srv, sr);
 }
 
-void GSDevice11::PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv)
+void GSDevice11::PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, GSTexture* sr)
 {
-	ASSERT(i < countof(m_state.ps_srv));
+	ASSERT(i < m_state.ps_sr_views.size());
 
-	if(m_state.ps_srv[i] != srv)
+	if(m_state.ps_sr_views[i] != srv)
 	{
-		m_state.ps_srv[i] = srv;
+		m_state.ps_sr_views[i] = srv;
+		m_state.ps_sr_texture[i] = (GSTexture11*)sr;
 
 		m_srv_changed = true;
 	}
@@ -1231,7 +1232,7 @@ void GSDevice11::PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb)
 
 	if(m_srv_changed)
 	{
-		m_ctx->PSSetShaderResources(0, countof(m_state.ps_srv), m_state.ps_srv);
+		m_ctx->PSSetShaderResources(0, m_state.ps_sr_views.size(), m_state.ps_sr_views.data());
 
 		m_srv_changed = false;
 	}

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1286,9 +1286,10 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector
 	if(rt) rtv = *(GSTexture11*)rt;
 	if(ds) dsv = *(GSTexture11*)ds;
 
-	if(m_state.rtv != rtv || m_state.dsv != dsv)
+	if(m_state.rt_view != rtv || m_state.dsv != dsv)
 	{
-		m_state.rtv = rtv;
+		m_state.rt_view = rtv;
+		m_state.rt_texture = (GSTexture11*)rt;
 		m_state.dsv = dsv;
 
 		m_ctx->OMSetRenderTargets(1, &rtv, dsv);
@@ -1326,7 +1327,8 @@ void GSDevice11::OMSetRenderTargets(const GSVector2i& rtsize, int count, ID3D11U
 {
 	m_ctx->OMSetRenderTargetsAndUnorderedAccessViews(0, NULL, NULL, 0, count, uav, counters);
 
-	m_state.rtv = NULL;
+	m_state.rt_view = NULL;
+	m_state.rt_texture = NULL;
 	m_state.dsv = NULL;
 
 	if(m_state.viewport != rtsize)

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -79,7 +79,8 @@ class GSDevice11 : public GSDeviceDX
 		uint8 sref;
 		ID3D11BlendState* bs;
 		float bf;
-		ID3D11RenderTargetView* rtv;
+		ID3D11RenderTargetView* rt_view;
+		GSTexture11* rt_texture;
 		ID3D11DepthStencilView* dsv;
 	} m_state;
 

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -69,7 +69,8 @@ class GSDevice11 : public GSDeviceDX
 		ID3D11Buffer* vs_cb;
 		ID3D11GeometryShader* gs;
 		ID3D11Buffer* gs_cb;
-		ID3D11ShaderResourceView* ps_srv[16];
+		std::array<ID3D11ShaderResourceView*, 16> ps_sr_views;
+		std::array<GSTexture11*, 16> ps_sr_texture;
 		ID3D11PixelShader* ps;
 		ID3D11Buffer* ps_cb;
 		ID3D11SamplerState* ps_ss[3];
@@ -209,7 +210,7 @@ public:
 	void GSSetShader(ID3D11GeometryShader* gs, ID3D11Buffer* gs_cb = NULL);
 	void PSSetShaderResources(GSTexture* sr0, GSTexture* sr1);
 	void PSSetShaderResource(int i, GSTexture* sr);
-	void PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv);
+	void PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1, ID3D11SamplerState* ss2 = NULL);
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, uint8 sref);

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -53,7 +53,6 @@ class GSDevice11 : public GSDeviceDX
 	CComPtr<ID3D11Buffer> m_ib;
 	CComPtr<ID3D11Buffer> m_ib_old;
 
-	bool m_srv_changed, m_ss_changed;
 	float m_hack_topleft_offset;
 
 	int m_mipmap;
@@ -214,6 +213,7 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr);
 	void PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
+	void PSUpdateShaderState();
 	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1, ID3D11SamplerState* ss2 = NULL);
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, uint8 sref);
 	void OMSetBlendState(ID3D11BlendState* bs, float bf);

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -192,6 +192,8 @@ public:
 
 	GSTexture* CopyOffscreen(GSTexture* src, const GSVector4& sRect, int w, int h, int format = 0, int ps_shader = 0);
 
+	GSTexture* CopyRenderTarget(GSTexture* src);
+
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r);
 
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, int shader = 0, bool linear = true);

--- a/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
@@ -274,3 +274,8 @@ GSTexture11::operator ID3D11DepthStencilView*()
 
 	return m_dsv;
 }
+
+bool GSTexture11::Equal(GSTexture11* tex)
+{
+	return tex && m_texture == tex->m_texture;
+}

--- a/plugins/GSdx/Renderers/DX11/GSTexture11.h
+++ b/plugins/GSdx/Renderers/DX11/GSTexture11.h
@@ -44,6 +44,7 @@ public:
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
 	void Unmap();
 	bool Save(const std::string& fn, bool dds = false);
+	bool Equal(GSTexture11* tex);
 
 	operator ID3D11Texture2D*();
 	operator ID3D11ShaderResourceView*();


### PR DESCRIPTION
Check for FB read on slot 4.
If it happens, copy the render target and replace slot 4.

This is useful for properly emulating the channel shuffle effect on dx11.

Much thanks to @gregory38 for his help on this.