### PR TITLE
DEV9: fix crash when closing game window with ethernet disabled

### DIFF
--- a/plugins/dev9ghzdrk/Win32/tap-win32.cpp
+++ b/plugins/dev9ghzdrk/Win32/tap-win32.cpp
@@ -280,6 +280,7 @@ TAPAdapter::TAPAdapter()
     write.Offset = 0;
     write.OffsetHigh = 0;
     write.hEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+    isActive = true;
 	
 	
 }
@@ -379,10 +380,13 @@ bool TAPAdapter::send(NetPacket* pkt)
 }
 TAPAdapter::~TAPAdapter()
 {
+	if (!isActive)
+		return;
 	CloseHandle(read.hEvent);
 	CloseHandle(write.hEvent);
 	TAPSetStatus(htap, FALSE);
 	CloseHandle(htap);
+	isActive = false;
 }
 
 //i leave these for reference, in case we need msth :p

--- a/plugins/dev9ghzdrk/Win32/tap.h
+++ b/plugins/dev9ghzdrk/Win32/tap.h
@@ -29,6 +29,7 @@ class TAPAdapter : public NetAdapter
 {
 	HANDLE htap;
 	OVERLAPPED read,write;
+	bool isActive = false;
 public:
 	TAPAdapter();
 	virtual bool blocks();


### PR DESCRIPTION
when ethernet is disabled we did not initialize a TAP interface so we check that we have an init'd interface before closing it