### PR TITLE
PCSX2: Update speed hack presets to be more friendly and usable

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -966,12 +966,12 @@ bool AppConfig::isOkGetPresetTextAndColor( int n, wxString& label, wxColor& c )
 {
 	const wxString presetNamesAndColors[][2] =
 	{
-		{ _t("Safest"),				L"Forest GREEN" },
-		{ _t("Safe (faster)"),		L"Dark Green" },
-		{ _t("Balanced"),			L"Blue" },
-		{ _t("Aggressive"),			L"Purple" },
-		{ _t("Aggressive plus"),	L"Orange"},
-		{ _t("Mostly Harmful"),		L"Red" }
+		{ _t("Safest (No hacks)"),	L"Blue" },
+		{ _t("Safe (Default)"),		L"Dark Green" },
+		{ _t("Balanced"),			L"Forest Green" },
+		{ _t("Aggressive"),			L"Orange" },
+		{ _t("Very Aggressive"),	L"Red"},
+		{ _t("Mostly Harmful"),		L"Purple" }
 	};
 	if( n<0 || n>GetMaxPresetIndex() )
 		return false;
@@ -983,9 +983,11 @@ bool AppConfig::isOkGetPresetTextAndColor( int n, wxString& label, wxColor& c )
 }
 
 
-//Apply one of several (currently 6) configuration subsets.
-//The scope of the subset which each preset controlls is hardcoded here.
-bool AppConfig::IsOkApplyPreset(int n)
+// Apply one of several (currently 6) configuration subsets.
+// The scope of the subset which each preset controlls is hardcoded here.
+// Use ignoreMTVU to avoid updating the MTVU field.
+// Main purpose is for the preset enforcement at launch, to avoid overwriting a user's setting.
+bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 {
 	if (n < 0 || n > GetMaxPresetIndex() )
 	{
@@ -1029,7 +1031,6 @@ bool AppConfig::IsOkApplyPreset(int n)
 	EmuOptions.EnablePatches		= true;
 	EmuOptions.GS					= default_Pcsx2Config.GS;
 	EmuOptions.GS.FrameLimitEnable	= original_GS.FrameLimitEnable;	//Frame limiter is not modified by presets
-	//EmuOptions.GS.VsyncEnable		= original_GS.VsyncEnable;
 	
 	EmuOptions.Cpu					= default_Pcsx2Config.Cpu;
 	EmuOptions.Gamefixes			= default_Pcsx2Config.Gamefixes;
@@ -1038,43 +1039,39 @@ bool AppConfig::IsOkApplyPreset(int n)
 	EmuOptions.Speedhacks.vuThread	= original_SpeedHacks.vuThread;
 	EnableSpeedHacks = true;
 
-	//Actual application of current preset over the base settings which all presets use (mostly pcsx2's default values).
-	//The presets themselves might need some voodoo tuning to be even more useful. Currently they mostly modify Speedhacks.
+	// Actual application of current preset over the base settings which all presets use (mostly pcsx2's default values).
 
-	bool vuUsed=false, eeUsed=false;//used to prevent application of specific lower preset values on fallthrough.
-	switch (n){	//currently implemented such that any preset also applies all lower presets, with few exceptions.
-
-		case 5 :	//Set VU cycle steal to 2 clicks (maximum-1)
-					vuUsed?0:(vuUsed=true, EmuOptions.Speedhacks.EECycleSkip = 2);
+	Pcsx2Config::CpuOptions& cpuOps(g_Conf->EmuOptions.Cpu);
+	bool isRateSet = false, isSkipSet = false, isMTVUSet = ignoreMTVU ? true : false; // used to prevent application of specific lower preset values on fallthrough.
+	switch (n) // Settings will waterfall down to the Safe preset, then stop. So, Balanced and higher will inherit any settings through Safe.
+	{
+		case 5: // Mostly Harmful
+			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = 1); // +1 EE cyclerate
+			isSkipSet ? 0 : (isSkipSet = true, EmuOptions.Speedhacks.EECycleSkip = 1); // +1 EE cycle skip
 		
-		case 4 :	//set EE cyclerate to 2 clicks (maximum)
-					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = -2);
+		case 4: // Very Aggressive
+			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = -2); // -2 EE cyclerate
 
-		case 3 :	//Set VU cycle steal to 1 click, set VU clamp mode to 'none'
-					vuUsed?0:(vuUsed=true, EmuOptions.Speedhacks.EECycleSkip = 1);
-					EmuOptions.Cpu.Recompiler.vuOverflow	  =
-					EmuOptions.Cpu.Recompiler.vuExtraOverflow =
-					EmuOptions.Cpu.Recompiler.vuSignOverflow = false; //VU Clamp mode to 'none'
+		case 3: // Aggressive
+			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = -1); // -1 EE cyclerate
 
-		//best balanced hacks combo?
-		case 2 :	//set EE cyclerate to 1 click.
-					eeUsed?0:(eeUsed=true, EmuOptions.Speedhacks.EECycleRate = -1);
-					// EE timing hack appears to break the BIOS text and cause slowdowns in a few titles.
-					//EnableGameFixes = true;
-					//EmuOptions.Gamefixes.EETimingHack = true;
+		case 2: // Balanced
+			isMTVUSet ? 0 : (isMTVUSet = true, EmuOptions.Speedhacks.vuThread = true); // Enable MTVU
 
-		case 1 :	//Recommended speed hacks.
-					EmuOptions.Speedhacks.IntcStat = true;
-					EmuOptions.Speedhacks.WaitLoop = true;
-					EmuOptions.Speedhacks.vuFlagHack = true;
-					break;
+		case 1: // Safe (Default)
+			EmuOptions.Speedhacks.IntcStat = true;
+			EmuOptions.Speedhacks.WaitLoop = true;
+			EmuOptions.Speedhacks.vuFlagHack = true;
+			
+			// If waterfalling from > Safe, break to avoid MTVU disable.
+			if (n > 1) break;
+			
+		case 0: // Safest
+			isMTVUSet ? 0 : (isMTVUSet = true, EmuOptions.Speedhacks.vuThread = false); // Disable MTVU
+			break;
 
-		case 0 :	//Base preset: Mostly pcsx2's defaults.
-					//Force disable MTVU hack on safest preset as it has lots of issues (Crashes/Slow downs) on various games.
-					EmuOptions.Speedhacks.vuThread = false;
-					break;
-
-		default:	Console.WriteLn("Developer Warning: Preset #%d is not implemented. (--> Using application default).", n);
+		default:
+			Console.WriteLn("Developer Warning: Preset #%d is not implemented. (--> Using application default).", n);
 	}
 
 
@@ -1261,7 +1258,7 @@ static void LoadVmSettings()
 	g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
 
 	if (g_Conf->EnablePresets){
-		g_Conf->IsOkApplyPreset(g_Conf->PresetIndex);
+		g_Conf->IsOkApplyPreset(g_Conf->PresetIndex, true);
 	}
 
 	sApp.DispatchVmSettingsEvent( vmloader );

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -359,7 +359,7 @@ public:
 	static int  GetMaxPresetIndex();
     static bool isOkGetPresetTextAndColor(int n, wxString& label, wxColor& c);
 	
-	bool        IsOkApplyPreset(int n);
+	bool        IsOkApplyPreset(int n, bool ignoreMTVU);
 
 
 	//The next 2 flags are used with ApplyConfigToGui which the presets system use:

--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -75,7 +75,7 @@ void Dialogs::SysConfigDialog::UpdateGuiForPreset ( int presetIndex, bool preset
 	//Console.WriteLn("Applying config to Gui: preset #%d, presets enabled: %s", presetIndex, presetsEnabled?"true":"false");
 
 	AppConfig preset = *g_Conf;
-	preset.IsOkApplyPreset( presetIndex );	//apply a preset to a copy of g_Conf.
+	preset.IsOkApplyPreset( presetIndex, false );	//apply a preset to a copy of g_Conf.
 	preset.EnablePresets = presetsEnabled;	//override IsOkApplyPreset (which always applies/enabled) to actual required state
 	
 	//update the config panels of SysConfigDialog to reflect the preset.
@@ -125,16 +125,16 @@ void Dialogs::SysConfigDialog::AddPresetsControl()
 		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL /*| wxSL_AUTOTICKS | wxSL_LABELS */);
 	m_slider_presets->SetMinSize(wxSize(100,25));
 
+	const wchar_t* presetTooltip = L"Presets apply some speed hacks that may boost speed on underpowered systems, or speed up games that have unusual performance requirements. Uncheck this box to apply settings manually.\n\n1) Safest - No speed hacks. Most reliable, but possibly slow setting.\n2) Safe - Default. A few speed hacks known to provide boosts, with minimal to no side effects.\n3) Balanced - May help quad core CPUs.\n4) Aggressive - May help underpowered CPUs on less demanding games, but risks causing problems in other cases.\n5) Very Aggressive - May help underpowered CPUs on less demanding games, but is likely to cause problems in other cases.\n6) Mostly Harmful - Harsh application of speed hacks. May help a very small set of games that have unusual performance requirements, but have adverse effects on most others. Not recommended for underpowered PCs.";
+
 	m_slider_presets->SetToolTip(
-		pxEt( L"The Presets apply speed hacks, some recompiler options and some game fixes known to boost speed.\nKnown important game fixes will be applied automatically.\n\nPresets info:\n1 -     The most accurate emulation but also the slowest.\n3 --> Tries to balance speed with compatibility.\n4 -     Some more aggressive hacks.\n6 -     Too many hacks which will probably slow down most games.\n"
-			)
+		pxEt(presetTooltip)
 	);
 	m_slider_presets->Enable(g_Conf->EnablePresets);
 
 	m_check_presets = new pxCheckBox( this, _("Preset:"), 0);
 	m_check_presets->SetToolTip(
-		pxEt( L"The Presets apply speed hacks, some recompiler options and some game fixes known to boost speed.\nKnown important game fixes will be applied automatically.\n\n--> Uncheck to modify settings manually (with current preset as base)"
-			)
+		pxEt(presetTooltip)
 	);
 	m_check_presets->SetValue(!!g_Conf->EnablePresets);
 	//Console.WriteLn("--> SysConfigDialog::AddPresetsControl: EnablePresets: %s", g_Conf->EnablePresets?"true":"false");

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -165,7 +165,7 @@ void Panels::GSWindowSettingsPanel::ApplyConfigToGui( AppConfig& configToApply, 
 	}
 
 	m_combo_vsync->SetSelection(enum_cast(configToApply.EmuOptions.GS.VsyncEnable));
-	m_combo_vsync->Enable( !configToApply.EnablePresets );//grayed-out when presets are enabled
+	m_combo_vsync->Enable(true); // Always allow, regardless of preset
 }
 
 void Panels::GSWindowSettingsPanel::Apply()

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -314,10 +314,8 @@ void Panels::SpeedHacksPanel::ApplyConfigToGui( AppConfig& configToApply, int fl
 	m_check_intc->SetValue(opts.IntcStat);
 	m_check_waitloop->SetValue(opts.WaitLoop);
 	m_check_fastCDVD->SetValue(opts.fastCDVD);
-
-	const bool preset_request = flags & AppConfig::APPLY_FLAG_FROM_PRESET;
-	if (!preset_request || configToApply.PresetIndex == 0)
-		m_check_vuThread->SetValue(opts.vuThread);
+	m_check_vuThread->SetValue(opts.vuThread);
+		
 
 	// Then, lock(gray out)/unlock the widgets as necessary.
 	EnableStuff( &configToApply );


### PR DESCRIPTION
Old presets touched parts such as VU clamping for what seems to be no good reason at all, and applied some rather dodgy combinations of EE cyclerate and cycle skipping. New presets are less destructive, but I am looking for feedback as to whether these remain helpful at all or should be revised.

~~Per Lightning's request, also made the clamping/rounding mode options unlock on presets 3-6. If this is unpopular (e.g. going against the purpose of having presets at all), this should be an easy reversion so a quick opinion poll will settle that.~~