### PR TITLE
SPU2: Remove cycleptr, grab current cycles directly

### DIFF
--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -154,8 +154,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 {
 	int size = sz;
 
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	if (MsgAutoDMA())
 		ConLog("* SPU2: DMA%c AutoDMA Transfer of %d bytes to %x (%02x %x %04x).OutPos %x\n",
@@ -167,7 +166,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 	{
 		ActiveTSA = 0x2000 + (Index << 10);
 		DMAICounter = size * 4;
-		LastClock = *cyclePtr;
+		LastClock = psxRegs.cycle;
 	}
 	else if (size >= 256)
 	{
@@ -194,7 +193,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 		ConLog("ADMA%c Error Size of %x too small\n", GetDmaIndexChar(), size);
 		InputDataLeft = 0;
 		DMAICounter = size * 4;
-		LastClock = *cyclePtr;
+		LastClock = psxRegs.cycle;
 	}
 }
 
@@ -214,13 +213,12 @@ void V_Core::PlainDMAWrite(u16* pMem, u32 size)
 		}
 	}
 
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	ReadSize = size;
 	IsDMARead = false;
 	DMAICounter = 0;
-	LastClock = *cyclePtr;
+	LastClock = psxRegs.cycle;
 	Regs.STATX &= ~0x80;
 	Regs.STATX |= 0x400;
 	TADR = MADR + (size << 1);
@@ -462,14 +460,13 @@ void V_Core::FinishDMAread()
 
 void V_Core::DoDMAread(u16* pMem, u32 size)
 {
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	DMARPtr = pMem;
 	ActiveTSA = TSA & 0xfffff;
 	ReadSize = size;
 	IsDMARead = true;
-	LastClock = *cyclePtr;
+	LastClock = psxRegs.cycle;
 	DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
 	Regs.STATX &= ~0x80;
 	Regs.STATX |= 0x400;
@@ -502,7 +499,7 @@ void V_Core::DoDMAwrite(u16* pMem, u32 size)
 		Regs.STATX &= ~0x80;
 		//Regs.ATTR |= 0x30;
 		DMAICounter = 1 * 4;
-		LastClock = *cyclePtr;
+		LastClock = psxRegs.cycle;
 		return;
 	}
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -43,7 +43,6 @@ static bool IsInitialized = false;
 
 static u32 pClocks = 0;
 
-u32* cyclePtr = nullptr;
 u32 lClocks = 0;
 //static bool cpu_detected = false;
 
@@ -77,8 +76,7 @@ void SPU2setLogDir(const char* dir)
 
 void SPU2readDMA4Mem(u16* pMem, u32 size) // size now in 16bit units
 {
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	FileLog("[%10d] SPU2 readDMA4Mem size %x\n", Cycles, size << 1);
 	Cores[0].DoDMAread(pMem, size);
@@ -86,8 +84,7 @@ void SPU2readDMA4Mem(u16* pMem, u32 size) // size now in 16bit units
 
 void SPU2writeDMA4Mem(u16* pMem, u32 size) // size now in 16bit units
 {
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	FileLog("[%10d] SPU2 writeDMA4Mem size %x at address %x\n", Cycles, size << 1, Cores[0].TSA);
 
@@ -114,8 +111,7 @@ void SPU2interruptDMA7()
 
 void SPU2readDMA7Mem(u16* pMem, u32 size)
 {
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	FileLog("[%10d] SPU2 readDMA7Mem size %x\n", Cycles, size << 1);
 	Cores[1].DoDMAread(pMem, size);
@@ -123,8 +119,7 @@ void SPU2readDMA7Mem(u16* pMem, u32 size)
 
 void SPU2writeDMA7Mem(u16* pMem, u32 size)
 {
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	FileLog("[%10d] SPU2 writeDMA7Mem size %x at address %x\n", Cycles, size << 1, Cores[1].TSA);
 
@@ -329,7 +324,7 @@ s32 SPU2open(void* pDsp)
 #endif
 
 	IsOpened = true;
-	lClocks = (cyclePtr != nullptr) ? *cyclePtr : 0;
+	lClocks = psxRegs.cycle;
 
 	try
 	{
@@ -347,7 +342,6 @@ s32 SPU2open(void* pDsp)
 		return -1;
 	}
 	SPU2setDMABaseAddr((uptr)iopMem->Main);
-	SPU2setClockPtr(&psxRegs.cycle);
 	return 0;
 }
 
@@ -418,15 +412,7 @@ void SPU2async(u32 cycles)
 {
 	DspUpdate();
 
-	if (cyclePtr != nullptr)
-	{
-		TimeUpdate(*cyclePtr);
-	}
-	else
-	{
-		pClocks += cycles;
-		TimeUpdate(pClocks);
-	}
+	TimeUpdate(psxRegs.cycle);
 
 #ifdef DEBUG_KEYS
 	u32 curTicks = GetTickCount();
@@ -506,8 +492,7 @@ u16 SPU2read(u32 rmem)
 	}
 	else
 	{
-		if (cyclePtr != nullptr)
-			TimeUpdate(*cyclePtr);
+		TimeUpdate(psxRegs.cycle);
 
 		if (rmem >> 16 == 0x1f80)
 		{
@@ -535,8 +520,7 @@ void SPU2write(u32 rmem, u16 value)
 	// If the SPU2 isn't in in sync with the IOP, samples can end up playing at rather
 	// incorrect pitches and loop lengths.
 
-	if (cyclePtr != nullptr)
-		TimeUpdate(*cyclePtr);
+	TimeUpdate(psxRegs.cycle);
 
 	if (rmem >> 16 == 0x1f80)
 		Cores[0].WriteRegPS1(rmem, value);

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -398,11 +398,6 @@ void SPU2shutdown()
 #endif
 }
 
-void SPU2setClockPtr(u32* ptr)
-{
-	cyclePtr = ptr;
-}
-
 #ifdef DEBUG_KEYS
 static u32 lastTicks;
 static bool lState[6];

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -57,7 +57,6 @@ void SPU2writeDMA7Mem(u16* pMem, u32 size);
 extern u8 callirq;
 
 extern u32 lClocks;
-extern u32* cyclePtr;
 
 extern void SPU2writeLog(const char* action, u32 rmem, u16 value);
 extern void TimeUpdate(u32 cClocks);

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -35,8 +35,6 @@ u16 SPU2read(u32 mem);
 bool SPU2setupRecording(const std::string* filename);
 void SPU2endRecording();
 
-void SPU2setClockPtr(u32* ptr);
-
 void SPU2async(u32 cycles);
 s32 SPU2freeze(int mode, freezeData* data);
 void SPU2DoFreezeIn(pxInputStream& infp);

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -453,11 +453,11 @@ __forceinline void TimeUpdate(u32 cClocks)
 	}
 
 	//Update DMA4 interrupt delay counter
-	if (Cores[0].DMAICounter > 0 && (*cyclePtr - Cores[0].LastClock) > 0)
+	if (Cores[0].DMAICounter > 0 && (psxRegs.cycle - Cores[0].LastClock) > 0)
 	{
-		const u32 amt = std::min(*cyclePtr - Cores[0].LastClock, (u32)Cores[0].DMAICounter);
+		const u32 amt = std::min(psxRegs.cycle - Cores[0].LastClock, (u32)Cores[0].DMAICounter);
 		Cores[0].DMAICounter -= amt;
-		Cores[0].LastClock = *cyclePtr;
+		Cores[0].LastClock = psxRegs.cycle;
 		if(!Cores[0].AdmaInProgress)
 			HW_DMA4_MADR += amt / 2;
 
@@ -506,11 +506,11 @@ __forceinline void TimeUpdate(u32 cClocks)
 	}
 
 	//Update DMA7 interrupt delay counter
-	if (Cores[1].DMAICounter > 0 && (*cyclePtr - Cores[1].LastClock) > 0)
+	if (Cores[1].DMAICounter > 0 && (psxRegs.cycle - Cores[1].LastClock) > 0)
 	{
-		const u32 amt = std::min(*cyclePtr - Cores[1].LastClock, (u32)Cores[1].DMAICounter);
+		const u32 amt = std::min(psxRegs.cycle - Cores[1].LastClock, (u32)Cores[1].DMAICounter);
 		Cores[1].DMAICounter -= amt;
-		Cores[1].LastClock = *cyclePtr;
+		Cores[1].LastClock = psxRegs.cycle;
 		if (!Cores[1].AdmaInProgress)
 			HW_DMA7_MADR += amt / 2;
 		if (Cores[1].DMAICounter <= 0)


### PR DESCRIPTION
This just changes the SPU2 to get the current IOP cycle directly instead of through a pointer. The non-pointer path seems to have been given up on anyway and there seems to be little reason for hiding it behind a pointer.

This removes the path where SPU2 runs off the provided cycle argument to SPU2Async, but that was unused anyway.