### PR TITLE
Clang-Format: Align with spaces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,5 +86,5 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        4
-UseTab:          ForContinuationAndIndentation
+UseTab:          AlignWithSpaces
 ...

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -219,7 +219,7 @@ static void cdvdNVM(u8* buffer, int offset, size_t bytes, bool read)
 
 	if (ret != bytes)
 		Console.Error(L"Failed to %s %s. Did only %zu/%zu bytes",
-					  read ? L"read from" : L"write to", WX_STR(fname), ret, bytes);
+		              read ? L"read from" : L"write to", WX_STR(fname), ret, bytes);
 }
 
 static void cdvdReadNVM(u8* dst, int offset, int bytes)
@@ -544,7 +544,7 @@ void cdvdReadKey(u8, u16, u32 arg2, u8* key)
 	}
 
 	DevCon.WriteLn("CDVD.KEY = %02X,%02X,%02X,%02X,%02X,%02X,%02X",
-				   cdvd.Key[0], cdvd.Key[1], cdvd.Key[2], cdvd.Key[3], cdvd.Key[4], cdvd.Key[14], cdvd.Key[15]);
+	               cdvd.Key[0], cdvd.Key[1], cdvd.Key[2], cdvd.Key[3], cdvd.Key[4], cdvd.Key[14], cdvd.Key[15]);
 }
 
 s32 cdvdGetToc(void* toc)
@@ -911,7 +911,7 @@ __fi void cdvdReadInterrupt()
 		cdvd.Sector = cdvd.SeekToSector;
 
 		CDVD_LOG("Cdvd Seek Complete > Scheduling block read interrupt at iopcycle=%8.8x.",
-				 psxRegs.cycle + cdvd.ReadTime);
+		         psxRegs.cycle + cdvd.ReadTime);
 
 		CDVDREAD_INT(cdvd.ReadTime);
 		return;
@@ -1320,11 +1320,11 @@ static void cdvdWrite04(u8 rt)
 			}
 
 			CDVD_LOG("CdRead > startSector=%d, seekTo=%d, nSectors=%d, RetryCnt=%x, Speed=%x(%x), ReadMode=%x(%x) (1074=%x)",
-					 cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, cdvd.Param[9], cdvd.ReadMode, cdvd.Param[10], psxHu32(0x1074));
+			         cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, cdvd.Param[9], cdvd.ReadMode, cdvd.Param[10], psxHu32(0x1074));
 
 			if (EmuConfig.CdvdVerboseReads)
 				Console.WriteLn(Color_Gray, L"CdRead: Reading Sector %07d (%03d Blocks of Size %d) at Speed=%dx",
-								cdvd.SeekToSector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed);
+				                cdvd.SeekToSector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed);
 
 			cdvd.ReadTime = cdvdBlockReadTime(MODE_CDROM);
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, MODE_CDROM));
@@ -1339,7 +1339,7 @@ static void cdvdWrite04(u8 rt)
 			// this'll skip the seek delay.
 			cdvd.Reading = 1;
 			break;
-		
+
 		case N_DVD_READ: // DvdRead
 			// Assign the seek to sector based on cdvd.Param[0]-[3], and the number of  sectors based on cdvd.Param[4]-[7].
 			cdvd.SeekToSector = *(u32*)(cdvd.Param + 0);
@@ -1356,11 +1356,11 @@ static void cdvdWrite04(u8 rt)
 			cdvd.BlockSize = 2064; // Why oh why was it 2064
 
 			CDVD_LOG("DvdRead > startSector=%d, seekTo=%d nSectors=%d, RetryCnt=%x, Speed=%x(%x), ReadMode=%x(%x) (1074=%x)",
-					 cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, cdvd.Param[9], cdvd.ReadMode, cdvd.Param[10], psxHu32(0x1074));
+			         cdvd.Sector, cdvd.SeekToSector, cdvd.nSectors, cdvd.RetryCnt, cdvd.Speed, cdvd.Param[9], cdvd.ReadMode, cdvd.Param[10], psxHu32(0x1074));
 
 			if (EmuConfig.CdvdVerboseReads)
 				Console.WriteLn(Color_Gray, L"DvdRead: Reading Sector %07d (%03d Blocks of Size %d) at Speed=%dx",
-								cdvd.SeekToSector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed);
+				                cdvd.SeekToSector, cdvd.nSectors, cdvd.BlockSize, cdvd.Speed);
 
 			cdvd.ReadTime = cdvdBlockReadTime(MODE_DVDROM);
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, MODE_DVDROM));
@@ -2015,9 +2015,9 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 					}
 
 					Console.WriteLn("[MG] ELF_size=0x%X Hdr_size=0x%X unk=0x%X flags=0x%X count=%d zones=%s",
-									*(u32*)&cdvd.mg_buffer[0x10], *(u16*)&cdvd.mg_buffer[0x14], *(u16*)&cdvd.mg_buffer[0x16],
-									*(u16*)&cdvd.mg_buffer[0x18], *(u16*)&cdvd.mg_buffer[0x1A],
-									zoneStr.c_str());
+					                *(u32*)&cdvd.mg_buffer[0x10], *(u16*)&cdvd.mg_buffer[0x14], *(u16*)&cdvd.mg_buffer[0x16],
+					                *(u16*)&cdvd.mg_buffer[0x18], *(u16*)&cdvd.mg_buffer[0x1A],
+					                zoneStr.c_str());
 
 					bit_ofs = mg_BIToffset(cdvd.mg_buffer);
 
@@ -2034,7 +2034,7 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 					//memcpy(cdvd.mg_kcon, &cdvd.mg_buffer[bit_ofs-0x10], 0x10);
 
 					if ((cdvd.mg_buffer[bit_ofs + 5] || cdvd.mg_buffer[bit_ofs + 6] || cdvd.mg_buffer[bit_ofs + 7]) ||
-						(cdvd.mg_buffer[bit_ofs + 4] * 16 + bit_ofs + 8 + 16 != *(u16*)&cdvd.mg_buffer[0x14]))
+					    (cdvd.mg_buffer[bit_ofs + 4] * 16 + bit_ofs + 8 + 16 != *(u16*)&cdvd.mg_buffer[0x14]))
 					{
 						fail_pol_cal();
 						break;
@@ -2048,7 +2048,7 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				cdvd.mg_size = 0;
 				cdvd.mg_datatype = 1; //header data
 				Console.WriteLn("[MG] hcode=%d cnum=%d a2=%d length=0x%X",
-								cdvd.Param[0], cdvd.Param[3], cdvd.Param[4], cdvd.mg_maxsize = cdvd.Param[1] | (((int)cdvd.Param[2]) << 8));
+				                cdvd.Param[0], cdvd.Param[3], cdvd.Param[4], cdvd.mg_maxsize = cdvd.Param[1] | (((int)cdvd.Param[2]) << 8));
 
 				cdvd.Result[0] = 0; // 0 complete ; 1 busy ; 0x80 error
 				break;
@@ -2137,8 +2137,8 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 	catch (Exception::CannotCreateStream&)
 	{
 		Cpu->ThrowException(Exception::RuntimeError()
-								.SetDiagMsg(L"Failed to read/write NVM/MEC file.")
-								.SetUserMsg(pxE(L"Failed to read/write NVM/MEC file. Check your BIOS setup/permission settings.")));
+		                        .SetDiagMsg(L"Failed to read/write NVM/MEC file.")
+		                        .SetUserMsg(pxE(L"Failed to read/write NVM/MEC file. Check your BIOS setup/permission settings.")));
 	}
 }
 

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -368,8 +368,8 @@ bool DoCDVDopen()
 
 	auto CurrentSourceType = enum_cast(m_CurrentSourceType);
 	int ret = CDVD->open(!m_SourceFilename[CurrentSourceType].IsEmpty() ?
-							 static_cast<const char*>(m_SourceFilename[CurrentSourceType].ToUTF8()) :
-							 (char*)NULL);
+                             static_cast<const char*>(m_SourceFilename[CurrentSourceType].ToUTF8()) :
+                             (char*)NULL);
 
 	if (ret == -1)
 		return false; // error! (handled by caller)
@@ -401,8 +401,8 @@ bool DoCDVDopen()
 	wxDateTime curtime(wxDateTime::GetTimeNow());
 
 	temp += pxsFmt(L" (%04d-%02d-%02d %02d-%02d-%02d)",
-				   curtime.GetYear(), curtime.GetMonth(), curtime.GetDay(),
-				   curtime.GetHour(), curtime.GetMinute(), curtime.GetSecond());
+	               curtime.GetYear(), curtime.GetMonth(), curtime.GetDay(),
+	               curtime.GetHour(), curtime.GetMinute(), curtime.GetSecond());
 #endif
 	temp += L".dump";
 

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -137,7 +137,7 @@ void keepAliveThread()
 	std::unique_lock<std::mutex> guard(s_keepalive_lock);
 
 	while (!s_keepalive_cv.wait_for(guard, std::chrono::seconds(30),
-									[]() { return !s_keepalive_is_open; }))
+	                                []() { return !s_keepalive_is_open; }))
 	{
 
 		//printf(" * keepAliveThread: polling drive.\n");

--- a/pcsx2/CDVD/CDVDdiscThread.cpp
+++ b/pcsx2/CDVD/CDVDdiscThread.cpp
@@ -25,7 +25,7 @@
 const u32 sectors_per_read = 16;
 
 static_assert(sectors_per_read > 1 && !(sectors_per_read & (sectors_per_read - 1)),
-			  "sectors_per_read must by a power of 2");
+              "sectors_per_read must by a power of 2");
 
 struct SectorInfo
 {

--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -256,7 +256,7 @@ s32 CALLBACK ISOgetTOC(void* toc)
 		}
 	}
 	else if ((type == CDVD_TYPE_CDDA) || (type == CDVD_TYPE_PS2CDDA) ||
-			 (type == CDVD_TYPE_PS2CD) || (type == CDVD_TYPE_PSCDDA) || (type == CDVD_TYPE_PSCD))
+	         (type == CDVD_TYPE_PS2CD) || (type == CDVD_TYPE_PSCDDA) || (type == CDVD_TYPE_PSCD))
 	{
 		// cd toc
 		// (could be replaced by 1 command that reads the full toc)

--- a/pcsx2/CDVD/ChunksCache.h
+++ b/pcsx2/CDVD/ChunksCache.h
@@ -34,7 +34,7 @@ public:
 	int Read(void* pDest, PX_off_t offset, int length);
 
 	static int CopyAvailable(void* pSrc, PX_off_t srcOffset, int srcSize,
-							 void* pDst, PX_off_t dstOffset, int maxCopySize)
+	                         void* pDst, PX_off_t dstOffset, int maxCopySize)
 	{
 		int available = CLAMP(maxCopySize, 0, (int)(srcOffset + srcSize - dstOffset));
 		memcpy(pDst, (char*)pSrc + (dstOffset - srcOffset), available);

--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -123,8 +123,8 @@ static wxString INDEX_TEMPLATE_KEY(L"$(f)");
 // No checks are performed if the result file name can be created.
 // If this proves useful, we can move it into Path:: . Right now there's no need.
 static wxString ApplyTemplate(const wxString& name, const wxDirName& base,
-							  const wxString& fileTemplate, const wxString& filename,
-							  bool canEndWithKey)
+                              const wxString& fileTemplate, const wxString& filename,
+                              bool canEndWithKey)
 {
 	wxString tem(fileTemplate);
 	wxString key = INDEX_TEMPLATE_KEY;
@@ -132,12 +132,12 @@ static wxString ApplyTemplate(const wxString& name, const wxDirName& base,
 
 	size_t first = tem.find(key);
 	if (first == wxString::npos    // not found
-		|| first != tem.rfind(key) // more than one instance
-		|| !canEndWithKey && first == tem.length() - key.length())
+	    || first != tem.rfind(key) // more than one instance
+	    || !canEndWithKey && first == tem.length() - key.length())
 	{
 		Console.Error(L"Invalid %s template '%s'.\n"
-					  L"Template must contain exactly one '%s' and must not end with it. Abotring.",
-					  WX_STR(name), WX_STR(tem), WX_STR(key));
+		              L"Template must contain exactly one '%s' and must not end with it. Abotring.",
+		              WX_STR(name), WX_STR(tem), WX_STR(key));
 		return L"";
 	}
 
@@ -317,7 +317,7 @@ bool GzippedFileReader::OkIndex()
 		if (m_pIndex->span != GZFILE_SPAN_DEFAULT)
 		{
 			Console.Warning(L"Note: This index has %1.1f MB intervals, while the current default for new indexes is %1.1f MB.",
-							(float)m_pIndex->span / 1024 / 1024, (float)GZFILE_SPAN_DEFAULT / 1024 / 1024);
+			                (float)m_pIndex->span / 1024 / 1024, (float)GZFILE_SPAN_DEFAULT / 1024 / 1024);
 			Console.Warning(L"It will work fine, but if you want to generate a new index with default intervals, delete this index file.");
 			Console.Warning(L"(smaller intervals mean bigger index file and quicker but more frequent decompressions)");
 		}
@@ -491,10 +491,10 @@ int GzippedFileReader::_ReadSync(void* pBuffer, PX_off_t offset, uint bytesToRea
 	int duration = NOW() - s;
 	if (duration > 10)
 		Console.WriteLn(Color_Gray, L"gunzip: chunk #%5d-%2d : %1.2f MB - %d ms",
-						(int)(offset / 4 / 1024 / 1024),
-						(int)(offset % (4 * 1024 * 1024) / GZFILE_READ_CHUNK_SIZE),
-						(float)size / 1024 / 1024,
-						duration);
+		                (int)(offset / 4 / 1024 / 1024),
+		                (int)(offset % (4 * 1024 * 1024) / GZFILE_READ_CHUNK_SIZE),
+		                (float)size / 1024 / 1024,
+		                duration);
 
 	return copied;
 }

--- a/pcsx2/CDVD/Linux/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Linux/IOCtlSrc.cpp
@@ -98,10 +98,10 @@ bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, u8* buffer) const
 
 	if (bytes_read == -1)
 		fprintf(stderr, " * CDVD read sectors %u-%u failed: %s\n",
-				sector, sector + count - 1, strerror(errno));
+		        sector, sector + count - 1, strerror(errno));
 	else
 		fprintf(stderr, " * CDVD read sectors %u-%u: %zd bytes read, %zd bytes expected\n",
-				sector, sector + count - 1, bytes_read, bytes_to_read);
+		        sector, sector + count - 1, bytes_read, bytes_to_read);
 	return false;
 }
 
@@ -121,7 +121,7 @@ bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8* buffer) const
 		if (ioctl(m_device, CDROMREADRAW, &data) == -1)
 		{
 			fprintf(stderr, " * CDVD CDROMREADRAW sector %u failed: %s\n",
-					lba, strerror(errno));
+			        lba, strerror(errno));
 			return false;
 		}
 		memcpy(buffer, data.buffer, CD_FRAMESIZE_RAW);
@@ -201,7 +201,7 @@ bool IOCtlSrc::ReadCDInfo()
 		entry.cdte_track = n;
 		if (ioctl(m_device, CDROMREADTOCENTRY, &entry) != -1)
 			m_toc.push_back({static_cast<u32>(entry.cdte_addr.lba), entry.cdte_track,
-							 entry.cdte_adr, entry.cdte_ctrl});
+			                 entry.cdte_adr, entry.cdte_ctrl});
 	}
 
 	// TODO: Do I need a fallback if this doesn't work?

--- a/pcsx2/CDVD/Windows/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Windows/IOCtlSrc.cpp
@@ -54,15 +54,15 @@ bool IOCtlSrc::Reopen()
 
 	// SPTI only works if the device is opened with GENERIC_WRITE access.
 	m_device = CreateFile(m_filename.c_str(), GENERIC_READ | GENERIC_WRITE,
-						  FILE_SHARE_READ, nullptr, OPEN_EXISTING,
-						  FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+	                      FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+	                      FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
 	if (m_device == INVALID_HANDLE_VALUE)
 		return false;
 
 	DWORD unused;
 	// Required to read from layer 1 of Dual layer DVDs
 	DeviceIoControl(m_device, FSCTL_ALLOW_EXTENDED_DASD_IO, nullptr, 0, nullptr,
-					0, &unused, nullptr);
+	                0, &unused, nullptr);
 
 	if (ReadDVDInfo() || ReadCDInfo())
 		SetSpindleSpeed(false);
@@ -83,7 +83,7 @@ void IOCtlSrc::SetSpindleSpeed(bool restore_defaults) const
 
 	DWORD unused;
 	if (DeviceIoControl(m_device, IOCTL_CDROM_SET_SPEED, &s, sizeof(s),
-						nullptr, 0, &unused, nullptr))
+	                    nullptr, 0, &unused, nullptr))
 	{
 		if (!restore_defaults)
 			printf(" * CDVD: setSpindleSpeed success (%uKB/s)\n", speed);
@@ -123,7 +123,7 @@ bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, u8* buffer) const
 	if (!SetFilePointerEx(m_device, offset, nullptr, FILE_BEGIN))
 	{
 		fprintf(stderr, " * CDVD SetFilePointerEx failed: sector %u: error %u\n",
-				sector, GetLastError());
+		        sector, GetLastError());
 		return false;
 	}
 
@@ -134,12 +134,12 @@ bool IOCtlSrc::ReadSectors2048(u32 sector, u32 count, u8* buffer) const
 		if (bytes_read == bytes_to_read)
 			return true;
 		fprintf(stderr, " * CDVD ReadFile: sectors %u-%u: %u bytes read, %u bytes expected\n",
-				sector, sector + count - 1, bytes_read, bytes_to_read);
+		        sector, sector + count - 1, bytes_read, bytes_to_read);
 	}
 	else
 	{
 		fprintf(stderr, " * CDVD ReadFile failed: sectors %u-%u: error %u\n",
-				sector, sector + count - 1, GetLastError());
+		        sector, sector + count - 1, GetLastError());
 	}
 
 	return false;
@@ -187,7 +187,7 @@ bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8* buffer) const
 
 		DWORD unused;
 		if (DeviceIoControl(m_device, IOCTL_SCSI_PASS_THROUGH_DIRECT, &sptd,
-							sizeof(sptd), &sptd, sizeof(sptd), &unused, nullptr))
+		                    sizeof(sptd), &sptd, sizeof(sptd), &unused, nullptr))
 		{
 			if (sptd.info.DataTransferLength == 2352)
 				continue;
@@ -215,7 +215,7 @@ bool IOCtlSrc::ReadDVDInfo()
 	DVD_READ_STRUCTURE dvdrs{{0}, DvdPhysicalDescriptor, 0, 0};
 
 	if (!DeviceIoControl(m_device, IOCTL_DVD_READ_STRUCTURE, &dvdrs, sizeof(dvdrs),
-						 buffer.data(), buffer.size(), &unused, nullptr))
+	                     buffer.data(), buffer.size(), &unused, nullptr))
 		return false;
 
 	auto& layer = *reinterpret_cast<DVD_LAYER_DESCRIPTOR*>(
@@ -236,7 +236,7 @@ bool IOCtlSrc::ReadDVDInfo()
 		// Dual layer, Parallel Track Path
 		dvdrs.LayerNumber = 1;
 		if (!DeviceIoControl(m_device, IOCTL_DVD_READ_STRUCTURE, &dvdrs, sizeof(dvdrs),
-							 buffer.data(), buffer.size(), &unused, nullptr))
+		                     buffer.data(), buffer.size(), &unused, nullptr))
 			return false;
 		u32 layer1_start_sector = _byteswap_ulong(layer.StartingDataSector);
 		u32 layer1_end_sector = _byteswap_ulong(layer.EndDataSector);
@@ -267,7 +267,7 @@ bool IOCtlSrc::ReadCDInfo()
 
 	CDROM_TOC toc;
 	if (!DeviceIoControl(m_device, IOCTL_CDROM_READ_TOC_EX, &toc_ex,
-						 sizeof(toc_ex), &toc, sizeof(toc), &unused, nullptr))
+	                     sizeof(toc_ex), &toc, sizeof(toc), &unused, nullptr))
 		return false;
 
 	m_toc.clear();
@@ -284,7 +284,7 @@ bool IOCtlSrc::ReadCDInfo()
 
 	GET_LENGTH_INFORMATION info;
 	if (!DeviceIoControl(m_device, IOCTL_DISK_GET_LENGTH_INFO, nullptr, 0, &info,
-						 sizeof(info), &unused, nullptr))
+	                     sizeof(info), &unused, nullptr))
 		return false;
 
 	m_sectors = static_cast<u32>(info.Length.QuadPart / 2048);
@@ -300,7 +300,7 @@ bool IOCtlSrc::DiscReady()
 
 	DWORD unused;
 	if (DeviceIoControl(m_device, IOCTL_STORAGE_CHECK_VERIFY, nullptr, 0,
-						nullptr, 0, &unused, nullptr))
+	                    nullptr, 0, &unused, nullptr))
 	{
 		if (!m_sectors)
 			Reopen();

--- a/pcsx2/CDVD/zlib_indexed.h
+++ b/pcsx2/CDVD/zlib_indexed.h
@@ -168,7 +168,7 @@ local void free_index(struct access* index)
 /* Add an entry to the access point list.  If out of memory, deallocate the
    existing list and return NULL. */
 local struct access* addpoint(struct access* index, int bits,
-							  PX_off_t in, PX_off_t out, unsigned left, unsigned char* window)
+                              PX_off_t in, PX_off_t out, unsigned left, unsigned char* window)
 {
 	struct point* next;
 
@@ -300,10 +300,10 @@ local int build_index(FILE* in, PX_off_t span, struct access** built)
                access point after the last block by checking bit 6 of data_type
              */
 			if ((strm.data_type & 128) && !(strm.data_type & 64) &&
-				(totout == 0 || totout - last > span))
+			    (totout == 0 || totout - last > span))
 			{
 				index = addpoint(index, strm.data_type & 7, totin,
-								 totout, strm.avail_out, window);
+				                 totout, strm.avail_out, window);
 				if (index == NULL)
 				{
 					ret = Z_MEM_ERROR;
@@ -363,7 +363,7 @@ static inline PX_off_t getInOffset(zstate* state)
    was generated.  extract() may also return Z_ERRNO if there is an error on
    reading or seeking the input file. */
 local int extract(FILE* in, struct access* index, PX_off_t offset,
-				  unsigned char* buf, int len, zstate* state)
+                  unsigned char* buf, int len, zstate* state)
 {
 	int ret, skip;
 	struct point* here;

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -54,7 +54,7 @@ static __inline__ unsigned long long GetTickCount(void)
 {
 	unsigned long long int x;
 	__asm__ volatile("rdtsc"
-					 : "=A"(x));
+	                 : "=A"(x));
 	return x;
 }
 
@@ -64,7 +64,7 @@ static __inline__ unsigned long long GetTickCount(void)
 {
 	unsigned hi, lo;
 	__asm__ __volatile__("rdtsc"
-						 : "=a"(lo), "=d"(hi));
+	                     : "=a"(lo), "=d"(hi));
 	return ((unsigned long long)lo) | (((unsigned long long)hi) << 32);
 }
 

--- a/pcsx2/DEV9/Linux/Config.cpp
+++ b/pcsx2/DEV9/Linux/Config.cpp
@@ -43,22 +43,22 @@ void SaveConf()
 	xmlDocSetRootElement(doc, root_node);
 
 	xmlNewChild(root_node, NULL, BAD_CAST "Eth",
-				BAD_CAST config.Eth);
+	            BAD_CAST config.Eth);
 
 	xmlNewChild(root_node, NULL, BAD_CAST "Hdd",
-				BAD_CAST config.Hdd);
+	            BAD_CAST config.Hdd);
 
 	sprintf(buff, "%d", config.HddSize);
 	xmlNewChild(root_node, NULL, BAD_CAST "HddSize",
-				BAD_CAST buff);
+	            BAD_CAST buff);
 
 	sprintf(buff, "%d", config.ethEnable);
 	xmlNewChild(root_node, NULL, BAD_CAST "ethEnable",
-				BAD_CAST buff);
+	            BAD_CAST buff);
 
 	sprintf(buff, "%d", config.hddEnable);
 	xmlNewChild(root_node, NULL, BAD_CAST "hddEnable",
-				BAD_CAST buff);
+	            BAD_CAST buff);
 	/*
      * Dumping document to stdio or file
      */

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -41,10 +41,10 @@ void SysMessage(char* fmt, ...)
 	va_end(list);
 
 	GtkWidget* dialog = gtk_message_dialog_new(NULL,
-											   GTK_DIALOG_MODAL,
-											   GTK_MESSAGE_ERROR,
-											   GTK_BUTTONS_CLOSE,
-											   "%s", tmp);
+	                                           GTK_DIALOG_MODAL,
+	                                           GTK_MESSAGE_ERROR,
+	                                           GTK_BUTTONS_CLOSE,
+	                                           "%s", tmp);
 	gtk_dialog_run(GTK_DIALOG(dialog));
 	gtk_widget_hide(dialog);
 }
@@ -74,9 +74,9 @@ void OnInitDialog()
 	}
 	gtk_entry_set_text((GtkEntry*)gtk_builder_get_object(builder, "IDC_HDDFILE"), config.Hdd);
 	gtk_toggle_button_set_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_ETHENABLED"),
-								 config.ethEnable);
+	                             config.ethEnable);
 	gtk_toggle_button_set_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_HDDENABLED"),
-								 config.hddEnable);
+	                             config.hddEnable);
 
 	initialized = 1;
 }

--- a/pcsx2/DEV9/Win32/DEV9WinConfig.cpp
+++ b/pcsx2/DEV9/Win32/DEV9WinConfig.cpp
@@ -29,7 +29,7 @@ bool FileExists(std::string szPath)
 {
 	DWORD dwAttrib = GetFileAttributesA(szPath.c_str());
 	return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
-			!(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+	        !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
 void SaveConf()

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -143,9 +143,9 @@ void DEV9configure()
 {
 	ScopedCoreThreadPause paused_core;
 	DialogBox(hInst,
-			  MAKEINTRESOURCE(IDD_CONFIG),
-			  GetActiveWindow(),
-			  (DLGPROC)ConfigureDlgProc);
+	          MAKEINTRESOURCE(IDD_CONFIG),
+	          GetActiveWindow(),
+	          (DLGPROC)ConfigureDlgProc);
 	//SysMessage("Nothing to Configure");
 	paused_core.AllowResume();
 }

--- a/pcsx2/DEV9/Win32/tap-win32.cpp
+++ b/pcsx2/DEV9/Win32/tap-win32.cpp
@@ -101,13 +101,13 @@ bool IsTAPDevice(const TCHAR* guid)
 		{
 			len = sizeof(component_id);
 			status = RegQueryValueEx(unit_key, component_id_string, nullptr, &data_type,
-									 (LPBYTE)component_id, &len);
+			                         (LPBYTE)component_id, &len);
 
 			if (!(status != ERROR_SUCCESS || data_type != REG_SZ))
 			{
 				len = sizeof(net_cfg_instance_id);
 				status = RegQueryValueEx(unit_key, net_cfg_instance_id_string, nullptr, &data_type,
-										 (LPBYTE)net_cfg_instance_id, &len);
+				                         (LPBYTE)net_cfg_instance_id, &len);
 
 				if (status == ERROR_SUCCESS && data_type == REG_SZ)
 				{
@@ -138,13 +138,13 @@ vector<tap_adapter>* GetTapAdapters()
 	DWORD cSubKeys = 0;
 
 	status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, NETWORK_CONNECTIONS_KEY, 0, KEY_READ | KEY_QUERY_VALUE,
-						  &control_net_key);
+	                      &control_net_key);
 
 	if (status != ERROR_SUCCESS)
 		return false;
 
 	status = RegQueryInfoKey(control_net_key, nullptr, nullptr, nullptr, &cSubKeys, nullptr, nullptr,
-							 nullptr, nullptr, nullptr, nullptr, nullptr);
+	                         nullptr, nullptr, nullptr, nullptr, nullptr);
 
 	if (status != ERROR_SUCCESS)
 		return false;
@@ -165,7 +165,7 @@ vector<tap_adapter>* GetTapAdapters()
 			continue;
 
 		_sntprintf(connection_string, sizeof(connection_string), _T("%s\\%s\\Connection"),
-				   NETWORK_CONNECTIONS_KEY, enum_name);
+		           NETWORK_CONNECTIONS_KEY, enum_name);
 
 		status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, connection_string, 0, KEY_READ, &connection_key);
 
@@ -173,7 +173,7 @@ vector<tap_adapter>* GetTapAdapters()
 		{
 			len = sizeof(name_data);
 			status = RegQueryValueEx(connection_key, name_string, nullptr, &name_type, (LPBYTE)name_data,
-									 &len);
+			                         &len);
 
 			if (status != ERROR_SUCCESS || name_type != REG_SZ)
 			{
@@ -203,8 +203,8 @@ static int TAPSetStatus(HANDLE handle, int status)
 	unsigned long len = 0;
 
 	return DeviceIoControl(handle, TAP_IOCTL_SET_MEDIA_STATUS,
-						   &status, sizeof(status),
-						   &status, sizeof(status), &len, NULL);
+	                       &status, sizeof(status),
+	                       &status, sizeof(status), &len, NULL);
 }
 //Open the TAP adapter and set the connection to enabled :)
 HANDLE TAPOpen(const char* device_guid)
@@ -220,9 +220,9 @@ HANDLE TAPOpen(const char* device_guid)
 	LONG version_len;
 
 	_snprintf(device_path, sizeof(device_path), "%s%s%s",
-			  USERMODEDEVICEDIR,
-			  device_guid,
-			  TAPSUFFIX);
+	          USERMODEDEVICEDIR,
+	          device_guid,
+	          TAPSUFFIX);
 
 	HANDLE handle = CreateFileA(
 		device_path,
@@ -239,8 +239,8 @@ HANDLE TAPOpen(const char* device_guid)
 	}
 
 	BOOL bret = DeviceIoControl(handle, TAP_IOCTL_GET_VERSION,
-								&version, sizeof(version),
-								&version, sizeof(version), (LPDWORD)&version_len, NULL);
+	                            &version, sizeof(version),
+	                            &version, sizeof(version), (LPDWORD)&version_len, NULL);
 
 	if (bret == FALSE)
 	{
@@ -288,10 +288,10 @@ bool TAPAdapter::recv(NetPacket* pkt)
 {
 	DWORD read_size;
 	BOOL result = ReadFile(htap,
-						   pkt->buffer,
-						   sizeof(pkt->buffer),
-						   &read_size,
-						   &read);
+	                       pkt->buffer,
+	                       sizeof(pkt->buffer),
+	                       &read_size,
+	                       &read);
 
 	if (!result)
 	{
@@ -300,7 +300,7 @@ bool TAPAdapter::recv(NetPacket* pkt)
 		{
 			WaitForSingleObject(read.hEvent, INFINITE);
 			result = GetOverlappedResult(htap, &read,
-										 &read_size, FALSE);
+			                             &read_size, FALSE);
 			if (!result)
 			{
 			}
@@ -335,10 +335,10 @@ bool TAPAdapter::send(NetPacket* pkt)
 {
 	DWORD writen;
 	BOOL result = WriteFile(htap,
-							pkt->buffer,
-							pkt->size,
-							&writen,
-							&write);
+	                        pkt->buffer,
+	                        pkt->size,
+	                        &writen,
+	                        &write);
 
 	if (!result)
 	{
@@ -347,7 +347,7 @@ bool TAPAdapter::send(NetPacket* pkt)
 		{
 			WaitForSingleObject(write.hEvent, INFINITE);
 			result = GetOverlappedResult(htap, &write,
-										 &writen, FALSE);
+			                             &writen, FALSE);
 			if (!result)
 			{
 			}

--- a/pcsx2/DEV9/Win32/tap.h
+++ b/pcsx2/DEV9/Win32/tap.h
@@ -21,8 +21,8 @@ using namespace std;
 
 struct tap_adapter
 {
-	TCHAR *name;
-	TCHAR *guid;
+	TCHAR* name;
+	TCHAR* guid;
 };
 vector<tap_adapter>* GetTapAdapters();
 class TAPAdapter : public NetAdapter

--- a/pcsx2/DEV9/flash.cpp
+++ b/pcsx2/DEV9/flash.cpp
@@ -285,7 +285,7 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 				{
 					const u32 blocks = address / BLOCK_SIZE;
 					u32 pages = address - (blocks * BLOCK_SIZE);
-					[[maybe_unused]]const u32 bytes = pages % PAGE_SIZE;
+					[[maybe_unused]] const u32 bytes = pages % PAGE_SIZE;
 					pages = pages / PAGE_SIZE;
 					DEV9_LOG("*FLASH ADDR = 0x%08lX (%d:%d:%d) (addrbyte=%d) FINAL\n", address, blocks, pages, bytes, addrbyte);
 				}

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -139,12 +139,12 @@ int pcap_io_init(char* adapter)
 
 	/* Open the adapter */
 	if ((adhandle = pcap_open_live(adapter, // name of the device
-								   65536,   // portion of the packet to capture.
-											// 65536 grants that the whole packet will be captured on all the MACs.
-								   1,       // promiscuous for Xlink usage
-								   1,       // read timeout
-								   errbuf   // error buffer
-								   )) == NULL)
+	                               65536,   // portion of the packet to capture.
+	                                        // 65536 grants that the whole packet will be captured on all the MACs.
+	                               1,       // promiscuous for Xlink usage
+	                               1,       // read timeout
+	                               errbuf   // error buffer
+	                               )) == NULL)
 	{
 		fprintf(stderr, "%s", errbuf);
 		fprintf(stderr, "\nUnable to open the adapter. %s is not supported by pcap\n", adapter);

--- a/pcsx2/SPU2/Debug.cpp
+++ b/pcsx2/SPU2/Debug.cpp
@@ -76,10 +76,10 @@ void ConLog(const char* fmt, ...)
 void V_VolumeSlide::DebugDump(FILE* dump, const char* title, const char* nameLR)
 {
 	fprintf(dump, "%s Volume for %s Channel:\t%x\n"
-				  "  - Value:     %x\n"
-				  "  - Mode:      %x\n"
-				  "  - Increment: %x\n",
-			title, nameLR, Reg_VOL, Value, Mode, Increment);
+	              "  - Value:     %x\n"
+	              "  - Mode:      %x\n"
+	              "  - Increment: %x\n",
+	        title, nameLR, Reg_VOL, Value, Mode, Increment);
 }
 
 void V_VolumeSlideLR::DebugDump(FILE* dump, const char* title)
@@ -173,28 +173,28 @@ void DoFullDump()
 				Cores[c].Voices[v].Volume.DebugDump(dump, "");
 
 				fprintf(dump, "  - ADSR Envelope: %x & %x\n"
-							  "     - Ar: %x\n"
-							  "     - Am: %x\n"
-							  "     - Dr: %x\n"
-							  "     - Sl: %x\n"
-							  "     - Sr: %x\n"
-							  "     - Sm: %x\n"
-							  "     - Rr: %x\n"
-							  "     - Rm: %x\n"
-							  "     - Phase: %x\n"
-							  "     - Value: %x\n",
-						Cores[c].Voices[v].ADSR.regADSR1,
-						Cores[c].Voices[v].ADSR.regADSR2,
-						Cores[c].Voices[v].ADSR.AttackRate,
-						Cores[c].Voices[v].ADSR.AttackMode,
-						Cores[c].Voices[v].ADSR.DecayRate,
-						Cores[c].Voices[v].ADSR.SustainLevel,
-						Cores[c].Voices[v].ADSR.SustainRate,
-						Cores[c].Voices[v].ADSR.SustainMode,
-						Cores[c].Voices[v].ADSR.ReleaseRate,
-						Cores[c].Voices[v].ADSR.ReleaseMode,
-						Cores[c].Voices[v].ADSR.Phase,
-						Cores[c].Voices[v].ADSR.Value);
+				              "     - Ar: %x\n"
+				              "     - Am: %x\n"
+				              "     - Dr: %x\n"
+				              "     - Sl: %x\n"
+				              "     - Sr: %x\n"
+				              "     - Sm: %x\n"
+				              "     - Rr: %x\n"
+				              "     - Rm: %x\n"
+				              "     - Phase: %x\n"
+				              "     - Value: %x\n",
+				        Cores[c].Voices[v].ADSR.regADSR1,
+				        Cores[c].Voices[v].ADSR.regADSR2,
+				        Cores[c].Voices[v].ADSR.AttackRate,
+				        Cores[c].Voices[v].ADSR.AttackMode,
+				        Cores[c].Voices[v].ADSR.DecayRate,
+				        Cores[c].Voices[v].ADSR.SustainLevel,
+				        Cores[c].Voices[v].ADSR.SustainRate,
+				        Cores[c].Voices[v].ADSR.SustainMode,
+				        Cores[c].Voices[v].ADSR.ReleaseRate,
+				        Cores[c].Voices[v].ADSR.ReleaseMode,
+				        Cores[c].Voices[v].ADSR.Phase,
+				        Cores[c].Voices[v].ADSR.Value);
 
 				fprintf(dump, "  - Pitch:     %x\n", Cores[c].Voices[v].Pitch);
 				fprintf(dump, "  - Modulated: %s\n", Cores[c].Voices[v].Modulated ? "Yes" : "No");

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -139,7 +139,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 
 	if (MsgAutoDMA())
 		ConLog("* SPU2: DMA%c AutoDMA Transfer of %d bytes to %x (%02x %x %04x).\n",
-			   GetDmaIndexChar(), size << 1, TSA, DMABits, AutoDMACtrl, (~Regs.ATTR) & 0x7fff);
+		       GetDmaIndexChar(), size << 1, TSA, DMABits, AutoDMACtrl, (~Regs.ATTR) & 0x7fff);
 
 	InputDataProgress = 0;
 	if ((AutoDMACtrl & (Index + 1)) == 0)
@@ -449,8 +449,8 @@ void V_Core::DoDMAwrite(u16* pMem, u32 size)
 	{
 		if (MsgDMA())
 			ConLog("* SPU2: DMA%c Transfer of %d bytes to %x (%02x %x %04x). IRQE = %d IRQA = %x \n",
-				   GetDmaIndexChar(), size << 1, TSA, DMABits, AutoDMACtrl, (~Regs.ATTR) & 0x7fff,
-				   Cores[0].IRQEnable, Cores[0].IRQA);
+			       GetDmaIndexChar(), size << 1, TSA, DMABits, AutoDMACtrl, (~Regs.ATTR) & 0x7fff,
+			       Cores[0].IRQEnable, Cores[0].IRQA);
 
 		PlainDMAWrite(pMem, size);
 	}

--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -600,8 +600,8 @@ static __forceinline StereoOut32 MixVoice(uint coreidx, uint voiceidx)
 	{
 		// Continue processing voice, even if it's "off". Or else we miss interrupts! (Fatal Frame engine died because of this.)
 		if (NEVER_SKIP_VOICES || (*GetMemPtr(vc.NextA & 0xFFFF8) >> 8 & 3) != 3 || vc.LoopStartA != (vc.NextA & ~7)    // not in a tight loop
-			|| (Cores[0].IRQEnable && (Cores[0].IRQA & ~7) == vc.LoopStartA)                                           // or should be interrupting regularly
-			|| (Cores[1].IRQEnable && (Cores[1].IRQA & ~7) == vc.LoopStartA) || !(thiscore.Regs.ENDX & 1 << voiceidx)) // or isn't currently flagged as having passed the endpoint
+		    || (Cores[0].IRQEnable && (Cores[0].IRQA & ~7) == vc.LoopStartA)                                           // or should be interrupting regularly
+		    || (Cores[1].IRQEnable && (Cores[1].IRQA & ~7) == vc.LoopStartA) || !(thiscore.Regs.ENDX & 1 << voiceidx)) // or isn't currently flagged as having passed the endpoint
 		{
 			UpdatePitch(coreidx, voiceidx);
 
@@ -906,9 +906,9 @@ __forceinline
 			p_cachestat_counter = 0;
 			if (MsgCache())
 				ConLog(" * SPU2 > CacheStats > Hits: %d  Misses: %d  Ignores: %d\n",
-					   g_counter_cache_hits,
-					   g_counter_cache_misses,
-					   g_counter_cache_ignores);
+				       g_counter_cache_hits,
+				       g_counter_cache_misses,
+				       g_counter_cache_ignores);
 
 			g_counter_cache_hits =
 				g_counter_cache_misses =

--- a/pcsx2/SPU2/RegLog.cpp
+++ b/pcsx2/SPU2/RegLog.cpp
@@ -23,7 +23,7 @@ __forceinline void _RegLog_(const char* action, int level, const char* RName, u3
 {
 	if (level > 1)
 		FileLog("[%10d] SPU2 %s mem %08x (core %d, register %s) value %04x\n",
-				Cycles, action, mem, core, RName, value);
+		        Cycles, action, mem, core, RName, value);
 }
 
 #define RegLog(lev, rname, mem, core, val) _RegLog_(action, lev, rname, mem, core, val)

--- a/pcsx2/SPU2/Reverb.cpp
+++ b/pcsx2/SPU2/Reverb.cpp
@@ -91,14 +91,14 @@ StereoOut32 V_Core::DoReverb(const StereoOut32& Input)
 		if (Cores[i].IRQEnable && ((Cores[i].IRQA >= EffectsStartA) && (Cores[i].IRQA <= EffectsEndA)))
 		{
 			if ((Cores[i].IRQA == same_src) || (Cores[i].IRQA == diff_src) ||
-				(Cores[i].IRQA == same_dst) || (Cores[i].IRQA == diff_dst) ||
-				(Cores[i].IRQA == same_prv) || (Cores[i].IRQA == diff_prv) ||
+			    (Cores[i].IRQA == same_dst) || (Cores[i].IRQA == diff_dst) ||
+			    (Cores[i].IRQA == same_prv) || (Cores[i].IRQA == diff_prv) ||
 
-				(Cores[i].IRQA == comb1_src) || (Cores[i].IRQA == comb2_src) ||
-				(Cores[i].IRQA == comb3_src) || (Cores[i].IRQA == comb4_src) ||
+			    (Cores[i].IRQA == comb1_src) || (Cores[i].IRQA == comb2_src) ||
+			    (Cores[i].IRQA == comb3_src) || (Cores[i].IRQA == comb4_src) ||
 
-				(Cores[i].IRQA == apf1_dst) || (Cores[i].IRQA == apf1_src) ||
-				(Cores[i].IRQA == apf2_dst) || (Cores[i].IRQA == apf2_src))
+			    (Cores[i].IRQA == apf1_dst) || (Cores[i].IRQA == apf1_src) ||
+			    (Cores[i].IRQA == apf2_dst) || (Cores[i].IRQA == apf2_src))
 			{
 				//printf("Core %d IRQ Called (Reverb). IRQA = %x\n",i,addr);
 				SetIrqCall(i);

--- a/pcsx2/SPU2/SndOut.cpp
+++ b/pcsx2/SPU2/SndOut.cpp
@@ -498,7 +498,7 @@ void SndBuffer::Write(const StereoOut32& Sample)
 		if (m_dsp_progress > 0)
 		{
 			memcpy(sndTempBuffer16, &sndTempBuffer16[ei],
-				   sizeof(sndTempBuffer16[0]) * m_dsp_progress);
+			       sizeof(sndTempBuffer16[0]) * m_dsp_progress);
 		}
 	}
 #endif

--- a/pcsx2/SPU2/SndOut_Portaudio.cpp
+++ b/pcsx2/SPU2/SndOut_Portaudio.cpp
@@ -39,10 +39,10 @@
 #include "Debug.h"
 
 int PaCallback(const void* inputBuffer, void* outputBuffer,
-			   unsigned long framesPerBuffer,
-			   const PaStreamCallbackTimeInfo* timeInfo,
-			   PaStreamCallbackFlags statusFlags,
-			   void* userData);
+               unsigned long framesPerBuffer,
+               const PaStreamCallbackTimeInfo* timeInfo,
+               PaStreamCallbackFlags statusFlags,
+               void* userData);
 
 class Portaudio : public SndOutModule
 {
@@ -78,10 +78,10 @@ private:
 	{
 	public:
 		virtual int ReadSamples(const void* inputBuffer, void* outputBuffer,
-								unsigned long framesPerBuffer,
-								const PaStreamCallbackTimeInfo* timeInfo,
-								PaStreamCallbackFlags statusFlags,
-								void* userData) = 0;
+		                        unsigned long framesPerBuffer,
+		                        const PaStreamCallbackTimeInfo* timeInfo,
+		                        PaStreamCallbackFlags statusFlags,
+		                        void* userData) = 0;
 	};
 
 	template <class T>
@@ -96,10 +96,10 @@ private:
 		}
 
 		virtual int ReadSamples(const void* inputBuffer, void* outputBuffer,
-								unsigned long framesPerBuffer,
-								const PaStreamCallbackTimeInfo* timeInfo,
-								PaStreamCallbackFlags statusFlags,
-								void* userData)
+		                        unsigned long framesPerBuffer,
+		                        const PaStreamCallbackTimeInfo* timeInfo,
+		                        PaStreamCallbackFlags statusFlags,
+		                        void* userData)
 		{
 			T* p1 = (T*)outputBuffer;
 
@@ -291,20 +291,20 @@ public:
 				infoPtr};
 
 			err = Pa_OpenStream(&stream,
-								nullptr, &outParams, SampleRate,
-								SndOutPacketSize,
-								paNoFlag,
-								PaCallback,
+			                    nullptr, &outParams, SampleRate,
+			                    SndOutPacketSize,
+			                    paNoFlag,
+			                    PaCallback,
 
-								nullptr);
+			                    nullptr);
 		}
 		else
 		{
 			err = Pa_OpenDefaultStream(&stream,
-									   0, actualUsedChannels, paInt32, 48000,
-									   SndOutPacketSize,
-									   PaCallback,
-									   nullptr);
+			                           0, actualUsedChannels, paInt32, 48000,
+			                           SndOutPacketSize,
+			                           PaCallback,
+			                           nullptr);
 		}
 		if (err != paNoError)
 		{
@@ -722,10 +722,10 @@ public:
 } static PA;
 
 int PaCallback(const void* inputBuffer, void* outputBuffer,
-			   unsigned long framesPerBuffer,
-			   const PaStreamCallbackTimeInfo* timeInfo,
-			   PaStreamCallbackFlags statusFlags,
-			   void* userData)
+               unsigned long framesPerBuffer,
+               const PaStreamCallbackTimeInfo* timeInfo,
+               PaStreamCallbackFlags statusFlags,
+               void* userData)
 {
 	return PA.ActualPaCallback->ReadSamples(inputBuffer, outputBuffer, framesPerBuffer, timeInfo, statusFlags, userData);
 }

--- a/pcsx2/SPU2/SndOut_SDL.cpp
+++ b/pcsx2/SPU2/SndOut_SDL.cpp
@@ -191,7 +191,7 @@ private:
 	SDLAudioMod()
 		: m_api("pulseaudio")
 		, spec({SampleRate, format, channels, 0,
-				desiredSamples, 0, 0, &callback_fillBuffer, nullptr})
+		        desiredSamples, 0, 0, &callback_fillBuffer, nullptr})
 	{
 		// Number of samples must be a multiple of packet size.
 		assert(samples % SndOutPacketSize == 0);

--- a/pcsx2/SPU2/Timestretcher.cpp
+++ b/pcsx2/SPU2/Timestretcher.cpp
@@ -252,7 +252,7 @@ void SndBuffer::UpdateTempoChangeSoundTouch2()
 		if (delta.GetMilliseconds() > 1000)
 		{ //report buffers state and tempo adjust every second
 			ConLog("buffers: %4d ms (%3.0f%%), tempo: %f, comp: %2.3f, iters: %d, (N-IPS:%d -> avg:%d, minokc:%d, div:%d) reset:%d\n",
-				   (int)(data / 48), (double)(100.0 * bufferFullness / baseTargetFullness), (double)tempoAdjust, (double)(dynamicTargetFullness / baseTargetFullness), iters, (int)targetIPS, AVERAGING_WINDOW, hys_min_ok_count, compensationDivider, gRequestStretcherReset);
+			       (int)(data / 48), (double)(100.0 * bufferFullness / baseTargetFullness), (double)tempoAdjust, (double)(dynamicTargetFullness / baseTargetFullness), iters, (int)targetIPS, AVERAGING_WINDOW, hys_min_ok_count, compensationDivider, gRequestStretcherReset);
 			last = unow;
 			iters = 0;
 		}
@@ -328,9 +328,9 @@ void SndBuffer::UpdateTempoChangeSoundTouch()
 	// little, the low-end portions of this check are less forgiving than the high-sides.
 
 	if (cTempo < 0.965f || cTempo > 1.060f ||
-		pctChange < -0.38f || pctChange > 0.54f ||
-		statusPct < -0.42f || statusPct > 0.70f ||
-		eTempo < 0.89f || eTempo > 1.19f)
+	    pctChange < -0.38f || pctChange > 0.54f ||
+	    statusPct < -0.42f || statusPct > 0.70f ||
+	    eTempo < 0.89f || eTempo > 1.19f)
 	{
 		//printf("Emergency stretch: cTempo = %f eTempo = %f pctChange = %f statusPct = %f\n",cTempo,eTempo,pctChange,statusPct);
 		emergencyAdj = (pow(statusPct * statusWeight, 3.0f) * statusRange);
@@ -499,7 +499,7 @@ void SndBuffer::timeStretchWrite()
 
 	int tempProgress;
 	while (tempProgress = pSoundTouch->receiveSamples((float*)sndTempBuffer, SndOutPacketSize),
-		   tempProgress != 0)
+	       tempProgress != 0)
 	{
 		// Hint: It's assumed that pSoundTouch will return chunks of 128 bytes (it always does as
 		// long as the SSE optimizations are enabled), which means we can do our own SSE opts here.

--- a/pcsx2/SPU2/WavFile.h
+++ b/pcsx2/SPU2/WavFile.h
@@ -91,9 +91,9 @@ public:
 	/// Constructor: Creates a new WAV file. Throws a 'runtime_error' exception
 	/// if file creation fails.
 	WavOutFile(const char* fileName, ///< Filename
-			   int sampleRate,       ///< Sample rate (e.g. 44100 etc)
-			   int bits,             ///< Bits per sample (8 or 16 bits)
-			   int channels          ///< Number of channels (1=mono, 2=stereo)
+	           int sampleRate,       ///< Sample rate (e.g. 44100 etc)
+	           int bits,             ///< Bits per sample (8 or 16 bits)
+	           int channels          ///< Number of channels (1=mono, 2=stereo)
 	);
 
 	/// Destructor: Finalizes & closes the WAV file.
@@ -102,7 +102,7 @@ public:
 	/// Write data to WAV file. Throws a 'runtime_error' exception if writing to
 	/// file fails.
 	void write(const short* buffer, ///< Pointer to sample data buffer.
-			   int numElems         ///< How many array items are to be written to file.
+	           int numElems         ///< How many array items are to be written to file.
 	);
 };
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -55,10 +55,10 @@ namespace WaveDump
 				safe_delete(m_CoreWav[cidx][srcidx]);
 #ifdef __POSIX__
 				sprintf(wavfilename, "logs/spu2x-Core%ud-%s.wav",
-						cidx, m_tbl_CoreOutputTypeNames[srcidx]);
+				        cidx, m_tbl_CoreOutputTypeNames[srcidx]);
 #else
 				sprintf(wavfilename, "logs\\spu2x-Core%ud-%s.wav",
-						cidx, m_tbl_CoreOutputTypeNames[srcidx]);
+				        cidx, m_tbl_CoreOutputTypeNames[srcidx]);
 #endif
 
 				try

--- a/pcsx2/SPU2/spu2freeze.cpp
+++ b/pcsx2/SPU2/spu2freeze.cpp
@@ -88,8 +88,8 @@ s32 __fastcall SPU2Savestate::ThawIt(DataBlock& spud)
 			fprintf(stderr, "\tThe savestate you are trying to load is incorrect or corrupted.\n");
 
 		fprintf(stderr,
-				"\tAudio may not recover correctly.  Save your game to memorycard, reset,\n\n"
-				"\tand then continue from there.\n\n");
+		        "\tAudio may not recover correctly.  Save your game to memorycard, reset,\n\n"
+		        "\tand then continue from there.\n\n");
 
 		// Do *not* reset the cores.
 		// We'll need some "hints" as to how the cores should be initialized, and the

--- a/pcsx2/SPU2/spu2replay.cpp
+++ b/pcsx2/SPU2/spu2replay.cpp
@@ -101,8 +101,8 @@ bool replay_mode = false;
 
 u16 dmabuffer[0xFFFFF];
 
-[[maybe_unused]]const u32 IOP_CLK = 768 * 48000;
-[[maybe_unused]]const u32 IOPCiclesPerMS = 768 * 48;
+[[maybe_unused]] const u32 IOP_CLK = 768 * 48000;
+[[maybe_unused]] const u32 IOPCiclesPerMS = 768 * 48;
 u32 CurrentIOPCycle = 0;
 
 u64 HighResFreq;

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -491,7 +491,7 @@ __forceinline void UpdateSpdifMode()
 	if (OPM != PlayMode)
 	{
 		ConLog("* SPU2: Play Mode Set to %s (%d).\n",
-			   (PlayMode == 0) ? "Normal" : ((PlayMode == 1) ? "PCM Clone" : ((PlayMode == 2) ? "PCM Bypass" : "BitStream Bypass")), PlayMode);
+		       (PlayMode == 0) ? "Normal" : ((PlayMode == 1) ? "PCM Clone" : ((PlayMode == 2) ? "PCM Bypass" : "BitStream Bypass")), PlayMode);
 	}
 }
 
@@ -1859,13 +1859,13 @@ void StartVoices(int core, u32 value)
 
 			if (MsgKeyOnOff())
 				ConLog("* SPU2: KeyOn: C%dV%02d: SSA: %8x; M: %s%s%s%s; H: %04x; P: %04x V: %04x/%04x; ADSR: %04x%04x\n",
-					   core, vc, thisvc.StartA,
-					   (Cores[core].VoiceGates[vc].DryL) ? "+" : "-", (Cores[core].VoiceGates[vc].DryR) ? "+" : "-",
-					   (Cores[core].VoiceGates[vc].WetL) ? "+" : "-", (Cores[core].VoiceGates[vc].WetR) ? "+" : "-",
-					   *(u16*)GetMemPtr(thisvc.StartA),
-					   thisvc.Pitch,
-					   thisvc.Volume.Left.Value >> 16, thisvc.Volume.Right.Value >> 16,
-					   thisvc.ADSR.regADSR1, thisvc.ADSR.regADSR2);
+				       core, vc, thisvc.StartA,
+				       (Cores[core].VoiceGates[vc].DryL) ? "+" : "-", (Cores[core].VoiceGates[vc].DryR) ? "+" : "-",
+				       (Cores[core].VoiceGates[vc].WetL) ? "+" : "-", (Cores[core].VoiceGates[vc].WetR) ? "+" : "-",
+				       *(u16*)GetMemPtr(thisvc.StartA),
+				       thisvc.Pitch,
+				       thisvc.Volume.Left.Value >> 16, thisvc.Volume.Right.Value >> 16,
+				       thisvc.ADSR.regADSR1, thisvc.ADSR.regADSR2);
 		}
 	}
 }

--- a/pcsx2/USB/configuration.cpp
+++ b/pcsx2/USB/configuration.cpp
@@ -25,19 +25,19 @@
 std::map<std::pair<int, std::string>, std::string> changedAPIs;
 wxString iniFileUSB(L"USB.ini");
 static TSTDSTRING usb_path;
-TSTDSTRING IniPath;  // default path, just in case
+TSTDSTRING IniPath; // default path, just in case
 TSTDSTRING LogDir;
 CIniFile ciniFile;
 bool USBpathSet = false;
 
 void USBsetSettingsDir()
 {
-	if(!USBpathSet)
+	if (!USBpathSet)
 	{
 #ifdef _WIN32
-		IniPath = GetSettingsFolder().Combine( iniFileUSB ).GetFullPath(); // default path, just in case
+		IniPath = GetSettingsFolder().Combine(iniFileUSB).GetFullPath(); // default path, just in case
 #else
-		IniPath = std::string(GetSettingsFolder().Combine( iniFileUSB ).GetFullPath()); // default path, just in case
+		IniPath = std::string(GetSettingsFolder().Combine(iniFileUSB).GetFullPath()); // default path, just in case
 #endif
 		USBpathSet = true;
 	}
@@ -54,7 +54,7 @@ void USBsetLogDir(const char* dir)
 
 std::string GetSelectedAPI(const std::pair<int, std::string>& pair)
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 	auto it = changedAPIs.find(pair);
 	if (it != changedAPIs.end())
 		return it->second;
@@ -63,7 +63,7 @@ std::string GetSelectedAPI(const std::pair<int, std::string>& pair)
 
 bool LoadSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TCHAR* param, TSTDSTRING& value)
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 	CIniKey* key;
 #ifdef _WIN32
 	auto sect = ciniFile.GetSection(section);
@@ -85,7 +85,7 @@ bool LoadSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TC
 
 bool LoadSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TCHAR* param, int32_t& value)
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 	CIniKey* key;
 #ifdef _WIN32
 	auto sect = ciniFile.GetSection(section);
@@ -116,7 +116,7 @@ bool LoadSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TC
 
 bool SaveSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TCHAR* param, const TSTDSTRING& value)
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 #ifdef _WIN32
 	ciniFile.SetKeyValue(section, param, value);
 #else
@@ -127,7 +127,7 @@ bool SaveSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TC
 
 bool SaveSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TCHAR* param, int32_t value)
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 #ifdef _WIN32
 	ciniFile.SetKeyValue(section, param, TSTDTOSTRING(value));
 #else
@@ -138,7 +138,7 @@ bool SaveSettingValue(const TSTDSTRING& ini, const TSTDSTRING& section, const TC
 
 void SaveConfig()
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 #ifdef _WIN32
 	SaveSetting(L"MAIN", L"log", conf.Log);
 #else
@@ -168,7 +168,7 @@ void SaveConfig()
 #ifdef _WIN32
 	bool ret = ciniFile.Save(IniPath);
 #else
-	[[maybe_unused]]bool ret = ciniFile.Save(str_to_wstr(IniPath));
+	[[maybe_unused]] bool ret = ciniFile.Save(str_to_wstr(IniPath));
 #endif
 }
 
@@ -220,7 +220,6 @@ void LoadConfig()
 				const auto& apis = dev->ListAPIs();
 				if (!apis.empty())
 					api = *apis.begin();
-
 			}
 		}
 
@@ -245,7 +244,7 @@ void ClearSection(const TCHAR* section)
 
 void RemoveSection(const char* dev_type, int port, const std::string& key)
 {
-	USBsetSettingsDir();	
+	USBsetSettingsDir();
 	TSTDSTRING tkey;
 	tkey.assign(key.begin(), key.end());
 

--- a/pcsx2/USB/deviceproxy.h
+++ b/pcsx2/USB/deviceproxy.h
@@ -205,7 +205,7 @@ public:
 		return *registerDevice;
 	}
 
-	~RegisterDevice() { }
+	~RegisterDevice() {}
 
 	static void Register();
 	void Unregister();
@@ -222,11 +222,11 @@ public:
 			if(k.first.name == name)
 				return k.second;
 		return nullptr;*/
-		auto proxy = std::find_if(registerDeviceMap.begin(),
-								  registerDeviceMap.end(),
-								  [&name](const RegisterDeviceMap::value_type& val) -> bool {
-									  return val.second->TypeName() == name;
-								  });
+		auto proxy = std::find_if(
+			registerDeviceMap.begin(), registerDeviceMap.end(),
+			[&name](const RegisterDeviceMap::value_type& val) -> bool {
+				return val.second->TypeName() == name;
+			});
 		if (proxy != registerDeviceMap.end())
 			return proxy->second.get();
 		return nullptr;
@@ -243,11 +243,11 @@ public:
 
 	DeviceType Index(const std::string& name)
 	{
-		auto proxy = std::find_if(registerDeviceMap.begin(),
-								  registerDeviceMap.end(),
-								  [&name](RegisterDeviceMap::value_type& val) -> bool {
-									  return val.second->TypeName() == name;
-								  });
+		auto proxy = std::find_if(
+			registerDeviceMap.begin(), registerDeviceMap.end(),
+			[&name](RegisterDeviceMap::value_type& val) -> bool {
+				return val.second->TypeName() == name;
+			});
 		if (proxy != registerDeviceMap.end())
 			return proxy->first;
 		return DEVTYPE_NONE;


### PR DESCRIPTION
Switches to the new clang-format option [`tabs: AlignWithSpaces`](https://bugs.llvm.org/show_bug.cgi?id=38381)

Makes code look much nicer on GitHub (and for anyone who prefers 2-space tabs)

Note: Requires the fairly new clang-format 11