### PR TITLE
CI/Travis: Fix newly introduced cmake failure in Travis-CI after adding {fmt}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache: ccache
 
 dist: xenial
 
-# build only master branch
-branches:
-  only:
-    - master
+# # build only master branch
+# branches:
+#   only:
+#     - master
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache: ccache
 
 dist: xenial
 
-# # build only master branch
-# branches:
-#   only:
-#     - master
+# build only master branch
+branches:
+  only:
+    - master
 
 matrix:
   include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,3 @@ else()
         INSTALL(FILES "${CMAKE_SOURCE_DIR}/linux_various/PCSX2-linux.sh"          DESTINATION "${CMAKE_SOURCE_DIR}/bin")
     endif()
 endif()
-
-# Link Libraries
-target_link_libraries(PCSX2 fmt::fmt)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -774,6 +774,7 @@ set(pcsx2FinalSources
 set(pcsx2FinalLibs
     Utilities
     x86emitter
+    fmt::fmt
     ${wxWidgets_LIBRARIES}
     ${GTK2_LIBRARIES}
     ${ZLIB_LIBRARIES}


### PR DESCRIPTION
Not quite sure why this didn't fail in actions...different cmake version?  

I pushed a commit to run Travis here as my fork's master differs in some respects (just README changes, but not risking anything this time)

Passing Travis Build - https://travis-ci.org/github/xTVaser/pcsx2-rr/builds/736561988

![](https://media.giphy.com/media/K1QnLV1caRpuw/giphy.gif)