### PR TITLE
SPU2: Switch to a more accurate noise algorithm

### DIFF
--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -399,7 +399,9 @@ struct V_Core
 	bool AdmaInProgress;
 
 	s8 DMABits;        // DMA related?
-	s8 NoiseClk;       // Noise Clock
+	u8 NoiseClk;       // Noise Clock
+	u32 NoiseCnt;      // Noise Counter
+	u32 NoiseOut;      // Noise Output
 	u16 AutoDMACtrl;   // AutoDMA Status
 	s32 DMAICounter;   // DMA Interrupt Counter
 	u32 LastClock;     // DMA Interrupt Clock Cycle Counter

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -130,6 +130,8 @@ void V_Core::Init(int index)
 	Mute = false;
 	DMABits = 0;
 	NoiseClk = 0;
+	NoiseCnt = 0;
+	NoiseOut = 0;
 	AutoDMACtrl = 0;
 	InputDataLeft = 0;
 	InputPosRead = 0;

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A17 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A18 << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
This algorithm comes from pcsxr and is an implementation of Dr. Hell's research. It's supposed to be very accurate.

Bumps savestate because of new SPU core struct members.

The previous implementation was a simple LFSR and did not use the provided noise clock from the ATTR register.