### PR TITLE
PAD/Counters: Make VSync Queue adjustable in the UI. Extra Pad update.

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -29,7 +29,11 @@
 #include "VUmicro.h"
 
 #include "ps2/HwInternal.h"
-
+#ifdef _WIN32
+#include "PAD/Windows/PAD.h"
+#else
+#include "PAD/Linux/PAD.h"
+#endif
 #include "Sio.h"
 
 #ifndef DISABLE_RECORDING
@@ -421,6 +425,7 @@ static __fi void frameLimitUpdateCore()
 {
 	GetCoreThread().VsyncInThread();
 	Cpu->CheckExecutionState();
+	PADupdate(0);
 }
 
 // Framelimiter - Measures the delta time between calls and stalls until a

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -453,11 +453,6 @@ void SysMtgsThread::ExecuteTaskInThread()
 							GSvsync(((u32&)RingBuffer.Regs[0x1000]) & 0x2000);
 							gsFrameSkip();
 
-							// if we're not using GSOpen2, then the GS window is on this thread (MTGS thread),
-							// so we need to call PADupdate from here.
-							if (GSopen2 == NULL)
-								PADupdate(0);
-
 							m_QueuedFrameCount.fetch_sub(1);
 							if (m_VsyncSignalListener.exchange(false))
 								m_sem_Vsync.Post();

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -303,6 +303,7 @@ namespace Panels
 	{
 	protected:
 		pxCheckBox*			m_check_SynchronousGS;
+		wxSpinCtrl*			m_spinner_VsyncQueue;
 		wxButton*			m_restore_defaults;
 		FrameSkipPanel*		m_span;
 		FramelimiterPanel*	m_fpan;

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -291,10 +291,13 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 		_t("For troubleshooting potential bugs in the MTGS only, as it is potentially very slow.")
 	);
 
+	m_spinner_VsyncQueue = new wxSpinCtrl(left);
+	m_spinner_VsyncQueue->SetRange(0, 3);
+
 	m_restore_defaults = new wxButton(right, wxID_DEFAULT, _("Restore Defaults"));
 
-	m_check_SynchronousGS->SetToolTip( pxEt( L"Enable this if you think MTGS thread sync is causing crashes or graphical errors. For debugging to see if GS is running at the correct speed.")
-	) ;
+	m_spinner_VsyncQueue->SetToolTip( pxEt(L"Setting this to a lower value improves input lag, a value around 2 or 3 will slightly improve framerates. (Default is 2)"));
+	m_check_SynchronousGS->SetToolTip( pxEt( L"Enable this if you think MTGS thread sync is causing crashes or graphical errors. For debugging to see if GS is running at the correct speed."));
 
 	//GSWindowSettingsPanel* winpan = new GSWindowSettingsPanel( left );
 	//winpan->AddFrame(_("Display/Window"));
@@ -306,6 +309,7 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 	m_fpan->AddFrame(_("Framelimiter"));
 
 	wxFlexGridSizer* s_table = new wxFlexGridSizer( 2 );
+	wxGridSizer* s_vsyncs = new wxGridSizer( 2 );
 	s_table->AddGrowableCol( 0, 1 );
 	s_table->AddGrowableCol( 1, 1 );
 
@@ -315,6 +319,11 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 
 	*left		+= m_fpan		| pxExpand;
 	*left		+= 5;
+	
+	*s_vsyncs	+= Label(_("Vsyncs in MTGS Queue:")) | StdExpand();
+	*s_vsyncs	+= m_spinner_VsyncQueue | pxBorder(wxTOP, -2).Right();
+	*left		+= s_vsyncs | StdExpand();
+	*left		+= 2;
 	*left		+= m_check_SynchronousGS | StdExpand();
 
 	*s_table	+= left		| StdExpand();
@@ -347,6 +356,7 @@ void Panels::VideoPanel::OnOpenWindowSettings( wxCommandEvent& evt )
 void Panels::VideoPanel::Apply()
 {
 	g_Conf->EmuOptions.GS.SynchronousMTGS	= m_check_SynchronousGS->GetValue();
+	g_Conf->EmuOptions.GS.VsyncQueueSize = m_spinner_VsyncQueue->GetValue();
 }
 
 void Panels::VideoPanel::AppStatusEvent_OnSettingsApplied()
@@ -357,7 +367,7 @@ void Panels::VideoPanel::AppStatusEvent_OnSettingsApplied()
 void Panels::VideoPanel::ApplyConfigToGui( AppConfig& configToApply, int flags ){
 	
 	m_check_SynchronousGS->SetValue( configToApply.EmuOptions.GS.SynchronousMTGS );
-
+	m_spinner_VsyncQueue->SetValue( configToApply.EmuOptions.GS.VsyncQueueSize );
 	m_check_SynchronousGS->Enable(!configToApply.EnablePresets);
 
 	if( flags & AppConfig::APPLY_FLAG_MANUALLY_PROPAGATE )


### PR DESCRIPTION
New UI option (ini option has been there a while) so users can choose between a little bit extra performance or better input lag. Also added the PAD Update to the VSync call in Counters as it seemed to improve Input lag marginally.

Improves #3008