### PR TITLE
gsdx-d3d11: enable splitting of alpha in dumps

### DIFF
--- a/plugins/GSdx/Renderers/Common/GSTexture.h
+++ b/plugins/GSdx/Renderers/Common/GSTexture.h
@@ -47,7 +47,7 @@ public:
 	virtual bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) = 0;
 	virtual void Unmap() = 0;
 	virtual void GenerateMipmap() {}
-	virtual bool Save(const std::string& fn, bool dds = false) = 0;
+	virtual bool Save(const std::string& fn) = 0;
 	virtual uint32 GetID() { return 0; }
 
 	GSVector2 GetScale() const {return m_scale;}

--- a/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
@@ -105,7 +105,7 @@ void GSTexture11::Unmap()
 	}
 }
 
-bool GSTexture11::Save(const std::string& fn, bool dds)
+bool GSTexture11::Save(const std::string& fn)
 {
 	CComPtr<ID3D11Texture2D> res;
 	D3D11_TEXTURE2D_DESC desc;

--- a/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTexture11.cpp
@@ -170,14 +170,17 @@ bool GSTexture11::Save(const std::string& fn, bool dds)
 
 	res->GetDesc(&desc);
 
-	GSPng::Format format;
+#ifdef ENABLE_OGL_DEBUG
+	GSPng::Format format = GSPng::RGB_A_PNG;
+#else
+	GSPng::Format format = GSPng::RGB_PNG;
+#endif
 	switch (desc.Format)
 	{
 	case DXGI_FORMAT_A8_UNORM:
 		format = GSPng::R8I_PNG;
 		break;
 	case DXGI_FORMAT_R8G8B8A8_UNORM:
-		format = dds ? GSPng::RGBA_PNG : (m_desc.BindFlags & D3D11_BIND_DEPTH_STENCIL ? GSPng::RGB_A_PNG : GSPng::RGB_PNG);
 		break;
 	default:
 		fprintf(stderr, "DXGI_FORMAT %d not saved to image\n", desc.Format);

--- a/plugins/GSdx/Renderers/DX11/GSTexture11.h
+++ b/plugins/GSdx/Renderers/DX11/GSTexture11.h
@@ -43,7 +43,7 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0);
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
 	void Unmap();
-	bool Save(const std::string& fn, bool dds = false);
+	bool Save(const std::string& fn);
 	bool Equal(GSTexture11* tex);
 
 	operator ID3D11Texture2D*();

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -947,13 +947,13 @@ void GSRendererHW::Draw()
 				(int)context->CLAMP.MINU, (int)context->CLAMP.MAXU,
 				(int)context->CLAMP.MINV, (int)context->CLAMP.MAXV);
 
-			tex->m_texture->Save(m_dump_root+s, true);
+			tex->m_texture->Save(m_dump_root+s);
 
 			if(tex->m_palette)
 			{
 				s = format("%05d_f%lld_itpx_%05x_%s.dds", s_n, frame, context->TEX0.CBP, psm_str(context->TEX0.CPSM));
 
-				tex->m_palette->Save(m_dump_root+s, true);
+				tex->m_palette->Save(m_dump_root+s);
 			}
 		}
 

--- a/plugins/GSdx/Renderers/Null/GSTextureNull.h
+++ b/plugins/GSdx/Renderers/Null/GSTextureNull.h
@@ -37,5 +37,5 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0) {return true;}
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) {return false;}
 	void Unmap() {}
-	bool Save(const std::string& fn, bool dds = false) {return false;}
+	bool Save(const std::string& fn) {return false;}
 };

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -464,7 +464,7 @@ void GSTextureOGL::GenerateMipmap()
 	}
 }
 
-bool GSTextureOGL::Save(const std::string& fn, bool dds)
+bool GSTextureOGL::Save(const std::string& fn)
 {
 	// Collect the texture data
 	uint32 pitch = 4 * m_size.x;

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.h
@@ -71,7 +71,7 @@ class GSTextureOGL final : public GSTexture
 		bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) final;
 		void Unmap() final;
 		void GenerateMipmap() final;
-		bool Save(const std::string& fn, bool dds = false) final;
+		bool Save(const std::string& fn) final;
 
 		bool IsBackbuffer() { return (m_type == GSTexture::Backbuffer); }
 		bool IsDss() { return (m_type == GSTexture::DepthStencil); }

--- a/plugins/GSdx/Renderers/SW/GSTextureSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSTextureSW.cpp
@@ -85,10 +85,8 @@ void GSTextureSW::Unmap()
 	m_mapped.clear(std::memory_order_release);
 }
 
-bool GSTextureSW::Save(const std::string& fn, bool dds)
+bool GSTextureSW::Save(const std::string& fn)
 {
-	if(dds) return false; // not implemented
-
 #ifdef ENABLE_OGL_DEBUG
 	GSPng::Format fmt = GSPng::RGB_A_PNG;
 #else

--- a/plugins/GSdx/Renderers/SW/GSTextureSW.h
+++ b/plugins/GSdx/Renderers/SW/GSTextureSW.h
@@ -38,5 +38,5 @@ public:
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0);
 	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
 	void Unmap();
-	bool Save(const std::string& fn, bool dds = false);
+	bool Save(const std::string& fn);
 };


### PR DESCRIPTION
This allows d3d11 to dump textures in a similar fashion to OGL.

Previous behavior was to output the texture with alpha.
Instead, let's split it as outputting the texture with alpha can produce a completely transparent texture which is useless for debugging.