### PR TITLE
SPU2: Ignore LSAL/H Writes after key on if voice sets loop point

### DIFF
--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -193,7 +193,7 @@ struct V_Voice
 	s32 SCurrent;
 
 	// it takes a few ticks for voices to start on the real SPU2?
-	bool Start();
+	void Start();
 	void Stop();
 };
 

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -136,6 +136,10 @@ public:
 struct V_Voice
 {
 	u32 PlayCycle; // SPU2 cycle where the Playing started
+	u32 LoopCycle; // SPU2 cycle where it last set its own Loop
+
+	u32 PendingLoopStartA;
+	bool PendingLoopStart;
 
 	V_VolumeSlideLR Volume;
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -336,32 +336,11 @@ void V_Core::UpdateEffectsBufferSize()
 	RevBuffers.APF2_R_SRC = EffectsBufferIndexer(Revb.APF2_R_DST - Revb.APF2_SIZE);
 }
 
-bool V_Voice::Start()
+void V_Voice::Start()
 {
-	if (StartA & 7)
-	{
-		fprintf(stderr, " *** Misaligned StartA %05x!\n", StartA);
-		StartA = (StartA + 0xFFFF8) + 0x8;
-	}
-
-	ADSR.Releasing = false;
-	ADSR.Value = 1;
-	ADSR.Phase = 1;
-	SCurrent = 28;
-	LoopMode = 0;
-	SP = 0;
-	LoopFlags = 0;
-	NextA = StartA | 1;
-	Prev1 = 0;
-	Prev2 = 0;
-	PendingLoopStart = false;
-
-	PV1 = PV2 = 0;
-	PV3 = PV4 = 0;
-	NextCrest = -0x8000;
 	PlayCycle = Cycles;
 	LoopCycle = Cycles - 1; // Get it out of the start range as to not confuse it
-	return true;
+	PendingLoopStart = false;
 }
 
 void V_Voice::Stop()
@@ -373,6 +352,37 @@ void V_Voice::Stop()
 uint TickInterval = 768;
 static const int SanityInterval = 4800;
 extern void UpdateDebugDialog();
+
+__forceinline bool StartQueuedVoice(uint coreidx, uint voiceidx)
+{
+	V_Voice& vc(Cores[coreidx].Voices[voiceidx]);
+
+	if ((Cycles - vc.PlayCycle) < 2)
+		return false;
+
+	if (vc.StartA & 7)
+	{
+		fprintf(stderr, " *** Misaligned StartA %05x!\n", vc.StartA);
+		vc.StartA = (vc.StartA + 0xFFFF8) + 0x8;
+	}
+
+	vc.ADSR.Releasing = false;
+	vc.ADSR.Value = 1;
+	vc.ADSR.Phase = 1;
+	vc.SCurrent = 28;
+	vc.LoopMode = 0;
+	vc.SP = 0;
+	vc.LoopFlags = 0;
+	vc.NextA = vc.StartA | 1;
+	vc.Prev1 = 0;
+	vc.Prev2 = 0;
+
+	vc.PV1 = vc.PV2 = 0;
+	vc.PV3 = vc.PV4 = 0;
+	vc.NextCrest = -0x8000;
+
+	return true;
+}
 
 __forceinline void TimeUpdate(u32 cClocks)
 {
@@ -429,6 +439,12 @@ __forceinline void TimeUpdate(u32 cClocks)
 		lClocks += TickInterval;
 		Cycles++;
 
+		// Start Queued Voices, they start after 2T (Tested on real HW)
+		for(int c = 0; c < 2; c++)
+			for (int v = 0; v < 24; v++)
+				if(Cores[c].KeyOn & (1 << v))
+					if(StartQueuedVoice(c, v))
+						Cores[c].KeyOn &= ~(1 << v);
 		// Note: IOP does not use MMX regs, so no need to save them.
 		//SaveMMXRegs();
 		Mix();
@@ -1970,8 +1986,7 @@ void StartVoices(int core, u32 value)
 		if (!((value >> vc) & 1))
 			continue;
 
-		if (Cores[core].Voices[vc].Start())
-			Cores[core].KeyOn &= ~(1 << vc);
+		Cores[core].Voices[vc].Start();
 
 		if (IsDevBuild)
 		{

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A1A << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A1B << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
Also delay key on events by 2T, tested on hardware and this seems to be the case.

Savestate bump again

Fixes behaviour with loop address writes within 4T's of a voice keying on which is what the old Delay Cycles tried to address, if the voice sets its own loop point the write from hardware is ignored.

Fixes Mafia music loops.  Fixes #4159