### PR TITLE
Performance fix for Primal and Ghosthunter. 

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -4685,7 +4685,10 @@ Compat = 5
 [patches = FCD89DC3]
 	author=Raziel I.C.H.I. Znot
 	comment=Performance fix
-	//microcode, remove wait loop
+	//PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
+	//so the game will wait endlessly in a wait loop until COP2 gets around to
+	//setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
+	//VU0 side, remove wait loop
 	patch=1,EE,0040F110,word,8000033c
 	patch=1,EE,0040F128,word,8000033c
 	patch=1,EE,0040F168,word,8000033c
@@ -4695,7 +4698,7 @@ Compat = 5
 	patch=1,EE,0040F738,word,8000033c
 	patch=1,EE,0040F778,word,8000033c
 	patch=1,EE,0040F790,word,8000033c
-	//EE code, rearrange code so VU code receives all data at once
+	//EE side, rearrange and clean code so VU0 receives all data at once
 	patch=1,EE,00399B14,word,00000000
 	patch=1,EE,00399B58,word,48A44800
 	patch=1,EE,00399B5C,word,4A00D839
@@ -39734,7 +39737,10 @@ Compat = 5
 [patches = 29C7DA54]
 	author=Raziel I.C.H.I. Znot
 	comment=Performance fix
-	//microcode, remove wait loop
+	//PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
+	//so the game will wait endlessly in a wait loop until COP2 gets around to
+	//setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
+	//VU0 side, remove wait loop
 	patch=1,EE,00461C68,word,8000033c
 	patch=1,EE,00461C80,word,8000033c
 	patch=1,EE,00461CC0,word,8000033c
@@ -39744,7 +39750,7 @@ Compat = 5
 	patch=1,EE,00463130,word,8000033c
 	patch=1,EE,00463170,word,8000033c
 	patch=1,EE,00463188,word,8000033c
-	//EE code, rearrange code so VU code receives all data at once
+	//EE side, rearrange and clean code so VU0 receives all data at once
 	patch=1,EE,003F8544,word,00000000
 	patch=1,EE,003F8588,word,48A44800
 	patch=1,EE,003F858C,word,4A00D839

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -4682,6 +4682,29 @@ Serial = SCUS-97142
 Name   = Primal - Civilization Is Only Skin Deep
 Region = NTSC-U
 Compat = 5
+[patches = FCD89DC3]
+	author=Raziel I.C.H.I. Znot
+	comment=Performance fix
+	//microcode
+	patch=1,EE,0040F110,word,8000033c
+	patch=1,EE,0040F128,word,8000033c
+	patch=1,EE,0040F168,word,8000033c
+	patch=1,EE,0040F180,word,8000033c
+	//duplicate, not sure that it's used, but patched anyway
+	patch=1,EE,0040F720,word,8000033c
+	patch=1,EE,0040F738,word,8000033c
+	patch=1,EE,0040F778,word,8000033c
+	patch=1,EE,0040F790,word,8000033c
+	//rearrange EE code accordingly
+	patch=1,EE,00399B14,word,00000000
+	patch=1,EE,00399B58,word,48A44800
+	patch=1,EE,00399B5C,word,4A00D839
+	patch=1,EE,00399B60,word,00000000
+	patch=1,EE,00399BA4,word,00000000
+	patch=1,EE,00399C10,word,48A44800
+	patch=1,EE,00399C14,word,4A00D839
+	patch=1,EE,00399C18,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SCUS-97144
 Name   = PlayStation Underground 5.1
@@ -39708,6 +39731,29 @@ Serial = SLUS-20993
 Name   = Ghosthunter
 Region = NTSC-U
 Compat = 5
+[patches = 29C7DA54]
+	author=Raziel I.C.H.I. Znot
+	comment=Performance fix
+	//microcode
+	patch=1,EE,00461C68,word,8000033c
+	patch=1,EE,00461C80,word,8000033c
+	patch=1,EE,00461CC0,word,8000033c
+	patch=1,EE,00461CD8,word,8000033c
+	//duplicate, not sure that it's used, but patched anyway
+	patch=1,EE,00463118,word,8000033c
+	patch=1,EE,00463130,word,8000033c
+	patch=1,EE,00463170,word,8000033c
+	patch=1,EE,00463188,word,8000033c
+	//rearrange EE code accordingly
+	patch=1,EE,003F8544,word,00000000
+	patch=1,EE,003F8588,word,48A44800
+	patch=1,EE,003F858C,word,4A00D839
+	patch=1,EE,003F8590,word,00000000
+	patch=1,EE,003F85D4,word,00000000
+	patch=1,EE,003F8640,word,48A44800
+	patch=1,EE,003F8644,word,4A00D839
+	patch=1,EE,003F8648,word,00000000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20994
 Name   = Full Metal Alchemist and The Broken Angel

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -4685,7 +4685,7 @@ Compat = 5
 [patches = FCD89DC3]
 	author=Raziel I.C.H.I. Znot
 	comment=Performance fix
-	//microcode
+	//microcode, remove wait loop
 	patch=1,EE,0040F110,word,8000033c
 	patch=1,EE,0040F128,word,8000033c
 	patch=1,EE,0040F168,word,8000033c
@@ -4695,7 +4695,7 @@ Compat = 5
 	patch=1,EE,0040F738,word,8000033c
 	patch=1,EE,0040F778,word,8000033c
 	patch=1,EE,0040F790,word,8000033c
-	//rearrange EE code accordingly
+	//EE code, rearrange code so VU code receives all data at once
 	patch=1,EE,00399B14,word,00000000
 	patch=1,EE,00399B58,word,48A44800
 	patch=1,EE,00399B5C,word,4A00D839
@@ -39734,7 +39734,7 @@ Compat = 5
 [patches = 29C7DA54]
 	author=Raziel I.C.H.I. Znot
 	comment=Performance fix
-	//microcode
+	//microcode, remove wait loop
 	patch=1,EE,00461C68,word,8000033c
 	patch=1,EE,00461C80,word,8000033c
 	patch=1,EE,00461CC0,word,8000033c
@@ -39744,7 +39744,7 @@ Compat = 5
 	patch=1,EE,00463130,word,8000033c
 	patch=1,EE,00463170,word,8000033c
 	patch=1,EE,00463188,word,8000033c
-	//rearrange EE code accordingly
+	//EE code, rearrange code so VU code receives all data at once
 	patch=1,EE,003F8544,word,00000000
 	patch=1,EE,003F8588,word,48A44800
 	patch=1,EE,003F858C,word,4A00D839


### PR DESCRIPTION
Fix for terrible performance in US versions of Primal (all the time) and Ghosthunter (when encountering Teddy Bear and in the moment of Gator-Man's rush attack, maybe few other cases). Both games use shared code with pretty dumb wait loops in the microcode, those are absolutely unnecessary and significantly kill performance on the emulator.