### PR TITLE
GSdx: Adjust dynamic crc hack

### DIFF
--- a/plugins/GSdx/config.h
+++ b/plugins/GSdx/config.h
@@ -28,9 +28,6 @@
 
 #define EXTERNAL_SHADER_LOADING 1
 
-//#define ENABLE_DYNAMIC_CRC_HACK
-#define DYNA_DLL_PATH "c:/dev/pcsx2/trunk/tools/dynacrchack/DynaCrcHack.dll"
-
 //#define DISABLE_HW_TEXTURE_CACHE // Slow but fixes a lot of bugs
 
 //#define DISABLE_BITMASKING
@@ -54,4 +51,9 @@
 
 #ifdef _WIN32
 //#define ENABLE_OPENCL
+
+//#define ENABLE_DYNAMIC_CRC_HACK
+#ifdef ENABLE_DYNAMIC_CRC_HACK
+#define DYNA_DLL_PATH "tools/DynaCrcHack.dll"
+#endif
 #endif


### PR DESCRIPTION
Currently dynamic crc hack is only supported on windows so better move
the defines to windows only, also enable the dll path define only when
dynamic crc hack is enabled.
This also adjusts the dll location for dynamic crc hack to be the pcsx2
install dir instead of a different location that seemed a bit odd.
"tools" folder needs to be created to place the dll in.

I wasn't sure if I should use the tools folder or not.