### PR TITLE
pcsx2: Auto select GSdx during plugin selection

### DIFF
--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -677,7 +677,31 @@ void Panels::PluginSelectorPanel::OnEnumComplete( wxCommandEvent& evt )
 
 		else if( m_ComponentBoxes->Get(pid).GetSelection() == wxNOT_FOUND )
 		{
-			m_ComponentBoxes->Get(pid).SetSelection( 0 );
+			if( pid == PluginId_GS )
+			{
+				int count = (int)m_ComponentBoxes->Get(pid).GetCount();
+
+				int index_avx2 = -1;
+				int index_sse4 = -1;
+				int index_sse2 = -1;
+
+				for( int i = 0; i < count; i++ )
+				{
+					auto str = m_ComponentBoxes->Get(pid).GetString( i );
+					
+					if( x86caps.hasAVX2 && str.Contains("AVX2") ) index_avx2 = i;
+					if( x86caps.hasStreamingSIMD4Extensions && str.Contains("SSE4") ) index_sse4 = i;
+					if( str.Contains("SSE2") ) index_sse2 = i;
+				}
+
+				if( index_avx2 >= 0 ) m_ComponentBoxes->Get(pid).SetSelection( index_avx2 );
+				else if( index_sse4 >= 0 ) m_ComponentBoxes->Get(pid).SetSelection( index_sse4 );
+				else if( index_sse2 >= 0 ) m_ComponentBoxes->Get(pid).SetSelection( index_sse2 );
+				else m_ComponentBoxes->Get(pid).SetSelection( 0 );
+			}
+			else
+				m_ComponentBoxes->Get(pid).SetSelection( 0 );
+
 			m_ComponentBoxes->GetConfigButton(pid).Enable( !CorePlugins.AreLoaded() );
 		}
 	} while( ++pi, pi->shortname != NULL );


### PR DESCRIPTION
When there's no previous plugin set, auto select the GSdx plugin in order AVX2 -> SSE4 -> SSE2. Might help avoid having the wrong plugin selected on the first time wizard.

PS: No idea if it works, I only get the SSE2 plugin.