### PR TITLE
DEV9: Correctly populate DNS2 field with DNS2 IP

### DIFF
--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -98,7 +98,7 @@ void AutoDNS1Changed(HWND hW)
 
 void AutoDNS2Changed(HWND hW)
 {
-	IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_DNS2), !Button_GetCheck(GetDlgItem(hW, IDC_CHECK_DNS2)), config.DNS1);
+	IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_DNS2), !Button_GetCheck(GetDlgItem(hW, IDC_CHECK_DNS2)), config.DNS2);
 }
 
 void InterceptChanged(HWND hW)
@@ -141,7 +141,7 @@ void InterceptChanged(HWND hW)
 		IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_SUBNET), false, config.Mask);
 		IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_GATEWAY), false, config.Gateway);
 		IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_DNS1), false, config.DNS1);
-		IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_DNS2), false, config.DNS1);
+		IPControl_Enable(GetDlgItem(hW, IDC_IPADDRESS_DNS2), false, config.DNS2);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Correctly populate DNS2 field with DNS2 IP in the DHCP section of the network ui

### Rationale behind Changes
Discovered this while testing my DNS pr after rebase.
This was probably a copy & past error, as it populated the field with DNS1 instead of DNS2

### Suggested Testing Steps
Manually configure DNS1 and DNS2 (with different IPs), apply and reopen the UI.
