### PR TITLE
pcsx2-gui: Change the console logger's theme on the fly

### DIFF
--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -161,8 +161,6 @@ void ConsoleLogFrame::ColorArray::SetFont( int fontsize )
 
 	for (size_t i = Color_StrongBlack; i < ConsoleColors_Count; ++i)
 		m_table[i].SetFont(fixedB);
-
-	SetColorScheme_Light();
 }
 
 void ConsoleLogFrame::ColorArray::SetColorScheme_Dark()
@@ -392,18 +390,23 @@ ConsoleLogFrame::ConsoleLogFrame( MainEmuFrame *parent, const wxString& title, A
 	SetMenuBar( pMenuBar );
 	SetIcons( wxGetApp().GetIconBundle() );
 
-	if (0==m_conf.Theme.CmpNoCase(L"Dark"))
+	if (m_conf.Theme.CmpNoCase(L"Dark") == 0)
 	{
 		m_ColorTable.SetColorScheme_Dark();
-		m_TextCtrl.SetBackgroundColour( wxColor( 38, 41, 48 ) );
+		m_TextCtrl.SetBackgroundColour(darkThemeBgColor);
+		m_TextCtrl.SetDefaultStyle(wxTextAttr(wxNullColour, darkThemeBgColor));
 	}
-	else //if ((0==m_conf.Theme.CmpNoCase("Default")) || (0==m_conf.Theme.CmpNoCase("Light")))
+	else
 	{
 		m_ColorTable.SetColorScheme_Light();
-		m_TextCtrl.SetBackgroundColour( wxColor( 230, 235, 242 ) );
+		m_TextCtrl.SetBackgroundColour(lightThemeBgColor);
+		m_TextCtrl.SetDefaultStyle(wxTextAttr(wxNullColour, lightThemeBgColor));
 	}
 
-	m_TextCtrl.SetDefaultStyle( m_ColorTable[DefaultConsoleColor] );
+	// TODO - SetDefaultStyle _should_ be returning a wxTextAttr with both foreground and background color info
+	// but I don't want to mess with it too much in fear of breaking existing functionality.
+	// instead, i just set the background color individually above
+	m_TextCtrl.SetDefaultStyle(m_ColorTable[DefaultConsoleColor]);
 
 	// SetDefaultStyle only sets the style of text in the control.  We need to
 	// also set the font of the control, so that sizing logic knows what font we use:
@@ -864,32 +867,31 @@ void ConsoleLogFrame::OnToggleSource( wxCommandEvent& evt )
 	}
 }
 
-void ConsoleLogFrame::OnToggleTheme( wxCommandEvent& evt )
+void ConsoleLogFrame::OnToggleTheme(wxCommandEvent& evt)
 {
 	evt.Skip();
-
 	const wxChar* newTheme = L"Default";
-
-	switch( evt.GetId() )
+	switch (evt.GetId())
 	{
-		case MenuId_ColorScheme_Light:
-			newTheme = L"Default";
-			m_ColorTable.SetColorScheme_Light();
-			m_TextCtrl.SetBackgroundColour( wxColor( 230, 235, 242 ) );
-		break;
-
 		case MenuId_ColorScheme_Dark:
 			newTheme = L"Dark";
 			m_ColorTable.SetColorScheme_Dark();
-			m_TextCtrl.SetBackgroundColour( wxColor( 38, 41, 48 ) );
-		break;
+			m_TextCtrl.SetBackgroundColour(darkThemeBgColor);
+			m_TextCtrl.SetDefaultStyle(wxTextAttr(wxNullColour, darkThemeBgColor));
+			break;
+		case MenuId_ColorScheme_Light:
+		default:
+			newTheme = L"Default";
+			m_ColorTable.SetColorScheme_Light();
+			m_TextCtrl.SetBackgroundColour(lightThemeBgColor);
+			m_TextCtrl.SetDefaultStyle(wxTextAttr(wxNullColour, lightThemeBgColor));
+			break;
 	}
 
-	if (0 == m_conf.Theme.CmpNoCase(newTheme)) return;
+	if (m_conf.Theme.CmpNoCase(newTheme) == 0)
+		return;
 	m_conf.Theme = newTheme;
-
-	m_ColorTable.SetFont( m_conf.FontSize );
-	m_TextCtrl.SetDefaultStyle( m_ColorTable[Color_White] );
+	m_ColorTable.SetFont(m_conf.FontSize);
 }
 
 void ConsoleLogFrame::OnFontSize( wxCommandEvent& evt )

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -878,6 +878,7 @@ void ConsoleLogFrame::OnToggleTheme(wxCommandEvent& evt)
 			m_ColorTable.SetColorScheme_Dark();
 			m_TextCtrl.SetBackgroundColour(darkThemeBgColor);
 			m_TextCtrl.SetDefaultStyle(wxTextAttr(wxNullColour, darkThemeBgColor));
+			m_TextCtrl.Clear();
 			break;
 		case MenuId_ColorScheme_Light:
 		default:
@@ -885,6 +886,7 @@ void ConsoleLogFrame::OnToggleTheme(wxCommandEvent& evt)
 			m_ColorTable.SetColorScheme_Light();
 			m_TextCtrl.SetBackgroundColour(lightThemeBgColor);
 			m_TextCtrl.SetDefaultStyle(wxTextAttr(wxNullColour, lightThemeBgColor));
+			m_TextCtrl.Clear();
 			break;
 	}
 

--- a/pcsx2/gui/ConsoleLogger.h
+++ b/pcsx2/gui/ConsoleLogger.h
@@ -130,6 +130,10 @@ protected:
 		ColorSection( ConsoleColors _color, int msgptr ) : color(_color), startpoint(msgptr) { }
 	};
 
+private:
+	wxColor lightThemeBgColor = wxColor(230, 235, 242);
+	wxColor darkThemeBgColor = wxColor(38, 41, 48);
+
 protected:
 	ConLogConfig&	m_conf;
 	wxTextCtrl&		m_TextCtrl;


### PR DESCRIPTION
Before, when changing the Console Logger's color theme, the text's background would not change.  This seems to be because `wxTextAttr` is not being used to set both background and foreground, which appears to be a separate concern from just `TextCtrl.SetBackground()`.

The caveat is that once text is written to the screen, it retains whatever color it used originally.  Meaning that **new** console logs will use the updated theme.  There is a way to solve this:
```cpp
m_TextCtrl.SetStyle(0, m_TextCtrl.GetLastPosition(), wxTextAttr(wxNullColour, darkThemeBgColor));
```
This will update the background color of all existing lines.  The problem with this, is the foreground color is potentially different on every line/character.  So lines are mostly unreadable (white text on a white background for example).  A solution could be to default the foreground color to contrast with the new background, once again this will lose their original coloring but they will be readable.  Interested to get feedback on this.

Another approach is to just clear the whole logger, but of course this will lose the logs.

To retain the color info, we'd have to re-style character-by-character...which is slow:
```cpp
wxTextAttr charStyle;
...
for (long i = 0; i < m_TextCtrl.GetLastPosition(); i++)
{
	m_TextCtrl.GetStyle(i, charStyle);
        // Convert charStyle.GetTextColor() to the opposite theme's equivalent.
	m_TextCtrl.SetStyle(i, i++, wxTextAttr(charStyle.GetTextColour(), darkThemeBgColor));
}
```

I was tempted to modify the color array class to return a wxTextAttr with both background and foreground information, but I was afraid this would impact existing behavior, and there didn't seem to be much incentive to do so (seems to work fine).  The color array is used in multiple locations other than just setting the text area, it's also used for the font and such so lots _could_ go wrong.

Demo:
![image](https://user-images.githubusercontent.com/13153231/92181160-a6010f80-ee16-11ea-9ca0-0ae89d5450d0.png)
