### PR TITLE
GSdx-HW: Dithering on Hardware

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -375,6 +375,7 @@ void GSdxApp::Init()
 	m_default_configuration["debug_glsl_shader"]                          = "0";
 	m_default_configuration["debug_opengl"]                               = "0";
 	m_default_configuration["disable_hw_gl_draw"]                         = "0";
+	m_default_configuration["dithering_ps2"]                              = "1";
 	m_default_configuration["dump"]                                       = "0";
 	m_default_configuration["extrathreads"]                               = "2";
 	m_default_configuration["extrathreads_height"]                        = "4";

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -49,6 +49,7 @@ GSRenderer::GSRenderer()
 	m_fxaa        = theApp.GetConfigB("fxaa");
 	m_shaderfx    = theApp.GetConfigB("shaderfx");
 	m_shadeboost  = theApp.GetConfigB("ShadeBoost");
+	m_dithering   = theApp.GetConfigI("dithering_ps2"); // 0 off, 1 auto, 2 auto no scale
 }
 
 GSRenderer::~GSRenderer()
@@ -572,6 +573,7 @@ void GSRenderer::KeyEvent(GSKeyEventData* e)
 #define VK_DELETE XK_Delete
 #define VK_INSERT XK_Insert
 #define VK_PRIOR XK_Prior
+#define VK_NEXT XK_Next
 #define VK_HOME XK_Home
 #endif
 
@@ -610,6 +612,11 @@ void GSRenderer::KeyEvent(GSKeyEventData* e)
 			m_shaderfx = !m_shaderfx;
 			theApp.SetConfig("shaderfx", m_shaderfx);
 			printf("GSdx: External post-processing is now %s.\n", m_shaderfx ? "enabled" : "disabled");
+			return;
+		case VK_NEXT: // As requested by Prafull, to be removed later
+			char dither_msg[3][16] = {"disabled", "auto", "auto unscaled"};
+			m_dithering = (m_dithering+1)%3;
+			printf("GSdx: Dithering is now %s.\n", dither_msg[m_dithering]);
 			return;
 		}
 

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -38,6 +38,7 @@ class GSRenderer : public GSState
 	bool m_control_key;
 
 protected:
+	int m_dithering;
 	int m_interlace;
 	int m_aspectratio;
 	int m_vsync;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -103,6 +103,7 @@ public:
 
 		GSVector4 TC_OffsetHack;
 		GSVector4 Af;
+		GSVector4 DitherMatrix[4];
 
 		PSConstantBuffer()
 		{
@@ -115,6 +116,11 @@ public:
 			ChannelShuffle = GSVector4i::zero();
 			FbMask = GSVector4i::zero();
 			Af = GSVector4::zero();
+
+			DitherMatrix[0] = GSVector4::zero();
+			DitherMatrix[1] = GSVector4::zero();
+			DitherMatrix[2] = GSVector4::zero();
+			DitherMatrix[3] = GSVector4::zero();
 		}
 
 		__forceinline bool Update(const PSConstantBuffer* cb)
@@ -123,7 +129,8 @@ public:
 			GSVector4i* b = (GSVector4i*)cb;
 
 			if(!((a[0] == b[0]) /*& (a[1] == b1)*/ & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4]) & (a[5] == b[5]) &
-				(a[6] == b[6]) & (a[7] == b[7]) & (a[9] == b[9])).alltrue()) // if WH matches HalfTexel does too
+				(a[6] == b[6]) & (a[7] == b[7]) & (a[9] == b[9]) & // if WH matches HalfTexel does too
+				(a[10] == b[10]) & (a[11] == b[11]) & (a[12] == b[12]) & (a[13] == b[13])).alltrue())
 			{
 				a[0] = b[0];
 				a[1] = b[1];
@@ -134,6 +141,11 @@ public:
 				a[6] = b[6];
 				a[7] = b[7];
 				a[9] = b[9];
+
+				a[10] = b[10];
+				a[11] = b[11];
+				a[12] = b[12];
+				a[13] = b[13];
 
 				return true;
 			}
@@ -211,16 +223,20 @@ public:
 				uint32 fbmask:1;
 
 				// Blend and Colclip
+				uint32 hdr:1;
 				uint32 blend_a:2;
-				uint32 blend_b:2;
-				uint32 blend_c:2;
+				uint32 blend_b:2; // bit30/31
+				uint32 blend_c:2; // bit0
 				uint32 blend_d:2;
 				uint32 clr1:1;
-				uint32 hdr:1;
+
 				uint32 colclip:1;
 
 				// Others ways to fetch the texture
 				uint32 channel:3;
+
+				// Dithering
+				uint32 dither:2;
 
 				// Hack
 				uint32 tcoffsethack:1;
@@ -229,7 +245,7 @@ public:
 				uint32 point_sampler:1;
 				uint32 invalid_tex0:1; // Lupin the 3rd
 
-				uint32 _free:18;
+				uint32 _free:16;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -982,6 +982,16 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 	}
 
 	m_ps_sel.fba = m_context->FBA.FBA;
+	m_ps_sel.dither = m_dithering > 0 && m_ps_sel.dfmt == 2 && m_env.DTHE.DTHE;
+
+	if(m_ps_sel.dither)
+	{
+		m_ps_sel.dither = m_dithering;
+		ps_cb.DitherMatrix[0] = GSVector4(m_env.DIMX.DM00, m_env.DIMX.DM10, m_env.DIMX.DM20, m_env.DIMX.DM30);
+		ps_cb.DitherMatrix[1] = GSVector4(m_env.DIMX.DM01, m_env.DIMX.DM11, m_env.DIMX.DM21, m_env.DIMX.DM31);
+		ps_cb.DitherMatrix[2] = GSVector4(m_env.DIMX.DM02, m_env.DIMX.DM12, m_env.DIMX.DM22, m_env.DIMX.DM32);
+		ps_cb.DitherMatrix[3] = GSVector4(m_env.DIMX.DM03, m_env.DIMX.DM13, m_env.DIMX.DM23, m_env.DIMX.DM33);
+	}
 
 	if (PRIM->FGE)
 	{

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -219,6 +219,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		sm.AddMacro("PS_BLEND_B", sel.blend_b);
 		sm.AddMacro("PS_BLEND_C", sel.blend_c);
 		sm.AddMacro("PS_BLEND_D", sel.blend_d);
+		sm.AddMacro("PS_DITHER", sel.dither);
 
 		CComPtr<ID3D11PixelShader> ps;
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -28,7 +28,6 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_custom_width(1024)
 	, m_custom_height(1024)
 	, m_reset(false)
-	, m_upscale_multiplier(1)
 	, m_userhacks_ts_half_bottom(-1)
 	, m_tc(tc)
 	, m_src(nullptr)
@@ -42,6 +41,7 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
 	m_large_framebuffer  = theApp.GetConfigB("large_framebuffer");
 	m_accurate_date = theApp.GetConfigI("accurate_date");
+	m_dithering = theApp.GetConfigI("dithering_ps2"); // 0 off, 1 auto, 2 auto no scale
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_userhacks_enabled_gs_mem_clear = !theApp.GetConfigB("UserHacks_Disable_Safe_Features");

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -41,7 +41,6 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
 	m_large_framebuffer  = theApp.GetConfigB("large_framebuffer");
 	m_accurate_date = theApp.GetConfigI("accurate_date");
-	m_dithering = theApp.GetConfigI("dithering_ps2"); // 0 off, 1 auto, 2 auto no scale
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_userhacks_enabled_gs_mem_clear = !theApp.GetConfigB("UserHacks_Disable_Safe_Features");

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -158,7 +158,6 @@ protected:
 
 	int m_accurate_date;
 	int m_sw_blending;
-	int m_dithering;
 
 	bool m_channel_shuffle;
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -158,6 +158,7 @@ protected:
 
 	int m_accurate_date;
 	int m_sw_blending;
+	int m_dithering;
 
 	bool m_channel_shuffle;
 

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -982,6 +982,7 @@ GLuint GSDeviceOGL::CompilePS(PSSelector sel)
 		+ format("#define PS_WRITE_RG %d\n", sel.write_rg)
 		+ format("#define PS_FBMASK %d\n", sel.fbmask)
 		+ format("#define PS_HDR %d\n", sel.hdr)
+		+ format("#define PS_DITHER %d\n", sel.dither)
 		// + format("#define PS_PABE %d\n", sel.pabe)
 	;
 

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -197,6 +197,7 @@ public:
 		GSVector4 HalfTexel;
 		GSVector4 MinMax;
 		GSVector4 TC_OH_TS;
+		GSVector4 DitherMatrix[4];
 
 		PSConstantBuffer()
 		{
@@ -208,6 +209,11 @@ public:
 			MskFix        = GSVector4i::zero();
 			TC_OH_TS      = GSVector4::zero();
 			FbMask        = GSVector4i::zero();
+
+			DitherMatrix[0] = GSVector4::zero();
+			DitherMatrix[1] = GSVector4::zero();
+			DitherMatrix[2] = GSVector4::zero();
+			DitherMatrix[3] = GSVector4::zero();
 		}
 
 		__forceinline bool Update(const PSConstantBuffer* cb)
@@ -217,7 +223,8 @@ public:
 
 			// if WH matches both HalfTexel and TC_OH_TS do too
 			// MinMax depends on WH and MskFix so no need to check it too
-			if(!((a[0] == b[0]) & (a[1] == b[1]) & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4])).alltrue())
+			if(!((a[0] == b[0]) & (a[1] == b[1]) & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4])
+				& (a[8] == b[8]) & (a[9] == b[9]) & (a[10] == b[10]) & (a[11] == b[11])).alltrue())
 			{
 				// Note previous check uses SSE already, a plain copy will be faster than any memcpy
 				a[0] = b[0];
@@ -226,6 +233,11 @@ public:
 				a[3] = b[3];
 				a[4] = b[4];
 				a[5] = b[5];
+
+				a[8] = b[8];
+				a[9] = b[9];
+				a[10] = b[10];
+				a[11] = b[11];
 
 				return true;
 			}
@@ -287,6 +299,9 @@ public:
 				// Others ways to fetch the texture
 				uint32 channel:3;
 
+				// Dithering
+				uint32 dither:2;
+
 				// Hack
 				uint32 tcoffsethack:1;
 				uint32 urban_chaos_hle:1;
@@ -297,7 +312,7 @@ public:
 				uint32 point_sampler:1;
 				uint32 invalid_tex0:1; // Lupin the 3rd
 
-				uint32 _free2:10;
+				uint32 _free2:8;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -1207,6 +1207,18 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	}
 
 	m_ps_sel.fba = m_context->FBA.FBA;
+	m_ps_sel.dither = m_dithering > 0 && m_ps_sel.dfmt == 2 && m_env.DTHE.DTHE;
+
+	if (m_ps_sel.dither)
+	{
+		GL_INS("DITHERING mode ENABLED (%d)", m_dithering);
+
+		m_ps_sel.dither = m_dithering;
+		ps_cb.DitherMatrix[0] = GSVector4(m_env.DIMX.DM00, m_env.DIMX.DM01, m_env.DIMX.DM02, m_env.DIMX.DM03);
+		ps_cb.DitherMatrix[1] = GSVector4(m_env.DIMX.DM10, m_env.DIMX.DM11, m_env.DIMX.DM12, m_env.DIMX.DM13);
+		ps_cb.DitherMatrix[2] = GSVector4(m_env.DIMX.DM20, m_env.DIMX.DM21, m_env.DIMX.DM22, m_env.DIMX.DM23);
+		ps_cb.DitherMatrix[3] = GSVector4(m_env.DIMX.DM30, m_env.DIMX.DM31, m_env.DIMX.DM32, m_env.DIMX.DM33);
+	}
 
 	if (PRIM->FGE)
 	{

--- a/plugins/GSdx/res/glsl/common_header.glsl
+++ b/plugins/GSdx/res/glsl/common_header.glsl
@@ -94,6 +94,8 @@ layout(std140, binding = 21) uniform cb21
 
     vec2 TextureScale;
     vec2 TC_OffsetHack;
+
+    mat4 DitherMatrix;
 };
 #endif
 


### PR DESCRIPTION
WIP: Initial basic implementation of dithering on the hardware renderers.

There's currently no check for dither matrix changes for buffers to be updated. **Edit: done.**
There's also no check for framebuffer format, in case it should only be enabled on some. **Edit: done.**
It currently does not scale with increased internal resolution. I kinda like the smaller dithering though.  **Edit: done, setting.**

SW renderer shows a darker more pronounced dithering although pattern seems to match.   **Edit: OpenGL can be pretty close to SW dithering.**

There should also be a setting to toggle dithering off, as many people seem to dislike the effect.  **Edit: done, setting.**

~~**TODO:** Move dither matrix to its own buffer.~~ Should be done when doing a constant buffer overhaul.