### PR TITLE
IPC: add a slot system

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -611,7 +611,7 @@ set(pcsx2GuiSources
 	gui/Dialogs/McdConfigDialog.cpp
 	gui/Dialogs/PickUserModeDialog.cpp
 	gui/Dialogs/SysConfigDialog.cpp
-    gui/Dialogs/IPCDialog.cpp
+	gui/Dialogs/IPCDialog.cpp
 	gui/Debugger/BreakpointWindow.cpp
 	gui/Debugger/CtrlDisassemblyView.cpp
 	gui/Debugger/CtrlRegisterList.cpp

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -611,6 +611,7 @@ set(pcsx2GuiSources
 	gui/Dialogs/McdConfigDialog.cpp
 	gui/Dialogs/PickUserModeDialog.cpp
 	gui/Dialogs/SysConfigDialog.cpp
+    gui/Dialogs/IPCDialog.cpp
 	gui/Debugger/BreakpointWindow.cpp
 	gui/Debugger/CtrlDisassemblyView.cpp
 	gui/Debugger/CtrlRegisterList.cpp

--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -42,7 +42,7 @@
 #include "svnrev.h"
 #include "IPC.h"
 
-SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot = DEFAULT_PORT)
+SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot)
 	: pxThread("IPC_Socket")
 {
 #ifdef _WIN32
@@ -85,11 +85,11 @@ SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot = DEFAULT_PORT)
 	char* tmp_socket;
 
 	if (runtime_dir == NULL)
-		m_socket_name = tmp_socket = (char*)"/tmp/pcsx2.sock";
+		m_socket_name = tmp_socket = (char*)"/tmp/" IPC_EMULATOR_NAME ".sock";
 	else
-		m_socket_name = tmp_socket = strcat(runtime_dir, "/pcsx2.sock");
+		m_socket_name = tmp_socket = strcat(runtime_dir, "/" IPC_EMULATOR_NAME ".sock");
 
-	if (slot != DEFAULT_PORT)
+	if (slot != IPC_DEFAULT_SLOT)
 	{
 		// maximum size of .%u
 		char slot_ending[34];

--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -56,7 +56,8 @@ SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot)
 		return;
 	}
 
-	if ((m_sock = socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET)
+	m_sock = socket(AF_INET, SOCK_STREAM, 0);
+	if ((m_sock == INVALID_SOCKET) || slot > 65536)
 	{
 		Console.WriteLn(Color_Red, "IPC: Cannot open socket! Shutting down...");
 		return;

--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -82,20 +82,17 @@ SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot)
 #endif
 	// fallback in case macOS or other OSes don't implement the XDG base
 	// spec
-	char* tmp_socket;
-
 	if (runtime_dir == NULL)
-		m_socket_name = tmp_socket = (char*)"/tmp/" IPC_EMULATOR_NAME ".sock";
+		m_socket_name = (char*)"/tmp/" IPC_EMULATOR_NAME ".sock";
 	else
-		m_socket_name = tmp_socket = strcat(runtime_dir, "/" IPC_EMULATOR_NAME ".sock");
+		m_socket_name = strcat(runtime_dir, "/" IPC_EMULATOR_NAME ".sock");
 
 	if (slot != IPC_DEFAULT_SLOT)
 	{
 		// maximum size of .%u
 		char slot_ending[34];
 		sprintf(slot_ending, ".%u", slot);
-		m_socket_name = strcat(tmp_socket, slot_ending);
-		free(tmp_socket);
+		m_socket_name = strcat(m_socket_name, slot_ending);
 	}
 
 	struct sockaddr_un server;

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -18,6 +18,13 @@
 
 #pragma once
 
+// IPC uses a concept of "slot" to be able to communicate with multiple
+// emulators at the same time, each slot should be unique to each emulator to
+// allow PnP and configurable by the end user so that several runs don't
+// conflict with each others
+#define IPC_DEFAULT_SLOT 28011
+#define IPC_EMULATOR_NAME "pcsx2"
+
 #include "Utilities/PersistentThread.h"
 #include "System/SysThreads.h"
 #ifdef _WIN32
@@ -29,7 +36,6 @@ using namespace Threading;
 
 class SocketIPC : public pxThread
 {
-
 	// parent thread
 	typedef pxThread _parent;
 
@@ -37,7 +43,6 @@ protected:
 #ifdef _WIN32
 	// windows claim to have support for AF_UNIX sockets but that is a blatant lie,
 	// their SDK won't even run their own examples, so we go on TCP sockets.
-#define DEFAULT_PORT 28011
 	SOCKET m_sock = INVALID_SOCKET;
 	// the message socket used in thread's accept().
 	SOCKET m_msgsock = INVALID_SOCKET;
@@ -200,7 +205,7 @@ public:
 	bool m_end = true;
 
 	/* Initializers */
-	SocketIPC(SysCoreThread* vm, unsigned int slot = DEFAULT_PORT);
+	SocketIPC(SysCoreThread* vm, unsigned int slot = IPC_DEFAULT_SLOT);
 	virtual ~SocketIPC();
 
 }; // class SocketIPC

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -37,7 +37,7 @@ protected:
 #ifdef _WIN32
 	// windows claim to have support for AF_UNIX sockets but that is a blatant lie,
 	// their SDK won't even run their own examples, so we go on TCP sockets.
-#define PORT 28011
+#define DEFAULT_PORT 28011
 	SOCKET m_sock = INVALID_SOCKET;
 	// the message socket used in thread's accept().
 	SOCKET m_msgsock = INVALID_SOCKET;
@@ -200,7 +200,7 @@ public:
 	bool m_end = true;
 
 	/* Initializers */
-	SocketIPC(SysCoreThread* vm);
+	SocketIPC(SysCoreThread* vm, unsigned int slot = DEFAULT_PORT);
 	virtual ~SocketIPC();
 
 }; // class SocketIPC

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -51,6 +51,11 @@
 
 bool g_CDVDReset = false;
 
+namespace IPCSettings
+{
+	unsigned int slot = IPC_DEFAULT_SLOT;
+};
+
 // --------------------------------------------------------------------------------------
 //  SysCoreThread *External Thread* Implementations
 //    (Called from outside the context of this thread)
@@ -270,7 +275,7 @@ void SysCoreThread::GameStartingInThread()
 	if (EmuConfig.EnableIPC && m_IpcState == OFF)
 	{
 		m_IpcState = ON;
-		m_socketIpc = std::make_unique<SocketIPC>(this);
+		m_socketIpc = std::make_unique<SocketIPC>(this, IPCSettings::slot);
 	}
 	if (m_IpcState == ON && m_socketIpc->m_end)
 		m_socketIpc->Start();

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -64,22 +64,22 @@ public:
 	};
 
 protected:
-	std::atomic<ExecutionMode>	m_ExecMode;
+	std::atomic<ExecutionMode> m_ExecMode;
 
 	// This lock is used to avoid simultaneous requests to Suspend/Resume/Pause from
 	// contending threads.
-	MutexRecursive		m_ExecModeMutex;
+	MutexRecursive m_ExecModeMutex;
 
 	// Used to wake up the thread from sleeping when it's in a suspended state.
-	Semaphore			m_sem_Resume;
+	Semaphore m_sem_Resume;
 
 	// Used to synchronize inline changes from paused to suspended status.
-	Semaphore			m_sem_ChangingExecMode;
+	Semaphore m_sem_ChangingExecMode;
 
 	// Locked whenever the thread is not in a suspended state (either closed or paused).
 	// Issue a Wait against this mutex for performing actions that require the thread
 	// to be suspended.
-	Mutex				m_RunningLock;
+	Mutex m_RunningLock;
 
 public:
 	explicit SysThreadBase();
@@ -111,7 +111,7 @@ public:
 	ExecutionMode GetExecutionMode() const { return m_ExecMode.load(); }
 	Mutex& ExecutionModeMutex() { return m_ExecModeMutex; }
 
-	virtual void Suspend( bool isBlocking = true );
+	virtual void Suspend(bool isBlocking = true);
 	virtual void Resume();
 	virtual void Pause(bool debug = false);
 	virtual void PauseSelf();
@@ -139,14 +139,14 @@ protected:
 	// prior to suspending the thread (ie, when Suspend() has been called on a separate
 	// thread, requesting this thread suspend itself temporarily).  After this is called,
 	// the thread enters a waiting state on the m_sem_Resume semaphore.
-	virtual void OnSuspendInThread()=0;
+	virtual void OnSuspendInThread() = 0;
 
 	// Extending classes should implement this, but should not call it.  The parent class
 	// handles invocation by the following guidelines: Called *in thread* from StateCheckInThread()
 	// prior to pausing the thread (ie, when Pause() has been called on a separate thread,
 	// requesting this thread pause itself temporarily).  After this is called, the thread
 	// enters a waiting state on the m_sem_Resume semaphore.
-	virtual void OnPauseInThread()=0;
+	virtual void OnPauseInThread() = 0;
 
 	// Extending classes should implement this, but should not call it.  The parent class
 	// handles invocation by the following guidelines: Called from StateCheckInThread() after the
@@ -154,7 +154,7 @@ protected:
 	// Parameter:
 	//   isSuspended - set to TRUE if the thread is returning from a suspended state, or
 	//     FALSE if it's returning from a paused state.
-	virtual void OnResumeInThread( bool isSuspended )=0;
+	virtual void OnResumeInThread(bool isSuspended) = 0;
 };
 
 
@@ -166,16 +166,16 @@ class SysCoreThread : public SysThreadBase
 	typedef SysThreadBase _parent;
 
 protected:
-	bool			m_resetRecompilers;
-	bool			m_resetProfilers;
-	bool			m_resetVsyncTimers;
-	bool			m_resetVirtualMachine;
+	bool m_resetRecompilers;
+	bool m_resetProfilers;
+	bool m_resetVsyncTimers;
+	bool m_resetVirtualMachine;
 
 	// Stores the state of the socket IPC thread.
 	std::unique_ptr<SocketIPC> m_socketIpc;
 
 	// Current state of the IPC thread
-	enum StateIPC 
+	enum StateIPC
 	{
 		OFF,
 		ON
@@ -188,9 +188,9 @@ protected:
 	// occurs while trying to upload a new state into the VM.
 	std::atomic<bool> m_hasActiveMachine;
 
-	wxString		m_elf_override;
+	wxString m_elf_override;
 
-	SSE_MXCSR		m_mxcsr_saved;
+	SSE_MXCSR m_mxcsr_saved;
 
 public:
 	explicit SysCoreThread();
@@ -201,20 +201,20 @@ public:
 	virtual void OnResumeReady();
 	virtual void Reset();
 	virtual void ResetQuick();
-	virtual void Cancel( bool isBlocking=true );
-	virtual bool Cancel( const wxTimeSpan& timeout );
+	virtual void Cancel(bool isBlocking = true);
+	virtual bool Cancel(const wxTimeSpan& timeout);
 
 	virtual bool StateCheckInThread();
 	virtual void VsyncInThread();
 	virtual void GameStartingInThread();
 
-	virtual void ApplySettings( const Pcsx2Config& src );
-	virtual void UploadStateCopy( const VmStateBuffer& copy );
+	virtual void ApplySettings(const Pcsx2Config& src);
+	virtual void UploadStateCopy(const VmStateBuffer& copy);
 
 	virtual bool HasActiveMachine() const { return m_hasActiveMachine; }
 
 	virtual const wxString& GetElfOverride() const { return m_elf_override; }
-	virtual void SetElfOverride( const wxString& elf );
+	virtual void SetElfOverride(const wxString& elf);
 
 protected:
 	void _reset_stuff_as_needed();
@@ -223,12 +223,12 @@ protected:
 	virtual void OnStart();
 	virtual void OnSuspendInThread();
 	virtual void OnPauseInThread() {}
-	virtual void OnResumeInThread( bool IsSuspended );
+	virtual void OnResumeInThread(bool IsSuspended);
 	virtual void OnCleanupInThread();
 	virtual void ExecuteTaskInThread();
 	virtual void DoCpuReset();
 	virtual void DoCpuExecute();
-	
+
 	void _StateCheckThrows();
 };
 
@@ -250,7 +250,7 @@ public:
 	IEventListener_SysState() {}
 	virtual ~IEventListener_SysState() = default;
 
-	virtual void DispatchEvent( const SysStateUnlockedParams& status )
+	virtual void DispatchEvent(const SysStateUnlockedParams& status)
 	{
 		SysStateAction_OnUnlocked();
 	}
@@ -267,3 +267,8 @@ protected:
 extern SysCoreThread& GetCoreThread();
 
 extern bool g_CDVDReset;
+
+namespace IPCSettings
+{
+	extern unsigned int slot;
+};

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -86,10 +86,10 @@ enum MenuIdentifiers
 	// Main Menu Section
 	MenuId_Boot = 1,
 	MenuId_Emulation,
-	MenuId_Config,				// General config, plus non audio/video plugins.
-	MenuId_Video,				// Video options filled in by GS plugin
-	MenuId_Audio,				// audio options filled in by SPU2 plugin
-	MenuId_Misc,				// Misc options and help!
+	MenuId_Config, // General config, plus non audio/video plugins.
+	MenuId_Video,  // Video options filled in by GS plugin
+	MenuId_Audio,  // audio options filled in by SPU2 plugin
+	MenuId_Misc,   // Misc options and help!
 
 	MenuId_Exit = wxID_EXIT,
 	MenuId_About = wxID_ABOUT,
@@ -101,9 +101,9 @@ enum MenuIdentifiers
 	MenuId_Src_Iso,
 	MenuId_Src_Disc,
 	MenuId_Src_NoDisc,
-	MenuId_Boot_Iso,			// Opens submenu with Iso browser, and recent isos.
+	MenuId_Boot_Iso, // Opens submenu with Iso browser, and recent isos.
 	MenuId_RecentIsos_reservedStart,
-	MenuId_IsoBrowse = MenuId_RecentIsos_reservedStart + 100,			// Open dialog, runs selected iso.
+	MenuId_IsoBrowse = MenuId_RecentIsos_reservedStart + 100, // Open dialog, runs selected iso.
 	MenuId_IsoClear,
 	MenuId_DriveSelector,
 	MenuId_DriveListRefresh,
@@ -114,15 +114,14 @@ enum MenuIdentifiers
 	//MenuId_Boot_Recent,			// Menu populated with recent source bootings
 
 
-	MenuId_Sys_SuspendResume,	// suspends/resumes active emulation, retains plugin states
-	MenuId_Sys_Shutdown,		// Closes virtual machine, shuts down plugins, wipes states.
-	MenuId_Sys_LoadStates,		// Opens load states submenu
-	MenuId_Sys_SaveStates,		// Opens save states submenu
-	MenuId_EnableBackupStates,	// Checkbox to enable/disables savestates backup
+	MenuId_Sys_SuspendResume,  // suspends/resumes active emulation, retains plugin states
+	MenuId_Sys_Shutdown,       // Closes virtual machine, shuts down plugins, wipes states.
+	MenuId_Sys_LoadStates,     // Opens load states submenu
+	MenuId_Sys_SaveStates,     // Opens save states submenu
+	MenuId_EnableBackupStates, // Checkbox to enable/disables savestates backup
 	MenuId_GameSettingsSubMenu,
 	MenuId_EnablePatches,
 	MenuId_EnableCheats,
-	MenuId_EnableIPC,
 	MenuId_EnableWideScreenPatches,
 	MenuId_EnableInputRecording,
 	MenuId_EnableLuaTools,
@@ -130,13 +129,13 @@ enum MenuIdentifiers
 
 	MenuId_State_Load,
 	MenuId_State_LoadFromFile,
-	MenuId_State_Load01,		// first of many load slots
-	MenuId_State_LoadBackup = MenuId_State_Load01+20,
+	MenuId_State_Load01, // first of many load slots
+	MenuId_State_LoadBackup = MenuId_State_Load01 + 20,
 	MenuId_State_Save,
 	MenuId_State_SaveToFile,
-	MenuId_State_Save01,		// first of many save slots
+	MenuId_State_Save01, // first of many save slots
 
-	MenuId_State_EndSlotSection = MenuId_State_Save01+20,
+	MenuId_State_EndSlotSection = MenuId_State_Save01 + 20,
 
 	// Config Subsection
 	MenuId_Config_SysSettings,
@@ -175,18 +174,18 @@ enum MenuIdentifiers
 	MenuId_PluginBase_Name = 0x100,
 	MenuId_PluginBase_Settings = 0x101,
 
-	MenuId_Video_CoreSettings = 0x200,// includes frame timings and skippings settings
+	MenuId_Video_CoreSettings = 0x200, // includes frame timings and skippings settings
 	MenuId_Video_WindowSettings,
 
 	// Miscellaneous Menu!  (Misc)
-	MenuId_Console,				// Enable console
-	MenuId_ChangeLang,			// Change language (resets first time wizard to show on next start)
-	MenuId_Console_Stdio,		// Enable Stdio
+	MenuId_Console,       // Enable console
+	MenuId_ChangeLang,    // Change language (resets first time wizard to show on next start)
+	MenuId_Console_Stdio, // Enable Stdio
 
 	// Debug Subsection
-	MenuId_Debug_Open,			// opens the debugger window / starts a debug session
+	MenuId_Debug_Open, // opens the debugger window / starts a debug session
 	MenuId_Debug_MemoryDump,
-	MenuId_Debug_Logging,		// dialog for selection additional log options
+	MenuId_Debug_Logging, // dialog for selection additional log options
 	MenuId_Debug_CreateBlockdump,
 	MenuId_Config_ResetAll,
 
@@ -210,6 +209,11 @@ enum MenuIdentifiers
 	MenuId_Recording_VirtualPad_Port1,
 #endif
 
+	// IPC Subsection
+	MenuId_IPC,
+	MenuId_IPC_Enable,
+	MenuId_IPC_Settings,
+
 };
 
 namespace Exception
@@ -220,16 +224,16 @@ namespace Exception
 	//
 	class StartupAborted : public CancelEvent
 	{
-		DEFINE_RUNTIME_EXCEPTION( StartupAborted, CancelEvent, L"Startup initialization was aborted by the user." )
+		DEFINE_RUNTIME_EXCEPTION(StartupAborted, CancelEvent, L"Startup initialization was aborted by the user.")
 
 	public:
-		StartupAborted( const wxString& reason )
+		StartupAborted(const wxString& reason)
 		{
 			m_message_diag = L"Startup aborted: " + reason;
 		}
 	};
 
-}
+} // namespace Exception
 
 // --------------------------------------------------------------------------------------
 //  AppImageIds  - Config and Toolbar Images and Icons
@@ -238,7 +242,7 @@ struct AppImageIds
 {
 	struct ConfigIds
 	{
-		int	Paths,
+		int Paths,
 			Plugins,
 			Speedhacks,
 			Gamefixes,
@@ -248,10 +252,10 @@ struct AppImageIds
 
 		ConfigIds()
 		{
-			Paths		= Plugins		=
-			Speedhacks	= Gamefixes		=
-			Video		= Cpu			= 
-			MemoryCard	= -1;
+			Paths = Plugins =
+				Speedhacks = Gamefixes =
+					Video = Cpu =
+						MemoryCard = -1;
 		}
 	} Config;
 
@@ -266,12 +270,12 @@ struct AppImageIds
 
 		ToolbarIds()
 		{
-			Settings    = -1;
-			Play        = -1;
-			Resume      = -1;
+			Settings = -1;
+			Play = -1;
+			Resume = -1;
 			PluginVideo = -1;
 			PluginAudio = -1;
-			PluginPad   = -1;
+			PluginPad = -1;
 		}
 	} Toolbars;
 };
@@ -285,14 +289,14 @@ struct AppImageIds
 class pxAppResources
 {
 public:
-	AppImageIds					ImageId;
+	AppImageIds ImageId;
 
-	std::unique_ptr<wxImageList>		ConfigImages;
-	std::unique_ptr<wxImageList>		ToolbarImages;
-	std::unique_ptr<wxIconBundle>		IconBundle;
-	std::unique_ptr<wxBitmap>			Bitmap_Logo;
-	std::unique_ptr<wxBitmap>			ScreenshotBitmap;
-	std::unique_ptr<AppGameDatabase>	GameDB;
+	std::unique_ptr<wxImageList> ConfigImages;
+	std::unique_ptr<wxImageList> ToolbarImages;
+	std::unique_ptr<wxIconBundle> IconBundle;
+	std::unique_ptr<wxBitmap> Bitmap_Logo;
+	std::unique_ptr<wxBitmap> ScreenshotBitmap;
+	std::unique_ptr<AppGameDatabase> GameDB;
 
 	pxAppResources();
 	virtual ~pxAppResources();
@@ -324,40 +328,40 @@ public:
 class StartupOptions
 {
 public:
-	bool			ForceWizard;
-	bool			ForceConsole;
-	bool			PortableMode;
+	bool ForceWizard;
+	bool ForceConsole;
+	bool PortableMode;
 
 	// Disables the fast boot option when auto-running games.  This option only applies
 	// if SysAutoRun is also true.
-	bool			NoFastBoot;
+	bool NoFastBoot;
 
 	// Specifies the Iso file to boot; used only if SysAutoRun is enabled and CdvdSource
 	// is set to ISO.
-	wxString		IsoFile;
+	wxString IsoFile;
 
-	wxString		ElfFile;
+	wxString ElfFile;
 
-	wxString		GameLaunchArgs;
+	wxString GameLaunchArgs;
 
 	// Specifies the CDVD source type to use when AutoRunning
 	CDVD_SourceType CdvdSource;
 
 	// Indicates if PCSX2 should autorun the configured CDVD source and/or ISO file.
-	bool			SysAutoRun;
-	bool			SysAutoRunElf;
-	bool			SysAutoRunIrx;
+	bool SysAutoRun;
+	bool SysAutoRunElf;
+	bool SysAutoRunIrx;
 
 	StartupOptions()
 	{
-		ForceWizard				= false;
-		ForceConsole			= false;
-		PortableMode			= false;
-		NoFastBoot				= false;
-		SysAutoRun				= false;
-		SysAutoRunElf			= false;
-		SysAutoRunIrx			= false;
-		CdvdSource				= CDVD_SourceType::NoDisc;
+		ForceWizard = false;
+		ForceConsole = false;
+		PortableMode = false;
+		NoFastBoot = false;
+		SysAutoRun = false;
+		SysAutoRunElf = false;
+		SysAutoRunIrx = false;
+		CdvdSource = CDVD_SourceType::NoDisc;
 	}
 };
 
@@ -371,35 +375,35 @@ enum GsWindowMode_t
 class CommandlineOverrides
 {
 public:
-	AppConfig::FilenameOptions	Filenames;
-	wxDirName		SettingsFolder;
-	wxFileName		VmSettingsFile;
+	AppConfig::FilenameOptions Filenames;
+	wxDirName SettingsFolder;
+	wxFileName VmSettingsFile;
 
-	bool			DisableSpeedhacks;
-	bool			ProfilingMode;
+	bool DisableSpeedhacks;
+	bool ProfilingMode;
 
 	// Note that gamefixes in this array should only be honored if the
 	// "HasCustomGamefixes" boolean is also enabled.
-	Pcsx2Config::GamefixOptions	Gamefixes;
-	bool			ApplyCustomGamefixes;
+	Pcsx2Config::GamefixOptions Gamefixes;
+	bool ApplyCustomGamefixes;
 
-	GsWindowMode_t	GsWindowMode;
+	GsWindowMode_t GsWindowMode;
 
 public:
 	CommandlineOverrides()
 	{
-		DisableSpeedhacks		= false;
-		ApplyCustomGamefixes	= false;
-		GsWindowMode			= GsWinMode_Unspecified;
-		ProfilingMode			= false;
+		DisableSpeedhacks = false;
+		ApplyCustomGamefixes = false;
+		GsWindowMode = GsWinMode_Unspecified;
+		ProfilingMode = false;
 	}
-	
+
 	// Returns TRUE if either speedhacks or gamefixes are being overridden.
 	bool HasCustomHacks() const
 	{
 		return DisableSpeedhacks || ApplyCustomGamefixes;
 	}
-	
+
 	void RemoveCustomHacks()
 	{
 		DisableSpeedhacks = false;
@@ -413,8 +417,9 @@ public:
 
 	bool HasPluginsOverride() const
 	{
-		for( int i=0; i<PluginId_Count; ++i )
-			if( Filenames.Plugins[i].IsOk() ) return true;
+		for (int i = 0; i < PluginId_Count; ++i)
+			if (Filenames.Plugins[i].IsOk())
+				return true;
 
 		return false;
 	}
@@ -433,97 +438,97 @@ class Pcsx2App : public wxAppWithHelpers
 	// on them and they are, themselves, fairly self-contained.
 
 protected:
-	EventSource<IEventListener_Plugins>		m_evtsrc_CorePluginStatus;
-	EventSource<IEventListener_CoreThread>	m_evtsrc_CoreThreadStatus;
-	EventSource<IEventListener_AppStatus>	m_evtsrc_AppStatus;
+	EventSource<IEventListener_Plugins> m_evtsrc_CorePluginStatus;
+	EventSource<IEventListener_CoreThread> m_evtsrc_CoreThreadStatus;
+	EventSource<IEventListener_AppStatus> m_evtsrc_AppStatus;
 
 public:
-	void AddListener( IEventListener_Plugins& listener )
+	void AddListener(IEventListener_Plugins& listener)
 	{
-		m_evtsrc_CorePluginStatus.Add( listener );	
+		m_evtsrc_CorePluginStatus.Add(listener);
 	}
 
-	void AddListener( IEventListener_CoreThread& listener )
+	void AddListener(IEventListener_CoreThread& listener)
 	{
-		m_evtsrc_CoreThreadStatus.Add( listener );
+		m_evtsrc_CoreThreadStatus.Add(listener);
 	}
 
-	void AddListener( IEventListener_AppStatus& listener )
+	void AddListener(IEventListener_AppStatus& listener)
 	{
-		m_evtsrc_AppStatus.Add( listener );
+		m_evtsrc_AppStatus.Add(listener);
 	}
 
-	void RemoveListener( IEventListener_Plugins& listener )
+	void RemoveListener(IEventListener_Plugins& listener)
 	{
-		m_evtsrc_CorePluginStatus.Remove( listener );	
+		m_evtsrc_CorePluginStatus.Remove(listener);
 	}
 
-	void RemoveListener( IEventListener_CoreThread& listener )
+	void RemoveListener(IEventListener_CoreThread& listener)
 	{
-		m_evtsrc_CoreThreadStatus.Remove( listener );
+		m_evtsrc_CoreThreadStatus.Remove(listener);
 	}
 
-	void RemoveListener( IEventListener_AppStatus& listener )
+	void RemoveListener(IEventListener_AppStatus& listener)
 	{
-		m_evtsrc_AppStatus.Remove( listener );
+		m_evtsrc_AppStatus.Remove(listener);
 	}
 
-	void AddListener( IEventListener_Plugins* listener )
+	void AddListener(IEventListener_Plugins* listener)
 	{
-		m_evtsrc_CorePluginStatus.Add( listener );	
+		m_evtsrc_CorePluginStatus.Add(listener);
 	}
 
-	void AddListener( IEventListener_CoreThread* listener )
+	void AddListener(IEventListener_CoreThread* listener)
 	{
-		m_evtsrc_CoreThreadStatus.Add( listener );
+		m_evtsrc_CoreThreadStatus.Add(listener);
 	}
 
-	void AddListener( IEventListener_AppStatus* listener )
+	void AddListener(IEventListener_AppStatus* listener)
 	{
-		m_evtsrc_AppStatus.Add( listener );
+		m_evtsrc_AppStatus.Add(listener);
 	}
 
-	void RemoveListener( IEventListener_Plugins* listener )
+	void RemoveListener(IEventListener_Plugins* listener)
 	{
-		m_evtsrc_CorePluginStatus.Remove( listener );	
+		m_evtsrc_CorePluginStatus.Remove(listener);
 	}
 
-	void RemoveListener( IEventListener_CoreThread* listener )
+	void RemoveListener(IEventListener_CoreThread* listener)
 	{
-		m_evtsrc_CoreThreadStatus.Remove( listener );
+		m_evtsrc_CoreThreadStatus.Remove(listener);
 	}
 
-	void RemoveListener( IEventListener_AppStatus* listener )
+	void RemoveListener(IEventListener_AppStatus* listener)
 	{
-		m_evtsrc_AppStatus.Remove( listener );
+		m_evtsrc_AppStatus.Remove(listener);
 	}
-	
-	void DispatchEvent( PluginEventType evt );
-	void DispatchEvent( AppEventType evt );
-	void DispatchEvent( CoreThreadStatus evt );
-	void DispatchUiSettingsEvent( IniInterface& ini );
-	void DispatchVmSettingsEvent( IniInterface& ini );
+
+	void DispatchEvent(PluginEventType evt);
+	void DispatchEvent(AppEventType evt);
+	void DispatchEvent(CoreThreadStatus evt);
+	void DispatchUiSettingsEvent(IniInterface& ini);
+	void DispatchVmSettingsEvent(IniInterface& ini);
 
 	bool HasGUI() { return m_UseGUI; };
 	bool ExitPromptWithNoGUI() { return m_NoGuiExitPrompt; };
 
 	// ----------------------------------------------------------------------------
 protected:
-	int								m_PendingSaves;
-	bool							m_ScheduledTermination;
-	bool							m_UseGUI;
-	bool							m_NoGuiExitPrompt;
+	int m_PendingSaves;
+	bool m_ScheduledTermination;
+	bool m_UseGUI;
+	bool m_NoGuiExitPrompt;
 
-	Threading::Mutex				m_mtx_Resources;
-	Threading::Mutex				m_mtx_LoadingGameDB;
+	Threading::Mutex m_mtx_Resources;
+	Threading::Mutex m_mtx_LoadingGameDB;
 
 public:
-	FramerateManager				FpsManager;
+	FramerateManager FpsManager;
 	std::unique_ptr<CommandDictionary> GlobalCommands;
 	std::unique_ptr<AcceleratorDictionary> GlobalAccels;
 
-	StartupOptions					Startup;
-	CommandlineOverrides			Overrides;
+	StartupOptions Startup;
+	CommandlineOverrides Overrides;
 
 	std::unique_ptr<wxTimer> m_timer_Termination;
 
@@ -539,58 +544,61 @@ public:
 	// Executor Thread for complex VM/System tasks.  This thread is used to execute such tasks
 	// in parallel to the main message pump, to allow the main pump to run without fear of
 	// blocked threads stalling the GUI.
-	ExecutorThread					SysExecutorThread;
+	ExecutorThread SysExecutorThread;
 	std::unique_ptr<SysCpuProviderPack> m_CpuProviders;
 	std::unique_ptr<SysMainMemory> m_VmReserve;
 
 protected:
-	wxWindowID			m_id_MainFrame;
-	wxWindowID			m_id_GsFrame;
-	wxWindowID			m_id_ProgramLogBox;
-	wxWindowID			m_id_Disassembler;
+	wxWindowID m_id_MainFrame;
+	wxWindowID m_id_GsFrame;
+	wxWindowID m_id_ProgramLogBox;
+	wxWindowID m_id_Disassembler;
 
 #ifndef DISABLE_RECORDING
-	wxWindowID			m_id_NewRecordingFrame;
+	wxWindowID m_id_NewRecordingFrame;
 #endif
 
-	wxKeyEvent			m_kevt;
+	wxKeyEvent m_kevt;
 
 public:
 	Pcsx2App();
 	virtual ~Pcsx2App();
 
-	void PostMenuAction( MenuIdentifiers menu_id ) const;
-	void PostAppMethod( FnPtr_Pcsx2App method );
-	void PostIdleAppMethod( FnPtr_Pcsx2App method );
+	void PostMenuAction(MenuIdentifiers menu_id) const;
+	void PostAppMethod(FnPtr_Pcsx2App method);
+	void PostIdleAppMethod(FnPtr_Pcsx2App method);
 
 	void SysApplySettings();
 	void SysExecute();
-	void SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override=wxEmptyString );
+	void SysExecute(CDVD_SourceType cdvdsrc, const wxString& elf_override = wxEmptyString);
 	void LogicalVsync();
-	
-	SysMainMemory& GetVmReserve();
-	
-	GSFrame&			GetGsFrame() const;
-	MainEmuFrame&		GetMainFrame() const;
 
-	GSFrame*			GetGsFramePtr() const		{ return (GSFrame*)wxWindow::FindWindowById( m_id_GsFrame ); }
-	MainEmuFrame*		GetMainFramePtr() const		{ return (MainEmuFrame*)wxWindow::FindWindowById( m_id_MainFrame ); }
-	DisassemblyDialog*	GetDisassemblyPtr() const	{ return (DisassemblyDialog*)wxWindow::FindWindowById(m_id_Disassembler); }
+	SysMainMemory& GetVmReserve();
+
+	GSFrame& GetGsFrame() const;
+	MainEmuFrame& GetMainFrame() const;
+
+	GSFrame* GetGsFramePtr() const { return (GSFrame*)wxWindow::FindWindowById(m_id_GsFrame); }
+	MainEmuFrame* GetMainFramePtr() const { return (MainEmuFrame*)wxWindow::FindWindowById(m_id_MainFrame); }
+	DisassemblyDialog* GetDisassemblyPtr() const { return (DisassemblyDialog*)wxWindow::FindWindowById(m_id_Disassembler); }
 
 #ifndef DISABLE_RECORDING
-	NewRecordingFrame*	GetNewRecordingFramePtr() const		{ return (NewRecordingFrame*)wxWindow::FindWindowById(m_id_NewRecordingFrame); }
+	NewRecordingFrame* GetNewRecordingFramePtr() const
+	{
+		return (NewRecordingFrame*)wxWindow::FindWindowById(m_id_NewRecordingFrame);
+	}
 #endif
 
 	void enterDebugMode();
 	void leaveDebugMode();
 	void resetDebugger();
 
-	bool HasMainFrame() const	{ return GetMainFramePtr() != NULL; }
+	bool HasMainFrame() const { return GetMainFramePtr() != NULL; }
 
 	void OpenGsPanel();
 	void CloseGsPanel();
-	void OnGsFrameClosed( wxWindowID id );
-	void OnMainFrameClosed( wxWindowID id );
+	void OnGsFrameClosed(wxWindowID id);
+	void OnMainFrameClosed(wxWindowID id);
 
 	// --------------------------------------------------------------------------
 	//  Startup / Shutdown Helpers
@@ -603,7 +611,7 @@ public:
 	void CleanupRestartable();
 	void CleanupResources();
 	void WipeUserModeSettings();
-	bool TestUserPermissionsRights( const wxDirName& testFolder, wxString& createFailedStr, wxString& accessFailedStr );
+	bool TestUserPermissionsRights(const wxDirName& testFolder, wxString& createFailedStr, wxString& accessFailedStr);
 	void EstablishAppUserMode();
 	void ForceFirstTimeWizardOnNextRun();
 
@@ -613,23 +621,23 @@ public:
 	bool HasPendingSaves() const;
 	void StartPendingSave();
 	void ClearPendingSave();
-	
+
 	// --------------------------------------------------------------------------
 	//  App-wide Resources
 	// --------------------------------------------------------------------------
 	// All of these accessors cache the resources on first use and retain them in
 	// memory until the program exits.
 
-	wxMenu&				GetRecentIsoMenu();
-	RecentIsoManager&	GetRecentIsoManager();
-	wxMenu&				GetDriveListMenu();
+	wxMenu& GetRecentIsoMenu();
+	RecentIsoManager& GetRecentIsoManager();
+	wxMenu& GetDriveListMenu();
 
-	pxAppResources&		GetResourceCache();
-	const wxIconBundle&	GetIconBundle();
-	const wxBitmap&		GetLogoBitmap();
-	const wxBitmap&		GetScreenshotBitmap();
-	wxImageList&		GetImgList_Config();
-	wxImageList&		GetImgList_Toolbars();
+	pxAppResources& GetResourceCache();
+	const wxIconBundle& GetIconBundle();
+	const wxBitmap& GetLogoBitmap();
+	const wxBitmap& GetScreenshotBitmap();
+	wxImageList& GetImgList_Config();
+	wxImageList& GetImgList_Toolbars();
 
 	const AppImageIds& GetImgId() const;
 	AppGameDatabase* GetGameDatabase();
@@ -639,37 +647,37 @@ public:
 	// --------------------------------------------------------------------------
 	wxAppTraits* CreateTraits();
 	bool OnInit();
-	int  OnExit();
+	int OnExit();
 	void CleanUp();
 
-	void OnInitCmdLine( wxCmdLineParser& parser );
-	bool OnCmdLineParsed( wxCmdLineParser& parser );
-	bool OnCmdLineError( wxCmdLineParser& parser );
-	bool ParseOverrides( wxCmdLineParser& parser );
+	void OnInitCmdLine(wxCmdLineParser& parser);
+	bool OnCmdLineParsed(wxCmdLineParser& parser);
+	bool OnCmdLineError(wxCmdLineParser& parser);
+	bool ParseOverrides(wxCmdLineParser& parser);
 
 #ifdef __WXDEBUG__
-	void OnAssertFailure( const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg );
+	void OnAssertFailure(const wxChar* file, int line, const wxChar* func, const wxChar* cond, const wxChar* msg);
 #endif
 
-	Threading::MutexRecursive	m_mtx_ProgramLog;
-	ConsoleLogFrame*			m_ptr_ProgramLog;
+	Threading::MutexRecursive m_mtx_ProgramLog;
+	ConsoleLogFrame* m_ptr_ProgramLog;
 
 	// ----------------------------------------------------------------------------
 	//   Console / Program Logging Helpers
 	// ----------------------------------------------------------------------------
 	ConsoleLogFrame* GetProgramLog();
 	const ConsoleLogFrame* GetProgramLog() const;
-	void ProgramLog_PostEvent( wxEvent& evt );
+	void ProgramLog_PostEvent(wxEvent& evt);
 	Threading::Mutex& GetProgramLogLock();
 
 	void EnableAllLogging();
 	void DisableWindowLogging() const;
 	void DisableDiskLogging() const;
-	void OnProgramLogClosed( wxWindowID id );
+	void OnProgramLogClosed(wxWindowID id);
 
 protected:
-	bool AppRpc_TryInvoke( FnPtr_Pcsx2App method );
-	bool AppRpc_TryInvokeAsync( FnPtr_Pcsx2App method );
+	bool AppRpc_TryInvoke(FnPtr_Pcsx2App method);
+	bool AppRpc_TryInvokeAsync(FnPtr_Pcsx2App method);
 
 	void AllocateCoreStuffs();
 	void InitDefaultGlobalAccelerators();
@@ -677,16 +685,16 @@ protected:
 	bool TryOpenConfigCwd();
 	void CleanupOnExit();
 	void OpenWizardConsole();
-	void PadKeyDispatch( const keyEvent& ev );
+	void PadKeyDispatch(const keyEvent& ev);
 
 protected:
 	void HandleEvent(wxEvtHandler* handler, wxEventFunction func, wxEvent& event) const;
 	void HandleEvent(wxEvtHandler* handler, wxEventFunction func, wxEvent& event);
 
-	void OnScheduledTermination( wxTimerEvent& evt );
-	void OnEmuKeyDown( wxKeyEvent& evt );
-	void OnSysExecutorTaskTimeout( wxTimerEvent& evt );
-	void OnDestroyWindow( wxWindowDestroyEvent& evt );
+	void OnScheduledTermination(wxTimerEvent& evt);
+	void OnEmuKeyDown(wxKeyEvent& evt);
+	void OnSysExecutorTaskTimeout(wxTimerEvent& evt);
+	void OnDestroyWindow(wxWindowDestroyEvent& evt);
 
 	// ----------------------------------------------------------------------------
 	//      Override wx default exception handling behavior
@@ -727,31 +735,36 @@ wxDECLARE_APP(Pcsx2App);
 // continue running silently.  These macros make that possible without any extra boilerplate
 // conditionals or temp variable defines in the code.
 //
-#define sApp \
-	if( Pcsx2App* __app_ = (Pcsx2App*)wxApp::GetInstance() ) (*__app_)
+#define sApp                                                \
+	if (Pcsx2App* __app_ = (Pcsx2App*)wxApp::GetInstance()) \
+	(*__app_)
 
-#define sLogFrame \
-	if( ConsoleLogFrame* __conframe_ = wxGetApp().GetProgramLog() ) (*__conframe_)
+#define sLogFrame                                                  \
+	if (ConsoleLogFrame* __conframe_ = wxGetApp().GetProgramLog()) \
+	(*__conframe_)
 
-#define sMainFrame \
-	if( MainEmuFrame* __frame_ = GetMainFramePtr() ) (*__frame_)
+#define sMainFrame                                  \
+	if (MainEmuFrame* __frame_ = GetMainFramePtr()) \
+	(*__frame_)
 
 // Use this within the scope of a wxWindow (wxDialog or wxFrame).  If the window has a valid menu
 // bar, the command will run, otherwise it will be silently ignored. :)
-#define sMenuBar \
-	if( wxMenuBar* __menubar_ = GetMenuBar() ) (*__menubar_)
+#define sMenuBar                              \
+	if (wxMenuBar* __menubar_ = GetMenuBar()) \
+	(*__menubar_)
 
 // --------------------------------------------------------------------------------------
 //  AppOpenDialog
 // --------------------------------------------------------------------------------------
 // Returns a wxWindow handle to the opened window.
 //
-template<typename DialogType>
-wxWindow* AppOpenDialog( wxWindow* parent=NULL )
+template <typename DialogType>
+wxWindow* AppOpenDialog(wxWindow* parent = NULL)
 {
-	wxWindow* window = wxFindWindowByName( L"Dialog:" + DialogType::GetNameStatic() );
-	
-	if( !window ) window = new DialogType( parent );
+	wxWindow* window = wxFindWindowByName(L"Dialog:" + DialogType::GetNameStatic());
+
+	if (!window)
+		window = new DialogType(parent);
 
 	window->Show();
 	window->SetFocus();
@@ -763,7 +776,7 @@ wxWindow* AppOpenDialog( wxWindow* parent=NULL )
 // --------------------------------------------------------------------------------------
 // Returns the ID of the button used to close the dialog.
 //
-template<typename DialogType>
+template <typename DialogType>
 int AppOpenModalDialog(wxString panel_name, wxWindow* parent = NULL)
 {
 	if (wxWindow* window = wxFindWindowByName(L"Dialog:" + DialogType::GetNameStatic()))
@@ -772,7 +785,8 @@ int AppOpenModalDialog(wxString panel_name, wxWindow* parent = NULL)
 		if (wxDialog* dialog = wxDynamicCast(window, wxDialog))
 		{
 			// Switch to the requested panel.
-			if (panel_name != wxEmptyString) {
+			if (panel_name != wxEmptyString)
+			{
 				wxCommandEvent evt(pxEvt_SetSettingsPage);
 				evt.SetString(panel_name);
 				dialog->GetEventHandler()->ProcessEvent(evt);
@@ -790,7 +804,8 @@ int AppOpenModalDialog(wxString panel_name, wxWindow* parent = NULL)
 		}
 		pxFailDev("Can only show wxDialog class windows as modal!");
 		return wxID_CANCEL;
-	} else
+	}
+	else
 		return DialogType(parent).ShowModal();
 }
 
@@ -800,20 +815,20 @@ extern pxDoAssertFnType AppDoAssert;
 //  External App-related Globals and Shortcuts
 // --------------------------------------------------------------------------------------
 
-extern int  EnumeratePluginsInFolder( const wxDirName& searchPath, wxArrayString* dest );
+extern int EnumeratePluginsInFolder(const wxDirName& searchPath, wxArrayString* dest);
 extern void LoadPluginsPassive();
 extern void LoadPluginsImmediate();
 extern void UnloadPlugins();
 extern void ShutdownPlugins();
 
 extern bool SysHasValidState();
-extern void SysUpdateIsoSrcFile( const wxString& newIsoFile );
-extern void SysUpdateDiscSrcDrive( const wxString& newDiscDrive );
-extern void SysStatus( const wxString& text );
+extern void SysUpdateIsoSrcFile(const wxString& newIsoFile);
+extern void SysUpdateDiscSrcDrive(const wxString& newDiscDrive);
+extern void SysStatus(const wxString& text);
 
-extern bool				HasMainFrame();
-extern MainEmuFrame&	GetMainFrame();
-extern MainEmuFrame*	GetMainFramePtr();
+extern bool HasMainFrame();
+extern MainEmuFrame& GetMainFrame();
+extern MainEmuFrame* GetMainFramePtr();
 
 extern __aligned16 AppCoreThread CoreThread;
 extern __aligned16 SysMtgsThread mtgsThread;
@@ -831,10 +846,10 @@ extern void UI_DisableSysShutdown();
 
 
 #define AffinityAssert_AllowFrom_SysExecutor() \
-	pxAssertMsg( wxGetApp().SysExecutorThread.IsSelf(), "Thread affinity violation: Call allowed from SysExecutor thread only." )
+	pxAssertMsg(wxGetApp().SysExecutorThread.IsSelf(), "Thread affinity violation: Call allowed from SysExecutor thread only.")
 
 #define AffinityAssert_DisallowFrom_SysExecutor() \
-	pxAssertMsg( !wxGetApp().SysExecutorThread.IsSelf(), "Thread affinity violation: Call is *not* allowed from SysExecutor thread." )
+	pxAssertMsg(!wxGetApp().SysExecutorThread.IsSelf(), "Thread affinity violation: Call is *not* allowed from SysExecutor thread.")
 
 extern ExecutorThread& GetSysExecutorThread();
 

--- a/pcsx2/gui/Dialogs/IPCDialog.cpp
+++ b/pcsx2/gui/Dialogs/IPCDialog.cpp
@@ -1,0 +1,61 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "App.h"
+#include "AppCommon.h"
+#include "MSWstuff.h"
+
+#include "Dialogs/ModalPopups.h"
+
+#include "System/SysThreads.h"
+
+#include "PathDefs.h"
+#include "AppConfig.h"
+
+using namespace pxSizerFlags;
+/* This dialog currently assumes the IPC server is started when launching a
+ * game, as such we can allow the IPC Settings window to change the slot in a
+ * volatile fashion so that it returns to the default but you can change it at
+ * each restart of the emulator to allow for multiple emulator sessions.
+ * If we change this behaviour we will need to change that accordingly.
+ */
+
+// --------------------------------------------------------------------------------------
+//  IPCDialog  Implementation
+// --------------------------------------------------------------------------------------
+
+Dialogs::IPCDialog::IPCDialog(wxWindow* parent)
+	: wxDialogWithHelpers(parent, _("IPC Settings"), pxDialogFlags())
+{
+	wxTextCtrl* ipc_slot = new wxTextCtrl(this, wxID_ANY, wxString::Format(wxT("%u"), IPCSettings::slot), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	ipc_slot->Bind(wxEVT_TEXT_ENTER, &Dialogs::IPCDialog::OnConfirm, this);
+
+	wxButton* confirm = new wxButton(this, wxID_OK);
+	confirm->SetDefault();
+
+	*this += new wxStaticText(this, wxID_ANY, _("IPC Slot"));
+	*this += ipc_slot;
+	*this += confirm;
+}
+
+void Dialogs::IPCDialog::OnConfirm(wxCommandEvent& evt)
+{
+	wxTextCtrl* textbox = dynamic_cast<wxTextCtrl*>(evt.GetEventObject());
+	if (textbox)
+	{
+		IPCSettings::slot = (unsigned int)atoi(textbox->GetValue().ToUTF8().data());
+	}
+}

--- a/pcsx2/gui/Dialogs/IPCDialog.cpp
+++ b/pcsx2/gui/Dialogs/IPCDialog.cpp
@@ -45,7 +45,6 @@ Dialogs::IPCDialog::IPCDialog(wxWindow* parent)
 
 	*this += new wxStaticText(this, wxID_ANY, _("IPC Slot"));
 	*this += ipc_slot;
-	*this += confirm;
 }
 
 void Dialogs::IPCDialog::OnConfirm(wxCommandEvent& evt)

--- a/pcsx2/gui/Dialogs/IPCDialog.cpp
+++ b/pcsx2/gui/Dialogs/IPCDialog.cpp
@@ -43,9 +43,6 @@ Dialogs::IPCDialog::IPCDialog(wxWindow* parent)
 	wxTextCtrl* ipc_slot = new wxTextCtrl(this, wxID_ANY, wxString::Format(wxT("%u"), IPCSettings::slot), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 	ipc_slot->Bind(wxEVT_TEXT_ENTER, &Dialogs::IPCDialog::OnConfirm, this);
 
-	wxButton* confirm = new wxButton(this, wxID_OK);
-	confirm->SetDefault();
-
 	*this += new wxStaticText(this, wxID_ANY, _("IPC Slot"));
 	*this += ipc_slot;
 	*this += confirm;
@@ -57,5 +54,6 @@ void Dialogs::IPCDialog::OnConfirm(wxCommandEvent& evt)
 	if (textbox)
 	{
 		IPCSettings::slot = (unsigned int)atoi(textbox->GetValue().ToUTF8().data());
+		Destroy();
 	}
 }

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -101,6 +101,17 @@ namespace Dialogs
 		AssertionDialog( const wxString& text, const wxString& stacktrace );
 		virtual ~AssertionDialog() = default;
 	};
+
+	class IPCDialog : public wxDialogWithHelpers
+	{
+	public:
+		IPCDialog(wxWindow* parent = NULL);
+		virtual ~IPCDialog() = default;
+
+		void OnConfirm(wxCommandEvent& evt);
+		static wxString GetNameStatic() { return L"IPCSettings"; }
+		wxString GetDialogName() const { return GetNameStatic(); }
+	};
 }
 
 wxWindowID pxIssueConfirmation( wxDialogWithHelpers& confirmDlg, const MsgButtons& buttons );

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -233,7 +233,8 @@ void MainEmuFrame::ConnectMenus()
 
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnablePatches_Click, this, MenuId_EnablePatches);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableCheats_Click, this, MenuId_EnableCheats);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableIPC_Click, this, MenuId_EnableIPC);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IPC_Enable_Click, this, MenuId_IPC_Enable);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IPC_Settings_Click, this, MenuId_IPC_Settings);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableWideScreenPatches_Click, this, MenuId_EnableWideScreenPatches);
 #ifndef DISABLE_RECORDING
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableRecordingTools_Click, this, MenuId_EnableInputRecording);
@@ -393,8 +394,12 @@ void MainEmuFrame::CreatePcsx2Menu()
 	m_GameSettingsSubmenu.Append(MenuId_EnableCheats, _("Enable &Cheats"),
 								 _("Use cheats otherwise known as pnachs from the cheats folder."), wxITEM_CHECK);
 
-	m_GameSettingsSubmenu.Append(MenuId_EnableIPC, _("Enable &IPC"),
-								 wxEmptyString, wxITEM_CHECK);
+	m_GameSettingsSubmenu.Append(MenuId_IPC_Enable, _("Configure &IPC"), &m_submenuIPC);
+
+	m_submenuIPC.Append(MenuId_IPC, _("&Enable IPC"),
+						wxEmptyString, wxITEM_CHECK);
+
+	m_submenuIPC.Append(MenuId_IPC_Settings, _("IPC &Settings"));
 
 	m_GameSettingsSubmenu.Append(MenuId_EnableWideScreenPatches, _("Enable &Widescreen Patches"),
 								 _("Enabling Widescreen Patches may occasionally cause issues."), wxITEM_CHECK);
@@ -551,6 +556,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	, m_menuWindow(*new wxMenu())
 	, m_menuCapture(*new wxMenu())
 	, m_submenuVideoCapture(*new wxMenu())
+	, m_submenuIPC(*new wxMenu())
 	, m_submenuScreenshot(*new wxMenu())
 #ifndef DISABLE_RECORDING
 	, m_menuRecording(*new wxMenu())
@@ -800,7 +806,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 	{ //these should not be affected by presets
 		menubar.Check(MenuId_EnableBackupStates, configToApply.EmuOptions.BackupSavestate);
 		menubar.Check(MenuId_EnableCheats, configToApply.EmuOptions.EnableCheats);
-		menubar.Check(MenuId_EnableIPC, configToApply.EmuOptions.EnableIPC);
+		menubar.Check(MenuId_IPC_Enable, configToApply.EmuOptions.EnableIPC);
 		menubar.Check(MenuId_EnableWideScreenPatches, configToApply.EmuOptions.EnableWideScreenPatches);
 #ifndef DISABLE_RECORDING
 		menubar.Check(MenuId_EnableInputRecording, configToApply.EmuOptions.EnableRecordingTools);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -117,6 +117,7 @@ protected:
 
 	wxMenu& m_menuCapture;
 	wxMenu& m_submenuVideoCapture;
+	wxMenu& m_submenuIPC;
 	wxMenu& m_submenuScreenshot;
 
 #ifndef DISABLE_RECORDING
@@ -208,7 +209,8 @@ protected:
 	void Menu_EnableBackupStates_Click(wxCommandEvent& event);
 	void Menu_EnablePatches_Click(wxCommandEvent& event);
 	void Menu_EnableCheats_Click(wxCommandEvent& event);
-	void Menu_EnableIPC_Click(wxCommandEvent& event);
+	void Menu_IPC_Enable_Click(wxCommandEvent& event);
+	void Menu_IPC_Settings_Click(wxCommandEvent& event);
 	void Menu_EnableWideScreenPatches_Click(wxCommandEvent& event);
 #ifndef DISABLE_RECORDING
 	void Menu_EnableRecordingTools_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -53,6 +53,11 @@ void MainEmuFrame::Menu_SysSettings_Click(wxCommandEvent& event)
 	AppOpenDialog<SysConfigDialog>(this);
 }
 
+void MainEmuFrame::Menu_IPC_Settings_Click(wxCommandEvent& event)
+{
+	AppOpenDialog<IPCDialog>(this);
+}
+
 void MainEmuFrame::Menu_AudioSettings_Click(wxCommandEvent& event)
 {
 	SPU2configure();
@@ -65,7 +70,7 @@ void MainEmuFrame::Menu_McdSettings_Click(wxCommandEvent& event)
 	AppOpenModalDialog<McdConfigDialog>(wxEmptyString, this);
 }
 
-void MainEmuFrame::Menu_NetworkSettings_Click(wxCommandEvent &event)
+void MainEmuFrame::Menu_NetworkSettings_Click(wxCommandEvent& event)
 {
 	DEV9configure();
 }
@@ -80,7 +85,7 @@ void MainEmuFrame::Menu_PADSettings_Click(wxCommandEvent& event)
 	PADconfigure();
 }
 
-void MainEmuFrame::Menu_WindowSettings_Click(wxCommandEvent &event)
+void MainEmuFrame::Menu_WindowSettings_Click(wxCommandEvent& event)
 {
 	wxCommandEvent evt(pxEvt_SetSettingsPage);
 	evt.SetString(L"GS Window");
@@ -433,7 +438,7 @@ void MainEmuFrame::_DoBootCdvd()
 			return;
 		}
 	}
-	
+
 	sApp.SysExecute(g_Conf->CdvdSource);
 }
 
@@ -564,9 +569,9 @@ void MainEmuFrame::Menu_EnableCheats_Click(wxCommandEvent&)
 	AppSaveSettings();
 }
 
-void MainEmuFrame::Menu_EnableIPC_Click(wxCommandEvent&)
+void MainEmuFrame::Menu_IPC_Enable_Click(wxCommandEvent&)
 {
-	g_Conf->EmuOptions.EnableIPC = GetMenuBar()->IsChecked(MenuId_EnableIPC);
+	g_Conf->EmuOptions.EnableIPC = GetMenuBar()->IsChecked(MenuId_IPC_Enable);
 	AppApplySettings();
 	AppSaveSettings();
 }
@@ -930,7 +935,7 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& even
 	GSmakeSnapshot(g_Conf->Folders.Snapshots.ToAscii());
 }
 
-void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent &event)
+void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& event)
 {
 	if (!CoreThread.IsOpen())
 		return;
@@ -970,7 +975,7 @@ void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 				return;
 			}
 		}
-		
+
 		if (!initiallyPaused)
 			g_InputRecordingControls.Resume();
 	}
@@ -999,7 +1004,7 @@ void MainEmuFrame::Menu_Recording_Play_Click(wxCommandEvent& event)
 			g_InputRecordingControls.Resume();
 		return;
 	}
-	
+
 	if (!g_InputRecording.GetInputRecordingData().FromSaveState())
 		StartInputRecording();
 }

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -299,6 +299,7 @@
     <ClCompile Include="..\..\gui\Debugger\DebugEvents.cpp" />
     <ClCompile Include="..\..\gui\Debugger\DebuggerLists.cpp" />
     <ClCompile Include="..\..\gui\Debugger\DisassemblyDialog.cpp" />
+    <ClCompile Include="..\..\gui\Dialogs\IPCDialog.cpp" />
     <ClCompile Include="..\..\gui\Dialogs\McdConfigDialog.cpp" />
     <ClCompile Include="..\..\gui\DriveList.cpp" />
     <ClCompile Include="..\..\gui\Panels\MemoryCardListView.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -1306,6 +1306,9 @@
     <ClCompile Include="..\..\PAD\Windows\PADRawInput.cpp">
       <Filter>System\Ps2\PAD</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gui\Dialogs\IPCDialog.cpp">
+      <Filter>AppHost\Dialogs</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Patch.h">


### PR DESCRIPTION
This allows multiple emulator sessions to run at the same time and windows user to configure their used port to their preferred one.

While slotting looks like ports they are not, they are simply used for compatiblity on systems that use TCP sockets to communicate, on linux for example unix sockets are used and the slot is transferred into the name of the socket. 
