### PR TITLE
SPU2: Resample reverb input/output.

### DIFF
--- a/pcsx2/SPU2/Reverb.cpp
+++ b/pcsx2/SPU2/Reverb.cpp
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "Global.h"
+#include <array>
 
 __forceinline s32 V_Core::RevbGetIndexer(s32 offset)
 {
@@ -106,7 +107,7 @@ s32 __forceinline V_Core::ReverbDownsample(bool right)
 	out += RevbDownBuf[right][((RevbSampleBufPos - NUM_TAPS) + 19) & 63] * filter_coefs[19];
 
 	out >>= 15;
-	Clampify(out, INT16_MIN, INT16_MAX);
+	Clampify(out, (s32)INT16_MIN, (s32)INT16_MAX);
 
 	return out;
 }
@@ -135,9 +136,9 @@ StereoOut32 __forceinline V_Core::ReverbUpsample(bool phase)
 	}
 
 	ls >>= 14;
-	Clampify(ls, INT16_MIN, INT16_MAX);
+	Clampify(ls, (s32)INT16_MIN, (s32)INT16_MAX);
 	rs >>= 14;
-	Clampify(rs, INT16_MIN, INT16_MAX);
+	Clampify(rs, (s32)INT16_MIN, (s32)INT16_MAX);
 
 	return StereoOut32(ls, rs);
 }

--- a/pcsx2/SPU2/Reverb.cpp
+++ b/pcsx2/SPU2/Reverb.cpp
@@ -96,10 +96,14 @@ s32 __forceinline V_Core::ReverbDownsample(bool right)
 {
 	s32 out = 0;
 
-	for (u32 i = 0; i < NUM_TAPS; i++)
+	// Skipping the 0 coefs.
+	for (u32 i = 0; i < NUM_TAPS; i += 2)
 	{
 		out += RevbDownBuf[right][((RevbSampleBufPos - NUM_TAPS) + i) & 63] * filter_coefs[i];
 	}
+
+	// We also skipped the middle so add that in.
+	out += RevbDownBuf[right][((RevbSampleBufPos - NUM_TAPS) + 19) & 63] * filter_coefs[19];
 
 	out >>= 15;
 	Clampify(out, INT16_MIN, INT16_MAX);

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -497,7 +497,7 @@ struct V_Core
 	s32 RevbGetIndexer(s32 offset);
 
 	s32 ReverbDownsample(bool right);
-	s32 ReverbUpsample();
+	StereoOut32 ReverbUpsample();
 
 	StereoOut32 ReadInput();
 	StereoOut32 ReadInput_HiFi();

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -497,7 +497,7 @@ struct V_Core
 	s32 RevbGetIndexer(s32 offset);
 
 	s32 ReverbDownsample(bool right);
-	StereoOut32 ReverbUpsample();
+	StereoOut32 ReverbUpsample(bool phase);
 
 	StereoOut32 ReadInput();
 	StereoOut32 ReadInput_HiFi();

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -416,6 +416,10 @@ struct V_Core
 
 	V_Reverb Revb;              // Reverb Registers
 	V_ReverbBuffers RevBuffers; // buffer pointers for reverb, pre-calculated and pre-clipped.
+
+	s32 RevbDownBuf[2][64]; // Downsample buffer for reverb, one for each channel
+	s32 RevbUpBuf[2][64]; // Upsample buffer for reverb, one for each channel
+	u32 RevbSampleBufPos;
 	u32 EffectsStartA;
 	u32 EffectsEndA;
 	u32 ExtEffectsStartA;
@@ -491,6 +495,9 @@ struct V_Core
 	void Reverb_AdvanceBuffer();
 	StereoOut32 DoReverb(const StereoOut32& Input);
 	s32 RevbGetIndexer(s32 offset);
+
+	s32 ReverbDownsample(bool right);
+	s32 ReverbUpsample();
 
 	StereoOut32 ReadInput();
 	StereoOut32 ReadInput_HiFi();

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -222,6 +222,10 @@ void V_Core::Init(int index)
 	Regs.ENDX = 0xffffff; // PS2 confirmed
 
 	RevBuffers.NeedsUpdated = true;
+	RevbSampleBufPos = 0;
+	memset(RevbDownBuf, 0, sizeof(RevbDownBuf));
+	memset(RevbUpBuf, 0, sizeof(RevbUpBuf));
+
 	UpdateEffectsBufferSize();
 }
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A1C << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A1D << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
The reverb runs at half the the samplerate of the rest of the SPU so a change of samplerate is required. They way this is currently done is by decimating when downsampling and duplicating samples when upsampling without doing any filtering.

This adds proper filtering to this process,  the filter coefficients are from mednafen but I *think* they were originally found by Neill Corlett.

I have not yet compared to real PS2 behavior and don't know when I'll get around to so I'm PR'ing this now.