### PR TITLE
gsdx:windows: Fix dialog filename handling

### DIFF
--- a/common/include/PluginCompatibility.h
+++ b/common/include/PluginCompatibility.h
@@ -22,6 +22,14 @@
 #include <cstdio>
 
 #ifdef _WIN32
+inline std::string convert_utf16_to_utf8(const std::wstring& utf16_string)
+{
+    const int size = WideCharToMultiByte(CP_UTF8, 0, utf16_string.c_str(), utf16_string.size(), nullptr, 0, nullptr, nullptr);
+    std::string converted_string(size, 0);
+    WideCharToMultiByte(CP_UTF8, 0, utf16_string.c_str(), utf16_string.size(), converted_string.data(), converted_string.size(), nullptr, nullptr);
+    return converted_string;
+}
+
 inline std::wstring convert_utf8_to_utf16(const std::string &utf8_string)
 {
     int size = MultiByteToWideChar(CP_UTF8, 0, utf8_string.c_str(), -1, nullptr, 0);

--- a/plugins/GSdx/GSCapture.cpp
+++ b/plugins/GSdx/GSCapture.cpp
@@ -424,15 +424,15 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 		const int start = dlg.m_filename.length() - 4;
 		if (start > 0)
 		{
-			std::string test = dlg.m_filename.substr(start);
+			std::wstring test = dlg.m_filename.substr(start);
 			std::transform(test.begin(), test.end(), test.begin(), (char(_cdecl*)(int))tolower);
-			if (test.compare(".avi") != 0)
-				dlg.m_filename += ".avi";
+			if (test.compare(L".avi") != 0)
+				dlg.m_filename += L".avi";
 		}
 		else
-			dlg.m_filename += ".avi";
+			dlg.m_filename += L".avi";
 
-		FILE* test = fopen(dlg.m_filename.c_str(), "w");
+		FILE* test = _wfopen(dlg.m_filename.c_str(), L"w");
 		if (test)
 			fclose(test);
 		else
@@ -507,7 +507,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 	CComQIPtr<IGSSource>(m_src)->DeliverNewSegment();
 
 	m_capturing = true;
-	filename = dlg.m_filename.erase(dlg.m_filename.length() - 3, 3) + "wav";
+	filename = convert_utf16_to_utf8(dlg.m_filename.erase(dlg.m_filename.length() - 3, 3) + L"wav");
 	return true;
 #elif defined(__unix__)
 	// Note I think it doesn't support multiple depth creation

--- a/plugins/GSdx/Window/GSCaptureDlg.h
+++ b/plugins/GSdx/Window/GSCaptureDlg.h
@@ -50,7 +50,7 @@ public:
 
 	int m_width;
 	int m_height;
-	std::string m_filename;
+	std::wstring m_filename;
 	INT_PTR m_colorspace;
 	CComPtr<IBaseFilter> m_enc;
 };

--- a/plugins/GSdx/Window/GSDialog.cpp
+++ b/plugins/GSdx/Window/GSDialog.cpp
@@ -125,9 +125,9 @@ bool GSDialog::OnCommand(HWND hWnd, UINT id, UINT code)
 	return false;
 }
 
-std::string GSDialog::GetText(UINT id)
+std::wstring GSDialog::GetText(UINT id)
 {
-	std::string s;
+	std::wstring s;
 
 	wchar_t* buff = NULL;
 
@@ -137,8 +137,7 @@ std::string GSDialog::GetText(UINT id)
 
 		if(GetDlgItemText(m_hWnd, id, buff, size))
 		{
-			std::wstring tmp(buff);
-			s = std::string(tmp.begin(), tmp.end());
+			s = buff;
 			size = limit;
 		}
 
@@ -150,7 +149,7 @@ std::string GSDialog::GetText(UINT id)
 
 int GSDialog::GetTextAsInt(UINT id)
 {
-	return atoi(GetText(id).c_str());
+	return _wtoi(GetText(id).c_str());
 }
 
 void GSDialog::SetText(UINT id, const wchar_t* str)

--- a/plugins/GSdx/Window/GSDialog.h
+++ b/plugins/GSdx/Window/GSDialog.h
@@ -45,7 +45,7 @@ public:
 
 	INT_PTR DoModal();
 
-	std::string GetText(UINT id);
+	std::wstring GetText(UINT id);
 	int GetTextAsInt(UINT id);
 
 	void SetText(UINT id, const wchar_t* str);

--- a/plugins/GSdx/Window/GSWndWGL.cpp
+++ b/plugins/GSdx/Window/GSWndWGL.cpp
@@ -34,7 +34,7 @@ static void win_error(const wchar_t* msg, bool fatal = true)
 		MessageBox(NULL, msg, L"ERROR", MB_OK | MB_ICONEXCLAMATION);
 		throw GSDXRecoverableError();
 	} else {
-		fprintf(stderr, "ERROR:%s\n", msg);
+		fprintf(stderr, "ERROR:%ls\n", msg);
 	}
 }
 


### PR DESCRIPTION
Changes:
 * Adds a UTF-16 to UTF-8 conversion function on Windows;
 * Handles the shader dialog filenames properly by storing them as UTF-8 in the ini, converting them to/from UTF-16 as necessary, and fixing the buffer overflows that were introduced when GSdx was switched over to Unicode on Windows.

Should fix #4317.