### PR TITLE
gsdx-debug: Add secret ini option for dump directory

### DIFF
--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -44,6 +44,7 @@ GSState::GSState()
 	, m_crc(0)
 	, m_options(0)
 	, m_frameskip(0)
+	, m_dump_root("")
 {
 	// m_nativeres seems to be a hack. Unfortunately it impacts draw call number which make debug painful in the replayer.
 	// Let's keep it disabled to ease debug.
@@ -63,13 +64,13 @@ GSState::GSState()
 	s_savef = theApp.GetConfigB("savef");
 	s_saven = theApp.GetConfigI("saven");
 	s_savel = theApp.GetConfigI("savel");
-	m_dump_root = "";
-#if defined(__unix__)
+
+	// note: HW will overwrite
+	m_dump_root = theApp.GetConfigS("dump_dir") + GS_DUMP_DIR_PREFIX + "_SW" + DIRECTORY_SEPARATOR;
+
 	if (s_dump) {
-		GSmkdir(root_hw.c_str());
-		GSmkdir(root_sw.c_str());
+		GSmkdir(m_dump_root.c_str());
 	}
-#endif
 
 	//s_dump = 1;
 	//s_save = 1;

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -366,6 +366,11 @@ void GSdxApp::Init()
 	m_default_configuration["debug_opengl"]                               = "0";
 	m_default_configuration["disable_hw_gl_draw"]                         = "0";
 	m_default_configuration["dump"]                                       = "0";
+#ifdef _WIN32
+	m_default_configuration["dump_dir"]                                   = "C:\\tmp\\";
+#else
+	m_default_configuration["dump_dir"]                                   = "/tmp/";
+#endif
 	m_default_configuration["extrathreads"]                               = "2";
 	m_default_configuration["extrathreads_height"]                        = "4";
 	m_default_configuration["filter"]                                     = std::to_string(static_cast<int8>(BiFiltering::PS2));

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -321,7 +321,7 @@ void GSRenderer::VSync(int field)
 
 	if(s_dump && s_n >= s_saven)
 	{
-		m_regs->Dump(root_sw + format("%05d_f%lld_gs_reg.txt", s_n, m_perfmon.GetFrame()));
+		m_regs->Dump(m_dump_root + format("%05d_f%lld_gs_reg.txt", s_n, m_perfmon.GetFrame()));
 	}
 
 	if(!m_dev->IsLost(true))

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -70,7 +70,11 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 		m_userHacks_merge_sprite         = false;
 	}
 
-	m_dump_root = root_hw;
+	m_dump_root = theApp.GetConfigS("dump_dir") + GS_DUMP_DIR_PREFIX + "_HW" + DIRECTORY_SEPARATOR;
+
+	if (s_dump) {
+		GSmkdir(m_dump_root.c_str());
+	}
 }
 
 void GSRendererHW::SetScaling()

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -75,8 +75,6 @@ GSRendererSW::GSRendererSW(int threads)
 	InitCVB(GS_TRIANGLE_CLASS);
 	InitCVB(GS_SPRITE_CLASS);
 
-	m_dump_root = root_sw;
-
 	// Reset handler with the auto flush hack enabled on the SW renderer
 	// Impact on perf is rather small, and it avoids an extra hack option.
 	if (!GLLoader::in_replayer) {
@@ -1549,7 +1547,7 @@ void GSRendererSW::SharedData::UpdateSource()
 
 				s = format("%05d_f%lld_itex%d_%05x_%s.bmp", m_parent->s_n, frame, i, TEX0.TBP0, psm_str(TEX0.PSM));
 
-				m_tex[i].t->Save(root_sw+s);
+				m_tex[i].t->Save(m_parent->m_dump_root+s);
 			}
 
 			if(global.clut != NULL)
@@ -1560,7 +1558,7 @@ void GSRendererSW::SharedData::UpdateSource()
 
 				s = format("%05d_f%lld_itexp_%05x_%s.bmp", m_parent->s_n, frame, (int)m_parent->m_context->TEX0.CBP, psm_str(m_parent->m_context->TEX0.CPSM));
 
-				t->Save(root_sw+s);
+				t->Save(m_parent->m_dump_root+s);
 
 				delete t;
 			}

--- a/plugins/GSdx/stdafx.cpp
+++ b/plugins/GSdx/stdafx.cpp
@@ -46,20 +46,6 @@ std::string format(const char* fmt, ...)
 	return {buffer.data()};
 }
 
-// Helper path to dump texture
-#ifdef _WIN32
-const std::string root_sw("c:\\temp1\\_");
-const std::string root_hw("c:\\temp2\\_");
-#else
-#ifdef _M_AMD64
-const std::string root_sw("/tmp/GS_SW_dump64/");
-const std::string root_hw("/tmp/GS_HW_dump64/");
-#else
-const std::string root_sw("/tmp/GS_SW_dump32/");
-const std::string root_hw("/tmp/GS_HW_dump32/");
-#endif
-#endif
-
 #ifdef _WIN32
 
 void* vmalloc(size_t size, bool code)

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -132,7 +132,7 @@ typedef int64 sint64;
 	#include "Renderers/OpenGL/GLLoader.h"
 
 	#define DIRECTORY_SEPARATOR '\\'
-
+	#define GS_DUMP_DIR_PREFIX "GSDX_32"
 #else
 
 	// Note use GL/glcorearb.h on the future
@@ -143,7 +143,7 @@ typedef int64 sint64;
 	#include <sys/stat.h> // mkdir
 
 	#define DIRECTORY_SEPARATOR '/'
-
+	#define GS_DUMP_DIR_PREFIX "GSDX_64"
 #endif
 
 #ifdef _MSC_VER
@@ -421,7 +421,3 @@ struct GLAutoPop {
 #define GL_INS(...)  (void)(0);
 #define GL_PERF(...) (void)(0);
 #endif
-
-// Helper path to dump texture
-extern const std::string root_sw;
-extern const std::string root_hw;


### PR DESCRIPTION
Add a secret ini option to change the raw dump directory.

Also the following changes:
- Windows creates the directory now
- Directory is now `GSDX_[32|64]_[SW|HW]`

#SaveTheSSDs