### PR TITLE
SPU2: Simplify reset function for sample rate

### DIFF
--- a/pcsx2/Hw.cpp
+++ b/pcsx2/Hw.cpp
@@ -65,12 +65,9 @@ void hwReset()
 	psHu32(DMAC_ENABLEW) = 0x1201;
 	psHu32(DMAC_ENABLER) = 0x1201;
 
-	if ((psxHu32(HW_ICFG) & (1 << 3)))
-	{
-		SPU2ps1reset();
-	}
-
-	SPU2reset();
+	// Sets SPU2 sample rate to PS2 standard (48KHz) whenever emulator is reset.
+	// For PSX mode sample rate setting, see HwWrite.cpp
+	SPU2reset(PS2Modes::PS2);
 
 	sifReset();
 

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -185,7 +185,7 @@ void __fastcall _hwWrite32( u32 mem, u32 value )
 						//pgifInit();
 						psxReset();
 						PSXCLK =  33868800;
-						SPU2ps1reset();
+						SPU2reset(PS2Modes::PSX);
 						setPs1CDVDSpeed(cdvd.Speed);
 						psxHu32(0x1f801450) = 0x8;
 						psxHu32(0x1f801078) = 1;

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -112,13 +112,27 @@ void SPU2writeDMA7Mem(u16* pMem, u32 size)
 	Cores[1].DoDMAwrite(pMem, size);
 }
 
-s32 SPU2reset()
+s32 SPU2reset(PS2Modes isRunningPSXMode)
 {
-	if (SndBuffer::Test() == 0 && SampleRate != 48000)
-	{
-		SampleRate = 48000;
-		SndBuffer::Cleanup();
+	u32 requiredSampleRate = (isRunningPSXMode == PS2Modes::PSX) ? 44100 : 48000;
 
+	if (isRunningPSXMode == PS2Modes::PS2)
+	{
+		memset(spu2regs, 0, 0x010000);
+		memset(_spu2mem, 0, 0x200000);
+		memset(_spu2mem + 0x2800, 7, 0x10); // from BIOS reversal. Locks the voices so they don't run free.
+		memset(_spu2mem + 0xe870, 7, 0x10); // Loop which gets left over by the BIOS, Megaman X7 relies on it being there.
+
+		Spdif.Info = 0; // Reset IRQ Status if it got set in a previously run game
+
+		Cores[0].Init(0);
+		Cores[1].Init(1);
+	}
+
+	if (SampleRate != requiredSampleRate)
+	{
+		SampleRate = requiredSampleRate;
+		SndBuffer::Cleanup();
 		try
 		{
 			SndBuffer::Init();
@@ -130,48 +144,6 @@ s32 SPU2reset()
 			return -1;
 		}
 	}
-	else
-		SampleRate = 48000;
-
-	memset(spu2regs, 0, 0x010000);
-	memset(_spu2mem, 0, 0x200000);
-	memset(_spu2mem + 0x2800, 7, 0x10); // from BIOS reversal. Locks the voices so they don't run free.
-	memset(_spu2mem + 0xe870, 7, 0x10); // Loop which gets left over by the BIOS, Megaman X7 relies on it being there.
-	Spdif.Info = 0; // Reset IRQ Status if it got set in a previously run game
-
-	Cores[0].Init(0);
-	Cores[1].Init(1);
-	return 0;
-}
-
-s32 SPU2ps1reset()
-{
-	printf("RESET PS1 \n");
-
-	if (SndBuffer::Test() == 0 && SampleRate != 44100)
-	{
-		SampleRate = 44100;
-		SndBuffer::Cleanup();
-
-		try
-		{
-			SndBuffer::Init();
-		}
-		catch (std::exception& ex)
-		{
-			fprintf(stderr, "SPU2 Error: Could not initialize device, or something.\nReason: %s", ex.what());
-			SPU2close();
-			return -1;
-		}
-	}
-	else
-		SampleRate = 44100;
-
-	/* memset(spu2regs, 0, 0x010000);
-    memset(_spu2mem, 0, 0x200000);
-    memset(_spu2mem + 0x2800, 7, 0x10); // from BIOS reversal. Locks the voices so they don't run free.
-    Cores[0].Init(0);
-    Cores[1].Init(1);*/
 	return 0;
 }
 
@@ -227,7 +199,7 @@ s32 SPU2init()
 		}
 	}
 
-	SPU2reset();
+	SPU2reset(PS2Modes::PS2);
 
 	DMALogOpen();
 	InitADSR();

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -41,7 +41,21 @@ u32 lClocks = 0;
 void SPU2configure()
 {
 	ScopedCoreThreadPause paused_core;
+
+	SndBuffer::Cleanup();
+
 	configure();
+
+	try
+	{
+		Console.Warning("SPU2: Sound output module reset");
+		SndBuffer::Init();
+	}
+	catch (std::exception& ex)
+	{
+		fprintf(stderr, "SPU2 Error: Could not initialize device, or something.\nReason: %s", ex.what());
+		SPU2close();
+	}
 	paused_core.AllowResume();
 }
 

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -20,9 +20,14 @@
 
 extern Threading::MutexRecursive mtx_SPU2Status;
 
+enum class PS2Modes
+{
+	PS2,
+	PSX,
+};
+
 s32 SPU2init();
-s32 SPU2reset();
-s32 SPU2ps1reset();
+s32 SPU2reset(PS2Modes isRunningPSXMode);
 s32 SPU2open(void* pDsp);
 void SPU2close();
 void SPU2shutdown();


### PR DESCRIPTION
This PR combines the previously separate sample rate functions for PS2 and PSX modes into a single one.