### PR TITLE
Implements IOP breakpoints

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -232,6 +232,11 @@ bool DebugInterface::parseExpression(PostfixExpression& exp, u64& dest)
 // R5900DebugInterface
 //
 
+BreakPointCpu R5900DebugInterface::getCpuType()
+{
+	return BREAKPOINT_EE;
+}
+
 u32 R5900DebugInterface::read8(u32 address)
 {
 	if (!isValidAddress(address))
@@ -627,6 +632,11 @@ u32 R5900DebugInterface::getCycles()
 // R3000DebugInterface
 //
 
+
+BreakPointCpu R3000DebugInterface::getCpuType()
+{
+	return BREAKPOINT_IOP;
+}
 
 u32 R3000DebugInterface::read8(u32 address)
 {

--- a/pcsx2/DebugTools/DebugInterface.h
+++ b/pcsx2/DebugTools/DebugInterface.h
@@ -19,6 +19,12 @@
 
 enum { EECAT_GPR, EECAT_CP0, EECAT_FPR, EECAT_FCR, EECAT_VU0F, EECAT_VU0I, EECAT_COUNT };
 enum { IOPCAT_GPR, IOPCAT_COUNT };
+enum BreakPointCpu
+{
+	BREAKPOINT_EE = 0x01,
+	BREAKPOINT_IOP = 0x02,
+	BREAKPOINT_IOP_AND_EE = 0x03
+};
 
 class DebugInterface
 {
@@ -51,6 +57,7 @@ public:
 	virtual std::string disasm(u32 address, bool simplify) = 0;
 	virtual bool isValidAddress(u32 address) = 0;
 	virtual u32 getCycles() = 0;
+	virtual BreakPointCpu getCpuType() = 0;
 	
 	bool initExpression(const char* exp, PostfixExpression& dest);
 	bool parseExpression(PostfixExpression& exp, u64& dest);
@@ -90,6 +97,7 @@ public:
 	virtual std::string disasm(u32 address, bool simplify);
 	virtual bool isValidAddress(u32 address);
 	virtual u32 getCycles();
+	virtual BreakPointCpu getCpuType();
 };
 
 
@@ -122,6 +130,7 @@ public:
 	virtual std::string disasm(u32 address, bool simplify);
 	virtual bool isValidAddress(u32 address);
 	virtual u32 getCycles();
+	virtual BreakPointCpu getCpuType();
 };
 
 extern R5900DebugInterface r5900Debug;

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -49,12 +49,12 @@ static void debugI()
 void intBreakpoint(bool memcheck)
 {
 	u32 pc = cpuRegs.pc;
- 	if (CBreakPoints::CheckSkipFirst(pc) != 0)
+ 	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_EE, pc) != 0)
 		return;
 
 	if (!memcheck)
 	{
-		auto cond = CBreakPoints::GetBreakPointCondition(pc);
+		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_EE, pc);
 		if (cond && !cond->Evaluate())
 			return;
 	}
@@ -73,7 +73,7 @@ void intMemcheck(u32 op, u32 bits, bool store)
 	if (bits == 128)
 		start &= ~0x0F;
 
-	start = standardizeBreakpointAddress(start);
+	start = standardizeBreakpointAddress(BREAKPOINT_EE, start);
 	u32 end = start + bits/8;
 	
 	auto checks = CBreakPoints::GetMemChecks();
@@ -81,6 +81,8 @@ void intMemcheck(u32 op, u32 bits, bool store)
 	{
 		auto& check = checks[i];
 
+		if (check.cpu != BREAKPOINT_EE)
+			continue;
 		if (check.result == 0)
 			continue;
 		if ((check.cond & MEMCHECK_WRITE) == 0 && store)

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -120,6 +120,7 @@ extern __aligned16 psxRegisters psxRegs;
 extern u32 g_iopNextEventCycle;
 extern s32 iopBreak;		// used when the IOP execution is broken and control returned to the EE
 extern s32 iopCycleEE;		// tracks IOP's current sych status with the EE
+extern bool iopBreakpoint;
 
 #ifndef _PC_
 
@@ -202,6 +203,9 @@ extern void psxReset();
 extern void __fastcall psxException(u32 code, u32 step);
 extern void iopEventTest();
 extern void psxMemReset();
+
+int psxIsBreakpointNeeded(u32 addr);
+int psxIsMemcheckNeeded(u32 pc);
 
 // Subsets
 extern void (*psxBSC[64])();

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -766,11 +766,11 @@ inline bool isBranchOrJump(u32 addr)
 int isBreakpointNeeded(u32 addr)
 {
 	int bpFlags = 0;
-	if (CBreakPoints::IsAddressBreakPoint(addr))
+	if (CBreakPoints::IsAddressBreakPoint(BREAKPOINT_EE, addr))
 		bpFlags += 1;
 
 	// there may be a breakpoint in the delay slot
-	if (isBranchOrJump(addr) && CBreakPoints::IsAddressBreakPoint(addr+4))
+	if (isBranchOrJump(addr) && CBreakPoints::IsAddressBreakPoint(BREAKPOINT_EE, addr+4))
 		bpFlags += 2;
 
 	return bpFlags;

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1122,7 +1122,8 @@ protected:
 
 		CoreThread.ResetQuick();
 		symbolMap.Clear();
-		CBreakPoints::SetSkipFirst(0);
+		CBreakPoints::SetSkipFirst(BREAKPOINT_EE, 0);
+		CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, 0);
 
 		CDVDsys_SetFile(CDVD_SourceType::Iso, g_Conf->CurrentIso );
 		if( m_UseCDVDsrc )

--- a/pcsx2/gui/Debugger/BreakpointWindow.cpp
+++ b/pcsx2/gui/Debugger/BreakpointWindow.cpp
@@ -325,10 +325,10 @@ void BreakpointWindow::addBreakpoint()
 		else if (enabled) result = MEMCHECK_BREAK;
 		else result = MEMCHECK_IGNORE;
 
-		CBreakPoints::AddMemCheck(address, address + size, (MemCheckCondition)cond, result);
+		CBreakPoints::AddMemCheck(cpu->getCpuType(), address, address + size, (MemCheckCondition)cond, result);
 	} else {
 		// add breakpoint
-		CBreakPoints::AddBreakPoint(address,false);
+		CBreakPoints::AddBreakPoint(cpu->getCpuType(), address,false);
 
 		if (condition[0] != 0)
 		{
@@ -336,12 +336,12 @@ void BreakpointWindow::addBreakpoint()
 			cond.debug = cpu;
 			strcpy(cond.expressionString,condition);
 			cond.expression = compiledCondition;
-			CBreakPoints::ChangeBreakPointAddCond(address,cond);
+			CBreakPoints::ChangeBreakPointAddCond(cpu->getCpuType(), address,cond);
 		}
 
 		if (!enabled)
 		{
-			CBreakPoints::ChangeBreakPoint(address,false);
+			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), address,false);
 		}
 	}
 }

--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -525,7 +525,7 @@ void CtrlDisassemblyView::render(wxDC& dc)
 		
 		// display address/symbol
 		bool enabled;
-		if (CBreakPoints::IsAddressBreakPoint(address,&enabled))
+		if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(),address,&enabled))
 		{
 			if (enabled)
 				textColor = 0x0000FF;
@@ -933,26 +933,26 @@ void CtrlDisassemblyView::scrollbarEvent(wxScrollWinEvent& evt)
 void CtrlDisassemblyView::toggleBreakpoint(bool toggleEnabled)
 {
 	bool enabled;
-	if (CBreakPoints::IsAddressBreakPoint(curAddress,&enabled))
+	if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(), curAddress,&enabled))
 	{
 		if (!enabled)
 		{
 			// enable disabled breakpoints
-			CBreakPoints::ChangeBreakPoint(curAddress,true);
-		} else if (!toggleEnabled && CBreakPoints::GetBreakPointCondition(curAddress) != NULL)
+			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), curAddress,true);
+		} else if (!toggleEnabled && CBreakPoints::GetBreakPointCondition(cpu->getCpuType(), curAddress) != NULL)
 		{
 			// don't just delete a breakpoint with a custom condition
-			CBreakPoints::RemoveBreakPoint(curAddress);
+			CBreakPoints::RemoveBreakPoint(cpu->getCpuType(), curAddress);
 		} else if (toggleEnabled)
 		{
 			// disable breakpoint
-			CBreakPoints::ChangeBreakPoint(curAddress,false);
+			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), curAddress,false);
 		} else {
 			// otherwise just remove breakpoint
-			CBreakPoints::RemoveBreakPoint(curAddress);
+			CBreakPoints::RemoveBreakPoint(cpu->getCpuType(), curAddress);
 		}
 	} else {
-		CBreakPoints::AddBreakPoint(curAddress);
+		CBreakPoints::AddBreakPoint(cpu->getCpuType(), curAddress);
 	}
 }
 
@@ -1266,7 +1266,7 @@ void CtrlDisassemblyView::editBreakpoint()
 	BreakpointWindow win(this,cpu);
 
 	bool exists = false;
-	if (CBreakPoints::IsAddressBreakPoint(curAddress))
+	if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(), curAddress))
 	{
 		auto breakpoints = CBreakPoints::GetBreakpoints();
 		for (size_t i = 0; i < breakpoints.size(); i++)
@@ -1286,7 +1286,7 @@ void CtrlDisassemblyView::editBreakpoint()
 	if (win.ShowModal() == wxID_OK)
 	{
 		if (exists)
-			CBreakPoints::RemoveBreakPoint(curAddress);
+			CBreakPoints::RemoveBreakPoint(cpu->getCpuType(), curAddress);
 		win.addBreakpoint();	
 		postEvent(debEVT_UPDATE,0);
 	}

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -325,7 +325,8 @@ void DisassemblyDialog::onBreakRunClicked(wxCommandEvent& evt)
 	if (r5900Debug.isCpuPaused())
 	{
 		// If the current PC is on a breakpoint, the user doesn't want to do nothing.
-		CBreakPoints::SetSkipFirst(r5900Debug.getPC());
+		CBreakPoints::SetSkipFirst(BREAKPOINT_EE, r5900Debug.getPC());
+		CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, r3000Debug.getPC());
 		r5900Debug.resumeCpu();
 	} else {
 		r5900Debug.pauseCpu();
@@ -371,19 +372,15 @@ void DisassemblyDialog::stepOver()
 {
 	if (!r5900Debug.isAlive() || !r5900Debug.isCpuPaused() || currentCpu == NULL)
 		return;
-	
-
-	// todo: breakpoints for iop
-	if (currentCpu != eeTab)
-		return;
+	DebugInterface *debug = currentCpu->getCpu();
 
 	CtrlDisassemblyView* disassembly = currentCpu->getDisassembly();
 
 	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
-	CBreakPoints::SetSkipFirst(r5900Debug.getPC());
-	u32 currentPc = r5900Debug.getPC();
+	CBreakPoints::SetSkipFirst(debug->getCpuType(), debug->getPC());
+	u32 currentPc = debug->getPC();
 
-	MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(&r5900Debug,r5900Debug.getPC());
+	MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(debug,debug->getPC());
 	u32 breakpointAddress = currentPc+disassembly->getInstructionSizeAt(currentPc);
 	if (info.isBranch)
 	{
@@ -410,7 +407,7 @@ void DisassemblyDialog::stepOver()
 		disassembly->scrollStepping(breakpointAddress);
 	}
 
-	CBreakPoints::AddBreakPoint(breakpointAddress,true);
+	CBreakPoints::AddBreakPoint(debug->getCpuType(), breakpointAddress,true);
 	r5900Debug.resumeCpu();
 }
 
@@ -420,17 +417,14 @@ void DisassemblyDialog::stepInto()
 	if (!r5900Debug.isAlive() || !r5900Debug.isCpuPaused() || currentCpu == NULL)
 		return;
 	
-	// todo: breakpoints for iop
-	if (currentCpu != eeTab)
-		return;
-
+	DebugInterface *debug = currentCpu->getCpu();
 	CtrlDisassemblyView* disassembly = currentCpu->getDisassembly();
 
 	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
-	CBreakPoints::SetSkipFirst(r5900Debug.getPC());
-	u32 currentPc = r5900Debug.getPC();
+	CBreakPoints::SetSkipFirst(debug->getCpuType(), debug->getPC());
+	u32 currentPc = debug->getPC();
 
-	MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(&r5900Debug,r5900Debug.getPC());
+	MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(debug,debug->getPC());
 	u32 breakpointAddress = currentPc+disassembly->getInstructionSizeAt(currentPc);
 	if (info.isBranch)
 	{
@@ -451,7 +445,7 @@ void DisassemblyDialog::stepInto()
 	if (info.isSyscall)
 		breakpointAddress = info.branchTarget;
 
-	CBreakPoints::AddBreakPoint(breakpointAddress,true);
+	CBreakPoints::AddBreakPoint(debug->getCpuType(), breakpointAddress,true);
 	r5900Debug.resumeCpu();
 }
 
@@ -459,14 +453,15 @@ void DisassemblyDialog::stepOut()
 {
 	if (!r5900Debug.isAlive() || !r5900Debug.isCpuPaused() || currentCpu == NULL)
 		return;
+	DebugInterface *debug = currentCpu->getCpu();
 	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
-	CBreakPoints::SetSkipFirst(r5900Debug.getPC());
+	CBreakPoints::SetSkipFirst(debug->getCpuType(), debug->getPC());
 
 	u32 addr = currentCpu->getStepOutAddress();
 	if (addr == (u32)-1)
 		return;
 
-	CBreakPoints::AddBreakPoint(addr,true);
+	CBreakPoints::AddBreakPoint(debug->getCpuType(), addr,true);
 	r5900Debug.resumeCpu();
 }
 
@@ -514,10 +509,7 @@ void DisassemblyDialog::onDebuggerEvent(wxCommandEvent& evt)
 		}
 	} else if (type == debEVT_RUNTOPOS)
 	{
-		// todo: breakpoints for iop
-		if (currentCpu != eeTab)
-			return;
-		CBreakPoints::AddBreakPoint(evt.GetInt(),true);
+		CBreakPoints::AddBreakPoint(currentCpu->getCpu()->getCpuType(), evt.GetInt(),true);
 		currentCpu->getCpu()->resumeCpu();
 	} else if (type == debEVT_GOTOINDISASM)
 	{
@@ -625,7 +617,8 @@ void DisassemblyDialog::setDebugMode(bool debugMode, bool switchPC)
 				if (currentCpu != NULL)
 					currentCpu->getDisassembly()->SetFocus();
 				CBreakPoints::SetBreakpointTriggered(false);
-				CBreakPoints::SetSkipFirst(0);
+				CBreakPoints::SetSkipFirst(BREAKPOINT_EE, 0);
+				CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, 0);
 			}
 
 			if (currentCpu != NULL)

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1055,7 +1055,7 @@ void psxDynarecCheckBreakpoint()
 		return;
 
 	CBreakPoints::SetBreakpointTriggered(true);
-	GetCoreThread().PauseSelf();
+	GetCoreThread().PauseSelfDebug();
 	iopBreakpoint = true;
 }
 
@@ -1066,7 +1066,7 @@ void psxDynarecMemcheck()
 		return;
 
 	CBreakPoints::SetBreakpointTriggered(true);
-	GetCoreThread().PauseSelf();
+	GetCoreThread().PauseSelfDebug();
 	iopBreakpoint = true;
 }
 

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -23,6 +23,8 @@
 #include "iR3000A.h"
 #include "BaseblockEx.h"
 #include "System/RecTypes.h"
+#include "System/SysThreads.h"
+#include "R5900OpcodeTables.h"
 
 #include <time.h>
 
@@ -37,6 +39,7 @@
 #include "AppConfig.h"
 
 #include "Utilities/Perf.h"
+#include "../DebugTools/Breakpoints.h"
 
 using namespace x86Emitter;
 
@@ -433,6 +436,11 @@ void _psxFlushCall(int flushtype)
 	_freeX86reg( eax );
 	_freeX86reg( ecx );
 	_freeX86reg( edx );
+
+	if ((flushtype & FLUSH_PC)/*&& !g_cpuFlushedPC*/) {
+		xMOV(ptr32[&psxRegs.pc], psxpc);
+		//g_cpuFlushedPC = true;
+	}
 
 	if( flushtype & FLUSH_CACHED_REGS )
 		_psxFlushConstRegs();
@@ -1021,10 +1029,166 @@ void rpsxBREAK()
 	//if (!psxbranch) psxbranch = 2;
 }
 
+void psxDynarecCheckBreakpoint()
+{
+	u32 pc = psxRegs.pc;
+	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_IOP, pc) == pc)
+		return;
+
+	int bpFlags = psxIsBreakpointNeeded(pc);
+	bool hit = false;
+	//check breakpoint at current pc
+	if (bpFlags & 1) {
+		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_IOP, pc);
+		if (cond == NULL || cond->Evaluate()) {
+			hit = true;
+		}
+	}
+	//check breakpoint in delay slot
+	if (bpFlags & 2) {
+		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_IOP, pc + 4);
+		if (cond == NULL || cond->Evaluate())
+			hit = true;
+	}
+
+	if (!hit)
+		return;
+
+	CBreakPoints::SetBreakpointTriggered(true);
+	GetCoreThread().PauseSelf();
+	iopBreakpoint = true;
+}
+
+void psxDynarecMemcheck()
+{
+	u32 pc = psxRegs.pc;
+	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_IOP, pc) == pc)
+		return;
+
+	CBreakPoints::SetBreakpointTriggered(true);
+	GetCoreThread().PauseSelf();
+	iopBreakpoint = true;
+}
+
+void __fastcall psxDynarecMemLogcheck(u32 start, bool store)
+{
+	if (store)
+		DevCon.WriteLn("Hit store breakpoint @0x%x", start);
+	else
+		DevCon.WriteLn("Hit load breakpoint @0x%x", start);
+}
+
+void psxRecMemcheck(u32 op, u32 bits, bool store)
+{
+	_psxFlushCall(FLUSH_EVERYTHING | FLUSH_PC);
+
+	// compute accessed address
+	_psxMoveGPRtoR(ecx, (op >> 21) & 0x1F);
+	if ((s16)op != 0)
+		xADD(ecx, (s16)op);
+	if (bits == 128)
+		xAND(ecx, ~0x0F);
+
+	xFastCall((void*)standardizeBreakpointAddressIop, ecx);
+	xMOV(ecx, eax);
+	xMOV(edx, eax);
+	xADD(edx, bits / 8);
+
+	// ecx = access address
+	// edx = access address+size
+
+	auto checks = CBreakPoints::GetMemChecks();
+	for (size_t i = 0; i < checks.size(); i++)
+	{
+		if (checks[i].cpu != BREAKPOINT_IOP)
+			continue;
+		if (checks[i].result == 0)
+			continue;
+		if ((checks[i].cond & MEMCHECK_WRITE) == 0 && store)
+			continue;
+		if ((checks[i].cond & MEMCHECK_READ) == 0 && !store)
+			continue;
+
+		// logic: memAddress < bpEnd && bpStart < memAddress+memSize
+
+		xMOV(eax, standardizeBreakpointAddress(BREAKPOINT_IOP, checks[i].end));
+		xCMP(ecx, eax);				// address < end
+		xForwardJGE8 next1;			// if address >= end then goto next1
+
+		xMOV(eax, standardizeBreakpointAddress(BREAKPOINT_IOP, checks[i].start));
+		xCMP(eax, edx);				// start < address+size
+		xForwardJGE8 next2;			// if start >= address+size then goto next2
+
+									// hit the breakpoint
+		if (checks[i].result & MEMCHECK_LOG) {
+			xMOV(edx, store);
+			xFastCall((void*)psxDynarecMemLogcheck, ecx, edx);
+		}
+		if (checks[i].result & MEMCHECK_BREAK) {
+			xFastCall((void*)psxDynarecMemcheck);
+		}
+
+		next1.SetTarget();
+		next2.SetTarget();
+	}
+	// get out of here
+	xCMP(ptr8[&iopBreakpoint], 0);
+	xJNE(iopExitRecompiledCode);
+}
+
+void psxEncodeBreakpoint()
+{
+	if (psxIsBreakpointNeeded(psxpc) != 0)
+	{
+		_psxFlushCall(FLUSH_EVERYTHING | FLUSH_PC);
+		xFastCall((void*)psxDynarecCheckBreakpoint);
+		// get out of here
+		xCMP(ptr8[&iopBreakpoint], 0);
+		xJNE(iopExitRecompiledCode);
+	}
+}
+
+void psxEncodeMemcheck()
+{
+	int needed = psxIsMemcheckNeeded(psxpc);
+	if (needed == 0)
+		return;
+
+	u32 op = iopMemRead32(needed == 2 ? psxpc + 4 : psxpc);
+	const R5900::OPCODE& opcode = R5900::GetInstruction(op);
+
+	bool store = (opcode.flags & IS_STORE) != 0;
+	switch (opcode.flags & MEMTYPE_MASK)
+	{
+	case MEMTYPE_BYTE:
+		psxRecMemcheck(op, 8, store);
+		break;
+	case MEMTYPE_HALF:
+		psxRecMemcheck(op, 16, store);
+		break;
+	case MEMTYPE_WORD:
+		psxRecMemcheck(op, 32, store);
+		break;
+	case MEMTYPE_DWORD:
+		psxRecMemcheck(op, 64, store);
+		break;
+	case MEMTYPE_QWORD:
+		psxRecMemcheck(op, 128, store);
+		break;
+	}
+}
+
 void psxRecompileNextInstruction(int delayslot)
 {
 	// pblock isn't used elsewhere in this function.
 	//BASEBLOCK* pblock = PSX_GETBLOCK(psxpc);
+
+	// add breakpoint
+	if (!delayslot)
+	{
+		psxEncodeBreakpoint();
+		psxEncodeMemcheck();
+	}
 
 	if( IsDebugBuild ) {
 		xNOP();

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -112,6 +112,7 @@ static u32 dumplog = 0;
 static void iBranchTest(u32 newpc = 0xffffffff);
 static void ClearRecLUT(BASEBLOCK* base, int count);
 static u32 scaleblockcycles();
+static void recExitExecution();
 
 void _eeFlushAllUnused()
 {
@@ -335,6 +336,11 @@ static DynGenFunc* DispatchPageReset    = NULL;
 static void recEventTest()
 {
 	_cpuEventTest_Shared();
+
+	if (iopBreakpoint) {
+		iopBreakpoint = false;
+		recExitExecution();
+	}
 }
 
 // The address for all cleared blocks.  It recompiles the current pc and then
@@ -1125,21 +1131,21 @@ int cop2flags(u32 code)
 void dynarecCheckBreakpoint()
 {
 	u32 pc = cpuRegs.pc;
- 	if (CBreakPoints::CheckSkipFirst(pc) != 0)
+ 	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_EE, pc) != 0)
 		return;
 
 	int bpFlags = isBreakpointNeeded(pc);
 	bool hit = false;
 	//check breakpoint at current pc
 	if (bpFlags & 1) {
-		auto cond = CBreakPoints::GetBreakPointCondition(pc);
+		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_EE, pc);
 		if (cond == NULL || cond->Evaluate()) {
 			hit = true;
 		}
 	}
 	//check breakpoint in delay slot
 	if (bpFlags & 2) {
-		auto cond = CBreakPoints::GetBreakPointCondition(pc + 4);
+		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_EE, pc + 4);
 		if (cond == NULL || cond->Evaluate())
 			hit = true;
 	}
@@ -1155,7 +1161,7 @@ void dynarecCheckBreakpoint()
 void dynarecMemcheck()
 {
 	u32 pc = cpuRegs.pc;
- 	if (CBreakPoints::CheckSkipFirst(pc) != 0)
+ 	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_EE, pc) != 0)
 		return;
 
 	CBreakPoints::SetBreakpointTriggered(true);
@@ -1182,7 +1188,7 @@ void recMemcheck(u32 op, u32 bits, bool store)
 	if (bits == 128)
 		xAND(ecx, ~0x0F);
 
-	xFastCall((void*)standardizeBreakpointAddress, ecx);
+	xFastCall((void*)standardizeBreakpointAddressEE, ecx);
 	xMOV(ecx,eax);
 	xMOV(edx,eax);
 	xADD(edx,bits/8);
@@ -1193,6 +1199,8 @@ void recMemcheck(u32 op, u32 bits, bool store)
 	auto checks = CBreakPoints::GetMemChecks();
 	for (size_t i = 0; i < checks.size(); i++)
 	{
+		if (checks[i].cpu != BREAKPOINT_EE)
+			continue;
 		if (checks[i].result == 0)
 			continue;
 		if ((checks[i].cond & MEMCHECK_WRITE) == 0 && store)
@@ -1202,11 +1210,11 @@ void recMemcheck(u32 op, u32 bits, bool store)
 
 		// logic: memAddress < bpEnd && bpStart < memAddress+memSize
 
-		xMOV(eax,standardizeBreakpointAddress(checks[i].end));
+		xMOV(eax,standardizeBreakpointAddress(BREAKPOINT_EE, checks[i].end));
 		xCMP(ecx,eax);				// address < end
 		xForwardJGE8 next1;			// if address >= end then goto next1
 
-		xMOV(eax,standardizeBreakpointAddress(checks[i].start));
+		xMOV(eax,standardizeBreakpointAddress(BREAKPOINT_EE, checks[i].start));
 		xCMP(eax,edx);				// start < address+size
 		xForwardJGE8 next2;			// if start >= address+size then goto next2
 


### PR DESCRIPTION
Breakpoints on the IOP will now actually break, and you can now step through it and shizz. I've only implemented this on recompiler, and not the interpreter.

Fixes #1746