### PR TITLE
GSdx: Log private GS registers when doing raw dump

### DIFF
--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1392,7 +1392,7 @@ struct GSPrivRegSet
 
 	void Dump(const std::string& filename)
 	{
-		FILE* fp = fopen(filename.c_str(), "wt");
+		FILE* fp = fopen(filename.c_str(), "at");
 		if (fp) {
 			Dump(fp);
 			fclose(fp);

--- a/plugins/GSdx/GSDrawingEnvironment.h
+++ b/plugins/GSdx/GSDrawingEnvironment.h
@@ -87,7 +87,7 @@ public:
 
 	void Dump(const std::string& filename)
 	{
-		FILE* fp = fopen(filename.c_str(), "wt");
+		FILE* fp = fopen(filename.c_str(), "at");
 		if (!fp) return;
 
 		fprintf(fp, "PRIM\n"

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -937,6 +937,7 @@ void GSRendererHW::Draw()
 
 			m_env.Dump(m_dump_root+s);
 			m_context->Dump(m_dump_root+s);
+            m_regs->Dump(m_dump_root+s);
 		}
 
 		if(s_savet && s_n >= s_saven && tex)

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -497,6 +497,7 @@ void GSRendererSW::Draw()
 
 			m_env.Dump(m_dump_root+s);
 			m_context->Dump(m_dump_root+s);
+            m_regs->Dump(m_dump_root+s);
 		}
 
 		if(s_savet && s_n >= s_saven && PRIM->TME)


### PR DESCRIPTION
This adds private GS registers to the context logs during dumps.