### PR TITLE
Appveyor: Drop vs2017 builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
     target: AppVeyor
     visualstudio_string: vs2019
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-  - platform: Win32
-    target: AppVeyor
-    visualstudio_string: vs2017
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
It will cut compile time half.