### PR TITLE
microVU: Fix empty register use

### DIFF
--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -890,12 +890,17 @@ static void writeBackISW(microVU& mVU, void *base_ptr, xAddressReg reg) {
 				xLEA(gprT3q, ptr[(void*)((sptr)base_ptr + offset)]);
 				register_offset = offset;
 			}
-			xMOV(ptr32[gprT3q+gprT2q+(offset-register_offset)], gprT1);
+			xMOV(ptr32[gprT3q+reg+(offset-register_offset)], gprT1);
 		};
 		if (_X) writeBackAt(0);
 		if (_Y) writeBackAt(4);
 		if (_Z) writeBackAt(8);
 		if (_W) writeBackAt(12);
+	} else if (reg.IsEmpty()) {
+		if (_X) xMOV(ptr32[(void*)((uptr)base_ptr)], gprT1);
+		if (_Y) xMOV(ptr32[(void*)((uptr)base_ptr+4)], gprT1);
+		if (_Z) xMOV(ptr32[(void*)((uptr)base_ptr+8)], gprT1);
+		if (_W) xMOV(ptr32[(void*)((uptr)base_ptr+12)], gprT1);
 	} else {
 		if (_X) xMOV(ptr32[base_ptr+reg], gprT1);
 		if (_Y) xMOV(ptr32[base_ptr+reg+4], gprT1);


### PR DESCRIPTION
Fixes an assertion failure in microVU from using an `xEmptyReg` as a value