### PR TITLE
Capture: Optimizations with file names, SPU2 recording, and capture menu gui

### DIFF
--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -134,8 +134,8 @@ void CALLBACK GSsetGameCRC(int crc, int gameoptions);
 void CALLBACK GSsetFrameSkip(int frameskip);
 
 // Starts recording GS frame data
-// returns a non zero value if successful
-int CALLBACK GSsetupRecording(std::string& filename);
+// returns true if successful
+bool CALLBACK GSsetupRecording(std::string& filename);
 
 // Stops recording GS frame data
 void CALLBACK GSendRecording();
@@ -185,7 +185,7 @@ typedef void(CALLBACK *_GSsetGameCRC)(int, int);
 typedef void(CALLBACK *_GSsetFrameSkip)(int frameskip);
 typedef void(CALLBACK *_GSsetVsync)(int enabled);
 typedef void(CALLBACK *_GSsetExclusive)(int isExclusive);
-typedef int(CALLBACK* _GSsetupRecording)(std::string&);
+typedef bool(CALLBACK* _GSsetupRecording)(std::string&);
 typedef void(CALLBACK* _GSendRecording)();
 typedef void(CALLBACK *_GSreset)();
 typedef void(CALLBACK *_GSwriteCSR)(u32 value);

--- a/common/include/PS2Edefs.h
+++ b/common/include/PS2Edefs.h
@@ -133,10 +133,12 @@ void CALLBACK GSsetGameCRC(int crc, int gameoptions);
 // controls frame skipping in the GS, if this routine isn't present, frame skipping won't be done
 void CALLBACK GSsetFrameSkip(int frameskip);
 
-// if start is 1, starts recording spu2 data, else stops
+// Starts recording GS frame data
 // returns a non zero value if successful
-// for now, pData is not used
-int CALLBACK GSsetupRecording(int start, void *pData);
+int CALLBACK GSsetupRecording(std::string& filename);
+
+// Stops recording GS frame data
+void CALLBACK GSendRecording();
 
 void CALLBACK GSreset();
 //deprecated: GSgetTitleInfo was used in PCSX2 but no plugin supported it prior to r4070:
@@ -183,7 +185,8 @@ typedef void(CALLBACK *_GSsetGameCRC)(int, int);
 typedef void(CALLBACK *_GSsetFrameSkip)(int frameskip);
 typedef void(CALLBACK *_GSsetVsync)(int enabled);
 typedef void(CALLBACK *_GSsetExclusive)(int isExclusive);
-typedef std::wstring*(CALLBACK *_GSsetupRecording)(int);
+typedef int(CALLBACK* _GSsetupRecording)(std::string&);
+typedef void(CALLBACK* _GSendRecording)();
 typedef void(CALLBACK *_GSreset)();
 typedef void(CALLBACK *_GSwriteCSR)(u32 value);
 typedef bool(CALLBACK *_GSmakeSnapshot)(const char *path);
@@ -220,6 +223,7 @@ extern _GSsetGameCRC GSsetGameCRC;
 extern _GSsetFrameSkip GSsetFrameSkip;
 extern _GSsetVsync GSsetVsync;
 extern _GSsetupRecording GSsetupRecording;
+extern _GSendRecording GSendRecording;
 extern _GSreset GSreset;
 extern _GSwriteCSR GSwriteCSR;
 #endif

--- a/pcsx2/PluginManager.cpp
+++ b/pcsx2/PluginManager.cpp
@@ -177,6 +177,7 @@ _GSsetFrameSkip		GSsetFrameSkip;
 _GSsetVsync			GSsetVsync;
 _GSsetExclusive		GSsetExclusive;
 _GSsetupRecording	GSsetupRecording;
+_GSendRecording		GSendRecording;
 _GSreset			GSreset;
 _GSwriteCSR			GSwriteCSR;
 #endif
@@ -316,6 +317,7 @@ static const LegacyApi_OptMethod s_MethMessOpt_GS[] =
 	{	"GSopen2",			(vMeth**)&GSopen2			},
 	{	"GSreset",			(vMeth**)&GSreset			},
 	{	"GSsetupRecording",	(vMeth**)&GSsetupRecording	},
+	{	"GSendRecording",	(vMeth**)&GSendRecording	},
 	{	"GSmakeSnapshot2",	(vMeth**)&GSmakeSnapshot2	},
 	{	"GSgifSoftReset",	(vMeth**)&GSgifSoftReset	},
 	{	"GSreadFIFO",		(vMeth**)&GSreadFIFO		},

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -682,7 +682,7 @@ extern SndOutModule* mods[];
 
 extern bool WavRecordEnabled;
 
-extern void RecordStart(std::wstring* filename);
+extern int RecordStart(const std::string* filename);
 extern void RecordStop();
 extern void RecordWrite(const StereoOut16& sample);
 

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -682,7 +682,7 @@ extern SndOutModule* mods[];
 
 extern bool WavRecordEnabled;
 
-extern int RecordStart(const std::string* filename);
+extern bool RecordStart(const std::string* filename);
 extern void RecordStop();
 extern void RecordWrite(const StereoOut16& sample);
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -110,7 +110,7 @@ bool WavRecordEnabled = false;
 static WavOutFile* m_wavrecord = nullptr;
 static Mutex WavRecordMutex;
 
-int RecordStart(const std::string* filename)
+bool RecordStart(const std::string* filename)
 {
 	try
 	{
@@ -121,16 +121,16 @@ int RecordStart(const std::string* filename)
 		else
 			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
 		WavRecordEnabled = true;
-		return 1;
+		return true;
 	}
 	catch (std::runtime_error&)
 	{
 		m_wavrecord = nullptr; // not needed, but what the heck. :)
 		if (filename)
-			SysMessage("SPU2-X couldn't open file for recording: %s.\nWavfile capture disabled.", filename->c_str());
+			SysMessage("SPU2 couldn't open file for recording: %s.\nWavfile capture disabled.", filename->c_str());
 		else
-			SysMessage("SPU2-X couldn't open file for recording: audio_recording.wav.\nWavfile capture disabled.");
-		return 0;
+			SysMessage("SPU2 couldn't open file for recording: audio_recording.wav.\nWavfile capture disabled.");
+		return false;
 	}
 }
 

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -110,28 +110,27 @@ bool WavRecordEnabled = false;
 static WavOutFile* m_wavrecord = nullptr;
 static Mutex WavRecordMutex;
 
-void RecordStart(std::wstring* filename)
+int RecordStart(const std::string* filename)
 {
-	WavRecordEnabled = false;
-
 	try
 	{
 		ScopedLock lock(WavRecordMutex);
 		safe_delete(m_wavrecord);
-#ifdef _WIN32
 		if (filename)
-			m_wavrecord = new WavOutFile((*filename) + "wav", 48000, 16, 2);
+			m_wavrecord = new WavOutFile(filename->c_str(), 48000, 16, 2);
 		else
 			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
-#elif defined(__unix__)
-		m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
-#endif
 		WavRecordEnabled = true;
+		return 1;
 	}
 	catch (std::runtime_error&)
 	{
 		m_wavrecord = nullptr; // not needed, but what the heck. :)
-		SysMessage("SPU2 couldn't open file for recording: %s.\nRecording to wavfile disabled.", "audio_recording.wav");
+		if (filename)
+			SysMessage("SPU2-X couldn't open file for recording: %s.\nWavfile capture disabled.", filename->c_str());
+		else
+			SysMessage("SPU2-X couldn't open file for recording: audio_recording.wav.\nWavfile capture disabled.");
+		return 0;
 	}
 }
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -579,7 +579,7 @@ void SPU2write(u32 rmem, u16 value)
 }
 
 // returns a non zero value if successful
-int SPU2setupRecording(const std::string* filename)
+bool SPU2setupRecording(const std::string* filename)
 {
 	return RecordStart(filename);
 }

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -578,17 +578,16 @@ void SPU2write(u32 rmem, u16 value)
 	}
 }
 
-// if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
-// for now, pData is not used
-int SPU2setupRecording(int start, std::wstring* filename)
+int SPU2setupRecording(const std::string* filename)
 {
-	if (start == 0)
-		RecordStop();
-	else if (start == 1)
-		RecordStart(filename);
+	return RecordStart(filename);
+}
 
-	return 0;
+void SPU2endRecording()
+{
+	if (WavRecordEnabled)
+		RecordStop();
 }
 
 s32 SPU2freeze(int mode, freezeData* data)

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -31,10 +31,9 @@ void SPU2write(u32 mem, u16 value);
 u16 SPU2read(u32 mem);
 
 // extended funcs
-// if start is 1, starts recording spu2 data, else stops
 // returns a non zero value if successful
-// for now, pData is not used
-int SPU2setupRecording(int start, std::wstring* filename);
+int SPU2setupRecording(const std::string* filename);
+void SPU2endRecording();
 
 void SPU2setClockPtr(u32* ptr);
 

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -31,8 +31,8 @@ void SPU2write(u32 mem, u16 value);
 u16 SPU2read(u32 mem);
 
 // extended funcs
-// returns a non zero value if successful
-int SPU2setupRecording(const std::string* filename);
+// returns true if successful
+bool SPU2setupRecording(const std::string* filename);
 void SPU2endRecording();
 
 void SPU2setClockPtr(u32* ptr);

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -193,6 +193,7 @@ enum MenuIdentifiers
 	MenuId_Capture_Video,
 	MenuId_Capture_Video_Record,
 	MenuId_Capture_Video_Stop,
+	MenuId_Capture_Video_IncludeAudio,
 	MenuId_Capture_Screenshot,
 	MenuId_Capture_Screenshot_Screenshot,
 	MenuId_Capture_Screenshot_Screenshot_As,

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -680,9 +680,9 @@ void AppConfig::LoadSave( IniInterface& ini )
 	GSWindow		.LoadSave( ini );
 	Framerate		.LoadSave( ini );
 #ifndef DISABLE_RECORDING
-	inputRecording	.loadSave( ini );
+	inputRecording.loadSave(ini);
 #endif
-	AudioCapture	.LoadSave( ini );
+	AudioCapture.LoadSave( ini );
 	Templates		.LoadSave( ini );
 
 	ini.Flush();

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -680,8 +680,9 @@ void AppConfig::LoadSave( IniInterface& ini )
 	GSWindow		.LoadSave( ini );
 	Framerate		.LoadSave( ini );
 #ifndef DISABLE_RECORDING
-	inputRecording.loadSave(ini);
+	inputRecording	.loadSave( ini );
 #endif
+	AudioCapture	.LoadSave( ini );
 	Templates		.LoadSave( ini );
 
 	ini.Flush();
@@ -953,6 +954,18 @@ void AppConfig::FramerateOptions::LoadSave( IniInterface& ini )
 
 	IniEntry( SkipOnLimit );
 	IniEntry( SkipOnTurbo );
+}
+
+AppConfig::CaptureOptions::CaptureOptions()
+{
+	EnableAudio = true;
+}
+
+void AppConfig::CaptureOptions::LoadSave(IniInterface& ini)
+{
+	ScopedIniGroup path(ini, L"Capture");
+
+	IniEntry( EnableAudio );
 }
 
 AppConfig::UiTemplateOptions::UiTemplateOptions()

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -287,7 +287,7 @@ public:
 
 	struct CaptureOptions
 	{
-		bool					EnableAudio;
+		bool EnableAudio;
 
 		CaptureOptions();
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -285,6 +285,15 @@ public:
 #endif
 	};
 
+	struct CaptureOptions
+	{
+		bool					EnableAudio;
+
+		CaptureOptions();
+
+		void LoadSave(IniInterface& conf);
+	};
+
 public:
 	wxPoint		MainGuiPosition;
 
@@ -361,6 +370,7 @@ public:
 	InputRecordingOptions   inputRecording;
 #endif
 	UiTemplateOptions		Templates;
+	CaptureOptions			AudioCapture;
 	
 	// PCSX2-core emulation options, which are passed to the emu core prior to initiating
 	// an emulation session.  Note these are the options saved into the GUI ini file and

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -476,15 +476,19 @@ namespace Implementations
 				// GSsetupRecording can be aborted/canceled by the user. Don't go on to record the audio if that happens.
 				std::string filename;
 				if (GSsetupRecording(filename))
-					// Note: Add a dialog box here (or in the function) that prompts the user to answer whether a failed
-					// SPU2 recording setup should still lead to the visuals being recorded.
-					SPU2setupRecording(&filename);
+				{
+					if (g_Conf->AudioCapture.EnableAudio && !SPU2setupRecording(&filename))
+					{
+						GSendRecording();
+						g_Pcsx2Recording = false;
+					}
+				}
 				else // recording dialog canceled by the user. align our state
 					g_Pcsx2Recording = false;
 			}
 			// the GS doesn't support recording
-			else
-				g_Pcsx2Recording = SPU2setupRecording(nullptr);
+			else if (!g_Conf->AudioCapture.EnableAudio || !SPU2setupRecording(nullptr))
+				g_Pcsx2Recording = false;
 
 			if (GetMainFramePtr() && needsMainFrameEnable)
 				GetMainFramePtr()->Enable();
@@ -494,7 +498,8 @@ namespace Implementations
 			// stop recording
 			if (GSendRecording)
 				GSendRecording();
-			SPU2endRecording();
+			if (g_Conf->AudioCapture.EnableAudio)
+				SPU2endRecording();
 		}
 	}
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -289,8 +289,8 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Debug_Open_Click, this, MenuId_Debug_Open);
 
 	// Capture
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Record_Click, this, MenuId_Capture_Video_Record);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_Stop_Click, this, MenuId_Capture_Video_Stop);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click, this, MenuId_Capture_Video_Record);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click, this, MenuId_Capture_Video_Stop);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click, this, MenuId_Capture_Screenshot_Screenshot);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click, this, MenuId_Capture_Screenshot_Screenshot_As);
 
@@ -573,6 +573,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 
 {
 	m_RestartEmuOnDelete = false;
+	m_capturingVideo = false;
 
 	for (int i = 0; i < PluginId_Count; ++i)
 		m_PluginMenuPacks[i].Populate((PluginsEnum_t)i);

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -291,6 +291,7 @@ void MainEmuFrame::ConnectMenus()
 	// Capture
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click, this, MenuId_Capture_Video_Record);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click, this, MenuId_Capture_Video_Stop);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Video_IncludeAudio_Click, this, MenuId_Capture_Video_IncludeAudio);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click, this, MenuId_Capture_Screenshot_Screenshot);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click, this, MenuId_Capture_Screenshot_Screenshot_As);
 
@@ -492,9 +493,14 @@ void MainEmuFrame::CreateCaptureMenu()
 {
 	m_menuCapture.Append(MenuId_Capture_Video, _("Video"), &m_submenuVideoCapture);
 	// Implement custom hotkeys (F12) with translatable string intact + not blank in GUI.
-	wxMenuItem* sysVideoCaptureItem = m_submenuVideoCapture.Append(MenuId_Capture_Video_Record, _("Start Screenrecorder"));
+	wxMenuItem* sysVideoCaptureItem = m_submenuVideoCapture.Append(MenuId_Capture_Video_Record, _("Start Video Capture"));
 	AppendShortcutToMenuOption(*sysVideoCaptureItem, wxGetApp().GlobalAccels->findKeycodeWithCommandId("Sys_RecordingToggle").toTitleizedString());
-	m_submenuVideoCapture.Append(MenuId_Capture_Video_Stop, _("Stop Screenrecorder"))->Enable(false);
+	sysVideoCaptureItem = m_submenuVideoCapture.Append(MenuId_Capture_Video_Stop, _("Stop Video Capture"));
+	sysVideoCaptureItem->Enable(false);
+	AppendShortcutToMenuOption(*sysVideoCaptureItem, wxGetApp().GlobalAccels->findKeycodeWithCommandId("Sys_RecordingToggle").toTitleizedString());
+	m_submenuVideoCapture.AppendSeparator();
+	m_submenuVideoCapture.Append(MenuId_Capture_Video_IncludeAudio, _("Include Audio"),
+		_("Enables/disables the creation of a synchronized wav audio file when capturing video footage."), wxITEM_CHECK);
 	// Implement custom hotkeys (F8) + (Shift + F8) + (Ctrl + Shift + F8) with translatable string intact + not blank in GUI.
 	// Fixme: GlobalCommands.cpp L1029-L1031 is having issues because FrameForGS already maps the hotkey first.
 	// Fixme: When you uncomment L1029-L1031 on that file; Linux says that Ctrl is already used for something else and will append (Shift + F8) while Windows will (Ctrl + Shift + F8)
@@ -809,6 +815,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 		menubar.Check(MenuId_EnableCheats, configToApply.EmuOptions.EnableCheats);
 		menubar.Check(MenuId_IPC_Enable, configToApply.EmuOptions.EnableIPC);
 		menubar.Check(MenuId_EnableWideScreenPatches, configToApply.EmuOptions.EnableWideScreenPatches);
+		menubar.Check(MenuId_Capture_Video_IncludeAudio, configToApply.AudioCapture.EnableAudio);
 #ifndef DISABLE_RECORDING
 		menubar.Check(MenuId_EnableInputRecording, configToApply.EmuOptions.EnableRecordingTools);
 #endif

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -172,6 +172,7 @@ public:
 	void CommitPreset_noTrigger();
 	void AppendShortcutToMenuOption(wxMenuItem& item, wxString keyCodeStr);
 	void UpdateStatusBar();
+	void VideoCaptureToggle();
 #ifndef DISABLE_RECORDING
 	void initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable = true);
 	void enableRecordingMenuItem(MenuIdentifiers menuId, bool enable);
@@ -252,9 +253,7 @@ protected:
 	void Menu_Wiki(wxCommandEvent& event);
 	void Menu_ShowAboutBox(wxCommandEvent& event);
 
-	void Menu_Capture_Video_Record_Click(wxCommandEvent& event);
-	void Menu_Capture_Video_Stop_Click(wxCommandEvent& event);
-	void VideoCaptureUpdate();
+	void Menu_Capture_Video_ToggleCapture_Click(wxCommandEvent& event);
 	void Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& event);
 	void Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& event);
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -254,6 +254,7 @@ protected:
 	void Menu_ShowAboutBox(wxCommandEvent& event);
 
 	void Menu_Capture_Video_ToggleCapture_Click(wxCommandEvent& event);
+	void Menu_Capture_Video_IncludeAudio_Click(wxCommandEvent& event);
 	void Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& event);
 	void Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& event);
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -758,6 +758,8 @@ void MainEmuFrame::Menu_SuspendResume_Click(wxCommandEvent& event)
 
 void MainEmuFrame::Menu_SysShutdown_Click(wxCommandEvent& event)
 {
+	if (m_capturingVideo)
+		VideoCaptureToggle();
 	UI_DisableSysShutdown();
 	Console.SetTitle("PCSX2 Program Log");
 	CoreThread.Reset();
@@ -855,6 +857,12 @@ void MainEmuFrame::Menu_Capture_Video_ToggleCapture_Click(wxCommandEvent& event)
 	VideoCaptureToggle();
 }
 
+void MainEmuFrame::Menu_Capture_Video_IncludeAudio_Click(wxCommandEvent& event)
+{
+	g_Conf->AudioCapture.EnableAudio = GetMenuBar()->IsChecked(MenuId_Capture_Video_IncludeAudio);
+	ApplySettings();
+}
+
 void MainEmuFrame::VideoCaptureToggle()
 {
 	GetMTGS().WaitGS(); // make sure GS is in sync with the audio stream when we start.
@@ -878,30 +886,31 @@ void MainEmuFrame::VideoCaptureToggle()
 			std::string filename;
 			if (GSsetupRecording(filename))
 			{
-				// Note: Add a dialog box here (or in the function) that prompts the user to answer whether a failed
-				// SPU2 recording setup should still lead to the visuals being recorded.
-				SPU2setupRecording(&filename);
-				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
-				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
+				if (!g_Conf->AudioCapture.EnableAudio || SPU2setupRecording(&filename))
+				{
+					m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
+					m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
+					m_submenuVideoCapture.Enable(MenuId_Capture_Video_IncludeAudio, false);
+				}
+				else
+				{
+					GSendRecording();
+					m_capturingVideo = false;
+				}
 			}
-			else
-			{
-				// recording dialog canceled by the user. align our state
+			else // recording dialog canceled by the user. align our state
 				m_capturingVideo = false;
-			}
+		}
+		// the GS doesn't support recording
+		else if (g_Conf->AudioCapture.EnableAudio && SPU2setupRecording(nullptr))
+		{
+			m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
+			m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
+			m_submenuVideoCapture.Enable(MenuId_Capture_Video_IncludeAudio, false);
 		}
 		else
-		{
-			// the GS doesn't support recording.
-			if (SPU2setupRecording(nullptr))
-			{
-				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, false);
-				m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, true);
-			}
-			else
-				m_capturingVideo = false;
-		}
-
+			m_capturingVideo = false;
+		
 		if (needsMainFrameEnable)
 			Enable();
 	}
@@ -910,9 +919,11 @@ void MainEmuFrame::VideoCaptureToggle()
 		// stop recording
 		if (GSendRecording)
 			GSendRecording();
-		SPU2endRecording();
+		if (g_Conf->AudioCapture.EnableAudio)
+			SPU2endRecording();
 		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Record, true);
 		m_submenuVideoCapture.Enable(MenuId_Capture_Video_Stop, false);
+		m_submenuVideoCapture.Enable(MenuId_Capture_Video_IncludeAudio, true);
 	}
 }
 

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -811,28 +811,28 @@ void pt(const char* str){
 	printf("%02i:%02i:%02i%s", current->tm_hour, current->tm_min, current->tm_sec, str);
 }
 
-EXPORT_C_(int) GSsetupRecording(std::string& filename)
+EXPORT_C_(bool) GSsetupRecording(std::string& filename)
 {
 	if (s_gs == NULL) {
 		printf("GSdx: no s_gs for recording\n");
-		return 0;
+		return false;
 	}
 #if defined(__unix__) || defined(__APPLE__)
 	if (!theApp.GetConfigB("capture_enabled")) {
 		printf("GSdx: Recording is disabled\n");
-		return 0;
+		return false;
 	}
 #endif
 	printf("GSdx: Recording start command\n");
 	if (s_gs->BeginCapture(filename))
 	{
 		pt(" - Capture started\n");
-		return 1;
+		return true;
 	}
 	else
 	{
 		pt(" - Capture cancelled\n");
-		return 0;
+		return false;
 	}
 }
 

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -404,7 +404,7 @@ GSCapture::~GSCapture()
 	EndCapture();
 }
 
-std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float aspect)
+int GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::string& filename)
 {
 	printf("Recommended resolution: %d x %d, DAR for muxing: %.4f\n", recommendedResolution.x, recommendedResolution.y, aspect);
 	std::lock_guard<std::recursive_mutex> lock(m_lock);
@@ -418,10 +418,10 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	GSCaptureDlg dlg;
 
 	if (IDOK != dlg.DoModal())
-		return nullptr;
+		return 0;
 
 	{
-		int start = dlg.m_filename.length() - 4;
+		const int start = dlg.m_filename.length() - 4;
 		if (start > 0)
 		{
 			std::string test = dlg.m_filename.substr(start);
@@ -438,11 +438,11 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 		else
 		{
 			dlg.InvalidFile();
-			return nullptr;
+			return 0;
 		}
 	}
 
-	std::wstring fn{dlg.m_filename.begin(), dlg.m_filename.end()};
+	;
 
 	m_size.x = (dlg.m_width + 7) & ~7;
 	m_size.y = (dlg.m_height + 7) & ~7;
@@ -456,9 +456,9 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	if(FAILED(hr = m_graph.CoCreateInstance(CLSID_FilterGraph))
 	|| FAILED(hr = cgb.CoCreateInstance(CLSID_CaptureGraphBuilder2))
 	|| FAILED(hr = cgb->SetFiltergraph(m_graph))
-	|| FAILED(hr = cgb->SetOutputFileName(&MEDIASUBTYPE_Avi, fn.c_str(), &mux, NULL)))
+	|| FAILED(hr = cgb->SetOutputFileName(&MEDIASUBTYPE_Avi, std::wstring(dlg.m_filename.begin(), dlg.m_filename.end()).c_str(), &mux, NULL)))
 	{
-		return nullptr;
+		return 0;
 	}
 
 	m_src = new GSSource(m_size.x, m_size.y, fps, NULL, hr, dlg.m_colorspace);
@@ -466,22 +466,22 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	if (dlg.m_enc==0)
 	{
 		if (FAILED(hr = m_graph->AddFilter(m_src, L"Source")))
-			return nullptr;
+			return 0;
 		if (FAILED(hr = m_graph->ConnectDirect(GetFirstPin(m_src, PINDIR_OUTPUT), GetFirstPin(mux, PINDIR_INPUT), NULL)))
-			return nullptr;
+			return 0;
 	}
 	else
 	{
 		if(FAILED(hr = m_graph->AddFilter(m_src, L"Source"))
 		|| FAILED(hr = m_graph->AddFilter(dlg.m_enc, L"Encoder")))
 		{
-			return nullptr;
+			return 0;
 		}
 
 		if(FAILED(hr = m_graph->ConnectDirect(GetFirstPin(m_src, PINDIR_OUTPUT), GetFirstPin(dlg.m_enc, PINDIR_INPUT), NULL))
 		|| FAILED(hr = m_graph->ConnectDirect(GetFirstPin(dlg.m_enc, PINDIR_OUTPUT), GetFirstPin(mux, PINDIR_INPUT), NULL)))
 		{
-			return nullptr;
+			return 0;
 		}
 	}
 
@@ -509,7 +509,8 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	CComQIPtr<IGSSource>(m_src)->DeliverNewSegment();
 
 	m_capturing = true;
-	return new std::wstring(dlg.m_filename.begin(), dlg.m_filename.end() - 3);
+	filename = dlg.m_filename.erase(dlg.m_filename.length() - 3, 3) + "wav";
+	return 1;
 #elif defined(__unix__)
 	// Note I think it doesn't support multiple depth creation
 	GSmkdir(m_out_dir.c_str());
@@ -525,7 +526,8 @@ std::wstring* GSCapture::BeginCapture(float fps, GSVector2i recommendedResolutio
 	}
 
 	m_capturing = true;
-	return new std::wstring();
+	filename = m_out_dir + "/audio_recording.wav";
+	return 1;
 #endif
 }
 
@@ -564,6 +566,9 @@ bool GSCapture::DeliverFrame(const void* bits, int pitch, bool rgba)
 
 bool GSCapture::EndCapture()
 {
+	if (!m_capturing)
+		return false;
+
 	std::lock_guard<std::recursive_mutex> lock(m_lock);
 
 #ifdef _WIN32

--- a/plugins/GSdx/GSCapture.h
+++ b/plugins/GSdx/GSCapture.h
@@ -53,7 +53,7 @@ public:
 	GSCapture();
 	virtual ~GSCapture();
 
-	std::wstring* BeginCapture(float fps, GSVector2i recommendedResolution, float aspect);
+	int BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::string& filename);
 	bool DeliverFrame(const void* bits, int pitch, bool rgba);
 	bool EndCapture();
 

--- a/plugins/GSdx/GSCapture.h
+++ b/plugins/GSdx/GSCapture.h
@@ -53,7 +53,7 @@ public:
 	GSCapture();
 	virtual ~GSCapture();
 
-	int BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::string& filename);
+	bool BeginCapture(float fps, GSVector2i recommendedResolution, float aspect, std::string& filename);
 	bool DeliverFrame(const void* bits, int pitch, bool rgba);
 	bool EndCapture();
 

--- a/plugins/GSdx/GSUtil.cpp
+++ b/plugins/GSdx/GSUtil.cpp
@@ -336,7 +336,7 @@ void GSmkdir(const wchar_t* dir)
 	if (!CreateDirectory(dir, nullptr)) {
 		DWORD errorID = ::GetLastError();
 		if (errorID != ERROR_ALREADY_EXISTS) {
-			fprintf(stderr, "Failed to create directory: %s error %u\n", dir, errorID);
+			fprintf(stderr, "Failed to create directory: %ls error %u\n", dir, errorID);
 		}
 	}
 #else

--- a/plugins/GSdx/GSdx.def
+++ b/plugins/GSdx/GSdx.def
@@ -34,6 +34,7 @@ EXPORTS
 	GSreadFIFO2
 	GSirqCallback
 	GSsetupRecording		
+	GSendRecording
 	GSsetGameCRC		
 	GSsetFrameSkip
 	GSsetVsync

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -533,7 +533,7 @@ bool GSRenderer::MakeSnapshot(const std::string& path)
 	return true;
 }
 
-int GSRenderer::BeginCapture(std::string& filename)
+bool GSRenderer::BeginCapture(std::string& filename)
 {
 	GSVector4i disp = m_wnd->GetClientRect().fit(m_aspectratio);
 	float aspect = (float)disp.width() / std::max(1, disp.height());

--- a/plugins/GSdx/Renderers/Common/GSRenderer.cpp
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.cpp
@@ -533,12 +533,12 @@ bool GSRenderer::MakeSnapshot(const std::string& path)
 	return true;
 }
 
-std::wstring* GSRenderer::BeginCapture()
+int GSRenderer::BeginCapture(std::string& filename)
 {
 	GSVector4i disp = m_wnd->GetClientRect().fit(m_aspectratio);
 	float aspect = (float)disp.width() / std::max(1, disp.height());
 
-	return m_capture.BeginCapture(GetTvRefreshRate(), GetInternalResolution(), aspect);
+	return m_capture.BeginCapture(GetTvRefreshRate(), GetInternalResolution(), aspect, filename);
 }
 
 void GSRenderer::EndCapture()

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -72,7 +72,7 @@ public:
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(int vsync);
 
-	virtual std::wstring* BeginCapture();
+	virtual int BeginCapture(std::string& filename);
 	virtual void EndCapture();
 
 	void PurgePool();

--- a/plugins/GSdx/Renderers/Common/GSRenderer.h
+++ b/plugins/GSdx/Renderers/Common/GSRenderer.h
@@ -72,7 +72,7 @@ public:
 	void SetAspectRatio(int aspect) {m_aspectratio = aspect;}
 	void SetVSync(int vsync);
 
-	virtual int BeginCapture(std::string& filename);
+	virtual bool BeginCapture(std::string& filename);
 	virtual void EndCapture();
 
 	void PurgePool();

--- a/plugins/GSdx/Window/GSCaptureDlg.cpp
+++ b/plugins/GSdx/Window/GSCaptureDlg.cpp
@@ -40,7 +40,8 @@
 void GSCaptureDlg::InvalidFile()
 {
 	wchar_t tmp[512];
-	swprintf_s(tmp, L"GSdx couldn't open file for capturing: %s.\nCapture aborted.", m_filename.c_str());
+	std::wstring tmpstr(m_filename.begin(), m_filename.end());
+	swprintf_s(tmp, L"GSdx couldn't open file for capturing: %ls.\nCapture aborted.", tmpstr.c_str());
 	MessageBox(GetActiveWindow(), tmp, L"GSdx System Message", MB_OK | MB_SETFOREGROUND);
 }
 


### PR DESCRIPTION
Addresses some oversights involving transferring a file name between the GS & SPU2 recording setups.
Adds a new audio toggle setting that allows a user to control whether a wav file should be generated alongside a video recording. In doing this, behavior for when SPU2 recording fails to be setup becomes more defined and consistent.
Additionally, F12 will now route to sMainFrame if gui is active as to keep the capture menu gui accurate to the current state. This change resolves #3729.