### PR TITLE
GSdx-sw: Remove s_n (draw number) parameter from GetSizeFixedTEX0.

### DIFF
--- a/plugins/GSdx/GSDrawingContext.cpp
+++ b/plugins/GSdx/GSDrawingContext.cpp
@@ -72,7 +72,7 @@ static int extend(int uv, int size)
 	return size;
 }
 
-GIFRegTEX0 GSDrawingContext::GetSizeFixedTEX0(int s_n, const GSVector4& st, bool linear, bool mipmap)
+GIFRegTEX0 GSDrawingContext::GetSizeFixedTEX0(const GSVector4& st, bool linear, bool mipmap)
 {
 	if(mipmap) return TEX0; // no mipmaping allowed
 
@@ -119,8 +119,7 @@ GIFRegTEX0 GSDrawingContext::GetSizeFixedTEX0(int s_n, const GSVector4& st, bool
 
 	if((theApp.GetCurrentRendererType() == GSRendererType::OGL_SW) && ((int)TEX0.TW != tw || (int)TEX0.TH != th))
 	{
-		GL_INS("%5d:FixedTEX0 %05x %d %d tw %d=>%d th %d=>%d st (%.0f,%.0f,%.0f,%.0f) uvmax %d,%d wm %d,%d (%d,%d,%d,%d)",
-			s_n,
+		GL_INS("FixedTEX0 %05x %d %d tw %d=>%d th %d=>%d st (%.0f,%.0f,%.0f,%.0f) uvmax %d,%d wm %d,%d (%d,%d,%d,%d)",
 			(int)TEX0.TBP0, (int)TEX0.TBW, (int)TEX0.PSM,
 			(int)TEX0.TW, tw, (int)TEX0.TH, th,
 			uvf.x, uvf.y, uvf.z, uvf.w,

--- a/plugins/GSdx/GSDrawingContext.h
+++ b/plugins/GSdx/GSDrawingContext.h
@@ -150,7 +150,7 @@ public:
 		return ZBUF.ZMSK == 0 && TEST.ZTE != 0; // ZTE == 0 is bug on the real hardware, write is blocked then
 	}
 
-	GIFRegTEX0 GetSizeFixedTEX0(int s_n, const GSVector4& st, bool linear, bool mipmap = false);
+	GIFRegTEX0 GetSizeFixedTEX0(const GSVector4& st, bool linear, bool mipmap = false);
 	void ComputeFixedTEX0(const GSVector4& st);
 	bool HasFixedTEX0() const { return m_fixed_tex0;}
 

--- a/plugins/GSdx/Renderers/OpenCL/GSRendererCL.cpp
+++ b/plugins/GSdx/Renderers/OpenCL/GSRendererCL.cpp
@@ -1453,7 +1453,7 @@ bool GSRendererCL::SetupParameter(TFXJob* job, TFXParameter* pb, GSVertexCL* ver
 
 			bool mipmap = IsMipMapActive();
 
-			GIFRegTEX0 TEX0 = m_context->GetSizeFixedTEX0(s_n, m_vt.m_min.t.xyxy(m_vt.m_max.t), m_vt.IsLinear(), mipmap);
+			GIFRegTEX0 TEX0 = m_context->GetSizeFixedTEX0(m_vt.m_min.t.xyxy(m_vt.m_max.t), m_vt.IsLinear(), mipmap);
 
 			GSVector4i r;
 

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -1063,7 +1063,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 			bool mipmap = IsMipMapActive();
 
-			GIFRegTEX0 TEX0 = m_context->GetSizeFixedTEX0(s_n, m_vt.m_min.t.xyxy(m_vt.m_max.t), m_vt.IsLinear(), mipmap);
+			GIFRegTEX0 TEX0 = m_context->GetSizeFixedTEX0(m_vt.m_min.t.xyxy(m_vt.m_max.t), m_vt.IsLinear(), mipmap);
 
 			GSVector4i r;
 


### PR DESCRIPTION
Opengl debug macro already provides draw number so it is esentially
useless.