### PR TITLE
Add reset button to debugger window

### DIFF
--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -594,7 +594,6 @@ void CtrlDisassemblyView::calculatePixelPositions()
 	pixelPositions.arrowsStart = pixelPositions.argumentsStart + 30*charWidth;
 }
 
-
 void CtrlDisassemblyView::followBranch()
 {
 	DisassemblyLineInfo line = DisassemblyLineInfo();
@@ -650,7 +649,6 @@ void CtrlDisassemblyView::assembleOpcode(u32 address, std::string defaultText)
 		wxMessageBox( wxString(errorText.c_str(),wxConvUTF8), L"Error.", wxICON_ERROR);
 	}
 }
-
 
 void CtrlDisassemblyView::onPopupClick(wxCommandEvent& evt)
 {
@@ -780,6 +778,9 @@ void CtrlDisassemblyView::onPopupClick(wxCommandEvent& evt)
 		}
 	case ID_DISASM_ASSEMBLE:
 		assembleOpcode(curAddress, disassembleCurAddress());
+		break;
+	case ID_DISASM_TOGGLEBREAKPOINT:
+		toggleBreakpoint(true);
 		break;
 	default:
 		wxMessageBox( L"Unimplemented.",  L"Unimplemented.", wxICON_INFORMATION);

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -267,6 +267,7 @@ DisassemblyDialog::DisassemblyDialog(wxWindow* parent):
 	breakpointButton = new wxButton( panel, wxID_ANY, L"Breakpoint" );
 	Bind(wxEVT_BUTTON, &DisassemblyDialog::onBreakpointClick, this, breakpointButton->GetId());
 	topRowSizer->Add(breakpointButton);
+
 	topSizer->Add(topRowSizer,0,wxLEFT|wxRIGHT|wxTOP,3);
 
 	// create middle part of the window

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -243,7 +243,11 @@ DisassemblyDialog::DisassemblyDialog(wxWindow* parent):
 
 	breakRunButton = new wxButton(panel, wxID_ANY, L"Run");
 	Bind(wxEVT_BUTTON, &DisassemblyDialog::onBreakRunClicked, this, breakRunButton->GetId());
-	topRowSizer->Add(breakRunButton,0,wxRIGHT,8);
+	topRowSizer->Add(breakRunButton,0,wxRIGHT,2);
+
+	resetButton = new wxButton(panel, wxID_ANY, L"Reset");
+	Bind(wxEVT_BUTTON, &DisassemblyDialog::onResetClick,this,resetButton->GetId());
+	topRowSizer->Add(resetButton,0,wxRIGHT,8);
 
 	stepIntoButton = new wxButton( panel, wxID_ANY, L"Step Into" );
 	stepIntoButton->Enable(false);
@@ -263,7 +267,6 @@ DisassemblyDialog::DisassemblyDialog(wxWindow* parent):
 	breakpointButton = new wxButton( panel, wxID_ANY, L"Breakpoint" );
 	Bind(wxEVT_BUTTON, &DisassemblyDialog::onBreakpointClick, this, breakpointButton->GetId());
 	topRowSizer->Add(breakpointButton);
-
 	topSizer->Add(topRowSizer,0,wxLEFT|wxRIGHT|wxTOP,3);
 
 	// create middle part of the window
@@ -342,6 +345,12 @@ void DisassemblyDialog::onBreakRunClicked(wxCommandEvent& evt)
 		r5900Debug.pauseCpu();
 		gotoPc();
 	}
+}
+
+void DisassemblyDialog::onResetClick(wxCommandEvent& evt)
+{
+	g_Conf->EmuOptions.UseBOOT2Injection = true;t
+	sApp.SysExecute();
 }
 
 void DisassemblyDialog::onStepOverClicked(wxCommandEvent& evt)

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -350,7 +350,7 @@ void DisassemblyDialog::onBreakRunClicked(wxCommandEvent& evt)
 
 void DisassemblyDialog::onResetClick(wxCommandEvent& evt)
 {
-	g_Conf->EmuOptions.UseBOOT2Injection = true;t
+	g_Conf->EmuOptions.UseBOOT2Injection = true;
 	sApp.SysExecute();
 }
 

--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -105,7 +105,7 @@ protected:
 	void onStepOutClicked(wxCommandEvent& evt);
 	void onDebuggerEvent(wxCommandEvent& evt);
 	void onPageChanging(wxCommandEvent& evt);
-	void onBreakpointClick(wxCommandEvent& evt);	
+	void onBreakpointClick(wxCommandEvent& evt);
 	void onSizeEvent(wxSizeEvent& event);
 	void onClose(wxCloseEvent& evt);
 	void stepOver();

--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -99,12 +99,13 @@ public:
 	wxDECLARE_EVENT_TABLE();
 protected:
 	void onBreakRunClicked(wxCommandEvent& evt);
+	void onResetClick(wxCommandEvent& evt);
 	void onStepOverClicked(wxCommandEvent& evt);
 	void onStepIntoClicked(wxCommandEvent& evt);
 	void onStepOutClicked(wxCommandEvent& evt);
 	void onDebuggerEvent(wxCommandEvent& evt);
 	void onPageChanging(wxCommandEvent& evt);
-	void onBreakpointClick(wxCommandEvent& evt);
+	void onBreakpointClick(wxCommandEvent& evt);	
 	void onSizeEvent(wxSizeEvent& event);
 	void onClose(wxCloseEvent& evt);
 	void stepOver();
@@ -119,6 +120,7 @@ private:
 
 	wxBoxSizer* topSizer;
 	wxButton* breakRunButton;
+	wxButton* resetButton;
 	wxButton* stepIntoButton;
 	wxButton* stepOverButton;
 	wxButton* stepOutButton;


### PR DESCRIPTION
When debugging games I found that accidentally stepping over or forgetting to check the registers is annoying especially when you need to restart the game.

Instead of selecting the ELF or going through the file menu to reset this PR adds a simple button that calls `sApp.SysExecute();`

Note: A side effect is found when resetting Gran Turismo 3, the game doesn't clear the R3000 buffer or something and broken graphics are shown until the game starts the opening scene. From my testing it doesn't have any other effect than that.