### PR TITLE
rawinput_usb.cpp: removed unused WM_ACTIVATE/SETFOCUS/KILLFOCUS logging

### DIFF
--- a/pcsx2/USB/shared/rawinput_usb.cpp
+++ b/pcsx2/USB/shared/rawinput_usb.cpp
@@ -178,17 +178,17 @@ namespace shared
 					skipInput = !wParam;
 					break;
 				case WM_ACTIVATE:
-					Console.WriteLn("******      WM_ACTIVATE        ****** %p %d\n", hWnd, LOWORD(wParam) != WA_INACTIVE);
+					DevCon.WriteLn("******      WM_ACTIVATE        ****** %p %d\n", hWnd, LOWORD(wParam) != WA_INACTIVE);
 					skipInput = LOWORD(wParam) == WA_INACTIVE;
 					if (LOWORD(wParam) == WA_INACTIVE)
 						CursorRelease();
 					break;
 				case WM_SETFOCUS:
-					Console.WriteLn("******      WM_SETFOCUS        ****** %p\n", hWnd);
+					DevCon.WriteLn("******      WM_SETFOCUS        ****** %p\n", hWnd);
 					skipInput = false;
 					break;
 				case WM_KILLFOCUS:
-					Console.WriteLn("******      WM_KILLFOCUS        ****** %p\n", hWnd);
+					DevCon.WriteLn("******      WM_KILLFOCUS        ****** %p\n", hWnd);
 					skipInput = true;
 					break;
 				case WM_SIZE:

--- a/pcsx2/USB/shared/rawinput_usb.cpp
+++ b/pcsx2/USB/shared/rawinput_usb.cpp
@@ -178,17 +178,14 @@ namespace shared
 					skipInput = !wParam;
 					break;
 				case WM_ACTIVATE:
-					DevCon.WriteLn("******      WM_ACTIVATE        ****** %p %d\n", hWnd, LOWORD(wParam) != WA_INACTIVE);
 					skipInput = LOWORD(wParam) == WA_INACTIVE;
 					if (LOWORD(wParam) == WA_INACTIVE)
 						CursorRelease();
 					break;
 				case WM_SETFOCUS:
-					DevCon.WriteLn("******      WM_SETFOCUS        ****** %p\n", hWnd);
 					skipInput = false;
 					break;
 				case WM_KILLFOCUS:
-					DevCon.WriteLn("******      WM_KILLFOCUS        ****** %p\n", hWnd);
 					skipInput = true;
 					break;
 				case WM_SIZE:


### PR DESCRIPTION
Currently the console is a little cluttered by these messages that are useless and essentially meaningless to the end-user:
```
******      WM_KILLFOCUS        ****** 00040328

******      WM_SETFOCUS        ****** 00040328
```
I believe that shifting these messages to the Dev console is harmless and tidies up console output a little.