### PR TITLE
Fix Emulated PSX GPU Version

### DIFF
--- a/pcsx2/ps2/pgif.cpp
+++ b/pcsx2/ps2/pgif.cpp
@@ -403,17 +403,7 @@ u32 immRespHndl(u32 cmd, u32 data)
         case 0x05:
             data = pgif4reg & 0x003FFFFF;
             break;  //Read Draw offset             ;GP0(E5h) ;22bit
-        case 0x06:
-            break;  //Returns Nothing (old value in GPUREAD remains unchanged)
-        case 0x07:
-            data = 0x2;
-            break;  //Read GPU Type (usually 2) See "GPU Versions" notes below
-        case 0x08:
-            data = 0;
-            break;  //Unknown (Returns 00000000h)
-                    //default: //Returns Nothing (old value in GPUREAD remains unchanged)
     }
-    //TODO: Is the PS2 "PS1 GPU" really a "version 2"-GPU???
     return data;
 }
 


### PR DESCRIPTION
This PR removes the extra commands that were added for the V2 PSX GPU. 

Previously it was thought that the PS2 would emulate the v2 GPU, but hardware tests show that it emulates the V0 GPU. 