### PR TITLE
Change visibility of end of file error

### DIFF
--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -62,7 +62,7 @@ void InputIsoFile::BeginRead2(uint lsn)
 	{
 		// While this usually indicates that the ISO is corrupted, some games do attempt
 		// to read past the end of the disc, so don't error here.
-		DevCon.Warning("isoFile error: Block index is past the end of file! (%u >= %u).", lsn, m_blocks);
+		Console.WriteLn("isoFile error: Block index is past the end of file! (%u >= %u).", lsn, m_blocks);
 		return;
 	}
 


### PR DESCRIPTION
We want this to be visible at all times so ISO damage issues are more visible without enabling advanced logs. Conversely, we don't want this to show up as a big red error, since it is not necessarily a critical error as mentioned in li's comment.