### PR TITLE
MFIFO: Maintain VIF DMA status and Empty condition on VIF reset

### DIFF
--- a/pcsx2/FiFo.cpp
+++ b/pcsx2/FiFo.cpp
@@ -105,8 +105,6 @@ void __fastcall WriteFIFO_VIF1(const mem128_t *value)
 		DevCon.Warning("Offset on VIF1 FIFO start!");
 	}
 
-	vif1ch.qwc += 1;
-
 	bool ret = VIF1transfer((u32*)value, 4);
 
 	if (vif1.cmd) {

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -158,28 +158,21 @@ __fi void vif1FBRST(u32 value) {
 		SaveCol._u64[1] = vif1.MaskCol._u64[1];
 		SaveRow._u64[0] = vif1.MaskRow._u64[0];
 		SaveRow._u64[1] = vif1.MaskRow._u64[1];
+		u8 mfifo_empty = vif1.inprogress & 0x10;
 		memzero(vif1);
 		vif1.MaskCol._u64[0] = SaveCol._u64[0];
 		vif1.MaskCol._u64[1] = SaveCol._u64[1];
 		vif1.MaskRow._u64[0] = SaveRow._u64[0];
 		vif1.MaskRow._u64[1] = SaveRow._u64[1];
-		cpuRegs.interrupt &= ~((1 << 1) | (1 << 10)); //Stop all vif1 DMA's
-		///vif1ch.qwc -= std::min((int)vif1ch.qwc, 16); //not sure if the dma should stop, FFWDing could be tricky
-		vif1ch.qwc = 0;
 
-		psHu64(VIF1_FIFO) = 0;
-		psHu64(VIF1_FIFO + 8) = 0;
-		vif1.done = true;
-		vif1ch.chcr.STR = false;
 
 		GUNIT_WARN(Color_Red, "VIF FBRST Reset MSK = %x", vif1Regs.mskpath3);
 		vif1Regs.mskpath3 = false;
 		gifRegs.stat.M3P  = 0;
 		vif1Regs.err.reset();
-		vif1.inprogress = 0;
+		vif1.inprogress = mfifo_empty;
 		vif1.cmd = 0;
 		vif1.vifstalled.enabled = false;
-		vif1.irqoffset.enabled = false;
 		vif1Regs.stat._u32 = 0;
 	}
 

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -436,6 +436,7 @@ void dmaVIF1()
 	        vif1ch.tadr, vif1ch.asr0, vif1ch.asr1);
 
 	g_vif1Cycles = 0;
+	vif1.inprogress = 0;
 
 	if (vif1ch.qwc > 0)   // Normal Mode
 	{

--- a/pcsx2/Vif_Transfer.cpp
+++ b/pcsx2/Vif_Transfer.cpp
@@ -90,6 +90,7 @@ _vifT static __fi bool vifTransfer(u32 *data, int size, bool TTE) {
 	if (!TTE) // *WARNING* - Tags CAN have interrupts! so lets just ignore the dma modifying stuffs (GT4)
 	{
 		transferred  = transferred >> 2;
+		transferred = std::min((int)vifXch.qwc, transferred);
 		vifXch.madr +=(transferred << 4);
 		vifXch.qwc  -= transferred;
 


### PR DESCRIPTION
Also don't decrement/change VIF1 QWC on VIF1 FIFO write

This involves removing an old VIF reset hack which was put in for Donald Duck Quack Attack, but doesn't seem to be needed anymore (game uses T-Bit on VU which has been fixed since this hack was placed in and could likely have been the problem)

Fixes #3954