### PR TITLE
3rdparty/pthreads4w: Revert recent pthreads changes/commits

### DIFF
--- a/3rdparty/pthreads4w/autostatic.c
+++ b/3rdparty/pthreads4w/autostatic.c
@@ -73,14 +73,9 @@ static void on_process_init(void)
 attribute_section(".ctors") void *gcc_ctor = on_process_init;
 attribute_section(".dtors") void *gcc_dtor = on_process_exit;
 
-#if !PCSX2_FIX
 attribute_section(".CRT$XCU") void *msc_ctor = on_process_init;
+#if !PCSX2_FIX
 attribute_section(".CRT$XPU") void *msc_dtor = on_process_exit;
-#else
-// MSVC puts all initializers in .CRT$XCU and order of those is not fully deterministic
-// Since the entire point of this is to call on_process_init before any other initializer,
-// move it to .CRT$XCP so it is guaranteed it initializes early
-attribute_section(".CRT$XCP") void *msc_ctor = on_process_init;
 #endif
 
 #endif /* defined(__MINGW64__) || defined(__MINGW32__) || defined(_MSC_VER) */

--- a/3rdparty/pthreads4w/autostatic.c
+++ b/3rdparty/pthreads4w/autostatic.c
@@ -36,33 +36,21 @@
 
 #if defined(PTW32_STATIC_LIB)
 
-#define PCSX2_FIX 1 // Comment out to restore code to pristine state
-
 #if defined(__MINGW64__) || defined(__MINGW32__) || defined(_MSC_VER)
 
 #include "pthread.h"
 #include "implement.h"
 
-#if !PCSX2_FIX
 static void on_process_init(void)
 {
     pthread_win32_process_attach_np ();
 }
-#endif
 
 static void on_process_exit(void)
 {
     pthread_win32_thread_detach_np  ();
     pthread_win32_process_detach_np ();
 }
-
-#if PCSX2_FIX
-static void on_process_init(void)
-{
-    pthread_win32_process_attach_np();
-    atexit(on_process_exit);
-}
-#endif
 
 #if defined(__MINGW64__) || defined(__MINGW32__)
 # define attribute_section(a) __attribute__((section(a)))
@@ -74,9 +62,7 @@ attribute_section(".ctors") void *gcc_ctor = on_process_init;
 attribute_section(".dtors") void *gcc_dtor = on_process_exit;
 
 attribute_section(".CRT$XCU") void *msc_ctor = on_process_init;
-#if !PCSX2_FIX
 attribute_section(".CRT$XPU") void *msc_dtor = on_process_exit;
-#endif
 
 #endif /* defined(__MINGW64__) || defined(__MINGW32__) || defined(_MSC_VER) */
 


### PR DESCRIPTION
This reverts commits:
https://github.com/PCSX2/pcsx2/commit/88a02941f698577ecc45450308269f57e1d066ad
https://github.com/PCSX2/pcsx2/commit/af6f04020225eaf3239bc9b4542f4afd84560540

It actually causes more issues instead of fixing so just revert the new
code. Porting to std::thread for 1.8 would be a far better alternative.

Current master is broken and hangs on pcsx2 launch.