### PR TITLE
Fix gamepad choice not affecting rumble test on Linux

### DIFF
--- a/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
@@ -114,7 +114,7 @@ void GamepadConfiguration::OnSliderReleased(wxCommandEvent& event)
 
 		// convert in a float value between 0 and 1, and run rumble feedback.
 		// 0 to 1 scales to 0x0 to 0x7FFF
-		s_vgamePad[m_pad_id]->TestForce(m_sl_rumble_intensity->GetValue() / (float)0x7FFF);
+		s_vgamePad[m_joy_map->GetSelection()]->TestForce(m_sl_rumble_intensity->GetValue() / (float)0x7FFF);
 	}
 	else if (sl_id == joy_slider_id)
 	{
@@ -135,7 +135,7 @@ void GamepadConfiguration::OnCheckboxChange(wxCommandEvent& event)
 		g_conf.pad_options[m_pad_id].forcefeedback = (m_cb_rumble->GetValue()) ? (u32)1 : (u32)0;
 		if (m_cb_rumble->GetValue())
 		{
-			s_vgamePad[m_pad_id]->TestForce();
+			s_vgamePad[m_joy_map->GetSelection()]->TestForce();
 			m_sl_rumble_intensity->Enable();
 		}
 		else


### PR DESCRIPTION
The rumble test using either the checkbox or the slider in the gamepad
configuration GUI always causes the first gamepad to rumble, even if
other gamepads are selected in the drop-down menu.

### Description of Changes
This change causes the currently selected gamepad to rumble instead of the first one.

### Rationale behind Changes
Rumble test running on the currently selected gamepad is the expected behavior.

### Suggested Testing Steps
- connect multiple gamepads;
- select each one and perform the rumble test;

Without this change the first gamepad will always be the one with rumble. With this change it will be the currently selected gamepad.