### PR TITLE
gsdx-hw: Adjust GSC_Bully crc hack

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -64,8 +64,8 @@ bool GSC_Bully(const GSFrameInfo& fi, int& skip)
 		{
 			// ntsc 0x02300, pal 0x02800
 			// Don't enable hack on native res if crc is below aggressive.
-			// skip 9 for pal but maybe 6 is enough, dump looks fine.
-			skip = 6; // Upscaling blur/ghosting
+			// Previous value 6, ntsc didn't like it.
+			skip = 8; // Upscaling blur/ghosting
 		}
 	}
 


### PR DESCRIPTION
Previous skip value 6 wasn't enough and caused some visual issues on the
ntsc version. Use value of 8 instead.

Issue reported by ozzie212121 on discord.