### PR TITLE
Input Recording: Resolve crash when closing emulator involving GUI elements

### DIFF
--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -140,6 +140,18 @@ void InputRecordingControls::Resume()
 	}
 	pauseEmulation = false;
 	resumeEmulation = true;
+}
+
+void InputRecordingControls::ResumeImmediately()
+{
+	if (!CoreThread.IsPaused())
+		return;
+	Resume();
+	if (CoreThread.IsPaused() && CoreThread.IsRunning())
+	{
+		emulationCurrentlyPaused = false;
+		CoreThread.Resume();
+	}
 }
 
 void InputRecordingControls::TogglePause()

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2020  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -38,19 +38,19 @@ public:
 	// Called much more frequently than HandleFrameAdvanceAndPausing, instead of being per frame
 	// this hooks into pcsx2's main App event handler as it has to be able to resume emulation
 	// when drawing frames has compltely stopped
-	// 
+	//
 	// Resumes emulation if:
 	// - CoreThread is currently open and paused
 	// - We've signaled emulation to be resumed via TogglePause or FrameAdvancing
 	void ResumeCoreThreadIfStarted();
-	
+
 	// Resume emulation (incase the emulation is currently paused) and pause after a single frame has passed
 	void FrameAdvance();
 	// Returns true if emulation is currently set up to frame advance.
 	bool IsFrameAdvancing();
 	// Returns true if the input recording has been paused, which can occur:
 	// - After a single frame has passed after InputRecordingControls::FrameAdvance
-	// - Explicitly paused via an InputRecordingControls function 
+	// - Explicitly paused via an InputRecordingControls function
 	bool IsPaused();
 	// Pause emulation at the next available Vsync
 	void Pause();
@@ -58,6 +58,10 @@ public:
 	void PauseImmediately();
 	// Resume emulation when the next pcsx2 App event is handled
 	void Resume();
+	/**
+	 * @brief Resumes emulation immediately, don't wait until the next VSync
+	*/
+	void ResumeImmediately();
 	// Alternates emulation between a paused and unpaused state
 	void TogglePause();
 	// Switches between recording and replaying the active input recording file

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -1045,9 +1045,10 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& e
 #ifndef DISABLE_RECORDING
 void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 {
-	const bool initiallyPaused = g_InputRecordingControls.IsPaused();
+	const bool emulation_initially_paused = CoreThread.IsPaused();
+	const bool recording_initially_paused = g_InputRecordingControls.IsPaused();
 
-	if (!initiallyPaused)
+	if (!emulation_initially_paused && !recording_initially_paused)
 		g_InputRecordingControls.PauseImmediately();
 
 	NewRecordingFrame* newRecordingFrame = wxGetApp().GetNewRecordingFramePtr();
@@ -1063,8 +1064,8 @@ void MainEmuFrame::Menu_Recording_New_Click(wxCommandEvent& event)
 			}
 		}
 
-		if (!initiallyPaused)
-			g_InputRecordingControls.Resume();
+		if (!emulation_initially_paused && !recording_initially_paused)
+			g_InputRecordingControls.ResumeImmediately();
 	}
 }
 


### PR DESCRIPTION
<!--
If this is your first PR to PCSX2, please review the relevant documentation:
- https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

The gist is we paused the CoreThread without resuming it (input recording's `Resume()` method will resume on the next VSync), the shutdown routine triggers it when all required window elements are already cleaned up, hence the crash.

![image](https://user-images.githubusercontent.com/13153231/115495791-6e749580-a236-11eb-8a11-5d1078ca35f0.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Solves a bug that results in an unexpected GUI error window when closing the emulator after very specific/edge-casey steps.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Reproduction Steps:
- boot game so gs window is open
- close the GS window
- open the dialog for a new input recording, then close it
- close pcsx2, should error.

fyi @sonicfind incase this breaks something to do with input-recording's frame locking behaviour.