### PR TITLE
man: Silence warnings.

### DIFF
--- a/bin/docs/PCSX2.1
+++ b/bin/docs/PCSX2.1
@@ -62,7 +62,7 @@ This allows you to play PS2 games on your PC, with many additional features and
 benefits.
 .Sh GENERAL OPTIONS
 .Bl -tag -width Ds
-.It Fl h, Fl \-help
+.It Fl h , Fl \-help
 Displays the list of available command line options.
 .It Fl \-cfg Ns = Ns Ar file
 Uses
@@ -116,7 +116,7 @@ Boots with an empty DVD tray.
 Use this to boot into the PS2 system menu.
 .It Fl \-usecd
 Boots using the configured CDVD plugin instead of booting
-.Ar iso Ns .
+.Ar iso .
 .It Fl \-fullscreen
 Runs the game in fullscreen mode.
 .It Fl \-windowed
@@ -177,7 +177,7 @@ User configuration and data directory.
 .An PCSX2 Dev Team and many other contributors
 .Sh BUGS
 Bugs can be reported by submitting an issue at the
-.Lk https://github.com/PCSX2/pcsx2/issues "PCSX2 Github issue tracker" Ns .
+.Lk https://github.com/PCSX2/pcsx2/issues "PCSX2 Github issue tracker" .
 .Sh PCSX2 RELATED WEBSITES
 .Bl -bullet
 .It


### PR DESCRIPTION
```
man: ./PCSX2.1:65:9: STYLE: no blank before trailing delimiter: Fl h,
man: ./PCSX2.1:119:9: WARNING: skipping no-space macro
man: ./PCSX2.1:180:72: WARNING: skipping no-space macro
```
Reproduced with `mandoc-1.14.5.`
```
man -Tlint -l ./PCSX2.1
```
https://mandoc.bsd.lv/

The only cosmetic change is the first warning where `man(1)` no longer recognizes the option as `-h,` and now shows `-h` correctly.

__Original__
![orig](https://i.imgur.com/ZcjT2TP.png)

__PR__
![pr](https://i.imgur.com/gZtbb92.png)