### PR TITLE
VIF: Don't start transfer if VIF1/0 is stalled

### DIFF
--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -312,6 +312,6 @@ void dmaVIF0()
 	//Using a delay as Beyond Good and Evil does the DMA twice with 2 different TADR's (no checks in the middle, all one block of code),
 	//the first bit it sends isnt required for it to work.
 	//Also being an end chain it ignores the second lot, this causes infinite loops ;p
-	// Chain Mode
-	CPU_INT(DMAC_VIF0, 4);
+	if (!vif0Regs.stat.test(VIF0_STAT_VSS | VIF0_STAT_VIS | VIF0_STAT_VFS))
+		CPU_INT(DMAC_VIF0, 4);
 }

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -482,6 +482,8 @@ void dmaVIF1()
 
 	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 
-	// Chain Mode
-	CPU_INT(DMAC_VIF1, 4);
+	// Check VIF isn't stalled before starting the loop.
+	// Batman Vengence does something stupid and instead of cancelling a stall it tries to restart VIF, THEN check the stall
+	if (!vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
+		CPU_INT(DMAC_VIF1, 4);
 }

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -322,6 +322,7 @@ void vifMFIFOInterrupt()
 			VIF_LOG("VIF1 MFIFO Stalled qwc = %x done = %x inprogress = %x", vif1ch.qwc, vif1.done, vif1.inprogress & 0x10);
 			//Used to check if the MFIFO was empty, there's really no need if it's finished what it needed.
 			if((vif1ch.qwc > 0 || !vif1.done)) {
+				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF1 MFIFO Stalled");
 				return;
 			}


### PR DESCRIPTION
Also Fix missing VIF status check on MFIFO


Fixes hang in Batman Vengeance, game stalls the VIF during an MFIFO transfer then stops and starts VIF while it's stalled, in the old code this causes it to ignore the stall and continue as normal, this PR fixes that behaviour.
