### PR TITLE
GSdx-hw: Add OI rendering fix for Big Mutha Truckers

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -42,16 +42,14 @@ bool GSC_BigMuthaTruckers(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
 	{
-		if(fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x00a00) && fi.FPSM == fi.TPSM && fi.TPSM == PSM_PSMCT16)
+		if(fi.TME && (fi.TBP0 == 0x01400 || fi.TBP0 == 0x012c0) && fi.FPSM == fi.TPSM && fi.TPSM == PSM_PSMCT16)
 		{
-			// A real mess.
-			// Half screen bottom and vertical stripes issues.
-			//
-			// HDR colclip/conclip not supported,
-			// Depth target lookup,
-			// Texture shuffle and SW emulated fbmask.
-			// https://github.com/PCSX2/pcsx2/issues/2449
-			skip = 3;
+			// Mid-texture pointer is a cache miss,
+			// luckily we replace a half-screen TS effect with a full-screen one in 
+			// EmulateTextureShuffleAndFbmask (see #2934).
+			// While this works for the time being, it's not ideal.
+			// Skip the unneeded extra TS draw.
+			skip = 1;
 		}
 	}
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -52,6 +52,7 @@ private:
 	void OI_GsMemClear(); // always on
 	void OI_DoubleHalfClear(GSTexture* rt, GSTexture* ds); // always on
 
+	bool OI_BigMuthaTruckers(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_FFXII(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_FFX(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_MetalSlug6(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);


### PR DESCRIPTION
Idea is to add an offset so the shadows get rendered properly at the half bottom screen.

Ease the crc hack to only skip misdetection of texture shuffle.

Issue #2449 