### PR TITLE
Avoid presets from resetting VsyncQueueSize

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -1065,7 +1065,8 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 	EmuOptions.GS					= default_Pcsx2Config.GS;
 	EmuOptions.GS.FrameLimitEnable	= original_GS.FrameLimitEnable;	//Frame limiter is not modified by presets
 	EmuOptions.GS.VsyncEnable		= original_GS.VsyncEnable;
-	
+	EmuOptions.GS.VsyncQueueSize	= original_GS.VsyncQueueSize;
+
 	EmuOptions.Cpu					= default_Pcsx2Config.Cpu;
 	EmuOptions.Gamefixes			= default_Pcsx2Config.Gamefixes;
 	EmuOptions.Speedhacks			= default_Pcsx2Config.Speedhacks;


### PR DESCRIPTION
The VsyncQueueSize setting is currently affected by presets, would revert to default on start as well. Since the setting is not grayed out, this change makes it be unaffected.