### PR TITLE
Dependencies: Bump {fmt} to `7.1.3`

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -72,18 +72,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Cache Submodules
-        id: cache-submodules
-        uses: actions/cache@v2.1.4
-        with:
-          key: submodules-${{ hashFiles('./.gitmodules') }}
-          path: |
-            ./.git/modules/
-            ./3rdparty/fmt
-            ./3rdparty/xz
-            ./3rdparty/yaml-cpp
-            ./3rdparty/gtest
-
       - name: Checkout Submodules
         if: steps.cache-submodules.outputs.cache-hit != 'true'
         run: git submodule update --init --recursive --jobs 2

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -51,18 +51,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Cache Submodules
-        id: cache-submodules
-        uses: actions/cache@v2.1.4
-        with:
-          key: submodules-${{ hashFiles('./.gitmodules') }}
-          path: |
-            ./.git/modules/
-            ./3rdparty/fmt
-            ./3rdparty/xz
-            ./3rdparty/yaml-cpp
-            ./3rdparty/gtest
-
       - name: Checkout Submodules
         if: steps.cache-submodules.outputs.cache-hit != 'true'
         run: git submodule update --init --recursive --jobs 2

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -257,7 +257,7 @@ if((GCC_VERSION VERSION_EQUAL "9.0" OR GCC_VERSION VERSION_GREATER "9.0") AND GC
     This text being in a compile log in an open issue may cause it to be closed.")
 endif()
 
-find_package(fmt "7.0.3" QUIET)
+find_package(fmt "7.1.3" QUIET)
 if(NOT fmt_FOUND)
     if(EXISTS "${CMAKE_SOURCE_DIR}/3rdparty/fmt/fmt/CMakeLists.txt")
         message(STATUS "No system fmt was found. Using bundled")


### PR DESCRIPTION
Issues have been reported surrounding the `{fmt}` library which seem to be environment specific https://github.com/PCSX2/pcsx2/pull/4295 .  These build errors occurred on the latest version `7.1.3`, and while there are people that have experienced no issues on this version and CI passes, it would be wise for us to keep the submodule up to date to ease troubleshooting.