### PR TITLE
recording: Don't reload cheats/settings on every frame-advance

### DIFF
--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -121,6 +121,11 @@ void InputRecordingControls::FrameAdvance()
 	Resume();
 }
 
+bool InputRecordingControls::IsFrameAdvancing()
+{
+	return frameAdvancing;
+}
+
 bool InputRecordingControls::IsPaused()
 {
 	return (emulationCurrentlyPaused && CoreThread.IsOpen() && CoreThread.IsPaused());

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -39,6 +39,8 @@ public:
 	
 	// Resume emulation (incase the emulation is currently paused) and pause after a single frame has passed
 	void FrameAdvance();
+	// Returns true if emulation is currently set up to frame advance.
+	bool IsFrameAdvancing();
 	// Returns true if the input recording has been paused, which can occur:
 	// - After a single frame has passed after InputRecordingControls::FrameAdvance
 	// - Explicitly paused via an InputRecordingControls function 
@@ -51,7 +53,7 @@ public:
 	void Resume();
 	void SetFrameCountTracker(u32 newFrame);
 	// Sets frameAdvancing variable to false
-	// Used to restrict a frameAdvaceTravker value from transferring between recordings
+	// Used to restrict a frameAdvanceTracker value from transferring between recordings
 	void DisableFrameAdvance();
 	// Alternates emulation between a paused and unpaused state
 	void TogglePause();

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -34,6 +34,10 @@
 #include "R5900Exceptions.h"
 #include "Sio.h"
 
+#ifndef DISABLE_RECORDING
+#include "Recording/InputRecordingControls.h"
+#endif
+
 __aligned16 SysMtgsThread mtgsThread;
 __aligned16 AppCoreThread CoreThread;
 
@@ -208,8 +212,16 @@ void Pcsx2App::SysApplySettings()
 
 void AppCoreThread::OnResumeReady()
 {
+#ifndef DISABLE_RECORDING
+	if (!g_InputRecordingControls.IsFrameAdvancing())
+	{
+		wxGetApp().SysApplySettings();
+		wxGetApp().PostMethod(AppSaveSettings);
+	}
+#else
 	wxGetApp().SysApplySettings();
 	wxGetApp().PostMethod(AppSaveSettings);
+#endif
 
 	sApp.PostAppMethod(&Pcsx2App::leaveDebugMode);
 	_parent::OnResumeReady();


### PR DESCRIPTION
I believe the intention of the cheats/settings reloading is for the conventional pause/resume from the MainFrame's menu.

However, with input recording, nothing ever actually gets closed so I doubt the settings need to be reloaded.  These changes stop that from happening on every individual frame advance.  

However, in case im wrong and it is needed, they do get re-applied when emulation is fully resumed (Shift+P by default).  This just dramatically reduces the console spam.

Now:
![image](https://user-images.githubusercontent.com/13153231/94228790-c67b3180-fecb-11ea-95a8-42e11bb8bf15.png)

Before:
![image](https://user-images.githubusercontent.com/13153231/94228721-9af84700-fecb-11ea-961d-aeb068d63edc.png)


fyi - @sonicfind 