### PR TITLE
gsdx-d3d11: ICO depth HLE

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1309,8 +1309,9 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector
 	if(m_state.rt_view != rtv || m_state.dsv != dsv)
 	{
 		m_state.rt_view = rtv;
-		m_state.rt_texture = (GSTexture11*)rt;
+		m_state.rt_texture = static_cast<GSTexture11*>(rt);
 		m_state.dsv = dsv;
+		m_state.rt_ds = static_cast<GSTexture11*>(ds);
 
 		m_ctx->OMSetRenderTargets(1, &rtv, dsv);
 	}
@@ -1349,6 +1350,7 @@ void GSDevice11::OMSetRenderTargets(const GSVector2i& rtsize, int count, ID3D11U
 
 	m_state.rt_view = NULL;
 	m_state.rt_texture = NULL;
+	m_state.rt_ds = NULL;
 	m_state.dsv = NULL;
 
 	if(m_state.viewport != rtsize)

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -81,6 +81,7 @@ class GSDevice11 : public GSDeviceDX
 		float bf;
 		ID3D11RenderTargetView* rt_view;
 		GSTexture11* rt_texture;
+		GSTexture11* rt_ds;
 		ID3D11DepthStencilView* dsv;
 	} m_state;
 

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -192,7 +192,7 @@ public:
 
 	GSTexture* CopyOffscreen(GSTexture* src, const GSVector4& sRect, int w, int h, int format = 0, int ps_shader = 0);
 
-	GSTexture* CopyRenderTarget(GSTexture* src);
+	void CloneTexture(GSTexture* src, GSTexture** dest);
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r);
 

--- a/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
+++ b/plugins/GSdx/Renderers/DXCommon/GSRendererDX.cpp
@@ -948,9 +948,25 @@ void GSRendererDX::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		{
 			// Note potentially we can limit to TBP0:0x2800
 
-			// DX doesn't support depth or channel shuffle yet so we can just do a partial port that skips the bad drawcalls,
-			// this way we can purge any remaining crc hacks.
-			throw GSDXRecoverableError();
+			// Depth buffer was moved so GSdx will invalide it which means a
+			// downscale. ICO uses the MSB depth bits as the texture alpha
+			// channel.  However this depth of field effect requires
+			// texel:pixel mapping accuracy.
+			//
+			// Use an HLE shader to sample depth directly as the alpha channel
+
+			// OutputDebugString("ICO HLE");
+
+			m_ps_sel.depth_fmt = 1;
+			m_ps_sel.channel = ChannelFetch_BLUE;
+
+			dev->PSSetShaderResource(4, ds);
+
+			if (!tex->m_palette)
+			{
+				uint16 pal = GSLocalMemory::m_psm[tex->m_TEX0.PSM].pal;
+				m_tc->AttachPaletteToSource(tex, pal, true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Port of the ICO HLE fix and update to fb copy on slot 4