### PR TITLE
IPC: Implement MsgVersion

### DIFF
--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -87,6 +87,7 @@ protected:
 		MsgWrite16 = 5,         /**< Write 16 bit value to memory. */
 		MsgWrite32 = 6,         /**< Write 32 bit value to memory. */
 		MsgWrite64 = 7,         /**< Write 64 bit value to memory. */
+		MsgVersion = 8,         /**< Returns PCSX2 version. */
 		MsgUnimplemented = 0xFF /**< Unimplemented IPC message. */
 	};
 


### PR DESCRIPTION
This adds an MsgVersion command to the IPC protocol allowing you to query pcsx2 version.
I also fixed a small boundings bug that was present in the initial merge, even though it couldn't do OOM operations it could still reuse old cached commands if you supplied a command whose size was inferior to what you said it was.