### PR TITLE
Prioritise the legacy VMM address during initialisation

### DIFF
--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -358,15 +358,13 @@ namespace HostMemoryMap {
 
 /// Attempts to find a spot near static variables for the main memory
 static VirtualMemoryManagerPtr makeMainMemoryManager() {
-	const uptr UpperBounds = 0U;
-	const bool Strict = true;
 	const wxString memoryManagerName = "Main Memory Manager";
 
 	// Historically, the base address has always been 0x20000000 for x86 builds. Many cheat tables and third party
 	// tools relies to this specific address, therefore try to initialize the memory manager using this base
 	// address first. This does not guarantee it, but it prioritise the legacy memory address.
 	const uptr LegacyMemoryBase = 0x20000000U;
-	auto mgr = std::make_shared<VirtualMemoryManager>(memoryManagerName, LegacyMemoryBase, HostMemoryMap::Size, UpperBounds, Strict);
+	auto mgr = std::make_shared<VirtualMemoryManager>(memoryManagerName, LegacyMemoryBase, HostMemoryMap::Size, /*upper_bounds=*/0, /*strict=*/true);
 	if (mgr->IsOk())
 		return mgr;
 
@@ -385,7 +383,7 @@ static VirtualMemoryManagerPtr makeMainMemoryManager() {
 			// VTLB will throw a fit if we try to put EE main memory here
 			continue;
 		}
-		auto mgr = std::make_shared<VirtualMemoryManager>(memoryManagerName, base, HostMemoryMap::Size, UpperBounds, Strict);
+		auto mgr = std::make_shared<VirtualMemoryManager>(memoryManagerName, base, HostMemoryMap::Size, /*upper_bounds=*/0, /*strict=*/true);
 		if (mgr->IsOk()) {
 			return mgr;
 		}

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -371,8 +371,8 @@ static VirtualMemoryManagerPtr makeMainMemoryManager() {
 	// tools relies to this specific address, therefore try to initialize the memory manager using this base
 	// address first. This does not guarantee it, but it prioritise the legacy memory address.
 	// This is only valid for x86 builds, as x64 have a high chance of failing an assertion by using this
-	// specific address. x64 builds currently uses 0x60000000.
-	if (sizeof(void*) == 4)
+	// specific address.
+	//if (sizeof(void*) == 4)
 	{
 		const uptr LegacyMemoryBase = 0x20000000U;
 		if (auto mgr = tryMakeAt(LegacyMemoryBase))

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -370,9 +370,14 @@ static VirtualMemoryManagerPtr makeMainMemoryManager() {
 	// Historically, the base address has always been 0x20000000 for x86 builds. Many cheat tables and third party
 	// tools relies to this specific address, therefore try to initialize the memory manager using this base
 	// address first. This does not guarantee it, but it prioritise the legacy memory address.
-	const uptr LegacyMemoryBase = 0x20000000U;
-	if (auto mgr = tryMakeAt(LegacyMemoryBase))
-		return mgr;
+	// This is only valid for x86 builds, as x64 have a high chance of failing an assertion by using this
+	// specific address. x64 builds currently uses 0x60000000.
+	if (sizeof(void*) == 4)
+	{
+		const uptr LegacyMemoryBase = 0x20000000U;
+		if (auto mgr = tryMakeAt(LegacyMemoryBase))
+			return mgr;
+	}
 
 	// Everything looks nicer when the start of all the sections is a nice round looking number.
 	// Also reduces the variation in the address due to small changes in code.

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -372,8 +372,7 @@ static VirtualMemoryManagerPtr makeMainMemoryManager() {
 	// address first. This does not guarantee it, but it prioritise the legacy memory address.
 	// This is only valid for x86 builds, as x64 have a high chance of failing an assertion by using this
 	// specific address.
-	//if (sizeof(void*) == 4)
-	{
+	if (sizeof(void*) == 4) {
 		const uptr LegacyMemoryBase = 0x20000000U;
 		if (auto mgr = tryMakeAt(LegacyMemoryBase))
 			return mgr;


### PR DESCRIPTION
This pull request aims to fix the problem described in #3638  .

The new system introduced in #3523 proposes various base addresses and check if they can be actually used by the Virtual Memory Manager. This change just proposes to try to initialise the VMM by using `0x20000000` as base address first, for ~both x64 and~ x86 builds.
Of course this does not guarantee that the legacy memory address will be used, but it will help third party software to work to new builds and to slowly migrate to an API that eventually will be exposed by the emulator.
