### PR TITLE
Add option to throw memory-related exceptions from recompiler

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -259,6 +259,10 @@ struct Pcsx2Config
 				PreBlockCheckIOP:1;
 			bool
 				EnableEECache   :1;
+
+			bool
+				ThrowAddressExceptions : 1;
+
 		BITFIELD_END
 
 		RecompilerOptions();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -132,6 +132,8 @@ Pcsx2Config::RecompilerOptions::RecompilerOptions()
 	fpuOverflow	= true;
 	//fpuExtraOverflow = false;
 	//fpuFullMode = false;
+
+	ThrowAddressExceptions = false;
 }
 
 void Pcsx2Config::RecompilerOptions::ApplySanityCheck()
@@ -192,6 +194,8 @@ void Pcsx2Config::RecompilerOptions::LoadSave( IniInterface& ini )
 	IniBitBool( StackFrameChecks );
 	IniBitBool( PreBlockCheckEE );
 	IniBitBool( PreBlockCheckIOP );
+
+	IniBitBool(ThrowAddressExceptions);
 }
 
 Pcsx2Config::CpuOptions::CpuOptions()

--- a/pcsx2/R5900Exceptions.h
+++ b/pcsx2/R5900Exceptions.h
@@ -30,6 +30,7 @@ class BaseR5900Exception : public Exception::Ps2Generic
 
 public:
 	cpuRegisters cpuState;
+	bool fatal = false;
 
 public:
 	u32 GetPc() const { return cpuState.pc; }

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -662,7 +662,7 @@ void AppCoreThread::DoCpuExecute()
 
 		// [TODO] : Debugger Hook!
 
-		if (++m_except_threshold > 6)
+		if (ex.fatal || ++m_except_threshold > 6)
 		{
 			// If too many TLB Misses occur, we're probably going to crash and
 			// the game is probably running miserably.

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -408,7 +408,7 @@ static __ri void vtlb_Miss(u32 addr,u32 mode)
 		throw Exception::CancelInstruction();
 	}
 
-	if( IsDevBuild )
+	if (IsDevBuild || EmuConfig.Cpu.Recompiler.ThrowAddressExceptions)
 		Cpu->ThrowCpuException( R5900Exception::TLBMiss( addr, !!mode ) );
 	else
 	{

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -409,7 +409,11 @@ static __ri void vtlb_Miss(u32 addr,u32 mode)
 	}
 
 	if (IsDevBuild || EmuConfig.Cpu.Recompiler.ThrowAddressExceptions)
-		Cpu->ThrowCpuException( R5900Exception::TLBMiss( addr, !!mode ) );
+	{
+		R5900Exception::TLBMiss ex(addr, !!mode);
+		ex.fatal = EmuConfig.Cpu.Recompiler.ThrowAddressExceptions;
+		Cpu->ThrowCpuException(ex);
+	}
 	else
 	{
 		static int spamStop = 0;

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -96,12 +96,18 @@ __aligned16 u32 dummyValue[4];
 
 void __fastcall throwReadAddressErrorException(u32 addr)
 {
-	Cpu->ThrowCpuException(::R5900Exception::AddressError(addr, false));
+	R5900Exception::AddressError ex(addr, false);
+	ex.fatal = true;
+
+	Cpu->ThrowCpuException(ex);
 }
 
 void __fastcall throwWriteAddressErrorException(u32 addr)
 {
-	Cpu->ThrowCpuException(::R5900Exception::AddressError(addr, true));
+	R5900Exception::AddressError ex(addr, true);
+	ex.fatal = true;
+
+	Cpu->ThrowCpuException(ex);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In some cases it can be useful to know when a game triggers invalid behavior, like unaligned memory access or TLB misses, that would crash a real system. This pull request adds a new option `Cpu.Recompiler.ThrowAddressExceptions` to achieve that. It can only be edited through the .ini file and is disabled by default.

TLB miss  exceptions were already thrown in developer builds, this is extended to when the new option is set. Loads and stores didn't check for unaligned access, so these checks are added. They are only written into the recompiled code if the option is enabled. Furthermore, as you explicitly opt-in to receive these exceptions, you definitely want to notice them - so any exceptions thrown due to the option are treated as immediately fatal.