### PR TITLE
GUI Improvements around savestate-based input recordings

### DIFF
--- a/bin/PCSX2_keys.ini.default
+++ b/bin/PCSX2_keys.ini.default
@@ -86,6 +86,9 @@ FrameAdvance                      =	SPACE
 TogglePause                       =	Shift-P
 InputRecordingModeToggle          =	Shift-R
 
+# Note - This is disabled if no input recording is active
+GoToFirstFrame                    =	Shift-L
+
 # Save State Management
 # Note - These are disabled if 'System > Enable Recording Tools' is disabled
 States_SaveSlot0                  =	Shift-KP_0

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -20,8 +20,6 @@
 
 #ifndef DISABLE_RECORDING
 
-#include <vector>
-
 #include "AppGameDatabase.h"
 #include "DebugTools/Debug.h"
 
@@ -395,6 +393,26 @@ bool InputRecording::Play(wxString fileName)
 		initialLoad = true;
 		sApp.SysExecute(g_Conf->CdvdSource);
 	}
+	return true;
+}
+
+bool InputRecording::GoToFirstFrame()
+{
+	if (inputRecordingData.FromSaveState())
+	{
+		if (!wxFileExists(inputRecordingData.GetFilename() + "_SaveState.p2s"))
+		{
+			inputRec::consoleLog(fmt::format("[REC]: Could not locate savestate file at location - {}_SaveState.p2s\n",
+												inputRecordingData.GetFilename()));
+			return false;
+		}
+		StateCopy_LoadFromFile(inputRecordingData.GetFilename() + "_SaveState.p2s");
+	}
+	else
+		sApp.SysExecute(g_Conf->CdvdSource);
+
+	if (IsRecording())
+		SetToReplayMode();
 	return true;
 }
 

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -85,7 +85,8 @@ public:
 	// Create a new input recording file
 	bool Create(wxString filename, const bool fromSaveState, wxString authorName);
 	// Play an existing input recording from a file
-	bool Play(wxString filename);
+	// Calls a file dialog if it fails to locate the default base savestate
+	bool Play(wxWindow* parent, wxString filename);
 	// Stop the active input recording
 	void Stop();
 	// Displays the VirtualPad window for the chosen pad
@@ -93,7 +94,8 @@ public:
 	// Logs the padData and redraws the virtualPad windows of active pads
 	void LogAndRedraw();
 	// Resets emulation to the beginning of a recording
-	bool GoToFirstFrame();
+	// Calls a file dialog if it fails to locate the base savestate
+	void GoToFirstFrame(wxWindow* parent);
 	// Resets a recording if the base savestate could not be loaded at the start
 	void FailedSavestate();
 
@@ -123,6 +125,7 @@ private:
 	s32 frameCounter = 0;
 	bool incrementUndo = false;
 	InputRecordingMode state = InputRecording::InputRecordingMode::NotActive;
+	wxString savestate;
 
 	// Array of usable pads (currently, only 2)
 	struct InputRecordingPad

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -88,10 +88,12 @@ public:
 	bool Play(wxString filename);
 	// Stop the active input recording
 	void Stop();
-// Displays the VirtualPad window for the chosen pad
+	// Displays the VirtualPad window for the chosen pad
 	void ShowVirtualPad(const int port);
 	// Logs the padData and redraws the virtualPad windows of active pads
 	void LogAndRedraw();
+	// Resets emulation to the beginning of a recording
+	bool GoToFirstFrame();
 	// Resets a recording if the base savestate could not be loaded at the start
 	void FailedSavestate();
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -109,11 +109,13 @@ void GSPanel::InitRecordingAccelerators()
 	m_Accels->Map(AAC(WXK_SPACE), "FrameAdvance");
 	m_Accels->Map(AAC(wxKeyCode('p')).Shift(), "TogglePause");
 	m_Accels->Map(AAC(wxKeyCode('r')).Shift(), "InputRecordingModeToggle");
+	m_Accels->Map(AAC(wxKeyCode('l')).Shift(), "GoToFirstFrame");
 #if defined(__unix__)
 	// Shift+P (80) and Shift+p (112) have two completely different codes 
 	// On Linux the former is sometimes fired so define bindings for both
 	m_Accels->Map(AAC(wxKeyCode('P')).Shift(), "TogglePause");
 	m_Accels->Map(AAC(wxKeyCode('R')).Shift(), "InputRecordingModeToggle");
+	m_Accels->Map(AAC(wxKeyCode('L')).Shift(), "GoToFirstFrame");
 #endif
 
 	m_Accels->Map(AAC(WXK_NUMPAD0).Shift(), "States_SaveSlot0");

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -141,16 +141,21 @@ void GSPanel::InitRecordingAccelerators()
 
 	GetMainFramePtr()->initializeRecordingMenuItem(
 		MenuId_Recording_FrameAdvance,
-		m_Accels->findKeycodeWithCommandId("FrameAdvance").toTitleizedString());
+		GetAssociatedKeyCode("FrameAdvance"));
 	GetMainFramePtr()->initializeRecordingMenuItem(
 		MenuId_Recording_TogglePause,
-		m_Accels->findKeycodeWithCommandId("TogglePause").toTitleizedString());
+		GetAssociatedKeyCode("TogglePause"));
 	GetMainFramePtr()->initializeRecordingMenuItem(
 		MenuId_Recording_ToggleRecordingMode,
-		m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString(),
+		GetAssociatedKeyCode("InputRecordingModeToggle"),
 		g_InputRecording.IsActive());
 
 	inputRec::consoleLog("Initialized Input Recording Key Bindings");
+}
+
+wxString GSPanel::GetAssociatedKeyCode(const char* id)
+{
+	return m_Accels->findKeycodeWithCommandId(id).toTitleizedString();
 }
 
 void GSPanel::RemoveRecordingAccelerators()

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -545,10 +545,8 @@ namespace Implementations
 	{
 		if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsActive())
 		{
-			if (!g_InputRecording.GoToFirstFrame())
-			{
-				sMainFrame.StopInputRecording();
-			}
+			// Assumes that gui is active, as you can't access recording options without it
+			g_InputRecording.GoToFirstFrame(GetMainFramePtr());
 		}
 	}
 

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -541,6 +541,17 @@ namespace Implementations
 		}
 	}
 
+	void GoToFirstFrame()
+	{
+		if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsActive())
+		{
+			if (!g_InputRecording.GoToFirstFrame())
+			{
+				sMainFrame.StopInputRecording();
+			}
+		}
+	}
+
 	void States_SaveSlot(int slot)
 	{
 		States_SetCurrentSlot(slot);
@@ -838,6 +849,8 @@ static const GlobalCommandDescriptor CommandDeclarations[] =
 		{"FrameAdvance", Implementations::FrameAdvance, NULL, NULL, false},
 		{"TogglePause", Implementations::TogglePause, NULL, NULL, false},
 		{"InputRecordingModeToggle", Implementations::InputRecordingModeToggle, NULL, NULL, false},
+		{"GoToFirstFrame", Implementations::GoToFirstFrame, NULL, NULL, false},
+
 		{"States_SaveSlot0", Implementations::States_SaveSlot0, NULL, NULL, false},
 		{"States_SaveSlot1", Implementations::States_SaveSlot1, NULL, NULL, false},
 		{"States_SaveSlot2", Implementations::States_SaveSlot2, NULL, NULL, false},
@@ -848,6 +861,7 @@ static const GlobalCommandDescriptor CommandDeclarations[] =
 		{"States_SaveSlot7", Implementations::States_SaveSlot7, NULL, NULL, false},
 		{"States_SaveSlot8", Implementations::States_SaveSlot8, NULL, NULL, false},
 		{"States_SaveSlot9", Implementations::States_SaveSlot9, NULL, NULL, false},
+
 		{"States_LoadSlot0", Implementations::States_LoadSlot0, NULL, NULL, false},
 		{"States_LoadSlot1", Implementations::States_LoadSlot1, NULL, NULL, false},
 		{"States_LoadSlot2", Implementations::States_LoadSlot2, NULL, NULL, false},

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -29,6 +29,10 @@
 
 #include "svnrev.h"
 #include "Saveslots.h"
+#ifndef DISABLE_RECORDING
+#	include "Recording/InputRecording.h"
+#endif
+
 
 #include "fmt/core.h"
 // ------------------------------------------------------------------------
@@ -65,11 +69,18 @@ void MainEmuFrame::UpdateStatusBar()
 {
 	wxString temp(wxEmptyString);
 
-	if (g_Conf->EnableFastBoot)
-		temp += "Fast Boot - ";
+#ifndef DISABLE_RECORDING
+	if (g_InputRecording.IsActive() && g_InputRecording.GetInputRecordingData().FromSaveState())
+		temp += "Base Savestate - " + g_InputRecording.GetInputRecordingData().GetFilename() + "_SaveState.p2s";
+	else
+#endif
+	{
+		if (g_Conf->EnableFastBoot)
+			temp += "Fast Boot - ";
 
-	if (g_Conf->CdvdSource == CDVD_SourceType::Iso)
-		temp += "Load: '" + wxFileName(g_Conf->CurrentIso).GetFullName() + "' ";
+		if (g_Conf->CdvdSource == CDVD_SourceType::Iso)
+			temp += "Load: '" + wxFileName(g_Conf->CurrentIso).GetFullName() + "' ";
+	}
 
 	m_statusbar.SetStatusText(temp, 0);
 	m_statusbar.SetStatusText(CDVD_SourceLabels[enum_cast(g_Conf->CdvdSource)], 1);
@@ -100,6 +111,10 @@ void MainEmuFrame::UpdateCdvdSrcSelection()
 			jNO_DEFAULT
 	}
 	sMenuBar.Check(cdsrc, true);
+#ifndef DISABLE_RECORDING
+	if (!g_InputRecording.IsActive())
+#endif
+		ApplyCDVDStatus();
 	UpdateStatusBar();
 }
 
@@ -348,7 +363,7 @@ void MainEmuFrame::DispatchEvent(const CoreThreadStatus& status)
 {
 	if (!pxAssertMsg(GetMenuBar() != NULL, "Mainframe menu bar is NULL!"))
 		return;
-	ApplyCoreStatus();
+	ApplySuspendStatus();
 }
 
 void MainEmuFrame::AppStatusEvent_OnSettingsApplied()
@@ -735,12 +750,16 @@ void MainEmuFrame::OnActivate(wxActivateEvent& evt)
 
 void MainEmuFrame::ApplyCoreStatus()
 {
-	wxMenuBar& menubar(*GetMenuBar());
+	ApplySuspendStatus();
+	ApplyCDVDStatus();
+}
 
+void MainEmuFrame::ApplySuspendStatus()
+{
 	// [TODO] : Ideally each of these items would bind a listener instance to the AppCoreThread
 	// dispatcher, and modify their states accordingly.  This is just a hack (for now) -- air
 
-	if (wxMenuItem* susres = menubar.FindItem(MenuId_Sys_SuspendResume))
+	if (wxMenuItem* susres = GetMenuBar()->FindItem(MenuId_Sys_SuspendResume))
 	{
 		if (!CoreThread.IsClosing())
 		{
@@ -766,10 +785,13 @@ void MainEmuFrame::ApplyCoreStatus()
 		// Re-init keybinding after changing the label.
 		AppendShortcutToMenuOption(*susres, wxGetApp().GlobalAccels->findKeycodeWithCommandId("Sys_SuspendResume").toTitleizedString());
 	}
+}
 
+void MainEmuFrame::ApplyCDVDStatus()
+{
 	const CDVD_SourceType Source = g_Conf->CdvdSource;
 
-	wxMenuItem* cdvd_menu = menubar.FindItem(MenuId_Boot_CDVD);
+	wxMenuItem* cdvd_menu = GetMenuBar()->FindItem(MenuId_Boot_CDVD);
 
 	wxString label;
 	wxString help_text = _("Use fast boot to skip PS2 startup and splash screens.");

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -163,7 +163,9 @@ public:
 	void CreateConfigMenu();
 	void CreateWindowsMenu();
 	void CreateCaptureMenu();
+#ifndef DISABLE_RECORDING
 	void CreateRecordMenu();
+#endif
 	void CreateHelpMenu();
 
 	bool Destroy();
@@ -186,6 +188,8 @@ protected:
 	//Apply here is from config to GUI.
 	void ApplySettings();
 	void ApplyCoreStatus();
+	void ApplySuspendStatus();
+	void ApplyCDVDStatus();
 
 	void InitLogBoxPosition(AppConfig::ConsoleLogOptions& conf);
 
@@ -262,6 +266,7 @@ protected:
 	void Menu_Recording_New_Click(wxCommandEvent& event);
 	void Menu_Recording_Play_Click(wxCommandEvent& event);
 	void Menu_Recording_Stop_Click(wxCommandEvent& event);
+	void ApplyFirstFrameStatus();
 	void Menu_Recording_TogglePause_Click(wxCommandEvent& event);
 	void Menu_Recording_FrameAdvance_Click(wxCommandEvent& event);
 	void Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -461,6 +461,10 @@ void MainEmuFrame::Menu_CdvdSource_Click(wxCommandEvent& event)
 	}
 
 	SwapOrReset_CdvdSrc(this, newsrc);
+#ifndef DISABLE_RECORDING
+	if (!g_InputRecording.IsActive())
+#endif
+		ApplyCDVDStatus();
 }
 
 void MainEmuFrame::Menu_BootCdvd_Click(wxCommandEvent& event)
@@ -1020,6 +1024,24 @@ void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent& event)
 		StartInputRecording();
 }
 
+void MainEmuFrame::ApplyFirstFrameStatus()
+{
+	wxMenuItem* cdvd_menu = m_menuSys.FindChildItem(MenuId_Boot_CDVD);
+
+	wxString keyCodeStr;
+	if (GSFrame* gsFrame = wxGetApp().GetGsFramePtr())
+		if (GSPanel* viewport = gsFrame->GetViewport())
+			keyCodeStr = '\t' + viewport->GetAssociatedKeyCode(("GoToFirstFrame"));
+
+	cdvd_menu->SetItemLabel(L"Restart Recording" + keyCodeStr);
+	if (g_InputRecording.GetInputRecordingData().FromSaveState())
+		cdvd_menu->SetHelp(L"Loads the savestate that accompanies the active input recording");
+	else
+		cdvd_menu->SetHelp(L"Reboots Emulation");
+		
+	UpdateStatusBar();
+}
+
 void MainEmuFrame::Menu_Recording_Stop_Click(wxCommandEvent& event)
 {
 	StopInputRecording();
@@ -1030,6 +1052,7 @@ void MainEmuFrame::StartInputRecording()
 	m_menuRecording.FindChildItem(MenuId_Recording_New)->Enable(false);
 	m_menuRecording.FindChildItem(MenuId_Recording_Stop)->Enable(true);
 	m_menuRecording.FindChildItem(MenuId_Recording_ToggleRecordingMode)->Enable(true);
+	ApplyFirstFrameStatus();
 }
 
 void MainEmuFrame::StopInputRecording()
@@ -1040,6 +1063,7 @@ void MainEmuFrame::StopInputRecording()
 		m_menuRecording.FindChildItem(MenuId_Recording_New)->Enable(true);
 		m_menuRecording.FindChildItem(MenuId_Recording_Stop)->Enable(false);
 		m_menuRecording.FindChildItem(MenuId_Recording_ToggleRecordingMode)->Enable(false);
+		ApplyCDVDStatus();
 	}
 }
 

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -465,8 +465,18 @@ void MainEmuFrame::Menu_CdvdSource_Click(wxCommandEvent& event)
 
 void MainEmuFrame::Menu_BootCdvd_Click(wxCommandEvent& event)
 {
-	g_Conf->EmuOptions.UseBOOT2Injection = g_Conf->EnableFastBoot;
-	_DoBootCdvd();
+#ifndef DISABLE_RECORDING
+	if (g_InputRecording.IsActive())
+	{
+		if (!g_InputRecording.GoToFirstFrame())
+			StopInputRecording();
+	}
+	else
+#endif
+	{
+		g_Conf->EmuOptions.UseBOOT2Injection = g_Conf->EnableFastBoot;
+		_DoBootCdvd();
+	}
 }
 
 void MainEmuFrame::Menu_FastBoot_Click(wxCommandEvent& event)

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -485,10 +485,7 @@ void MainEmuFrame::Menu_BootCdvd_Click(wxCommandEvent& event)
 {
 #ifndef DISABLE_RECORDING
 	if (g_InputRecording.IsActive())
-	{
-		if (!g_InputRecording.GoToFirstFrame())
-			StopInputRecording();
-	}
+		g_InputRecording.GoToFirstFrame(this);
 	else
 #endif
 	{
@@ -1058,7 +1055,7 @@ void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent& event)
 	}
 
 	StopInputRecording();
-	if (!g_InputRecording.Play(openFileDialog.GetPath()))
+	if (!g_InputRecording.Play(this, openFileDialog.GetPath()))
 	{
 		if (!initiallyPaused)
 			g_InputRecordingControls.Resume();


### PR DESCRIPTION
* Originally, a user would have to navigate through a few menus to load up the file dialog and then manually select to load the savestate. To rectify this, a new `GoTofirstFrame()` function (along with the accompanying command code `Shift + L`) has been added. Calling this will automatically search for and attempt to load the base savestate. This command will be tied to the Boot option with a recording active and will also change its label to "Load savestate" when appropriate.
* If an attempt to explicitly load the base savestate fails due to it not being located, a file dialog will prompt the user for a new one. Whatever savestate gets chosen will be saved as the new base for the rest of the session. **Note: changing the savestate mid session will NOT change the starting frame count.**
* Choosing the shutdown option with **any** recording active, regardless of start type, will close said recording - but only after confirming the action in a safety prompt.
* Swapping the current source or source type with a savestate recording will add a line of warning text to the prompt that normally appears. It's just to make sure users are aware of possible savestate incompatibilities.