### PR TITLE
UI: Asynchronous BIOS enumeration

### DIFF
--- a/pcsx2/gui/Panels/BiosSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/BiosSelectorPanel.cpp
@@ -44,8 +44,8 @@ wxDEFINE_EVENT(pxEvt_BiosEnumerationFinished, wxCommandEvent);
 // upgraded to wx2.9/3.0, it should incorporate such functionality into this base class.  (for now
 // we just provide the user with a "refresh" button).
 //
-Panels::BaseSelectorPanel::BaseSelectorPanel( wxWindow* parent )
-	: BaseApplicableConfigPanel( parent, wxVERTICAL )
+Panels::BaseSelectorPanel::BaseSelectorPanel(wxWindow* parent)
+	: BaseApplicableConfigPanel(parent, wxVERTICAL)
 {
 	Bind(wxEVT_DIRPICKER_CHANGED, &BaseSelectorPanel::OnFolderChanged, this);
 	Bind(wxEVT_SHOW, &BaseSelectorPanel::OnShow, this);
@@ -54,22 +54,22 @@ Panels::BaseSelectorPanel::BaseSelectorPanel( wxWindow* parent )
 void Panels::BaseSelectorPanel::OnShow(wxShowEvent& evt)
 {
 	evt.Skip();
-	if( evt.IsShown() )
+	if (evt.IsShown())
 		OnShown();
 }
 
 void Panels::BaseSelectorPanel::OnShown()
 {
-	if( !ValidateEnumerationStatus() )
+	if (!ValidateEnumerationStatus())
 		DoRefresh();
 }
 
-bool Panels::BaseSelectorPanel::Show( bool visible )
+bool Panels::BaseSelectorPanel::Show(bool visible)
 {
-	if( visible )
+	if (visible)
 		OnShown();
 
-	return BaseApplicableConfigPanel::Show( visible );
+	return BaseApplicableConfigPanel::Show(visible);
 }
 
 void Panels::BaseSelectorPanel::RefreshSelections()
@@ -78,13 +78,13 @@ void Panels::BaseSelectorPanel::RefreshSelections()
 	DoRefresh();
 }
 
-void Panels::BaseSelectorPanel::OnRefreshSelections( wxCommandEvent& evt )
+void Panels::BaseSelectorPanel::OnRefreshSelections(wxCommandEvent& evt)
 {
 	evt.Skip();
 	RefreshSelections();
 }
 
-void Panels::BaseSelectorPanel::OnFolderChanged( wxFileDirPickerEvent& evt )
+void Panels::BaseSelectorPanel::OnFolderChanged(wxFileDirPickerEvent& evt)
 {
 	evt.Skip();
 	OnShown();
@@ -93,30 +93,30 @@ void Panels::BaseSelectorPanel::OnFolderChanged( wxFileDirPickerEvent& evt )
 // =====================================================================================================
 //  BiosSelectorPanel
 // =====================================================================================================
-Panels::BiosSelectorPanel::BiosSelectorPanel( wxWindow* parent )
-	: BaseSelectorPanel( parent )
+Panels::BiosSelectorPanel::BiosSelectorPanel(wxWindow* parent)
+	: BaseSelectorPanel(parent)
 {
-	SetMinWidth( 480 );
+	SetMinWidth(480);
 
-	m_ComboBox		= new wxListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_SINGLE | wxLB_SORT | wxLB_NEEDED_SB );
-	m_FolderPicker	= new DirPickerPanel( this, FolderId_Bios,
-		_("BIOS Search Path:"),						// static box label
-		_("Select folder with PS2 BIOS roms")		// dir picker popup label
+	m_ComboBox = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_SINGLE | wxLB_SORT | wxLB_NEEDED_SB);
+	m_FolderPicker = new DirPickerPanel(this, FolderId_Bios,
+		_("BIOS Search Path:"), // static box label
+		_("Select folder with PS2 BIOS roms") // dir picker popup label
 	);
 
-	m_ComboBox->SetFont( pxGetFixedFont( m_ComboBox->GetFont().GetPointSize()+1 ) );
-	m_ComboBox->SetMinSize( wxSize( wxDefaultCoord, std::max( m_ComboBox->GetMinSize().GetHeight(), 96 ) ) );
+	m_ComboBox->SetFont(pxGetFixedFont(m_ComboBox->GetFont().GetPointSize() + 1));
+	m_ComboBox->SetMinSize(wxSize(wxDefaultCoord, std::max(m_ComboBox->GetMinSize().GetHeight(), 96)));
 
 	//if (InstallationMode != InstallMode_Portable)
-		m_FolderPicker->SetStaticDesc( _("Click the Browse button to select a different folder where PCSX2 will look for PS2 BIOS roms.") );
+	m_FolderPicker->SetStaticDesc(_("Click the Browse button to select a different folder where PCSX2 will look for PS2 BIOS roms."));
 
-	wxButton* refreshButton = new wxButton( this, wxID_ANY, _("Refresh list") );
+	wxButton* refreshButton = new wxButton(this, wxID_ANY, _("Refresh list"));
 
-	*this	+= Label(_("Select a BIOS rom:"));
-	*this	+= m_ComboBox		| StdExpand();
-	*this	+= refreshButton	| pxBorder(wxLEFT, StdPadding);
-	*this	+= 8;
-	*this	+= m_FolderPicker	| StdExpand();
+	*this += Label(_("Select a BIOS rom:"));
+	*this += m_ComboBox | StdExpand();
+	*this += refreshButton | pxBorder(wxLEFT, StdPadding);
+	*this += 8;
+	*this += m_FolderPicker | StdExpand();
 
 	Bind(pxEvt_BiosEnumerationFinished, &BiosSelectorPanel::OnEnumComplete, this);
 
@@ -126,15 +126,15 @@ Panels::BiosSelectorPanel::BiosSelectorPanel( wxWindow* parent )
 void Panels::BiosSelectorPanel::Apply()
 {
 	// User never visited this tab, so there's nothing to apply.
-	if( !m_BiosList ) return;
+	if (!m_BiosList)
+		return;
 
 	int sel = m_ComboBox->GetSelection();
-	if( sel == wxNOT_FOUND )
+	if (sel == wxNOT_FOUND)
 	{
 		throw Exception::CannotApplySettings(this)
 			.SetDiagMsg(L"User did not specify a valid BIOS selection.")
-			.SetUserMsg( pxE( L"Please select a valid BIOS.  If you are unable to make a valid selection then press Cancel to close the Configuration panel."
-			) );
+			.SetUserMsg(pxE(L"Please select a valid BIOS.  If you are unable to make a valid selection then press Cancel to close the Configuration panel."));
 	}
 
 	g_Conf->BaseFilenames.Bios = (*m_BiosList)[(sptr)m_ComboBox->GetClientData(sel)];
@@ -152,10 +152,10 @@ bool Panels::BiosSelectorPanel::ValidateEnumerationStatus()
 	// occurs during file enumeration.
 	std::unique_ptr<wxArrayString> bioslist(new wxArrayString());
 
-	if( m_FolderPicker->GetPath().Exists() )
+	if (m_FolderPicker->GetPath().Exists())
 		wxDir::GetAllFiles(m_FolderPicker->GetPath().ToString(), bioslist.get(), L"*.*", wxDIR_FILES);
 
-	if( !m_BiosList || (*bioslist != *m_BiosList) )
+	if (!m_BiosList || (*bioslist != *m_BiosList))
 		validated = false;
 
 	m_BiosList.swap(bioslist);
@@ -172,7 +172,8 @@ void Panels::BiosSelectorPanel::EnumThread::ExecuteTaskInThread()
 	for (size_t i = 0; i < m_parent.m_BiosList->GetCount(); ++i)
 	{
 		wxString description;
-		if (!IsBIOS((*m_parent.m_BiosList)[i], description)) continue;
+		if (!IsBIOS((*m_parent.m_BiosList)[i], description))
+			continue;
 		Result.emplace_back(std::move(description), i);
 	}
 
@@ -184,7 +185,8 @@ void Panels::BiosSelectorPanel::EnumThread::ExecuteTaskInThread()
 void Panels::BiosSelectorPanel::DoRefresh()
 {
 	m_ComboBox->Clear();
-	if (!m_BiosList->size()) return;
+	if (!m_BiosList->size())
+		return;
 
 	m_ComboBox->Append(wxString("Enumerating BIOSes..."));
 	m_ComboBox->Update();
@@ -194,11 +196,12 @@ void Panels::BiosSelectorPanel::DoRefresh()
 	m_EnumeratorThread->Start();
 }
 
-void Panels::BiosSelectorPanel::OnEnumComplete(wxCommandEvent &evt)
+void Panels::BiosSelectorPanel::OnEnumComplete(wxCommandEvent& evt)
 {
 	auto enumThread = static_cast<EnumThread*>(evt.GetClientData());
 	// Sanity check, in case m_BiosList was updated by ValidateEnumerationStatus() while the EnumThread was running
-	if (m_EnumeratorThread.get() != enumThread || m_BiosList->size() < enumThread->Result.size()) return;
+	if (m_EnumeratorThread.get() != enumThread || m_BiosList->size() < enumThread->Result.size())
+		return;
 
 	const wxFileName& currentBios = g_Conf->FullpathToBios();
 	m_ComboBox->Clear(); // Clear the "Enumerating BIOSes..."
@@ -211,5 +214,5 @@ void Panels::BiosSelectorPanel::OnEnumComplete(wxCommandEvent &evt)
 	}
 };
 
-Panels::BiosSelectorPanel::EnumThread::EnumThread(BiosSelectorPanel &parent) : m_parent(parent)
-{};
+Panels::BiosSelectorPanel::EnumThread::EnumThread(BiosSelectorPanel& parent)
+	: m_parent(parent){};

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -42,41 +42,41 @@ namespace Panels
 		typedef BaseApplicableConfigPanel _parent;
 
 	protected:
-		FoldersEnum_t		m_FolderId;
-		wxDirPickerCtrl*	m_pickerCtrl;
-		pxCheckBox*			m_checkCtrl;
-		wxTextCtrl*			m_textCtrl;
-		wxButton*			b_explore;
+		FoldersEnum_t m_FolderId;
+		wxDirPickerCtrl* m_pickerCtrl;
+		pxCheckBox* m_checkCtrl;
+		wxTextCtrl* m_textCtrl;
+		wxButton* b_explore;
 
 	public:
-		DirPickerPanel( wxWindow* parent, FoldersEnum_t folderid, const wxString& label, const wxString& dialogLabel );
-		DirPickerPanel( wxWindow* parent, FoldersEnum_t folderid, const wxString& dialogLabel );
+		DirPickerPanel(wxWindow* parent, FoldersEnum_t folderid, const wxString& label, const wxString& dialogLabel);
+		DirPickerPanel(wxWindow* parent, FoldersEnum_t folderid, const wxString& dialogLabel);
 		virtual ~DirPickerPanel() = default;
 
 		void Reset();
 		wxDirName GetPath() const;
-		void SetPath( const wxString& src );
+		void SetPath(const wxString& src);
 
-		DirPickerPanel& SetStaticDesc( const wxString& msg );
-		DirPickerPanel& SetToolTip( const wxString& tip );
+		DirPickerPanel& SetStaticDesc(const wxString& msg);
+		DirPickerPanel& SetToolTip(const wxString& tip);
 
 		wxWindowID GetId() const;
 		wxWindowID GetPanelId() const { return m_windowId; }
 
 		// Overrides!
-		
+
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		bool Enable( bool enable=true );
+		bool Enable(bool enable = true);
 
 	protected:
-		void Init( FoldersEnum_t folderid, const wxString& dialogLabel, bool isCompact );
-		void InitForPortableMode( const wxString& normalized );
-		void InitForRegisteredMode( const wxString& normalized, const wxString& dialogLabel, bool isCompact );
+		void Init(FoldersEnum_t folderid, const wxString& dialogLabel, bool isCompact);
+		void InitForPortableMode(const wxString& normalized);
+		void InitForRegisteredMode(const wxString& normalized, const wxString& dialogLabel, bool isCompact);
 
-		void UseDefaultPath_Click( wxCommandEvent &event );
-		void Explore_Click( wxCommandEvent &event );
-		void UpdateCheckStatus( bool someNoteworthyBoolean );
+		void UseDefaultPath_Click(wxCommandEvent& event);
+		void Explore_Click(wxCommandEvent& event);
+		void UpdateCheckStatus(bool someNoteworthyBoolean);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -85,38 +85,38 @@ namespace Panels
 	class DocsFolderPickerPanel : public BaseApplicableConfigPanel
 	{
 	protected:
-		pxRadioPanel*	m_radio_UserMode;
-		DirPickerPanel*	m_dirpicker_custom;
+		pxRadioPanel* m_radio_UserMode;
+		DirPickerPanel* m_dirpicker_custom;
 
 	public:
 		virtual ~DocsFolderPickerPanel() = default;
-		DocsFolderPickerPanel( wxWindow* parent, bool isFirstTime = true );
+		DocsFolderPickerPanel(wxWindow* parent, bool isFirstTime = true);
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		
+
 		DocsModeType GetDocsMode() const;
 		wxWindowID GetDirPickerId() const { return m_dirpicker_custom ? m_dirpicker_custom->GetId() : 0; }
 
 	protected:
-		void OnRadioChanged( wxCommandEvent& evt );
+		void OnRadioChanged(wxCommandEvent& evt);
 	};
 
 	class LanguageSelectionPanel : public BaseApplicableConfigPanel
 	{
 	protected:
-		LangPackList	m_langs;
-		wxComboBox*		m_picker;
+		LangPackList m_langs;
+		wxComboBox* m_picker;
 
 	public:
 		virtual ~LanguageSelectionPanel() = default;
-		LanguageSelectionPanel( wxWindow* parent, bool showApply = true );
+		LanguageSelectionPanel(wxWindow* parent, bool showApply = true);
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 
 	protected:
-		void OnApplyLanguage_Clicked( wxCommandEvent& evt );
+		void OnApplyLanguage_Clicked(wxCommandEvent& evt);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -130,18 +130,18 @@ namespace Panels
 	{
 
 	protected:
-		pxRadioPanel*	m_RoundModePanel;
-		pxRadioPanel*	m_ClampModePanel;
+		pxRadioPanel* m_RoundModePanel;
+		pxRadioPanel* m_ClampModePanel;
 
 	public:
-		BaseAdvancedCpuOptions( wxWindow* parent );
+		BaseAdvancedCpuOptions(wxWindow* parent);
 		virtual ~BaseAdvancedCpuOptions() = default;
 
 		void RestoreDefaults();
 
 	protected:
-		void OnRestoreDefaults( wxCommandEvent& evt );
-		void ApplyRoundmode( SSE_MXCSR& mxcsr );
+		void OnRestoreDefaults(wxCommandEvent& evt);
+		void ApplyRoundmode(SSE_MXCSR& mxcsr);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -150,22 +150,21 @@ namespace Panels
 	class AdvancedOptionsFPU : public BaseAdvancedCpuOptions
 	{
 	public:
-		AdvancedOptionsFPU( wxWindow* parent );
+		AdvancedOptionsFPU(wxWindow* parent);
 		virtual ~AdvancedOptionsFPU() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	};
 
 	class AdvancedOptionsVU : public BaseAdvancedCpuOptions
 	{
 	public:
-		AdvancedOptionsVU( wxWindow* parent );
+		AdvancedOptionsVU(wxWindow* parent);
 		virtual ~AdvancedOptionsVU() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
-
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -174,43 +173,43 @@ namespace Panels
 	class CpuPanelEE : public BaseApplicableConfigPanel_SpecificConfig
 	{
 	protected:
-		pxRadioPanel*		m_panel_RecEE;
-		pxRadioPanel*		m_panel_RecIOP;
-		pxCheckBox*			m_check_EECacheEnable;
-		AdvancedOptionsFPU*	m_advancedOptsFpu;
-		wxButton*			m_button_RestoreDefaults;
+		pxRadioPanel* m_panel_RecEE;
+		pxRadioPanel* m_panel_RecIOP;
+		pxCheckBox* m_check_EECacheEnable;
+		AdvancedOptionsFPU* m_advancedOptsFpu;
+		wxButton* m_button_RestoreDefaults;
 
 	public:
-		CpuPanelEE( wxWindow* parent );
+		CpuPanelEE(wxWindow* parent);
 		virtual ~CpuPanelEE() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui(AppConfig& configToApply, int flags=0);
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 
 	protected:
-		void OnRestoreDefaults( wxCommandEvent& evt );
-		void EECache_Event( wxCommandEvent& evt );
+		void OnRestoreDefaults(wxCommandEvent& evt);
+		void EECache_Event(wxCommandEvent& evt);
 	};
 
 	class CpuPanelVU : public BaseApplicableConfigPanel_SpecificConfig
 	{
 	protected:
-		pxRadioPanel*				m_panel_VU0;
-		pxRadioPanel*				m_panel_VU1;
-		Panels::AdvancedOptionsVU*	m_advancedOptsVu;
-		wxButton *m_button_RestoreDefaults;
+		pxRadioPanel* m_panel_VU0;
+		pxRadioPanel* m_panel_VU1;
+		Panels::AdvancedOptionsVU* m_advancedOptsVu;
+		wxButton* m_button_RestoreDefaults;
 
 	public:
-		CpuPanelVU( wxWindow* parent );
+		CpuPanelVU(wxWindow* parent);
 		virtual ~CpuPanelVU() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 
 	protected:
-		void OnRestoreDefaults( wxCommandEvent& evt );
+		void OnRestoreDefaults(wxCommandEvent& evt);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -219,18 +218,18 @@ namespace Panels
 	class FrameSkipPanel : public BaseApplicableConfigPanel_SpecificConfig
 	{
 	protected:
-		wxSpinCtrl*		m_spin_FramesToSkip;
-		wxSpinCtrl*		m_spin_FramesToDraw;
+		wxSpinCtrl* m_spin_FramesToSkip;
+		wxSpinCtrl* m_spin_FramesToDraw;
 
-		pxRadioPanel*	m_radio_SkipMode;
+		pxRadioPanel* m_radio_SkipMode;
 
 	public:
-		FrameSkipPanel( wxWindow* parent );
-		virtual	~FrameSkipPanel() = default;
+		FrameSkipPanel(wxWindow* parent);
+		virtual ~FrameSkipPanel() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -239,25 +238,25 @@ namespace Panels
 	class FramelimiterPanel : public BaseApplicableConfigPanel_SpecificConfig
 	{
 	protected:
-		pxCheckBox*		m_check_LimiterDisable;
-		wxSpinCtrl*		m_spin_NominalPct;
-		wxSpinCtrl*		m_spin_SlomoPct;
-		wxSpinCtrl*		m_spin_TurboPct;
+		pxCheckBox* m_check_LimiterDisable;
+		wxSpinCtrl* m_spin_NominalPct;
+		wxSpinCtrl* m_spin_SlomoPct;
+		wxSpinCtrl* m_spin_TurboPct;
 
-		wxTextCtrl*		m_text_BaseNtsc;
-		wxTextCtrl*		m_text_BasePal;
+		wxTextCtrl* m_text_BaseNtsc;
+		wxTextCtrl* m_text_BasePal;
 
-		wxCheckBox*		m_SkipperEnable;
-		wxCheckBox*		m_TurboSkipEnable;
-		wxSpinCtrl*		m_spin_SkipThreshold;
+		wxCheckBox* m_SkipperEnable;
+		wxCheckBox* m_TurboSkipEnable;
+		wxSpinCtrl* m_spin_SkipThreshold;
 
 	public:
-		FramelimiterPanel( wxWindow* parent );
+		FramelimiterPanel(wxWindow* parent);
 		virtual ~FramelimiterPanel() = default;
 
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -273,50 +272,50 @@ namespace Panels
 		//    and PCSX2's code doesn't seem to use this API anywhere. So, no exclusive mode for now.
 		//    - avih
 
-		wxComboBox*		m_combo_AspectRatio;
-		wxComboBox*		m_combo_FMVAspectRatioSwitch;
-		wxComboBox*		m_combo_vsync;
+		wxComboBox* m_combo_AspectRatio;
+		wxComboBox* m_combo_FMVAspectRatioSwitch;
+		wxComboBox* m_combo_vsync;
 
-		wxTextCtrl*		m_text_Zoom;
+		wxTextCtrl* m_text_Zoom;
 
-		pxCheckBox*		m_check_CloseGS;
-		pxCheckBox*		m_check_SizeLock;
-		pxCheckBox*		m_check_VsyncEnable;
-		pxCheckBox*		m_check_Fullscreen;
+		pxCheckBox* m_check_CloseGS;
+		pxCheckBox* m_check_SizeLock;
+		pxCheckBox* m_check_VsyncEnable;
+		pxCheckBox* m_check_Fullscreen;
 
-		pxCheckBox*		m_check_HideMouse;
-		pxCheckBox*		m_check_DclickFullscreen;
+		pxCheckBox* m_check_HideMouse;
+		pxCheckBox* m_check_DclickFullscreen;
 
-		wxTextCtrl*		m_text_WindowWidth;
-		wxTextCtrl*		m_text_WindowHeight;
+		wxTextCtrl* m_text_WindowWidth;
+		wxTextCtrl* m_text_WindowHeight;
 
 	public:
-		GSWindowSettingsPanel( wxWindow* parent );
+		GSWindowSettingsPanel(wxWindow* parent);
 		virtual ~GSWindowSettingsPanel() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	};
 
 	class VideoPanel : public BaseApplicableConfigPanel_SpecificConfig
 	{
 	protected:
-		pxCheckBox*			m_check_SynchronousGS;
-		wxSpinCtrl*			m_spinner_VsyncQueue;
-		wxButton*			m_restore_defaults;
-		FrameSkipPanel*		m_span;
-		FramelimiterPanel*	m_fpan;
+		pxCheckBox* m_check_SynchronousGS;
+		wxSpinCtrl* m_spinner_VsyncQueue;
+		wxButton* m_restore_defaults;
+		FrameSkipPanel* m_span;
+		FramelimiterPanel* m_fpan;
 
 	public:
-		VideoPanel( wxWindow* parent );
+		VideoPanel(wxWindow* parent);
 		virtual ~VideoPanel() = default;
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
 		void Defaults_Click(wxCommandEvent& evt);
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 
 	protected:
-		void OnOpenWindowSettings( wxCommandEvent& evt );
+		void OnOpenWindowSettings(wxCommandEvent& evt);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -328,42 +327,42 @@ namespace Panels
 		wxBoxSizer* m_sizer;
 		wxFlexGridSizer* s_table;
 
-		pxCheckBox*		m_check_Enable;
-		wxButton*		m_button_Defaults;
+		pxCheckBox* m_check_Enable;
+		wxButton* m_button_Defaults;
 
 		wxPanelWithHelpers* m_eeRateSliderPanel;
 		wxPanelWithHelpers* m_eeSkipSliderPanel;
-		wxSlider*		m_slider_eeRate;
-		wxSlider*		m_slider_eeSkip;
-		pxStaticText*	m_msg_eeRate;
-		pxStaticText*	m_msg_eeSkip;
+		wxSlider* m_slider_eeRate;
+		wxSlider* m_slider_eeSkip;
+		pxStaticText* m_msg_eeRate;
+		pxStaticText* m_msg_eeSkip;
 
-		pxCheckBox*		m_check_intc;
-		pxCheckBox*		m_check_waitloop;
-		pxCheckBox*		m_check_fastCDVD;
-		pxCheckBox*		m_check_vuFlagHack;
-		pxCheckBox*		m_check_vuThread;
-		pxCheckBox*		m_check_vu1Instant;
+		pxCheckBox* m_check_intc;
+		pxCheckBox* m_check_waitloop;
+		pxCheckBox* m_check_fastCDVD;
+		pxCheckBox* m_check_vuFlagHack;
+		pxCheckBox* m_check_vuThread;
+		pxCheckBox* m_check_vu1Instant;
 
 	public:
 		virtual ~SpeedHacksPanel() = default;
-		SpeedHacksPanel( wxWindow* parent );
+		SpeedHacksPanel(wxWindow* parent);
 		void Apply();
-		void EnableStuff( AppConfig* configToUse=NULL );
+		void EnableStuff(AppConfig* configToUse = NULL);
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 
 	protected:
-		const wxChar* GetEECycleRateSliderMsg( int val );
-		const wxChar* GetEECycleSkipSliderMsg( int val );
+		const wxChar* GetEECycleRateSliderMsg(int val);
+		const wxChar* GetEECycleSkipSliderMsg(int val);
 		void SetEEcycleSliderMsg();
 		void SetVUcycleSliderMsg();
 
-		void OnEnable_Toggled( wxCommandEvent& evt );
-		void Defaults_Click( wxCommandEvent& evt );
-		void EECycleRate_Scroll(wxScrollEvent &event);
-		void VUCycleRate_Scroll(wxScrollEvent &event);
-		void VUThread_Enable ( wxCommandEvent& evt );
+		void OnEnable_Toggled(wxCommandEvent& evt);
+		void Defaults_Click(wxCommandEvent& evt);
+		void EECycleRate_Scroll(wxScrollEvent& event);
+		void VUCycleRate_Scroll(wxScrollEvent& event);
+		void VUThread_Enable(wxCommandEvent& evt);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -372,23 +371,23 @@ namespace Panels
 	class GameFixesPanel : public BaseApplicableConfigPanel_SpecificConfig
 	{
 	protected:
-		pxCheckBox*			m_checkbox[GamefixId_COUNT];
-		pxCheckBox*			m_check_Enable;
+		pxCheckBox* m_checkbox[GamefixId_COUNT];
+		pxCheckBox* m_check_Enable;
 
 	public:
-		GameFixesPanel( wxWindow* parent );
+		GameFixesPanel(wxWindow* parent);
 		virtual ~GameFixesPanel() = default;
-		void EnableStuff( AppConfig* configToUse=NULL );
-		void OnEnable_Toggled( wxCommandEvent& evt );
+		void EnableStuff(AppConfig* configToUse = NULL);
+		void OnEnable_Toggled(wxCommandEvent& evt);
 		void Apply();
 		void AppStatusEvent_OnSettingsApplied();
-		void ApplyConfigToGui( AppConfig& configToApply, int flags=0 );
+		void ApplyConfigToGui(AppConfig& configToApply, int flags = 0);
 	};
 
 	class SettingsDirPickerPanel : public DirPickerPanel
 	{
 	public:
-		SettingsDirPickerPanel( wxWindow* parent );
+		SettingsDirPickerPanel(wxWindow* parent);
 	};
 
 	// --------------------------------------------------------------------------------------
@@ -397,7 +396,7 @@ namespace Panels
 	class BasePathsPanel : public wxPanelWithHelpers
 	{
 	public:
-		BasePathsPanel( wxWindow* parent );
+		BasePathsPanel(wxWindow* parent);
 
 	protected:
 	};
@@ -405,33 +404,33 @@ namespace Panels
 	class StandardPathsPanel : public BasePathsPanel
 	{
 	public:
-		StandardPathsPanel( wxWindow* parent );
+		StandardPathsPanel(wxWindow* parent);
 	};
 
 	// --------------------------------------------------------------------------------------
 	//  BaseSelectorPanel
 	// --------------------------------------------------------------------------------------
-	class BaseSelectorPanel: public BaseApplicableConfigPanel
+	class BaseSelectorPanel : public BaseApplicableConfigPanel
 	{
 		typedef BaseApplicableConfigPanel _parent;
 
 	public:
 		virtual ~BaseSelectorPanel() = default;
-		BaseSelectorPanel( wxWindow* parent );
+		BaseSelectorPanel(wxWindow* parent);
 
 		virtual void RefreshSelections();
 
-		virtual bool Show( bool visible=true );
+		virtual bool Show(bool visible = true);
 		virtual void OnShown();
-		virtual void OnFolderChanged( wxFileDirPickerEvent& evt );
+		virtual void OnFolderChanged(wxFileDirPickerEvent& evt);
 
 	protected:
-		void OnRefreshSelections( wxCommandEvent& evt );
+		void OnRefreshSelections(wxCommandEvent& evt);
 
 		// This method is called when the enumeration contents have changed.  The implementing
 		// class should populate or re-populate listbox/selection components when invoked.
-		// 
-		virtual void DoRefresh()=0;
+		//
+		virtual void DoRefresh() = 0;
 
 		// This method is called when an event has indicated that the enumeration status of the
 		// selector may have changed.  The implementing class should re-enumerate the folder/source
@@ -441,8 +440,8 @@ namespace Panels
 		// If the implementation returns FALSE, then the BaseSelectorPanel will invoke a call to
 		// DoRefresh() [which also must be implemented]
 		//
-		virtual bool ValidateEnumerationStatus()=0;
-	
+		virtual bool ValidateEnumerationStatus() = 0;
+
 		void OnShow(wxShowEvent& evt);
 	};
 
@@ -457,7 +456,7 @@ namespace Panels
 		DirPickerPanel* m_FolderPicker;
 
 	public:
-		BiosSelectorPanel( wxWindow* parent );
+		BiosSelectorPanel(wxWindow* parent);
 		virtual ~BiosSelectorPanel() = default;
 
 		class EnumThread : public Threading::pxThread
@@ -467,7 +466,8 @@ namespace Panels
 
 			virtual ~EnumThread()
 			{
-				try {
+				try
+				{
 					pxThread::Cancel();
 				}
 				DESTRUCTOR_CATCHALL
@@ -485,7 +485,7 @@ namespace Panels
 		virtual void DoRefresh();
 		virtual void OnEnumComplete(wxCommandEvent& evt);
 		virtual bool ValidateEnumerationStatus();
-		
+
 		std::unique_ptr<EnumThread> m_EnumeratorThread;
 	};
 } // namespace Panels

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -460,10 +460,32 @@ namespace Panels
 		BiosSelectorPanel( wxWindow* parent );
 		virtual ~BiosSelectorPanel() = default;
 
+		class EnumThread : public Threading::pxThread
+		{
+		public:
+			std::vector<std::pair<wxString, u32>> Result;
+
+			virtual ~EnumThread()
+			{
+				try {
+					pxThread::Cancel();
+				}
+				DESTRUCTOR_CATCHALL
+			}
+			EnumThread(BiosSelectorPanel& parent);
+
+		protected:
+			void ExecuteTaskInThread();
+			BiosSelectorPanel& m_parent;
+		};
+
 	protected:
 		virtual void Apply();
 		virtual void AppStatusEvent_OnSettingsApplied();
 		virtual void DoRefresh();
+		virtual void OnEnumComplete(wxCommandEvent& evt);
 		virtual bool ValidateEnumerationStatus();
+		
+		std::unique_ptr<EnumThread> m_EnumeratorThread;
 	};
 } // namespace Panels


### PR DESCRIPTION
### Description of Changes
Instead of blocking the UI, show the text "Enumerating..." and run a thread to enumerate through the BIOSes

### Rationale behind Changes
It can look like PCSX2 has crashed when verifying BIOSes in a directory.
Expensive file I/O shouldn't be on the UI thread

### Suggested Testing Steps
Duplicate your BIOS bin files and put them in a single directory.
Go to the BIOS selection page and set the BIOS directory to said directory.
You should see "Enumerating BIOSes..." as the first item in the BIOS list, the UI shouldn't freeze
Once the thread is done working, the list box should contain your BIOSes