### PR TITLE
GSDumpGUI - GsDumpFinder: fix error when dir not found

### DIFF
--- a/tools/GSDumpGUI/Forms/Helper/GsDumpFinder.cs
+++ b/tools/GSDumpGUI/Forms/Helper/GsDumpFinder.cs
@@ -38,7 +38,17 @@ namespace GSDumpGUI.Forms.Helper
 
         public IEnumerable<GsDumpFile> GetValidGsdxDumps(DirectoryInfo directory)
         {
-            var dumps = directory.GetFiles("*.gs", SearchOption.TopDirectoryOnly);
+            var dumps = new FileInfo[0];
+
+            try
+            {
+                dumps = directory.GetFiles("*.gs", SearchOption.TopDirectoryOnly);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                _logger.Warning($"Failed to open folder '{directory}'.");
+                yield break;
+            }
 
             foreach (var dump in dumps)
             {


### PR DESCRIPTION
Log error in console instead of having the application crashing when the selected GSdx dumps directory is not found.

How to reproduce the error without this fix:

1. Select a GSdx dumps directory
2. Close GSDumpGUI
3. Delete selected directory
4. Open GSDumpGUI
5. Crash

