### PR TITLE
GSdx-d3d11: Enable break on D3D message

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -337,6 +337,7 @@ void GSdxApp::Init()
 	m_default_configuration["Adapter"]                                    = "default";
 	m_default_configuration["CaptureFileName"]                            = "";
 	m_default_configuration["CaptureVideoCodecDisplayName"]               = "";
+	m_default_configuration["dx_break_on_severity"]                       = "0";
 
 	// OpenCL device. Windows only for now.
 	m_default_configuration["ocldev"]                                     = "";

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -252,6 +252,28 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 
 	hr = m_dev->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &options, sizeof(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS));
 
+	// debug
+#ifdef _DEBUG
+	CComPtr<ID3D11Debug> debug;
+	hr = m_dev->QueryInterface<ID3D11Debug>(&debug);
+
+	if (SUCCEEDED(hr))
+	{
+		CComPtr<ID3D11InfoQueue> info_queue;
+		hr = debug->QueryInterface<ID3D11InfoQueue>(&info_queue);
+
+		if (SUCCEEDED(hr))
+		{
+			int break_on = theApp.GetConfigI("dx_break_on_severity");
+
+			info_queue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_CORRUPTION, break_on & (1 << 0));
+			info_queue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_ERROR, break_on & (1 << 1));
+			info_queue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_WARNING, break_on & (1 << 2));
+			info_queue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_INFO, break_on & (1 << 3));
+		}
+	}
+#endif
+
 	// convert
 
 	D3D11_INPUT_ELEMENT_DESC il_convert[] =


### PR DESCRIPTION
Enable automatic breaking on d3d11 messages:
- `D3D11_MESSAGE_SEVERITY_CORRUPTION`
- `D3D11_MESSAGE_SEVERITY_ERROR`
- `D3D11_MESSAGE_SEVERITY_WARNING`
- `D3D11_MESSAGE_SEVERITY_INFO`

Hidden option `dx_break_on_severity` bitfield

Debug build only.