### PR TITLE
misc: Replace Fall through comments with c++17 attribute.

### DIFF
--- a/pcsx2/COP0.cpp
+++ b/pcsx2/COP0.cpp
@@ -451,6 +451,7 @@ void MFC0()
 			s_iLastCOP0Cycle = cpuRegs.cycle;
 			if( !_Rt_ ) break;
 		}
+			[[fallthrough]];
 
 		default:
 			cpuRegs.GPR.r[_Rt_].UD[0] = (s64)cpuRegs.CP0.r[_Rd_];

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -461,6 +461,7 @@ static __fi bool ipuVDEC(u32 val)
 			// This is due to differences with IPU and the MPEG standard. See get_macroblock_address_increment().
 
 			ipuRegs.ctrl.ECD = (ipuRegs.cmd.DATA == 0);
+			[[fallthrough]];
 
 		case 1:
 			if (!getBits32((u8*)&ipuRegs.top, 0))

--- a/pcsx2/IPU/mpeg2lib/Mpeg.cpp
+++ b/pcsx2/IPU/mpeg2lib/Mpeg.cpp
@@ -255,7 +255,7 @@ int get_macroblock_address_increment()
 				DUMPBITS(11);
 				return 0xb0022;
 			}
-			// Fall through
+			[[fallthrough]];
 
 		default:
 			return 0;//error
@@ -435,7 +435,7 @@ static bool get_intra_block()
 			ipu_cmd.pos[4] = 0;
 			return true;
 		}
-		// Fall through
+		[[fallthrough]];
 
 	  case 1:
 	  {
@@ -588,7 +588,7 @@ static bool get_non_intra_block(int * last)
 				ipu_cmd.pos[4] = 0;
 				return true;
 			}
-			// Fall through
+			[[fallthrough]];
 
 		case 1:
 			if (!GETWORD())
@@ -707,7 +707,7 @@ __fi bool mpeg2sliceIDEC()
 
 		ipuRegs.top = 0;
 		ipuRegs.ctrl.ECD = 0;
-		// Fall through
+		[[fallthrough]];
 
 	case 1:
 		ipu_cmd.pos[0] = 1;
@@ -715,7 +715,7 @@ __fi bool mpeg2sliceIDEC()
 		{
 			return false;
 		}
-		// Fall through
+		[[fallthrough]];
 
 	case 2:
 		ipu_cmd.pos[0] = 2;
@@ -741,7 +741,7 @@ __fi bool mpeg2sliceIDEC()
 				decoder.coded_block_pattern = 0x3F;//all 6 blocks
 				memzero_sse_a(mb8);
 				memzero_sse_a(rgb32);
-				// Fall through
+				[[fallthrough]];
 
 			case 1:
 				ipu_cmd.pos[1] = 1;
@@ -766,7 +766,7 @@ __fi bool mpeg2sliceIDEC()
 						ipu_cmd.pos[2] = 1;
 						return false;
 					}
-					// Fall through
+					[[fallthrough]];
 
 				case 2:
 					if (!slice_intra_DCT(0, (u8*)mb8.Y + 8, DCT_stride, ipu_cmd.pos[2] == 2))
@@ -774,7 +774,7 @@ __fi bool mpeg2sliceIDEC()
 						ipu_cmd.pos[2] = 2;
 						return false;
 					}
-					// Fall through
+					[[fallthrough]];
 
 				case 3:
 					if (!slice_intra_DCT(0, (u8*)mb8.Y + DCT_offset, DCT_stride, ipu_cmd.pos[2] == 3))
@@ -782,7 +782,7 @@ __fi bool mpeg2sliceIDEC()
 						ipu_cmd.pos[2] = 3;
 						return false;
 					}
-					// Fall through
+					[[fallthrough]];
 
 				case 4:
 					if (!slice_intra_DCT(0, (u8*)mb8.Y + DCT_offset + 8, DCT_stride, ipu_cmd.pos[2] == 4))
@@ -790,7 +790,7 @@ __fi bool mpeg2sliceIDEC()
 						ipu_cmd.pos[2] = 4;
 						return false;
 					}
-					// Fall through
+					[[fallthrough]];
 
 				case 5:
 					if (!slice_intra_DCT(1, (u8*)mb8.Cb, decoder_stride >> 1, ipu_cmd.pos[2] == 5))
@@ -798,7 +798,7 @@ __fi bool mpeg2sliceIDEC()
 						ipu_cmd.pos[2] = 5;
 						return false;
 					}
-					// Fall through
+					[[fallthrough]];
 
 				case 6:
 					if (!slice_intra_DCT(2, (u8*)mb8.Cr, decoder_stride >> 1, ipu_cmd.pos[2] == 6))
@@ -821,7 +821,7 @@ __fi bool mpeg2sliceIDEC()
 					ipu_dither(rgb32, rgb16, decoder.dte);
 					decoder.SetOutputTo(rgb16);
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 2:
 			{
@@ -839,7 +839,7 @@ __fi bool mpeg2sliceIDEC()
 
 				mbaCount = 0;
 			}
-			// Fall through
+				[[fallthrough]];
 
 			case 3:
 				while (1)
@@ -865,7 +865,7 @@ __fi bool mpeg2sliceIDEC()
 					{
 						case 8:		/* macroblock_escape */
 							mbaCount += 33;
-							// Fall through
+							[[fallthrough]];
 
 						case 15:	/* macroblock_stuffing (MPEG1 only) */
 							DUMPBITS(11);
@@ -887,7 +887,7 @@ __fi bool mpeg2sliceIDEC()
 					decoder.dc_dct_pred[1] =
 					decoder.dc_dct_pred[2] = 128 << decoder.intra_dc_precision;
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 4:
 				if (!GETWORD())
@@ -903,11 +903,10 @@ __fi bool mpeg2sliceIDEC()
 			ipu_cmd.pos[1] = 0;
 			ipu_cmd.pos[2] = 0;
 		}
-		// Fall through
 
 finish_idec:
 		finishmpeg2sliceIDEC();
-		// Fall through
+		[[fallthrough]];
 
 	case 3:
 	{
@@ -924,7 +923,7 @@ finish_idec:
 			ipuRegs.ctrl.SCD = 1;
 		}
 	}
-	// Fall through
+		[[fallthrough]];
 
 	case 4:
 		if (!getBits32((u8*)&ipuRegs.top, 0))
@@ -963,7 +962,7 @@ __fi bool mpeg2_slice()
 		ipuRegs.top = 0;
 		memzero_sse_a(mb8);
 		memzero_sse_a(mb16);
-		// Fall through 
+		[[fallthrough]];
 
 	case 1:
 		if (!bitstream_init())
@@ -971,7 +970,7 @@ __fi bool mpeg2_slice()
 			ipu_cmd.pos[0] = 1;
 			return false;
 		}
-		// Fall through
+		[[fallthrough]];
 
 	case 2:
 		ipu_cmd.pos[0] = 2;
@@ -993,7 +992,7 @@ __fi bool mpeg2_slice()
 			{
 			case 0:
 				decoder.coded_block_pattern = 0x3F;
-				// Fall through
+				[[fallthrough]];
 
 			case 1:
 				if (!slice_intra_DCT(0, (u8*)mb8.Y, DCT_stride, ipu_cmd.pos[1] == 1))
@@ -1001,7 +1000,7 @@ __fi bool mpeg2_slice()
 					ipu_cmd.pos[1] = 1;
 					return false;
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 2:
 				if (!slice_intra_DCT(0, (u8*)mb8.Y + 8, DCT_stride, ipu_cmd.pos[1] == 2))
@@ -1009,7 +1008,7 @@ __fi bool mpeg2_slice()
 					ipu_cmd.pos[1] = 2;
 					return false;
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 3:
 				if (!slice_intra_DCT(0, (u8*)mb8.Y + DCT_offset, DCT_stride, ipu_cmd.pos[1] == 3))
@@ -1017,7 +1016,7 @@ __fi bool mpeg2_slice()
 					ipu_cmd.pos[1] = 3;
 					return false;
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 4:
 				if (!slice_intra_DCT(0, (u8*)mb8.Y + DCT_offset + 8, DCT_stride, ipu_cmd.pos[1] == 4))
@@ -1025,7 +1024,7 @@ __fi bool mpeg2_slice()
 					ipu_cmd.pos[1] = 4;
 					return false;
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 5:
 				if (!slice_intra_DCT(1, (u8*)mb8.Cb, decoder_stride >> 1, ipu_cmd.pos[1] == 5))
@@ -1033,7 +1032,7 @@ __fi bool mpeg2_slice()
 					ipu_cmd.pos[1] = 5;
 					return false;
 				}
-				// Fall through
+				[[fallthrough]];
 
 			case 6:
 				if (!slice_intra_DCT(2, (u8*)mb8.Cr, decoder_stride >> 1, ipu_cmd.pos[1] == 6))
@@ -1080,7 +1079,7 @@ __fi bool mpeg2_slice()
 				{
 				case 0:
 					decoder.coded_block_pattern = get_coded_block_pattern();  // max 9bits
-					// Fall through
+					[[fallthrough]];
 
 				case 1:
 					if (decoder.coded_block_pattern & 0x20)
@@ -1091,7 +1090,7 @@ __fi bool mpeg2_slice()
 							return false;
 						}
 					}
-					// Fall through
+					[[fallthrough]];
 
 				case 2:
 					if (decoder.coded_block_pattern & 0x10)
@@ -1102,8 +1101,8 @@ __fi bool mpeg2_slice()
 							return false;
 						}
 					}
-					// Fall through
-					
+					[[fallthrough]];
+
 				case 3:
 					if (decoder.coded_block_pattern & 0x08)
 					{
@@ -1113,8 +1112,8 @@ __fi bool mpeg2_slice()
 							return false;
 						}
 					}
-					// Fall through
-					
+					[[fallthrough]];
+
 				case 4:
 					if (decoder.coded_block_pattern & 0x04)
 					{
@@ -1124,8 +1123,8 @@ __fi bool mpeg2_slice()
 							return false;
 						}
 					}
-					// Fall through
-					
+					[[fallthrough]];
+
 				case 5:
 					if (decoder.coded_block_pattern & 0x2)
 					{
@@ -1135,8 +1134,8 @@ __fi bool mpeg2_slice()
 							return false;
 						}
 					}
-					// Fall through
-					
+					[[fallthrough]];
+
 				case 6:
 					if (decoder.coded_block_pattern & 0x1)
 					{
@@ -1158,7 +1157,7 @@ __fi bool mpeg2_slice()
 		coded_block_pattern = decoder.coded_block_pattern;
 
 		decoder.SetOutputTo(mb16);
-		// Fall through
+		[[fallthrough]];
 
 	case 3:
 	{
@@ -1176,8 +1175,8 @@ __fi bool mpeg2_slice()
 
 		mbaCount = 0;
 	}
-	// Fall through
-	
+		[[fallthrough]];
+
 	case 4:
 	{
 		u8 bit8;
@@ -1193,8 +1192,8 @@ __fi bool mpeg2_slice()
 			ipuRegs.ctrl.SCD = 1;
 		}
 	}
-	// Fall through
-	
+		[[fallthrough]];
+
 	case 5:
 		if (!getBits32((u8*)&ipuRegs.top, 0))
 		{

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -440,6 +440,7 @@ SIO_WRITE memcardWrite(u8 data)
 					once = false;
 					break;
 				}
+				[[fallthrough]];
 
 			default:
 				DevCon.Warning("%s cmd: %02X??", __FUNCTION__, data);
@@ -530,6 +531,7 @@ SIO_WRITE memcardRead(u8 data)
 					once = false;
 					break;
 				}
+				[[fallthrough]];
 
 			default:
 				DevCon.Warning("%s cmd: %02X??", __FUNCTION__, data);
@@ -713,7 +715,7 @@ SIO_WRITE sioWriteMemcard(u8 data)
 		case 0x11: // On Boot/Probe
 		case 0x12: // On Write/Delete/Recheck?
 			sio2.packet.recvVal3 = 0x8C;
-			// Fall through
+			[[fallthrough]];
 
 		case 0x81: // Checked right after copy/delete
 		case 0xBF: // Wtf?? On game booting?

--- a/pcsx2/System/SysThreadBase.cpp
+++ b/pcsx2/System/SysThreadBase.cpp
@@ -305,7 +305,7 @@ bool SysThreadBase::StateCheckInThread()
 			m_ExecMode = ExecMode_Paused;
 			m_RunningLock.Release();
 		}
-		// fallthrough...
+			[[fallthrough]];
 
 		case ExecMode_Paused:
 			while( m_ExecMode == ExecMode_Paused )
@@ -320,8 +320,9 @@ bool SysThreadBase::StateCheckInThread()
 			}
 			m_sem_ChangingExecMode.Post();
 			
+			[[fallthrough]];
+		
 		// fallthrough if we're switching to closing state...
-
 		// -------------------------------------
 		case ExecMode_Closing:
 		{
@@ -329,7 +330,7 @@ bool SysThreadBase::StateCheckInThread()
 			m_ExecMode = ExecMode_Closed;
 			m_RunningLock.Release();
 		}
-		// Fall through
+			[[fallthrough]];
 
 		case ExecMode_Closed:
 			while( m_ExecMode == ExecMode_Closed )

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -348,7 +348,8 @@ void vifMFIFOInterrupt()
 			case 0: //Set up transfer
 				mfifoVIF1transfer();
 				vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
-				
+				[[fallthrough]];
+
 			case 1: //Transfer data
 				if(vif1.inprogress & 0x1) //Just in case the tag breaks early (or something wierd happens)!
 					mfifo_VIF1chain();

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -491,10 +491,17 @@ template<int idx> static __fi int _vifCode_STColRow(const u32* data, u32* pmem2)
 	pxAssume(ret > 0);
 
 	switch (ret) {
-		case 4: pmem2[3] = data[3]; // Fall through
-		case 3: pmem2[2] = data[2]; // Fall through
-		case 2: pmem2[1] = data[1]; // Fall through
-		case 1: pmem2[0] = data[0];
+		case 4:
+			pmem2[3] = data[3];
+			[[fallthrough]];
+		case 3:
+			pmem2[2] = data[2];
+			[[fallthrough]];
+		case 2:
+			pmem2[1] = data[1];
+			[[fallthrough]];
+		case 1:
+			pmem2[0] = data[0];
 				break;
 		jNO_DEFAULT
 	}

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1074,19 +1074,19 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 		case 5: // Mostly Harmful
 			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = 1); // +1 EE cyclerate
 			isSkipSet ? 0 : (isSkipSet = true, EmuOptions.Speedhacks.EECycleSkip = 1); // +1 EE cycle skip
-            // Fall through
+			[[fallthrough]];
 		
 		case 4: // Very Aggressive
 			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = -2); // -2 EE cyclerate
-            // Fall through
+			[[fallthrough]];
 
 		case 3: // Aggressive
 			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = -1); // -1 EE cyclerate
-            // Fall through
+			[[fallthrough]];
 
 		case 2: // Balanced
 			isMTVUSet ? 0 : (isMTVUSet = true, EmuOptions.Speedhacks.vuThread = true); // Enable MTVU
-            // Fall through
+			[[fallthrough]];
 
 		case 1: // Safe (Default)
 			EmuOptions.Speedhacks.IntcStat = true;
@@ -1095,7 +1095,7 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 			
 			// If waterfalling from > Safe, break to avoid MTVU disable.
 			if (n > 1) break;
-            // Fall through
+			[[fallthrough]];
 			
 		case 0: // Safest
 			isMTVUSet ? 0 : (isMTVUSet = true, EmuOptions.Speedhacks.vuThread = false); // Disable MTVU

--- a/pcsx2/ps2/Iop/PsxBios.cpp
+++ b/pcsx2/ps2/Iop/PsxBios.cpp
@@ -86,6 +86,7 @@ bool __fastcall psxBiosCall()
             // putc(c, fd)
             if (psxRegs.GPR.n.a1 != 1)
                 return false;
+            [[fallthrough]];
         // fd=1, fall through to putchar
         case 0xa3c:
         case 0xb3d:

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -2783,7 +2783,7 @@ __forceinline void GSState::VertexKick(uint32 skip)
 		case GS_LINESTRIP:
 		case GS_TRIANGLESTRIP:
 			m_vertex.head = head + 1;
-			// fall through
+			[[fallthrough]];
 		case GS_TRIANGLEFAN:
 			if(tail >= m_vertex.maxcount) GrowVertexBuffer(); // in case too many vertices were skipped
 			break;

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -489,7 +489,7 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 	const bool blend_non_recursive = !!(blend_flag & BLEND_NO_REC);
 
 	// Warning no break on purpose
-	// Note: the "fall through" comments tell gcc not to complain about not having breaks.
+	// Note: the [[fallthrough]] attribute tell compilers not to complain about not having breaks.
 	switch (m_sw_blending) {
 		case ACC_BLEND_ULTRA:
 			sw_blending |= true;

--- a/plugins/onepad/state_management.cpp
+++ b/plugins/onepad/state_management.cpp
@@ -200,7 +200,7 @@ u8 pad_poll(u8 value)
                     query.set_result(ConfigExit);
                     return 0xF3;
                 }
-            // fallthrough on purpose (but I don't know why)
+                [[fallthrough]]; // fallthrough on purpose (but I don't know why)
 
             case CMD_READ_DATA_AND_VIBRATE: {
                 query.response[2] = 0x5A;

--- a/plugins/onepad_legacy/state_management.cpp
+++ b/plugins/onepad_legacy/state_management.cpp
@@ -202,7 +202,7 @@ u8 pad_poll(u8 value)
                     query.set_result(ConfigExit);
                     return 0xF3;
                 }
-                // fallthrough on purpose (but I don't know why)
+                [[fallthrough]]; // fallthrough on purpose (but I don't know why)
 
             case CMD_READ_DATA_AND_VIBRATE:
             {


### PR DESCRIPTION
Silences warnings about not having breaks on switch cases.
Added a few missing ones too.

Previously comments worked on gcc only.