### PR TITLE
Don't check the backup save slot when updating the ui.

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -27,9 +27,6 @@
 #include "AppCoreThread.h"
 #include "RecentIsoList.h"
 
-//Purely to make sure the saveslot define comes through. Remove if it gets removed.
-#include "Saveslots.h"
-
 #ifndef DISABLE_RECORDING
 #	include "Recording/VirtualPad.h"
 #	include "Recording/NewRecordingFrame.h"

--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -30,10 +30,9 @@
 // --------------------------------------------------------------------------------------
 
 static int StatesC = 0;
-static const int StateSlotsCount = 10;
 
 #ifdef USE_NEW_SAVESLOTS_UI
-Saveslot saveslot_cache[10] = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}};
+std::array<Saveslot,StateSlotsCount> saveslot_cache = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 #endif
 
 // FIXME : Use of the IsSavingOrLoading flag is mostly a hack until we implement a
@@ -80,14 +79,7 @@ void States_FreezeCurrentSlot()
 	StateCopy_SaveToSlot(StatesC);
 
 #ifdef USE_NEW_SAVESLOTS_UI
-	// Update the saveslot cache with the new saveslot, and give it the current timestamp, 
-	// Because we aren't going to be able to get the real timestamp from disk right now.
-	saveslot_cache[StatesC].empty = false;
-	saveslot_cache[StatesC].updated = wxDateTime::Now();
-	saveslot_cache[StatesC].crc = ElfCRC;
-
-	// Update the slot next time we run through the UI update.
-	saveslot_cache[StatesC].menu_update = true;
+	saveslot_cache[StatesC].Used();
 #endif
 
 	GetSysExecutorThread().PostIdleEvent(SysExecEvent_ClearSavingLoadingFlag());

--- a/pcsx2/gui/Saveslots.h
+++ b/pcsx2/gui/Saveslots.h
@@ -19,6 +19,8 @@
 #include "PS2Edefs.h"
 #include "System.h"
 #include "Elfheader.h"
+#include "App.h"
+#include <array>
 
 // Uncomment to turn on the new saveslot UI.
 #define USE_NEW_SAVESLOTS_UI
@@ -37,6 +39,7 @@
 #endif
 
 extern wxString DiscSerial;
+static const int StateSlotsCount = 10;
 
 class Saveslot
 {
@@ -47,17 +50,9 @@ public:
 	u32 crc;
 	wxString serialName;
 	bool menu_update, invalid_cache;
+	int load_item_id, save_item_id;
 
-	Saveslot()
-	{
-		slot_num = 0;
-		empty = true;
-		updated = wxInvalidDateTime;
-		crc = 0;
-		serialName = L"";
-		menu_update = false;
-		invalid_cache = true;
-	}
+	Saveslot() = delete;
 
 	Saveslot(int i)
 	{
@@ -68,6 +63,8 @@ public:
 		serialName =  L"";
 		menu_update = false;
 		invalid_cache = true;
+		load_item_id = MenuId_State_Load01 + i + 1;
+		save_item_id = MenuId_State_Save01 + i + 1;
 	}
 
 	bool isUsed()
@@ -115,9 +112,21 @@ public:
 		//if (isUsed())
 		//	Console.WriteLn(wxsFormat(_("The disk has a file on it dated %s %s."), GetTimestamp().FormatDate(), GetTimestamp().FormatTime()));
 	}
+
+	void Used()
+	{
+		// Update the saveslot cache with the new saveslot, and give it the current timestamp, 
+		// Because we aren't going to be able to get the real timestamp from disk right now.
+		empty = false;
+		updated = wxDateTime::Now();
+		crc = ElfCRC;
+
+		// Update the slot next time we run through the UI update.
+		menu_update = true;
+	}
 };
 
-extern Saveslot saveslot_cache[10];
+extern std::array<Saveslot,10> saveslot_cache;
 extern void States_DefrostCurrentSlotBackup();
 extern void States_DefrostCurrentSlot();
 extern void States_FreezeCurrentSlot();

--- a/pcsx2/gui/SysState.cpp
+++ b/pcsx2/gui/SysState.cpp
@@ -476,11 +476,6 @@ protected:
 
 	void CleanupEvent()
 	{
-#ifdef USE_NEW_SAVESLOTS_UI
-		// I have a feeling this doesn't need to be here, so I'm commenting this out for the moment.
-		// I'll remove it if it doesn't cause other issues.
-		//UI_UpdateSysControls();
-#endif
 	}
 };
 

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "MainFrame.h"
 #include "GSFrame.h"
+#include "Saveslots.h"
 
 // General Notes:
 //  * It's very important that we re-discover menu items by ID every time we change them,
@@ -44,45 +45,41 @@ static void _SaveLoadStuff(bool enabled)
 	sMainFrame.EnableMenuItem(MenuId_Sys_SaveStates, enabled);
 
 #ifdef USE_NEW_SAVESLOTS_UI
-	// Run though all the slots.Update if they need updating or the crc changed.
-	for (int i = 0; i < 10; i++)
+	// Run though all the slots. Update if they need updating or the crc changed.
+	for (Saveslot &slot : saveslot_cache)
 	{
-		int load_menu_item = MenuId_State_Load01 + i + 1;
-		int save_menu_item = MenuId_State_Save01 + i + 1;
-		
 		// We need to reload the file information if the crc or serial # changed.
-		if ((saveslot_cache[i].crc != ElfCRC)|| (saveslot_cache[i].serialName != DiscSerial)) saveslot_cache[i].invalid_cache = true;
+		if ((slot.crc != ElfCRC)|| (slot.serialName != DiscSerial)) slot.invalid_cache = true;
 
 		// Either the cache needs updating, or the menu items do, or both.
-		if (saveslot_cache[i].menu_update || saveslot_cache[i].invalid_cache)
+		if (slot.menu_update || slot.invalid_cache)
 		{
 			#ifdef SAVESLOT_LOGS
-			Console.WriteLn("Updating slot %i.", i);
-			if (saveslot_cache[i].menu_update) Console.WriteLn("Menu update needed.");
-			if (saveslot_cache[i].invalid_cache) Console.WriteLn("Invalid cache. (CRC different or just initialized.)");
+			Console.WriteLn("Updating slot %i.", slot.slot_num);
+			if (slot.menu_update) Console.WriteLn("Menu update needed.");
+			if (slot.invalid_cache) Console.WriteLn("Invalid cache. (CRC different or just initialized.)");
 			#endif
 
-			if (saveslot_cache[i].invalid_cache)
+			if (slot.invalid_cache)
 			{
 				// Pull everything from disk.
-				saveslot_cache[i].UpdateCache();
+				slot.UpdateCache();
 
 				#ifdef SAVESLOT_LOGS
-				saveslot_cache[i].ConsoleDump();
+				slot.ConsoleDump();
 				#endif
 			}
 
 			// Update from the cached information.
-			saveslot_cache[i].menu_update = false;
-			saveslot_cache[i].crc = ElfCRC;
+			slot.menu_update = false;
+			slot.crc = ElfCRC;
 
-			sMainFrame.EnableMenuItem(load_menu_item, !saveslot_cache[i].empty);
-			sMainFrame.SetMenuItemLabel(load_menu_item, saveslot_cache[i].SlotName());
-			sMainFrame.SetMenuItemLabel(save_menu_item, saveslot_cache[i].SlotName());
+			sMainFrame.EnableMenuItem(slot.load_item_id, !slot.empty);
+			sMainFrame.SetMenuItemLabel(slot.load_item_id, slot.SlotName());
+			sMainFrame.SetMenuItemLabel(slot.save_item_id, slot.SlotName());
 		}
 
 	}
-	Sstates_updateLoadBackupMenuItem(false);
 #endif
 }
 


### PR DESCRIPTION
Only update the backup when freezing or defrosting or changing active save slot, not when updating the ui. Gets rid of potential latency. 

I also refactored the saveslot code a bit to be more readable and use a ranged for.