### PR TITLE
gsdx-d3d11: Truncate fog in tfx.fx shader.

### DIFF
--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -604,7 +604,7 @@ float4 fog(float4 c, float f)
 {
 	if(PS_FOG)
 	{
-		c.rgb = lerp(FogColor, c.rgb, f);
+		c.rgb = trunc(lerp(FogColor, c.rgb, f));
 	}
 
 	return c;


### PR DESCRIPTION
The change should've been pushed in #3091

Fixes regression with fog rendering.