### PR TITLE
GSdx-d3d: Update EmulateZbuffer code to use bppz for depth masking

### DIFF
--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
@@ -116,10 +116,12 @@ void GSRendererDX::EmulateZbuffer()
 	else if (m_context->ZBUF.PSM == PSM_PSMZ24)
 	{
 		max_z = 0xFFFFFF;
+		m_vs_sel.bppz = 1;
 	}
 	else
 	{
 		max_z = 0xFFFF;
+		m_vs_sel.bppz = 2;
 	}
 
 	// The real GS appears to do no masking based on the Z buffer format and writing larger Z values


### PR DESCRIPTION
This removes the old code for VS_BPPZ which was used in the older
EmulateZbuffer code and replace it with a VS constant buffer bit
DepthMask. This matches the gl code and behavior.