### PR TITLE
gui: Visually indicate the current savestate slot in the load/save menu

### DIFF
--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -43,7 +43,8 @@ wxMenu* MainEmuFrame::MakeStatesSubMenu(int baseid, int loadBackupId) const
 	for (int i = 0; i < 10; i++)
 	{
 		// Will be changed once an iso is loaded.
-		mnuSubstates->Append(baseid + i + 1, wxsFormat(_("Slot %d"), i));
+		wxMenuItem* m = mnuSubstates->Append(baseid + i + 1, wxsFormat(_("Slot %d"), i), wxEmptyString, wxITEM_CHECK);
+		m->Check(i == 0); // 0 is the default selected slot
 	}
 
 	if (loadBackupId >= 0)

--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -139,20 +139,23 @@ int States_GetCurrentSlot()
 	return StatesC;
 }
 
-void States_SetCurrentSlot(int slot)
+void States_SetCurrentSlot(int slot_num)
 {
-	StatesC = std::min(std::max(slot, 0), StateSlotsCount);
+	StatesC = std::min(std::max(slot_num, 0), StateSlotsCount);
+	for (Saveslot& slot : saveslot_cache)
+	{
+		sMainFrame.CheckMenuItem(slot.load_item_id, slot.slot_num == slot_num);
+		sMainFrame.CheckMenuItem(slot.save_item_id, slot.slot_num == slot_num);
+	}
 	OnSlotChanged();
 }
 
 void States_CycleSlotForward()
 {
-	StatesC = (StatesC + 1) % StateSlotsCount;
-	OnSlotChanged();
+	States_SetCurrentSlot((StatesC + 1) % StateSlotsCount);
 }
 
 void States_CycleSlotBackward()
 {
-	StatesC = (StatesC + StateSlotsCount - 1) % StateSlotsCount;
-	OnSlotChanged();
+	States_SetCurrentSlot((StatesC + StateSlotsCount - 1) % StateSlotsCount);
 }

--- a/pcsx2/gui/Saveslots.h
+++ b/pcsx2/gui/Saveslots.h
@@ -132,6 +132,6 @@ extern void States_DefrostCurrentSlot();
 extern void States_FreezeCurrentSlot();
 extern void States_CycleSlotForward();
 extern void States_CycleSlotBackward();
-extern void States_SetCurrentSlot(int slot);
+extern void States_SetCurrentSlot(int slot_num);
 extern int States_GetCurrentSlot();
 extern void States_updateLoadBackupMenuItem();

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -86,6 +86,7 @@ static void _SaveLoadStuff(bool enabled)
 			slot.crc = ElfCRC;
 
 			sMainFrame.EnableMenuItem(slot.load_item_id, !slot.empty);
+			sMainFrame.CheckMenuItem(slot.load_item_id, slot.slot_num == States_GetCurrentSlot());
 			sMainFrame.SetMenuItemLabel(slot.load_item_id, slot.SlotName());
 			sMainFrame.SetMenuItemLabel(slot.save_item_id, slot.SlotName());
 		}


### PR DESCRIPTION
Resolves https://github.com/PCSX2/pcsx2/issues/4247

Comments on some of the ideas in that issue:
- Changing the active slot via the GUI
  - To me, this can already be accomplished with the current GUI.  If you save or load a savestate, it will switch and make that the active slot.  Having a way to select the active slot first in the GUI, doesn't really solve anything, it just adds an extra step that i think most people would avoid?  (ie. why switch to a slot, then save it, when you could just save it in one step)
- However, I do think it would be cool to retain the select slot between sessions in the config, instead of always defaulting to `0`
  - And agreed, I think having a separate active slot for loading/saving would get too confusing and im not sure what the use-case would be.

![image](https://user-images.githubusercontent.com/13153231/111574316-9fb6fd00-8782-11eb-87a0-27d5209887dd.png)
![image](https://user-images.githubusercontent.com/13153231/111574549-12c07380-8783-11eb-982c-26bfcbaee6d4.png)

fyi @RedDevilus 