### PR TITLE
PAD: Delay load dependent DLLs

### DIFF
--- a/plugins/LilyPad/LilyPad.cpp
+++ b/plugins/LilyPad/LilyPad.cpp
@@ -330,17 +330,19 @@ void UpdateEnabledDevices(int updateList = 0)
 #ifdef _MSC_VER
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD fdwReason, void *lpvReserved)
 {
-    hInst = hInstance;
     if (fdwReason == DLL_PROCESS_ATTACH) {
+        hInst = hInstance;
         InitializeCriticalSection(&updateLock);
 
         DisableThreadLibraryCalls(hInstance);
     } else if (fdwReason == DLL_PROCESS_DETACH) {
-        while (openCount)
-            PADclose();
-        PADshutdown();
-        UninitLibUsb();
-        DeleteCriticalSection(&updateLock);
+        if (lpvReserved == nullptr) {
+            while (openCount)
+                PADclose();
+            PADshutdown();
+            UninitLibUsb();
+            DeleteCriticalSection(&updateLock);
+        }
     }
     return 1;
 }
@@ -1183,7 +1185,7 @@ u8 CALLBACK PADpoll(u8 value)
                     return 0xF3;
                 }
                 // Fall through
-                
+
             // READ_DATA_AND_VIBRATE
             case 0x42:
                 query.response[2] = 0x5A;
@@ -1598,7 +1600,7 @@ s32 CALLBACK PADfreeze(int mode, freezeData *data)
             }
 
             if (pdata.slot[port] < 4)
-            slots[port] = pdata.slot[port];
+                slots[port] = pdata.slot[port];
         }
     } else if (mode == FREEZE_SAVE) {
         if (data->size != sizeof(PadPluginFreezeData))

--- a/plugins/LilyPad/LilyPad.vcxproj
+++ b/plugins/LilyPad/LilyPad.vcxproj
@@ -53,6 +53,7 @@
     <Link>
       <AdditionalDependencies>Setupapi.lib;Winmm.lib;Comdlg32.lib;dinput8.lib;dxguid.lib;comctl32.lib;hid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>.\LilyPad.def</ModuleDefinitionFile>
+      <DelayLoadDLLs>dinput8.dll;hid.dll;setupapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <TargetMachine Condition="'$(Platform)'=='Win32'">MachineX86</TargetMachine>
       <TargetMachine Condition="'$(Platform)'=='x64'">MachineX64</TargetMachine>
     </Link>


### PR DESCRIPTION
This PR "fixes" a possible crash when enumerating plugins. As LilyPad depends on dinput8.dll, it was loaded and unloaded together with LilyPad, however it seems that DInput8 on Windows 10 regressed and now such rapid load/unload can cause it to crash.

With this PR, dinput8.dll and other dependant DLLs are delay loaded, so they are loaded before they are **actually** needed. Only dinput8.dll required this to work around the crash, but I also included the others (hid.dll and setupapi.dll), since it looks like it's totally possible to go through an entire session without using their functions. This should also speed up enumeration and startup, since less DLLs load at these points now.


Overview of DInput8 bug which could have resulted in a crash when enumerating LilyPad:
https://cookieplmonster.github.io/2019/08/02/win10-dinput8-crash/