### PR TITLE
changes required to compile and run using VS 2019

### DIFF
--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -18,6 +18,10 @@
 //#include "Common.h"
 #include "AppConfig.h"
 
+// _Target_ is defined by R300A.h and R5900.h and the definition leaks to here.
+// The problem, at least with Visual Studio 2019 on Windows,
+// is that unordered_map includes xhash which uses _Target_ as a template
+// parameter. Unless we undef it here, the build breaks with a cryptic error message.
 #undef _Target_
 #include <unordered_map>
 #include <wx/wfstream.h>

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -18,6 +18,7 @@
 //#include "Common.h"
 #include "AppConfig.h"
 
+#undef _Target_
 #include <unordered_map>
 #include <wx/wfstream.h>
 

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -281,7 +281,7 @@ void LoadBIOS()
 		BiosChecksum = 0;
 
 		wxString biosZone;
-		wxFFile fp( Bios );
+		wxFFile fp( Bios , "rb");
 		fp.Read( eeMem->ROM, std::min<s64>( Ps2MemSize::Rom, filesize ) );
 
 		ChecksumIt( BiosChecksum, eeMem->ROM );

--- a/plugins/dev9ghzdrk/Win32/tap.h
+++ b/plugins/dev9ghzdrk/Win32/tap.h
@@ -15,6 +15,7 @@
 
 #pragma once
 #include <vector>
+#include <string>
 #include "..\net.h"
 using namespace std;
 


### PR DESCRIPTION
in vs 2019, the system xhash used by unordered_map uses _Target_ in its template definition. pcsx2 #defines this in the r5900 and r3000 headers which leak cause a cryptic compilation error. A quick fix here is just to undef it in gamebase.h. A better fix would be to encapsulate the definition or use something more c++ to avoid the pre-processor.

tap.h did not have string defined. I guess this was included transitively somewhere with an earlier set of system headers.

Finally in biostools, the file is opened in text mode which causes the bios to be partially read. I'm not sure that's vs2019 specific but it's wrong in any case. Maybe the default mode parameter changed at some point. Maybe wxFile would be a better choice here rather than WxFFile because wxFile always open s in binary mode.