### PR TITLE
GameDB: Add FMV fix for Twisted Metal - Head-On [Extra Twisted Edition]

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -6161,6 +6161,15 @@ Serial = SCUS-97621
 Name   = Twisted Metal - Head-On [Extra Twisted Edition]
 Region = NTSC-U
 Compat = 5
+[patches = 3DC2FE45]
+	author=Aced14
+	comment=Fix FMV resolution
+	// FMVs are meant to be letterboxed (640x368 with 40 pixel top/bottom bars).
+	// Without this patch, FMVs are rendered at 720x480 with bars on 3 sides
+	// (40 pixels at the top, 80 on the right, 72 at the bottom).
+	patch=1,EE,0023F954,short,00000280 //240602D0 - FMV horizontal resolution
+	patch=1,EE,0023F958,short,000001C0 //240701E0 - FMV vertical resolution
+[/patches]
 ---------------------------------------------
 Serial = SCUS-97622
 Name   = SingStar 80's [with Microphone]


### PR DESCRIPTION
This game's FMVs are meant to be letterboxed (640x368 with 40 pixel top/bottom bars). Without this patch, FMVs are rendered at 720x480 with bars on 3 sides (40 pixels at the top, 80 on the right, 72 at the bottom).

Related to #961 and #2226.

**Screenshots (GSdx SW+HW)...**

**Before:**
![gsdx_20200301211148](https://user-images.githubusercontent.com/13129485/76133072-50bd8000-5fe4-11ea-8de3-fd8a6c4fac3d.png)

**After:**
![gsdx_20200301212003](https://user-images.githubusercontent.com/13129485/76133074-52874380-5fe4-11ea-8ed6-e5fb12744123.png)