### PR TITLE
DEV9: Always use binary mode for HDD file

### DIFF
--- a/pcsx2/DEV9/ATA/ATA_State.cpp
+++ b/pcsx2/DEV9/ATA/ATA_State.cpp
@@ -34,9 +34,7 @@ int ATA::Open(ghc::filesystem::path hddPath)
 	CreateHDDinfo(config.HddSize);
 
 	//Open File
-	if (ghc::filesystem::exists(hddPath))
-		hddImage = ghc::filesystem::fstream(hddPath, std::ios::in | std::ios::out | std::ios::binary);
-	else
+	if (!ghc::filesystem::exists(hddPath))
 	{
 		HddCreate hddCreator;
 		hddCreator.filePath = hddPath;
@@ -45,9 +43,8 @@ int ATA::Open(ghc::filesystem::path hddPath)
 
 		if (hddCreator.errored)
 			return -1;
-
-		hddImage = ghc::filesystem::fstream(hddPath);
 	}
+	hddImage = ghc::filesystem::fstream(hddPath, std::ios::in | std::ios::out | std::ios::binary);
 
 	//Store HddImage size for later check
 	hddImage.seekg(0, std::ios::end);


### PR DESCRIPTION
### Description of Changes
Previously the file was only opened in binary mode if it existed before starting emulation.
If the image file was created during emulation startup (where the original file is missing or wasn't created), the file would not be opened in binary mode.
This PR addresses that, always opening the file in binary mode.

### Rationale behind Changes
Opening the file in binary mode is the intended behaviour (and was done in the most common situation),

### Suggested Testing Steps
Test HDD enabled games,
Also test situations where the configured HDD image is missing on emulation startup.
