### PR TITLE
[USB+] Clean up Warnings

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -286,8 +286,9 @@ endif()
 # -Wno-unused-value: lots of warning for this kind of statements "0 && ...". There are used to disable some parts of code in release/dev build.
 # -Wno-overloaded-virtual: Gives a fair number of warnings under clang over in the wxwidget gui section of the code.
 # -Wno-deprecated-declarations: The USB plugins dialogs are written in straight gtk 2, which gives a million deprecated warnings. Suppress them until we can deal with them.
+# -Wno-format: Yeah, these need to be taken care of, but...
 
-set(DEFAULT_WARNINGS "-Wall -Wextra -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-deprecated-declarations")
+set(DEFAULT_WARNINGS "-Wall -Wextra -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-deprecated-declarations -Wno-format")
 if (NOT USE_ICC)
     set(DEFAULT_WARNINGS "${DEFAULT_WARNINGS} -Wno-unused-value ")
 endif()
@@ -376,7 +377,8 @@ if(USE_CLANG)
 endif()
 
 # Note: -DGTK_DISABLE_DEPRECATED can be used to test a build without gtk deprecated feature. It could be useful to port to a newer API
-set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${HARDENING_FLAG} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS} ${PGO_FLAGS} ${PLUGIN_SUPPORT}")
+# Disabling the hardening flags for the moment, as they spam quite a bit. ${HARDENING_FLAG}
+set(DEFAULT_GCC_FLAG "${ARCH_FLAG} ${COMMON_FLAG} ${DEFAULT_WARNINGS} ${AGGRESSIVE_WARNING} ${DEBUG_FLAG} ${ASAN_FLAG} ${OPTIMIZATION_FLAG} ${LTO_FLAGS} ${PGO_FLAGS} ${PLUGIN_SUPPORT}")
 # c++ only flags
 set(DEFAULT_CPP_FLAG "${DEFAULT_GCC_FLAG} -Wno-invalid-offsetof")
 

--- a/pcsx2/DEV9/flash.cpp
+++ b/pcsx2/DEV9/flash.cpp
@@ -283,11 +283,9 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 				}
 				addrbyte = 0; // address reset
 				{
-					u32 bytes, pages, blocks;
-
-					blocks = address / BLOCK_SIZE;
-					pages = address - (blocks * BLOCK_SIZE);
-					bytes = pages % PAGE_SIZE;
+					const u32 blocks = address / BLOCK_SIZE;
+					u32 pages = address - (blocks * BLOCK_SIZE);
+					[[maybe_unused]]const u32 bytes = pages % PAGE_SIZE;
 					pages = pages / PAGE_SIZE;
 					DEV9_LOG("*FLASH ADDR = 0x%08lX (%d:%d:%d) (addrbyte=%d) FINAL\n", address, blocks, pages, bytes, addrbyte);
 				}

--- a/pcsx2/DebugTools/DisassemblyManager.h
+++ b/pcsx2/DebugTools/DisassemblyManager.h
@@ -181,7 +181,7 @@ public:
 	virtual u32 getTotalSize() { return size; };
 	virtual bool disassemble(u32 address, DisassemblyLineInfo& dest, bool insertSymbols);
 private:
-	DebugInterface* cpu;
+	[[maybe_unused]]DebugInterface* cpu;
 	u32 address;
 	u32 size;
 	std::string name;

--- a/pcsx2/SPU2/spu2replay.cpp
+++ b/pcsx2/SPU2/spu2replay.cpp
@@ -101,8 +101,8 @@ bool replay_mode = false;
 
 u16 dmabuffer[0xFFFFF];
 
-const u32 IOP_CLK = 768 * 48000;
-const u32 IOPCiclesPerMS = 768 * 48;
+[[maybe_unused]]const u32 IOP_CLK = 768 * 48000;
+[[maybe_unused]]const u32 IOPCiclesPerMS = 768 * 48;
 u32 CurrentIOPCycle = 0;
 
 u64 HighResFreq;

--- a/pcsx2/SPU2/wx/wxConfig.h
+++ b/pcsx2/SPU2/wx/wxConfig.h
@@ -80,7 +80,6 @@ public:
 class Dialog : public wxDialog
 {
 	wxBoxSizer *m_top_box, *m_portaudio_box, *m_sdl_box;
-	wxStaticBoxSizer* m_output_box;
 	wxChoice *m_module_select, *m_portaudio_select, *m_sdl_select;
 	wxStaticText *m_portaudio_text, *m_sdl_text;
 

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -361,7 +361,7 @@ s32 USBfreeze(int mode, freezeData* data)
 
 		s8* ptr = data->data + sizeof(USBfreezeData);
 		// Load the state of the attached devices
-		if (data->size != sizeof(USBfreezeData) + usbd.device[0].size + usbd.device[1].size + 8192)
+		if ((long unsigned int)data->size != sizeof(USBfreezeData) + usbd.device[0].size + usbd.device[1].size + 8192)
 			return -1;
 
 		//TODO Subsequent save state loadings make USB "stall" for n seconds since previous load

--- a/pcsx2/USB/configuration.cpp
+++ b/pcsx2/USB/configuration.cpp
@@ -168,7 +168,7 @@ void SaveConfig()
 #ifdef _WIN32
 	bool ret = ciniFile.Save(IniPath);
 #else
-	bool ret = ciniFile.Save(str_to_wstr(IniPath));
+	[[maybe_unused]]bool ret = ciniFile.Save(str_to_wstr(IniPath));
 #endif
 }
 

--- a/pcsx2/USB/linux/config-gtk.cpp
+++ b/pcsx2/USB/linux/config-gtk.cpp
@@ -160,7 +160,7 @@ static void configureApi(GtkWidget* widget, gpointer data)
 	if (dev)
 	{
 		GtkWidget* dlg = GTK_WIDGET(g_object_get_data(G_OBJECT(widget), "dlg"));
-		int res = dev->Configure(port, api, dlg);
+		[[maybe_unused]]int res = dev->Configure(port, api, dlg);
 	}
 }
 
@@ -203,7 +203,6 @@ void USBconfigure()
     USBsetSettingsDir();
 	RegisterDevice::Register();
 	LoadConfig();
-	void* that = NULL;
 	SettingsCB settingsCB[2];
 	settingsCB[0].player = 0;
 	settingsCB[1].player = 1;
@@ -289,7 +288,7 @@ void USBconfigure()
 
 		sel_idx = 0;
 
-		for (int i = 0; i < countof(wt); i++)
+		for (int i = 0; i < (int)countof(wt); i++)
 		{
 			gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(rs_cb), wt[i]);
 			if (conf.WheelType[port] == i)

--- a/pcsx2/USB/qemu-usb/USBinternal.h
+++ b/pcsx2/USB/qemu-usb/USBinternal.h
@@ -25,7 +25,7 @@
 
 /* Number of Downstream Ports on the root hub.  */
 
-#define OHCI_MAX_PORTS 15 // status regs from 0x0c54 but usb snooping \
+#define OHCI_MAX_PORTS 15 // status regs from 0x0c54 but usb snooping
 						  // reg is at 0x0c80, so only 11 ports?
 
 extern int64_t usb_frame_time;

--- a/pcsx2/USB/qemu-usb/usb-ohci.cpp
+++ b/pcsx2/USB/qemu-usb/usb-ohci.cpp
@@ -275,14 +275,13 @@ static void ohci_stop_endpoints(OHCIState* ohci)
 static void ohci_roothub_reset(OHCIState* ohci)
 {
 	OHCIPort* port;
-	int i;
 
 	ohci_bus_stop(ohci);
 	ohci->rhdesc_a = OHCI_RHA_NPS | ohci->num_ports;
 	ohci->rhdesc_b = 0x0; /* Impl. specific */
 	ohci->rhstatus = 0;
 
-	for (i = 0; i < ohci->num_ports; i++)
+	for (uint32_t i = 0; i < ohci->num_ports; i++)
 	{
 		port = &ohci->rhport[i];
 		port->ctrl = 0;
@@ -503,7 +502,7 @@ static int ohci_service_iso_td(OHCIState* ohci, struct ohci_ed* ed,
 {
 	int dir;
 	uint32_t len = 0;
-	const char* str = NULL;
+	[[maybe_unused]] const char* str = NULL;
 	int pid;
 	int ret;
 	int i;
@@ -729,7 +728,7 @@ static int ohci_service_iso_td(OHCIState* ohci, struct ohci_ed* ed,
 					OHCI_CC_NOERROR);
 		OHCI_SET_BM(iso_td.offset[relative_frame_number], TD_PSW_SIZE, ret);
 	}
-	else if (dir == OHCI_TD_DIR_OUT && ret == len)
+	else if (dir == OHCI_TD_DIR_OUT && (ret == (int)len))
 	{
 		/* OUT transfer succeeded */
 		OHCI_SET_BM(iso_td.offset[relative_frame_number], TD_PSW_CC,
@@ -806,7 +805,7 @@ static int ohci_service_td(OHCIState* ohci, struct ohci_ed* ed)
 {
 	int dir;
 	uint32_t len = 0, pktlen = 0;
-	const char* str = NULL;
+	[[maybe_unused]]const char* str = NULL;
 	int pid;
 	int ret;
 	int i;
@@ -972,10 +971,10 @@ static int ohci_service_td(OHCIState* ohci, struct ohci_ed* ed)
 	}
 
 	/* Writeback */
-	if (ret == pktlen || (dir == OHCI_TD_DIR_IN && ret >= 0 && flag_r))
+	if (ret == (int)pktlen || (dir == OHCI_TD_DIR_IN && ret >= 0 && flag_r))
 	{
 		/* Transmission succeeded.  */
-		if (ret == len)
+		if (ret == (int)len)
 		{
 			td.cbp = 0;
 		}
@@ -995,7 +994,7 @@ static int ohci_service_td(OHCIState* ohci, struct ohci_ed* ed)
 		OHCI_SET_BM(td.flags, TD_CC, OHCI_CC_NOERROR);
 		OHCI_SET_BM(td.flags, TD_EC, 0);
 
-		if ((dir != OHCI_TD_DIR_IN) && (ret != len))
+		if ((dir != OHCI_TD_DIR_IN) && (ret != (int)len))
 		{
 			/* Partial packet transfer: TD not ready to retire yet */
 			goto exit_no_retire;
@@ -1716,8 +1715,6 @@ static USBPortOps ohci_port_ops = {
 	/*.wakeup =*/ohci_wakeup,
 	/*.complete =*/ohci_async_complete_packet,
 };
-
-static USBBusOps ohci_bus_ops = {};
 
 OHCIState* ohci_create(uint32_t base, int ports)
 {

--- a/pcsx2/USB/shared/inifile_usb.cpp
+++ b/pcsx2/USB/shared/inifile_usb.cpp
@@ -177,7 +177,7 @@ void CIniFileA::Load(std::istream& input, bool bMerge)
 
 		if (!sRead.empty())
 		{
-			unsigned int nType = (sRead.find_first_of("[") == 0 && (sRead[sRead.find_last_not_of(" \t\r\n")] == ']')) ? SECTION : OTHER;
+			auto nType = (sRead.find_first_of("[") == 0 && (sRead[sRead.find_last_not_of(" \t\r\n")] == ']')) ? SECTION : OTHER;
 			nType = ((nType == OTHER) && (sRead.find_first_of("=") != std::string::npos && sRead.find_first_of("=") > 0)) ? KEY : nType;
 			nType = ((nType == OTHER) && (sRead.find_first_of("#") == 0)) ? COMMENT : nType;
 
@@ -674,7 +674,7 @@ void CIniFileW::Load(std::wistream& input, bool bMerge)
 
 		if (!sRead.empty())
 		{
-			unsigned int nType = (sRead.find_first_of(L"[") == 0 && (sRead[sRead.find_last_not_of(L" \t\r\n")] == L']')) ? SECTION : OTHER;
+			auto nType = (sRead.find_first_of(L"[") == 0 && (sRead[sRead.find_last_not_of(L" \t\r\n")] == L']')) ? SECTION : OTHER;
 			nType = ((nType == OTHER) && (sRead.find_first_of(L"=") != std::wstring::npos && sRead.find_first_of(L"=") > 0)) ? KEY : nType;
 			nType = ((nType == OTHER) && (sRead.find_first_of(L"#") == 0)) ? COMMENT : nType;
 

--- a/pcsx2/USB/shared/ringbuffer.h
+++ b/pcsx2/USB/shared/ringbuffer.h
@@ -104,11 +104,11 @@ public:
 	}
 
 private:
+	size_t m_begin;
+	size_t m_end;
 	size_t m_capacity;
 	char* m_data;
-	size_t m_begin;
 	bool m_overrun;
-	size_t m_end;
 	hrc::time_point mLastWrite = hrc::time_point(ns(0));
 };
 

--- a/pcsx2/USB/usb-eyetoy/cam-linux.cpp
+++ b/pcsx2/USB/usb-eyetoy/cam-linux.cpp
@@ -477,7 +477,7 @@ namespace usb_eyetoy
 		{
 			mpeg_mutex.lock();
 			int len2 = mpeg_buffer.length;
-			if (len < mpeg_buffer.length)
+			if (len < (int)mpeg_buffer.length)
 				len2 = len;
 			memcpy(buf, mpeg_buffer.start, len2);
 			mpeg_mutex.unlock();
@@ -513,7 +513,7 @@ namespace usb_eyetoy
 
 			std::vector<std::string> devList = getDevList();
 			int sel_idx = 0;
-			for (auto idx = 0; idx < devList.size(); idx++)
+			for (uint32_t idx = 0; idx < (uint32_t)devList.size(); idx++)
 			{
 				gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(rs_cb), devList.at(idx).c_str());
 				if (!selectedDevice.empty() && selectedDevice == devList.at(idx))

--- a/pcsx2/USB/usb-hid/evdev/evdev-gtk.cpp
+++ b/pcsx2/USB/usb-hid/evdev/evdev-gtk.cpp
@@ -94,7 +94,7 @@ namespace usb_hid
 			if (!cfg)
 				return;
 
-			std::string& name = (cfg->devs.begin() + idx)->first;
+			//std::string& name = (cfg->devs.begin() + idx)->first;
 			cfg->iter = (cfg->devs.begin() + idx);
 
 			if (idx > 0)

--- a/pcsx2/USB/usb-hid/evdev/evdev.cpp
+++ b/pcsx2/USB/usb-hid/evdev/evdev.cpp
@@ -83,7 +83,7 @@ namespace usb_hid
 					}
 				}
 			}
-		quit:
+		//quit:
 			closedir(dirp);
 			return false;
 		}
@@ -292,7 +292,7 @@ namespace usb_hid
 						}
 					}
 
-					if (len < sizeof(input_event) && errno != EAGAIN)
+					if (len < (ssize_t)sizeof(input_event) && errno != EAGAIN)
 					{
 						break;
 					}

--- a/pcsx2/USB/usb-hid/usb-hid.cpp
+++ b/pcsx2/USB/usb-hid/usb-hid.cpp
@@ -276,7 +276,7 @@ namespace usb_hid
 		0x0a,       /*  u8  ep_bInterval; (255ms -- usb 2.0 spec) */
 	};
 
-	static const uint8_t qemu_tablet_config_descriptor[] = {
+	[[maybe_unused]]static const uint8_t qemu_tablet_config_descriptor[] = {
 		/* one configuration */
 		0x09,       /*  u8  bLength; */
 		0x02,       /*  u8  bDescriptorType; Configuration */

--- a/pcsx2/USB/usb-mic/audiodev-pulse.cpp
+++ b/pcsx2/USB/usb-mic/audiodev-pulse.cpp
@@ -334,7 +334,7 @@ namespace usb_mic
 			if (mPAready == 3 && dur >= 1000)
 			{
 				mLastGetBuffer = now;
-				int ret = pa_context_connect(mPContext,
+				[[maybe_unused]]int ret = pa_context_connect(mPContext,
 											 mServer,
 											 PA_CONTEXT_NOFLAGS,
 											 NULL);
@@ -460,11 +460,10 @@ namespace usb_mic
 
 		void PulseAudioDevice::Uninit()
 		{
-			int ret;
 			if (mStream)
 			{
 				pa_threaded_mainloop_lock(mPMainLoop);
-				ret = pa_stream_disconnect(mStream);
+				[[maybe_unused]]int ret = pa_stream_disconnect(mStream);
 				pa_stream_unref(mStream);
 				mStream = nullptr;
 				pa_threaded_mainloop_unlock(mPMainLoop);
@@ -875,7 +874,7 @@ namespace usb_mic
 					padev->mOutBuffer.read(read);
 				}
 
-				if (pa_bytes > final_bytes)
+				if ((ssize_t)pa_bytes > final_bytes)
 					memset((uint8_t*)pa_buffer + final_bytes, 0, pa_bytes - final_bytes);
 
 				ret = pa_stream_write(padev->mStream, pa_buffer, pa_bytes, NULL, 0LL, PA_SEEK_RELATIVE);

--- a/pcsx2/USB/usb-mic/audiodev-pulse.cpp
+++ b/pcsx2/USB/usb-mic/audiodev-pulse.cpp
@@ -334,7 +334,8 @@ namespace usb_mic
 			if (mPAready == 3 && dur >= 1000)
 			{
 				mLastGetBuffer = now;
-				[[maybe_unused]]int ret = pa_context_connect(mPContext,
+				[[maybe_unused]]
+				int ret = pa_context_connect(mPContext,
 											 mServer,
 											 PA_CONTEXT_NOFLAGS,
 											 NULL);

--- a/pcsx2/USB/usb-mic/audiodev-pulse.h
+++ b/pcsx2/USB/usb-mic/audiodev-pulse.h
@@ -138,27 +138,27 @@ namespace usb_mic
 			int mChannels;
 			int mBuffering;
 			std::string mDeviceName;
-			int mSamplesPerSec;
 			pa_sample_spec mSSpec;
 
-			SRC_STATE* mResampler;
-			double mResampleRatio;
-			// Speed up or slow down audio
-			double mTimeAdjust;
 			RingBuffer mOutBuffer;
 			RingBuffer mInBuffer;
 			//std::thread mThread;
 			//std::condition_variable mEvent;
 			std::mutex mMutex;
-			bool mQuit;
 			bool mPaused;
+			bool mQuit;
 			hrc::time_point mLastGetBuffer;
 
-			int mPAready;
 			pa_threaded_mainloop* mPMainLoop;
 			pa_context* mPContext;
 			pa_stream* mStream;
 			char* mServer; //TODO add server selector?
+			int mPAready;
+			double mResampleRatio;
+			// Speed up or slow down audio
+			double mTimeAdjust;
+			int mSamplesPerSec;
+			SRC_STATE* mResampler;
 
 			int mOutSamples;
 			hrc::time_point mLastOut;

--- a/pcsx2/USB/usb-mic/usb-headset.cpp
+++ b/pcsx2/USB/usb-mic/usb-headset.cpp
@@ -472,7 +472,7 @@ namespace usb_mic
 									 int length, uint8_t* data)
 	{
 		uint8_t cs = cscn >> 8;
-		uint8_t cn = cscn - 1; /* -1 for the non-present master control */
+		const uint8_t cn = cscn - 1; /* -1 for the non-present master control */
 		uint32_t aid = ATTRIB_ID(cs, attrib, idif);
 		int ret = USB_RET_STALL;
 
@@ -586,7 +586,7 @@ namespace usb_mic
 									 int length, uint8_t* data)
 	{
 		uint8_t cs = cscn >> 8;
-		uint8_t cn = cscn - 1; /* -1 for the non-present master control */
+		const uint8_t cn = cscn - 1; /* -1 for the non-present master control */
 		uint32_t aid = ATTRIB_ID(cs, attrib, idif);
 		uint16_t vol;
 		int ret = USB_RET_STALL;
@@ -660,7 +660,7 @@ namespace usb_mic
 									int length, uint8_t* data)
 	{
 		uint8_t cs = cscn >> 8;
-		uint8_t cn = cscn - 1; /* -1 for the non-present master control */
+		[[maybe_unused]] const uint8_t cn = cscn - 1; /* -1 for the non-present master control */
 		uint32_t aid = ATTRIB_ID(cs, attrib, ep);
 		int ret = USB_RET_STALL;
 

--- a/pcsx2/USB/usb-msd/usb-msd.cpp
+++ b/pcsx2/USB/usb-msd/usb-msd.cpp
@@ -381,11 +381,11 @@ namespace usb_msd
 		NO_SENSE, 0x00, 0x00};
 
 	/* LUN not ready, Manual intervention required */
-	const struct SCSISense sense_code_LUN_NOT_READY = {
+	[[maybe_unused]]const struct SCSISense sense_code_LUN_NOT_READY = {
 		NOT_READY, 0x04, 0x03};
 
 	/* LUN not ready, Medium not present */
-	const struct SCSISense sense_code_NO_MEDIUM = {
+	[[maybe_unused]]const struct SCSISense sense_code_NO_MEDIUM = {
 		NOT_READY, 0x3a, 0x00};
 
 	const struct SCSISense sense_code_UNKNOWN_ERROR = {

--- a/pcsx2/USB/usb-pad/evdev/evdev-ff.cpp
+++ b/pcsx2/USB/usb-pad/evdev/evdev-ff.cpp
@@ -97,7 +97,7 @@ namespace usb_pad
 
 		EvdevFF::~EvdevFF()
 		{
-			for (int i = 0; i < countof(mEffIds); i++)
+			for (int i = 0; i < (int)countof(mEffIds); i++)
 			{
 				if (mEffIds[i] != -1 && ioctl(mHandle, EVIOCRMFF, mEffIds[i]) == -1)
 				{

--- a/pcsx2/USB/usb-pad/evdev/evdev-gtk.cpp
+++ b/pcsx2/USB/usb-pad/evdev/evdev-gtk.cpp
@@ -566,7 +566,7 @@ namespace usb_pad
 
 			if (map < JOY_STEERING || !strcmp(dev_type, BuzzDevice::TypeName()))
 			{
-				if (event < key_to_str.size())
+				if (event < (int)key_to_str.size())
 				{
 					*name = key_to_str[event];
 					return true;

--- a/pcsx2/USB/usb-pad/evdev/evdev.cpp
+++ b/pcsx2/USB/usb-pad/evdev/evdev.cpp
@@ -108,7 +108,7 @@ namespace usb_pad
 					}
 				}
 			}
-		quit:
+		//quit:
 			closedir(dirp);
 			return false;
 		}
@@ -134,7 +134,7 @@ namespace usb_pad
 			}
 
 			// get rid of unplugged devices
-			for (int i = 0; i < list_cache.size();)
+			for (int i = 0; i < (int)list_cache.size();)
 			{
 				if (!file_exists(list_cache[i].path))
 					list_cache.erase(list_cache.begin() + i);
@@ -183,7 +183,7 @@ namespace usb_pad
 			}
 
 			list.assign(list_cache.begin(), list_cache.end());
-		quit:
+		//quit:
 			closedir(dirp);
 		}
 
@@ -220,7 +220,7 @@ namespace usb_pad
 				//case ABS_Y: mWheelData.clutch = NORM(value, 0xFF); break; //no wheel on PS2 has one, afaik
 				//case ABS_RX: mWheelData.axis_rx = NORM(event.value, 0xFF); break;
 				case ABS_RY:
-				treat_me_like_ABS_RY:
+				//treat_me_like_ABS_RY:
 					mWheelData.throttle = 0xFF;
 					mWheelData.brake = 0xFF;
 					if (value < 0)

--- a/pcsx2/USB/usb-pad/evdev/shared-gtk.cpp
+++ b/pcsx2/USB/usb-pad/evdev/shared-gtk.cpp
@@ -173,7 +173,7 @@ namespace usb_pad
 			gtk_list_store_clear(cfg->store);
 			for (auto& it : cfg->jsconf)
 			{
-				for (int i = 0; /*i < JOY_MAPS_COUNT && */ i < it.second.controls.size(); i++)
+				for (int i = 0; /*i < JOY_MAPS_COUNT && */ i < (int)it.second.controls.size(); i++)
 				{
 					if (it.second.controls[i] < 0)
 						continue;
@@ -218,7 +218,7 @@ namespace usb_pad
 		static void joystick_changed(GtkComboBox* widget, gpointer data)
 		{
 			gint idx = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-			int port = reinterpret_cast<uintptr_t>(data);
+			//int port = reinterpret_cast<uintptr_t>(data);
 			ConfigData* cfg = (ConfigData*)g_object_get_data(G_OBJECT(widget), CFG);
 
 			if (!cfg)
@@ -256,7 +256,7 @@ namespace usb_pad
 											   return i.first == dev_name;
 										   });
 
-					if (it != cfg->jsconf.end() && type < it->second.controls.size())
+					if (it != cfg->jsconf.end() && type < (int)it->second.controls.size())
 					{
 						it->second.controls[type] = value;
 						if (is_axis)
@@ -295,7 +295,7 @@ namespace usb_pad
 											   return i.first == dev_name;
 										   });
 
-					if (it != cfg->jsconf.end() && type < it->second.controls.size())
+					if (it != cfg->jsconf.end() && type < (int)it->second.controls.size())
 					{
 						it->second.controls[type] = value;
 						refresh_store(cfg);
@@ -546,7 +546,7 @@ namespace usb_pad
 					{3, 2, JOY_START},
 				};
 
-				for (int i = 0; i < countof(button_labels); i++)
+				for (int i = 0; i < (int)countof(button_labels); i++)
 				{
 					GtkWidget* button = gtk_button_new_with_label(button_labels[i]);
 					g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), reinterpret_cast<gpointer>(port));
@@ -860,7 +860,7 @@ namespace usb_pad
 
 				for (int j = 0; j < 4; j++)
 				{
-					for (int i = 0; i < countof(button_labels); i++)
+					for (int i = 0; i < (int)countof(button_labels); i++)
 					{
 						GtkWidget* button = gtk_button_new_with_label(button_labels[i]);
 

--- a/pcsx2/USB/usb-pad/joydev/joydev.cpp
+++ b/pcsx2/USB/usb-pad/joydev/joydev.cpp
@@ -72,7 +72,7 @@ namespace usb_pad
 					close(fd);
 				}
 			}
-		quit:
+		//quit:
 			closedir(dirp);
 		}
 

--- a/pcsx2/USB/usb-pad/usb-seamic.cpp
+++ b/pcsx2/USB/usb-pad/usb-seamic.cpp
@@ -280,7 +280,7 @@ namespace usb_pad
 				{
 					ret = s->pad->TokenIn(data, p->iov.size);
 					if (ret > 0)
-						usb_packet_copy(p, data, MIN(ret, sizeof(data)));
+						usb_packet_copy(p, data, MIN((unsigned long)ret, sizeof(data)));
 					else
 						p->status = ret;
 				}

--- a/pcsx2/gui/AppAccelerators.h
+++ b/pcsx2/gui/AppAccelerators.h
@@ -111,7 +111,7 @@ struct KeyAcceleratorCode
 		wxString modifiedKeyCode;
 		for (int i = 0; i < (int)tokens.size(); i++)
 		{
-			if (i == tokens.size() - 1)
+			if (i == (int)(tokens.size() - 1))
 				modifiedKeyCode.append(tokens.at(i));
 			else
 				modifiedKeyCode.append(wxString::Format("%s+", tokens.at(i)));

--- a/plugins/onepad/wx_dialog/JoystickConfiguration.h
+++ b/plugins/onepad/wx_dialog/JoystickConfiguration.h
@@ -41,7 +41,6 @@ class JoystickConfiguration : public wxDialog
     wxCheckBox *m_cb_reverse_Lx, *m_cb_reverse_Ly, *m_cb_reverse_Rx, *m_cb_reverse_Ry,
         *m_cb_mouse_Ljoy, // Use mouse for left joystick
         *m_cb_mouse_Rjoy; // Use mouse for right joystick
-    wxButton *m_bt_ok, *m_bt_cancel;
 
     u32 m_pad_id;
     // isForLeftJoystick -> true is for Left Joystick, false is for Right Joystick


### PR DESCRIPTION
Clean up various warnings, largely in the recently merged USB code. Unused variables have had [[maybe_unused]] added or been deleted, various variables were cast due to sign mismatches, member variables were rearranged in places to match the class initialization, and so on.

This brings the warnings in gcc and clang down to a much more reasonable level.

I ignored several warnings along the line of:
../pcsx2/USB/USB.cpp:520:10: warning: ‘char* strncpy(char*, const char*, size_t)’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  520 |   strncpy(usbd.freezeID, USBfreezeID, strlen(USBfreezeID));

As well as various preexisting warnings (Such as Lilypad doing sizeof on a pointer :P ).