### PR TITLE
Don't call DEV9open if isSuspendedthread is false in OnResumeThread()

### DIFF
--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -316,7 +316,8 @@ void SysCoreThread::OnResumeInThread(bool isSuspended)
 		DoCDVDopen();
 	FWopen();
 	SPU2open((void*)pDsp);
-	DEV9open((void*)pDsp);
+	if (isSuspended)
+		DEV9open((void*)pDsp);
 }
 
 

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -303,21 +303,22 @@ void SysCoreThread::ExecuteTaskInThread()
 void SysCoreThread::OnSuspendInThread()
 {
 	GetCorePlugins().Close();
-	DEV9close();
 	DoCDVDclose();
 	FWclose();
 	SPU2close();
+	DEV9close();
 }
 
 void SysCoreThread::OnResumeInThread(bool isSuspended)
 {
 	GetCorePlugins().Open();
 	if (isSuspended)
+	{
 		DoCDVDopen();
+		DEV9open((void*)pDsp);
+	}
 	FWopen();
 	SPU2open((void*)pDsp);
-	if (isSuspended)
-		DEV9open((void*)pDsp);
 }
 
 


### PR DESCRIPTION
During emulation, if you open a plug-in's config menu (such as changing lilypad's settings) OnSuspendInThread is not called, meaning DEV9close is not called, meaning DEV9's RxThread is still running

When the plug-in's config menu is closed, OnResumeInThread() is called with isSuspended set false

Before, we would always call DEV9open(), which would create a new RxThread without stopping the old thread (as the code never expected DEV9open to be called more than once without a DEV9close)

Now we check isSuspendedthread before calling DEV9open, preventing the above situation