### PR TITLE
GameDB: Add GT Concept 2002 memcard filter

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1533,6 +1533,7 @@ Serial = SCES-50858
 Name   = Gran Turismo - Concept 2002 Tokyo-Geneva
 Region = PAL-M6
 Compat = 5
+MemCardFilter = SCES-50858/SCES-50294
 ---------------------------------------------
 Serial = SCES-50878
 Name   = Tekken 4


### PR DESCRIPTION
Gran Turismo Concept has a feature where it can drop money & passed licenses to the Gran Turismo 3 save, so it needs to see them.

I was only able to test the PAL version so I only applied a filter to that. If needed, I can source game serials from the wiki and add those pre-emptively too.