### PR TITLE
debugger: Muti-byte hex strings can now be pasted into the memory view

### DIFF
--- a/bin/docs/debugger.txt
+++ b/bin/docs/debugger.txt
@@ -32,6 +32,7 @@ memory view:
     right click     open context menu
     ctrl+wheel      zoom memory view
     esc             return to previous goto address
+    ctrl+v          paste a hex string into memory
 
 breakpoint list:
 

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -489,6 +489,10 @@ void CtrlMemView::keydownEvent(wxKeyEvent& evt)
 				}
 			}
 			break;
+		case 'v':
+		case 'V':
+			pasteHex();
+			break;
 		default:
 			evt.Skip();
 			break;
@@ -728,4 +732,35 @@ void CtrlMemView::gotoPoint(int x, int y)
 void CtrlMemView::updateReference(u32 address) {
 	referencedAddress = address;
 	redraw();
+}
+
+void CtrlMemView::pasteHex()
+{
+	if (wxTheClipboard->Open())
+	{
+		if (wxTheClipboard->IsSupported(wxDF_TEXT))
+		{
+			wxTextDataObject data;
+			wxTheClipboard->GetData(data);
+			wxString str = data.GetText();
+			str.Replace(" ", "");
+			str.Replace("\n", "");
+			str.Replace("\r", "");
+			str.Replace("\t", "");
+			std::size_t i;
+			for (i = 0; i < str.size() / 2; i++)
+			{
+				long byte;
+				if (str.Mid(i * 2, 2).ToLong(&byte, 16))
+				{
+					cpu->write8(curAddress + i, static_cast<u8>(byte));
+				}
+				else {
+					break;
+				}
+			}
+			scrollCursor(i);
+		}
+		wxTheClipboard->Close();
+	}
 }

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -747,6 +747,11 @@ void CtrlMemView::pasteHex()
 			str.Replace("\n", "");
 			str.Replace("\r", "");
 			str.Replace("\t", "");
+
+			bool active = !cpu->isCpuPaused();
+			if (active)
+				cpu->pauseCpu();
+
 			std::size_t i;
 			for (i = 0; i < str.size() / 2; i++)
 			{
@@ -760,6 +765,9 @@ void CtrlMemView::pasteHex()
 				}
 			}
 			scrollCursor(i);
+
+			if(active)
+				cpu->resumeCpu();
 		}
 		wxTheClipboard->Close();
 	}

--- a/pcsx2/gui/Debugger/CtrlMemView.h
+++ b/pcsx2/gui/Debugger/CtrlMemView.h
@@ -32,6 +32,7 @@ public:
 	void redraw();
 	void gotoAddress(u32 address, bool pushInHistory = false);
 	void updateReference(u32 address);
+	void pasteHex();
 
 	wxDECLARE_EVENT_TABLE();
 private:

--- a/pcsx2/gui/Debugger/CtrlMemView.h
+++ b/pcsx2/gui/Debugger/CtrlMemView.h
@@ -32,7 +32,6 @@ public:
 	void redraw();
 	void gotoAddress(u32 address, bool pushInHistory = false);
 	void updateReference(u32 address);
-	void pasteHex();
 
 	wxDECLARE_EVENT_TABLE();
 private:
@@ -47,6 +46,7 @@ private:
 	void scrollCursor(int bytes);
 	void onPopupClick(wxCommandEvent& evt);
 	void focusEvent(wxFocusEvent& evt) { Refresh(); };
+	void pasteHex();
 
 	DebugInterface* cpu;
 	int rowHeight;


### PR DESCRIPTION
You can now paste a hex string into the memory view (with Ctrl+V). Needs testing on Windows.

![Peek 2019-05-14 22-49](https://user-images.githubusercontent.com/43898262/57734873-e32e1500-769a-11e9-9c63-046c44bb523c.gif)
