### PR TITLE
Support build with system fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,6 @@ if(NOT NO_TRANSLATION)
     endif()
 endif()
 
-# 3rdpary Libraries
-if(EXISTS "${CMAKE_SOURCE_DIR}/3rdparty/fmt/fmt")
-    add_subdirectory(3rdparty/fmt/fmt)
-endif()
-
 # make common
 if(common_libs)
     add_subdirectory(common/src/Utilities)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -242,3 +242,15 @@ if((GCC_VERSION VERSION_EQUAL "9.0" OR GCC_VERSION VERSION_GREATER "9.0") AND GC
     Even with that patch, compiling with LTO may still segfault. Use at your own risk!
     This text being in a compile log in an open issue may cause it to be closed.")
 endif()
+
+find_package(fmt "7.0.3" QUIET)
+if(NOT fmt_FOUND)
+    if(EXISTS "${CMAKE_SOURCE_DIR}/3rdparty/fmt/fmt/CMakeLists.txt")
+        message(STATUS "No system fmt was found. Using bundled")
+        add_subdirectory(3rdparty/fmt/fmt)
+    else()
+        message(FATAL_ERROR "No system or bundled fmt was found")
+    endif()
+else()
+    message(STATUS "Found fmt: ${fmt_VERSION}")
+endif()


### PR DESCRIPTION
```
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: pcsx2/CMakeFiles/PCSX2.dir/gui/FrameForGS.cpp.o: in function `GSPanel::InitRecordingAccelerators()':
FrameForGS.cpp:(.text+0x4ffd): undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: pcsx2/CMakeFiles/PCSX2.dir/Recording/InputRecording.cpp.o: in function `inputRec::consoleLog(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
InputRecording.cpp:(.text+0x1685): undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: pcsx2/CMakeFiles/PCSX2.dir/Recording/InputRecording.cpp.o: in function `InputRecording::SetStartingFrame(unsigned int)':
InputRecording.cpp:(.text+0x187d): undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: pcsx2/CMakeFiles/PCSX2.dir/Recording/InputRecording.cpp.o: in function `inputRec::log(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
InputRecording.cpp:(.text+0x198d): undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: pcsx2/CMakeFiles/PCSX2.dir/Recording/InputRecording.cpp.o: in function `InputRecording::Create(wxString, bool, wxString)':
InputRecording.cpp:(.text+0x253b): undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld.bfd: pcsx2/CMakeFiles/PCSX2.dir/Recording/InputRecording.cpp.o:InputRecording.cpp:(.text+0x2b7c): more undefined references to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)' follow
collect2: error: ld returned 1 exit status
```