### PR TITLE
Fix microVU debug logging.

### DIFF
--- a/pcsx2/x86/microVU_Log.inl
+++ b/pcsx2/x86/microVU_Log.inl
@@ -28,6 +28,7 @@ _mVUt void __mVULog(const char* fmt, ...) {
 	va_start(list, fmt);
 
 	// concatenate the log message after the prefix:
+	vsprintf(tmp, fmt, list);
 	va_end(list);
 
 	mVU.logFile->Write( tmp );


### PR DESCRIPTION
A [previous commit](https://github.com/PCSX2/pcsx2/commit/ea38e2eba58ba87e8e245c8cc795363fb95cb3be#diff-136d6ae872176c8acc158d97dc2cea19L31) inadvertently removed a vsprintf call necessary for microVU debug logging to function properly.