### PR TITLE
Recording: Add on-screen-display logging around appropriate Input Recording actions

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -555,6 +555,7 @@ set(pcsx2RecordingHeaders
 	${rec_src}/InputRecordingFile.h
 	${rec_src}/NewRecordingFrame.h
 	${rec_src}/PadData.h
+    ${rec_src}/Utilities/InputRecordingLogger.h
 	${rec_vp_src}/VirtualPad.h
 	${rec_vp_src}/VirtualPadData.h
 	${rec_vp_src}/VirtualPadResources.h

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -555,7 +555,7 @@ set(pcsx2RecordingHeaders
 	${rec_src}/InputRecordingFile.h
 	${rec_src}/NewRecordingFrame.h
 	${rec_src}/PadData.h
-    ${rec_src}/Utilities/InputRecordingLogger.h
+	${rec_src}/Utilities/InputRecordingLogger.h
 	${rec_vp_src}/VirtualPad.h
 	${rec_vp_src}/VirtualPadData.h
 	${rec_vp_src}/VirtualPadResources.h

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -27,6 +27,7 @@
 
 #include "InputRecording.h"
 #include "InputRecordingControls.h"
+#include "Utilities/InputRecordingLogger.h"
 
 #endif
 
@@ -221,7 +222,7 @@ void InputRecording::SetToRecordMode()
 	state = InputRecordingMode::Recording;
 	virtualPads[CONTROLLER_PORT_ONE]->SetReadOnlyMode(false);
 	virtualPads[CONTROLLER_PORT_TWO]->SetReadOnlyMode(false);
-	recordingConLog("[REC]: Record mode ON.\n");
+	inputRec::log("Record mode ON");
 }
 
 void InputRecording::SetToReplayMode()
@@ -229,15 +230,15 @@ void InputRecording::SetToReplayMode()
 	state = InputRecordingMode::Replaying;
 	virtualPads[CONTROLLER_PORT_ONE]->SetReadOnlyMode(true);
 	virtualPads[CONTROLLER_PORT_TWO]->SetReadOnlyMode(true);
-	recordingConLog("[REC]: Replay mode ON.\n");
+	inputRec::log("Replay mode ON");
 }
 
 void InputRecording::SetFrameCounter(u32 newGFrameCount)
 {
 	if (newGFrameCount > startingFrame + (u32)g_InputRecording.GetInputRecordingData().GetTotalFrames())
 	{
-		recordingConLog(L"[REC]: Warning, you've loaded PCSX2 emulation to a point after the end of the original recording. This should be avoided.\n");
-		recordingConLog(L"[REC]: Savestate's framecount has been ignored.\n");
+		inputRec::consoleLog("Warning, you've loaded PCSX2 emulation to a point after the end of the original recording. This should be avoided.");
+		inputRec::consoleLog("Savestate's framecount has been ignored.");
 		frameCounter = g_InputRecording.GetInputRecordingData().GetTotalFrames();
 		if (state == InputRecordingMode::Replaying)
 			SetToRecordMode();
@@ -247,7 +248,7 @@ void InputRecording::SetFrameCounter(u32 newGFrameCount)
 	{
 		if (newGFrameCount < startingFrame)
 		{
-			recordingConLog(L"[REC]: Warning, you've loaded PCSX2 emulation to a point before the start of the original recording. This should be avoided.\n");
+			inputRec::consoleLog("Warning, you've loaded PCSX2 emulation to a point before the start of the original recording. This should be avoided.");
 			if (state == InputRecordingMode::Recording)
 				SetToReplayMode();
 		}
@@ -261,9 +262,8 @@ void InputRecording::SetFrameCounter(u32 newGFrameCount)
 void InputRecording::SetStartingFrame(u32 newStartingFrame)
 {
 	startingFrame = newStartingFrame;
-	// TODO - make a function of my own to simplify working with the logging macros
 	if (inputRecordingData.FromSaveState())
-		recordingConLog(wxString::Format(L"[REC]: Internal Starting Frame: %d\n", startingFrame));
+		inputRec::consoleLog("Internal Starting Frame: %d", startingFrame);
 	frameCounter = 0;
 	initialLoad = false;
 	g_InputRecordingControls.Lock(startingFrame);
@@ -276,7 +276,7 @@ void InputRecording::Stop()
 	virtualPads[CONTROLLER_PORT_TWO]->SetReadOnlyMode(false);
 	incrementUndo = false;
 	if (inputRecordingData.Close())
-		recordingConLog(L"[REC]: InputRecording Recording Stopped.\n");
+		inputRec::log("Input recording stopped");
 }
 
 bool InputRecording::Create(wxString FileName, bool fromSaveState, wxString authorName)
@@ -307,7 +307,8 @@ bool InputRecording::Create(wxString FileName, bool fromSaveState, wxString auth
 	inputRecordingData.WriteHeader();
 	SetToRecordMode();
 	g_InputRecordingControls.DisableFrameAdvance();
-	recordingConLog(wxString::Format(L"[REC]: Started new recording - [%s]\n", FileName));
+	inputRec::log("Started new input recording");
+	inputRec::consoleLog("Filename %s", std::string(FileName));
 	return true;
 }
 
@@ -324,14 +325,14 @@ bool InputRecording::Play(wxString fileName)
 	{
 		if (!CoreThread.IsOpen())
 		{
-			recordingConLog(L"[REC]: Game is not open, aborting playing input recording which starts on a save-state.\n");
+			inputRec::consoleLog("Game is not open, aborting playing input recording which starts on a save-state.");
 			inputRecordingData.Close();
 			return false;
 		}
 		if (!wxFileExists(inputRecordingData.GetFilename() + "_SaveState.p2s"))
 		{
-			recordingConLog(wxString::Format("[REC]: Could not locate savestate file at location - %s_SaveState.p2s\n",
-											 inputRecordingData.GetFilename()));
+			inputRec::consoleLog("Could not locate savestate file at location - %s_SaveState.p2s",
+								 inputRecordingData.GetFilename());
 			inputRecordingData.Close();
 			return false;
 		}
@@ -347,18 +348,19 @@ bool InputRecording::Play(wxString fileName)
 	// Check if the current game matches with the one used to make the original recording
 	if (!g_Conf->CurrentIso.IsEmpty())
 		if (resolveGameName() != inputRecordingData.GetHeader().gameName)
-			recordingConLog(L"[REC]: Recording was possibly constructed for a different game.\n");
+			inputRec::consoleLog("Input recording was possibly constructed for a different game.");
 
 	incrementUndo = true;
 	SetToReplayMode();
+	inputRec::log("Playing input recording");
 	g_InputRecordingControls.DisableFrameAdvance();
-	recordingConLog(wxString::Format(L"[REC]: Replaying input recording - [%s]\n", inputRecordingData.GetFilename()));
-	recordingConLog(wxString::Format(L"[REC]: PCSX2 Version Used: %s\n", inputRecordingData.GetHeader().emu));
-	recordingConLog(wxString::Format(L"[REC]: Recording File Version: %d\n", inputRecordingData.GetHeader().version));
-	recordingConLog(wxString::Format(L"[REC]: Associated Game Name or ISO Filename: %s\n", inputRecordingData.GetHeader().gameName));
-	recordingConLog(wxString::Format(L"[REC]: Author: %s\n", inputRecordingData.GetHeader().author));
-	recordingConLog(wxString::Format(L"[REC]: Total Frames: %d\n", inputRecordingData.GetTotalFrames()));
-	recordingConLog(wxString::Format(L"[REC]: Undo Count: %d\n", inputRecordingData.GetUndoCount()));
+	inputRec::consoleMultiLog({wxString::Format("Replaying input recording - [%s]", std::string(inputRecordingData.GetFilename())),
+							   wxString::Format("PCSX2 Version Used: %s", std::string(inputRecordingData.GetHeader().emu)),
+							   wxString::Format("Recording File Version: %d", inputRecordingData.GetHeader().version),
+							   wxString::Format("Associated Game Name or ISO Filename: %s", std::string(inputRecordingData.GetHeader().gameName)),
+							   wxString::Format("Author: %s", inputRecordingData.GetHeader().author),
+							   wxString::Format("Total Frames: %d", inputRecordingData.GetTotalFrames()),
+							   wxString::Format("Undo Count: %d", inputRecordingData.GetUndoCount())});
 	return true;
 }
 

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -25,7 +25,7 @@
 
 #include "InputRecording.h"
 #include "InputRecordingControls.h"
-
+#include "Utilities/InputRecordingLogger.h"
 
 InputRecordingControls g_InputRecordingControls;
 
@@ -43,7 +43,7 @@ void InputRecordingControls::HandleFrameAdvanceAndPausing()
 		if (g_FrameCount == frameCountTracker)
 		{
 			frameLock = false;
-			g_InputRecordingControls.Resume();
+			Resume();
 		}
 		else if (!emulationCurrentlyPaused && CoreThread.IsOpen() && CoreThread.IsRunning())
 		{
@@ -62,7 +62,7 @@ void InputRecordingControls::HandleFrameAdvanceAndPausing()
 		frameCountTracker = g_FrameCount;
 		if (g_InputRecording.GetFrameCounter() < INT_MAX)
 			g_InputRecording.IncrementFrameCounter();
-	} 
+	}
 	else
 	{
 		if (pauseEmulation)
@@ -79,17 +79,18 @@ void InputRecordingControls::HandleFrameAdvanceAndPausing()
 		switchToReplay = false;
 	}
 
-	if ((g_InputRecording.IsReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
-		|| g_InputRecording.GetFrameCounter() == INT_MAX)
+	if ((g_InputRecording.IsReplaying() &&
+		 g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames()) ||
+		g_InputRecording.GetFrameCounter() == INT_MAX)
 		pauseEmulation = true;
 
 	// If we haven't yet advanced atleast a single frame from when we paused, setup things to be paused
-	if (frameAdvancing && frameAdvanceMarker < g_InputRecording.GetFrameCounter()) 
+	if (frameAdvancing && frameAdvanceMarker < g_InputRecording.GetFrameCounter())
 	{
 		frameAdvancing = false;
 		pauseEmulation = true;
 	}
-	
+
 	// Pause emulation if we need to (either due to frame advancing, or pause has been explicitly toggled on)
 	if (pauseEmulation && CoreThread.IsOpen() && CoreThread.IsRunning())
 	{
@@ -110,8 +111,8 @@ void InputRecordingControls::ResumeCoreThreadIfStarted()
 
 void InputRecordingControls::FrameAdvance()
 {
-	if (g_InputRecording.IsReplaying()
-		&& g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
+	if (g_InputRecording.IsReplaying() &&
+		g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
@@ -146,8 +147,8 @@ void InputRecordingControls::PauseImmediately()
 
 void InputRecordingControls::Resume()
 {
-	if (g_InputRecording.IsReplaying()
-		&& g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
+	if (g_InputRecording.IsReplaying() &&
+		g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
@@ -168,20 +169,23 @@ void InputRecordingControls::DisableFrameAdvance()
 
 void InputRecordingControls::TogglePause()
 {
-	if (pauseEmulation && g_InputRecording.IsReplaying()
-		&& g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
+	if (pauseEmulation &&
+		g_InputRecording.IsReplaying() &&
+		g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetTotalFrames())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
 	}
 	pauseEmulation = !pauseEmulation;
 	resumeEmulation = !pauseEmulation;
+	inputRec::log(pauseEmulation ? "Paused Emulation" : "Resumed Emulation");
 }
 
 void InputRecordingControls::RecordModeToggle()
 {
-	if (IsPaused() || g_InputRecording.IsReplaying()
-		|| g_InputRecording.GetFrameCounter() < g_InputRecording.GetInputRecordingData().GetTotalFrames())
+	if (IsPaused() ||
+		g_InputRecording.IsReplaying() ||
+		g_InputRecording.GetFrameCounter() < g_InputRecording.GetInputRecordingData().GetTotalFrames())
 	{
 		if (g_InputRecording.IsReplaying())
 			g_InputRecording.SetToRecordMode();

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -21,7 +21,8 @@
 #include "MainFrame.h"
 #include "MemoryTypes.h"
 
-#include "Recording/InputRecordingFile.h"
+#include "InputRecordingFile.h"
+#include "Utilities/InputRecordingLogger.h"
 
 void InputRecordingFileHeader::Init()
 {
@@ -120,10 +121,10 @@ bool InputRecordingFile::open(const wxString path, bool newRecording)
 			return true;
 		}
 		Close();
-		recordingConLog(wxString::Format("[REC]: Input recording file header is invalid\n"));
+		inputRec::consoleLog("Input recording file header is invalid");
 		return false;
 	}
-	recordingConLog(wxString::Format("[REC]: Input recording file opening failed. Error - %s\n", strerror(errno)));
+	inputRec::consoleLog("Input recording file opening failed. Error - %s", strerror(errno));
 	return false;
 }
 
@@ -140,7 +141,7 @@ bool InputRecordingFile::OpenNew(const wxString path, bool fromSavestate)
 			}
 		}
 		else
-			recordingConLog(L"[REC]: Game is not open, aborting playing input recording which starts on a save-state.\n");
+			inputRec::consoleLog("Game is not open, aborting playing input recording which starts on a save-state.");
 		return false;
 	}
 	else if (open(path, true))
@@ -242,7 +243,7 @@ bool InputRecordingFile::verifyRecordingFileHeader()
 	// Check for current verison
 	if (header.version != 1)
 	{
-		recordingConLog(wxString::Format("[REC]: Input recording file is not a supported version - %d\n", header.version));
+		inputRec::consoleLog("Input recording file is not a supported version - %d", header.version);
 		return false;
 	}
 	return true;

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.h
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.h
@@ -1,0 +1,86 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "App.h"
+#include "ConsoleLogger.h"
+#include "DebugTools/Debug.h"
+#include "Utilities/Console.h"
+
+#include <memory>
+#include <string>
+
+namespace inputRec
+{
+	namespace
+	{
+		template <typename... Args>
+		static std::string fmtStr(const std::string& format, Args... args)
+		{
+			size_t size = snprintf(nullptr, 0, format.c_str(), args...) + 1;
+			if (size <= 0)
+				return std::string("");
+
+			std::unique_ptr<char[]> buf(new char[size]);
+			snprintf(buf.get(), size, format.c_str(), args...);
+			return std::string(buf.get(), buf.get() + size - 1);
+		}
+	} // namespace
+
+
+	template <typename... Args>
+	static void log(const std::string& format, Args... args)
+	{
+		std::string finalStr = fmtStr(format, std::forward<Args>(args)...);
+		if (finalStr.empty())
+			return;
+
+		recordingConLog("[REC]: " + finalStr + "\n");
+
+		// NOTE - Color is not currently used for OSD logs
+		if (GSosdLog)
+			GSosdLog(finalStr.c_str(), wxGetApp().GetProgramLog()->GetRGBA(ConsoleColors::Color_StrongMagenta));
+	}
+
+	template <typename... Args>
+	static void consoleLog(const std::string& format, Args... args)
+	{
+		std::string finalStr = fmtStr(format, std::forward<Args>(args)...);
+		if (finalStr.empty())
+			return;
+
+		recordingConLog(finalStr + "\n");
+	}
+
+	static void consoleMultiLog(std::vector<std::string> strs)
+	{
+		std::string finalStr;
+		for (std::string s : strs)
+			finalStr.append("[REC]: " + s + "\n");
+
+		recordingConLog(finalStr);
+	}
+
+
+	static void consoleMultiLog(std::vector<wxString> strs)
+	{
+		std::vector<std::string> stdStrs;
+		for (wxString s : strs)
+			stdStrs.push_back(std::string(s));
+
+		consoleMultiLog(stdStrs);
+	}
+} // namespace inputRec

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -27,6 +27,7 @@
 
 #ifndef DISABLE_RECORDING
 #	include "Recording/InputRecording.h"
+#	include "Recording/Utilities/InputRecordingLogger.h"
 #endif
 
 #include <wx/utils.h>
@@ -142,7 +143,7 @@ void GSPanel::InitRecordingAccelerators()
 		m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString(),
 		g_InputRecording.IsActive());
 
-	recordingConLog(L"Initialized Input Recording Key Bindings\n");
+	inputRec::consoleLog("Initialized Input Recording Key Bindings");
 }
 
 void GSPanel::RemoveRecordingAccelerators()

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -598,6 +598,7 @@
     <ClInclude Include="..\..\Recording\VirtualPad\VirtualPad.h" />
     <ClInclude Include="..\..\Recording\VirtualPad\VirtualPadData.h" />
     <ClInclude Include="..\..\Recording\VirtualPad\VirtualPadResources.h" />
+    <ClInclude Include="..\..\Recording\Utilities\InputRecordingLogger.h" />
     <ClInclude Include="..\..\Utilities\AsciiFile.h" />
     <ClInclude Include="..\..\Elfheader.h" />
     <ClInclude Include="..\..\CDVD\IsoFileFormats.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -163,6 +163,9 @@
     <Filter Include="System\Ps2\SPU2">
       <UniqueIdentifier>{bed493d6-96dc-4057-a1f2-31f88ec927d9}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Recording\Utilities">
+      <UniqueIdentifier>{85c5a0d2-6404-439f-8756-d908a1442b96}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Recording\VirtualPad\Images">
       <UniqueIdentifier>{ad528458-08eb-49a2-aefa-3c2b86ab8896}</UniqueIdentifier>
     </Filter>
@@ -1517,6 +1520,9 @@
     </ClInclude>
     <ClInclude Include="..\..\SPU2\Windows\WinConfig.h">
       <Filter>System\Ps2\SPU2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Recording\Utilities\InputRecordingLogger.h">
+      <Filter>Recording\Utilities</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This adds OSD logs around input recording actions, specifically:
- Pausing (note that since its pausing emulation, the log won't show up until the next frame)
- Resuming
- Recording Mode Toggling
- Starting a new Recording
- Playing an existing Recording
- Stopping a Recording

I did not include actions for frame-advance, because it would just fill the screen with logs and as mentioned before, the log will only show up the next frame.

I also added a small logging utility header which simplifies the logging story.

### Examples

![image](https://user-images.githubusercontent.com/13153231/94978470-731c6b00-04eb-11eb-993c-1312cf443e77.png)
![image](https://user-images.githubusercontent.com/13153231/94978499-87f8fe80-04eb-11eb-894d-3fa3eb70bb84.png)
![image](https://user-images.githubusercontent.com/13153231/94978518-97784780-04eb-11eb-9adc-dcd06e11a925.png)
