### PR TITLE
3rdparty/pthreads4w: Ensure on_process_init early execution

### DIFF
--- a/3rdparty/pthreads4w/autostatic.c
+++ b/3rdparty/pthreads4w/autostatic.c
@@ -73,9 +73,14 @@ static void on_process_init(void)
 attribute_section(".ctors") void *gcc_ctor = on_process_init;
 attribute_section(".dtors") void *gcc_dtor = on_process_exit;
 
-attribute_section(".CRT$XCU") void *msc_ctor = on_process_init;
 #if !PCSX2_FIX
+attribute_section(".CRT$XCU") void *msc_ctor = on_process_init;
 attribute_section(".CRT$XPU") void *msc_dtor = on_process_exit;
+#else
+// MSVC puts all initializers in .CRT$XCU and order of those is not fully deterministic
+// Since the entire point of this is to call on_process_init before any other initializer,
+// move it to .CRT$XCP so it is guaranteed it initializes early
+attribute_section(".CRT$XCP") void *msc_ctor = on_process_init;
 #endif
 
 #endif /* defined(__MINGW64__) || defined(__MINGW32__) || defined(_MSC_VER) */


### PR DESCRIPTION
This fixes a semi-consistent regression introduced by #3056, where `on_process_exit` would execute before other destructors relying on pthreads.

Now `on_process_init` has been moved to an earlier section of static initializers, **ensuring** it will be initialized first. Previously, this initializer was placed in the same section as any other initializer, making their order of execution non-deterministic across compilations - for example, I was unable to reproduce this issue as soon as I forced `pthreads4w.c` to recompile last!