### PR TITLE
IPU: Return contents of the bottom of the FIFO in CMD except FDEC/VDEC

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -6872,18 +6872,6 @@ SLES-50423:
   name: "F1 2001"
   region: "PAL-M4"
   compat: 5
-  patches:
-    063FF7DB:
-      content: |-
-        author=prafull
-        // Skips IPU videos.
-        // Each videos can be called separately
-        // on this game.
-        // This seems like the only way of patching
-        // them all. The issue here is the PCSX2 IPU
-        // do not support well the EA proprietary IPU
-        // Library causing hanging in menus.
-        patch=1,EE,001f4d2c,word,00000000
 SLES-50424:
   name: "Cricket 2002"
   region: "PAL-E"
@@ -7782,13 +7770,6 @@ SLES-50874:
   name: "F1 2002"
   region: "PAL-M4"
   compat: 5
-  patches:
-    A0ED2D23:
-      content: |-
-        comment=Patch by Prafull
-        // Fixes controller issue but skips videos.
-        patch=0,EE,002d8568,word,03e00008
-        patch=0,EE,002d856c,word,00000000
 SLES-50875:
   name: "F1 2002"
   region: "PAL-I"
@@ -19505,14 +19486,6 @@ SLPM-62524:
   name: "Simple 2000 Series Vol.59 - The Uchyujin to Hanashi Sou!"
   region: "NTSC-J"
   compat: 5
-  patches:
-    85E92C92:
-      content: |-
-        // Skip videos (custom).
-        patch=0,EE,001b4cd8,word,00000000
-        // Skip videos (custom).
-        patch=0,EE,001b4c90,word,03e00008
-        patch=0,EE,001b4c94,word,00000000
 SLPM-62525:
   name: "Simple 2000 Series Vol.61 - The O-Ane-Chan-Bara"
   region: "NTSC-J"
@@ -22464,8 +22437,6 @@ SLPM-65752:
     A70549D6:
       content: |-
         comment=Patch by Prafull, Jelta
-        // New patch fixes most issues.
-        patch=0,EE,003A95B8,word,00000000
         // Fix hang at Level 4.
         patch=0,EE,0037B264,word,03e00008
         patch=0,EE,0037B268,word,00000000
@@ -32010,18 +31981,6 @@ SLUS-20263:
 SLUS-20264:
   name: "F1 2001"
   region: "NTSC-U"
-  patches:
-    2870c248:
-      content: |-
-        author=Prafull
-        // Skips IPU videos.
-        // Each video can be called separately
-        // on this game.
-        // This seems like the only way of patching
-        // them all. The issue here is the PCSX2 IPU
-        // do not support well the EA proprietary IPU
-        // Library causing hanging in menus.
-        patch=1,EE,001f4d2c,word,00000000
 SLUS-20265:
   name: "James Bond 007 - Agent Under Fire"
   region: "NTSC-U"
@@ -32810,13 +32769,6 @@ SLUS-20454:
 SLUS-20455:
   name: "F1 2002"
   region: "NTSC-U"
-  patches:
-    8FF059A1:
-      content: |-
-        comment=Patch by Prafull
-        // Fixes controller issue but skips videos.
-        patch=0,EE,002d8c58,word,03e00008
-        patch=0,EE,002d8c5c,word,00000000
 SLUS-20456:
   name: "Soccer Mania"
   region: "NTSC-U"
@@ -34907,8 +34859,6 @@ SLUS-20961:
     08901101:
       content: |-
         comment=Patch by Prafull
-        // New patch fixes most issues.
-        patch=0,EE,003a94f8,word,00000000
         // Fix hang at Level 4.
         patch=0,EE,0037b1a4,word,03e00008
         patch=0,EE,0037b1a8,word,00000000

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -204,6 +204,16 @@ __fi u32 ipuRead32(u32 mem)
 
 	switch (mem)
 	{
+		ipucase(IPU_CMD) : // IPU_CMD
+		{
+			if (ipu_cmd.CMD != SCE_IPU_FDEC && ipu_cmd.CMD != SCE_IPU_VDEC)
+			{
+				if (getBits32((u8*)&ipuRegs.cmd.DATA, 0))
+					ipuRegs.cmd.DATA = BigEndian(ipuRegs.cmd.DATA);
+			}
+			return ipuRegs.cmd.DATA;
+		}
+
 		ipucase(IPU_CTRL): // IPU_CTRL
 		{
 			ipuRegs.ctrl.IFC = g_BP.IFC;
@@ -247,9 +257,17 @@ __fi u64 ipuRead64(u32 mem)
 	switch (mem)
 	{
 		ipucase(IPU_CMD): // IPU_CMD
+		{
+			if (ipu_cmd.CMD != SCE_IPU_FDEC && ipu_cmd.CMD != SCE_IPU_VDEC)
+			{
+				if (getBits32((u8*)&ipuRegs.cmd.DATA, 0))
+					ipuRegs.cmd.DATA = BigEndian(ipuRegs.cmd.DATA);
+			}
+			
 			if (ipuRegs.cmd.DATA & 0xffffff)
 				IPU_LOG("read64: IPU_CMD=BUSY=%x, DATA=%08X", ipuRegs.cmd.BUSY ? 1 : 0, ipuRegs.cmd.DATA);
-			break;
+			return ipuRegs.cmd._u64;
+		}
 
 		ipucase(IPU_CTRL):
 			DevCon.Warning("reading 64bit IPU ctrl");
@@ -980,6 +998,6 @@ __noinline void IPUWorker()
 
 	// success
 	ipuRegs.ctrl.BUSY = 0;
-	ipu_cmd.current = 0xffffffff;
+	//ipu_cmd.current = 0xffffffff;
 	hwIntcIrq(INTC_IPU);
 }

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -29,12 +29,16 @@
 // Bitfield Structures
 //
 
-struct tIPU_CMD
+union tIPU_CMD
 {
-	u32 DATA;
-	u32 BUSY;
-	
-	void SetBusy(bool busy=true)
+	struct
+	{
+		u32 DATA;
+		u32 BUSY;
+	};
+	u64 _u64;
+
+	void SetBusy(bool busy = true)
 	{
 		BUSY = busy ? 0x80000000 : 0;
 	}


### PR DESCRIPTION
This is based on the work by @PSI-Rockin on Dobiestation but modified based on my theory that it always returns the first 32bits of the FIFO unless an FDEC/VDEC command is executed, however FDEC is basically doing this anyway, but VDEC returns decoded information.

Fixed videos for probably all broken EA games, but namely:
F1 2001
F1 2002
Neo Contra
Shox
Theme Park Rollercoaster/World


Unrelated PR but a note for myself when removing video skip patches for games which are no longer broken:
Simple 2000 Series Vol.59 - The Uchyujin to Hanashi Sou!