### PR TITLE
Fix VIF unpack log message in Vif_Unpack.cpp

### DIFF
--- a/pcsx2/Vif_Unpack.cpp
+++ b/pcsx2/Vif_Unpack.cpp
@@ -230,7 +230,7 @@ _vifT void vifUnpackSetup(const u32 *data) {
 	if (idx && ((addr>>15)&1)) addr += vif1Regs.tops;
 	vifX.tag.addr = (addr<<4) & (idx ? 0x3ff0 : 0xff0);
 
-	VIF_LOG("Unpack VIF%x, QWC %x tagsize %x", idx, vifNum, vif0.tag.size);
+	VIF_LOG("Unpack VIF%x, QWC %x tagsize %x", idx, vifNum, vifX.tag.size);
 
 	vifX.cl			 = 0;
 	vifX.tag.cmd	 = vifX.cmd;


### PR DESCRIPTION
The relevant VIF_LOG statement previously printed the packet size from the structure relating to VIF0, regardless of whether the log message was for VIF0 or VIF1. I'm pretty sure this is just a typo.