### PR TITLE
Don't `Destroy()` modals

### DIFF
--- a/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
@@ -49,9 +49,6 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow* parent)
 	gamepad_box->Add(rumble_box, wxSizerFlags().Expand().Border(wxALL, 5));
 	gamepad_box->Add(joy_box, wxSizerFlags().Expand().Border(wxALL, 5));
 
-	gamepad_box->Add(CreateSeparatedButtonSizer(wxOK), wxSizerFlags().Right().Border(wxALL, 5));
-
-	Bind(wxEVT_BUTTON, &GamepadConfiguration::OnOk, this, wxID_OK);
 	Bind(wxEVT_SCROLL_THUMBRELEASE, &GamepadConfiguration::OnSliderReleased, this);
 	Bind(wxEVT_CHECKBOX, &GamepadConfiguration::OnCheckboxChange, this);
 	Bind(wxEVT_CHOICE, &GamepadConfiguration::OnChoiceChange, this);
@@ -97,11 +94,6 @@ void GamepadConfiguration::InitGamepadConfiguration()
 		m_cb_rumble->Disable();               // disable the rumble checkbox
 		m_sl_rumble_intensity->Disable();     // disable the rumble intensity slider
 	}
-}
-
-void GamepadConfiguration::OnOk(wxCommandEvent& event)
-{
-	Destroy();
 }
 
 /**

--- a/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
@@ -105,6 +105,8 @@ void GamepadConfiguration::OnSliderReleased(wxCommandEvent& event)
 {
 	wxSlider* sl_tmp = (wxSlider*)event.GetEventObject();
 	int sl_id = sl_tmp->GetId();
+	if (!sl_tmp->IsEnabled()) // wxCocoa sends events even when the button is disabled
+		return;
 
 	if (sl_id == rumble_slider_id)
 	{
@@ -112,7 +114,7 @@ void GamepadConfiguration::OnSliderReleased(wxCommandEvent& event)
 
 		// convert in a float value between 0 and 1, and run rumble feedback.
 		// 0 to 1 scales to 0x0 to 0x7FFF
-		s_vgamePad[m_pad_id]->TestForce(m_sl_rumble_intensity->GetValue() / 0x7FFF);
+		s_vgamePad[m_pad_id]->TestForce(m_sl_rumble_intensity->GetValue() / (float)0x7FFF);
 	}
 	else if (sl_id == joy_slider_id)
 	{

--- a/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
@@ -17,7 +17,7 @@
 
 GamepadConfiguration::GamepadConfiguration(int pad, wxWindow* parent)
 	: wxDialog(parent, wxID_ANY, _T("Gamepad"), wxDefaultPosition, wxDefaultSize,
-			   wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN)
+	           wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN)
 {
 	m_pad_id = pad;
 
@@ -34,11 +34,11 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow* parent)
 
 	wxStaticBoxSizer* rumble_box = new wxStaticBoxSizer(wxVERTICAL, this, wxT("Rumble intensity"));
 	m_sl_rumble_intensity = new wxSlider(this, rumble_slider_id, 0, 0, 0x7FFF, wxDefaultPosition, wxDefaultSize,
-										 wxSL_HORIZONTAL | wxSL_LABELS | wxSL_BOTTOM);
+	                                     wxSL_HORIZONTAL | wxSL_LABELS | wxSL_BOTTOM);
 
 	wxStaticBoxSizer* joy_box = new wxStaticBoxSizer(wxVERTICAL, this, wxT("Joystick sensibility"));
 	m_sl_joystick_sensibility = new wxSlider(this, joy_slider_id, 0, 0, 200, wxDefaultPosition, wxDefaultSize,
-											 wxSL_HORIZONTAL | wxSL_LABELS | wxSL_BOTTOM);
+	                                         wxSL_HORIZONTAL | wxSL_LABELS | wxSL_BOTTOM);
 
 	gamepad_box->Add(m_joy_map, wxSizerFlags().Expand().Border(wxALL, 5));
 	gamepad_box->Add(m_cb_rumble, wxSizerFlags().Expand());
@@ -59,26 +59,26 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow* parent)
 }
 
 /**
-    Initialize the frame
-    Check if a gamepad is detected
-    Check if the gamepad support rumbles
-*/
+ * Initialize the frame
+ * Check if a gamepad is detected
+ * Check if the gamepad support rumbles
+ */
 void GamepadConfiguration::InitGamepadConfiguration()
 {
 	repopulate(); // Set label and fit simulated key array
 	/*
-     * Check if there exist at least one pad available
-     * if the pad id is 0, you need at least 1 gamepad connected,
-     * if the pad id is 1, you need at least 2 gamepads connected,
-     * Prevent to use a none initialized value on s_vgamePad (core dump)
-    */
+	 * Check if there exist at least one pad available
+	 * if the pad id is 0, you need at least 1 gamepad connected,
+	 * if the pad id is 1, you need at least 2 gamepads connected,
+	 * Prevent to use a none initialized value on s_vgamePad (core dump)
+	 */
 	if (s_vgamePad.size() >= m_pad_id + 1)
 	{
 		/*
-         * Determine if the device can use rumble
-         * Use TestForce with a very low strength (can't be felt)
-         * May be better to create a new function in order to check only that
-        */
+		 * Determine if the device can use rumble
+		 * Use TestForce with a very low strength (can't be felt)
+		 * May be better to create a new function in order to check only that
+		 */
 
 		// Bad idea. Some connected devices might support rumble but not all connected devices.
 		//        if (!s_vgamePad[m_pad_id]->TestForce(0.001f)) {
@@ -100,7 +100,7 @@ void GamepadConfiguration::InitGamepadConfiguration()
  * Slider event, called when the use release the slider button
  * @FIXME The current solution can't change the joystick sensibility and the rumble intensity
  *        for a specific gamepad. The same value is used for both
-*/
+ */
 void GamepadConfiguration::OnSliderReleased(wxCommandEvent& event)
 {
 	wxSlider* sl_tmp = (wxSlider*)event.GetEventObject();
@@ -124,7 +124,7 @@ void GamepadConfiguration::OnSliderReleased(wxCommandEvent& event)
 
 /**
  * Checkbox event, called when the value of the checkbox change
-*/
+ */
 void GamepadConfiguration::OnCheckboxChange(wxCommandEvent& event)
 {
 	wxCheckBox* cb_tmp = (wxCheckBox*)event.GetEventObject(); // get the slider object
@@ -145,7 +145,7 @@ void GamepadConfiguration::OnCheckboxChange(wxCommandEvent& event)
 	}
 }
 
-/*
+/**
  * Checkbox event, called when the value of the choice box change
  */
 void GamepadConfiguration::OnChoiceChange(wxCommandEvent& event)

--- a/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.h
+++ b/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.h
@@ -40,7 +40,6 @@ class GamepadConfiguration : public wxDialog
 	void repopulate();
 
 	// Events
-	void OnOk(wxCommandEvent&);
 	void OnSliderReleased(wxCommandEvent&);
 	void OnCheckboxChange(wxCommandEvent&);
 	void OnChoiceChange(wxCommandEvent&);

--- a/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.cpp
@@ -22,7 +22,7 @@ static const s32 joy_check_id = wxID_HIGHEST + 100 + 3;
 // Constructor of JoystickConfiguration
 JoystickConfiguration::JoystickConfiguration(int pad, bool left, wxWindow* parent)
 	: wxDialog(parent, wxID_ANY, _T("Joystick configuration"), wxDefaultPosition, wxDefaultSize,
-			   wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN)
+	           wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN)
 {
 	m_pad_id = pad;
 	m_isForLeftJoystick = left;
@@ -52,18 +52,18 @@ JoystickConfiguration::JoystickConfiguration(int pad, bool left, wxWindow* paren
 }
 
 /**
-    Initialize the frame
-    Check if a gamepad is detected
-*/
+ * Initialize the frame
+ * Check if a gamepad is detected
+ */
 void JoystickConfiguration::InitJoystickConfiguration()
 {
 	repopulate(); // Set label and fit simulated key array
 	/*
-     * Check if there exist at least one pad available
-     * if the pad id is 0, you need at least 1 gamepad connected,
-     * if the pad id is 1, you need at least 2 gamepads connected,
-     * Prevent to use a none initialized value on s_vgamePad (core dump)
-    */
+	 * Check if there exist at least one pad available
+	 * if the pad id is 0, you need at least 1 gamepad connected,
+	 * if the pad id is 1, you need at least 2 gamepads connected,
+	 * Prevent to use a none initialized value on s_vgamePad (core dump)
+	 */
 	if (s_vgamePad.size() < m_pad_id + 1)
 	{
 		if (s_vgamePad.empty())
@@ -79,7 +79,7 @@ void JoystickConfiguration::InitJoystickConfiguration()
 
 /**
  * Checkbox event, called when the value of the checkbox change
-*/
+ */
 void JoystickConfiguration::OnCheckboxChange(wxCommandEvent& event)
 {
 	wxCheckBox* cb_tmp = (wxCheckBox*)event.GetEventObject(); // get the slider object

--- a/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.cpp
@@ -15,15 +15,15 @@
 
 #include "JoystickConfiguration.h"
 
+static const s32 x_check_id = wxID_HIGHEST + 100 + 1;
+static const s32 y_check_id = wxID_HIGHEST + 100 + 2;
+static const s32 joy_check_id = wxID_HIGHEST + 100 + 3;
+
 // Constructor of JoystickConfiguration
 JoystickConfiguration::JoystickConfiguration(int pad, bool left, wxWindow* parent)
 	: wxDialog(parent, wxID_ANY, _T("Joystick configuration"), wxDefaultPosition, wxDefaultSize,
 			   wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN)
 {
-	m_init_reverse_Lx = m_init_reverse_Ly =
-		m_init_reverse_Rx = m_init_reverse_Ry =
-			m_init_mouse_Ljoy = m_init_mouse_Rjoy = false;
-
 	m_pad_id = pad;
 	m_isForLeftJoystick = left;
 
@@ -31,33 +31,21 @@ JoystickConfiguration::JoystickConfiguration(int pad, bool left, wxWindow* paren
 
 	if (m_isForLeftJoystick)
 	{
-		m_cb_reverse_Lx = new wxCheckBox(this, Lx_check_id, _T("Reverse Lx"));
-		m_cb_reverse_Ly = new wxCheckBox(this, Ly_check_id, _T("Reverse Ly"));
-		m_cb_mouse_Ljoy = new wxCheckBox(this, Ljoy_check_id, _T("Use mouse for left analog joystick"));
-
-		joy_conf_box->Add(m_cb_reverse_Lx, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
-		joy_conf_box->Add(m_cb_reverse_Ly, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
-		joy_conf_box->Add(m_cb_mouse_Ljoy, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
-
-		m_cb_reverse_Rx = m_cb_reverse_Ry = m_cb_mouse_Rjoy = nullptr;
+		m_cb_reverse_x = new wxCheckBox(this, x_check_id, _T("Reverse Lx"));
+		m_cb_reverse_y = new wxCheckBox(this, y_check_id, _T("Reverse Ly"));
+		m_cb_mouse_joy = new wxCheckBox(this, joy_check_id, _T("Use mouse for left analog joystick"));
 	}
 	else
 	{
-		m_cb_reverse_Rx = new wxCheckBox(this, Rx_check_id, _T("Reverse Rx"));
-		m_cb_reverse_Ry = new wxCheckBox(this, Ry_check_id, _T("Reverse Ry"));
-		m_cb_mouse_Rjoy = new wxCheckBox(this, Rjoy_check_id, _T("Use mouse for right analog joystick"));
-
-		joy_conf_box->Add(m_cb_reverse_Rx, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
-		joy_conf_box->Add(m_cb_reverse_Ry, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
-		joy_conf_box->Add(m_cb_mouse_Rjoy, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
-
-		m_cb_reverse_Lx = m_cb_reverse_Ly = m_cb_mouse_Ljoy = nullptr;
+		m_cb_reverse_x = new wxCheckBox(this, x_check_id, _T("Reverse Rx"));
+		m_cb_reverse_y = new wxCheckBox(this, y_check_id, _T("Reverse Ry"));
+		m_cb_mouse_joy = new wxCheckBox(this, joy_check_id, _T("Use mouse for right analog joystick"));
 	}
 
-	joy_conf_box->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL), wxSizerFlags().Border(wxALL, 5).Right());
+	joy_conf_box->Add(m_cb_reverse_x, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
+	joy_conf_box->Add(m_cb_reverse_y, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
+	joy_conf_box->Add(m_cb_mouse_joy, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 5));
 
-	Bind(wxEVT_BUTTON, &JoystickConfiguration::OnOk, this, wxID_OK);
-	Bind(wxEVT_BUTTON, &JoystickConfiguration::OnCancel, this, wxID_CANCEL);
 	Bind(wxEVT_CHECKBOX, &JoystickConfiguration::OnCheckboxChange, this);
 
 	SetSizerAndFit(joy_conf_box);
@@ -84,28 +72,9 @@ void JoystickConfiguration::InitJoystickConfiguration()
 			wxMessageBox(L"No second gamepad detected.");
 
 		// disable all checkboxes
-		if (m_isForLeftJoystick)
-		{
-			m_cb_reverse_Lx->Disable();
-			m_cb_reverse_Ly->Disable();
-		}
-		else
-		{
-			m_cb_reverse_Rx->Disable();
-			m_cb_reverse_Ry->Disable();
-		}
+		m_cb_reverse_y->Disable();
+		m_cb_reverse_x->Disable();
 	}
-}
-
-void JoystickConfiguration::OnOk(wxCommandEvent& event)
-{
-	Destroy();
-}
-
-void JoystickConfiguration::OnCancel(wxCommandEvent& event)
-{
-	reset();
-	Destroy();
 }
 
 /**
@@ -120,16 +89,16 @@ void JoystickConfiguration::OnCheckboxChange(wxCommandEvent& event)
 	{
 		switch (cb_id)
 		{
-			case Lx_check_id:
-				g_conf.pad_options[m_pad_id].reverse_lx = m_cb_reverse_Lx->GetValue();
+			case x_check_id:
+				g_conf.pad_options[m_pad_id].reverse_lx = m_cb_reverse_x->GetValue();
 				break;
 
-			case Ly_check_id:
-				g_conf.pad_options[m_pad_id].reverse_ly = m_cb_reverse_Ly->GetValue();
+			case y_check_id:
+				g_conf.pad_options[m_pad_id].reverse_ly = m_cb_reverse_y->GetValue();
 				break;
 
-			case Ljoy_check_id:
-				g_conf.pad_options[m_pad_id].mouse_l = m_cb_mouse_Ljoy->GetValue();
+			case joy_check_id:
+				g_conf.pad_options[m_pad_id].mouse_l = m_cb_mouse_joy->GetValue();
 				break;
 
 			default:
@@ -140,16 +109,16 @@ void JoystickConfiguration::OnCheckboxChange(wxCommandEvent& event)
 	{
 		switch (cb_id)
 		{
-			case Rx_check_id:
-				g_conf.pad_options[m_pad_id].reverse_rx = m_cb_reverse_Rx->GetValue();
+			case x_check_id:
+				g_conf.pad_options[m_pad_id].reverse_rx = m_cb_reverse_x->GetValue();
 				break;
 
-			case Ry_check_id:
-				g_conf.pad_options[m_pad_id].reverse_ry = m_cb_reverse_Ry->GetValue();
+			case y_check_id:
+				g_conf.pad_options[m_pad_id].reverse_ry = m_cb_reverse_y->GetValue();
 				break;
 
-			case Rjoy_check_id:
-				g_conf.pad_options[m_pad_id].mouse_r = m_cb_mouse_Rjoy->GetValue();
+			case joy_check_id:
+				g_conf.pad_options[m_pad_id].mouse_r = m_cb_mouse_joy->GetValue();
 				break;
 
 			default:
@@ -162,46 +131,19 @@ void JoystickConfiguration::OnCheckboxChange(wxCommandEvent& event)
 /*********** Methods functions **********/
 /****************************************/
 
-// Reset checkbox and slider values
-void JoystickConfiguration::reset()
-{
-	if (m_isForLeftJoystick)
-	{
-		m_cb_reverse_Lx->SetValue(m_init_reverse_Lx);
-		m_cb_reverse_Ly->SetValue(m_init_reverse_Ly);
-		m_cb_mouse_Ljoy->SetValue(m_init_mouse_Ljoy);
-	}
-	else
-	{
-		m_cb_reverse_Rx->SetValue(m_init_reverse_Rx);
-		m_cb_reverse_Ry->SetValue(m_init_reverse_Ry);
-		m_cb_mouse_Rjoy->SetValue(m_init_mouse_Rjoy);
-	}
-}
-
 // Set button values
 void JoystickConfiguration::repopulate()
 {
 	if (m_isForLeftJoystick)
 	{
-		m_init_reverse_Lx = g_conf.pad_options[m_pad_id].reverse_lx;
-		m_cb_reverse_Lx->SetValue(m_init_reverse_Lx);
-
-		m_init_reverse_Ly = g_conf.pad_options[m_pad_id].reverse_ly;
-		m_cb_reverse_Ly->SetValue(m_init_reverse_Ly);
-
-		m_init_mouse_Ljoy = g_conf.pad_options[m_pad_id].mouse_l;
-		m_cb_mouse_Ljoy->SetValue(m_init_mouse_Ljoy);
+		m_cb_reverse_x->SetValue(g_conf.pad_options[m_pad_id].reverse_lx);
+		m_cb_reverse_y->SetValue(g_conf.pad_options[m_pad_id].reverse_ly);
+		m_cb_mouse_joy->SetValue(g_conf.pad_options[m_pad_id].mouse_l);
 	}
 	else
 	{
-		m_init_reverse_Rx = g_conf.pad_options[m_pad_id].reverse_rx;
-		m_cb_reverse_Rx->SetValue(m_init_reverse_Rx);
-
-		m_init_reverse_Ry = g_conf.pad_options[m_pad_id].reverse_ry;
-		m_cb_reverse_Ry->SetValue(m_init_reverse_Ry);
-
-		m_init_mouse_Rjoy = g_conf.pad_options[m_pad_id].mouse_r;
-		m_cb_mouse_Rjoy->SetValue(m_init_mouse_Rjoy);
+		m_cb_reverse_x->SetValue(g_conf.pad_options[m_pad_id].reverse_rx);
+		m_cb_reverse_y->SetValue(g_conf.pad_options[m_pad_id].reverse_ry);
+		m_cb_mouse_joy->SetValue(g_conf.pad_options[m_pad_id].mouse_r);
 	}
 }

--- a/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.h
+++ b/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.h
@@ -24,33 +24,20 @@
 #include "../keyboard.h"
 #include "../PAD.h"
 
-static const s32 Lx_check_id = wxID_HIGHEST + 100 + 1;
-static const s32 Ly_check_id = wxID_HIGHEST + 100 + 2;
-static const s32 Ljoy_check_id = wxID_HIGHEST + 100 + 3;
-
-static const s32 Rx_check_id = wxID_HIGHEST + 100 + 4;
-static const s32 Ry_check_id = wxID_HIGHEST + 100 + 5;
-static const s32 Rjoy_check_id = wxID_HIGHEST + 100 + 6;
-
 class JoystickConfiguration : public wxDialog
 {
-	wxCheckBox *m_cb_reverse_Lx, *m_cb_reverse_Ly, *m_cb_reverse_Rx, *m_cb_reverse_Ry,
-		*m_cb_mouse_Ljoy, // Use mouse for left joystick
-		*m_cb_mouse_Rjoy; // Use mouse for right joystick
+	wxCheckBox *m_cb_reverse_x, *m_cb_reverse_y,
+		*m_cb_mouse_joy; // Use mouse for joystick
 
 	u32 m_pad_id;
 	// isForLeftJoystick -> true is for Left Joystick, false is for Right Joystick
-	bool m_init_reverse_Lx, m_init_reverse_Ly, m_init_reverse_Rx, m_init_reverse_Ry,
-		m_init_mouse_Ljoy, m_init_mouse_Rjoy, m_isForLeftJoystick;
+	bool m_isForLeftJoystick;
 
 	// Methods
 	void repopulate();
-	void reset();
 
 	// Events
 	void OnCheckboxChange(wxCommandEvent&);
-	void OnOk(wxCommandEvent&);
-	void OnCancel(wxCommandEvent&);
 
 public:
 	JoystickConfiguration(int, bool, wxWindow*);


### PR DESCRIPTION
On macOS it prevents the parent window from regaining focus

Also, JoystickConfiguration had an incredibly complicated system for setting preferences as the user clicked checkboxes and undoing them if they clicked cancel.  Replaced with just setting preferences at the end if the user clicks `OK`