### PR TITLE
ipc: rename to pine

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -130,7 +130,7 @@ set(pcsx2Sources
 	IopIrq.cpp
 	IopMem.cpp
 	IopSio2.cpp
-	IPC.cpp
+	PINE.cpp
 	Mdec.cpp
 	Memory.cpp
 	MemoryCardFile.cpp
@@ -205,7 +205,7 @@ set(pcsx2Headers
 	IopHw.h
 	IopMem.h
 	IopSio2.h
-	IPC.h
+	PINE.h
 	Mdec.h
 	MTVU.h
 	Memory.h
@@ -908,7 +908,7 @@ set(pcsx2GuiSources
 	gui/Dialogs/McdConfigDialog.cpp
 	gui/Dialogs/PickUserModeDialog.cpp
 	gui/Dialogs/SysConfigDialog.cpp
-	gui/Dialogs/IPCDialog.cpp
+	gui/Dialogs/PINEDialog.cpp
 	gui/Debugger/BreakpointWindow.cpp
 	gui/Debugger/CtrlDisassemblyView.cpp
 	gui/Debugger/CtrlRegisterList.cpp

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -545,7 +545,7 @@ struct Pcsx2Config
 		CdvdShareWrite : 1, // allows the iso to be modified while it's loaded
 		EnablePatches : 1, // enables patch detection and application
 		EnableCheats : 1, // enables cheat detection and application
-		EnableIPC : 1, // enables inter-process communication
+		EnablePINE : 1, // enables inter-process communication
 		EnableWideScreenPatches : 1,
 #ifndef DISABLE_RECORDING
 		EnableRecordingTools : 1,

--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -380,6 +380,8 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 			}
 			case MsgVersion:
 			{
+				if (!m_vm->HasActiveMachine())
+					goto error;
 				char version[256] = {};
 				if (GIT_TAGGED_COMMIT) // Nightly builds
 				{
@@ -391,11 +393,14 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 				{
 					sprintf(version, "PCSX2 %u.%u.%u-%lld", PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo, SVN_REV);
 				}
-				version[255] = 0x00;
-				if (!SafetyChecks(buf_cnt, 0, ret_cnt, 256, buf_size))
+				const u32 size = strlen(version) + 1;
+				version[size] = 0x00;
+				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
-				memcpy(&ret_buffer[ret_cnt], version, 256);
-				ret_cnt += 256;
+				ToArray(ret_buffer, size, ret_cnt);
+				ret_cnt += 4;
+				memcpy(&ret_buffer[ret_cnt], version, size);
+				ret_cnt += size;
 				break;
 			}
 			case MsgSaveState:
@@ -422,52 +427,64 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				if (!SafetyChecks(buf_cnt, 0, ret_cnt, 256, buf_size))
-					goto error;
-				char title[256] = {};
+				char title[GameInfo::gameName.size() + 1] = {};
 				sprintf(title, "%s", GameInfo::gameName.ToUTF8().data());
-				title[255] = 0x00;
-				memcpy(&ret_buffer[ret_cnt], title, 256);
-				ret_cnt += 256;
+				const u32 size = strlen(title) + 1;
+				title[size] = 0x00;
+				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
+					goto error;
+				ToArray(ret_buffer, size, ret_cnt);
+				ret_cnt += 4;
+				memcpy(&ret_buffer[ret_cnt], title, size);
+				ret_cnt += size;
 				break;
 			}
 			case MsgID:
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				if (!SafetyChecks(buf_cnt, 0, ret_cnt, 256, buf_size))
+				char title[GameInfo::gameName.size() + 1] = {};
+				sprintf(title, "%s", GameInfo::gameSerial.ToUTF8().data());
+				const u32 size = strlen(title) + 1;
+				title[size] = 0x00;
+				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
-				char id[256] = {};
-				sprintf(id, "%s", GameInfo::gameSerial.ToUTF8().data());
-				id[255] = 0x00;
-				memcpy(&ret_buffer[ret_cnt], id, 256);
-				ret_cnt += 256;
+				ToArray(ret_buffer, size, ret_cnt);
+				ret_cnt += 4;
+				memcpy(&ret_buffer[ret_cnt], title, size);
+				ret_cnt += size;
 				break;
 			}
 			case MsgUUID:
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				if (!SafetyChecks(buf_cnt, 0, ret_cnt, 256, buf_size))
+				char title[GameInfo::gameName.size() + 1] = {};
+				sprintf(title, "%s", GameInfo::gameCRC.ToUTF8().data());
+				const u32 size = strlen(title) + 1;
+				title[size] = 0x00;
+				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
-				char uuid[256] = {};
-				sprintf(uuid, "%s", GameInfo::gameCRC.ToUTF8().data());
-				uuid[255] = 0x00;
-				memcpy(&ret_buffer[ret_cnt], uuid, 256);
-				ret_cnt += 256;
+				ToArray(ret_buffer, size, ret_cnt);
+				ret_cnt += 4;
+				memcpy(&ret_buffer[ret_cnt], title, size);
+				ret_cnt += size;
 				break;
 			}
 			case MsgGameVersion:
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				if (!SafetyChecks(buf_cnt, 0, ret_cnt, 256, buf_size))
+				char title[GameInfo::gameName.size() + 1] = {};
+				sprintf(title, "%s", GameInfo::gameVersion.ToUTF8().data());
+				const u32 size = strlen(title) + 1;
+				title[size] = 0x00;
+				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 					goto error;
-				char version[256] = {};
-				sprintf(version, "%s", GameInfo::gameVersion.ToUTF8().data());
-				version[255] = 0x00;
-				memcpy(&ret_buffer[ret_cnt], version, 256);
-				ret_cnt += 256;
+				ToArray(ret_buffer, size, ret_cnt);
+				ret_cnt += 4;
+				memcpy(&ret_buffer[ret_cnt], title, size);
+				ret_cnt += size;
 				break;
 			}
 			case MsgStatus:

--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -427,7 +427,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				char title[GameInfo::gameName.size() + 1] = {};
+				char* title = new char[GameInfo::gameName.size() + 1];
 				sprintf(title, "%s", GameInfo::gameName.ToUTF8().data());
 				const u32 size = strlen(title) + 1;
 				title[size] = 0x00;
@@ -437,13 +437,14 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 				ret_cnt += 4;
 				memcpy(&ret_buffer[ret_cnt], title, size);
 				ret_cnt += size;
+				delete[] title;
 				break;
 			}
 			case MsgID:
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				char title[GameInfo::gameName.size() + 1] = {};
+				char* title = new char[GameInfo::gameSerial.size() + 1];
 				sprintf(title, "%s", GameInfo::gameSerial.ToUTF8().data());
 				const u32 size = strlen(title) + 1;
 				title[size] = 0x00;
@@ -453,13 +454,14 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 				ret_cnt += 4;
 				memcpy(&ret_buffer[ret_cnt], title, size);
 				ret_cnt += size;
+				delete[] title;
 				break;
 			}
 			case MsgUUID:
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				char title[GameInfo::gameName.size() + 1] = {};
+				char* title = new char[GameInfo::gameCRC.size() + 1];
 				sprintf(title, "%s", GameInfo::gameCRC.ToUTF8().data());
 				const u32 size = strlen(title) + 1;
 				title[size] = 0x00;
@@ -469,13 +471,14 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 				ret_cnt += 4;
 				memcpy(&ret_buffer[ret_cnt], title, size);
 				ret_cnt += size;
+				delete[] title;
 				break;
 			}
 			case MsgGameVersion:
 			{
 				if (!m_vm->HasActiveMachine())
 					goto error;
-				char title[GameInfo::gameName.size() + 1] = {};
+				char* title = new char[GameInfo::gameVersion.size() + 1];
 				sprintf(title, "%s", GameInfo::gameVersion.ToUTF8().data());
 				const u32 size = strlen(title) + 1;
 				title[size] = 0x00;
@@ -485,6 +488,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(char* buf, char* ret_buffer, u32 
 				ret_cnt += 4;
 				memcpy(&ret_buffer[ret_cnt], title, size);
 				ret_cnt += size;
+				delete[] title;
 				break;
 			}
 			case MsgStatus:

--- a/pcsx2/PINE.h
+++ b/pcsx2/PINE.h
@@ -13,17 +13,17 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Client code example for interfacing with the IPC interface is available 
- * here: https://code.govanify.com/govanify/pcsx2_ipc/ */
+/* A reference client implementation for interfacing with PINE is available 
+ * here: https://code.govanify.com/govanify/pine/ */
 
 #pragma once
 
-// IPC uses a concept of "slot" to be able to communicate with multiple
+// PINE uses a concept of "slot" to be able to communicate with multiple
 // emulators at the same time, each slot should be unique to each emulator to
 // allow PnP and configurable by the end user so that several runs don't
 // conflict with each others
-#define IPC_DEFAULT_SLOT 28011
-#define IPC_EMULATOR_NAME "pcsx2"
+#define PINE_DEFAULT_SLOT 28011
+#define PINE_EMULATOR_NAME "pcsx2"
 
 #include "common/PersistentThread.h"
 #include "System/SysThreads.h"
@@ -35,7 +35,7 @@
 
 using namespace Threading;
 
-class SocketIPC : public pxThread
+class PINEServer : public pxThread
 {
 	// parent thread
 	typedef pxThread _parent;
@@ -89,22 +89,22 @@ protected:
 	 */
 	enum IPCCommand : unsigned char
 	{
-		MsgRead8 = 0,           /**< Read 8 bit value to memory. */
-		MsgRead16 = 1,          /**< Read 16 bit value to memory. */
-		MsgRead32 = 2,          /**< Read 32 bit value to memory. */
-		MsgRead64 = 3,          /**< Read 64 bit value to memory. */
-		MsgWrite8 = 4,          /**< Write 8 bit value to memory. */
-		MsgWrite16 = 5,         /**< Write 16 bit value to memory. */
-		MsgWrite32 = 6,         /**< Write 32 bit value to memory. */
-		MsgWrite64 = 7,         /**< Write 64 bit value to memory. */
-		MsgVersion = 8,         /**< Returns PCSX2 version. */
-		MsgSaveState = 9,       /**< Saves a savestate. */
-		MsgLoadState = 0xA,     /**< Loads a savestate. */
-		MsgTitle = 0xB,         /**< Returns the game title. */
-		MsgID = 0xC,            /**< Returns the game ID. */
-		MsgUUID = 0xD,          /**< Returns the game UUID. */
-		MsgGameVersion = 0xE,   /**< Returns the game verion. */
-		MsgStatus = 0xF,        /**< Returns the emulator status. */
+		MsgRead8 = 0, /**< Read 8 bit value to memory. */
+		MsgRead16 = 1, /**< Read 16 bit value to memory. */
+		MsgRead32 = 2, /**< Read 32 bit value to memory. */
+		MsgRead64 = 3, /**< Read 64 bit value to memory. */
+		MsgWrite8 = 4, /**< Write 8 bit value to memory. */
+		MsgWrite16 = 5, /**< Write 16 bit value to memory. */
+		MsgWrite32 = 6, /**< Write 32 bit value to memory. */
+		MsgWrite64 = 7, /**< Write 64 bit value to memory. */
+		MsgVersion = 8, /**< Returns PCSX2 version. */
+		MsgSaveState = 9, /**< Saves a savestate. */
+		MsgLoadState = 0xA, /**< Loads a savestate. */
+		MsgTitle = 0xB, /**< Returns the game title. */
+		MsgID = 0xC, /**< Returns the game ID. */
+		MsgUUID = 0xD, /**< Returns the game UUID. */
+		MsgGameVersion = 0xE, /**< Returns the game verion. */
+		MsgStatus = 0xF, /**< Returns the emulator status. */
 		MsgUnimplemented = 0xFF /**< Unimplemented IPC message. */
 	};
 
@@ -115,7 +115,7 @@ protected:
 	enum EmuStatus : uint32_t
 	{
 		Running = 0, /**< Game is running */
-		Paused = 1,  /**< Game is paused */
+		Paused = 1, /**< Game is paused */
 		Shutdown = 2 /**< Game is shutdown */
 	};
 
@@ -125,7 +125,7 @@ protected:
 	 */
 	struct IPCBuffer
 	{
-		int size;     /**< Size of the buffer. */
+		int size; /**< Size of the buffer. */
 		char* buffer; /**< Buffer. */
 	};
 
@@ -137,7 +137,7 @@ protected:
 	 */
 	enum IPCResult : unsigned char
 	{
-		IPC_OK = 0,     /**< IPC command successfully completed. */
+		IPC_OK = 0, /**< IPC command successfully completed. */
 		IPC_FAIL = 0xFF /**< IPC command failed to complete. */
 	};
 
@@ -218,7 +218,7 @@ public:
 	bool m_end = true;
 
 	/* Initializers */
-	SocketIPC(SysCoreThread* vm, unsigned int slot = IPC_DEFAULT_SLOT);
-	virtual ~SocketIPC();
+	PINEServer(SysCoreThread* vm, unsigned int slot = PINE_DEFAULT_SLOT);
+	virtual ~PINEServer();
 
 }; // class SocketIPC

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -572,7 +572,7 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(CdvdShareWrite);
 	SettingsWrapBitBool(EnablePatches);
 	SettingsWrapBitBool(EnableCheats);
-	SettingsWrapBitBool(EnableIPC);
+	SettingsWrapBitBool(EnablePINE);
 	SettingsWrapBitBool(EnableWideScreenPatches);
 #ifndef DISABLE_RECORDING
 	SettingsWrapBitBool(EnableRecordingTools);
@@ -708,7 +708,7 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	CdvdShareWrite = cfg.CdvdShareWrite;
 	EnablePatches = cfg.EnablePatches;
 	EnableCheats = cfg.EnableCheats;
-	EnableIPC = cfg.EnableIPC;
+	EnablePINE = cfg.EnablePINE;
 	EnableWideScreenPatches = cfg.EnableWideScreenPatches;
 #ifndef DISABLE_RECORDING
 	EnableRecordingTools = cfg.EnableRecordingTools;

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -29,7 +29,7 @@ extern WindowInfo g_gs_window_info;
 #include "Patch.h"
 #include "SysThreads.h"
 #include "MTVU.h"
-#include "IPC.h"
+#include "PINE.h"
 #include "FW.h"
 #include "SPU2/spu2.h"
 #include "DEV9/DEV9.h"
@@ -53,9 +53,9 @@ extern WindowInfo g_gs_window_info;
 
 bool g_CDVDReset = false;
 
-namespace IPCSettings
+namespace PINESettings
 {
-	unsigned int slot = IPC_DEFAULT_SLOT;
+	unsigned int slot = PINE_DEFAULT_SLOT;
 };
 
 // --------------------------------------------------------------------------------------
@@ -267,13 +267,13 @@ void SysCoreThread::GameStartingInThread()
 #ifdef USE_SAVESLOT_UI_UPDATES
 	UI_UpdateSysControls();
 #endif
-	if (EmuConfig.EnableIPC && m_IpcState == OFF)
+	if (EmuConfig.EnablePINE && m_PineState == OFF)
 	{
-		m_IpcState = ON;
-		m_socketIpc = std::make_unique<SocketIPC>(this, IPCSettings::slot);
+		m_PineState = ON;
+		m_pineServer = std::make_unique<PINEServer>(this, PINESettings::slot);
 	}
-	if (m_IpcState == ON && m_socketIpc->m_end)
-		m_socketIpc->Start();
+	if (m_PineState == ON && m_pineServer->m_end)
+		m_pineServer->Start();
 }
 
 bool SysCoreThread::StateCheckInThread()

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -19,7 +19,7 @@
 
 #include "common/PersistentThread.h"
 #include "common/emitter/tools.h"
-#include "IPC.h"
+#include "PINE.h"
 
 
 using namespace Threading;
@@ -185,16 +185,16 @@ protected:
 	bool m_resetVsyncTimers;
 	bool m_resetVirtualMachine;
 
-	// Stores the state of the socket IPC thread.
-	std::unique_ptr<SocketIPC> m_socketIpc;
+	// Stores the state of the PINE thread.
+	std::unique_ptr<PINEServer> m_pineServer;
 
-	// Current state of the IPC thread
-	enum StateIPC
+	// Current state of the PINE thread
+	enum StatePINE
 	{
 		OFF,
 		ON
 	};
-	StateIPC m_IpcState = OFF;
+	StatePINE m_PineState = OFF;
 
 	// Indicates if the system has an active virtual machine state.  Pretty much always
 	// true anytime between subcomponents being initialized and being shutdown.  Gets
@@ -284,7 +284,7 @@ extern SysCoreThread& GetCoreThread();
 
 extern bool g_CDVDReset;
 
-namespace IPCSettings
+namespace PINESettings
 {
 	extern unsigned int slot;
 };

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -199,10 +199,10 @@ enum MenuIdentifiers
 	MenuId_Recording_VirtualPad_Port1,
 #endif
 
-	// IPC Subsection
-	MenuId_IPC,
-	MenuId_IPC_Enable,
-	MenuId_IPC_Settings,
+	//  Subsection
+	MenuId_PINE,
+	MenuId_PINE_Enable,
+	MenuId_PINE_Settings,
 
 };
 

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -424,7 +424,7 @@ static void _ApplySettings(const Pcsx2Config& src, Pcsx2Config& fixup)
 		GameInfo::gameCRC = L""; // Needs to be reset when rebooting otherwise previously loaded patches may load
 
 	if (ingame && !DiscSerial.IsEmpty())
-		GameInfo::gameSerial = L" [" + DiscSerial + L"]";
+		GameInfo::gameSerial = DiscSerial;
 
 	const wxString newGameKey(ingame ? SysGetDiscID() : SysGetBiosDiscID());
 	const bool verbose(newGameKey != curGameKey && ingame);
@@ -512,7 +512,7 @@ static void _ApplySettings(const Pcsx2Config& src, Pcsx2Config& fixup)
 	// When we're booting, the bios loader will set a a title which would be more interesting than this
 	// to most users - with region, version, etc, so don't overwrite it with patch info. That's OK. Those
 	// users which want to know the status of the patches at the bios can check the console content.
-	wxString consoleTitle = GameInfo::gameName + GameInfo::gameSerial;
+	wxString consoleTitle = GameInfo::gameName + L" [" + GameInfo::gameSerial + L"]";
 	consoleTitle += L" [" + GameInfo::gameCRC.MakeUpper() + L"]" + gameCompat + gameFixes + gamePatch + gameCheats + gameWsHacks;
 	if (ingame)
 		Console.SetTitle(consoleTitle);

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -400,14 +400,14 @@ namespace Dialogs
 		virtual ~AssertionDialog() = default;
 	};
 
-	class IPCDialog : public wxDialogWithHelpers
+	class PINEDialog : public wxDialogWithHelpers
 	{
 	public:
-		IPCDialog(wxWindow* parent = NULL);
-		virtual ~IPCDialog() = default;
+		PINEDialog(wxWindow* parent = NULL);
+		virtual ~PINEDialog() = default;
 
 		void OnConfirm(wxCommandEvent& evt);
-		static wxString GetNameStatic() { return L"IPCSettings"; }
+		static wxString GetNameStatic() { return L"PINESettings"; }
 		wxString GetDialogName() const { return GetNameStatic(); }
 	};
 } // namespace Dialogs

--- a/pcsx2/gui/Dialogs/PINEDialog.cpp
+++ b/pcsx2/gui/Dialogs/PINEDialog.cpp
@@ -26,7 +26,7 @@
 #include "gui/AppConfig.h"
 
 using namespace pxSizerFlags;
-/* This dialog currently assumes the IPC server is started when launching a
+/* This dialog currently assumes the PINE server is started when launching a
  * game, as such we can allow the IPC Settings window to change the slot in a
  * volatile fashion so that it returns to the default but you can change it at
  * each restart of the emulator to allow for multiple emulator sessions.
@@ -34,25 +34,25 @@ using namespace pxSizerFlags;
  */
 
 // --------------------------------------------------------------------------------------
-//  IPCDialog  Implementation
+//  PINEDialog  Implementation
 // --------------------------------------------------------------------------------------
 
-Dialogs::IPCDialog::IPCDialog(wxWindow* parent)
-	: wxDialogWithHelpers(parent, _("IPC Settings"), pxDialogFlags())
+Dialogs::PINEDialog::PINEDialog(wxWindow* parent)
+	: wxDialogWithHelpers(parent, _("PINE Settings"), pxDialogFlags())
 {
-	wxTextCtrl* ipc_slot = new wxTextCtrl(this, wxID_ANY, wxString::Format(wxT("%u"), IPCSettings::slot), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
-	ipc_slot->Bind(wxEVT_TEXT_ENTER, &Dialogs::IPCDialog::OnConfirm, this);
+	wxTextCtrl* ipc_slot = new wxTextCtrl(this, wxID_ANY, wxString::Format(wxT("%u"), PINESettings::slot), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	ipc_slot->Bind(wxEVT_TEXT_ENTER, &Dialogs::PINEDialog::OnConfirm, this);
 
-	*this += new wxStaticText(this, wxID_ANY, _("IPC Slot"));
+	*this += new wxStaticText(this, wxID_ANY, _("PINE Slot"));
 	*this += ipc_slot;
 }
 
-void Dialogs::IPCDialog::OnConfirm(wxCommandEvent& evt)
+void Dialogs::PINEDialog::OnConfirm(wxCommandEvent& evt)
 {
 	wxTextCtrl* obj = static_cast<wxTextCtrl*>(evt.GetEventObject());
 	if (obj != nullptr)
 	{
-		IPCSettings::slot = (unsigned int)atoi(obj->GetValue().ToUTF8().data());
+		PINESettings::slot = (unsigned int)atoi(obj->GetValue().ToUTF8().data());
 		Destroy();
 	}
 }

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -262,8 +262,8 @@ void MainEmuFrame::ConnectMenus()
 
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnablePatches_Click, this, MenuId_EnablePatches);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableCheats_Click, this, MenuId_EnableCheats);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IPC_Enable_Click, this, MenuId_IPC_Enable);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IPC_Settings_Click, this, MenuId_IPC_Settings);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_PINE_Enable_Click, this, MenuId_PINE_Enable);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_PINE_Settings_Click, this, MenuId_PINE_Settings);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableWideScreenPatches_Click, this, MenuId_EnableWideScreenPatches);
 #ifndef DISABLE_RECORDING
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_EnableRecordingTools_Click, this, MenuId_EnableInputRecording);
@@ -395,12 +395,12 @@ void MainEmuFrame::CreatePcsx2Menu()
 	m_GameSettingsSubmenu.Append(MenuId_EnableCheats, _("Enable &Cheats"),
 		_("Use cheats otherwise known as pnachs from the cheats folder."), wxITEM_CHECK);
 
-	m_GameSettingsSubmenu.Append(MenuId_IPC, _("Configure &IPC"), &m_submenuIPC);
+	m_GameSettingsSubmenu.Append(MenuId_PINE, _("Configure &PINE"), &m_submenuPINE);
 
-	m_submenuIPC.Append(MenuId_IPC_Enable, _("&Enable IPC"),
+	m_submenuPINE.Append(MenuId_PINE_Enable, _("&Enable PINE"),
 		wxEmptyString, wxITEM_CHECK);
 
-	m_submenuIPC.Append(MenuId_IPC_Settings, _("IPC &Settings"));
+	m_submenuPINE.Append(MenuId_PINE_Settings, _("PINE &Settings"));
 
 	m_GameSettingsSubmenu.Append(MenuId_EnableWideScreenPatches, _("Enable &Widescreen Patches"),
 		_("Enabling Widescreen Patches may occasionally cause issues."), wxITEM_CHECK);
@@ -568,7 +568,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	, m_menuWindow(*new wxMenu())
 	, m_menuCapture(*new wxMenu())
 	, m_submenuVideoCapture(*new wxMenu())
-	, m_submenuIPC(*new wxMenu())
+	, m_submenuPINE(*new wxMenu())
 	, m_submenuScreenshot(*new wxMenu())
 #ifndef DISABLE_RECORDING
 	, m_menuRecording(*new wxMenu())
@@ -830,7 +830,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 	{ //these should not be affected by presets
 		menubar.Check(MenuId_EnableBackupStates, configToApply.EmuOptions.BackupSavestate);
 		menubar.Check(MenuId_EnableCheats, configToApply.EmuOptions.EnableCheats);
-		menubar.Check(MenuId_IPC_Enable, configToApply.EmuOptions.EnableIPC);
+		menubar.Check(MenuId_PINE_Enable, configToApply.EmuOptions.EnablePINE);
 		menubar.Check(MenuId_EnableWideScreenPatches, configToApply.EmuOptions.EnableWideScreenPatches);
 		menubar.Check(MenuId_Capture_Video_IncludeAudio, configToApply.AudioCapture.EnableAudio);
 #ifndef DISABLE_RECORDING

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -69,7 +69,7 @@ protected:
 
 	wxMenu& m_menuCapture;
 	wxMenu& m_submenuVideoCapture;
-	wxMenu& m_submenuIPC;
+	wxMenu& m_submenuPINE;
 	wxMenu& m_submenuScreenshot;
 
 #ifndef DISABLE_RECORDING
@@ -165,8 +165,8 @@ protected:
 	void Menu_EnableBackupStates_Click(wxCommandEvent& event);
 	void Menu_EnablePatches_Click(wxCommandEvent& event);
 	void Menu_EnableCheats_Click(wxCommandEvent& event);
-	void Menu_IPC_Enable_Click(wxCommandEvent& event);
-	void Menu_IPC_Settings_Click(wxCommandEvent& event);
+	void Menu_PINE_Enable_Click(wxCommandEvent& event);
+	void Menu_PINE_Settings_Click(wxCommandEvent& event);
 	void Menu_EnableWideScreenPatches_Click(wxCommandEvent& event);
 #ifndef DISABLE_RECORDING
 	void Menu_EnableRecordingTools_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -54,9 +54,9 @@ void MainEmuFrame::Menu_SysSettings_Click(wxCommandEvent& event)
 	AppOpenModalDialog<SysConfigDialog>(wxEmptyString, this);
 }
 
-void MainEmuFrame::Menu_IPC_Settings_Click(wxCommandEvent& event)
+void MainEmuFrame::Menu_PINE_Settings_Click(wxCommandEvent& event)
 {
-	AppOpenDialog<IPCDialog>(this);
+	AppOpenDialog<PINEDialog>(this);
 }
 
 void MainEmuFrame::Menu_AudioSettings_Click(wxCommandEvent& event)
@@ -634,9 +634,9 @@ void MainEmuFrame::Menu_EnableCheats_Click(wxCommandEvent&)
 	AppSaveSettings();
 }
 
-void MainEmuFrame::Menu_IPC_Enable_Click(wxCommandEvent&)
+void MainEmuFrame::Menu_PINE_Enable_Click(wxCommandEvent&)
 {
-	g_Conf->EmuOptions.EnableIPC = GetMenuBar()->IsChecked(MenuId_IPC_Enable);
+	g_Conf->EmuOptions.EnablePINE = GetMenuBar()->IsChecked(MenuId_PINE_Enable);
 	AppApplySettings();
 	AppSaveSettings();
 }

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -318,7 +318,7 @@
     <ClCompile Include="gui\Debugger\DebugEvents.cpp" />
     <ClCompile Include="gui\Debugger\DebuggerLists.cpp" />
     <ClCompile Include="gui\Debugger\DisassemblyDialog.cpp" />
-    <ClCompile Include="gui\Dialogs\IPCDialog.cpp" />
+    <ClCompile Include="gui\Dialogs\PINEDialog.cpp" />
     <ClCompile Include="gui\Dialogs\GSDumpDialog.cpp" />
     <ClCompile Include="gui\Dialogs\McdConfigDialog.cpp" />
     <ClCompile Include="gui\DriveList.cpp" />
@@ -331,7 +331,7 @@
     <ClCompile Include="gui\wxAppWithHelpers.cpp" />
     <ClCompile Include="gui\wxSettingsInterface.cpp" />
     <ClCompile Include="IopGte.cpp" />
-    <ClCompile Include="IPC.cpp" />
+    <ClCompile Include="PINE.cpp" />
     <ClCompile Include="FW.cpp" />
     <ClCompile Include="MemoryCardFile.cpp" />
     <ClCompile Include="MemoryCardFolder.cpp" />
@@ -767,7 +767,7 @@
     <ClInclude Include="gui\wxSettingsInterface.h" />
     <ClInclude Include="Host.h" />
     <ClInclude Include="IopGte.h" />
-    <ClInclude Include="IPC.h" />
+    <ClInclude Include="PINE.h" />
     <ClInclude Include="FW.h" />
     <ClInclude Include="MemoryCardFile.h" />
     <ClInclude Include="MemoryCardFolder.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1052,7 +1052,7 @@
     <ClCompile Include="gui\DriveList.cpp">
       <Filter>AppHost</Filter>
     </ClCompile>
-    <ClCompile Include="IPC.cpp">
+    <ClCompile Include="PINE.cpp">
       <Filter>System</Filter>
     </ClCompile>
     <ClCompile Include="FW.cpp">
@@ -1466,7 +1466,7 @@
     <ClCompile Include="GS\GSLzma.cpp">
       <Filter>System\Ps2\GS</Filter>
     </ClCompile>
-    <ClCompile Include="gui\Dialogs\IPCDialog.cpp">
+    <ClCompile Include="gui\Dialogs\PINEDialog.cpp">
       <Filter>AppHost\Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="gui\Dialogs\GSDumpDialog.cpp">
@@ -2141,7 +2141,7 @@
     <ClInclude Include="gui\DriveList.h">
       <Filter>AppHost\Include</Filter>
     </ClInclude>
-    <ClInclude Include="IPC.h">
+    <ClInclude Include="PINE.h">
       <Filter>System\Include</Filter>
     </ClInclude>
     <ClInclude Include="FW.h">


### PR DESCRIPTION
This is a long coming change related to our ipc implementation: as the protocol is slowly getting adopted by other projects/other contributors stepped in the name had to stop being related to pcsx2 specifically. 

PINE (Protocol for the Instrumentation of Emulators) was chosen, this patch reflects that.