### PR TITLE
GSdx-d3d11: Redo destination format and alpha output

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -209,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[26];
+		std::string str[27];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -234,9 +234,10 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[20] = format("%d", sel.channel);
 		str[21] = format("%d", sel.tales_of_abyss_hle);
 		str[22] = format("%d", sel.urban_chaos_hle);
-		str[23] = format("%d", sel.depth_fmt);
-		str[24] = format("%d", sel.fmt >> 2);
-		str[25] = format("%d", m_upscale_multiplier);
+		str[23] = format("%d", sel.dfmt);
+		str[24] = format("%d", sel.depth_fmt);
+		str[25] = format("%d", sel.fmt >> 2);
+		str[26] = format("%d", m_upscale_multiplier);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -263,9 +264,10 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_CHANNEL_FETCH", str[20].c_str() },
 			{"PS_TALES_OF_ABYSS_HLE", str[21].c_str() },
 			{"PS_URBAN_CHAOS_HLE", str[22].c_str() },
-			{"PS_DEPTH_FMT", str[23].c_str() },
-			{"PS_PAL_FMT", str[24].c_str() },
-			{"PS_SCALE_FACTOR", str[25].c_str() },
+			{"PS_DFMT", str[23].c_str() },
+			{"PS_DEPTH_FMT", str[24].c_str() },
+			{"PS_PAL_FMT", str[25].c_str() },
+			{"PS_SCALE_FACTOR", str[26].c_str() },
 			{NULL, NULL},
 		};
 

--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
@@ -583,14 +583,16 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 	m_ps_sel.clr1 = m_om_bsel.IsCLR1();
 	m_ps_sel.fba = m_context->FBA.FBA;
 
+	// FIXME: Purge aout with AlphaHack when FbMask emulation is added.
 	if (m_ps_sel.shuffle)
 	{
 		m_ps_sel.aout = 0;
 	}
 	else
 	{
-		m_ps_sel.aout = UserHacks_AlphaHack || m_context->FRAME.PSM == PSM_PSMCT16 || m_context->FRAME.PSM == PSM_PSMCT16S || (m_context->FRAME.FBMSK & 0xff000000) == 0x7f000000 ? 1 : 0;
+		m_ps_sel.aout = UserHacks_AlphaHack || (m_context->FRAME.FBMSK & 0xff000000) == 0x7f000000;
 	}
+	// END OF FIXME
 
 	if (PRIM->FGE)
 	{

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -39,6 +39,7 @@
 #define PS_POINT_SAMPLER 0
 #define PS_SHUFFLE 0
 #define PS_READ_BA 0
+#define PS_DFMT 0
 #define PS_DEPTH_FMT 0
 #define PS_PAL_FMT 0
 #define PS_CHANNEL_FETCH 0
@@ -1002,13 +1003,13 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 	output.c1 = c.a * 2; // used for alpha blending
 
-	if(PS_AOUT) // 16 bit output
+	if((PS_DFMT == FMT_16) || PS_AOUT) // 16 bit output
 	{
 		float a = 128.0f / 255; // alpha output will be 0x80
 
 		c.a = PS_FBA ? a : step(0.5, c.a) * a;
 	}
-	else if(PS_FBA)
+	else if((PS_DFMT == FMT_32) && PS_FBA)
 	{
 		if(c.a < 0.5) c.a += 0.5;
 	}


### PR DESCRIPTION
Dfmt in texture shuffle function already picks the 16 format on slot 2
so it's better to let it call the shader instead of aout.

We can keep old aout code until FbMask emulation is added on d3d11. We
can purge aout along with alpha hack then.