### PR TITLE
Allocate memory in an x86-64-compatible way

### DIFF
--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -25,6 +25,7 @@
 // [TODO] OS-X (Darwin) platforms should use the Mach exception model (not implemented)
 
 #include "EventSource.h"
+#include <atomic>
 
 struct PageFaultInfo
 {
@@ -123,6 +124,63 @@ protected:
 
 
 // --------------------------------------------------------------------------------------
+//  VirtualMemoryManager: Manages the allocation of PCSX2 VM
+//    Ensures that all memory is close enough together for rip-relative addressing
+// --------------------------------------------------------------------------------------
+class VirtualMemoryManager
+{
+    DeclareNoncopyableObject(VirtualMemoryManager);
+
+    wxString m_name;
+
+    uptr m_baseptr;
+
+    // An array to track page usage (to trigger asserts if things try to overlap)
+    std::atomic<bool> *m_pageuse;
+
+    // reserved memory (in pages)
+    u32 m_pages_reserved;
+
+public:
+    // If upper_bounds is nonzero and the OS fails to allocate memory that is below it,
+    // calls to IsOk() will return false and Alloc() will always return null pointers
+    VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds = 0);
+    ~VirtualMemoryManager();
+
+    void *GetBase() const { return (void *)m_baseptr; }
+
+    // Request the use of the memory at offsetLocation bytes from the start of the reserved memory area
+    // offsetLocation must be page-aligned
+    void *Alloc(uptr offsetLocation, size_t size) const;
+
+    void *AllocAtAddress(void *address, size_t size) const {
+        return Alloc(size, (uptr)address - m_baseptr);
+    }
+
+    void Free(void *address, size_t size) const;
+
+    // Was this VirtualMemoryManager successfully able to get its memory mapping?
+    // (If not, calls to Alloc will return null pointers)
+    bool IsOk() const { return m_baseptr != 0; }
+};
+
+typedef std::shared_ptr<const VirtualMemoryManager> VirtualMemoryManagerPtr;
+
+// --------------------------------------------------------------------------------------
+//  VirtualMemoryBumpAllocator: Allocates memory for things that don't have explicitly-reserved spots
+// --------------------------------------------------------------------------------------
+class VirtualMemoryBumpAllocator
+{
+    const VirtualMemoryManagerPtr m_allocator;
+    std::atomic<uptr> m_baseptr{0};
+    const uptr m_endptr = 0;
+public:
+    VirtualMemoryBumpAllocator(VirtualMemoryManagerPtr allocator, size_t size, uptr offsetLocation);
+    void *Alloc(size_t size);
+    const VirtualMemoryManagerPtr& GetAllocator() { return m_allocator; }
+};
+
+// --------------------------------------------------------------------------------------
 //  VirtualMemoryReserve
 // --------------------------------------------------------------------------------------
 class VirtualMemoryReserve
@@ -131,6 +189,9 @@ class VirtualMemoryReserve
 
 protected:
     wxString m_name;
+
+    // Where the memory came from (so we can return it)
+    VirtualMemoryManagerPtr m_allocator;
 
     // Default size of the reserve, in bytes.  Can be specified when the object is constructed.
     // Is used as the reserve size when Reserve() is called, unless an override is specified
@@ -155,17 +216,32 @@ protected:
     // as well.
     bool m_allow_writes;
 
+    // Allows the implementation to decide how much memory it needs to allocate if someone requests the given size
+    // Should translate requests of size 0 to m_defsize
+    virtual size_t GetSize(size_t requestedSize);
+
 public:
-    VirtualMemoryReserve(const wxString &name = wxEmptyString, size_t size = 0);
+    VirtualMemoryReserve(const wxString &name, size_t size = 0);
     virtual ~VirtualMemoryReserve()
     {
         Release();
     }
 
-    virtual void *Reserve(size_t size = 0, uptr base = 0, uptr upper_bounds = 0);
-    virtual void *ReserveAt(uptr base = 0, uptr upper_bounds = 0)
+    // Initialize with the given piece of memory
+    // Note: The memory is already allocated, the allocator is for future use to free the region
+    // It may be null in which case there is no way to free the memory in a way it will be usable again
+    virtual void *Assign(VirtualMemoryManagerPtr allocator, void *baseptr, size_t size);
+
+    void *Reserve(VirtualMemoryManagerPtr allocator, uptr baseOffset, size_t size = 0)
     {
-        return Reserve(m_defsize, base, upper_bounds);
+        size = GetSize(size);
+        void *allocation = allocator->Alloc(baseOffset, size);
+        return Assign(std::move(allocator), allocation, size);
+    }
+    void *Reserve(VirtualMemoryBumpAllocator& allocator, size_t size = 0)
+    {
+        size = GetSize(size);
+        return Assign(allocator.GetAllocator(), allocator.Alloc(size), size);
     }
 
     virtual void Reset();
@@ -177,7 +253,7 @@ public:
     virtual void AllowModification();
 
     bool IsOk() const { return m_baseptr != NULL; }
-    wxString GetName() const { return m_name; }
+    const wxString& GetName() const { return m_name; }
 
     uptr GetReserveSizeInBytes() const { return m_pages_reserved * __pagesize; }
     uptr GetReserveSizeInPages() const { return m_pages_reserved; }
@@ -189,8 +265,6 @@ public:
     u8 *GetPtrEnd() { return (u8 *)m_baseptr + (m_pages_reserved * __pagesize); }
     const u8 *GetPtrEnd() const { return (u8 *)m_baseptr + (m_pages_reserved * __pagesize); }
 
-    VirtualMemoryReserve &SetName(const wxString &newname);
-    VirtualMemoryReserve &SetBaseAddr(uptr newaddr);
     VirtualMemoryReserve &SetPageAccessOnCommit(const PageProtectionMode &mode);
 
     operator void *() { return m_baseptr; }

--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -122,62 +122,16 @@ protected:
     virtual void _DispatchRaw(ListenerIterator iter, const ListenerIterator &iend, const PageFaultInfo &evt);
 };
 
-
-// --------------------------------------------------------------------------------------
-//  VirtualMemoryManager: Manages the allocation of PCSX2 VM
-//    Ensures that all memory is close enough together for rip-relative addressing
-// --------------------------------------------------------------------------------------
-class VirtualMemoryManager
-{
-    DeclareNoncopyableObject(VirtualMemoryManager);
-
-    wxString m_name;
-
-    uptr m_baseptr;
-
-    // An array to track page usage (to trigger asserts if things try to overlap)
-    std::atomic<bool> *m_pageuse;
-
-    // reserved memory (in pages)
-    u32 m_pages_reserved;
-
-public:
-    // If upper_bounds is nonzero and the OS fails to allocate memory that is below it,
-    // calls to IsOk() will return false and Alloc() will always return null pointers
-    VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds = 0);
-    ~VirtualMemoryManager();
-
-    void *GetBase() const { return (void *)m_baseptr; }
-
-    // Request the use of the memory at offsetLocation bytes from the start of the reserved memory area
-    // offsetLocation must be page-aligned
-    void *Alloc(uptr offsetLocation, size_t size) const;
-
-    void *AllocAtAddress(void *address, size_t size) const {
-        return Alloc(size, (uptr)address - m_baseptr);
-    }
-
-    void Free(void *address, size_t size) const;
-
-    // Was this VirtualMemoryManager successfully able to get its memory mapping?
-    // (If not, calls to Alloc will return null pointers)
-    bool IsOk() const { return m_baseptr != 0; }
-};
-
-typedef std::shared_ptr<const VirtualMemoryManager> VirtualMemoryManagerPtr;
-
 // --------------------------------------------------------------------------------------
 //  VirtualMemoryBumpAllocator: Allocates memory for things that don't have explicitly-reserved spots
 // --------------------------------------------------------------------------------------
 class VirtualMemoryBumpAllocator
 {
-    const VirtualMemoryManagerPtr m_allocator;
     std::atomic<uptr> m_baseptr{0};
     const uptr m_endptr = 0;
 public:
-    VirtualMemoryBumpAllocator(VirtualMemoryManagerPtr allocator, size_t size, uptr offsetLocation);
+    VirtualMemoryBumpAllocator(void *mem, size_t size);
     void *Alloc(size_t size);
-    const VirtualMemoryManagerPtr& GetAllocator() { return m_allocator; }
 };
 
 // --------------------------------------------------------------------------------------
@@ -189,9 +143,6 @@ class VirtualMemoryReserve
 
 protected:
     wxString m_name;
-
-    // Where the memory came from (so we can return it)
-    VirtualMemoryManagerPtr m_allocator;
 
     // Default size of the reserve, in bytes.  Can be specified when the object is constructed.
     // Is used as the reserve size when Reserve() is called, unless an override is specified
@@ -216,43 +167,28 @@ protected:
     // as well.
     bool m_allow_writes;
 
-    // Allows the implementation to decide how much memory it needs to allocate if someone requests the given size
-    // Should translate requests of size 0 to m_defsize
-    virtual size_t GetSize(size_t requestedSize);
-
 public:
     VirtualMemoryReserve(const wxString &name, size_t size = 0);
     virtual ~VirtualMemoryReserve()
     {
-        Release();
+        Reset();
     }
 
-    // Initialize with the given piece of memory
-    // Note: The memory is already allocated, the allocator is for future use to free the region
-    // It may be null in which case there is no way to free the memory in a way it will be usable again
-    virtual void *Assign(VirtualMemoryManagerPtr allocator, void *baseptr, size_t size);
+    // Initialize with the given piece of (reserved but not committed) memory
+    virtual void *Assign(void *baseptr, size_t size);
 
-    void *Reserve(VirtualMemoryManagerPtr allocator, uptr baseOffset, size_t size = 0)
-    {
-        size = GetSize(size);
-        void *allocation = allocator->Alloc(baseOffset, size);
-        return Assign(std::move(allocator), allocation, size);
-    }
     void *Reserve(VirtualMemoryBumpAllocator& allocator, size_t size = 0)
     {
-        size = GetSize(size);
-        return Assign(allocator.GetAllocator(), allocator.Alloc(size), size);
+        size = size == 0 ? m_defsize : size;
+        return Assign(allocator.Alloc(size), size);
     }
 
     virtual void Reset();
-    virtual void Release();
-    virtual bool TryResize(uint newsize);
     virtual bool Commit();
 
     virtual void ForbidModification();
     virtual void AllowModification();
 
-    bool IsOk() const { return m_baseptr != NULL; }
     const wxString& GetName() const { return m_name; }
 
     uptr GetReserveSizeInBytes() const { return m_pages_reserved * __pagesize; }

--- a/common/include/Utilities/PageFaultSource.h
+++ b/common/include/Utilities/PageFaultSource.h
@@ -144,7 +144,8 @@ class VirtualMemoryManager
 public:
     // If upper_bounds is nonzero and the OS fails to allocate memory that is below it,
     // calls to IsOk() will return false and Alloc() will always return null pointers
-    VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds = 0);
+    // strict indicates that the allocation should quietly fail if the memory can't be mapped at `base`
+    VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds = 0, bool strict = false);
     ~VirtualMemoryManager();
 
     void *GetBase() const { return (void *)m_baseptr; }

--- a/common/src/Utilities/VirtualMemory.cpp
+++ b/common/src/Utilities/VirtualMemory.cpp
@@ -76,7 +76,7 @@ static size_t pageAlign(size_t size)
 //  VirtualMemoryManager  (implementations)
 // --------------------------------------------------------------------------------------
 
-VirtualMemoryManager::VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds)
+VirtualMemoryManager::VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds, bool strict)
     : m_name(name), m_baseptr(0), m_pageuse(nullptr), m_pages_reserved(0)
 {
     if (!size) return;
@@ -99,7 +99,12 @@ VirtualMemoryManager::VirtualMemoryManager(const wxString &name, uptr base, size
         }
     }
 
-    if ((upper_bounds != 0) && ((m_baseptr + reserved_bytes) > upper_bounds)) {
+    bool fulfillsRequirements = true;
+    if (strict && m_baseptr != base)
+        fulfillsRequirements = false;
+    if ((upper_bounds != 0) && ((m_baseptr + reserved_bytes) > upper_bounds))
+        fulfillsRequirements = false;
+    if (!fulfillsRequirements) {
         SafeSysMunmap(m_baseptr, reserved_bytes);
     }
 

--- a/common/src/Utilities/VirtualMemory.cpp
+++ b/common/src/Utilities/VirtualMemory.cpp
@@ -67,68 +67,24 @@ void SrcType_PageFault::_DispatchRaw(ListenerIterator iter, const ListenerIterat
     } while ((++iter != iend) && !m_handled);
 }
 
+static size_t pageAlign(size_t size)
+{
+    return (size + __pagesize - 1) / __pagesize * __pagesize;
+}
+
 // --------------------------------------------------------------------------------------
-//  VirtualMemoryReserve  (implementations)
+//  VirtualMemoryManager  (implementations)
 // --------------------------------------------------------------------------------------
-VirtualMemoryReserve::VirtualMemoryReserve(const wxString &name, size_t size)
-    : m_name(name)
+
+VirtualMemoryManager::VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds)
+    : m_name(name), m_baseptr(0), m_pageuse(nullptr), m_pages_reserved(0)
 {
-    m_defsize = size;
+    if (!size) return;
 
-    m_pages_commited = 0;
-    m_pages_reserved = 0;
-    m_baseptr = NULL;
-    m_prot_mode = PageAccess_None();
-    m_allow_writes = true;
-}
+    uptr reserved_bytes = pageAlign(size);
+    m_pages_reserved = reserved_bytes / __pagesize;
 
-VirtualMemoryReserve &VirtualMemoryReserve::SetName(const wxString &newname)
-{
-    m_name = newname;
-    return *this;
-}
-
-VirtualMemoryReserve &VirtualMemoryReserve::SetBaseAddr(uptr newaddr)
-{
-    if (!pxAssertDev(!m_pages_reserved, "Invalid object state: you must release the virtual memory reserve prior to changing its base address!"))
-        return *this;
-
-    m_baseptr = (void *)newaddr;
-    return *this;
-}
-
-VirtualMemoryReserve &VirtualMemoryReserve::SetPageAccessOnCommit(const PageProtectionMode &mode)
-{
-    m_prot_mode = mode;
-    return *this;
-}
-
-// Notes:
-//  * This method should be called if the object is already in an released (unreserved) state.
-//    Subsequent calls will be ignored, and the existing reserve will be returned.
-//
-// Parameters:
-//   size - size of the reserve, in bytes. (optional)
-//     If not specified (or zero), then the default size specified in the constructor for the
-//     object instance is used.
-//
-//   upper_bounds - criteria that must be met for the allocation to be valid.
-//     If the OS refuses to allocate the memory below the specified address, the
-//     object will fail to initialize and an exception will be thrown.
-void *VirtualMemoryReserve::Reserve(size_t size, uptr base, uptr upper_bounds)
-{
-    if (!pxAssertDev(m_baseptr == NULL, "(VirtualMemoryReserve) Invalid object state; object has already been reserved."))
-        return m_baseptr;
-
-    if (!size)
-        size = m_defsize;
-    if (!size)
-        return NULL;
-
-    m_pages_reserved = (size + __pagesize - 4) / __pagesize;
-    uptr reserved_bytes = m_pages_reserved * __pagesize;
-
-    m_baseptr = (void *)HostSys::MmapReserve(base, reserved_bytes);
+    m_baseptr = (uptr)HostSys::MmapReserve(base, reserved_bytes);
 
     if (!m_baseptr || (upper_bounds != 0 && (((uptr)m_baseptr + reserved_bytes) > upper_bounds))) {
         DevCon.Warning(L"%s: host memory @ %ls -> %ls is unavailable; attempting to map elsewhere...",
@@ -139,17 +95,171 @@ void *VirtualMemoryReserve::Reserve(size_t size, uptr base, uptr upper_bounds)
         if (base) {
             // Let's try again at an OS-picked memory area, and then hope it meets needed
             // boundschecking criteria below.
-            m_baseptr = HostSys::MmapReserve(0, reserved_bytes);
+            m_baseptr = (uptr)HostSys::MmapReserve(0, reserved_bytes);
         }
     }
 
-    if ((upper_bounds != 0) && (((uptr)m_baseptr + reserved_bytes) > upper_bounds)) {
+    if ((upper_bounds != 0) && ((m_baseptr + reserved_bytes) > upper_bounds)) {
         SafeSysMunmap(m_baseptr, reserved_bytes);
-        // returns null, caller should throw an exception or handle appropriately.
     }
 
+    if (!m_baseptr) return;
+
+    m_pageuse = new std::atomic<bool>[m_pages_reserved]();
+
+    FastFormatUnicode mbkb;
+    uint mbytes = reserved_bytes / _1mb;
+    if (mbytes)
+        mbkb.Write("[%umb]", mbytes);
+    else
+        mbkb.Write("[%ukb]", reserved_bytes / 1024);
+
+    DevCon.WriteLn(Color_Gray, L"%-32s @ %ls -> %ls %ls", WX_STR(m_name),
+                   pxsPtr(m_baseptr), pxsPtr((uptr)m_baseptr + reserved_bytes), mbkb.c_str());
+}
+
+VirtualMemoryManager::~VirtualMemoryManager()
+{
+    if (m_pageuse) delete[] m_pageuse;
+    if (m_baseptr) HostSys::Munmap(m_baseptr, m_pages_reserved * __pagesize);
+}
+
+static bool VMMMarkPagesAsInUse(std::atomic<bool> *begin, std::atomic<bool> *end) {
+    for (auto current = begin; current < end; current++) {
+        bool expected = false;
+        if (!current->compare_exchange_strong(expected, true), std::memory_order_relaxed) {
+            // This was already allocated!  Undo the things we've set until this point
+            while (--current >= begin) {
+                if (!current->compare_exchange_strong(expected, false, std::memory_order_relaxed)) {
+                    // In the time we were doing this, someone set one of the things we just set to true back to false
+                    // This should never happen, but if it does we'll just stop and hope nothing bad happens
+                    pxAssert(0);
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+    return true;
+}
+
+void *VirtualMemoryManager::Alloc(uptr offsetLocation, size_t size) const
+{
+    size = pageAlign(size);
+    if (!pxAssertDev(offsetLocation % __pagesize == 0, "(VirtualMemoryManager) alloc at unaligned offsetLocation"))
+        return nullptr;
+    if (!pxAssertDev(size + offsetLocation <= m_pages_reserved * __pagesize, "(VirtualMemoryManager) alloc outside reserved area"))
+        return nullptr;
+    if (m_baseptr == 0)
+        return nullptr;
+    auto puStart = &m_pageuse[offsetLocation / __pagesize];
+    auto puEnd = &m_pageuse[(offsetLocation+size) / __pagesize];
+    if (!pxAssertDev(VMMMarkPagesAsInUse(puStart, puEnd), "(VirtualMemoryManager) allocation requests overlapped"))
+        return nullptr;
+    return (void *)(m_baseptr + offsetLocation);
+}
+
+void VirtualMemoryManager::Free(void *address, size_t size) const
+{
+    uptr offsetLocation = (uptr)address - m_baseptr;
+    if (!pxAssertDev(offsetLocation % __pagesize == 0, "(VirtualMemoryManager) free at unaligned address")) {
+        uptr newLoc = pageAlign(offsetLocation);
+        size -= (offsetLocation - newLoc);
+        offsetLocation = newLoc;
+    }
+    if (!pxAssertDev(size % __pagesize == 0, "(VirtualMemoryManager) free with unaligned size"))
+        size -= size % __pagesize;
+    if (!pxAssertDev(size + offsetLocation <= m_pages_reserved * __pagesize, "(VirtualMemoryManager) free outside reserved area"))
+        return;
+    auto puStart = &m_pageuse[offsetLocation / __pagesize];
+    auto puEnd = &m_pageuse[(offsetLocation+size) / __pagesize];
+    for (; puStart < puEnd; puStart++) {
+        bool expected = true;
+        if (!puStart->compare_exchange_strong(expected, false, std::memory_order_relaxed)) {
+            pxAssertDev(0, "(VirtaulMemoryManager) double-free");
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------
+//  VirtualMemoryBumpAllocator  (implementations)
+// --------------------------------------------------------------------------------------
+VirtualMemoryBumpAllocator::VirtualMemoryBumpAllocator(VirtualMemoryManagerPtr allocator, uptr offsetLocation, size_t size)
+    : m_allocator(std::move(allocator)), m_baseptr((uptr)m_allocator->Alloc(offsetLocation, size)), m_endptr(m_baseptr + size)
+{
+    if (m_baseptr.load() == 0)
+        pxAssertDev(0, "(VirtualMemoryBumpAllocator) tried to construct from bad VirtualMemoryManager");
+}
+
+void *VirtualMemoryBumpAllocator::Alloc(size_t size)
+{
+    if (m_baseptr.load() == 0) // True if constructed from bad VirtualMemoryManager (assertion was on initialization)
+        return nullptr;
+
+    size_t reservedSize = pageAlign(size);
+
+    uptr out = m_baseptr.fetch_add(reservedSize, std::memory_order_relaxed);
+
+    if (!pxAssertDev(out - reservedSize + size <= m_endptr, "(VirtualMemoryBumpAllocator) ran out of memory"))
+        return nullptr;
+
+    return (void *)out;
+}
+
+// --------------------------------------------------------------------------------------
+//  VirtualMemoryReserve  (implementations)
+// --------------------------------------------------------------------------------------
+VirtualMemoryReserve::VirtualMemoryReserve(const wxString &name, size_t size)
+    : m_name(name)
+{
+    m_defsize = size;
+
+    m_allocator = nullptr;
+    m_pages_commited = 0;
+    m_pages_reserved = 0;
+    m_baseptr = nullptr;
+    m_prot_mode = PageAccess_None();
+    m_allow_writes = true;
+}
+
+VirtualMemoryReserve &VirtualMemoryReserve::SetPageAccessOnCommit(const PageProtectionMode &mode)
+{
+    m_prot_mode = mode;
+    return *this;
+}
+
+size_t VirtualMemoryReserve::GetSize(size_t requestedSize)
+{
+    if (!requestedSize)
+        return pageAlign(m_defsize);
+    return pageAlign(requestedSize);
+}
+
+// Notes:
+//  * This method should be called if the object is already in an released (unreserved) state.
+//    Subsequent calls will be ignored, and the existing reserve will be returned.
+//
+// Parameters:
+//   baseptr - the new base pointer that's about to be assigned
+//   size - size of the region pointed to by baseptr
+//
+void *VirtualMemoryReserve::Assign(VirtualMemoryManagerPtr allocator, void * baseptr, size_t size)
+{
+    if (!pxAssertDev(m_baseptr == NULL, "(VirtualMemoryReserve) Invalid object state; object has already been reserved."))
+        return m_baseptr;
+
+    if (!size)
+        return nullptr;
+
+    m_allocator = std::move(allocator);
+
+    m_baseptr = baseptr;
+
+    uptr reserved_bytes = pageAlign(size);
+    m_pages_reserved = reserved_bytes / __pagesize;
+
     if (!m_baseptr)
-        return NULL;
+        return nullptr;
 
     FastFormatUnicode mbkb;
     uint mbytes = reserved_bytes / _1mb;
@@ -184,7 +294,10 @@ void VirtualMemoryReserve::Reset()
 
 void VirtualMemoryReserve::Release()
 {
-    SafeSysMunmap(m_baseptr, m_pages_reserved * __pagesize);
+    if (!m_baseptr) return;
+    Reset();
+    m_allocator->Free(m_baseptr, m_pages_reserved * __pagesize);
+    m_baseptr = nullptr;
 }
 
 bool VirtualMemoryReserve::Commit()
@@ -222,7 +335,7 @@ void VirtualMemoryReserve::ForbidModification()
 //  newsize - new size of the reserved buffer, in bytes.
 bool VirtualMemoryReserve::TryResize(uint newsize)
 {
-    uint newPages = (newsize + __pagesize - 1) / __pagesize;
+    uint newPages = pageAlign(newsize) / __pagesize;
 
     if (newPages > m_pages_reserved) {
         uint toReservePages = newPages - m_pages_reserved;
@@ -230,11 +343,10 @@ bool VirtualMemoryReserve::TryResize(uint newsize)
 
         DevCon.WriteLn(L"%-32s is being expanded by %u pages.", WX_STR(m_name), toReservePages);
 
-        m_baseptr = (void *)HostSys::MmapReserve((uptr)GetPtrEnd(), toReserveBytes);
-
-        if (!m_baseptr) {
-            Console.Warning("%-32s could not be passively resized due to virtual memory conflict!");
+        if (!m_allocator->AllocAtAddress(GetPtrEnd(), toReserveBytes)) {
+            Console.Warning("%-32s could not be passively resized due to virtual memory conflict!", WX_STR(m_name));
             Console.Indent().Warning("(attempted to map memory @ %08p -> %08p)", m_baseptr, (uptr)m_baseptr + toReserveBytes);
+            return false;
         }
 
         DevCon.WriteLn(Color_Gray, L"%-32s @ %08p -> %08p [%umb]", WX_STR(m_name),
@@ -248,12 +360,13 @@ bool VirtualMemoryReserve::TryResize(uint newsize)
 
         DevCon.WriteLn(L"%-32s is being shrunk by %u pages.", WX_STR(m_name), toRemovePages);
 
-        HostSys::MmapResetPtr(GetPtrEnd(), toRemoveBytes);
+        m_allocator->Free(GetPtrEnd() - toRemoveBytes, toRemoveBytes);
 
         DevCon.WriteLn(Color_Gray, L"%-32s @ %08p -> %08p [%umb]", WX_STR(m_name),
-                       m_baseptr, (uptr)m_baseptr + toRemoveBytes, toRemoveBytes / _1mb);
+                       m_baseptr, GetPtrEnd(), GetReserveSizeInBytes() / _1mb);
     }
 
+    m_pages_reserved = newPages;
     return true;
 }
 

--- a/common/src/Utilities/VirtualMemory.cpp
+++ b/common/src/Utilities/VirtualMemory.cpp
@@ -73,10 +73,123 @@ static size_t pageAlign(size_t size)
 }
 
 // --------------------------------------------------------------------------------------
+//  VirtualMemoryManager  (implementations)
+// --------------------------------------------------------------------------------------
+
+VirtualMemoryManager::VirtualMemoryManager(const wxString &name, uptr base, size_t size, uptr upper_bounds)
+    : m_name(name), m_baseptr(0), m_pageuse(nullptr), m_pages_reserved(0)
+{
+    if (!size) return;
+
+    uptr reserved_bytes = pageAlign(size);
+    m_pages_reserved = reserved_bytes / __pagesize;
+
+    m_baseptr = (uptr)HostSys::MmapReserve(base, reserved_bytes);
+
+    if (!m_baseptr || (upper_bounds != 0 && (((uptr)m_baseptr + reserved_bytes) > upper_bounds))) {
+        DevCon.Warning(L"%s: host memory @ %ls -> %ls is unavailable; attempting to map elsewhere...",
+                       WX_STR(m_name), pxsPtr(base), pxsPtr(base + size));
+
+        SafeSysMunmap(m_baseptr, reserved_bytes);
+
+        if (base) {
+            // Let's try again at an OS-picked memory area, and then hope it meets needed
+            // boundschecking criteria below.
+            m_baseptr = (uptr)HostSys::MmapReserve(0, reserved_bytes);
+        }
+    }
+
+    if ((upper_bounds != 0) && ((m_baseptr + reserved_bytes) > upper_bounds)) {
+        SafeSysMunmap(m_baseptr, reserved_bytes);
+    }
+
+    if (!m_baseptr) return;
+
+    m_pageuse = new std::atomic<bool>[m_pages_reserved]();
+
+    FastFormatUnicode mbkb;
+    uint mbytes = reserved_bytes / _1mb;
+    if (mbytes)
+        mbkb.Write("[%umb]", mbytes);
+    else
+        mbkb.Write("[%ukb]", reserved_bytes / 1024);
+
+    DevCon.WriteLn(Color_Gray, L"%-32s @ %ls -> %ls %ls", WX_STR(m_name),
+                   pxsPtr(m_baseptr), pxsPtr((uptr)m_baseptr + reserved_bytes), mbkb.c_str());
+}
+
+VirtualMemoryManager::~VirtualMemoryManager()
+{
+    if (m_pageuse) delete[] m_pageuse;
+    if (m_baseptr) HostSys::Munmap(m_baseptr, m_pages_reserved * __pagesize);
+}
+
+static bool VMMMarkPagesAsInUse(std::atomic<bool> *begin, std::atomic<bool> *end) {
+    for (auto current = begin; current < end; current++) {
+        bool expected = false;
+        if (!current->compare_exchange_strong(expected, true), std::memory_order_relaxed) {
+            // This was already allocated!  Undo the things we've set until this point
+            while (--current >= begin) {
+                if (!current->compare_exchange_strong(expected, false, std::memory_order_relaxed)) {
+                    // In the time we were doing this, someone set one of the things we just set to true back to false
+                    // This should never happen, but if it does we'll just stop and hope nothing bad happens
+                    pxAssert(0);
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+    return true;
+}
+
+void *VirtualMemoryManager::Alloc(uptr offsetLocation, size_t size) const
+{
+    size = pageAlign(size);
+    if (!pxAssertDev(offsetLocation % __pagesize == 0, "(VirtualMemoryManager) alloc at unaligned offsetLocation"))
+        return nullptr;
+    if (!pxAssertDev(size + offsetLocation <= m_pages_reserved * __pagesize, "(VirtualMemoryManager) alloc outside reserved area"))
+        return nullptr;
+    if (m_baseptr == 0)
+        return nullptr;
+    auto puStart = &m_pageuse[offsetLocation / __pagesize];
+    auto puEnd = &m_pageuse[(offsetLocation+size) / __pagesize];
+    if (!pxAssertDev(VMMMarkPagesAsInUse(puStart, puEnd), "(VirtualMemoryManager) allocation requests overlapped"))
+        return nullptr;
+    return (void *)(m_baseptr + offsetLocation);
+}
+
+void VirtualMemoryManager::Free(void *address, size_t size) const
+{
+    uptr offsetLocation = (uptr)address - m_baseptr;
+    if (!pxAssertDev(offsetLocation % __pagesize == 0, "(VirtualMemoryManager) free at unaligned address")) {
+        uptr newLoc = pageAlign(offsetLocation);
+        size -= (offsetLocation - newLoc);
+        offsetLocation = newLoc;
+    }
+    if (!pxAssertDev(size % __pagesize == 0, "(VirtualMemoryManager) free with unaligned size"))
+        size -= size % __pagesize;
+    if (!pxAssertDev(size + offsetLocation <= m_pages_reserved * __pagesize, "(VirtualMemoryManager) free outside reserved area"))
+        return;
+    auto puStart = &m_pageuse[offsetLocation / __pagesize];
+    auto puEnd = &m_pageuse[(offsetLocation+size) / __pagesize];
+    for (; puStart < puEnd; puStart++) {
+        bool expected = true;
+        if (!puStart->compare_exchange_strong(expected, false, std::memory_order_relaxed)) {
+            pxAssertDev(0, "(VirtaulMemoryManager) double-free");
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------
 //  VirtualMemoryBumpAllocator  (implementations)
 // --------------------------------------------------------------------------------------
-VirtualMemoryBumpAllocator::VirtualMemoryBumpAllocator(void *mem, size_t size)
-    : m_baseptr((uptr)mem), m_endptr(m_baseptr + size) {}
+VirtualMemoryBumpAllocator::VirtualMemoryBumpAllocator(VirtualMemoryManagerPtr allocator, uptr offsetLocation, size_t size)
+    : m_allocator(std::move(allocator)), m_baseptr((uptr)m_allocator->Alloc(offsetLocation, size)), m_endptr(m_baseptr + size)
+{
+    if (m_baseptr.load() == 0)
+        pxAssertDev(0, "(VirtualMemoryBumpAllocator) tried to construct from bad VirtualMemoryManager");
+}
 
 void *VirtualMemoryBumpAllocator::Alloc(size_t size)
 {
@@ -101,6 +214,7 @@ VirtualMemoryReserve::VirtualMemoryReserve(const wxString &name, size_t size)
 {
     m_defsize = size;
 
+    m_allocator = nullptr;
     m_pages_commited = 0;
     m_pages_reserved = 0;
     m_baseptr = nullptr;
@@ -114,6 +228,13 @@ VirtualMemoryReserve &VirtualMemoryReserve::SetPageAccessOnCommit(const PageProt
     return *this;
 }
 
+size_t VirtualMemoryReserve::GetSize(size_t requestedSize)
+{
+    if (!requestedSize)
+        return pageAlign(m_defsize);
+    return pageAlign(requestedSize);
+}
+
 // Notes:
 //  * This method should be called if the object is already in an released (unreserved) state.
 //    Subsequent calls will be ignored, and the existing reserve will be returned.
@@ -122,13 +243,15 @@ VirtualMemoryReserve &VirtualMemoryReserve::SetPageAccessOnCommit(const PageProt
 //   baseptr - the new base pointer that's about to be assigned
 //   size - size of the region pointed to by baseptr
 //
-void *VirtualMemoryReserve::Assign(void * baseptr, size_t size)
+void *VirtualMemoryReserve::Assign(VirtualMemoryManagerPtr allocator, void * baseptr, size_t size)
 {
     if (!pxAssertDev(m_baseptr == NULL, "(VirtualMemoryReserve) Invalid object state; object has already been reserved."))
         return m_baseptr;
 
     if (!size)
         return nullptr;
+
+    m_allocator = std::move(allocator);
 
     m_baseptr = baseptr;
 
@@ -169,6 +292,14 @@ void VirtualMemoryReserve::Reset()
     m_pages_commited = 0;
 }
 
+void VirtualMemoryReserve::Release()
+{
+    if (!m_baseptr) return;
+    Reset();
+    m_allocator->Free(m_baseptr, m_pages_reserved * __pagesize);
+    m_baseptr = nullptr;
+}
+
 bool VirtualMemoryReserve::Commit()
 {
     if (!m_pages_reserved)
@@ -176,9 +307,8 @@ bool VirtualMemoryReserve::Commit()
     if (!pxAssert(!m_pages_commited))
         return true;
 
-    bool ok = HostSys::MmapCommitPtr(m_baseptr, m_pages_reserved * __pagesize, m_prot_mode);
-    if (ok) { m_pages_commited = m_pages_reserved; }
-    return ok;
+    m_pages_commited = m_pages_reserved;
+    return HostSys::MmapCommitPtr(m_baseptr, m_pages_reserved * __pagesize, m_prot_mode);
 }
 
 void VirtualMemoryReserve::AllowModification()
@@ -191,6 +321,53 @@ void VirtualMemoryReserve::ForbidModification()
 {
     m_allow_writes = false;
     HostSys::MemProtect(m_baseptr, m_pages_commited * __pagesize, PageProtectionMode(m_prot_mode).Write(false));
+}
+
+
+// If growing the array, or if shrinking the array to some point that's still *greater* than the
+// committed memory range, then attempt a passive "on-the-fly" resize that maps/unmaps some portion
+// of the reserve.
+//
+// If the above conditions are not met, or if the map/unmap fails, this method returns false.
+// The caller will be responsible for manually resetting the reserve.
+//
+// Parameters:
+//  newsize - new size of the reserved buffer, in bytes.
+bool VirtualMemoryReserve::TryResize(uint newsize)
+{
+    uint newPages = pageAlign(newsize) / __pagesize;
+
+    if (newPages > m_pages_reserved) {
+        uint toReservePages = newPages - m_pages_reserved;
+        uint toReserveBytes = toReservePages * __pagesize;
+
+        DevCon.WriteLn(L"%-32s is being expanded by %u pages.", WX_STR(m_name), toReservePages);
+
+        if (!m_allocator->AllocAtAddress(GetPtrEnd(), toReserveBytes)) {
+            Console.Warning("%-32s could not be passively resized due to virtual memory conflict!", WX_STR(m_name));
+            Console.Indent().Warning("(attempted to map memory @ %08p -> %08p)", m_baseptr, (uptr)m_baseptr + toReserveBytes);
+            return false;
+        }
+
+        DevCon.WriteLn(Color_Gray, L"%-32s @ %08p -> %08p [%umb]", WX_STR(m_name),
+                       m_baseptr, (uptr)m_baseptr + toReserveBytes, toReserveBytes / _1mb);
+    } else if (newPages < m_pages_reserved) {
+        if (m_pages_commited > newsize)
+            return false;
+
+        uint toRemovePages = m_pages_reserved - newPages;
+        uint toRemoveBytes = toRemovePages * __pagesize;
+
+        DevCon.WriteLn(L"%-32s is being shrunk by %u pages.", WX_STR(m_name), toRemovePages);
+
+        m_allocator->Free(GetPtrEnd() - toRemoveBytes, toRemoveBytes);
+
+        DevCon.WriteLn(Color_Gray, L"%-32s @ %08p -> %08p [%umb]", WX_STR(m_name),
+                       m_baseptr, GetPtrEnd(), GetReserveSizeInBytes() / _1mb);
+    }
+
+    m_pages_reserved = newPages;
+    return true;
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -29,14 +29,12 @@ __pagealigned u8 iopHw[Ps2MemSize::IopHardware];
 //  iopMemoryReserve
 // --------------------------------------------------------------------------------------
 iopMemoryReserve::iopMemoryReserve()
-	: _parent( L"IOP Main Memory (2mb)", sizeof(*iopMem) )
+	: _parent( L"IOP Main Memory (2mb)")
 {
 }
 
-void iopMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
-{
-	_parent::Reserve(std::move(allocator), HostMemoryMap::IOPmemOffset);
-	//_parent::Reserve(EmuConfig.HostMap.IOP);
+bool iopMemoryReserve::IsSizeOK(size_t size) {
+	return size >= sizeof(*iopMem);
 }
 
 void iopMemoryReserve::Commit()

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -29,12 +29,14 @@ __pagealigned u8 iopHw[Ps2MemSize::IopHardware];
 //  iopMemoryReserve
 // --------------------------------------------------------------------------------------
 iopMemoryReserve::iopMemoryReserve()
-	: _parent( L"IOP Main Memory (2mb)")
+	: _parent( L"IOP Main Memory (2mb)", sizeof(*iopMem) )
 {
 }
 
-bool iopMemoryReserve::IsSizeOK(size_t size) {
-	return size >= sizeof(*iopMem);
+void iopMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
+{
+	_parent::Reserve(std::move(allocator), HostMemoryMap::IOPmemOffset);
+	//_parent::Reserve(EmuConfig.HostMap.IOP);
 }
 
 void iopMemoryReserve::Commit()

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -33,9 +33,9 @@ iopMemoryReserve::iopMemoryReserve()
 {
 }
 
-void iopMemoryReserve::Reserve()
+void iopMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
 {
-	_parent::Reserve(HostMemoryMap::IOPmem);
+	_parent::Reserve(std::move(allocator), HostMemoryMap::IOPmemOffset);
 	//_parent::Reserve(EmuConfig.HostMap.IOP);
 }
 
@@ -111,12 +111,6 @@ void iopMemoryReserve::Decommit()
 
 	safe_aligned_free(psxMemWLUT);
 	psxMemRLUT = NULL;
-	iopMem = NULL;
-}
-
-void iopMemoryReserve::Release()
-{
-	_parent::Release();
 	iopMem = NULL;
 }
 

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -709,9 +709,9 @@ eeMemoryReserve::eeMemoryReserve()
 {
 }
 
-void eeMemoryReserve::Reserve()
+void eeMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
 {
-	_parent::Reserve(HostMemoryMap::EEmem);
+	_parent::Reserve(std::move(allocator), HostMemoryMap::EEmemOffset);
 	//_parent::Reserve(EmuConfig.HostMap.IOP);
 }
 
@@ -856,11 +856,9 @@ void eeMemoryReserve::Decommit()
 	eeMem = NULL;
 }
 
-void eeMemoryReserve::Release()
+eeMemoryReserve::~eeMemoryReserve()
 {
 	safe_delete(mmap_faultHandler);
-	_parent::Release();
-	eeMem = NULL;
 	vtlb_Term();
 }
 

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -705,12 +705,14 @@ void memBindConditionalHandlers()
 //  eeMemoryReserve  (implementations)
 // --------------------------------------------------------------------------------------
 eeMemoryReserve::eeMemoryReserve()
-	: _parent( L"EE Main Memory" )
+	: _parent( L"EE Main Memory", sizeof(*eeMem) )
 {
 }
 
-bool eeMemoryReserve::IsSizeOK(size_t size) {
-	return size >= sizeof(*eeMem);
+void eeMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
+{
+	_parent::Reserve(std::move(allocator), HostMemoryMap::EEmemOffset);
+	//_parent::Reserve(EmuConfig.HostMap.IOP);
 }
 
 void eeMemoryReserve::Commit()

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -705,14 +705,12 @@ void memBindConditionalHandlers()
 //  eeMemoryReserve  (implementations)
 // --------------------------------------------------------------------------------------
 eeMemoryReserve::eeMemoryReserve()
-	: _parent( L"EE Main Memory", sizeof(*eeMem) )
+	: _parent( L"EE Main Memory" )
 {
 }
 
-void eeMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
-{
-	_parent::Reserve(std::move(allocator), HostMemoryMap::EEmemOffset);
-	//_parent::Reserve(EmuConfig.HostMap.IOP);
+bool eeMemoryReserve::IsSizeOK(size_t size) {
+	return size >= sizeof(*eeMem);
 }
 
 void eeMemoryReserve::Commit()

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -390,11 +390,38 @@ namespace HostMemoryMap {
 	uptr EEmem, IOPmem, VUmem, EErec, IOPrec, VIF0rec, VIF1rec, mVU0rec, mVU1rec, bumpAllocator;
 }
 
+/// Attempts to find a spot near static variables for the main memory
+static VirtualMemoryManagerPtr makeMainMemoryManager() {
+	// Everything looks nicer when the start of all the sections is a nice round looking number.
+	// Also reduces the variation in the address due to small changes in code.
+	// Breaks ASLR but so does anything else that tries to make addresses constant for our debugging pleasure
+	uptr codeBase = (uptr)(void*)makeMainMemoryManager / (1 << 28) * (1 << 28);
+
+	// The allocation is ~640mb in size, slighly under 3*2^28.
+	// We'll hope that the code generated for the PCSX2 executable stays under 512mb (which is likely)
+	// On x86-64, code can reach 8*2^28 from its address [-6*2^28, 4*2^28] is the region that allows for code in the 640mb allocation to reach 512mb of code that either starts at codeBase or 256mb before it.
+	// We start high and count down because on macOS code starts at the beginning of useable address space, so starting as far ahead as possible reduces address variations due to code size.  Not sure about other platforms.  Obviously this only actually affects what shows up in a debugger and won't affect performance or correctness of anything.
+	for (int offset = 4; offset >= -6; offset--) {
+		uptr base = codeBase + (offset << 28);
+		auto mgr = std::make_shared<VirtualMemoryManager>("Main Memory Manager", base, HostMemoryMap::Size, /*upper_bounds=*/0, /*strict=*/true);
+		if (mgr->IsOk()) {
+			return mgr;
+		}
+	}
+
+	// If the above failed and it's x86-64, recompiled code is going to break!
+	// If it's i386 anything can reach anything so it doesn't matter
+	if (sizeof(void*) == 8) {
+		pxAssertRel(0, "Failed to find a good place for the main memory allocation, recompilers may fail");
+	}
+	return std::make_shared<VirtualMemoryManager>("Main Memory Manager", 0, HostMemoryMap::Size);
+}
+
 // --------------------------------------------------------------------------------------
 //  SysReserveVM  (implementations)
 // --------------------------------------------------------------------------------------
 SysMainMemory::SysMainMemory()
-	: m_mainMemory(std::make_shared<VirtualMemoryManager>("Main Memory Manager", 0x140000000, HostMemoryMap::Size))
+	: m_mainMemory(makeMainMemoryManager())
 	, m_bumpAllocator(m_mainMemory, HostMemoryMap::bumpAllocatorOffset, HostMemoryMap::Size - HostMemoryMap::bumpAllocatorOffset)
 {
 	uptr base = (uptr)MainMemory()->GetBase();

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -369,6 +369,10 @@ static VirtualMemoryManagerPtr makeMainMemoryManager() {
 	// We start high and count down because on macOS code starts at the beginning of useable address space, so starting as far ahead as possible reduces address variations due to code size.  Not sure about other platforms.  Obviously this only actually affects what shows up in a debugger and won't affect performance or correctness of anything.
 	for (int offset = 4; offset >= -6; offset--) {
 		uptr base = codeBase + (offset << 28);
+		if ((sptr)base < 0 || (sptr)(base + HostMemoryMap::Size - 1) < 0) {
+			// VTLB will throw a fit if we try to put EE main memory here
+			continue;
+		}
 		auto mgr = std::make_shared<VirtualMemoryManager>("Main Memory Manager", base, HostMemoryMap::Size, /*upper_bounds=*/0, /*strict=*/true);
 		if (mgr->IsOk()) {
 			return mgr;

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -57,15 +57,15 @@ void RecompiledCodeReserve::_termProfiler()
 {
 }
 
-void* RecompiledCodeReserve::Assign( VirtualMemoryManagerPtr allocator, void *baseptr, size_t size )
+void* RecompiledCodeReserve::Assign( void *baseptr, size_t size )
 {
-	if (!_parent::Assign(std::move(allocator), baseptr, size)) return NULL;
+	if (!_parent::Assign(baseptr, size)) return NULL;
 
 	Commit();
 
 	_registerProfiler();
 
-	return m_baseptr;
+	return IsOk() ? m_baseptr : nullptr;
 }
 
 void RecompiledCodeReserve::Reset()
@@ -101,6 +101,10 @@ RecompiledCodeReserve& RecompiledCodeReserve::SetProfilerName( const wxString& s
 	return *this;
 }
 
+bool RecompiledCodeReserve::IsOk() const {
+	return m_baseptr != nullptr && m_pages_commited == m_pages_reserved;
+}
+
 // This error message is shared by R5900, R3000, and microVU recompilers.
 void RecompiledCodeReserve::ThrowIfNotOk() const
 {
@@ -111,40 +115,6 @@ void RecompiledCodeReserve::ThrowIfNotOk() const
 		.SetUserMsg( pxE( L"This recompiler was unable to reserve contiguous memory required for internal caches.  This error can be caused by low virtual memory resources, such as a small or disabled swapfile, or by another program that is hogging a lot of memory."
 		));
 }
-
-#ifdef __M_X86_64
-static sptr CodegenAccessibleMemory = 0;
-static std::atomic<sptr> CodegenAccessibleMemoryNext{0};
-static sptr CodegenAccessibleMemoryEnd = 0;
-
-void *HostSys::detail::MakeCodegenAccessible(void *ptr, sptr size)
-{
-	// Don't do anything if the pointer is already in codegen-accessible memory
-	if ((sptr)ptr >= CodegenAccessibleMemory && (sptr)ptr < CodegenAccessibleMemoryEnd) {
-		return ptr;
-	}
-
-	if (!CodegenAccessibleMemoryNext.load(std::memory_order_relaxed)) {
-		const sptr sectionsize = __pagesize;
-		auto tmp = (sptr)GetVmMemory().BumpAllocator().Alloc(sectionsize);
-		HostSys::MmapCommit(tmp, sectionsize, PageProtectionMode().Read().Write());
-		sptr expected = 0;
-		if (CodegenAccessibleMemoryNext.compare_exchange_strong(expected, tmp, std::memory_order_relaxed)) {
-			CodegenAccessibleMemory = tmp;
-			CodegenAccessibleMemoryEnd = tmp + sectionsize;
-		} else {
-			HostSys::MmapReset(tmp, sectionsize);
-		}
-	}
-
-	// Align to 32 bytes
-	void *ret = (void *)CodegenAccessibleMemoryNext.fetch_add(size + 0x1f & ~0x1f, std::memory_order_relaxed);
-	pxAssertDev((sptr)ret + size < CodegenAccessibleMemoryEnd,
-		"Ran out of space for codegen accessible memory, need to increase size");
-	memcpy(ret, ptr, size);
-	return ret;
-}
-#endif
 
 void SysOutOfMemory_EmergencyResponse(uptr blocksize)
 {
@@ -385,29 +355,39 @@ static wxString GetMemoryErrorVM()
 	);
 }
 
-namespace HostMemoryMap {
-	// For debuggers
-	uptr EEmem, IOPmem, VUmem, EErec, IOPrec, VIF0rec, VIF1rec, mVU0rec, mVU1rec, bumpAllocator;
+__pagealigned EEVM_MemoryAllocMess HostMemoryMap::EEmem;
+__pagealigned u8 HostMemoryMap::IOPmem[(sizeof(IopVM_MemoryAllocMess) + __pagesize - 1) & -__pagesize];
+__pagealigned u8 HostMemoryMap::VUmem[_64kb];
+__pagealigned u8 HostMemoryMap::EErec[_64mb];
+__pagealigned u8 HostMemoryMap::IOPrec[_32mb];
+__pagealigned u8 HostMemoryMap::VIF0rec[_8mb];
+__pagealigned u8 HostMemoryMap::VIF1rec[_8mb];
+__pagealigned u8 HostMemoryMap::mVU0rec[_64mb];
+__pagealigned u8 HostMemoryMap::mVU1rec[_64mb];
+__pagealigned u8 HostMemoryMap::bumpAllocator[_64mb];
+
+template <typename T>
+static void DecommitBSS(T& t) {
+	static_assert(sizeof(T) % __pagesize == 0, "Size must be page-aligned");
+	HostSys::MmapResetPtr((void*)&t, sizeof(T));
 }
 
 // --------------------------------------------------------------------------------------
 //  SysReserveVM  (implementations)
 // --------------------------------------------------------------------------------------
 SysMainMemory::SysMainMemory()
-	: m_mainMemory(std::make_shared<VirtualMemoryManager>("Main Memory Manager", HostMemoryMap::Base, HostMemoryMap::Size))
-	, m_bumpAllocator(m_mainMemory, HostMemoryMap::bumpAllocatorOffset, HostMemoryMap::Size - HostMemoryMap::bumpAllocatorOffset)
+	: m_bumpAllocator((void*)HostMemoryMap::bumpAllocator, sizeof(HostMemoryMap::bumpAllocator))
 {
-	uptr base = (uptr)MainMemory()->GetBase();
-	HostMemoryMap::EEmem   = base + HostMemoryMap::EEmemOffset;
-	HostMemoryMap::IOPmem  = base + HostMemoryMap::IOPmemOffset;
-	HostMemoryMap::VUmem   = base + HostMemoryMap::VUmemOffset;
-	HostMemoryMap::EErec   = base + HostMemoryMap::EErecOffset;
-	HostMemoryMap::IOPrec  = base + HostMemoryMap::IOPrecOffset;
-	HostMemoryMap::VIF0rec = base + HostMemoryMap::VIF0recOffset;
-	HostMemoryMap::VIF1rec = base + HostMemoryMap::VIF1recOffset;
-	HostMemoryMap::mVU0rec = base + HostMemoryMap::mVU0recOffset;
-	HostMemoryMap::mVU1rec = base + HostMemoryMap::mVU1recOffset;
-	HostMemoryMap::bumpAllocator = base + HostMemoryMap::bumpAllocatorOffset;
+	DecommitBSS(HostMemoryMap::EEmem);
+	DecommitBSS(HostMemoryMap::IOPmem);
+	DecommitBSS(HostMemoryMap::VUmem);
+	DecommitBSS(HostMemoryMap::EErec);
+	DecommitBSS(HostMemoryMap::IOPrec);
+	DecommitBSS(HostMemoryMap::VIF0rec);
+	DecommitBSS(HostMemoryMap::VIF1rec);
+	DecommitBSS(HostMemoryMap::mVU0rec);
+	DecommitBSS(HostMemoryMap::mVU1rec);
+	DecommitBSS(HostMemoryMap::bumpAllocator);
 }
 
 SysMainMemory::~SysMainMemory()
@@ -425,9 +405,9 @@ void SysMainMemory::ReserveAll()
 	DevCon.WriteLn( Color_StrongBlue, "Mapping host memory for virtual systems..." );
 	ConsoleIndentScope indent(1);
 
-	m_ee.Reserve(MainMemory());
-	m_iop.Reserve(MainMemory());
-	m_vu.Reserve(MainMemory());
+	m_ee.Assign(HostMemoryMap::EEmem);
+	m_iop.Assign(HostMemoryMap::IOPmem);
+	m_vu.Assign(HostMemoryMap::VUmem);
 }
 
 void SysMainMemory::CommitAll()

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -41,52 +41,35 @@ class RecompiledCodeReserve;
 
 namespace HostMemoryMap
 {
-#if defined(__M_X86_64)
-	// We have lots of space so try to keep the allocation away from everything else to catch any places where we try to reference outside things with 32-bit relative offsets
-	static const uptr Base = 2ull << 32;
-#elif defined(ASAN_WORKAROUND)
-	// address sanitizer uses a shadow memory to monitor the state of the memory. Shadow is computed
-	// as S = (M >> 3) + 0x20000000. So PCSX2 can't use 0x20000000 to 0x3FFFFFFF... Just add another
-	// 0x20000000 offset to avoid conflict.
-	static const uptr Base = 0x40000000;
-#else
-	static const uptr Base = 0x20000000;
-#endif
-	static const u32 Size = 0x28000000;
-
-	// The actual addresses may not be equivalent to Base + Offset in the event that allocation at Base failed
-	// Each of these offsets has a debugger-accessible equivalent variable without the Offset suffix that will hold the actual address (not here because we don't want code using it)
-
 	// PS2 main memory, SPR, and ROMs
-	static const u32 EEmemOffset   = 0x00000000;
+	extern __pagealigned EEVM_MemoryAllocMess EEmem;
 
 	// IOP main memory and ROMs
-	static const u32 IOPmemOffset  = 0x04000000;
+	extern __pagealigned u8 IOPmem[(sizeof(IopVM_MemoryAllocMess) + __pagesize - 1) & -__pagesize];
 
 	// VU0 and VU1 memory.
-	static const u32 VUmemOffset   = 0x08000000;
+	extern __pagealigned u8 VUmem[_64kb];
 
 	// EE recompiler code cache area (64mb)
-	static const u32 EErecOffset   = 0x10000000;
+	extern __pagealigned u8 EErec[_64mb];
 
 	// IOP recompiler code cache area (16 or 32mb)
-	static const u32 IOPrecOffset  = 0x14000000;
+	extern __pagealigned u8 IOPrec[_32mb];
 
 	// newVif0 recompiler code cache area (16mb)
-	static const u32 VIF0recOffset = 0x16000000;
+	extern __pagealigned u8 VIF0rec[_8mb];
 
 	// newVif1 recompiler code cache area (32mb)
-	static const u32 VIF1recOffset = 0x18000000;
+	extern __pagealigned u8 VIF1rec[_8mb];
 
 	// microVU1 recompiler code cache area (32 or 64mb)
-	static const u32 mVU0recOffset = 0x1C000000;
+	extern __pagealigned u8 mVU0rec[_64mb];
 
 	// microVU0 recompiler code cache area (64mb)
-	static const u32 mVU1recOffset = 0x20000000;
+	extern __pagealigned u8 mVU1rec[_64mb];
 
 	// Bump allocator for any other small allocations
-	// size: Difference between it and HostMemoryMap::Size, so nothing should allocate higher than it!
-	static const u32 bumpAllocatorOffset = 0x24000000;
+	extern __pagealigned u8 bumpAllocator[_64mb];
 }
 
 // --------------------------------------------------------------------------------------
@@ -96,18 +79,16 @@ namespace HostMemoryMap
 class SysMainMemory
 {
 protected:
-	const VirtualMemoryManagerPtr m_mainMemory;
-	VirtualMemoryBumpAllocator    m_bumpAllocator;
-	eeMemoryReserve               m_ee;
-	iopMemoryReserve              m_iop;
-	vuMemoryReserve               m_vu;
+	VirtualMemoryBumpAllocator m_bumpAllocator;
+	eeMemoryReserve            m_ee;
+	iopMemoryReserve           m_iop;
+	vuMemoryReserve            m_vu;
 
 public:
 	SysMainMemory();
 	virtual ~SysMainMemory();
 
-	const VirtualMemoryManagerPtr& MainMemory()    { return m_mainMemory; }
-	VirtualMemoryBumpAllocator&    BumpAllocator() { return m_bumpAllocator; }
+	VirtualMemoryBumpAllocator& BumpAllocator() { return m_bumpAllocator; }
 
 	virtual void ReserveAll();
 	virtual void CommitAll();

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -41,35 +41,52 @@ class RecompiledCodeReserve;
 
 namespace HostMemoryMap
 {
+#if defined(__M_X86_64)
+	// We have lots of space so try to keep the allocation away from everything else to catch any places where we try to reference outside things with 32-bit relative offsets
+	static const uptr Base = 2ull << 32;
+#elif defined(ASAN_WORKAROUND)
+	// address sanitizer uses a shadow memory to monitor the state of the memory. Shadow is computed
+	// as S = (M >> 3) + 0x20000000. So PCSX2 can't use 0x20000000 to 0x3FFFFFFF... Just add another
+	// 0x20000000 offset to avoid conflict.
+	static const uptr Base = 0x40000000;
+#else
+	static const uptr Base = 0x20000000;
+#endif
+	static const u32 Size = 0x28000000;
+
+	// The actual addresses may not be equivalent to Base + Offset in the event that allocation at Base failed
+	// Each of these offsets has a debugger-accessible equivalent variable without the Offset suffix that will hold the actual address (not here because we don't want code using it)
+
 	// PS2 main memory, SPR, and ROMs
-	extern __pagealigned EEVM_MemoryAllocMess EEmem;
+	static const u32 EEmemOffset   = 0x00000000;
 
 	// IOP main memory and ROMs
-	extern __pagealigned u8 IOPmem[(sizeof(IopVM_MemoryAllocMess) + __pagesize - 1) & -__pagesize];
+	static const u32 IOPmemOffset  = 0x04000000;
 
 	// VU0 and VU1 memory.
-	extern __pagealigned u8 VUmem[_64kb];
+	static const u32 VUmemOffset   = 0x08000000;
 
 	// EE recompiler code cache area (64mb)
-	extern __pagealigned u8 EErec[_64mb];
+	static const u32 EErecOffset   = 0x10000000;
 
 	// IOP recompiler code cache area (16 or 32mb)
-	extern __pagealigned u8 IOPrec[_32mb];
+	static const u32 IOPrecOffset  = 0x14000000;
 
 	// newVif0 recompiler code cache area (16mb)
-	extern __pagealigned u8 VIF0rec[_8mb];
+	static const u32 VIF0recOffset = 0x16000000;
 
 	// newVif1 recompiler code cache area (32mb)
-	extern __pagealigned u8 VIF1rec[_8mb];
+	static const u32 VIF1recOffset = 0x18000000;
 
 	// microVU1 recompiler code cache area (32 or 64mb)
-	extern __pagealigned u8 mVU0rec[_64mb];
+	static const u32 mVU0recOffset = 0x1C000000;
 
 	// microVU0 recompiler code cache area (64mb)
-	extern __pagealigned u8 mVU1rec[_64mb];
+	static const u32 mVU1recOffset = 0x20000000;
 
 	// Bump allocator for any other small allocations
-	extern __pagealigned u8 bumpAllocator[_64mb];
+	// size: Difference between it and HostMemoryMap::Size, so nothing should allocate higher than it!
+	static const u32 bumpAllocatorOffset = 0x24000000;
 }
 
 // --------------------------------------------------------------------------------------
@@ -79,16 +96,18 @@ namespace HostMemoryMap
 class SysMainMemory
 {
 protected:
-	VirtualMemoryBumpAllocator m_bumpAllocator;
-	eeMemoryReserve            m_ee;
-	iopMemoryReserve           m_iop;
-	vuMemoryReserve            m_vu;
+	const VirtualMemoryManagerPtr m_mainMemory;
+	VirtualMemoryBumpAllocator    m_bumpAllocator;
+	eeMemoryReserve               m_ee;
+	iopMemoryReserve              m_iop;
+	vuMemoryReserve               m_vu;
 
 public:
 	SysMainMemory();
 	virtual ~SysMainMemory();
 
-	VirtualMemoryBumpAllocator& BumpAllocator() { return m_bumpAllocator; }
+	const VirtualMemoryManagerPtr& MainMemory()    { return m_mainMemory; }
+	VirtualMemoryBumpAllocator&    BumpAllocator() { return m_bumpAllocator; }
 
 	virtual void ReserveAll();
 	virtual void CommitAll();

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -41,51 +41,52 @@ class RecompiledCodeReserve;
 
 namespace HostMemoryMap
 {
-#ifdef ASAN_WORKAROUND
+#if defined(__M_X86_64)
+	// We have lots of space so try to keep the allocation away from everything else to catch any places where we try to reference outside things with 32-bit relative offsets
+	static const uptr Base = 2ull << 32;
+#elif defined(ASAN_WORKAROUND)
 	// address sanitizer uses a shadow memory to monitor the state of the memory. Shadow is computed
 	// as S = (M >> 3) + 0x20000000. So PCSX2 can't use 0x20000000 to 0x3FFFFFFF... Just add another
 	// 0x20000000 offset to avoid conflict.
-	static const uptr EEmem		= 0x40000000;
-	static const uptr IOPmem	= 0x44000000;
-	static const uptr VUmem		= 0x48000000;
-	static const uptr EErec		= 0x50000000;
-	static const uptr IOPrec	= 0x54000000;
-	static const uptr VIF0rec	= 0x56000000;
-	static const uptr VIF1rec	= 0x58000000;
-	static const uptr mVU0rec	= 0x5C000000;
-	static const uptr mVU1rec	= 0x60000000;
-	static const uptr codegenAccessibleMemory = 0x64000000;
+	static const uptr Base = 0x40000000;
 #else
+	static const uptr Base = 0x20000000;
+#endif
+	static const u32 Size = 0x28000000;
+
+	// The actual addresses may not be equivalent to Base + Offset in the event that allocation at Base failed
+	// Each of these offsets has a debugger-accessible equivalent variable without the Offset suffix that will hold the actual address (not here because we don't want code using it)
+
 	// PS2 main memory, SPR, and ROMs
-	static const uptr EEmem		= 0x20000000;
+	static const u32 EEmemOffset   = 0x00000000;
 
 	// IOP main memory and ROMs
-	static const uptr IOPmem	= 0x24000000;
+	static const u32 IOPmemOffset  = 0x04000000;
 
 	// VU0 and VU1 memory.
-	static const uptr VUmem		= 0x28000000;
+	static const u32 VUmemOffset   = 0x08000000;
 
 	// EE recompiler code cache area (64mb)
-	static const uptr EErec		= 0x30000000;
+	static const u32 EErecOffset   = 0x10000000;
 
 	// IOP recompiler code cache area (16 or 32mb)
-	static const uptr IOPrec	= 0x34000000;
+	static const u32 IOPrecOffset  = 0x14000000;
 
 	// newVif0 recompiler code cache area (16mb)
-	static const uptr VIF0rec	= 0x36000000;
+	static const u32 VIF0recOffset = 0x16000000;
 
 	// newVif1 recompiler code cache area (32mb)
-	static const uptr VIF1rec	= 0x38000000;
+	static const u32 VIF1recOffset = 0x18000000;
 
 	// microVU1 recompiler code cache area (32 or 64mb)
-	static const uptr mVU0rec	= 0x3C000000;
+	static const u32 mVU0recOffset = 0x1C000000;
 
 	// microVU0 recompiler code cache area (64mb)
-	static const uptr mVU1rec	= 0x40000000;
+	static const u32 mVU1recOffset = 0x20000000;
 
-	// Codegen-accessible static memory (4kb, x86-64 only)
-	static const uptr codegenAccessibleMemory = 0x44000000;
-#endif
+	// Bump allocator for any other small allocations
+	// size: Difference between it and HostMemoryMap::Size, so nothing should allocate higher than it!
+	static const u32 bumpAllocatorOffset = 0x24000000;
 }
 
 // --------------------------------------------------------------------------------------
@@ -95,13 +96,18 @@ namespace HostMemoryMap
 class SysMainMemory
 {
 protected:
-	eeMemoryReserve			m_ee;
-	iopMemoryReserve		m_iop;
-	vuMemoryReserve			m_vu;
+	const VirtualMemoryManagerPtr m_mainMemory;
+	VirtualMemoryBumpAllocator    m_bumpAllocator;
+	eeMemoryReserve               m_ee;
+	iopMemoryReserve              m_iop;
+	vuMemoryReserve               m_vu;
 
 public:
 	SysMainMemory();
 	virtual ~SysMainMemory();
+
+	const VirtualMemoryManagerPtr& MainMemory()    { return m_mainMemory; }
+	VirtualMemoryBumpAllocator&    BumpAllocator() { return m_bumpAllocator; }
 
 	virtual void ReserveAll();
 	virtual void CommitAll();

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -54,6 +54,7 @@ namespace HostMemoryMap
 	static const uptr VIF1rec	= 0x58000000;
 	static const uptr mVU0rec	= 0x5C000000;
 	static const uptr mVU1rec	= 0x60000000;
+	static const uptr codegenAccessibleMemory = 0x64000000;
 #else
 	// PS2 main memory, SPR, and ROMs
 	static const uptr EEmem		= 0x20000000;
@@ -81,8 +82,10 @@ namespace HostMemoryMap
 
 	// microVU0 recompiler code cache area (64mb)
 	static const uptr mVU1rec	= 0x40000000;
-#endif
 
+	// Codegen-accessible static memory (4kb, x86-64 only)
+	static const uptr codegenAccessibleMemory = 0x44000000;
+#endif
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -41,17 +41,6 @@ class RecompiledCodeReserve;
 
 namespace HostMemoryMap
 {
-#if defined(__M_X86_64)
-	// We have lots of space so try to keep the allocation away from everything else to catch any places where we try to reference outside things with 32-bit relative offsets
-	static const uptr Base = 2ull << 32;
-#elif defined(ASAN_WORKAROUND)
-	// address sanitizer uses a shadow memory to monitor the state of the memory. Shadow is computed
-	// as S = (M >> 3) + 0x20000000. So PCSX2 can't use 0x20000000 to 0x3FFFFFFF... Just add another
-	// 0x20000000 offset to avoid conflict.
-	static const uptr Base = 0x40000000;
-#else
-	static const uptr Base = 0x20000000;
-#endif
 	static const u32 Size = 0x28000000;
 
 	// The actual addresses may not be equivalent to Base + Offset in the event that allocation at Base failed

--- a/pcsx2/System/RecTypes.h
+++ b/pcsx2/System/RecTypes.h
@@ -34,9 +34,9 @@ public:
 	RecompiledCodeReserve( const wxString& name=wxEmptyString, uint defCommit = 0 );
 	virtual ~RecompiledCodeReserve();
 
-	virtual void* Reserve( size_t size, uptr base=0, uptr upper_bounds=0 );
-	virtual void Reset();
-	virtual bool Commit();
+	virtual void* Assign( VirtualMemoryManagerPtr allocator, void *baseptr, size_t size ) override;
+	virtual void Reset() override;
+	virtual bool Commit() override;
 
 	virtual RecompiledCodeReserve& SetProfilerName( const wxString& shortname );
 	virtual RecompiledCodeReserve& SetProfilerName( const char* shortname )

--- a/pcsx2/System/RecTypes.h
+++ b/pcsx2/System/RecTypes.h
@@ -58,3 +58,37 @@ protected:
 	void _registerProfiler();
 	void _termProfiler();
 };
+
+// --------------------------------------------------------------------------------------
+//  CodegenAccessible
+// --------------------------------------------------------------------------------------
+// In x86-64, codegen can't reference any other address, only addresses within the lower
+// 2GB of address space or within 2GB of the current instruction pointer.
+// Because of this, static variables that need to be read by generated code will need to
+// be copied to a referencable place.
+//
+#ifndef __M_X86_64
+template <typename T> using CodegenAccessible = T&;
+namespace HostSys {
+	// On 32-bit all addresses are codegen accessible, so we don't need to do anything
+	template <typename T>
+	void MakeCodegenAccessible(CodegenAccessible<T> item) {}
+}
+#else
+template <typename T> using CodegenAccessible = std::reference_wrapper<T>;
+
+namespace HostSys {
+	namespace detail {
+		extern void *MakeCodegenAccessible(void *ptr, sptr size);
+	}
+
+	/// Moves the given CodegenAccessible item somewhere that's codegen-accessible
+	/// It's okay to call this on the same object multiple times, only the first one will actually do anything
+	template <typename T>
+	void MakeCodegenAccessible(CodegenAccessible<T>& item)
+	{
+		T* ptr = &item.get();
+		item = *(T*)detail::MakeCodegenAccessible((void *)ptr, sizeof(T));
+	}
+}
+#endif

--- a/pcsx2/System/RecTypes.h
+++ b/pcsx2/System/RecTypes.h
@@ -34,7 +34,7 @@ public:
 	RecompiledCodeReserve( const wxString& name=wxEmptyString, uint defCommit = 0 );
 	virtual ~RecompiledCodeReserve();
 
-	virtual void* Assign( VirtualMemoryManagerPtr allocator, void *baseptr, size_t size ) override;
+	virtual void* Assign( void *baseptr, size_t size ) override;
 	virtual void Reset() override;
 	virtual bool Commit() override;
 
@@ -44,6 +44,7 @@ public:
 		return SetProfilerName( fromUTF8(shortname) );
 	}
 
+	bool IsOk() const;
 	void ThrowIfNotOk() const;
 
 	operator void*()				{ return m_baseptr; }
@@ -58,37 +59,3 @@ protected:
 	void _registerProfiler();
 	void _termProfiler();
 };
-
-// --------------------------------------------------------------------------------------
-//  CodegenAccessible
-// --------------------------------------------------------------------------------------
-// In x86-64, codegen can't reference any other address, only addresses within the lower
-// 2GB of address space or within 2GB of the current instruction pointer.
-// Because of this, static variables that need to be read by generated code will need to
-// be copied to a referencable place.
-//
-#ifndef __M_X86_64
-template <typename T> using CodegenAccessible = T&;
-namespace HostSys {
-	// On 32-bit all addresses are codegen accessible, so we don't need to do anything
-	template <typename T>
-	void MakeCodegenAccessible(CodegenAccessible<T> item) {}
-}
-#else
-template <typename T> using CodegenAccessible = std::reference_wrapper<T>;
-
-namespace HostSys {
-	namespace detail {
-		extern void *MakeCodegenAccessible(void *ptr, sptr size);
-	}
-
-	/// Moves the given CodegenAccessible item somewhere that's codegen-accessible
-	/// It's okay to call this on the same object multiple times, only the first one will actually do anything
-	template <typename T>
-	void MakeCodegenAccessible(CodegenAccessible<T>& item)
-	{
-		T* ptr = &item.get();
-		item = *(T*)detail::MakeCodegenAccessible((void *)ptr, sizeof(T));
-	}
-}
-#endif

--- a/pcsx2/System/RecTypes.h
+++ b/pcsx2/System/RecTypes.h
@@ -58,37 +58,3 @@ protected:
 	void _registerProfiler();
 	void _termProfiler();
 };
-
-// --------------------------------------------------------------------------------------
-//  CodegenAccessible
-// --------------------------------------------------------------------------------------
-// In x86-64, codegen can't reference any other address, only addresses within the lower
-// 2GB of address space or within 2GB of the current instruction pointer.
-// Because of this, static variables that need to be read by generated code will need to
-// be copied to a referencable place.
-//
-#ifndef __M_X86_64
-template <typename T> using CodegenAccessible = T&;
-namespace HostSys {
-	// On 32-bit all addresses are codegen accessible, so we don't need to do anything
-	template <typename T>
-	void MakeCodegenAccessible(CodegenAccessible<T> item) {}
-}
-#else
-template <typename T> using CodegenAccessible = std::reference_wrapper<T>;
-
-namespace HostSys {
-	namespace detail {
-		extern void *MakeCodegenAccessible(void *ptr, sptr size);
-	}
-
-	/// Moves the given CodegenAccessible item somewhere that's codegen-accessible
-	/// It's okay to call this on the same object multiple times, only the first one will actually do anything
-	template <typename T>
-	void MakeCodegenAccessible(CodegenAccessible<T>& item)
-	{
-		T* ptr = &item.get();
-		item = *(T*)detail::MakeCodegenAccessible((void *)ptr, sizeof(T));
-	}
-}
-#endif

--- a/pcsx2/VUmicroMem.cpp
+++ b/pcsx2/VUmicroMem.cpp
@@ -27,9 +27,9 @@ vuMemoryReserve::vuMemoryReserve()
 {
 }
 
-void vuMemoryReserve::Reserve()
+void vuMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
 {
-	_parent::Reserve(HostMemoryMap::VUmem);
+	_parent::Reserve(std::move(allocator), HostMemoryMap::VUmemOffset);
 	//_parent::Reserve(EmuConfig.HostMemMap.VUmem);
 
 	u8* curpos = m_reserve.GetPtr();
@@ -39,10 +39,8 @@ void vuMemoryReserve::Reserve()
 	VU1.Mem		= curpos; curpos += VU1_MEMSIZE;
 }
 
-void vuMemoryReserve::Release()
+vuMemoryReserve::~vuMemoryReserve()
 {
-	_parent::Release();
-
 	VU0.Micro	= VU0.Mem	= NULL;
 	VU1.Micro	= VU1.Mem	= NULL;
 }

--- a/pcsx2/VUmicroMem.cpp
+++ b/pcsx2/VUmicroMem.cpp
@@ -23,16 +23,16 @@ __aligned16 VURegs vuRegs[2];
 
 
 vuMemoryReserve::vuMemoryReserve()
-	: _parent( L"VU0/1 on-chip memory", VU1_PROGSIZE + VU1_MEMSIZE + VU0_PROGSIZE + VU0_MEMSIZE )
+	: _parent( L"VU0/1 on-chip memory" )
 {
 }
 
-void vuMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
-{
-	_parent::Reserve(std::move(allocator), HostMemoryMap::VUmemOffset);
-	//_parent::Reserve(EmuConfig.HostMemMap.VUmem);
+bool vuMemoryReserve::IsSizeOK(size_t size) {
+	return size >= VU1_PROGSIZE + VU1_MEMSIZE + VU0_PROGSIZE + VU0_MEMSIZE;
+}
 
-	u8* curpos = m_reserve.GetPtr();
+void vuMemoryReserve::DidAssign(void *mem) {
+	u8* curpos = (u8*)mem;
 	VU0.Micro	= curpos; curpos += VU0_PROGSIZE;
 	VU0.Mem		= curpos; curpos += VU0_MEMSIZE;
 	VU1.Micro	= curpos; curpos += VU1_PROGSIZE;

--- a/pcsx2/VUmicroMem.cpp
+++ b/pcsx2/VUmicroMem.cpp
@@ -23,16 +23,16 @@ __aligned16 VURegs vuRegs[2];
 
 
 vuMemoryReserve::vuMemoryReserve()
-	: _parent( L"VU0/1 on-chip memory" )
+	: _parent( L"VU0/1 on-chip memory", VU1_PROGSIZE + VU1_MEMSIZE + VU0_PROGSIZE + VU0_MEMSIZE )
 {
 }
 
-bool vuMemoryReserve::IsSizeOK(size_t size) {
-	return size >= VU1_PROGSIZE + VU1_MEMSIZE + VU0_PROGSIZE + VU0_MEMSIZE;
-}
+void vuMemoryReserve::Reserve(VirtualMemoryManagerPtr allocator)
+{
+	_parent::Reserve(std::move(allocator), HostMemoryMap::VUmemOffset);
+	//_parent::Reserve(EmuConfig.HostMemMap.VUmem);
 
-void vuMemoryReserve::DidAssign(void *mem) {
-	u8* curpos = (u8*)mem;
+	u8* curpos = m_reserve.GetPtr();
 	VU0.Micro	= curpos; curpos += VU0_PROGSIZE;
 	VU0.Mem		= curpos; curpos += VU0_MEMSIZE;
 	VU1.Micro	= curpos; curpos += VU1_PROGSIZE;

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -791,9 +791,7 @@ void vtlb_Term()
 	//nothing to do for now
 }
 
-// We need this to be near recompiled code
-static __pagealigned sptr vtlbdata_vmap[VTLB_VMAP_ITEMS];
-static_assert(sizeof(vtlbdata_vmap) % __pagesize == 0, "We decommit this when we're not using it");
+constexpr size_t VMAP_SIZE = sizeof(sptr) * VTLB_VMAP_ITEMS;
 
 // Reserves the vtlb core allocation used by various emulation components!
 // [TODO] basemem - request allocating memory at the specified virtual location, which can allow
@@ -801,17 +799,15 @@ static_assert(sizeof(vtlbdata_vmap) % __pagesize == 0, "We decommit this when we
 //    default is used.
 void vtlb_Core_Alloc()
 {
-	static bool hasRun = false; // Memory starts out committed
+	// Can't return regions to the bump allocator
+	static sptr* vmap = nullptr;
+	if (!vmap)
+		vmap = (sptr*)GetVmMemory().BumpAllocator().Alloc(VMAP_SIZE);
 	if (!vtlbdata.vmap)
 	{
-		bool okay = true;
-		if (hasRun) {
-			okay = HostSys::MmapCommitPtr(vtlbdata_vmap, sizeof(vtlbdata_vmap), PageProtectionMode().Read().Write());
-		} else {
-			hasRun = true;
-		}
+		bool okay = HostSys::MmapCommitPtr(vmap, VMAP_SIZE, PageProtectionMode().Read().Write());
 		if (okay) {
-			vtlbdata.vmap = vtlbdata_vmap;
+			vtlbdata.vmap = vmap;
 		} else {
 			throw Exception::OutOfMemory( L"VTLB Virtual Address Translation LUT" )
 				.SetDiagMsg(pxsFmt("(%u megs)", VTLB_VMAP_ITEMS * sizeof(*vtlbdata.vmap) / _1mb)
@@ -839,7 +835,7 @@ void vtlb_Alloc_Ppmap()
 void vtlb_Core_Free()
 {
 	if (vtlbdata.vmap) {
-		HostSys::MmapResetPtr(vtlbdata_vmap, sizeof(vtlbdata_vmap));
+		HostSys::MmapResetPtr(vtlbdata.vmap, VMAP_SIZE);
 		vtlbdata.vmap = nullptr;
 	}
 	safe_aligned_free( vtlbdata.ppmap );

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -844,9 +844,9 @@ VtlbMemoryReserve::VtlbMemoryReserve( const wxString& name, size_t size )
 	m_reserve.SetPageAccessOnCommit( PageAccess_ReadWrite() );
 }
 
-void VtlbMemoryReserve::Reserve( sptr hostptr )
+void VtlbMemoryReserve::Reserve( VirtualMemoryManagerPtr allocator, sptr offset )
 {
-	if (!m_reserve.ReserveAt( hostptr ))
+	if (!m_reserve.Reserve( std::move(allocator), offset ))
 	{
 		throw Exception::OutOfMemory( m_reserve.GetName() )
 			.SetDiagMsg(L"Vtlb memory could not be reserved.")
@@ -874,11 +874,6 @@ void VtlbMemoryReserve::Reset()
 void VtlbMemoryReserve::Decommit()
 {
 	m_reserve.Reset();
-}
-
-void VtlbMemoryReserve::Release()
-{
-	m_reserve.Release();
 }
 
 bool VtlbMemoryReserve::IsCommitted() const

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -854,20 +854,21 @@ static wxString GetHostVmErrorMsg()
 // --------------------------------------------------------------------------------------
 //  VtlbMemoryReserve  (implementations)
 // --------------------------------------------------------------------------------------
-VtlbMemoryReserve::VtlbMemoryReserve( const wxString& name, size_t size )
-	: m_reserve( name, size )
+VtlbMemoryReserve::VtlbMemoryReserve( const wxString& name )
+	: m_reserve( name, 0 )
 {
 	m_reserve.SetPageAccessOnCommit( PageAccess_ReadWrite() );
 }
 
-void VtlbMemoryReserve::Reserve( VirtualMemoryManagerPtr allocator, sptr offset )
+void VtlbMemoryReserve::Assign(void *ptr, size_t size)
 {
-	if (!m_reserve.Reserve( std::move(allocator), offset ))
-	{
-		throw Exception::OutOfMemory( m_reserve.GetName() )
-			.SetDiagMsg(L"Vtlb memory could not be reserved.")
-			.SetUserMsg(GetHostVmErrorMsg());
+	if (!IsSizeOK(size)) {
+		char str[256];
+		sprintf(str, "0x%lx bytes not enough for %s", size, WX_STR(m_reserve.GetName()));
+		pxAssertMsg(0, str);
 	}
+	m_reserve.Assign( ptr, size );
+	DidAssign(ptr);
 }
 
 void VtlbMemoryReserve::Commit()

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -791,19 +791,32 @@ void vtlb_Term()
 	//nothing to do for now
 }
 
+// We need this to be near recompiled code
+static __pagealigned sptr vtlbdata_vmap[VTLB_VMAP_ITEMS];
+static_assert(sizeof(vtlbdata_vmap) % __pagesize == 0, "We decommit this when we're not using it");
+
 // Reserves the vtlb core allocation used by various emulation components!
 // [TODO] basemem - request allocating memory at the specified virtual location, which can allow
 //    for easier debugging and/or 3rd party cheat programs.  If 0, the operating system
 //    default is used.
 void vtlb_Core_Alloc()
 {
+	static bool hasRun = false; // Memory starts out committed
 	if (!vtlbdata.vmap)
 	{
-		vtlbdata.vmap = (sptr*)_aligned_malloc( VTLB_VMAP_ITEMS * sizeof(*vtlbdata.vmap), 16 );
-		if (!vtlbdata.vmap)
+		bool okay = true;
+		if (hasRun) {
+			okay = HostSys::MmapCommitPtr(vtlbdata_vmap, sizeof(vtlbdata_vmap), PageProtectionMode().Read().Write());
+		} else {
+			hasRun = true;
+		}
+		if (okay) {
+			vtlbdata.vmap = vtlbdata_vmap;
+		} else {
 			throw Exception::OutOfMemory( L"VTLB Virtual Address Translation LUT" )
 				.SetDiagMsg(pxsFmt("(%u megs)", VTLB_VMAP_ITEMS * sizeof(*vtlbdata.vmap) / _1mb)
 			);
+		}
 	}
 }
 
@@ -825,7 +838,10 @@ void vtlb_Alloc_Ppmap()
 
 void vtlb_Core_Free()
 {
-	safe_aligned_free( vtlbdata.vmap );
+	if (vtlbdata.vmap) {
+		HostSys::MmapResetPtr(vtlbdata_vmap, sizeof(vtlbdata_vmap));
+		vtlbdata.vmap = nullptr;
+	}
 	safe_aligned_free( vtlbdata.ppmap );
 }
 

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -100,13 +100,8 @@ protected:
 
 public:
 	VtlbMemoryReserve( const wxString& name, size_t size );
-	virtual ~VtlbMemoryReserve()
-	{
-		m_reserve.Release();
-	}
 
-	void Reserve( sptr hostptr );
-	virtual void Release();
+	void Reserve( VirtualMemoryManagerPtr allocator, sptr offset );
 
 	virtual void Commit();
 	virtual void Reset();
@@ -124,16 +119,12 @@ class eeMemoryReserve : public VtlbMemoryReserve
 
 public:
 	eeMemoryReserve();
-	virtual ~eeMemoryReserve()
-	{
-		Release();
-	}
+	~eeMemoryReserve();
 
-	void Reserve();
-	void Commit();
-	void Decommit();
-	void Reset();
-	void Release();
+	void Reserve(VirtualMemoryManagerPtr allocator);
+	void Commit() override;
+	void Decommit() override;
+	void Reset() override;
 };
 
 // --------------------------------------------------------------------------------------
@@ -145,16 +136,11 @@ class iopMemoryReserve : public VtlbMemoryReserve
 
 public:
 	iopMemoryReserve();
-	virtual ~iopMemoryReserve()
-	{
-		Release();
-	}
 
-	void Reserve();
-	void Commit();
-	void Decommit();
-	void Release();
-	void Reset();
+	void Reserve(VirtualMemoryManagerPtr allocator);
+	void Commit() override;
+	void Decommit() override;
+	void Reset() override;
 };
 
 // --------------------------------------------------------------------------------------
@@ -166,15 +152,11 @@ class vuMemoryReserve : public VtlbMemoryReserve
 
 public:
 	vuMemoryReserve();
-	virtual ~vuMemoryReserve()
-	{
-		Release();
-	}
+	~vuMemoryReserve();
 
-	void Reserve();
-	void Release();
+	void Reserve(VirtualMemoryManagerPtr allocator);
 
-	void Reset();
+	void Reset() override;
 };
 
 namespace vtlb_private

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -98,10 +98,17 @@ class VtlbMemoryReserve
 protected:
 	VirtualMemoryReserve	m_reserve;
 
+	virtual bool IsSizeOK(size_t size) { return true; }
+	virtual void DidAssign(void *mem) {}
 public:
-	VtlbMemoryReserve( const wxString& name, size_t size );
+	VtlbMemoryReserve( const wxString& name );
 
-	void Reserve( VirtualMemoryManagerPtr allocator, sptr offset );
+	void Assign( void *ptr, size_t size );
+
+	template <typename T, typename = typename std::enable_if<std::is_trivial<T>::value>::type>
+	void Assign(T& t) {
+		Assign((void*)&t, sizeof(T));
+	}
 
 	virtual void Commit();
 	virtual void Reset();
@@ -117,11 +124,11 @@ class eeMemoryReserve : public VtlbMemoryReserve
 {
 	typedef VtlbMemoryReserve _parent;
 
+	bool IsSizeOK(size_t size) override;
 public:
 	eeMemoryReserve();
 	~eeMemoryReserve();
 
-	void Reserve(VirtualMemoryManagerPtr allocator);
 	void Commit() override;
 	void Decommit() override;
 	void Reset() override;
@@ -134,10 +141,10 @@ class iopMemoryReserve : public VtlbMemoryReserve
 {
 	typedef VtlbMemoryReserve _parent;
 
+	bool IsSizeOK(size_t size) override;
 public:
 	iopMemoryReserve();
 
-	void Reserve(VirtualMemoryManagerPtr allocator);
 	void Commit() override;
 	void Decommit() override;
 	void Reset() override;
@@ -150,11 +157,11 @@ class vuMemoryReserve : public VtlbMemoryReserve
 {
 	typedef VtlbMemoryReserve _parent;
 
+	bool IsSizeOK(size_t size) override;
+	void DidAssign(void *mem) override;
 public:
 	vuMemoryReserve();
 	~vuMemoryReserve();
-
-	void Reserve(VirtualMemoryManagerPtr allocator);
 
 	void Reset() override;
 };

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -98,17 +98,10 @@ class VtlbMemoryReserve
 protected:
 	VirtualMemoryReserve	m_reserve;
 
-	virtual bool IsSizeOK(size_t size) { return true; }
-	virtual void DidAssign(void *mem) {}
 public:
-	VtlbMemoryReserve( const wxString& name );
+	VtlbMemoryReserve( const wxString& name, size_t size );
 
-	void Assign( void *ptr, size_t size );
-
-	template <typename T, typename = typename std::enable_if<std::is_trivial<T>::value>::type>
-	void Assign(T& t) {
-		Assign((void*)&t, sizeof(T));
-	}
+	void Reserve( VirtualMemoryManagerPtr allocator, sptr offset );
 
 	virtual void Commit();
 	virtual void Reset();
@@ -124,11 +117,11 @@ class eeMemoryReserve : public VtlbMemoryReserve
 {
 	typedef VtlbMemoryReserve _parent;
 
-	bool IsSizeOK(size_t size) override;
 public:
 	eeMemoryReserve();
 	~eeMemoryReserve();
 
+	void Reserve(VirtualMemoryManagerPtr allocator);
 	void Commit() override;
 	void Decommit() override;
 	void Reset() override;
@@ -141,10 +134,10 @@ class iopMemoryReserve : public VtlbMemoryReserve
 {
 	typedef VtlbMemoryReserve _parent;
 
-	bool IsSizeOK(size_t size) override;
 public:
 	iopMemoryReserve();
 
+	void Reserve(VirtualMemoryManagerPtr allocator);
 	void Commit() override;
 	void Decommit() override;
 	void Reset() override;
@@ -157,11 +150,11 @@ class vuMemoryReserve : public VtlbMemoryReserve
 {
 	typedef VtlbMemoryReserve _parent;
 
-	bool IsSizeOK(size_t size) override;
-	void DidAssign(void *mem) override;
 public:
 	vuMemoryReserve();
 	~vuMemoryReserve();
+
+	void Reserve(VirtualMemoryManagerPtr allocator);
 
 	void Reset() override;
 };

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -631,10 +631,7 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		uptr requestedSize = m_ConfiguredCacheReserve * _1mb;
-		uptr actualSize = sizeof(HostMemoryMap::IOPrec);
-		pxAssert(requestedSize <= actualSize);
-		if (recMem->Assign((void*)HostMemoryMap::IOPrec, std::min(requestedSize, actualSize)) != NULL) break;
+		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::IOPrecOffset, m_ConfiguredCacheReserve * _1mb) != NULL) break;
 
 		// If it failed, then try again (if possible):
 		if (m_ConfiguredCacheReserve < 4) break;

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -631,7 +631,7 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		if (recMem->Reserve( m_ConfiguredCacheReserve * _1mb, HostMemoryMap::IOPrec ) != NULL) break;
+		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::IOPrecOffset, m_ConfiguredCacheReserve * _1mb) != NULL) break;
 
 		// If it failed, then try again (if possible):
 		if (m_ConfiguredCacheReserve < 4) break;

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -631,7 +631,10 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::IOPrecOffset, m_ConfiguredCacheReserve * _1mb) != NULL) break;
+		uptr requestedSize = m_ConfiguredCacheReserve * _1mb;
+		uptr actualSize = sizeof(HostMemoryMap::IOPrec);
+		pxAssert(requestedSize <= actualSize);
+		if (recMem->Assign((void*)HostMemoryMap::IOPrec, std::min(requestedSize, actualSize)) != NULL) break;
 
 		// If it failed, then try again (if possible):
 		if (m_ConfiguredCacheReserve < 4) break;

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -479,7 +479,7 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		if (recMem->Reserve( m_ConfiguredCacheReserve * _1mb, HostMemoryMap::EErec ) != NULL) break;
+		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::EErecOffset, m_ConfiguredCacheReserve * _1mb) != NULL) break;
 
 		// If it failed, then try again (if possible):
 		if (m_ConfiguredCacheReserve < 16) break;

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -479,7 +479,10 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::EErecOffset, m_ConfiguredCacheReserve * _1mb) != NULL) break;
+		sptr requestedSize = m_ConfiguredCacheReserve * _1mb;
+		sptr actualSize = sizeof(HostMemoryMap::EErec);
+		pxAssert(requestedSize <= actualSize);
+		if (recMem->Assign((void*)HostMemoryMap::EErec, std::min(requestedSize, actualSize)) != NULL) break;
 
 		// If it failed, then try again (if possible):
 		if (m_ConfiguredCacheReserve < 16) break;

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -479,10 +479,7 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		sptr requestedSize = m_ConfiguredCacheReserve * _1mb;
-		sptr actualSize = sizeof(HostMemoryMap::EErec);
-		pxAssert(requestedSize <= actualSize);
-		if (recMem->Assign((void*)HostMemoryMap::EErec, std::min(requestedSize, actualSize)) != NULL) break;
+		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::EErecOffset, m_ConfiguredCacheReserve * _1mb) != NULL) break;
 
 		// If it failed, then try again (if possible):
 		if (m_ConfiguredCacheReserve < 16) break;

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -36,10 +36,15 @@ void mVUreserveCache(microVU& mVU) {
 
 	mVU.cache_reserve = new RecompiledCodeReserve(pxsFmt("Micro VU%u Recompiler Cache", mVU.index), _16mb);
 	mVU.cache_reserve->SetProfilerName(pxsFmt("mVU%urec", mVU.index));
-	
+
+	uptr requestedSize = mVU.cacheSize * _1mb;
+	uptr actualSize = mVU.index ? sizeof(HostMemoryMap::mVU1rec) : sizeof(HostMemoryMap::mVU0rec);
+	pxAssert(requestedSize <= actualSize);
+	uptr sizeToUse = std::min(requestedSize, actualSize);
+
 	mVU.cache = mVU.index ?
-		(u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU1recOffset, mVU.cacheSize * _1mb):
-		(u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU0recOffset, mVU.cacheSize * _1mb);
+		(u8*)mVU.cache_reserve->Assign((void*)HostMemoryMap::mVU1rec, sizeToUse):
+		(u8*)mVU.cache_reserve->Assign((void*)HostMemoryMap::mVU0rec, sizeToUse);
 
 	mVU.cache_reserve->ThrowIfNotOk();
 }

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -38,8 +38,8 @@ void mVUreserveCache(microVU& mVU) {
 	mVU.cache_reserve->SetProfilerName(pxsFmt("mVU%urec", mVU.index));
 	
 	mVU.cache = mVU.index ?
-		(u8*)mVU.cache_reserve->Reserve(mVU.cacheSize * _1mb, HostMemoryMap::mVU1rec):
-		(u8*)mVU.cache_reserve->Reserve(mVU.cacheSize * _1mb, HostMemoryMap::mVU0rec);
+		(u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU1recOffset, mVU.cacheSize * _1mb):
+		(u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU0recOffset, mVU.cacheSize * _1mb);
 
 	mVU.cache_reserve->ThrowIfNotOk();
 }

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -36,15 +36,10 @@ void mVUreserveCache(microVU& mVU) {
 
 	mVU.cache_reserve = new RecompiledCodeReserve(pxsFmt("Micro VU%u Recompiler Cache", mVU.index), _16mb);
 	mVU.cache_reserve->SetProfilerName(pxsFmt("mVU%urec", mVU.index));
-
-	uptr requestedSize = mVU.cacheSize * _1mb;
-	uptr actualSize = mVU.index ? sizeof(HostMemoryMap::mVU1rec) : sizeof(HostMemoryMap::mVU0rec);
-	pxAssert(requestedSize <= actualSize);
-	uptr sizeToUse = std::min(requestedSize, actualSize);
-
+	
 	mVU.cache = mVU.index ?
-		(u8*)mVU.cache_reserve->Assign((void*)HostMemoryMap::mVU1rec, sizeToUse):
-		(u8*)mVU.cache_reserve->Assign((void*)HostMemoryMap::mVU0rec, sizeToUse);
+		(u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU1recOffset, mVU.cacheSize * _1mb):
+		(u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU0recOffset, mVU.cacheSize * _1mb);
 
 	mVU.cache_reserve->ThrowIfNotOk();
 }

--- a/pcsx2/x86/newVif.h
+++ b/pcsx2/x86/newVif.h
@@ -76,6 +76,6 @@ extern void releaseNewVif(int idx);
 
 extern __aligned16 nVifStruct nVif[2];
 extern __aligned16 nVifCall nVifUpk[(2*2*16)*4]; // ([USN][Masking][Unpack Type]) [curCycle]
-extern CodegenAccessible<u32[3][4][4]> nVifMask; // [MaskNumber][CycleNumber][Vector]
+extern __aligned16 u32      nVifMask[3][4][4];   // [MaskNumber][CycleNumber][Vector]
 
 static const bool newVifDynaRec = 1; // Use code in newVif_Dynarec.inl

--- a/pcsx2/x86/newVif.h
+++ b/pcsx2/x86/newVif.h
@@ -76,6 +76,6 @@ extern void releaseNewVif(int idx);
 
 extern __aligned16 nVifStruct nVif[2];
 extern __aligned16 nVifCall nVifUpk[(2*2*16)*4]; // ([USN][Masking][Unpack Type]) [curCycle]
-extern __aligned16 u32      nVifMask[3][4][4];   // [MaskNumber][CycleNumber][Vector]
+extern CodegenAccessible<u32[3][4][4]> nVifMask; // [MaskNumber][CycleNumber][Vector]
 
 static const bool newVifDynaRec = 1; // Use code in newVif_Dynarec.inl

--- a/pcsx2/x86/newVif.h
+++ b/pcsx2/x86/newVif.h
@@ -76,6 +76,6 @@ extern void releaseNewVif(int idx);
 
 extern __aligned16 nVifStruct nVif[2];
 extern __aligned16 nVifCall nVifUpk[(2*2*16)*4]; // ([USN][Masking][Unpack Type]) [curCycle]
-extern __aligned16 u32		nVifMask[3][4][4];	 // [MaskNumber][CycleNumber][Vector]
+extern CodegenAccessible<u32[3][4][4]> nVifMask; // [MaskNumber][CycleNumber][Vector]
 
 static const bool newVifDynaRec = 1; // Use code in newVif_Dynarec.inl

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -34,8 +34,9 @@ void dVifReserve(int idx) {
 	if(!nVif[idx].recReserve)
 		nVif[idx].recReserve = new RecompiledCodeReserve(pxsFmt(L"VIF%u Unpack Recompiler Cache", idx), _8mb);
 
-	auto offset = idx ? HostMemoryMap::VIF1recOffset : HostMemoryMap::VIF0recOffset;
-	nVif[idx].recReserve->Reserve(GetVmMemory().MainMemory(), offset, 8 * _1mb);
+	auto offset = idx ? HostMemoryMap::VIF1rec : HostMemoryMap::VIF0rec;
+	auto size = idx ? sizeof(HostMemoryMap::VIF1rec) : sizeof(HostMemoryMap::VIF0rec);
+	nVif[idx].recReserve->Assign((void*)offset, size);
 }
 
 void dVifReset(int idx) {

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -34,9 +34,8 @@ void dVifReserve(int idx) {
 	if(!nVif[idx].recReserve)
 		nVif[idx].recReserve = new RecompiledCodeReserve(pxsFmt(L"VIF%u Unpack Recompiler Cache", idx), _8mb);
 
-	auto offset = idx ? HostMemoryMap::VIF1rec : HostMemoryMap::VIF0rec;
-	auto size = idx ? sizeof(HostMemoryMap::VIF1rec) : sizeof(HostMemoryMap::VIF0rec);
-	nVif[idx].recReserve->Assign((void*)offset, size);
+	auto offset = idx ? HostMemoryMap::VIF1recOffset : HostMemoryMap::VIF0recOffset;
+	nVif[idx].recReserve->Reserve(GetVmMemory().MainMemory(), offset, 8 * _1mb);
 }
 
 void dVifReset(int idx) {

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -34,7 +34,8 @@ void dVifReserve(int idx) {
 	if(!nVif[idx].recReserve)
 		nVif[idx].recReserve = new RecompiledCodeReserve(pxsFmt(L"VIF%u Unpack Recompiler Cache", idx), _8mb);
 
-	nVif[idx].recReserve->Reserve( 8 * _1mb, idx ? HostMemoryMap::VIF1rec : HostMemoryMap::VIF0rec );
+	auto offset = idx ? HostMemoryMap::VIF1recOffset : HostMemoryMap::VIF0recOffset;
+	nVif[idx].recReserve->Reserve(GetVmMemory().MainMemory(), offset, 8 * _1mb);
 }
 
 void dVifReset(int idx) {

--- a/pcsx2/x86/newVif_Unpack.cpp
+++ b/pcsx2/x86/newVif_Unpack.cpp
@@ -32,8 +32,7 @@ __aligned16 nVifCall	nVifUpk[(2*2*16)  *4];
 // This is used by the interpreted SSE unpacks only.  Recompiled SSE unpacks
 // and the interpreted C unpacks use the vif.MaskRow/MaskCol members directly.
 //  [MaskNumber][CycleNumber][Vector]
-static __aligned16 u32			_nVifMask[3][4][4] = {0};
-CodegenAccessible<decltype(_nVifMask)> nVifMask = _nVifMask;
+__aligned16 u32			nVifMask[3][4][4] = {0};
 
 // Number of bytes of data in the source stream needed for each vector.
 // [equivalent to ((32 >> VL) * (VN+1)) / 8]

--- a/pcsx2/x86/newVif_Unpack.cpp
+++ b/pcsx2/x86/newVif_Unpack.cpp
@@ -32,7 +32,8 @@ __aligned16 nVifCall	nVifUpk[(2*2*16)  *4];
 // This is used by the interpreted SSE unpacks only.  Recompiled SSE unpacks
 // and the interpreted C unpacks use the vif.MaskRow/MaskCol members directly.
 //  [MaskNumber][CycleNumber][Vector]
-__aligned16 u32			nVifMask[3][4][4] = {0};
+static __aligned16 u32			_nVifMask[3][4][4] = {0};
+CodegenAccessible<decltype(_nVifMask)> nVifMask = _nVifMask;
 
 // Number of bytes of data in the source stream needed for each vector.
 // [equivalent to ((32 >> VL) * (VN+1)) / 8]

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -22,13 +22,14 @@
 #define xMOV64(regX, loc)	xMOVUPS(regX, loc)
 #define xMOV128(regX, loc)	xMOVUPS(regX, loc)
 
-static const __aligned16 u32 SSEXYZWMask[4][4] =
+static const __aligned16 u32 _SSEXYZWMask[4][4] =
 {
 	{0xffffffff, 0xffffffff, 0xffffffff, 0x00000000},
 	{0xffffffff, 0xffffffff, 0x00000000, 0xffffffff},
 	{0xffffffff, 0x00000000, 0xffffffff, 0xffffffff},
 	{0x00000000, 0xffffffff, 0xffffffff, 0xffffffff}
 };
+static CodegenAccessible<decltype(_SSEXYZWMask)> SSEXYZWMask = _SSEXYZWMask;
 
 //static __pagealigned u8 nVifUpkExec[__pagesize*4];
 static RecompiledCodeReserve* nVifUpkExec = NULL;
@@ -418,6 +419,9 @@ static void nVifGen(int usn, int mask, int curCycle) {
 
 void VifUnpackSSE_Init()
 {
+	HostSys::MakeCodegenAccessible(SSEXYZWMask);
+	HostSys::MakeCodegenAccessible(nVifMask);
+
 	if (nVifUpkExec) return;
 
 	DevCon.WriteLn( "Generating SSE-optimized unpacking functions for VIF interpreters..." );

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -428,7 +428,7 @@ void VifUnpackSSE_Init()
 
 	nVifUpkExec = new RecompiledCodeReserve(L"VIF SSE-optimized Unpacking Functions", _64kb);
 	nVifUpkExec->SetProfilerName("iVIF-SSE");
-	nVifUpkExec->Reserve( _64kb );
+	nVifUpkExec->Reserve(GetVmMemory().BumpAllocator(), _64kb);
 
 	nVifUpkExec->ThrowIfNotOk();
 

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -22,14 +22,13 @@
 #define xMOV64(regX, loc)	xMOVUPS(regX, loc)
 #define xMOV128(regX, loc)	xMOVUPS(regX, loc)
 
-static const __aligned16 u32 _SSEXYZWMask[4][4] =
+static const __aligned16 u32 SSEXYZWMask[4][4] =
 {
 	{0xffffffff, 0xffffffff, 0xffffffff, 0x00000000},
 	{0xffffffff, 0xffffffff, 0x00000000, 0xffffffff},
 	{0xffffffff, 0x00000000, 0xffffffff, 0xffffffff},
 	{0x00000000, 0xffffffff, 0xffffffff, 0xffffffff}
 };
-static CodegenAccessible<decltype(_SSEXYZWMask)> SSEXYZWMask = _SSEXYZWMask;
 
 //static __pagealigned u8 nVifUpkExec[__pagesize*4];
 static RecompiledCodeReserve* nVifUpkExec = NULL;
@@ -419,9 +418,6 @@ static void nVifGen(int usn, int mask, int curCycle) {
 
 void VifUnpackSSE_Init()
 {
-	HostSys::MakeCodegenAccessible(SSEXYZWMask);
-	HostSys::MakeCodegenAccessible(nVifMask);
-
 	if (nVifUpkExec) return;
 
 	DevCon.WriteLn( "Generating SSE-optimized unpacking functions for VIF interpreters..." );


### PR DESCRIPTION
Another part of #3451

Note: While this shouldn't change how anything works, it's been the #1 source of breakage of 32-bit builds in #3451 (it was the cause for the failure of win32 to allocate memory and the failure of linux-32 afterward) so we should definitely make sure it gets tested

There are a number of solutions to the problem so I'd like to list them here

The problem: On x86-64, most instructions that reference memory do it with a 32-bit offset from the current instruction pointer.  This means that code in the memory allocated without requesting a specific location probably won't be able access variables in global variables without a large and unwieldy `mov tmpRegister, address` before each usage (which would bloat access to the EE registers horribly)

Possible solutions
1. Move all code allocations to global arrays
	- Pros:
		- Modern debuggers will notice memory accesses are offsets into the static arrays and will annotate them accordingly (e.g. `HostMemoryMap::eeMem + 128` commented after an access to `eeMem->Main[128]`)
	- Cons:
		- On linux with overcommit turned off, will require the full 640mb of reserved memory available to launch (but will release it immediately after)
		- On windows, will be completely unable to decommit memory, meaning that all the memory must be available (even if just in the page file), and the emulator will be unable to tell Windows that it's done using pieces of memory that were allocated for recompilers or the EE.
2. Allocate things by requesting addresses near the executable
	- Cons:
		- Could fail if the system loads the executable in a 4GB sea of small allocations or memory that can't be mmap'd (we need 640mb contiguous space).  This hasn't happened on any of the systems tested (Windows 10 2004 32/64, Ubuntu 18.04 64, macOS 10.12 32/64, macOS 10.15 64) and I doubt it will in the future but you never know
3. Allocate things anywhere, use `mov rax, address; jmp rax` to call functions in the executable, and move all global variables into the allocation
	- Cons:
		- Will dirty extra memory for global constants (minor, there's not many)
		- Debuggers won't notice global variables, e.g. this:
			```asm
			0x15002cf25: mov    dword ptr [rip - 0x100174c7], esi
		    0x15002cf2b: nop    
		    0x15002cf2c: mov    r13d, dword ptr [rip - 0x4da765c3] ; cpuRegs + 496
		    0x15002cf33: nop    
		    0x15002cf34: mov    dword ptr [rip - 0x4da76513], r13d ; cpuRegs + 680
		    0x15002cf3b: mov    dword ptr [rip - 0x4da767b5], 0x80010000 ; cpuRegs + 12
		    ```
		    will turn into this:
		    ```asm
			0x15002cf25: mov    dword ptr [rip - 0x100174c7], esi
		    0x15002cf2b: nop    
		    0x15002cf2c: mov    r13d, dword ptr [rip - 0x4da765c3] ; 0x1025b6970
		    0x15002cf33: nop    
		    0x15002cf34: mov    dword ptr [rip - 0x4da76513], r13d ; 0x1025b6a28
		    0x15002cf3b: mov    dword ptr [rip - 0x4da767b5], 0x80010000 ; 0x1025b6790
		    ```

This PR implements option 2 (my current preference), though I'd like others' thoughts on which they think would be best