### PR TITLE
USB: Fix integer overflow on IOP memory range check

### DIFF
--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -621,7 +621,7 @@ void USBasync(u32 cycles)
 int cpu_physical_memory_rw(u32 addr, u8* buf, size_t len, int is_write)
 {
 	// invalid address, reset and try again
-	if (addr + len >= 0x200000)
+	if ((u64)addr + len >= 0x200000)
 	{
 		if (qemu_ohci)
 			ohci_soft_reset(qemu_ohci);


### PR DESCRIPTION
When the address is equal to the max value of a unsigned integer, this check will overflow leading to a false negative and crashes PCSX2 when we then try to read that address.

Cast addr to a 64bit integer to enforce a 64bit comparison.

This issue occurs when launching a game via OPL (tested OPL version was 1020)