### PR TITLE
common: Silence -Wunused-function clang warnings.

### DIFF
--- a/common/include/Utilities/gtkGuiTools.h
+++ b/common/include/Utilities/gtkGuiTools.h
@@ -34,6 +34,11 @@
 // on what it's built for.
 //
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
 static GtkWidget *ps_gtk_hbox_new(int padding = 5)
 {
 #if GTK_MAJOR_VERSION < 3
@@ -131,3 +136,7 @@ static void pcsx2_message(const wchar_t *fmt, ...)
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/common/include/x86emitter/x86_intrin.h
+++ b/common/include/x86emitter/x86_intrin.h
@@ -69,16 +69,21 @@ static __inline__ __attribute__((always_inline)) unsigned long long xgetbv(unsig
 
 // Rotate instruction
 #if defined(__clang__) && __clang_major__ < 9
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+
 // Seriously what is so complicated to provided this bunch of intrinsics in clangs.
-[[maybe_unused]] static unsigned int _rotr(unsigned int x, int s)
+static unsigned int _rotr(unsigned int x, int s)
 {
     return (x >> s) | (x << (32 - s));
 }
 
-[[maybe_unused]] static unsigned int _rotl(unsigned int x, int s)
+static unsigned int _rotl(unsigned int x, int s)
 {
     return (x << s) | (x >> (32 - s));
 }
+
+#pragma clang diagnostic pop
 #endif
 
 // Not correctly defined in GCC4.8 and below ! (dunno for VS)


### PR DESCRIPTION
This silences many duplicate and very noisy trivial warnings with clang, silencing them is helpful because they make viewing potentially more serious warnings harder.
```
[3/641] Building CXX object plugins/spu2-x/src/CMakeFiles/spu2x-2.0.0.dir/Linux/Dialogs.cpp.o
In file included from ../plugins/spu2-x/src/Linux/Dialogs.cpp:20:
In file included from ../plugins/spu2-x/src/Linux/Dialogs.h:23:
../common/include/Utilities/gtkGuiTools.h:37:19: warning: unused function 'ps_gtk_hbox_new' [-Wunused-function]
static GtkWidget *ps_gtk_hbox_new(int padding = 5)
                  ^
../common/include/Utilities/gtkGuiTools.h:46:19: warning: unused function 'ps_gtk_vbox_new' [-Wunused-function]
static GtkWidget *ps_gtk_vbox_new(int padding = 5)
                  ^
../common/include/Utilities/gtkGuiTools.h:56:19: warning: unused function 'ps_gtk_hscale_new_with_range' [-Wunused-function]
static GtkWidget *ps_gtk_hscale_new_with_range(double g_min, double g_max, int g_step = 5)
                  ^
../common/include/Utilities/gtkGuiTools.h:65:19: warning: unused function 'ps_gtk_vscale_new_with_range' [-Wunused-function]
static GtkWidget *ps_gtk_vscale_new_with_range(double g_min, double g_max, int g_step = 5)
                  ^
../common/include/Utilities/gtkGuiTools.h:75:19: warning: unused function 'ps_gtk_hseparator_new' [-Wunused-function]
static GtkWidget *ps_gtk_hseparator_new()
                  ^
../common/include/Utilities/gtkGuiTools.h:84:19: warning: unused function 'ps_gtk_vseparator_new' [-Wunused-function]
static GtkWidget *ps_gtk_vseparator_new()
                  ^
../common/include/Utilities/gtkGuiTools.h:95:13: warning: unused function 'pcsx2_message' [-Wunused-function]
static void pcsx2_message(const char *fmt, ...)
            ^
../common/include/Utilities/gtkGuiTools.h:117:13: warning: unused function 'pcsx2_message' [-Wunused-function]
static void pcsx2_message(const wchar_t *fmt, ...)
            ^
8 warnings generated.
```
Please note:

* `ps_gtk_vscale_new_with_range`, `ps_gtk_hseparator_new`, `ps_gtk_vseparator_new` and `pcsx2_message` all seem completely unused based on my results with `grep -r`. I am not sure its better to leave them be or to remove them?
* Why are there two slightly different `pcsx2_message` functions? Should at least one of them be removed? Or maybe combined?