### PR TITLE
Fixes to WX

### DIFF
--- a/common/src/Utilities/IniInterface.cpp
+++ b/common/src/Utilities/IniInterface.cpp
@@ -170,7 +170,12 @@ void IniLoader::Entry(const wxString &var, uint &value, const uint defvalue)
 void IniLoader::Entry(const wxString &var, bool &value, const bool defvalue)
 {
     // TODO : Stricter value checking on enabled/disabled?
-    wxString dest(defvalue ? L"enabled" : L"disabled");
+    wxString dest;
+    if(defvalue)
+        dest = wxString("enabled");
+    else
+        dest = wxString("disabled");
+
     if (m_Config)
         m_Config->Read(var, &dest, dest);
     value = (dest == L"enabled") || (dest == L"1");


### PR DESCRIPTION
Attempt number 2 to fix the std::Length error that occurs in the Arch AUR package. This is also an attempt to force proper defaults with pcsx2.