### PR TITLE
CMake: fix typo in BuildParameters.cmake

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -91,7 +91,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(USE_GCC TRUE)
     message(STATUS "Building with GNU GCC")
 else()
-    message(FATAL_ERROR "Unknow compiler: ${CMAKE_CXX_COMPILER_ID}")
+    message(FATAL_ERROR "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed a typo in BuildParameters.cmake file.