### PR TITLE
DEV9: Fix potential out of bounds access when manual DNS1 & automatic DNS2 are used together.

### DIFF
--- a/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
+++ b/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
@@ -356,10 +356,12 @@ namespace InternalServers
 						Console.Error("DHCP: RouterIP missmatch");
 					break;
 				case 6:
+					// clang-format off
 					if (((((DHCPopDNS*)dhcp.options[i])->dnsServers.size() == 0 && dns1.integer == 0) ||
 						 (((DHCPopDNS*)dhcp.options[i])->dnsServers.size() == 1 && dns1.integer != 0 && dns2.integer == 0) ||
 						 (((DHCPopDNS*)dhcp.options[i])->dnsServers.size() == 2 && dns2.integer != 0)) == false)
 						Console.Error("DHCP: DNS count missmatch");
+					// clang-format on
 
 					if ((((DHCPopDNS*)dhcp.options[i])->dnsServers.size() > 0 && dns1 != ((DHCPopDNS*)dhcp.options[i])->dnsServers[0]) ||
 						(((DHCPopDNS*)dhcp.options[i])->dnsServers.size() > 1 && dns2 != ((DHCPopDNS*)dhcp.options[i])->dnsServers[1]))
@@ -390,8 +392,8 @@ namespace InternalServers
 				case 57:
 					maxMs = ((DHCPopMMSGS*)(dhcp.options[i]))->maxMessageSize;
 					break;
-				case 60:  //ClassID
-				case 61:  //ClientID
+				case 60: //ClassID
+				case 61: //ClientID
 				case 255: //End
 					break;
 				default:

--- a/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
+++ b/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
@@ -290,8 +290,8 @@ namespace InternalServers
 			//Use adapter's DNS2 if it has one
 			//otherwise use adapter's DNS1
 
-			if (dnsIPs.size() >= 1)
-				dns2 = dnsIPs[std::min((size_t)2, dnsIPs.size())];
+			if (!dnsIPs.empty())
+				dns2 = dnsIPs[std::min<size_t>(1, dnsIPs.size() - 1)];
 		}
 		if (dns1.integer == 0 && dns2.integer != 0)
 		{


### PR DESCRIPTION
### Description of Changes
Fix an off-by-one error for array access.

### Rationale behind Changes
If DNS1 was manually specified, but DNS2 set to be automatically assigned, an off by one error could result in an out of bounds access to an array of adapter DNS addresses.

### Suggested Testing Steps
Enable DHCP intercept
Test manual DNS1 & automatic DNS2 with an adapter that has DNS addresses assigned to it. 
