### PR TITLE
Remove/revert Klonoa 2 workarounds

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1327,11 +1327,6 @@ Region = PAL-M5
 Compat = 5
 eeClampMode = 3 // Objects appear in wrong places without it.
 vuClampMode = 2 // Fixes water reflection.
-[patches = 7EBEEBBD]
-	comment=Patch by Prafull
-	// Fixes hang in few stages and also fixes corrupt textures.
-	patch=1,EE,003076e8,word,03e00008
-[/patches]
 ---------------------------------------------
 Serial = SCES-50360
 Name   = Twisted Metal - Black
@@ -31492,12 +31487,6 @@ Region = NTSC-J
 Compat = 5
 eeClampMode = 3 // Objects appear in wrong places without it.
 vuClampMode = 2 // Fixes water reflection.
-[patches = 1645DE53]
-	comment=Patch by Prafull and Arapapa
-	// Fixes hang in few stages and also fixes corrupt textures.
-	// 2d408000 1c00028d
-	patch=1,EE,00304600,word,03e00008
-[/patches]
 ---------------------------------------------
 Serial = SLPS-25034
 Name   = Flower, Sun and Rain
@@ -35734,11 +35723,6 @@ Region = NTSC-U
 Compat = 5
 eeClampMode = 3 // Objects appear in wrong places without it.
 vuClampMode = 2 // Fixes water reflection.
-[patches = 2F56CBC9]
-	comment=Patch by Prafull
-	// Fixes hang in few stages and also fixes corrupt textures.
-	patch=1,EE,003059c0,word,03e00008
-[/patches]
 ---------------------------------------------
 Serial = SLUS-20152
 Name   = Ace Combat 4 - Shattered Skies

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -47,8 +47,7 @@ static rgb16_t vqclut[16];			//clut conversion table
 static u8 s_thresh[2];				//thresholds for color conversions
 int coded_block_pattern = 0;
 
-
-u8 indx4[16*16/2];
+alignas(16) static u8 indx4[16*16/2];
 
 uint eecount_on_last_vdec = 0;
 bool FMVstarted = false;

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -119,18 +119,8 @@ int IPU_Fifo_Output::write(const u32 *value, uint size)
 		size -= transsize;
 		while (transsize > 0)
 		{
-			//For some reason this causes stack corruption or something 
-			//and it loses the pointer causing access violations in Klonoa 2 - Ref
-			//CopyQWC(&data[writepos], value);
-			//Here's the workaround
-			data[writepos] = value[0];
-			writepos = (writepos + 1) & 31;
-			data[writepos] = value[1];
-			writepos = (writepos + 1) & 31;
-			data[writepos] = value[2];
-			writepos = (writepos + 1) & 31;
-			data[writepos] = value[3];
-			writepos = (writepos + 1) & 31;
+			CopyQWC(&data[writepos], value);
+			writepos = (writepos + 4) & 31;
 			value += 4;
 			--transsize;
 		}


### PR DESCRIPTION
Changes:
 - Removes GameDB patches for Klonoa 2
 - Reverts workaround for Klonoa 2 crashes.

I believe #3119 made both of these unnecessary.