### PR TITLE
Make recLUT not hardcoded to 32 MB.

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -519,7 +519,7 @@ static void recAlloc()
 	for (int i = 0; i < 0x10000; i++)
 		recLUT_SetPage(recLUT, 0, 0, 0, i, 0);
 
-	for ( int i = 0x0000; i < 0x0200; i++ )
+	for ( int i = 0x0000; i < Ps2MemSize::MainRam / 0x10000; i++ )
 	{
 		recLUT_SetPage(recLUT, hwLUT, recRAM, 0x0000, i, i);
 		recLUT_SetPage(recLUT, hwLUT, recRAM, 0x2000, i, i);


### PR DESCRIPTION
This change makes the EE recompiler not hardcoded to working with 32 MB of RAM, and instead work with the amount of RAM set in Ps2MemSize::MainRam. The rest of PCSX2 seems to work fine with more than 32 MB of RAM - it is only the EE recompiler that has trouble. If the Ps2MemSize::MainRam value is not changed from the default 32 MB, there should be no change: 32 MB / 0x10000 = 0x200, the value that was there previously.

This may be helpful if anybody else in the future wants to emulate a PS2 dev kit with 128 MB or RAM, or maybe the PSX dvr thing which I think has 64 MB of RAM. I've confirmed that with the change, you could set Ps2MemSize::MainRam to 128 MB, and execute code with the recompiler that's above the first 32 MB of RAM, and do VIF and scratchpad DMA transfers from this upper memory as well.