### PR TITLE
Input-Recording: Add a new viewer/editor GUI Window

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -833,6 +833,7 @@ set(pcsx2RDebugHeaders
 
 # Recording sources
 set(rec_src "Recording")
+set(rec_viewer_src "${rec_src}/Viewer")
 set(rec_vp_src "${rec_src}/VirtualPad")
 set(pcsx2RecordingSources
 	${rec_src}/InputRecording.cpp
@@ -841,6 +842,9 @@ set(pcsx2RecordingSources
 	${rec_src}/NewRecordingFrame.cpp
 	${rec_src}/PadData.cpp
 	${rec_src}/Utilities/InputRecordingLogger.cpp
+	${rec_viewer_src}/InputRecordingViewer.cpp
+	${rec_viewer_src}/RecordingFileGridTable.cpp
+	${rec_viewer_src}/RecordingMetadataDialog.cpp
 	${rec_vp_src}/VirtualPad.cpp
 	${rec_vp_src}/VirtualPadData.cpp
 	${rec_vp_src}/VirtualPadResources.cpp
@@ -854,6 +858,9 @@ set(pcsx2RecordingHeaders
 	${rec_src}/NewRecordingFrame.h
 	${rec_src}/PadData.h
 	${rec_src}/Utilities/InputRecordingLogger.h
+	${rec_viewer_src}/InputRecordingViewer.h
+	${rec_viewer_src}/RecordingFileGridTable.h
+	${rec_viewer_src}/RecordingMetadataDialog.h
 	${rec_vp_src}/VirtualPad.h
 	${rec_vp_src}/VirtualPadData.h
 	${rec_vp_src}/VirtualPadResources.h

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -845,6 +845,7 @@ set(pcsx2RecordingSources
 	${rec_viewer_src}/InputRecordingViewer.cpp
 	${rec_viewer_src}/RecordingFileGridTable.cpp
 	${rec_viewer_src}/RecordingMetadataDialog.cpp
+	${rec_viewer_src}/RecordingViewerColumn.cpp
 	${rec_vp_src}/VirtualPad.cpp
 	${rec_vp_src}/VirtualPadData.cpp
 	${rec_vp_src}/VirtualPadResources.cpp
@@ -861,6 +862,7 @@ set(pcsx2RecordingHeaders
 	${rec_viewer_src}/InputRecordingViewer.h
 	${rec_viewer_src}/RecordingFileGridTable.h
 	${rec_viewer_src}/RecordingMetadataDialog.h
+	${rec_viewer_src}/RecordingViewerColumn.h
 	${rec_vp_src}/VirtualPad.h
 	${rec_vp_src}/VirtualPadData.h
 	${rec_vp_src}/VirtualPadResources.h

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -197,7 +197,6 @@ std::map<uint, PadData> InputRecordingFile::BulkReadPadData(long frameStart, lon
 	frameStart = frameStart < 0 ? 0 : frameStart;
 
 	// TODO - it would be nice to move to streams eventually
-	long seek = getRecordingBlockSeekPoint(frameStart) + controllerInputBytes * port;
 	
 	std::array<u8, controllerInputBytes> padBytes;
 

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -36,25 +36,28 @@ void InputRecordingFileHeader::SetEmulatorVersion()
 	SetEmulatorVersion(emuVersion);
 }
 
+template <size_t charCount>
+void strcpy_safe(char (&output)[charCount], const char* pSrc)
+{
+	// Copy the string — don’t copy too many bytes.
+	strncpy(output, pSrc, charCount);
+	// Ensure null-termination.
+	output[charCount - 1] = 0;
+}
+
 void InputRecordingFileHeader::SetEmulatorVersion(wxString version)
 {
-	int max = ArraySize(emu) - 1;
-	strncpy(emu, version.c_str(), max);
-	emu[max] = 0;
+	strcpy_safe(emu, version.c_str());
 }
 
 void InputRecordingFileHeader::SetAuthor(wxString _author)
 {
-	int max = ArraySize(author) - 1;
-	strncpy(author, _author.c_str(), max);
-	author[max] = 0;
+	strcpy_safe(author, _author.c_str());
 }
 
 void InputRecordingFileHeader::SetGameName(wxString _gameName)
 {
-	int max = ArraySize(gameName) - 1;
-	strncpy(gameName, _gameName.c_str(), max);
-	gameName[max] = 0;
+	strcpy_safe(gameName, _gameName.c_str());
 }
 
 bool InputRecordingFile::Close()

--- a/pcsx2/Recording/InputRecordingFile.h
+++ b/pcsx2/Recording/InputRecordingFile.h
@@ -71,7 +71,6 @@ public:
 	// Increment the number of undo actions and commit it to the recording file
 	void IncrementUndoCount();
 	bool IsFileOpen();
-	void SetUndoCount(long undoCount);
 	// Open an existing recording file
 	bool OpenExisting(const wxString& path);
 	// Create and open a brand new input recording, either starting from a save-state or from
@@ -108,8 +107,6 @@ private:
 	static const int seekpointTotalFrames = sizeof(InputRecordingFileHeader);
 	static const int seekpointUndoCount = sizeof(InputRecordingFileHeader) + 4;
 	static const int seekpointSaveStateHeader = seekpointUndoCount + 4;
-
-	bool fileOpen = false;
 
 	InputRecordingFileHeader header;
 	wxString filename = "";

--- a/pcsx2/Recording/PadData.cpp
+++ b/pcsx2/Recording/PadData.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -97,7 +97,7 @@ void PadData::UpdateControllerData(u16 bufIndex, u8 const& bufVal)
 	}
 }
 
-u8 PadData::PollControllerData(u16 bufIndex)
+u8 PadData::PollControllerData(u16 bufIndex) const
 {
 	u8 byte = 0;
 	BufferIndex index = static_cast<BufferIndex>(bufIndex);
@@ -172,7 +172,7 @@ bool PadData::IsButtonPressed(ButtonResolver buttonResolver, u8 const& bufVal)
 	return (~bufVal & buttonResolver.buttonBitmask) > 0;
 }
 
-u8 PadData::BitmaskOrZero(bool pressed, ButtonResolver buttonInfo)
+u8 PadData::BitmaskOrZero(bool pressed, ButtonResolver buttonInfo) const
 {
 	return pressed ? buttonInfo.buttonBitmask : 0;
 }

--- a/pcsx2/Recording/PadData.h
+++ b/pcsx2/Recording/PadData.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -89,7 +89,7 @@ public:
 
 	// Given the input buffer and the current index, updates the correct field(s)
 	void UpdateControllerData(u16 bufIndex, u8 const& bufVal);
-	u8 PollControllerData(u16 bufIndex);
+	u8 PollControllerData(u16 bufIndex) const;
 
 	// Prints current PadData to the Controller Log filter which disabled by default
 	void LogPadData(u8 const& port);
@@ -120,7 +120,7 @@ private:
 
 	// Checks and returns if button a is pressed or not
 	bool IsButtonPressed(ButtonResolver buttonResolver, u8 const& bufVal);
-	u8 BitmaskOrZero(bool pressed, ButtonResolver buttonInfo);
+	u8 BitmaskOrZero(bool pressed, ButtonResolver buttonInfo) const;
 
 	wxString RawPadBytesToString(int start, int end);
 };

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.cpp
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.cpp
@@ -43,100 +43,100 @@ InputRecordingViewer::InputRecordingViewer(wxWindow* parent, AppConfig::InputRec
 	, options(options)
 {
 	// Init Menus
-	menuBar = new wxMenuBar();
-	fileMenu = new wxMenu();
-	openMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Open"), _("Open an Input Recording file to view/edit")), true);
-	closeMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Close"), _("Close the current file")), false);
-	fileMenu->AppendSeparator();
-	saveMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Save"), _("Save the current file, overwriting the original")), false);
-	saveAsMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Save As"), _("Save the current file to a specified location")), false);
+	m_menu_bar = new wxMenuBar();
+	m_file_menu = new wxMenu();
+	m_open_menu_item = enableMenuItem(m_file_menu->Append(wxID_ANY, _("Open"), _("Open an Input Recording file to view/edit")), true);
+	m_close_menu_item = enableMenuItem(m_file_menu->Append(wxID_ANY, _("Close"), _("Close the current file")), false);
+	m_file_menu->AppendSeparator();
+	m_save_menu_item = enableMenuItem(m_file_menu->Append(wxID_ANY, _("Save"), _("Save the current file, overwriting the original")), false);
+	m_save_as_menu_item = enableMenuItem(m_file_menu->Append(wxID_ANY, _("Save As"), _("Save the current file to a specified location")), false);
 	// TODO - implement Exporting!
 	// fileMenu->AppendSeparator();
 	// importMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Import From YAML"), _("Import recording data from a YAML file")), false);
 	// exportMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Export As YAML"), _("Export recording data to a YAML file")), false);
-	menuBar->Append(fileMenu, _("File"));
+	m_menu_bar->Append(m_file_menu, _("File"));
 
-	editMenu = new wxMenu();
-	changeMetadataMenuItem = enableMenuItem(editMenu->Append(wxID_ANY, _("Change Metadata"), _("Change the recordings relevant metadata")), false);
+	m_edit_menu = new wxMenu();
+	m_change_metadata_menu_item = enableMenuItem(m_edit_menu->Append(wxID_ANY, _("Change Metadata"), _("Change the recordings relevant metadata")), false);
 	// TODO - implement these at a later date
 	// changeRecordingTypeMenuItem = enableMenuItem(editMenu->Append(wxID_ANY, _("Change Recording Type"), _("Change the recording's type (ie. power-on / save-state)")), false);
 	// changeBaseSavestateMenuItem = enableMenuItem(editMenu->Append(wxID_ANY, _("Change Base Savestate"), _("Change the base savestate for the recording")), false);
-	menuBar->Append(editMenu, _("Edit"));
+	m_menu_bar->Append(m_edit_menu, _("Edit"));
 
-	viewMenu = new wxMenu();
-	configColumnsMenuItem = enableMenuItem(viewMenu->Append(wxID_ANY, _("Config Columns"), _("Change the order and displaying of columns")), true);
-	viewMenu->AppendSeparator();
-	jumpToFrameMenuItem = enableMenuItem(viewMenu->Append(wxID_ANY, _("Jump to Frame"), _("Jump to a specific frame")), false);
-	viewMenu->AppendSeparator();
-	wxMenu* controllerMenu = new wxMenu();
-	portOneMenuItem = checkMenuItem(controllerMenu->Append(wxID_ANY, _("Port 1"), _("Select port 1"), wxITEM_CHECK), true);
-	portTwoMenuItem = checkMenuItem(controllerMenu->Append(wxID_ANY, _("Port 2"), _("Select port 2"), wxITEM_CHECK), false);
-	controllerPortSubmenu = enableMenuItem(viewMenu->AppendSubMenu(controllerMenu, _("Change Controller"), _("Switch which controller port is active")), false);
-	menuBar->Append(viewMenu, _("View"));
+	m_view_menu = new wxMenu();
+	m_config_columns_menu_item = enableMenuItem(m_view_menu->Append(wxID_ANY, _("Config Columns"), _("Change the order and displaying of columns")), true);
+	m_view_menu->AppendSeparator();
+	m_jump_to_frame_menu_item = enableMenuItem(m_view_menu->Append(wxID_ANY, _("Jump to Frame"), _("Jump to a specific frame")), false);
+	m_view_menu->AppendSeparator();
+	wxMenu* controller_menu = new wxMenu();
+	m_port_one_menu_item = checkMenuItem(controller_menu->Append(wxID_ANY, _("Port 1"), _("Select port 1"), wxITEM_CHECK), true);
+	m_port_two_menu_item = checkMenuItem(controller_menu->Append(wxID_ANY, _("Port 2"), _("Select port 2"), wxITEM_CHECK), false);
+	m_controller_port_submenu = enableMenuItem(m_view_menu->AppendSubMenu(controller_menu, _("Change Controller"), _("Switch which controller port is active")), false);
+	m_menu_bar->Append(m_view_menu, _("View"));
 
-	dataMenu = new wxMenu();
-	clearFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Clear Frame"), _("Clear the entire frame of data")), false);
-	defaultFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Default Frame"), _("Set the frame to the controllers default neutral values")), false);
-	duplicateFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Duplicate Frame"), _("Duplicate and insert the frame")), false);
-	insertFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Insert Frame"), _("Insert a new default frame")), false);
-	insertFramesMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Insert Frame(s)"), _("Insert multiple default frames")), false);
-	removeFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Remove Frame"), _("Remove a frame")), false);
-	removeFramesMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Remove Frame(s)"), _("Remove multiple frames")), false);
+	m_data_menu = new wxMenu();
+	m_clear_frame_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Clear Frame"), _("Clear the entire frame of data")), false);
+	m_default_frame_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Default Frame"), _("Set the frame to the controllers default neutral values")), false);
+	m_duplicate_frame_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Duplicate Frame"), _("Duplicate and insert the frame")), false);
+	m_insert_frame_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Insert Frame"), _("Insert a new default frame")), false);
+	m_insert_frames_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Insert Frame(s)"), _("Insert multiple default frames")), false);
+	m_remove_frame_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Remove Frame"), _("Remove a frame")), false);
+	m_remove_frames_menu_item = enableMenuItem(m_data_menu->Append(wxID_ANY, _("Remove Frame(s)"), _("Remove multiple frames")), false);
 	// TODO - implement Data menu and event handlers
 	// menuBar->Append(dataMenu, _("Data"));
 
 	// Initialize Grid Column Order
-	InitColumns();
+	initColumns();
 
 	// Init Widgets
-	recordingDataSource = new RecordingFileGridTable(gridColumns);
-	recordingGrid = new wxGrid(this, wxID_ANY);
-	recordingGrid->SetTable(recordingDataSource, true);
-	recordingGrid->EnableDragColSize(false);
-	recordingGrid->EnableDragRowSize(false);
-	recordingGrid->EnableDragGridSize(false);
-	recordingGrid->SetColSize(0, 100);
-	recordingGrid->SetColSize(1, 100);
-	recordingGrid->SetColSize(2, 100);
-	recordingGrid->SetColSize(3, 100);
-	recordingGrid->SetColLabelSize(75);
+	m_recording_data_source = new RecordingFileGridTable(m_grid_columns);
+	m_recording_grid = new wxGrid(this, wxID_ANY);
+	m_recording_grid->SetTable(m_recording_data_source, true);
+	m_recording_grid->EnableDragColSize(false);
+	m_recording_grid->EnableDragRowSize(false);
+	m_recording_grid->EnableDragGridSize(false);
+	m_recording_grid->SetColSize(0, 100);
+	m_recording_grid->SetColSize(1, 100);
+	m_recording_grid->SetColSize(2, 100);
+	m_recording_grid->SetColSize(3, 100);
+	m_recording_grid->SetColLabelSize(75);
 
 	// Bind Events
-	Bind(wxEVT_CLOSE_WINDOW, &InputRecordingViewer::OnClose, this);
-	Bind(wxEVT_MOVE, &InputRecordingViewer::OnMoveAround, this);
+	Bind(wxEVT_CLOSE_WINDOW, &InputRecordingViewer::onClose, this);
+	Bind(wxEVT_MOVE, &InputRecordingViewer::onMoveAround, this);
 
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnOpenFile, this, openMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnCloseFile, this, closeMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnSaveFile, this, saveMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnSaveAsFile, this, saveAsMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onOpenFile, this, m_open_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onCloseFile, this, m_close_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onSaveFile, this, m_save_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onSaveAsFile, this, m_save_as_menu_item->GetId());
 	// TODO - implement Exporting!
 	// Bind(wxEVT_MENU, &InputRecordingViewer::OnImport, this, importMenuItem->GetId());
 	// Bind(wxEVT_MENU, &InputRecordingViewer::OnExport, this, exportMenuItem->GetId());
 
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnChangeMetadata, this, changeMetadataMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onChangeMetadata, this, m_change_metadata_menu_item->GetId());
 	// TODO - implement!
 	// Bind(wxEVT_MENU, &InputRecordingViewer::OnChangeRecordingType, this, changeRecordingTypeMenuItem->GetId());
 	// Bind(wxEVT_MENU, &InputRecordingViewer::OnChangeBaseSavestate, this, changeBaseSavestateMenuItem->GetId());
 
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnConfigColumns, this, configColumnsMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnJumpToFrame, this, jumpToFrameMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnSelectPortOne, this, portOneMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnSelectPortTwo, this, portTwoMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onConfigColumns, this, m_config_columns_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onJumpToFrame, this, m_jump_to_frame_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onSelectPortOne, this, m_port_one_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onSelectPortTwo, this, m_port_two_menu_item->GetId());
 
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnClearFrame, this, clearFrameMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnDefaultFrame, this, defaultFrameMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnDuplicateFrame, this, duplicateFrameMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnInsertFrame, this, insertFrameMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnInsertFrames, this, insertFramesMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnRemoveFrame, this, removeFrameMenuItem->GetId());
-	Bind(wxEVT_MENU, &InputRecordingViewer::OnRemoveFrames, this, removeFramesMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onClearFrame, this, m_clear_frame_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onDefaultFrame, this, m_default_frame_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onDuplicateFrame, this, m_duplicate_frame_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onInsertFrame, this, m_insert_frame_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onInsertFrames, this, m_insert_frames_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onRemoveFrame, this, m_remove_frame_menu_item->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::onRemoveFrames, this, m_remove_frames_menu_item->GetId());
 
 	// Sizers
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-	sizer->Add(recordingGrid, 1, wxEXPAND, 0);
+	sizer->Add(m_recording_grid, 1, wxEXPAND, 0);
 	sizer->SetSizeHints(this);
 
-	SetMenuBar(menuBar);
+	SetMenuBar(m_menu_bar);
 	SetIcons(wxGetApp().GetIconBundle());
 
 	CreateStatusBar(1);
@@ -145,19 +145,19 @@ InputRecordingViewer::InputRecordingViewer(wxWindow* parent, AppConfig::InputRec
 	SetSizer(sizer);
 	SetMinSize(wxSize(500, 500));
 	Layout();
-	RefreshColumns();
+	refreshColumns();
 }
 
-void InputRecordingViewer::OnClose(wxCloseEvent& event)
+void InputRecordingViewer::onClose(wxCloseEvent& event)
 {
-	if (fileOpened)
+	if (m_file_opened)
 	{
-		CloseActiveFile();
+		closeActiveFile();
 	}
 	Hide();
 }
 
-void InputRecordingViewer::OnMoveAround(wxMoveEvent& event)
+void InputRecordingViewer::onMoveAround(wxMoveEvent& event)
 {
 	if (IsBeingDeleted() || !IsVisible() || IsIconized())
 		return;
@@ -167,69 +167,69 @@ void InputRecordingViewer::OnMoveAround(wxMoveEvent& event)
 	event.Skip();
 }
 
-void InputRecordingViewer::ToggleMenuItems(bool fileOpen)
+void InputRecordingViewer::toggleMenuItems(bool file_open)
 {
-	closeMenuItem->Enable(fileOpen);
-	saveMenuItem->Enable(fileOpen);
-	saveAsMenuItem->Enable(fileOpen);
+	m_close_menu_item->Enable(file_open);
+	m_save_menu_item->Enable(file_open);
+	m_save_as_menu_item->Enable(file_open);
 	// importMenuItem->Enable(fileOpen);
 	// exportMenuItem->Enable(fileOpen);
 
-	changeMetadataMenuItem->Enable(fileOpen);
+	m_change_metadata_menu_item->Enable(file_open);
 	// changeRecordingTypeMenuItem->Enable(fileOpen);
 	// changeBaseSavestateMenuItem->Enable(fileOpen);
 
-	jumpToFrameMenuItem->Enable(fileOpen);
-	controllerPortSubmenu->Enable(fileOpen);
-	portOneMenuItem->Check(fileOpen && recordingDataSource->GetControllerPort() == 1);
-	portTwoMenuItem->Check(fileOpen && recordingDataSource->GetControllerPort() == 2);
+	m_jump_to_frame_menu_item->Enable(file_open);
+	m_controller_port_submenu->Enable(file_open);
+	m_port_one_menu_item->Check(file_open && m_recording_data_source->getControllerPort() == 1);
+	m_port_two_menu_item->Check(file_open && m_recording_data_source->getControllerPort() == 2);
 
-	clearFrameMenuItem->Enable(fileOpen);
-	defaultFrameMenuItem->Enable(fileOpen);
-	duplicateFrameMenuItem->Enable(fileOpen);
-	insertFrameMenuItem->Enable(fileOpen);
-	insertFramesMenuItem->Enable(fileOpen);
-	removeFrameMenuItem->Enable(fileOpen);
-	removeFramesMenuItem->Enable(fileOpen);
+	m_clear_frame_menu_item->Enable(file_open);
+	m_default_frame_menu_item->Enable(file_open);
+	m_duplicate_frame_menu_item->Enable(file_open);
+	m_insert_frame_menu_item->Enable(file_open);
+	m_insert_frames_menu_item->Enable(file_open);
+	m_remove_frame_menu_item->Enable(file_open);
+	m_remove_frames_menu_item->Enable(file_open);
 }
 
-void InputRecordingViewer::InitColumns()
+void InputRecordingViewer::initColumns()
 {
 	for (int i = 0; i < NUM_COLUMNS; i++)
 	{
-		appendColumn(i, gridColumns, options);
+		appendColumn(i, m_grid_columns, options);
 	}
 }
 
-void InputRecordingViewer::RefreshColumns()
+void InputRecordingViewer::refreshColumns()
 {
-	recordingDataSource->UpdateGridColumns(gridColumns);
-	for (auto& columnEntry : gridColumns)
+	m_recording_data_source->updateGridColumns(m_grid_columns);
+	for (auto& columnEntry : m_grid_columns)
 	{
-		columnEntry.second.shown ? recordingGrid->ShowCol(columnEntry.first) : recordingGrid->HideCol(columnEntry.first);
+		columnEntry.second.m_shown ? m_recording_grid->ShowCol(columnEntry.first) : m_recording_grid->HideCol(columnEntry.first);
 	}
-	saveColumnsToConfig(gridColumns, options);
-	recordingGrid->ForceRefresh();
+	saveColumnsToConfig(m_grid_columns, options);
+	m_recording_grid->ForceRefresh();
 }
 
-void InputRecordingViewer::CloseActiveFile()
+void InputRecordingViewer::closeActiveFile()
 {
-	recordingDataSource->CloseRecordingFile();
-	recordingGrid->ForceRefresh();
-	if (wxFileExists(tempFilePath))
+	m_recording_data_source->closeRecordingFile();
+	m_recording_grid->ForceRefresh();
+	if (wxFileExists(m_temp_filepath))
 	{
-		wxRemoveFile(tempFilePath);
+		wxRemoveFile(m_temp_filepath);
 	}
-	ToggleMenuItems(false);
-	fileOpened = false;
+	toggleMenuItems(false);
+	m_file_opened = false;
 }
 
-void InputRecordingViewer::OnOpenFile(wxCommandEvent& event)
+void InputRecordingViewer::onOpenFile(wxCommandEvent& event)
 {
-	if (fileOpened)
+	if (m_file_opened)
 	{
 		int answer;
-		if (recordingDataSource->AreChangesUnsaved())
+		if (m_recording_data_source->areChangesUnsaved())
 		{
 			answer = wxMessageBox(_("Close active file without saving changes?"), _("Confirm"),
 								  wxYES_NO | wxCANCEL, this);
@@ -243,23 +243,23 @@ void InputRecordingViewer::OnOpenFile(wxCommandEvent& event)
 		{
 			return;
 		}
-		CloseActiveFile();
+		closeActiveFile();
 	}
 
-	wxFileDialog* openFileDialog =
+	wxFileDialog* open_file_dialog =
 		new wxFileDialog(this, _("Open Input Recording File"), wxEmptyString, wxEmptyString, "p2m2 file(*.p2m2)|*.p2m2",
 						 wxFD_OPEN, wxDefaultPosition);
 
-	if (openFileDialog->ShowModal() == wxID_OK)
+	if (open_file_dialog->ShowModal() == wxID_OK)
 	{
 		// TODO - utility function
-		filePath = openFileDialog->GetPath();
+		m_filepath = open_file_dialog->GetPath();
 		// wxWidget's removes the extension if it contains wildcards
 		// on wxGTK https://trac.wxwidgets.org/ticket/15285
-		if (!filePath.EndsWith(".p2m2"))
-			filePath = wxString::Format("%s.p2m2", filePath);
+		if (!m_filepath.EndsWith(".p2m2"))
+			m_filepath = wxString::Format("%s.p2m2", m_filepath);
 
-		if (!wxFileExists(filePath))
+		if (!wxFileExists(m_filepath))
 		{
 			wxMessageBox(_("Unable to Open Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 			return;
@@ -268,25 +268,25 @@ void InputRecordingViewer::OnOpenFile(wxCommandEvent& event)
 		// Copy the file, as this is out working copy if edits are made
 		// The user can then choose to overwrite the existing file, or save elsewhere.
 		// At which time, we remove the temp file
-		tempFilePath = filePath + ".tmp";
-		if (!wxCopyFile(filePath, tempFilePath, true))
+		m_temp_filepath = m_filepath + ".tmp";
+		if (!wxCopyFile(m_filepath, m_temp_filepath, true))
 		{
 			wxMessageBox(_("Unable to Open Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 			return;
 		}
 
-		recordingDataSource->OpenRecordingFile(tempFilePath);
-		recordingGrid->ForceRefresh();
+		m_recording_data_source->openRecordingFile(m_temp_filepath);
+		m_recording_grid->ForceRefresh();
 
 		// Enable various menu options
-		ToggleMenuItems(true);
-		fileOpened = true;
+		toggleMenuItems(true);
+		m_file_opened = true;
 	}
 }
 
-void InputRecordingViewer::OnCloseFile(wxCommandEvent& event)
+void InputRecordingViewer::onCloseFile(wxCommandEvent& event)
 {
-	if (recordingDataSource->AreChangesUnsaved())
+	if (m_recording_data_source->areChangesUnsaved())
 	{
 		int answer = wxMessageBox(_("Close without saving changes?"), _("Confirm"),
 								  wxYES_NO | wxCANCEL, this);
@@ -295,65 +295,65 @@ void InputRecordingViewer::OnCloseFile(wxCommandEvent& event)
 			return;
 		}
 	}
-	CloseActiveFile();
+	closeActiveFile();
 }
 
 // TODO - a note on saving, currently we don't allow modifying the original save-state, so there are no concerns about it
 // When we do though, these save functions will need to expand!
 
-void InputRecordingViewer::OnSaveFile(wxCommandEvent& event)
+void InputRecordingViewer::onSaveFile(wxCommandEvent& event)
 {
-	if (!wxCopyFile(tempFilePath, filePath + ".bak", true))
+	if (!wxCopyFile(m_temp_filepath, m_filepath + ".bak", true))
 	{
 		wxMessageBox(_("Unable to backup original recording before saving, aborting!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 		return;
 	}
 
 	// Overwrite existing file, this is just a simple rename
-	if (!wxCopyFile(tempFilePath, filePath, true))
+	if (!wxCopyFile(m_temp_filepath, m_filepath, true))
 	{
 		wxMessageBox(_("Unable to Save Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 		return;
 	}
 
-	recordingDataSource->ClearUnsavedChanges();
+	m_recording_data_source->clearUnsavedChanges();
 }
 
-void InputRecordingViewer::OnSaveAsFile(wxCommandEvent& event)
+void InputRecordingViewer::onSaveAsFile(wxCommandEvent& event)
 {
-	wxFileDialog* openFileDialog =
+	wxFileDialog* open_file_dialog =
 		new wxFileDialog(this, _("Save Input Recording File"), wxEmptyString, wxEmptyString, "p2m2 file(*.p2m2)|*.p2m2",
 						 wxFD_SAVE | wxFD_OVERWRITE_PROMPT, wxDefaultPosition);
 
-	if (openFileDialog->ShowModal() == wxID_OK)
+	if (open_file_dialog->ShowModal() == wxID_OK)
 	{
-		wxString savePath = openFileDialog->GetPath();
+		wxString savePath = open_file_dialog->GetPath();
 		// wxWidget's removes the extension if it contains wildcards
 		// on wxGTK https://trac.wxwidgets.org/ticket/15285
 		if (!savePath.EndsWith(".p2m2"))
 			savePath = wxString::Format("%s.p2m2", savePath);
 
-		if (savePath == filePath)
+		if (savePath == m_filepath)
 		{
-			if (!wxCopyFile(tempFilePath, savePath + ".bak", true))
+			if (!wxCopyFile(m_temp_filepath, savePath + ".bak", true))
 			{
 				wxMessageBox(_("Unable to backup original recording before saving, aborting!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 				return;
 			}
 		}
 
-		if (!wxCopyFile(tempFilePath, savePath, true))
+		if (!wxCopyFile(m_temp_filepath, savePath, true))
 		{
 			wxMessageBox(_("Unable to Save Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 			return;
 		}
 
 		// If it's a save-state recording, copy over the save-state as well
-		if (recordingDataSource->IsFromSavestate())
+		if (m_recording_data_source->isFromSavestate())
 		{
-			if (wxFileExists(filePath + "_SaveState.p2s"))
+			if (wxFileExists(m_filepath + "_SaveState.p2s"))
 			{
-				if (savePath != filePath && !wxCopyFile(filePath + "_SaveState.p2s", savePath + "_SaveState.p2s", true))
+				if (savePath != m_filepath && !wxCopyFile(m_filepath + "_SaveState.p2s", savePath + "_SaveState.p2s", true))
 				{
 					wxMessageBox(_("Unable to Save Input Recording's SaveState!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
 				}
@@ -364,48 +364,48 @@ void InputRecordingViewer::OnSaveAsFile(wxCommandEvent& event)
 			}
 		}
 
-		recordingDataSource->ClearUnsavedChanges();
+		m_recording_data_source->clearUnsavedChanges();
 	}
 }
 
-void InputRecordingViewer::OnImport(wxCommandEvent& event)
+void InputRecordingViewer::onImport(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnExport(wxCommandEvent& event)
+void InputRecordingViewer::onExport(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnChangeMetadata(wxCommandEvent& event)
+void InputRecordingViewer::onChangeMetadata(wxCommandEvent& event)
 {
-	InputRecordingFileHeader currHeader = recordingDataSource->GetRecordingFileHeader();
-	RecordingMetadataDialog* custom = new RecordingMetadataDialog(this, currHeader.author, currHeader.gameName);
+	InputRecordingFileHeader current_header = m_recording_data_source->getRecordingFileHeader();
+	RecordingMetadataDialog* custom = new RecordingMetadataDialog(this, current_header.author, current_header.gameName);
 	if (custom->ShowModal() == wxID_OK)
 	{
-		recordingDataSource->UpdateRecordingFileHeader(custom->GetAuthor(), custom->GetGameName());
+		m_recording_data_source->updateRecordingFileHeader(custom->getAuthor(), custom->getGameName());
 	}
 }
 
-void InputRecordingViewer::OnChangeRecordingType(wxCommandEvent& event)
+void InputRecordingViewer::onChangeRecordingType(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnChangeBaseSavestate(wxCommandEvent& event)
+void InputRecordingViewer::onChangeBaseSavestate(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnConfigColumns(wxCommandEvent& event)
+void InputRecordingViewer::onConfigColumns(wxCommandEvent& event)
 {
 	wxArrayString items;
 	wxArrayInt order;
-	for (auto& columnEntry : gridColumns)
+	for (auto& columnEntry : m_grid_columns)
 	{
-		items.push_back(columnEntry.second.label);
-		order.push_back(columnEntry.second.shown ? columnEntry.first : ~columnEntry.first);
+		items.push_back(columnEntry.second.m_label);
+		order.push_back(columnEntry.second.m_shown ? columnEntry.first : ~columnEntry.first);
 	}
 	wxRearrangeDialog dlg(NULL,
 						  "You can also uncheck the items you don't like at all.",
@@ -425,69 +425,69 @@ void InputRecordingViewer::OnConfigColumns(wxCommandEvent& event)
 			{
 				oldIndex = abs(oldIndex + 1);
 			}
-			newGridColumns[i] = gridColumns.at(oldIndex);
-			newGridColumns.at(i).shown = order[i] >= 0;
+			newGridColumns[i] = m_grid_columns.at(oldIndex);
+			newGridColumns.at(i).m_shown = order[i] >= 0;
 		}
-		gridColumns = newGridColumns;
-		RefreshColumns();
+		m_grid_columns = newGridColumns;
+		refreshColumns();
 	}
 }
 
-void InputRecordingViewer::OnJumpToFrame(wxCommandEvent& event)
+void InputRecordingViewer::onJumpToFrame(wxCommandEvent& event)
 {
-	long frame = wxGetNumberFromUser(_("Enter Frame Number"), wxEmptyString, _("Jump To Frame"), 0, 0, recordingDataSource->GetNumberRows(), this);
+	long frame = wxGetNumberFromUser(_("Enter Frame Number"), wxEmptyString, _("Jump To Frame"), 0, 0, m_recording_data_source->GetNumberRows(), this);
 	frame = frame == 0 ? 0 : frame - 1;
-	recordingGrid->SelectRow(frame);
-	recordingGrid->MakeCellVisible(frame, 0);
+	m_recording_grid->SelectRow(frame);
+	m_recording_grid->MakeCellVisible(frame, 0);
 }
 
-void InputRecordingViewer::OnSelectPortOne(wxCommandEvent& event)
+void InputRecordingViewer::onSelectPortOne(wxCommandEvent& event)
 {
-	bool selected = portOneMenuItem->IsChecked();
-	portTwoMenuItem->Check(!selected);
-	recordingDataSource->SetControllerPort(1);
-	recordingGrid->ForceRefresh();
+	bool selected = m_port_one_menu_item->IsChecked();
+	m_port_two_menu_item->Check(!selected);
+	m_recording_data_source->setControllerPort(1);
+	m_recording_grid->ForceRefresh();
 }
 
-void InputRecordingViewer::OnSelectPortTwo(wxCommandEvent& event)
+void InputRecordingViewer::onSelectPortTwo(wxCommandEvent& event)
 {
-	bool selected = portTwoMenuItem->IsChecked();
-	portOneMenuItem->Check(!selected);
-	recordingDataSource->SetControllerPort(2);
-	recordingGrid->ForceRefresh();
+	bool selected = m_port_two_menu_item->IsChecked();
+	m_port_one_menu_item->Check(!selected);
+	m_recording_data_source->setControllerPort(2);
+	m_recording_grid->ForceRefresh();
 }
 
-void InputRecordingViewer::OnClearFrame(wxCommandEvent& event)
-{
-	// TODO
-}
-
-void InputRecordingViewer::OnDefaultFrame(wxCommandEvent& event)
+void InputRecordingViewer::onClearFrame(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnDuplicateFrame(wxCommandEvent& event)
+void InputRecordingViewer::onDefaultFrame(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnInsertFrame(wxCommandEvent& event)
+void InputRecordingViewer::onDuplicateFrame(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnInsertFrames(wxCommandEvent& event)
+void InputRecordingViewer::onInsertFrame(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnRemoveFrame(wxCommandEvent& event)
+void InputRecordingViewer::onInsertFrames(wxCommandEvent& event)
 {
 	// TODO
 }
 
-void InputRecordingViewer::OnRemoveFrames(wxCommandEvent& event)
+void InputRecordingViewer::onRemoveFrame(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::onRemoveFrames(wxCommandEvent& event)
 {
 	// TODO
 }

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.cpp
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.cpp
@@ -1,0 +1,458 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include <wx/dc.h>
+#include <wx/grid.h>
+#include <wx/numdlg.h>
+#include <wx/renderer.h>
+
+#include "App.h"
+#include "InputRecordingViewer.h"
+#include "RecordingMetadataDialog.h"
+#include "Utilities/EmbeddedImage.h"
+
+wxMenuItem* enableMenuItem(wxMenuItem* item, bool enabled)
+{
+	item->Enable(enabled);
+	return item;
+}
+
+wxMenuItem* checkMenuItem(wxMenuItem* item, bool checked)
+{
+	item->Check(checked);
+	return item;
+}
+
+InputRecordingViewer::InputRecordingViewer(wxWindow* parent)
+	: wxFrame(parent, wxID_ANY, _("Recording Viewer"), wxDefaultPosition, wxDefaultSize)
+{
+	// Init Menus
+	menuBar = new wxMenuBar();
+	fileMenu = new wxMenu();
+	openMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Open"), _("Open an Input Recording file to view/edit")), true);
+	closeMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Close"), _("Close the current file")), false);
+	fileMenu->AppendSeparator();
+	saveMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Save"), _("Save the current file, overwriting the original")), false);
+	saveAsMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Save As"), _("Save the current file to a specified location")), false);
+	// TODO - implement Exporting!
+	// fileMenu->AppendSeparator();
+	// importMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Import From YAML"), _("Import recording data from a YAML file")), false);
+	// exportMenuItem = enableMenuItem(fileMenu->Append(wxID_ANY, _("Export As YAML"), _("Export recording data to a YAML file")), false);
+	menuBar->Append(fileMenu, _("File"));
+
+	editMenu = new wxMenu();
+	changeMetadataMenuItem = enableMenuItem(editMenu->Append(wxID_ANY, _("Change Metadata"), _("Change the recordings relevant metadata")), false);
+	// TODO - implement these at a later date
+	// changeRecordingTypeMenuItem = enableMenuItem(editMenu->Append(wxID_ANY, _("Change Recording Type"), _("Change the recording's type (ie. power-on / save-state)")), false);
+	// changeBaseSavestateMenuItem = enableMenuItem(editMenu->Append(wxID_ANY, _("Change Base Savestate"), _("Change the base savestate for the recording")), false);
+	menuBar->Append(editMenu, _("Edit"));
+
+	viewMenu = new wxMenu();
+	wxMenu* columnMenu = new wxMenu();
+	showAnalogSticksMenuItem = checkMenuItem(columnMenu->Append(wxID_ANY, _("Analog Sticks"), _("Show/hide the analog stick columns"), wxITEM_CHECK), showAnalogSticks);
+	showFaceButtonsMenuItem = checkMenuItem(columnMenu->Append(wxID_ANY, _("Face Buttons"), _("Show/hide the face button columns"), wxITEM_CHECK), showFaceButtons);
+	showDirectionalPadMenuItem = checkMenuItem(columnMenu->Append(wxID_ANY, _("Directional Pad"), _("Show/hide the D-Pad columns"), wxITEM_CHECK), showDirectionalPad);
+	showShoulderButtonsMenuItem = checkMenuItem(columnMenu->Append(wxID_ANY, _("Shoulder Buttons"), _("Show/hide the shoulder button columns"), wxITEM_CHECK), showShoulderButtons);
+	showMiscButtonsMenuItem = checkMenuItem(columnMenu->Append(wxID_ANY, _("Miscellaneous Buttons"), _("Show/hide the remaining miscellaneous columns"), wxITEM_CHECK), showMiscButtons);
+	showColumnsSubmenu = enableMenuItem(viewMenu->AppendSubMenu(columnMenu, _("Show Columns"), _("Show/hide sections of controller data")), true);
+	viewMenu->AppendSeparator();
+	jumpToFrameMenuItem = enableMenuItem(viewMenu->Append(wxID_ANY, _("Jump to Frame"), _("Jump to a specific frame")), false);
+	viewMenu->AppendSeparator();
+	wxMenu* controllerMenu = new wxMenu();
+	portOneMenuItem = checkMenuItem(controllerMenu->Append(wxID_ANY, _("Port 1"), _("Select port 1"), wxITEM_CHECK), true);
+	portTwoMenuItem = checkMenuItem(controllerMenu->Append(wxID_ANY, _("Port 2"), _("Select port 2"), wxITEM_CHECK), false);
+	controllerPortSubmenu = enableMenuItem(viewMenu->AppendSubMenu(controllerMenu, _("Change Controller"), _("Switch which controller port is active")), false);
+	menuBar->Append(viewMenu, _("View"));
+
+	dataMenu = new wxMenu();
+	clearFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Clear Frame"), _("Clear the entire frame of data")), false);
+	defaultFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Default Frame"), _("Set the frame to the controllers default neutral values")), false);
+	duplicateFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Duplicate Frame"), _("Duplicate and insert the frame")), false);
+	insertFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Insert Frame"), _("Insert a new default frame")), false);
+	insertFramesMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Insert Frame(s)"), _("Insert multiple default frames")), false);
+	removeFrameMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Remove Frame"), _("Remove a frame")), false);
+	removeFramesMenuItem = enableMenuItem(dataMenu->Append(wxID_ANY, _("Remove Frame(s)"), _("Remove multiple frames")), false);
+	// TODO - implement Data menu and event handlers
+	// menuBar->Append(dataMenu, _("Data"));
+
+	// Init Widgets
+	recordingDataSource = new RecordingFileGridTable(NUM_COLUMNS);
+	recordingGrid = new wxGrid(this, wxID_ANY);
+	recordingGrid->SetTable(recordingDataSource, true);
+	recordingGrid->EnableDragColSize(false);
+	recordingGrid->EnableDragRowSize(false);
+	recordingGrid->EnableDragGridSize(false);
+	recordingGrid->SetColSize(0, 100);
+	recordingGrid->SetColSize(1, 100);
+	recordingGrid->SetColSize(2, 100);
+	recordingGrid->SetColSize(3, 100);
+	recordingGrid->SetColLabelSize(75);
+
+	// Bind Events
+	Bind(wxEVT_CLOSE_WINDOW, &InputRecordingViewer::OnCloseWindow, this);
+
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnOpenFile, this, openMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnCloseFile, this, closeMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnSaveFile, this, saveMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnSaveAsFile, this, saveAsMenuItem->GetId());
+	// TODO - implement Exporting!
+	// Bind(wxEVT_MENU, &InputRecordingViewer::OnImport, this, importMenuItem->GetId());
+	// Bind(wxEVT_MENU, &InputRecordingViewer::OnExport, this, exportMenuItem->GetId());
+
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnChangeMetadata, this, changeMetadataMenuItem->GetId());
+	// TODO - implement!
+	// Bind(wxEVT_MENU, &InputRecordingViewer::OnChangeRecordingType, this, changeRecordingTypeMenuItem->GetId());
+	// Bind(wxEVT_MENU, &InputRecordingViewer::OnChangeBaseSavestate, this, changeBaseSavestateMenuItem->GetId());
+
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnShowAnalogSticks, this, showAnalogSticksMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnShowFaceButtons, this, showFaceButtonsMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnShowDirectionalPad, this, showDirectionalPadMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnShowShoulderButtons, this, showShoulderButtonsMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnShowMiscButtons, this, showMiscButtonsMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnJumpToFrame, this, jumpToFrameMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnSelectPortOne, this, portOneMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnSelectPortTwo, this, portTwoMenuItem->GetId());
+
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnClearFrame, this, clearFrameMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnDefaultFrame, this, defaultFrameMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnDuplicateFrame, this, duplicateFrameMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnInsertFrame, this, insertFrameMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnInsertFrames, this, insertFramesMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnRemoveFrame, this, removeFrameMenuItem->GetId());
+	Bind(wxEVT_MENU, &InputRecordingViewer::OnRemoveFrames, this, removeFramesMenuItem->GetId());
+
+	// Sizers
+	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+	sizer->Add(recordingGrid, 1, wxEXPAND, 0);
+	sizer->SetSizeHints(this);
+
+	SetMenuBar(menuBar);
+	SetIcons(wxGetApp().GetIconBundle());
+
+	CreateStatusBar(1);
+
+	SetSizer(sizer);
+	SetMinSize(wxSize(500, 500));
+	Layout();
+	DisplayColumns();
+}
+
+void InputRecordingViewer::OnCloseWindow(wxCloseEvent& event)
+{
+	recordingDataSource->CloseRecordingFile();
+	recordingGrid->ForceRefresh();
+	wxRemoveFile(tempFilePath);
+	ToggleMenuItems(false);
+	Hide();
+}
+
+void InputRecordingViewer::ToggleMenuItems(bool fileOpen)
+{
+	openMenuItem->Enable(!fileOpen);
+	closeMenuItem->Enable(fileOpen);
+	saveMenuItem->Enable(fileOpen);
+	saveAsMenuItem->Enable(fileOpen);
+	// importMenuItem->Enable(fileOpen);
+	// exportMenuItem->Enable(fileOpen);
+
+	changeMetadataMenuItem->Enable(fileOpen);
+	// changeRecordingTypeMenuItem->Enable(fileOpen);
+	// changeBaseSavestateMenuItem->Enable(fileOpen);
+
+	jumpToFrameMenuItem->Enable(fileOpen);
+	controllerPortSubmenu->Enable(fileOpen);
+	portOneMenuItem->Check(fileOpen && recordingDataSource->GetControllerPort() == 1);
+	portTwoMenuItem->Check(fileOpen && recordingDataSource->GetControllerPort() == 2);
+
+	clearFrameMenuItem->Enable(fileOpen);
+	defaultFrameMenuItem->Enable(fileOpen);
+	duplicateFrameMenuItem->Enable(fileOpen);
+	insertFrameMenuItem->Enable(fileOpen);
+	insertFramesMenuItem->Enable(fileOpen);
+	removeFrameMenuItem->Enable(fileOpen);
+	removeFramesMenuItem->Enable(fileOpen);
+}
+
+void InputRecordingViewer::DisplayColumns()
+{
+	for (int i = 0; i < 4; i++)
+	{
+		showAnalogSticks ? recordingGrid->ShowCol(i) : recordingGrid->HideCol(i);
+	}
+	for (int i = 4; i < 8; i++)
+	{
+		showFaceButtons ? recordingGrid->ShowCol(i) : recordingGrid->HideCol(i);
+	}
+	for (int i = 8; i < 12; i++)
+	{
+		showDirectionalPad ? recordingGrid->ShowCol(i) : recordingGrid->HideCol(i);
+	}
+	for (int i = 12; i < 16; i++)
+	{
+		showShoulderButtons ? recordingGrid->ShowCol(i) : recordingGrid->HideCol(i);
+	}
+	for (int i = 16; i < 20; i++)
+	{
+		showMiscButtons ? recordingGrid->ShowCol(i) : recordingGrid->HideCol(i);
+	}
+}
+
+void InputRecordingViewer::OnOpenFile(wxCommandEvent& event)
+{
+	wxFileDialog* openFileDialog =
+		new wxFileDialog(this, _("Open Input Recording File"), wxEmptyString, wxEmptyString, "p2m2 file(*.p2m2)|*.p2m2",
+						 wxFD_OPEN, wxDefaultPosition);
+
+	if (openFileDialog->ShowModal() == wxID_OK)
+	{
+		// TODO - utility function
+		filePath = openFileDialog->GetPath();
+		// wxWidget's removes the extension if it contains wildcards
+		// on wxGTK https://trac.wxwidgets.org/ticket/15285
+		if (!filePath.EndsWith(".p2m2"))
+			filePath = wxString::Format("%s.p2m2", filePath);
+
+		if (!wxFileExists(filePath))
+		{
+			wxMessageBox(_("Unable to Open Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+			return;
+		}
+
+		// Copy the file, as this is out working copy if edits are made
+		// The user can then choose to overwrite the existing file, or save elsewhere.
+		// At which time, we remove the temp file
+		tempFilePath = filePath + ".tmp";
+		if (!wxCopyFile(filePath, tempFilePath, true))
+		{
+			wxMessageBox(_("Unable to Open Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+			return;
+		}
+
+		recordingDataSource->OpenRecordingFile(tempFilePath);
+		recordingGrid->ForceRefresh();
+
+		// Enable various menu options
+		ToggleMenuItems(true);
+	}
+}
+
+void InputRecordingViewer::OnCloseFile(wxCommandEvent& event)
+{
+	if (recordingDataSource->AreChangesUnsaved())
+	{
+		int answer = wxMessageBox(_("Close without saving changes?"), _("Confirm"),
+								  wxYES_NO | wxCANCEL, this);
+		if (answer != wxYES)
+		{
+			return;
+		}
+	}
+	recordingDataSource->CloseRecordingFile();
+	recordingGrid->ForceRefresh();
+	wxRemoveFile(tempFilePath);
+	ToggleMenuItems(false);
+}
+
+// TODO - a not on saving, currently we don't allow modifying the original save-state, so there are no concerns about it
+// When we do though, these save functions will need to expand!
+
+void InputRecordingViewer::OnSaveFile(wxCommandEvent& event)
+{
+	if (!wxCopyFile(tempFilePath, filePath + ".bak", true))
+	{
+		wxMessageBox(_("Unable to backup original recording before saving, aborting!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	// Overwrite existing file, this is just a simple rename
+	if (!wxCopyFile(tempFilePath, filePath, true))
+	{
+		wxMessageBox(_("Unable to Save Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	recordingDataSource->ClearUnsavedChanges();
+}
+
+void InputRecordingViewer::OnSaveAsFile(wxCommandEvent& event)
+{
+	wxFileDialog* openFileDialog =
+		new wxFileDialog(this, _("Save Input Recording File"), wxEmptyString, wxEmptyString, "p2m2 file(*.p2m2)|*.p2m2",
+						 wxFD_SAVE | wxFD_OVERWRITE_PROMPT, wxDefaultPosition);
+
+	if (openFileDialog->ShowModal() == wxID_OK)
+	{
+		wxString savePath = openFileDialog->GetPath();
+		// wxWidget's removes the extension if it contains wildcards
+		// on wxGTK https://trac.wxwidgets.org/ticket/15285
+		if (!savePath.EndsWith(".p2m2"))
+			savePath = wxString::Format("%s.p2m2", savePath);
+
+		if (savePath == filePath)
+		{
+			if (!wxCopyFile(tempFilePath, savePath + ".bak", true))
+			{
+				wxMessageBox(_("Unable to backup original recording before saving, aborting!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+				return;
+			}
+		}
+
+		if (!wxCopyFile(tempFilePath, savePath, true))
+		{
+			wxMessageBox(_("Unable to Save Input Recording File"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+			return;
+		}
+
+		// If it's a save-state recording, copy over the save-state as well
+		if (recordingDataSource->IsFromSavestate())
+		{
+			if (wxFileExists(filePath + "_SaveState.p2s"))
+			{
+				if (savePath != filePath && !wxCopyFile(filePath + "_SaveState.p2s", savePath + "_SaveState.p2s", true))
+				{
+					wxMessageBox(_("Unable to Save Input Recording's SaveState!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+				}
+			}
+			else
+			{
+				wxMessageBox(_("Unable to Save Input Recording's SaveState, not found!"), "Input Recording Viewer Error", wxOK | wxICON_ERROR, this);
+			}
+		}
+
+		recordingDataSource->ClearUnsavedChanges();
+	}
+}
+
+void InputRecordingViewer::OnImport(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnExport(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnChangeMetadata(wxCommandEvent& event)
+{
+	InputRecordingFileHeader currHeader = recordingDataSource->GetRecordingFileHeader();
+	RecordingMetadataDialog* custom = new RecordingMetadataDialog(this, currHeader.author, currHeader.gameName, recordingDataSource->GetUndoCount());
+	if (custom->ShowModal() == wxID_OK)
+	{
+		recordingDataSource->UpdateRecordingFileHeader(custom->GetAuthor(), custom->GetGameName());
+		recordingDataSource->SetUndoCount(custom->GetUndoCount());
+	}
+}
+
+void InputRecordingViewer::OnChangeRecordingType(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnChangeBaseSavestate(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnShowAnalogSticks(wxCommandEvent& event)
+{
+	showAnalogSticks = showAnalogSticksMenuItem->IsChecked();
+	DisplayColumns();
+}
+
+void InputRecordingViewer::OnShowFaceButtons(wxCommandEvent& event)
+{
+	showFaceButtons = showFaceButtonsMenuItem->IsChecked();
+	DisplayColumns();
+}
+
+void InputRecordingViewer::OnShowDirectionalPad(wxCommandEvent& event)
+{
+	showDirectionalPad = showDirectionalPadMenuItem->IsChecked();
+	DisplayColumns();
+}
+
+void InputRecordingViewer::OnShowShoulderButtons(wxCommandEvent& event)
+{
+	showShoulderButtons = showShoulderButtonsMenuItem->IsChecked();
+	DisplayColumns();
+}
+
+void InputRecordingViewer::OnShowMiscButtons(wxCommandEvent& event)
+{
+	showMiscButtons = showMiscButtonsMenuItem->IsChecked();
+	DisplayColumns();
+}
+
+void InputRecordingViewer::OnJumpToFrame(wxCommandEvent& event)
+{
+	long frame = wxGetNumberFromUser(_("Enter Frame Number"), wxEmptyString, _("Jump To Frame"), 0, 0, recordingDataSource->GetNumberRows(), this);
+	frame = frame == 0 ? 0 : frame - 1;
+	recordingGrid->SelectRow(frame);
+	recordingGrid->MakeCellVisible(frame, 0);
+}
+
+void InputRecordingViewer::OnSelectPortOne(wxCommandEvent& event)
+{
+	bool selected = portOneMenuItem->IsChecked();
+	portTwoMenuItem->Check(!selected);
+	recordingDataSource->SetControllerPort(1);
+	recordingGrid->ForceRefresh();
+}
+
+void InputRecordingViewer::OnSelectPortTwo(wxCommandEvent& event)
+{
+	bool selected = portTwoMenuItem->IsChecked();
+	portOneMenuItem->Check(!selected);
+	recordingDataSource->SetControllerPort(2);
+	recordingGrid->ForceRefresh();
+}
+
+void InputRecordingViewer::OnClearFrame(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnDefaultFrame(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnDuplicateFrame(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnInsertFrame(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnInsertFrames(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnRemoveFrame(wxCommandEvent& event)
+{
+	// TODO
+}
+
+void InputRecordingViewer::OnRemoveFrames(wxCommandEvent& event)
+{
+	// TODO
+}

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.cpp
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.cpp
@@ -38,7 +38,7 @@ wxMenuItem* checkMenuItem(wxMenuItem* item, bool checked)
 }
 
 InputRecordingViewer::InputRecordingViewer(wxWindow* parent, AppConfig::InputRecordingOptions& options)
-	: wxFrame(parent, wxID_ANY, _("Recording Viewer"), wxDefaultPosition, wxDefaultSize)
+	: wxFrame(parent, wxID_ANY, _("Input Recording Viewer"), wxDefaultPosition, wxDefaultSize)
 	, options(options)
 {
 	// Init Menus

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.h
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.h
@@ -26,16 +26,10 @@
 class InputRecordingViewer : public wxFrame
 {
 public:
-	InputRecordingViewer(wxWindow* parent);
+	InputRecordingViewer(wxWindow* parent, AppConfig::InputRecordingOptions& options);
 
 private:
-	// -- Persisted in config files
-	bool showAnalogSticks = true;
-	bool showFaceButtons = true;
-	bool showDirectionalPad = true;
-	bool showShoulderButtons = true;
-	bool showMiscButtons = true;
-	// -------
+	AppConfig::InputRecordingOptions& options;
 
 	const int NUM_COLUMNS = 20;
 
@@ -49,6 +43,7 @@ private:
 	void DisplayColumns();
 
 	void OnCloseWindow(wxCloseEvent& event);
+	void OnMoveAround(wxMoveEvent& event);
 
 	// Menu items and handlers
 	wxMenuBar* menuBar;

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.h
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.h
@@ -1,0 +1,115 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wx/filepicker.h>
+#include <wx/grid.h>
+#include <wx/image.h>
+#include <wx/wx.h>
+
+#include "Recording/InputRecordingFile.h"
+#include "RecordingFileGridTable.h"
+
+class InputRecordingViewer : public wxFrame
+{
+public:
+	InputRecordingViewer(wxWindow* parent);
+
+private:
+	// -- Persisted in config files
+	bool showAnalogSticks = true;
+	bool showFaceButtons = true;
+	bool showDirectionalPad = true;
+	bool showShoulderButtons = true;
+	bool showMiscButtons = true;
+	// -------
+
+	const int NUM_COLUMNS = 20;
+
+	wxString filePath;
+	wxString tempFilePath;
+
+	RecordingFileGridTable* recordingDataSource;
+	wxGrid* recordingGrid;
+
+	void ToggleMenuItems(bool fileOpen);
+	void DisplayColumns();
+
+	void OnCloseWindow(wxCloseEvent& event);
+
+	// Menu items and handlers
+	wxMenuBar* menuBar;
+
+	wxMenu* fileMenu;
+	wxMenuItem* openMenuItem;
+	wxMenuItem* closeMenuItem;
+	wxMenuItem* saveMenuItem;
+	wxMenuItem* saveAsMenuItem;
+	wxMenuItem* importMenuItem;
+	wxMenuItem* exportMenuItem;
+	void OnOpenFile(wxCommandEvent& event);
+	void OnCloseFile(wxCommandEvent& event);
+	void OnSaveFile(wxCommandEvent& event);
+	void OnSaveAsFile(wxCommandEvent& event);
+	void OnImport(wxCommandEvent& event);
+	void OnExport(wxCommandEvent& event);
+
+	wxMenu* editMenu;
+	wxMenuItem* changeMetadataMenuItem;
+	wxMenuItem* changeRecordingTypeMenuItem;
+	wxMenuItem* changeBaseSavestateMenuItem;
+	void OnChangeMetadata(wxCommandEvent& event);
+	void OnChangeRecordingType(wxCommandEvent& event);
+	void OnChangeBaseSavestate(wxCommandEvent& event);
+
+	wxMenu* viewMenu;
+	wxMenuItem* showColumnsSubmenu;
+	wxMenuItem* showAnalogSticksMenuItem;
+	wxMenuItem* showFaceButtonsMenuItem;
+	wxMenuItem* showDirectionalPadMenuItem;
+	wxMenuItem* showShoulderButtonsMenuItem;
+	wxMenuItem* showMiscButtonsMenuItem;
+
+	wxMenuItem* jumpToFrameMenuItem;
+
+	wxMenuItem* controllerPortSubmenu;
+	wxMenuItem* portOneMenuItem;
+	wxMenuItem* portTwoMenuItem;
+	void OnShowAnalogSticks(wxCommandEvent& event);
+	void OnShowFaceButtons(wxCommandEvent& event);
+	void OnShowDirectionalPad(wxCommandEvent& event);
+	void OnShowShoulderButtons(wxCommandEvent& event);
+	void OnShowMiscButtons(wxCommandEvent& event);
+	void OnJumpToFrame(wxCommandEvent& event);
+	void OnSelectPortOne(wxCommandEvent& event);
+	void OnSelectPortTwo(wxCommandEvent& event);
+
+	wxMenu* dataMenu;
+	wxMenuItem* clearFrameMenuItem;
+	wxMenuItem* defaultFrameMenuItem;
+	wxMenuItem* duplicateFrameMenuItem;
+	wxMenuItem* insertFrameMenuItem;
+	wxMenuItem* insertFramesMenuItem;
+	wxMenuItem* removeFrameMenuItem;
+	wxMenuItem* removeFramesMenuItem;
+	void OnClearFrame(wxCommandEvent& event);
+	void OnDefaultFrame(wxCommandEvent& event);
+	void OnDuplicateFrame(wxCommandEvent& event);
+	void OnInsertFrame(wxCommandEvent& event);
+	void OnInsertFrames(wxCommandEvent& event);
+	void OnRemoveFrame(wxCommandEvent& event);
+	void OnRemoveFrames(wxCommandEvent& event);
+};

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.h
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.h
@@ -22,6 +22,7 @@
 
 #include "Recording/InputRecordingFile.h"
 #include "RecordingFileGridTable.h"
+#include "RecordingViewerColumn.h"
 
 class InputRecordingViewer : public wxFrame
 {
@@ -32,6 +33,8 @@ private:
 	AppConfig::InputRecordingOptions& options;
 
 	const int NUM_COLUMNS = 20;
+	// displayIndex : RecordingViewerColumn
+	std::map<int, RecordingViewerColumn> gridColumns;
 	
 	bool fileOpened = false;
 
@@ -42,7 +45,8 @@ private:
 	wxGrid* recordingGrid;
 
 	void ToggleMenuItems(bool fileOpen);
-	void DisplayColumns();
+	void InitColumns();
+	void RefreshColumns();
 	void CloseActiveFile();
 
 	void OnClose(wxCloseEvent& event);
@@ -74,23 +78,12 @@ private:
 	void OnChangeBaseSavestate(wxCommandEvent& event);
 
 	wxMenu* viewMenu;
-	wxMenuItem* showColumnsSubmenu;
-	wxMenuItem* showAnalogSticksMenuItem;
-	wxMenuItem* showFaceButtonsMenuItem;
-	wxMenuItem* showDirectionalPadMenuItem;
-	wxMenuItem* showShoulderButtonsMenuItem;
-	wxMenuItem* showMiscButtonsMenuItem;
-
+	wxMenuItem* configColumnsMenuItem;
 	wxMenuItem* jumpToFrameMenuItem;
-
 	wxMenuItem* controllerPortSubmenu;
 	wxMenuItem* portOneMenuItem;
 	wxMenuItem* portTwoMenuItem;
-	void OnShowAnalogSticks(wxCommandEvent& event);
-	void OnShowFaceButtons(wxCommandEvent& event);
-	void OnShowDirectionalPad(wxCommandEvent& event);
-	void OnShowShoulderButtons(wxCommandEvent& event);
-	void OnShowMiscButtons(wxCommandEvent& event);
+	void OnConfigColumns(wxCommandEvent& event);
 	void OnJumpToFrame(wxCommandEvent& event);
 	void OnSelectPortOne(wxCommandEvent& event);
 	void OnSelectPortTwo(wxCommandEvent& event);

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.h
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.h
@@ -34,73 +34,73 @@ private:
 
 	const int NUM_COLUMNS = 20;
 	// displayIndex : RecordingViewerColumn
-	std::map<int, RecordingViewerColumn> gridColumns;
-	
-	bool fileOpened = false;
+	std::map<int, RecordingViewerColumn> m_grid_columns;
 
-	wxString filePath;
-	wxString tempFilePath;
+	bool m_file_opened = false;
 
-	RecordingFileGridTable* recordingDataSource;
-	wxGrid* recordingGrid;
+	wxString m_filepath;
+	wxString m_temp_filepath;
 
-	void ToggleMenuItems(bool fileOpen);
-	void InitColumns();
-	void RefreshColumns();
-	void CloseActiveFile();
+	RecordingFileGridTable* m_recording_data_source;
+	wxGrid* m_recording_grid;
 
-	void OnClose(wxCloseEvent& event);
-	void OnMoveAround(wxMoveEvent& event);
+	void toggleMenuItems(bool file_open);
+	void initColumns();
+	void refreshColumns();
+	void closeActiveFile();
+
+	void onClose(wxCloseEvent& event);
+	void onMoveAround(wxMoveEvent& event);
 
 	// Menu items and handlers
-	wxMenuBar* menuBar;
+	wxMenuBar* m_menu_bar;
 
-	wxMenu* fileMenu;
-	wxMenuItem* openMenuItem;
-	wxMenuItem* closeMenuItem;
-	wxMenuItem* saveMenuItem;
-	wxMenuItem* saveAsMenuItem;
-	wxMenuItem* importMenuItem;
-	wxMenuItem* exportMenuItem;
-	void OnOpenFile(wxCommandEvent& event);
-	void OnCloseFile(wxCommandEvent& event);
-	void OnSaveFile(wxCommandEvent& event);
-	void OnSaveAsFile(wxCommandEvent& event);
-	void OnImport(wxCommandEvent& event);
-	void OnExport(wxCommandEvent& event);
+	wxMenu* m_file_menu;
+	wxMenuItem* m_open_menu_item;
+	wxMenuItem* m_close_menu_item;
+	wxMenuItem* m_save_menu_item;
+	wxMenuItem* m_save_as_menu_item;
+	wxMenuItem* m_import_menu_item;
+	wxMenuItem* m_export_menu_item;
+	void onOpenFile(wxCommandEvent& event);
+	void onCloseFile(wxCommandEvent& event);
+	void onSaveFile(wxCommandEvent& event);
+	void onSaveAsFile(wxCommandEvent& event);
+	void onImport(wxCommandEvent& event);
+	void onExport(wxCommandEvent& event);
 
-	wxMenu* editMenu;
-	wxMenuItem* changeMetadataMenuItem;
-	wxMenuItem* changeRecordingTypeMenuItem;
-	wxMenuItem* changeBaseSavestateMenuItem;
-	void OnChangeMetadata(wxCommandEvent& event);
-	void OnChangeRecordingType(wxCommandEvent& event);
-	void OnChangeBaseSavestate(wxCommandEvent& event);
+	wxMenu* m_edit_menu;
+	wxMenuItem* m_change_metadata_menu_item;
+	wxMenuItem* m_change_recording_type_menu_item;
+	wxMenuItem* m_change_base_savestate_menu_item;
+	void onChangeMetadata(wxCommandEvent& event);
+	void onChangeRecordingType(wxCommandEvent& event);
+	void onChangeBaseSavestate(wxCommandEvent& event);
 
-	wxMenu* viewMenu;
-	wxMenuItem* configColumnsMenuItem;
-	wxMenuItem* jumpToFrameMenuItem;
-	wxMenuItem* controllerPortSubmenu;
-	wxMenuItem* portOneMenuItem;
-	wxMenuItem* portTwoMenuItem;
-	void OnConfigColumns(wxCommandEvent& event);
-	void OnJumpToFrame(wxCommandEvent& event);
-	void OnSelectPortOne(wxCommandEvent& event);
-	void OnSelectPortTwo(wxCommandEvent& event);
+	wxMenu* m_view_menu;
+	wxMenuItem* m_config_columns_menu_item;
+	wxMenuItem* m_jump_to_frame_menu_item;
+	wxMenuItem* m_controller_port_submenu;
+	wxMenuItem* m_port_one_menu_item;
+	wxMenuItem* m_port_two_menu_item;
+	void onConfigColumns(wxCommandEvent& event);
+	void onJumpToFrame(wxCommandEvent& event);
+	void onSelectPortOne(wxCommandEvent& event);
+	void onSelectPortTwo(wxCommandEvent& event);
 
-	wxMenu* dataMenu;
-	wxMenuItem* clearFrameMenuItem;
-	wxMenuItem* defaultFrameMenuItem;
-	wxMenuItem* duplicateFrameMenuItem;
-	wxMenuItem* insertFrameMenuItem;
-	wxMenuItem* insertFramesMenuItem;
-	wxMenuItem* removeFrameMenuItem;
-	wxMenuItem* removeFramesMenuItem;
-	void OnClearFrame(wxCommandEvent& event);
-	void OnDefaultFrame(wxCommandEvent& event);
-	void OnDuplicateFrame(wxCommandEvent& event);
-	void OnInsertFrame(wxCommandEvent& event);
-	void OnInsertFrames(wxCommandEvent& event);
-	void OnRemoveFrame(wxCommandEvent& event);
-	void OnRemoveFrames(wxCommandEvent& event);
+	wxMenu* m_data_menu;
+	wxMenuItem* m_clear_frame_menu_item;
+	wxMenuItem* m_default_frame_menu_item;
+	wxMenuItem* m_duplicate_frame_menu_item;
+	wxMenuItem* m_insert_frame_menu_item;
+	wxMenuItem* m_insert_frames_menu_item;
+	wxMenuItem* m_remove_frame_menu_item;
+	wxMenuItem* m_remove_frames_menu_item;
+	void onClearFrame(wxCommandEvent& event);
+	void onDefaultFrame(wxCommandEvent& event);
+	void onDuplicateFrame(wxCommandEvent& event);
+	void onInsertFrame(wxCommandEvent& event);
+	void onInsertFrames(wxCommandEvent& event);
+	void onRemoveFrame(wxCommandEvent& event);
+	void onRemoveFrames(wxCommandEvent& event);
 };

--- a/pcsx2/Recording/Viewer/InputRecordingViewer.h
+++ b/pcsx2/Recording/Viewer/InputRecordingViewer.h
@@ -32,6 +32,8 @@ private:
 	AppConfig::InputRecordingOptions& options;
 
 	const int NUM_COLUMNS = 20;
+	
+	bool fileOpened = false;
 
 	wxString filePath;
 	wxString tempFilePath;
@@ -41,8 +43,9 @@ private:
 
 	void ToggleMenuItems(bool fileOpen);
 	void DisplayColumns();
+	void CloseActiveFile();
 
-	void OnCloseWindow(wxCloseEvent& event);
+	void OnClose(wxCloseEvent& event);
 	void OnMoveAround(wxMoveEvent& event);
 
 	// Menu items and handlers

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
@@ -19,6 +19,7 @@
 #include <regex>
 
 RecordingFileGridTable::RecordingFileGridTable(int numColumns)
+	: numColumns(numColumns)
 {
 }
 
@@ -61,7 +62,7 @@ bool RecordingFileGridTable::IsFromSavestate()
 
 int RecordingFileGridTable::GetNumberCols()
 {
-	return 20;
+	return numColumns;
 }
 
 std::pair<bool, int> getPressedAndPressure(std::string cellValue)
@@ -116,7 +117,7 @@ void RecordingFileGridTable::SetValue(int row, int col, const wxString& value)
 		singleValue = wxAtoi(value);
 		if (col >= 16 && col <= 19)
 		{
-			singleValue = singleValue != 0 || singleValue != 1 ? 0 : singleValue;
+			singleValue = singleValue == 0 || singleValue == 1 ? singleValue : 0;
 		}
 		else
 		{
@@ -314,7 +315,7 @@ InputRecordingFileHeader RecordingFileGridTable::GetRecordingFileHeader()
 	return activeFile.GetHeader();
 }
 
-void RecordingFileGridTable::UpdateRecordingFileHeader(const std::string author, const std::string gameName)
+void RecordingFileGridTable::UpdateRecordingFileHeader(const std::string& author, const std::string& gameName)
 {
 	// Check to see if any changes were made
 	// TODO - comparison func in InputRecordingFileHeader, not going to bother right now though since v2 is on the horizon

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
@@ -18,8 +18,8 @@
 #include "RecordingFileGridTable.h"
 #include <regex>
 
-RecordingFileGridTable::RecordingFileGridTable(int numColumns)
-	: numColumns(numColumns)
+RecordingFileGridTable::RecordingFileGridTable(const std::map<int, RecordingViewerColumn>& gridColumns)
+	: gridColumns(gridColumns)
 {
 }
 
@@ -62,7 +62,7 @@ bool RecordingFileGridTable::IsFromSavestate()
 
 int RecordingFileGridTable::GetNumberCols()
 {
-	return numColumns;
+	return gridColumns.size();
 }
 
 std::pair<bool, int> getPressedAndPressure(std::string cellValue)
@@ -163,36 +163,36 @@ void RecordingFileGridTable::SetValue(int row, int col, const wxString& value)
 			padData.trianglePressure = multiValueCell.second;
 			break;
 		case 8:
-			padData.leftPressed = multiValueCell.first;
-			padData.leftPressure = multiValueCell.second;
-			break;
-		case 9:
-			padData.downPressed = multiValueCell.first;
-			padData.downPressure = multiValueCell.second;
-			break;
-		case 10:
-			padData.rightPressed = multiValueCell.first;
-			padData.rightPressure = multiValueCell.second;
-			break;
-		case 11:
-			padData.upPressed = multiValueCell.first;
-			padData.upPressure = multiValueCell.second;
-			break;
-		case 12:
 			padData.r1Pressed = multiValueCell.first;
 			padData.r1Pressure = multiValueCell.second;
 			break;
-		case 13:
+		case 9:
 			padData.r2Pressed = multiValueCell.first;
 			padData.r2Pressure = multiValueCell.second;
 			break;
-		case 14:
+		case 10:
 			padData.l1Pressed = multiValueCell.first;
 			padData.l1Pressure = multiValueCell.second;
 			break;
-		case 15:
+		case 11:
 			padData.l2Pressed = multiValueCell.first;
 			padData.l2Pressure = multiValueCell.second;
+			break;
+		case 12:
+			padData.leftPressed = multiValueCell.first;
+			padData.leftPressure = multiValueCell.second;
+			break;
+		case 13:
+			padData.downPressed = multiValueCell.first;
+			padData.downPressure = multiValueCell.second;
+			break;
+		case 14:
+			padData.rightPressed = multiValueCell.first;
+			padData.rightPressure = multiValueCell.second;
+			break;
+		case 15:
+			padData.upPressed = multiValueCell.first;
+			padData.upPressure = multiValueCell.second;
 			break;
 		case 16:
 			padData.r3 = singleValue;
@@ -226,7 +226,7 @@ wxString RecordingFileGridTable::GetColLabelValue(int col)
 	{
 		return "?";
 	}
-	return columnLabels.at(col);
+	return wxString(gridColumns.at(col).label);
 }
 
 wxString RecordingFileGridTable::GetValue(int row, int col)
@@ -266,21 +266,21 @@ wxString RecordingFileGridTable::GetValue(int row, int col)
 		case 7:
 			return wxString::Format("%d (%d)", padData.trianglePressed, padData.trianglePressure);
 		case 8:
-			return wxString::Format("%d (%d)", padData.leftPressed, padData.leftPressure);
-		case 9:
-			return wxString::Format("%d (%d)", padData.downPressed, padData.downPressure);
-		case 10:
-			return wxString::Format("%d (%d)", padData.rightPressed, padData.rightPressure);
-		case 11:
-			return wxString::Format("%d (%d)", padData.upPressed, padData.upPressure);
-		case 12:
 			return wxString::Format("%d (%d)", padData.r1Pressed, padData.r1Pressure);
-		case 13:
+		case 9:
 			return wxString::Format("%d (%d)", padData.r2Pressed, padData.r2Pressure);
-		case 14:
+		case 10:
 			return wxString::Format("%d (%d)", padData.l1Pressed, padData.l1Pressure);
-		case 15:
+		case 11:
 			return wxString::Format("%d (%d)", padData.l2Pressed, padData.l2Pressure);
+		case 12:
+			return wxString::Format("%d (%d)", padData.leftPressed, padData.leftPressure);
+		case 13:
+			return wxString::Format("%d (%d)", padData.downPressed, padData.downPressure);
+		case 14:
+			return wxString::Format("%d (%d)", padData.rightPressed, padData.rightPressure);
+		case 15:
+			return wxString::Format("%d (%d)", padData.upPressed, padData.upPressure);
 		case 16:
 			return wxString::Format("%d", padData.r3);
 		case 17:
@@ -310,6 +310,11 @@ void RecordingFileGridTable::CloseRecordingFile()
 	activeFile.Close();
 	dataBuffer.clear();
 	changes = false;
+}
+
+void RecordingFileGridTable::UpdateGridColumns(const std::map<int, RecordingViewerColumn>& gridColumns)
+{
+	this->gridColumns = gridColumns;
 }
 
 InputRecordingFileHeader RecordingFileGridTable::GetRecordingFileHeader()

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
@@ -300,6 +300,7 @@ void RecordingFileGridTable::OpenRecordingFile(wxString filePath)
 	dataBuffer.clear();
 	wxGridTableMessage msg(this, wxGRIDTABLE_NOTIFY_ROWS_APPENDED, activeFile.GetTotalFrames(), 0);
 	GetView()->ProcessTableMessage(msg);
+	changes = false;
 }
 
 void RecordingFileGridTable::CloseRecordingFile()
@@ -308,6 +309,7 @@ void RecordingFileGridTable::CloseRecordingFile()
 	GetView()->ProcessTableMessage(msg);
 	activeFile.Close();
 	dataBuffer.clear();
+	changes = false;
 }
 
 InputRecordingFileHeader RecordingFileGridTable::GetRecordingFileHeader()
@@ -333,15 +335,4 @@ void RecordingFileGridTable::UpdateRecordingFileHeader(const std::string& author
 long RecordingFileGridTable::GetUndoCount()
 {
 	return activeFile.GetUndoCount();
-}
-
-void RecordingFileGridTable::SetUndoCount(long undoCount)
-{
-	if (activeFile.GetUndoCount() == undoCount)
-	{
-		return;
-	}
-	changes = true;
-	activeFile.SetUndoCount(undoCount);
-	activeFile.WriteHeader();
 }

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.cpp
@@ -1,0 +1,346 @@
+﻿/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "RecordingFileGridTable.h"
+#include <regex>
+
+RecordingFileGridTable::RecordingFileGridTable(int numColumns)
+{
+}
+
+int RecordingFileGridTable::GetNumberRows()
+{
+	if (!activeFile.IsFileOpen())
+	{
+		return 0;
+	}
+	return activeFile.GetTotalFrames();
+}
+
+bool RecordingFileGridTable::AreChangesUnsaved()
+{
+	return changes;
+}
+
+void RecordingFileGridTable::ClearUnsavedChanges()
+{
+	changes = false;
+}
+
+int RecordingFileGridTable::GetControllerPort()
+{
+	return controllerPort;
+}
+
+
+void RecordingFileGridTable::SetControllerPort(int port)
+{
+	port = port == 0 ? port : port - 1;
+	controllerPort = port;
+	dataBuffer = activeFile.BulkReadPadData(bufferPos - bufferSize, bufferPos + bufferSize, controllerPort);
+}
+
+bool RecordingFileGridTable::IsFromSavestate()
+{
+	return activeFile.FromSaveState();
+}
+
+int RecordingFileGridTable::GetNumberCols()
+{
+	return 20;
+}
+
+std::pair<bool, int> getPressedAndPressure(std::string cellValue)
+{
+	std::regex regex("(\\d+)\\s*\\((\\d+)\\)");
+	std::smatch matches;
+
+	if (std::regex_search(cellValue, matches, regex))
+	{
+		if (matches.size() != 3)
+		{
+			return {0, 0}; // TODO constants in PadData would be better
+		}
+		return {std::stoi(matches[1]), std::stoi(matches[2])};
+	}
+	return {0, 0}; // TODO constants in PadData would be better
+}
+
+void RecordingFileGridTable::SetValue(int row, int col, const wxString& value)
+{
+	// Check if we have to refresh the cache
+	if (dataBuffer.empty() || row > (bufferPos + bufferThreshold) || row < (bufferPos - bufferThreshold))
+	{
+		dataBuffer = activeFile.BulkReadPadData(row - bufferSize, row + bufferSize, controllerPort);
+		bufferPos = row;
+	}
+
+	if (dataBuffer.count(row) != 1)
+	{
+		return;
+	}
+	// Get that entire frame's structure, we can modify it, then save the appropriate buffer
+	PadData padData = dataBuffer.at(row);
+
+	int singleValue;
+	std::pair<bool, int> multiValueCell;
+
+	if (col >= 4 && col <= 15)
+	{
+		multiValueCell = getPressedAndPressure(value.ToStdString());
+		if (multiValueCell.second < 0)
+		{
+			multiValueCell.second = 0;
+		}
+		else if (multiValueCell.second > 255)
+		{
+			multiValueCell.second = 255;
+		}
+	}
+	else
+	{
+		singleValue = wxAtoi(value);
+		if (col >= 16 && col <= 19)
+		{
+			singleValue = singleValue != 0 || singleValue != 1 ? 0 : singleValue;
+		}
+		else
+		{
+			if (singleValue < 0)
+			{
+				singleValue = 0;
+			}
+			else if (singleValue > 255)
+			{
+				singleValue = 255;
+			}
+		}
+	}
+
+	switch (col)
+	{
+		case 0:
+			padData.leftAnalogX = singleValue;
+			break;
+		case 1:
+			padData.leftAnalogY = singleValue;
+			break;
+		case 2:
+			padData.rightAnalogX = singleValue;
+			break;
+		case 3:
+			padData.rightAnalogY = singleValue;
+			break;
+		case 4:
+			padData.squarePressed = multiValueCell.first;
+			padData.squarePressure = multiValueCell.second;
+			break;
+		case 5:
+			padData.crossPressed = multiValueCell.first;
+			padData.crossPressure = multiValueCell.second;
+			break;
+		case 6:
+			padData.circlePressed = multiValueCell.first;
+			padData.circlePressure = multiValueCell.second;
+			break;
+		case 7:
+			padData.trianglePressed = multiValueCell.first;
+			padData.trianglePressure = multiValueCell.second;
+			break;
+		case 8:
+			padData.leftPressed = multiValueCell.first;
+			padData.leftPressure = multiValueCell.second;
+			break;
+		case 9:
+			padData.downPressed = multiValueCell.first;
+			padData.downPressure = multiValueCell.second;
+			break;
+		case 10:
+			padData.rightPressed = multiValueCell.first;
+			padData.rightPressure = multiValueCell.second;
+			break;
+		case 11:
+			padData.upPressed = multiValueCell.first;
+			padData.upPressure = multiValueCell.second;
+			break;
+		case 12:
+			padData.r1Pressed = multiValueCell.first;
+			padData.r1Pressure = multiValueCell.second;
+			break;
+		case 13:
+			padData.r2Pressed = multiValueCell.first;
+			padData.r2Pressure = multiValueCell.second;
+			break;
+		case 14:
+			padData.l1Pressed = multiValueCell.first;
+			padData.l1Pressure = multiValueCell.second;
+			break;
+		case 15:
+			padData.l2Pressed = multiValueCell.first;
+			padData.l2Pressure = multiValueCell.second;
+			break;
+		case 16:
+			padData.r3 = singleValue;
+			break;
+		case 17:
+			padData.l3 = singleValue;
+			break;
+		case 18:
+			padData.select = singleValue;
+			break;
+		case 19:
+			padData.start = singleValue;
+			break;
+		default:
+			return;
+	}
+
+	// Save the frame
+	activeFile.WriteFrame(row, controllerPort, padData);
+
+	// Refresh the cache for subsequent GetValues
+	dataBuffer = activeFile.BulkReadPadData(bufferPos - bufferSize, bufferPos + bufferSize, controllerPort);
+
+	changes = true;
+	return;
+}
+
+wxString RecordingFileGridTable::GetColLabelValue(int col)
+{
+	if (col > GetNumberCols() - 1)
+	{
+		return "?";
+	}
+	return columnLabels.at(col);
+}
+
+wxString RecordingFileGridTable::GetValue(int row, int col)
+{
+	if (!activeFile.IsFileOpen())
+		return "";
+
+	// Check if we have to refresh the cache
+	if (dataBuffer.empty() || row > (bufferPos + bufferThreshold) || row < (bufferPos - bufferThreshold))
+	{
+		dataBuffer = activeFile.BulkReadPadData(row - bufferSize, row + bufferSize, controllerPort);
+		bufferPos = row;
+	}
+
+	if (dataBuffer.count(row) != 1)
+	{
+		return "";
+	}
+	const PadData padData = dataBuffer.at(row);
+
+	switch (col)
+	{
+		case 0:
+			return wxString::Format("%d", padData.leftAnalogX);
+		case 1:
+			return wxString::Format("%d", padData.leftAnalogY);
+		case 2:
+			return wxString::Format("%d", padData.rightAnalogX);
+		case 3:
+			return wxString::Format("%d", padData.rightAnalogY);
+		case 4:
+			return wxString::Format("%d (%d)", padData.squarePressed, padData.squarePressure);
+		case 5:
+			return wxString::Format("%d (%d)", padData.crossPressed, padData.crossPressure);
+		case 6:
+			return wxString::Format("%d (%d)", padData.circlePressed, padData.circlePressure);
+		case 7:
+			return wxString::Format("%d (%d)", padData.trianglePressed, padData.trianglePressure);
+		case 8:
+			return wxString::Format("%d (%d)", padData.leftPressed, padData.leftPressure);
+		case 9:
+			return wxString::Format("%d (%d)", padData.downPressed, padData.downPressure);
+		case 10:
+			return wxString::Format("%d (%d)", padData.rightPressed, padData.rightPressure);
+		case 11:
+			return wxString::Format("%d (%d)", padData.upPressed, padData.upPressure);
+		case 12:
+			return wxString::Format("%d (%d)", padData.r1Pressed, padData.r1Pressure);
+		case 13:
+			return wxString::Format("%d (%d)", padData.r2Pressed, padData.r2Pressure);
+		case 14:
+			return wxString::Format("%d (%d)", padData.l1Pressed, padData.l1Pressure);
+		case 15:
+			return wxString::Format("%d (%d)", padData.l2Pressed, padData.l2Pressure);
+		case 16:
+			return wxString::Format("%d", padData.r3);
+		case 17:
+			return wxString::Format("%d", padData.l3);
+		case 18:
+			return wxString::Format("%d", padData.select);
+		case 19:
+			return wxString::Format("%d", padData.start);
+		default:
+			return "?";
+	}
+}
+
+void RecordingFileGridTable::OpenRecordingFile(wxString filePath)
+{
+	activeFile.OpenExisting(filePath);
+	dataBuffer.clear();
+	wxGridTableMessage msg(this, wxGRIDTABLE_NOTIFY_ROWS_APPENDED, activeFile.GetTotalFrames(), 0);
+	GetView()->ProcessTableMessage(msg);
+}
+
+void RecordingFileGridTable::CloseRecordingFile()
+{
+	wxGridTableMessage msg(this, wxGRIDTABLE_NOTIFY_ROWS_DELETED, 0, activeFile.GetTotalFrames());
+	GetView()->ProcessTableMessage(msg);
+	activeFile.Close();
+	dataBuffer.clear();
+}
+
+InputRecordingFileHeader RecordingFileGridTable::GetRecordingFileHeader()
+{
+	return activeFile.GetHeader();
+}
+
+void RecordingFileGridTable::UpdateRecordingFileHeader(const std::string author, const std::string gameName)
+{
+	// Check to see if any changes were made
+	// TODO - comparison func in InputRecordingFileHeader, not going to bother right now though since v2 is on the horizon
+	InputRecordingFileHeader currHeader = activeFile.GetHeader();
+	if (author == currHeader.author && gameName == currHeader.gameName)
+	{
+		return;
+	}
+	changes = true;
+	activeFile.GetHeader().SetAuthor(author);
+	activeFile.GetHeader().SetGameName(gameName);
+	activeFile.WriteHeader();
+}
+
+long RecordingFileGridTable::GetUndoCount()
+{
+	return activeFile.GetUndoCount();
+}
+
+void RecordingFileGridTable::SetUndoCount(long undoCount)
+{
+	if (activeFile.GetUndoCount() == undoCount)
+	{
+		return;
+	}
+	changes = true;
+	activeFile.SetUndoCount(undoCount);
+	activeFile.WriteHeader();
+}

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.h
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.h
@@ -18,12 +18,13 @@
 #include <wx/wx.h>
 #include <wx/grid.h>
 
+#include "RecordingViewerColumn.h"
 #include "Recording/InputRecordingFile.h"
 
 class RecordingFileGridTable : public wxGridTableBase
 {
 public:
-	RecordingFileGridTable(int numColumns);
+	RecordingFileGridTable(const std::map<int, RecordingViewerColumn>& gridColumns);
 
 	wxString GetValue(int row, int col) override;
 	wxString GetColLabelValue(int col) override;
@@ -39,10 +40,10 @@ public:
 
 	void OpenRecordingFile(wxString filePath);
 	void CloseRecordingFile();
+	void UpdateGridColumns(const std::map<int, RecordingViewerColumn>& gridColumns);
 
 	InputRecordingFileHeader GetRecordingFileHeader();
 	void UpdateRecordingFileHeader(const std::string& author, const std::string& gameName);
-
 	long GetUndoCount();
 
 	bool AreChangesUnsaved();
@@ -58,31 +59,9 @@ public:
 	bool IsFromSavestate();
 
 private:
-	int numColumns;
+	std::map<int, RecordingViewerColumn> gridColumns;
 	int controllerPort = 0;
 	bool changes = false;
-
-	const std::vector<std::string> columnLabels = {
-		"Left\nAnalog X",
-		"Left\nAnalog Y",
-		"Right\nAnalog X",
-		"Right\nAnalog Y",
-		"Square",
-		"Cross",
-		"Circle",
-		"Triangle",
-		"Left",
-		"Down",
-		"Right",
-		"Up",
-		"R1",
-		"R2",
-		"L1",
-		"L2",
-		"R3",
-		"L3",
-		"Select",
-		"Start"};
 
 	InputRecordingFile activeFile;
 

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.h
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.h
@@ -1,0 +1,95 @@
+﻿/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wx/wx.h>
+#include <wx/grid.h>
+
+#include "Recording/InputRecordingFile.h"
+
+class RecordingFileGridTable : public wxGridTableBase
+{
+public:
+	RecordingFileGridTable(int numColumns);
+
+	wxString GetValue(int row, int col) override;
+	wxString GetColLabelValue(int col) override;
+	int GetNumberRows() override;
+	int GetNumberCols() override;
+	// NOTE - in typical wxWidgets fashion, the performance is terrible when you format many cells
+	// Even their own example complains about the problem!
+	// - https://github.com/wxWidgets/wxWidgets/blob/2a536c359cf9475ebda7c37647f50a49f4b0c2ae/samples/grid/griddemo.cpp#L1962-L1964
+	// I'm not going down another performance rabbit-hole
+	// wxGridCellAttr* GetAttr(int row, int col, wxGridCellAttr::wxAttrKind kind) override;
+	void SetValue(int row, int col, const wxString& value) override;
+	bool IsEmptyCell(int, int) override { return false; }
+
+	void OpenRecordingFile(wxString filePath);
+	void CloseRecordingFile();
+
+	InputRecordingFileHeader GetRecordingFileHeader();
+	void UpdateRecordingFileHeader(const std::string author, const std::string gameName);
+
+	long GetUndoCount();
+	void SetUndoCount(long undoCount);
+
+	bool AreChangesUnsaved();
+	void ClearUnsavedChanges();
+
+	int GetControllerPort();
+	/**
+	 * @brief Set the active port to be viewed
+	 * @param port Controller port (not zero-based)
+	*/
+	void SetControllerPort(int port);
+
+	bool IsFromSavestate();
+
+private:
+	int controllerPort = 0;
+	bool changes = false;
+
+	const std::vector<std::string> columnLabels = {
+		"Left\nAnalog X",
+		"Left\nAnalog Y",
+		"Right\nAnalog X",
+		"Right\nAnalog Y",
+		"Square",
+		"Cross",
+		"Circle",
+		"Triangle",
+		"Left",
+		"Down",
+		"Right",
+		"Up",
+		"R1",
+		"R2",
+		"L1",
+		"L2",
+		"R3",
+		"L3",
+		"Select",
+		"Start"};
+
+	InputRecordingFile activeFile;
+
+	// Cache 1000 rows around current position to enable smooth scrolling / limit file IO
+	int bufferSize = 1000;
+	int bufferPos;
+	// When we get 500 rows beyond the last bufferPos, evict the cache and update!
+	int bufferThreshold = 500;
+	std::map<uint, PadData> dataBuffer;
+};

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.h
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.h
@@ -44,7 +44,6 @@ public:
 	void UpdateRecordingFileHeader(const std::string& author, const std::string& gameName);
 
 	long GetUndoCount();
-	void SetUndoCount(long undoCount);
 
 	bool AreChangesUnsaved();
 	void ClearUnsavedChanges();

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.h
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.h
@@ -24,7 +24,7 @@
 class RecordingFileGridTable : public wxGridTableBase
 {
 public:
-	RecordingFileGridTable(const std::map<int, RecordingViewerColumn>& gridColumns);
+	RecordingFileGridTable(const std::map<int, RecordingViewerColumn>& grid_columns);
 
 	wxString GetValue(int row, int col) override;
 	wxString GetColLabelValue(int col) override;
@@ -38,37 +38,37 @@ public:
 	void SetValue(int row, int col, const wxString& value) override;
 	bool IsEmptyCell(int, int) override { return false; }
 
-	void OpenRecordingFile(wxString filePath);
-	void CloseRecordingFile();
-	void UpdateGridColumns(const std::map<int, RecordingViewerColumn>& gridColumns);
+	void openRecordingFile(wxString filePath);
+	void closeRecordingFile();
+	void updateGridColumns(const std::map<int, RecordingViewerColumn>& grid_columns);
 
-	InputRecordingFileHeader GetRecordingFileHeader();
-	void UpdateRecordingFileHeader(const std::string& author, const std::string& gameName);
-	long GetUndoCount();
+	InputRecordingFileHeader getRecordingFileHeader();
+	void updateRecordingFileHeader(const std::string& author, const std::string& game_name);
+	long getUndoCount();
 
-	bool AreChangesUnsaved();
-	void ClearUnsavedChanges();
+	bool areChangesUnsaved();
+	void clearUnsavedChanges();
 
-	int GetControllerPort();
+	int getControllerPort();
 	/**
 	 * @brief Set the active port to be viewed
 	 * @param port Controller port (not zero-based)
 	*/
-	void SetControllerPort(int port);
+	void setControllerPort(int port);
 
-	bool IsFromSavestate();
+	bool isFromSavestate();
 
 private:
-	std::map<int, RecordingViewerColumn> gridColumns;
-	int controllerPort = 0;
-	bool changes = false;
+	std::map<int, RecordingViewerColumn> m_grid_columns;
+	int m_controller_port = 0;
+	bool m_changes = false;
 
-	InputRecordingFile activeFile;
+	InputRecordingFile m_active_file;
 
 	// Cache 1000 rows around current position to enable smooth scrolling / limit file IO
-	int bufferSize = 1000;
-	int bufferPos = 0;
+	int m_buffer_size = 1000;
+	int m_buffer_pos = 0;
 	// When we get 500 rows beyond the last bufferPos, evict the cache and update!
-	int bufferThreshold = 500;
-	std::map<uint, PadData> dataBuffer;
+	int m_buffer_threshold = 500;
+	std::map<uint, PadData> m_data_buffer;
 };

--- a/pcsx2/Recording/Viewer/RecordingFileGridTable.h
+++ b/pcsx2/Recording/Viewer/RecordingFileGridTable.h
@@ -41,7 +41,7 @@ public:
 	void CloseRecordingFile();
 
 	InputRecordingFileHeader GetRecordingFileHeader();
-	void UpdateRecordingFileHeader(const std::string author, const std::string gameName);
+	void UpdateRecordingFileHeader(const std::string& author, const std::string& gameName);
 
 	long GetUndoCount();
 	void SetUndoCount(long undoCount);
@@ -59,6 +59,7 @@ public:
 	bool IsFromSavestate();
 
 private:
+	int numColumns;
 	int controllerPort = 0;
 	bool changes = false;
 
@@ -88,7 +89,7 @@ private:
 
 	// Cache 1000 rows around current position to enable smooth scrolling / limit file IO
 	int bufferSize = 1000;
-	int bufferPos;
+	int bufferPos = 0;
 	// When we get 500 rows beyond the last bufferPos, evict the cache and update!
 	int bufferThreshold = 500;
 	std::map<uint, PadData> dataBuffer;

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
@@ -64,12 +64,12 @@ void RecordingMetadataDialog::OnConfirm(wxCommandEvent& event)
 
 std::string RecordingMetadataDialog::GetAuthor()
 {
-	return authorField->GetValue();
+	return authorField->GetValue().ToStdString();
 }
 
 std::string RecordingMetadataDialog::GetGameName()
 {
-	return gameNameField->GetValue();
+	return gameNameField->GetValue().ToStdString();
 }
 
 int RecordingMetadataDialog::GetUndoCount()

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
@@ -19,10 +19,9 @@
 
 #include "RecordingMetadataDialog.h"
 
-RecordingMetadataDialog::RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName, int undoCount)
+RecordingMetadataDialog::RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName)
 	: m_author(author)
 	, m_gameName(gameName)
-	, m_undoCount(undoCount)
 	, wxDialog(parent, wxID_ANY, wxString("Change Recording Metadata"))
 {
 	wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
@@ -32,8 +31,6 @@ RecordingMetadataDialog::RecordingMetadataDialog(wxWindow* parent, const std::st
 	authorField = new wxTextCtrl(this, wxID_ANY, m_author);
 	gameNameLabel = new wxStaticText(this, wxID_ANY, _("Game Name"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
 	gameNameField = new wxTextCtrl(this, wxID_ANY, m_gameName);
-	undoCountLabel = new wxStaticText(this, wxID_ANY, _("Undo Count"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
-	undoCountField = new wxSpinCtrl(this, wxID_ANY, wxString::Format(wxT("%i"), m_undoCount), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, LONG_MAX);
 
 	wxBoxSizer* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
 	confirmBtn = new wxButton(this, wxID_OK);
@@ -43,8 +40,6 @@ RecordingMetadataDialog::RecordingMetadataDialog(wxWindow* parent, const std::st
 	widgetSizer->Add(authorField, 0, wxALL, 5);
 	widgetSizer->Add(gameNameLabel, 0, wxALL, 5);
 	widgetSizer->Add(gameNameField, 0, wxALL, 5);
-	widgetSizer->Add(undoCountLabel, 0, wxALL, 5);
-	widgetSizer->Add(undoCountField, 0, wxALL, 5);
 	buttonSizer->Add(confirmBtn, 0, wxALL, 5);
 	buttonSizer->Add(cancelBtn, 0, wxALL, 5);
 	widgetSizer->Add(buttonSizer, 0, wxALL, 5);
@@ -70,9 +65,4 @@ std::string RecordingMetadataDialog::GetAuthor()
 std::string RecordingMetadataDialog::GetGameName()
 {
 	return gameNameField->GetValue().ToStdString();
-}
-
-int RecordingMetadataDialog::GetUndoCount()
-{
-	return undoCountField->GetValue();
 }

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
@@ -1,0 +1,78 @@
+﻿/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include <wx/spinctrl.h>
+
+#include "RecordingMetadataDialog.h"
+
+RecordingMetadataDialog::RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName, int undoCount)
+	: m_author(author)
+	, m_gameName(gameName)
+	, m_undoCount(undoCount)
+	, wxDialog(parent, wxID_ANY, wxString("Change Recording Metadata"))
+{
+	wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* widgetSizer = new wxBoxSizer(wxVERTICAL);
+
+	authorLabel = new wxStaticText(this, wxID_ANY, _("Author"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	authorField = new wxTextCtrl(this, wxID_ANY, m_author);
+	gameNameLabel = new wxStaticText(this, wxID_ANY, _("Game Name"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	gameNameField = new wxTextCtrl(this, wxID_ANY, m_gameName);
+	undoCountLabel = new wxStaticText(this, wxID_ANY, _("Undo Count"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	undoCountField = new wxSpinCtrl(this, wxID_ANY, wxString::Format(wxT("%i"), m_undoCount), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, LONG_MAX);
+
+	wxBoxSizer* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+	confirmBtn = new wxButton(this, wxID_OK);
+	cancelBtn = new wxButton(this, wxID_CLOSE);
+
+	widgetSizer->Add(authorLabel, 0, wxALL, 5);
+	widgetSizer->Add(authorField, 0, wxALL, 5);
+	widgetSizer->Add(gameNameLabel, 0, wxALL, 5);
+	widgetSizer->Add(gameNameField, 0, wxALL, 5);
+	widgetSizer->Add(undoCountLabel, 0, wxALL, 5);
+	widgetSizer->Add(undoCountField, 0, wxALL, 5);
+	buttonSizer->Add(confirmBtn, 0, wxALL, 5);
+	buttonSizer->Add(cancelBtn, 0, wxALL, 5);
+	widgetSizer->Add(buttonSizer, 0, wxALL, 5);
+
+	mainSizer->Add(widgetSizer, 0, wxALL, 20);
+
+	Bind(wxEVT_BUTTON, &RecordingMetadataDialog::OnConfirm, this, confirmBtn->GetId());
+
+	SetSizerAndFit(mainSizer);
+	SetEscapeId(wxID_CLOSE);
+}
+
+void RecordingMetadataDialog::OnConfirm(wxCommandEvent& event)
+{
+	EndModal(wxID_OK);
+}
+
+std::string RecordingMetadataDialog::GetAuthor()
+{
+	return authorField->GetValue();
+}
+
+std::string RecordingMetadataDialog::GetGameName()
+{
+	return gameNameField->GetValue();
+}
+
+int RecordingMetadataDialog::GetUndoCount()
+{
+	return undoCountField->GetValue();
+}

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.cpp
@@ -21,48 +21,48 @@
 
 RecordingMetadataDialog::RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName)
 	: m_author(author)
-	, m_gameName(gameName)
+	, m_game_name(gameName)
 	, wxDialog(parent, wxID_ANY, wxString("Change Recording Metadata"))
 {
-	wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
-	wxBoxSizer* widgetSizer = new wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* widget_sizer = new wxBoxSizer(wxVERTICAL);
 
-	authorLabel = new wxStaticText(this, wxID_ANY, _("Author"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
-	authorField = new wxTextCtrl(this, wxID_ANY, m_author);
+	m_author_label = new wxStaticText(this, wxID_ANY, _("Author"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	m_author_field = new wxTextCtrl(this, wxID_ANY, m_author);
 	gameNameLabel = new wxStaticText(this, wxID_ANY, _("Game Name"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
-	gameNameField = new wxTextCtrl(this, wxID_ANY, m_gameName);
+	m_game_name_field = new wxTextCtrl(this, wxID_ANY, m_game_name);
 
-	wxBoxSizer* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
-	confirmBtn = new wxButton(this, wxID_OK);
-	cancelBtn = new wxButton(this, wxID_CLOSE);
+	wxBoxSizer* button_sizer = new wxBoxSizer(wxHORIZONTAL);
+	m_confirm_btn = new wxButton(this, wxID_OK);
+	m_cancel_btn = new wxButton(this, wxID_CLOSE);
 
-	widgetSizer->Add(authorLabel, 0, wxALL, 5);
-	widgetSizer->Add(authorField, 0, wxALL, 5);
-	widgetSizer->Add(gameNameLabel, 0, wxALL, 5);
-	widgetSizer->Add(gameNameField, 0, wxALL, 5);
-	buttonSizer->Add(confirmBtn, 0, wxALL, 5);
-	buttonSizer->Add(cancelBtn, 0, wxALL, 5);
-	widgetSizer->Add(buttonSizer, 0, wxALL, 5);
+	widget_sizer->Add(m_author_label, 0, wxALL, 5);
+	widget_sizer->Add(m_author_field, 0, wxALL, 5);
+	widget_sizer->Add(gameNameLabel, 0, wxALL, 5);
+	widget_sizer->Add(m_game_name_field, 0, wxALL, 5);
+	button_sizer->Add(m_confirm_btn, 0, wxALL, 5);
+	button_sizer->Add(m_cancel_btn, 0, wxALL, 5);
+	widget_sizer->Add(button_sizer, 0, wxALL, 5);
 
-	mainSizer->Add(widgetSizer, 0, wxALL, 20);
+	main_sizer->Add(widget_sizer, 0, wxALL, 20);
 
-	Bind(wxEVT_BUTTON, &RecordingMetadataDialog::OnConfirm, this, confirmBtn->GetId());
+	Bind(wxEVT_BUTTON, &RecordingMetadataDialog::onConfirm, this, m_confirm_btn->GetId());
 
-	SetSizerAndFit(mainSizer);
+	SetSizerAndFit(main_sizer);
 	SetEscapeId(wxID_CLOSE);
 }
 
-void RecordingMetadataDialog::OnConfirm(wxCommandEvent& event)
+void RecordingMetadataDialog::onConfirm(wxCommandEvent& event)
 {
 	EndModal(wxID_OK);
 }
 
-std::string RecordingMetadataDialog::GetAuthor()
+std::string RecordingMetadataDialog::getAuthor()
 {
-	return authorField->GetValue().ToStdString();
+	return m_author_field->GetValue().ToStdString();
 }
 
-std::string RecordingMetadataDialog::GetGameName()
+std::string RecordingMetadataDialog::getGameName()
 {
-	return gameNameField->GetValue().ToStdString();
+	return m_game_name_field->GetValue().ToStdString();
 }

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.h
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.h
@@ -1,0 +1,50 @@
+﻿/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wx/wx.h>
+
+class RecordingMetadataDialog : public wxDialog
+{
+public:
+	RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName, int undoCount);
+
+	std::string GetAuthor();
+	std::string GetGameName();
+	int GetUndoCount();
+
+	bool Ok() { return ok; }
+
+private:
+	bool ok = false;
+
+	std::string m_author;
+	std::string m_gameName;
+	int m_undoCount;
+
+	wxStaticText* authorLabel;
+	wxStaticText* gameNameLabel;
+	wxStaticText* undoCountLabel;
+
+	wxTextCtrl* authorField;
+	wxTextCtrl* gameNameField;
+	wxSpinCtrl* undoCountField;
+
+	wxButton* confirmBtn;
+	wxButton* cancelBtn;
+
+	void OnConfirm(wxCommandEvent& event);
+};

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.h
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.h
@@ -20,27 +20,27 @@
 class RecordingMetadataDialog : public wxDialog
 {
 public:
-	RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName);
+	RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& game_name);
 
-	std::string GetAuthor();
-	std::string GetGameName();
+	std::string getAuthor();
+	std::string getGameName();
 
-	bool Ok() { return ok; }
+	bool ok() { return m_ok; }
 
 private:
-	bool ok = false;
+	bool m_ok = false;
 
 	std::string m_author;
-	std::string m_gameName;
+	std::string m_game_name;
 
-	wxStaticText* authorLabel;
+	wxStaticText* m_author_label;
 	wxStaticText* gameNameLabel;
 
-	wxTextCtrl* authorField;
-	wxTextCtrl* gameNameField;
+	wxTextCtrl* m_author_field;
+	wxTextCtrl* m_game_name_field;
 
-	wxButton* confirmBtn;
-	wxButton* cancelBtn;
+	wxButton* m_confirm_btn;
+	wxButton* m_cancel_btn;
 
-	void OnConfirm(wxCommandEvent& event);
+	void onConfirm(wxCommandEvent& event);
 };

--- a/pcsx2/Recording/Viewer/RecordingMetadataDialog.h
+++ b/pcsx2/Recording/Viewer/RecordingMetadataDialog.h
@@ -20,11 +20,10 @@
 class RecordingMetadataDialog : public wxDialog
 {
 public:
-	RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName, int undoCount);
+	RecordingMetadataDialog(wxWindow* parent, const std::string& author, const std::string& gameName);
 
 	std::string GetAuthor();
 	std::string GetGameName();
-	int GetUndoCount();
 
 	bool Ok() { return ok; }
 
@@ -33,15 +32,12 @@ private:
 
 	std::string m_author;
 	std::string m_gameName;
-	int m_undoCount;
 
 	wxStaticText* authorLabel;
 	wxStaticText* gameNameLabel;
-	wxStaticText* undoCountLabel;
 
 	wxTextCtrl* authorField;
 	wxTextCtrl* gameNameField;
-	wxSpinCtrl* undoCountField;
 
 	wxButton* confirmBtn;
 	wxButton* cancelBtn;

--- a/pcsx2/Recording/Viewer/RecordingViewerColumn.cpp
+++ b/pcsx2/Recording/Viewer/RecordingViewerColumn.cpp
@@ -1,0 +1,218 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "RecordingViewerColumn.h"
+
+const std::vector<std::string> columnLabels = {
+	"Left\nAnalog X",
+	"Left\nAnalog Y",
+	"Right\nAnalog X",
+	"Right\nAnalog Y",
+	"Square",
+	"Cross",
+	"Circle",
+	"Triangle",
+	"R1",
+	"R2",
+	"L1",
+	"L2",
+	"Left",
+	"Down",
+	"Right",
+	"Up",
+	"R3",
+	"L3",
+	"Select",
+	"Start"};
+
+RecordingViewerColumn::RecordingViewerColumn()
+{
+}
+
+RecordingViewerColumn::RecordingViewerColumn(int internalIndex, bool shown)
+	: internalIndex(internalIndex)
+	, label(columnLabels.at(internalIndex))
+	, shown(shown)
+{
+}
+
+void appendColumn(int internalIndex, std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options)
+{
+	// TODO - AppConfig and .ini system doesn't have an easy way to just use string keys or collections so...another switch it is!
+	// Refactor ALL of this once we have a better config system
+	switch (internalIndex)
+	{
+		case 0:
+			gridColumns[options.ViewerLeftAnalogXIndex] = RecordingViewerColumn(internalIndex, options.ViewerLeftAnalogXShown);
+			break;
+		case 1:
+			gridColumns[options.ViewerLeftAnalogYIndex] = RecordingViewerColumn(internalIndex, options.ViewerLeftAnalogYShown);
+			break;
+		case 2:
+			gridColumns[options.ViewerRightAnalogXIndex] = RecordingViewerColumn(internalIndex, options.ViewerRightAnalogXShown);
+			break;
+		case 3:
+			gridColumns[options.ViewerRightAnalogYIndex] = RecordingViewerColumn(internalIndex, options.ViewerRightAnalogYShown);
+			break;
+		case 4:
+			gridColumns[options.ViewerSquareIndex] = RecordingViewerColumn(internalIndex, options.ViewerSquareShown);
+			break;
+		case 5:
+			gridColumns[options.ViewerCrossIndex] = RecordingViewerColumn(internalIndex, options.ViewerCrossShown);
+			break;
+		case 6:
+			gridColumns[options.ViewerCircleIndex] = RecordingViewerColumn(internalIndex, options.ViewerCircleShown);
+			break;
+		case 7:
+			gridColumns[options.ViewerTriangleIndex] = RecordingViewerColumn(internalIndex, options.ViewerTriangleShown);
+			break;
+		case 8:
+			gridColumns[options.ViewerR1Index] = RecordingViewerColumn(internalIndex, options.ViewerR1Shown);
+			break;
+		case 9:
+			gridColumns[options.ViewerR2Index] = RecordingViewerColumn(internalIndex, options.ViewerR2Shown);
+			break;
+		case 10:
+			gridColumns[options.ViewerL1Index] = RecordingViewerColumn(internalIndex, options.ViewerL1Shown);
+			break;
+		case 11:
+			gridColumns[options.ViewerL2Index] = RecordingViewerColumn(internalIndex, options.ViewerL2Shown);
+			break;
+		case 12:
+			gridColumns[options.ViewerLeftIndex] = RecordingViewerColumn(internalIndex, options.ViewerLeftShown);
+			break;
+		case 13:
+			gridColumns[options.ViewerDownIndex] = RecordingViewerColumn(internalIndex, options.ViewerDownShown);
+			break;
+		case 14:
+			gridColumns[options.ViewerRightIndex] = RecordingViewerColumn(internalIndex, options.ViewerRightShown);
+			break;
+		case 15:
+			gridColumns[options.ViewerUpIndex] = RecordingViewerColumn(internalIndex, options.ViewerUpShown);
+			break;
+		case 16:
+			gridColumns[options.ViewerR3Index] = RecordingViewerColumn(internalIndex, options.ViewerR3Shown);
+			break;
+		case 17:
+			gridColumns[options.ViewerL3Index] = RecordingViewerColumn(internalIndex, options.ViewerL3Shown);
+			break;
+		case 18:
+			gridColumns[options.ViewerSelectIndex] = RecordingViewerColumn(internalIndex, options.ViewerSelectShown);
+			break;
+		case 19:
+			gridColumns[options.ViewerStartIndex] = RecordingViewerColumn(internalIndex, options.ViewerStartShown);
+			break;
+		default:
+			return;
+	}
+}
+
+void saveColumnsToConfig(const std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options)
+{
+	// TODO - AppConfig and .ini system doesn't have an easy way to just use string keys or collections so...another switch it is!
+	// Refactor ALL of this once we have a better config system
+	for (auto& columnEntry : gridColumns)
+	{
+		int columnIndex = columnEntry.first;
+		bool shown = columnEntry.second.shown;
+		switch (columnEntry.second.internalIndex)
+		{
+			case 0:
+				options.ViewerLeftAnalogXIndex = columnIndex;
+				options.ViewerLeftAnalogXShown = shown;
+				break;
+			case 1:
+				options.ViewerLeftAnalogYIndex = columnIndex;
+				options.ViewerLeftAnalogYShown = shown;
+				break;
+			case 2:
+				options.ViewerRightAnalogXIndex = columnIndex;
+				options.ViewerRightAnalogXShown = shown;
+				break;
+			case 3:
+				options.ViewerRightAnalogYIndex = columnIndex;
+				options.ViewerRightAnalogYShown = shown;
+				break;
+			case 4:
+				options.ViewerSquareIndex = columnIndex;
+				options.ViewerSquareShown = shown;
+				break;
+			case 5:
+				options.ViewerCrossIndex = columnIndex;
+				options.ViewerCrossShown = shown;
+				break;
+			case 6:
+				options.ViewerCircleIndex = columnIndex;
+				options.ViewerCircleShown = shown;
+				break;
+			case 7:
+				options.ViewerTriangleIndex = columnIndex;
+				options.ViewerTriangleShown = shown;
+				break;
+			case 8:
+				options.ViewerR1Index = columnIndex;
+				options.ViewerR1Shown = shown;
+				break;
+			case 9:
+				options.ViewerR2Index = columnIndex;
+				options.ViewerR2Shown = shown;
+				break;
+			case 10:
+				options.ViewerL1Index = columnIndex;
+				options.ViewerL1Shown = shown;
+				break;
+			case 11:
+				options.ViewerL2Index = columnIndex;
+				options.ViewerL2Shown = shown;
+				break;
+			case 12:
+				options.ViewerLeftIndex = columnIndex;
+				options.ViewerLeftShown = shown;
+				break;
+			case 13:
+				options.ViewerDownIndex = columnIndex;
+				options.ViewerDownShown = shown;
+				break;
+			case 14:
+				options.ViewerRightIndex = columnIndex;
+				options.ViewerRightShown = shown;
+				break;
+			case 15:
+				options.ViewerUpIndex = columnIndex;
+				options.ViewerUpShown = shown;
+				break;
+			case 16:
+				options.ViewerR3Index = columnIndex;
+				options.ViewerR3Shown = shown;
+				break;
+			case 17:
+				options.ViewerL3Index = columnIndex;
+				options.ViewerL3Shown = shown;
+				break;
+			case 18:
+				options.ViewerSelectIndex = columnIndex;
+				options.ViewerSelectShown = shown;
+				break;
+			case 19:
+				options.ViewerStartIndex = columnIndex;
+				options.ViewerStartShown = shown;
+				break;
+			default:
+				return;
+		}
+	}
+}

--- a/pcsx2/Recording/Viewer/RecordingViewerColumn.cpp
+++ b/pcsx2/Recording/Viewer/RecordingViewerColumn.cpp
@@ -17,7 +17,7 @@
 
 #include "RecordingViewerColumn.h"
 
-const std::vector<std::string> columnLabels = {
+const std::vector<std::string> column_labels = {
 	"Left\nAnalog X",
 	"Left\nAnalog Y",
 	"Right\nAnalog X",
@@ -43,172 +43,172 @@ RecordingViewerColumn::RecordingViewerColumn()
 {
 }
 
-RecordingViewerColumn::RecordingViewerColumn(int internalIndex, bool shown)
-	: internalIndex(internalIndex)
-	, label(columnLabels.at(internalIndex))
-	, shown(shown)
+RecordingViewerColumn::RecordingViewerColumn(int internal_index, bool shown)
+	: m_internal_index(internal_index)
+	, m_label(column_labels.at(internal_index))
+	, m_shown(shown)
 {
 }
 
-void appendColumn(int internalIndex, std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options)
+void appendColumn(int internal_index, std::map<int, RecordingViewerColumn>& grid_columns, AppConfig::InputRecordingOptions& options)
 {
 	// TODO - AppConfig and .ini system doesn't have an easy way to just use string keys or collections so...another switch it is!
 	// Refactor ALL of this once we have a better config system
-	switch (internalIndex)
+	switch (internal_index)
 	{
 		case 0:
-			gridColumns[options.ViewerLeftAnalogXIndex] = RecordingViewerColumn(internalIndex, options.ViewerLeftAnalogXShown);
+			grid_columns[options.ViewerLeftAnalogXIndex] = RecordingViewerColumn(internal_index, options.ViewerLeftAnalogXShown);
 			break;
 		case 1:
-			gridColumns[options.ViewerLeftAnalogYIndex] = RecordingViewerColumn(internalIndex, options.ViewerLeftAnalogYShown);
+			grid_columns[options.ViewerLeftAnalogYIndex] = RecordingViewerColumn(internal_index, options.ViewerLeftAnalogYShown);
 			break;
 		case 2:
-			gridColumns[options.ViewerRightAnalogXIndex] = RecordingViewerColumn(internalIndex, options.ViewerRightAnalogXShown);
+			grid_columns[options.ViewerRightAnalogXIndex] = RecordingViewerColumn(internal_index, options.ViewerRightAnalogXShown);
 			break;
 		case 3:
-			gridColumns[options.ViewerRightAnalogYIndex] = RecordingViewerColumn(internalIndex, options.ViewerRightAnalogYShown);
+			grid_columns[options.ViewerRightAnalogYIndex] = RecordingViewerColumn(internal_index, options.ViewerRightAnalogYShown);
 			break;
 		case 4:
-			gridColumns[options.ViewerSquareIndex] = RecordingViewerColumn(internalIndex, options.ViewerSquareShown);
+			grid_columns[options.ViewerSquareIndex] = RecordingViewerColumn(internal_index, options.ViewerSquareShown);
 			break;
 		case 5:
-			gridColumns[options.ViewerCrossIndex] = RecordingViewerColumn(internalIndex, options.ViewerCrossShown);
+			grid_columns[options.ViewerCrossIndex] = RecordingViewerColumn(internal_index, options.ViewerCrossShown);
 			break;
 		case 6:
-			gridColumns[options.ViewerCircleIndex] = RecordingViewerColumn(internalIndex, options.ViewerCircleShown);
+			grid_columns[options.ViewerCircleIndex] = RecordingViewerColumn(internal_index, options.ViewerCircleShown);
 			break;
 		case 7:
-			gridColumns[options.ViewerTriangleIndex] = RecordingViewerColumn(internalIndex, options.ViewerTriangleShown);
+			grid_columns[options.ViewerTriangleIndex] = RecordingViewerColumn(internal_index, options.ViewerTriangleShown);
 			break;
 		case 8:
-			gridColumns[options.ViewerR1Index] = RecordingViewerColumn(internalIndex, options.ViewerR1Shown);
+			grid_columns[options.ViewerR1Index] = RecordingViewerColumn(internal_index, options.ViewerR1Shown);
 			break;
 		case 9:
-			gridColumns[options.ViewerR2Index] = RecordingViewerColumn(internalIndex, options.ViewerR2Shown);
+			grid_columns[options.ViewerR2Index] = RecordingViewerColumn(internal_index, options.ViewerR2Shown);
 			break;
 		case 10:
-			gridColumns[options.ViewerL1Index] = RecordingViewerColumn(internalIndex, options.ViewerL1Shown);
+			grid_columns[options.ViewerL1Index] = RecordingViewerColumn(internal_index, options.ViewerL1Shown);
 			break;
 		case 11:
-			gridColumns[options.ViewerL2Index] = RecordingViewerColumn(internalIndex, options.ViewerL2Shown);
+			grid_columns[options.ViewerL2Index] = RecordingViewerColumn(internal_index, options.ViewerL2Shown);
 			break;
 		case 12:
-			gridColumns[options.ViewerLeftIndex] = RecordingViewerColumn(internalIndex, options.ViewerLeftShown);
+			grid_columns[options.ViewerLeftIndex] = RecordingViewerColumn(internal_index, options.ViewerLeftShown);
 			break;
 		case 13:
-			gridColumns[options.ViewerDownIndex] = RecordingViewerColumn(internalIndex, options.ViewerDownShown);
+			grid_columns[options.ViewerDownIndex] = RecordingViewerColumn(internal_index, options.ViewerDownShown);
 			break;
 		case 14:
-			gridColumns[options.ViewerRightIndex] = RecordingViewerColumn(internalIndex, options.ViewerRightShown);
+			grid_columns[options.ViewerRightIndex] = RecordingViewerColumn(internal_index, options.ViewerRightShown);
 			break;
 		case 15:
-			gridColumns[options.ViewerUpIndex] = RecordingViewerColumn(internalIndex, options.ViewerUpShown);
+			grid_columns[options.ViewerUpIndex] = RecordingViewerColumn(internal_index, options.ViewerUpShown);
 			break;
 		case 16:
-			gridColumns[options.ViewerR3Index] = RecordingViewerColumn(internalIndex, options.ViewerR3Shown);
+			grid_columns[options.ViewerR3Index] = RecordingViewerColumn(internal_index, options.ViewerR3Shown);
 			break;
 		case 17:
-			gridColumns[options.ViewerL3Index] = RecordingViewerColumn(internalIndex, options.ViewerL3Shown);
+			grid_columns[options.ViewerL3Index] = RecordingViewerColumn(internal_index, options.ViewerL3Shown);
 			break;
 		case 18:
-			gridColumns[options.ViewerSelectIndex] = RecordingViewerColumn(internalIndex, options.ViewerSelectShown);
+			grid_columns[options.ViewerSelectIndex] = RecordingViewerColumn(internal_index, options.ViewerSelectShown);
 			break;
 		case 19:
-			gridColumns[options.ViewerStartIndex] = RecordingViewerColumn(internalIndex, options.ViewerStartShown);
+			grid_columns[options.ViewerStartIndex] = RecordingViewerColumn(internal_index, options.ViewerStartShown);
 			break;
 		default:
 			return;
 	}
 }
 
-void saveColumnsToConfig(const std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options)
+void saveColumnsToConfig(const std::map<int, RecordingViewerColumn>& grid_columns, AppConfig::InputRecordingOptions& options)
 {
 	// TODO - AppConfig and .ini system doesn't have an easy way to just use string keys or collections so...another switch it is!
 	// Refactor ALL of this once we have a better config system
-	for (auto& columnEntry : gridColumns)
+	for (auto& column_entry : grid_columns)
 	{
-		int columnIndex = columnEntry.first;
-		bool shown = columnEntry.second.shown;
-		switch (columnEntry.second.internalIndex)
+		int column_index = column_entry.first;
+		bool shown = column_entry.second.m_shown;
+		switch (column_entry.second.m_internal_index)
 		{
 			case 0:
-				options.ViewerLeftAnalogXIndex = columnIndex;
+				options.ViewerLeftAnalogXIndex = column_index;
 				options.ViewerLeftAnalogXShown = shown;
 				break;
 			case 1:
-				options.ViewerLeftAnalogYIndex = columnIndex;
+				options.ViewerLeftAnalogYIndex = column_index;
 				options.ViewerLeftAnalogYShown = shown;
 				break;
 			case 2:
-				options.ViewerRightAnalogXIndex = columnIndex;
+				options.ViewerRightAnalogXIndex = column_index;
 				options.ViewerRightAnalogXShown = shown;
 				break;
 			case 3:
-				options.ViewerRightAnalogYIndex = columnIndex;
+				options.ViewerRightAnalogYIndex = column_index;
 				options.ViewerRightAnalogYShown = shown;
 				break;
 			case 4:
-				options.ViewerSquareIndex = columnIndex;
+				options.ViewerSquareIndex = column_index;
 				options.ViewerSquareShown = shown;
 				break;
 			case 5:
-				options.ViewerCrossIndex = columnIndex;
+				options.ViewerCrossIndex = column_index;
 				options.ViewerCrossShown = shown;
 				break;
 			case 6:
-				options.ViewerCircleIndex = columnIndex;
+				options.ViewerCircleIndex = column_index;
 				options.ViewerCircleShown = shown;
 				break;
 			case 7:
-				options.ViewerTriangleIndex = columnIndex;
+				options.ViewerTriangleIndex = column_index;
 				options.ViewerTriangleShown = shown;
 				break;
 			case 8:
-				options.ViewerR1Index = columnIndex;
+				options.ViewerR1Index = column_index;
 				options.ViewerR1Shown = shown;
 				break;
 			case 9:
-				options.ViewerR2Index = columnIndex;
+				options.ViewerR2Index = column_index;
 				options.ViewerR2Shown = shown;
 				break;
 			case 10:
-				options.ViewerL1Index = columnIndex;
+				options.ViewerL1Index = column_index;
 				options.ViewerL1Shown = shown;
 				break;
 			case 11:
-				options.ViewerL2Index = columnIndex;
+				options.ViewerL2Index = column_index;
 				options.ViewerL2Shown = shown;
 				break;
 			case 12:
-				options.ViewerLeftIndex = columnIndex;
+				options.ViewerLeftIndex = column_index;
 				options.ViewerLeftShown = shown;
 				break;
 			case 13:
-				options.ViewerDownIndex = columnIndex;
+				options.ViewerDownIndex = column_index;
 				options.ViewerDownShown = shown;
 				break;
 			case 14:
-				options.ViewerRightIndex = columnIndex;
+				options.ViewerRightIndex = column_index;
 				options.ViewerRightShown = shown;
 				break;
 			case 15:
-				options.ViewerUpIndex = columnIndex;
+				options.ViewerUpIndex = column_index;
 				options.ViewerUpShown = shown;
 				break;
 			case 16:
-				options.ViewerR3Index = columnIndex;
+				options.ViewerR3Index = column_index;
 				options.ViewerR3Shown = shown;
 				break;
 			case 17:
-				options.ViewerL3Index = columnIndex;
+				options.ViewerL3Index = column_index;
 				options.ViewerL3Shown = shown;
 				break;
 			case 18:
-				options.ViewerSelectIndex = columnIndex;
+				options.ViewerSelectIndex = column_index;
 				options.ViewerSelectShown = shown;
 				break;
 			case 19:
-				options.ViewerStartIndex = columnIndex;
+				options.ViewerStartIndex = column_index;
 				options.ViewerStartShown = shown;
 				break;
 			default:

--- a/pcsx2/Recording/Viewer/RecordingViewerColumn.h
+++ b/pcsx2/Recording/Viewer/RecordingViewerColumn.h
@@ -1,0 +1,34 @@
+﻿/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <map>
+
+#include <AppConfig.h>
+
+struct RecordingViewerColumn
+{
+	int internalIndex;
+	std::string label;
+	bool shown;
+	RecordingViewerColumn();
+	RecordingViewerColumn(int internalIndex, bool shown);
+};
+
+extern const std::vector<std::string> columnLabels;
+extern void appendColumn(int internalIndex, std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options);
+extern void saveColumnsToConfig(const std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options);

--- a/pcsx2/Recording/Viewer/RecordingViewerColumn.h
+++ b/pcsx2/Recording/Viewer/RecordingViewerColumn.h
@@ -22,13 +22,13 @@
 
 struct RecordingViewerColumn
 {
-	int internalIndex;
-	std::string label;
-	bool shown;
+	int m_internal_index;
+	std::string m_label;
+	bool m_shown;
 	RecordingViewerColumn();
-	RecordingViewerColumn(int internalIndex, bool shown);
+	RecordingViewerColumn(int internal_index, bool shown);
 };
 
-extern const std::vector<std::string> columnLabels;
-extern void appendColumn(int internalIndex, std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options);
-extern void saveColumnsToConfig(const std::map<int, RecordingViewerColumn>& gridColumns, AppConfig::InputRecordingOptions& options);
+extern const std::vector<std::string> column_labels;
+extern void appendColumn(int internal_index, std::map<int, RecordingViewerColumn>& grid_columns, AppConfig::InputRecordingOptions& options);
+extern void saveColumnsToConfig(const std::map<int, RecordingViewerColumn>& grid_columns, AppConfig::InputRecordingOptions& options);

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -30,6 +30,7 @@
 
 #ifndef DISABLE_RECORDING
 #include "Recording/NewRecordingFrame.h"
+#include "Recording/Viewer/InputRecordingViewer.h"
 #endif
 
 class DisassemblyDialog;
@@ -209,6 +210,7 @@ enum MenuIdentifiers
 	MenuId_Recording_ToggleRecordingMode,
 	MenuId_Recording_VirtualPad_Port0,
 	MenuId_Recording_VirtualPad_Port1,
+	MenuId_Recording_Viewer,
 #endif
 
 	// IPC Subsection
@@ -558,6 +560,7 @@ protected:
 
 #ifndef DISABLE_RECORDING
 	wxWindowID m_id_NewRecordingFrame;
+	wxWindowID m_id_RecordingViewerFrame;
 #endif
 
 	wxKeyEvent m_kevt;
@@ -589,6 +592,7 @@ public:
 	{
 		return (NewRecordingFrame*)wxWindow::FindWindowById(m_id_NewRecordingFrame);
 	}
+	InputRecordingViewer* GetRecordingViewerPtr() const { return (InputRecordingViewer*)wxWindow::FindWindowById(m_id_RecordingViewerFrame); }
 #endif
 
 	void enterDebugMode();

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -914,11 +914,46 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 AppConfig::InputRecordingOptions::InputRecordingOptions()
 	: VirtualPadPosition(wxDefaultPosition)
 	, ViewerPosition(wxDefaultPosition)
-	, ViewerShowAnalogSticks(true)
-	, ViewerShowFaceButtons(true)
-	, ViewerShowDirectionalPad(true)
-	, ViewerShowShoulderButtons(true)
-	, ViewerShowMiscButtons(true)
+	, ViewerLeftAnalogXIndex(0)
+	, ViewerLeftAnalogYIndex(1)
+	, ViewerRightAnalogXIndex(2)
+	, ViewerRightAnalogYIndex(3)
+	, ViewerSquareIndex(4)
+	, ViewerCrossIndex(5)
+	, ViewerCircleIndex(6)
+	, ViewerTriangleIndex(7)
+	, ViewerR1Index(8)
+	, ViewerR2Index(9)
+	, ViewerL1Index(10)
+	, ViewerL2Index(11)
+	, ViewerLeftIndex(12)
+	, ViewerDownIndex(13)
+	, ViewerRightIndex(14)
+	, ViewerUpIndex(15)
+	, ViewerR3Index(16)
+	, ViewerL3Index(17)
+	, ViewerSelectIndex(18)
+	, ViewerStartIndex(19)
+	, ViewerLeftAnalogXShown(true)
+	, ViewerLeftAnalogYShown(true)
+	, ViewerRightAnalogXShown(true)
+	, ViewerRightAnalogYShown(true)
+	, ViewerSquareShown(true)
+	, ViewerCrossShown(true)
+	, ViewerCircleShown(true)
+	, ViewerTriangleShown(true)
+	, ViewerR1Shown(true)
+	, ViewerR2Shown(true)
+	, ViewerL1Shown(true)
+	, ViewerL2Shown(true)
+	, ViewerLeftShown(true)
+	, ViewerDownShown(true)
+	, ViewerRightShown(true)
+	, ViewerUpShown(true)
+	, ViewerR3Shown(true)
+	, ViewerL3Shown(true)
+	, ViewerSelectShown(true)
+	, ViewerStartShown(true)
 {
 }
 
@@ -928,11 +963,51 @@ void AppConfig::InputRecordingOptions::loadSave(IniInterface& ini)
 
 	IniEntry(VirtualPadPosition);
 	IniEntry(ViewerPosition);
-	IniEntry(ViewerShowAnalogSticks);
-	IniEntry(ViewerShowFaceButtons);
-	IniEntry(ViewerShowDirectionalPad);
-	IniEntry(ViewerShowShoulderButtons);
-	IniEntry(ViewerShowMiscButtons);
+	// Analog Sticks
+	IniEntry(ViewerLeftAnalogXIndex);
+	IniEntry(ViewerLeftAnalogXShown);
+	IniEntry(ViewerLeftAnalogYIndex);
+	IniEntry(ViewerLeftAnalogYShown);
+	IniEntry(ViewerRightAnalogXIndex);
+	IniEntry(ViewerRightAnalogXShown);
+	IniEntry(ViewerRightAnalogYIndex);
+	IniEntry(ViewerRightAnalogYShown);
+	// Face Buttons
+	IniEntry(ViewerSquareIndex);
+	IniEntry(ViewerSquareShown);
+	IniEntry(ViewerCrossIndex);
+	IniEntry(ViewerCrossShown);
+	IniEntry(ViewerCircleIndex);
+	IniEntry(ViewerCircleShown);
+	IniEntry(ViewerTriangleIndex);
+	IniEntry(ViewerTriangleShown);
+	// Shoulder Buttons
+	IniEntry(ViewerR1Index);
+	IniEntry(ViewerR1Shown);
+	IniEntry(ViewerR2Index);
+	IniEntry(ViewerR2Shown);
+	IniEntry(ViewerL1Index);
+	IniEntry(ViewerL1Shown);
+	IniEntry(ViewerL2Index);
+	IniEntry(ViewerL2Shown);
+	// D-Pad
+	IniEntry(ViewerLeftIndex);
+	IniEntry(ViewerLeftShown);
+	IniEntry(ViewerDownIndex);
+	IniEntry(ViewerDownShown);
+	IniEntry(ViewerRightIndex);
+	IniEntry(ViewerRightShown);
+	IniEntry(ViewerUpIndex);
+	IniEntry(ViewerUpShown);
+	// Misc
+	IniEntry(ViewerR3Index);
+	IniEntry(ViewerR3Shown);
+	IniEntry(ViewerL3Index);
+	IniEntry(ViewerL3Shown);
+	IniEntry(ViewerSelectIndex);
+	IniEntry(ViewerSelectShown);
+	IniEntry(ViewerStartIndex);
+	IniEntry(ViewerStartShown);
 }
 #endif
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -913,6 +913,12 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 #ifndef DISABLE_RECORDING
 AppConfig::InputRecordingOptions::InputRecordingOptions()
 	: VirtualPadPosition(wxDefaultPosition)
+	, ViewerPosition(wxDefaultPosition)
+	, ViewerShowAnalogSticks(true)
+	, ViewerShowFaceButtons(true)
+	, ViewerShowDirectionalPad(true)
+	, ViewerShowShoulderButtons(true)
+	, ViewerShowMiscButtons(true)
 {
 }
 
@@ -921,6 +927,12 @@ void AppConfig::InputRecordingOptions::loadSave(IniInterface& ini)
 	ScopedIniGroup path(ini, L"InputRecording");
 
 	IniEntry(VirtualPadPosition);
+	IniEntry(ViewerPosition);
+	IniEntry(ViewerShowAnalogSticks);
+	IniEntry(ViewerShowFaceButtons);
+	IniEntry(ViewerShowDirectionalPad);
+	IniEntry(ViewerShowShoulderButtons);
+	IniEntry(ViewerShowMiscButtons);
 }
 #endif
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -259,10 +259,16 @@ public:
 #ifndef DISABLE_RECORDING
 	struct InputRecordingOptions
 	{
-		wxPoint		VirtualPadPosition;
+		wxPoint VirtualPadPosition;
+		wxPoint ViewerPosition;
+		bool ViewerShowAnalogSticks;
+		bool ViewerShowFaceButtons;
+		bool ViewerShowDirectionalPad;
+		bool ViewerShowShoulderButtons;
+		bool ViewerShowMiscButtons;
 
 		InputRecordingOptions();
-		void loadSave( IniInterface& conf );
+		void loadSave(IniInterface& conf);
 	};
 #endif
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -261,11 +261,52 @@ public:
 	{
 		wxPoint VirtualPadPosition;
 		wxPoint ViewerPosition;
-		bool ViewerShowAnalogSticks;
-		bool ViewerShowFaceButtons;
-		bool ViewerShowDirectionalPad;
-		bool ViewerShowShoulderButtons;
-		bool ViewerShowMiscButtons;
+		// TODO - YAML - can be simplified to a native map
+		// Analog Sticks
+		int ViewerLeftAnalogXIndex;
+		bool ViewerLeftAnalogXShown;
+		int ViewerLeftAnalogYIndex;
+		bool ViewerLeftAnalogYShown;
+		int ViewerRightAnalogXIndex;
+		bool ViewerRightAnalogXShown;
+		int ViewerRightAnalogYIndex;
+		bool ViewerRightAnalogYShown;
+		// Face Buttons
+		int ViewerSquareIndex;
+		bool ViewerSquareShown;
+		int ViewerCrossIndex;
+		bool ViewerCrossShown;
+		int ViewerCircleIndex;
+		bool ViewerCircleShown;
+		int ViewerTriangleIndex;
+		bool ViewerTriangleShown;
+		// Shoulder Buttons
+		int ViewerR1Index;
+		bool ViewerR1Shown;
+		int ViewerR2Index;
+		bool ViewerR2Shown;
+		int ViewerL1Index;
+		bool ViewerL1Shown;
+		int ViewerL2Index;
+		bool ViewerL2Shown;
+		// D-Pad
+		int ViewerLeftIndex;
+		bool ViewerLeftShown;
+		int ViewerDownIndex;
+		bool ViewerDownShown;
+		int ViewerRightIndex;
+		bool ViewerRightShown;
+		int ViewerUpIndex;
+		bool ViewerUpShown;
+		// Misc
+		int ViewerR3Index;
+		bool ViewerR3Shown;
+		int ViewerL3Index;
+		bool ViewerL3Shown;
+		int ViewerSelectIndex;
+		bool ViewerSelectShown;
+		int ViewerStartIndex;
+		bool ViewerStartShown;
 
 		InputRecordingOptions();
 		void loadSave(IniInterface& conf);

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -28,6 +28,7 @@
 
 #ifndef DISABLE_RECORDING
 #include "Recording/InputRecording.h"
+#include "Recording/Viewer/InputRecordingViewer.h"
 #endif
 
 #include <wx/cmdline.h>
@@ -79,6 +80,9 @@ void Pcsx2App::OpenMainFrame()
 	m_id_Disassembler = disassembly->GetId();
 
 #ifndef DISABLE_RECORDING
+	InputRecordingViewer* recordingViewerFrame = new InputRecordingViewer(mainFrame);
+	m_id_RecordingViewerFrame = recordingViewerFrame->GetId();
+    
 	NewRecordingFrame* newRecordingFrame = new NewRecordingFrame(mainFrame);
 	m_id_NewRecordingFrame = newRecordingFrame->GetId();
 	if (g_Conf->EmuOptions.EnableRecordingTools)

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -80,7 +80,7 @@ void Pcsx2App::OpenMainFrame()
 	m_id_Disassembler = disassembly->GetId();
 
 #ifndef DISABLE_RECORDING
-	InputRecordingViewer* recordingViewerFrame = new InputRecordingViewer(mainFrame);
+	InputRecordingViewer* recordingViewerFrame = new InputRecordingViewer(mainFrame, g_Conf->inputRecording);
 	m_id_RecordingViewerFrame = recordingViewerFrame->GetId();
     
 	NewRecordingFrame* newRecordingFrame = new NewRecordingFrame(mainFrame);

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -322,6 +322,7 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_ToggleRecordingMode_Click, this, MenuId_Recording_ToggleRecordingMode);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port0);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port1);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_Viewer_Open_Click, this, MenuId_Recording_Viewer);
 #endif
 }
 
@@ -543,6 +544,8 @@ void MainEmuFrame::CreateRecordMenu()
 	m_menuRecording.Append(MenuId_Recording_TogglePause, _("Toggle Pause"), _("Pause or resume emulation on the fly."))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_FrameAdvance, _("Frame Advance"), _("Advance emulation forward by a single frame at a time."))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_ToggleRecordingMode, _("Toggle Recording Mode"), _("Save/playback inputs to/from the recording file."))->Enable(false);
+	m_menuRecording.AppendSeparator();
+	m_menuRecording.Append(MenuId_Recording_Viewer, _("Recording Viewer"));
 	m_menuRecording.AppendSeparator();
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port0, _("Virtual Pad (Port 1)"));
 	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port1, _("Virtual Pad (Port 2)"));

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -272,6 +272,7 @@ protected:
 	void Menu_Recording_FrameAdvance_Click(wxCommandEvent& event);
 	void Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent& event);
 	void Menu_Recording_VirtualPad_Open_Click(wxCommandEvent& event);
+	void Menu_Recording_Viewer_Open_Click(wxCommandEvent &event);
 #endif
 
 	void _DoBootCdvd();

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -43,6 +43,7 @@
 #include "Recording/InputRecording.h"
 #include "Recording/InputRecordingControls.h"
 #include "Recording/VirtualPad/VirtualPad.h"
+#include "Recording/Viewer/InputRecordingViewer.h"
 #endif
 
 
@@ -1161,5 +1162,11 @@ void MainEmuFrame::Menu_Recording_ToggleRecordingMode_Click(wxCommandEvent& even
 void MainEmuFrame::Menu_Recording_VirtualPad_Open_Click(wxCommandEvent& event)
 {
 	g_InputRecording.ShowVirtualPad(event.GetId() - MenuId_Recording_VirtualPad_Port0);
+}
+
+void MainEmuFrame::Menu_Recording_Viewer_Open_Click(wxCommandEvent& event)
+{
+	InputRecordingViewer* recordingViewer = wxGetApp().GetRecordingViewerPtr();
+	recordingViewer->Show();
 }
 #endif

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -88,6 +88,7 @@
   <ItemGroup>
     <None Include="..\..\PAD\Windows\Default.ini" />
     <None Include="..\..\Recording\Viewer\RecordingMetadataDialog.h" />
+    <None Include="..\..\Recording\Viewer\RecordingViewerColumn.h" />
     <None Include="..\..\Utilities\folderdesc.txt" />
     <None Include="..\..\Docs\License.txt" />
     <None Include="..\..\x86\microVU_Alloc.inl" />
@@ -345,6 +346,7 @@
     <ClCompile Include="..\..\Recording\Utilities\InputRecordingLogger.cpp" />
     <ClCompile Include="..\..\Recording\Viewer\RecordingFileGridTable.cpp" />
     <ClCompile Include="..\..\Recording\Viewer\RecordingMetadataDialog.cpp" />
+    <ClCompile Include="..\..\Recording\Viewer\RecordingViewerColumn.cpp" />
     <ClCompile Include="..\..\SPU2\DplIIdecoder.cpp" />
     <ClCompile Include="..\..\SPU2\debug.cpp" />
     <ClCompile Include="..\..\SPU2\RegLog.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -87,6 +87,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="..\..\PAD\Windows\Default.ini" />
+    <None Include="..\..\Recording\Viewer\RecordingMetadataDialog.h" />
     <None Include="..\..\Utilities\folderdesc.txt" />
     <None Include="..\..\Docs\License.txt" />
     <None Include="..\..\x86\microVU_Alloc.inl" />
@@ -342,6 +343,8 @@
     <ClCompile Include="..\..\PAD\Windows\WndProcEater.cpp" />
     <ClCompile Include="..\..\PAD\Windows\XInputEnum.cpp" />
     <ClCompile Include="..\..\Recording\Utilities\InputRecordingLogger.cpp" />
+    <ClCompile Include="..\..\Recording\Viewer\RecordingFileGridTable.cpp" />
+    <ClCompile Include="..\..\Recording\Viewer\RecordingMetadataDialog.cpp" />
     <ClCompile Include="..\..\SPU2\DplIIdecoder.cpp" />
     <ClCompile Include="..\..\SPU2\debug.cpp" />
     <ClCompile Include="..\..\SPU2\RegLog.cpp" />
@@ -393,6 +396,7 @@
     <ClCompile Include="..\..\ps2\LegacyDmac.cpp" />
     <ClCompile Include="..\..\ps2\pgif.cpp" />
     <ClCompile Include="..\..\Recording\InputRecordingControls.cpp" />
+    <ClCompile Include="..\..\Recording\Viewer\InputRecordingViewer.cpp" />
     <ClCompile Include="..\..\Recording\VirtualPad\VirtualPad.cpp" />
     <ClCompile Include="..\..\Recording\VirtualPad\VirtualPadData.cpp" />
     <ClCompile Include="..\..\Recording\VirtualPad\VirtualPadResources.cpp" />
@@ -715,6 +719,7 @@
     <ClInclude Include="..\..\PAD\Windows\WindowsMouse.h" />
     <ClInclude Include="..\..\PAD\Windows\WndProcEater.h" />
     <ClInclude Include="..\..\PAD\Windows\XInputEnum.h" />
+    <ClInclude Include="..\..\Recording\Viewer\RecordingFileGridTable.h" />
     <ClInclude Include="..\..\SPU2\Config.h" />
     <ClInclude Include="..\..\SPU2\Global.h" />
     <ClInclude Include="..\..\SPU2\interpolate_table.h" />
@@ -743,6 +748,7 @@
     <ClInclude Include="..\..\Recording\NewRecordingFrame.h" />
     <ClInclude Include="..\..\Recording\InputRecordingFile.h" />
     <ClInclude Include="..\..\Recording\PadData.h" />
+    <ClInclude Include="..\..\Recording\Viewer\InputRecordingViewer.h" />
     <ClInclude Include="..\..\Recording\VirtualPad\VirtualPad.h" />
     <ClInclude Include="..\..\Recording\VirtualPad\VirtualPadData.h" />
     <ClInclude Include="..\..\Recording\VirtualPad\VirtualPadResources.h" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -2361,12 +2361,9 @@
       <Filter>AppHost\Resources</Filter>
     </Manifest>
   </ItemGroup>
-<<<<<<< HEAD
-=======
   <ItemGroup>
     <Image Include="..\..\gui\Resources\NoIcon.png">
       <Filter>AppHost\Resources</Filter>
     </Image>
   </ItemGroup>
->>>>>>> 9fde4768c (input-rec: Create new Viewer/Editor window)
 </Project>

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -300,6 +300,9 @@
     <None Include="..\..\Recording\Viewer\RecordingMetadataDialog.h">
       <Filter>Recording\Viewer</Filter>
     </None>
+    <None Include="..\..\Recording\Viewer\RecordingViewerColumn.h">
+      <Filter>Recording\Viewer</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Patch.cpp">
@@ -1373,6 +1376,9 @@
       <Filter>Recording\Viewer</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Recording\Viewer\RecordingFileGridTable.cpp">
+      <Filter>Recording\Viewer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Recording\Viewer\RecordingViewerColumn.cpp">
       <Filter>Recording\Viewer</Filter>
     </ClCompile>
   </ItemGroup>

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -241,6 +241,9 @@
     <Filter Include="System\Ps2\PAD">
       <UniqueIdentifier>{e1cbcaf6-9f65-4f14-9e89-27dd0f10e047}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Recording\Viewer">
+      <UniqueIdentifier>{7afc0700-53d9-4a76-af60-5eb516e84f0c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Utilities\folderdesc.txt">
@@ -293,6 +296,9 @@
     </None>
     <None Include="..\..\PAD\Windows\Default.ini">
       <Filter>System\Ps2\PAD</Filter>
+    </None>
+    <None Include="..\..\Recording\Viewer\RecordingMetadataDialog.h">
+      <Filter>Recording\Viewer</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>
@@ -1360,6 +1366,15 @@
     <ClCompile Include="..\..\Recording\Utilities\InputRecordingLogger.cpp">
       <Filter>Recording\Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Recording\Viewer\InputRecordingViewer.cpp">
+      <Filter>Recording\Viewer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Recording\Viewer\RecordingMetadataDialog.cpp">
+      <Filter>Recording\Viewer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Recording\Viewer\RecordingFileGridTable.cpp">
+      <Filter>Recording\Viewer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Patch.h">
@@ -2172,6 +2187,12 @@
     <ClInclude Include="..\..\PAD\Windows\resource_pad.h">
       <Filter>System\Ps2\PAD</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Recording\Viewer\InputRecordingViewer.h">
+      <Filter>Recording\Viewer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Recording\Viewer\RecordingFileGridTable.h">
+      <Filter>Recording\Viewer</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\wxResources.rc">
@@ -2334,4 +2355,12 @@
       <Filter>AppHost\Resources</Filter>
     </Manifest>
   </ItemGroup>
+<<<<<<< HEAD
+=======
+  <ItemGroup>
+    <Image Include="..\..\gui\Resources\NoIcon.png">
+      <Filter>AppHost\Resources</Filter>
+    </Image>
+  </ItemGroup>
+>>>>>>> 9fde4768c (input-rec: Create new Viewer/Editor window)
 </Project>


### PR DESCRIPTION
This is the last new GUI window on my list of ideas that input recording needs.  Two reasons for this:
1. It is apparently becoming more and more popular to create TASes (either in full, or partially) by editing the recording data itself, rather than actually "playing" the game.  This new window lays the basic groundwork for doing so, but also a location for future related tooling.
    - ie, you'll find a bunch of currently commented out menu options such as the ability to `export` and `import` frame data / bulk edit rows, etc.  These are all features I plan to follow up on.
2. It serves as a good tool to debug recording file problems / desync / etc.  Up until now I've been manually setting breakpoints or using the very spammy console log source.  In a vast majority of cases, a tool like this would have been _way_ nicer to work with.

![image](https://user-images.githubusercontent.com/13153231/111056725-56e40900-844f-11eb-8abd-5e039389a0e7.png)

### Testing Suggestions
- Make some recordings, ideally large ones to scale test the UI, load it up and try to:
  - Locate expected values
  - edit values / edit metadata (save and reload)
  - When saving make sure the original file isn't ruined (it should also be `.bak`'d if overwritten)
  - Change controller ports
  - Hide columns, these should persist across emulator restarts
- I've created a very basic caching strategy to make the grid not terribly slow.  Currently it will load 1000 frames before and after your current position.  However, if you quickly scroll through a multi-thousand frame recording, expect a bit of tearing (but nothing should break!)