### PR TITLE
pcsx2-gui: Modern Dark Themed Console v2

### DIFF
--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -393,7 +393,7 @@ ConsoleLogFrame::ConsoleLogFrame( MainEmuFrame *parent, const wxString& title, A
 	if (0==m_conf.Theme.CmpNoCase(L"Dark"))
 	{
 		m_ColorTable.SetColorScheme_Dark();
-		m_TextCtrl.SetBackgroundColour( wxColor( 54, 57, 62 ) );
+		m_TextCtrl.SetBackgroundColour( wxColor( 38, 41, 48 ) );
 	}
 	else //if ((0==m_conf.Theme.CmpNoCase("Default")) || (0==m_conf.Theme.CmpNoCase("Light")))
 	{
@@ -868,7 +868,7 @@ void ConsoleLogFrame::OnToggleTheme( wxCommandEvent& evt )
 		case MenuId_ColorScheme_Dark:
 			newTheme = L"Dark";
 			m_ColorTable.SetColorScheme_Dark();
-			m_TextCtrl.SetBackgroundColour( wxColor( 54, 57, 62 ) );
+			m_TextCtrl.SetBackgroundColour( wxColor( 38, 41, 48 ) );
 		break;
 	}
 


### PR DESCRIPTION
Makes it relatively darker by 30%

dev117 / PR 3446:
![image](https://user-images.githubusercontent.com/24227051/87252806-4e799f80-c476-11ea-9abb-103cfaa4743c.png)
![image](https://user-images.githubusercontent.com/24227051/87252884-ccd64180-c476-11ea-8edd-8b4111c9aa6b.png)

This PR:
![image](https://user-images.githubusercontent.com/24227051/87252811-5c2f2500-c476-11ea-8393-939a57da9fd4.png)
![image](https://user-images.githubusercontent.com/24227051/87252837-8e408700-c476-11ea-9ff6-a4e9adc24ce5.png)

Comparison slider:
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=fea2a7ce-c464-11ea-bf88-a15b6c7adf9a