### PR TITLE
msbuild: fix libchdr include directory

### DIFF
--- a/3rdparty/libchdr/libchdr.vcxproj
+++ b/3rdparty/libchdr/libchdr.vcxproj
@@ -54,9 +54,6 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>
-    <PublicIncludeDirectories>$(ProjectDir)/libchdr/include/;$(PublicIncludeDirectories)</PublicIncludeDirectories>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);_7ZIP_ST</PreprocessorDefinitions>

--- a/common/vsprops/3rdpartyDeps.props
+++ b/common/vsprops/3rdpartyDeps.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SvnRootDir)\3rdparty\;$(SvnRootDir)\3rdparty\soundtouch\;$(SolutionDir)\3rdparty\yaml-cpp\yaml-cpp\include\;$(SolutionDir)\3rdparty\fmt\fmt\include\;$(SolutionDir)\3rdparty\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SvnRootDir)\3rdparty\;$(SvnRootDir)\3rdparty\soundtouch\;$(SolutionDir)\3rdparty\yaml-cpp\yaml-cpp\include\;$(SolutionDir)\3rdparty\fmt\fmt\include\;$(SolutionDir)\3rdparty\libchdr\libchdr\include;$(SolutionDir)\3rdparty\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(SvnRootDir)\deps\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
I don't know what PublicIncludeDirectories is, it's not documented anywhere by MS.
Even if it doesn't fix the bot, it's at least consistent now.