### PR TITLE
GameDB: Ecco the dolphin - Defender of the Future patch

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -36623,6 +36623,15 @@ Serial = SLUS-20394
 Name   = Ecco the Dolphin - Defender of the Future
 Region = NTSC-U
 Compat = 2
+[patches = B78EAA30]
+	author=PSI
+	// Ecco has an evil race condition: one of its custom IOP modules resets CDVDMAN while it's loading a module from disc.
+	// The race condition is resolved by making the EE slower. This gives enough time for CDVDMAN to reset itself before
+	// the EE sends a request to load a module.
+	// Alternatively, this patch swaps the load order of the modules.
+	patch=1,EE,201018d8,extended,24040007
+	patch=1,EE,201018e4,extended,24040006
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20395
 Name   = GTC Africa


### PR DESCRIPTION
This PR add a patch for the game : Ecco the Dolphin - Defender of the Future

This resolve a race condition causing the game to hang on the main loading screen.