### PR TITLE
Recording: Upgrade to Input Recording file V2 (Multitap support+) and other Input Recording Improvements

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -236,6 +236,8 @@ void CALLBACK PADupdate(int pad);
 // before the pad saw them. So the gui needs to send them back to the pad.
 void CALLBACK PADWriteEvent(keyEvent &evt);
 
+void CALLBACK PADSetupInputRecording(bool start, char padsRequested);
+
 // extended funcs
 
 void CALLBACK PADgsDriverInfo(GSdriverInfo *info);
@@ -374,6 +376,7 @@ typedef void(CALLBACK *_PADgsDriverInfo)(GSdriverInfo *info);
 typedef s32(CALLBACK *_PADsetSlot)(u8 port, u8 slot);
 typedef s32(CALLBACK *_PADqueryMtap)(u8 port);
 typedef void(CALLBACK *_PADWriteEvent)(keyEvent &evt);
+typedef void(CALLBACK *_PADSetupInputRecording)(bool start, char padsRequested);
 
 // DEV9
 // NOTE: The read/write functions CANNOT use XMM/MMX regs
@@ -453,6 +456,7 @@ extern _PADgsDriverInfo PADgsDriverInfo;
 extern _PADsetSlot PADsetSlot;
 extern _PADqueryMtap PADqueryMtap;
 extern _PADWriteEvent PADWriteEvent;
+extern _PADSetupInputRecording PADSetupInputRecording;
 #endif
 
 // DEV9

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -259,16 +259,17 @@ static void CALLBACK GS_Legacy_GSreadFIFO2(u64* pMem, int qwc) {
 
 // PAD
 #ifndef BUILTIN_PAD_PLUGIN
-_PADinit           PADinit;
-_PADopen           PADopen;
-_PADstartPoll      PADstartPoll;
-_PADpoll           PADpoll;
-_PADquery          PADquery;
-_PADupdate         PADupdate;
-_PADkeyEvent       PADkeyEvent;
-_PADsetSlot        PADsetSlot;
-_PADqueryMtap      PADqueryMtap;
-_PADWriteEvent	   PADWriteEvent;
+_PADinit                PADinit;
+_PADopen                PADopen;
+_PADstartPoll           PADstartPoll;
+_PADpoll                PADpoll;
+_PADquery               PADquery;
+_PADupdate              PADupdate;
+_PADkeyEvent            PADkeyEvent;
+_PADsetSlot             PADsetSlot;
+_PADqueryMtap           PADqueryMtap;
+_PADWriteEvent          PADWriteEvent;
+_PADSetupInputRecording PADSetupInputRecording;
 #endif
 
 static void PAD_update( u32 padslot ) { }
@@ -405,8 +406,11 @@ static const LegacyApi_ReqMethod s_MethMessReq_PAD[] =
 
 static const LegacyApi_OptMethod s_MethMessOpt_PAD[] =
 {
-	{	"PADupdate",		(vMeth**)&PADupdate },
-	{   "PADWriteEvent",	(vMeth**)&PADWriteEvent },
+	{	"PADupdate",				(vMeth**)&PADupdate },
+	{   "PADWriteEvent",			(vMeth**)&PADWriteEvent },
+#ifndef DISABLE_RECORDING
+	{	"PADSetupInputRecording",	(vMeth**)&PADSetupInputRecording },
+#endif
 	{ NULL },
 };
 

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -365,6 +365,27 @@ bool InputRecording::Play(wxString fileName)
 	return true;
 }
 
+bool InputRecording::GoToFirstFrame()
+{
+	if (inputRecordingData.FromSaveState())
+	{
+		if (!wxFileExists(inputRecordingData.GetFilename() + "_SaveState.p2s"))
+		{
+			recordingConLog(wxString::Format("[REC]: Could not locate savestate file at location - %s_SaveState.p2s\n",
+												inputRecordingData.GetFilename()));
+			Stop();
+			return false;
+		}
+		StateCopy_LoadFromFile(inputRecordingData.GetFilename() + "_SaveState.p2s");
+	}
+	else
+		sApp.SysExecute(g_Conf->CdvdSource);
+
+	if (IsRecording())
+		SetToReplayMode();
+	return true;
+}
+
 wxString InputRecording::resolveGameName()
 {
 	// Code loosely taken from AppCoreThread::_ApplySettings to resolve the Game Name

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -89,6 +89,8 @@ public:
 	void Stop();
 	// Initialze VirtualPad window
 	void setVirtualPadPtr(VirtualPad* ptr, int const port);
+	// Resets emulation to the beginning of a recording
+	bool GoToFirstFrame();
 
 private:
 	enum class InputRecordingMode

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -30,7 +30,7 @@ public:
 	// This is to prevent any inaccuracy issues caused by having a different
 	// internal emulation frame count than what it was at the beginning of the
 	// original recording
-	void RecordingReset();
+	void OnBoot();
 
 	// Main handler for ingesting input data and either saving it to the recording file (recording)
 	// or mutating it to the contents of the recording file (replaying)

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -39,35 +39,35 @@ public:
 	void ControllerInterrupt(const u8 data, const u8 port, const u8 slot, const u16 bufCount, u8& bufVal);
 
 	// The running frame counter for the input recording
-	s32 GetFrameCounter();
+	s32 GetFrameCounter() const noexcept;
 
-	InputRecordingFile& GetInputRecordingData();
+	InputRecordingFile& GetInputRecordingData() noexcept;
 
 	// The internal PCSX2 g_FrameCount value on the first frame of the recording
-	u32 GetStartingFrame();
+	u32 GetStartingFrame() const noexcept;
 
-	void IncrementFrameCounter();
+	void IncrementFrameCounter() noexcept;
 
 	// DEPRECATED: Slated for removal
 	// If the current frame contains controller / input data
-	bool IsInterruptFrame();
+	bool IsInterruptFrame() const noexcept;
 
 	// If there is currently an input recording being played back or actively being recorded
-	bool IsActive();
+	bool IsActive() const noexcept;
 
 	// Whether or not the recording's initial state has yet to be loaded or saved and
 	// the rest of the recording can be initialized
 	// This is not applicable to recordings from a "power-on" state
-	bool IsInitialLoad();
+	bool IsInitialLoad() const noexcept;
 
 	// If there is currently an input recording being played back
-	bool IsReplaying();
+	bool IsReplaying() const noexcept;
 
 	// If there are inputs currently being recorded to a file
-	bool IsRecording();
+	bool IsRecording() const noexcept;
 
 	// String representation of the current recording mode to be interpolated into the title
-	wxString RecordingModeTitleSegment();
+	wxString RecordingModeTitleSegment() const noexcept;
 
 	// Sets input recording to Record Mode
 	void SetToRecordMode();
@@ -79,7 +79,7 @@ public:
 	void SetFrameCounter(u32 newGFrameCount);
 
 	// Store the starting internal PCSX2 g_FrameCount value
-	void SetStartingFrame(u32 newStartingFrame);
+	void SetStartingFrame(u32 newStartingFrame) noexcept;
 
 	/// Functions called from GUI
 
@@ -102,50 +102,50 @@ private:
 		Replaying,
 	};
 
-	static const u8 NUM_PORTS = 2;
-	static const u8 NUM_SLOTS = 4;
+	static const u8 s_NUM_PORTS = 2;
+	static const u8 s_NUM_SLOTS = 4;
 
 	// 0x42 is the magic number to indicate the default controller read query
 	// See - Lilypad.cpp::PADpoll - https://github.com/PCSX2/pcsx2/blob/v1.5.0-dev/plugins/LilyPad/LilyPad.cpp#L1193
-	static const u8 READ_DATA_AND_VIBRATE_FIRST_BYTE = 0x42;
+	static const u8 s_READ_DATA_AND_VIBRATE_FIRST_BYTE = 0x42;
 	// 0x5A is always the second byte in the buffer when the normal READ_DATA_AND_VIBRATE (0x42) query is executed.
 	// See - LilyPad.cpp::PADpoll - https://github.com/PCSX2/pcsx2/blob/v1.5.0-dev/plugins/LilyPad/LilyPad.cpp#L1194
-	static const u8 READ_DATA_AND_VIBRATE_SECOND_BYTE = 0x5A;
+	static const u8 s_READ_DATA_AND_VIBRATE_SECOND_BYTE = 0x5A;
 
-	std::unique_ptr<NewRecordingFrame> newRecordingFrame;
-	std::unique_ptr<wxFileDialog> openFileDialog;
 	// DEPRECATED: Slated for removal
-	bool fInterruptFrame = false;
-	InputRecordingFile inputRecordingData;
-	bool initialLoad = false;
-	u32 startingFrame = 0;
-	s32 frameCounter = 0;
-	bool incrementRedo = false;
-	InputRecordingMode state = InputRecordingMode::NotActive;
+	bool m_fInterruptFrame = false;
+	std::unique_ptr<NewRecordingFrame> m_newRecordingFrame;
+	std::unique_ptr<wxFileDialog> m_openFileDialog;
+	InputRecordingFile m_inputRecordingData;
+	bool m_initialLoad = false;
+	u32 m_startingFrame = 0;
+	s32 m_frameCounter = 0;
+	bool m_incrementRedo = false;
+	InputRecordingMode m_state = InputRecordingMode::NotActive;
 
 	struct InputRecordingPad
 	{
 		// Controller data
-		std::unique_ptr<PadData> padData;
+		std::unique_ptr<PadData> m_padData;
 		// VirtualPad
-		std::unique_ptr<VirtualPad> virtualPad;
+		std::unique_ptr<VirtualPad> m_virtualPad;
 		// Recording Mode
-		InputRecordingMode state;
+		InputRecordingMode m_state;
 		// File seek offset
-		u8 seekOffset;
+		u8 m_seekOffset;
 		InputRecordingPad();
 		~InputRecordingPad();
-	} pads[NUM_PORTS][NUM_SLOTS];
+	} m_pads[s_NUM_PORTS][s_NUM_SLOTS];
 
-	InputRecordingPad& GetPad(const int port, const int slot) noexcept { return pads[port][slot]; }
+	InputRecordingPad& GetPad(const int port, const int slot) noexcept { return m_pads[port][slot]; }
 	void SetPads(const bool newRecording);
 
 	// Holds the multitap and fastboot settings from before loading a recording
 	struct Buffer
 	{
-		bool multitaps[NUM_PORTS] = {false, false};
+		bool multitaps[s_NUM_PORTS] = {false, false};
 		bool fastBoot = false;
-	} buffers;
+	} m_buffers;
 
 	// Resolve the name and region of the game currently loaded using the GameDB
 	// If the game cannot be found in the DB, the fallback is the ISO filename

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -207,7 +207,7 @@ void InputRecordingControls::Lock(u32 frame)
 	frameCountTracker = frame;
 	resumeEmulation = false;
 	//Ensures that g_frameCount can be used to resume emulation after a fast/full boot
-	if (!g_InputRecording.GetInputRecordingData().FromSaveState())
+	if (!g_InputRecording.GetInputRecordingData().FromSavestate())
 		g_FrameCount = frame + 1;
 }
 #endif

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -46,15 +46,15 @@ public:
 	// - Explicitly paused via an InputRecordingControls function 
 	bool IsPaused();
 	// Pause emulation at the next available Vsync
-	void Pause();
+	void Pause() noexcept;
 	// Pause emulation immediately, not waiting for the next Vsync
 	void PauseImmediately();
 	// Resume emulation when the next pcsx2 App event is handled
 	void Resume();
-	void SetFrameCountTracker(u32 newFrame);
+	void SetFrameCountTracker(const u32 newFrame) noexcept;
 	// Sets frameAdvancing variable to false
 	// Used to restrict a frameAdvanceTracker value from transferring between recordings
-	void DisableFrameAdvance();
+	void DisableFrameAdvance() noexcept;
 	// Alternates emulation between a paused and unpaused state
 	void TogglePause();
 	// Switches between recording and replaying the active input recording file
@@ -62,26 +62,26 @@ public:
 	// Enables the frame locking mechanism so that when recordings are loaded
 	// or when processing a reboot with a recording active that no frames are
 	// lost in prior emulation
-	void Lock(u32 frame);
+	void Lock(u32 frame) noexcept;
 
 private:
 	// Indicates if the input recording controls have explicitly paused emulation or not
-	bool emulationCurrentlyPaused = false;
+	bool m_emulationCurrentlyPaused = false;
 	// Indicates on the next VSync if we are frame advancing, this value
 	// and should be cleared once a single frame has passed
-	bool frameAdvancing = false;
+	bool m_frameAdvancing = false;
 	// The input recording frame that frame advancing began on
-	s32 frameAdvanceMarker = 0;
+	s32 m_frameAdvanceMarker = 0;
 	// Used to detect if the internal PCSX2 g_FrameCount has changed
-	u32 frameCountTracker = -1;
+	u32 m_frameCountTracker = -1;
 	// Indicates if we intend to call CoreThread.PauseSelf() on the current or next available vsync
-	bool pauseEmulation = false;
+	bool m_pauseEmulation = false;
 	// Indicates if we intend to call CoreThread.Resume() when the next pcsx2 App event is handled
-	bool resumeEmulation = false;
+	bool m_resumeEmulation = false;
 	// Indicates to switch to replay mode after the next vsync
-	bool switchToReplay = false;
+	bool m_switchToReplay = false;
 	// Used to stop recording frames from incrementing during a reset
-	bool frameLock = false;
+	bool m_frameLock = false;
 };
 
 extern InputRecordingControls g_InputRecordingControls;

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -173,15 +173,23 @@ bool InputRecordingFile::ReadKeyBuffer(u8 &result, const uint &frame, const uint
 	return true;
 }
 
-void InputRecordingFile::SetTotalFrames(long frame)
+bool InputRecordingFile::SetTotalFrames(long frame)
 {
-	if (recordingFile == nullptr || totalFrames >= frame)
+	bool ret = false;
+	if (recordingFile != nullptr)
 	{
-		return;
+		if (totalFrames < frame)
+		{
+			totalFrames = frame;
+			fseek(recordingFile, seekpointTotalFrames, SEEK_SET);
+			fwrite(&totalFrames, 4, 1, recordingFile);
+			ret = true;
+		}
+		else if (totalFrames == frame)
+			ret = true;
+		fflush(recordingFile);
 	}
-	totalFrames = frame;
-	fseek(recordingFile, seekpointTotalFrames, SEEK_SET);
-	fwrite(&totalFrames, 4, 1, recordingFile);
+	return ret;
 }
 
 bool InputRecordingFile::WriteHeader()

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -130,26 +130,10 @@ bool InputRecordingFile::open(const wxString path, bool newRecording)
 
 bool InputRecordingFile::OpenNew(const wxString path, bool fromSavestate)
 {
-	if (fromSavestate)
-	{
-		if (CoreThread.IsOpen())
-		{
-			if (open(path, true))
-			{
-				savestate.fromSavestate = true;
-				return true;
-			}
-		}
-		else
-			inputRec::consoleLog("Game is not open, aborting playing input recording which starts on a save-state.");
+	if (!open(path, true))
 		return false;
-	}
-	else if (open(path, true))
-	{
-		savestate.fromSavestate = false;
-		return true;
-	}
-	return false;
+	savestate.fromSavestate = fromSavestate;
+	return true;
 }
 
 bool InputRecordingFile::OpenExisting(const wxString path)

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -224,7 +224,7 @@ bool InputRecordingFile::ReadKeyBuffer(u8& result, const u32 frame, const u32 se
 	return fseek(m_recordingFile, seek, SEEK_SET) == 0 && fread(&result, 1, 1, m_recordingFile) == 1;
 }
 
-bool InputRecordingFile::WriteHeader()
+bool InputRecordingFile::WriteHeader() const
 {
 	if (m_recordingFile == nullptr)
 		return false;

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -24,100 +24,149 @@
 #include "InputRecordingFile.h"
 #include "Utilities/InputRecordingLogger.h"
 
-void InputRecordingFileHeader::Init()
+void InputRecordingFile::InputRecordingFileHeader::Init() noexcept
 {
-	memset(author, 0, ArraySize(author));
-	memset(gameName, 0, ArraySize(gameName));
+	m_fileVersion = 2;
+	m_totalFrames = 0;
+	m_redoCount = 0;
 }
 
-void InputRecordingFileHeader::SetEmulatorVersion()
+bool InputRecordingFile::InputRecordingFileHeader::ReadHeader(FILE* m_recordingFile)
 {
-	wxString emuVersion = wxString::Format("%s-%d.%d.%d", pxGetAppName().c_str(), PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo);
-	int max = ArraySize(emu) - 1;
-	strncpy(emu, emuVersion.c_str(), max);
-	emu[max] = 0;
+	return (fread(this, s_seekpointTotalFrames, 1, m_recordingFile) == 1 && fread(&m_totalFrames, 9, 1, m_recordingFile) == 1); // Reads in totalFrames, redoCount, & startType
 }
 
-void InputRecordingFileHeader::SetAuthor(wxString _author)
+void InputRecordingFile::InputRecordingFileHeader::SetEmulatorVersion()
 {
-	int max = ArraySize(author) - 1;
-	strncpy(author, _author.c_str(), max);
-	author[max] = 0;
+	const wxString emulatorVersion = wxString::Format("%s-%d.%d.%d", pxGetAppName().c_str(), PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo);
+	m_emulatorVersion.fill(0);
+	strncpy(m_emulatorVersion.data(), emulatorVersion.c_str(), m_emulatorVersion.size() - 1);
 }
 
-void InputRecordingFileHeader::SetGameName(wxString _gameName)
+void InputRecordingFile::InputRecordingFileHeader::SetAuthor(wxString author)
 {
-	int max = ArraySize(gameName) - 1;
-	strncpy(gameName, _gameName.c_str(), max);
-	gameName[max] = 0;
+	m_author.fill(0);
+	strncpy(m_author.data(), author.c_str(), m_author.size() - 1);
+}
+
+void InputRecordingFile::InputRecordingFileHeader::SetGameName(wxString gameName)
+{
+	m_gameName.fill(0);
+	strncpy(m_gameName.data(), gameName.c_str(), m_gameName.size() - 1);
+}
+
+u8 InputRecordingFile::GetFileVersion() const noexcept
+{
+	return m_header.m_fileVersion;
+}
+
+const char* InputRecordingFile::GetEmulatorVersion() const noexcept
+{
+	return m_header.m_emulatorVersion.data();
+}
+
+const char* InputRecordingFile::GetAuthor() const noexcept
+{
+	return m_header.m_author.data();
+}
+
+const char* InputRecordingFile::GetGameName() const noexcept
+{
+	return m_header.m_gameName.data();
+}
+
+long InputRecordingFile::GetTotalFrames() const noexcept
+{
+	return m_header.m_totalFrames;
+}
+
+unsigned long InputRecordingFile::GetRedoCount() const noexcept
+{
+	return m_header.m_redoCount;
+}
+
+InputRecordingStartType InputRecordingFile::GetStartType() const noexcept
+{
+	return m_header.m_startType;
+}
+
+bool InputRecordingFile::FromSavestate() const noexcept
+{
+	return m_header.m_startType == InputRecordingStartType::Savestate;
+}
+
+wxByte InputRecordingFile::GetPads() const noexcept
+{
+	return m_header.m_pads;
 }
 
 bool InputRecordingFile::Close()
 {
-	if (recordingFile == nullptr)
-	{
+	if (m_recordingFile == nullptr)
 		return false;
-	}
-	fclose(recordingFile);
-	recordingFile = nullptr;
-	filename = "";
+	fclose(m_recordingFile);
+	m_recordingFile = nullptr;
+	m_filename = "";
+	m_padCount = 0;
 	return true;
 }
 
-const wxString &InputRecordingFile::GetFilename()
+const wxString& InputRecordingFile::GetFilename() const noexcept
 {
-	return filename;
+	return m_filename;
 }
 
-InputRecordingFileHeader &InputRecordingFile::GetHeader()
+InputRecordingFile::InputRecordingFileHeader& InputRecordingFile::GetHeader() noexcept
 {
-	return header;
+	return m_header;
 }
 
-long &InputRecordingFile::GetTotalFrames()
+int InputRecordingFile::GetPadCount() const noexcept
 {
-	return totalFrames;
+	return m_padCount;
 }
 
-unsigned long &InputRecordingFile::GetUndoCount()
+bool InputRecordingFile::IsPortUsed(const int port) const noexcept
 {
-	return undoCount;
+	return m_header.m_pads & (15 << 4 * port);
 }
 
-bool InputRecordingFile::FromSaveState()
+bool InputRecordingFile::IsMultitapUsed(const int port) const noexcept
 {
-	return savestate.fromSavestate;
+	return m_header.m_pads & (14 << 4 * port);
 }
 
-void InputRecordingFile::IncrementUndoCount()
+bool InputRecordingFile::IsSlotUsed(const int port, const int slot) const noexcept
 {
-	undoCount++;
-	if (recordingFile == nullptr)
+	return m_header.m_pads & (1 << (4 * port + slot));
+}
+
+void InputRecordingFile::IncrementRedoCount()
+{
+	if (m_recordingFile != nullptr)
 	{
-		return;
+		m_header.m_redoCount++;
+		fseek(m_recordingFile, InputRecordingFileHeader::s_seekpointRedoCount, SEEK_SET);
+		fwrite(&m_header.m_redoCount, 4, 1, m_recordingFile);
 	}
-	fseek(recordingFile, seekpointUndoCount, SEEK_SET);
-	fwrite(&undoCount, 4, 1, recordingFile);
 }
 
-bool InputRecordingFile::open(const wxString path, bool newRecording)
+bool InputRecordingFile::open(const wxString path, const bool newRecording)
 {
 	if (newRecording)
 	{
-		if ((recordingFile = wxFopen(path, L"wb+")) != nullptr)
+		if ((m_recordingFile = wxFopen(path, L"wb+")) != nullptr)
 		{
-			filename = path;
-			totalFrames = 0;
-			undoCount = 0;
-			header.Init();
+			m_filename = path;
+			m_header.Init();
 			return true;
 		}
 	}
-	else if ((recordingFile = wxFopen(path, L"rb+")) != nullptr)
+	else if ((m_recordingFile = wxFopen(path, L"rb+")) != nullptr)
 	{
 		if (verifyRecordingFileHeader())
 		{
-			filename = path;
+			m_filename = path;
 			return true;
 		}
 		Close();
@@ -128,11 +177,17 @@ bool InputRecordingFile::open(const wxString path, bool newRecording)
 	return false;
 }
 
-bool InputRecordingFile::OpenNew(const wxString path, bool fromSavestate)
+bool InputRecordingFile::OpenNew(const wxString path, const char startType, const wxByte slots)
 {
 	if (!open(path, true))
 		return false;
-	savestate.fromSavestate = fromSavestate;
+	m_header.m_startType = static_cast<InputRecordingStartType>(startType);
+	m_header.m_pads = slots;
+	for (u8 pad = 0; pad < 8; pad++)
+		if (m_header.m_pads & (1 << pad))
+			m_padCount++;
+	m_recordingBlockSize = s_controllerInputBytes * m_padCount;
+	m_seekpointInputData = InputRecordingFileHeader::s_seekpointPads + 1;
 	return true;
 }
 
@@ -141,102 +196,93 @@ bool InputRecordingFile::OpenExisting(const wxString path)
 	return open(path, false);
 }
 
-bool InputRecordingFile::ReadKeyBuffer(u8 &result, const uint &frame, const uint port, const uint bufIndex)
-{
-	if (recordingFile == nullptr)
-	{
-		return false;
-	}
-
-	long seek = getRecordingBlockSeekPoint(frame) + controllerInputBytes * port + bufIndex;
-	if (fseek(recordingFile, seek, SEEK_SET) != 0 || fread(&result, 1, 1, recordingFile) != 1)
-	{
-		return false;
-	}
-
-	return true;
-}
-
-bool InputRecordingFile::SetTotalFrames(long frame)
+bool InputRecordingFile::SetTotalFrames(const long frame) noexcept
 {
 	bool ret = false;
-	if (recordingFile != nullptr)
+	if (m_recordingFile != nullptr)
 	{
-		if (totalFrames < frame)
+		if (m_header.m_totalFrames < frame)
 		{
-			totalFrames = frame;
-			fseek(recordingFile, seekpointTotalFrames, SEEK_SET);
-			fwrite(&totalFrames, 4, 1, recordingFile);
+			m_header.m_totalFrames = frame;
+			fseek(m_recordingFile, InputRecordingFileHeader::s_seekpointTotalFrames, SEEK_SET);
+			fwrite(&m_header.m_totalFrames, 4, 1, m_recordingFile);
 			ret = true;
 		}
-		else if (totalFrames == frame)
+		else if (m_header.m_totalFrames == frame)
 			ret = true;
-		fflush(recordingFile);
+		fflush(m_recordingFile);
 	}
 	return ret;
 }
 
+bool InputRecordingFile::ReadKeyBuffer(u8& result, const u32 frame, const u32 seekOffset) const
+{
+	if (m_recordingFile == nullptr)
+		return false;
+
+	const u64 seek = getRecordingBlockSeekPoint(frame) + seekOffset;
+	return fseek(m_recordingFile, seek, SEEK_SET) == 0 && fread(&result, 1, 1, m_recordingFile) == 1;
+}
+
 bool InputRecordingFile::WriteHeader()
 {
-	if (recordingFile == nullptr)
-	{
+	if (m_recordingFile == nullptr)
 		return false;
-	}
-	rewind(recordingFile);
-	if (fwrite(&header, sizeof(InputRecordingFileHeader), 1, recordingFile) != 1
-		|| fwrite(&totalFrames, 4, 1, recordingFile) != 1
-		|| fwrite(&undoCount, 4, 1, recordingFile) != 1
-		|| fwrite(&savestate, 1, 1, recordingFile) != 1)
-	{
-		return false;
-	}
-	return true;
+	rewind(m_recordingFile);
+	return fwrite(&m_header, InputRecordingFileHeader::s_seekpointTotalFrames, 1, m_recordingFile) == 1 && fwrite(&m_header.m_totalFrames, 10, 1, m_recordingFile) == 1; // Writes totalFrames, redoCount, startType, & pads
 }
 
-bool InputRecordingFile::WriteKeyBuffer(const uint &frame, const uint port, const uint bufIndex, const u8 &buf)
+bool InputRecordingFile::WriteKeyBuffer(const u8 buf, const u32 frame, const u32 seekOffset) const
 {
-	if (recordingFile == nullptr)
-	{
+	if (m_recordingFile == nullptr)
 		return false;
-	}
 
-	long seek = getRecordingBlockSeekPoint(frame) + 18 * port + bufIndex;
-
-	if (fseek(recordingFile, seek, SEEK_SET) != 0 || fwrite(&buf, 1, 1, recordingFile) != 1)
-	{
-		return false;
-	}
-
-	fflush(recordingFile);
-	return true;
+	const u64 seek = getRecordingBlockSeekPoint(frame) + seekOffset;
+	return fseek(m_recordingFile, seek, SEEK_SET) == 0 && fwrite(&buf, 1, 1, m_recordingFile) == 1;
 }
 
-long InputRecordingFile::getRecordingBlockSeekPoint(const long &frame)
+u64 InputRecordingFile::getRecordingBlockSeekPoint(const u32 frame) const
 {
-	return headerSize + sizeof(bool) + frame * inputBytesPerFrame;
+	return m_seekpointInputData + frame * m_recordingBlockSize;
 }
 
 bool InputRecordingFile::verifyRecordingFileHeader()
 {
-	if (recordingFile == nullptr)
-	{
+	if (m_recordingFile == nullptr)
 		return false;
-	}
+
 	// Verify header contents
-	rewind(recordingFile);
-	if (fread(&header, sizeof(InputRecordingFileHeader), 1, recordingFile) != 1
-		|| fread(&totalFrames, 4, 1, recordingFile) != 1
-		|| fread(&undoCount, 4, 1, recordingFile) != 1
-		|| fread(&savestate.fromSavestate, sizeof(bool), 1, recordingFile) != 1)
+	m_header.ReadHeader(m_recordingFile);
+
+	// Check for valid verison
+	switch (m_header.m_fileVersion)
 	{
-		return false;
-	}
-	
-	// Check for current verison
-	if (header.version != 1)
-	{
-		inputRec::consoleLog(fmt::format("Input recording file is not a supported version - {}", header.version));
-		return false;
+		case 1: // Official version 1 with no slot info written to file; Backwards compatibility
+			m_padCount = 2;
+			m_recordingBlockSize = 36;
+			m_seekpointInputData = InputRecordingFileHeader::s_seekpointPads;
+			m_header.m_startType = (char)m_header.m_startType == 0 ? InputRecordingStartType::UnspecifiedBoot : InputRecordingStartType::Savestate;
+			m_header.m_pads = 17; // Pads 1A (1) & 2A (16)
+			break;
+		case 2: // Official Version 2
+			// Additional: header -> pads
+			if (fread(&m_header.m_pads, 1, 1, m_recordingFile) != 1)
+				return false;
+
+			if (m_header.m_pads == 0)
+			{
+				inputRec::log("Input Recording File must have at least 1 controller");
+				return false;
+			}
+			for (u8 pad = 0; pad < 8; pad++)
+				if (m_header.m_pads & (1 << pad))
+					m_padCount++;
+			m_recordingBlockSize = s_controllerInputBytes * m_padCount;
+			m_seekpointInputData = InputRecordingFileHeader::s_seekpointPads + 1;
+			break;
+		default:
+			inputRec::consoleLog(fmt::format("Input recording file is not a supported version - {}", m_header.m_fileVersion));
+			return false;
 	}
 	return true;
 }

--- a/pcsx2/Recording/InputRecordingFile.h
+++ b/pcsx2/Recording/InputRecordingFile.h
@@ -77,7 +77,7 @@ public:
 	// the current frame's value from the emulator
 	bool ReadKeyBuffer(u8 &result, const uint &frame, const uint port, const uint bufIndex);
 	// Updates the total frame counter and commit it to the recording file
-	void SetTotalFrames(long frames);
+	bool SetTotalFrames(long frames);
 	// Persist the input recording file header's current state to the file
 	bool WriteHeader();
 	// Writes the current frame's input data to the file so it can be replayed

--- a/pcsx2/Recording/InputRecordingFile.h
+++ b/pcsx2/Recording/InputRecordingFile.h
@@ -116,7 +116,7 @@ public:
 	// the current frame's value from the emulator
 	bool ReadKeyBuffer(u8& result, const u32 frame, const u32 seekOffset) const;
 	// Persist the input recording file header's current state to the file
-	bool WriteHeader();
+	bool WriteHeader() const;
 	// Writes the current frame's input data to the file so it can be replayed
 	bool WriteKeyBuffer(const u8 buf, const u32 frame, const u32 seekOffset) const;
 

--- a/pcsx2/Recording/NewRecordingFrame.cpp
+++ b/pcsx2/Recording/NewRecordingFrame.cpp
@@ -103,7 +103,7 @@ void NewRecordingFrame::OnFileChanged(wxFileDirPickerEvent& event)
 
 void NewRecordingFrame::OnBoxCheck(wxCommandEvent& event)
 {
-	pads ^= 1 << (((event.GetId() - MenuIds_New_Recording_Frame_Port_0) << 2) + event.GetInt());
+	m_pads ^= 1 << (((event.GetId() - MenuIds_New_Recording_Frame_Port_0) << 2) + event.GetInt());
 	EnableOkBox();
 }
 
@@ -117,7 +117,7 @@ void NewRecordingFrame::EnableOkBox()
 	}
 	else if (m_fileBrowsed)
 	{
-		if (pads == 0)
+		if (m_pads == 0)
 		{
 			m_startRecording->SetLabel(_("No Pads"));
 			m_startRecording->Enable(false);
@@ -152,6 +152,6 @@ char NewRecordingFrame::GetStartType() const
 
 wxByte NewRecordingFrame::GetPads() const noexcept
 {
-	return pads;
+	return m_pads;
 }
 #endif

--- a/pcsx2/Recording/NewRecordingFrame.cpp
+++ b/pcsx2/Recording/NewRecordingFrame.cpp
@@ -24,17 +24,30 @@ NewRecordingFrame::NewRecordingFrame(wxWindow* parent)
 {
 	wxPanel* panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _("panel"));
 
-	wxFlexGridSizer* fgs = new wxFlexGridSizer(4, 2, 20, 20);
+	wxFlexGridSizer* fgs = new wxFlexGridSizer(7, 2, 20, 20);
 	wxBoxSizer* container = new wxBoxSizer(wxVERTICAL);
 
 	m_fileLabel = new wxStaticText(panel, wxID_ANY, _("File Path"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	m_filePicker = new wxFilePickerCtrl(panel, MenuIds_New_Recording_Frame_File, wxEmptyString, "New Recording File", L"pcsx2 recording file(*.pirec, *.p2m2)|*.pirec;*.p2m2", wxDefaultPosition, wxDefaultSize, wxFLP_SAVE | wxFLP_OVERWRITE_PROMPT | wxFLP_USE_TEXTCTRL);
+	
 	m_authorLabel = new wxStaticText(panel, wxID_ANY, _("Author"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
-	m_fromLabel = new wxStaticText(panel, wxID_ANY, _("Record From"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
-
-	m_filePicker = new wxFilePickerCtrl(panel, MenuIds_New_Recording_Frame_File, wxEmptyString, "File", L"p2m2 file(*.p2m2)|*.p2m2", wxDefaultPosition, wxDefaultSize, wxFLP_SAVE | wxFLP_OVERWRITE_PROMPT | wxFLP_USE_TEXTCTRL);
 	m_authorInput = new wxTextCtrl(panel, MenuIds_New_Recording_Frame_Author, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+
+	m_ControllerLabel = new wxStaticText(panel, wxID_ANY, _("Controller Slots"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	const char* slots[2][4] = { {"1A", "1B", "1C", "1D"}, {"2A", "2B", "2C", "2D"} };
+#ifndef __linux__
+	m_ControllerCheck[0] = new wxCheckListBox(panel, MenuIds_New_Recording_Frame_Port_0, wxDefaultPosition, wxDefaultSize, wxArrayString(4, slots[0]), wxLB_MULTIPLE, wxDefaultValidator, "Port 1");
+	m_ControllerCheck[1] = new wxCheckListBox(panel, MenuIds_New_Recording_Frame_Port_1, wxDefaultPosition, wxDefaultSize, wxArrayString(4, slots[1]), wxLB_MULTIPLE, wxDefaultValidator, "Port 2");
+#else
+	m_ControllerCheck[0] = new wxCheckListBox(panel, MenuIds_New_Recording_Frame_Port_0, wxDefaultPosition, wxDefaultSize, wxArrayString(1, slots[0]), wxLB_MULTIPLE, wxDefaultValidator, "Port 1");
+	m_ControllerCheck[1] = new wxCheckListBox(panel, MenuIds_New_Recording_Frame_Port_1, wxDefaultPosition, wxDefaultSize, wxArrayString(1, slots[1]), wxLB_MULTIPLE, wxDefaultValidator, "Port 2");
+#endif
+	
+	m_ControllerCheck[0]->Bind(wxEVT_CHECKLISTBOX, &NewRecordingFrame::OnBoxCheck, this);
+	m_ControllerCheck[1]->Bind(wxEVT_CHECKLISTBOX, &NewRecordingFrame::OnBoxCheck, this);
+
+	m_fromLabel = new wxStaticText(panel, wxID_ANY, _("Record From"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
 	m_fromChoice = new wxChoice(panel, MenuIds_New_Recording_Frame_From, wxDefaultPosition, wxDefaultSize, NULL);
-	m_fromChoice->SetSelection(0);
 
 	m_startRecording = new wxButton(panel, wxID_OK, _("Browse Required"), wxDefaultPosition, wxDefaultSize);
 	m_startRecording->Enable(false);
@@ -45,6 +58,12 @@ NewRecordingFrame::NewRecordingFrame(wxWindow* parent)
 
 	fgs->Add(m_authorLabel, 1);
 	fgs->Add(m_authorInput, 1, wxEXPAND);
+
+	fgs->Add(m_ControllerLabel, 1);
+	fgs->Add(new wxStaticText(panel, wxID_ANY, _(""), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER), 1); //Empty spot
+
+	fgs->Add(m_ControllerCheck[0], 1);
+	fgs->Add(m_ControllerCheck[1], 1);
 
 	fgs->Add(m_fromLabel, 1);
 	fgs->Add(m_fromChoice, 1, wxEXPAND);
@@ -64,8 +83,8 @@ NewRecordingFrame::NewRecordingFrame(wxWindow* parent)
 
 int NewRecordingFrame::ShowModal(const bool isCoreThreadOpen)
 {
-	static const char* choices[2] = {"Boot", "Current Frame"};
-	m_fromChoice->Set(wxArrayString(1 + isCoreThreadOpen, &choices[0]));
+	static const char* choices[3] = {"Full Boot", "Fast Boot", "Current Frame"};
+	m_fromChoice->Set(wxArrayString(2 + isCoreThreadOpen, &choices[0]));
 	m_fromChoice->SetSelection(0);
 	return wxDialog::ShowModal();
 }
@@ -82,6 +101,12 @@ void NewRecordingFrame::OnFileChanged(wxFileDirPickerEvent& event)
 	EnableOkBox();
 }
 
+void NewRecordingFrame::OnBoxCheck(wxCommandEvent& event)
+{
+	pads ^= 1 << (((event.GetId() - MenuIds_New_Recording_Frame_Port_0) << 2) + event.GetInt());
+	EnableOkBox();
+}
+
 void NewRecordingFrame::EnableOkBox()
 {
 	if (m_filePicker->GetPath().length() == 0)
@@ -92,8 +117,16 @@ void NewRecordingFrame::EnableOkBox()
 	}
 	else if (m_fileBrowsed)
 	{
-		m_startRecording->SetLabel(_("Start"));
-		m_startRecording->Enable(true);
+		if (pads == 0)
+		{
+			m_startRecording->SetLabel(_("No Pads"));
+			m_startRecording->Enable(false);
+		}
+		else
+		{
+			m_startRecording->SetLabel(_("Start"));
+			m_startRecording->Enable(true);
+		}
 	}
 }
 
@@ -102,10 +135,8 @@ wxString NewRecordingFrame::GetFile() const
 	wxString path = m_filePicker->GetPath();
 	// wxWidget's removes the extension if it contains wildcards
 	// on wxGTK https://trac.wxwidgets.org/ticket/15285
-	if (!path.EndsWith(".p2m2"))
-	{
-		return wxString::Format("%s.p2m2", path);
-	}
+	if (!path.EndsWith(".pirec") && !path.EndsWith(".p2m2"))
+		path += ".pirec";
 	return path;
 }
 
@@ -114,8 +145,13 @@ wxString NewRecordingFrame::GetAuthor() const
 	return m_authorInput->GetValue();
 }
 
-int NewRecordingFrame::GetFrom() const
+char NewRecordingFrame::GetStartType() const
 {
 	return m_fromChoice->GetSelection();
+}
+
+wxByte NewRecordingFrame::GetPads() const noexcept
+{
+	return pads;
 }
 #endif

--- a/pcsx2/Recording/NewRecordingFrame.cpp
+++ b/pcsx2/Recording/NewRecordingFrame.cpp
@@ -33,13 +33,11 @@ NewRecordingFrame::NewRecordingFrame(wxWindow* parent)
 
 	m_filePicker = new wxFilePickerCtrl(panel, MenuIds_New_Recording_Frame_File, wxEmptyString, "File", L"p2m2 file(*.p2m2)|*.p2m2", wxDefaultPosition, wxDefaultSize, wxFLP_SAVE | wxFLP_OVERWRITE_PROMPT | wxFLP_USE_TEXTCTRL);
 	m_authorInput = new wxTextCtrl(panel, MenuIds_New_Recording_Frame_Author, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
-	wxArrayString choices;
-	choices.Add("Current Frame");
-	choices.Add("Power-On");
-	m_fromChoice = new wxChoice(panel, MenuIds_New_Recording_Frame_From, wxDefaultPosition, wxDefaultSize, choices);
+	m_fromChoice = new wxChoice(panel, MenuIds_New_Recording_Frame_From, wxDefaultPosition, wxDefaultSize, NULL);
 	m_fromChoice->SetSelection(0);
 
-	m_startRecording = new wxButton(panel, wxID_OK, _("Ok"), wxDefaultPosition, wxDefaultSize);
+	m_startRecording = new wxButton(panel, wxID_OK, _("Browse Required"), wxDefaultPosition, wxDefaultSize);
+	m_startRecording->Enable(false);
 	m_cancelRecording = new wxButton(panel, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize);
 
 	fgs->Add(m_fileLabel, 1);
@@ -58,6 +56,45 @@ NewRecordingFrame::NewRecordingFrame(wxWindow* parent)
 	panel->SetSizer(container);
 	panel->GetSizer()->Fit(this);
 	Centre();
+
+	m_fileBrowsed = false;
+	m_filePicker->GetPickerCtrl()->Bind(wxEVT_FILEPICKER_CHANGED, &NewRecordingFrame::OnFileDirChange, this);
+	m_filePicker->Bind(wxEVT_FILEPICKER_CHANGED, &NewRecordingFrame::OnFileChanged, this);
+}
+
+int NewRecordingFrame::ShowModal(const bool isCoreThreadOpen)
+{
+	static const char* choices[2] = {"Boot", "Current Frame"};
+	m_fromChoice->Set(wxArrayString(1 + isCoreThreadOpen, &choices[0]));
+	m_fromChoice->SetSelection(0);
+	return wxDialog::ShowModal();
+}
+
+void NewRecordingFrame::OnFileDirChange(wxFileDirPickerEvent& event)
+{
+	m_filePicker->wxFileDirPickerCtrlBase::OnFileDirChange(event);
+	m_fileBrowsed = true;
+	EnableOkBox();
+}
+
+void NewRecordingFrame::OnFileChanged(wxFileDirPickerEvent& event)
+{
+	EnableOkBox();
+}
+
+void NewRecordingFrame::EnableOkBox()
+{
+	if (m_filePicker->GetPath().length() == 0)
+	{
+		m_fileBrowsed = false;
+		m_startRecording->SetLabel(_("Browse Required"));
+		m_startRecording->Enable(false);
+	}
+	else if (m_fileBrowsed)
+	{
+		m_startRecording->SetLabel(_("Start"));
+		m_startRecording->Enable(true);
+	}
 }
 
 wxString NewRecordingFrame::GetFile() const

--- a/pcsx2/Recording/NewRecordingFrame.h
+++ b/pcsx2/Recording/NewRecordingFrame.h
@@ -32,14 +32,21 @@ class NewRecordingFrame : public wxDialog
 {
 public:
 	NewRecordingFrame(wxWindow* parent);
+	int ShowModal(const bool isCoreThreadOpen);
 
 	wxString GetFile() const;
 	wxString GetAuthor() const;
 	int GetFrom() const;
 
+protected:
+	void OnFileDirChange(wxFileDirPickerEvent& event);
+	void OnFileChanged(wxFileDirPickerEvent& event);
+	void EnableOkBox();
+
 private:
 	wxStaticText* m_fileLabel;
 	wxFilePickerCtrl* m_filePicker;
+	bool m_fileBrowsed;
 	wxStaticText* m_authorLabel;
 	wxTextCtrl* m_authorInput;
 	wxStaticText* m_fromLabel;

--- a/pcsx2/Recording/NewRecordingFrame.h
+++ b/pcsx2/Recording/NewRecordingFrame.h
@@ -24,7 +24,9 @@ enum MenuIds_New_Recording_Frame
 {
 	MenuIds_New_Recording_Frame_File = 0,
 	MenuIds_New_Recording_Frame_Author,
-	MenuIds_New_Recording_Frame_From
+	MenuIds_New_Recording_Frame_From,
+	MenuIds_New_Recording_Frame_Port_0,
+	MenuIds_New_Recording_Frame_Port_1
 };
 
 // The Dialog to pop-up when recording a new movie
@@ -36,22 +38,26 @@ public:
 
 	wxString GetFile() const;
 	wxString GetAuthor() const;
-	int GetFrom() const;
+	char GetStartType() const;
+	wxByte GetPads() const noexcept;
 
 protected:
 	void OnFileDirChange(wxFileDirPickerEvent& event);
 	void OnFileChanged(wxFileDirPickerEvent& event);
+	void OnBoxCheck(wxCommandEvent& event);
 	void EnableOkBox();
 
-private:
 	wxStaticText* m_fileLabel;
 	wxFilePickerCtrl* m_filePicker;
 	bool m_fileBrowsed;
 	wxStaticText* m_authorLabel;
 	wxTextCtrl* m_authorInput;
+	wxStaticText* m_ControllerLabel;
+	wxCheckListBox* m_ControllerCheck[2];
 	wxStaticText* m_fromLabel;
 	wxChoice* m_fromChoice;
 	wxButton* m_startRecording;
 	wxButton* m_cancelRecording;
+	wxByte pads = 0;
 };
 #endif

--- a/pcsx2/Recording/NewRecordingFrame.h
+++ b/pcsx2/Recording/NewRecordingFrame.h
@@ -58,6 +58,6 @@ protected:
 	wxChoice* m_fromChoice;
 	wxButton* m_startRecording;
 	wxButton* m_cancelRecording;
-	wxByte pads = 0;
+	wxByte m_pads = 0;
 };
 #endif

--- a/pcsx2/Recording/PadData.cpp
+++ b/pcsx2/Recording/PadData.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copym_right (C) 2002-2020  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -27,72 +27,72 @@ void PadData::UpdateControllerData(u16 bufIndex, u8 const& bufVal)
 	switch (index)
 	{
 		case BufferIndex::PressedFlagsGroupOne:
-			leftPressed = IsButtonPressed(LEFT, bufVal);
-			downPressed = IsButtonPressed(DOWN, bufVal);
-			rightPressed = IsButtonPressed(RIGHT, bufVal);
-			upPressed = IsButtonPressed(UP, bufVal);
-			start = IsButtonPressed(START, bufVal);
-			r3 = IsButtonPressed(R3, bufVal);
-			l3 = IsButtonPressed(L3, bufVal);
-			select = IsButtonPressed(SELECT, bufVal);
+			m_leftPressed = IsButtonPressed(m_LEFT, bufVal);
+			m_downPressed = IsButtonPressed(m_DOWN, bufVal);
+			m_rightPressed = IsButtonPressed(m_RIGHT, bufVal);
+			m_upPressed = IsButtonPressed(m_UP, bufVal);
+			m_start = IsButtonPressed(m_START, bufVal);
+			m_r3 = IsButtonPressed(m_R3, bufVal);
+			m_l3 = IsButtonPressed(m_L3, bufVal);
+			m_select = IsButtonPressed(m_SELECT, bufVal);
 			break;
 		case BufferIndex::PressedFlagsGroupTwo:
-			squarePressed = IsButtonPressed(SQUARE, bufVal);
-			crossPressed = IsButtonPressed(CROSS, bufVal);
-			circlePressed = IsButtonPressed(CIRCLE, bufVal);
-			trianglePressed = IsButtonPressed(TRIANGLE, bufVal);
-			r1Pressed = IsButtonPressed(R1, bufVal);
-			l1Pressed = IsButtonPressed(L1, bufVal);
-			r2Pressed = IsButtonPressed(R2, bufVal);
-			l2Pressed = IsButtonPressed(L2, bufVal);
+			m_squarePressed = IsButtonPressed(m_SQUARE, bufVal);
+			m_crossPressed = IsButtonPressed(m_CROSS, bufVal);
+			m_circlePressed = IsButtonPressed(m_CIRCLE, bufVal);
+			m_trianglePressed = IsButtonPressed(m_TRIANGLE, bufVal);
+			m_r1Pressed = IsButtonPressed(m_R1, bufVal);
+			m_l1Pressed = IsButtonPressed(m_L1, bufVal);
+			m_r2Pressed = IsButtonPressed(m_R2, bufVal);
+			m_l2Pressed = IsButtonPressed(m_L2, bufVal);
 			break;
 		case BufferIndex::RightAnalogXVector:
-			rightAnalogX = bufVal;
+			m_rightAnalogX = bufVal;
 			break;
 		case BufferIndex::RightAnalogYVector:
-			rightAnalogY = bufVal;
+			m_rightAnalogY = bufVal;
 			break;
 		case BufferIndex::LeftAnalogXVector:
-			leftAnalogX = bufVal;
+			m_leftAnalogX = bufVal;
 			break;
 		case BufferIndex::LeftAnalogYVector:
-			leftAnalogY = bufVal;
+			m_leftAnalogY = bufVal;
 			break;
 		case BufferIndex::RightPressure:
-			rightPressure = bufVal;
+			m_rightPressure = bufVal;
 			break;
 		case BufferIndex::LeftPressure:
-			leftPressure = bufVal;
+			m_leftPressure = bufVal;
 			break;
 		case BufferIndex::UpPressure:
-			upPressure = bufVal;
+			m_upPressure = bufVal;
 			break;
 		case BufferIndex::DownPressure:
-			downPressure = bufVal;
+			m_downPressure = bufVal;
 			break;
 		case BufferIndex::TrianglePressure:
-			trianglePressure = bufVal;
+			m_trianglePressure = bufVal;
 			break;
 		case BufferIndex::CirclePressure:
-			circlePressure = bufVal;
+			m_circlePressure = bufVal;
 			break;
 		case BufferIndex::CrossPressure:
-			crossPressure = bufVal;
+			m_crossPressure = bufVal;
 			break;
 		case BufferIndex::SquarePressure:
-			squarePressure = bufVal;
+			m_squarePressure = bufVal;
 			break;
 		case BufferIndex::L1Pressure:
-			l1Pressure = bufVal;
+			m_l1Pressure = bufVal;
 			break;
 		case BufferIndex::R1Pressure:
-			r1Pressure = bufVal;
+			m_r1Pressure = bufVal;
 			break;
 		case BufferIndex::L2Pressure:
-			l2Pressure = bufVal;
+			m_l2Pressure = bufVal;
 			break;
 		case BufferIndex::R2Pressure:
-			r2Pressure = bufVal;
+			m_r2Pressure = bufVal;
 			break;
 	}
 }
@@ -105,60 +105,60 @@ u8 PadData::PollControllerData(u16 bufIndex)
 	{
 		case BufferIndex::PressedFlagsGroupOne:
 			// Construct byte by combining flags if the buttons are pressed
-			byte |= BitmaskOrZero(leftPressed, LEFT);
-			byte |= BitmaskOrZero(downPressed, DOWN);
-			byte |= BitmaskOrZero(rightPressed, RIGHT);
-			byte |= BitmaskOrZero(upPressed, UP);
-			byte |= BitmaskOrZero(start, START);
-			byte |= BitmaskOrZero(r3, R3);
-			byte |= BitmaskOrZero(l3, L3);
-			byte |= BitmaskOrZero(select, SELECT);
+			byte |= BitmaskOrZero(m_leftPressed, m_LEFT);
+			byte |= BitmaskOrZero(m_downPressed, m_DOWN);
+			byte |= BitmaskOrZero(m_rightPressed, m_RIGHT);
+			byte |= BitmaskOrZero(m_upPressed, m_UP);
+			byte |= BitmaskOrZero(m_start, m_START);
+			byte |= BitmaskOrZero(m_r3, m_R3);
+			byte |= BitmaskOrZero(m_l3, m_L3);
+			byte |= BitmaskOrZero(m_select, m_SELECT);
 			// We flip the bits because as mentioned below, 0 = pressed
 			return ~byte;
 		case BufferIndex::PressedFlagsGroupTwo:
 			// Construct byte by combining flags if the buttons are pressed
-			byte |= BitmaskOrZero(squarePressed, SQUARE);
-			byte |= BitmaskOrZero(crossPressed, CROSS);
-			byte |= BitmaskOrZero(circlePressed, CIRCLE);
-			byte |= BitmaskOrZero(trianglePressed, TRIANGLE);
-			byte |= BitmaskOrZero(r1Pressed, R1);
-			byte |= BitmaskOrZero(l1Pressed, L1);
-			byte |= BitmaskOrZero(r2Pressed, R2);
-			byte |= BitmaskOrZero(l2Pressed, L2);
+			byte |= BitmaskOrZero(m_squarePressed, m_SQUARE);
+			byte |= BitmaskOrZero(m_crossPressed, m_CROSS);
+			byte |= BitmaskOrZero(m_circlePressed, m_CIRCLE);
+			byte |= BitmaskOrZero(m_trianglePressed, m_TRIANGLE);
+			byte |= BitmaskOrZero(m_r1Pressed, m_R1);
+			byte |= BitmaskOrZero(m_l1Pressed, m_L1);
+			byte |= BitmaskOrZero(m_r2Pressed, m_R2);
+			byte |= BitmaskOrZero(m_l2Pressed, m_L2);
 			// We flip the bits because as mentioned below, 0 = pressed
 			return ~byte;
 		case BufferIndex::RightAnalogXVector:
-			return rightAnalogX;
+			return m_rightAnalogX;
 		case BufferIndex::RightAnalogYVector:
-			return rightAnalogY;
+			return m_rightAnalogY;
 		case BufferIndex::LeftAnalogXVector:
-			return leftAnalogX;
+			return m_leftAnalogX;
 		case BufferIndex::LeftAnalogYVector:
-			return leftAnalogY;
+			return m_leftAnalogY;
 		case BufferIndex::RightPressure:
-			return rightPressure;
+			return m_rightPressure;
 		case BufferIndex::LeftPressure:
-			return leftPressure;
+			return m_leftPressure;
 		case BufferIndex::UpPressure:
-			return upPressure;
+			return m_upPressure;
 		case BufferIndex::DownPressure:
-			return downPressure;
+			return m_downPressure;
 		case BufferIndex::TrianglePressure:
-			return trianglePressure;
+			return m_trianglePressure;
 		case BufferIndex::CirclePressure:
-			return circlePressure;
+			return m_circlePressure;
 		case BufferIndex::CrossPressure:
-			return crossPressure;
+			return m_crossPressure;
 		case BufferIndex::SquarePressure:
-			return squarePressure;
+			return m_squarePressure;
 		case BufferIndex::L1Pressure:
-			return l1Pressure;
+			return m_l1Pressure;
 		case BufferIndex::R1Pressure:
-			return r1Pressure;
+			return m_r1Pressure;
 		case BufferIndex::L2Pressure:
-			return l2Pressure;
+			return m_l2Pressure;
 		case BufferIndex::R2Pressure:
-			return r2Pressure;
+			return m_r2Pressure;
 		default:
 			return 0;
 	}
@@ -169,18 +169,18 @@ bool PadData::IsButtonPressed(ButtonResolver buttonResolver, u8 const& bufVal)
 	// Rather than the flags being SET if the button is pressed, it is the opposite
 	// For example: 0111 1111 with `left` being the first bit indicates `left` is pressed.
 	// So, we are forced to flip the pressed bits with a NOT first
-	return (~bufVal & buttonResolver.buttonBitmask) > 0;
+	return (~bufVal & buttonResolver.m_buttonBitmask) > 0;
 }
 
 u8 PadData::BitmaskOrZero(bool pressed, ButtonResolver buttonInfo)
 {
-	return pressed ? buttonInfo.buttonBitmask : 0;
+	return pressed ? buttonInfo.m_buttonBitmask : 0;
 }
 
-wxString PadData::RawPadBytesToString(int start, int end)
+wxString PadData::RawPadBytesToString(int m_start, int end)
 {
 	wxString str;
-	for (int i = start; i < end; i++)
+	for (int i = m_start; i < end; i++)
 	{
 		str += wxString::Format("%d", PollControllerData(i));
 		if (i != end - 1)

--- a/pcsx2/Recording/PadData.h
+++ b/pcsx2/Recording/PadData.h
@@ -21,8 +21,8 @@ class PadData
 {
 public:
 	/// Constants
-	static const u8 ANALOG_VECTOR_NEUTRAL = 127;
-	static const u16 END_INDEX_CONTROLLER_BUFFER = 17;
+	static const u8 s_ANALOG_VECTOR_NEUTRAL = 127;
+	static const u16 s_END_INDEX_CONTROLLER_BUFFER = 17;
 
 	enum class BufferIndex
 	{
@@ -47,46 +47,46 @@ public:
 	};
 
 	/// Pressure Buttons - 0-255
-	u8 circlePressure = 0;
-	u8 crossPressure = 0;
-	u8 squarePressure = 0;
-	u8 trianglePressure = 0;
-	u8 downPressure = 0;
-	u8 leftPressure = 0;
-	u8 rightPressure = 0;
-	u8 upPressure = 0;
-	u8 l1Pressure = 0;
-	u8 l2Pressure = 0;
-	u8 r1Pressure = 0;
-	u8 r2Pressure = 0;
+	u8 m_circlePressure = 0;
+	u8 m_crossPressure = 0;
+	u8 m_squarePressure = 0;
+	u8 m_trianglePressure = 0;
+	u8 m_downPressure = 0;
+	u8 m_leftPressure = 0;
+	u8 m_rightPressure = 0;
+	u8 m_upPressure = 0;
+	u8 m_l1Pressure = 0;
+	u8 m_l2Pressure = 0;
+	u8 m_r1Pressure = 0;
+	u8 m_r2Pressure = 0;
 
 	/// Pressure Button Flags
 	/// NOTE - It shouldn't be possible to depress a button while also having no pressure
 	/// But for the sake of completeness, it should be tracked.
-	bool circlePressed = false;
-	bool crossPressed = false;
-	bool squarePressed = false;
-	bool trianglePressed = false;
-	bool downPressed = false;
-	bool leftPressed = false;
-	bool rightPressed = false;
-	bool upPressed = false;
-	bool l1Pressed = false;
-	bool l2Pressed = false;
-	bool r1Pressed = false;
-	bool r2Pressed = false;
+	bool m_circlePressed = false;
+	bool m_crossPressed = false;
+	bool m_squarePressed = false;
+	bool m_trianglePressed = false;
+	bool m_downPressed = false;
+	bool m_leftPressed = false;
+	bool m_rightPressed = false;
+	bool m_upPressed = false;
+	bool m_l1Pressed = false;
+	bool m_l2Pressed = false;
+	bool m_r1Pressed = false;
+	bool m_r2Pressed = false;
 
 	/// Normal (un)pressed buttons
-	bool select = false;
-	bool start = false;
-	bool l3 = false;
-	bool r3 = false;
+	bool m_select = false;
+	bool m_start = false;
+	bool m_l3 = false;
+	bool m_r3 = false;
 
 	/// Analog Sticks - 0-255 (127 center)
-	u8 leftAnalogX = ANALOG_VECTOR_NEUTRAL;
-	u8 leftAnalogY = ANALOG_VECTOR_NEUTRAL;
-	u8 rightAnalogX = ANALOG_VECTOR_NEUTRAL;
-	u8 rightAnalogY = ANALOG_VECTOR_NEUTRAL;
+	u8 m_leftAnalogX = s_ANALOG_VECTOR_NEUTRAL;
+	u8 m_leftAnalogY = s_ANALOG_VECTOR_NEUTRAL;
+	u8 m_rightAnalogX = s_ANALOG_VECTOR_NEUTRAL;
+	u8 m_rightAnalogY = s_ANALOG_VECTOR_NEUTRAL;
 
 	// Given the input buffer and the current index, updates the correct field(s)
 	void UpdateControllerData(u16 bufIndex, u8 const& bufVal);
@@ -98,26 +98,26 @@ public:
 private:
 	struct ButtonResolver
 	{
-		u8 buttonBitmask;
+		u8 m_buttonBitmask;
 	};
 
-	const ButtonResolver LEFT = ButtonResolver{0b10000000};
-	const ButtonResolver DOWN = ButtonResolver{0b01000000};
-	const ButtonResolver RIGHT = ButtonResolver{0b00100000};
-	const ButtonResolver UP = ButtonResolver{0b00010000};
-	const ButtonResolver START = ButtonResolver{0b00001000};
-	const ButtonResolver R3 = ButtonResolver{0b00000100};
-	const ButtonResolver L3 = ButtonResolver{0b00000010};
-	const ButtonResolver SELECT = ButtonResolver{0b00000001};
+	const ButtonResolver m_LEFT = ButtonResolver{0b10000000};
+	const ButtonResolver m_DOWN = ButtonResolver{0b01000000};
+	const ButtonResolver m_RIGHT = ButtonResolver{0b00100000};
+	const ButtonResolver m_UP = ButtonResolver{0b00010000};
+	const ButtonResolver m_START = ButtonResolver{0b00001000};
+	const ButtonResolver m_R3 = ButtonResolver{0b00000100};
+	const ButtonResolver m_L3 = ButtonResolver{0b00000010};
+	const ButtonResolver m_SELECT = ButtonResolver{0b00000001};
 
-	const ButtonResolver SQUARE = ButtonResolver{0b10000000};
-	const ButtonResolver CROSS = ButtonResolver{0b01000000};
-	const ButtonResolver CIRCLE = ButtonResolver{0b00100000};
-	const ButtonResolver TRIANGLE = ButtonResolver{0b00010000};
-	const ButtonResolver R1 = ButtonResolver{0b00001000};
-	const ButtonResolver L1 = ButtonResolver{0b00000100};
-	const ButtonResolver R2 = ButtonResolver{0b00000010};
-	const ButtonResolver L2 = ButtonResolver{0b00000001};
+	const ButtonResolver m_SQUARE = ButtonResolver{0b10000000};
+	const ButtonResolver m_CROSS = ButtonResolver{0b01000000};
+	const ButtonResolver m_CIRCLE = ButtonResolver{0b00100000};
+	const ButtonResolver m_TRIANGLE = ButtonResolver{0b00010000};
+	const ButtonResolver m_R1 = ButtonResolver{0b00001000};
+	const ButtonResolver m_L1 = ButtonResolver{0b00000100};
+	const ButtonResolver m_R2 = ButtonResolver{0b00000010};
+	const ButtonResolver m_L2 = ButtonResolver{0b00000001};
 
 	// Checks and returns if button a is pressed or not
 	bool IsButtonPressed(ButtonResolver buttonResolver, u8 const& bufVal);

--- a/pcsx2/Recording/VirtualPad/VirtualPad.cpp
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.cpp
@@ -50,7 +50,7 @@
 #include "Recording/VirtualPad/img/upPressed.h"
 
 
-VirtualPad::VirtualPad(wxWindow* parent, int controllerPort, AppConfig::InputRecordingOptions& options)
+VirtualPad::VirtualPad(wxWindow* parent, int controllerPort, int controllerSlot, AppConfig::InputRecordingOptions& options)
 	: wxFrame(parent, wxID_ANY, wxEmptyString)
 	, options(options)
 {
@@ -129,7 +129,7 @@ VirtualPad::VirtualPad(wxWindow* parent, int controllerPort, AppConfig::InputRec
 
 	// Finalize layout
 	SetIcons(wxGetApp().GetIconBundle());
-	SetTitle(wxString::Format("Virtual Pad - Port %d", controllerPort + 1));
+	SetTitle(wxString::Format("Virtual Pad - Slot %d%c", controllerPort + 1, 'A' + controllerSlot));
 	SetPosition(options.VirtualPadPosition);
 	SetBackgroundColour(*wxWHITE);
 	SetBackgroundStyle(wxBG_STYLE_PAINT);

--- a/pcsx2/Recording/VirtualPad/VirtualPad.cpp
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.cpp
@@ -52,7 +52,7 @@
 
 VirtualPad::VirtualPad(wxWindow* parent, int controllerPort, int controllerSlot, AppConfig::InputRecordingOptions& options)
 	: wxFrame(parent, wxID_ANY, wxEmptyString)
-	, options(options)
+	, m_options(options)
 {
 	// Images at 1.00 scale are designed to work well on HiDPI (4k) at 150% scaling (default recommended setting on windows)
 	// Therefore, on a 1080p monitor we halve the scaling, on 1440p we reduce it by 25%, which from some quick tests looks comparable
@@ -64,57 +64,54 @@ VirtualPad::VirtualPad(wxWindow* parent, int controllerPort, int controllerSlot,
 	const wxRect screen = display.GetClientArea();
 	float dpiScale = MSW_GetDPIScale();                // linux returns 1.0
 	if (screen.height > 1080 && screen.height <= 1440) // 1440p display
-		scalingFactor = 0.75 * dpiScale;
+		m_scalingFactor = 0.75 * dpiScale;
 	else if (screen.height <= 1080) // 1080p display
-	{
-		scalingFactor = 0.5 * dpiScale;
-	}
+		m_scalingFactor = 0.5 * dpiScale;
 	// otherwise use default 1.0 scaling
 
-	virtualPadData = VirtualPadData();
+	m_virtualPadData = VirtualPadData();
 	// Based on the scaling factor, select the appropriate background image
 	// Don't scale these images as they've already been pre-scaled
-	if (floatCompare(scalingFactor, 0.5))
-		virtualPadData.background = NewBitmap(EmbeddedImage<res_controllerHalf>().Get(), wxPoint(0, 0), true);
-	else if (floatCompare(scalingFactor, 0.75))
-		virtualPadData.background = NewBitmap(EmbeddedImage<res_controllerThreeQuarters>().Get(), wxPoint(0, 0), true);
+	if (floatCompare(m_scalingFactor, 0.5))
+		m_virtualPadData.m_background = NewBitmap(EmbeddedImage<res_controllerHalf>().Get(), wxPoint(0, 0), true);
+	else if (floatCompare(m_scalingFactor, 0.75))
+		m_virtualPadData.m_background = NewBitmap(EmbeddedImage<res_controllerThreeQuarters>().Get(), wxPoint(0, 0), true);
 	else
 		// Otherwise, scale down/up (or don't in the case of 1.0) the largst image
-		virtualPadData.background = NewBitmap(EmbeddedImage<res_controllerFull>().Get(), wxPoint(0, 0));
-
+		m_virtualPadData.m_background = NewBitmap(EmbeddedImage<res_controllerFull>().Get(), wxPoint(0, 0));
 	// Use the background image's size to define the window size
-	SetClientSize(virtualPadData.background.width, virtualPadData.background.height);
+	SetClientSize(m_virtualPadData.m_background.m_width, m_virtualPadData.m_background.m_height);
 
 	// These hard-coded pixels correspond to where the background image's components are (ie. the buttons)
 	// Everything is automatically scaled and adjusted based on the `scalingFactor` variable
-	InitPressureButtonGuiElements(virtualPadData.square, NewBitmap(EmbeddedImage<res_squarePressed>().Get(), wxPoint(852, 287)), this, wxPoint(1055, 525));
-	InitPressureButtonGuiElements(virtualPadData.triangle, NewBitmap(EmbeddedImage<res_trianglePressed>().Get(), wxPoint(938, 201)), this, wxPoint(1055, 565));
-	InitPressureButtonGuiElements(virtualPadData.circle, NewBitmap(EmbeddedImage<res_circlePressed>().Get(), wxPoint(1024, 286)), this, wxPoint(1055, 605));
-	InitPressureButtonGuiElements(virtualPadData.cross, NewBitmap(EmbeddedImage<res_crossPressed>().Get(), wxPoint(938, 369)), this, wxPoint(1055, 645));
+	InitPressureButtonGuiElements(m_virtualPadData.m_square, NewBitmap(EmbeddedImage<res_squarePressed>().Get(), wxPoint(852, 287)), this, wxPoint(1055, 525));
+	InitPressureButtonGuiElements(m_virtualPadData.m_triangle, NewBitmap(EmbeddedImage<res_trianglePressed>().Get(), wxPoint(938, 201)), this, wxPoint(1055, 565));
+	InitPressureButtonGuiElements(m_virtualPadData.m_circle, NewBitmap(EmbeddedImage<res_circlePressed>().Get(), wxPoint(1024, 286)), this, wxPoint(1055, 605));
+	InitPressureButtonGuiElements(m_virtualPadData.m_cross, NewBitmap(EmbeddedImage<res_crossPressed>().Get(), wxPoint(938, 369)), this, wxPoint(1055, 645));
 
-	InitPressureButtonGuiElements(virtualPadData.left, NewBitmap(EmbeddedImage<res_leftPressed>().Get(), wxPoint(110, 303)), this, wxPoint(175, 525), true);
-	InitPressureButtonGuiElements(virtualPadData.up, NewBitmap(EmbeddedImage<res_upPressed>().Get(), wxPoint(186, 227)), this, wxPoint(175, 565), true);	
-	InitPressureButtonGuiElements(virtualPadData.right, NewBitmap(EmbeddedImage<res_rightPressed>().Get(), wxPoint(248, 302)), this, wxPoint(175, 605), true);
-	InitPressureButtonGuiElements(virtualPadData.down, NewBitmap(EmbeddedImage<res_downPressed>().Get(), wxPoint(186, 359)), this, wxPoint(175, 645), true);
+	InitPressureButtonGuiElements(m_virtualPadData.m_left, NewBitmap(EmbeddedImage<res_leftPressed>().Get(), wxPoint(110, 303)), this, wxPoint(175, 525), true);
+	InitPressureButtonGuiElements(m_virtualPadData.m_up, NewBitmap(EmbeddedImage<res_upPressed>().Get(), wxPoint(186, 227)), this, wxPoint(175, 565), true);	
+	InitPressureButtonGuiElements(m_virtualPadData.m_right, NewBitmap(EmbeddedImage<res_rightPressed>().Get(), wxPoint(248, 302)), this, wxPoint(175, 605), true);
+	InitPressureButtonGuiElements(m_virtualPadData.m_down, NewBitmap(EmbeddedImage<res_downPressed>().Get(), wxPoint(186, 359)), this, wxPoint(175, 645), true);
 
-	InitPressureButtonGuiElements(virtualPadData.l1, NewBitmap(EmbeddedImage<res_l1Pressed>().Get(), wxPoint(156, 98)), this, wxPoint(170, 135));
-	InitPressureButtonGuiElements(virtualPadData.l2, NewBitmap(EmbeddedImage<res_l2Pressed>().Get(), wxPoint(156, 57)), this, wxPoint(170, 52), false, true);
-	InitPressureButtonGuiElements(virtualPadData.r1, NewBitmap(EmbeddedImage<res_r1Pressed>().Get(), wxPoint(921, 98)), this, wxPoint(1035, 135), true);
-	InitPressureButtonGuiElements(virtualPadData.r2, NewBitmap(EmbeddedImage<res_r2Pressed>().Get(), wxPoint(921, 57)), this, wxPoint(1035, 52), true, true);
+	InitPressureButtonGuiElements(m_virtualPadData.m_l1, NewBitmap(EmbeddedImage<res_l1Pressed>().Get(), wxPoint(156, 98)), this, wxPoint(170, 135));
+	InitPressureButtonGuiElements(m_virtualPadData.m_l2, NewBitmap(EmbeddedImage<res_l2Pressed>().Get(), wxPoint(156, 57)), this, wxPoint(170, 52), false, true);
+	InitPressureButtonGuiElements(m_virtualPadData.m_r1, NewBitmap(EmbeddedImage<res_r1Pressed>().Get(), wxPoint(921, 98)), this, wxPoint(1035, 135), true);
+	InitPressureButtonGuiElements(m_virtualPadData.m_r2, NewBitmap(EmbeddedImage<res_r2Pressed>().Get(), wxPoint(921, 57)), this, wxPoint(1035, 52), true, true);
 
-	InitNormalButtonGuiElements(virtualPadData.select, NewBitmap(EmbeddedImage<res_selectPressed>().Get(), wxPoint(458, 313)), this, wxPoint(530, 315));
-	InitNormalButtonGuiElements(virtualPadData.start, NewBitmap(EmbeddedImage<res_startPressed>().Get(), wxPoint(688, 311)), this, wxPoint(646, 315));
-	InitNormalButtonGuiElements(virtualPadData.l3, NewBitmap(EmbeddedImage<res_l3Pressed>().Get(), wxPoint(336, 453)), this, wxPoint(560, 638));
-	InitNormalButtonGuiElements(virtualPadData.r3, NewBitmap(EmbeddedImage<res_r3Pressed>().Get(), wxPoint(726, 453)), this, wxPoint(615, 638));
+	InitNormalButtonGuiElements(m_virtualPadData.m_select, NewBitmap(EmbeddedImage<res_selectPressed>().Get(), wxPoint(458, 313)), this, wxPoint(530, 315));
+	InitNormalButtonGuiElements(m_virtualPadData.m_start, NewBitmap(EmbeddedImage<res_startPressed>().Get(), wxPoint(688, 311)), this, wxPoint(646, 315));
+	InitNormalButtonGuiElements(m_virtualPadData.m_l3, NewBitmap(EmbeddedImage<res_l3Pressed>().Get(), wxPoint(336, 453)), this, wxPoint(560, 638));
+	InitNormalButtonGuiElements(m_virtualPadData.m_r3, NewBitmap(EmbeddedImage<res_r3Pressed>().Get(), wxPoint(726, 453)), this, wxPoint(615, 638));
 
-	InitAnalogStickGuiElements(virtualPadData.leftAnalog, this, wxPoint(404, 522), 100, wxPoint(314, 642), wxPoint(526, 432), false, wxPoint(504, 685), wxPoint(570, 425), true);
-	InitAnalogStickGuiElements(virtualPadData.rightAnalog, this, wxPoint(794, 522), 100, wxPoint(706, 642), wxPoint(648, 432), true, wxPoint(700, 685), wxPoint(635, 425));
+	InitAnalogStickGuiElements(m_virtualPadData.m_leftAnalog, this, wxPoint(404, 522), 100, wxPoint(314, 642), wxPoint(526, 432), false, wxPoint(504, 685), wxPoint(570, 425), true);
+	InitAnalogStickGuiElements(m_virtualPadData.m_rightAnalog, this, wxPoint(794, 522), 100, wxPoint(706, 642), wxPoint(648, 432), true, wxPoint(700, 685), wxPoint(635, 425));
 
-	ignoreRealControllerBox = new wxCheckBox(this, wxID_ANY, wxEmptyString, ScaledPoint(wxPoint(586, 135)), wxDefaultSize);
-	resetButton = new wxButton(this, wxID_ANY, _("Reset"), ScaledPoint(wxPoint(1195, 5), wxSize(100, 50), true), ScaledSize(wxSize(100, 50)));
+	m_ignoreRealControllerBox = new wxCheckBox(this, wxID_ANY, wxEmptyString, ScaledPoint(wxPoint(586, 135)), wxDefaultSize);
+	m_resetButton = new wxButton(this, wxID_ANY, _("Reset"), ScaledPoint(wxPoint(1195, 5), wxSize(100, 50), true), ScaledSize(wxSize(100, 50)));
 
-	Bind(wxEVT_CHECKBOX, &VirtualPad::OnIgnoreRealController, this, ignoreRealControllerBox->GetId());
-	Bind(wxEVT_BUTTON, &VirtualPad::OnResetButton, this, resetButton->GetId());
+	Bind(wxEVT_CHECKBOX, &VirtualPad::OnIgnoreRealController, this, m_ignoreRealControllerBox->GetId());
+	Bind(wxEVT_BUTTON, &VirtualPad::OnResetButton, this, m_resetButton->GetId());
 
 	// Bind Window Events
 	Bind(wxEVT_MOVE, &VirtualPad::OnMoveAround, this);
@@ -146,14 +143,14 @@ void VirtualPad::OnMoveAround(wxMoveEvent& event)
 		return;
 
 	if (!IsMaximized())
-		options.VirtualPadPosition = GetPosition();
+		m_options.VirtualPadPosition = GetPosition();
 	event.Skip();
 }
 
 void VirtualPad::OnClose(wxCloseEvent& event)
 {
 	// Re-bind the Paint event in case this is due to a game being opened/closed
-	manualRedrawMode = false;
+	m_manualRedrawMode = false;
 	Bind(wxEVT_PAINT, &VirtualPad::OnPaint, this);
 	// DevCon.WriteLn("Paint Event Bound");
 	Hide();
@@ -163,7 +160,7 @@ void VirtualPad::OnIconize(wxIconizeEvent& event)
 {
 	if (event.IsIconized())
 	{
-		manualRedrawMode = false;
+		m_manualRedrawMode = false;
 		Bind(wxEVT_PAINT, &VirtualPad::OnPaint, this);
 		// DevCon.WriteLn("Paint Event Bound");
 	}
@@ -192,25 +189,25 @@ void VirtualPad::Redraw()
 void VirtualPad::Render(wxDC& bdc)
 {
 	// Update GUI Elements and figure out what needs to be rendered
-	for (VirtualPadElement* virtualPadElement : virtualPadElements)
-		virtualPadElement->UpdateGuiElement(renderQueue, clearScreenRequired);
+	for (VirtualPadElement* virtualPadElement : m_virtualPadElements)
+		virtualPadElement->UpdateGuiElement(m_renderQueue, m_clearScreenRequired);
 
 	// Update Graphic Elements off render stack
 	// Before we start rendering (if we have to) clear and re-draw the background
-	if (!manualRedrawMode || clearScreenRequired || !renderQueue.empty())
+	if (!m_manualRedrawMode || m_clearScreenRequired || !m_renderQueue.empty())
 	{
 		bdc.SetBrush(*wxWHITE);
 		bdc.DrawRectangle(wxPoint(0, 0), bdc.GetSize());
 		bdc.SetBrush(wxNullBrush);
-		bdc.DrawBitmap(virtualPadData.background.image, virtualPadData.background.coords, true);
-		clearScreenRequired = false;
+		bdc.DrawBitmap(m_virtualPadData.m_background.m_image, m_virtualPadData.m_background.m_coords, true);
+		m_clearScreenRequired = false;
 
 		// Switch to Manual Rendering once the first user action on the VirtualPad is taken
-		if (!manualRedrawMode && !renderQueue.empty())
+		if (!m_manualRedrawMode && !m_renderQueue.empty())
 		{
 			// DevCon.WriteLn("Paint Event Unbound");
 			Unbind(wxEVT_PAINT, &VirtualPad::OnPaint, this);
-			manualRedrawMode = true;
+			m_manualRedrawMode = true;
 		}
 
 		// NOTE - there is yet another (and I think final) micro-optimization that can be done:
@@ -220,106 +217,106 @@ void VirtualPad::Render(wxDC& bdc)
 		// despite the screen never being cleared - so this is not strictly necessary.
 		//
 		// Though after some tests, the performance impact is well within reason, and on the hardware renderer modes, is almost non-existant.
-		while (!renderQueue.empty())
+		while (!m_renderQueue.empty())
 		{
-			VirtualPadElement* element = renderQueue.front();
+			VirtualPadElement* element = m_renderQueue.front();
 			if (element)
 				element->Render(bdc);
-			renderQueue.pop();
+			m_renderQueue.pop();
 		}
 	}
 }
 
 bool VirtualPad::UpdateControllerData(u16 const bufIndex, PadData* padData)
 {
-	return virtualPadData.UpdateVirtualPadData(bufIndex, padData, ignoreRealController && !readOnlyMode, readOnlyMode);
+	return m_virtualPadData.UpdateVirtualPadData(bufIndex, padData, m_ignoreRealController && !m_readOnlyMode, m_readOnlyMode);
 }
 
 void VirtualPad::enableUiElements(bool enable)
 {
-	ignoreRealControllerBox->Enable(enable);
-	resetButton->Enable(enable);
-	for (VirtualPadElement* virtualPadElement : virtualPadElements)
+	m_ignoreRealControllerBox->Enable(enable);
+	m_resetButton->Enable(enable);
+	for (VirtualPadElement* virtualPadElement : m_virtualPadElements)
 		virtualPadElement->EnableWidgets(enable);
 }
 
 void VirtualPad::SetReadOnlyMode(bool readOnly)
 {
 	enableUiElements(!readOnly);
-	readOnlyMode = readOnly;
+	m_readOnlyMode = readOnly;
 }
 
 void VirtualPad::OnIgnoreRealController(wxCommandEvent& event)
 {
 	const wxCheckBox* ignoreButton = (wxCheckBox*)event.GetEventObject();
 	if (ignoreButton)
-		ignoreRealController = ignoreButton->GetValue();
+		m_ignoreRealController = ignoreButton->GetValue();
 }
 
 void VirtualPad::OnResetButton(wxCommandEvent& event)
 {
-	if (readOnlyMode)
+	if (m_readOnlyMode)
 		return;
 
-	for (VirtualPadElement* virtualPadElement : virtualPadElements)
+	for (VirtualPadElement* virtualPadElement : m_virtualPadElements)
 		virtualPadElement->Reset(this);
 }
 
 void VirtualPad::OnNormalButtonPress(wxCommandEvent& event)
 {
 	const wxCheckBox* pressedButton = (wxCheckBox*)event.GetEventObject();
-	ControllerNormalButton* eventBtn = buttonElements[pressedButton->GetId()];
+	ControllerNormalButton* eventBtn = m_buttonElements[pressedButton->GetId()];
 
 	if (pressedButton)
-		eventBtn->pressed = pressedButton->GetValue();
+		eventBtn->m_pressed = pressedButton->GetValue();
 
-	if (!eventBtn->isControllerPressBypassed)
-		eventBtn->isControllerPressBypassed = true;
+	if (!eventBtn->m_isControllerPressBypassed)
+		eventBtn->m_isControllerPressBypassed = true;
 }
 
 void VirtualPad::OnPressureButtonPressureChange(wxCommandEvent& event)
 {
 	const wxSpinCtrl* pressureSpinner = (wxSpinCtrl*)event.GetEventObject();
-	ControllerPressureButton* eventBtn = pressureElements[pressureSpinner->GetId()];
+	ControllerPressureButton* eventBtn = m_pressureElements[pressureSpinner->GetId()];
 
 	if (pressureSpinner)
-		eventBtn->pressure = pressureSpinner->GetValue();
+		eventBtn->m_pressure = pressureSpinner->GetValue();
 
-	eventBtn->pressed = eventBtn->pressure > 0;
+	eventBtn->m_pressed = eventBtn->m_pressure > 0;
 
-	if (!eventBtn->isControllerPressureBypassed || !eventBtn->isControllerPressBypassed)
+	if (!eventBtn->m_isControllerPressureBypassed || !eventBtn->m_isControllerPressBypassed)
 	{
-		eventBtn->isControllerPressureBypassed = true;
-		eventBtn->isControllerPressBypassed = true;
+		eventBtn->m_isControllerPressureBypassed = true;
+		eventBtn->m_isControllerPressBypassed = true;
 	}
 }
 
 void VirtualPad::OnAnalogSpinnerChange(wxCommandEvent& event)
 {
 	const wxSpinCtrl* analogSpinner = (wxSpinCtrl*)event.GetEventObject();
-	AnalogVector* eventVector = analogElements[analogSpinner->GetId()];
+	AnalogVector* eventVector = m_analogElements[analogSpinner->GetId()];
 
 	if (analogSpinner)
-		eventVector->val = analogSpinner->GetValue();
+		eventVector->m_val = analogSpinner->GetValue();
 
-	eventVector->slider->SetValue(eventVector->val);
+	eventVector->m_slider->SetValue(eventVector->m_val);
 
-	if (!eventVector->isControllerBypassed)
-		eventVector->isControllerBypassed = true;
+	if (!eventVector->m_isControllerBypassed)
+		eventVector->m_isControllerBypassed = true;
 }
 
 void VirtualPad::OnAnalogSliderChange(wxCommandEvent& event)
 {
 	const wxSlider* analogSlider = (wxSlider*)event.GetEventObject();
-	AnalogVector* eventVector = analogElements[analogSlider->GetId()];
+	AnalogVector* eventVector = m_analogElements[analogSlider->GetId()];
 
 	if (analogSlider)
-		eventVector->val = analogSlider->GetValue();
+		eventVector->m_val = analogSlider->GetValue();
 
-	eventVector->spinner->SetValue(eventVector->val);
+	eventVector->m_spinner->SetValue(eventVector->m_val);
 
-	if (!eventVector->isControllerBypassed)
-		eventVector->isControllerBypassed = true;
+	if (!eventVector->m_isControllerBypassed)
+		eventVector->m_isControllerBypassed = true;
 }
 
 /// GUI Element Utility Functions
@@ -336,16 +333,16 @@ wxPoint VirtualPad::ScaledPoint(wxPoint point, wxSize widgetWidth, bool rightAli
 
 wxPoint VirtualPad::ScaledPoint(int x, int y, int widgetWidth, int widgetHeight, bool rightAlignedCoord, bool bottomAlignedCoord)
 {
-	wxPoint scaledPoint = wxPoint(x * scalingFactor, y * scalingFactor);
+	wxPoint scaledPoint = wxPoint(x * m_scalingFactor, y * m_scalingFactor);
 	if (rightAlignedCoord)
 	{
-		scaledPoint.x -= widgetWidth * scalingFactor;
+		scaledPoint.x -= widgetWidth * m_scalingFactor;
 		if (scaledPoint.x < 0)
 			scaledPoint.x = 0;
 	}
 	if (bottomAlignedCoord)
 	{
-		scaledPoint.y -= widgetHeight * scalingFactor;
+		scaledPoint.y -= widgetHeight * m_scalingFactor;
 		if (scaledPoint.y < 0)
 			scaledPoint.y = 0;
 	}
@@ -359,12 +356,12 @@ wxSize VirtualPad::ScaledSize(wxSize size)
 
 wxSize VirtualPad::ScaledSize(int x, int y)
 {
-	return wxSize(x * scalingFactor, y * scalingFactor);
+	return wxSize(x * m_scalingFactor, y * m_scalingFactor);
 }
 
 ImageFile VirtualPad::NewBitmap(wxImage resource, wxPoint imgCoord, bool dontScale)
 {
-	return NewBitmap(dontScale ? 1 : scalingFactor, resource, imgCoord);
+	return NewBitmap(dontScale ? 1 : m_scalingFactor, resource, imgCoord);
 }
 
 ImageFile VirtualPad::NewBitmap(float scalingFactor, wxImage resource, wxPoint imgCoord)
@@ -372,67 +369,67 @@ ImageFile VirtualPad::NewBitmap(float scalingFactor, wxImage resource, wxPoint i
 	wxBitmap bitmap = wxBitmap(resource.Rescale(resource.GetWidth() * scalingFactor, resource.GetHeight() * scalingFactor, wxIMAGE_QUALITY_HIGH));
 
 	ImageFile image = ImageFile();
-	image.image = bitmap;
-	image.width = bitmap.GetWidth();
-	image.height = bitmap.GetHeight();
-	image.coords = ScaledPoint(imgCoord);
+	image.m_image = bitmap;
+	image.m_width = bitmap.GetWidth();
+	image.m_height = bitmap.GetHeight();
+	image.m_coords = ScaledPoint(imgCoord);
 	return image;
 }
 
 void VirtualPad::InitNormalButtonGuiElements(ControllerNormalButton& button, ImageFile image, wxWindow* parentWindow, wxPoint checkboxCoord)
 {
-	button.icon = image;
-	button.pressedBox = new wxCheckBox(parentWindow, wxID_ANY, wxEmptyString, ScaledPoint(checkboxCoord), wxDefaultSize);
-	Bind(wxEVT_CHECKBOX, &VirtualPad::OnNormalButtonPress, this, button.pressedBox->GetId());
-	buttonElements[button.pressedBox->GetId()] = &button;
-	virtualPadElements.push_back(&button);
+	button.m_icon = image;
+	button.m_pressedBox = new wxCheckBox(parentWindow, wxID_ANY, wxEmptyString, ScaledPoint(checkboxCoord), wxDefaultSize);
+	Bind(wxEVT_CHECKBOX, &VirtualPad::OnNormalButtonPress, this, button.m_pressedBox->GetId());
+	m_buttonElements[button.m_pressedBox->GetId()] = &button;
+	m_virtualPadElements.push_back(&button);
 }
 
 void VirtualPad::InitPressureButtonGuiElements(ControllerPressureButton& button, ImageFile image, wxWindow* parentWindow, wxPoint pressureSpinnerCoord, bool rightAlignedCoord, bool bottomAlignedCoord)
 {
-	const wxPoint scaledPoint = ScaledPoint(pressureSpinnerCoord, SPINNER_SIZE, rightAlignedCoord, bottomAlignedCoord);
-	wxSpinCtrl* spinner = new wxSpinCtrl(parentWindow, wxID_ANY, wxEmptyString, scaledPoint, ScaledSize(SPINNER_SIZE), wxSP_ARROW_KEYS, 0, 255, 0);
+	const wxPoint scaledPoint = ScaledPoint(pressureSpinnerCoord, m_SPINNER_SIZE, rightAlignedCoord, bottomAlignedCoord);
+	wxSpinCtrl* spinner = new wxSpinCtrl(parentWindow, wxID_ANY, wxEmptyString, scaledPoint, ScaledSize(m_SPINNER_SIZE), wxSP_ARROW_KEYS, 0, 255, 0);
 
-	button.icon = image;
-	button.pressureSpinner = spinner;
-	Bind(wxEVT_SPINCTRL, &VirtualPad::OnPressureButtonPressureChange, this, button.pressureSpinner->GetId());
-	pressureElements[button.pressureSpinner->GetId()] = &button;
-	virtualPadElements.push_back(&button);
+	button.m_icon = image;
+	button.m_pressureSpinner = spinner;
+	Bind(wxEVT_SPINCTRL, &VirtualPad::OnPressureButtonPressureChange, this, button.m_pressureSpinner->GetId());
+	m_pressureElements[button.m_pressureSpinner->GetId()] = &button;
+	m_virtualPadElements.push_back(&button);
 }
 
 void VirtualPad::InitAnalogStickGuiElements(AnalogStick& analog, wxWindow* parentWindow, wxPoint centerPoint, int radius,
 											wxPoint xSliderPoint, wxPoint ySliderPoint, bool flipYSlider, wxPoint xSpinnerPoint, wxPoint ySpinnerPoint, bool rightAlignedSpinners)
 {
 	AnalogPosition analogPos = AnalogPosition();
-	analogPos.centerCoords = ScaledPoint(centerPoint);
-	analogPos.endCoords = ScaledPoint(centerPoint);
-	analogPos.radius = radius * scalingFactor;
-	analogPos.lineThickness = 6 * scalingFactor;
+	analogPos.m_centerCoords = ScaledPoint(centerPoint);
+	analogPos.m_endCoords = ScaledPoint(centerPoint);
+	analogPos.m_radius = radius * m_scalingFactor;
+	analogPos.m_lineThickness = 6 * m_scalingFactor;
 
-	const wxPoint xSpinnerScaledPoint = ScaledPoint(xSpinnerPoint, SPINNER_SIZE, rightAlignedSpinners);
-	const wxPoint ySpinnerScaledPoint = ScaledPoint(ySpinnerPoint, SPINNER_SIZE, rightAlignedSpinners, true);
+	const wxPoint xSpinnerScaledPoint = ScaledPoint(xSpinnerPoint, m_SPINNER_SIZE, rightAlignedSpinners);
+	const wxPoint ySpinnerScaledPoint = ScaledPoint(ySpinnerPoint, m_SPINNER_SIZE, rightAlignedSpinners, true);
 
-	wxSlider* xSlider = new wxSlider(parentWindow, wxID_ANY, ANALOG_NEUTRAL, 0, ANALOG_MAX,
-									 ScaledPoint(xSliderPoint), ScaledSize(ANALOG_SLIDER_WIDTH, ANALOG_SLIDER_HEIGHT));
-	wxSlider* ySlider = new wxSlider(parentWindow, wxID_ANY, ANALOG_NEUTRAL, 0, ANALOG_MAX,
-									 ScaledPoint(ySliderPoint), ScaledSize(ANALOG_SLIDER_HEIGHT, ANALOG_SLIDER_WIDTH), flipYSlider ? wxSL_LEFT : wxSL_RIGHT);
-	wxSpinCtrl* xSpinner = new wxSpinCtrl(parentWindow, wxID_ANY, wxEmptyString, xSpinnerScaledPoint, ScaledSize(SPINNER_SIZE), wxSP_ARROW_KEYS, 0, 255, 127);
-	wxSpinCtrl* ySpinner = new wxSpinCtrl(parentWindow, wxID_ANY, wxEmptyString, ySpinnerScaledPoint, ScaledSize(SPINNER_SIZE), wxSP_ARROW_KEYS, 0, 255, 127);
+	wxSlider* xSlider = new wxSlider(parentWindow, wxID_ANY, s_ANALOG_NEUTRAL, 0, s_ANALOG_MAX,
+									 ScaledPoint(xSliderPoint), ScaledSize(s_ANALOG_SLIDER_WIDTH, s_ANALOG_SLIDER_HEIGHT));
+	wxSlider* ySlider = new wxSlider(parentWindow, wxID_ANY, s_ANALOG_NEUTRAL, 0, s_ANALOG_MAX,
+									 ScaledPoint(ySliderPoint), ScaledSize(s_ANALOG_SLIDER_HEIGHT, s_ANALOG_SLIDER_WIDTH), flipYSlider ? wxSL_LEFT : wxSL_RIGHT);
+	wxSpinCtrl* xSpinner = new wxSpinCtrl(parentWindow, wxID_ANY, wxEmptyString, xSpinnerScaledPoint, ScaledSize(m_SPINNER_SIZE), wxSP_ARROW_KEYS, 0, 255, 127);
+	wxSpinCtrl* ySpinner = new wxSpinCtrl(parentWindow, wxID_ANY, wxEmptyString, ySpinnerScaledPoint, ScaledSize(m_SPINNER_SIZE), wxSP_ARROW_KEYS, 0, 255, 127);
 
-	analog.xVector.slider = xSlider;
-	analog.yVector.slider = ySlider;
-	analog.xVector.spinner = xSpinner;
-	analog.yVector.spinner = ySpinner;
-	analog.positionGraphic = analogPos;
+	analog.m_xVector.m_slider = xSlider;
+	analog.m_yVector.m_slider = ySlider;
+	analog.m_xVector.m_spinner = xSpinner;
+	analog.m_yVector.m_spinner = ySpinner;
+	analog.m_positionGraphic = analogPos;
 	Bind(wxEVT_SLIDER, &VirtualPad::OnAnalogSliderChange, this, xSlider->GetId());
 	Bind(wxEVT_SLIDER, &VirtualPad::OnAnalogSliderChange, this, ySlider->GetId());
 	Bind(wxEVT_SPINCTRL, &VirtualPad::OnAnalogSpinnerChange, this, xSpinner->GetId());
 	Bind(wxEVT_SPINCTRL, &VirtualPad::OnAnalogSpinnerChange, this, ySpinner->GetId());
-	analogElements[xSlider->GetId()] = &analog.xVector;
-	analogElements[ySlider->GetId()] = &analog.yVector;
-	analogElements[xSpinner->GetId()] = &analog.xVector;
-	analogElements[ySpinner->GetId()] = &analog.yVector;
-	virtualPadElements.push_back(&analog);
+	m_analogElements[xSlider->GetId()] = &analog.m_xVector;
+	m_analogElements[ySlider->GetId()] = &analog.m_yVector;
+	m_analogElements[xSpinner->GetId()] = &analog.m_xVector;
+	m_analogElements[ySpinner->GetId()] = &analog.m_yVector;
+	m_virtualPadElements.push_back(&analog);
 }
 
 #endif

--- a/pcsx2/Recording/VirtualPad/VirtualPad.h
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.h
@@ -49,37 +49,37 @@ public:
 
 private:
 	/// Constants
-	const wxSize SPINNER_SIZE = wxSize(100, 40);
-	static const int ANALOG_SLIDER_WIDTH = 185;
-	static const int ANALOG_SLIDER_HEIGHT = 30;
+	const wxSize m_SPINNER_SIZE = wxSize(100, 40);
+	static const int s_ANALOG_SLIDER_WIDTH = 185;
+	static const int s_ANALOG_SLIDER_HEIGHT = 30;
 
-	static const int PRESSURE_MAX = 255;
-	static const int ANALOG_NEUTRAL = 127;
-	static const int ANALOG_MAX = 255;
+	static const int s_PRESSURE_MAX = 255;
+	static const int s_ANALOG_NEUTRAL = 127;
+	static const int s_ANALOG_MAX = 255;
 
-	AppConfig::InputRecordingOptions& options;
+	AppConfig::InputRecordingOptions& m_options;
 
-	bool clearScreenRequired = false;
-	bool ignoreRealController = false;
+	bool m_clearScreenRequired = false;
+	bool m_ignoreRealController = false;
 	// When enabled, forces the VirtualPad to be re-rendered even if no updates are made.
 	// This helps to make sure the UI is rendered prior to receiving data from the controller
-	bool manualRedrawMode = false;
-	bool readOnlyMode = false;
+	bool m_manualRedrawMode = false;
+	bool m_readOnlyMode = false;
 
-	VirtualPadData virtualPadData;
+	VirtualPadData m_virtualPadData;
 
-	std::vector<VirtualPadElement*> virtualPadElements;
-	std::queue<VirtualPadElement*> renderQueue;
+	std::vector<VirtualPadElement*> m_virtualPadElements;
+	std::queue<VirtualPadElement*> m_renderQueue;
 
 	void enableUiElements(bool enable);
 
 	/// GUI Elements
-	wxCheckBox* ignoreRealControllerBox;
-	wxButton* resetButton;
+	wxCheckBox* m_ignoreRealControllerBox;
+	wxButton* m_resetButton;
 
-	std::map<wxWindowID, ControllerNormalButton*> buttonElements;
-	std::map<wxWindowID, ControllerPressureButton*> pressureElements;
-	std::map<wxWindowID, AnalogVector*> analogElements;
+	std::map<wxWindowID, ControllerNormalButton*> m_buttonElements;
+	std::map<wxWindowID, ControllerPressureButton*> m_pressureElements;
+	std::map<wxWindowID, AnalogVector*> m_analogElements;
 
 	/// Event Listeners
 	void OnMoveAround(wxMoveEvent& event);
@@ -97,7 +97,7 @@ private:
 	void OnResetButton(wxCommandEvent& event);
 
 	/// GUI Creation Utility Functions
-	float scalingFactor = 1.0;
+	float m_scalingFactor = 1.0;
 	bool floatCompare(float A, float B, float epsilon = 0.005f);
 
 	wxSize ScaledSize(wxSize size);

--- a/pcsx2/Recording/VirtualPad/VirtualPad.h
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.h
@@ -32,13 +32,12 @@
 #include "wx/window.h"
 #include "wx/windowid.h"
 
-#include "Recording/PadData.h"
 #include "Recording/VirtualPad/VirtualPadData.h"
 
 class VirtualPad : public wxFrame
 {
 public:
-	VirtualPad(wxWindow* parent, int controllerPort, AppConfig::InputRecordingOptions& options);
+	VirtualPad(wxWindow* parent, int controllerPort, int controllerSlot, AppConfig::InputRecordingOptions& options);
 	// Updates the VirtualPad's data if necessary, as well as updates the provided PadData if the VirtualPad overrides it
 	// - PadData will not be updated if ReadOnly mode is set
 	// - returns a bool to indicate if the PadData has been updated

--- a/pcsx2/Recording/VirtualPad/VirtualPadData.cpp
+++ b/pcsx2/Recording/VirtualPad/VirtualPadData.cpp
@@ -26,57 +26,57 @@ bool VirtualPadData::UpdateVirtualPadData(u16 bufIndex, PadData* padData, bool i
 	switch (index)
 	{
 		case PadData::BufferIndex::PressedFlagsGroupOne:
-			changeDetected |= left.UpdateData(padData->leftPressed, ignoreRealController, readOnly);
-			changeDetected |= down.UpdateData(padData->downPressed, ignoreRealController, readOnly);
-			changeDetected |= right.UpdateData(padData->rightPressed, ignoreRealController, readOnly);
-			changeDetected |= up.UpdateData(padData->upPressed, ignoreRealController, readOnly);
-			changeDetected |= start.UpdateData(padData->start, ignoreRealController, readOnly);
-			changeDetected |= r3.UpdateData(padData->r3, ignoreRealController, readOnly);
-			changeDetected |= l3.UpdateData(padData->l3, ignoreRealController, readOnly);
-			changeDetected |= select.UpdateData(padData->select, ignoreRealController, readOnly);
+			changeDetected |= m_left.UpdateData(padData->m_leftPressed, ignoreRealController, readOnly);
+			changeDetected |= m_down.UpdateData(padData->m_downPressed, ignoreRealController, readOnly);
+			changeDetected |= m_right.UpdateData(padData->m_rightPressed, ignoreRealController, readOnly);
+			changeDetected |= m_up.UpdateData(padData->m_upPressed, ignoreRealController, readOnly);
+			changeDetected |= m_start.UpdateData(padData->m_start, ignoreRealController, readOnly);
+			changeDetected |= m_r3.UpdateData(padData->m_r3, ignoreRealController, readOnly);
+			changeDetected |= m_l3.UpdateData(padData->m_l3, ignoreRealController, readOnly);
+			changeDetected |= m_select.UpdateData(padData->m_select, ignoreRealController, readOnly);
 			return changeDetected;
 		case PadData::BufferIndex::PressedFlagsGroupTwo:
-			changeDetected |= square.UpdateData(padData->squarePressed, ignoreRealController, readOnly);
-			changeDetected |= cross.UpdateData(padData->crossPressed, ignoreRealController, readOnly);
-			changeDetected |= circle.UpdateData(padData->circlePressed, ignoreRealController, readOnly);
-			changeDetected |= triangle.UpdateData(padData->trianglePressed, ignoreRealController, readOnly);
-			changeDetected |= r1.UpdateData(padData->r1Pressed, ignoreRealController, readOnly);
-			changeDetected |= l1.UpdateData(padData->l1Pressed, ignoreRealController, readOnly);
-			changeDetected |= r2.UpdateData(padData->r2Pressed, ignoreRealController, readOnly);
-			changeDetected |= l2.UpdateData(padData->l2Pressed, ignoreRealController, readOnly);
+			changeDetected |= m_square.UpdateData(padData->m_squarePressed, ignoreRealController, readOnly);
+			changeDetected |= m_cross.UpdateData(padData->m_crossPressed, ignoreRealController, readOnly);
+			changeDetected |= m_circle.UpdateData(padData->m_circlePressed, ignoreRealController, readOnly);
+			changeDetected |= m_triangle.UpdateData(padData->m_trianglePressed, ignoreRealController, readOnly);
+			changeDetected |= m_r1.UpdateData(padData->m_r1Pressed, ignoreRealController, readOnly);
+			changeDetected |= m_l1.UpdateData(padData->m_l1Pressed, ignoreRealController, readOnly);
+			changeDetected |= m_r2.UpdateData(padData->m_r2Pressed, ignoreRealController, readOnly);
+			changeDetected |= m_l2.UpdateData(padData->m_l2Pressed, ignoreRealController, readOnly);
 			return changeDetected;
 		case PadData::BufferIndex::RightAnalogXVector:
-			return rightAnalog.xVector.UpdateData(padData->rightAnalogX, ignoreRealController, readOnly);
+			return m_rightAnalog.m_xVector.UpdateData(padData->m_rightAnalogX, ignoreRealController, readOnly);
 		case PadData::BufferIndex::RightAnalogYVector:
-			return rightAnalog.yVector.UpdateData(padData->rightAnalogY, ignoreRealController, readOnly);
+			return m_rightAnalog.m_yVector.UpdateData(padData->m_rightAnalogY, ignoreRealController, readOnly);
 		case PadData::BufferIndex::LeftAnalogXVector:
-			return leftAnalog.xVector.UpdateData(padData->leftAnalogX, ignoreRealController, readOnly);
+			return m_leftAnalog.m_xVector.UpdateData(padData->m_leftAnalogX, ignoreRealController, readOnly);
 		case PadData::BufferIndex::LeftAnalogYVector:
-			return leftAnalog.yVector.UpdateData(padData->leftAnalogY, ignoreRealController, readOnly);
+			return m_leftAnalog.m_yVector.UpdateData(padData->m_leftAnalogY, ignoreRealController, readOnly);
 		case PadData::BufferIndex::RightPressure:
-			return right.UpdateData(padData->rightPressure, ignoreRealController, readOnly);
+			return m_right.UpdateData(padData->m_rightPressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::LeftPressure:
-			return left.UpdateData(padData->leftPressure, ignoreRealController, readOnly);
+			return m_left.UpdateData(padData->m_leftPressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::UpPressure:
-			return up.UpdateData(padData->upPressure, ignoreRealController, readOnly);
+			return m_up.UpdateData(padData->m_upPressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::DownPressure:
-			return down.UpdateData(padData->downPressure, ignoreRealController, readOnly);
+			return m_down.UpdateData(padData->m_downPressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::TrianglePressure:
-			return triangle.UpdateData(padData->trianglePressure, ignoreRealController, readOnly);
+			return m_triangle.UpdateData(padData->m_trianglePressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::CirclePressure:
-			return circle.UpdateData(padData->circlePressure, ignoreRealController, readOnly);
+			return m_circle.UpdateData(padData->m_circlePressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::CrossPressure:
-			return cross.UpdateData(padData->crossPressure, ignoreRealController, readOnly);
+			return m_cross.UpdateData(padData->m_crossPressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::SquarePressure:
-			return square.UpdateData(padData->squarePressure, ignoreRealController, readOnly);
+			return m_square.UpdateData(padData->m_squarePressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::L1Pressure:
-			return l1.UpdateData(padData->l1Pressure, ignoreRealController, readOnly);
+			return m_l1.UpdateData(padData->m_l1Pressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::R1Pressure:
-			return r1.UpdateData(padData->r1Pressure, ignoreRealController, readOnly);
+			return m_r1.UpdateData(padData->m_r1Pressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::L2Pressure:
-			return l2.UpdateData(padData->l2Pressure, ignoreRealController, readOnly);
+			return m_l2.UpdateData(padData->m_l2Pressure, ignoreRealController, readOnly);
 		case PadData::BufferIndex::R2Pressure:
-			return r2.UpdateData(padData->r2Pressure, ignoreRealController, readOnly);
+			return m_r2.UpdateData(padData->m_r2Pressure, ignoreRealController, readOnly);
 	}
 	return changeDetected;
 }

--- a/pcsx2/Recording/VirtualPad/VirtualPadData.h
+++ b/pcsx2/Recording/VirtualPad/VirtualPadData.h
@@ -26,31 +26,31 @@ class VirtualPadData
 {
 public:
 	/// Controller Background
-	ImageFile background;
+	ImageFile m_background;
 
 	/// Pressure Buttons
-	ControllerPressureButton circle;
-	ControllerPressureButton cross;
-	ControllerPressureButton down;
-	ControllerPressureButton l1;
-	ControllerPressureButton l2;
-	ControllerPressureButton left;
-	ControllerPressureButton r1;
-	ControllerPressureButton r2;
-	ControllerPressureButton right;
-	ControllerPressureButton square;
-	ControllerPressureButton triangle;
-	ControllerPressureButton up;
+	ControllerPressureButton m_circle;
+	ControllerPressureButton m_cross;
+	ControllerPressureButton m_down;
+	ControllerPressureButton m_l1;
+	ControllerPressureButton m_l2;
+	ControllerPressureButton m_left;
+	ControllerPressureButton m_r1;
+	ControllerPressureButton m_r2;
+	ControllerPressureButton m_right;
+	ControllerPressureButton m_square;
+	ControllerPressureButton m_triangle;
+	ControllerPressureButton m_up;
 
 	/// Normal (un)pressed buttons
-	ControllerNormalButton l3;
-	ControllerNormalButton r3;
-	ControllerNormalButton select;
-	ControllerNormalButton start;
+	ControllerNormalButton m_l3;
+	ControllerNormalButton m_r3;
+	ControllerNormalButton m_select;
+	ControllerNormalButton m_start;
 
 	/// Analog Sticks
-	AnalogStick leftAnalog;
-	AnalogStick rightAnalog;
+	AnalogStick m_leftAnalog;
+	AnalogStick m_rightAnalog;
 
 	// Given the input buffer and the current index, updates the respective field(s) within this object
 	// Additionally overwrites the PadData object under the following criteria:

--- a/pcsx2/Recording/VirtualPad/VirtualPadResources.h
+++ b/pcsx2/Recording/VirtualPad/VirtualPadResources.h
@@ -29,22 +29,22 @@
 
 struct ImageFile
 {
-	wxBitmap image;
-	wxPoint coords;
-	u32 width = 0;
-	u32 height = 0;
+	wxBitmap m_image;
+	wxPoint m_coords;
+	u32 m_width = 0;
+	u32 m_height = 0;
 };
 
 struct AnalogVector
 {
-	wxSlider* slider = 0;
-	wxSpinCtrl* spinner = 0;
+	wxSlider* m_slider = 0;
+	wxSpinCtrl* m_spinner = 0;
 
-	u8 val = 127;
+	u8 m_val = 127;
 
-	bool isControllerBypassed = false;
-	bool widgetUpdateRequired = false;
-	u8 prevVal = 127;
+	bool m_isControllerBypassed = false;
+	bool m_widgetUpdateRequired = false;
+	u8 m_prevVal = 127;
 
 	bool UpdateData(u8& padDataVal, bool ignoreRealController, bool readOnly);
 };
@@ -52,17 +52,17 @@ struct AnalogVector
 
 struct AnalogPosition
 {
-	wxPoint centerCoords;
-	wxPoint endCoords;
+	wxPoint m_centerCoords;
+	wxPoint m_endCoords;
 
-	int lineThickness = 0;
-	int radius = 0;
+	int m_lineThickness = 0;
+	int m_radius = 0;
 };
 
 class VirtualPadElement
 {
 public:
-	bool currentlyRendered = false;
+	bool m_currentlyRendered = false;
 
 	wxCommandEvent ConstructEvent(wxEventTypeTag<wxCommandEvent> eventType, wxWindow *obj);
 	wxCommandEvent ConstructEvent(wxEventTypeTag<wxSpinEvent> eventType, wxWindow *obj);
@@ -76,10 +76,10 @@ public:
 class ControllerButton
 {
 public:
-	bool isControllerPressBypassed = false;
-	bool pressed = false;
-	bool prevPressedVal = false;
-	bool widgetUpdateRequired = false;
+	bool m_isControllerPressBypassed = false;
+	bool m_pressed = false;
+	bool m_prevPressedVal = false;
+	bool m_widgetUpdateRequired = false;
 
 	bool UpdateButtonData(bool& padDataVal, bool ignoreRealController, bool readOnly);
 };
@@ -87,8 +87,8 @@ public:
 class ControllerNormalButton : public ControllerButton, public VirtualPadElement
 {
 public:
-	ImageFile icon;
-	wxCheckBox* pressedBox = 0;
+	ImageFile m_icon;
+	wxCheckBox* m_pressedBox = 0;
 
 	bool UpdateData(bool& padDataVal, bool ignoreRealController, bool readOnly);
 	void EnableWidgets(bool enable) override;
@@ -100,13 +100,13 @@ public:
 class ControllerPressureButton : public ControllerButton, public VirtualPadElement
 {
 public:
-	ImageFile icon;
-	wxSpinCtrl* pressureSpinner = 0;
+	ImageFile m_icon;
+	wxSpinCtrl* m_pressureSpinner = 0;
 
-	u8 pressure = 0;
+	u8 m_pressure = 0;
 
-	bool isControllerPressureBypassed = false;
-	u8 prevPressureVal = 0;
+	bool m_isControllerPressureBypassed = false;
+	u8 m_prevPressureVal = 0;
 
 	bool UpdateData(bool& padDataVal, bool ignoreRealController, bool readOnly);
 	bool UpdateData(u8& padDataVal, bool ignoreRealController, bool readOnly);
@@ -119,10 +119,10 @@ public:
 class AnalogStick : public VirtualPadElement
 {
 public:
-	AnalogVector xVector;
-	AnalogVector yVector;
+	AnalogVector m_xVector;
+	AnalogVector m_yVector;
 
-	AnalogPosition positionGraphic;
+	AnalogPosition m_positionGraphic;
 
 	void EnableWidgets(bool enable) override;
 	void Render(wxDC& dc) override;

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -214,13 +214,8 @@ SIO_WRITE sioWriteController(u8 data)
 		sio.buf[sio.bufCount] = PADpoll(data);
 #ifndef DISABLE_RECORDING
 		if (g_Conf->EmuOptions.EnableRecordingTools)
-		{
-			// Only examine controllers 1 / 2
-			if (sio.slot[sio.port] == 0)
-			{
-				g_InputRecording.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
-			}
-		}
+			if (!g_InputRecording.IsActive() || g_InputRecording.GetInputRecordingData().IsSlotUsed(sio.port, sio.GetSlot()))
+				g_InputRecording.ControllerInterrupt(data, sio.port, sio.GetSlot(), sio.bufCount, sio.buf[sio.bufCount]);
 #endif
 		break;
 	}

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -209,6 +209,14 @@ enum MenuIdentifiers
 	MenuId_Recording_ToggleRecordingMode,
 	MenuId_Recording_VirtualPad_Port0,
 	MenuId_Recording_VirtualPad_Port1,
+	MenuId_Recording_VirtualPad_Port0_0,
+	MenuId_Recording_VirtualPad_Port0_1,
+	MenuId_Recording_VirtualPad_Port0_2,
+	MenuId_Recording_VirtualPad_Port0_3,
+	MenuId_Recording_VirtualPad_Port1_0,
+	MenuId_Recording_VirtualPad_Port1_1,
+	MenuId_Recording_VirtualPad_Port1_2,
+	MenuId_Recording_VirtualPad_Port1_3,
 #endif
 
 };

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -550,11 +550,6 @@ protected:
 	wxWindowID			m_id_ProgramLogBox;
 	wxWindowID			m_id_Disassembler;
 
-#ifndef DISABLE_RECORDING
-	wxWindowID			m_id_VirtualPad[2];
-	wxWindowID			m_id_NewRecordingFrame;
-#endif
-
 	wxKeyEvent			m_kevt;
 
 public:
@@ -578,11 +573,6 @@ public:
 	GSFrame*			GetGsFramePtr() const		{ return (GSFrame*)wxWindow::FindWindowById( m_id_GsFrame ); }
 	MainEmuFrame*		GetMainFramePtr() const		{ return (MainEmuFrame*)wxWindow::FindWindowById( m_id_MainFrame ); }
 	DisassemblyDialog*	GetDisassemblyPtr() const	{ return (DisassemblyDialog*)wxWindow::FindWindowById(m_id_Disassembler); }
-
-#ifndef DISABLE_RECORDING
-	VirtualPad*			GetVirtualPadPtr(int port) const	{ return (VirtualPad*)wxWindow::FindWindowById(m_id_VirtualPad[port]); }
-	NewRecordingFrame*	GetNewRecordingFramePtr() const		{ return (NewRecordingFrame*)wxWindow::FindWindowById(m_id_NewRecordingFrame); }
-#endif
 
 	void enterDebugMode();
 	void leaveDebugMode();

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -26,11 +26,6 @@
 
 #include "Debugger/DisassemblyDialog.h"
 
-#ifndef DISABLE_RECORDING
-#   include "Recording/InputRecording.h"
-#	include "Recording/VirtualPad/VirtualPad.h"
-#endif
-
 #include <wx/cmdline.h>
 #include <wx/intl.h>
 #include <wx/stdpaths.h>
@@ -76,19 +71,6 @@ void Pcsx2App::OpenMainFrame()
 
 	DisassemblyDialog* disassembly = new DisassemblyDialog( mainFrame );
 	m_id_Disassembler = disassembly->GetId();
-
-#ifndef DISABLE_RECORDING
-	VirtualPad* virtualPad0 = new VirtualPad(mainFrame, 0, g_Conf->inputRecording);
-	g_InputRecording.setVirtualPadPtr(virtualPad0, 0);
-	m_id_VirtualPad[0] = virtualPad0->GetId();
-
-	VirtualPad* virtualPad1 = new VirtualPad(mainFrame, 1, g_Conf->inputRecording);
-	g_InputRecording.setVirtualPadPtr(virtualPad1, 1);
-	m_id_VirtualPad[1] = virtualPad1->GetId();
-
-	NewRecordingFrame* newRecordingFrame = new NewRecordingFrame(mainFrame);
-	m_id_NewRecordingFrame = newRecordingFrame->GetId();
-#endif
 
 	if (g_Conf->EmuOptions.Debugger.ShowDebuggerOnStart)
 		disassembly->Show();

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1071,9 +1071,7 @@ void Pcsx2App::OnMainFrameClosed( wxWindowID id )
 {
 #ifndef DISABLE_RECORDING
 	if (g_InputRecording.IsActive())
-	{
 		g_InputRecording.Stop();
-	}
 #endif
 
 	// Nothing threaded depends on the mainframe (yet) -- it all passes through the main wxApp

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1015,7 +1015,11 @@ void Pcsx2App::OpenGsPanel()
 	gsFrame->ShowFullScreen( g_Conf->GSWindow.IsFullscreen );
 
 #ifndef DISABLE_RECORDING
-	// Disable recording controls that only make sense if the game is running
+	// Enable New & Play after the first game load of the session
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_New, !g_InputRecording.IsActive());
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_Play, true);
+
+	// Enable recording menu options as the game is now running
 	sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, true);
 	sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, true);
 	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, g_InputRecording.IsActive());

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1160,7 +1160,7 @@ void Pcsx2App::SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override
 {
 	SysExecutorThread.PostEvent( new SysExecEvent_Execute(cdvdsrc, elf_override) );
 #ifndef DISABLE_RECORDING
-	g_InputRecording.RecordingReset();
+	g_InputRecording.OnBoot();
 #endif
 }
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -104,11 +104,13 @@ void GSPanel::InitRecordingAccelerators()
 	m_Accels->Map(AAC(WXK_SPACE), "FrameAdvance");
 	m_Accels->Map(AAC(wxKeyCode('p')).Shift(), "TogglePause");
 	m_Accels->Map(AAC(wxKeyCode('r')).Shift(), "InputRecordingModeToggle");
+	m_Accels->Map(AAC(wxKeyCode('l')).Shift(), "GoToFirstFrame");
 #if defined(__unix__)
 	// Shift+P (80) and Shift+p (112) have two completely different codes 
 	// On Linux the former is sometimes fired so define bindings for both
 	m_Accels->Map(AAC(wxKeyCode('P')).Shift(), "TogglePause");
 	m_Accels->Map(AAC(wxKeyCode('R')).Shift(), "InputRecordingModeToggle");
+	m_Accels->Map(AAC(wxKeyCode('L')).Shift(), "GoToFirstFrame");
 #endif
 
 	m_Accels->Map(AAC(WXK_NUMPAD0).Shift(), "States_SaveSlot0");
@@ -134,16 +136,21 @@ void GSPanel::InitRecordingAccelerators()
 
 	GetMainFramePtr()->initializeRecordingMenuItem(
 		MenuId_Recording_FrameAdvance,
-		m_Accels->findKeycodeWithCommandId("FrameAdvance").toTitleizedString());
+		GetAssociatedKeyCode("FrameAdvance"));
 	GetMainFramePtr()->initializeRecordingMenuItem(
 		MenuId_Recording_TogglePause,
-		m_Accels->findKeycodeWithCommandId("TogglePause").toTitleizedString());
+		GetAssociatedKeyCode("TogglePause"));
 	GetMainFramePtr()->initializeRecordingMenuItem(
 		MenuId_Recording_ToggleRecordingMode,
-		m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString(),
+		GetAssociatedKeyCode("InputRecordingModeToggle"),
 		g_InputRecording.IsActive());
 
 	inputRec::consoleLog("Initialized Input Recording Key Bindings");
+}
+
+wxString GSPanel::GetAssociatedKeyCode(const char* id)
+{
+	return m_Accels->findKeycodeWithCommandId(id).toTitleizedString();
 }
 
 void GSPanel::RemoveRecordingAccelerators()

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -531,6 +531,15 @@ namespace Implementations
 		}
 	}
 
+	void GoToFirstFrame()
+	{
+		if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsActive())
+		{
+			if (!g_InputRecording.GoToFirstFrame() && wxGetApp().HasGUI())
+				sMainFrame.RecordingMenuReset();
+		}
+	}
+
 	void States_SaveSlot(int slot)
 	{
 		States_SetCurrentSlot(slot);
@@ -825,29 +834,30 @@ static const GlobalCommandDescriptor CommandDeclarations[] =
 		},
 
 #ifndef DISABLE_RECORDING
-		{"FrameAdvance", Implementations::FrameAdvance, NULL, NULL, false},
-		{"TogglePause", Implementations::TogglePause, NULL, NULL, false},
-		{"InputRecordingModeToggle", Implementations::InputRecordingModeToggle, NULL, NULL, false},
-		{"States_SaveSlot0", Implementations::States_SaveSlot0, NULL, NULL, false},
-		{"States_SaveSlot1", Implementations::States_SaveSlot1, NULL, NULL, false},
-		{"States_SaveSlot2", Implementations::States_SaveSlot2, NULL, NULL, false},
-		{"States_SaveSlot3", Implementations::States_SaveSlot3, NULL, NULL, false},
-		{"States_SaveSlot4", Implementations::States_SaveSlot4, NULL, NULL, false},
-		{"States_SaveSlot5", Implementations::States_SaveSlot5, NULL, NULL, false},
-		{"States_SaveSlot6", Implementations::States_SaveSlot6, NULL, NULL, false},
-		{"States_SaveSlot7", Implementations::States_SaveSlot7, NULL, NULL, false},
-		{"States_SaveSlot8", Implementations::States_SaveSlot8, NULL, NULL, false},
-		{"States_SaveSlot9", Implementations::States_SaveSlot9, NULL, NULL, false},
-		{"States_LoadSlot0", Implementations::States_LoadSlot0, NULL, NULL, false},
-		{"States_LoadSlot1", Implementations::States_LoadSlot1, NULL, NULL, false},
-		{"States_LoadSlot2", Implementations::States_LoadSlot2, NULL, NULL, false},
-		{"States_LoadSlot3", Implementations::States_LoadSlot3, NULL, NULL, false},
-		{"States_LoadSlot4", Implementations::States_LoadSlot4, NULL, NULL, false},
-		{"States_LoadSlot5", Implementations::States_LoadSlot5, NULL, NULL, false},
-		{"States_LoadSlot6", Implementations::States_LoadSlot6, NULL, NULL, false},
-		{"States_LoadSlot7", Implementations::States_LoadSlot7, NULL, NULL, false},
-		{"States_LoadSlot8", Implementations::States_LoadSlot8, NULL, NULL, false},
-		{"States_LoadSlot9", Implementations::States_LoadSlot9, NULL, NULL, false},
+		{ "FrameAdvance"				, Implementations::FrameAdvance,				NULL, NULL, false },
+		{ "TogglePause"					, Implementations::TogglePause,					NULL, NULL, false },
+		{ "InputRecordingModeToggle"	, Implementations::InputRecordingModeToggle,	NULL, NULL, false },
+		{ "GoToFirstFrame"				, Implementations::GoToFirstFrame,				NULL, NULL, false },
+		{ "States_SaveSlot0"			, Implementations::States_SaveSlot0,			NULL, NULL, false },
+		{ "States_SaveSlot1"			, Implementations::States_SaveSlot1,			NULL, NULL, false },
+		{ "States_SaveSlot2"			, Implementations::States_SaveSlot2,			NULL, NULL, false },
+		{ "States_SaveSlot3"			, Implementations::States_SaveSlot3,			NULL, NULL, false },
+		{ "States_SaveSlot4"			, Implementations::States_SaveSlot4,			NULL, NULL, false },
+		{ "States_SaveSlot5"			, Implementations::States_SaveSlot5,			NULL, NULL, false },
+		{ "States_SaveSlot6"			, Implementations::States_SaveSlot6,			NULL, NULL, false },
+		{ "States_SaveSlot7"			, Implementations::States_SaveSlot7,			NULL, NULL, false },
+		{ "States_SaveSlot8"			, Implementations::States_SaveSlot8,			NULL, NULL, false },
+		{ "States_SaveSlot9"			, Implementations::States_SaveSlot9,			NULL, NULL, false },
+		{ "States_LoadSlot0"			, Implementations::States_LoadSlot0,			NULL, NULL, false },
+		{ "States_LoadSlot1"			, Implementations::States_LoadSlot1,			NULL, NULL, false },
+		{ "States_LoadSlot2"			, Implementations::States_LoadSlot2,			NULL, NULL, false },
+		{ "States_LoadSlot3"			, Implementations::States_LoadSlot3,			NULL, NULL, false },
+		{ "States_LoadSlot4"			, Implementations::States_LoadSlot4,			NULL, NULL, false },
+		{ "States_LoadSlot5"			, Implementations::States_LoadSlot5,			NULL, NULL, false },
+		{ "States_LoadSlot6"			, Implementations::States_LoadSlot6,			NULL, NULL, false },
+		{ "States_LoadSlot7"			, Implementations::States_LoadSlot7,			NULL, NULL, false },
+		{ "States_LoadSlot8"			, Implementations::States_LoadSlot8,			NULL, NULL, false },
+		{ "States_LoadSlot9"			, Implementations::States_LoadSlot9,			NULL, NULL, false },
 #endif
 		// Command Declarations terminator:
 		// (must always be last in list!!)

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -517,34 +517,26 @@ namespace Implementations
 	void FrameAdvance()
 	{
 		if (g_Conf->EmuOptions.EnableRecordingTools)
-		{
 			g_InputRecordingControls.FrameAdvance();
-		}
 	}
 
 	void TogglePause()
 	{
 		if (g_Conf->EmuOptions.EnableRecordingTools)
-		{
 			g_InputRecordingControls.TogglePause();
-		}
 	}
 
 	void InputRecordingModeToggle()
 	{
 		if (g_Conf->EmuOptions.EnableRecordingTools)
-		{
 			g_InputRecordingControls.RecordModeToggle();
-		}
 	}
 
 	void GoToFirstFrame()
 	{
 		if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsActive())
-		{
 			if (!g_InputRecording.GoToFirstFrame() && wxGetApp().HasGUI())
 				sMainFrame.RecordingMenuReset();
-		}
 	}
 
 	void States_SaveSlot(int slot)

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -376,10 +376,17 @@ namespace Implementations
 		if (CoreThread.HasPendingStateChangeRequest())
 			return;
 
+#ifndef DISABLE_RECORDING
+		if (g_InputRecordingControls.IsPaused() || !CoreThread.IsPaused())
+			Sys_Suspend();
+		else
+			Sys_Resume();
+#else
 		if (CoreThread.IsPaused())
 			Sys_Resume();
 		else
 			Sys_Suspend();
+#endif
 	}
 
 	void Sys_TakeSnapshot()

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -29,6 +29,10 @@
 
 #include "svnrev.h"
 #include "Saveslots.h"
+#ifndef DISABLE_RECORDING
+#	include "Recording/InputRecording.h"
+#endif
+
 
 // ------------------------------------------------------------------------
 wxMenu* MainEmuFrame::MakeStatesSubMenu(int baseid, int loadBackupId) const
@@ -57,11 +61,18 @@ void MainEmuFrame::UpdateStatusBar()
 {
 	wxString temp(wxEmptyString);
 
-	if (g_Conf->EnableFastBoot)
-		temp += "Fast Boot - ";
+#ifndef DISABLE_RECORDING
+	if (g_InputRecording.IsActive() && g_InputRecording.GetInputRecordingData().FromSaveState())
+		temp += "Base Savestate - " + g_InputRecording.GetInputRecordingData().GetFilename() + "_SaveState.p2s";
+	else
+#endif
+	{
+		if (g_Conf->EnableFastBoot)
+			temp += "Fast Boot - ";
 
-	if (g_Conf->CdvdSource == CDVD_SourceType::Iso)
-		temp += "Load: '" + wxFileName(g_Conf->CurrentIso).GetFullName() + "' ";
+		if (g_Conf->CdvdSource == CDVD_SourceType::Iso)
+			temp += "Load: '" + wxFileName(g_Conf->CurrentIso).GetFullName() + "' ";
+	}
 
 	m_statusbar.SetStatusText(temp, 0);
 	m_statusbar.SetStatusText(CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], 1);
@@ -92,6 +103,12 @@ void MainEmuFrame::UpdateCdvdSrcSelection()
 			jNO_DEFAULT
 	}
 	sMenuBar.Check(cdsrc, true);
+#ifndef DISABLE_RECORDING
+	if (g_InputRecording.IsActive())
+		ApplyFirstFrameStatus();
+	else
+#endif
+		ApplyCDVDStatus();
 	UpdateStatusBar();
 }
 
@@ -335,7 +352,7 @@ void MainEmuFrame::DispatchEvent(const CoreThreadStatus& status)
 {
 	if (!pxAssertMsg(GetMenuBar() != NULL, "Mainframe menu bar is NULL!"))
 		return;
-	ApplyCoreStatus();
+	ApplySuspendStatus();
 }
 
 void MainEmuFrame::AppStatusEvent_OnSettingsApplied()
@@ -698,12 +715,16 @@ void MainEmuFrame::OnActivate(wxActivateEvent& evt)
 
 void MainEmuFrame::ApplyCoreStatus()
 {
-	wxMenuBar& menubar(*GetMenuBar());
+	ApplySuspendStatus();
+	ApplyCDVDStatus();
+}
 
+void MainEmuFrame::ApplySuspendStatus()
+{
 	// [TODO] : Ideally each of these items would bind a listener instance to the AppCoreThread
 	// dispatcher, and modify their states accordingly.  This is just a hack (for now) -- air
 
-	if (wxMenuItem* susres = menubar.FindItem(MenuId_Sys_SuspendResume))
+	if (wxMenuItem* susres = GetMenuBar()->FindItem(MenuId_Sys_SuspendResume))
 	{
 		if (!CoreThread.IsClosing())
 		{
@@ -727,10 +748,13 @@ void MainEmuFrame::ApplyCoreStatus()
 			}
 		}
 	}
+}
 
+void MainEmuFrame::ApplyCDVDStatus()
+{
 	const CDVD_SourceType Source = g_Conf->CdvdSource;
 
-	wxMenuItem* cdvd_menu = menubar.FindItem(MenuId_Boot_CDVD);
+	wxMenuItem* cdvd_menu = GetMenuBar()->FindItem(MenuId_Boot_CDVD);
 
 	wxString label;
 	wxString help_text = _("Use fast boot to skip PS2 startup and splash screens");

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -483,9 +483,9 @@ void MainEmuFrame::CreateCaptureMenu()
 void MainEmuFrame::CreateRecordMenu()
 {
 #ifndef DISABLE_RECORDING
-	m_menuRecording.Append(MenuId_Recording_New, _("New"), _("Create a new input recording."));
+	m_menuRecording.Append(MenuId_Recording_New, _("New"), _("Create a new input recording."))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_Stop, _("Stop"), _("Stop the active input recording."))->Enable(false);
-	m_menuRecording.Append(MenuId_Recording_Play, _("Play"), _("Playback an existing input recording."));
+	m_menuRecording.Append(MenuId_Recording_Play, _("Play"), _("Playback an existing input recording."))->Enable(false);
 	m_menuRecording.AppendSeparator();
 	m_menuRecording.Append(MenuId_Recording_TogglePause, _("Toggle Pause"), _("Pause or resume emulation on the fly."))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_FrameAdvance, _("Frame Advance"), _("Advance emulation forward by a single frame at a time."))->Enable(false);

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -510,6 +510,8 @@ void MainEmuFrame::CreateRecordMenu()
 	m_menuRecording.AppendSeparator();
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port0, _("Virtual Pad (Port 1)"));
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port1, _("Virtual Pad (Port 2)"));
+	if (g_Conf->EmuOptions.EnableRecordingTools)
+		g_InputRecording.InitInputRecordingWindows(this);
 #endif
 }
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -816,7 +816,7 @@ void MainEmuFrame::AppendKeycodeNamesToMenuOptions()
 }
 
 #ifndef DISABLE_RECORDING
-void MainEmuFrame::initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable)
+void MainEmuFrame::initializeRecordingMenuItem(int menuId, wxString keyCodeStr, bool enable)
 {
 	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);
 	wxString text = item.GetItemLabel();
@@ -825,9 +825,9 @@ void MainEmuFrame::initializeRecordingMenuItem(MenuIdentifiers menuId, wxString 
 	item.Enable(enable);
 }
 
-void MainEmuFrame::enableRecordingMenuItem(MenuIdentifiers menuId, bool enable)
+void MainEmuFrame::enableRecordingMenuItem(int menuId, bool enable)
 {
-	wxMenuItem& item = *m_menuRecording.FindChildItem(menuId);
+	wxMenuItem& item = *m_menuRecording.FindItem(menuId);
 	item.Enable(enable);
 }
 #endif

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -172,8 +172,8 @@ public:
 	void AppendKeycodeNamesToMenuOptions();
 	void UpdateStatusBar();
 #ifndef DISABLE_RECORDING
-	void initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable = true);
-	void enableRecordingMenuItem(MenuIdentifiers menuId, bool enable);
+	void initializeRecordingMenuItem(int menuId, wxString keyCodeStr, bool enable = true);
+	void enableRecordingMenuItem(int menuId, bool enable);
 #endif
 
 protected:

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -120,7 +120,9 @@ protected:
 	wxMenu&	m_submenuScreenshot;
 
 #ifndef DISABLE_RECORDING
-	wxMenu& m_menuRecording;
+	wxMenu&	m_menuRecording;
+	wxMenu&	m_submenuvirtualPort0;
+	wxMenu&	m_submenuvirtualPort1;
 #endif
 	wxMenu& m_menuHelp;
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -224,6 +224,7 @@ protected:
 	void Menu_SaveStates_Click(wxCommandEvent& event);
 	void Menu_LoadStateFromFile_Click(wxCommandEvent& event);
 	void Menu_SaveStateToFile_Click(wxCommandEvent& event);
+	bool Dialog_Savestate(wxFileDialog& dialog);
 	void Menu_Exit_Click(wxCommandEvent& event);
 
 	void Menu_SuspendResume_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -162,7 +162,10 @@ public:
 	void CreateConfigMenu();
 	void CreateWindowsMenu();
 	void CreateCaptureMenu();
+#ifndef DISABLE_RECORDING
 	void CreateRecordMenu();
+	void RecordingMenuReset();
+#endif
 	void CreateHelpMenu();
 
 	bool Destroy();
@@ -182,6 +185,8 @@ protected:
 	//Apply here is from config to GUI.
 	void ApplySettings();
 	void ApplyCoreStatus();
+	void ApplySuspendStatus();
+	void ApplyCDVDStatus();
 
 	void InitLogBoxPosition(AppConfig::ConsoleLogOptions& conf);
 
@@ -255,6 +260,7 @@ protected:
 	void Menu_Recording_New_Click(wxCommandEvent& event);
 	void Menu_Recording_Play_Click(wxCommandEvent& event);
 	void Menu_Recording_Stop_Click(wxCommandEvent& event);
+	void ApplyFirstFrameStatus();
 	void Menu_Recording_TogglePause_Click(wxCommandEvent &event);
 	void Menu_Recording_FrameAdvance_Click(wxCommandEvent &event);
 	void Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent &event);

--- a/plugins/LilyPad/Global.h
+++ b/plugins/LilyPad/Global.h
@@ -193,3 +193,5 @@ EXPORT_C_(s32)
 PADqueryMtap(u8 port);
 EXPORT_C_(void)
 PADsetSettingsDir(const char *dir);
+EXPORT_C_(void)
+PADSetupInputRecording(bool start, char padsRequested);

--- a/plugins/LilyPad/LilyPad.def
+++ b/plugins/LilyPad/LilyPad.def
@@ -20,3 +20,4 @@ EXPORTS
 	PADsetSlot
 	PADsetSettingsDir
 	PADqueryMtap
+	PADSetupInputRecording


### PR DESCRIPTION
With the integration of multitap in input recordings, a few additional accompanying updates had to be made:
* The number of Virtual Pads has also increased to 8 and their menu options have been split into two submenus of 4 by port.
Multitap 1 active:
![image](https://user-images.githubusercontent.com/52436993/94461364-ab384c80-017f-11eb-9f7c-f104a4b6dc37.png)
Multitap 2 inactive:
![image](https://user-images.githubusercontent.com/52436993/94461470-cd31cf00-017f-11eb-8412-5fa596b0355d.png)

* Automatic enabling and disabling of multitaps and of the fast boot configuration option now occurs when opening a recording according to necessity.
* With the increased possible pad count, a recording file size optimization was needed. Now, every frame in *.pirec files (previously *.p2m2) only hold the input data for the number of pads used - in comparison to version 1's consistent two-pad style. Singleplayer recordings will now be about *HALF* the size.
* **Note:** *Steps were taken to ensure backwards compatibility with version 1 recording files. However, there will be no converter from V1 to V2, at least not right now.*

Additionally, all instances of UndoCount have been changed to RedoCount to more accurately describe that behavior.

The actual use and construction of multitap-based recordings are only *fully* compatible with lilypad. Once onepad fully supports multitap, that will change.