### PR TITLE
Input Recording: Cleanup inputRec utility namespace

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -818,6 +818,7 @@ set(pcsx2RecordingSources
 	${rec_src}/InputRecordingFile.cpp
 	${rec_src}/NewRecordingFrame.cpp
 	${rec_src}/PadData.cpp
+	${rec_src}/Utilities/InputRecordingLogger.cpp
 	${rec_vp_src}/VirtualPad.cpp
 	${rec_vp_src}/VirtualPadData.cpp
 	${rec_vp_src}/VirtualPadResources.cpp

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
@@ -1,0 +1,50 @@
+﻿/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#include "InputRecordingLogger.h"
+
+namespace inputRec
+{
+	void log(const std::string log)
+	{
+		if (log.empty())
+			return;
+
+		recordingConLog(fmt::format("[REC]: {}\n", log));
+
+		// NOTE - Color is not currently used for OSD logs
+		if (GSosdLog)
+			GSosdLog(log.c_str(), wxGetApp().GetProgramLog()->GetRGBA(ConsoleColors::Color_StrongMagenta));
+	}
+
+	void consoleLog(const std::string log)
+	{
+		if (log.empty())
+			return;
+
+		recordingConLog(fmt::format("[REC]: {}\n", log));
+	}
+
+	void consoleMultiLog(std::vector<std::string> logs)
+	{
+		std::string log;
+		for (std::string l : logs)
+			log.append(fmt::format("[REC]: {}\n", l));
+
+		recordingConLog(log);
+	}
+} // namespace inputRec

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
@@ -19,7 +19,7 @@
 
 namespace inputRec
 {
-	void log(const std::string log)
+	void log(const std::string& log)
 	{
 		if (log.empty())
 			return;
@@ -31,7 +31,7 @@ namespace inputRec
 			GSosdLog(log.c_str(), wxGetApp().GetProgramLog()->GetRGBA(ConsoleColors::Color_StrongMagenta));
 	}
 
-	void consoleLog(const std::string log)
+	void consoleLog(const std::string& log)
 	{
 		if (log.empty())
 			return;
@@ -39,7 +39,7 @@ namespace inputRec
 		recordingConLog(fmt::format("[REC]: {}\n", log));
 	}
 
-	void consoleMultiLog(std::vector<std::string> logs)
+	void consoleMultiLog(const std::vector<std::string>& logs)
 	{
 		std::string log;
 		for (std::string l : logs)

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.h
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -28,32 +28,7 @@
 
 namespace inputRec
 {
-	static void log(const std::string log)
-	{
-		if (log.empty())
-			return;
-
-		recordingConLog(fmt::format("[REC]: {}\n", log));
-
-		// NOTE - Color is not currently used for OSD logs
-		if (GSosdLog)
-			GSosdLog(log.c_str(), wxGetApp().GetProgramLog()->GetRGBA(ConsoleColors::Color_StrongMagenta));
-	}
-
-	static void consoleLog(const std::string log)
-	{
-		if (log.empty())
-			return;
-
-		recordingConLog(fmt::format("[REC]: {}\n", log));
-	}
-
-	static void consoleMultiLog(std::vector<std::string> logs)
-	{
-		std::string log;
-		for (std::string l : logs)
-			log.append(fmt::format("[REC]: {}\n", l));
-
-		recordingConLog(log);
-	}
+	extern void log(const std::string log);
+	extern void consoleLog(const std::string log);
+	extern void consoleMultiLog(std::vector<std::string> logs);
 } // namespace inputRec

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.h
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.h
@@ -28,7 +28,7 @@
 
 namespace inputRec
 {
-	extern void log(const std::string log);
-	extern void consoleLog(const std::string log);
-	extern void consoleMultiLog(std::vector<std::string> logs);
+	void log(const std::string& log);
+	void consoleLog(const std::string& log);
+	void consoleMultiLog(const std::vector<std::string>& logs);
 } // namespace inputRec

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj
@@ -331,6 +331,7 @@
     <ClCompile Include="..\..\PAD\Windows\WindowsMouse.cpp" />
     <ClCompile Include="..\..\PAD\Windows\WndProcEater.cpp" />
     <ClCompile Include="..\..\PAD\Windows\XInputEnum.cpp" />
+    <ClCompile Include="..\..\Recording\Utilities\InputRecordingLogger.cpp" />
     <ClCompile Include="..\..\SPU2\DplIIdecoder.cpp" />
     <ClCompile Include="..\..\SPU2\debug.cpp" />
     <ClCompile Include="..\..\SPU2\RegLog.cpp" />

--- a/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
+++ b/pcsx2/windows/VCprojects/pcsx2.vcxproj.filters
@@ -1315,6 +1315,9 @@
     <ClCompile Include="..\..\CDVD\ChdFileReader.cpp">
       <Filter>System\ISO</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Recording\Utilities\InputRecordingLogger.cpp">
+      <Filter>Recording\Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Patch.h">
@@ -2243,10 +2246,5 @@
     <Manifest Include="..\PCSX2.manifest">
       <Filter>AppHost\Resources</Filter>
     </Manifest>
-  </ItemGroup>
-  <ItemGroup>
-    <Image Include="..\..\gui\Resources\NoIcon.png">
-      <Filter>AppHost\Resources</Filter>
-    </Image>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When these utility functions / namespace were originally made it wasn't done in the ideal way, this just quickly cleans that up.