### PR TITLE
spu2-x: Fix crash with an invalid output module.

### DIFF
--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -132,24 +132,20 @@ void ReadSettings()
 // find current API
 #ifdef __linux__
     CfgReadStr(L"PORTAUDIO", L"HostApi", temp, L"ALSA");
-    OutputAPI = -1;
-    if (temp == L"ALSA")
-        OutputAPI = 0;
     if (temp == L"OSS")
         OutputAPI = 1;
-    if (temp == L"JACK")
+    else if (temp == L"JACK")
         OutputAPI = 2;
+    else // L"ALSA"
+        OutputAPI = 0;
 #else
     CfgReadStr(L"PORTAUDIO", L"HostApi", temp, L"OSS");
-    OutputAPI = -1;
-
-    if (temp == L"OSS")
-        OutputAPI = 0;
+    OutputAPI = 0; // L"OSS"
 #endif
 
 #ifdef __unix__
     CfgReadStr(L"SDL", L"HostApi", temp, L"pulseaudio");
-    SdlOutputAPI = -1;
+    SdlOutputAPI = 0;
 #if SDL_MAJOR_VERSION >= 2
     // YES It sucks ...
     for (int i = 0; i < SDL_GetNumAudioDrivers(); ++i) {

--- a/plugins/spu2-x/src/Linux/Config.cpp
+++ b/plugins/spu2-x/src/Linux/Config.cpp
@@ -174,6 +174,12 @@ void ReadSettings()
 
     Clampify(SndOutLatencyMS, LATENCY_MIN, LATENCY_MAX);
 
+    if (mods[OutputModule] == NULL) {
+        fwprintf(stderr, L"* SPU2-X: Unknown output module '%s' specified in configuration file.\n", temp.wc_str());
+        fprintf(stderr, "* SPU2-X: Defaulting to SDL (%S).\n", SDLOut->GetIdent());
+        OutputModule = FindOutputModuleById(SDLOut->GetIdent());
+    }
+
     WriteSettings();
     spuConfig->Flush();
 }


### PR DESCRIPTION
Fixes https://github.com/PCSX2/pcsx2/issues/3124

This will default to `SDLOut` to match the current default and also its unlikely that someone will use PCSX2 without SDL installed since its required for onepad.