### PR TITLE
Move PSXCLK and setpsxspeed to proper reset function

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1417,8 +1417,7 @@ static __fi void cdvdWrite14(u8 rt) { // PS1 MODE?? // This should be done in th
 		Console.Warning("*PCSX2*: go PS1 mode DISC SPEED = %dX", rt);
 
 	psxReset();
-	PSXCLK =  33868800;
-	setPsxSpeed();
+
 	// psxmode: todo: we should recalculate video timings for iop and ee. how to do that best?
 	// unlike regular ps2 games, the video mode for ps1driver isn't going through the GS set mode syscall
 	// so.. something like this? :

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -63,7 +63,8 @@ void psxReset()
 	g_iopNextEventCycle = psxRegs.cycle + 4;
 
 	psxHwReset();
-	PSXCLK = 36864000;
+	PSXCLK =  33868800;
+	setPsxSpeed();
 	ioman::reset();
 	psxBiosReset();
 }


### PR DESCRIPTION
https://www.youtube.com/watch?v=pQzCptidLmw - This PR in a nutshell… It moves some lines of code for ps1 mode to a more correct spot. Also rama should the PCSX2 GO DISC SPEED stuff in CDVD cdvdWrite14 go in CdRom.cpp setpsxmode()?