### PR TITLE
PNACH: New patch type: apply repeating codes also on load

### DIFF
--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -61,9 +61,20 @@ enum patch_data_type {
 // PCSX2 currently supports the following values:
 // 0 - apply the patch line once on game boot/startup
 // 1 - apply the patch line continuously (technically - on every vsync)
+// 2 - effect of 0 and 1 combined, see below 
+// Note:
+// - while it may seem that a value of 1 does the same as 0, but also later
+//   continues to apply the patch on every vsync - it's not.
+//   The current (and past) behavior is that these patches are applied at different
+//   places at the code, and it's possible, depending on circumstances, that 0 patches
+//   will get applied before the first vsync and therefore earlier than 1 patches.
+// - There's no "place" value which indicates to apply both once on startup
+//   and then also continuously, however such behavior can be achieved by
+//   duplicating the line where one has a 0 place and the other has a 1 place. 
 enum patch_place_type {
 	PPT_ONCE_ON_LOAD = 0,
 	PPT_CONTINUOUSLY = 1,
+	PPT_COMBINED_0_1 = 2,
 
 	_PPT_END_MARKER
 };

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -61,16 +61,6 @@ enum patch_data_type {
 // PCSX2 currently supports the following values:
 // 0 - apply the patch line once on game boot/startup
 // 1 - apply the patch line continuously (technically - on every vsync)
-// Note:
-// - while it may seem that a value of 1 does the same as 0, but also later
-//   continues to apply the patch on every vsync - it's not.
-//   The current (and past) behavior is that these patches are applied at different
-//   places at the code, and it's possible, depending on circumstances, that 0 patches
-//   will get applied before the first vsync and therefore earlier than 1 patches.
-// - There's no "place" value which indicates to apply both once on startup
-//   and then also continuously, however such behavior can be achieved by
-//   duplicating the line where one has a 0 place and the other has a 1 place.
-// FIXME: Do we want to apply the place=1 patches also on startup? (when the 0 patches are applied)
 enum patch_place_type {
 	PPT_ONCE_ON_LOAD = 0,
 	PPT_CONTINUOUSLY = 1,

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -236,6 +236,7 @@ void SysCoreThread::GameStartingInThread()
 	sApp.PostAppMethod(&Pcsx2App::resetDebugger);
 
 	ApplyLoadedPatches(PPT_ONCE_ON_LOAD);
+	ApplyLoadedPatches(PPT_CONTINUOUSLY);
 #ifdef USE_SAVESLOT_UI_UPDATES
 	UI_UpdateSysControls();
 #endif

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -225,6 +225,7 @@ void SysCoreThread::DoCpuReset()
 void SysCoreThread::VsyncInThread()
 {
 	ApplyLoadedPatches(PPT_CONTINUOUSLY);
+	ApplyLoadedPatches(PPT_COMBINED_0_1);
 }
 
 void SysCoreThread::GameStartingInThread()
@@ -236,7 +237,7 @@ void SysCoreThread::GameStartingInThread()
 	sApp.PostAppMethod(&Pcsx2App::resetDebugger);
 
 	ApplyLoadedPatches(PPT_ONCE_ON_LOAD);
-	ApplyLoadedPatches(PPT_CONTINUOUSLY);
+	ApplyLoadedPatches(PPT_COMBINED_0_1);
 #ifdef USE_SAVESLOT_UI_UPDATES
 	UI_UpdateSysControls();
 #endif


### PR DESCRIPTION
There is no real reason to make the behavior of type-{0,1} pnach different on load. Keeping the behavior consistent not only makes more sense but also avoids some weird edge case we could run into.