### PR TITLE
GSdx-hw: Colclip adjustments

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -521,7 +521,7 @@ void GSRendererDX11::EmulateBlending()
 		}
 		else
 		{
-			//Breath of Fire Dragon Quarter triggers this in battles. Graphics are fine though.
+			// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars.
 			//ASSERT(0);
 		}
 	}

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -463,23 +463,21 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 	// No blending so early exit
 	if (!(PRIM->ABE || PRIM->AA1 && m_vt.m_primclass == GS_LINE_CLASS)) {
 #ifdef ENABLE_OGL_DEBUG
-		if (m_env.PABE.PABE) {
-			GL_INS("!!! ENV PABE  without ABE !!!");
-		}
+		if (m_env.PABE.PABE)
+			GL_INS("ERROR: ENV PABE without ABE!");
 #endif
 		dev->OMSetBlendState();
 		return;
 	}
 
-	if (m_env.PABE.PABE)
-	{
-		GL_INS("!!! ENV PABE  not supported !!!");
+	if (m_env.PABE.PABE) {
+		GL_INS("ERROR: ENV PABE not supported!");
 		if (m_sw_blending >= ACC_BLEND_MEDIUM) {
 			// m_ps_sel.pabe = 1;
 			m_require_full_barrier |= (ALPHA.C == 1);
 			sw_blending = true;
 		}
-		//Breath of Fire Dragon Quarter triggers this in battles. Graphics are fine though.
+		// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars.
 		//ASSERT(0);
 	}
 

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -474,7 +474,7 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 	if (m_env.PABE.PABE)
 	{
 		GL_INS("!!! ENV PABE  not supported !!!");
-		if (m_sw_blending >= ACC_BLEND_CCLIP_DALPHA) {
+		if (m_sw_blending >= ACC_BLEND_MEDIUM) {
 			// m_ps_sel.pabe = 1;
 			m_require_full_barrier |= (ALPHA.C == 1);
 			sw_blending = true;
@@ -501,22 +501,27 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 	// Warning no break on purpose
 	// Note: the "fall through" comments tell gcc not to complain about not having breaks.
 	switch (m_sw_blending) {
-		case ACC_BLEND_ULTRA:           sw_blending |= true;
-										// fall through
-		case ACC_BLEND_FULL:            if (!m_vt.m_alpha.valid && (ALPHA.C == 0)) GetAlphaMinMax();
-										sw_blending |= (ALPHA.A != ALPHA.B) &&
-												((ALPHA.C == 0 && m_vt.m_alpha.max > 128) || (ALPHA.C == 2 && ALPHA.FIX > 128u));
-										// fall through
-		case ACC_BLEND_CCLIP_DALPHA:    sw_blending |= (ALPHA.C == 1);
-										// Initial idea was to enable accurate blending for sprite rendering to handle
-										// correctly post-processing effect. Some games (ZoE) use tons of sprites as particles.
-										// In order to keep it fast, let's limit it to smaller draw call.
-										// fall through
-		case ACC_BLEND_SPRITE:          sw_blending |= m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 100;
-										// fall through
-		case ACC_BLEND_FREE:            sw_blending |= impossible_or_free_blend;
-										// fall through
-		default:                        /*sw_blending |= accumulation_blend*/;
+		case ACC_BLEND_ULTRA:
+			sw_blending |= true;
+			// fall through
+		case ACC_BLEND_FULL:
+			if (!m_vt.m_alpha.valid && (ALPHA.C == 0)) GetAlphaMinMax();
+			sw_blending |= (ALPHA.A != ALPHA.B) && ((ALPHA.C == 0 && m_vt.m_alpha.max > 128) || (ALPHA.C == 2 && ALPHA.FIX > 128u));
+			// fall through
+		case ACC_BLEND_HIGH:
+			sw_blending |= (ALPHA.C == 1);
+			// fall through
+		case ACC_BLEND_MEDIUM:
+			// Initial idea was to enable accurate blending for sprite rendering to handle
+			// correctly post-processing effect. Some games (ZoE) use tons of sprites as particles.
+			// In order to keep it fast, let's limit it to smaller draw call.
+			sw_blending |= m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 100;
+			// fall through
+		case ACC_BLEND_BASIC:
+			sw_blending |= impossible_or_free_blend;
+			// fall through
+		default:
+			/*sw_blending |= accumulation_blend*/;
 	}
 	// SW Blending
 	// GL42 interact very badly with sw blending. GL42 uses the primitiveID to find the primitive

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
@@ -40,12 +40,12 @@ class GSRendererOGL final : public GSRendererHW
 	};
 
 	enum ACC_BLEND {
-		ACC_BLEND_NONE = 0,
-		ACC_BLEND_FREE = 1,
-		ACC_BLEND_SPRITE = 2,
-		ACC_BLEND_CCLIP_DALPHA = 3,
-		ACC_BLEND_FULL = 4,
-		ACC_BLEND_ULTRA = 5
+		ACC_BLEND_NONE   = 0,
+		ACC_BLEND_BASIC  = 1,
+		ACC_BLEND_MEDIUM = 2,
+		ACC_BLEND_HIGH   = 3,
+		ACC_BLEND_FULL   = 4,
+		ACC_BLEND_ULTRA  = 5
 	};
 
 	private:


### PR DESCRIPTION
gsdx-d3d11: Always enable sw colclip for BLEND_NO_BAR.
- Free blending and it's faster than standard hdr algo when Blending
Accuracy is disabled.

- Add assert when disabling hw blending, hw blending should only be disabled
on free/no barrier blending. D3D11 lacks other types of blending.

- Use const to get rid of some warnings.


gsdx-ogl:
- Always enable sw colclip for BLEND_NO_BAR.
Free blending and it's faster than standard hdr algo when Blending
Accuracy is disabled.

- Enable sw colclip for Safe FBMASK SW emulated.
instead of hdr mode with accumulation blend so we don't use a mix of sw
and hw blending. It is more accurate.
Test case: Superman Shadows of Apokolips

- Use const to get rid of some warnings.