### PR TITLE
Misc: Save ELF last path when auto-running an elf

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -511,7 +511,7 @@ bool Pcsx2App::OnInit()
 		else if (Startup.SysAutoRunElf)
 		{
 			g_Conf->EmuOptions.UseBOOT2Injection = true;
-
+			g_Conf->Folders.RunELF = wxFileName(Startup.ElfFile).GetPath();
 			sApp.SysExecute(Startup.CdvdSource, Startup.ElfFile);
 		}
 		else if (Startup.SysAutoRunIrx)


### PR DESCRIPTION
Save the last elf path when using the `--elf` command-line argument.
Helpful when you do something like this

`emu: $(EE_BIN)`
`<TAB>/path/to/pcsx2.exe  --elf="P://path/to/elf.elf"`
(I use wsl)
And instead of running `make emu` again, you can just easily open the elf browser without digging through your unorganized directories.

