### PR TITLE
GSdx: Adjust GSC_XenosagaE3 crc hacks and some gui tooltips to reflect recent changes.

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -1040,36 +1040,6 @@ bool GSC_SlyGames(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_XenosagaE3(const GSFrameInfo& fi, int& skip)
-{
-	if(skip == 0)
-	{
-		if(fi.TPSM == PSM_PSMT8H && fi.FBMSK >= 0xEFFFFFFF)
-		{
-			skip = 73; // Animation
-		}
-		else if(fi.TME && fi.FBP ==0x03800 && fi.TBP0 && fi.TPSM ==0  && fi.FBMSK == 0)
-		{
-			skip = 1; // Ghosting
-		}
-		else
-		{
-			if(fi.TME)
-			{
-				// depth textures (bully, mgs3s1 intro, Front Mission 5)
-				if( (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
-					// General, often problematic post processing
-					(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
-				{
-					skip = 1;
-				}
-			}
-		}
-	}
-
-	return true;
-}
-
 bool GSC_Grandia3(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1257,6 +1227,36 @@ bool GSC_ShinOnimusha(const GSFrameInfo& fi, int& skip)
 		else if(fi.TME && (fi.TBP0 ==0x1400 || fi.TBP0 ==0x1000 ||fi.TBP0 == 0x1200) && (fi.TPSM == PSM_PSMCT32 || fi.TPSM == PSM_PSMCT24))
 		{
 			skip = 1; // Eliminate excessive flooding, water and other light and shadow
+		}
+	}
+
+	return true;
+}
+
+bool GSC_XenosagaE3(const GSFrameInfo& fi, int& skip)
+{
+	if(skip == 0)
+	{
+		if(fi.TPSM == PSM_PSMT8H && fi.FBMSK >= 0xEFFFFFFF)
+		{
+			skip = 73; // Animation
+		}
+		else if(fi.TME && fi.FBP ==0x03800 && fi.TBP0 && fi.TPSM ==0  && fi.FBMSK == 0)
+		{
+			skip = 1; // Ghosting
+		}
+		else
+		{
+			if(fi.TME)
+			{
+				// depth textures (bully, mgs3s1 intro, Front Mission 5)
+				if( (fi.TPSM == PSM_PSMZ32 || fi.TPSM == PSM_PSMZ24 || fi.TPSM == PSM_PSMZ16 || fi.TPSM == PSM_PSMZ16S) ||
+					// General, often problematic post processing
+					(GSUtil::HasSharedBits(fi.FBP, fi.FPSM, fi.TBP0, fi.TPSM)) )
+				{
+					skip = 1;
+				}
+			}
 		}
 	}
 
@@ -1486,7 +1486,6 @@ void GSState::SetupCrcHack()
 
 		// Needs testing
 		lut[CRC::Grandia3] = GSC_Grandia3;
-		lut[CRC::XenosagaE3] = GSC_XenosagaE3;
 
 		// These games emulate a stencil buffer with the alpha channel of the RT (too slow to move to Aggressive)
 		// Needs at least Basic Blending,
@@ -1508,6 +1507,7 @@ void GSState::SetupCrcHack()
 		lut[CRC::SMTDDS2] = GSC_SMTNocturneDDS<0x20435BF0>;
 		lut[CRC::SMTNocturne] = GSC_SMTNocturneDDS<0x2054E870>;
 		lut[CRC::SoTC] = GSC_SoTC;
+		lut[CRC::XenosagaE3] = GSC_XenosagaE3;
 
 		// Upscaling issues
 		lut[CRC::GodOfWar] = GSC_GodOfWar;

--- a/plugins/GSdx/Window/GSSetting.cpp
+++ b/plugins/GSdx/Window/GSSetting.cpp
@@ -58,7 +58,7 @@ const char* dialog_message(int ID, bool* updateText) {
 				"Full:\nFor an optimal experience with Direct3D.\n\n"
 				"Aggressive:\nUse more aggressive CRC hacks.\n"
 				"Removes effects in some games which make the image appear sharper/clearer.\n"
-				"Affected games: AC4, BleachBB, Bully, DBZBT 2 & 3, DeathByDegrees, Evangelion, FF games, FightingBeautyWulong, GOW 1 & 2, Kunoichi, IkkiTousen, Okami, Oneechanbara2, OnimushaDoD, RDRevolver, Simple2000Vol114, SoTC, SMT3, SMTDDS 1 & 2, SteambotChronicles, Tekken5, Ultraman, Yakuza 1 & 2.\n";
+				"Affected games: AC4, BleachBB, Bully, DBZBT 2 & 3, DeathByDegrees, Evangelion, FF games, FightingBeautyWulong, GOW 1 & 2, Kunoichi, IkkiTousen, Okami, Oneechanbara2, OnimushaDoD, RDRevolver, Simple2000Vol114, SoTC, SMT3, SMTDDS 1 & 2, SteambotChronicles, Tekken5, Ultraman, XenosagaE3, Yakuza 1 & 2.\n";
 		case IDC_SKIPDRAWHACK:
 		case IDC_SKIPDRAWHACKEDIT:
 		case IDC_SKIPDRAWOFFSET:
@@ -169,8 +169,8 @@ const char* dialog_message(int ID, bool* updateText) {
 				"Automatic detection is recommended.\n\n"
 				"Note: This option is only supported by GPUs which support at least Direct3D 10.";
 		case IDC_IMAGE_LOAD_STORE:
-			return "Allows advanced atomic operations to speed up Accurate Date.\n"
-				"Only disable this if using Accurate Date causes (GPU driver) issues.\n\n"
+			return "Allows advanced atomic operations to speed up DATE Accuracy.\n"
+				"Only disable this if using DATE Accuracy causes (GPU driver) issues.\n\n"
 				"Note: This option is only supported by GPUs which support at least Direct3D 11.";
 		case IDC_SPARSE_TEXTURE:
 			return "Allows to reduce VRAM usage on the GPU.\n\n"


### PR DESCRIPTION
gsdx-hw: Move GSC_XenosagaE3 crc hacks to Aggressive state.
It will allow D3D11 to render Texture shuffle effects.
Keep the crc hacks on aggressive instead of removing them as they might
still be useful.

gsdx-gui: Update crc hack level and Image load store tooltips to reflect recent changes.