### PR TITLE
gsdx-hw: Some adjustments to blending.

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -1353,7 +1353,7 @@ void GSDevice11::OMSetBlendState(ID3D11BlendState* bs, float bf)
 		m_state.bs = bs;
 		m_state.bf = bf;
 
-		float BlendFactor[] = {bf, bf, bf, 0};
+		const float BlendFactor[] = {bf, bf, bf, 0};
 
 		m_ctx->OMSetBlendState(bs, BlendFactor, 0xffffffff);
 	}

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.h
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.h
@@ -316,7 +316,7 @@ public:
 				uint32 wa:1;
 				// Alpha blending
 				uint32 blend_index:7;
-				uint32 abe:1;
+				uint32 alpha_blend:1;
 				uint32 accu_blend:1;
 			};
 
@@ -556,7 +556,7 @@ public:
 	void SetupVS(VSSelector sel, const VSConstantBuffer* cb);
 	void SetupGS(GSSelector sel, const GSConstantBuffer* cb);
 	void SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSelector ssel);
-	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix);
+	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 blend_factor);
 
 	ID3D11Device* operator->() {return m_dev;}
 	operator ID3D11Device*() {return m_dev;}

--- a/plugins/GSdx/Renderers/DX11/GSRendererDX11.h
+++ b/plugins/GSdx/Renderers/DX11/GSRendererDX11.h
@@ -41,7 +41,7 @@ private:
 	inline void ResetStates();
 	inline void SetupIA(const float& sx, const float& sy);
 	inline void EmulateZbuffer();
-	inline void EmulateBlending();
+	inline void EmulateBlending(uint8& blend_factor);
 	inline void EmulateTextureShuffleAndFbmask();
 	inline void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
 	inline void EmulateTextureSampler(const GSTextureCache::Source* tex);

--- a/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSTextureFX11.cpp
@@ -288,7 +288,7 @@ void GSDevice11::SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSe
 	PSSetShader(i->second, m_ps_cb);
 }
 
-void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 afix)
+void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uint8 blend_factor)
 {
 	auto i = std::as_const(m_om_dss).find(dssel);
 
@@ -347,11 +347,10 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 
 		memset(&bd, 0, sizeof(bd));
 
-		bd.RenderTarget[0].BlendEnable = bsel.abe;
-
-		if(bsel.abe)
+		if (bsel.alpha_blend)
 		{
 			HWBlend blend = GetBlend(bsel.blend_index);
+			bd.RenderTarget[0].BlendEnable = TRUE;
 			bd.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
 			bd.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;
 			bd.RenderTarget[0].DestBlend = (D3D11_BLEND)blend.dst;
@@ -380,5 +379,5 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 		j = m_om_bs.find(bsel);
 	}
 
-	OMSetBlendState(j->second, (float)(int)afix / 0x80);
+	OMSetBlendState(j->second, (float)(int)blend_factor / 0x80);
 }

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1743,8 +1743,8 @@ void GSDeviceOGL::OMSetBlendState(uint8 blend_index, uint8 blend_factor, bool is
 
 		if (is_blend_constant && GLState::bf != blend_factor) {
 			GLState::bf = blend_factor;
-			float bf = (float)blend_factor / 128.0f;
-			glBlendColor(bf, bf, bf, bf);
+			const float bf = (float)blend_factor / 128.0f;
+			glBlendColor(bf, bf, bf, 0);
 		}
 
 		HWBlend b = GetBlend(blend_index);


### PR DESCRIPTION
gsdx-d3d11: Some adjustments to blending.
Just like on gl use 1.0f fix factor on 24bit when using hw blending.
Set blend factor value in EmulateBlending function.

gsdx-ogl: Set alpha blend factor to 0.