### PR TITLE
Replace cached GSOffset with live calculations

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -220,7 +220,9 @@ option(USE_PGO_OPTIMIZE "Enable PGO optimization (use profile)")
 
 # Note1: Builtin strcmp/memcmp was proved to be slower on Mesa than stdlib version.
 # Note2: float operation SSE is impacted by the PCSX2 SSE configuration. In particular, flush to zero denormal.
-if(NOT MSVC)
+if(MSVC)
+	add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/Zc:externConstexpr>")
+else()
 	add_compile_options(-pipe -fvisibility=hidden -pthread -fno-builtin-strcmp -fno-builtin-memcmp -mfpmath=sse -fno-operator-names)
 endif()
 

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -196,16 +196,14 @@ void GSClut::WriteCLUT16S_I4_CSM1(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& T
 template <int n>
 void GSClut::WriteCLUT32_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
-	GSOffset* off = m_mem->GetOffset(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT32);
-
-	uint32* RESTRICT s = &m_mem->m_vm32[off->pixel.row[TEXCLUT.COV]];
-	int* RESTRICT col = &off->pixel.col[0][TEXCLUT.COU << 4];
+	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT32);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
 
 	uint16* RESTRICT clut = m_clut + ((TEX0.CSA & 15) << 4);
 
-	for (int i = 0; i < n; i++)
+	for (int i = 0; i < n; pa.incX(), i++)
 	{
-		uint32 c = s[col[i]];
+		uint32 c = m_mem->m_vm32[pa.value()];
 
 		clut[i] = (uint16)(c & 0xffff);
 		clut[i + 256] = (uint16)(c >> 16);
@@ -215,32 +213,28 @@ void GSClut::WriteCLUT32_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCL
 template <int n>
 void GSClut::WriteCLUT16_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
-	GSOffset* off = m_mem->GetOffset(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16);
-
-	uint16* RESTRICT s = &m_mem->m_vm16[off->pixel.row[TEXCLUT.COV]];
-	int* RESTRICT col = &off->pixel.col[0][TEXCLUT.COU << 4];
+	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
 
 	uint16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
-	for (int i = 0; i < n; i++)
+	for (int i = 0; i < n; pa.incX(), i++)
 	{
-		clut[i] = s[col[i]];
+		clut[i] = m_mem->m_vm16[pa.value()];
 	}
 }
 
 template <int n>
 void GSClut::WriteCLUT16S_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
-	GSOffset* off = m_mem->GetOffset(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16S);
-
-	uint16* RESTRICT s = &m_mem->m_vm16[off->pixel.row[TEXCLUT.COV]];
-	int* RESTRICT col = &off->pixel.col[0][TEXCLUT.COU << 4];
+	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16S);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
 
 	uint16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
-	for (int i = 0; i < n; i++)
+	for (int i = 0; i < n; pa.incX(), i++)
 	{
-		clut[i] = s[col[i]];
+		clut[i] = m_mem->m_vm16[pa.value()];
 	}
 }
 

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -197,14 +197,13 @@ template <int n>
 void GSClut::WriteCLUT32_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT32);
-	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COV);
+	auto pa = off.paMulti(m_mem->m_vm32, TEXCLUT.COU << 4, TEXCLUT.COV);
 
-	int x = TEXCLUT.COU << 4;
 	uint16* RESTRICT clut = m_clut + ((TEX0.CSA & 15) << 4);
 
-	for (int i = 0; i < n; x++, i++)
+	for (int i = 0; i < n; i++)
 	{
-		uint32 c = m_mem->m_vm32[pa.value(x)];
+		uint32 c = *pa.value(i);
 
 		clut[i] = (uint16)(c & 0xffff);
 		clut[i + 256] = (uint16)(c >> 16);
@@ -215,14 +214,13 @@ template <int n>
 void GSClut::WriteCLUT16_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16);
-	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COV);
+	auto pa = off.paMulti(m_mem->m_vm16, TEXCLUT.COU << 4, TEXCLUT.COV);
 
-	int x = TEXCLUT.COU << 4;
 	uint16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
-	for (int i = 0; i < n; x++, i++)
+	for (int i = 0; i < n; i++)
 	{
-		clut[i] = m_mem->m_vm16[pa.value(x)];
+		clut[i] = *pa.value(i);
 	}
 }
 
@@ -230,14 +228,13 @@ template <int n>
 void GSClut::WriteCLUT16S_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16S);
-	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COV);
+	auto pa = off.paMulti(m_mem->m_vm16, TEXCLUT.COU << 4, TEXCLUT.COV);
 
-	int x = TEXCLUT.COU << 4;
 	uint16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
-	for (int i = 0; i < n; x++, i++)
+	for (int i = 0; i < n; i++)
 	{
-		clut[i] = m_mem->m_vm16[pa.value(x)];
+		clut[i] = *pa.value(i);
 	}
 }
 

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -197,13 +197,14 @@ template <int n>
 void GSClut::WriteCLUT32_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT32);
-	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COV);
 
+	int x = TEXCLUT.COU << 4;
 	uint16* RESTRICT clut = m_clut + ((TEX0.CSA & 15) << 4);
 
-	for (int i = 0; i < n; pa.incX(), i++)
+	for (int i = 0; i < n; x++, i++)
 	{
-		uint32 c = m_mem->m_vm32[pa.value()];
+		uint32 c = m_mem->m_vm32[pa.value(x)];
 
 		clut[i] = (uint16)(c & 0xffff);
 		clut[i + 256] = (uint16)(c >> 16);
@@ -214,13 +215,14 @@ template <int n>
 void GSClut::WriteCLUT16_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16);
-	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COV);
 
+	int x = TEXCLUT.COU << 4;
 	uint16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
-	for (int i = 0; i < n; pa.incX(), i++)
+	for (int i = 0; i < n; x++, i++)
 	{
-		clut[i] = m_mem->m_vm16[pa.value()];
+		clut[i] = m_mem->m_vm16[pa.value(x)];
 	}
 }
 
@@ -228,13 +230,14 @@ template <int n>
 void GSClut::WriteCLUT16S_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16S);
-	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COU << 4, TEXCLUT.COV);
+	GSOffset::PAHelper pa = off.paMulti(TEXCLUT.COV);
 
+	int x = TEXCLUT.COU << 4;
 	uint16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
-	for (int i = 0; i < n; pa.incX(), i++)
+	for (int i = 0; i < n; x++, i++)
 	{
-		clut[i] = m_mem->m_vm16[pa.value()];
+		clut[i] = m_mem->m_vm16[pa.value(x)];
 	}
 }
 

--- a/pcsx2/GS/GSDrawingContext.h
+++ b/pcsx2/GS/GSDrawingContext.h
@@ -48,9 +48,9 @@ public:
 
 	struct
 	{
-		GSOffset* fb;
-		GSOffset* zb;
-		GSOffset* tex;
+		GSOffset fb;
+		GSOffset zb;
+		GSOffset tex;
 		GSPixelOffset* fzb;
 		GSPixelOffset4* fzb4;
 	} offset;

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -211,8 +211,7 @@ GSLocalMemory::GSLocalMemory()
 
 	for (size_t i = 0; i < countof(m_psm); i++)
 	{
-		m_psm[i].pa = &GSLocalMemory::PixelAddress32;
-		m_psm[i].bn = &GSLocalMemory::BlockNumber32;
+		m_psm[i].info = GSLocalMemory::swizzle32;
 		m_psm[i].rp = &GSLocalMemory::ReadPixel32;
 		m_psm[i].rpa = &GSLocalMemory::ReadPixel32;
 		m_psm[i].wp = &GSLocalMemory::WritePixel32;
@@ -237,25 +236,15 @@ GSLocalMemory::GSLocalMemory()
 		m_psm[i].depth = 0;
 	}
 
-	m_psm[PSM_PSGPU24].pa = &GSLocalMemory::PixelAddress16;
-	m_psm[PSM_PSMCT16].pa = &GSLocalMemory::PixelAddress16;
-	m_psm[PSM_PSMCT16S].pa = &GSLocalMemory::PixelAddress16S;
-	m_psm[PSM_PSMT8].pa = &GSLocalMemory::PixelAddress8;
-	m_psm[PSM_PSMT4].pa = &GSLocalMemory::PixelAddress4;
-	m_psm[PSM_PSMZ32].pa = &GSLocalMemory::PixelAddress32Z;
-	m_psm[PSM_PSMZ24].pa = &GSLocalMemory::PixelAddress32Z;
-	m_psm[PSM_PSMZ16].pa = &GSLocalMemory::PixelAddress16Z;
-	m_psm[PSM_PSMZ16S].pa = &GSLocalMemory::PixelAddress16SZ;
-
-	m_psm[PSM_PSGPU24].bn = &GSLocalMemory::BlockNumber16;
-	m_psm[PSM_PSMCT16].bn = &GSLocalMemory::BlockNumber16;
-	m_psm[PSM_PSMCT16S].bn = &GSLocalMemory::BlockNumber16S;
-	m_psm[PSM_PSMT8].bn = &GSLocalMemory::BlockNumber8;
-	m_psm[PSM_PSMT4].bn = &GSLocalMemory::BlockNumber4;
-	m_psm[PSM_PSMZ32].bn = &GSLocalMemory::BlockNumber32Z;
-	m_psm[PSM_PSMZ24].bn = &GSLocalMemory::BlockNumber32Z;
-	m_psm[PSM_PSMZ16].bn = &GSLocalMemory::BlockNumber16Z;
-	m_psm[PSM_PSMZ16S].bn = &GSLocalMemory::BlockNumber16SZ;
+	m_psm[PSM_PSGPU24].info = GSLocalMemory::swizzle16;
+	m_psm[PSM_PSMCT16].info = GSLocalMemory::swizzle16;
+	m_psm[PSM_PSMCT16S].info = GSLocalMemory::swizzle16S;
+	m_psm[PSM_PSMT8].info = GSLocalMemory::swizzle8;
+	m_psm[PSM_PSMT4].info = GSLocalMemory::swizzle4;
+	m_psm[PSM_PSMZ32].info = GSLocalMemory::swizzle32Z;
+	m_psm[PSM_PSMZ24].info = GSLocalMemory::swizzle32Z;
+	m_psm[PSM_PSMZ16].info = GSLocalMemory::swizzle16Z;
+	m_psm[PSM_PSMZ16S].info = GSLocalMemory::swizzle16SZ;
 
 	m_psm[PSM_PSMCT24].rp = &GSLocalMemory::ReadPixel24;
 	m_psm[PSM_PSMCT16].rp = &GSLocalMemory::ReadPixel16;
@@ -549,16 +538,13 @@ GSPixelOffset* GSLocalMemory::GetPixelOffset(const GIFRegFRAME& FRAME, const GIF
 	off->zpsm = zpsm;
 	off->bw = bw;
 
-	pixelAddress fpa = m_psm[fpsm].pa;
-	pixelAddress zpa = m_psm[zpsm].pa;
-
 	int fs = m_psm[fpsm].bpp >> 5;
 	int zs = m_psm[zpsm].bpp >> 5;
 
 	for (int i = 0; i < 2048; i++)
 	{
-		off->row[i].x = (int)fpa(0, i, fbp, bw) << fs;
-		off->row[i].y = (int)zpa(0, i, zbp, bw) << zs;
+		off->row[i].x = (int)m_psm[fpsm].info.pa(0, i, fbp, bw) << fs;
+		off->row[i].y = (int)m_psm[zpsm].info.pa(0, i, zbp, bw) << zs;
 	}
 
 	for (int i = 0; i < 2048; i++)
@@ -605,16 +591,13 @@ GSPixelOffset4* GSLocalMemory::GetPixelOffset4(const GIFRegFRAME& FRAME, const G
 	off->zpsm = zpsm;
 	off->bw = bw;
 
-	pixelAddress fpa = m_psm[fpsm].pa;
-	pixelAddress zpa = m_psm[zpsm].pa;
-
 	int fs = m_psm[fpsm].bpp >> 5;
 	int zs = m_psm[zpsm].bpp >> 5;
 
 	for (int i = 0; i < 2048; i++)
 	{
-		off->row[i].x = (int)fpa(0, i, fbp, bw) << fs;
-		off->row[i].y = (int)zpa(0, i, zbp, bw) << zs;
+		off->row[i].x = (int)m_psm[fpsm].info.pa(0, i, fbp, bw) << fs;
+		off->row[i].y = (int)m_psm[zpsm].info.pa(0, i, zbp, bw) << zs;
 	}
 
 	for (int i = 0; i < 512; i++)
@@ -1276,7 +1259,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x++, pd++)
@@ -1300,7 +1283,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x++, pb += 3)
@@ -1326,7 +1309,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x++, pw++)
@@ -1347,7 +1330,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x++, pb++)
@@ -1368,7 +1351,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x += 2, pb++)
@@ -1390,7 +1373,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x++, pb++)
@@ -1411,7 +1394,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x += 2, pb++)
@@ -1433,7 +1416,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const uint8* src, int len, GIF
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x += 2, pb++)
@@ -1490,7 +1473,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* RESTRICT offset = psm->rowOffset[y & 7];
-				uint32* RESTRICT ps = &m_vm32[psm->pa(0, y, bp, bw)];
+				uint32* RESTRICT ps = &m_vm32[psm->info.pa(0, y, bp, bw)];
 
 				for (; len > 0 && x < ex && (x & 7); len--, x++, pd++)
 				{
@@ -1532,7 +1515,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* RESTRICT offset = psm->rowOffset[y & 7];
-				uint32* RESTRICT ps = &m_vm32[psm->pa(0, y, bp, bw)];
+				uint32* RESTRICT ps = &m_vm32[psm->info.pa(0, y, bp, bw)];
 
 				for (; len > 0 && x < ex; len--, x++, pb += 3)
 				{
@@ -1562,7 +1545,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* RESTRICT offset = psm->rowOffset[y & 7];
-				uint16* RESTRICT ps = &m_vm16[psm->pa(0, y, bp, bw)];
+				uint16* RESTRICT ps = &m_vm16[psm->info.pa(0, y, bp, bw)];
 
 				for (int ex4 = ex - 4; len >= 4 && x <= ex4; len -= 4, x += 4, pw += 4)
 				{
@@ -1591,7 +1574,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* RESTRICT offset = psm->rowOffset[y & 7];
-				uint8* RESTRICT ps = &m_vm8[psm->pa(0, y, bp, bw)];
+				uint8* RESTRICT ps = &m_vm8[psm->info.pa(0, y, bp, bw)];
 
 				for (int ex4 = ex - 4; len >= 4 && x <= ex4; len -= 4, x += 4, pb += 4)
 				{
@@ -1619,7 +1602,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 
 			while (len > 0)
 			{
-				uint32 addr = psm->pa(0, y, bp, bw);
+				uint32 addr = psm->info.pa(0, y, bp, bw);
 				int* RESTRICT offset = psm->rowOffset[y & 7];
 
 				for (; len > 0 && x < ex; len--, x += 2, pb++)
@@ -1641,7 +1624,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* RESTRICT offset = psm->rowOffset[y & 7];
-				uint32* RESTRICT ps = &m_vm32[psm->pa(0, y, bp, bw)];
+				uint32* RESTRICT ps = &m_vm32[psm->info.pa(0, y, bp, bw)];
 
 				for (int ex4 = ex - 4; len >= 4 && x <= ex4; len -= 4, x += 4, pb += 4)
 				{
@@ -1670,7 +1653,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* offset = psm->rowOffset[y & 7];
-				uint32* RESTRICT ps = &m_vm32[psm->pa(0, y, bp, bw)];
+				uint32* RESTRICT ps = &m_vm32[psm->info.pa(0, y, bp, bw)];
 
 				for (; len > 0 && x < ex; len--, x += 2, pb++)
 				{
@@ -1694,7 +1677,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, uint8* dst, int len, GIFRegBITB
 			while (len > 0)
 			{
 				int* RESTRICT offset = psm->rowOffset[y & 7];
-				uint32* RESTRICT ps = &m_vm32[psm->pa(0, y, bp, bw)];
+				uint32* RESTRICT ps = &m_vm32[psm->info.pa(0, y, bp, bw)];
 
 				for (; len > 0 && x < ex; len--, x += 2, pb++)
 				{
@@ -2122,20 +2105,16 @@ GSOffset::GSOffset(uint32 _bp, uint32 _bw, uint32 _psm)
 {
 	hash = _bp | (_bw << 14) | (_psm << 20);
 
-	GSLocalMemory::pixelAddress bn = GSLocalMemory::m_psm[_psm].bn;
-
 	for (int i = 0; i < 256; i++)
 	{
-		block.row[i] = (short)bn(0, i << 3, _bp, _bw);
+		block.row[i] = (short)GSLocalMemory::m_psm[_psm].info.bn(0, i << 3, _bp, _bw);
 	}
 
 	block.col = GSLocalMemory::m_psm[_psm].blockOffset;
 
-	GSLocalMemory::pixelAddress pa = GSLocalMemory::m_psm[_psm].pa;
-
 	for (int i = 0; i < 4096; i++)
 	{
-		pixel.row[i] = (int)pa(0, i & 0x7ff, _bp, _bw);
+		pixel.row[i] = (int)GSLocalMemory::m_psm[_psm].info.pa(0, i & 0x7ff, _bp, _bw);
 	}
 
 	for (int i = 0; i < 8; i++)

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -144,7 +144,7 @@ public:
 
 	struct alignas(128) psm_t
 	{
-		pixelAddress pa, bn;
+		GSSwizzleInfo info;
 		readPixel rp;
 		readPixelAddr rpa;
 		writePixel wp;

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -423,7 +423,6 @@ public:
 		readTextureBlock rtxb, rtxbP;
 		uint16 bpp, trbpp, pal, fmt;
 		GSVector2i bs, pgs;
-		int* rowOffset[8];
 		uint8 msk, depth;
 	};
 
@@ -448,15 +447,6 @@ protected:
 	static uint32 pageOffset16SZ[32][64][64];
 	static uint32 pageOffset8[32][64][128];
 	static uint32 pageOffset4[32][128][128];
-
-	static int rowOffset32[4096];
-	static int rowOffset32Z[4096];
-	static int rowOffset16[4096];
-	static int rowOffset16S[4096];
-	static int rowOffset16Z[4096];
-	static int rowOffset16SZ[4096];
-	static int rowOffset8[2][4096];
-	static int rowOffset4[2][4096];
 
 public:
 	static constexpr GSSwizzleInfo swizzle32{{8, 8}, &blockTable32, pageOffset32};

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -406,7 +406,6 @@ public:
 		uint16 bpp, trbpp, pal, fmt;
 		GSVector2i bs, pgs;
 		int* rowOffset[8];
-		short* blockOffset;
 		uint8 msk, depth;
 	};
 
@@ -441,15 +440,6 @@ protected:
 	static int rowOffset8[2][4096];
 	static int rowOffset4[2][4096];
 
-	static short blockOffset32[256];
-	static short blockOffset32Z[256];
-	static short blockOffset16[256];
-	static short blockOffset16S[256];
-	static short blockOffset16Z[256];
-	static short blockOffset16SZ[256];
-	static short blockOffset8[256];
-	static short blockOffset4[256];
-
 public:
 	static constexpr GSSwizzleInfo swizzle32{{8, 8}, &blockTable32, pageOffset32};
 	static constexpr GSSwizzleInfo swizzle32Z{{8, 8}, &blockTable32Z, pageOffset32Z};
@@ -480,7 +470,6 @@ protected:
 
 	//
 
-	std::unordered_map<uint32, GSOffset*> m_omap;
 	std::unordered_map<uint32, GSPixelOffset*> m_pomap;
 	std::unordered_map<uint32, GSPixelOffset4*> m_po4map;
 	std::unordered_map<uint64, std::vector<GSVector2i>*> m_p2tmap;

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -73,6 +73,58 @@ struct GSPixelOffset4
 	uint32 fbp, zbp, fpsm, zpsm, bw;
 };
 
+class GSSwizzleInfo
+{
+	/// Table for storing swizzling of blocks within a page
+	const GSBlockSwizzleTable* m_blockSwizzle;
+	/// Table for storing swizzling of pixels within a page
+	const uint32* m_pixelSwizzle;
+	GSVector2i m_pageMask;  ///< Mask for getting the offset of a pixel that's within a page (may also be used as page dimensions - 1)
+	GSVector2i m_blockMask; ///< Mask for getting the offset of a pixel that's within a block (may also be used as block dimensions - 1)
+	uint8 m_pageShiftX;  ///< Amount to rshift x value by to get page offset
+	uint8 m_pageShiftY;  ///< Amount to rshift y value by to get page offset
+	uint8 m_blockShiftX; ///< Amount to rshift x value by to get offset in block
+	uint8 m_blockShiftY; ///< Amount to rshift y value by to get offset in block
+	static constexpr uint8 ilog2(uint32 i) { return i < 2 ? 0 : 1 + ilog2(i>>1); }
+public:
+	GSSwizzleInfo() = default;
+
+	/// @param PageWidth Width of page in pixels
+	/// @param PageHeight Height of page in pixels
+	/// @param blockSize Size of block in pixels
+	template <int PageWidth, int PageHeight>
+	constexpr GSSwizzleInfo(GSVector2i blockSize, const GSBlockSwizzleTable* blockSwizzle, const uint32 (&pxSwizzle)[32][PageHeight][PageWidth])
+		: m_blockSwizzle(blockSwizzle)
+		, m_pixelSwizzle(&pxSwizzle[0][0][0])
+		, m_pageMask{PageWidth - 1, PageHeight - 1}
+		, m_blockMask{blockSize.x - 1, blockSize.y - 1}
+		, m_pageShiftX(ilog2(PageWidth)), m_pageShiftY(ilog2(PageHeight))
+		, m_blockShiftX(ilog2(blockSize.x)), m_blockShiftY(ilog2(blockSize.y))
+	{
+		static_assert(1 << ilog2(PageWidth) == PageWidth, "PageWidth must be a power of 2");
+		static_assert(1 << ilog2(PageHeight) == PageHeight, "PageHeight must be a power of 2");
+	}
+
+	/// Get the block number of the given pixel
+	uint32 bn(int x, int y, uint32 bp, uint32 bw) const
+	{
+		int yAmt = ((y >> (m_pageShiftY - 5)) & ~0x1f) * (bw >> (m_pageShiftX - 6));
+		int xAmt = ((x >> (m_pageShiftX - 5)) & ~0x1f);
+		return bp + yAmt + xAmt + m_blockSwizzle->lookup(x >> m_blockShiftX, y >> m_blockShiftY);
+	}
+
+	/// Get the address of the given pixel
+	uint32 pa(int x, int y, uint32 bp, uint32 bw) const
+	{
+		int shift = m_pageShiftX + m_pageShiftY;
+		uint32 page = ((bp >> 5) + (y >> m_pageShiftY) * (bw >> (m_pageShiftX - 6)) + (x >> m_pageShiftX)) % MAX_PAGES;
+		// equivalent of pageOffset[bp & 0x1f][y & pageMaskY][x & pageMaskX]
+		uint32 offsetIdx = ((bp & 0x1f) << shift) + ((y & m_pageMask.y) << m_pageShiftX) + (x & m_pageMask.x);
+		uint32 word = (page << shift) + m_pixelSwizzle[offsetIdx];
+		return word;
+	}
+};
+
 class GSLocalMemory : public GSAlignedClass<32>
 {
 public:
@@ -151,6 +203,17 @@ protected:
 	static short blockOffset8[256];
 	static short blockOffset4[256];
 
+public:
+	static constexpr GSSwizzleInfo swizzle32{{8, 8}, &blockTable32, pageOffset32};
+	static constexpr GSSwizzleInfo swizzle32Z{{8, 8}, &blockTable32Z, pageOffset32Z};
+	static constexpr GSSwizzleInfo swizzle16{{16, 8}, &blockTable16, pageOffset16};
+	static constexpr GSSwizzleInfo swizzle16S{{16, 8}, &blockTable16S, pageOffset16S};
+	static constexpr GSSwizzleInfo swizzle16Z{{16, 8}, &blockTable16Z, pageOffset16Z};
+	static constexpr GSSwizzleInfo swizzle16SZ{{16, 8}, &blockTable16SZ, pageOffset16SZ};
+	static constexpr GSSwizzleInfo swizzle8{{16, 16}, &blockTable8, pageOffset8};
+	static constexpr GSSwizzleInfo swizzle4{{32, 16}, &blockTable4, pageOffset4};
+
+protected:
 	__forceinline static uint32 Expand24To32(uint32 c, const GIFRegTEXA& TEXA)
 	{
 		return (((!TEXA.AEM | (c & 0xffffff)) ? TEXA.TA0 : 0) << 24) | (c & 0xffffff);
@@ -188,46 +251,46 @@ public:
 
 	static uint32 BlockNumber32(int x, int y, uint32 bp, uint32 bw)
 	{
-		return bp + (y & ~0x1f) * bw + ((x >> 1) & ~0x1f) + blockTable32[(y >> 3) & 3][(x >> 3) & 7];
+		return swizzle32.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber16(int x, int y, uint32 bp, uint32 bw)
 	{
-		return bp + ((y >> 1) & ~0x1f) * bw + ((x >> 1) & ~0x1f) + blockTable16[(y >> 3) & 7][(x >> 4) & 3];
+		return swizzle16.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber16S(int x, int y, uint32 bp, uint32 bw)
 	{
-		return bp + ((y >> 1) & ~0x1f) * bw + ((x >> 1) & ~0x1f) + blockTable16S[(y >> 3) & 7][(x >> 4) & 3];
+		return swizzle16S.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber8(int x, int y, uint32 bp, uint32 bw)
 	{
 		// ASSERT((bw & 1) == 0); // allowed for mipmap levels
 
-		return bp + ((y >> 1) & ~0x1f) * (bw >> 1) + ((x >> 2) & ~0x1f) + blockTable8[(y >> 4) & 3][(x >> 4) & 7];
+		return swizzle8.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber4(int x, int y, uint32 bp, uint32 bw)
 	{
 		// ASSERT((bw & 1) == 0); // allowed for mipmap levels
 
-		return bp + ((y >> 2) & ~0x1f) * (bw >> 1) + ((x >> 2) & ~0x1f) + blockTable4[(y >> 4) & 7][(x >> 5) & 3];
+		return swizzle4.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber32Z(int x, int y, uint32 bp, uint32 bw)
 	{
-		return bp + (y & ~0x1f) * bw + ((x >> 1) & ~0x1f) + blockTable32Z[(y >> 3) & 3][(x >> 3) & 7];
+		return swizzle32Z.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber16Z(int x, int y, uint32 bp, uint32 bw)
 	{
-		return bp + ((y >> 1) & ~0x1f) * bw + ((x >> 1) & ~0x1f) + blockTable16Z[(y >> 3) & 7][(x >> 4) & 3];
+		return swizzle16Z.bn(x, y, bp, bw);
 	}
 
 	static uint32 BlockNumber16SZ(int x, int y, uint32 bp, uint32 bw)
 	{
-		return bp + ((y >> 1) & ~0x1f) * bw + ((x >> 1) & ~0x1f) + blockTable16SZ[(y >> 3) & 7][(x >> 4) & 3];
+		return swizzle16SZ.bn(x, y, bp, bw);
 	}
 
 	uint8* BlockPtr(uint32 bp) const
@@ -317,70 +380,46 @@ public:
 
 	static __forceinline uint32 PixelAddress32(int x, int y, uint32 bp, uint32 bw)
 	{
-		uint32 page = ((bp >> 5) + (y >> 5) * bw + (x >> 6)) % MAX_PAGES;
-		uint32 word = (page << 11) + pageOffset32[bp & 0x1f][y & 0x1f][x & 0x3f];
-
-		return word;
+		return swizzle32.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress16(int x, int y, uint32 bp, uint32 bw)
 	{
-		uint32 page = ((bp >> 5) + (y >> 6) * bw + (x >> 6)) % MAX_PAGES;
-		uint32 word = (page << 12) + pageOffset16[bp & 0x1f][y & 0x3f][x & 0x3f];
-
-		return word;
+		return swizzle16.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress16S(int x, int y, uint32 bp, uint32 bw)
 	{
-		uint32 page = ((bp >> 5) + (y >> 6) * bw + (x >> 6)) % MAX_PAGES;
-		uint32 word = (page << 12) + pageOffset16S[bp & 0x1f][y & 0x3f][x & 0x3f];
-
-		return word;
+		return swizzle16S.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress8(int x, int y, uint32 bp, uint32 bw)
 	{
 		// ASSERT((bw & 1) == 0); // allowed for mipmap levels
 
-		uint32 page = ((bp >> 5) + (y >> 6) * (bw >> 1) + (x >> 7)) % MAX_PAGES;
-		uint32 word = (page << 13) + pageOffset8[bp & 0x1f][y & 0x3f][x & 0x7f];
-
-		return word;
+		return swizzle8.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress4(int x, int y, uint32 bp, uint32 bw)
 	{
 		// ASSERT((bw & 1) == 0); // allowed for mipmap levels
 
-		uint32 page = ((bp >> 5) + (y >> 7) * (bw >> 1) + (x >> 7)) % MAX_PAGES;
-		uint32 word = (page << 14) + pageOffset4[bp & 0x1f][y & 0x7f][x & 0x7f];
-
-		return word;
+		return swizzle4.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress32Z(int x, int y, uint32 bp, uint32 bw)
 	{
-		uint32 page = ((bp >> 5) + (y >> 5) * bw + (x >> 6)) % MAX_PAGES;
-		uint32 word = (page << 11) + pageOffset32Z[bp & 0x1f][y & 0x1f][x & 0x3f];
-
-		return word;
+		return swizzle32Z.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress16Z(int x, int y, uint32 bp, uint32 bw)
 	{
-		uint32 page = ((bp >> 5) + (y >> 6) * bw + (x >> 6)) % MAX_PAGES;
-		uint32 word = (page << 12) + pageOffset16Z[bp & 0x1f][y & 0x3f][x & 0x3f];
-
-		return word;
+		return swizzle16Z.pa(x, y, bp, bw);
 	}
 
 	static __forceinline uint32 PixelAddress16SZ(int x, int y, uint32 bp, uint32 bw)
 	{
-		uint32 page = ((bp >> 5) + (y >> 6) * bw + (x >> 6)) % MAX_PAGES;
-		uint32 word = (page << 12) + pageOffset16SZ[bp & 0x1f][y & 0x3f][x & 0x3f];
-
-		return word;
+		return swizzle16SZ.pa(x, y, bp, bw);
 	}
 
 	// pixel R/W

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -298,6 +298,10 @@ public:
 	{
 		pageLooperForRect(rect).loopPages(std::forward<Fn>(fn));
 	}
+
+	/// Use compile-time dimensions from `swz` as a performance optimization
+	/// Also asserts if your assumption was wrong
+	constexpr GSOffset assertSizesMatch(const GSSwizzleInfo& swz) const;
 };
 
 class GSSwizzleInfo
@@ -370,6 +374,20 @@ constexpr inline GSOffset::GSOffset(const GSSwizzleInfo& swz, uint32 bp, uint32 
 	, m_bwPg(bw >> (m_pageShiftX - 6))
 	, m_psm(psm)
 {
+}
+
+constexpr GSOffset GSOffset::assertSizesMatch(const GSSwizzleInfo& swz) const
+{
+	GSOffset o = *this;
+#define MATCH(x) ASSERT(o.x == swz.x); o.x = swz.x;
+	MATCH(m_pageMask)
+	MATCH(m_blockMask)
+	MATCH(m_pageShiftX)
+	MATCH(m_pageShiftY)
+	MATCH(m_blockShiftX)
+	MATCH(m_blockShiftY)
+#undef MATCH
+	return o;
 }
 
 class GSLocalMemory : public GSAlignedClass<32>
@@ -478,7 +496,10 @@ public:
 	GSLocalMemory();
 	virtual ~GSLocalMemory();
 
-	GSOffset GetOffset(uint32 bp, uint32 bw, uint32 psm);
+	GSOffset GetOffset(uint32 bp, uint32 bw, uint32 psm) const
+	{
+		return GSOffset(m_psm[psm].info, bp, bw, psm);
+	}
 	GSPixelOffset* GetPixelOffset(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1663,14 +1663,12 @@ void GSState::Move()
 		{
 			for (int y = 0; y < h; y++, sy += yinc, dy += yinc)
 			{
-				GSOffset::PAHelper s = spo.paMulti(sx, sy);
-				GSOffset::PAHelper d = dpo.paMulti(dx, dy);
+				GSOffset::PAHelper s = spo.paMulti(sy);
+				GSOffset::PAHelper d = dpo.paMulti(dy);
 
 				for (int x = 0; x < w; x++)
 				{
-					pxCopyFn(d.value(), s.value());
-					s.incX();
-					d.incX();
+					pxCopyFn(d.value(dx + x), s.value(sx + x));
 				}
 			}
 		}
@@ -1678,14 +1676,12 @@ void GSState::Move()
 		{
 			for (int y = 0; y < h; y++, sy += yinc, dy += yinc)
 			{
-				GSOffset::PAHelper s = spo.paMulti(sx, sy);
-				GSOffset::PAHelper d = dpo.paMulti(dx, dy);
+				GSOffset::PAHelper s = spo.paMulti(sy);
+				GSOffset::PAHelper d = dpo.paMulti(dy);
 
 				for (int x = 0; x < w; x++)
 				{
-					pxCopyFn(d.value(), s.value());
-					s.decX();
-					d.decX();
+					pxCopyFn(d.value(dx - x), s.value(sx - x));
 				}
 			}
 		}

--- a/pcsx2/GS/GSTables.cpp
+++ b/pcsx2/GS/GSTables.cpp
@@ -19,7 +19,18 @@
 #include "GSTables.h"
 #include "GS_types.h"
 
-const uint8 blockTable32[4][8] =
+template <int Width, int Height>
+static constexpr GSBlockSwizzleTable makeSwizzleTable(const uint8 (&arr)[Height][Width]) {
+	GSBlockSwizzleTable table = {};
+	for (int y = 0; y < 8; y++) {
+		for (int x = 0; x < 8; x++) {
+			table.value[y][x] = arr[y % Height][x % Width];
+		}
+	}
+	return table;
+}
+
+static constexpr uint8 _blockTable32[4][8] =
 {
 	{  0,  1,  4,  5, 16, 17, 20, 21},
 	{  2,  3,  6,  7, 18, 19, 22, 23},
@@ -27,7 +38,7 @@ const uint8 blockTable32[4][8] =
 	{ 10, 11, 14, 15, 26, 27, 30, 31}
 };
 
-const uint8 blockTable32Z[4][8] =
+static constexpr uint8 _blockTable32Z[4][8] =
 {
 	{ 24, 25, 28, 29,  8,  9, 12, 13},
 	{ 26, 27, 30, 31, 10, 11, 14, 15},
@@ -35,7 +46,7 @@ const uint8 blockTable32Z[4][8] =
 	{ 18, 19, 22, 23,  2,  3,  6,  7}
 };
 
-const uint8 blockTable16[8][4] =
+static constexpr uint8 _blockTable16[8][4] =
 {
 	{  0,  2,  8, 10 },
 	{  1,  3,  9, 11 },
@@ -47,7 +58,7 @@ const uint8 blockTable16[8][4] =
 	{ 21, 23, 29, 31 }
 };
 
-const uint8 blockTable16S[8][4] =
+static constexpr uint8 _blockTable16S[8][4] =
 {
 	{  0,  2, 16, 18 },
 	{  1,  3, 17, 19 },
@@ -59,7 +70,7 @@ const uint8 blockTable16S[8][4] =
 	{ 13, 15, 29, 31 }
 };
 
-const uint8 blockTable16Z[8][4] =
+static constexpr uint8 _blockTable16Z[8][4] =
 {
 	{ 24, 26, 16, 18 },
 	{ 25, 27, 17, 19 },
@@ -71,7 +82,7 @@ const uint8 blockTable16Z[8][4] =
 	{ 13, 15,  5,  7 }
 };
 
-const uint8 blockTable16SZ[8][4] =
+static constexpr uint8 _blockTable16SZ[8][4] =
 {
 	{ 24, 26,  8, 10 },
 	{ 25, 27,  9, 11 },
@@ -83,7 +94,7 @@ const uint8 blockTable16SZ[8][4] =
 	{ 21, 23,  5,  7 }
 };
 
-const uint8 blockTable8[4][8] =
+static constexpr uint8 _blockTable8[4][8] =
 {
 	{  0,  1,  4,  5, 16, 17, 20, 21},
 	{  2,  3,  6,  7, 18, 19, 22, 23},
@@ -91,7 +102,7 @@ const uint8 blockTable8[4][8] =
 	{ 10, 11, 14, 15, 26, 27, 30, 31}
 };
 
-const uint8 blockTable4[8][4] =
+static constexpr uint8 _blockTable4[8][4] =
 {
 	{  0,  2,  8, 10 },
 	{  1,  3,  9, 11 },
@@ -103,7 +114,16 @@ const uint8 blockTable4[8][4] =
 	{ 21, 23, 29, 31 }
 };
 
-const uint8 columnTable32[8][8] =
+constexpr GSBlockSwizzleTable blockTable32   = makeSwizzleTable(_blockTable32);
+constexpr GSBlockSwizzleTable blockTable32Z  = makeSwizzleTable(_blockTable32Z);
+constexpr GSBlockSwizzleTable blockTable16   = makeSwizzleTable(_blockTable16);
+constexpr GSBlockSwizzleTable blockTable16S  = makeSwizzleTable(_blockTable16S);
+constexpr GSBlockSwizzleTable blockTable16Z  = makeSwizzleTable(_blockTable16Z);
+constexpr GSBlockSwizzleTable blockTable16SZ = makeSwizzleTable(_blockTable16SZ);
+constexpr GSBlockSwizzleTable blockTable8    = makeSwizzleTable(_blockTable8);
+constexpr GSBlockSwizzleTable blockTable4    = makeSwizzleTable(_blockTable4);
+
+constexpr uint8 columnTable32[8][8] =
 {
 	{  0,  1,  4,  5,  8,  9, 12, 13 },
 	{  2,  3,  6,  7, 10, 11, 14, 15 },
@@ -115,7 +135,7 @@ const uint8 columnTable32[8][8] =
 	{ 50, 51, 54, 55, 58, 59, 62, 63 },
 };
 
-const uint8 columnTable16[8][16] =
+constexpr uint8 columnTable16[8][16] =
 {
 	{   0,   2,   8,  10,  16,  18,  24,  26,
 	    1,   3,   9,  11,  17,  19,  25,  27 },
@@ -135,7 +155,7 @@ const uint8 columnTable16[8][16] =
 	  101, 103, 109, 111, 117, 119, 125, 127 },
 };
 
-const uint8 columnTable8[16][16] =
+constexpr uint8 columnTable8[16][16] =
 {
 	{   0,   4,  16,  20,  32,  36,  48,  52,	// column 0
 	    2,   6,  18,  22,  34,  38,  50,  54 },
@@ -171,7 +191,7 @@ const uint8 columnTable8[16][16] =
 	  203, 207, 219, 223, 235, 239, 251, 255 },
 };
 
-const uint16 columnTable4[16][32] =
+constexpr uint16 columnTable4[16][32] =
 {
 	{   0,   8,  32,  40,  64,  72,  96, 104,	// column 0
 	    2,  10,  34,  42,  66,  74,  98, 106,
@@ -239,7 +259,7 @@ const uint16 columnTable4[16][32] =
 	  407, 415, 439, 447, 471, 479, 503, 511 },
 };
 
-const uint8 clutTableT32I8[128] =
+constexpr uint8 clutTableT32I8[128] =
 {
 	0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
 	64, 65, 68, 69, 72, 73, 76, 77, 66, 67, 70, 71, 74, 75, 78, 79,
@@ -251,13 +271,13 @@ const uint8 clutTableT32I8[128] =
 	112, 113, 116, 117, 120, 121, 124, 125, 114, 115, 118, 119, 122, 123, 126, 127
 };
 
-const uint8 clutTableT32I4[16] =
+constexpr uint8 clutTableT32I4[16] =
 {
 	0, 1, 4, 5, 8, 9, 12, 13,
 	2, 3, 6, 7, 10, 11, 14, 15
 };
 
-const uint8 clutTableT16I8[32] =
+constexpr uint8 clutTableT16I8[32] =
 {
 	0, 2, 8, 10, 16, 18, 24, 26,
 	4, 6, 12, 14, 20, 22, 28, 30,
@@ -265,7 +285,7 @@ const uint8 clutTableT16I8[32] =
 	5, 7, 13, 15, 21, 23, 29, 31
 };
 
-const uint8 clutTableT16I4[16] =
+constexpr uint8 clutTableT16I4[16] =
 {
 	0, 2, 8, 10, 16, 18, 24, 26,
 	4, 6, 12, 14, 20, 22, 28, 30

--- a/pcsx2/GS/GSTables.h
+++ b/pcsx2/GS/GSTables.h
@@ -17,14 +17,26 @@
 
 #include "GS_types.h"
 
-extern const uint8 blockTable32[4][8];
-extern const uint8 blockTable32Z[4][8];
-extern const uint8 blockTable16[8][4];
-extern const uint8 blockTable16S[8][4];
-extern const uint8 blockTable16Z[8][4];
-extern const uint8 blockTable16SZ[8][4];
-extern const uint8 blockTable8[4][8];
-extern const uint8 blockTable4[8][4];
+/// Table for storing swizzling of blocks within a page
+struct alignas(64) GSBlockSwizzleTable
+{
+	// Some swizzles are 4x8 and others are 8x4.  An 8x8 table can store either at the cost of 2x size
+	uint8 value[8][8];
+
+	constexpr uint8 lookup(int x, int y) const
+	{
+		return value[y & 7][x & 7];
+	}
+};
+
+extern const GSBlockSwizzleTable blockTable32;
+extern const GSBlockSwizzleTable blockTable32Z;
+extern const GSBlockSwizzleTable blockTable16;
+extern const GSBlockSwizzleTable blockTable16S;
+extern const GSBlockSwizzleTable blockTable16Z;
+extern const GSBlockSwizzleTable blockTable16SZ;
+extern const GSBlockSwizzleTable blockTable8;
+extern const GSBlockSwizzleTable blockTable4;
 extern const uint8 columnTable32[8][8];
 extern const uint8 columnTable16[8][16];
 extern const uint8 columnTable8[16][16];

--- a/pcsx2/GS/GSTables.h
+++ b/pcsx2/GS/GSTables.h
@@ -29,14 +29,88 @@ struct alignas(64) GSBlockSwizzleTable
 	}
 };
 
-extern const GSBlockSwizzleTable blockTable32;
-extern const GSBlockSwizzleTable blockTable32Z;
-extern const GSBlockSwizzleTable blockTable16;
-extern const GSBlockSwizzleTable blockTable16S;
-extern const GSBlockSwizzleTable blockTable16Z;
-extern const GSBlockSwizzleTable blockTable16SZ;
-extern const GSBlockSwizzleTable blockTable8;
-extern const GSBlockSwizzleTable blockTable4;
+/// Adds sizes to GSBlockSwizzleTable for to feel better about not making mistakes
+template <int Height, int Width>
+struct GSSizedBlockSwizzleTable : public GSBlockSwizzleTable
+{
+};
+
+/// Table for storing offsets of x = 0 pixels from the beginning of the page
+/// Add values from a GSPixelRowOffsetTable to get the pixels for x != 0
+template <int Height>
+struct alignas(128) GSPixelColOffsetTable
+{
+	int value[Height] = {};
+
+	int operator[](int y) const
+	{
+		return value[y % Height];
+	}
+};
+
+/// Table for storing offsets of x != 0 pixels from the pixel at the same y where x = 0
+/// Unlike ColOffsets, this table stretches to the maximum size of a texture so no masking is needed
+struct alignas(128) GSPixelRowOffsetTable
+{
+	int value[2048] = {};
+
+	int operator[](size_t x) const
+	{
+		ASSERT(x < 2048);
+		return value[x];
+	}
+};
+
+/// Adds size to GSPixelRowOffsetTable to feel better about not making mistakes
+template <int PageWidth>
+struct GSSizedPixelRowOffsetTable : public GSPixelRowOffsetTable
+{
+};
+
+/// List of row offset tables
+/// Some swizzlings (PSMT8 and PSMT4) have different row offsets depending on which column they're a part of
+/// The ones that do use an a a b b b b a a pattern that repeats every 8 rows.
+/// You can always look up the correct row in this list with y & 7, but if you use y & Mask where Mask is known at compile time, the compiler should be able to optimize better
+template <int PageWidth, int Mask>
+struct alignas(sizeof(void*) * 8) GSPixelRowOffsetTableList
+{
+	const GSPixelRowOffsetTable* rows[8];
+
+	const GSPixelRowOffsetTable& operator[](int y) const
+	{
+		return *rows[y & Mask];
+	}
+};
+
+/// Full pixel offset table
+/// Template values are for objects constructing from one of these tables
+template <int PageHeight, int PageWidth, int BlockHeight, int BlockWidth, int RowMask>
+struct GSSwizzleTableList
+{
+	const GSSizedBlockSwizzleTable<BlockHeight, BlockWidth>& block;
+	const GSPixelColOffsetTable<PageHeight>& col;
+	const GSPixelRowOffsetTableList<PageWidth, RowMask>& row;
+};
+
+/// List of all tables for a given swizzle for easy setup
+template <int PageHeight, int PageWidth, int BlockHeight, int BlockWidth, int RowMask>
+constexpr GSSwizzleTableList<PageHeight, PageWidth, BlockHeight, BlockWidth, RowMask>
+makeSwizzleTableList(
+	const GSSizedBlockSwizzleTable<BlockHeight, BlockWidth>& block,
+	const GSPixelColOffsetTable<PageHeight>& col,
+	const GSPixelRowOffsetTableList<PageWidth, RowMask>& row)
+{
+	return {block, col, row};
+}
+
+extern const GSSizedBlockSwizzleTable<4, 8> blockTable32;
+extern const GSSizedBlockSwizzleTable<4, 8> blockTable32Z;
+extern const GSSizedBlockSwizzleTable<8, 4> blockTable16;
+extern const GSSizedBlockSwizzleTable<8, 4> blockTable16S;
+extern const GSSizedBlockSwizzleTable<8, 4> blockTable16Z;
+extern const GSSizedBlockSwizzleTable<8, 4> blockTable16SZ;
+extern const GSSizedBlockSwizzleTable<4, 8> blockTable8;
+extern const GSSizedBlockSwizzleTable<8, 4> blockTable4;
 extern const uint8 columnTable32[8][8];
 extern const uint8 columnTable16[8][16];
 extern const uint8 columnTable8[16][16];
@@ -45,3 +119,57 @@ extern const uint8 clutTableT32I8[128];
 extern const uint8 clutTableT32I4[16];
 extern const uint8 clutTableT16I8[32];
 extern const uint8 clutTableT16I4[16];
+extern const GSPixelColOffsetTable< 32> pixelColOffset32;
+extern const GSPixelColOffsetTable< 32> pixelColOffset32Z;
+extern const GSPixelColOffsetTable< 64> pixelColOffset16;
+extern const GSPixelColOffsetTable< 64> pixelColOffset16S;
+extern const GSPixelColOffsetTable< 64> pixelColOffset16Z;
+extern const GSPixelColOffsetTable< 64> pixelColOffset16SZ;
+extern const GSPixelColOffsetTable< 64> pixelColOffset8;
+extern const GSPixelColOffsetTable<128> pixelColOffset4;
+
+template <int PageWidth>
+constexpr GSPixelRowOffsetTableList<PageWidth, 0> makeRowOffsetTableList(
+	const GSSizedPixelRowOffsetTable<PageWidth>* a)
+{
+	return {{a, a, a, a, a, a, a, a}};
+}
+
+template <int PageWidth>
+constexpr GSPixelRowOffsetTableList<PageWidth, 7> makeRowOffsetTableList(
+	const GSSizedPixelRowOffsetTable<PageWidth>* a,
+	const GSSizedPixelRowOffsetTable<PageWidth>* b)
+{
+	return {{a, a, b, b, b, b, a, a}};
+}
+
+/// Just here to force external linkage so we don't end up with multiple copies of pixelRowOffset*
+struct GSTables
+{
+	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset32;
+	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset32Z;
+	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16;
+	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16S;
+	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16Z;
+	static const GSSizedPixelRowOffsetTable< 64> _pixelRowOffset16SZ;
+	static const GSSizedPixelRowOffsetTable<128> _pixelRowOffset8[2];
+	static const GSSizedPixelRowOffsetTable<128> _pixelRowOffset4[2];
+
+	static constexpr auto pixelRowOffset32   = makeRowOffsetTableList(&_pixelRowOffset32);
+	static constexpr auto pixelRowOffset32Z  = makeRowOffsetTableList(&_pixelRowOffset32Z);
+	static constexpr auto pixelRowOffset16   = makeRowOffsetTableList(&_pixelRowOffset16);
+	static constexpr auto pixelRowOffset16S  = makeRowOffsetTableList(&_pixelRowOffset16S);
+	static constexpr auto pixelRowOffset16Z  = makeRowOffsetTableList(&_pixelRowOffset16Z);
+	static constexpr auto pixelRowOffset16SZ = makeRowOffsetTableList(&_pixelRowOffset16SZ);
+	static constexpr auto pixelRowOffset8 = makeRowOffsetTableList(&_pixelRowOffset8[0], &_pixelRowOffset8[1]);
+	static constexpr auto pixelRowOffset4 = makeRowOffsetTableList(&_pixelRowOffset4[0], &_pixelRowOffset4[1]);
+};
+
+constexpr auto swizzleTables32   = makeSwizzleTableList(blockTable32,   pixelColOffset32,   GSTables::pixelRowOffset32  );
+constexpr auto swizzleTables32Z  = makeSwizzleTableList(blockTable32Z,  pixelColOffset32Z,  GSTables::pixelRowOffset32Z );
+constexpr auto swizzleTables16   = makeSwizzleTableList(blockTable16,   pixelColOffset16,   GSTables::pixelRowOffset16  );
+constexpr auto swizzleTables16Z  = makeSwizzleTableList(blockTable16Z,  pixelColOffset16Z,  GSTables::pixelRowOffset16Z );
+constexpr auto swizzleTables16S  = makeSwizzleTableList(blockTable16S,  pixelColOffset16S,  GSTables::pixelRowOffset16S );
+constexpr auto swizzleTables16SZ = makeSwizzleTableList(blockTable16SZ, pixelColOffset16SZ, GSTables::pixelRowOffset16SZ);
+constexpr auto swizzleTables8    = makeSwizzleTableList(blockTable8,    pixelColOffset8,    GSTables::pixelRowOffset8   );
+constexpr auto swizzleTables4    = makeSwizzleTableList(blockTable4,    pixelColOffset4,    GSTables::pixelRowOffset4   );

--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -63,12 +63,12 @@ public:
 	{
 	}
 
-	bool operator==(const GSVector2T& v) const
+	constexpr bool operator==(const GSVector2T& v) const
 	{
 		return x == v.x && y == v.y;
 	}
 
-	bool operator!=(const GSVector2T& v) const
+	constexpr bool operator!=(const GSVector2T& v) const
 	{
 		return x != v.x || y != v.y;
 	}

--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -53,20 +53,14 @@ public:
 		struct { T v[2]; };
 	};
 
-	GSVector2T()
+	GSVector2T() = default;
+
+	constexpr GSVector2T(T x): x(x), y(x)
 	{
 	}
 
-	GSVector2T(T x)
+	constexpr GSVector2T(T x, T y): x(x), y(y)
 	{
-		this->x = x;
-		this->y = x;
-	}
-
-	GSVector2T(T x, T y)
-	{
-		this->x = x;
-		this->y = y;
 	}
 
 	bool operator==(const GSVector2T& v) const

--- a/pcsx2/GS/Renderers/DX11/GSTextureCache11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureCache11.cpp
@@ -79,7 +79,7 @@ void GSTextureCache11::Read(Target* t, const GSVector4i& r)
 		{
 			// TODO: block level write
 
-			GSOffset* off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
+			GSOffset off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
 			switch (TEX0.PSM)
 			{
@@ -124,7 +124,7 @@ void GSTextureCache11::Read(Source* t, const GSVector4i& r)
 
 		if (offscreen->Map(m, &r_offscreen))
 		{
-			GSOffset* off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
+			GSOffset off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
 			m_renderer->m_mem.WritePixel32(m.bits, m.pitch, off, r);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1827,7 +1827,7 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel32
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				GSOffset::PAHelper pa = off.paMulti(r.left, y);
+				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(r.left, y);
 
 				for (; pa.x() < r.right; pa.incX())
 				{
@@ -1840,7 +1840,7 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel24
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				GSOffset::PAHelper pa = off.paMulti(r.left, y);
+				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(r.left, y);
 
 				for (; pa.x() < r.right; pa.incX())
 				{
@@ -1855,7 +1855,7 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel16
 			for(int y = r.top; y < r.bottom; y++)
 			{
-				GSOffset::PAHelper pa = off.paMulti(r.left, y);
+				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(r.left, y);
 
 				for(int x = r.left; x < r.right; x++)
 				{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -907,26 +907,22 @@ void GSRendererHW::SwSpriteRender()
 
 	for (int y = 0; y < h; y++, ++sy, ++dy)
 	{
-		GSOffset::PAHelper spa = texture_mapping_enabled ? spo.paMulti(sx, sy) : GSOffset::PAHelper();
-		GSOffset::PAHelper dpa = dpo.paMulti(dx, dy);
+		GSOffset::PAHelper spa = texture_mapping_enabled ? spo.paMulti(sy) : GSOffset::PAHelper();
+		GSOffset::PAHelper dpa = dpo.paMulti(dy);
 
 		ASSERT(w % 2 == 0);
 
 		for (int x = 0; x < w; x += 2)
 		{
-			uint32 di = dpa.value();
-			dpa.incX();
-			ASSERT(di + 1 == dpa.value()); // Destination pixel pair is adjacent in memory
-			dpa.incX();
+			uint32 di = dpa.value(dx + x);
+			ASSERT(di + 1 == dpa.value(dx + x + 1)); // Destination pixel pair is adjacent in memory
 
 			GSVector4i sc;
 			if (texture_mapping_enabled)
 			{
-				uint32 si = spa.value();
-				spa.incX();
+				uint32 si = spa.value(sx + x);
 				// Read 2 source pixel colors
-				ASSERT((si + 1) == spa.value()); // Source pixel pair is adjacent in memory
-				spa.incX();
+				ASSERT((si + 1) == spa.value(sx + x + 1)); // Source pixel pair is adjacent in memory
 				sc = GSVector4i::loadl(&m_mem.m_vm32[si]).u8to16(); // 0x00AA00BB00GG00RR00aa00bb00gg00rr
 
 				// Apply TFX
@@ -1827,11 +1823,11 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel32
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(r.left, y);
+				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(y);
 
-				for (; pa.x() < r.right; pa.incX())
+				for (int x = r.left; x < r.right; x++)
 				{
-					m_mem.m_vm32[pa.value()] = 0; // Here the constant color
+					m_mem.m_vm32[pa.value(x)] = 0; // Here the constant color
 				}
 			}
 		}
@@ -1840,11 +1836,11 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel24
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(r.left, y);
+				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(y);
 
-				for (; pa.x() < r.right; pa.incX())
+				for (int x = r.left; x < r.right; x++)
 				{
-					m_mem.m_vm32[pa.value()] &= 0xff000000; // Clear the color
+					m_mem.m_vm32[pa.value(x)] &= 0xff000000; // Clear the color
 				}
 			}
 		}
@@ -1855,11 +1851,11 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel16
 			for(int y = r.top; y < r.bottom; y++)
 			{
-				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(r.left, y);
+				GSOffset::PAHelper pa = off.assertSizesMatch(GSLocalMemory::swizzle16).paMulti(y);
 
 				for(int x = r.left; x < r.right; x++)
 				{
-					m_mem.m_vm16[pa.value()] = 0; // Here the constant color
+					m_mem.m_vm16[pa.value(x)] = 0; // Here the constant color
 				}
 			}
 #endif

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -276,7 +276,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 		uint32 bw = TEX0.TBW;
 		int tw = 1 << TEX0.TW;
 		int th = 1 << TEX0.TH;
-		uint32 bp_end = psm_s.bn(tw - 1, th - 1, bp, bw); // Valid only for color formats
+		uint32 bp_end = psm_s.info.bn(tw - 1, th - 1, bp, bw); // Valid only for color formats
 
 		// Arc the Lad finds the wrong surface here when looking for a depth stencil.
 		// Since we're currently not caching depth stencils (check ToDo in CreateSource) we should not look for it here.
@@ -376,7 +376,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 						{
 							if (candidate_x_offset == 0 && candidate_y_offset == 0)
 								continue;
-							uint32 candidate_bp = psm_s.bn(candidate_x_offset, candidate_y_offset, t->m_TEX0.TBP0, bw);
+							uint32 candidate_bp = psm_s.info.bn(candidate_x_offset, candidate_y_offset, t->m_TEX0.TBP0, bw);
 							if (bp == candidate_bp && bp_end <= t->m_end_block)
 							{
 								// SWEEP HIT: <x,y> offset found
@@ -847,7 +847,7 @@ void GSTextureCache::InvalidateVideoMem(GSOffset* off, const GSVector4i& rect, b
 		// we are screwed.
 		if (m_renderer->m_game.title == CRC::HauntingGround)
 		{
-			uint32 end_block = GSLocalMemory::m_psm[psm].bn(rect.z - 1, rect.w - 1, bp, bw); // Valid only for color formats
+			uint32 end_block = GSLocalMemory::m_psm[psm].info.bn(rect.z - 1, rect.w - 1, bp, bw); // Valid only for color formats
 			auto type = RenderTarget;
 
 			for (auto t : m_dst[type])
@@ -1724,14 +1724,14 @@ void GSTextureCache::Surface::UpdateAge()
 bool GSTextureCache::Surface::Inside(uint32 bp, uint32 bw, uint32 psm, const GSVector4i& rect)
 {
 	// Valid only for color formats.
-	uint32 const end_block = GSLocalMemory::m_psm[psm].bn(rect.z - 1, rect.w - 1, bp, bw);
+	uint32 const end_block = GSLocalMemory::m_psm[psm].info.bn(rect.z - 1, rect.w - 1, bp, bw);
 	return bp >= m_TEX0.TBP0 && end_block <= m_end_block;
 }
 
 bool GSTextureCache::Surface::Overlaps(uint32 bp, uint32 bw, uint32 psm, const GSVector4i& rect)
 {
 	// Valid only for color formats.
-	uint32 const end_block = GSLocalMemory::m_psm[psm].bn(rect.z - 1, rect.w - 1, bp, bw);
+	uint32 const end_block = GSLocalMemory::m_psm[psm].info.bn(rect.z - 1, rect.w - 1, bp, bw);
 	return (m_TEX0.TBP0 <= bp        && bp        <= m_end_block)
 	    || (m_TEX0.TBP0 <= end_block && end_block <= m_end_block);
 }
@@ -2123,7 +2123,7 @@ void GSTextureCache::Target::UpdateValidity(const GSVector4i& rect)
 	m_valid = m_valid.runion(rect);
 
 	// Block of the bottom right texel of the validity rectangle, last valid block of the texture
-	m_end_block = GSLocalMemory::m_psm[m_TEX0.PSM].bn(m_valid.z - 1, m_valid.w - 1, m_TEX0.TBP0, m_TEX0.TBW); // Valid only for color formats
+	m_end_block = GSLocalMemory::m_psm[m_TEX0.PSM].info.bn(m_valid.z - 1, m_valid.w - 1, m_TEX0.TBP0, m_TEX0.TBW); // Valid only for color formats
 
 	// GL_CACHE("UpdateValidity (0x%x->0x%x) from R:%d,%d Valid: %d,%d", m_TEX0.TBP0, m_end_block, rect.z, rect.w, m_valid.z, m_valid.w);
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -125,7 +125,7 @@ public:
 		GIFRegTEX0 m_layer_TEX0[7]; // Detect already loaded value
 		// Keep a GSTextureCache::SourceMap::m_map iterator to allow fast erase
 		std::array<uint16, MAX_PAGES> m_erase_it;
-		uint32* m_pages_as_bit;
+		GSOffset::PageLooper m_pages;
 
 	public:
 		Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, uint8* temp, bool dummy_container = false);
@@ -189,7 +189,7 @@ public:
 			memset(m_pages, 0, sizeof(m_pages));
 		}
 
-		void Add(Source* s, const GIFRegTEX0& TEX0, GSOffset* off);
+		void Add(Source* s, const GIFRegTEX0& TEX0, const GSOffset& off);
 		void RemoveAll();
 		void RemovePartial();
 		void RemoveAt(Source* s);
@@ -249,8 +249,8 @@ public:
 
 	void InvalidateVideoMemType(int type, uint32 bp);
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
-	void InvalidateVideoMem(GSOffset* off, const GSVector4i& r, bool target = true);
-	void InvalidateLocalMem(GSOffset* off, const GSVector4i& r);
+	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool target = true);
+	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r);
 
 	void IncAge();
 	bool UserHacks_HalfPixelOffset;

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureCacheOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureCacheOGL.cpp
@@ -78,7 +78,7 @@ void GSTextureCacheOGL::Read(Target* t, const GSVector4i& r)
 		{
 			// TODO: block level write
 
-			GSOffset* off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
+			GSOffset off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
 			switch (TEX0.PSM)
 			{
@@ -125,7 +125,7 @@ void GSTextureCacheOGL::Read(Source* t, const GSVector4i& r)
 
 		if (offscreen->Map(m, &r_offscreen))
 		{
-			GSOffset* off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
+			GSOffset off = m_renderer->m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
 			m_renderer->m_mem.WritePixel32(m.bits, m.pitch, off, r);
 

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -2811,31 +2811,28 @@ void GSDrawScanline::DrawRect(const GSVector4i& r, const GSVertexSW& v)
 
 	if (m != 0xffffffff)
 	{
-		const int* zbr = m_global.zbr;
-		const int* zbc = m_global.zbc;
-
 		uint32 z = v.t.u32[3]; // (uint32)v.p.z;
 
 		if (m_global.sel.zpsm != 2)
 		{
 			if (m == 0)
 			{
-				DrawRectT<uint32, false>(zbr, zbc, r, z, m);
+				DrawRectT<uint32, false>(m_global.zbo, r, z, m);
 			}
 			else
 			{
-				DrawRectT<uint32, true>(zbr, zbc, r, z, m);
+				DrawRectT<uint32, true>(m_global.zbo, r, z, m);
 			}
 		}
 		else
 		{
 			if ((m & 0xffff) == 0)
 			{
-				DrawRectT<uint16, false>(zbr, zbc, r, z, m);
+				DrawRectT<uint16, false>(m_global.zbo, r, z, m);
 			}
 			else
 			{
-				DrawRectT<uint16, true>(zbr, zbc, r, z, m);
+				DrawRectT<uint16, true>(m_global.zbo, r, z, m);
 			}
 		}
 	}
@@ -2848,9 +2845,6 @@ void GSDrawScanline::DrawRect(const GSVector4i& r, const GSVertexSW& v)
 
 	if (m != 0xffffffff)
 	{
-		const int* fbr = m_global.fbr;
-		const int* fbc = m_global.fbc;
-
 		uint32 c = (GSVector4i(v.c) >> 7).rgba32();
 
 		if (m_global.sel.fba)
@@ -2862,11 +2856,11 @@ void GSDrawScanline::DrawRect(const GSVector4i& r, const GSVertexSW& v)
 		{
 			if (m == 0)
 			{
-				DrawRectT<uint32, false>(fbr, fbc, r, c, m);
+				DrawRectT<uint32, false>(m_global.fbo, r, c, m);
 			}
 			else
 			{
-				DrawRectT<uint32, true>(fbr, fbc, r, c, m);
+				DrawRectT<uint32, true>(m_global.fbo, r, c, m);
 			}
 		}
 		else
@@ -2875,18 +2869,18 @@ void GSDrawScanline::DrawRect(const GSVector4i& r, const GSVertexSW& v)
 
 			if ((m & 0xffff) == 0)
 			{
-				DrawRectT<uint16, false>(fbr, fbc, r, c, m);
+				DrawRectT<uint16, false>(m_global.fbo, r, c, m);
 			}
 			else
 			{
-				DrawRectT<uint16, true>(fbr, fbc, r, c, m);
+				DrawRectT<uint16, true>(m_global.fbo, r, c, m);
 			}
 		}
 	}
 }
 
 template <class T, bool masked>
-void GSDrawScanline::DrawRectT(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, uint32 c, uint32 m)
+void GSDrawScanline::DrawRectT(const GSOffset& off, const GSVector4i& r, uint32 c, uint32 m)
 {
 	if (m == 0xffffffff)
 		return;
@@ -2921,25 +2915,25 @@ void GSDrawScanline::DrawRectT(const int* RESTRICT row, const int* RESTRICT col,
 
 	if (!br.rempty())
 	{
-		FillRect<T, masked>(row, col, GSVector4i(r.x, r.y, r.z, br.y), c, m);
-		FillRect<T, masked>(row, col, GSVector4i(r.x, br.w, r.z, r.w), c, m);
+		FillRect<T, masked>(off, GSVector4i(r.x, r.y, r.z, br.y), c, m);
+		FillRect<T, masked>(off, GSVector4i(r.x, br.w, r.z, r.w), c, m);
 
 		if (r.x < br.x || br.z < r.z)
 		{
-			FillRect<T, masked>(row, col, GSVector4i(r.x, br.y, br.x, br.w), c, m);
-			FillRect<T, masked>(row, col, GSVector4i(br.z, br.y, r.z, br.w), c, m);
+			FillRect<T, masked>(off, GSVector4i(r.x, br.y, br.x, br.w), c, m);
+			FillRect<T, masked>(off, GSVector4i(br.z, br.y, r.z, br.w), c, m);
 		}
 
-		FillBlock<T, masked>(row, col, br, color, mask);
+		FillBlock<T, masked>(off, br, color, mask);
 	}
 	else
 	{
-		FillRect<T, masked>(row, col, r, c, m);
+		FillRect<T, masked>(off, r, c, m);
 	}
 }
 
 template <class T, bool masked>
-void GSDrawScanline::FillRect(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, uint32 c, uint32 m)
+void GSDrawScanline::FillRect(const GSOffset& off, const GSVector4i& r, uint32 c, uint32 m)
 {
 	if (r.x >= r.z)
 		return;
@@ -2948,11 +2942,12 @@ void GSDrawScanline::FillRect(const int* RESTRICT row, const int* RESTRICT col, 
 
 	for (int y = r.y; y < r.w; y++)
 	{
-		T* RESTRICT d = &vm[row[y]];
+		GSOffset::PAHelper pa = off.paMulti(r.x, y);
 
-		for (int x = r.x; x < r.z; x++)
+		for (; pa.x() < r.z; pa.incX())
 		{
-			d[col[x]] = (T)(!masked ? c : (c | (d[col[x]] & m)));
+			T& d = vm[pa.value()];
+			d = (T)(!masked ? c : (c | (d & m)));
 		}
 	}
 }
@@ -2960,7 +2955,7 @@ void GSDrawScanline::FillRect(const int* RESTRICT row, const int* RESTRICT col, 
 #if _M_SSE >= 0x501
 
 template <class T, bool masked>
-void GSDrawScanline::FillBlock(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, const GSVector8i& c, const GSVector8i& m)
+void GSDrawScanline::FillBlock(const GSOffset& off, const GSVector4i& r, const GSVector8i& c, const GSVector8i& m)
 {
 	if (r.x >= r.z)
 		return;
@@ -2969,11 +2964,9 @@ void GSDrawScanline::FillBlock(const int* RESTRICT row, const int* RESTRICT col,
 
 	for (int y = r.y; y < r.w; y += 8)
 	{
-		T* RESTRICT d = &vm[row[y]];
-
 		for (int x = r.x; x < r.z; x += 8 * 4 / sizeof(T))
 		{
-			GSVector8i* RESTRICT p = (GSVector8i*)&d[col[x]];
+			GSVector8i* RESTRICT p = (GSVector8i*)&vm[off.pa(x, y)];
 
 			p[0] = !masked ? c : (c | (p[0] & m));
 			p[1] = !masked ? c : (c | (p[1] & m));
@@ -2990,7 +2983,7 @@ void GSDrawScanline::FillBlock(const int* RESTRICT row, const int* RESTRICT col,
 #else
 
 template <class T, bool masked>
-void GSDrawScanline::FillBlock(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, const GSVector4i& c, const GSVector4i& m)
+void GSDrawScanline::FillBlock(const GSOffset& off, const GSVector4i& r, const GSVector4i& c, const GSVector4i& m)
 {
 	if (r.x >= r.z)
 		return;
@@ -2999,11 +2992,9 @@ void GSDrawScanline::FillBlock(const int* RESTRICT row, const int* RESTRICT col,
 
 	for (int y = r.y; y < r.w; y += 8)
 	{
-		T* RESTRICT d = &vm[row[y]];
-
 		for (int x = r.x; x < r.z; x += 8 * 4 / sizeof(T))
 		{
-			GSVector4i* RESTRICT p = (GSVector4i*)&d[col[x]];
+			GSVector4i* RESTRICT p = (GSVector4i*)&vm[off.pa(x, y)];
 
 			for (int i = 0; i < 16; i += 4)
 			{

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -2942,11 +2942,11 @@ void GSDrawScanline::FillRect(const GSOffset& off, const GSVector4i& r, uint32 c
 
 	for (int y = r.y; y < r.w; y++)
 	{
-		GSOffset::PAHelper pa = off.paMulti(y);
+		auto pa = off.paMulti(vm, 0, y);
 
 		for (int x = r.x; x < r.z; x++)
 		{
-			T& d = vm[pa.value(x)];
+			T& d = *pa.value(x);
 			d = (T)(!masked ? c : (c | (d & m)));
 		}
 	}
@@ -2992,9 +2992,11 @@ void GSDrawScanline::FillBlock(const GSOffset& off, const GSVector4i& r, const G
 
 	for (int y = r.y; y < r.w; y += 8)
 	{
+		auto pa = off.paMulti(vm, 0, y);
+
 		for (int x = r.x; x < r.z; x += 8 * 4 / sizeof(T))
 		{
-			GSVector4i* RESTRICT p = (GSVector4i*)&vm[off.pa(x, y)];
+			GSVector4i* RESTRICT p = (GSVector4i*)pa.value(x);
 
 			for (int i = 0; i < 16; i += 4)
 			{

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -2942,11 +2942,11 @@ void GSDrawScanline::FillRect(const GSOffset& off, const GSVector4i& r, uint32 c
 
 	for (int y = r.y; y < r.w; y++)
 	{
-		GSOffset::PAHelper pa = off.paMulti(r.x, y);
+		GSOffset::PAHelper pa = off.paMulti(y);
 
-		for (; pa.x() < r.z; pa.incX())
+		for (int x = r.x; x < r.z; x++)
 		{
-			T& d = vm[pa.value()];
+			T& d = vm[pa.value(x)];
 			d = (T)(!masked ? c : (c | (d & m)));
 		}
 	}

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.h
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.h
@@ -38,20 +38,20 @@ protected:
 	GSCodeGeneratorFunctionMap<GSDrawScanlineCodeGenerator, uint64, DrawScanlinePtr> m_ds_map;
 
 	template <class T, bool masked>
-	void DrawRectT(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, uint32 c, uint32 m);
+	void DrawRectT(const GSOffset& off, const GSVector4i& r, uint32 c, uint32 m);
 
 	template <class T, bool masked>
-	__forceinline void FillRect(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, uint32 c, uint32 m);
+	__forceinline void FillRect(const GSOffset& off, const GSVector4i& r, uint32 c, uint32 m);
 
 #if _M_SSE >= 0x501
 
 	template <class T, bool masked>
-	__forceinline void FillBlock(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, const GSVector8i& c, const GSVector8i& m);
+	__forceinline void FillBlock(const GSOffset& off, const GSVector4i& r, const GSVector8i& c, const GSVector8i& m);
 
 #else
 
 	template <class T, bool masked>
-	__forceinline void FillBlock(const int* RESTRICT row, const int* RESTRICT col, const GSVector4i& r, const GSVector4i& c, const GSVector4i& m);
+	__forceinline void FillBlock(const GSOffset& off, const GSVector4i& r, const GSVector4i& c, const GSVector4i& m);
 
 #endif
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.h
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.h
@@ -35,8 +35,8 @@ class GSRendererSW : public GSRenderer
 
 	public:
 		GSRendererSW* m_parent;
-		const uint32* m_fb_pages;
-		const uint32* m_zb_pages;
+		GSOffset::PageLooper m_fb_pages;
+		GSOffset::PageLooper m_zb_pages;
 		int m_fpsm;
 		int m_zpsm;
 		bool m_using_pages;
@@ -52,7 +52,7 @@ class GSRendererSW : public GSRenderer
 		SharedData(GSRendererSW* parent);
 		virtual ~SharedData();
 
-		void UsePages(const uint32* fb_pages, int fpsm, const uint32* zb_pages, int zpsm);
+		void UsePages(const GSOffset::PageLooper* fb_pages, int fpsm, const GSOffset::PageLooper* zb_pages, int zpsm);
 		void ReleasePages();
 
 		void SetSource(GSTextureCacheSW::Texture* t, const GSVector4i& r, int level);
@@ -76,7 +76,6 @@ protected:
 	uint32 m_fzb_cur_pages[16];
 	std::atomic<uint32> m_fzb_pages[512]; // uint16 frame/zbuf pages interleaved
 	std::atomic<uint16> m_tex_pages[512];
-	uint32 m_tmp_pages[512 + 1];
 
 	void Reset();
 	void VSync(int field);
@@ -90,10 +89,10 @@ protected:
 	void InvalidateVideoMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r);
 	void InvalidateLocalMem(const GIFRegBITBLTBUF& BITBLTBUF, const GSVector4i& r, bool clut = false);
 
-	void UsePages(const uint32* pages, const int type);
-	void ReleasePages(const uint32* pages, const int type);
+	void UsePages(const GSOffset::PageLooper& pages, const int type);
+	void ReleasePages(const GSOffset::PageLooper& pages, const int type);
 
-	bool CheckTargetPages(const uint32* fb_pages, const uint32* zb_pages, const GSVector4i& r);
+	bool CheckTargetPages(const GSOffset::PageLooper* fb_pages, const GSOffset::PageLooper* zb_pages, const GSVector4i& r);
 	bool CheckSourcePages(SharedData* sd);
 
 	bool GetScanlineGlobalData(SharedData* data);

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -127,10 +127,8 @@ struct alignas(32) GSScanlineGlobalData // per batch variables, this is like a p
 	uint32* clut;
 	GSVector4i* dimx;
 
-	const int* fbr;
-	const int* zbr;
-	const int* fbc;
-	const int* zbc;
+	GSOffset fbo;
+	GSOffset zbo;
 	const GSVector2i* fzbr;
 	const GSVector2i* fzbc;
 

--- a/pcsx2/GS/Renderers/SW/GSTextureCacheSW.h
+++ b/pcsx2/GS/Renderers/SW/GSTextureCacheSW.h
@@ -25,7 +25,8 @@ public:
 	{
 	public:
 		GSState* m_state;
-		GSOffset* m_offset;
+		GSOffset m_offset;
+		GSOffset::PageLooper m_pages;
 		GIFRegTEX0 m_TEX0;
 		GIFRegTEXA m_TEXA;
 		void* m_buff;
@@ -36,7 +37,6 @@ public:
 		std::vector<GSVector2i>* m_p2t;
 		uint32 m_valid[MAX_PAGES];
 		std::array<uint16, MAX_PAGES> m_erase_it;
-		struct { uint32 bm[16]; const uint32* n; } m_pages;
 		const uint32* RESTRICT m_sharedbits;
 
 		// m_valid
@@ -61,7 +61,7 @@ public:
 
 	Texture* Lookup(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, uint32 tw0 = 0);
 
-	void InvalidatePages(const uint32* pages, uint32 psm);
+	void InvalidatePages(const GSOffset::PageLooper& pages, uint32 psm);
 
 	void RemoveAll();
 	void IncAge();

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -46,6 +46,7 @@
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>PrecompiledHeader.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+      <AdditionalOptions>/Zc:externConstexpr %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;SPU2X_PORTAUDIO;DIRECTINPUT_VERSION=0x0800;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Devel))">PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/tests/ctest/GS/swizzle_test_nops.cpp
+++ b/tests/ctest/GS/swizzle_test_nops.cpp
@@ -21,7 +21,7 @@
 #include "GSLocalMemory.h"
 
 GSLocalMemory::psm_t GSLocalMemory::m_psm[64];
-GSOffset* GSLocalMemory::GetOffset(uint32 bp, uint32 bw, uint32 psm)
+GSOffset GSLocalMemory::GetOffset(uint32 bp, uint32 bw, uint32 psm)
 {
 	abort();
 }

--- a/tests/ctest/GS/swizzle_test_nops.cpp
+++ b/tests/ctest/GS/swizzle_test_nops.cpp
@@ -21,10 +21,6 @@
 #include "GSLocalMemory.h"
 
 GSLocalMemory::psm_t GSLocalMemory::m_psm[64];
-GSOffset GSLocalMemory::GetOffset(uint32 bp, uint32 bw, uint32 psm)
-{
-	abort();
-}
 
 void* vmalloc(size_t size, bool code)
 {


### PR DESCRIPTION
Should fix #2686, please test

The non-cached calculations are pretty fast, but generally not quite as fast as the cached versions.  I haven't noticed any slowdown in anything I've tested, but it might be good for others to test.

Also this makes heavy use of lambdas hoping they'll be inlined, so we should performance test MSVC and make sure it actually does

Finally, we haven't used them much before, so what are people's thoughts on formatting lambdas passed to functions? I went with this (indented like you would the content of a loop):
```cpp
s->m_pages.loopPages([this, s](uint32 page)
{
	s->m_erase_it[page] = m_map[page].InsertFront(s);
});
```
but we could also go with this
```cpp
s->m_pages.loopPages([this, s](uint32 page)
	{
		s->m_erase_it[page] = m_map[page].InsertFront(s);
	});
```
or this
```cpp
s->m_pages.loopPages(
	[this, s](uint32 page)
	{
		s->m_erase_it[page] = m_map[page].InsertFront(s);
	});
```
I personally would like to not go with clang-format's preference of this, it destroys horizontal space
```cpp
s->m_pages.loopPages([this, s](uint32 page)
                     {
                         s->m_erase_it[page] = m_map[page].InsertFront(s);
                     });
```
Same question for locals
```cpp
auto helper = [&](...)
{
};
```
or
```cpp
auto helper = [&](...)
	{
	};
```