### PR TITLE
GSdx-d3d11: Allow DATE_one to run on unsupported cases.

### DIFF
--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1455,6 +1455,13 @@ enum class CRCHackLevel : int8
 	Aggressive
 };
 
+enum class AccurateDate : uint8
+{
+	None,
+	Fast,
+	Full
+};
+
 #ifdef ENABLE_ACCURATE_BUFFER_EMULATION
 const GSVector2i default_rt_size(2048, 2048);
 #else

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -291,9 +291,11 @@ void GSdxApp::Init()
 		GSSetting(CRCHackLevel::Aggressive, "Aggressive", ""),
 	};
 
-	m_gs_acc_date_level.push_back(GSSetting(0, "Off", ""));
-	m_gs_acc_date_level.push_back(GSSetting(1, "Fast", "Default"));
-	m_gs_acc_date_level.push_back(GSSetting(2, "Full", "Slow"));
+	m_gs_acc_date_level = {
+		GSSetting(AccurateDate::None, "Off", ""),
+		GSSetting(AccurateDate::Fast, "Fast", "Default"),
+		GSSetting(AccurateDate::Full, "Full", "Slow"),
+	};
 
 	m_gs_acc_blend_level.push_back(GSSetting(0, "None", "Fastest"));
 	m_gs_acc_blend_level.push_back(GSSetting(1, "Basic", "Recommended"));
@@ -326,7 +328,7 @@ void GSdxApp::Init()
 	m_default_configuration["linux_replay"]                               = "1";
 #endif
 	m_default_configuration["aa1"]                                        = "0";
-	m_default_configuration["accurate_date"]                              = "1";
+	m_default_configuration["accurate_date"]                              = std::to_string(static_cast<uint8>(AccurateDate::Fast));
 	m_default_configuration["accurate_blending_unit"]                     = "1";
 	m_default_configuration["AspectRatio"]                                = "1";
 	m_default_configuration["autoflush_sw"]                               = "1";

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -838,9 +838,10 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 	{
 		if (m_texture_shuffle)
 		{
-			// DATE case not supported yet so keep using the old method.
-			// Leave the check in to make sure other DATE cases are triggered correctly.
+			// Advanced case not yet supported, use DATE_one on Full level, might help some games.
 			// fprintf(stderr, "%d: DATE with texture shuffle\n", s_n);
+			if (m_accurate_date == AccurateDate::Full)
+				DATE_one = true;
 		}
 		else if (m_om_bsel.wa && !m_context->TEST.ATE)
 		{
@@ -860,9 +861,11 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 			}
 			else if ((m_vt.m_primclass == GS_SPRITE_CLASS /*&& m_drawlist.size() < 50*/) || (m_index.tail < 100))
 			{
-				// DATE case not supported yet so keep using the old method.
-				// Leave the check in to make sure other DATE cases are triggered correctly.
+				// Advanced case not yet supported, use DATE_one on Full level, might help some games.
+				// Amagami will break with DATE_one case tho.
 				// fprintf(stderr, "%d: Slow DATE with alpha %d-%d not supported\n", s_n, m_vt.m_alpha.min, m_vt.m_alpha.max);
+				if (m_accurate_date == AccurateDate::Full)
+					DATE_one = true;
 			}
 			else
 			{

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -866,7 +866,7 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 			}
 			else
 			{
-				if (m_accurate_date)
+				if (m_accurate_date == AccurateDate::Fast || m_accurate_date == AccurateDate::Full)
 				{
 					// fprintf(stderr, "%d: Fast Accurate DATE with alpha %d-%d\n", s_n, m_vt.m_alpha.min, m_vt.m_alpha.max);
 					DATE_one = true;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -42,7 +42,7 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	m_mipmap = theApp.GetConfigI("mipmap_hw");
 	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
 	m_large_framebuffer  = theApp.GetConfigB("large_framebuffer");
-	m_accurate_date = theApp.GetConfigI("accurate_date");
+	m_accurate_date      = static_cast<AccurateDate>(theApp.GetConfigI("accurate_date"));
 
 	if (theApp.GetConfigB("UserHacks")) {
 		m_userhacks_enabled_gs_mem_clear = !theApp.GetConfigB("UserHacks_Disable_Safe_Features");

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -158,7 +158,7 @@ protected:
 	float m_userhacks_tcoffset_x;
 	float m_userhacks_tcoffset_y;
 
-	int m_accurate_date;
+	AccurateDate m_accurate_date;
 	int m_sw_blending;
 
 	bool m_channel_shuffle;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -1081,7 +1081,7 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 				DATE = false;
 			} else {
 				switch (m_accurate_date) {
-					case ACC_DATE_FULL:
+					case AccurateDate::Full:
 						GL_PERF("Full Accurate DATE with alpha %d-%d", m_vt.m_alpha.min, m_vt.m_alpha.max);
 						if (GLLoader::found_GL_ARB_shader_image_load_store && GLLoader::found_GL_ARB_clear_texture) {
 							DATE_GL42 = true;
@@ -1091,11 +1091,11 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 							DATE = false;
 						}
 						break;
-					case ACC_DATE_FAST:
+					case AccurateDate::Fast:
 						GL_PERF("Fast Accurate DATE with alpha %d-%d", m_vt.m_alpha.min, m_vt.m_alpha.max);
 						DATE_one = true;
 						break;
-					case ACC_DATE_NONE:
+					case AccurateDate::None:
 					default:
 						GL_PERF("Inaccurate DATE with alpha %d-%d", m_vt.m_alpha.min, m_vt.m_alpha.max);
 						break;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
@@ -33,12 +33,6 @@ class GSRendererOGL final : public GSRendererHW
 		PRIM_OVERLAP_NO
 	};
 
-	enum ACC_DATE {
-		ACC_DATE_NONE = 0,
-		ACC_DATE_FAST = 1,
-		ACC_DATE_FULL = 2
-	};
-
 	enum ACC_BLEND {
 		ACC_BLEND_NONE   = 0,
 		ACC_BLEND_BASIC  = 1,


### PR DESCRIPTION
Shared:
Use enum for AccurateDate throughout.

Direct3D11:
It might help rendering in some games, not confirmed.
Amagami is one of the games that breaks unfortunately, but wasn't
rendered properly even without it as well.
Maybe it is better to only enable it on texture shuffle case.