### PR TITLE
IPC: Socket reusability

### DIFF
--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -144,6 +144,12 @@ protected:
 	static inline char* MakeFailIPC(char* ret_buffer, uint32_t size);
 
 	/**
+	 * Initializes an open socket for IPC communication.
+	 * return value: -1 if a fatal failure happened, 0 otherwise. 
+	 */
+	int StartSocket();
+
+	/**
 	 * Converts an uint to an char* in little endian 
 	 * res_array: the array to modify 
 	 * res: the value to convert


### PR DESCRIPTION
This avoids port overfills on windows, while increasing perf substantially on platforms that do port overfills. 

This is NOT a breaking change, despite its looks.

Tested by Juhn, requires an up-to-date pcsx2_ipc implem