### PR TITLE
SPU: Make SPU use the DMA registers from iopHw

### DIFF
--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -277,6 +277,7 @@ static dma_mbc&		hw_dma12	= (dma_mbc&) iopHw[0x1550];
 #define HW_DMA7_MADR (psxHu32(0x1500)) // SPU2 DMA
 #define HW_DMA7_BCR  (psxHu32(0x1504))
 #define HW_DMA7_CHCR (psxHu32(0x1508))
+#define HW_DMA7_TADR (psxHu32(0x150C))
 
 #define HW_DMA8_MADR (psxHu32(0x1510)) // DEV9 DMA
 #define HW_DMA8_BCR  (psxHu32(0x1514))

--- a/pcsx2/SPU2/Dma.h
+++ b/pcsx2/SPU2/Dma.h
@@ -15,6 +15,9 @@
 
 #pragma once
 
+#define MADR (Index == 0 ? HW_DMA4_MADR : HW_DMA7_MADR)
+#define TADR (Index == 0 ? HW_DMA4_TADR : HW_DMA7_TADR)
+
 extern void DMALogOpen();
 extern void DMA4LogWrite(void* lpData, u32 ulSize);
 extern void DMA7LogWrite(void* lpData, u32 ulSize);

--- a/pcsx2/SPU2/ReadInput.cpp
+++ b/pcsx2/SPU2/ReadInput.cpp
@@ -17,6 +17,7 @@
 #include "Global.h"
 #include "Dma.h"
 #include "IopDma.h"
+#include "IopHw.h"
 
 #include "spu2.h" // required for ENABLE_NEW_IOPDMA_SPU2 define
 

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -451,8 +451,6 @@ struct V_Core
 	u16* DMARPtr; // Mem pointer for DMA Reads
 	u32 ReadSize;
 	bool IsDMARead;
-	u32 MADR;
-	u32 TADR;
 
 	u32 KeyOn; // not the KON register (though maybe it is)
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -60,15 +60,6 @@ void SPU2configure()
 
 u16* DMABaseAddr;
 
-u32 SPU2ReadMemAddr(int core)
-{
-	return Cores[core].MADR;
-}
-void SPU2WriteMemAddr(int core, u32 value)
-{
-	Cores[core].MADR = value;
-}
-
 void SPU2setDMABaseAddr(uptr baseaddr)
 {
 	DMABaseAddr = (u16*)baseaddr;

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -44,8 +44,6 @@ void SPU2DoFreezeOut(void* dest);
 void SPU2configure();
 
 
-u32 SPU2ReadMemAddr(int core);
-void SPU2WriteMemAddr(int core, u32 value);
 void SPU2setDMABaseAddr(uptr baseaddr);
 void SPU2setSettingsDir(const char* dir);
 void SPU2setLogDir(const char* dir);

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -144,8 +144,6 @@ void V_Core::Init(int index)
 	AttrBit0 = 0;
 	DmaMode = 0;
 	DMAPtr = nullptr;
-	MADR = 0;
-	TADR = 0;
 	KeyOn = 0;
 	OutPos = 0;
 
@@ -461,7 +459,7 @@ __forceinline void TimeUpdate(u32 cClocks)
 		Cores[0].DMAICounter -= amt;
 		Cores[0].LastClock = *cyclePtr;
 		if(!Cores[0].AdmaInProgress)
-			Cores[0].MADR += amt / 2;
+			HW_DMA4_MADR += amt / 2;
 
 		if (Cores[0].DMAICounter <= 0)
 		{
@@ -488,7 +486,7 @@ __forceinline void TimeUpdate(u32 cClocks)
 			}
 			if (Cores[0].DMAICounter <= 0)
 			{
-				Cores[0].MADR = Cores[0].TADR;
+				HW_DMA4_MADR = HW_DMA4_TADR;
 				spu2DMA4Irq();
 			}
 		}
@@ -514,7 +512,7 @@ __forceinline void TimeUpdate(u32 cClocks)
 		Cores[1].DMAICounter -= amt;
 		Cores[1].LastClock = *cyclePtr;
 		if (!Cores[1].AdmaInProgress)
-			Cores[1].MADR += amt / 2;
+			HW_DMA7_MADR += amt / 2;
 		if (Cores[1].DMAICounter <= 0)
 		{
 			if (((Cores[1].AutoDMACtrl & 2) != 2) && Cores[1].ReadSize)
@@ -541,7 +539,7 @@ __forceinline void TimeUpdate(u32 cClocks)
 
 			if (Cores[1].DMAICounter <= 0)
 			{
-				Cores[1].MADR = Cores[1].TADR;
+				HW_DMA7_MADR = HW_DMA7_TADR;
 				spu2DMA7Irq();
 			}
 		}

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A1E << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A1F << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)

--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -301,17 +301,6 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 			break;
 
 			// ------------------------------------------------------------------------
-			// Soon-to-be outdated SPU2 DMA hack (spu2 manages its own DMA MADR).
-			//
-			mcase(0x1f8010C0):
-				ret = SPU2ReadMemAddr(0);
-			break;
-
-			mcase(0x1f801500):
-				ret = SPU2ReadMemAddr(1);
-			break;
-
-			// ------------------------------------------------------------------------
 			// Legacy GPU  emulation
 			//
 			mcase(0x1f8010ac) :

--- a/pcsx2/ps2/Iop/IopHwWrite.cpp
+++ b/pcsx2/ps2/Iop/IopHwWrite.cpp
@@ -347,20 +347,6 @@ static __fi void _HwWrite_16or32_Page1( u32 addr, T val )
 			break;
 
 			// ------------------------------------------------------------------------
-			// Soon-to-be outdated SPU2 DMA hack (spu2 manages its own DMA MADR currently,
-			// as asinine as that may seem).
-			//
-			mcase(0x1f8010C0):
-				SPU2WriteMemAddr( 0, val );
-				HW_DMA4_MADR = val;
-			break;
-
-			mcase(0x1f801500):
-				SPU2WriteMemAddr( 1, val );
-				HW_DMA7_MADR = val;
-			break;
-
-			// ------------------------------------------------------------------------
 			//
 			
 			mcase(0x1f801088) :	// DMA0 CHCR -- MDEC IN


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The SPU was managing its own DMA Addresses, this makes it use the iopHw functionality for this instead.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Removes two functions in the SPU and some special case code in iopHw.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check for any SPU breakage.