### PR TITLE
GSVertexTrace::FindMinMax improvements

### DIFF
--- a/pcsx2/GS/GSVector4.h
+++ b/pcsx2/GS/GSVector4.h
@@ -205,6 +205,17 @@ public:
 		return m;
 	}
 
+	/// Makes Clang think that the whole vector is needed, preventing it from changing shuffles around because it thinks we don't need the whole vector
+	/// Useful for e.g. preventing clang from optimizing shuffles that remove possibly-denormal garbage data from vectors before computing with them
+	__forceinline GSVector4 noopt()
+	{
+		// Note: Clang is currently the only compiler that attempts to optimize vector intrinsics, if that changes in the future the implementation should be updated
+#ifdef __clang__
+		__asm__("":"+x"(m)::);
+#endif
+		return *this;
+	}
+
 	__forceinline uint32 rgba32() const
 	{
 		return GSVector4i(*this).rgba32();

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -202,9 +202,9 @@ void GSVertexTrace::FindMinMax(const void* vertex, const uint32* index, int coun
 					GSVector4 q = stq.wwww();
 
 					if (accurate_stq)
-						stq = (stq.xyww() / q).xyww(q);
+						stq = (stq.xyww() / q).noopt().xyww(q);
 					else
-						stq = (stq.xyww() * q.rcpnr()).xyww(q);
+						stq = (stq.xyww() * q.rcpnr()).noopt().xyww(q);
 
 					tmin = tmin.min(stq);
 					tmax = tmax.max(stq);
@@ -256,19 +256,21 @@ void GSVertexTrace::FindMinMax(const void* vertex, const uint32* index, int coun
 					GSVector4 stq0 = GSVector4::cast(c0);
 					GSVector4 stq1 = GSVector4::cast(c1);
 
+					GSVector4 q = stq0.wwww(stq1);
+
 					if (accurate_stq)
 					{
-						GSVector4 q = stq0.wwww(stq1);
+						GSVector4 st = stq0.xyxy(stq1) / q;
 
-						stq0 = (stq0.xyww() / q.xxxx()).xyww(stq0);
-						stq1 = (stq1.xyww() / q.zzzz()).xyww(stq1);
+						stq0 = st.xyww(stq1);
+						stq1 = st.zwww(stq1);
 					}
 					else
 					{
-						GSVector4 q = stq0.wwww(stq1).rcpnr();
+						GSVector4 st = stq0.xyxy(stq1) * q.rcpnr();
 
-						stq0 = (stq0.xyww() * q.xxxx()).xyww(stq0);
-						stq1 = (stq1.xyww() * q.zzzz()).xyww(stq1);
+						stq0 = st.xyww(stq0);
+						stq1 = st.zwww(stq1);
 					}
 
 					tmin = tmin.min(stq0.min(stq1));
@@ -331,19 +333,20 @@ void GSVertexTrace::FindMinMax(const void* vertex, const uint32* index, int coun
 
 					if (accurate_stq)
 					{
-						GSVector4 q = stq0.wwww(stq1).xzww(stq2);
+						GSVector4 st01 = stq0.xyxy(stq1) / stq0.wwww(stq1);
 
-						stq0 = (stq0.xyww() / q.xxxx()).xyww(stq0);
-						stq1 = (stq1.xyww() / q.yyyy()).xyww(stq1);
-						stq2 = (stq2.xyww() / q.zzzz()).xyww(stq2);
+						stq0 = st01.xyww(stq0);
+						stq1 = st01.zwww(stq1);
+						stq2 = (stq2.xyww() / stq2.wwww()).noopt().xyww(stq2);
 					}
 					else
 					{
 						GSVector4 q = stq0.wwww(stq1).xzww(stq2).rcpnr();
+						GSVector4 st01 = stq0.xyxy(stq1) * q.xxyy();
 
-						stq0 = (stq0.xyww() * q.xxxx()).xyww(stq0);
-						stq1 = (stq1.xyww() * q.yyyy()).xyww(stq1);
-						stq2 = (stq2.xyww() * q.zzzz()).xyww(stq2);
+						stq0 = st01.xyww(stq0);
+						stq1 = st01.zwww(stq1);
+						stq2 = (stq2.xyww() * q.zzzz()).noopt().xyww(stq2);
 					}
 
 					tmin = tmin.min(stq2).min(stq0.min(stq1));
@@ -410,17 +413,17 @@ void GSVertexTrace::FindMinMax(const void* vertex, const uint32* index, int coun
 
 					if (accurate_stq)
 					{
-						GSVector4 q = stq1.wwww();
+						GSVector4 st = stq0.xyxy(stq1) / stq1.wwww();
 
-						stq0 = (stq0.xyww() / q).xyww(stq1);
-						stq1 = (stq1.xyww() / q).xyww(stq1);
+						stq0 = st.xyww(stq1);
+						stq1 = st.zwww(stq1);
 					}
 					else
 					{
-						GSVector4 q = stq1.wwww().rcpnr();
+						GSVector4 st = stq0.xyxy(stq1) * stq1.wwww().rcpnr();
 
-						stq0 = (stq0.xyww() * q).xyww(stq1);
-						stq1 = (stq1.xyww() * q).xyww(stq1);
+						stq0 = st.xyww(stq1);
+						stq1 = st.zwww(stq1);
 					}
 
 					tmin = tmin.min(stq0.min(stq1));

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -47,9 +47,9 @@ protected:
 
 	typedef void (GSVertexTrace::*FindMinMaxPtr)(const void* vertex, const uint32* index, int count);
 
-	FindMinMaxPtr m_fmm[2][2][2][2][2][4];
+	FindMinMaxPtr m_fmm[2][2][2][2][4];
 
-	template <GS_PRIM_CLASS primclass, uint32 iip, uint32 tme, uint32 fst, uint32 color, uint32 accurate_stq>
+	template <GS_PRIM_CLASS primclass, uint32 iip, uint32 tme, uint32 fst, uint32 color>
 	void FindMinMax(const void* vertex, const uint32* index, int count);
 
 public:

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -87,6 +87,9 @@ void GSRendererOGL::SetupIA(const float& sx, const float& sy)
 			//
 			// Note2: Due to MultiThreaded driver, Nvidia suffers less of the previous issue. Still it isn't free
 			// Shadow Heart is 90 fps (gs) vs 113 fps (no gs)
+			//
+			// Note3: Some GPUs (Happens on GT 750m, not on Intel 5200) don't properly divide by large floats (e.g. FLT_MAX/FLT_MAX == 0)
+			// Lines2Sprites predivides by Q, avoiding this issue, so always use it if m_vt.m_accurate_stq
 
 			// If the draw calls contains few primitives. Geometry Shader gain with be rather small versus
 			// the extra validation cost of the extra stage.


### PR DESCRIPTION
*when you spend a bunch of time optimizing a function because you think it accounts for 30% of runtime but that was actually due to the compiler being stupid and not issues with the algorithm*

This PR contains the following changes:

- Prevents clang from optimizing out our denormal-removal shuffles (10x faster than before for people who compile with clang!)
- Run divides on four elements at a time instead of two elements and two useless numbers
- ~~Run per-vertex instead of per-primitive for all things that need to apply to all vertices of a primitive anyways (prevents double-checking vertices in triangle strips, and also reduces pointer chases in the main loop)~~ This broke stuff
- Remove inaccurate stq
  - With the above division improvements, on processors with partially-pipelined division (Ivy Bridge and later, Bulldozer and later), accurate stq is actually faster (according to both IACA of [inaccurate](https://gist.github.com/tellowkrinkle/36124c0871ce3bd1ebdb5d6a7dd5e1b4#file-findminmax00-analysis-hsw-txt) vs [accurate](https://gist.github.com/tellowkrinkle/36124c0871ce3bd1ebdb5d6a7dd5e1b4#file-findminmax01-analysis-hsw-txt) and [LLVM MCA](https://analysis.godbolt.org/z/xqvY64)).  On older CPUs expect performance to be about 2/3 of the old algorithm before taking into account improvements from not double-checking vertices.  
  - ~~There seems to be a check of `accurate_stq` when the OGL backend is deciding whether to use geometry shaders to process sprites, does anyone know if that's important or just something someone threw in there that's okay to remove?~~ Reason found, added as comment

In the end, ignoring clang issues, GSVertexTrace::FindMinMax goes from taking about 3% of MTGS thread runtime to 1.5% on my computer.  (Most of the time was spent doing OpenGL things so if you have a more efficient OpenGL driver it might make more of a difference for you)