### PR TITLE
Add CODEOWNERS file to automatically assign PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,61 @@
+# ------
+# DOCUMENTATION / EXAMPLES
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+# ------
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# * @global-owner1 and @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+# /build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+# apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository and any of its
+# subdirectories.
+# /docs/ @doctocat
+
+# -------
+# ACTUAL RULES
+# -------
+
+# -- NOTE ---
+# The people you choose as code owners must have write permissions for the repository. When the code owner is a team,
+# that team must have write permissions, even if all the individual members of the team already have write permissions
+# directly, through organization membership, or through another team membership.
+
+# --- GENERAL ---
+# * @pcsx2/dev
+
+# --- CI/GITHUB ---
+.github/ @xtvaser
+
+# --- PLUGINS ---
+plugins/GSdx/ @tadanokojin
+
+# --- INPUT RECORDING ---
+pcsx2/recording/ @xtvaser @sonicfind


### PR DESCRIPTION
I started this as a base, please review if you don't want to be auto-added (or if you do).  Can obviously be expanded upon.

Note, even though I added myself in two spots, I won't get assigned for reviews because I do not have write access.

Documentation - https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners