### PR TITLE
Spu2-x: Fix noise generator

### DIFF
--- a/plugins/spu2-x/src/Mixer.cpp
+++ b/plugins/spu2-x/src/Mixer.cpp
@@ -257,7 +257,7 @@ static __forceinline void GetNextDataDummy(V_Core &thiscore, uint voiceidx)
 
 static s32 __forceinline GetNoiseValues()
 {
-    static s32 Seed = 0x41595321;
+    /*static s32 Seed = 0x41595321;
     s32 retval = 0x8000;
 
     if (Seed & 0x100)
@@ -272,7 +272,8 @@ static s32 __forceinline GetNoiseValues()
     y ^= x;
     Seed = _rotr(y, 0x3);
 
-    return retval;
+    return retval;*/
+    return (s32)(rand() & 0xFF) << 8;
 }
 /////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/spu2-x/src/Mixer.cpp
+++ b/plugins/spu2-x/src/Mixer.cpp
@@ -257,23 +257,12 @@ static __forceinline void GetNextDataDummy(V_Core &thiscore, uint voiceidx)
 
 static s32 __forceinline GetNoiseValues()
 {
-    /*static s32 Seed = 0x41595321;
-    s32 retval = 0x8000;
+    static u16 lfsr = 0xC0FEu;
 
-    if (Seed & 0x100)
-        retval = (Seed & 0xff) << 8;
-    else if (Seed & 0xffff)
-        retval = 0x7fff;
+    u16 bit = lfsr ^ (lfsr << 3) ^ (lfsr << 4) ^ (lfsr << 5);
+    lfsr = (lfsr << 1) | (bit >> 15);
 
-    s32 x = _rotr(Seed, 0x5);
-    x ^= 0x9a;
-    s32 y = _rotl(x, 0x2);
-    y += x;
-    y ^= x;
-    Seed = _rotr(y, 0x3);
-
-    return retval;*/
-    return (s32)(rand() & 0xFF) << 8;
+    return (s16)lfsr;
 }
 /////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes the noise generator outputting a 4.8 kHz tone instead of white noise. The random number generator used in GetNoiseValues currently repeats every 10 samples, which is really really awful for a random number generator.

Here's what it sounded like before the fix: https://streamable.com/pa1fi
Here's what it sounds like after the fix: https://streamable.com/u5zhi
Here's what it sounds like on a real PS2: https://streamable.com/ipi5s

Not entirely accurate but a massive improvement over playing a 4.8 kHz tone.