### PR TITLE
gsdx-osd: fix crashing on d3d11

### DIFF
--- a/plugins/GSdx/Renderers/Common/GSOsdManager.cpp
+++ b/plugins/GSdx/Renderers/Common/GSOsdManager.cpp
@@ -57,7 +57,7 @@ void GSOsdManager::LoadSize() {
 	/* This is not exact, I'm sure there's some convoluted way to determine these
 	 * from FreeType but they don't make it easy. */
 	m_atlas_w = m_size * 96; // random guess
-	m_atlas_h = m_size; // another random guess
+	m_atlas_h = m_size + 10; // another random guess
 }
 
 GSOsdManager::GSOsdManager() : m_atlas_h(0)


### PR DESCRIPTION
not a good fix but fixes the crashing for now.
OSD is calculating the wrong texture size and it is causing d3d11 to crash.

Note to self: replace OSD with something sane.