### PR TITLE
Refactor a repeatedly used plugin loop.

### DIFF
--- a/pcsx2/Plugins.h
+++ b/pcsx2/Plugins.h
@@ -425,6 +425,30 @@ protected:
 
 extern const PluginInfo tbl_PluginInfo[];
 
+template<typename Func>
+static void ForPlugins(const Func& f)
+{
+	const PluginInfo* pi = tbl_PluginInfo;
+
+	do
+	{
+		f(pi);
+	}  while(++pi, pi->shortname != nullptr);
+}
+
+template<typename Func>
+static bool IfPlugins(const Func& f)
+{
+	const PluginInfo* pi = tbl_PluginInfo;
+
+	do
+	{
+		if (f(pi)) return true;
+	}  while(++pi, pi->shortname != nullptr);
+
+	return false;
+}
+
 // GetPluginManager() is a required external implementation. This function is *NOT*
 // provided by the PCSX2 core library.  It provides an interface for the linking User
 // Interface apps or DLLs to reference their own instance of SysCorePlugins (also allowing

--- a/pcsx2/gui/AppCorePlugins.cpp
+++ b/pcsx2/gui/AppCorePlugins.cpp
@@ -88,13 +88,12 @@ static void PostPluginStatus( PluginEventType pevt )
 
 static void ConvertPluginFilenames( wxString (&passins)[PluginId_Count] )
 {
-	const PluginInfo* pi = tbl_PluginInfo; do
-	{
+	ForPlugins([&] (const PluginInfo * pi) {
 		passins[pi->id] = wxGetApp().Overrides.Filenames[pi->id].GetFullPath();
 
 		if( passins[pi->id].IsEmpty() || !wxFileExists( passins[pi->id] ) )
 			passins[pi->id] = g_Conf->FullpathTo( pi->id );
-	} while( ++pi, pi->shortname != NULL );
+	});
 }
 
 typedef void (AppCorePlugins::*FnPtr_AppPluginManager)();
@@ -335,12 +334,6 @@ void AppCorePlugins::Open()
 {
 	AffinityAssert_AllowFrom_CoreThread();
 
-	/*if( !GetSysExecutorThread().IsSelf() )
-	{
-		GetSysExecutorThread().ProcessEvent( new SysExecEvent_AppPluginManager( &AppCorePlugins::Open ) );
-		return;
-	}*/
-
     SetLogFolder( GetLogFolder().ToString() );
 	SetSettingsFolder( GetSettingsFolder().ToString() );
 
@@ -547,7 +540,6 @@ void SysExecEvent_SaveSinglePlugin::InvokeEvent()
 	s_DisableGsWindow = true;		// keeps the GS window smooth by avoiding closing the window
 
 	ScopedCoreThreadPause paused_core;
-	//_LoadPluginsImmediate();
 
 	if( CorePlugins.AreLoaded() )
 	{
@@ -569,8 +561,6 @@ void SysExecEvent_SaveSinglePlugin::InvokeEvent()
 			Console.WriteLn( Color_Green, L"Recovering single plugin: " + tbl_PluginInfo[m_pid].GetShortname() );
 			memLoadingState load( plugstore.get() );
 			GetCorePlugins().Freeze( m_pid, load );
-			// GS plugin suspend / resume hack. Removed in r4363, hopefully never to return :p
-			//GetCorePlugins().Close( m_pid );		// hack for stupid GS plugins.
 		}
 	}
 


### PR DESCRIPTION
Nothing too critical. I just noticed the same while loop over and over again, and figured there had to be a way to factor it out.

So I did.

If you want to loop through the plugins, pass the ForPlugins function a lambda with [&] (const PluginInfo * pi), and do everything with the plugin info from pi. If you want to loop through and halt when something is true, use IfPlugins instead, and return a bool.

I think it's more readable than:
const PluginInfo* pi = tbl_PluginInfo; do {
		...
	}  while(++pi, pi->shortname != NULL);

Especially since there's the weirdness that tbl_PluginInfo actually has all the plugins in it, then NULL, to cause the loop to halt, and then the memory card "plugin".

I could use to make sure it doesn't break anything, though, since I did have to make changes to anything that used continue or return in the loop.