### PR TITLE
Address filename issues relating to capturing Video (.AVI) & Audio (.WAV)

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -555,7 +555,7 @@ typedef void(CALLBACK *_GSsetGameCRC)(int, int);
 typedef void(CALLBACK *_GSsetFrameSkip)(int frameskip);
 typedef void(CALLBACK *_GSsetVsync)(int enabled);
 typedef void(CALLBACK *_GSsetExclusive)(int isExclusive);
-typedef int(CALLBACK *_GSsetupRecording)(int, void *);
+typedef std::wstring*(CALLBACK *_GSsetupRecording)(int);
 typedef void(CALLBACK *_GSreset)();
 typedef void(CALLBACK *_GSwriteCSR)(u32 value);
 typedef void(CALLBACK *_GSmakeSnapshot)(const char *path);
@@ -590,7 +590,7 @@ typedef void(CALLBACK *_SPU2irqCallback)(void (*SPU2callback)(), void (*DMA4call
 typedef u32(CALLBACK *_SPU2ReadMemAddr)(int core);
 typedef void(CALLBACK *_SPU2WriteMemAddr)(int core, u32 value);
 
-typedef int(CALLBACK *_SPU2setupRecording)(int, void *);
+typedef int(CALLBACK *_SPU2setupRecording)(int, std::wstring*);
 
 typedef void(CALLBACK *_SPU2setClockPtr)(u32 *ptr);
 typedef void(CALLBACK *_SPU2setTimeStretcher)(short int enable);

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -421,37 +421,52 @@ namespace Implementations
 		g_Pcsx2Recording ^= 1;
 
 		GetMTGS().WaitGS();		// make sure GS is in sync with the audio stream when we start.
-		if (g_Pcsx2Recording) {
+		if (g_Pcsx2Recording)
+		{
 			// start recording
 
 			// make the recording setup dialog[s] pseudo-modal also for the main PCSX2 window
 			// (the GSdx dialog is already properly modal for the GS window)
 			bool needsMainFrameEnable = false;
-			if (GetMainFramePtr() && GetMainFramePtr()->IsEnabled()) {
+			if (GetMainFramePtr() && GetMainFramePtr()->IsEnabled())
+			{
 				needsMainFrameEnable = true;
 				GetMainFramePtr()->Disable();
 			}
 
-			if (GSsetupRecording) {
+			if (GSsetupRecording)
+			{
 				// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens.
-				if (GSsetupRecording(g_Pcsx2Recording, NULL)) {
-					if (SPU2setupRecording) SPU2setupRecording(g_Pcsx2Recording, NULL);
-				} else {
+				std::wstring* filename = nullptr;
+				if (filename = GSsetupRecording(g_Pcsx2Recording))
+				{
+					if (SPU2setupRecording)
+						SPU2setupRecording(g_Pcsx2Recording, filename);
+					delete filename;
+				}
+				else
+				{
 					// recording dialog canceled by the user. align our state
 					g_Pcsx2Recording ^= 1;
 				}
-			} else {
-				// the GS doesn't support recording.
-				if (SPU2setupRecording) SPU2setupRecording(g_Pcsx2Recording, NULL);
+			}
+			else
+			{
+				// the GS doesn't support recording
+				if (SPU2setupRecording)
+					SPU2setupRecording(g_Pcsx2Recording, NULL);
 			}
 
 			if (GetMainFramePtr() && needsMainFrameEnable)
 				GetMainFramePtr()->Enable();
-
-		} else {
+		}
+		else
+		{
 			// stop recording
-			if (GSsetupRecording) GSsetupRecording(g_Pcsx2Recording, NULL);
-			if (SPU2setupRecording) SPU2setupRecording(g_Pcsx2Recording, NULL);
+			if (GSsetupRecording)
+				GSsetupRecording(g_Pcsx2Recording);
+			if (SPU2setupRecording)
+				SPU2setupRecording(g_Pcsx2Recording, NULL);
 		}
 	}
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -806,13 +806,13 @@ void MainEmuFrame::VideoCaptureUpdate()
 
 		if (GSsetupRecording)
 		{
-			// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens.
-			if (GSsetupRecording(m_capturingVideo, NULL))
+			// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens
+			std::wstring* filename = nullptr;
+			if (filename = GSsetupRecording(m_capturingVideo))
 			{
 				if (SPU2setupRecording)
-				{
-					SPU2setupRecording(m_capturingVideo, NULL);
-				}
+					SPU2setupRecording(m_capturingVideo, filename);
+				delete filename;
 			}
 			else
 			{
@@ -825,27 +825,21 @@ void MainEmuFrame::VideoCaptureUpdate()
 			// the GS doesn't support recording.
 			if (SPU2setupRecording)
 			{
-				SPU2setupRecording(m_capturingVideo, NULL);
+				SPU2setupRecording(m_capturingVideo, nullptr);
 			}
 		}
 
 		if (GetMainFramePtr() && needsMainFrameEnable)
-		{
 			GetMainFramePtr()->Enable();
-		}
 
 	}
 	else
 	{
 		// stop recording
 		if (GSsetupRecording)
-		{
-			GSsetupRecording(m_capturingVideo, NULL);
-		}
+			GSsetupRecording(m_capturingVideo);
 		if (SPU2setupRecording)
-		{
-			SPU2setupRecording(m_capturingVideo, NULL);
-		}
+			SPU2setupRecording(m_capturingVideo, nullptr);
 	}
 
 	if (m_capturingVideo)

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -811,27 +811,31 @@ void pt(const char* str){
 	printf("%02i:%02i:%02i%s", current->tm_hour, current->tm_min, current->tm_sec, str);
 }
 
-EXPORT_C_(int) GSsetupRecording(int start, void* data)
+EXPORT_C_(std::wstring*) GSsetupRecording(int start)
 {
 	if (s_gs == NULL) {
 		printf("GSdx: no s_gs for recording\n");
-		return 0;
+		return nullptr;
 	}
 #if defined(__unix__)
 	if (!theApp.GetConfigB("capture_enabled")) {
 		printf("GSdx: Recording is disabled\n");
-		return 0;
+		return nullptr;
 	}
 #endif
-
+	std::wstring* filename = nullptr;
 	if(start & 1)
 	{
 		printf("GSdx: Recording start command\n");
-		if (s_gs->BeginCapture()) {
+		filename = s_gs->BeginCapture();
+		if (filename)
+		{
 			pt(" - Capture started\n");
-		} else {
+		}
+		else
+		{
 			pt(" - Capture cancelled\n");
-			return 0;
+			return nullptr;
 		}
 	}
 	else
@@ -841,7 +845,7 @@ EXPORT_C_(int) GSsetupRecording(int start, void* data)
 		pt(" - Capture ended\n");
 	}
 
-	return 1;
+	return filename;
 }
 
 EXPORT_C GSsetGameCRC(uint32 crc, int options)

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -417,11 +417,24 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 
 	GSCaptureDlg dlg;
 
-	if(IDOK != dlg.DoModal()) return false;
+	if (IDOK != dlg.DoModal())
+		return false;
 
 	m_size.x = (dlg.m_width + 7) & ~7;
 	m_size.y = (dlg.m_height + 7) & ~7;
 
+	{
+		int start = dlg.m_filename.length() - 4;
+		if (start > 0)
+		{
+			std::string test = dlg.m_filename.substr(start);
+			std::transform(test.begin(), test.end(), test.begin(), tolower);
+			if (test.compare(".avi") != 0)
+				dlg.m_filename += ".avi";
+		}
+		else
+			dlg.m_filename += ".avi";
+	}
 	std::wstring fn{dlg.m_filename.begin(), dlg.m_filename.end()};
 
 	//

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -404,7 +404,7 @@ GSCapture::~GSCapture()
 	EndCapture();
 }
 
-bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float aspect)
+std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float aspect)
 {
 	printf("Recommended resolution: %d x %d, DAR for muxing: %.4f\n", recommendedResolution.x, recommendedResolution.y, aspect);
 	std::lock_guard<std::recursive_mutex> lock(m_lock);
@@ -418,7 +418,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	GSCaptureDlg dlg;
 
 	if (IDOK != dlg.DoModal())
-		return false;
+		return nullptr;
 
 	m_size.x = (dlg.m_width + 7) & ~7;
 	m_size.y = (dlg.m_height + 7) & ~7;
@@ -428,7 +428,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 		if (start > 0)
 		{
 			std::string test = dlg.m_filename.substr(start);
-			std::transform(test.begin(), test.end(), test.begin(), tolower);
+			std::transform(test.begin(), test.end(), test.begin(), (char(_cdecl*)(int))tolower);
 			if (test.compare(".avi") != 0)
 				dlg.m_filename += ".avi";
 		}
@@ -449,7 +449,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	|| FAILED(hr = cgb->SetFiltergraph(m_graph))
 	|| FAILED(hr = cgb->SetOutputFileName(&MEDIASUBTYPE_Avi, fn.c_str(), &mux, NULL)))
 	{
-		return false;
+		return nullptr;
 	}
 
 	m_src = new GSSource(m_size.x, m_size.y, fps, NULL, hr, dlg.m_colorspace);
@@ -457,31 +457,30 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	if (dlg.m_enc==0)
 	{
 		if (FAILED(hr = m_graph->AddFilter(m_src, L"Source")))
-			return false;
+			return nullptr;
 		if (FAILED(hr = m_graph->ConnectDirect(GetFirstPin(m_src, PINDIR_OUTPUT), GetFirstPin(mux, PINDIR_INPUT), NULL)))
-			return false;
+			return nullptr;
 	}
 	else
 	{
 		if(FAILED(hr = m_graph->AddFilter(m_src, L"Source"))
 		|| FAILED(hr = m_graph->AddFilter(dlg.m_enc, L"Encoder")))
 		{
-			return false;
+			return nullptr;
 		}
 
 		if(FAILED(hr = m_graph->ConnectDirect(GetFirstPin(m_src, PINDIR_OUTPUT), GetFirstPin(dlg.m_enc, PINDIR_INPUT), NULL))
 		|| FAILED(hr = m_graph->ConnectDirect(GetFirstPin(dlg.m_enc, PINDIR_OUTPUT), GetFirstPin(mux, PINDIR_INPUT), NULL)))
 		{
-			return false;
+			return nullptr;
 		}
 	}
 
 	BeginEnumFilters(m_graph, pEF, pBF)
 	{
-		CFilterInfo fi;
-		pBF->QueryFilterInfo(&fi);
-		std::wstring s{fi.achName};
-		printf("Filter [%p]: %s\n", pBF.p, std::string{s.begin(), s.end()}.c_str());
+		CFilterInfo filter;
+		pBF->QueryFilterInfo(&filter);
+		printf("Filter [%p]: %ls\n", pBF.p, &(*filter.achName));
 
 		BeginEnumPins(pBF, pEP, pPin)
 		{
@@ -490,8 +489,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 
 			CPinInfo pi;
 			pPin->QueryPinInfo(&pi);
-			std::wstring s{pi.achName};
-			printf("- Pin [%p - %p]: %s (%s)\n", pPin.p, pPinTo.p, std::string{s.begin(), s.end()}.c_str(), pi.dir ? "out" : "in");
+			printf("- Pin [%p - %p]: %ls (%s)\n", pPin.p, pPinTo.p, &(*filter.achName), pi.dir ? "out" : "in");
 		}
 		EndEnumPins
 	}
@@ -501,6 +499,8 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 
 	CComQIPtr<IGSSource>(m_src)->DeliverNewSegment();
 
+	m_capturing = true;
+	return new std::wstring(dlg.m_filename.begin(), dlg.m_filename.end() - 3);
 #elif defined(__unix__)
 	// Note I think it doesn't support multiple depth creation
 	GSmkdir(m_out_dir.c_str());
@@ -514,11 +514,10 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	for(int i = 0; i < m_threads; i++) {
 		m_workers.push_back(std::unique_ptr<GSPng::Worker>(new GSPng::Worker(&GSPng::Process)));
 	}
-#endif
 
 	m_capturing = true;
-
-	return true;
+	return new std::wstring();
+#endif
 }
 
 bool GSCapture::DeliverFrame(const void* bits, int pitch, bool rgba)

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -420,9 +420,6 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	if (IDOK != dlg.DoModal())
 		return nullptr;
 
-	m_size.x = (dlg.m_width + 7) & ~7;
-	m_size.y = (dlg.m_height + 7) & ~7;
-
 	{
 		int start = dlg.m_filename.length() - 4;
 		if (start > 0)
@@ -434,9 +431,21 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 		}
 		else
 			dlg.m_filename += ".avi";
+
+		FILE* test = fopen(dlg.m_filename.c_str(), "w");
+		if (test)
+			fclose(test);
+		else
+		{
+			dlg.InvalidFile();
+			return nullptr;
+		}
 	}
+
 	std::wstring fn{dlg.m_filename.begin(), dlg.m_filename.end()};
 
+	m_size.x = (dlg.m_width + 7) & ~7;
+	m_size.y = (dlg.m_height + 7) & ~7;
 	//
 
 	HRESULT hr;

--- a/plugins/GSdx/GSCapture.h
+++ b/plugins/GSdx/GSCapture.h
@@ -53,7 +53,7 @@ public:
 	GSCapture();
 	virtual ~GSCapture();
 
-	bool BeginCapture(float fps, GSVector2i recommendedResolution, float aspect);
+	std::wstring* BeginCapture(float fps, GSVector2i recommendedResolution, float aspect);
 	bool DeliverFrame(const void* bits, int pitch, bool rgba);
 	bool EndCapture();
 

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -529,7 +529,7 @@ bool GSRenderer::MakeSnapshot(const std::string& path)
 	return true;
 }
 
-bool GSRenderer::BeginCapture()
+std::wstring* GSRenderer::BeginCapture()
 {
 	GSVector4i disp = m_wnd->GetClientRect().fit(m_aspectratio);
 	float aspect = (float)disp.width() / std::max(1, disp.height());

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -72,7 +72,7 @@ public:
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(int vsync);
 
-	virtual bool BeginCapture();
+	virtual std::wstring* BeginCapture();
 	virtual void EndCapture();
 
 	void PurgePool();

--- a/plugins/GSdx/Window/GSCaptureDlg.cpp
+++ b/plugins/GSdx/Window/GSCaptureDlg.cpp
@@ -155,6 +155,11 @@ bool GSCaptureDlg::OnCommand(HWND hWnd, UINT id, UINT code)
 {
 	switch (id)
 	{
+	case IDC_FILENAME:
+	{
+		EnableWindow(GetDlgItem(m_hWnd, IDOK), GetText(IDC_FILENAME).length() != 0);
+		return false;
+	}
 	case IDC_BROWSE:
 	{
 		if (code == BN_CLICKED)

--- a/plugins/GSdx/Window/GSCaptureDlg.cpp
+++ b/plugins/GSdx/Window/GSCaptureDlg.cpp
@@ -143,9 +143,7 @@ void GSCaptureDlg::OnInit()
 
 		m_codecs.push_back(c);
 
-		std::string s{c.FriendlyName.begin(), c.FriendlyName.end()};
-
-		ComboBoxAppend(IDC_CODECS, s.c_str(), (LPARAM)&m_codecs.back(), c.DisplayName == selected);
+		ComboBoxAppend(IDC_CODECS, c.FriendlyName.c_str(), (LPARAM)&m_codecs.back(), c.DisplayName == selected);
 	}
 	EndEnumSysDev
 	UpdateConfigureButton();

--- a/plugins/GSdx/Window/GSCaptureDlg.cpp
+++ b/plugins/GSdx/Window/GSCaptureDlg.cpp
@@ -35,6 +35,13 @@
 
 #define EndEnumSysDev }}}
 
+void GSCaptureDlg::InvalidFile()
+{
+	char tmp[512];
+	sprintf_s(tmp, "GSdx couldn't open file for capturing: %s.\nCapture aborted.", m_filename.c_str());
+	MessageBox(GetActiveWindow(), tmp, "GSdx System Message", MB_OK | MB_SETFOREGROUND);
+}
+
 GSCaptureDlg::GSCaptureDlg()
 	: GSDialog(IDD_CAPTURE)
 {

--- a/plugins/GSdx/Window/GSCaptureDlg.h
+++ b/plugins/GSdx/Window/GSCaptureDlg.h
@@ -46,6 +46,7 @@ protected:
 
 public:
 	GSCaptureDlg();
+	void InvalidFile();
 
 	int m_width;
 	int m_height;

--- a/plugins/GSdx/Window/GSDialog.cpp
+++ b/plugins/GSdx/Window/GSDialog.cpp
@@ -200,12 +200,22 @@ void GSDialog::ComboBoxInit(UINT id, const std::vector<GSSetting>& settings, int
 int GSDialog::ComboBoxAppend(UINT id, const char* str, LPARAM data, bool select)
 {
 	HWND hWnd = GetDlgItem(m_hWnd, id);
+	int item = (int)SendMessageA(hWnd, CB_ADDSTRING, 0, (LPARAM)str);
+	return BoxAppend(hWnd, item, data, select);
+}
 
-	int item = (int)SendMessage(hWnd, CB_ADDSTRING, 0, (LPARAM)str);
+int GSDialog::ComboBoxAppend(UINT id, const wchar_t* str, LPARAM data, bool select)
+{
+	HWND hWnd = GetDlgItem(m_hWnd, id);
+	int item = (int)SendMessageW(hWnd, CB_ADDSTRING, 0, (LPARAM)str);
+	return BoxAppend(hWnd, item, data, select);
+}
 
+int GSDialog::BoxAppend(HWND& hWnd, int item, LPARAM data, bool select)
+{
 	SendMessage(hWnd, CB_SETITEMDATA, item, (LPARAM)data);
 
-	if(select)
+	if (select)
 	{
 		SendMessage(hWnd, CB_SETCURSEL, item, 0);
 	}

--- a/plugins/GSdx/Window/GSDialog.h
+++ b/plugins/GSdx/Window/GSDialog.h
@@ -53,6 +53,7 @@ public:
 
 	void ComboBoxInit(UINT id, const std::vector<GSSetting>& settings, int32_t selectionValue, int32_t maxValue = INT32_MAX);
 	int ComboBoxAppend(UINT id, const char* str, LPARAM data = 0, bool select = false);
+	int ComboBoxAppend(UINT id, const wchar_t* str, LPARAM data = 0, bool select = false);
 	bool ComboBoxGetSelData(UINT id, INT_PTR& data);
 	void ComboBoxFixDroppedWidth(UINT id);
 
@@ -61,4 +62,7 @@ public:
 	void AddTooltip(UINT id);
 
 	static void InitCommonControls();
+
+private:
+	int BoxAppend(HWND& hWnd, int item, LPARAM data = 0, bool select = false);
 };

--- a/plugins/spu2-x/src/PS2E-spu2.cpp
+++ b/plugins/spu2-x/src/PS2E-spu2.cpp
@@ -627,12 +627,12 @@ SPU2write(u32 rmem, u16 value)
 // returns a non zero value if successful
 // for now, pData is not used
 EXPORT_C_(int)
-SPU2setupRecording(int start, void *pData)
+SPU2setupRecording(int start, std::wstring* filename)
 {
     if (start == 0)
         RecordStop();
     else if (start == 1)
-        RecordStart();
+        RecordStart(filename);
 
     return 0;
 }

--- a/plugins/spu2-x/src/PS2E-spu2.h
+++ b/plugins/spu2-x/src/PS2E-spu2.h
@@ -79,7 +79,7 @@ SPU2irqCallback(void (*SPU2callback)(), void (*DMA4callback)(), void (*DMA7callb
 // returns a non zero value if successful
 // for now, pData is not used
 EXPORT_C_(int)
-SPU2setupRecording(int start, void *pData);
+SPU2setupRecording(int start, std::wstring* filename);
 
 EXPORT_C_(void)
 SPU2setClockPtr(u32 *ptr);

--- a/plugins/spu2-x/src/SndOut.h
+++ b/plugins/spu2-x/src/SndOut.h
@@ -688,7 +688,7 @@ extern SndOutModule *mods[];
 
 extern bool WavRecordEnabled;
 
-extern void RecordStart();
+extern void RecordStart(std::wstring* filename);
 extern void RecordStop();
 extern void RecordWrite(const StereoOut16 &sample);
 

--- a/plugins/spu2-x/src/Wavedump_wav.cpp
+++ b/plugins/spu2-x/src/Wavedump_wav.cpp
@@ -104,18 +104,25 @@ bool WavRecordEnabled = false;
 static WavOutFile *m_wavrecord = NULL;
 static Mutex WavRecordMutex;
 
-void RecordStart()
+void RecordStart(std::wstring* filename)
 {
     WavRecordEnabled = false;
 
     try {
         ScopedLock lock(WavRecordMutex);
         safe_delete(m_wavrecord);
-        m_wavrecord = new WavOutFile("recording.wav", 48000, 16, 2);
+#ifdef _WIN32
+        if (filename)
+            m_wavrecord = new WavOutFile((*filename) + "wav", 48000, 16, 2);
+        else
+            m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
+#elif defined(__unix__)
+        m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
+#endif
         WavRecordEnabled = true;
     } catch (std::runtime_error &) {
         m_wavrecord = NULL; // not needed, but what the heck. :)
-        SysMessage("SPU2-X couldn't open file for recording: %s.\nRecording to wavfile disabled.", "recording.wav");
+        SysMessage("SPU2-X couldn't open file for recording: %s.\nRecording to wavfile disabled.", "audio_recording.wav");
     }
 }
 


### PR DESCRIPTION
Before, if you were to insert a filename in the dialog box, it would be taken as is. As a result, pcsx2 would export the avi file with a different extension or no extension althogether. This simply fixes that.
Additionally, the filename set for the AVI will be transfered over to the WAV allowing them to match up. No more overrding an alreadt existing recording.wav file.