### PR TITLE
GUI/Recording - Add menu items for recording controls with keyboard shortcuts.

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -202,10 +202,11 @@ enum MenuIdentifiers
 	MenuId_Recording_New,
 	MenuId_Recording_Play,
 	MenuId_Recording_Stop,
-	MenuId_Recording_Editor,
+	MenuId_Recording_TogglePause,
+	MenuId_Recording_FrameAdvance,
+	MenuId_Recording_ToggleRecordingMode,
 	MenuId_Recording_VirtualPad_Port0,
 	MenuId_Recording_VirtualPad_Port1,
-	MenuId_Recording_Conversions,
 #endif
 
 };

--- a/pcsx2/gui/AppCorePlugins.cpp
+++ b/pcsx2/gui/AppCorePlugins.cpp
@@ -363,7 +363,7 @@ bool AppCorePlugins::OpenPlugin_GS()
 void AppCorePlugins::ClosePlugin_GS()
 {
 	_parent::ClosePlugin_GS();
-	if( CloseViewportWithPlugins && GetMTGS().IsSelf() && GSopen2 ) sApp.CloseGsPanel();
+	if( GetMTGS().IsSelf() && GSopen2 ) sApp.CloseGsPanel();
 }
 
 

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1038,6 +1038,12 @@ void Pcsx2App::CloseGsPanel()
 		if (GSPanel* woot = gsFrame->GetViewport())
 			woot->Destroy();
 	}
+#ifndef DISABLE_RECORDING
+	// Disable recording controls that only make sense if the game is running
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
+#endif
 }
 
 void Pcsx2App::OnGsFrameClosed( wxWindowID id )
@@ -1052,15 +1058,6 @@ void Pcsx2App::OnGsFrameClosed( wxWindowID id )
 		// right now there's no way to resume from suspend without GUI.
 		PrepForExit();
 	}
-#ifndef DISABLE_RECORDING
-	else
-	{
-		// Disable recording controls that only make sense if the game is running
-		sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
-		sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
-		sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
-	}
-#endif
 }
 
 void Pcsx2App::OnProgramLogClosed( wxWindowID id )

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1019,6 +1019,13 @@ void Pcsx2App::OpenGsPanel()
 #endif
 
 	gsFrame->ShowFullScreen( g_Conf->GSWindow.IsFullscreen );
+
+#ifndef DISABLE_RECORDING
+	// Disable recording controls that only make sense if the game is running
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, true);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, true);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, g_InputRecording.IsActive());
+#endif
 }
 
 void Pcsx2App::CloseGsPanel()
@@ -1045,6 +1052,15 @@ void Pcsx2App::OnGsFrameClosed( wxWindowID id )
 		// right now there's no way to resume from suspend without GUI.
 		PrepForExit();
 	}
+#ifndef DISABLE_RECORDING
+	else
+	{
+		// Disable recording controls that only make sense if the game is running
+		sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
+		sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
+		sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
+	}
+#endif
 }
 
 void Pcsx2App::OnProgramLogClosed( wxWindowID id )

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -142,7 +142,14 @@ void GSPanel::InitRecordingAccelerators()
 		m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString(),
 		g_InputRecording.IsActive());
 
-	recordingConLog(L"Initialized Recording Key Bindings\n");
+	recordingConLog(L"Initialized Input Recording Key Bindings\n");
+}
+
+void GSPanel::RemoveRecordingAccelerators()
+{
+	m_Accels.reset(new AcceleratorDictionary);
+	InitDefaultAccelerators();
+	recordingConLog(L"Disabled Input Recording Key Bindings\n");
 }
 #endif
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -20,6 +20,7 @@
 #include "AppSaveStates.h"
 #include "Counters.h"
 #include "GS.h"
+#include "MainFrame.h"
 #include "MSWstuff.h"
 
 #include "ConsoleLogger.h"
@@ -129,6 +130,10 @@ void GSPanel::InitRecordingAccelerators()
 	m_Accels->Map(AAC(WXK_NUMPAD7), "States_LoadSlot7");
 	m_Accels->Map(AAC(WXK_NUMPAD8), "States_LoadSlot8");
 	m_Accels->Map(AAC(WXK_NUMPAD9), "States_LoadSlot9");
+
+	GetMainFramePtr()->appendKeycodeNamesToRecordingMenuOptions(MenuId_Recording_FrameAdvance, m_Accels->findKeycodeWithCommandId("FrameAdvance").toTitleizedString());
+	GetMainFramePtr()->appendKeycodeNamesToRecordingMenuOptions(MenuId_Recording_TogglePause, m_Accels->findKeycodeWithCommandId("TogglePause").toTitleizedString());
+	GetMainFramePtr()->appendKeycodeNamesToRecordingMenuOptions(MenuId_Recording_ToggleRecordingMode, m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString());
 
 	recordingConLog(L"Initialized Recording Key Bindings\n");
 }

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -131,9 +131,16 @@ void GSPanel::InitRecordingAccelerators()
 	m_Accels->Map(AAC(WXK_NUMPAD8), "States_LoadSlot8");
 	m_Accels->Map(AAC(WXK_NUMPAD9), "States_LoadSlot9");
 
-	GetMainFramePtr()->appendKeycodeNamesToRecordingMenuOptions(MenuId_Recording_FrameAdvance, m_Accels->findKeycodeWithCommandId("FrameAdvance").toTitleizedString());
-	GetMainFramePtr()->appendKeycodeNamesToRecordingMenuOptions(MenuId_Recording_TogglePause, m_Accels->findKeycodeWithCommandId("TogglePause").toTitleizedString());
-	GetMainFramePtr()->appendKeycodeNamesToRecordingMenuOptions(MenuId_Recording_ToggleRecordingMode, m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString());
+	GetMainFramePtr()->initializeRecordingMenuItem(
+		MenuId_Recording_FrameAdvance,
+		m_Accels->findKeycodeWithCommandId("FrameAdvance").toTitleizedString());
+	GetMainFramePtr()->initializeRecordingMenuItem(
+		MenuId_Recording_TogglePause,
+		m_Accels->findKeycodeWithCommandId("TogglePause").toTitleizedString());
+	GetMainFramePtr()->initializeRecordingMenuItem(
+		MenuId_Recording_ToggleRecordingMode,
+		m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString(),
+		g_InputRecording.IsActive());
 
 	recordingConLog(L"Initialized Recording Key Bindings\n");
 }

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -56,6 +56,7 @@ public:
 	void DirectKeyCommand( wxKeyEvent& evt );
 	void DirectKeyCommand( const KeyAcceleratorCode& kac );
 	void InitDefaultAccelerators();
+	wxString GetAssociatedKeyCode(const char* id);
 #ifndef DISABLE_RECORDING
 	void InitRecordingAccelerators();
 #endif

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -59,6 +59,7 @@ public:
 	wxString GetAssociatedKeyCode(const char* id);
 #ifndef DISABLE_RECORDING
 	void InitRecordingAccelerators();
+	void RemoveRecordingAccelerators();
 #endif
 
 protected:

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -912,6 +912,19 @@ void AcceleratorDictionary::Map( const KeyAcceleratorCode& _acode, const char *s
 	}
 }
 
+KeyAcceleratorCode AcceleratorDictionary::findKeycodeWithCommandId(const char* commandId)
+{
+	for (auto entry = this->begin(); entry != this->end(); entry++)
+	{
+		if (strcmp(entry->second->Id, commandId) == 0)
+		{
+			const KeyAcceleratorCode keycode(entry->first);
+			return keycode;
+		}
+	}
+	return KeyAcceleratorCode(0);
+}
+
 void Pcsx2App::BuildCommandHash()
 {
 	if( !GlobalCommands ) GlobalCommands = std::unique_ptr<CommandDictionary>(new CommandDictionary);
@@ -932,6 +945,8 @@ void Pcsx2App::InitDefaultGlobalAccelerators()
 
 	// Why do we even have those here? all of them seem to be overridden
 	// by GSPanel::m_Accels ( GSPanel::InitDefaultAccelerators() )
+	// - One reason is because this is used to initialize shortcuts in the MainFrame's UI (see - MainFrame::AppendShortcutToMenuOption)
+	//   this is before the GS Window has been initialized.
 
 	GlobalAccels->Map( AAC( WXK_F1 ),			"States_FreezeCurrentSlot" );
 	GlobalAccels->Map( AAC( WXK_F3 ),			"States_DefrostCurrentSlot" );

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -471,6 +471,10 @@ void MainEmuFrame::CreateRecordMenu()
 	m_menuRecording.Append(MenuId_Recording_Stop, _("Stop"))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_Play, _("Play"));
 	m_menuRecording.AppendSeparator();
+	m_menuRecording.Append(MenuId_Recording_TogglePause, _("Toggle Pause"));
+	m_menuRecording.Append(MenuId_Recording_FrameAdvance, _("Frame Advance"));
+	m_menuRecording.Append(MenuId_Recording_ToggleRecordingMode, _("Toggle Recording Mode"));
+	m_menuRecording.AppendSeparator();
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port0, _("Virtual Pad (Port 1)"));
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port1, _("Virtual Pad (Port 2)"));
 #endif
@@ -776,24 +780,26 @@ void MainEmuFrame::CommitPreset_noTrigger()
 	g_Conf->EmuOptions.EnablePatches = menubar.IsChecked( MenuId_EnablePatches );
 }
 
-static void AppendShortcutToMenuOption( wxMenuItem& item, const char* id ) {
-	// this is NOT how a dictionary works but it has like 30 entries so this should still perform okay
-	auto* dict = &wxGetApp().GlobalAccels;
-	for ( auto it = ( *dict )->begin(); it != ( *dict )->end(); ++it ) {
-		if ( strcmp( it->second->Id, id ) == 0 ) {
-			wxString text = item.GetItemLabel();
-			size_t tabPos = text.rfind( L'\t' );
-			KeyAcceleratorCode keycode( (wxKeyCode)it->first );
-			item.SetItemLabel( text.Mid( 0, tabPos ) + L"\t" + keycode.ToString() );
-		}
-	}
+static void AppendShortcutToMenuOption( wxMenuItem& item, wxString keyCodeStr ) {
+	wxString text = item.GetItemLabel();
+	const size_t tabPos = text.rfind(L'\t');
+	item.SetItemLabel(text.Mid(0, tabPos ) + L"\t" + keyCodeStr);
 }
 
 void MainEmuFrame::AppendKeycodeNamesToMenuOptions() {
-	AppendShortcutToMenuOption( *m_menuSys.FindChildItem( MenuId_Sys_LoadStates ), "States_DefrostCurrentSlot" );
-	AppendShortcutToMenuOption( *m_menuSys.FindChildItem( MenuId_Sys_SaveStates ), "States_FreezeCurrentSlot" );
+	
+	AppendShortcutToMenuOption(*m_menuSys.FindChildItem( MenuId_Sys_LoadStates ), wxGetApp().GlobalAccels->findKeycodeWithCommandId("States_DefrostCurrentSlot").toTitleizedString());
+	AppendShortcutToMenuOption(*m_menuSys.FindChildItem( MenuId_Sys_SaveStates ), wxGetApp().GlobalAccels->findKeycodeWithCommandId("States_FreezeCurrentSlot").toTitleizedString());
 }
 
+#ifndef DISABLE_RECORDING
+void MainEmuFrame::appendKeycodeNamesToRecordingMenuOptions(MenuIdentifiers menuId, wxString keyCodeStr) {
+	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);
+	wxString text = item.GetItemLabel();
+	const size_t tabPos = text.rfind(L'\t');
+	item.SetItemLabel(text.Mid(0, tabPos ) + L"\t" + keyCodeStr);
+}
+#endif
 
 // ------------------------------------------------------------------------
 //   "Extensible" Plugin Menus

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -276,6 +276,9 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_New_Click, this, MenuId_Recording_New);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_Play_Click, this, MenuId_Recording_Play);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_Stop_Click, this, MenuId_Recording_Stop);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_TogglePause_Click, this, MenuId_Recording_TogglePause);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_FrameAdvance_Click, this, MenuId_Recording_FrameAdvance);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_ToggleRecordingMode_Click, this, MenuId_Recording_ToggleRecordingMode);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port0);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port1);
 #endif

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -796,13 +796,15 @@ void MainEmuFrame::AppendKeycodeNamesToMenuOptions() {
 }
 
 #ifndef DISABLE_RECORDING
-void MainEmuFrame::initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable) {
+void MainEmuFrame::initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable)
+{
 	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);
 	wxString text = item.GetItemLabel();
 	const size_t tabPos = text.rfind(L'\t');
-	item.SetItemLabel(text.Mid(0, tabPos ) + L"\t" + keyCodeStr);
+	item.SetItemLabel(text.Mid(0, tabPos) + L"\t" + keyCodeStr);
 	item.Enable(enable);
 }
+
 void MainEmuFrame::enableRecordingMenuItem(MenuIdentifiers menuId, bool enable)
 {
 	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -470,13 +470,13 @@ void MainEmuFrame::CreateCaptureMenu()
 void MainEmuFrame::CreateRecordMenu()
 {
 #ifndef DISABLE_RECORDING
-	m_menuRecording.Append(MenuId_Recording_New, _("New"));
-	m_menuRecording.Append(MenuId_Recording_Stop, _("Stop"))->Enable(false);
-	m_menuRecording.Append(MenuId_Recording_Play, _("Play"));
+	m_menuRecording.Append(MenuId_Recording_New, _("New"), _("Create a new input recording."));
+	m_menuRecording.Append(MenuId_Recording_Stop, _("Stop"), _("Stop the active input recording."))->Enable(false);
+	m_menuRecording.Append(MenuId_Recording_Play, _("Play"), _("Playback an existing input recording."));
 	m_menuRecording.AppendSeparator();
-	m_menuRecording.Append(MenuId_Recording_TogglePause, _("Toggle Pause"));
-	m_menuRecording.Append(MenuId_Recording_FrameAdvance, _("Frame Advance"));
-	m_menuRecording.Append(MenuId_Recording_ToggleRecordingMode, _("Toggle Recording Mode"));
+	m_menuRecording.Append(MenuId_Recording_TogglePause, _("Toggle Pause"), _("Pause or resume emulation on the fly."))->Enable(false);
+	m_menuRecording.Append(MenuId_Recording_FrameAdvance, _("Frame Advance"), _("Advance emulation forward by a single frame at a time."))->Enable(false);
+	m_menuRecording.Append(MenuId_Recording_ToggleRecordingMode, _("Toggle Recording Mode"), _("Save/playback inputs to/from the recording file."))->Enable(false);
 	m_menuRecording.AppendSeparator();
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port0, _("Virtual Pad (Port 1)"));
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port1, _("Virtual Pad (Port 2)"));
@@ -796,11 +796,17 @@ void MainEmuFrame::AppendKeycodeNamesToMenuOptions() {
 }
 
 #ifndef DISABLE_RECORDING
-void MainEmuFrame::appendKeycodeNamesToRecordingMenuOptions(MenuIdentifiers menuId, wxString keyCodeStr) {
+void MainEmuFrame::initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable) {
 	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);
 	wxString text = item.GetItemLabel();
 	const size_t tabPos = text.rfind(L'\t');
 	item.SetItemLabel(text.Mid(0, tabPos ) + L"\t" + keyCodeStr);
+	item.Enable(enable);
+}
+void MainEmuFrame::enableRecordingMenuItem(MenuIdentifiers menuId, bool enable)
+{
+	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);
+	item.Enable(enable);
 }
 #endif
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -167,7 +167,8 @@ public:
 	void AppendKeycodeNamesToMenuOptions();
 	void UpdateStatusBar();
 #ifndef DISABLE_RECORDING
-	void appendKeycodeNamesToRecordingMenuOptions(MenuIdentifiers menuId, wxString keyCodeStr);
+	void initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable = true);
+	void enableRecordingMenuItem(MenuIdentifiers menuId, bool enable);
 #endif
 
 protected:

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -167,7 +167,7 @@ public:
 	void AppendKeycodeNamesToMenuOptions();
 	void UpdateStatusBar();
 #ifndef DISABLE_RECORDING
-	void AppendKeycodeNamesToRecordingMenuOptions(MenuIdentifiers menuId, wxString keyCodeStr);
+	void appendKeycodeNamesToRecordingMenuOptions(MenuIdentifiers menuId, wxString keyCodeStr);
 #endif
 
 protected:
@@ -247,6 +247,9 @@ protected:
 	void Menu_Recording_New_Click(wxCommandEvent &event);
 	void Menu_Recording_Play_Click(wxCommandEvent &event);
 	void Menu_Recording_Stop_Click(wxCommandEvent &event);
+	void Menu_Recording_TogglePause_Click(wxCommandEvent &event);
+	void Menu_Recording_FrameAdvance_Click(wxCommandEvent &event);
+	void Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent &event);
 	void Menu_Recording_VirtualPad_Open_Click(wxCommandEvent &event);
 #endif
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -166,6 +166,9 @@ public:
 	void CommitPreset_noTrigger();
 	void AppendKeycodeNamesToMenuOptions();
 	void UpdateStatusBar();
+#ifndef DISABLE_RECORDING
+	void AppendKeycodeNamesToRecordingMenuOptions(MenuIdentifiers menuId, wxString keyCodeStr);
+#endif
 
 protected:
 	void DoGiveHelp(const wxString& text, bool show);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -932,6 +932,7 @@ void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent &event)
 	}
 	m_menuRecording.FindChildItem(MenuId_Recording_New)->Enable(false);
 	m_menuRecording.FindChildItem(MenuId_Recording_Stop)->Enable(true);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, g_InputRecording.IsActive());
 }
 
 void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent &event)
@@ -963,6 +964,7 @@ void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent &event)
 		m_menuRecording.FindChildItem(MenuId_Recording_New)->Enable(false);
 		m_menuRecording.FindChildItem(MenuId_Recording_Stop)->Enable(true);
 	}
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, g_InputRecording.IsActive());
 }
 
 void MainEmuFrame::Menu_Recording_Stop_Click(wxCommandEvent &event)
@@ -970,6 +972,7 @@ void MainEmuFrame::Menu_Recording_Stop_Click(wxCommandEvent &event)
 	g_InputRecording.Stop();
 	m_menuRecording.FindChildItem(MenuId_Recording_New)->Enable(true);
 	m_menuRecording.FindChildItem(MenuId_Recording_Stop)->Enable(false);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, g_InputRecording.IsActive());
 }
 
 void MainEmuFrame::Menu_Recording_TogglePause_Click(wxCommandEvent& event)

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -972,7 +972,25 @@ void MainEmuFrame::Menu_Recording_Stop_Click(wxCommandEvent &event)
 	m_menuRecording.FindChildItem(MenuId_Recording_Stop)->Enable(false);
 }
 
-void MainEmuFrame::Menu_Recording_VirtualPad_Open_Click(wxCommandEvent &event)
+void MainEmuFrame::Menu_Recording_TogglePause_Click(wxCommandEvent& event)
+{
+	if (g_Conf->EmuOptions.EnableRecordingTools)
+		g_RecordingControls.TogglePause();
+}
+
+void MainEmuFrame::Menu_Recording_FrameAdvance_Click(wxCommandEvent& event)
+{
+	if (g_Conf->EmuOptions.EnableRecordingTools)
+		g_RecordingControls.FrameAdvance();
+}
+
+void MainEmuFrame::Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent& event)
+{
+	if (g_Conf->EmuOptions.EnableRecordingTools)
+		g_InputRecording.RecordModeToggle();
+}
+
+void MainEmuFrame::Menu_Recording_VirtualPad_Open_Click(wxCommandEvent& event)
 {
 	wxGetApp().GetVirtualPadPtr(event.GetId() - MenuId_Recording_VirtualPad_Port0)->Show();
 }

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -562,6 +562,7 @@ void MainEmuFrame::Menu_EnableRecordingTools_Click(wxCommandEvent& event)
 	if (checked)
 	{
 		GetMenuBar()->Insert(TopLevelMenu_InputRecording, &m_menuRecording, _("&Input Record"));
+		SysConsole.recordingConsole.Enabled = true;
 		// Enable Recording Keybindings
 		if (GSFrame* gsFrame = wxGetApp().GetGsFramePtr())
 		{
@@ -584,15 +585,15 @@ void MainEmuFrame::Menu_EnableRecordingTools_Click(wxCommandEvent& event)
 		{
 			if (GSPanel* viewport = gsFrame->GetViewport())
 			{
-				viewport->InitDefaultAccelerators();
+				viewport->RemoveRecordingAccelerators();
 			}
 		}
+		SysConsole.recordingConsole.Enabled = false;
 		if (g_InputRecordingControls.IsPaused())
 			g_InputRecordingControls.Resume();
 	}
 
 	g_Conf->EmuOptions.EnableRecordingTools = checked;
-	SysConsole.recordingConsole.Enabled = checked;
 	// Enable Recording Logs
 	ConsoleLogFrame* progLog = wxGetApp().GetProgramLog();
 	progLog->UpdateLogList();
@@ -978,19 +979,19 @@ void MainEmuFrame::Menu_Recording_Stop_Click(wxCommandEvent &event)
 void MainEmuFrame::Menu_Recording_TogglePause_Click(wxCommandEvent& event)
 {
 	if (g_Conf->EmuOptions.EnableRecordingTools)
-		g_RecordingControls.TogglePause();
+		g_InputRecordingControls.TogglePause();
 }
 
 void MainEmuFrame::Menu_Recording_FrameAdvance_Click(wxCommandEvent& event)
 {
 	if (g_Conf->EmuOptions.EnableRecordingTools)
-		g_RecordingControls.FrameAdvance();
+		g_InputRecordingControls.FrameAdvance();
 }
 
 void MainEmuFrame::Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent& event)
 {
 	if (g_Conf->EmuOptions.EnableRecordingTools)
-		g_InputRecording.RecordModeToggle();
+		g_InputRecordingControls.RecordModeToggle();
 }
 
 void MainEmuFrame::Menu_Recording_VirtualPad_Open_Click(wxCommandEvent& event)


### PR DESCRIPTION
This makes the recording tools a little more intuitive to use since there still is no proper documentation around it.

In the process, I found out that the current way of adding the keyboard shortcuts to the menu items would omit modifiers such as `shift`.  So I fixed that in both places.

By default wxWidget's `ToString` will return the keyboard character in it's correct case.  For example, if the bind is `Shift+p` it will be printed as such.  However, in most UI's I've seen, the key is capitalized anyway.  So I had to write a small routine to do so.

New menu options (note that the keybinds will only appear once the GS window has been opened, as this is when the majority of pcsx2's keybindings are assigned)
![image](https://user-images.githubusercontent.com/13153231/90992545-86e4c100-e57e-11ea-8e7f-6587668be7d6.png)

Existing binds are still set properly after my changes:
![image](https://user-images.githubusercontent.com/13153231/90992551-9532dd00-e57e-11ea-83a9-b8e78bbd8aff.png)

