### PR TITLE
Generate a Position Independant Executable

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -185,7 +185,7 @@ if(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386")
     #     - code uses the ebx register so it's not compliant with PIC.
     #     - Impacts the performance too much.
     #     - Only plugins. No package will link to them.
-    set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     if(NOT DEFINED ARCH_FLAG)
         if (DISABLE_ADVANCE_SIMD)

--- a/common/include/Utilities/StringHelpers.h
+++ b/common/include/Utilities/StringHelpers.h
@@ -226,7 +226,7 @@ extern bool pxParseAssignmentString(const wxString &src, wxString &ldest, wxStri
 #define pxsFmt FastFormatUnicode().Write
 #define pxsFmtV FastFormatUnicode().WriteV
 
-#define pxsPtr(ptr) pxsFmt("0x%08X", (ptr)).c_str()
+#define pxsPtr(ptr) pxsFmt("0x%08llX", (u64)(uptr)(ptr)).c_str()
 
 extern wxString &operator+=(wxString &str1, const FastFormatUnicode &str2);
 extern wxString operator+(const wxString &str1, const FastFormatUnicode &str2);

--- a/common/src/Utilities/Windows/WinHostSys.cpp
+++ b/common/src/Utilities/Windows/WinHostSys.cpp
@@ -110,40 +110,7 @@ void *HostSys::MmapReserve(uptr base, size_t size)
     if(base==0)
         return MmapReservePtr(0, size);
 #ifndef JIT_DEBUG
-    // 32 bit has sign requirements for the jit that 64 shouldn't have issues
-    // with
- 	if (sizeof(void*) == 4)
-    {
-        // as the entropy used by mmap address randomization is unknown 
-        // and that we need to clear one bit of entropy for our JIT to work we
-        // generate our own cryptographically secure address like a good boy.
-        // entropy of approximately 29.5 bits, aka 800M, probably unrealistic to
-        // brute force.
-        HCRYPTPROV hProvider;
-        if (FALSE == CryptAcquireContext(&hProvider, NULL, NULL, PROV_RSA_FULL, 0)) 
-        {
-            if (NTE_BAD_KEYSET == GetLastError()) 
-            {
-                if (FALSE == CryptAcquireContext(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET)) 
-                {
-                    return MmapReservePtr(0, size);
-                }
-            }
-        }
-        do
-        {
-            CryptGenRandom(hProvider, sizeof base, (BYTE *)&base);
-        }while(!((base)<0x30000000));
-        CryptReleaseContext(hProvider, 0U);
-    }
-    else 
-    {
-        // our system allocator uses the codebase address as a hint and finds the
-        // closest available address to our code pointer, reusing the main
-        // executable ASLR. Best we can do 'til we rewrite our VTLB and JIT
-        // handlers.
-        base = (uptr)&_platform_InstallSignalHandler;
-    }
+	return MmapReservePtr((void*)0x50000000, size);
 #endif
     return MmapReservePtr((void *)base, size);
 }

--- a/common/src/Utilities/Windows/WinHostSys.cpp
+++ b/common/src/Utilities/Windows/WinHostSys.cpp
@@ -18,6 +18,7 @@
 #include "PageFaultSource.h"
 
 #include <winnt.h>
+#include <wincrypt.h>
 
 static long DoSysPageFaultExceptionFilter(EXCEPTION_POINTERS *eps)
 {
@@ -103,9 +104,47 @@ void HostSys::MmapResetPtr(void *base, size_t size)
     VirtualFree(base, size, MEM_DECOMMIT);
 }
 
-
 void *HostSys::MmapReserve(uptr base, size_t size)
 {
+    // V or when our JIT is fully relocatable
+    if(base==0)
+        return MmapReservePtr(0, size);
+#ifndef JIT_DEBUG
+    // 32 bit has sign requirements for the jit that 64 shouldn't have issues
+    // with
+ 	if (sizeof(void*) == 4)
+    {
+        // as the entropy used by mmap address randomization is unknown 
+        // and that we need to clear one bit of entropy for our JIT to work we
+        // generate our own cryptographically secure address like a good boy.
+        // entropy of approximately 29.5 bits, aka 800M, probably unrealistic to
+        // brute force.
+        HCRYPTPROV hProvider;
+        if (FALSE == CryptAcquireContext(&hProvider, NULL, NULL, PROV_RSA_FULL, 0)) 
+        {
+            if (NTE_BAD_KEYSET == GetLastError()) 
+            {
+                if (FALSE == CryptAcquireContext(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET)) 
+                {
+                    return MmapReservePtr(0, size);
+                }
+            }
+        }
+        do
+        {
+            CryptGenRandom(hProvider, sizeof base, (BYTE *)&base);
+        }while(!((base)<0x30000000));
+        CryptReleaseContext(hProvider, 0U);
+    }
+    else 
+    {
+        // our system allocator uses the codebase address as a hint and finds the
+        // closest available address to our code pointer, reusing the main
+        // executable ASLR. Best we can do 'til we rewrite our VTLB and JIT
+        // handlers.
+        base = (uptr)&_platform_InstallSignalHandler;
+    }
+#endif
     return MmapReservePtr((void *)base, size);
 }
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -826,7 +826,10 @@ if(USE_VTUNE)
     set(pcsx2FinalLibs ${pcsx2FinalLibs} ${VTUNE_LIBRARIES})
 endif()
 
+include(CheckPIESupported)
+check_pie_supported()
 add_pcsx2_executable(${Output} "${pcsx2FinalSources}" "${pcsx2FinalLibs}" "${pcsx2FinalFlags}")
+set_property(TARGET ${Output} PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_compile_features(${Output} PRIVATE cxx_std_17)
 
 if(COMMAND target_precompile_headers)

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -360,7 +360,7 @@ namespace HostMemoryMap {
 static VirtualMemoryManagerPtr makeMainMemoryManager() {
 	// Everything looks nicer when the start of all the sections is a nice round looking number.
 	// Also reduces the variation in the address due to small changes in code.
-	// Breaks ASLR but so does anything else that tries to make addresses constant for our debugging pleasure
+	// Ignored if JIT_DEBUG isn't set as it breaks ASLR.
 	uptr codeBase = (uptr)(void*)makeMainMemoryManager / (1 << 28) * (1 << 28);
 
 	// The allocation is ~640mb in size, slighly under 3*2^28.

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -57,12 +57,11 @@ static vtlbHandler UnmappedPhyHandler0;
 static vtlbHandler UnmappedPhyHandler1;
 
 vtlb_private::VTLBPhysical vtlb_private::VTLBPhysical::fromPointer(sptr ptr) {
-	pxAssertMsg(ptr >= 0, "Address too high");
-	return VTLBPhysical(ptr);
+	return VTLBPhysical(ptr, false);
 }
 
 vtlb_private::VTLBPhysical vtlb_private::VTLBPhysical::fromHandler(vtlbHandler handler) {
-	return VTLBPhysical(handler | POINTER_SIGN_BIT);
+	return VTLBPhysical(handler, true);
 }
 
 vtlb_private::VTLBVirtual::VTLBVirtual(VTLBPhysical phys, u32 paddr, u32 vaddr) {
@@ -70,7 +69,7 @@ vtlb_private::VTLBVirtual::VTLBVirtual(VTLBPhysical phys, u32 paddr, u32 vaddr) 
 	pxAssertMsg(0 == (vaddr & VTLB_PAGE_MASK), "Should be page aligned");
 	pxAssertMsg((uptr)paddr < POINTER_SIGN_BIT, "Address too high");
 	if (phys.isHandler()) {
-		value = phys.raw() + paddr - vaddr;
+		value = (phys.raw() | POINTER_SIGN_BIT) + paddr - vaddr;
 	} else {
 		value = phys.raw() - vaddr;
 	}

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -212,8 +212,8 @@ namespace vtlb_private
 	private:
 		explicit VTLBVirtual(uptr value): value(value) { }
 	public:
-		bool handler = false;
 		uptr value;
+		bool handler = true;
 		VTLBVirtual(): value(0) {}
 		VTLBVirtual(VTLBPhysical phys, u32 paddr, u32 vaddr);
 		static VTLBVirtual fromPointer(uptr ptr, u32 vaddr) {

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -210,9 +210,10 @@ namespace vtlb_private
 	struct VTLBVirtual
 	{
 	private:
-		uptr value;
 		explicit VTLBVirtual(uptr value): value(value) { }
 	public:
+		bool handler = false;
+		uptr value;
 		VTLBVirtual(): value(0) {}
 		VTLBVirtual(VTLBPhysical phys, u32 paddr, u32 vaddr);
 		static VTLBVirtual fromPointer(uptr ptr, u32 vaddr) {

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -190,11 +190,10 @@ namespace vtlb_private
 	{
 	private:
 		sptr value;
-		explicit VTLBPhysical(sptr value): value(value) { }
+		bool handler = false;
+		explicit VTLBPhysical(sptr value, bool handler): value(value), handler(handler) { }
 	public:
 		VTLBPhysical(): value(0) {}
-		/// Create from a pointer to raw memory
-		static VTLBPhysical fromPointer(void *ptr) { return fromPointer((sptr)ptr); }
 		/// Create from an integer representing a pointer to raw memory
 		static VTLBPhysical fromPointer(sptr ptr);
 		/// Create from a handler and address
@@ -203,11 +202,9 @@ namespace vtlb_private
 		/// Get the raw value held by the entry
 		uptr raw() const { return value; }
 		/// Returns whether or not this entry is a handler
-		bool isHandler() const { return value < 0; }
+		bool isHandler() const { return handler; }
 		/// Assumes the entry is a pointer, giving back its value
 		uptr assumePtr() const { return value; }
-		/// Assumes the entry is a handler, and gets the raw handler ID
-		u8 assumeHandler() const { return value; }
 	};
 
 	struct VTLBVirtual

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -152,6 +152,7 @@ namespace vtlb_private
 {
 
 	std::unique_ptr<VTLBVirtual> vtlb_dummy(new VTLBVirtual());
+	const sptr vtlb_val_offset = (uptr)&(vtlb_dummy->value) - (uptr)vtlb_dummy.get(); 
 
 	// ------------------------------------------------------------------------
 	// Prepares eax, ecx, and, ebx for Direct or Indirect operations.
@@ -165,9 +166,7 @@ namespace vtlb_private
 		xMOV( eax, arg1regd );
 		xSHR( eax, VTLB_PAGE_BITS );
 		
-		uptr offset = (uptr)vtlb_dummy.get();
-		offset -= (uptr)&(vtlb_dummy->value);
-		xMOV( rax, ptrNative[xComplexAddress(rbx, vtlbdata.vmap, (rax*wordsize)+offset)] );
+		xMOV( rax, ptrNative[xComplexAddress(rbx, vtlbdata.vmap, rax*wordsize)] );
 		u32* writeback = xLEA_Writeback( rbx );
 		xADD( arg1reg, rax );
 

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -150,6 +150,9 @@ static void iMOV64_Smart( const xIndirectVoid& destRm, const xIndirectVoid& srcR
 
 namespace vtlb_private
 {
+
+	std::unique_ptr<VTLBVirtual> vtlb_dummy(new VTLBVirtual());
+
 	// ------------------------------------------------------------------------
 	// Prepares eax, ecx, and, ebx for Direct or Indirect operations.
 	// Returns the writeback pointer for ebx (return address from indirect handling)
@@ -161,7 +164,10 @@ namespace vtlb_private
 
 		xMOV( eax, arg1regd );
 		xSHR( eax, VTLB_PAGE_BITS );
-		xMOV( rax, ptrNative[xComplexAddress(rbx, vtlbdata.vmap, rax*wordsize)] );
+		
+		uptr offset = (uptr)vtlb_dummy.get();
+		offset -= (uptr)&(vtlb_dummy->value);
+		xMOV( rax, ptrNative[xComplexAddress(rbx, vtlbdata.vmap, (rax*wordsize)+offset)] );
 		u32* writeback = xLEA_Writeback( rbx );
 		xADD( arg1reg, rax );
 


### PR DESCRIPTION
PIE/PIC is pretty much mandatory when dealing with libraries in modern OSes. Our plugins are already PIC(64 bit only currently but moot point since I'm merging plugins) but not the main executable. As the reasons why PIC was disabled on 32bit are pretty much moot now I enabled PIE globally.

~~This currently only implements it in CMake, I'll check msbuild later today.~~ msbuild seems to enable it by default.

This probably doesn't require much testing, if it boots and the jit doesn't crash we're good basically