### PR TITLE
Debugger: Remove delay slot for ERET and SYSCALL opcodes

### DIFF
--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -755,7 +755,12 @@ inline bool isBranchOrJump(u32 addr)
 {
 	u32 op = memRead32(addr);
 	const OPCODE& opcode = GetInstruction(op);
-
+	
+	// Return false for eret & syscall as they are branch type in pcsx2 debugging tools,
+	// but shouldn't have delay slot in isBreakpointNeeded/isMemcheckNeeded.
+	if ((opcode.flags == (IS_BRANCH | BRANCHTYPE_SYSCALL)) || (opcode.flags == (IS_BRANCH | BRANCHTYPE_ERET)))
+		return false;
+		
 	return (opcode.flags & IS_BRANCH) != 0;
 }
 


### PR DESCRIPTION
Workaround for delay slot for ERET, and SYSCALL opcodes in isBreakpointNeeded/isMemcheckNeeded. Currently pcsx2 debugger treat next instruction as a delay slot, which is wrong behavior. 

Before: 
![ab8](https://user-images.githubusercontent.com/15552250/97114176-3826e500-16ef-11eb-8196-64a0b2771e66.jpg)

After:
![ab8 — kopia](https://user-images.githubusercontent.com/15552250/97114183-4248e380-16ef-11eb-800e-64394ea80254.jpg)
