### PR TITLE
ci: Automatically label pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,108 @@
+# Documentation - https://github.com/actions/labeler
+
+# General Labels
+'Build | Project System':
+  - '.github/*'
+  - '.github/**/*'
+  - '*.sln'
+  - '**/*.sln'
+  - '*.vcxproj*'
+  - '**/*.vcxproj*'
+  - 'cmake/*'
+  - 'cmake/**/*'
+  - 'CMakeLists.txt'
+  - '**/CMakeLists.txt'
+  - 'buildbot.xml'
+  - 'build.sh'
+'Dependencies':
+  - '3rdparty/*'
+  - '3rdparty/**/*'
+  - '**/3rdpartyDeps.props'
+  - '.gitmodules'
+'Documentation':
+  - '*.md'
+  - '**/*.md'
+  - '*.pdf'
+  - '**/*.pdf'
+'GUI/WX':
+  - 'pcsx2/gui/*'
+  - 'pcsx2/gui/**/*'
+'GameDB':
+  - '**/GameIndex.*'
+'Installer | Package':
+  - 'nsis/*'
+  - 'nsis/**/*'
+  - 'build.sh'
+
+# Tools / Features
+'Debugger':
+  - 'pcsx2/DebugTools/*'
+  - 'pcsx2/DebugTools/**/*'
+  - 'pcsx2/gui/Debugger/*'
+  - 'pcsx2/gui/Debugger/**/*'
+'IPC':
+  - 'pcsx2/IPC*'
+  - 'pcsx2/**/IPC*'
+'TAS Functionality':
+  - 'pcsx2/Recording/*'
+  - 'pcsx2/Recording/**/*'
+
+# Emulation Components
+'Counters':
+  - 'pcsx2/Counters.*'
+'Vector Units':
+  - 'pcsx2/VU*'
+  - 'pcsx2/**/VU*'
+  - 'pcsx2/*VU*'
+  - 'pcsx2/**/*VU*'
+'VIF':
+  - 'pcsx2/Vif*'
+  - 'pcsx2/**/Vif*'
+  - 'pcsx2/VIF*'
+  - 'pcsx2/**/VIF*'
+
+# GS Related Labels
+'Plugin: GS': # TODO - update after plugin merge
+  - '**/GSdx/*'
+  - '**/GSdx/**'
+'GS: Direct3D':
+  - '**/GSdx/Renderers/DX11/*'
+  - '**/GSdx/Renderers/DX11/**/*'
+'GS: Hardware':
+  - '**/GSdx/Renderers/HW/*'
+  - '**/GSdx/Renderers/HW/**/*'
+'GS: OpenGL':
+  - '**/GSdx/Renderers/OpenGL/*'
+  - '**/GSdx/Renderers/OpenGL/**/*'
+'GS: Texture Cache':
+  - '**/GSdx/Renderers/*TextureCache*.*'
+  - '**/GSdx/Renderers/**/*TextureCache*.*'
+'GS: Software':
+  - '**/GSdx/Renderers/SW/*'
+  - '**/GSdx/Renderers/SW/**/*'
+
+# Other Core Components
+'CDVD':
+  - 'pcsx2/CDVD/*'
+  - 'pcsx2/CDVD/**/*'
+'DEV9':
+  - 'pcsx2/DEV9/*'
+  - 'pcsx2/DEV9/**/*'
+'IPU':
+  - 'pcsx2/IPU/*'
+  - 'pcsx2/IPU/**/*'
+'Memory Card':
+  - 'pcsx2/gui/MemoryCard*'
+  - 'pcsx2/gui/**/MemoryCard*'
+'PAD: Linux/Mac':
+  - 'pcsx2/PAD/Linux/*'
+  - 'pcsx2/PAD/Linux/**/*'
+'PAD: Windows':
+  - 'pcsx2/PAD/Windows/*'
+  - 'pcsx2/PAD/Windows/**/*'
+'SPU2':
+  - 'pcsx2/SPU2/*'
+  - 'pcsx2/SPU2/**/*'
+'USB':
+  - 'pcsx2/USB/*'
+  - 'pcsx2/USB/**/*'

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,15 @@
+# Runs steps to triage an incoming Pull Request, for example - applying labels.
+name: "Pull Request Triage"
+
+on:
+  pull_request_target:
+    branches:
+      - '*'
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
I'm a bit late on this, but with https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/ Github Actions finally has a path forward on doing things that require the repo's write-token on forked pull requests (ie. applying labels).  In the past, this lacking feature made these types of triaging efforts impractical.

I verified this actually works in my fork:
https://github.com/xTVaser/pcsx2-rr/pull/74
And got someone to make a PR to my fork who didn't have write-access:
https://github.com/xTVaser/pcsx2-rr/pull/75

I went through the repo's label list sorting by most-issues and i think i got the majority of the useful ones, but of course this can be iterated on https://github.com/PCSX2/pcsx2/labels?sort=count-desc