### PR TITLE
Core: Preserve read only bits in the COP0 config register

### DIFF
--- a/pcsx2/COP0.cpp
+++ b/pcsx2/COP0.cpp
@@ -41,10 +41,14 @@ void __fastcall WriteCP0Status(u32 value) {
 	//DMA_LOG("COP0 Status write = 0x%08x", value);
 
 	cpuRegs.CP0.n.Status.val = value;
-    cpuUpdateOperationMode();
     cpuSetNextEventDelta(4);
 }
 
+void __fastcall WriteCP0Config(u32 value) {
+	// Protect the read-only ICacheSize (IC) and DataCacheSize (DC) bits
+	cpuRegs.CP0.n.Config = value & ~0xFC0;
+	cpuRegs.CP0.n.Config |= 0x440;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Performance Counters Update Stuff!
@@ -470,6 +474,10 @@ void MTC0()
 
 		case 12:
 			WriteCP0Status(cpuRegs.GPR.r[_Rt_].UL[0]);
+		break;
+
+		case 16:
+			WriteCP0Config(cpuRegs.GPR.r[_Rt_].UL[0]);
 		break;
 
 		case 24:

--- a/pcsx2/COP0.h
+++ b/pcsx2/COP0.h
@@ -17,6 +17,7 @@
 #define __COP0_H__
 
 extern void __fastcall WriteCP0Status(u32 value);
+extern void __fastcall WriteCP0Config(u32 value);
 extern void cpuUpdateOperationMode();
 extern void WriteTLB(int i);
 extern void UnmapTLB(int i);

--- a/pcsx2/x86/iCOP0.cpp
+++ b/pcsx2/x86/iCOP0.cpp
@@ -212,7 +212,12 @@ void recMTC0()
 		{
 			case 12:
 				iFlushCall(FLUSH_INTERPRETER);
-				xFastCall((void*)WriteCP0Status, g_cpuConstRegs[_Rt_].UL[0] );
+				xFastCall((void*)WriteCP0Status, g_cpuConstRegs[_Rt_].UL[0]);
+			break;
+
+			case 16:
+				iFlushCall(FLUSH_INTERPRETER);
+				xFastCall((void*)WriteCP0Config, g_cpuConstRegs[_Rt_].UL[0]);
 			break;
 
 			case 9:
@@ -263,6 +268,12 @@ void recMTC0()
 				iFlushCall(FLUSH_INTERPRETER);
 				_eeMoveGPRtoR(ecx, _Rt_);
 				xFastCall((void*)WriteCP0Status, ecx );
+			break;
+
+			case 16:
+				iFlushCall(FLUSH_INTERPRETER);
+				_eeMoveGPRtoR(ecx, _Rt_);
+				xFastCall((void*)WriteCP0Config, ecx);
 			break;
 
 			case 9:


### PR DESCRIPTION
The read-only bits in question are the Instruction cache size (IC) and the Data cache size (DC)

Before this pr, MTC0 would freely write to the entire config register.