### PR TITLE
PAD: Just enable pressure on CMD 0x4F

### DIFF
--- a/pcsx2/PAD/Linux/state_management.cpp
+++ b/pcsx2/PAD/Linux/state_management.cpp
@@ -467,16 +467,7 @@ u8 pad_poll(u8 value)
 				{
 					pad->umask[query.lastByte - 3] = value;
 				}
-
-				if (query.lastByte == 5)
-				{
-					if (!(value & 1))
-						pad->set_mode(MODE_DIGITAL);
-					else if (!(value & 2))
-						pad->set_mode(MODE_ANALOG);
-					else
-						pad->set_mode(MODE_DS2_NATIVE);
-				}
+				pad->set_mode(MODE_DS2_NATIVE);
 				break;
 
 			default:

--- a/pcsx2/PAD/Windows/PAD.cpp
+++ b/pcsx2/PAD/Windows/PAD.cpp
@@ -1484,22 +1484,7 @@ u8 PADpoll(u8 value)
 				{
 					pad->umask[query.lastByte - 3] = value;
 				}
-
-				if (query.lastByte == 5)
-				{
-					if (!(value & 1))
-					{
-						pad->mode = MODE_DIGITAL;
-					}
-					else if (!(value & 2))
-					{
-						pad->mode = MODE_ANALOG;
-					}
-					else
-					{
-						pad->mode = MODE_DS2_NATIVE;
-					}
-				}
+				pad->mode = MODE_DS2_NATIVE;
 				break;
 			default:
 				DEBUG_OUT(0);


### PR DESCRIPTION
Another try into Fix #4026

As far as I know, CMD 0x4F sets response byte masks and pressure mode, DS2 0x79 (includes pressure report, 18 bytes total), without any conditionals which is how I set it up on Pokopom [(code)](https://github.com/KrossX/Pokopom/blob/2f3f6a3b3dd02d73762b1c7badd1d4cae0984103/Pokopom/playstation_dualshock2.cpp#L120). I excluded this change before trying to keep the changes to a minimum as the game seemed to work fine, probably tested the wrong build.

pcsx2.exe build: [pcsx2_1164_pad4F.zip](https://github.com/PCSX2/pcsx2/files/6216352/pcsx2_1164_pad4F.zip)
 