### PR TITLE
Environment variables for use in containers that change path at run time

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -173,6 +173,12 @@ namespace PathDefs
 
 	wxDirName GetProgramDataDir()
 	{
+		//Runtime Environment Variable for AppImage and others containers:
+		char * val = getenv( "PCSX2_GAMEINDEX_DIR" );
+		if ( val != NULL )
+		{
+			return wxDirName( xGAMEINDEX_str( std::string(val) ) );
+		}
 #ifndef GAMEINDEX_DIR_COMPILATION
 		return AppRoot();
 #else
@@ -221,6 +227,13 @@ namespace PathDefs
 
 	wxDirName GetPlugins()
 	{
+		//Runtime Environment Variable for AppImage and others containers:
+		char * val = getenv( "PCSX2_PLUGIN_DIR" );
+		if ( val != NULL )
+		{
+			return wxDirName( xPLUGIN_DIR_str( std::string(val) ) );
+		}
+
 		// Each linux distributions have his rules for path so we give them the possibility to
 		// change it with compilation flags. -- Gregory
 #ifndef PLUGIN_DIR_COMPILATION

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -173,12 +173,6 @@ namespace PathDefs
 
 	wxDirName GetProgramDataDir()
 	{
-		//Runtime Environment Variable for AppImage and others containers:
-		char * val = getenv( "PCSX2_GAMEINDEX_DIR" );
-		if ( val != NULL )
-		{
-			return wxDirName( xGAMEINDEX_str( std::string(val) ) );
-		}
 #ifndef GAMEINDEX_DIR_COMPILATION
 		return AppRoot();
 #else
@@ -186,6 +180,12 @@ namespace PathDefs
 		// change it with compilation flags. -- Gregory
 #define xGAMEINDEX_str(s) GAMEINDEX_DIR_str(s)
 #define GAMEINDEX_DIR_str(s) #s
+		//Runtime Environment Variable for AppImage and others containers:
+		char * val = getenv( "PCSX2_GAMEINDEX_DIR" );
+		if ( val != NULL )
+		{
+			return wxDirName( xGAMEINDEX_str( std::string(val) ) );
+		}
 		return wxDirName( xGAMEINDEX_str(GAMEINDEX_DIR_COMPILATION) );
 #endif
 	}
@@ -227,13 +227,6 @@ namespace PathDefs
 
 	wxDirName GetPlugins()
 	{
-		//Runtime Environment Variable for AppImage and others containers:
-		char * val = getenv( "PCSX2_PLUGIN_DIR" );
-		if ( val != NULL )
-		{
-			return wxDirName( xPLUGIN_DIR_str( std::string(val) ) );
-		}
-
 		// Each linux distributions have his rules for path so we give them the possibility to
 		// change it with compilation flags. -- Gregory
 #ifndef PLUGIN_DIR_COMPILATION
@@ -241,6 +234,12 @@ namespace PathDefs
 #else
 #define xPLUGIN_DIR_str(s) PLUGIN_DIR_str(s)
 #define PLUGIN_DIR_str(s) #s
+		//Runtime Environment Variable for AppImage and others containers:
+		char * val = getenv( "PCSX2_PLUGIN_DIR" );
+		if ( val != NULL )
+		{
+			return wxDirName( xPLUGIN_DIR_str( std::string(val) ) );
+		}
 		return wxDirName( xPLUGIN_DIR_str(PLUGIN_DIR_COMPILATION) );
 #endif
 	}

--- a/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
+++ b/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
@@ -71,15 +71,24 @@ Panels::FirstTimeIntroPanel::FirstTimeIntroPanel( wxWindow* parent )
 	SetMinWidth( MSW_GetDPIScale() * 600 );
 
 	FastFormatUnicode faqFile;
+	//Runtime Environment Variable for AppImage and others containers:
+	char * val = getenv( "PCSX2_DOC_DIR" );
+	if ( val != NULL )
+	{
+		faqFile.Write( L"file://%s/PCSX2_FAQ.pdf", WX_STR(wxDirName(xDOC_str(std::string(val))).ToString()) );
+	}
+	else
+	{
 #ifndef DOC_DIR_COMPILATION
-	faqFile.Write( L"file:///%s/Docs/PCSX2_FAQ.pdf", WX_STR(InstallFolder.ToString()) );
+		faqFile.Write( L"file:///%s/Docs/PCSX2_FAQ.pdf", WX_STR(InstallFolder.ToString()) );
 #else
-	// Each linux distributions have his rules for path so we give them the possibility to
-	// change it with compilation flags. -- Gregory
+		// Each linux distributions have his rules for path so we give them the possibility to
+		// change it with compilation flags. -- Gregory
 #define xDOC_str(s) DOC_str(s)
 #define DOC_str(s) #s
-	faqFile.Write( L"file://%s/PCSX2_FAQ.pdf", WX_STR(wxDirName(xDOC_str(DOC_DIR_COMPILATION)).ToString()) );
+		faqFile.Write( L"file://%s/PCSX2_FAQ.pdf", WX_STR(wxDirName(xDOC_str(DOC_DIR_COMPILATION)).ToString()) );
 #endif
+	}
 
 	wxStaticBoxSizer& langSel	= *new wxStaticBoxSizer( wxVERTICAL, this, _("Language selector") );
 

--- a/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
+++ b/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
@@ -71,6 +71,13 @@ Panels::FirstTimeIntroPanel::FirstTimeIntroPanel( wxWindow* parent )
 	SetMinWidth( MSW_GetDPIScale() * 600 );
 
 	FastFormatUnicode faqFile;
+#ifndef DOC_DIR_COMPILATION
+	faqFile.Write( L"file:///%s/Docs/PCSX2_FAQ.pdf", WX_STR(InstallFolder.ToString()) );
+#else
+	// Each linux distributions have his rules for path so we give them the possibility to
+	// change it with compilation flags. -- Gregory
+#define xDOC_str(s) DOC_str(s)
+#define DOC_str(s) #s
 	//Runtime Environment Variable for AppImage and others containers:
 	char * val = getenv( "PCSX2_DOC_DIR" );
 	if ( val != NULL )
@@ -79,16 +86,9 @@ Panels::FirstTimeIntroPanel::FirstTimeIntroPanel( wxWindow* parent )
 	}
 	else
 	{
-#ifndef DOC_DIR_COMPILATION
-		faqFile.Write( L"file:///%s/Docs/PCSX2_FAQ.pdf", WX_STR(InstallFolder.ToString()) );
-#else
-		// Each linux distributions have his rules for path so we give them the possibility to
-		// change it with compilation flags. -- Gregory
-#define xDOC_str(s) DOC_str(s)
-#define DOC_str(s) #s
 		faqFile.Write( L"file://%s/PCSX2_FAQ.pdf", WX_STR(wxDirName(xDOC_str(DOC_DIR_COMPILATION)).ToString()) );
-#endif
 	}
+#endif
 
 	wxStaticBoxSizer& langSel	= *new wxStaticBoxSizer( wxVERTICAL, this, _("Language selector") );
 


### PR DESCRIPTION
* Environment variables for use in containers that change path at run time (like AppImage).
* Environment variables:
PCSX2_PLUGIN_DIR, PCSX2_GAMEINDEX_DIR and PCSX2_DOC_DIR
* This code only run for builds that have changed the default path at compilation time first (hence the need for different paths).
