### PR TITLE
microVU: Tighten VU sync when using VU Kickstart

### DIFF
--- a/pcsx2/x86/microVU.h
+++ b/pcsx2/x86/microVU.h
@@ -217,7 +217,7 @@ struct microVU {
 	u32		p;			  // Holds current P instance index
 	u32		q;			  // Holds current Q instance index
 	u32		totalCycles;  // Total Cycles that mVU is expected to run for
-	u32		cycles;		  // Cycles Counter
+	s32		cycles;		  // Cycles Counter
 
 	VURegs& regs() const { return ::vuRegs[index]; }
 

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -167,7 +167,7 @@ _mVUt void mVUcleanUp() {
 	mVU.regs().cycle += mVU.cycles;
 
 	if (!vuIndex || !THREAD_VU1) {
-		u32 cycles_passed = std::min(mVU.cycles, 3000u) * EmuConfig.Speedhacks.EECycleSkip;
+		u32 cycles_passed = std::min(mVU.cycles, 3000) * EmuConfig.Speedhacks.EECycleSkip;
 		if (cycles_passed > 0) {
 			s32 vu0_offset = VU0.cycle - cpuRegs.cycle;
 			cpuRegs.cycle += cycles_passed;

--- a/pcsx2/x86/microVU_Flags.inl
+++ b/pcsx2/x86/microVU_Flags.inl
@@ -157,10 +157,10 @@ __fi void mVUsetFlags(mV, microFlagCycles& mFC) {
 	}
 
 	if(!ffOn && !(mVUpBlock->pState.needExactMatch & 1)) {
-		xS = (mVUpBlock->pState.flagInfo >> 2) & 3;
+		//xS = (mVUpBlock->pState.flagInfo >> 2) & 3;
 		mFC.xStatus[0] = -1; mFC.xStatus[1] = -1;
 		mFC.xStatus[2] = -1; mFC.xStatus[3] = -1;
-		mFC.xStatus[(xS-1)&3] = 0;
+		//mFC.xStatus[(xS-1)&3] = 0;
 	}
 
 	if(!ffOn && !(mVUpBlock->pState.needExactMatch & 2)) {


### PR DESCRIPTION
Update STATUS flags in a similar way to MAC flags. Fixes holes in Ratchet Gladiator shadows

Not exactly sure how the flag things work, but it seemed to improve the game, Cotton obviously thought something was wrong when he originally commented it out for MAC flags.

Will need a good bit of testing