### PR TITLE
Switch over the null plugins dialog code to use wxWidgets instead of gtk on Linux.

### DIFF
--- a/common/include/PS2Eext.h
+++ b/common/include/PS2Eext.h
@@ -32,8 +32,8 @@
 
 #elif defined(__unix__)
 
-#include <gtk/gtk.h>
 #include <cstring>
+#include <wx/msgdlg.h>
 
 #define EXPORT_C_(type) extern "C" __attribute__((stdcall, externally_visible, visibility("default"))) type
 
@@ -203,7 +203,6 @@ struct PluginConf
 };
 
 #if defined(__unix__)
-
 static void SysMessage(const char *fmt, ...)
 {
     va_list list;
@@ -216,44 +215,8 @@ static void SysMessage(const char *fmt, ...)
     if (msg[strlen(msg) - 1] == '\n')
         msg[strlen(msg) - 1] = 0;
 
-    GtkWidget *dialog;
-    dialog = gtk_message_dialog_new(NULL,
-                                    GTK_DIALOG_DESTROY_WITH_PARENT,
-                                    GTK_MESSAGE_INFO,
-                                    GTK_BUTTONS_OK,
-                                    "%s", msg);
-    gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-}
-
-static void __forceinline set_logging(GtkToggleButton *check, int &log)
-{
-    log = gtk_toggle_button_get_active(check);
-}
-
-static void __forceinline PluginNullConfigure(std::string desc, int &log)
-{
-    GtkWidget *dialog, *label, *check_box;
-
-    /* Create the widgets */
-    dialog = gtk_dialog_new();
-    label = gtk_label_new(desc.c_str());
-    check_box = gtk_check_button_new_with_label("Logging");
-
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_box), (log != 0));
-
-    /* Ensure that the dialog box is destroyed when the user clicks ok, and that we get the check box value. */
-    g_signal_connect(check_box, "toggled", G_CALLBACK(set_logging), &log);
-
-    /* Add all our widgets, and show everything we've added to the dialog. */
-    gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), label);
-    gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), check_box);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Ok", 0);
-
-    gtk_widget_show_all(dialog);
-
-    gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
+    wxMessageDialog *dial = new wxMessageDialog(NULL, msg, wxT("Info"), wxOK);
+    dial->ShowModal();
 }
 
 #define ENTRY_POINT /* We don't need no stinkin' entry point! */

--- a/common/include/PS2Eext.h
+++ b/common/include/PS2Eext.h
@@ -215,8 +215,8 @@ static void SysMessage(const char *fmt, ...)
     if (msg[strlen(msg) - 1] == '\n')
         msg[strlen(msg) - 1] = 0;
 
-    wxMessageDialog *dial = new wxMessageDialog(NULL, msg, wxT("Info"), wxOK);
-    dial->ShowModal();
+    wxMessageDialog dialog(nullptr, msg, "Info", wxOK);
+    dialog.ShowModal();
 }
 
 #define ENTRY_POINT /* We don't need no stinkin' entry point! */

--- a/plugins/GSnull/Linux/Config.cpp
+++ b/plugins/GSnull/Linux/Config.cpp
@@ -21,6 +21,7 @@ using namespace std;
 
 #include "GS.h"
 #include "Config.h"
+#include "null/config.inl"
 
 extern string s_strIniPath;
 PluginConf Ini;
@@ -33,7 +34,7 @@ void CFGabout()
 void CFGconfigure()
 {
     LoadConfig();
-    PluginNullConfigure("Since this is a null plugin, all that is really configurable is logging.", conf.Log);
+    ConfigureLogging();
     SaveConfig();
 }
 
@@ -42,7 +43,7 @@ void LoadConfig()
     const std::string iniFile(s_strIniPath + "/GSNull.ini");
 
     if (!Ini.Open(iniFile, READ_FILE)) {
-        printf("failed to open %s\n", iniFile.c_str());
+        g_plugin_log.WriteLn("failed to open %s", iniFile.c_str());
         SaveConfig(); //save and return
         return;
     }
@@ -56,7 +57,7 @@ void SaveConfig()
     const std::string iniFile(s_strIniPath + "/GSNull.ini");
 
     if (!Ini.Open(iniFile, WRITE_FILE)) {
-        printf("failed to open %s\n", iniFile.c_str());
+        g_plugin_log.WriteLn("failed to open %s", iniFile.c_str());
         return;
     }
 

--- a/plugins/PadNull/Linux/Config.cpp
+++ b/plugins/PadNull/Linux/Config.cpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "Pad.h"
+#include "null/config.inl"
 
 extern std::string s_strIniPath;
 PluginConf Ini;
@@ -33,7 +34,7 @@ EXPORT_C_(void)
 PADconfigure()
 {
     LoadConfig();
-    PluginNullConfigure("Since this is a null plugin, all that is really configurable is logging.", conf.Log);
+    ConfigureLogging();
     SaveConfig();
 }
 
@@ -42,7 +43,7 @@ void LoadConfig()
     const std::string iniFile(s_strIniPath + "/Padnull.ini");
 
     if (!Ini.Open(iniFile, READ_FILE)) {
-        printf("failed to open %s\n", iniFile.c_str());
+        g_plugin_log.WriteLn("failed to open %s", iniFile.c_str());
         SaveConfig();  //save and return
         return;
     }
@@ -56,7 +57,7 @@ void SaveConfig()
     const std::string iniFile(s_strIniPath + "/Padnull.ini");
 
     if (!Ini.Open(iniFile, WRITE_FILE)) {
-        printf("failed to open %s\n", iniFile.c_str());
+        g_plugin_log.WriteLn("failed to open %s", iniFile.c_str());
         return;
     }
 

--- a/plugins/PadNull/Linux/PadLinux.cpp
+++ b/plugins/PadNull/Linux/PadLinux.cpp
@@ -16,6 +16,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  */
 #include <gdk/gdkx.h>
+#include <gtk/gtk.h>
 #include "PadLinux.h"
 
 Display *GSdsp;

--- a/plugins/SPU2null/Linux/Config.cpp
+++ b/plugins/SPU2null/Linux/Config.cpp
@@ -18,6 +18,7 @@
 
 #include "Config.h"
 #include "SPU2.h"
+#include "null/config.inl"
 using namespace std;
 
 extern string s_strIniPath;
@@ -27,7 +28,7 @@ EXPORT_C_(void)
 SPU2configure()
 {
     LoadConfig();
-    PluginNullConfigure("Since this is a null plugin, all that is really configurable is logging.", conf.Log);
+    ConfigureLogging();
     SaveConfig();
 }
 
@@ -43,7 +44,7 @@ void LoadConfig()
     const std::string iniFile(s_strIniPath + "/Spu2null.ini");
 
     if (!Ini.Open(iniFile, READ_FILE)) {
-        printf("failed to open %s\n", iniFile.c_str());
+        g_plugin_log.WriteLn("failed to open %s", iniFile.c_str());
         SaveConfig(); //save and return
         return;
     }
@@ -57,7 +58,7 @@ void SaveConfig()
     const std::string iniFile(s_strIniPath + "/Spu2null.ini");
 
     if (!Ini.Open(iniFile, WRITE_FILE)) {
-        printf("failed to open %s\n", iniFile.c_str());
+        g_plugin_log.WriteLn("failed to open %s", iniFile.c_str());
         return;
     }
 


### PR DESCRIPTION
I left the windows code as-is because I didn't want to accidentally break the windows build, though if anyone else wants to make windows use the wx code as well, it'd be a good idea.

I'd largely like to get rid of as much gtk code as we can, regardless of whether we end up getting rid of wx at some point.

Naturally, other plugins should be converted to wx dialogs as well, but one step at a time...