### PR TITLE
Folder memcards: Add an index file to track order of files

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -26,10 +26,11 @@
 
 #include "svnrev.h"
 
-bool RemoveDirectory( const wxString& dirname );
+bool RemoveDirectory(const wxString& dirname);
 
 // A helper function to parse the YAML file
-static YAML::Node LoadYAMLFromFile( const wxString& fileName ) {
+static YAML::Node LoadYAMLFromFile(const wxString& fileName)
+{
 	YAML::Node index;
 
 	wxFFile indexFile;
@@ -37,20 +38,23 @@ static YAML::Node LoadYAMLFromFile( const wxString& fileName ) {
 	{
 		// Suppress "file does not exist" errors
 		wxLogNull noLog;
-		result = indexFile.Open( fileName, L"r" );
+		result = indexFile.Open(fileName, L"r");
 	}
 
-	if ( result ) {
+	if (result)
+	{
 		wxString fileContents;
-		if ( indexFile.ReadAll( &fileContents ) ) {
-			index = YAML::Load( fileContents.mbc_str() );
+		if (indexFile.ReadAll(&fileContents))
+		{
+			index = YAML::Load(fileContents.mbc_str());
 		}
 	}
 
 	return index;
 }
 
-FolderMemoryCard::FolderMemoryCard() {
+FolderMemoryCard::FolderMemoryCard()
+{
 	m_slot = 0;
 	m_isEnabled = false;
 	m_performFileWrites = false;
@@ -60,12 +64,13 @@ FolderMemoryCard::FolderMemoryCard() {
 	m_filteringString = L"";
 }
 
-void FolderMemoryCard::InitializeInternalData() {
-	memset( &m_superBlock, 0xFF, sizeof( m_superBlock ) );
-	memset( &m_indirectFat, 0xFF, sizeof( m_indirectFat ) );
-	memset( &m_fat, 0xFF, sizeof( m_fat ) );
-	memset( &m_backupBlock1, 0xFF, sizeof( m_backupBlock1 ) );
-	memset( &m_backupBlock2, 0xFF, sizeof( m_backupBlock2 ) );
+void FolderMemoryCard::InitializeInternalData()
+{
+	memset(&m_superBlock, 0xFF, sizeof(m_superBlock));
+	memset(&m_indirectFat, 0xFF, sizeof(m_indirectFat));
+	memset(&m_fat, 0xFF, sizeof(m_fat));
+	memset(&m_backupBlock1, 0xFF, sizeof(m_backupBlock1));
+	memset(&m_backupBlock2, 0xFF, sizeof(m_backupBlock2));
 	m_cache.clear();
 	m_oldDataCache.clear();
 	m_lastAccessedFile.CloseAll();
@@ -78,62 +83,78 @@ void FolderMemoryCard::InitializeInternalData() {
 	m_filteringString = L"";
 }
 
-bool FolderMemoryCard::IsFormatted() const {
+bool FolderMemoryCard::IsFormatted() const
+{
 	// this should be a good enough arbitrary check, if someone can think of a case where this doesn't work feel free to change
 	return m_superBlock.raw[0x16] == 0x6F;
 }
 
-void FolderMemoryCard::Open( const bool enableFiltering, const wxString& filter ) {
-	Open( g_Conf->FullpathToMcd( m_slot ), g_Conf->Mcd[m_slot], 0, enableFiltering, filter, false );
+void FolderMemoryCard::Open(const bool enableFiltering, const wxString& filter)
+{
+	Open(g_Conf->FullpathToMcd(m_slot), g_Conf->Mcd[m_slot], 0, enableFiltering, filter, false);
 }
 
-void FolderMemoryCard::Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter, bool simulateFileWrites ) {
+void FolderMemoryCard::Open(const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter, bool simulateFileWrites)
+{
 	InitializeInternalData();
 	m_performFileWrites = !simulateFileWrites;
 
-	wxFileName configuredFileName( fullPath );
-	m_folderName = wxFileName( configuredFileName.GetFullPath() + L"/" );
-	wxString str( configuredFileName.GetFullPath() );
+	wxFileName configuredFileName(fullPath);
+	m_folderName = wxFileName(configuredFileName.GetFullPath() + L"/");
+	wxString str(configuredFileName.GetFullPath());
 	bool disabled = false;
 
-	if ( mcdOptions.Enabled && mcdOptions.Type == MemoryCardType::MemoryCard_Folder ) {
-		if ( configuredFileName.GetFullName().IsEmpty() ) {
+	if (mcdOptions.Enabled && mcdOptions.Type == MemoryCardType::MemoryCard_Folder)
+	{
+		if (configuredFileName.GetFullName().IsEmpty())
+		{
 			str = L"[empty filename]";
 			disabled = true;
 		}
-		if ( !disabled && configuredFileName.FileExists() ) {
+		if (!disabled && configuredFileName.FileExists())
+		{
 			str = L"[is file, should be folder]";
 			disabled = true;
 		}
 
 		// if nothing exists at a valid location, create a directory for the memory card
-		if ( !disabled && m_performFileWrites && !m_folderName.DirExists() ) {
-			if ( !m_folderName.Mkdir() ) {
+		if (!disabled && m_performFileWrites && !m_folderName.DirExists())
+		{
+			if (!m_folderName.Mkdir())
+			{
 				str = L"[couldn't create folder]";
 				disabled = true;
 			}
 		}
-	} else {
+	}
+	else
+	{
 		// if the user has disabled this slot or is using a different memory card type, just return without a console log
 		return;
 	}
 
-	Console.WriteLn( disabled ? Color_Gray : Color_Green, L"McdSlot %u: [Folder] " + str, m_slot );
-	if ( disabled ) return;
+	Console.WriteLn(disabled ? Color_Gray : Color_Green, L"McdSlot %u: [Folder] " + str, m_slot);
+	if (disabled)
+		return;
 
 	m_isEnabled = true;
 	m_filteringEnabled = enableFiltering;
 	m_filteringString = filter;
-	LoadMemoryCardData( sizeInClusters, enableFiltering, filter );
+	LoadMemoryCardData(sizeInClusters, enableFiltering, filter);
 
 	SetTimeLastWrittenToNow();
 	m_framesUntilFlush = 0;
 }
 
-void FolderMemoryCard::Close( bool flush ) {
-	if ( !m_isEnabled ) { return; }
+void FolderMemoryCard::Close(bool flush)
+{
+	if (!m_isEnabled)
+	{
+		return;
+	}
 
-	if ( flush ) {
+	if (flush)
+	{
 		Flush();
 	}
 
@@ -143,83 +164,98 @@ void FolderMemoryCard::Close( bool flush ) {
 	m_fileMetadataQuickAccess.clear();
 }
 
-bool FolderMemoryCard::ReIndex( bool enableFiltering, const wxString& filter ) {
-	if ( !m_isEnabled ) { return false; }
+bool FolderMemoryCard::ReIndex(bool enableFiltering, const wxString& filter)
+{
+	if (!m_isEnabled)
+	{
+		return false;
+	}
 
-	if ( m_filteringEnabled != enableFiltering || m_filteringString != filter ) {
+	if (m_filteringEnabled != enableFiltering || m_filteringString != filter)
+	{
 		Close();
-		Open( enableFiltering, filter );
+		Open(enableFiltering, filter);
 		return true;
 	}
 
 	return false;
 }
 
-void FolderMemoryCard::LoadMemoryCardData( const u32 sizeInClusters, const bool enableFiltering, const wxString& filter ) {
+void FolderMemoryCard::LoadMemoryCardData(const u32 sizeInClusters, const bool enableFiltering, const wxString& filter)
+{
 	bool formatted = false;
 
 	// read superblock if it exists
-	wxFileName superBlockFileName( m_folderName.GetPath(), L"_pcsx2_superblock" );
-	if ( superBlockFileName.FileExists() ) {
-		wxFFile superBlockFile( superBlockFileName.GetFullPath().c_str(), L"rb" );
-		if ( superBlockFile.IsOpened() && superBlockFile.Read( &m_superBlock.raw, sizeof( m_superBlock.raw ) ) >= sizeof( m_superBlock.data ) ) {
+	wxFileName superBlockFileName(m_folderName.GetPath(), L"_pcsx2_superblock");
+	if (superBlockFileName.FileExists())
+	{
+		wxFFile superBlockFile(superBlockFileName.GetFullPath().c_str(), L"rb");
+		if (superBlockFile.IsOpened() && superBlockFile.Read(&m_superBlock.raw, sizeof(m_superBlock.raw)) >= sizeof(m_superBlock.data))
+		{
 			formatted = IsFormatted();
 		}
 	}
 
-	if ( sizeInClusters > 0 && sizeInClusters != GetSizeInClusters() ) {
-		SetSizeInClusters( sizeInClusters );
-		FlushBlock( 0 );
+	if (sizeInClusters > 0 && sizeInClusters != GetSizeInClusters())
+	{
+		SetSizeInClusters(sizeInClusters);
+		FlushBlock(0);
 	}
 
 	// if superblock was valid, load folders and files
-	if ( formatted ) {
-		if ( enableFiltering ) {
-			Console.WriteLn( Color_Green, L"(FolderMcd) Indexing slot %u with filter \"%s\".", m_slot, WX_STR( filter ) );
-		} else {
-			Console.WriteLn( Color_Green, L"(FolderMcd) Indexing slot %u without filter.", m_slot );
+	if (formatted)
+	{
+		if (enableFiltering)
+		{
+			Console.WriteLn(Color_Green, L"(FolderMcd) Indexing slot %u with filter \"%s\".", m_slot, WX_STR(filter));
+		}
+		else
+		{
+			Console.WriteLn(Color_Green, L"(FolderMcd) Indexing slot %u without filter.", m_slot);
 		}
 
 		CreateFat();
 		CreateRootDir();
 		MemoryCardFileEntry* const rootDirEntry = &m_fileEntryDict[m_superBlock.data.rootdir_cluster].entries[0];
-		AddFolder( rootDirEntry, m_folderName.GetPath(), nullptr, enableFiltering, filter );
-		
-		#ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
-		WriteToFile( m_folderName.GetFullPath().RemoveLast() + L"-debug_" +  wxDateTime::Now().Format( L"%Y-%m-%d-%H-%M-%S" ) + L"_load.ps2" );
-		#endif
+		AddFolder(rootDirEntry, m_folderName.GetPath(), nullptr, enableFiltering, filter);
+
+#ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
+		WriteToFile(m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format(L"%Y-%m-%d-%H-%M-%S") + L"_load.ps2");
+#endif
 	}
 }
 
-void FolderMemoryCard::CreateFat() {
+void FolderMemoryCard::CreateFat()
+{
 	const u32 totalClusters = m_superBlock.data.clusters_per_card;
 	const u32 clusterSize = m_superBlock.data.page_len * m_superBlock.data.pages_per_cluster;
 	const u32 fatEntriesPerCluster = clusterSize / 4;
-	const u32 countFatClusters = ( totalClusters % fatEntriesPerCluster ) != 0 ? ( totalClusters / fatEntriesPerCluster + 1 ) : ( totalClusters / fatEntriesPerCluster );
+	const u32 countFatClusters = (totalClusters % fatEntriesPerCluster) != 0 ? (totalClusters / fatEntriesPerCluster + 1) : (totalClusters / fatEntriesPerCluster);
 	const u32 countDataClusters = m_superBlock.data.alloc_end;
 
 	// create indirect FAT
-	for ( unsigned int i = 0; i < countFatClusters; ++i ) {
+	for (unsigned int i = 0; i < countFatClusters; ++i)
+	{
 		m_indirectFat.data[0][i] = GetFreeSystemCluster();
 	}
 
 	// fill FAT with default values
-	for ( unsigned int i = 0; i < countDataClusters; ++i ) {
+	for (unsigned int i = 0; i < countDataClusters; ++i)
+	{
 		m_fat.data[0][0][i] = 0x7FFFFFFFu;
 	}
 }
 
-void FolderMemoryCard::CreateRootDir() {
+void FolderMemoryCard::CreateRootDir()
+{
 	MemoryCardFileEntryCluster* const rootCluster = &m_fileEntryDict[m_superBlock.data.rootdir_cluster];
-	memset( rootCluster->entries[0].entry.raw, 0x00, sizeof( rootCluster->entries[0].entry.raw ) );
-	rootCluster->entries[0].entry.data.mode = MemoryCardFileEntry::Mode_Read | MemoryCardFileEntry::Mode_Write | MemoryCardFileEntry::Mode_Execute
-	                                        | MemoryCardFileEntry::Mode_Directory | MemoryCardFileEntry::Mode_Unknown0x0400 | MemoryCardFileEntry::Mode_Used;
+	memset(rootCluster->entries[0].entry.raw, 0x00, sizeof(rootCluster->entries[0].entry.raw));
+	rootCluster->entries[0].entry.data.mode = MemoryCardFileEntry::Mode_Read | MemoryCardFileEntry::Mode_Write | MemoryCardFileEntry::Mode_Execute | MemoryCardFileEntry::Mode_Directory | MemoryCardFileEntry::Mode_Unknown0x0400 | MemoryCardFileEntry::Mode_Used;
 	rootCluster->entries[0].entry.data.length = 2;
 	rootCluster->entries[0].entry.data.name[0] = '.';
 
-	memset( rootCluster->entries[1].entry.raw, 0x00, sizeof( rootCluster->entries[1].entry.raw ) );
-	rootCluster->entries[1].entry.data.mode = MemoryCardFileEntry::Mode_Write | MemoryCardFileEntry::Mode_Execute | MemoryCardFileEntry::Mode_Directory
-	                                        | MemoryCardFileEntry::Mode_Unknown0x0400 | MemoryCardFileEntry::Mode_Unknown0x2000 | MemoryCardFileEntry::Mode_Used;
+	memset(rootCluster->entries[1].entry.raw, 0x00, sizeof(rootCluster->entries[1].entry.raw));
+	rootCluster->entries[1].entry.data.mode = MemoryCardFileEntry::Mode_Write | MemoryCardFileEntry::Mode_Execute | MemoryCardFileEntry::Mode_Directory | MemoryCardFileEntry::Mode_Unknown0x0400 | MemoryCardFileEntry::Mode_Unknown0x2000 | MemoryCardFileEntry::Mode_Used;
 	rootCluster->entries[1].entry.data.name[0] = '.';
 	rootCluster->entries[1].entry.data.name[1] = '.';
 
@@ -227,20 +263,25 @@ void FolderMemoryCard::CreateRootDir() {
 	m_fat.data[0][0][m_superBlock.data.rootdir_cluster] = LastDataCluster | DataClusterInUseMask;
 }
 
-u32 FolderMemoryCard::GetFreeSystemCluster() const {
+u32 FolderMemoryCard::GetFreeSystemCluster() const
+{
 	// first block is reserved for superblock
-	u32 highestUsedCluster = ( m_superBlock.data.pages_per_block / m_superBlock.data.pages_per_cluster ) - 1;
+	u32 highestUsedCluster = (m_superBlock.data.pages_per_block / m_superBlock.data.pages_per_cluster) - 1;
 
 	// can't use any of the indirect fat clusters
-	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
-		highestUsedCluster = std::max( highestUsedCluster, m_superBlock.data.ifc_list[i] );
+	for (int i = 0; i < IndirectFatClusterCount; ++i)
+	{
+		highestUsedCluster = std::max(highestUsedCluster, m_superBlock.data.ifc_list[i]);
 	}
 
 	// or fat clusters
-	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
-		for ( int j = 0; j < ClusterSize / 4; ++j ) {
-			if ( m_indirectFat.data[i][j] != IndirectFatUnused ) {
-				highestUsedCluster = std::max( highestUsedCluster, m_indirectFat.data[i][j] );
+	for (int i = 0; i < IndirectFatClusterCount; ++i)
+	{
+		for (int j = 0; j < ClusterSize / 4; ++j)
+		{
+			if (m_indirectFat.data[i][j] != IndirectFatUnused)
+			{
+				highestUsedCluster = std::max(highestUsedCluster, m_indirectFat.data[i][j]);
 			}
 		}
 	}
@@ -248,22 +289,26 @@ u32 FolderMemoryCard::GetFreeSystemCluster() const {
 	return highestUsedCluster + 1;
 }
 
-u32 FolderMemoryCard::GetAmountDataClusters() const {
+u32 FolderMemoryCard::GetAmountDataClusters() const
+{
 	// BIOS reports different cluster values than what the memory card actually has, match that when adding files
 	//  8mb card -> BIOS:  7999 clusters / Superblock:  8135 clusters
 	// 16mb card -> BIOS: 15999 clusters / Superblock: 16295 clusters
 	// 32mb card -> BIOS: 31999 clusters / Superblock: 32615 clusters
 	// 64mb card -> BIOS: 64999 clusters / Superblock: 65255 clusters
-	return ( m_superBlock.data.alloc_end / 1000 ) * 1000 - 1;
+	return (m_superBlock.data.alloc_end / 1000) * 1000 - 1;
 }
 
-u32 FolderMemoryCard::GetFreeDataCluster() const {
+u32 FolderMemoryCard::GetFreeDataCluster() const
+{
 	const u32 countDataClusters = GetAmountDataClusters();
 
-	for ( unsigned int i = 0; i < countDataClusters; ++i ) {
+	for (unsigned int i = 0; i < countDataClusters; ++i)
+	{
 		const u32 cluster = m_fat.data[0][0][i];
 
-		if ( ( cluster & DataClusterInUseMask ) == 0 ) {
+		if ((cluster & DataClusterInUseMask) == 0)
+		{
 			return i;
 		}
 	}
@@ -271,14 +316,17 @@ u32 FolderMemoryCard::GetFreeDataCluster() const {
 	return 0xFFFFFFFFu;
 }
 
-u32 FolderMemoryCard::GetAmountFreeDataClusters() const {
+u32 FolderMemoryCard::GetAmountFreeDataClusters() const
+{
 	const u32 countDataClusters = GetAmountDataClusters();
 	u32 countFreeDataClusters = 0;
 
-	for ( unsigned int i = 0; i < countDataClusters; ++i ) {
+	for (unsigned int i = 0; i < countDataClusters; ++i)
+	{
 		const u32 cluster = m_fat.data[0][0][i];
 
-		if ( ( cluster & DataClusterInUseMask ) == 0 ) {
+		if ((cluster & DataClusterInUseMask) == 0)
+		{
 			++countFreeDataClusters;
 		}
 	}
@@ -286,28 +334,37 @@ u32 FolderMemoryCard::GetAmountFreeDataClusters() const {
 	return countFreeDataClusters;
 }
 
-u32 FolderMemoryCard::GetLastClusterOfData( const u32 cluster ) const {
+u32 FolderMemoryCard::GetLastClusterOfData(const u32 cluster) const
+{
 	u32 entryCluster;
 	u32 nextCluster = cluster;
-	do {
+	do
+	{
 		entryCluster = nextCluster;
 		nextCluster = m_fat.data[0][0][entryCluster] & NextDataClusterMask;
-	} while ( nextCluster != LastDataCluster );
+	} while (nextCluster != LastDataCluster);
 	return entryCluster;
 }
 
-MemoryCardFileEntry* FolderMemoryCard::AppendFileEntryToDir( const MemoryCardFileEntry* const dirEntry ) {
-	u32 entryCluster = GetLastClusterOfData( dirEntry->entry.data.cluster );
+MemoryCardFileEntry* FolderMemoryCard::AppendFileEntryToDir(const MemoryCardFileEntry* const dirEntry)
+{
+	u32 entryCluster = GetLastClusterOfData(dirEntry->entry.data.cluster);
 
 	MemoryCardFileEntry* newFileEntry;
-	if ( dirEntry->entry.data.length % 2 == 0 ) {
+	if (dirEntry->entry.data.length % 2 == 0)
+	{
 		// need new cluster
 		u32 newCluster = GetFreeDataCluster();
-		if ( newCluster == 0xFFFFFFFFu ) { return nullptr; }
+		if (newCluster == 0xFFFFFFFFu)
+		{
+			return nullptr;
+		}
 		m_fat.data[0][0][entryCluster] = newCluster | DataClusterInUseMask;
 		m_fat.data[0][0][newCluster] = LastDataCluster | DataClusterInUseMask;
 		newFileEntry = &m_fileEntryDict[newCluster].entries[0];
-	} else {
+	}
+	else
+	{
 		// can use last page of existing clusters
 		newFileEntry = &m_fileEntryDict[entryCluster].entries[1];
 	}
@@ -315,17 +372,21 @@ MemoryCardFileEntry* FolderMemoryCard::AppendFileEntryToDir( const MemoryCardFil
 	return newFileEntry;
 }
 
-bool FilterMatches( const wxString& fileName, const wxString& filter ) {
+bool FilterMatches(const wxString& fileName, const wxString& filter)
+{
 	size_t start = 0;
 	size_t len = filter.Len();
-	while ( start < len ) {
-		size_t end = filter.find( '/', start );
-		if ( end == wxString::npos ) {
+	while (start < len)
+	{
+		size_t end = filter.find('/', start);
+		if (end == wxString::npos)
+		{
 			end = len;
 		}
 
-		wxString singleFilter = filter.Mid( start, end - start );
-		if ( fileName.Contains( singleFilter ) ) {
+		wxString singleFilter = filter.Mid(start, end - start);
+		if (fileName.Contains(singleFilter))
+		{
 			return true;
 		}
 
@@ -335,71 +396,89 @@ bool FilterMatches( const wxString& fileName, const wxString& filter ) {
 	return false;
 }
 
-bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, MemoryCardFileMetadataReference* parent, const bool enableFiltering, const wxString& filter ) {
-	if ( wxDir::Exists( dirPath ) ) {
+bool FolderMemoryCard::AddFolder(MemoryCardFileEntry* const dirEntry, const wxString& dirPath, MemoryCardFileMetadataReference* parent, const bool enableFiltering, const wxString& filter)
+{
+	if (wxDir::Exists(dirPath))
+	{
 
 		wxString localFilter;
-		if ( enableFiltering ) {
+		if (enableFiltering)
+		{
 			bool hasFilter = !filter.IsEmpty();
-			if ( hasFilter ) {
+			if (hasFilter)
+			{
 				localFilter = L"DATA-SYSTEM/BWNETCNF/" + filter;
-			} else {
+			}
+			else
+			{
 				localFilter = L"DATA-SYSTEM/BWNETCNF";
 			}
 		}
 
 		int entryNumber = 2; // include . and ..
-		for ( const auto& file : GetOrderedFiles( dirPath ) ) {
+		for (const auto& file : GetOrderedFiles(dirPath))
+		{
 
-			wxFileName fileInfo( dirPath, file.m_fileName );
+			wxFileName fileInfo(dirPath, file.m_fileName);
 
-			if ( file.m_isFile ) {
+			if (file.m_isFile)
+			{
 				// don't load files in the root dir if we're filtering; no official software stores files there
-				if ( enableFiltering && parent == nullptr ) {
+				if (enableFiltering && parent == nullptr)
+				{
 					continue;
 				}
-				if ( AddFile( dirEntry, dirPath, file, parent ) ) {
+				if (AddFile(dirEntry, dirPath, file, parent))
+				{
 					++entryNumber;
 				}
-			} else {
+			}
+			else
+			{
 				// if possible filter added directories by game serial
 				// this has the effective result of only files relevant to the current game being loaded into the memory card
 				// which means every game essentially sees the memory card as if no other files exist
-				if ( enableFiltering && !FilterMatches( file.m_fileName, localFilter ) ) {
+				if (enableFiltering && !FilterMatches(file.m_fileName, localFilter))
+				{
 					continue;
 				}
 
 				// make sure we have enough space on the memcard for the directory
-				const u32 newNeededClusters = CalculateRequiredClustersOfDirectory( dirPath + L"/" + file.m_fileName ) + ( ( dirEntry->entry.data.length % 2 ) == 0 ? 1 : 0 );
-				if ( newNeededClusters > GetAmountFreeDataClusters() ) {
-					Console.Warning( GetCardFullMessage( file.m_fileName ) );
+				const u32 newNeededClusters = CalculateRequiredClustersOfDirectory(dirPath + L"/" + file.m_fileName) + ((dirEntry->entry.data.length % 2) == 0 ? 1 : 0);
+				if (newNeededClusters > GetAmountFreeDataClusters())
+				{
+					Console.Warning(GetCardFullMessage(file.m_fileName));
 					continue;
 				}
 
 				// is a subdirectory
-				fileInfo.AppendDir( fileInfo.GetFullName() );
-				fileInfo.SetName( L"" );
+				fileInfo.AppendDir(fileInfo.GetFullName());
+				fileInfo.SetName(L"");
 				fileInfo.ClearExt();
 
 				// add entry for subdir in parent dir
-				MemoryCardFileEntry* newDirEntry = AppendFileEntryToDir( dirEntry );
+				MemoryCardFileEntry* newDirEntry = AppendFileEntryToDir(dirEntry);
 				dirEntry->entry.data.length++;
 
 				// set metadata
-				wxFileName metaFileName( dirPath, L"_pcsx2_meta_directory" );
-				metaFileName.AppendDir( file.m_fileName );
+				wxFileName metaFileName(dirPath, L"_pcsx2_meta_directory");
+				metaFileName.AppendDir(file.m_fileName);
 				wxFFile metaFile;
-				if ( metaFileName.FileExists() && metaFile.Open( metaFileName.GetFullPath(), L"rb" ) ) {
-					size_t bytesRead = metaFile.Read( &newDirEntry->entry.raw, sizeof( newDirEntry->entry.raw ) );
+				if (metaFileName.FileExists() && metaFile.Open(metaFileName.GetFullPath(), L"rb"))
+				{
+					size_t bytesRead = metaFile.Read(&newDirEntry->entry.raw, sizeof(newDirEntry->entry.raw));
 					metaFile.Close();
-					if ( bytesRead < 0x60 ) {
-						strcpy( reinterpret_cast<char*>(newDirEntry->entry.data.name), file.m_fileName.mbc_str() );
+					if (bytesRead < 0x60)
+					{
+						strcpy(reinterpret_cast<char*>(newDirEntry->entry.data.name), file.m_fileName.mbc_str());
 					}
-				} else {
+				}
+				else
+				{
 					newDirEntry->entry.data.mode = MemoryCardFileEntry::DefaultDirMode;
-					newDirEntry->entry.data.timeCreated = MemoryCardFileEntryDateTime::FromTime( file.m_timeCreated );
-					newDirEntry->entry.data.timeModified = MemoryCardFileEntryDateTime::FromTime( file.m_timeModified );
-					strcpy( reinterpret_cast<char*>(newDirEntry->entry.data.name), file.m_fileName.mbc_str() );
+					newDirEntry->entry.data.timeCreated = MemoryCardFileEntryDateTime::FromTime(file.m_timeCreated);
+					newDirEntry->entry.data.timeModified = MemoryCardFileEntryDateTime::FromTime(file.m_timeModified);
+					strcpy(reinterpret_cast<char*>(newDirEntry->entry.data.name), file.m_fileName.mbc_str());
 				}
 
 				// create new cluster for . and .. entries
@@ -409,22 +488,22 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 				newDirEntry->entry.data.cluster = newCluster;
 
 				MemoryCardFileEntryCluster* const subDirCluster = &m_fileEntryDict[newCluster];
-				memset( subDirCluster->entries[0].entry.raw, 0x00, sizeof( subDirCluster->entries[0].entry.raw ) );
+				memset(subDirCluster->entries[0].entry.raw, 0x00, sizeof(subDirCluster->entries[0].entry.raw));
 				subDirCluster->entries[0].entry.data.mode = MemoryCardFileEntry::DefaultDirMode;
 				subDirCluster->entries[0].entry.data.dirEntry = entryNumber;
 				subDirCluster->entries[0].entry.data.name[0] = '.';
 
-				memset( subDirCluster->entries[1].entry.raw, 0x00, sizeof( subDirCluster->entries[1].entry.raw ) );
+				memset(subDirCluster->entries[1].entry.raw, 0x00, sizeof(subDirCluster->entries[1].entry.raw));
 				subDirCluster->entries[1].entry.data.mode = MemoryCardFileEntry::DefaultDirMode;
 				subDirCluster->entries[1].entry.data.name[0] = '.';
 				subDirCluster->entries[1].entry.data.name[1] = '.';
 
-				MemoryCardFileMetadataReference* dirRef = AddDirEntryToMetadataQuickAccess( newDirEntry, parent );
+				MemoryCardFileMetadataReference* dirRef = AddDirEntryToMetadataQuickAccess(newDirEntry, parent);
 
 				++entryNumber;
 
 				// and add all files in subdir
-				AddFolder( newDirEntry, fileInfo.GetFullPath(), dirRef );
+				AddFolder(newDirEntry, fileInfo.GetFullPath(), dirRef);
 			}
 		}
 
@@ -434,115 +513,136 @@ bool FolderMemoryCard::AddFolder( MemoryCardFileEntry* const dirEntry, const wxS
 	return false;
 }
 
-bool FolderMemoryCard::AddFile( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const EnumeratedFileEntry& fileEntry, MemoryCardFileMetadataReference* parent ) {
-	wxFileName relativeFilePath( dirPath, fileEntry.m_fileName );
-	relativeFilePath.MakeRelativeTo( m_folderName.GetPath() );
+bool FolderMemoryCard::AddFile(MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const EnumeratedFileEntry& fileEntry, MemoryCardFileMetadataReference* parent)
+{
+	wxFileName relativeFilePath(dirPath, fileEntry.m_fileName);
+	relativeFilePath.MakeRelativeTo(m_folderName.GetPath());
 
-	wxFileName fileInfo( dirPath, fileEntry.m_fileName );
-	wxFFile file( fileInfo.GetFullPath(), L"rb" );
-	if ( file.IsOpened() ) {
+	wxFileName fileInfo(dirPath, fileEntry.m_fileName);
+	wxFFile file(fileInfo.GetFullPath(), L"rb");
+	if (file.IsOpened())
+	{
 		// make sure we have enough space on the memcard to hold the data
 		const u32 clusterSize = m_superBlock.data.pages_per_cluster * m_superBlock.data.page_len;
 		const u32 filesize = file.Length();
-		const u32 countClusters = ( filesize % clusterSize ) != 0 ? ( filesize / clusterSize + 1 ) : ( filesize / clusterSize );
-		const u32 newNeededClusters = ( dirEntry->entry.data.length % 2 ) == 0 ? countClusters + 1 : countClusters;
-		if ( newNeededClusters > GetAmountFreeDataClusters() ) {
-			Console.Warning( GetCardFullMessage( relativeFilePath.GetFullPath() ) );
+		const u32 countClusters = (filesize % clusterSize) != 0 ? (filesize / clusterSize + 1) : (filesize / clusterSize);
+		const u32 newNeededClusters = (dirEntry->entry.data.length % 2) == 0 ? countClusters + 1 : countClusters;
+		if (newNeededClusters > GetAmountFreeDataClusters())
+		{
+			Console.Warning(GetCardFullMessage(relativeFilePath.GetFullPath()));
 			return false;
 		}
 
-		MemoryCardFileEntry* newFileEntry = AppendFileEntryToDir( dirEntry );
+		MemoryCardFileEntry* newFileEntry = AppendFileEntryToDir(dirEntry);
 
 		// set file entry metadata
-		memset( newFileEntry->entry.raw, 0x00, sizeof( newFileEntry->entry.raw ) );
+		memset(newFileEntry->entry.raw, 0x00, sizeof(newFileEntry->entry.raw));
 
-		wxFileName metaFileName( dirPath, fileEntry.m_fileName );
-		metaFileName.AppendDir( L"_pcsx2_meta" );
+		wxFileName metaFileName(dirPath, fileEntry.m_fileName);
+		metaFileName.AppendDir(L"_pcsx2_meta");
 		wxFFile metaFile;
-		if ( metaFileName.FileExists() && metaFile.Open( metaFileName.GetFullPath(), L"rb" ) ) {
-			size_t bytesRead = metaFile.Read( &newFileEntry->entry.raw, sizeof( newFileEntry->entry.raw ) );
+		if (metaFileName.FileExists() && metaFile.Open(metaFileName.GetFullPath(), L"rb"))
+		{
+			size_t bytesRead = metaFile.Read(&newFileEntry->entry.raw, sizeof(newFileEntry->entry.raw));
 			metaFile.Close();
-			if ( bytesRead < 0x60 ) {
-				strcpy( reinterpret_cast<char*>(newFileEntry->entry.data.name), fileEntry.m_fileName.mbc_str() );
+			if (bytesRead < 0x60)
+			{
+				strcpy(reinterpret_cast<char*>(newFileEntry->entry.data.name), fileEntry.m_fileName.mbc_str());
 			}
-		} else {
+		}
+		else
+		{
 			newFileEntry->entry.data.mode = MemoryCardFileEntry::DefaultFileMode;
-			newFileEntry->entry.data.timeCreated = MemoryCardFileEntryDateTime::FromTime( fileEntry.m_timeCreated );
-			newFileEntry->entry.data.timeModified = MemoryCardFileEntryDateTime::FromTime( fileEntry.m_timeModified );
-			strcpy( reinterpret_cast<char*>(newFileEntry->entry.data.name), fileEntry.m_fileName.mbc_str() );
+			newFileEntry->entry.data.timeCreated = MemoryCardFileEntryDateTime::FromTime(fileEntry.m_timeCreated);
+			newFileEntry->entry.data.timeModified = MemoryCardFileEntryDateTime::FromTime(fileEntry.m_timeModified);
+			strcpy(reinterpret_cast<char*>(newFileEntry->entry.data.name), fileEntry.m_fileName.mbc_str());
 		}
 
 		newFileEntry->entry.data.length = filesize;
-		if ( filesize != 0 ) {
+		if (filesize != 0)
+		{
 			u32 fileDataStartingCluster = GetFreeDataCluster();
 			newFileEntry->entry.data.cluster = fileDataStartingCluster;
 
 			// mark the appropriate amount of clusters as used
 			u32 dataCluster = fileDataStartingCluster;
 			m_fat.data[0][0][dataCluster] = LastDataCluster | DataClusterInUseMask;
-			for ( unsigned int i = 0; i < countClusters - 1; ++i ) {
+			for (unsigned int i = 0; i < countClusters - 1; ++i)
+			{
 				u32 newCluster = GetFreeDataCluster();
 				m_fat.data[0][0][dataCluster] = newCluster | DataClusterInUseMask;
 				m_fat.data[0][0][newCluster] = LastDataCluster | DataClusterInUseMask;
 				dataCluster = newCluster;
 			}
-		} else {
+		}
+		else
+		{
 			newFileEntry->entry.data.cluster = MemoryCardFileEntry::EmptyFileCluster;
 		}
 
 		file.Close();
 
-		MemoryCardFileMetadataReference* fileRef = AddFileEntryToMetadataQuickAccess( newFileEntry, parent );
-		if ( fileRef != nullptr ) {
+		MemoryCardFileMetadataReference* fileRef = AddFileEntryToMetadataQuickAccess(newFileEntry, parent);
+		if (fileRef != nullptr)
+		{
 			// acquire a handle on the file so nothing else can change the file contents while the memory card is open
-			m_lastAccessedFile.ReOpen( m_folderName, fileRef );
+			m_lastAccessedFile.ReOpen(m_folderName, fileRef);
 		}
 
 		// and finally, increase file count in the directory entry
 		dirEntry->entry.data.length++;
 
 		return true;
-	} else {
-		Console.WriteLn( L"(FolderMcd) Could not open file: %s", WX_STR( relativeFilePath.GetFullPath() ) );
+	}
+	else
+	{
+		Console.WriteLn(L"(FolderMcd) Could not open file: %s", WX_STR(relativeFilePath.GetFullPath()));
 		return false;
 	}
 }
 
-u32 FolderMemoryCard::CalculateRequiredClustersOfDirectory( const wxString& dirPath ) const {
+u32 FolderMemoryCard::CalculateRequiredClustersOfDirectory(const wxString& dirPath) const
+{
 	const u32 clusterSize = m_superBlock.data.pages_per_cluster * m_superBlock.data.page_len;
 	u32 requiredFileEntryPages = 2;
 	u32 requiredClusters = 0;
 
 	// No need to read the index file as we are only counting space required; order of files is irrelevant.
-	wxDir dir( dirPath );
+	wxDir dir(dirPath);
 	wxString fileName;
-	bool hasNext = dir.GetFirst( &fileName );
-	while ( hasNext ) {
-		if ( fileName.StartsWith( L"_pcsx2_" ) ) {
-			hasNext = dir.GetNext( &fileName );
+	bool hasNext = dir.GetFirst(&fileName);
+	while (hasNext)
+	{
+		if (fileName.StartsWith(L"_pcsx2_"))
+		{
+			hasNext = dir.GetNext(&fileName);
 			continue;
 		}
 
 		++requiredFileEntryPages;
-		wxFileName file( dirPath, fileName );
+		wxFileName file(dirPath, fileName);
 		wxString path = file.GetFullPath();
-		bool isFile = wxFile::Exists( path );
+		bool isFile = wxFile::Exists(path);
 
-		if ( isFile ) {
+		if (isFile)
+		{
 			const u32 filesize = file.GetSize().GetValue();
-			const u32 countClusters = ( filesize % clusterSize ) != 0 ? ( filesize / clusterSize + 1 ) : ( filesize / clusterSize );
+			const u32 countClusters = (filesize % clusterSize) != 0 ? (filesize / clusterSize + 1) : (filesize / clusterSize);
 			requiredClusters += countClusters;
-		} else {
-			requiredClusters += CalculateRequiredClustersOfDirectory( path );
+		}
+		else
+		{
+			requiredClusters += CalculateRequiredClustersOfDirectory(path);
 		}
 
-		hasNext = dir.GetNext( &fileName );
+		hasNext = dir.GetNext(&fileName);
 	}
 
-	return requiredClusters + requiredFileEntryPages / 2 + ( requiredFileEntryPages % 2 == 0 ? 0 : 1 );
+	return requiredClusters + requiredFileEntryPages / 2 + (requiredFileEntryPages % 2 == 0 ? 0 : 1);
 }
 
-MemoryCardFileMetadataReference* FolderMemoryCard::AddDirEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent ) {
+MemoryCardFileMetadataReference* FolderMemoryCard::AddDirEntryToMetadataQuickAccess(MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent)
+{
 	MemoryCardFileMetadataReference* ref = &m_fileMetadataQuickAccess[entry->entry.data.cluster];
 	ref->parent = parent;
 	ref->entry = entry;
@@ -550,46 +650,53 @@ MemoryCardFileMetadataReference* FolderMemoryCard::AddDirEntryToMetadataQuickAcc
 	return ref;
 }
 
-MemoryCardFileMetadataReference* FolderMemoryCard::AddFileEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent ) {
+MemoryCardFileMetadataReference* FolderMemoryCard::AddFileEntryToMetadataQuickAccess(MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent)
+{
 	const u32 firstFileCluster = entry->entry.data.cluster;
 	u32 fileCluster = firstFileCluster;
 
 	// zero-length files have no file clusters
-	if ( fileCluster == 0xFFFFFFFFu ) {
+	if (fileCluster == 0xFFFFFFFFu)
+	{
 		return nullptr;
 	}
 
 	u32 clusterNumber = 0;
-	do {
+	do
+	{
 		MemoryCardFileMetadataReference* ref = &m_fileMetadataQuickAccess[fileCluster & NextDataClusterMask];
 		ref->parent = parent;
 		ref->entry = entry;
 		ref->consecutiveCluster = clusterNumber;
 		++clusterNumber;
-	} while ( ( fileCluster = m_fat.data[0][0][fileCluster & NextDataClusterMask]) != ( LastDataCluster | DataClusterInUseMask ) );
+	} while ((fileCluster = m_fat.data[0][0][fileCluster & NextDataClusterMask]) != (LastDataCluster | DataClusterInUseMask));
 
 	return &m_fileMetadataQuickAccess[firstFileCluster & NextDataClusterMask];
 }
 
-s32 FolderMemoryCard::IsPresent() const {
+s32 FolderMemoryCard::IsPresent() const
+{
 	return m_isEnabled;
 }
 
-void FolderMemoryCard::GetSizeInfo( PS2E_McdSizeInfo& outways ) const {
+void FolderMemoryCard::GetSizeInfo(PS2E_McdSizeInfo& outways) const
+{
 	outways.SectorSize = PageSize;
 	outways.EraseBlockSizeInSectors = BlockSize / PageSize;
 	outways.McdSizeInSectors = GetSizeInClusters() * 2;
 
-	u8 *pdata = (u8*)&outways.McdSizeInSectors;
+	u8* pdata = (u8*)&outways.McdSizeInSectors;
 	outways.Xor = 18;
 	outways.Xor ^= pdata[0] ^ pdata[1] ^ pdata[2] ^ pdata[3];
 }
 
-bool FolderMemoryCard::IsPSX() const {
+bool FolderMemoryCard::IsPSX() const
+{
 	return false;
 }
 
-u8* FolderMemoryCard::GetSystemBlockPointer( const u32 adr ) {
+u8* FolderMemoryCard::GetSystemBlockPointer(const u32 adr)
+{
 	const u32 block = adr / BlockSizeRaw;
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
@@ -597,35 +704,49 @@ u8* FolderMemoryCard::GetSystemBlockPointer( const u32 adr ) {
 
 	const u32 startDataCluster = m_superBlock.data.alloc_offset;
 	const u32 endDataCluster = startDataCluster + m_superBlock.data.alloc_end;
-	if ( cluster >= startDataCluster && cluster < endDataCluster ) {
+	if (cluster >= startDataCluster && cluster < endDataCluster)
+	{
 		// trying to access a file entry?
 		const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
 		// if this cluster is unused according to FAT, we can assume we won't find anything
-		if ( ( m_fat.data[0][0][fatCluster] & DataClusterInUseMask ) == 0 ) {
+		if ((m_fat.data[0][0][fatCluster] & DataClusterInUseMask) == 0)
+		{
 			return nullptr;
 		}
-		return GetFileEntryPointer( fatCluster, page % 2, offset );
+		return GetFileEntryPointer(fatCluster, page % 2, offset);
 	}
 
-	if ( block == 0 ) {
+	if (block == 0)
+	{
 		return &m_superBlock.raw[page * PageSize + offset];
-	} else if ( block == m_superBlock.data.backup_block1 ) {
-		return &m_backupBlock1[( page % 16 ) * PageSize + offset];
-	} else if ( block == m_superBlock.data.backup_block2 ) {
-		return &m_backupBlock2.raw[( page % 16 ) * PageSize + offset];
-	} else {
+	}
+	else if (block == m_superBlock.data.backup_block1)
+	{
+		return &m_backupBlock1[(page % 16) * PageSize + offset];
+	}
+	else if (block == m_superBlock.data.backup_block2)
+	{
+		return &m_backupBlock2.raw[(page % 16) * PageSize + offset];
+	}
+	else
+	{
 		// trying to access indirect FAT?
-		for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
-			if ( cluster == m_superBlock.data.ifc_list[i] ) {
-				return &m_indirectFat.raw[i][( page % 2 ) * PageSize + offset];
+		for (int i = 0; i < IndirectFatClusterCount; ++i)
+		{
+			if (cluster == m_superBlock.data.ifc_list[i])
+			{
+				return &m_indirectFat.raw[i][(page % 2) * PageSize + offset];
 			}
 		}
 		// trying to access FAT?
-		for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
-			for ( int j = 0; j < ClusterSize / 4; ++j ) {
+		for (int i = 0; i < IndirectFatClusterCount; ++i)
+		{
+			for (int j = 0; j < ClusterSize / 4; ++j)
+			{
 				const u32 fatCluster = m_indirectFat.data[i][j];
-				if ( fatCluster != IndirectFatUnused && fatCluster == cluster ) {
-					return &m_fat.raw[i][j][( page % 2 ) * PageSize + offset];
+				if (fatCluster != IndirectFatUnused && fatCluster == cluster)
+				{
+					return &m_fat.raw[i][j][(page % 2) * PageSize + offset];
 				}
 			}
 		}
@@ -634,39 +755,53 @@ u8* FolderMemoryCard::GetSystemBlockPointer( const u32 adr ) {
 	return nullptr;
 }
 
-u8* FolderMemoryCard::GetFileEntryPointer( const u32 searchCluster, const u32 entryNumber, const u32 offset ) {
+u8* FolderMemoryCard::GetFileEntryPointer(const u32 searchCluster, const u32 entryNumber, const u32 offset)
+{
 	const u32 fileCount = m_fileEntryDict[m_superBlock.data.rootdir_cluster].entries[0].entry.data.length;
-	MemoryCardFileEntryCluster* ptr = GetFileEntryCluster( m_superBlock.data.rootdir_cluster, searchCluster, fileCount );
-	if ( ptr != nullptr ) {
+	MemoryCardFileEntryCluster* ptr = GetFileEntryCluster(m_superBlock.data.rootdir_cluster, searchCluster, fileCount);
+	if (ptr != nullptr)
+	{
 		return &ptr->entries[entryNumber].entry.raw[offset];
 	}
 
 	return nullptr;
 }
 
-MemoryCardFileEntryCluster* FolderMemoryCard::GetFileEntryCluster( const u32 currentCluster, const u32 searchCluster, const u32 fileCount ) {
+MemoryCardFileEntryCluster* FolderMemoryCard::GetFileEntryCluster(const u32 currentCluster, const u32 searchCluster, const u32 fileCount)
+{
 	// we found the correct cluster, return pointer to it
-	if ( currentCluster == searchCluster ) {
+	if (currentCluster == searchCluster)
+	{
 		return &m_fileEntryDict[currentCluster];
 	}
 
 	// check other clusters of this directory
 	const u32 nextCluster = m_fat.data[0][0][currentCluster] & NextDataClusterMask;
-	if ( nextCluster != LastDataCluster ) {
-		MemoryCardFileEntryCluster* ptr = GetFileEntryCluster( nextCluster, searchCluster, fileCount - 2 );
-		if ( ptr != nullptr ) { return ptr; }
+	if (nextCluster != LastDataCluster)
+	{
+		MemoryCardFileEntryCluster* ptr = GetFileEntryCluster(nextCluster, searchCluster, fileCount - 2);
+		if (ptr != nullptr)
+		{
+			return ptr;
+		}
 	}
 
 	// check subdirectories
-	auto it = m_fileEntryDict.find( currentCluster );
-	if ( it != m_fileEntryDict.end() ) {
-		const u32 filesInThisCluster = std::min( fileCount, 2u );
-		for ( unsigned int i = 0; i < filesInThisCluster; ++i ) {
+	auto it = m_fileEntryDict.find(currentCluster);
+	if (it != m_fileEntryDict.end())
+	{
+		const u32 filesInThisCluster = std::min(fileCount, 2u);
+		for (unsigned int i = 0; i < filesInThisCluster; ++i)
+		{
 			const MemoryCardFileEntry* const entry = &it->second.entries[i];
-			if ( entry->IsValid() && entry->IsUsed() && entry->IsDir() && !entry->IsDotDir() ) {
+			if (entry->IsValid() && entry->IsUsed() && entry->IsDir() && !entry->IsDotDir())
+			{
 				const u32 newFileCount = entry->entry.data.length;
-				MemoryCardFileEntryCluster* ptr = GetFileEntryCluster( entry->entry.data.cluster, searchCluster, newFileCount );
-				if ( ptr != nullptr ) { return ptr; }
+				MemoryCardFileEntryCluster* ptr = GetFileEntryCluster(entry->entry.data.cluster, searchCluster, newFileCount);
+				if (ptr != nullptr)
+				{
+					return ptr;
+				}
 			}
 		}
 	}
@@ -676,39 +811,51 @@ MemoryCardFileEntryCluster* FolderMemoryCard::GetFileEntryCluster( const u32 cur
 
 // This method is actually unused since the introduction of m_fileMetadataQuickAccess.
 // I'll leave it here anyway though to show how you traverse the file system.
-MemoryCardFileEntry* FolderMemoryCard::GetFileEntryFromFileDataCluster( const u32 currentCluster, const u32 searchCluster, wxFileName* fileName, const size_t originalDirCount, u32* outClusterNumber ) {
+MemoryCardFileEntry* FolderMemoryCard::GetFileEntryFromFileDataCluster(const u32 currentCluster, const u32 searchCluster, wxFileName* fileName, const size_t originalDirCount, u32* outClusterNumber)
+{
 	// check both entries of the current cluster if they're the file we're searching for, and if yes return it
-	for ( int i = 0; i < 2; ++i ) {
+	for (int i = 0; i < 2; ++i)
+	{
 		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
-		if ( entry->IsValid() && entry->IsUsed() && entry->IsFile() ) {
+		if (entry->IsValid() && entry->IsUsed() && entry->IsFile())
+		{
 			u32 fileCluster = entry->entry.data.cluster;
 			u32 clusterNumber = 0;
-			do {
-				if ( fileCluster == searchCluster ) {
-					fileName->SetName( wxString::FromAscii( (const char*)entry->entry.data.name ) );
+			do
+			{
+				if (fileCluster == searchCluster)
+				{
+					fileName->SetName(wxString::FromAscii((const char*)entry->entry.data.name));
 					*outClusterNumber = clusterNumber;
 					return entry;
 				}
 				++clusterNumber;
-			} while ( ( fileCluster = m_fat.data[0][0][fileCluster] & NextDataClusterMask ) != LastDataCluster );
+			} while ((fileCluster = m_fat.data[0][0][fileCluster] & NextDataClusterMask) != LastDataCluster);
 		}
 	}
 
 	// check other clusters of this directory
 	// this can probably be solved more efficiently by looping through nextClusters instead of recursively calling
 	const u32 nextCluster = m_fat.data[0][0][currentCluster] & NextDataClusterMask;
-	if ( nextCluster != LastDataCluster ) {
-		MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster( nextCluster, searchCluster, fileName, originalDirCount, outClusterNumber );
-		if ( ptr != nullptr ) { return ptr; }
+	if (nextCluster != LastDataCluster)
+	{
+		MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster(nextCluster, searchCluster, fileName, originalDirCount, outClusterNumber);
+		if (ptr != nullptr)
+		{
+			return ptr;
+		}
 	}
 
 	// check subdirectories
-	for ( int i = 0; i < 2; ++i ) {
+	for (int i = 0; i < 2; ++i)
+	{
 		MemoryCardFileEntry* const entry = &m_fileEntryDict[currentCluster].entries[i];
-		if ( entry->IsValid() && entry->IsUsed() && entry->IsDir() && !entry->IsDotDir() ) {
-			MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster( entry->entry.data.cluster, searchCluster, fileName, originalDirCount, outClusterNumber );
-			if ( ptr != nullptr ) {
-				fileName->InsertDir( originalDirCount, wxString::FromAscii( (const char*)entry->entry.data.name ) );
+		if (entry->IsValid() && entry->IsUsed() && entry->IsDir() && !entry->IsDotDir())
+		{
+			MemoryCardFileEntry* ptr = GetFileEntryFromFileDataCluster(entry->entry.data.cluster, searchCluster, fileName, originalDirCount, outClusterNumber);
+			if (ptr != nullptr)
+			{
+				fileName->InsertDir(originalDirCount, wxString::FromAscii((const char*)entry->entry.data.name));
 				return ptr;
 			}
 		}
@@ -717,34 +864,40 @@ MemoryCardFileEntry* FolderMemoryCard::GetFileEntryFromFileDataCluster( const u3
 	return nullptr;
 }
 
-bool FolderMemoryCard::ReadFromFile( u8 *dest, u32 adr, u32 dataLength ) {
+bool FolderMemoryCard::ReadFromFile(u8* dest, u32 adr, u32 dataLength)
+{
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
 	const u32 cluster = adr / ClusterSizeRaw;
 	const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
 
 	// if the cluster is unused according to FAT, just return
-	if ( ( m_fat.data[0][0][fatCluster] & DataClusterInUseMask ) == 0 ) {
+	if ((m_fat.data[0][0][fatCluster] & DataClusterInUseMask) == 0)
+	{
 		return false;
 	}
 
 	// figure out which file to read from
-	auto it = m_fileMetadataQuickAccess.find( fatCluster );
-	if ( it != m_fileMetadataQuickAccess.end() ) {
+	auto it = m_fileMetadataQuickAccess.find(fatCluster);
+	if (it != m_fileMetadataQuickAccess.end())
+	{
 		const u32 clusterNumber = it->second.consecutiveCluster;
-		wxFFile* file = m_lastAccessedFile.ReOpen( m_folderName, &it->second );
-		if ( file->IsOpened() ) {
-			const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
+		wxFFile* file = m_lastAccessedFile.ReOpen(m_folderName, &it->second);
+		if (file->IsOpened())
+		{
+			const u32 clusterOffset = (page % 2) * PageSize + offset;
 			const u32 fileOffset = clusterNumber * ClusterSize + clusterOffset;
 
-			if ( fileOffset != file->Tell() ) {
-				file->Seek( fileOffset );
+			if (fileOffset != file->Tell())
+			{
+				file->Seek(fileOffset);
 			}
-			size_t bytesRead = file->Read( dest, dataLength );
+			size_t bytesRead = file->Read(dest, dataLength);
 
 			// if more bytes were requested than actually exist, fill the rest with 0xFF
-			if ( bytesRead < dataLength ) {
-				memset( &dest[bytesRead], 0xFF, dataLength - bytesRead );
+			if (bytesRead < dataLength)
+			{
+				memset(&dest[bytesRead], 0xFF, dataLength - bytesRead);
 			}
 
 			return bytesRead > 0;
@@ -754,51 +907,59 @@ bool FolderMemoryCard::ReadFromFile( u8 *dest, u32 adr, u32 dataLength ) {
 	return false;
 }
 
-s32 FolderMemoryCard::Read( u8 *dest, u32 adr, int size ) {
+s32 FolderMemoryCard::Read(u8* dest, u32 adr, int size)
+{
 	//const u32 block = adr / BlockSizeRaw;
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
 	//const u32 cluster = adr / ClusterSizeRaw;
 	const u32 end = offset + size;
 
-	if ( end > PageSizeRaw ) {
+	if (end > PageSizeRaw)
+	{
 		// is trying to read more than one page at a time
 		// do this recursively so that each function call only has to care about one page
 		const u32 toNextPage = PageSizeRaw - offset;
-		Read( dest + toNextPage, adr + toNextPage, size - toNextPage );
+		Read(dest + toNextPage, adr + toNextPage, size - toNextPage);
 		size = toNextPage;
 	}
 
-	if ( offset < PageSize ) {
+	if (offset < PageSize)
+	{
 		// is trying to read (part of) an actual data block
-		const u32 dataLength = std::min( (u32)size, (u32)( PageSize - offset ) );
+		const u32 dataLength = std::min((u32)size, (u32)(PageSize - offset));
 
 		// if we have a cache for this page, just load from that
-		auto it = m_cache.find( page );
-		if ( it != m_cache.end() ) {
-			memcpy( dest, &it->second.raw[offset], dataLength );
-		} else {
-			ReadDataWithoutCache( dest, adr, dataLength );
+		auto it = m_cache.find(page);
+		if (it != m_cache.end())
+		{
+			memcpy(dest, &it->second.raw[offset], dataLength);
+		}
+		else
+		{
+			ReadDataWithoutCache(dest, adr, dataLength);
 		}
 	}
 
-	if ( end > PageSize ) {
+	if (end > PageSize)
+	{
 		// is trying to (partially) read the ECC
 		const u32 eccOffset = PageSize - offset;
-		const u32 eccLength = std::min( (u32)( size - offset ), (u32)EccSize );
+		const u32 eccLength = std::min((u32)(size - offset), (u32)EccSize);
 		const u32 adrStart = page * PageSizeRaw;
 
 		u8 data[PageSize];
-		Read( data, adrStart, PageSize );
+		Read(data, adrStart, PageSize);
 
 		u8 ecc[EccSize];
-		memset( ecc, 0xFF, EccSize );
+		memset(ecc, 0xFF, EccSize);
 
-		for ( int i = 0; i < PageSize / 0x80; ++i ) {
-			FolderMemoryCard::CalculateECC( ecc + ( i * 3 ), &data[i * 0x80] );
+		for (int i = 0; i < PageSize / 0x80; ++i)
+		{
+			FolderMemoryCard::CalculateECC(ecc + (i * 3), &data[i * 0x80]);
 		}
 
-		memcpy( dest + eccOffset, ecc, eccLength );
+		memcpy(dest + eccOffset, ecc, eccLength);
 	}
 
 	SetTimeLastReadToNow();
@@ -807,50 +968,61 @@ s32 FolderMemoryCard::Read( u8 *dest, u32 adr, int size ) {
 	return 1;
 }
 
-void FolderMemoryCard::ReadDataWithoutCache( u8* const dest, const u32 adr, const u32 dataLength ) {
-	u8* src = GetSystemBlockPointer( adr );
-	if ( src != nullptr ) {
-		memcpy( dest, src, dataLength );
-	} else {
-		if ( !ReadFromFile( dest, adr, dataLength ) ) {
-			memset( dest, 0xFF, dataLength );
+void FolderMemoryCard::ReadDataWithoutCache(u8* const dest, const u32 adr, const u32 dataLength)
+{
+	u8* src = GetSystemBlockPointer(adr);
+	if (src != nullptr)
+	{
+		memcpy(dest, src, dataLength);
+	}
+	else
+	{
+		if (!ReadFromFile(dest, adr, dataLength))
+		{
+			memset(dest, 0xFF, dataLength);
 		}
 	}
 }
 
-s32 FolderMemoryCard::Save( const u8 *src, u32 adr, int size ) {
+s32 FolderMemoryCard::Save(const u8* src, u32 adr, int size)
+{
 	//const u32 block = adr / BlockSizeRaw;
 	//const u32 cluster = adr / ClusterSizeRaw;
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
 	const u32 end = offset + size;
 
-	if ( end > PageSizeRaw ) {
+	if (end > PageSizeRaw)
+	{
 		// is trying to store more than one page at a time
 		// do this recursively so that each function call only has to care about one page
 		const u32 toNextPage = PageSizeRaw - offset;
-		Save( src + toNextPage, adr + toNextPage, size - toNextPage );
+		Save(src + toNextPage, adr + toNextPage, size - toNextPage);
 		size = toNextPage;
 	}
 
-	if ( offset < PageSize ) {
+	if (offset < PageSize)
+	{
 		// is trying to store (part of) an actual data block
-		const u32 dataLength = std::min( (u32)size, PageSize - offset );
+		const u32 dataLength = std::min((u32)size, PageSize - offset);
 
 		// if cache page has not yet been touched, fill it with the data from our memory card
-		auto it = m_cache.find( page );
+		auto it = m_cache.find(page);
 		MemoryCardPage* cachePage;
-		if ( it == m_cache.end() ) {
+		if (it == m_cache.end())
+		{
 			cachePage = &m_cache[page];
 			const u32 adrLoad = page * PageSizeRaw;
-			ReadDataWithoutCache( &cachePage->raw[0], adrLoad, PageSize );
-			memcpy( &m_oldDataCache[page].raw[0], &cachePage->raw[0], PageSize );
-		} else {
+			ReadDataWithoutCache(&cachePage->raw[0], adrLoad, PageSize);
+			memcpy(&m_oldDataCache[page].raw[0], &cachePage->raw[0], PageSize);
+		}
+		else
+		{
 			cachePage = &it->second;
 		}
 
 		// then just write to the cache
-		memcpy( &cachePage->raw[offset], src, dataLength );
+		memcpy(&cachePage->raw[offset], src, dataLength);
 
 		SetTimeLastWrittenToNow();
 	}
@@ -858,37 +1030,48 @@ s32 FolderMemoryCard::Save( const u8 *src, u32 adr, int size ) {
 	return 1;
 }
 
-void FolderMemoryCard::NextFrame() {
-	if ( m_framesUntilFlush > 0 && --m_framesUntilFlush == 0 ) {
+void FolderMemoryCard::NextFrame()
+{
+	if (m_framesUntilFlush > 0 && --m_framesUntilFlush == 0)
+	{
 		Flush();
 	}
 }
 
-void FolderMemoryCard::Flush() {
-	if ( m_cache.empty() ) { return; }
+void FolderMemoryCard::Flush()
+{
+	if (m_cache.empty())
+	{
+		return;
+	}
 
-	#ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
-	WriteToFile( m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format( L"%Y-%m-%d-%H-%M-%S" ) + L"_pre-flush.ps2" );
-	#endif
+#ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
+	WriteToFile(m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format(L"%Y-%m-%d-%H-%M-%S") + L"_pre-flush.ps2");
+#endif
 
-	Console.WriteLn( L"(FolderMcd) Writing data for slot %u to file system...", m_slot );
+	Console.WriteLn(L"(FolderMcd) Writing data for slot %u to file system...", m_slot);
 	const u64 timeFlushStart = wxGetLocalTimeMillis().GetValue();
 
 	// Keep a copy of the old file entries so we can figure out which files and directories, if any, have been deleted from the memory card.
 	std::vector<MemoryCardFileEntryTreeNode> oldFileEntryTree;
-	if ( IsFormatted() ) {
-		CopyEntryDictIntoTree( &oldFileEntryTree, m_superBlock.data.rootdir_cluster, m_fileEntryDict[m_superBlock.data.rootdir_cluster].entries[0].entry.data.length );
+	if (IsFormatted())
+	{
+		CopyEntryDictIntoTree(&oldFileEntryTree, m_superBlock.data.rootdir_cluster, m_fileEntryDict[m_superBlock.data.rootdir_cluster].entries[0].entry.data.length);
 	}
 
 	// first write the superblock if necessary
 	FlushSuperBlock();
-	if ( !IsFormatted() ) { return; }
+	if (!IsFormatted())
+	{
+		return;
+	}
 
 	// check if we were interrupted in the middle of a save operation, if yes abort
-	FlushBlock( m_superBlock.data.backup_block1 );
-	FlushBlock( m_superBlock.data.backup_block2 );
-	if ( m_backupBlock2.programmedBlock != 0xFFFFFFFFu ) {
-		Console.Warning( L"(FolderMcd) Aborting flush of slot %u, emulation was interrupted during save process!", m_slot );
+	FlushBlock(m_superBlock.data.backup_block1);
+	FlushBlock(m_superBlock.data.backup_block2);
+	if (m_backupBlock2.programmedBlock != 0xFFFFFFFFu)
+	{
+		Console.Warning(L"(FolderMcd) Aborting flush of slot %u, emulation was interrupted during save process!", m_slot);
 		return;
 	}
 
@@ -896,19 +1079,24 @@ void FolderMemoryCard::Flush() {
 	const u32 pageCount = clusterCount * 2;
 
 	// then write the indirect FAT
-	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
+	for (int i = 0; i < IndirectFatClusterCount; ++i)
+	{
 		const u32 cluster = m_superBlock.data.ifc_list[i];
-		if ( cluster > 0 && cluster < clusterCount ) {
-			FlushCluster( cluster );
+		if (cluster > 0 && cluster < clusterCount)
+		{
+			FlushCluster(cluster);
 		}
 	}
 
 	// and the FAT
-	for ( int i = 0; i < IndirectFatClusterCount; ++i ) {
-		for ( int j = 0; j < ClusterSize / 4; ++j ) {
+	for (int i = 0; i < IndirectFatClusterCount; ++i)
+	{
+		for (int j = 0; j < ClusterSize / 4; ++j)
+		{
 			const u32 cluster = m_indirectFat.data[i][j];
-			if ( cluster > 0 && cluster < clusterCount ) {
-				FlushCluster( cluster );
+			if (cluster > 0 && cluster < clusterCount)
+			{
+				FlushCluster(cluster);
 			}
 		}
 	}
@@ -917,11 +1105,12 @@ void FolderMemoryCard::Flush() {
 	FlushFileEntries();
 
 	// Now we have the new file system, compare it to the old one and "delete" any files that were in it before but aren't anymore.
-	FlushDeletedFilesAndRemoveUnchangedDataFromCache( oldFileEntryTree );
+	FlushDeletedFilesAndRemoveUnchangedDataFromCache(oldFileEntryTree);
 
 	// and finally, flush everything that hasn't been flushed yet
-	for ( uint i = 0; i < pageCount; ++i ) {
-		FlushPage( i );
+	for (uint i = 0; i < pageCount; ++i)
+	{
+		FlushPage(i);
 	}
 
 	m_lastAccessedFile.FlushAll();
@@ -929,142 +1118,179 @@ void FolderMemoryCard::Flush() {
 	m_oldDataCache.clear();
 
 	const u64 timeFlushEnd = wxGetLocalTimeMillis().GetValue();
-	Console.WriteLn( L"(FolderMcd) Done! Took %u ms.", timeFlushEnd - timeFlushStart );
+	Console.WriteLn(L"(FolderMcd) Done! Took %u ms.", timeFlushEnd - timeFlushStart);
 
-	#ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
-	WriteToFile( m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format( L"%Y-%m-%d-%H-%M-%S" ) + L"_post-flush.ps2" );
-	#endif
+#ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
+	WriteToFile(m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format(L"%Y-%m-%d-%H-%M-%S") + L"_post-flush.ps2");
+#endif
 }
 
-bool FolderMemoryCard::FlushPage( const u32 page ) {
-	auto it = m_cache.find( page );
-	if ( it != m_cache.end() ) {
-		WriteWithoutCache( &it->second.raw[0], page * PageSizeRaw, PageSize );
-		m_cache.erase( it );
+bool FolderMemoryCard::FlushPage(const u32 page)
+{
+	auto it = m_cache.find(page);
+	if (it != m_cache.end())
+	{
+		WriteWithoutCache(&it->second.raw[0], page * PageSizeRaw, PageSize);
+		m_cache.erase(it);
 		return true;
 	}
 	return false;
 }
 
-bool FolderMemoryCard::FlushCluster( const u32 cluster ) {
+bool FolderMemoryCard::FlushCluster(const u32 cluster)
+{
 	const u32 page = cluster * 2;
 	bool flushed = false;
-	if ( FlushPage( page ) ) { flushed = true; }
-	if ( FlushPage( page + 1 ) ) { flushed = true; }
-	return flushed;
-}
-
-bool FolderMemoryCard::FlushBlock( const u32 block ) {
-	const u32 page = block * 16;
-	bool flushed = false;
-	for ( int i = 0; i < 16; ++i ) {
-		if ( FlushPage( page + i ) ) { flushed = true; }
+	if (FlushPage(page))
+	{
+		flushed = true;
+	}
+	if (FlushPage(page + 1))
+	{
+		flushed = true;
 	}
 	return flushed;
 }
 
-void FolderMemoryCard::FlushSuperBlock() {
-	if ( FlushBlock( 0 ) && m_performFileWrites ) {
-		wxFileName superBlockFileName( m_folderName.GetPath(), L"_pcsx2_superblock" );
-		wxFFile superBlockFile( superBlockFileName.GetFullPath().c_str(), L"wb" );
-		if ( superBlockFile.IsOpened() ) {
-			superBlockFile.Write( &m_superBlock.raw, sizeof( m_superBlock.raw ) );
+bool FolderMemoryCard::FlushBlock(const u32 block)
+{
+	const u32 page = block * 16;
+	bool flushed = false;
+	for (int i = 0; i < 16; ++i)
+	{
+		if (FlushPage(page + i))
+		{
+			flushed = true;
+		}
+	}
+	return flushed;
+}
+
+void FolderMemoryCard::FlushSuperBlock()
+{
+	if (FlushBlock(0) && m_performFileWrites)
+	{
+		wxFileName superBlockFileName(m_folderName.GetPath(), L"_pcsx2_superblock");
+		wxFFile superBlockFile(superBlockFileName.GetFullPath().c_str(), L"wb");
+		if (superBlockFile.IsOpened())
+		{
+			superBlockFile.Write(&m_superBlock.raw, sizeof(m_superBlock.raw));
 		}
 	}
 }
 
-void FolderMemoryCard::FlushFileEntries() {
+void FolderMemoryCard::FlushFileEntries()
+{
 	// Flush all file entry data from the cache into m_fileEntryDict.
 	const u32 rootDirCluster = m_superBlock.data.rootdir_cluster;
-	FlushCluster( rootDirCluster + m_superBlock.data.alloc_offset );
+	FlushCluster(rootDirCluster + m_superBlock.data.alloc_offset);
 	MemoryCardFileEntryCluster* rootEntries = &m_fileEntryDict[rootDirCluster];
-	if ( rootEntries->entries[0].IsValid() && rootEntries->entries[0].IsUsed() ) {
-		FlushFileEntries( rootDirCluster, rootEntries->entries[0].entry.data.length );
+	if (rootEntries->entries[0].IsValid() && rootEntries->entries[0].IsUsed())
+	{
+		FlushFileEntries(rootDirCluster, rootEntries->entries[0].entry.data.length);
 	}
 }
 
-void FolderMemoryCard::FlushFileEntries( const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath, MemoryCardFileMetadataReference* parent ) {
+void FolderMemoryCard::FlushFileEntries(const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath, MemoryCardFileMetadataReference* parent)
+{
 	// flush the current cluster
-	FlushCluster( dirCluster + m_superBlock.data.alloc_offset );
+	FlushCluster(dirCluster + m_superBlock.data.alloc_offset);
 
 	// if either of the current entries is a subdir, flush that too
 	MemoryCardFileEntryCluster* entries = &m_fileEntryDict[dirCluster];
-	const u32 filesInThisCluster = std::min( remainingFiles, 2u );
-	for ( unsigned int i = 0; i < filesInThisCluster; ++i ) {
+	const u32 filesInThisCluster = std::min(remainingFiles, 2u);
+	for (unsigned int i = 0; i < filesInThisCluster; ++i)
+	{
 		MemoryCardFileEntry* entry = &entries->entries[i];
-		if ( entry->IsValid() && entry->IsUsed() )
-		{	
-			if ( entry->IsDir() )
+		if (entry->IsValid() && entry->IsUsed())
+		{
+			if (entry->IsDir())
 			{
-				if ( !entry->IsDotDir() ) {
-					char cleanName[sizeof( entry->entry.data.name )];
-					memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-					bool filenameCleaned = FileAccessHelper::CleanMemcardFilename( cleanName );
-					const wxString subDirName = wxString::FromAscii( (const char*)cleanName );
+				if (!entry->IsDotDir())
+				{
+					char cleanName[sizeof(entry->entry.data.name)];
+					memcpy(cleanName, (const char*)entry->entry.data.name, sizeof(cleanName));
+					bool filenameCleaned = FileAccessHelper::CleanMemcardFilename(cleanName);
+					const wxString subDirName = wxString::FromAscii((const char*)cleanName);
 					const wxString subDirPath = dirPath + L"/" + subDirName;
 
-					if ( m_performFileWrites ) {
+					if (m_performFileWrites)
+					{
 						// if this directory has nonstandard metadata, write that to the file system
-						wxFileName metaFileName( m_folderName.GetFullPath() + subDirPath, L"_pcsx2_meta_directory" );
-						if ( !metaFileName.DirExists() ) {
+						wxFileName metaFileName(m_folderName.GetFullPath() + subDirPath, L"_pcsx2_meta_directory");
+						if (!metaFileName.DirExists())
+						{
 							metaFileName.Mkdir();
 						}
 
-						if ( filenameCleaned || entry->entry.data.mode != MemoryCardFileEntry::DefaultDirMode || entry->entry.data.attr != 0 ) {
-							wxFFile metaFile( metaFileName.GetFullPath(), L"wb" );
-							if ( metaFile.IsOpened() ) {
-								metaFile.Write( entry->entry.raw, sizeof( entry->entry.raw ) );
+						if (filenameCleaned || entry->entry.data.mode != MemoryCardFileEntry::DefaultDirMode || entry->entry.data.attr != 0)
+						{
+							wxFFile metaFile(metaFileName.GetFullPath(), L"wb");
+							if (metaFile.IsOpened())
+							{
+								metaFile.Write(entry->entry.raw, sizeof(entry->entry.raw));
 							}
-						} else {
+						}
+						else
+						{
 							// if metadata is standard make sure to remove a possibly existing metadata file
-							if ( metaFileName.FileExists() ) {
-								wxRemoveFile( metaFileName.GetFullPath() );
+							if (metaFileName.FileExists())
+							{
+								wxRemoveFile(metaFileName.GetFullPath());
 							}
 						}
 
 						// write the directory index
-						metaFileName.SetName( L"_pcsx2_index" );
-						YAML::Node index = LoadYAMLFromFile( metaFileName.GetFullPath() );
-						YAML::Node entryNode = index[ "%ROOT" ];
+						metaFileName.SetName(L"_pcsx2_index");
+						YAML::Node index = LoadYAMLFromFile(metaFileName.GetFullPath());
+						YAML::Node entryNode = index["%ROOT"];
 
 						entryNode["timeCreated"] = entry->entry.data.timeCreated.ToTime();
 						entryNode["timeModified"] = entry->entry.data.timeModified.ToTime();
 
 						// Write out the changes
 						wxFFile indexFile;
-						if ( indexFile.Open( metaFileName.GetFullPath(), L"w" ) ) {
-							indexFile.Write( YAML::Dump( index ) );
+						if (indexFile.Open(metaFileName.GetFullPath(), L"w"))
+						{
+							indexFile.Write(YAML::Dump(index));
 						}
 					}
 
-					MemoryCardFileMetadataReference* dirRef = AddDirEntryToMetadataQuickAccess( entry, parent );
+					MemoryCardFileMetadataReference* dirRef = AddDirEntryToMetadataQuickAccess(entry, parent);
 
-					FlushFileEntries( entry->entry.data.cluster, entry->entry.data.length, subDirPath, dirRef );
+					FlushFileEntries(entry->entry.data.cluster, entry->entry.data.length, subDirPath, dirRef);
 				}
-			} else if ( entry->IsFile() ) {
-				AddFileEntryToMetadataQuickAccess( entry, parent );
+			}
+			else if (entry->IsFile())
+			{
+				AddFileEntryToMetadataQuickAccess(entry, parent);
 
-				if ( entry->entry.data.length == 0 ) {
+				if (entry->entry.data.length == 0)
+				{
 					// empty files need to be explicitly created, as there will be no data cluster referencing it later
-					if ( m_performFileWrites ) {
-						char cleanName[sizeof( entry->entry.data.name )];
-						memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-						FileAccessHelper::CleanMemcardFilename( cleanName );
-						const wxString filePath = dirPath + L"/" + wxString::FromAscii( (const char*)cleanName );
-						wxFileName fn( m_folderName.GetFullPath() + filePath );
+					if (m_performFileWrites)
+					{
+						char cleanName[sizeof(entry->entry.data.name)];
+						memcpy(cleanName, (const char*)entry->entry.data.name, sizeof(cleanName));
+						FileAccessHelper::CleanMemcardFilename(cleanName);
+						const wxString filePath = dirPath + L"/" + wxString::FromAscii((const char*)cleanName);
+						wxFileName fn(m_folderName.GetFullPath() + filePath);
 
-						if ( !fn.FileExists() ) {
-							if ( !fn.DirExists() ) {
-								fn.Mkdir( 0777, wxPATH_MKDIR_FULL );
+						if (!fn.FileExists())
+						{
+							if (!fn.DirExists())
+							{
+								fn.Mkdir(0777, wxPATH_MKDIR_FULL);
 							}
-							wxFFile createEmptyFile( fn.GetFullPath(), L"wb" );
+							wxFFile createEmptyFile(fn.GetFullPath(), L"wb");
 							createEmptyFile.Close();
 						}
 					}
 				}
 
-				if ( m_performFileWrites ) {
-					FileAccessHelper::WriteIndex( m_folderName.GetFullPath() + dirPath, entry, parent );
+				if (m_performFileWrites)
+				{
+					FileAccessHelper::WriteIndex(m_folderName.GetFullPath() + dirPath, entry, parent);
 				}
 			}
 		}
@@ -1072,79 +1298,99 @@ void FolderMemoryCard::FlushFileEntries( const u32 dirCluster, const u32 remaini
 
 	// continue to the next cluster of this directory
 	const u32 nextCluster = m_fat.data[0][0][dirCluster];
-	if ( nextCluster != ( LastDataCluster | DataClusterInUseMask ) ) {
-		FlushFileEntries( nextCluster & NextDataClusterMask, remainingFiles - 2, dirPath, parent );
+	if (nextCluster != (LastDataCluster | DataClusterInUseMask))
+	{
+		FlushFileEntries(nextCluster & NextDataClusterMask, remainingFiles - 2, dirPath, parent);
 	}
 }
 
-void FolderMemoryCard::FlushDeletedFilesAndRemoveUnchangedDataFromCache( const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries ) {
+void FolderMemoryCard::FlushDeletedFilesAndRemoveUnchangedDataFromCache(const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries)
+{
 	const u32 newRootDirCluster = m_superBlock.data.rootdir_cluster;
 	const u32 newFileCount = m_fileEntryDict[newRootDirCluster].entries[0].entry.data.length;
-	FlushDeletedFilesAndRemoveUnchangedDataFromCache( oldFileEntries, newRootDirCluster, newFileCount, "" );
+	FlushDeletedFilesAndRemoveUnchangedDataFromCache(oldFileEntries, newRootDirCluster, newFileCount, "");
 }
 
-void FolderMemoryCard::FlushDeletedFilesAndRemoveUnchangedDataFromCache( const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries, const u32 newCluster, const u32 newFileCount, const wxString& dirPath ) {
+void FolderMemoryCard::FlushDeletedFilesAndRemoveUnchangedDataFromCache(const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries, const u32 newCluster, const u32 newFileCount, const wxString& dirPath)
+{
 	// go through all file entires of the current directory of the old data
-	for ( auto it = oldFileEntries.cbegin(); it != oldFileEntries.cend(); ++it ) {
+	for (auto it = oldFileEntries.cbegin(); it != oldFileEntries.cend(); ++it)
+	{
 		const MemoryCardFileEntry* entry = &it->entry;
-		if ( entry->IsValid() && entry->IsUsed() && !entry->IsDotDir() ) {
+		if (entry->IsValid() && entry->IsUsed() && !entry->IsDotDir())
+		{
 			// check if an equivalent entry exists in m_fileEntryDict
-			const MemoryCardFileEntry* newEntry = FindEquivalent( entry, newCluster, newFileCount );
-			if ( newEntry == nullptr ) {
+			const MemoryCardFileEntry* newEntry = FindEquivalent(entry, newCluster, newFileCount);
+			if (newEntry == nullptr)
+			{
 				// file/dir doesn't exist anymore, remove!
-				char cleanName[sizeof( entry->entry.data.name )];
-				memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-				FileAccessHelper::CleanMemcardFilename( cleanName );
-				const wxString fileName = wxString::FromAscii( cleanName );
+				char cleanName[sizeof(entry->entry.data.name)];
+				memcpy(cleanName, (const char*)entry->entry.data.name, sizeof(cleanName));
+				FileAccessHelper::CleanMemcardFilename(cleanName);
+				const wxString fileName = wxString::FromAscii(cleanName);
 				const wxString filePath = m_folderName.GetFullPath() + dirPath + L"/" + fileName;
-				m_lastAccessedFile.CloseMatching( filePath );
+				m_lastAccessedFile.CloseMatching(filePath);
 				const wxString newFilePath = m_folderName.GetFullPath() + dirPath + L"/_pcsx2_deleted_" + fileName;
-				if ( wxFileName::DirExists( newFilePath ) ) {
+				if (wxFileName::DirExists(newFilePath))
+				{
 					// wxRenameFile doesn't overwrite directories, so we have to remove the old one first
-					RemoveDirectory( newFilePath );
+					RemoveDirectory(newFilePath);
 				}
-				wxRenameFile( filePath, newFilePath );
-				DeleteFromIndex( m_folderName.GetFullPath() + dirPath, fileName );
-
-			} else if ( entry->IsDir() ) {
+				wxRenameFile(filePath, newFilePath);
+				DeleteFromIndex(m_folderName.GetFullPath() + dirPath, fileName);
+			}
+			else if (entry->IsDir())
+			{
 				// still exists and is a directory, recursive call for subdir
-				char cleanName[sizeof( entry->entry.data.name )];
-				memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-				FileAccessHelper::CleanMemcardFilename( cleanName );
-				const wxString subDirName = wxString::FromAscii( cleanName );
+				char cleanName[sizeof(entry->entry.data.name)];
+				memcpy(cleanName, (const char*)entry->entry.data.name, sizeof(cleanName));
+				FileAccessHelper::CleanMemcardFilename(cleanName);
+				const wxString subDirName = wxString::FromAscii(cleanName);
 				const wxString subDirPath = dirPath + L"/" + subDirName;
-				FlushDeletedFilesAndRemoveUnchangedDataFromCache( it->subdir, newEntry->entry.data.cluster, newEntry->entry.data.length, subDirPath );
-			} else if ( entry->IsFile() ) {
+				FlushDeletedFilesAndRemoveUnchangedDataFromCache(it->subdir, newEntry->entry.data.cluster, newEntry->entry.data.length, subDirPath);
+			}
+			else if (entry->IsFile())
+			{
 				// still exists and is a file, see if we can remove unchanged data from m_cache
-				RemoveUnchangedDataFromCache( entry, newEntry );
+				RemoveUnchangedDataFromCache(entry, newEntry);
 			}
 		}
 	}
 }
 
-void FolderMemoryCard::RemoveUnchangedDataFromCache( const MemoryCardFileEntry* const oldEntry, const MemoryCardFileEntry* const newEntry ) {
+void FolderMemoryCard::RemoveUnchangedDataFromCache(const MemoryCardFileEntry* const oldEntry, const MemoryCardFileEntry* const newEntry)
+{
 	// Disclaimer: Technically, to actually prove that file data has not changed and still belongs to the same file, we'd need to keep a copy
 	// of the old FAT cluster chain and compare that as well, and only acknowledge the file as unchanged if none of those have changed. However,
 	// the chain of events that leads to a file having the exact same file contents as a deleted old file while also being placed in the same
 	// data clusters as the deleted file AND matching this condition here, in a quick enough succession that no flush has occurred yet since the
 	// deletion of that old file is incredibly unlikely, so I'm not sure if it's actually worth coding for.
-	if ( oldEntry->entry.data.timeModified != newEntry->entry.data.timeModified || oldEntry->entry.data.timeCreated != newEntry->entry.data.timeCreated
-	  || oldEntry->entry.data.length != newEntry->entry.data.length || oldEntry->entry.data.cluster != newEntry->entry.data.cluster ) {
+	if (oldEntry->entry.data.timeModified != newEntry->entry.data.timeModified || oldEntry->entry.data.timeCreated != newEntry->entry.data.timeCreated || oldEntry->entry.data.length != newEntry->entry.data.length || oldEntry->entry.data.cluster != newEntry->entry.data.cluster)
+	{
 		return;
 	}
 
 	u32 cluster = newEntry->entry.data.cluster & NextDataClusterMask;
 	const u32 alloc_offset = m_superBlock.data.alloc_offset;
-	while ( cluster != LastDataCluster ) {
-		for ( int i = 0; i < 2; ++i ) {
-			const u32 page = ( cluster + alloc_offset ) * 2 + i;
-			auto newIt = m_cache.find( page );
-			if ( newIt == m_cache.end() ) { continue; }
-			auto oldIt = m_oldDataCache.find( page );
-			if ( oldIt == m_oldDataCache.end() ) { continue; }
+	while (cluster != LastDataCluster)
+	{
+		for (int i = 0; i < 2; ++i)
+		{
+			const u32 page = (cluster + alloc_offset) * 2 + i;
+			auto newIt = m_cache.find(page);
+			if (newIt == m_cache.end())
+			{
+				continue;
+			}
+			auto oldIt = m_oldDataCache.find(page);
+			if (oldIt == m_oldDataCache.end())
+			{
+				continue;
+			}
 
-			if ( memcmp( &oldIt->second.raw[0], &newIt->second.raw[0], PageSize ) == 0 ) {
-				m_cache.erase( newIt );
+			if (memcmp(&oldIt->second.raw[0], &newIt->second.raw[0], PageSize) == 0)
+			{
+				m_cache.erase(newIt);
 			}
 		}
 
@@ -1152,34 +1398,41 @@ void FolderMemoryCard::RemoveUnchangedDataFromCache( const MemoryCardFileEntry* 
 	}
 }
 
-s32 FolderMemoryCard::WriteWithoutCache( const u8 *src, u32 adr, int size ) {
+s32 FolderMemoryCard::WriteWithoutCache(const u8* src, u32 adr, int size)
+{
 	//const u32 block = adr / BlockSizeRaw;
 	//const u32 cluster = adr / ClusterSizeRaw;
 	//const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
 	const u32 end = offset + size;
 
-	if ( end > PageSizeRaw ) {
+	if (end > PageSizeRaw)
+	{
 		// is trying to store more than one page at a time
 		// do this recursively so that each function call only has to care about one page
 		const u32 toNextPage = PageSizeRaw - offset;
-		Save( src + toNextPage, adr + toNextPage, size - toNextPage );
+		Save(src + toNextPage, adr + toNextPage, size - toNextPage);
 		size = toNextPage;
 	}
 
-	if ( offset < PageSize ) {
+	if (offset < PageSize)
+	{
 		// is trying to store (part of) an actual data block
-		const u32 dataLength = std::min( (u32)size, PageSize - offset );
+		const u32 dataLength = std::min((u32)size, PageSize - offset);
 
-		u8* dest = GetSystemBlockPointer( adr );
-		if ( dest != nullptr ) {
-			memcpy( dest, src, dataLength );
-		} else {
-			WriteToFile( src, adr, dataLength );
+		u8* dest = GetSystemBlockPointer(adr);
+		if (dest != nullptr)
+		{
+			memcpy(dest, src, dataLength);
+		}
+		else
+		{
+			WriteToFile(src, adr, dataLength);
 		}
 	}
 
-	if ( end > PageSize ) {
+	if (end > PageSize)
+	{
 		// is trying to store ECC
 		// simply ignore this, is automatically generated when reading
 	}
@@ -1188,50 +1441,61 @@ s32 FolderMemoryCard::WriteWithoutCache( const u8 *src, u32 adr, int size ) {
 	return 1;
 }
 
-bool FolderMemoryCard::WriteToFile( const u8* src, u32 adr, u32 dataLength ) {
+bool FolderMemoryCard::WriteToFile(const u8* src, u32 adr, u32 dataLength)
+{
 	const u32 cluster = adr / ClusterSizeRaw;
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
 	const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
 
 	// if the cluster is unused according to FAT, just skip all this, we're not gonna find anything anyway
-	if ( ( m_fat.data[0][0][fatCluster] & DataClusterInUseMask ) == 0 ) {
+	if ((m_fat.data[0][0][fatCluster] & DataClusterInUseMask) == 0)
+	{
 		return false;
 	}
 
 	// figure out which file to write to
-	auto it = m_fileMetadataQuickAccess.find( fatCluster );
-	if ( it != m_fileMetadataQuickAccess.end() ) {
+	auto it = m_fileMetadataQuickAccess.find(fatCluster);
+	if (it != m_fileMetadataQuickAccess.end())
+	{
 		const MemoryCardFileEntry* const entry = it->second.entry;
 		const u32 clusterNumber = it->second.consecutiveCluster;
-		
-		if ( m_performFileWrites ) {
-			wxFFile* file = m_lastAccessedFile.ReOpen( m_folderName, &it->second, true );
-			if ( file->IsOpened() ) {
-				const u32 clusterOffset = ( page % 2 ) * PageSize + offset;
+
+		if (m_performFileWrites)
+		{
+			wxFFile* file = m_lastAccessedFile.ReOpen(m_folderName, &it->second, true);
+			if (file->IsOpened())
+			{
+				const u32 clusterOffset = (page % 2) * PageSize + offset;
 				const u32 fileSize = entry->entry.data.length;
-				const u32 fileOffsetStart = std::min( clusterNumber * ClusterSize + clusterOffset, fileSize );
-				const u32 fileOffsetEnd = std::min( fileOffsetStart + dataLength, fileSize );
+				const u32 fileOffsetStart = std::min(clusterNumber * ClusterSize + clusterOffset, fileSize);
+				const u32 fileOffsetEnd = std::min(fileOffsetStart + dataLength, fileSize);
 				const u32 bytesToWrite = fileOffsetEnd - fileOffsetStart;
 
 				wxFileOffset actualFileSize = file->Length();
-				if ( actualFileSize < fileOffsetStart ) {
-					file->Seek( actualFileSize );
+				if (actualFileSize < fileOffsetStart)
+				{
+					file->Seek(actualFileSize);
 					const u32 diff = fileOffsetStart - actualFileSize;
 					u8 temp = 0xFF;
-					for ( u32 i = 0; i < diff; ++i ) {
-						file->Write( &temp, 1 );
+					for (u32 i = 0; i < diff; ++i)
+					{
+						file->Write(&temp, 1);
 					}
 				}
 
 				const wxFileOffset fileOffset = file->Tell();
-				if ( fileOffset != fileOffsetStart ) {
-					file->Seek( fileOffsetStart );
+				if (fileOffset != fileOffsetStart)
+				{
+					file->Seek(fileOffsetStart);
 				}
-				if ( bytesToWrite > 0 ) {
-					file->Write( src, bytesToWrite );
+				if (bytesToWrite > 0)
+				{
+					file->Write(src, bytesToWrite);
 				}
-			} else {
+			}
+			else
+			{
 				return false;
 			}
 		}
@@ -1242,47 +1506,62 @@ bool FolderMemoryCard::WriteToFile( const u8* src, u32 adr, u32 dataLength ) {
 	return false;
 }
 
-void FolderMemoryCard::CopyEntryDictIntoTree( std::vector<MemoryCardFileEntryTreeNode>* fileEntryTree, const u32 cluster, const u32 fileCount ) {
+void FolderMemoryCard::CopyEntryDictIntoTree(std::vector<MemoryCardFileEntryTreeNode>* fileEntryTree, const u32 cluster, const u32 fileCount)
+{
 	const MemoryCardFileEntryCluster* entryCluster = &m_fileEntryDict[cluster];
 	u32 fileCluster = cluster;
 
-	for ( size_t i = 0; i < fileCount; ++i ) {
+	for (size_t i = 0; i < fileCount; ++i)
+	{
 		const MemoryCardFileEntry* entry = &entryCluster->entries[i % 2];
 
-		if ( entry->IsValid() && entry->IsUsed() ) {
-			fileEntryTree->emplace_back( *entry );
+		if (entry->IsValid() && entry->IsUsed())
+		{
+			fileEntryTree->emplace_back(*entry);
 
-			if ( entry->IsDir() && !entry->IsDotDir() ) {
+			if (entry->IsDir() && !entry->IsDotDir())
+			{
 				MemoryCardFileEntryTreeNode* treeEntry = &fileEntryTree->back();
-				CopyEntryDictIntoTree( &treeEntry->subdir, entry->entry.data.cluster, entry->entry.data.length );
+				CopyEntryDictIntoTree(&treeEntry->subdir, entry->entry.data.cluster, entry->entry.data.length);
 			}
 		}
 
-		if ( i % 2 == 1 ) {
+		if (i % 2 == 1)
+		{
 			fileCluster = m_fat.data[0][0][fileCluster] & 0x7FFFFFFFu;
-			if ( fileCluster == 0x7FFFFFFFu ) { return; }
+			if (fileCluster == 0x7FFFFFFFu)
+			{
+				return;
+			}
 			entryCluster = &m_fileEntryDict[fileCluster];
 		}
 	}
 }
 
-const MemoryCardFileEntry* FolderMemoryCard::FindEquivalent( const MemoryCardFileEntry* searchEntry, const u32 cluster, const u32 fileCount ) {
+const MemoryCardFileEntry* FolderMemoryCard::FindEquivalent(const MemoryCardFileEntry* searchEntry, const u32 cluster, const u32 fileCount)
+{
 	const MemoryCardFileEntryCluster* entryCluster = &m_fileEntryDict[cluster];
 	u32 fileCluster = cluster;
 
-	for ( size_t i = 0; i < fileCount; ++i ) {
+	for (size_t i = 0; i < fileCount; ++i)
+	{
 		const MemoryCardFileEntry* entry = &entryCluster->entries[i % 2];
 
-		if ( entry->IsValid() && entry->IsUsed() ) {
-			if ( entry->IsFile() == searchEntry->IsFile() && entry->IsDir() == searchEntry->IsDir()
-			  && strncmp( (const char*)searchEntry->entry.data.name, (const char*)entry->entry.data.name, sizeof( entry->entry.data.name ) ) == 0 ) {
+		if (entry->IsValid() && entry->IsUsed())
+		{
+			if (entry->IsFile() == searchEntry->IsFile() && entry->IsDir() == searchEntry->IsDir() && strncmp((const char*)searchEntry->entry.data.name, (const char*)entry->entry.data.name, sizeof(entry->entry.data.name)) == 0)
+			{
 				return entry;
 			}
 		}
 
-		if ( i % 2 == 1 ) {
+		if (i % 2 == 1)
+		{
 			fileCluster = m_fat.data[0][0][fileCluster] & 0x7FFFFFFFu;
-			if ( fileCluster == 0x7FFFFFFFu ) { return nullptr; }
+			if (fileCluster == 0x7FFFFFFFu)
+			{
+				return nullptr;
+			}
 			entryCluster = &m_fileEntryDict[fileCluster];
 		}
 	}
@@ -1290,46 +1569,55 @@ const MemoryCardFileEntry* FolderMemoryCard::FindEquivalent( const MemoryCardFil
 	return nullptr;
 }
 
-s32 FolderMemoryCard::EraseBlock( u32 adr ) {
+s32 FolderMemoryCard::EraseBlock(u32 adr)
+{
 	const u32 block = adr / BlockSizeRaw;
 
 	u8 eraseData[PageSize];
-	memset( eraseData, 0xFF, PageSize );
-	for ( int page = 0; page < 16; ++page ) {
+	memset(eraseData, 0xFF, PageSize);
+	for (int page = 0; page < 16; ++page)
+	{
 		const u32 adr = block * BlockSizeRaw + page * PageSizeRaw;
-		Save( eraseData, adr, PageSize );
+		Save(eraseData, adr, PageSize);
 	}
 
 	// return 0 on fail, 1 on success?
 	return 1;
 }
 
-u64 FolderMemoryCard::GetCRC() const {
+u64 FolderMemoryCard::GetCRC() const
+{
 	// Since this is just used as integrity check for savestate loading,
 	// give a timestamp of the last time the memory card was written to
 	return m_timeLastWritten;
 }
 
-void FolderMemoryCard::SetSlot( uint slot ) {
-	pxAssert( slot < 8 );
+void FolderMemoryCard::SetSlot(uint slot)
+{
+	pxAssert(slot < 8);
 	m_slot = slot;
 }
 
-u32 FolderMemoryCard::GetSizeInClusters() const {
+u32 FolderMemoryCard::GetSizeInClusters() const
+{
 	const u32 clusters = m_superBlock.data.clusters_per_card;
-	if ( clusters > 0 && clusters < 0xFFFFFFFFu ) {
+	if (clusters > 0 && clusters < 0xFFFFFFFFu)
+	{
 		return clusters;
-	} else {
+	}
+	else
+	{
 		return TotalClusters;
 	}
 }
 
-void FolderMemoryCard::SetSizeInClusters( u32 clusters ) {
+void FolderMemoryCard::SetSizeInClusters(u32 clusters)
+{
 	superBlockUnion newSuperBlock;
-	memcpy( &newSuperBlock.raw[0], &m_superBlock.raw[0], sizeof( newSuperBlock.raw ) );
+	memcpy(&newSuperBlock.raw[0], &m_superBlock.raw[0], sizeof(newSuperBlock.raw));
 
 	newSuperBlock.data.clusters_per_card = clusters;
-	
+
 	const u32 alloc_offset = clusters / 0x100 + 9;
 	newSuperBlock.data.alloc_offset = alloc_offset;
 	newSuperBlock.data.alloc_end = clusters - 0x10 - alloc_offset;
@@ -1338,32 +1626,37 @@ void FolderMemoryCard::SetSizeInClusters( u32 clusters ) {
 	newSuperBlock.data.backup_block1 = blocks - 1;
 	newSuperBlock.data.backup_block2 = blocks - 2;
 
-	for ( size_t i = 0; i < sizeof( newSuperBlock.raw ) / PageSize; ++i ) {
-		Save( &newSuperBlock.raw[i * PageSize], i * PageSizeRaw, PageSize );
+	for (size_t i = 0; i < sizeof(newSuperBlock.raw) / PageSize; ++i)
+	{
+		Save(&newSuperBlock.raw[i * PageSize], i * PageSizeRaw, PageSize);
 	}
 }
 
-void FolderMemoryCard::SetSizeInMB( u32 megaBytes ) {
-	SetSizeInClusters( ( megaBytes * 1024 * 1024 ) / ClusterSize );
+void FolderMemoryCard::SetSizeInMB(u32 megaBytes)
+{
+	SetSizeInClusters((megaBytes * 1024 * 1024) / ClusterSize);
 }
 
-void FolderMemoryCard::SetTimeLastReadToNow() {
+void FolderMemoryCard::SetTimeLastReadToNow()
+{
 	m_framesUntilFlush = FramesAfterWriteUntilFlush;
 }
 
-void FolderMemoryCard::SetTimeLastWrittenToNow() {
+void FolderMemoryCard::SetTimeLastWrittenToNow()
+{
 	m_timeLastWritten = wxGetLocalTimeMillis().GetValue();
 	m_framesUntilFlush = FramesAfterWriteUntilFlush;
 }
 
-std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedFiles( const wxString& dirPath ) const
+std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedFiles(const wxString& dirPath) const
 {
 	std::vector<EnumeratedFileEntry> result;
 
-	wxDir dir( dirPath );
-	if ( dir.IsOpened() ) {
+	wxDir dir(dirPath);
+	if (dir.IsOpened())
+	{
 
-		const YAML::Node index = LoadYAMLFromFile( wxFileName( dirPath, "_pcsx2_index" ).GetFullPath() );
+		const YAML::Node index = LoadYAMLFromFile(wxFileName(dirPath, "_pcsx2_index").GetFullPath());
 
 		// We must be able to support legacy folder memcards without the index file, so for those
 		// track an order variable and make it negative - this way new files get their order preserved
@@ -1372,88 +1665,96 @@ std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedF
 		// all possible values without cutting them off
 		// Also exploit the fact pairs sort lexicographically to ensure directories are listed first
 		// (since they don't carry their own order in the index file)
-		std::map< std::pair<bool, int64_t>, EnumeratedFileEntry > sortContainer;
+		std::map<std::pair<bool, int64_t>, EnumeratedFileEntry> sortContainer;
 		int64_t orderForDirectories = 1;
 		int64_t orderForLegacyFiles = -1;
 
-		const auto getOptionalNodeAttribute = []( const YAML::Node& node, const char* attribName, auto def ) {
+		const auto getOptionalNodeAttribute = [](const YAML::Node& node, const char* attribName, auto def) {
 			auto result = std::move(def);
-			if ( node.IsDefined() ) {
-				result = node[attribName].as<decltype(def)>( def );
+			if (node.IsDefined())
+			{
+				result = node[attribName].as<decltype(def)>(def);
 			}
 			return result;
 		};
 
 		wxString fileName;
-		bool hasNext = dir.GetFirst( &fileName );
-		while ( hasNext ) {
-			if ( fileName.StartsWith( L"_pcsx2_" ) ) {
-				hasNext = dir.GetNext( &fileName );
+		bool hasNext = dir.GetFirst(&fileName);
+		while (hasNext)
+		{
+			if (fileName.StartsWith(L"_pcsx2_"))
+			{
+				hasNext = dir.GetNext(&fileName);
 				continue;
 			}
 
-			wxFileName fileInfo( dirPath, fileName );
-			if ( wxFile::Exists( fileInfo.GetFullPath() ) ) {
+			wxFileName fileInfo(dirPath, fileName);
+			if (wxFile::Exists(fileInfo.GetFullPath()))
+			{
 				wxDateTime creationTime, modificationTime;
-				fileInfo.GetTimes( nullptr, &modificationTime, &creationTime );
+				fileInfo.GetTimes(nullptr, &modificationTime, &creationTime);
 
-				const wxCharTypeBuffer fileNameUTF8( fileName.ToUTF8() );
-				const YAML::Node& node = index[ fileNameUTF8.data() ];
+				const wxCharTypeBuffer fileNameUTF8(fileName.ToUTF8());
+				const YAML::Node& node = index[fileNameUTF8.data()];
 
 				// orderForLegacyFiles will decrement even if it ends up being unused, but that's fine
-				auto key = std::make_pair( true, getOptionalNodeAttribute( node, "order", orderForLegacyFiles-- ) );
-				EnumeratedFileEntry entry { fileName, getOptionalNodeAttribute( node, "timeCreated", creationTime.GetTicks() ),
-											getOptionalNodeAttribute( node, "timeModified", modificationTime.GetTicks() ), true };
-				sortContainer.try_emplace( std::move(key), std::move(entry) );
+				auto key = std::make_pair(true, getOptionalNodeAttribute(node, "order", orderForLegacyFiles--));
+				EnumeratedFileEntry entry{fileName, getOptionalNodeAttribute(node, "timeCreated", creationTime.GetTicks()),
+					getOptionalNodeAttribute(node, "timeModified", modificationTime.GetTicks()), true};
+				sortContainer.try_emplace(std::move(key), std::move(entry));
 			}
-			else {
-				fileInfo.AppendDir( fileInfo.GetFullName() );
-				fileInfo.SetName( L"" );
+			else
+			{
+				fileInfo.AppendDir(fileInfo.GetFullName());
+				fileInfo.SetName(L"");
 
 				wxDateTime creationTime, modificationTime;
-				fileInfo.GetTimes( nullptr, &modificationTime, &creationTime );
+				fileInfo.GetTimes(nullptr, &modificationTime, &creationTime);
 
-				const YAML::Node indexForDirectory = LoadYAMLFromFile( wxFileName( fileInfo.GetFullPath(), "_pcsx2_index" ).GetFullPath() );
-				const YAML::Node& node = indexForDirectory[ "%ROOT" ];
+				const YAML::Node indexForDirectory = LoadYAMLFromFile(wxFileName(fileInfo.GetFullPath(), "_pcsx2_index").GetFullPath());
+				const YAML::Node& node = indexForDirectory["%ROOT"];
 
 				// orderForDirectories will increment even if it ends up being unused, but that's fine
-				auto key = std::make_pair( false, orderForDirectories++ );
-				EnumeratedFileEntry entry { fileName, getOptionalNodeAttribute( node, "timeCreated", creationTime.GetTicks() ),
-											getOptionalNodeAttribute( node, "timeModified", modificationTime.GetTicks() ), false };
-				sortContainer.try_emplace( std::move(key), std::move(entry) );
+				auto key = std::make_pair(false, orderForDirectories++);
+				EnumeratedFileEntry entry{fileName, getOptionalNodeAttribute(node, "timeCreated", creationTime.GetTicks()),
+					getOptionalNodeAttribute(node, "timeModified", modificationTime.GetTicks()), false};
+				sortContainer.try_emplace(std::move(key), std::move(entry));
 			}
 
-			hasNext = dir.GetNext( &fileName );
+			hasNext = dir.GetNext(&fileName);
 		}
 
 		// Move items from the intermediate map to a final vector
-		result.reserve( sortContainer.size() );
-		for ( auto& e : sortContainer ) {
-			result.push_back( std::move(e.second) );
+		result.reserve(sortContainer.size());
+		for (auto& e : sortContainer)
+		{
+			result.push_back(std::move(e.second));
 		}
 	}
 
 	return result;
 }
 
-void FolderMemoryCard::DeleteFromIndex( const wxString& filePath, const wxString& entry ) const
+void FolderMemoryCard::DeleteFromIndex(const wxString& filePath, const wxString& entry) const
 {
-	const wxString indexName = wxFileName( filePath, "_pcsx2_index" ).GetFullPath();
+	const wxString indexName = wxFileName(filePath, "_pcsx2_index").GetFullPath();
 
-	YAML::Node index = LoadYAMLFromFile( indexName );
+	YAML::Node index = LoadYAMLFromFile(indexName);
 
-	const wxCharTypeBuffer entryUTF8( entry.ToUTF8() );
-	index.remove( entryUTF8.data() );
+	const wxCharTypeBuffer entryUTF8(entry.ToUTF8());
+	index.remove(entryUTF8.data());
 
 	// Write out the changes
 	wxFFile indexFile;
-	if ( indexFile.Open( indexName, L"w" ) ) {
-		indexFile.Write( YAML::Dump( index ) );
+	if (indexFile.Open(indexName, L"w"))
+	{
+		indexFile.Write(YAML::Dump(index));
 	}
 }
 
 // from http://www.oocities.org/siliconvalley/station/8269/sma02/sma02.html#ECC
-void FolderMemoryCard::CalculateECC( u8* ecc, const u8* data ) {
+void FolderMemoryCard::CalculateECC(u8* ecc, const u8* data)
+{
 	static const u8 Table[] = {
 		0x00, 0x87, 0x96, 0x11, 0xa5, 0x22, 0x33, 0xb4, 0xb4, 0x33, 0x22, 0xa5, 0x11, 0x96, 0x87, 0x00,
 		0xc3, 0x44, 0x55, 0xd2, 0x66, 0xe1, 0xf0, 0x77, 0x77, 0xf0, 0xe1, 0x66, 0xd2, 0x55, 0x44, 0xc3,
@@ -1470,18 +1771,19 @@ void FolderMemoryCard::CalculateECC( u8* ecc, const u8* data ) {
 		0x11, 0x96, 0x87, 0x00, 0xb4, 0x33, 0x22, 0xa5, 0xa5, 0x22, 0x33, 0xb4, 0x00, 0x87, 0x96, 0x11,
 		0xd2, 0x55, 0x44, 0xc3, 0x77, 0xf0, 0xe1, 0x66, 0x66, 0xe1, 0xf0, 0x77, 0xc3, 0x44, 0x55, 0xd2,
 		0xc3, 0x44, 0x55, 0xd2, 0x66, 0xe1, 0xf0, 0x77, 0x77, 0xf0, 0xe1, 0x66, 0xd2, 0x55, 0x44, 0xc3,
-		0x00, 0x87, 0x96, 0x11, 0xa5, 0x22, 0x33, 0xb4, 0xb4, 0x33, 0x22, 0xa5, 0x11, 0x96, 0x87, 0x00
-	};
+		0x00, 0x87, 0x96, 0x11, 0xa5, 0x22, 0x33, 0xb4, 0xb4, 0x33, 0x22, 0xa5, 0x11, 0x96, 0x87, 0x00};
 
 	int i, c;
 
 	ecc[0] = ecc[1] = ecc[2] = 0;
 
-	for ( i = 0; i < 0x80; i++ ) {
+	for (i = 0; i < 0x80; i++)
+	{
 		c = Table[data[i]];
 
 		ecc[0] ^= c;
-		if ( c & 0x80 ) {
+		if (c & 0x80)
+		{
 			ecc[1] ^= ~i;
 			ecc[2] ^= i;
 		}
@@ -1498,109 +1800,130 @@ void FolderMemoryCard::CalculateECC( u8* ecc, const u8* data ) {
 	return;
 }
 
-void FolderMemoryCard::WriteToFile( const wxString& filename ) {
-	wxFFile targetFile( filename, L"wb" );
+void FolderMemoryCard::WriteToFile(const wxString& filename)
+{
+	wxFFile targetFile(filename, L"wb");
 
 	u8 buffer[FolderMemoryCard::PageSizeRaw];
 	u32 adr = 0;
-	while ( adr < GetSizeInClusters() * FolderMemoryCard::ClusterSizeRaw ) {
-		Read( buffer, adr, FolderMemoryCard::PageSizeRaw );
-		targetFile.Write( buffer, FolderMemoryCard::PageSizeRaw );
+	while (adr < GetSizeInClusters() * FolderMemoryCard::ClusterSizeRaw)
+	{
+		Read(buffer, adr, FolderMemoryCard::PageSizeRaw);
+		targetFile.Write(buffer, FolderMemoryCard::PageSizeRaw);
 		adr += FolderMemoryCard::PageSizeRaw;
 	}
 }
 
 
-FileAccessHelper::FileAccessHelper() {
+FileAccessHelper::FileAccessHelper()
+{
 }
 
-FileAccessHelper::~FileAccessHelper() {
+FileAccessHelper::~FileAccessHelper()
+{
 	this->CloseAll();
 }
 
-wxFFile* FileAccessHelper::Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata ) {
-	wxFileName fn( folderName );
-	fileRef->GetPath( &fn );
-	wxString filename( fn.GetFullPath() );
+wxFFile* FileAccessHelper::Open(const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata)
+{
+	wxFileName fn(folderName);
+	fileRef->GetPath(&fn);
+	wxString filename(fn.GetFullPath());
 
-	if ( !fn.FileExists() ) {
-		if ( !fn.DirExists() ) {
-			fn.Mkdir( 0777, wxPATH_MKDIR_FULL );
+	if (!fn.FileExists())
+	{
+		if (!fn.DirExists())
+		{
+			fn.Mkdir(0777, wxPATH_MKDIR_FULL);
 		}
-		wxFFile createEmptyFile( filename, L"wb" );
+		wxFFile createEmptyFile(filename, L"wb");
 		createEmptyFile.Close();
 	}
 
-	wxFFile* file = new wxFFile( filename, L"r+b" );
+	wxFFile* file = new wxFFile(filename, L"r+b");
 
 	std::string internalPath;
-	fileRef->GetInternalPath( &internalPath );
+	fileRef->GetInternalPath(&internalPath);
 	MemoryCardFileHandleStructure handleStruct;
 	handleStruct.fileHandle = file;
 	handleStruct.fileRef = fileRef;
-	m_files.emplace( std::move(internalPath), std::move(handleStruct) );
+	m_files.emplace(std::move(internalPath), std::move(handleStruct));
 
-	if ( writeMetadata ) {
-		WriteMetadata( folderName, fileRef );
+	if (writeMetadata)
+	{
+		WriteMetadata(folderName, fileRef);
 	}
 
 	return file;
 }
 
-void FileAccessHelper::WriteMetadata( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef ) {
-	const bool cleanedFilename = fileRef->GetPath( &folderName );
-	folderName.AppendDir( L"_pcsx2_meta" );
+void FileAccessHelper::WriteMetadata(wxFileName folderName, const MemoryCardFileMetadataReference* fileRef)
+{
+	const bool cleanedFilename = fileRef->GetPath(&folderName);
+	folderName.AppendDir(L"_pcsx2_meta");
 
 	const auto* entry = &fileRef->entry->entry;
 	const bool metadataIsNonstandard = cleanedFilename || entry->data.mode != MemoryCardFileEntry::DefaultFileMode || entry->data.attr != 0;
 
-	if ( metadataIsNonstandard ) {
+	if (metadataIsNonstandard)
+	{
 		// write metadata of file if it's nonstandard
-		if ( !folderName.DirExists() ) {
+		if (!folderName.DirExists())
+		{
 			folderName.Mkdir();
 		}
-		wxFFile metaFile( folderName.GetFullPath(), L"wb" );
-		if ( metaFile.IsOpened() ) {
-			metaFile.Write( entry->raw, sizeof( entry->raw ) );
+		wxFFile metaFile(folderName.GetFullPath(), L"wb");
+		if (metaFile.IsOpened())
+		{
+			metaFile.Write(entry->raw, sizeof(entry->raw));
 		}
-	} else {
+	}
+	else
+	{
 		// if metadata is standard remove metadata file if it exists
-		if ( folderName.FileExists() ) {
-			wxRemoveFile( folderName.GetFullPath() );
+		if (folderName.FileExists())
+		{
+			wxRemoveFile(folderName.GetFullPath());
 
 			// and remove the metadata dir if it's now empty
-			wxDir metaDir( folderName.GetPath() );
-			if ( metaDir.IsOpened() && !metaDir.HasFiles() ) {
-				wxRmdir( folderName.GetPath() );
+			wxDir metaDir(folderName.GetPath());
+			if (metaDir.IsOpened() && !metaDir.HasFiles())
+			{
+				wxRmdir(folderName.GetPath());
 			}
 		}
 	}
 }
 
-void FileAccessHelper::WriteIndex( wxFileName folderName, MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent )
+void FileAccessHelper::WriteIndex(wxFileName folderName, MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent)
 {
-	parent->GetPath( &folderName );
-	char cleanName[sizeof( entry->entry.data.name )];
-	memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-	FileAccessHelper::CleanMemcardFilename( cleanName );
+	parent->GetPath(&folderName);
+	char cleanName[sizeof(entry->entry.data.name)];
+	memcpy(cleanName, (const char*)entry->entry.data.name, sizeof(cleanName));
+	FileAccessHelper::CleanMemcardFilename(cleanName);
 
-	if ( entry->IsDir() ) {
-		folderName.AppendDir( wxString::FromAscii( cleanName ) );
-	} else if ( entry->IsFile() ) {
-		folderName.SetName( wxString::FromAscii( cleanName ) );
+	if (entry->IsDir())
+	{
+		folderName.AppendDir(wxString::FromAscii(cleanName));
+	}
+	else if (entry->IsFile())
+	{
+		folderName.SetName(wxString::FromAscii(cleanName));
 	}
 
-	const wxCharTypeBuffer fileName( folderName.GetName().ToUTF8() );
-	folderName.SetName( L"_pcsx2_index" );
+	const wxCharTypeBuffer fileName(folderName.GetName().ToUTF8());
+	folderName.SetName(L"_pcsx2_index");
 
-	YAML::Node index = LoadYAMLFromFile( folderName.GetFullPath() );
-	YAML::Node entryNode = index[ fileName.data() ];
+	YAML::Node index = LoadYAMLFromFile(folderName.GetFullPath());
+	YAML::Node entryNode = index[fileName.data()];
 
-	if ( !entryNode.IsDefined() ) {
+	if (!entryNode.IsDefined())
+	{
 		// Newly added file - figure out the sort order as the entry should be added to the end of the list
 		unsigned int order = 0;
-		for ( const auto& node : index ) {
-			order = std::max( order, node.second["order"].as<unsigned int>(0) );
+		for (const auto& node : index)
+		{
+			order = std::max(order, node.second["order"].as<unsigned int>(0));
 		}
 
 		entryNode["order"] = order + 1;
@@ -1613,26 +1936,34 @@ void FileAccessHelper::WriteIndex( wxFileName folderName, MemoryCardFileEntry* c
 
 	// Write out the changes
 	wxFFile indexFile;
-	if ( indexFile.Open( folderName.GetFullPath(), L"w" ) ) {
-		indexFile.Write( YAML::Dump( index ) );
+	if (indexFile.Open(folderName.GetFullPath(), L"w"))
+	{
+		indexFile.Write(YAML::Dump(index));
 	}
 }
 
-wxFFile* FileAccessHelper::ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata ) {
+wxFFile* FileAccessHelper::ReOpen(const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata)
+{
 	std::string internalPath;
-	fileRef->GetInternalPath( &internalPath );
-	auto it = m_files.find( internalPath );
-	if ( it != m_files.end() ) {
+	fileRef->GetInternalPath(&internalPath);
+	auto it = m_files.find(internalPath);
+	if (it != m_files.end())
+	{
 		// we already have a handle to this file
 
 		// if the caller wants to write metadata and we haven't done this recently, do so and remember that we did
-		if ( writeMetadata ) {
-			if ( m_lastWrittenFileRef != fileRef ) {
-				WriteMetadata( folderName, fileRef );
+		if (writeMetadata)
+		{
+			if (m_lastWrittenFileRef != fileRef)
+			{
+				WriteMetadata(folderName, fileRef);
 				m_lastWrittenFileRef = fileRef;
 			}
-		} else {
-			if ( m_lastWrittenFileRef != nullptr ) {
+		}
+		else
+		{
+			if (m_lastWrittenFileRef != nullptr)
+			{
 				m_lastWrittenFileRef = nullptr;
 			}
 		}
@@ -1641,181 +1972,225 @@ wxFFile* FileAccessHelper::ReOpen( const wxFileName& folderName, MemoryCardFileM
 		it->second.fileRef = fileRef;
 
 		return it->second.fileHandle;
-	} else {
-		return this->Open( folderName, fileRef, writeMetadata );
+	}
+	else
+	{
+		return this->Open(folderName, fileRef, writeMetadata);
 	}
 }
 
-void FileAccessHelper::CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry ) {
+void FileAccessHelper::CloseFileHandle(wxFFile* file, const MemoryCardFileEntry* entry)
+{
 	file->Close();
 
 	delete file;
 }
 
-void FileAccessHelper::CloseMatching( const wxString& path ) {
-	wxFileName fn( path );
+void FileAccessHelper::CloseMatching(const wxString& path)
+{
+	wxFileName fn(path);
 	fn.Normalize();
 	wxString pathNormalized = fn.GetFullPath();
-	for ( auto it = m_files.begin(); it != m_files.end(); ) {
+	for (auto it = m_files.begin(); it != m_files.end();)
+	{
 		wxString openPath = it->second.fileHandle->GetName();
-		if ( openPath.StartsWith( pathNormalized ) ) {
-			CloseFileHandle( it->second.fileHandle, it->second.fileRef->entry );
-			it = m_files.erase( it );
-		} else {
+		if (openPath.StartsWith(pathNormalized))
+		{
+			CloseFileHandle(it->second.fileHandle, it->second.fileRef->entry);
+			it = m_files.erase(it);
+		}
+		else
+		{
 			++it;
 		}
 	}
 }
 
-void FileAccessHelper::CloseAll() {
-	for ( auto it = m_files.begin(); it != m_files.end(); ++it ) {
-		CloseFileHandle( it->second.fileHandle, it->second.fileRef->entry );
+void FileAccessHelper::CloseAll()
+{
+	for (auto it = m_files.begin(); it != m_files.end(); ++it)
+	{
+		CloseFileHandle(it->second.fileHandle, it->second.fileRef->entry);
 	}
 	m_files.clear();
 }
 
-void FileAccessHelper::FlushAll() {
-	for ( auto it = m_files.begin(); it != m_files.end(); ++it ) {
+void FileAccessHelper::FlushAll()
+{
+	for (auto it = m_files.begin(); it != m_files.end(); ++it)
+	{
 		it->second.fileHandle->Flush();
 	}
 }
 
-void FileAccessHelper::ClearMetadataWriteState() {
+void FileAccessHelper::ClearMetadataWriteState()
+{
 	m_lastWrittenFileRef = nullptr;
 }
 
-bool FileAccessHelper::CleanMemcardFilename( char* name ) {
+bool FileAccessHelper::CleanMemcardFilename(char* name)
+{
 	// invalid characters for filenames in the PS2 file system: { '/', '?', '*' }
 	// the following characters are valid in a PS2 memcard file system but invalid in Windows
 	// there's less restrictions on Linux but by cleaning them always we keep the folders cross-compatible
-	const char illegalChars[] = { '\\', '%', ':', '|', '"', '<', '>' };
+	const char illegalChars[] = {'\\', '%', ':', '|', '"', '<', '>'};
 	bool cleaned = false;
 
-	const size_t filenameLength = strlen( name );
-	for ( size_t i = 0; i < sizeof( illegalChars ); ++i ) {
-		for ( size_t j = 0; j < filenameLength; ++j ) {
-			if ( name[j] == illegalChars[i] ) {
+	const size_t filenameLength = strlen(name);
+	for (size_t i = 0; i < sizeof(illegalChars); ++i)
+	{
+		for (size_t j = 0; j < filenameLength; ++j)
+		{
+			if (name[j] == illegalChars[i])
+			{
 				name[j] = '_';
 				cleaned = true;
 			}
 		}
 	}
 
-	cleaned |= CleanMemcardFilenameEndDotOrSpace( name, filenameLength );
+	cleaned |= CleanMemcardFilenameEndDotOrSpace(name, filenameLength);
 
 	return cleaned;
 }
 
-bool FileAccessHelper::CleanMemcardFilenameEndDotOrSpace( char* name, size_t length ) {
+bool FileAccessHelper::CleanMemcardFilenameEndDotOrSpace(char* name, size_t length)
+{
 	// Windows truncates dots and spaces at the end of filenames, so make sure that doesn't happen
 	bool cleaned = false;
-	for ( size_t j = length; j > 0; --j ) {
-		switch ( name[j - 1] ) {
-		case ' ':
-		case '.':
-			name[j - 1] = '_';
-			cleaned = true;
-			break;
-		default:
-			return cleaned;
+	for (size_t j = length; j > 0; --j)
+	{
+		switch (name[j - 1])
+		{
+			case ' ':
+			case '.':
+				name[j - 1] = '_';
+				cleaned = true;
+				break;
+			default:
+				return cleaned;
 		}
 	}
 
 	return cleaned;
 }
 
-bool MemoryCardFileMetadataReference::GetPath( wxFileName* fileName ) const {
+bool MemoryCardFileMetadataReference::GetPath(wxFileName* fileName) const
+{
 	bool parentCleaned = false;
-	if ( parent ) {
-		parentCleaned = parent->GetPath( fileName );
+	if (parent)
+	{
+		parentCleaned = parent->GetPath(fileName);
 	}
 
-	char cleanName[sizeof( entry->entry.data.name )];
-	memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-	bool localCleaned = FileAccessHelper::CleanMemcardFilename( cleanName );
+	char cleanName[sizeof(entry->entry.data.name)];
+	memcpy(cleanName, (const char*)entry->entry.data.name, sizeof(cleanName));
+	bool localCleaned = FileAccessHelper::CleanMemcardFilename(cleanName);
 
-	if ( entry->IsDir() ) {
-		fileName->AppendDir( wxString::FromAscii( cleanName ) );
-	} else if ( entry->IsFile() ) {
-		fileName->SetName( wxString::FromAscii( cleanName ) );
+	if (entry->IsDir())
+	{
+		fileName->AppendDir(wxString::FromAscii(cleanName));
+	}
+	else if (entry->IsFile())
+	{
+		fileName->SetName(wxString::FromAscii(cleanName));
 	}
 
 	return parentCleaned || localCleaned;
 }
 
-void MemoryCardFileMetadataReference::GetInternalPath( std::string* fileName ) const {
-	if ( parent ) {
-		parent->GetInternalPath( fileName );
+void MemoryCardFileMetadataReference::GetInternalPath(std::string* fileName) const
+{
+	if (parent)
+	{
+		parent->GetInternalPath(fileName);
 	}
 
-	fileName->append( (const char*)entry->entry.data.name );
+	fileName->append((const char*)entry->entry.data.name);
 
-	if ( entry->IsDir() ) {
-		fileName->append( "/" );
-	}
-}
-
-FolderMemoryCardAggregator::FolderMemoryCardAggregator() {
-	for ( uint i = 0; i < TotalCardSlots; ++i ) {
-		m_cards[i].SetSlot( i );
+	if (entry->IsDir())
+	{
+		fileName->append("/");
 	}
 }
 
-void FolderMemoryCardAggregator::Open() {
-	for ( int i = 0; i < TotalCardSlots; ++i ) {
-		m_cards[i].Open( m_enableFiltering, m_lastKnownFilter );
+FolderMemoryCardAggregator::FolderMemoryCardAggregator()
+{
+	for (uint i = 0; i < TotalCardSlots; ++i)
+	{
+		m_cards[i].SetSlot(i);
 	}
 }
 
-void FolderMemoryCardAggregator::Close() {
-	for ( int i = 0; i < TotalCardSlots; ++i ) {
+void FolderMemoryCardAggregator::Open()
+{
+	for (int i = 0; i < TotalCardSlots; ++i)
+	{
+		m_cards[i].Open(m_enableFiltering, m_lastKnownFilter);
+	}
+}
+
+void FolderMemoryCardAggregator::Close()
+{
+	for (int i = 0; i < TotalCardSlots; ++i)
+	{
 		m_cards[i].Close();
 	}
 }
 
-void FolderMemoryCardAggregator::SetFiltering( const bool enableFiltering ) {
+void FolderMemoryCardAggregator::SetFiltering(const bool enableFiltering)
+{
 	m_enableFiltering = enableFiltering;
 }
 
-s32 FolderMemoryCardAggregator::IsPresent( uint slot ) {
+s32 FolderMemoryCardAggregator::IsPresent(uint slot)
+{
 	return m_cards[slot].IsPresent();
 }
 
-void FolderMemoryCardAggregator::GetSizeInfo( uint slot, PS2E_McdSizeInfo& outways ) {
-	m_cards[slot].GetSizeInfo( outways );
+void FolderMemoryCardAggregator::GetSizeInfo(uint slot, PS2E_McdSizeInfo& outways)
+{
+	m_cards[slot].GetSizeInfo(outways);
 }
 
-bool FolderMemoryCardAggregator::IsPSX( uint slot ) {
+bool FolderMemoryCardAggregator::IsPSX(uint slot)
+{
 	return m_cards[slot].IsPSX();
 }
 
-s32 FolderMemoryCardAggregator::Read( uint slot, u8 *dest, u32 adr, int size ) {
-	return m_cards[slot].Read( dest, adr, size );
+s32 FolderMemoryCardAggregator::Read(uint slot, u8* dest, u32 adr, int size)
+{
+	return m_cards[slot].Read(dest, adr, size);
 }
 
-s32 FolderMemoryCardAggregator::Save( uint slot, const u8 *src, u32 adr, int size ) {
-	return m_cards[slot].Save( src, adr, size );
+s32 FolderMemoryCardAggregator::Save(uint slot, const u8* src, u32 adr, int size)
+{
+	return m_cards[slot].Save(src, adr, size);
 }
 
-s32 FolderMemoryCardAggregator::EraseBlock( uint slot, u32 adr ) {
-	return m_cards[slot].EraseBlock( adr );
+s32 FolderMemoryCardAggregator::EraseBlock(uint slot, u32 adr)
+{
+	return m_cards[slot].EraseBlock(adr);
 }
 
-u64 FolderMemoryCardAggregator::GetCRC( uint slot ) {
+u64 FolderMemoryCardAggregator::GetCRC(uint slot)
+{
 	return m_cards[slot].GetCRC();
 }
 
-void FolderMemoryCardAggregator::NextFrame( uint slot ) {
+void FolderMemoryCardAggregator::NextFrame(uint slot)
+{
 	m_cards[slot].NextFrame();
 }
 
-bool FolderMemoryCardAggregator::ReIndex( uint slot, const bool enableFiltering, const wxString& filter ) {
-	if ( m_cards[slot].ReIndex( enableFiltering, filter ) ) {
-		SetFiltering( enableFiltering );
+bool FolderMemoryCardAggregator::ReIndex(uint slot, const bool enableFiltering, const wxString& filter)
+{
+	if (m_cards[slot].ReIndex(enableFiltering, filter))
+	{
+		SetFiltering(enableFiltering);
 		m_lastKnownFilter = filter;
 		return true;
 	}
 
 	return false;
 }
-

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1382,7 +1382,8 @@ std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedF
 				wxDateTime creationTime, modificationTime;
 				fileInfo.GetTimes( nullptr, &modificationTime, &creationTime );
 
-				const YAML::Node& node = index[ fileName.ToStdString() ];
+				const wxCharTypeBuffer fileNameUTF8( fileName.ToUTF8() );
+				const YAML::Node& node = index[ fileNameUTF8.data() ];
 
 				// orderForLegacyFiles will decrement even if it ends up being unused, but that's fine
 				auto key = std::make_pair( true, node["order"].as<unsigned int>( orderForLegacyFiles-- ) );
@@ -1425,7 +1426,9 @@ void FolderMemoryCard::DeleteFromIndex( const wxString& filePath, const wxString
 	const wxString indexName = wxFileName( filePath, "_pcsx2_index" ).GetFullPath();
 
 	YAML::Node index = LoadYAMLFromFile( indexName );
-	index.remove( entry.ToStdString() );
+
+	const wxCharTypeBuffer entryUTF8( entry.ToUTF8() );
+	index.remove( entryUTF8.data() );
 
 	// Write out the changes
 	wxFFile indexFile;
@@ -1563,11 +1566,11 @@ void FileAccessHelper::WriteIndex( wxFileName folderName, const MemoryCardFileMe
 {
 	fileRef->GetPath( &folderName );
 
-	const std::string fileName = folderName.GetName();
+	const wxCharTypeBuffer fileName( folderName.GetName().ToUTF8() );
 	folderName.SetName( L"_pcsx2_index" );
 
 	YAML::Node index = LoadYAMLFromFile( folderName.GetFullPath() );
-	YAML::Node entryNode = index[fileName];
+	YAML::Node entryNode = index[ fileName.data() ];
 
 	if ( !entryNode.IsDefined() ) {
 		// Newly added file - figure out the sort order as the entry should be added to the end of the list

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -33,7 +33,14 @@ static YAML::Node LoadYAMLFromFile( const wxString& fileName ) {
 	YAML::Node index;
 
 	wxFFile indexFile;
-	if ( indexFile.Open( fileName, L"r" ) ) {
+	bool result;
+	{
+		// Suppress "file does not exist" errors
+		wxLogNull noLog;
+		result = indexFile.Open( fileName, L"r" );
+	}
+
+	if ( result ) {
 		wxString fileContents;
 		if ( indexFile.ReadAll( &fileContents ) ) {
 			index = YAML::Load( fileContents.mbc_str() );

--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -1575,7 +1575,7 @@ void FileAccessHelper::WriteIndex( wxFileName folderName, MemoryCardFileEntry* c
 	parent->GetPath( &folderName );
 	char cleanName[sizeof( entry->entry.data.name )];
 	memcpy( cleanName, (const char*)entry->entry.data.name, sizeof( cleanName ) );
-	bool localCleaned = FileAccessHelper::CleanMemcardFilename( cleanName );
+	FileAccessHelper::CleanMemcardFilename( cleanName );
 
 	if ( entry->IsDir() ) {
 		folderName.AppendDir( wxString::FromAscii( cleanName ) );

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -246,7 +246,7 @@ public:
 	// returns true if any changes were made
 	static bool CleanMemcardFilename( char* name );
 
-	static void WriteIndex( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef );
+	static void WriteIndex( wxFileName folderName, MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
 
 private:
 	// helper function for CleanMemcardFilename()

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -246,6 +246,8 @@ public:
 	// returns true if any changes were made
 	static bool CleanMemcardFilename( char* name );
 
+	static void WriteIndex( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef );
+
 private:
 	// helper function for CleanMemcardFilename()
 	static bool CleanMemcardFilenameEndDotOrSpace( char* name, size_t length );
@@ -257,7 +259,6 @@ private:
 	void CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry = nullptr );
 
 	void WriteMetadata( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef );
-	void WriteIndex( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef );
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -30,29 +30,31 @@
 //  Superblock Header Struct
 // --------------------------------------------------------------------------------------
 #pragma pack(push, 1)
-struct superblock {
-	char magic[28]; 			// 0x00
-	char version[12]; 			// 0x1c
-	u16 page_len; 				// 0x28
-	u16 pages_per_cluster;	 	// 0x2a
-	u16 pages_per_block;		// 0x2c
-	u16 unused; 				// 0x2e
-	u32 clusters_per_card;	 	// 0x30
-	u32 alloc_offset; 			// 0x34
-	u32 alloc_end; 				// 0x38
-	u32 rootdir_cluster;		// 0x3c
-	u32 backup_block1;			// 0x40
-	u32 backup_block2;			// 0x44
-	u64 padding0x48;			// 0x48
-	u32 ifc_list[32]; 			// 0x50
-	u32 bad_block_list[32]; 	// 0xd0
-	u8 card_type; 				// 0x150
-	u8 card_flags; 				// 0x151
+struct superblock
+{
+	char magic[28]; // 0x00
+	char version[12]; // 0x1c
+	u16 page_len; // 0x28
+	u16 pages_per_cluster; // 0x2a
+	u16 pages_per_block; // 0x2c
+	u16 unused; // 0x2e
+	u32 clusters_per_card; // 0x30
+	u32 alloc_offset; // 0x34
+	u32 alloc_end; // 0x38
+	u32 rootdir_cluster; // 0x3c
+	u32 backup_block1; // 0x40
+	u32 backup_block2; // 0x44
+	u64 padding0x48; // 0x48
+	u32 ifc_list[32]; // 0x50
+	u32 bad_block_list[32]; // 0xd0
+	u8 card_type; // 0x150
+	u8 card_flags; // 0x151
 };
 #pragma pack(pop)
 
 #pragma pack(push, 1)
-struct MemoryCardFileEntryDateTime {
+struct MemoryCardFileEntryDateTime
+{
 	u8 unused;
 	u8 second;
 	u8 minute;
@@ -61,11 +63,13 @@ struct MemoryCardFileEntryDateTime {
 	u8 month;
 	u16 year;
 
-	static MemoryCardFileEntryDateTime FromWxDateTime( const wxDateTime& time ) {
+	static MemoryCardFileEntryDateTime FromWxDateTime(const wxDateTime& time)
+	{
 		MemoryCardFileEntryDateTime t;
 
-		if ( time.IsValid() ) {
-			wxDateTime::Tm tm = time.GetTm( wxDateTime::GMT9 );
+		if (time.IsValid())
+		{
+			wxDateTime::Tm tm = time.GetTm(wxDateTime::GMT9);
 
 			t.unused = 0;
 			t.second = tm.sec;
@@ -74,7 +78,9 @@ struct MemoryCardFileEntryDateTime {
 			t.day = tm.mday;
 			t.month = tm.mon + 1;
 			t.year = tm.year;
-		} else {
+		}
+		else
+		{
 			t.unused = 0;
 			t.second = 0;
 			t.minute = 0;
@@ -87,12 +93,14 @@ struct MemoryCardFileEntryDateTime {
 		return t;
 	}
 
-	static MemoryCardFileEntryDateTime FromTime( time_t time ) {
+	static MemoryCardFileEntryDateTime FromTime(time_t time)
+	{
 		// TODO: When wx is gone, this will have to be handled differently; for now, rely on wx
-		return FromWxDateTime( wxDateTime(time) );
+		return FromWxDateTime(wxDateTime(time));
 	}
 
-	wxDateTime ToWxDateTime() const {
+	wxDateTime ToWxDateTime() const
+	{
 		wxDateTime::Tm tm;
 		tm.sec = this->second;
 		tm.min = this->minute;
@@ -101,21 +109,23 @@ struct MemoryCardFileEntryDateTime {
 		tm.mon = (wxDateTime::Month)(this->month - 1);
 		tm.year = this->year;
 
-		wxDateTime time( tm );
-		return time.FromTimezone( wxDateTime::GMT9 );
+		wxDateTime time(tm);
+		return time.FromTimezone(wxDateTime::GMT9);
 	}
 
-	time_t ToTime() const {
+	time_t ToTime() const
+	{
 		// TODO: When wx is gone, this will have to be handled differently; for now, rely on wx
 		return ToWxDateTime().GetTicks();
 	}
 
-	bool operator==( const MemoryCardFileEntryDateTime& other ) const {
-		return unused == other.unused && second == other.second && minute == other.minute && hour == other.hour
-		    && day == other.day && month == other.month && year == other.year;
+	bool operator==(const MemoryCardFileEntryDateTime& other) const
+	{
+		return unused == other.unused && second == other.second && minute == other.minute && hour == other.hour && day == other.day && month == other.month && year == other.year;
 	}
-	bool operator!=( const MemoryCardFileEntryDateTime& other ) const {
-		return !( *this == other );
+	bool operator!=(const MemoryCardFileEntryDateTime& other) const
+	{
+		return !(*this == other);
 	}
 };
 #pragma pack(pop)
@@ -125,28 +135,32 @@ struct MemoryCardFileEntryDateTime {
 // --------------------------------------------------------------------------------------
 // Structure for directory and file relationships as stored on memory cards
 #pragma pack(push, 1)
-struct MemoryCardFileEntry {
-	enum MemoryCardFileModeFlags {
-		Mode_Read          = 0x0001,
-		Mode_Write         = 0x0002,
-		Mode_Execute       = 0x0004,
+struct MemoryCardFileEntry
+{
+	enum MemoryCardFileModeFlags
+	{
+		Mode_Read = 0x0001,
+		Mode_Write = 0x0002,
+		Mode_Execute = 0x0004,
 		Mode_CopyProtected = 0x0008,
-		Mode_File          = 0x0010,
-		Mode_Directory     = 0x0020,
+		Mode_File = 0x0010,
+		Mode_Directory = 0x0020,
 		Mode_Unknown0x0040 = 0x0040,
 		Mode_Unknown0x0080 = 0x0080,
 		Mode_Unknown0x0100 = 0x0100,
 		Mode_Unknown0x0200 = 0x0200,
 		Mode_Unknown0x0400 = 0x0400, // Maybe Mode_PS2_Save or something along those lines?
 		Mode_PocketStation = 0x0800,
-		Mode_PSX           = 0x1000,
+		Mode_PSX = 0x1000,
 		Mode_Unknown0x2000 = 0x2000, // Supposedly Mode_Hidden but files still show up in the PS2 browser with this set
 		Mode_Unknown0x4000 = 0x4000,
-		Mode_Used          = 0x8000
+		Mode_Used = 0x8000
 	};
 
-	union {
-		struct MemoryCardFileEntryData {
+	union
+	{
+		struct MemoryCardFileEntryData
+		{
 			u32 mode;
 			u32 length; // number of bytes for file, number of files for dir
 			MemoryCardFileEntryDateTime timeCreated;
@@ -161,12 +175,12 @@ struct MemoryCardFileEntry {
 		u8 raw[0x200];
 	} entry;
 
-	bool IsFile() const { return !!( entry.data.mode & Mode_File ); }
-	bool IsDir()  const { return !!( entry.data.mode & Mode_Directory ); }
-	bool IsUsed() const { return !!( entry.data.mode & Mode_Used ); }
+	bool IsFile() const { return !!(entry.data.mode & Mode_File); }
+	bool IsDir() const { return !!(entry.data.mode & Mode_Directory); }
+	bool IsUsed() const { return !!(entry.data.mode & Mode_Used); }
 	bool IsValid() const { return entry.data.mode != 0xFFFFFFFF; }
 	// checks if we're either "." or ".."
-	bool IsDotDir() const { return entry.data.name[0] == '.' && ( entry.data.name[1] == '\0' || ( entry.data.name[1] == '.' && entry.data.name[2] == '\0' ) ); }
+	bool IsDotDir() const { return entry.data.name[0] == '.' && (entry.data.name[1] == '\0' || (entry.data.name[1] == '.' && entry.data.name[2] == '\0')); }
 
 	static const u32 DefaultDirMode = Mode_Read | Mode_Write | Mode_Execute | Mode_Directory | Mode_Unknown0x0400 | Mode_Used;
 	static const u32 DefaultFileMode = Mode_Read | Mode_Write | Mode_Execute | Mode_File | Mode_Unknown0x0080 | Mode_Unknown0x0400 | Mode_Used;
@@ -177,42 +191,50 @@ struct MemoryCardFileEntry {
 #pragma pack(pop)
 
 #pragma pack(push, 1)
-struct MemoryCardFileEntryCluster {
+struct MemoryCardFileEntryCluster
+{
 	MemoryCardFileEntry entries[2];
 };
 #pragma pack(pop)
 
 #pragma pack(push, 1)
-struct MemoryCardPage {
+struct MemoryCardPage
+{
 	static const int PageSize = 0x200;
 	u8 raw[PageSize];
 };
 #pragma pack(pop)
 
-struct MemoryCardFileEntryTreeNode {
+struct MemoryCardFileEntryTreeNode
+{
 	MemoryCardFileEntry entry;
 	std::vector<MemoryCardFileEntryTreeNode> subdir;
 
-	MemoryCardFileEntryTreeNode( const MemoryCardFileEntry& entry ) : entry(entry) {}
+	MemoryCardFileEntryTreeNode(const MemoryCardFileEntry& entry)
+		: entry(entry)
+	{
+	}
 };
 
 // --------------------------------------------------------------------------------------
 //  MemoryCardFileMetadataReference
 // --------------------------------------------------------------------------------------
 // Helper structure to quickly access file entries from any file data FAT cluster
-struct MemoryCardFileMetadataReference {
+struct MemoryCardFileMetadataReference
+{
 	MemoryCardFileMetadataReference* parent;
 	MemoryCardFileEntry* entry;
 	u32 consecutiveCluster;
 
 	// returns true if filename was modified and metadata containing the actual filename should be written
-	bool GetPath( wxFileName* fileName ) const;
+	bool GetPath(wxFileName* fileName) const;
 
 	// gives the internal memory card file system path, not to be used for writes to the host file system
-	void GetInternalPath( std::string* fileName ) const;
+	void GetInternalPath(std::string* fileName) const;
 };
 
-struct MemoryCardFileHandleStructure {
+struct MemoryCardFileHandleStructure
+{
 	MemoryCardFileMetadataReference* fileRef;
 	wxFFile* fileHandle;
 };
@@ -220,8 +242,9 @@ struct MemoryCardFileHandleStructure {
 // --------------------------------------------------------------------------------------
 //  FileAccessHelper
 // --------------------------------------------------------------------------------------
-// Small helper class to keep memory card files opened between calls to Read()/Save() 
-class FileAccessHelper {
+// Small helper class to keep memory card files opened between calls to Read()/Save()
+class FileAccessHelper
+{
 private:
 	std::map<std::string, MemoryCardFileHandleStructure> m_files;
 	MemoryCardFileMetadataReference* m_lastWrittenFileRef = nullptr; // we remember this to reduce redundant metadata checks/writes
@@ -231,9 +254,9 @@ public:
 	~FileAccessHelper();
 
 	// Get an already opened file if possible, or open a new one and remember it
-	wxFFile* ReOpen( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
+	wxFFile* ReOpen(const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false);
 	// Close all open files that start with the given path, so either a file if a filename is given or all files in a directory and its subdirectories when a directory is given
-	void CloseMatching( const wxString& path );
+	void CloseMatching(const wxString& path);
 	// Close all open files
 	void CloseAll();
 	// Flush the written data of all open files to the file system
@@ -244,28 +267,29 @@ public:
 
 	// removes characters from a PS2 file name that would be illegal in a Windows file system
 	// returns true if any changes were made
-	static bool CleanMemcardFilename( char* name );
+	static bool CleanMemcardFilename(char* name);
 
-	static void WriteIndex( wxFileName folderName, MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
+	static void WriteIndex(wxFileName folderName, MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent);
 
 private:
 	// helper function for CleanMemcardFilename()
-	static bool CleanMemcardFilenameEndDotOrSpace( char* name, size_t length );
+	static bool CleanMemcardFilenameEndDotOrSpace(char* name, size_t length);
 
 	// Open a new file and remember it for later
-	wxFFile* Open( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false );
+	wxFFile* Open(const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef, bool writeMetadata = false);
 	// Close a file and delete its handle
 	// If entry is given, it also attempts to set the created and modified timestamps of the file according to the entry
-	void CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry = nullptr );
+	void CloseFileHandle(wxFFile* file, const MemoryCardFileEntry* entry = nullptr);
 
-	void WriteMetadata( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef );
+	void WriteMetadata(wxFileName folderName, const MemoryCardFileMetadataReference* fileRef);
 };
 
 // --------------------------------------------------------------------------------------
 //  FolderMemoryCard
 // --------------------------------------------------------------------------------------
 // Fakes a memory card using a regular folder/file structure in the host file system
-class FolderMemoryCard {
+class FolderMemoryCard
+{
 public:
 	// a few constants so we could in theory change the memory card size without too much effort
 	static const int IndirectFatClusterCount = 1; // should be 32 but only 1 is ever used
@@ -289,20 +313,24 @@ public:
 	static const int FramesAfterWriteUntilFlush = 2;
 
 protected:
-	union superBlockUnion {
+	union superBlockUnion
+	{
 		superblock data;
 		u8 raw[BlockSize];
 	} m_superBlock;
-	union indirectFatUnion {
+	union indirectFatUnion
+	{
 		u32 data[IndirectFatClusterCount][ClusterSize / 4];
 		u8 raw[IndirectFatClusterCount][ClusterSize];
 	} m_indirectFat;
-	union fatUnion {
+	union fatUnion
+	{
 		u32 data[IndirectFatClusterCount][ClusterSize / 4][ClusterSize / 4];
 		u8 raw[IndirectFatClusterCount][ClusterSize / 4][ClusterSize];
 	} m_fat;
 	u8 m_backupBlock1[BlockSize];
-	union backupBlock2Union {
+	union backupBlock2Union
+	{
 		u32 programmedBlock;
 		u8 raw[BlockSize];
 	} m_backupBlock2;
@@ -350,44 +378,45 @@ public:
 	void Unlock();
 
 	// Initialize & Load Memory Card with values configured in the Memory Card Manager
-	void Open( const bool enableFiltering, const wxString& filter );
+	void Open(const bool enableFiltering, const wxString& filter);
 	// Initialize & Load Memory Card with provided custom values
-	void Open( const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter, bool simulateFileWrites = false );
+	void Open(const wxString& fullPath, const AppConfig::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, const wxString& filter, bool simulateFileWrites = false);
 	// Close the memory card and flush changes to the file system. Set flush to false to not store changes.
-	void Close( bool flush = true );
+	void Close(bool flush = true);
 
 	// Closes and reopens card with given filter options if they differ from the current ones (returns true),
 	// or does nothing if they match already (returns false).
 	// Does nothing and returns false when called on a closed memory card.
-	bool ReIndex( bool enableFiltering, const wxString& filter );
+	bool ReIndex(bool enableFiltering, const wxString& filter);
 
-	s32  IsPresent() const;
-	void GetSizeInfo( PS2E_McdSizeInfo& outways ) const;
+	s32 IsPresent() const;
+	void GetSizeInfo(PS2E_McdSizeInfo& outways) const;
 	bool IsPSX() const;
-	s32  Read( u8 *dest, u32 adr, int size );
-	s32  Save( const u8 *src, u32 adr, int size );
-	s32  EraseBlock( u32 adr );
-	u64  GetCRC() const;
+	s32 Read(u8* dest, u32 adr, int size);
+	s32 Save(const u8* src, u32 adr, int size);
+	s32 EraseBlock(u32 adr);
+	u64 GetCRC() const;
 
-	void SetSlot( uint slot );
+	void SetSlot(uint slot);
 
 	u32 GetSizeInClusters() const;
 
 	// WARNING: The intended use-case for this is resetting back to 8MB if a differently-sized superblock was loaded
 	// setting to a different size is untested and will probably not work correctly
-	void SetSizeInClusters( u32 clusters );
+	void SetSizeInClusters(u32 clusters);
 	// see SetSizeInClusters()
-	void SetSizeInMB( u32 megaBytes );
+	void SetSizeInMB(u32 megaBytes);
 
 	// called once per frame, used for flushing data after FramesAfterWriteUntilFlush frames of no writes
 	void NextFrame();
 
-	static void CalculateECC( u8* ecc, const u8* data );
+	static void CalculateECC(u8* ecc, const u8* data);
 
-	void WriteToFile( const wxString& filename );
+	void WriteToFile(const wxString& filename);
 
 protected:
-	struct EnumeratedFileEntry {
+	struct EnumeratedFileEntry
+	{
 		wxString m_fileName; // TODO: Replace with std::string
 		time_t m_timeCreated;
 		time_t m_timeModified;
@@ -401,21 +430,21 @@ protected:
 
 	// returns the in-memory address of data the given memory card adr corresponds to
 	// returns nullptr if adr corresponds to a folder or file entry
-	u8* GetSystemBlockPointer( const u32 adr );
+	u8* GetSystemBlockPointer(const u32 adr);
 
 	// returns in-memory address of file or directory metadata searchCluster corresponds to
 	// returns nullptr if searchCluster contains something else
 	// - searchCluster: the cluster that is being accessed, relative to alloc_offset in the superblock
 	// - entryNumber: page of cluster
 	// - offset: offset of page
-	u8* GetFileEntryPointer( const u32 searchCluster, const u32 entryNumber, const u32 offset );
+	u8* GetFileEntryPointer(const u32 searchCluster, const u32 entryNumber, const u32 offset);
 
 	// used by GetFileEntryPointer to find the correct cluster
 	// returns nullptr if searchCluster is not a file or directory metadata cluster
 	// - currentCluster: the cluster we're currently traversing
 	// - searchCluster: the cluster we want
 	// - fileCount: the number of files left in the directory currently traversed
-	MemoryCardFileEntryCluster* GetFileEntryCluster( const u32 currentCluster, const u32 searchCluster, const u32 fileCount );
+	MemoryCardFileEntryCluster* GetFileEntryCluster(const u32 currentCluster, const u32 searchCluster, const u32 fileCount);
 
 	// returns file entry of the file at the given searchCluster
 	// the passed fileName will be filled with a path to the file being accessed
@@ -427,14 +456,14 @@ protected:
 	// - originalDirCount: the point in fileName where to insert the found folder path, usually fileName->GetDirCount()
 	// - outClusterNumber: the cluster's sequential number of the file will be written to this pointer,
 	//                     which can be used to calculate the in-file offset of the address being accessed
-	MemoryCardFileEntry* GetFileEntryFromFileDataCluster( const u32 currentCluster, const u32 searchCluster, wxFileName* fileName, const size_t originalDirCount, u32* outClusterNumber );
+	MemoryCardFileEntry* GetFileEntryFromFileDataCluster(const u32 currentCluster, const u32 searchCluster, wxFileName* fileName, const size_t originalDirCount, u32* outClusterNumber);
 
 
 	// loads files and folders from the host file system if a superblock exists in the root directory
 	// - sizeInClusters: total memory card size in clusters, 0 for default
 	// - enableFiltering: if set to true, only folders whose name contain the filter string are loaded
 	// - filter: can include multiple filters by separating them with "/"
-	void LoadMemoryCardData( const u32 sizeInClusters, const bool enableFiltering, const wxString& filter );
+	void LoadMemoryCardData(const u32 sizeInClusters, const bool enableFiltering, const wxString& filter);
 
 	// creates the FAT and indirect FAT
 	void CreateFat();
@@ -458,59 +487,59 @@ protected:
 	u32 GetAmountFreeDataClusters() const;
 
 	// returns the final cluster of the file or directory which is (partially) stored in the given cluster
-	u32 GetLastClusterOfData( const u32 cluster ) const;
+	u32 GetLastClusterOfData(const u32 cluster) const;
 
 
 	// creates and returns a new file entry in the given directory entry, ready to be filled
 	// returns nullptr when the memory card is full
-	MemoryCardFileEntry* AppendFileEntryToDir( const MemoryCardFileEntry* const dirEntry );
+	MemoryCardFileEntry* AppendFileEntryToDir(const MemoryCardFileEntry* const dirEntry);
 
 	// adds a folder in the host file system to the memory card, including all files and subdirectories
 	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
 	// - dirPath: the full path to the directory in the host file system
 	// - parent: pointer to the parent dir's quick-access reference element
 	// - enableFiltering and filter: filter loaded contents, see LoadMemoryCardData()
-	bool AddFolder( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, MemoryCardFileMetadataReference* parent = nullptr, const bool enableFiltering = false, const wxString& filter = L"" );
+	bool AddFolder(MemoryCardFileEntry* const dirEntry, const wxString& dirPath, MemoryCardFileMetadataReference* parent = nullptr, const bool enableFiltering = false, const wxString& filter = L"");
 
 	// adds a file in the host file sytem to the memory card
 	// - dirEntry: the entry of the directory in the parent directory, or the root "." entry
 	// - dirPath: the full path to the directory containing the file in the host file system
 	// - fileName: the name of the file, without path
 	// - parent: pointer to the parent dir's quick-access reference element
-	bool AddFile( MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const EnumeratedFileEntry& fileEntry, MemoryCardFileMetadataReference* parent = nullptr );
+	bool AddFile(MemoryCardFileEntry* const dirEntry, const wxString& dirPath, const EnumeratedFileEntry& fileEntry, MemoryCardFileMetadataReference* parent = nullptr);
 
 	// calculates the amount of clusters a directory would use up if put into a memory card
-	u32 CalculateRequiredClustersOfDirectory( const wxString& dirPath ) const;
+	u32 CalculateRequiredClustersOfDirectory(const wxString& dirPath) const;
 
 
 	// adds a file to the quick-access dictionary, so it can be accessed more efficiently (ie, without searching through the entire file system) later
 	// returns the MemoryCardFileMetadataReference of the first file cluster, or nullptr if the file is zero-length
-	MemoryCardFileMetadataReference* AddFileEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
+	MemoryCardFileMetadataReference* AddFileEntryToMetadataQuickAccess(MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent);
 
 	// creates a reference to a directory entry, so it can be passed as parent to other files/directories
-	MemoryCardFileMetadataReference* AddDirEntryToMetadataQuickAccess( MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent );
+	MemoryCardFileMetadataReference* AddDirEntryToMetadataQuickAccess(MemoryCardFileEntry* const entry, MemoryCardFileMetadataReference* const parent);
 
-	
+
 	// read data from the memory card, ignoring the cache
 	// do NOT attempt to read ECC with this method, it will not work
-	void ReadDataWithoutCache( u8* const dest, const u32 adr, const u32 dataLength );
+	void ReadDataWithoutCache(u8* const dest, const u32 adr, const u32 dataLength);
 
 
-	bool ReadFromFile( u8 *dest, u32 adr, u32 dataLength );
-	bool WriteToFile( const u8* src, u32 adr, u32 dataLength );
+	bool ReadFromFile(u8* dest, u32 adr, u32 dataLength);
+	bool WriteToFile(const u8* src, u32 adr, u32 dataLength);
 
 
 	// flush the whole cache to the internal data and/or host file system
 	void Flush();
 
 	// flush a single page of the cache to the internal data and/or host file system
-	bool FlushPage( const u32 page );
+	bool FlushPage(const u32 page);
 
 	// flush a memory card cluster of the cache to the internal data and/or host file system
-	bool FlushCluster( const u32 cluster );
+	bool FlushCluster(const u32 cluster);
 
 	// flush a whole memory card block of the cache to the internal data and/or host file system
-	bool FlushBlock( const u32 block );
+	bool FlushBlock(const u32 block);
 
 	// flush the superblock to the internal data and/or host file system
 	void FlushSuperBlock();
@@ -519,56 +548,58 @@ protected:
 	void FlushFileEntries();
 
 	// flush a directory's file entries and all its subdirectories to the internal data
-	void FlushFileEntries( const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath = L"", MemoryCardFileMetadataReference* parent = nullptr );
+	void FlushFileEntries(const u32 dirCluster, const u32 remainingFiles, const wxString& dirPath = L"", MemoryCardFileMetadataReference* parent = nullptr);
 
 	// "delete" (prepend '_pcsx2_deleted_' to) any files that exist in oldFileEntries but no longer exist in m_fileEntryDict
 	// also calls RemoveUnchangedDataFromCache() since both operate on comparing with the old file entires
-	void FlushDeletedFilesAndRemoveUnchangedDataFromCache( const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries );
+	void FlushDeletedFilesAndRemoveUnchangedDataFromCache(const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries);
 
 	// recursive worker method of the above
 	// - newCluster: Current directory dotdir cluster of the new entries.
 	// - newFileCount: Number of file entries in the new directory.
 	// - dirPath: Path to the current directory relative to the root of the memcard. Must be identical for both entries.
-	void FlushDeletedFilesAndRemoveUnchangedDataFromCache( const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries, const u32 newCluster, const u32 newFileCount, const wxString& dirPath );
+	void FlushDeletedFilesAndRemoveUnchangedDataFromCache(const std::vector<MemoryCardFileEntryTreeNode>& oldFileEntries, const u32 newCluster, const u32 newFileCount, const wxString& dirPath);
 
 	// try and remove unchanged data from m_cache
 	// oldEntry and newEntry should be equivalent entries found by FindEquivalent()
-	void RemoveUnchangedDataFromCache( const MemoryCardFileEntry* const oldEntry, const MemoryCardFileEntry* const newEntry );
+	void RemoveUnchangedDataFromCache(const MemoryCardFileEntry* const oldEntry, const MemoryCardFileEntry* const newEntry);
 
 	// write data as Save() normally would, but ignore the cache; used for flushing
-	s32 WriteWithoutCache( const u8 *src, u32 adr, int size );
+	s32 WriteWithoutCache(const u8* src, u32 adr, int size);
 
 	// copies the contents of m_fileEntryDict into the tree structure fileEntryTree
-	void CopyEntryDictIntoTree( std::vector<MemoryCardFileEntryTreeNode>* fileEntryTree, const u32 cluster, const u32 fileCount );
+	void CopyEntryDictIntoTree(std::vector<MemoryCardFileEntryTreeNode>* fileEntryTree, const u32 cluster, const u32 fileCount);
 
 	// find equivalent (same name and type) of searchEntry in m_fileEntryDict in the directory indicated by cluster
-	const MemoryCardFileEntry* FindEquivalent( const MemoryCardFileEntry* searchEntry, const u32 cluster, const u32 fileCount );
+	const MemoryCardFileEntry* FindEquivalent(const MemoryCardFileEntry* searchEntry, const u32 cluster, const u32 fileCount);
 
 	void SetTimeLastReadToNow();
 	void SetTimeLastWrittenToNow();
 
-	
-	wxString GetDisabledMessage( uint slot ) const {
-		return wxsFormat( pxE( L"The PS2-slot %d has been automatically disabled.  You can correct the problem\nand re-enable it at any time using Config:Memory cards from the main menu."
-			), slot//TODO: translate internal slot index to human-readable slot description
-			);
+
+	wxString GetDisabledMessage(uint slot) const
+	{
+		return wxsFormat(pxE(L"The PS2-slot %d has been automatically disabled.  You can correct the problem\nand re-enable it at any time using Config:Memory cards from the main menu."), slot //TODO: translate internal slot index to human-readable slot description
+		);
 	}
-	wxString GetCardFullMessage( const wxString& filePath ) const {
-		return wxsFormat( pxE( L"(FolderMcd) Memory Card is full, could not add: %s" ), WX_STR( filePath ) );
+	wxString GetCardFullMessage(const wxString& filePath) const
+	{
+		return wxsFormat(pxE(L"(FolderMcd) Memory Card is full, could not add: %s"), WX_STR(filePath));
 	}
 
 	// get the list of files (and their timestamps) in directory ordered as specified by the index file
 	// for legacy entries without an entry in the index file, order is unspecified and should not be relied on
-	std::vector<EnumeratedFileEntry> GetOrderedFiles( const wxString& dirPath ) const;
+	std::vector<EnumeratedFileEntry> GetOrderedFiles(const wxString& dirPath) const;
 
-	void DeleteFromIndex( const wxString& filePath, const wxString& entry ) const;
+	void DeleteFromIndex(const wxString& filePath, const wxString& entry) const;
 };
 
 // --------------------------------------------------------------------------------------
 //  FolderMemoryCardAggregator
 // --------------------------------------------------------------------------------------
 // Forwards the API's requests for specific memory card slots to the correct FolderMemoryCard.
-class FolderMemoryCardAggregator {
+class FolderMemoryCardAggregator
+{
 protected:
 	static const int TotalCardSlots = 8;
 	FolderMemoryCard m_cards[TotalCardSlots];
@@ -585,15 +616,15 @@ public:
 	void Open();
 	void Close();
 
-	void SetFiltering( const bool enableFiltering );
+	void SetFiltering(const bool enableFiltering);
 
-	s32  IsPresent( uint slot );
-	void GetSizeInfo( uint slot, PS2E_McdSizeInfo& outways );
-	bool IsPSX( uint slot );
-	s32  Read( uint slot, u8 *dest, u32 adr, int size );
-	s32  Save( uint slot, const u8 *src, u32 adr, int size );
-	s32  EraseBlock( uint slot, u32 adr );
-	u64  GetCRC( uint slot );
-	void NextFrame( uint slot );
-	bool ReIndex( uint slot, const bool enableFiltering, const wxString& filter );
+	s32 IsPresent(uint slot);
+	void GetSizeInfo(uint slot, PS2E_McdSizeInfo& outways);
+	bool IsPSX(uint slot);
+	s32 Read(uint slot, u8* dest, u32 adr, int size);
+	s32 Save(uint slot, const u8* src, u32 adr, int size);
+	s32 EraseBlock(uint slot, u32 adr);
+	u64 GetCRC(uint slot);
+	void NextFrame(uint slot);
+	bool ReIndex(uint slot, const bool enableFiltering, const wxString& filter);
 };

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -390,6 +390,7 @@ protected:
 		wxString m_fileName; // TODO: Replace with std::string
 		time_t m_timeCreated;
 		time_t m_timeModified;
+		bool m_isFile;
 	};
 
 	// initializes memory card data, as if it was fresh from the factory

--- a/pcsx2/gui/MemoryCardFolder.h
+++ b/pcsx2/gui/MemoryCardFolder.h
@@ -212,9 +212,9 @@ struct MemoryCardFileHandleStructure {
 // --------------------------------------------------------------------------------------
 // Small helper class to keep memory card files opened between calls to Read()/Save() 
 class FileAccessHelper {
-protected:
+private:
 	std::map<std::string, MemoryCardFileHandleStructure> m_files;
-	MemoryCardFileMetadataReference* m_lastWrittenFileRef; // we remember this to reduce redundant metadata checks/writes
+	MemoryCardFileMetadataReference* m_lastWrittenFileRef = nullptr; // we remember this to reduce redundant metadata checks/writes
 
 public:
 	FileAccessHelper();
@@ -236,7 +236,7 @@ public:
 	// returns true if any changes were made
 	static bool CleanMemcardFilename( char* name );
 
-protected:
+private:
 	// helper function for CleanMemcardFilename()
 	static bool CleanMemcardFilenameEndDotOrSpace( char* name, size_t length );
 
@@ -246,8 +246,7 @@ protected:
 	// If entry is given, it also attempts to set the created and modified timestamps of the file according to the entry
 	void CloseFileHandle( wxFFile* file, const MemoryCardFileEntry* entry = nullptr );
 
-	void WriteMetadata( const wxFileName& folderName, MemoryCardFileMetadataReference* fileRef );
-	void WriteMetadata( bool metadataIsNonstandard, wxFileName& metadataFilename, const MemoryCardFileEntry* const entry );
+	void WriteMetadata( wxFileName folderName, const MemoryCardFileMetadataReference* fileRef );
 };
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
**~This PR depends on #3950 because of its addition of yaml-cpp. Do not merge it before that PR.~**

This PR adds an index file for folder memory cards in order to track timestamps and order of files in the FAT partition properly. This normally shouldn't matter, but there are at least a few games (ie. GTA games) which rely on the order of files on the memory card. Previously, folder memcards would not care about the order and populate the partition in whatever order the host filesystem provided the files (so, in the case of NTFS partitions, alphabetically). In reality, FAT partitions don't specify the order of files, which means in practice they are sorted by the order of creation.

I added a YAML based index file to every subdirectory in folder memory cards to retain the original order in which game writes data to the card. Additionally, instead of relying on host timestamps, they are preserved in the index file as well. This resolves issues where moving/copying the folder memory card around would change timestamps.

I verified this against all 5 GTAs and they work properly. Vice City Stories still decided to reject the memory card if I converted the files from a regular memory card to a folder memory card, but converting back and forth now works fine instead of producing "corrupted" blocks (as far as the game was concerned). This is something worth revisiting in the future, but it's an extreme edge case.

Fixes #3888. Also fixes saving in **all** GTA games, not just Vice City Stories.
Test with games from #3918, as some/all of those issues may be potentially fixed.