### PR TITLE
DEV9: Merge _DEV9*() functions into *Net(), and check ethEnable before calling InitNet()

### DIFF
--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -219,7 +219,10 @@ s32 DEV9open(void* pDsp)
 			config.hddEnable = false;
 	}
 
-	return _DEV9open();
+	if (config.ethEnable)
+		InitNet();
+
+	return 0;
 }
 
 void DEV9close()
@@ -227,7 +230,7 @@ void DEV9close()
 	DevCon.WriteLn("DEV9close");
 
 	dev9.ata->Close();
-	_DEV9close();
+	TermNet();
 }
 
 int DEV9irqHandler(void)

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -723,6 +723,7 @@ u32 DEV9read32(u32 addr);
 void DEV9write8(u32 addr, u8 value);
 void DEV9write16(u32 addr, u16 value);
 void DEV9write32(u32 addr, u32 value);
+void ApplyConfigIfRunning(Config oldConfig);
 
 #ifdef _WIN32
 #pragma warning(error : 4013)

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -135,10 +135,6 @@ EXTERN dev9Struct dev9;
 
 EXTERN int ThreadRun;
 
-s32 _DEV9open();
-void _DEV9close();
-//void DEV9thread();
-
 //Yes these are meant to be a lowercase extern
 extern std::string s_strIniPath;
 extern std::string s_strLogPath;

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -186,6 +186,8 @@ void OnOk()
 void DEV9configure()
 {
 	ScopedCoreThreadPause paused_core;
+	Config oldConfig = config;
+
 	gtk_init(NULL, NULL);
 	GError* error = NULL;
 	if (builder == nullptr)
@@ -217,5 +219,8 @@ void DEV9configure()
 			break;
 	}
 	gtk_widget_hide(GTK_WIDGET(dlg));
+
+	ApplyConfigIfRunning(oldConfig);
+
 	paused_core.AllowResume();
 }

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -219,35 +219,3 @@ void DEV9configure()
 	gtk_widget_hide(GTK_WIDGET(dlg));
 	paused_core.AllowResume();
 }
-
-NetAdapter* GetNetAdapter()
-{
-	NetAdapter* na;
-	na = new PCAPAdapter();
-
-	if (!na->isInitialised())
-	{
-		delete na;
-		return 0;
-	}
-	return na;
-}
-s32 _DEV9open()
-{
-	NetAdapter* na = GetNetAdapter();
-	if (!na)
-	{
-		Console.Error("Failed to GetNetAdapter()");
-		config.ethEnable = false;
-	}
-	else
-	{
-		InitNet(na);
-	}
-	return 0;
-}
-
-void _DEV9close()
-{
-	TermNet();
-}

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -358,11 +358,16 @@ BOOL CALLBACK ConfigureDlgProc(HWND hW, UINT uMsg, WPARAM wParam, LPARAM lParam)
 void DEV9configure()
 {
 	ScopedCoreThreadPause paused_core;
+	Config oldConfig = config;
+
 	DialogBox(hInst,
 			  MAKEINTRESOURCE(IDD_CONFIG),
 			  GetActiveWindow(),
 			  (DLGPROC)ConfigureDlgProc);
 	//SysMessage("Nothing to Configure");
+
+	ApplyConfigIfRunning(oldConfig);
+
 	paused_core.AllowResume();
 }
 

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -372,38 +372,3 @@ UINT DEV9ThreadProc() {
 
 	return 0;
 }*/
-NetAdapter* GetNetAdapter()
-{
-	NetAdapter* na = static_cast<NetAdapter*>(new TAPAdapter());
-
-	if (!na->isInitialised())
-	{
-		delete na;
-		return 0;
-	}
-	return na;
-}
-s32 _DEV9open()
-{
-	//handleDEV9Thread = CreateThread (NULL, 0, (LPTHREAD_START_ROUTINE) DEV9ThreadProc, &dwThrdParam, CREATE_SUSPENDED, &dwThreadId);
-	//SetThreadPriority(handleDEV9Thread,THREAD_PRIORITY_HIGHEST);
-	//ResumeThread (handleDEV9Thread);
-	NetAdapter* na = GetNetAdapter();
-	if (!na)
-	{
-		Console.Error("Failed to GetNetAdapter()");
-		config.ethEnable = false;
-	}
-	else
-	{
-		InitNet(na);
-	}
-	return 0;
-}
-
-void _DEV9close()
-{
-	//TerminateThread(handleDEV9Thread,0);
-	//handleDEV9Thread = NULL;
-	TermNet();
-}

--- a/pcsx2/DEV9/net.h
+++ b/pcsx2/DEV9/net.h
@@ -56,5 +56,5 @@ protected:
 };
 
 void tx_put(NetPacket* ptr);
-void InitNet(NetAdapter* adapter);
+void InitNet();
 void TermNet();


### PR DESCRIPTION
Previously, the ethEnable config value was not checked before starting network RX net thread.

This PR merges the platform specific  ``_DEV9open()`` into``InitNet()``, ``_DEV9close()`` into ``TermNet()`` and adds a check before calling InitNet()