### PR TITLE
LilyPad: Adjust Special Inputs window and button behavior

### DIFF
--- a/plugins/LilyPad/Config.cpp
+++ b/plugins/LilyPad/Config.cpp
@@ -491,6 +491,8 @@ void SelChanged(int port, int slot)
     config.bind = false;
 
     // Input & Special Bindings:
+    SetWindowTextW(GetDlgItem(hWnd, ID_SPECIAL_INPUTS), config.specialInputs[port][slot] ? L"Hide Special Inputs" : L"Show Special Inputs");
+    SetWindowPos(hWndList, NULL, 0, 0, 275, config.specialInputs[port][slot] ? 324 : 440, SWP_NOZORDER | SWP_NOMOVE);
     for (i = IDC_DPAD; i <= ID_SPECIAL_INPUTS; i++) {
         hWndTemp = GetDlgItem(hWnd, i);
         if (hWndTemp) {
@@ -1982,8 +1984,6 @@ INT_PTR CALLBACK DialogProc(HWND hWnd, unsigned int msg, WPARAM wParam, LPARAM l
                     config.configureOnBind = IsDlgButtonChecked(hWnd, IDC_CONFIGURE_ON_BIND);
                 } else if (cmd == ID_SPECIAL_INPUTS) {
                     config.specialInputs[port][slot] = !config.specialInputs[port][slot];
-                    SetWindowTextW(GetDlgItem(hWnd, ID_SPECIAL_INPUTS), config.specialInputs[port][slot] ? L"Hide Special Inputs" : L"Show Special Inputs");
-                    SetWindowPos(hWndList, NULL, 0, 0, 275, config.specialInputs[port][slot] ? 324 : 440, SWP_NOZORDER | SWP_NOMOVE);
                     ListView_SetColumnWidth(hWndList, 2, LVSCW_AUTOSIZE_USEHEADER);
                     UnselectAll(hWndList);
                     SelChanged(port, slot);


### PR DESCRIPTION
Fixes an issue with the window size and Show/Hide special inputs button
resetting when lilypad was closed and reopened, this was because the
code was executed only when the button was actually clicked.

The values will be properly stored in cache along with the rest already
working properly buttons.


I don't know if this is actually proper, not sure if I should move a bit more of the code as well.