### PR TITLE
SIF: Fix attempting to write junk when FIFO full

### DIFF
--- a/pcsx2/Sif.h
+++ b/pcsx2/Sif.h
@@ -51,12 +51,18 @@ struct sifFifo
 	{
 		if (words > 0)
 		{
-			const int wP0 = std::min((FIFO_SIF_W - writePos), words);
-			const int wP1 = words - wP0;
+			if ((FIFO_SIF_W - size) < words)
+				DevCon.Warning("Not enough space in SIF0 FIFO!\n");
+
 			if (size < 4)
 			{
-				memcpy(&junk[size], from, (4 - size) << 2);
+				u32 amt = std::min(4 - size, words);
+				memcpy(&junk[size], from, amt << 2);
 			}
+
+			const int wP0 = std::min((FIFO_SIF_W - writePos), words);
+			const int wP1 = words - wP0;
+
 			memcpy(&data[writePos], from, wP0 << 2);
 			memcpy(&data[0], &from[wP0], wP1 << 2);
 
@@ -70,6 +76,8 @@ struct sifFifo
 	{
 		if (words > 0)
 		{
+			if ((FIFO_SIF_W - size) < words)
+				DevCon.Warning("Not enough Junk space in SIF0 FIFO!\n");
 			const int wP0 = std::min((FIFO_SIF_W - writePos), words);
 			const int wP1 = words - wP0;
 
@@ -130,7 +138,7 @@ struct sif_iop
 	bool busy;
 
 	s32 cycles;
-	u32 writeJunk;
+	s32 writeJunk;
 
 	s32 counter; // Used to keep track of how much is left in IOP.
 	struct sifData data; // Only used in IOP.

--- a/pcsx2/Sif0.cpp
+++ b/pcsx2/Sif0.cpp
@@ -83,12 +83,7 @@ static __fi bool WriteIOPtoFifo()
 	sif0.iop.cycles += writeSize; //1 word per cycle
 	sif0.iop.counter -= writeSize;
 
-	if (sif0.iop.counter == 0 && sif0.iop.writeJunk)
-	{
-		SIF_LOG("Writing Junk %d", sif0.iop.writeJunk);
-		sif0.fifo.writeJunk(sif0.iop.writeJunk);
-		sif0.iop.writeJunk = 0;
-	}
+	
 	return true;
 }
 
@@ -231,7 +226,7 @@ static __fi void HandleEETransfer()
 	if (sif0ch.qwc > 0) // If we're writing something, continue to do so.
 	{
 		// Write from Fifo to EE.
-		if (sif0.fifo.size > 0)
+		if (sif0.fifo.size >= 4)
 		{
 			WriteFifoToEE();
 		}
@@ -312,6 +307,13 @@ __fi void SIF0Dma()
 	{
 		//I realise this is very hacky in a way but its an easy way of checking if both are doing something
 		BusyCheck = 0;
+
+		if (sif0.iop.counter == 0 && sif0.iop.writeJunk && sif0.fifo.sif_free() >= sif0.iop.writeJunk)
+		{
+			SIF_LOG("Writing Junk %d", sif0.iop.writeJunk);
+			sif0.fifo.writeJunk(sif0.iop.writeJunk);
+			sif0.iop.writeJunk = 0;
+		}
 
 		if (sif0.iop.busy)
 		{


### PR DESCRIPTION
Also fix the amount of words written to temporary junk

Fixes Ghosthunter, possibly Primal which were broken in the recent SIF commit