### PR TITLE
pcsx2-gui: Fix DPI scaling for speedhacks window when moving the sliders

### DIFF
--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "App.h"
 #include "ConfigurationPanels.h"
+#include "MSWstuff.h"
 
 using namespace pxSizerFlags;
 
@@ -128,8 +129,8 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	wxPanelWithHelpers* left	= new wxPanelWithHelpers( this, wxVERTICAL );
 	wxPanelWithHelpers* right	= new wxPanelWithHelpers( this, wxVERTICAL );
 
-	left->SetMinWidth( 350 );
-	right->SetMinWidth( 350 );
+	left->SetMinWidth( MSW_GetDPIScale() * 350 );
+	right->SetMinWidth( MSW_GetDPIScale() * 350 );
 
 	m_button_Defaults = new wxButton( right, wxID_DEFAULT, _("Restore Defaults") );
 


### PR DESCRIPTION
We can have it for either 1.6 or 1.8. Leaving it to the rest to cast their vote.

Testing was done on 1080p, 150% scale.
Before:
![image](https://user-images.githubusercontent.com/18107717/77116804-11a21c80-6a31-11ea-81f2-85de5858af87.png)

After:
![image](https://user-images.githubusercontent.com/18107717/77116822-18309400-6a31-11ea-94ea-8c9a856c6321.png)
