### PR TITLE
GSdx-d3d11: Adjust anisotropic filtering handle

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -46,6 +46,13 @@ GSDevice11::GSDevice11()
 
 	m_mipmap = theApp.GetConfigI("mipmap");
 	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
+	
+	const BiFiltering nearest_filter = static_cast<BiFiltering>(theApp.GetConfigI("filter"));
+	const int aniso_level = theApp.GetConfigI("MaxAnisotropy");
+	if ((nearest_filter != BiFiltering::Nearest && !theApp.GetConfigB("paltex") && aniso_level))
+		m_aniso_filter = aniso_level;
+	else
+		m_aniso_filter = 0;
 }
 
 bool GSDevice11::LoadD3DCompiler()
@@ -408,18 +415,18 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 
 	memset(&sd, 0, sizeof(sd));
 
-	sd.Filter = theApp.GetConfigI("MaxAnisotropy") && !theApp.GetConfigB("paltex") ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+	sd.Filter = m_aniso_filter ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_LINEAR;
 	sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.MinLOD = -FLT_MAX;
 	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = theApp.GetConfigI("MaxAnisotropy");
+	sd.MaxAnisotropy = m_aniso_filter;
 	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 	hr = m_dev->CreateSamplerState(&sd, &m_convert.ln);
 
-	sd.Filter = theApp.GetConfigI("MaxAnisotropy") && !theApp.GetConfigB("paltex") ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_POINT;
+	sd.Filter = m_aniso_filter ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_POINT;
 
 	hr = m_dev->CreateSamplerState(&sd, &m_convert.pt);
 

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -341,6 +341,7 @@ public:
 private:
 	float m_hack_topleft_offset;
 	int m_upscale_multiplier;
+	int m_aniso_filter;
 	int m_mipmap;
 	int m_d3d_texsize;
 

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -64,13 +64,13 @@ bool GSDevice11::CreateTextureFX()
 
 	memset(&sd, 0, sizeof(sd));
 
-	sd.Filter = theApp.GetConfigI("MaxAnisotropy") && !theApp.GetConfigB("paltex") ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_POINT;
+	sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
 	sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.MinLOD = -FLT_MAX;
 	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = theApp.GetConfigI("MaxAnisotropy");
+	sd.MaxAnisotropy = D3D11_MIN_MAXANISOTROPY;
 	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 	hr = m_dev->CreateSamplerState(&sd, &m_palette_ss);
@@ -259,7 +259,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 
 			memset(&sd, 0, sizeof(sd));
 
-			af.Filter = theApp.GetConfigI("MaxAnisotropy") && !theApp.GetConfigB("paltex") ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+			af.Filter = m_aniso_filter ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
 			sd.Filter = ssel.ltf ? af.Filter : D3D11_FILTER_MIN_MAG_MIP_POINT;
 
 			sd.AddressU = ssel.tau ? D3D11_TEXTURE_ADDRESS_WRAP : D3D11_TEXTURE_ADDRESS_CLAMP;
@@ -267,7 +267,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.MinLOD = -FLT_MAX;
 			sd.MaxLOD = FLT_MAX;
-			sd.MaxAnisotropy = theApp.GetConfigI("MaxAnisotropy");
+			sd.MaxAnisotropy = m_aniso_filter;
 			sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 			m_dev->CreateSamplerState(&sd, &ss0);


### PR DESCRIPTION
Previous behaviour:
Anisotropic filtering was continuing to run even with Nearest filtering.
On opengl it doesn't run on nearest filtering. The gui for both
renderers also greys out aniso when nearest is selected.

Anisotropic filtering being able to run on palette texture. This caused
to break the rendering on palette textures for games that use it.

PR behavior:
The PR corrects both of these behaviors, Aniso won't run on palette
textures as well as nearest filtering.

Test cases for observing the issues were used: Star Ocean 3, Fifa
Street.

Visual issue representation below is when anisotropic filtering runs on palette textures.
Comparison master, Bilinear PS2, Aniso 16x:
![gsdx_20200118212951](https://user-images.githubusercontent.com/18107717/72670107-e489bb80-3a39-11ea-86ae-db83bef450cd.png)

Comparison PR, Bilinear PS2, Aniso 16x:
![gsdx_20200118212958](https://user-images.githubusercontent.com/18107717/72670111-f0757d80-3a39-11ea-9db5-5589c65952dd.png)
