### PR TITLE
gsdx-ogl: Swap DATE_GL42 with DATE_GL45 on sw blending draw.

### DIFF
--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -518,7 +518,8 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 	// that write the bad alpha value. Sw blending will force the draw to run primitive by primitive
 	// (therefore primitiveID will be constant to 1).
 	// Switch DATE_GL42 with DATE_GL45 in such cases to ensure accuracy.
-	if (sw_blending && DATE_GL42) {
+	// No mix of COLCLIP + sw blend + DATE_GL42, neither sw fbmask + DATE_GL42.
+	if ((((accumulation_blend || blend_non_recursive) && m_env.COLCLAMP.CLAMP == 0) || sw_blending) && DATE_GL42) {
 		GL_PERF("DATE: Swap DATE_GL42 with DATE_GL45");
 		m_require_full_barrier = true;
 		DATE_GL42 = false;
@@ -553,12 +554,6 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 			m_ps_sel.hdr = 1;
 		}
 	}
-
-	// Seriously don't expect me to support this kind of crazyness.
-	// No mix of COLCLIP + accumulation_blend + DATE GL42
-	// Neither fbmask and GL42
-	ASSERT(!(m_ps_sel.hdr && DATE_GL42));
-	ASSERT(!(m_ps_sel.fbmask && DATE_GL42));
 
 	// For stat to optimize accurate option
 #if 0

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.h
@@ -73,7 +73,7 @@ class GSRendererOGL final : public GSRendererHW
 		inline void SetupIA(const float& sx, const float& sy);
 		inline void EmulateTextureShuffleAndFbmask();
 		inline void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
-		inline void EmulateBlending(bool DATE_GL42);
+		inline void EmulateBlending(bool& DATE_GL42, bool& DATE_GL45);
 		inline void EmulateTextureSampler(const GSTextureCache::Source* tex);
 		inline void EmulateAtst(const int pass, const GSTextureCache::Source* tex);
 		inline void EmulateZbuffer();


### PR DESCRIPTION
It will allow to run sw blending with DATE draw which was previously
DATE_GL42 by default.

Fix #3738 