### PR TITLE
Properly cancel an input recording on a bad initial savestate

### DIFF
--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -276,7 +276,8 @@ void InputRecording::SetupInitialState(u32 newStartingFrame)
 				inputRec::consoleLog("Input recording was possibly constructed for a different game.");
 
 		incrementUndo = true;
-		inputRec::consoleMultiLog({fmt::format("Replaying input recording - [{}]", std::string(inputRecordingData.GetFilename())),
+		inputRec::log("Replaying input recording");
+		inputRec::consoleMultiLog({fmt::format("File: {}", std::string(inputRecordingData.GetFilename())),
 								   fmt::format("PCSX2 Version Used: {}", std::string(inputRecordingData.GetHeader().emu)),
 								   fmt::format("Recording File Version: {}", inputRecordingData.GetHeader().version),
 								   fmt::format("Associated Game Name or ISO Filename: {}", std::string(inputRecordingData.GetHeader().gameName)),

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -76,8 +76,8 @@ public:
 	// Set the running frame counter for the input recording to an arbitrary value
 	void SetFrameCounter(u32 newGFrameCount);
 
-	// Store the starting internal PCSX2 g_FrameCount value
-	void SetStartingFrame(u32 newStartingFrame);
+	// Sets up all values and prints console logs pertaining to the start of a recording
+	void SetupInitialState(u32 newStartingFrame);
 
 	/// Functions called from GUI
 
@@ -89,6 +89,8 @@ public:
 	void Stop();
 	// Initialze VirtualPad window
 	void setVirtualPadPtr(VirtualPad* ptr, int const port);
+	// Resets a recording if the base savestate could not be loaded at the start
+	void FailedSavestate();
 
 private:
 	enum class InputRecordingMode

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -20,7 +20,7 @@
 #include "App.h"
 #include "Counters.h"
 #include "DebugTools/Debug.h"
-#include "GSFrame.h"
+#include "MainFrame.h"
 #include "MemoryTypes.h"
 
 #include "InputRecording.h"
@@ -209,5 +209,7 @@ void InputRecordingControls::Lock(u32 frame)
 	//Ensures that g_frameCount can be used to resume emulation after a fast/full boot
 	if (!g_InputRecording.GetInputRecordingData().FromSaveState())
 		g_FrameCount = frame + 1;
+	else
+		sMainFrame.StartInputRecording();
 }
 #endif

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -662,6 +662,11 @@ void Pcsx2App::HandleEvent(wxEvtHandler* handler, wxEventFunction func, wxEvent&
 		// Saved state load failed prior to the system getting corrupted (ie, file not found
 		// or some zipfile error) -- so log it and resume emulation.
 		Console.Warning( ex.FormatDiagnosticMessage() );
+#ifndef DISABLE_RECORDING
+		if (g_InputRecording.IsInitialLoad())
+			g_InputRecording.FailedSavestate();
+#endif
+
 		CoreThread.Resume();
 	}
 	// ----------------------------------------------------------------------------

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -174,6 +174,8 @@ public:
 #ifndef DISABLE_RECORDING
 	void initializeRecordingMenuItem(MenuIdentifiers menuId, wxString keyCodeStr, bool enable = true);
 	void enableRecordingMenuItem(MenuIdentifiers menuId, bool enable);
+	void StartInputRecording();
+	void StopInputRecording();
 #endif
 
 protected:


### PR DESCRIPTION
One of the problems with the current implementation was that it never accounted for a failed savestate load. If you were to load a recording that was based on a savestate that no longer works (corrupted or outdated), the emulator would not know to cancel loading the recording. This now accounts for that by forcing most input recording elements to wait until confirmation.