### PR TITLE
gsdx-hw: Don't always set MaxDepth on ps/fs.

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.cpp
@@ -175,7 +175,7 @@ void GSRendererDX11::EmulateZbuffer()
 	const bool clamp_z = (uint32)(GSVector4i(m_vt.m_max.p).z) > max_z;
 
 	vs_cb.MaxDepth = GSVector2i(0xFFFFFFFF);
-	ps_cb.Af_MaxDepth.y = 1.0f;
+	//ps_cb.Af_MaxDepth.y = 1.0f;
 	m_ps_sel.zclamp = 0;
 
 	if (clamp_z)
@@ -190,8 +190,6 @@ void GSRendererDX11::EmulateZbuffer()
 			m_ps_sel.zclamp = 1;
 		}
 	}
-
-	
 
 	GSVertex* v = &m_vertex.buff[0];
 	// Minor optimization of a corner case (it allow to better emulate some alpha test effects)

--- a/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSRendererOGL.cpp
@@ -177,7 +177,7 @@ void GSRendererOGL::EmulateZbuffer()
 	const bool clamp_z = (uint32)(GSVector4i(m_vt.m_max.p).z) > max_z;
 
 	vs_cb.MaxDepth = GSVector2i(0xFFFFFFFF);
-	ps_cb.MaxDepth = GSVector4(0.0f, 0.0f, 0.0f, 1.0f);
+	//ps_cb.MaxDepth = GSVector4(0.0f, 0.0f, 0.0f, 1.0f);
 	m_ps_sel.zclamp = 0;
 
 	if (clamp_z) {


### PR DESCRIPTION
Value will be read only when zclamp is enabled. It will avoid an extra upload to buffer maybe.