### PR TITLE
Github/CI - Add first-time contributor PR message  and label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,3 @@
-<!--
-If this is your first PR to PCSX2, please review the relevant documentation:
-- https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
--->
-
 ### Description of Changes
 <!-- Brief description or overview on what was changed in the PR -->
 

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -23,7 +23,7 @@ jobs:
 
           As this is your first pull request, [please be aware of the contributing guidelines](https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md).
 
-          Additionally, as per recent changes in Github Actions, your pull request will need to be approved by a maintainer before Github Actions can run against it.
+          Additionally, as per recent changes in Github Actions, your pull request will need to be approved by a maintainer before Github Actions can run against it. [You can find more information about this change here.](https://github.blog/2021-04-22-github-actions-update-helping-maintainers-combat-bad-actors/)
 
-          Please be patient until this happens, in the meantime if you'd like to confirm the builds passing before that happens, you have the option of opening a PR on your own fork, just make sure your fork's master branch is up to date!  [You can find more information about this change here.](https://github.blog/2021-04-22-github-actions-update-helping-maintainers-combat-bad-actors/)
+          Please be patient until this happens. In the meantime if you'd like to confirm the builds are passing, you have the option of opening a PR on your own fork, just make sure your fork's master branch is up to date!
         pr-labels: "First Time Contribution"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -13,3 +13,17 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+    - uses: xTVaser/first-interaction@v1.2.4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        debug-mode: false
+        pr-message: |-
+          ## Thank you for submitting a contribution to PCSX2
+
+          As this is your first pull request, [please be aware of the contributing guidelines](https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md).
+
+          Additionally, as per recent changes in Github Actions, your pull request will need to be approved by a maintainer before Github Actions can run against it.
+
+          Please be patient until this happens, in the meantime if you'd like to confirm the builds passing before that happens, you have the option of opening a PR on your own fork, just make sure your fork's master branch is up to date!  [You can find more information about this change here.](https://github.blog/2021-04-22-github-actions-update-helping-maintainers-combat-bad-actors/)
+        pr-labels: "First Time Contribution"

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -42,11 +42,11 @@ jobs:
 
     steps:
       # NOTE - useful for debugging
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
+      # - name: Dump GitHub context
+      #   env:
+      #     GITHUB_CONTEXT: ${{ toJson(github) }}
+      #   run: |
+      #     echo "$GITHUB_CONTEXT"
 
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Assumes there is a label made already with the name `First Time Contribution` (leave feedback if a different name is preferred)

I removed the comment from the PR template because it now feels redundant, the comment links them to the document (its clickable!) and explains the CI situation.  Lastly, it adds the label.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Improvement from a link in a markdown comment, removes it from non-first timers PR drafting.
Label makes it more visible that a maintainer needs to take action.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

I tested here - https://github.com/xTVaser/pcsx2-rr/pull/83