### PR TITLE
GSDumpGUI: Usability improvements

### DIFF
--- a/tools/GSDumpGUI/Core/Program.cs
+++ b/tools/GSDumpGUI/Core/Program.cs
@@ -48,7 +48,7 @@ namespace GSDumpGUI
 
         static private TreeNode CurrentNode;
         static public IntPtr hMainIcon;
-        static public bool prog_running;
+        static public bool isProgRunning;
 
         [STAThread]
         static void Main(String[] args)
@@ -118,14 +118,14 @@ namespace GSDumpGUI
                 Server.OnClientAfterConnect += new TCPLibrary.Core.Server.ConnectedHandler(Server_OnClientAfterConnect);
                 Server.OnClientAfterDisconnected += new TCPLibrary.Core.Server.DisconnectedHandler(Server_OnClientAfterDisconnected);
                 Server.Enabled = true;
-                prog_running = true;
+                isProgRunning = true;
 
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
                 frmMain = new GSDumpGUI();
                 Application.Run(frmMain);
 
-                prog_running = false;
+                isProgRunning = false;
                 Server.Enabled = false;
             }
         }

--- a/tools/GSDumpGUI/Core/Program.cs
+++ b/tools/GSDumpGUI/Core/Program.cs
@@ -48,6 +48,7 @@ namespace GSDumpGUI
 
         static private TreeNode CurrentNode;
         static public IntPtr hMainIcon;
+        static public bool prog_running;
 
         [STAThread]
         static void Main(String[] args)
@@ -117,12 +118,14 @@ namespace GSDumpGUI
                 Server.OnClientAfterConnect += new TCPLibrary.Core.Server.ConnectedHandler(Server_OnClientAfterConnect);
                 Server.OnClientAfterDisconnected += new TCPLibrary.Core.Server.DisconnectedHandler(Server_OnClientAfterDisconnected);
                 Server.Enabled = true;
+                prog_running = true;
 
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
                 frmMain = new GSDumpGUI();
                 Application.Run(frmMain);
 
+                prog_running = false;
                 Server.Enabled = false;
             }
         }

--- a/tools/GSDumpGUI/Core/Program.cs
+++ b/tools/GSDumpGUI/Core/Program.cs
@@ -48,7 +48,6 @@ namespace GSDumpGUI
 
         static private TreeNode CurrentNode;
         static public IntPtr hMainIcon;
-        static public bool isProgRunning;
 
         [STAThread]
         static void Main(String[] args)
@@ -118,14 +117,15 @@ namespace GSDumpGUI
                 Server.OnClientAfterConnect += new TCPLibrary.Core.Server.ConnectedHandler(Server_OnClientAfterConnect);
                 Server.OnClientAfterDisconnected += new TCPLibrary.Core.Server.DisconnectedHandler(Server_OnClientAfterDisconnected);
                 Server.Enabled = true;
-                isProgRunning = true;
 
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
-                frmMain = new GSDumpGUI();
-                Application.Run(frmMain);
 
-                isProgRunning = false;
+                using (frmMain = new GSDumpGUI())
+                {
+                    Application.Run(frmMain);
+                }
+
                 Server.Enabled = false;
             }
         }

--- a/tools/GSDumpGUI/Core/Program.cs
+++ b/tools/GSDumpGUI/Core/Program.cs
@@ -43,17 +43,19 @@ namespace GSDumpGUI
         static public List<TCPLibrary.MessageBased.Core.BaseMessageClientS> Clients;
 
         static public TCPLibrary.MessageBased.Core.BaseMessageClient Client;
-        static private Boolean ChangeIcon;
         static private GSDump dump;
         static private GSDXWrapper wrap;
 
         static private TreeNode CurrentNode;
+        static public IntPtr hMainIcon;
 
         [STAThread]
         static void Main(String[] args)
         {
             if (args.Length == 5)
             {
+                hMainIcon = Resources.AppIcon.Handle;
+
                 // do this first, else racy mess ;)
                 wrap = new GSDXWrapper();
                 var port = Convert.ToInt32(args[4]);
@@ -68,29 +70,6 @@ namespace GSDumpGUI
                 {
                     Client = null;
                 }
-
-                Thread thd = new Thread(new ThreadStart(delegate
-                {
-                    while (true)
-                    {
-                        IntPtr pt = Process.GetCurrentProcess().MainWindowHandle;
-                        if (ChangeIcon)
-                        {
-                            if (pt.ToInt64() != 0)
-                            {
-                                NativeMethods.SetClassLong(pt, -14, Resources.AppIcon.Handle.ToInt64());
-                                ChangeIcon = false;
-                            }
-                        }
-
-                        Int32 tmp = NativeMethods.GetAsyncKeyState(0x1b) & 0xf;
-                        if (tmp != 0)
-                            Process.GetCurrentProcess().Kill();
-                        Thread.Sleep(16);
-                    }
-                }));
-                thd.IsBackground = true;
-                thd.Start();
 
                 // Retrieve parameters
                 String DLLPath = args[0];
@@ -111,7 +90,6 @@ namespace GSDumpGUI
                     }
 
                     wrap.Run(dump, Renderer);
-                    ChangeIcon = true;
                 }
                 else
                     wrap.GSConfig();

--- a/tools/GSDumpGUI/Forms/Helper/GsDumpFinder.cs
+++ b/tools/GSDumpGUI/Forms/Helper/GsDumpFinder.cs
@@ -53,7 +53,7 @@ namespace GSDumpGUI.Forms.Helper
             foreach (var dump in dumps)
             {
                 int crc;
-                using (var fileStream = File.Open(dump.FullName, FileMode.Open))
+                using (var fileStream = File.OpenRead(dump.FullName))
                 {
                     using (var br = new BinaryReader(fileStream))
                     {

--- a/tools/GSDumpGUI/Forms/frmMain.Designer.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.Designer.cs
@@ -95,7 +95,7 @@
             this.txtGSDXDirectory.Size = new System.Drawing.Size(243, 20);
             this.txtGSDXDirectory.TabIndex = 0;
             this.txtGSDXDirectory.TabStop = false;
-			this.txtGSDXDirectory.Enter += new System.EventHandler(this.txtGSDXDirectory_Enter);
+            this.txtGSDXDirectory.Enter += new System.EventHandler(this.txtGSDXDirectory_Enter);
             this.txtGSDXDirectory.Leave += new System.EventHandler(this.txtGSDXDirectory_Leave);
             // 
             // lblDirectory
@@ -145,7 +145,7 @@
             this.txtDumpsDirectory.Size = new System.Drawing.Size(243, 20);
             this.txtDumpsDirectory.TabIndex = 3;
             this.txtDumpsDirectory.TabStop = false;
-			this.txtDumpsDirectory.Enter += new System.EventHandler(this.txtDumpsDirectory_Enter);
+            this.txtDumpsDirectory.Enter += new System.EventHandler(this.txtDumpsDirectory_Enter);
             this.txtDumpsDirectory.Leave += new System.EventHandler(this.txtDumpsDirectory_Leave);
             // 
             // lstGSDX

--- a/tools/GSDumpGUI/Forms/frmMain.Designer.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.Designer.cs
@@ -13,9 +13,12 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                DisposeExtra();
+
+                if (components != null)
+                    components.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/tools/GSDumpGUI/Forms/frmMain.Designer.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.Designer.cs
@@ -97,6 +97,7 @@
             this.txtGSDXDirectory.TabStop = false;
             this.txtGSDXDirectory.Enter += new System.EventHandler(this.txtGSDXDirectory_Enter);
             this.txtGSDXDirectory.Leave += new System.EventHandler(this.txtGSDXDirectory_Leave);
+            this.txtGSDXDirectory.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtGSDXDirectory_KeyDown);
             // 
             // lblDirectory
             // 
@@ -147,6 +148,7 @@
             this.txtDumpsDirectory.TabStop = false;
             this.txtDumpsDirectory.Enter += new System.EventHandler(this.txtDumpsDirectory_Enter);
             this.txtDumpsDirectory.Leave += new System.EventHandler(this.txtDumpsDirectory_Leave);
+            this.txtDumpsDirectory.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtDumpsDirectory_KeyDown);
             // 
             // lstGSDX
             // 

--- a/tools/GSDumpGUI/Forms/frmMain.Designer.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.Designer.cs
@@ -95,6 +95,7 @@
             this.txtGSDXDirectory.Size = new System.Drawing.Size(243, 20);
             this.txtGSDXDirectory.TabIndex = 0;
             this.txtGSDXDirectory.TabStop = false;
+			this.txtGSDXDirectory.Enter += new System.EventHandler(this.txtGSDXDirectory_Enter);
             this.txtGSDXDirectory.Leave += new System.EventHandler(this.txtGSDXDirectory_Leave);
             // 
             // lblDirectory
@@ -144,6 +145,7 @@
             this.txtDumpsDirectory.Size = new System.Drawing.Size(243, 20);
             this.txtDumpsDirectory.TabIndex = 3;
             this.txtDumpsDirectory.TabStop = false;
+			this.txtDumpsDirectory.Enter += new System.EventHandler(this.txtDumpsDirectory_Enter);
             this.txtDumpsDirectory.Leave += new System.EventHandler(this.txtDumpsDirectory_Leave);
             // 
             // lstGSDX

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -494,7 +494,7 @@ namespace GSDumpGUI
 
         private void GSDumpGUI_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyCode == Keys.Return)
+            if (e.KeyCode == Keys.Return && !txtGSDXDirectory.Focused && !txtDumpsDirectory.Focused)
                 cmdRun_Click(sender, e);
 
             if (e.KeyCode == Keys.F1)
@@ -524,7 +524,22 @@ namespace GSDumpGUI
         private void txtGSDXDirectory_Leave(object sender, EventArgs e)
         {
             string newpath = txtGSDXDirectory.Text;
+            if (!_gsdxPathOld.ToLower().Equals(newpath.ToLower()))
+                txtGSDXDirectory.Text = _gsdxPathOld;
+        }
 
+        private void txtDumpsDirectory_Leave(object sender, EventArgs e)
+        {
+            string newpath = txtDumpsDirectory.Text;
+            if(!_dumpPathOld.ToLower().Equals(newpath.ToLower()))
+                txtDumpsDirectory.Text = _dumpPathOld;
+        }
+
+        private void txtGSDXDirectory_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode != Keys.Return) return;
+
+            string newpath = txtGSDXDirectory.Text;
             if (!String.IsNullOrEmpty(newpath) &&
                 !_gsdxPathOld.ToLower().Equals(newpath.ToLower()) &&
                 Directory.Exists(newpath))
@@ -536,10 +551,11 @@ namespace GSDumpGUI
             }
         }
 
-        private void txtDumpsDirectory_Leave(object sender, EventArgs e)
+        private void txtDumpsDirectory_KeyDown(object sender, KeyEventArgs e)
         {
-            string newpath = txtDumpsDirectory.Text;
+            if (e.KeyCode != Keys.Return) return;
 
+            string newpath = txtDumpsDirectory.Text;
             if (!String.IsNullOrEmpty(newpath) &&
                 !_dumpPathOld.ToLower().Equals(newpath.ToLower()) &&
                 Directory.Exists(newpath))

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -116,7 +116,7 @@ namespace GSDumpGUI
 
             _availableGsDumps.OnIndexUpdatedEvent += UpdatePreviewImage;
 
-            this.Text += " " + (IntPtr.Size * 8).ToString() + "bits";
+            this.Text += Environment.Is64BitProcess ? " 64bits" : " 32bits";
 
             if (String.IsNullOrEmpty(Settings.GSDXDir) || !Directory.Exists(Settings.GSDXDir))
                 Settings.GSDXDir = AppDomain.CurrentDomain.BaseDirectory;
@@ -217,7 +217,7 @@ namespace GSDumpGUI
 
             _dllWatcher.Clear();
 
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i < paths.Length; i++)
             {
                 try
                 {
@@ -256,7 +256,7 @@ namespace GSDumpGUI
 
             _dumpWatcher.Clear();
 
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < paths.Length; i++)
             {
                 try
                 {
@@ -294,7 +294,7 @@ namespace GSDumpGUI
             if(ofd.ShowDialog() == DialogResult.OK)
             {
                 string newpath = Path.GetDirectoryName(ofd.FileName);
-                if (!Settings.GSDXDir.ToLower().Equals(newpath.ToLower()))
+                if (!Settings.GSDXDir.Equals(newpath, StringComparison.OrdinalIgnoreCase))
                 {
                     txtGSDXDirectory.Text = newpath;
                     Settings.GSDXDir = newpath;
@@ -317,7 +317,7 @@ namespace GSDumpGUI
             if (ofd.ShowDialog() == DialogResult.OK)
             {
                 string newpath = Path.GetDirectoryName(ofd.FileName);
-                if (!Settings.DumpDir.ToLower().Equals(newpath.ToLower()))
+                if (!Settings.DumpDir.Equals(newpath, StringComparison.OrdinalIgnoreCase))
                 {
                     txtDumpsDirectory.Text = newpath;
                     Settings.DumpDir = newpath;
@@ -524,46 +524,50 @@ namespace GSDumpGUI
         private void txtGSDXDirectory_Leave(object sender, EventArgs e)
         {
             string newpath = txtGSDXDirectory.Text;
-            if (!_gsdxPathOld.ToLower().Equals(newpath.ToLower()))
+            if (!_gsdxPathOld.Equals(newpath, StringComparison.OrdinalIgnoreCase))
                 txtGSDXDirectory.Text = _gsdxPathOld;
         }
 
         private void txtDumpsDirectory_Leave(object sender, EventArgs e)
         {
             string newpath = txtDumpsDirectory.Text;
-            if(!_dumpPathOld.ToLower().Equals(newpath.ToLower()))
+            if(!_dumpPathOld.Equals(newpath, StringComparison.OrdinalIgnoreCase))
                 txtDumpsDirectory.Text = _dumpPathOld;
         }
 
         private void txtGSDXDirectory_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyCode != Keys.Return) return;
-
-            string newpath = txtGSDXDirectory.Text;
-            if (!String.IsNullOrEmpty(newpath) &&
-                !_gsdxPathOld.ToLower().Equals(newpath.ToLower()) &&
-                Directory.Exists(newpath))
+            if (e.KeyCode == Keys.Return)
             {
-                Settings.GSDXDir = newpath;
-                Settings.Save();
-                ReloadGsdxDlls();
-                _availableGsDlls.Selected = _availableGsDlls.Files.FirstOrDefault();
+                string newpath = txtGSDXDirectory.Text;
+                if (!String.IsNullOrEmpty(newpath) &&
+                    !_gsdxPathOld.Equals(newpath, StringComparison.OrdinalIgnoreCase) &&
+                    Directory.Exists(newpath))
+                {
+                    _gsdxPathOld = newpath;
+                    Settings.GSDXDir = newpath;
+                    Settings.Save();
+                    ReloadGsdxDlls();
+                    _availableGsDlls.Selected = _availableGsDlls.Files.FirstOrDefault();
+                }
             }
         }
 
         private void txtDumpsDirectory_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyCode != Keys.Return) return;
-
-            string newpath = txtDumpsDirectory.Text;
-            if (!String.IsNullOrEmpty(newpath) &&
-                !_dumpPathOld.ToLower().Equals(newpath.ToLower()) &&
-                Directory.Exists(newpath))
+            if (e.KeyCode == Keys.Return)
             {
-                Settings.DumpDir = newpath;
-                Settings.Save();
-                ReloadGsdxDumps();
-                _availableGsDumps.Selected = _availableGsDumps.Files.FirstOrDefault();
+                string newpath = txtDumpsDirectory.Text;
+                if (!String.IsNullOrEmpty(newpath) &&
+                    !_dumpPathOld.Equals(newpath, StringComparison.OrdinalIgnoreCase) &&
+                    Directory.Exists(newpath))
+                {
+                    _dumpPathOld = newpath;
+                    Settings.DumpDir = newpath;
+                    Settings.Save();
+                    ReloadGsdxDumps();
+                    _availableGsDumps.Selected = _availableGsDumps.Files.FirstOrDefault();
+                }
             }
         }
 

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -398,8 +398,8 @@ namespace GSDumpGUI
             psi.FileName = Process.GetCurrentProcess().ProcessName;
             psi.Arguments = "\"" + dllPath + "\"" + " \"" + dumpPath + "\"" + " \"" + Function + "\"" + " " + SelectedRenderer + " " + port;
             Process p = Process.Start(psi);
-            p.OutputDataReceived += new DataReceivedEventHandler(p_OutputDataReceived);
-            p.ErrorDataReceived += new DataReceivedEventHandler(p_OutputDataReceived);
+            p.OutputDataReceived += new DataReceivedEventHandler(p_StdOutDataReceived);
+            p.ErrorDataReceived += new DataReceivedEventHandler(p_StdErrDataReceived);
             p.BeginOutputReadLine();
             p.Exited += new EventHandler(p_Exited);
             Processes.Add(p);
@@ -429,9 +429,14 @@ namespace GSDumpGUI
             Processes.Remove((Process)sender);
         }
 
-        private void p_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        private void p_StdOutDataReceived(object sender, DataReceivedEventArgs e)
         {
             _gsdxLogger.Information(e.Data);
+        }
+
+        private void p_StdErrDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            _gsdxLogger.Error(e.Data);
         }
 
         private void cmdConfigGSDX_Click(object sender, EventArgs e)

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -393,12 +393,13 @@ namespace GSDumpGUI
             ProcessStartInfo psi = new ProcessStartInfo();
             psi.UseShellExecute = false;
             psi.RedirectStandardOutput = true;
-            psi.RedirectStandardError = false;
+            psi.RedirectStandardError = true;
             psi.CreateNoWindow = true;
             psi.FileName = Process.GetCurrentProcess().ProcessName;
             psi.Arguments = "\"" + dllPath + "\"" + " \"" + dumpPath + "\"" + " \"" + Function + "\"" + " " + SelectedRenderer + " " + port;
             Process p = Process.Start(psi);
             p.OutputDataReceived += new DataReceivedEventHandler(p_OutputDataReceived);
+            p.ErrorDataReceived += new DataReceivedEventHandler(p_OutputDataReceived);
             p.BeginOutputReadLine();
             p.Exited += new EventHandler(p_Exited);
             Processes.Add(p);

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -401,6 +401,7 @@ namespace GSDumpGUI
             p.OutputDataReceived += new DataReceivedEventHandler(p_StdOutDataReceived);
             p.ErrorDataReceived += new DataReceivedEventHandler(p_StdErrDataReceived);
             p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
             p.Exited += new EventHandler(p_Exited);
             Processes.Add(p);
         }

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -116,6 +116,8 @@ namespace GSDumpGUI
 
             _availableGsDumps.OnIndexUpdatedEvent += UpdatePreviewImage;
 
+            this.Text += " " + (IntPtr.Size * 8).ToString() + "bits";
+
             if (String.IsNullOrEmpty(Settings.GSDXDir) || !Directory.Exists(Settings.GSDXDir))
                 Settings.GSDXDir = AppDomain.CurrentDomain.BaseDirectory;
 

--- a/tools/GSDumpGUI/Forms/frmMain.cs
+++ b/tools/GSDumpGUI/Forms/frmMain.cs
@@ -116,10 +116,10 @@ namespace GSDumpGUI
 
             _availableGsDumps.OnIndexUpdatedEvent += UpdatePreviewImage;
 
-            if (String.IsNullOrEmpty(Settings.GSDXDir))
+            if (String.IsNullOrEmpty(Settings.GSDXDir) || !Directory.Exists(Settings.GSDXDir))
                 Settings.GSDXDir = AppDomain.CurrentDomain.BaseDirectory;
 
-            if (String.IsNullOrEmpty(Settings.DumpDir))
+            if (String.IsNullOrEmpty(Settings.DumpDir) || !Directory.Exists(Settings.DumpDir))
                 Settings.DumpDir = AppDomain.CurrentDomain.BaseDirectory;
 
             txtGSDXDirectory.Text = Settings.GSDXDir;

--- a/tools/GSDumpGUI/GSDumpGUI.csproj
+++ b/tools/GSDumpGUI/GSDumpGUI.csproj
@@ -20,29 +20,47 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>6</LangVersion>
-    <Prefer32Bit>false</Prefer32Bit>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tools/GSDumpGUI/GSDumpGUI.sln
+++ b/tools/GSDumpGUI/GSDumpGUI.sln
@@ -1,20 +1,31 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GSDumpGUI", "GSDumpGUI.csproj", "{825E4311-652D-4A1E-8AA1-F6D81B186E33}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Debug|x64.ActiveCfg = Debug|x64
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Debug|x64.Build.0 = Debug|x64
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Debug|x86.ActiveCfg = Debug|x86
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Debug|x86.Build.0 = Debug|x86
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Release|x64.ActiveCfg = Release|x64
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Release|x64.Build.0 = Release|x64
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Release|x86.ActiveCfg = Release|x86
+		{825E4311-652D-4A1E-8AA1-F6D81B186E33}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {19DB287E-B866-4E97-B0AE-95CF54B00134}
 	EndGlobalSection
 EndGlobal

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -262,7 +262,7 @@ namespace GSDumpGUI
                                 }
                             }
 
-                            if (!Running)
+                            if (!Running || !NativeMethods.IsWindowVisible(hWnd))
                                 break;
 
                             if (DebugMode)

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -238,6 +238,9 @@ namespace GSDumpGUI
                         GSsetBaseMem(new IntPtr(pointer));
                         GSfreeze(0, new IntPtr(fr));
 
+                        GSData gsd_vsync = new GSData();
+                        gsd_vsync.id = GSType.VSync;
+
                         int gs_idx = 0;
                         int debug_idx = 0;
                         NativeMessage msg;
@@ -308,10 +311,7 @@ namespace GSDumpGUI
                                     ExternalEvent.Set();
                                 }
 
-                                GSData g = new GSData();
-                                g.id = GSType.VSync;
-                                Step(g, pointer);
-                                    
+                                Step(gsd_vsync, pointer);
                             }
                             else
                             {

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -215,7 +215,7 @@ namespace GSDumpGUI
 
                 GSsetGameCRC(dump.CRC, 0);
 
-                NativeMethods.SetClassLong(hWnd,/*GCL_HICON*/ -14, Program.hMainIcon.ToInt32());
+                NativeMethods.SetClassLong(hWnd,/*GCL_HICON*/ -14, (uint)Program.hMainIcon.ToInt32());
 
                 fixed (byte* freeze = dump.StateData)
                 {

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -315,9 +315,15 @@ namespace GSDumpGUI
                             }
                             else
                             {
-                                GSData itm = dump.Data[gs_idx++];
-                                CurrentGIFPacket = itm;
-                                Step(itm, pointer);
+                                while (gs_idx < dump.Data.Count)
+                                {
+                                    GSData itm = dump.Data[gs_idx++];
+                                    CurrentGIFPacket = itm;
+                                    Step(itm, pointer);
+
+                                    if (gs_idx < dump.Data.Count && dump.Data[gs_idx].id == GSType.VSync)
+                                        break;
+                                }
 
                                 if (gs_idx >= dump.Data.Count) gs_idx = 0;
                             }

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -101,62 +101,58 @@ namespace GSDumpGUI
                     Unload();
 
                 string dir = DLL;
-                while (true)
+                dir = Path.GetDirectoryName(dir);
+                if (dir == null) return;
+
+                Directory.SetCurrentDirectory(dir);
+                System.Diagnostics.Trace.WriteLine("LoadLibrary: " + DLL);
+                IntPtr hmod = NativeMethods.LoadLibrary(DLL);
+                if (hmod != IntPtr.Zero)
                 {
-                    dir = Path.GetDirectoryName(dir);
-                    if (dir == null)
-                        break;
-                    Directory.SetCurrentDirectory(dir);
-                    IntPtr hmod = NativeMethods.LoadLibrary(DLL);
-                    if (hmod.ToInt64() > 0)
-                    {
-                        DLLAddr = hmod;
+                    DLLAddr = hmod;
 
-                        IntPtr funcaddrLibName = NativeMethods.GetProcAddress(hmod, "PS2EgetLibName");
-                        IntPtr funcaddrConfig = NativeMethods.GetProcAddress(hmod, "GSconfigure");
+                    IntPtr funcaddrLibName = NativeMethods.GetProcAddress(hmod, "PS2EgetLibName");
+                    IntPtr funcaddrConfig = NativeMethods.GetProcAddress(hmod, "GSconfigure");
 
-                        IntPtr funcaddrGIF = NativeMethods.GetProcAddress(hmod, "GSgifTransfer");
-                        IntPtr funcaddrGIF1 = NativeMethods.GetProcAddress(hmod, "GSgifTransfer1");
-                        IntPtr funcaddrGIF2 = NativeMethods.GetProcAddress(hmod, "GSgifTransfer2");
-                        IntPtr funcaddrGIF3 = NativeMethods.GetProcAddress(hmod, "GSgifTransfer3");
-                        IntPtr funcaddrVSync = NativeMethods.GetProcAddress(hmod, "GSvsync");
-                        IntPtr funcaddrSetBaseMem = NativeMethods.GetProcAddress(hmod, "GSsetBaseMem");
-                        IntPtr funcaddrGSReset = NativeMethods.GetProcAddress(hmod, "GSreset");
-                        IntPtr funcaddrOpen = NativeMethods.GetProcAddress(hmod, "GSopen");
-                        IntPtr funcaddrSetCRC = NativeMethods.GetProcAddress(hmod, "GSsetGameCRC");
-                        IntPtr funcaddrClose = NativeMethods.GetProcAddress(hmod, "GSclose");
-                        IntPtr funcaddrShutdown = NativeMethods.GetProcAddress(hmod, "GSshutdown");
-                        IntPtr funcaddrFreeze = NativeMethods.GetProcAddress(hmod, "GSfreeze");
-                        IntPtr funcaddrGSreadFIFO2 = NativeMethods.GetProcAddress(hmod, "GSreadFIFO2");
-                        IntPtr funcaddrinit = NativeMethods.GetProcAddress(hmod, "GSinit");
-                        IntPtr funcmakeSnapshot = NativeMethods.GetProcAddress(hmod, "GSmakeSnapshot");
+                    IntPtr funcaddrGIF = NativeMethods.GetProcAddress(hmod, "GSgifTransfer");
+                    IntPtr funcaddrGIF1 = NativeMethods.GetProcAddress(hmod, "GSgifTransfer1");
+                    IntPtr funcaddrGIF2 = NativeMethods.GetProcAddress(hmod, "GSgifTransfer2");
+                    IntPtr funcaddrGIF3 = NativeMethods.GetProcAddress(hmod, "GSgifTransfer3");
+                    IntPtr funcaddrVSync = NativeMethods.GetProcAddress(hmod, "GSvsync");
+                    IntPtr funcaddrSetBaseMem = NativeMethods.GetProcAddress(hmod, "GSsetBaseMem");
+                    IntPtr funcaddrGSReset = NativeMethods.GetProcAddress(hmod, "GSreset");
+                    IntPtr funcaddrOpen = NativeMethods.GetProcAddress(hmod, "GSopen");
+                    IntPtr funcaddrSetCRC = NativeMethods.GetProcAddress(hmod, "GSsetGameCRC");
+                    IntPtr funcaddrClose = NativeMethods.GetProcAddress(hmod, "GSclose");
+                    IntPtr funcaddrShutdown = NativeMethods.GetProcAddress(hmod, "GSshutdown");
+                    IntPtr funcaddrFreeze = NativeMethods.GetProcAddress(hmod, "GSfreeze");
+                    IntPtr funcaddrGSreadFIFO2 = NativeMethods.GetProcAddress(hmod, "GSreadFIFO2");
+                    IntPtr funcaddrinit = NativeMethods.GetProcAddress(hmod, "GSinit");
+                    IntPtr funcmakeSnapshot = NativeMethods.GetProcAddress(hmod, "GSmakeSnapshot");
 
-                        if (!((funcaddrConfig.ToInt64() > 0) && (funcaddrLibName.ToInt64() > 0) && (funcaddrGIF.ToInt64() > 0)))
-                        {
-                            break;
-                        }
+                    if (!((funcaddrConfig.ToInt64() > 0) && (funcaddrLibName.ToInt64() > 0) && (funcaddrGIF.ToInt64() > 0)))
+                        throw new InvalidGSPlugin("");
 
-                        gsConfigure = (GSConfigure) Marshal.GetDelegateForFunctionPointer(funcaddrConfig, typeof(GSConfigure));
-                        PsegetLibName = (PSEgetLibName) Marshal.GetDelegateForFunctionPointer(funcaddrLibName, typeof(PSEgetLibName));
+                    gsConfigure = (GSConfigure) Marshal.GetDelegateForFunctionPointer(funcaddrConfig, typeof(GSConfigure));
+                    PsegetLibName = (PSEgetLibName) Marshal.GetDelegateForFunctionPointer(funcaddrLibName, typeof(PSEgetLibName));
 
-                        this.GSgifTransfer = (GSgifTransfer) Marshal.GetDelegateForFunctionPointer(funcaddrGIF, typeof(GSgifTransfer));
-                        this.GSgifTransfer1 = (GSgifTransfer1) Marshal.GetDelegateForFunctionPointer(funcaddrGIF1, typeof(GSgifTransfer1));
-                        this.GSgifTransfer2 = (GSgifTransfer2) Marshal.GetDelegateForFunctionPointer(funcaddrGIF2, typeof(GSgifTransfer2));
-                        this.GSgifTransfer3 = (GSgifTransfer3) Marshal.GetDelegateForFunctionPointer(funcaddrGIF3, typeof(GSgifTransfer3));
-                        this.GSVSync = (GSVSync) Marshal.GetDelegateForFunctionPointer(funcaddrVSync, typeof(GSVSync));
-                        this.GSsetBaseMem = (GSsetBaseMem) Marshal.GetDelegateForFunctionPointer(funcaddrSetBaseMem, typeof(GSsetBaseMem));
-                        this.GSopen = (GSopen) Marshal.GetDelegateForFunctionPointer(funcaddrOpen, typeof(GSopen));
-                        this.GSsetGameCRC = (GSsetGameCRC) Marshal.GetDelegateForFunctionPointer(funcaddrSetCRC, typeof(GSsetGameCRC));
-                        this.GSclose = (GSclose) Marshal.GetDelegateForFunctionPointer(funcaddrClose, typeof(GSclose));
-                        this.GSshutdown = (GSshutdown) Marshal.GetDelegateForFunctionPointer(funcaddrShutdown, typeof(GSshutdown));
-                        this.GSfreeze = (GSfreeze) Marshal.GetDelegateForFunctionPointer(funcaddrFreeze, typeof(GSfreeze));
-                        this.GSreset = (GSreset) Marshal.GetDelegateForFunctionPointer(funcaddrGSReset, typeof(GSreset));
-                        this.GSreadFIFO2 = (GSreadFIFO2) Marshal.GetDelegateForFunctionPointer(funcaddrGSreadFIFO2, typeof(GSreadFIFO2));
-                        this.GSinit = (GSinit) Marshal.GetDelegateForFunctionPointer(funcaddrinit, typeof(GSinit));
-                        this.GSmakeSnapshot = (GSmakeSnapshot)Marshal.GetDelegateForFunctionPointer(funcmakeSnapshot, typeof(GSmakeSnapshot));
+                    this.GSgifTransfer = (GSgifTransfer) Marshal.GetDelegateForFunctionPointer(funcaddrGIF, typeof(GSgifTransfer));
+                    this.GSgifTransfer1 = (GSgifTransfer1) Marshal.GetDelegateForFunctionPointer(funcaddrGIF1, typeof(GSgifTransfer1));
+                    this.GSgifTransfer2 = (GSgifTransfer2) Marshal.GetDelegateForFunctionPointer(funcaddrGIF2, typeof(GSgifTransfer2));
+                    this.GSgifTransfer3 = (GSgifTransfer3) Marshal.GetDelegateForFunctionPointer(funcaddrGIF3, typeof(GSgifTransfer3));
+                    this.GSVSync = (GSVSync) Marshal.GetDelegateForFunctionPointer(funcaddrVSync, typeof(GSVSync));
+                    this.GSsetBaseMem = (GSsetBaseMem) Marshal.GetDelegateForFunctionPointer(funcaddrSetBaseMem, typeof(GSsetBaseMem));
+                    this.GSopen = (GSopen) Marshal.GetDelegateForFunctionPointer(funcaddrOpen, typeof(GSopen));
+                    this.GSsetGameCRC = (GSsetGameCRC) Marshal.GetDelegateForFunctionPointer(funcaddrSetCRC, typeof(GSsetGameCRC));
+                    this.GSclose = (GSclose) Marshal.GetDelegateForFunctionPointer(funcaddrClose, typeof(GSclose));
+                    this.GSshutdown = (GSshutdown) Marshal.GetDelegateForFunctionPointer(funcaddrShutdown, typeof(GSshutdown));
+                    this.GSfreeze = (GSfreeze) Marshal.GetDelegateForFunctionPointer(funcaddrFreeze, typeof(GSfreeze));
+                    this.GSreset = (GSreset) Marshal.GetDelegateForFunctionPointer(funcaddrGSReset, typeof(GSreset));
+                    this.GSreadFIFO2 = (GSreadFIFO2) Marshal.GetDelegateForFunctionPointer(funcaddrGSreadFIFO2, typeof(GSreadFIFO2));
+                    this.GSinit = (GSinit) Marshal.GetDelegateForFunctionPointer(funcaddrinit, typeof(GSinit));
+                    this.GSmakeSnapshot = (GSmakeSnapshot)Marshal.GetDelegateForFunctionPointer(funcmakeSnapshot, typeof(GSmakeSnapshot));
 
-                        Loaded = true;
-                    }
+                    Loaded = true;
                 }
 
                 if (!Loaded)
@@ -178,6 +174,7 @@ namespace GSDumpGUI
 
         public void Unload()
         {
+            System.Diagnostics.Trace.WriteLine("FreeLibrary: " + DLL);
             NativeMethods.FreeLibrary(DLLAddr);
             Loaded = false;
         }

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -212,13 +212,24 @@ namespace GSDumpGUI
 
                 GSsetGameCRC(dump.CRC, 0);
 
-                NativeMethods.SetClassLong(hWnd,/*GCL_HICON*/ -14, (uint)Program.hMainIcon.ToInt32());
+                NativeMethods.SetClassLong(hWnd,/*GCL_HICON*/ -14, Program.hMainIcon);
 
                 fixed (byte* freeze = dump.StateData)
                 {
-                    byte[] GSFreez = new byte[8];
-                    Array.Copy(BitConverter.GetBytes(dump.StateData.Length), 0, GSFreez, 0, 4);
-                    Array.Copy(BitConverter.GetBytes(new IntPtr(freeze).ToInt32()), 0, GSFreez, 4, 4);
+                    byte[] GSFreez;
+
+                    if (IntPtr.Size > 4)
+                    {
+                        GSFreez = new byte[16];
+                        Array.Copy(BitConverter.GetBytes((Int64)dump.StateData.Length), 0, GSFreez, 0, 8);
+                        Array.Copy(BitConverter.GetBytes(new IntPtr(freeze).ToInt64()), 0, GSFreez, 8, 8);
+                    }
+                    else
+                    {
+                        GSFreez = new byte[8];
+                        Array.Copy(BitConverter.GetBytes((Int32)dump.StateData.Length), 0, GSFreez, 0, 4);
+                        Array.Copy(BitConverter.GetBytes(new IntPtr(freeze).ToInt32()), 0, GSFreez, 4, 4);
+                    }
 
                     fixed (byte* fr = GSFreez)
                     {
@@ -226,7 +237,7 @@ namespace GSDumpGUI
                         if (ris == -1)
                         {
                             DumpTooOld = true;
-                            return;
+                            Running = false;
                         }
                         GSVSync(1);
 

--- a/tools/GSDumpGUI/Library/GSDXWrapper.cs
+++ b/tools/GSDumpGUI/Library/GSDXWrapper.cs
@@ -31,22 +31,22 @@ using System.Threading;
 
 namespace GSDumpGUI
 {
-    public delegate void GSgifTransfer(IntPtr data, int size);
-    public delegate void GSgifTransfer1(IntPtr data, int size);
-    public delegate void GSgifTransfer2(IntPtr data, int size);
-    public delegate void GSgifTransfer3(IntPtr data, int size);
-    public delegate void GSVSync(byte field);
-    public delegate void GSreset();
-    public delegate void GSreadFIFO2(IntPtr data, int size);
-    public delegate void GSsetGameCRC(int crc, int options);
-    public delegate  int GSfreeze(int mode, IntPtr data);
-    public delegate  int GSopen(IntPtr hwnd, String Title, int renderer);
-    public delegate void GSclose();
-    public delegate void GSshutdown();
-    public delegate void GSConfigure();
-    public delegate void GSsetBaseMem(IntPtr data);
+    public delegate   void GSgifTransfer(IntPtr data, int size);
+    public delegate   void GSgifTransfer1(IntPtr data, int size);
+    public delegate   void GSgifTransfer2(IntPtr data, int size);
+    public delegate   void GSgifTransfer3(IntPtr data, int size);
+    public delegate   void GSVSync(byte field);
+    public delegate   void GSreset();
+    public delegate   void GSreadFIFO2(IntPtr data, int size);
+    public delegate   void GSsetGameCRC(int crc, int options);
+    public delegate    int GSfreeze(int mode, IntPtr data);
+    public delegate    int GSopen(IntPtr hwnd, String Title, int renderer);
+    public delegate   void GSclose();
+    public delegate   void GSshutdown();
+    public delegate   void GSConfigure();
+    public delegate   void GSsetBaseMem(IntPtr data);
     public delegate IntPtr PSEgetLibName();
-    public delegate void GSinit();
+    public delegate   void GSinit();
     public delegate UInt32 GSmakeSnapshot(string path);
 
     public class InvalidGSPlugin : Exception
@@ -105,7 +105,6 @@ namespace GSDumpGUI
                 if (dir == null) return;
 
                 Directory.SetCurrentDirectory(dir);
-                System.Diagnostics.Trace.WriteLine("LoadLibrary: " + DLL);
                 IntPtr hmod = NativeMethods.LoadLibrary(DLL);
                 if (hmod != IntPtr.Zero)
                 {
@@ -174,7 +173,6 @@ namespace GSDumpGUI
 
         public void Unload()
         {
-            System.Diagnostics.Trace.WriteLine("FreeLibrary: " + DLL);
             NativeMethods.FreeLibrary(DLLAddr);
             Loaded = false;
         }
@@ -218,7 +216,7 @@ namespace GSDumpGUI
                 {
                     byte[] GSFreez;
 
-                    if (IntPtr.Size > 4)
+                    if (Environment.Is64BitProcess)
                     {
                         GSFreez = new byte[16];
                         Array.Copy(BitConverter.GetBytes((Int64)dump.StateData.Length), 0, GSFreez, 0, 8);
@@ -281,15 +279,18 @@ namespace GSDumpGUI
                                     switch (Mess.MessageType)
                                     {
                                         case MessageType.Step:
-                                            if (debug_idx >= dump.Data.Count) debug_idx = 0;
+                                            if (debug_idx >= dump.Data.Count)
+                                                debug_idx = 0;
                                             RunTo = debug_idx;
                                             break;
                                         case MessageType.RunToCursor:
                                             RunTo = (int)Mess.Parameters[0];
-                                            if(debug_idx > RunTo) debug_idx = 0;
+                                            if(debug_idx > RunTo)
+                                                debug_idx = 0;
                                             break;
                                         case MessageType.RunToNextVSync:
-                                            if (debug_idx >= dump.Data.Count) debug_idx = 1;
+                                            if (debug_idx >= dump.Data.Count)
+                                                debug_idx = 1;
                                             RunTo = dump.Data.FindIndex(debug_idx, a => a.id == GSType.VSync);
                                             break;
                                         default:

--- a/tools/GSDumpGUI/Library/GSDump/GSDump.cs
+++ b/tools/GSDumpGUI/Library/GSDump/GSDump.cs
@@ -101,8 +101,8 @@ namespace GSDumpGUI
             dmp.CRC = br.ReadInt32();
 
             Int32 ss = br.ReadInt32();
-            dmp.StateData = br.ReadBytes(ss);         
-        
+            dmp.StateData = br.ReadBytes(ss); 
+
             dmp.Registers = br.ReadBytes(8192);
 
             while (br.PeekChar() != -1)

--- a/tools/GSDumpGUI/Library/NativeMethods.cs
+++ b/tools/GSDumpGUI/Library/NativeMethods.cs
@@ -90,7 +90,7 @@ namespace GSDumpGUI
 
         public static UIntPtr SetClassLong(IntPtr hWnd, Int32 index, IntPtr dwNewLong)
         {
-            if (IntPtr.Size > 4) return SetClassLong64(hWnd, index, dwNewLong);
+            if (Environment.Is64BitProcess) return SetClassLong64(hWnd, index, dwNewLong);
             else return new UIntPtr(SetClassLong32(hWnd, index, dwNewLong.ToInt32()));
         }
     }

--- a/tools/GSDumpGUI/Library/NativeMethods.cs
+++ b/tools/GSDumpGUI/Library/NativeMethods.cs
@@ -62,7 +62,7 @@ namespace GSDumpGUI
 
         [SuppressUnmanagedCodeSecurityAttribute]
         [DllImport("user32", CharSet = CharSet.Ansi)]
-        public extern static int SetClassLong(IntPtr HWND, int index, long newlong);
+        public extern static int SetClassLong(IntPtr HWND, int index, uint newlong);
 
         [SuppressUnmanagedCodeSecurityAttribute]
         [DllImport("user32", CharSet = CharSet.Ansi)]

--- a/tools/GSDumpGUI/Library/NativeMethods.cs
+++ b/tools/GSDumpGUI/Library/NativeMethods.cs
@@ -33,55 +33,66 @@ namespace GSDumpGUI
     static public class NativeMethods
     {
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("kernel32")]
+        [DllImport("kernel32", CharSet = CharSet.Auto, SetLastError = true)]
         public extern static IntPtr LoadLibrary(string lpLibFileName);
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("kernel32")]
+        [DllImport("kernel32", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public extern static bool FreeLibrary(IntPtr hLibModule);
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("kernel32", CharSet = CharSet.Ansi)]
+        [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
         public extern static IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("kernel32", CharSet = CharSet.Ansi)]
-        public extern static int SetErrorMode(int Value);
+        [DllImport("kernel32")]
+        public extern static UInt32 SetErrorMode(UInt32 uMode);
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("kernel32", CharSet = CharSet.Ansi)]
-        public extern static int GetLastError();
+        [DllImport("kernel32")]
+        public extern static UInt32 GetLastError();
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("kernel32", CharSet = CharSet.Ansi)]
-        public extern static int WritePrivateProfileString(string lpAppName, string lpKeyName, string lpString, string lpFileName);
-
-        [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("user32", CharSet = CharSet.Ansi)]
-        public extern static short GetAsyncKeyState(int key);
-
-        [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("user32", CharSet = CharSet.Ansi)]
-        public extern static int SetClassLong(IntPtr HWND, int index, uint newlong);
-
-        [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("user32", CharSet = CharSet.Ansi)]
-        public extern static bool IsWindowVisible(IntPtr HWND);
-
-        [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+        [DllImport("kernel32", CharSet = CharSet.Auto, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool PeekMessage(out NativeMessage message, IntPtr hwnd, uint messageFilterMin, uint messageFilterMax, uint flags);
+        public extern static bool WritePrivateProfileString(string lpAppName, string lpKeyName, string lpString, string lpFileName);
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool TranslateMessage(ref NativeMessage message);
+        [DllImport("user32")]
+        public extern static UInt16 GetAsyncKeyState(Int32 vKey);
 
         [SuppressUnmanagedCodeSecurityAttribute]
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+        [DllImport("user32", CharSet = CharSet.Auto, EntryPoint = "SetClassLong")]
+        public extern static UInt32 SetClassLong32(IntPtr hWnd, Int32 index, Int32 dwNewLong);
+
+        [SuppressUnmanagedCodeSecurityAttribute]
+        [DllImport("user32", CharSet = CharSet.Auto, EntryPoint = "SetClassLongPtr")]
+        public extern static UIntPtr SetClassLong64(IntPtr hWnd, Int32 index, IntPtr dwNewLong);
+
+        [SuppressUnmanagedCodeSecurityAttribute]
+        [DllImport("user32")]
+        public extern static bool IsWindowVisible(IntPtr hWnd);
+
+        [SuppressUnmanagedCodeSecurityAttribute]
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool DispatchMessage(ref NativeMessage message);
+        public static extern bool PeekMessage(out NativeMessage lpMsg, IntPtr hWnd, UInt32 wMsgFilterMin, UInt32 wMsgFilterMax, UInt32 wRemoveMsg);
+
+        [SuppressUnmanagedCodeSecurityAttribute]
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool TranslateMessage(ref NativeMessage lpMsg);
+
+        [SuppressUnmanagedCodeSecurityAttribute]
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern UInt32 DispatchMessage(ref NativeMessage lpMsg);
+
+        public static UIntPtr SetClassLong(IntPtr hWnd, Int32 index, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size > 4) return SetClassLong64(hWnd, index, dwNewLong);
+            else return new UIntPtr(SetClassLong32(hWnd, index, dwNewLong.ToInt32()));
+        }
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -94,5 +105,4 @@ namespace GSDumpGUI
         public uint time;
         public Point p;
     }
-
 }


### PR DESCRIPTION
- [x] Changed the main loop to process messages per frame which makes the GSdx window more responsive and allows for the window title information to show up. The plugin has its own message loop that runs on vsync, GUI message loop then runs before the vsync package to avoid missed messages.
- [x] Process termination is done using the new message loop.
- [x] Window icon is now set after GSopen, as there's a valid window handle to use.
- [x] Added GSmakeSnapshot to the loaded functions and is used when pressing the F8 key.
- [x] Added FileSystemWatchers to check for changes in dump and dll paths to update the respective lists.
- [x] Replaced directory selection tree dialog with a normal file selection dialog.
- [x] Fixed path labels updating lists on change.
- [x] Enabled and fixed STDERR redirection for the plugin process.
- [x] Avoid leaving opened file handles.
- [x] Fixed some exceptions.
- [x] Make it work in 64bit.