### PR TITLE
pcsx2: Partially fix IPU PACK command

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -606,15 +606,14 @@ static __ri bool ipuPACK(tIPU_CMD_CSC csc)
 
 	for (;ipu_cmd.index < (int)csc.MBC; ipu_cmd.index++)
 	{
-		for(;ipu_cmd.pos[0] < 8; ipu_cmd.pos[0]++)
+		for(;ipu_cmd.pos[0] < (int)sizeof(macroblock_rgb32) / 8; ipu_cmd.pos[0]++)
 		{
-			if (!getBits64((u8*)&decoder.mb8 + 8 * ipu_cmd.pos[0], 1)) return false;
+			if (!getBits64((u8*)&decoder.rgb32 + 8 * ipu_cmd.pos[0], 1)) return false;
 		}
 
-		ipu_csc(decoder.mb8, decoder.rgb32, 0);
 		ipu_dither(decoder.rgb32, decoder.rgb16, csc.DTE);
 
-		if (csc.OFM) ipu_vq(decoder.rgb16, indx4);
+		if (!csc.OFM) ipu_vq(decoder.rgb16, indx4);
 
 		if (csc.OFM)
 		{


### PR DESCRIPTION
The pack command converts from RGB32 to RGB16/INDX4, not RAW8 to RGB16/INDX4.

Also, the VQ conversion (still unimplemented) only occurs when the output format is 0, so fix that as well.