### PR TITLE
pcsx2-gui: Some menu changes

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -154,6 +154,7 @@ enum MenuIdentifiers
 
 	MenuId_Config_Multitap0Toggle,
 	MenuId_Config_Multitap1Toggle,
+	MenuId_Config_FastBoot,
 
 	MenuId_Help_GetStarted,
 	MenuId_Help_Forums,

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -70,15 +70,15 @@ static const bool CloseViewportWithPlugins = false;
 
 enum TopLevelMenuIndices
 {
-	TopLevelMenu_System = 0,
+	TopLevelMenu_Pcsx2 = 0,
 	TopLevelMenu_Cdvd,
 	TopLevelMenu_Config,
-	TopLevelMenu_Misc,
-	TopLevelMenu_Debug,
+	TopLevelMenu_Window,
 	TopLevelMenu_Capture,
 #ifndef DISABLE_RECORDING
 	TopLevelMenu_Recording,
 #endif
+	TopLevelMenu_Help
 };
 
 enum MenuIdentifiers
@@ -157,6 +157,7 @@ enum MenuIdentifiers
 	MenuId_Config_FastBoot,
 
 	MenuId_Help_GetStarted,
+	MenuId_Help_Compatibility,
 	MenuId_Help_Forums,
 	MenuId_Help_Website,
 	MenuId_Help_Wiki,

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -117,6 +117,7 @@ enum MenuIdentifiers
 	MenuId_Sys_LoadStates,		// Opens load states submenu
 	MenuId_Sys_SaveStates,		// Opens save states submenu
 	MenuId_EnableBackupStates,	// Checkbox to enable/disables savestates backup
+	MenuId_GameSettingsSubMenu,
 	MenuId_EnablePatches,
 	MenuId_EnableCheats,
 	MenuId_EnableWideScreenPatches,
@@ -153,6 +154,12 @@ enum MenuIdentifiers
 
 	MenuId_Config_Multitap0Toggle,
 	MenuId_Config_Multitap1Toggle,
+
+	MenuId_Help_GetStarted,
+	MenuId_Help_Forums,
+	MenuId_Help_Website,
+	MenuId_Help_Wiki,
+	MenuId_Help_Github,
 
 	// Plugin Sections
 	// ---------------

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -525,6 +525,7 @@ AppConfig::AppConfig()
 	#endif
 	EnableSpeedHacks	= true;
 	EnableGameFixes		= false;
+	EnableFastBoot		= true;
 
 	EnablePresets		= true;
 	PresetIndex			= 1;
@@ -646,6 +647,7 @@ void AppConfig::LoadSaveRootItems( IniInterface& ini )
 
 	IniEntry( EnableSpeedHacks );
 	IniEntry( EnableGameFixes );
+	IniEntry( EnableFastBoot );
 
 	IniEntry( EnablePresets );
 	IniEntry( PresetIndex );
@@ -1032,7 +1034,6 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 	Framerate.SlomoScalar = original_Framerate.SlomoScalar;
 	Framerate.TurboScalar = original_Framerate.TurboScalar;
 
-	EnableSpeedHacks	= false;
 	EnableGameFixes		= false;
 
 	EmuOptions.EnablePatches		= true;

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -309,6 +309,7 @@ public:
 	// (the toggle is applied when a new EmuConfig is sent through AppCoreThread::ApplySettings)
 	bool		EnableSpeedHacks;
 	bool		EnableGameFixes;
+	bool		EnableFastBoot;
 
 	// Presets try to prevent users from overwhelming when they want to change settings (usually to make a game run faster).
 	// The presets allow to modify the balance between emulation accuracy and emulation speed using a pseudo-linear control.

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1178,6 +1178,7 @@ void SysUpdateIsoSrcFile( const wxString& newIsoFile )
 {
 	g_Conf->CurrentIso = newIsoFile;
 	sMainFrame.UpdateIsoSrcSelection();
+	sMainFrame.UpdateStatusBar();
 }
 
 bool HasMainFrame()

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/Console.h"
 #include "Utilities/IniInterface.h"
 #include "Utilities/SafeArray.inl"
+#include "Dialogs/LogOptionsDialog.h"
 #include "DebugTools/Debug.h"
 
 #include <wx/textfile.h>
@@ -243,6 +244,7 @@ enum MenuIDs_t
 	MenuId_ColorScheme_Dark,
 
 	MenuId_AutoDock,
+	MenuId_Log_Settings,
 
 	MenuId_LogSource_EnableAll = 0x30,
 	MenuId_LogSource_DisableAll,
@@ -433,6 +435,7 @@ ConsoleLogFrame::ConsoleLogFrame( MainEmuFrame *parent, const wxString& title, A
 	//	_t("When checked the log window will be visible over other foreground windows."), wxITEM_CHECK );
 
 	menuLog.Append(wxID_SAVE,	_("&Save..."),		_("Save log contents to file"));
+	menuLog.Append(MenuId_Log_Settings,	_("&Settings..."),		_("Open the logging settings dialog"));
 	menuLog.Append(wxID_CLEAR,	_("C&lear"),		_("Clear the log window contents"));
 	menuLog.AppendSeparator();
 	menuLog.AppendCheckItem(MenuId_AutoDock, _("Auto&dock"), _("Dock log window to main PCSX2 window"))->Check(m_conf.AutoDock);
@@ -479,6 +482,9 @@ ConsoleLogFrame::ConsoleLogFrame( MainEmuFrame *parent, const wxString& title, A
 	Bind(wxEVT_MENU, &ConsoleLogFrame::OnClose, this, wxID_CLOSE);
 	Bind(wxEVT_MENU, &ConsoleLogFrame::OnSave, this, wxID_SAVE);
 	Bind(wxEVT_MENU, &ConsoleLogFrame::OnClear, this, wxID_CLEAR);
+#ifdef PCSX2_DEVBUILD
+	Bind(wxEVT_MENU, &ConsoleLogFrame::OnLogSettings, this, MenuId_Log_Settings);
+#endif
 
 	Bind(wxEVT_MENU, &ConsoleLogFrame::OnFontSize, this, MenuId_FontSize_Small, MenuId_FontSize_Huge);
 	Bind(wxEVT_MENU, &ConsoleLogFrame::OnToggleTheme, this, MenuId_ColorScheme_Light, MenuId_ColorScheme_Dark);
@@ -807,6 +813,11 @@ void ConsoleLogFrame::OnSave(wxCommandEvent& WXUNUSED(event))
 void ConsoleLogFrame::OnClear(wxCommandEvent& WXUNUSED(event))
 {
 	m_TextCtrl.Clear();
+}
+
+void ConsoleLogFrame::OnLogSettings(wxCommandEvent& WXUNUSED(event))
+{
+	AppOpenDialog<Dialogs::LogOptionsDialog>( this );
 }
 
 void ConsoleLogFrame::OnToggleCDVDInfo( wxCommandEvent& evt )

--- a/pcsx2/gui/ConsoleLogger.h
+++ b/pcsx2/gui/ConsoleLogger.h
@@ -199,6 +199,7 @@ protected:
 	void OnClose(wxCommandEvent& event);
 	void OnSave (wxCommandEvent& event);
 	void OnClear(wxCommandEvent& event);
+	void OnLogSettings(wxCommandEvent& event);
 
 	void OnEnableAllLogging(wxCommandEvent& event);
 	void OnDisableAllLogging(wxCommandEvent& event);

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -311,7 +311,7 @@ WXLRESULT DisassemblyDialog::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARA
 			WXHWND hwnd = GetHWND();
 
 			u32 style = GetWindowLong((HWND)hwnd,GWL_STYLE);
-			style &= ~(WS_MINIMIZEBOX|WS_MAXIMIZEBOX);
+			//style &= ~(WS_MINIMIZEBOX|WS_MAXIMIZEBOX);
 			SetWindowLong((HWND)hwnd,GWL_STYLE,style);
 
 			u32 exStyle = GetWindowLong((HWND)hwnd,GWL_EXSTYLE);

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -304,38 +304,6 @@ void DisassemblyDialog::onSizeEvent(wxSizeEvent& event)
 	event.Skip();
 }
 
-#ifdef _WIN32
-WXLRESULT DisassemblyDialog::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
-{
-	switch (nMsg)
-	{
-	case WM_SHOWWINDOW:
-		{
-			WXHWND hwnd = GetHWND();
-
-			u32 style = GetWindowLong((HWND)hwnd,GWL_STYLE);
-			//style &= ~(WS_MINIMIZEBOX|WS_MAXIMIZEBOX);
-			SetWindowLong((HWND)hwnd,GWL_STYLE,style);
-
-			u32 exStyle = GetWindowLong((HWND)hwnd,GWL_EXSTYLE);
-			exStyle |= (WS_EX_CONTEXTHELP);
-			SetWindowLong((HWND)hwnd,GWL_EXSTYLE,exStyle);
-		}
-		break;
-	case WM_SYSCOMMAND:
-		if (wParam == SC_CONTEXTHELP)
-		{
-			DebuggerHelpDialog help(this);
-			help.ShowModal();
-			return 0;
-		}
-		break;
-	}
-
-	return wxFrame::MSWWindowProc(nMsg,wParam,lParam);
-}
-#endif
-
 void DisassemblyDialog::onBreakRunClicked(wxCommandEvent& evt)
 {	
 	if (r5900Debug.isCpuPaused())

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -15,6 +15,8 @@
 
 #include "PrecompiledHeader.h"
 
+#include "App.h"
+#include "MainFrame.h"
 #include "DisassemblyDialog.h"
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/DisassemblyManager.h"
@@ -570,7 +572,10 @@ void DisassemblyDialog::onDebuggerEvent(wxCommandEvent& evt)
 
 void DisassemblyDialog::onClose(wxCloseEvent& evt)
 {
+	auto* mainFrame = GetMainFramePtr();
+
 	Hide();
+	mainFrame->CheckMenuItem(MenuId_Debug_Open, false);
 }
 
 void DisassemblyDialog::update()

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -229,7 +229,7 @@ u32 CpuTabPage::getStepOutAddress()
 }
 
 DisassemblyDialog::DisassemblyDialog(wxWindow* parent):
-	wxFrame( parent, wxID_ANY, L"Debugger", wxDefaultPosition,wxDefaultSize,wxRESIZE_BORDER|wxCLOSE_BOX|wxCAPTION|wxSYSTEM_MENU ),
+	wxFrame( parent, wxID_ANY, L"Debugger", wxDefaultPosition,wxDefaultSize,wxRESIZE_BORDER|wxCLOSE_BOX|wxCAPTION|wxSYSTEM_MENU|wxMINIMIZE_BOX|wxMAXIMIZE_BOX ),
 	currentCpu(NULL)
 {
 	int width = g_Conf->EmuOptions.Debugger.WindowWidth;

--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -91,10 +91,6 @@ public:
 	void reset();
 	void populate();
 	void setDebugMode(bool debugMode, bool switchPC);
-	
-#ifdef _WIN32
-	WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam);
-#endif
 
 	wxDECLARE_EVENT_TABLE();
 protected:

--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -102,9 +102,10 @@ protected:
 	void onStepOverClicked(wxCommandEvent& evt);
 	void onStepIntoClicked(wxCommandEvent& evt);
 	void onStepOutClicked(wxCommandEvent& evt);
+	void onHelpClicked(wxCommandEvent& evt);
 	void onDebuggerEvent(wxCommandEvent& evt);
 	void onPageChanging(wxCommandEvent& evt);
-	void onBreakpointClick(wxCommandEvent& evt);
+	void onBreakpointClicked(wxCommandEvent& evt);
 	void onSizeEvent(wxSizeEvent& event);
 	void onClose(wxCloseEvent& evt);
 	void stepOver();
@@ -118,9 +119,5 @@ private:
 	wxNotebook* middleBook;
 
 	wxBoxSizer* topSizer;
-	wxButton* breakRunButton;
-	wxButton* stepIntoButton;
-	wxButton* stepOverButton;
-	wxButton* stepOutButton;
-	wxButton* breakpointButton;
+	wxButton *breakRunButton, *stepIntoButton, *stepOverButton, *stepOutButton, *breakpointButton, *helpButton;
 };

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -53,6 +53,26 @@ wxMenu* MainEmuFrame::MakeStatesSubMenu( int baseid, int loadBackupId ) const
 	return mnuSubstates;
 }
 
+void MainEmuFrame::UpdateStatusBar()
+{
+	wxString temp(wxEmptyString);
+
+	if (g_Conf->EnableFastBoot)
+		temp += "Fast Boot - ";
+
+	if (g_Conf->CdvdSource == CDVD_SourceType::Iso)
+		temp += "Selected: '" + wxFileName(g_Conf->CurrentIso).GetFullName() +"' ";
+
+#ifdef __M_X86_64
+	temp+= "(64 bit) ";
+#else
+	temp += "(32 bit) ";
+#endif
+
+	m_statusbar.SetStatusText(temp, 0);
+	m_statusbar.SetStatusText(CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], 1);
+}
+
 void MainEmuFrame::UpdateIsoSrcSelection()
 {
 	MenuIdentifiers cdsrc = MenuId_Src_Iso;
@@ -66,12 +86,8 @@ void MainEmuFrame::UpdateIsoSrcSelection()
 		jNO_DEFAULT
 	}
 	sMenuBar.Check( cdsrc, true );
-	m_statusbar.SetStatusText( CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], 1 );
-
+	UpdateStatusBar();
 	EnableCdvdPluginSubmenu( cdsrc == MenuId_Src_Plugin );
-
-	//sMenuBar.SetLabel( MenuId_Src_Iso, wxsFormat( L"%s -> %s", _("Iso"),
-	//	exists ? Path::GetFilename(g_Conf->CurrentIso).c_str() : _("Empty") ) );
 }
 
 bool MainEmuFrame::Destroy()

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -418,17 +418,18 @@ void MainEmuFrame::CreateConfigMenu()
 
 	m_menuConfig.AppendSeparator();
 
-	m_menuConfig.Append( MenuId_ChangeLang,			L"Change &Language" ); // Always in English
+	m_menuConfig.Append(MenuId_ChangeLang,			L"Change &Language" ); // Always in English
 	m_menuConfig.Append(MenuId_Config_ResetAll,	_("C&lear all settings..."),
 		AddAppName(_("Clears all %s settings and re-runs the startup wizard.")));
 }
 
 void MainEmuFrame::CreateWindowsMenu()
 {
-	m_menuWindow.Append(MenuId_Debug_Open,		_("&Open Debug Window..."),	wxEmptyString);
+	m_menuWindow.Append(MenuId_Debug_Open,		_("&Show Debug"),	wxEmptyString, wxITEM_CHECK );
 
 	m_menuWindow.Append( &m_MenuItem_Console );
 #if defined(__unix__)
+	m_menuWindow.AppendSeparator();
 	m_menuWindow.Append( &m_MenuItem_Console_Stdio );
 #endif
 }

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -468,15 +468,15 @@ void MainEmuFrame::CreateRecordMenu()
 
 void MainEmuFrame::CreateHelpMenu()
 {
-	m_menuHelp.Append(MenuId_Help_GetStarted,				_("&Getting Started") );
-	m_menuHelp.Append(MenuId_Help_Compatibility,			_("&Compatibility") );
+	m_menuHelp.Append(MenuId_Help_GetStarted,				_("&Getting Started"));
+	m_menuHelp.Append(MenuId_Help_Compatibility,			_("&Compatibility"));
 	m_menuHelp.AppendSeparator();
-	m_menuHelp.Append(MenuId_Help_Forums,					_("&Pcsx2 Forums") );
-	m_menuHelp.Append(MenuId_Help_Website,					_("&Pcsx2 Website") );
-	m_menuHelp.Append(MenuId_Help_Wiki,						_("&Pcsx2 Wiki") );
-	m_menuHelp.Append(MenuId_Help_Github,					_("&Pcsx2 Github Project") );
+	m_menuHelp.Append(MenuId_Help_Website,					_("&Website"));
+	m_menuHelp.Append(MenuId_Help_Wiki,						_("&Wiki"));
+	m_menuHelp.Append(MenuId_Help_Forums,					_("&Support Forums"));
+	m_menuHelp.Append(MenuId_Help_Github,					_("&Github Repository"));
 	m_menuHelp.AppendSeparator();
-	m_menuHelp.Append(MenuId_About,							_("&About...") );
+	m_menuHelp.Append(MenuId_About,							_("&About..."));
 }
 
 // ------------------------------------------------------------------------

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -255,6 +255,7 @@ void MainEmuFrame::ConnectMenus()
 #endif
 
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_GetStarted, this, MenuId_Help_GetStarted);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Compatibility, this, MenuId_Help_Compatibility);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Forums, this, MenuId_Help_Forums);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Website, this, MenuId_Help_Website);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Github, this, MenuId_Help_Github);
@@ -358,15 +359,8 @@ void MainEmuFrame::CreatePcsx2Menu()
 	m_menuSys.Append( MenuId_Config_FastBoot,_("Fast Boot"),
 		_("Skips PS2 splash screens when booting from ISO or DVD media"), wxITEM_CHECK );
 
-	m_menuSys.AppendSeparator();
-
-	m_menuSys.Append(MenuId_Sys_LoadStates,	_("&Load state"), &m_LoadStatesSubmenu);
-	m_menuSys.Append(MenuId_Sys_SaveStates,	_("&Save state"), &m_SaveStatesSubmenu);
-
-	m_menuSys.Append(MenuId_EnableBackupStates,	_("&Backup before save"), wxEmptyString, wxITEM_CHECK);
 	m_menuSys.AppendCheckItem(MenuId_Debug_CreateBlockdump, _("Create &Blockdump"), _("Creates a block dump for debugging purposes."));
 
-	m_menuSys.AppendSeparator();
 	m_menuSys.Append(MenuId_GameSettingsSubMenu,	_("&Game Settings"), &m_GameSettingsSubmenu);
 
 	m_GameSettingsSubmenu.Append(MenuId_EnablePatches,	_("Automatic &Gamefixes"),
@@ -386,6 +380,15 @@ void MainEmuFrame::CreatePcsx2Menu()
 	if(IsDebugBuild || IsDevBuild)
 		m_GameSettingsSubmenu.Append(MenuId_EnableHostFs,	_("Enable &Host Filesystem"),
 			wxEmptyString, wxITEM_CHECK);
+
+	m_menuSys.AppendSeparator();
+
+	m_menuSys.Append(MenuId_Sys_LoadStates,	_("&Load state"), &m_LoadStatesSubmenu);
+	m_menuSys.Append(MenuId_Sys_SaveStates,	_("&Save state"), &m_SaveStatesSubmenu);
+
+	m_menuSys.Append(MenuId_EnableBackupStates,	_("&Backup before save"), wxEmptyString, wxITEM_CHECK);
+
+	m_menuSys.AppendSeparator();
 
 	m_menuSys.Append(MenuId_Exit,			_("E&xit"),
 		AddAppName(_("Closing %s may be hazardous to your health")));
@@ -466,6 +469,7 @@ void MainEmuFrame::CreateRecordMenu()
 void MainEmuFrame::CreateHelpMenu()
 {
 	m_menuHelp.Append(MenuId_Help_GetStarted,				_("&Getting Started") );
+	m_menuHelp.Append(MenuId_Help_Compatibility,			_("&Compatibility") );
 	m_menuHelp.AppendSeparator();
 	m_menuHelp.Append(MenuId_Help_Forums,					_("&Pcsx2 Forums") );
 	m_menuHelp.Append(MenuId_Help_Website,					_("&Pcsx2 Website") );

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -61,16 +61,16 @@ void MainEmuFrame::UpdateStatusBar()
 		temp += "Fast Boot - ";
 
 	if (g_Conf->CdvdSource == CDVD_SourceType::Iso)
-		temp += "Selected: '" + wxFileName(g_Conf->CurrentIso).GetFullName() +"' ";
-
-#ifdef __M_X86_64
-	temp+= "(64 bit) ";
-#else
-	temp += "(32 bit) ";
-#endif
+		temp += "Load: '" + wxFileName(g_Conf->CurrentIso).GetFullName() +"' ";
 
 	m_statusbar.SetStatusText(temp, 0);
 	m_statusbar.SetStatusText(CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], 1);
+
+#ifdef __M_X86_64
+	m_statusbar.SetStatusText("x64", 2);
+#else
+	m_statusbar.SetStatusText("x32", 2);
+#endif
 }
 
 void MainEmuFrame::UpdateIsoSrcSelection()
@@ -566,8 +566,9 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	// I cannot get it to work despite following various examples to the letter.
 	SetIcons( wxGetApp().GetIconBundle() );
 
-	int m_statusbar_widths[] = { (int)(backsize.GetWidth()*0.73), (int)(backsize.GetWidth()*0.25) };
-	m_statusbar.SetStatusWidths(2, m_statusbar_widths);
+	int m_statusbar_widths[] = { (int)-20, (int)-3, (int) -2 };
+	m_statusbar.SetFieldsCount(3);
+	m_statusbar.SetStatusWidths(3, m_statusbar_widths);
 	m_statusbar.SetStatusText( wxEmptyString, 0);
 
 	wxBoxSizer& joe( *new wxBoxSizer( wxVERTICAL ) );

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -248,7 +248,6 @@ void MainEmuFrame::ConnectMenus()
 
 	// Debug
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Debug_Open_Click, this, MenuId_Debug_Open);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Debug_Logging_Click, this, MenuId_Debug_Logging);
 
 	// Capture
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Record_Click, this, MenuId_Capture_Video_Record);
@@ -344,8 +343,6 @@ void MainEmuFrame::CreatePcsx2Menu()
 		_("Skips PS2 splash screens when booting from ISO or DVD media"), wxITEM_CHECK );
 
 	m_menuSys.AppendSeparator();
-	//m_menuSys.Append(MenuId_Sys_Close,		_("Close"),
-	//	_("Stops emulation and closes the GS window."));
 
 	m_menuSys.Append(MenuId_Sys_LoadStates,	_("&Load state"), &m_LoadStatesSubmenu);
 	m_menuSys.Append(MenuId_Sys_SaveStates,	_("&Save state"), &m_SaveStatesSubmenu);
@@ -399,9 +396,6 @@ void MainEmuFrame::CreateConfigMenu()
 	m_menuConfig.Append(MenuId_Config_SysSettings,	_("Emulation &Settings...") );
 	m_menuConfig.Append(MenuId_Config_McdSettings,	_("&Memory cards...") );
 	m_menuConfig.Append(MenuId_Config_BIOS,			_("&Plugin/BIOS Selector...") );
-#ifdef PCSX2_DEVBUILD
-	m_menuConfig.Append(MenuId_Debug_Logging,		_("&Logging Settings..."),			wxEmptyString);
-#endif
 
 	m_menuConfig.AppendSeparator();
 
@@ -418,7 +412,7 @@ void MainEmuFrame::CreateConfigMenu()
 
 	m_menuConfig.AppendSeparator();
 
-	m_menuConfig.Append(MenuId_ChangeLang,			L"Change &Language" ); // Always in English
+	m_menuConfig.Append(MenuId_ChangeLang,			L"Change &language..." ); // Always in English
 	m_menuConfig.Append(MenuId_Config_ResetAll,	_("C&lear all settings..."),
 		AddAppName(_("Clears all %s settings and re-runs the startup wizard.")));
 }
@@ -455,12 +449,6 @@ void MainEmuFrame::CreateRecordMenu()
 
 void MainEmuFrame::CreateHelpMenu()
 {
-
-	MenuId_Help_GetStarted,
-	MenuId_Help_Forums,
-	MenuId_Help_Website,
-	MenuId_Help_Github,
-
 	m_menuHelp.Append(MenuId_Help_GetStarted,				_("&Getting Started") );
 	m_menuHelp.AppendSeparator();
 	m_menuHelp.Append(MenuId_Help_Forums,					_("&Pcsx2 Forums") );
@@ -514,7 +502,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	m_menubar.Append( &m_menuSys,		_("&PCSX2") );
 	m_menubar.Append( &m_menuCDVD,		_("CD&VD") );
 	m_menubar.Append( &m_menuConfig,	_("&Config") );
-	m_menubar.Append( &m_menuWindow,		_("&Window") );
+	m_menubar.Append( &m_menuWindow,	_("&Window") );
 	m_menubar.Append( &m_menuCapture,	_("&Capture") );
 
 	SetMenuBar( &m_menubar );

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -164,6 +164,7 @@ public:
 	void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	void CommitPreset_noTrigger();
 	void AppendKeycodeNamesToMenuOptions();
+	void UpdateStatusBar();
 
 protected:
 	void DoGiveHelp(const wxString& text, bool show);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -147,6 +147,7 @@ public:
 	void UpdateIsoSrcSelection();
 	void RemoveCdvdMenu();
 	void EnableMenuItem( int id, bool enable );
+	void CheckMenuItem(int id, bool checked);
 	void SetMenuItemLabel(int id, wxString str);
 	void EnableCdvdPluginSubmenu(bool isEnable = true);
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -226,6 +226,7 @@ protected:
 	void Menu_ShowConsole_Stdio(wxCommandEvent &event);
 
 	void Menu_GetStarted(wxCommandEvent &event);
+	void Menu_Compatibility(wxCommandEvent &event);
 	void Menu_Forums(wxCommandEvent &event);
 	void Menu_Website(wxCommandEvent &event);
 	void Menu_Github(wxCommandEvent &event);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -109,8 +109,7 @@ protected:
 	wxMenu&			m_menuCDVD;
 	wxMenu&			m_menuSys;
 	wxMenu&			m_menuConfig;
-	wxMenu&			m_menuMisc;
-	wxMenu&			m_menuDebug;
+	wxMenu&			m_menuWindow;
 
 	wxMenu&			m_menuCapture;
 	wxMenu&			m_submenuVideoCapture;
@@ -118,9 +117,11 @@ protected:
 #ifndef DISABLE_RECORDING
 	wxMenu&			m_menuRecording;
 #endif
+	wxMenu&			m_menuHelp;
 
 	wxMenu&			m_LoadStatesSubmenu;
 	wxMenu&			m_SaveStatesSubmenu;
+	wxMenu&			m_GameSettingsSubmenu;
 
 	wxMenuItem*		m_menuItem_RecentIsoMenu;
 	wxMenuItem&		m_MenuItem_Console;
@@ -148,6 +149,14 @@ public:
 	void EnableMenuItem( int id, bool enable );
 	void SetMenuItemLabel(int id, wxString str);
 	void EnableCdvdPluginSubmenu(bool isEnable = true);
+
+	void CreateCdvdMenu();
+	void CreatePcsx2Menu();
+	void CreateConfigMenu();
+	void CreateWindowsMenu();
+	void CreateCaptureMenu();
+	void CreateRecordMenu();
+	void CreateHelpMenu();
 	
 	bool Destroy();
 
@@ -213,6 +222,12 @@ protected:
 	void Menu_ShowConsole(wxCommandEvent &event);
 	void Menu_ChangeLang(wxCommandEvent &event);
 	void Menu_ShowConsole_Stdio(wxCommandEvent &event);
+
+	void Menu_GetStarted(wxCommandEvent &event);
+	void Menu_Forums(wxCommandEvent &event);
+	void Menu_Website(wxCommandEvent &event);
+	void Menu_Github(wxCommandEvent &event);
+	void Menu_Wiki(wxCommandEvent &event);
 	void Menu_ShowAboutBox(wxCommandEvent &event);
 
 	void Menu_Capture_Video_Record_Click(wxCommandEvent &event);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -217,7 +217,6 @@ protected:
 
 	void Menu_Debug_Open_Click(wxCommandEvent &event);
 	void Menu_Debug_MemoryDump_Click(wxCommandEvent &event);
-	void Menu_Debug_Logging_Click(wxCommandEvent &event);
 	void Menu_Debug_CreateBlockdump_Click(wxCommandEvent &event);
 	void Menu_Ask_On_Boot_Click(wxCommandEvent &event);
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -197,7 +197,8 @@ protected:
 	void Menu_EnableHostFs_Click(wxCommandEvent &event);
 
 	void Menu_BootCdvd_Click(wxCommandEvent &event);
-	void Menu_BootCdvd2_Click(wxCommandEvent &event);
+	void Menu_FastBoot_Click(wxCommandEvent &event);
+
 	void Menu_OpenELF_Click(wxCommandEvent &event);
 	void Menu_CdvdSource_Click(wxCommandEvent &event);
 	void Menu_LoadStates_Click(wxCommandEvent &event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -384,14 +384,15 @@ void MainEmuFrame::Menu_CdvdSource_Click( wxCommandEvent &event )
 
 void MainEmuFrame::Menu_BootCdvd_Click( wxCommandEvent &event )
 {
-	g_Conf->EmuOptions.UseBOOT2Injection = false;
+	g_Conf->EmuOptions.UseBOOT2Injection = g_Conf->EnableFastBoot;
 	_DoBootCdvd();
 }
 
-void MainEmuFrame::Menu_BootCdvd2_Click( wxCommandEvent &event )
+void MainEmuFrame::Menu_FastBoot_Click( wxCommandEvent &event )
 {
-	g_Conf->EmuOptions.UseBOOT2Injection = true;
-	_DoBootCdvd();
+	g_Conf->EnableFastBoot = GetMenuBar()->IsChecked( MenuId_Config_FastBoot );
+	AppApplySettings();
+	AppSaveSettings();
 }
 
 wxString GetMsg_IsoImageChanged()

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -649,8 +649,6 @@ void MainEmuFrame::Menu_SuspendResume_Click(wxCommandEvent &event)
 
 void MainEmuFrame::Menu_SysShutdown_Click(wxCommandEvent &event)
 {
-	//if( !SysHasValidState() && !CorePlugins.AreAnyInitialized() ) return;
-
 	UI_DisableSysShutdown();
 	Console.SetTitle("PCSX2 Program Log");
 	CoreThread.Reset();
@@ -676,7 +674,12 @@ void MainEmuFrame::Menu_Debug_Open_Click(wxCommandEvent &event)
 {
 	DisassemblyDialog* dlg = wxGetApp().GetDisassemblyPtr();
 	if (dlg)
-		dlg->Show();
+	{
+		if (event.IsChecked())
+			dlg->Show();
+		else
+			dlg->Hide();
+	}
 }
 
 void MainEmuFrame::Menu_Debug_MemoryDump_Click(wxCommandEvent &event)

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -158,6 +158,7 @@ wxWindowID SwapOrReset_Iso( wxWindow* owner, IScopedCoreThread& core_control, co
 
 	g_Conf->CdvdSource = CDVD_SourceType::Iso;
 	SysUpdateIsoSrcFile( isoFilename );
+
 	if( result == wxID_RESET )
 	{
 		core_control.DisallowResume();
@@ -392,6 +393,7 @@ void MainEmuFrame::Menu_FastBoot_Click( wxCommandEvent &event )
 	g_Conf->EnableFastBoot = GetMenuBar()->IsChecked( MenuId_Config_FastBoot );
 	AppApplySettings();
 	AppSaveSettings();
+	UpdateStatusBar();
 }
 
 wxString GetMsg_IsoImageChanged()

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -707,6 +707,11 @@ void MainEmuFrame::Menu_GetStarted(wxCommandEvent &event)
 	wxLaunchDefaultBrowser("https://pcsx2.net/getting-started.html");
 }
 
+void MainEmuFrame::Menu_Compatibility(wxCommandEvent &event)
+{
+	wxLaunchDefaultBrowser("https://pcsx2.net/compatibility-list.html");
+}
+
 void MainEmuFrame::Menu_Forums(wxCommandEvent &event)
 {
 	wxLaunchDefaultBrowser("https://forums.pcsx2.net/");

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -26,7 +26,6 @@
 
 #include "Dialogs/ModalPopups.h"
 #include "Dialogs/ConfigurationDialog.h"
-#include "Dialogs/LogOptionsDialog.h"
 #include "Debugger/DisassemblyDialog.h"
 
 #include "Utilities/IniInterface.h"
@@ -684,11 +683,6 @@ void MainEmuFrame::Menu_Debug_Open_Click(wxCommandEvent &event)
 
 void MainEmuFrame::Menu_Debug_MemoryDump_Click(wxCommandEvent &event)
 {
-}
-
-void MainEmuFrame::Menu_Debug_Logging_Click(wxCommandEvent &event)
-{
-	AppOpenDialog<LogOptionsDialog>( this );
 }
 
 void MainEmuFrame::Menu_ShowConsole(wxCommandEvent &event)

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -508,7 +508,7 @@ void MainEmuFrame::Menu_EnableRecordingTools_Click(wxCommandEvent&)
 			"These tools are provided as-is and should be enabled under your own discretion."), "Enabling Recording Tools"))
 		{
 			checked = false;
-			m_menuSys.FindChildItem(MenuId_EnableRecordingTools)->Check(false);
+			m_GameSettingsSubmenu.FindChildItem(MenuId_EnableRecordingTools)->Check(false);
 		}
 	}
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -702,6 +702,31 @@ void MainEmuFrame::Menu_ShowConsole_Stdio(wxCommandEvent &event)
 	AppSaveSettings();
 }
 
+void MainEmuFrame::Menu_GetStarted(wxCommandEvent &event)
+{
+	wxLaunchDefaultBrowser("https://pcsx2.net/getting-started.html");
+}
+
+void MainEmuFrame::Menu_Forums(wxCommandEvent &event)
+{
+	wxLaunchDefaultBrowser("https://forums.pcsx2.net/");
+}
+
+void MainEmuFrame::Menu_Website(wxCommandEvent &event)
+{
+	wxLaunchDefaultBrowser("https://pcsx2.net/");
+}
+
+void MainEmuFrame::Menu_Github(wxCommandEvent &event)
+{
+	wxLaunchDefaultBrowser("https://github.com/PCSX2/pcsx2");
+}
+
+void MainEmuFrame::Menu_Wiki(wxCommandEvent &event)
+{
+	wxLaunchDefaultBrowser("https://wiki.pcsx2.net/Main_Page");
+}
+
 void MainEmuFrame::Menu_ShowAboutBox(wxCommandEvent &event)
 {
 	AppOpenDialog<AboutBoxDialog>( this );

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -39,6 +39,12 @@ void MainEmuFrame::SetMenuItemLabel(int id, wxString str)
 		item->SetItemLabel(str);
 }
 
+void MainEmuFrame::CheckMenuItem(int id, bool checked)
+{
+	if (wxMenuItem *item = m_menubar.FindItem(id))
+		item->Check(checked);
+}
+
 static void _SaveLoadStuff(bool enabled)
 {
 	sMainFrame.EnableMenuItem(MenuId_Sys_LoadStates, enabled);


### PR DESCRIPTION
This pretty much rearranges the menus a bit in a way that makes sense to me.

Descriptions of the changes follow, though you'd probably get a better idea from compiling and running it.

The System menu is now the PCSX2 menu, and has been substantially rearranged. At the top, we have Boot ISO, Pause/Resume, Shutdown, and Run ELF. Fast Boot is now a checkbox, followed by "Create Blockdump", and then a Game Settings submenu with the other settings that used to be directly in the menu. then you have the normal save state menus, the backup save item, and exit, as normal.

CDVD, I didn't touch, as I didn't want to interfere with the CDVD plugin merge.

Config is mostly the same, except that Change Language is now in there.

Misc and Debug are gone.

Next we have the Window Menu, with "Show Debug", "Show Console", and "Console to Stdio". I'm likely to add more items here, like a savestate window, an iso library window, etc..., later.

Then Capture and Recording are the same.

And there's a new Help menu, which is mostly menu items that go to websites. The Getting Started page, the Compatibility page, the forums, the main website, the wiki, the github page, and, naturally, about.

Also, the status bar shows if fast boot is on, the current iso name, and if it's a 32 or 64 bit build.

I'm curious what people think, and if there are other changes I should make here...