### PR TITLE
Actions: Add dependabot to automatically keep actions dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Due to the recent CVE, our Windows workflow is now being flagged.

I've created an issue in the offending dependency https://github.com/microsoft/setup-msbuild/issues/26 and once updated, dependabot should pick it up and make a PR to update it and eliminate the CVE annotation.