### PR TITLE
Socket IPC implementation

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -75,6 +75,7 @@ set(pcsx2Sources
 	IopIrq.cpp
 	IopMem.cpp
 	IopSio2.cpp
+	IPC.cpp
 	Mdec.cpp
 	Memory.cpp
 	MMI.cpp
@@ -147,6 +148,7 @@ set(pcsx2Headers
 	IopHw.h
 	IopMem.h
 	IopSio2.h
+	IPC.h
 	Mdec.h
 	MTVU.h
 	Memory.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -454,6 +454,7 @@ struct Pcsx2Config
 			CdvdShareWrite		:1,		// allows the iso to be modified while it's loaded
 			EnablePatches		:1,		// enables patch detection and application
 			EnableCheats		:1,		// enables cheat detection and application
+			EnableIPC		    :1,		// enables inter-process communication 
 			EnableWideScreenPatches		:1,
 #ifndef DISABLE_RECORDING
 			EnableRecordingTools :1,

--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -1,0 +1,256 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <thread>
+#include <sys/types.h>
+#if _WIN32
+#define read_portable(a, b, c) (recv(a, b, c, 0))
+#define write_portable(a, b, c) (send(a, b, c, 0))
+#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
+#include <windows.h>
+#else
+#define read_portable(a, b, c) (read(a, b, c))
+#define write_portable(a, b, c) (write(a, b, c))
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
+#include "Common.h"
+#include "Memory.h"
+#include "System/SysThreads.h"
+#include "IPC.h"
+
+SocketIPC::SocketIPC(SysCoreThread* vm)
+	: pxThread("IPC_Socket")
+{
+#ifdef _WIN32
+	WSADATA wsa;
+	SOCKET new_socket;
+	struct sockaddr_in server, client;
+	int c;
+
+
+	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+	{
+		Console.WriteLn(Color_Red, "IPC: Cannot initialize winsock! Shutting down...");
+		return;
+	}
+
+	if ((m_sock = socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET)
+	{
+		Console.WriteLn(Color_Red, "IPC: Cannot open socket! Shutting down...");
+		return;
+	}
+
+	// yes very good windows s/sun/sin/g sure is fine
+	server.sin_family = AF_INET;
+	// localhost only
+	server.sin_addr.s_addr = inet_addr("127.0.0.1");
+	server.sin_port = htons(PORT);
+
+	if (bind(m_sock, (struct sockaddr*)&server, sizeof(server)) == SOCKET_ERROR)
+	{
+		Console.WriteLn(Color_Red, "IPC: Error while binding to socket! Shutting down...");
+		return;
+	}
+
+#else
+	struct sockaddr_un server;
+
+	m_sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (m_sock < 0)
+	{
+		Console.WriteLn(Color_Red, "IPC: Cannot open socket! Shutting down...");
+		return;
+	}
+	server.sun_family = AF_UNIX;
+	strcpy(server.sun_path, SOCKET_NAME);
+
+	// we unlink the socket so that when releasing this thread the socket gets
+	// freed even if we didn't close correctly the loop
+	unlink(SOCKET_NAME);
+	if (bind(m_sock, (struct sockaddr*)&server, sizeof(struct sockaddr_un)))
+	{
+		Console.WriteLn(Color_Red, "IPC: Error while binding to socket! Shutting down...");
+		return;
+	}
+#endif
+
+	// maximum queue of SOMAXCONN commands before refusing, which stops the thread
+	listen(m_sock, SOMAXCONN);
+
+	// we save a handle of the main vm object
+	m_vm = vm;
+
+	// we start the thread
+	Start();
+}
+
+void SocketIPC::ExecuteTaskInThread()
+{
+	int msgsock = 0;
+	// for the sake of speed we malloc once a return buffer and reuse it by just
+	// cropping its size when needed, it is 450k long which is the size of 50k
+	// MsgWrite64 replies, should be good enough even if we implement batch IPC
+	// processing. Coincidentally 650k is the size of 50k MsgWrite64 REQUESTS so
+	// we just allocate a 1mb buffer in the end, lul
+	ret_buffer = (char*)malloc(450000 * sizeof(char));
+	ipc_buffer = (char*)malloc(650000 * sizeof(char));
+	while (true)
+	{
+		msgsock = accept(m_sock, 0, 0);
+		if (msgsock == -1)
+		{
+			return;
+		}
+		else
+		{
+			if (read_portable(msgsock, ipc_buffer, 650000) < 0)
+			{
+				return;
+			}
+			else
+			{
+				auto res = ParseCommand(ipc_buffer, ret_buffer);
+				if (write_portable(msgsock, res.second, res.first) < 0)
+				{
+					return;
+				}
+			}
+		}
+	}
+}
+
+SocketIPC::~SocketIPC()
+{
+#ifdef _WIN32
+	closesocket(m_sock);
+	WSACleanup();
+#else
+	close(m_sock);
+	unlink(SOCKET_NAME);
+#endif
+	free(ret_buffer);
+	free(ipc_buffer);
+	// destroy the thread
+	try
+	{
+		pxThread::Cancel();
+	}
+	DESTRUCTOR_CATCHALL
+}
+
+char* SocketIPC::MakeOkIPC(char* ret_buffer)
+{
+	ret_buffer[0] = (unsigned char)IPC_OK;
+	return ret_buffer;
+}
+
+char* SocketIPC::MakeFailIPC(char* ret_buffer)
+{
+	ret_buffer[0] = (unsigned char)IPC_FAIL;
+	return ret_buffer;
+}
+
+std::pair<int, char*> SocketIPC::ParseCommand(char* buf, char* ret_buffer)
+{
+	// currently all our instructions require a running VM so we check once
+	// here, will help perf when/if we implement multi-ipc processing in one
+	// socket roundtrip.
+	if (!m_vm->HasActiveMachine())
+		return std::make_pair(1, MakeFailIPC(ret_buffer));
+
+	//         IPC Message event (1 byte)
+	//         |  Memory address (4 byte)
+	//         |  |           argument (VLE)
+	//         |  |           |
+	// format: XX YY YY YY YY ZZ ZZ ZZ ZZ
+	//        reply code: 00 = OK, FF = NOT OK
+	//        |  return value (VLE)
+	//        |  |
+	// reply: XX ZZ ZZ ZZ ZZ
+	IPCCommand opcode = (IPCCommand)buf[0];
+
+	// return value
+	std::pair<int, char*> rval;
+
+	// YY YY YY YY from schema above
+	u32 a = FromArray<u32>(buf, 1);
+	switch (opcode)
+	{
+		case MsgRead8:
+		{
+			u8 res;
+			res = memRead8(a);
+			rval = std::make_pair(2, ToArray(MakeOkIPC(ret_buffer), res, 1));
+			break;
+		}
+		case MsgRead16:
+		{
+			u16 res;
+			res = memRead16(a);
+			rval = std::make_pair(3, ToArray(MakeOkIPC(ret_buffer), res, 1));
+			break;
+		}
+		case MsgRead32:
+		{
+			u32 res;
+			res = memRead32(a);
+			rval = std::make_pair(5, ToArray(MakeOkIPC(ret_buffer), res, 1));
+			break;
+		}
+		case MsgRead64:
+		{
+			u64 res;
+			memRead64(a, &res);
+			rval = std::make_pair(9, ToArray(MakeOkIPC(ret_buffer), res, 1));
+			break;
+		}
+		case MsgWrite8:
+		{
+			memWrite8(a, FromArray<u8>(buf, 5));
+			rval = std::make_pair(1, MakeOkIPC(ret_buffer));
+			break;
+		}
+		case MsgWrite16:
+		{
+			memWrite16(a, FromArray<u16>(buf, 5));
+			rval = std::make_pair(1, MakeOkIPC(ret_buffer));
+			break;
+		}
+		case MsgWrite32:
+		{
+			memWrite32(a, FromArray<u32>(buf, 5));
+			rval = std::make_pair(1, MakeOkIPC(ret_buffer));
+			break;
+		}
+		case MsgWrite64:
+		{
+			memWrite64(a, FromArray<u64>(buf, 5));
+			rval = std::make_pair(1, MakeOkIPC(ret_buffer));
+			break;
+		}
+		default:
+		{
+			rval = std::make_pair(1, MakeFailIPC(ret_buffer));
+			break;
+		}
+	}
+	return rval;
+}

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -88,7 +88,7 @@ protected:
 		MsgWrite16 = 5,        /**< Write 16 bit value to memory. */
 		MsgWrite32 = 6,        /**< Write 32 bit value to memory. */
 		MsgWrite64 = 7,        /**< Write 64 bit value to memory. */
-		MsgMultiCommand = 0xFF /**< Treats multiple IPC commands in batch. */
+		MsgUnimplemented = 0xFF /**< Unimplemented IPC message. */
 	};
 
 

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -38,9 +38,8 @@ protected:
 	// the message socket used in thread's accept().
 	SOCKET m_msgsock = INVALID_SOCKET;
 #else
-	// absolute path of the socket. Stored in the temporary directory in linux since
-	// /run requires superuser permission
-	const char* SOCKET_NAME = "/tmp/pcsx2.sock";
+	// absolute path of the socket. Stored in XDG_RUNTIME_DIR, if unset /tmp
+	char* m_socket_name;
 	int m_sock = 0;
 	// the message socket used in thread's accept().
 	int m_msgsock = 0;
@@ -80,14 +79,14 @@ protected:
      */
 	enum IPCCommand : unsigned char
 	{
-		MsgRead8 = 0,          /**< Read 8 bit value to memory. */
-		MsgRead16 = 1,         /**< Read 16 bit value to memory. */
-		MsgRead32 = 2,         /**< Read 32 bit value to memory. */
-		MsgRead64 = 3,         /**< Read 64 bit value to memory. */
-		MsgWrite8 = 4,         /**< Write 8 bit value to memory. */
-		MsgWrite16 = 5,        /**< Write 16 bit value to memory. */
-		MsgWrite32 = 6,        /**< Write 32 bit value to memory. */
-		MsgWrite64 = 7,        /**< Write 64 bit value to memory. */
+		MsgRead8 = 0,           /**< Read 8 bit value to memory. */
+		MsgRead16 = 1,          /**< Read 16 bit value to memory. */
+		MsgRead32 = 2,          /**< Read 32 bit value to memory. */
+		MsgRead64 = 3,          /**< Read 64 bit value to memory. */
+		MsgWrite8 = 4,          /**< Write 8 bit value to memory. */
+		MsgWrite16 = 5,         /**< Write 16 bit value to memory. */
+		MsgWrite32 = 6,         /**< Write 32 bit value to memory. */
+		MsgWrite64 = 7,         /**< Write 64 bit value to memory. */
 		MsgUnimplemented = 0xFF /**< Unimplemented IPC message. */
 	};
 

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -42,18 +42,17 @@ protected:
 	int m_sock = 0;
 #endif
 
-
 	/**
      * Maximum memory used by an IPC message request.
      * Equivalent to 50,000 Write64 requests.
      */
-	const unsigned int MAX_IPC_SIZE = 650000;
+#define MAX_IPC_SIZE 650000
 
 	/**
      * Maximum memory used by an IPC message reply.
      * Equivalent to 50,000 Read64 replies.
      */
-	const unsigned int MAX_IPC_RETURN_SIZE = 450000;
+#define MAX_IPC_RETURN_SIZE 450000
 
 	/**
      * IPC return buffer.
@@ -152,6 +151,19 @@ protected:
 	static T FromArray(char* arr, int i)
 	{
 		return *(T*)(arr + i);
+	}
+
+	/**
+     * Ensures an IPC message isn't too big.
+     * return value: false if checks failed, true otherwise.
+     */
+	static inline bool SafetyChecks(u32 command_len, int command_size, u32 reply_len, int reply_size = 0)
+	{
+		bool res = ((command_len + command_size) >= MAX_IPC_SIZE ||
+					(reply_len + reply_size) >= MAX_IPC_RETURN_SIZE);
+		if (unlikely(res))
+			return false;
+		return true;
 	}
 
 public:

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -130,10 +130,11 @@ protected:
 
 	/* Formats an IPC buffer
          * ret_buffer: return buffer to use. 
+         * size: size of the IPC buffer.
          * return value: buffer containing the status code allocated of size
          *               size */
-	static inline char* MakeOkIPC(char* ret_buffer);
-	static inline char* MakeFailIPC(char* ret_buffer);
+	static inline char* MakeOkIPC(char* ret_buffer, uint32_t size);
+	static inline char* MakeFailIPC(char* ret_buffer, uint32_t size);
 
 	/* Converts an uint to an char* in little endian 
          * res_array: the array to modify 

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -47,36 +47,36 @@ protected:
 
 
 	/**
-     * Maximum memory used by an IPC message request.
-     * Equivalent to 50,000 Write64 requests.
-     */
+	 * Maximum memory used by an IPC message request.
+	 * Equivalent to 50,000 Write64 requests.
+	 */
 #define MAX_IPC_SIZE 650000
 
 	/**
-     * Maximum memory used by an IPC message reply.
-     * Equivalent to 50,000 Read64 replies.
-     */
+	 * Maximum memory used by an IPC message reply.
+	 * Equivalent to 50,000 Read64 replies.
+	 */
 #define MAX_IPC_RETURN_SIZE 450000
 
 	/**
-     * IPC return buffer.
-     * A preallocated buffer used to store all IPC replies.
-     * to the size of 50.000 MsgWrite64 IPC calls.
-     */
+	 * IPC return buffer.
+	 * A preallocated buffer used to store all IPC replies.
+	 * to the size of 50.000 MsgWrite64 IPC calls.
+	 */
 	char* m_ret_buffer;
 
 	/**
-     * IPC messages buffer.
-     * A preallocated buffer used to store all IPC messages.
-     */
+	 * IPC messages buffer.
+	 * A preallocated buffer used to store all IPC messages.
+	 */
 	char* m_ipc_buffer;
 
 	/**
-     * IPC Command messages opcodes.  
-     * A list of possible operations possible by the IPC.  
-     * Each one of them is what we call an "opcode" and is the first
-     * byte sent by the IPC to differentiate between commands.  
-     */
+	 * IPC Command messages opcodes.  
+	 * A list of possible operations possible by the IPC.  
+	 * Each one of them is what we call an "opcode" and is the first
+	 * byte sent by the IPC to differentiate between commands.  
+	 */
 	enum IPCCommand : unsigned char
 	{
 		MsgRead8 = 0,           /**< Read 8 bit value to memory. */
@@ -92,9 +92,9 @@ protected:
 
 
 	/**
-     * IPC message buffer. 
-     * A list of all needed fields to store an IPC message.
-     */
+	 * IPC message buffer. 
+	 * A list of all needed fields to store an IPC message.
+	 */
 	struct IPCBuffer
 	{
 		int size;     /**< Size of the buffer. */
@@ -102,11 +102,11 @@ protected:
 	};
 
 	/**
-     * IPC result codes.
-     * A list of possible result codes the IPC can send back.
-     * Each one of them is what we call an "opcode" or "tag" and is the
-     * first byte sent by the IPC to differentiate between results.
-     */
+	 * IPC result codes.
+	 * A list of possible result codes the IPC can send back.
+	 * Each one of them is what we call an "opcode" or "tag" and is the
+	 * first byte sent by the IPC to differentiate between results.
+	 */
 	enum IPCResult : unsigned char
 	{
 		IPC_OK = 0,     /**< IPC command successfully completed. */
@@ -119,28 +119,33 @@ protected:
 	// Thread used to relay IPC commands.
 	void ExecuteTaskInThread();
 
-	/* Internal function, Parses an IPC command.
-         * buf: buffer containing the IPC command.
-         * buf_size: size of the buffer announced.
-         * ret_buffer: buffer that will be used to send the reply.
-         * return value: IPCBuffer containing a buffer with the result 
-         *               of the command and its size. */
+	/**
+	 * Internal function, Parses an IPC command.
+	 * buf: buffer containing the IPC command.
+	 * buf_size: size of the buffer announced.
+	 * ret_buffer: buffer that will be used to send the reply.
+	 * return value: IPCBuffer containing a buffer with the result 
+	 *               of the command and its size. 
+	 */
 	IPCBuffer ParseCommand(char* buf, char* ret_buffer, u32 buf_size);
 
-	/* Formats an IPC buffer
-         * ret_buffer: return buffer to use. 
-         * size: size of the IPC buffer.
-         * return value: buffer containing the status code allocated of size
-         *               size */
+	/**
+	 * Formats an IPC buffer
+	 * ret_buffer: return buffer to use. 
+	 * size: size of the IPC buffer.
+	 * return value: buffer containing the status code allocated of size
+	 */
 	static inline char* MakeOkIPC(char* ret_buffer, uint32_t size);
 	static inline char* MakeFailIPC(char* ret_buffer, uint32_t size);
 
-	/* Converts an uint to an char* in little endian 
-         * res_array: the array to modify 
-         * res: the value to convert
-         * i: when to insert it into the array 
-         * return value: res_array 
-         * NB: implicitely inlined */
+	/**
+	 * Converts an uint to an char* in little endian 
+	 * res_array: the array to modify 
+	 * res: the value to convert
+	 * i: when to insert it into the array 
+	 * return value: res_array 
+	 * NB: implicitely inlined 
+	 */
 	template <typename T>
 	static char* ToArray(char* res_array, T res, int i)
 	{
@@ -148,11 +153,13 @@ protected:
 		return res_array;
 	}
 
-	/* Converts a char* to an uint in little endian 
-         * arr: the array to convert
-         * i: when to load it from the array 
-         * return value: the converted value 
-         * NB: implicitely inlined */
+	/**
+	 * Converts a char* to an uint in little endian 
+	 * arr: the array to convert
+	 * i: when to load it from the array 
+	 * return value: the converted value 
+	 * NB: implicitely inlined 
+	 */
 	template <typename T>
 	static T FromArray(char* arr, int i)
 	{
@@ -160,9 +167,9 @@ protected:
 	}
 
 	/**
-     * Ensures an IPC message isn't too big.
-     * return value: false if checks failed, true otherwise.
-     */
+	 * Ensures an IPC message isn't too big.
+	 * return value: false if checks failed, true otherwise.
+	 */
 	static inline bool SafetyChecks(u32 command_len, int command_size, u32 reply_len, int reply_size = 0, u32 buf_size = MAX_IPC_SIZE - 1)
 	{
 		bool res = ((command_len + command_size) > buf_size ||

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -35,12 +35,17 @@ protected:
 	// their SDK won't even run their own examples, so we go on TCP sockets.
 #define PORT 28011
 	SOCKET m_sock = INVALID_SOCKET;
+	// the message socket used in thread's accept().
+	SOCKET m_msgsock = INVALID_SOCKET;
 #else
 	// absolute path of the socket. Stored in the temporary directory in linux since
 	// /run requires superuser permission
 	const char* SOCKET_NAME = "/tmp/pcsx2.sock";
 	int m_sock = 0;
+	// the message socket used in thread's accept().
+	int m_msgsock = 0;
 #endif
+
 
 	/**
      * Maximum memory used by an IPC message request.
@@ -112,7 +117,7 @@ protected:
 	// handle to the main vm thread
 	SysCoreThread* m_vm;
 
-	/* Thread used to relay IPC commands. */
+	// Thread used to relay IPC commands.
 	void ExecuteTaskInThread();
 
 	/* Internal function, Parses an IPC command.
@@ -167,6 +172,9 @@ protected:
 	}
 
 public:
+	// Whether the socket processing thread should stop executing/is stopped.
+	bool m_end = true;
+
 	/* Initializers */
 	SocketIPC(SysCoreThread* vm);
 	virtual ~SocketIPC();

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -122,10 +122,11 @@ protected:
 
 	/* Internal function, Parses an IPC command.
          * buf: buffer containing the IPC command.
+         * buf_size: size of the buffer announced.
          * ret_buffer: buffer that will be used to send the reply.
          * return value: IPCBuffer containing a buffer with the result 
          *               of the command and its size. */
-	IPCBuffer ParseCommand(char* buf, char* ret_buffer);
+	IPCBuffer ParseCommand(char* buf, char* ret_buffer, u32 buf_size);
 
 	/* Formats an IPC buffer
          * ret_buffer: return buffer to use. 
@@ -162,9 +163,9 @@ protected:
      * Ensures an IPC message isn't too big.
      * return value: false if checks failed, true otherwise.
      */
-	static inline bool SafetyChecks(u32 command_len, int command_size, u32 reply_len, int reply_size = 0)
+	static inline bool SafetyChecks(u32 command_len, int command_size, u32 reply_len, int reply_size = 0, u32 buf_size = MAX_IPC_SIZE - 1)
 	{
-		bool res = ((command_len + command_size) >= MAX_IPC_SIZE ||
+		bool res = ((command_len + command_size) > buf_size ||
 					(reply_len + reply_size) >= MAX_IPC_RETURN_SIZE);
 		if (unlikely(res))
 			return false;

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -1,0 +1,122 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Client code example for interfacing with the IPC interface is available 
+ * here: https://code.govanify.com/govanify/pcsx2_ipc/ */
+
+#pragma once
+
+#include "Utilities/PersistentThread.h"
+#include "System/SysThreads.h"
+
+using namespace Threading;
+
+class SocketIPC : public pxThread
+{
+
+	typedef pxThread _parent;
+
+protected:
+#ifdef _WIN32
+	// windows claim to have support for AF_UNIX sockets but that is a blatant lie,
+	// their SDK won't even run their own examples, so we go on TCP sockets.
+#define PORT 28011
+#else
+	// absolute path of the socket. Stored in the temporary directory in linux since
+	// /run requires superuser permission
+	const char* SOCKET_NAME = "/tmp/pcsx2.sock";
+#endif
+
+	// socket handlers
+#ifdef _WIN32
+	SOCKET m_sock = INVALID_SOCKET;
+#else
+	int m_sock = 0;
+#endif
+
+	// buffers that store the ipc request and reply messages.
+	char* ret_buffer;
+	char* ipc_buffer;
+
+	// possible command messages
+	enum IPCCommand
+	{
+		MsgRead8 = 0,
+		MsgRead16 = 1,
+		MsgRead32 = 2,
+		MsgRead64 = 3,
+		MsgWrite8 = 4,
+		MsgWrite16 = 5,
+		MsgWrite32 = 6,
+		MsgWrite64 = 7
+	};
+
+	// possible result codes
+	enum IPCResult
+	{
+		IPC_OK = 0,
+		IPC_FAIL = 0xFF
+	};
+
+	// handle to the main vm thread
+	SysCoreThread* m_vm;
+
+	/* Thread used to relay IPC commands. */
+	void ExecuteTaskInThread();
+
+	/* Internal function, Parses an IPC command.
+         * buf: buffer containing the IPC command.
+         * ret_buffer: buffer that will be used to send the reply.
+         * return value: pair containing a buffer with the result 
+         *               of the command and its size. */
+	std::pair<int, char*> ParseCommand(char* buf, char* ret_buffer);
+
+	/* Formats an IPC buffer
+         * ret_buffer: return buffer to use. 
+         * return value: buffer containing the status code allocated of size
+         *               size */
+	static inline char* MakeOkIPC(char* ret_buffer);
+	static inline char* MakeFailIPC(char* ret_buffer);
+
+	/* Converts an uint to an char* in little endian 
+         * res_array: the array to modify 
+         * res: the value to convert
+         * i: when to insert it into the array 
+         * return value: res_array 
+         * NB: implicitely inlined */
+	template <typename T>
+	static char* ToArray(char* res_array, T res, int i)
+	{
+		memcpy((res_array + i), (char*)&res, sizeof(T));
+		return res_array;
+	}
+
+	/* Converts a char* to an uint in little endian 
+         * arr: the array to convert
+         * i: when to load it from the array 
+         * return value: the converted value 
+         * NB: implicitely inlined */
+	template <typename T>
+	static T FromArray(char* arr, int i)
+	{
+		return *(T*)(arr + i);
+	}
+
+public:
+	/* Initializers */
+	SocketIPC(SysCoreThread* vm);
+	virtual ~SocketIPC();
+
+}; // class SocketIPC

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -436,6 +436,7 @@ void Pcsx2Config::LoadSave( IniInterface& ini )
 	IniBitBool( CdvdShareWrite );
 	IniBitBool( EnablePatches );
 	IniBitBool( EnableCheats );
+	IniBitBool( EnableIPC );
 	IniBitBool( EnableWideScreenPatches );
 #ifndef DISABLE_RECORDING
 	IniBitBool( EnableRecordingTools );

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -24,6 +24,7 @@
 #include "Patch.h"
 #include "SysThreads.h"
 #include "MTVU.h"
+#include "IPC.h"
 
 #include "../DebugTools/MIPSAnalyst.h"
 #include "../DebugTools/SymbolMap.h"
@@ -243,6 +244,11 @@ void SysCoreThread::GameStartingInThread()
 #ifdef USE_SAVESLOT_UI_UPDATES
 	UI_UpdateSysControls();
 #endif
+	if(EmuConfig.EnableIPC && m_IpcState == OFF)
+	{
+		m_IpcState = ON;
+		m_socketIpc = std::make_unique<SocketIPC>(this);
+	}
 }
 
 bool SysCoreThread::StateCheckInThread()

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -244,7 +244,7 @@ void SysCoreThread::GameStartingInThread()
 #ifdef USE_SAVESLOT_UI_UPDATES
 	UI_UpdateSysControls();
 #endif
-	if(EmuConfig.EnableIPC && m_IpcState == OFF)
+	if (EmuConfig.EnableIPC && m_IpcState == OFF)
 	{
 		m_IpcState = ON;
 		m_socketIpc = std::make_unique<SocketIPC>(this);

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -249,6 +249,8 @@ void SysCoreThread::GameStartingInThread()
 		m_IpcState = ON;
 		m_socketIpc = std::make_unique<SocketIPC>(this);
 	}
+	if (m_IpcState == ON && m_socketIpc->m_end)
+		m_socketIpc->Start();
 }
 
 bool SysCoreThread::StateCheckInThread()

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -19,6 +19,7 @@
 
 #include "Utilities/PersistentThread.h"
 #include "x86emitter/tools.h"
+#include "IPC.h"
 
 
 using namespace Threading;
@@ -169,6 +170,17 @@ protected:
 	bool			m_resetProfilers;
 	bool			m_resetVsyncTimers;
 	bool			m_resetVirtualMachine;
+
+	// Stores the state of the socket IPC thread.
+	std::unique_ptr<SocketIPC> m_socketIpc;
+
+	// Current state of the IPC thread
+	enum StateIPC 
+	{
+		OFF,
+		ON
+	};
+	StateIPC m_IpcState = OFF;
 
 	// Indicates if the system has an active virtual machine state.  Pretty much always
 	// true anytime between plugins being initialized and plugins being shutdown.  Gets

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -123,6 +123,7 @@ enum MenuIdentifiers
 	MenuId_GameSettingsSubMenu,
 	MenuId_EnablePatches,
 	MenuId_EnableCheats,
+	MenuId_EnableIPC,
 	MenuId_EnableWideScreenPatches,
 	MenuId_EnableInputRecording,
 	MenuId_EnableLuaTools,

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -216,6 +216,7 @@ void MainEmuFrame::ConnectMenus()
 
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnablePatches_Click, this, MenuId_EnablePatches);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableCheats_Click, this, MenuId_EnableCheats);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableIPC_Click, this, MenuId_EnableIPC);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableWideScreenPatches_Click, this, MenuId_EnableWideScreenPatches);
 #ifndef DISABLE_RECORDING
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableRecordingTools_Click, this, MenuId_EnableInputRecording);
@@ -366,6 +367,9 @@ void MainEmuFrame::CreatePcsx2Menu()
 		_("Automatically applies needed Gamefixes to known problematic games"), wxITEM_CHECK);
 
 	m_GameSettingsSubmenu.Append(MenuId_EnableCheats,	_("Enable &Cheats"),
+		wxEmptyString, wxITEM_CHECK);
+
+	m_GameSettingsSubmenu.Append(MenuId_EnableIPC,	_("Enable &IPC"),
 		wxEmptyString, wxITEM_CHECK);
 
 	m_GameSettingsSubmenu.Append(MenuId_EnableWideScreenPatches,	_("Enable &Widescreen Patches"),
@@ -744,6 +748,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 	{//these should not be affected by presets
 		menubar.Check( MenuId_EnableBackupStates, configToApply.EmuOptions.BackupSavestate );
 		menubar.Check( MenuId_EnableCheats,  configToApply.EmuOptions.EnableCheats );
+		menubar.Check( MenuId_EnableIPC,  configToApply.EmuOptions.EnableIPC );
 		menubar.Check( MenuId_EnableWideScreenPatches,  configToApply.EmuOptions.EnableWideScreenPatches );
 #ifndef DISABLE_RECORDING
 		menubar.Check( MenuId_EnableInputRecording, configToApply.EmuOptions.EnableRecordingTools);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -193,6 +193,7 @@ protected:
 	void Menu_EnableBackupStates_Click(wxCommandEvent &event);
 	void Menu_EnablePatches_Click(wxCommandEvent &event);
 	void Menu_EnableCheats_Click(wxCommandEvent &event);
+	void Menu_EnableIPC_Click(wxCommandEvent &event);
 	void Menu_EnableWideScreenPatches_Click(wxCommandEvent &event);
 #ifndef DISABLE_RECORDING
 	void Menu_EnableRecordingTools_Click(wxCommandEvent &event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -528,6 +528,13 @@ void MainEmuFrame::Menu_EnableCheats_Click( wxCommandEvent& )
 	AppSaveSettings();
 }
 
+void MainEmuFrame::Menu_EnableIPC_Click( wxCommandEvent& )
+{
+	g_Conf->EmuOptions.EnableIPC  = GetMenuBar()->IsChecked( MenuId_EnableIPC );
+	AppApplySettings();
+	AppSaveSettings();
+}
+
 void MainEmuFrame::Menu_EnableWideScreenPatches_Click( wxCommandEvent& )
 {
 	g_Conf->EmuOptions.EnableWideScreenPatches  = GetMenuBar()->IsChecked( MenuId_EnableWideScreenPatches );

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="..\..\gui\DriveList.cpp" />
     <ClCompile Include="..\..\gui\Panels\MemoryCardListView.cpp" />
     <ClCompile Include="..\..\IopGte.cpp" />
+    <ClCompile Include="..\..\IPC.cpp" />
     <ClCompile Include="..\..\IPU\IPUdma.cpp" />
     <ClCompile Include="..\..\IPU\IPUdither.cpp" />
     <ClCompile Include="..\..\Linux\LnxConsolePipe.cpp">
@@ -437,6 +438,7 @@
     <ClInclude Include="..\..\gui\Debugger\DisassemblyDialog.h" />
     <ClInclude Include="..\..\gui\Panels\MemoryCardPanels.h" />
     <ClInclude Include="..\..\IopGte.h" />
+    <ClInclude Include="..\..\IPC.h" />
     <ClInclude Include="..\..\IPU\IPUdma.h" />
     <ClInclude Include="..\..\Mdec.h" />
     <ClInclude Include="..\..\Patch.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -887,6 +887,8 @@
     </ClCompile>
     <ClCompile Include="..\..\gui\DriveList.cpp">
       <Filter>AppHost</Filter>
+    <ClCompile Include="..\..\IPC.cpp">
+      <Filter>System</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1341,6 +1343,8 @@
     </ClInclude>
     <ClInclude Include="..\..\gui\DriveList.h">
       <Filter>AppHost\Include</Filter>
+    <ClInclude Include="..\..\IPC.h">
+      <Filter>System\Include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request implements a small socket based IPC for pcsx2.

# Why

Among the years [several](https://github.com/GovanifY/Teamod/blob/master/Teamod_2/PCSX2_DMA.cs) [tools](https://www.youtube.com/watch?v=6Ust-45nOWc) [have](https://www.youtube.com/watch?v=snDEzmUciZw) been developed by various romhacking communities to, say, test mods in real time and/or expand on the game features. They all have been implemented by using the equivalent of `ptrace pcsx2` and scanning the memory to find the correct addresses.
Needless to say this was prone to breakage, could differ between versions (and emulators) and was simply a bad idea. If you need to visualize the context think about tools that rewrote the JIT region in realtime.
  
An IPC for a tool->game communication makes sense, but the opposite is also true: due to memory limitations and complexity of implementation some mods have extended the logic of the game outside of the emulator by this mean. One tool I'm thinking of hooked to the file loading routine, while another overlayed images on top of the OpenGL renderer of PCSX2 while communicating with the game.  

Dolphin implemented an IPC for a game<->emulator protocol ( https://dolphin-emu.org/blog/2019/12/06/dolphin-progress-report-november-2019/#50-11186-add-devdolphin-device-for-homebrew-to-communicate-with-dolphin-by-leseratte ) but in this case I believe an OS<->game IPC to be more generally useful to extend logic.

PNACH have also been investigated in the past but because of its one way communication, emu->game only and severe performance hit(each memory patching instruction is executed at each VSync) it has been quickly deemed a bad idea(tm). A previous PR that has been designed in order to extend pnach https://github.com/PCSX2/pcsx2/pull/3157 has, for example, implemented timers in pnach which effectively checks a timer at every vsync to verify if it should execute lines. This is simply hacky and not a good idea..
Lua has also been considered to replicate something like Bizhawk LUA API but ultimately I decided against it to avoid external dependencies, platform bloat should PCSX2 one day decide to have a non wxwidgets/plugin centric codebase, and to avoid bad performance while also allowing more extensibility in the toolset and possible code reuse of the IPC mechanism, which could be reused for an event syscall-based IPC for a game<->emu communication without any external tooling.

Concrete example: Kingdom Hearts 2 Final Mix does not have enough memory to implement streamed music at every point in the game. We would like to run said music without having to hardcode a music loading routine into PCSX2 or ptrace into PCSX2.

# Implementation details

This IPC is event-based, thanks to a socket implementation.  
It has thus two-way communication with virtually no performance hit.  
The BSD implementation uses a unix socket at the path `/tmp/pcsx2.sock` while the windows version uses a local TCP socket on port `28011`. 
A socket based implementation has been preferred over named pipes for its two way communication and possible code reuse in the future if we were to implement a gdbstub.  

The IPC currently implements those commands:
```cpp
        // possible command messages
        enum IPCCommand {
            MsgRead8 = 0,
            MsgRead16 = 1,
            MsgRead32 = 2,
            MsgRead64 = 3,
            MsgWrite8 = 4,
            MsgWrite16 = 5,
            MsgWrite32 = 6,
            MsgWrite64 = 7
        };
```
which are the simplest way to interact with the emulated game in a deterministic fashion. PS2 executables not being PIE allows us to know where a global variable is at any time.  
A menu option has been added, "Enable IPC" in the included picture. The IPC thread automatically starts itself when enabled upon game startup.  
![image](https://user-images.githubusercontent.com/6375438/89836689-d70f5c80-db56-11ea-9f02-647c4e11516c.png)
Safety of the memRead/Write operations is ensured by verifying the state of the vm before executing those operations.  

The IPC could also theoretically be extended to change in real time emulator specific settings and/or emulation itself, but is not currently implemented. I will probably extend the IPC protocol once merged to allow stuff like this.
A 3 way communication can thus be established, game->OS; OS->game; OS->emu and game->emu.  
game->OS IPC is poll based, OS->game event, game->emu poll and OS->emu event.  
This is due to how the IPC is implemented: Dolphin IPC implements an event based IPC for emu<->game at the cost of having to modify the executable code of the game to implement this.  
The upside of this PR is thus that you do not need to modify the game executable, only to reverse engineer it to find state variables and read off from it. As such this is not a no-cost implementation if the logic requires this.

In a nutshell:
* PR: reads global variable every 0.5seconds to verify if state has changed
* Dolphin: game sends a trap interrupt to the emulator and parse its reply

Of course an event based IPC for game<->emu communication could eventually be implemented but is out of the scope of this PR.  
A client implementation is available [here](https://code.govanify.com/govanify/pcsx2_ipc/).

This PR has been tested to work under windows and linux. MacOS should normally work out of the box since they use BSD sockets too.

The format of IPC message is the following:
```cpp
    //         IPC Message event (1 byte)
    //         |  Memory address (4 byte)
    //         |  |           argument (VLE)
    //         |  |           |
    // format: XX YY YY YY YY ZZ ZZ ZZ ZZ
    //        reply code: 00 = OK, FF = NOT OK
    //        |  return value (VLE)
    //        |  |
    // reply: XX ZZ ZZ ZZ ZZ
```
In the future address could become unecessary but for the memRead/Write operations it is always present.

If you need to generate any doc on the format or any additional information ping me sooner rather than later!
  