### PR TITLE
vs/deps: Workaround patch for libsamplerate on VS 16.9

### DIFF
--- a/3rdparty/libsamplerate/float_cast.h
+++ b/3rdparty/libsamplerate/float_cast.h
@@ -117,6 +117,9 @@
 	**	most likely both WIN32 and WIN64 will be defined in 64-bit case.
 	*/
 
+/* MSVC pre 16.8 do not have lrintf */
+#if defined(_MSC_VER) && _MSC_VER < 1928
+
 	#include	<math.h>
 
 	/*	Win64 doesn't seem to have these functions, nor inline assembly.
@@ -137,11 +140,15 @@
 		return _mm_cvtss_si32(_mm_load_ss(&flt));
 	}
 
+#endif
+
 #elif (defined (WIN32) || defined (_WIN32))
 
 	#undef		HAVE_LRINT_REPLACEMENT
 	#define		HAVE_LRINT_REPLACEMENT	1
 
+/* MSVC pre 16.8 do not have lrintf */
+#if defined(_MSC_VER) && _MSC_VER < 1928
 	#include	<math.h>
 
 	/*
@@ -172,6 +179,7 @@
 
 		return intgr ;
 	}
+#endif
 
 #elif (defined (__MWERKS__) && defined (macintosh))
 


### PR DESCRIPTION
Taken from https://github.com/microsoft/vcpkg/pull/14348

I believe this is also fixed in the latest version `0.2.1` so likely good followup work (it removes float_case entirely) but I wasn't able to get VS to build it, atleast this gets things back to a build-able state in the interim.