### PR TITLE
GameDB: WRC avec sebastien loeb performance fixes

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -2281,6 +2281,12 @@ Serial = SCES-53680
 Name   = WRC avec Sebastien Loeb
 Region = PAL-M5
 XgKickHack = 1 // SPS.
+[patches = 79BAD675]
+	author=By Prafull
+	// Nopping a branch in delay slot instruction causing very bad performances
+	// in the playground mode when using physics (such as moving barrels etc..).
+	patch=1,EE,003d2394,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SCES-53688
 Name   = Urban Reign


### PR DESCRIPTION
This PR add a modified patch to "WRC avec sebastien loeb", this fixes a very bad performance problem with a delay slot instruction which for an unknow reason (Timing?) tanks the performances when using physics in the playground mode.

With the delay slot instruction:

![Capture](https://user-images.githubusercontent.com/26351275/56080911-4b24dd80-5e07-11e9-9973-5b2b07893985.PNG)

Without the delay slot instruction:

![Capture2](https://user-images.githubusercontent.com/26351275/56080915-5ed04400-5e07-11e9-9301-459e66fa8cc0.PNG)