### PR TITLE
gsdx-d3d11: Framebuffer copy improvements

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -331,6 +331,8 @@ private:
 	void InitExternalFX();
 	void InitFXAA(); // Bug workaround! Stack corruption? Heap corruption? No idea
 	void RenderOsd(GSTexture* dt);
+	void BeforeDraw();
+	void AfterDraw();
 	
 	//
 
@@ -368,6 +370,7 @@ private:
 		GSTexture11* rt_texture;
 		GSTexture11* rt_ds;
 		ID3D11DepthStencilView* dsv;
+		uint16_t ps_sr_bitfield;
 	} m_state;
 
 	CComPtr<ID3D11RasterizerState> m_rs;


### PR DESCRIPTION
Improved handling of frame buffer copy by accounting for fb read on all slots.

- implement before/after draw functions
- defer setting of resources on the api to just before the draw
- use a bitfield to keep track of set/copied resources
- recycle copies after draw

Fixes: RE4 and Tales of Abyss