### PR TITLE
DEV9: Add HDD emulation

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -315,6 +315,17 @@ compile_gresources( pcsx2DEV9UIHeaders
 
 # DEV9 sources
 set(pcsx2DEV9Sources
+	DEV9/ATA/Commands/ATA_Command.cpp
+	DEV9/ATA/Commands/ATA_CmdDMA.cpp
+	DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
+	DEV9/ATA/Commands/ATA_CmdNoData.cpp
+	DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+	DEV9/ATA/Commands/ATA_CmdSMART.cpp
+	DEV9/ATA/Commands/ATA_SCE.cpp
+	DEV9/ATA/ATA_Info.cpp
+	DEV9/ATA/ATA_State.cpp
+	DEV9/ATA/ATA_Transfer.cpp
+	DEV9/ATA/HddCreate.cpp
 	DEV9/smap.cpp
 	DEV9/DEV9.cpp
 	DEV9/flash.cpp
@@ -327,8 +338,9 @@ set(pcsx2DEV9Sources
 
 # DEV9 headers
 set(pcsx2DEV9Headers
+	DEV9/ATA/ATA.h
+	DEV9/ATA/HddCreate.h
 	DEV9/DEV9.h
-	DEV9/ata.h
 	DEV9/net.h
 	DEV9/pcap_io.h
 	DEV9/smap.h

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -31,7 +31,7 @@ class ATA
 public:
 	//Transfer
 	bool dmaReady = false;
-	int nsector = 0; //sector count
+	int nsector = 0;     //sector count
 	int nsectorLeft = 0; //sectors left to transfer
 private:
 	const bool lba48Supported = false;
@@ -51,7 +51,7 @@ private:
 
 	u8 curMultipleSectorsSetting = 128;
 
-	u8 identifyData[512] = { 0 };
+	u8 identifyData[512] = {0};
 
 	//LBA48 in use?
 	bool lba48 = false;
@@ -143,7 +143,7 @@ private:
 	int pioPtr;
 	int pioEnd;
 	u8 pioBuffer[512];
-	
+
 	int sectorsPerInterrupt;
 	void (ATA::*pioDRQEndTransferFunc)() = nullptr;
 	//PIO Buffer
@@ -175,7 +175,7 @@ public:
 	u16 ATAreadPIO();
 	//ATAwritePIO;
 
- private:
+private:
 	//Info
 	void CreateHDDinfo(int sizeMb);
 	void CreateHDDinfoCsum();
@@ -231,7 +231,7 @@ public:
 	void PostCmdDMADataFromHost();
 	void HDD_ReadDMA(bool isLBA48);
 	void HDD_WriteDMA(bool isLBA48);
-	
+
 	void PreCmdExecuteDeviceDiag();
 	void PostCmdExecuteDeviceDiag();
 	void HDD_ExecuteDeviceDiag();
@@ -273,4 +273,3 @@ public:
 	static void WriteUInt64(u8* data, int* index, u64 value);
 	static void WritePaddedString(u8* data, int* index, std::string value, u32 len);
 };
-

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -1,0 +1,276 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+#include "ghc/filesystem.h"
+#include <fstream>
+
+#include "PS2Edefs.h"
+#include "PS2Eext.h"
+
+class ATA
+{
+public:
+	//Transfer
+	bool dmaReady = false;
+	int nsector = 0; //sector count
+	int nsectorLeft = 0; //sectors left to transfer
+private:
+	const bool lba48Supported = false;
+
+	std::fstream hddImage;
+	u64 hddImageSize;
+
+	int pioMode;
+	int sdmaMode;
+	int mdmaMode;
+	int udmaMode;
+
+	//Info
+	u8 curHeads = 16;
+	u8 curSectors = 63;
+	u16 curCylinders = 0;
+
+	u8 curMultipleSectorsSetting = 128;
+
+	u8 identifyData[512] = { 0 };
+
+	//LBA48 in use?
+	bool lba48 = false;
+
+	//Enable/disable features
+	bool fetSmartEnabled = true;
+	bool fetSecurityEnabled = false;
+	bool fetWriteCacheEnabled = true;
+	bool fetHostProtectedAreaEnabled = false;
+
+	//Regs
+	u16 regCommand; //WriteOnly, Only to be written BSY and DRQ are cleared, DMACK is not set and device is not sleeping, except for DEVICE RESET
+	//PIO Read/Write, Only to be written DMACK is not set and DRQ is 1
+	//COMMAND REG (WriteOnly) Only to be written DMACK is not set
+	//Bit 0 = 0
+	bool regControlEnableIRQ = false; //Bit 1 = 1 Disable Interrupt
+	//Bit 2 = 1 Software Reset
+	bool regControlHOBRead = false; //Bit 7 = HOB (cleared by any write to RegCommand, Sets if Low order or High order bytes are read in ATAread16)
+	//End COMMAND REG
+	u8 regError; //ReadOnly
+
+	//DEVICE REG (Read/Write)
+	u8 regSelect;
+	//Bit 0-3: LBA Bits 24-27 (Unused in 48bit) or Command Dependent
+	//Bit 4: Selected Device
+	//Bit 5: Obsolete (All?)
+	//Bit 6: Command Dependent
+	//Bit 7: Obsolete (All?)
+	//End COMMAND REG
+	u8 regFeature; //WriteOnly, Only to be written BSY and DRQ are cleared and DMACK is not set
+	u8 regFeatureHOB;
+
+	//Following regs are Read/Write, Only to be written BSY and DRQ are cleared and DMACK is not set
+	u8 regSector; //Sector Number or LBA Low
+	u8 regSectorHOB;
+	u8 regLcyl; //LBA Mid
+	u8 regLcylHOB;
+	u8 regHcyl; //LBA High
+	u8 regHcylHOB;
+	//TODO handle nsector code
+	u8 regNsector;
+	u8 regNsectorHOB;
+
+	u8 regStatus; //ReadOnly. When read via AlternateStatus pending interrupts are not cleared
+
+	//Transfer
+	//Write Buffer(s)
+	bool awaitFlush = false;
+	u8* currentWrite; //array
+	u32 currentWriteLength;
+	u64 currentWriteSectors;
+
+	struct WriteQueueEntry
+	{
+		std::atomic_bool ready{false};
+		WriteQueueEntry* next;
+		u8* data;
+		u32 length;
+		u64 sector;
+	};
+
+	WriteQueueEntry* head = nullptr;
+	WriteQueueEntry* tail = nullptr;
+
+	std::thread ioThread;
+	bool ioRunning = false;
+	std::mutex ioMutex;
+
+	std::condition_variable ioThreadIdle_cv;
+	bool ioThreadIdle_bool = false;
+
+	std::condition_variable ioReady;
+	std::atomic_bool ioClose{false};
+	bool ioWrite;
+	bool ioRead;
+	void (ATA::*waitingCmd)() = nullptr;
+	//Write Buffer(s)
+
+	//Read Buffer
+	int rdTransferred = 0;
+	int wrTransferred = 0;
+	//Max tranfer on 24bit is 256*512 = 128KB
+	//Max tranfer on 48bit is 65536*512 = 32MB
+	int readBufferLen;
+	u8* readBuffer = nullptr;
+	//Read Buffer
+
+	//PIO Buffer
+	int pioPtr;
+	int pioEnd;
+	u8 pioBuffer[512];
+	
+	int sectorsPerInterrupt;
+	void (ATA::*pioDRQEndTransferFunc)() = nullptr;
+	//PIO Buffer
+
+	//Smart
+	bool smartAutosave = true;
+	bool smartErrors = false;
+	u8 smartSelfTestCount = 0;
+	//Smart
+
+	u8 sceSec[256 * 2] = {0};
+
+public:
+	ATA();
+
+	int Open(ghc::filesystem::path hddPath);
+	void Close();
+
+	void ATA_HardReset();
+
+	u16 Read16(u32 addr);
+	void Write16(u32 addr, u16 value);
+
+	void Async(u32 cycles);
+
+	void ATAreadDMA8Mem(u8* pMem, int size);
+	void ATAwriteDMA8Mem(u8* pMem, int size);
+
+	u16 ATAreadPIO();
+	//ATAwritePIO;
+
+ private:
+	//Info
+	void CreateHDDinfo(int sizeMb);
+	void CreateHDDinfoCsum();
+
+	//State
+	void ResetBegin();
+	void ResetEnd(bool hard);
+
+	u8 GetSelectedDevice()
+	{
+		return (regSelect >> 4) & 1;
+	}
+	void SetSelectedDevice(u8 value)
+	{
+		if (value == 1)
+			regSelect |= (1 << 4);
+		else
+			regSelect &= ~(1 << 4);
+	}
+
+	s64 HDD_GetLBA();
+	void HDD_SetLBA(s64 sectorNum);
+
+	bool HDD_CanSeek();
+	bool HDD_CanAccess(int* sectors);
+
+	void ClearHOB();
+
+	//Transfer
+	void IO_Thread();
+	void IO_Read();
+	bool IO_Write();
+	void HDD_ReadAsync(void (ATA::*drqCMD)());
+	void HDD_ReadSync(void (ATA::*drqCMD)());
+	bool HDD_CanAssessOrSetError();
+	void HDD_SetErrorAtTransferEnd();
+
+	void QueueWrite(u64 sector, u8* data, u32 length);
+	bool DequeueWrite(u64* sector, u8** data, u32* length);
+	bool IsQueueEmpty();
+
+	//Commands
+	void IDE_ExecCmd(u16 value);
+
+	bool PreCmd();
+	void HDD_Unk();
+
+	void IDE_CmdLBA48Transform(bool islba48);
+
+	void DRQCmdDMADataToHost();
+	void PostCmdDMADataToHost();
+	void DRQCmdDMADataFromHost();
+	void PostCmdDMADataFromHost();
+	void HDD_ReadDMA(bool isLBA48);
+	void HDD_WriteDMA(bool isLBA48);
+	
+	void PreCmdExecuteDeviceDiag();
+	void PostCmdExecuteDeviceDiag();
+	void HDD_ExecuteDeviceDiag();
+
+	void PostCmdNoData();
+	void CmdNoDataAbort();
+	void HDD_FlushCache();
+	void HDD_InitDevParameters();
+	void HDD_ReadVerifySectors(bool isLBA48);
+	void HDD_SeekCmd();
+	void HDD_SetFeatures();
+	void HDD_SetMultipleMode();
+	void HDD_Nop();
+	void HDD_Idle();
+
+	void DRQCmdPIODataToHost(u8* buff, int buffLen, int buffIndex, int size, bool sendIRQ);
+	void PostCmdPIODataToHost();
+	void HDD_IdentifyDevice();
+
+	void HDD_ReadMultiple(bool isLBA48);
+	void HDD_ReadSectors(bool isLBA48);
+	void HDD_ReadPIO(bool isLBA48);
+	void HDD_ReadPIOS2();
+	void HDD_ReadPIOEndBlock();
+	//HDD_Write*
+
+	void HDD_Smart();
+	void SMART_SetAutoSaveAttribute();
+	void SMART_ExecuteOfflineImmediate();
+	void SMART_EnableOps(bool enable);
+	void SMART_ReturnStatus();
+
+	void HDD_SCE();
+	void SCE_IDENTIFY_DRIVE();
+
+	//In here temporally
+	static void WriteUInt16(u8* data, int* index, u16 value);
+	static void WriteUInt32(u8* data, int* index, u32 value);
+	static void WriteUInt64(u8* data, int* index, u64 value);
+	static void WritePaddedString(u8* data, int* index, std::string value, u32 len);
+};
+

--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -1,0 +1,392 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "ATA.h"
+#include "../DEV9.h"
+
+void ATA::WriteUInt16(u8* data, int* index, u16 value)
+{
+	*(u16*)&data[*index] = value;
+	*index += sizeof(value);
+}
+
+void ATA::WriteUInt32(u8* data, int* index, u32 value)
+{
+	*(u32*)&data[*index] = value;
+	*index += sizeof(value);
+}
+
+void ATA::WriteUInt64(u8* data, int* index, u64 value)
+{
+	*(u64*)&data[*index] = value;
+	*index += sizeof(value);
+}
+
+//No null char
+void ATA::WritePaddedString(u8* data, int* index, std::string value, u32 len)
+{
+	memset(&data[*index], (u8)' ', len);
+	memcpy(&data[*index], value.c_str(), value.length() < len ? value.length() : len);
+	*index += len;
+}
+
+void ATA::CreateHDDinfo(int sizeMb)
+{
+	const u16 sectorSize = 512;
+	DEV9_LOG_VERB("HddSize : %i\n", config.HddSize);
+	const u64 nbSectors = ((u64)(sizeMb / sectorSize) * 1024 * 1024);
+	DEV9_LOG_VERB("nbSectors : %i\n", nbSectors);
+
+	memset(&identifyData, 0, sizeof(identifyData));
+	//Defualt CHS translation
+	const u16 defHeads = 16;
+	const u16 defSectors = 63;
+	u64 cylinderslong = std::min<u64>(nbSectors, 16514064) / defHeads / defSectors;
+	const u16 defCylinders = (u16)std::min<u64>(cylinderslong, UINT16_MAX);
+
+	//Curent CHS translation
+	cylinderslong = std::min<u64>(nbSectors, 16514064) / curHeads / curSectors;
+	curCylinders = (u16)std::min<u64>(cylinderslong, UINT16_MAX);
+
+	const int curOldsize = curCylinders * curHeads * curSectors;
+	//SET MAX ADDRESS will set the nbSectors reported
+
+	//General configuration bit-significant information:
+	/*
+	 * 0x848A is for CFA devices
+	 * bit 0: Resv                                          (all?)
+	 * bit 1: Hard Sectored                                 (ATA-1)
+	 * bit 2: Soft Sectored                                 (ATA-1) / Response incomplete (ATA-5,6,7,8)
+	 * bit 3: Not MFM encoded                               (ATA-1)
+	 * bit 4: Head switch time > 15 usec                    (ATA-1)
+	 * bit 5: Spindle motor control option implemented      (ATA-1)
+	 * bit 6: Non-Removable (Obsolete)                      (ATA-1,2,3,4,5)
+	 * bit 7: Removable                                     (ATA-1,2,3,4,5,6,7,8)
+	 * bit 8: disk transfer rate > 10Mbs                    (ATA-1)
+	 * bit 9: disk transfer rate > 5Mbs but <= 10Mbs        (ATA-1)
+	 * bit 10: disk transfer rate <= 5Mbs                   (ATA-1)
+	 * bit 11: rotational speed tolerance is > 0.5%         (ATA-1)
+	 * bit 12: data strobe offset option available          (ATA-1)
+	 * bit 13: track offset option available                (ATA-1)
+	 * bit 14: format speed tolerance gap required          (ATA-1)
+	 * bit 15: 0 = ATA dev                                  (All?)
+	 */
+	int index = 0;
+	WriteUInt16(identifyData, &index, 0x0040); //word 0
+	//Default Num of cylinders
+	WriteUInt16(identifyData, &index, defCylinders); //word 1
+	//Specific configuration
+	index += 1 * 2; //word 2
+	//Default Num of heads (Retired)
+	WriteUInt16(identifyData, &index, defHeads); //word 3
+	//Number of unformatted bytes per track (Retired)
+	WriteUInt16(identifyData, &index, (u16)(sectorSize * defSectors)); //word 4
+	//Number of unformatted bytes per sector (Retired)
+	WriteUInt16(identifyData, &index, sectorSize); //word 5
+	//Default Number of sectors per track (Retired)
+	WriteUInt16(identifyData, &index, defSectors); //word 6
+	//Reserved for assignment by the CompactFlash™ Association
+	index += 2 * 2; //word 7-8
+	//Retired
+	index += 1 * 2; //word 9
+	//Serial number (20 ASCII characters)
+	WritePaddedString(identifyData, &index, "PCSX2-DEV9-ATA-HDD", 20); //word 10-19
+	//Buffer(cache) type (Retired)
+	WriteUInt16(identifyData, &index, /*3*/ 0); //word 20
+	//Buffer(cache) size in sectors (Retired)
+	WriteUInt16(identifyData, &index, /*512*/ 0); //word 21
+	//Number of ECC bytes available on read / write long commands (Obsolete)
+	WriteUInt16(identifyData, &index, /*4*/ 0); //word 22
+	//Firmware revision (8 ASCII characters)
+	WritePaddedString(identifyData, &index, "FIRM100", 8); //word 23-26
+	//Model number (40 ASCII characters)
+	WritePaddedString(identifyData, &index, "PCSX2-DEV9-ATA-HDD", 40); //word 27-46
+	//READ/WRITE MULI max sectors
+	WriteUInt16(identifyData, &index, 128 & (0x80 << 8)); //word 47
+	//Dword IO supported
+	WriteUInt16(identifyData, &index, 1); //word 48
+	//Capabilities
+	/*
+	 * bits 7-0: Retired
+	 * bit 8: DMA supported
+	 * bit 9: LBA supported
+	 * bit 10:IORDY may be disabled
+	 * bit 11:IORDY supported
+	 * bit 12:Reserved
+	 * bit 13:Standby timer values as specified in this standard are supported
+	 */
+	WriteUInt16(identifyData, &index, ((1 << 11) | (1 << 9) | (1 << 8))); //word 49
+	//Capabilities (0-Shall be set to one to indicate a device specific Standby timer value minimum)
+	index += 1 * 2; //word 50
+	//PIO data transfer cycle timing mode (Obsolete)
+	WriteUInt16(identifyData, &index, (u8)((pioMode > 2 ? pioMode : 2) << 8)); //word 51
+	//DMA data transfer cycle timing mode (Obsolete)
+	WriteUInt16(identifyData, &index, 0); //word 52
+	//
+	/*
+	 * bit 0: Fields in 54:58 are valid (CHS sizes)(Obsolete)
+	 * bit 1: Fields in 64:70 are valid (pio3,4 and MWDMA info)
+	 * bit 2: Fields in 88 are valid    (UDMA modes)
+	 */
+	WriteUInt16(identifyData, &index, (1 | (1 << 1) | (1 << 2))); //word 53
+	//Number of current cylinders
+	WriteUInt16(identifyData, &index, curCylinders); //word 54
+	//Number of current heads
+	WriteUInt16(identifyData, &index, curHeads); //word 55
+	//Number of current sectors per track
+	WriteUInt16(identifyData, &index, curSectors); //word 56
+	//Current capacity in sectors
+	WriteUInt32(identifyData, &index, (u32)curOldsize); //word 57-58
+	//PIO READ/WRITE Multiple setting
+	/*
+	 * bit 7-0: Current setting for number of logical sectors that shall be transferred per DRQ
+	 *			data block on READ/WRITE Multiple commands
+	 * bit 8: Multiple sector setting is valid
+	 */
+	WriteUInt16(identifyData, &index, (u16)(curMultipleSectorsSetting | (1 << 8))); //word 59
+	//Total number of user addressable logical sectors
+	WriteUInt32(identifyData, &index, (u32)(nbSectors < 268435456 ? nbSectors : 268435456)); //word 60-61
+	//DMA modes
+	/*
+	 * bits 0-7: Singleword modes supported (0,1,2)
+	 * bits 8-15: Transfer mode active
+	 */
+	if (sdmaMode > 0)
+		WriteUInt16(identifyData, &index, (u16)(0x07 | (1 << (sdmaMode + 8)))); //word 62
+	else
+		WriteUInt16(identifyData, &index, 0x07); //word 62
+	//DMA Modes
+	/*
+	 * bits 0-7: Multiword modes supported (0,1,2)
+	 * bits 8-15: Transfer mode active
+	 */
+	if (mdmaMode > 0)
+		WriteUInt16(identifyData, &index, (u16)(0x07 | (1 << (mdmaMode + 8)))); //word 63
+	else
+		WriteUInt16(identifyData, &index, 0x07); //word 63
+	//Bit 0-7-PIO modes supported (0,1,2,3,4)
+	WriteUInt16(identifyData, &index, 0x1F); //word 64 (pio3,4 supported) selection not reported here
+	//Minimum Multiword DMA transfer cycle time per word
+	WriteUInt16(identifyData, &index, 80); //word 65
+	//Manufacturer’s recommended Multiword DMA transfer cycle time
+	WriteUInt16(identifyData, &index, 80); //word 66
+	//Minimum PIO transfer cycle time without flow control
+	WriteUInt16(identifyData, &index, 120); //word 67
+	//Minimum PIO transfer cycle time with IORDY flow control
+	WriteUInt16(identifyData, &index, 120); //word 68
+	//Reserved
+	//69-70
+	//Reserved
+	//71-74
+	//Queue depth (4bit, Maximum queue depth - 1)
+	//75
+	//Reserved
+	//76-79
+	index = 80 * 2;
+	//Major revision number (1-3-Obsolete, 4-7-ATA4-7 supported)
+	WriteUInt16(identifyData, &index, 0x70); //word 80
+	//Minor revision number
+	WriteUInt16(identifyData, &index, 0); //word 81
+	//Supported Feature Sets (82)
+	/*
+	 * bit 0: Smart
+	 * bit 1: Security Mode
+	 * bit 2: Removable media feature set
+	 * bit 3: Power management
+	 * bit 4: Packet (the CD features)
+	 * bit 5: Write cache
+	 * bit 6: Look-ahead
+	 * bit 7: Release interrupt
+	 * bit 8: SERVICE interrupt
+	 * bit 9: DEVICE RESET interrupt
+	 * bit 10: Host Protected Area
+	 * bit 11: (Obsolete)
+	 * bit 12: WRITE BUFFER command
+	 * bit 13: READ BUFFER command
+	 * bit 14: NOP
+	 * bit 15: (Obsolete)
+	 */
+	WriteUInt16(identifyData, &index, (u16)((1 << 14) | (1 << 5) | /*(1 << 1) | (1 << 10) |*/ 1)); //word 82
+	//Supported Feature Sets (83)
+	/*
+	 * bit 0: DOWNLOAD MICROCODE
+	 * bit 1: READ/WRITE DMA QUEUED
+	 * bit 2: CFA (Card reader)
+	 * bit 3: Advanced Power Management
+	 * bit 4: Removable Media Status Notifications
+	 * bit 5: Power-Up Standby
+	 * bit 6: SET FEATURES required to spin up after power-up
+	 * bit 7: ??
+	 * bit 8: SET MAX security extension
+	 * bit 9: Automatic Acoustic Management
+	 * bit 10: 48bit LBA
+	 * bit 11: Device Configuration Overlay
+	 * bit 12: FLUSH CACHE
+	 * bit 13: FLUSH CACHE EXT
+	 * bit 14: 1
+	 */
+	WriteUInt16(identifyData, &index, (u16)((1 << 14) | (1 << 13) | (1 << 12) /*| (1 << 8)*/ | ((lba48Supported ? 1 : 0) << 10))); //word 83
+	//Supported Feature Sets (84)
+	/*
+	 * bit 0: Smart error logging
+	 * bit 1: smart self-test
+	 * bit 2: Media serial number
+	 * bit 3: Media Card Pass Though
+	 * bit 4: Streaming feature set
+	 * bit 5: General Purpose Logging
+	 * bit 6: WRITE DMA FUA EXT & WRITE MULTIPLE FUA EXT
+	 * bit 7: WRITE DMA QUEUED FUA EXT
+	 * bit 8: 64bit World Wide Name
+	 * bit 9: URG bit supported for WRITE STREAM DMA EXT amd WRITE STREAM EXT
+	 * bit 10: URG bit supported for READ STREAM DMA EXT amd READ STREAM EXT
+	 * bit 13: IDLE IMMEDIATE with UNLOAD FEATURE
+	 * bit 14: 1
+	 */
+	WriteUInt16(identifyData, &index, (u16)((1 << 14) | (1 << 1) | 1)); //word 84
+	//Command set/feature enabled/supported (See word 82)
+	WriteUInt16(identifyData, &index, (u16)((fetSmartEnabled << 0) | (fetSecurityEnabled << 1) | (fetWriteCacheEnabled << 5) | (fetHostProtectedAreaEnabled << 10) | (1 << 14))); //Fixed      //word 85
+	//Command set/feature enabled/supported (See word 83)
+	WriteUInt16(identifyData, &index, (u16)(
+		/*(1 << 8) |						//SET MAX */
+		((lba48Supported ? 1 : 0) << 10) |	//Fixed
+		(1 << 12) |							//Fixed
+		(1 << 13)));						//Fixed      //word 86
+	//Command set/feature enabled/supported (See word 84)
+	WriteUInt16(identifyData, &index, (u16)((1 << 14) | (1 << 1) | 1));
+	WriteUInt16(identifyData, &index, (u16)(
+		(1) |								//Fixed
+		((1) << 1)));						//Fixed      //word 87
+	//UDMA modes
+	/*
+	 * bits 0-7: ultraword modes supported (0,1,2,4,5,6,7)
+	 * bits 8-15: Transfer mode active
+	 */
+	if (udmaMode > 0)
+		WriteUInt16(identifyData, &index, (u16)(0x7f | (1 << (udmaMode + 8)))); //word 88
+	else
+		WriteUInt16(identifyData, &index, 0x7f); //word 88
+	//Time required for security erase unit completion
+	//89
+	//Time required for Enhanced security erase completion
+	//90
+	//Current advanced power management value
+	//91
+	//Master Password Identifier
+	//92
+	//Hardware reset result. The contents of bits (12:0) of this word shall change only during the execution of a hardware reset.
+	/*
+	 * bit 0: 1
+	 * bit 1-2: How Dev0 determined Dev number (11 = unk)
+	 * bit 3: Dev 0 Passes Diag
+	 * bit 4: Dev 0 Detected assertion of PDIAG
+	 * bit 5: Dev 0 Detected assertion of DSAP
+	 * bit 6: Dev 0 Responds when Dev1 is selected
+	 * bit 7: Reserved
+	 * bit 8: 1
+	 * bit 9-10: How Dev1 determined Dev number
+	 * bit 11: Dev1 asserted 1
+	 * bit 12: Reserved
+	 * bit 13: Dev detected CBLID above Vih
+	 * bit 14: 1
+	 */
+	index = 93 * 2;
+	WriteUInt16(identifyData, &index, (u16)(1 | (1 << 14) | 0x2000)); //word 93
+	//Vendor’s recommended acoustic management value.
+	//94
+	//Stream Minimum Request Size
+	//95
+	//Streaming Transfer Time - DMA
+	//96
+	//Streaming Access Latency - DMA and PIO
+	//97
+	//Streaming Performance Granularity
+	//98-99
+	//Total Number of User Addressable Sectors for the 48-bit Address feature set.
+	index = 100 * 2;
+	WriteUInt64(identifyData, &index, (u16)nbSectors);
+	index -= 2;
+	WriteUInt16(identifyData, &index, 0); //truncate to 48bits
+	//Streaming Transfer Time - PIO
+	//104
+	//Reserved
+	//105
+	//Physical sector size / Logical Sector Size
+	/*
+	 * bit 0-3: 2^X logical sectors per physical sector
+	 * bit 12: Logical sector longer than 512 bytes
+	 * bit 13: multiple logical sectors per physical sector
+	 * bit 14: 1
+	 */
+	index = 106 * 2;
+	WriteUInt16(identifyData, &index, (u16)((1 << 14) | 0));
+	//Inter-seek delay for ISO-7779acoustic testing in microseconds
+	//107
+	//WNN
+	//108-111
+	//Reserved
+	//112-115
+	//Reserved
+	//116
+	//Words per Logical Sector
+	//117-118
+	//Reserved
+	//119-126
+	//Removable Media Status Notification feature support
+	//127
+	//Security status
+	/*
+	 * bit 0: Security supported
+	 * bit 1: Security enabled
+	 * bit 2: Security locked
+	 * bit 3: Security frozen
+	 * bit 4: Security count expired
+	 * bit 5: Enhanced erase supported
+	 * bit 6-7: reserved
+	 * bit 8: is Maximum Security
+	 */
+	//Vendor Specific
+	//129-159
+	//CFA power mode 1
+	//160
+	//Reserved for CFA
+	//161-175
+	//Current media serial number (60 ASCII characters)
+	//176-205
+	//Reserved
+	//206-254
+	//Integrity word
+	//15:8 Checksum, 7:0 Signature
+	CreateHDDinfoCsum();
+}
+void ATA::CreateHDDinfoCsum() //Is this correct?
+{
+	u8 counter = 0;
+
+	for (int i = 0; i < (512 - 1); i++)
+		counter += identifyData[i];
+
+	counter += 0xA5;
+
+	identifyData[510] = 0xA5;
+	identifyData[511] = (u8)(255 - counter + 1);
+	counter = 0;
+
+	for (int i = 0; i < (512); i++)
+		counter += identifyData[i];
+
+	DEV9_LOG_VERB("%s\n", counter);
+}

--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -47,9 +47,9 @@ void ATA::WritePaddedString(u8* data, int* index, std::string value, u32 len)
 void ATA::CreateHDDinfo(int sizeMb)
 {
 	const u16 sectorSize = 512;
-	DEV9_LOG_VERB("HddSize : %i\n", config.HddSize);
+	DevCon.WriteLn("HddSize : %i", config.HddSize);
 	const u64 nbSectors = ((u64)(sizeMb / sectorSize) * 1024 * 1024);
-	DEV9_LOG_VERB("nbSectors : %i\n", nbSectors);
+	DevCon.WriteLn("nbSectors : %i", nbSectors);
 
 	memset(&identifyData, 0, sizeof(identifyData));
 	//Defualt CHS translation
@@ -390,5 +390,5 @@ void ATA::CreateHDDinfoCsum() //Is this correct?
 	for (int i = 0; i < (512); i++)
 		counter += identifyData[i];
 
-	DEV9_LOG_VERB("%s\n", counter);
+	DevCon.WriteLn("%i", counter);
 }

--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -260,6 +260,7 @@ void ATA::CreateHDDinfo(int sizeMb)
 	//Command set/feature enabled/supported (See word 82)
 	WriteUInt16(identifyData, &index, (u16)((fetSmartEnabled << 0) | (fetSecurityEnabled << 1) | (fetWriteCacheEnabled << 5) | (fetHostProtectedAreaEnabled << 10) | (1 << 14))); //Fixed      //word 85
 	//Command set/feature enabled/supported (See word 83)
+	// clang-format off
 	WriteUInt16(identifyData, &index, (u16)(
 		/*(1 << 8) |						//SET MAX */
 		((lba48Supported ? 1 : 0) << 10) |	//Fixed
@@ -270,6 +271,7 @@ void ATA::CreateHDDinfo(int sizeMb)
 	WriteUInt16(identifyData, &index, (u16)(
 		(1) |								//Fixed
 		((1) << 1)));						//Fixed      //word 87
+	// clang-format on
 	//UDMA modes
 	/*
 	 * bits 0-7: ultraword modes supported (0,1,2,4,5,6,7)

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -1,0 +1,446 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "ATA.h"
+#include "../DEV9.h"
+#include "HddCreate.h"
+
+ATA::ATA()
+{
+	//Power on, Would do self-Diag + Hardware Init
+	ResetBegin();
+	ResetEnd(true);
+}
+
+int ATA::Open(ghc::filesystem::path hddPath)
+{
+	readBufferLen = 256 * 512;
+	readBuffer = new u8[readBufferLen];
+
+	CreateHDDinfo(config.HddSize);
+
+	//Open File
+	if (ghc::filesystem::exists(hddPath))
+		hddImage = ghc::filesystem::fstream(hddPath, std::ios::in | std::ios::out | std::ios::binary);
+	else
+	{
+		HddCreate hddCreator;
+		hddCreator.filePath = hddPath;
+		hddCreator.neededSize = config.HddSize;
+		hddCreator.Start();
+
+		if (hddCreator.errored)
+			return -1;
+
+		hddImage = ghc::filesystem::fstream(hddPath);
+	}
+
+	//Store HddImage size for later check
+	hddImage.seekg(0, std::ios::end);
+	hddImageSize = hddImage.tellg();
+
+	//Setup Write queue
+	tail = new WriteQueueEntry();
+	head = tail;
+
+	{
+		std::lock_guard ioSignallock(ioMutex);
+		ioRead = false;
+		ioWrite = false;
+	}
+
+	ioThread = std::thread(&ATA::IO_Thread, this);
+	ioRunning = true;
+
+	return 0;
+}
+
+void ATA::Close()
+{
+	//Wait for async code to finish
+	if (ioRunning)
+	{
+		ioClose.store(true);
+		{
+			std::lock_guard ioSignallock(ioMutex);
+			ioWrite = true;
+		}
+		ioReady.notify_all();
+
+		ioThread.join();
+		ioRunning = false;
+	}
+	//Delete queue
+	if (head != nullptr)
+	{
+		if (!IsQueueEmpty())
+		{
+			DEV9_LOG_ERROR("Write queue not empty");
+			pxAssert(false);
+			abort(); //All data must be written at this point
+		}
+
+		delete head;
+		head = nullptr;
+		tail = nullptr;
+	}
+	//Close File Handle
+	if (hddImage.is_open())
+		hddImage.close();
+
+	delete[] readBuffer;
+	readBuffer = nullptr;
+}
+
+void ATA::ResetBegin()
+{
+	PreCmdExecuteDeviceDiag();
+}
+void ATA::ResetEnd(bool hard)
+{
+	curHeads = 16;
+	curSectors = 63;
+	curCylinders = 0;
+	curMultipleSectorsSetting = 128;
+
+	//UDMA Mode setting is preserved
+	//across SRST
+	if (hard)
+	{
+		pioMode = 4;
+		sdmaMode = -1;
+		mdmaMode = 2;
+		udmaMode = -1;
+	}
+	else
+	{
+		pioMode = 4;
+		if (udmaMode == -1)
+		{
+			sdmaMode = -1;
+			mdmaMode = 2;
+		}
+	}
+
+	regControlEnableIRQ = false;
+	HDD_ExecuteDeviceDiag();
+	regControlEnableIRQ = true;
+}
+
+void ATA::ATA_HardReset()
+{
+	DEV9_LOG_VERB("*ATA_HARD RESET\n");
+	ResetBegin();
+	ResetEnd(true);
+}
+
+u16 ATA::Read16(u32 addr)
+{
+	switch (addr)
+	{
+		case ATA_R_DATA:
+			return ATAreadPIO();
+		case ATA_R_ERROR:
+			DEV9_LOG_VERB("*ATA_R_ERROR 16bit read at address %x, value %x, Active %s\n", addr, regError, (GetSelectedDevice() == 0) ? "True" : "False");
+			if (GetSelectedDevice() != 0)
+				return 0;
+			return regError;
+		case ATA_R_NSECTOR:
+			DEV9_LOG_VERB("*ATA_R_NSECTOR 16bit read at address %x, value %x, Active %s\n", addr, nsector, (GetSelectedDevice() == 0) ? "True" : "False");
+			if (GetSelectedDevice() != 0)
+				return 0;
+			if (!regControlHOBRead)
+				return regNsector;
+			else
+				return regNsectorHOB;
+		case ATA_R_SECTOR:
+			DEV9_LOG_VERB("*ATA_R_NSECTOR 16bit read at address %x, value %x, Active %s\n", addr, regSector, (GetSelectedDevice() == 0) ? "True" : "False");
+			if (GetSelectedDevice() != 0)
+				return 0;
+			if (!regControlHOBRead)
+				return regSector;
+			else
+				return regSectorHOB;
+		case ATA_R_LCYL:
+			DEV9_LOG_VERB("*ATA_R_LCYL 16bit read at address %x, value %x, Active %s\n", addr, regLcyl, (GetSelectedDevice() == 0) ? "True" : "False");
+			if (GetSelectedDevice() != 0)
+				return 0;
+			if (!regControlHOBRead)
+				return regLcyl;
+			else
+				return regLcylHOB;
+		case ATA_R_HCYL:
+			DEV9_LOG_VERB("*ATA_R_HCYL 16bit read at address % x, value % x, Active %s\n", addr, regHcyl, (GetSelectedDevice() == 0) ? " True " : " False ");
+			if (GetSelectedDevice() != 0)
+				return 0;
+			if (!regControlHOBRead)
+				return regHcyl;
+			else
+				return regHcylHOB;
+		case ATA_R_SELECT:
+			DEV9_LOG_VERB("*ATA_R_SELECT 16bit read at address % x, value % x, Active %s\n", addr, regSelect, (GetSelectedDevice() == 0) ? " True " : " False ");
+			return regSelect;
+		case ATA_R_STATUS:
+			DEV9_LOG_VERB("*ATA_R_STATUS (Fallthough to ATA_R_ALT_STATUS)\n");
+			//Clear irqcause
+			dev9.irqcause &= ~ATA_INTR_INTRQ;
+			[[fallthrough]];
+		case ATA_R_ALT_STATUS:
+			DEV9_LOG_VERB("*ATA_R_ALT_STATUS 16bit read at address % x, value % x, Active %s\n", addr, regStatus, (GetSelectedDevice() == 0) ? " True " : " False ");
+			//raise IRQ?
+			if (GetSelectedDevice() != 0)
+				return 0;
+			return regStatus;
+		default:
+			DEV9_LOG_ERROR("*Unknown 16bit read at address %x\n", addr);
+			return 0xff;
+	}
+}
+
+void ATA::Write16(u32 addr, u16 value)
+{
+	if (addr != ATA_R_CMD && (regStatus & (ATA_STAT_BUSY | ATA_STAT_DRQ)) != 0)
+	{
+		DEV9_LOG_ERROR("*DEVICE BUSY, DROPPING WRITE\n");
+		return;
+	}
+	switch (addr)
+	{
+		case ATA_R_FEATURE:
+			DEV9_LOG_VERB("*ATA_R_FEATURE 16bit write at address %x, value %x\n", addr, value);
+			ClearHOB();
+			regFeatureHOB = regFeature;
+			regFeature = (u8)value;
+			break;
+		case ATA_R_NSECTOR:
+			DEV9_LOG_VERB("*ATA_R_NSECTOR 16bit write at address %x, value %x\n", addr, value);
+			ClearHOB();
+			regNsectorHOB = regNsector;
+			regNsector = (u8)value;
+			break;
+		case ATA_R_SECTOR:
+			DEV9_LOG_VERB("*ATA_R_SECTOR 16bit write at address %x, value %x\n", addr, value);
+			ClearHOB();
+			regSectorHOB = regSector;
+			regSector = (u8)value;
+			break;
+		case ATA_R_LCYL:
+			DEV9_LOG_VERB("*ATA_R_LCYL 16bit write at address %x, value %x\n", addr, value);
+			ClearHOB();
+			regLcylHOB = regLcyl;
+			regLcyl = (u8)value;
+			break;
+		case ATA_R_HCYL:
+			DEV9_LOG_VERB("*ATA_R_HCYL 16bit write at address %x, value %x\n", addr, value);
+			ClearHOB();
+			regHcylHOB = regHcyl;
+			regHcyl = (u8)value;
+			break;
+		case ATA_R_SELECT:
+			DEV9_LOG_VERB("*ATA_R_SELECT 16bit write at address %x, value %x\n", addr, value);
+			regSelect = (u8)value;
+			//bus->ifs[0].select = (val & ~0x10) | 0xa0;
+			//bus->ifs[1].select = (val | 0x10) | 0xa0;
+			break;
+		case ATA_R_CONTROL:
+			DEV9_LOG_VERB("*ATA_R_CONTROL 16bit write at address %x, value %x\n", addr, value);
+			//dev9Ru16(ATA_R_CONTROL) = value;
+			if ((value & 0x2) != 0)
+			{
+				//Supress all IRQ
+				dev9.irqcause &= ~ATA_INTR_INTRQ;
+				regControlEnableIRQ = false;
+			}
+			else
+				regControlEnableIRQ = true;
+
+			if ((value & 0x4) != 0)
+			{
+				DEV9_LOG_VERB("*ATA_R_CONTROL RESET\n");
+				ResetBegin();
+				ResetEnd(false);
+			}
+			if ((value & 0x80) != 0)
+				regControlHOBRead = true;
+
+			break;
+		case ATA_R_CMD:
+			DEV9_LOG_VERB("*ATA_R_CMD 16bit write at address %x, value %x\n", addr, value);
+			regCommand = value;
+			regControlHOBRead = false;
+			dev9.irqcause &= ~ATA_INTR_INTRQ;
+			IDE_ExecCmd(value);
+			break;
+		default:
+			DEV9_LOG_ERROR("*UNKOWN 16bit write at address %x, value %x\n", addr, value);
+			break;
+	}
+}
+
+void ATA::Async(uint cycles)
+{
+	if (!hddImage.is_open())
+		return;
+
+	if ((regStatus & (ATA_STAT_BUSY | ATA_STAT_DRQ)) == 0 ||
+		awaitFlush || (waitingCmd != nullptr))
+	{
+		{
+			std::lock_guard ioSignallock(ioMutex);
+			if (ioRead || ioWrite)
+				//IO Running
+				return;
+		}
+
+		//Note, ioThread may still be working.
+		if (waitingCmd != nullptr) //Are we waiting to continue a command?
+		{
+			//Log_Info("Running waiting command");
+			void(ATA::*cmd)() = waitingCmd;
+			waitingCmd = nullptr;
+			(this->*cmd)();
+		}
+		else if (!IsQueueEmpty()) //Flush cache
+		{
+			//Log_Info("Starting async write");
+			{
+				std::lock_guard ioSignallock(ioMutex);
+				ioWrite = true;
+			}
+			ioReady.notify_all();
+		}
+		else if (awaitFlush) //Fire IRQ on flush completion?
+		{
+			//Log_Info("Flush done, raise IRQ");
+			awaitFlush = false;
+			PostCmdNoData();
+		}
+	}
+}
+
+s64 ATA::HDD_GetLBA()
+{
+	if ((regSelect & 0x40) != 0)
+	{
+		if (!lba48)
+		{
+			return (regSector |
+					(regLcyl << 8) |
+					(regHcyl << 16) |
+					((regSelect & 0x0f) << 24));
+		}
+		else
+		{
+			return ((s64)regHcylHOB << 40) |
+				   ((s64)regLcylHOB << 32) |
+				   ((s64)regSectorHOB << 24) |
+				   ((s64)regHcyl << 16) |
+				   ((s64)regLcyl << 8) |
+				   regSector;
+		}
+	}
+	else
+	{
+		regStatus |= (u8)ATA_STAT_ERR;
+		regError |= (u8)ATA_ERR_ABORT;
+
+		DEV9_LOG_ERROR("DEV9 ERROR : tried to get LBA address while LBA mode disabled\n");
+		//(c.Nh + h).Ns+(s-1)
+		//s64 CHSasLBA = ((regLcyl + (regHcyl << 8)) * curHeads + (regSelect & 0x0F)) * curSectors + (regSector - 1);
+		return -1;
+	}
+}
+
+void ATA::HDD_SetLBA(s64 sectorNum)
+{
+	if ((regSelect & 0x40) != 0)
+	{
+		if (!lba48)
+		{
+			regSelect = (u8)((regSelect & 0xf0) | (int)((sectorNum >> 24) & 0x0f));
+			regHcyl = (u8)(sectorNum >> 16);
+			regLcyl = (u8)(sectorNum >> 8);
+			regSector = (u8)(sectorNum);
+		}
+		else
+		{
+			regSector = (u8)sectorNum;
+			regLcyl = (u8)(sectorNum >> 8);
+			regHcyl = (u8)(sectorNum >> 16);
+			regSectorHOB = (u8)(sectorNum >> 24);
+			regLcylHOB = (u8)(sectorNum >> 32);
+			regHcylHOB = (u8)(sectorNum >> 40);
+		}
+	}
+	else
+	{
+		regStatus |= ATA_STAT_ERR;
+		regError |= ATA_ERR_ABORT;
+
+		DEV9_LOG_ERROR("DEV9 ERROR : tried to get LBA address while LBA mode disabled\n");
+	}
+}
+
+bool ATA::HDD_CanSeek()
+{
+	int sectors = 0;
+	return HDD_CanAccess(&sectors);
+}
+
+bool ATA::HDD_CanAccess(int* sectors)
+{
+	s64 lba;
+	s64 posStart;
+	s64 posEnd;
+	s64 maxLBA;
+
+	maxLBA = std::min<s64>((s64)config.HddSize * 1024 * 1024 / 512, hddImageSize);
+	if ((regSelect & 0x40) == 0) //CHS mode
+		maxLBA = std::min<s64>(maxLBA, curCylinders * curHeads * curSectors);
+
+	lba = HDD_GetLBA();
+	if (lba == -1)
+		return false;
+
+	DEV9_LOG_VERB("LBA :%i\n", lba);
+	posStart = lba;
+
+	if (posStart > maxLBA)
+	{
+		*sectors = -1;
+		return false;
+	}
+
+	posEnd = posStart + *sectors;
+
+	if (posEnd > maxLBA)
+	{
+		const s64 overshoot = posEnd - maxLBA;
+		s64 space = *sectors - overshoot;
+		*sectors = (int)space;
+		return false;
+	}
+
+	return true;
+}
+
+//QEMU stuff
+void ATA::ClearHOB()
+{
+	/* any write clears HOB high bit of device control register */
+	regControlHOBRead = false;
+}

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -310,7 +310,7 @@ void ATA::Async(uint cycles)
 		if (waitingCmd != nullptr) //Are we waiting to continue a command?
 		{
 			//Log_Info("Running waiting command");
-			void(ATA::*cmd)() = waitingCmd;
+			void (ATA::*cmd)() = waitingCmd;
 			waitingCmd = nullptr;
 			(this->*cmd)();
 		}

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -1,0 +1,250 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "ATA.h"
+#include "../DEV9.h"
+
+void ATA::IO_Thread()
+{
+	std::unique_lock ioWaitHandle(ioMutex);
+	ioThreadIdle_bool = false;
+	ioWaitHandle.unlock();
+
+	while (true)
+	{
+		ioWaitHandle.lock();
+		ioThreadIdle_bool = true;
+		ioThreadIdle_cv.notify_all();
+
+		ioReady.wait(ioWaitHandle, [&] { return ioRead | ioWrite; });
+		ioThreadIdle_bool = false;
+
+		int ioType = -1;
+		if (ioRead)
+			ioType = 0;
+		else if (ioWrite)
+			ioType = 1;
+		
+		ioWaitHandle.unlock();
+
+		//Read or Write
+		if (ioType == 0)
+			IO_Read();
+		else if (ioType == 1)
+		{
+			if (!IO_Write())
+			{
+				if (ioClose.load())
+				{
+					ioClose.store(false);
+					ioWaitHandle.lock();
+					ioThreadIdle_bool = true;
+					ioWaitHandle.unlock();
+					return;
+				}
+			}
+		}
+	}
+}
+
+void ATA::IO_Read()
+{
+	const s64 lba = HDD_GetLBA();
+
+	if (lba == -1)
+	{
+		DEV9_LOG_ERROR("Invalid LBA");
+		pxAssert(false);
+		abort();
+	}
+
+	const u64 pos = lba * 512;
+	hddImage.seekg(pos, std::ios::beg);
+	if (hddImage.fail())
+	{
+		DEV9_LOG_ERROR("Read error");
+		pxAssert(false);
+		abort();
+	}
+	hddImage.read((char*)readBuffer, (u64)nsector * 512);
+	{
+		std::lock_guard ioSignallock(ioMutex);
+		ioRead = false;
+	}
+}
+
+bool ATA::IO_Write()
+{
+	u64 sector = 0;
+	u8* data = nullptr;
+	u32 len = 0;
+	if (!DequeueWrite(&sector, &data, &len))
+	{
+		std::lock_guard ioSignallock(ioMutex);
+		ioWrite = false;
+		return false;
+	}
+
+	hddImage.seekp(sector * 512, std::ios::beg);
+	hddImage.write((char*)data, len);
+	if (hddImage.fail())
+	{
+		DEV9_LOG_ERROR("Write error");
+		pxAssert(false);
+		abort();
+	}
+	hddImage.flush();
+	delete[] data;
+	return true;
+}
+
+void ATA::HDD_ReadAsync(void (ATA::*drqCMD)())
+{
+	nsectorLeft = 0;
+
+	if (!HDD_CanAssessOrSetError())
+		return;
+
+	nsectorLeft = nsector;
+	if (readBufferLen < nsector * 512)
+	{
+		delete readBuffer;
+		readBuffer = new u8[nsector * 512];
+		readBufferLen = nsector * 512;
+	}
+	waitingCmd = drqCMD;
+
+	{
+		std::lock_guard ioSignallock(ioMutex);
+		ioRead = true;
+	}
+	ioReady.notify_all();
+}
+
+//Note, we don't expect both Async & Sync Reads
+//Do one of the other
+void ATA::HDD_ReadSync(void (ATA::*drqCMD)())
+{
+	//unique_lock instead of lock_guard as also used for cv
+	std::unique_lock ioWaitHandle(ioMutex);
+	//Set ioWrite false to prevent reading & writing at the same time
+	const bool ioWritePaused = ioWrite;
+	ioWrite = false;
+
+	//wait until thread waiting
+	ioThreadIdle_cv.wait(ioWaitHandle, [&] { return ioThreadIdle_bool; });
+	ioWaitHandle.unlock();
+
+	nsectorLeft = 0;
+
+	if (!HDD_CanAssessOrSetError())
+	{
+		if (ioWritePaused)
+		{
+			ioWaitHandle.lock();
+			ioWrite = true;
+			ioWaitHandle.unlock();
+			ioReady.notify_all();
+		}
+		return;
+	}
+
+	nsectorLeft = nsector;
+	if (readBufferLen < nsector * 512)
+	{
+		delete[] readBuffer;
+		readBuffer = new u8[nsector * 512];
+		readBufferLen = nsector * 512;
+	}
+
+	IO_Read();
+
+	if (ioWritePaused)
+	{
+		ioWaitHandle.lock();
+		ioWrite = true;
+		ioWaitHandle.unlock();
+		ioReady.notify_all();
+	}
+
+	(this->*drqCMD)();
+}
+
+bool ATA::HDD_CanAssessOrSetError()
+{
+	if (!HDD_CanAccess(&nsector))
+	{
+		//Read what we can
+		regStatus |= (u8)ATA_STAT_ERR;
+		regError |= (u8)ATA_ERR_ID;
+		if (nsector == -1)
+		{
+			PostCmdNoData();
+			return false;
+		}
+	}
+	return true;
+}
+void ATA::HDD_SetErrorAtTransferEnd()
+{
+	u64 currSect = HDD_GetLBA();
+	currSect += nsector;
+	if ((regStatus & ATA_STAT_ERR) != 0)
+	{
+		//Error condition
+		//Write errored sector to LBA
+		currSect++;
+		HDD_SetLBA(currSect);
+	}
+}
+
+//Used by EE thread only
+void ATA::QueueWrite(u64 sector, u8* data, u32 length)
+{
+	WriteQueueEntry* newEntry = head;
+	newEntry->data = data;
+	newEntry->length = length;
+	newEntry->sector = sector;
+
+	//Allocate Next entry
+	newEntry->next = new WriteQueueEntry();
+	head = newEntry->next;
+	//Set ready
+	newEntry->ready.store(true);
+}
+
+//Used by IO thread only
+bool ATA::DequeueWrite(u64* sector, u8** data, u32* length)
+{
+	if (!tail->ready.load())
+		return false;
+
+	WriteQueueEntry* entry = tail;
+	tail = entry->next;
+
+	*sector = entry->sector;
+	*data = entry->data;
+	*length = entry->length;
+	delete entry;
+	return true;
+}
+
+//Used by EE thread only
+bool ATA::IsQueueEmpty()
+{
+	return !tail->ready.load();
+}

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -67,7 +67,7 @@ void ATA::IO_Read()
 
 	if (lba == -1)
 	{
-		DEV9_LOG_ERROR("Invalid LBA");
+		Console.Error("ATA: Invalid LBA");
 		pxAssert(false);
 		abort();
 	}
@@ -76,7 +76,7 @@ void ATA::IO_Read()
 	hddImage.seekg(pos, std::ios::beg);
 	if (hddImage.fail())
 	{
-		DEV9_LOG_ERROR("Read error");
+		Console.Error("ATA: File read error");
 		pxAssert(false);
 		abort();
 	}
@@ -103,7 +103,7 @@ bool ATA::IO_Write()
 	hddImage.write((char*)data, len);
 	if (hddImage.fail())
 	{
-		DEV9_LOG_ERROR("Write error");
+		Console.Error("ATA: File write error");
 		pxAssert(false);
 		abort();
 	}

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -38,7 +38,7 @@ void ATA::IO_Thread()
 			ioType = 0;
 		else if (ioWrite)
 			ioType = 1;
-		
+
 		ioWaitHandle.unlock();
 
 		//Read or Write

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -92,8 +92,7 @@ void ATA::ATAreadDMA8Mem(u8* pMem, int size)
 	{
 		if (size == 0)
 			return;
-
-		DEV9_LOG_VERB("DMA read, size %i, transferred %i, total size %i\n", size, rdTransferred, nsector * 512);
+		DevCon.WriteLn("DMA read, size %i, transferred %i, total size %i", size, rdTransferred, nsector * 512);
 
 		//read
 		memcpy(pMem, &readBuffer[rdTransferred], size);
@@ -116,7 +115,7 @@ void ATA::ATAwriteDMA8Mem(u8* pMem, int size)
 	if ((udmaMode >= 0) &&
 		(dev9.if_ctrl & SPD_IF_ATA_DMAEN) != 0)
 	{
-		DEV9_LOG_VERB("DMA write, size %i, transferred %i, total size %i\n", size, wrTransferred, nsector * 512);
+		DevCon.WriteLn("DMA write, size %i, transferred %i, total size %i", size, wrTransferred, nsector * 512);
 
 		//write
 		memcpy(&currentWrite[wrTransferred], pMem, size);
@@ -140,7 +139,7 @@ void ATA::HDD_ReadDMA(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_VERB("HDD_ReadDMA\n");
+	DevCon.WriteLn("HDD_ReadDMA");
 
 	IDE_CmdLBA48Transform(isLBA48);
 
@@ -160,7 +159,7 @@ void ATA::HDD_WriteDMA(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_VERB("HDD_WriteDMA\n");
+	DevCon.WriteLn("HDD_WriteDMA");
 
 	IDE_CmdLBA48Transform(isLBA48);
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -1,0 +1,177 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::DRQCmdDMADataToHost()
+{
+	//Ready to Start DMA
+	regStatus &= ~ATA_STAT_BUSY;
+	regStatus |= ATA_STAT_DRQ;
+	dmaReady = true;
+	_DEV9irq(SPD_INTR_ATA_FIFO_DATA, 1);
+	//PCSX2 will Start DMA
+}
+void ATA::PostCmdDMADataToHost()
+{
+	//readBuffer = null;
+	nsectorLeft = 0;
+
+	regStatus &= ~ATA_STAT_DRQ;
+	regStatus &= ~ATA_STAT_BUSY;
+	dmaReady = false;
+
+	dev9.irqcause &= ~SPD_INTR_ATA_FIFO_DATA;
+	if (regControlEnableIRQ)
+		_DEV9irq(ATA_INTR_INTRQ, 1);
+	//PCSX2 Will Start DMA
+}
+
+void ATA::DRQCmdDMADataFromHost()
+{
+	//Ready to Start DMA
+	if (!HDD_CanAssessOrSetError())
+		return;
+
+	nsectorLeft = nsector;
+	currentWrite = new u8[nsector * 512];
+	currentWriteLength = nsector * 512;
+	currentWriteSectors = HDD_GetLBA();
+
+
+	regStatus &= ~ATA_STAT_BUSY;
+	regStatus |= ATA_STAT_DRQ;
+	dmaReady = true;
+	_DEV9irq(SPD_INTR_ATA_FIFO_DATA, 1);
+	//PCSX2 will Start DMA
+}
+void ATA::PostCmdDMADataFromHost()
+{
+	QueueWrite(currentWriteSectors, currentWrite, currentWriteLength);
+	currentWrite = nullptr;
+	currentWriteLength = 0;
+	currentWriteSectors = 0;
+	nsectorLeft = 0;
+
+	regStatus &= ~ATA_STAT_DRQ;
+	dmaReady = false;
+
+	dev9.irqcause &= ~SPD_INTR_ATA_FIFO_DATA;
+
+	if (fetWriteCacheEnabled)
+	{
+		regStatus &= ~ATA_STAT_BUSY;
+		if (regControlEnableIRQ)
+			_DEV9irq(ATA_INTR_INTRQ, 1); //0x6C
+	}
+	else
+		awaitFlush = true;
+
+	Async(-1);
+}
+
+void ATA::ATAreadDMA8Mem(u8* pMem, int size)
+{
+	if ((udmaMode >= 0) &&
+		(dev9.if_ctrl & SPD_IF_ATA_DMAEN) != 0)
+	{
+		if (size == 0)
+			return;
+
+		DEV9_LOG_VERB("DMA read, size %i, transferred %i, total size %i\n", size, rdTransferred, nsector * 512);
+
+		//read
+		memcpy(pMem, &readBuffer[rdTransferred], size);
+
+		rdTransferred += size;
+
+		if (rdTransferred >= nsector * 512)
+		{
+			HDD_SetErrorAtTransferEnd();
+
+			nsector = 0;
+			rdTransferred = 0;
+			PostCmdDMADataToHost();
+		}
+	}
+}
+
+void ATA::ATAwriteDMA8Mem(u8* pMem, int size)
+{
+	if ((udmaMode >= 0) &&
+		(dev9.if_ctrl & SPD_IF_ATA_DMAEN) != 0)
+	{
+		DEV9_LOG_VERB("DMA write, size %i, transferred %i, total size %i\n", size, wrTransferred, nsector * 512);
+
+		//write
+		memcpy(&currentWrite[wrTransferred], pMem, size);
+
+		wrTransferred += size;
+
+		if (wrTransferred >= nsector * 512)
+		{
+			HDD_SetErrorAtTransferEnd();
+
+			nsector = 0;
+			wrTransferred = 0;
+			PostCmdDMADataFromHost();
+		}
+	}
+}
+
+//GENRAL FEATURE SET
+
+void ATA::HDD_ReadDMA(bool isLBA48)
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_VERB("HDD_ReadDMA\n");
+
+	IDE_CmdLBA48Transform(isLBA48);
+
+	if (!HDD_CanSeek())
+	{
+		regStatus |= ATA_STAT_ERR;
+		regError |= ATA_ERR_ID;
+		PostCmdNoData();
+		return;
+	}
+
+	//Do Sync Read
+	HDD_ReadSync(&ATA::DRQCmdDMADataToHost);
+}
+
+void ATA::HDD_WriteDMA(bool isLBA48)
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_VERB("HDD_WriteDMA\n");
+
+	IDE_CmdLBA48Transform(isLBA48);
+
+	if (!HDD_CanSeek())
+	{
+		regStatus |= ATA_STAT_ERR;
+		regError |= ATA_ERR_ID;
+		PostCmdNoData();
+		return;
+	}
+
+	//Do Async write
+	DRQCmdDMADataFromHost();
+}

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdExecuteDeviceDiag.cpp
@@ -1,0 +1,62 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::PreCmdExecuteDeviceDiag()
+{
+	regStatus |= ATA_STAT_BUSY;
+	regStatus &= ~ATA_STAT_READY;
+	dev9.irqcause &= ~ATA_INTR_INTRQ;
+	//dev9.spd.regIntStat &= unchecked((UInt16)~DEV9Header.ATA_INTR_DMA_RDY); //Is this correct?
+}
+
+void ATA::PostCmdExecuteDeviceDiag()
+{
+	regStatus &= ~ATA_STAT_BUSY;
+	regStatus |= ATA_STAT_READY;
+
+	SetSelectedDevice(0);
+
+	if (regControlEnableIRQ)
+		_DEV9irq(ATA_INTR_INTRQ, 1);
+}
+
+//GENRAL FEATURE SET
+
+void ATA::HDD_ExecuteDeviceDiag()
+{
+	PreCmdExecuteDeviceDiag();
+	//Perform Self Diag
+	//Log_Error("ExecuteDeviceDiag");
+	//Would check both drives, but the PS2 would only have 1
+	regError &= ~ATA_ERR_ICRC;
+	//Passed self-Diag
+	regError = (0x01 | (regError & ATA_ERR_ICRC));
+
+	regNsector = 1;
+	regSector = 1;
+	regLcyl = 0;
+	regHcyl = 0;
+
+	regStatus &= ~ATA_STAT_DRQ;
+	regStatus &= ~ATA_STAT_ECC;
+	regStatus &= ~ATA_STAT_ERR;
+
+	PostCmdExecuteDeviceDiag();
+}

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -41,7 +41,7 @@ void ATA::HDD_FlushCache() //Can't when DRQ set
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_VERB("HDD_FlushCache\n");
+	DevCon.WriteLn("HDD_FlushCache");
 
 	awaitFlush = true;
 	Async(-1);
@@ -50,7 +50,7 @@ void ATA::HDD_FlushCache() //Can't when DRQ set
 void ATA::HDD_InitDevParameters()
 {
 	PreCmd(); //Ignore DRDY bit
-	DEV9_LOG_INFO("HDD_InitDevParameters\n");
+	DevCon.WriteLn("HDD_InitDevParameters");
 
 	curSectors = regNsector;
 	curHeads = (u8)((regSelect & 0x7) + 1);
@@ -61,7 +61,7 @@ void ATA::HDD_ReadVerifySectors(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_VERB("HDD_ReadVerifySectors\n");
+	DevCon.WriteLn("HDD_ReadVerifySectors");
 
 	IDE_CmdLBA48Transform(isLBA48);
 
@@ -74,7 +74,7 @@ void ATA::HDD_SeekCmd()
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_INFO("HDD_SeekCmd\n");
+	DevCon.WriteLn("HDD_SeekCmd");
 
 	regStatus &= ~ATA_STAT_SEEK;
 
@@ -93,7 +93,7 @@ void ATA::HDD_SetFeatures()
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_VERB("HDD_SetFeatures\n");
+	DevCon.WriteLn("HDD_SetFeatures");
 
 	switch (regFeature)
 	{
@@ -113,49 +113,49 @@ void ATA::HDD_SetFeatures()
 			{
 				case 0x00: //pio default
 					//if mode = 1, disable IORDY
-					DEV9_LOG_ERROR("PIO Default\n");
+					DevCon.WriteLn("PIO Default");
 					pioMode = 4;
 					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x01: //pio mode (3,4)
-					DEV9_LOG_ERROR("PIO Mode %i\n", mode);
+					DevCon.WriteLn("PIO Mode %i", mode);
 					pioMode = mode;
 					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x02: //Single word dma mode (0,1,2)
-					DEV9_LOG_ERROR("SDMA Mode %i\n", mode);
+					DevCon.WriteLn("SDMA Mode %i", mode);
 					//pioMode = -1;
 					sdmaMode = mode;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x04: //Multi word dma mode (0,1,2)
-					DEV9_LOG_ERROR("MDMA Mode %i\n", mode);
+					DevCon.WriteLn("MDMA Mode %i", mode);
 					//pioMode = -1;
 					sdmaMode = -1;
 					mdmaMode = mode;
 					udmaMode = -1;
 					break;
 				case 0x08: //Ulta dma mode (0,1,2,3,4,5,6)
-					DEV9_LOG_ERROR("UDMA Mode %i\n", mode);
+					DevCon.WriteLn("UDMA Mode %i", mode);
 					//pioMode = -1;
 					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = mode;
 					break;
 				default:
-					DEV9_LOG_ERROR("Unkown transfer mode\n");
+					Console.Error("ATA: Unkown transfer mode");
 					CmdNoDataAbort();
 					break;
 			}
 		}
 		break;
 		default:
-			DEV9_LOG_ERROR("Unkown feature mode\n");
+			Console.Error("ATA: Unkown feature mode");
 			break;
 	}
 	PostCmdNoData();
@@ -165,7 +165,7 @@ void ATA::HDD_SetMultipleMode()
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_INFO("HDD_SetMultipleMode\n");
+	DevCon.WriteLn("HDD_SetMultipleMode");
 
 	curMultipleSectorsSetting = regNsector;
 
@@ -176,8 +176,7 @@ void ATA::HDD_Nop()
 {
 	if (!PreCmd())
 		return;
-
-	DEV9_LOG_INFO("HDD_Nop\n");
+	DevCon.WriteLn("HDD_Nop");
 
 	if (regFeature == 0)
 	{
@@ -196,8 +195,7 @@ void ATA::HDD_Idle()
 {
 	if (!PreCmd())
 		return;
-
-	DEV9_LOG_VERB("HDD_Idle\n");
+	DevCon.WriteLn("HDD_Idle");
 
 	long idleTime = 0; //in seconds
 	if (regNsector >= 1 && regNsector <= 240)
@@ -229,6 +227,6 @@ void ATA::HDD_Idle()
 		}
 	}
 
-	DEV9_LOG_VERB("HDD_Idle for %is\n", idleTime);
+	DevCon.WriteLn("HDD_Idle for %is", idleTime);
 	PostCmdNoData();
 }

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -1,0 +1,234 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::PostCmdNoData()
+{
+	regStatus &= ~ATA_STAT_BUSY;
+
+	if (regControlEnableIRQ)
+		_DEV9irq(ATA_INTR_INTRQ, 1);
+}
+
+void ATA::CmdNoDataAbort()
+{
+	PreCmd();
+
+	regError |= ATA_ERR_ABORT;
+	regStatus |= ATA_STAT_ERR;
+	PostCmdNoData();
+}
+
+//GENRAL FEATURE SET
+
+void ATA::HDD_FlushCache() //Can't when DRQ set
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_VERB("HDD_FlushCache\n");
+
+	awaitFlush = true;
+	Async(-1);
+}
+
+void ATA::HDD_InitDevParameters()
+{
+	PreCmd(); //Ignore DRDY bit
+	DEV9_LOG_INFO("HDD_InitDevParameters\n");
+
+	curSectors = regNsector;
+	curHeads = (u8)((regSelect & 0x7) + 1);
+	PostCmdNoData();
+}
+
+void ATA::HDD_ReadVerifySectors(bool isLBA48)
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_VERB("HDD_ReadVerifySectors\n");
+
+	IDE_CmdLBA48Transform(isLBA48);
+
+	HDD_CanAssessOrSetError();
+
+	PostCmdNoData();
+}
+
+void ATA::HDD_SeekCmd()
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_INFO("HDD_SeekCmd\n");
+
+	regStatus &= ~ATA_STAT_SEEK;
+
+	if (HDD_CanSeek())
+	{
+		regStatus |= ATA_STAT_ERR;
+		regError |= ATA_ERR_ID;
+	}
+	else
+		regStatus |= ATA_STAT_SEEK;
+
+	PostCmdNoData();
+}
+
+void ATA::HDD_SetFeatures()
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_VERB("HDD_SetFeatures\n");
+
+	switch (regFeature)
+	{
+		case 0x02:
+			fetWriteCacheEnabled = true;
+			break;
+		case 0x82:
+			fetWriteCacheEnabled = false;
+			awaitFlush = true; //Flush Cache
+			return;
+		case 0x03: //Set transfer mode
+		{
+			const u16 xferMode = (u16)regNsector; //Set Transfer mode
+
+			const int mode = xferMode & 0x07;
+			switch ((xferMode) >> 3)
+			{
+				case 0x00: //pio default
+					//if mode = 1, disable IORDY
+					DEV9_LOG_ERROR("PIO Default\n");
+					pioMode = 4;
+					sdmaMode = -1;
+					mdmaMode = -1;
+					udmaMode = -1;
+					break;
+				case 0x01: //pio mode (3,4)
+					DEV9_LOG_ERROR("PIO Mode %i\n", mode);
+					pioMode = mode;
+					sdmaMode = -1;
+					mdmaMode = -1;
+					udmaMode = -1;
+					break;
+				case 0x02: //Single word dma mode (0,1,2)
+					DEV9_LOG_ERROR("SDMA Mode %i\n", mode);
+					//pioMode = -1;
+					sdmaMode = mode;
+					mdmaMode = -1;
+					udmaMode = -1;
+					break;
+				case 0x04: //Multi word dma mode (0,1,2)
+					DEV9_LOG_ERROR("MDMA Mode %i\n", mode);
+					//pioMode = -1;
+					sdmaMode = -1;
+					mdmaMode = mode;
+					udmaMode = -1;
+					break;
+				case 0x08: //Ulta dma mode (0,1,2,3,4,5,6)
+					DEV9_LOG_ERROR("UDMA Mode %i\n", mode);
+					//pioMode = -1;
+					sdmaMode = -1;
+					mdmaMode = -1;
+					udmaMode = mode;
+					break;
+				default:
+					DEV9_LOG_ERROR("Unkown transfer mode\n");
+					CmdNoDataAbort();
+					break;
+			}
+		}
+		break;
+		default:
+			DEV9_LOG_ERROR("Unkown feature mode\n");
+			break;
+	}
+	PostCmdNoData();
+}
+
+void ATA::HDD_SetMultipleMode()
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_INFO("HDD_SetMultipleMode\n");
+
+	curMultipleSectorsSetting = regNsector;
+
+	PostCmdNoData();
+}
+
+void ATA::HDD_Nop()
+{
+	if (!PreCmd())
+		return;
+
+	DEV9_LOG_INFO("HDD_Nop\n");
+
+	if (regFeature == 0)
+	{
+		//This would abort queues if the
+		//PS2 HDD supported them.
+	}
+	//Always ends in error
+	regError |= ATA_ERR_ABORT;
+	regStatus |= ATA_STAT_ERR;
+	PostCmdNoData();
+}
+
+//Other Feature Sets
+
+void ATA::HDD_Idle()
+{
+	if (!PreCmd())
+		return;
+
+	DEV9_LOG_VERB("HDD_Idle\n");
+
+	long idleTime = 0; //in seconds
+	if (regNsector >= 1 && regNsector <= 240)
+		idleTime = 5 * regNsector;
+	else if (regNsector >= 241 && regNsector <= 251)
+		idleTime = 30 * (regNsector - 240) * 60;
+	else
+	{
+		switch (regNsector)
+		{
+			case 0:
+				idleTime = 0;
+				break;
+			case 252:
+				idleTime = 21 * 60;
+				break;
+			case 253: //bettween 8 and 12 hrs
+				idleTime = 10 * 60 * 60;
+				break;
+			case 254: //reserved
+				idleTime = -1;
+				break;
+			case 255:
+				idleTime = 21 * 60 + 15;
+				break;
+			default:
+				idleTime = 0;
+				break;
+		}
+	}
+
+	DEV9_LOG_VERB("HDD_Idle for %is\n", idleTime);
+	PostCmdNoData();
+}

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -1,0 +1,155 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::DRQCmdPIODataToHost(u8* buff, int buffLen, int buffIndex, int size, bool sendIRQ)
+{
+	//Data in PIO ready to be sent
+	pioPtr = 0;
+	pioEnd = size >> 1;
+
+	memcpy(pioBuffer, &buff[buffIndex], size < (buffLen - buffIndex) ? size : (buffLen - buffIndex));
+
+	regStatus &= ~ATA_STAT_BUSY;
+	regStatus |= ATA_STAT_DRQ;
+
+	if (regControlEnableIRQ && sendIRQ)
+		_DEV9irq(ATA_INTR_INTRQ, 1); //0x6c cycles before
+}
+void ATA::PostCmdPIODataToHost()
+{
+	pioPtr = 0;
+	pioEnd = 0;
+	//AnyMoreData?
+	if (pioDRQEndTransferFunc != nullptr)
+	{
+		regStatus |= ATA_STAT_BUSY;
+		regStatus &= ~ATA_STAT_DRQ;
+		//Call cmd to retrive more data
+		(this->*pioDRQEndTransferFunc)();
+	}
+	else
+		regStatus &= ~ATA_STAT_DRQ;
+}
+
+//FromHost
+u16 ATA::ATAreadPIO()
+{
+	DEV9_LOG_VERB("*ATA_R_DATA 16bit read, pio_count %i,  pio_size %i\n", pioPtr, pioEnd);
+	if (pioPtr < pioEnd)
+	{
+		const u16 ret = *(u16*)&pioBuffer[pioPtr * 2];
+		DEV9_LOG_VERB("*ATA_R_DATA returned value is  %x\n", ret);
+		pioPtr++;
+		if (pioPtr >= pioEnd) //Fnished transfer (Changed from MegaDev9)
+			PostCmdPIODataToHost();
+
+		return ret;
+	}
+	return 0xFF;
+}
+//ATAwritePIO
+
+void ATA::HDD_IdentifyDevice()
+{
+	if (!PreCmd())
+		return;
+	DEV9_LOG_VERB("HddidentifyDevice\n");
+
+	//IDE transfer start
+	CreateHDDinfo(config.HddSize);
+
+	pioDRQEndTransferFunc = nullptr;
+	DRQCmdPIODataToHost(identifyData, 256 * 2, 0, 256 * 2, true);
+}
+
+//Read Buffer
+
+void ATA::HDD_ReadMultiple(bool isLBA48)
+{
+	sectorsPerInterrupt = curMultipleSectorsSetting;
+	HDD_ReadPIO(isLBA48);
+}
+
+void ATA::HDD_ReadSectors(bool isLBA48)
+{
+	sectorsPerInterrupt = 1;
+	HDD_ReadPIO(isLBA48);
+}
+
+void ATA::HDD_ReadPIO(bool isLBA48)
+{
+	//Log_Info("HDD_ReadPIO");
+	if (!PreCmd())
+		return;
+
+	if (sectorsPerInterrupt == 0)
+	{
+		CmdNoDataAbort();
+		return;
+	}
+
+	IDE_CmdLBA48Transform(isLBA48);
+
+	if (!HDD_CanSeek())
+	{
+		regStatus |= ATA_STAT_ERR;
+		regError |= ATA_ERR_ID;
+		PostCmdNoData();
+		return;
+	}
+
+	HDD_ReadSync(&ATA::HDD_ReadPIOS2);
+}
+
+void ATA::HDD_ReadPIOS2()
+{
+	//Log_Info("HDD_ReadPIO Stage 2");
+	pioDRQEndTransferFunc = &ATA::HDD_ReadPIOEndBlock;
+	DRQCmdPIODataToHost(readBuffer, readBufferLen, 0, 256 * 2, true);
+}
+
+void ATA::HDD_ReadPIOEndBlock()
+{
+	//Log_Info("HDD_ReadPIO End Block");
+	rdTransferred += 512;
+	if (rdTransferred >= nsector * 512)
+	{
+		//Log_Info("HDD_ReadPIO Done");
+		HDD_SetErrorAtTransferEnd();
+		regStatus &= ~ATA_STAT_BUSY;
+		pioDRQEndTransferFunc = nullptr;
+		rdTransferred = 0;
+	}
+	else
+	{
+		if ((rdTransferred / 512) % sectorsPerInterrupt == 0)
+			DRQCmdPIODataToHost(readBuffer, readBufferLen, rdTransferred, 256 * 2, true);
+		else
+			DRQCmdPIODataToHost(readBuffer, readBufferLen, rdTransferred, 256 * 2, false);
+	}
+}
+
+//Write Buffer
+
+//Write Multiple
+
+//Write Sectors
+
+//Download Microcode (Used for FW updates)

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -51,11 +51,11 @@ void ATA::PostCmdPIODataToHost()
 //FromHost
 u16 ATA::ATAreadPIO()
 {
-	DEV9_LOG_VERB("*ATA_R_DATA 16bit read, pio_count %i,  pio_size %i\n", pioPtr, pioEnd);
+	DevCon.WriteLn("*ATA_R_DATA 16bit read, pio_count %i,  pio_size %i", pioPtr, pioEnd);
 	if (pioPtr < pioEnd)
 	{
 		const u16 ret = *(u16*)&pioBuffer[pioPtr * 2];
-		DEV9_LOG_VERB("*ATA_R_DATA returned value is  %x\n", ret);
+		DevCon.WriteLn("*ATA_R_DATA returned value is  %x", ret);
 		pioPtr++;
 		if (pioPtr >= pioEnd) //Fnished transfer (Changed from MegaDev9)
 			PostCmdPIODataToHost();
@@ -70,7 +70,7 @@ void ATA::HDD_IdentifyDevice()
 {
 	if (!PreCmd())
 		return;
-	DEV9_LOG_VERB("HddidentifyDevice\n");
+	DevCon.WriteLn("HddidentifyDevice");
 
 	//IDE transfer start
 	CreateHDDinfo(config.HddSize);

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
@@ -20,7 +20,7 @@
 
 void ATA::HDD_Smart()
 {
-	DEV9_LOG_VERB("HDD_Smart\n");
+	DevCon.WriteLn("HDD_Smart");
 
 	if ((regStatus & ATA_STAT_READY) == 0)
 		return;
@@ -54,22 +54,22 @@ void ATA::HDD_Smart()
 			SMART_ReturnStatus();
 			return;
 		case 0xD1: //SMART_READ_THRESH
-			DEV9_LOG_ERROR("DEV9 : SMART_READ_THRESH Not Impemented\n");
+			Console.Error("ATA: SMART_READ_THRESH Not Impemented");
 			CmdNoDataAbort();
 			return;
 		case 0xD0: //SMART_READ_DATA
-			DEV9_LOG_ERROR("DEV9 : SMART_READ_DATA Not Impemented\n");
+			Console.Error("ATA: SMART_READ_DATA Not Impemented");
 			CmdNoDataAbort();
 			return;
 		case 0xD5: //SMART_READ_LOG
-			DEV9_LOG_ERROR("DEV9 : SMART_READ_LOG Not Impemented\n");
+			Console.Error("ATA: SMART_READ_LOG Not Impemented");
 			CmdNoDataAbort();
 			return;
 		case 0xD4: //SMART_EXECUTE_OFFLINE
 			SMART_ExecuteOfflineImmediate();
 			return;
 		default:
-			DEV9_LOG_ERROR("DEV9 : Unknown SMART command %x\n", regFeature);
+			Console.Error("ATA: Unknown SMART command %x", regFeature);
 			CmdNoDataAbort();
 			return;
 	}
@@ -87,7 +87,7 @@ void ATA::SMART_SetAutoSaveAttribute()
 			smartAutosave = true;
 			break;
 		default:
-			DEV9_LOG_ERROR("DEV9 : Unknown SMART_ATTR_AUTOSAVE command %s\n", regSector);
+			Console.Error("ATA: Unknown SMART_ATTR_AUTOSAVE command %s", regSector);
 			CmdNoDataAbort();
 			return;
 	}

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
@@ -1,0 +1,157 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::HDD_Smart()
+{
+	DEV9_LOG_VERB("HDD_Smart\n");
+
+	if ((regStatus & ATA_STAT_READY) == 0)
+		return;
+
+	if (regHcyl != 0xC2 || regLcyl != 0x4F)
+	{
+		CmdNoDataAbort();
+		return;
+	}
+
+	if (!fetSmartEnabled && regFeature != 0xD8)
+	{
+		CmdNoDataAbort();
+		return;
+	}
+
+	switch (regFeature)
+	{
+		case 0xD9: //SMART_DISABLE
+			SMART_EnableOps(false);
+			return;
+		case 0xD8: //SMART_ENABLE
+			SMART_EnableOps(true);
+			return;
+		case 0xD2: //SMART_ATTR_AUTOSAVE
+			SMART_SetAutoSaveAttribute();
+			return;
+		case 0xD3: //SMART_ATTR_SAVE
+			return;
+		case 0xDA: //SMART_STATUS (is fault in disk?)
+			SMART_ReturnStatus();
+			return;
+		case 0xD1: //SMART_READ_THRESH
+			DEV9_LOG_ERROR("DEV9 : SMART_READ_THRESH Not Impemented\n");
+			CmdNoDataAbort();
+			return;
+		case 0xD0: //SMART_READ_DATA
+			DEV9_LOG_ERROR("DEV9 : SMART_READ_DATA Not Impemented\n");
+			CmdNoDataAbort();
+			return;
+		case 0xD5: //SMART_READ_LOG
+			DEV9_LOG_ERROR("DEV9 : SMART_READ_LOG Not Impemented\n");
+			CmdNoDataAbort();
+			return;
+		case 0xD4: //SMART_EXECUTE_OFFLINE
+			SMART_ExecuteOfflineImmediate();
+			return;
+		default:
+			DEV9_LOG_ERROR("DEV9 : Unknown SMART command %x\n", regFeature);
+			CmdNoDataAbort();
+			return;
+	}
+}
+
+void ATA::SMART_SetAutoSaveAttribute()
+{
+	PreCmd();
+	switch (regSector)
+	{
+		case 0x00:
+			smartAutosave = false;
+			break;
+		case 0xF1:
+			smartAutosave = true;
+			break;
+		default:
+			DEV9_LOG_ERROR("DEV9 : Unknown SMART_ATTR_AUTOSAVE command %s\n", regSector);
+			CmdNoDataAbort();
+			return;
+	}
+	PostCmdNoData();
+}
+
+void ATA::SMART_ExecuteOfflineImmediate()
+{
+	PreCmd();
+	int n = 0;
+	switch (regSector)
+	{
+		case 0: /* off-line routine */
+		case 1: /* short self test */
+		case 2: /* extended self test */
+			smartSelfTestCount++;
+			if (smartSelfTestCount > 21)
+				smartSelfTestCount = 1;
+
+			n = 2 + (smartSelfTestCount - 1) * 24;
+			//s->smart_selftest_data[n] = s->sector;
+			//s->smart_selftest_data[n + 1] = 0x00; /* OK and finished */
+			//s->smart_selftest_data[n + 2] = 0x34; /* hour count lsb */
+			//s->smart_selftest_data[n + 3] = 0x12; /* hour count msb */
+			break;
+		case 127: /* abort off-line routine */
+			break;
+		case 129: /* short self test, which holds BSY until complete */
+		case 130: /* extended self test, which holds BSY until complete */
+			smartSelfTestCount++;
+			if (smartSelfTestCount > 21)
+			{
+				smartSelfTestCount = 1;
+			}
+			n = 2 + (smartSelfTestCount - 1) * 24;
+
+			SMART_ReturnStatus();
+			return;
+		default:
+			CmdNoDataAbort();
+			return;
+	}
+	PostCmdNoData();
+}
+
+void ATA::SMART_EnableOps(bool enable)
+{
+	PreCmd();
+	fetSmartEnabled = enable;
+	PostCmdNoData();
+}
+
+void ATA::SMART_ReturnStatus()
+{
+	PreCmd();
+	if (!smartErrors)
+	{
+		regHcyl = 0xC2;
+		regLcyl = 0x4F;
+	}
+	else
+	{
+		regHcyl = 0x2C;
+		regLcyl = 0xF4;
+	}
+	PostCmdNoData();
+}

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -1,0 +1,183 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::IDE_ExecCmd(u16 value)
+{
+	switch (value)
+	{
+		case 0x00:
+			HDD_Nop();
+			break;
+		case 0x20:
+			HDD_ReadSectors(false);
+			break;
+			//0x21
+		case 0x40:
+			HDD_ReadVerifySectors(false);
+			break;
+			//0x41
+		case 0x70:
+			HDD_SeekCmd();
+			break;
+		case 0x90:
+			HDD_ExecuteDeviceDiag();
+			break;
+		case 0x91:
+			HDD_InitDevParameters();
+			break;
+		case 0xB0:
+			HDD_Smart();
+			break;
+		case 0xC4:
+			HDD_ReadMultiple(false);
+			break;
+		case 0xC8:
+			HDD_ReadDMA(false);
+			break;
+			//0xC9
+		case 0xCA:
+			HDD_WriteDMA(false);
+			break;
+			//0xCB
+			//0x25 = HDDreadDMA48;
+			//0x35 = HDDwriteDMA48;*/
+		case 0xE3:
+			HDD_Idle();
+			break;
+		case 0xE7:
+			HDD_FlushCache();
+			break;
+			//0xEA = HDDflushCache48
+		case 0xEC:
+			HDD_IdentifyDevice();
+			break;
+			//0xA1 = HDDidentifyPktDevice
+		case 0xEF:
+			HDD_SetFeatures();
+			break;
+
+			//0xF1 = HDDsecSetPassword
+			//0xF2 = HDDsecUnlock
+			//0xF3 = HDDsecErasePrepare;
+			//0xF4 = HDDsecEraseUnit;
+
+			/* This command is Sony-specific and isn't part of the IDE standard */
+			/* The Sony HDD has a modified firmware that supports this command */
+			/* Sending this command to a standard HDD will give an error */
+			/* We roughly emulate it to make programs think the HDD is a Sony one */
+			/* However, we only send null, if anyting checks the returned data */
+			/* it will fail */
+		case 0x8E:
+			HDD_SCE();
+			break;
+
+		default:
+			HDD_Unk();
+			break;
+	}
+}
+
+void ATA::HDD_Unk()
+{
+	DEV9_LOG_ERROR("DEV9 HDD error : unknown cmd %x\n", regCommand);
+
+	PreCmd();
+
+	regError |= ATA_ERR_ABORT;
+	regStatus |= ATA_STAT_ERR;
+	PostCmdNoData();
+}
+
+bool ATA::PreCmd()
+{
+	if ((regStatus & ATA_STAT_READY) == 0)
+	{
+		//Ignore CMD write except for EXECUTE DEVICE DIAG and INITIALIZE DEVICE PARAMETERS
+		return false;
+	}
+	regStatus |= ATA_STAT_BUSY;
+
+	regStatus &= ~ATA_STAT_WRERR;
+	regStatus &= ~ATA_STAT_DRQ;
+	regStatus &= ~ATA_STAT_ERR;
+
+	regStatus &= ~ATA_STAT_SEEK;
+
+	regError = 0;
+
+	return true;
+}
+
+void ATA::IDE_CmdLBA48Transform(bool islba48)
+{
+	lba48 = islba48;
+	//TODO
+	/* handle the 'magic' 0 nsector count conversion here. to avoid
+             * fiddling with the rest of the read logic, we just store the
+             * full sector count in ->nsector
+             */
+	if (!lba48)
+	{
+		if (regNsector == 0)
+			nsector = 256;
+		else
+			nsector = regNsector;
+	}
+	else
+	{
+		if (regNsector == 0 && regNsectorHOB == 0)
+			nsector = 65536;
+		else
+		{
+			const int lo = regNsector;
+			const int hi = regNsectorHOB;
+
+			nsector = (hi << 8) | lo;
+		}
+	}
+}
+
+//OTHER FEATURE SETS BELOW (TODO?)
+
+//CFA ERASE SECTORS
+//WRITE MULTIPLE
+//SET MULTIPLE
+
+//CFA WRITE MULTIPLE WITHOUT ERASE
+//GET MEDIA STATUS
+//MEDIA LOCK
+//MEDIA UNLOCK
+//STANDBY IMMEDIAYTE
+//IDLE IMMEDIATE
+//STANBY
+
+//CHECK POWER MODE
+//SLEEP
+
+//MEDIA EJECT
+
+//SECURITY SET PASSWORD
+//SECURITY UNLOCK
+//SECUTIRY ERASE PREPARE
+//SECURITY ERASE UNIT
+//SECURITY FREEZE LOCK
+//SECURITY DIABLE PASSWORD
+//READ NATIVE MAX ADDRESS
+//SET MAX ADDRESS

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -96,7 +96,7 @@ void ATA::IDE_ExecCmd(u16 value)
 
 void ATA::HDD_Unk()
 {
-	DEV9_LOG_ERROR("DEV9 HDD error : unknown cmd %x\n", regCommand);
+	Console.Error("ATA: Unknown cmd %x", regCommand);
 
 	PreCmd();
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_SCE.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_SCE.cpp
@@ -20,7 +20,7 @@
 
 void ATA::HDD_SCE()
 {
-	DEV9_LOG_INFO("DEV9 : SONY-SPECIFIC SECURITY CONTROL COMMAND %x\n", regFeature);
+	DevCon.WriteLn("DEV9 : SONY-SPECIFIC SECURITY CONTROL COMMAND %x", regFeature);
 
 	switch (regFeature)
 	{
@@ -28,7 +28,7 @@ void ATA::HDD_SCE()
 			SCE_IDENTIFY_DRIVE();
 			break;
 		default:
-			DEV9_LOG_ERROR("DEV9 : Unknown SCE command %x\n", regFeature);
+			Console.Error("ATA: Unknown SCE command %x", regFeature);
 			CmdNoDataAbort();
 			return;
 	}

--- a/pcsx2/DEV9/ATA/Commands/ATA_SCE.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_SCE.cpp
@@ -1,0 +1,56 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "../ATA.h"
+#include "../../DEV9.h"
+
+void ATA::HDD_SCE()
+{
+	DEV9_LOG_INFO("DEV9 : SONY-SPECIFIC SECURITY CONTROL COMMAND %x\n", regFeature);
+
+	switch (regFeature)
+	{
+		case 0xEC:
+			SCE_IDENTIFY_DRIVE();
+			break;
+		default:
+			DEV9_LOG_ERROR("DEV9 : Unknown SCE command %x\n", regFeature);
+			CmdNoDataAbort();
+			return;
+	}
+}
+//Has
+//ATA_SCE_IDENTIFY_DRIVE @ 0xEC
+
+//ATA_SCE_SECURITY_ERASE_PREPARE @ 0xF1
+//ATA_SCE_SECURITY_ERASE_UNIT
+//ATA_SCE_SECURITY_FREEZE_LOCK
+//ATA_SCE_SECURITY_SET_PASSWORD
+//ATA_SCE_SECURITY_UNLOCK
+
+//ATA_SCE_SECURITY_WRITE_ID @ 0x20
+//ATA_SCE_SECURITY_READ_ID @ 0x30
+
+void ATA::SCE_IDENTIFY_DRIVE()
+{
+	PreCmd();
+
+	//HDD_IdentifyDevice(); //Maybe?
+
+	pioDRQEndTransferFunc = nullptr;
+	DRQCmdPIODataToHost(sceSec, 256 * 2, 0, 256 * 2, true);
+}

--- a/pcsx2/DEV9/ATA/HddCreate.cpp
+++ b/pcsx2/DEV9/ATA/HddCreate.cpp
@@ -1,0 +1,107 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include <fstream>
+#include "HddCreate.h"
+
+void HddCreate::Start()
+{
+	fileThread = std::thread(&HddCreate::WriteImage, this, filePath, neededSize);
+	fileThread.join();
+}
+
+void HddCreate::WriteImage(ghc::filesystem::path hddPath, int reqSizeMiB)
+{
+	constexpr int buffsize = 4 * 1024;
+	u8 buff[buffsize] = {0}; //4kb
+
+	if (ghc::filesystem::exists(hddPath))
+	{
+		SetError();
+		return;
+	}
+
+	std::fstream newImage = ghc::filesystem::fstream(hddPath, std::ios::out | std::ios::binary);
+
+	if (newImage.fail())
+	{
+		SetError();
+		return;
+	}
+
+	//Size file
+	newImage.seekp(((u64)reqSizeMiB) * 1024 * 1024 - 1, std::ios::beg);
+	const char zero = 0;
+	newImage.write(&zero, 1);
+
+	if (newImage.fail())
+	{
+		newImage.close();
+		ghc::filesystem::remove(filePath);
+		SetError();
+		return;
+	}
+
+	lastUpdate = std::chrono::steady_clock::now();
+
+	newImage.seekp(0, std::ios::beg);
+
+	for (int iMiB = 0; iMiB < reqSizeMiB; iMiB++)
+	{
+		for (int i4kb = 0; i4kb < 256; i4kb++)
+		{
+			newImage.write((char*)buff, buffsize);
+			if (newImage.fail())
+			{
+				newImage.close();
+				ghc::filesystem::remove(filePath);
+				SetError();
+				return;
+			}
+		}
+		SetFileProgress(iMiB + 1);
+	}
+	newImage.flush();
+	newImage.close();
+
+	SetDone();
+}
+
+void HddCreate::SetFileProgress(int currentSize)
+{
+	std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+
+	if (std::chrono::duration_cast<std::chrono::seconds>(now - lastUpdate).count() >= 1)
+	{
+		lastUpdate = now;
+		fprintf(stdout, "%i / %i MiB\n", currentSize, neededSize);
+	}
+}
+
+void HddCreate::SetError()
+{
+	fprintf(stderr, "Unable to create file\n");
+	errored.store(true);
+	completed.store(true);
+}
+
+void HddCreate::SetDone()
+{
+	fprintf(stdout, "%i / %i MiB\n", neededSize, neededSize);
+	fprintf(stdout, "Done\n");
+	completed.store(true);
+}

--- a/pcsx2/DEV9/ATA/HddCreate.h
+++ b/pcsx2/DEV9/ATA/HddCreate.h
@@ -14,17 +14,33 @@
  */
 
 #pragma once
-#include "DEV9.h"
 
-void ata_init();
-void ata_term();
+#include <string>
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include "ghc/filesystem.h"
 
-template <int sz>
-void ata_write(u32 addr, u32 value);
-template <int sz>
-u8 ata_read(u32 addr);
+class HddCreate
+{
+public:
+	ghc::filesystem::path filePath;
+	int neededSize;
 
-EXPORT_C_(void)
-ata_readDMA8Mem(u32* pMem, int size);
-EXPORT_C_(void)
-ata_writeDMA8Mem(u32* pMem, int size);
+	std::atomic_bool errored{false};
+
+private:
+	std::thread fileThread;
+	std::atomic_bool completed{false};
+
+	std::chrono::steady_clock::time_point lastUpdate;
+
+public:
+	void Start();
+
+private:
+	void SetFileProgress(int currentSize);
+	void SetError();
+	void SetDone();
+	void WriteImage(ghc::filesystem::path hddPath, int reqSizeMB);
+};

--- a/pcsx2/DEV9/ATA/HddCreate.h
+++ b/pcsx2/DEV9/ATA/HddCreate.h
@@ -15,9 +15,12 @@
 
 #pragma once
 
+#include <wx/progdlg.h>
+
 #include <string>
 #include <thread>
 #include <atomic>
+#include <condition_variable>
 #include <chrono>
 #include "ghc/filesystem.h"
 
@@ -30,8 +33,16 @@ public:
 	std::atomic_bool errored{false};
 
 private:
+	wxProgressDialog* progressDialog;
+	std::atomic_int written{0};
+
 	std::thread fileThread;
-	std::atomic_bool completed{false};
+
+	std::atomic_bool canceled{false};
+
+	std::mutex completedMutex;
+	std::condition_variable completedCV;
+	bool completed = false;
 
 	std::chrono::steady_clock::time_point lastUpdate;
 
@@ -41,6 +52,5 @@ public:
 private:
 	void SetFileProgress(int currentSize);
 	void SetError();
-	void SetDone();
 	void WriteImage(ghc::filesystem::path hddPath, int reqSizeMB);
 };

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -269,7 +269,7 @@ s32 DEV9open(void* pDsp)
 		ghc::filesystem::path path(GetSettingsFolder().ToUTF8().data());
 		hddPath = path / hddPath;
 	}
-	
+
 	if (config.hddEnable)
 	{
 		if (dev9.ata->Open(hddPath) != 0)
@@ -876,7 +876,7 @@ void DEV9write16(u32 addr, u16 value)
 				dev9.fifo_bytes_write = 0;
 				dev9.fifo_bytes_read = 0;
 				dev9.xfr_ctrl &= ~SPD_XFR_WRITE; //?
-				dev9.if_ctrl |= SPD_IF_READ; //?
+				dev9.if_ctrl |= SPD_IF_READ;     //?
 
 				FIFOIntr();
 			}

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -27,6 +27,7 @@
 #include <err.h>
 #endif
 
+#include "ghc/filesystem.h"
 
 #include <fcntl.h>
 #include <stdlib.h>
@@ -37,8 +38,9 @@
 #include "DEV9.h"
 #undef EXTERN
 #include "Config.h"
+#include "AppConfig.h"
 #include "smap.h"
-#include "ata.h"
+
 
 #ifdef _WIN32
 #pragma warning(disable : 4244)
@@ -250,7 +252,19 @@ s32 DEV9open(void* pDsp)
 #else
 	DEV9_LOG("open r+: %s\n", config.Hdd);
 #endif
-	config.HddSize = 8 * 1024;
+
+#ifdef _WIN32
+	ghc::filesystem::path hddPath(std::wstring(config.Hdd));
+#else
+	ghc::filesystem::path hddPath(config.Hdd);
+#endif
+
+	if (hddPath.is_relative())
+	{
+		//GHC uses UTF8 on all platforms
+		ghc::filesystem::path path(GetSettingsFolder().ToUTF8().data());
+		hddPath = path / hddPath;
+	}
 
 #ifdef ENABLE_ATA
 	ata_init();

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -774,6 +774,7 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 
 	DEV9_LOG("*DEV9readDMA8Mem: size %x\n", size);
 	emu_printf("rDMA\n");
+	size >>= 1;
 
 	smap_readDMA8Mem(pMem, size);
 #ifdef ENABLE_ATA
@@ -788,6 +789,7 @@ void DEV9writeDMA8Mem(u32* pMem, int size)
 
 	DEV9_LOG("*DEV9writeDMA8Mem: size %x\n", size);
 	emu_printf("wDMA\n");
+	size >>= 1;
 
 	smap_writeDMA8Mem(pMem, size);
 #ifdef ENABLE_ATA

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -138,12 +138,15 @@ void __Log(int level, const char* fmt, ...)
 
 void LogInit()
 {
-	const std::string LogFile(s_strLogPath + "/dev9Log.txt");
-	if (logFile)
-	{
-		DEV9Log.WriteToFile = true;
-		DEV9Log.Open(LogFile);
-	}
+	const char* logName = "dev9Log.txt";
+
+	//GHC uses UTF8 on all platforms
+	ghc::filesystem::path path(GetLogFolder().ToUTF8().data());
+	path /= logName;
+	std::string strPath = path.u8string();
+
+	DEV9Log.WriteToFile = true;
+	DEV9Log.Open(strPath.c_str());
 }
 
 s32 DEV9init()
@@ -239,7 +242,14 @@ s32 DEV9open(void* pDsp)
 {
 	DEV9_LOG("DEV9open\n");
 	LoadConf();
+#ifdef _WIN32
+	//Convert to utf8
+	char mbHdd[sizeof(config.Hdd)] = {0};
+	WideCharToMultiByte(CP_UTF8, 0, config.Hdd, -1, mbHdd, sizeof(mbHdd) - 1, nullptr, nullptr);
+	DEV9_LOG("open r+: %s\n", mbHdd);
+#else
 	DEV9_LOG("open r+: %s\n", config.Hdd);
+#endif
 	config.HddSize = 8 * 1024;
 
 #ifdef ENABLE_ATA

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -65,6 +65,9 @@ bool rx_fifo_can_rx();
 #define HDD_DEF "DEV9hdd.raw"
 #endif
 
+#define HDD_MIN_GB 8
+#define HDD_MAX_GB 120
+
 typedef struct
 {
 	char Eth[256];

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -41,14 +41,18 @@
 #define __inline inline
 
 #endif
+// clang-format off
+#define DEV_LOG_LEVEL_VERBOSE	1
+#define DEV_LOG_LEVEL_INFO		2
+#define DEV_LOG_LEVEL_ERROR		3
 
-//#define DEV9_LOG_ENABLE
+#define DEV9_LOG_LEVEL	DEV_LOG_LEVEL_INFO
 
-#ifdef DEV9_LOG_ENABLE
-#define DEV9_LOG __Log
-#else
-#define DEV9_LOG(...)
-#endif
+#define DEV9_LOG(...)		__Log(DEV_LOG_LEVEL_VERBOSE,__VA_ARGS__)
+#define DEV9_LOG_VERB(...)	__Log(DEV_LOG_LEVEL_VERBOSE,__VA_ARGS__)
+#define DEV9_LOG_INFO(...)	__Log(DEV_LOG_LEVEL_INFO,	__VA_ARGS__)
+#define DEV9_LOG_ERROR(...)	__Log(DEV_LOG_LEVEL_ERROR,	__VA_ARGS__)
+// clang-format on
 
 void rx_process(NetPacket* pk);
 bool rx_fifo_can_rx();
@@ -130,7 +134,7 @@ EXTERN PluginLog DEV9Log;
 //Yes these are meant to be a lowercase extern
 extern std::string s_strIniPath;
 extern std::string s_strLogPath;
-void __Log(char* fmt, ...);
+void __Log(int level, const char* fmt, ...);
 
 void SysMessage(char* fmt, ...);
 
@@ -718,6 +722,7 @@ void DEV9write16(u32 addr, u16 value);
 void DEV9write32(u32 addr, u32 value);
 
 int emu_printf(const char* fmt, ...);
+int emu_vprintf(const char* fmt, va_list);
 
 #ifdef _WIN32
 #pragma warning(error : 4013)

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -42,18 +42,6 @@
 #define __inline inline
 
 #endif
-// clang-format off
-#define DEV_LOG_LEVEL_VERBOSE	1
-#define DEV_LOG_LEVEL_INFO		2
-#define DEV_LOG_LEVEL_ERROR		3
-
-#define DEV9_LOG_LEVEL	DEV_LOG_LEVEL_INFO
-
-#define DEV9_LOG(...)		__Log(DEV_LOG_LEVEL_VERBOSE,__VA_ARGS__)
-#define DEV9_LOG_VERB(...)	__Log(DEV_LOG_LEVEL_VERBOSE,__VA_ARGS__)
-#define DEV9_LOG_INFO(...)	__Log(DEV_LOG_LEVEL_INFO,	__VA_ARGS__)
-#define DEV9_LOG_ERROR(...)	__Log(DEV_LOG_LEVEL_ERROR,	__VA_ARGS__)
-// clang-format on
 
 void rx_process(NetPacket* pk);
 bool rx_fifo_can_rx();
@@ -151,11 +139,9 @@ s32 _DEV9open();
 void _DEV9close();
 //void DEV9thread();
 
-EXTERN PluginLog DEV9Log;
 //Yes these are meant to be a lowercase extern
 extern std::string s_strIniPath;
 extern std::string s_strLogPath;
-void __Log(int level, const char* fmt, ...);
 
 void SysMessage(char* fmt, ...);
 
@@ -741,9 +727,6 @@ u32 DEV9read32(u32 addr);
 void DEV9write8(u32 addr, u8 value);
 void DEV9write16(u32 addr, u16 value);
 void DEV9write32(u32 addr, u32 value);
-
-int emu_printf(const char* fmt, ...);
-int emu_vprintf(const char* fmt, va_list);
 
 #ifdef _WIN32
 #pragma warning(error : 4013)

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -58,12 +58,20 @@ void rx_process(NetPacket* pk);
 bool rx_fifo_can_rx();
 
 #define ETH_DEF "eth0"
+#ifdef _WIN32
+#define HDD_DEF L"DEV9hdd.raw"
+#else
 #define HDD_DEF "DEV9hdd.raw"
+#endif
 
 typedef struct
 {
 	char Eth[256];
+#ifdef _WIN32
+	wchar_t Hdd[256];
+#else
 	char Hdd[256];
+#endif
 	int HddSize;
 
 	int hddEnable;

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -28,6 +28,7 @@
 #include "PS2Edefs.h"
 #include "PS2Eext.h"
 #include "net.h"
+#include "ATA/ATA.h"
 
 #ifdef _WIN32
 
@@ -82,6 +83,8 @@ EXTERN Config config;
 
 typedef struct
 {
+	ATA* ata;
+
 	s8 dev9R[0x10000];
 	u8 eeprom_state;
 	u8 eeprom_command;
@@ -99,14 +102,21 @@ typedef struct
 	u16 txfifo_rd_ptr;
 
 	u8 bd_swap;
-	u16 atabuf[1024];
-	u32 atacount;
-	u32 atasize;
 	u16 phyregs[32];
-	int irqcause;
-	u8 atacmd;
-	u32 atasector;
-	u32 atansector;
+
+	u16 irqcause;
+	u16 irqmask;
+	u16 dma_ctrl;
+	u16 xfr_ctrl;
+	u16 if_ctrl;
+
+	u16 pio_mode;
+	u16 mdma_mode;
+	u16 udma_mode;
+
+	//Non-Regs
+	int fifo_bytes_read;
+	int fifo_bytes_write;
 } dev9Struct;
 
 //EEPROM states

--- a/pcsx2/DEV9/Linux/Config.cpp
+++ b/pcsx2/DEV9/Linux/Config.cpp
@@ -13,6 +13,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "PrecompiledHeader.h"
 
 #include <stdlib.h>
 

--- a/pcsx2/DEV9/Linux/Config.cpp
+++ b/pcsx2/DEV9/Linux/Config.cpp
@@ -67,7 +67,7 @@ void SaveConf()
 
 	const std::string file(GetSettingsFolder().Combine(wxString("DEV9.cfg")).GetFullPath());
 
-	fprintf(stderr, "CONF: %s", file.c_str());
+	Console.WriteLn("CONF: %s", file.c_str());
 
 	xmlSaveFormatFileEnc(file.c_str(), doc, "UTF-8", 1);
 	//    free(configFile);

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -22,6 +22,9 @@
 #include <pwd.h>
 #include <string.h>
 
+#include <string>
+#include "ghc/filesystem.h"
+
 #include "../Config.h"
 #include "../DEV9.h"
 #include "pcap.h"
@@ -29,7 +32,9 @@
 #include "../net.h"
 #include "AppCoreThread.h"
 
-static GtkBuilder* builder;
+#include "../ATA/HddCreate.h"
+
+static GtkBuilder* builder = nullptr;
 
 void SysMessage(char* fmt, ...)
 {
@@ -72,7 +77,29 @@ void OnInitDialog()
 		}
 		idx++;
 	}
+
 	gtk_entry_set_text((GtkEntry*)gtk_builder_get_object(builder, "IDC_HDDFILE"), config.Hdd);
+
+	//HDDSpin
+	gtk_spin_button_set_range((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN"), HDD_MIN_GB, HDD_MAX_GB);
+	gtk_spin_button_set_increments((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN"), 1, 10);
+	gtk_spin_button_set_value((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN"), config.HddSize / 1024);
+
+	//HDDSlider
+	gtk_range_set_range((GtkRange*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), HDD_MIN_GB, HDD_MAX_GB);
+	gtk_range_set_increments((GtkRange*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), 1, 10);
+
+	gtk_scale_add_mark((GtkScale*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), HDD_MIN_GB, GTK_POS_BOTTOM, (std::to_string(HDD_MIN_GB) + " GiB").c_str());
+	gtk_scale_add_mark((GtkScale*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), HDD_MAX_GB, GTK_POS_BOTTOM, (std::to_string(HDD_MAX_GB) + " GiB").c_str());
+
+	for (int i = 15; i < HDD_MAX_GB; i += 5)
+	{
+		gtk_scale_add_mark((GtkScale*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), i, GTK_POS_BOTTOM, nullptr);
+	}
+
+	gtk_range_set_value((GtkRange*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), config.HddSize / 1024);
+
+	//Checkboxes
 	gtk_toggle_button_set_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_ETHENABLED"),
 								 config.ethEnable);
 	gtk_toggle_button_set_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_HDDENABLED"),
@@ -81,46 +108,77 @@ void OnInitDialog()
 	initialized = 1;
 }
 
+void OnBrowse(GtkButton* button, gpointer usr_data)
+{
+	ghc::filesystem::path inis(GetSettingsFolder().ToString().ToStdString());
+
+	static const wxChar* hddFilterType = L"HDD|*.raw;*.RAW";
+
+	wxFileDialog ctrl(nullptr, _("HDD Image File"), GetSettingsFolder().ToString(), HDD_DEF,
+					  (wxString)hddFilterType + L"|" + _("All Files (*.*)") + L"|*.*", wxFD_SAVE);
+
+	if (ctrl.ShowModal() != wxID_CANCEL)
+	{
+		ghc::filesystem::path hddFile(ctrl.GetPath().ToStdString());
+
+		if (ghc::filesystem::exists(hddFile))
+		{
+			//Get file size
+			int filesizeGb = ghc::filesystem::file_size(hddFile) / (1024 * 1024 * 1024);
+
+			gtk_range_set_value((GtkRange*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"), filesizeGb);
+			gtk_spin_button_set_value((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN"), filesizeGb);
+		}
+
+		if (hddFile.parent_path() == inis)
+			hddFile = hddFile.filename();
+
+		gtk_entry_set_text((GtkEntry*)gtk_builder_get_object(builder, "IDC_HDDFILE"), hddFile.c_str());
+	}
+}
+
+void OnSpin(GtkSpinButton* spin, gpointer usr_data)
+{
+	gtk_range_set_value((GtkRange*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"),
+						gtk_spin_button_get_value(spin));
+}
+
+void OnSlide(GtkRange* range, gpointer usr_data)
+{
+	gtk_spin_button_set_value((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN"),
+							  gtk_range_get_value(range));
+}
+
 void OnOk()
 {
-
 	char* ptr = gtk_combo_box_text_get_active_text((GtkComboBoxText*)gtk_builder_get_object(builder, "IDC_ETHDEV"));
 	if (ptr != nullptr)
 		strcpy(config.Eth, ptr);
 
 	strcpy(config.Hdd, gtk_entry_get_text((GtkEntry*)gtk_builder_get_object(builder, "IDC_HDDFILE")));
+	config.HddSize = gtk_spin_button_get_value((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN")) * 1024;
 
 	config.ethEnable = gtk_toggle_button_get_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_ETHENABLED"));
 	config.hddEnable = gtk_toggle_button_get_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_HDDENABLED"));
 
-	SaveConf();
-}
+	ghc::filesystem::path hddPath(config.Hdd);
 
-/* Simple GTK+2 variant of gtk_builder_add_from_resource() */
-static guint builder_add_from_resource(GtkBuilder* builder, const gchar* resource_path, GError** error)
-{
-	GBytes* data;
-	const gchar* buffer;
-	gsize buffer_length;
-	guint ret;
-
-	g_assert(error && *error == NULL);
-
-	data = g_resources_lookup_data(resource_path, G_RESOURCE_LOOKUP_FLAGS_NONE, error);
-	if (data == NULL)
+	if (hddPath.is_relative())
 	{
-		return 0;
+		//GHC uses UTF8 on all platforms
+		ghc::filesystem::path path(GetSettingsFolder().ToUTF8().data());
+		hddPath = path / hddPath;
 	}
 
-	buffer_length = 0;
-	buffer = (const gchar*)g_bytes_get_data(data, &buffer_length);
-	g_assert(buffer != NULL);
+	if (config.hddEnable && !ghc::filesystem::exists(hddPath))
+	{
+		HddCreate hddCreator;
+		hddCreator.filePath = hddPath;
+		hddCreator.neededSize = config.HddSize;
+		hddCreator.Start();
+	}
 
-	ret = gtk_builder_add_from_string(builder, buffer, buffer_length, error);
-
-	g_bytes_unref(data);
-
-	return ret;
+	SaveConf();
 }
 
 void DEV9configure()
@@ -128,12 +186,22 @@ void DEV9configure()
 	ScopedCoreThreadPause paused_core;
 	gtk_init(NULL, NULL);
 	GError* error = NULL;
-	builder = gtk_builder_new();
-	if (!builder_add_from_resource(builder, "/net/pcsx2/dev9/DEV9/Linux/dev9.ui", &error))
+	if (builder == nullptr)
 	{
-		g_warning("Could not build config ui: %s", error->message);
-		g_error_free(error);
-		g_object_unref(G_OBJECT(builder));
+		builder = gtk_builder_new();
+		gtk_builder_add_callback_symbols(builder,
+										 "OnBrowse", G_CALLBACK(&OnBrowse),
+										 "OnSpin", G_CALLBACK(&OnSpin),
+										 "OnSlide", G_CALLBACK(&OnSlide), nullptr);
+		if (!gtk_builder_add_from_resource(builder, "/net/pcsx2/dev9/DEV9/Linux/dev9.ui", &error))
+		{
+			g_warning("Could not build config ui: %s", error->message);
+			g_error_free(error);
+			g_object_unref(G_OBJECT(builder));
+			builder = nullptr;
+			return;
+		}
+		gtk_builder_connect_signals(builder, nullptr);
 	}
 	GtkDialog* dlg = GTK_DIALOG(gtk_builder_get_object(builder, "IDD_CONFDLG"));
 	OnInitDialog();

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -237,7 +237,7 @@ s32 _DEV9open()
 	NetAdapter* na = GetNetAdapter();
 	if (!na)
 	{
-		emu_printf("Failed to GetNetAdapter()\n");
+		Console.Error("Failed to GetNetAdapter()");
 		config.ethEnable = false;
 	}
 	else

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -13,6 +13,8 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "PrecompiledHeader.h"
+
 #include <stdio.h>
 
 #include <gtk/gtk.h>

--- a/pcsx2/DEV9/Linux/dev9.ui
+++ b/pcsx2/DEV9/Linux/dev9.ui
@@ -1,241 +1,302 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="2.24"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="IDD_CONFDLG">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Network and HDD Settings</property>
+    <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="spacing">2</property>
-    <child internal-child="action_area">
-      <object class="GtkHButtonBox" id="dialog-action_area1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="layout_style">end</property>
-        <child>
-          <object class="GtkButton" id="IDOK">
-        <property name="label" translatable="yes">OK</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-          </object>
-          <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="IDCANCEL">
-        <property name="label" translatable="yes">Cancel</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-          </object>
-          <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="pack_type">end</property>
-        <property name="position">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkHBox" id="hbox1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <child>
-          <object class="GtkLabel" id="label3">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">DEV9 Type: </property>
-          </object>
-          <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="IDC_BAYTYPE">
-         <property name="sensitive">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="has_entry">True</property>
-        <property name="entry_text_column">0</property>
-          </object>
-          <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkExpander" id="expander1">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <child>
-          <object class="GtkVBox" id="vbox1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <child>
-          <object class="GtkCheckButton" id="IDC_ETHENABLED">
-            <property name="label" translatable="yes">Enabled</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkHBox" id="hbox3">
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
-              <object class="GtkLabel" id="label4">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Ethernet Device: </property>
+              <object class="GtkButton" id="IDOK">
+                <property name="label" translatable="yes">OK</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="IDCANCEL">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <child>
+              <object class="GtkComboBoxText" id="IDC_BAYTYPE">
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="has_entry">True</property>
+                <child internal-child="entry">
+                  <object class="GtkEntry">
+                    <property name="can_focus">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkComboBoxText" id="IDC_ETHDEV">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="has_entry">False</property>
-            <property name="entry_text_column">0</property>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">DEV9 Type: </property>
               </object>
               <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">1</property>
           </packing>
         </child>
-          </object>
-        </child>
-        <child type="label">
-          <object class="GtkLabel" id="label1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Ethernet</property>
-          </object>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkExpander" id="expander2">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
         <child>
-          <object class="GtkVBox" id="vbox2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <child>
-          <object class="GtkCheckButton" id="IDC_HDDENABLED">
-            <property name="label" translatable="yes">ENABLED</property>
-            <property name="sensitive">False</property>
+          <object class="GtkExpander" id="expander1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <child>
+                  <object class="GtkGrid">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <child>
+                      <object class="GtkComboBoxText" id="IDC_ETHDEV">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Ethernet Device: </property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="IDC_ETHENABLED">
+                    <property name="label" translatable="yes">Enabled</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Ethernet</property>
+              </object>
+            </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox5">
+          <object class="GtkExpander" id="expander2">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <child>
-              <object class="GtkLabel" id="label5">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label" translatable="yes">HDD File: </property>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <child>
+                  <object class="GtkCheckButton" id="IDC_HDDENABLED">
+                    <property name="label" translatable="yes">Enabled</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkGrid">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <child>
+                      <object class="GtkEntry" id="IDC_HDDFILE">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">HDD File: </property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="IDC_BROWSE">
+                        <property name="label" translatable="yes">Browse</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="OnBrowse" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">HDD Size (GiB): </property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="IDC_HDDSIZE_SPIN">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <signal name="value-changed" handler="OnSpin" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScale" id="IDC_HDDSIZE_SLIDER">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="round_digits">0</property>
+                        <property name="digits">0</property>
+                        <property name="value_pos">bottom</property>
+                        <signal name="value-changed" handler="OnSlide" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
               </object>
-              <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-              </packing>
             </child>
-            <child>
-              <object class="GtkEntry" id="IDC_HDDFILE">
-            <property name="sensitive">False</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <child type="label">
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Hard Disk Drive</property>
               </object>
-              <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">3</property>
           </packing>
         </child>
-          </object>
-        </child>
-        <child type="label">
-          <object class="GtkLabel" id="label2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Hard Disk Drive (not yet properly implemented)</property>
-          </object>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">3</property>
-      </packing>
-    </child>
       </object>
     </child>
     <action-widgets>

--- a/pcsx2/DEV9/Win32/DEV9WinConfig.cpp
+++ b/pcsx2/DEV9/Win32/DEV9WinConfig.cpp
@@ -17,42 +17,60 @@
 #include "PrecompiledHeader.h"
 #include <stdlib.h>
 
+#include <fstream>
+
 //#include <winsock2.h>
 #include "..\DEV9.h"
 #include "AppConfig.h"
 
-BOOL WritePrivateProfileInt(LPCSTR lpAppName, LPCSTR lpKeyName, int intvar, LPCSTR lpFileName)
+BOOL WritePrivateProfileInt(LPCWSTR lpAppName, LPCWSTR lpKeyName, int intvar, LPCWSTR lpFileName)
 {
-	return WritePrivateProfileStringA(lpAppName, lpKeyName, std::to_string(intvar).c_str(), lpFileName);
+	return WritePrivateProfileString(lpAppName, lpKeyName, std::to_wstring(intvar).c_str(), lpFileName);
 }
-bool FileExists(std::string szPath)
+bool FileExists(std::wstring szPath)
 {
-	DWORD dwAttrib = GetFileAttributesA(szPath.c_str());
+	DWORD dwAttrib = GetFileAttributes(szPath.c_str());
 	return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
 			!(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
 void SaveConf()
 {
-	const std::string file(GetSettingsFolder().Combine(wxString("DEV9.cfg")).GetFullPath());
-	DeleteFileA(file.c_str());
+	const std::wstring file(GetSettingsFolder().Combine(wxString("DEV9.cfg")).GetFullPath());
+	DeleteFile(file.c_str());
 
-	WritePrivateProfileStringA("DEV9", "Eth", config.Eth, file.c_str());
-	WritePrivateProfileStringA("DEV9", "Hdd", config.Hdd, file.c_str());
-	WritePrivateProfileInt("DEV9", "HddSize", config.HddSize, file.c_str());
-	WritePrivateProfileInt("DEV9", "ethEnable", config.ethEnable, file.c_str());
-	WritePrivateProfileInt("DEV9", "hddEnable", config.hddEnable, file.c_str());
+	//Create file with UT16 BOM to allow PrivateProfile to save unicode data
+	int bom = 0xFEFF;
+	std::fstream nfile = std::fstream(file, std::ios::out | std::ios::binary);
+	nfile.write((char*)&bom, 2);
+	//Write header to avoid empty line
+	nfile.write((char*)L"[DEV9]", 14);
+	nfile.close();
+
+	wchar_t wEth[sizeof(config.Eth)] = {0};
+	mbstowcs(wEth, config.Eth, sizeof(config.Eth) - 1);
+	WritePrivateProfileString(L"DEV9", L"Eth", wEth, file.c_str());
+	WritePrivateProfileString(L"DEV9", L"Hdd", config.Hdd, file.c_str());
+
+	WritePrivateProfileInt(L"DEV9", L"HddSize", config.HddSize, file.c_str());
+	WritePrivateProfileInt(L"DEV9", L"ethEnable", config.ethEnable, file.c_str());
+	WritePrivateProfileInt(L"DEV9", L"hddEnable", config.hddEnable, file.c_str());
 }
 
 void LoadConf()
 {
-	const std::string file(GetSettingsFolder().Combine(wxString("DEV9.cfg")).GetFullPath());
+	const std::wstring file(GetSettingsFolder().Combine(wxString("DEV9.cfg")).GetFullPath());
 	if (FileExists(file.c_str()) == false)
 		return;
 
-	GetPrivateProfileStringA("DEV9", "Eth", ETH_DEF, config.Eth, sizeof(config.Eth), file.c_str());
-	GetPrivateProfileStringA("DEV9", "Hdd", HDD_DEF, config.Hdd, sizeof(config.Hdd), file.c_str());
-	config.HddSize = GetPrivateProfileIntA("DEV9", "HddSize", config.HddSize, file.c_str());
-	config.ethEnable = GetPrivateProfileIntA("DEV9", "ethEnable", config.ethEnable, file.c_str());
-	config.hddEnable = GetPrivateProfileIntA("DEV9", "hddEnable", config.hddEnable, file.c_str());
+	wchar_t wEth[sizeof(config.Eth)] = {0};
+	mbstowcs(wEth, ETH_DEF, sizeof(config.Eth) - 1);
+	GetPrivateProfileString(L"DEV9", L"Eth", wEth, wEth, sizeof(config.Eth), file.c_str());
+	wcstombs(config.Eth, wEth, sizeof(config.Eth) - 1);
+
+	GetPrivateProfileString(L"DEV9", L"Hdd", HDD_DEF, config.Hdd, sizeof(config.Hdd), file.c_str());
+
+	config.HddSize = GetPrivateProfileInt(L"DEV9", L"HddSize", config.HddSize, file.c_str());
+	config.ethEnable = GetPrivateProfileInt(L"DEV9", L"ethEnable", config.ethEnable, file.c_str());
+	config.hddEnable = GetPrivateProfileInt(L"DEV9", L"hddEnable", config.hddEnable, file.c_str());
 }

--- a/pcsx2/DEV9/Win32/DEV9ghzdrk.rc
+++ b/pcsx2/DEV9/Win32/DEV9ghzdrk.rc
@@ -15,7 +15,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// Espagnol (Argentine) resources
+// Spanish (Argentina) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ESS)
 LANGUAGE LANG_SPANISH, SUBLANG_SPANISH_ARGENTINA
@@ -54,23 +54,30 @@ END
 // Dialog
 //
 
-IDD_CONFIG DIALOGEX 0, 0, 290, 170
-STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+IDD_CONFIG DIALOGEX 0, 0, 290, 205
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Network and HDD Settings"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    DEFPUSHBUTTON   "OK",IDOK,92,150,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,148,150,50,14
+    DEFPUSHBUTTON   "OK",IDOK,92,185,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,148,185,50,14
     LTEXT           "DEV9 Type:",IDC_STATIC,15,10,41,11,SS_CENTERIMAGE
-    COMBOBOX        IDC_BAYTYPE,60,8,223,47,CBS_DROPDOWNLIST | CBS_SORT | WS_DISABLED
-    GROUPBOX        "Ethernet",IDC_STATIC,7,30,276,50
+    COMBOBOX        IDC_BAYTYPE,61,8,223,47,CBS_DROPDOWNLIST | CBS_SORT | WS_DISABLED
+    GROUPBOX        "Ethernet",IDC_STATIC,7,30,277,50
     CONTROL         "Enabled",IDC_ETHENABLED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,45,42,8
     LTEXT           "Ethernet Device:",IDC_STATIC,26,60,60,8,SS_CENTERIMAGE
     COMBOBOX        IDC_ETHDEV,94,58,182,82,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    GROUPBOX        "Hard Disk Drive (not yet properly implemented)",IDC_STATIC,7,90,276,50
-    CONTROL         "Enabled",IDC_HDDENABLED,"Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,15,105,42,8
-    LTEXT           "HDD File:",IDC_STATIC,26,120,60,8,SS_CENTERIMAGE | WS_DISABLED
-    EDITTEXT        IDC_HDDFILE,94,118,182,13,ES_AUTOHSCROLL | WS_DISABLED
+    GROUPBOX        "Hard Disk Drive",IDC_STATIC,7,90,277,85
+    CONTROL         "Enabled",IDC_HDDENABLED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,105,42,8
+    LTEXT           "HDD File:",IDC_STATIC,26,120,60,8,SS_CENTERIMAGE
+    EDITTEXT        IDC_HDDFILE,94,118,130,13,ES_AUTOHSCROLL
+    CONTROL         "",IDC_HDDSIZE_SLIDER,"msctls_trackbar32",WS_TABSTOP,90,141,150,15
+    LTEXT           "HDD Size (GiB):",IDC_STATIC,26,143,60,8,SS_CENTERIMAGE
+    EDITTEXT        IDC_HDDSIZE_TEXT,240,141,25,13,ES_AUTOHSCROLL | ES_NUMBER
+    CONTROL         "",IDC_HDDSIZE_SPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_AUTOBUDDY | UDS_ARROWKEYS,265,141,11,13
+    LTEXT           "8 GiB",IDC_STATIC,89,158,17,8
+    LTEXT           "120 GiB",IDC_STATIC,219,157,25,8,0,WS_EX_RIGHT
+    PUSHBUTTON      "Browse",IDC_BROWSE,226,117,50,15
 END
 
 
@@ -85,14 +92,25 @@ BEGIN
     IDD_CONFIG, DIALOG
     BEGIN
         LEFTMARGIN, 7
-        RIGHTMARGIN, 283
+        RIGHTMARGIN, 284
         TOPMARGIN, 7
-        BOTTOMMARGIN, 164
+        BOTTOMMARGIN, 273
     END
 END
 #endif    // APSTUDIO_INVOKED
 
-#endif    // Espagnol (Argentine) resources
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_CONFIG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+#endif    // Spanish (Argentina) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -18,6 +18,8 @@
 //#include <windows.h>
 //#include <windowsx.h>
 
+#include <filesystem>
+
 #include "..\Config.h"
 #include "resource.h"
 #include "..\DEV9.h"
@@ -73,7 +75,7 @@ void OnInitDialog(HWND hW)
 		}
 	}
 
-	SetWindowTextA(GetDlgItem(hW, IDC_HDDFILE), config.Hdd);
+	SetWindowText(GetDlgItem(hW, IDC_HDDFILE), config.Hdd);
 
 	Button_SetCheck(GetDlgItem(hW, IDC_ETHENABLED), config.ethEnable);
 	Button_SetCheck(GetDlgItem(hW, IDC_HDDENABLED), config.hddEnable);
@@ -106,7 +108,7 @@ void OnOk(HWND hW)
 		strcpy(config.Eth, ptr);
 	}
 
-	GetWindowTextA(GetDlgItem(hW, IDC_HDDFILE), config.Hdd, 256);
+	GetWindowText(GetDlgItem(hW, IDC_HDDFILE), config.Hdd, 256);
 
 	config.ethEnable = Button_GetCheck(GetDlgItem(hW, IDC_ETHENABLED));
 	config.hddEnable = Button_GetCheck(GetDlgItem(hW, IDC_HDDENABLED));

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -391,7 +391,7 @@ s32 _DEV9open()
 	NetAdapter* na = GetNetAdapter();
 	if (!na)
 	{
-		emu_printf("Failed to GetNetAdapter()\n");
+		Console.Error("Failed to GetNetAdapter()");
 		config.ethEnable = false;
 	}
 	else

--- a/pcsx2/DEV9/Win32/resource.h
+++ b/pcsx2/DEV9/Win32/resource.h
@@ -1,6 +1,6 @@
 //{{NO_DEPENDENCIES}}
-// fichier Include Microsoft Visual C++.
-// Utilisé par DEV9ghzdrk.rc
+// Microsoft Visual C++ generated include file.
+// Used by DEV9ghzdrk.rc
 //
 #define IDD_CONFDLG                     801
 #define IDD_CONFIG                      801
@@ -11,15 +11,19 @@
 #define IDC_ETHENABLED                  8009
 #define IDC_HDDFILE                     8010
 #define IDC_HDDENABLED                  8011
+#define IDC_HDDSIZE_SLIDER              8012
+#define IDC_HDDSIZE_SPIN                8013
+#define IDC_HDDSIZE_TEXT                8015
+#define IDC_BROWSE                      8017
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        805
+#define _APS_NEXT_RESOURCE_VALUE        806
 #define _APS_NEXT_COMMAND_VALUE         40002
-#define _APS_NEXT_CONTROL_VALUE         8011
+#define _APS_NEXT_CONTROL_VALUE         8018
 #define _APS_NEXT_SYMED_VALUE           801
 #endif
 #endif

--- a/pcsx2/DEV9/flash.cpp
+++ b/pcsx2/DEV9/flash.cpp
@@ -94,7 +94,7 @@ void FLASHinit()
 		ret = fread(file, 1, CARD_SIZE_ECC, fd);
 		if (ret != CARD_SIZE_ECC)
 		{
-			DEV9_LOG("Reading error.");
+			DevCon.WriteLn("Reading error.");
 		}
 
 		fclose(fd);
@@ -112,7 +112,7 @@ u32 FLASHread32(u32 addr, int size)
 		case FLASH_R_DATA:
 			memcpy(&value, &data[counter], size);
 			counter += size;
-			DEV9_LOG("*FLASH DATA %dbit read 0x%08lX %s\n", size * 8, value, (ctrl & FLASH_PP_READ) ? "READ_ENABLE" : "READ_DISABLE");
+			DevCon.WriteLn("*FLASH DATA %dbit read 0x%08lX %s", size * 8, value, (ctrl & FLASH_PP_READ) ? "READ_ENABLE" : "READ_DISABLE");
 			if (cmd == SM_CMD_READ3)
 			{
 				if (counter >= PAGE_SIZE_ECC)
@@ -148,33 +148,33 @@ u32 FLASHread32(u32 addr, int size)
 			return value;
 
 		case FLASH_R_CMD:
-			DEV9_LOG("*FLASH CMD %dbit read %s DENIED\n", size * 8, getCmdName(cmd));
+			DevCon.WriteLn("*FLASH CMD %dbit read %s DENIED", size * 8, getCmdName(cmd));
 			return cmd;
 
 		case FLASH_R_ADDR:
-			DEV9_LOG("*FLASH ADDR %dbit read DENIED\n", size * 8);
+			DevCon.WriteLn("*FLASH ADDR %dbit read DENIED", size * 8);
 			return 0;
 
 		case FLASH_R_CTRL:
-			DEV9_LOG("*FLASH CTRL %dbit read 0x%08lX\n", size * 8, ctrl);
+			DevCon.WriteLn("*FLASH CTRL %dbit read 0x%08lX", size * 8, ctrl);
 			return ctrl;
 
 		case FLASH_R_ID:
 			if (cmd == SM_CMD_READID)
 			{
-				DEV9_LOG("*FLASH ID %dbit read 0x%08lX\n", size * 8, id);
+				DevCon.WriteLn("*FLASH ID %dbit read 0x%08lX", size * 8, id);
 				return id; //0x98=Toshiba/0xEC=Samsung maker code should be returned first
 			}
 			else if (cmd == SM_CMD_GETSTATUS)
 			{
 				value = 0x80 | ((ctrl & 1) << 6); // 0:0=pass, 6:ready/busy, 7:1=not protected
-				DEV9_LOG("*FLASH STATUS %dbit read 0x%08lX\n", size * 8, value);
+				DevCon.WriteLn("*FLASH STATUS %dbit read 0x%08lX", size * 8, value);
 				return value;
 			} //else fall off
 			return 0;
 
 		default:
-			DEV9_LOG("*FLASH Unknown %dbit read at address %lx\n", size * 8, addr);
+			DevCon.WriteLn("*FLASH Unknown %dbit read at address %lx", size * 8, addr);
 			return 0;
 	}
 }
@@ -186,7 +186,7 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 	{
 		case FLASH_R_DATA:
 
-			DEV9_LOG("*FLASH DATA %dbit write 0x%08lX %s\n", size * 8, value, (ctrl & FLASH_PP_WRITE) ? "WRITE_ENABLE" : "WRITE_DISABLE");
+			DevCon.WriteLn("*FLASH DATA %dbit write 0x%08lX %s", size * 8, value, (ctrl & FLASH_PP_WRITE) ? "WRITE_ENABLE" : "WRITE_DISABLE");
 			memcpy(&data[counter], &value, size);
 			counter += size;
 			counter %= PAGE_SIZE_ECC; //should not get past the last byte, but at the end
@@ -197,7 +197,7 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 			{
 				if ((value != SM_CMD_GETSTATUS) && (value != SM_CMD_RESET))
 				{
-					DEV9_LOG("*FLASH CMD %dbit write %s ILLEGAL in busy mode - IGNORED\n", size * 8, getCmdName(value));
+					DevCon.WriteLn("*FLASH CMD %dbit write %s ILLEGAL in busy mode - IGNORED", size * 8, getCmdName(value));
 					break;
 				}
 			}
@@ -205,12 +205,12 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 			{
 				if ((value != SM_CMD_PROGRAMPAGE) && (value != SM_CMD_RESET))
 				{
-					DEV9_LOG("*FLASH CMD %dbit write %s ILLEGAL after WRITEDATA cmd - IGNORED\n", size * 8, getCmdName(value));
+					DevCon.WriteLn("*FLASH CMD %dbit write %s ILLEGAL after WRITEDATA cmd - IGNORED", size * 8, getCmdName(value));
 					ctrl &= ~FLASH_PP_READY; //go busy, reset is needed
 					break;
 				}
 			}
-			DEV9_LOG("*FLASH CMD %dbit write %s\n", size * 8, getCmdName(value));
+			DevCon.WriteLn("*FLASH CMD %dbit write %s", size * 8, getCmdName(value));
 			switch (value)
 			{ // A8 bit is encoded in READ cmd;)
 				case SM_CMD_READ1:
@@ -268,10 +268,10 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 			break;
 
 		case FLASH_R_ADDR:
-			DEV9_LOG("*FLASH ADDR %dbit write 0x%08lX\n", size * 8, value);
+			DevCon.WriteLn("*FLASH ADDR %dbit write 0x%08lX", size * 8, value);
 			address |= (value & 0xFF) << (addrbyte == 0 ? 0 : (1 + 8 * addrbyte));
 			addrbyte++;
-			DEV9_LOG("*FLASH ADDR = 0x%08lX (addrbyte=%d)\n", address, addrbyte);
+			DevCon.WriteLn("*FLASH ADDR = 0x%08lX (addrbyte=%d)", address, addrbyte);
 			if (!(value & 0x100))
 			{ // address is complete
 				if ((cmd == SM_CMD_READ1) || (cmd == SM_CMD_READ2) || (cmd == SM_CMD_READ3))
@@ -287,22 +287,22 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 					u32 pages = address - (blocks * BLOCK_SIZE);
 					[[maybe_unused]]const u32 bytes = pages % PAGE_SIZE;
 					pages = pages / PAGE_SIZE;
-					DEV9_LOG("*FLASH ADDR = 0x%08lX (%d:%d:%d) (addrbyte=%d) FINAL\n", address, blocks, pages, bytes, addrbyte);
+					DevCon.WriteLn("*FLASH ADDR = 0x%08lX (%d:%d:%d) (addrbyte=%d) FINAL", address, blocks, pages, bytes, addrbyte);
 				}
 			}
 			break;
 
 		case FLASH_R_CTRL:
-			DEV9_LOG("*FLASH CTRL %dbit write 0x%08lX\n", size * 8, value);
+			DevCon.WriteLn("*FLASH CTRL %dbit write 0x%08lX", size * 8, value);
 			ctrl = (ctrl & FLASH_PP_READY) | (value & ~FLASH_PP_READY);
 			break;
 
 		case FLASH_R_ID:
-			DEV9_LOG("*FLASH ID %dbit write 0x%08lX DENIED :P\n", size * 8, value);
+			DevCon.WriteLn("*FLASH ID %dbit write 0x%08lX DENIED :P", size * 8, value);
 			break;
 
 		default:
-			DEV9_LOG("*FLASH Unkwnown %dbit write at address 0x%08lX= 0x%08lX IGNORED\n", size * 8, addr, value);
+			DevCon.WriteLn("*FLASH Unkwnown %dbit write at address 0x%08lX= 0x%08lX IGNORED", size * 8, addr, value);
 			break;
 	}
 }

--- a/pcsx2/DEV9/net.cpp
+++ b/pcsx2/DEV9/net.cpp
@@ -74,9 +74,9 @@ void TermNet()
 	{
 		RxRunning = false;
 		nif->close();
-		emu_printf("Waiting for RX-net thread to terminate..");
+		Console.WriteLn("Waiting for RX-net thread to terminate..");
 		rx_thread.join();
-		emu_printf(".done\n");
+		Console.WriteLn("Done");
 
 		delete nif;
 		nif = nullptr;

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -119,7 +119,7 @@ int pcap_io_init(char* adapter, mac_address virtual_mac)
 	char filter[1024] = "ether broadcast or ether dst ";
 	int dlt;
 	char* dlt_name;
-	emu_printf("Opening adapter '%s'...", adapter);
+	Console.WriteLn("Opening adapter '%s'...", adapter);
 
 	/* Open the adapter */
 	if ((adhandle = pcap_open_live(adapter, // name of the device
@@ -130,8 +130,8 @@ int pcap_io_init(char* adapter, mac_address virtual_mac)
 								   errbuf   // error buffer
 								   )) == NULL)
 	{
-		fprintf(stderr, "%s", errbuf);
-		fprintf(stderr, "\nUnable to open the adapter. %s is not supported by pcap\n", adapter);
+		Console.Error("%s", errbuf);
+		Console.Error("Unable to open the adapter. %s is not supported by pcap", adapter);
 		return -1;
 	}
 	char virtual_mac_str[18];
@@ -141,13 +141,13 @@ int pcap_io_init(char* adapter, mac_address virtual_mac)
 
 	if (pcap_compile(adhandle, &fp, filter, 1, PCAP_NETMASK_UNKNOWN) == -1)
 	{
-		fprintf(stderr, "Error calling pcap_compile: %s\n", pcap_geterr(adhandle));
+		Console.Error("Error calling pcap_compile: %s", pcap_geterr(adhandle));
 		return -1;
 	}
 
 	if (pcap_setfilter(adhandle, &fp) == -1)
 	{
-		fprintf(stderr, "Error setting filter: %s\n", pcap_geterr(adhandle));
+		Console.Error("Error setting filter: %s", pcap_geterr(adhandle));
 		return -1;
 	}
 
@@ -155,7 +155,7 @@ int pcap_io_init(char* adapter, mac_address virtual_mac)
 	dlt = pcap_datalink(adhandle);
 	dlt_name = (char*)pcap_datalink_val_to_name(dlt);
 
-	fprintf(stderr, "Device uses DLT %d: %s\n", dlt, dlt_name);
+	Console.Error("Device uses DLT %d: %s", dlt, dlt_name);
 	switch (dlt)
 	{
 		case DLT_EN10MB:
@@ -171,7 +171,7 @@ int pcap_io_init(char* adapter, mac_address virtual_mac)
 	dump_pcap = pcap_dump_open(adhandle, plfile.c_str());
 
 	pcap_io_running = 1;
-	emu_printf("Ok.\n");
+	Console.WriteLn("Adapter Ok.");
 #endif
 	return 0;
 }

--- a/pcsx2/DEV9/smap.cpp
+++ b/pcsx2/DEV9/smap.cpp
@@ -96,7 +96,7 @@ void rx_process(NetPacket* pk)
 
 	if (!(pbd->ctrl_stat & SMAP_BD_RX_EMPTY))
 	{
-		emu_printf("ERROR : Discarding %d bytes (RX%d not ready)\n", bytes, dev9.rxbdi);
+		Console.Error("ERROR : Discarding %d bytes (RX%d not ready)", bytes, dev9.rxbdi);
 		return;
 	}
 
@@ -148,7 +148,7 @@ void tx_process()
 
 		if (!(pbd->ctrl_stat & SMAP_BD_TX_READY))
 		{
-			emu_printf("ERROR : !pbd->ctrl_stat&SMAP_BD_TX_READY\n");
+			Console.Error("SMAP: ERROR : !pbd->ctrl_stat&SMAP_BD_TX_READY");
 			break;
 		}
 		if (pbd->length & 3)
@@ -158,19 +158,18 @@ void tx_process()
 
 		if (pbd->length > 1514)
 		{
-			emu_printf("ERROR : Trying to send packet too big.\n");
+			Console.Error("SMAP: ERROR : Trying to send packet too big.");
 		}
 		else
 		{
 			u32 base = (pbd->pointer - 0x1000) & 16383;
-			DEV9_LOG("Sending Packet from base %x, size %d\n", base, pbd->length);
-			//spams// emu_printf("Sending Packet from base %x, size %u\n", base, pbd->length);
+			DevCon.WriteLn("Sending Packet from base %x, size %d", base, pbd->length);
 
 			pk.size = pbd->length;
 
 			if (!(pbd->pointer >= 0x1000))
 			{
-				emu_printf("ERROR: odd , !pbd->pointer>0x1000 | 0x%X %u\n", pbd->pointer, pbd->length);
+				Console.Error("SMAP: ERROR: odd , !pbd->pointer>0x1000 | 0x%X %u", pbd->pointer, pbd->length);
 			}
 			//increase fifo pointer(s)
 			//uh does that even exist on real h/w ?
@@ -212,7 +211,7 @@ void tx_process()
 				u32 was = 16384 - base;
 				memcpy(pk.buffer, dev9.txfifo + base, was);
 				memcpy(pk.buffer + was, dev9.txfifo, pbd->length - was);
-				printf("Warped read, was=%u, sz=%u, sz-was=%u\n", was, pbd->length, pbd->length - was);
+				DevCon.WriteLn("Warped read, was=%u, sz=%u, sz-was=%u", was, pbd->length, pbd->length - was);
 			}
 			else
 			{
@@ -236,7 +235,7 @@ void tx_process()
 	//if some error/early exit signal TXDNV
 	if (fc != cnt || cnt == 0)
 	{
-		printf("WARN : (fc!=cnt || cnt==0) but packet send request was made oO..\n");
+		Console.Error("SMAP: WARN : (fc!=cnt || cnt==0) but packet send request was made oO..");
 		_DEV9irq(SMAP_INTR_TXDNV, 0);
 	}
 	//if we actualy send something send TXEND
@@ -251,32 +250,32 @@ void emac3_write(u32 addr)
 	switch (addr)
 	{
 		case SMAP_R_EMAC3_MODE0_L:
-			DEV9_LOG("SMAP: SMAP_R_EMAC3_MODE0 write %x\n", value);
+			DevCon.WriteLn("SMAP: SMAP_R_EMAC3_MODE0 write %x", value);
 			value = (value & (~SMAP_E3_SOFT_RESET)) | SMAP_E3_TXMAC_IDLE | SMAP_E3_RXMAC_IDLE;
 			dev9Ru16(SMAP_R_EMAC3_STA_CTRL_H) |= SMAP_E3_PHY_OP_COMP;
 			break;
 		case SMAP_R_EMAC3_TxMODE0_L:
-			DEV9_LOG("SMAP: SMAP_R_EMAC3_TxMODE0_L write %x\n", value);
+			DevCon.WriteLn("SMAP: SMAP_R_EMAC3_TxMODE0_L write %x", value);
 			//spams// emu_printf("SMAP: SMAP_R_EMAC3_TxMODE0_L write %x\n", value);
 			//Process TX  here ?
 			if (!(value & SMAP_E3_TX_GNP_0))
-				emu_printf("SMAP_R_EMAC3_TxMODE0_L: SMAP_E3_TX_GNP_0 not set\n");
+				Console.Error("SMAP_R_EMAC3_TxMODE0_L: SMAP_E3_TX_GNP_0 not set");
 
 			tx_process();
 			value = value & ~SMAP_E3_TX_GNP_0;
 			if (value)
-				emu_printf("SMAP_R_EMAC3_TxMODE0_L: extra bits set !\n");
+				Console.Error("SMAP_R_EMAC3_TxMODE0_L: extra bits set !");
 			break;
 		case SMAP_R_EMAC3_TxMODE1_L:
-			emu_printf("SMAP_R_EMAC3_TxMODE1_L 32bit write %x\n", value);
+			DevCon.WriteLn("SMAP_R_EMAC3_TxMODE1_L 32bit write %x", value);
 			if (value == 0x380f0000)
 			{
-				emu_printf("Adapter Detection Hack - Resetting RX/TX\n");
+				Console.WriteLn("Adapter Detection Hack - Resetting RX/TX");
 				_DEV9irq(SMAP_INTR_RXEND | SMAP_INTR_TXEND | SMAP_INTR_TXDNV, 5);
 			}
 			break;
 		case SMAP_R_EMAC3_STA_CTRL_L:
-			DEV9_LOG("SMAP: SMAP_R_EMAC3_STA_CTRL write %x\n", value);
+			DevCon.WriteLn("SMAP: SMAP_R_EMAC3_STA_CTRL write %x", value);
 			{
 				if (value & (SMAP_E3_PHY_READ))
 				{
@@ -294,7 +293,7 @@ void emac3_write(u32 addr)
 								val |= SMAP_PHY_STS_LINK | SMAP_PHY_STS_100M | SMAP_PHY_STS_FDX | SMAP_PHY_STS_ANCP;
 							break;
 					}
-					DEV9_LOG("phy_read %d: %x\n", reg, val);
+					DevCon.WriteLn("phy_read %d: %x", reg, val);
 					value = (value & 0xFFFF) | (val << 16);
 				}
 				if (value & (SMAP_E3_PHY_WRITE))
@@ -309,13 +308,13 @@ void emac3_write(u32 addr)
 							val |= 0x1;
 							break;
 					}
-					DEV9_LOG("phy_write %d: %x\n", reg, val);
+					DevCon.WriteLn("phy_write %d: %x", reg, val);
 					dev9.phyregs[reg] = val;
 				}
 			}
 			break;
 		default:
-			DEV9_LOG("SMAP: emac3 write  %x=%x\n", addr, value);
+			DevCon.WriteLn("SMAP: emac3 write  %x=%x", addr, value);
 	}
 	dev9Ru32(addr) = wswap(value);
 }
@@ -325,21 +324,21 @@ smap_read8(u32 addr)
 	switch (addr)
 	{
 		case SMAP_R_TXFIFO_FRAME_CNT:
-			printf("SMAP_R_TXFIFO_FRAME_CNT read 8\n");
+			DevCon.WriteLn("SMAP_R_TXFIFO_FRAME_CNT read 8");
 			break;
 		case SMAP_R_RXFIFO_FRAME_CNT:
-			printf("SMAP_R_RXFIFO_FRAME_CNT read 8\n");
+			DevCon.WriteLn("SMAP_R_RXFIFO_FRAME_CNT read 8");
 			break;
 
 		case SMAP_R_BD_MODE:
 			return dev9.bd_swap;
 
 		default:
-			DEV9_LOG("SMAP : Unknown 8 bit read @ %X,v=%X\n", addr, dev9Ru8(addr));
+			DevCon.WriteLn("SMAP : Unknown 8 bit read @ %X,v=%X", addr, dev9Ru8(addr));
 			return dev9Ru8(addr);
 	}
 
-	DEV9_LOG("SMAP : error , 8 bit read @ %X,v=%X\n", addr, dev9Ru8(addr));
+	DevCon.WriteLn("SMAP : error , 8 bit read @ %X,v=%X", addr, dev9Ru8(addr));
 	return dev9Ru8(addr);
 }
 EXPORT_C_(u16)
@@ -356,25 +355,25 @@ smap_read16(u32 addr)
 		{
 		case 0: // ctrl_stat
 			hard = dev9Ru16(addr);
-			//DEV9_LOG("TX_CTRL_STAT[%d]: read %x\n", (addr - SMAP_BD_TX_BASE) / 8, hard);
+			//DevCon.WriteLn("TX_CTRL_STAT[%d]: read %x", (addr - SMAP_BD_TX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		case 2: // unknown
 			hard = dev9Ru16(addr);
-			//DEV9_LOG("TX_UNKNOWN[%d]: read %x\n", (addr - SMAP_BD_TX_BASE) / 8, hard);
+			//DevCon.WriteLn("TX_UNKNOWN[%d]: read %x", (addr - SMAP_BD_TX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		case 4: // length
 			hard = dev9Ru16(addr);
-			DEV9_LOG("TX_LENGTH[%d]: read %x\n", (addr - SMAP_BD_TX_BASE) / 8, hard);
+			DevCon.WriteLn("TX_LENGTH[%d]: read %x", (addr - SMAP_BD_TX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		case 6: // pointer
 			hard = dev9Ru16(addr);
-			DEV9_LOG("TX_POINTER[%d]: read %x\n", (addr - SMAP_BD_TX_BASE) / 8, hard);
+			DevCon.WriteLn("TX_POINTER[%d]: read %x", (addr - SMAP_BD_TX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
@@ -391,105 +390,105 @@ smap_read16(u32 addr)
 		{
 		case 0: // ctrl_stat
 			hard = dev9Ru16(addr);
-			//DEV9_LOG("RX_CTRL_STAT[%d]: read %x\n", (addr - SMAP_BD_RX_BASE) / 8, hard);
+			//DevCon.WriteLn("RX_CTRL_STAT[%d]: read %x", (addr - SMAP_BD_RX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		case 2: // unknown
 			hard = dev9Ru16(addr);
-			//DEV9_LOG("RX_UNKNOWN[%d]: read %x\n", (addr - SMAP_BD_RX_BASE) / 8, hard);
+			//DevCon.WriteLn("RX_UNKNOWN[%d]: read %x", (addr - SMAP_BD_RX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		case 4: // length
 			hard = dev9Ru16(addr);
-			DEV9_LOG("RX_LENGTH[%d]: read %x\n", (addr - SMAP_BD_RX_BASE) / 8, hard);
+			DevCon.WriteLn("RX_LENGTH[%d]: read %x", (addr - SMAP_BD_RX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		case 6: // pointer
 			hard = dev9Ru16(addr);
-			DEV9_LOG("RX_POINTER[%d]: read %x\n", (addr - SMAP_BD_RX_BASE) / 8, hard);
+			DevCon.WriteLn("RX_POINTER[%d]: read %x", (addr - SMAP_BD_RX_BASE) / 8, hard);
 			if(dev9.bd_swap)
 				return (hard<<8)|(hard>>8);
 			return hard;
 		}
 		*/
 	}
-#if (DEV9_LOG_LEVEL <= 1)
+#if (0)
 	switch (addr)
 	{
 		case SMAP_R_TXFIFO_FRAME_CNT:
-			printf("SMAP_R_TXFIFO_FRAME_CNT read 16\n");
+			DevCon.WriteLn("SMAP_R_TXFIFO_FRAME_CNT read 16");
 			return dev9Ru16(addr);
 		case SMAP_R_RXFIFO_FRAME_CNT:
-			printf("SMAP_R_RXFIFO_FRAME_CNT read 16\n");
+			DevCon.WriteLn("SMAP_R_RXFIFO_FRAME_CNT read 16");
 			return dev9Ru16(addr);
 		case SMAP_R_EMAC3_MODE0_L:
-			DEV9_LOG("SMAP_R_EMAC3_MODE0_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_MODE0_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_MODE0_H:
-			DEV9_LOG("SMAP_R_EMAC3_MODE0_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_MODE0_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_MODE1_L:
-			DEV9_LOG("SMAP_R_EMAC3_MODE1_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_MODE1_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_MODE1_H:
-			DEV9_LOG("SMAP_R_EMAC3_MODE1_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_MODE1_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_RxMODE_L:
-			DEV9_LOG("SMAP_R_EMAC3_RxMODE_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_RxMODE_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_RxMODE_H:
-			DEV9_LOG("SMAP_R_EMAC3_RxMODE_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_RxMODE_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_INTR_STAT_L:
-			DEV9_LOG("SMAP_R_EMAC3_INTR_STAT_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_INTR_STAT_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_INTR_STAT_H:
-			DEV9_LOG("SMAP_R_EMAC3_INTR_STAT_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_INTR_STAT_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_INTR_ENABLE_L:
-			DEV9_LOG("SMAP_R_EMAC3_INTR_ENABLE_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_INTR_ENABLE_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_INTR_ENABLE_H:
-			DEV9_LOG("SMAP_R_EMAC3_INTR_ENABLE_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_INTR_ENABLE_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_TxMODE0_L:
-			DEV9_LOG("SMAP_R_EMAC3_TxMODE0_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_TxMODE0_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_TxMODE0_H:
-			DEV9_LOG("SMAP_R_EMAC3_TxMODE0_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_TxMODE0_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_TxMODE1_L:
-			DEV9_LOG("SMAP_R_EMAC3_TxMODE1_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_TxMODE1_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_TxMODE1_H:
-			DEV9_LOG("SMAP_R_EMAC3_TxMODE1_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_TxMODE1_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_STA_CTRL_L:
-			DEV9_LOG("SMAP_R_EMAC3_STA_CTRL_L 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_STA_CTRL_L 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 
 		case SMAP_R_EMAC3_STA_CTRL_H:
-			DEV9_LOG("SMAP_R_EMAC3_STA_CTRL_H 16bit read %x\n", dev9Ru16(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_STA_CTRL_H 16bit read %x", dev9Ru16(addr));
 			return dev9Ru16(addr);
 		default:
-			DEV9_LOG("SMAP : Unknown 16 bit read @ %X,v=%X\n", addr, dev9Ru16(addr));
+			DevCon.WriteLn("SMAP : Unknown 16 bit read @ %X,v=%X", addr, dev9Ru16(addr));
 			return dev9Ru16(addr);
 	}
 #endif
@@ -508,13 +507,13 @@ smap_read32(u32 addr)
 	switch (addr)
 	{
 		case SMAP_R_TXFIFO_FRAME_CNT:
-			printf("SMAP_R_TXFIFO_FRAME_CNT read 32\n");
+			DevCon.WriteLn("SMAP_R_TXFIFO_FRAME_CNT read 32");
 			return dev9Ru32(addr);
 		case SMAP_R_RXFIFO_FRAME_CNT:
-			printf("SMAP_R_RXFIFO_FRAME_CNT read 32\n");
+			DevCon.WriteLn("SMAP_R_RXFIFO_FRAME_CNT read 32");
 			return dev9Ru32(addr);
 		case SMAP_R_EMAC3_STA_CTRL_L:
-			DEV9_LOG("SMAP_R_EMAC3_STA_CTRL_L 32bit read value %x\n", dev9Ru32(addr));
+			DevCon.WriteLn("SMAP_R_EMAC3_STA_CTRL_L 32bit read value %x", dev9Ru32(addr));
 			return dev9Ru32(addr);
 
 		case SMAP_R_RXFIFO_DATA:
@@ -528,11 +527,11 @@ smap_read32(u32 addr)
 			if (dev9.bd_swap)
 				rv = (rv << 24) | (rv >> 24) | ((rv >> 8) & 0xFF00) | ((rv << 8) & 0xFF0000);
 
-			DEV9_LOG("SMAP_R_RXFIFO_DATA 32bit read %x\n", rv);
+			DevCon.WriteLn("SMAP_R_RXFIFO_DATA 32bit read %x", rv);
 			return rv;
 		}
 		default:
-			DEV9_LOG("SMAP : Unknown 32 bit read @ %X,v=%X\n", addr, dev9Ru32(addr));
+			DevCon.WriteLn("SMAP : Unknown 32 bit read @ %X,v=%X", addr, dev9Ru32(addr));
 			return dev9Ru32(addr);
 	}
 }
@@ -544,14 +543,14 @@ smap_write8(u32 addr, u8 value)
 	switch (addr)
 	{
 		case SMAP_R_TXFIFO_FRAME_INC:
-			DEV9_LOG("SMAP_R_TXFIFO_FRAME_INC 8bit write %x\n", value);
+			DevCon.WriteLn("SMAP_R_TXFIFO_FRAME_INC 8bit write %x", value);
 			{
 				dev9Ru8(SMAP_R_TXFIFO_FRAME_CNT)++;
 			}
 			return;
 
 		case SMAP_R_RXFIFO_FRAME_DEC:
-			DEV9_LOG("SMAP_R_RXFIFO_FRAME_DEC 8bit write %x\n", value);
+			DevCon.WriteLn("SMAP_R_RXFIFO_FRAME_DEC 8bit write %x", value);
 			counter_lock.lock();
 			dev9Ru8(addr) = value;
 			{
@@ -561,7 +560,7 @@ smap_write8(u32 addr, u8 value)
 			return;
 
 		case SMAP_R_TXFIFO_CTRL:
-			DEV9_LOG("SMAP_R_TXFIFO_CTRL 8bit write %x\n", value);
+			DevCon.WriteLn("SMAP_R_TXFIFO_CTRL 8bit write %x", value);
 			if (value & SMAP_TXFIFO_RESET)
 			{
 				dev9.txbdi = 0;
@@ -575,7 +574,7 @@ smap_write8(u32 addr, u8 value)
 			return;
 
 		case SMAP_R_RXFIFO_CTRL:
-			DEV9_LOG("SMAP_R_RXFIFO_CTRL 8bit write %x\n", value);
+			DevCon.WriteLn("SMAP_R_RXFIFO_CTRL 8bit write %x", value);
 			if (value & SMAP_RXFIFO_RESET)
 			{
 				reset_lock.lock(); //lock reset mutex 1st
@@ -595,19 +594,17 @@ smap_write8(u32 addr, u8 value)
 		case SMAP_R_BD_MODE:
 			if (value & SMAP_BD_SWAP)
 			{
-				DEV9_LOG("SMAP_R_BD_MODE: byteswapped.\n");
-				emu_printf("BD Byteswapping enabled.\n");
+				DevCon.WriteLn("SMAP_R_BD_MODE: Byteswapping enabled.");
 				dev9.bd_swap = 1;
 			}
 			else
 			{
-				DEV9_LOG("SMAP_R_BD_MODE: NOT byteswapped.\n");
-				emu_printf("BD Byteswapping disabled.\n");
+				DevCon.WriteLn("SMAP_R_BD_MODE: Byteswapping disabled.");
 				dev9.bd_swap = 0;
 			}
 			return;
 		default:
-			DEV9_LOG("SMAP : Unknown 8 bit write @ %X,v=%X\n", addr, value);
+			DevCon.WriteLn("SMAP : Unknown 8 bit write @ %X,v=%X", addr, value);
 			dev9Ru8(addr) = value;
 			return;
 	}
@@ -624,20 +621,20 @@ smap_write16(u32 addr, u16 value)
 		switch (addr & 0x7) 
 		{
 		case 0: // ctrl_stat
-			DEV9_LOG("TX_CTRL_STAT[%d]: write %x\n", (addr - SMAP_BD_TX_BASE) / 8, value);
+			DevCon.WriteLn("TX_CTRL_STAT[%d]: write %x", (addr - SMAP_BD_TX_BASE) / 8, value);
 			//hacky
 			dev9Ru16(addr) = value;
 			return;
 		case 2: // unknown
-			//DEV9_LOG("TX_UNKNOWN[%d]: write %x\n", (addr - SMAP_BD_TX_BASE) / 8, value);
+			//DevCon.WriteLn("TX_UNKNOWN[%d]: write %x", (addr - SMAP_BD_TX_BASE) / 8, value);
 			dev9Ru16(addr) = value;
 			return;
 		case 4: // length
-			DEV9_LOG("TX_LENGTH[%d]: write %x\n", (addr - SMAP_BD_TX_BASE) / 8, value);
+			DevCon.WriteLn("TX_LENGTH[%d]: write %x", (addr - SMAP_BD_TX_BASE) / 8, value);
 			dev9Ru16(addr) = value;
 			return;
 		case 6: // pointer
-			DEV9_LOG("TX_POINTER[%d]: write %x\n", (addr - SMAP_BD_TX_BASE) / 8, value);
+			DevCon.WriteLn("TX_POINTER[%d]: write %x", (addr - SMAP_BD_TX_BASE) / 8, value);
 			dev9Ru16(addr) = value;
 			return;
 		}
@@ -654,23 +651,23 @@ smap_write16(u32 addr, u16 value)
 		switch (addr & 0x7) 
 		{
 		case 0: // ctrl_stat
-			DEV9_LOG("RX_CTRL_STAT[%d]: write %x\n", rx_index, value);
+			DevCon.WriteLn("RX_CTRL_STAT[%d]: write %x", rx_index, value);
 			dev9Ru16(addr) = value;
 			if(value&0x8000)
 			{
-				DEV9_LOG(" * * PACKET READ COMPLETE:   rd_ptr=%d, wr_ptr=%d\n", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
+				DevCon.WriteLn(" * * PACKET READ COMPLETE:   rd_ptr=%d, wr_ptr=%d", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
 			}
 			return;
 		case 2: // unknown
-			//DEV9_LOG("RX_UNKNOWN[%d]: write %x\n", rx_index, value);
+			//DevCon.WriteLn("RX_UNKNOWN[%d]: write %x", rx_index, value);
 			dev9Ru16(addr) = value;
 			return;
 		case 4: // length
-			DEV9_LOG("RX_LENGTH[%d]: write %x\n", rx_index, value);
+			DevCon.WriteLn("RX_LENGTH[%d]: write %x", rx_index, value);
 			dev9Ru16(addr) = value;
 			return;
 		case 6: // pointer
-			DEV9_LOG("RX_POINTER[%d]: write %x\n", rx_index, value);
+			DevCon.WriteLn("RX_POINTER[%d]: write %x", rx_index, value);
 			dev9Ru16(addr) = value;
 			return;
 		}
@@ -681,17 +678,17 @@ smap_write16(u32 addr, u16 value)
 	switch (addr)
 	{
 		case SMAP_R_INTR_CLR:
-			DEV9_LOG("SMAP: SMAP_R_INTR_CLR 16bit write %x\n", value);
+			DevCon.WriteLn("SMAP: SMAP_R_INTR_CLR 16bit write %x", value);
 			dev9.irqcause &= ~value;
 			return;
 
 		case SMAP_R_TXFIFO_WR_PTR:
-			DEV9_LOG("SMAP: SMAP_R_TXFIFO_WR_PTR 16bit write %x\n", value);
+			DevCon.WriteLn("SMAP: SMAP_R_TXFIFO_WR_PTR 16bit write %x", value);
 			dev9Ru16(addr) = value;
 			return;
 #define EMAC3_L_WRITE(name)                                   \
 	case name:                                                \
-		DEV9_LOG("SMAP: " #name " 16 bit write %x\n", value); \
+		DevCon.WriteLn("SMAP: " #name " 16 bit write %x", value); \
 		dev9Ru16(addr) = value;                               \
 		return;
 	// clang-format off
@@ -728,7 +725,7 @@ smap_write16(u32 addr, u16 value)
 
 #define EMAC3_H_WRITE(name)                                   \
 	case name:                                                \
-		DEV9_LOG("SMAP: " #name " 16 bit write %x\n", value); \
+		DevCon.WriteLn("SMAP: " #name " 16 bit write %x", value); \
 		dev9Ru16(addr) = value;                               \
 		emac3_write(addr - 2);                                \
 		return;
@@ -765,11 +762,11 @@ smap_write16(u32 addr, u16 value)
 	// clang-format on
 			/*
 	case SMAP_R_EMAC3_MODE0_L:
-		DEV9_LOG("SMAP: SMAP_R_EMAC3_MODE0 write %x\n", value);
+		DevCon.WriteLn("SMAP: SMAP_R_EMAC3_MODE0 write %x", value);
 		dev9Ru16(addr) = value;
 		return;
 	case SMAP_R_EMAC3_TxMODE0_L:
-		DEV9_LOG("SMAP: SMAP_R_EMAC3_TxMODE0_L 16bit write %x\n", value);
+		DevCon.WriteLn("SMAP: SMAP_R_EMAC3_TxMODE0_L 16bit write %x", value);
 		dev9Ru16(addr) = value;
 		return;
 	case SMAP_R_EMAC3_TxMODE1_L:
@@ -787,13 +784,13 @@ smap_write16(u32 addr, u16 value)
 		dev9Ru16(addr) = value;
 		return;
 	case SMAP_R_EMAC3_STA_CTRL_H:
-		DEV9_LOG("SMAP: SMAP_R_EMAC3_STA_CTRL_H 16bit write %x\n", value);
+		DevCon.WriteLn("SMAP: SMAP_R_EMAC3_STA_CTRL_H 16bit write %x", value);
 		dev9Ru16(addr) = value;
 		return;
 		*/
 
 		default:
-			DEV9_LOG("SMAP : Unknown 16 bit write @ %X,v=%X\n", addr, value);
+			DevCon.WriteLn("SMAP : Unknown 16 bit write @ %X,v=%X", addr, value);
 			dev9Ru16(addr) = value;
 			return;
 	}
@@ -813,12 +810,12 @@ smap_write32(u32 addr, u32 value)
 			if (dev9.bd_swap)
 				value = (value << 24) | (value >> 24) | ((value >> 8) & 0xFF00) | ((value << 8) & 0xFF0000);
 
-			DEV9_LOG("SMAP_R_TXFIFO_DATA 32bit write %x\n", value);
+			DevCon.WriteLn("SMAP_R_TXFIFO_DATA 32bit write %x", value);
 			*((u32*)(dev9.txfifo + dev9Ru32(SMAP_R_TXFIFO_WR_PTR))) = value;
 			dev9Ru32(SMAP_R_TXFIFO_WR_PTR) = (dev9Ru32(SMAP_R_TXFIFO_WR_PTR) + 4) & 16383;
 			return;
 		default:
-			DEV9_LOG("SMAP : Unknown 32 bit write @ %X,v=%X\n", addr, value);
+			DevCon.WriteLn("SMAP : Unknown 32 bit write @ %X,v=%X", addr, value);
 			dev9Ru32(addr) = value;
 			return;
 	}
@@ -830,7 +827,7 @@ smap_readDMA8Mem(u32* pMem, int size)
 	{
 		dev9Ru32(SMAP_R_RXFIFO_RD_PTR) &= 16383;
 
-		DEV9_LOG(" * * SMAP DMA READ START: rd_ptr=%d, wr_ptr=%d\n", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
+		DevCon.WriteLn(" * * SMAP DMA READ START: rd_ptr=%d, wr_ptr=%d", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
 		while (size > 0)
 		{
 			*pMem = *((u32*)(dev9.rxfifo + dev9Ru32(SMAP_R_RXFIFO_RD_PTR)));
@@ -839,7 +836,7 @@ smap_readDMA8Mem(u32* pMem, int size)
 
 			size -= 4;
 		}
-		DEV9_LOG(" * * SMAP DMA READ END:   rd_ptr=%d, wr_ptr=%d\n", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
+		DevCon.WriteLn(" * * SMAP DMA READ END:   rd_ptr=%d, wr_ptr=%d", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
 
 		dev9Ru16(SMAP_R_RXFIFO_CTRL) &= ~SMAP_RXFIFO_DMAEN;
 	}
@@ -851,7 +848,7 @@ smap_writeDMA8Mem(u32* pMem, int size)
 	{
 		dev9Ru32(SMAP_R_TXFIFO_WR_PTR) &= 16383;
 
-		DEV9_LOG(" * * SMAP DMA WRITE START: wr_ptr=%d, rd_ptr=%d\n", dev9Ru32(SMAP_R_TXFIFO_WR_PTR), dev9.txfifo_rd_ptr);
+		DevCon.WriteLn(" * * SMAP DMA WRITE START: wr_ptr=%d, rd_ptr=%d", dev9Ru32(SMAP_R_TXFIFO_WR_PTR), dev9.txfifo_rd_ptr);
 		while (size > 0)
 		{
 			int value = *pMem;
@@ -862,7 +859,7 @@ smap_writeDMA8Mem(u32* pMem, int size)
 			dev9Ru32(SMAP_R_TXFIFO_WR_PTR) = (dev9Ru32(SMAP_R_TXFIFO_WR_PTR) + 4) & 16383;
 			size -= 4;
 		}
-		DEV9_LOG(" * * SMAP DMA WRITE END:   wr_ptr=%d, rd_ptr=%d\n", dev9Ru32(SMAP_R_TXFIFO_WR_PTR), dev9.txfifo_rd_ptr);
+		DevCon.WriteLn(" * * SMAP DMA WRITE END:   wr_ptr=%d, rd_ptr=%d", dev9Ru32(SMAP_R_TXFIFO_WR_PTR), dev9.txfifo_rd_ptr);
 
 		dev9Ru16(SMAP_R_TXFIFO_CTRL) &= ~SMAP_TXFIFO_DMAEN;
 	}

--- a/pcsx2/DEV9/smap.cpp
+++ b/pcsx2/DEV9/smap.cpp
@@ -416,7 +416,7 @@ smap_read16(u32 addr)
 		}
 		*/
 	}
-#ifdef DEV9_LOG_ENABLE
+#if (DEV9_LOG_LEVEL <= 1)
 	switch (addr)
 	{
 		case SMAP_R_TXFIFO_FRAME_CNT:
@@ -829,7 +829,7 @@ smap_readDMA8Mem(u32* pMem, int size)
 	if (dev9Ru16(SMAP_R_RXFIFO_CTRL) & SMAP_RXFIFO_DMAEN)
 	{
 		dev9Ru32(SMAP_R_RXFIFO_RD_PTR) &= 16383;
-		size >>= 1;
+
 		DEV9_LOG(" * * SMAP DMA READ START: rd_ptr=%d, wr_ptr=%d\n", dev9Ru32(SMAP_R_RXFIFO_RD_PTR), dev9.rxfifo_wr_ptr);
 		while (size > 0)
 		{
@@ -850,7 +850,7 @@ smap_writeDMA8Mem(u32* pMem, int size)
 	if (dev9Ru16(SMAP_R_TXFIFO_CTRL) & SMAP_TXFIFO_DMAEN)
 	{
 		dev9Ru32(SMAP_R_TXFIFO_WR_PTR) &= 16383;
-		size >>= 1;
+
 		DEV9_LOG(" * * SMAP DMA WRITE START: wr_ptr=%d, rd_ptr=%d\n", dev9Ru32(SMAP_R_TXFIFO_WR_PTR), dev9.txfifo_rd_ptr);
 		while (size > 0)
 		{

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -267,6 +267,17 @@
     <ClCompile Include="..\..\DebugTools\MipsAssemblerTables.cpp" />
     <ClCompile Include="..\..\DebugTools\MipsStackWalk.cpp" />
     <ClCompile Include="..\..\DebugTools\SymbolMap.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_Command.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdDMA.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdExecuteDeviceDiag.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdNoData.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdPIOData.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdSMART.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_SCE.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\ATA_Info.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\ATA_State.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\ATA_Transfer.cpp" />
+    <ClCompile Include="..\..\DEV9\ATA\HddCreate.cpp" />
     <ClCompile Include="..\..\DEV9\DEV9.cpp" />
     <ClCompile Include="..\..\DEV9\flash.cpp" />
     <ClCompile Include="..\..\DEV9\pcap_io.cpp" />
@@ -628,7 +639,8 @@
     <ClInclude Include="..\..\DebugTools\MipsAssemblerTables.h" />
     <ClInclude Include="..\..\DebugTools\MipsStackWalk.h" />
     <ClInclude Include="..\..\DebugTools\SymbolMap.h" />
-    <ClInclude Include="..\..\DEV9\ata.h" />
+    <ClInclude Include="..\..\DEV9\ATA\ATA.h" />
+    <ClInclude Include="..\..\DEV9\ATA\HddCreate.h" />
     <ClInclude Include="..\..\DEV9\Config.h" />
     <ClInclude Include="..\..\DEV9\DEV9.h" />
     <ClInclude Include="..\..\DEV9\net.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -1066,6 +1066,9 @@
     <ClCompile Include="..\..\DEV9\smap.cpp">
       <Filter>System\Ps2\DEV9</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\DEV9\net.cpp">
+      <Filter>System\Ps2\DEV9</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\DEV9\Win32\tap-win32.cpp">
       <Filter>System\Ps2\DEV9</Filter>
     </ClCompile>
@@ -1210,7 +1213,6 @@
     <ClCompile Include="..\..\USB\shared\rawinput_usb.cpp">
       <Filter>System\Ps2\USB\shared</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\DEV9\net.cpp" />
     <ClCompile Include="..\..\PAD\Windows\DeviceEnumerator.cpp">
       <Filter>System\Ps2\PAD</Filter>
     </ClCompile>

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -172,6 +172,12 @@
     <Filter Include="System\Ps2\DEV9">
       <UniqueIdentifier>{8d5454f9-590c-4c53-aae1-8391c6465e50}</UniqueIdentifier>
     </Filter>
+    <Filter Include="System\Ps2\DEV9\ATA">
+      <UniqueIdentifier>{bc20f567-851d-4440-a3fd-ef470241962e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="System\Ps2\DEV9\ATA\Commands">
+      <UniqueIdentifier>{9e9b52d7-7b1c-44b2-82d8-1e0d8085e7e0}</UniqueIdentifier>
+    </Filter>
     <Filter Include="System\Ps2\USB">
       <UniqueIdentifier>{df9de75c-2272-4f73-b2a0-4f9f492ba1e9}</UniqueIdentifier>
     </Filter>
@@ -1054,6 +1060,39 @@
     <ClCompile Include="..\..\SPU2\SndOut_Portaudio.cpp">
       <Filter>System\Ps2\SPU2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_Command.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdDMA.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdExecuteDeviceDiag.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdNoData.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdPIOData.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_CmdSMART.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\Commands\ATA_SCE.cpp">
+      <Filter>System\Ps2\DEV9\ATA\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\ATA_Info.cpp">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\ATA_State.cpp">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\ATA_Transfer.cpp">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DEV9\ATA\HddCreate.cpp">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\DEV9\DEV9.cpp">
       <Filter>System\Ps2\DEV9</Filter>
     </ClCompile>
@@ -1788,8 +1827,11 @@
     <ClInclude Include="..\..\Recording\Utilities\InputRecordingLogger.h">
       <Filter>Recording\Utilities</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\DEV9\ata.h">
-      <Filter>System\Ps2\DEV9</Filter>
+    <ClInclude Include="..\..\DEV9\ATA\ATA.h">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\DEV9\ATA\HddCreate.h">
+      <Filter>System\Ps2\DEV9\ATA</Filter>
     </ClInclude>
     <ClInclude Include="..\..\DEV9\Config.h">
       <Filter>System\Ps2\DEV9</Filter>


### PR DESCRIPTION
This is mostly the code from CLR_DEV9, with some tweaks and changes that I spotted during the porting process.

While CLR_DEV9 had split the speed emulation into a separate file, I chose to not do so for bringing in my changes to the speed code.

The emulator will auto create the file if it is missing

As a todo list

- [x] Add to Linux build scripts
- [x] Wire up the config for Linux
- [x] Config HDD UI for windows
- [x] Config HDD UI for Linux
- [x] HDD creation progress UI
- [x] Mac OS support (Requires #3999 to be merged first)
