### PR TITLE
Allow reading of 8bit timers (and other hardware pages)

### DIFF
--- a/pcsx2/HwRead.cpp
+++ b/pcsx2/HwRead.cpp
@@ -235,7 +235,7 @@ mem8_t __fastcall _hwRead8(u32 mem)
 template< uint page >
 mem8_t __fastcall hwRead8(u32 mem)
 {
-	mem8_t ret8 = _hwRead8<0x0f>(mem);
+	mem8_t ret8 = _hwRead8<page>(mem);
 	eeHwTraceLog( mem, ret8, true );
 	return ret8;
 }


### PR DESCRIPTION
Fixes Robin Hood