### PR TITLE
GSdx-hw: Fix border issue on ComputeFixedTEX0.

### DIFF
--- a/plugins/GSdx/GSDrawingContext.cpp
+++ b/plugins/GSdx/GSDrawingContext.cpp
@@ -138,23 +138,39 @@ GIFRegTEX0 GSDrawingContext::GetSizeFixedTEX0(int s_n, const GSVector4& st, bool
 
 void GSDrawingContext::ComputeFixedTEX0(const GSVector4& st, bool linear)
 {
-	GIFRegTEX0 reg = GetSizeFixedTEX0(0, st, linear, false);
+	// It is quite complex to handle rescaling so this function is less stricter than GetSizeFixedTEX0,
+	// therefore we remove the reduce optimization and we don't handle bilinear filtering which might create wrong interpolation at the border.
 
-	if(reg.TW > TEX0.TW)
+	int tw = TEX0.TW;
+	int th = TEX0.TH;
+
+	int wms = (int)CLAMP.WMS;
+	int wmt = (int)CLAMP.WMT;
+
+	int minu = (int)CLAMP.MINU;
+	int minv = (int)CLAMP.MINV;
+	int maxu = (int)CLAMP.MAXU;
+	int maxv = (int)CLAMP.MAXV;
+
+	GSVector4i uv = GSVector4i(st.floor());
+
+	uv.x = findmax(uv.x, uv.z, (1 << TEX0.TW) - 1, wms, minu, maxu);
+	uv.y = findmax(uv.y, uv.w, (1 << TEX0.TH) - 1, wmt, minv, maxv);
+
+	if (wms == CLAMP_REGION_CLAMP || wms == CLAMP_REGION_REPEAT)
+		tw = extend(uv.x, tw);
+
+	if (wmt == CLAMP_REGION_CLAMP || wmt == CLAMP_REGION_REPEAT)
+		th = extend(uv.y, th);
+
+	if ((tw != (int)TEX0.TW) || (th != (int)TEX0.TH))
 	{
 		m_fixed_tex0 = true;
-		TEX0.TW = reg.TW;
-	}
-	if(reg.TH > TEX0.TH)
-	{
-		m_fixed_tex0 = true;
-		TEX0.TH = reg.TH;
-	}
+		TEX0.TW = tw;
+		TEX0.TH = th;
 
-	if(m_fixed_tex0)
-	{
 		GL_INS("FixedTEX0 TW %d=>%d, TH %d=>%d wm %d,%d",
-				(int)stack.TEX0.TW, (int)TEX0.TW, (int)stack.TEX0.TH, (int)TEX0.TH,
-				(int)CLAMP.WMS, (int)CLAMP.WMT);
+			(int)stack.TEX0.TW, (int)TEX0.TW, (int)stack.TEX0.TH, (int)TEX0.TH,
+			(int)CLAMP.WMS, (int)CLAMP.WMT);
 	}
 }

--- a/plugins/GSdx/GSDrawingContext.cpp
+++ b/plugins/GSdx/GSDrawingContext.cpp
@@ -136,7 +136,7 @@ GIFRegTEX0 GSDrawingContext::GetSizeFixedTEX0(int s_n, const GSVector4& st, bool
 	return res;
 }
 
-void GSDrawingContext::ComputeFixedTEX0(const GSVector4& st, bool linear)
+void GSDrawingContext::ComputeFixedTEX0(const GSVector4& st)
 {
 	// It is quite complex to handle rescaling so this function is less stricter than GetSizeFixedTEX0,
 	// therefore we remove the reduce optimization and we don't handle bilinear filtering which might create wrong interpolation at the border.

--- a/plugins/GSdx/GSDrawingContext.h
+++ b/plugins/GSdx/GSDrawingContext.h
@@ -147,7 +147,7 @@ public:
 	}
 
 	GIFRegTEX0 GetSizeFixedTEX0(int s_n, const GSVector4& st, bool linear, bool mipmap = false);
-	void ComputeFixedTEX0(const GSVector4& st, bool linear);
+	void ComputeFixedTEX0(const GSVector4& st);
 	bool HasFixedTEX0() const { return m_fixed_tex0;}
 
 	// Save & Restore before/after draw allow to correct/optimize current register for current draw

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -675,6 +675,9 @@ void GSRendererDX11::EmulateTextureSampler(const GSTextureCache::Source* tex)
 		// Use invalid size to denormalize ST coordinate
 		ps_cb.WH.x = (float)(1 << m_context->stack.TEX0.TW);
 		ps_cb.WH.y = (float)(1 << m_context->stack.TEX0.TH);
+
+		// We can't handle m_target with invalid_tex0 atm due to upscaling
+		ASSERT(!tex->m_target);
 	}
 
 	// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -822,7 +822,7 @@ void GSRendererHW::Draw()
 
 	// Fix TEX0 size
 	if(PRIM->TME && !IsMipMapActive())
-		m_context->ComputeFixedTEX0(m_vt.m_min.t.xyxy(m_vt.m_max.t), m_vt.IsLinear());
+		m_context->ComputeFixedTEX0(m_vt.m_min.t.xyxy(m_vt.m_max.t));
 
 	// skip alpha test if possible
 	// Note: do it first so we know if frame/depth writes are masked

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -785,6 +785,9 @@ void GSRendererOGL::EmulateTextureSampler(const GSTextureCache::Source* tex)
 		// Use invalid size to denormalize ST coordinate
 		ps_cb.WH.x = (float)(1 << m_context->stack.TEX0.TW);
 		ps_cb.WH.y = (float)(1 << m_context->stack.TEX0.TH);
+
+		// We can't handle m_target with invalid_tex0 atm due to upscaling
+		ASSERT(!tex->m_target);
 	}
 
 	// Only enable clamping in CLAMP mode. REGION_CLAMP will be done manually in the shader


### PR DESCRIPTION
It is quite complex to handle rescaling on ComputeFixedTEX0
so this function is less stricter than GetSizeFixedTEX0,
therefore we remove the reduce optimization,
and we don't handle bilinear filtering which might create wrong interpolation at the border.

Fixes FFX upscaling issues on Bilinear filter during cutscenes.

Fixes #2961