### PR TITLE
DMA: Correctly emulate QWC 0 on NORMAL transfers

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -107,7 +107,6 @@
 Serial = GUST-00009
 Name   = Mana Khemia: Alchemists of Al-Revis [Premium Box]
 Region = NTSC-J
-DMABusyHack = 1
 eeRoundMode = 0 // Fixes jump issue.
 GIFFIFOHack = 1 // Fixes flickering sprites.
 ---------------------------------------------
@@ -20022,7 +20021,6 @@ Serial = SLES-55443
 Name   = Mana Khemia - Alchemists of Al-Revis
 Region = PAL-E
 Compat = 5
-DMABusyHack = 1
 eeRoundMode = 0 // Fixes jump issue.
 GIFFIFOHack = 1 // Fixes flickering sprites.
 ---------------------------------------------
@@ -45463,7 +45461,6 @@ Serial = SLUS-21735
 Name   = Mana Khemia - Alchemists of Al-Revis
 Region = NTSC-U
 Compat = 5
-DMABusyHack = 1
 eeRoundMode = 0 // Fixes jump issue.
 GIFFIFOHack = 1 // Fixes flickering sprites.
 ---------------------------------------------

--- a/pcsx2/Dmac.h
+++ b/pcsx2/Dmac.h
@@ -161,8 +161,7 @@ union tDMA_SADR {
 
 union tDMA_QWC {
 	struct {
-		u16 QWC;
-		u16 _unused;
+		u32 QWC;
 	};
 	u32 _u32;
 
@@ -178,7 +177,7 @@ struct DMACh {
 	u32 _null0[3];
 	u32 madr;
 	u32 _null1[3];
-	u16 qwc; u16 pad;
+	u32 qwc;
 	u32 _null2[3];
 	u32 tadr;
 	u32 _null3[3];

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -392,7 +392,7 @@ void GIFdma()
 			if (ptag == NULL) return;
 			//DevCon.Warning("GIF Reading Tag MSK = %x", vif1Regs.mskpath3);
 			GIF_LOG("gifdmaChain %8.8x_%8.8x size=%d, id=%d, addr=%lx tadr=%lx", ptag[1]._u32, ptag[0]._u32, gifch.qwc, ptag->ID, gifch.madr, gifch.tadr);
-			if (!CHECK_GIFFIFOHACK)gifRegs.stat.FQC = std::min((u16)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
+			if (!CHECK_GIFFIFOHACK)gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
 			if (dmacRegs.ctrl.STD == STD_GIF)
 			{
 				// there are still bugs, need to also check if gifch.madr +16*qwc >= stadr, if not, stall
@@ -420,7 +420,7 @@ void GIFdma()
 
 
 		if (!CHECK_GIFFIFOHACK) {
-			gifRegs.stat.FQC = std::min((u16)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
+			gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
 			clearFIFOstuff(true);
 		}
 
@@ -470,7 +470,7 @@ void dmaGIF()
 	gifInterrupt();
 }
 
-static u16 QWCinGIFMFIFO(u32 DrainADDR)
+static u32 QWCinGIFMFIFO(u32 DrainADDR)
 {
 	u32 ret;
 
@@ -495,7 +495,7 @@ static u16 QWCinGIFMFIFO(u32 DrainADDR)
 
 static __fi bool mfifoGIFrbTransfer()
 {
-	u16 qwc = std::min(QWCinGIFMFIFO(gifch.madr), gifch.qwc);
+	u32 qwc = std::min(QWCinGIFMFIFO(gifch.madr), gifch.qwc);
 	if (qwc == 0) {
 		DevCon.Warning("GIF FIFO EMPTY before transfer (how?)");
 	}

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -170,7 +170,7 @@ __fi void vif0Interrupt()
 
 	g_vif0Cycles = 0;
 
-	vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u16)8);
+	vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u32)8);
 
 	if (!(vif0ch.chcr.STR)) Console.WriteLn("vif0 running when CHCR == %x", vif0ch.chcr._u32);
 
@@ -199,7 +199,7 @@ __fi void vif0Interrupt()
 
 			// One game doesn't like vif stalling at end, can't remember what. Spiderman isn't keen on it tho
 			//vif0ch.chcr.STR = false;
-			vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
+			vif0Regs.stat.FQC = std::min((u32)0x8, vif0ch.qwc);
 			if (vif0ch.qwc > 0 || !vif0.done)
 			{
 				vif0Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
@@ -224,7 +224,7 @@ __fi void vif0Interrupt()
 	if (vif0.inprogress & 0x1)
 	{
 		_VIF0chain();
-		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u16)8);
+		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u32)8);
 		CPU_INT(DMAC_VIF0, g_vif0Cycles);
 		return;
 	}
@@ -239,7 +239,7 @@ __fi void vif0Interrupt()
 		}
 
 		if ((vif0.inprogress & 0x1) == 0) vif0SetupTransfer();
-		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u16)8);
+		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u32)8);
 		CPU_INT(DMAC_VIF0, g_vif0Cycles);
 		return;
 	}
@@ -256,7 +256,7 @@ __fi void vif0Interrupt()
 #endif
 
 	vif0ch.chcr.STR = false;
-	vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
+	vif0Regs.stat.FQC = std::min((u32)0x8, vif0ch.qwc);
 	vif0.vifstalled.enabled = false;
 	vif0.irqoffset.enabled = false;
 	if(vif0.queued_program) vifExecQueue(0);
@@ -307,7 +307,7 @@ void dmaVIF0()
 		vif0.inprogress &= ~0x1;
 	}
 
-	vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
+	vif0Regs.stat.FQC = std::min((u32)0x8, vif0ch.qwc);
 
 	//Using a delay as Beyond Good and Evil does the DMA twice with 2 different TADR's (no checks in the middle, all one block of code),
 	//the first bit it sends isnt required for it to work.

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -298,7 +298,7 @@ __fi void vif1Interrupt()
 		//Console.WriteLn("VIFMFIFO\n");
 		// Test changed because the Final Fantasy 12 opening somehow has the tag in *Undefined* mode, which is not in the documentation that I saw.
 		if (vif1ch.chcr.MOD == NORMAL_MODE) Console.WriteLn("MFIFO mode is normal (which isn't normal here)! %x", vif1ch.chcr._u32);
-		vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+		vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 		vifMFIFOInterrupt();
 		return;
 	}
@@ -316,7 +316,7 @@ __fi void vif1Interrupt()
 			return;
 		}
 		vif1Regs.stat.VGW = 0; //Path 3 isn't busy so we don't need to wait for it.
-		vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+		vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 		//Simulated GS transfer time done, clear the flags
 	}
 	
@@ -348,7 +348,7 @@ __fi void vif1Interrupt()
 
 			//NFSHPS stalls when the whole packet has gone across (it stalls in the last 32bit cmd)
 			//In this case VIF will end
-			vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+			vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 			if((vif1ch.qwc > 0 || !vif1.done) && !CHECK_VIF1STALLHACK)	
 			{
 				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
@@ -375,7 +375,7 @@ __fi void vif1Interrupt()
             _VIF1chain();
             // VIF_NORMAL_FROM_MEM_MODE is a very slow operation.
             // Timesplitters 2 depends on this beeing a bit higher than 128.
-            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 		
 			if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
 				CPU_INT(DMAC_VIF1, g_vif1Cycles);
@@ -392,7 +392,7 @@ __fi void vif1Interrupt()
             }
 
             if ((vif1.inprogress & 0x1) == 0) vif1SetupTransfer();
-            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 
 			if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
 	            CPU_INT(DMAC_VIF1, g_vif1Cycles);
@@ -416,7 +416,7 @@ __fi void vif1Interrupt()
 		gifRegs.stat.OPH = false;
 	}
 
-	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 
 	vif1ch.chcr.STR = false;
 	vif1.vifstalled.enabled = false;
@@ -479,7 +479,7 @@ void dmaVIF1()
 		
 	}
 
-	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 
 	// Chain Mode
 	CPU_INT(DMAC_VIF1, 4);

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -24,7 +24,7 @@ static u32 qwctag(u32 mask)
 	return (dmacRegs.rbor.ADDR + (mask & dmacRegs.rbsr.RMSK));
 }
 
-static u16 QWCinVIFMFIFO(u32 DrainADDR, u16 qwc)
+static u32 QWCinVIFMFIFO(u32 DrainADDR, u32 qwc)
 {
 	u32 ret;
 	
@@ -49,7 +49,7 @@ static u16 QWCinVIFMFIFO(u32 DrainADDR, u16 qwc)
 static __fi bool mfifoVIF1rbTransfer()
 {
 	u32 msize = dmacRegs.rbor.ADDR + dmacRegs.rbsr.RMSK + 16;
-	u16 mfifoqwc = std::min(QWCinVIFMFIFO(vif1ch.madr, vif1ch.qwc), vif1ch.qwc);
+	u32 mfifoqwc = std::min(QWCinVIFMFIFO(vif1ch.madr, vif1ch.qwc), vif1ch.qwc);
 	u32 *src;
 	bool ret;
 	
@@ -318,7 +318,7 @@ void vifMFIFOInterrupt()
 		if (vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS)) {
 			//vif1Regs.stat.FQC = 0; // FQC=0
 			//vif1ch.chcr.STR = false;
-			vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+			vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 			VIF_LOG("VIF1 MFIFO Stalled qwc = %x done = %x inprogress = %x", vif1ch.qwc, vif1.done, vif1.inprogress & 0x10);
 			//Used to check if the MFIFO was empty, there's really no need if it's finished what it needed.
 			if((vif1ch.qwc > 0 || !vif1.done)) {
@@ -347,7 +347,7 @@ void vifMFIFOInterrupt()
 		switch(vif1.inprogress & 1) {
 			case 0: //Set up transfer
 				mfifoVIF1transfer();
-				vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+				vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 				[[fallthrough]];
 
 			case 1: //Transfer data
@@ -357,7 +357,7 @@ void vifMFIFOInterrupt()
 				if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
 					CPU_INT(DMAC_MFIFO_VIF, (g_vif1Cycles == 0 ? 4 : g_vif1Cycles) );	
 
-				vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+				vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 				return;
 		}
 		return;
@@ -372,7 +372,7 @@ void vifMFIFOInterrupt()
 	}
 
 	g_vif1Cycles = 0;
-	vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+	vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 	vif1ch.chcr.STR = false;
 	hwDmacIrq(DMAC_VIF1);
 	DMA_LOG("VIF1 MFIFO DMA End");

--- a/pcsx2/ps2/LegacyDmac.cpp
+++ b/pcsx2/ps2/LegacyDmac.cpp
@@ -278,6 +278,12 @@ static __ri void DmaExec( void (*func)(), u32 mem, u32 value )
 		}
 		reg.chcr.MOD = 0x1;
 	}
+
+	// As tested on hardware, if NORMAL mode is started with 0 QWC it will actually transfer 1 QWC then underflows and transfer another 0xFFFF QWC's
+	// The easiest way to handle this is to just say 0x10000 QWC
+	if (reg.chcr.STR && !reg.chcr.MOD && reg.qwc == 0)
+		reg.qwc = 0x10000;
+
 	if (reg.chcr.STR && dmacRegs.ctrl.DMAE && !psHu8(DMAC_ENABLER+2))
 	{
 		func();
@@ -318,10 +324,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D0_QWC) // dma0 - vif0
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D1_CHCR) // dma1 - vif1 - chcr
 		{
 			DMA_LOG("VIF1dma EXECUTE, value=0x%x", value);
 			DmaExec(dmaVIF1, mem, value);
+			return false;
+		}
+
+		icase(D1_QWC) // dma1 - vif1
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -332,10 +350,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D2_QWC) // dma2 - gif
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D3_CHCR) // dma3 - fromIPU
 		{
 			DMA_LOG("IPU0dma EXECUTE, value=0x%x\n", value);
 			DmaExec(dmaIPU0, mem, value);
+			return false;
+		}
+
+		icase(D3_QWC) // dma3 - fromIPU
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -346,10 +376,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D4_QWC) // dma4 - toIPU
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D5_CHCR) // dma5 - sif0
 		{
 			DMA_LOG("SIF0dma EXECUTE, value=0x%x", value);
 			DmaExec(dmaSIF0, mem, value);
+			return false;
+		}
+
+		icase(D5_QWC) // dma5 - sif0
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -360,6 +402,12 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D6_QWC) // dma6 - sif1
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D7_CHCR) // dma7 - sif2
 		{
 			DMA_LOG("SIF2dma EXECUTE, value=0x%x", value);
@@ -367,10 +415,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D7_QWC) // dma7 - sif2
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D8_CHCR) // dma8 - fromSPR
 		{
 			DMA_LOG("SPR0dma EXECUTE (fromSPR), value=0x%x", value);
 			DmaExec(dmaSPR0, mem, value);
+			return false;
+		}
+
+		icase(D8_QWC) // dma8 - fromSPR
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -406,6 +466,12 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 		{
 			DMA_LOG("SPR1dma EXECUTE (toSPR), value=0x%x", value);
 			DmaExec(dmaSPR1, mem, value);
+			return false;
+		}
+
+		icase(D9_QWC) // dma9 - toSPR
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 


### PR DESCRIPTION
This removes 2 hacks on the IPU for Enter the Matrix and Mana Khemia

On the PS2 is a NORMAL DMA transfer is started with QWC 0, the DMA overflows and transfers another 0xFFFF quadwords on top of the underflowed one, this correctly emulates that.

I did have to do a "kind of" hack to make Mana Khemia work properly, the game relies on the IPU to take some time to decode macroblocks, but we handle them instantly, so I had to place an artifical delay on starting the DMA to let it catch up and do what it needs to do. It shouldn't have any negative impacts.