### PR TITLE
pcsx2-gui: Internalize VirtualPad and Upgrade NewRecordingFrame

### DIFF
--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -18,12 +18,13 @@
 #ifndef DISABLE_RECORDING
 
 #include "Recording/InputRecordingFile.h"
-
+#include "Recording/VirtualPad/VirtualPad.h"
 
 class InputRecording
 {
 public:
-	InputRecording();
+	// Initializes all VirtualPad windows with "parent" as their base
+	void InitVirtualPadWindows(wxWindow* parent);
 
 	// Save or load PCSX2's global frame counter (g_FrameCount) along with each full/fast boot
 	//
@@ -82,13 +83,13 @@ public:
 	/// Functions called from GUI
 
 	// Create a new input recording file
-	bool Create(wxString filename, bool fromSaveState, wxString authorName);
+	bool Create(wxString filename, const bool fromSaveState, wxString authorName);
 	// Play an existing input recording from a file
 	bool Play(wxString filename);
 	// Stop the active input recording
 	void Stop();
-	// Initialze VirtualPad window
-	void setVirtualPadPtr(VirtualPad* ptr, int const port);
+// Displays the VirtualPad window for the chosen pad
+	void ShowVirtualPad(const int port);
 	// Logs the padData and redraws the virtualPad windows of active pads
 	void LogAndRedraw();
 	// Resets a recording if the base savestate could not be loaded at the start
@@ -121,11 +122,16 @@ private:
 	bool incrementUndo = false;
 	InputRecordingMode state = InputRecording::InputRecordingMode::NotActive;
 
-	// Controller Data
-	PadData* padData[2];
-
-	// VirtualPads
-	VirtualPad* virtualPads[2];
+	// Array of usable pads (currently, only 2)
+	struct InputRecordingPad
+	{
+		// Controller Data
+		PadData* padData;
+		// VirtualPad
+		VirtualPad* virtualPad;
+		InputRecordingPad();
+		~InputRecordingPad();
+	} pads[2];
 
 	// Resolve the name and region of the game currently loaded using the GameDB
 	// If the game cannot be found in the DB, the fallback is the ISO filename

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -130,26 +130,10 @@ bool InputRecordingFile::open(const wxString path, bool newRecording)
 
 bool InputRecordingFile::OpenNew(const wxString& path, bool fromSavestate)
 {
-	if (fromSavestate)
-	{
-		if (CoreThread.IsOpen())
-		{
-			if (open(path, true))
-			{
-				savestate.fromSavestate = true;
-				return true;
-			}
-		}
-		else
-			inputRec::consoleLog("Game is not open, aborting playing input recording which starts on a save-state.");
+	if (!open(path, true))
 		return false;
-	}
-	else if (open(path, true))
-	{
-		savestate.fromSavestate = false;
-		return true;
-	}
-	return false;
+	savestate.fromSavestate = fromSavestate;
+	return true;
 }
 
 bool InputRecordingFile::OpenExisting(const wxString& path)

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -128,7 +128,7 @@ bool InputRecordingFile::open(const wxString path, bool newRecording)
 	return false;
 }
 
-bool InputRecordingFile::OpenNew(const wxString path, bool fromSavestate)
+bool InputRecordingFile::OpenNew(const wxString& path, bool fromSavestate)
 {
 	if (fromSavestate)
 	{
@@ -152,7 +152,7 @@ bool InputRecordingFile::OpenNew(const wxString path, bool fromSavestate)
 	return false;
 }
 
-bool InputRecordingFile::OpenExisting(const wxString path)
+bool InputRecordingFile::OpenExisting(const wxString& path)
 {
 	return open(path, false);
 }

--- a/pcsx2/Recording/InputRecordingFile.h
+++ b/pcsx2/Recording/InputRecordingFile.h
@@ -69,10 +69,10 @@ public:
 	// Increment the number of undo actions and commit it to the recording file
 	void IncrementUndoCount();
 	// Open an existing recording file
-	bool OpenExisting(const wxString path);
+	bool OpenExisting(const wxString& path);
 	// Create and open a brand new input recording, either starting from a save-state or from
 	// booting the game
-	bool OpenNew(const wxString path, bool fromSaveState);
+	bool OpenNew(const wxString& path, bool fromSaveState);
 	// Reads the current frame's input data from the file in order to intercept and overwrite
 	// the current frame's value from the emulator
 	bool ReadKeyBuffer(u8 &result, const uint &frame, const uint port, const uint bufIndex);

--- a/pcsx2/Recording/NewRecordingFrame.h
+++ b/pcsx2/Recording/NewRecordingFrame.h
@@ -32,14 +32,21 @@ class NewRecordingFrame : public wxDialog
 {
 public:
 	NewRecordingFrame(wxWindow* parent);
+	int ShowModal(const bool isCoreThreadOpen);
 
 	wxString GetFile() const;
 	wxString GetAuthor() const;
 	int GetFrom() const;
 
+protected:
+	void OnFileDirChange(wxFileDirPickerEvent& event);
+	void OnFileChanged(wxFileDirPickerEvent& event);
+	void EnableOkBox();
+
 private:
 	wxStaticText* m_fileLabel;
 	wxFilePickerCtrl* m_filePicker;
+	bool m_fileBrowsed;
 	wxStaticText* m_authorLabel;
 	wxTextCtrl* m_authorInput;
 	wxStaticText* m_fromLabel;

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -29,8 +29,7 @@
 #include "DriveList.h"
 
 #ifndef DISABLE_RECORDING
-#	include "Recording/VirtualPad/VirtualPad.h"
-#	include "Recording/NewRecordingFrame.h"
+#include "Recording/NewRecordingFrame.h"
 #endif
 
 class DisassemblyDialog;
@@ -551,7 +550,6 @@ protected:
 	wxWindowID			m_id_Disassembler;
 
 #ifndef DISABLE_RECORDING
-	wxWindowID			m_id_VirtualPad[2];
 	wxWindowID			m_id_NewRecordingFrame;
 #endif
 
@@ -580,7 +578,6 @@ public:
 	DisassemblyDialog*	GetDisassemblyPtr() const	{ return (DisassemblyDialog*)wxWindow::FindWindowById(m_id_Disassembler); }
 
 #ifndef DISABLE_RECORDING
-	VirtualPad*			GetVirtualPadPtr(int port) const	{ return (VirtualPad*)wxWindow::FindWindowById(m_id_VirtualPad[port]); }
 	NewRecordingFrame*	GetNewRecordingFramePtr() const		{ return (NewRecordingFrame*)wxWindow::FindWindowById(m_id_NewRecordingFrame); }
 #endif
 

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -28,7 +28,6 @@
 
 #ifndef DISABLE_RECORDING
 #include "Recording/InputRecording.h"
-#include "Recording/VirtualPad/VirtualPad.h"
 #endif
 
 #include <wx/cmdline.h>
@@ -80,16 +79,10 @@ void Pcsx2App::OpenMainFrame()
 	m_id_Disassembler = disassembly->GetId();
 
 #ifndef DISABLE_RECORDING
-	VirtualPad* virtualPad0 = new VirtualPad(mainFrame, 0, g_Conf->inputRecording);
-	g_InputRecording.setVirtualPadPtr(virtualPad0, 0);
-	m_id_VirtualPad[0] = virtualPad0->GetId();
-
-	VirtualPad* virtualPad1 = new VirtualPad(mainFrame, 1, g_Conf->inputRecording);
-	g_InputRecording.setVirtualPadPtr(virtualPad1, 1);
-	m_id_VirtualPad[1] = virtualPad1->GetId();
-
 	NewRecordingFrame* newRecordingFrame = new NewRecordingFrame(mainFrame);
 	m_id_NewRecordingFrame = newRecordingFrame->GetId();
+	if (g_Conf->EmuOptions.EnableRecordingTools)
+		g_InputRecording.InitVirtualPadWindows(mainFrame);
 #endif
 
 	if (g_Conf->EmuOptions.Debugger.ShowDebuggerOnStart)

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1025,7 +1025,11 @@ void Pcsx2App::OpenGsPanel()
 	gsFrame->ShowFullScreen( g_Conf->GSWindow.IsFullscreen );
 
 #ifndef DISABLE_RECORDING
-	// Disable recording controls that only make sense if the game is running
+	// Enable New & Play after the first game load of the session
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_New, !g_InputRecording.IsActive());
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_Play, true);
+
+	// Enable recording menu options as the game is now running
 	sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, true);
 	sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, true);
 	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, g_InputRecording.IsActive());

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -486,9 +486,9 @@ void MainEmuFrame::CreateCaptureMenu()
 void MainEmuFrame::CreateRecordMenu()
 {
 #ifndef DISABLE_RECORDING
-	m_menuRecording.Append(MenuId_Recording_New, _("New"), _("Create a new input recording."));
+	m_menuRecording.Append(MenuId_Recording_New, _("New"), _("Create a new input recording."))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_Stop, _("Stop"), _("Stop the active input recording."))->Enable(false);
-	m_menuRecording.Append(MenuId_Recording_Play, _("Play"), _("Playback an existing input recording."));
+	m_menuRecording.Append(MenuId_Recording_Play, _("Play"), _("Playback an existing input recording."))->Enable(false);
 	m_menuRecording.AppendSeparator();
 	m_menuRecording.Append(MenuId_Recording_TogglePause, _("Toggle Pause"), _("Pause or resume emulation on the fly."))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_FrameAdvance, _("Frame Advance"), _("Advance emulation forward by a single frame at a time."))->Enable(false);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -956,9 +956,9 @@ void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 	NewRecordingFrame* newRecordingFrame = wxGetApp().GetNewRecordingFramePtr();
 	if (newRecordingFrame)
 	{
-		if (newRecordingFrame->ShowModal() != wxID_CANCEL)
+		if (newRecordingFrame->ShowModal(CoreThread.IsOpen()) != wxID_CANCEL)
 		{
-			if (g_InputRecording.Create(newRecordingFrame->GetFile(), !newRecordingFrame->GetFrom(), newRecordingFrame->GetAuthor()))
+			if (g_InputRecording.Create(newRecordingFrame->GetFile(), newRecordingFrame->GetFrom(), newRecordingFrame->GetAuthor()))
 			{
 				if (!g_InputRecording.GetInputRecordingData().FromSaveState())
 					StartInputRecording();

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -599,6 +599,7 @@ void MainEmuFrame::Menu_EnableRecordingTools_Click(wxCommandEvent& event)
 	if (checked)
 	{
 		GetMenuBar()->Insert(TopLevelMenu_InputRecording, &m_menuRecording, _("&Input Record"));
+		g_InputRecording.InitVirtualPadWindows(this);
 		SysConsole.recordingConsole.Enabled = true;
 		// Enable Recording Keybindings
 		if (GSFrame* gsFrame = wxGetApp().GetGsFramePtr())
@@ -948,8 +949,10 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent &e
 void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 {
 	const bool initiallyPaused = g_InputRecordingControls.IsPaused();
+
 	if (!initiallyPaused)
 		g_InputRecordingControls.PauseImmediately();
+
 	NewRecordingFrame* newRecordingFrame = wxGetApp().GetNewRecordingFramePtr();
 	if (newRecordingFrame)
 	{
@@ -971,8 +974,10 @@ void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent& event)
 {
 	const bool initiallyPaused = g_InputRecordingControls.IsPaused();
+
 	if (!initiallyPaused)
 		g_InputRecordingControls.PauseImmediately();
+
 	wxFileDialog openFileDialog(this, _("Select P2M2 record file."), L"", L"",
 								L"p2m2 file(*.p2m2)|*.p2m2", wxFD_OPEN);
 	if (openFileDialog.ShowModal() == wxID_CANCEL)
@@ -989,6 +994,7 @@ void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent& event)
 			g_InputRecordingControls.Resume();
 		return;
 	}
+	
 	if (!g_InputRecording.GetInputRecordingData().FromSaveState())
 		StartInputRecording();
 }
@@ -1036,6 +1042,6 @@ void MainEmuFrame::Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent& even
 
 void MainEmuFrame::Menu_Recording_VirtualPad_Open_Click(wxCommandEvent& event)
 {
-	wxGetApp().GetVirtualPadPtr(event.GetId() - MenuId_Recording_VirtualPad_Port0)->Show();
+	g_InputRecording.ShowVirtualPad(event.GetId() - MenuId_Recording_VirtualPad_Port0);
 }
 #endif


### PR DESCRIPTION
Simplifies virtualPad access by solely holding the virtualPad window pointers in the g_inputRecording object. This will be useful later down the line when more virtualPads are added.

NewRecordingFrame has improved functionality:
* Users can now only choose to create a savestate-based recording if GS is open.
* Forced file browsing in certain situations.

Also, forces a game to have been loaded before being allowed to mess with input recordings.