### PR TITLE
gamedb: Delimit memcard filters with '/' instead of ','

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -18,6 +18,7 @@
 #include "GameDatabase.h"
 
 #include "fmt/core.h"
+#include "fmt/ranges.h"
 #include "yaml-cpp/yaml.h"
 #include <fstream>
 #include <algorithm>
@@ -39,18 +40,7 @@ bool compareStrNoCase(const std::string str1, const std::string str2)
 
 std::string GameDatabaseSchema::GameEntry::memcardFiltersAsString() const
 {
-	if (memcardFilters.empty())
-		return "";
-
-	std::string filters;
-	for (u32 i = 0; i < memcardFilters.size(); i++)
-	{
-		std::string f = memcardFilters.at(i);
-		filters.append(f);
-		if (i != memcardFilters.size() - 1)
-			filters.append(",");
-	}
-	return filters;
+	return fmt::to_string(fmt::join(memcardFilters, "/"));
 }
 
 bool GameDatabaseSchema::GameEntry::findPatch(const std::string crc, Patch& patch) const

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -77,6 +77,7 @@ public:
 		std::vector<std::string> memcardFilters;
 		std::unordered_map<std::string, Patch> patches;
 
+		// Returns the list of memory card serials as a `/` delimited string
 		std::string memcardFiltersAsString() const;
 		bool findPatch(const std::string crc, Patch& patch) const;
 	};


### PR DESCRIPTION
This was a mistake from the original migration, for some reason i thought this list was comma delimited but no, it's slash delimited.

I tested via RaC3, with this fix, i was able to load my save files successfully.  Also nicely cleans up the `join` logic thanks to `fmt`.

Resolves - https://github.com/PCSX2/pcsx2/issues/4098