### PR TITLE
gsdx-hw: Set Full DATE accuracy as default.

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -286,8 +286,8 @@ void GSdxApp::Init()
 	};
 
 	m_gs_acc_date_level.push_back(GSSetting(0, "Off", ""));
-	m_gs_acc_date_level.push_back(GSSetting(1, "Fast", "Default"));
-	m_gs_acc_date_level.push_back(GSSetting(2, "Full", "Slow"));
+	m_gs_acc_date_level.push_back(GSSetting(1, "Basic", ""));
+	m_gs_acc_date_level.push_back(GSSetting(2, "Full", "Default"));
 
 	m_gs_acc_blend_level.push_back(GSSetting(0, "None", "Fastest"));
 	m_gs_acc_blend_level.push_back(GSSetting(1, "Basic", "Recommended"));
@@ -320,7 +320,7 @@ void GSdxApp::Init()
 	m_default_configuration["linux_replay"]                               = "1";
 #endif
 	m_default_configuration["aa1"]                                        = "0";
-	m_default_configuration["accurate_date"]                              = "1";
+	m_default_configuration["accurate_date"]                              = "2";
 	m_default_configuration["accurate_blending_unit"]                     = "1";
 	m_default_configuration["AspectRatio"]                                = "1";
 	m_default_configuration["autoflush_sw"]                               = "1";

--- a/plugins/GSdx/Window/GSSetting.cpp
+++ b/plugins/GSdx/Window/GSSetting.cpp
@@ -98,13 +98,12 @@ const char* dialog_message(int ID, bool* updateText) {
 		case IDC_ACCURATE_DATE:
 			return "Implement a more accurate algorithm to compute GS destination alpha testing.\n"
 				"It improves shadow and transparency rendering.\n\n"
-				"None:\nDisables accurate destination alpha testing.\n\n"
-				"Fast:\nFast accurate destination alpha testing.\n"
-				"Most of the time this option should be enough.\n"
+				"None:\nDisables DATE accuracy.\n\n"
+				"Basic:\nBasic DATE accuracy.\n"
+				"Can be inaccurate at times.\n"
+				"Full:\nFully emulates DATE accuracy. Might be slower.\n"
 				"This is the recommended setting.\n\n"
-				"Full:\nSlower but fully emulates destination alpha testing.\n"
-				"Not needed unless Fast mode isn't enough.\n\n"
-				"Note: Full mode is not available on Direct3D.";
+				"Note: Full mode is not available on Direct3D, Basic mode will be used on Full level as well.";
 		case IDC_ACCURATE_BLEND_UNIT:
 			return "Control the accuracy level of the GS blending unit emulation.\n\n"
 				"None:\nFast but introduces various rendering issues.\n"


### PR DESCRIPTION
GL only, D3D11 doesn't have Full level.
It is more accurate and there likely isn't any speed impact.

Rename Fast level to Basic.