### PR TITLE
GSdx-hw: Onimusha 3 crc hack and texture shuffling

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSHwHack.cpp
+++ b/plugins/GSdx/Renderers/HW/GSHwHack.cpp
@@ -310,16 +310,6 @@ bool GSC_IkkiTousen(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_Onimusha3(const GSFrameInfo& fi, int& skip)
-{
-	if(fi.TME /*&& (fi.FBP == 0x00000 || fi.FBP == 0x00700)*/ && (fi.TBP0 == 0x01180 || fi.TBP0 == 0x00e00 || fi.TBP0 == 0x01000 || fi.TBP0 == 0x01200) && (fi.TPSM == PSM_PSMCT32 || fi.TPSM == PSM_PSMCT24))
-	{
-		skip = 1;
-	}
-
-	return true;
-}
-
 bool GSC_Genji(const GSFrameInfo& fi, int& skip)
 {
 	if(skip == 0)
@@ -1418,7 +1408,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::Kunoichi] = GSC_Kunoichi;
 		lut[CRC::Manhunt2] = GSC_Manhunt2;
 		lut[CRC::MidnightClub3] = GSC_MidnightClub3;
-		lut[CRC::Onimusha3] = GSC_Onimusha3;
 		lut[CRC::SacredBlaze] = GSC_SacredBlaze;
 		lut[CRC::SakuraTaisen] = GSC_SakuraTaisen;
 		lut[CRC::SakuraWarsSoLongMyLove] = GSC_SakuraWarsSoLongMyLove;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1228,20 +1228,28 @@ void GSRendererHW::Draw()
 		m_texture_shuffle = (GSLocalMemory::m_psm[context->FRAME.PSM].bpp == 16) && (tex_psm.bpp == 16)
 			&& draw_sprite_tex && m_src->m_32_bits_fmt;
 
-		// Shadow_of_memories_Shadow_Flickering (Okami mustn't call this code)
+		// Okami mustn't call this code
 		if (m_texture_shuffle && m_vertex.next < 3 && PRIM->FST && (m_context->FRAME.FBMSK == 0)) {
 			// Avious dubious call to m_texture_shuffle on 16 bits games
 			// The pattern is severals column of 8 pixels. A single sprite
 			// smell fishy but a big sprite is wrong.
 
-			// Tomb Raider Angel of Darkness relies on this behavior to produce a fog effect.
-			// In this case, the address of the framebuffer and texture are the same. 
-			// The game will take RG => BA and then the BA => RG of next pixels. 
-			// However, only RG => BA needs to be emulated because RG isn't used.
 			GL_INS("WARNING: Possible misdetection of a texture shuffle effect");
-
 			GSVertex* v = &m_vertex.buff[0];
-			m_texture_shuffle = ((v[1].U - v[0].U) < 256) || m_context->FRAME.Block() == m_context->TEX0.TBP0;
+			m_texture_shuffle =
+				// Shadow of Memories/Destiny shouldn't call this code.
+				// Causes shadow flickering.
+				((v[1].U - v[0].U) < 256) ||
+				// Tomb Raider Angel of Darkness relies on this behavior to produce a fog effect.
+				// In this case, the address of the framebuffer and texture are the same. 
+				// The game will take RG => BA and then the BA => RG of next pixels. 
+				// However, only RG => BA needs to be emulated because RG isn't used.
+				m_context->FRAME.Block() == m_context->TEX0.TBP0 ||
+				// FIXME: Temporary solution, find a solution without relying on crc
+				// in the future.
+				// Onimusha requires texture shuffle to properly emulate shadows and
+				// other effects.
+				m_game.title == CRC::Onimusha3;
 		}
 
 		// Texture shuffle is not yet supported with strange clamp mode


### PR DESCRIPTION
gsdx-hw: Remove GSC_Onimusha3 crc hack. 
It will allow to render shadows in certain locations in Ominusha 3.
Issue #3429

gsdx-hw: Add a temporary fix for Onimusha 3.
Allow texture shuffle to run. It will allow to render
shadows and other effects properly.
Would be nice to have a better solution with no crc in the future.

Close #3429 #3428