### PR TITLE
Onepad (legacy) sensibility implementation for linux

### DIFF
--- a/plugins/onepad_legacy/Linux/linux.cpp
+++ b/plugins/onepad_legacy/Linux/linux.cpp
@@ -131,11 +131,11 @@ void PollForJoystickInput(int cpad)
                 int value = gamePad->GetAxisFromKey(cpad, i);
                 bool sign = key_to_axis_sign(cpad, i);
                 bool full_axis = key_to_axis_type(cpad, i);
-
+                float k=conf->get_sensibility()/100.0; // convert sensibility to float
                 if (IsAnalogKey(i))
                 {
                     if (abs(value) > gamePad->GetDeadzone())
-                        key_status->press(cpad, i, value);
+                        key_status->press(cpad, i, value*k);
                     else
                         key_status->release(cpad, i);
                 }
@@ -152,9 +152,9 @@ void PollForJoystickInput(int cpad)
                     else
                     {
                         if (sign && (-value > gamePad->GetDeadzone()))
-                            key_status->press(cpad, i, std::min(-value / 128, 0xFF));
+                            key_status->press(cpad, i, std::min((-value*k) / 128, 0xFF));
                         else if (!sign && (value > gamePad->GetDeadzone()))
-                            key_status->press(cpad, i, std::min(value / 128, 0xFF));
+                            key_status->press(cpad, i, std::min((value*k) / 128, 0xFF));
                         else
                             key_status->release(cpad, i);
                     }

--- a/plugins/onepad_legacy/Linux/linux.cpp
+++ b/plugins/onepad_legacy/Linux/linux.cpp
@@ -135,7 +135,7 @@ void PollForJoystickInput(int cpad)
                 if (IsAnalogKey(i))
                 {
                     if (abs(value) > gamePad->GetDeadzone())
-                        key_status->press(cpad, i, value*k);
+                        key_status->press(cpad, i, (int)(value*k));
                     else
                         key_status->release(cpad, i);
                 }
@@ -152,9 +152,9 @@ void PollForJoystickInput(int cpad)
                     else
                     {
                         if (sign && (-value > gamePad->GetDeadzone()))
-                            key_status->press(cpad, i, std::min((-value*k) / 128, 0xFF));
+                            key_status->press(cpad, i, std::min((int)(-value*k) / 128, 0xFF));
                         else if (!sign && (value > gamePad->GetDeadzone()))
-                            key_status->press(cpad, i, std::min((value*k) / 128, 0xFF));
+                            key_status->press(cpad, i, std::min((int)(value*k) / 128, 0xFF));
                         else
                             key_status->release(cpad, i);
                     }

--- a/plugins/onepad_legacy/controller.h
+++ b/plugins/onepad_legacy/controller.h
@@ -85,7 +85,7 @@ public:
         memset(&keys, 0, sizeof(keys));
         log = packed_options = joyid_map = 0;
         ff_intensity = 0x7FFF; // set it at max value by default
-        sensibility = 500;
+        sensibility = 100;   // set it at 100%
         for (int pad = 0; pad < GAMEPAD_NUMBER; pad++)
         {
             keysym_map[pad].clear();

--- a/plugins/onepad_legacy/controller.h
+++ b/plugins/onepad_legacy/controller.h
@@ -127,16 +127,21 @@ public:
     }
 
     /**
-	 * Set sensibility value, sensibility is not yet implemented(and will probably be after evdev)
-	 * However, there will be an upper range too, less than 0 is an obvious wrong
-	 * Anyway, we are doing object oriented code, members are definitely not supposed to be public
+	 * Set sensibility value.
+	 * There will be an upper range, and less than 0 is obviously wrong.
+	 * We are doing object oriented code, so members are definitely not supposed to be public.
 	 **/
     void set_sensibility(u32 new_sensibility)
     {
-        if (sensibility > 0)
+        if (new_sensibility > 0)
         {
             sensibility = new_sensibility;
         }
+        else
+        {
+            sensibility = 1;
+        }
+        
     }
 
     u32 get_sensibility()

--- a/plugins/onepad_legacy/wx_dialog/GamepadConfiguration.cpp
+++ b/plugins/onepad_legacy/wx_dialog/GamepadConfiguration.cpp
@@ -26,7 +26,7 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow *parent)
           wxID_ANY,                    // ID
           _T("Gamepad configuration"), // Title
           wxDefaultPosition,           // Position
-          wxSize(400, 230),            // Width + Length
+          wxSize(400, 270),            // Width + Length
           // Style
           wxSYSTEM_MENU |
               wxCAPTION |
@@ -38,8 +38,8 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow *parent)
     m_pan_gamepad_config = new wxPanel(
         this,              // Parent
         wxID_ANY,          // ID
-        wxDefaultPosition, // Prosition
-        wxSize(300, 200)   // Size
+        wxDefaultPosition, // Position
+        wxSize(300, 230)   // Size
     );
     m_cb_rumble = new wxCheckBox(
         m_pan_gamepad_config, // Parent
@@ -78,7 +78,8 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow *parent)
         0,                    // min value 0x0000
         0x7FFF,               // max value 0x7FFF
         wxPoint(150, 83),     // Position
-        wxSize(200, 30)       // Size
+        wxSize(200, 50),       // Size
+        wxSL_HORIZONTAL | wxSL_LABELS | wxSL_BOTTOM
     );
 
     wxString txt_joystick = wxT("Joystick sensibility");
@@ -86,7 +87,7 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow *parent)
         m_pan_gamepad_config, // Parent
         wxID_ANY,             // ID
         txt_joystick,         // Text which must be displayed
-        wxPoint(20, 120),     // Position
+        wxPoint(20, 150),     // Position
         wxDefaultSize         // Size
     );
 
@@ -96,23 +97,24 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow *parent)
         0,                    // value
         0,                    // min value
         200,                  // max value
-        wxPoint(150, 113),    // Position
-        wxSize(200, 30)       // Size
-    );
-
-    m_bt_ok = new wxButton(
-        m_pan_gamepad_config, // Parent
-        wxID_ANY,             // ID
-        _T("&OK"),            // Label
-        wxPoint(250, 160),    // Position
-        wxSize(60, 25)        // Size
+        wxPoint(150, 143),    // Position
+        wxSize(200, 50),       // Size
+        wxSL_HORIZONTAL | wxSL_LABELS | wxSL_BOTTOM
     );
 
     m_bt_cancel = new wxButton(
         m_pan_gamepad_config, // Parent
         wxID_ANY,             // ID
         _T("&Cancel"),        // Label
-        wxPoint(320, 160),    // Position
+        wxPoint(250, 210),    // Position
+        wxSize(60, 25)        // Size
+    );
+
+    m_bt_ok = new wxButton(
+        m_pan_gamepad_config, // Parent
+        wxID_ANY,             // ID
+        _T("&OK"),            // Label
+        wxPoint(320, 210),    // Position
         wxSize(60, 25)        // Size
     );
 

--- a/plugins/onepad_legacy/wx_dialog/GamepadConfiguration.cpp
+++ b/plugins/onepad_legacy/wx_dialog/GamepadConfiguration.cpp
@@ -95,7 +95,7 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow *parent)
         wxID_ANY,             // ID
         0,                    // value
         0,                    // min value
-        100,                  // max value
+        200,                  // max value
         wxPoint(150, 113),    // Position
         wxSize(200, 30)       // Size
     );


### PR DESCRIPTION
Sensibility slider now can be used to set sensibility of gamepad axis in linux version of OnePad plugin. Perhaps it is done in wrong way at wrong place.