### PR TITLE
GSdx-d3d11: Remove old colclip algo and add support for HDR colclip

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -207,7 +207,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 	if(i == m_ps.end())
 	{
-		std::string str[26];
+		std::string str[25];
 
 		str[0] = format("%d", sel.fst);
 		str[1] = format("%d", sel.wms);
@@ -222,19 +222,18 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		str[10] = format("%d", sel.fba);
 		str[11] = format("%d", sel.aout);
 		str[12] = format("%d", sel.ltf);
-		str[13] = format("%d", sel.colclip);
-		str[14] = format("%d", sel.spritehack);
-		str[15] = format("%d", sel.tcoffsethack);
-		str[16] = format("%d", sel.point_sampler);
-		str[17] = format("%d", sel.shuffle);
-		str[18] = format("%d", sel.read_ba);
-		str[19] = format("%d", sel.channel);
-		str[20] = format("%d", sel.tales_of_abyss_hle);
-		str[21] = format("%d", sel.urban_chaos_hle);
-		str[22] = format("%d", sel.dfmt);
-		str[23] = format("%d", sel.depth_fmt);
-		str[24] = format("%d", sel.fmt >> 2);
-		str[25] = format("%d", m_upscale_multiplier);
+		str[13] = format("%d", sel.spritehack);
+		str[14] = format("%d", sel.tcoffsethack);
+		str[15] = format("%d", sel.point_sampler);
+		str[16] = format("%d", sel.shuffle);
+		str[17] = format("%d", sel.read_ba);
+		str[18] = format("%d", sel.channel);
+		str[19] = format("%d", sel.tales_of_abyss_hle);
+		str[20] = format("%d", sel.urban_chaos_hle);
+		str[21] = format("%d", sel.dfmt);
+		str[22] = format("%d", sel.depth_fmt);
+		str[23] = format("%d", sel.fmt >> 2);
+		str[24] = format("%d", m_upscale_multiplier);
 
 		D3D_SHADER_MACRO macro[] =
 		{
@@ -251,19 +250,18 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			{"PS_FBA", str[10].c_str()},
 			{"PS_AOUT", str[11].c_str()},
 			{"PS_LTF", str[12].c_str()},
-			{"PS_COLCLIP", str[13].c_str()},
-			{"PS_SPRITEHACK", str[14].c_str()},
-			{"PS_TCOFFSETHACK", str[15].c_str()},
-			{"PS_POINT_SAMPLER", str[16].c_str()},
-			{"PS_SHUFFLE", str[17].c_str() },
-			{"PS_READ_BA", str[18].c_str() },
-			{"PS_CHANNEL_FETCH", str[19].c_str() },
-			{"PS_TALES_OF_ABYSS_HLE", str[20].c_str() },
-			{"PS_URBAN_CHAOS_HLE", str[21].c_str() },
-			{"PS_DFMT", str[22].c_str() },
-			{"PS_DEPTH_FMT", str[23].c_str() },
-			{"PS_PAL_FMT", str[24].c_str() },
-			{"PS_SCALE_FACTOR", str[25].c_str() },
+			{"PS_SPRITEHACK", str[13].c_str()},
+			{"PS_TCOFFSETHACK", str[14].c_str()},
+			{"PS_POINT_SAMPLER", str[15].c_str()},
+			{"PS_SHUFFLE", str[16].c_str() },
+			{"PS_READ_BA", str[17].c_str() },
+			{"PS_CHANNEL_FETCH", str[18].c_str() },
+			{"PS_TALES_OF_ABYSS_HLE", str[19].c_str() },
+			{"PS_URBAN_CHAOS_HLE", str[20].c_str() },
+			{"PS_DFMT", str[21].c_str() },
+			{"PS_DEPTH_FMT", str[22].c_str() },
+			{"PS_PAL_FMT", str[23].c_str() },
+			{"PS_SCALE_FACTOR", str[24].c_str() },
 			{NULL, NULL},
 		};
 
@@ -404,22 +402,6 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 			bd.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
 			bd.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
 			bd.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
-
-			// Not very good but I don't wanna write another 81 row table
-
-			if(bsel.negative)
-			{
-				if(bd.RenderTarget[0].BlendOp == D3D11_BLEND_OP_ADD)
-				{
-					bd.RenderTarget[0].BlendOp = D3D11_BLEND_OP_REV_SUBTRACT;
-				}
-				else if(bd.RenderTarget[0].BlendOp == D3D11_BLEND_OP_REV_SUBTRACT)
-				{
-					bd.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
-				}
-				else
-					; // god knows, best just not to mess with it for now
-			}
 		}
 
 		if(bsel.wr) bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_RED;

--- a/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
+++ b/plugins/GSdx/Renderers/DXCommon/GSDeviceDX.h
@@ -202,7 +202,6 @@ public:
 				// *** Word 2
 				// Blend and Colclip
 				uint32 clr1:1;
-				uint32 colclip:2;
 
 				// Others ways to fetch the texture
 				uint32 channel:3;
@@ -215,7 +214,7 @@ public:
 				uint32 tales_of_abyss_hle:1;
 				uint32 point_sampler:1;
 
-				uint32 _free:26;
+				uint32 _free:28;
 			};
 
 			uint64 key;
@@ -281,7 +280,6 @@ public:
 				uint32 wg:1;
 				uint32 wb:1;
 				uint32 wa:1;
-				uint32 negative:1;
 			};
 
 			struct
@@ -294,7 +292,7 @@ public:
 			uint32 key;
 		};
 
-		operator uint32() {return key & 0x3fff;}
+		operator uint32() {return key & 0x1fff;}
 
 		OMBlendSelector() : key(0) {}
 

--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
@@ -538,21 +538,6 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		}
 	}
 
-	bool colclip_wrap = m_env.COLCLAMP.CLAMP == 0 && !tex && PRIM->PRIM != GS_POINTLIST;
-	if (colclip_wrap)
-	{
-		if ((m_context->ALPHA.A == m_context->ALPHA.B) || !m_om_bsel.abe) // Optimize-away colclip
-		{
-			// No addition neither substraction so no risk of overflow the [0:255] range.
-			colclip_wrap = false;
-		}
-		else
-		{
-			m_ps_sel.colclip = 1;
-			// fprintf(stderr, "COLCLIP ENABLED (blending is %d/%d/%d/%d)\n", m_context->ALPHA.A, m_context->ALPHA.B, m_context->ALPHA.C, m_context->ALPHA.D);
-		}
-	}
-
 	m_ps_sel.clr1 = m_om_bsel.IsCLR1();
 	m_ps_sel.fba = m_context->FBA.FBA;
 
@@ -691,21 +676,6 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 	if (ate_first_pass)
 	{
 		dev->DrawIndexedPrimitive();
-
-		if (colclip_wrap)
-		{
-			GSDeviceDX::OMBlendSelector om_bselneg(m_om_bsel);
-			GSDeviceDX::PSSelector ps_selneg(m_ps_sel);
-
-			om_bselneg.negative = 1;
-			ps_selneg.colclip = 2;
-
-			dev->SetupOM(m_om_dssel, om_bselneg, afix);
-			dev->SetupPS(ps_selneg, &ps_cb, m_ps_ssel);
-
-			dev->DrawIndexedPrimitive();
-			dev->SetupOM(m_om_dssel, m_om_bsel, afix);
-		}
 	}
 
 	if (ate_second_pass)
@@ -767,20 +737,6 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 			dev->SetupOM(m_om_dssel, m_om_bsel, afix);
 
 			dev->DrawIndexedPrimitive();
-
-			if (colclip_wrap)
-			{
-				GSDeviceDX::OMBlendSelector om_bselneg(m_om_bsel);
-				GSDeviceDX::PSSelector ps_selneg(m_ps_sel);
-
-				om_bselneg.negative = 1;
-				ps_selneg.colclip = 2;
-
-				dev->SetupOM(m_om_dssel, om_bselneg, afix);
-				dev->SetupPS(ps_selneg, &ps_cb, m_ps_ssel);
-
-				dev->DrawIndexedPrimitive();
-			}
 		}
 	}
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -489,6 +489,14 @@ GSVector4 GSRendererHW::RealignTargetTextureCoordinate(const GSTextureCache::Sou
 	return half_offset;
 }
 
+GSVector4i GSRendererHW::ComputeBoundingBox(const GSVector2& rtscale, const GSVector2i& rtsize)
+{
+	GSVector4 scale = GSVector4(rtscale.x, rtscale.y);
+	GSVector4 offset = GSVector4(-1.0f, 1.0f); // Round value
+	GSVector4 box = m_vt.m_min.p.xyxy(m_vt.m_max.p) + offset.xxyy();
+	return GSVector4i(box * scale.xyxy()).rintersect(GSVector4i(0, 0, rtsize.x, rtsize.y));
+}
+
 void GSRendererHW::MergeSprite(GSTextureCache::Source* tex)
 {
 	// Upscaling hack to avoid various line/grid issues

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -169,6 +169,7 @@ public:
 	void SetScaling();
 	void Lines2Sprites();
 	GSVector4 RealignTargetTextureCoordinate(const GSTextureCache::Source* tex);
+	GSVector4i ComputeBoundingBox(const GSVector2& rtscale, const GSVector2i& rtsize);
 	void MergeSprite(GSTextureCache::Source* tex);
 
 	void Reset();

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -964,14 +964,6 @@ GSRendererOGL::PRIM_OVERLAP GSRendererOGL::PrimitiveOverlap()
 	return overlap;
 }
 
-GSVector4i GSRendererOGL::ComputeBoundingBox(const GSVector2& rtscale, const GSVector2i& rtsize)
-{
-	GSVector4 scale = GSVector4(rtscale.x, rtscale.y);
-	GSVector4 offset = GSVector4(-1.0f, 1.0f); // Round value
-	GSVector4 box = m_vt.m_min.p.xyxy(m_vt.m_max.p) + offset.xxyy();
-	return GSVector4i(box * scale.xyxy()).rintersect(GSVector4i(0, 0, rtsize.x, rtsize.y));
-}
-
 void GSRendererOGL::SendDraw()
 {
 	GSDeviceOGL* dev = (GSDeviceOGL*)m_dev;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
@@ -59,8 +59,6 @@ class GSRendererOGL final : public GSRendererHW
 		GSDeviceOGL::VSConstantBuffer vs_cb;
 		GSDeviceOGL::PSConstantBuffer ps_cb;
 
-		GSVector4i ComputeBoundingBox(const GSVector2& rtscale, const GSVector2i& rtsize);
-
 		bool m_require_one_barrier;
 		bool m_require_full_barrier;
 

--- a/plugins/GSdx/res/convert.fx
+++ b/plugins/GSdx/res/convert.fx
@@ -131,8 +131,13 @@ PS_OUTPUT ps_main3(PS_INPUT input)
 PS_OUTPUT ps_main4(PS_INPUT input)
 {
 	PS_OUTPUT output;
-	
-	output.c = fmod(sample_c(input.t) * 255 + 0.5f, 256) / 255;
+
+	float4 c = round(sample_c(input.t) * 255);
+	// We use 2 fmod to avoid negative value.
+	float4 fmod1 = fmod(c, 256) + 256;
+	float4 fmod2 = fmod(fmod1, 256);
+
+	output.c = fmod2 / 255.0f;
 
 	return output;
 }

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -31,7 +31,6 @@
 #define PS_FBA 0
 #define PS_AOUT 0
 #define PS_LTF 1
-#define PS_COLCLIP 0
 #define PS_SPRITEHACK 0
 #define PS_TCOFFSETHACK 0
 #define PS_POINT_SAMPLER 0
@@ -634,16 +633,6 @@ float4 ps_color(PS_INPUT input)
 	atst(c);
 
 	c = fog(c, input.t.z);
-
-	// FIXME: Colclip and Depth sampling shouldn't run together.
-	if (PS_COLCLIP == 2)
-	{
-		c.rgb = 256./255. - c.rgb;
-	}
-	if (PS_COLCLIP > 0)
-	{
-		c.rgb *= c.rgb < 128./255;
-	}
 
 	if(PS_CLR1) // needed for Cd * (As/Ad/F + 1) blending modes
 	{


### PR DESCRIPTION
Remove colclip and negative blend algo.
Code was old and inefficient. HDR colclip will do a better job.

GSdx-d3d11: Add/port HDR colclip support.
It helps render shadows a lot better compared to the old code.

convert.fx: Update main4 shader to better support hdr colclip.

Credits to @gregory38 and  @tadanokojin for helping with the code.