### PR TITLE
recording: Update the GS Frame's freq. properly on enabling/disabling input recording

### DIFF
--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -589,8 +589,7 @@ bool GSFrame::ShowFullScreen(bool show, bool updateConfig)
 	return retval;
 }
 
-
-void GSFrame::CoreThread_OnResumed()
+void GSFrame::UpdateTitleUpdateFreq()
 {
 #ifndef DISABLE_RECORDING
 	if (g_Conf->EmuOptions.EnableRecordingTools)
@@ -604,8 +603,15 @@ void GSFrame::CoreThread_OnResumed()
 #else
 	m_timer_UpdateTitle.Start(TitleBarUpdateMs);
 #endif
-	
-	if( !IsShown() ) Show();
+}
+
+void GSFrame::CoreThread_OnResumed()
+{
+	UpdateTitleUpdateFreq();
+	if (!IsShown())
+	{
+		Show();
+	}
 }
 
 void GSFrame::CoreThread_OnSuspended()

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -107,6 +107,7 @@ public:
 	bool Show( bool shown=true );
 
 	bool ShowFullScreen(bool show, bool updateConfig = true);
+	void UpdateTitleUpdateFreq();
 
 protected:
 	void OnCloseWindow( wxCloseEvent& evt );

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -630,6 +630,11 @@ void MainEmuFrame::Menu_EnableRecordingTools_Click(wxCommandEvent& event)
 	}
 
 	g_Conf->EmuOptions.EnableRecordingTools = checked;
+	// Update GS Title Frequency
+	if (GSFrame* gsFrame = wxGetApp().GetGsFramePtr())
+	{
+		gsFrame->UpdateTitleUpdateFreq();
+	}
 	// Enable Recording Logs
 	ConsoleLogFrame* progLog = wxGetApp().GetProgramLog();
 	progLog->UpdateLogList();


### PR DESCRIPTION
Prior to this, if you enabled input recording after already having the GS window open, the title bar would continue to use it's slow default until you restarted the entire emulator.

This fixes that, and also should put the frequency back down when disabled.

To test this, you don't need to even do any recording, the speed difference should be obvious.  These steps should cover most cases:
- Open Game > Enable Recording Tools > Title should update quickly.
  - Disable Recording Tools, title should go back to being slow
- Restart Emu > Disable Recording Tools > Open Game > Title should update slowly
- Restart Emu > Enable Recording Tools > Open Game > Title should update quickly
