### PR TITLE
clang-format: change alignment settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,12 @@
 ---
 Language:        Cpp
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
+AlignEscapedNewlines: DontAlign
 AlignOperands:   true
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false


### PR DESCRIPTION
A few common issues I saw while formatting GSdx:

### AlignTrailingComments on → off
When formatting GSdx code, I found that clang-format found random unrelated comments that just happened to be next to each other and decided to align them much more often than it found related comments that actually made sense to try to align, so defaulting to off decreases the number of cases that we have to disagree with clang-format.

### AlignAfterOpenBracket on → off
This changes the default alignment of multiline function calls from this
```cpp
longFunctionName(param1, param2
                 param3, param4)
```
to this
```cpp
longFunctionName(param1, param2
	param3, param4)
```
Two reasons for this:
1. Clang-format currently does this with tabs instead of spaces, causing the alignment to fail to align on e.g. the GitHub website.  #4000 does fix this but after having used that mode on some other stuff, clang-format 11's implementation of it breaks just as many things as it fixes.  We also don't have to worry about requiring clang-format 11 this way
2. While I do usually prefer the alignment for shorter function names, once the function name gets long starting each line halfway across the screen doesn't work out so well if you ever decide to resize your window e.g. for 2-column view.  Therefore I think that while aligning function parameters is a nice thing to do on a case-by-case basis, having it the default in the autoformatter is a net negative and it should be disabled

### AlignEscapedNewlines Left → DontAlign
This is similar to issue 2 above, if you're working on a small display with soft wrap for whatever reason, this:
```cpp
#define REG64(name) \
union name			\
{					\
	uint64 u64;		\
	uint32 u32[2];	\
	void operator = (const GSVector4i& v) {GSVector4i::storel(this, v);} \
	bool operator == (const union name& r) const {return ((GSVector4i)r).eq(*this);} \
	bool operator != (const union name& r) const {return !((GSVector4i)r).eq(*this);} \
	operator GSVector4i() const {return GSVector4i::loadl(this);} \
	struct {		\
```
turns into this
```cpp
#define REG64(name) \
union name          \
{                   \
    uint64 u64;     \
    uint32 u32[2];  \
    void operator = (const GSVector4i& v) {GSVector4i::storel(this,
        v);} \
    bool operator == (const union name& r) const {return
        ((GSVector4i)r).eq(*this);} \
    bool operator != (const union name& r) const {return
        !((GSVector4i)r).eq(*this);} \
    operator GSVector4i() const {return GSVector4i::loadl(this);} \
    struct {        \
```
but this
```cpp
#define REG64(name)                                                                   \
union name                                                                            \
{                                                                                     \
    uint64 u64;                                                                       \
    uint32 u32[2];                                                                    \
    void operator = (const GSVector4i& v) {GSVector4i::storel(this, v);}              \
    bool operator == (const union name& r) const {return ((GSVector4i)r).eq(*this);}  \
    bool operator != (const union name& r) const {return !((GSVector4i)r).eq(*this);} \
    operator GSVector4i() const {return GSVector4i::loadl(this);}                     \
    struct {                                                                          \
```
turns into this
```cpp
#define REG64(name)                                                    
                   \
union name                                                             
                   \
{                                                                      
                   \
    uint64 u64;                                                        
                       \
    uint32 u32[2];                                                     
                       \
    void operator = (const GSVector4i& v) {GSVector4i::storel(this,
        v);}              \
    bool operator == (const union name& r) const {return
        ((GSVector4i)r).eq(*this);}  \
    bool operator != (const union name& r) const {return
        !((GSVector4i)r).eq(*this);} \
    operator GSVector4i() const {return GSVector4i::loadl(this);}     
                        \
    struct {                                                          
                        \
```
Which is considerably less readable.  Given that clang-format does not have an "align with longest line shorter than x" option, I think the best default is to not align at all.