### PR TITLE
Add new debugger controls to go-to specific disassembly or memory addresses

### DIFF
--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -102,12 +102,15 @@ protected:
 	void onDebuggerEvent(wxCommandEvent& evt);
 	void onPageChanging(wxCommandEvent& evt);
 	void onBreakpointClicked(wxCommandEvent& evt);
+	void onGoToDisassemblyAddressFieldEntered(wxCommandEvent& evt);
+	void onGoToMemoryAddressFieldEntered(wxCommandEvent& evt);
 	void onSizeEvent(wxSizeEvent& event);
 	void onClose(wxCloseEvent& evt);
 	void stepOver();
 	void stepInto();
 	void stepOut();
 	void gotoPc();
+
 private:
 	CpuTabPage* eeTab;
 	CpuTabPage* iopTab;
@@ -115,5 +118,14 @@ private:
 	wxNotebook* middleBook;
 
 	wxBoxSizer* topSizer;
-	wxButton *breakRunButton, *stepIntoButton, *stepOverButton, *stepOutButton, *breakpointButton, *helpButton;
+	wxButton* breakRunButton;
+	wxButton* stepIntoButton;
+	wxButton* stepOverButton;
+	wxButton* stepOutButton;
+	wxButton* breakpointButton;
+	wxButton* helpButton;
+
+	wxTextCtrl* goToDisassemblyAddressField;
+	wxTextCtrl* goToMemoryAddressField;
+	void gotoAddress(wxString fieldText, bool disasmAddress);
 };


### PR DESCRIPTION
Lately I've been using pcsx2's debug view a lot to look at specific memory addresses or disassembly values.  Currently the only way I've found to jump to addresses is to create a breakpoint and then use that breakpoint to jump to the disassembly or memory value by double clicking it.

This is pretty clunky, but is especially annoying if whatever you are debugging crashes the emulator / requires the emulator to be restarted between iterations as you have to setup the breakpoint each time.

So this just adds some simple text fields next to the existing debug control buttons to jump to an explicit memory address or disassembly address.

Demo Video - https://www.youtube.com/watch?v=3MdNQaj9kM0