### PR TITLE
SPU2: Make sure cache hits match previous block decoded samples

### DIFF
--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -198,7 +198,7 @@ static __forceinline s32 GetNextDataBuffered(V_Core& thiscore, uint voiceidx)
 		PcmCacheEntry& cacheLine = pcm_cache_data[cacheIdx];
 		vc.SBuffer = cacheLine.Sampledata;
 
-		if (cacheLine.Validated)
+		if (cacheLine.Validated && vc.Prev1 == cacheLine.Prev1 && vc.Prev2 == cacheLine.Prev2)
 		{
 			// Cached block!  Read from the cache directly.
 			// Make sure to propagate the prev1/prev2 ADPCM:
@@ -215,7 +215,11 @@ static __forceinline s32 GetNextDataBuffered(V_Core& thiscore, uint voiceidx)
 		{
 			// Only flag the cache if it's a non-dynamic memory range.
 			if (vc.NextA >= SPU2_DYN_MEMLINE)
+			{
 				cacheLine.Validated = true;
+				cacheLine.Prev1 = vc.Prev1;
+				cacheLine.Prev2 = vc.Prev2;
+			}
 
 			if (IsDevBuild)
 			{

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -594,6 +594,8 @@ struct PcmCacheEntry
 {
 	bool Validated;
 	s16 Sampledata[pcm_DecodedSamplesPerBlock];
+	s32 Prev1;
+	s32 Prev2;
 };
 
 extern PcmCacheEntry* pcm_cache_data;


### PR DESCRIPTION
Caching blocks of ADPCM is a bit sketchy because the previous samples (which it uses to generate the new ones) can change depending on if it's the start of the voice on or if it has looped around, so you can end up with blips and glitches in the sample stream, this should avoid that problem whilst not making the cache completely unusable.

Should get rid of clicking and popping noises in loops samples.

Fixes #4197
Also fixes remaining blips in Vexx