### PR TITLE
SPU2: Improve DMA/IRQ timing.

### DIFF
--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -146,7 +146,7 @@ void psxRcntInit()
 	psxCounters[4].interrupt = 0x08000;
 	psxCounters[5].interrupt = 0x10000;
 
-	psxCounters[6].rate = 768 * 12;
+	psxCounters[6].rate = 768; // One SPU tick
 	psxCounters[6].CycleT = psxCounters[6].rate;
 	psxCounters[6].mode = 0x8;
 

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -43,7 +43,7 @@ static void __fastcall psxDmaGeneric(u32 madr, u32 bcr, u32 chcr, u32 spuCore)
 	//Console.Status("cycles sent to SPU2 %x\n", psxRegs.cycle - psxCounters[6].sCycleT);
 
 	psxCounters[6].sCycleT = psxRegs.cycle;
-	psxCounters[6].CycleT = size * 2;
+	psxCounters[6].CycleT = size * 4;
 
 	psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 	psxNextsCounter = psxRegs.cycle;

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -43,7 +43,7 @@ static void __fastcall psxDmaGeneric(u32 madr, u32 bcr, u32 chcr, u32 spuCore)
 	//Console.Status("cycles sent to SPU2 %x\n", psxRegs.cycle - psxCounters[6].sCycleT);
 
 	psxCounters[6].sCycleT = psxRegs.cycle;
-	psxCounters[6].CycleT = size * 3;
+	psxCounters[6].CycleT = size * 2;
 
 	psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 	psxNextsCounter = psxRegs.cycle;

--- a/pcsx2/SPU2/ReadInput.cpp
+++ b/pcsx2/SPU2/ReadInput.cpp
@@ -142,7 +142,7 @@ StereoOut32 V_Core::ReadInput()
 
 	InputPosRead++;
 
-	if (AutoDMACtrl & (Index + 1) && (InputPosRead == 0x100 || InputPosRead == 0x200))
+	if (AutoDMACtrl & (Index + 1) && (InputPosRead == 0x180 || InputPosRead == 0x80))
 	{
 		AdmaInProgress = 0;
 		if (InputDataLeft >= 0x200)

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -533,6 +533,7 @@ struct V_Core
 	void AutoDMAReadBuffer(int mode);
 	void StartADMAWrite(u16* pMem, u32 sz);
 	void PlainDMAWrite(u16* pMem, u32 sz);
+	void FinishDMAwrite();
 };
 
 extern V_Core Cores[2];

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -401,6 +401,7 @@ struct V_Core
 	s8 NoiseClk;       // Noise Clock
 	u16 AutoDMACtrl;   // AutoDMA Status
 	s32 DMAICounter;   // DMA Interrupt Counter
+	u32 LastClock;     // DMA Interrupt Clock Cycle Counter
 	u32 InputDataLeft; // Input Buffer
 	u32 InputPosRead;
 	u32 InputPosWrite;
@@ -549,6 +550,7 @@ extern s16* _spu2mem;
 extern int PlayMode;
 
 extern void SetIrqCall(int core);
+extern void SetIrqCallDMA(int core);
 extern void StartVoices(int core, u32 value);
 extern void StopVoices(int core, u32 value);
 extern void InitADSR();

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -134,7 +134,6 @@ void SPU2interruptDMA4()
 	FileLog("[%10d] SPU2 interruptDMA4\n", Cycles);
 	Cores[0].Regs.STATX |= 0x80;
 	Cores[0].Regs.STATX &= ~0x400;
-	Cores[0].Regs.ATTR &= ~0x30;
 }
 
 void SPU2interruptDMA7()
@@ -142,7 +141,6 @@ void SPU2interruptDMA7()
 	FileLog("[%10d] SPU2 interruptDMA7\n", Cycles);
 	Cores[1].Regs.STATX |= 0x80;
 	Cores[1].Regs.STATX &= ~0x400;
-	Cores[1].Regs.ATTR &= ~0x30;
 }
 
 void SPU2readDMA7Mem(u16* pMem, u32 size)

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -133,14 +133,16 @@ void SPU2interruptDMA4()
 {
 	FileLog("[%10d] SPU2 interruptDMA4\n", Cycles);
 	Cores[0].Regs.STATX |= 0x80;
-	//Cores[0].Regs.ATTR &= ~0x30;
+	Cores[0].Regs.STATX &= ~0x400;
+	Cores[0].Regs.ATTR &= ~0x30;
 }
 
 void SPU2interruptDMA7()
 {
 	FileLog("[%10d] SPU2 interruptDMA7\n", Cycles);
 	Cores[1].Regs.STATX |= 0x80;
-	//Cores[1].Regs.ATTR &= ~0x30;
+	Cores[1].Regs.STATX &= ~0x400;
+	Cores[1].Regs.ATTR &= ~0x30;
 }
 
 void SPU2readDMA7Mem(u16* pMem, u32 size)


### PR DESCRIPTION
Fixes The Simple 2000 Series Vol 51 - The Senkan (AKA The Battleship) which was not booting with anything but ZeroSPU2
Fixes The Simpsons (For real) problem was due to an ADMA refill bug.

Don't know what other games will be affected.