### PR TITLE
vs-build: use the win10 sdk

### DIFF
--- a/3rdparty/baseclasses/baseclasses.vcxproj
+++ b/3rdparty/baseclasses/baseclasses.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{27F17499-A372-4408-8AFA-4F9F4584FBD3}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/freetype/builds/windows/freetype.vcxproj
+++ b/3rdparty/freetype/builds/windows/freetype.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/libjpeg/libjpeg.vcxproj
+++ b/3rdparty/libjpeg/libjpeg.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BC236261-77E8-4567-8D09-45CD02965EB6}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/libpng/projects/vstudio/libpng/libpng.vcxproj
+++ b/3rdparty/libpng/projects/vstudio/libpng/libpng.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D6973076-9317-4EF2-A0B8-B7A18AC0713E}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/opencl/opencl.vcxproj
+++ b/3rdparty/opencl/opencl.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D80D4A75-C385-41BD-AE62-83D2E2B595A7}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/portaudio/build/msvc/portaudio.vcxproj
+++ b/3rdparty/portaudio/build/msvc/portaudio.vcxproj
@@ -50,6 +50,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0A18A071-125E-442F-AFF7-A3F68ABECF99}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/pthreads4w/build/pthreads4w.vcxproj
+++ b/3rdparty/pthreads4w/build/pthreads4w.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0FAE817D-9A32-4830-857E-81DA57246E16}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/wxwidgets3.0/build/msw/wx30_adv.vcxproj
+++ b/3rdparty/wxwidgets3.0/build/msw/wx30_adv.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{24C45343-FD20-5C92-81C1-35A2AE841E79}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/wxwidgets3.0/build/msw/wx30_base.vcxproj
+++ b/3rdparty/wxwidgets3.0/build/msw/wx30_base.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3FCC50C2-81E9-5DB2-B8D8-2129427568B1}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/wxwidgets3.0/build/msw/wx30_config.vcxproj
+++ b/3rdparty/wxwidgets3.0/build/msw/wx30_config.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{01F4CE10-2CFB-41A8-B41F-E54337868A1D}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/wxwidgets3.0/build/msw/wx30_core.vcxproj
+++ b/3rdparty/wxwidgets3.0/build/msw/wx30_core.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6744DAD8-9C70-574A-BFF2-9F8DDDB24A75}</ProjectGuid>
   </PropertyGroup>

--- a/3rdparty/xz/liblzma.vcxproj
+++ b/3rdparty/xz/liblzma.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{12728250-16EC-4DC6-94D7-E21DD88947F8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/3rdparty/zlib/zlib.vcxproj
+++ b/3rdparty/zlib/zlib.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2F6C0388-20CB-4242-9F6C-A6EBB6A83F47}</ProjectGuid>
   </PropertyGroup>

--- a/common/build/Utilities/utilities.vcxproj
+++ b/common/build/Utilities/utilities.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4639972E-424E-4E13-8B07-CA403C481346}</ProjectGuid>
   </PropertyGroup>

--- a/common/build/x86emitter/x86emitter.vcxproj
+++ b/common/build/x86emitter/x86emitter.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A51123F5-9505-4EAE-85E7-D320290A272C}</ProjectGuid>
   </PropertyGroup>

--- a/common/vsprops/WinSDK.props
+++ b/common/vsprops/WinSDK.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- TODO: vs2017 doesn't support using the lastest installed, 2019 does, this is the workaround -->
+  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(LatestTargetPlatformVersion)</TargetPlatformVersion>
+  </PropertyGroup>
+</Project>

--- a/common/vsprops/WinSDK.props
+++ b/common/vsprops/WinSDK.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- TODO: vs2017 doesn't support using the lastest installed, 2019 does, this is the workaround -->
+  <!-- TODO: vs2017 doesn't support using the latest installed, 2019 does, this is the workaround -->
   <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
     <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -26,6 +26,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1CEFD830-2B76-4596-A4EE-BCD7280A60BD}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/FWnull/Windows/FWnull.vcxproj
+++ b/plugins/FWnull/Windows/FWnull.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3D0EB14D-32F3-4D82-9C6D-B806ADBB859C}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/GSdx/GSdx.vcxproj
+++ b/plugins/GSdx/GSdx.vcxproj
@@ -50,6 +50,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{18E42F6F-3A62-41EE-B42F-79366C4F1E95}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/LilyPad/LilyPad.vcxproj
+++ b/plugins/LilyPad/LilyPad.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E4081455-398C-4610-A87C-90A8A7D72DC3}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/USBnull/Windows/USBnull.vcxproj
+++ b/plugins/USBnull/Windows/USBnull.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BF7B81A5-E348-4F7C-A69F-F74C8EEEAD70}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/cdvdGigaherz/src/Windows/cdvdGigaherz.vcxproj
+++ b/plugins/cdvdGigaherz/src/Windows/cdvdGigaherz.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5CF88D5F-64DD-4EDC-9F1A-436BD502940A}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/dev9ghzdrk/Win32/DEV9ghzdrk.vcxproj
+++ b/plugins/dev9ghzdrk/Win32/DEV9ghzdrk.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BBE4E5FB-530A-4D18-A633-35AF0577B7F3}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/dev9null/Windows/DEV9null.vcxproj
+++ b/plugins/dev9null/Windows/DEV9null.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{04439C5F-05FB-4A9C-AAD1-5388C25377DB}</ProjectGuid>
   </PropertyGroup>

--- a/plugins/spu2-x/src/Windows/Spu2-X.vcxproj
+++ b/plugins/spu2-x/src/Windows/Spu2-X.vcxproj
@@ -34,6 +34,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5307BBB7-EBB9-4AA4-8CB6-A94EC473C8C4}</ProjectGuid>
   </PropertyGroup>

--- a/tools/bin2cpp/bin2c.vcxproj
+++ b/tools/bin2cpp/bin2c.vcxproj
@@ -18,6 +18,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
   <PropertyGroup Label="Globals">
     <ProjectName>bin2cpp</ProjectName>
     <ProjectGuid>{677B7D11-D5E1-40B3-88B1-9A4DF83D2213}</ProjectGuid>


### PR DESCRIPTION
Makes the project build with the latest win10 SDK on the system. Uses a workaround for vs2017 to be replaced whenever we drop that build.

Doing this to address build issues in #3549 