### PR TITLE
DEV9: Move ATA write queue logic into its own class

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -344,6 +344,7 @@ set(pcsx2DEV9Headers
 	DEV9/DEV9.h
 	DEV9/net.h
 	DEV9/pcap_io.h
+	DEV9/SimpleQueue.h
 	DEV9/smap.h
 	${pcsx2DEV9UIHeaders}
 	)

--- a/pcsx2/DEV9/ATA/ATA.h
+++ b/pcsx2/DEV9/ATA/ATA.h
@@ -26,6 +26,8 @@
 #include "PS2Edefs.h"
 #include "PS2Eext.h"
 
+#include "../SimpleQueue.h"
+
 class ATA
 {
 public:
@@ -106,15 +108,11 @@ private:
 
 	struct WriteQueueEntry
 	{
-		std::atomic_bool ready{false};
-		WriteQueueEntry* next;
 		u8* data;
 		u32 length;
 		u64 sector;
 	};
-
-	WriteQueueEntry* head = nullptr;
-	WriteQueueEntry* tail = nullptr;
+	SimpleQueue<WriteQueueEntry> writeQueue;
 
 	std::thread ioThread;
 	bool ioRunning = false;
@@ -212,10 +210,6 @@ private:
 	void HDD_ReadSync(void (ATA::*drqCMD)());
 	bool HDD_CanAssessOrSetError();
 	void HDD_SetErrorAtTransferEnd();
-
-	void QueueWrite(u64 sector, u8* data, u32 length);
-	bool DequeueWrite(u64* sector, u8** data, u32* length);
-	bool IsQueueEmpty();
 
 	//Commands
 	void IDE_ExecCmd(u16 value);

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -62,7 +62,11 @@ void ATA::DRQCmdDMADataFromHost()
 }
 void ATA::PostCmdDMADataFromHost()
 {
-	QueueWrite(currentWriteSectors, currentWrite, currentWriteLength);
+	WriteQueueEntry entry{0};
+	entry.data = currentWrite;
+	entry.length = currentWriteLength;
+	entry.sector = currentWriteSectors;
+	writeQueue.Enqueue(entry);
 	currentWrite = nullptr;
 	currentWriteLength = 0;
 	currentWriteSectors = 0;

--- a/pcsx2/DEV9/SimpleQueue.h
+++ b/pcsx2/DEV9/SimpleQueue.h
@@ -1,0 +1,110 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+//Designed to allow one thread to queue data to another thread
+template <class T>
+class SimpleQueue
+{
+private:
+	struct SimpleQueueEntry
+	{
+		std::atomic_bool ready{false};
+		SimpleQueueEntry* next;
+		T value;
+	};
+
+	std::atomic<SimpleQueueEntry*> head{nullptr};
+	SimpleQueueEntry* tail = nullptr;
+
+public:
+	SimpleQueue();
+
+	//Used by single queue thread (i.e. EE)
+	void Enqueue(T entry);
+	//Used by single worker thread (i.e. IO)
+	bool Dequeue(T* entry);
+	//May return false negative when another thread is mid Queue()
+	//Intended to only be used from queue thread
+	bool IsQueueEmpty();
+
+	~SimpleQueue();
+};
+
+template <class T>
+SimpleQueue<T>::SimpleQueue()
+{
+	tail = new SimpleQueueEntry();
+	head.store(tail);
+}
+
+template <class T>
+void SimpleQueue<T>::Enqueue(T entry)
+{
+	//Allocate Next entry, and assign to head
+	SimpleQueueEntry* newHead = new SimpleQueueEntry();
+	SimpleQueueEntry* newEntry = head.exchange(newHead);
+
+	//Fill in
+	newEntry->value = entry;
+	newEntry->next = newHead;
+
+	//Set ready (can be dequeued)
+	newEntry->ready.store(true);
+}
+
+template <class T>
+bool SimpleQueue<T>::Dequeue(T* entry)
+{
+	if (!tail->ready.load())
+		return false;
+
+	SimpleQueueEntry* retEntry = tail;
+	tail = retEntry->next;
+
+	*entry = retEntry->value;
+	delete retEntry;
+	return true;
+}
+
+//Note, next entry may not be ready to dequeue
+template <class T>
+bool SimpleQueue<T>::IsQueueEmpty()
+{
+	return head.load() == tail;
+}
+
+template <class T>
+SimpleQueue<T>::~SimpleQueue()
+{
+	if (head != nullptr)
+	{
+		if (!IsQueueEmpty())
+		{
+			Console.Error("DEV9: Queue not empty");
+			pxAssert(false);
+
+			//Empty Queue
+			T entry;
+			while (!IsQueueEmpty())
+				Dequeue(&entry);
+		}
+
+		delete head;
+		head = nullptr;
+		tail = nullptr;
+	}
+}

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -649,6 +649,7 @@
     <ClInclude Include="..\..\DEV9\DEV9.h" />
     <ClInclude Include="..\..\DEV9\net.h" />
     <ClInclude Include="..\..\DEV9\pcap_io.h" />
+    <ClInclude Include="..\..\DEV9\SimpleQueue.h" />
     <ClInclude Include="..\..\DEV9\smap.h" />
     <ClInclude Include="..\..\DEV9\Win32\pcap_io_win32_funcs.h" />
     <ClInclude Include="..\..\DEV9\Win32\resource.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -1848,6 +1848,9 @@
     <ClInclude Include="..\..\DEV9\pcap_io.h">
       <Filter>System\Ps2\DEV9</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\DEV9\SimpleQueue.h">
+      <Filter>System\Ps2\DEV9</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\DEV9\smap.h">
       <Filter>System\Ps2\DEV9</Filter>
     </ClInclude>


### PR DESCRIPTION
This will be useful for porting other CLR_DEV9 features into pcsx2

Also adds the ability for multiple threads to add to the queue, as needed by the DNS pr