### PR TITLE
Cop2: Make sure the status flag gets updated on DIV/SQRT/RSQRT

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -19887,13 +19887,6 @@ Region = NTSC-J
 Serial = SLPM-62051
 Name   = Yanya Caballista - featuring Gawoo
 Region = NTSC-J
-[patches = 402435E5]
-	author=Prafull and Refraction
-	// Fix slow and choppy gameplay.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,00298370,word,48488800
-	patch=1,EE,00298398,word,4a0203bd
-[/patches]
 ---------------------------------------------
 Serial = SLPM-62052
 Name   = Beatmania Da! Da! Da!
@@ -36342,13 +36335,6 @@ Serial = SLUS-20278
 Name   = Yanya Caballista - City Skater
 Region = NTSC-U
 Compat = 4
-[patches = 12BCE532]
-	author=Prafull
-	// Fix slow and choppy gameplay.
-	// Fixed by rearranging COP2 instructions.
-	patch=1,EE,002aaa58,word,48488800
-	patch=1,EE,002aaa80,word,4a0203bd
-[/patches]
 ---------------------------------------------
 Serial = SLUS-20279
 Name   = X-Men - Next Dimension

--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1693,15 +1693,13 @@ Serial = SCES-51176
 Name   = Disney's Treasure Planet
 Region = PAL-M4
 EETimingHack = 1 // Fixes hang before going ingame.
-eeRoundMode = 0 // Fixes characters flying into sky.
-eeClampMode = 3 // Required to load areas correctly.
+vuClampMode = 3 // Fixes SPS when the solar surfer's engines are inactive
 ---------------------------------------------
 Serial = SCES-51177
 Name   = Disney's Treasure Planet
 Region = PAL
 EETimingHack = 1 // Fixes hang before going ingame.
-eeRoundMode = 0 // Fixes characters flying into sky.
-eeClampMode = 3 // Required to load areas correctly.
+vuClampMode = 3 // Fixes SPS when the solar surfer's engines are inactive
 ---------------------------------------------
 Serial = SCES-51179
 Name   = This is Football 2003
@@ -4773,8 +4771,7 @@ Serial = SCUS-97146
 Name   = Disney's Treasure Planet
 Region = NTSC-U
 EETimingHack = 1 // Fixes hang before going ingame.
-eeRoundMode = 0 // Fixes characters flying into sky.
-eeClampMode = 3 // Required to load areas correctly.
+vuClampMode = 3 // Fixes SPS when the solar surfer's engines are inactive
 ---------------------------------------------
 Serial = SCUS-97147
 Name   = Cool Boarders 2001 [Demo]
@@ -40068,8 +40065,10 @@ Name   = Disney's Stitch - Experiment 626
 Region = NTSC-U
 ---------------------------------------------
 Serial = SLUS-21054
-Name   = Disney's Classics - Treasure Planet
+Name   = Disney's Treasure Planet (Disney Classics)
 Region = NTSC-U
+EETimingHack = 1 // Fixes hang before going ingame.
+vuClampMode = 3 // Fixes SPS when the solar surfer's engines are inactive
 ---------------------------------------------
 Serial = SLUS-21056
 Name   = Cabal, The ~~CANCELLED~~

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -79,6 +79,9 @@ mVUop(mVU_DIV) {
 
 		writeQreg(Fs, mVUinfo.writeQ);
 
+		if (mVU.cop2)
+			xOR(gprF0, ptr32[&mVU.divFlag]);
+
 		mVU.regAlloc->clearNeeded(Fs);
 		mVU.regAlloc->clearNeeded(Ft);
 		mVU.regAlloc->clearNeeded(t1);
@@ -98,6 +101,9 @@ mVUop(mVU_SQRT) {
 		if (CHECK_VU_OVERFLOW) xMIN.SS(Ft, ptr32[mVUglob.maxvals]); // Clamp infinities (only need to do positive clamp since xmmFt is positive)
 		xSQRT.SS(Ft, Ft);
 		writeQreg(Ft, mVUinfo.writeQ);
+
+		if (mVU.cop2)
+			xOR(gprF0, ptr32[&mVU.divFlag]);
 
 		mVU.regAlloc->clearNeeded(Ft);
 		mVU.profiler.EmitOp(opSQRT);
@@ -137,6 +143,9 @@ mVUop(mVU_RSQRT) {
 		djmp.SetTarget();
 
 		writeQreg(Fs, mVUinfo.writeQ);
+
+		if (mVU.cop2)
+			xOR(gprF0, ptr32[&mVU.divFlag]);
 
 		mVU.regAlloc->clearNeeded(Fs);
 		mVU.regAlloc->clearNeeded(Ft);

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -203,9 +203,9 @@ REC_COP2_mVU0(CLIP,		"CLIP",		0x08);
 // Macro VU - Redirect Lower Instructions
 //------------------------------------------------------------------
 
-REC_COP2_mVU0(DIV,		"DIV",		0x02);
-REC_COP2_mVU0(SQRT,		"SQRT",		0x02);
-REC_COP2_mVU0(RSQRT,	"RSQRT",	0x02);
+REC_COP2_mVU0(DIV,		"DIV",		0x12);
+REC_COP2_mVU0(SQRT,		"SQRT",		0x12);
+REC_COP2_mVU0(RSQRT,	"RSQRT",	0x12);
 REC_COP2_mVU0(IADD,		"IADD",		0x04);
 REC_COP2_mVU0(IADDI,	"IADDI",	0x04);
 REC_COP2_mVU0(IAND,		"IAND",		0x04);


### PR DESCRIPTION
Fixes Yanya Caballista running slow (patches removed)
Fixes Disney's Treasure Plantet's crazy camera (that flies off) and ground displacement. Fixes #3441