### PR TITLE
Explicitly add libx11-xcb-dev to Debian packager

### DIFF
--- a/debian-packager/control
+++ b/debian-packager/control
@@ -20,6 +20,7 @@ Build-Depends: cmake (>= 2.8.5),
     libwxgtk3.0-dev,
     libxml2-dev,
     libx11-dev,
+    libx11-xcb-dev,
     locales | locales-all,
     portaudio19-dev,
     zlib1g-dev


### PR DESCRIPTION
Ubuntu 20.04 onwards stopped pulling in libx11-xcb-dev with libx11-dev

Close #3618