### PR TITLE
cmake: Re add mxsave and add mfxsr flag to compiler flags.

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -212,7 +212,7 @@ if(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386")
             # AVX requires some fix of the ABI (mangling) (default 2)
             # Note: V6 requires GCC 4.7
             #set(ARCH_FLAG "-march=native -fabi-version=6")
-            set(ARCH_FLAG "-march=native")
+            set(ARCH_FLAG "-mfxsr -mxsave -march=native")
         endif()
     endif()
 


### PR DESCRIPTION
The warnings issue should be resolved now thanks to arcum.
Fixes compiling issues on some systems/distros using gcc 8.2+
Idea by turtleli.

Also add -mfxsr flag suggested by Gregory.

Issue https://github.com/PCSX2/pcsx2/issues/2669