### PR TITLE
GSdx-hw: EmulateZbuffer changes

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -105,7 +105,7 @@ public:
 		GSVector4i FbMask;
 
 		GSVector4 TC_OffsetHack;
-		GSVector4 Af;
+		GSVector4 Af_MaxDepth;
 		GSVector4 DitherMatrix[4];
 
 		PSConstantBuffer()
@@ -118,7 +118,7 @@ public:
 			MskFix = GSVector4i::zero();
 			ChannelShuffle = GSVector4i::zero();
 			FbMask = GSVector4i::zero();
-			Af = GSVector4::zero();
+			Af_MaxDepth = GSVector4::zero();
 
 			DitherMatrix[0] = GSVector4::zero();
 			DitherMatrix[1] = GSVector4::zero();
@@ -241,6 +241,9 @@ public:
 				// Dithering
 				uint32 dither:2;
 
+				// Depth clamp
+				uint32 zclamp:1;
+
 				// Hack
 				uint32 tcoffsethack:1;
 				uint32 urban_chaos_hle:1;
@@ -248,7 +251,7 @@ public:
 				uint32 point_sampler:1;
 				uint32 invalid_tex0:1; // Lupin the 3rd
 
-				uint32 _free:16;
+				uint32 _free:15;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -42,11 +42,14 @@ public:
 		GSVector4 VertexOffset;
 		GSVector4 Texture_Scale_Offset;
 
+		GSVector2i DepthMask;
+
 		VSConstantBuffer()
 		{
-			VertexScale = GSVector4::zero();
-			VertexOffset = GSVector4::zero();
+			VertexScale          = GSVector4::zero();
+			VertexOffset         = GSVector4::zero();
 			Texture_Scale_Offset = GSVector4::zero();
+			DepthMask            = GSVector2i(0);
 		}
 
 		__forceinline bool Update(const VSConstantBuffer* cb)
@@ -74,11 +77,10 @@ public:
 		{
 			struct
 			{
-				uint32 bppz:2;
 				uint32 tme:1;
 				uint32 fst:1;
 
-				uint32 _free:28;
+				uint32 _free:30;
 			};
 
 			uint32 key;

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -41,15 +41,16 @@ public:
 		GSVector4 VertexScale;
 		GSVector4 VertexOffset;
 		GSVector4 Texture_Scale_Offset;
-
-		GSVector2i DepthMask;
+		GSVector2i MaxDepth;
+		GSVector2i pad_vscb;
 
 		VSConstantBuffer()
 		{
 			VertexScale          = GSVector4::zero();
 			VertexOffset         = GSVector4::zero();
 			Texture_Scale_Offset = GSVector4::zero();
-			DepthMask            = GSVector2i(0);
+			MaxDepth             = GSVector2i(0);
+			pad_vscb             = GSVector2i(0);
 		}
 
 		__forceinline bool Update(const VSConstantBuffer* cb)

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -176,6 +176,7 @@ void GSRendererDX11::EmulateZbuffer()
 	// The real GS appears to do no masking based on the Z buffer format and writing larger Z values
 	// than the buffer supports seems to be an error condition on the real GS, causing it to crash.
 	// We are probably receiving bad coordinates from VU1 in these cases.
+	vs_cb.DepthMask = GSVector2i(0xFFFFFFFF, 0xFFFFFFFF);
 
 	if (m_om_dssel.ztst >= ZTST_ALWAYS && m_om_dssel.zwe && (m_context->ZBUF.PSM != PSM_PSMZ32))
 	{
@@ -188,6 +189,7 @@ void GSRendererDX11::EmulateZbuffer()
 #ifdef _DEBUG
 				fprintf(stdout, "%d: Bad Z size on %s buffers\n", s_n, psm_str(m_context->ZBUF.PSM));
 #endif
+				vs_cb.DepthMask = GSVector2i(max_z, max_z);
 				m_om_dssel.ztst = ZTST_ALWAYS;
 			}
 		}

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -176,7 +176,7 @@ void GSRendererDX11::EmulateZbuffer()
 	// The real GS appears to do no masking based on the Z buffer format and writing larger Z values
 	// than the buffer supports seems to be an error condition on the real GS, causing it to crash.
 	// We are probably receiving bad coordinates from VU1 in these cases.
-	vs_cb.DepthMask = GSVector2i(0xFFFFFFFF, 0xFFFFFFFF);
+	vs_cb.DepthMask = GSVector2i(max_z, max_z);
 
 	if (m_om_dssel.ztst >= ZTST_ALWAYS && m_om_dssel.zwe && (m_context->ZBUF.PSM != PSM_PSMZ32))
 	{
@@ -189,7 +189,6 @@ void GSRendererDX11::EmulateZbuffer()
 #ifdef _DEBUG
 				fprintf(stdout, "%d: Bad Z size on %s buffers\n", s_n, psm_str(m_context->ZBUF.PSM));
 #endif
-				vs_cb.DepthMask = GSVector2i(max_z, max_z);
 				m_om_dssel.ztst = ZTST_ALWAYS;
 			}
 		}

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -178,22 +178,6 @@ void GSRendererDX11::EmulateZbuffer()
 	// We are probably receiving bad coordinates from VU1 in these cases.
 	vs_cb.DepthMask = GSVector2i(max_z, max_z);
 
-	if (m_om_dssel.ztst >= ZTST_ALWAYS && m_om_dssel.zwe && (m_context->ZBUF.PSM != PSM_PSMZ32))
-	{
-		if (m_vt.m_max.p.z > max_z)
-		{
-			ASSERT(m_vt.m_min.p.z > max_z); // sfex capcom logo
-			// Fixme :Following conditional fixes some dialog frame in Wild Arms 3, but may not be what was intended.
-			if (m_vt.m_min.p.z > max_z)
-			{
-#ifdef _DEBUG
-				fprintf(stdout, "%d: Bad Z size on %s buffers\n", s_n, psm_str(m_context->ZBUF.PSM));
-#endif
-				m_om_dssel.ztst = ZTST_ALWAYS;
-			}
-		}
-	}
-
 	GSVertex* v = &m_vertex.buff[0];
 	// Minor optimization of a corner case (it allow to better emulate some alpha test effects)
 	if (m_om_dssel.ztst == ZTST_GEQUAL && m_vt.m_eq.z && v[0].XYZ.Z == max_z)

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -101,7 +101,6 @@ void GSDevice11::SetupVS(VSSelector sel, const VSConstantBuffer* cb)
 	{
 		ShaderMacro sm(m_shader.model);
 
-		sm.AddMacro("VS_BPPZ", sel.bppz);
 		sm.AddMacro("VS_TME", sel.tme);
 		sm.AddMacro("VS_FST", sel.fst);
 

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -219,6 +219,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 		sm.AddMacro("PS_BLEND_C", sel.blend_c);
 		sm.AddMacro("PS_BLEND_D", sel.blend_d);
 		sm.AddMacro("PS_DITHER", sel.dither);
+		sm.AddMacro("PS_ZCLAMP", sel.zclamp);
 
 		CComPtr<ID3D11PixelShader> ps;
 

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -983,6 +983,7 @@ GLuint GSDeviceOGL::CompilePS(PSSelector sel)
 		+ format("#define PS_FBMASK %d\n", sel.fbmask)
 		+ format("#define PS_HDR %d\n", sel.hdr)
 		+ format("#define PS_DITHER %d\n", sel.dither)
+		+ format("#define PS_ZCLAMP %d\n", sel.zclamp)
 		// + format("#define PS_PABE %d\n", sel.pabe)
 	;
 

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -137,6 +137,7 @@ public:
 			{
 				a[0] = b[0];
 				a[1] = b[1];
+				a[2] = b[2];
 
 				return true;
 			}

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -117,15 +117,15 @@ public:
 
 		GSVector4 TextureOffset;
 
-		GSVector2i DepthMask;
 		GSVector2 PointSize;
+		GSVector2i MaxDepth;
 
 		VSConstantBuffer()
 		{
 			Vertex_Scale_Offset = GSVector4::zero();
 			TextureOffset       = GSVector4::zero();
-			DepthMask           = GSVector2i(0);
 			PointSize           = GSVector2(0);
+			MaxDepth            = GSVector2i(0);
 		}
 
 		__forceinline bool Update(const VSConstantBuffer* cb)

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.h
@@ -198,6 +198,8 @@ public:
 		GSVector4 HalfTexel;
 		GSVector4 MinMax;
 		GSVector4 TC_OH_TS;
+		GSVector4 MaxDepth;
+
 		GSVector4 DitherMatrix[4];
 
 		PSConstantBuffer()
@@ -210,6 +212,7 @@ public:
 			MskFix        = GSVector4i::zero();
 			TC_OH_TS      = GSVector4::zero();
 			FbMask        = GSVector4i::zero();
+			MaxDepth      = GSVector4::zero();
 
 			DitherMatrix[0] = GSVector4::zero();
 			DitherMatrix[1] = GSVector4::zero();
@@ -225,7 +228,7 @@ public:
 			// if WH matches both HalfTexel and TC_OH_TS do too
 			// MinMax depends on WH and MskFix so no need to check it too
 			if(!((a[0] == b[0]) & (a[1] == b[1]) & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4])
-				& (a[8] == b[8]) & (a[9] == b[9]) & (a[10] == b[10]) & (a[11] == b[11])).alltrue())
+				& (a[8] == b[8]) & (a[9] == b[9]) & (a[10] == b[10]) & (a[11] == b[11]) & (a[12] == b[12])).alltrue())
 			{
 				// Note previous check uses SSE already, a plain copy will be faster than any memcpy
 				a[0] = b[0];
@@ -236,9 +239,11 @@ public:
 				a[5] = b[5];
 
 				a[8] = b[8];
+
 				a[9] = b[9];
 				a[10] = b[10];
 				a[11] = b[11];
+				a[12] = b[12];
 
 				return true;
 			}
@@ -303,6 +308,9 @@ public:
 				// Dithering
 				uint32 dither:2;
 
+				// Depth clamp
+				uint32 zclamp:1;
+
 				// Hack
 				uint32 tcoffsethack:1;
 				uint32 urban_chaos_hle:1;
@@ -313,7 +321,7 @@ public:
 				uint32 point_sampler:1;
 				uint32 invalid_tex0:1; // Lupin the 3rd
 
-				uint32 _free2:8;
+				uint32 _free2:7;
 			};
 
 			uint64 key;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -185,17 +185,6 @@ void GSRendererOGL::EmulateZbuffer()
 	// We are probably receiving bad coordinates from VU1 in these cases.
 	vs_cb.DepthMask = GSVector2i(max_z, max_z);
 
-	if (m_om_dssel.ztst >= ZTST_ALWAYS && m_om_dssel.zwe && (m_context->ZBUF.PSM != PSM_PSMZ32)) {
-		if (m_vt.m_max.p.z > max_z) {
-			ASSERT(m_vt.m_min.p.z > max_z); // sfex capcom logo
-			// Fixme :Following conditional fixes some dialog frame in Wild Arms 3, but may not be what was intended.
-			if (m_vt.m_min.p.z > max_z) {
-				GL_DBG("Bad Z size (%f %f) on %s buffers", m_vt.m_min.p.z, m_vt.m_max.p.z, psm_str(m_context->ZBUF.PSM));
-				m_om_dssel.ztst = ZTST_ALWAYS;
-			}
-		}
-	}
-
 	GSVertex* v = &m_vertex.buff[0];
 	// Minor optimization of a corner case (it allow to better emulate some alpha test effects)
 	if (m_om_dssel.ztst == ZTST_GEQUAL && m_vt.m_eq.z && v[0].XYZ.Z == max_z) {

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -183,7 +183,7 @@ void GSRendererOGL::EmulateZbuffer()
 	// The real GS appears to do no masking based on the Z buffer format and writing larger Z values
 	// than the buffer supports seems to be an error condition on the real GS, causing it to crash.
 	// We are probably receiving bad coordinates from VU1 in these cases.
-	vs_cb.DepthMask = GSVector2i(0xFFFFFFFF, 0xFFFFFFFF);
+	vs_cb.DepthMask = GSVector2i(max_z, max_z);
 
 	if (m_om_dssel.ztst >= ZTST_ALWAYS && m_om_dssel.zwe && (m_context->ZBUF.PSM != PSM_PSMZ32)) {
 		if (m_vt.m_max.p.z > max_z) {
@@ -191,7 +191,6 @@ void GSRendererOGL::EmulateZbuffer()
 			// Fixme :Following conditional fixes some dialog frame in Wild Arms 3, but may not be what was intended.
 			if (m_vt.m_min.p.z > max_z) {
 				GL_DBG("Bad Z size (%f %f) on %s buffers", m_vt.m_min.p.z, m_vt.m_max.p.z, psm_str(m_context->ZBUF.PSM));
-				vs_cb.DepthMask = GSVector2i(max_z, max_z);
 				m_om_dssel.ztst = ZTST_ALWAYS;
 			}
 		}

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -175,11 +175,18 @@ void GSRendererOGL::EmulateZbuffer()
 	// Clamping is done after rasterization.
 	const uint32 max_z = 0xFFFFFFFF >> (GSLocalMemory::m_psm[m_context->ZBUF.PSM].fmt * 8);
 	const bool clamp_z = (uint32)(GSVector4i(m_vt.m_max.p).z) > max_z;
+
 	vs_cb.MaxDepth = GSVector2i(0xFFFFFFFF);
+	ps_cb.MaxDepth = GSVector4(1.0f);
+	m_ps_sel.zclamp = 0;
+
 	if (clamp_z) {
-		// FIXME: Do z clamping for sprites on vs, triangles on ps.
-		if (m_vt.m_primclass == GS_SPRITE_CLASS)
+		if (m_vt.m_primclass == GS_SPRITE_CLASS || m_vt.m_primclass == GS_POINT_CLASS) {
 			vs_cb.MaxDepth = GSVector2i(max_z);
+		} else {
+			ps_cb.MaxDepth = GSVector4(max_z * ldexpf(1, -32));
+			m_ps_sel.zclamp = 1;
+		}
 	}
 
 	GSVertex* v = &m_vertex.buff[0];

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -171,19 +171,16 @@ void GSRendererOGL::EmulateZbuffer()
 		m_om_dssel.ztst = ZTST_ALWAYS;
 	}
 
-	uint32 max_z;
-	if (m_context->ZBUF.PSM == PSM_PSMZ32) {
-		max_z     = 0xFFFFFFFF;
-	} else if (m_context->ZBUF.PSM == PSM_PSMZ24) {
-		max_z     = 0xFFFFFF;
-	} else {
-		max_z     = 0xFFFF;
+	// On the real GS we appear to do clamping on the max z value the format allows.
+	// Clamping is done after rasterization.
+	const uint32 max_z = 0xFFFFFFFF >> (GSLocalMemory::m_psm[m_context->ZBUF.PSM].fmt * 8);
+	const bool clamp_z = (uint32)(GSVector4i(m_vt.m_max.p).z) > max_z;
+	vs_cb.MaxDepth = GSVector2i(0xFFFFFFFF);
+	if (clamp_z) {
+		// FIXME: Do z clamping for sprites on vs, triangles on ps.
+		if (m_vt.m_primclass == GS_SPRITE_CLASS)
+			vs_cb.MaxDepth = GSVector2i(max_z);
 	}
-
-	// The real GS appears to do no masking based on the Z buffer format and writing larger Z values
-	// than the buffer supports seems to be an error condition on the real GS, causing it to crash.
-	// We are probably receiving bad coordinates from VU1 in these cases.
-	vs_cb.DepthMask = GSVector2i(max_z, max_z);
 
 	GSVertex* v = &m_vertex.buff[0];
 	// Minor optimization of a corner case (it allow to better emulate some alpha test effects)

--- a/plugins/GSdx/res/glsl/common_header.glsl
+++ b/plugins/GSdx/res/glsl/common_header.glsl
@@ -95,6 +95,9 @@ layout(std140, binding = 21) uniform cb21
     vec2 TextureScale;
     vec2 TC_OffsetHack;
 
+	float MaxDepthPS;
+	vec3 pad_cb21;
+
     mat4 DitherMatrix;
 };
 #endif

--- a/plugins/GSdx/res/glsl/common_header.glsl
+++ b/plugins/GSdx/res/glsl/common_header.glsl
@@ -65,9 +65,9 @@ layout(std140, binding = 20) uniform cb20
 
     vec4  TextureOffset;
 
-    uint  DepthMask;
-    uint  cb20_pad;
     vec2  PointSize;
+    uint  MaxDepth;
+    uint  pad_cb20;
 };
 #endif
 

--- a/plugins/GSdx/res/glsl/tfx_fs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_fs.glsl
@@ -877,6 +877,10 @@ void ps_main()
 // #endif
     SV_Target0 = C / 255.0f;
     SV_Target1 = vec4(alpha_blend);
+
+#if PS_ZCLAMP
+	gl_FragDepth = min(gl_FragCoord.z, MaxDepthPS);
+#endif 
 }
 
 #endif

--- a/plugins/GSdx/res/glsl/tfx_vgs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_vgs.glsl
@@ -44,8 +44,8 @@ void texture_coord()
 
 void vs_main()
 {
-    // Clamp to depth mask, gs doesn't wrap
-    highp uint z = min(i_z, DepthMask);
+    // Clamp to max depth, gs doesn't wrap
+    highp uint z = min(i_z, MaxDepth);
 
     // pos -= 0.05 (1/320 pixel) helps avoiding rounding problems (integral part of pos is usually 5 digits, 0.05 is about as low as we can go)
     // example: ceil(afterseveralvertextransformations(y = 133)) => 134 => line 133 stays empty

--- a/plugins/GSdx/res/glsl/tfx_vgs.glsl
+++ b/plugins/GSdx/res/glsl/tfx_vgs.glsl
@@ -44,7 +44,8 @@ void texture_coord()
 
 void vs_main()
 {
-    highp uint z = i_z & DepthMask;
+    // Clamp to depth mask, gs doesn't wrap
+    highp uint z = min(i_z, DepthMask);
 
     // pos -= 0.05 (1/320 pixel) helps avoiding rounding problems (integral part of pos is usually 5 digits, 0.05 is about as low as we can go)
     // example: ceil(afterseveralvertextransformations(y = 133)) => 134 => line 133 stays empty

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -787,7 +787,8 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 VS_OUTPUT vs_main(VS_INPUT input)
 {
-	input.z &= DepthMask;
+	// Clamp to depth mask, gs doesn't wrap
+	input.z = min(input.z, DepthMask);
 
 	VS_OUTPUT output;
 

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -4,8 +4,7 @@
 #define FMT_24 1
 #define FMT_16 2
 
-#ifndef VS_BPPZ
-#define VS_BPPZ 0
+#ifndef VS_TME
 #define VS_TME 1
 #define VS_FST 1
 #endif
@@ -100,6 +99,8 @@ cbuffer cb0
 	float4 VertexScale;
 	float4 VertexOffset;
 	float4 Texture_Scale_Offset;
+	uint DepthMask;
+	uint3 _pad_cb0;
 };
 
 cbuffer cb1
@@ -786,14 +787,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 VS_OUTPUT vs_main(VS_INPUT input)
 {
-	if(VS_BPPZ == 1) // 24
-	{
-		input.z = input.z & 0xffffff;
-	}
-	else if(VS_BPPZ == 2) // 16
-	{
-		input.z = input.z & 0xffff;
-	}
+	input.z &= DepthMask;
 
 	VS_OUTPUT output;
 

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -49,6 +49,7 @@
 #define PS_BLEND_C 0
 #define PS_BLEND_D 0
 #define PS_DITHER 0
+#define PS_ZCLAMP 0
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
@@ -85,6 +86,9 @@ struct PS_OUTPUT
 {
 	float4 c0 : SV_Target0;
 	float4 c1 : SV_Target1;
+#if PS_ZCLAMP
+	float depth : SV_Depth;
+#endif
 };
 
 Texture2D<float4> Texture : register(t0);
@@ -117,7 +121,8 @@ cbuffer cb1
 	uint4 FbMask;
 	float4 TC_OffsetHack;
 	float Af;
-	float3 _pad;
+	float MaxDepthPS;
+	float2 pad_cb1;
 	float4x4 DitherMatrix;
 };
 
@@ -777,6 +782,10 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 	output.c0 = C / 255.0f;
 	output.c1 = (float4)(alpha_blend);
+
+#if PS_ZCLAMP
+	output.depth = min(input.p.z, MaxDepthPS);
+#endif
 
 	return output;
 }

--- a/plugins/GSdx/res/tfx.fx
+++ b/plugins/GSdx/res/tfx.fx
@@ -99,8 +99,8 @@ cbuffer cb0
 	float4 VertexScale;
 	float4 VertexOffset;
 	float4 Texture_Scale_Offset;
-	uint DepthMask;
-	uint3 _pad_cb0;
+	uint MaxDepth;
+	uint3 pad_cb0;
 };
 
 cbuffer cb1
@@ -787,8 +787,8 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 VS_OUTPUT vs_main(VS_INPUT input)
 {
-	// Clamp to depth mask, gs doesn't wrap
-	input.z = min(input.z, DepthMask);
+	// Clamp to max depth, gs doesn't wrap
+	input.z = min(input.z, MaxDepth);
 
 	VS_OUTPUT output;
 


### PR DESCRIPTION
gsdx-d3d11: Port/add depth mask support to EmulateZbuffer.
Add support for depthmasking to EmulateZbuffer, previous old code had
support but wasn't ported properly with the new code a few years back.
VS Constant buffer is now properly setup.

gsdx-hw: Clamp zbuffer to depthmask instead of wrapping.
The behavior was verified on Dobie to be correct.
The code needs to be ported to SW renderer too to
improve rendering on SW side.
Current PR will fix plenty of games on HW renderer
that had/have zbuffer issues before.
v2. Set DepthMask to the maximum the current depth format allows.
Will properly clamp for 16bit and 24bit formats.
v3. gl: Fix uniform buffer upload/cache for VSConstantBuffer.

gsdx-hw: Remove the code block for the bad Z sise check in EmulateZbeffer.
Also fixes Itadaki Street text and F1 2004 starting lights.

gsdx-hw: Cleanup a bit EmulateZbuffer.
Update the comment to reflect recent changes,
Rename DepthMask to MaxDepth,
Initialize max_z to 0 at start so it doesn't complain,
Do vs cb padding on d3d11.

gsdx-hw: Do z clamping only on sprites.
For some reason for triangle primitives even without clamping games look
fine, doing clamping on ps/fs will be more costly so let's leave it out
till we find a game that has issues.

gsdx-hw: Add zclamping to ps/fs.
Add zclamping to ps/fs, enable vs, ps/fs clamp when needed with a macro.

~~Fix also needs to be ported to SW renderer.~~

Fixes #2623
Fixes #2271
Fixes #3061
Fixes #3396