### PR TITLE
GameDB: Patch for Ecco the Dolphin PAL

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -1420,6 +1420,15 @@ Serial = SCES-50499
 Name   = Ecco the Dolphin - Defender of the Future
 Region = PAL-M5
 Compat = 2
+[patches = 7FEDF999]
+	author=PSI
+	// Ecco has an evil race condition: one of its custom IOP modules resets CDVDMAN while it's loading a module from disc.
+	// The race condition is resolved by making the EE slower. This gives enough time for CDVDMAN to reset itself before
+	// the EE sends a request to load a module.
+	// Alternatively, this patch swaps the load order of the modules.
+	patch=1,EE,201018d8,extended,24040007
+	patch=1,EE,201018e4,extended,24040006
+[/patches]
 ---------------------------------------------
 Serial = SCES-50500
 Name   = Headhunter


### PR DESCRIPTION
PSI patch ported to PAL version (PAL use the same offset). 
There is not much that can be done from pcsx2 code side without EE/DMA cycle accuracy, so... fixes #1743