### PR TITLE
DebugInterface: Display Vector Unit registers as floats

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -37,7 +37,8 @@ R3000DebugInterface r3000Debug;
 #define strcasecmp stricmp
 #endif
 
-enum ReferenceIndexType {
+enum ReferenceIndexType
+{
 	REF_INDEX_PC = 32,
 	REF_INDEX_HI = 33,
 	REF_INDEX_LO = 34,
@@ -49,10 +50,11 @@ enum ReferenceIndexType {
 };
 
 
-class MipsExpressionFunctions: public IExpressionFunctions
+class MipsExpressionFunctions : public IExpressionFunctions
 {
 public:
-	MipsExpressionFunctions(DebugInterface* cpu): cpu(cpu) { };
+	MipsExpressionFunctions(DebugInterface* cpu)
+		: cpu(cpu){};
 
 	virtual bool parseReference(char* str, u64& referenceIndex)
 	{
@@ -92,7 +94,7 @@ public:
 	virtual bool parseSymbol(char* str, u64& symbolValue)
 	{
 		u32 value;
-		bool result = symbolMap.GetLabelValue(str,value);
+		bool result = symbolMap.GetLabelValue(str, value);
 		symbolValue = value;
 		return result;
 	}
@@ -110,44 +112,49 @@ public:
 		return -1;
 	}
 
-	virtual ExpressionType getReferenceType(u64 referenceIndex) {
-		if (referenceIndex & REF_INDEX_IS_FLOAT) {
+	virtual ExpressionType getReferenceType(u64 referenceIndex)
+	{
+		if (referenceIndex & REF_INDEX_IS_FLOAT)
+		{
 			return EXPR_TYPE_FLOAT;
 		}
 		return EXPR_TYPE_UINT;
 	}
-	
+
 	virtual bool getMemoryValue(u32 address, int size, u64& dest, char* error)
 	{
 		switch (size)
 		{
-		case 1: case 2: case 4: case 8:
-			break;
-		default:
-			sprintf(error,"Invalid memory access size %d",size);
-			return false;
+			case 1:
+			case 2:
+			case 4:
+			case 8:
+				break;
+			default:
+				sprintf(error, "Invalid memory access size %d", size);
+				return false;
 		}
 
 		if (address % size)
 		{
-			sprintf(error,"Invalid memory access (unaligned)");
+			sprintf(error, "Invalid memory access (unaligned)");
 			return false;
 		}
 
 		switch (size)
 		{
-		case 1:
-			dest = cpu->read8(address);
-			break;
-		case 2:
-			dest = cpu->read16(address);
-			break;
-		case 4:
-			dest = cpu->read32(address);
-			break;
-		case 8:
-			dest = cpu->read64(address);
-			break;
+			case 1:
+				dest = cpu->read8(address);
+				break;
+			case 2:
+				dest = cpu->read16(address);
+				break;
+			case 4:
+				dest = cpu->read32(address);
+				break;
+			case 8:
+				dest = cpu->read64(address);
+				break;
 		}
 
 		return true;
@@ -189,26 +196,31 @@ void DebugInterface::resumeCpu()
 char* DebugInterface::stringFromPointer(u32 p)
 {
 	const int BUFFER_LEN = 25;
-	static char buf[BUFFER_LEN] = { 0 };
+	static char buf[BUFFER_LEN] = {0};
 
 	if (!isValidAddress(p))
 		return NULL;
 
-	try {
-		for (u32 i = 0; i < BUFFER_LEN; i++) {
+	try
+	{
+		for (u32 i = 0; i < BUFFER_LEN; i++)
+		{
 			char c = read8(p + i);
 			buf[i] = c;
 
-			if (c == 0) {
+			if (c == 0)
+			{
 				return i > 0 ? buf : NULL;
 			}
-			else if (c < 0x20 || c >= 0x7f) {
+			else if (c < 0x20 || c >= 0x7f)
+			{
 				// non printable character
 				return NULL;
 			}
 		}
 	}
-	catch (Exception::Ps2Generic&) {
+	catch (Exception::Ps2Generic&)
+	{
 		return NULL;
 	}
 	buf[BUFFER_LEN - 1] = 0;
@@ -219,13 +231,13 @@ char* DebugInterface::stringFromPointer(u32 p)
 bool DebugInterface::initExpression(const char* exp, PostfixExpression& dest)
 {
 	MipsExpressionFunctions funcs(this);
-	return initPostfixExpression(exp,&funcs,dest);
+	return initPostfixExpression(exp, &funcs, dest);
 }
 
 bool DebugInterface::parseExpression(PostfixExpression& exp, u64& dest)
 {
 	MipsExpressionFunctions funcs(this);
-	return parsePostfixExpression(exp,&funcs,dest);
+	return parsePostfixExpression(exp, &funcs, dest);
 }
 
 
@@ -268,7 +280,7 @@ u64 R5900DebugInterface::read64(u32 address)
 		return -1;
 
 	u64 result;
-	memRead64(address,result);
+	memRead64(address, result);
 	return result;
 }
 
@@ -281,7 +293,7 @@ u128 R5900DebugInterface::read128(u32 address)
 		return result;
 	}
 
-	memRead128(address,result);
+	memRead128(address, result);
 	return result;
 }
 
@@ -290,7 +302,7 @@ void R5900DebugInterface::write8(u32 address, u8 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite8(address,value);
+	memWrite8(address, value);
 }
 
 void R5900DebugInterface::write32(u32 address, u32 value)
@@ -298,7 +310,7 @@ void R5900DebugInterface::write32(u32 address, u32 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite32(address,value);
+	memWrite32(address, value);
 }
 
 
@@ -311,22 +323,22 @@ const char* R5900DebugInterface::getRegisterCategoryName(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		return "GPR";
-	case EECAT_CP0:
-		return "CP0";
-	case EECAT_FPR:
-		return "FPR";
-	case EECAT_FCR:
-		return "FCR";
-	case EECAT_VU0F:
-		return "VU0f";
-	case EECAT_VU0I:
-		return "VU0i";
-	case EECAT_GSPRIV:
-		return "GS";
-	default:
-		return "Invalid";
+		case EECAT_GPR:
+			return "GPR";
+		case EECAT_CP0:
+			return "CP0";
+		case EECAT_FPR:
+			return "FPR";
+		case EECAT_FCR:
+			return "FCR";
+		case EECAT_VU0F:
+			return "VU0f";
+		case EECAT_VU0I:
+			return "VU0i";
+		case EECAT_GSPRIV:
+			return "GS";
+		default:
+			return "Invalid";
 	}
 }
 
@@ -334,18 +346,18 @@ int R5900DebugInterface::getRegisterSize(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-	case EECAT_VU0F:
-		return 128;
-	case EECAT_CP0:
-	case EECAT_FPR:
-	case EECAT_FCR:
-	case EECAT_VU0I:
-		return 32;
-	case EECAT_GSPRIV:
-		return 64;
-	default:
-		return 0;
+		case EECAT_GPR:
+		case EECAT_VU0F:
+			return 128;
+		case EECAT_CP0:
+		case EECAT_FPR:
+		case EECAT_FCR:
+		case EECAT_VU0I:
+			return 32;
+		case EECAT_GSPRIV:
+			return 64;
+		default:
+			return 0;
 	}
 }
 
@@ -353,19 +365,19 @@ int R5900DebugInterface::getRegisterCount(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		return 35;	// 32 + pc + hi + lo
-	case EECAT_CP0:
-	case EECAT_FPR:
-	case EECAT_FCR:
-	case EECAT_VU0I:
-		return 32;
-	case EECAT_VU0F:
-		return 33;  // 32 + ACC
-	case EECAT_GSPRIV:
-		return 19;
-	default:
-		return 0;
+		case EECAT_GPR:
+			return 35; // 32 + pc + hi + lo
+		case EECAT_CP0:
+		case EECAT_FPR:
+		case EECAT_FCR:
+		case EECAT_VU0I:
+			return 32;
+		case EECAT_VU0F:
+			return 33; // 32 + ACC
+		case EECAT_GSPRIV:
+			return 19;
+		default:
+			return 0;
 	}
 }
 
@@ -373,16 +385,16 @@ DebugInterface::RegisterType R5900DebugInterface::getRegisterType(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-	case EECAT_CP0:
-	case EECAT_VU0I:
-	case EECAT_FCR:
-	case EECAT_GSPRIV:
-	default:
-		return NORMAL;
-	case EECAT_FPR:
-    case EECAT_VU0F:
-		return SPECIAL;
+		case EECAT_GPR:
+		case EECAT_CP0:
+		case EECAT_VU0I:
+		case EECAT_FCR:
+		case EECAT_GSPRIV:
+		default:
+			return NORMAL;
+		case EECAT_FPR:
+		case EECAT_VU0F:
+			return SPECIAL;
 	}
 }
 
@@ -390,38 +402,38 @@ const char* R5900DebugInterface::getRegisterName(int cat, int num)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			return "pc";
-		case 33:	// hi
-			return "hi";
-		case 34:	// lo
-			return "lo";
+		case EECAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					return "pc";
+				case 33: // hi
+					return "hi";
+				case 34: // lo
+					return "lo";
+				default:
+					return R5900::GPR_REG[num];
+			}
+		case EECAT_CP0:
+			return R5900::COP0_REG[num];
+		case EECAT_FPR:
+			return R5900::COP1_REG_FP[num];
+		case EECAT_FCR:
+			return R5900::COP1_REG_FCR[num];
+		case EECAT_VU0F:
+			switch (num)
+			{
+				case 32: // ACC
+					return "ACC";
+				default:
+					return R5900::COP2_REG_FP[num];
+			}
+		case EECAT_VU0I:
+			return R5900::COP2_REG_CTL[num];
+		case EECAT_GSPRIV:
+			return R5900::GS_REG_PRIV[num];
 		default:
-			return R5900::GPR_REG[num];
-		}
-	case EECAT_CP0:
-		return R5900::COP0_REG[num];
-	case EECAT_FPR:
-		return R5900::COP1_REG_FP[num];
-	case EECAT_FCR:
-		return R5900::COP1_REG_FCR[num];
-	case EECAT_VU0F:
-		switch (num)
-		{
-		case 32:	// ACC
-			return "ACC";
-		default:
-			return R5900::COP2_REG_FP[num];
-		}
-	case EECAT_VU0I:
-		return R5900::COP2_REG_CTL[num];
-	case EECAT_GSPRIV:
-		return R5900::GS_REG_PRIV[num];
-	default:
-		return "Invalid";
+			return "Invalid";
 	}
 }
 
@@ -430,52 +442,52 @@ u128 R5900DebugInterface::getRegister(int cat, int num)
 	u128 result;
 	switch (cat)
 	{
-	case EECAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			result = u128::From32(cpuRegs.pc);
+		case EECAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					result = u128::From32(cpuRegs.pc);
+					break;
+				case 33: // hi
+					result = cpuRegs.HI.UQ;
+					break;
+				case 34: // lo
+					result = cpuRegs.LO.UQ;
+					break;
+				default:
+					result = cpuRegs.GPR.r[num].UQ;
+					break;
+			}
 			break;
-		case 33:	// hi
-			result = cpuRegs.HI.UQ;
+		case EECAT_CP0:
+			result = u128::From32(cpuRegs.CP0.r[num]);
 			break;
-		case 34:	// lo
-			result = cpuRegs.LO.UQ;
+		case EECAT_FPR:
+			result = u128::From32(fpuRegs.fpr[num].UL);
+			break;
+		case EECAT_FCR:
+			result = u128::From32(fpuRegs.fprc[num]);
+			break;
+		case EECAT_VU0F:
+			switch (num)
+			{
+				case 32: // ACC
+					result = VU0.ACC.UQ;
+					break;
+				default:
+					result = VU0.VF[num].UQ;
+					break;
+			}
+			break;
+		case EECAT_VU0I:
+			result = u128::From32(VU0.VI[num].UL);
+			break;
+		case EECAT_GSPRIV:
+			result = gsNonMirroredRead(0x12000000 | R5900::GS_REG_PRIV_ADDR[num]);
 			break;
 		default:
-			result = cpuRegs.GPR.r[num].UQ;
+			result = u128::From32(0);
 			break;
-		}
-		break;
-	case EECAT_CP0:
-		result = u128::From32(cpuRegs.CP0.r[num]);
-		break;
-	case EECAT_FPR:
-		result = u128::From32(fpuRegs.fpr[num].UL);
-		break;
-	case EECAT_FCR:
-		result = u128::From32(fpuRegs.fprc[num]);
-		break;
-	case EECAT_VU0F:
-		switch (num)
-		{
-		case 32:	// ACC
-			result = VU0.ACC.UQ;
-			break;
-		default:
-			result = VU0.VF[num].UQ;
-			break;
-		}
-		break;
-	case EECAT_VU0I:
-		result = u128::From32(VU0.VI[num].UL);
-		break;
-	case EECAT_GSPRIV:
-		result = gsNonMirroredRead(0x12000000 | R5900::GS_REG_PRIV_ADDR[num]);
-		break;
-	default:
-		result = u128::From32(0);
-		break;
 	}
 
 	return result;
@@ -485,24 +497,24 @@ wxString R5900DebugInterface::getRegisterString(int cat, int num)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-	case EECAT_CP0:
-	case EECAT_FCR:
-		return getRegister(cat,num).ToString();
-	case EECAT_FPR:
+		case EECAT_GPR:
+		case EECAT_CP0:
+		case EECAT_FCR:
+			return getRegister(cat, num).ToString();
+		case EECAT_FPR:
 		{
 			char str[64];
-			sprintf(str,"%f",fpuRegs.fpr[num].f);
-			return wxString(str,wxConvUTF8);
+			sprintf(str, "%f", fpuRegs.fpr[num].f);
+			return wxString(str, wxConvUTF8);
 		}
-    case EECAT_VU0F:
+		case EECAT_VU0F:
 		{
-            char str[256];
+			char str[256];
 			sprintf(str, "%7.2f %7.2f %7.2f %7.2f", VU0.VF[num].F[0], VU0.VF[num].F[1], VU0.VF[num].F[2], VU0.VF[num].F[3]);
-            return wxString(str, wxConvUTF8);
+			return wxString(str, wxConvUTF8);
 		}
-	default:
-		return L"";
+		default:
+			return L"";
 	}
 }
 
@@ -531,51 +543,51 @@ void R5900DebugInterface::setRegister(int cat, int num, u128 newValue)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			cpuRegs.pc = newValue._u32[0];
+		case EECAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					cpuRegs.pc = newValue._u32[0];
+					break;
+				case 33: // hi
+					cpuRegs.HI.UQ = newValue;
+					break;
+				case 34: // lo
+					cpuRegs.LO.UQ = newValue;
+					break;
+				default:
+					cpuRegs.GPR.r[num].UQ = newValue;
+					break;
+			}
 			break;
-		case 33:	// hi
-			cpuRegs.HI.UQ = newValue;
+		case EECAT_CP0:
+			cpuRegs.CP0.r[num] = newValue._u32[0];
 			break;
-		case 34:	// lo
-			cpuRegs.LO.UQ = newValue;
+		case EECAT_FPR:
+			fpuRegs.fpr[num].UL = newValue._u32[0];
+			break;
+		case EECAT_FCR:
+			fpuRegs.fprc[num] = newValue._u32[0];
+			break;
+		case EECAT_VU0F:
+			switch (num)
+			{
+				case 32: // ACC
+					VU0.ACC.UQ = newValue;
+					break;
+				default:
+					VU0.VF[num].UQ = newValue;
+					break;
+			}
+			break;
+		case EECAT_VU0I:
+			VU0.VI[num].UL = newValue._u32[0];
+			break;
+		case EECAT_GSPRIV:
+			memWrite64(0x12000000 | R5900::GS_REG_PRIV_ADDR[num], newValue.lo);
 			break;
 		default:
-			cpuRegs.GPR.r[num].UQ = newValue;
 			break;
-		}
-		break;
-	case EECAT_CP0:
-		cpuRegs.CP0.r[num] = newValue._u32[0];
-		break;
-	case EECAT_FPR:
-		fpuRegs.fpr[num].UL = newValue._u32[0];
-		break;
-	case EECAT_FCR:
-		fpuRegs.fprc[num] = newValue._u32[0];
-		break;
-	case EECAT_VU0F:
-		switch (num)
-		{
-		case 32:	// ACC
-			VU0.ACC.UQ = newValue;
-			break;
-		default:
-			VU0.VF[num].UQ = newValue;
-			break;
-		}
-		break;
-	case EECAT_VU0I:
-		VU0.VI[num].UL = newValue._u32[0];
-		break;
-	case EECAT_GSPRIV:
-		memWrite64(0x12000000 | R5900::GS_REG_PRIV_ADDR[num], newValue.lo);
-		break;
-	default:
-		break;
 	}
 }
 
@@ -584,7 +596,7 @@ std::string R5900DebugInterface::disasm(u32 address, bool simplify)
 	std::string out;
 
 	u32 op = read32(address);
-	R5900::disR5900Fasm(out,op,address,simplify);
+	R5900::disR5900Fasm(out, op, address, simplify);
 	return out;
 }
 
@@ -595,51 +607,51 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 	// get rid of ee ram mirrors
 	switch (addr >> 28)
 	{
-	case 0:
-	case 2:
-		// case 3: throw exception (not mapped ?)
-		// [ 0000_8000 - 01FF_FFFF ] RAM
-		// [ 2000_8000 - 21FF_FFFF ] RAM MIRROR
-		// [ 3000_8000 - 31FF_FFFF ] RAM MIRROR
-		if (lopart >= 0x80000 && lopart <= 0x1ffFFff)
-			return !!vtlb_GetPhyPtr(lopart);
-		break;
-	case 1:
-		// [ 1000_0000 - 1000_CFFF ] EE register
-		if (lopart <= 0xcfff)
-			return true;
+		case 0:
+		case 2:
+			// case 3: throw exception (not mapped ?)
+			// [ 0000_8000 - 01FF_FFFF ] RAM
+			// [ 2000_8000 - 21FF_FFFF ] RAM MIRROR
+			// [ 3000_8000 - 31FF_FFFF ] RAM MIRROR
+			if (lopart >= 0x80000 && lopart <= 0x1ffFFff)
+				return !!vtlb_GetPhyPtr(lopart);
+			break;
+		case 1:
+			// [ 1000_0000 - 1000_CFFF ] EE register
+			if (lopart <= 0xcfff)
+				return true;
 
-		// [ 1100_0000 - 1100_FFFF ] VU mem
-		if (lopart >= 0x1000000 && lopart <= 0x100FFff)
-			return true;
+			// [ 1100_0000 - 1100_FFFF ] VU mem
+			if (lopart >= 0x1000000 && lopart <= 0x100FFff)
+				return true;
 
-		// [ 1200_0000 - 1200_FFFF ] GS regs
-		if (lopart >= 0x2000000 && lopart <= 0x20010ff)
-			return true;
+			// [ 1200_0000 - 1200_FFFF ] GS regs
+			if (lopart >= 0x2000000 && lopart <= 0x20010ff)
+				return true;
 
-		// [ 1E00_0000 - 1FFF_FFFF ] ROM
-		// if (lopart >= 0xe000000)
-		// 	return true; throw exception (not mapped ?)
-		break;
-	case 7:
-		// [ 7000_0000 - 7000_3FFF ] Scratchpad
-		if (lopart <= 0x3fff)
-			return true;
-		break;
-	case 8:
-	case 9:
-	case 0xA:
-	case 0xB:
-		// [ 8000_0000 - BFFF_FFFF ] kernel
-		// We only need to access the EE kernel (which is 1 MB large)
-		if (lopart < 0x100000)
-			return true;
-		break;
-	case 0xF:
-		// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
-		if (lopart >= 0xfff8000)
-			return true;
-		break;
+			// [ 1E00_0000 - 1FFF_FFFF ] ROM
+			// if (lopart >= 0xe000000)
+			// 	return true; throw exception (not mapped ?)
+			break;
+		case 7:
+			// [ 7000_0000 - 7000_3FFF ] Scratchpad
+			if (lopart <= 0x3fff)
+				return true;
+			break;
+		case 8:
+		case 9:
+		case 0xA:
+		case 0xB:
+			// [ 8000_0000 - BFFF_FFFF ] kernel
+			// We only need to access the EE kernel (which is 1 MB large)
+			if (lopart < 0x100000)
+				return true;
+			break;
+		case 0xF:
+			// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
+			if (lopart >= 0xfff8000)
+				return true;
+			break;
 	}
 
 	return false;
@@ -696,7 +708,7 @@ void R3000DebugInterface::write8(u32 address, u8 value)
 	if (!isValidAddress(address))
 		return;
 
-	iopMemWrite8(address,value);
+	iopMemWrite8(address, value);
 }
 
 void R3000DebugInterface::write32(u32 address, u32 value)
@@ -704,7 +716,7 @@ void R3000DebugInterface::write32(u32 address, u32 value)
 	if (!isValidAddress(address))
 		return;
 
-	iopMemWrite32(address,value);
+	iopMemWrite32(address, value);
 }
 
 int R3000DebugInterface::getRegisterCategoryCount()
@@ -716,10 +728,10 @@ const char* R3000DebugInterface::getRegisterCategoryName(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return "GPR";
-	default:
-		return "Invalid";
+		case IOPCAT_GPR:
+			return "GPR";
+		default:
+			return "Invalid";
 	}
 }
 
@@ -727,10 +739,10 @@ int R3000DebugInterface::getRegisterSize(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return 32;
-	default:
-		return 0;
+		case IOPCAT_GPR:
+			return 32;
+		default:
+			return 0;
 	}
 }
 
@@ -738,10 +750,10 @@ int R3000DebugInterface::getRegisterCount(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return 35;	// 32 + pc + hi + lo
-	default:
-		return 0;
+		case IOPCAT_GPR:
+			return 35; // 32 + pc + hi + lo
+		default:
+			return 0;
 	}
 }
 
@@ -749,9 +761,9 @@ DebugInterface::RegisterType R3000DebugInterface::getRegisterType(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-	default:
-		return DebugInterface::NORMAL;
+		case IOPCAT_GPR:
+		default:
+			return DebugInterface::NORMAL;
 	}
 }
 
@@ -759,49 +771,49 @@ const char* R3000DebugInterface::getRegisterName(int cat, int num)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			return "pc";
-		case 33:	// hi
-			return "hi";
-		case 34:	// lo
-			return "lo";
+		case IOPCAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					return "pc";
+				case 33: // hi
+					return "hi";
+				case 34: // lo
+					return "lo";
+				default:
+					return R5900::GPR_REG[num];
+			}
 		default:
-			return R5900::GPR_REG[num];
-		}
-	default:
-		return "Invalid";
+			return "Invalid";
 	}
 }
 
 u128 R3000DebugInterface::getRegister(int cat, int num)
 {
 	u32 value;
-	
+
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			value = psxRegs.pc;
-			break;
-		case 33:	// hi
-			value = psxRegs.GPR.n.hi;
-			break;
-		case 34:	// lo
-			value = psxRegs.GPR.n.lo;
+		case IOPCAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					value = psxRegs.pc;
+					break;
+				case 33: // hi
+					value = psxRegs.GPR.n.hi;
+					break;
+				case 34: // lo
+					value = psxRegs.GPR.n.lo;
+					break;
+				default:
+					value = psxRegs.GPR.r[num];
+					break;
+			}
 			break;
 		default:
-			value = psxRegs.GPR.r[num];
+			value = -1;
 			break;
-		}
-		break;
-	default:
-		value = -1;
-		break;
 	}
 
 	return u128::From32(value);
@@ -811,10 +823,10 @@ wxString R3000DebugInterface::getRegisterString(int cat, int num)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return getRegister(cat,num).ToString();
-	default:
-		return L"Invalid";
+		case IOPCAT_GPR:
+			return getRegister(cat, num).ToString();
+		default:
+			return L"Invalid";
 	}
 }
 
@@ -842,25 +854,25 @@ void R3000DebugInterface::setRegister(int cat, int num, u128 newValue)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			psxRegs.pc = newValue._u32[0];
-			break;
-		case 33:	// hi
-			psxRegs.GPR.n.hi = newValue._u32[0];
-			break;
-		case 34:	// lo
-			psxRegs.GPR.n.lo = newValue._u32[0];
+		case IOPCAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					psxRegs.pc = newValue._u32[0];
+					break;
+				case 33: // hi
+					psxRegs.GPR.n.hi = newValue._u32[0];
+					break;
+				case 34: // lo
+					psxRegs.GPR.n.lo = newValue._u32[0];
+					break;
+				default:
+					psxRegs.GPR.r[num] = newValue._u32[0];
+					break;
+			}
 			break;
 		default:
-			psxRegs.GPR.r[num] = newValue._u32[0];
 			break;
-		}
-		break;
-	default:
-		break;
 	}
 }
 
@@ -869,7 +881,7 @@ std::string R3000DebugInterface::disasm(u32 address, bool simplify)
 	std::string out;
 
 	u32 op = read32(address);
-	R5900::disR5900Fasm(out,op,address,simplify);
+	R5900::disR5900Fasm(out, op, address, simplify);
 	return out;
 }
 

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -375,13 +375,13 @@ DebugInterface::RegisterType R5900DebugInterface::getRegisterType(int cat)
 	{
 	case EECAT_GPR:
 	case EECAT_CP0:
-	case EECAT_VU0F:
 	case EECAT_VU0I:
 	case EECAT_FCR:
 	case EECAT_GSPRIV:
 	default:
 		return NORMAL;
 	case EECAT_FPR:
+    case EECAT_VU0F:
 		return SPECIAL;
 	}
 }
@@ -494,6 +494,12 @@ wxString R5900DebugInterface::getRegisterString(int cat, int num)
 			char str[64];
 			sprintf(str,"%f",fpuRegs.fpr[num].f);
 			return wxString(str,wxConvUTF8);
+		}
+    case EECAT_VU0F:
+		{
+            char str[256];
+			sprintf(str, "%7.2f %7.2f %7.2f %7.2f", VU0.VF[num].F[0], VU0.VF[num].F[1], VU0.VF[num].F[2], VU0.VF[num].F[3]);
+            return wxString(str, wxConvUTF8);
 		}
 	default:
 		return L"";


### PR DESCRIPTION
This PR displays the values of the packed floats in the VU as floats in the debugger (using `%7.2f`), rather than the raw hexadecimal values. I'd like to provide a more precise display, but there is very limited space for text on the UI. That said, these values are likely more parse-able than just the hexadecimal values.

![](https://cdn.discordapp.com/attachments/480478597799346186/527331800050040841/unknown.png)