### PR TITLE
GSdx-hw: Enable automatic mipmapping for Jak X.

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -212,6 +212,7 @@ void GSRendererHW::SetGameCRC(uint32 crc, int options)
 			case CRC::HarryPotterOOTP:
 			case CRC::Jak1:
 			case CRC::Jak3:
+			case CRC::JakX:
 			case CRC::LegacyOfKainDefiance:
 			case CRC::NicktoonsUnite:
 			case CRC::ProjectSnowblind:


### PR DESCRIPTION
Fixes screen rendering.