### PR TITLE
GSdx-ogl: Check if primitives are triangles instead of overlapping

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -660,7 +660,6 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 	EmulateTextureShuffleAndFbmask();
 
 	// DATE: selection of the algorithm.
-
 	if (DATE)
 	{
 		if (m_texture_shuffle)


### PR DESCRIPTION
Single triangle draw can now hit the tex_is_fb path.
Primitive Overlap will return no overlap  for single primitive (triangle).
Ratchet and Clank, Jak, tri-Ace games.

It should improve shadow rendering.

Idea by Gregory.

Issue #2889