### PR TITLE
Avoid hang when spamming F4 (Frame Limiter Toggle)

### DIFF
--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -672,7 +672,7 @@ static const GlobalCommandDescriptor CommandDeclarations[] =
 		Implementations::Framelimiter_MasterToggle,
 		NULL,
 		NULL,
-		true,
+		false,
 	},
 
 	{	"GSwindow_CycleAspectRatio",


### PR DESCRIPTION
Hitting F4 toggles the master framelimiter and the `AlsoApplyToGui` property causes `AppApplySettings()` to be called. This makes it unresponsive compared to turbo keys and locks the application.

Setting it to false, I assumed the use of F4 will not be reflected in the UI but if you open the settings panel it shows as expected. So no bad side effect, possibly.