### PR TITLE
linux: Fix compile issues due to wxWidgets and GTK version mismatches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-sudo: required
+os: linux
 
 cache: ccache
 
@@ -11,20 +11,16 @@ branches:
   only:
     - master
 
-matrix:
+jobs:
   include:
     - env: VERSION=8 BITS=64
       compiler: gcc
-      os: linux
     - env: VERSION=8 BITS=32
       compiler: gcc
-      os: linux
     - env: VERSION=7 BITS=32
       compiler: gcc
-      os: linux
     - env: VERSION=3.8 BITS=32
       compiler: clang
-      os: linux
 
 before_install:
   - ./travis.sh before_install

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -39,12 +39,13 @@ endif()
 # I'm removing the version check, because it excludes newer versions and requires specifically 3.0.
 #list(APPEND wxWidgets_CONFIG_OPTIONS --version=3.0)
 
-# Let's not specifically require Gtk 2 or 3, either. As long as you have wx there...
-#if(GTK2_API AND NOT APPLE)
-#    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk2)
-#elseif(NOT APPLE)
-#    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk3)
-#endif()
+# The wx version must be specified so a mix of gtk2 and gtk3 isn't used
+# as that can cause compile errors.
+if(GTK2_API AND NOT APPLE)
+    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk2)
+elseif(NOT APPLE)
+    list(APPEND wxWidgets_CONFIG_OPTIONS --toolkit=gtk3)
+endif()
 
 # wx2.8 => /usr/bin/wx-config-2.8
 # lib32-wx2.8 => /usr/bin/wx-config32-2.8
@@ -81,7 +82,7 @@ else()
     if(EXISTS "/usr/bin/wx-config")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config")
     endif()
-    if(EXISTS "/usr/bin/wx-config-gtk3")
+    if(NOT GTK2_API AND EXISTS "/usr/bin/wx-config-gtk3")
         set(wxWidgets_CONFIG_EXECUTABLE "/usr/bin/wx-config-gtk3")
     endif()
 endif()

--- a/travis.sh
+++ b/travis.sh
@@ -86,6 +86,7 @@ linux_32_script() {
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_REPLAY_LOADERS=TRUE \
 		-DCMAKE_BUILD_PO=FALSE \
+		-DGTK2_API=TRUE \
 		..
 
 	# Documentation says 1.5 cores, so 2 or 3 threads should work ok.
@@ -129,6 +130,7 @@ linux_64_script() {
 		-DCMAKE_BUILD_TYPE=Devel \
 		-DBUILD_REPLAY_LOADERS=TRUE \
 		-DCMAKE_BUILD_PO=FALSE \
+		-DGTK2_API=TRUE \
 		..
 
 	# Documentation says 1.5 cores, so 2 or 3 threads should work ok.


### PR DESCRIPTION
Changes:
 * Fix compilation errors due to WX and GTK mismatches.
 * Update the Travis CI build (There is a temporary commit on top to test that is supposed to show that it works but seems to highlight other issues (EDIT: See https://travis-ci.org/github/turtleli/pcsx2/builds/741138728). EDIT: Temp commit has been removed.)