### PR TITLE
Make VU run closer in sync with EE, implement Mbit

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -71,6 +71,7 @@
 -- FMVinSoftwareHack      = 1 // Silent Hill 2-3. Fixes FMVs that are obscured when using hardware rendering by switching to software rendering while an FMV plays.
 -- ScarfaceIbitHack       = 1 // VU I bit Hack avoid constant recompilation (Scarface The World Is Yours).
 -- CrashTagTeamRacingIbit = 1 // VU I bit Hack avoid constant recompilation (Crash Tag Team Racing).
+-- VU0KickstartHack       = 1 // Let VU0 run ahead to fix some timing issues
 
 ---------------------------------------------
 -- Speed Hacks (SpeedHackName = <value>)
@@ -118,10 +119,12 @@ Region = NTSC-J
 Serial = PAPX-90222
 Name   = Jak x Daxter: Kyuusekai no Isan [Demo, Taikenba]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = PAPX-90223
 Name   = Jak x Daxter: Kyuusekai no Isan [Demo, Taikenba]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = PAPX-90231
 Name   = Kaitou Sly Cooper [Demo, Taikenba]
@@ -136,6 +139,7 @@ vuClampMode = 2 // Text in GT mode works.
 Serial = PAPX-90516
 Name   = Jak and Daxter II [Trial]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = PBPX-95201
 Name   = Dead or Alive 2
@@ -247,6 +251,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20001
 Name   = Ratchet & Clank
 Region = NTSC-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20002
 Name   = Gallop Racer 6 - Revolution
@@ -501,6 +506,7 @@ Serial = SCAJ-20070
 Name   = Star Ocean 3 [Director's Cut]
 Region = NTSC-Unk
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20072
 Name   = Ghost in the Shell - Stand Alone Complex
@@ -509,6 +515,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20073
 Name   = Jak and Daxter II
 Region = NTSC-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20074
 Name   = King of Fighters 2002, The
@@ -650,6 +657,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20109
 Name   = Ratchet & Clank 3 - Up your Arsenal
 Region = NTSC-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20110
 Name   = Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi
@@ -659,6 +667,7 @@ Serial = SCAJ-20111
 Name   = Crash Bandicoot 5
 Region = NTSC-Unk
 XgKickHack = 1 // Fixes bad Geometry.
+VU0KickstartHack = 1 // Fixes loading hang.
 ---------------------------------------------
 Serial = SCAJ-20112
 Name   = Tales of Rebirth
@@ -688,6 +697,7 @@ Serial = SCAJ-20118
 Name   = Radiata Stories
 Region = NTSC-J
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20119
 Name   = Gladiator - Road to Freedom
@@ -856,6 +866,7 @@ Region = NTSC-Unk
 Serial = SCAJ-20157
 Name   = Ratchet & Clank 4th - GiriGiri Gingano Giga-battle
 Region = NTSC-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20158
 Name   = Ikusa Gami
@@ -938,6 +949,7 @@ Name   = Valkyrie Profile 2 - Silmeria
 Region = NTSC-Unk
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20178
 Name   = Ape Escape - Million Monkeys
@@ -1012,6 +1024,7 @@ Name   = Valkyrie Profile 2 - Silmeria [Ultimate Hits]
 Region = NTSC-Unk
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCAJ-20198
 Name   = Everybody's Tennis [PlayStation 2 The Best]
@@ -1127,6 +1140,7 @@ Region = PAL-Unk
 Serial = SCED-50614
 Name   = Jak and Daxter: The Precursor Legacy [Demo]
 Region = PAL-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCED-50642
 Name   = Final Fantasy X [Demo] [Final Fantasy VI PS1 - Bonus Disc]
@@ -1181,6 +1195,7 @@ Compat = 5
 Serial = SCED-51700
 Name   = Jak II: Renegade [Demo]
 Region = PAL-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCED-52049
 Name   = Dog's Life [Demo]
@@ -1208,6 +1223,7 @@ Region = PAL-M11
 Serial = SCED-52952
 Name   = Jak 3 [Demo]
 Region = PAL-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCED-52970
 Name   = SCEE Hits Demo
@@ -1341,6 +1357,7 @@ Serial = SCES-50361
 Name   = Jak and Daxter: The Precursor Legacy
 Region = PAL-M6
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCES-50408
 Name   = PaRappa the Rapper 2
@@ -1480,6 +1497,7 @@ Region = PAL-M5
 Serial = SCES-50614
 Name   = Jak and Daxter: The Precursor Legacy
 Region = PAL-Unk
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCES-50759
 Name   = Virtua Fighter 4
@@ -1551,6 +1569,7 @@ Serial = SCES-50916
 Name   = Ratchet & Clank
 Region = PAL-M5
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCES-50917
 Name   = Sly Racoon
@@ -1658,21 +1677,6 @@ Name   = Primal
 Region = PAL-M5
 Compat = 5 // With GSdx, SW-mode only.
 vuRoundMode = 0 // Fixes SPS.
-[patches = dcc4eeea]
-	author=Prafull
-	// Fix slow and choppy gameplay.
-	// PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
-	// so the game will wait endlessly in a wait loop until COP2 gets around to
-	// setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
-	// VU0 side, remove wait loop.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,00399cb0,word,48a44800
-	patch=1,EE,00399cb4,word,48c02800
-	patch=1,EE,00399cb8,word,4a00d839
-	patch=1,EE,00399d68,word,48a44800
-	patch=1,EE,00399d6c,word,48c02800
-	patch=1,EE,00399d70,word,4a00d839
-[/patches]
 ---------------------------------------------
 Serial = SCES-51159
 Name   = The Getaway
@@ -1728,21 +1732,6 @@ Serial = SCES-51463
 Name   = Ghosthunter
 Region = PAL-M6
 Compat = 5
-[patches = 3bd85da4]
-	author=Prafull
-	// Fix slow and choppy gameplay.
-	// PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
-	// so the game will wait endlessly in a wait loop until COP2 gets around to
-	// setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
-	// VU0 side, remove wait loop.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,003f4e58,word,48a44800
-	patch=1,EE,003f4e5c,word,48c02800
-	patch=1,EE,003f4e60,word,4a00d839
-	patch=1,EE,003f4f10,word,48a44800
-	patch=1,EE,003f4f14,word,48c02800
-	patch=1,EE,003f4f18,word,4a00d839
-[/patches]
 ---------------------------------------------
 Serial = SCES-51480
 Name   = Twisted Metal - Black - Online
@@ -1774,6 +1763,7 @@ Serial = SCES-51607
 Name   = Ratchet & Clank 2 - Locked & Loaded
 Region = PAL-M5
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 // Reads Ratchet 1 data.
 MemCardFilter = SCES-51607/SCES-50916
 ---------------------------------------------
@@ -1781,6 +1771,7 @@ Serial = SCES-51608
 Name   = Jak II: Renegade
 Region = PAL-M7
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 [patches]
 	comment=- This gamedisc supports multiple languages through the BIOS configuration.
 	comment=- Implementation requires Full boot - "Boot CDVD (full)".
@@ -1835,21 +1826,6 @@ Name   = Primal
 Region = PAL-E-R
 vuRoundMode = 0 // Fixes SPS.
 vuRoundMode = 0 // Fix SPS.
-[patches = E7ABDDC7]
-	author=Prafull
-	// Fix slow and choppy gameplay.
-	// PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
-	// so the game will wait endlessly in a wait loop until COP2 gets around to
-	// setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
-	// VU0 side, remove wait loop.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,00399e68,word,48a44800
-	patch=1,EE,00399e6c,word,48c02800
-	patch=1,EE,00399e70,word,4a00d839
-	patch=1,EE,00399f20,word,48a44800
-	patch=1,EE,00399f24,word,48c02800
-	patch=1,EE,00399f28,word,4a00d839
-[/patches]
 ---------------------------------------------
 Serial = SCES-51706
 Name   = Amplitude
@@ -2062,6 +2038,7 @@ Serial = SCES-52456
 Name   = Ratchet & Clank 3
 Region = PAL-M5
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 // Reads Ratchet 1 & 2 data.
 MemCardFilter = SCES-52456/SCES-51607/SCES-50916
 ---------------------------------------------
@@ -2069,6 +2046,7 @@ Serial = SCES-52460
 Name   = Jak 3
 Region = PAL-M7
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 [patches]
 	comment=- This gamedisc supports multiple languages through the BIOS configuration.
 	comment=- Implementation requires Full boot - "Boot CDVD (full)".
@@ -2254,10 +2232,12 @@ Serial = SCES-53285
 Name   = Ratchet - Gladiator
 Region = PAL-M5
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCES-53286
 Name   = Jak X - Combat Racing
 Region = PAL-M7
+VU0KickstartHack = 1 // Fixes Character SPS.
 // Reads Ratchet Gladiator data.
 MemCardFilter = SCES-53286/SCES-53285
 ---------------------------------------------
@@ -2841,6 +2821,7 @@ Compat = 5
 Serial = SCES-55510
 Name   = Jak and Daxter: The Lost Frontier
 Region = PAL-M12
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCES-55535
 Name   = Desi Adda: Games of India
@@ -2908,10 +2889,12 @@ Compat = 5
 Serial = SCKA-20010
 Name   = Jak II
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCKA-20011
 Name   = Ratchet & Clank 2
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCKA-20011/SCKA-20120
 ---------------------------------------------
 Serial = SCKA-20012
@@ -3011,6 +2994,7 @@ Region = NTSC-K
 Serial = SCKA-20037
 Name   = Ratchet & Clank 3
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCKA-20037/SCKA-20011/SCKA-20120
 ---------------------------------------------
 Serial = SCKA-20038
@@ -3024,6 +3008,7 @@ Region = NTSC-K
 Serial = SCKA-20040
 Name   = Jak 3
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCKA-20043
 Name   = Magna Carta
@@ -3097,6 +3082,7 @@ Compat = 5
 Serial = SCKA-20060
 Name   = Ratchet - Deadlocked
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCKA-20061
 Name   = Wanda to Kyozou (Shadow of the Colossus)
@@ -3156,6 +3142,7 @@ Name   = Valkyrie Profile 2 - Silmeria
 Region = NTSC-K
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCKA-20081
 Name   = Tekken 5 [PlayStation 2 Big Hit Series]
@@ -3214,6 +3201,7 @@ Region = NTSC-K
 Serial = SCKA-20120
 Name   = Ratchet & Clank
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCKA-20132
 Name   = Shin Megami Tensei: Persona 4
@@ -3503,6 +3491,7 @@ Region = NTSC-J
 Serial = SCPS-15021
 Name   = Jak x Daxter: Kyuusekai no Isan
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-15022
 Name   = Dual Hearts
@@ -3570,6 +3559,7 @@ Region = NTSC-J
 Serial = SCPS-15037
 Name   = Ratchet & Clank
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-15038
 Name   = Operator's Side
@@ -3662,11 +3652,13 @@ MemCardFilter = SCAJ-20066/SCAJ-30006/SCAJ-30007/SCAJ-30008/SCPS-15055/SCPS-1700
 Serial = SCPS-15056
 Name   = Ratchet & Clank 2
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCPS-15056/SCPS-15037
 ---------------------------------------------
 Serial = SCPS-15057
 Name   = Jak and Daxter II
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-15058
 Name   = Arc the Lad - Generation
@@ -3780,6 +3772,7 @@ Region = NTSC-J
 Serial = SCPS-15084
 Name   = Ratchet & Clank 3
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCPS-15084/SCPS-15056/SCPS-15037
 ---------------------------------------------
 Serial = SCPS-15085
@@ -3849,10 +3842,12 @@ Region = NTSC-J
 Serial = SCPS-15099
 Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-15100
 Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-15101
 Name   = Bleach - Hanatareshi Yabou
@@ -3945,6 +3940,7 @@ OPHFLagHack = 1 // Special moves "Bankai" hang otherwise
 Serial = SCPS-15120
 Name   = Ratchet & Clank 5 Gekitotsu! Dodeka Ginga no Mirimiri Gundan
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-17001
 Name   = Gran Turismo 4
@@ -4055,10 +4051,12 @@ Region = NTSC-J
 Serial = SCPS-19210
 Name   = Jak x Daxter: Kyuusekai no Isan [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19211
 Name   = Ratchet & Clank [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19213
 Name   = Operator's Side [PlayStation 2 The Best] [with Microphone]
@@ -4094,6 +4092,7 @@ Region = NTSC-J
 Serial = SCPS-19302
 Name   = Ratchet & Clank 2 [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19303
 Name   = Boku no Natsuyasumi 2 [PlayStation 2 The Best]
@@ -4125,10 +4124,12 @@ Region = NTSC-J
 Serial = SCPS-19309
 Name   = Ratchet & Clank 3 - Up Your Arsenal [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19310
 Name   = Ratchet & Clank [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19311
 Name   = Saru Get You 3 [PlayStation 2 The Best]
@@ -4150,10 +4151,12 @@ Region = NTSC-J
 Serial = SCPS-19316
 Name   = Ratchet & Clank [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19317
 Name   = Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19318
 Name   = Genji - Dawn of the Samurai [PlayStation 2 The Best]
@@ -4171,6 +4174,7 @@ MemCardFilter = SCAJ-20146/SCAJ-20196/SCAJ-20099/SCPS-11003/SCPS-19103/SCPS-1915
 Serial = SCPS-19321
 Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19322
 Name   = Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]
@@ -4202,6 +4206,7 @@ Region = NTSC-J
 Serial = SCPS-19328
 Name   = Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-19329
 Name   = Bleach - Blade Battlers [PlayStation 2 The Best]
@@ -4290,6 +4295,7 @@ Region = NTSC-J
 Serial = SCPS-55004
 Name   = Jak x Daxter: Kyuusekai no Isan
 Region = NTSC-J
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-55005
 Name   = Gran Turismo - Concept 2001 Tokyo
@@ -4350,6 +4356,7 @@ Name   = Star Ocean 3 - Till the End of Time
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-55020
 Name   = Kengo 2
@@ -4496,6 +4503,7 @@ Compat = 5
 Serial = SCPS-56003
 Name   = Jak and Daxter: The Precursor Legacy
 Region = NTSC-K
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCPS-56005
 Name   = Gran Turismo Concept 2002 Tokyo-Seoul
@@ -4663,6 +4671,7 @@ Serial = SCUS-97124
 Name   = Jak and Daxter: The Precursor Legacy
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97125
 Name   = Frequency
@@ -4746,32 +4755,6 @@ Name   = Primal - Civilization Is Only Skin Deep
 Region = NTSC-U
 Compat = 5
 vuRoundMode = 0 // Fixes SPS.
-[patches = FCD89DC3]
-	author=Raziel I.C.H.I. Znot
-	comment=Performance fix
-	// PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
-	// so the game will wait endlessly in a wait loop until COP2 gets around to
-	// setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
-	// VU0 side, remove wait loop.
-	patch=1,EE,0040F110,word,8000033c
-	patch=1,EE,0040F128,word,8000033c
-	patch=1,EE,0040F168,word,8000033c
-	patch=1,EE,0040F180,word,8000033c
-	// Duplicate, not sure that it's used, but patched anyway.
-	patch=1,EE,0040F720,word,8000033c
-	patch=1,EE,0040F738,word,8000033c
-	patch=1,EE,0040F778,word,8000033c
-	patch=1,EE,0040F790,word,8000033c
-	// EE side, rearrange and clean code so VU0 receives all data at once.
-	patch=1,EE,00399B14,word,00000000
-	patch=1,EE,00399B58,word,48A44800
-	patch=1,EE,00399B5C,word,4A00D839
-	patch=1,EE,00399B60,word,00000000
-	patch=1,EE,00399BA4,word,00000000
-	patch=1,EE,00399C10,word,48A44800
-	patch=1,EE,00399C14,word,4A00D839
-	patch=1,EE,00399C18,word,00000000
-[/patches]
 ---------------------------------------------
 Serial = SCUS-97144
 Name   = PlayStation Underground 5.1
@@ -4870,10 +4853,12 @@ Region = NTSC-U
 Serial = SCUS-97170
 Name   = Jak and Daxter: The Precursor Legacy [Cingular Wireless Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97171
 Name   = Jak and Daxter: The Precursor Legacy [PS Underground Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97172
 Name   = World Tour Soccer 2002
@@ -4981,6 +4966,7 @@ Serial = SCUS-97199
 Name   = Ratchet & Clank
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97200
 Name   = Kiosk Demo Disc 2.05
@@ -5016,6 +5002,7 @@ Region = NTSC-U
 Serial = SCUS-97209
 Name   = Ratchet & Clank [E3 Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97210
 Name   = Sly Cooper and the Thievius Raccoonus [Demo]
@@ -5134,6 +5121,7 @@ Region = NTSC-U
 Serial = SCUS-97240
 Name   = Ratchet & Clank [EB Games Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97241
 Name   = Official U.S. PlayStation Magazine Demo Disc 066
@@ -5244,6 +5232,7 @@ Serial = SCUS-97265
 Name   = Jak II
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97266
 Name   = Final Fantasy XI [Disc1of2]
@@ -5254,6 +5243,7 @@ Serial = SCUS-97268
 Name   = Ratchet & Clank - Going Commando
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCUS-97268/SCUS-97199
 ---------------------------------------------
 Serial = SCUS-97269
@@ -5276,10 +5266,12 @@ Region = NTSC-U
 Serial = SCUS-97273
 Name   = Jak II [Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97274
 Name   = Jak II [Video Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97275
 Name   = SOCOM II - U.S. Navy SEALs
@@ -5359,10 +5351,12 @@ Region = NTSC-U
 Serial = SCUS-97322
 Name   = Ratchet & Clank 2 - Going Commando [Regular Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97323
 Name   = Ratchet & Clank 2 - Going Commando [Retail Employees Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97324
 Name   = Kiosk Demo Disc 2.11
@@ -5397,6 +5391,7 @@ Serial = SCUS-97330
 Name   = Jak 3
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97331
 Name   = Official U.S. PlayStation Magazine Demo Disc 078
@@ -5463,6 +5458,7 @@ Serial = SCUS-97353
 Name   = Ratchet & Clank - Up Your Arsenal
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCUS-97353/SCUS-97268/SCUS-97199
 ---------------------------------------------
 Serial = SCUS-97355
@@ -5523,6 +5519,7 @@ Region = NTSC-U
 Serial = SCUS-97374
 Name   = Ratchet & Clank 2 - Going Commando & Jak II [Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS (for both).
 ---------------------------------------------
 Serial = SCUS-97377
 Name   = Syphon Filter - The Omega Strain [Regular Demo]
@@ -5544,6 +5541,7 @@ Region = NTSC-U
 Serial = SCUS-97381
 Name   = Ratchet & Clank 2 - Going Commando [GameStop Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97382
 Name   = NBA Shootout 2004 [Demo]
@@ -5631,14 +5629,17 @@ Region = NTSC-U
 Serial = SCUS-97411
 Name   = Ratchet & Clank - Up Your Arsenal [Regular Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97412
 Name   = Jak 3 [Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97413
 Name   = Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97414
 Name   = EyeToy - AntiGrav
@@ -5702,6 +5703,7 @@ Serial = SCUS-97429
 Name   = Jak X - Combat Racing
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SCUS-97429/SCUS-97465
 ---------------------------------------------
 Serial = SCUS-97430
@@ -5735,6 +5737,7 @@ Region = NTSC-U
 Serial = SCUS-97440
 Name   = Jak and Daxter Trilogy [Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97441
 Name   = The Getaway - Black Monday [Demo]
@@ -5828,6 +5831,7 @@ Serial = SCUS-97465
 Name   = Ratchet - Deadlocked
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97466
 Name   = Gretzky NHL '06
@@ -5920,19 +5924,23 @@ vuRoundMode = 0 // Fixes game engine issue with bombs and ladders.
 Serial = SCUS-97485
 Name   = Ratchet - Deadlocked [Regular Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97486
 Name   = Jak X - Combat Racing [Regular Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97487
 Name   = Ratchet - Deadlocked [Public Beta v.1]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97488
 Name   = Jak X - Combat Racing [Public Beta v.1]
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97489
 Name   = SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]
@@ -6014,6 +6022,7 @@ Region = NTSC-U
 Serial = SCUS-97509
 Name   = Jak II [Greatest Hits]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97510
 Name   = ATV Off-Road Fury 2 [Greatest Hits]
@@ -6034,6 +6043,7 @@ MemCardFilter = SCUS-97512/SCUS-97102
 Serial = SCUS-97513
 Name   = Ratchet & Clank - Going Commando [Greatest Hits]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97514
 Name   = ATV Off-Road Fury 3 [Greatest Hits]
@@ -6046,6 +6056,7 @@ Region = NTSC-U
 Serial = SCUS-97516
 Name   = Jak 3 [Greatest Hits]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97517
 Name   = Killzone [Greatest Hits]
@@ -6055,6 +6066,7 @@ vuClampMode = 0 // Resolves I Reg Clamping / performance impact and yellow graph
 Serial = SCUS-97518
 Name   = Ratchet & Clank - Up Your Arsenal [Greatest Hits]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97519
 Name   = Sly 2 - Band of Thieves [Greatest Hits]
@@ -6148,6 +6160,7 @@ Region = NTSC-U
 Serial = SCUS-97555
 Name   = Jak and Daxter Complete Trilogy [Demo]
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS (for all 3 games).
 ---------------------------------------------
 Serial = SCUS-97556
 Name   = MLB '07 - The Show
@@ -6161,6 +6174,7 @@ Serial = SCUS-97558
 Name   = Jak and Daxter: The Lost Frontier
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97560
 Name   = SOCOM - U.S. Navy SEALs - Combined Assault [Demo]
@@ -6262,6 +6276,7 @@ Region = NTSC-U
 Serial = SCUS-97615
 Name   = Ratchet & Clank - Size Matters
 Region = NTSC-U
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SCUS-97616
 Name   = SingStar 80's
@@ -8995,11 +9010,13 @@ Serial = SLES-50984
 Name   = Gumball 3000
 Region = PAL-E
 Compat = 5
+VU0KickstartHack = 1 // Fixes minor random car SPS.
 ---------------------------------------------
 Serial = SLES-50985
 Name   = Gumball 3000
 Region = PAL-M5
 Compat = 5
+VU0KickstartHack = 1 // Fixes minor random car SPS.
 ---------------------------------------------
 Serial = SLES-50986
 Name   = Twin Caliber
@@ -10211,15 +10228,7 @@ Region = PAL-Unk
 Serial = SLES-51547
 Name   = Next Generation Tennis 2003
 Region = PAL-M5
-vuClampMode = 3 // Fixes SPS menus, also needed for patch.
-[patches = 393e3efa]
-	author=Prafull
-	// Fixes ingame SPS.
-	// Also requires vu clamping extra or higher.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,0013f1f0,word,d9100010
-	patch=1,EE,0013f1f4,word,4a000038
-[/patches]
+vuClampMode = 3 // Fixes SPS menus.
 ---------------------------------------------
 Serial = SLES-51548
 Name   = This is Football
@@ -12392,6 +12401,7 @@ Name   = Crash Twinsanity
 Region = PAL-M5
 Compat = 5
 XgKickHack = 1 // Fixes bad Geometry.
+VU0KickstartHack = 1 // Fixes loading hang.
 ---------------------------------------------
 Serial = SLES-52569
 Name   = Spyro - A Hero's Tail
@@ -15060,6 +15070,7 @@ Serial = SLES-53701
 Name   = Super Monkey Ball Adventure
 Region = PAL-M5
 Compat = 5
+VU0KickstartHack = 1 // Fixes loading hang.
 ---------------------------------------------
 Serial = SLES-53702
 Name   = Resident Evil 4
@@ -17080,28 +17091,33 @@ Name   = Valkyrie Profile 2 - Silmeria
 Region = PAL-E
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-54645
 Name   = Valkyrie Profile 2 - Silmeria
 Region = PAL-F
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-54646
 Name   = Valkyrie Profile 2 - Silmeria
 Region = PAL-G
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-54647
 Name   = Valkyrie Profile 2 - Silmeria
 Region = PAL-I
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-54648
 Name   = Valkyrie Profile 2 - Silmeria
 Region = PAL-S
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-54657
 Name   = Charlotte's Web
@@ -17713,6 +17729,7 @@ Compat = 5
 Serial = SLES-55019
 Name   = Ratchet & Clank - Size Matters
 Region = PAL-M13
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-55020
 Name   = Die Simpsons - Das Spiel
@@ -18556,12 +18573,14 @@ Name   = Star Ocean 3 - Till the End of Time [Disc1of2]
 Region = PAL-E
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLES-82029
 Name   = Star Ocean 3 - Till the End of Time [Disc2of2]
 Region = PAL-E
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SLES-82028
 ---------------------------------------------
 Serial = SLES-82030
@@ -22898,6 +22917,7 @@ Name   = Star Ocean 3 [Limited Edition]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLPM-65210
 Name   = Chou Battle Houshin - Bundle #1
@@ -23721,12 +23741,14 @@ Name   = Star Ocean 3 [Director's Cut] [Disc1of2]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLPM-65439
 Name   = Star Ocean 3 [Director's Cut] [Disc2of2]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SLPM-65438
 ---------------------------------------------
 Serial = SLPM-65441
@@ -25056,12 +25078,14 @@ Serial = SLPM-65800
 Name   = Radiata Stories
 Region = NTSC-J
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLPM-65801
 Name   = Crash Bandicoot 5
 Region = NTSC-J
 Compat = 5
 XgKickHack = 1 // Fixes bad geometry.
+VU0KickstartHack = 1 // Fixes loading hang.
 ---------------------------------------------
 Serial = SLPM-65802
 Name   = Def Jam - Vendetta [EA Best Hits]
@@ -27319,6 +27343,7 @@ Name   = Valkyrie Profile 2 - Silmeria
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLPM-66420
 Name   = Front Mission 4 [Ultimate Hits]
@@ -27552,12 +27577,14 @@ Name   = Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc1of2]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLPM-66479
 Name   = Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc2of2]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SLPM-66478
 ---------------------------------------------
 Serial = SLPM-66480
@@ -28722,6 +28749,7 @@ Name   = Valkyrie Profile 2 - Silmeria [Ultimate Hits]
 Region = NTSC-J
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLPM-66783
 Name   = Idol Janshi Suchie-Pai 4 [Limited Edition]
@@ -37316,6 +37344,7 @@ Name   = Star Ocean 3 - Till the End of Time [Disc1of2]
 Region = NTSC-U
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLUS-20489
 Name   = Whirl Tour
@@ -39170,6 +39199,7 @@ Name   = Star Ocean 3 - Till the End of Time [Disc2of2]
 Region = NTSC-U
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 MemCardFilter = SLUS-20488
 ---------------------------------------------
 Serial = SLUS-20892
@@ -39261,6 +39291,7 @@ Name   = Crash Twinsanity
 Region = NTSC-U
 Compat = 5
 XgKickHack = 1 // Fixes bad geometry.
+VU0KickstartHack = 1 // Fixes loading hang.
 ---------------------------------------------
 Serial = SLUS-20910
 Name   = Test Drive - Eve of Destruction
@@ -39713,32 +39744,6 @@ Serial = SLUS-20993
 Name   = Ghosthunter
 Region = NTSC-U
 Compat = 5
-[patches = 29C7DA54]
-	author=Raziel I.C.H.I. Znot
-	comment=Performance fix
-	// PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
-	// so the game will wait endlessly in a wait loop until COP2 gets around to
-	// setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
-	// VU0 side, remove wait loop.
-	patch=1,EE,00461C68,word,8000033c
-	patch=1,EE,00461C80,word,8000033c
-	patch=1,EE,00461CC0,word,8000033c
-	patch=1,EE,00461CD8,word,8000033c
-	// Duplicate, not sure that it's used, but patched anyway.
-	patch=1,EE,00463118,word,8000033c
-	patch=1,EE,00463130,word,8000033c
-	patch=1,EE,00463170,word,8000033c
-	patch=1,EE,00463188,word,8000033c
-	// EE side, rearrange and clean code so VU0 receives all data at once.
-	patch=1,EE,003F8544,word,00000000
-	patch=1,EE,003F8588,word,48A44800
-	patch=1,EE,003F858C,word,4A00D839
-	patch=1,EE,003F8590,word,00000000
-	patch=1,EE,003F85D4,word,00000000
-	patch=1,EE,003F8640,word,48A44800
-	patch=1,EE,003F8644,word,4A00D839
-	patch=1,EE,003F8648,word,00000000
-[/patches]
 ---------------------------------------------
 Serial = SLUS-20994
 Name   = Full Metal Alchemist and The Broken Angel
@@ -41083,6 +41088,7 @@ Name   = Radiata Stories
 Region = NTSC-U
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLUS-21263
 Name   = Romancing SaGa
@@ -41116,21 +41122,6 @@ Serial = SLUS-21268
 Name   = 24: The Game
 Region = NTSC-U
 Compat = 5
-[patches = f1c7201e]
-	author=Prafull
-	// Fix slow and choppy gameplay.
-	// PCSX2 attempts to run VU0 for thousands of cycles as soon as it is started,
-	// so the game will wait endlessly in a wait loop until COP2 gets around to
-	// setting vi5(to break the loop) and vf9(to finish calculation) which is many thousands of cycles later.
-	// VU0 side, remove wait loop.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,004155a8,word,48a44800
-	patch=1,EE,004155ac,word,48c02800
-	patch=1,EE,004155b0,word,4a00d839
-	patch=1,EE,00415660,word,48a44800
-	patch=1,EE,00415664,word,48c02800
-	patch=1,EE,00415668,word,4a00d839
-[/patches]
 ---------------------------------------------
 Serial = SLUS-21269
 Name   = Bully
@@ -41152,6 +41143,7 @@ Serial = SLUS-21272
 Name   = Super Monkey Ball Adventure
 Region = NTSC-U
 Compat = 5
+VU0KickstartHack = 1 // Fixes loading hang.
 ---------------------------------------------
 Serial = SLUS-21273
 Name   = Matrix, The - Path of Neo
@@ -42078,6 +42070,7 @@ Name   = Valkyrie Profile 2 - Silmeria
 Region = NTSC-U
 Compat = 5
 VuAddSubHack = 1
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = SLUS-21453
 Name   = Disney's Meet the Robinsons
@@ -44710,6 +44703,7 @@ Serial = SLUS-29101
 Name   = Crash Twinsanity & Spyro - A Hero's Tail [Demo]
 Region = NTSC-U
 XgKickHack = 1 // Fixes bad geometry.
+VU0KickstartHack = 1 // Fixes loading hang (only for Crash).
 ---------------------------------------------
 Serial = SLUS-29104
 Name   = Galactic Wrestling - Featuring Ultimate Muscle [Demo]
@@ -45002,6 +44996,7 @@ Region = PAL-E
 Serial = TCES-52456
 Name   = Ratchet and Clank 3 Beta Trial Code
 Region = PAL-E
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = TCES-52582
 Name   = Everybody's Golf 4 Beta Trial Code
@@ -45020,6 +45015,7 @@ Serial = TCES-53286
 Name   = Jak X Beta Trial Code
 Region = PAL-E
 Compat = 5
+VU0KickstartHack = 1 // Fixes Character SPS.
 ---------------------------------------------
 Serial = TCPS-10058
 Name   = Densha de Go! Shinkansen [with Controller]

--- a/pcsx2/COP2.cpp
+++ b/pcsx2/COP2.cpp
@@ -29,13 +29,13 @@ using namespace R5900::Interpreter;
 void VCALLMS() {
 	vu0Finish();
 	vu0ExecMicro(((cpuRegs.code >> 6) & 0x7FFF));
-	vif0Regs.stat.VEW = false;
+	//vif0Regs.stat.VEW = false;
 }
 
 void VCALLMSR() {
 	vu0Finish();
 	vu0ExecMicro(VU0.VI[REG_CMSAR0].US[0]);
-	vif0Regs.stat.VEW = false;
+	//vif0Regs.stat.VEW = false;
 }
 
 void BC2F()

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -59,6 +59,7 @@ enum GamefixId
 	Fix_GoemonTlbMiss,
 	Fix_ScarfaceIbit,
 	Fix_CrashTagTeamIbit,
+	Fix_VU0Kickstart,
 
 	GamefixId_COUNT
 };
@@ -361,7 +362,8 @@ struct Pcsx2Config
             FMVinSoftwareHack : 1,      // Toggle in and out of software rendering when an FMV runs.
             GoemonTlbHack : 1,          // Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
             ScarfaceIbit : 1,           // Scarface I bit hack. Needed to stop constant VU recompilation
-            CrashTagTeamRacingIbit : 1; // Crash Tag Team Racing I bit hack. Needed to stop constant VU recompilation
+            CrashTagTeamRacingIbit : 1, // Crash Tag Team Racing I bit hack. Needed to stop constant VU recompilation
+            VU0KickstartHack : 1;       // Speed up VU0 at start of program to avoid some VU1 sync issues
 		BITFIELD_END
 
 		GamefixOptions();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -267,7 +267,8 @@ const wxChar *const tbl_GamefixNames[] =
 	L"FMVinSoftware",
 	L"GoemonTlb",
 	L"ScarfaceIbit",
-    L"CrashTagTeamRacingIbit"
+	L"CrashTagTeamRacingIbit",
+	L"VU0Kickstart"
 };
 
 const __fi wxChar* EnumToString( GamefixId id )
@@ -330,7 +331,8 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_FMVinSoftware:	FMVinSoftwareHack	= enabled;  break;
 		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;  break;
 		case Fix_ScarfaceIbit:  ScarfaceIbit        = enabled;  break;
-        case Fix_CrashTagTeamIbit: CrashTagTeamRacingIbit = enabled; break;
+		case Fix_CrashTagTeamIbit: CrashTagTeamRacingIbit = enabled; break;
+		case Fix_VU0Kickstart:	VU0KickstartHack	= enabled; break;
 		jNO_DEFAULT;
 	}
 }
@@ -356,7 +358,8 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_FMVinSoftware:	return FMVinSoftwareHack;
 		case Fix_GoemonTlbMiss: return GoemonTlbHack;
 		case Fix_ScarfaceIbit:  return ScarfaceIbit;
-        case Fix_CrashTagTeamIbit: return CrashTagTeamRacingIbit;
+		case Fix_CrashTagTeamIbit: return CrashTagTeamRacingIbit;
+		case Fix_VU0Kickstart:	return VU0KickstartHack;
 		jNO_DEFAULT;
 	}
 	return false;		// unreachable, but we still need to suppress warnings >_<
@@ -382,7 +385,8 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( FMVinSoftwareHack );
 	IniBitBool( GoemonTlbHack );
 	IniBitBool( ScarfaceIbit );
-    IniBitBool( CrashTagTeamRacingIbit );
+	IniBitBool( CrashTagTeamRacingIbit );
+	IniBitBool( VU0KickstartHack );
 }
 
 

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -141,7 +141,12 @@ struct __aligned16 VURegs {
 	u32 branchpc;
 	u32 delaybranchpc;
 	bool takedelaybranch;
+	u32 pending_q;
+	u32 pending_p;
 
+	__aligned16 u32 micro_macflags[4];
+	__aligned16 u32 micro_clipflags[4];
+	__aligned16 u32 micro_statusflags[4];
 	// MAC/Status flags -- these are used by interpreters but are kind of hacky
 	// and shouldn't be relied on for any useful/valid info.  Would like to move them out of
 	// this struct eventually.

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -44,7 +44,7 @@ void __fastcall vu0ExecMicro(u32 addr) {
 
 	VU0.VI[REG_VPU_STAT].UL &= ~0xFF;
 	VU0.VI[REG_VPU_STAT].UL |=  0x01;
-
+	VU0.cycle = cpuRegs.cycle;
 	if ((s32)addr != -1) VU0.VI[REG_TPC].UL = addr;
 	_vuExecMicroDebug(VU0);
 	CpuVU0->ExecuteBlock(1);

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -157,12 +157,12 @@ static void _vu0Exec(VURegs* VU)
 
 			if(VU->takedelaybranch)
 			{				
-				VU->branch = 2;
-				DevCon.Warning("VU0 - Branch/Jump in Delay Slot");			
+				VU->branch = 1;
+				DevCon.Warning("VU0 - Branch/Jump in Delay Slot");
 				VU->branchpc = VU->delaybranchpc;
 				VU->delaybranchpc = 0;
 				VU->takedelaybranch = false;
-			}			
+			}
 		}
 	}
 
@@ -206,8 +206,9 @@ void InterpVU0::Step()
 void InterpVU0::Execute(u32 cycles)
 {
 	VU0.VI[REG_TPC].UL <<= 3;
-	for (int i = (int)cycles; i > 0 ; i--) {
-		if (!(VU0.VI[REG_VPU_STAT].UL & 0x1)) {
+	VU0.flags &= ~VUFLAG_MFLAGSET;
+	for (int i = (int)cycles; i > 0; i--) {
+		if (!(VU0.VI[REG_VPU_STAT].UL & 0x1) || (VU0.flags & VUFLAG_MFLAGSET)) {
 			if (VU0.branch || VU0.ebit) {
 				vu0Exec(&VU0); // run branch delay slot?
 			}
@@ -217,4 +218,3 @@ void InterpVU0::Execute(u32 cycles)
 	}
 	VU0.VI[REG_TPC].UL >>= 3;
 }
-

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -57,10 +57,9 @@ void __fastcall vu1ExecMicro(u32 addr)
 	vu1Finish();
 
 	VUM_LOG("vu1ExecMicro %x (count=%d)", addr, count++);
-
+	VU1.cycle = cpuRegs.cycle;
 	VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
 	VU0.VI[REG_VPU_STAT].UL |=  0x0100;
-
 	if ((s32)addr != -1) VU1.VI[REG_TPC].UL = addr;
 	_vuExecMicroDebug(VU1);
 

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -157,7 +157,7 @@ static void _vu1Exec(VURegs* VU)
 
 			if(VU->takedelaybranch)
 			{				
-				VU->branch = 2;
+				VU->branch = 1;
 				//DevCon.Warning("VU1 - Branch/Jump in Delay Slot");			
 				VU->branchpc = VU->delaybranchpc;
 				VU->delaybranchpc = 0;

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -262,6 +262,7 @@ extern BaseVUmicroCPU* CpuVU1;
 extern void vu0ResetRegs();
 extern void __fastcall vu0ExecMicro(u32 addr);
 extern void vu0Exec(VURegs* VU);
+extern void _vu0FinishMicro();
 extern void vu0Finish();
 extern void iDumpVU0Registers();
 

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -174,10 +174,16 @@ __fi void vif0Interrupt()
 
 	if (!(vif0ch.chcr.STR)) Console.WriteLn("vif0 running when CHCR == %x", vif0ch.chcr._u32);
 
+	if(vif0.waitforvu)
+	{
+		//CPU_INT(DMAC_VIF0, 16);
+		return;
+	}
+
 	if (vif0.irq && vif0.vifstalled.enabled && vif0.vifstalled.value == VIF_IRQ_STALL)
 	{
 		vif0Regs.stat.INT = true;
-		
+
 		//Yakuza watches VIF_STAT so lets do this here.
 		if (((vif0Regs.code >> 24) & 0x7f) != 0x7) {
 			vif0Regs.stat.VIS = true;
@@ -193,19 +199,12 @@ __fi void vif0Interrupt()
 			// One game doesn't like vif stalling at end, can't remember what. Spiderman isn't keen on it tho
 			//vif0ch.chcr.STR = false;
 			vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
-			if(vif0ch.qwc > 0 || !vif0.done)	
+			if (vif0ch.qwc > 0 || !vif0.done)
 			{
 				VIF_LOG("VIF0 Stalled");
 				return;
 			}
 		}
-	}
-
-	if(vif0.waitforvu)
-	{
-		//DevCon.Warning("Waiting on VU0");
-		//CPU_INT(DMAC_VIF0, 16);
-		return;
 	}
 
 	vif0.vifstalled.enabled = false;

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -36,7 +36,7 @@ vifOp(vifCode_Null);
 
 __ri void vifExecQueue(int idx)
 {
-	if (!GetVifX.queued_program)
+	if (!GetVifX.queued_program || (VU0.VI[REG_VPU_STAT].UL & 1 << (idx * 8)))
 		return;
 
 	GetVifX.queued_program = false;
@@ -59,6 +59,8 @@ __ri void vifExecQueue(int idx)
 }
 
 static __fi void vifFlush(int idx) {
+	vifExecQueue(idx);
+
 	if (!idx) vif0FLUSH();
 	else      vif1FLUSH();
 
@@ -119,6 +121,7 @@ void ExecuteVU(int idx)
 		vifX.cmd = 0;
 		vifX.pass = 0;
 	}
+	vifExecQueue(idx);
 }
 
 //------------------------------------------------------------------

--- a/pcsx2/Vif_Transfer.cpp
+++ b/pcsx2/Vif_Transfer.cpp
@@ -49,7 +49,7 @@ _vifT void vifTransferLoop(u32* &data) {
 			vifX.cmd	  = data[0] >> 24;
 			
 			
-			//VIF_LOG("New VifCMD %x tagsize %x", vifX.cmd, vifX.tag.size);
+			VIF_LOG("New VifCMD %x tagsize %x irq %d", vifX.cmd, vifX.tag.size, vifX.irq);
 			if (IsDevBuild && SysTrace.EE.VIFcode.IsActive()) {
 				// Pass 2 means "log it"
 				vifCmdHandler[idx][vifX.cmd & 0x7f](2, data);

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -104,9 +104,13 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			_("VU I bit Hack avoid constant recompilation (Scarface The World Is Yours)"),
 			wxEmptyString
 		},
-        {
+		{
 			_("VU I bit Hack avoid constant recompilation (Crash Tag Team Racing)"),
-             wxEmptyString
+			wxEmptyString
+		},
+		{
+			_("VU0 Kickstart to avoid sync problems with VU1"),
+			wxEmptyString
 		}
 	};
 

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -74,6 +74,7 @@ void SetBranchImm( u32 imm );
 void iFlushCall(int flushtype);
 void recBranchCall( void (*func)() );
 void recCall( void (*func)() );
+u32 scaleblockcycles_clear();
 
 namespace R5900{
 namespace Dynarec {

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1027,6 +1027,31 @@ static u32 scaleblockcycles()
 
 	return scaled;
 }
+u32 scaleblockcycles_clear()
+{
+	u32 scaled = scaleblockcycles_calculation();
+
+#if 0 // Enable this to get some runtime statistics about the scaling result in practice
+	static u32 scaled_overall = 0, unscaled_overall = 0;
+	if (g_resetEeScalingStats)
+	{
+		scaled_overall = unscaled_overall = 0;
+		g_resetEeScalingStats = false;
+	}
+	u32 unscaled = DEFAULT_SCALED_BLOCKS();
+	if (!unscaled) unscaled = 1;
+
+	scaled_overall += scaled;
+	unscaled_overall += unscaled;
+	float ratio = static_cast<float>(unscaled_overall) / scaled_overall;
+
+	DevCon.WriteLn(L"Unscaled overall: %d,  scaled overall: %d,  relative EE clock speed: %d %%",
+		unscaled_overall, scaled_overall, static_cast<int>(100 * ratio));
+#endif
+	s_nBlockCycles &= 0x7;
+
+	return scaled;
+}
 
 // Generates dynarec code for Event tests followed by a block dispatch (branch).
 // Parameters:

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -573,6 +573,14 @@ void recSWC1()
 
 void recLQC2()
 {
+	iFlushCall(FLUSH_EVERYTHING);
+	xMOV(eax, ptr[&cpuRegs.cycle]);
+	xADD(eax, scaleblockcycles_clear());
+	xMOV(ptr[&cpuRegs.cycle], eax); // update cycles
+	xLoadFarAddr(arg1reg, CpuVU0);
+	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+	iFlushCall(FLUSH_EVERYTHING);
+
 	if (_Rt_)
 		xLEA(arg2reg, ptr[&VU0.VF[_Ft_].UD[0]]);
 	else
@@ -602,6 +610,14 @@ void recLQC2()
 
 void recSQC2()
 {
+	iFlushCall(FLUSH_EVERYTHING);
+	xMOV(eax, ptr[&cpuRegs.cycle]);
+	xADD(eax, scaleblockcycles_clear());
+	xMOV(ptr[&cpuRegs.cycle], eax); // update cycles
+	xLoadFarAddr(arg1reg, CpuVU0);
+	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+	iFlushCall(FLUSH_EVERYTHING);
+
 	xLEA(arg2reg, ptr[&VU0.VF[_Ft_].UD[0]]);
 
 	if (GPR_IS_CONST1(_Rs_))

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -351,8 +351,11 @@ void recMicroVU1::Reset() {
 void recMicroVU0::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
 
+	VU0.flags &= ~VUFLAG_MFLAGSET;
+
 	if(!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
 	VU0.VI[REG_TPC].UL <<= 3;
+
 	// Sometimes games spin on vu0, so be careful with this value
 	// woody hangs if too high on sVU (untested on mVU)
 	// Edit: Need to test this again, if anyone ever has a "Woody" game :p

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -356,7 +356,7 @@ void mVUdebugPrintBlocks(microVU& mVU, bool isEndPC) {
 
 // vu0 is allowed to exit early, so are dev builds (for inf loops)
 __fi bool doEarlyExit(microVU& mVU) {
-	return IsDevBuild || !isVU1;
+	return true;// IsDevBuild || !isVU1;
 }
 
 // Saves Pipeline State for resuming from early exits
@@ -368,27 +368,32 @@ __fi void mVUsavePipelineState(microVU& mVU) {
 }
 
 // Test cycles to see if we need to exit-early...
-void mVUtestCycles(microVU& mVU) {
+void mVUtestCycles(microVU& mVU, microFlagCycles& mFC) {
 	iPC = mVUstartPC;
 	if (doEarlyExit(mVU)) {
-		xCMP(ptr32[&mVU.cycles], 0);
-		xForwardJG32 skip;
+		xMOV(eax, ptr32[&mVU.cycles]);
+		if (!EmuConfig.Gamefixes.VU0KickstartHack)
+			xSUB(eax, mVUcycles); // Running behind, make sure we have time to run the block
+		else
+			xSUB(eax, 1); // Running ahead, make sure cycles left are above 0
+		xCMP(eax, 0);
+		xForwardJGE32 skip;
+		mVUsavePipelineState(mVU);
 		if (isVU0) {
 			// TEST32ItoM((uptr)&mVU.regs().flags, VUFLAG_MFLAGSET);
 			// xFowardJZ32 vu0jmp;
 			// mVUbackupRegs(mVU, true);
 			// xFastCall(mVUwarning0, mVU.prog.cur->idx, xPC); // VU0 is allowed early exit for COP2 Interlock Simulation
 			// mVUrestoreRegs(mVU, true);
-			mVUsavePipelineState(mVU);
-			mVUendProgram(mVU, NULL, 0);
+			mVUendProgram(mVU, &mFC, 0);
 			// vu0jmp.SetTarget();
 		}
 		else {
-			mVUbackupRegs(mVU, true);
+			/*mVUbackupRegs(mVU, true);
 			xFastCall(mVUwarning1, mVU.prog.cur->idx, xPC);
 			mVUrestoreRegs(mVU, true);
-			mVUsavePipelineState(mVU);
-			mVUendProgram(mVU, NULL, 0);
+			mVUsavePipelineState(mVU);*/
+			mVUendProgram(mVU, &mFC, 0);
 		}
 		skip.SetTarget();
 	}
@@ -401,7 +406,7 @@ void mVUtestCycles(microVU& mVU) {
 
 // This gets run at the start of every loop of mVU's first pass
 __fi void startLoop(mV) {
-	if (curI & _Mbit_)	{ DevCon.WriteLn (Color_Green, "microVU%d: M-bit set! PC = %x", getIndex, xPC); }
+	if (curI & _Mbit_ && isVU0)	{ DevCon.WriteLn (Color_Green, "microVU%d: M-bit set! PC = %x", getIndex, xPC); }
 	if (curI & _Dbit_)	{ DevCon.WriteLn (Color_Green, "microVU%d: D-bit set! PC = %x", getIndex, xPC); }
 	if (curI & _Tbit_)	{ DevCon.WriteLn (Color_Green, "microVU%d: T-bit set! PC = %x", getIndex, xPC); }
 	memzero(mVUinfo);
@@ -475,8 +480,8 @@ void* mVUcompileSingleInstruction(microVU& mVU, u32 startPC, uptr pState, microF
 	mVUsetCycles(mVU);
 	mVUinfo.readQ  =  mVU.q;
 	mVUinfo.writeQ = !mVU.q;
-	mVUinfo.readP  =  mVU.p;
-	mVUinfo.writeP = !mVU.p;
+	mVUinfo.readP  =  mVU.p && isVU1;
+	mVUinfo.writeP = !mVU.p && isVU1;
 	mVUcount++;
 	mVUsetFlagInfo(mVU);
 	incPC(1);
@@ -485,7 +490,8 @@ void* mVUcompileSingleInstruction(microVU& mVU, u32 startPC, uptr pState, microF
 	mVUsetFlags(mVU, mFC);           // Sets Up Flag instances
 	mVUoptimizePipeState(mVU);       // Optimize the End Pipeline State for nicer Block Linking
 	mVUdebugPrintBlocks(mVU, false); // Prints Start/End PC of blocks executed, for debugging...
-	mVUtestCycles(mVU);              // Update VU Cycles and Exit Early if Necessary
+	
+	mVUtestCycles(mVU, mFC);              // Update VU Cycles and Exit Early if Necessary
 
 	// Second Pass
 	iPC = startPC / 4;
@@ -534,37 +540,52 @@ void mVUSaveFlags(microVU& mVU,microFlagCycles &mFC, microFlagCycles &mFCBackup)
 	memcpy(&mFCBackup, &mFC, sizeof(microFlagCycles));
 	mVUsetFlags(mVU, mFCBackup);	   // Sets Up Flag instances
 }
-void* mVUcompile(microVU& mVU, u32 startPC, uptr pState) {
-
+void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
+{
 	microFlagCycles mFC;
-	u8*				thisPtr  = x86Ptr;
-	const u32		endCount = (((microRegInfo*)pState)->blockType) ? 1 : (mVU.microMemSize / 8);
+	u8* thisPtr = x86Ptr;
+	const u32 endCount = (((microRegInfo*)pState)->blockType) ? 1 : (mVU.microMemSize / 8);
 
 	// First Pass
 	iPC = startPC / 4;
 	mVUsetupRange(mVU, startPC, 1); // Setup Program Bounds/Range
-	mVU.regAlloc->reset(); // Reset regAlloc
+	mVU.regAlloc->reset();          // Reset regAlloc
 	mVUinitFirstPass(mVU, pState, thisPtr);
 	mVUbranch = 0;
-	for(int branch = 0; mVUcount < endCount;) {
+	for (int branch = 0; mVUcount < endCount;) {
 		incPC(1);
 		startLoop(mVU);
 		mVUincCycles(mVU, 1);
 		mVUopU(mVU, 0);
 		mVUcheckBadOp(mVU);
-		if (curI & _Ebit_)  { eBitPass1(mVU, branch); }
-		
-		if (curI & _Mbit_)  { mVUup.mBit = true; }
-		
-		if (curI & _Ibit_)  { mVUlow.isNOP = true; mVUup.iBit = true; }
-		else                { incPC(-1); mVUopL(mVU, 0); incPC(1); }
-		if (curI & _Dbit_)  { mVUup.dBit = true; }
-		if (curI & _Tbit_)  { mVUup.tBit = true; }
+		if (curI & _Ebit_) {
+			eBitPass1(mVU, branch);
+		}
+
+		if ((curI & _Mbit_) && isVU0) {
+			mVUup.mBit = true;
+		}
+
+		if (curI & _Ibit_) {
+			mVUlow.isNOP = true;
+			mVUup.iBit = true;
+		}
+		else {
+			incPC(-1);
+			mVUopL(mVU, 0);
+			incPC(1);
+		}
+		if (curI & _Dbit_) {
+			mVUup.dBit = true;
+		}
+		if (curI & _Tbit_) {
+			mVUup.tBit = true;
+		}
 		mVUsetCycles(mVU);
-		mVUinfo.readQ  =  mVU.q;
+		mVUinfo.readQ = mVU.q;
 		mVUinfo.writeQ = !mVU.q;
-		mVUinfo.readP  =  mVU.p;
-		mVUinfo.writeP = !mVU.p;
+		mVUinfo.readP = mVU.p && isVU1;
+		mVUinfo.writeP = !mVU.p && isVU1;
 		mVUcount++;
 
 		if (branch >= 2) {
@@ -588,6 +609,9 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState) {
 			mVUbranch = 0;
 		}
 
+		if (mVUup.mBit && !branch && !mVUup.eBit)
+			break;
+
 		if (mVUinfo.isEOB)
 			break;
 
@@ -595,30 +619,43 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState) {
 	}
 
 	// Fix up vi15 const info for propagation through blocks
-	mVUregs.vi15  = (doConstProp && mVUconstReg[15].isValid) ? (u16)mVUconstReg[15].regValue : 0;
+	mVUregs.vi15 = (doConstProp && mVUconstReg[15].isValid) ? (u16)mVUconstReg[15].regValue : 0;
 	mVUregs.vi15v = (doConstProp && mVUconstReg[15].isValid) ? 1 : 0;
 
 	mVUsetFlags(mVU, mFC);           // Sets Up Flag instances
 	mVUoptimizePipeState(mVU);       // Optimize the End Pipeline State for nicer Block Linking
 	mVUdebugPrintBlocks(mVU, false); // Prints Start/End PC of blocks executed, for debugging...
-	mVUtestCycles(mVU);              // Update VU Cycles and Exit Early if Necessary
+	mVUtestCycles(mVU, mFC);              // Update VU Cycles and Exit Early if Necessary
 
 	// Second Pass
 	iPC = mVUstartPC;
 	setCode();
 	mVUbranch = 0;
 	u32 x = 0;
-	for( ; x < endCount; x++) {
-		if (mVUinfo.isEOB)			{ handleBadOp(mVU, x); x = 0xffff; } // handleBadOp currently just prints a warning
-		if (mVUup.mBit)				{ xOR(ptr32[&mVU.regs().flags], VUFLAG_MFLAGSET); }
+
+	for (; x < endCount; x++) {
+		if (mVUinfo.isEOB) {
+			handleBadOp(mVU, x);
+			x = 0xffff;
+		} // handleBadOp currently just prints a warning
+		if (mVUup.mBit) {
+			xOR(ptr32[&mVU.regs().flags], VUFLAG_MFLAGSET);
+		}
 		mVUexecuteInstruction(mVU);
-		if(!mVUinfo.isBdelay && !mVUlow.branch) //T/D Bit on branch is handled after the branch, branch delay slots are executed.
+		if (!mVUinfo.isBdelay && !mVUlow.branch) //T/D Bit on branch is handled after the branch, branch delay slots are executed.
 		{
 			if (mVUup.tBit) {
 				mVUDoTBit(mVU, &mFC);
 			}
 			else if (mVUup.dBit && doDBitHandling) {
 				mVUDoDBit(mVU, &mFC);
+			}
+			else if (mVUup.mBit && !mVUup.eBit && !mVUinfo.isEOB) {
+				mVUsetupRange(mVU, xPC, false);
+				incPC(2);
+				mVUendProgram(mVU, &mFC, 0);
+				incPC(-2);
+				goto perf_and_return;
 			}
 		}
 
@@ -640,22 +677,41 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState) {
 			incPC(-3); // Go back to branch opcode
 
 			switch (mVUlow.branch) {
-				case 1: case 2:  normBranch(mVU, mFC);			  goto perf_and_return; // B/BAL
-				case 9: case 10: normJump  (mVU, mFC);			  goto perf_and_return; // JR/JALR
-				case 3: condBranch(mVU, mFC, Jcc_Equal);		  goto perf_and_return; // IBEQ
-				case 4: condBranch(mVU, mFC, Jcc_GreaterOrEqual); goto perf_and_return; // IBGEZ
-				case 5: condBranch(mVU, mFC, Jcc_Greater);		  goto perf_and_return; // IBGTZ
-				case 6: condBranch(mVU, mFC, Jcc_LessOrEqual);	  goto perf_and_return; // IBLEQ
-				case 7: condBranch(mVU, mFC, Jcc_Less);			  goto perf_and_return; // IBLTZ
-				case 8: condBranch(mVU, mFC, Jcc_NotEqual);		  goto perf_and_return; // IBNEQ
+			case 1: // B/BAL
+			case 2:
+				normBranch(mVU, mFC);
+				goto perf_and_return;
+			case 9: // JR/JALR
+			case 10:
+				normJump(mVU, mFC);
+				goto perf_and_return;
+			case 3: // IBEQ
+				condBranch(mVU, mFC, Jcc_Equal);
+				goto perf_and_return;
+			case 4: // IBGEZ
+				condBranch(mVU, mFC, Jcc_GreaterOrEqual);
+				goto perf_and_return;
+			case 5: // IBGTZ
+				condBranch(mVU, mFC, Jcc_Greater);
+				goto perf_and_return;
+			case 6: // IBLEQ
+				condBranch(mVU, mFC, Jcc_LessOrEqual);
+				goto perf_and_return;
+			case 7: // IBLTZ
+				condBranch(mVU, mFC, Jcc_Less);
+				goto perf_and_return;
+			case 8: // IBNEQ
+				condBranch(mVU, mFC, Jcc_NotEqual);
+				goto perf_and_return;
 			}
-
 		}
 	}
-	if ((x == endCount) && (x!=1)) { Console.Error("microVU%d: Possible infinite compiling loop!", mVU.index); }
+	if ((x == endCount) && (x != 1)) {
+		Console.Error("microVU%d: Possible infinite compiling loop!", mVU.index);
+	}
 
 	// E-bit End
-	mVUsetupRange(mVU, xPC-8, false);
+	mVUsetupRange(mVU, xPC - 8, false);
 	mVUendProgram(mVU, &mFC, 1);
 
 perf_and_return:


### PR DESCRIPTION
Changes by Refraction:
Implement basic cycle counting for COP2 operations, implement COP2 detection while not interlocking, implement Mbit, change drastically cycles required to run every microprogram. Improved flag handling while COP2 update them.

Additionally:  
As explained here: [Link](https://www.patreon.com/posts/shadow-of-fixing-33354075). Hardware tests proved that VU run at the same speed as EE mips core. So lets set that in pcsx2 where it is possible.

Fixed games in this commit:
- (VIF) Hitman games - Could have potentially crashed randomly with TLB misses or FIFO errors, no longer happening

- 24 The game, Primal, Ghosthunter - No longer need patches to get full speed
- Air Rescue Ranger - Textures are now displayed correctly
- Amplitude - SPS on characters fixed
- Gift, Woody Woodpecker, Kaan - Now work full speed
- Lotus Challenge - Cars are no longer bouncy!
- My Street - missing characters now visible, still exhibit a small amount of SPS in microVU0 but perfect in VU0 Int
- Mike Tysons Heavyweight Box - T posing seethrough characters are now whole and animated
- Next Generation Tennis 2003 - No longer need patch to fix SPS
- Nichibeikan Pro Yakyuu: Final League / World Fantasista - Random glitches are gone
- Phase Paradox - Lighting and Camera in cutscenes are fixed
- Ratchet Gladiator - Improved shadow geometry (not fully fixed yet)
- Rayman 2 Revolution - Random jittering no longer happens
- Sega Superstars Tennis - SPS on hands/feet is now gone
- Tiger woods PGA Tour 2002 - Fixed player stance
- Tony Hawk 4 - Wakeboarding Unleashed demo no longer crash at loading screen (demo need XGKick hack)
- Totally Spies Totally Party! - Bad SPS somewhat fixed - Will require you to set EE Cyclerate + 3 to completely fix.
- Twisted Metal Head-On - Black doors have now proper colors
- Wakeboarding Unleashed - No longer hangs getting to the menu on release builds
- World Series Baseball 2k3 - No longer hang on loading screen (game still have other issues)

Game issues fixed:
fixes #1448 fixes #3252 fixes #3028 fixes #1473 fixes #94 

Games Broken:
DT Racer - Game will randomly hang, this game has other issues and these changes just made them more apparent.