### PR TITLE
GSdx-ogl: Small colclip improvements

### DIFF
--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -561,7 +561,7 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 										sw_blending |= (ALPHA.A != ALPHA.B) &&
 												((ALPHA.C == 0 && m_vt.m_alpha.max > 128) || (ALPHA.C == 2 && ALPHA.FIX > 128u));
 										// fall through
-		case ACC_BLEND_CCLIP_DALPHA:    sw_blending |= (ALPHA.C == 1) || (m_env.COLCLAMP.CLAMP == 0);
+		case ACC_BLEND_CCLIP_DALPHA:    sw_blending |= (ALPHA.C == 1);
 										// Initial idea was to enable accurate blending for sprite rendering to handle
 										// correctly post-processing effect. Some games (ZoE) use tons of sprites as particles.
 										// In order to keep it fast, let's limit it to smaller draw call.
@@ -598,7 +598,8 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 			m_ps_sel.colclip = 1;
 		} else {
 			// Speed hack skip previous slow algo
-			GL_INS("Sorry colclip isn't supported");
+			GL_INS("COLCLIP HDR Rare case ENABLED");
+			m_ps_sel.hdr = 1;
 		}
 	}
 

--- a/plugins/GSdx/res/glsl/tfx_fs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_fs.glsl
@@ -838,15 +838,15 @@ void ps_main()
 
     ps_fbmask(C);
 
-#if PS_HDR == 1
+// #if PS_HDR == 1
     // Use negative value to avoid overflow of the texture (in accumulation mode)
     // Note: code were initially done for an Half-Float texture. Due to overflow
     // the texture was upgraded to a full float. Maybe this code is useless now!
     // Good testcase is castlevania
-    if (any(greaterThan(C.rgb, vec3(128.0f)))) {
-        C.rgb = (C.rgb - 256.0f);
-    }
-#endif
+    // if (any(greaterThan(C.rgb, vec3(128.0f)))) {
+        // C.rgb = (C.rgb - 256.0f);
+    // }
+// #endif
     SV_Target0 = C / 255.0f;
     SV_Target1 = vec4(alpha_blend);
 }


### PR DESCRIPTION
1. Allow hrd colclip to also run on the unsupported
cases which should be pretty rare.

2. Remove colclip from high sw blending.

3. Disable the hdr colclip shader which may not be
actually required to run.

Note: I didn't run any tests to compare raw dump, only performance comparison which was within margin.

Idea by @gregory38 