### PR TITLE
GameDB: Add patch for Nascar 09

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -43074,7 +43074,14 @@ Compat = 5
 Serial = SLUS-21744
 Name   = NASCAR '09
 Region = NTSC-U
-Compat = 5 // The game only load with the EE set to interpreter + cache enable.
+Compat = 5
+[patches = 1B6C22B9]
+	author=PSI
+	// This game intentionally corrupts a DMA transfer by writing junk values to a buffer just before starting a transfer. 
+	// Normally this would require EE data cache, but this patch NOPs out the bad writes. This is likely anti-emulation code
+	patch=1,EE,003cb014,word,00000000
+	patch=1,EE,003cb124,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-21746
 Name   = Call Of Duty - World At War - Final Fronts


### PR DESCRIPTION
 This prevents the DMA transfer from being corrupted intentionally from values written in cached memory (that require the EE data cache).