### PR TITLE
Revert "gsdx-ogl/d3d11: Add a assert when texture is too small or too big."

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -645,9 +645,6 @@ void GSDevice11::ClearStencil(GSTexture* t, uint8 c)
 
 GSTexture* GSDevice11::CreateSurface(int type, int w, int h, int format)
 {
-	ASSERT(w > 0 && w <= m_d3d_texsize);
-	ASSERT(h > 0 && h <= m_d3d_texsize);
-
 	HRESULT hr;
 
 	D3D11_TEXTURE2D_DESC desc;

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -155,9 +155,6 @@ namespace PboPool {
 GSTextureOGL::GSTextureOGL(int type, int w, int h, int format, GLuint fbo_read, bool mipmap)
 	: m_clean(false), m_generate_mipmap(true), m_local_buffer(nullptr), m_r_x(0), m_r_y(0), m_r_w(0), m_r_h(0), m_layer(0)
 {
-	ASSERT(w > 0);
-	ASSERT(h > 0);
-
 	// OpenGL didn't like dimensions of size 0
 	m_size.x = std::max(1,w);
 	m_size.y = std::max(1,h);


### PR DESCRIPTION
This reverts commit 99f814d3764bc4ce87491ebeedac84762b3d68f3.

The assert gets triggered on Linux and so debug build can't be used properly.
Would be nice to investigate why in the first place but until then revert the
entire commit. We have checks for texture limits anyway so it shouldn't be an issue.