### PR TITLE
GameDB: 'Network Access Disc & Hardware - Online Arena' needs InstantVU1

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -1924,6 +1924,8 @@ SCES-52677:
   name: "Network Access Disc & Hardware - Online Arena"
   region: "PAL-M7"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 1  # Fixes not rendering most the screen
   patches:
     default:
       content: |-


### PR DESCRIPTION
Pal region, SCES-52677

Without the speedhack, I see this;
![gsdx_20210111201424](https://user-images.githubusercontent.com/4604733/104233722-406b0280-544a-11eb-956c-7e9eddfffa9e.png)

With the log getting spammed with `Gif Unit - GS packet size exceeded VU memory size!`

With the speedhack, it renders correctly and with no log spam. So add it to the gameDB.