### PR TITLE
Fix build error with clang9.

### DIFF
--- a/common/include/x86emitter/x86_intrin.h
+++ b/common/include/x86emitter/x86_intrin.h
@@ -68,7 +68,7 @@ static __inline__ __attribute__((always_inline)) unsigned long long xgetbv(unsig
 #endif
 
 // Rotate instruction
-#if defined(__clang__)
+#if defined(__clang__) && __clang_major__ < 9
 // Seriously what is so complicated to provided this bunch of intrinsics in clangs.
 [[maybe_unused]] static unsigned int _rotr(unsigned int x, int s)
 {


### PR DESCRIPTION
Fixes a build issue with `clang-9.0.0`. Please see this comment https://github.com/PCSX2/pcsx2/issues/3096#issuecomment-536298922.

Note that it still doesn't build with clang, but it gets as far as the original issue now.