### PR TITLE
CDVD: Allow executing ELFs with "ISO" selected 

### DIFF
--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -368,12 +368,20 @@ bool DoCDVDopen()
 
 	auto CurrentSourceType = enum_cast(m_CurrentSourceType);
 	int ret = CDVD->open(!m_SourceFilename[CurrentSourceType].IsEmpty() ?
-							 static_cast<const char*>(m_SourceFilename[CurrentSourceType].ToUTF8()) :
-							 (char*)NULL);
+							static_cast<const char*>(m_SourceFilename[CurrentSourceType].ToUTF8()) :
+							(char*)NULL,
+							(CurrentSourceType == CDVD_TYPE_NODISC));
 
 	if (ret == -1)
-		return false; // error! (handled by caller)
-	//if( ret == 1 )	throw Exception::CancelEvent(L"User canceled the CDVD plugin's open dialog."); <--- TODO_CDVD is this still needed?
+	{
+		// CDVD was unable to open, error handled by caller
+		return false;
+	}
+	if (ret == -2)
+	{
+		// CDVD was unable to open but it doesn't matter because we are launching an ELF
+		return true;
+	}
 
 	int cdtype = DoCDVDdetectDiskType();
 
@@ -544,7 +552,7 @@ void DoCDVDresetDiskTypeCache()
 
 
 
-s32 CALLBACK NODISCopen(const char* pTitle)
+s32 CALLBACK NODISCopen(const char* pTitle, bool launchELF)
 {
 	return 0;
 }

--- a/pcsx2/CDVD/CDVDaccess.h
+++ b/pcsx2/CDVD/CDVDaccess.h
@@ -81,7 +81,7 @@ typedef struct _cdvdTN
 // CDVD
 // NOTE: The read/write functions CANNOT use XMM/MMX regs
 // If you want to use them, need to save and restore current ones
-typedef s32(CALLBACK* _CDVDopen)(const char* pTitleFilename);
+typedef s32(CALLBACK* _CDVDopen)(const char* pTitleFilename, bool launchELF);
 
 // Initiates an asynchronous track read operation.
 // Returns -1 on error (invalid track)

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -181,7 +181,7 @@ void StopKeepAliveThread()
 	s_keepalive_thread.join();
 }
 
-s32 CALLBACK DISCopen(const char* pTitle)
+s32 CALLBACK DISCopen(const char* pTitle, bool launchELF)
 {
 #if defined(_WIN32)
 	std::wstring drive = g_Conf->Folders.RunDisc.GetPath().ToStdWstring();

--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -40,12 +40,18 @@ void CALLBACK ISOclose()
 	iso.Close();
 }
 
-s32 CALLBACK ISOopen(const char* pTitle)
+s32 CALLBACK ISOopen(const char* pTitle, bool launchELF)
 {
 	ISOclose(); // just in case
 
 	if ((pTitle == NULL) || (pTitle[0] == 0))
 	{
+		if (launchELF) 
+		{
+			// In this case, no ISO is specified but we are launching from an ELF so it doesn't matter
+			return -2;
+		}
+		
 		Console.Error("CDVDiso Error: No filename specified.");
 		return -1;
 	}

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -626,6 +626,7 @@ void MainEmuFrame::Menu_OpenELF_Click(wxCommandEvent&)
 	if (_DoSelectELFBrowser())
 	{
 		g_Conf->EmuOptions.UseBOOT2Injection = true;
+		CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
 		sApp.SysExecute(g_Conf->CdvdSource, g_Conf->CurrentELF);
 	}
 


### PR DESCRIPTION
This fix allows us to tell CDVD to check if we are loading an ELF or not. This is required due to the fact that CDVD loads whatever it can on plugin load.

As shown in issue #3720, whenever there is no ISO selected in the ISO selector and CDVD is set to "ISO" mode, it'll prompt you with an error message.

Also: I attempted to at least allow CDVD to try and load when executing an ELF, this is for those who use homebrew but still need to emulate a DVD drive.