### PR TITLE
GSdx-hw: Make d3d11 not crash on W7.

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -105,7 +105,7 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd> &wnd)
 
 	// create factory
 	{
-		const HRESULT result = CreateDXGIFactory2(0, IID_PPV_ARGS(&m_factory));
+		const HRESULT result = CreateDXGIFactory1(IID_PPV_ARGS(&m_factory));
 		if (FAILED(result))
 		{
 			fprintf(stderr, "D3D11: Unable to create DXGIFactory2 (reason: %x)\n", result);


### PR DESCRIPTION
Changes `CreateDXGIFactory2` to `CreateDXGIFactory1` which is available in Windows7 and is also able to create `IDXGIFactory2` interfaces.

[CreateDXGIFactory2 function](https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_3/nf-dxgi1_3-createdxgifactory2)

> **Remarks**
> This function accepts a flag indicating whether DXGIDebug.dll is loaded. The function otherwise behaves identically to CreateDXGIFactory1.