### PR TITLE
Added support for little endian data for patches

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -61,6 +61,9 @@ static const PatchTextTable dataType[] =
 	{ 3, L"word", NULL },
 	{ 4, L"double", NULL },
 	{ 5, L"extended", NULL },
+	{ 6, L"leshort", NULL},
+	{ 7, L"leword", NULL},
+	{ 8, L"ledouble", NULL},
 	{ 0, wxEmptyString, NULL }
 };
 

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -51,7 +51,10 @@ enum patch_data_type {
 	SHORT_T,
 	WORD_T,
 	DOUBLE_T,
-	EXTENDED_T
+	EXTENDED_T,
+	SHORT_LE_T,
+	WORD_LE_T,
+	DOUBLE_LE_T
 };
 
 // "place" is the first number at a pnach line (patch=<place>,...), e.g.:
@@ -128,3 +131,8 @@ extern void PatchesVerboseReset();
 // regardless, they don't seem to have an implementation anywhere.
 // extern int  AddPatch(int Mode, int Place, int Address, int Size, u64 data);
 // extern void ResetPatch(void);
+
+//Swaps endianess of InputNum
+//ex. 01020304 -> 04030201
+//Could be made more portable if we remove the patch_data_type bar
+extern u64 SwapEndian(u64 InputNum, patch_data_type);

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -132,7 +132,7 @@ extern void PatchesVerboseReset();
 // extern int  AddPatch(int Mode, int Place, int Address, int Size, u64 data);
 // extern void ResetPatch(void);
 
-//Swaps endianess of InputNum
-//ex. 01020304 -> 04030201
-//Could be made more portable if we remove the patch_data_type bar
-extern u64 SwapEndian(u64 InputNum, patch_data_type);
+// Swaps endianess of InputNum
+// ex. 01020304 -> 04030201
+// BitLength is length of InputNum in bits, ex. double,64  word,32  short,16
+extern u64 SwapEndian(u64 InputNum, u8 BitLength);

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -422,19 +422,19 @@ void _ApplyPatch(IniPatch *p)
 
 		case SHORT_LE_T:
 			if (memRead16(p->addr) != (u16)p->data)
-				memWrite16(p->addr, (u16) SwapEndian(p->data,SHORT_LE_T));
+				memWrite16(p->addr, (u16) SwapEndian(p->data,16));
 			break;
 
 		case WORD_LE_T:
 			if (memRead32(p->addr) != (u32)p->data)
-				memWrite32(p->addr, (u32) SwapEndian( p->data , WORD_LE_T ) );
+				memWrite32(p->addr, (u32) SwapEndian( p->data , 32 ) );
 			break;
 
 		case DOUBLE_LE_T:
 			u64 memle;
 			memRead64(p->addr, &memle);
 			if (mem != p->data)
-				memWrite64(p->addr, SwapEndian(p->data, DOUBLE_LE_T ) );
+				memWrite64(p->addr, SwapEndian(p->data, 64 ) );
 			break;
 
 		default:
@@ -467,17 +467,17 @@ void _ApplyPatch(IniPatch *p)
 	}
 }
 
-u64 SwapEndian(u64 InputNum, patch_data_type Type)
+u64 SwapEndian(u64 InputNum, u8 BitLength)
 {
-	if (Type == DOUBLE_LE_T) //DOUBLE_LE_T
+	if (BitLength == 64) // DOUBLE_LE_T
 	{
 		InputNum = (InputNum & 0x00000000FFFFFFFF) << 32 | (InputNum & 0xFFFFFFFF00000000) >> 32; //Swaps 4 bytes
 	}
-	if ((Type == WORD_LE_T)||(Type==DOUBLE_LE_T)) //WORD_LE_T
+	if ((BitLength == 32)||(BitLength==64)) // WORD_LE_T
 	{
 		InputNum = (InputNum & 0x0000FFFF0000FFFF) << 16 | (InputNum & 0xFFFF0000FFFF0000) >> 16; // Swaps 2 bytes
 	}
-	InputNum = (InputNum & 0x00FF00FF00FF00FF) << 8 | (InputNum & 0xFF00FF00FF00FF00) >> 8;   //Swaps 1 byte
+	InputNum = (InputNum & 0x00FF00FF00FF00FF) << 8 | (InputNum & 0xFF00FF00FF00FF00) >> 8;   // Swaps 1 byte
 	return InputNum;
 }
 

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -420,6 +420,23 @@ void _ApplyPatch(IniPatch *p)
 			handle_extended_t(p);
 			break;
 
+		case SHORT_LE_T:
+			if (memRead16(p->addr) != (u16)p->data)
+				memWrite16(p->addr, (u16) SwapEndian(p->data,SHORT_LE_T));
+			break;
+
+		case WORD_LE_T:
+			if (memRead32(p->addr) != (u32)p->data)
+				memWrite32(p->addr, (u32) SwapEndian( p->data , WORD_LE_T ) );
+			break;
+
+		case DOUBLE_LE_T:
+			u64 memle;
+			memRead64(p->addr, &memle);
+			if (mem != p->data)
+				memWrite64(p->addr, SwapEndian(p->data, DOUBLE_LE_T ) );
+			break;
+
 		default:
 			break;
 		}
@@ -449,3 +466,18 @@ void _ApplyPatch(IniPatch *p)
 		break;
 	}
 }
+
+u64 SwapEndian(u64 InputNum, patch_data_type Type)
+{
+	if (Type == DOUBLE_LE_T) //DOUBLE_LE_T
+	{
+		InputNum = (InputNum & 0x00000000FFFFFFFF) << 32 | (InputNum & 0xFFFFFFFF00000000) >> 32; //Swaps 4 bytes
+	}
+	if ((Type == WORD_LE_T)||(Type==DOUBLE_LE_T)) //WORD_LE_T
+	{
+		InputNum = (InputNum & 0x0000FFFF0000FFFF) << 16 | (InputNum & 0xFFFF0000FFFF0000) >> 16; // Swaps 2 bytes
+	}
+	InputNum = (InputNum & 0x00FF00FF00FF00FF) << 8 | (InputNum & 0xFF00FF00FF00FF00) >> 8;   //Swaps 1 byte
+	return InputNum;
+}
+

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -397,7 +397,6 @@ void _ApplyPatch(IniPatch *p)
 	case CPU_EE:
 		switch (p->type)
 		{
-		
 		case BYTE_T:
 			if (memRead8(p->addr) != (u8)p->data)
 				memWrite8(p->addr, (u8)p->data);

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -431,14 +431,14 @@ void _ApplyPatch(IniPatch *p)
 		case WORD_LE_T:
 			ledata = SwapEndian(p->data, 32);
 			if (memRead32(p->addr) != (u32)ledata)
-				memWrite32(p->addr,(u32)ledata);
+				memWrite32(p->addr, (u32)ledata);
 			break;
 
 		case DOUBLE_LE_T:
 			ledata = SwapEndian(p->data, 64);
 			memRead64(p->addr, &mem);
 			if (mem != ledata)
-				memWrite64(p->addr,ledata);
+				memWrite64(p->addr, ledata);
 			break;
 
 		default:

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -394,6 +394,8 @@ void _ApplyPatch(IniPatch *p)
 	case CPU_EE:
 		switch (p->type)
 		{
+		u64 mem;
+		u64 ledata;
 		case BYTE_T:
 			if (memRead8(p->addr) != (u8)p->data)
 				memWrite8(p->addr, (u8)p->data);
@@ -410,7 +412,6 @@ void _ApplyPatch(IniPatch *p)
 			break;
 
 		case DOUBLE_T:
-			u64 mem;
 			memRead64(p->addr, &mem);
 			if (mem != p->data)
 				memWrite64(p->addr, &p->data);
@@ -421,20 +422,22 @@ void _ApplyPatch(IniPatch *p)
 			break;
 
 		case SHORT_LE_T:
-			if (memRead16(p->addr) != (u16)p->data)
-				memWrite16(p->addr, (u16) SwapEndian(p->data,16));
+			ledata = SwapEndian(p->data, 16);
+			if (memRead16(p->addr) != (u16)ledata)
+				memWrite16(p->addr, (u16)ledata);
 			break;
 
 		case WORD_LE_T:
-			if (memRead32(p->addr) != (u32)p->data)
-				memWrite32(p->addr, (u32) SwapEndian( p->data , 32 ) );
+			ledata = SwapEndian(p->data, 32);
+			if (memRead32(p->addr) != (u32)ledata)
+				memWrite32(p->addr, (u32) ledata );
 			break;
 
 		case DOUBLE_LE_T:
-			u64 memle;
-			memRead64(p->addr, &memle);
-			if (mem != p->data)
-				memWrite64(p->addr, SwapEndian(p->data, 64 ) );
+			ledata = SwapEndian(p->data, 64);
+			memRead64(p->addr, &mem);
+			if (mem != ledata)
+				memWrite64(p->addr, ledata );
 			break;
 
 		default:

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -387,6 +387,9 @@ void handle_extended_t(IniPatch *p)
 // Patch.cpp itself declares this prototype, so make sure to keep in sync.
 void _ApplyPatch(IniPatch *p)
 {
+	u64 mem = 0;
+	u64 ledata = 0;
+
 	if (p->enabled == 0) return;
 
 	switch (p->cpu)
@@ -394,8 +397,7 @@ void _ApplyPatch(IniPatch *p)
 	case CPU_EE:
 		switch (p->type)
 		{
-		u64 mem;
-		u64 ledata;
+		
 		case BYTE_T:
 			if (memRead8(p->addr) != (u8)p->data)
 				memWrite8(p->addr, (u8)p->data);

--- a/pcsx2/Patch_Memory.cpp
+++ b/pcsx2/Patch_Memory.cpp
@@ -432,14 +432,14 @@ void _ApplyPatch(IniPatch *p)
 		case WORD_LE_T:
 			ledata = SwapEndian(p->data, 32);
 			if (memRead32(p->addr) != (u32)ledata)
-				memWrite32(p->addr, (u32) ledata );
+				memWrite32(p->addr,(u32)ledata);
 			break;
 
 		case DOUBLE_LE_T:
 			ledata = SwapEndian(p->data, 64);
 			memRead64(p->addr, &mem);
 			if (mem != ledata)
-				memWrite64(p->addr, ledata );
+				memWrite64(p->addr,ledata);
 			break;
 
 		default:


### PR DESCRIPTION
Allows users to use the leshort, leword, and ledouble datatypes inside their patches. Using these datatypes ensures that values in the memory view appear the same as the values in the patch.
This was made with easing patch development in mind as now developers can make patches without having to reverse endianness. This is especially useful when using programs like ghidra who display an instructions bytes in little endian.
![image](https://user-images.githubusercontent.com/64274155/109246155-baafd600-77af-11eb-89c0-3f78829ce07a.png)
![image](https://user-images.githubusercontent.com/64274155/109246288-f0ed5580-77af-11eb-8263-e1ff5c7496b5.png)
