### PR TITLE
PCSX2: Remove the arbitrary limit on patches by converting the patch list to a vector

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -36,7 +36,6 @@ extern void _ApplyPatch(IniPatch *p);
 
 std::vector<IniPatch> Patch;
 
-
 wxString strgametitle;
 
 struct PatchTextTable

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -349,7 +349,8 @@ namespace PatchFunc
 // This is for applying patches directly to memory
 void ApplyLoadedPatches(patch_place_type place)
 {
-    for (auto i : Patch){
+    for (auto& i : Patch)
+    {
 	    if (i.placetopatch == place)
             _ApplyPatch(&i);
 	}

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -349,9 +349,8 @@ namespace PatchFunc
 // This is for applying patches directly to memory
 void ApplyLoadedPatches(patch_place_type place)
 {
-	for (unsigned int i = 0; i < Patch.size(); i++)
-	{
-	    if (Patch[i].placetopatch == place)
-            _ApplyPatch(&Patch[i]);
+    for (auto i : Patch){
+	    if (i.placetopatch == place)
+            _ApplyPatch(&i);
 	}
 }

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -115,7 +115,7 @@ static void inifile_command(const wxString& cmd)
 
 	// Is this really what we want to be doing here? Seems like just leaving it empty/blank
 	// would make more sense... --air
-    if (set.rvalue.IsEmpty()) set.rvalue = set.lvalue;
+	if (set.rvalue.IsEmpty()) set.rvalue = set.lvalue;
 
 	/*int code = */PatchTableExecute(set, commands_patch);
 }
@@ -126,7 +126,7 @@ void TrimPatches(wxString& s)
 {
 	wxStringTokenizer tkn( s, L"\n" );
 
-    while(tkn.HasMoreTokens()) {
+	while(tkn.HasMoreTokens()) {
 		inifile_command(tkn.GetNextToken());
 	}
 }
@@ -157,24 +157,24 @@ int LoadPatchesFromGamesDB(const wxString& crc, const Game_Data& game)
 
 void inifile_processString(const wxString& inStr)
 {
-  wxString str(inStr);
-  inifile_trim(str);
-  if (!str.IsEmpty()) inifile_command(str);
+	wxString str(inStr);
+	inifile_trim(str);
+	if (!str.IsEmpty()) inifile_command(str);
 }
 
 // This routine receives a file from inifile_read, trims it,
 // Then sends the command to be parsed.
 void inifile_process(wxTextFile &f1 )
 {
-    for (uint i = 0; i < f1.GetLineCount(); i++)
-    {
-        inifile_processString(f1[i]);
-    }
+	for (uint i = 0; i < f1.GetLineCount(); i++)
+	{
+		inifile_processString(f1[i]);
+	}
 }
 
 void ForgetLoadedPatches()
 {
-    Patch.clear();
+	Patch.clear();
 }
 
 static int _LoadPatchFiles(const wxDirName& folderName, wxString& fileSpec, const wxString& friendlyName, int& numberFoundPatchFiles)
@@ -200,7 +200,7 @@ static int _LoadPatchFiles(const wxDirName& folderName, wxString& fileSpec, cons
 			f.Close();
 			int loaded = Patch.size() - before;
 			PatchesCon->WriteLn((loaded ? Color_Green : Color_Gray), L"Loaded %d %s from '%s' at '%s'",
-			                    loaded, WX_STR(friendlyName), WX_STR(buffer), WX_STR(folderName.ToString()));
+								loaded, WX_STR(friendlyName), WX_STR(buffer), WX_STR(folderName.ToString()));
 			numberFoundPatchFiles++;
 		}
 		found = dir.GetNext(&buffer);
@@ -227,7 +227,7 @@ int LoadPatchesFromZip(wxString gameCRC, const wxString& patchesArchiveFilename)
 		name.MakeUpper();
 		if (name.Find(gameCRC) == 0 && name.Find(L".PNACH")+6u == name.Length()) {
 			PatchesCon->WriteLn(Color_Green, L"Loading patch '%s' from archive '%s'",
-			                    WX_STR(entry->GetName()), WX_STR(patchesArchiveFilename));
+								WX_STR(entry->GetName()), WX_STR(patchesArchiveFilename));
 			wxTextInputStream pnach(zip);
 			while (!zip.Eof()) {
 				inifile_processString(pnach.ReadLine());
@@ -263,28 +263,28 @@ int LoadPatchesFromDir(wxString name, const wxDirName& folderName, const wxStrin
 
 static u32 StrToU32(const wxString& str, int base = 10)
 {
-    unsigned long l;
-    str.ToULong(&l, base);
-    return l;
+	unsigned long l;
+	str.ToULong(&l, base);
+	return l;
 }
 
 static u64 StrToU64(const wxString& str, int base = 10)
 {
-    wxULongLong_t l;
-    str.ToULongLong(&l, base);
-    return l;
+	wxULongLong_t l;
+	str.ToULongLong(&l, base);
+	return l;
 }
 
 // PatchFunc Functions.
 namespace PatchFunc
 {
-    void comment( const wxString& text1, const wxString& text2 )
-    {
+	void comment( const wxString& text1, const wxString& text2 )
+	{
 		PatchesCon->WriteLn(L"comment: " + text2);
-    }
+	}
 
-    struct PatchPieces
-    {
+	struct PatchPieces
+	{
 		wxArrayString m_pieces;
 
 		PatchPieces( const wxString& param )
@@ -299,7 +299,7 @@ namespace PatchFunc
 		const wxString& MemAddr() const			{ return m_pieces[2]; }
 		const wxString& OperandSize() const		{ return m_pieces[3]; }
 		const wxString& WriteValue() const		{ return m_pieces[4]; }
-    };
+	};
 
 	void patchHelper(const wxString& cmd, const wxString& param) {
 		// Error Handling Note:  I just throw simple wxStrings here, and then catch them below and
@@ -315,7 +315,7 @@ namespace PatchFunc
 		{
 			PatchPieces pieces(param);
 
-            IniPatch iPatch = { 0 };
+			IniPatch iPatch = { 0 };
 			iPatch.enabled = 0;
 			iPatch.placetopatch	= StrToU32(pieces.PlaceToPatch(), 10);
 
@@ -334,7 +334,7 @@ namespace PatchFunc
 				throw wxsFormat(L"Unrecognized Operand Size: '%s'", WX_STR(pieces.OperandSize()));
 
 			iPatch.enabled = 1; // omg success!!
-            Patch.push_back(iPatch);
+			Patch.push_back(iPatch);
 
 		}
 		catch( wxString& exmsg )
@@ -349,9 +349,9 @@ namespace PatchFunc
 // This is for applying patches directly to memory
 void ApplyLoadedPatches(patch_place_type place)
 {
-    for (auto& i : Patch)
-    {
-	    if (i.placetopatch == place)
-            _ApplyPatch(&i);
+	for (auto& i : Patch)
+	{
+		if (i.placetopatch == place)
+			_ApplyPatch(&i);
 	}
 }

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -200,7 +200,7 @@ static int _LoadPatchFiles(const wxDirName& folderName, wxString& fileSpec, cons
 			f.Close();
 			int loaded = Patch.size() - before;
 			PatchesCon->WriteLn((loaded ? Color_Green : Color_Gray), L"Loaded %d %s from '%s' at '%s'",
-								loaded, WX_STR(friendlyName), WX_STR(buffer), WX_STR(folderName.ToString()));
+				loaded, WX_STR(friendlyName), WX_STR(buffer), WX_STR(folderName.ToString()));
 			numberFoundPatchFiles++;
 		}
 		found = dir.GetNext(&buffer);

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -227,7 +227,7 @@ int LoadPatchesFromZip(wxString gameCRC, const wxString& patchesArchiveFilename)
 		name.MakeUpper();
 		if (name.Find(gameCRC) == 0 && name.Find(L".PNACH")+6u == name.Length()) {
 			PatchesCon->WriteLn(Color_Green, L"Loading patch '%s' from archive '%s'",
-								WX_STR(entry->GetName()), WX_STR(patchesArchiveFilename));
+				WX_STR(entry->GetName()), WX_STR(patchesArchiveFilename));
 			wxTextInputStream pnach(zip);
 			while (!zip.Eof()) {
 				inifile_processString(pnach.ReadLine());

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -22,6 +22,7 @@
 #include "GameDatabase.h"
 
 #include <memory>
+#include <vector>
 #include <wx/textfile.h>
 #include <wx/dir.h>
 #include <wx/txtstrm.h>
@@ -33,7 +34,8 @@
 extern void _ApplyPatch(IniPatch *p);
 
 
-IniPatch Patch[ MAX_PATCH ];
+
+std::vector<IniPatch> Patch;
 
 int patchnumber = 0;
 
@@ -313,17 +315,15 @@ namespace PatchFunc
 
 		try
 		{
-			if(patchnumber >= MAX_PATCH)
-				throw wxString( L"Maximum number of patches reached" );
-
-			IniPatch& iPatch = Patch[patchnumber];
 			PatchPieces pieces(param);
 
+            IniPatch iPatch = { 0 };
 			iPatch.enabled = 0;
-
 			iPatch.placetopatch	= StrToU32(pieces.PlaceToPatch(), 10);
+
 			if (iPatch.placetopatch >= _PPT_END_MARKER)
 				throw wxsFormat(L"Invalid 'place' value '%s' (0 - once on startup, 1: continuously)", WX_STR(pieces.PlaceToPatch()));
+
 			iPatch.cpu			= (patch_cpu_type)PatchTableExecute(pieces.CpuType(), cpuCore);
 			iPatch.addr			= StrToU32(pieces.MemAddr(), 16);
 			iPatch.type			= (patch_data_type)PatchTableExecute(pieces.OperandSize(), dataType);
@@ -336,6 +336,7 @@ namespace PatchFunc
 				throw wxsFormat(L"Unrecognized Operand Size: '%s'", WX_STR(pieces.OperandSize()));
 
 			iPatch.enabled = 1; // omg success!!
+            Patch.push_back(iPatch);
 
 			patchnumber++;
 		}

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -38,7 +38,6 @@
 #include "Pcsx2Defs.h"
 #include "SysForwardDefs.h"
 
-
 enum patch_cpu_type {
 	NO_CPU,
 	CPU_EE,

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -38,7 +38,6 @@
 #include "Pcsx2Defs.h"
 #include "SysForwardDefs.h"
 
-#define MAX_PATCH 2048
 
 enum patch_cpu_type {
 	NO_CPU,
@@ -85,7 +84,6 @@ typedef void PATCHTABLEFUNC( const wxString& text1, const wxString& text2 );
 struct IniPatch
 {
 	int enabled;
-	int group;
 	patch_data_type type;
 	patch_cpu_type cpu;
 	int placetopatch;

--- a/pcsx2/windows/cheats/browser.cpp
+++ b/pcsx2/windows/cheats/browser.cpp
@@ -75,7 +75,7 @@ void RefreshListBox(HWND hWnd)
 	char cpucore[2][10]={"EE", "IOP"};
 
 	// Adding items
-	for (int i = patchnumber-1; i >= 0; i--)
+	for (int i = Patch.size()-1; i >= 0; i--)
 	{
 		sprintf(Address, "0x%.8x", patch[i].addr);
 		sprintf(CPU, "%s", cpucore[patch[i].cpu-1]);
@@ -697,8 +697,7 @@ BOOL CALLBACK AddPatchProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
 						break;
 
 					// Add new patch, refresh and exit
-					memcpy((void *)&patch[patchnumber], (void *)&temp, sizeof(IniPatch));
-					patchnumber++;
+                    Patch.push_back(temp);
 					RefreshListBox(hParent);
 					EndDialog(hWnd,1);
 					break;
@@ -952,7 +951,7 @@ BOOL CALLBACK pnachWriterProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
 					}
 
 					// write patches
-					for(int i=0;i<patchnumber;i++)
+					for(unsigned int i=0;i<Patch.size();i++)
 					{
 						char cpucore[10], type[10];
 						switch(patch[i].cpu)

--- a/pcsx2/windows/cheats/browser.cpp
+++ b/pcsx2/windows/cheats/browser.cpp
@@ -951,10 +951,10 @@ BOOL CALLBACK pnachWriterProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
 					}
 
 					// write patches
-					for(unsigned int i=0;i<Patch.size();i++)
+					for (const auto& i : Patch)
 					{
 						char cpucore[10], type[10];
-						switch(patch[i].cpu)
+						switch(i.cpu)
 						{
 							case 1:
 								strcpy(cpucore, "EE");
@@ -964,7 +964,7 @@ BOOL CALLBACK pnachWriterProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
 								break;
 						}
 
-						switch(patch[i].type)
+						switch(i.type)
 						{
 							case 1:
 								strcpy(type, "byte");
@@ -980,7 +980,7 @@ BOOL CALLBACK pnachWriterProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
 								break;
 						}
 						//patch=placetopatch,cpucore,address,type,data
-						fprintf(fp, "patch=%d,%s,%.8x,%s,%.8x\n", patch[i].placetopatch, cpucore, patch[i].addr, type, patch[i].data);
+						fprintf(fp, "patch=%d,%s,%.8x,%s,%.8x\n", i.placetopatch, cpucore, i.addr, type, i.data);
 					}
 
 					fclose(fp);

--- a/pcsx2/windows/cheats/browser.cpp
+++ b/pcsx2/windows/cheats/browser.cpp
@@ -697,7 +697,7 @@ BOOL CALLBACK AddPatchProc(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
 						break;
 
 					// Add new patch, refresh and exit
-                    Patch.push_back(temp);
+					Patch.push_back(temp);
 					RefreshListBox(hParent);
 					EndDialog(hWnd,1);
 					break;


### PR DESCRIPTION
Pnach had a limit that, while increased at some point to 2048, is still not enough for everyone. This uses a vector to avoid that limit, as there is no reason to keep it and people loading pnach with over 2048 patches most likely know what they are doing.
Inipatch group member was also unused in the whole codebase so I did some cleanup and removed it.