### PR TITLE
dev9ghzdrk: pthread_create returns status, not thread handle

### DIFF
--- a/plugins/dev9ghzdrk/Linux/net.cpp
+++ b/plugins/dev9ghzdrk/Linux/net.cpp
@@ -55,7 +55,7 @@ void InitNet(NetAdapter* ad)
        int max_prio_for_policy = 0;
 
 
-       rx_thread = pthread_create(&rx_thread, NULL, NetRxThread, NULL);
+       int ret = pthread_create(&rx_thread, NULL, NetRxThread, NULL);
        pthread_attr_init(&thAttr);
        pthread_attr_getschedpolicy(&thAttr, &policy);
        max_prio_for_policy = sched_get_priority_max(policy);


### PR DESCRIPTION
I'm a bit suprised this code ever worked before (did it?). I got crashes on startup and decided to look into it.

It turns out the `rx_thread` handle was being overwritten by the returned status.

I did not add code to handle any errors (and I wouldn't know how). The original code also didn't handle this, so I assume this will be fine.

---

I'm having some issues with the networking dialog in the bios; so I'm still unable to test if network traffic actually works. There are also some other issues that need to be addressed, like non-descriptive errors if opening the adapter with pcap fails; however, I'll probably leave that to someone else.

*CC @lowlyocean who wrote the original code (in #2586)*