### PR TITLE
GameDB: Fix PlayStation Underground 4.4 entries

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -4506,12 +4506,8 @@ Serial = SCUS-97118
 Name   = NFL GameDay 2001 [Demo]
 Region = NTSC-U
 ---------------------------------------------
-Serial = SCUS-97120
-Name   = PlayStation Underground Demo Disc 4.4 [Disc1&2]
-Region = NTSC-U
----------------------------------------------
 Serial = SCUS-97121
-Name   = PlayStation Underground 4.3 [Disc2]
+Name   = PlayStation Underground 4.4 [Disc2]
 Region = NTSC-U
 ---------------------------------------------
 Serial = SCUS-97122


### PR DESCRIPTION
PlayStation Underground 4.4 is a set of 2 discs:
* SCUS-97120: PS1 CD (disc 1)
* SCUS-97121: PS2 DVD (disc 2)

Specific changes:
* Remove disc 1 since it's out of scope
* Change 4.3 to 4.4 in disc 2's name (4.3 doesn't include any PS2 discs)