### PR TITLE
GSdx-hw: Restore GSC_LordOfTheRingsTwoTowers crc hack to PAL regions only

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -313,6 +313,14 @@ CRC::Game CRC::m_games[] =
 	{0xEB198738, LordOfTheRingsThirdAge, US, 0},
 	{0x614F4CF4, LordOfTheRingsThirdAge, EU, 0},
 	{0x37CD4279, LordOfTheRingsThirdAge, KO, 0},
+	{0xDC43F2B8, LordOfTheRingsTwoTowers, EU, 0},
+	{0x9ABF90FB, LordOfTheRingsTwoTowers, ES, 0},
+	{0x5FF407EE, LordOfTheRingsTwoTowers, IT, 0},
+	{0x88F67266, LordOfTheRingsTwoTowers, FR, 0},
+	// {0xC818BEC2, LordOfTheRingsTwoTowers, US, 0}, // Only PAL regions are required, but keep ntsc ones commented just in case.
+	// {0xC0E909E9, LordOfTheRingsTwoTowers, JP, 0},
+	// {0x6898435D, LordOfTheRingsTwoTowers, KO, 0},
+	// {0xDC2F9B98, LordOfTheRingsTwoTowers, CH, 0},
 	{0xE169BAF8, RedDeadRevolver, US, 0},
 	{0xE2E67E23, RedDeadRevolver, EU, 0},
 	{0x87844524, RedDeadRevolver, RU, 0}, // Unofficial RU-version

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -92,6 +92,7 @@ public:
 		Lamune,
 		LegacyOfKainDefiance,
 		LordOfTheRingsThirdAge,
+		LordOfTheRingsTwoTowers,
 		MajokkoALaMode2,
 		Manhunt2,
 		MetalSlug6,

--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -481,6 +481,32 @@ bool GSC_TimeSplitters2(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
+bool GSC_LordOfTheRingsTwoTowers(const GSFrameInfo& fi, int& skip)
+{
+	// Currently we can't use the TS half bottom fix on PAL regions because we get a height delta bigger than 64.
+	// Needs to be further investigated.
+	if(skip == 0)
+	{
+		if(fi.TME && (fi.FBP == 0x01180 || fi.FBP == 0x01400) && fi.FPSM == fi.TPSM && (fi.TBP0 == 0x00000 || fi.TBP0 == 0x01000) && fi.TPSM == PSM_PSMCT16)
+		{
+			skip = 1000; // Shadows
+		}
+		else if(fi.TME && fi.TPSM == PSM_PSMZ16 && fi.TBP0 == 0x01400 && fi.FPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
+		{
+			skip = 3; // Wall of fog
+		}
+	}
+	else
+	{
+		if(fi.TME && (fi.FBP == 0x00000 || fi.FBP == 0x01000) && (fi.TBP0 == 0x01180 || fi.TBP0 == 0x01400) && fi.FPSM == PSM_PSMCT32)
+		{
+			skip = 2;
+		}
+	}
+
+	return true;
+}
+
 bool GSC_LordOfTheRingsThirdAge(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1473,6 +1499,7 @@ void GSState::SetupCrcHack()
 
 		// Half Screen bottom issue
 		lut[CRC::DemonStone] = GSC_DemonStone; // Half screen on texture shuffle
+		lut[CRC::LordOfTheRingsTwoTowers] = GSC_LordOfTheRingsTwoTowers;
 		lut[CRC::Tekken5] = GSC_Tekken5;
 
 		// Needs testing


### PR DESCRIPTION
Currently we can't use the TS half bottom fix on PAL regions because we
get a height delta bigger than 64. NTSC versions seem fine.

Fixes regression with PAL regions experiencing a half screen bottom
issue.

gs dump for testing
[LordOfTheRingsTwoTowers.gs.zip](https://github.com/PCSX2/pcsx2/files/4068040/LordOfTheRingsTwoTowers.gs.zip)


Maybe instead of reintroducing the crc hack we just force enable the half screen fix on Lord of the Rings
Will wait for feedback.