### PR TITLE
Corrected Parsing Error in Pnach Type 6 Code Parsing

### DIFF
--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -147,7 +147,7 @@ void handle_extended_t(IniPatch *p)
 			}
 			else
 			{
-				if (((mem & 0x0FFFFFFF) & 0x3FFFFFFC) != 0)
+				if (((mem & 0x0FFFFFFF) & 0x3FFFFFFC) == 0)
 					PrevCheatType = 0;
 				else
 					PrevCheatType = 0x6001;


### PR DESCRIPTION
The parsing error results in type 6 codes with more than one offsets getting terminated early.