### PR TITLE
BIOSHLE: Use BIOS settings on fastboot

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -259,6 +259,11 @@ static void cdvdWriteMAC(const u8* num)
 	setNvmData(num, 0, 8, offsetof(NVMLayout, mac));
 }
 
+void cdvdReadLanguageParams(u8* config)
+{
+	getNvmData(config, 0xF, 16, offsetof(NVMLayout, config1));
+}
+
 s32 cdvdReadConfig(u8* config)
 {
 	// make sure its in read mode

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -139,6 +139,8 @@ struct cdvdStruct
 
 extern cdvdStruct cdvd;
 
+extern void cdvdReadLanguageParams(u8* config);
+
 extern void cdvdReset();
 extern void cdvdVsync();
 extern void cdvdActionInterrupt();

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -132,7 +132,7 @@ const char * const R5900::bios[256]=
 	"KSeg0",				"EnableCache",	"DisableCache",			"GetCop0",
 	"FlushCache",			"RFU101",		"CpuConfig",			"iGetCop0",
 	"iFlushCache",			"RFU105",		"iCpuConfig", 			"sceSifStopDma",
-	"SetCPUTimerHandler",	"SetCPUTimer",	"SetOsdConfigParam2",	"SetOsdConfigParam2",
+	"SetCPUTimerHandler",	"SetCPUTimer",	"SetOsdConfigParam2",	"GetOsdConfigParam2",
 //0x70
 	"GsGetIMR_iGsGetIMR",				"GsGetIMR_iGsPutIMR",	"SetPgifHandler", 				"SetVSyncFlag",
 	"RFU116",							"print", 				"sceSifDmaStat_isceSifDmaStat", "sceSifSetDma_isceSifSetDma",
@@ -950,6 +950,7 @@ void SYSCALL()
 				u8 params[16];
 			
 				cdvdReadLanguageParams(params);
+
 				u32 osdconf = 0;
 				u32 timezone = params[4] | ((u32)(params[3] & 0x7) << 8);
 
@@ -962,8 +963,21 @@ void SYSCALL()
 				memcpy(pointer, &osdconf, 4);
 				return;
 			}
-		break;
+			break;
+		case Syscall::GetOSParamConfig2:
+			if (g_SkipBiosHack)
+			{
+				u8* pointer = (u8*)PSM(cpuRegs.GPR.n.a0.UL[0]);
+				u8 params[16];
 
+				cdvdReadLanguageParams(params);
+
+				u32 osdconf2 = (u32)((params[3] & 0x78) << 1);  // Daylight Savings, 24hr clock, Date format
+
+				memcpy(pointer, &osdconf2, 4);
+				return;
+			}
+			break;
 		case Syscall::SetVTLBRefillHandler:
 			DevCon.Warning("A tlb refill handler is set. New handler %x", (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));
 			break;

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -23,6 +23,7 @@
 #include "R5900OpcodeTables.h"
 #include "R5900Exceptions.h"
 #include "GS.h"
+#include "CDVD/CDVD.h"
 
 GS_VideoMode gsVideoMode = GS_VideoMode::Uninitialized;
 bool gsIsInterlaced = false;
@@ -942,6 +943,26 @@ void SYSCALL()
 					DevCon.Warning("Set GS CRTC configuration. %s %s (%s)",mode.c_str(), inter, field);
 				}
 				break;
+		case Syscall::GetOSParamConfig:
+			if(g_SkipBiosHack)
+			{
+				u8* pointer = (u8*)PSM(cpuRegs.GPR.n.a0.UL[0]);
+				u8 params[16];
+			
+				cdvdReadLanguageParams(params);
+				u32 osdconf = 0;
+				u32 timezone = params[4] | ((u32)(params[3] & 0x7) << 8);
+
+				osdconf |= params[1] & 0x1F;						// SPDIF, Screen mode, RGB/Comp, Jap/Eng Switch (Early bios)
+				osdconf |= (u32)params[0] << 5;						// PS1 Mode Settings
+				osdconf |= (u32)((params[2] & 0xE0) >> 5) << 13;	// OSD Ver (Not sure but best guess)
+				osdconf |= (u32)(params[2] & 0x1F) << 16;			// Language
+				osdconf |= timezone << 21;							// Timezone
+
+				memcpy(pointer, &osdconf, 4);
+				return;
+			}
+		break;
 
 		case Syscall::SetVTLBRefillHandler:
 			DevCon.Warning("A tlb refill handler is set. New handler %x", (u32*)PSM(cpuRegs.GPR.n.a1.UL[0]));

--- a/pcsx2/R5900OpcodeTables.h
+++ b/pcsx2/R5900OpcodeTables.h
@@ -22,6 +22,7 @@ enum Syscall : u8
 	SetGsCrt = 2,
 	SetVTLBRefillHandler = 13,
 	GetOSParamConfig = 75,
+	GetOSParamConfig2 = 111,
 	sysPrintOut = 117,
 	sceSifSetDma = 119,
 	Deci2Call = 124

--- a/pcsx2/R5900OpcodeTables.h
+++ b/pcsx2/R5900OpcodeTables.h
@@ -21,6 +21,7 @@ enum Syscall : u8
 {
 	SetGsCrt = 2,
 	SetVTLBRefillHandler = 13,
+	GetOSParamConfig = 75,
 	sysPrintOut = 117,
 	sceSifSetDma = 119,
 	Deci2Call = 124


### PR DESCRIPTION
Should fix bad fonts when booting a game fast
Selects correct language for games depending on your BIOS setting when using fast boot
Stops games such as Guitar Hero 2 from crashing on fast boot.

PR also now corrects timezones in games.

Fixes #480