### PR TITLE
SPU2: Attempt 96khz sample rate if 48khz fails (WASAPI)

### DIFF
--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -893,6 +893,9 @@ __forceinline
 
 	SndBuffer::Write(Out);
 
+	if(SampleRate == 96000) // Double up samples for 96khz (Port Audio Non-Exclusive)
+		SndBuffer::Write(Out);
+
 	// Update AutoDMA output positioning
 	OutPos++;
 	if (OutPos >= 0x200)

--- a/pcsx2/SPU2/SndOut_Portaudio.cpp
+++ b/pcsx2/SPU2/SndOut_Portaudio.cpp
@@ -297,6 +297,22 @@ public:
 								PaCallback,
 
 								nullptr);
+
+			if (err == paInvalidSampleRate && SampleRate == 48000)
+			{
+				DevCon.Warning("Failed to create device at 48khz, trying 96khz");
+				SampleRate = 96000;
+				err = Pa_OpenStream(&stream,
+					nullptr, &outParams, SampleRate,
+					SndOutPacketSize,
+					paNoFlag,
+					PaCallback,
+
+					nullptr);
+			}
+
+			if (err == paInvalidSampleRate && SampleRate == 96000) // It didn't work, so lets just put the samplerate back
+				SampleRate = 48000;
 		}
 		else
 		{
@@ -308,6 +324,8 @@ public:
 		}
 		if (err != paNoError)
 		{
+			if(err == paInvalidSampleRate)
+				Console.Warning("Failed to create Port Audio Device %dkhz, Please use Exclusive Mode", SampleRate / 1000);
 			fprintf(stderr, "* SPU2: PortAudio error: %s\n", Pa_GetErrorText(err));
 			Pa_Terminate();
 			return -1;


### PR DESCRIPTION
WASAPI is terrible and doesn't support sample rate conversion in shared (normal) mode and requires exclusive mode.

This PR basically attempts to double the PS2 sample rate of 48khz to 96khz as this tends to be the other windows default.  If this fails it will put a log message to say you need to use Exclusive mode.

Note: When using PS1 game emulation you will need to use exclusive mode, nothing I can do about this (44.1khz doesn't divide nicely from 48khz or 96khz)