### PR TITLE
GSdx: External Shader adjustments

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -951,7 +951,7 @@ void GSDevice11::InitExternalFX()
 			}
 		}
 		catch (GSDXRecoverableError) {
-			printf("GSdx: failed to compile external post-processing shader. \n");
+			fprintf(stderr, "GSdx: failed to compile external post-processing shader.\n");
 		}
 		ExShader_Compiled = true;
 	}

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1537,20 +1537,26 @@ void GSDeviceOGL::DoExternalFX(GSTexture* sTex, GSTexture* dTex)
 		std::ifstream fconfig(config_name);
 		std::stringstream config;
 		config << "#extension GL_ARB_gpu_shader5 : require\n";
-		if (fconfig.good())
+		if (!fconfig.good()) {
+			if (!m_flog.fconfig)
+				fprintf(stderr, "GSdx: External shader config '%s' not loaded.\n", config_name.c_str());
+			m_flog.fconfig = true;
+		} else {
 			config << fconfig.rdbuf();
-		else
-			fprintf(stderr, "Warning failed to load '%s'. External Shader might be wrongly configured\n", config_name.c_str());
+			m_flog.fconfig = false;
+		}
 
 		std::string   shader_name(theApp.GetConfigS("shaderfx_glsl"));
 		std::ifstream fshader(shader_name);
 		std::stringstream shader;
 		if (!fshader.good()) {
-			fprintf(stderr, "Error failed to load '%s'. External Shader will be disabled !\n", shader_name.c_str());
+			if (!m_flog.fshader)
+				fprintf(stderr, "GSdx: External shader '%s' not loaded and will be disabled!\n", shader_name.c_str());
+			m_flog.fshader = true;
 			return;
 		}
 		shader << fshader.rdbuf();
-
+		m_flog.fshader = false;
 
 		m_shaderfx.cb = new GSUniformBufferOGL("eFX UBO", g_fx_cb_index, sizeof(ExternalFXConstantBuffer));
 		GLuint ps = m_shader->Compile("Extra", "ps_main", GL_FRAGMENT_SHADER, shader.str().c_str(), config.str());

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -490,6 +490,8 @@ private:
 	struct {
 		bool fconfig;
 		bool fshader;
+		bool fcheck_once;
+		bool fbad_compile;
 	} m_flog{};
 
 	GLuint m_vs[1<<1];

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -487,6 +487,11 @@ private:
 		GLuint timer() { return timer_query[last_query]; }
 	} m_profiler;
 
+	struct {
+		bool fconfig;
+		bool fshader;
+	} m_flog{};
+
 	GLuint m_vs[1<<1];
 	GLuint m_gs[1<<3];
 	GLuint m_ps_ss[1<<7];


### PR DESCRIPTION
gsdx-d3d11: Adjust external shader log on failed compile.

gsdx-ogl: Avoid pasting logs for external shader for each draw.
Adjust log behavior for external shader config and shader when
external shader is not configured properly.

gsdx-ogl: Check if shader compiled only once and disable external shader if compilation failed.