### PR TITLE
gsdx-hw: Clean up blending code a bit.

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -309,29 +309,27 @@ public:
 		{
 			struct
 			{
-				uint32 abe:1;
-				uint32 a:2;
-				uint32 b:2;
-				uint32 c:2;
-				uint32 d:2;
+				// Color mask
 				uint32 wr:1;
 				uint32 wg:1;
 				uint32 wb:1;
 				uint32 wa:1;
+				// Alpha blending
+				uint32 blend_index:7;
+				uint32 abe:1;
 				uint32 accu_blend:1;
 			};
 
 			struct
 			{
-				uint32 _pad:1;
-				uint32 abcd:8;
+				// Color mask
 				uint32 wrgba:4;
 			};
 
 			uint32 key;
 		};
 
-		operator uint32() {return key & 0x3fff;}
+		operator uint32() {return key & 0x1fff;}
 
 		OMBlendSelector() : key(0) {}
 	};

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -505,29 +505,22 @@ void GSRendererDX11::EmulateBlending()
 		return;
 
 	m_om_bsel.abe = 1;
-	m_om_bsel.a = ALPHA.A;
-	m_om_bsel.b = ALPHA.B;
-	m_om_bsel.c = ALPHA.C;
-	m_om_bsel.d = ALPHA.D;
 
 	if (m_env.PABE.PABE)
 	{
-		if (m_om_bsel.a == 0 && m_om_bsel.b == 1 && m_om_bsel.c == 0 && m_om_bsel.d == 1)
+		if (ALPHA.A == 0 && ALPHA.B == 1 && ALPHA.C == 0 && ALPHA.D == 1)
 		{
 			// this works because with PABE alpha blending is on when alpha >= 0x80, but since the pixel shader
 			// cannot output anything over 0x80 (== 1.0) blending with 0x80 or turning it off gives the same result
 
 			m_om_bsel.abe = 0;
 		}
-		else
-		{
-			// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars.
-			//ASSERT(0);
-		}
+
+		// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars.
 	}
 
-	const uint8 blend_index  = uint8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
-	const int blend_flag = m_dev->GetBlendFlags(blend_index);
+	m_om_bsel.blend_index = uint8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
+	const int blend_flag = m_dev->GetBlendFlags(m_om_bsel.blend_index);
 
 	// Do the multiplication in shader for blending accumulation: Cs*As + Cd or Cs*Af + Cd
 	const bool accumulation_blend = !!(blend_flag & BLEND_ACCU);

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -534,7 +534,7 @@ void GSRendererDX11::EmulateBlending()
 		case ACC_BLEND_MEDIUM_D3D11:
 		case ACC_BLEND_BASIC_D3D11:
 			sw_blending |= accumulation_blend || blend_non_recursive;
-			// fall through
+			[[fallthrough]];
 		default: break;
 	}
 

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -351,9 +351,7 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 
 		if(bsel.abe)
 		{
-			int i = ((bsel.a * 3 + bsel.b) * 3 + bsel.c) * 3 + bsel.d;
-
-			HWBlend blend = GetBlend(i);
+			HWBlend blend = GetBlend(bsel.blend_index);
 			bd.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
 			bd.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;
 			bd.RenderTarget[0].DestBlend = (D3D11_BLEND)blend.dst;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -493,23 +493,23 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 	switch (m_sw_blending) {
 		case ACC_BLEND_ULTRA:
 			sw_blending |= true;
-			// fall through
+			[[fallthrough]];
 		case ACC_BLEND_FULL:
 			if (!m_vt.m_alpha.valid && (ALPHA.C == 0)) GetAlphaMinMax();
 			sw_blending |= (ALPHA.A != ALPHA.B) && ((ALPHA.C == 0 && m_vt.m_alpha.max > 128) || (ALPHA.C == 2 && ALPHA.FIX > 128u));
-			// fall through
+			[[fallthrough]];
 		case ACC_BLEND_HIGH:
 			sw_blending |= (ALPHA.C == 1);
-			// fall through
+			[[fallthrough]];
 		case ACC_BLEND_MEDIUM:
 			// Initial idea was to enable accurate blending for sprite rendering to handle
 			// correctly post-processing effect. Some games (ZoE) use tons of sprites as particles.
 			// In order to keep it fast, let's limit it to smaller draw call.
 			sw_blending |= m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 100;
-			// fall through
+			[[fallthrough]];
 		case ACC_BLEND_BASIC:
 			sw_blending |= impossible_or_free_blend;
-			// fall through
+			[[fallthrough]];
 		default:
 			/*sw_blending |= accumulation_blend*/;
 	}


### PR DESCRIPTION
d3d11: Directly calculate blend index in rendererdx11, and send the value to
SetupOM. Get rid of duplicate calculation and abcd variables.
Code is cleaner this way.

hw: EmulateBlending -> add [[fallthrough]] attribute to switch cases.