### PR TITLE
Fix Linux build not compiling afer commit a37e62337dea943de65571baa88…

### DIFF
--- a/common/include/PS2Eext.h
+++ b/common/include/PS2Eext.h
@@ -37,6 +37,7 @@
 
 #include <cstring>
 #include <wx/msgdlg.h>
+#include <wx/app.h>
 
 #define EXPORT_C_(type) extern "C" __attribute__((stdcall, externally_visible, visibility("default"))) type
 


### PR DESCRIPTION
…349dc50065622

Missing include leads to wxTheApp macro not being defined and throw errors (GCC 10, Linux x86_64)