### PR TITLE
ipc: remove possible memory corruption due to strcat on provided pointer

### DIFF
--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -76,17 +76,22 @@ SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot)
 	}
 
 #else
+	char* runtime_dir = nullptr;
 #ifdef __APPLE__
-	char* runtime_dir = std::getenv("TMPDIR");
+	runtime_dir = std::getenv("TMPDIR");
 #else
-	char* runtime_dir = std::getenv("XDG_RUNTIME_DIR");
+	runtime_dir = std::getenv("XDG_RUNTIME_DIR");
 #endif
 	// fallback in case macOS or other OSes don't implement the XDG base
 	// spec
-	if (runtime_dir == NULL)
+	if (runtime_dir == nullptr)
 		m_socket_name = (char*)"/tmp/" IPC_EMULATOR_NAME ".sock";
 	else
-		m_socket_name = strcat(runtime_dir, "/" IPC_EMULATOR_NAME ".sock");
+	{
+		m_socket_name = new char[strlen(runtime_dir) + strlen("/" IPC_EMULATOR_NAME ".sock") + 1];
+		strcpy(m_socket_name, runtime_dir);
+		strcat(m_socket_name, "/" IPC_EMULATOR_NAME ".sock");
+	}
 
 	if (slot != IPC_DEFAULT_SLOT)
 	{

--- a/pcsx2/IPC.cpp
+++ b/pcsx2/IPC.cpp
@@ -93,7 +93,7 @@ SocketIPC::SocketIPC(SysCoreThread* vm, unsigned int slot)
 	}
 
 	if (slot != IPC_DEFAULT_SLOT)
-		m_socket_name += std::to_string(slot);
+		m_socket_name += "." + std::to_string(slot);
 
 	struct sockaddr_un server;
 

--- a/pcsx2/IPC.h
+++ b/pcsx2/IPC.h
@@ -27,6 +27,7 @@
 
 #include "Utilities/PersistentThread.h"
 #include "System/SysThreads.h"
+#include <string>
 #ifdef _WIN32
 #include <WinSock2.h>
 #include <windows.h>
@@ -48,7 +49,7 @@ protected:
 	SOCKET m_msgsock = INVALID_SOCKET;
 #else
 	// absolute path of the socket. Stored in XDG_RUNTIME_DIR, if unset /tmp
-	char* m_socket_name;
+	std::string m_socket_name;
 	int m_sock = 0;
 	// the message socket used in thread's accept().
 	int m_msgsock = 0;


### PR DESCRIPTION
I was using strcat on a getenv pointer which was reused by the system's lib instead of providing a new one.
Because of this behaviour and me mistakenly appending to this pointer, I ended up corrupting the stack if called enough times.
tl;dr: code bad