### PR TITLE
[skip ci] Handle dumpPath as optional.

### DIFF
--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -263,8 +263,11 @@ namespace GSDumpGUI
             }
             var port = Program.Server.Port;
 
+            // dll path is mandatory for the two operations GSReplay and GSconfigure but dumpPath only for GSReplay
             var dllPath = _availableGsDlls.Selected.File.FullName;
-            var dumpPath = _availableGsDumps.Selected.File.FullName;
+            var dumpPath = _availableGsDumps.Selected?.File?.FullName;
+            if (string.IsNullOrWhiteSpace(dumpPath) && "GSReplay".Equals(Function))
+                throw new ArgumentException("You need to specify a dump path in case you want to replay a GsDump.", nameof(dumpPath));
 
             _gsdxLogger.Information("Start new gsdx instance");
             _gsdxLogger.Information($"\tdll: {dllPath}");


### PR DESCRIPTION
GsDump file can be optional in case you just want to launch the plugin config dialog
Throw with a meaningful error message in case validation layer fails