### PR TITLE
GSdx-hw: Cleanup blending a bit, mostly d3d11.

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -310,10 +310,6 @@ public:
 			struct
 			{
 				uint32 abe:1;
-				uint32 a:2;
-				uint32 b:2;
-				uint32 c:2;
-				uint32 d:2;
 				uint32 wr:1;
 				uint32 wg:1;
 				uint32 wb:1;
@@ -323,15 +319,14 @@ public:
 
 			struct
 			{
-				uint32 _pad:1;
-				uint32 abcd:8;
+				uint32 _pad:2;
 				uint32 wrgba:4;
 			};
 
 			uint32 key;
 		};
 
-		operator uint32() {return key & 0x3fff;}
+		operator uint32() {return key & 0x3f;}
 
 		OMBlendSelector() : key(0) {}
 	};
@@ -558,7 +553,7 @@ public:
 	void SetupVS(VSSelector sel, const VSConstantBuffer* cb);
 	void SetupGS(GSSelector sel, const GSConstantBuffer* cb);
 	void SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSelector ssel);
-	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix);
+	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 blend_index, uint8 afix);
 
 	ID3D11Device* operator->() {return m_dev;}
 	operator ID3D11Device*() {return m_dev;}

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -526,9 +526,7 @@ void GSRendererDX11::EmulateBlending()
 		}
 	}
 
-	const uint8 blend_index  = uint8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
 	const int blend_flag = m_dev->GetBlendFlags(blend_index);
-
 	// Do the multiplication in shader for blending accumulation: Cs*As + Cd or Cs*Af + Cd
 	const bool accumulation_blend = !!(blend_flag & BLEND_ACCU);
 

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -505,14 +505,10 @@ void GSRendererDX11::EmulateBlending()
 		return;
 
 	m_om_bsel.abe = 1;
-	m_om_bsel.a = ALPHA.A;
-	m_om_bsel.b = ALPHA.B;
-	m_om_bsel.c = ALPHA.C;
-	m_om_bsel.d = ALPHA.D;
 
 	if (m_env.PABE.PABE)
 	{
-		if (m_om_bsel.a == 0 && m_om_bsel.b == 1 && m_om_bsel.c == 0 && m_om_bsel.d == 1)
+		if (ALPHA.A == 0 && ALPHA.B == 1 && ALPHA.C == 0 && ALPHA.D == 1)
 		{
 			// this works because with PABE alpha blending is on when alpha >= 0x80, but since the pixel shader
 			// cannot output anything over 0x80 (== 1.0) blending with 0x80 or turning it off gives the same result
@@ -1109,8 +1105,8 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 
 	SetupIA(sx, sy);
 
-	uint8 afix = m_context->ALPHA.FIX;
-	dev->SetupOM(m_om_dssel, m_om_bsel, afix);
+	const uint8 afix = m_context->ALPHA.FIX;
+	dev->SetupOM(m_om_dssel, m_om_bsel, blend_index, afix);
 	dev->SetupVS(m_vs_sel, &vs_cb);
 	dev->SetupGS(m_gs_sel, &gs_cb);
 	dev->SetupPS(m_ps_sel, &ps_cb, m_ps_ssel);
@@ -1178,7 +1174,7 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 			m_om_bsel.wb = b;
 			m_om_bsel.wa = a;
 
-			dev->SetupOM(m_om_dssel, m_om_bsel, afix);
+			dev->SetupOM(m_om_dssel, m_om_bsel, blend_index, afix);
 
 			dev->DrawIndexedPrimitive();
 		}

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -288,7 +288,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 	PSSetShader(i->second, m_ps_cb);
 }
 
-void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix)
+void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 blend_index, uint8 afix)
 {
 	auto i = std::as_const(m_om_dss).find(dssel);
 
@@ -351,9 +351,7 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 
 		if(bsel.abe)
 		{
-			int i = ((bsel.a * 3 + bsel.b) * 3 + bsel.c) * 3 + bsel.d;
-
-			HWBlend blend = GetBlend(i);
+			const HWBlend blend = GetBlend(blend_index);
 			bd.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
 			bd.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;
 			bd.RenderTarget[0].DestBlend = (D3D11_BLEND)blend.dst;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -149,6 +149,9 @@ protected:
 
 	virtual void DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* tex) = 0;
 
+	// Compute the blending equation to detect special case
+	const uint8 blend_index = uint8(((m_context->ALPHA.A * 3 + m_context->ALPHA.B) * 3 + m_context->ALPHA.C) * 3 + m_context->ALPHA.D);
+
 	int m_userhacks_round_sprite_offset;
 	int m_userHacks_HPO;
 	bool m_userHacks_enabled_unscale_ptln;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -473,10 +473,7 @@ void GSRendererOGL::EmulateBlending(bool DATE_GL42)
 		//ASSERT(0);
 	}
 
-	// Compute the blending equation to detect special case
-	const uint8 blend_index  = uint8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
 	const int blend_flag = m_dev->GetBlendFlags(blend_index);
-
 	// SW Blend is (nearly) free. Let's use it.
 	const bool impossible_or_free_blend = (blend_flag & (BLEND_NO_REC|BLEND_A_MAX|BLEND_ACCU)) // Blend doesn't requires the costly barrier
 		|| (m_prim_overlap == PRIM_OVERLAP_NO) // Blend can be done in a single draw


### PR DESCRIPTION
gsdx-hw: Move blend_index to rendererhw so it can be shared.

gsdx-d3d11: Cleanup blending code a bit.
Use same blend_index from rendererhw and pass it as a parameter to SetupOM.
Remove bsel abcd bits.