### PR TITLE
Added VU patch for Powerdrome PAL

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -11994,8 +11994,8 @@ Name   = Powerdrome
 Region = PAL-M5
 Compat = 4
 [patches = 52085DF1]
-	//Game takes advantage of the VU's extended float range.
-	//This limits it so x86 can handle it.
+	// Game takes advantage of the VU's extended float range.
+	// This limits it so x86 can handle it.
 	author=refraction and PSI
 	comment=VU float patch
 	patch=1,EE,0037A680,word,7e7fffff

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -11994,9 +11994,10 @@ Name   = Powerdrome
 Region = PAL-M5
 Compat = 4
 [patches = 52085DF1]
-	//Game takes advantage of the VU's extended float range
-	//This limits it so x86 can handle it
-	comment=VU Float patch by refraction
+	//Game takes advantage of the VU's extended float range.
+	//This limits it so x86 can handle it.
+	author=refraction and PSI
+	comment=VU float patch
 	patch=1,EE,0037A680,word,7e7fffff
 	patch=1,EE,0037A688,word,fe7fffff
 [/patches]

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -11993,6 +11993,13 @@ Serial = SLES-52418
 Name   = Powerdrome
 Region = PAL-M5
 Compat = 4
+[patches = 52085DF1]
+	//Game takes advantage of the VU's extended float range
+	//This limits it so x86 can handle it
+	comment=VU Float patch by refraction
+	patch=1,EE,0037A680,word,7e7fffff
+	patch=1,EE,0037A688,word,fe7fffff
+[/patches]
 ---------------------------------------------
 Serial = SLES-52423
 Name   = Smash Court Tennis - Pro Tournament 2


### PR DESCRIPTION
This patches some values in Powerdromes VU microprogram, which restores the 3d models of the characters.
The game uses the extended PS2 float range to do some culling calculations, so I have brung them down to be usable by x86, no other way to really fix this game.