### PR TITLE
spu2-x: Remove unused GetLinearSrAr code

### DIFF
--- a/plugins/spu2-x/src/ADSR.cpp
+++ b/plugins/spu2-x/src/ADSR.cpp
@@ -37,18 +37,6 @@ void InitADSR() // INIT ADSR
     }
 }
 
-// Returns the linear slide value for AR and SR inputs.
-// (currently not used, it's buggy)
-static int GetLinearSrAr(uint SrAr)
-{
-    // The Sr/Ar settings work in quarter steps, which means
-    // the bottom 2 bits go on the left side of the shift, and
-    // the right side of the shift gets divided by 4:
-
-    const uint newSr = 0x7f - SrAr;
-    return ((1 | (newSr & 3)) << (newSr >> 2));
-}
-
 bool V_ADSR::Calculate()
 {
     pxAssume(Phase != 0);


### PR DESCRIPTION
Get rid of GetLinearSrAr code, it wasn't used anywhere so I don't see a
reason why to keep it, other than clogging up the code, if someone wants
to work on it they can re add the function in the future.

I happen to spot this by chance in one of the compile warnings on travis.