### PR TITLE
SPU2: Delay DMA Reads to prevent overrun

### DIFF
--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -437,6 +437,9 @@ struct V_Core
 
 	// old dma only
 	u16* DMAPtr;
+	u16* DMARPtr; // Mem pointer for DMA Reads
+	u32 ReadSize;
+	bool IsDMARead;
 	u32 MADR;
 	u32 TADR;
 
@@ -525,6 +528,7 @@ struct V_Core
 	// old dma only
 	void DoDMAwrite(u16* pMem, u32 size);
 	void DoDMAread(u16* pMem, u32 size);
+	void FinishDMAread();
 
 	void AutoDMAReadBuffer(int mode);
 	void StartADMAWrite(u16* pMem, u32 sz);

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -427,6 +427,9 @@ __forceinline void TimeUpdate(u32 cClocks)
 			Cores[0].DMAICounter -= TickInterval;
 			if (Cores[0].DMAICounter <= 0)
 			{
+				if (Cores[0].IsDMARead)
+					Cores[0].FinishDMAread();
+
 				//ConLog("counter set and callback!\n");
 				Cores[0].MADR = Cores[0].TADR;
 				Cores[0].DMAICounter = 0;
@@ -447,6 +450,9 @@ __forceinline void TimeUpdate(u32 cClocks)
 			Cores[1].DMAICounter -= TickInterval;
 			if (Cores[1].DMAICounter <= 0)
 			{
+				if (Cores[1].IsDMARead)
+					Cores[1].FinishDMAread();
+
 				Cores[1].MADR = Cores[1].TADR;
 				Cores[1].DMAICounter = 0;
 				//ConLog( "* SPU2 > DMA 7 Callback!  %d\n", Cycles );

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A10 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A11 << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
Fixes The Simpsons, the game does a DMA read of the Core 0 output in memory, but because the DMA is instant it overruns the core updating memory, so we will delay the DMA read until the estimated time has passed.

Fixes #3937