### PR TITLE
onepad: Maps the menu button to the analog button.

### DIFF
--- a/pcsx2/PAD/Linux/KeyStatus.cpp
+++ b/pcsx2/PAD/Linux/KeyStatus.cpp
@@ -19,9 +19,9 @@ void KeyStatus::Init()
 {
 	for (int pad = 0; pad < GAMEPAD_NUMBER; pad++)
 	{
-		m_button[pad] = 0xFFFF;
-		m_internal_button_kbd[pad] = 0xFFFF;
-		m_internal_button_joy[pad] = 0xFFFF;
+		m_button[pad] = 0xFFFFFFFF;
+		m_internal_button_kbd[pad] = 0xFFFFFFFF;
+		m_internal_button_joy[pad] = 0xFFFFFFFF;
 		m_state_acces[pad] = false;
 
 		for (int index = 0; index < MAX_KEYS; index++)
@@ -91,7 +91,7 @@ void KeyStatus::release(u32 pad, u32 index)
 	}
 }
 
-u16 KeyStatus::get(u32 pad)
+u32 KeyStatus::get(u32 pad)
 {
 	return m_button[pad];
 }

--- a/pcsx2/PAD/Linux/KeyStatus.h
+++ b/pcsx2/PAD/Linux/KeyStatus.h
@@ -31,9 +31,9 @@ class KeyStatus
 private:
 	const u8 m_analog_released_val;
 
-	u16 m_button[GAMEPAD_NUMBER];
-	u16 m_internal_button_kbd[GAMEPAD_NUMBER];
-	u16 m_internal_button_joy[GAMEPAD_NUMBER];
+	u32 m_button[GAMEPAD_NUMBER];
+	u32 m_internal_button_kbd[GAMEPAD_NUMBER];
+	u32 m_internal_button_joy[GAMEPAD_NUMBER];
 
 	u8 m_button_pressure[GAMEPAD_NUMBER][MAX_KEYS];
 	u8 m_internal_button_pressure[GAMEPAD_NUMBER][MAX_KEYS];
@@ -62,7 +62,7 @@ public:
 	void press(u32 pad, u32 index, s32 value = 0xFF);
 	void release(u32 pad, u32 index);
 
-	u16 get(u32 pad);
+	u32 get(u32 pad);
 	u8 get(u32 pad, u32 index);
 
 

--- a/pcsx2/PAD/Linux/PAD.h
+++ b/pcsx2/PAD/Linux/PAD.h
@@ -69,39 +69,11 @@ enum PadCommands
 	CMD_CONFIG_MODE = 0x43,
 	CMD_SET_MODE_AND_LOCK = 0x44,
 	CMD_QUERY_MODEL_AND_MODE = 0x45,
-	CMD_QUERY_ACT = 0x46,  // ??
+	CMD_QUERY_ACT = 0x46, // ??
 	CMD_QUERY_COMB = 0x47, // ??
 	CMD_QUERY_MODE = 0x4C, // QUERY_MODE ??
 	CMD_VIBRATION_TOGGLE = 0x4D,
 	CMD_SET_DS2_NATIVE_MODE = 0x4F // SET_DS2_NATIVE_MODE
-};
-
-enum gamePadValues
-{
-	PAD_L2 = 0,   // L2 button
-	PAD_R2,       // R2 button
-	PAD_L1,       // L1 button
-	PAD_R1,       // R1 button
-	PAD_TRIANGLE, // Triangle button ▲
-	PAD_CIRCLE,   // Circle button ●
-	PAD_CROSS,    // Cross button ✖
-	PAD_SQUARE,   // Square button ■
-	PAD_SELECT,   // Select button
-	PAD_L3,       // Left joystick button (L3)
-	PAD_R3,       // Right joystick button (R3)
-	PAD_START,    // Start button
-	PAD_UP,       // Directional pad ↑
-	PAD_RIGHT,    // Directional pad →
-	PAD_DOWN,     // Directional pad ↓
-	PAD_LEFT,     // Directional pad ←
-	PAD_L_UP,     // Left joystick (Up) ↑
-	PAD_L_RIGHT,  // Left joystick (Right) →
-	PAD_L_DOWN,   // Left joystick (Down) ↓
-	PAD_L_LEFT,   // Left joystick (Left) ←
-	PAD_R_UP,     // Right joystick (Up) ↑
-	PAD_R_RIGHT,  // Right joystick (Right) →
-	PAD_R_DOWN,   // Right joystick (Down) ↓
-	PAD_R_LEFT    // Right joystick (Left) ←
 };
 
 #if defined(__unix__) || defined(__APPLE__)

--- a/pcsx2/PAD/Linux/SDL/joystick.cpp
+++ b/pcsx2/PAD/Linux/SDL/joystick.cpp
@@ -148,6 +148,7 @@ JoystickInfo::JoystickInfo(int id)
 	m_pad_to_sdl[PAD_R_RIGHT] = SDL_CONTROLLER_AXIS_RIGHTX;
 	m_pad_to_sdl[PAD_R_DOWN] = SDL_CONTROLLER_AXIS_RIGHTY;
 	m_pad_to_sdl[PAD_R_LEFT] = SDL_CONTROLLER_AXIS_RIGHTX;
+	m_pad_to_sdl[PAD_ANALOG] = SDL_CONTROLLER_BUTTON_GUIDE;
 
 	if (SDL_IsGameController(id))
 	{
@@ -176,7 +177,7 @@ JoystickInfo::JoystickInfo(int id)
 						"You can use SDL2 Gamepad Tool (https://www.generalarcade.com/gamepadtool/) or Steam to configure your joystick\n"
 						"The mapping can be stored in PAD.ini as 'SDL2 = <...mapping description...>'\n"
 						"Please post the new generated mapping to (https://github.com/gabomdq/SDL_GameControllerDB) so it can be added to the database.",
-				devname, guid);
+			devname, guid);
 
 #if SDL_MINOR_VERSION >= 4 // Version before 2.0.4 are bugged, JoystickClose crashes randomly
 		SDL_JoystickClose(joy);
@@ -242,7 +243,7 @@ JoystickInfo::JoystickInfo(int id)
 	}
 
 	fprintf(stdout, "PAD: controller (%s) detected%s, GUID:%s\n",
-			devname, m_haptic ? " with rumble support" : "", guid);
+		devname, m_haptic ? " with rumble support" : "", guid);
 
 	m_no_error = true;
 }

--- a/pcsx2/PAD/Linux/controller.h
+++ b/pcsx2/PAD/Linux/controller.h
@@ -16,7 +16,38 @@
 #pragma once
 #include <string.h> // for memset
 #include "PS2Edefs.h"
-#define MAX_KEYS 24
+
+// clang-format off
+enum gamePadValues {
+	PAD_L2 = 0,   // L2 button
+	PAD_R2,       // R2 button
+	PAD_L1,       // L1 button
+	PAD_R1,       // R1 button
+	PAD_TRIANGLE, // Triangle button ▲
+	PAD_CIRCLE,   // Circle button ●
+	PAD_CROSS,    // Cross button ✖
+	PAD_SQUARE,   // Square button ■
+	PAD_SELECT,   // Select button
+	PAD_L3,       // Left joystick button (L3)
+	PAD_R3,       // Right joystick button (R3)
+	PAD_START,    // Start button
+	PAD_UP,       // Directional pad ↑
+	PAD_RIGHT,    // Directional pad →
+	PAD_DOWN,     // Directional pad ↓
+	PAD_LEFT,     // Directional pad ←
+	PAD_L_UP,     // Left joystick (Up) ↑
+	PAD_L_RIGHT,  // Left joystick (Right) →
+	PAD_L_DOWN,   // Left joystick (Down) ↓
+	PAD_L_LEFT,   // Left joystick (Left) ←
+	PAD_R_UP,     // Right joystick (Up) ↑
+	PAD_R_RIGHT,  // Right joystick (Right) →
+	PAD_R_DOWN,   // Right joystick (Down) ↓
+	PAD_R_LEFT,   // Right joystick (Left) ←
+	PAD_ANALOG,
+
+	MAX_KEYS
+};
+// clang-format on
 
 extern void set_keyboard_key(int pad, int keysym, int index);
 extern int get_keyboard_key(int pad, int keysym);
@@ -39,9 +70,9 @@ public:
 			u16 reverse_ry : 1;
 			u16 mouse_l : 1;
 			u16 mouse_r : 1;
-			u16 _free : 9;             // The 9 remaining bits are unused, do what you wish with them ;)
+			u16 _free : 9; // The 9 remaining bits are unused, do what you wish with them ;)
 		} pad_options[GAMEPAD_NUMBER]; // One for each pads
-		u32 packed_options;            // Only first 8 bits of each 16 bits series are really used, rest is padding
+		u32 packed_options; // Only first 8 bits of each 16 bits series are really used, rest is padding
 	};
 
 	u32 log;

--- a/pcsx2/PAD/Linux/state_management.cpp
+++ b/pcsx2/PAD/Linux/state_management.cpp
@@ -77,6 +77,11 @@ void Pad::set_mode(int _mode)
 	mode = _mode;
 }
 
+void Pad::toggle_mode()
+{
+	mode = mode == MODE_DIGITAL ? MODE_ANALOG : MODE_DIGITAL;
+}
+
 void Pad::set_vibrate(int motor, u8 val)
 {
 	nextVibrate[motor] = val;
@@ -183,6 +188,17 @@ u8 pad_poll(u8 value)
 		query.lastByte++;
 		query.currentCommand = value;
 
+
+		if (!pad->modeLock)
+		{
+			u32 analog = !(g_key_status.get(query.port) & (1 << PAD_ANALOG));
+			if (analog && !pad->analogPressed)
+			{
+				pad->toggle_mode();
+			}
+			pad->analogPressed = analog;
+		}
+
 		switch (value)
 		{
 			case CMD_CONFIG_MODE:
@@ -233,7 +249,7 @@ u8 pad_poll(u8 value)
 					b1=b1 & 0x1f;
 #endif
 
-				uint16_t buttons = g_key_status.get(query.port);
+				uint32_t buttons = g_key_status.get(query.port);
 
 				query.numBytes = 5;
 

--- a/pcsx2/PAD/Linux/state_management.h
+++ b/pcsx2/PAD/Linux/state_management.h
@@ -80,7 +80,7 @@ struct PadFreezeData
 class Pad : public PadFreezeData
 {
 public:
-	// Lilypad store here the state of PC pad
+	u8 analogPressed;
 
 	void rumble(unsigned port);
 	void set_vibrate(int motor, u8 val);
@@ -88,6 +88,7 @@ public:
 	void reset();
 
 	void set_mode(int mode);
+	void toggle_mode();
 
 	static void reset_all();
 	static void stop_vibrate_all();

--- a/pcsx2/PAD/Linux/wx_dialog/dialog.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/dialog.cpp
@@ -159,7 +159,7 @@ static std::string KeyName(int pad, int key, int keysym)
 		case kVK_JIS_Eisu:            return "英数";
 		case kVK_JIS_Kana:            return "かな";
 		default: return "Key " + std::to_string(keysym);
-		// clang-format on
+			// clang-format on
 	}
 }
 #else
@@ -189,16 +189,16 @@ static std::string KeyName(int pad, int key, int keysym)
 
 // Construtor of Dialog
 PADDialog::PADDialog()
-	: wxDialog(NULL,                                  // Parent
-			   wxID_ANY,                              // ID
-			   _T("GamePad configuration"),            // Title
-			   wxDefaultPosition,                     // Position
-			   wxSize(DEFAULT_WIDTH, DEFAULT_HEIGHT), // Width + Lenght
-			   // Style
-			   wxSYSTEM_MENU |
-				   wxCAPTION |
-				   wxCLOSE_BOX |
-				   wxCLIP_CHILDREN)
+	: wxDialog(NULL, // Parent
+		  wxID_ANY, // ID
+		  _T("GamePad configuration"), // Title
+		  wxDefaultPosition, // Position
+		  wxSize(DEFAULT_WIDTH, DEFAULT_HEIGHT), // Width + Lenght
+		  // Style
+		  wxSYSTEM_MENU |
+			  wxCAPTION |
+			  wxCLOSE_BOX |
+			  wxCLIP_CHILDREN)
 {
 
 	/*
@@ -212,193 +212,193 @@ PADDialog::PADDialog()
 
 	// L1
 	padding[PAD_L1][0] = 218; // Width
-	padding[PAD_L1][1] = 28;  // Height
-	padding[PAD_L1][2] = 50;  // X
+	padding[PAD_L1][1] = 28; // Height
+	padding[PAD_L1][2] = 50; // X
 	padding[PAD_L1][3] = 175; // Y
 
 	// L2
 	padding[PAD_L2][0] = 218; // Width
-	padding[PAD_L2][1] = 28;  // Height
-	padding[PAD_L2][2] = 50;  // X
+	padding[PAD_L2][1] = 28; // Height
+	padding[PAD_L2][2] = 50; // X
 	padding[PAD_L2][3] = 104; // Y
 
 	// R1
 	padding[PAD_R1][0] = 218; // Width
-	padding[PAD_R1][1] = 28;  // Height
+	padding[PAD_R1][1] = 28; // Height
 	padding[PAD_R1][2] = 726; // X
 	padding[PAD_R1][3] = 175; // Y
 
 	// R2
 	padding[PAD_R2][0] = 218; // Width
-	padding[PAD_R2][1] = 28;  // Height
+	padding[PAD_R2][1] = 28; // Height
 	padding[PAD_R2][2] = 726; // X
 	padding[PAD_R2][3] = 104; // Y
 
 	// Triangle
 	padding[PAD_TRIANGLE][0] = 218; // Width
-	padding[PAD_TRIANGLE][1] = 28;  // Height
+	padding[PAD_TRIANGLE][1] = 28; // Height
 	padding[PAD_TRIANGLE][2] = 726; // X
 	padding[PAD_TRIANGLE][3] = 246; // Y
 
 	// Circle
 	padding[PAD_CIRCLE][0] = 218; // Width
-	padding[PAD_CIRCLE][1] = 28;  // Height
+	padding[PAD_CIRCLE][1] = 28; // Height
 	padding[PAD_CIRCLE][2] = 726; // X
 	padding[PAD_CIRCLE][3] = 319; // Y
 
 	// Cross
 	padding[PAD_CROSS][0] = 218; // Width
-	padding[PAD_CROSS][1] = 28;  // Height
+	padding[PAD_CROSS][1] = 28; // Height
 	padding[PAD_CROSS][2] = 726; // X
 	padding[PAD_CROSS][3] = 391; // Y
 
 	// Square
 	padding[PAD_SQUARE][0] = 218; // Width
-	padding[PAD_SQUARE][1] = 28;  // Height
+	padding[PAD_SQUARE][1] = 28; // Height
 	padding[PAD_SQUARE][2] = 726; // X
 	padding[PAD_SQUARE][3] = 463; // Y
 
 	// Directional pad up
 	padding[PAD_UP][0] = 100; // Width
-	padding[PAD_UP][1] = 25;  // Height
+	padding[PAD_UP][1] = 25; // Height
 	padding[PAD_UP][2] = 108; // X
 	padding[PAD_UP][3] = 290; // Y
 
 	// Directional pad down
 	padding[PAD_DOWN][0] = 100; // Width
-	padding[PAD_DOWN][1] = 25;  // Height
+	padding[PAD_DOWN][1] = 25; // Height
 	padding[PAD_DOWN][2] = 108; // X
 	padding[PAD_DOWN][3] = 340; // Y
 
 	// Directional pad right
 	padding[PAD_RIGHT][0] = 109; // Width
-	padding[PAD_RIGHT][1] = 25;  // Height
+	padding[PAD_RIGHT][1] = 25; // Height
 	padding[PAD_RIGHT][2] = 159; // X
 	padding[PAD_RIGHT][3] = 315; // Y
 
 	// Directional pad left
 	padding[PAD_LEFT][0] = 109; // Width
-	padding[PAD_LEFT][1] = 25;  // Height
-	padding[PAD_LEFT][2] = 50;  // X
+	padding[PAD_LEFT][1] = 25; // Height
+	padding[PAD_LEFT][2] = 50; // X
 	padding[PAD_LEFT][3] = 315; // Y
 
 	// Left Joystick up
 	padding[PAD_L_UP][0] = 100; // Width
-	padding[PAD_L_UP][1] = 25;  // Height
+	padding[PAD_L_UP][1] = 25; // Height
 	padding[PAD_L_UP][2] = 325; // X
 	padding[PAD_L_UP][3] = 527; // Y
 
 	// Left Joystick down
 	padding[PAD_L_DOWN][0] = 100; // Width
-	padding[PAD_L_DOWN][1] = 25;  // Height
+	padding[PAD_L_DOWN][1] = 25; // Height
 	padding[PAD_L_DOWN][2] = 325; // X
 	padding[PAD_L_DOWN][3] = 577; // Y
 
 	// Left Joystick right
 	padding[PAD_L_RIGHT][0] = 109; // Width
-	padding[PAD_L_RIGHT][1] = 25;  // Height
+	padding[PAD_L_RIGHT][1] = 25; // Height
 	padding[PAD_L_RIGHT][2] = 377; // X
 	padding[PAD_L_RIGHT][3] = 552; // Y
 
 	// Left Joystick left
 	padding[PAD_L_LEFT][0] = 109; // Width
-	padding[PAD_L_LEFT][1] = 25;  // Height
+	padding[PAD_L_LEFT][1] = 25; // Height
 	padding[PAD_L_LEFT][2] = 268; // X
 	padding[PAD_L_LEFT][3] = 552; // Y
 
 	// L3
 	padding[PAD_L3][0] = 218; // Width
-	padding[PAD_L3][1] = 28;  // Height
+	padding[PAD_L3][1] = 28; // Height
 	padding[PAD_L3][2] = 268; // X
 	padding[PAD_L3][3] = 641; // Y
 
 	// Right Joystick up
 	padding[PAD_R_UP][0] = 100; // Width
-	padding[PAD_R_UP][1] = 25;  // Height
+	padding[PAD_R_UP][1] = 25; // Height
 	padding[PAD_R_UP][2] = 555; // X
 	padding[PAD_R_UP][3] = 527; // Y
 
 	// Right Joystick down
 	padding[PAD_R_DOWN][0] = 100; // Width
-	padding[PAD_R_DOWN][1] = 25;  // Height
+	padding[PAD_R_DOWN][1] = 25; // Height
 	padding[PAD_R_DOWN][2] = 555; // X
 	padding[PAD_R_DOWN][3] = 577; // Y
 
 	// Right Joystick right
 	padding[PAD_R_RIGHT][0] = 109; // Width
-	padding[PAD_R_RIGHT][1] = 25;  // Height
+	padding[PAD_R_RIGHT][1] = 25; // Height
 	padding[PAD_R_RIGHT][2] = 607; // X
 	padding[PAD_R_RIGHT][3] = 552; // Y
 
 	// Right Joystick left
 	padding[PAD_R_LEFT][0] = 109; // Width
-	padding[PAD_R_LEFT][1] = 25;  // Height
+	padding[PAD_R_LEFT][1] = 25; // Height
 	padding[PAD_R_LEFT][2] = 498; // X
 	padding[PAD_R_LEFT][3] = 552; // Y
 
 	// R3
 	padding[PAD_R3][0] = 218; // Width
-	padding[PAD_R3][1] = 28;  // Height
+	padding[PAD_R3][1] = 28; // Height
 	padding[PAD_R3][2] = 498; // X
 	padding[PAD_R3][3] = 641; // Y
 
 	// Start
 	padding[PAD_START][0] = 218; // Width
-	padding[PAD_START][1] = 28;  // Height
+	padding[PAD_START][1] = 28; // Height
 	padding[PAD_START][2] = 503; // X
-	padding[PAD_START][3] = 34;  // Y
+	padding[PAD_START][3] = 34; // Y
 
 	// Select
 	padding[PAD_SELECT][0] = 218; // Width
-	padding[PAD_SELECT][1] = 28;  // Height
+	padding[PAD_SELECT][1] = 28; // Height
 	padding[PAD_SELECT][2] = 273; // X
-	padding[PAD_SELECT][3] = 34;  // Y
+	padding[PAD_SELECT][3] = 34; // Y
 
 	// Analog
 	padding[Analog][0] = 218; // Width
-	padding[Analog][1] = 28;  // Height
-	padding[Analog][2] = 50;  // X
+	padding[Analog][1] = 28; // Height
+	padding[Analog][2] = 50; // X
 	padding[Analog][3] = 452; // Y
 
 	// Left Joystick Configuration
 	padding[JoyL_config][0] = 180; // Width
-	padding[JoyL_config][1] = 28;  // Height
-	padding[JoyL_config][2] = 50;  // X
+	padding[JoyL_config][1] = 28; // Height
+	padding[JoyL_config][2] = 50; // X
 	padding[JoyL_config][3] = 550; // Y
 
 	// Right Joystick Configuration
 	padding[JoyR_config][0] = 180; // Width
-	padding[JoyR_config][1] = 28;  // Height
+	padding[JoyR_config][1] = 28; // Height
 	padding[JoyR_config][2] = 764; // X
 	padding[JoyR_config][3] = 550; // Y
 
 	// Gamepad Configuration
 	padding[Gamepad_config][0] = 180; // Width
-	padding[Gamepad_config][1] = 28;  // Height
-	padding[Gamepad_config][2] = 50;  // X
+	padding[Gamepad_config][1] = 28; // Height
+	padding[Gamepad_config][2] = 50; // X
 	padding[Gamepad_config][3] = 585; // Y
 
 	// Set All Buttons
 	padding[Set_all][0] = 180; // Width
-	padding[Set_all][1] = 28;  // Height
+	padding[Set_all][1] = 28; // Height
 	padding[Set_all][2] = 764; // X
 	padding[Set_all][3] = 585; // Y
 
 	// Apply modifications without exit
-	padding[Apply][0] = 70;  // Width
-	padding[Apply][1] = 28;  // Height
+	padding[Apply][0] = 70; // Width
+	padding[Apply][1] = 28; // Height
 	padding[Apply][2] = 833; // X
 	padding[Apply][3] = 642; // Y
 
 	// Ok button
-	padding[Ok][0] = 70;  // Width
-	padding[Ok][1] = 28;  // Height
+	padding[Ok][0] = 70; // Width
+	padding[Ok][1] = 28; // Height
 	padding[Ok][2] = 913; // X
 	padding[Ok][3] = 642; // Y
 
 	// Cancel button
-	padding[Cancel][0] = 70;  // Width
-	padding[Cancel][1] = 28;  // Height
+	padding[Cancel][0] = 70; // Width
+	padding[Cancel][1] = 28; // Height
 	padding[Cancel][2] = 753; // X
 	padding[Cancel][3] = 642; // Y
 
@@ -419,7 +419,7 @@ PADDialog::PADDialog()
 		sstm << label << i;
 		// New page creation
 		m_tab_gamepad->AddPage(
-			m_pan_tabs[i],                           // Parent
+			m_pan_tabs[i], // Parent
 			wxString(sstm.str().c_str(), wxConvUTF8) // Title
 		);
 
@@ -427,11 +427,11 @@ PADDialog::PADDialog()
 		{
 			// Gamepad buttons
 			m_bt_gamepad[i][j] = new wxButton(
-				m_pan_tabs[i],                         // Parent
-				wxID_HIGHEST + j + 1,                  // ID
-				_T("Undefined"),                       // Label
+				m_pan_tabs[i], // Parent
+				wxID_HIGHEST + j + 1, // ID
+				_T("Undefined"), // Label
 				wxPoint(padding[j][2], padding[j][3]), // Position
-				wxSize(padding[j][0], padding[j][1])   // Size
+				wxSize(padding[j][0], padding[j][1]) // Size
 			);
 		}
 		// Redefine others gui buttons label
@@ -461,8 +461,8 @@ PADDialog::PADDialog()
 void PADDialog::InitDialog()
 {
 	GamePad::EnumerateGamePads(s_vgamePad); // activate gamepads
-	PADLoadConfig();                        // Load configuration from the ini file
-	repopulate();                           // Set label and fit simulated key array
+	PADLoadConfig(); // Load configuration from the ini file
+	repopulate(); // Set label and fit simulated key array
 }
 
 /****************************************/
@@ -473,10 +473,10 @@ void PADDialog::OnButtonClicked(wxCommandEvent& event)
 {
 	// Affichage d'un message à chaque clic sur le bouton
 	wxButton* bt_tmp = (wxButton*)event.GetEventObject(); // get the button object
-	int bt_id = bt_tmp->GetId() - wxID_HIGHEST - 1;       // get the real ID
-	int gamepad_id = m_tab_gamepad->GetSelection();       // get the tab ID (equivalent to the gamepad id)
+	int bt_id = bt_tmp->GetId() - wxID_HIGHEST - 1; // get the real ID
+	int gamepad_id = m_tab_gamepad->GetSelection(); // get the tab ID (equivalent to the gamepad id)
 	if (bt_id >= 0 && bt_id <= PAD_R_LEFT)
-	{                      // if the button ID is a gamepad button
+	{ // if the button ID is a gamepad button
 		bt_tmp->Disable(); // switch the button state to "Disable"
 		config_key(gamepad_id, bt_id);
 		bt_tmp->Enable(); // switch the button state to "Enable"
@@ -506,6 +506,9 @@ void PADDialog::OnButtonClicked(wxCommandEvent& event)
 	{ // If the button ID is equals to the Set_all button ID
 		for (int i = 0; i < MAX_KEYS; ++i)
 		{
+			if (i == PAD_ANALOG)
+				continue;
+
 			bt_tmp = m_bt_gamepad[gamepad_id][i];
 			switch (i)
 			{
@@ -576,16 +579,16 @@ void PADDialog::OnButtonClicked(wxCommandEvent& event)
 		}
 	}
 	else if (bt_id == Ok)
-	{                    // If the button ID is equals to the Ok button ID
+	{ // If the button ID is equals to the Ok button ID
 		PADSaveConfig(); // Save the configuration
-		Close();         // Close the window
+		Close(); // Close the window
 	}
 	else if (bt_id == Apply)
-	{                    // If the button ID is equals to the Apply button ID
+	{ // If the button ID is equals to the Apply button ID
 		PADSaveConfig(); // Save the configuration
 	}
 	else if (bt_id == Cancel)
-	{            // If the button ID is equals to the cancel button ID
+	{ // If the button ID is equals to the cancel button ID
 		Close(); // Close the window
 	}
 }


### PR DESCRIPTION
Allows the user to toggle the analog stick with the menu button.  Fix
for Sky Odyssey.