### PR TITLE
SPU2: Change VolumeSteps from 42 to 5

### DIFF
--- a/pcsx2/SPU2/Windows/Config.cpp
+++ b/pcsx2/SPU2/Windows/Config.cpp
@@ -268,7 +268,7 @@ BOOL CALLBACK ConfigProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			SetWindowText(GetDlgItem(hWnd, IDC_LATENCY_LABEL), temp);
 
 			int configvol = (int)(FinalVolume * 100 + 0.5f);
-			INIT_SLIDER(IDC_VOLUME_SLIDER, 0, 100, 10, 42, 1);
+			INIT_SLIDER(IDC_VOLUME_SLIDER, 0, 100, 10, 5, 1);
 
 			SendDialogMsg(hWnd, IDC_VOLUME_SLIDER, TBM_SETPOS, TRUE, configvol);
 			swprintf_s(temp, L"%d%%", configvol);


### PR DESCRIPTION
This will change the jumps from 42 to 5, scroll wheel will still be 2 and all the arrows keys on 1. If you click and hold and  then move just outside of the slider you now get nice jumps of multitudes of 5. It will affect the value for pagesize which is the number of steps the slider moves when the user pages up or down. Taking a part from #3787