### PR TITLE
IPU: Stop IPU0 looping when there's no data for it to read

### DIFF
--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -125,7 +125,8 @@ int IPU_Fifo_Output::write(const u32 *value, uint size)
 			--transsize;
 		}
 	/*} while(true);*/
-
+	if(ipu0ch.chcr.STR)
+		IPU_INT_FROM(64);
 	return origsize - size;
 }
 

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -196,7 +196,6 @@ void IPU0dma()
 {
 	if(!ipuRegs.ctrl.OFC) 
 	{
-		IPU_INT_FROM( 64 );
 		IPUProcessInterrupt();
 		return;
 	}


### PR DESCRIPTION
Fixes bad slowdowns in Ratchet games when using EE Timing fix caused by bad IPU streams