### PR TITLE
Address EE Memory to a static value in x86 build, while maintaining x86_64 compatibility. 

### DIFF
--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -385,14 +385,6 @@ static VirtualMemoryManagerPtr makeMainMemoryManager()
 		return std::make_shared<VirtualMemoryManager>("Main Memory Manager", 0x20000000, HostMemoryMap::Size);
 }
 
-	// If the above failed and it's x86-64, recompiled code is going to break!
-	// If it's i386 anything can reach anything so it doesn't matter
-	if (sizeof(void*) == 8) {
-		pxAssertRel(0, "Failed to find a good place for the main memory allocation, recompilers may fail");
-	}
-	return std::make_shared<VirtualMemoryManager>("Main Memory Manager", 0, HostMemoryMap::Size);
-}
-
 // --------------------------------------------------------------------------------------
 //  SysReserveVM  (implementations)
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
This is provided as a solution to #3638 

**Description of #3638**
_Previous to #3523 merge, we were able to create tools that were able to attach to PCSX2 process to read and write in real time values from the EE RAM at 0x20000000. This was very convenient and hasn't been changed for at least 10 years from what I remember. Due to that change, basically all our tools and cheat tables will break. Most of our tools (and more) depends from this specific address._

**Description of this PR**
This PR aims to address the EE Memory to the static value of 0x20000000 on x86 builds to maintain backwards compatibility with all cheating and reversing solutions [i.e. Cheat Engine and EmuHaste] while addressing the EE Memory to a region determined dynamically in x86_64 builds to maintain x86_64 compatibility.

Since x86 had the static EE Memory address of 0x20000000 for **years**, people have made many tools for the emulator for different games, and many cheat tables to help with reverse engineering. In x86 builds, after many tests, no issue has been found reverting the static memory to this value. So nothing comes as a consequence of reverting the EE Memory address to the static value of 0x20000000 .

However, since a static EE Memory address will cause an SIB Target issue on x86_64 builds, dynamic assignment on x86_64 builds have been preserved to avoid any and all problems that come with it.

This PR has been tested with:
- Kingdom Hearts 2: Final Mix
- Soul Calibur 2 [USA]
- Soul Calibur 3 [USA]
- Soul Calibur 3: Arcade Edition [PS2 - USA - MOD]

With Configuration:
- Release SSE2 x86
- Release SSE2 x86_64
- Debug SSE2 x86
- Debug SSE2 x86_64

In all cases, the game boots and plays without an issue, and this way, backwards compatibility with cheating and reversing tools is maintained.