### PR TITLE
GameDB: add Nearest EErounding to SSX and SSX tricky 

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -31565,6 +31565,8 @@ SLUS-20095:
   name: "SSX"
   region: "NTSC-U"
   compat: 5
+  roundModes:
+    eeRoundMode: 0
 SLUS-20096:
   name: "Swing Away Golf"
   region: "NTSC-U"
@@ -32437,6 +32439,8 @@ SLUS-20326:
   name: "SSX Tricky"
   region: "NTSC-U"
   compat: 5
+  roundModes:
+    eeRoundMode: 0
 SLUS-20327:
   name: "Aggressive Inline"
   region: "NTSC-U"

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -31566,7 +31566,7 @@ SLUS-20095:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0
+    eeRoundMode: 0 # Fixes riders vanish into the floor
 SLUS-20096:
   name: "Swing Away Golf"
   region: "NTSC-U"
@@ -32440,7 +32440,7 @@ SLUS-20326:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0
+    eeRoundMode: 0 # Fixes riders vanish into the floor
 SLUS-20327:
   name: "Aggressive Inline"
   region: "NTSC-U"

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -6122,6 +6122,8 @@ SLES-50029:
 SLES-50030:
   name: "SSX Snowboarding"
   region: "PAL-M3"
+   roundModes:
+    eeRoundMode: 0 # Fixes riders vanish into the floor
 SLES-50031:
   name: "X-Squad"
   region: "PAL-E"
@@ -7100,6 +7102,8 @@ SLES-50544:
 SLES-50545:
   name: "SSX Tricky"
   region: "PAL-M3"
+  roundModes:
+    eeRoundMode: 0 # Fixes riders vanish into the floor
 SLES-50546:
   name: "LMA Manager 2002"
   region: "PAL-E"
@@ -26821,6 +26825,8 @@ SLPS-20024:
 SLPS-20025:
   name: "SSX - Snowboard Supercross"
   region: "NTSC-J"
+  roundModes:
+    eeRoundMode: 0 # Fixes riders vanish into the floor
 SLPS-20027:
   name: "Aquaqua"
   region: "NTSC-J"
@@ -28042,6 +28048,8 @@ SLPS-25077:
 SLPS-25078:
   name: "SSX Tricky"
   region: "NTSC-J"
+  roundModes:
+    eeRoundMode: 0 # Fixes riders vanish into the floor
 SLPS-25079:
   name: "Madden NFL 2002"
   region: "NTSC-J"


### PR DESCRIPTION
<!--
If this is your first PR to PCSX2, please review the relevant documentation:
- https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
add Nearest EErounding to SSX and SSX tricky (NTSC-U & PAL &NTSC-J) to the  GameDB
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
To fix SSX and SSX tricky(NTSC-U & PAL &NTSC-J)
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
