### PR TITLE
GSdx-d3d11: Remove exclusive fs from gsopen legacy. Remove Dispatch function, was never used.

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -320,7 +320,6 @@ void GSdxApp::Init()
 	m_default_configuration["CaptureFileName"]                            = "";
 	m_default_configuration["CaptureVideoCodecDisplayName"]               = "";
 	m_default_configuration["dx_break_on_severity"]                       = "0";
-	m_default_configuration["windowed"]                                   = "1";
 	// D3D Blending option
 	m_default_configuration["accurate_blending_unit_d3d11"]               = "1";
 #else

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -70,7 +70,6 @@ public:
 	GSVector2i GetInternalResolution();
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(int vsync);
-	virtual void SetExclusive(bool isExcl) {}
 
 	virtual bool BeginCapture();
 	virtual void EndCapture();

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -463,14 +463,6 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 
 	m_dev->CreateBlendState(&blend, &m_date.bs);
 
-	// Exclusive/Fullscreen flip, issued for legacy (managed) windows only.  GSopen2 style
-	// emulators will issue the flip themselves later on.
-
-	if(m_wnd->IsManaged())
-	{
-		SetExclusive(!theApp.GetConfigB("windowed"));
-	}
-
 	GSVector2i tex_font = m_osd.get_texture_font_size();
 
 	m_font = std::unique_ptr<GSTexture>(
@@ -505,28 +497,6 @@ bool GSDevice11::Reset(int w, int h)
 	}
 
 	return true;
-}
-
-void GSDevice11::SetExclusive(bool isExcl)
-{
-	if(!m_swapchain) return;
-
-	// TODO : Support for alternative display modes, by finishing this code below:
-	//  Video mode info should be pulled form config/ini.
-
-	/*DXGI_MODE_DESC desc;
-	memset(&desc, 0, sizeof(desc));
-	desc.RefreshRate = 0;		// must be zero for best results.
-
-	m_swapchain->ResizeTarget(&desc);
-	*/
-
-	HRESULT hr = m_swapchain->SetFullscreenState(isExcl, NULL);
-
-	if(hr == DXGI_ERROR_NOT_CURRENTLY_AVAILABLE)
-	{
-		fprintf(stderr, "(GSdx10) SetExclusive(%s) failed; request unavailable.", isExcl ? "true" : "false");
-	}
 }
 
 void GSDevice11::SetVSync(int vsync)

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -612,11 +612,6 @@ void GSDevice11::DrawIndexedPrimitive(int offset, int count)
 	AfterDraw();
 }
 
-void GSDevice11::Dispatch(uint32 x, uint32 y, uint32 z)
-{
-	m_ctx->Dispatch(x, y, z);
-}
-
 void GSDevice11::ClearRenderTarget(GSTexture* t, const GSVector4& c)
 {
 	if (!t) return;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -495,8 +495,6 @@ public:
 	void Flip();
 	void SetVSync(int vsync) final;
 
-	void SetExclusive(bool isExcl);
-
 	void DrawPrimitive() final;
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count) final;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -500,7 +500,6 @@ public:
 	void DrawPrimitive() final;
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count) final;
-	void Dispatch(uint32 x, uint32 y, uint32 z);
 
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c) final;
 	void ClearRenderTarget(GSTexture* t, uint32 c) final;


### PR DESCRIPTION
gsdx-d3d11: Remove Dispatch function, was never used.

gsdx-d3d11: Remove exclusive fullscreen code used in legacy gsopen.