### PR TITLE
CI: Add an explicit flag to retain debugging artifacts (.pdb, .exp, .lib, etc) in Windows builds

### DIFF
--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -23,6 +23,12 @@ on:
       - debian-packager/
       - bin/PCSX2_keys.ini.default
       - "pcsx2/PAD/Linux/**"
+  workflow_dispatch:
+    inputs:
+      retainDebugArtifacts:
+        description: 'Retain debug artifacts (.pdb/.exp/.lib) for an easier debugging experience'
+        required: true
+        default: 'false'
 
 jobs:
   build:
@@ -67,7 +73,7 @@ jobs:
       - name: Build PCSX2
         env:
           # Set to 'true' to retain the .pdb / .exp / .lib, etc files which can be useful for repro'ing issues that only occur in the compiled .exe
-          RetainDebuggingArtifacts: "false"
+          RetainDebuggingArtifacts: "${{ github.event.inputs.retainDebugArtifacts == 'true' }}"
         run: msbuild "buildbot.xml" /m /v:n /t:ReleaseAll /p:Platform=${{ matrix.platform }}
 
       - name: Prepare Artifact Metadata

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       retainDebugArtifacts:
-        description: 'Retain debug artifacts (.pdb/.exp/.lib) for an easier debugging experience'
+        description: 'Retain debug artifacts (.pdb/.exp/.lib) for an easier debugging experience. (true|false)'
         required: true
         default: 'false'
 
@@ -73,7 +73,7 @@ jobs:
       - name: Build PCSX2
         env:
           # Set to 'true' to retain the .pdb / .exp / .lib, etc files which can be useful for repro'ing issues that only occur in the compiled .exe
-          RetainDebuggingArtifacts: "${{ github.event.inputs.retainDebugArtifacts == 'true' }}"
+          RetainDebuggingArtifacts: ${{ github.event.inputs.retainDebugArtifacts == 'true' }}
         run: msbuild "buildbot.xml" /m /v:n /t:ReleaseAll /p:Platform=${{ matrix.platform }}
 
       - name: Prepare Artifact Metadata

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -65,6 +65,9 @@ jobs:
           vs-version: 16.7
 
       - name: Build PCSX2
+        env:
+          # Set to 'true' to retain the .pdb / .exp / .lib, etc files which can be useful for repro'ing issues that only occur in the compiled .exe
+          RetainDebuggingArtifacts: "false"
         run: msbuild "buildbot.xml" /m /v:n /t:ReleaseAll /p:Platform=${{ matrix.platform }}
 
       - name: Prepare Artifact Metadata

--- a/buildbot.xml
+++ b/buildbot.xml
@@ -20,8 +20,11 @@
       CreateHardLinksForPublishFilesIfPossible=$(CreateHardLinksIfPossible);
     </CompileFastPlz>
   </PropertyGroup>
+  <PropertyGroup>
+    <RetainDebuggingArtifacts Condition="'$(RetainDebuggingArtifacts)' == ''">false</RetainDebuggingArtifacts>
+  </PropertyGroup>
   <!-- Add all the custom targets here. -->
-  <Target Name="CleanBloat" AfterTargets="InternalBuild">
+  <Target Name="CleanBloat" AfterTargets="InternalBuild" Condition="'$(RetainDebuggingArtifacts)' == 'false'">
     <ItemGroup>
       <BloatToDelete Include="$(MSBuildProjectDirectory)\bin\**\*.bsc"/>
       <BloatToDelete Include="$(MSBuildProjectDirectory)\bin\**\*.exp"/>


### PR DESCRIPTION
When debugging a recent PR we ran into issues where the CI build would consistently produce an exception that could not be replicated conventionally via the local Visual Studio build.  It seems valuable to me to easily flip on these artifacts going forward, to make it easier to attach a debugger to the process and get a stacktrace at a minimum.

However, enabling these does increase the artifact size by 4x (numbers in the actions summary pages are the uncompressed file-size which are much larger).  So I've left them still off by default.

An example commit/build that flips this flag to `true` - https://github.com/xTVaser/pcsx2-rr/actions/runs/508048107

