### PR TITLE
GSdx: Don't modify the Y offset value when feedback write is enabled

### DIFF
--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -221,7 +221,10 @@ bool GSRenderer::Merge(int field)
 			off.x = tex[i]->GetScale().x * frame_diff.x;
 		}
 
-		if(display_diff.y >= 4) // Shouldn't this be >= 2?
+		// The Suffering series uses feedback write to render a post processing
+		// color effect into the frame. We don't want to modify the offset when this is happening because it causes
+		// the frame to "bob" up and down (between the correct and bad result).
+		if(display_diff.y >= 4 && !feedback_merge) // Shouldn't this be >= 2?
 		{
 			off.y = tex[i]->GetScale().y * display_diff.y;
 


### PR DESCRIPTION
Fixes the frame output height when viewing security cameras in The Suffering series.

The output height is now reported correctly as 640x448 instead of 640x494 in the title bar as well.

Master: (HW)
![ts_master](https://user-images.githubusercontent.com/16314399/59446897-5fb62f80-8dd0-11e9-8198-b6670728a371.gif)

PR: (HW - ignore flickering, it's another bug with output blending)
![ts_pr](https://user-images.githubusercontent.com/16314399/59446789-27aeec80-8dd0-11e9-887e-65a5af8ae84f.gif)

Master: (SW)
![pcsx2_2019_06_13_12_05_00_287](https://user-images.githubusercontent.com/16314399/59448607-82961300-8dd3-11e9-8444-a8a3a7ffb5e2.png)

PR: (SW)
![pcsx2_2019_06_13_12_06_04_100](https://user-images.githubusercontent.com/16314399/59448653-a0637800-8dd3-11e9-8080-0255f1a0b959.png)



