### PR TITLE
GSdx: Cleanup file includes

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -21,8 +21,6 @@
 
 #include "stdafx.h"
 #include "GSRendererDX11.h"
-#include "GSCrc.h"
-#include "resource.h"
 
 GSRendererDX11::GSRendererDX11()
 	: GSRendererDX(new GSTextureCache11(this), GSVector2(-0.5f))

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#include "Renderers/Common/GSRenderer.h"
 #include "Renderers/Common/GSTextureCache.h"
-#include "GSCrc.h"
 #include "Renderers/Common/GSFunctionMap.h"
 #include "GSState.h"
 

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -24,7 +24,6 @@
 #include "GSDeviceOGL.h"
 #include "GLState.h"
 #include "GSUtil.h"
-#include "Renderers/Common/GSOsdManager.h"
 #include <fstream>
 
 //#define ONLY_LINES

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -28,7 +28,6 @@
 #include "GSUniformBufferOGL.h"
 #include "GSShaderOGL.h"
 #include "GLState.h"
-#include "Renderers/Common/GSOsdManager.h"
 
 // A couple of flag to determine the blending behavior
 #define BLEND_A_MAX		(0x100) // Impossible blending uses coeff bigger than 1

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -21,7 +21,6 @@
 
 #include "stdafx.h"
 #include "GSRendererOGL.h"
-#include "Renderers/Common/GSRenderer.h"
 
 
 GSRendererOGL::GSRendererOGL()

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
@@ -22,8 +22,6 @@
 #pragma once
 
 #include "Renderers/HW/GSRendererHW.h"
-
-#include "Renderers/Common/GSRenderer.h"
 #include "GSTextureCacheOGL.h"
 #include "Renderers/HW/GSVertexHW.h"
 

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.h
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "Renderers/Common/GSRenderer.h"
 #include "Renderers/SW/GSTextureCacheSW.h"
 #include "Renderers/SW/GSDrawScanline.h"
 


### PR DESCRIPTION
Remove GSCrc.h include in GSRendererHW and GSRendererDX11, file is
already included in GSState.h.

Remove GSRenderer.h include from renderers except Null and CL, file already
included in TextureCache hw/sw.

Remove resource.h include from GSRendererDX11, already included in GSDevice11.

Remove GSOsdManager.h from GSDeviceOGL, already included in GSDevice.