### PR TITLE
SPU2: Change default of latency slider

### DIFF
--- a/pcsx2/SPU2/Linux/Config.cpp
+++ b/pcsx2/SPU2/Linux/Config.cpp
@@ -65,7 +65,7 @@ bool _visual_debug_enabled = false; // windows only feature
 
 // OUTPUT
 u32 OutputModule = 0;
-int SndOutLatencyMS = 300;
+int SndOutLatencyMS = 100;
 int SynchMode = 0; // Time Stretch, Async or Disabled
 #ifdef SPU2X_PORTAUDIO
 u32 OutputAPI = 0;
@@ -149,7 +149,7 @@ void ReadSettings()
 #endif
 #endif
 
-	SndOutLatencyMS = CfgReadInt(L"OUTPUT", L"Latency", 300);
+	SndOutLatencyMS = CfgReadInt(L"OUTPUT", L"Latency", 100);
 	SynchMode = CfgReadInt(L"OUTPUT", L"Synch_Mode", 0);
 	numSpeakers = CfgReadInt(L"OUTPUT", L"SpeakerConfiguration", 0);
 

--- a/pcsx2/SPU2/Windows/Config.cpp
+++ b/pcsx2/SPU2/Windows/Config.cpp
@@ -264,7 +264,7 @@ BOOL CALLBACK ConfigProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			double minlat = (SynchMode == 0) ? LATENCY_MIN_TS : LATENCY_MIN;
 			int minexp = (int)(pow(minlat + 1, 1.0 / 3.0) * 128.0);
 			int maxexp = (int)(pow((double)LATENCY_MAX + 2, 1.0 / 3.0) * 128.0);
-			INIT_SLIDER(IDC_LATENCY_SLIDER, minexp, maxexp, 200, 42, 1);
+			INIT_SLIDER(IDC_LATENCY_SLIDER, minexp, maxexp, 200, 13, 15);
 
 			SendDialogMsg(hWnd, IDC_LATENCY_SLIDER, TBM_SETPOS, TRUE, (int)((pow((double)SndOutLatencyMS, 1.0 / 3.0) * 128.0) + 1));
 			swprintf_s(temp, L"%d ms (avg)", SndOutLatencyMS);


### PR DESCRIPTION
Linux: 300 to 100 (which should be fine for everyone), windows was already 100ms.
Windows: Change the steps to start from 3 and increment on higher numbers instead of 0.5 steps which is just stupid to be that granular.