### PR TITLE
logs: make the memory regions print in release too

### DIFF
--- a/common/include/Utilities/StringHelpers.h
+++ b/common/include/Utilities/StringHelpers.h
@@ -226,7 +226,7 @@ extern bool pxParseAssignmentString(const wxString &src, wxString &ldest, wxStri
 #define pxsFmt FastFormatUnicode().Write
 #define pxsFmtV FastFormatUnicode().WriteV
 
-#define pxsPtr(ptr) pxsFmt("0x%08X", (ptr)).c_str()
+#define pxsPtr(ptr) pxsFmt("0x%08llX", (u64)(uptr)(ptr)).c_str()
 
 extern wxString &operator+=(wxString &str1, const FastFormatUnicode &str2);
 extern wxString operator+(const wxString &str1, const FastFormatUnicode &str2);

--- a/common/src/Utilities/VirtualMemory.cpp
+++ b/common/src/Utilities/VirtualMemory.cpp
@@ -273,7 +273,7 @@ void *VirtualMemoryReserve::Assign(VirtualMemoryManagerPtr allocator, void * bas
     else
         mbkb.Write("[%ukb]", reserved_bytes / 1024);
 
-    DevCon.WriteLn(Color_Gray, L"%-32s @ %ls -> %ls %ls", WX_STR(m_name),
+    Console.WriteLn(Color_Gray, L"%-32s @ %ls -> %ls %ls", WX_STR(m_name),
                    pxsPtr(m_baseptr), pxsPtr((uptr)m_baseptr + reserved_bytes), mbkb.c_str());
 
     return m_baseptr;


### PR DESCRIPTION
This fixes https://github.com/PCSX2/pcsx2/issues/3638 .