### PR TITLE
HostFS: free fds when shutting down vm

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -326,7 +326,14 @@ namespace ioman {
 	void reset()
 	{
 		for (int i = 0; i < maxfds; i++)
-			fds[i].close();
+		{
+			// WARNING: the original IopBios code assumes that arrays are initialized at 0,
+			// which is very dumb but I don't feel like writing an initializer for the whole thing so 
+			// you'll just have to read my comment and fix it when something breaks. 
+			// Please don't do a git blame I'm not the cause of this madness
+			if (fds[i])
+				fds[i].close();
+		}
 	}
 
 	bool is_host(const std::string path)

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -257,6 +257,7 @@ namespace ioman {
 			IOManDir *dir;
 		};
 
+		constexpr filedesc(): type(FILE_FREE), file(nullptr) {}
 		operator bool() const { return type != FILE_FREE; }
 		operator IOManFile*() const { return type == FILE_FILE ? file : NULL; }
 		operator IOManDir*() const { return type == FILE_DIR ? dir : NULL; }
@@ -327,10 +328,6 @@ namespace ioman {
 	{
 		for (int i = 0; i < maxfds; i++)
 		{
-			// WARNING: the original IopBios code assumes that arrays are initialized at 0,
-			// which is very dumb but I don't feel like writing an initializer for the whole thing so 
-			// you'll just have to read my comment and fix it when something breaks. 
-			// Please don't do a git blame I'm not the cause of this madness
 			if (fds[i])
 				fds[i].close();
 		}

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -30,6 +30,7 @@
 
 #include "Utilities/PageFaultSource.h"
 #include "Utilities/Threading.h"
+#include "IopBios.h"
 
 #ifdef __WXMSW__
 #	include <wx/msw/wrapwin.h>
@@ -64,12 +65,14 @@ SysCoreThread::~SysCoreThread()
 void SysCoreThread::Cancel( bool isBlocking )
 {
 	m_hasActiveMachine = false;
+	R3000A::ioman::reset();
 	_parent::Cancel();
 }
 
 bool SysCoreThread::Cancel( const wxTimeSpan& span )
 {
 	m_hasActiveMachine = false;
+	R3000A::ioman::reset();
 	return _parent::Cancel( span );
 }
 
@@ -123,6 +126,7 @@ void SysCoreThread::ResetQuick()
 
 	m_resetVirtualMachine	= true;
 	m_hasActiveMachine		= false;
+	R3000A::ioman::reset();
 }
 
 void SysCoreThread::Reset()
@@ -291,6 +295,7 @@ void SysCoreThread::OnCleanupInThread()
 	m_hasActiveMachine		= false;
 	m_resetVirtualMachine	= true;
 
+	R3000A::ioman::reset();
 	// FIXME: temporary workaround for deadlock on exit, which actually should be a crash
 	vu1Thread.WaitVU();
 	GetCorePlugins().Close();


### PR DESCRIPTION
On express demand of @tadanokojin this fixes an issue where PCSX2 was not closing file handles used by the Host Filesystem subsystem until the process was closed, which was then freed by the OS.

As the ioman HostFS is implemented under a namespace I unfortunately can't put the reset into a destructor and had to put it in the core, which, while the changes are minimal, seems pretty dirty.
We should eventually move to a class for this as it assumes an array is initd at 0 when it very possibly cannot, but this requires basically rewriting the entire HostFS codebase, which I'm not very fond of doing at the moment.

I'll let you review and try to find a solution not quite as dirty