### PR TITLE
PAD: Add one more byte to umask.

### DIFF
--- a/pcsx2/PAD/Linux/state_management.cpp
+++ b/pcsx2/PAD/Linux/state_management.cpp
@@ -26,7 +26,7 @@ static const u8 queryComb[7] = {0x5A, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00};
 static const u8 queryMode[7] = {0x5A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 static const u8 setNativeMode[7] = {0x5A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5A};
 
-static u8 queryMaskMode[7] = {0x5A, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x5A};
+static u8 queryMaskMode[7] = {0x5A, 0xFF, 0xFF, 0x03, 0x00, 0x00, 0x5A};
 
 static const u8 queryAct[2][7] = {
 	{0x5A, 0x00, 0x00, 0x01, 0x02, 0x00, 0x0A},
@@ -95,7 +95,9 @@ void Pad::reset()
 	memset(this, 0, sizeof(PadFreezeData));
 
 	set_mode(MODE_DIGITAL);
-	umask[0] = umask[1] = 0xFF;
+	umask[0] = 0xFF;
+	umask[1] = 0xFF;
+	umask[2] = 0x03;
 
 	// Sets up vibrate variable.
 	reset_vibrate();
@@ -322,7 +324,7 @@ u8 pad_poll(u8 value)
 				{
 					queryMaskMode[1] = pad->umask[0];
 					queryMaskMode[2] = pad->umask[1];
-					queryMaskMode[3] = 0x03;
+					queryMaskMode[3] = pad->umask[2];
 					// Not entirely sure about this.
 					//queryMaskMode[3] = 0x01 | (pad->mode == MODE_DS2_NATIVE)*2;
 					queryMaskMode[6] = 0x5A;
@@ -461,11 +463,12 @@ u8 pad_poll(u8 value)
 				break;
 
 			case CMD_SET_DS2_NATIVE_MODE:
-				if (query.lastByte == 3 || query.lastByte == 4)
+				if (query.lastByte > 2 && query.lastByte < 6)
 				{
 					pad->umask[query.lastByte - 3] = value;
 				}
-				else if (query.lastByte == 5)
+
+				if (query.lastByte == 5)
 				{
 					if (!(value & 1))
 						pad->set_mode(MODE_DIGITAL);

--- a/pcsx2/PAD/Linux/state_management.h
+++ b/pcsx2/PAD/Linux/state_management.h
@@ -61,7 +61,7 @@ struct PadFreezeData
 	u8 config;
 
 	u8 vibrate[8];
-	u8 umask[2];
+	u8 umask[3];
 
 	// Vibration indices.
 	u8 vibrateI[2];

--- a/pcsx2/PAD/Windows/PAD.cpp
+++ b/pcsx2/PAD/Windows/PAD.cpp
@@ -154,7 +154,7 @@ struct ButtonSum
 	Stick sticks[2];
 };
 
-#define PAD_SAVE_STATE_VERSION 6
+#define PAD_SAVE_STATE_VERSION 5
 
 // Freeze data, for a single pad.  Basically has all pad state that
 // a PS2 can set.

--- a/pcsx2/PAD/Windows/PAD.cpp
+++ b/pcsx2/PAD/Windows/PAD.cpp
@@ -154,7 +154,7 @@ struct ButtonSum
 	Stick sticks[2];
 };
 
-#define PAD_SAVE_STATE_VERSION 5
+#define PAD_SAVE_STATE_VERSION 6
 
 // Freeze data, for a single pad.  Basically has all pad state that
 // a PS2 can set.
@@ -171,7 +171,7 @@ struct PadFreezeData
 	u8 config;
 
 	u8 vibrate[8];
-	u8 umask[2];
+	u8 umask[3];
 
 	// Vibration indices.
 	u8 vibrateI[2];
@@ -813,7 +813,9 @@ void ResetPad(int port, int slot)
 	else
 		pads[port][slot].mode = MODE_DIGITAL;
 
-	pads[port][slot].umask[0] = pads[port][slot].umask[1] = 0xFF;
+	pads[port][slot].umask[0] = 0xFF;
+	pads[port][slot].umask[1] = 0xFF;
+	pads[port][slot].umask[2] = 0x03;
 	// Sets up vibrate variable.
 	ResetVibrate(port, slot);
 	pads[port][slot].initialized = 1;
@@ -1316,7 +1318,7 @@ u8 PADpoll(u8 value)
 				{
 					queryMaskMode[1] = pad->umask[0];
 					queryMaskMode[2] = pad->umask[1];
-					queryMaskMode[3] = 0x03;
+					queryMaskMode[3] = pad->umask[2];
 					// Not entirely sure about this.
 					//queryMaskMode[3] = 0x01 | (pad->mode == MODE_DS2_NATIVE)*2;
 					queryMaskMode[6] = 0x5A;
@@ -1478,7 +1480,7 @@ u8 PADpoll(u8 value)
 				break;
 			// SET_DS2_NATIVE_MODE
 			case 0x4F:
-				if (query.lastByte == 3 || query.lastByte == 4)
+				if (query.lastByte >2 && query.lastByte < 6)
 				{
 					pad->umask[query.lastByte - 3] = value;
 				}

--- a/pcsx2/PAD/Windows/PAD.cpp
+++ b/pcsx2/PAD/Windows/PAD.cpp
@@ -1484,7 +1484,8 @@ u8 PADpoll(u8 value)
 				{
 					pad->umask[query.lastByte - 3] = value;
 				}
-				else if (query.lastByte == 5)
+
+				if (query.lastByte == 5)
 				{
 					if (!(value & 1))
 					{

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A1D << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A1E << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
Seems to be enough to fix Warriors of Might and Magic.
Fixes #4026

Increased savestate version since it changes the size of the PadFreezeData struct.