### PR TITLE
Greg/gsdx sparse

### DIFF
--- a/plugins/GSdx/Renderers/Common/GSDevice.cpp
+++ b/plugins/GSdx/Renderers/Common/GSDevice.cpp
@@ -163,6 +163,7 @@ void GSDevice::Recycle(GSTexture* t)
 {
 	if(t)
 	{
+		t->Uncommit();
 		t->last_frame_used = m_frame;
 
 		m_pool.push_front(t);

--- a/plugins/GSdx/Renderers/Common/GSDevice.cpp
+++ b/plugins/GSdx/Renderers/Common/GSDevice.cpp
@@ -163,7 +163,12 @@ void GSDevice::Recycle(GSTexture* t)
 {
 	if(t)
 	{
+#ifdef _DEBUG
+		// Uncommit saves memory but it means a futur allocation when we want to reuse the texture.
+		// Which is slow and defeat the purpose of the m_pool cache.
+		// However, it can help to spot part of texture that we forgot to commit
 		t->Uncommit();
+#endif
 		t->last_frame_used = m_frame;
 
 		m_pool.push_front(t);

--- a/plugins/GSdx/Renderers/Common/GSDevice.cpp
+++ b/plugins/GSdx/Renderers/Common/GSDevice.cpp
@@ -201,6 +201,16 @@ void GSDevice::PurgePool()
 	}
 }
 
+GSTexture* GSDevice::CreateSparseRenderTarget(int w, int h, int format)
+{
+	return FetchSurface(HasColorSparse() ? GSTexture::SparseRenderTarget : GSTexture::RenderTarget, w, h, format);
+}
+
+GSTexture* GSDevice::CreateSparseDepthStencil(int w, int h, int format)
+{
+	return FetchSurface(HasDepthSparse() ? GSTexture::SparseDepthStencil : GSTexture::DepthStencil, w, h, format);
+}
+
 GSTexture* GSDevice::CreateRenderTarget(int w, int h, int format)
 {
 	return FetchSurface(GSTexture::RenderTarget, w, h, format);

--- a/plugins/GSdx/Renderers/Common/GSDevice.h
+++ b/plugins/GSdx/Renderers/Common/GSDevice.h
@@ -167,11 +167,16 @@ public:
 	virtual void DrawIndexedPrimitive(int offset, int count) {}
 	virtual void EndScene();
 
+	virtual bool HasDepthSparse() { return false; }
+	virtual bool HasColorSparse() { return false; }
+
 	virtual void ClearRenderTarget(GSTexture* t, const GSVector4& c) {}
 	virtual void ClearRenderTarget(GSTexture* t, uint32 c) {}
 	virtual void ClearDepth(GSTexture* t) {}
 	virtual void ClearStencil(GSTexture* t, uint8 c) {}
 
+	GSTexture* CreateSparseRenderTarget(int w, int h, int format = 0);
+	GSTexture* CreateSparseDepthStencil(int w, int h, int format = 0);
 	GSTexture* CreateRenderTarget(int w, int h, int format = 0);
 	GSTexture* CreateDepthStencil(int w, int h, int format = 0);
 	GSTexture* CreateTexture(int w, int h, int format = 0);

--- a/plugins/GSdx/Renderers/Common/GSTexture.cpp
+++ b/plugins/GSdx/Renderers/Common/GSTexture.cpp
@@ -25,11 +25,66 @@
 GSTexture::GSTexture()
 	: m_scale(1, 1)
 	, m_size(0, 0)
+	, m_committed_size(0, 0)
+	, m_gpu_page_size(0, 0)
 	, m_type(0)
 	, m_format(0)
+	, m_sparse(false)
 	, last_frame_used(0)
 	, LikelyOffset(false)
 	, OffsetHack_modx(0.0f)
 	, OffsetHack_mody(0.0f)
 {
+}
+
+void GSTexture::CommitRegion(const GSVector2i& region)
+{
+	if (!m_sparse)
+		return;
+
+	GSVector2i aligned_region = RoundUpPage(region);
+	aligned_region.x = std::max(m_committed_size.x, aligned_region.x);
+	aligned_region.y = std::max(m_committed_size.y, aligned_region.y);
+	if (aligned_region != m_committed_size)
+		CommitPages(aligned_region, true);
+}
+
+void GSTexture::Commit()
+{
+	if (!m_sparse)
+		return;
+
+	if (m_committed_size != m_size)
+		CommitPages(m_size, true);
+}
+
+void GSTexture::Uncommit()
+{
+	if (!m_sparse)
+		return;
+
+	GSVector2i zero = GSVector2i(0, 0);
+
+	if (m_committed_size != zero)
+		CommitPages(m_committed_size, false);
+}
+
+void GSTexture::SetGpuPageSize(const GSVector2i& page_size)
+{
+	ASSERT(std::bitset<32>(page_size.x + 1).count() == 1);
+	ASSERT(std::bitset<32>(page_size.y + 1).count() == 1);
+
+	m_gpu_page_size = page_size;
+}
+
+GSVector2i GSTexture::RoundUpPage(GSVector2i v)
+{
+	v.x = std::min(m_size.x, v.x);
+	v.y = std::min(m_size.y, v.y);
+	v.x += m_gpu_page_size.x;
+	v.y += m_gpu_page_size.y;
+	v.x &= ~m_gpu_page_size.x;
+	v.y &= ~m_gpu_page_size.y;
+
+	return v;
 }

--- a/plugins/GSdx/Renderers/Common/GSTexture.h
+++ b/plugins/GSdx/Renderers/Common/GSTexture.h
@@ -28,8 +28,11 @@ class GSTexture
 protected:
 	GSVector2 m_scale;
 	GSVector2i m_size;
+	GSVector2i m_committed_size;
+	GSVector2i m_gpu_page_size;
 	int m_type;
 	int m_format;
+	bool m_sparse;
 
 public:
 	struct GSMap {uint8* bits; int pitch;};
@@ -58,6 +61,14 @@ public:
 
 	int GetType() const {return m_type;}
 	int GetFormat() const {return m_format;}
+
+	virtual void CommitPages(const GSVector2i& region, bool commit) {};
+	void CommitRegion(const GSVector2i& region);
+	void Commit();
+	void Uncommit();
+	GSVector2i GetCommittedSize() const { return m_committed_size; }
+	void SetGpuPageSize(const GSVector2i& page_size);
+	GSVector2i RoundUpPage(GSVector2i v);
 
 	// frame number (arbitrary base) the texture was recycled on
 	// different purpose than texture cache ages, do not attempt to merge

--- a/plugins/GSdx/Renderers/Common/GSTexture.h
+++ b/plugins/GSdx/Renderers/Common/GSTexture.h
@@ -34,7 +34,7 @@ protected:
 public:
 	struct GSMap {uint8* bits; int pitch;};
 
-	enum {RenderTarget = 1, DepthStencil, Texture, Offscreen, Backbuffer};
+	enum {RenderTarget = 1, DepthStencil, Texture, Offscreen, Backbuffer, SparseRenderTarget, SparseDepthStencil};
 
 public:
 	GSTexture();

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -713,7 +713,7 @@ GSTexture* GSDevice11::CreateSurface(int type, int w, int h, int format)
 GSTexture* GSDevice11::FetchSurface(int type, int w, int h, int format)
 {
 	if (format == 0)
-		format = (type == GSTexture::DepthStencil) ? DXGI_FORMAT_R32G8X24_TYPELESS : DXGI_FORMAT_R8G8B8A8_UNORM;
+		format = (type == GSTexture::DepthStencil || type == GSTexture::SparseDepthStencil) ? DXGI_FORMAT_R32G8X24_TYPELESS : DXGI_FORMAT_R8G8B8A8_UNORM;
 
 	return __super::FetchSurface(type, w, h, format);
 }

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1319,15 +1319,22 @@ void GSRendererHW::OI_DoubleHalfClear(GSTexture* rt, GSTexture* ds)
 		// If both buffers are side by side we can expect a fast clear in on-going
 		if (half <= (base + written_pages)) {
 			uint32 color = v[1].RGBAQ.u32[0];
+			bool clear_depth = (m_context->FRAME.FBP > m_context->ZBUF.ZBP);
 
-			GL_INS("OI_DoubleHalfClear: base %x half %x. w_pages %d h_pages %d fbw %d. Color %x", base << 5, half << 5, w_pages, h_pages, m_context->FRAME.FBW, color);
+			GL_INS("OI_DoubleHalfClear:%s: base %x half %x. w_pages %d h_pages %d fbw %d. Color %x",
+					clear_depth ? "depth" : "target", base << 5, half << 5, w_pages, h_pages, m_context->FRAME.FBW, color);
 
-			if (m_context->FRAME.FBP > m_context->ZBUF.ZBP) {
+			// Commit texture with a factor 2 on the height
+			GSTexture* t = clear_depth ? ds : rt;
+			GSVector4i commitRect = ComputeBoundingBox(t->GetScale(), t->GetSize());
+			t->CommitRegion(GSVector2i(commitRect.z, 2 * commitRect.w));
+
+			if (clear_depth) {
 				// Only pure clear are supported for depth
 				ASSERT(color == 0);
-				m_dev->ClearDepth(ds);
+				m_dev->ClearDepth(t);
 			} else {
-				m_dev->ClearRenderTarget(rt, color);
+				m_dev->ClearRenderTarget(t, color);
 			}
 		}
 	}
@@ -1553,6 +1560,7 @@ bool GSRendererHW::OI_FFX(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* 
 	{
 		// random battle transition (z buffer written directly, clear it now)
 
+		ds->Commit(); // Don't bother to save few MB for a single game
 		m_dev->ClearDepth(ds);
 	}
 
@@ -1603,6 +1611,7 @@ bool GSRendererHW::OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTex
 
 			if(GSTextureCache::Target* tmp_rt = m_tc->LookupTarget(TEX0, m_width, m_height, GSTextureCache::RenderTarget, true))
 			{
+				tmp_rt->m_texture->Commit(); // Don't bother to save few MB for a single game
 				m_dev->ClearRenderTarget(tmp_rt->m_texture, 0);
 			}
 
@@ -1620,6 +1629,7 @@ bool GSRendererHW::OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTex
 
 			if(GSTextureCache::Target* tmp_ds = m_tc->LookupTarget(TEX0, m_width, m_height, GSTextureCache::DepthStencil, true))
 			{
+				tmp_ds->m_texture->Commit(); // Don't bother to save few MB for a single game
 				m_dev->ClearDepth(tmp_ds->m_texture);
 			}
 
@@ -1639,6 +1649,7 @@ bool GSRendererHW::OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTex
 	{
 		if(FPSM == PSM_PSMCT24 && FBP == 0x2bc0)
 		{
+			ds->Commit(); // Don't bother to save few MB for a single game
 			m_dev->ClearDepth(ds);
 
 			return false;
@@ -1648,6 +1659,7 @@ bool GSRendererHW::OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTex
 	{
 		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_max.p.z == 0))
 		{
+			ds->Commit(); // Don't bother to save few MB for a single game
 			m_dev->ClearDepth(ds);
 		}
 	}
@@ -1732,6 +1744,7 @@ bool GSRendererHW::OI_SuperManReturns(GSTexture* rt, GSTexture* ds, GSTextureCac
 	ASSERT((v->RGBAQ.A << 24 | v->RGBAQ.B << 16 | v->RGBAQ.G << 8 | v->RGBAQ.R) == (int)v->XYZ.Z);
 
 	// Do a direct write
+	rt->Commit(); // Don't bother to save few MB for a single game
 	m_dev->ClearRenderTarget(rt, GSVector4(m_vt.m_min.c));
 
 	m_tc->InvalidateVideoMemType(GSTextureCache::DepthStencil, ctx->FRAME.Block());
@@ -1766,6 +1779,7 @@ bool GSRendererHW::OI_ArTonelico2(GSTexture* rt, GSTexture* ds, GSTextureCache::
 
 	if (m_vertex.next == 2 && !PRIM->TME && m_context->FRAME.FBW == 10 && v->XYZ.Z == 0 && m_context->TEST.ZTST == ZTST_ALWAYS) {
 		GL_INS("OI_ArTonelico2");
+		ds->Commit(); // Don't bother to save few MB for a single game
 		m_dev->ClearDepth(ds);
 	}
 

--- a/plugins/GSdx/Renderers/HW/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/HW/GSTextureCache.cpp
@@ -1452,13 +1452,13 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int
 
 	if(type == RenderTarget)
 	{
-		t->m_texture = m_renderer->m_dev->CreateRenderTarget(w, h);
+		t->m_texture = m_renderer->m_dev->CreateSparseRenderTarget(w, h);
 
 		t->m_used = true; // FIXME
 	}
 	else if(type == DepthStencil)
 	{
-		t->m_texture = m_renderer->m_dev->CreateDepthStencil(w, h);
+		t->m_texture = m_renderer->m_dev->CreateSparseDepthStencil(w, h);
 	}
 
 	m_dst[type].push_front(t);

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -257,7 +257,7 @@ GSTexture* GSDeviceOGL::CreateSurface(int type, int w, int h, int fmt)
 GSTexture* GSDeviceOGL::FetchSurface(int type, int w, int h, int format)
 {
 	if (format == 0)
-		format = (type == GSTexture::DepthStencil) ? GL_DEPTH32F_STENCIL8 : GL_RGBA8;
+		format = (type == GSTexture::DepthStencil || type == GSTexture::SparseDepthStencil) ? GL_DEPTH32F_STENCIL8 : GL_RGBA8;
 
 	GSTexture* t = GSDevice::FetchSurface(type, w, h, format);
 

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1351,6 +1351,7 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	// ************************************
 	// Draw
 	// ************************************
+	dTex->CommitRegion(GSVector2i(dRect.z + 1, dRect.w + 1));
 	DrawPrimitive();
 
 	// ************************************

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1220,6 +1220,8 @@ void GSDeviceOGL::CopyRectConv(GSTexture* sTex, GSTexture* dTex, const GSVector4
 
 	GL_PUSH(format("CopyRectConv from %d to %d", sid, did).c_str());
 
+	dTex->CommitRegion(GSVector2i(r.z, r.w));
+
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo_read);
 
 	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sid, 0);
@@ -1246,6 +1248,8 @@ void GSDeviceOGL::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r
 #ifdef ENABLE_OGL_DEBUG
 	PSSetShaderResource(6, sTex);
 #endif
+
+	dTex->CommitRegion(GSVector2i(r.z, r.w));
 
 	ASSERT(GLExtension::Has("GL_ARB_copy_image") && glCopyImageSubData);
 	glCopyImageSubData( sid, GL_TEXTURE_2D,

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -239,6 +239,10 @@ GSTexture* GSDeviceOGL::CreateSurface(int type, int w, int h, int fmt)
 	// FIXME: it will be more logical to do it in FetchSurface. This code is only called at first creation
 	//  of the texture. However we could reuse a deleted texture.
 	if (m_force_texture_clear == 0) {
+		// Clear won't be done if the texture isn't committed. Commit the full texture to ensure
+		// correct behavior of force clear option (debug option)
+		t->Commit();
+
 		switch(type)
 		{
 			case GSTexture::RenderTarget:
@@ -263,6 +267,10 @@ GSTexture* GSDeviceOGL::FetchSurface(int type, int w, int h, int format)
 
 
 	if (m_force_texture_clear) {
+		// Clear won't be done if the texture isn't committed. Commit the full texture to ensure
+		// correct behavior of force clear option (debug option)
+		t->Commit();
+
 		GSVector4 red(1.0f, 0.0f, 0.0f, 1.0f);
 		switch(type)
 		{

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1351,7 +1351,7 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	// ************************************
 	// Draw
 	// ************************************
-	dTex->CommitRegion(GSVector2i(dRect.z + 1, dRect.w + 1));
+	dTex->CommitRegion(GSVector2i((int)dRect.z + 1, (int)dRect.w + 1));
 	DrawPrimitive();
 
 	// ************************************

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -563,6 +563,8 @@ public:
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL) final;
 	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector());
 
+	virtual bool HasColorSparse() { return GLLoader::found_compatible_GL_ARB_sparse_texture2; }
+	virtual bool HasDepthSparse() { return GLLoader::found_compatible_sparse_depth; }
 
 	void CreateTextureFX();
 	GLuint CompileVS(VSSelector sel);

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -1290,6 +1290,14 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 	dev->SetupPipeline(m_vs_sel, m_gs_sel, m_ps_sel);
 
+	GSVector4i commitRect = ComputeBoundingBox(rtscale, rtsize);
+
+	if (rt)
+		rt->CommitRegion(GSVector2i(commitRect.z, commitRect.w));
+
+	if (ds)
+		ds->CommitRegion(GSVector2i(commitRect.z, commitRect.w));
+
 	if (DATE_GL42) {
 		GL_PUSH("Date GL42");
 		// It could be good idea to use stencil in the same time.

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -515,6 +515,24 @@ void GSTextureOGL::GenerateMipmap()
 	}
 }
 
+void GSTextureOGL::CommitPages(const GSVector2i& region, bool commit)
+{
+	GLState::available_vram += m_mem_usage;
+
+	if (commit) {
+		GL_INS("CommitPages %dx%d of %u", region.x, region.y, m_texture_id);
+		m_committed_size = region;
+	} else {
+		GL_INS("CommitPages release of %u", m_texture_id);
+		m_committed_size = GSVector2i(0, 0);
+	}
+
+	m_mem_usage = (m_committed_size.x * m_committed_size.y) << m_int_shift;
+	GLState::available_vram -= m_mem_usage;
+
+	glTexturePageCommitmentEXT(m_texture_id, GL_TEX_LEVEL_0, 0, 0, 0, m_committed_size.x, m_committed_size.y, 1, commit);
+}
+
 bool GSTextureOGL::Save(const std::string& fn)
 {
 	// Collect the texture data

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.h
@@ -84,5 +84,7 @@ class GSTextureOGL final : public GSTexture
 		void Clear(const void* data);
 		void Clear(const void* data, const GSVector4i& area);
 
+		void CommitPages(const GSVector2i& region, bool commit) final;
+
 		uint32 GetMemUsage();
 };

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.h
@@ -74,7 +74,7 @@ class GSTextureOGL final : public GSTexture
 		bool Save(const std::string& fn) final;
 
 		bool IsBackbuffer() { return (m_type == GSTexture::Backbuffer); }
-		bool IsDss() { return (m_type == GSTexture::DepthStencil); }
+		bool IsDss() { return (m_type == GSTexture::DepthStencil || m_type == GSTexture::SparseDepthStencil); }
 
 		uint32 GetID() final { return m_texture_id; }
 		bool HasBeenCleaned() { return m_clean; }

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -117,6 +117,7 @@ typedef int64 sint64;
 #include <condition_variable>
 #include <functional>
 #include <memory>
+#include <bitset>
 
 #include <zlib.h>
 


### PR DESCRIPTION
Please find some code to create/manage sparse render target&depth buffer.

GL backend is mostly done. Likely need to fix function that rely on texture size.

Dx will gracefully fallback to standard mode.

Nothing is done on renderer neither the texture cache to really use those sparse texture.