### PR TITLE
GSdx: Add CRC hack for Sniper Elite

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -165,6 +165,7 @@ CRC::Game CRC::m_games[] =
 	{0x6BA2F6B9, ResidentEvil4, EU, 0},
 	{0x60FA8C69, ResidentEvil4, JP, 0},
 	{0x5F254B7C, ResidentEvil4, KO, 0},
+	{0x395779C5, SniperElite, US, 0},
 	{0x72E1E60E, Spartan, EU, 0},
 	{0x26689C87, Spartan, JP, 0},
 	{0x08277A9E, Spartan, US, 0},

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -126,6 +126,7 @@ public:
 		SMTDDS1,
 		SMTDDS2,
 		SMTNocturne,
+		SniperElite,
 		SonicUnleashed,
 		SoTC,
 		SoulReaver2,

--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -38,6 +38,28 @@ CRC::Region g_crc_region = CRC::NoRegion;
 // (note: could potentially work with latest OpenGL)
 ////////////////////////////////////////////////////////////////////////////////
 
+bool GSC_SniperElite(const GSFrameInfo& fi, int& skip)
+{
+	// Broken CS effect causing ghosting even on native res.
+	// Former TS half screen trouble child but fixed in #2934
+	// Pattern is:
+	// TS RG => BA
+	// CS
+
+	if (skip == 0)
+	{
+		if (fi.TME && fi.TBP0 == 0x2d80 && fi.FBP == 0x2a00 && fi.FPSM == PSM_PSMCT32)
+			skip = 1000;
+	}
+	else
+	{
+		if (fi.TME && fi.TBP0 == 0x3000 && (fi.FBP == 0xe00 || fi.FBP == 0x0000))
+			skip = 0;
+	}
+
+	return true;
+}
+
 bool GSC_BigMuthaTruckers(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1478,6 +1500,7 @@ void GSState::SetupCrcHack()
 		lut[CRC::GiTS] = GSC_GiTS;
 		lut[CRC::SkyGunner] = GSC_SkyGunner; // Maybe not a channel effect
 		lut[CRC::SteambotChronicles] = GSC_SteambotChronicles;
+		lut[CRC::SniperElite] = GSC_SniperElite;
 
 		// Colclip not supported
 		lut[CRC::LordOfTheRingsThirdAge] = GSC_LordOfTheRingsThirdAge;


### PR DESCRIPTION
Game has ghosting even on native due to an unimplemented CS effect.
Temporary fix until it's properly implemented.