### PR TITLE
GameDB: UEFA Euro 2004 black box fix

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -11580,6 +11580,7 @@ Region = PAL-E
 Serial = SLES-52395
 Name   = UFEA Euro 2004
 Region = PAL-F-G
+vuClampMode = 2 // Fixes black box issues everywhere ingame.
 ---------------------------------------------
 Serial = SLES-52396
 Name   = Euro 2004


### PR DESCRIPTION
The PR fixes black box issues when going ingame with UEFA Euro 2004.

I only apply it on the fr-g version as it's the only I can test.

Without the fix:
![image](https://user-images.githubusercontent.com/26351275/51089526-07222e00-176f-11e9-8871-1ae1b0def08c.png)

With it:
![image](https://user-images.githubusercontent.com/26351275/51089547-510b1400-176f-11e9-829b-c3ef45a51476.png)