### PR TITLE
mVU: Keep start PC, modify prog search to avoid recompilation + MTVU bug

### DIFF
--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -113,6 +113,7 @@ void VU_Thread::ExecuteRingBuffer()
 					vifRegs.itop = Read();
 
 					if (addr != -1) vuRegs.VI[REG_TPC].UL = addr;
+					vuCPU->SetStartPC(vuRegs.VI[REG_TPC].UL << 3);
 					vuCPU->Execute(vu1RunCycles);
 					gifUnit.gifPath[GIF_PATH_1].FinishGSPacketMTVU();
 					semaXGkick.Post(); // Tell MTGS a path1 packet is complete

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A11 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A12 << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -134,6 +134,7 @@ struct __aligned16 VURegs {
 	// Current opcode being interpreted or recompiled (this var is used by Interps
 	// but not microVU.  Would like to have it local to their respective classes... someday)
 	u32 code;
+	u32 start_pc;
 
 	// branch/branchpc are used by interpreter only, but making them local to the interpreter
 	// classes requires considerable code refactoring.  Maybe later. >_<

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -48,6 +48,8 @@ void __fastcall vu0ExecMicro(u32 addr) {
 	VU0.VI[REG_VPU_STAT].UL |=  0x01;
 	VU0.cycle = cpuRegs.cycle;
 	if ((s32)addr != -1) VU0.VI[REG_TPC].UL = addr;
+
+	CpuVU0->SetStartPC(VU0.VI[REG_TPC].UL << 3);
 	_vuExecMicroDebug(VU0);
 	CpuVU0->ExecuteBlock(1);
 }

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -198,6 +198,11 @@ InterpVU0::InterpVU0()
 	IsInterpreter = true;
 }
 
+void InterpVU0::SetStartPC(u32 startPC)
+{
+	VU0.start_pc = startPC;
+}
+
 void InterpVU0::Step()
 {
 	vu0Exec( &VU0 );

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -61,7 +61,8 @@ void __fastcall vu1ExecMicro(u32 addr)
 	VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
 	VU0.VI[REG_VPU_STAT].UL |=  0x0100;
 	if ((s32)addr != -1) VU1.VI[REG_TPC].UL = addr;
-	_vuExecMicroDebug(VU1);
 
+	CpuVU1->SetStartPC(VU1.VI[REG_TPC].UL << 3);
+	_vuExecMicroDebug(VU1);
 	CpuVU1->Execute(vu1RunCycles);
 }

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -202,6 +202,11 @@ void InterpVU1::Shutdown() noexcept {
 	vu1Thread.WaitVU();
 }
 
+void InterpVU1::SetStartPC(u32 startPC)
+{
+	VU1.start_pc = startPC;
+}
+
 void InterpVU1::Step()
 {
 	VU1.VI[REG_TPC].UL &= VU1_PROGMASK;

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -85,6 +85,7 @@ public:
 	virtual void Reserve()=0;
 	virtual void Shutdown()=0;
 	virtual void Reset()=0;
+	virtual void SetStartPC(u32 startPC)=0;
 	virtual void Execute(u32 cycles)=0;
 	virtual void ExecuteBlock(bool startUp)=0;
 
@@ -172,6 +173,7 @@ public:
 	void Reset() { }
 
 	void Step();
+	void SetStartPC(u32 startPC);
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size) {}
 
@@ -192,6 +194,7 @@ public:
 	void Shutdown() noexcept;
 	void Reset();
 
+	void SetStartPC(u32 startPC);
 	void Step();
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size) {}
@@ -217,6 +220,7 @@ public:
 	void Shutdown() noexcept;
 
 	void Reset();
+	void SetStartPC(u32 startPC);
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size);
 	void Vsync() noexcept;
@@ -237,6 +241,7 @@ public:
 	void Reserve();
 	void Shutdown() noexcept;
 	void Reset();
+	void SetStartPC(u32 startPC);
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size);
 	void Vsync() noexcept;

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -267,6 +267,7 @@ static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
 
 	if (idx && THREAD_VU1) {
 		vu1Thread.WriteMicroMem(addr, (u8*)data, size*4);
+		vifX.tag.addr = size * 4;
 		return;
 	}
 

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -118,19 +118,19 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 
 void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 
-	int fStatus = getLastFlagInst(mVUpBlock->pState, mFC->xStatus, 0, isEbit);
-	int fMac	= getLastFlagInst(mVUpBlock->pState, mFC->xMac,    1, isEbit);
-	int fClip	= getLastFlagInst(mVUpBlock->pState, mFC->xClip,   2, isEbit);
+	int fStatus = getLastFlagInst(mVUpBlock->pState, mFC->xStatus, 0, isEbit && isEbit != 3);
+	int fMac	= getLastFlagInst(mVUpBlock->pState, mFC->xMac,    1, isEbit && isEbit != 3);
+	int fClip	= getLastFlagInst(mVUpBlock->pState, mFC->xClip,   2, isEbit && isEbit != 3);
 	int qInst	= 0;
 	int pInst	= 0;
 	microBlock stateBackup;
 	memcpy(&stateBackup, &mVUregs, sizeof(mVUregs)); //backup the state, it's about to get screwed with.
-	if(!isEbit)
+	if(!isEbit || isEbit == 3)
 		mVU.regAlloc->TDwritebackAll(); //Writing back ok, invalidating early kills the rec, so don't do it :P
 	else
 		mVU.regAlloc->flushAll();
 
-	if (isEbit) {
+	if (isEbit && isEbit != 3) {
 		memzero(mVUinfo);
 		memzero(mVUregsTemp);
 		mVUincCycles(mVU, 100); // Ensures Valid P/Q instances (And sets all cycle data to 0)
@@ -178,7 +178,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	xMOV(ptr32[&mVU.regs().VI[REG_MAC_FLAG].UL],	gprT1);
 	xMOV(ptr32[&mVU.regs().VI[REG_CLIP_FLAG].UL],	gprT2);
 
-	if (!isEbit) { // Backup flag instances
+	if (!isEbit || isEbit == 3) { // Backup flag instances
 		xMOVAPS(xmmT1, ptr128[mVU.macFlag]);
 		xMOVAPS(ptr128[&mVU.regs().micro_macflags], xmmT1);
 		xMOVAPS(xmmT1, ptr128[mVU.clipFlag]);
@@ -204,14 +204,14 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	}
 
 
-	if (isEbit || isVU1) { // Clear 'is busy' Flags
+	if ((isEbit && isEbit != 3) || isVU1) { // Clear 'is busy' Flags
 		if (!mVU.index || !THREAD_VU1) {
 			xAND(ptr32[&VU0.VI[REG_VPU_STAT].UL], (isVU1 ? ~0x100 : ~0x001)); // VBS0/VBS1 flag
 			//xAND(ptr32[&mVU.getVifRegs().stat], ~VIF1_STAT_VEW); // Clear VU 'is busy' signal for vif
 		}
 	}
 
-	if (isEbit != 2) { // Save PC, and Jump to Exit Point
+	if (isEbit != 2 && isEbit != 3) { // Save PC, and Jump to Exit Point
 		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
 		xJMP(mVU.exitFunct);
 	}
@@ -292,6 +292,21 @@ void normBranch(mV, microFlagCycles& mFC) {
 		mVUDTendProgram(mVU, &mFC, 1);
 		eJMP.SetTarget();
 		iPC = tempPC;	
+	}
+	if (mVUup.mBit)
+	{
+		DevCon.Warning("M-Bit on normal branch, report if broken");
+		u32 tempPC = iPC;
+		u32* cpS = (u32*)&mVUregs;
+		u32* lpS = (u32*)&mVU.prog.lpState;
+		for (size_t i = 0; i < (sizeof(microRegInfo) - 4) / 4; i++, lpS++, cpS++) {
+			xMOV(ptr32[lpS], cpS[0]);
+		}
+		mVUendProgram(mVU, &mFC, 3);
+		iPC = branchAddr(mVU) / 4;
+		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
+		xJMP(mVU.exitFunct);
+		iPC = tempPC;
 	}
 	if (mVUup.eBit) { 
 		if(mVUlow.badBranch) 
@@ -408,7 +423,27 @@ void condBranch(mV, microFlagCycles& mFC, int JMPcc) {
 		eJMP.SetTarget();
 		iPC = tempPC;
 	}
-
+	if (mVUup.mBit)
+	{
+		u32 tempPC = iPC;
+		u32* cpS = (u32*)&mVUregs;
+		u32* lpS = (u32*)&mVU.prog.lpState;
+		for (size_t i = 0; i < (sizeof(microRegInfo) - 4) / 4; i++, lpS++, cpS++) {
+			xMOV(ptr32[lpS], cpS[0]);
+		}
+		mVUendProgram(mVU, &mFC, 3);
+		xCMP(ptr16[&mVU.branch], 0);
+		xForwardJump32 dJMP((JccComparisonType)JMPcc);
+		incPC(4); // Set PC to First instruction of Non-Taken Side
+		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
+		xJMP(mVU.exitFunct);
+		dJMP.SetTarget();
+		incPC(-4); // Go Back to Branch Opcode to get branchAddr
+		iPC = branchAddr(mVU) / 4;
+		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
+		xJMP(mVU.exitFunct);
+		iPC = tempPC;
+	}
 	if (mVUup.eBit) { // Conditional Branch With E-Bit Set
 		if(mVUlow.evilBranch) 
 			DevCon.Warning("End on evil branch! - Not implemented! - If game broken report to PCSX2 Team");
@@ -471,6 +506,10 @@ void condBranch(mV, microFlagCycles& mFC, int JMPcc) {
 }
 
 void normJump(mV, microFlagCycles& mFC) {
+	if (mVUup.mBit)
+	{
+		DevCon.Warning("M-Bit on Jump! Please report if broken");
+	}
 	if (mVUlow.constJump.isValid) { // Jump Address is Constant
 		if (mVUup.eBit) { // E-bit Jump
 			iPC = (mVUlow.constJump.regValue*2) & (mVU.progMemMask);

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -567,13 +567,18 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 		}
 
 		if ((curI & _Mbit_) && isVU0) {
-			incPC(-2);
-			if (!(curI & _Mbit_)) { //If the last instruction was also M-Bit we don't need to sync again
-				incPC(2);
-				mVUup.mBit = true;
+			if (xPC > 0)
+			{
+				incPC(-2);
+				if (!(curI & _Mbit_)) { //If the last instruction was also M-Bit we don't need to sync again
+					incPC(2);
+					mVUup.mBit = true;
+				}
+				else
+					incPC(2);
 			}
 			else
-				incPC(2);
+				mVUup.mBit = true;
 		}
 
 		if (curI & _Ibit_) {
@@ -677,6 +682,7 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 				mVUsetupRange(mVU, xPC, false);
 				incPC(2);
 				mVUendProgram(mVU, &mFC, 0);
+				normBranchCompile(mVU, xPC);
 				incPC(-2);
 				goto perf_and_return;
 			}
@@ -773,6 +779,7 @@ _mVUt void* __fastcall mVUcompileJIT(u32 startPC, uptr ptr) {
 	if (doJumpAsSameProgram) { // Treat jump as part of same microProgram
 		return mVUblockFetch(mVUx, startPC, ptr);
 	}
+	mVUx.regs().start_pc = startPC;
 	if (doJumpCaching) { // When doJumpCaching, ptr is a microBlock pointer
 		microVU& mVU = mVUx;
 		microBlock* pBlock = (microBlock*)ptr;

--- a/pcsx2/x86/microVU_Tables.inl
+++ b/pcsx2/x86/microVU_Tables.inl
@@ -211,7 +211,7 @@ mVUop(mVULowerOP_T3_11)	{ mVULowerOP_T3_11_OPCODE	[((mVU.code >> 6) & 0x1f)](mX)
 mVUop(mVUopU)			{ mVU_UPPER_OPCODE			[ (mVU.code & 0x3f) ](mX); } // Gets Upper Opcode
 mVUop(mVUopL)			{ mVULOWER_OPCODE			[ (mVU.code >>  25) ](mX); } // Gets Lower Opcode
 mVUop(mVUunknown) {
-	pass1 { mVUinfo.isBadOp = true; }
+	pass1 { if (mVU.code != 0x8000033c) mVUinfo.isBadOp = true; }
 	pass2 { if(mVU.code != 0x8000033c) Console.Error("microVU%d: Unknown Micro VU opcode called (%x) [%04x]\n", getIndex, mVU.code, xPC); }
 	pass3 { mVUlog("Unknown", mVU.code); }
 }


### PR DESCRIPTION
Also fix some M-Bit stuff to reduce programs created and fix them happening on branches.

Hopefully shouldn't be much in the way of compatibility changes, but should cut down the recompilation of MicroVU0 programs due to the change in how VU0 operates and how things are going to work going forward. MGS3 went down from 115 (and climbing) to around 13. Crash Twinsanity went down from 32 by the main menu to about 15.

This also sets up some future work of synchronising VU1

Savestate version bump due to new parameter

Also fixes a bug in VIF when using MTVU, fixes Def Jam Fight for NY when using MTVU, maybe others.