### PR TITLE
[GameDB] Fixes, serial and patches update.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -2292,6 +2292,19 @@ Serial = SCES-53669
 Name   = Buzz! The Music Quiz
 Region = PAL-E
 ---------------------------------------------
+Serial = SCES-53680
+Name   = WRC avec Sebastien Loeb
+Region = PAL-M5
+[patches = 79BAD675]
+	comment=patch by Prafull
+	// Fixes branch in delay slot hanging.
+	patch=1,EE,003d2024,word,00000000
+	patch=1,EE,003d2200,word,00000000
+	patch=1,EE,003d2394,word,00000000
+	patch=1,EE,003d26b0,word,00000000
+	patch=1,EE,003d1774,word,00000000
+[/patches]
+---------------------------------------------
 Serial = SCES-53688
 Name   = Urban Reign
 Region = PAL-M5
@@ -6669,6 +6682,7 @@ Compat = 5
 Serial = SLES-50051
 Name   = Eternal Ring
 Region = PAL-E
+eeRoundMode = 0 // Fixes FPU errors causing instant death in Limestone Cave.
 ---------------------------------------------
 Serial = SLES-50052
 Name   = Pool Master
@@ -6885,7 +6899,7 @@ Serial = SLES-50155
 Name   = Operation Winback
 Region = PAL-M3
 Compat = 5
-vuClampMode = 3 // For full textures showing.
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
 ---------------------------------------------
 Serial = SLES-50158
 Name   = Gungriffon Blaze
@@ -15446,6 +15460,7 @@ Region = PAL-M5
 Serial = SLES-54080
 Name   = World Super Police
 Region = PAL-E
+EETimingHack = 1 // Fixes game hanging at mission 1.
 ---------------------------------------------
 Serial = SLES-54081
 Name   = FIFA World Cup 2006
@@ -15607,6 +15622,7 @@ Serial = SLES-54151
 Name   = Let's Make a Soccer Team!
 Region = PAL-M5
 Compat = 5
+eeClampMode = 3 // Makes the game to correctly register left and right Dpad button input.
 ---------------------------------------------
 Serial = SLES-54152
 Name   = Ant Bully, The
@@ -18459,6 +18475,7 @@ Serial = SLKA-25214
 Name   = Final Fantasy X - International [PlayStation 2 - Big Hit Series]
 Region = NTSC-K
 IPUWaitHack = 1
+eeRoundMode = 1 // Fixes reverse control and boss in some places.
 ---------------------------------------------
 Serial = SLKA-25215
 Name   = Shining Wild
@@ -19147,6 +19164,7 @@ Region = NTSC-J
 Serial = SLPM-62023
 Name   = Winback
 Region = NTSC-J
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
 ---------------------------------------------
 Serial = SLPM-62027
 Name   = Snowboard Heaven
@@ -19583,6 +19601,7 @@ Region = NTSC-J
 Serial = SLPM-62201
 Name   = Winback
 Region = NTSC-J
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
 ---------------------------------------------
 Serial = SLPM-62202
 Name   = Winning Post 4 Maximum 2001
@@ -19903,6 +19922,7 @@ Region = NTSC-J
 Serial = SLPM-62299
 Name   = Winback [Koei The Best]
 Region = NTSC-J
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
 ---------------------------------------------
 Serial = SLPM-62300
 Name   = Horse Breaker [Koei The Best]
@@ -20794,6 +20814,7 @@ Region = NTSC-J
 Serial = SLPM-62567
 Name   = Winback [Koei Best Series]
 Region = NTSC-J
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
 ---------------------------------------------
 Serial = SLPM-62568
 Name   = Shin Sangoku Musou [Koei The Best]
@@ -21535,6 +21556,11 @@ Serial = SLPM-62784
 Name   = Kao no nai Tsuki Select Story
 Region = NTSC-J
 ---------------------------------------------
+Serial = SLPM-64502
+Name   = Winback
+Region = NTSC-J
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
+---------------------------------------------
 Serial = SLPM-64504
 Name   = Maximo
 Region = NTSC-K
@@ -21945,6 +21971,7 @@ Serial = SLPM-65115
 Name   = Final Fantasy X International
 Region = NTSC-J
 IPUWaitHack = 1
+eeRoundMode = 1 // Fixes reverse control and boss in some places.
 ---------------------------------------------
 Serial = SLPM-65116
 Name   = Lilie no Atelier Plus: Salburg no Renkinjutsushi 3
@@ -24220,6 +24247,7 @@ Region = NTSC-J
 Serial = SLPM-65761
 Name   = World Super Police
 Region = NTSC-J
+EETimingHack = 1 // Fixes game hanging at mission 1.
 ---------------------------------------------
 Serial = SLPM-65762
 Name   = Katakamuna
@@ -26272,6 +26300,7 @@ Region = NTSC-J
 Serial = SLPM-66316
 Name   = Pro Soccer Club o Tsukurou! Europe Championship
 Region = NTSC-J
+eeClampMode = 3 // Makes the game to correctly register left and right Dpad button input.
 ---------------------------------------------
 Serial = SLPM-66317
 Name   = Capcom Classics Collection Vol.1
@@ -27597,6 +27626,7 @@ Serial = SLPM-66677
 Name   = Final Fantasy X - International [Ultimate Hits]
 Region = NTSC-J
 IPUWaitHack = 1
+eeRoundMode = 1 // Fixes reverse control and boss in some places.
 ---------------------------------------------
 Serial = SLPM-66678
 Name   = Final Fantasy X-2 - International + Last Mission [Ultimate Hits]
@@ -28850,6 +28880,7 @@ Serial = SLPM-67513
 Name   = Final Fantasy X International
 Region = NTSC-K
 IPUWaitHack = 1
+eeRoundMode = 1 // Fixes reverse control and boss in some places.
 ---------------------------------------------
 Serial = SLPM-67514
 Name   = Kessen
@@ -30588,6 +30619,7 @@ Serial = SLPS-25001
 Name   = Eternal Ring
 Region = NTSC-J
 Compat = 5
+eeRoundMode = 0 // Fixes FPU errors causing instant death in Limestone Cave.
 ---------------------------------------------
 Serial = SLPS-25002
 Name   = Dead or Alive 2
@@ -30911,6 +30943,7 @@ Name   = Final Fantasy X International
 Region = NTSC-J
 Compat = 5
 IPUWaitHack = 1
+eeRoundMode = 1 // Fixes reverse control and boss in some places.
 ---------------------------------------------
 Serial = SLPS-25094
 Name   = Reveal Fantasia
@@ -34434,6 +34467,7 @@ Serial = SLUS-20015
 Name   = Eternal Ring
 Region = NTSC-U
 Compat = 5
+eeRoundMode = 0 // Fixes FPU errors causing instant death in Limestone Cave.
 ---------------------------------------------
 Serial = SLUS-20016
 Name   = Evergrace
@@ -34966,6 +35000,7 @@ Serial = SLUS-20160
 Name   = Winback - Covert Operations
 Region = NTSC-U
 Compat = 5
+vuClampMode = 3 // Fixes missing 3D polygons when going ingame.
 ---------------------------------------------
 Serial = SLUS-20162
 Name   = Aqua Aqua


### PR DESCRIPTION
This PR add:
- A Emotion Engine timing fix for World super police (Tested by @prafullpcsx2 and Discord member)
- The rounding fix for the international version of Final Fantasy X (Tested by @Mensa41 Close https://github.com/PCSX2/pcsx2/issues/2891)
- A Emotion Engine Clamping fix for let's make a soccer team (Tested by @atomic83GitHub)
- A Emotion Engine rounding fix for Eternal Ring (Tested by @atomic83GitHub)
- Add the WRC avec Sebastien Loeb patch. (Made by @prafullpcsx2, tested by @atomic83GitHub)

There are also several additons about Winback fixes for various regions.