### PR TITLE
This is a fix for a Voodoo issue that occurs on Arch Linux AUR.

### DIFF
--- a/common/src/Utilities/IniInterface.cpp
+++ b/common/src/Utilities/IniInterface.cpp
@@ -170,7 +170,7 @@ void IniLoader::Entry(const wxString &var, uint &value, const uint defvalue)
 void IniLoader::Entry(const wxString &var, bool &value, const bool defvalue)
 {
     // TODO : Stricter value checking on enabled/disabled?
-    wxString dest(defvalue ? L"enabled" : L"disabled");
+    wxString dest(defvalue ? "enabled" : "disabled", 8);
     if (m_Config)
         m_Config->Read(var, &dest, dest);
     value = (dest == L"enabled") || (dest == L"1");


### PR DESCRIPTION
This is a PR to fix what could be considered a voodoo issue that occurs on Arch Linux with the AUR. I say voodoo as this issue is known not to happen to everyone and has happened with different circumstances. If I build the PKGBUILD file with the clang compiler the crash this amends will occur but not with GCC. As of issue #3408 it's discovered this can occur with the GCC compiler as well. Language selection has no known effect on the issue.

The issue this pr is stated to amend is thus. For previous users of pcsx2 there are settings files that pcsx2 will attempt to load. Doing so causes the WXstring in IniInterface.cpp Ln 173 to report an incorrect length thus crashing pcsx2. Clearing all settings files and folders is known to work around the issue being discussed. 
```
 12:49:07: Warning: Mismatch between the program and library build versions detected.
The library used 3.0 (wchar_t,compiler with C++ ABI 1011,wx containers,compatible with 2.8),
and your program used 3.0 (wchar_t,compiler with C++ ABI 1002,wx containers,compatible with 2.8).

(PCSX2:90102): Gtk-WARNING **: 12:49:07.439: Unable to locate theme engine in module_path: "adwaita",

(PCSX2:90102): Gtk-WARNING **: 12:49:07.442: Unable to locate theme engine in module_path: "adwaita",
Interface is initializing.  Entering Pcsx2App::OnInit!
Applying operating system default language...
Command line parsing...
Command line parsed!
terminate called after throwing an instance of 'std::length_error'
  what():  basic_string::_M_create
 Aborted (core dumped)
```

Is the prior error this pr deals with