### PR TITLE
GameDB: Resolve missing blade issue in Castlevania Curse of Darkness

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -15068,6 +15068,7 @@ Name   = Castlevania - Curse of Darkness
 Region = PAL-M5
 Compat = 5
 vuClampMode = 0 // SPS with microVU.
+eeClampMode = 2 // Fixes missing blade.
 // Reads Lament of Innocence save for easter egg.
 MemCardFilter = SLES-53755/SLES-52118
 ---------------------------------------------
@@ -19050,6 +19051,7 @@ Name   = Castlevania - Curse of Darkness
 Region = NTSC-K
 Compat = 5
 vuClampMode = 0 // SPS with microVU.
+eeClampMode = 2 // Fixes missing blade.
 MemCardFilter = SLKA-25328/SLKA-25082
 ---------------------------------------------
 Serial = SLKA-25329
@@ -40220,6 +40222,7 @@ Name   = Castlevania - Curse of Darkness
 Region = NTSC-U
 Compat = 5
 vuClampMode = 0 // SPS with microVU.
+eeClampMode = 2 // Fixes missing blade.
 MemCardFilter = SLUS-21168/SLUS-20733
 ---------------------------------------------
 Serial = SLUS-21169


### PR DESCRIPTION
Fixes issue regarding a missing blade in Castlevania Curse of Darkness. User reported in Discord that any EE clamping modes besides full would work (they used Extra + Preserve sign, so we've done that here as well)