### PR TITLE
Use precompiled headers with Clang

### DIFF
--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -117,3 +117,8 @@ set(UtilitiesFinalLibs
 
 add_pcsx2_lib(${Output} "${UtilitiesFinalSources}" "${UtilitiesFinalLibs}" "${UtilitiesFinalFlags}")
 add_pcsx2_lib(${Output}_NO_TLS "${UtilitiesFinalSources}" "${UtilitiesFinalLibs}" "${UtilitiesFinalFlags} -DPCSX2_THREAD_LOCAL=0")
+
+if(COMMAND target_precompile_headers)
+	target_precompile_headers(${Output} PRIVATE PrecompiledHeader.h)
+	target_precompile_headers(${Output}_NO_TLS PRIVATE PrecompiledHeader.h)
+endif()

--- a/common/src/x86emitter/CMakeLists.txt
+++ b/common/src/x86emitter/CMakeLists.txt
@@ -73,3 +73,7 @@ set(x86emitterFinalLibs
 )
 
 add_pcsx2_lib(${Output} "${x86emitterFinalSources}" "${x86emitterFinalLibs}" "${x86emitterFinalFlags}")
+
+if(COMMAND target_precompile_headers)
+	target_precompile_headers(${Output} PRIVATE PrecompiledHeader.h)
+endif()

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -714,11 +714,9 @@ endif()
 
 add_pcsx2_executable(${Output} "${pcsx2FinalSources}" "${pcsx2FinalLibs}" "${pcsx2FinalFlags}")
 
-if(NOT USE_CLANG)
-	if(COMMAND target_precompile_headers)
-		message("Using precompiled headers.")
-		target_precompile_headers(${Output} PRIVATE PrecompiledHeader.h)
-	endif()
+if(COMMAND target_precompile_headers)
+	message("Using precompiled headers.")
+	target_precompile_headers(${Output} PRIVATE PrecompiledHeader.h)
 endif()
 
 if (APPLE)


### PR DESCRIPTION
Full compile of PCSX2 (without plugins) on my laptop: 230s → 85s

@arcum42 When you added PCH you said it wasn't working with Clang, what was breaking for you?