### PR TITLE
gsdx:windows: Use precise floating point behaviour

### DIFF
--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -8,7 +8,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointModel>Precise</FloatingPointModel>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>


### PR DESCRIPTION
Fast floating point behaviour can optimise out handling for special floating point values e.g. NaNs. As GSdx needs to handle NaNs in a few places, precise floating point behaviour should be used instead.

Fixes a flashlight regression in Silent Hill 2/3 that was caused by VS2019 optimising out NaN handling.
Related #2817