### PR TITLE
IPU: Fill Input FIFO on command end ready for next command

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -1000,4 +1000,10 @@ __noinline void IPUWorker()
 	ipuRegs.ctrl.BUSY = 0;
 	//ipu_cmd.current = 0xffffffff;
 	hwIntcIrq(INTC_IPU);
+
+	// Fill the FIFO ready for the next command
+	if (ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
+	{
+		CPU_INT(DMAC_TO_IPU, 32);
+	}
 }

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -366,6 +366,14 @@ __fi bool ipuWrite64(u32 mem, u64 value)
 
 static void ipuBCLR(u32 val)
 {
+	// The Input FIFO shouldn't be cleared when the DMA is running, however if it is the DMA should drain
+	// as it is constantly fighting it....
+	while(ipu1ch.chcr.STR)
+	{
+		ipu_fifo.in.clear();
+		ipu1Interrupt();
+	}
+	
 	ipu_fifo.in.clear();
 
 	memzero(g_BP);
@@ -452,7 +460,7 @@ static __fi bool ipuVDEC(u32 val)
 
 				case 1://Macroblock Type
 					decoder.frame_pred_frame_dct = 1;
-					decoder.coding_type = ipuRegs.ctrl.PCT;
+					decoder.coding_type = ipuRegs.ctrl.PCT > 0 ? ipuRegs.ctrl.PCT : 1; // Kaiketsu Zorro Mezase doesn't set a Picture type, seems happy with I
 					ipuRegs.cmd.DATA = get_macroblock_modes();
 					break;
 


### PR DESCRIPTION
Fixes Dance Summit 2001 - Bust a Move


So basically what the game does is it does some IPU stuff, but the DMA is left with 1 QWC left to be read on the DMA, on the hardware this will normally be flushed in to the FIFO.  The game then does a FIFO reset (To get rid of it) then starts another DMA.

The problem we have is because we still had the DMA pending for 1 QWC, it ignored the new DMA start and the IPU would hang up waiting for data to be fed in.  This PR resolves that problem.

Also added DMA 4 (To IPU) being flushed if BCLR is called without first stopping the DMA, fixes Test Drive

Set the Picture type on VDEC to I-Picture if set to 0 in the IPU_CTRL, this fixes a bunch of Eyetoy games which incorrectly set this register.

Fixes #3432 
Fixes #4125
Fixes #3700
Fixes #1863
