### PR TITLE
Extended argument support

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -513,6 +513,8 @@ bool Pcsx2App::OnInit()
 			g_Conf->EmuOptions.UseBOOT2Injection = true;
 
 			sApp.SysExecute(Startup.CdvdSource, Startup.ElfFile);
+			if (strchr(Startup.ElfFile, ' ') != NULL)
+				g_Conf->CurrentGameArgs = Startup.GameLaunchArgs;
 		}
 		else if (Startup.SysAutoRunIrx)
 		{
@@ -522,6 +524,8 @@ bool Pcsx2App::OnInit()
 
 			// FIXME: ElfFile is an irx it will crash
 			sApp.SysExecute(Startup.CdvdSource, Startup.ElfFile);
+			if (strchr(Startup.ElfFile, ' ') != NULL)
+				g_Conf->CurrentGameArgs = Startup.GameLaunchArgs;
 		}
 	}
 	// ----------------------------------------------------------------------------


### PR DESCRIPTION
Enable support for the combination of CLI arguments: --gameargs and --elf (or --irx) if the path to .elf (or .irx) does not contain spaces.

### Description of Changes
This PR will allow combining CLI `--elf/--irx` with `--gameargs`. There is a silent check if the path contains spaces. If the path contains spaces `gameargs` will be ignored like it was before this PR.

### Rationale behind Changes
This will improve homebrew testing. Before developers were forced to make an ISO file to test an app with custom arguments or use some other workarounds.

The check for spaces in the path is necessary because of argument support logic in the project. If the path string contains spaces, later this string will be cut into arguments by space delimiter. The first part will be used as a path, other parts - as arguments. Thus it is necessary to perform this check, or completely rewrite argument parsing logic.
