### PR TITLE
Improve readability of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PCSX2 is a free and open-source PlayStation 2 (PS2) emulator. Its purpose is to 
 
 # Project Details
 
-The PCSX2 project has been running for more than ten years. Once only able to run a few public domain demos, newer versions enable many games to work at full speed, including popular titles such as Final Fantasy X and Devil May Cry 3. Visit the [PCSX2 homepage](https://pcsx2.net) to check the latest compatibility status of games (with more than 2000 titles tested), or ask for help in the [official forums](https://forums.pcsx2.net/).
+The PCSX2 project has been running for more than ten years. Past versions could only run a few public domain game demos, but newer versions can run many games at full speed, including popular titles such as Final Fantasy X and Devil May Cry 3. Visit the [PCSX2 homepage](https://pcsx2.net) to check the latest compatibility status of games (with more than 2000 titles tested), or ask for help in the [official forums](https://forums.pcsx2.net/).
 
 The latest officially released stable version is version 1.4.0.
 
@@ -37,7 +37,7 @@ Development builds are also available from [our website](https://pcsx2.net/downl
 
 - Because of copyright issues, and the complexity of trying to work around it, you need a BIOS dump extracted from a legitimately-owned PS2 console to use the emulator. For more information about the BIOS and how to get it from your console, visit [this page](https://pcsx2.net/config-guide/official-english-pcsx2-configuration-guide.html#Bios).
 
-- PCSX2 mainly takes advantage of 2 CPU cores. As of [this commit](https://github.com/PCSX2/pcsx2/commit/ac9bf45) PCSX2 can now take advantage of more than 2 cores using the MTVU speedhack. This can be a significant speedup on CPUs with 3+ cores, however on GS-limited games (or on CPUs with fewer than 2 cores) it may be a slowdown.
+- PCSX2 mainly takes advantage of 2 CPU cores. As of [this commit](https://github.com/PCSX2/pcsx2/commit/ac9bf45) PCSX2 can now take advantage of more than 2 cores using the MTVU speedhack. This can be a significant speedup on CPUs with 3+ cores, but it may be a slowdown on GS-limited games (or on CPUs with fewer than 2 cores).
 
 # Screenshots
 


### PR DESCRIPTION
- Improve awkward expression. "Once only able to run a few public domain demos, newer versions enable many games to work at full speed..." -> "Past versions could only run a few public domain game demos, but newer versions can run many games at full speed..." 
- Balance sentence for better readability. "This can be a significant speedup on CPUs with 3+ cores, however on GS-limited games (or on CPUs with fewer than 2 cores) it may be a slowdown." -> "This can be a significant speedup on CPUs with 3+ cores, but it may be a slowdown on GS-limited games (or on CPUs with fewer than 2 cores)."