### PR TITLE
ghactions:macos: Disable homebrew cleanup

### DIFF
--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
         run: |
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew install sound-touch portaudio wxmac gtk+3 sdl2 libsamplerate
           brew install --cask xquartz # We use its OpenGL headers
 


### PR DESCRIPTION
Homebrew periodic cleanup and containers don't mix well, as the "every 30 days" turns into "every time", ends up wasting 1-2m of build time