### PR TITLE
onepad-legacy: Allows the user to map the analog button.

### DIFF
--- a/plugins/onepad_legacy/KeyStatus.cpp
+++ b/plugins/onepad_legacy/KeyStatus.cpp
@@ -25,9 +25,9 @@ void KeyStatus::Init()
 {
     for (int pad = 0; pad < GAMEPAD_NUMBER; pad++)
     {
-        m_button[pad] = 0xFFFF;
-        m_internal_button_kbd[pad] = 0xFFFF;
-        m_internal_button_joy[pad] = 0xFFFF;
+        m_button[pad] = 0xFFFFFFFF;
+        m_internal_button_kbd[pad] = 0xFFFFFFFF;
+        m_internal_button_joy[pad] = 0xFFFFFFFF;
         m_state_acces[pad] = false;
 
         for (int index = 0; index < MAX_KEYS; index++)
@@ -97,7 +97,7 @@ void KeyStatus::release(u32 pad, u32 index)
     }
 }
 
-u16 KeyStatus::get(u32 pad)
+u32 KeyStatus::get(u32 pad)
 {
     return m_button[pad];
 }

--- a/plugins/onepad_legacy/KeyStatus.h
+++ b/plugins/onepad_legacy/KeyStatus.h
@@ -37,9 +37,9 @@ class KeyStatus
 private:
     const u8 m_analog_released_val;
 
-    u16 m_button[GAMEPAD_NUMBER];
-    u16 m_internal_button_kbd[GAMEPAD_NUMBER];
-    u16 m_internal_button_joy[GAMEPAD_NUMBER];
+    u32 m_button[GAMEPAD_NUMBER];
+    u32 m_internal_button_kbd[GAMEPAD_NUMBER];
+    u32 m_internal_button_joy[GAMEPAD_NUMBER];
 
     u8 m_button_pressure[GAMEPAD_NUMBER][MAX_KEYS];
     u8 m_internal_button_pressure[GAMEPAD_NUMBER][MAX_KEYS];
@@ -68,9 +68,8 @@ public:
     void press(u32 pad, u32 index, s32 value = 0xFF);
     void release(u32 pad, u32 index);
 
-    u16 get(u32 pad);
+    u32 get(u32 pad);
     u8 get(u32 pad, u32 index);
-
 
     void commit_status(u32 pad);
 };

--- a/plugins/onepad_legacy/Linux/ini.cpp
+++ b/plugins/onepad_legacy/Linux/ini.cpp
@@ -209,18 +209,26 @@ void LoadConfig()
             sprintf(str, "[%d][%d] = 0x%%x\n", pad, key);
             u32 temp = 0;
 
+            //Read in data, but if we fail, reset the file pointer
+            long current = ftell(f);
             if (fscanf(f, str, &temp) == 0)
+            {
+                fseek( f, current, SEEK_SET );
                 temp = 0;
+            }
+
+            //Store the read data
             set_key(pad, key, temp);
             if (temp && pad == 0)
                 have_user_setting = true;
         }
     }
 
+    //We for-loop here because if the file is malformed, we'll hang the whole program
     u32 pad;
     u32 keysym;
     u32 index;
-    while (fscanf(f, "PAD %u:KEYSYM 0x%x = %u\n", &pad, &keysym, &index) != EOF)
+    while ( fscanf(f, "PAD %u:KEYSYM 0x%x = %u\n", &pad, &keysym, &index) == 3 )
     {
         set_keyboard_key(pad & 1, keysym, index);
         if (pad == 0)

--- a/plugins/onepad_legacy/controller.h
+++ b/plugins/onepad_legacy/controller.h
@@ -21,7 +21,37 @@
 
 #pragma once
 #include <string.h> // for memset
-#define MAX_KEYS 24
+
+enum gamePadValues {
+    PAD_L2 = 0,   // L2 button
+    PAD_R2,       // R2 button
+    PAD_L1,       // L1 button
+    PAD_R1,       // R1 button
+    PAD_TRIANGLE, // Triangle button ▲
+    PAD_CIRCLE,   // Circle button ●
+    PAD_CROSS,    // Cross button ✖
+    PAD_SQUARE,   // Square button ■
+    PAD_SELECT,   // Select button
+    PAD_L3,       // Left joystick button (L3)
+    PAD_R3,       // Right joystick button (R3)
+    PAD_START,    // Start button
+    PAD_UP,       // Directional pad ↑
+    PAD_RIGHT,    // Directional pad →
+    PAD_DOWN,     // Directional pad ↓
+    PAD_LEFT,     // Directional pad ←
+    PAD_L_UP,     // Left joystick (Up) ↑
+    PAD_L_RIGHT,  // Left joystick (Right) →
+    PAD_L_DOWN,   // Left joystick (Down) ↓
+    PAD_L_LEFT,   // Left joystick (Left) ←
+    PAD_R_UP,     // Right joystick (Up) ↑
+    PAD_R_RIGHT,  // Right joystick (Right) →
+    PAD_R_DOWN,   // Right joystick (Down) ↓
+    PAD_R_LEFT,   // Right joystick (Left) ←
+
+    PAD_ANALOG,
+
+    MAX_KEYS
+};
 
 enum KeyType {
     PAD_JOYBUTTONS = 0,

--- a/plugins/onepad_legacy/onepad.h
+++ b/plugins/onepad_legacy/onepad.h
@@ -96,33 +96,6 @@ enum PadCommands {
     CMD_SET_DS2_NATIVE_MODE = 0x4F // SET_DS2_NATIVE_MODE
 };
 
-enum gamePadValues {
-    PAD_L2 = 0,   // L2 button
-    PAD_R2,       // R2 button
-    PAD_L1,       // L1 button
-    PAD_R1,       // R1 button
-    PAD_TRIANGLE, // Triangle button ▲
-    PAD_CIRCLE,   // Circle button ●
-    PAD_CROSS,    // Cross button ✖
-    PAD_SQUARE,   // Square button ■
-    PAD_SELECT,   // Select button
-    PAD_L3,       // Left joystick button (L3)
-    PAD_R3,       // Right joystick button (R3)
-    PAD_START,    // Start button
-    PAD_UP,       // Directional pad ↑
-    PAD_RIGHT,    // Directional pad →
-    PAD_DOWN,     // Directional pad ↓
-    PAD_LEFT,     // Directional pad ←
-    PAD_L_UP,     // Left joystick (Up) ↑
-    PAD_L_RIGHT,  // Left joystick (Right) →
-    PAD_L_DOWN,   // Left joystick (Down) ↓
-    PAD_L_LEFT,   // Left joystick (Left) ←
-    PAD_R_UP,     // Right joystick (Up) ↑
-    PAD_R_RIGHT,  // Right joystick (Right) →
-    PAD_R_DOWN,   // Right joystick (Down) ↓
-    PAD_R_LEFT    // Right joystick (Left) ←
-};
-
 extern keyEvent event;
 extern MtQueue<keyEvent> g_ev_fifo;
 

--- a/plugins/onepad_legacy/state_management.h
+++ b/plugins/onepad_legacy/state_management.h
@@ -86,6 +86,7 @@ struct PadFreezeData
 class Pad : public PadFreezeData
 {
 public:
+    u8 analogPressed;
     // Lilypad store here the state of PC pad
 
     void rumble(int port);
@@ -94,6 +95,7 @@ public:
     void reset();
 
     void set_mode(int mode);
+    void toggle_mode();
 
     static void reset_all();
     static void stop_vibrate_all();

--- a/plugins/onepad_legacy/wx_dialog/dialog.cpp
+++ b/plugins/onepad_legacy/wx_dialog/dialog.cpp
@@ -187,10 +187,10 @@ Dialog::Dialog()
     padding[PAD_SELECT][3] = 34;  // Y
 
     // Analog
-    padding[Analog][0] = 218; // Width
-    padding[Analog][1] = 28;  // Height
-    padding[Analog][2] = 50;  // X
-    padding[Analog][3] = 452; // Y
+    padding[PAD_ANALOG][0] = 218; // Width
+    padding[PAD_ANALOG][1] = 28;  // Height
+    padding[PAD_ANALOG][2] = 50;  // X
+    padding[PAD_ANALOG][3] = 452; // Y
 
     // Left Joystick Configuration
     padding[JoyL_config][0] = 180; // Width
@@ -274,9 +274,6 @@ Dialog::Dialog()
         m_bt_gamepad[i][Cancel]->SetLabel(_T("&Cancel"));
         m_bt_gamepad[i][Apply]->SetLabel(_T("&Apply"));
         m_bt_gamepad[i][Ok]->SetLabel(_T("&Ok"));
-
-        // Disable analog button (not yet supported)
-        m_bt_gamepad[i][Analog]->Disable();
     }
 
     Bind(wxEVT_BUTTON, &Dialog::OnButtonClicked, this);
@@ -312,7 +309,7 @@ void Dialog::OnButtonClicked(wxCommandEvent &event)
     wxButton *bt_tmp = (wxButton *)event.GetEventObject(); // get the button object
     int bt_id = bt_tmp->GetId() - wxID_HIGHEST - 1;        // get the real ID
     int gamepad_id = m_tab_gamepad->GetSelection();        // get the tab ID (equivalent to the gamepad id)
-    if (bt_id >= 0 && bt_id <= PAD_R_LEFT)                 // if the button ID is a gamepad button
+    if (bt_id >= 0 && bt_id <= MAX_KEYS )
     {
         bt_tmp->Disable();                                 // switch the button state to "Disable"
         config_key(gamepad_id, bt_id);
@@ -532,7 +529,7 @@ void Dialog::JoystickEvent(wxTimerEvent &event)
                             it = m_map_images[events.jhat.which].find(key);
                             if (it != m_map_images[events.jhat.which].end())
                             {
-                                m_pan_tabs[events.jhat.which]->ShowImg(img_dp_up);
+                                m_pan_tabs[events.jhat.which]->ShowImg(PAD_UP);
                             }
                             break;
                         case SDL_HAT_DOWN:
@@ -540,7 +537,7 @@ void Dialog::JoystickEvent(wxTimerEvent &event)
                             it = m_map_images[events.jhat.which].find(key);
                             if (it != m_map_images[events.jhat.which].end())
                             {
-                                m_pan_tabs[events.jhat.which]->ShowImg(img_dp_bottom);
+                                m_pan_tabs[events.jhat.which]->ShowImg(PAD_DOWN);
                             }
                             break;
                         case SDL_HAT_RIGHT:
@@ -548,7 +545,7 @@ void Dialog::JoystickEvent(wxTimerEvent &event)
                             it = m_map_images[events.jhat.which].find(key);
                             if (it != m_map_images[events.jhat.which].end())
                             {
-                                m_pan_tabs[events.jhat.which]->ShowImg(img_dp_right);
+                                m_pan_tabs[events.jhat.which]->ShowImg(PAD_RIGHT);
                             }
                             break;
                         case SDL_HAT_LEFT:
@@ -556,14 +553,14 @@ void Dialog::JoystickEvent(wxTimerEvent &event)
                             it = m_map_images[events.jhat.which].find(key);
                             if (it != m_map_images[events.jhat.which].end())
                             {
-                                m_pan_tabs[events.jhat.which]->ShowImg(img_dp_left);
+                                m_pan_tabs[events.jhat.which]->ShowImg(PAD_LEFT);
                             }
                             break;
                         case SDL_HAT_CENTERED:
-                            m_pan_tabs[events.jhat.which]->HideImg(img_dp_up);
-                            m_pan_tabs[events.jhat.which]->HideImg(img_dp_bottom);
-                            m_pan_tabs[events.jhat.which]->HideImg(img_dp_right);
-                            m_pan_tabs[events.jhat.which]->HideImg(img_dp_left);
+                            m_pan_tabs[events.jhat.which]->HideImg(PAD_UP);
+                            m_pan_tabs[events.jhat.which]->HideImg(PAD_DOWN);
+                            m_pan_tabs[events.jhat.which]->HideImg(PAD_RIGHT);
+                            m_pan_tabs[events.jhat.which]->HideImg(PAD_LEFT);
                     }
                 }
                 break;

--- a/plugins/onepad_legacy/wx_dialog/dialog.h
+++ b/plugins/onepad_legacy/wx_dialog/dialog.h
@@ -48,20 +48,21 @@
 // see onepad.h for more details about gamepad button id
 
 enum gui_buttons {
-    Analog = PAD_R_LEFT + 1, // Analog button (not yet supported ?)
-    JoyL_config,             // Left Joystick Configuration
+    //Analog = PAD_R_LEFT + 1, // Analog button (not yet supported ?)
+    JoyL_config = MAX_KEYS,  // Left Joystick Configuration
     JoyR_config,             // Right Joystick Configuration
     Gamepad_config,          // Gamepad Configuration
     Set_all,                 // Set all buttons
     Apply,                   // Apply modifications without exit
     Ok,                      // Apply modifications and exit
-    Cancel                   // Exit without apply modificatons
+    Cancel,                  // Exit without apply modificatons
+
+    BUTTONS_LENGTH
 };
 
-#define BUTTONS_LENGTH 32 // numbers of buttons on the gamepad
 #define UPDATE_TIME 5
 #define DEFAULT_WIDTH 1000
-#define DEFAULT_HEIGHT 740
+#define DEFAULT_HEIGHT 820 //Up from 740 to deal with 4k screens cutting off bottom
 
 class Dialog : public wxDialog
 {

--- a/plugins/onepad_legacy/wx_dialog/opPanel.cpp
+++ b/plugins/onepad_legacy/wx_dialog/opPanel.cpp
@@ -50,27 +50,27 @@ opPanel::opPanel(wxWindow *parent,
 {
     m_picture[img_background] = EmbeddedImage<res_dualshock2>().Get();
 
-    m_picture[img_start] = EmbeddedImage<res_start>().Get();
-    m_picture[img_select] = EmbeddedImage<res_select>().Get();
-    m_picture[img_analog] = EmbeddedImage<res_analog>().Get();
+    m_picture[PAD_START] = EmbeddedImage<res_start>().Get();
+    m_picture[PAD_SELECT] = EmbeddedImage<res_select>().Get();
+    m_picture[PAD_ANALOG] = EmbeddedImage<res_analog>().Get();
 
-    m_picture[img_dp_left] = EmbeddedImage<res_dp_left>().Get();
-    m_picture[img_dp_right] = EmbeddedImage<res_dp_right>().Get();
-    m_picture[img_dp_up] = EmbeddedImage<res_dp_up>().Get();
-    m_picture[img_dp_bottom] = EmbeddedImage<res_dp_bottom>().Get();
+    m_picture[PAD_LEFT] = EmbeddedImage<res_dp_left>().Get();
+    m_picture[PAD_RIGHT] = EmbeddedImage<res_dp_right>().Get();
+    m_picture[PAD_UP] = EmbeddedImage<res_dp_up>().Get();
+    m_picture[PAD_DOWN] = EmbeddedImage<res_dp_bottom>().Get();
 
-    m_picture[img_square] = EmbeddedImage<res_square>().Get();
-    m_picture[img_circle] = EmbeddedImage<res_circle>().Get();
-    m_picture[img_cross] = EmbeddedImage<res_cross>().Get();
-    m_picture[img_triangle] = EmbeddedImage<res_triangle>().Get();
+    m_picture[PAD_SQUARE] = EmbeddedImage<res_square>().Get();
+    m_picture[PAD_CIRCLE] = EmbeddedImage<res_circle>().Get();
+    m_picture[PAD_CROSS] = EmbeddedImage<res_cross>().Get();
+    m_picture[PAD_TRIANGLE] = EmbeddedImage<res_triangle>().Get();
 
-    m_picture[img_l1] = EmbeddedImage<res_l1>().Get();
-    m_picture[img_l3] = EmbeddedImage<res_l3>().Get();
-    m_picture[img_l2] = EmbeddedImage<res_l2>().Get();
+    m_picture[PAD_L1] = EmbeddedImage<res_l1>().Get();
+    m_picture[PAD_L3] = EmbeddedImage<res_l3>().Get();
+    m_picture[PAD_L2] = EmbeddedImage<res_l2>().Get();
 
-    m_picture[img_r1] = EmbeddedImage<res_r1>().Get();
-    m_picture[img_r3] = EmbeddedImage<res_r3>().Get();
-    m_picture[img_r2] = EmbeddedImage<res_r2>().Get();
+    m_picture[PAD_R1] = EmbeddedImage<res_r1>().Get();
+    m_picture[PAD_R3] = EmbeddedImage<res_r3>().Get();
+    m_picture[PAD_R2] = EmbeddedImage<res_r2>().Get();
 
     m_picture[img_left_cursor] = EmbeddedImage<res_joystick_cursor>().Get();
     m_picture[img_right_cursor] = EmbeddedImage<res_joystick_cursor>().Get();
@@ -153,25 +153,25 @@ void opPanel::OnPaint(wxPaintEvent &event)
         temp_r_arrow_bottom, temp_r_arrow_left;
 
     temp_background.SelectObject(m_picture[img_background]);
-    temp_start.SelectObject(m_picture[img_start]);
-    temp_select.SelectObject(m_picture[img_select]);
-    temp_analog.SelectObject(m_picture[img_analog]);
-    temp_dp_left.SelectObject(m_picture[img_dp_left]);
+    temp_start.SelectObject(m_picture[PAD_START]);
+    temp_select.SelectObject(m_picture[PAD_SELECT]);
+    temp_analog.SelectObject(m_picture[PAD_ANALOG]);
+    temp_dp_left.SelectObject(m_picture[PAD_LEFT]);
 
-    temp_dp_right.SelectObject(m_picture[img_dp_right]);
-    temp_dp_up.SelectObject(m_picture[img_dp_up]);
-    temp_dp_bottom.SelectObject(m_picture[img_dp_bottom]);
-    temp_l1.SelectObject(m_picture[img_l1]);
-    temp_r1.SelectObject(m_picture[img_r1]);
-    temp_L3.SelectObject(m_picture[img_l3]);
-    temp_l2_2.SelectObject(m_picture[img_l2]);
+    temp_dp_right.SelectObject(m_picture[PAD_RIGHT]);
+    temp_dp_up.SelectObject(m_picture[PAD_UP]);
+    temp_dp_bottom.SelectObject(m_picture[PAD_DOWN]);
+    temp_l1.SelectObject(m_picture[PAD_L1]);
+    temp_r1.SelectObject(m_picture[PAD_R1]);
+    temp_L3.SelectObject(m_picture[PAD_L3]);
+    temp_l2_2.SelectObject(m_picture[PAD_L2]);
 
-    temp_R3.SelectObject(m_picture[img_r3]);
-    temp_r2_2.SelectObject(m_picture[img_r2]);
-    temp_square.SelectObject(m_picture[img_square]);
-    temp_circle.SelectObject(m_picture[img_circle]);
-    temp_cross.SelectObject(m_picture[img_cross]);
-    temp_triangle.SelectObject(m_picture[img_triangle]);
+    temp_R3.SelectObject(m_picture[PAD_R3]);
+    temp_r2_2.SelectObject(m_picture[PAD_R2]);
+    temp_square.SelectObject(m_picture[PAD_SQUARE]);
+    temp_circle.SelectObject(m_picture[PAD_CIRCLE]);
+    temp_cross.SelectObject(m_picture[PAD_CROSS]);
+    temp_triangle.SelectObject(m_picture[PAD_TRIANGLE]);
 
     temp_left_cursor.SelectObject(m_picture[img_left_cursor]);
     temp_right_cursor.SelectObject(m_picture[img_right_cursor]);
@@ -188,39 +188,39 @@ void opPanel::OnPaint(wxPaintEvent &event)
 
     if (m_show_image[img_background])
         dc.Blit(wxPoint(0, 0), temp_background.GetSize(), &temp_background, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_start])
+    if (m_show_image[PAD_START])
         dc.Blit(wxPoint(526, 296), temp_start.GetSize(), &temp_start, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_select])
+    if (m_show_image[PAD_SELECT])
         dc.Blit(wxPoint(450, 297), temp_select.GetSize(), &temp_select, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_analog])
+    if (m_show_image[PAD_ANALOG])
         dc.Blit(wxPoint(489, 358), temp_analog.GetSize(), &temp_analog, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_dp_left])
+    if (m_show_image[PAD_LEFT])
         dc.Blit(wxPoint(334, 292), temp_dp_left.GetSize(), &temp_dp_left, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_dp_right])
+    if (m_show_image[PAD_RIGHT])
         dc.Blit(wxPoint(378, 292), temp_dp_right.GetSize(), &temp_dp_right, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_dp_up])
+    if (m_show_image[PAD_UP])
         dc.Blit(wxPoint(358, 269), temp_dp_up.GetSize(), &temp_dp_up, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_dp_bottom])
+    if (m_show_image[PAD_DOWN])
         dc.Blit(wxPoint(358, 312), temp_dp_bottom.GetSize(), &temp_dp_bottom, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_l1])
+    if (m_show_image[PAD_L1])
         dc.Blit(wxPoint(343, 186), temp_l1.GetSize(), &temp_l1, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_r1])
+    if (m_show_image[PAD_R1])
         dc.Blit(wxPoint(593, 186), temp_r1.GetSize(), &temp_r1, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_l3])
+    if (m_show_image[PAD_L3])
         dc.Blit(wxPoint(409, 344), temp_L3.GetSize(), &temp_L3, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_l2])
+    if (m_show_image[PAD_L2])
         dc.Blit(wxPoint(346, 158), temp_l2_2.GetSize(), &temp_l2_2, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_r3])
+    if (m_show_image[PAD_R3])
         dc.Blit(wxPoint(525, 344), temp_R3.GetSize(), &temp_R3, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_r2])
+    if (m_show_image[PAD_R2])
         dc.Blit(wxPoint(582, 158), temp_r2_2.GetSize(), &temp_r2_2, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_square])
+    if (m_show_image[PAD_SQUARE])
         dc.Blit(wxPoint(573, 287), temp_square.GetSize(), &temp_square, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_circle])
+    if (m_show_image[PAD_CIRCLE])
         dc.Blit(wxPoint(647, 287), temp_circle.GetSize(), &temp_circle, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_cross])
+    if (m_show_image[PAD_CROSS])
         dc.Blit(wxPoint(610, 324), temp_cross.GetSize(), &temp_cross, wxPoint(0, 0), wxCOPY, true);
-    if (m_show_image[img_triangle])
+    if (m_show_image[PAD_TRIANGLE])
         dc.Blit(wxPoint(610, 250), temp_triangle.GetSize(), &temp_triangle, wxPoint(0, 0), wxCOPY, true);
     if (m_show_image[img_left_cursor])
         dc.Blit(wxPoint(439 + m_left_cursor_x, 374 + m_left_cursor_y), temp_left_cursor.GetSize(), &temp_left_cursor, wxPoint(0, 0), wxCOPY, true);

--- a/plugins/onepad_legacy/wx_dialog/opPanel.h
+++ b/plugins/onepad_legacy/wx_dialog/opPanel.h
@@ -25,28 +25,12 @@
 #include <wx/wx.h>
 
 #include "EmbeddedImage.h"
+#include <onepad.h>
 
 enum gui_img {
-    img_l2,
-    img_r2,
-    img_l1,
-    img_r1,
-    img_triangle,
-    img_circle,
-    img_cross,
-    img_square,
-    img_select,
-    img_l3,
-    img_r3,
-    img_start,
-    img_dp_up,
-    img_dp_right,
-    img_dp_bottom,
-    img_dp_left,
+    img_background = MAX_KEYS, // background pic
     img_left_cursor,
     img_right_cursor,
-    img_analog,
-    img_background, // background pic
     img_l_arrow_up,
     img_l_arrow_right,
     img_l_arrow_bottom,
@@ -54,10 +38,10 @@ enum gui_img {
     img_r_arrow_up,
     img_r_arrow_right,
     img_r_arrow_bottom,
-    img_r_arrow_left
-};
+    img_r_arrow_left,
 
-#define NB_IMG 28
+    NB_IMG
+};
 
 class opPanel : public wxPanel
 {


### PR DESCRIPTION
When the analog button is pressed, the analog stick is toggled.  Fix for
Sky Odyssey