### PR TITLE
CI: Static Analysis -- Add Codacy

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - '3rdparty/**'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Windows Build](https://github.com/PCSX2/pcsx2/workflows/Windows%20Build/badge.svg)
 ![Linux Build](https://github.com/PCSX2/pcsx2/workflows/Linux%20Build/badge.svg)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/1f7c0d75fec74d6daa6adb084e5b4f71)](https://www.codacy.com/gh/PCSX2/pcsx2/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=PCSX2/pcsx2&amp;utm_campaign=Badge_Grade)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/6310/badge.svg)](https://scan.coverity.com/projects/6310)
 [![Discord Server](https://img.shields.io/discord/309643527816609793)](https://discord.com/invite/TCz3t9k)
 


### PR DESCRIPTION
I set it up on my fork to offer a demonstration - https://app.codacy.com/gh/xTVaser/pcsx2-rr

Steps to turning this on **(do this before merging this PR)**:
1. You need to be someone with admin access to the PCSX2 repo / org
2. Set up the free OSS plan for the organization - https://github.com/marketplace/codacy
3. Log-in via GitHub if it doesn't already redirect you (can't recall) here - https://www.codacy.com/
4. Add the PCSX2/pcsx2 repo
5. If annotations on PRs are desired, enable them here - https://app.codacy.com/gh/PCSX2/pcsx2-rr/settings/integrations
    - They will look like this - https://github.com/xTVaser/pcsx2-rr/pull/61/files
6. That's it!  Codacy checks will start appearing on PRs and master commits should be scanned and the issues in the repo should be tracked overtime / the dashboard can be used to identify and solve issues.

Codacy automatically enables checks based on the GitHub language stats.  ie if you use python code, it turns on PyLint.

Potential follow-up:
- We can analyze the CPP code further by running `clang-tidy` and sending the report to Codacy from Github Actions so the issues can be tracked.  However, `cppcheck` gives us plenty of issues to chew on for now.