### PR TITLE
Input Recording - Allow configuration of the frame advance amount

### DIFF
--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -31,7 +31,8 @@ InputRecordingControls g_InputRecordingControls;
 
 void InputRecordingControls::CheckPauseStatus()
 {
-	if (frameAdvancing)
+	frame_advance_frame_counter++;
+	if (frameAdvancing && frame_advance_frame_counter >= frames_per_frame_advance)
 	{
 		frameAdvancing = false;
 		pauseEmulation = true;
@@ -99,7 +100,13 @@ void InputRecordingControls::FrameAdvance()
 		return;
 	}
 	frameAdvancing = true;
+	frame_advance_frame_counter = 0;
 	Resume();
+}
+
+void InputRecordingControls::setFrameAdvanceAmount(int amount)
+{
+	frames_per_frame_advance = amount;
 }
 
 bool InputRecordingControls::IsFrameAdvancing()

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -46,6 +46,7 @@ public:
 	
 	// Resume emulation (incase the emulation is currently paused) and pause after a single frame has passed
 	void FrameAdvance();
+	void setFrameAdvanceAmount(int amount);
 	// Returns true if emulation is currently set up to frame advance.
 	bool IsFrameAdvancing();
 	// Returns true if the input recording has been paused, which can occur:
@@ -73,6 +74,8 @@ private:
 	// Indicates on the next VSync if we are frame advancing, this value
 	// and should be cleared once a single frame has passed
 	bool frameAdvancing = false;
+	u32 frame_advance_frame_counter = 0;
+	u32 frames_per_frame_advance = 1;
 	// Indicates if we intend to call CoreThread.PauseSelf() on the current or next available vsync
 	bool pauseEmulation = false;
 	// Indicates if we intend to call CoreThread.Resume() when the next pcsx2 App event is handled

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -204,6 +204,8 @@ enum MenuIdentifiers
 	MenuId_Recording_New,
 	MenuId_Recording_Play,
 	MenuId_Recording_Stop,
+	MenuId_Recording_Settings,
+	MenuId_Recording_Config_FrameAdvance,
 	MenuId_Recording_TogglePause,
 	MenuId_Recording_FrameAdvance,
 	MenuId_Recording_ToggleRecordingMode,

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -913,6 +913,7 @@ void AppConfig::GSWindowOptions::LoadSave( IniInterface& ini )
 #ifndef DISABLE_RECORDING
 AppConfig::InputRecordingOptions::InputRecordingOptions()
 	: VirtualPadPosition(wxDefaultPosition)
+	, m_frame_advance_amount(1)
 {
 }
 
@@ -921,6 +922,7 @@ void AppConfig::InputRecordingOptions::loadSave(IniInterface& ini)
 	ScopedIniGroup path(ini, L"InputRecording");
 
 	IniEntry(VirtualPadPosition);
+	IniEntry(m_frame_advance_amount);
 }
 #endif
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -259,10 +259,11 @@ public:
 #ifndef DISABLE_RECORDING
 	struct InputRecordingOptions
 	{
-		wxPoint		VirtualPadPosition;
+		wxPoint VirtualPadPosition;
+		int m_frame_advance_amount;
 
 		InputRecordingOptions();
-		void loadSave( IniInterface& conf );
+		void loadSave(IniInterface& conf);
 	};
 #endif
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -122,6 +122,7 @@ protected:
 
 #ifndef DISABLE_RECORDING
 	wxMenu& m_menuRecording;
+	wxMenu& m_submenu_recording_settings;
 #endif
 	wxMenu& m_menuHelp;
 
@@ -164,7 +165,7 @@ public:
 	void CreateWindowsMenu();
 	void CreateCaptureMenu();
 #ifndef DISABLE_RECORDING
-	void CreateRecordMenu();
+	void CreateInputRecordingMenu();
 #endif
 	void CreateHelpMenu();
 
@@ -267,6 +268,7 @@ protected:
 	void Menu_Recording_New_Click(wxCommandEvent& event);
 	void Menu_Recording_Play_Click(wxCommandEvent& event);
 	void Menu_Recording_Stop_Click(wxCommandEvent& event);
+	void Menu_Recording_Config_FrameAdvance(wxCommandEvent& event);
 	void ApplyFirstFrameStatus();
 	void Menu_Recording_TogglePause_Click(wxCommandEvent& event);
 	void Menu_Recording_FrameAdvance_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -39,6 +39,9 @@
 
 #include "Utilities/IniInterface.h"
 
+#include "fmt/core.h"
+#include "wx/numdlg.h"
+
 #ifndef DISABLE_RECORDING
 #include "Recording/InputRecording.h"
 #include "Recording/InputRecordingControls.h"
@@ -1117,6 +1120,19 @@ void MainEmuFrame::ApplyFirstFrameStatus()
 void MainEmuFrame::Menu_Recording_Stop_Click(wxCommandEvent& event)
 {
 	StopInputRecording();
+}
+
+void MainEmuFrame::Menu_Recording_Config_FrameAdvance(wxCommandEvent& event)
+{
+	long result = wxGetNumberFromUser(_("Enter the number of frames to advance per advance"), _("Number of Frames"), _("Configure Frame Advance"), g_Conf->inputRecording.m_frame_advance_amount, 1, INT_MAX);
+	if (result != -1)
+	{
+		g_Conf->inputRecording.m_frame_advance_amount = result;
+		g_InputRecordingControls.setFrameAdvanceAmount(result);
+		wxString frame_advance_label = wxString(_("Configure Frame Advance"));
+		frame_advance_label.Append(fmt::format(" ({})", result));
+		m_submenu_recording_settings.SetLabel(MenuId_Recording_Config_FrameAdvance, frame_advance_label);
+	}
 }
 
 void MainEmuFrame::StartInputRecording()


### PR DESCRIPTION
<!--
If this is your first PR to PCSX2, please review the relevant documentation:
- https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Adds a GUI configurable setting to control how many frames the frame-advance feature should advance.

![image](https://user-images.githubusercontent.com/13153231/115947464-c826cb00-a495-11eb-8d31-ae1431baf82a.png)![image](https://user-images.githubusercontent.com/13153231/115947466-cd841580-a495-11eb-8cae-d194107b8000.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

It's not unreasonable to imagine a use-case where you may want to advance frames in multiples other than `1s`.  So this gives that ability to the user.

In the future, it would probably be nice to have 2 key-bindings, one that always advances by `1s` and another that uses a custom/configurable value.  Wouldn't be too difficult to add but I think I'm tempted to wait until PCSX2 in general has better key-binding configuration for features like that.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Easier to confirm the right amount of frames are being advanced if you are recording/playing back a recording.  Change the value, restart the emulator (should persist), etc.
