### PR TITLE
VIF: Set decoding status on VIF stall

### DIFF
--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -196,16 +196,17 @@ struct Gif_Path {
 	void Reset(bool softReset = false) {
 		state = GIF_PATH_IDLE;
 		if (softReset) {
-			GUNIT_WARN("Gif Path %d - Soft Reset", idx+1);
-			//gifTag.Reset();
-			//gsPack.Reset();
-			//curOffset = curSize;
+			if (!isMTVU()) // MTVU Freaks out if you try to reset it, so let's just let it transfer
+			{
+				GUNIT_WARN("Gif Path %d - Soft Reset", idx + 1);
+				curSize = curOffset;
+			}
 			return;
 		}
 		mtvu.Reset();
-		curSize     = 0;
-		curOffset   = 0;
-		readAmount  = 0;
+		curSize = 0;
+		curOffset = 0;
+		readAmount = 0;
 		gifTag.Reset();
 		gsPack.Reset();
 	}

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -175,38 +175,15 @@ __fi void vif1FBRST(u32 value) {
 		vif1.done = true;
 		vif1ch.chcr.STR = false;
 
-		//HACK!! Dynasty Warriors 5 Empires has some sort of wierd packet alignment thing going off, meaning
-		//the packet ends before the DirectHL in progress has finished. Not sure what causes that, but the GIF
-		//Unit is still waiting for more data, so we have to "pretend" it is finished when the game issues a reset
-		//which it does without causing any pauses.
-		//In most cases, this will never ever happen, so doing the following won't matter.
-		if(!gifUnit.gifPath[GIF_PATH_2].isDone()) 
-		{
-			DevCon.Warning("VIF1 FBRST While GIF Path2 is waiting for data!");
-			gifUnit.gifPath[GIF_PATH_2].state = GIF_PATH_IDLE;
-			gifUnit.gifPath[GIF_PATH_2].curSize = gifUnit.gifPath[GIF_PATH_2].curOffset;
-
-			if( gifRegs.stat.APATH == 2)
-			{
-				gifRegs.stat.APATH = 0;
-				gifRegs.stat.OPH = 0;
-				vif1Regs.stat.VGW = false; //Let vif continue if it's stuck on a flush
-
-				if(gifUnit.checkPaths(1,0,1)) gifUnit.Execute(false, true);
-			}
-		}
-
 		GUNIT_WARN(Color_Red, "VIF FBRST Reset MSK = %x", vif1Regs.mskpath3);
 		vif1Regs.mskpath3 = false;
 		gifRegs.stat.M3P  = 0;
-
 		vif1Regs.err.reset();
 		vif1.inprogress = 0;
 		vif1.cmd = 0;
 		vif1.vifstalled.enabled = false;
 		vif1.irqoffset.enabled = false;
-		vif1Regs.stat.FQC = 0;
-		vif1Regs.stat.clear_flags(VIF1_STAT_FDR | VIF1_STAT_INT | VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS | VIF1_STAT_VPS);
+		vif1Regs.stat._u32 = 0;
 	}
 
 	/* Fixme: Forcebreaks are pretty unknown for operation, presumption is it just stops it what its doing

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -182,7 +182,8 @@ __fi void vif0Interrupt()
 
 	if (vif0.irq && vif0.vifstalled.enabled && vif0.vifstalled.value == VIF_IRQ_STALL)
 	{
-		vif0Regs.stat.INT = true;
+		if (!vif0Regs.stat.ER1)
+			vif0Regs.stat.INT = true;
 
 		//Yakuza watches VIF_STAT so lets do this here.
 		if (((vif0Regs.code >> 24) & 0x7f) != 0x7) {
@@ -201,6 +202,7 @@ __fi void vif0Interrupt()
 			vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
 			if (vif0ch.qwc > 0 || !vif0.done)
 			{
+				vif0Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF0 Stalled");
 				return;
 			}

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -331,7 +331,8 @@ __fi void vif1Interrupt()
 	if (vif1.irq && vif1.vifstalled.enabled && vif1.vifstalled.value == VIF_IRQ_STALL)
 	{
 		VIF_LOG("VIF IRQ Firing");
-		vif1Regs.stat.INT = true;
+		if (!vif1Regs.stat.ER1)
+			vif1Regs.stat.INT = true;
 		
 		//Yakuza watches VIF_STAT so lets do this here.
 		if (((vif1Regs.code >> 24) & 0x7f) != 0x7) {
@@ -350,6 +351,7 @@ __fi void vif1Interrupt()
 			vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
 			if((vif1ch.qwc > 0 || !vif1.done) && !CHECK_VIF1STALLHACK)	
 			{
+				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF1 Stalled");
 				return;
 			}

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -406,8 +406,8 @@ __fi void vif1Interrupt()
 		return; //Dont want to end if vif is stalled.
 	}
 #ifdef PCSX2_DEVBUILD
-	if (vif1ch.qwc > 0) Console.WriteLn("VIF1 Ending with %x QWC left", vif1ch.qwc);
-	if (vif1.cmd != 0) Console.WriteLn("vif1.cmd still set %x tag size %x", vif1.cmd, vif1.tag.size);
+	if (vif1ch.qwc > 0) DevCon.WriteLn("VIF1 Ending with %x QWC left", vif1ch.qwc);
+	if (vif1.cmd != 0) DevCon.WriteLn("vif1.cmd still set %x tag size %x", vif1.cmd, vif1.tag.size);
 #endif
 
 	if((vif1ch.chcr.DIR == VIF_NORMAL_TO_MEM_MODE) && vif1.GSLastDownloadSize <= 16)

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -434,13 +434,6 @@ vifOp(vifCode_Nop) {
 		GetVifX.pass = 0;
 		vifExecQueue(idx);
 
-		//If the top bit was set to interrupt, we don't want it to take commands from a bad code if it's interpreted as a nop by us.
-		//Onimusha - Blade Warriors
-		if ((vifXRegs.code & 0x80000000) && (vifXRegs.code & 0xFF0000) != 0 && vifXch.qwc > 0 /*Not tag*/)
-		{
-			GetVifX.irq = 0;
-		}
-
 		if (GetVifX.vifpacketsize > 1)
 		{
 			if(((data[1] >> 24) & 0x7f) == 0x6 && (data[1] & 0x1)) //is mskpath3 next


### PR DESCRIPTION
Removes an old VIF hack
Fix GIF resets

Fixes the memcard screen on Onimusha Blade Warriors, no longer invisible.

Gets rid of the vifcmd error spam in Ratchet & Clank when completing the game, doesn't totally fix it (at least I don't think the behaviour is completely correct) but it stops it being so messy.