### PR TITLE
GSdx: Purge D3D11 Software

### DIFF
--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -57,8 +57,7 @@ static void (*s_irq)() = NULL;
 static uint8* s_basemem = NULL;
 static int s_vsync = 0;
 static bool s_exclusive = true;
-static const char *s_renderer_name = "";
-static const char *s_renderer_type = "";
+static std::string s_renderer_name;
 bool gsopen_done = false; // crash guard for GSgetTitleInfo2 and GSKeyEvent (replace with lock?)
 
 EXPORT_C_(uint32) PS2EgetLibType()
@@ -302,48 +301,36 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 			}
 		}
 
-		const char* renderer_fullname = "";
-		const char* renderer_mode = "";
-
-		switch (renderer)
-		{
-		case GSRendererType::DX1011_SW:
-		case GSRendererType::OGL_SW:
-			renderer_mode = "(Software renderer)";
-			break;
-		case GSRendererType::Null:
-			renderer_mode = "(Null renderer)";
-			break;
-		default:
-			renderer_mode = "(Hardware renderer)";
-			break;
-		}
+		std::string renderer_name;
 
 		switch (renderer)
 		{
 		default:
 #ifdef _WIN32
 		case GSRendererType::DX1011_HW:
-		case GSRendererType::DX1011_SW:
 			dev = new GSDevice11();
-			s_renderer_name = " D3D11";
-			renderer_fullname = "Direct3D 11";
+			s_renderer_name = "D3D11";
+			renderer_name = "Direct3D 11";
 			break;
 #endif
-		case GSRendererType::Null:
-			dev = new GSDeviceNull();
-			s_renderer_name = " Null";
-			renderer_fullname = "Null";
-			break;
 		case GSRendererType::OGL_HW:
+			dev = new GSDeviceOGL();
+			s_renderer_name = "OGL";
+			renderer_name = "OpenGL";
+			break;
 		case GSRendererType::OGL_SW:
 			dev = new GSDeviceOGL();
-			s_renderer_name = " OGL";
-			renderer_fullname = "OpenGL";
+			s_renderer_name = "SW";
+			renderer_name = "Software";
+			break;
+		case GSRendererType::Null:
+			dev = new GSDeviceNull();
+			s_renderer_name = "NULL";
+			renderer_name = "Null";
 			break;
 		}
 
-		printf("Current Renderer: %s %s\n", renderer_fullname, renderer_mode);
+		printf("Current Renderer: %s\n", renderer_name.c_str());
 
 		if (dev == NULL)
 		{
@@ -358,21 +345,16 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 #ifdef _WIN32
 			case GSRendererType::DX1011_HW:
 				s_gs = (GSRenderer*)new GSRendererDX11();
-				s_renderer_type = " HW";
 				break;
 #endif
 			case GSRendererType::OGL_HW:
 				s_gs = (GSRenderer*)new GSRendererOGL();
-				s_renderer_type = " HW";
 				break;
-			case GSRendererType::DX1011_SW:
 			case GSRendererType::OGL_SW:
 				s_gs = new GSRendererSW(threads);
-				s_renderer_type = " SW";
 				break;
 			case GSRendererType::Null:
 				s_gs = new GSRendererNull();
-				s_renderer_type = "";
 				break;
 			}
 			if (s_gs == NULL)
@@ -433,35 +415,47 @@ EXPORT_C_(void) GSosdMonitor(const char *key, const char *value, uint32 color)
 EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 {
 	static bool stored_toggle_state = false;
-	bool toggle_state = !!(flags & 4);
+	const bool toggle_state = !!(flags & 4);
 
-	GSRendererType renderer = theApp.GetCurrentRendererType();
+	auto current_renderer = theApp.GetCurrentRendererType();
 
-	if (renderer != GSRendererType::Undefined && stored_toggle_state != toggle_state)
+	if (current_renderer != GSRendererType::Undefined && stored_toggle_state != toggle_state)
 	{
-#ifdef _WIN32
-		switch (renderer) {
-			// Use alternative renderer (SW if currently using HW renderer, and vice versa, keeping the same API and API version)
-			case GSRendererType::DX1011_SW: renderer = GSRendererType::DX1011_HW; break;
-			case GSRendererType::DX1011_HW: renderer = GSRendererType::DX1011_SW; break;
-			case GSRendererType::OGL_SW: renderer = GSRendererType::OGL_HW; break;
-			case GSRendererType::OGL_HW: renderer = GSRendererType::OGL_SW; break;
-			default: renderer = GSRendererType::DX1011_SW; break; // If wasn't using one of the above mentioned ones, use best SW renderer.
-		}
+		// SW -> HW and HW -> SW (F9 Switch)
+		switch (current_renderer)
+		{
+			#ifdef _WIN32
+			case GSRendererType::DX1011_HW:
+				current_renderer = GSRendererType::OGL_SW;
+				break;
+			#endif
+			case GSRendererType::OGL_SW:
+			#ifdef _WIN32
+			{
+				const auto config_renderer = static_cast<GSRendererType>(
+					theApp.GetConfigI("Renderer")
+				);
 
-#endif
-#if defined(__unix__)
-		switch(renderer) {
-			// Use alternative renderer (SW if currently using HW renderer, and vice versa)
-		case GSRendererType::OGL_SW: renderer = GSRendererType::OGL_HW; break;
-		case GSRendererType::OGL_HW: renderer = GSRendererType::OGL_SW; break;
-		default: renderer = GSRendererType::OGL_SW; break; // fallback to OGL SW
+				if (current_renderer == config_renderer)
+					current_renderer = GSUtil::GetBestRenderer();
+				else
+					current_renderer = config_renderer;
+			}
+			#else
+				current_renderer = GSRendererType::OGL_HW;
+			#endif
+				break;
+			case GSRendererType::OGL_HW:
+				current_renderer = GSRendererType::OGL_SW;
+				break;
+			default:
+				current_renderer = GSRendererType::OGL_SW;
+				break;
 		}
-#endif
 	}
 	stored_toggle_state = toggle_state;
 
-	int retval = _GSopen(dsp, "", renderer);
+	int retval = _GSopen(dsp, "", current_renderer);
 
 	if (s_gs != NULL)
 		s_gs->SetAspectRatio(0);	 // PCSX2 manages the aspect ratios
@@ -473,14 +467,6 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 
 EXPORT_C_(int) GSopen(void** dsp, const char* title, int mt)
 {
-	/*
-	if(!XInitThreads()) return -1;
-
-	Display* display = XOpenDisplay(0);
-
-	XCloseDisplay(display);
-	*/
-
 	GSRendererType renderer = GSRendererType::Default;
 
 	// Legacy GUI expects to acquire vsync from the configuration files.
@@ -490,13 +476,6 @@ EXPORT_C_(int) GSopen(void** dsp, const char* title, int mt)
 	if(mt == 2)
 	{
 		// pcsx2 sent a switch renderer request
-
-#ifdef _WIN32
-
-		renderer = GSRendererType::DX1011_SW;
-
-#endif
-
 		mt = 1;
 	}
 	else
@@ -856,9 +835,8 @@ EXPORT_C GSgetLastTag(uint32* tag)
 
 EXPORT_C GSgetTitleInfo2(char* dest, size_t length)
 {
-	std::string s{"GSdx"};
-	s.append(s_renderer_name).append(s_renderer_type);
-
+	std::string s;
+	s.append(s_renderer_name);
 	// TODO: this gets called from a different thread concurrently with GSOpen (on linux)
 	if (gsopen_done && s_gs != NULL && s_gs->m_GStitleInfoBuffer[0])
 	{

--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -232,7 +232,6 @@ enum class GSRendererType : int8_t
 {
 	Undefined = -1,
 	DX1011_HW = 3,
-	DX1011_SW,
 	Null = 11,
 	OGL_HW,
 	OGL_SW,

--- a/plugins/GSdx/GSLocalMemory.cpp
+++ b/plugins/GSdx/GSLocalMemory.cpp
@@ -87,10 +87,10 @@ GSLocalMemory::GSLocalMemory()
 	m_use_fifo_alloc = theApp.GetConfigB("UserHacks") && theApp.GetConfigB("wrap_gs_mem");
 	switch (theApp.GetCurrentRendererType()) {
 		case GSRendererType::OGL_SW:
-		case GSRendererType::DX1011_SW:
 			m_use_fifo_alloc = true;
 			break;
-		default: break;
+		default:
+			break;
 	}
 
 	if (m_use_fifo_alloc)

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -205,17 +205,16 @@ void GSdxApp::Init()
 	m_section = "Settings";
 
 #ifdef _WIN32
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_HW), "Direct3D 11", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW), "OpenGL", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_SW), "Direct3D 11", "Software"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW), "OpenGL", "Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::DX1011_HW), "Direct3D 11", ""));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW), "OpenGL", ""));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW), "Software", ""));
 #else // Linux
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW), "OpenGL", "Hardware"));
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW), "OpenGL", "Software"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_HW), "OpenGL", ""));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::OGL_SW), "Software", ""));
 #endif
 
 	// The null renderer goes third, it has use for benchmarking purposes in a release build
-	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null), "None", "Core Benchmark"));
+	m_gs_renderers.push_back(GSSetting(static_cast<uint32>(GSRendererType::Null), "Null", ""));
 
 	m_gs_interlace.push_back(GSSetting(0, "None", ""));
 	m_gs_interlace.push_back(GSSetting(1, "Weave tff", "saw-tooth"));
@@ -556,7 +555,7 @@ void GSdxApp::SetCurrentRendererType(GSRendererType type)
 	m_current_renderer_type = type;
 }
 
-GSRendererType GSdxApp::GetCurrentRendererType()
+GSRendererType GSdxApp::GetCurrentRendererType() const
 {
 	return m_current_renderer_type;
 }

--- a/plugins/GSdx/GSdx.h
+++ b/plugins/GSdx/GSdx.h
@@ -61,7 +61,7 @@ public:
 	std::string GetConfigS(const char* entry);
 
 	void SetCurrentRendererType(GSRendererType type);
-	GSRendererType GetCurrentRendererType();
+	GSRendererType GetCurrentRendererType() const;
 
 	void SetConfigDir(const char* dir);
 

--- a/plugins/GSdx/Window/GSSettingsDlg.cpp
+++ b/plugins/GSdx/Window/GSSettingsDlg.cpp
@@ -39,7 +39,7 @@ GSSettingsDlg::GSSettingsDlg()
 	{
 		auto is_d3d11_renderer = [](const auto &renderer) {
 			const GSRendererType type = static_cast<GSRendererType>(renderer.value);
-			return type == GSRendererType::DX1011_HW || type == GSRendererType::DX1011_SW;
+			return type == GSRendererType::DX1011_HW;
 		};
 		m_renderers.erase(std::remove_if(m_renderers.begin(), m_renderers.end(), is_d3d11_renderer), m_renderers.end());
 	}
@@ -85,7 +85,7 @@ void GSSettingsDlg::OnInit()
 	__super::OnInit();
 
 	GSRendererType renderer = GSRendererType(theApp.GetConfigI("Renderer"));
-	const bool dx11 = renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW;
+	const bool dx11 = renderer == GSRendererType::DX1011_HW;
 	if (renderer == GSRendererType::Undefined || m_d3d11_adapters.empty() && dx11)
 		renderer = GSUtil::GetBestRenderer();
 	ComboBoxInit(IDC_RENDERER, m_renderers, static_cast<int32_t>(renderer));
@@ -275,7 +275,7 @@ void GSSettingsDlg::UpdateAdapters()
 		return;
 
 	const GSRendererType renderer = static_cast<GSRendererType>(data);
-	const bool dx11 = renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW;
+	const bool dx11 = renderer == GSRendererType::DX1011_HW;
 
 	EnableWindow(GetDlgItem(m_hWnd, IDC_ADAPTER), dx11);
 	EnableWindow(GetDlgItem(m_hWnd, IDC_ADAPTER_TEXT), dx11);
@@ -316,11 +316,11 @@ void GSSettingsDlg::UpdateControls()
 	{
 		const GSRendererType renderer = static_cast<GSRendererType>(i);
 
-		const bool dx11 = renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::DX1011_SW;
+		const bool dx11 = renderer == GSRendererType::DX1011_HW;
 		const bool ogl = renderer == GSRendererType::OGL_HW || renderer == GSRendererType::OGL_SW;
 
 		const bool hw =  renderer == GSRendererType::DX1011_HW || renderer == GSRendererType::OGL_HW;
-		const bool sw =  renderer == GSRendererType::DX1011_SW || renderer == GSRendererType::OGL_SW;
+		const bool sw =  renderer == GSRendererType::OGL_SW;
 		const bool null = renderer == GSRendererType::Null;
 
 		const int sw_threads = SendMessage(GetDlgItem(m_hWnd, IDC_SWTHREADS), UDM_GETPOS, 0, 0);


### PR DESCRIPTION
1.6.0:
![005728](https://user-images.githubusercontent.com/26046960/93706080-d7552d00-faf0-11ea-8d64-6b5ad456a367.png)

This PR:
![005727](https://user-images.githubusercontent.com/26046960/93706085-e0de9500-faf0-11ea-83f0-75b2b591b2c6.png)

1.6.0:
![005729](https://user-images.githubusercontent.com/26046960/93706138-534f7500-faf1-11ea-8488-0f557a3a72b3.png)

This PR:
![005730](https://user-images.githubusercontent.com/26046960/93706142-59455600-faf1-11ea-9e15-b7c655897fc6.png)

F9 has been modified on Windows to have the following functionality:
- If the renderer in the config is D3D11, switch between D3D11 and SW
- If the renderer in the config is OGL, switch between OGL and SW
- If the renderer in the config is SW, switch between SW and the renderer returned by GetBestRenderer()