### PR TITLE
GSdx-hw OGL: fix PBO pool map size.

### DIFF
--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -69,7 +69,8 @@ namespace PboPool {
 
 	char* Map(uint32 size) {
 		char* map;
-		m_size = size;
+		// Note: keep offset aligned for SSE/AVX
+		m_size = (size + 63) & ~0x3F;
 
 		if (m_size > m_pbo_size) {
 			fprintf(stderr, "BUG: PBO too small %u but need %u\n", m_pbo_size, m_size);
@@ -142,8 +143,7 @@ namespace PboPool {
 	}
 
 	void EndTransfer() {
-		// Note: keep offset aligned for SSE/AVX
-		m_offset += (m_size + 63) & ~0x3F;
+		m_offset += m_size;
 	}
 }
 

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -121,6 +121,11 @@ namespace PboPool {
 			// Align current transfer on the start of the segment
 			m_offset = m_seg_size * segment_next;
 
+			if (m_size > m_seg_size) {
+				fprintf(stderr, "BUG: PBO Map size %u is bigger than a single segment %u. Crossing more than one fence is not supported yet, texture data may be corrupted.\n", m_size, m_seg_size);
+				// TODO Synchronize all crossed fences
+			}
+
 			// protect the left segment
 			m_fence[segment_current] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 


### PR DESCRIPTION
Fix `PboPool::Map` method by rounding up the size for alignment before computing the offset for the writes, thus avoiding memcpy after the end of PBO buffer.

Bonus: an error log and a TODO are added in the case that the size of the write will exceed the size of the PBO segment (currently 16MB), in which case not all the required memory fences will be synchronized, thus texture data corruption may occur.

Special thanks to @gregory38 for spotting the issue and proposing the solution, and to @atomic83GitHub for the intense testing.

Closes #2916 
