### PR TITLE
gsdx-gui: Remove partial and full crc hack levels on release builds.

### DIFF
--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -280,8 +280,10 @@ void GSdxApp::Init()
 		GSSetting(CRCHackLevel::Automatic, "Automatic", "Default"),
 		GSSetting(CRCHackLevel::None, "None", "Debug"),
 		GSSetting(CRCHackLevel::Minimum, "Minimum", "Debug"),
+#ifdef _DEBUG
 		GSSetting(CRCHackLevel::Partial, "Partial", "OpenGL"),
 		GSSetting(CRCHackLevel::Full, "Full", "Direct3D"),
+#endif
 		GSSetting(CRCHackLevel::Aggressive, "Aggressive", ""),
 	};
 

--- a/plugins/GSdx/Window/GSSetting.cpp
+++ b/plugins/GSdx/Window/GSSetting.cpp
@@ -58,12 +58,9 @@ const char* dialog_message(int ID, bool* updateText)
 		case IDC_CRC_LEVEL:
 			return cvtString("Control the number of Auto-CRC fixes and hacks applied to games.\n\n"
 				"Automatic:\nAutomatically sets the recommended CRC level based on the selected renderer.\n"
-				"This is the recommended setting.\n"
-				"Partial will be selected for OpenGL.\nFull will be selected for Direct3D 11.\n\n"
+				"This is the recommended setting.\n\n"
 				"None:\nRemove all CRC rendering fixes and hacks.\n\n"
 				"Minimum:\nEnables CRC lookup for special post processing effects.\n\n"
-				"Partial:\nFor an optimal experience with OpenGL.\n\n"
-				"Full:\nFor an optimal experience with Direct3D 11.\n\n"
 				"Aggressive:\nUse more aggressive CRC hacks.\n"
 				"Removes effects in some games which make the image appear sharper/clearer.\n"
 				"Affected games: AC4, BleachBB, Bully, DBZBT 2 & 3, DeathByDegrees, Evangelion, FF games, FightingBeautyWulong, GOW 1 & 2, Kunoichi, IkkiTousen, Okami, Oneechanbara2, OnimushaDoD, RDRevolver, Simple2000Vol114, SoTC, SteambotChronicles, Tekken5, Ultraman, XenosagaE3, Yakuza 1 & 2.\n");


### PR DESCRIPTION
Normal users shouldn't really need to choose partial or full since
automatic already does that.
Keep the options on debug for testing only.