### PR TITLE
Minor fix to the C++ GS Dump functionality (for debugging purposes)

### DIFF
--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -444,8 +444,8 @@ void SysMtgsThread::ExecuteTaskInThread()
 							((u32&)RingBuffer.Regs[0x1010])				= remainder[1];
 							((GSRegSIGBLID&)RingBuffer.Regs[0x1080])	= (GSRegSIGBLID&)remainder[2];
 
-							// CSR & 0x2000; is the pageflip id.
-							GSvsync(((u32&)RingBuffer.Regs[0x1000]) & 0x2000);
+							// CSR & 0x2000 is the FIELD value (1 for odd, 0 for even).
+							GSvsync(!!(((u32&)RingBuffer.Regs[0x1000]) & 0x2000));
 							gsFrameSkip();
 
 							// if we're not using GSOpen2, then the GS window is on this thread (MTGS thread),

--- a/plugins/GSdx/GSDump.cpp
+++ b/plugins/GSdx/GSDump.cpp
@@ -65,7 +65,7 @@ void GSDumpBase::ReadFIFO(uint32 size)
 	AppendRawData(&size, 4);
 }
 
-bool GSDumpBase::VSync(int field, bool last, const GSPrivRegSet* regs)
+bool GSDumpBase::VSync(bool odd_field, bool last, const GSPrivRegSet* regs)
 {
 	// dump file is bad, return done to delete the object
 	if (!m_gs)
@@ -75,7 +75,7 @@ bool GSDumpBase::VSync(int field, bool last, const GSPrivRegSet* regs)
 	AppendRawData(regs, sizeof(*regs));
 
 	AppendRawData(1);
-	AppendRawData(static_cast<uint8>(field));
+	AppendRawData(odd_field ? 1 : 0);
 
 	if (last)
 		m_extra_frames--;

--- a/plugins/GSdx/GSDump.h
+++ b/plugins/GSdx/GSDump.h
@@ -63,7 +63,7 @@ public:
 
 	void ReadFIFO(uint32 size);
 	void Transfer(int index, const uint8* mem, size_t size);
-	bool VSync(int field, bool last, const GSPrivRegSet* regs);
+	bool VSync(bool odd_field, bool last, const GSPrivRegSet* regs);
 };
 
 class GSDump final : public GSDumpBase

--- a/plugins/GSdx/Renderers/Common/GSDevice.cpp
+++ b/plugins/GSdx/Renderers/Common/GSDevice.cpp
@@ -283,7 +283,7 @@ void GSDevice::Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, con
 	m_current = m_merge;
 }
 
-void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffset)
+void GSDevice::Interlace(const GSVector2i& ds, bool odd_field, int mode, float yoffset)
 {
 	ResizeTarget(&m_weavebob, ds.x, ds.y);
 
@@ -291,7 +291,7 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 	{
 		// weave first
 
-		DoInterlace(m_merge, m_weavebob, field, false, 0);
+		DoInterlace(m_merge, m_weavebob, odd_field ? 1 : 0, false, 0);
 
 		if(mode == 2)
 		{
@@ -310,7 +310,7 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 	}
 	else if(mode == 1) // bob
 	{
-		DoInterlace(m_merge, m_weavebob, 3, true, yoffset * field);
+		DoInterlace(m_merge, m_weavebob, 3, true, odd_field ? yoffset : 0);
 
 		m_current = m_weavebob;
 	}

--- a/plugins/GSdx/Renderers/Common/GSDevice.h
+++ b/plugins/GSdx/Renderers/Common/GSDevice.h
@@ -227,7 +227,7 @@ public:
 	GSTexture* GetCurrent();
 
 	void Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, const GSVector2i& fs, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c);
-	void Interlace(const GSVector2i& ds, int field, int mode, float yoffset);
+	void Interlace(const GSVector2i& ds, bool odd_field, int mode, float yoffset);
 	void FXAA();
 	void ShadeBoost();
 	void ExternalFX();

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -83,7 +83,7 @@ void GSRenderer::ResetDevice()
     if(m_dev) m_dev->Reset(1, 1);
 }
 
-bool GSRenderer::Merge(int field)
+bool GSRenderer::Merge(bool odd_field)
 {
 	bool en[2];
 
@@ -269,15 +269,14 @@ bool GSRenderer::Merge(int field)
 		{
 			if(m_interlace == 7 && m_regs->SMODE2.FFMD) // Auto interlace enabled / Odd frame interlace setting
 			{
-				int field2 = 0;
 				int mode = 2;
-				m_dev->Interlace(ds, field ^ field2, mode, tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
+				m_dev->Interlace(ds, odd_field, mode, tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
 			}
 			else
 			{
-				int field2 = 1 - ((m_interlace - 1) & 1);
+				bool field_flip = m_interlace & 1;
 				int mode = (m_interlace - 1) >> 1;
-				m_dev->Interlace(ds, field ^ field2, mode, tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
+				m_dev->Interlace(ds, odd_field ^ field_flip, mode, tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
 			}
 		}
 
@@ -312,7 +311,7 @@ void GSRenderer::SetVSync(int vsync)
 	if(m_dev) m_dev->SetVSync(m_vsync);
 }
 
-void GSRenderer::VSync(int field)
+void GSRenderer::VSync(bool odd_field)
 {
 	GSPerfMonAutoTimer pmat(&m_perfmon);
 
@@ -327,7 +326,7 @@ void GSRenderer::VSync(int field)
 
 	if(!m_dev->IsLost(true))
 	{
-		if(!Merge(field ? 1 : 0))
+		if(!Merge(odd_field))
 		{
 			return;
 		}
@@ -469,7 +468,7 @@ void GSRenderer::VSync(int field)
 	}
 	else if(m_dump)
 	{
-		if(m_dump->VSync(field, !m_control_key, m_regs))
+		if(m_dump->VSync(odd_field, !m_control_key, m_regs))
 			m_dump.reset();
 	}
 

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -32,7 +32,7 @@ class GSRenderer : public GSState
 	std::string m_snapshot;
 	int m_shader;
 
-	bool Merge(int field);
+	bool Merge(bool odd_field);
 
 	bool m_shift_key;
 	bool m_control_key;
@@ -62,7 +62,7 @@ public:
 
 	virtual bool CreateDevice(GSDevice* dev);
 	virtual void ResetDevice();
-	virtual void VSync(int field);
+	virtual void VSync(bool odd_field);
 	virtual bool MakeSnapshot(const std::string& path);
 	virtual void KeyEvent(GSKeyEventData* e);
 	virtual bool CanUpscale() {return false;}


### PR DESCRIPTION
Minor update the C++ GSReplay functions (for debugging purposes) to be more accurate and match the C# GSDumpGUI app.

When I was debugging the GS a year or so ago I was using the GSReplay function in GS.cpp noticed that it was slightly different from the GSDumpGUI app because of the way VSync is handled. The C++ function used the FIELD value from the dump, but the C# version uses the FIELD values in the CSR register:
GSDXWrapper.cs line 386:
`GSVSync((*((int*)(registers + 4096)) & 0x2000) > 0 ? (byte)1 : (byte)0);`

Its not a terribly important change and I don't know if anyone else uses this function for debugging but it might save someone else some headache.

PS. How do people usually debug graphical problems? I have been using C++ GSReplay because that way I can set breakpoints in the actual GS code and dump textures, do logging, etc. To me the GSDumpGUI app is not very useful because it runs in a separate process from the GS (can't set breakpoints).