### PR TITLE
Add no-pch build to GitHub Actions

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -34,12 +34,27 @@ jobs:
       # Prevent one build from failing everything (although maybe those should be included as experimental builds instead)
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        platform: [x86, x64]
-        compiler: [gcc, clang]
-        experimental: [false]
+        include:
+          - os: ubuntu-20.04
+            platform: x86
+            compiler: gcc
+            experimental: false
+          - os: ubuntu-20.04
+            platform: x64
+            compiler: gcc
+            experimental: false
+          - os: ubuntu-20.04
+            platform: x86
+            compiler: clang
+            experimental: false
+          - os: ubuntu-20.04
+            platform: x86
+            compiler: gcc
+            cmakeflags: -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+            detail: -nopch
+            experimental: true
 
-    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}${{ matrix.detail }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
@@ -84,9 +99,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          key: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}${{ matrix.detail }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}-ccache-
+            ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}${{ matrix.detail }}-ccache-
 
       - name: Install Packages
         env:
@@ -98,6 +113,7 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
           COMPILER: ${{ matrix.compiler }}
+          ADDITIONAL_CMAKE_ARGS: ${{ matrix.cmakeflags }}
         run: ./.github/workflows/scripts/linux/generate-cmake.sh
 
       - name: Build PCSX2

--- a/.github/workflows/scripts/linux/generate-cmake.sh
+++ b/.github/workflows/scripts/linux/generate-cmake.sh
@@ -17,6 +17,7 @@ echo "Additional CMake Args - ${ADDITIONAL_CMAKE_ARGS}"
 
 # Generate CMake into ./build
 cmake \
+-D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
 -D CMAKE_BUILD_TYPE=Release \
 -D BUILD_REPLAY_LOADERS=TRUE \
 -D CMAKE_BUILD_PO=FALSE \

--- a/.github/workflows/scripts/linux/generate-cmake.sh
+++ b/.github/workflows/scripts/linux/generate-cmake.sh
@@ -18,6 +18,7 @@ echo "Additional CMake Args - ${ADDITIONAL_CMAKE_ARGS}"
 # Generate CMake into ./build
 cmake \
 -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+-D DISABLE_ADVANCE_SIMD=TRUE \
 -D CMAKE_BUILD_TYPE=Release \
 -D BUILD_REPLAY_LOADERS=TRUE \
 -D CMAKE_BUILD_PO=FALSE \

--- a/.github/workflows/scripts/linux/generate-cmake.sh
+++ b/.github/workflows/scripts/linux/generate-cmake.sh
@@ -9,9 +9,9 @@ else
   export CC=clang
   export CXX=clang++
 fi
-ADDITIONAL_CMAKE_ARGS=""
+
 if [ "${PLATFORM}" = "x86" ]; then
-  ADDITIONAL_CMAKE_ARGS="-D CMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake"
+  ADDITIONAL_CMAKE_ARGS="$ADDITIONAL_CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake"
 fi
 echo "Additional CMake Args - ${ADDITIONAL_CMAKE_ARGS}"
 

--- a/common/include/Utilities/SafeArray.h
+++ b/common/include/Utilities/SafeArray.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "Utilities/Dependencies.h"
+
 // pxUSE_SECURE_MALLOC - enables bounds checking on scoped malloc allocations.
 
 #ifndef pxUSE_SECURE_MALLOC

--- a/common/include/Utilities/pxEvents.h
+++ b/common/include/Utilities/pxEvents.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <wx/event.h>
+
 wxDECLARE_EVENT(pxEvt_StartIdleEventTimer, wxCommandEvent);
 wxDECLARE_EVENT(pxEvt_DeleteObject, wxCommandEvent);
 wxDECLARE_EVENT(pxEvt_DeleteThread, wxCommandEvent);

--- a/common/include/x86emitter/tools.h
+++ b/common/include/x86emitter/tools.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "Utilities/Dependencies.h"
+
 enum x86VendorType {
     x86Vendor_Intel = 0,
     x86Vendor_AMD = 1,

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -17,6 +17,10 @@
 
 #include "x86emitter/tools.h"
 
+#include "Utilities/FixedPointTypes.h"
+#include "Utilities/General.h"
+#include <wx/filename.h>
+
 class IniInterface;
 
 enum PluginsEnum_t

--- a/pcsx2/PathDefs.h
+++ b/pcsx2/PathDefs.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "Utilities/Path.h"
+
 enum FoldersEnum_t
 {
 	// FIXME : Plugins and Settings folders are no longer part of the user-local

--- a/pcsx2/Plugins.h
+++ b/pcsx2/Plugins.h
@@ -18,9 +18,11 @@
 #define PLUGINtypedefs
 #define PLUGINfuncs
 
+#include "Config.h"
 #include "PS2Edefs.h"
 #include "PluginCallbacks.h"
 
+#include <Utilities/MemcpyFast.h>
 #include "Utilities/Threading.h"
 
 #include <wx/dynlib.h>

--- a/pcsx2/USB/configuration.h
+++ b/pcsx2/USB/configuration.h
@@ -15,11 +15,12 @@
 
 #pragma once
 
+#include "platcompat.h"
+#include <wx/string.h>
 #include <vector>
 #include <string>
 #include <map>
 #include <sstream>
-#include "platcompat.h"
 
 #define RESULT_CANCELED 0
 #define RESULT_OK 1

--- a/pcsx2/USB/linux/config.cpp
+++ b/pcsx2/USB/linux/config.cpp
@@ -13,12 +13,13 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
+
 #include "../configuration.h"
 #include "../deviceproxy.h"
 #include "../usb-pad/padproxy.h"
 #include "../usb-mic/audiodeviceproxy.h"
-
-#include "config.h"
+#include "Utilities/Console.h"
 
 void SysMessage_stderr(const char* fmt, ...)
 {

--- a/pcsx2/USB/usb-eyetoy/cam-linux.cpp
+++ b/pcsx2/USB/usb-eyetoy/cam-linux.cpp
@@ -13,6 +13,13 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "cam-linux.h"
+#include "usb-eyetoy-webcam.h"
+#include "jpgd/jpgd.h"
+#include "jo_mpeg.h"
+#include "../gtk.h"
+#include "Utilities/Console.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -27,13 +34,6 @@
 #include <unistd.h>
 
 #include <linux/videodev2.h>
-
-#include "../gtk.h"
-
-#include "cam-linux.h"
-#include "usb-eyetoy-webcam.h"
-#include "jpgd/jpgd.h"
-#include "jo_mpeg.h"
 
 GtkWidget* new_combobox(const char* label, GtkWidget* vbox); // src/linux/config-gtk.cpp
 

--- a/pcsx2/USB/usb-hid/evdev/evdev.h
+++ b/pcsx2/USB/usb-hid/evdev/evdev.h
@@ -14,13 +14,14 @@
  */
 
 #pragma once
+#include "../usb-hid.h"
 #include "../../linux/util.h"
+#include "Utilities/Console.h"
 #include <linux/input.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <thread>
 #include <atomic>
-#include "../usb-hid.h"
 
 namespace usb_hid
 {

--- a/pcsx2/USB/usb-msd/usb-msd-gtk.cpp
+++ b/pcsx2/USB/usb-msd/usb-msd-gtk.cpp
@@ -17,6 +17,7 @@
 #include "../linux/ini.h"
 #include "../configuration.h"
 #include "../gtk.h"
+#include "Utilities/Console.h"
 
 namespace usb_msd
 {

--- a/pcsx2/USB/usb-pad/evdev/evdev.h
+++ b/pcsx2/USB/usb-pad/evdev/evdev.h
@@ -14,14 +14,15 @@
  */
 
 #pragma once
+#include "evdev-ff.h"
+#include "shared.h"
 #include "../../linux/util.h"
+#include "../../readerwriterqueue/readerwriterqueue.h"
+#include "Utilities/Console.h"
 //#include <dirent.h> //gtk.h pulls in?
 #include <thread>
 #include <array>
 #include <atomic>
-#include "evdev-ff.h"
-#include "shared.h"
-#include "../../readerwriterqueue/readerwriterqueue.h"
 
 namespace usb_pad
 {

--- a/pcsx2/USB/usb-pad/joydev/joydev.cpp
+++ b/pcsx2/USB/usb-pad/joydev/joydev.cpp
@@ -14,9 +14,10 @@
  */
 
 #include "joydev.h"
+#include "../../linux/util.h"
+#include "Utilities/Console.h"
 #include <cassert>
 #include <sstream>
-#include "../../linux/util.h"
 
 namespace usb_pad
 {

--- a/pcsx2/USB/usb-pad/joydev/joydev.h
+++ b/pcsx2/USB/usb-pad/joydev/joydev.h
@@ -17,6 +17,7 @@
 #include "../../linux/util.h"
 #include "../evdev/evdev-ff.h"
 #include "../evdev/shared.h"
+#include "Utilities/Console.h"
 
 namespace usb_pad
 {

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -16,8 +16,14 @@
 #pragma once
 
 #include "AppForwardDefs.h"
+#include "Config.h"
 #include "PathDefs.h"
 #include "CDVD/CDVDaccess.h"
+#include "Utilities/General.h"
+#include "Utilities/Path.h"
+
+#include <wx/colour.h>
+#include <wx/gdicmn.h>
 #include <memory>
 
 enum DocsModeType

--- a/pcsx2/gui/pxEventThread.h
+++ b/pcsx2/gui/pxEventThread.h
@@ -17,6 +17,8 @@
 
 #include "Utilities/PersistentThread.h"
 #include "Utilities/pxEvents.h"
+
+#include <wx/timer.h>
 #include <memory>
 
 // TODO!!  Make the system defined in this header system a bit more generic, and then move

--- a/plugins/GSdx/GSVector4i.h
+++ b/plugins/GSdx/GSVector4i.h
@@ -777,10 +777,11 @@ public:
 
 		#else
 
+		// The `& 0xF` keeps the compiler happy on cases that won't actually be hit
 		if(i == 0) return *this;
-		else if(i < 16) return srl<i>() | v.sll<16 - i>();
+		else if(i < 16) return srl<i & 0xF>() | v.sll<(16 - i) & 0xF>();
 		else if(i == 16) return v;
-		else if(i < 32) return v.srl<i - 16>();
+		else if(i < 32) return v.srl<(i - 16) & 0xF>();
 		else return zero();
 
 		#endif


### PR DESCRIPTION
- Adds a no-pch build to GitHub Actions
- Switches GitHub Actions from a matrix to a main x86 gcc build plus each of the other options with only the one change (so there's an x86 clang build, x64 gcc build, but no x64 clang build or no-pch clang build)
- Makes GitHub Actions use ccache properly (important as the no-pch build takes like 20 minutes)
- Disables march=native for GitHub Actions builds (required for ccache)
- Fixes #3096 (build failure with Clang + SSE2)

Note: An alternative fix for clang SSE2 is to flex our C++17ness and use `if constexpr`.  Preferences?