### PR TITLE
Add "Screenshot As..." feature to Capture options

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -196,6 +196,8 @@ enum MenuIdentifiers
 	MenuId_Capture_Video_Record,
 	MenuId_Capture_Video_Stop,
 	MenuId_Capture_Screenshot,
+	MenuId_Capture_Screenshot_Screenshot,
+	MenuId_Capture_Screenshot_Screenshot_As,
 
 #ifndef DISABLE_RECORDING
 	// Input Recording Subsection

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -279,7 +279,8 @@ void MainEmuFrame::ConnectMenus()
 	// Capture
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Record_Click, this, MenuId_Capture_Video_Record);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Stop_Click, this, MenuId_Capture_Video_Stop);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click, this, MenuId_Capture_Screenshot);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click, this, MenuId_Capture_Screenshot_Screenshot);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click, this, MenuId_Capture_Screenshot_Screenshot_As);
 
 #ifndef DISABLE_RECORDING
 	// Recording
@@ -474,7 +475,9 @@ void MainEmuFrame::CreateCaptureMenu()
 	m_submenuVideoCapture.Append(MenuId_Capture_Video_Record, _("Start Screenrecorder"));
 	m_submenuVideoCapture.Append(MenuId_Capture_Video_Stop, _("Stop Screenrecorder"))->Enable(false);
 
-	m_menuCapture.Append(MenuId_Capture_Screenshot, _("Screenshot"));
+	m_menuCapture.Append(MenuId_Capture_Screenshot, _("Screenshot"), &m_submenuScreenshot);
+	m_submenuScreenshot.Append(MenuId_Capture_Screenshot_Screenshot, _("Screenshot"));
+	m_submenuScreenshot.Append(MenuId_Capture_Screenshot_Screenshot_As, _("Screenshot As..."));
 }
 
 void MainEmuFrame::CreateRecordMenu()
@@ -523,6 +526,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	, m_menuWindow(*new wxMenu())
 	, m_menuCapture(*new wxMenu())
 	, m_submenuVideoCapture(*new wxMenu())
+	, m_submenuScreenshot(*new wxMenu())
 #ifndef DISABLE_RECORDING
 	, m_menuRecording(*new wxMenu())
 #endif

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -115,8 +115,9 @@ protected:
 	wxMenu& m_menuConfig;
 	wxMenu& m_menuWindow;
 
-	wxMenu& m_menuCapture;
-	wxMenu& m_submenuVideoCapture;
+	wxMenu&	m_menuCapture;
+	wxMenu&	m_submenuVideoCapture;
+	wxMenu&	m_submenuScreenshot;
 
 #ifndef DISABLE_RECORDING
 	wxMenu& m_menuRecording;
@@ -248,6 +249,7 @@ protected:
 	void Menu_Capture_Video_Stop_Click(wxCommandEvent& event);
 	void VideoCaptureUpdate();
 	void Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& event);
+	void Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& event);
 
 #ifndef DISABLE_RECORDING
 	void Menu_Recording_New_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -924,10 +924,19 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent &e
 	if (!CoreThread.IsOpen())
 		return;
 
-	wxFileDialog fileDialog(this, "Select a file", g_Conf->Folders.Snapshots.ToAscii(), wxEmptyString, "PNG files (*.png)|*.png", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+	// Ensure emulation is paused so that the correct image is captured
+	bool wasPaused = CoreThread.IsPaused();
+	if (!wasPaused)
+		CoreThread.Pause();
+
+	wxFileDialog fileDialog(this, _("Select a file"), g_Conf->Folders.Snapshots.ToAscii(), wxEmptyString, "PNG files (*.png)|*.png", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
 	if (fileDialog.ShowModal() == wxID_OK)
 		GSmakeSnapshot(fileDialog.GetPath());
+
+	// Resume emulation
+	if (!wasPaused)
+		CoreThread.Resume();
 }
 
 #ifndef DISABLE_RECORDING

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -919,6 +919,17 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& even
 	GSmakeSnapshot(g_Conf->Folders.Snapshots.ToAscii());
 }
 
+void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent &event)
+{
+	if (!CoreThread.IsOpen())
+		return;
+
+	wxFileDialog fileDialog(this, "Select a file", g_Conf->Folders.Snapshots.ToAscii(), wxEmptyString, "PNG files (*.png)|*.png", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+	if (fileDialog.ShowModal() == wxID_OK)
+		GSmakeSnapshot(fileDialog.GetPath());
+}
+
 #ifndef DISABLE_RECORDING
 void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 {

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -679,7 +679,9 @@ EXPORT_C_(uint32) GSmakeSnapshot(char* path)
 		if (!s.empty())
 		{
 			// Allows for providing a complete path
-			if (s.substr(s.size() - 4, 4) == ".png")
+			std::string extension = s.substr(s.size() - 4, 4);
+			std::transform(extension.begin(), extension.end(), extension.begin(), tolower); 
+			if (extension == ".png")
 				return s_gs->MakeSnapshot(s);
 			else if (s[s.length() - 1] != DIRECTORY_SEPARATOR)
 				s = s + DIRECTORY_SEPARATOR;

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -676,9 +676,13 @@ EXPORT_C_(uint32) GSmakeSnapshot(char* path)
 	{
 		std::string s{path};
 
-		if(!s.empty() && s[s.length() - 1] != DIRECTORY_SEPARATOR)
+		if (!s.empty())
 		{
-			s = s + DIRECTORY_SEPARATOR;
+			// Allows for providing a complete path
+			if (s.substr(s.size() - 4, 4) == ".png")
+				return s_gs->MakeSnapshot(s);
+			else if (s[s.length() - 1] != DIRECTORY_SEPARATOR)
+				s = s + DIRECTORY_SEPARATOR;
 		}
 
 		return s_gs->MakeSnapshot(s + "gsdx");

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -80,7 +80,7 @@ bool GSRenderer::CreateDevice(GSDevice* dev)
 
 void GSRenderer::ResetDevice()
 {
-    if(m_dev) m_dev->Reset(1, 1);
+	if(m_dev) m_dev->Reset(1, 1);
 }
 
 bool GSRenderer::Merge(int field)
@@ -462,7 +462,7 @@ void GSRenderer::VSync(int field)
 
 		if(GSTexture* t = m_dev->GetCurrent())
 		{
-			t->Save(m_snapshot + ".bmp");
+			t->Save(m_snapshot + ".png");
 		}
 
 		m_snapshot.clear();
@@ -500,29 +500,33 @@ void GSRenderer::VSync(int field)
 
 bool GSRenderer::MakeSnapshot(const std::string& path)
 {
-	if(m_snapshot.empty())
+	if (m_snapshot.empty())
 	{
-		time_t cur_time = time(nullptr);
-		static time_t prev_snap;
-		// The variable 'n' is used for labelling the screenshots when multiple screenshots are taken in
-		// a single second, we'll start using this variable for naming when a second screenshot request is detected
-		// at the same time as the first one. Hence, we're initially setting this counter to 2 to imply that
-		// the captured image is the 2nd image captured at this specific time.
-		static int n = 2;
-		char local_time[16];
-
-		if (strftime(local_time, sizeof(local_time), "%Y%m%d%H%M%S", localtime(&cur_time)))
+		// Allows for providing a complete path
+		if (path.substr(path.size() - 4, 4) == ".png")
+			m_snapshot = path.substr(0, path.size() - 4);
+		else
 		{
-			if (cur_time == prev_snap)
+			time_t cur_time = time(nullptr);
+			static time_t prev_snap;
+			// The variable 'n' is used for labelling the screenshots when multiple screenshots are taken in
+			// a single second, we'll start using this variable for naming when a second screenshot request is detected
+			// at the same time as the first one. Hence, we're initially setting this counter to 2 to imply that
+			// the captured image is the 2nd image captured at this specific time.
+			static int n = 2;
+			char local_time[16];
+
+			if (strftime(local_time, sizeof(local_time), "%Y%m%d%H%M%S", localtime(&cur_time)))
 			{
-				m_snapshot = format("%s_%s_(%d)", path.c_str(), local_time, n++);
+				if (cur_time == prev_snap)
+					m_snapshot = format("%s_%s_(%d)", path.c_str(), local_time, n++);
+				else
+				{
+					n = 2;
+					m_snapshot = format("%s_%s", path.c_str(), local_time);
+				}
+				prev_snap = cur_time;
 			}
-			else
-			{
-				n = 2;
-				m_snapshot = format("%s_%s", path.c_str(), local_time);
-			}
-			prev_snap = cur_time;
 		}
 	}
 

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -80,7 +80,7 @@ bool GSRenderer::CreateDevice(GSDevice* dev)
 
 void GSRenderer::ResetDevice()
 {
-	if(m_dev) m_dev->Reset(1, 1);
+    if(m_dev) m_dev->Reset(1, 1);
 }
 
 bool GSRenderer::Merge(int field)


### PR DESCRIPTION
This was a new feature that was dropped from the initial recording tools PR as it was out of scope, adding it back now https://github.com/PCSX2/pcsx2/commit/64104ca9fdeec1b5b19b26e75b5c564ed230613b

Allows you to specify where you want the screenshot to be saved via a file browser. 
![image](https://user-images.githubusercontent.com/13153231/86993364-d196af00-c171-11ea-8fb8-96619549ed7b.png)

This also changes GSdx to save screenshots with the `png` extension, as that is actually the compression used - https://github.com/PCSX2/pcsx2/blob/master/plugins/GSdx/GSPng.cpp