### PR TITLE
Recording: Fix VS filters on new image files and safeguards around save-state code

### DIFF
--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -32,23 +32,28 @@
 
 void SaveStateBase::InputRecordingFreeze()
 {
+	// NOTE - BE CAREFUL
+	// CHANGING THIS WILL BREAK BACKWARDS COMPATIBILITY ON SAVESTATES
 	FreezeTag("InputRecording");
 	Freeze(g_FrameCount);
 
 #ifndef DISABLE_RECORDING
-	// Loading a save-state is an asynchronous task. If we are playing a recording
-	// that starts from a savestate (not power-on) and the starting (pcsx2 internal) frame
-	// marker has not been set (which comes from the save-state), we initialize it.
-	if (g_InputRecording.IsInitialLoad())
-		g_InputRecording.SetStartingFrame(g_FrameCount);
-	else if (g_InputRecording.IsActive())
+	if (g_Conf->EmuOptions.EnableRecordingTools)
 	{
-		// Explicitly set the frame change tracking variable as to not
-		// detect saving or loading a savestate as a frame being drawn
-		g_InputRecordingControls.SetFrameCountTracker(g_FrameCount);
+		// Loading a save-state is an asynchronous task. If we are playing a recording
+		// that starts from a savestate (not power-on) and the starting (pcsx2 internal) frame
+		// marker has not been set (which comes from the save-state), we initialize it.
+		if (g_InputRecording.IsInitialLoad())
+			g_InputRecording.SetStartingFrame(g_FrameCount);
+		else if (g_InputRecording.IsActive())
+		{
+			// Explicitly set the frame change tracking variable as to not
+			// detect saving or loading a savestate as a frame being drawn
+			g_InputRecordingControls.SetFrameCountTracker(g_FrameCount);
 
-		if (IsLoading())
-			g_InputRecording.SetFrameCounter(g_FrameCount);
+			if (IsLoading())
+				g_InputRecording.SetFrameCounter(g_FrameCount);
+		}
 	}
 #endif
 }

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -163,6 +163,9 @@
     <Filter Include="System\Ps2\SPU2">
       <UniqueIdentifier>{bed493d6-96dc-4057-a1f2-31f88ec927d9}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Recording\VirtualPad\Images">
+      <UniqueIdentifier>{ad528458-08eb-49a2-aefa-3c2b86ab8896}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Utilities\folderdesc.txt">
@@ -1595,6 +1598,63 @@
     </CustomBuild>
     <CustomBuild Include="..\..\gui\Resources\Logo.png">
       <Filter>AppHost\Resources</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\circlePressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\controllerFull.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\controllerHalf.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\controllerThreeQuarters.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\crossPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\downPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\l1Pressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\l2Pressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\l3Pressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\leftPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\startPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\r1Pressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\r2Pressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\r3Pressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\rightPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\selectPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\squarePressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\trianglePressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\Recording\VirtualPad\img\upPressed.png">
+      <Filter>Recording\VirtualPad\Images</Filter>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The SaveState handler in `InputRecording` is always accessible because it needs to be, even if input-recording tools are disabled.  However, the extra code within it, should not be executed if the recording tools are disabled, so I fixed that.

Also at the same time I noticed that since I didn't specify a filter for the new VirtualPad image files, they get shoved into the top level project folder so fixed that up at the same time.