### PR TITLE
Update GameIndex.yaml - KOF '94 Rebout NTSC-J

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -29152,6 +29152,19 @@ SLPS-25448:
 SLPS-25449:
   name: "King of Fighters '94, The - Rebout"
   region: "NTSC-J"
+  patches:
+    E64F90E5:
+      content: |-
+        author=kozarovv
+        // Fix for Depth precision.
+        // Game fills upper 16bits of depth with 0xFFFF.
+        // This results in a really high 32 bit value which is then converted to float
+        // because both hw and sw renderers lack double precision the lower 16 bits of the initial 32 bit value lose precision.
+        patch=1,EE,000ffc00,word,f88a0000
+        patch=1,EE,000ffc04,word,a080000b
+        patch=1,EE,000ffc08,word,080836b3
+        patch=1,EE,0020dac4,word,0803ff00
+        patch=1,EE,0020dac8,word,4bea497d
 SLPS-25450:
   name: "Tales of Rebirth"
   region: "NTSC-J"


### PR DESCRIPTION
Adds patch from kozarovv to KOF '94 Rebout - NTSC-J, the normal version (not the special disc)