### PR TITLE
Spin before sleeping threads to reduce thread sleeps/wakes

### DIFF
--- a/common/build/Utilities/utilities.vcxproj
+++ b/common/build/Utilities/utilities.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="..\..\src\Utilities\Windows\WinMisc.cpp" />
     <ClCompile Include="..\..\src\Utilities\Windows\WinThreads.cpp" />
     <ClCompile Include="..\..\src\Utilities\Mutex.cpp" />
+    <ClCompile Include="..\..\src\Utilities\Misc.cpp" />
     <ClCompile Include="..\..\src\Utilities\RwMutex.cpp" />
     <ClCompile Include="..\..\src\Utilities\Semaphore.cpp" />
     <ClCompile Include="..\..\src\Utilities\ThreadTools.cpp" />

--- a/common/build/Utilities/utilities.vcxproj.filters
+++ b/common/build/Utilities/utilities.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClCompile Include="..\..\src\Utilities\Mutex.cpp">
       <Filter>Source Files\Threading</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Utilities\Misc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Utilities\Semaphore.cpp">
       <Filter>Source Files\Threading</Filter>
     </ClCompile>

--- a/common/include/Utilities/General.h
+++ b/common/include/Utilities/General.h
@@ -15,6 +15,9 @@
 
 #pragma once
 
+#include "Pcsx2Defs.h"
+#include "Pcsx2Types.h"
+
 // This macro is actually useful for about any and every possible application of C++
 // equality operators.
 #define OpEqu(field) (field == right.field)

--- a/common/include/Utilities/General.h
+++ b/common/include/Utilities/General.h
@@ -263,6 +263,11 @@ extern void InitCPUTicks();
 extern u64 GetTickFrequency();
 extern u64 GetCPUTicks();
 extern u64 GetPhysicalMemory();
+/// Spin for a short period of time (call while spinning waiting for a lock)
+/// Returns the approximate number of ns that passed
+extern u32 ShortSpin();
+/// Number of ns to spin for before sleeping a thread
+extern const u32 SPIN_TIME_NS;
 
 extern wxString GetOSVersionString();
 

--- a/common/include/Utilities/Threading.h
+++ b/common/include/Utilities/Threading.h
@@ -253,6 +253,20 @@ public:
     bool WaitWithoutYield(const wxTimeSpan &timeout);
     void WaitNoCancel();
     void WaitNoCancel(const wxTimeSpan &timeout);
+    void WaitWithoutYieldWithSpin()
+    {
+        u32 waited = 0;
+        while (true)
+        {
+            if (TryWait())
+                return;
+            if (waited >= SPIN_TIME_NS)
+                break;
+            waited += ShortSpin();
+        }
+        WaitWithoutYield();
+    }
+    bool TryWait();
     int Count();
 
     void Wait();
@@ -282,6 +296,7 @@ public:
     bool AcquireWithoutYield(const wxTimeSpan &timeout);
 
     void Wait();
+    void WaitWithSpin();
     bool Wait(const wxTimeSpan &timeout);
     void WaitWithoutYield();
     bool WaitWithoutYield(const wxTimeSpan &timeout);

--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UtilitiesSources
 	IniInterface.cpp
 	Linux/LnxHostSys.cpp
 	Mutex.cpp
+	Misc.cpp
 	PathUtils.cpp
 	PrecompiledHeader.cpp
 	Perf.cpp

--- a/common/src/Utilities/Darwin/DarwinSemaphore.cpp
+++ b/common/src/Utilities/Darwin/DarwinSemaphore.cpp
@@ -65,13 +65,12 @@ Threading::Semaphore::Semaphore()
     // other platforms explicitly make a thread-private (unshared) semaphore
     // here. But it seems Mach doesn't support that.
     MACH_CHECK(semaphore_create(mach_task_self(), (semaphore_t *)&m_sema, SYNC_POLICY_FIFO, 0));
-    __atomic_store_n(&m_counter, 0, __ATOMIC_SEQ_CST);
+    __atomic_store_n(&m_counter, 0, __ATOMIC_RELEASE);
 }
 
 Threading::Semaphore::~Semaphore()
 {
     MACH_CHECK(semaphore_destroy(mach_task_self(), (semaphore_t)m_sema));
-    __atomic_store_n(&m_counter, 0, __ATOMIC_SEQ_CST);
 }
 
 void Threading::Semaphore::Reset()
@@ -83,23 +82,22 @@ void Threading::Semaphore::Reset()
 
 void Threading::Semaphore::Post()
 {
-    MACH_CHECK(semaphore_signal(m_sema));
-    __atomic_add_fetch(&m_counter, 1, __ATOMIC_SEQ_CST);
+    if (__atomic_fetch_add(&m_counter, 1, __ATOMIC_RELEASE) < 0)
+        MACH_CHECK(semaphore_signal(m_sema));
 }
 
 void Threading::Semaphore::Post(int multiple)
 {
     for (int i = 0; i < multiple; ++i) {
-        MACH_CHECK(semaphore_signal(m_sema));
+        Post();
     }
-    __atomic_add_fetch(&m_counter, multiple, __ATOMIC_SEQ_CST);
 }
 
 void Threading::Semaphore::WaitWithoutYield()
 {
     pxAssertMsg(!wxThread::IsMain(), "Unyielding semaphore wait issued from the main/gui thread.  Please use Wait() instead.");
-    MACH_CHECK(semaphore_wait(m_sema));
-    __atomic_sub_fetch(&m_counter, 1, __ATOMIC_SEQ_CST);
+    if (__atomic_sub_fetch(&m_counter, 1, __ATOMIC_ACQUIRE) < 0)
+        MACH_CHECK(semaphore_wait(m_sema));
 }
 
 bool Threading::Semaphore::WaitWithoutYield(const wxTimeSpan &timeout)
@@ -110,6 +108,9 @@ bool Threading::Semaphore::WaitWithoutYield(const wxTimeSpan &timeout)
     // signal has worken it up. The best official "documentation" for
     // semaphore_timedwait() is the way it's used in Grand Central Dispatch,
     // which is open-source.
+
+    if (__atomic_sub_fetch(&m_counter, 1, __ATOMIC_ACQUIRE) >= 0)
+        return true;
 
     // on x86 platforms, mach_absolute_time() returns nanoseconds
     // TODO(aktau): on iOS a scale value from mach_timebase_info will be necessary
@@ -122,7 +123,8 @@ bool Threading::Semaphore::WaitWithoutYield(const wxTimeSpan &timeout)
          kr == KERN_ABORTED; now = mach_absolute_time()) {
         if (now > deadline) {
             // timed out by definition
-            return false;
+            kr = KERN_OPERATION_TIMED_OUT;
+            break;
         }
 
         u64 timeleft = deadline - now;
@@ -140,15 +142,20 @@ bool Threading::Semaphore::WaitWithoutYield(const wxTimeSpan &timeout)
     }
 
     if (kr == KERN_OPERATION_TIMED_OUT) {
-        return false;
+        int orig = __atomic_load_n(&m_counter, __ATOMIC_RELAXED);
+        while (orig < 0)
+        {
+            if (__atomic_compare_exchange_n(&m_counter, &orig, orig + 1, true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED))
+                return false;
+        }
+        // Semaphore was signalled between our wait expiring and now, keep kernel sema in sync
+        kr = semaphore_wait(m_sema);
     }
 
     // while it's entirely possible to have KERN_FAILURE here, we should
     // probably assert so we can study and correct the actual error here
     // (the thread dying while someone is wainting for it).
     MACH_CHECK(kr);
-
-    __atomic_sub_fetch(&m_counter, 1, __ATOMIC_SEQ_CST);
     return true;
 }
 
@@ -240,5 +247,5 @@ void Threading::Semaphore::WaitNoCancel(const wxTimeSpan &timeout)
 
 int Threading::Semaphore::Count()
 {
-    return __atomic_load_n(&m_counter, __ATOMIC_SEQ_CST);
+    return __atomic_load_n(&m_counter, __ATOMIC_RELAXED);
 }

--- a/common/src/Utilities/Darwin/DarwinSemaphore.cpp
+++ b/common/src/Utilities/Darwin/DarwinSemaphore.cpp
@@ -216,6 +216,13 @@ bool Threading::Semaphore::Wait(const wxTimeSpan &timeout)
 #endif
 }
 
+bool Threading::Semaphore::TryWait()
+{
+    int counter = __atomic_load_n(&m_counter, __ATOMIC_RELAXED);
+    while (counter > 0 && !__atomic_compare_exchange_n(&m_counter, &counter, counter - 1, true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED));
+    return counter > 0;
+}
+
 // Performs an uncancellable wait on a semaphore; restoring the thread's previous cancel state
 // after the wait has completed.  Useful for situations where the semaphore itself is stored on
 // the stack and passed to another thread via GUI message or such, avoiding complications where

--- a/common/src/Utilities/Misc.cpp
+++ b/common/src/Utilities/Misc.cpp
@@ -1,0 +1,73 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+static u32 PAUSE_TIME = 0;
+
+static void MultiPause()
+{
+	_mm_pause();
+	_mm_pause();
+	_mm_pause();
+	_mm_pause();
+	_mm_pause();
+	_mm_pause();
+	_mm_pause();
+	_mm_pause();
+}
+
+__noinline static void UpdatePauseTime()
+{
+	u64 start = GetCPUTicks();
+	for (int i = 0; i < 64; i++)
+	{
+		MultiPause();
+	}
+	u64 time = GetCPUTicks() - start;
+	u64 nanos = (time * 1000000000) / GetTickFrequency();
+	PAUSE_TIME = (nanos / 64) + 1;
+}
+
+u32 ShortSpin()
+{
+	u32 inc = PAUSE_TIME;
+	if (unlikely(inc == 0))
+	{
+		UpdatePauseTime();
+		inc = PAUSE_TIME;
+	}
+
+	u32 time = 0;
+	// Sleep for approximately 500ns
+	for (; time < 500; time += inc)
+		MultiPause();
+
+	return time;
+}
+
+static u32 GetSpinTime()
+{
+	if (char* req = getenv("WAIT_SPIN_MICROSECONDS"))
+	{
+		return 1000 * atoi(req);
+	}
+	else
+	{
+		return 50 * 1000; // 50µs
+	}
+}
+
+const u32 SPIN_TIME_NS = GetSpinTime();

--- a/common/src/Utilities/Mutex.cpp
+++ b/common/src/Utilities/Mutex.cpp
@@ -252,6 +252,24 @@ void Threading::Mutex::Wait()
     Release();
 }
 
+// Like wait but spins for a while before sleeping the thread
+void Threading::Mutex::WaitWithSpin()
+{
+    u32 waited = 0;
+    while (true)
+    {
+        if (TryAcquire())
+        {
+            Release();
+            return;
+        }
+        if (waited >= SPIN_TIME_NS)
+            break;
+        waited += ShortSpin();
+    }
+    Wait();
+}
+
 void Threading::Mutex::WaitWithoutYield()
 {
     AcquireWithoutYield();

--- a/common/src/Utilities/Semaphore.cpp
+++ b/common/src/Utilities/Semaphore.cpp
@@ -157,6 +157,11 @@ void Threading::Semaphore::WaitNoCancel(const wxTimeSpan &timeout)
     pthread_setcancelstate(oldstate, NULL);
 }
 
+bool Threading::Semaphore::TryWait()
+{
+    return sem_trywait(&m_sema) == 0;
+}
+
 int Threading::Semaphore::Count()
 {
     int retval;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -413,10 +413,13 @@ void SysMtgsThread::ExecuteTaskInThread()
 				{
 					MTVU_LOG("MTGS - Waiting on semaXGkick!");
 					vu1Thread.KickStart(true);
-					busy.PartialRelease();
-					// Wait for MTVU to complete vu1 program
-					vu1Thread.semaXGkick.WaitWithoutYieldWithSpin();
-					busy.PartialAcquire();
+					if (!vu1Thread.semaXGkick.TryWait())
+					{
+						busy.PartialRelease();
+						// Wait for MTVU to complete vu1 program
+						vu1Thread.semaXGkick.WaitWithoutYieldWithSpin();
+						busy.PartialAcquire();
+					}
 					Gif_Path& path = gifUnit.gifPath[GIF_PATH_1];
 					GS_Packet gsPack = path.GetGSPacketMTVU(); // Get vu1 program's xgkick packet(s)
 					if (gsPack.size)

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -290,7 +290,7 @@ void SysMtgsThread::ExecuteTaskInThread()
 		// is very optimized (only 1 instruction test in most cases), so no point in trying
 		// to avoid it.
 
-		m_sem_event.WaitWithoutYield();
+		m_sem_event.WaitWithoutYieldWithSpin();
 		StateCheckInThread();
 		busy.Acquire();
 
@@ -415,7 +415,7 @@ void SysMtgsThread::ExecuteTaskInThread()
 					vu1Thread.KickStart(true);
 					busy.PartialRelease();
 					// Wait for MTVU to complete vu1 program
-					vu1Thread.semaXGkick.WaitWithoutYield();
+					vu1Thread.semaXGkick.WaitWithoutYieldWithSpin();
 					busy.PartialAcquire();
 					Gif_Path& path = gifUnit.gifPath[GIF_PATH_1];
 					GS_Packet gsPack = path.GetGSPacketMTVU(); // Get vu1 program's xgkick packet(s)
@@ -620,9 +620,9 @@ void SysMtgsThread::WaitGS(bool syncRegs, bool weakWait, bool isMTVU)
 		for (;;)
 		{
 			if (weakWait)
-				m_mtx_RingBufferBusy2.Wait();
+				m_mtx_RingBufferBusy2.WaitWithSpin();
 			else
-				m_mtx_RingBufferBusy.Wait();
+				m_mtx_RingBufferBusy.WaitWithSpin();
 			RethrowException();
 			if (!isMTVU && m_ReadPos.load(std::memory_order_relaxed) == m_WritePos.load(std::memory_order_relaxed))
 				break;

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -129,7 +129,7 @@ void VU_Thread::ExecuteRingBuffer()
 {
 	for (;;)
 	{
-		semaEvent.WaitWithoutYield();
+		semaEvent.WaitWithoutYieldWithSpin();
 		ScopedLockBool lock(mtxBusy, isBusy);
 		while (m_ato_read_pos.load(std::memory_order_relaxed) != GetWritePos())
 		{

--- a/plugins/GSdx/CMakeLists.txt
+++ b/plugins/GSdx/CMakeLists.txt
@@ -238,6 +238,7 @@ set(GSdxFinalLibs
     ${PNG_LIBRARIES}
     ${FREETYPE_LIBRARIES}
     ${LIBLZMA_LIBRARIES}
+    Utilities_NO_TLS
 )
 
 if(USE_VTUNE)

--- a/plugins/GSdx/GSThread_CXX11.h
+++ b/plugins/GSdx/GSThread_CXX11.h
@@ -24,6 +24,8 @@
 #include "GSdx.h"
 #include "Utilities/boost_spsc_queue.hpp"
 
+#include "Utilities/General.h"
+
 template<class T, int CAPACITY> class GSJobQueue final
 {
 private:
@@ -51,13 +53,24 @@ private:
 
 			l.unlock();
 
-			while (m_queue.consume_one(*this))
-				;
-
+			uint32 waited = 0;
+			while (true)
 			{
-				std::lock_guard<std::mutex> wait_guard(m_wait_lock);
+				while (m_queue.consume_one(*this))
+					waited = 0;
+
+				if (waited == 0)
+				{
+					{
+						std::lock_guard<std::mutex> wait_guard(m_wait_lock);
+					}
+					m_empty.notify_one();
+				}
+
+				if (waited >= SPIN_TIME_NS)
+					break;
+				waited += ShortSpin();
 			}
-			m_empty.notify_one();
 
 			l.lock();
 		}
@@ -99,8 +112,15 @@ public:
 
 	void Wait()
 	{
-		if (IsEmpty())
-			return;
+		uint32 waited = 0;
+		while (true)
+		{
+			if (IsEmpty())
+				return;
+			if (waited >= SPIN_TIME_NS)
+				break;
+			waited += ShortSpin();
+		}
 
 		std::unique_lock<std::mutex> l(m_wait_lock);
 		while (!IsEmpty())

--- a/plugins/GSdx/stdafx.h
+++ b/plugins/GSdx/stdafx.h
@@ -65,11 +65,7 @@ typedef unsigned int uint32;
 typedef signed int int32;
 typedef unsigned long long uint64;
 typedef signed long long int64;
-#ifdef _M_AMD64
-typedef uint64 uptr;
-#else
-typedef uint32 uptr;
-#endif
+typedef uintptr_t uptr;
 
 
 // xbyak compatibilities


### PR DESCRIPTION
Sleeping and waking a thread with a condition variable is pretty expensive.  [You can benchmark it on your computer with this (may need `-lpthread`)](https://gist.github.com/tellowkrinkle/56591861a014bf1f478132a061749120), it takes about 8µs on the computers I tested

We had a number of places where we could end up with threads constantly sleeping and waking each other with condition variables, most notably in the software renderer when something needed to sync.

Improves speed for games that ran into those situations