### PR TITLE
Reduce header dependencies on x86Emitter

### DIFF
--- a/common/include/x86emitter/tools.h
+++ b/common/include/x86emitter/tools.h
@@ -15,8 +15,6 @@
 
 #pragma once
 
-#include "x86emitter.h"
-
 enum x86VendorType {
     x86Vendor_Intel = 0,
     x86Vendor_AMD = 1,
@@ -134,6 +132,12 @@ enum SSE_RoundMode {
 };
 
 ImplementEnumOperators(SSE_RoundMode);
+
+// Predeclaration for xIndirect32
+namespace x86Emitter {
+	template <typename T> class xIndirect;
+	typedef xIndirect<u32> xIndirect32;
+}
 
 // --------------------------------------------------------------------------------------
 //  SSE_MXCSR  -  Control/Status Register (bitfield)


### PR DESCRIPTION
`x86emitter/tools.h` is included by PCSX2's main `PrecompiledHeader.h`, meaning that it (and everything it includes) is a dependency of practically every file in PCSX2.

Removing its dependency on `x86emitter/x86emitter.h` reduces the rebuild time from editing other headers in `x86emitter` from 200s to 45s on my laptop (4c8t 2.8GHz Haswell)