### PR TITLE
cmake: Add missing sonames.

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -690,10 +690,10 @@ set(pcsx2FinalLibs
 )
 
 if(BUILTIN_GS)
-    set(pcsx2FinalLibs "${pcsx2FinalLibs} GSdx")
+    set(pcsx2FinalLibs "${pcsx2FinalLibs} GSdx-1.2.0")
 endif()
 if(BUILTIN_PAD)
-    set(pcsx2FinalLibs "${pcsx2FinalLibs} onepad-1.2.0")
+    set(pcsx2FinalLibs "${pcsx2FinalLibs} onepad-2.0.0")
 endif()
 if(BUILTIN_SPU2)
     set(pcsx2FinalLibs "${pcsx2FinalLibs} spu2x-2.0.0")

--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -5,9 +5,8 @@ if(NOT TOP_CMAKE_WAS_SOURCED)
     It is advice to delete all wrongly generated cmake stuff => CMakeFiles & CMakeCache.txt")
 endif()
 
-
 # plugin name (no version number to ease future version bump and bisect)
-set(Output GSdx)
+set(Output GSdx-1.2.0)
 
 set(CommonFlags
     -fno-operator-names # because Xbyak uses and()/xor()/or()/not() function
@@ -42,7 +41,6 @@ endif()
 if(XDG_STD)
     set(GSdxFinalFlags ${GSdxFinalFlags} -DXDG_STD)
 endif()
-
 
 set(GSdxSources
     GS.cpp

--- a/plugins/onepad/CMakeLists.txt
+++ b/plugins/onepad/CMakeLists.txt
@@ -39,7 +39,7 @@ set(onepadGuiResources
     )
 
 # plugin name
-set(Output onepad)
+set(Output onepad-2.0.0)
 
 set(onepadFinalFlags
     -fvisibility=hidden

--- a/plugins/onepad_legacy/CMakeLists.txt
+++ b/plugins/onepad_legacy/CMakeLists.txt
@@ -40,7 +40,7 @@ set(onepadGuiResources
     )
 
 # plugin name
-set(Output onepad-legacy)
+set(Output onepad-legacy-1.3.0)
 
 set(onepadFinalFlags
     -fvisibility=hidden


### PR DESCRIPTION
Adds missing library sonames to the installed filename for GSdx, onepad and onepad-legacy.