### PR TITLE
Remove check for program range wrap in mVU

### DIFF
--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -67,32 +67,25 @@ void mVUsetupRange(microVU& mVU, s32 pc, bool isStartPC) {
 		ranges->push_front(mRange);
 		return;
 	}
-	if (mVUrange.start <= pc) {
-		mVUrange.end = pc;
-		bool mergedRange = false;
-		s32  rStart = mVUrange.start;
-		s32  rEnd   = mVUrange.end;
-		std::deque<microRange>::iterator it(ranges->begin());
-		for (++it; it != ranges->end(); ++it) {
-			if((it[0].start >= rStart) && (it[0].start <= rEnd)) {
-				it[0].end   = std::max(it[0].end, rEnd);
-				mergedRange = true;
-			}
-			else if ((it[0].end >= rStart) && (it[0].end <= rEnd)) {
-				it[0].start = std::min(it[0].start, rStart);
-				mergedRange = true;
-			}
+
+	mVUrange.end = pc;
+	bool mergedRange = false;
+	s32  rStart = mVUrange.start;
+	s32  rEnd   = mVUrange.end;
+	std::deque<microRange>::iterator it(ranges->begin());
+	for (++it; it != ranges->end(); ++it) {
+		if((it[0].start >= rStart) && (it[0].start <= rEnd)) {
+			it[0].end   = std::max(it[0].end, rEnd);
+			mergedRange = true;
 		}
-		if (mergedRange) {
-			//DevCon.WriteLn(Color_Green, "microVU%d: Prog Range Merging", mVU.index);
-			ranges->erase(ranges->begin());
+		else if ((it[0].end >= rStart) && (it[0].end <= rEnd)) {
+			it[0].start = std::min(it[0].start, rStart);
+			mergedRange = true;
 		}
 	}
-	else {
-		DevCon.WriteLn(Color_Green, "microVU%d: Prog Range Wrap [%04x] [%d]", mVU.index, mVUrange.start, mVUrange.end);
-		mVUrange.end = mVU.microMemSize;
-		microRange mRange = {0, pc};
-		ranges->push_front(mRange);
+	if (mergedRange) {
+		//DevCon.WriteLn(Color_Green, "microVU%d: Prog Range Merging", mVU.index);
+		ranges->erase(ranges->begin());
 	}
 }
 


### PR DESCRIPTION
Previously every VU program that wrapped program counter from 0x3FF8 to 0x0 was cached as new one. 
That caused bad performance, and unnecessary caching of the same program on and on. This commit:

- Remove check for mVUrange.start to be lower or even with current pc
- Remove old code to handle situation when mVUrange.start was higher than pc 
- Allow pc ranges to be merged for games that do this, instead of caching 0 to 3ff8
- Affect, and fix only games that previously used that code path (TOCA3, IHRA 2005, Goosebumps Horrorland, ProStroke Golf - World Tour 2007, and probably other produced by Gusto Games).

fixes #2388 