### PR TITLE
GSdx-d3d11: Adjust maximum texture size limit based on available feature level

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -226,6 +226,12 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 		return false;
 	}
 
+	// Set maximum texture size limit based on supported feature level.
+	if (level >= D3D_FEATURE_LEVEL_11_0)
+		m_d3d_texsize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
+	else
+		m_d3d_texsize = D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION;
+
 	{	// HACK: check nVIDIA
 		// Note: It can cause issues on several games such as SOTC, Fatal Frame, plus it adds border offset.
 		bool disable_safe_features = theApp.GetConfigB("UserHacks") && theApp.GetConfigB("UserHacks_Disable_Safe_Features");
@@ -638,8 +644,9 @@ GSTexture* GSDevice11::CreateSurface(int type, int w, int h, int format)
 
 	memset(&desc, 0, sizeof(desc));
 
-	desc.Width = std::max(1, std::min(w, 8192)); // Texture limit for D3D10 min 1, max 8192
-	desc.Height = std::max(1, std::min(h, 8192));
+	// Texture limit for D3D10/11 min 1, max 8192 D3D10, max 16384 D3D11.
+	desc.Width = std::max(1, std::min(w, m_d3d_texsize));
+	desc.Height = std::max(1, std::min(h, m_d3d_texsize));
 	desc.Format = (DXGI_FORMAT)format;
 	desc.MipLevels = 1;
 	desc.ArraySize = 1;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -638,6 +638,9 @@ void GSDevice11::ClearStencil(GSTexture* t, uint8 c)
 
 GSTexture* GSDevice11::CreateSurface(int type, int w, int h, int format)
 {
+	ASSERT(w > 0 && w <= m_d3d_texsize);
+	ASSERT(h > 0 && h <= m_d3d_texsize);
+
 	HRESULT hr;
 
 	D3D11_TEXTURE2D_DESC desc;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -342,6 +342,7 @@ private:
 	float m_hack_topleft_offset;
 	int m_upscale_multiplier;
 	int m_mipmap;
+	int m_d3d_texsize;
 
 	GSTexture* CreateSurface(int type, int w, int h, int format);
 	GSTexture* FetchSurface(int type, int w, int h, int format);

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -155,6 +155,9 @@ namespace PboPool {
 GSTextureOGL::GSTextureOGL(int type, int w, int h, int format, GLuint fbo_read, bool mipmap)
 	: m_clean(false), m_generate_mipmap(true), m_local_buffer(nullptr), m_r_x(0), m_r_y(0), m_r_w(0), m_r_h(0), m_layer(0)
 {
+	ASSERT(w > 0);
+	ASSERT(h > 0);
+
 	// OpenGL didn't like dimensions of size 0
 	m_size.x = std::max(1,w);
 	m_size.y = std::max(1,h);


### PR DESCRIPTION
d3d10 = 8192
d3d11 = 16384

Seems it is easier to hit the limit. Champions of Norrath with 8x upscale for example.