### PR TITLE
CDVD: Adjust read speed depending on if in inner/outer edge

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -38152,7 +38152,6 @@ Serial = SLUS-20217
 Name   = Arctic Thunder
 Region = NTSC-U
 Compat = 5
-SkipMPEGHack = 1
 ---------------------------------------------
 Serial = SLUS-20218
 Name   = Stunt GP

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -600,7 +600,35 @@ static s32 cdvdReadDvdDualInfo(s32* dualType, u32* layer1Start)
 
 static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode)
 {
-	return (PSXCLK * cdvd.BlockSize) / (((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed);
+	int numSectors = 0;
+	int offset = 0;
+	// Sector counts are taken from google for Single layer, Dual layer DVD's and for 700MB CD's
+	switch (cdvd.Type)
+	{
+		case CDVD_TYPE_DETCTDVDS:
+		case CDVD_TYPE_PS2DVD:
+			numSectors = 2298496;
+			break;
+		case CDVD_TYPE_DETCTDVDD:
+			numSectors = 4173824 / 2; // Total sectors for both layers, assume half per layer
+			u32 layer1Start;
+			s32 dualType;
+
+			// Layer 1 needs an offset as it goes back to the middle of the disc
+			cdvdReadDvdDualInfo(&dualType, &layer1Start);
+			if (cdvd.Sector >= layer1Start)
+				offset = layer1Start;
+			break;
+		default: // Pretty much every CD format
+			numSectors = 360000;
+			break;
+	}
+	// Read speed is roughly 37% at lowest and full speed on outer edge. I imagine it's more logarithmic than this
+	// Required for Shadowman to work
+	// Use SeekToSector as Sector hasn't been updated yet
+	const float sectorSpeed = (((float)(cdvd.SeekToSector-offset) / numSectors) * 0.63f) + 0.37f; 
+	//DevCon.Warning("Read speed %f sector %d\n", sectorSpeed, cdvd.Sector);
+	return ((PSXCLK * cdvd.BlockSize) / ((float)(((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed) * sectorSpeed));
 }
 
 void cdvdReset()

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -123,13 +123,8 @@ static const uint tbl_ContigiousSeekDelta[3] =
 // concerned with accurate(ish) seek delays and less concerned with actual block read speeds.
 // Translation: it's a minor speedhack :D
 
-//Fixme ( voodoocycles ):
-//The current CD mode gives a too low transfer rate. HDloader reports 900kb/s, while the theoretical max is 3600kb/s
-//Silent Hill 2 videos starve of data and stall.
-//So let's double that until the cause of the slow data rate is known.
-
-static const uint PSX_CD_READSPEED = 153600 * 2;        // 1 Byte Time @ x1 (150KB = cd x 1)
-static const uint PSX_DVD_READSPEED = 1382400 + 256000; // normal is 1 Byte Time @ x1 (1350KB = dvd x 1).
+static const uint PSX_CD_READSPEED = 153600;   // 1 Byte Time @ x1 (150KB = cd x 1)
+static const uint PSX_DVD_READSPEED = 1382400; // 1 Byte Time @ x1 (1350KB = dvd x 1).
 
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".


### PR DESCRIPTION
Fixes Shadowman 2 Second Coming textures
Fixes Arctic Thunder loading problems
Fixes looping music on ONI title screen and skipping dialogues
Fixes Klonoa 2 missing audio
Fixes SPS at the beginning of matches in Next Generation Tennis 2003 (Ronald Garros) - This one surprised me too

Original comments mentioned Silent Hill 2 being starved during videos, but seems fine to me, but if somebody could test further in to the game, that'd be great.

Edit: It does cause the second video (and later ones) to hang, however this isn't being starved of data, I can run the CDVD at 0.3x the normal speed and it works, so there's some sort of annoying timing issue going on.  Can be gotten around by setting the EE cycle rate to -1 or enabling the Fast CDVD speedhack

Edit 2: Okay Silent Hill 2 seems to be working when using this PR mixed with #3998 as long as MTVU and Instant VU1 are disabled (the game doesn't need MTVU anyway)

Also please check dual layer games, I couldn't really test any that use the second layer so I'm less confident that code is great.

Fixes #64
Fixes #2385 without needing Skipmpeg