### PR TITLE
NSIS: Add support for command line flags and fix silent install

### DIFF
--- a/nsis/SectionVersionCheck.nsh
+++ b/nsis/SectionVersionCheck.nsh
@@ -27,7 +27,7 @@ ${EndIf}
 
 UserPrompt:
 ; Installing another version
-MessageBox MB_ICONEXCLAMATION|MB_OKCANCEL "An existing version of PCSX2 has been detected and will be REMOVED. The config folder in Documents will be duplicated (if it exists) and renamed as PCSX2_backup. Backup any important files and click OK to uninstall PCSX2 or Cancel to abort the setup." IDOK SetUninstPath IDCANCEL false
+MessageBox MB_ICONEXCLAMATION|MB_OKCANCEL "An existing version of PCSX2 has been detected and will be REMOVED. The config folder in Documents will be duplicated (if it exists) and renamed as PCSX2_backup. Backup any important files and click OK to uninstall PCSX2 or Cancel to abort the setup." /SD IDOK IDOK SetUninstPath IDCANCEL false
 
 false:
 Quit

--- a/nsis/SharedDefs.nsh
+++ b/nsis/SharedDefs.nsh
@@ -3,6 +3,8 @@
 ; These definitions are shared between the 2 installers (pre-install/portable and full)
 ; This reduces duplicate code throughout both installers.
 
+!include "FileFunc.nsh"
+
 ManifestDPIAware true
 Unicode true
 ShowInstDetails nevershow
@@ -62,4 +64,58 @@ ${If} $UserPrivileges == "Admin"
     ${ElseIf} $UserPrivileges == "User"
     StrCpy $IsAdmin 0
 ${EndIf}
+FunctionEnd
+
+Function ShowHelpMessage
+  !define line1 "Command line options:$\r$\n$\r$\n"
+	!define line2 "/S - silent install (must be uppercase)$\r$\n"
+	!define line3 "/D=path\to\install\folder - Change install directory$\r$\n"
+	!define line4 "   (Must be uppercase, the last option given and no quotes)$\r$\n$\r$\n"
+	!define line5 "/NoStart - Do not create start menu shortcut$\r$\n"
+	!define line6 "/NoDesktop - Do not create desktop shortcut$\r$\n"
+  !define line7 "/Portable- Install in portable mode instead of full install, no effect unless /S is passed as well"
+	MessageBox MB_OK "${line1}${line2}${line3}${line4}${line5}${line6}${line7}"
+	Abort
+FunctionEnd
+
+Function .onInit
+    var /GLOBAL cmdLineParams
+    Push $R0
+    ${GetParameters} $cmdLineParams
+    ClearErrors
+
+    ${GetOptions} $cmdLineParams '/?' $R0
+    IfErrors +2 0
+    Call ShowHelpMessage
+
+  	${GetOptions} $cmdLineParams '/H' $R0
+    IfErrors +2 0
+    Call ShowHelpMessage
+
+    Pop $R0
+
+
+    Var /GLOBAL option_startMenu
+    Var /GLOBAL option_desktop
+    Var /GLOBAL option_portable
+    StrCpy $option_startMenu     1
+  	StrCpy $option_desktop       1
+    StrCpy $option_portable      0
+
+    Push $R0
+
+  	${GetOptions} $cmdLineParams '/NoStart' $R0
+    IfErrors +2 0
+  	StrCpy $option_startMenu 0
+
+    ${GetOptions} $cmdLineParams '/NoDesktop' $R0
+    IfErrors +2 0
+    StrCpy $option_desktop 0
+
+    ${GetOptions} $cmdLineParams '/Portable' $R0
+    IfErrors +2 0
+    StrCpy $option_portable 1
+
+    Pop $R0
+    
 FunctionEnd

--- a/nsis/SharedDefs.nsh
+++ b/nsis/SharedDefs.nsh
@@ -78,7 +78,7 @@ Function ShowHelpMessage
 FunctionEnd
 
 Function .onInit
-    var /GLOBAL cmdLineParams
+    Var /GLOBAL cmdLineParams
     Push $R0
     ${GetParameters} $cmdLineParams
     ClearErrors
@@ -87,7 +87,7 @@ Function .onInit
     IfErrors +2 0
     Call ShowHelpMessage
 
-  	${GetOptions} $cmdLineParams '/H' $R0
+    ${GetOptions} $cmdLineParams '/H' $R0
     IfErrors +2 0
     Call ShowHelpMessage
 
@@ -98,14 +98,14 @@ Function .onInit
     Var /GLOBAL option_desktop
     Var /GLOBAL option_portable
     StrCpy $option_startMenu     1
-  	StrCpy $option_desktop       1
+    StrCpy $option_desktop       1
     StrCpy $option_portable      0
 
     Push $R0
 
-  	${GetOptions} $cmdLineParams '/NoStart' $R0
+    ${GetOptions} $cmdLineParams '/NoStart' $R0
     IfErrors +2 0
-  	StrCpy $option_startMenu 0
+    StrCpy $option_startMenu 0
 
     ${GetOptions} $cmdLineParams '/NoDesktop' $R0
     IfErrors +2 0

--- a/nsis/SharedDefs.nsh
+++ b/nsis/SharedDefs.nsh
@@ -68,14 +68,13 @@ FunctionEnd
 
 Function ShowHelpMessage
   !define line1 "Command line options:$\r$\n$\r$\n"
-	!define line2 "/S - silent install (must be uppercase)$\r$\n"
-	!define line3 "/D=path\to\install\folder - Change install directory$\r$\n"
-	!define line4 "   (Must be uppercase, the last option given and no quotes)$\r$\n$\r$\n"
-	!define line5 "/NoStart - Do not create start menu shortcut$\r$\n"
-	!define line6 "/NoDesktop - Do not create desktop shortcut$\r$\n"
-  !define line7 "/Portable- Install in portable mode instead of full install, no effect unless /S is passed as well"
-	MessageBox MB_OK "${line1}${line2}${line3}${line4}${line5}${line6}${line7}"
-	Abort
+  !define line2 "/S - silent install (must be uppercase)$\r$\n"
+  !define line3 "/D=path\to\install\folder - Change install directory (Must be uppercase, the last option given and no quotes)$\r$\n"
+  !define line4 "/NoStart - Do not create start menu shortcut$\r$\n"
+  !define line5 "/NoDesktop - Do not create desktop shortcut$\r$\n"
+  !define line6 "/Portable- Install in portable mode instead of full install, no effect unless /S is passed as well"
+  MessageBox MB_OK "${line1}${line2}${line3}${line4}${line5}${line6}"
+  Abort
 FunctionEnd
 
 Function .onInit

--- a/nsis/SharedShortcuts.nsh
+++ b/nsis/SharedShortcuts.nsh
@@ -1,13 +1,15 @@
 Section "Start Menu Shortcuts" SEC_STARTMENU
-
-  ; CreateShortCut gets the working directory from OutPath
-  SetOutPath "$INSTDIR"
-  CreateShortCut "$SMPROGRAMS\${APP_NAME}.lnk"                "${APP_EXE}"         ""    "${APP_EXE}"       0
+  ${If} $option_startMenu == 1
+    ; CreateShortCut gets the working directory from OutPath
+    SetOutPath "$INSTDIR"
+    CreateShortCut "$SMPROGRAMS\${APP_NAME}.lnk"                "${APP_EXE}"         ""    "${APP_EXE}"       0
+  ${EndIf}
 SectionEnd
 
 Section "Desktop Shortcut" SEC_DESKTOP
-
-  ; CreateShortCut gets the working directory from OutPath
-  SetOutPath "$INSTDIR"
-  CreateShortCut "$DESKTOP\${APP_NAME}.lnk"            "${APP_EXE}"      "" "${APP_EXE}"     0 "" "" "A Playstation 2 Emulator"
+  ${If} $option_desktop == 1
+    ; CreateShortCut gets the working directory from OutPath
+    SetOutPath "$INSTDIR"
+    CreateShortCut "$DESKTOP\${APP_NAME}.lnk"            "${APP_EXE}"      "" "${APP_EXE}"     0 "" "" "A Playstation 2 Emulator"
+  ${EndIf}
 SectionEnd

--- a/nsis/pcsx2_shared_init.nsi
+++ b/nsis/pcsx2_shared_init.nsi
@@ -33,6 +33,11 @@ Page Custom InstallMode InstallModeLeave
 ; Function located in SharedDefs
 Section ""
 Call IsUserAdmin
+IfSilent 0 +5
+Call TempFilesOut
+${If} $option_portable == 0
+  Call StartFullInstaller
+${EndIf}
 SectionEnd
 
 Function PreInstallDialog
@@ -57,6 +62,15 @@ ${NSD_KillTimer} NSD_Timer.Callback
 ;-----------------------------------------
 ; Copy installer files to a temp directory instead of repacking twice (for each installer)
     ${NSD_CreateLabel} 0 45 80% 10u "Unpacking files. Maybe it's time to upgrade that computer!"
+    Call TempFilesOut
+    ${NSD_CreateLabel} 0 45 100% 10u "Moving on"
+;-----------------------------------------
+
+    Call PreInstall_UsrWait
+SendMessage $HWNDPARENT ${WM_COMMAND} 1 0
+FunctionEnd
+
+Function TempFilesOut
   SetOutPath "$TEMP\PCSX2 ${APP_VERSION}"
     File ..\bin\pcsx2.exe
     File ..\bin\GameIndex.dbf
@@ -80,13 +94,8 @@ ${NSD_KillTimer} NSD_Timer.Callback
     File /nonfatal ..\bin\Plugins\DEV9null.dll
     File /nonfatal ..\bin\Plugins\FWnull.dll
 
-    SetOutPath "$TEMP\PCSX2 ${APP_VERSION}\Langs"
+  SetOutPath "$TEMP\PCSX2 ${APP_VERSION}\Langs"
     File /nonfatal /r ..\bin\Langs\*.mo
-    ${NSD_CreateLabel} 0 45 100% 10u "Moving on"
-;-----------------------------------------
-
-    Call PreInstall_UsrWait
-SendMessage $HWNDPARENT ${WM_COMMAND} 1 0
 FunctionEnd
 
 Function PreInstall_UsrWait
@@ -155,11 +164,19 @@ ${NSD_GetState} $InstallMode_Normal $0
 ${NSD_GetState} $InstallMode_Portable $1
 
 ${If} ${BST_CHECKED} == $0
-SetOutPath "$TEMP"
-File "pcsx2-${APP_VERSION}-include_standard.exe"
-ExecShell open "$TEMP\pcsx2-${APP_VERSION}-include_standard.exe"
-Quit
+Call StartFullInstaller
 ${EndIf}
+FunctionEnd
+
+Function StartFullInstaller
+  ;Checks if install directory is changed from default with /D, and if not, changes to standard full install directory.
+  ${If} $INSTDIR == "$DOCUMENTS\PCSX2 ${APP_VERSION}"
+  StrCpy $INSTDIR "$PROGRAMFILES\PCSX2"
+  ${EndIf}
+  SetOutPath "$TEMP"
+  File "pcsx2-${APP_VERSION}-include_standard.exe"
+  ExecShell open "$TEMP\pcsx2-${APP_VERSION}-include_standard.exe" "$cmdLineParams /D=$INSTDIR"
+  Quit
 FunctionEnd
 
 ; ----------------------------------


### PR DESCRIPTION
Fixes #3431 

- Fixes `/D` install directory override, works for both portable and install
- Fixes `/S` silent install, defaults to install
- Adds `/?` and `/H` which show a help message with the available flags
- Adds `/NoStart` and `/NoDesktop` which respectively disable the creation of start menu and desktop shortcuts.
- Adds `/Portable`, which switches the installer over to portable mode if it is silent(`/S`) as opposed to the default mode of install.