### PR TITLE
cmake: Fix build with cmake-3.5.2.

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -220,7 +220,7 @@ if(GCC_VERSION VERSION_EQUAL "7.0" OR GCC_VERSION VERSION_EQUAL "7.1")
     GCC7_BUG()
 endif()
 
-if(GCC_VERSION GREATER_EQUAL "9.0" AND GCC_VERSION LESS "9.2")
+if((GCC_VERSION VERSION_EQUAL "9.0" OR GCC_VERSION VERSION_GREATER "9.0") AND GCC_VERSION LESS "9.2")
     message(WARNING "
     It looks like you are compiling with 9.0.x or 9.1.x. Using these versions is not recommended,
     as there is a bug known to cause the compiler to segfault while compiling. See patch


### PR DESCRIPTION
For Slackware stable (`14.2`) it has the older `cmake-3.5.2` which does not seem to support `GREATER_EQUAL`. So I replaced it with `VERSION_EQUAL` and `VERSION_GREATER` which is more verbose, but works with both newer and older cmake versions.

Unfortunately I am stuck testing against older cmake versions until Slackware 15.0 is out (When its ready).
```
CMake Error at cmake/SearchForStuff.cmake:225 (if):
  if given arguments:

    "GCC_VERSION" "GREATER_EQUAL" "9.0" "AND" "GCC_VERSION" "LESS" "9.2"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:27 (include)


-- Configuring incomplete, errors occurred!
See also "/tmp/SBo/pcsx2/build/CMakeFiles/CMakeOutput.log".
See also "/tmp/SBo/pcsx2/build/CMakeFiles/CMakeError.log".
```