### PR TITLE
IPU Improvements

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -384,6 +384,7 @@ set(pcsx2GuiResources
 set(pcsx2IPUSources
 	IPU/IPU.cpp
 	IPU/IPU_Fifo.cpp
+	IPU/IPUdither.cpp
 	IPU/IPUdma.cpp
 	IPU/mpeg2lib/Idct.cpp
 	IPU/mpeg2lib/Mpeg.cpp

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -677,21 +677,6 @@ __fi void ipu_csc(macroblock_8& mb8, macroblock_rgb32& rgb32, int sgn)
 	}
 }
 
-__fi void ipu_dither(const macroblock_rgb32& rgb32, macroblock_rgb16& rgb16, int dte)
-{
-	int i, j;
-	for (i = 0; i < 16; ++i)
-	{
-		for (j = 0; j < 16; ++j)
-		{
-			rgb16.c[i][j].r = rgb32.c[i][j].r >> 3;
-			rgb16.c[i][j].g = rgb32.c[i][j].g >> 3;
-			rgb16.c[i][j].b = rgb32.c[i][j].b >> 3;
-			rgb16.c[i][j].a = rgb32.c[i][j].a == 0x40;
-		}
-	}
-}
-
 __fi void ipu_vq(macroblock_rgb16& rgb16, u8* indx4)
 {
 	Console.Error("IPU: VQ not implemented");

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -679,7 +679,30 @@ __fi void ipu_csc(macroblock_8& mb8, macroblock_rgb32& rgb32, int sgn)
 
 __fi void ipu_vq(macroblock_rgb16& rgb16, u8* indx4)
 {
-	Console.Error("IPU: VQ not implemented");
+	const auto closest_index = [&](int i, int j) {
+		u8 index = 0;
+		int min_distance = std::numeric_limits<int>::max();
+		for (u8 k = 0; k < 16; ++k)
+		{
+			const int dr = rgb16.c[i][j].r - vqclut[k].r;
+			const int dg = rgb16.c[i][j].g - vqclut[k].g;
+			const int db = rgb16.c[i][j].b - vqclut[k].b;
+			const int distance = dr * dr + dg * dg + db * db;
+
+			// XXX: If two distances are the same which index is used?
+			if (min_distance > distance)
+			{
+				index = k;
+				min_distance = distance;
+			}
+		}
+
+		return index;
+	};
+
+	for (int i = 0; i < 16; ++i)
+		for (int j = 0; j < 8; ++j)
+			indx4[i * 8 + j] = closest_index(i, 2 * j + 1) << 4 | closest_index(i, 2 * j);
 }
 
 

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -43,7 +43,7 @@ void IPUWorker();
 //u8 PCT[] = {'r', 'I', 'P', 'B', 'D', '-', '-', '-'};		// unused?
 
 // Quantization matrix
-static u16 vqclut[16];				//clut conversion table
+static rgb16_t vqclut[16];			//clut conversion table
 static u8 s_thresh[2];				//thresholds for color conversions
 int coded_block_pattern = 0;
 
@@ -546,23 +546,23 @@ static bool ipuSETVQ(u32 val)
 	    "%02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d\n"
 	    "%02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d\n"
 	    "%02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d\n"
-		"%02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d",
-	    vqclut[0] >> 10, (vqclut[0] >> 5) & 0x1F, vqclut[0] & 0x1F,
-	    vqclut[1] >> 10, (vqclut[1] >> 5) & 0x1F, vqclut[1] & 0x1F,
-	    vqclut[2] >> 10, (vqclut[2] >> 5) & 0x1F, vqclut[2] & 0x1F,
-	    vqclut[3] >> 10, (vqclut[3] >> 5) & 0x1F, vqclut[3] & 0x1F,
-	    vqclut[4] >> 10, (vqclut[4] >> 5) & 0x1F, vqclut[4] & 0x1F,
-	    vqclut[5] >> 10, (vqclut[5] >> 5) & 0x1F, vqclut[5] & 0x1F,
-	    vqclut[6] >> 10, (vqclut[6] >> 5) & 0x1F, vqclut[6] & 0x1F,
-	    vqclut[7] >> 10, (vqclut[7] >> 5) & 0x1F, vqclut[7] & 0x1F,
-	    vqclut[8] >> 10, (vqclut[8] >> 5) & 0x1F, vqclut[8] & 0x1F,
-	    vqclut[9] >> 10, (vqclut[9] >> 5) & 0x1F, vqclut[9] & 0x1F,
-	    vqclut[10] >> 10, (vqclut[10] >> 5) & 0x1F, vqclut[10] & 0x1F,
-	    vqclut[11] >> 10, (vqclut[11] >> 5) & 0x1F, vqclut[11] & 0x1F,
-	    vqclut[12] >> 10, (vqclut[12] >> 5) & 0x1F, vqclut[12] & 0x1F,
-	    vqclut[13] >> 10, (vqclut[13] >> 5) & 0x1F, vqclut[13] & 0x1F,
-	    vqclut[14] >> 10, (vqclut[14] >> 5) & 0x1F, vqclut[14] & 0x1F,
-	    vqclut[15] >> 10, (vqclut[15] >> 5) & 0x1F, vqclut[15] & 0x1F);
+	    "%02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d %02d:%02d:%02d",
+	    vqclut[0].r, vqclut[0].g, vqclut[0].b,
+	    vqclut[1].r, vqclut[1].g, vqclut[1].b,
+	    vqclut[2].r, vqclut[2].g, vqclut[2].b,
+	    vqclut[3].r, vqclut[3].g, vqclut[3].b,
+	    vqclut[4].r, vqclut[4].g, vqclut[4].b,
+	    vqclut[5].r, vqclut[5].g, vqclut[5].b,
+	    vqclut[6].r, vqclut[6].g, vqclut[6].b,
+	    vqclut[7].r, vqclut[7].g, vqclut[7].b,
+	    vqclut[8].r, vqclut[8].g, vqclut[8].b,
+	    vqclut[9].r, vqclut[9].g, vqclut[9].b,
+	    vqclut[10].r, vqclut[10].g, vqclut[10].b,
+	    vqclut[11].r, vqclut[11].g, vqclut[11].b,
+	    vqclut[12].r, vqclut[12].g, vqclut[12].b,
+	    vqclut[13].r, vqclut[13].g, vqclut[13].b,
+	    vqclut[14].r, vqclut[14].g, vqclut[14].b,
+	    vqclut[15].r, vqclut[15].g, vqclut[15].b);
 
 	return true;
 }

--- a/pcsx2/IPU/IPUdither.cpp
+++ b/pcsx2/IPU/IPUdither.cpp
@@ -21,7 +21,15 @@
 #include "yuv2rgb.h"
 #include "mpeg2lib/Mpeg.h"
 
+void ipu_dither_reference(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte);
+void ipu_dither_sse2(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte);
+
 __ri void ipu_dither(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte)
+{
+    ipu_dither_sse2(rgb32, rgb16, dte);
+}
+
+__ri void ipu_dither_reference(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte)
 {
     if (dte) {
         // I'm guessing values are rounded down when clamping.
@@ -52,6 +60,63 @@ __ri void ipu_dither(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int
                 rgb16.c[i][j].b = rgb32.c[i][j].b >> 3;
                 rgb16.c[i][j].a = rgb32.c[i][j].a == 0x40;
             }
+        }
+    }
+}
+
+__ri void ipu_dither_sse2(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte)
+{
+    const __m128i alpha_test = _mm_set1_epi16(0x40);
+    const __m128i dither_add_matrix[] = {
+        _mm_setr_epi32(0x00000000, 0x00000000, 0x00000000, 0x00010101),
+        _mm_setr_epi32(0x00020202, 0x00000000, 0x00030303, 0x00000000),
+        _mm_setr_epi32(0x00000000, 0x00010101, 0x00000000, 0x00000000),
+        _mm_setr_epi32(0x00030303, 0x00000000, 0x00020202, 0x00000000),
+    };
+    const __m128i dither_sub_matrix[] = {
+        _mm_setr_epi32(0x00040404, 0x00000000, 0x00030303, 0x00000000),
+        _mm_setr_epi32(0x00000000, 0x00020202, 0x00000000, 0x00010101),
+        _mm_setr_epi32(0x00030303, 0x00000000, 0x00040404, 0x00000000),
+        _mm_setr_epi32(0x00000000, 0x00010101, 0x00000000, 0x00020202),
+    };
+    for (int i = 0; i < 16; ++i) {
+        const __m128i dither_add = dither_add_matrix[i & 3];
+        const __m128i dither_sub = dither_sub_matrix[i & 3];
+        for (int n = 0; n < 2; ++n) {
+            __m128i rgba_8_0123 = _mm_load_si128(reinterpret_cast<const __m128i *>(&rgb32.c[i][n * 8]));
+            __m128i rgba_8_4567 = _mm_load_si128(reinterpret_cast<const __m128i *>(&rgb32.c[i][n * 8 + 4]));
+
+            // Dither and clamp
+            if (dte) {
+                rgba_8_0123 = _mm_adds_epu8(rgba_8_0123, dither_add);
+                rgba_8_0123 = _mm_subs_epu8(rgba_8_0123, dither_sub);
+                rgba_8_4567 = _mm_adds_epu8(rgba_8_4567, dither_add);
+                rgba_8_4567 = _mm_subs_epu8(rgba_8_4567, dither_sub);
+            }
+
+            // Split into channel components and extend to 16 bits
+            const __m128i rgba_16_0415 = _mm_unpacklo_epi8(rgba_8_0123, rgba_8_4567);
+            const __m128i rgba_16_2637 = _mm_unpackhi_epi8(rgba_8_0123, rgba_8_4567);
+            const __m128i rgba_32_0246 = _mm_unpacklo_epi8(rgba_16_0415, rgba_16_2637);
+            const __m128i rgba_32_1357 = _mm_unpackhi_epi8(rgba_16_0415, rgba_16_2637);
+            const __m128i rg_64_01234567 = _mm_unpacklo_epi8(rgba_32_0246, rgba_32_1357);
+            const __m128i ba_64_01234567 = _mm_unpackhi_epi8(rgba_32_0246, rgba_32_1357);
+
+            const __m128i zero = _mm_setzero_si128();
+            __m128i r = _mm_unpacklo_epi8(rg_64_01234567, zero);
+            __m128i g = _mm_unpackhi_epi8(rg_64_01234567, zero);
+            __m128i b = _mm_unpacklo_epi8(ba_64_01234567, zero);
+            __m128i a = _mm_unpackhi_epi8(ba_64_01234567, zero);
+
+            // Create RGBA
+            r = _mm_srli_epi16(r, 3);
+            g = _mm_slli_epi16(_mm_srli_epi16(g, 3), 5);
+            b = _mm_slli_epi16(_mm_srli_epi16(b, 3), 10);
+            a = _mm_slli_epi16(_mm_cmpeq_epi16(a, alpha_test), 15);
+
+            const __m128i rgba16 = _mm_or_si128(_mm_or_si128(r, g), _mm_or_si128(b, a));
+
+            _mm_store_si128(reinterpret_cast<__m128i *>(&rgb16.c[i][n * 8]), rgba16);
         }
     }
 }

--- a/pcsx2/IPU/IPUdither.cpp
+++ b/pcsx2/IPU/IPUdither.cpp
@@ -1,0 +1,34 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2019  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "Common.h"
+
+#include "IPU.h"
+#include "IPUdma.h"
+#include "yuv2rgb.h"
+#include "mpeg2lib/Mpeg.h"
+
+__ri void ipu_dither(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte)
+{
+    for (int i = 0; i < 16; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            rgb16.c[i][j].r = rgb32.c[i][j].r >> 3;
+            rgb16.c[i][j].g = rgb32.c[i][j].g >> 3;
+            rgb16.c[i][j].b = rgb32.c[i][j].b >> 3;
+            rgb16.c[i][j].a = rgb32.c[i][j].a == 0x40;
+        }
+    }
+}

--- a/pcsx2/IPU/IPUdither.cpp
+++ b/pcsx2/IPU/IPUdither.cpp
@@ -23,12 +23,35 @@
 
 __ri void ipu_dither(const macroblock_rgb32 &rgb32, macroblock_rgb16 &rgb16, int dte)
 {
-    for (int i = 0; i < 16; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            rgb16.c[i][j].r = rgb32.c[i][j].r >> 3;
-            rgb16.c[i][j].g = rgb32.c[i][j].g >> 3;
-            rgb16.c[i][j].b = rgb32.c[i][j].b >> 3;
-            rgb16.c[i][j].a = rgb32.c[i][j].a == 0x40;
+    if (dte) {
+        // I'm guessing values are rounded down when clamping.
+        const int dither_coefficient[4][4] = {
+            {-4, 0, -3, 1},
+            {2, -2, 3, -1},
+            {-3, 1, -4, 0},
+            {3, -1, 2, -2},
+        };
+        for (int i = 0; i < 16; ++i) {
+            for (int j = 0; j < 16; ++j) {
+                const int dither = dither_coefficient[i & 3][j & 3];
+                const int r = std::max(0, std::min(rgb32.c[i][j].r + dither, 255));
+                const int g = std::max(0, std::min(rgb32.c[i][j].g + dither, 255));
+                const int b = std::max(0, std::min(rgb32.c[i][j].b + dither, 255));
+
+                rgb16.c[i][j].r = r >> 3;
+                rgb16.c[i][j].g = g >> 3;
+                rgb16.c[i][j].b = b >> 3;
+                rgb16.c[i][j].a = rgb32.c[i][j].a == 0x40;
+            }
+        }
+    } else {
+        for (int i = 0; i < 16; ++i) {
+            for (int j = 0; j < 16; ++j) {
+                rgb16.c[i][j].r = rgb32.c[i][j].r >> 3;
+                rgb16.c[i][j].g = rgb32.c[i][j].g >> 3;
+                rgb16.c[i][j].b = rgb32.c[i][j].b >> 3;
+                rgb16.c[i][j].a = rgb32.c[i][j].a == 0x40;
+            }
         }
     }
 }

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="..\..\gui\Panels\MemoryCardListView.cpp" />
     <ClCompile Include="..\..\IopGte.cpp" />
     <ClCompile Include="..\..\IPU\IPUdma.cpp" />
+    <ClCompile Include="..\..\IPU\IPUdither.cpp" />
     <ClCompile Include="..\..\Linux\LnxConsolePipe.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -889,6 +889,9 @@
     <ClCompile Include="..\..\Recording\VirtualPad.cpp">
       <Filter>Recording\gui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\IPU\IPUdither.cpp">
+      <Filter>System\Ps2\IPU</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Patch.h">


### PR DESCRIPTION
Changes:
 - Adds dithering to the RGB32->RGB16 conversion (see images from Hisshou Pachinko PachiSlot Kouryaku Series Vol 10)
 - Adds SSE2 implementation of RGB32->RGB16 conversion (speed on the opening FMV in the above mentioned game goes from ~175% to ~275% with frame limiter disabled on my system using GSdx software mode)
 - Implements VQ (see images from Klonoa 2)

Dithering before:
![ipu_pre](https://user-images.githubusercontent.com/10976277/79253503-398f6f00-7e7b-11ea-9e73-570c91e14e25.png)

Dithering after:
![ipu_round_down](https://user-images.githubusercontent.com/10976277/79253514-3eecb980-7e7b-11ea-91c7-611bd9347a89.png)

VQ before:
![noflames](https://user-images.githubusercontent.com/10976277/79253528-444a0400-7e7b-11ea-8ab6-1243d9177880.png)

VQ after:
![flames](https://user-images.githubusercontent.com/10976277/79253546-4ad87b80-7e7b-11ea-9ec9-c13c4cc54207.png)

Side note:
10ee832dc13c7aee9623aaf2e0d2875ceecc4797 might be revertable and Klonoa 2 patches might be removable because of #3119 (needs to be checked).