### PR TITLE
MTVU: Clean up GS SIGNAL/LABEL/FINISH communication

### DIFF
--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -44,16 +44,19 @@ class VU_Thread : public pxThread {
 public:
 	__aligned16  vifStruct        vif;
 	__aligned16  VIFregisters     vifRegs;
-	__aligned(4) Semaphore semaXGkick;
-	__aligned(4) std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
-	__aligned(4) u32 vuCycleIdx;  // Used for VU cycle stealing hack
-	__aligned(4) u32 lastSignal;
-	__aligned(4) u32 lastLabel;
-	__aligned(4) std::atomic<unsigned int> gsFinish; // Used for GS Signal, Finish etc
-	__aligned(4) std::atomic<u32> gsLabelCnt; // Used for GS Label command
-	__aligned(4) std::atomic<u32> gsSignalCnt; // Used for GS Signal command
-	__aligned(4) std::atomic<u64> gsLabel; // Used for GS Label command
-	__aligned(4) std::atomic<u64> gsSignal; // Used for GS Signal command
+	Semaphore semaXGkick;
+	std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
+	u32 vuCycleIdx;  // Used for VU cycle stealing hack
+
+	enum InterruptFlag {
+		InterruptFlagFinish = 1 << 0,
+		InterruptFlagSignal = 1 << 1,
+		InterruptFlagLabel  = 1 << 2,
+	};
+
+	std::atomic<u32> gsInterrupts; // Used for GS Signal, Finish etc
+	std::atomic<u64> gsLabel; // Used for GS Label command
+	std::atomic<u64> gsSignal; // Used for GS Signal command
 
 	VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs);
 	virtual ~VU_Thread();

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A14 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A15 << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
Fixes atomic usage and ensures all communication goes in one direction

Also removed some forced 4-byte alignment, for 4-byte types it's unnecessary and for 8-byte types it's either unnecessary or harmful