### PR TITLE
PCSX2: Set pad plugin and bios defaults automatically.

### DIFF
--- a/pcsx2/gui/Panels/BiosSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/BiosSelectorPanel.cpp
@@ -155,24 +155,35 @@ bool Panels::BiosSelectorPanel::ValidateEnumerationStatus()
 
 	m_BiosList.swap(bioslist);
 
+	int sel = m_ComboBox->GetSelection();
+	if ((sel == wxNOT_FOUND) && !(m_ComboBox->IsEmpty()))
+		m_ComboBox->SetSelection(0);
+
 	return validated;
 }
 
 void Panels::BiosSelectorPanel::DoRefresh()
 {
-	if( !m_BiosList ) return;
+	if (!m_BiosList) return;
 
 	m_ComboBox->Clear();
 
-	const wxFileName right( g_Conf->FullpathToBios() );
+	const wxFileName right(g_Conf->FullpathToBios());
+	bool biosSet = false;
 
-	for( size_t i=0; i<m_BiosList->GetCount(); ++i )
+	for(size_t i=0; i<m_BiosList->GetCount(); ++i)
 	{
 		wxString description;
-		if( !IsBIOS((*m_BiosList)[i], description) ) continue;
+		if (!IsBIOS((*m_BiosList)[i], description)) continue;
 		int sel = m_ComboBox->Append( description, (void*)i );
 
-		if( wxFileName((*m_BiosList)[i] ) == right )
-			m_ComboBox->SetSelection( sel );
+		if (wxFileName((*m_BiosList)[i] ) == right)
+		{
+			m_ComboBox->SetSelection(sel);
+			biosSet = true;
+		}
 	}
+
+	if ((!biosSet) && !(m_ComboBox->IsEmpty()))
+		m_ComboBox->SetSelection(0);
 }

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -579,7 +579,7 @@ bool Panels::PluginSelectorPanel::ValidateEnumerationStatus()
 
 	m_FileList.swap(pluginlist);
 
-	// set the gague length a little shorter than the plugin count.  2 reasons:
+	// set the gauge length a little shorter than the plugin count.  2 reasons:
 	//  * some of the plugins might be duds.
 	//  * on high end machines and Win7, the statusbar lags a lot and never gets to 100% before being hidden.
 	
@@ -669,7 +669,9 @@ void Panels::PluginSelectorPanel::OnEnumComplete( wxCommandEvent& evt )
 	//  (for now we just force it to selection zero if nothing's selected)
 
 	int emptyBoxes = 0;
-	const PluginInfo* pi = tbl_PluginInfo; do
+	const PluginInfo* pi = tbl_PluginInfo;
+
+	do
 	{
 		const PluginsEnum_t pid = pi->id;
 		if( m_ComponentBoxes->Get(pid).GetCount() <= 0 )
@@ -677,7 +679,7 @@ void Panels::PluginSelectorPanel::OnEnumComplete( wxCommandEvent& evt )
 
 		else if( m_ComponentBoxes->Get(pid).GetSelection() == wxNOT_FOUND )
 		{
-			if( pid == PluginId_GS )
+			if (pid == PluginId_GS)
 			{
 				int count = (int)m_ComponentBoxes->Get(pid).GetCount();
 
@@ -698,6 +700,48 @@ void Panels::PluginSelectorPanel::OnEnumComplete( wxCommandEvent& evt )
 				else if( index_sse4 >= 0 ) m_ComponentBoxes->Get(pid).SetSelection( index_sse4 );
 				else if( index_sse2 >= 0 ) m_ComponentBoxes->Get(pid).SetSelection( index_sse2 );
 				else m_ComponentBoxes->Get(pid).SetSelection( 0 );
+			}
+			else if (pid == PluginId_PAD)
+			{
+				int count = (int)m_ComponentBoxes->Get(pid).GetCount();
+
+				int index_lilypad = -1;
+				int index_onepad = -1;
+				int index_onepad_legacy = -1;
+
+				for( int i = 0; i < count; i++ )
+				{
+					auto str = m_ComponentBoxes->Get(pid).GetString(i);
+
+					if (str.Contains("lilypad")) index_lilypad = i;
+					if (str.Contains("onepad"))
+					{
+						if (str.Contains("legacy"))
+							index_onepad_legacy = i;
+						else
+							index_onepad = i;
+					}
+				}
+
+				#ifdef _WIN32
+					if (index_lilypad >= 0)
+						m_ComponentBoxes->Get(pid).SetSelection(index_lilypad);
+					/* else if (index_onepad >= 0)
+						m_ComponentBoxes->Get(pid).SetSelection(index_onepad);
+					else if (index_onepad_legacy >= 0)
+						m_ComponentBoxes->Get(pid).SetSelection(index_onepad_legacy); */
+					else
+						m_ComponentBoxes->Get(pid).SetSelection(0);
+				#else
+					if (index_onepad >= 0)
+						m_ComponentBoxes->Get(pid).SetSelection(index_onepad);
+					else if (index_onepad_legacy >= 0)
+						m_ComponentBoxes->Get(pid).SetSelection(index_onepad_legacy);
+					else if (index_lilypad >= 0)
+						m_ComponentBoxes->Get(pid).SetSelection(index_lilypad);
+					else
+						m_ComponentBoxes->Get(pid).SetSelection(0);
+				#endif
 			}
 			else
 				m_ComponentBoxes->Get(pid).SetSelection( 0 );

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -711,7 +711,7 @@ void Panels::PluginSelectorPanel::OnEnumComplete( wxCommandEvent& evt )
 
 				for( int i = 0; i < count; i++ )
 				{
-					auto str = m_ComponentBoxes->Get(pid).GetString(i);
+					auto str = m_ComponentBoxes->Get(pid).GetString(i).Lower();
 
 					if (str.Contains("lilypad")) index_lilypad = i;
 					if (str.Contains("onepad"))


### PR DESCRIPTION
This builds on the auto GS plugin selection to automatically set a pad plugin as well, picking the non-legacy version of onepad on Linux and lilypad on windows. (I'm largely doing this because it's possible to build lilypad for Linux, and it *shouldn't* be the default, but l is before o alphabetically...)

I also added some code to pick the bios by default. This isn't perfect; if you never go to the screen where it shows the bios, it's still not set. If you do go to that window, it'll automatically pick the first bios in the list, though, which is probably the only one.

This needs testing on Windows.