### PR TITLE
GUI: Force Full Boot on first run of new version

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -468,7 +468,8 @@ struct Pcsx2Config
 			MultitapPort1_Enabled:1,
 
 			ConsoleToStdio		:1,
-			HostFs				:1;
+			HostFs				:1,
+			FullBootConfig		:1;
 	BITFIELD_END
 
 	CpuOptions			Cpu;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -439,6 +439,7 @@ void Pcsx2Config::LoadSave( IniInterface& ini )
 #endif
 	IniBitBool( ConsoleToStdio );
 	IniBitBool( HostFs );
+	IniBitBool( FullBootConfig );
 
 	IniBitBool( BackupSavestate );
 	IniBitBool( McdEnableEjection );

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -423,7 +423,19 @@ void MainEmuFrame::_DoBootCdvd()
 			return;
 		}
 	}
+	
+	if (!g_Conf->EmuOptions.FullBootConfig && g_Conf->EmuOptions.UseBOOT2Injection)
+	{
+		g_Conf->EmuOptions.UseBOOT2Injection = false;
+		g_Conf->EmuOptions.FullBootConfig = true;
 
+		wxString message;
+		message.Printf(_("For the first run of this version of the emulator, you will be forced to boot to your BIOS. You are required to configure the BIOS language before proceeding. Once this has been done you can Fast Boot normally."));
+		Msgbox::Alert(message, _("BIOS Configuration"));
+	}
+	else
+		g_Conf->EmuOptions.FullBootConfig = true;
+	
 	sApp.SysExecute(g_Conf->CdvdSource);
 }
 


### PR DESCRIPTION
This gets around users having crashes because they haven't configured the language in their BIOS


Expected behaviour: First time you run this version it will ask you to configure then force a full boot, next time (and subsequent times) it will fast boot as normal, including if you shut down the emulator.