### PR TITLE
DEV9: Generate unique MAC for TAP

### DIFF
--- a/pcsx2/DEV9/Win32/tap-win32.cpp
+++ b/pcsx2/DEV9/Win32/tap-win32.cpp
@@ -259,6 +259,7 @@ HANDLE TAPOpen(const char* device_guid)
 
 
 TAPAdapter::TAPAdapter()
+	: NetAdapter()
 {
 	if (config.ethEnable == 0)
 		return;

--- a/pcsx2/DEV9/net.cpp
+++ b/pcsx2/DEV9/net.cpp
@@ -82,3 +82,21 @@ void TermNet()
 		nif = nullptr;
 	}
 }
+
+NetAdapter::NetAdapter()
+{
+	//Ensure eeprom matches our default 
+	SetMACAddress(ps2MAC);
+}
+
+void NetAdapter::SetMACAddress(u8* mac)
+{
+	if (ps2MAC != mac)
+		memcpy(ps2MAC, mac, 6);
+
+	for (int i = 0; i < 3; i++)
+		dev9.eeprom[i] = ((u16*)mac)[i];
+
+	//The checksum seems to be all the values of the mac added up in 16bit chunks
+	dev9.eeprom[3] = (dev9.eeprom[0] + dev9.eeprom[1] + dev9.eeprom[2]) & 0xffff;
+}

--- a/pcsx2/DEV9/net.cpp
+++ b/pcsx2/DEV9/net.cpp
@@ -86,16 +86,18 @@ void TermNet()
 NetAdapter::NetAdapter()
 {
 	//Ensure eeprom matches our default 
-	SetMACAddress(ps2MAC);
+	SetMACAddress(nullptr);
 }
 
 void NetAdapter::SetMACAddress(u8* mac)
 {
-	if (ps2MAC != mac)
+	if (mac == nullptr)
+		memcpy(ps2MAC, defaultMAC, 6);
+	else
 		memcpy(ps2MAC, mac, 6);
 
 	for (int i = 0; i < 3; i++)
-		dev9.eeprom[i] = ((u16*)mac)[i];
+		dev9.eeprom[i] = ((u16*)ps2MAC)[i];
 
 	//The checksum seems to be all the values of the mac added up in 16bit chunks
 	dev9.eeprom[3] = (dev9.eeprom[0] + dev9.eeprom[1] + dev9.eeprom[2]) & 0xffff;

--- a/pcsx2/DEV9/net.h
+++ b/pcsx2/DEV9/net.h
@@ -17,6 +17,9 @@
 #include <stdlib.h>
 #include <string.h> //uh isnt memcpy @ stdlib ?
 
+// first three recognized by Xlink as Sony PS2
+const u8 defaultMAC[6] = {0x00, 0x04, 0x1F, 0x82, 0x30, 0x31};
+
 struct NetPacket
 {
 	NetPacket() { size = 0; }
@@ -37,8 +40,7 @@ extern mtfifo<NetPacket*> tx_fifo;
 class NetAdapter
 {
 protected:
-	// first three recognized by Xlink as Sony PS2
-	u8 ps2MAC[6] = {0x00, 0x04, 0x1F, 0x82, 0x30, 0x31};
+	u8 ps2MAC[6];
 
 public:
 	NetAdapter();

--- a/pcsx2/DEV9/net.h
+++ b/pcsx2/DEV9/net.h
@@ -36,13 +36,21 @@ extern mtfifo<NetPacket*> tx_fifo;
 
 class NetAdapter
 {
+protected:
+	// first three recognized by Xlink as Sony PS2
+	u8 ps2MAC[6] = {0x00, 0x04, 0x1F, 0x82, 0x30, 0x31};
+
 public:
+	NetAdapter();
 	virtual bool blocks() = 0;
 	virtual bool isInitialised() = 0;
 	virtual bool recv(NetPacket* pkt) = 0; //gets a packet
 	virtual bool send(NetPacket* pkt) = 0; //sends the packet and deletes it when done
 	virtual void close() {}
 	virtual ~NetAdapter() {}
+
+protected:
+	void SetMACAddress(u8* mac);
 };
 
 void tx_put(NetPacket* ptr);

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -352,7 +352,7 @@ PCAPAdapter::PCAPAdapter()
 		SysMessage("Can't open Device '%s'\n", config.Eth);
 	}
 #else
-	SysMessage("pcap not supported on windows\n");
+	Console.Error("pcap not supported on windows\n");
 #endif
 }
 bool PCAPAdapter::blocks()


### PR DESCRIPTION
A unique MAC is needed for full compatibility with XLink Kai.

Uses a method similar to what was done for pcap.

