### PR TITLE
PCSX2: Wait some frames between F9 SW render toggles

### DIFF
--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -362,7 +362,7 @@ namespace Implementations
 
 	void Sys_RenderToggle()
 	{
-		if(do_renderswitch == 0)
+		if (do_renderswitch == 0)
 			do_renderswitch = -1;
 	}
 

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -35,6 +35,7 @@
 
 // renderswitch - tells GSdx to go into dx9 sw if "renderswitch" is set.
 bool renderswitch = false;
+uint do_renderswitch = 0;
 
 extern bool switchAR;
 
@@ -361,9 +362,8 @@ namespace Implementations
 
 	void Sys_RenderToggle()
 	{
-		ScopedCoreThreadPause paused_core( new SysExecEvent_SaveSinglePlugin(PluginId_GS) );
-		renderswitch = !renderswitch;
-		paused_core.AllowResume();
+		if(do_renderswitch == 0)
+			do_renderswitch = -1;
 	}
 
 	void Sys_LoggingToggle()


### PR DESCRIPTION
Attempt to fix issue #370.

Setting the toggle variable is now at the vsync point. FMV toggle should still work as usual, but the F9 toggle should have to wait the full period of around 32 frames. This seems short enough while also depends on how fast those frames can rendered, avoiding having to set a timer in ms.

Fixes #370