### PR TITLE
gsdx-ogl: Fix MaxDepthPS byte alignment.

### DIFF
--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -177,14 +177,14 @@ void GSRendererOGL::EmulateZbuffer()
 	const bool clamp_z = (uint32)(GSVector4i(m_vt.m_max.p).z) > max_z;
 
 	vs_cb.MaxDepth = GSVector2i(0xFFFFFFFF);
-	ps_cb.MaxDepth = GSVector4(1.0f);
+	ps_cb.MaxDepth = GSVector4(0.0f, 0.0f, 0.0f, 1.0f);
 	m_ps_sel.zclamp = 0;
 
 	if (clamp_z) {
 		if (m_vt.m_primclass == GS_SPRITE_CLASS || m_vt.m_primclass == GS_POINT_CLASS) {
 			vs_cb.MaxDepth = GSVector2i(max_z);
 		} else {
-			ps_cb.MaxDepth = GSVector4(max_z * ldexpf(1, -32));
+			ps_cb.MaxDepth = GSVector4(0.0f, 0.0f, 0.0f, max_z * ldexpf(1, -32));
 			m_ps_sel.zclamp = 1;
 		}
 	}

--- a/plugins/GSdx/res/glsl/common_header.glsl
+++ b/plugins/GSdx/res/glsl/common_header.glsl
@@ -95,8 +95,8 @@ layout(std140, binding = 21) uniform cb21
     vec2 TextureScale;
     vec2 TC_OffsetHack;
 
-	float MaxDepthPS;
-	vec3 pad_cb21;
+    vec3 pad_cb21;
+    float MaxDepthPS;
 
     mat4 DitherMatrix;
 };


### PR DESCRIPTION
Bigger value comes first, then smaller to fill the gap so the alignment
can be proper.
vec3
float