### PR TITLE
Fix out of bounds array access in folder memcards

### DIFF
--- a/pcsx2/gui/MemoryCardFolder.cpp
+++ b/pcsx2/gui/MemoryCardFolder.cpp
@@ -560,7 +560,7 @@ MemoryCardFileMetadataReference* FolderMemoryCard::AddFileEntryToMetadataQuickAc
 		ref->entry = entry;
 		ref->consecutiveCluster = clusterNumber;
 		++clusterNumber;
-	} while ( ( fileCluster = m_fat.data[0][0][fileCluster] ) != ( LastDataCluster | DataClusterInUseMask ) );
+	} while ( ( fileCluster = m_fat.data[0][0][fileCluster & NextDataClusterMask]) != ( LastDataCluster | DataClusterInUseMask ) );
 
 	return &m_fileMetadataQuickAccess[firstFileCluster & NextDataClusterMask];
 }


### PR DESCRIPTION
Don't keep the DataClusterInUse bit when accessing the next cluster.

With this folder memcards work on 64bit, but I'm confused why they would have worked on 32bit in the first place.

fixes #3839