### PR TITLE
FPU: Removed forced rounding on DIV/SQRT/RSQRT (Do Not merge!)

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -14612,10 +14612,12 @@ vuRoundMode = 0 // Fixes textures and crashes.
 Serial = SLES-53524
 Name   = Mortal Kombat - Shaolin Monks
 Region = PAL-M5
+eeRoundMode = 2 // Fixes texture sizes
 ---------------------------------------------
 Serial = SLES-53525
 Name   = Mortal Kombat - Shaolin Monks
 Region = PAL-G
+eeRoundMode = 2 // Fixes texture sizes
 ---------------------------------------------
 Serial = SLES-53526
 Name   = Suffering, The - Ties that Bind
@@ -40239,6 +40241,7 @@ Serial = SLUS-21087
 Name   = Mortal Kombat - Shaolin Monks
 Region = NTSC-U
 Compat = 5
+eeRoundMode = 2 // Fixes texture sizes
 ---------------------------------------------
 Serial = SLUS-21088
 Name   = Disney's Chicken Little

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -1028,19 +1028,6 @@ void recDIV_S_xmm(int info)
 			roundmodeFlag = true;
 		}
 	}
-	else
-	{
-		if (g_sseMXCSR.GetRoundMode() != SSEround_Nearest)
-		{
-			// Set roundmode to nearest since it isn't already
-			//Console.WriteLn("div to nearest");
-
-			roundmode_nearest = g_sseMXCSR;
-			roundmode_nearest.SetRoundMode( SSEround_Nearest );
-			xLDMXCSR( roundmode_nearest );
-			roundmodeFlag = true;
-		}
-	}
 
 	switch(info & (PROCESS_EE_S|PROCESS_EE_T) ) {
 		case PROCESS_EE_S:
@@ -1600,16 +1587,6 @@ void recSQRT_S_xmm(int info)
 	bool roundmodeFlag = false;
 	//Console.WriteLn("FPU: SQRT");
 
-	if (g_sseMXCSR.GetRoundMode() != SSEround_Nearest)
-	{
-		// Set roundmode to nearest if it isn't already
-		//Console.WriteLn("sqrt to nearest");
-		roundmode_nearest = g_sseMXCSR;
-		roundmode_nearest.SetRoundMode( SSEround_Nearest );
-		xLDMXCSR (roundmode_nearest);
-		roundmodeFlag = true;
-	}
-
 	if( info & PROCESS_EE_T ) xMOVSS(xRegisterSSE(EEREC_D), xRegisterSSE(EEREC_T));
 	else xMOVSSZX(xRegisterSSE(EEREC_D), ptr[&fpuRegs.fpr[_Ft_]]);
 
@@ -1633,8 +1610,6 @@ void recSQRT_S_xmm(int info)
 	if (CHECK_FPU_OVERFLOW) xMIN.SS(xRegisterSSE(EEREC_D), ptr[&g_maxvals[0]]);// Only need to do positive clamp, since EEREC_D is positive
 	xSQRT.SS(xRegisterSSE(EEREC_D), xRegisterSSE(EEREC_D));
 	if (CHECK_FPU_EXTRA_OVERFLOW) ClampValues(EEREC_D); // Shouldn't need to clamp again since SQRT of a number will always be smaller than the original number, doing it just incase :/
-
-	if (roundmodeFlag) xLDMXCSR (g_sseMXCSR);
 }
 
 FPURECOMPILE_CONSTCODE(SQRT_S, XMMINFO_WRITED|XMMINFO_READT);

--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -652,20 +652,7 @@ void recDIV_S_xmm(int info)
 			roundmodeFlag = true;
 		}
 	}
-	else
-	{
-		if (g_sseMXCSR.GetRoundMode() != SSEround_Nearest)
-		{
-			// Set roundmode to nearest since it isn't already
-			//Console.WriteLn("div to nearest");
-
-			roundmode_nearest = g_sseMXCSR;
-			roundmode_nearest.SetRoundMode( SSEround_Nearest );
-			xLDMXCSR( roundmode_nearest );
-			roundmodeFlag = true;
-		}
-	}
-
+	
 	int sreg, treg;
 
 	ALLOC_S(sreg); ALLOC_T(treg);
@@ -927,20 +914,9 @@ void recSQRT_S_xmm(int info)
 {
 	EE::Profiler.EmitOp(eeOpcode::SQRT_F);
 	u8 *pjmp;
-	int roundmodeFlag = 0;
 	int tempReg = _allocX86reg(xEmptyReg, X86TYPE_TEMP, 0, 0);
 	int t1reg = _allocTempXMMreg(XMMT_FPS, -1);
 	//Console.WriteLn("FPU: SQRT");
-
-	if (g_sseMXCSR.GetRoundMode() != SSEround_Nearest)
-	{
-		// Set roundmode to nearest if it isn't already
-		//Console.WriteLn("sqrt to nearest");
-		roundmode_nearest = g_sseMXCSR;
-		roundmode_nearest.SetRoundMode( SSEround_Nearest );
-		xLDMXCSR (roundmode_nearest);
-		roundmodeFlag = 1;
-	}
 
 	GET_T(EEREC_D);
 
@@ -966,10 +942,6 @@ void recSQRT_S_xmm(int info)
 	xSQRT.SD(xRegisterSSE(EEREC_D), xRegisterSSE(EEREC_D));
 
 	ToPS2FPU(EEREC_D, false, t1reg, false);
-
-	if (roundmodeFlag == 1) {
-		xLDMXCSR (g_sseMXCSR);
-	}
 
 	_freeX86reg(tempReg);
 	_freeXMMreg(t1reg);
@@ -1056,17 +1028,6 @@ void recRSQRT_S_xmm(int info)
 	// Should this do the same?  or is changing the roundmode to nearest the better
 	// behavior for both recs? --air
 
-	bool roundmodeFlag = false;
-	if (g_sseMXCSR.GetRoundMode() != SSEround_Nearest)
-	{
-		// Set roundmode to nearest if it isn't already
-		//Console.WriteLn("sqrt to nearest");
-		roundmode_nearest = g_sseMXCSR;
-		roundmode_nearest.SetRoundMode( SSEround_Nearest );
-		xLDMXCSR (roundmode_nearest);
-		roundmodeFlag = true;
-	}
-
 	ALLOC_S(sreg); ALLOC_T(treg);
 
 	if (FPU_FLAGS_ID)
@@ -1077,8 +1038,6 @@ void recRSQRT_S_xmm(int info)
 	xMOVSS(xRegisterSSE(EEREC_D), xRegisterSSE(sreg));
 
 	_freeXMMreg(treg); _freeXMMreg(sreg);
-
-	if (roundmodeFlag) xLDMXCSR (g_sseMXCSR);
 }
 
 FPURECOMPILE_CONSTCODE(RSQRT_S, XMMINFO_WRITED|XMMINFO_READS|XMMINFO_READT);


### PR DESCRIPTION
Added gamefix for Mortal Kombat Shaolin Monks

Description:

For a very long time PCSX2 has had the rounding mode of DIV, SQRT and RSQRT on the FPU forced to "Nearest" instead of Chop/Zero (unless you use the Neg DIV hack), presumably because it fixed some game and seemed like a good idea.  This PR aims to remove it, but it needs to be tested thoroughly before we even think about merging it.  I suspect a few games will require a gamefix (like Shaolin Monks did) but many other games might see a positive benefit from doing this.

Please reply below if any game needs any other rounding setting and if it has any adverse effects on the game.

Improvements:
Stuntman - AI is improved (but still not brilliant)
Freakstyle - Less issue with invisible walls
ONI - Interactable doors now fixed

Regressions:
Mortal Kombat Shaolin Monks - Texture sizes, fixed by setting rounding to positive