### PR TITLE
x86emitter: register class improvements

### DIFF
--- a/common/src/x86emitter/jmp.cpp
+++ b/common/src/x86emitter/jmp.cpp
@@ -128,35 +128,6 @@ void xImpl_FastCall::operator()(const xIndirectNative &f, const xRegisterLong &a
 
 const xImpl_FastCall xFastCall = {};
 
-void xSmartJump::SetTarget()
-{
-    u8 *target = xGetPtr();
-    if (m_baseptr == NULL)
-        return;
-
-    xSetPtr(m_baseptr);
-    u8 *const saveme = m_baseptr + GetMaxInstructionSize();
-    xJccKnownTarget(m_cc, target, true);
-
-    // Copy recompiled data inward if the jump instruction didn't fill the
-    // alloted buffer (means that we optimized things to a j8!)
-
-    const int spacer = (sptr)saveme - (sptr)xGetPtr();
-    if (spacer != 0) {
-        u8 *destpos = xGetPtr();
-        const int copylen = (sptr)target - (sptr)saveme;
-
-        memcpy(destpos, saveme, copylen);
-        xSetPtr(target - spacer);
-    }
-}
-
-xSmartJump::~xSmartJump()
-{
-    SetTarget();
-    m_baseptr = NULL; // just in case (sometimes helps in debugging too)
-}
-
 // ------------------------------------------------------------------------
 // Emits a 32 bit jump, and returns a pointer to the 32 bit displacement.
 // (displacements should be assigned relative to the end of the jump instruction,

--- a/common/src/x86emitter/jmp.cpp
+++ b/common/src/x86emitter/jmp.cpp
@@ -55,17 +55,17 @@ void prepareRegsForFastcall(const Reg1 &a1, const Reg2 &a2) {
 
     // Make sure we don't mess up if someone tries to fastcall with a1 in arg2reg and a2 in arg1reg
     if (a2.Id != arg1reg.Id) {
-        xMOV(Reg1(arg1reg.Id), a1);
+        xMOV(Reg1(arg1reg), a1);
         if (!a2.IsEmpty()) {
-            xMOV(Reg2(arg2reg.Id), a2);
+            xMOV(Reg2(arg2reg), a2);
         }
     } else if (a1.Id != arg2reg.Id) {
-        xMOV(Reg2(arg2reg.Id), a2);
-        xMOV(Reg1(arg1reg.Id), a1);
+        xMOV(Reg2(arg2reg), a2);
+        xMOV(Reg1(arg1reg), a1);
     } else {
         xPUSH(a1);
-        xMOV(Reg2(arg2reg.Id), a2);
-        xPOP(Reg1(arg1reg.Id));
+        xMOV(Reg2(arg2reg), a2);
+        xPOP(Reg1(arg1reg));
     }
 }
 

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -206,7 +206,7 @@ namespace vtlb_private
 	// ------------------------------------------------------------------------
 	static void DynGen_DirectWrite( u32 bits )
 	{
-		// TODO: x86Emitter can't use dil (and xRegister8(rdi.Id) is not dil)
+		// TODO: x86Emitter can't use dil
 		switch(bits)
 		{
 			//8 , 16, 32 : data on EDX
@@ -216,7 +216,7 @@ namespace vtlb_private
 			break;
 
 			case 16:
-				xMOV( ptr[arg1reg], xRegister16(arg2reg.Id) );
+				xMOV( ptr[arg1reg], xRegister16(arg2reg) );
 			break;
 
 			case 32:
@@ -543,7 +543,7 @@ void vtlb_DynGenWrite_Const( u32 bits, u32 addr_const )
 	auto vmv = vtlbdata.vmap[addr_const>>VTLB_PAGE_BITS];
 	if( !vmv.isHandler(addr_const) )
 	{
-		// TODO: x86Emitter can't use dil (and xRegister8(rdi.Id) is not dil)
+		// TODO: x86Emitter can't use dil
 		auto ppf = vmv.assumePtr(addr_const);
 		switch(bits)
 		{
@@ -554,7 +554,7 @@ void vtlb_DynGenWrite_Const( u32 bits, u32 addr_const )
 			break;
 
 			case 16:
-				xMOV( ptr[(void*)ppf], xRegister16(arg2reg.Id) );
+				xMOV( ptr[(void*)ppf], xRegister16(arg2reg) );
 			break;
 
 			case 32:

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -916,10 +916,10 @@ mVUop(mVU_ISW) {
 		if (!_Is_)
 			xXOR(gprT2, gprT2);
 		xADD(gprT2, _Imm11_);
-		mVUaddrFix (mVU, gprT2);
+		mVUaddrFix (mVU, gprT2q);
 
 		mVUallocVIa(mVU, gprT1, _It_);
-		writeBackISW(mVU, ptr, gprT2);
+		writeBackISW(mVU, ptr, gprT2q);
 		mVU.profiler.EmitOp(opISW);
 	}
 	pass3 { mVUlog("ISW.%s vi%02d, vi%02d + %d", _XYZW_String, _Ft_, _Fs_, _Imm11_);  }


### PR DESCRIPTION
The virtual method dispatch made it incredibly hard to make a method return a register with a dynamic size from a method, as to be a dynamic size the register would have to be a pointer, which meant someone had to hold on to the memory.  This resulted in the xRegister64 having to hold an xRegister32 with the same ID inside of it, just to return a pointer to in the off chance that someone called `GetNonWide()`, along with some fairly messy code in the xLEA implementation to attempt to match the sizes of two registers

In addition, this meant that an `xRegisterLong` was 32 bytes on x86-64 (8 byte vtable, 4 byte ID, 4 bytes padding, 16 byte xRegister32) compared to just 8 bytes on x86-32 (4 byte vtable, 4 byte ID), leading to an increase in stack overflows in compilers that weren't very good at reusing stack space

This PR switches the virtual method dispatch to a 4-byte operand size field, which makes it possible to pass registers with runtime-variable operand sizes by value, and makes all register objects 8 bytes.

It also adds a proper way to convert between register sizes, which allows it to check for mistakes like trying to get the 8-bit version of `rdi` (the 8-bit register with `rdi`'s ID is not `dil`, but `bh`).  Previously conversions were made by initializing new registers with the ID of the old one, which prevented these checks from being made.

Finally it also removes some unused classes from x86emitter