### PR TITLE
Fix paths on macOS

### DIFF
--- a/cmake/Translation.cmake
+++ b/cmake/Translation.cmake
@@ -52,6 +52,21 @@ MACRO(GETTEXT_CREATE_TRANSLATIONS_PCSX2 _potFile _firstPoFileArg)
         GET_FILENAME_COMPONENT(_gmoBase ${_absFile} NAME_WE)
         GET_FILENAME_COMPONENT(_lang ${_abs_PATH} NAME_WE)
         SET(_gmoFile ${CMAKE_BINARY_DIR}/${_lang}__${_gmoBase}.gmo)
+        IF (APPLE)
+            # CMake doesn't support generator expressions as the OUTPUT of a custom command
+            # Instead, use ${_gmoFile} to detect changes, and output to the bundle as a side effect
+            # In addition, we have have to preprocess the po files to remove mnemonics:
+            # On Windows, menu items have "mnemonics", the items with a letter underlined that you can use with alt to select menu items.  MacOS doesn't do this.
+            # Some languages don't use easily-typable characters, so it's common to add a dedicated character for the mnemonic (e.g. in Japanese on Windows, the File menu would be "ファイル(&F)").
+            # On MacOS, these extra letters in parentheses are useless and should be avoided.
+            SET(_mnemonicless "${CMAKE_BINARY_DIR}/${_lang}__${_gmoBase}.nomnemonic.po")
+            SET(_extraCommands
+                COMMAND sed -e "\"s/[(]&[A-Za-z][)]//g\"" "${_absFile}" > "${_mnemonicless}"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:PCSX2>/../Resources/${_lang}/"
+                COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o "$<TARGET_FILE_DIR:PCSX2>/../Resources/${_lang}/${_potBasename}.mo" ${_mnemonicless})
+        ELSE (APPLE)
+            SET(_extraCommands)
+        ENDIF (APPLE)
 
         IF (_currentPoFile MATCHES "\\.git")
             continue()
@@ -61,10 +76,12 @@ MACRO(GETTEXT_CREATE_TRANSLATIONS_PCSX2 _potFile _firstPoFileArg)
             ADD_CUSTOM_COMMAND( OUTPUT ${_gmoFile}
                 COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --quiet --update --backup=none -s ${_absFile} ${_absPotFile}
                 COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${_gmoFile} ${_absFile}
+                ${_extraCommands}
                 DEPENDS ${_absPotFile} ${_absFile} )
         ELSE (CMAKE_BUILD_PO)
             ADD_CUSTOM_COMMAND( OUTPUT ${_gmoFile}
                 COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${_gmoFile} ${_absFile}
+                ${_extraCommands}
                 DEPENDS ${_absPotFile} ${_absFile} )
         ENDIF (CMAKE_BUILD_PO)
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1025,7 +1025,9 @@ if (APPLE)
 	)
 
 	target_sources(${Output} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/gui/Resources/PCSX2.icns")
+	target_sources(${Output} PRIVATE "${CMAKE_SOURCE_DIR}/bin/GameIndex.yaml")
 	set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/gui/Resources/PCSX2.icns" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+	set_source_files_properties("${CMAKE_SOURCE_DIR}/bin/GameIndex.yaml" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
 	# If they say to skip postprocess bundle, leave the target in but make it so they have
 	# to manually run it

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -244,7 +244,11 @@ namespace PathDefs
 
 	wxDirName GetLangs()
 	{
+#ifdef __APPLE__
+		return wxDirName(wxStandardPaths::Get().GetResourcesDir());
+#else
 		return AppRoot() + Base::Langs();
+#endif
 	}
 
 	wxDirName Get( FoldersEnum_t folderidx )

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -173,7 +173,9 @@ namespace PathDefs
 
 	wxDirName GetProgramDataDir()
 	{
-#ifndef GAMEINDEX_DIR_COMPILATION
+#ifdef __APPLE__
+		return wxDirName(wxStandardPaths::Get().GetResourcesDir());
+#elif !defined(GAMEINDEX_DIR_COMPILATION)
 		return AppRoot();
 #else
 		// Each linux distributions have his rules for path so we give them the possibility to

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -152,7 +152,7 @@ namespace PathDefs
 	{
 		switch( mode )
 		{
-#ifdef XDG_STD
+#if defined(XDG_STD) || defined(__APPLE__) // Expected location for this kind of stuff on macOS
 			// Move all user data file into central configuration directory (XDG_CONFIG_DIR)
 			case DocsFolder_User:	return GetUserLocalDataDir();
 #else

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -742,6 +742,7 @@ Pcsx2App::Pcsx2App()
 		_("Save &As...");
 		_("&Help");
 		_("&Home");
+		_("&Window");
 
 		_("Show about dialog.")
 	}

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -417,6 +417,7 @@ wxMessageOutput* Pcsx2AppTraits::CreateMessageOutput()
 //  Pcsx2StandardPaths
 // --------------------------------------------------------------------------------------
 #ifdef wxUSE_STDPATHS
+#ifndef __APPLE__ // macOS uses wx's defaults
 class Pcsx2StandardPaths : public wxStandardPaths
 {
 public:
@@ -457,11 +458,16 @@ public:
 #endif
 
 };
+#endif // ifdef __APPLE__
 
 wxStandardPaths& Pcsx2AppTraits::GetStandardPaths()
 {
+#ifdef __APPLE__
+	return _parent::GetStandardPaths();
+#else
 	static Pcsx2StandardPaths stdPaths;
 	return stdPaths;
+#endif
 }
 #endif
 

--- a/pcsx2/gui/i18n.cpp
+++ b/pcsx2/gui/i18n.cpp
@@ -362,7 +362,7 @@ void i18n_SetLanguagePath()
 	// default location for windows
 	wxLocale::AddCatalogLookupPathPrefix( wxGetCwd() );
 	// additional location for linux
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
 	wxLocale::AddCatalogLookupPathPrefix( PathDefs::GetLangs().ToString() );
 #endif
 


### PR DESCRIPTION
MacOS was using linux paths rather than wx's macOS-specific subclass, which doesn't match how the app is installed in macOS (all paths should be relative to the executable).  Also adds steps to copy missing resources into the app bundle

Specific changes: 
- Save directory to `~/Library/Application Support`
- Localization files now included
- GameIndex.yaml now included