### PR TITLE
GSFrame: Pass focus to GSPanel once Frame receives focus

### DIFF
--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -565,7 +565,7 @@ GSFrame::GSFrame( const wxString& title)
 	Bind(wxEVT_CLOSE_WINDOW, &GSFrame::OnCloseWindow, this);
 	Bind(wxEVT_MOVE, &GSFrame::OnMove, this);
 	Bind(wxEVT_SIZE, &GSFrame::OnResize, this);
-	Bind(wxEVT_ACTIVATE, &GSFrame::OnActivate, this);
+	Bind(wxEVT_SET_FOCUS, &GSFrame::OnFocus, this);
 
 	Bind(wxEVT_TIMER, &GSFrame::OnUpdateTitle, this, m_timer_UpdateTitle.GetId());
 }
@@ -799,11 +799,11 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 	SetTitle(title);
 }
 
-void GSFrame::OnActivate( wxActivateEvent& evt )
+void GSFrame::OnFocus( wxFocusEvent& evt )
 {
 	if( IsBeingDeleted() ) return;
 
-	evt.Skip();
+	evt.Skip(false); // Reject the focus message, as we pass focus to the child
 	if( wxWindow* gsPanel = GetViewport() ) gsPanel->SetFocus();
 }
 

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -112,7 +112,7 @@ protected:
 	void OnCloseWindow( wxCloseEvent& evt );
 	void OnMove( wxMoveEvent& evt );
 	void OnResize( wxSizeEvent& evt );
-	void OnActivate( wxActivateEvent& evt );
+	void OnFocus( wxFocusEvent& evt );
 	void OnUpdateTitle( wxTimerEvent& evt );
 
 	void AppStatusEvent_OnSettingsApplied();


### PR DESCRIPTION
Passing focus on the focus message instead of the activate message resolves an issue where external processes (e.g. NVIDIA overlay) forced a focus change to the GS Frame, requiring the window to be refocused in order for keyboard inputs to work again.

Currently, GSFrame rejects focus messages and instead passes it to the child GSPanel.

To better illustrate the changes, let's compare the GSFrame message flow before and after this change:

# Before

## WM_SETFOCUS
* Do nothing special. GSFrame receives focus and accepts it.
* Continue with default window procedure.

## WM_ACTIVATE
* Set focus to GSPanel. This prevents `WM_ACTIVATE` from setting focus to GSFrame (as it is contractually done by the default window handler).
* Continue with default window procedure.

# After

## WM_SETFOCUS
* Set focus to GSPanel. This prevents GSFrame from getting focused at.
* Set the message as processed, **ignoring the default window procedure**. This essentially "rejects" the focus message.

## WM_ACTIVATE
* Do nothing special. GSFrame receives focus, but because of a new `WM_SETFOCUS` handler, it is going to reject it and pass it to GSPanel instead.
* Continue with default window procedure.

In the case of NVIDIA overlay (and possibly more), a focus message was sent to the GSFrame **without** `WM_ACTIVATE`, so the existing logic failed to pass focus to the GSPanel. I have not managed to locate what exactly sends this message, but I confirmed it does not come from the PCSX2 process, so it must be posted from elsewhere.