### PR TITLE
IPU: Perform an interrupt on IPU_CTRL Reset.

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -9873,12 +9873,6 @@ Serial = SLES-51390
 Name   = Fightbox
 Region = PAL-E
 vuClampMode = 0 // Fixes missing 3D
-[patches = E7EFA0BF]
-	comment= Gets around GS SIGNAL hang, game expects value other than C in SIGNAL but the PATH2 packet sends double 0xC
-	comment= The SIGNAL value is compared to the value at address 0x34CDF3, if this address contains 0x4 (OR'd with 0x8)
-	commend= the interrupt doesn't get acknoledged and cleared and so the PATH2 packet hangs
-	patch=1,EE,001f5a0c,word,30840008
-[/patches]
 ---------------------------------------------
 Serial = SLES-51391
 Name   = RTL Skispringen 2003

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -283,6 +283,7 @@ void ipuSoftReset()
 	ipuRegs.cmd.DATA = 0; // required for Enthusia - Professional Racing after fix, or will freeze at start of next video.
 
 	memzero(g_BP);
+	hwIntcIrq(INTC_IPU); // required for FightBox
 }
 
 __fi bool ipuWrite32(u32 mem, u32 value)


### PR DESCRIPTION
Doing this reset performs a forced command end, meaning the IPU will run through the procedure of ending any command running and telling the core that it is done, even if there is no command currently active.
Fixes Fightbox