### PR TITLE
ci appveyor/travis: Build only master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache: ccache
 
 dist: xenial
 
+# build only master branch
+branches:
+  only:
+    - master
+
 matrix:
   include:
     - env: VERSION=8 BITS=64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,11 @@ version: 1.{build}-{branch}
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 
+# build only master branch
+branches:
+  only:
+    - master
+
 # Skip building commits if only the following directories/files are changed
 skip_commits:
   files:


### PR DESCRIPTION
Keep them around for now, we will remove them along the way.

Replaced by Github Actions.

Webhook settings were adjusted as well, pr events have been disabled.