### PR TITLE
Automatically find the next free TCP port by setting requested port t…

### DIFF
--- a/tools/GSDumpGUI/Core/Program.cs
+++ b/tools/GSDumpGUI/Core/Program.cs
@@ -137,7 +137,7 @@ namespace GSDumpGUI
                 Server.OnClientMessageReceived += new BaseMessageServer.MessageReceivedHandler(Server_OnClientMessageReceived);
                 Server.OnClientAfterConnect += new TCPLibrary.Core.Server.ConnectedHandler(Server_OnClientAfterConnect);
                 Server.OnClientAfterDisconnected += new TCPLibrary.Core.Server.DisconnectedHandler(Server_OnClientAfterDisconnected);
-                Server.Port = 9999;
+                Server.Port = 0; // Automatically let the OS find the next free port
                 Server.Enabled = true;
 
                 Application.EnableVisualStyles();


### PR DESCRIPTION
…o 0.

Fixes multi-instance crashes as each instance now uses it's own TCP Port.