### PR TITLE
IPC: fix windows warnings

### DIFF
--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -44,8 +44,7 @@ SocketIPC::SocketIPC(SysCoreThread* vm)
 {
 #ifdef _WIN32
 	WSADATA wsa;
-	SOCKET new_socket;
-	struct sockaddr_in server, client;
+	struct sockaddr_in server;
 
 
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)


### PR DESCRIPTION
This fixes windows only warnings about the IPC code that I hadn't picked up on until now.