### PR TITLE
GUI: Apply missing recording menu option disablers

### DIFF
--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -363,7 +363,15 @@ namespace Implementations
 		}
 
 		if (g_Conf->GSWindow.CloseOnEsc)
+		{
 			sMainFrame.SetFocus();
+#ifndef DISABLE_RECORDING
+			// Disable recording controls that only make sense if the game is running
+			sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
+			sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
+			sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
+#endif
+		}
 	}
 
 	void Sys_Resume()

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -721,7 +721,15 @@ protected:
 	void InvokeEvent()
 	{
 		if (CoreThread.IsOpen())
+		{
 			CoreThread.Suspend();
+#ifndef DISABLE_RECORDING
+			// Disable recording controls that only make sense if the game is running
+			sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
+			sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
+			sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
+#endif
+		}
 		else
 			CoreThread.Resume();
 	}


### PR DESCRIPTION
Fixes recording keybind menu options not disabling when `pause` is selected or when the `ESC` key is used (a consequence of the "Close All Windows" fix). Once a more long-term fix for it can be done - these can be removed.