### PR TITLE
IPC: Fix type polymorphism & checkbox

### DIFF
--- a/pcsx2/gui/Dialogs/IPCDialog.cpp
+++ b/pcsx2/gui/Dialogs/IPCDialog.cpp
@@ -49,10 +49,10 @@ Dialogs::IPCDialog::IPCDialog(wxWindow* parent)
 
 void Dialogs::IPCDialog::OnConfirm(wxCommandEvent& evt)
 {
-	wxTextCtrl* textbox = dynamic_cast<wxTextCtrl*>(evt.GetEventObject());
-	if (textbox)
+	wxTextCtrl* obj = static_cast<wxTextCtrl*>(evt.GetEventObject());
+	if (obj != nullptr)
 	{
-		IPCSettings::slot = (unsigned int)atoi(textbox->GetValue().ToUTF8().data());
+		IPCSettings::slot = (unsigned int)atoi(obj->GetValue().ToUTF8().data());
 		Destroy();
 	}
 }

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -394,9 +394,9 @@ void MainEmuFrame::CreatePcsx2Menu()
 	m_GameSettingsSubmenu.Append(MenuId_EnableCheats, _("Enable &Cheats"),
 								 _("Use cheats otherwise known as pnachs from the cheats folder."), wxITEM_CHECK);
 
-	m_GameSettingsSubmenu.Append(MenuId_IPC_Enable, _("Configure &IPC"), &m_submenuIPC);
+	m_GameSettingsSubmenu.Append(MenuId_IPC, _("Configure &IPC"), &m_submenuIPC);
 
-	m_submenuIPC.Append(MenuId_IPC, _("&Enable IPC"),
+	m_submenuIPC.Append(MenuId_IPC_Enable, _("&Enable IPC"),
 						wxEmptyString, wxITEM_CHECK);
 
 	m_submenuIPC.Append(MenuId_IPC_Settings, _("IPC &Settings"));


### PR DESCRIPTION
Some versions of wxWidgets are more sensitive than others on dynamic casting, so instead I used a C style cast to prevent any crash.