### PR TITLE
GSdx-sw: Add Z clamping to GSdx SW mode

### DIFF
--- a/plugins/GSdx/Renderers/SW/GSDrawScanline.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanline.cpp
@@ -587,6 +587,9 @@ void GSDrawScanline::DrawScanline(int pixels, int left, int top, const GSVertexS
 						zdo -= GSVector8i::x80000000();
 					}
 
+					if (sel.zclamp)
+						zso = zso.min_u32(GSVector8i::xffffffff().srl32(sel.zpsm * 8));
+
 					switch(sel.ztst)
 					{
 					case ZTST_GEQUAL: test |= zso < zdo; break;
@@ -1219,6 +1222,9 @@ void GSDrawScanline::DrawScanline(int pixels, int left, int top, const GSVertexS
 					zs = zs.blend8(zd, zm);
 				}
 
+				if (sel.zclamp)
+					zs = zs.min_u32(GSVector8i::xffffffff().srl32(sel.zpsm * 8));
+
 				bool fast = sel.ztest ? sel.zpsm < 2 : sel.zpsm == 0 && sel.notest;
 
 				if(sel.notest)
@@ -1694,6 +1700,16 @@ void GSDrawScanline::DrawScanline(int pixels, int left, int top, const GSVertexS
 					{
 						zso -= GSVector4i::x80000000();
 						zdo -= GSVector4i::x80000000();
+					}
+
+					if (sel.zclamp)
+					{
+						const unsigned int z_max = 0xffffffff >> (sel.zpsm * 8);
+
+						zso.u32[0] = std::min(z_max, zso.u32[0]);
+						zso.u32[1] = std::min(z_max, zso.u32[1]);
+						zso.u32[2] = std::min(z_max, zso.u32[2]);
+						zso.u32[3] = std::min(z_max, zso.u32[3]);
 					}
 
 					switch(sel.ztst)
@@ -2331,6 +2347,16 @@ void GSDrawScanline::DrawScanline(int pixels, int left, int top, const GSVertexS
 				if(sel.ztest && sel.zpsm < 2)
 				{
 					zs = zs.blend8(zd, zm);
+				}
+
+				if (sel.zclamp)
+				{
+					const unsigned int z_max = 0xffffffff >> (sel.zpsm * 8);
+
+					zs.u32[0] = std::min(z_max, zs.u32[0]);
+					zs.u32[1] = std::min(z_max, zs.u32[1]);
+					zs.u32[2] = std::min(z_max, zs.u32[2]);
+					zs.u32[3] = std::min(z_max, zs.u32[3]);
 				}
 
 				bool fast = sel.ztest ? sel.zpsm < 2 : sel.zpsm == 0 && sel.notest;

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx.cpp
@@ -635,7 +635,7 @@ void GSDrawScanlineCodeGenerator::TestZ_AVX(const Xmm& temp1, const Xmm& temp2)
 			vcvttps2dq(xmm0, xmm0);
 		}
 
-		//Clamp Z to ZPSM_FMT_MAX
+		// Clamp Z to ZPSM_FMT_MAX
 		vpcmpeqd(temp1, temp1);
 		vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
 		vpminsd(xmm0, temp1);
@@ -2383,7 +2383,7 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_AVX()
 		vpblendvb(xmm1, ptr[&m_local.temp.zd], xmm4);
 	}
 
-	//Clamp Z to ZPSM_FMT_MAX
+	// Clamp Z to ZPSM_FMT_MAX
 	vpcmpeqd(xmm7, xmm7);
 	vpsrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
 	vpminsd(xmm1, xmm7);

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx.cpp
@@ -635,6 +635,11 @@ void GSDrawScanlineCodeGenerator::TestZ_AVX(const Xmm& temp1, const Xmm& temp2)
 			vcvttps2dq(xmm0, xmm0);
 		}
 
+		//Clamp Z to ZPSM_FMT_MAX
+		vpcmpeqd(temp1, temp1);
+		vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+		vpminsd(xmm0, temp1);
+
 		if(m_sel.zwrite)
 		{
 			vmovdqa(ptr[&m_local.temp.zs], xmm0);
@@ -2377,6 +2382,11 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_AVX()
 
 		vpblendvb(xmm1, ptr[&m_local.temp.zd], xmm4);
 	}
+
+	//Clamp Z to ZPSM_FMT_MAX
+	vpcmpeqd(xmm7, xmm7);
+	vpsrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+	vpminsd(xmm1, xmm7);
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;
 

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx.cpp
@@ -636,9 +636,12 @@ void GSDrawScanlineCodeGenerator::TestZ_AVX(const Xmm& temp1, const Xmm& temp2)
 		}
 
 		// Clamp Z to ZPSM_FMT_MAX
-		vpcmpeqd(temp1, temp1);
-		vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
-		vpminsd(xmm0, temp1);
+		if (m_sel.zclamp)
+		{
+			vpcmpeqd(temp1, temp1);
+			vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+			vpminsd(xmm0, temp1);
+		}
 
 		if(m_sel.zwrite)
 		{
@@ -2384,9 +2387,12 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_AVX()
 	}
 
 	// Clamp Z to ZPSM_FMT_MAX
-	vpcmpeqd(xmm7, xmm7);
-	vpsrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
-	vpminsd(xmm1, xmm7);
+	if (m_sel.zclamp)
+	{
+		vpcmpeqd(xmm7, xmm7);
+		vpsrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+		vpminsd(xmm1, xmm7);
+	}
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;
 

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx2.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx2.cpp
@@ -637,7 +637,7 @@ void GSDrawScanlineCodeGenerator::TestZ(const Ymm& temp1, const Ymm& temp2)
 			vcvttps2dq(ymm0, ymm0);
 		}
 
-		//Clamp Z to ZPSM_FMT_MAX
+		// Clamp Z to ZPSM_FMT_MAX
 		vpcmpeqd(temp1, temp1);
 		vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
 		vpminsd(ymm0, temp1);
@@ -2379,7 +2379,7 @@ void GSDrawScanlineCodeGenerator::WriteZBuf()
 		vpbroadcastd(ymm1, ptr[&m_local.p.z]);
 	}
 
-	//Clamp Z to ZPSM_FMT_MAX
+	// Clamp Z to ZPSM_FMT_MAX
 	vpcmpeqd(ymm7, ymm7);
 	vpsrld(ymm7, (uint8)((m_sel.zpsm & 0x3) * 8));
 	vpminsd(ymm1, ymm7);

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx2.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx2.cpp
@@ -637,6 +637,11 @@ void GSDrawScanlineCodeGenerator::TestZ(const Ymm& temp1, const Ymm& temp2)
 			vcvttps2dq(ymm0, ymm0);
 		}
 
+		//Clamp Z to ZPSM_FMT_MAX
+		vpcmpeqd(temp1, temp1);
+		vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+		vpminsd(ymm0, temp1);
+
 		if(m_sel.zwrite)
 		{
 			vmovdqa(ptr[&m_local.temp.zs], ymm0);
@@ -2373,6 +2378,11 @@ void GSDrawScanlineCodeGenerator::WriteZBuf()
 	{
 		vpbroadcastd(ymm1, ptr[&m_local.p.z]);
 	}
+
+	//Clamp Z to ZPSM_FMT_MAX
+	vpcmpeqd(ymm7, ymm7);
+	vpsrld(ymm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+	vpminsd(ymm1, ymm7);
 
 	if(m_sel.ztest && m_sel.zpsm < 2)
 	{

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx2.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.avx2.cpp
@@ -638,9 +638,12 @@ void GSDrawScanlineCodeGenerator::TestZ(const Ymm& temp1, const Ymm& temp2)
 		}
 
 		// Clamp Z to ZPSM_FMT_MAX
-		vpcmpeqd(temp1, temp1);
-		vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
-		vpminsd(ymm0, temp1);
+		if (m_sel.zclamp)
+		{
+			vpcmpeqd(temp1, temp1);
+			vpsrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+			vpminsd(ymm0, temp1);
+		}
 
 		if(m_sel.zwrite)
 		{
@@ -2380,9 +2383,12 @@ void GSDrawScanlineCodeGenerator::WriteZBuf()
 	}
 
 	// Clamp Z to ZPSM_FMT_MAX
-	vpcmpeqd(ymm7, ymm7);
-	vpsrld(ymm7, (uint8)((m_sel.zpsm & 0x3) * 8));
-	vpminsd(ymm1, ymm7);
+	if (m_sel.zclamp)
+	{
+		vpcmpeqd(ymm7, ymm7);
+		vpsrld(ymm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+		vpminsd(ymm1, ymm7);
+	}
 
 	if(m_sel.ztest && m_sel.zpsm < 2)
 	{

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
@@ -640,6 +640,11 @@ void GSDrawScanlineCodeGenerator::TestZ_SSE(const Xmm& temp1, const Xmm& temp2)
 			cvttps2dq(xmm0, xmm0);
 		}
 
+		//Clamp Z to ZPSM_FMT_MAX
+		pcmpeqd(temp1, temp1);
+		psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+		pminsd(xmm0, temp1);
+
 		if(m_sel.zwrite)
 		{
 			movdqa(ptr[&m_local.temp.zs], xmm0);
@@ -2411,6 +2416,11 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_SSE()
 		movdqa(xmm7, ptr[&m_local.temp.zd]);
 		blend8(xmm1, xmm7);
 	}
+
+	//Clamp Z to ZPSM_FMT_MAX
+	pcmpeqd(xmm7, xmm7);
+	psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+	pminsd(xmm1, xmm7);
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;
 

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
@@ -641,9 +641,12 @@ void GSDrawScanlineCodeGenerator::TestZ_SSE(const Xmm& temp1, const Xmm& temp2)
 		}
 
 		// Clamp Z to ZPSM_FMT_MAX
-		pcmpeqd(temp1, temp1);
-		psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
-		pminsd(xmm0, temp1);
+		if (m_sel.zclamp)
+		{
+			pcmpeqd(temp1, temp1);
+			psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+			pminsd(xmm0, temp1);
+		}
 
 		if(m_sel.zwrite)
 		{
@@ -2418,9 +2421,12 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_SSE()
 	}
 
 	// Clamp Z to ZPSM_FMT_MAX
-	pcmpeqd(xmm7, xmm7);
-	psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
-	pminsd(xmm1, xmm7);
+	if (m_sel.zclamp)
+	{
+		pcmpeqd(xmm7, xmm7);
+		psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+		pminsd(xmm1, xmm7);
+	}
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;
 

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
@@ -640,6 +640,7 @@ void GSDrawScanlineCodeGenerator::TestZ_SSE(const Xmm& temp1, const Xmm& temp2)
 			cvttps2dq(xmm0, xmm0);
 		}
 
+#if _M_SSE >= 0x401
 		// Clamp Z to ZPSM_FMT_MAX
 		if (m_sel.zclamp)
 		{
@@ -647,6 +648,7 @@ void GSDrawScanlineCodeGenerator::TestZ_SSE(const Xmm& temp1, const Xmm& temp2)
 			psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
 			pminsd(xmm0, temp1);
 		}
+#endif
 
 		if(m_sel.zwrite)
 		{
@@ -2419,7 +2421,7 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_SSE()
 		movdqa(xmm7, ptr[&m_local.temp.zd]);
 		blend8(xmm1, xmm7);
 	}
-
+#if _M_SSE >= 0x401
 	// Clamp Z to ZPSM_FMT_MAX
 	if (m_sel.zclamp)
 	{
@@ -2427,6 +2429,7 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_SSE()
 		psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
 		pminsd(xmm1, xmm7);
 	}
+#endif
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;
 

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
@@ -640,15 +640,25 @@ void GSDrawScanlineCodeGenerator::TestZ_SSE(const Xmm& temp1, const Xmm& temp2)
 			cvttps2dq(xmm0, xmm0);
 		}
 
-#if _M_SSE >= 0x401
+
 		// Clamp Z to ZPSM_FMT_MAX
 		if (m_sel.zclamp)
 		{
+#if _M_SSE >= 0x401
 			pcmpeqd(temp1, temp1);
 			psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
 			pminsd(xmm0, temp1);
-		}
+#else
+			pcmpeqd(temp1, temp1);
+			psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+			pcmpgtd(temp1, xmm0);
+			pand(xmm0, temp1);
+			pcmpeqd(temp2, temp2);
+			pxor(temp1, temp2);
+			psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
+			por(xmm0, temp1);
 #endif
+		}
 
 		if(m_sel.zwrite)
 		{
@@ -2421,15 +2431,25 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_SSE()
 		movdqa(xmm7, ptr[&m_local.temp.zd]);
 		blend8(xmm1, xmm7);
 	}
-#if _M_SSE >= 0x401
+
 	// Clamp Z to ZPSM_FMT_MAX
 	if (m_sel.zclamp)
 	{
+#if _M_SSE >= 0x401
 		pcmpeqd(xmm7, xmm7);
 		psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
 		pminsd(xmm1, xmm7);
-	}
+#else
+		static GSVector4i all_1s = GSVector4i(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+		pcmpeqd(xmm7, xmm7);
+		psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+		pcmpgtd(xmm7, xmm1);
+		pand(xmm1, xmm7);
+		pxor(xmm7, ptr[&all_1s]);
+		psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
+		por(xmm1, xmm7);
 #endif
+	}
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;
 

--- a/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
+++ b/plugins/GSdx/Renderers/SW/GSDrawScanlineCodeGenerator.x86.cpp
@@ -640,7 +640,7 @@ void GSDrawScanlineCodeGenerator::TestZ_SSE(const Xmm& temp1, const Xmm& temp2)
 			cvttps2dq(xmm0, xmm0);
 		}
 
-		//Clamp Z to ZPSM_FMT_MAX
+		// Clamp Z to ZPSM_FMT_MAX
 		pcmpeqd(temp1, temp1);
 		psrld(temp1, (uint8)((m_sel.zpsm & 0x3) * 8));
 		pminsd(xmm0, temp1);
@@ -2417,7 +2417,7 @@ void GSDrawScanlineCodeGenerator::WriteZBuf_SSE()
 		blend8(xmm1, xmm7);
 	}
 
-	//Clamp Z to ZPSM_FMT_MAX
+	// Clamp Z to ZPSM_FMT_MAX
 	pcmpeqd(xmm7, xmm7);
 	psrld(xmm7, (uint8)((m_sel.zpsm & 0x3) * 8));
 	pminsd(xmm1, xmm7);

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -387,7 +387,7 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 		{
 			#if _M_SSE >= 0x401
 
-			xyzuvf = xyzuvf.xyzw().min_u32(z_max);
+			xyzuvf = xyzuvf.min_u32(z_max);
 			t = t.insert32<1, 3>(GSVector4::cast(xyzuvf));
 
 			#else

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -389,7 +389,7 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 
 			xyzuvf = xyzuvf.xyzw().min_u32(z_max);
 			t = t.insert32<1, 3>(GSVector4::cast(xyzuvf));
-			
+
 			#else
 
 			z = std::min(z, z_max);

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -293,15 +293,15 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 
 	switch (m_context->ZBUF.PSM)
 	{
-	case 0:
-		z_max = GSVector4i::xffffffff();
-		break;
-	case 1:
-		z_max = GSVector4i::x00ffffff();
-		break;
-	default:
-		z_max = GSVector4i::x0000ffff();
-		break;
+		case 0:
+			z_max = GSVector4i::xffffffff();
+			break;
+		case 1:
+			z_max = GSVector4i::x00ffffff();
+			break;
+		default:
+			z_max = GSVector4i::x0000ffff();
+			break;
 	}
 
 	#else
@@ -310,15 +310,15 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 
 	switch (m_context->ZBUF.PSM)
 	{
-	case 0:
-		z_max = 0xffffffff;
-		break;
-	case 1:
-		z_max = 0x00ffffff;
-		break;
-	default:
-		z_max = 0x0000ffff;
-		break;
+		case 0:
+			z_max = 0xffffffff;
+			break;
+		case 1:
+			z_max = 0x00ffffff;
+			break;
+		default:
+			z_max = 0x0000ffff;
+			break;
 	}
 
 	#endif
@@ -1364,9 +1364,25 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 	if(zwrite || ztest)
 	{
+		uint32_t z_max;
+
+		switch (GSLocalMemory::m_psm[context->ZBUF.PSM].fmt)
+		{
+			case 0:
+				z_max = 0xffffffff;
+				break;
+			case 1:
+				z_max = 0x00ffffff;
+				break;
+			default:
+				z_max = 0x0000ffff;
+				break;
+		}
+
 		gd.sel.zpsm = GSLocalMemory::m_psm[context->ZBUF.PSM].fmt;
 		gd.sel.ztst = ztest ? context->TEST.ZTST : (int)ZTST_ALWAYS;
 		gd.sel.zoverflow = (uint32)GSVector4i(m_vt.m_max.p).z == 0x80000000U;
+		gd.sel.zclamp = (uint32)GSVector4i(m_vt.m_max.p).z > z_max;
 	}
 
 	#if _M_SSE >= 0x501

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -1371,7 +1371,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 			case PSM_PSMZ32:
 				z_max = 0xffffffff;
 				break;
-			case 1:
+			case PSM_PSMZ24:
 				z_max = 0x00ffffff;
 				break;
 			default:

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -293,10 +293,10 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 
 	switch (m_context->ZBUF.PSM)
 	{
-		case 0:
+		case PSM_PSMZ32:
 			z_max = GSVector4i::xffffffff();
 			break;
-		case 1:
+		case PSM_PSMZ24:
 			z_max = GSVector4i::x00ffffff();
 			break;
 		default:
@@ -310,10 +310,10 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 
 	switch (m_context->ZBUF.PSM)
 	{
-		case 0:
+		case PSM_PSMZ32:
 			z_max = 0xffffffff;
 			break;
-		case 1:
+		case PSM_PSMZ24:
 			z_max = 0x00ffffff;
 			break;
 		default:
@@ -1366,9 +1366,9 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 	{
 		uint32_t z_max;
 
-		switch (GSLocalMemory::m_psm[context->ZBUF.PSM].fmt)
+		switch (context->ZBUF.PSM)
 		{
-			case 0:
+			case PSM_PSMZ32:
 				z_max = 0xffffffff;
 				break;
 			case 1:

--- a/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
+++ b/plugins/GSdx/Renderers/SW/GSRendererSW.cpp
@@ -289,37 +289,11 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 
 	#if _M_SSE >= 0x401
 
-	GSVector4i z_max;
-
-	switch (m_context->ZBUF.PSM)
-	{
-		case PSM_PSMZ32:
-			z_max = GSVector4i::xffffffff();
-			break;
-		case PSM_PSMZ24:
-			z_max = GSVector4i::x00ffffff();
-			break;
-		default:
-			z_max = GSVector4i::x0000ffff();
-			break;
-	}
+	GSVector4i z_max = GSVector4i::xffffffff().srl32(GSLocalMemory::m_psm[m_context->ZBUF.PSM].fmt * 8);
 
 	#else
 
-	uint32_t z_max;
-
-	switch (m_context->ZBUF.PSM)
-	{
-		case PSM_PSMZ32:
-			z_max = 0xffffffff;
-			break;
-		case PSM_PSMZ24:
-			z_max = 0x00ffffff;
-			break;
-		default:
-			z_max = 0x0000ffff;
-			break;
-	}
+	uint32_t z_max = 0xffffffff >> (GSLocalMemory::m_psm[m_context->ZBUF.PSM].fmt * 8);
 
 	#endif
 
@@ -1364,20 +1338,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 	if(zwrite || ztest)
 	{
-		uint32_t z_max;
-
-		switch (context->ZBUF.PSM)
-		{
-			case PSM_PSMZ32:
-				z_max = 0xffffffff;
-				break;
-			case PSM_PSMZ24:
-				z_max = 0x00ffffff;
-				break;
-			default:
-				z_max = 0x0000ffff;
-				break;
-		}
+		uint32_t z_max = 0xffffffff >> (GSLocalMemory::m_psm[context->ZBUF.PSM].fmt * 8);
 
 		gd.sel.zpsm = GSLocalMemory::m_psm[context->ZBUF.PSM].fmt;
 		gd.sel.ztst = ztest ? context->TEST.ZTST : (int)ZTST_ALWAYS;

--- a/plugins/GSdx/Renderers/SW/GSScanlineEnvironment.h
+++ b/plugins/GSdx/Renderers/SW/GSScanlineEnvironment.h
@@ -55,19 +55,20 @@ union GSScanlineSelector
 		uint32 zwrite:1; // 35
 		uint32 ztest:1; // 36
 		uint32 zoverflow:1; // 37 (z max >= 0x80000000)
-		uint32 wms:2; // 38
-		uint32 wmt:2; // 40
-		uint32 datm:1; // 42
-		uint32 colclamp:1; // 43
-		uint32 fba:1; // 44
-		uint32 dthe:1; // 45
-		uint32 prim:2; // 46
+		uint32 zclamp:1; // 38
+		uint32 wms:2; // 39
+		uint32 wmt:2; // 41
+		uint32 datm:1; // 43
+		uint32 colclamp:1; // 44
+		uint32 fba:1; // 45
+		uint32 dthe:1; // 46
+		uint32 prim:2; // 47
 
-		uint32 edge:1; // 48
-		uint32 tw:3; // 49 (encodes values between 3 -> 10, texture cache makes sure it is at least 3)
-		uint32 lcm:1; // 52
-		uint32 mmin:2; // 53
-		uint32 notest:1; // 54 (no ztest, no atest, no date, no scissor test, and horizontally aligned to 4 pixels)
+		uint32 edge:1; // 49
+		uint32 tw:3; // 50 (encodes values between 3 -> 10, texture cache makes sure it is at least 3)
+		uint32 lcm:1; // 53
+		uint32 mmin:2; // 54
+		uint32 notest:1; // 55 (no ztest, no atest, no date, no scissor test, and horizontally aligned to 4 pixels)
 		// TODO: 1D texture flag? could save 2 texture reads and 4 lerps with bilinear, and also the texture coordinate clamp/wrap code in one direction
 
 		uint32 breakpoint:1; // Insert a trap to stop the program, helpful to stop debugger on a program


### PR DESCRIPTION
Follow up from #3414. SW renderer port.

Fixes SW renderer on #2623, #2271