### PR TITLE
gsdx-d3d11: Fix CopyOffscreen bug

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -671,7 +671,7 @@ GSTexture* GSDevice11::CopyOffscreen(GSTexture* src, const GSVector4& sRect, int
 
 		if(GSTexture* src2 = src->IsMSAA() ? Resolve(src) : src)
 		{
-			StretchRect(src2, sRect, rt, dRect, m_convert.ps[format == DXGI_FORMAT_R16_UINT ? 1 : 0], NULL);
+			StretchRect(src2, sRect, rt, dRect, m_convert.ps[ps_shader], NULL);
 
 			if(src2 != src) Recycle(src2);
 		}


### PR DESCRIPTION
Update `CopyOffscreen` to accept the `ps_shader` value when doing `StretchRect`.
This fixes an issue where it was selecting the wrong PS for depth cache read.

Should (hopefully) fix SMT.

And once again thanks Greg for pointing this bug out to me.