### PR TITLE
GSdx-hw: improve and use sw sprite render in DBZ:BT2, replacing OO & CU with OI

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -72,22 +72,6 @@ bool GSC_Bully(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_DBZBT2(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if((Aggressive || !s_nativeres) && !fi.TME && (fi.FBP == 0x02a00 || fi.FBP == 0x03000) && fi.FPSM == PSM_PSMCT16)
-		{
-			// Character outlines.
-			// Glow/blur effect. Causes ghosting on upscaled resolution.
-			// Don't enable hack on native res if crc is below aggressive.
-			skip = 10;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_DBZBT3(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1462,7 +1446,6 @@ void GSState::SetupCrcHack()
 
 		// Upscaling hacks
 		lut[CRC::Bully] = GSC_Bully;
-		lut[CRC::DBZBT2] = GSC_DBZBT2;
 		lut[CRC::DBZBT3] = GSC_DBZBT3;
 		lut[CRC::EvangelionJo] = GSC_EvangelionJo;
 		lut[CRC::FightingBeautyWulong] = GSC_FightingBeautyWulong;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -811,6 +811,7 @@ void GSRendererHW::SwSpriteRender()
 	bool fb_mask_enabled = m_context->FRAME.FBMSK != 0x0;
 	GSVector4i fb_mask = GSVector4i(m_context->FRAME.FBMSK).u8to16(); // 0x00AA00BB00GG00RR00AA00BB00GG00RR
 
+	uint8 tex0_tfx = m_context->TEX0.TFX;
 	uint8 tex0_tcc = m_context->TEX0.TCC;
 	uint8 alpha_b = m_context->ALPHA.B;
 	uint8 alpha_c = m_context->ALPHA.C;
@@ -833,8 +834,10 @@ void GSRendererHW::SwSpriteRender()
 				sc = GSVector4i::loadl(&s[scol[x]]).u8to16();  // 0x00AA00BB00GG00RR00aa00bb00gg00rr
 
 				// Apply TFX
-				ASSERT(m_context->TEX0.TFX == 0);
-				sc = sc.mul16l(vc).srl16(7).clamp8();  // clamp((sc * vc) >> 7, 0, 255), srl16 is ok because 16 bit values are unsigned
+				ASSERT(tex0_tfx == 0 || tex0_tfx == 1);
+				if (tex0_tfx == 0)
+					sc = sc.mul16l(vc).srl16(7).clamp8();  // clamp((sc * vc) >> 7, 0, 255), srl16 is ok because 16 bit values are unsigned
+
 				if (tex0_tcc == 0)
 					sc = sc.blend(vc, a_mask);
 			}

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -724,7 +724,6 @@ void GSRendererHW::SwSpriteRender()
 {
 	// Supported drawing attributes
 	ASSERT(PRIM->PRIM == GS_TRIANGLESTRIP || PRIM->PRIM == GS_SPRITE);
-	ASSERT(!PRIM->IIP);  // Flat shading method
 	ASSERT(!PRIM->FGE);  // No FOG
 	ASSERT(!PRIM->AA1);  // No antialiasing
 	ASSERT(!PRIM->FIX);  // Normal fragment value control
@@ -744,9 +743,10 @@ void GSRendererHW::SwSpriteRender()
 	ASSERT(m_context->FRAME.PSM == PSM_PSMCT32);
 
 	// No rasterization required
-	ASSERT(m_vt.m_eq.rgba == 0xffff);
-	ASSERT(m_vt.m_eq.z == 0x1);
-	ASSERT(!PRIM->TME || PRIM->FST || m_vt.m_eq.q == 0x1);  // Check Q equality only if texturing enabled and STQ coords used
+	ASSERT(PRIM->PRIM == GS_SPRITE
+		|| ((PRIM->IIP || m_vt.m_eq.rgba == 0xffff)
+			&& m_vt.m_eq.z == 0x1
+			&& (!PRIM->TME || PRIM->FST || m_vt.m_eq.q == 0x1)));  // Check Q equality only if texturing enabled and STQ coords used
 
 	bool texture_mapping_enabled = PRIM->TME;
 
@@ -804,8 +804,9 @@ void GSRendererHW::SwSpriteRender()
 
 	bool alpha_blending_enabled = PRIM->ABE;
 
-	GSVector4i vc = m_vt.m_min.c;  // 0x000000AA000000BB000000GG000000RR
-	vc = vc.ps32();                // 0x00AA00BB00GG00RR00AA00BB00GG00RR
+	const GSVertex& v = m_vertex.buff[m_index.buff[m_index.tail - 1]];  // Last vertex.
+	const GSVector4i vc = GSVector4i(v.RGBAQ.R, v.RGBAQ.G, v.RGBAQ.B, v.RGBAQ.A)  // 0x000000AA000000BB000000GG000000RR
+							.ps32();  // 0x00AA00BB00GG00RR00AA00BB00GG00RR
 
 	GSVector4i a_mask = GSVector4i::xff000000().u8to16();  // 0x00FF00000000000000FF000000000000
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -723,7 +723,7 @@ float GSRendererHW::alpha1(int L, int X0, int X1)
 void GSRendererHW::SwSpriteRender()
 {
 	// Supported drawing attributes
-	ASSERT(PRIM->PRIM == 4 || PRIM->PRIM == 6);
+	ASSERT(PRIM->PRIM == GS_TRIANGLESTRIP || PRIM->PRIM == GS_SPRITE);
 	ASSERT(!PRIM->IIP);  // Flat shading method
 	ASSERT(!PRIM->FGE);  // No FOG
 	ASSERT(!PRIM->AA1);  // No antialiasing

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -750,10 +750,10 @@ void GSRendererHW::SwSpriteRender()
 			&& m_vt.m_eq.z == 0x1
 			&& (!PRIM->TME || PRIM->FST || m_vt.m_eq.q == 0x1)));  // Check Q equality only if texturing enabled and STQ coords used
 
-	bool texture_mapping_enabled = PRIM->TME;
+	const bool texture_mapping_enabled = PRIM->TME;
 
 	// Setup registers for SW rendering
-	GIFRegBITBLTBUF bitbltbuf;
+	GIFRegBITBLTBUF bitbltbuf = {};
 
 	if (texture_mapping_enabled)
 	{
@@ -771,14 +771,14 @@ void GSRendererHW::SwSpriteRender()
 	ASSERT(!PRIM->TME || (abs(m_vt.m_max.t.x - m_r.z) <= SSR_UV_TOLERANCE && abs(m_vt.m_max.t.y - m_r.w) <= SSR_UV_TOLERANCE));  // No input texture min/mag, if any
 	ASSERT(!PRIM->TME || (m_vt.m_max.t.x <= (1 << m_context->TEX0.TW) && m_vt.m_max.t.y <= (1 << m_context->TEX0.TH)));  // No texture UV wrap, if any
 
-	GIFRegTRXPOS trxpos;
+	GIFRegTRXPOS trxpos = {};
 
 	trxpos.DSAX = 0;
 	trxpos.DSAY = 0;
 	trxpos.SSAX = 0;
 	trxpos.SSAY = 0;
 
-	GIFRegTRXREG trxreg;
+	GIFRegTRXREG trxreg = {};
 
 	trxreg.RRW = m_r.z;
 	trxreg.RRH = m_r.w;
@@ -789,8 +789,8 @@ void GSRendererHW::SwSpriteRender()
 	int sy = trxpos.SSAY;
 	int dx = trxpos.DSAX;
 	int dy = trxpos.DSAY;
-	int w = trxreg.RRW;
-	int h = trxreg.RRH;
+	const int w = trxreg.RRW;
+	const int h = trxreg.RRH;
 
 	GL_INS("SwSpriteRender: Dest 0x%x W:%d F:%s, size(%d %d)", bitbltbuf.DBP, bitbltbuf.DBW, psm_str(bitbltbuf.DPSM), w, h);
 
@@ -801,29 +801,29 @@ void GSRendererHW::SwSpriteRender()
 	GSOffset* RESTRICT spo = texture_mapping_enabled ? m_mem.GetOffset(bitbltbuf.SBP, bitbltbuf.SBW, bitbltbuf.SPSM) : nullptr;
 	GSOffset* RESTRICT dpo = m_mem.GetOffset(bitbltbuf.DBP, bitbltbuf.DBW, bitbltbuf.DPSM);
 
-	int* RESTRICT scol = texture_mapping_enabled ? &spo->pixel.col[0][sx] : nullptr;
+	const int* RESTRICT scol = texture_mapping_enabled ? &spo->pixel.col[0][sx] : nullptr;
 	int* RESTRICT dcol = &dpo->pixel.col[0][dx];
 
-	bool alpha_blending_enabled = PRIM->ABE;
+	const bool alpha_blending_enabled = PRIM->ABE;
 
 	const GSVertex& v = m_vertex.buff[m_index.buff[m_index.tail - 1]];  // Last vertex.
 	const GSVector4i vc = GSVector4i(v.RGBAQ.R, v.RGBAQ.G, v.RGBAQ.B, v.RGBAQ.A)  // 0x000000AA000000BB000000GG000000RR
 							.ps32();  // 0x00AA00BB00GG00RR00AA00BB00GG00RR
 
-	GSVector4i a_mask = GSVector4i::xff000000().u8to16();  // 0x00FF00000000000000FF000000000000
+	const GSVector4i a_mask = GSVector4i::xff000000().u8to16();  // 0x00FF00000000000000FF000000000000
 
-	bool fb_mask_enabled = m_context->FRAME.FBMSK != 0x0;
-	GSVector4i fb_mask = GSVector4i(m_context->FRAME.FBMSK).u8to16(); // 0x00AA00BB00GG00RR00AA00BB00GG00RR
+	const bool fb_mask_enabled = m_context->FRAME.FBMSK != 0x0;
+	const GSVector4i fb_mask = GSVector4i(m_context->FRAME.FBMSK).u8to16(); // 0x00AA00BB00GG00RR00AA00BB00GG00RR
 
-	uint8 tex0_tfx = m_context->TEX0.TFX;
-	uint8 tex0_tcc = m_context->TEX0.TCC;
-	uint8 alpha_b = m_context->ALPHA.B;
-	uint8 alpha_c = m_context->ALPHA.C;
-	uint8 alpha_fix = m_context->ALPHA.FIX;
+	const uint8 tex0_tfx = m_context->TEX0.TFX;
+	const uint8 tex0_tcc = m_context->TEX0.TCC;
+	const uint8 alpha_b = m_context->ALPHA.B;
+	const uint8 alpha_c = m_context->ALPHA.C;
+	const uint8 alpha_fix = m_context->ALPHA.FIX;
 
 	for (int y = 0; y < h; y++, ++sy, ++dy)
 	{
-		uint32* RESTRICT s = texture_mapping_enabled ? &m_mem.m_vm32[spo->pixel.row[sy]] : nullptr;
+		const uint32* RESTRICT s = texture_mapping_enabled ? &m_mem.m_vm32[spo->pixel.row[sy]] : nullptr;
 		uint32* RESTRICT d = &m_mem.m_vm32[dpo->pixel.row[dy]];
 
 		ASSERT(w % 2 == 0);
@@ -920,10 +920,10 @@ void GSRendererHW::SwSpriteRender()
 
 bool GSRendererHW::CanUseSwSpriteRender(bool allow_64x64_sprite)
 {
-	bool r_0_0_64_64 = allow_64x64_sprite ? (m_r == GSVector4i(0, 0, 64, 64)).alltrue() : false;
+	const bool r_0_0_64_64 = allow_64x64_sprite ? (m_r == GSVector4i(0, 0, 64, 64)).alltrue() : false;
 	if (r_0_0_64_64 && !allow_64x64_sprite)  // Rendering region 64x64 support is enabled via parameter
 		return false;
-	bool r_0_0_16_16 = (m_r == GSVector4i(0, 0, 16, 16)).alltrue();
+	const bool r_0_0_16_16 = (m_r == GSVector4i(0, 0, 16, 16)).alltrue();
 	if (!r_0_0_16_16 && !r_0_0_64_64)  // Rendering region is 16x16 or 64x64, without offset
 		return false;
 	if (PRIM->PRIM != GS_SPRITE
@@ -956,8 +956,8 @@ bool GSRendererHW::CanUseSwSpriteRender(bool allow_64x64_sprite)
 			return false;
 		if (abs(m_vt.m_max.t.x - m_r.z) > SSR_UV_TOLERANCE || abs(m_vt.m_max.t.y - m_r.w) > SSR_UV_TOLERANCE)  // No texture width or height mag/min
 			return false;
-		int tw = 1 << m_context->TEX0.TW;
-		int th = 1 << m_context->TEX0.TH;
+		const int tw = 1 << m_context->TEX0.TW;
+		const int th = 1 << m_context->TEX0.TH;
 		if (m_vt.m_max.t.x > tw || m_vt.m_max.t.y > th)  // No UV wrapping
 			return false;
 	}

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -809,7 +809,7 @@ void GSRendererHW::SwSpriteRender()
 	GSVector4i a_mask = GSVector4i::xff000000().u8to16();  // 0x00FF00000000000000FF000000000000
 
 	bool fb_mask_enabled = m_context->FRAME.FBMSK != 0x0;
-	GSVector4i fb_mask = GSVector4i(m_context->FRAME.FBMSK).xxxx(); // 0x????????????????MMMMMMMMMMMMMMMM
+	GSVector4i fb_mask = GSVector4i(m_context->FRAME.FBMSK).u8to16(); // 0x00AA00BB00GG00RR00AA00BB00GG00RR
 
 	uint8 tex0_tcc = m_context->TEX0.TCC;
 	uint8 alpha_b = m_context->ALPHA.B;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -764,6 +764,11 @@ void GSRendererHW::SwSpriteRender()
 	bitbltbuf.DBW = m_context->FRAME.FBW;
 	bitbltbuf.DPSM = m_context->FRAME.PSM;
 
+	ASSERT(m_r.x == 0 && m_r.y == 0);  // No rendering region offset
+	ASSERT(!PRIM->TME || (abs(m_vt.m_min.t.x) <= 1e-3 && abs(m_vt.m_min.t.y) <= 1e-3));  // No input texture offset, if any
+	ASSERT(!PRIM->TME || (abs(m_vt.m_max.t.x - m_r.z) <= 1e-3 && abs(m_vt.m_max.t.y - m_r.w) <= 1e-3));  // No input texture min/mag, if any
+	ASSERT(!PRIM->TME || (m_vt.m_max.t.x <= (1 << m_context->TEX0.TW) && m_vt.m_max.t.y <= (1 << m_context->TEX0.TH)));  // No texture UV wrap, if any
+
 	GIFRegTRXPOS trxpos;
 
 	trxpos.DSAX = 0;
@@ -773,12 +778,8 @@ void GSRendererHW::SwSpriteRender()
 
 	GIFRegTRXREG trxreg;
 
-	GSVector4i r = m_r;  // Rectangle of the draw
-	ASSERT(r.x == 0 && r.y == 0);  // No offset
-	ASSERT(!texture_mapping_enabled || (r.z <= (1 << m_context->TEX0.TW)) && (r.w <= (1 << m_context->TEX0.TH)));  // Input texture is big enough, if any
-
-	trxreg.RRW = r.width();
-	trxreg.RRH = r.height();
+	trxreg.RRW = m_r.z;
+	trxreg.RRH = m_r.w;
 
 	// SW rendering code, mainly taken from GSState::Move(), TRXPOS.DIR{X,Y} management excluded
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -41,6 +41,8 @@ private:
 	bool m_userhacks_enabled_gs_mem_clear;
 	bool m_userHacks_merge_sprite;
 
+	static const float SSR_UV_TOLERANCE;
+
 	#pragma region hacks
 
 	typedef bool (GSRendererHW::*OI_Ptr)(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
@@ -138,6 +140,7 @@ private:
 	float alpha0(int L, int X0, int X1);
 	float alpha1(int L, int X0, int X1);
 	void SwSpriteRender();
+	bool CanUseSwSpriteRender(bool allow_64x64_sprite);
 
 	template <bool linear> void RoundSpriteOffset();
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -55,6 +55,7 @@ private:
 	void OI_DoubleHalfClear(GSTexture* rt, GSTexture* ds); // always on
 
 	bool OI_BigMuthaTruckers(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
+	bool OI_DBZBT2(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_FFXII(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_FFX(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_MetalSlug6(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
@@ -67,10 +68,8 @@ private:
 	bool OI_ItadakiStreet(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_JakGames(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
-	void OO_DBZBT2();
 	void OO_MajokkoALaMode2();
 
-	bool CU_DBZBT2();
 	bool CU_MajokkoALaMode2();
 	bool CU_TalesOfAbyss();
 


### PR DESCRIPTION
Improve and use `GSRendererHW::SwSpriteRender` for rendering sprites in DBZ:BT2, replacing the current OO and CU methods with an OI method, similar to what has been done for Jak games.

This both improves the performances and correctly renders some effects such as kaioken and character outlines also at upscaled resolutions.

Function `GSC_DBZBT2` in `GSHwHack.cpp` has been removed, as it clashes with the new OI method (if it is not removed, blur builds up around characters models).

Some assertions in `GSRendererHW::SwSpriteRender` have been improved to ease debugging.

An handy method `GSRendererHW::CanUseSwSpriteRender` has been implemented, to factorize the checks that are needed to be performed prior calling the `GSRendererHW::SwSpriteRender` to replace current draw call.
Looking forward to backport the usage of the usage of `GSRendererHW::CanUseSwSpriteRender` to `GSRendererHW::OI_JakGames` to reduce custom checking code.

Changelist:

- In `GSRendererHW::SwSpriteRender`, improve alpha blending by implementing all the possible `ALPHA.C` cases,
- In `GSRendererHW::SwSpriteRender`, improve texture function by implementing the `TEX0.TFX = 1` case,
- In `GSRendererHW::SwSpriteRender`, use `GS_PRIM` enums for `PRIM.PRIM` register checks in assertions instead of hardcoded values,
- In `GSRendererHW::SwSpriteRender`, use `m_r` as drawing region rectangle directly,
- In `GSRendererHW::SwSpriteRender`, correct assertions for no input texture offset, no input texture min/mag, no input texture UV wrap,
- In `GSRendererHW::SwSpriteRender`, allow non flat shading,
- In `GSRendererHW::SwSpriteRender`, ensure color equality only in case the draw is not a sprite draw,
- In `GSRendererHW::SwSpriteRender`, use the color of last vertex for the draw,
- In `GSRendererHW::SwSpriteRender`, fix the implementation of frame buffer masking using `FRAME.FBMSK`,
- Add `GSRendererHW::CanUseSwSpriteRender` method to factorize the checks needed before calling `GSRendererHW::SwSpriteRender` to replace current draw,
- In `GSHwHack.cpp` remove function `GSC_DBZBT2`,
- In `GSRendererHW`, replace OO & CU methods for DBZ:BT2 with a new OI method using the sw sprite render,


Tests shown up to 3ms frametime reduction on Intel i5-2500k and Nvidia GTX 770.


Needed https://github.com/PCSX2/pcsx2/pull/3091