### PR TITLE
Add a GSdump comparer to the CI

### DIFF
--- a/.github/workflows/gsdump-workflow.yml
+++ b/.github/workflows/gsdump-workflow.yml
@@ -1,0 +1,97 @@
+name: GSDump Comparer
+on: 
+  push:
+    branches:
+      - master
+    paths:
+      - .github
+      - plugins/GSdx
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github
+      - plugins/GSdx
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - renderer: sw
+            platform: x86
+            compiler: gcc
+          - renderer: gl
+            platform: x86
+            compiler: gcc
+    name: ${{ matrix.renderer }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Checkout Submodules
+        run: git submodule update --init --recursive --jobs 2
+
+      - name: Checkout GSDumps
+        uses: actions/checkout@v2
+        with:
+          repository: tellowkrinkle/gsdumps
+          path: gsdumps
+
+      # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+      - name: Prepare cache timestamp
+        id: cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      # Note: We re-save this every time, even if it wasn't updated.  Fix when https://github.com/actions/cache/pull/498 merges
+      - name: Cache images
+        uses: actions/cache@v2
+        with:
+          path: images
+          key: images-${{ matrix.renderer }}-${{ steps.cache_timestamp.outputs.timestamp }}
+          restore-keys: images-${{ matrix.renderer }}-
+
+      - name: ccache cache files
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ccache-${{ steps.cache_timestamp.outputs.timestamp }}
+          restore-keys: ccache-
+            
+      - name: Install Packages
+        env:
+          GSDUMP: "ON"
+          PLATFORM: ${{ matrix.platform }}
+          COMPILER: ${{ matrix.compiler }}
+        run: ./.github/workflows/scripts/linux/install-packages.sh
+
+      - name: Generate CMake
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          COMPILER: ${{ matrix.compiler }}
+          ADDITIONAL_CMAKE_ARGS: -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+        run: ./.github/workflows/scripts/linux/generate-cmake.sh
+
+      - name: Build
+        working-directory: ./build
+        run: ../.github/workflows/scripts/linux/compile-gsdx.sh
+
+      - name: Run
+        env:
+          RENDERER: ${{ matrix.renderer }}
+          GSDUMP_SO: build/plugins/GSdx/libGSdx.so
+        run: ./.github/workflows/scripts/linux/gsdump-comparer.sh
+
+      - name: Update results
+        if: github.ref == 'refs/heads/master'
+        run: "[ -d output ] && (! [ -d images ] || rm -r images) && mv output images"
+
+      - name: Upload changes
+        uses: actions/upload-artifact@v2
+        with:
+          name: changed-gsdump-outputs-${{ matrix.renderer }}
+          path: changes/
+          if-no-files-found: ignore

--- a/.github/workflows/scripts/linux/compile-gsdx.sh
+++ b/.github/workflows/scripts/linux/compile-gsdx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+export CCACHE_BASEDIR=${GITHUB_WORKSPACE}
+export CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache
+export CCACHE_COMPRESS="true"
+export CCACHE_COMPRESSLEVEL="6"
+export CCACHE_MAXSIZE="400M"
+
+# Prepare the Cache
+ccache -p
+ccache -z
+# Build
+make -j4 -C plugins/GSdx/ GSdx pcsx2_GSReplayLoader
+# Save the Cache
+ccache -s

--- a/.github/workflows/scripts/linux/gsdump-comparer.sh
+++ b/.github/workflows/scripts/linux/gsdump-comparer.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+function notify {
+	echo "$1 $(echo "$2" | sed -e 's/[^/]*\///')..."
+}
+
+find gsdumps -name "*.gs.xz" -print0 | while read -d $'\0' file
+do
+	output="${file/gsdumps/output}"
+	mkdir -p "$(dirname "$output")"
+	notify Rendering "$file"
+	xvfb-run -s '-screen 0 1280x1024x24' build/plugins/GSdx/pcsx2_GSReplayLoader -c "$(dirname "$file")" -o "$(dirname "$output")/$(basename "$output" .gs.xz).%d.png" -r "$RENDERER" "$file"
+done
+echo "Comparing images..."
+find output -name "*.png" -print0 | while read -d $'\0' file
+do
+	reference="${file/output/images}"
+	if [ ! -f "$reference" ]; then
+		notify "New image" "$file"
+		continue
+	fi
+	if cmp -s "$file" "$reference"; then # Fast binary compare
+		different="NO"
+	elif compare -metric AE "$file" "$reference" /dev/null 2>/dev/null; then # Slower image compare
+		different="NO"
+	else
+		different="YES"
+	fi
+
+	if [ "$different" == "YES" ]; then
+		notify "Changed image:" "$file"
+		changes="${file/output/changes}"
+		changesbase="$(dirname "$changes")/$(basename "$changes" .png)"
+		mkdir -p "$(dirname "$changes")"
+		cp "$reference" "$changesbase.old.png"
+		cp "$file" "$changesbase.new.png"
+		compare -metric AE "$file" "$reference" "$changesbase.diff.png" 2>/dev/null || true # Don't fail because of this
+	fi
+done

--- a/.github/workflows/scripts/linux/install-packages.sh
+++ b/.github/workflows/scripts/linux/install-packages.sh
@@ -81,6 +81,11 @@ declare -a PCSX2_PACKAGES=(
   "zlib1g-dev"
 )
 
+declare -a GSDUMP_PACKAGES=(
+  "xvfb"
+  "imagemagick"
+)
+
 # - https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 ARCH=""
 echo "${PLATFORM}"
@@ -127,3 +132,12 @@ sudo apt-get -y install libgcc-s1:i386
 fi
 echo "Will install the following packages for pcsx2 - ${PCSX2_PACKAGES_STR}"
 sudo apt-get -y install ${PCSX2_PACKAGES_STR}
+
+if [ ! -z "$GSDUMP" ]; then
+  GSDUMP_PACKAGES_STR=""
+  for i in "${GSDUMP_PACKAGES[@]}"; do
+    GSDUMP_PACKAGES_STR="${GSDUMP_PACKAGES_STR} ${i}"
+  done
+  echo "Will install the following packages for processing gsdumps - ${GSDUMP_PACKAGES_STR}"
+  sudo apt-get -y install "${GSDUMP_PACKAGES_STR[@]}"
+fi

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -1073,7 +1073,7 @@ public:
 
 			case PacketType::VSync:
 
-				GSvsync(p.param);
+				GSvsync(*(int*)(regs + 4096) & 0x2000 ? 1 : 0);
 
 				break;
 

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -1324,7 +1324,7 @@ inline unsigned long timeGetTime()
 }
 
 // Note
-EXPORT_C GSReplay(char* lpszCmdLine, int renderer)
+EXPORT_C GSReplay(const char* lpszCmdLine, int renderer)
 {
 	GLLoader::in_replayer = true;
 	// Required by multithread driver

--- a/plugins/GSdx/GSLzma.cpp
+++ b/plugins/GSdx/GSLzma.cpp
@@ -21,7 +21,7 @@
 #include "stdafx.h"
 #include "GSLzma.h"
 
-GSDumpFile::GSDumpFile(char* filename, const char* repack_filename) {
+GSDumpFile::GSDumpFile(const char* filename, const char* repack_filename) {
 	m_fp = fopen(filename, "rb");
 	if (m_fp == nullptr) {
 		fprintf(stderr, "failed to open %s\n", filename);
@@ -54,7 +54,7 @@ GSDumpFile::~GSDumpFile() {
 }
 
 /******************************************************************/
-GSDumpLzma::GSDumpLzma(char* filename, const char* repack_filename) : GSDumpFile(filename, repack_filename) {
+GSDumpLzma::GSDumpLzma(const char* filename, const char* repack_filename) : GSDumpFile(filename, repack_filename) {
 
 	memset(&m_strm, 0, sizeof(lzma_stream));
 
@@ -150,7 +150,7 @@ GSDumpLzma::~GSDumpLzma() {
 
 /******************************************************************/
 
-GSDumpRaw::GSDumpRaw(char* filename, const char* repack_filename) : GSDumpFile(filename, repack_filename) {
+GSDumpRaw::GSDumpRaw(const char* filename, const char* repack_filename) : GSDumpFile(filename, repack_filename) {
 	m_buff_size = 0;
 	m_area      = NULL;
 	m_inbuf     = NULL;

--- a/plugins/GSdx/GSLzma.h
+++ b/plugins/GSdx/GSLzma.h
@@ -32,7 +32,7 @@ class GSDumpFile {
 	virtual bool IsEof() = 0;
 	virtual bool Read(void* ptr, size_t size) = 0;
 
-	GSDumpFile(char* filename, const char* repack_filename);
+	GSDumpFile(const char* filename, const char* repack_filename);
 	virtual ~GSDumpFile();
 };
 
@@ -51,7 +51,7 @@ class GSDumpLzma : public GSDumpFile {
 
 	public:
 
-	GSDumpLzma(char* filename, const char* repack_filename);
+	GSDumpLzma(const char* filename, const char* repack_filename);
 	virtual ~GSDumpLzma();
 
 	bool IsEof() final;
@@ -69,7 +69,7 @@ class GSDumpRaw : public GSDumpFile {
 
 	public:
 
-	GSDumpRaw(char* filename, const char* repack_filename);
+	GSDumpRaw(const char* filename, const char* repack_filename);
 	virtual ~GSDumpRaw() = default;
 
 	bool IsEof() final;

--- a/plugins/GSdx/linux_replay.cpp
+++ b/plugins/GSdx/linux_replay.cpp
@@ -67,7 +67,7 @@ int main ( int argc, char *argv[] )
 	}
 
 	__attribute__((stdcall)) void (*GSsetSettingsDir_ptr)(const char*);
-	__attribute__((stdcall)) void (*GSReplay_ptr)(char*, int);
+	__attribute__((stdcall)) void (*GSReplay_ptr)(const char*, int);
 
 	GSsetSettingsDir_ptr = reinterpret_cast<decltype(GSsetSettingsDir_ptr)>(dlsym(handle, "GSsetSettingsDir"));
 	GSReplay_ptr = reinterpret_cast<decltype(GSReplay_ptr)>(dlsym(handle, "GSReplay"));


### PR DESCRIPTION
Uses the compiled GSdx to render some gs files, then compares the results to the result of the latest master.  If there are any differences, it will upload them as an artifact.

Notes:
- Uses the GitHub Actions cache to store the results of the latest master.  Will be considerably less useful if the cache ends up getting evicted between uses.  Maybe we should find another place to store this?
- We should create a gsdumps repository in the PCSX2 organization and change the checkout gsdumps action to point at that