### PR TITLE
gsdx ogl: bypass the texture cache when the frame buffer will be sampled

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -1690,11 +1690,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::DeathByDegreesTekkenNinaWilliams] = GSC_DeathByDegreesTekkenNinaWilliams; // + Upscaling issues
 		lut[CRC::SonicUnleashed] = GSC_SonicUnleashed; // + Half screen on texture shuffle
 
-		// These games emulate a stencil buffer with the alpha channel of the RT (too slow to move to Aggressive)
-		lut[CRC::RadiataStories] = GSC_RadiataStories;
-		lut[CRC::StarOcean3] = GSC_StarOcean3;
-		lut[CRC::ValkyrieProfile2] = GSC_ValkyrieProfile2;
-
 		// Upscaling hacks
 		lut[CRC::Bully] = GSC_Bully;
 		lut[CRC::EvangelionJo] = GSC_EvangelionJo;
@@ -1723,13 +1718,20 @@ void GSState::SetupCrcHack()
 		lut[CRC::HauntingGround] = GSC_HauntingGround; // + Texture cache issue + Date
 		lut[CRC::XenosagaE3] = GSC_XenosagaE3;
 
-		// Those games might requires accurate fbmask
+		// These games might requires accurate fbmask
 		lut[CRC::Sly2] = GSC_SlyGames; // + Upscaling issue
 		lut[CRC::Sly3] = GSC_SlyGames; // + Upscaling issue
 
-		// Those games require accurate_colclip (perf)
+		// These games require accurate_colclip (perf)
 		lut[CRC::CastlevaniaCoD] = GSC_CastlevaniaGames;
 		lut[CRC::CastlevaniaLoI] = GSC_CastlevaniaGames;
+
+		// These games emulate a stencil buffer with the alpha channel of the RT (too slow to move to Aggressive)
+		// Needs at least Basic Blending,
+		// see https://github.com/PCSX2/pcsx2/pull/2921
+		lut[CRC::RadiataStories] = GSC_RadiataStories;
+		lut[CRC::StarOcean3] = GSC_StarOcean3;
+		lut[CRC::ValkyrieProfile2] = GSC_ValkyrieProfile2;
 	}
 
 	if (Aggressive) {

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -180,4 +180,7 @@ public:
 	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r);
 	void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false);
 	void Draw();
+
+	// Called by the texture cache to know if current texture is useful
+	virtual bool IsDummyTexture() const { return false;}
 };

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
@@ -90,4 +90,6 @@ class GSRendererOGL final : public GSRendererHW
 		PRIM_OVERLAP PrimitiveOverlap();
 
 		void SendDraw();
+
+		bool IsDummyTexture() const final;
 };


### PR DESCRIPTION
Proof of concept. It should provide a huge speedup when accurate
blending is enabled for tri-ace / Jak / R&C series (shadow rendering)

See #2894
Need PR #2892