### PR TITLE
gsdx-d3d11: Remove legacy d3dcompiler code

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -148,13 +148,7 @@ EXPORT_C_(int) GSinit()
 		g_const->Init();
 
 #ifdef _WIN32
-
 	s_hr = ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
-
-	if (!GSDevice11::LoadD3DCompiler())
-	{
-		return -1;
-	}
 #endif
 
 	return 0;
@@ -170,16 +164,12 @@ EXPORT_C GSshutdown()
 	theApp.SetCurrentRendererType(GSRendererType::Undefined);
 
 #ifdef _WIN32
-
 	if(SUCCEEDED(s_hr))
 	{
 		::CoUninitialize();
 
 		s_hr = E_FAIL;
 	}
-
-	GSDevice11::FreeD3DCompiler();
-
 #endif
 }
 
@@ -825,34 +815,7 @@ EXPORT_C GSconfigure()
 EXPORT_C_(int) GStest()
 {
 	if(!GSUtil::CheckSSE())
-	{
 		return -1;
-	}
-
-#ifdef _WIN32
-
-	s_hr = ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
-
-	if(!GSUtil::CheckDirectX())
-	{
-		if(SUCCEEDED(s_hr))
-		{
-			::CoUninitialize();
-		}
-
-		s_hr = E_FAIL;
-
-		return -1;
-	}
-
-	if(SUCCEEDED(s_hr))
-	{
-		::CoUninitialize();
-	}
-
-	s_hr = E_FAIL;
-
-#endif
 
 	return 0;
 }

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -339,26 +339,6 @@ std::string GSUtil::GetDeviceUniqueName(cl::Device& device)
 
 #ifdef _WIN32
 
-bool GSUtil::CheckDirectX()
-{
-	if (GSDevice11::LoadD3DCompiler())
-	{
-		GSDevice11::FreeD3DCompiler();
-		return true;
-	}
-
-	// User's system is likely broken if it fails and is Windows 8.1 or greater.
-	if (!IsWindows8Point1OrGreater())
-	{
-		printf("Cannot find d3dcompiler_43.dll\n");
-		if (MessageBox(nullptr, TEXT("You need to update some DirectX libraries, would you like to do it now?"), TEXT("GSdx"), MB_YESNO) == IDYES)
-		{
-			ShellExecute(nullptr, TEXT("open"), TEXT("https://www.microsoft.com/en-us/download/details.aspx?id=8109"), nullptr, nullptr, SW_SHOWNORMAL);
-		}
-	}
-	return false;
-}
-
 // ---------------------------------------------------------------------------------
 //  DX11 Detection (includes DXGI detection and dynamic library method bindings)
 // ---------------------------------------------------------------------------------

--- a/plugins/GSdx/GSUtil.h
+++ b/plugins/GSdx/GSUtil.h
@@ -60,13 +60,10 @@ public:
 #endif
 
 #ifdef _WIN32
-
-	static bool CheckDirectX();
 	static bool CheckDXGI();
 	static bool CheckD3D11();
 	static GSRendererType GetBestRenderer();
 	static D3D_FEATURE_LEVEL CheckDirect3D11Level(IDXGIAdapter *adapter = NULL, D3D_DRIVER_TYPE type = D3D_DRIVER_TYPE_HARDWARE);
-
 #endif
 };
 

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -27,10 +27,6 @@
 #include <fstream>
 #include <VersionHelpers.h>
 
-HMODULE GSDevice11::s_d3d_compiler_dll = nullptr;
-decltype(&D3DCompile) GSDevice11::s_pD3DCompile = nullptr;
-bool GSDevice11::s_old_d3d_compiler_dll;
-
 GSDevice11::GSDevice11()
 {
 	memset(&m_state, 0, sizeof(m_state));
@@ -53,50 +49,6 @@ GSDevice11::GSDevice11()
 		m_aniso_filter = aniso_level;
 	else
 		m_aniso_filter = 0;
-}
-
-bool GSDevice11::LoadD3DCompiler()
-{
-	// Windows 8.1 and later come with the latest d3dcompiler_47.dll, but
-	// Windows 7 devs might also have the dll available for use (which will
-	// have to be placed in the application directory)
-	s_d3d_compiler_dll = LoadLibraryEx(D3DCOMPILER_DLL, nullptr, LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
-
-	// Windows Vista and 7 can use the older version. If the previous LoadLibrary
-	// call fails on Windows 8.1 and later, then the user's system is likely
-	// broken.
-	if (s_d3d_compiler_dll)
-	{
-		s_old_d3d_compiler_dll = false;
-	}
-	else
-	{
-		if (!IsWindows8Point1OrGreater())
-			// Use LoadLibrary instead of LoadLibraryEx, some Windows 7 systems
-			// have issues with it.
-			s_d3d_compiler_dll = LoadLibrary("D3DCompiler_43.dll");
-
-		if (s_d3d_compiler_dll == nullptr)
-			return false;
-
-		s_old_d3d_compiler_dll = true;
-	}
-
-	s_pD3DCompile = reinterpret_cast<decltype(&D3DCompile)>(GetProcAddress(s_d3d_compiler_dll, "D3DCompile"));
-	if (s_pD3DCompile)
-		return true;
-
-	FreeLibrary(s_d3d_compiler_dll);
-	s_d3d_compiler_dll = nullptr;
-	return false;
-}
-
-void GSDevice11::FreeD3DCompiler()
-{
-	s_pD3DCompile = nullptr;
-	if (s_d3d_compiler_dll)
-		FreeLibrary(s_d3d_compiler_dll);
-	s_d3d_compiler_dll = nullptr;
 }
 
 bool GSDevice11::SetFeatureLevel(D3D_FEATURE_LEVEL level, bool compat_mode)
@@ -1526,8 +1478,6 @@ void GSDevice11::CreateShader(std::vector<char> source, const char* fn, ID3DIncl
 
 void GSDevice11::CompileShader(std::vector<char> source, const char* fn, ID3DInclude *include, const char* entry, D3D_SHADER_MACRO* macro, ID3DBlob** shader, std::string shader_model)
 {
-	HRESULT hr;
-
 	CComPtr<ID3DBlob> error;
 
 	UINT flags = 0;
@@ -1536,17 +1486,17 @@ void GSDevice11::CompileShader(std::vector<char> source, const char* fn, ID3DInc
 	flags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION | D3DCOMPILE_AVOID_FLOW_CONTROL;
 #endif
 
-	hr = s_pD3DCompile(source.data(), source.size(), fn, macro, include, entry, shader_model.c_str(), flags, 0, shader, &error);
+	const HRESULT hr = D3DCompile(
+		source.data(), source.size(), fn, macro,
+		include, entry, shader_model.c_str(),
+		flags, 0, shader, &error
+	);
 
-	if(error)
-	{
+	if (error)
 		fprintf(stderr, "%s\n", (const char*)error->GetBufferPointer());
-	}
 
-	if(FAILED(hr))
-	{
+	if (FAILED(hr))
 		throw GSDXRecoverableError();
-	}
 }
 
 uint16 GSDevice11::ConvertBlendEnum(uint16 generic)

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -495,22 +495,12 @@ private:
 
 protected:
 	struct {D3D_FEATURE_LEVEL level; std::string model, vs, gs, ps, cs;} m_shader;
-
-	static HMODULE s_d3d_compiler_dll;
-	static decltype(&D3DCompile) s_pD3DCompile;
-	// Older version doesn't support D3D_COMPILE_STANDARD_FILE_INCLUDE, which
-	// could be useful for external shaders.
-	static bool s_old_d3d_compiler_dll;
-
 public:
 	GSDevice11();
 	virtual ~GSDevice11() {}
 
 	bool SetFeatureLevel(D3D_FEATURE_LEVEL level, bool compat_mode);
 	void GetFeatureLevel(D3D_FEATURE_LEVEL& level) const { level = m_shader.level; }
-
-	static bool LoadD3DCompiler();
-	static void FreeD3DCompiler();
 
 	bool Create(const std::shared_ptr<GSWnd> &wnd);
 	bool Reset(int w, int h);

--- a/plugins/GSdx/vsprops/common.props
+++ b/plugins/GSdx/vsprops/common.props
@@ -18,8 +18,8 @@
       <PreprocessorDefinitions>LZMA_API_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;winmm.lib;strmiids.lib;opengl32.lib;comsuppw.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>d3d11.dll;dxgi.dll;opengl32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>d3dcompiler.lib;d3d11.lib;dxgi.lib;dxguid.lib;winmm.lib;strmiids.lib;opengl32.lib;comsuppw.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>d3dcompiler_47.dll;d3d11.dll;dxgi.dll;opengl32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>


### PR DESCRIPTION
Further cleanup following #3508 