### PR TITLE
recording: Resolve VirtualPads not drawing for some games

### DIFF
--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -111,7 +111,7 @@ void InputRecording::ControllerInterrupt(u8& data, u8& port, u16& bufCount, u8 b
 			if (frameCounter >= 0 && frameCounter < INT_MAX)
 			{
 				if (!inputRecordingData.ReadKeyBuffer(bufVal, frameCounter, port, bufIndex))
-					inputRec::consoleLog(fmt::format("[REC]: Failed to read input data at frame {}", frameCounter));
+					inputRec::consoleLog(fmt::format("Failed to read input data at frame {}", frameCounter));
 
 				// Update controller data state for future VirtualPad / logging usage.
 				padData[port]->UpdateControllerData(bufIndex, bufVal);
@@ -142,7 +142,7 @@ void InputRecording::ControllerInterrupt(u8& data, u8& port, u16& bufCount, u8 b
 					}
 
 					if (frameCounter < INT_MAX && !inputRecordingData.WriteKeyBuffer(frameCounter, port, bufIndex, bufVal))
-						inputRec::consoleLog(fmt::format("[REC]: Failed to write input data at frame {}", frameCounter));
+						inputRec::consoleLog(fmt::format("Failed to write input data at frame {}", frameCounter));
 				}
 			}
 			// If the VirtualPad updated the PadData, we have to update the buffer

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -89,6 +89,8 @@ public:
 	void Stop();
 	// Initialze VirtualPad window
 	void setVirtualPadPtr(VirtualPad* ptr, int const port);
+	// Logs the padData and redraws the virtualPad windows of active pads
+	void LogAndRedraw();
 	// Resets a recording if the base savestate could not be loaded at the start
 	void FailedSavestate();
 

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -60,8 +60,7 @@ void InputRecordingControls::HandleFrameAdvanceAndPausing()
 	else if (frameCountTracker != g_FrameCount)
 	{
 		frameCountTracker = g_FrameCount;
-		if (g_InputRecording.GetFrameCounter() < INT_MAX)
-			g_InputRecording.IncrementFrameCounter();
+		g_InputRecording.IncrementFrameCounter();
 	}
 	else
 	{

--- a/pcsx2/Recording/PadData.h
+++ b/pcsx2/Recording/PadData.h
@@ -22,7 +22,6 @@ class PadData
 public:
 	/// Constants
 	static const u8 ANALOG_VECTOR_NEUTRAL = 127;
-	static const u16 END_INDEX_CONTROLLER_BUFFER = 17;
 
 	enum class BufferIndex
 	{


### PR DESCRIPTION
The call for the virtualPads to redraw their visual assets originally required for the sio to provide a `bufCount` of **20** to `controllerInterrupt` - the last value index used for polling controller data (reinterpreted as **17**). However, for some of the games that do not utilize button pressure, that value will only ever reach a max of  **8** (Ex: Sonic Mega Collection Plus); consequently, the virtual pad will never be drawn.

By unhooking the padData logging and virtualPad redrawing from this conditional and instead calling it from a static location, both will now occur regardless of max `bufCount` value. `ControllerInterrupt` was also rearranged to allow virtualPads to be utilized outside of the limited frame window of an input recording (with limitations in record mode).