### PR TITLE
ci: Resolve git-submodules related Actions warning

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -64,10 +64,11 @@ jobs:
           path: |
             ./3rdparty/xz
             ./3rdparty/gtest
+            ./.git/modules/
 
       - name: Checkout Submodules
         if: steps.cache-submodules.outputs.cache-hit != 'true'
-        run: git submodule update --init --recursive
+        run: git submodule update --init --recursive --jobs 2
 
       # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       - name: Prepare ccache timestamp

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -65,10 +65,11 @@ jobs:
           path: |
             ./3rdparty/xz
             ./3rdparty/gtest
+            ./.git/modules/
 
       - name: Checkout Submodules
         if: steps.cache-submodules.outputs.cache-hit != 'true'
-        run: git submodule update --init --recursive
+        run: git submodule update --init --recursive --jobs 2
 
       - name: Prepare Artifact Git Info
         shell: bash


### PR DESCRIPTION
The `.git/modules` folder was not being cached/restored, which caused the post-cleanup of the `Checkout` step to flag an error at the end.  Caching this folder and thus completely caching anything submodule related, should eliminate this warning.

Also allowed submodules to be pulled in parallel when they aren't cached.

Current error:
![image](https://user-images.githubusercontent.com/13153231/93692647-c6da8d80-fac3-11ea-9014-ad43ab51a78a.png)
From:
![image](https://user-images.githubusercontent.com/13153231/93692650-ce9a3200-fac3-11ea-86b4-7373c54e74c0.png)
