### PR TITLE
Misc:Debugger: Support write-only GS priv reads

### DIFF
--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -37,6 +37,8 @@ namespace R5900
 	extern const char * const COP2_REG_FP[32];
 	extern const char * const COP2_REG_CTL[32];
 	extern const char * const COP2_VFnames[4];
+	extern const char * const GS_REG_PRIV[19];
+	extern const u32 GS_REG_PRIV_ADDR[19];
 }
 
 namespace R3000A

--- a/pcsx2/DebugTools/DebugInterface.h
+++ b/pcsx2/DebugTools/DebugInterface.h
@@ -17,7 +17,7 @@
 #include "MemoryTypes.h"
 #include "ExpressionParser.h"
 
-enum { EECAT_GPR, EECAT_CP0, EECAT_FPR, EECAT_FCR, EECAT_VU0F, EECAT_VU0I, EECAT_COUNT };
+enum { EECAT_GPR, EECAT_CP0, EECAT_FPR, EECAT_FCR, EECAT_VU0F, EECAT_VU0I, EECAT_GSPRIV, EECAT_COUNT };
 enum { IOPCAT_GPR, IOPCAT_COUNT };
 enum BreakPointCpu
 {

--- a/pcsx2/DebugTools/DisR5900asm.cpp
+++ b/pcsx2/DebugTools/DisR5900asm.cpp
@@ -142,6 +142,19 @@ const char * const COP2_REG_CTL[32] ={
 
 const char * const COP2_VFnames[4] = { "x", "y", "z", "w" };
 
+//gs privileged registers
+const char * const GS_REG_PRIV[19] = {
+	"PMODE","SMODE1","SMODE2","SRFSH","SYNCH1","SYNCH2","SYNCV",
+	"DISPFB1","DISPLAY1","DISPFB2","DISPLAY2","EXTBUF","EXTDATA",
+	"EXTWRITE","BGCOLOR","CSR","IMR","BUSDIR","SIGLBLID",
+};
+
+//gs privileged register addresses relative to 12000000h
+const u32 GS_REG_PRIV_ADDR[19] = {
+	0x00,0x10,0x20,0x30,0x40,0x50,0x60,0x70,0x80,0x90,
+	0xa0,0xb0,0xc0,0xd0,0xE0,0x1000,0x1010,0x1040,0x1080
+};
+
 void P_COP2_Unknown( std::string& output );
 void P_COP2_SPECIAL2( std::string& output );
 void P_COP2_SPECIAL( std::string& output );

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -349,6 +349,11 @@ __fi u64 gsRead64(u32 mem)
 	}
 }
 
+__fi u128 gsNonMirroredRead(u32 mem)
+{
+	return *(u128*)PS2GS_BASE(mem);
+}
+
 void gsIrq() {
 	hwIntcIrq(INTC_GS);
 }

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -435,6 +435,7 @@ extern u8   gsRead8(u32 mem);
 extern u16  gsRead16(u32 mem);
 extern u32  gsRead32(u32 mem);
 extern u64  gsRead64(u32 mem);
+extern u128 gsNonMirroredRead(u32 mem);
 
 void gsIrq();
 


### PR DESCRIPTION
Fixes #4336 

Introduces a new register category based around GS Privileged registers.

- [x] Supports reading
- [x] Supports writing


![](https://user-images.githubusercontent.com/29295048/112870344-1bbb1a00-908c-11eb-9d01-72c1f6f0457f.png)

Note: The memory view still shows the mirrored CSR values and writing to the registers using the memory view does not work.

