### PR TITLE
Capture Optimizations and Input Recording Interactivity

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -172,7 +172,7 @@ void CALLBACK GSsetFrameSkip(int frameskip);
 
 // Starts recording GS frame data
 // returns a non zero value if successful
-int CALLBACK GSsetupRecording(std::wstring& filename);
+int CALLBACK GSsetupRecording(std::string& filename);
 
 // Stops recording GS frame data
 void CALLBACK GSendRecording();
@@ -269,7 +269,7 @@ typedef void(CALLBACK *_GSsetGameCRC)(int, int);
 typedef void(CALLBACK *_GSsetFrameSkip)(int frameskip);
 typedef void(CALLBACK *_GSsetVsync)(int enabled);
 typedef void(CALLBACK *_GSsetExclusive)(int isExclusive);
-typedef int(CALLBACK* _GSsetupRecording)(std::wstring&);
+typedef int(CALLBACK* _GSsetupRecording)(std::string&);
 typedef void(CALLBACK* _GSendRecording)();
 typedef void(CALLBACK *_GSreset)();
 typedef void(CALLBACK *_GSwriteCSR)(u32 value);

--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -173,7 +173,7 @@ void CALLBACK GSsetFrameSkip(int frameskip);
 // if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
 // for now, pData is not used
-int CALLBACK GSsetupRecording(int start, void *pData);
+std::wstring* CALLBACK GSsetupRecording(int start);
 
 void CALLBACK GSreset();
 //deprecated: GSgetTitleInfo was used in PCSX2 but no plugin supported it prior to r4070:

--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -170,10 +170,12 @@ void CALLBACK GSsetGameCRC(int crc, int gameoptions);
 // controls frame skipping in the GS, if this routine isn't present, frame skipping won't be done
 void CALLBACK GSsetFrameSkip(int frameskip);
 
-// if start is 1, starts recording spu2 data, else stops
+// Starts recording GS frame data
 // returns a non zero value if successful
-// for now, pData is not used
-std::wstring* CALLBACK GSsetupRecording(int start);
+int CALLBACK GSsetupRecording(std::wstring& filename);
+
+// Stops recording GS frame data
+void CALLBACK GSendRecording();
 
 void CALLBACK GSreset();
 //deprecated: GSgetTitleInfo was used in PCSX2 but no plugin supported it prior to r4070:
@@ -267,7 +269,8 @@ typedef void(CALLBACK *_GSsetGameCRC)(int, int);
 typedef void(CALLBACK *_GSsetFrameSkip)(int frameskip);
 typedef void(CALLBACK *_GSsetVsync)(int enabled);
 typedef void(CALLBACK *_GSsetExclusive)(int isExclusive);
-typedef std::wstring*(CALLBACK *_GSsetupRecording)(int);
+typedef int(CALLBACK* _GSsetupRecording)(std::wstring&);
+typedef void(CALLBACK* _GSendRecording)();
 typedef void(CALLBACK *_GSreset)();
 typedef void(CALLBACK *_GSwriteCSR)(u32 value);
 typedef bool(CALLBACK *_GSmakeSnapshot)(const char *path);
@@ -316,6 +319,7 @@ extern _GSsetGameCRC GSsetGameCRC;
 extern _GSsetFrameSkip GSsetFrameSkip;
 extern _GSsetVsync GSsetVsync;
 extern _GSsetupRecording GSsetupRecording;
+extern _GSendRecording GSendRecording;
 extern _GSreset GSreset;
 extern _GSwriteCSR GSwriteCSR;
 #endif

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -174,6 +174,7 @@ _GSsetFrameSkip		GSsetFrameSkip;
 _GSsetVsync			GSsetVsync;
 _GSsetExclusive		GSsetExclusive;
 _GSsetupRecording	GSsetupRecording;
+_GSendRecording		GSendRecording;
 _GSreset			GSreset;
 _GSwriteCSR			GSwriteCSR;
 #endif
@@ -334,6 +335,7 @@ static const LegacyApi_OptMethod s_MethMessOpt_GS[] =
 	{	"GSopen2",			(vMeth**)&GSopen2			},
 	{	"GSreset",			(vMeth**)&GSreset			},
 	{	"GSsetupRecording",	(vMeth**)&GSsetupRecording	},
+	{	"GSendRecording",	(vMeth**)&GSendRecording	},
 	{	"GSmakeSnapshot2",	(vMeth**)&GSmakeSnapshot2	},
 	{	"GSgifSoftReset",	(vMeth**)&GSgifSoftReset	},
 	{	"GSreadFIFO",		(vMeth**)&GSreadFIFO		},

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -82,6 +82,8 @@ private:
 	bool switchToReplay = false;
 	// Used to stop recording frames from incrementing during a reset
 	bool frameLock = false;
+	bool IsFinishedReplaying() const;
+	void EndVideoCapture() const;
 };
 
 extern InputRecordingControls g_InputRecordingControls;

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -682,7 +682,7 @@ extern SndOutModule* mods[];
 
 extern bool WavRecordEnabled;
 
-extern void RecordStart(const std::string* filename);
+extern int RecordStart(const std::string* filename);
 extern void RecordStop();
 extern void RecordWrite(const StereoOut16& sample);
 

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -682,7 +682,7 @@ extern SndOutModule* mods[];
 
 extern bool WavRecordEnabled;
 
-extern void RecordStart(std::wstring* filename);
+extern void RecordStart(const std::wstring* filename);
 extern void RecordStop();
 extern void RecordWrite(const StereoOut16& sample);
 

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -682,7 +682,7 @@ extern SndOutModule* mods[];
 
 extern bool WavRecordEnabled;
 
-extern void RecordStart(const std::wstring* filename);
+extern void RecordStart(const std::string* filename);
 extern void RecordStop();
 extern void RecordWrite(const StereoOut16& sample);
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -110,10 +110,8 @@ bool WavRecordEnabled = false;
 static WavOutFile* m_wavrecord = nullptr;
 static Mutex WavRecordMutex;
 
-void RecordStart(const std::string* filename)
+int RecordStart(const std::string* filename)
 {
-	WavRecordEnabled = false;
-
 	try
 	{
 		ScopedLock lock(WavRecordMutex);
@@ -123,6 +121,7 @@ void RecordStart(const std::string* filename)
 		else
 			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
 		WavRecordEnabled = true;
+		return 1;
 	}
 	catch (std::runtime_error&)
 	{
@@ -131,6 +130,7 @@ void RecordStart(const std::string* filename)
 			SysMessage("SPU2-X couldn't open file for recording: %s.\nWavfile capture disabled.", filename->c_str());
 		else
 			SysMessage("SPU2-X couldn't open file for recording: audio_recording.wav.\nWavfile capture disabled.");
+		return 0;
 	}
 }
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -118,20 +118,19 @@ void RecordStart(std::wstring* filename)
 	{
 		ScopedLock lock(WavRecordMutex);
 		safe_delete(m_wavrecord);
-#ifdef _WIN32
 		if (filename)
 			m_wavrecord = new WavOutFile((*filename) + "wav", 48000, 16, 2);
 		else
 			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
-#elif defined(__unix__)
-		m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
-#endif
 		WavRecordEnabled = true;
 	}
 	catch (std::runtime_error&)
 	{
 		m_wavrecord = nullptr; // not needed, but what the heck. :)
-		SysMessage("SPU2 couldn't open file for recording: %s.\nRecording to wavfile disabled.", "audio_recording.wav");
+		if (filename)
+			SysMessage("SPU2-X couldn't open file for recording: %swav.\nRecording to wavfile disabled.", filename->c_str());
+		else
+			SysMessage("SPU2-X couldn't open file for recording: audio_recording.wav.\nRecording to wavfile disabled.");
 	}
 }
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -110,7 +110,7 @@ bool WavRecordEnabled = false;
 static WavOutFile* m_wavrecord = nullptr;
 static Mutex WavRecordMutex;
 
-void RecordStart(std::wstring* filename)
+void RecordStart(const std::wstring* filename)
 {
 	WavRecordEnabled = false;
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -110,7 +110,7 @@ bool WavRecordEnabled = false;
 static WavOutFile* m_wavrecord = nullptr;
 static Mutex WavRecordMutex;
 
-void RecordStart(const std::wstring* filename)
+void RecordStart(const std::string* filename)
 {
 	WavRecordEnabled = false;
 
@@ -119,7 +119,7 @@ void RecordStart(const std::wstring* filename)
 		ScopedLock lock(WavRecordMutex);
 		safe_delete(m_wavrecord);
 		if (filename)
-			m_wavrecord = new WavOutFile((*filename) + "wav", 48000, 16, 2);
+			m_wavrecord = new WavOutFile(filename->c_str(), 48000, 16, 2);
 		else
 			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
 		WavRecordEnabled = true;
@@ -128,9 +128,9 @@ void RecordStart(const std::wstring* filename)
 	{
 		m_wavrecord = nullptr; // not needed, but what the heck. :)
 		if (filename)
-			SysMessage("SPU2-X couldn't open file for recording: %swav.\nRecording to wavfile disabled.", filename->c_str());
+			SysMessage("SPU2-X couldn't open file for recording: %s.\nWavfile capture disabled.", filename->c_str());
 		else
-			SysMessage("SPU2-X couldn't open file for recording: audio_recording.wav.\nRecording to wavfile disabled.");
+			SysMessage("SPU2-X couldn't open file for recording: audio_recording.wav.\nWavfile capture disabled.");
 	}
 }
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -588,17 +588,16 @@ void SPU2write(u32 rmem, u16 value)
 	}
 }
 
-// if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
-// for now, pData is not used
-int SPU2setupRecording(int start, std::string* filename)
+int SPU2setupRecording(const std::string* filename)
 {
-	if (start == 0)
-		RecordStop();
-	else if (start == 1)
-		RecordStart(filename);
+	return RecordStart(filename);
+}
 
-	return 0;
+void SPU2endRecording()
+{
+	if (WavRecordEnabled)
+		RecordStop();
 }
 
 s32 SPU2freeze(int mode, freezeData* data)

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -591,7 +591,7 @@ void SPU2write(u32 rmem, u16 value)
 // if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
 // for now, pData is not used
-int SPU2setupRecording(int start, std::wstring* filename)
+int SPU2setupRecording(int start, std::string* filename)
 {
 	if (start == 0)
 		RecordStop();

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -36,7 +36,7 @@ u16 SPU2read(u32 mem);
 // if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
 // for now, pData is not used
-int SPU2setupRecording(int start, std::wstring* filename);
+int SPU2setupRecording(int start, std::string* filename);
 
 void SPU2setClockPtr(u32* ptr);
 

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -33,10 +33,9 @@ void SPU2write(u32 mem, u16 value);
 u16 SPU2read(u32 mem);
 
 // extended funcs
-// if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
-// for now, pData is not used
-int SPU2setupRecording(int start, std::string* filename);
+int SPU2setupRecording(const std::string* filename);
+void SPU2endRecording();
 
 void SPU2setClockPtr(u32* ptr);
 

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -469,7 +469,7 @@ namespace Implementations
 			if (GSsetupRecording)
 			{
 				// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens.
-				std::wstring filename;
+				std::string filename;
 				if (GSsetupRecording(filename))
 					SPU2setupRecording(true, &filename);
 				else

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -471,18 +471,15 @@ namespace Implementations
 				// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens.
 				std::string filename;
 				if (GSsetupRecording(filename))
-					SPU2setupRecording(true, &filename);
-				else
-				{
-					// recording dialog canceled by the user. align our state
+					// Note: Add a dialog box here (or in the function) that prompts the user to answer whether a failed
+					// SPU2 recording setup should still lead to the visuals being recorded.
+					SPU2setupRecording(&filename);
+				else // recording dialog canceled by the user. align our state
 					g_Pcsx2Recording = false;
-				}
 			}
+			// the GS doesn't support recording
 			else
-			{
-				// the GS doesn't support recording
-				SPU2setupRecording(true, nullptr);
-			}
+				g_Pcsx2Recording = SPU2setupRecording(nullptr);
 
 			if (GetMainFramePtr() && needsMainFrameEnable)
 				GetMainFramePtr()->Enable();
@@ -492,7 +489,7 @@ namespace Implementations
 			// stop recording
 			if (GSendRecording)
 				GSendRecording();
-			SPU2setupRecording(false, nullptr);
+			SPU2endRecording();
 		}
 	}
 

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -469,12 +469,9 @@ namespace Implementations
 			if (GSsetupRecording)
 			{
 				// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens.
-				std::wstring* filename = nullptr;
-				if (filename = GSsetupRecording(true))
-				{
-					SPU2setupRecording(true, filename);
-					delete filename;
-				}
+				std::wstring filename;
+				if (GSsetupRecording(filename))
+					SPU2setupRecording(true, &filename);
 				else
 				{
 					// recording dialog canceled by the user. align our state
@@ -484,7 +481,7 @@ namespace Implementations
 			else
 			{
 				// the GS doesn't support recording
-				SPU2setupRecording(true, NULL);
+				SPU2setupRecording(true, nullptr);
 			}
 
 			if (GetMainFramePtr() && needsMainFrameEnable)
@@ -493,9 +490,9 @@ namespace Implementations
 		else
 		{
 			// stop recording
-			if (GSsetupRecording)
-				GSsetupRecording(false);
-			SPU2setupRecording(false, NULL);
+			if (GSendRecording)
+				GSendRecording();
+			SPU2setupRecording(false, nullptr);
 		}
 	}
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -279,8 +279,8 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Debug_Open_Click, this, MenuId_Debug_Open);
 
 	// Capture
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Record_Click, this, MenuId_Capture_Video_Record);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Stop_Click, this, MenuId_Capture_Video_Stop);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click, this, MenuId_Capture_Video_Record);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click, this, MenuId_Capture_Video_Stop);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click, this, MenuId_Capture_Screenshot_Screenshot);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click, this, MenuId_Capture_Screenshot_Screenshot_As);
 
@@ -544,6 +544,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 
 {
 	m_RestartEmuOnDelete = false;
+	m_capturingVideo = false;
 
 	for (int i = 0; i < PluginId_Count; ++i)
 		m_PluginMenuPacks[i].Populate((PluginsEnum_t)i);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -136,7 +136,6 @@ protected:
 #endif
 
 	PerPluginMenuInfo m_PluginMenuPacks[PluginId_Count];
-
 	bool m_capturingVideo;
 
 	virtual void DispatchEvent(const PluginEventType& plugin_evt);
@@ -172,6 +171,8 @@ public:
 	void AppendKeycodeNamesToMenuOptions();
 	void UpdateStatusBar();
 	void VideoCaptureToggle();
+	bool IsCapturing() const noexcept { return m_capturingVideo; }
+
 #ifndef DISABLE_RECORDING
 	void initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable = true);
 	void enableRecordingMenuItem(MenuIdentifiers menuId, bool enable);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -171,6 +171,7 @@ public:
 	void CommitPreset_noTrigger();
 	void AppendKeycodeNamesToMenuOptions();
 	void UpdateStatusBar();
+	void VideoCaptureToggle();
 #ifndef DISABLE_RECORDING
 	void initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable = true);
 	void enableRecordingMenuItem(MenuIdentifiers menuId, bool enable);
@@ -247,9 +248,7 @@ protected:
 	void Menu_Wiki(wxCommandEvent& event);
 	void Menu_ShowAboutBox(wxCommandEvent& event);
 
-	void Menu_Capture_Video_Record_Click(wxCommandEvent& event);
-	void Menu_Capture_Video_Stop_Click(wxCommandEvent& event);
-	void VideoCaptureUpdate();
+	void Menu_Capture_Video_ToggleCapture_Click(wxCommandEvent& event);
 	void Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& event);
 	void Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& event);
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -883,7 +883,7 @@ void MainEmuFrame::VideoCaptureToggle()
 		if (GSsetupRecording)
 		{
 			// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens
-			std::wstring filename;
+			std::string filename;
 			if (GSsetupRecording(filename))
 			{
 				SPU2setupRecording(true, &filename);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -886,7 +886,9 @@ void MainEmuFrame::VideoCaptureToggle()
 			std::string filename;
 			if (GSsetupRecording(filename))
 			{
-				SPU2setupRecording(true, &filename);
+				// Note: Add a dialog box here (or in the function) that prompts the user to answer whether a failed
+				// SPU2 recording setup should still lead to the visuals being recorded.
+				SPU2setupRecording(&filename);
 				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
 				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
 			}
@@ -899,9 +901,13 @@ void MainEmuFrame::VideoCaptureToggle()
 		else
 		{
 			// the GS doesn't support recording.
-			SPU2setupRecording(true, nullptr);
-			m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
-			m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
+			if (SPU2setupRecording(nullptr))
+			{
+				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
+				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
+			}
+			else
+				m_capturingVideo = false;
 		}
 
 		if (needsMainFrameEnable)
@@ -912,7 +918,7 @@ void MainEmuFrame::VideoCaptureToggle()
 		// stop recording
 		if (GSendRecording)
 			GSendRecording();
-		SPU2setupRecording(false, nullptr);
+		SPU2endRecording();
 		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, true);
 		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, false);
 	}

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -742,6 +742,8 @@ void MainEmuFrame::Menu_SuspendResume_Click(wxCommandEvent& event)
 
 void MainEmuFrame::Menu_SysShutdown_Click(wxCommandEvent& event)
 {
+	if (m_capturingVideo)
+		VideoCaptureToggle();
 	UI_DisableSysShutdown();
 	Console.SetTitle("PCSX2 Program Log");
 	CoreThread.Reset();

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -856,27 +856,17 @@ void MainEmuFrame::Menu_ShowAboutBox(wxCommandEvent& event)
 	AppOpenDialog<AboutBoxDialog>(this);
 }
 
-void MainEmuFrame::Menu_Capture_Video_Record_Click(wxCommandEvent& event)
+void MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click(wxCommandEvent& event)
 {
 	ScopedCoreThreadPause paused_core;
 	paused_core.AllowResume();
-
-	m_capturingVideo = true;
-	VideoCaptureUpdate();
+	VideoCaptureToggle();
 }
 
-void MainEmuFrame::Menu_Capture_Video_Stop_Click(wxCommandEvent& event)
-{
-	ScopedCoreThreadPause paused_core;
-	paused_core.AllowResume();
-
-	m_capturingVideo = false;
-	VideoCaptureUpdate();
-}
-
-void MainEmuFrame::VideoCaptureUpdate()
+void MainEmuFrame::VideoCaptureToggle()
 {
 	GetMTGS().WaitGS(); // make sure GS is in sync with the audio stream when we start.
+	m_capturingVideo = !m_capturingVideo;
 	if (m_capturingVideo)
 	{
 		// start recording
@@ -884,20 +874,22 @@ void MainEmuFrame::VideoCaptureUpdate()
 		// make the recording setup dialog[s] pseudo-modal also for the main PCSX2 window
 		// (the GSdx dialog is already properly modal for the GS window)
 		bool needsMainFrameEnable = false;
-		if (GetMainFramePtr() && GetMainFramePtr()->IsEnabled())
+		if (IsEnabled())
 		{
 			needsMainFrameEnable = true;
-			GetMainFramePtr()->Disable();
+			Disable();
 		}
 
 		if (GSsetupRecording)
 		{
 			// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens
 			std::wstring* filename = nullptr;
-			if (filename = GSsetupRecording(m_capturingVideo))
+			if (filename = GSsetupRecording(true))
 			{
-				SPU2setupRecording(m_capturingVideo, filename);
+				SPU2setupRecording(true, filename);
 				delete filename;
+				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
+				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
 			}
 			else
 			{
@@ -908,29 +900,22 @@ void MainEmuFrame::VideoCaptureUpdate()
 		else
 		{
 			// the GS doesn't support recording.
-			SPU2setupRecording(m_capturingVideo, nullptr);
+			SPU2setupRecording(true, nullptr);
+			m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
+			m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
 		}
 
-		if (GetMainFramePtr() && needsMainFrameEnable)
-			GetMainFramePtr()->Enable();
+		if (needsMainFrameEnable)
+			Enable();
 	}
 	else
 	{
 		// stop recording
 		if (GSsetupRecording)
-			GSsetupRecording(m_capturingVideo);
-		SPU2setupRecording(m_capturingVideo, nullptr);
-	}
-
-	if (m_capturingVideo)
-	{
-		m_submenuVideoCapture.FindItem(MenuId_Capture_Video_Record)->Enable(false);
-		m_submenuVideoCapture.FindItem(MenuId_Capture_Video_Stop)->Enable(true);
-	}
-	else
-	{
-		m_submenuVideoCapture.FindItem(MenuId_Capture_Video_Record)->Enable(true);
-		m_submenuVideoCapture.FindItem(MenuId_Capture_Video_Stop)->Enable(false);
+			GSsetupRecording(false);
+		SPU2setupRecording(false, nullptr);
+		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, true);
+		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, false);
 	}
 }
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -883,11 +883,10 @@ void MainEmuFrame::VideoCaptureToggle()
 		if (GSsetupRecording)
 		{
 			// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens
-			std::wstring* filename = nullptr;
-			if (filename = GSsetupRecording(true))
+			std::wstring filename;
+			if (GSsetupRecording(filename))
 			{
-				SPU2setupRecording(true, filename);
-				delete filename;
+				SPU2setupRecording(true, &filename);
 				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
 				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
 			}
@@ -911,8 +910,8 @@ void MainEmuFrame::VideoCaptureToggle()
 	else
 	{
 		// stop recording
-		if (GSsetupRecording)
-			GSsetupRecording(false);
+		if (GSendRecording)
+			GSendRecording();
 		SPU2setupRecording(false, nullptr);
 		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, true);
 		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, false);

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -819,7 +819,7 @@ void pt(const char* str){
 	printf("%02i:%02i:%02i%s", current->tm_hour, current->tm_min, current->tm_sec, str);
 }
 
-EXPORT_C_(int) GSsetupRecording(std::wstring& filename)
+EXPORT_C_(int) GSsetupRecording(std::string& filename)
 {
 	if (s_gs == NULL) {
 		printf("GSdx: no s_gs for recording\n");

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -819,41 +819,36 @@ void pt(const char* str){
 	printf("%02i:%02i:%02i%s", current->tm_hour, current->tm_min, current->tm_sec, str);
 }
 
-EXPORT_C_(std::wstring*) GSsetupRecording(int start)
+EXPORT_C_(int) GSsetupRecording(std::wstring& filename)
 {
 	if (s_gs == NULL) {
 		printf("GSdx: no s_gs for recording\n");
-		return nullptr;
+		return 0;
 	}
 #if defined(__unix__) || defined(__APPLE__)
 	if (!theApp.GetConfigB("capture_enabled")) {
 		printf("GSdx: Recording is disabled\n");
-		return nullptr;
+		return 0;
 	}
 #endif
-	std::wstring* filename = nullptr;
-	if(start & 1)
+	printf("GSdx: Recording start command\n");
+	if (s_gs->BeginCapture(filename))
 	{
-		printf("GSdx: Recording start command\n");
-		filename = s_gs->BeginCapture();
-		if (filename)
-		{
-			pt(" - Capture started\n");
-		}
-		else
-		{
-			pt(" - Capture cancelled\n");
-			return nullptr;
-		}
+		pt(" - Capture started\n");
+		return 1;
 	}
 	else
 	{
-		printf("GSdx: Recording end command\n");
-		s_gs->EndCapture();
-		pt(" - Capture ended\n");
+		pt(" - Capture cancelled\n");
+		return 0;
 	}
+}
 
-	return filename;
+EXPORT_C_(void) GSendRecording()
+{
+	printf("GSdx: Recording end command\n");
+	s_gs->EndCapture();
+	pt(" - Capture ended\n");
 }
 
 EXPORT_C GSsetGameCRC(uint32 crc, int options)

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -404,7 +404,7 @@ GSCapture::~GSCapture()
 	EndCapture();
 }
 
-int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::wstring& filename)
+int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::string& filename)
 {
 	printf("Recommended resolution: %d x %d, DAR for muxing: %.4f\n", recommendedResolution.x, recommendedResolution.y, aspect);
 	std::lock_guard<std::recursive_mutex> lock(m_lock);
@@ -442,7 +442,7 @@ int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float a
 		}
 	}
 
-	std::wstring fn{dlg.m_filename.begin(), dlg.m_filename.end()};
+	;
 
 	m_size.x = (dlg.m_width + 7) & ~7;
 	m_size.y = (dlg.m_height + 7) & ~7;
@@ -456,7 +456,9 @@ int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float a
 	if(FAILED(hr = m_graph.CoCreateInstance(CLSID_FilterGraph))
 	|| FAILED(hr = cgb.CoCreateInstance(CLSID_CaptureGraphBuilder2))
 	|| FAILED(hr = cgb->SetFiltergraph(m_graph))
-	|| FAILED(hr = cgb->SetOutputFileName(&MEDIASUBTYPE_Avi, fn.c_str(), &mux, NULL)))
+	|| FAILED(hr = cgb->SetOutputFileName(&MEDIASUBTYPE_Avi,
+											std::wstring(dlg.m_filename.begin(), dlg.m_filename.end()).c_str(),
+											&mux, NULL)))
 	{
 		return 0;
 	}
@@ -509,7 +511,7 @@ int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float a
 	CComQIPtr<IGSSource>(m_src)->DeliverNewSegment();
 
 	m_capturing = true;
-	filename = std::wstring(dlg.m_filename.begin(), dlg.m_filename.end() - 3);
+	filename = dlg.m_filename.erase(dlg.m_filename.length() - 3, 3) + "wav";
 	return 1;
 #elif defined(__unix__)
 	// Note I think it doesn't support multiple depth creation
@@ -526,8 +528,7 @@ int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float a
 	}
 
 	m_capturing = true;
-	std::string fn = m_out_dir + "/audio_recording.";
-	filename = std::wstring(fn.begin(), fn.end());
+	filename = m_out_dir + "/audio_recording.wav";
 	return 1;
 #endif
 }

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -568,6 +568,9 @@ bool GSCapture::DeliverFrame(const void* bits, int pitch, bool rgba)
 
 bool GSCapture::EndCapture()
 {
+	if (!m_capturing)
+		return false;
+
 	std::lock_guard<std::recursive_mutex> lock(m_lock);
 
 #ifdef _WIN32

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -525,7 +525,8 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	}
 
 	m_capturing = true;
-	return new std::wstring();
+	std::string fn = m_out_dir + "/audio_recording.";
+	return new std::wstring(fn.begin(), fn.end());
 #endif
 }
 

--- a/plugins/GSdx/GSCapture.h
+++ b/plugins/GSdx/GSCapture.h
@@ -53,7 +53,7 @@ public:
 	GSCapture();
 	virtual ~GSCapture();
 
-	int BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::wstring& filename);
+	int BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::string& filename);
 	bool DeliverFrame(const void* bits, int pitch, bool rgba);
 	bool EndCapture();
 

--- a/plugins/GSdx/GSCapture.h
+++ b/plugins/GSdx/GSCapture.h
@@ -53,7 +53,7 @@ public:
 	GSCapture();
 	virtual ~GSCapture();
 
-	std::wstring* BeginCapture(float fps, GSVector2i recommendedResolution, float aspect);
+	int BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::wstring& filename);
 	bool DeliverFrame(const void* bits, int pitch, bool rgba);
 	bool EndCapture();
 

--- a/plugins/GSdx/GSdx.def
+++ b/plugins/GSdx/GSdx.def
@@ -34,6 +34,7 @@ EXPORTS
 	GSreadFIFO2
 	GSirqCallback
 	GSsetupRecording		
+	GSendRecording
 	GSsetGameCRC		
 	GSsetFrameSkip
 	GSsetVsync

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -533,12 +533,12 @@ bool GSRenderer::MakeSnapshot(const std::string& path)
 	return true;
 }
 
-std::wstring* GSRenderer::BeginCapture()
+int GSRenderer::BeginCapture(std::wstring& filename)
 {
 	GSVector4i disp = m_wnd->GetClientRect().fit(m_aspectratio);
 	float aspect = (float)disp.width() / std::max(1, disp.height());
 
-	return m_capture.BeginCapture(GetTvRefreshRate(), GetInternalResolution(), aspect);
+	return m_capture.BeginCapture(GetTvRefreshRate(), GetInternalResolution(), aspect, filename);
 }
 
 void GSRenderer::EndCapture()

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -533,7 +533,7 @@ bool GSRenderer::MakeSnapshot(const std::string& path)
 	return true;
 }
 
-int GSRenderer::BeginCapture(std::wstring& filename)
+int GSRenderer::BeginCapture(std::string& filename)
 {
 	GSVector4i disp = m_wnd->GetClientRect().fit(m_aspectratio);
 	float aspect = (float)disp.width() / std::max(1, disp.height());

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -72,7 +72,7 @@ public:
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(int vsync);
 
-	virtual int BeginCapture(std::wstring& filename);
+	virtual int BeginCapture(std::string& filename);
 	virtual void EndCapture();
 
 	void PurgePool();

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -72,7 +72,7 @@ public:
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(int vsync);
 
-	virtual std::wstring* BeginCapture();
+	virtual int BeginCapture(std::wstring& filename);
 	virtual void EndCapture();
 
 	void PurgePool();


### PR DESCRIPTION
Video capture will now end if an input recording reaches its final frame in Replay mode.
Additionally, should fix some oversights with filenames transferring to Spu2, especially on Linux.
Directly related to xTVaser#14
Possibly fixes #3729