### PR TITLE
Remove wxString ↔︎ std::string implicit conversions

### DIFF
--- a/3rdparty/wxwidgets3.0/include/wx/string.h
+++ b/3rdparty/wxwidgets3.0/include/wx/string.h
@@ -1319,7 +1319,7 @@ public:
     wxString(const wxStdWideString& str)
         { assign(str.c_str(), str.length()); }
   #endif
-
+#ifndef _WIN32 // PCSX2: We don't want to accidentally interpret utf-8 std::strings as something else!
   #if !wxUSE_UNICODE // ANSI build
     // FIXME-UTF8: do this in UTF8 build #if wxUSE_UTF8_LOCALE_ONLY, too
     wxString(const std::string& str) : m_impl(str) {}
@@ -1327,6 +1327,7 @@ public:
     wxString(const std::string& str)
         { assign(str.c_str(), str.length()); }
   #endif
+#endif
 #endif // wxUSE_STD_STRING
 
   // Also always provide explicit conversions to std::[w]string in any case,

--- a/3rdparty/wxwidgets3.0/include/wx/string.h
+++ b/3rdparty/wxwidgets3.0/include/wx/string.h
@@ -1621,13 +1621,17 @@ public:
     // messages for the code which relies on implicit conversion to char* in
     // STL build
 #if !wxUSE_STD_STRING_CONV_IN_WXSTRING
+#ifndef _WIN32 // PCSX2: std::string conversion removal
     operator const char*() const { return c_str(); }
+#endif
     operator const wchar_t*() const { return c_str(); }
 
+#ifndef _WIN32 // PCSX2: std::string conversion removal
     // implicit conversion to untyped pointer for compatibility with previous
     // wxWidgets versions: this is the same as conversion to const char * so it
     // may fail!
     operator const void*() const { return c_str(); }
+#endif
 #endif // !wxUSE_STD_STRING_CONV_IN_WXSTRING
 
     // identical to c_str(), for MFC compatibility

--- a/3rdparty/wxwidgets3.0/include/wx/variant.h
+++ b/3rdparty/wxwidgets3.0/include/wx/variant.h
@@ -230,6 +230,7 @@ public:
     wxString GetString() const;
 
 #if wxUSE_STD_STRING
+#ifndef _WIN32 // PCSX2: std::string conversion removal
     wxVariant(const std::string& val, const wxString& name = wxEmptyString);
     bool operator==(const std::string& value) const
         { return operator==(wxString(value)); }
@@ -238,6 +239,7 @@ public:
     wxVariant& operator=(const std::string& value)
         { return operator=(wxString(value)); }
     operator std::string() const { return (operator wxString()).ToStdString(); }
+#endif
 
     wxVariant(const wxStdWideString& val, const wxString& name = wxEmptyString);
     bool operator==(const wxStdWideString& value) const

--- a/3rdparty/wxwidgets3.0/src/common/variant.cpp
+++ b/3rdparty/wxwidgets3.0/src/common/variant.cpp
@@ -981,11 +981,13 @@ wxVariant::wxVariant(const wxScopedWCharBuffer& val, const wxString& name)
 }
 
 #if wxUSE_STD_STRING
+#ifndef _WIN32 // PCSX2: std::string conversion removal
 wxVariant::wxVariant(const std::string& val, const wxString& name)
 {
     m_refData = new wxVariantDataString(wxString(val));
     m_name = name;
 }
+#endif
 
 wxVariant::wxVariant(const wxStdWideString& val, const wxString& name)
 {

--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -470,6 +470,28 @@ bool IConsoleWriter::Warning(const wxString fmt, ...) const
 	return false;
 }
 
+bool IConsoleWriter::WriteLn(ConsoleColors color, const std::string& str) const
+{
+	ConsoleColorScope cs(color);
+	return WriteLn(str);
+}
+
+bool IConsoleWriter::WriteLn(const std::string& str) const
+{
+	DoWriteLn(_addIndentation(fromUTF8(str), conlog_Indent));
+
+	return false;
+}
+
+bool IConsoleWriter::Error(const std::string& str) const
+{
+	return WriteLn(Color_StrongRed, str);
+}
+
+bool IConsoleWriter::Warning(const std::string& str) const
+{
+	return WriteLn(Color_StrongOrange, str);
+}
 
 // --------------------------------------------------------------------------------------
 //  ConsoleColorScope / ConsoleIndentScope

--- a/common/Console.h
+++ b/common/Console.h
@@ -125,6 +125,11 @@ struct IConsoleWriter
 	bool WriteLn(const wxString fmt, ...) const;
 	bool Error(const wxString fmt, ...) const;
 	bool Warning(const wxString fmt, ...) const;
+
+	bool WriteLn(ConsoleColors color, const std::string& str) const;
+	bool WriteLn(const std::string& str) const;
+	bool Error(const std::string& str) const;
+	bool Warning(const std::string& str) const;
 };
 
 // --------------------------------------------------------------------------------------

--- a/common/Dependencies.h
+++ b/common/Dependencies.h
@@ -270,6 +270,7 @@ extern const wxChar* __fastcall pxExpandMsg(const wxChar* message);
 extern const wxChar* __fastcall pxGetTranslation(const wxChar* message);
 extern bool pxIsEnglish(int id);
 
+extern wxString fromUTF8(const std::string& str);
 extern wxString fromUTF8(const char* src);
 extern wxString fromAscii(const char* src);
 

--- a/common/IniInterface.cpp
+++ b/common/IniInterface.cpp
@@ -274,7 +274,7 @@ void IniLoader::Entry(const wxString& var, std::string& value, const std::string
 	if (m_Config)
 	{
 		wxString temp;
-		m_Config->Read(var, &temp, wxString(default_value));
+		m_Config->Read(var, &temp, fromUTF8(default_value));
 		value = temp.ToStdString();
 	}
 	else if (&value != &default_value)
@@ -443,5 +443,5 @@ void IniSaver::Entry(const wxString& var, std::string& value, const std::string&
 {
 	if (!m_Config)
 		return;
-	m_Config->Write(var, wxString(value));
+	m_Config->Write(var, fromUTF8(value));
 }

--- a/common/StringHelpers.cpp
+++ b/common/StringHelpers.cpp
@@ -31,6 +31,11 @@ __fi wxString fromUTF8(const char* src)
 	return wxString(src, wxMBConvUTF8());
 }
 
+__fi wxString fromUTF8(const std::string& str)
+{
+	return wxString(str.data(), wxMBConvUTF8(), str.size());
+}
+
 __fi wxString fromAscii(const char* src)
 {
 	return wxString::FromAscii(src);

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -376,7 +376,7 @@ bool DoCDVDopen()
 		return true;
 	}
 
-	wxString somepick(Path::GetFilenameWithoutExt(m_SourceFilename[CurrentSourceType]));
+	wxString somepick(Path::GetFilenameWithoutExt(fromUTF8(m_SourceFilename[CurrentSourceType])));
 	//FWIW Disc serial availability doesn't seem reliable enough, sometimes it's there and sometime it's just null
 	//Shouldn't the serial be available all time? Potentially need to look into Elfreloadinfo() reliability
 	//TODO: Add extra fallback case for CRC.

--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -185,7 +185,7 @@ static wxString iso2indexname(const wxString& isoname)
 	wxDirName appRoot = // TODO: have only one of this in PCSX2. Right now have few...
 		(wxDirName)(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath());
 	//TestTemplate(appRoot, isoname, false);
-	return ApplyTemplate(L"gzip index", appRoot, EmuConfig.GzipIsoIndexTemplate, isoname, false);
+	return ApplyTemplate(L"gzip index", appRoot, fromUTF8(EmuConfig.GzipIsoIndexTemplate), isoname, false);
 }
 
 GzippedFileReader::GzippedFileReader(void)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -301,7 +301,6 @@ set(pcsx2SPU2Sources
 	SPU2/spu2sys.cpp
 	SPU2/Timestretcher.cpp
 	SPU2/Wavedump_wav.cpp
-	SPU2/WavFile.cpp
 	)
 
 if(TARGET PkgConfig::PORTAUDIO)
@@ -813,6 +812,7 @@ else(WIN32)
 		SPU2/Linux/ConfigDebug.cpp
 		SPU2/Linux/ConfigSoundTouch.cpp
 		SPU2/Linux/Dialogs.cpp
+		SPU2/WavFile.cpp
 		SPU2/wx/wxConfig.cpp
 	)
 	list(APPEND pcsx2SPU2Headers

--- a/pcsx2/DEV9/DEV9Config.cpp
+++ b/pcsx2/DEV9/DEV9Config.cpp
@@ -43,10 +43,10 @@ void SaveDnsHosts()
 		ScopedIniGroup iniEntry(ini, groupName);
 		ConfigHost entry = config.EthHosts[i];
 
-		wxString url(entry.Url);
+		wxString url(fromUTF8(entry.Url));
 		ini.Entry(L"Url", url);
 		//TODO UTF8(?)
-		wxString desc(entry.Desc);
+		wxString desc(fromUTF8(entry.Desc));
 		ini.Entry(L"Desc", desc);
 
 		char addrBuff[INET_ADDRSTRLEN];

--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -242,6 +242,11 @@ public:
 
 		return false;
 	}
+
+	bool Write(const std::string& msg) const
+	{
+		return Write(fromUTF8(msg));
+	}
 };
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1365,7 +1365,7 @@ void GSApp::SetConfigDir()
 	// core settings aren't populated yet, thus we do populate it if needed either when
 	// opening GS settings or init -- govanify
 	wxString iniName(L"GS.ini");
-	m_ini = EmuFolders::Settings.Combine(iniName).GetFullPath();
+	m_ini = EmuFolders::Settings.Combine(iniName).GetFullPath().ToUTF8();
 }
 
 std::string GSApp::GetConfigS(const char* entry)

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -235,7 +235,7 @@ void GSUIElementHolder::Save()
 				break;
 			case UIElem::Type::File:
 			case UIElem::Type::Directory:
-				theApp.SetConfig(elem.config, static_cast<wxFileDirPickerCtrlBase*>(elem.control)->GetPath());
+				theApp.SetConfig(elem.config, static_cast<wxFileDirPickerCtrlBase*>(elem.control)->GetPath().ToUTF8());
 				break;
 		}
 	}

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -36,9 +36,9 @@ namespace
 		for (const GSSetting& setting : s)
 		{
 			if (!setting.note.empty())
-				arr.Add(setting.name + " (" + setting.note + ")");
+				arr.Add(fromUTF8(setting.name + " (" + setting.note + ")"));
 			else
-				arr.Add(setting.name);
+				arr.Add(fromUTF8(setting.name));
 		}
 	}
 
@@ -204,8 +204,8 @@ void GSUIElementHolder::Load()
 			case UIElem::Type::Directory:
 			{
 				auto* picker = static_cast<wxFileDirPickerCtrlBase*>(elem.control);
-				picker->SetInitialDirectory(theApp.GetConfigS(elem.config));
-				picker->SetPath(theApp.GetConfigS(elem.config));
+				picker->SetInitialDirectory(fromUTF8(theApp.GetConfigS(elem.config)));
+				picker->SetPath(fromUTF8(theApp.GetConfigS(elem.config)));
 				break;
 			}
 		}

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -103,7 +103,7 @@ GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::entryFromYaml(const std::str
 			bool fixValidated = false;
 			for (GamefixId id = GamefixId_FIRST; id < pxEnumEnd; id++)
 			{
-				std::string validFix = fmt::format("{}Hack", wxString(EnumToString(id)));
+				std::string validFix = fmt::format("{}Hack", wxString(EnumToString(id)).ToUTF8());
 				if (validFix == fix)
 				{
 					fixValidated = true;
@@ -129,7 +129,7 @@ GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::entryFromYaml(const std::str
 				bool speedHackValidated = false;
 				for (SpeedhackId id = SpeedhackId_FIRST; id < pxEnumEnd; id++)
 				{
-					std::string validSpeedHack = fmt::format("{}SpeedHack", wxString(EnumToString(id)));
+					std::string validSpeedHack = fmt::format("{}SpeedHack", wxString(EnumToString(id)).ToUTF8());
 					if (validSpeedHack == speedHack)
 					{
 						speedHackValidated = true;

--- a/pcsx2/PAD/Windows/PADConfig.cpp
+++ b/pcsx2/PAD/Windows/PADConfig.cpp
@@ -337,7 +337,7 @@ void PADsetSettingsDir(const char* dir)
 
 	//uint targlen = MultiByteToWideChar(CP_ACP, 0, dir, -1, NULL, 0);
 	wxString iniName = "PAD.ini";
-	MultiByteToWideChar(CP_UTF8, 0, std::string(EmuFolders::Settings.Combine(iniName).GetFullPath()).c_str(), -1, iniFileUSB, MAX_PATH * 2);
+	StrCpyNW(iniFileUSB, EmuFolders::Settings.Combine(iniName).GetFullPath(), std::size(iniFileUSB));
 
 	createIniDir = false;
 

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -134,7 +134,7 @@ int LoadPatchesFromGamesDB(const wxString& crc, const GameDatabaseSchema::GameEn
 	if (game.isValid)
 	{
 		GameDatabaseSchema::Patch patch;
-		bool patchFound = game.findPatch(std::string(crc), patch);
+		bool patchFound = game.findPatch(std::string(crc.ToUTF8()), patch);
 		if (patchFound && patch.patchLines.size() > 0)
 		{
 			for (auto line : patch.patchLines)

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -139,7 +139,7 @@ int LoadPatchesFromGamesDB(const wxString& crc, const GameDatabaseSchema::GameEn
 		{
 			for (auto line : patch.patchLines)
 			{
-				inifile_command(line);
+				inifile_command(fromUTF8(line));
 			}
 		}
 	}

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -715,7 +715,7 @@ void __fastcall eeloadHook()
 		}
 	}
 
-	if (!g_GameStarted && (disctype == 2 || disctype == 1) && elfname == discelf)
+	if (!g_GameStarted && (disctype == 2 || disctype == 1) && fromUTF8(elfname) == discelf)
 		g_GameLoading = true;
 }
 

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -286,7 +286,7 @@ void InputRecording::SetupInitialState(u32 newStartingFrame)
 	if (state != InputRecordingMode::Replaying)
 	{
 		inputRec::log("Started new input recording");
-		inputRec::consoleLog(fmt::format("Filename {}", std::string(inputRecordingData.GetFilename())));
+		inputRec::consoleLog(fmt::format("Filename {}", inputRecordingData.GetFilename().ToUTF8()));
 		SetToRecordMode();
 	}
 	else
@@ -298,7 +298,7 @@ void InputRecording::SetupInitialState(u32 newStartingFrame)
 
 		incrementUndo = true;
 		inputRec::log("Replaying input recording");
-		inputRec::consoleMultiLog({fmt::format("File: {}", std::string(inputRecordingData.GetFilename())),
+		inputRec::consoleMultiLog({fmt::format("File: {}", inputRecordingData.GetFilename().ToUTF8()),
 								   fmt::format("PCSX2 Version Used: {}", std::string(inputRecordingData.GetHeader().emu)),
 								   fmt::format("Recording File Version: {}", inputRecordingData.GetHeader().version),
 								   fmt::format("Associated Game Name or ISO Filename: {}", std::string(inputRecordingData.GetHeader().gameName)),
@@ -317,7 +317,7 @@ void InputRecording::SetupInitialState(u32 newStartingFrame)
 
 void InputRecording::FailedSavestate()
 {
-	inputRec::consoleLog(fmt::format("{} is not compatible with this version of PCSX2", savestate));
+	inputRec::consoleLog(fmt::format("{} is not compatible with this version of PCSX2", savestate.ToUTF8()));
 	inputRec::consoleLog(fmt::format("Original PCSX2 version used: {}", inputRecordingData.GetHeader().emu));
 	inputRecordingData.Close();
 	initialLoad = false;
@@ -388,14 +388,14 @@ bool InputRecording::Play(wxWindow* parent, wxString filename)
 										 L"Savestate files (*.p2s)|*.p2s", wxFD_OPEN);
 			if (loadStateDialog.ShowModal() == wxID_CANCEL)
 			{
-				inputRec::consoleLog(fmt::format("Could not locate savestate file at location - {}", savestate));
+				inputRec::consoleLog(fmt::format("Could not locate savestate file at location - {}", savestate.ToUTF8()));
 				inputRec::log("Savestate load failed");
 				inputRecordingData.Close();
 				return false;
 			}
 
 			savestate = loadStateDialog.GetPath();
-			inputRec::consoleLog(fmt::format("Base savestate set to {}", savestate));
+			inputRec::consoleLog(fmt::format("Base savestate set to {}", savestate.ToUTF8()));
 		}
 		state = InputRecordingMode::Replaying;
 		initialLoad = true;
@@ -421,7 +421,7 @@ void InputRecording::GoToFirstFrame(wxWindow* parent)
 			if (!initiallyPaused)
 				g_InputRecordingControls.PauseImmediately();
 
-			inputRec::consoleLog(fmt::format("Could not locate savestate file at location - {}\n", savestate));
+			inputRec::consoleLog(fmt::format("Could not locate savestate file at location - {}\n", savestate.ToUTF8()));
 			wxFileDialog loadStateDialog(parent, _("Select a savestate to accompany the recording with"), L"", L"",
 										 L"Savestate files (*.p2s)|*.p2s", wxFD_OPEN);
 			int result = loadStateDialog.ShowModal();
@@ -434,7 +434,7 @@ void InputRecording::GoToFirstFrame(wxWindow* parent)
 				return;
 			}
 			savestate = loadStateDialog.GetPath();
-			inputRec::consoleLog(fmt::format ("Base savestate swapped to {}", savestate));
+			inputRec::consoleLog(fmt::format ("Base savestate swapped to {}", savestate.ToUTF8()));
 		}
 		StateCopy_LoadFromFile(savestate);
 	}
@@ -454,7 +454,7 @@ wxString InputRecording::resolveGameName()
 	{
 		if (IGameDatabase* gameDB = AppHost_GetGameDatabase())
 		{
-			GameDatabaseSchema::GameEntry game = gameDB->findGame(std::string(gameKey));
+			GameDatabaseSchema::GameEntry game = gameDB->findGame(std::string(gameKey.ToUTF8()));
 			if (game.isValid)
 			{
 				gameName = fromUTF8(game.name);

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -457,8 +457,8 @@ wxString InputRecording::resolveGameName()
 			GameDatabaseSchema::GameEntry game = gameDB->findGame(std::string(gameKey));
 			if (game.isValid)
 			{
-				gameName = game.name;
-				gameName += L" (" + game.region + L")";
+				gameName = fromUTF8(game.name);
+				gameName += L" (" + fromUTF8(game.region) + L")";
 			}
 		}
 	}

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -19,6 +19,7 @@
 #include "WavFile.h"
 #else
 #include "soundtouch/source/SoundStretch/WavFile.h"
+#include "common/StringUtil.h"
 #endif
 
 static WavOutFile* _new_WavOutFile(const char* destfile)
@@ -117,7 +118,11 @@ bool RecordStart(const std::string* filename)
 		ScopedLock lock(WavRecordMutex);
 		safe_delete(m_wavrecord);
 		if (filename)
+#ifdef _WIN32
+			m_wavrecord = new WavOutFile(_wfopen(StringUtil::UTF8StringToWideString(*filename).c_str(), L"wb"), 48000, 16, 2);
+#else
 			m_wavrecord = new WavOutFile(filename->c_str(), 48000, 16, 2);
+#endif
 		else
 			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
 		WavRecordEnabled = true;

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -314,7 +314,7 @@ static int loadGameSettings(Pcsx2Config& dest, const GameDatabaseSchema::GameEnt
 	// TODO - config - this could be simplified with maps instead of bitfields and enums
 	for (SpeedhackId id = SpeedhackId_FIRST; id < pxEnumEnd; id++)
 	{
-		std::string key = fmt::format("{}SpeedHack", wxString(EnumToString(id)));
+		std::string key = fmt::format("{}SpeedHack", wxString(EnumToString(id)).ToUTF8());
 
 		// Gamefixes are already guaranteed to be valid, any invalid ones are dropped
 		if (game.speedHacks.count(key) == 1)
@@ -331,7 +331,7 @@ static int loadGameSettings(Pcsx2Config& dest, const GameDatabaseSchema::GameEnt
 	// TODO - config - this could be simplified with maps instead of bitfields and enums
 	for (GamefixId id = GamefixId_FIRST; id < pxEnumEnd; id++)
 	{
-		std::string key = fmt::format("{}Hack", wxString(EnumToString(id)));
+		std::string key = fmt::format("{}Hack", wxString(EnumToString(id)).ToUTF8());
 
 		// Gamefixes are already guaranteed to be valid, any invalid ones are dropped
 		if (std::find(game.gameFixes.begin(), game.gameFixes.end(), key) != game.gameFixes.end())
@@ -452,7 +452,7 @@ static void _ApplySettings(const Pcsx2Config& src, Pcsx2Config& fixup)
 	{
 		if (IGameDatabase* GameDB = AppHost_GetGameDatabase())
 		{
-			GameDatabaseSchema::GameEntry game = GameDB->findGame(std::string(curGameKey));
+			GameDatabaseSchema::GameEntry game = GameDB->findGame(std::string(curGameKey.ToUTF8()));
 			if (game.isValid)
 			{
 				GameInfo::gameName = fromUTF8(game.name);

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -323,7 +323,7 @@ static int loadGameSettings(Pcsx2Config& dest, const GameDatabaseSchema::GameEnt
 			// are effectively booleans like the gamefixes
 			bool mode = game.speedHacks.at(key) ? 1 : 0;
 			dest.Speedhacks.Set(id, mode);
-			PatchesCon->WriteLn(L"(GameDB) Setting Speedhack '" + key + "' to [mode=%d]", mode);
+			PatchesCon->WriteLn(fmt::format("(GameDB) Setting Speedhack '{}' to [mode={}]", key, (int)mode));
 			gf++;
 		}
 	}
@@ -338,7 +338,7 @@ static int loadGameSettings(Pcsx2Config& dest, const GameDatabaseSchema::GameEnt
 		{
 			// if the fix is present, it is said to be enabled
 			dest.Gamefixes.Set(id, true);
-			PatchesCon->WriteLn(L"(GameDB) Enabled Gamefix: " + key);
+			PatchesCon->WriteLn("(GameDB) Enabled Gamefix: " + key);
 			gf++;
 
 			// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB)
@@ -455,10 +455,10 @@ static void _ApplySettings(const Pcsx2Config& src, Pcsx2Config& fixup)
 			GameDatabaseSchema::GameEntry game = GameDB->findGame(std::string(curGameKey));
 			if (game.isValid)
 			{
-				GameInfo::gameName = game.name;
-				GameInfo::gameName += L" (" + game.region + L")";
+				GameInfo::gameName = fromUTF8(game.name);
+				GameInfo::gameName += L" (" + fromUTF8(game.region) + L")";
 				gameCompat = L" [Status = " + compatToStringWX(game.compat) + L"]";
-				gameMemCardFilter = game.memcardFiltersAsString();
+				gameMemCardFilter = fromUTF8(game.memcardFiltersAsString());
 			}
 
 			if (fixup.EnablePatches)

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1019,7 +1019,7 @@ void Pcsx2App::SysExecute()
 // sources.
 void Pcsx2App::SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override )
 {
-	SysExecutorThread.PostEvent( new SysExecEvent_Execute(cdvdsrc, elf_override.ToStdString()) );
+	SysExecutorThread.PostEvent( new SysExecEvent_Execute(cdvdsrc, elf_override) );
 #ifndef DISABLE_RECORDING
 	if (g_Conf->EmuOptions.EnableRecordingTools)
 	{

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -1273,6 +1273,6 @@ void OSDlog(ConsoleColors color, bool console, const std::string& str)
 }
 
 void OSDmonitor(ConsoleColors color, const std::string key, const std::string value) {
-	GSosdMonitor(wxString(key).utf8_str(), wxString(value).utf8_str(), wxGetApp().GetProgramLog()->GetRGBA(color));
+	GSosdMonitor(key.c_str(), value.c_str(), wxGetApp().GetProgramLog()->GetRGBA(color));
 }
 

--- a/pcsx2/gui/Debugger/CtrlMemSearch.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemSearch.cpp
@@ -229,7 +229,7 @@ void CtrlMemSearch::Search(wxCommandEvent& evt)
 	wxString searchString = txtSearch->GetValue();
 	if (m_SearchThread->m_type == SEARCHTYPE::STRING)
 	{
-		m_SearchThread->m_value_string = searchString;
+		m_SearchThread->m_value_string = searchString.ToUTF8();
 	}
 	else if (chkHexadecimal->IsChecked())
 	{

--- a/pcsx2/gui/DriveList.cpp
+++ b/pcsx2/gui/DriveList.cpp
@@ -55,8 +55,8 @@ void DriveListManager::RefreshList()
 	for (auto i : drives)
 	{
 		std::unique_ptr<DriveListItem> dli = std::unique_ptr<DriveListItem>(new DriveListItem());
-		dli->driveLetter = wxString(i);
-		dli->itemPtr = m_Menu->AppendRadioItem(wxID_ANY, i);
+		dli->driveLetter = fromUTF8(i);
+		dli->itemPtr = m_Menu->AppendRadioItem(wxID_ANY, dli->driveLetter);
 
 		// Check the last used drive item
 		if (g_Conf->Folders.RunDisc == dli->driveLetter)

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -62,9 +62,9 @@ wxMenu* MainEmuFrame::MakeStatesSubMenu(int baseid, int loadBackupId) const
 	// For safety i also made them inactive aka grayed out to signify that's it's only for informational purposes
 	// Fixme: In the future this can still be expanded to actually cycle savestates in the GUI.
 	mnuSubstates->Append(baseid - 1, _("File..."));
-	wxMenuItem* CycleNext = mnuSubstates->Append(baseid - 2, _("Cycle to next slot") + wxString("  ") + fmt::format("({})", wxGetApp().GlobalAccels->findKeycodeWithCommandId("States_CycleSlotForward").toTitleizedString()));
+	wxMenuItem* CycleNext = mnuSubstates->Append(baseid - 2, _("Cycle to next slot") + wxString("\t") + wxGetApp().GlobalAccels->findKeycodeWithCommandId("States_CycleSlotForward").toTitleizedString());
 	CycleNext->Enable(false);
-	wxMenuItem* CycleBack = mnuSubstates->Append(baseid - 3, _("Cycle to previous slot") + wxString("  ") + fmt::format("({})", wxGetApp().GlobalAccels->findKeycodeWithCommandId("States_CycleSlotBackward").toTitleizedString()));
+	wxMenuItem* CycleBack = mnuSubstates->Append(baseid - 3, _("Cycle to previous slot") + wxString("\t") + wxGetApp().GlobalAccels->findKeycodeWithCommandId("States_CycleSlotBackward").toTitleizedString());
 	CycleBack->Enable(false);
 	return mnuSubstates;
 }
@@ -89,7 +89,7 @@ void MainEmuFrame::UpdateStatusBar()
 	m_statusbar.SetStatusText(temp, 0);
 
 	if (g_Conf->EnablePresets)
-		m_statusbar.SetStatusText(fmt::format("P:{}", g_Conf->PresetIndex + 1), 1);
+		m_statusbar.SetStatusText(wxString::Format(L"P:%d", g_Conf->PresetIndex + 1), 1);
 	else
 		m_statusbar.SetStatusText("---", 1);
 
@@ -524,7 +524,7 @@ void MainEmuFrame::CreateInputRecordingMenu()
 
 	m_menuRecording.Append(MenuId_Recording_Settings, _("Settings"), &m_submenu_recording_settings);
 	wxString frame_advance_label = wxString(_("Configure Frame Advance"));
-	frame_advance_label.Append(fmt::format(" ({})", g_Conf->inputRecording.m_frame_advance_amount));
+	frame_advance_label.Append(wxString::Format(" (%d)", g_Conf->inputRecording.m_frame_advance_amount));
 	m_submenu_recording_settings.Append(MenuId_Recording_Config_FrameAdvance, frame_advance_label, _("Change the amount of frames advanced each time"));
 	m_menuRecording.AppendSeparator();
 
@@ -836,7 +836,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 #ifndef DISABLE_RECORDING
 		menubar.Check(MenuId_EnableInputRecording, configToApply.EmuOptions.EnableRecordingTools);
 		wxString frame_advance_label = wxString(_("Configure Frame Advance"));
-		frame_advance_label.Append(fmt::format(" ({})", configToApply.inputRecording.m_frame_advance_amount));
+		frame_advance_label.Append(wxString::Format(" (%d)", configToApply.inputRecording.m_frame_advance_amount));
 		m_submenu_recording_settings.SetLabel(MenuId_Recording_Config_FrameAdvance, frame_advance_label);
 		g_InputRecordingControls.setFrameAdvanceAmount(configToApply.inputRecording.m_frame_advance_amount);
 #endif

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -1114,7 +1114,7 @@ void MainEmuFrame::Menu_Recording_Config_FrameAdvance(wxCommandEvent& event)
 		g_Conf->inputRecording.m_frame_advance_amount = result;
 		g_InputRecordingControls.setFrameAdvanceAmount(result);
 		wxString frame_advance_label = wxString(_("Configure Frame Advance"));
-		frame_advance_label.Append(fmt::format(" ({})", result));
+		frame_advance_label.Append(wxString::Format(" (%ld)", result));
 		m_submenu_recording_settings.SetLabel(MenuId_Recording_Config_FrameAdvance, frame_advance_label);
 	}
 }

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -107,7 +107,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 	s_AspectRatio.AddGrowableCol(1);
 
 	// Implement custom hotkeys (F6) with translatable string intact + not blank in GUI.
-	s_AspectRatio += Label(_("Aspect Ratio:") + wxString(" ") + fmt::format("({})", wxGetApp().GlobalAccels->findKeycodeWithCommandId("GSwindow_CycleAspectRatio").toTitleizedString())) | pxMiddle;
+	s_AspectRatio += Label(_("Aspect Ratio:") + wxString("\t") + wxGetApp().GlobalAccels->findKeycodeWithCommandId("GSwindow_CycleAspectRatio").toTitleizedString()) | pxMiddle;
 	s_AspectRatio += m_combo_AspectRatio | pxAlignRight;
 	s_AspectRatio += Label(_("FMV Aspect Ratio Override:")) | pxMiddle;
 	s_AspectRatio += m_combo_FMVAspectRatioSwitch | pxAlignRight;

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -65,7 +65,7 @@ Panels::FramelimiterPanel::FramelimiterPanel( wxWindow* parent )
 
 	//  Implement custom hotkeys (Shift + Tab) with translatable string intact + not blank in GUI. 
 
-	s_spins += Label(_("Slow Motion Adjust:") + wxString(" ") + fmt::format("({})", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Framelimiter_SlomoToggle").toTitleizedString())) | StdExpand();
+	s_spins += Label(_("Slow Motion Adjust:") + wxString::Format(" (%s)", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Framelimiter_SlomoToggle").toTitleizedString())) | StdExpand();
 	s_spins += 5;
 	s_spins += m_spin_SlomoPct						| pxBorder(wxTOP, 3);
 	s_spins += Label(L"%")							| StdExpand();
@@ -73,7 +73,7 @@ Panels::FramelimiterPanel::FramelimiterPanel( wxWindow* parent )
 
 	//  Implement custom hotkeys (Tab) with translatable string intact + not blank in GUI. 
 
-	s_spins += Label(_("Turbo Adjust:") + wxString(" ") + fmt::format("({})", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Framelimiter_TurboToggle").toTitleizedString())) | StdExpand();
+	s_spins += Label(_("Turbo Adjust:") + wxString::Format(" (%s)", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Framelimiter_TurboToggle").toTitleizedString())) | StdExpand();
 	s_spins += 5;
 	s_spins += m_spin_TurboPct						| pxBorder(wxTOP, 3);
 	s_spins += Label(L"%") 							| StdExpand();
@@ -176,11 +176,11 @@ Panels::FrameSkipPanel::FrameSkipPanel( wxWindow* parent )
 		),
 		//  Implement custom hotkeys (Tab) with translatable string intact + not blank in GUI.  
 		RadioPanelItem(
-			_("Skip only on Turbo, to enable press") + fmt::format("{} ({})", " ", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Framelimiter_TurboToggle").toTitleizedString())
+			_("Skip only on Turbo, to enable press") + wxString::Format(" (%s)", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Framelimiter_TurboToggle").toTitleizedString())
 		),
 		//  Implement custom hotkeys (Shift + F4) with translatable string intact + not blank in GUI.  
 		RadioPanelItem(
-			_("Constant skipping") + fmt::format("{} ({})", " ", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Frameskip_Toggle").toTitleizedString()),
+			_("Constant skipping") + wxString::Format(" (%s)", wxGetApp().GlobalAccels->findKeycodeWithCommandId("Frameskip_Toggle").toTitleizedString()),
 			wxEmptyString,
 			_("Normal and Turbo limit rates skip frames.  Slow motion mode will still disable frameskipping.")
 		),

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -228,8 +228,9 @@ static void LoadIrx( const std::string& filename, u8* dest )
 	s64 filesize = 0;
 	try
 	{
-		wxFile irx(filename);
-		if( (filesize=Path::GetFileSize( filename ) ) <= 0 ) {
+		wxString wname = fromUTF8(filename);
+		wxFile irx(wname);
+		if( (filesize=Path::GetFileSize( wname ) ) <= 0 ) {
 			Console.Warning("IRX Warning: %s could not be read", filename.c_str());
 			return;
 		}


### PR DESCRIPTION
They're non-unicode on windows and were breaking everything

This removes them from our included wx, preventing them from inadvertently being used.  Hopefully this will make PCSX2 an application that manages two character sets (UTF-8, UTF16), rather than three (UTF-8, UTF-16, Current Windows Locale)

Also fixes up some plugins that were calling the non-unicode versions of various library calls

Note: Should probably test to make sure I didn't break anything in doing that