### PR TITLE
Debugging 32-bit Ubuntu Package installation Failure

### DIFF
--- a/.github/workflows/scripts/linux/install-packages.sh
+++ b/.github/workflows/scripts/linux/install-packages.sh
@@ -119,5 +119,9 @@ PCSX2_PACKAGES_STR=""
 for i in "${PCSX2_PACKAGES[@]}"; do
   PCSX2_PACKAGES_STR="${PCSX2_PACKAGES_STR} ${i}${ARCH}"
 done
+if [ "${PLATFORM}" == "x86" ]; then
+echo "Installing workaround attempt"
+sudo apt-get -y install libgcc-s1:i386
+fi
 echo "Will install the following packages for pcsx2 - ${PCSX2_PACKAGES_STR}"
 sudo apt-get -y install ${PCSX2_PACKAGES_STR}


### PR DESCRIPTION
Tracking - https://bugs.launchpad.net/ubuntu/focal/+source/apt/+bug/1871268

I'm not familiar with Canoical's package release process, but i assume they would test something in 20.10 before rolling it to 20.04.  It seems like this issue has been resolved and is currently baking in 20.10.