### PR TITLE
SPU2: Improve ADMA behaviour/timing

### DIFF
--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -97,7 +97,7 @@ void V_Core::LogAutoDMA(FILE* fp)
 
 void V_Core::AutoDMAReadBuffer(int mode) //mode: 0= split stereo; 1 = do not split stereo
 {
-	int spos = ActiveTSA & 0x100;// ((InputPosRead + 0xff) & 0x100); //starting position of the free buffer
+	int spos = ActiveTSA & 0x100; // Starting position passed by TSA
 
 	if (spos == (OutPos & 0x100))
 		return;
@@ -173,9 +173,6 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 				AutoDMAReadBuffer(Index, 0);
 			}
 #else
-			if (((PlayMode & 4) == 4) && (Index == 0))
-				Cores[0].InputPosRead = 0;
-
 			AutoDMAReadBuffer(0);
 #endif
 

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -133,7 +133,7 @@ void V_Core::AutoDMAReadBuffer(int mode) //mode: 0= split stereo; 1 = do not spl
 
 			if (DMAPtr != nullptr)
 				memcpy(GetMemPtr(0x2000 + (Index << 10) + spos), DMAPtr + InputDataProgress, 0x200);
-			MADR += 0x200;
+			InputDataTransferred += 0x200;
 			InputDataLeft -= 0x100;
 			InputDataProgress += 0x100;
 			leftbuffer = !leftbuffer;

--- a/pcsx2/SPU2/ReadInput.cpp
+++ b/pcsx2/SPU2/ReadInput.cpp
@@ -33,23 +33,10 @@ StereoOut32 V_Core::ReadInput_HiFi()
 {
 	if (psxmode)
 		ConLog("ReadInput_HiFi!!!!!\n");
-	InputPosRead &= ~1;
-	//
-	//#ifdef PCM24_S1_INTERLEAVE
-	//	StereoOut32 retval(
-	//		*((s32*)(ADMATempBuffer+(InputPosRead<<1))),
-	//		*((s32*)(ADMATempBuffer+(InputPosRead<<1)+2))
-	//	);
-	//#else
-	//	StereoOut32 retval(
-	//		(s32&)(ADMATempBuffer[InputPosRead]),
-	//		(s32&)(ADMATempBuffer[InputPosRead+0x200])
-	//	);
-	//#endif
 
 	StereoOut32 retval(
-		(s32&)(*GetMemPtr(0x2000 + (Index << 10) + InputPosRead)),
-		(s32&)(*GetMemPtr(0x2200 + (Index << 10) + InputPosRead)));
+		(s32&)(*GetMemPtr(0x2000 + (Index << 10) + OutPos)),
+		(s32&)(*GetMemPtr(0x2200 + (Index << 10) + OutPos)));
 
 	if (Index == 1)
 	{
@@ -61,25 +48,19 @@ StereoOut32 V_Core::ReadInput_HiFi()
 		retval.Right >>= 4;
 	}
 
-	InputPosRead += 2;
-
 	// Why does CDDA mode check for InputPos == 0x100? In the old code, SPDIF mode did not but CDDA did.
 	//  One of these seems wrong, they should be the same.  Since standard ADMA checks too I'm assuming that as default. -- air
 
-	if ((InputPosRead == 0x100) || (InputPosRead >= 0x200))
+	if ((OutPos == 0xFF || OutPos == 0x1FF))
 	{
-		AdmaInProgress = 0;
 		if (InputDataLeft >= 0x200)
 		{
-#ifdef PCM24_S1_INTERLEAVE
-			AutoDMAReadBuffer(1);
-#else
+			int oldOutPos = OutPos;
+			OutPos = (OutPos + 1) & 0x1FF;
 			AutoDMAReadBuffer(0);
-#endif
+			OutPos = oldOutPos;
 			AdmaInProgress = 1;
 
-			ActiveTSA = (Index << 10) + InputPosRead;
-			TSA = ActiveTSA;
 			if (InputDataLeft < 0x200)
 			{
 				FileLog("[%10d] %s AutoDMA%c block end.\n", (Index == 1) ? "CDDA" : "SPDIF", Cycles, GetDmaIndexChar());
@@ -92,26 +73,12 @@ StereoOut32 V_Core::ReadInput_HiFi()
 							ConLog("WARNING: adma buffer didn't finish with a whole block!!\n");
 					}
 				}
+				AdmaInProgress = 0;
 				InputDataLeft = 0;
-				// Hack, kinda. We call the interrupt early here, since PCSX2 doesn't like them delayed.
-				//DMAICounter		= 1;
-				if (Index == 0)
-				{
-					if (!SPU2_dummy_callback)
-						spu2DMA4Irq();
-					else
-						SPU2interruptDMA4();
-				}
-				else
-				{
-					if (!SPU2_dummy_callback)
-						spu2DMA7Irq();
-					else
-						SPU2interruptDMA7();
-				}
+				DMAICounter = 0x200 * 4;
+				LastClock = *cyclePtr;
 			}
 		}
-		InputPosRead &= 0x1ff;
 	}
 	return retval;
 }
@@ -126,21 +93,15 @@ StereoOut32 V_Core::ReadInput()
 			if (Cores[i].IRQEnable && 0x2000 + (Index << 10) + OutPos == (Cores[i].IRQA & 0xfffffdff))
 				SetIrqCall(i);
 
-		//retval = StereoOut32(
-		//	(s32)ADMATempBuffer[InputPosRead],
-		//	(s32)ADMATempBuffer[InputPosRead+0x200]
-		//);
 		retval = StereoOut32(
 			(s32)(*GetMemPtr(0x2000 + (Index << 10) + OutPos)),
 			(s32)(*GetMemPtr(0x2200 + (Index << 10) + OutPos)));
 	}
 
 #ifdef PCSX2_DEVBUILD
-	DebugCores[Index].admaWaveformL[InputPosRead % 0x100] = retval.Left;
-	DebugCores[Index].admaWaveformR[InputPosRead % 0x100] = retval.Right;
+	DebugCores[Index].admaWaveformL[OutPos % 0x100] = retval.Left;
+	DebugCores[Index].admaWaveformR[OutPos % 0x100] = retval.Right;
 #endif
-
-	InputPosRead++;
 
 	if ((OutPos == 0xFF || OutPos == 0x1FF))
 	{
@@ -173,6 +134,5 @@ StereoOut32 V_Core::ReadInput()
 			}
 		}
 	}
-	InputPosRead &= 0x1ff;
 	return retval;
 }

--- a/pcsx2/SPU2/ReadInput.cpp
+++ b/pcsx2/SPU2/ReadInput.cpp
@@ -48,9 +48,6 @@ StereoOut32 V_Core::ReadInput_HiFi()
 		retval.Right >>= 4;
 	}
 
-	// Why does CDDA mode check for InputPos == 0x100? In the old code, SPDIF mode did not but CDDA did.
-	//  One of these seems wrong, they should be the same.  Since standard ADMA checks too I'm assuming that as default. -- air
-
 	if ((OutPos == 0xFF || OutPos == 0x1FF))
 	{
 		if (InputDataLeft >= 0x200)
@@ -103,9 +100,9 @@ StereoOut32 V_Core::ReadInput()
 	DebugCores[Index].admaWaveformR[OutPos % 0x100] = retval.Right;
 #endif
 
-	if ((OutPos == 0xFF || OutPos == 0x1FF))
+	if (OutPos == 0xFF || OutPos == 0x1FF || OutPos == 0x7F || OutPos == 0x17F)
 	{
-		if (InputDataLeft >= 0x200)
+		if (InputDataLeft >= 0x100)
 		{
 			//u8 k=InputDataLeft>=InputDataProgress;
 			int oldOutPos = OutPos;
@@ -113,7 +110,7 @@ StereoOut32 V_Core::ReadInput()
 			AutoDMAReadBuffer(0);
 			OutPos = oldOutPos;
 			AdmaInProgress = 1;
-			if (InputDataLeft < 0x200)
+			if (InputDataLeft < 0x100)
 			{
 				if ((AutoDMACtrl & (Index + 1)))
 					AutoDMACtrl |= ~3;

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -406,6 +406,7 @@ struct V_Core
 	s32 DMAICounter;   // DMA Interrupt Counter
 	u32 LastClock;     // DMA Interrupt Clock Cycle Counter
 	u32 InputDataLeft; // Input Buffer
+	u32 InputDataTransferred; // Used for simulating MADR increase (GTA VC)
 	u32 InputPosWrite;
 	u32 InputDataProgress;
 

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -406,7 +406,6 @@ struct V_Core
 	s32 DMAICounter;   // DMA Interrupt Counter
 	u32 LastClock;     // DMA Interrupt Clock Cycle Counter
 	u32 InputDataLeft; // Input Buffer
-	u32 InputPosRead;
 	u32 InputPosWrite;
 	u32 InputDataProgress;
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -132,7 +132,8 @@ void SPU2writeDMA4Mem(u16* pMem, u32 size) // size now in 16bit units
 void SPU2interruptDMA4()
 {
 	FileLog("[%10d] SPU2 interruptDMA4\n", Cycles);
-	Cores[0].Regs.STATX |= 0x80;
+	if(Cores[0].DmaMode)
+		Cores[0].Regs.STATX |= 0x80;
 	Cores[0].Regs.STATX &= ~0x400;
 	Cores[0].TSA = Cores[0].ActiveTSA;
 }
@@ -140,7 +141,8 @@ void SPU2interruptDMA4()
 void SPU2interruptDMA7()
 {
 	FileLog("[%10d] SPU2 interruptDMA7\n", Cycles);
-	Cores[1].Regs.STATX |= 0x80;
+	if (Cores[1].DmaMode)
+		Cores[1].Regs.STATX |= 0x80;
 	Cores[1].Regs.STATX &= ~0x400;
 	Cores[1].TSA = Cores[1].ActiveTSA;
 }

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1522,11 +1522,11 @@ static void __fastcall RegWrite_Core(u16 value)
 				return;
 			}
 			thiscore.AutoDMACtrl = value;
-			if (value == 0 && thiscore.AdmaInProgress && (thiscore.Regs.STATX & 0x400))
+			if (value == 0 && thiscore.AdmaInProgress)
 			{
+				// Kill the current transfer so it doesn't continue
 				thiscore.AdmaInProgress = 0;
-				thiscore.Regs.STATX &= ~0x400; // Set DMA as not busy transferring
-				// No need to end the DMA here, the IOP seems to handle that
+				thiscore.InputDataLeft = 0;
 			}
 			break;
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -134,8 +134,9 @@ void V_Core::Init(int index)
 	NoiseOut = 0;
 	AutoDMACtrl = 0;
 	InputDataLeft = 0;
-	InputPosWrite = 0;
+	InputPosWrite = 0x100;
 	InputDataProgress = 0;
+	InputDataTransferred = 0;
 	ReverbX = 0;
 	LastEffect.Left = 0;
 	LastEffect.Right = 0;
@@ -1530,6 +1531,7 @@ static void __fastcall RegWrite_Core(u16 value)
 				thiscore.AdmaInProgress = 0;
 				thiscore.InputDataLeft = 0;
 				thiscore.DMAICounter = 0;
+				thiscore.InputDataTransferred = 0;
 			}
 			break;
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -134,7 +134,6 @@ void V_Core::Init(int index)
 	NoiseOut = 0;
 	AutoDMACtrl = 0;
 	InputDataLeft = 0;
-	InputPosRead = 0;
 	InputPosWrite = 0;
 	InputDataProgress = 0;
 	ReverbX = 0;

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A18 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A19 << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A19 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A1A << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
Seems to have a positive impact on The Simpsons (I know I keep saying this)
Hopefully improves the crackling in burnout 3, Fixes #2341
Apparently fixes music looping in Ratatouille
Fixes #3846 Vexx clicking sound (Partial ADMA transfers)
Fixes the Dolby Pro Logic video missing sound in Primal (Partial ADMA transfers)
Splinter Cell panning audio problem and high pitched noises in cutscenes, Fixes #2056
Myst 3 panning audio problem, Fixes #4160
Dynasty Warriors 5 stuttering videos when Dolby is enabled

If you have any other games which had constantly crackly audio or missing audio, especially in videos, this might help.