### PR TITLE
DEV9: Don't import pcap_bufsize

### DIFF
--- a/pcsx2/DEV9/Win32/pcap_io_win32_funcs.h
+++ b/pcsx2/DEV9/Win32/pcap_io_win32_funcs.h
@@ -70,7 +70,7 @@ FUNCTION_SHIM_1_ARG(int, pcap_snapshot, pcap_t*)
 FUNCTION_SHIM_1_ARG(int, pcap_is_swapped, pcap_t*)
 FUNCTION_SHIM_1_ARG(int, pcap_major_version, pcap_t*)
 FUNCTION_SHIM_1_ARG(int, pcap_minor_version, pcap_t*)
-FUNCTION_SHIM_1_ARG(int, pcap_bufsize, pcap_t*)
+//FUNCTION_SHIM_1_ARG(int, pcap_bufsize, pcap_t*)
 //
 FUNCTION_SHIM_1_ARG(FILE*, pcap_file, pcap_t*)
 FUNCTION_SHIM_1_ARG(int, pcap_fileno, pcap_t*)


### PR DESCRIPTION
This got accidentally re-added in 4b722cc253e1605d633d2642fed186f8e9095853

It is a function that Npcap has, but winPcap doesn't.

This should fix the winPcap computability reported in discord