### PR TITLE
DEV9: consistently prefix all console output with `DEV9: `

### DIFF
--- a/pcsx2/DEV9/ATA/ATA_Info.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Info.cpp
@@ -47,9 +47,9 @@ void ATA::WritePaddedString(u8* data, int* index, std::string value, u32 len)
 void ATA::CreateHDDinfo(int sizeMb)
 {
 	const u16 sectorSize = 512;
-	DevCon.WriteLn("HddSize : %i", config.HddSize);
+	DevCon.WriteLn("DEV9: HddSize : %i", config.HddSize);
 	const u64 nbSectors = ((u64)(sizeMb / sectorSize) * 1024 * 1024);
-	DevCon.WriteLn("nbSectors : %i", nbSectors);
+	DevCon.WriteLn("DEV9: nbSectors : %i", nbSectors);
 
 	memset(&identifyData, 0, sizeof(identifyData));
 	//Defualt CHS translation
@@ -390,5 +390,5 @@ void ATA::CreateHDDinfoCsum() //Is this correct?
 	for (int i = 0; i < (512); i++)
 		counter += identifyData[i];
 
-	DevCon.WriteLn("%i", counter);
+	DevCon.WriteLn("DEV9: %i", counter);
 }

--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -89,7 +89,7 @@ void ATA::Close()
 	{
 		if (!IsQueueEmpty())
 		{
-			Console.Error("ATA: Write queue not empty");
+			Console.Error("DEV9: ATA: Write queue not empty");
 			pxAssert(false);
 			abort(); //All data must be written at this point
 		}
@@ -143,7 +143,7 @@ void ATA::ResetEnd(bool hard)
 
 void ATA::ATA_HardReset()
 {
-	DevCon.WriteLn("*ATA_HARD RESET");
+	DevCon.WriteLn("DEV9: *ATA_HARD RESET");
 	ResetBegin();
 	ResetEnd(true);
 }
@@ -155,12 +155,12 @@ u16 ATA::Read16(u32 addr)
 		case ATA_R_DATA:
 			return ATAreadPIO();
 		case ATA_R_ERROR:
-			DevCon.WriteLn("*ATA_R_ERROR 16bit read at address %x, value %x, Active %s", addr, regError, (GetSelectedDevice() == 0) ? "True" : "False");
+			DevCon.WriteLn("DEV9: *ATA_R_ERROR 16bit read at address %x, value %x, Active %s", addr, regError, (GetSelectedDevice() == 0) ? "True" : "False");
 			if (GetSelectedDevice() != 0)
 				return 0;
 			return regError;
 		case ATA_R_NSECTOR:
-			DevCon.WriteLn("*ATA_R_NSECTOR 16bit read at address %x, value %x, Active %s", addr, nsector, (GetSelectedDevice() == 0) ? "True" : "False");
+			DevCon.WriteLn("DEV9: *ATA_R_NSECTOR 16bit read at address %x, value %x, Active %s", addr, nsector, (GetSelectedDevice() == 0) ? "True" : "False");
 			if (GetSelectedDevice() != 0)
 				return 0;
 			if (!regControlHOBRead)
@@ -168,7 +168,7 @@ u16 ATA::Read16(u32 addr)
 			else
 				return regNsectorHOB;
 		case ATA_R_SECTOR:
-			DevCon.WriteLn("*ATA_R_NSECTOR 16bit read at address %x, value %x, Active %s", addr, regSector, (GetSelectedDevice() == 0) ? "True" : "False");
+			DevCon.WriteLn("DEV9: *ATA_R_NSECTOR 16bit read at address %x, value %x, Active %s", addr, regSector, (GetSelectedDevice() == 0) ? "True" : "False");
 			if (GetSelectedDevice() != 0)
 				return 0;
 			if (!regControlHOBRead)
@@ -176,7 +176,7 @@ u16 ATA::Read16(u32 addr)
 			else
 				return regSectorHOB;
 		case ATA_R_LCYL:
-			DevCon.WriteLn("*ATA_R_LCYL 16bit read at address %x, value %x, Active %s", addr, regLcyl, (GetSelectedDevice() == 0) ? "True" : "False");
+			DevCon.WriteLn("DEV9: *ATA_R_LCYL 16bit read at address %x, value %x, Active %s", addr, regLcyl, (GetSelectedDevice() == 0) ? "True" : "False");
 			if (GetSelectedDevice() != 0)
 				return 0;
 			if (!regControlHOBRead)
@@ -184,7 +184,7 @@ u16 ATA::Read16(u32 addr)
 			else
 				return regLcylHOB;
 		case ATA_R_HCYL:
-			DevCon.WriteLn("*ATA_R_HCYL 16bit read at address % x, value % x, Active %s", addr, regHcyl, (GetSelectedDevice() == 0) ? " True " : " False ");
+			DevCon.WriteLn("DEV9: *ATA_R_HCYL 16bit read at address % x, value % x, Active %s", addr, regHcyl, (GetSelectedDevice() == 0) ? " True " : " False ");
 			if (GetSelectedDevice() != 0)
 				return 0;
 			if (!regControlHOBRead)
@@ -192,21 +192,21 @@ u16 ATA::Read16(u32 addr)
 			else
 				return regHcylHOB;
 		case ATA_R_SELECT:
-			DevCon.WriteLn("*ATA_R_SELECT 16bit read at address % x, value % x, Active %s", addr, regSelect, (GetSelectedDevice() == 0) ? " True " : " False ");
+			DevCon.WriteLn("DEV9: *ATA_R_SELECT 16bit read at address % x, value % x, Active %s", addr, regSelect, (GetSelectedDevice() == 0) ? " True " : " False ");
 			return regSelect;
 		case ATA_R_STATUS:
-			DevCon.WriteLn("*ATA_R_STATUS (Fallthough to ATA_R_ALT_STATUS)");
+			DevCon.WriteLn("DEV9: *ATA_R_STATUS (Fallthough to ATA_R_ALT_STATUS)");
 			//Clear irqcause
 			dev9.irqcause &= ~ATA_INTR_INTRQ;
 			[[fallthrough]];
 		case ATA_R_ALT_STATUS:
-			DevCon.WriteLn("*ATA_R_ALT_STATUS 16bit read at address % x, value % x, Active %s", addr, regStatus, (GetSelectedDevice() == 0) ? " True " : " False ");
+			DevCon.WriteLn("DEV9: *ATA_R_ALT_STATUS 16bit read at address % x, value % x, Active %s", addr, regStatus, (GetSelectedDevice() == 0) ? " True " : " False ");
 			//raise IRQ?
 			if (GetSelectedDevice() != 0)
 				return 0;
 			return regStatus;
 		default:
-			Console.Error("ATA: Unknown 16bit read at address %x", addr);
+			Console.Error("DEV9: ATA: Unknown 16bit read at address %x", addr);
 			return 0xff;
 	}
 }
@@ -215,49 +215,49 @@ void ATA::Write16(u32 addr, u16 value)
 {
 	if (addr != ATA_R_CMD && (regStatus & (ATA_STAT_BUSY | ATA_STAT_DRQ)) != 0)
 	{
-		Console.Error("ATA: DEVICE BUSY, DROPPING WRITE");
+		Console.Error("DEV9: ATA: DEVICE BUSY, DROPPING WRITE");
 		return;
 	}
 	switch (addr)
 	{
 		case ATA_R_FEATURE:
-			DevCon.WriteLn("*ATA_R_FEATURE 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_FEATURE 16bit write at address %x, value %x", addr, value);
 			ClearHOB();
 			regFeatureHOB = regFeature;
 			regFeature = (u8)value;
 			break;
 		case ATA_R_NSECTOR:
-			DevCon.WriteLn("*ATA_R_NSECTOR 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_NSECTOR 16bit write at address %x, value %x", addr, value);
 			ClearHOB();
 			regNsectorHOB = regNsector;
 			regNsector = (u8)value;
 			break;
 		case ATA_R_SECTOR:
-			DevCon.WriteLn("*ATA_R_SECTOR 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_SECTOR 16bit write at address %x, value %x", addr, value);
 			ClearHOB();
 			regSectorHOB = regSector;
 			regSector = (u8)value;
 			break;
 		case ATA_R_LCYL:
-			DevCon.WriteLn("*ATA_R_LCYL 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_LCYL 16bit write at address %x, value %x", addr, value);
 			ClearHOB();
 			regLcylHOB = regLcyl;
 			regLcyl = (u8)value;
 			break;
 		case ATA_R_HCYL:
-			DevCon.WriteLn("*ATA_R_HCYL 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_HCYL 16bit write at address %x, value %x", addr, value);
 			ClearHOB();
 			regHcylHOB = regHcyl;
 			regHcyl = (u8)value;
 			break;
 		case ATA_R_SELECT:
-			DevCon.WriteLn("*ATA_R_SELECT 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_SELECT 16bit write at address %x, value %x", addr, value);
 			regSelect = (u8)value;
 			//bus->ifs[0].select = (val & ~0x10) | 0xa0;
 			//bus->ifs[1].select = (val | 0x10) | 0xa0;
 			break;
 		case ATA_R_CONTROL:
-			DevCon.WriteLn("*ATA_R_CONTROL 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_CONTROL 16bit write at address %x, value %x", addr, value);
 			//dev9Ru16(ATA_R_CONTROL) = value;
 			if ((value & 0x2) != 0)
 			{
@@ -270,7 +270,7 @@ void ATA::Write16(u32 addr, u16 value)
 
 			if ((value & 0x4) != 0)
 			{
-				DevCon.WriteLn("*ATA_R_CONTROL RESET");
+				DevCon.WriteLn("DEV9: *ATA_R_CONTROL RESET");
 				ResetBegin();
 				ResetEnd(false);
 			}
@@ -279,14 +279,14 @@ void ATA::Write16(u32 addr, u16 value)
 
 			break;
 		case ATA_R_CMD:
-			DevCon.WriteLn("*ATA_R_CMD 16bit write at address %x, value %x", addr, value);
+			DevCon.WriteLn("DEV9: *ATA_R_CMD 16bit write at address %x, value %x", addr, value);
 			regCommand = value;
 			regControlHOBRead = false;
 			dev9.irqcause &= ~ATA_INTR_INTRQ;
 			IDE_ExecCmd(value);
 			break;
 		default:
-			Console.Error("ATA: UNKOWN 16bit write at address %x, value %x", addr, value);
+			Console.Error("DEV9: ATA: UNKNOWN 16bit write at address %x, value %x", addr, value);
 			break;
 	}
 }
@@ -358,7 +358,7 @@ s64 ATA::HDD_GetLBA()
 		regStatus |= (u8)ATA_STAT_ERR;
 		regError |= (u8)ATA_ERR_ABORT;
 
-		Console.Error("ATA: Tried to get LBA address while LBA mode disabled");
+		Console.Error("DEV9: ATA: Tried to get LBA address while LBA mode disabled");
 		//(c.Nh + h).Ns+(s-1)
 		//s64 CHSasLBA = ((regLcyl + (regHcyl << 8)) * curHeads + (regSelect & 0x0F)) * curSectors + (regSector - 1);
 		return -1;
@@ -391,7 +391,7 @@ void ATA::HDD_SetLBA(s64 sectorNum)
 		regStatus |= ATA_STAT_ERR;
 		regError |= ATA_ERR_ABORT;
 
-		Console.Error("ATA: Tried to set LBA address while LBA mode disabled");
+		Console.Error("DEV9: ATA: Tried to set LBA address while LBA mode disabled");
 	}
 }
 
@@ -416,7 +416,7 @@ bool ATA::HDD_CanAccess(int* sectors)
 	if (lba == -1)
 		return false;
 
-	DevCon.WriteLn("LBA :%i", lba);
+	DevCon.WriteLn("DEV9: LBA :%i", lba);
 	posStart = lba;
 
 	if (posStart > maxLBA)

--- a/pcsx2/DEV9/ATA/ATA_Transfer.cpp
+++ b/pcsx2/DEV9/ATA/ATA_Transfer.cpp
@@ -67,7 +67,7 @@ void ATA::IO_Read()
 
 	if (lba == -1)
 	{
-		Console.Error("ATA: Invalid LBA");
+		Console.Error("DEV9: ATA: Invalid LBA");
 		pxAssert(false);
 		abort();
 	}
@@ -76,7 +76,7 @@ void ATA::IO_Read()
 	hddImage.seekg(pos, std::ios::beg);
 	if (hddImage.fail())
 	{
-		Console.Error("ATA: File read error");
+		Console.Error("DEV9: ATA: File read error");
 		pxAssert(false);
 		abort();
 	}
@@ -103,7 +103,7 @@ bool ATA::IO_Write()
 	hddImage.write((char*)data, len);
 	if (hddImage.fail())
 	{
-		Console.Error("ATA: File write error");
+		Console.Error("DEV9: ATA: File write error");
 		pxAssert(false);
 		abort();
 	}

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdDMA.cpp
@@ -92,7 +92,7 @@ void ATA::ATAreadDMA8Mem(u8* pMem, int size)
 	{
 		if (size == 0)
 			return;
-		DevCon.WriteLn("DMA read, size %i, transferred %i, total size %i", size, rdTransferred, nsector * 512);
+		DevCon.WriteLn("DEV9: DMA read, size %i, transferred %i, total size %i", size, rdTransferred, nsector * 512);
 
 		//read
 		memcpy(pMem, &readBuffer[rdTransferred], size);
@@ -115,7 +115,7 @@ void ATA::ATAwriteDMA8Mem(u8* pMem, int size)
 	if ((udmaMode >= 0) &&
 		(dev9.if_ctrl & SPD_IF_ATA_DMAEN) != 0)
 	{
-		DevCon.WriteLn("DMA write, size %i, transferred %i, total size %i", size, wrTransferred, nsector * 512);
+		DevCon.WriteLn("DEV9: DMA write, size %i, transferred %i, total size %i", size, wrTransferred, nsector * 512);
 
 		//write
 		memcpy(&currentWrite[wrTransferred], pMem, size);
@@ -139,7 +139,7 @@ void ATA::HDD_ReadDMA(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_ReadDMA");
+	DevCon.WriteLn("DEV9: HDD_ReadDMA");
 
 	IDE_CmdLBA48Transform(isLBA48);
 
@@ -159,7 +159,7 @@ void ATA::HDD_WriteDMA(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_WriteDMA");
+	DevCon.WriteLn("DEV9: HDD_WriteDMA");
 
 	IDE_CmdLBA48Transform(isLBA48);
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdNoData.cpp
@@ -41,7 +41,7 @@ void ATA::HDD_FlushCache() //Can't when DRQ set
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_FlushCache");
+	DevCon.WriteLn("DEV9: HDD_FlushCache");
 
 	awaitFlush = true;
 	Async(-1);
@@ -50,7 +50,7 @@ void ATA::HDD_FlushCache() //Can't when DRQ set
 void ATA::HDD_InitDevParameters()
 {
 	PreCmd(); //Ignore DRDY bit
-	DevCon.WriteLn("HDD_InitDevParameters");
+	DevCon.WriteLn("DEV9: HDD_InitDevParameters");
 
 	curSectors = regNsector;
 	curHeads = (u8)((regSelect & 0x7) + 1);
@@ -61,7 +61,7 @@ void ATA::HDD_ReadVerifySectors(bool isLBA48)
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_ReadVerifySectors");
+	DevCon.WriteLn("DEV9: HDD_ReadVerifySectors");
 
 	IDE_CmdLBA48Transform(isLBA48);
 
@@ -74,7 +74,7 @@ void ATA::HDD_SeekCmd()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_SeekCmd");
+	DevCon.WriteLn("DEV9: HDD_SeekCmd");
 
 	regStatus &= ~ATA_STAT_SEEK;
 
@@ -93,7 +93,7 @@ void ATA::HDD_SetFeatures()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_SetFeatures");
+	DevCon.WriteLn("DEV9: HDD_SetFeatures");
 
 	switch (regFeature)
 	{
@@ -113,49 +113,49 @@ void ATA::HDD_SetFeatures()
 			{
 				case 0x00: //pio default
 					//if mode = 1, disable IORDY
-					DevCon.WriteLn("PIO Default");
+					DevCon.WriteLn("DEV9: PIO Default");
 					pioMode = 4;
 					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x01: //pio mode (3,4)
-					DevCon.WriteLn("PIO Mode %i", mode);
+					DevCon.WriteLn("DEV9: PIO Mode %i", mode);
 					pioMode = mode;
 					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x02: //Single word dma mode (0,1,2)
-					DevCon.WriteLn("SDMA Mode %i", mode);
+					DevCon.WriteLn("DEV9: SDMA Mode %i", mode);
 					//pioMode = -1;
 					sdmaMode = mode;
 					mdmaMode = -1;
 					udmaMode = -1;
 					break;
 				case 0x04: //Multi word dma mode (0,1,2)
-					DevCon.WriteLn("MDMA Mode %i", mode);
+					DevCon.WriteLn("DEV9: MDMA Mode %i", mode);
 					//pioMode = -1;
 					sdmaMode = -1;
 					mdmaMode = mode;
 					udmaMode = -1;
 					break;
 				case 0x08: //Ulta dma mode (0,1,2,3,4,5,6)
-					DevCon.WriteLn("UDMA Mode %i", mode);
+					DevCon.WriteLn("DEV9: UDMA Mode %i", mode);
 					//pioMode = -1;
 					sdmaMode = -1;
 					mdmaMode = -1;
 					udmaMode = mode;
 					break;
 				default:
-					Console.Error("ATA: Unkown transfer mode");
+					Console.Error("DEV9: ATA: Unknown transfer mode");
 					CmdNoDataAbort();
 					break;
 			}
 		}
 		break;
 		default:
-			Console.Error("ATA: Unkown feature mode");
+			Console.Error("DEV9: ATA: Unknown feature mode");
 			break;
 	}
 	PostCmdNoData();
@@ -165,7 +165,7 @@ void ATA::HDD_SetMultipleMode()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_SetMultipleMode");
+	DevCon.WriteLn("DEV9: HDD_SetMultipleMode");
 
 	curMultipleSectorsSetting = regNsector;
 
@@ -176,7 +176,7 @@ void ATA::HDD_Nop()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_Nop");
+	DevCon.WriteLn("DEV9: HDD_Nop");
 
 	if (regFeature == 0)
 	{
@@ -195,7 +195,7 @@ void ATA::HDD_Idle()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_Idle");
+	DevCon.WriteLn("DEV9: HDD_Idle");
 
 	long idleTime = 0; //in seconds
 	if (regNsector >= 1 && regNsector <= 240)
@@ -227,7 +227,7 @@ void ATA::HDD_Idle()
 		}
 	}
 
-	DevCon.WriteLn("HDD_Idle for %is", idleTime);
+	DevCon.WriteLn("DEV9: HDD_Idle for %is", idleTime);
 	PostCmdNoData();
 }
 
@@ -235,6 +235,6 @@ void ATA::HDD_IdleImmediate()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HDD_IdleImmediate");
+	DevCon.WriteLn("DEV9: HDD_IdleImmediate");
 	PostCmdNoData();
 }

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdPIOData.cpp
@@ -51,11 +51,11 @@ void ATA::PostCmdPIODataToHost()
 //FromHost
 u16 ATA::ATAreadPIO()
 {
-	DevCon.WriteLn("*ATA_R_DATA 16bit read, pio_count %i,  pio_size %i", pioPtr, pioEnd);
+	DevCon.WriteLn("DEV9: *ATA_R_DATA 16bit read, pio_count %i,  pio_size %i", pioPtr, pioEnd);
 	if (pioPtr < pioEnd)
 	{
 		const u16 ret = *(u16*)&pioBuffer[pioPtr * 2];
-		DevCon.WriteLn("*ATA_R_DATA returned value is  %x", ret);
+		DevCon.WriteLn("DEV9: *ATA_R_DATA returned value is  %x", ret);
 		pioPtr++;
 		if (pioPtr >= pioEnd) //Fnished transfer (Changed from MegaDev9)
 			PostCmdPIODataToHost();
@@ -70,7 +70,7 @@ void ATA::HDD_IdentifyDevice()
 {
 	if (!PreCmd())
 		return;
-	DevCon.WriteLn("HddidentifyDevice");
+	DevCon.WriteLn("DEV9: HddidentifyDevice");
 
 	//IDE transfer start
 	CreateHDDinfo(config.HddSize);

--- a/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_CmdSMART.cpp
@@ -20,7 +20,7 @@
 
 void ATA::HDD_Smart()
 {
-	DevCon.WriteLn("HDD_Smart");
+	DevCon.WriteLn("DEV9: HDD_Smart");
 
 	if ((regStatus & ATA_STAT_READY) == 0)
 		return;
@@ -54,22 +54,22 @@ void ATA::HDD_Smart()
 			SMART_ReturnStatus();
 			return;
 		case 0xD1: //SMART_READ_THRESH
-			Console.Error("ATA: SMART_READ_THRESH Not Impemented");
+			Console.Error("DEV9: ATA: SMART_READ_THRESH Not Implemented");
 			CmdNoDataAbort();
 			return;
 		case 0xD0: //SMART_READ_DATA
-			Console.Error("ATA: SMART_READ_DATA Not Impemented");
+			Console.Error("DEV9: ATA: SMART_READ_DATA Not Implemented");
 			CmdNoDataAbort();
 			return;
 		case 0xD5: //SMART_READ_LOG
-			Console.Error("ATA: SMART_READ_LOG Not Impemented");
+			Console.Error("DEV9: ATA: SMART_READ_LOG Not Implemented");
 			CmdNoDataAbort();
 			return;
 		case 0xD4: //SMART_EXECUTE_OFFLINE
 			SMART_ExecuteOfflineImmediate();
 			return;
 		default:
-			Console.Error("ATA: Unknown SMART command %x", regFeature);
+			Console.Error("DEV9: ATA: Unknown SMART command %x", regFeature);
 			CmdNoDataAbort();
 			return;
 	}
@@ -87,7 +87,7 @@ void ATA::SMART_SetAutoSaveAttribute()
 			smartAutosave = true;
 			break;
 		default:
-			Console.Error("ATA: Unknown SMART_ATTR_AUTOSAVE command %s", regSector);
+			Console.Error("DEV9: ATA: Unknown SMART_ATTR_AUTOSAVE command %s", regSector);
 			CmdNoDataAbort();
 			return;
 	}

--- a/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_Command.cpp
@@ -99,7 +99,7 @@ void ATA::IDE_ExecCmd(u16 value)
 
 void ATA::HDD_Unk()
 {
-	Console.Error("ATA: Unknown cmd %x", regCommand);
+	Console.Error("DEV9: ATA: Unknown cmd %x", regCommand);
 
 	PreCmd();
 

--- a/pcsx2/DEV9/ATA/Commands/ATA_SCE.cpp
+++ b/pcsx2/DEV9/ATA/Commands/ATA_SCE.cpp
@@ -20,7 +20,7 @@
 
 void ATA::HDD_SCE()
 {
-	DevCon.WriteLn("DEV9 : SONY-SPECIFIC SECURITY CONTROL COMMAND %x", regFeature);
+	DevCon.WriteLn("DEV9: HDD_SCE SONY-SPECIFIC SECURITY CONTROL COMMAND %x", regFeature);
 
 	switch (regFeature)
 	{
@@ -28,7 +28,7 @@ void ATA::HDD_SCE()
 			SCE_IDENTIFY_DRIVE();
 			break;
 		default:
-			Console.Error("ATA: Unknown SCE command %x", regFeature);
+			Console.Error("DEV9: ATA: Unknown SCE command %x", regFeature);
 			CmdNoDataAbort();
 			return;
 	}

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -101,13 +101,13 @@ bool isRunning = false;
 
 s32 DEV9init()
 {
-	DevCon.WriteLn("DEV9init");
+	DevCon.WriteLn("DEV9: DEV9init");
 
 	memset(&dev9, 0, sizeof(dev9));
 	dev9.ata = new ATA();
-	DevCon.WriteLn("DEV9init2");
+	DevCon.WriteLn("DEV9: DEV9init2");
 
-	DevCon.WriteLn("DEV9init3");
+	DevCon.WriteLn("DEV9: DEV9init3");
 
 	FLASHinit();
 
@@ -175,28 +175,28 @@ s32 DEV9init()
 		pbd->length = 0;
 	}
 
-	DevCon.WriteLn("DEV9init ok");
+	DevCon.WriteLn("DEV9: DEV9init ok");
 
 	return 0;
 }
 
 void DEV9shutdown()
 {
-	DevCon.WriteLn("DEV9shutdown");
+	DevCon.WriteLn("DEV9: DEV9shutdown");
 	delete dev9.ata;
 }
 
 s32 DEV9open(void* pDsp)
 {
-	DevCon.WriteLn("DEV9open");
+	DevCon.WriteLn("DEV9: DEV9open");
 	LoadConf();
 #ifdef _WIN32
 	//Convert to utf8
 	char mbHdd[sizeof(config.Hdd)] = {0};
 	WideCharToMultiByte(CP_UTF8, 0, config.Hdd, -1, mbHdd, sizeof(mbHdd) - 1, nullptr, nullptr);
-	DevCon.WriteLn("open r+: %s", mbHdd);
+	DevCon.WriteLn("DEV9: open r+: %s", mbHdd);
 #else
-	DevCon.WriteLn("open r+: %s", config.Hdd);
+	DevCon.WriteLn("DEV9: open r+: %s", config.Hdd);
 #endif
 
 #ifdef _WIN32
@@ -230,7 +230,7 @@ s32 DEV9open(void* pDsp)
 
 void DEV9close()
 {
-	DevCon.WriteLn("DEV9close");
+	DevCon.WriteLn("DEV9: DEV9close");
 
 	dev9.ata->Close();
 	TermNet();
@@ -240,7 +240,7 @@ void DEV9close()
 int DEV9irqHandler(void)
 {
 	//dev9Ru16(SPD_R_INTR_STAT)|= dev9.irqcause;
-	DevCon.WriteLn("_DEV9irqHandler %x, %x", dev9.irqcause, dev9.irqmask);
+	DevCon.WriteLn("DEV9: DEV9irqHandler %x, %x", dev9.irqcause, dev9.irqmask);
 	if (dev9.irqcause & dev9.irqmask)
 		return 1;
 	return 0;
@@ -248,7 +248,7 @@ int DEV9irqHandler(void)
 
 void _DEV9irq(int cause, int cycles)
 {
-	DevCon.WriteLn("_DEV9irq %x, %x", cause, dev9.irqmask);
+	DevCon.WriteLn("DEV9: _DEV9irq %x, %x", cause, dev9.irqmask);
 
 	dev9.irqcause |= cause;
 
@@ -327,7 +327,7 @@ u8 DEV9read8(u32 addr)
 	u8 hard;
 	if (addr >= ATA_DEV9_HDD_BASE && addr < ATA_DEV9_HDD_END)
 	{
-		Console.Error("ATA does not support 8bit reads %lx", addr);
+		Console.Error("DEV9: ATA does not support 8bit reads %lx", addr);
 		return 0;
 	}
 	if (addr >= SMAP_REGBASE && addr < FLASH_REGBASE)
@@ -370,12 +370,12 @@ u8 DEV9read8(u32 addr)
 			}
 			else
 				hard = 0;
-			DevCon.WriteLn("SPD_R_PIO_DATA 8bit read %x", hard);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_DATA 8bit read %x", hard);
 			return hard;
 
 		case DEV9_R_REV:
 			hard = 0x32; // expansion bay
-			DevCon.WriteLn("DEV9_R_REV 8bit read %x", hard);
+			DevCon.WriteLn("DEV9: DEV9_R_REV 8bit read %x", hard);
 			return hard;
 
 		default:
@@ -408,11 +408,11 @@ u16 DEV9read16(u32 addr)
 	switch (addr)
 	{
 		case SPD_R_INTR_STAT:
-			DevCon.WriteLn("SPD_R_INTR_STAT 16bit read %x", dev9.irqcause);
+			DevCon.WriteLn("DEV9: SPD_R_INTR_STAT 16bit read %x", dev9.irqcause);
 			return dev9.irqcause;
 
 		case SPD_R_INTR_MASK:
-			DevCon.WriteLn("SPD_R_INTR_MASK 16bit read %x", dev9.irqmask);
+			DevCon.WriteLn("DEV9: SPD_R_INTR_MASK 16bit read %x", dev9.irqmask);
 			return dev9.irqmask;
 
 		case SPD_R_PIO_DATA:
@@ -443,22 +443,22 @@ u16 DEV9read16(u32 addr)
 			}
 			else
 				hard = 0;
-			DevCon.WriteLn("SPD_R_PIO_DATA 16bit read %x", hard);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_DATA 16bit read %x", hard);
 			return hard;
 
 		case DEV9_R_REV:
 			//hard = 0x0030; // expansion bay
-			DevCon.WriteLn("DEV9_R_REV 16bit read %x", dev9.irqmask);
+			DevCon.WriteLn("DEV9: DEV9_R_REV 16bit read %x", dev9.irqmask);
 			hard = 0x0032;
 			return hard;
 
 		case SPD_R_REV_1:
-			DevCon.WriteLn("SPD_R_REV_1 16bit read %x", 0);
+			DevCon.WriteLn("DEV9: SPD_R_REV_1 16bit read %x", 0);
 			return 0;
 
 		case SPD_R_REV_2:
 			hard = 0x0011;
-			DevCon.WriteLn("STD_R_REV_1 16bit read %x", hard);
+			DevCon.WriteLn("DEV9: STD_R_REV_1 16bit read %x", hard);
 			return hard;
 
 		case SPD_R_REV_3:
@@ -468,15 +468,15 @@ u16 DEV9read16(u32 addr)
 			if (config.ethEnable)
 				hard |= SPD_CAPS_SMAP;
 			hard |= SPD_CAPS_FLASH;
-			DevCon.WriteLn("SPD_R_REV_3 16bit read %x", hard);
+			DevCon.WriteLn("DEV9: SPD_R_REV_3 16bit read %x", hard);
 			return hard;
 
 		case SPD_R_0e:
 			hard = 0x0002; //Have HDD inserted
-			DevCon.WriteLn("SPD_R_0e 16bit read %x", hard);
+			DevCon.WriteLn("DEV9: SPD_R_0e 16bit read %x", hard);
 			return hard;
 		case SPD_R_XFR_CTRL:
-			DevCon.WriteLn("SPD_R_XFR_CTRL 16bit read %x", dev9.xfr_ctrl);
+			DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL 16bit read %x", dev9.xfr_ctrl);
 			return dev9.xfr_ctrl;
 		case SPD_R_DBUF_STAT:
 		{
@@ -512,11 +512,11 @@ u16 DEV9read16(u32 addr)
 				hard |= SPD_DBUF_STAT_FULL;
 			}
 
-			DevCon.WriteLn("SPD_R_DBUF_STAT 16bit read %x", hard);
+			DevCon.WriteLn("DEV9: SPD_R_DBUF_STAT 16bit read %x", hard);
 			return hard;
 		}
 		case SPD_R_IF_CTRL:
-			DevCon.WriteLn("SPD_R_IF_CTRL 16bit read %x", dev9.if_ctrl);
+			DevCon.WriteLn("DEV9: SPD_R_IF_CTRL 16bit read %x", dev9.if_ctrl);
 			return dev9.if_ctrl;
 		default:
 			hard = dev9Ru16(addr);
@@ -533,7 +533,7 @@ u32 DEV9read32(u32 addr)
 	u32 hard;
 	if (addr >= ATA_DEV9_HDD_BASE && addr < ATA_DEV9_HDD_END)
 	{
-		Console.Error("ATA does not support 32bit reads %lx", addr);
+		Console.Error("DEV9: ATA does not support 32bit reads %lx", addr);
 		return 0;
 	}
 	if (addr >= SMAP_REGBASE && addr < FLASH_REGBASE)
@@ -578,19 +578,19 @@ void DEV9write8(u32 addr, u8 value)
 	switch (addr)
 	{
 		case 0x10000020:
-			Console.Error("SPD_R_INTR_CAUSE, WTFH ?");
+			Console.Error("DEV9: SPD_R_INTR_CAUSE, WTFH ?");
 			dev9.irqcause = 0xff;
 			break;
 		case SPD_R_INTR_STAT:
-			Console.Error("SPD_R_INTR_STAT,  WTFH ?");
+			Console.Error("DEV9: SPD_R_INTR_STAT,  WTFH ?");
 			dev9.irqcause = value;
 			return;
 		case SPD_R_INTR_MASK:
-			Console.Error("SPD_R_INTR_MASK8, WTFH ?");
+			Console.Error("DEV9: SPD_R_INTR_MASK8, WTFH ?");
 			break;
 
 		case SPD_R_PIO_DIR:
-			DevCon.WriteLn("SPD_R_PIO_DIR 8bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_DIR 8bit write %x", value);
 
 			if ((value & 0xc0) != 0xc0)
 				return;
@@ -604,7 +604,7 @@ void DEV9write8(u32 addr, u8 value)
 			return;
 
 		case SPD_R_PIO_DATA:
-			DevCon.WriteLn("SPD_R_PIO_DATA 8bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_DATA 8bit write %x", value);
 
 			if ((value & 0xc0) != 0xc0)
 				return;
@@ -652,7 +652,7 @@ void DEV9write8(u32 addr, u8 value)
 				}
 				break;
 				default:
-					Console.Error("DEV9: Unkown EEPROM COMMAND");
+					Console.Error("DEV9: Unknown EEPROM COMMAND");
 					break;
 			}
 			return;
@@ -688,17 +688,17 @@ void DEV9write16(u32 addr, u16 value)
 	switch (addr)
 	{
 		case SPD_R_INTR_MASK:
-			DevCon.WriteLn("SPD_R_INTR_MASK 16bit write %x	, checking for masked/unmasked interrupts", value);
+			DevCon.WriteLn("DEV9: SPD_R_INTR_MASK 16bit write %x	, checking for masked/unmasked interrupts", value);
 			if ((dev9.irqmask != value) && ((dev9.irqmask | value) & dev9.irqcause))
 			{
-				DevCon.WriteLn("SPD_R_INTR_MASK16 firing unmasked interrupts");
+				DevCon.WriteLn("DEV9: SPD_R_INTR_MASK16 firing unmasked interrupts");
 				dev9Irq(1);
 			}
 			dev9.irqmask = value;
 			break;
 
 		case SPD_R_PIO_DIR:
-			DevCon.WriteLn("SPD_R_PIO_DIR 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_DIR 16bit write %x", value);
 
 			if ((value & 0xc0) != 0xc0)
 				return;
@@ -712,7 +712,7 @@ void DEV9write16(u32 addr, u16 value)
 			return;
 
 		case SPD_R_PIO_DATA:
-			DevCon.WriteLn("SPD_R_PIO_DATA 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_DATA 16bit write %x", value);
 
 			if ((value & 0xc0) != 0xc0)
 				return;
@@ -760,69 +760,69 @@ void DEV9write16(u32 addr, u16 value)
 				}
 				break;
 				default:
-					Console.Error("Unkown EEPROM COMMAND");
+					Console.Error("DEV9: Unknown EEPROM COMMAND");
 					break;
 			}
 			return;
 
 		case SPD_R_DMA_CTRL:
-			DevCon.WriteLn("SPD_R_IF_CTRL 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_IF_CTRL 16bit write %x", value);
 			dev9.dma_ctrl = value;
 
 			if (value & SPD_DMA_TO_SMAP)
-				DevCon.WriteLn("SPD_R_DMA_CTRL DMA For SMAP");
+				DevCon.WriteLn("DEV9: SPD_R_DMA_CTRL DMA For SMAP");
 			else
-				DevCon.WriteLn("SPD_R_DMA_CTRL DMA For ATA");
+				DevCon.WriteLn("DEV9: SPD_R_DMA_CTRL DMA For ATA");
 
 			if ((value & SPD_DMA_FASTEST) != 0)
-				DevCon.WriteLn("SPD_R_DMA_CTRL Fastest DMA Mode");
+				DevCon.WriteLn("DEV9: SPD_R_DMA_CTRL Fastest DMA Mode");
 			else
-				DevCon.WriteLn("SPD_R_DMA_CTRL Slower DMA Mode");
+				DevCon.WriteLn("DEV9: SPD_R_DMA_CTRL Slower DMA Mode");
 
 			if ((value & SPD_DMA_WIDE) != 0)
-				DevCon.WriteLn("SPD_R_DMA_CTRL Wide(32bit) DMA Mode Set");
+				DevCon.WriteLn("DEV9: SPD_R_DMA_CTRL Wide(32bit) DMA Mode Set");
 			else
-				DevCon.WriteLn("SPD_R_DMA_CTRL 16bit DMA Mode");
+				DevCon.WriteLn("DEV9: SPD_R_DMA_CTRL 16bit DMA Mode");
 
 			if ((value & SPD_DMA_PAUSE) != 0)
-				Console.Error("SPD_R_DMA_CTRL Pause DMA Not Implemented");
+				Console.Error("DEV9: SPD_R_DMA_CTRL Pause DMA Not Implemented");
 
 			if ((value & 0b1111111111101000) != 0)
-				Console.Error("SPD_R_DMA_CTRL Unkown value written %x", value);
+				Console.Error("DEV9: SPD_R_DMA_CTRL Unknown value written %x", value);
 
 			break;
 		case SPD_R_XFR_CTRL:
-			DevCon.WriteLn("SPD_R_IF_CTRL 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_IF_CTRL 16bit write %x", value);
 			dev9.xfr_ctrl = value;
 
 			if (value & SPD_XFR_WRITE)
-				DevCon.WriteLn("SPD_R_XFR_CTRL Set Write");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL Set Write");
 			else
-				DevCon.WriteLn("SPD_R_XFR_CTRL Set Read");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL Set Read");
 
 			if ((value & (1 << 1)) != 0)
-				DevCon.WriteLn("SPD_R_XFR_CTRL Unkown Bit 1");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL Unknown Bit 1");
 
 			if ((value & (1 << 2)) != 0)
-				DevCon.WriteLn("SPD_R_XFR_CTRL Unkown Bit 2");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL Unknown Bit 2");
 
 			if (value & SPD_XFR_DMAEN)
-				DevCon.WriteLn("SPD_R_XFR_CTRL For DMA Enabled");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL For DMA Enabled");
 			else
-				DevCon.WriteLn("SPD_R_XFR_CTRL For DMA Disabled");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL For DMA Disabled");
 
 			if ((value & 0b1111111101111000) != 0)
 			{
-				Console.Error("SPD_R_XFR_CTRL Unkown value written %x", value);
+				Console.Error("DEV9: SPD_R_XFR_CTRL Unknown value written %x", value);
 			}
 
 			break;
 		case SPD_R_DBUF_STAT:
-			DevCon.WriteLn("SPD_R_DBUF_STAT 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_DBUF_STAT 16bit write %x", value);
 
 			if ((value & SPD_DBUF_RESET_FIFO) != 0)
 			{
-				DevCon.WriteLn("SPD_R_XFR_CTRL Reset FIFO");
+				DevCon.WriteLn("DEV9: SPD_R_XFR_CTRL Reset FIFO");
 				dev9.fifo_bytes_write = 0;
 				dev9.fifo_bytes_read = 0;
 				dev9.xfr_ctrl &= ~SPD_XFR_WRITE; //?
@@ -832,25 +832,25 @@ void DEV9write16(u32 addr, u16 value)
 			}
 
 			if (value != 3)
-				Console.Error("SPD_R_38 16bit write %x Which != 3!!!", value);
+				Console.Error("DEV9: SPD_R_38 16bit write %x Which != 3!!!", value);
 			break;
 
 		case SPD_R_IF_CTRL:
-			DevCon.WriteLn("SPD_R_IF_CTRL 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_IF_CTRL 16bit write %x", value);
 			dev9.if_ctrl = value;
 
 			if (value & SPD_IF_UDMA)
-				DevCon.WriteLn("IF_CTRL UDMA Enabled");
+				DevCon.WriteLn("DEV9: IF_CTRL UDMA Enabled");
 			else
-				DevCon.WriteLn("IF_CTRL UDMA Disabled");
+				DevCon.WriteLn("DEV9: IF_CTRL UDMA Disabled");
 			if (value & SPD_IF_READ)
-				DevCon.WriteLn("IF_CTRL DMA Is ATA Read");
+				DevCon.WriteLn("DEV9: IF_CTRL DMA Is ATA Read");
 			else
-				DevCon.WriteLn("IF_CTRL DMA Is ATA Write");
+				DevCon.WriteLn("DEV9: IF_CTRL DMA Is ATA Write");
 
 			if (value & SPD_IF_ATA_DMAEN)
 			{
-				DevCon.WriteLn("IF_CTRL ATA DMA Enabled");
+				DevCon.WriteLn("DEV9: IF_CTRL ATA DMA Enabled");
 				if (value & SPD_IF_READ) //Semi async
 				{
 					HDDWriteFIFO(); //Yes this is not a typo
@@ -862,24 +862,24 @@ void DEV9write16(u32 addr, u16 value)
 				FIFOIntr();
 			}
 			else
-				DevCon.WriteLn("IF_CTRL ATA DMA Disabled");
+				DevCon.WriteLn("DEV9: IF_CTRL ATA DMA Disabled");
 
 			if (value & (1 << 3))
-				DevCon.WriteLn("IF_CTRL Unkown Bit 3 Set");
+				DevCon.WriteLn("DEV9: IF_CTRL Unknown Bit 3 Set");
 
 			if (value & (1 << 4))
-				Console.Error("IF_CTRL Unkown Bit 4 Set");
+				Console.Error("DEV9: IF_CTRL Unknown Bit 4 Set");
 			if (value & (1 << 5))
-				Console.Error("IF_CTRL Unkown Bit 5 Set");
+				Console.Error("DEV9: IF_CTRL Unknown Bit 5 Set");
 
 			if ((value & SPD_IF_HDD_RESET) == 0) //Maybe?
 			{
-				DevCon.WriteLn("IF_CTRL HDD Hard Reset");
+				DevCon.WriteLn("DEV9: IF_CTRL HDD Hard Reset");
 				dev9.ata->ATA_HardReset();
 			}
 			if ((value & SPD_IF_ATA_RESET) != 0)
 			{
-				DevCon.WriteLn("IF_CTRL ATA Reset");
+				DevCon.WriteLn("DEV9: IF_CTRL ATA Reset");
 				//0x62        0x0020
 				dev9.if_ctrl = 0x001A;
 				//0x66        0x0001
@@ -890,87 +890,87 @@ void DEV9write16(u32 addr, u16 value)
 			}
 
 			if ((value & 0xFF00) > 0)
-				Console.Error("IF_CTRL Unkown Bit(s) %x", (value & 0xFF00));
+				Console.Error("DEV9: IF_CTRL Unknown Bit(s) %x", (value & 0xFF00));
 
 			break;
 		case SPD_R_PIO_MODE: //ATA only? or includes EEPROM?
-			DevCon.WriteLn("SPD_R_PIO_MODE 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_PIO_MODE 16bit write %x", value);
 			dev9.pio_mode = value;
 
 			switch (value)
 			{
 				case 0x92:
-					DevCon.WriteLn("SPD_R_PIO_MODE 0");
+					DevCon.WriteLn("DEV9: SPD_R_PIO_MODE 0");
 					break;
 				case 0x72:
-					DevCon.WriteLn("SPD_R_PIO_MODE 1");
+					DevCon.WriteLn("DEV9: SPD_R_PIO_MODE 1");
 					break;
 				case 0x32:
-					DevCon.WriteLn("SPD_R_PIO_MODE 2");
+					DevCon.WriteLn("DEV9: SPD_R_PIO_MODE 2");
 					break;
 				case 0x24:
-					DevCon.WriteLn("SPD_R_PIO_MODE 3");
+					DevCon.WriteLn("DEV9: SPD_R_PIO_MODE 3");
 					break;
 				case 0x23:
-					DevCon.WriteLn("SPD_R_PIO_MODE 4");
+					DevCon.WriteLn("DEV9: SPD_R_PIO_MODE 4");
 					break;
 
 				default:
-					Console.Error("SPD_R_PIO_MODE UNKOWN MODE %x", value);
+					Console.Error("DEV9: SPD_R_PIO_MODE UNKNOWN MODE %x", value);
 					break;
 			}
 			break;
 		case SPD_R_MDMA_MODE: //ATA only? or includes EEPROM?
-			DevCon.WriteLn("SPD_R_MDMA_MODE 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_MDMA_MODE 16bit write %x", value);
 			dev9.mdma_mode = value;
 
 			switch (value)
 			{
 				case 0xFF:
-					DevCon.WriteLn("SPD_R_MDMA_MODE 0");
+					DevCon.WriteLn("DEV9: SPD_R_MDMA_MODE 0");
 					break;
 				case 0x45:
-					DevCon.WriteLn("SPD_R_MDMA_MODE 1");
+					DevCon.WriteLn("DEV9: SPD_R_MDMA_MODE 1");
 					break;
 				case 0x24:
-					DevCon.WriteLn("SPD_R_MDMA_MODE 2");
+					DevCon.WriteLn("DEV9: SPD_R_MDMA_MODE 2");
 					break;
 				default:
-					Console.Error("SPD_R_MDMA_MODE UNKOWN MODE %x", value);
+					Console.Error("DEV9: SPD_R_MDMA_MODE UNKNOWN MODE %x", value);
 					break;
 			}
 
 			break;
 		case SPD_R_UDMA_MODE: //ATA only?
-			DevCon.WriteLn("SPD_R_UDMA_MODE 16bit write %x", value);
+			DevCon.WriteLn("DEV9: SPD_R_UDMA_MODE 16bit write %x", value);
 			dev9.udma_mode = value;
 
 			switch (value)
 			{
 				case 0xa7:
-					DevCon.WriteLn("SPD_R_UDMA_MODE 0");
+					DevCon.WriteLn("DEV9: SPD_R_UDMA_MODE 0");
 					break;
 				case 0x85:
-					DevCon.WriteLn("SPD_R_UDMA_MODE 1");
+					DevCon.WriteLn("DEV9: SPD_R_UDMA_MODE 1");
 					break;
 				case 0x63:
-					DevCon.WriteLn("SPD_R_UDMA_MODE 2");
+					DevCon.WriteLn("DEV9: SPD_R_UDMA_MODE 2");
 					break;
 				case 0x62:
-					DevCon.WriteLn("SPD_R_UDMA_MODE 3");
+					DevCon.WriteLn("DEV9: SPD_R_UDMA_MODE 3");
 					break;
 				case 0x61:
-					DevCon.WriteLn("SPD_R_UDMA_MODE 4");
+					DevCon.WriteLn("DEV9: SPD_R_UDMA_MODE 4");
 					break;
 				default:
-					Console.Error("SPD_R_UDMA_MODE UNKOWN MODE %x", value);
+					Console.Error("DEV9: SPD_R_UDMA_MODE UNKNOWN MODE %x", value);
 					break;
 			}
 			break;
 
 		default:
 			dev9Ru16(addr) = value;
-			Console.Error("*Unknown 16bit write at address %lx value %x", addr, value);
+			Console.Error("DEV9: *Unknown 16bit write at address %lx value %x", addr, value);
 			return;
 	}
 }
@@ -1002,7 +1002,7 @@ void DEV9write32(u32 addr, u32 value)
 	switch (addr)
 	{
 		case SPD_R_INTR_MASK:
-			Console.Error("SPD_R_INTR_MASK	, WTFH ?");
+			Console.Error("DEV9: SPD_R_INTR_MASK, WTFH ?");
 			break;
 		default:
 			dev9Ru32(addr) = value;
@@ -1018,7 +1018,7 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 
 	size >>= 1;
 
-	DevCon.WriteLn("*DEV9readDMA8Mem: size %x", size);
+	DevCon.WriteLn("DEV9: *DEV9readDMA8Mem: size %x", size);
 
 	if (dev9.dma_ctrl & SPD_DMA_TO_SMAP)
 		smap_readDMA8Mem(pMem, size);
@@ -1044,7 +1044,7 @@ void DEV9writeDMA8Mem(u32* pMem, int size)
 
 	size >>= 1;
 
-	DevCon.WriteLn("*DEV9writeDMA8Mem: size %x", size);
+	DevCon.WriteLn("DEV9: *DEV9writeDMA8Mem: size %x", size);
 
 	if (dev9.dma_ctrl & SPD_DMA_TO_SMAP)
 		smap_writeDMA8Mem(pMem, size);

--- a/pcsx2/DEV9/Linux/Config.cpp
+++ b/pcsx2/DEV9/Linux/Config.cpp
@@ -71,7 +71,7 @@ void SaveConf()
 
 	const std::string file(GetSettingsFolder().Combine(wxString("DEV9.cfg")).GetFullPath());
 
-	Console.WriteLn("CONF: %s", file.c_str());
+	Console.WriteLn("DEV9: CONF: %s", file.c_str());
 
 	xmlSaveFormatFileEnc(file.c_str(), doc, "UTF-8", 1);
 	//    free(configFile);

--- a/pcsx2/DEV9/Win32/pcap_io_win32.cpp
+++ b/pcsx2/DEV9/Win32/pcap_io_win32.cpp
@@ -115,7 +115,7 @@ bool load_pcap()
 	if (fp_##name == nullptr)                                \
 	{                                                        \
 		FreeLibrary(hpcap);                                  \
-		Console.Error("%s not found", #name);                \
+		Console.Error("DEV9: %s not found", #name);          \
 		hpcap = nullptr;                                     \
 		return false;                                        \
 	}

--- a/pcsx2/DEV9/flash.cpp
+++ b/pcsx2/DEV9/flash.cpp
@@ -94,7 +94,7 @@ void FLASHinit()
 		ret = fread(file, 1, CARD_SIZE_ECC, fd);
 		if (ret != CARD_SIZE_ECC)
 		{
-			DevCon.WriteLn("Reading error.");
+			DevCon.WriteLn("DEV9: Reading error.");
 		}
 
 		fclose(fd);
@@ -112,7 +112,7 @@ u32 FLASHread32(u32 addr, int size)
 		case FLASH_R_DATA:
 			memcpy(&value, &data[counter], size);
 			counter += size;
-			DevCon.WriteLn("*FLASH DATA %dbit read 0x%08lX %s", size * 8, value, (ctrl & FLASH_PP_READ) ? "READ_ENABLE" : "READ_DISABLE");
+			DevCon.WriteLn("DEV9: *FLASH DATA %dbit read 0x%08lX %s", size * 8, value, (ctrl & FLASH_PP_READ) ? "READ_ENABLE" : "READ_DISABLE");
 			if (cmd == SM_CMD_READ3)
 			{
 				if (counter >= PAGE_SIZE_ECC)
@@ -148,33 +148,33 @@ u32 FLASHread32(u32 addr, int size)
 			return value;
 
 		case FLASH_R_CMD:
-			DevCon.WriteLn("*FLASH CMD %dbit read %s DENIED", size * 8, getCmdName(cmd));
+			DevCon.WriteLn("DEV9: *FLASH CMD %dbit read %s DENIED", size * 8, getCmdName(cmd));
 			return cmd;
 
 		case FLASH_R_ADDR:
-			DevCon.WriteLn("*FLASH ADDR %dbit read DENIED", size * 8);
+			DevCon.WriteLn("DEV9: *FLASH ADDR %dbit read DENIED", size * 8);
 			return 0;
 
 		case FLASH_R_CTRL:
-			DevCon.WriteLn("*FLASH CTRL %dbit read 0x%08lX", size * 8, ctrl);
+			DevCon.WriteLn("DEV9: *FLASH CTRL %dbit read 0x%08lX", size * 8, ctrl);
 			return ctrl;
 
 		case FLASH_R_ID:
 			if (cmd == SM_CMD_READID)
 			{
-				DevCon.WriteLn("*FLASH ID %dbit read 0x%08lX", size * 8, id);
+				DevCon.WriteLn("DEV9: *FLASH ID %dbit read 0x%08lX", size * 8, id);
 				return id; //0x98=Toshiba/0xEC=Samsung maker code should be returned first
 			}
 			else if (cmd == SM_CMD_GETSTATUS)
 			{
 				value = 0x80 | ((ctrl & 1) << 6); // 0:0=pass, 6:ready/busy, 7:1=not protected
-				DevCon.WriteLn("*FLASH STATUS %dbit read 0x%08lX", size * 8, value);
+				DevCon.WriteLn("DEV9: *FLASH STATUS %dbit read 0x%08lX", size * 8, value);
 				return value;
 			} //else fall off
 			return 0;
 
 		default:
-			DevCon.WriteLn("*FLASH Unknown %dbit read at address %lx", size * 8, addr);
+			DevCon.WriteLn("DEV9: *FLASH Unknown %dbit read at address %lx", size * 8, addr);
 			return 0;
 	}
 }
@@ -186,7 +186,7 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 	{
 		case FLASH_R_DATA:
 
-			DevCon.WriteLn("*FLASH DATA %dbit write 0x%08lX %s", size * 8, value, (ctrl & FLASH_PP_WRITE) ? "WRITE_ENABLE" : "WRITE_DISABLE");
+			DevCon.WriteLn("DEV9: *FLASH DATA %dbit write 0x%08lX %s", size * 8, value, (ctrl & FLASH_PP_WRITE) ? "WRITE_ENABLE" : "WRITE_DISABLE");
 			memcpy(&data[counter], &value, size);
 			counter += size;
 			counter %= PAGE_SIZE_ECC; //should not get past the last byte, but at the end
@@ -197,7 +197,7 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 			{
 				if ((value != SM_CMD_GETSTATUS) && (value != SM_CMD_RESET))
 				{
-					DevCon.WriteLn("*FLASH CMD %dbit write %s ILLEGAL in busy mode - IGNORED", size * 8, getCmdName(value));
+					DevCon.WriteLn("DEV9: *FLASH CMD %dbit write %s ILLEGAL in busy mode - IGNORED", size * 8, getCmdName(value));
 					break;
 				}
 			}
@@ -205,12 +205,12 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 			{
 				if ((value != SM_CMD_PROGRAMPAGE) && (value != SM_CMD_RESET))
 				{
-					DevCon.WriteLn("*FLASH CMD %dbit write %s ILLEGAL after WRITEDATA cmd - IGNORED", size * 8, getCmdName(value));
+					DevCon.WriteLn("DEV9: *FLASH CMD %dbit write %s ILLEGAL after WRITEDATA cmd - IGNORED", size * 8, getCmdName(value));
 					ctrl &= ~FLASH_PP_READY; //go busy, reset is needed
 					break;
 				}
 			}
-			DevCon.WriteLn("*FLASH CMD %dbit write %s", size * 8, getCmdName(value));
+			DevCon.WriteLn("DEV9: *FLASH CMD %dbit write %s", size * 8, getCmdName(value));
 			switch (value)
 			{ // A8 bit is encoded in READ cmd;)
 				case SM_CMD_READ1:
@@ -268,10 +268,10 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 			break;
 
 		case FLASH_R_ADDR:
-			DevCon.WriteLn("*FLASH ADDR %dbit write 0x%08lX", size * 8, value);
+			DevCon.WriteLn("DEV9: *FLASH ADDR %dbit write 0x%08lX", size * 8, value);
 			address |= (value & 0xFF) << (addrbyte == 0 ? 0 : (1 + 8 * addrbyte));
 			addrbyte++;
-			DevCon.WriteLn("*FLASH ADDR = 0x%08lX (addrbyte=%d)", address, addrbyte);
+			DevCon.WriteLn("DEV9: *FLASH ADDR = 0x%08lX (addrbyte=%d)", address, addrbyte);
 			if (!(value & 0x100))
 			{ // address is complete
 				if ((cmd == SM_CMD_READ1) || (cmd == SM_CMD_READ2) || (cmd == SM_CMD_READ3))
@@ -287,22 +287,22 @@ void FLASHwrite32(u32 addr, u32 value, int size)
 					u32 pages = address - (blocks * BLOCK_SIZE);
 					[[maybe_unused]]const u32 bytes = pages % PAGE_SIZE;
 					pages = pages / PAGE_SIZE;
-					DevCon.WriteLn("*FLASH ADDR = 0x%08lX (%d:%d:%d) (addrbyte=%d) FINAL", address, blocks, pages, bytes, addrbyte);
+					DevCon.WriteLn("DEV9: *FLASH ADDR = 0x%08lX (%d:%d:%d) (addrbyte=%d) FINAL", address, blocks, pages, bytes, addrbyte);
 				}
 			}
 			break;
 
 		case FLASH_R_CTRL:
-			DevCon.WriteLn("*FLASH CTRL %dbit write 0x%08lX", size * 8, value);
+			DevCon.WriteLn("DEV9: *FLASH CTRL %dbit write 0x%08lX", size * 8, value);
 			ctrl = (ctrl & FLASH_PP_READY) | (value & ~FLASH_PP_READY);
 			break;
 
 		case FLASH_R_ID:
-			DevCon.WriteLn("*FLASH ID %dbit write 0x%08lX DENIED :P", size * 8, value);
+			DevCon.WriteLn("DEV9: *FLASH ID %dbit write 0x%08lX DENIED :P", size * 8, value);
 			break;
 
 		default:
-			DevCon.WriteLn("*FLASH Unkwnown %dbit write at address 0x%08lX= 0x%08lX IGNORED", size * 8, addr, value);
+			DevCon.WriteLn("DEV9: *FLASH Unkwnown %dbit write at address 0x%08lX= 0x%08lX IGNORED", size * 8, addr, value);
 			break;
 	}
 }

--- a/pcsx2/DEV9/net.cpp
+++ b/pcsx2/DEV9/net.cpp
@@ -90,7 +90,7 @@ void InitNet()
 
 	if (!na)
 	{
-		Console.Error("Failed to GetNetAdapter()");
+		Console.Error("DEV9: Failed to GetNetAdapter()");
 		config.ethEnable = false;
 		return;
 	}
@@ -119,9 +119,9 @@ void TermNet()
 	{
 		RxRunning = false;
 		nif->close();
-		Console.WriteLn("Waiting for RX-net thread to terminate..");
+		Console.WriteLn("DEV9: Waiting for RX-net thread to terminate..");
 		rx_thread.join();
-		Console.WriteLn("Done");
+		Console.WriteLn("DEV9: Done");
 
 		delete nif;
 		nif = nullptr;

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -74,11 +74,11 @@ bool GetWin32Adapter(const char* name, PIP_ADAPTER_ADDRESSES adapter, std::uniqu
 
 	if (dwStatus == ERROR_BUFFER_OVERFLOW)
 	{
-		DevCon.WriteLn("GetWin32Adapter() buffer too small, resizing");
+		DevCon.WriteLn("DEV9: GetWin32Adapter() buffer too small, resizing");
 		neededSize = dwBufLen / sizeof(IP_ADAPTER_ADDRESSES) + 1;
 		AdapterInfo = std::make_unique<IP_ADAPTER_ADDRESSES[]>(neededSize);
 		dwBufLen = sizeof(IP_ADAPTER_ADDRESSES) * neededSize;
-		DevCon.WriteLn("New size %i", neededSize);
+		DevCon.WriteLn("DEV9: New size %i", neededSize);
 
 		DWORD dwStatus = GetAdaptersAddresses(
 			AF_UNSPEC,
@@ -145,7 +145,7 @@ int pcap_io_init(char* adapter, bool switched, mac_address virtual_mac)
 	char filter[1024] = "ether broadcast or ether dst ";
 	int dlt;
 	char* dlt_name;
-	Console.WriteLn("Opening adapter '%s'...", adapter);
+	Console.WriteLn("DEV9: Opening adapter '%s'...", adapter);
 
 	pcap_io_switched = switched;
 
@@ -158,8 +158,8 @@ int pcap_io_init(char* adapter, bool switched, mac_address virtual_mac)
 								   errbuf // error buffer
 								   )) == NULL)
 	{
-		Console.Error("%s", errbuf);
-		Console.Error("Unable to open the adapter. %s is not supported by pcap", adapter);
+		Console.Error("DEV9: %s", errbuf);
+		Console.Error("DEV9: Unable to open the adapter. %s is not supported by pcap", adapter);
 		return -1;
 	}
 	if (switched)
@@ -171,13 +171,13 @@ int pcap_io_init(char* adapter, bool switched, mac_address virtual_mac)
 
 		if (pcap_compile(adhandle, &fp, filter, 1, PCAP_NETMASK_UNKNOWN) == -1)
 		{
-			Console.Error("Error calling pcap_compile: %s", pcap_geterr(adhandle));
+			Console.Error("DEV9: Error calling pcap_compile: %s", pcap_geterr(adhandle));
 			return -1;
 		}
 
 		if (pcap_setfilter(adhandle, &fp) == -1)
 		{
-			Console.Error("Error setting filter: %s", pcap_geterr(adhandle));
+			Console.Error("DEV9: Error setting filter: %s", pcap_geterr(adhandle));
 			return -1;
 		}
 	}
@@ -186,7 +186,7 @@ int pcap_io_init(char* adapter, bool switched, mac_address virtual_mac)
 	dlt = pcap_datalink(adhandle);
 	dlt_name = (char*)pcap_datalink_val_to_name(dlt);
 
-	Console.Error("Device uses DLT %d: %s", dlt, dlt_name);
+	Console.Error("DEV9: Device uses DLT %d: %s", dlt, dlt_name);
 	switch (dlt)
 	{
 		case DLT_EN10MB:
@@ -204,7 +204,7 @@ int pcap_io_init(char* adapter, bool switched, mac_address virtual_mac)
 #endif
 
 	pcap_io_running = 1;
-	Console.WriteLn("Adapter Ok.");
+	Console.WriteLn("DEV9: Adapter Ok.");
 	return 0;
 }
 


### PR DESCRIPTION
Around half of the debug and console output from the DEV9 tree already
had this prefix. Adding it everywhere for consistency. Also fixed
misspelling of "Unknown" whilst there.

This is a follow-on from https://github.com/PCSX2/pcsx2/pull/4364 as requested by @lightningterror 