### PR TITLE
GameDB: Add Xenosaga save point crash patch

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -4409,6 +4409,14 @@ Region = NTSC-J
 Serial = SCPS-55901
 Name   = Xenosaga Episode I - Der Wille zur Macht
 Region = NTSC-J
+[patches = A3D63039]
+	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
+	// the game from calling its own exit function, which was strangely its safety
+	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
+	comment=Save Point Crash Prevention
+	author=pandubz, PSI, turtleli
+	patch=1,EE,20285f48,extended,24040000
+[/patches]
 ---------------------------------------------
 Serial = SCPS-55902
 Name   = Gran Turismo - Concept 2002 Tokyo-Geneva
@@ -34747,11 +34755,27 @@ Region = NTSC-J
 Serial = SLPS-29001
 Name   = Xenosaga Episode 1 - Der Wille zur Macht [Premium Box]
 Region = NTSC-J
+[patches = A3D63039]
+	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
+	// the game from calling its own exit function, which was strangely its safety
+	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
+	comment=Save Point Crash Prevention
+	author=pandubz, PSI, turtleli
+	patch=1,EE,20285f48,extended,24040000
+[/patches]
 ---------------------------------------------
 Serial = SLPS-29002
 Name   = Xenosaga Episode 1 - Der Wille zur Macht
 Region = NTSC-J
 Compat = 5
+[patches = A3D63039]
+	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
+	// the game from calling its own exit function, which was strangely its safety
+	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
+	comment=Save Point Crash Prevention
+	author=pandubz, PSI, turtleli
+	patch=1,EE,20285f48,extended,24040000
+[/patches]
 ---------------------------------------------
 Serial = SLPS-29003
 Name   = Lord of the Rings - The Two Towers [Collector's Box]
@@ -34767,6 +34791,14 @@ vuClampMode = 3 // fix white shiny weapons
 Serial = SLPS-29005
 Name   = Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]
 Region = NTSC-J
+[patches = A3D63039]
+	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
+	// the game from calling its own exit function, which was strangely its safety
+	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
+	comment=Save Point Crash Prevention
+	author=pandubz, PSI, turtleli
+	patch=1,EE,20285f48,extended,24040000
+[/patches]
 ---------------------------------------------
 Serial = SLPS-72501
 Name   = Final Fantasy X [Mega Hits]
@@ -35182,6 +35214,14 @@ Region = NTSC-J
 Serial = SLPS-73901
 Name   = Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 The Best]
 Region = NTSC-J
+[patches = A3D63039]
+	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
+	// the game from calling its own exit function, which was strangely its safety
+	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
+	comment=Save Point Crash Prevention
+	author=pandubz, PSI, turtleli
+	patch=1,EE,20285f48,extended,24040000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20001
 Name   = Tekken Tag Tournament
@@ -37220,6 +37260,14 @@ Serial = SLUS-20469
 Name   = Xenosaga - Episode I - Der Wille zur Macht
 Region = NTSC-U
 Compat = 5
+[patches = 6D1276AB]
+	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
+	// the game from calling its own exit function, which was strangely its safety
+	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
+	comment=Save Point Crash Prevention
+	author=pandubz, PSI, turtleli
+	patch=1,EE,20289db0,extended,24040000
+[/patches]
 ---------------------------------------------
 Serial = SLUS-20470
 Name   = EverQuest - Online Adventures

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -34791,14 +34791,6 @@ vuClampMode = 3 // fix white shiny weapons
 Serial = SLPS-29005
 Name   = Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]
 Region = NTSC-J
-[patches = A3D63039]
-	// Reduces JPEG quality to its minimum for save file thumbnails. This prevents
-	// the game from calling its own exit function, which was strangely its safety
-	// mechanism for when a captured thumbnail exceeded 4 KB in size. 
-	comment=Save Point Crash Prevention
-	author=pandubz, PSI, turtleli
-	patch=1,EE,20285f48,extended,24040000
-[/patches]
 ---------------------------------------------
 Serial = SLPS-72501
 Name   = Final Fantasy X [Mega Hits]


### PR DESCRIPTION
Adds the Xenosaga save point crash patch to GameDB.

Patch location on the forums: https://forums.pcsx2.net/Thread-Post-your-PCSX2-cheats-patches-here?pid=603236#pid603236

The two questions that need answered:

1. Is the patch proven to be stable?
2. Is it a good idea to, even though PCSX2 accuracy makes it worse than a real PS2, patch something that's technically correct behavior for a better user experience?

My answers:

1. Yes, it's been in the field for a while and there's been several hundred downloads with no reported issues.
2. I do think so, simply in that users would appreciate not having to manually search up and retrieve the patch.

There's probably plenty of conflicting opinions, so lets discuss. To merge, or not to merge?