### PR TITLE
gui: If available, enable menu option to load backup savestate when a game is first launched

### DIFF
--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -71,7 +71,6 @@ void States_FreezeCurrentSlot()
 		Console.WriteLn("Load or save action is already pending.");
 		return;
 	}
-	States_updateLoadBackupMenuItem(true);
 
 	GSchangeSaveState(StatesC, SaveStateBase::GetFilename(StatesC).ToUTF8());
 	StateCopy_SaveToSlot(StatesC);
@@ -81,6 +80,8 @@ void States_FreezeCurrentSlot()
 #endif
 
 	GetSysExecutorThread().PostIdleEvent(SysExecEvent_ClearSavingLoadingFlag());
+
+	States_updateLoadBackupMenuItem();
 }
 
 void _States_DefrostCurrentSlot(bool isFromBackup)
@@ -115,14 +116,9 @@ void States_DefrostCurrentSlotBackup()
 	_States_DefrostCurrentSlot(true);
 }
 
-void States_updateLoadBackupMenuItem(bool isBeforeSave)
+void States_updateLoadBackupMenuItem()
 {
-	wxString file = SaveStateBase::GetFilename(StatesC);
-
-	if (!(isBeforeSave && g_Conf->EmuOptions.BackupSavestate))
-	{
-		file = file + L".backup";
-	}
+	wxString file = SaveStateBase::GetFilename(StatesC) + ".backup";
 
 	sMainFrame.EnableMenuItem(MenuId_State_LoadBackup, wxFileExists(file));
 	sMainFrame.SetMenuItemLabel(MenuId_State_LoadBackup, wxsFormat(L"%s %d", _("Backup"), StatesC));

--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -56,8 +56,6 @@ protected:
 	}
 };
 
-void Sstates_updateLoadBackupMenuItem(bool isBeforeSave);
-
 void States_FreezeCurrentSlot()
 {
 	// FIXME : Use of the IsSavingOrLoading flag is mostly a hack until we implement a
@@ -73,7 +71,7 @@ void States_FreezeCurrentSlot()
 		Console.WriteLn("Load or save action is already pending.");
 		return;
 	}
-	Sstates_updateLoadBackupMenuItem(true);
+	States_updateLoadBackupMenuItem(true);
 
 	GSchangeSaveState(StatesC, SaveStateBase::GetFilename(StatesC).ToUTF8());
 	StateCopy_SaveToSlot(StatesC);
@@ -104,7 +102,7 @@ void _States_DefrostCurrentSlot(bool isFromBackup)
 
 	GetSysExecutorThread().PostIdleEvent(SysExecEvent_ClearSavingLoadingFlag());
 
-	Sstates_updateLoadBackupMenuItem(false);
+	States_updateLoadBackupMenuItem();
 }
 
 void States_DefrostCurrentSlot()
@@ -117,8 +115,7 @@ void States_DefrostCurrentSlotBackup()
 	_States_DefrostCurrentSlot(true);
 }
 
-// I'd keep an eye on this function, as it may still be problematic.
-void Sstates_updateLoadBackupMenuItem(bool isBeforeSave)
+void States_updateLoadBackupMenuItem(bool isBeforeSave)
 {
 	wxString file = SaveStateBase::GetFilename(StatesC);
 
@@ -138,7 +135,7 @@ static void OnSlotChanged()
 	if (GSchangeSaveState != NULL)
 		GSchangeSaveState(StatesC, SaveStateBase::GetFilename(StatesC).utf8_str());
 
-	Sstates_updateLoadBackupMenuItem(false);
+	States_updateLoadBackupMenuItem();
 }
 
 int States_GetCurrentSlot()

--- a/pcsx2/gui/Saveslots.h
+++ b/pcsx2/gui/Saveslots.h
@@ -134,4 +134,4 @@ extern void States_CycleSlotForward();
 extern void States_CycleSlotBackward();
 extern void States_SetCurrentSlot(int slot);
 extern int States_GetCurrentSlot();
-extern void States_updateLoadBackupMenuItem(bool isBeforeSave = false);
+extern void States_updateLoadBackupMenuItem();

--- a/pcsx2/gui/Saveslots.h
+++ b/pcsx2/gui/Saveslots.h
@@ -134,4 +134,4 @@ extern void States_CycleSlotForward();
 extern void States_CycleSlotBackward();
 extern void States_SetCurrentSlot(int slot);
 extern int States_GetCurrentSlot();
-extern void Sstates_updateLoadBackupMenuItem(bool isBeforeSave);
+extern void States_updateLoadBackupMenuItem(bool isBeforeSave = false);

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -51,11 +51,16 @@ static void _SaveLoadStuff(bool enabled)
 	sMainFrame.EnableMenuItem(MenuId_Sys_SaveStates, enabled);
 
 #ifdef USE_NEW_SAVESLOTS_UI
+	bool crcChanged = false;
 	// Run though all the slots. Update if they need updating or the crc changed.
 	for (Saveslot &slot : saveslot_cache)
 	{
 		// We need to reload the file information if the crc or serial # changed.
-		if ((slot.crc != ElfCRC)|| (slot.serialName != DiscSerial)) slot.invalid_cache = true;
+		if ((slot.crc != ElfCRC)|| (slot.serialName != DiscSerial))
+		{
+			slot.invalid_cache = true;
+			crcChanged = true;
+		}
 
 		// Either the cache needs updating, or the menu items do, or both.
 		if (slot.menu_update || slot.invalid_cache)
@@ -85,7 +90,10 @@ static void _SaveLoadStuff(bool enabled)
 			sMainFrame.SetMenuItemLabel(slot.save_item_id, slot.SlotName());
 		}
 	}
-	States_updateLoadBackupMenuItem();
+	if (crcChanged)
+	{
+		States_updateLoadBackupMenuItem();
+	}
 #endif
 }
 

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -84,8 +84,8 @@ static void _SaveLoadStuff(bool enabled)
 			sMainFrame.SetMenuItemLabel(slot.load_item_id, slot.SlotName());
 			sMainFrame.SetMenuItemLabel(slot.save_item_id, slot.SlotName());
 		}
-
 	}
+	States_updateLoadBackupMenuItem();
 #endif
 }
 


### PR DESCRIPTION
I noticed this very small issue when working on something bigger than involved savestates.  When PCSX2 is first opened, and a game is launched saveslot `0` is selected, but even if there is a backup for slot 0 the menu option is not enabled (until you perform other savestate actions)

I deleted the comment labeling the function as potentially problematic because after simplifying the function and thinking through the possibilities, it looks fine to me.  The only hairy path is during saving:
- If backups are disabled, we look for an existing `.backup` savestate which shouldn't be touched by the save routine (and we don't expect a new one to be created)
- If backups are enabled, the `.backup` file will have already been created via renaming the original save-state.  The asynchronous process is dumping the _current emulation state_, so by the time we've hit this function the rename has already taken place so we have a guarantee to go off.
  - This solves a potential bug in the existing code (which probably would have never been hit):
    1. Save to a slot that has no current backup
    2. Rename fails
    3. Update method looks for the file without `.backup`, which is still there.  
    4. Load backup option is enabled despite there not actually being a backup to load.
- And for loading, files are not modified or renamed so we have a guarantee around what we are checking.