### PR TITLE
Replace Star Wars - Force Unleashed CRC hack with GameDB patch. 

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -17305,12 +17305,8 @@ Name   = Star Wars - The Force Unleashed
 Region = PAL-M5
 [patches = 87109051]
 	author=kozarovv
-	// Fixes various graphics glitches.
-	// It's a problem which apply to all games made by Khrome studio.
-	// The EE seems to send invalid data to the GS and expect
-	// some kind of unknown behaviour to operate.
-	// This can be fixed on the GS side but the software render is impossible to fix.
-	// So this patch correct the issue on the EE side.
+	// Fix for graphical issues, QTE events, subtitles, health bar.
+	// Patch replace values passed to FPU to workaround x86 rounding issues.
 	patch=1,EE,0017cb84,word,3464fff0
 	patch=1,EE,0017cb90,word,3463fffc
 [/patches]
@@ -17318,6 +17314,13 @@ Region = PAL-M5
 Serial = SLES-54659
 Name   = Star Wars - The Force Unleashed
 Region = PAL-M4
+[patches = DAF2145C]
+	author=kozarovv
+	// Fix for graphical issues, QTE events, subtitles, health bar.
+	// Patch replace values passed to FPU to workaround x86 rounding issues.
+	patch=1,EE,0017cb84,word,3464fff0
+	patch=1,EE,0017cb90,word,3463fffc
+[/patches]
 ---------------------------------------------
 Serial = SLES-54663
 Name   = Jackass - The Game
@@ -34849,6 +34852,13 @@ Region = NTSC-J
 Serial = SLPS-25888
 Name   = Star Wars - The Force Unleashed
 Region = NTSC-J
+[patches = CC9BFDE3]
+	author=kozarovv
+	// Fix for graphical issues, QTE events, subtitles, health bar.
+	// Patch replace values passed to FPU to workaround x86 rounding issues.
+	patch=1,EE,0017d454,word,3464fff0
+	patch=1,EE,0017d460,word,3463fffc
+[/patches]
 ---------------------------------------------
 Serial = SLPS-25889
 Name   = Guitar Hero - Aerosmith
@@ -43043,6 +43053,13 @@ Serial = SLUS-21614
 Name   = Star Wars - The Force Unleashed
 Region = NTSC-U
 Compat = 4
+[patches = 879CDA5E]
+	author=kozarovv
+	// Fix for graphical issues, QTE events, subtitles, health bar.
+	// Patch replace values passed to FPU to workaround x86 rounding issues.
+	patch=1,EE,0017cf24,word,3464fff0
+	patch=1,EE,0017cf30,word,3463fffc
+[/patches]
 ---------------------------------------------
 Serial = SLUS-21615
 Name   = Wild ARMs 5

--- a/plugins/GSdx/GSCrc.cpp
+++ b/plugins/GSdx/GSCrc.cpp
@@ -318,11 +318,6 @@ CRC::Game CRC::m_games[] =
 	{0xBC8B3F50, TombRaiderLegend, US, 0}, // cutie comment
 	{0x365172A0, TombRaiderLegend, JP, 0},
 	{0x05177ECE, TombRaiderLegend, EU, 0},
-	{0x879CDA5E, StarWarsForceUnleashed, US, 0},
-	{0x137C792E, StarWarsForceUnleashed, US, 0},
-	{0xCC9BFDE3, StarWarsForceUnleashed, JP, 0},
-	{0xDAF2145C, StarWarsForceUnleashed, EU, 0},
-	{0x87109051, StarWarsForceUnleashed, EU, 0},
 	{0xBEBF8793, BurnoutTakedown, US, 0},
 	{0xBB2E845F, BurnoutTakedown, JP, 0},
 	{0x5F060991, BurnoutTakedown, KO, 0},

--- a/plugins/GSdx/GSCrc.h
+++ b/plugins/GSdx/GSCrc.h
@@ -125,7 +125,6 @@ public:
 		SoulReaver2,
 		Spartan,
 		StarOcean3,
-		StarWarsForceUnleashed,
 		SteambotChronicles,
 		SuperManReturns,
 		SVCChaos,

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1603,7 +1603,6 @@ GSRendererHW::Hacks::Hacks()
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::MetalSlug6, CRC::RegionCount, &GSRendererHW::OI_MetalSlug6));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::RozenMaidenGebetGarden, CRC::RegionCount, &GSRendererHW::OI_RozenMaidenGebetGarden));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SonicUnleashed, CRC::RegionCount, &GSRendererHW::OI_SonicUnleashed));
-	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::StarWarsForceUnleashed, CRC::RegionCount, &GSRendererHW::OI_StarWarsForceUnleashed));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::SuperManReturns, CRC::RegionCount, &GSRendererHW::OI_SuperManReturns));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::ArTonelico2, CRC::RegionCount, &GSRendererHW::OI_ArTonelico2));
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::Jak2, CRC::RegionCount, &GSRendererHW::OI_JakGames));
@@ -2075,25 +2074,6 @@ bool GSRendererHW::OI_SonicUnleashed(GSTexture* rt, GSTexture* ds, GSTextureCach
 	m_dev->StretchRect(src->m_texture, sRect, rt, dRect, true, true, true, false);
 
 	return false;
-}
-
-bool GSRendererHW::OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
-{
-	uint32 FBP = m_context->FRAME.Block();
-	uint32 FPSM = m_context->FRAME.PSM;
-
-	if(PRIM->TME)
-	{
-		if((FBP == 0x0 || FBP == 0x01180) && FPSM == PSM_PSMCT32 && (m_vt.m_eq.z && m_vt.m_max.p.z == 0))
-		{
-			GL_INS("OI_StarWarsForceUnleashed FB clear");
-			if(ds)
-				ds->Commit(); // Don't bother to save few MB for a single game
-			m_dev->ClearDepth(ds);
-		}
-	}
-
-	return true;
 }
 
 bool GSRendererHW::OI_PointListPalette(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -61,7 +61,6 @@ private:
 	bool OI_MetalSlug6(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_SonicUnleashed(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	bool OI_StarWarsForceUnleashed(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_PointListPalette(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_SuperManReturns(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_ArTonelico2(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);


### PR DESCRIPTION
EE patches work also in software mode. 

Note: CRC 0x137C792E seems to be some mistake. That game have only one version for US region.

Close #3175