### PR TITLE
Move ISO decompression to a separate thread

### DIFF
--- a/common/include/Utilities/PersistentThread.h
+++ b/common/include/Utilities/PersistentThread.h
@@ -58,6 +58,9 @@ protected:
     virtual void OnThreadCleanup() = 0;
 };
 
+/// Set the name of the current thread
+void SetNameOfCurrentThread(const char* name);
+
 // --------------------------------------------------------------------------------------
 // pxThread - Helper class for the basics of starting/managing persistent threads.
 // --------------------------------------------------------------------------------------
@@ -194,7 +197,7 @@ protected:
     bool _basecancel();
     void _selfRunningTest(const wxChar *name) const;
     void _DoSetThreadName(const wxString &name);
-    void _DoSetThreadName(const char *name);
+    void _DoSetThreadName(const char *name) { SetNameOfCurrentThread(name); }
     void _internal_execute();
     void _try_virtual_invoke(void (pxThread::*method)());
     void _ThreadCleanup();

--- a/common/src/Utilities/Darwin/DarwinThreads.cpp
+++ b/common/src/Utilities/Darwin/DarwinThreads.cpp
@@ -126,7 +126,7 @@ void Threading::pxThread::_platform_specific_OnCleanupInThread()
 }
 
 // name can be up to 16 bytes
-void Threading::pxThread::_DoSetThreadName(const char *name)
+void Threading::SetNameOfCurrentThread(const char *name)
 {
     pthread_setname_np(name);
 }

--- a/common/src/Utilities/Linux/LnxThreads.cpp
+++ b/common/src/Utilities/Linux/LnxThreads.cpp
@@ -118,7 +118,7 @@ void Threading::pxThread::_platform_specific_OnCleanupInThread()
     // Cleanup handles here, which were opened above.
 }
 
-void Threading::pxThread::_DoSetThreadName(const char *name)
+void Threading::SetNameOfCurrentThread(const char *name)
 {
 #if defined(__linux__)
     // Extract of manpage: "The name can be up to 16 bytes long, and should be

--- a/common/src/Utilities/Windows/WinThreads.cpp
+++ b/common/src/Utilities/Windows/WinThreads.cpp
@@ -103,7 +103,7 @@ void Threading::pxThread::_platform_specific_OnCleanupInThread()
     CloseHandle((HANDLE)m_native_handle);
 }
 
-void Threading::pxThread::_DoSetThreadName(const char *name)
+void Threading::SetNameOfCurrentThread(const char *name)
 {
 // This feature needs Windows headers and MSVC's SEH support:
 

--- a/pcsx2/CDVD/ChdFileReader.h
+++ b/pcsx2/CDVD/ChdFileReader.h
@@ -14,10 +14,10 @@
  */
 
 #pragma once
-#include "AsyncFileReader.h"
+#include "ThreadedFileReader.h"
 #include "libchdr/chd.h"
 
-class ChdFileReader : public AsyncFileReader
+class ChdFileReader : public ThreadedFileReader
 {
 	DeclareNoncopyableObject(ChdFileReader);
 
@@ -25,26 +25,17 @@ public:
 	virtual ~ChdFileReader(void) { Close(); };
 
 	static bool CanHandle(const wxString& fileName);
-	bool Open(const wxString& fileName) override;
+	bool Open2(const wxString& fileName) override;
 
-	int ReadSync(void* pBuffer, uint sector, uint count) override;
+	Chunk ChunkForOffset(u64 offset) override;
+	int ReadChunk(void *dst, s64 blockID) override;
 
-	void BeginRead(void* pBuffer, uint sector, uint count) override;
-	int FinishRead(void) override;
-	void CancelRead(void) override{};
-
-	void Close(void) override;
-	void SetBlockSize(uint blocksize);
-	uint GetBlockSize() const;
+	void Close2(void) override;
 	uint GetBlockCount(void) const override;
 	ChdFileReader(void);
 
 private:
 	chd_file* ChdFile;
-	u8* hunk_buffer;
-	u32 sector_size;
-	u32 sector_count;
-	u32 sectors_per_hunk;
-	u32 current_hunk;
-	u32 async_read;
+	u64 file_size;
+	u32 hunk_size;
 };

--- a/pcsx2/CDVD/CsoFileReader.cpp
+++ b/pcsx2/CDVD/CsoFileReader.cpp
@@ -85,9 +85,9 @@ bool CsoFileReader::ValidateHeader(const CsoHeader& hdr)
 	return true;
 }
 
-bool CsoFileReader::Open(const wxString& fileName)
+bool CsoFileReader::Open2(const wxString& fileName)
 {
-	Close();
+	Close2();
 	m_filename = fileName;
 	m_src = PX_fopen_rb(m_filename);
 
@@ -99,7 +99,7 @@ bool CsoFileReader::Open(const wxString& fileName)
 
 	if (!success)
 	{
-		Close();
+		Close2();
 		return false;
 	}
 	return true;
@@ -152,10 +152,6 @@ bool CsoFileReader::InitializeBuffers()
 		m_readBuffer = new u8[m_frameSize + (1 << m_indexShift)];
 	}
 
-	// This is a buffer for the most recently decompressed frame.
-	m_zlibBuffer = new u8[m_frameSize + (1 << m_indexShift)];
-	m_zlibBufferFrame = numFrames;
-
 	const u32 indexSize = numFrames + 1;
 	m_index = new u32[indexSize];
 	if (fread(m_index, sizeof(u32), indexSize, m_src) != indexSize)
@@ -177,12 +173,9 @@ bool CsoFileReader::InitializeBuffers()
 	return true;
 }
 
-void CsoFileReader::Close()
+void CsoFileReader::Close2()
 {
 	m_filename.Empty();
-#if CSO_USE_CHUNKSCACHE
-	m_cache.Clear();
-#endif
 
 	if (m_src)
 	{
@@ -200,11 +193,6 @@ void CsoFileReader::Close()
 		delete[] m_readBuffer;
 		m_readBuffer = NULL;
 	}
-	if (m_zlibBuffer)
-	{
-		delete[] m_zlibBuffer;
-		m_zlibBuffer = NULL;
-	}
 	if (m_index)
 	{
 		delete[] m_index;
@@ -212,68 +200,28 @@ void CsoFileReader::Close()
 	}
 }
 
-int CsoFileReader::ReadSync(void* pBuffer, uint sector, uint count)
+ThreadedFileReader::Chunk CsoFileReader::ChunkForOffset(u64 offset)
 {
-	if (!m_src)
+	Chunk chunk = {0};
+	if (offset >= m_totalSize)
 	{
-		return 0;
+		chunk.chunkID = -1;
 	}
-
-	// Note that, in practice, count will always be 1.  It seems one sector is read
-	// per interrupt, even if multiple are requested by the application.
-
-	u8* dest = (u8*)pBuffer;
-	// We do it this way in case m_blocksize is not well aligned to our frame size.
-	u64 pos = (u64)sector * (u64)m_blocksize;
-	int remaining = count * m_blocksize;
-	int bytes = 0;
-
-	while (remaining > 0)
+	else
 	{
-		int readBytes;
-
-#if CSO_USE_CHUNKSCACHE
-		// Try first to read from the cache.
-		readBytes = m_cache.Read(dest + bytes, pos + bytes, remaining);
-#else
-		readBytes = -1;
-#endif
-		if (readBytes < 0)
-		{
-			readBytes = ReadFromFrame(dest + bytes, pos + bytes, remaining);
-			if (readBytes == 0)
-			{
-				// We hit EOF.
-				break;
-			}
-
-#if CSO_USE_CHUNKSCACHE
-			// Add the bytes into the cache.  We need to allocate a buffer for it.
-			void* cached = malloc(readBytes);
-			memcpy(cached, dest + bytes, readBytes);
-			m_cache.Take(cached, pos + bytes, readBytes, readBytes);
-#endif
-		}
-
-		bytes += readBytes;
-		remaining -= readBytes;
+		chunk.chunkID = offset >> m_frameShift;
+		chunk.length = m_frameSize;
+		chunk.offset = chunk.chunkID << m_frameShift;
 	}
-
-	return bytes;
+	return chunk;
 }
 
-int CsoFileReader::ReadFromFrame(u8* dest, u64 pos, int maxBytes)
+int CsoFileReader::ReadChunk(void *dst, s64 chunkID)
 {
-	if (pos >= m_totalSize)
-	{
-		// Can't read anything passed the end.
-		return 0;
-	}
+	if (chunkID < 0)
+		return -1;
 
-	const u32 frame = (u32)(pos >> m_frameShift);
-	const u32 offset = (u32)(pos - (frame << m_frameShift));
-	// This is how many bytes we will actually be reading from this frame.
-	const u32 bytes = (u32)(std::min(m_blocksize, static_cast<uint>(m_frameSize - offset)));
+	const u32 frame = chunkID;
 
 	// Grab the index data for the frame we're about to read.
 	const bool compressed = (m_index[frame + 0] & 0x80000000) == 0;
@@ -287,77 +235,36 @@ int CsoFileReader::ReadFromFrame(u8* dest, u64 pos, int maxBytes)
 	if (!compressed)
 	{
 		// Just read directly, easy.
-		if (PX_fseeko(m_src, m_dataoffset + frameRawPos + offset, SEEK_SET) != 0)
+		if (PX_fseeko(m_src, frameRawPos, SEEK_SET) != 0)
 		{
 			Console.Error("Unable to seek to uncompressed CSO data.");
 			return 0;
 		}
-		return fread(dest, 1, bytes, m_src);
+		return fread(dst, 1, m_frameSize, m_src);
 	}
 	else
 	{
-		// We don't need to decompress if we already did this same frame last time.
-		if (m_zlibBufferFrame != frame)
+		if (PX_fseeko(m_src, frameRawPos, SEEK_SET) != 0)
 		{
-			if (PX_fseeko(m_src, m_dataoffset + frameRawPos, SEEK_SET) != 0)
-			{
-				Console.Error("Unable to seek to compressed CSO data.");
-				return 0;
-			}
-			// This might be less bytes than frameRawSize in case of padding on the last frame.
-			// This is because the index positions must be aligned.
-			const u32 readRawBytes = fread(m_readBuffer, 1, frameRawSize, m_src);
-			if (!DecompressFrame(frame, readRawBytes))
-			{
-				return 0;
-			}
+			Console.Error("Unable to seek to compressed CSO data.");
+			return 0;
 		}
+		// This might be less bytes than frameRawSize in case of padding on the last frame.
+		// This is because the index positions must be aligned.
+		const u32 readRawBytes = fread(m_readBuffer, 1, frameRawSize, m_src);
 
-		// Now we just copy the offset data from the cache.
-		memcpy(dest, m_zlibBuffer + offset, bytes);
+		m_z_stream->next_in = m_readBuffer;
+		m_z_stream->avail_in = readRawBytes;
+		m_z_stream->next_out = static_cast<Bytef*>(dst);
+		m_z_stream->avail_out = m_frameSize;
+
+		int status = inflate(m_z_stream, Z_FINISH);
+		bool success = status == Z_STREAM_END && m_z_stream->total_out == m_frameSize;
+
+		if (!success)
+			Console.Error("Unable to decompress CSO frame using zlib.");
+		inflateReset(m_z_stream);
+
+		return success ? m_frameSize : 0;
 	}
-
-	return bytes;
-}
-
-bool CsoFileReader::DecompressFrame(u32 frame, u32 readBufferSize)
-{
-	m_z_stream->next_in = m_readBuffer;
-	m_z_stream->avail_in = readBufferSize;
-	m_z_stream->next_out = m_zlibBuffer;
-	m_z_stream->avail_out = m_frameSize;
-
-	int status = inflate(m_z_stream, Z_FINISH);
-	bool success = status == Z_STREAM_END && m_z_stream->total_out == m_frameSize;
-	if (success)
-	{
-		// Our buffer now contains this frame.
-		m_zlibBufferFrame = frame;
-	}
-	else
-	{
-		Console.Error("Unable to decompress CSO frame using zlib.");
-		m_zlibBufferFrame = (u32)-1;
-	}
-
-	inflateReset(m_z_stream);
-	return success;
-}
-
-void CsoFileReader::BeginRead(void* pBuffer, uint sector, uint count)
-{
-	// TODO: No async support yet, implement as sync.
-	m_bytesRead = ReadSync(pBuffer, sector, count);
-}
-
-int CsoFileReader::FinishRead()
-{
-	int res = m_bytesRead;
-	m_bytesRead = -1;
-	return res;
-}
-
-void CsoFileReader::CancelRead()
-{
-	// TODO: No async read support yet.
 }

--- a/pcsx2/CDVD/ThreadedFileReader.cpp
+++ b/pcsx2/CDVD/ThreadedFileReader.cpp
@@ -1,0 +1,360 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "ThreadedFileReader.h"
+
+ThreadedFileReader::ThreadedFileReader()
+{
+	m_readThread = std::thread([](ThreadedFileReader* r){ r->Loop(); }, this);
+}
+
+ThreadedFileReader::~ThreadedFileReader()
+{
+	m_quit = true;
+	(void)std::lock_guard<std::mutex>{m_mtx};
+	m_condition.notify_one();
+	m_readThread.join();
+	for (auto& buffer : m_buffer)
+		if (buffer.ptr)
+			free(buffer.ptr);
+}
+
+size_t ThreadedFileReader::CopyBlocks(void* dst, const void* src, size_t size) const
+{
+	char* cdst = static_cast<char*>(dst);
+	const char* csrc = static_cast<const char*>(src);
+	const char* cend = csrc + size;
+	if (m_internalBlockSize)
+	{
+		for (; csrc < cend; csrc += m_internalBlockSize, cdst += m_blocksize)
+		{
+			memcpy(cdst, csrc, m_blocksize);
+		}
+		return cdst - static_cast<char*>(dst);
+	}
+	else
+	{
+		memcpy(dst, src, size);
+		return size;
+	}
+}
+
+void ThreadedFileReader::Loop()
+{
+	Threading::SetNameOfCurrentThread("ISO Decompress");
+
+	std::unique_lock<std::mutex> lock(m_mtx);
+
+	while (true)
+	{
+		while (!m_requestSize && !m_quit)
+			m_condition.wait(lock);
+
+		if (m_quit)
+			return;
+
+		u64 requestOffset = m_requestOffset;
+		u32 requestSize = m_requestSize;
+		void* ptr = m_requestPtr.load(std::memory_order_relaxed);
+
+		m_running = true;
+		lock.unlock();
+
+		bool ok = true;
+
+		if (ptr)
+		{
+			ok = Decompress(ptr, requestOffset, requestSize);
+		}
+
+		m_requestPtr.store(nullptr, std::memory_order_release);
+		m_condition.notify_one();
+
+		if (ok)
+		{
+			// Readahead
+			Chunk blk = ChunkForOffset(requestOffset + requestSize);
+			if (blk.chunkID >= 0)
+			{
+				(void)GetBlockPtr(blk, true);
+				blk = ChunkForOffset(blk.offset + blk.length);
+				if (blk.chunkID >= 0)
+					(void)GetBlockPtr(blk, true);
+			}
+		}
+
+		lock.lock();
+		if (requestSize == m_requestSize && requestOffset == m_requestOffset && !m_requestPtr)
+		{
+			// If no one's added more work, mark this one as done
+			m_requestSize = 0;
+		}
+
+		m_running = false;
+		m_condition.notify_one(); // For things waiting on m_running == false
+	}
+}
+
+ThreadedFileReader::Buffer* ThreadedFileReader::GetBlockPtr(const Chunk& block, bool isReadahead)
+{
+	for (int i = 0; i < static_cast<int>(ArraySize(m_buffer)); i++)
+	{
+		if (m_buffer[i].valid.load(std::memory_order_acquire) && m_buffer[i].offset == block.offset)
+		{
+			m_nextBuffer = (i + 1) % ArraySize(m_buffer);
+			return m_buffer + i;
+		}
+	}
+
+	Buffer& buf = m_buffer[m_nextBuffer];
+	{
+		// This can be called from both the read thread threads in ReadSync
+		// Calls from ReadSync are done with the lock already held to keep the read thread out
+		// Therefore we should only lock on the read thread
+		std::unique_lock<std::mutex> lock(m_mtx, std::defer_lock);
+		if (std::this_thread::get_id() == m_readThread.get_id())
+			lock.lock();
+		if (buf.size < block.length)
+			buf.ptr = realloc(buf.ptr, block.length);
+		buf.valid.store(false, std::memory_order_relaxed);
+
+	}
+	int size = ReadChunk(buf.ptr, block.chunkID);
+	if (size > 0)
+	{
+		buf.offset = block.offset;
+		buf.size = size;
+		buf.valid.store(true, std::memory_order_release);
+		m_nextBuffer = (m_nextBuffer + 1) % ArraySize(m_buffer);
+		return &buf;
+	}
+	return nullptr;
+}
+
+bool ThreadedFileReader::Decompress(void* target, u64 begin, u32 size)
+{
+	Chunk blk = ChunkForOffset(begin);
+	char* write = static_cast<char*>(target);
+	u32 remaining = size;
+	if (blk.offset != begin)
+	{
+		u32 off = begin - blk.offset;
+		u32 len = std::min(blk.length - off, size);
+		// Partial block
+		if (Buffer* buf = GetBlockPtr(blk))
+		{
+			if (buf->size < blk.length)
+				return false;
+			write += CopyBlocks(write, static_cast<char*>(buf->ptr) + off, len);
+			remaining -= len;
+			blk = ChunkForOffset(blk.offset + blk.length);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	while (blk.length <= remaining)
+	{
+		if (m_requestCancelled.load(std::memory_order_relaxed))
+		{
+			return false;
+		}
+		if (m_internalBlockSize)
+		{
+			if (Buffer* buf = GetBlockPtr(blk))
+			{
+				if (buf->size < blk.length)
+					return false;
+				write += CopyBlocks(write, buf->ptr, blk.length);
+			}
+		}
+		else
+		{
+			int amt = ReadChunk(write, blk.chunkID);
+			if (amt < static_cast<int>(blk.length))
+				return false;
+			write += blk.length;
+		}
+		remaining -= blk.length;
+		blk = ChunkForOffset(blk.offset + blk.length);
+	}
+	if (remaining)
+	{
+		if (Buffer* buf = GetBlockPtr(blk))
+		{
+			if (buf->size < remaining)
+				return false;
+			write += CopyBlocks(write, buf->ptr, remaining);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	m_amtRead += write - static_cast<char*>(target);
+	return true;
+}
+
+bool ThreadedFileReader::TryCachedRead(void*& buffer, u64& offset, u32& size, const std::lock_guard<std::mutex>&)
+{
+	// Run through twice so that if m_buffer[1] contains the first half and m_buffer[0] contains the second half it still works
+	m_amtRead = 0;
+	u64 end = 0;
+	bool allDone = false;
+	for (int i = 0; i < static_cast<int>(ArraySize(m_buffer) * 2); i++)
+	{
+		Buffer& buf = m_buffer[i % ArraySize(m_buffer)];
+		if (!buf.valid.load(std::memory_order_acquire))
+			continue;
+		if (buf.offset <= offset && buf.offset + buf.size > offset)
+		{
+			u32 off = offset - buf.offset;
+			u32 cpysize = std::min(size, buf.size - off);
+			size_t read = CopyBlocks(buffer, static_cast<char*>(buf.ptr) + off, cpysize);
+			m_amtRead += read;
+			size -= cpysize;
+			offset += cpysize;
+			buffer = static_cast<char*>(buffer) + read;
+			if (size == 0)
+				end = buf.offset + buf.size;
+		}
+		// Do buffers contain the current and next block?
+		if (end > 0 && buf.offset == end)
+			allDone = true;
+	}
+	return allDone;
+}
+
+bool ThreadedFileReader::Open(const wxString& fileName)
+{
+	CancelAndWaitUntilStopped();
+	return Open2(fileName);
+}
+
+int ThreadedFileReader::ReadSync(void* pBuffer, uint sector, uint count)
+{
+	u32 blocksize = InternalBlockSize();
+	u64 offset = (u64)sector * (u64)blocksize + m_dataoffset;
+	u32 size = count * blocksize;
+	{
+		std::lock_guard<std::mutex> l(m_mtx);
+		if (TryCachedRead(pBuffer, offset, size, l))
+			return m_amtRead;
+
+		if (size > 0 && !m_running)
+		{
+			// Don't wait for read thread to start back up
+			if (Decompress(pBuffer, offset, size))
+			{
+				offset += size;
+				size = 0;
+			}
+		}
+
+		if (size == 0)
+		{
+			// For readahead
+			m_requestOffset = offset - 1;
+			m_requestSize = 1;
+			m_requestPtr.store(nullptr, std::memory_order_relaxed);
+		}
+		else
+		{
+			m_requestOffset = offset;
+			m_requestSize = size;
+			m_requestPtr.store(pBuffer, std::memory_order_relaxed);
+		}
+		m_requestCancelled.store(false, std::memory_order_relaxed);
+	}
+	m_condition.notify_one();
+	if (size == 0)
+		return m_amtRead;
+	return FinishRead();
+}
+
+void ThreadedFileReader::CancelAndWaitUntilStopped(void)
+{
+	m_requestCancelled.store(true, std::memory_order_relaxed);
+	std::unique_lock<std::mutex> lock(m_mtx);
+	while (m_running)
+		m_condition.wait(lock);
+}
+
+void ThreadedFileReader::BeginRead(void* pBuffer, uint sector, uint count)
+{
+	s32 blocksize = InternalBlockSize();
+	u64 offset = (u64)sector * (u64)blocksize + m_dataoffset;
+	u32 size = count * blocksize;
+	{
+		std::lock_guard<std::mutex> l(m_mtx);
+		if (TryCachedRead(pBuffer, offset, size, l))
+			return;
+		if (size == 0)
+		{
+			// For readahead
+			m_requestOffset = offset - 1;
+			m_requestSize = 1;
+			m_requestPtr.store(nullptr, std::memory_order_relaxed);
+		}
+		else
+		{
+			m_requestOffset = offset;
+			m_requestSize = size;
+			m_requestPtr.store(pBuffer, std::memory_order_relaxed);
+		}
+		m_requestCancelled.store(false, std::memory_order_relaxed);
+	}
+	m_condition.notify_one();
+}
+
+int ThreadedFileReader::FinishRead(void)
+{
+	if (m_requestPtr.load(std::memory_order_acquire) == nullptr)
+		return m_amtRead;
+	std::unique_lock<std::mutex> lock(m_mtx);
+	while (m_requestPtr)
+		m_condition.wait(lock);
+	return m_amtRead;
+}
+
+void ThreadedFileReader::CancelRead(void)
+{
+	if (m_requestPtr.load(std::memory_order_acquire) == nullptr)
+		return;
+	m_requestCancelled.store(true, std::memory_order_release);
+	std::unique_lock<std::mutex> lock(m_mtx);
+	while (m_requestPtr.load(std::memory_order_relaxed))
+		m_condition.wait(lock);
+}
+
+void ThreadedFileReader::Close(void)
+{
+	CancelAndWaitUntilStopped();
+	for (auto& buf : m_buffer)
+		buf.valid.store(false, std::memory_order_relaxed);
+	Close2();
+}
+
+void ThreadedFileReader::SetBlockSize(uint bytes)
+{
+	m_blocksize = bytes;
+}
+
+void ThreadedFileReader::SetDataOffset(int bytes)
+{
+	m_dataoffset = bytes;
+}

--- a/pcsx2/CDVD/ThreadedFileReader.h
+++ b/pcsx2/CDVD/ThreadedFileReader.h
@@ -1,0 +1,121 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "AsyncFileReader.h"
+#include "Utilities/PersistentThread.h"
+
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <condition_variable>
+
+/// A file reader for use with compressed formats
+/// Calls decompression code on a separate thread to make a synchronous decompression API async
+class ThreadedFileReader : public AsyncFileReader
+{
+	ThreadedFileReader(ThreadedFileReader&&) = delete;
+protected:
+	struct Chunk
+	{
+		/// Negative block IDs indicate invalid blocks
+		s64 chunkID;
+		u64 offset;
+		u32 length;
+	};
+
+	/// Set nonzero to separate block size of read blocks from m_blocksize
+	/// Requires that chunk size is a multiple of internal block size
+	/// Use to avoid overrunning stack because PCSX2 likes to allocate 2448-byte buffers
+	int m_internalBlockSize = 0;
+
+	/// Get the block containing the given offset
+	virtual Chunk ChunkForOffset(u64 offset) = 0;
+	/// Synchronously read the given block into `dst`
+	virtual int ReadChunk(void* dst, s64 chunkID) = 0;
+	/// AsyncFileReader open but ThreadedFileReader needs prep work first
+	virtual bool Open2(const wxString& fileName) = 0;
+	/// AsyncFileReader close but ThreadedFileReader needs prep work first
+	virtual void Close2(void) = 0;
+
+	ThreadedFileReader();
+	~ThreadedFileReader();
+
+private:
+	int m_amtRead;
+	/// Pointer to read into
+	/// If null when m_requestSize > 0, indicates a request for readahead only
+	std::atomic<void*> m_requestPtr{nullptr};
+	/// Request offset in (internal block) bytes from the beginning of the file
+	u64 m_requestOffset = 0;
+	/// Request size in (internal block) bytes
+	/// In addition to marking the request size, the loop thread uses this variable to decide whether there's work to do (size of 0 means no work)
+	u32 m_requestSize = 0;
+	/// Used to cancel requests early
+	/// Note: It might take a while for the cancellation request to be noticed, wait until `m_requestPtr` is cleared to ensure it's not being written to
+	std::atomic<bool> m_requestCancelled{false};
+	struct Buffer
+	{
+		void* ptr = nullptr;
+		u64 offset = 0;
+		u32 size = 0;
+		std::atomic<bool> valid{false};
+	};
+	/// 2 buffers for readahead (current block, next block)
+	Buffer m_buffer[2];
+	u32 m_nextBuffer = 0;
+
+	std::thread m_readThread;
+	std::mutex m_mtx;
+	std::condition_variable m_condition;
+	/// True to tell the thread to exit
+	bool m_quit = false;
+	/// True if the thread is currently doing something other than waiting
+	/// View while holding `m_mtx`.  If false, you may touch decompression functions from other threads
+	bool m_running = false;
+
+	/// Get the internal block size
+	u32 InternalBlockSize() const { return m_internalBlockSize ? m_internalBlockSize : m_blocksize; }
+	/// memcpy from internal to external blocks
+	/// `size` is in internal block bytes
+	/// Returns the number of external block bytes copied
+	size_t CopyBlocks(void* dst, const void* src, size_t size) const;
+
+	/// Main loop of read thread
+	void Loop();
+
+	/// Load the given block into one of the `m_buffer` buffers if necessary and return a pointer to its contents if successful
+	/// Writes to `m_status` if `!isReadahead`
+	Buffer* GetBlockPtr(const Chunk& block, bool isReadahead = false);
+	/// Decompress from offset to size into
+	bool Decompress(void* ptr, u64 offset, u32 size);
+	/// Cancel any inflight read and wait until the thread is no longer doing anything
+	void CancelAndWaitUntilStopped(void);
+	/// Attempt to read from the cache
+	/// Adjusts pointer, offset, and size if successful
+	/// Returns true if no additional reads are necessary
+	bool TryCachedRead(void*& buffer, u64& offset, u32& size, const std::lock_guard<std::mutex>&);
+
+public:
+	bool Open(const wxString& fileName) final override;
+	int ReadSync(void* pBuffer, uint sector, uint count) final override;
+	void BeginRead(void* pBuffer, uint sector, uint count) final override;
+	int FinishRead(void) final override;
+	void CancelRead(void) final override;
+	void Close(void) final override;
+	void SetBlockSize(uint bytes) final override;
+	void SetDataOffset(int bytes) final override;
+};

--- a/pcsx2/CDVD/ThreadedFileReader.h
+++ b/pcsx2/CDVD/ThreadedFileReader.h
@@ -71,8 +71,8 @@ private:
 	{
 		void* ptr = nullptr;
 		u64 offset = 0;
-		u32 size = 0;
-		std::atomic<bool> valid{false};
+		std::atomic<u32> size{0};
+		u32 cap = 0;
 	};
 	/// 2 buffers for readahead (current block, next block)
 	Buffer m_buffer[2];
@@ -98,8 +98,7 @@ private:
 	void Loop();
 
 	/// Load the given block into one of the `m_buffer` buffers if necessary and return a pointer to its contents if successful
-	/// Writes to `m_status` if `!isReadahead`
-	Buffer* GetBlockPtr(const Chunk& block, bool isReadahead = false);
+	Buffer* GetBlockPtr(const Chunk& block);
 	/// Decompress from offset to size into
 	bool Decompress(void* ptr, u64 offset, u32 size);
 	/// Cancel any inflight read and wait until the thread is no longer doing anything

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -205,6 +205,7 @@ set(pcsx2CDVDSources
 	CDVD/ChdFileReader.cpp
 	CDVD/CsoFileReader.cpp
 	CDVD/GzippedFileReader.cpp
+	CDVD/ThreadedFileReader.cpp
 	CDVD/IsoFS/IsoFile.cpp
 	CDVD/IsoFS/IsoFSCDVD.cpp
 	CDVD/IsoFS/IsoFS.cpp
@@ -224,6 +225,7 @@ set(pcsx2CDVDHeaders
 	CDVD/ChdFileReader.h
 	CDVD/CsoFileReader.h
 	CDVD/GzippedFileReader.h
+	CDVD/ThreadedFileReader.h
 	CDVD/IsoFileFormats.h
 	CDVD/IsoFS/IsoDirectory.h
 	CDVD/IsoFS/IsoFileDescriptor.h

--- a/pcsx2/gui/Resources/Info.plist.in
+++ b/pcsx2/gui/Resources/Info.plist.in
@@ -9,6 +9,7 @@
 			<array>
 				<string>iso</string>
 				<string>cso</string>
+				<string>chd</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
 			<string>PCSX2.icns</string>

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="CDVD\CsoFileReader.cpp" />
     <ClCompile Include="CDVD\GzippedFileReader.cpp" />
     <ClCompile Include="CDVD\OutputIsoFile.cpp" />
+    <ClCompile Include="CDVD\ThreadedFileReader.cpp" />
     <ClCompile Include="CDVD\Linux\DriveUtility.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -737,6 +738,7 @@
     <ClInclude Include="CDVD\CompressedFileReaderUtils.h" />
     <ClInclude Include="CDVD\CsoFileReader.h" />
     <ClInclude Include="CDVD\GzippedFileReader.h" />
+    <ClInclude Include="CDVD\ThreadedFileReader.h" />
     <ClInclude Include="CDVD\zlib_indexed.h" />
     <ClInclude Include="DebugTools\Breakpoints.h" />
     <ClInclude Include="DebugTools\DebugInterface.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -891,6 +891,9 @@
     <ClCompile Include="DebugTools\MipsStackWalk.cpp">
       <Filter>System\Ps2\Debug</Filter>
     </ClCompile>
+    <ClCompile Include="CDVD\ThreadedFileReader.cpp">
+      <Filter>System\ISO</Filter>
+    </ClCompile>
     <ClCompile Include="CDVD\CsoFileReader.cpp">
       <Filter>System\ISO</Filter>
     </ClCompile>
@@ -1959,6 +1962,9 @@
     </ClInclude>
     <ClInclude Include="DebugTools\MipsStackWalk.h">
       <Filter>System\Ps2\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="CDVD\ThreadedFileReader.h">
+      <Filter>System\ISO</Filter>
     </ClInclude>
     <ClInclude Include="CDVD\CsoFileReader.h">
       <Filter>System\ISO</Filter>


### PR DESCRIPTION
Closes #4319

When loading from a mostly-LZMA CHD (SSD, i7-4980HQ w/ turbo boost off)
Time to play P3FES intro cutscene (disk-heavy, linear, timed with phone stopwatch)
- Uncompressed ISO: 57s
- Async + Readahead: 57s
- Asyncronous: 61s
- Synchronous: 65s

I was expecting hunk size to make more of a difference, but results were about the same for both my default settings (~20kb hunks) chd and max size one (~1mb hunks, chdman refuses to make bigger ones), however this FMV reads 100% linearly, so that might be why.

Also for anyone on slow HDDs, this also means that using compressed formats won't take away your async file reading (previously none of the compressed disk readers used async file APIs.  They still don't but now they don't block the EE thread calling them)