### PR TITLE
DEV9: Update ATA code for wchar GHC

### DIFF
--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -1089,11 +1089,7 @@ void ApplyConfigIfRunning(Config oldConfig)
 
 	//Hdd
 	//Hdd Validate Path
-#ifdef _WIN32
-	ghc::filesystem::path hddPath(std::wstring(config.Hdd));
-#else
 	ghc::filesystem::path hddPath(config.Hdd);
-#endif
 
 	if (hddPath.empty())
 		config.hddEnable = false;
@@ -1101,7 +1097,7 @@ void ApplyConfigIfRunning(Config oldConfig)
 	if (hddPath.is_relative())
 	{
 		//GHC uses UTF8 on all platforms
-		ghc::filesystem::path path(GetSettingsFolder().ToUTF8().data());
+		ghc::filesystem::path path(GetSettingsFolder().ToString().wx_str());
 		hddPath = path / hddPath;
 	}
 

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -199,19 +199,14 @@ s32 DEV9open(void* pDsp)
 	DevCon.WriteLn("DEV9: open r+: %s", config.Hdd);
 #endif
 
-#ifdef _WIN32
-	ghc::filesystem::path hddPath(std::wstring(config.Hdd));
-#else
 	ghc::filesystem::path hddPath(config.Hdd);
-#endif
 
 	if (hddPath.empty())
 		config.hddEnable = false;
 
 	if (hddPath.is_relative())
 	{
-		//GHC uses UTF8 on all platforms
-		ghc::filesystem::path path(GetSettingsFolder().ToUTF8().data());
+		ghc::filesystem::path path(GetSettingsFolder().ToString().wx_str());
 		hddPath = path / hddPath;
 	}
 

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -821,7 +821,7 @@ void DEV9write16(u32 addr, u16 value)
 				dev9.fifo_bytes_write = 0;
 				dev9.fifo_bytes_read = 0;
 				dev9.xfr_ctrl &= ~SPD_XFR_WRITE; //?
-				dev9.if_ctrl |= SPD_IF_READ;     //?
+				dev9.if_ctrl |= SPD_IF_READ; //?
 
 				FIFOIntr();
 			}

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -60,7 +60,7 @@ IP_Address IPControl_GetValue(GtkEntry* entryCtl)
 	return {0};
 }
 
-void IPControl_Enable(GtkEntry *ipEntry, bool enabled, IP_Address value)
+void IPControl_Enable(GtkEntry* ipEntry, bool enabled, IP_Address value)
 {
 	if (enabled)
 	{
@@ -74,27 +74,27 @@ void IPControl_Enable(GtkEntry *ipEntry, bool enabled, IP_Address value)
 	}
 }
 
-void OnAutoMaskChanged(GtkToggleButton *togglebutton, gpointer usr_data)
+void OnAutoMaskChanged(GtkToggleButton* togglebutton, gpointer usr_data)
 {
 	IPControl_Enable((GtkEntry*)gtk_builder_get_object(builder, "IDC_IPADDRESS_SUBNET"), !gtk_toggle_button_get_active(togglebutton), config.Mask);
 }
 
-void OnAutoGatewayChanged(GtkToggleButton *togglebutton, gpointer usr_data)
+void OnAutoGatewayChanged(GtkToggleButton* togglebutton, gpointer usr_data)
 {
 	IPControl_Enable((GtkEntry*)gtk_builder_get_object(builder, "IDC_IPADDRESS_GATEWAY"), !gtk_toggle_button_get_active(togglebutton), config.Gateway);
 }
 
-void OnAutoDNS1Changed(GtkToggleButton *togglebutton, gpointer usr_data)
+void OnAutoDNS1Changed(GtkToggleButton* togglebutton, gpointer usr_data)
 {
 	IPControl_Enable((GtkEntry*)gtk_builder_get_object(builder, "IDC_IPADDRESS_DNS1"), !gtk_toggle_button_get_active(togglebutton), config.DNS1);
 }
 
-void OnAutoDNS2Changed(GtkToggleButton *togglebutton, gpointer usr_data)
+void OnAutoDNS2Changed(GtkToggleButton* togglebutton, gpointer usr_data)
 {
 	IPControl_Enable((GtkEntry*)gtk_builder_get_object(builder, "IDC_IPADDRESS_DNS2"), !gtk_toggle_button_get_active(togglebutton), config.DNS2);
 }
 
-void OnInterceptChanged(GtkToggleButton *togglebutton, gpointer usr_data)
+void OnInterceptChanged(GtkToggleButton* togglebutton, gpointer usr_data)
 {
 	if (gtk_toggle_button_get_active(togglebutton))
 	{
@@ -190,9 +190,9 @@ void OnInitDialog()
 
 	//Checkboxes
 	gtk_toggle_button_set_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_ETHENABLED"),
-								 config.ethEnable);
+		config.ethEnable);
 	gtk_toggle_button_set_active((GtkToggleButton*)gtk_builder_get_object(builder, "IDC_HDDENABLED"),
-								 config.hddEnable);
+		config.hddEnable);
 
 	initialized = 1;
 }
@@ -204,7 +204,7 @@ void OnBrowse(GtkButton* button, gpointer usr_data)
 	static const wxChar* hddFilterType = L"HDD|*.raw;*.RAW";
 
 	wxFileDialog ctrl(nullptr, _("HDD Image File"), GetSettingsFolder().ToString(), HDD_DEF,
-					  (wxString)hddFilterType + L"|" + _("All Files (*.*)") + L"|*.*", wxFD_SAVE);
+		(wxString)hddFilterType + L"|" + _("All Files (*.*)") + L"|*.*", wxFD_SAVE);
 
 	if (ctrl.ShowModal() != wxID_CANCEL)
 	{
@@ -229,13 +229,13 @@ void OnBrowse(GtkButton* button, gpointer usr_data)
 void OnSpin(GtkSpinButton* spin, gpointer usr_data)
 {
 	gtk_range_set_value((GtkRange*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SLIDER"),
-						gtk_spin_button_get_value(spin));
+		gtk_spin_button_get_value(spin));
 }
 
 void OnSlide(GtkRange* range, gpointer usr_data)
 {
 	gtk_spin_button_set_value((GtkSpinButton*)gtk_builder_get_object(builder, "IDC_HDDSIZE_SPIN"),
-							  gtk_range_get_value(range));
+		gtk_range_get_value(range));
 }
 
 void OnOk()
@@ -305,14 +305,14 @@ void DEV9configure()
 	{
 		builder = gtk_builder_new();
 		gtk_builder_add_callback_symbols(builder,
-										 "OnInterceptChanged", G_CALLBACK(&OnInterceptChanged),
-										 "OnAutoMaskChanged", G_CALLBACK(&OnAutoMaskChanged),
-										 "OnAutoGatewayChanged", G_CALLBACK(&OnAutoGatewayChanged),
-										 "OnAutoDNS1Changed", G_CALLBACK(&OnAutoDNS1Changed),
-										 "OnAutoDNS2Changed", G_CALLBACK(&OnAutoDNS2Changed),
-										 "OnBrowse", G_CALLBACK(&OnBrowse),
-										 "OnSpin", G_CALLBACK(&OnSpin),
-										 "OnSlide", G_CALLBACK(&OnSlide), nullptr);
+			"OnInterceptChanged", G_CALLBACK(&OnInterceptChanged),
+			"OnAutoMaskChanged", G_CALLBACK(&OnAutoMaskChanged),
+			"OnAutoGatewayChanged", G_CALLBACK(&OnAutoGatewayChanged),
+			"OnAutoDNS1Changed", G_CALLBACK(&OnAutoDNS1Changed),
+			"OnAutoDNS2Changed", G_CALLBACK(&OnAutoDNS2Changed),
+			"OnBrowse", G_CALLBACK(&OnBrowse),
+			"OnSpin", G_CALLBACK(&OnSpin),
+			"OnSlide", G_CALLBACK(&OnSlide), nullptr);
 		if (!gtk_builder_add_from_resource(builder, "/net/pcsx2/dev9/DEV9/Linux/dev9.ui", &error))
 		{
 			g_warning("Could not build config ui: %s", error->message);

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -279,8 +279,7 @@ void OnOk()
 
 	if (hddPath.is_relative())
 	{
-		//GHC uses UTF8 on all platforms
-		ghc::filesystem::path path(GetSettingsFolder().ToUTF8().data());
+		ghc::filesystem::path path(GetSettingsFolder().ToString().wx_str());
 		hddPath = path / hddPath;
 	}
 

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -183,30 +183,30 @@ void OnInitDialog(HWND hW)
 	Edit_LimitText(GetDlgItem(hW, IDC_HDDSIZE_TEXT), 3); //Excluding null char
 	//HDDSpin
 	SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SPIN), UDM_SETRANGE,
-				(WPARAM)0,
-				(LPARAM)MAKELPARAM(HDD_MAX_GB, HDD_MIN_GB));
+		(WPARAM)0,
+		(LPARAM)MAKELPARAM(HDD_MAX_GB, HDD_MIN_GB));
 	SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SPIN), UDM_SETPOS,
-				(WPARAM)0,
-				(LPARAM)(config.HddSize / 1024));
+		(WPARAM)0,
+		(LPARAM)(config.HddSize / 1024));
 
 	//HDDSlider
 	SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETRANGE,
-				(WPARAM)FALSE,
-				(LPARAM)MAKELPARAM(HDD_MIN_GB, HDD_MAX_GB));
+		(WPARAM)FALSE,
+		(LPARAM)MAKELPARAM(HDD_MIN_GB, HDD_MAX_GB));
 	SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETPAGESIZE,
-				(WPARAM)0,
-				(LPARAM)10);
+		(WPARAM)0,
+		(LPARAM)10);
 
 	for (int i = 15; i < HDD_MAX_GB; i += 5)
 	{
 		SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETTIC,
-					(WPARAM)0,
-					(LPARAM)i);
+			(WPARAM)0,
+			(LPARAM)i);
 	}
 
 	SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETPOS,
-				(WPARAM)TRUE,
-				(LPARAM)(config.HddSize / 1024));
+		(WPARAM)TRUE,
+		(LPARAM)(config.HddSize / 1024));
 
 	//Checkboxes
 	Button_SetCheck(GetDlgItem(hW, IDC_ETHENABLED), config.ethEnable);
@@ -245,11 +245,11 @@ void OnBrowse(HWND hW)
 			int filesizeGb = ghc::filesystem::file_size(hddFile) / (1024 * 1024 * 1024);
 			//Set slider
 			SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SPIN), UDM_SETPOS,
-						(WPARAM)0,
-						(LPARAM)filesizeGb);
+				(WPARAM)0,
+				(LPARAM)filesizeGb);
 			SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETPOS,
-						(WPARAM)TRUE,
-						(LPARAM)filesizeGb);
+				(WPARAM)TRUE,
+				(LPARAM)filesizeGb);
 		}
 
 		if (hddFile.parent_path() == inis)
@@ -421,11 +421,11 @@ BOOL CALLBACK ConfigureDlgProc(HWND hW, UINT uMsg, WPARAM wParam, LPARAM lParam)
 								return TRUE;
 
 							SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SPIN), UDM_SETPOS,
-										(WPARAM)0,
-										(LPARAM)curpos);
+								(WPARAM)0,
+								(LPARAM)curpos);
 							SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETPOS,
-										(WPARAM)TRUE,
-										(LPARAM)curpos);
+								(WPARAM)TRUE,
+								(LPARAM)curpos);
 							return TRUE;
 						}
 					}
@@ -454,8 +454,8 @@ BOOL CALLBACK ConfigureDlgProc(HWND hW, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				case TB_THUMBTRACK:
 					//Update Textbox
 					SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SPIN), UDM_SETPOS,
-								(WPARAM)0,
-								(LPARAM)curpos);
+						(WPARAM)0,
+						(LPARAM)curpos);
 					return TRUE;
 
 				default:
@@ -483,8 +483,8 @@ BOOL CALLBACK ConfigureDlgProc(HWND hW, UINT uMsg, WPARAM wParam, LPARAM lParam)
 					//Update Textbox
 					//Edit_SetText(GetDlgItem(hW, IDC_HDDSIZE_TEXT), to_wstring(curpos).c_str());
 					SendMessage(GetDlgItem(hW, IDC_HDDSIZE_SLIDER), TBM_SETPOS,
-								(WPARAM)TRUE,
-								(LPARAM)curpos);
+						(WPARAM)TRUE,
+						(LPARAM)curpos);
 					return TRUE;
 
 				default:
@@ -501,9 +501,9 @@ void DEV9configure()
 	Config oldConfig = config;
 
 	DialogBox(hInst,
-			  MAKEINTRESOURCE(IDD_CONFIG),
-			  GetActiveWindow(),
-			  (DLGPROC)ConfigureDlgProc);
+		MAKEINTRESOURCE(IDD_CONFIG),
+		GetActiveWindow(),
+		(DLGPROC)ConfigureDlgProc);
 	//SysMessage("Nothing to Configure");
 
 	ApplyConfigIfRunning(oldConfig);

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -218,8 +218,7 @@ void OnBrowse(HWND hW)
 	wchar_t wbuff[4096] = {0};
 	memcpy(wbuff, HDD_DEF, sizeof(HDD_DEF));
 
-	//GHC uses UTF8 on all platforms
-	ghc::filesystem::path inis = GetSettingsFolder().ToUTF8().data();
+	ghc::filesystem::path inis(GetSettingsFolder().ToString().wx_str());
 	wstring w_inis = inis.wstring();
 
 	OPENFILENAMEW ofn;


### PR DESCRIPTION
### Description of Changes
Use wchar instead of UTF8 for ghc::filesystem::path constructor on windows

### Rationale behind Changes
The GHC dependency got updated to a version that uses wchar instead of UTF8 on windows, see https://github.com/PCSX2/pcsx2/pull/4422

### Suggested Testing Steps
Test unicode paths with HDD files (including testing with the inis folder in a unicode path)
