### PR TITLE
counters: account for vertical frequency differences in non-interlaced anolog modes

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -278,18 +278,36 @@ const char* ReportVideoMode()
 
 Fixed100 GetVerticalFrequency()
 {
+	// Note about NTSC/PAL "double strike" modes:
+	// NTSC and PAL can be configured in such a way to produce a non-interlaced signal.
+	// This involves modifying the signal slightly by either adding or subtracting a line (526/524 instead of 525)
+	// which has the function of causing the odd and even fields to strike the same lines.
+	// Doing this modifies the vertical refresh rate slightly. Beatmania is sensitive to this and
+	// not accounting for it will cause the audio and video to become desynced.
+	//
+	// In the case of the GS, I believe it adds a halfline to the vertical back porch but more research is needed.
+	// For now I'm just going to subtract off the config setting.
+	//
+	// According to the GS:
+	// NTSC (interlaced): 59.94
+	// NTSC (non-interlaced): 59.82
+	// PAL (interlaced): 50.00
+	// PAL (non-interlaced): 49.76
+	//
+	// More Information:
+	// https://web.archive.org/web/20201031235528/https://wiki.nesdev.com/w/index.php/NTSC_video
+	// https://web.archive.org/web/20201102100937/http://forums.nesdev.com/viewtopic.php?t=7909
+	// https://web.archive.org/web/20120629231826fw_/http://ntsc-tv.com/index.html
+	// https://web.archive.org/web/20200831051302/https://www.hdretrovision.com/240p/
 	switch (gsVideoMode)
 	{
 	case GS_VideoMode::Uninitialized: // SetGsCrt hasn't executed yet, give some temporary values.
 		return 60;
 	case GS_VideoMode::PAL:
 	case GS_VideoMode::DVD_PAL:
-		return EmuConfig.GS.FrameratePAL;
+		return gsIsInterlaced ? EmuConfig.GS.FrameratePAL : EmuConfig.GS.FrameratePAL - 0.24f;
 	case GS_VideoMode::NTSC:
 	case GS_VideoMode::DVD_NTSC:
-		// TODO: beatmania appears to use a strange NTSC mode setting with interlace disabled
-		// As far as I know this isn't a valid setting, but hw tests confirm this drops the
-		// framerate slightly which allows the audio to sync back up.
 		return gsIsInterlaced ? EmuConfig.GS.FramerateNTSC : EmuConfig.GS.FramerateNTSC - 0.11f;
 	case GS_VideoMode::SDTV_480P:
 		return 59.94;

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -287,7 +287,10 @@ Fixed100 GetVerticalFrequency()
 		return EmuConfig.GS.FrameratePAL;
 	case GS_VideoMode::NTSC:
 	case GS_VideoMode::DVD_NTSC:
-		return EmuConfig.GS.FramerateNTSC;
+		// TODO: beatmania appears to use a strange NTSC mode setting with interlace disabled
+		// As far as I know this isn't a valid setting, but hw tests confirm this drops the
+		// framerate slightly which allows the audio to sync back up.
+		return gsIsInterlaced ? EmuConfig.GS.FramerateNTSC : EmuConfig.GS.FramerateNTSC - 0.11f;
 	case GS_VideoMode::SDTV_480P:
 		return 59.94;
 	case GS_VideoMode::HDTV_1080P:

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -36,9 +36,6 @@ void gsOnModeChanged( Fixed100 framerate, u32 newTickrate )
 
 void gsSetVideoMode(GS_VideoMode mode )
 {
-	if( gsVideoMode == mode )
-		return;
-
 	gsVideoMode = mode;
 	UpdateVSyncRate();
 }


### PR DESCRIPTION
timing adjustments for double strike analog modes
fixes #450