### PR TITLE
GSdx-hw TC: improve search/invalidate tex in RT

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -440,18 +440,18 @@ CRC::Game CRC::m_games[] =
 	{0XE8F7BAB6, SuperManReturns, EU, 0},
 	{0x06A7506A, SacredBlaze, JP, 0},
 	{0x4CE7FB04, ItadakiStreet, JP, 0},
-	{0x9C712FF0, Jak1, EU, 0}, // Jak and Daxter: The Precursor Legacy
-	{0x472E7699, Jak1, US, 0},
-	{0x2479F4A9, Jak2, EU, 0},
-	{0x9184AAF1, Jak2, US, 0},
-	{0xA2034C69, Jak2, US, 0}, // Demo
-	{0x12804727, Jak3, EU, 0},
-	{0x644CFD03, Jak3, US, 0},
-	{0x23F8D35B, Jak3, NoRegion, 0}, // EU Preview, US Internal test build
-	{0xDF659E77, JakX, EU, 0}, // Jak X: Combat Racing
-	{0xC20596DB, JakX, EU, 0}, // Beta Trial Disc, v0.01
-	{0x3091E6FB, JakX, US, 0},
-	{0xDA366A53, JakX, US, 0}, // Public Beta v.1
+	{0x9C712FF0, Jak1, EU, TextureInsideRt}, // Jak and Daxter: The Precursor Legacy
+	{0x472E7699, Jak1, US, TextureInsideRt},
+	{0x2479F4A9, Jak2, EU, TextureInsideRt},
+	{0x9184AAF1, Jak2, US, TextureInsideRt},
+	{0xA2034C69, Jak2, US, TextureInsideRt}, // Demo
+	{0x12804727, Jak3, EU, TextureInsideRt},
+	{0x644CFD03, Jak3, US, TextureInsideRt},
+	{0x23F8D35B, Jak3, NoRegion, TextureInsideRt}, // EU Preview, US Internal test build
+	{0xDF659E77, JakX, EU, TextureInsideRt}, // Jak X: Combat Racing
+	{0xC20596DB, JakX, EU, TextureInsideRt}, // Beta Trial Disc, v0.01
+	{0x3091E6FB, JakX, US, TextureInsideRt},
+	{0xDA366A53, JakX, US, TextureInsideRt}, // Public Beta v.1
 	{0x4653CA3E, HarleyDavidson, US, 0},
 	// Games list for Automatic Mipmapping
 	// Basic mipmapping

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -185,6 +185,7 @@ public:
 	enum Flags
 	{
 		PointListPalette = 1,
+		TextureInsideRt = 2,
 	};
 
 	struct Game

--- a/plugins/GSdx/Renderers/HW/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/HW/GSTextureCache.cpp
@@ -154,6 +154,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		src->m_shared_texture = true;
 		src->m_target = true; // So renderer can check if a conversion is required
 		src->m_from_target = dst->m_texture; // avoid complex condition on the renderer
+		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_32_bits_fmt = dst->m_32_bits_fmt;
 		src->m_valid_rect = dst->m_valid;
 
@@ -698,7 +699,8 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 			Source* s = *i;
 			++i;
 
-			if(GSUtil::HasSharedBits(bp, psm, s->m_TEX0.TBP0, s->m_TEX0.PSM))
+			if (GSUtil::HasSharedBits(bp, psm, s->m_TEX0.TBP0, s->m_TEX0.PSM) ||
+				GSUtil::HasSharedBits(bp, psm, s->m_from_target_TEX0.TBP0, s->m_TEX0.PSM))
 			{
 				m_src.RemoveAt(s);
 			}
@@ -804,6 +806,8 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 				{
 					// render target used as input texture
 					// TODO
+
+					b |= bp == s->m_from_target_TEX0.TBP0;
 
 					if(b)
 					{
@@ -1156,6 +1160,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_texture = dTex;
 		src->m_target = true;
 		src->m_from_target = dst->m_texture;
+		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_texture->SetScale(scale);
 
 		if (psm.pal > 0) {
@@ -1182,6 +1187,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_texture = dTex;
 		src->m_target = true;
 		src->m_from_target = dst->m_texture;
+		src->m_from_target_TEX0 = dst->m_TEX0;
 
 		// Even if we sample the framebuffer directly we might need the palette
 		// to handle the format conversion on GPU
@@ -1213,6 +1219,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// Keep a trace of origin of the texture
 		src->m_target = true;
 		src->m_from_target = dst->m_texture;
+		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_valid_rect = dst->m_valid;
 
 		dst->Update();
@@ -1547,6 +1554,7 @@ GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFR
 	, m_complete(false)
 	, m_p2t(NULL)
 	, m_from_target(NULL)
+	, m_from_target_TEX0(TEX0)
 {
 	m_TEX0 = TEX0;
 	m_TEXA = TEXA;

--- a/plugins/GSdx/Renderers/HW/GSTextureCache.cpp
+++ b/plugins/GSdx/Renderers/HW/GSTextureCache.cpp
@@ -1925,7 +1925,7 @@ bool GSTextureCache::Target::Inside(uint32 bp, uint32 bw, uint32 psm, const GSVe
 {
 	uint32 block = GSLocalMemory::m_psm[psm].bn(rect.z - 1, rect.w - 1, bp, bw);  // Valid only for color formats
 
-	return bp > m_TEX0.TBP0 && block <= m_end_block;
+	return bp >= m_TEX0.TBP0 && block <= m_end_block;
 }
 
 // GSTextureCache::SourceMap

--- a/plugins/GSdx/Renderers/HW/GSTextureCache.h
+++ b/plugins/GSdx/Renderers/HW/GSTextureCache.h
@@ -113,6 +113,7 @@ public:
 		// still be valid on future. However it ought to be good when the source is created
 		// so it can be used to access un-converted data for the current draw call.
 		GSTexture* m_from_target;
+		GIFRegTEX0 m_from_target_TEX0;  // TEX0 of the target texture, if any, else equal to texture TEX0
 		GIFRegTEX0 m_layer_TEX0[7]; // Detect already loaded value
 		// Keep a GSTextureCache::SourceMap::m_map iterator to allow fast erase
 		std::array<uint16, MAX_PAGES> m_erase_it;

--- a/plugins/GSdx/Renderers/HW/GSTextureCache.h
+++ b/plugins/GSdx/Renderers/HW/GSTextureCache.h
@@ -185,6 +185,19 @@ public:
 		void RemoveAt(Source* s);
 	};
 
+	struct TexInsideRtCacheEntry
+	{
+		uint32 psm;
+		uint32 bp;
+		uint32 bp_end;
+		uint32 bw;
+		uint32 t_tex0_tbp0;
+		uint32 m_end_block;
+		bool has_valid_offset;
+		int x_offset;
+		int y_offset;
+	};
+
 protected:
 	GSRenderer* m_renderer;
 	PaletteMap m_palette_map;
@@ -199,6 +212,8 @@ protected:
 	static bool m_disable_partial_invalidation;
 	bool m_texture_inside_rt;
 	static bool m_wrap_gs_mem;
+	uint8 m_texture_inside_rt_cache_size = 255;
+	std::vector<TexInsideRtCacheEntry> m_texture_inside_rt_cache;
 
 	virtual Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false, int x_offset = 0, int y_offset = 0);
 	virtual Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type);
@@ -230,6 +245,8 @@ public:
 	void IncAge();
 	bool UserHacks_HalfPixelOffset;
 	void ScaleTexture(GSTexture* texture);
+
+	bool ShallSearchTextureInsideRt();
 
 	const char* to_string(int type) {
 		return (type == DepthStencil) ? "Depth" : "Color";


### PR DESCRIPTION
Fixes eyes rendering in Jak games both ingame and in cutscenes.
Previous method yielded no eyes in Jak 2/3/X cutscenes and no eyes invalidation in any Jak game (i.e. no blinking).

- Keep track of Target TBP0 in Source built from Target
- Invalidate Source using also from Target TBP0 information
- Generalized offset search logic with caching system (works for BW > 1 and any PSM, limited to PSMCT32 for now)
- CRC Flags mechanism for default behavior enabling in Jak games

https://www.youtube.com/watch?v=lXlOzzE7Qhw

Various:

- Fix texture end block computation around the code, using the block of the bottom right texel as last valid block
- Fix Target::Inside method which is now inclusive both on start and end blocks
