### PR TITLE
GSdx-d3d11: Enable Blend no barrier support on d3d11

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -217,6 +217,7 @@ public:
 				uint32 blend_d:2;
 				uint32 clr1:1;
 				uint32 hdr:1;
+				uint32 colclip:1;
 
 				// Others ways to fetch the texture
 				uint32 channel:3;
@@ -228,7 +229,7 @@ public:
 				uint32 point_sampler:1;
 				uint32 invalid_tex0:1; // Lupin the 3rd
 
-				uint32 _free:19;
+				uint32 _free:18;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -547,10 +547,24 @@ void GSRendererDX11::EmulateBlending()
 
 	if (m_env.COLCLAMP.CLAMP == 0)
 	{
-		// fprintf(stderr, "%d: COLCLIP HDR mode%s\n", s_n, accumulation_blend ? " with accumulation blend" : "");
 		if (accumulation_blend)
+		{
+			// fprintf(stderr, "%d: COLCLIP HDR mode with accumulation blend\n", s_n);
 			sw_blending = true;
-		m_ps_sel.hdr = 1;
+			m_ps_sel.hdr = 1;
+		}
+		else if (sw_blending)
+		{
+			// So far only BLEND_NO_BAR should hit this path, it's faster than standard HDR algo.
+			// Note: Isolate the code to BLEND_NO_BAR if other blending conditions are added.
+			// fprintf(stderr, "%d: COLCLIP SW ENABLED (blending is %d/%d/%d/%d)\n", s_n, ALPHA.A, ALPHA.B, ALPHA.C, ALPHA.D);
+			m_ps_sel.colclip = 1;
+		}
+		else
+		{
+			// fprintf(stderr, "%d: COLCLIP HDR mode\n", s_n);
+			m_ps_sel.hdr = 1;
+		}
 	}
 
 	/*fprintf(stderr, "%d: BLEND_INFO: %d/%d/%d/%d. Clamp:%d. Prim:%d number %d (sw %d)\n",

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -218,6 +218,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		sm.AddMacro("PS_PAL_FMT", sel.fmt >> 2);
 		sm.AddMacro("PS_INVALID_TEX0", sel.invalid_tex0);
 		sm.AddMacro("PS_HDR", sel.hdr);
+		sm.AddMacro("PS_COLCLIP", sel.colclip);
 		sm.AddMacro("PS_BLEND_A", sel.blend_a);
 		sm.AddMacro("PS_BLEND_B", sel.blend_b);
 		sm.AddMacro("PS_BLEND_C", sel.blend_c);

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -44,6 +44,7 @@
 #define PS_INVALID_TEX0 0
 #define PS_SCALE_FACTOR 1
 #define PS_HDR 0
+#define PS_COLCLIP 0
 #define PS_BLEND_A 0
 #define PS_BLEND_B 0
 #define PS_BLEND_C 0
@@ -897,12 +898,14 @@ void ps_blend(inout float4 Color, float As, float2 pos_xy)
 		Cv = (PS_BLEND_A == PS_BLEND_B) ? D : trunc(((A - B) * C) + D);
 
 		// Standard Clamp
-		if (PS_HDR == 0)
+		if (PS_COLCLIP == 0 && PS_HDR == 0)
 			Cv = clamp(Cv, (float3)0.0f, (float3)255.0f);
 
 		// In 16 bits format, only 5 bits of color are used. It impacts shadows computation of Castlevania
 		if (PS_DFMT == FMT_16)
 			Cv = (float3)((int3)Cv & (int3)0xF8);
+		else if (PS_COLCLIP == 1 && PS_HDR == 0)
+			Cv = (float3)((int3)Cv & (int3)0xFF);
 
 		Color.rgb = Cv / 255.0f;
 	}


### PR DESCRIPTION
gsdx-d3d11: Extend sw blending to BLEND_NO_BAR which is also free and doesn't require rt sample nor any barriers.
It helps light rendering in SW Battlefront 2, VP2 also triggers it but needs to be further tested what it does.


gsdx-d3d11: Extend BLEND_NO_BAR to also hit on clamp 0, it's faster than standard HDR algo.

GOW shows a nice fps improvement. Spyro too maybe.