### PR TITLE
OnePad: Fixes analog sticks not registering in some games.

### DIFF
--- a/plugins/onepad/GamePad.h
+++ b/plugins/onepad/GamePad.h
@@ -57,6 +57,10 @@ public:
      * Rumble will differ according to type which is either 0(small motor) or 1(big motor)
      */
     virtual void Rumble(unsigned type, unsigned pad) {}
+
+    //Returns true if the user expects the joystict to be analog
+    virtual bool GetGuideButton() { return false; }
+
     /*
      * Safely dispatch to the Rumble method above
      */

--- a/plugins/onepad/KeyStatus.cpp
+++ b/plugins/onepad/KeyStatus.cpp
@@ -29,6 +29,9 @@ void KeyStatus::Init()
         m_internal_button_joy[pad] = 0xFFFF;
         m_state_acces[pad] = false;
 
+        m_guide_button[pad] = false;
+        m_guide_button_pressed[pad] = false;
+
         for (int index = 0; index < MAX_KEYS; index++) {
             m_button_pressure[pad][index] = 0xFF;
             m_internal_button_pressure[pad][index] = 0xFF;
@@ -87,6 +90,25 @@ void KeyStatus::release(u32 pad, u32 index)
     } else {
         analog_set(pad, index, m_analog_released_val);
     }
+}
+
+void KeyStatus::pressGuide( u32 pad )
+{
+    m_guide_button_pressed[pad] = true;
+}
+
+void KeyStatus::releaseGuide( u32 pad )
+{
+    if ( m_guide_button_pressed[pad] )
+    {
+        m_guide_button_pressed[pad] = false;
+        m_guide_button[pad] = !m_guide_button[pad];
+    }
+}
+
+bool KeyStatus::getGuide(u32 pad)
+{
+    return m_guide_button[pad];
 }
 
 u16 KeyStatus::get(u32 pad)

--- a/plugins/onepad/KeyStatus.h
+++ b/plugins/onepad/KeyStatus.h
@@ -54,6 +54,9 @@ private:
     bool analog_is_reversed(u32 pad, u32 index);
     u8 analog_merge(u8 kbd, u8 joy);
 
+    bool m_guide_button[GAMEPAD_NUMBER];
+    bool m_guide_button_pressed[GAMEPAD_NUMBER];
+
 public:
     KeyStatus()
         : m_analog_released_val(0x7F)
@@ -67,6 +70,10 @@ public:
 
     void press(u32 pad, u32 index, s32 value = 0xFF);
     void release(u32 pad, u32 index);
+
+    void pressGuide(u32 pad);
+    void releaseGuide(u32 pad);
+    bool getGuide(u32 pad);
 
     u16 get(u32 pad);
     u8 get(u32 pad, u32 index);

--- a/plugins/onepad/Linux/linux.cpp
+++ b/plugins/onepad/Linux/linux.cpp
@@ -88,6 +88,11 @@ void PollForJoystickInput(int cpad)
 
     gamePad->UpdateGamePadState();
 
+    if ( gamePad->GetGuideButton() )
+        g_key_status.pressGuide( cpad );
+    else
+        g_key_status.releaseGuide( cpad );
+
     for (int i = 0; i < MAX_KEYS; i++) {
         s32 value = gamePad->GetInput((gamePadValues)i);
         if (value != 0)

--- a/plugins/onepad/SDL/joystick.cpp
+++ b/plugins/onepad/SDL/joystick.cpp
@@ -267,8 +267,9 @@ int JoystickInfo::GetInput(gamePadValues input)
 
     // Handle analog inputs which range from -32k to +32k. Range conversion is handled later in the controller
     if (IsAnalogKey(input)) {
-        int value = SDL_GameControllerGetAxis(m_controller, (SDL_GameControllerAxis)m_pad_to_sdl[input]);
-        value *= k;
+        float f_value = (float)SDL_GameControllerGetAxis(m_controller, (SDL_GameControllerAxis)m_pad_to_sdl[input]);
+        f_value *= k;
+        int value = (int)f_value;
         return (abs(value) > m_deadzone) ? value : 0;
     }
 
@@ -281,6 +282,11 @@ int JoystickInfo::GetInput(gamePadValues input)
     // Remain buttons
     int value = SDL_GameControllerGetButton(m_controller, (SDL_GameControllerButton)m_pad_to_sdl[input]);
     return value ? 0xFF : 0; // Max pressure
+}
+
+bool JoystickInfo::GetGuideButton()
+{
+    return SDL_GameControllerGetButton(m_controller, SDL_CONTROLLER_BUTTON_GUIDE) != 0;
 }
 
 void JoystickInfo::UpdateGamePadState()

--- a/plugins/onepad/SDL/joystick.h
+++ b/plugins/onepad/SDL/joystick.h
@@ -54,6 +54,8 @@ public:
 
     size_t GetUniqueIdentifier() final;
 
+    bool GetGuideButton() override;
+
 private:
     SDL_GameController *m_controller;
     SDL_Haptic *m_haptic;

--- a/plugins/onepad/state_management.cpp
+++ b/plugins/onepad/state_management.cpp
@@ -42,6 +42,8 @@ QueryInfo query;
 Pad pads[2][4];
 int slots[2] = {0, 0};
 
+bool _forceAnalog[2] = { false, false };
+
 //////////////////////////////////////////////////////////////////////
 // QueryInfo implementation
 //////////////////////////////////////////////////////////////////////
@@ -188,6 +190,7 @@ u8 pad_poll(u8 value)
     }
 
     Pad *pad = &pads[query.port][query.slot];
+    bool force = false;
 
     if (query.lastByte == 0) {
         query.lastByte++;
@@ -240,6 +243,15 @@ u8 pad_poll(u8 value)
 					b1=b1 & 0x1f;
 #endif
 
+                //Set teh force mode
+                force = g_key_status.getGuide( query.port );
+                if ( _forceAnalog[query.port] != force )
+                {
+                    _forceAnalog[query.port] = force;
+                    pad->rumble_all();
+                    printf("OnePad transition to %s mode\r\n", force? "Forced Analog": "Normal");
+                }
+
                 uint16_t buttons = g_key_status.get(query.port);
 
                 query.numBytes = 5;
@@ -247,7 +259,39 @@ u8 pad_poll(u8 value)
                 query.response[3] = (buttons >> 8) & 0xFF;
                 query.response[4] = (buttons >> 0) & 0xFF;
 
-                if (pad->mode != MODE_DIGITAL) { // ANALOG || DS2 native
+                //Normal mode
+                if ( !force )
+                {
+                    if (pad->mode != MODE_DIGITAL) { // ANALOG || DS2 native
+                        query.numBytes = 9;
+
+                        query.response[5] = g_key_status.get(query.port, PAD_R_RIGHT);
+                        query.response[6] = g_key_status.get(query.port, PAD_R_UP);
+                        query.response[7] = g_key_status.get(query.port, PAD_L_RIGHT);
+                        query.response[8] = g_key_status.get(query.port, PAD_L_UP);
+
+                        if (pad->mode != MODE_ANALOG) { // DS2 native
+                            query.numBytes = 21;
+
+                            query.response[9] = !test_bit(buttons, 13) ? g_key_status.get(query.port, PAD_RIGHT) : 0;
+                            query.response[10] = !test_bit(buttons, 15) ? g_key_status.get(query.port, PAD_LEFT) : 0;
+                            query.response[11] = !test_bit(buttons, 12) ? g_key_status.get(query.port, PAD_UP) : 0;
+                            query.response[12] = !test_bit(buttons, 14) ? g_key_status.get(query.port, PAD_DOWN) : 0;
+
+                            query.response[13] = !test_bit(buttons, 4) ? g_key_status.get(query.port, PAD_TRIANGLE) : 0;
+                            query.response[14] = !test_bit(buttons, 5) ? g_key_status.get(query.port, PAD_CIRCLE) : 0;
+                            query.response[15] = !test_bit(buttons, 6) ? g_key_status.get(query.port, PAD_CROSS) : 0;
+                            query.response[16] = !test_bit(buttons, 7) ? g_key_status.get(query.port, PAD_SQUARE) : 0;
+                            query.response[17] = !test_bit(buttons, 2) ? g_key_status.get(query.port, PAD_L1) : 0;
+                            query.response[18] = !test_bit(buttons, 3) ? g_key_status.get(query.port, PAD_R1) : 0;
+                            query.response[19] = !test_bit(buttons, 0) ? g_key_status.get(query.port, PAD_L2) : 0;
+                            query.response[20] = !test_bit(buttons, 1) ? g_key_status.get(query.port, PAD_R2) : 0;
+                        }
+                    }
+                }
+                //In force mode, we always store the analog and dialog values
+                else
+                {
                     query.numBytes = 9;
 
                     query.response[5] = g_key_status.get(query.port, PAD_R_RIGHT);
@@ -255,23 +299,21 @@ u8 pad_poll(u8 value)
                     query.response[7] = g_key_status.get(query.port, PAD_L_RIGHT);
                     query.response[8] = g_key_status.get(query.port, PAD_L_UP);
 
-                    if (pad->mode != MODE_ANALOG) { // DS2 native
-                        query.numBytes = 21;
+                    query.numBytes = 21;
 
-                        query.response[9] = !test_bit(buttons, 13) ? g_key_status.get(query.port, PAD_RIGHT) : 0;
-                        query.response[10] = !test_bit(buttons, 15) ? g_key_status.get(query.port, PAD_LEFT) : 0;
-                        query.response[11] = !test_bit(buttons, 12) ? g_key_status.get(query.port, PAD_UP) : 0;
-                        query.response[12] = !test_bit(buttons, 14) ? g_key_status.get(query.port, PAD_DOWN) : 0;
+                    query.response[9] = !test_bit(buttons, 13) ? g_key_status.get(query.port, PAD_RIGHT) : 0;
+                    query.response[10] = !test_bit(buttons, 15) ? g_key_status.get(query.port, PAD_LEFT) : 0;
+                    query.response[11] = !test_bit(buttons, 12) ? g_key_status.get(query.port, PAD_UP) : 0;
+                    query.response[12] = !test_bit(buttons, 14) ? g_key_status.get(query.port, PAD_DOWN) : 0;
 
-                        query.response[13] = !test_bit(buttons, 4) ? g_key_status.get(query.port, PAD_TRIANGLE) : 0;
-                        query.response[14] = !test_bit(buttons, 5) ? g_key_status.get(query.port, PAD_CIRCLE) : 0;
-                        query.response[15] = !test_bit(buttons, 6) ? g_key_status.get(query.port, PAD_CROSS) : 0;
-                        query.response[16] = !test_bit(buttons, 7) ? g_key_status.get(query.port, PAD_SQUARE) : 0;
-                        query.response[17] = !test_bit(buttons, 2) ? g_key_status.get(query.port, PAD_L1) : 0;
-                        query.response[18] = !test_bit(buttons, 3) ? g_key_status.get(query.port, PAD_R1) : 0;
-                        query.response[19] = !test_bit(buttons, 0) ? g_key_status.get(query.port, PAD_L2) : 0;
-                        query.response[20] = !test_bit(buttons, 1) ? g_key_status.get(query.port, PAD_R2) : 0;
-                    }
+                    query.response[13] = !test_bit(buttons, 4) ? g_key_status.get(query.port, PAD_TRIANGLE) : 0;
+                    query.response[14] = !test_bit(buttons, 5) ? g_key_status.get(query.port, PAD_CIRCLE) : 0;
+                    query.response[15] = !test_bit(buttons, 6) ? g_key_status.get(query.port, PAD_CROSS) : 0;
+                    query.response[16] = !test_bit(buttons, 7) ? g_key_status.get(query.port, PAD_SQUARE) : 0;
+                    query.response[17] = !test_bit(buttons, 2) ? g_key_status.get(query.port, PAD_L1) : 0;
+                    query.response[18] = !test_bit(buttons, 3) ? g_key_status.get(query.port, PAD_R1) : 0;
+                    query.response[19] = !test_bit(buttons, 0) ? g_key_status.get(query.port, PAD_L2) : 0;
+                    query.response[20] = !test_bit(buttons, 1) ? g_key_status.get(query.port, PAD_R2) : 0;
                 }
 
 #if 0
@@ -312,7 +354,7 @@ u8 pad_poll(u8 value)
             }
 
                 query.lastByte = 1;
-                return pad->mode;
+                return (!force) ? pad->mode: MODE_ANALOG;
 
             case CMD_SET_VREF_PARAM:
                 query.set_final_result(noclue);


### PR DESCRIPTION
Linux has a bug with some games that don't detect the analog sticks. Sky Odyssey is the game I observed this behavior on.

This update adds default behavior to the Guide button (Tested on Xbox 360 controller) which forces the analog sticks to update. Previously the guide button wasn't referenced in OnePad.

I've added a few extra state-full variables that track the Guide button. None of the core logic for handling key presses was touched in OnePad.

I've tested for several hours with multiple games, the change appears to be stable.

Usage:

    Load a game.
    Once the game has started, the user can press the guide button to toggle between normal and force analog mode.
    In force analog mode, the analog sticks function as expected in game.
    A printf is sent to the log window
    The default state is untouched
    The patch always starts in the default state.
