### PR TITLE
GSdx-d3d11: Update point sampler handle

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -130,6 +130,7 @@ bool GSDevice11::SetFeatureLevel(D3D_FEATURE_LEVEL level, bool compat_mode)
 bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 {
 	bool nvidia_vendor = false;
+	m_amd_vendor = false;
 
 	if(!__super::Create(wnd))
 	{
@@ -170,6 +171,8 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 				{
 					if (desc.VendorId == 0x10DE)
 						nvidia_vendor = true;
+					else if (desc.VendorId == 0x1002)
+						m_amd_vendor = true;
 
 					adapter = enum_adapter;
 					driver_type = D3D_DRIVER_TYPE_UNKNOWN;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -343,6 +343,7 @@ private:
 	int m_upscale_multiplier;
 	int m_mipmap;
 	int m_d3d_texsize;
+	bool m_amd_vendor;
 
 	GSTexture* CreateSurface(int type, int w, int h, int format);
 	GSTexture* FetchSurface(int type, int w, int h, int format);

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -186,6 +186,8 @@ void GSDevice11::SetupGS(GSSelector sel, const GSConstantBuffer* cb)
 
 void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSelector ssel)
 {
+	const bool amd_point_sampler = sel.point_sampler && m_amd_vendor;
+
 	auto i = std::as_const(m_ps).find(sel);
 
 	if(i == m_ps.end())
@@ -207,7 +209,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		sm.AddMacro("PS_FBMASK", sel.fbmask);
 		sm.AddMacro("PS_LTF", sel.ltf);
 		sm.AddMacro("PS_TCOFFSETHACK", sel.tcoffsethack);
-		sm.AddMacro("PS_POINT_SAMPLER", sel.point_sampler);
+		sm.AddMacro("PS_POINT_SAMPLER", amd_point_sampler);
 		sm.AddMacro("PS_SHUFFLE", sel.shuffle);
 		sm.AddMacro("PS_READ_BA", sel.read_ba);
 		sm.AddMacro("PS_CHANNEL_FETCH", sel.channel);


### PR DESCRIPTION
gsdx-d3d11: Update point sampler code.
Make sure point sampler is enabled only on amd gpus. Not needed for
nvidia and intel, behavior is the same on opengl as well. Helps #1026

