### PR TITLE
ci: Validate VS filter files in buiild

### DIFF
--- a/.github/workflows/scripts/validate-vs-filters.ps1
+++ b/.github/workflows/scripts/validate-vs-filters.ps1
@@ -1,0 +1,19 @@
+$filterFiles = Get-ChildItem $PWD -name -recurse *.vcxproj.filters
+
+$failed = $FALSE
+foreach ($file in $filterFiles) {
+  # Skip 3rdparty files
+  if ($file -NotMatch "^3rdparty") {
+    $expression  = "python -c `"import sys, xml.dom.minidom as d; d.parse(sys.argv[1])`" $($file)"
+    $expression += ';$LastExitCode'
+    $exitCode = Invoke-Expression $expression
+    if($exitCode -ne 0){
+      Write-Host -foregroundColor red "$($file) - Invalid VS filters file.  Likely missing tags"
+      $failed = $TRUE
+    }
+  }
+}
+
+if ($failed) {
+  exit 1
+}

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -87,6 +87,10 @@ jobs:
           echo "##[set-output name=artifact-metadata;]${ARTIFACT_NAME}"
         id: git-vars
 
+      - name: Verify VS Project Files
+        shell: powershell
+        run: .\.github\workflows\scripts\validate-vs-filters.ps1
+
       - name: Setup msbuild
         uses: microsoft/setup-msbuild@v1.0.1
         with:


### PR DESCRIPTION
msbuild does not use the project in it's entirety to build the app.  This means problems can slip through, so an easy solution is just to ensure the XML is well-formed.  More sophisticated validation could be done with something like `xmllint` but seems overkill (and more of a challenge to get installed on windows than linux of course).

Hopefully this will help to avoid issues like this getting into master:
- https://github.com/PCSX2/pcsx2/commit/2a292fdc05d037533e3db6bd9cebde33dca5aa59

A failure-test: https://github.com/xTVaser/pcsx2-rr/pull/39/commits/487af547c439145e9c78c25d2c1fe6d3ba52b445