### PR TITLE
Revamp the wx spu2-x dialog.

### DIFF
--- a/plugins/spu2-x/src/wx/wxConfig.cpp
+++ b/plugins/spu2-x/src/wx/wxConfig.cpp
@@ -18,139 +18,397 @@
 #include "Global.h"
 #include "wxConfig.h"
 
-Dialog::Dialog()
-    : wxDialog(nullptr, wxID_ANY, "SPU2-X Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
+MixerTab::MixerTab(wxWindow* parent)
+	: wxPanel(parent, wxID_ANY)
 {
-    m_top_box = new wxBoxSizer(wxHORIZONTAL);
-    m_left_box = new wxBoxSizer(wxVERTICAL);
-    m_right_box = new wxBoxSizer(wxVERTICAL);
+	auto* top_box = new wxBoxSizer(wxVERTICAL);
+
+	// Mixing Settings
+	top_box->Add(new wxStaticText(this, wxID_ANY, "Interpolation"), wxSizerFlags().Centre());
+
+	m_interpolation.Add("Nearest (Fastest/bad quality)");
+	m_interpolation.Add("Linear (Simple/okay sound)");
+	m_interpolation.Add("Cubic (Artificial highs)");
+	m_interpolation.Add("Hermite (Better highs)");
+	m_interpolation.Add("Catmull-Rom (PS2-like/slow)");
+
+	m_inter_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_interpolation);
+
+	effect_check = new wxCheckBox(this, wxID_ANY, "Disable Effects Processing (Speedup)");
+	dealias_check = new wxCheckBox(this, wxID_ANY, "Use the de-alias filter (Overemphasizes the highs) ");
+
+	// Latency Slider
+	const int min_latency = SynchMode == 0 ? LATENCY_MIN_TIMESTRETCH : LATENCY_MIN;
+
+	m_latency_box = new wxStaticBoxSizer(wxVERTICAL, this, "Latency");
+	m_latency_slider = new wxSlider(this, wxID_ANY, SndOutLatencyMS, min_latency, LATENCY_MAX, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
+	m_latency_box->Add(m_latency_slider, wxSizerFlags().Expand());
+
+	// Volume Slider
+	m_volume_box = new wxStaticBoxSizer(wxVERTICAL, this, "Volume");
+	m_volume_slider = new wxSlider(this, wxID_ANY, FinalVolume * 100, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
+	m_volume_box->Add(m_volume_slider, wxSizerFlags().Expand());
+
+	m_audio_box = new wxBoxSizer(wxVERTICAL);
+	m_audio_box->Add(new wxStaticText(this, wxID_ANY, "Audio Expansion Mode"), wxSizerFlags().Centre());
+	m_audio.Add("Stereo (None, Default)");
+	m_audio.Add("Quadrafonic");
+	m_audio.Add("Surround 5.1");
+	m_audio.Add("Surround 7.1");
+	m_audio_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_audio);
+	m_audio_box->Add(m_audio_select, wxSizerFlags().Expand());
+
+	top_box->Add(m_inter_select, wxSizerFlags().Centre());
+	top_box->Add(effect_check, wxSizerFlags().Centre());
+	top_box->Add(dealias_check, wxSizerFlags().Centre());
+	top_box->Add(m_latency_box, wxSizerFlags().Expand());
+	top_box->Add(m_volume_box, wxSizerFlags().Expand());
+	top_box->Add(m_audio_box, wxSizerFlags().Expand());
+
+	SetSizerAndFit(top_box);
+}
+
+void MixerTab::Load()
+{
+	m_inter_select->SetSelection(Interpolation);
+
+	effect_check->SetValue(EffectsDisabled);
+	dealias_check->SetValue(postprocess_filter_dealias);
+	m_audio_select->SetSelection(numSpeakers);
+
+	m_volume_slider->SetValue(FinalVolume * 100);
+	m_latency_slider->SetValue(SndOutLatencyMS);
+}
+
+void MixerTab::Save()
+{
+	Interpolation = m_inter_select->GetSelection();
+	EffectsDisabled = effect_check->GetValue();
+	postprocess_filter_dealias = dealias_check->GetValue();
+
+	numSpeakers = m_audio_select->GetSelection();
+
+	FinalVolume = m_volume_slider->GetValue() / 100.0;
+	SndOutLatencyMS = m_latency_slider->GetValue();
+}
+
+void MixerTab::Update()
+{
+}
+
+void MixerTab::CallUpdate(wxCommandEvent& /*event*/)
+{
+	Update();
+}
+
+SyncTab::SyncTab(wxWindow* parent)
+	: wxPanel(parent, wxID_ANY)
+{
+	auto* top_box = new wxBoxSizer(wxVERTICAL);
+
+	top_box->Add(new wxStaticText(this, wxID_ANY, "Synchronization"), wxSizerFlags().Centre());
+	m_sync.Add("TimeStretch (Recommended)");
+	m_sync.Add("Async Mix (Breaks some games!)");
+	m_sync.Add("None (Audio can skip.)");
+	m_sync_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_sync);
+
+	auto* adv_box = new wxStaticBoxSizer(wxVERTICAL, this, "Advanced");
+	auto* babble_box = new wxBoxSizer(wxVERTICAL);
+
+	auto* babble = new wxTextCtrl(this, wxID_ANY,
+								  "These are advanced configuration options for fine tuning time stretching behavior.\nLarger values are better for slowdown, while smaller values are better for speedup (more then 60 fps.).\nAll options are in microseconds.\n",
+								  wxDefaultPosition, wxSize(200, 100), wxTE_READONLY | wxTE_CENTRE | wxTE_MULTILINE);
+
+	babble_box->Add(babble, wxSizerFlags().Expand().Border(wxALL, 5).Centre());
+
+	adv_box->Add(babble_box, wxSizerFlags().Expand().Centre());
+
+	auto* soundtouch_grid = new wxFlexGridSizer(2, 10, 50);
+
+	seq_spin = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT, SoundtouchCfg::SequenceLen_Min, SoundtouchCfg::SequenceLen_Max, SoundtouchCfg::SequenceLenMS);
+	auto* seq_label = new wxStaticText(this, wxID_ANY, "Sequence Length");
+
+	seek_spin = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT, SoundtouchCfg::SeekWindow_Min, SoundtouchCfg::SeekWindow_Max, SoundtouchCfg::SeekWindowMS);
+	auto* seek_label = new wxStaticText(this, wxID_ANY, "Seek Window Size");
+
+	overlap_spin = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT, SoundtouchCfg::Overlap_Min, SoundtouchCfg::Overlap_Max, SoundtouchCfg::OverlapMS);
+	auto* overlap_label = new wxStaticText(this, wxID_ANY, "Overlap");
+
+	soundtouch_grid->Add(seq_label, wxSizerFlags().Border(wxALL, 5));
+	soundtouch_grid->Add(seq_spin, wxSizerFlags().Expand().Right());
+	soundtouch_grid->Add(seek_label, wxSizerFlags().Border(wxALL, 5));
+	soundtouch_grid->Add(seek_spin, wxSizerFlags().Expand().Right());
+	soundtouch_grid->Add(overlap_label, wxSizerFlags().Border(wxALL, 5));
+	soundtouch_grid->Add(overlap_spin, wxSizerFlags().Expand().Right());
+
+	adv_box->Add(soundtouch_grid);
+
+	reset_button = new wxButton(this, wxID_ANY, "Reset To Defaults");
+	adv_box->Add(reset_button, wxSizerFlags().Centre().Border(wxALL, 5));
+
+	top_box->Add(m_sync_select, wxSizerFlags().Centre());
+	top_box->Add(adv_box, wxSizerFlags().Expand().Centre());
+	SetSizerAndFit(top_box);
+	Bind(wxEVT_BUTTON, &SyncTab::OnButtonClicked, this);
+	Bind(wxEVT_CHOICE, &SyncTab::CallUpdate, this);
+}
+
+void SyncTab::Load()
+{
+	m_sync_select->SetSelection(SynchMode);
+
+	SoundtouchCfg::ReadSettings();
+	seq_spin->SetValue(SoundtouchCfg::SequenceLenMS);
+	seek_spin->SetValue(SoundtouchCfg::SeekWindowMS);
+	overlap_spin->SetValue(SoundtouchCfg::OverlapMS);
+}
+
+void SyncTab::Save()
+{
+	SynchMode = m_sync_select->GetSelection();
+
+	SoundtouchCfg::SequenceLenMS = seq_spin->GetValue();
+	SoundtouchCfg::SeekWindowMS = seek_spin->GetValue();
+	SoundtouchCfg::OverlapMS = overlap_spin->GetValue();
+	SoundtouchCfg::WriteSettings();
+}
+
+void SyncTab::Update()
+{
+	seq_spin->Enable(m_sync_select->GetCurrentSelection() == 0);
+	seek_spin->Enable(m_sync_select->GetCurrentSelection() == 0);
+	overlap_spin->Enable(m_sync_select->GetCurrentSelection() == 0);
+}
+
+void SyncTab::CallUpdate(wxCommandEvent& /*event*/)
+{
+	Update();
+}
+
+void SyncTab::OnButtonClicked(wxCommandEvent& event)
+{
+	seq_spin->SetValue(30);
+	seek_spin->SetValue(20);
+	overlap_spin->SetValue(10);
+}
+
+DebugTab::DebugTab(wxWindow* parent)
+	: wxPanel(parent, wxID_ANY)
+{
+	auto* top_box = new wxBoxSizer(wxVERTICAL);
+
+	debug_check = new wxCheckBox(this, wxID_ANY, "Enable Debug Options");
+	show_check = new wxCheckBox(this, wxID_ANY, "Show in console");
+	top_box->Add(debug_check, wxSizerFlags().Expand());
+	top_box->Add(show_check);
+
+	m_console_box = new wxStaticBoxSizer(wxVERTICAL, this, "Events");
+	auto* console_grid = new wxFlexGridSizer(2, 0, 0);
+
+	key_check = new wxCheckBox(this, wxID_ANY, "Key On/Off");
+	voice_check = new wxCheckBox(this, wxID_ANY, "Voice Stop");
+	dma_check = new wxCheckBox(this, wxID_ANY, "DMA Operations");
+	autodma_check = new wxCheckBox(this, wxID_ANY, "AutoDMA Operations");
+	buffer_check = new wxCheckBox(this, wxID_ANY, "Buffer Over/Underruns");
+	adpcm_check = new wxCheckBox(this, wxID_ANY, "ADPCM Cache");
+
+	console_grid->Add(key_check);
+	console_grid->Add(voice_check);
+	console_grid->Add(dma_check);
+	console_grid->Add(autodma_check);
+	console_grid->Add(buffer_check);
+	console_grid->Add(adpcm_check);
+	m_console_box->Add(console_grid);
+
+	m_log_only_box = new wxStaticBoxSizer(wxVERTICAL, this, "Log Only");
+	auto* log_grid = new wxFlexGridSizer(2, 0, 0);
+
+	dma_actions_check = new wxCheckBox(this, wxID_ANY, "Register/DMA Actions");
+	dma_writes_check = new wxCheckBox(this, wxID_ANY, "DMA Writes");
+	auto_output_check = new wxCheckBox(this, wxID_ANY, "Audio Output");
+
+	log_grid->Add(dma_actions_check);
+	log_grid->Add(dma_writes_check);
+	log_grid->Add(auto_output_check);
+	m_log_only_box->Add(log_grid);
+
+	dump_box = new wxStaticBoxSizer(wxVERTICAL, this, "Dump on Close");
+	auto* dump_grid = new wxFlexGridSizer(2, 0, 0);
+
+	core_voice_check = new wxCheckBox(this, wxID_ANY, "Core && Voice Stats");
+	memory_check = new wxCheckBox(this, wxID_ANY, "Memory Contents");
+	register_check = new wxCheckBox(this, wxID_ANY, "Register Data");
+	dump_grid->Add(core_voice_check);
+	dump_grid->Add(memory_check);
+	dump_grid->Add(register_check);
+	dump_box->Add(dump_grid);
+
+	top_box->Add(m_console_box, wxSizerFlags().Expand());
+	top_box->Add(m_log_only_box, wxSizerFlags().Expand());
+	top_box->Add(dump_box, wxSizerFlags().Expand());
+
+	SetSizerAndFit(top_box);
+	Bind(wxEVT_CHECKBOX, &DebugTab::CallUpdate, this);
+}
+
+void DebugTab::Load()
+{
+	debug_check->SetValue(DebugEnabled);
+
+	show_check->SetValue(_MsgToConsole);
+	key_check->SetValue(_MsgKeyOnOff);
+	voice_check->SetValue(_MsgVoiceOff);
+	dma_check->SetValue(_MsgDMA);
+	autodma_check->SetValue(_MsgAutoDMA);
+	buffer_check->SetValue(_MsgOverruns);
+	adpcm_check->SetValue(_MsgCache);
+
+	dma_actions_check->SetValue(_AccessLog);
+	dma_writes_check->SetValue(_DMALog);
+	auto_output_check->SetValue(_WaveLog);
+
+	core_voice_check->SetValue(_CoresDump);
+	memory_check->SetValue(_MemDump);
+	register_check->SetValue(_RegDump);
+	Update();
+}
+
+void DebugTab::Save()
+{
+	DebugEnabled = debug_check->GetValue();
+
+	_MsgToConsole = show_check->GetValue();
+	_MsgKeyOnOff = key_check->GetValue();
+	_MsgVoiceOff = voice_check->GetValue();
+	_MsgDMA = dma_check->GetValue();
+	_MsgAutoDMA = autodma_check->GetValue();
+	_MsgOverruns = buffer_check->GetValue();
+	_MsgCache = adpcm_check->GetValue();
+
+	_AccessLog = dma_actions_check->GetValue();
+	_DMALog = dma_writes_check->GetValue();
+	_WaveLog = auto_output_check->GetValue();
+
+	_CoresDump = core_voice_check->GetValue();
+	_MemDump = memory_check->GetValue();
+	_RegDump = register_check->GetValue();
+}
+
+void DebugTab::Update()
+{
+	if (debug_check->GetValue())
+	{
+		show_check->Enable();
+
+		key_check->Enable();
+		voice_check->Enable();
+		dma_check->Enable();
+		autodma_check->Enable();
+		buffer_check->Enable();
+		adpcm_check->Enable();
+
+		dma_actions_check->Enable();
+		dma_writes_check->Enable();
+		auto_output_check->Enable();
+
+		core_voice_check->Enable();
+		memory_check->Enable();
+		register_check->Enable();
+	}
+	else
+	{
+		show_check->Disable();
+
+		key_check->Disable();
+		voice_check->Disable();
+		dma_check->Disable();
+		autodma_check->Disable();
+		buffer_check->Disable();
+		adpcm_check->Disable();
+
+		dma_actions_check->Disable();
+		dma_writes_check->Disable();
+		auto_output_check->Disable();
+
+		core_voice_check->Disable();
+		memory_check->Disable();
+		register_check->Disable();
+	}
+}
+
+void DebugTab::CallUpdate(wxCommandEvent& /*event*/)
+{
+	Update();
+}
+
+Dialog::Dialog()
+	: wxDialog(nullptr, wxID_ANY, "SPU2-X Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
+{
+	m_top_box = new wxBoxSizer(wxVERTICAL);
+	auto* module_box = new wxBoxSizer(wxVERTICAL);
+
+	// Module
+	module_box->Add(new wxStaticText(this, wxID_ANY, "Module"), wxSizerFlags().Centre());
+	m_module.Add("No Sound (Emulate SPU2 only)");
 #ifdef SPU2X_PORTAUDIO
-    m_portaudio_box = new wxBoxSizer(wxVERTICAL);
+	m_module.Add("PortAudio (Cross-platform)");
 #endif
-    m_sdl_box = new wxBoxSizer(wxVERTICAL);
+	m_module.Add("SDL Audio (Recommended for PulseAudio)");
+	m_module_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_module);
+	module_box->Add(m_module_select, wxSizerFlags().Centre());
 
-    m_mix_box = new wxStaticBoxSizer(wxVERTICAL, this, "Mixing Settings");
-    m_debug_box = new wxStaticBoxSizer(wxVERTICAL, this, "Debug Settings");
-    m_output_box = new wxStaticBoxSizer(wxVERTICAL, this, "Output Settings");
-
-    // Mixing Settings
-    m_mix_box->Add(new wxStaticText(this, wxID_ANY, "Interpolation"), wxSizerFlags().Centre());
-
-    m_interpolation.Add("Nearest (Fastest/bad quality)");
-    m_interpolation.Add("Linear (Simple/okay sound)");
-    m_interpolation.Add("Cubic (Artificial highs)");
-    m_interpolation.Add("Hermite (Better highs)");
-    m_interpolation.Add("Catmull-Rom (PS2-like/slow)");
-
-    m_inter_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_interpolation);
-
-    effect_check = new wxCheckBox(this, wxID_ANY, "Disable Effects Processing (Speedup)");
-    dealias_check = new wxCheckBox(this, wxID_ANY, "Use the de-alias filter (Overemphasizes the highs)");
-
-    m_mix_box->Add(m_inter_select, wxSizerFlags().Centre());
-    m_mix_box->Add(effect_check, wxSizerFlags().Centre());
-    m_mix_box->Add(dealias_check, wxSizerFlags().Centre());
-
-    // Debug Settings
-    debug_check = new wxCheckBox(this, wxID_ANY, "Enable Debug Options");
-    launch_debug_dialog = new wxButton(this, wxID_ANY, "Configure...");
-
-    m_debug_box->Add(debug_check, wxSizerFlags().Expand());
-    m_debug_box->Add(launch_debug_dialog, wxSizerFlags().Expand());
-
-    // Output Settings
-
-    // Module
-    m_output_box->Add(new wxStaticText(this, wxID_ANY, "Module"), wxSizerFlags().Centre());
-    m_module.Add("No Sound (Emulate SPU2 only)");
 #ifdef SPU2X_PORTAUDIO
-    m_module.Add("PortAudio (Cross-platform)");
-#endif
-    m_module.Add("SDL Audio (Recommended for PulseAudio)");
-    m_module_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_module);
-    m_output_box->Add(m_module_select, wxSizerFlags().Centre());
-#ifdef SPU2X_PORTAUDIO
-    // Portaudio
-    m_portaudio_text = new wxStaticText(this, wxID_ANY, "Portaudio API");
-    m_portaudio_box->Add(m_portaudio_text, wxSizerFlags().Centre());
+	// Portaudio
+	m_portaudio_box = new wxBoxSizer(wxVERTICAL);
+	m_portaudio_text = new wxStaticText(this, wxID_ANY, "Portaudio API");
+	m_portaudio_box->Add(m_portaudio_text, wxSizerFlags().Centre());
 #ifdef __linux__
-    m_portaudio.Add("ALSA (recommended)");
-    m_portaudio.Add("OSS (legacy)");
-    m_portaudio.Add("JACK");
+	m_portaudio.Add("ALSA (recommended)");
+	m_portaudio.Add("OSS (legacy)");
+	m_portaudio.Add("JACK");
 #elif defined(__APPLE__)
-    m_portaudio.Add("CoreAudio");
+	m_portaudio.Add("CoreAudio");
 #else
-    m_portaudio.Add("OSS");
+	m_portaudio.Add("OSS");
 #endif
-    m_portaudio_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_portaudio);
-    m_portaudio_box->Add(m_portaudio_select, wxSizerFlags().Centre());
+	m_portaudio_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_portaudio);
+	m_portaudio_box->Add(m_portaudio_select, wxSizerFlags().Centre());
 #endif
 
-    // SDL
-    m_sdl_text = new wxStaticText(this, wxID_ANY, "SDL API");
-    m_sdl_box->Add(m_sdl_text, wxSizerFlags().Centre());
+	// SDL
+	m_sdl_box = new wxBoxSizer(wxVERTICAL);
+	m_sdl_text = new wxStaticText(this, wxID_ANY, "SDL API");
+	m_sdl_box->Add(m_sdl_text, wxSizerFlags().Centre());
 
-    for (int i = 0; i < SDL_GetNumAudioDrivers(); ++i)
-        m_sdl.Add(SDL_GetAudioDriver(i));
+	for (int i = 0; i < SDL_GetNumAudioDrivers(); ++i)
+		m_sdl.Add(SDL_GetAudioDriver(i));
 
-    m_sdl_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_sdl);
-    m_sdl_box->Add(m_sdl_select, wxSizerFlags().Centre());
+	m_sdl_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_sdl);
+	m_sdl_box->Add(m_sdl_select, wxSizerFlags().Centre());
+
 #ifdef SPU2X_PORTAUDIO
-    m_output_box->Add(m_portaudio_box, wxSizerFlags().Expand());
+	module_box->Add(m_portaudio_box, wxSizerFlags().Expand());
 #endif
-    m_output_box->Add(m_sdl_box, wxSizerFlags().Expand());
+	module_box->Add(m_sdl_box, wxSizerFlags().Expand());
 
-    // Synchronization Mode
-    m_sync_box = new wxStaticBoxSizer(wxHORIZONTAL, this, "Synchronization ");
-    m_sync.Add("TimeStretch (Recommended)");
-    m_sync.Add("Async Mix (Breaks some games!)");
-    m_sync.Add("None (Audio can skip.)");
-    m_sync_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_sync);
-    m_sync_box->Add(m_sync_select, wxSizerFlags().Centre());
+	m_top_box->Add(module_box, wxSizerFlags().Centre().Border(wxALL, 5));
 
-    launch_adv_dialog = new wxButton(this, wxID_ANY, "Advanced...");
-    m_sync_box->Add(launch_adv_dialog);
+	auto* book = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize);
+	m_mixer_panel = new MixerTab(book);
+	m_sync_panel = new SyncTab(book);
+	m_debug_panel = new DebugTab(book);
 
-    m_left_box->Add(m_output_box, wxSizerFlags().Expand());
-    m_left_box->Add(m_mix_box, wxSizerFlags().Expand());
-    m_left_box->Add(m_sync_box, wxSizerFlags().Expand().Border(wxALL, 5));
+	book->AddPage(m_mixer_panel, "Mixing", true);
+	book->AddPage(m_sync_panel, "Sync");
+	book->AddPage(m_debug_panel, "Debug");
 
-    // Latency Slider
-    const int min_latency = SynchMode == 0 ? LATENCY_MIN_TIMESTRETCH : LATENCY_MIN;
+	m_top_box->Add(book, wxSizerFlags().Centre());
+	m_top_box->Add(CreateStdDialogButtonSizer(wxOK | wxCANCEL), wxSizerFlags().Right());
 
-    m_latency_box = new wxStaticBoxSizer(wxVERTICAL, this, "Latency");
-    m_latency_slider = new wxSlider(this, wxID_ANY, SndOutLatencyMS, min_latency, LATENCY_MAX, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
-    m_latency_box->Add(m_latency_slider, wxSizerFlags().Expand());
+	SetSizerAndFit(m_top_box);
 
-    // Volume Slider
-    m_volume_box = new wxStaticBoxSizer(wxVERTICAL, this, "Volume");
-    m_volume_slider = new wxSlider(this, wxID_ANY, FinalVolume * 100, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
-    m_volume_box->Add(m_volume_slider, wxSizerFlags().Expand());
-
-    m_right_box->Add(m_latency_box, wxSizerFlags().Expand());
-    m_right_box->Add(m_volume_box, wxSizerFlags().Expand());
-
-    m_audio_box = new wxBoxSizer(wxVERTICAL);
-    m_audio_box->Add(new wxStaticText(this, wxID_ANY, "Audio Expansion Mode"));
-    m_audio.Add("Stereo (None, Default)");
-    m_audio.Add("Quadrafonic");
-    m_audio.Add("Surround 5.1");
-    m_audio.Add("Surround 7.1");
-    m_audio_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_audio);
-    m_audio_box->Add(m_audio_select, wxSizerFlags().Expand());
-
-    m_right_box->Add(m_audio_box);
-    m_right_box->Add(m_debug_box);
-
-    m_top_box->Add(m_left_box, wxSizerFlags().Left());
-    m_top_box->Add(m_right_box, wxSizerFlags().Right());
-
-
-    SetSizerAndFit(m_top_box);
-
-    Bind(wxEVT_BUTTON, &Dialog::OnButtonClicked, this);
-    Bind(wxEVT_CHOICE, &Dialog::CallReconfigure, this);
-    Bind(wxEVT_CHECKBOX, &Dialog::CallReconfigure, this);
+	Bind(wxEVT_CHOICE, &Dialog::CallReconfigure, this);
+	Bind(wxEVT_CHECKBOX, &Dialog::CallReconfigure, this);
 }
 
 Dialog::~Dialog()
@@ -159,330 +417,87 @@ Dialog::~Dialog()
 
 void Dialog::Reconfigure()
 {
-    const int mod = m_module_select->GetCurrentSelection();
-    bool show_portaudio = false, show_sdl = false;
+	const int mod = m_module_select->GetCurrentSelection();
+	bool show_portaudio = false, show_sdl = false;
 
-    switch (mod) {
-        case 0:
-            show_portaudio = false;
-            show_sdl = false;
-            break;
+	switch (mod)
+	{
+		case 0:
+			show_portaudio = false;
+			show_sdl = false;
+			break;
 
-        case 1:
-            show_portaudio = true;
-            show_sdl = false;
-            break;
+		case 1:
+			show_portaudio = true;
+			show_sdl = false;
+			break;
 
-        case 2:
-            show_portaudio = false;
-            show_sdl = true;
-            break;
+		case 2:
+			show_portaudio = false;
+			show_sdl = true;
+			break;
 
-        default:
-            show_portaudio = false;
-            show_sdl = false;
-            break;
-    }
+		default:
+			show_portaudio = false;
+			show_sdl = false;
+			break;
+	}
 #ifdef SPU2X_PORTAUDIO
-    m_output_box->Show(m_portaudio_box, show_portaudio, true);
+	m_top_box->Show(m_portaudio_box, show_portaudio, true);
 #endif
-    m_output_box->Show(m_sdl_box, show_sdl, true);
+	m_top_box->Show(m_sdl_box, show_sdl, true);
 
-    // Recalculating both of these accounts for if neither was showing initially.
-    m_top_box->Layout();
-    SetSizerAndFit(m_top_box);
-
-    launch_debug_dialog->Enable(debug_check->GetValue());
-    launch_adv_dialog->Enable(m_sync_select->GetCurrentSelection() == 0);
+	// Recalculating both of these accounts for if neither was showing initially.
+	m_top_box->Layout();
+	SetSizerAndFit(m_top_box);
 }
 
-void Dialog::CallReconfigure(wxCommandEvent &event)
+void Dialog::CallReconfigure(wxCommandEvent& event)
 {
-    Reconfigure();
+	Reconfigure();
 }
 
-void Dialog::OnButtonClicked(wxCommandEvent &event)
+void Dialog::Load()
 {
-    wxButton *bt = (wxButton *)event.GetEventObject();
-
-    if (bt == launch_debug_dialog)
-    {
-        auto debug_dialog = new DebugDialog;
-        debug_dialog->Display();
-        wxDELETE(debug_dialog);
-    }
-
-    if (bt == launch_adv_dialog)
-    {
-        auto adv_dialog = new SoundtouchCfg::AdvDialog;
-        adv_dialog->Display();
-        wxDELETE(adv_dialog);
-    }
-}
-
-void Dialog::ResetToValues()
-{
-    m_inter_select->SetSelection(Interpolation);
-    m_module_select->SetSelection(OutputModule);
+	m_module_select->SetSelection(OutputModule);
 #ifdef SPU2X_PORTAUDIO
-    m_portaudio_select->SetSelection(OutputAPI);
+	m_portaudio_select->SetSelection(OutputAPI);
 #endif
-    m_sdl_select->SetSelection(SdlOutputAPI);
-    m_sync_select->SetSelection(SynchMode);
-    m_audio_select->SetSelection(numSpeakers);
+	m_sdl_select->SetSelection(SdlOutputAPI);
 
-    effect_check->SetValue(EffectsDisabled);
-    dealias_check->SetValue(postprocess_filter_dealias);
-    debug_check->SetValue(DebugEnabled);
+	m_mixer_panel->Load();
+	m_sync_panel->Load();
+	m_debug_panel->Load();
 
-    m_volume_slider->SetValue(FinalVolume * 100);
-    m_latency_slider->SetValue(SndOutLatencyMS);
-
-    Reconfigure();
+	Reconfigure();
 }
 
-void Dialog::SaveValues()
+void Dialog::Save()
 {
-    Interpolation = m_inter_select->GetSelection();
-    OutputModule = m_module_select->GetSelection();
+	OutputModule = m_module_select->GetSelection();
 
 #ifdef SPU2X_PORTAUDIO
-    OutputAPI = m_portaudio_select->GetSelection();
-    wxString p_api(m_portaudio_select->GetStringSelection());
-    if (p_api.Find("ALSA") != wxNOT_FOUND) p_api = "ALSA";
-    if (p_api.Find("OSS") != wxNOT_FOUND) p_api = "OSS";
-    PortaudioOut->SetApiSettings(p_api);
+	OutputAPI = m_portaudio_select->GetSelection();
+	wxString p_api(m_portaudio_select->GetStringSelection());
+	if (p_api.Find("ALSA") != wxNOT_FOUND)
+		p_api = "ALSA";
+	if (p_api.Find("OSS") != wxNOT_FOUND)
+		p_api = "OSS";
+	PortaudioOut->SetApiSettings(p_api);
 #endif
 
-    SdlOutputAPI = m_sdl_select->GetSelection();
-    SDLOut->SetApiSettings(m_sdl_select->GetStringSelection());
+	SdlOutputAPI = m_sdl_select->GetSelection();
+	SDLOut->SetApiSettings(m_sdl_select->GetStringSelection());
 
-    SynchMode = m_sync_select->GetSelection();
-    numSpeakers = m_audio_select->GetSelection();
-
-    EffectsDisabled = effect_check->GetValue();
-    postprocess_filter_dealias = dealias_check->GetValue();
-    DebugEnabled = debug_check->GetValue();
-
-    FinalVolume = m_volume_slider->GetValue() / 100.0;
-    SndOutLatencyMS = m_latency_slider->GetValue();
+	m_mixer_panel->Save();
+	m_sync_panel->Save();
+	m_debug_panel->Save();
 }
 
 // Main
 void Dialog::Display()
 {
-    ResetToValues();
-    ShowModal();
-    SaveValues();
+	Load();
+	if (ShowModal() == wxID_OK)
+		Save();
 }
-
-// Debug dialog box
-DebugDialog::DebugDialog()
-    : wxDialog(nullptr, wxID_ANY, "SPU2-X Debug", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
-{
-    m_debug_top_box = new wxBoxSizer(wxHORIZONTAL);
-    m_together_box = new wxBoxSizer(wxVERTICAL);
-
-    show_check = new wxCheckBox(this, wxID_ANY, "Show in console");
-    m_together_box->Add(show_check);
-
-    m_console_box = new wxStaticBoxSizer(wxVERTICAL, this, "Events");
-
-    key_check = new wxCheckBox(this, wxID_ANY, "Key On/Off");
-    voice_check = new wxCheckBox(this, wxID_ANY, "Voice Stop");
-    dma_check = new wxCheckBox(this, wxID_ANY, "DMA Operations");
-    autodma_check = new wxCheckBox(this, wxID_ANY, "AutoDMA Operations");
-    buffer_check = new wxCheckBox(this, wxID_ANY, "Buffer Over/Underruns");
-    adpcm_check = new wxCheckBox(this, wxID_ANY, "ADPCM Cache");
-    m_console_box->Add(key_check);
-    m_console_box->Add(voice_check);
-    m_console_box->Add(dma_check);
-    m_console_box->Add(autodma_check);
-    m_console_box->Add(buffer_check);
-    m_console_box->Add(adpcm_check);
-
-    m_log_only_box = new wxStaticBoxSizer(wxVERTICAL, this, "Log Only");
-    dma_actions_check = new wxCheckBox(this, wxID_ANY, "Register/DMA Actions");
-    dma_writes_check = new wxCheckBox(this, wxID_ANY, "DMA Writes");
-    auto_output_check = new wxCheckBox(this, wxID_ANY, "Audio Output");
-    m_log_only_box->Add(dma_actions_check);
-    m_log_only_box->Add(dma_writes_check);
-    m_log_only_box->Add(auto_output_check);
-
-    dump_box = new wxStaticBoxSizer(wxVERTICAL, this, "Dump on Close");
-    core_voice_check = new wxCheckBox(this, wxID_ANY, "Core && Voice Stats");
-    memory_check = new wxCheckBox(this, wxID_ANY, "Memory Contents");
-    register_check = new wxCheckBox(this, wxID_ANY, "Register Data");
-    dump_box->Add(core_voice_check);
-    dump_box->Add(memory_check);
-    dump_box->Add(register_check);
-
-    m_together_box->Add(m_console_box);
-    m_debug_top_box->Add(m_together_box, wxSizerFlags().Expand());
-    m_debug_top_box->Add(m_log_only_box, wxSizerFlags().Expand());
-    m_debug_top_box->Add(dump_box, wxSizerFlags().Expand());
-
-    SetSizerAndFit(m_debug_top_box);
-    Bind(wxEVT_CHECKBOX, &DebugDialog::CallReconfigure, this);
-}
-
-DebugDialog::~DebugDialog()
-{
-}
-
-void DebugDialog::Reconfigure()
-{
-    if (show_check->GetValue()) {
-        _MsgKeyOnOff = key_check->Enable();
-        _MsgVoiceOff = voice_check->Enable();
-        _MsgDMA = dma_check->Enable();
-        _MsgAutoDMA = autodma_check->Enable();
-        _MsgOverruns = buffer_check->Enable();
-        _MsgCache = adpcm_check->Enable();
-    } else {
-        _MsgKeyOnOff = key_check->Disable();
-        _MsgVoiceOff = voice_check->Disable();
-        _MsgDMA = dma_check->Disable();
-        _MsgAutoDMA = autodma_check->Disable();
-        _MsgOverruns = buffer_check->Disable();
-        _MsgCache = adpcm_check->Disable();
-    }
-}
-
-void DebugDialog::CallReconfigure(wxCommandEvent &event)
-{
-    Reconfigure();
-}
-
-void DebugDialog::ResetToValues()
-{
-    show_check->SetValue(_MsgToConsole);
-    key_check->SetValue(_MsgKeyOnOff);
-    voice_check->SetValue(_MsgVoiceOff);
-    dma_check->SetValue(_MsgDMA);
-    autodma_check->SetValue(_MsgAutoDMA);
-    buffer_check->SetValue(_MsgOverruns);
-    adpcm_check->SetValue(_MsgCache);
-
-    dma_actions_check->SetValue(_AccessLog);
-    dma_writes_check->SetValue(_DMALog);
-    auto_output_check->SetValue(_WaveLog);
-
-    core_voice_check->SetValue(_CoresDump);
-    memory_check->SetValue(_MemDump);
-    register_check->SetValue(_RegDump);
-    Reconfigure();
-}
-
-void DebugDialog::SaveValues()
-{
-    _MsgToConsole = show_check->GetValue();
-    _MsgKeyOnOff = key_check->GetValue();
-    _MsgVoiceOff = voice_check->GetValue();
-    _MsgDMA = dma_check->GetValue();
-    _MsgAutoDMA = autodma_check->GetValue();
-    _MsgOverruns = buffer_check->GetValue();
-    _MsgCache = adpcm_check->GetValue();
-
-    _AccessLog = dma_actions_check->GetValue();
-    _DMALog = dma_writes_check->GetValue();
-    _WaveLog = auto_output_check->GetValue();
-
-    _CoresDump = core_voice_check->GetValue();
-    _MemDump = memory_check->GetValue();
-    _RegDump = register_check->GetValue();
-}
-
-void DebugDialog::Display()
-{
-    ResetToValues();
-    ShowModal();
-    SaveValues();
-    WriteSettings();
-}
-namespace SoundtouchCfg
-{
-AdvDialog::AdvDialog()
-    : wxDialog(nullptr, wxID_ANY, "Soundtouch Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
-{
-    m_adv_box = new wxBoxSizer(wxVERTICAL);
-    m_babble_box = new wxBoxSizer(wxVERTICAL);
-
-    m_adv_text = new wxStaticText(this, wxID_ANY, "These are advanced configuration options for fine tuning time stretching behavior.", wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
-    m_adv_text2 = new wxStaticText(this, wxID_ANY, "Larger values are better for slowdown, while smaller values are better for speedup (more then 60 fps.).", wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
-    m_adv_text3 = new wxStaticText(this, wxID_ANY, "All options are in microseconds.", wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
-
-    m_adv_text->Wrap(200);
-    m_adv_text2->Wrap(200);
-    m_adv_text2->Wrap(200);
-
-    m_babble_box->Add(m_adv_text, wxSizerFlags().Expand().Border(wxALL, 5).Centre());
-    m_babble_box->Add(m_adv_text2, wxSizerFlags().Expand().Border(wxALL, 5).Centre());
-    m_babble_box->Add(m_adv_text3, wxSizerFlags().Expand().Border(wxALL, 5).Centre());
-
-    m_adv_box->Add(m_babble_box, wxSizerFlags().Expand().Centre());
-
-    reset_button = new wxButton(this, wxID_ANY, "Reset To Defaults");
-    m_adv_box->Add(reset_button, wxSizerFlags().Expand().Centre().Border(wxALL, 5));
-
-    // Volume Slider
-    seq_box = new wxStaticBoxSizer(wxVERTICAL, this, "Sequence Length");
-    seq_slider = new wxSlider(this, wxID_ANY, SoundtouchCfg::SequenceLenMS, SoundtouchCfg::SequenceLen_Min, SoundtouchCfg::SequenceLen_Max, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
-    seq_box->Add(seq_slider, wxSizerFlags().Expand());
-    m_adv_box->Add(seq_box, wxSizerFlags().Expand().Centre().Border(wxALL, 5));
-
-    // Volume Slider
-    seek_box = new wxStaticBoxSizer(wxVERTICAL, this, "Seek Window Size");
-    seek_slider = new wxSlider(this, wxID_ANY, SoundtouchCfg::SeekWindowMS, SoundtouchCfg::SeekWindow_Min, SoundtouchCfg::SeekWindow_Max, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
-    seek_box->Add(seek_slider, wxSizerFlags().Expand());
-    m_adv_box->Add(seek_box, wxSizerFlags().Expand().Centre().Border(wxALL, 5));
-
-    // Volume Slider
-    overlap_box = new wxStaticBoxSizer(wxVERTICAL, this, "Overlap");
-    overlap_slider = new wxSlider(this, wxID_ANY, SoundtouchCfg::OverlapMS, SoundtouchCfg::Overlap_Min, SoundtouchCfg::Overlap_Max, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
-    overlap_box->Add(overlap_slider, wxSizerFlags().Expand().Centre());
-    m_adv_box->Add(overlap_box, wxSizerFlags().Expand().Centre().Border(wxALL, 5));
-
-    SetSizerAndFit(m_adv_box);
-    Bind(wxEVT_BUTTON, &AdvDialog::CallReset, this);
-}
-
-AdvDialog::~AdvDialog()
-{
-}
-
-void AdvDialog::Reset()
-{
-    seq_slider->SetValue(30);
-    seek_slider->SetValue(20);
-    overlap_slider->SetValue(10);
-}
-
-void AdvDialog::CallReset(wxCommandEvent &event)
-{
-    Reset();
-}
-
-void AdvDialog::LoadValues()
-{
-    SoundtouchCfg::ReadSettings();
-    seq_slider->SetValue(SoundtouchCfg::SequenceLenMS);
-    seek_slider->SetValue(SoundtouchCfg::SeekWindowMS);
-    overlap_slider->SetValue(SoundtouchCfg::OverlapMS);
-}
-
-void AdvDialog::SaveValues()
-{
-    SoundtouchCfg::SequenceLenMS = seq_slider->GetValue();
-    SoundtouchCfg::SeekWindowMS = seek_slider->GetValue();
-    SoundtouchCfg::OverlapMS = overlap_slider->GetValue();
-    SoundtouchCfg::WriteSettings();
-}
-
-void AdvDialog::Display()
-{
-    LoadValues();
-    ShowModal();
-    SaveValues();
-}
-}; // namespace SoundtouchCfg

--- a/plugins/spu2-x/src/wx/wxConfig.cpp
+++ b/plugins/spu2-x/src/wx/wxConfig.cpp
@@ -118,8 +118,10 @@ SyncTab::SyncTab(wxWindow* parent)
 	"For fine-tuning time stretching.\n"\
 	"Larger is better for slowdown, && smaller for speedup (60+ fps).\n"\
 	"All options in microseconds.",\
-	wxDefaultPosition, wxSize(200, 65), wxALIGN_CENTRE_HORIZONTAL);
-	adv_box->Add(babble_label, wxSizerFlags().Expand().Centre());
+	wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
+	babble_label->Wrap(300);
+
+	adv_box->Add(babble_label, wxSizerFlags().Centre());
 
 	auto* soundtouch_grid = new wxFlexGridSizer(2, 10, 50);
 

--- a/plugins/spu2-x/src/wx/wxConfig.cpp
+++ b/plugins/spu2-x/src/wx/wxConfig.cpp
@@ -113,15 +113,13 @@ SyncTab::SyncTab(wxWindow* parent)
 	m_sync_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_sync);
 
 	auto* adv_box = new wxStaticBoxSizer(wxVERTICAL, this, "Advanced");
-	auto* babble_box = new wxBoxSizer(wxVERTICAL);
 
-	auto* babble = new wxTextCtrl(this, wxID_ANY,
-								  "These are advanced configuration options for fine tuning time stretching behavior.\nLarger values are better for slowdown, while smaller values are better for speedup (more then 60 fps.).\nAll options are in microseconds.\n",
-								  wxDefaultPosition, wxSize(200, 100), wxTE_READONLY | wxTE_CENTRE | wxTE_MULTILINE);
-
-	babble_box->Add(babble, wxSizerFlags().Expand().Border(wxALL, 5).Centre());
-
-	adv_box->Add(babble_box, wxSizerFlags().Expand().Centre());
+	auto* babble_label = new wxStaticText(this, wxID_ANY, \
+	"For fine-tuning time stretching.\n"\
+	"Larger is better for slowdown, && smaller for speedup (60+ fps).\n"\
+	"All options in microseconds.",\
+	wxDefaultPosition, wxSize(200, 65), wxALIGN_CENTRE_HORIZONTAL);
+	adv_box->Add(babble_label, wxSizerFlags().Expand().Centre());
 
 	auto* soundtouch_grid = new wxFlexGridSizer(2, 10, 50);
 
@@ -342,7 +340,7 @@ void DebugTab::CallUpdate(wxCommandEvent& /*event*/)
 }
 
 Dialog::Dialog()
-	: wxDialog(nullptr, wxID_ANY, "SPU2-X Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
+	: wxDialog(nullptr, wxID_ANY, "Spu2 Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
 {
 	m_top_box = new wxBoxSizer(wxVERTICAL);
 	auto* module_box = new wxBoxSizer(wxVERTICAL);

--- a/plugins/spu2-x/src/wx/wxConfig.cpp
+++ b/plugins/spu2-x/src/wx/wxConfig.cpp
@@ -340,7 +340,7 @@ void DebugTab::CallUpdate(wxCommandEvent& /*event*/)
 }
 
 Dialog::Dialog()
-	: wxDialog(nullptr, wxID_ANY, "Spu2 Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
+	: wxDialog(nullptr, wxID_ANY, "SPU2 Config", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
 {
 	m_top_box = new wxBoxSizer(wxVERTICAL);
 	auto* module_box = new wxBoxSizer(wxVERTICAL);

--- a/plugins/spu2-x/src/wx/wxConfig.h
+++ b/plugins/spu2-x/src/wx/wxConfig.h
@@ -18,75 +18,93 @@
 #include <wx/wx.h>
 #include <wx/panel.h>
 #include <wx/wrapsizer.h>
+#include <wx/notebook.h>
+#include <wx/spinctrl.h>
 
 #if defined(__unix__) || defined(__APPLE__)
 #include <SDL.h>
 #include <SDL_audio.h>
 #include "Linux/Config.h"
 #endif
-namespace SoundtouchCfg
-{
-class AdvDialog : public wxDialog
-{
-    wxBoxSizer *m_adv_box, *m_babble_box;
 
-    wxButton *reset_button;
-    wxStaticText *m_adv_text, *m_adv_text2, *m_adv_text3;
-    wxSlider *seq_slider, *seek_slider, *overlap_slider;
-    wxStaticBoxSizer *seq_box, *seek_box, *overlap_box;
-
+class MixerTab : public wxPanel
+{
 public:
-    AdvDialog();
-    ~AdvDialog();
-    void Display();
-    void LoadValues();
-    void SaveValues();
-    void Reset();
-    void CallReset(wxCommandEvent &event);
+	wxArrayString m_interpolation;
+	wxChoice* m_inter_select;
+	wxCheckBox *effect_check, *dealias_check;
+	wxSlider *m_latency_slider, *m_volume_slider;
+	wxArrayString m_audio;
+	wxChoice* m_audio_select;
+	wxStaticBoxSizer *m_mix_box, *m_volume_box, *m_latency_box;
+	wxBoxSizer* m_audio_box;
+
+	MixerTab(wxWindow* parent);
+	void Load();
+	void Save();
+	void Update();
+	void CallUpdate(wxCommandEvent& event);
 };
-}; // namespace SoundtouchCfg
 
-class DebugDialog : public wxDialog
+class SyncTab : public wxPanel
 {
-    wxBoxSizer *m_debug_top_box;
-    wxBoxSizer *m_together_box;
-    wxStaticBoxSizer *m_console_box, *m_log_only_box, *dump_box;
-    wxCheckBox *show_check;
-    wxCheckBox *key_check, *voice_check, *dma_check, *autodma_check, *buffer_check, *adpcm_check;
-    wxCheckBox *dma_actions_check, *dma_writes_check, *auto_output_check;
-    wxCheckBox *core_voice_check, *memory_check, *register_check;
-
 public:
-    DebugDialog();
-    ~DebugDialog();
-    void Display();
-    void ResetToValues();
-    void SaveValues();
-    void Reconfigure();
-    void CallReconfigure(wxCommandEvent &event);
+	wxStaticBoxSizer* m_sync_box;
+	wxArrayString m_sync;
+	wxChoice* m_sync_select;
+	wxButton* launch_adv_dialog;
+
+	wxButton* reset_button;
+	wxSpinCtrl *seq_spin, *seek_spin, *overlap_spin;
+
+	SyncTab(wxWindow* parent);
+	void Load();
+	void Save();
+	void Update();
+	void CallUpdate(wxCommandEvent& event);
+	void OnButtonClicked(wxCommandEvent& event);
+};
+
+class DebugTab : public wxPanel
+{
+public:
+	wxCheckBox* debug_check;
+	wxButton* launch_debug_dialog;
+
+	wxBoxSizer* m_together_box;
+	wxStaticBoxSizer *m_console_box, *m_log_only_box, *dump_box;
+	wxCheckBox* show_check;
+	wxCheckBox *key_check, *voice_check, *dma_check, *autodma_check, *buffer_check, *adpcm_check;
+	wxCheckBox *dma_actions_check, *dma_writes_check, *auto_output_check;
+	wxCheckBox *core_voice_check, *memory_check, *register_check;
+
+	DebugTab(wxWindow* parent);
+	void Load();
+	void Save();
+	void Update();
+	void CallUpdate(wxCommandEvent& event);
 };
 
 class Dialog : public wxDialog
 {
-    wxBoxSizer *m_top_box, *m_left_box, *m_right_box;
-    wxBoxSizer *m_portaudio_box, *m_sdl_box, *m_audio_box;
-    wxStaticBoxSizer *m_mix_box, *m_debug_box, *m_output_box, *m_volume_box, *m_latency_box, *m_sync_box;
+	wxBoxSizer *m_top_box, *m_left_box, *m_right_box;
+	wxBoxSizer *m_portaudio_box, *m_sdl_box;
+	wxStaticBoxSizer* m_output_box;
 
-    wxArrayString m_interpolation, m_module, m_portaudio, m_sdl, m_sync, m_audio;
-    wxChoice *m_inter_select, *m_module_select, *m_portaudio_select, *m_sdl_select, *m_sync_select, *m_audio_select;
-    wxStaticText *m_portaudio_text, *m_sdl_text;
+	wxArrayString m_module, m_portaudio, m_sdl;
+	wxChoice *m_module_select, *m_portaudio_select, *m_sdl_select;
+	wxStaticText *m_portaudio_text, *m_sdl_text;
 
-    wxCheckBox *effect_check, *dealias_check, *debug_check;
-    wxSlider *m_latency_slider, *m_volume_slider;
-    wxButton *launch_debug_dialog, *launch_adv_dialog;
+	MixerTab* m_mixer_panel;
+	SyncTab* m_sync_panel;
+	DebugTab* m_debug_panel;
 
 public:
-    Dialog();
-    ~Dialog();
-    void Display();
-    void ResetToValues();
-    void SaveValues();
-    void Reconfigure();
-    void CallReconfigure(wxCommandEvent &event);
-    void OnButtonClicked(wxCommandEvent &event);
+	Dialog();
+	~Dialog();
+	void Display();
+	void Load();
+	void Save();
+	void Reconfigure();
+	void CallReconfigure(wxCommandEvent& event);
 };


### PR DESCRIPTION
Now that I've gone and spent a bunch of time on the GSdx dialog, the wx one I did for spu2-x felt like I could do it better. Here it what it currently looks like:
![old-dialog](https://user-images.githubusercontent.com/26599/92315019-d2429a80-ef94-11ea-858e-f9ab5e0d59e7.png)

So, lets make this have a tabbed interface, combine all the extra dialogs into the main dialog, and add Ok/Cancel buttons.
![spu2-x1](https://user-images.githubusercontent.com/26599/92315031-fd2cee80-ef94-11ea-9048-3528cb6976c1.png)
![spu2-x2](https://user-images.githubusercontent.com/26599/92315033-ff8f4880-ef94-11ea-8924-017b4d26bb9d.png)
![spu2-x3](https://user-images.githubusercontent.com/26599/92315037-01f1a280-ef95-11ea-8662-03c4c69c2f38.png)