### PR TITLE
VU: Log the index of VU microprograms upon execution

### DIFF
--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -350,7 +350,9 @@ void recMicroVU1::Reset() {
 
 void recMicroVU0::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
-
+	
+	VUM_LOG("VU0 Microprogram Index: %d", microVU0.prog.cur->idx);
+	
 	if(!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
 
 	// Sometimes games spin on vu0, so be careful with this value
@@ -366,7 +368,9 @@ void recMicroVU0::Execute(u32 cycles) {
 }
 void recMicroVU1::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
-
+	
+	VUM_LOG("VU1 Microprogram Index: %d", microVU1.prog.cur->idx);
+	
 	if (!THREAD_VU1) {
 		if(!(VU0.VI[REG_VPU_STAT].UL & 0x100)) return;
 	}

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -351,9 +351,9 @@ void recMicroVU1::Reset() {
 void recMicroVU0::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
 	
-	VUM_LOG("VU0 Microprogram Index: %d", microVU0.prog.cur->idx);
-	
 	if(!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
+
+	VUM_LOG("VU0 Microprogram Index: %d", microVU0.prog.cur->idx);
 
 	// Sometimes games spin on vu0, so be careful with this value
 	// woody hangs if too high on sVU (untested on mVU)
@@ -369,11 +369,12 @@ void recMicroVU0::Execute(u32 cycles) {
 void recMicroVU1::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
 	
-	VUM_LOG("VU1 Microprogram Index: %d", microVU1.prog.cur->idx);
-	
 	if (!THREAD_VU1) {
 		if(!(VU0.VI[REG_VPU_STAT].UL & 0x100)) return;
 	}
+	
+	VUM_LOG("VU1 Microprogram Index: %d", microVU1.prog.cur->idx);
+	
 	((mVUrecCall)microVU1.startFunct)(VU1.VI[REG_TPC].UL, cycles);
 
 	if(microVU1.regs().flags & 0x4)

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -350,10 +350,8 @@ void recMicroVU1::Reset() {
 
 void recMicroVU0::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
-	
-	if(!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
 
-	VUM_LOG("VU0 Microprogram Index: %d", microVU0.prog.cur->idx);
+	if(!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
 
 	// Sometimes games spin on vu0, so be careful with this value
 	// woody hangs if too high on sVU (untested on mVU)
@@ -368,13 +366,10 @@ void recMicroVU0::Execute(u32 cycles) {
 }
 void recMicroVU1::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
-	
+
 	if (!THREAD_VU1) {
 		if(!(VU0.VI[REG_VPU_STAT].UL & 0x100)) return;
 	}
-	
-	VUM_LOG("VU1 Microprogram Index: %d", microVU1.prog.cur->idx);
-	
 	((mVUrecCall)microVU1.startFunct)(VU1.VI[REG_TPC].UL, cycles);
 
 	if(microVU1.regs().flags & 0x4)

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -130,7 +130,11 @@ _mVUt void* __fastcall mVUexecute(u32 startPC, u32 cycles) {
 	mVU.totalCycles = cycles;
 
 	xSetPtr(mVU.prog.x86ptr); // Set x86ptr to where last program left off
-	return mVUsearchProg<vuIndex>(startPC & vuLimit, (uptr)&mVU.prog.lpState); // Find and set correct program
+	void* entryPoint = mVUsearchProg<vuIndex>(startPC & vuLimit, (uptr)&mVU.prog.lpState); // Find and set correct program
+	
+	VUM_LOG("microVU%d: Executing Microprogram %d for %d cycles", vuIndex, mVU.prog.cur->idx, cycles);
+	
+	return entryPoint;
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
microVU supports [dumping out the disassembly of VU microprograms](https://github.com/PCSX2/pcsx2/blob/49e316e488c224bf50df0ee1e3bfbc55fa738343/pcsx2/x86/microVU.h#L17) with file names in the form "microVU1 prog - %d.html" where %d is the index of the microprogram.

The only time I've been able to find this index being printed out is when the microprogram is recompiled, which seems hard to correlate with e.g. the execution of a VIF MPG instruction. To get around this, I've added log messages to print out the index of a microprogram when it is executed.

It seems much easier to figure out which dumped microprogram is which now, unless I'm just blind and it's already logging everything I need, in which case ignore this PR.

I've tested this with a VU1 microprogram and it seems to be printing out the right numbers.