### PR TITLE
DEV9: Do not apply byteswapping to TX/RX FIFO writes/reads

### DIFF
--- a/pcsx2/DEV9/smap.cpp
+++ b/pcsx2/DEV9/smap.cpp
@@ -524,9 +524,6 @@ smap_read32(u32 addr)
 
 			dev9Ru32(SMAP_R_RXFIFO_RD_PTR) = ((rd_ptr + 4) & 16383);
 
-			if (dev9.bd_swap)
-				rv = (rv << 24) | (rv >> 24) | ((rv >> 8) & 0xFF00) | ((rv << 8) & 0xFF0000);
-
 			DevCon.WriteLn("SMAP_R_RXFIFO_DATA 32bit read %x", rv);
 			return rv;
 		}
@@ -807,9 +804,6 @@ smap_write32(u32 addr, u32 value)
 	switch (addr)
 	{
 		case SMAP_R_TXFIFO_DATA:
-			if (dev9.bd_swap)
-				value = (value << 24) | (value >> 24) | ((value >> 8) & 0xFF00) | ((value << 8) & 0xFF0000);
-
 			DevCon.WriteLn("SMAP_R_TXFIFO_DATA 32bit write %x", value);
 			*((u32*)(dev9.txfifo + dev9Ru32(SMAP_R_TXFIFO_WR_PTR))) = value;
 			dev9Ru32(SMAP_R_TXFIFO_WR_PTR) = (dev9Ru32(SMAP_R_TXFIFO_WR_PTR) + 4) & 16383;


### PR DESCRIPTION
### Description of Changes
Remove the byte swapping done to TX/RX FIFO writes/reads performed via registers.

### Rationale behind Changes
Removing this fixes https://github.com/PCSX2/pcsx2/issues/3192, which now completes connecting to the network.
I suspect this setting is only for reads/writes to the SMAP_BD_TX/SMAP_BD_RX registers.

It was also brought to my attention that a demo version of Frequency, included on one of the Network Setup Discs, also needs this change to connect to the network.

### Suggested Testing Steps
Test various Network/LAN games for any regressions.
