### PR TITLE
Remove PSX references to distinguish between PS1 and DVR

### DIFF
--- a/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
@@ -261,8 +261,8 @@ void Dialogs::CreateMemoryCardDialog::CreateControls()
 						  "You can always convert back between folder type and single memcard file.\n"))
 		.	SetInt(0),
 
-		RadioPanelItem(_("128 KiB (PSX)"), _("This is the standard Sony-provisioned size PSX memory card, only compatible with PSX games."))
-		.	SetToolTip(_t("This memory card is required by PSX games. It is not compatible with PS2 games."))
+		RadioPanelItem(_("128 KiB (PS1)"), _("This is the standard Sony-provisioned size PS1 memory card, only compatible with PS1 games."))
+		.	SetToolTip(_t("This memory card is required by PS1 games. It is not compatible with PS2 games."))
 		.	SetInt(1)
 	};
 

--- a/pcsx2/gui/Panels/MemoryCardListView.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListView.cpp
@@ -149,7 +149,7 @@ wxString MemoryCardListView_Simple::OnGetItemText(long item, long column) const
 */		
 		case McdColS_Size:			return prefix + ( !it.IsPresent ? L"" : (it.IsPSX? pxsFmt( L"%u MBit", it.SizeInMB ) : ( it.SizeInMB > 0 ? pxsFmt( L"%u MiB", it.SizeInMB ) : L"Auto" ) ) );
 		case McdColS_Formatted:		return prefix + ( !it.IsPresent ? L"" : ( it.IsFormatted ? _("Yes") : _("No")) );
-		case McdColS_Type:			return prefix + ( !it.IsPresent ? L"" : ( it.IsPSX? _("PSX") : _("PS2")) );
+		case McdColS_Type:			return prefix + ( !it.IsPresent ? L"" : ( it.IsPSX? _("PS1") : _("PS2")) );
 		case McdColS_DateModified:	return prefix + ( !it.IsPresent || !it.DateModified.IsValid() ? L"" : it.DateModified.FormatDate() );
 		case McdColS_DateCreated:	return prefix + ( !it.IsPresent || !it.DateCreated.IsValid() ? L"" : it.DateCreated.FormatDate() );
 


### PR DESCRIPTION
### Description of Changes
Remove PSX references to distinguish between PS1 and DVR

