### PR TITLE
GSdx-d3d11: Adjust DATE code, remove RTCopy sampler

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1238,13 +1238,12 @@ void GSDevice11::PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, G
 	}
 }
 
-void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1, ID3D11SamplerState* ss2)
+void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1)
 {
-	if(m_state.ps_ss[0] != ss0 || m_state.ps_ss[1] != ss1 || m_state.ps_ss[2] != ss2)
+	if(m_state.ps_ss[0] != ss0 || m_state.ps_ss[1] != ss1)
 	{
 		m_state.ps_ss[0] = ss0;
 		m_state.ps_ss[1] = ss1;
-		m_state.ps_ss[2] = ss2;
 	}
 }
 

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -214,7 +214,7 @@ public:
 	void PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState();
-	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1, ID3D11SamplerState* ss2 = NULL);
+	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1);
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, uint8 sref);
 	void OMSetBlendState(ID3D11BlendState* bs, float bf);
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL);
@@ -224,8 +224,6 @@ public:
 	void SetupGS(GSSelector sel, const GSConstantBuffer* cb);
 	void SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSelector ssel);
 	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix);
-
-	bool HasStencil() { return true; }
 
 	ID3D11Device* operator->() {return m_dev;}
 	operator ID3D11Device*() {return m_dev;}

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -103,19 +103,17 @@ void GSDevice11::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 
 	if(i == m_vs.end())
 	{
-		std::string str[4];
+		std::string str[3];
 
 		str[0] = format("%d", sel.bppz);
 		str[1] = format("%d", sel.tme);
 		str[2] = format("%d", sel.fst);
-		str[3] = format("%d", sel.rtcopy);
 
 		D3D_SHADER_MACRO macro[] =
 		{
 			{"VS_BPPZ", str[0].c_str()},
 			{"VS_TME", str[1].c_str()},
 			{"VS_FST", str[2].c_str()},
-			{"VS_RTCOPY", str[3].c_str()},
 			{NULL, NULL},
 		};
 
@@ -209,7 +207,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[27];
+		std::string str[26];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -225,19 +223,18 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[11] = format("%d", sel.aout);
 		str[12] = format("%d", sel.ltf);
 		str[13] = format("%d", sel.colclip);
-		str[14] = format("%d", sel.date);
-		str[15] = format("%d", sel.spritehack);
-		str[16] = format("%d", sel.tcoffsethack);
-		str[17] = format("%d", sel.point_sampler);
-		str[18] = format("%d", sel.shuffle);
-		str[19] = format("%d", sel.read_ba);
-		str[20] = format("%d", sel.channel);
-		str[21] = format("%d", sel.tales_of_abyss_hle);
-		str[22] = format("%d", sel.urban_chaos_hle);
-		str[23] = format("%d", sel.dfmt);
-		str[24] = format("%d", sel.depth_fmt);
-		str[25] = format("%d", sel.fmt >> 2);
-		str[26] = format("%d", m_upscale_multiplier);
+		str[14] = format("%d", sel.spritehack);
+		str[15] = format("%d", sel.tcoffsethack);
+		str[16] = format("%d", sel.point_sampler);
+		str[17] = format("%d", sel.shuffle);
+		str[18] = format("%d", sel.read_ba);
+		str[19] = format("%d", sel.channel);
+		str[20] = format("%d", sel.tales_of_abyss_hle);
+		str[21] = format("%d", sel.urban_chaos_hle);
+		str[22] = format("%d", sel.dfmt);
+		str[23] = format("%d", sel.depth_fmt);
+		str[24] = format("%d", sel.fmt >> 2);
+		str[25] = format("%d", m_upscale_multiplier);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -255,19 +252,18 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_AOUT", str[11].c_str()},
 			{"PS_LTF", str[12].c_str()},
 			{"PS_COLCLIP", str[13].c_str()},
-			{"PS_DATE", str[14].c_str()},
-			{"PS_SPRITEHACK", str[15].c_str()},
-			{"PS_TCOFFSETHACK", str[16].c_str()},
-			{"PS_POINT_SAMPLER", str[17].c_str()},
-			{"PS_SHUFFLE", str[18].c_str() },
-			{"PS_READ_BA", str[19].c_str() },
-			{"PS_CHANNEL_FETCH", str[20].c_str() },
-			{"PS_TALES_OF_ABYSS_HLE", str[21].c_str() },
-			{"PS_URBAN_CHAOS_HLE", str[22].c_str() },
-			{"PS_DFMT", str[23].c_str() },
-			{"PS_DEPTH_FMT", str[24].c_str() },
-			{"PS_PAL_FMT", str[25].c_str() },
-			{"PS_SCALE_FACTOR", str[26].c_str() },
+			{"PS_SPRITEHACK", str[14].c_str()},
+			{"PS_TCOFFSETHACK", str[15].c_str()},
+			{"PS_POINT_SAMPLER", str[16].c_str()},
+			{"PS_SHUFFLE", str[17].c_str() },
+			{"PS_READ_BA", str[18].c_str() },
+			{"PS_CHANNEL_FETCH", str[19].c_str() },
+			{"PS_TALES_OF_ABYSS_HLE", str[20].c_str() },
+			{"PS_URBAN_CHAOS_HLE", str[21].c_str() },
+			{"PS_DFMT", str[22].c_str() },
+			{"PS_DEPTH_FMT", str[23].c_str() },
+			{"PS_PAL_FMT", str[24].c_str() },
+			{"PS_SCALE_FACTOR", str[25].c_str() },
 			{NULL, NULL},
 		};
 
@@ -332,7 +328,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		}
 	}
 
-	PSSetSamplerState(ss0, ss1, sel.date ? m_rt_ss : NULL);
+	PSSetSamplerState(ss0, ss1);
 
 	PSSetShader(i->second, m_ps_cb);
 }

--- a/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
@@ -74,9 +74,8 @@ public:
 				uint32 bppz:2;
 				uint32 tme:1;
 				uint32 fst:1;
-				uint32 rtcopy:1;
 
-				uint32 _free:27;
+				uint32 _free:28;
 			};
 
 			uint32 key;
@@ -188,7 +187,6 @@ public:
 				// Fog
 				uint32 fog:1;
 				// Pixel test
-				uint32 date:2;
 				uint32 atst:3;
 				// Color sampling
 				uint32 fst:1;
@@ -204,7 +202,6 @@ public:
 				// *** Word 2
 				// Blend and Colclip
 				uint32 clr1:1;
-				uint32 rt:1;
 				uint32 colclip:2;
 
 				// Others ways to fetch the texture
@@ -218,7 +215,7 @@ public:
 				uint32 tales_of_abyss_hle:1;
 				uint32 point_sampler:1;
 
-				uint32 _free:23;
+				uint32 _free:26;
 			};
 
 			uint64 key;
@@ -338,8 +335,6 @@ public:
 	virtual void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix) = 0;
 
 	virtual void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm) = 0;
-
-	virtual bool HasStencil() = 0;
 
 	static bool LoadD3DCompiler();
 	static void FreeD3DCompiler();

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -519,8 +519,6 @@ public:
 	// Used by OpenGL, so the same calling convention is required.
 	static void APIENTRY DebugOutputToFile(GLenum gl_source, GLenum gl_type, GLuint id, GLenum gl_severity, GLsizei gl_length, const GLchar *gl_message, const void* userParam);
 
-	bool HasStencil() { return true; }
-
 	bool Create(const std::shared_ptr<GSWnd> &wnd);
 	bool Reset(int w, int h);
 	void Flip();


### PR DESCRIPTION
tfx.fx: Remove datst (DATE).
Code was never hit on D3D11. D3D11 uses stencil operations.

GSdx-d3d11: Adjust DATE code.
Remove DATE shader macro and bit.
Remove useless HasStencil case. If DATE is enabled stencil is also
enabled, this check is useless.
Also remove leftover rtCopy , RTCopy sampler and rt cases.