### PR TITLE
GameFix: Adjust function of DMA Busy hack

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -12069,16 +12069,10 @@ SLES-53098:
 SLES-53099:
   name: "Pilot Down - Behind Enemy Lines"
   region: "PAL-M5"
+  gameFixes:
+    - DMABusyHack # Game has weird DMA handling, this allows required DMA's to finish.
   roundModes:
     vuRoundMode: 0
-  patches:
-    53BB63A0:
-      content: |-
-        author=kozarovv
-        // Patch allow sending VU1 mpg successfully. This fix missing graphic. Thanks to PSI for figuring what is wrong.
-        // Game need at least -2 EE cyclerate + MTVU on my pc to get full speed.
-        // To fix shadows set VU rounding to nearest - thx Atomic83
-        patch=1,EE,00426140,word,00000000
 SLES-53100:
   name: "Scooby Doo! Unmasked"
   region: "PAL-M4"

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -75,8 +75,8 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			)
 		},
 		{
-			_("Ignore DMAC writes when it is busy."),
-			pxEt( L"Known to affect following games:\n * Mana Khemia 1 (Going \"off campus\")\n"
+			_("Handle DMAC writes when it is busy."),
+			pxEt( L"Known to affect following games:\n * Mana Khemia 1 (Going \"off campus\"), Metal Saga (Intro FMV), Pilot Down Behind Enemy Lines\n"
 			)
 		},
 		{


### PR DESCRIPTION
Aim of this PR is to adjust how the DMA Busy hack works to deal with some DMA issues (described later)

Pilot Down Behind Enemy Lines is the main focus of this PR, the game starts important DMA transfers off then almost immediately overwrites the DMA information.  Either the DMA is has internal handling for the current transfers (this the registers are ignored until later transfers) or the game expects the DMA to maintain bus control before it overwrites the information.  Currently I'm unsure how to fix this properly, so I have adjusted the DMA hack to wait until the current transfer has finished. 

Handling of IPU is a tricky one, but because IPU_FROM pauses when there is no data waiting, it's possible that the QWC register gets rechecked once the transfer restarts, however I believe the MADR (Memory address) is only read once, plus we can't just wait for this to finish like we can other channels.  This affects how it is handled with Mana Khemia and Metal Saga, but both should still work, but these should be tested.

Fixes #4083