### PR TITLE
GSdx-d3d11: Cleanup GSDevice11, GSTextureFX11

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1261,36 +1261,33 @@ void GSDevice11::IASetIndexBuffer(const void* index, size_t count)
 {
 	ASSERT(m_index.count == 0);
 
-	if(count > m_index.limit)
+	if (count > m_index.limit)
 	{
 		m_ib_old = m_ib;
-		m_ib = NULL;
+		m_ib = nullptr;
 
 		m_index.start = 0;
 		m_index.limit = std::max<int>(count * 3 / 2, 11000);
 	}
 
-	if(m_ib == NULL)
+	if (m_ib == nullptr)
 	{
-		D3D11_BUFFER_DESC bd;
+		D3D11_BUFFER_DESC buffer_desc = {};
 
-		memset(&bd, 0, sizeof(bd));
+		buffer_desc.Usage = D3D11_USAGE_DYNAMIC;
+		buffer_desc.ByteWidth = m_index.limit * sizeof(uint32);
+		buffer_desc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+		buffer_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-		bd.Usage = D3D11_USAGE_DYNAMIC;
-		bd.ByteWidth = m_index.limit * sizeof(uint32);
-		bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-		bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		HRESULT hr = m_dev->CreateBuffer(&buffer_desc, nullptr, &m_ib);
 
-		HRESULT hr;
-
-		hr = m_dev->CreateBuffer(&bd, NULL, &m_ib);
-
-		if(FAILED(hr)) return;
+		if (FAILED(hr))
+			return;
 	}
 
 	D3D11_MAP type = D3D11_MAP_WRITE_NO_OVERWRITE;
 
-	if(m_index.start + count > m_index.limit)
+	if (m_index.start + count > m_index.limit)
 	{
 		m_index.start = 0;
 
@@ -1299,7 +1296,7 @@ void GSDevice11::IASetIndexBuffer(const void* index, size_t count)
 
 	D3D11_MAPPED_SUBRESOURCE m;
 
-	if(SUCCEEDED(m_ctx->Map(m_ib, 0, type, 0, &m)))
+	if (SUCCEEDED(m_ctx->Map(m_ib, 0, type, 0, &m)))
 	{
 		memcpy((uint8*)m.pData + m_index.start * sizeof(uint32), index, count * sizeof(uint32));
 

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -831,7 +831,7 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 
 void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha)
 {
-	D3D11_BLEND_DESC bd = {};
+	D3D11_BLEND_DESC blend_desc = {};
 	CComPtr<ID3D11BlendState> bs;
 
 	uint8 write_mask = 0;
@@ -841,11 +841,12 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	if (blue)  write_mask |= D3D11_COLOR_WRITE_ENABLE_BLUE;
 	if (alpha) write_mask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
 
-	bd.RenderTarget[0].RenderTargetWriteMask = write_mask;
+	blend_desc.RenderTarget[0].RenderTargetWriteMask = write_mask;
 
-	m_dev->CreateBlendState(&bd, &bs);
+	HRESULT hr = m_dev->CreateBlendState(&blend_desc, &bs);
 
-	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[ShaderConvert_COPY], nullptr, bs, false);
+	if (SUCCEEDED(hr))
+		StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[ShaderConvert_COPY], nullptr, bs, false);
 }
 
 void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, ID3D11BlendState* bs , bool linear)

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1486,8 +1486,7 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector
 	{
 		m_state.viewport = size;
 
-		D3D11_VIEWPORT vp;
-		memset(&vp, 0, sizeof(vp));
+		D3D11_VIEWPORT vp = {};
 
 		vp.TopLeftX = m_hack_topleft_offset;
 		vp.TopLeftY = m_hack_topleft_offset;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1188,31 +1188,28 @@ bool GSDevice11::IAMapVertexBuffer(void** vertex, size_t stride, size_t count)
 {
 	ASSERT(m_vertex.count == 0);
 
-	if(count * stride > m_vertex.limit * m_vertex.stride)
+	if (count * stride > m_vertex.limit * m_vertex.stride)
 	{
 		m_vb_old = m_vb;
-		m_vb = NULL;
+		m_vb = nullptr;
 
 		m_vertex.start = 0;
 		m_vertex.limit = std::max<int>(count * 3 / 2, 11000);
 	}
 
-	if(m_vb == NULL)
+	if (m_vb == nullptr)
 	{
-		D3D11_BUFFER_DESC bd;
+		D3D11_BUFFER_DESC buffer_desc = {};
 
-		memset(&bd, 0, sizeof(bd));
+		buffer_desc.Usage = D3D11_USAGE_DYNAMIC;
+		buffer_desc.ByteWidth = m_vertex.limit * stride;
+		buffer_desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+		buffer_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-		bd.Usage = D3D11_USAGE_DYNAMIC;
-		bd.ByteWidth = m_vertex.limit * stride;
-		bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-		bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+		HRESULT hr = m_dev->CreateBuffer(&buffer_desc, nullptr, &m_vb);
 
-		HRESULT hr;
-
-		hr = m_dev->CreateBuffer(&bd, NULL, &m_vb);
-
-		if(FAILED(hr)) return false;
+		if (FAILED(hr)) 
+			return false;
 	}
 
 	D3D11_MAP type = D3D11_MAP_WRITE_NO_OVERWRITE;
@@ -1226,7 +1223,7 @@ bool GSDevice11::IAMapVertexBuffer(void** vertex, size_t stride, size_t count)
 
 	D3D11_MAPPED_SUBRESOURCE m;
 
-	if(FAILED(m_ctx->Map(m_vb, 0, type, 0, &m)))
+	if (FAILED(m_ctx->Map(m_vb, 0, type, 0, &m)))
 	{
 		return false;
 	}

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -294,28 +294,26 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 {
 	auto i = std::as_const(m_om_dss).find(dssel);
 
-	if(i == m_om_dss.end())
+	if (i == m_om_dss.end())
 	{
-		D3D11_DEPTH_STENCIL_DESC dsd;
+		D3D11_DEPTH_STENCIL_DESC depth_stencil_desc = {};
 
-		memset(&dsd, 0, sizeof(dsd));
-
-		if(dssel.date)
+		if (dssel.date)
 		{
-			dsd.StencilEnable = true;
-			dsd.StencilReadMask = 1;
-			dsd.StencilWriteMask = 1;
-			dsd.FrontFace.StencilFunc = D3D11_COMPARISON_EQUAL;
-			dsd.FrontFace.StencilPassOp = dssel.date_one ? D3D11_STENCIL_OP_ZERO : D3D11_STENCIL_OP_KEEP;
-			dsd.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
-			dsd.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
-			dsd.BackFace.StencilFunc = D3D11_COMPARISON_EQUAL;
-			dsd.BackFace.StencilPassOp = dssel.date_one ? D3D11_STENCIL_OP_ZERO : D3D11_STENCIL_OP_KEEP;
-			dsd.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
-			dsd.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+			depth_stencil_desc.StencilEnable = true;
+			depth_stencil_desc.StencilReadMask = 1;
+			depth_stencil_desc.StencilWriteMask = 1;
+			depth_stencil_desc.FrontFace.StencilFunc = D3D11_COMPARISON_EQUAL;
+			depth_stencil_desc.FrontFace.StencilPassOp = dssel.date_one ? D3D11_STENCIL_OP_ZERO : D3D11_STENCIL_OP_KEEP;
+			depth_stencil_desc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+			depth_stencil_desc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+			depth_stencil_desc.BackFace.StencilFunc = D3D11_COMPARISON_EQUAL;
+			depth_stencil_desc.BackFace.StencilPassOp = dssel.date_one ? D3D11_STENCIL_OP_ZERO : D3D11_STENCIL_OP_KEEP;
+			depth_stencil_desc.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+			depth_stencil_desc.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
 		}
 
-		if(dssel.ztst != ZTST_ALWAYS || dssel.zwe)
+		if (dssel.ztst != ZTST_ALWAYS || dssel.zwe)
 		{
 			static const D3D11_COMPARISON_FUNC ztst[] =
 			{
@@ -325,14 +323,14 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 				D3D11_COMPARISON_GREATER
 			};
 
-			dsd.DepthEnable = true;
-			dsd.DepthWriteMask = dssel.zwe ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
-			dsd.DepthFunc = ztst[dssel.ztst];
+			depth_stencil_desc.DepthEnable = true;
+			depth_stencil_desc.DepthWriteMask = dssel.zwe ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
+			depth_stencil_desc.DepthFunc = ztst[dssel.ztst];
 		}
 
 		CComPtr<ID3D11DepthStencilState> dss;
 
-		m_dev->CreateDepthStencilState(&dsd, &dss);
+		m_dev->CreateDepthStencilState(&depth_stencil_desc, &dss);
 
 		m_om_dss[dssel] = dss;
 
@@ -343,41 +341,43 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 
 	auto j = std::as_const(m_om_bs).find(bsel);
 
-	if(j == m_om_bs.end())
+	if (j == m_om_bs.end())
 	{
-		D3D11_BLEND_DESC bd;
+		D3D11_BLEND_DESC blend_desc = {};
 
-		memset(&bd, 0, sizeof(bd));
-
-		bd.RenderTarget[0].BlendEnable = bsel.abe;
+		blend_desc.RenderTarget[0].BlendEnable = bsel.abe;
 
 		if(bsel.abe)
 		{
 			int i = ((bsel.a * 3 + bsel.b) * 3 + bsel.c) * 3 + bsel.d;
 
 			HWBlend blend = GetBlend(i);
-			bd.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
-			bd.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;
-			bd.RenderTarget[0].DestBlend = (D3D11_BLEND)blend.dst;
-			bd.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
-			bd.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
-			bd.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+			blend_desc.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
+			blend_desc.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;
+			blend_desc.RenderTarget[0].DestBlend = (D3D11_BLEND)blend.dst;
+			blend_desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+			blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+			blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
 
 			if (bsel.accu_blend)
 			{
-				bd.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
-				bd.RenderTarget[0].DestBlend = D3D11_BLEND_ONE;
+				blend_desc.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
+				blend_desc.RenderTarget[0].DestBlend = D3D11_BLEND_ONE;
 			}
 		}
 
-		if(bsel.wr) bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_RED;
-		if(bsel.wg) bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_GREEN;
-		if(bsel.wb) bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_BLUE;
-		if(bsel.wa) bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
+		uint8 write_mask = 0;
+
+		if (bsel.wr) write_mask |= D3D11_COLOR_WRITE_ENABLE_RED;
+		if (bsel.wg) write_mask |= D3D11_COLOR_WRITE_ENABLE_GREEN;
+		if (bsel.wb) write_mask |= D3D11_COLOR_WRITE_ENABLE_BLUE;
+		if (bsel.wa) write_mask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
+
+		blend_desc.RenderTarget[0].RenderTargetWriteMask = write_mask;
 
 		CComPtr<ID3D11BlendState> bs;
 
-		m_dev->CreateBlendState(&bd, &bs);
+		m_dev->CreateBlendState(&blend_desc, &bs);
 
 		m_om_bs[bsel] = bs;
 

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -28,58 +28,69 @@ bool GSDevice11::CreateTextureFX()
 {
 	HRESULT hr;
 
-	D3D11_BUFFER_DESC bd;
+	// Create Buffers
+	{
+		D3D11_BUFFER_DESC buffer_desc = {};
 
-	memset(&bd, 0, sizeof(bd));
+		buffer_desc.ByteWidth = sizeof(VSConstantBuffer);
+		buffer_desc.Usage = D3D11_USAGE_DEFAULT;
+		buffer_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 
-	bd.ByteWidth = sizeof(VSConstantBuffer);
-	bd.Usage = D3D11_USAGE_DEFAULT;
-	bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		hr = m_dev->CreateBuffer(&buffer_desc, nullptr, &m_vs_cb);
 
-	hr = m_dev->CreateBuffer(&bd, NULL, &m_vs_cb);
+		if (FAILED(hr))
+			return false;
+	}
 
-	if(FAILED(hr)) return false;
+	{
+		D3D11_BUFFER_DESC buffer_desc = {};
 
-	memset(&bd, 0, sizeof(bd));
+		buffer_desc.ByteWidth = sizeof(GSConstantBuffer);
+		buffer_desc.Usage = D3D11_USAGE_DEFAULT;
+		buffer_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 
-	bd.ByteWidth = sizeof(GSConstantBuffer);
-	bd.Usage = D3D11_USAGE_DEFAULT;
-	bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		hr = m_dev->CreateBuffer(&buffer_desc, nullptr, &m_gs_cb);
 
-	hr = m_dev->CreateBuffer(&bd, NULL, &m_gs_cb);
+		if (FAILED(hr))
+			return false;
+	}
 
-	if (FAILED(hr)) return false;
+	{
+		D3D11_BUFFER_DESC buffer_desc = {};
 
-	memset(&bd, 0, sizeof(bd));
+		buffer_desc.ByteWidth = sizeof(PSConstantBuffer);
+		buffer_desc.Usage = D3D11_USAGE_DEFAULT;
+		buffer_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 
-	bd.ByteWidth = sizeof(PSConstantBuffer);
-	bd.Usage = D3D11_USAGE_DEFAULT;
-	bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+		hr = m_dev->CreateBuffer(&buffer_desc, nullptr, &m_ps_cb);
 
-	hr = m_dev->CreateBuffer(&bd, NULL, &m_ps_cb);
+		if (FAILED(hr))
+			return false;
+	}
 
-	if(FAILED(hr)) return false;
+	// Create samplers
+	{
+		D3D11_SAMPLER_DESC sampler_desc = {};
 
-	D3D11_SAMPLER_DESC sd;
+		sampler_desc.Filter = theApp.GetConfigI("MaxAnisotropy") && !theApp.GetConfigB("paltex") ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_POINT;
+		sampler_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sampler_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sampler_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		sampler_desc.MinLOD = -FLT_MAX;
+		sampler_desc.MaxLOD = FLT_MAX;
+		sampler_desc.MaxAnisotropy = theApp.GetConfigI("MaxAnisotropy");
+		sampler_desc.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
-	memset(&sd, 0, sizeof(sd));
+		hr = m_dev->CreateSamplerState(&sampler_desc, &m_palette_ss);
 
-	sd.Filter = theApp.GetConfigI("MaxAnisotropy") && !theApp.GetConfigB("paltex") ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_POINT;
-	sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-	sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-	sd.MinLOD = -FLT_MAX;
-	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = theApp.GetConfigI("MaxAnisotropy");
-	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
+		if (FAILED(hr))
+			return false;
 
-	hr = m_dev->CreateSamplerState(&sd, &m_palette_ss);
+		hr = m_dev->CreateSamplerState(&sampler_desc, &m_rt_ss);
 
-	if(FAILED(hr)) return false;
-
-	hr = m_dev->CreateSamplerState(&sd, &m_rt_ss);
-
-	if(FAILED(hr)) return false;
+		if (FAILED(hr))
+			return false;
+	}
 
 	// create layout
 


### PR DESCRIPTION
Update the following functions: Create, CreateSurface, IAMapVertexBuffer, IASetIndexBuffer, OMSetRenderTargets, SetupOM, StretchRect(for sonic workaround).

Get rid of memsets, rename structure device descriptions to improve readability, use nullpointears instead of old NULLs on the same functions, some tweaks on Colormask code in SetupOM.

Add missing HRESULT check on Create functions that require it.