### PR TITLE
GSdx-ocl: Enable OpenCL build option on Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -219,6 +219,7 @@ for ARG in "$@"; do
         --no-cross-multilib ) useCross=0; ;;
         --coverity          ) CoverityBuild=1; cleanBuild=1; ;;
         --vtune             ) flags="$flags -DUSE_VTUNE=TRUE" ;;
+        --opencl            ) flags="$flags -DOPENCL_API=TRUE" ;;
         -D*                 ) flags="$flags $ARG" ;;
 
         *)
@@ -239,6 +240,7 @@ for ARG in "$@"; do
             echo "--glsl          : Replace CG backend of ZZogl by GLSL"
             echo "--egl           : Replace GLX by EGL (ZZogl/GSdx plugins)"
             echo "--cross-multilib: Build a 32bit PCSX2 on a 64bit machine using multilib."
+            echo "--opencl        : Enable experimental OpenCL support"
             echo
             echo "** Distribution Compatibilities **"
             echo "--sdl12         : Build with SDL1.2 (requires if wx is linked against SDL1.2)"

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -35,7 +35,7 @@ option(USE_VTUNE "Plug VTUNE to profile GSdx JIT.")
 #-------------------------------------------------------------------------------
 option(GLSL_API "Replace ZZogl CG backend by GLSL (experimental option)")
 option(EGL_API "Use EGL on ZZogl/GSdx (experimental/developer option)")
-option(OPENCL_API "Add OpenCL suppport on GSdx")
+option(OPENCL_API "Add OpenCL support on GSdx")
 option(REBUILD_SHADER "Rebuild GLSL/CG shader (developer option)")
 option(BUILD_REPLAY_LOADERS "Build GS replayer to ease testing (developer option)")
 option(GSDX_LEGACY "Build a GSdx legacy plugin compatible with GL3.3")

--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -48,7 +48,7 @@ if(EGL_API AND EGL_FOUND)
 endif()
 
 
-if(OPENCL_API)
+if(OPENCL_FOUND)
     set(GSdxFinalFlags ${GSdxFinalFlags} -DENABLE_OPENCL)
 endif()
 

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -347,9 +347,6 @@ void GSdxApp::Init()
 	// D3D Blending option
 	m_default_configuration["accurate_blending_unit_d3d11"]               = "1";
 
-	// OpenCL device. Windows only for now.
-	m_default_configuration["ocldev"]                                     = "";
-
 	// PSX option. Not supported on linux.
 	m_default_configuration["dithering"]                                  = "1";
 	m_default_configuration["ModeRefreshRate"]                            = "0";
@@ -391,6 +388,7 @@ void GSdxApp::Init()
 	m_default_configuration["ModeHeight"]                                 = "480";
 	m_default_configuration["ModeWidth"]                                  = "640";
 	m_default_configuration["NTSC_Saturation"]                            = "1";
+	m_default_configuration["ocldev"]                                     = "";
 #ifdef _WIN32
 	m_default_configuration["osd_fontname"]                               = "C:\\Windows\\Fonts\\tahoma.ttf";
 #else

--- a/plugins/GSdx/res/tfx.cl
+++ b/plugins/GSdx/res/tfx.cl
@@ -1,9 +1,3 @@
-#if defined(CL_VERSION_2_0)
-
-#error hello
-
-#endif
-
 #if defined(CL_VERSION_1_1) || defined(CL_VERSION_1_2) // make safe to include in resource file to enforce dependency
 
 #ifdef cl_amd_printf


### PR DESCRIPTION
Easy as adding `--opencl` when running `./build.sh`.
Removed #error hello since latest 32-bit version of OpenCL is 1.2 anyway and there isn't any significance noted for it.
This doesn't improve the renderer but I thought this might help.