### PR TITLE
CDVD-GUI: Swap buttons `Browse...` and `Ask when booting` and default to unchecked state.

### DIFF
--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -43,10 +43,11 @@
 RecentIsoList::RecentIsoList(int firstIdForMenuItems_or_wxID_ANY)
 {
 	Menu = std::unique_ptr<wxMenu>(new wxMenu());
-	Menu->AppendCheckItem( MenuId_Ask_On_Booting, _("Always ask when booting"), _("Manually select an ISO upon boot ignoring the selection from recent ISO list.") );
+	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history."));
 	Menu->AppendSeparator();
-	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history."))->Enable(!g_Conf->AskOnBoot);
+	Menu->AppendCheckItem( MenuId_Ask_On_Booting, _("Always ask when booting"), _("Manually select an ISO upon boot ignoring the selection from recent ISO list.") );
 	Menu->Check( MenuId_Ask_On_Booting, g_Conf->AskOnBoot );
+
 	Manager = std::unique_ptr<RecentIsoManager>(new RecentIsoManager( Menu.get(), firstIdForMenuItems_or_wxID_ANY ));
 }
 

--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -43,12 +43,12 @@
 RecentIsoList::RecentIsoList(int firstIdForMenuItems_or_wxID_ANY)
 {
 	Menu = std::unique_ptr<wxMenu>(new wxMenu());
-	Menu->Append( MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history."));
+	Menu->Append(MenuId_IsoBrowse, _("Browse..."), _("Browse for an ISO that is not in your recent history."));
 	Menu->AppendSeparator();
-	Menu->AppendCheckItem( MenuId_Ask_On_Booting, _("Always ask when booting"), _("Manually select an ISO upon boot ignoring the selection from recent ISO list.") );
-	Menu->Check( MenuId_Ask_On_Booting, g_Conf->AskOnBoot );
+	Menu->AppendCheckItem(MenuId_Ask_On_Booting, _("Always ask when booting"), _("Manually select an ISO upon boot ignoring the selection from recent ISO list."));
+	Menu->Check(MenuId_Ask_On_Booting, g_Conf->AskOnBoot);
 
-	Manager = std::unique_ptr<RecentIsoManager>(new RecentIsoManager( Menu.get(), firstIdForMenuItems_or_wxID_ANY ));
+	Manager = std::unique_ptr<RecentIsoManager>(new RecentIsoManager(Menu.get(), firstIdForMenuItems_or_wxID_ANY));
 }
 
 pxAppResources::pxAppResources()
@@ -59,19 +59,21 @@ pxAppResources::~pxAppResources() = default;
 
 wxMenu& Pcsx2App::GetRecentIsoMenu()
 {
-	if (!m_RecentIsoList) m_RecentIsoList = std::unique_ptr<RecentIsoList>(new RecentIsoList( MenuId_RecentIsos_reservedStart ));
+	if (!m_RecentIsoList)
+		m_RecentIsoList = std::unique_ptr<RecentIsoList>(new RecentIsoList(MenuId_RecentIsos_reservedStart));
 	return *m_RecentIsoList->Menu;
 }
 
 RecentIsoManager& Pcsx2App::GetRecentIsoManager()
 {
-	if (!m_RecentIsoList) m_RecentIsoList = std::unique_ptr<RecentIsoList>(new RecentIsoList( MenuId_RecentIsos_reservedStart ));
+	if (!m_RecentIsoList)
+		m_RecentIsoList = std::unique_ptr<RecentIsoList>(new RecentIsoList(MenuId_RecentIsos_reservedStart));
 	return *m_RecentIsoList->Manager;
 }
 
 wxMenu& Pcsx2App::GetDriveListMenu()
 {
-	if( !m_DriveList )
+	if (!m_DriveList)
 	{
 		m_DriveList = std::unique_ptr<DriveList>(new DriveList());
 	}
@@ -81,8 +83,8 @@ wxMenu& Pcsx2App::GetDriveListMenu()
 
 pxAppResources& Pcsx2App::GetResourceCache()
 {
-	ScopedLock lock( m_mtx_Resources );
-	if( !m_Resources )
+	ScopedLock lock(m_mtx_Resources);
+	if (!m_Resources)
 		m_Resources = std::unique_ptr<pxAppResources>(new pxAppResources());
 
 	return *m_Resources;
@@ -90,13 +92,13 @@ pxAppResources& Pcsx2App::GetResourceCache()
 
 const wxIconBundle& Pcsx2App::GetIconBundle()
 {
-	std::unique_ptr<wxIconBundle>& bundle( GetResourceCache().IconBundle );
-	if( !bundle )
+	std::unique_ptr<wxIconBundle>& bundle(GetResourceCache().IconBundle);
+	if (!bundle)
 	{
 		bundle = std::unique_ptr<wxIconBundle>(new wxIconBundle());
-		bundle->AddIcon( EmbeddedImage<res_AppIcon32>().GetIcon() );
-		bundle->AddIcon( EmbeddedImage<res_AppIcon64>().GetIcon() );
-		bundle->AddIcon( EmbeddedImage<res_AppIcon16>().GetIcon() );
+		bundle->AddIcon(EmbeddedImage<res_AppIcon32>().GetIcon());
+		bundle->AddIcon(EmbeddedImage<res_AppIcon64>().GetIcon());
+		bundle->AddIcon(EmbeddedImage<res_AppIcon16>().GetIcon());
 	}
 
 	return *bundle;
@@ -104,8 +106,9 @@ const wxIconBundle& Pcsx2App::GetIconBundle()
 
 const wxBitmap& Pcsx2App::GetLogoBitmap()
 {
-	std::unique_ptr <wxBitmap>& logo(GetResourceCache().Bitmap_Logo);
-	if( logo ) return *logo;
+	std::unique_ptr<wxBitmap>& logo(GetResourceCache().Bitmap_Logo);
+	if (logo)
+		return *logo;
 
 	wxImage img = EmbeddedImage<res_BackgroundLogo>().Get();
 	float scale = MSW_GetDPIScale(); // 1.0 for non-Windows
@@ -117,7 +120,8 @@ const wxBitmap& Pcsx2App::GetLogoBitmap()
 const wxBitmap& Pcsx2App::GetScreenshotBitmap()
 {
 	std::unique_ptr<wxBitmap>& screenshot(GetResourceCache().ScreenshotBitmap);
-	if (screenshot) return *screenshot;
+	if (screenshot)
+		return *screenshot;
 
 	wxImage img = EmbeddedImage<res_ButtonIcon_Camera>().Get();
 	float scale = MSW_GetDPIScale(); // 1.0 for non-Windows
@@ -128,27 +132,27 @@ const wxBitmap& Pcsx2App::GetScreenshotBitmap()
 
 wxImageList& Pcsx2App::GetImgList_Config()
 {
-	std::unique_ptr<wxImageList>& images( GetResourceCache().ConfigImages );
-	if( !images )
+	std::unique_ptr<wxImageList>& images(GetResourceCache().ConfigImages);
+	if (!images)
 	{
 		int image_size = MSW_GetDPIScale() * g_Conf->Listbook_ImageSize;
 		images = std::unique_ptr<wxImageList>(new wxImageList(image_size, image_size));
 
-		#undef  FancyLoadMacro
-		#define FancyLoadMacro( name ) \
-		{ \
-			wxImage img = EmbeddedImage<res_ConfigIcon_##name>().Get(); \
-			img.Rescale(image_size, image_size, wxIMAGE_QUALITY_HIGH); \
-			m_Resources->ImageId.Config.name = images->Add(img); \
-		}
+#undef FancyLoadMacro
+#define FancyLoadMacro(name) \
+	{ \
+		wxImage img = EmbeddedImage<res_ConfigIcon_##name>().Get(); \
+		img.Rescale(image_size, image_size, wxIMAGE_QUALITY_HIGH); \
+		m_Resources->ImageId.Config.name = images->Add(img); \
+	}
 
-		FancyLoadMacro( Paths );
-		FancyLoadMacro( Plugins );
-		FancyLoadMacro( Gamefixes );
-		FancyLoadMacro( Speedhacks );
-		FancyLoadMacro( MemoryCard );
-		FancyLoadMacro( Video );
-		FancyLoadMacro( Cpu );
+		FancyLoadMacro(Paths);
+		FancyLoadMacro(Plugins);
+		FancyLoadMacro(Gamefixes);
+		FancyLoadMacro(Speedhacks);
+		FancyLoadMacro(MemoryCard);
+		FancyLoadMacro(Video);
+		FancyLoadMacro(Cpu);
 	}
 	return *images;
 }
@@ -156,20 +160,19 @@ wxImageList& Pcsx2App::GetImgList_Config()
 // This stuff seems unused?
 wxImageList& Pcsx2App::GetImgList_Toolbars()
 {
-	std::unique_ptr<wxImageList>& images( GetResourceCache().ToolbarImages );
+	std::unique_ptr<wxImageList>& images(GetResourceCache().ToolbarImages);
 
-	if( !images )
+	if (!images)
 	{
 		const int imgSize = g_Conf->Toolbar_ImageSize ? 64 : 32;
 		images = std::unique_ptr<wxImageList>(new wxImageList(imgSize, imgSize));
 
-		#undef  FancyLoadMacro
-		#define FancyLoadMacro( name ) \
-		{ \
-			wxImage img = EmbeddedImage<res_ToolbarIcon_##name>(imgSize, imgSize).Get(); \
-			m_Resources.ImageId.Toolbars.name = images->Add(img); \
-		}
-
+#undef FancyLoadMacro
+#define FancyLoadMacro(name) \
+	{ \
+		wxImage img = EmbeddedImage<res_ToolbarIcon_##name>(imgSize, imgSize).Get(); \
+		m_Resources.ImageId.Toolbars.name = images->Add(img); \
+	}
 	}
 	return *images;
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Swap the GUI options Ask when booting and Browse... in CDVD. Ask when booting is also no longer on by default.

Old:
![image](https://user-images.githubusercontent.com/24227051/116935469-b0560080-ac66-11eb-97e3-c5e4b5587431.png)

New:
![image](https://user-images.githubusercontent.com/24227051/116935402-987e7c80-ac66-11eb-855e-ccc99f537584.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Makes more sense for muscle memory. It does seem cleaner as well, though perhaps biased.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test some games and swap between them. Disabling checkbox at another test to see if the GUI updates properly.