### PR TITLE
GSdx-hw: fix sw sprite renderer

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -708,7 +708,6 @@ void GSRendererHW::SwSpriteRender()
 	ASSERT(!PRIM->IIP);  // Flat shading method
 	ASSERT(!PRIM->FGE);  // No FOG
 	ASSERT(!PRIM->AA1);  // No antialiasing
-	ASSERT(!PRIM->FST);  // STQ texture coordinates
 	ASSERT(!PRIM->FIX);  // Normal fragment value control
 
 	ASSERT(!m_env.DTHE.DTHE); // No dithering
@@ -728,7 +727,7 @@ void GSRendererHW::SwSpriteRender()
 	// No rasterization required
 	ASSERT(m_vt.m_eq.rgba == 0xffff);
 	ASSERT(m_vt.m_eq.z == 0x1);
-	ASSERT(m_vt.m_eq.q == 0x1);
+	ASSERT(!PRIM->TME || PRIM->FST || m_vt.m_eq.q == 0x1);  // Check Q equality only if texturing enabled and STQ coords used
 
 	bool texture_mapping_enabled = PRIM->TME;
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -754,19 +754,12 @@ void GSRendererHW::SwSpriteRender()
 
 	GIFRegTRXREG trxreg;
 
-	if (texture_mapping_enabled)
-	{
-		trxreg.RRW = m_context->TEX0.TW * 4;
-		trxreg.RRH = m_context->TEX0.TH * 4;
-		// Check drawing region
-		ASSERT((GSVector4i(m_vt.m_min.p.xyxy(m_vt.m_max.p)).rintersect(GSVector4i(m_context->scissor.in)) == GSVector4i(0, 0, trxreg.RRW, trxreg.RRH)).alltrue());
-	}
-	else
-	{
-		GSVector4i r = GSVector4i(m_vt.m_min.p.xyxy(m_vt.m_max.p)).rintersect(GSVector4i(m_context->scissor.in));
-		trxreg.RRW = r.width();
-		trxreg.RRH = r.height();
-	}
+	GSVector4i r = m_r;  // Rectangle of the draw
+	ASSERT(r.x == 0 && r.y == 0);  // No offset
+	ASSERT(!texture_mapping_enabled || (r.z <= (1 << m_context->TEX0.TW)) && (r.w <= (1 << m_context->TEX0.TH)));  // Input texture is big enough, if any
+
+	trxreg.RRW = r.width();
+	trxreg.RRH = r.height();
 
 	// SW rendering code, mainly taken from GSState::Move(), TRXPOS.DIR{X,Y} management excluded
 


### PR DESCRIPTION
Two small fixes in the `GSRendererHW::SwSpriteRender` method:

- Avoid asserting on Q coords equality if texture coordinate system is UV and not STQ, when checking that no rasterization is required (rasterization is not supported).
- Always use the rectangle of the draw to compute width and height of the draw; Assert that there is no offset (not supported yet), and that if texturing is enabled, the reported texture size is big enough (no junk reads).

These fixes do not have impact on `GSRendererHW::OI_JakGames` (which is calling the renderer only if specific conditions are met, like STQ coords and 16x16 rectangle draw without offset), but nevertheless are essential for extending the usage of the method to other games that might benefit from it (like Dragon Ball Z: Budokai Tenkaichi 2).
