### PR TITLE
gsdx_legacy: Silence very verbose clang warnings.

### DIFF
--- a/plugins/GSdx_legacy/CMakeLists.txt
+++ b/plugins/GSdx_legacy/CMakeLists.txt
@@ -15,11 +15,16 @@ set(CommonFlags
     -Wno-unknown-pragmas
     -Wno-parentheses
     -Wunused-variable # __dummy variable need to be investigated
-    # The next two need to be looked at, but spam really badly in gcc 8.
-    # Largely class alignment in GSDevice.h and memcpy in GSVector*.h.
-    -Wno-class-memaccess 
-    -Wno-packed-not-aligned
     )
+
+# The next two need to be looked at, but spam really badly in gcc 8.
+# Largely class alignment in GSDevice.h and memcpy in GSVector*.h.
+if(GCC_VERSION VERSION_EQUAL "8.0" OR GCC_VERSION VERSION_GREATER "8.0")
+    set(CommonFlags ${CommonFlags}
+        -Wno-packed-not-aligned
+        -Wno-class-memaccess
+       )
+endif()
 
 set(GSdxFinalFlags ${CommonFlags})
 


### PR DESCRIPTION
This silences many annoyingly verbose warnings using clang and the legacy GSdx plugin copying the code in the newer GSdx.

https://github.com/PCSX2/pcsx2/blob/e2d899231019ecb9e93af77cb0d57acd6fbb10c2/plugins/GSdx/CMakeLists.txt#L21

```
[107/641] Building CXX object plugins/GSdx_legacy/CMakeFiles/GSdx-legacy-1.0.0.dir/stdafx.cpp.o
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
2 warnings generated.
```