### PR TITLE
GSdx SW: Fix SSE2 mipmap code generation.

### DIFF
--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
@@ -1765,7 +1765,7 @@ void GSDrawScanlineCodeGenerator::SampleTextureLOD_SSE()
 			// c[0] = c00 & mask;
 			// c[1] = (c00 >> 8) & mask;
 
-			split16_2x8(xmm5, xmm6, xmm5);
+			split16_2x8(xmm5, xmm6, xmm6);
 		}
 
 		movdqa(xmm0, ptr[m_sel.lcm ? &m_local.gd->lod.f : &m_local.temp.lod.f]);


### PR DESCRIPTION
~~It seems SEL.LTF was beign set to the mipmap filter while SEL.MMIN was being set to the texture filter. Setting LTF to the first bit and MMIN to the last one instead, fixes Hot Pursuit 2 mipmap on SW.~~ That was just fine.

Problem seems to be a typo in a duplicated code of the SSE2 code generator part.

Before:
![sw_before](https://user-images.githubusercontent.com/2485237/62486302-49579f00-b795-11e9-8ce2-a3adfc7f58aa.png)

After:
![sw_after2](https://user-images.githubusercontent.com/2485237/62507996-7f6c4180-b7dc-11e9-8811-eeff3d4d1007.png)
