### PR TITLE
DEV9: Cancel read of TAP device on suspend/shutdown

### DIFF
--- a/pcsx2/DEV9/Win32/tap-win32.cpp
+++ b/pcsx2/DEV9/Win32/tap-win32.cpp
@@ -271,6 +271,9 @@ TAPAdapter::TAPAdapter()
 	write.Offset = 0;
 	write.OffsetHigh = 0;
 	write.hEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+	cancel = CreateEvent(NULL, TRUE, FALSE, NULL);
+
 	isActive = true;
 }
 
@@ -298,9 +301,20 @@ bool TAPAdapter::recv(NetPacket* pkt)
 		DWORD dwError = GetLastError();
 		if (dwError == ERROR_IO_PENDING)
 		{
-			WaitForSingleObject(read.hEvent, INFINITE);
-			result = GetOverlappedResult(htap, &read,
-										 &read_size, FALSE);
+			HANDLE readHandles[]{read.hEvent, cancel};
+			const DWORD waitResult = WaitForMultipleObjects(2, readHandles, FALSE, INFINITE);
+
+			if (waitResult == WAIT_OBJECT_0 + 1)
+			{
+				CancelIo(htap);
+				//Wait for the I/O subsystem to acknowledge our cancellation
+				result = GetOverlappedResult(htap, &read,
+											 &read_size, TRUE);
+			}
+			else
+				result = GetOverlappedResult(htap, &read,
+											 &read_size, FALSE);
+
 			if (!result)
 			{
 			}
@@ -367,12 +381,17 @@ bool TAPAdapter::send(NetPacket* pkt)
 	else
 		return false;
 }
+void TAPAdapter::close()
+{
+	SetEvent(cancel);
+}
 TAPAdapter::~TAPAdapter()
 {
 	if (!isActive)
 		return;
 	CloseHandle(read.hEvent);
 	CloseHandle(write.hEvent);
+	CloseHandle(cancel);
 	TAPSetStatus(htap, FALSE);
 	CloseHandle(htap);
 	isActive = false;

--- a/pcsx2/DEV9/Win32/tap-win32.cpp
+++ b/pcsx2/DEV9/Win32/tap-win32.cpp
@@ -312,13 +312,6 @@ bool TAPAdapter::recv(NetPacket* pkt)
 			}
 			else
 				result = GetOverlappedResult(htap, &read, &read_size, FALSE);
-
-			if (!result)
-			{
-			}
-		}
-		else
-		{
 		}
 	}
 
@@ -359,13 +352,6 @@ bool TAPAdapter::send(NetPacket* pkt)
 		{
 			WaitForSingleObject(write.hEvent, INFINITE);
 			result = GetOverlappedResult(htap, &write, &writen, FALSE);
-
-			if (!result)
-			{
-			}
-		}
-		else
-		{
 		}
 	}
 

--- a/pcsx2/DEV9/Win32/tap-win32.cpp
+++ b/pcsx2/DEV9/Win32/tap-win32.cpp
@@ -308,12 +308,10 @@ bool TAPAdapter::recv(NetPacket* pkt)
 			{
 				CancelIo(htap);
 				//Wait for the I/O subsystem to acknowledge our cancellation
-				result = GetOverlappedResult(htap, &read,
-											 &read_size, TRUE);
+				result = GetOverlappedResult(htap, &read, &read_size, TRUE);
 			}
 			else
-				result = GetOverlappedResult(htap, &read,
-											 &read_size, FALSE);
+				result = GetOverlappedResult(htap, &read, &read_size, FALSE);
 
 			if (!result)
 			{
@@ -360,8 +358,8 @@ bool TAPAdapter::send(NetPacket* pkt)
 		if (dwError == ERROR_IO_PENDING)
 		{
 			WaitForSingleObject(write.hEvent, INFINITE);
-			result = GetOverlappedResult(htap, &write,
-										 &writen, FALSE);
+			result = GetOverlappedResult(htap, &write, &writen, FALSE);
+
 			if (!result)
 			{
 			}

--- a/pcsx2/DEV9/Win32/tap.h
+++ b/pcsx2/DEV9/Win32/tap.h
@@ -29,6 +29,7 @@ class TAPAdapter : public NetAdapter
 {
 	HANDLE htap;
 	OVERLAPPED read, write;
+	HANDLE cancel;
 	bool isActive = false;
 
 public:
@@ -39,5 +40,6 @@ public:
 	virtual bool recv(NetPacket* pkt);
 	//sends the packet and deletes it when done (if successful).rv :true success
 	virtual bool send(NetPacket* pkt);
+	virtual void close();
 	virtual ~TAPAdapter();
 };

--- a/pcsx2/DEV9/net.cpp
+++ b/pcsx2/DEV9/net.cpp
@@ -73,6 +73,7 @@ void TermNet()
 	if (RxRunning)
 	{
 		RxRunning = false;
+		nif->close();
 		emu_printf("Waiting for RX-net thread to terminate..");
 		rx_thread.join();
 		emu_printf(".done\n");

--- a/pcsx2/DEV9/net.h
+++ b/pcsx2/DEV9/net.h
@@ -41,6 +41,7 @@ public:
 	virtual bool isInitialised() = 0;
 	virtual bool recv(NetPacket* pkt) = 0; //gets a packet
 	virtual bool send(NetPacket* pkt) = 0; //sends the packet and deletes it when done
+	virtual void close() {}
 	virtual ~NetAdapter() {}
 };
 


### PR DESCRIPTION
As above, only deals with the issue on windows.
winPcap (and thus Linux) needs to be looked at separately (and also isn't fixed on CLR_DEV9)

The implementation of the fix differs from what CLR_DEV9 does as I mostly used C#'s filestream, instead of direct Win32 calls.

This should speed up closing rx thread significantly.

I've only done minimal testing, just fyi

