### PR TITLE
Updated Jak CRCs

### DIFF
--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -434,16 +434,18 @@ CRC::Game CRC::m_games[] =
 	{0xA2034C69, Jak2, US, TextureInsideRt}, // Demo
 	{0x25FE4D23, Jak2, KO, TextureInsideRt},
 	{0xB4976DAF, Jak2, JP, TextureInsideRt},
+	{0x1ED2EF9E, Jak2, NoRegion, TextureInsideRt}, // EU Preview, EU Review
 	{0x12804727, Jak3, EU, TextureInsideRt},
 	{0xE59E10BF, Jak3, EU, TextureInsideRt},
 	{0xCA68E4D5, Jak3, EU, TextureInsideRt}, // Demo
 	{0x644CFD03, Jak3, US, TextureInsideRt},
 	{0xD401BC20, Jak3, US, TextureInsideRt}, // Demo
 	{0xD1368EAE, Jak3, KO, TextureInsideRt},
-	{0x23F8D35B, Jak3, NoRegion, TextureInsideRt}, // EU Preview, US Internal test build
+	{0x23F8D35B, Jak3, NoRegion, TextureInsideRt}, // EU Preview, EU Review, US Internal test build
 	{0xDF659E77, JakX, EU, TextureInsideRt}, // Jak X: Combat Racing
 	{0xC20596DB, JakX, EU, TextureInsideRt}, // Beta Trial Disc, v0.01
 	{0x3091E6FB, JakX, US, TextureInsideRt},
+	{0xC417D919, JakX, US, TextureInsideRt}, // Demo
 	{0xDA366A53, JakX, US, TextureInsideRt}, // Public Beta v.1
 	{0x7B564230, JakX, US, TextureInsideRt}, // Jak and Daxter Complete Trilogy Demo
 	{0x4653CA3E, HarleyDavidson, US, 0},


### PR DESCRIPTION
Added missing CRC for Jak II PAL Preview and Review builds. Due to the protection, the CRCs are identical.

Added mention of Jak 3 Review build in comments. Same CRC as two other builds, due to its protection.

Added a missing Jak X Demo CRC.