### PR TITLE
Fix various cmake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(Pcsx2)
 # Debian-based distributions require at least 2.8.5 due to multiarch.
 # Bumping up to 3.0 seems reasonable at this point, and will let us modernize
 # things a bit.
-cmake_minimum_required(VERSION 3.0.2)
+#
+# Setting it to a range tells it that it supports the features on the newer
+# versions as well, avoiding setting policies.
+cmake_minimum_required(VERSION 3.0.2...3.17)
 
 # Variable to check that people use the good file
 set(TOP_CMAKE_WAS_SOURCED TRUE)

--- a/build.sh
+++ b/build.sh
@@ -195,6 +195,7 @@ for ARG in "$@"; do
         --clean             ) cleanBuild=1 ;;
         --clean-plugins     ) cleanBuild=2 ;;
         --clang-tidy        ) flags="$flags -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"; clangTidy=1 ; useClang=1;;
+        --ftime-trace       ) flags="$flags -DTIMETRACE=TRUE"; useClang=1;;
         --clang             ) useClang=1 ;;
         --intel             ) useIcc=1 ;;
         --cppcheck          ) cppcheck=1 ;;
@@ -262,6 +263,7 @@ for ARG in "$@"; do
             echo "--cppcheck      : Do a cppcheck analysis. Results can be found in build directory"
             echo "--coverity      : Do a build for coverity"
             echo "--vtune         : Plug GSdx with VTUNE"
+            echo "--ftime-trace   : Analyse build time. Clang only."
 
             exit 1
     esac

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -407,6 +407,12 @@ else()
     set(GCOV_LIBRARIES "-lgcov")
 endif()
 
+if(USE_CLANG)
+    if(TIMETRACE)
+        set(COMMON_FLAG "${COMMON_FLAG} -ftime-trace ")
+    endif()
+endif()
+
 # Note: -DGTK_DISABLE_DEPRECATED can be used to test a build without gtk deprecated feature. It could be useful to port to a newer API
 set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS} ${PGO_FLAGS} ${PLUGIN_SUPPORT}")
 # c++ only flags

--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -1,5 +1,6 @@
 
 # Copyright (c) 2012, Intel Corporation
+# Copyright (c) 2019 Sony Interactive Entertainment Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -28,15 +29,153 @@
 # Try to find Harfbuzz include and library directories.
 #
 # After successful discovery, this will set for inclusion where needed:
-# HARFBUZZ_INCLUDE_DIRS - containg the HarfBuzz headers
-# HARFBUZZ_LIBRARIES - containg the HarfBuzz library
-INCLUDE(FindPkgConfig)
-PKG_CHECK_MODULES(PC_HARFBUZZ harfbuzz>=0.9.0)
-FIND_PATH(HARFBUZZ_INCLUDE_DIRS NAMES hb.h
-  HINTS ${PC_HARFBUZZ_INCLUDE_DIRS} ${PC_HARFBUZZ_INCLUDEDIR}
+# HarfBuzz_INCLUDE_DIRS - containg the HarfBuzz headers
+# HarfBuzz_LIBRARIES - containg the HarfBuzz library
+
+#[=======================================================================[.rst:
+FindHarfBuzz
+--------------
+
+Find HarfBuzz headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``HarfBuzz::HarfBuzz``
+  The HarfBuzz library, if found.
+
+``HarfBuzz::ICU``
+  The HarfBuzz ICU library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``HarfBuzz_FOUND``
+  true if (the requested version of) HarfBuzz is available.
+``HarfBuzz_VERSION``
+  the version of HarfBuzz.
+``HarfBuzz_LIBRARIES``
+  the libraries to link against to use HarfBuzz.
+``HarfBuzz_INCLUDE_DIRS``
+  where to find the HarfBuzz headers.
+``HarfBuzz_COMPILE_OPTIONS``
+  this should be passed to target_compile_options(), if the
+  target is not used for linking
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_HARFBUZZ QUIET harfbuzz)
+set(HarfBuzz_COMPILE_OPTIONS ${PC_HARFBUZZ_CFLAGS_OTHER})
+set(HarfBuzz_VERSION ${PC_HARFBUZZ_CFLAGS_VERSION})
+
+find_path(HarfBuzz_INCLUDE_DIR
+    NAMES hb.h
+    HINTS ${PC_HARFBUZZ_INCLUDEDIR} ${PC_HARFBUZZ_INCLUDE_DIRS}
+    PATH_SUFFIXES harfbuzz
 )
-FIND_LIBRARY(HARFBUZZ_LIBRARIES NAMES harfbuzz
-  HINTS ${PC_HARFBUZZ_LIBRARY_DIRS} ${PC_HARFBUZZ_LIBDIR}
+
+find_library(HarfBuzz_LIBRARY
+    NAMES ${HarfBuzz_NAMES} harfbuzz
+    HINTS ${PC_HARFBUZZ_LIBDIR} ${PC_HARFBUZZ_LIBRARY_DIRS}
 )
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(HarfBuzz DEFAULT_MSG HARFBUZZ_INCLUDE_DIRS HARFBUZZ_LIBRARIES)
+
+if (HarfBuzz_INCLUDE_DIR AND NOT HarfBuzz_VERSION)
+    if (EXISTS "${HarfBuzz_INCLUDE_DIR}/hb-version.h")
+        file(READ "${HarfBuzz_INCLUDE_DIR}/hb-version.h" _harfbuzz_version_content)
+
+        string(REGEX MATCH "#define +HB_VERSION_STRING +\"([0-9]+\.[0-9]+\.[0-9]+)\"" _dummy "${_harfbuzz_version_content}")
+        set(HarfBuzz_VERSION "${CMAKE_MATCH_1}")
+    endif ()
+endif ()
+
+if ("${HarfBuzz_FIND_VERSION}" VERSION_GREATER "${HarfBuzz_VERSION}")
+    message(FATAL_ERROR "Required version (" ${HarfBuzz_FIND_VERSION} ") is higher than found version (" ${HarfBuzz_VERSION} ")")
+endif ()
+
+# Find components
+if (HarfBuzz_INCLUDE_DIR AND HarfBuzz_LIBRARY)
+    set(_HarfBuzz_REQUIRED_LIBS_FOUND ON)
+    set(HarfBuzz_LIBS_FOUND "HarfBuzz (required): ${HarfBuzz_LIBRARY}")
+else ()
+    set(_HarfBuzz_REQUIRED_LIBS_FOUND OFF)
+    set(HarfBuzz_LIBS_NOT_FOUND "HarfBuzz (required)")
+endif ()
+
+if ("ICU" IN_LIST HarfBuzz_FIND_COMPONENTS)
+    pkg_check_modules(PC_HARFBUZZ_ICU QUIET harfbuzz-icu)
+    set(HarfBuzz_ICU_COMPILE_OPTIONS ${PC_HARFBUZZ_ICU_CFLAGS_OTHER})
+
+    find_library(HarfBuzz_ICU_LIBRARY
+        NAMES ${HarfBuzz_ICU_NAMES} harfbuzz-icu
+        HINTS ${PC_HARFBUZZ_ICU_LIBDIR} ${PC_HARFBUZZ_ICU_LIBRARY_DIRS}
+    )
+
+    if (HarfBuzz_ICU_LIBRARY)
+        if (HarfBuzz_FIND_REQUIRED_ICU)
+            list(APPEND HarfBuzz_LIBS_FOUND "ICU (required): ${HarfBuzz_ICU_LIBRARY}")
+        else ()
+           list(APPEND HarfBuzz_LIBS_FOUND "ICU (optional): ${HarfBuzz_ICU_LIBRARY}")
+        endif ()
+    else ()
+        if (HarfBuzz_FIND_REQUIRED_ICU)
+           set(_HarfBuzz_REQUIRED_LIBS_FOUND OFF)
+           list(APPEND HarfBuzz_LIBS_NOT_FOUND "ICU (required)")
+        else ()
+           list(APPEND HarfBuzz_LIBS_NOT_FOUND "ICU (optional)")
+        endif ()
+    endif ()
+endif ()
+
+if (NOT HarfBuzz_FIND_QUIETLY)
+    if (HarfBuzz_LIBS_FOUND)
+        message(STATUS "Found the following HarfBuzz libraries:")
+        foreach (found ${HarfBuzz_LIBS_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+    if (HarfBuzz_LIBS_NOT_FOUND)
+        message(STATUS "The following HarfBuzz libraries were not found:")
+        foreach (found ${HarfBuzz_LIBS_NOT_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HarfBuzz
+    FOUND_VAR HarfBuzz_FOUND
+    REQUIRED_VARS HarfBuzz_INCLUDE_DIR HarfBuzz_LIBRARY _HarfBuzz_REQUIRED_LIBS_FOUND
+    VERSION_VAR HarfBuzz_VERSION
+)
+
+if (HarfBuzz_LIBRARY AND NOT TARGET HarfBuzz::HarfBuzz)
+    add_library(HarfBuzz::HarfBuzz UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(HarfBuzz::HarfBuzz PROPERTIES
+        IMPORTED_LOCATION "${HarfBuzz_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${HarfBuzz_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${HarfBuzz_INCLUDE_DIR}"
+    )
+endif ()
+
+if (HarfBuzz_ICU_LIBRARY AND NOT TARGET HarfBuzz::ICU)
+    add_library(HarfBuzz::ICU UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(HarfBuzz::ICU PROPERTIES
+        IMPORTED_LOCATION "${HarfBuzz_ICU_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${HarfBuzz_ICU_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${HarfBuzz_INCLUDE_DIR}"
+    )
+endif ()
+
+mark_as_advanced(
+    HarfBuzz_INCLUDE_DIR
+    HarfBuzz_LIBRARY
+    HarfBuzz_ICU_LIBRARY
+)
+
+if (HarfBuzz_FOUND)
+   set(HarfBuzz_LIBRARIES ${HarfBuzz_LIBRARY} ${HarfBuzz_ICU_LIBRARY})
+   set(HarfBuzz_INCLUDE_DIRS ${HarfBuzz_INCLUDE_DIR})
+endif ()

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -739,7 +739,7 @@ endif()
 add_pcsx2_executable(${Output} "${pcsx2FinalSources}" "${pcsx2FinalLibs}" "${pcsx2FinalFlags}")
 
 if(NOT USE_CLANG)
-	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
+	if(COMMAND target_precompile_headers)
 		message("Using precompiled headers.")
 		target_precompile_headers(${Output} PRIVATE PrecompiledHeader.h)
 	endif()

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -738,6 +738,13 @@ endif()
 
 add_pcsx2_executable(${Output} "${pcsx2FinalSources}" "${pcsx2FinalLibs}" "${pcsx2FinalFlags}")
 
+if(NOT USE_CLANG)
+	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
+		message("Using precompiled headers.")
+		target_precompile_headers(${Output} PRIVATE PrecompiledHeader.h)
+	endif()
+endif()
+
 if(dev9ghzdrk)
     if(PACKAGE_MODE)
         install(CODE "execute_process(COMMAND /bin/bash -c \"echo 'Enabling networking capability on Linux...';set -x; [ -f ${BIN_DIR}/${Output} ] && sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' ${BIN_DIR}/${Output}; set +x\")")


### PR DESCRIPTION
This does the following:
The Harzbuzz module is updated, resolving issue #3313 
The cmake minimum version is now a range, causing it to use the newer flags by default on newer versions up to 3.17, resolving Issue #3310
There's a new option to compile with flag -ftime-trace with clang, which can be useful for determining things that slow compile time.
If you are on gcc and cmake 3.16+, actually precompile PrecompiledHeader.h.