### PR TITLE
GSdx-hw: Add Jak II and Jak X to Automatic Mipmap

### DIFF
--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -213,7 +213,9 @@ void GSRendererHW::SetGameCRC(uint32 crc, int options)
 			case CRC::HarryPotterATPOA:
 			case CRC::HarryPotterOOTP:
 			case CRC::Jak1:
+			case CRC::Jak2:
 			case CRC::Jak3:
+			case CRC::JakX:
 			case CRC::LegacyOfKainDefiance:
 			case CRC::NicktoonsUnite:
 			case CRC::Persona3:


### PR DESCRIPTION
Like other games in the series, Jak II and Jak X benefit from mipmapping.
Various textures appear broken without it (e.g. car turntable stripes on Jak X main menu, many distant and/or transparent textures (grass, vines) in both games).