### PR TITLE
Support wxGTK3 3.2 and wxQt

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -35,9 +35,14 @@ else()
     set(wxWidgets_CONFIG_OPTIONS --unicode=yes)
 endif()
 
-list(APPEND wxWidgets_CONFIG_OPTIONS --version=3.2)
+# Use system wxWidgets version when packaging for Linux
+if(NOT PACKAGE_MODE)
+    list(APPEND wxWidgets_CONFIG_OPTIONS --version=3.0)
+endif()
 
-if(GTK3_API AND NOT APPLE)
+if(QT_API AND NOT APPLE)
+    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=qt)
+elseif(GTK3_API AND NOT APPLE)
     list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk3)
 elseif(NOT APPLE)
     list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk2)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -35,7 +35,7 @@ else()
     set(wxWidgets_CONFIG_OPTIONS --unicode=yes)
 endif()
 
-list(APPEND wxWidgets_CONFIG_OPTIONS --version=3.0)
+list(APPEND wxWidgets_CONFIG_OPTIONS --version=3.2)
 
 if(GTK3_API AND NOT APPLE)
     list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk3)
@@ -68,6 +68,9 @@ else()
     endif()
     if(EXISTS "/usr/bin/wx-config-3.0")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-3.0")
+    endif()
+    if(EXISTS "/usr/bin/wx-config")
+        set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config")
     endif()
 endif()
 


### PR DESCRIPTION
It is not necessary to limit wxWidgets to 3.0 because 3.2 also works fine.

It was impossible to build PCSX2 with GTK3 if it is limited to 3.0. In some Linux distributions, only wxGTK3 3.2 is available.

Also, wxQt can also be supported for KDE/LXQt users.