### PR TITLE
Add percentage to satisfy Gettext

### DIFF
--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -26,19 +26,19 @@ const wxChar* Panels::SpeedHacksPanel::GetEECycleRateSliderMsg( int val )
 		case -3:
 		{
 			m_msg_eeRate->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"50% cyclerate. Significant reduction of CPU requirements. Speedup for very lightweight games, slows down others. FMVs and audio may stutter or skip.");
+			return pxEt(L"50%% cyclerate. Significant reduction of CPU requirements. Speedup for very lightweight games, slows down others. FMVs and audio may stutter or skip.");
 		}
 		case -2:
 		{
 			const wxColour LightRed = wxColour(255, 80, 0);
 			m_msg_eeRate->SetForegroundColour(LightRed);
-			return pxEt(L"60% cyclerate. Moderate reduction of CPU requirements. Speedup for lightweight games, slows down others. FMVs and audio may stutter or skip.");
+			return pxEt(L"60%% cyclerate. Moderate reduction of CPU requirements. Speedup for lightweight games, slows down others. FMVs and audio may stutter or skip.");
 		}
 		case -1:
 		{
 			const wxColour Orange = wxColour(255, 120, 0);
 			m_msg_eeRate->SetForegroundColour(Orange);
-			return pxEt(L"75% cyclerate. Slight reduction of CPU requirements. Speedup for less demanding games, slows down others.");
+			return pxEt(L"75%% cyclerate. Slight reduction of CPU requirements. Speedup for less demanding games, slows down others.");
 		}
 		case 0:
 		{
@@ -50,18 +50,18 @@ const wxChar* Panels::SpeedHacksPanel::GetEECycleRateSliderMsg( int val )
 		{
 			const wxColour Orange = wxColour(255, 120, 0);
 			m_msg_eeRate->SetForegroundColour(Orange);
-			return pxEt(L"130% cyclerate. Moderate increase of CPU requirements. Variable framerate games may have higher internal framerates.");
+			return pxEt(L"130%% cyclerate. Moderate increase of CPU requirements. Variable framerate games may have higher internal framerates.");
 		}
 		case 2:
 		{
 			const wxColour LightRed = wxColour(255, 80, 0);
 			m_msg_eeRate->SetForegroundColour(LightRed);
-			return pxEt(L"180% cyclerate. Significant increase of CPU requirements. Variable framerate games will have higher internal framerates. FMVs may be slow. May cause stability problems.");
+			return pxEt(L"180%% cyclerate. Significant increase of CPU requirements. Variable framerate games will have higher internal framerates. FMVs may be slow. May cause stability problems.");
 		}
 		case 3:
 		{
 			m_msg_eeRate->SetForegroundColour(wxColour(L"Red"));
-			return pxEt(L"300% cyclerate. Extreme increase of CPU requirements. Variable framerate games will have higher internal framerates. FMVs may be slow. May cause stability problems.");
+			return pxEt(L"300%% cyclerate. Extreme increase of CPU requirements. Variable framerate games will have higher internal framerates. FMVs may be slow. May cause stability problems.");
 		}
 		default:
 			break;


### PR DESCRIPTION
With only one percentage sign in the c-format string, Gettext will treat "% c" as a placeholder, which is not the case of these strings. The translation of "% c" would be considered an error by Gettext, unless another percentage sign is added.

An example of error displayed by Gettext due to the missing second percentage sign is:
```
$ LC_ALL=C sudo msgfmt -co /usr/share/locale/pt_BR/LC_MESSAGES/pcsx2_Iconized.mo locales/pt_BR/pcsx2_Iconized.po 
locales/pt_BR/pcsx2_Iconized.po:601: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
locales/pt_BR/pcsx2_Iconized.po:611: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
locales/pt_BR/pcsx2_Iconized.po:620: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
locales/pt_BR/pcsx2_Iconized.po:636: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
locales/pt_BR/pcsx2_Iconized.po:646: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
locales/pt_BR/pcsx2_Iconized.po:657: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
msgfmt: found 6 fatal errors
```