### PR TITLE
Fix a few crashes in macOS

### DIFF
--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -89,7 +89,9 @@ void RecentIsoManager::RemoveAllFromMenu()
 	if( m_Menu == NULL ) return;
 
 	int cnt = m_Items.size();
-	for( int i=0; i<cnt; ++i )
+	// Note: Go backwards to work around https://trac.wxwidgets.org/ticket/18772
+	// Switch it back to forwards once that's fixed in a relased WX version
+	for( int i=cnt-1; i>=0; --i )
 	{
 		RecentItem& curitem( m_Items[i] );
 		if( curitem.ItemPtr == NULL ) continue;


### PR DESCRIPTION
I feel like the change for the shutdown crash I made should work on linux as well, but [the comment in `MmapResetPtr`](https://github.com/PCSX2/pcsx2/blob/5903ee95fe05df1684791ac32da3dcd1707414f3/common/src/Utilities/Linux/LnxHostSys.cpp#L181-L182) makes me doubt myself...  Does anyone know why mmap with `MAP_FIXED` might not do what we want?  For now it's ifdef'd for macOS only but if it does work on Linux we could use it all the time