### PR TITLE
Ability to completly unbind hotkeys

### DIFF
--- a/3rdparty/wxwidgets3.0/src/common/accelcmn.cpp
+++ b/3rdparty/wxwidgets3.0/src/common/accelcmn.cpp
@@ -112,6 +112,7 @@ static const struct wxKeyName
     { WXK_WINDOWS_RIGHT,    /*TRANSLATORS: Name of keyboard key*/ wxTRANSLATE("Windows_Right") },
     { WXK_WINDOWS_MENU,     /*TRANSLATORS: Name of keyboard key*/ wxTRANSLATE("Windows_Menu") },
     { WXK_COMMAND,          /*TRANSLATORS: Name of keyboard key*/ wxTRANSLATE("Command") },
+    { WXK_SPECIAL20,        /*TRANSLATORS: Name of keyboard key*/ wxTRANSLATE("None") },
 };
 
 wxGCC_WARNING_RESTORE(missing-field-initializers)

--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -32,6 +32,8 @@
 # KP_DELETE KP_EQUAL KP_MULTIPLY KP_ADD KP_SEPARATOR KP_SUBTRACT KP_DECIMAL
 # KP_DIVIDE WINDOWS_LEFT WINDOWS_RIGHT WINDOWS_MENU COMMAND
 
+# To unbind key for preventing accidental pressing type None
+
 # save state: freeze is save state, defrost is load state.
 States_FreezeCurrentSlot          = F1
 States_DefrostCurrentSlot         = F3


### PR DESCRIPTION
I spent three hours trying to do better it way. WXK_NONE is not working, it just uses a default hotkey. I had to use some unused special key, that actually doesn't exist on keyboards

Fixes https://github.com/PCSX2/pcsx2/issues/3214