### PR TITLE
Core / VUx: Disable MTVU when VU1 Interpreter is selected

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -237,10 +237,6 @@ struct Pcsx2Config
 				EnableIOP		:1,
 				EnableVU0		:1,
 				EnableVU1		:1;
-
-			bool
-				UseMicroVU0		:1,
-				UseMicroVU1		:1;
 
 			bool
 				vuOverflow		:1,
@@ -542,10 +538,8 @@ TraceLogFilters&				SetTraceConfig();
 
 // ------------ CPU / Recompiler Options ---------------
 
-#define THREAD_VU1					(EmuConfig.Cpu.Recompiler.UseMicroVU1 && EmuConfig.Speedhacks.vuThread)
+#define THREAD_VU1					(EmuConfig.Cpu.Recompiler.EnableVU1 && EmuConfig.Speedhacks.vuThread)
 #define INSTANT_VU1					(EmuConfig.Speedhacks.vu1Instant)
-#define CHECK_MICROVU0				(EmuConfig.Cpu.Recompiler.UseMicroVU0)
-#define CHECK_MICROVU1				(EmuConfig.Cpu.Recompiler.UseMicroVU1)
 #define CHECK_EEREC					(EmuConfig.Cpu.Recompiler.EnableEE && GetCpuProviders().IsRecAvailable_EE())
 #define CHECK_CACHE					(EmuConfig.Cpu.Recompiler.EnableEECache)
 #define CHECK_IOPREC				(EmuConfig.Cpu.Recompiler.EnableIOP && GetCpuProviders().IsRecAvailable_IOP())

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -120,9 +120,6 @@ Pcsx2Config::RecompilerOptions::RecompilerOptions()
 	EnableVU0	= true;
 	EnableVU1	= true;
 
-	UseMicroVU0	= true;
-	UseMicroVU1	= true;
-
 	// vu and fpu clamping default to standard overflow.
 	vuOverflow	= true;
 	//vuExtraOverflow = false;
@@ -176,9 +173,6 @@ void Pcsx2Config::RecompilerOptions::LoadSave( IniInterface& ini )
 	IniBitBool( EnableEECache );
 	IniBitBool( EnableVU0 );
 	IniBitBool( EnableVU1 );
-
-	IniBitBool( UseMicroVU0 );
-	IniBitBool( UseMicroVU1 );
 
 	IniBitBool( vuOverflow );
 	IniBitBool( vuExtraOverflow );

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -182,14 +182,12 @@ void Pcsx2App::AllocateCoreStuffs()
 			if (BaseException* ex = m_CpuProviders->GetException_MicroVU0())
 			{
 				scrollableTextArea->AppendText(L"* microVU0\n\t" + ex->FormatDisplayMessage() + L"\n\n");
-				recOps.UseMicroVU0 = false;
 				recOps.EnableVU0 = false;
 			}
 
 			if (BaseException* ex = m_CpuProviders->GetException_MicroVU1())
 			{
 				scrollableTextArea->AppendText(L"* microVU1\n\t" + ex->FormatDisplayMessage() + L"\n\n");
-				recOps.UseMicroVU1 = false;
 				recOps.EnableVU1 = false;
 			}
 


### PR DESCRIPTION
Also clean up Config.h a little

<!--
If this is your first PR to PCSX2, please review the relevant documentation:
- https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Description of Changes
Disable **Multi-Threaded VU1** (MTVU) when the VU1 interpreter is selected

### Rationale behind Changes
Upon testing basic homebrew, I realized that the interpreter is not at all working with MTVU. I spent a couple of hours trying to figure it out but there's no point, I don't have enough knowledge (yet?) and the interpreter is pretty broken anyways.

### Suggested Testing Steps
Switch between MVU and Interpreter for both the VUs and make sure the config is properly set I guess?
