### PR TITLE
Reorganize and realign InputRecordingControls

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -482,7 +482,7 @@ static __fi void VSyncStart(u32 sCycle)
 	{
 		// It is imperative that any frame locking that must happen occurs before Vsync is started
 		// Not doing so would sacrifice a frame of a savestate-based recording when loading any savestate
-		g_InputRecordingControls.HandleFrameCountLocking();
+		g_InputRecordingControls.HandlePausingAndLocking();
 	}
 #endif
 
@@ -543,7 +543,7 @@ static __fi void VSyncEnd(u32 sCycle)
 #ifndef DISABLE_RECORDING
 	if (g_Conf->EmuOptions.EnableRecordingTools)
 	{
-		g_InputRecordingControls.HandleFrameAdvanceAndPausing();
+		g_InputRecordingControls.CheckPauseStatus();
 	}
 #endif
 

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -186,7 +186,6 @@ void InputRecording::IncrementFrameCounter()
 				incrementUndo = false;
 		}
 	}
-	g_InputRecording.LogAndRedraw();
 }
 
 void InputRecording::LogAndRedraw()

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -54,6 +54,7 @@ void InputRecordingControls::CheckPauseStatus()
 			pauseEmulation = true;
 		}
 	}
+	g_InputRecording.LogAndRedraw();
 }
 
 void InputRecordingControls::HandlePausingAndLocking()

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -31,10 +31,6 @@ InputRecordingControls g_InputRecordingControls;
 
 void InputRecordingControls::CheckPauseStatus()
 {
-	// We do not want to increment/advance anything while the frame lock mechanism is active
-	if (frameLock)
-		return;
-
 	if (frameAdvancing)
 	{
 		frameAdvancing = false;

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -20,14 +20,21 @@
 class InputRecordingControls
 {
 public:
-	// Intended to be called at the end of each frame, but will no-op if the frame count has not
-	// truly incremented
+	// Intended to be called at the end of each frame, but will no-op if frame lock is active
 	//
-	// Increments the input recording's frame counter and will pause emulation if:
+	// Will pause emulation if:
 	// - The InputRecordingControls::FrameAdvance was hit on the previous frame
 	// - Emulation was explicitly paused using InputRecordingControls::TogglePause
 	// - We are replaying an input recording and have hit the end
 	void HandleFrameAdvanceAndPausing();
+
+	// When loading a recording file or booting with a recording active, lock will be enabled.
+	// Emulation will be forced into and remain in a paused state until the transition in progress
+	// has completed - signaled when g_framecount and frameCountTracker are equal
+	//
+	// Additonally, this function will ensure emulation stays paused after loading a savestate
+	void HandleFrameCountLocking();
+
 	// Called much more frequently than HandleFrameAdvanceAndPausing, instead of being per frame
 	// this hooks into pcsx2's main App event handler as it has to be able to resume emulation
 	// when drawing frames has compltely stopped

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -22,18 +22,18 @@ class InputRecordingControls
 public:
 	// Intended to be called at the end of each frame, but will no-op if frame lock is active
 	//
-	// Will pause emulation if:
+	// Will set the pausing parameters for emulation if:
 	// - The InputRecordingControls::FrameAdvance was hit on the previous frame
 	// - Emulation was explicitly paused using InputRecordingControls::TogglePause
 	// - We are replaying an input recording and have hit the end
-	void HandleFrameAdvanceAndPausing();
+	void CheckPauseStatus();
 
 	// When loading a recording file or booting with a recording active, lock will be enabled.
 	// Emulation will be forced into and remain in a paused state until the transition in progress
 	// has completed - signaled when g_framecount and frameCountTracker are equal
 	//
-	// Additonally, this function will ensure emulation stays paused after loading a savestate
-	void HandleFrameCountLocking();
+	// This function also handles actually pausing emulation when told to
+	void HandlePausingAndLocking();
 
 	// Called much more frequently than HandleFrameAdvanceAndPausing, instead of being per frame
 	// this hooks into pcsx2's main App event handler as it has to be able to resume emulation
@@ -58,10 +58,6 @@ public:
 	void PauseImmediately();
 	// Resume emulation when the next pcsx2 App event is handled
 	void Resume();
-	void SetFrameCountTracker(u32 newFrame);
-	// Sets frameAdvancing variable to false
-	// Used to restrict a frameAdvanceTracker value from transferring between recordings
-	void DisableFrameAdvance();
 	// Alternates emulation between a paused and unpaused state
 	void TogglePause();
 	// Switches between recording and replaying the active input recording file
@@ -77,10 +73,6 @@ private:
 	// Indicates on the next VSync if we are frame advancing, this value
 	// and should be cleared once a single frame has passed
 	bool frameAdvancing = false;
-	// The input recording frame that frame advancing began on
-	s32 frameAdvanceMarker = 0;
-	// Used to detect if the internal PCSX2 g_FrameCount has changed
-	u32 frameCountTracker = -1;
 	// Indicates if we intend to call CoreThread.PauseSelf() on the current or next available vsync
 	bool pauseEmulation = false;
 	// Indicates if we intend to call CoreThread.Resume() when the next pcsx2 App event is handled
@@ -89,6 +81,8 @@ private:
 	bool switchToReplay = false;
 	// Used to stop recording frames from incrementing during a reset
 	bool frameLock = false;
+	// The frame value to use as the frame lock reset point
+	u32 frameLockTracker = 0;
 };
 
 extern InputRecordingControls g_InputRecordingControls;

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1183,7 +1183,10 @@ void Pcsx2App::SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override
 {
 	SysExecutorThread.PostEvent( new SysExecEvent_Execute(cdvdsrc, elf_override) );
 #ifndef DISABLE_RECORDING
-	g_InputRecording.RecordingReset();
+	if (g_Conf->EmuOptions.EnableRecordingTools)
+	{
+		g_InputRecording.RecordingReset();
+	}
 #endif
 }
 


### PR DESCRIPTION
Splits the checking of pause status and the actual pausing of emulation to separate functions called at different points during VSync. `VSyncEnd` is called once per frame, so checking for `g_FrameCount` increments is no longer required.