### PR TITLE
Core: Attempt to fix CDVD regression

### DIFF
--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -167,7 +167,7 @@ void SysCoreThread::ApplySettings(const Pcsx2Config& src)
 	if (src == EmuConfig)
 		return;
 
-	if (!pxAssertDev(IsPaused(), "CoreThread is not paused; settings cannot be applied."))
+	if (!pxAssertDev(IsPaused() | IsSelf(), "CoreThread is not paused; settings cannot be applied."))
 		return;
 
 	m_resetRecompilers = (src.Cpu != EmuConfig.Cpu) || (src.Gamefixes != EmuConfig.Gamefixes) || (src.Speedhacks != EmuConfig.Speedhacks);

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -326,7 +326,6 @@ void SysCoreThread::OnResumeInThread(bool isSuspended)
 	GetCorePlugins().Open();
 	if (isSuspended)
 	{
-		DoCDVDopen();
 		DEV9open((void*)pDsp);
 		USBopen((void*)pDsp);
 	}

--- a/pcsx2/System/SysThreadBase.cpp
+++ b/pcsx2/System/SysThreadBase.cpp
@@ -332,7 +332,9 @@ bool SysThreadBase::StateCheckInThread()
 			if (m_ExecMode != ExecMode_Closing)
 			{
 				if (g_CDVDReset)
-					DoCDVDopen();
+					//AppCoreThread deals with Reseting CDVD
+					OnResumeInThread(false);
+					
 				g_CDVDReset = false;
 				break;
 			}

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -585,8 +585,11 @@ void AppCoreThread::OnResumeInThread(bool isSuspended)
 	{
 		CDVDsys_ChangeSource(g_Conf->CdvdSource);
 		cdvdCtrlTrayOpen();
+		DoCDVDopen();
 		m_resetCdvd = false;
 	}
+	else if (isSuspended)
+		DoCDVDopen();
 
 	_parent::OnResumeInThread(isSuspended);
 	PostCoreStatus(CoreThread_Resumed);

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -553,7 +553,7 @@ void AppCoreThread::ApplySettings(const Pcsx2Config& src)
 	if (fixup == EmuConfig)
 		return;
 
-	if (m_ExecMode >= ExecMode_Opened)
+	if (m_ExecMode >= ExecMode_Opened && !IsSelf())
 	{
 		ScopedCoreThreadPause paused_core;
 		_parent::ApplySettings(fixup);


### PR DESCRIPTION
Turns out there is more to CDVD than just DoCDVDOpen()

Hopefully this fixes #4119, and doesn't break anything else.