### PR TITLE
GameDB: Crazy Frog Racer 2/Alone in the Dark fixes

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -16642,6 +16642,7 @@ Serial = SLES-54549
 Name   = Crazy Frog Racer 2
 Region = PAL-M5
 Compat = 5
+FPUNegDivHack = 1 // Fixes black fade effects and some overlays texts in the menus.
 ---------------------------------------------
 Serial = SLES-54551
 Name   = Premier Manager 2006-2007
@@ -17126,10 +17127,16 @@ Serial = SLES-54880
 Name   = NBA 2K8
 Region = PAL-M5
 ---------------------------------------------
+Serial = SLES-54883
+Name   = Alone in the Dark
+Region = PAL-I
+EETimingHack = 1 // Fixes game hanging at boot.
+---------------------------------------------
 Serial = SLES-54884
 Name   = Alone in the Dark
 Region = PAL-E
 Compat = 5
+EETimingHack = 1 // Fixes game hanging at boot.
 ---------------------------------------------
 Serial = SLES-54885
 Name   = Moto X Maniac
@@ -17546,6 +17553,7 @@ Region = PAL-M6
 Serial = SLES-55207
 Name   = Alone in the Dark
 Region = PAL-M4
+EETimingHack = 1 // Fixes game hanging at boot.
 ---------------------------------------------
 Serial = SLES-55208
 Name   = The Incredible Hulk
@@ -22066,7 +22074,7 @@ Name   = Houshin Engi 2
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-65085
-Name   = Alone in the Dark
+Name   = Alone in the Dark: The New Nightmare
 Region = NTSC-J
 ---------------------------------------------
 Serial = SLPM-65086
@@ -42220,9 +42228,10 @@ Region = NTSC-U
 Compat = 5
 ---------------------------------------------
 Serial = SLUS-21634
-Name   = Crazy Frog Racer
+Name   = Crazy Frog Racer 2
 Region = NTSC-U
 Compat = 5
+FPUNegDivHack = 1 // Fixes black fade effects and some overlays texts in the menus.
 ---------------------------------------------
 Serial = SLUS-21635
 Name   = Monster Jam
@@ -42487,7 +42496,7 @@ Serial = SLUS-21690
 Name   = Alone in the Dark
 Region = NTSC-U
 Compat = 5
-EETimingHack = 1
+EETimingHack = 1 // Fixes game hanging at boot.
 ---------------------------------------------
 Serial = SLUS-21691
 Name   = Swashbucklers - Blue vs. Grey


### PR DESCRIPTION
This PR add a FPU negative div hack to Crazy Frog Racer 2 to fix black fade effects and some overlays texts in the menus.

It also add EETimingHack on some missing Alone in the Dark revisions which fixes game hanging at boot.

Tested by Forum member:
- LoStraniero1991