### PR TITLE
IOP: Run the SPU at a consistent rate

### DIFF
--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -542,6 +542,8 @@ void psxRcntUpdate()
 		psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
 		psxCounters[CNT_SPU_DMA].CycleT = psxCounters[CNT_SPU_DMA].rate;
 		SPU2RunDma(difference);
+		// The spu might have updateed the next cycle target
+		c = psxCounters[CNT_SPU_DMA].CycleT;
 	}
 	else
 		c -= difference;

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -146,20 +146,18 @@ void psxRcntInit()
 	psxCounters[4].interrupt = 0x08000;
 	psxCounters[5].interrupt = 0x10000;
 
-	// SPU sample
-	psxCounters[6].rate = 768;
-	psxCounters[6].CycleT = psxCounters[6].rate;
-	psxCounters[6].mode = 0x8;
+	// Counters for driving emulation compenents
+	psxCounters[CNT_SPU_SAMPLE].rate = 768;
+	psxCounters[CNT_SPU_SAMPLE].CycleT = psxCounters[6].rate;
+	psxCounters[CNT_SPU_SAMPLE].mode = 0x8;
 
-	// USB
-	psxCounters[7].rate = PSXCLK / 1000;
-	psxCounters[7].CycleT = psxCounters[7].rate;
-	psxCounters[7].mode = 0x8;
+	psxCounters[CNT_USB].rate = PSXCLK / 1000;
+	psxCounters[CNT_USB].CycleT = psxCounters[7].rate;
+	psxCounters[CNT_USB].mode = 0x8;
 
-	// SPU DMA
-	psxCounters[8].rate = 1000;
-	psxCounters[8].CycleT = psxCounters[6].rate;
-	psxCounters[8].mode = 0x8;
+	psxCounters[CNT_SPU_DMA].rate = 1000;
+	psxCounters[CNT_SPU_DMA].CycleT = psxCounters[6].rate;
+	psxCounters[CNT_SPU_DMA].mode = 0x8;
 
 	for (i = 0; i < NUM_COUNTERS; i++)
 		psxCounters[i].sCycleT = psxRegs.cycle;
@@ -508,42 +506,44 @@ void psxRcntUpdate()
 	}
 
 
-	s32 difference = psxRegs.cycle - psxCounters[6].sCycleT;
-	s32 c = psxCounters[6].CycleT;
+	s32 difference = psxRegs.cycle - psxCounters[CNT_SPU_SAMPLE].sCycleT;
+	s32 c = psxCounters[CNT_SPU_SAMPLE].CycleT;
 
-	if (difference >= psxCounters[6].CycleT)
+	if (difference >= psxCounters[CNT_SPU_SAMPLE].CycleT)
 	{
-		psxCounters[6].sCycleT = psxRegs.cycle;
-		psxCounters[6].CycleT = psxCounters[6].rate;
+		psxCounters[CNT_SPU_SAMPLE].sCycleT = psxRegs.cycle;
+		psxCounters[CNT_SPU_SAMPLE].CycleT = psxCounters[CNT_SPU_SAMPLE].rate;
 		SPU2async(difference);
 	}
 	else
 		c -= difference;
 	psxNextCounter = c;
+
 	DEV9async(1);
-    const s32 diffusb = psxRegs.cycle - psxCounters[7].sCycleT;
-    s32 cusb = psxCounters[7].CycleT;
 
-    if (diffusb >= psxCounters[7].CycleT)
-    {
-		USBasync(diffusb);
-		psxCounters[7].sCycleT = psxRegs.cycle;
-		psxCounters[7].CycleT = psxCounters[7].rate;
-    }
-    else
-		cusb -= diffusb;
-    if (cusb < psxNextCounter)
-		psxNextCounter = cusb;
+	difference = psxRegs.cycle - psxCounters[CNT_USB].sCycleT;
+	c = psxCounters[CNT_USB].CycleT;
 
-    difference = psxRegs.cycle - psxCounters[8].sCycleT;
-	c = psxCounters[8].CycleT;
-    if (c >= psxCounters[8].CycleT)
-    {
-		psxCounters[8].sCycleT = psxRegs.cycle;
-		psxCounters[8].CycleT = psxCounters[8].rate;
+	if (difference >= psxCounters[CNT_USB].CycleT)
+	{
+		USBasync(difference);
+		psxCounters[CNT_USB].sCycleT = psxRegs.cycle;
+		psxCounters[CNT_USB].CycleT = psxCounters[CNT_USB].rate;
+	}
+	else
+		c -= difference;
+	if (c < psxNextCounter)
+		psxNextCounter = c;
+
+	difference = psxRegs.cycle - psxCounters[CNT_SPU_DMA].sCycleT;
+	c = psxCounters[CNT_SPU_DMA].CycleT;
+	if (c >= psxCounters[CNT_SPU_DMA].CycleT)
+	{
+		psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
+		psxCounters[CNT_SPU_DMA].CycleT = psxCounters[CNT_SPU_DMA].rate;
 		SPU2RunDma(difference);
-    }
-    else
+	}
+	else
 		c -= difference;
     if (c < psxNextCounter)
 		psxNextCounter = c;

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -516,7 +516,6 @@ void psxRcntUpdate()
 		psxCounters[6].sCycleT = psxRegs.cycle;
 		psxCounters[6].CycleT = psxCounters[6].rate;
 		SPU2async(difference);
-		c = psxCounters[6].CycleT;
 	}
 	else
 		c -= difference;

--- a/pcsx2/IopCounters.h
+++ b/pcsx2/IopCounters.h
@@ -24,7 +24,7 @@ struct psxCounter {
 	s32 CycleT;
 };
 
-#define NUM_COUNTERS 8
+#define NUM_COUNTERS 9
 
 extern psxCounter psxCounters[NUM_COUNTERS];
 

--- a/pcsx2/IopCounters.h
+++ b/pcsx2/IopCounters.h
@@ -26,6 +26,10 @@ struct psxCounter {
 
 #define NUM_COUNTERS 9
 
+#define CNT_SPU_SAMPLE 6
+#define CNT_USB 7
+#define CNT_SPU_DMA 8
+
 extern psxCounter psxCounters[NUM_COUNTERS];
 
 extern void psxRcntInit();

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -37,25 +37,6 @@ static void __fastcall psxDmaGeneric(u32 madr, u32 bcr, u32 chcr, u32 spuCore)
 
 	const int size = (bcr >> 16) * (bcr & 0xFFFF);
 
-	// Update the spu2 to the current cycle before initiating the DMA
-
-	SPU2async(psxRegs.cycle - psxCounters[6].sCycleT);
-	//Console.Status("cycles sent to SPU2 %x\n", psxRegs.cycle - psxCounters[6].sCycleT);
-
-	psxCounters[6].sCycleT = psxRegs.cycle;
-	psxCounters[6].CycleT = size * 4;
-
-	psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
-	psxNextsCounter = psxRegs.cycle;
-	if (psxCounters[6].CycleT < psxNextCounter)
-		psxNextCounter = psxCounters[6].CycleT;
-
-	if ((g_iopNextEventCycle - psxNextsCounter) > (u32)psxNextCounter)
-	{
-		//DevCon.Warning("SPU2async Setting new counter branch, old %x new %x ((%x - %x = %x) > %x delta)", g_iopNextEventCycle, psxNextsCounter + psxNextCounter, g_iopNextEventCycle, psxNextsCounter, (g_iopNextEventCycle - psxNextsCounter), psxNextCounter);
-		g_iopNextEventCycle = psxNextsCounter + psxNextCounter;
-	}
-
 	switch (chcr)
 	{
 		case 0x01000201: //cpu to spu2 transfer

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -348,15 +348,15 @@ void V_Core::FinishDMAwrite()
 	{
 		DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
 
-		if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+		if (((psxCounters[CNT_SPU_DMA].sCycleT + psxCounters[CNT_SPU_DMA].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
 		{
-			psxCounters[8].sCycleT = psxRegs.cycle;
-			psxCounters[8].CycleT = DMAICounter;
+			psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
+			psxCounters[CNT_SPU_DMA].CycleT = DMAICounter;
 
 			psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 			psxNextsCounter = psxRegs.cycle;
-			if (psxCounters[8].CycleT < psxNextCounter)
-				psxNextCounter = psxCounters[8].CycleT;
+			if (psxCounters[CNT_SPU_DMA].CycleT < psxNextCounter)
+				psxNextCounter = psxCounters[CNT_SPU_DMA].CycleT;
 		}
 	}
 	ActiveTSA = TDA;
@@ -444,15 +444,15 @@ void V_Core::FinishDMAread()
 	{
 		DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
 
-		if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+		if (((psxCounters[CNT_SPU_DMA].sCycleT + psxCounters[CNT_SPU_DMA].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
 		{
-			psxCounters[8].sCycleT = psxRegs.cycle;
-			psxCounters[8].CycleT = DMAICounter;
+			psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
+			psxCounters[CNT_SPU_DMA].CycleT = DMAICounter;
 
 			psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 			psxNextsCounter = psxRegs.cycle;
-			if (psxCounters[8].CycleT < psxNextCounter)
-				psxNextCounter = psxCounters[8].CycleT;
+			if (psxCounters[CNT_SPU_DMA].CycleT < psxNextCounter)
+				psxNextCounter = psxCounters[CNT_SPU_DMA].CycleT;
 		}
 	}
 	ActiveTSA = TDA;
@@ -476,15 +476,15 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	//Regs.ATTR |= 0x30;
 	TADR = MADR + (size << 1);
 
-	if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+	if (((psxCounters[CNT_SPU_DMA].sCycleT + psxCounters[CNT_SPU_DMA].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
 	{
-		psxCounters[8].sCycleT = psxRegs.cycle;
-		psxCounters[8].CycleT = DMAICounter;
+		psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
+		psxCounters[CNT_SPU_DMA].CycleT = DMAICounter;
 
 		psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 		psxNextsCounter = psxRegs.cycle;
-		if (psxCounters[8].CycleT < psxNextCounter)
-			psxNextCounter = psxCounters[8].CycleT;
+		if (psxCounters[CNT_SPU_DMA].CycleT < psxNextCounter)
+			psxNextCounter = psxCounters[CNT_SPU_DMA].CycleT;
 	}
 
 	if (MsgDMA())

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -348,15 +348,15 @@ void V_Core::FinishDMAwrite()
 	{
 		DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
 
-		if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+		if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
 		{
-			psxCounters[6].sCycleT = psxRegs.cycle;
-			psxCounters[6].CycleT = DMAICounter;
+			psxCounters[8].sCycleT = psxRegs.cycle;
+			psxCounters[8].CycleT = DMAICounter;
 
 			psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 			psxNextsCounter = psxRegs.cycle;
-			if (psxCounters[6].CycleT < psxNextCounter)
-				psxNextCounter = psxCounters[6].CycleT;
+			if (psxCounters[8].CycleT < psxNextCounter)
+				psxNextCounter = psxCounters[8].CycleT;
 		}
 	}
 	ActiveTSA = TDA;
@@ -444,15 +444,15 @@ void V_Core::FinishDMAread()
 	{
 		DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
 
-		if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+		if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
 		{
-			psxCounters[6].sCycleT = psxRegs.cycle;
-			psxCounters[6].CycleT = DMAICounter;
+			psxCounters[8].sCycleT = psxRegs.cycle;
+			psxCounters[8].CycleT = DMAICounter;
 
 			psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 			psxNextsCounter = psxRegs.cycle;
-			if (psxCounters[6].CycleT < psxNextCounter)
-				psxNextCounter = psxCounters[6].CycleT;
+			if (psxCounters[8].CycleT < psxNextCounter)
+				psxNextCounter = psxCounters[8].CycleT;
 		}
 	}
 	ActiveTSA = TDA;
@@ -476,15 +476,15 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	//Regs.ATTR |= 0x30;
 	TADR = MADR + (size << 1);
 
-	if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
+	if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)DMAICounter)
 	{
-		psxCounters[6].sCycleT = psxRegs.cycle;
-		psxCounters[6].CycleT = DMAICounter;
+		psxCounters[8].sCycleT = psxRegs.cycle;
+		psxCounters[8].CycleT = DMAICounter;
 
 		psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 		psxNextsCounter = psxRegs.cycle;
-		if (psxCounters[6].CycleT < psxNextCounter)
-			psxNextCounter = psxCounters[6].CycleT;
+		if (psxCounters[8].CycleT < psxNextCounter)
+			psxNextCounter = psxCounters[8].CycleT;
 	}
 
 	if (MsgDMA())

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -61,6 +61,7 @@ extern u32* cyclePtr;
 
 extern void SPU2writeLog(const char* action, u32 rmem, u16 value);
 extern void TimeUpdate(u32 cClocks);
+extern void SPU2RunDma(u32 cClocks);
 extern void SPU2_FastWrite(u32 rmem, u16 value);
 
 extern void LowPassFilterInit();

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -496,15 +496,17 @@ void SPU2RunDma(u32 cClocks)
 		}
 		else
 		{
-			if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)Cores[0].DMAICounter)
+			if (((psxCounters[CNT_SPU_DMA].sCycleT +
+					 psxCounters[CNT_SPU_DMA].CycleT) -
+					psxRegs.cycle) > (u32)Cores[0].DMAICounter)
 			{
-				psxCounters[8].sCycleT = psxRegs.cycle;
-				psxCounters[8].CycleT = Cores[0].DMAICounter;
+				psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
+				psxCounters[CNT_SPU_DMA].CycleT = Cores[0].DMAICounter;
 
 				psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 				psxNextsCounter = psxRegs.cycle;
-				if (psxCounters[8].CycleT < psxNextCounter)
-					psxNextCounter = psxCounters[8].CycleT;
+				if (psxCounters[CNT_SPU_DMA].CycleT < psxNextCounter)
+					psxNextCounter = psxCounters[CNT_SPU_DMA].CycleT;
 			}
 		}
 	}
@@ -549,10 +551,12 @@ void SPU2RunDma(u32 cClocks)
 		}
 		else
 		{
-			if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)Cores[1].DMAICounter)
+			if (((psxCounters[CNT_SPU_DMA].sCycleT +
+					 psxCounters[CNT_SPU_DMA].CycleT) -
+					psxRegs.cycle) > (u32)Cores[1].DMAICounter)
 			{
-				psxCounters[8].sCycleT = psxRegs.cycle;
-				psxCounters[8].CycleT = Cores[1].DMAICounter;
+				psxCounters[CNT_SPU_DMA].sCycleT = psxRegs.cycle;
+				psxCounters[CNT_SPU_DMA].CycleT = Cores[1].DMAICounter;
 
 				psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 				psxNextsCounter = psxRegs.cycle;

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -450,8 +450,12 @@ __forceinline void TimeUpdate(u32 cClocks)
 		//SaveMMXRegs();
 		Mix();
 		//RestoreMMXRegs();
-	}
 
+	}
+}
+
+void SPU2RunDma(u32 cClocks)
+{
 	//Update DMA4 interrupt delay counter
 	if (Cores[0].DMAICounter > 0 && (*cyclePtr - Cores[0].LastClock) > 0)
 	{
@@ -492,15 +496,15 @@ __forceinline void TimeUpdate(u32 cClocks)
 		}
 		else
 		{
-			if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)Cores[0].DMAICounter)
+			if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)Cores[0].DMAICounter)
 			{
-				psxCounters[6].sCycleT = psxRegs.cycle;
-				psxCounters[6].CycleT = Cores[0].DMAICounter;
+				psxCounters[8].sCycleT = psxRegs.cycle;
+				psxCounters[8].CycleT = Cores[0].DMAICounter;
 
 				psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 				psxNextsCounter = psxRegs.cycle;
-				if (psxCounters[6].CycleT < psxNextCounter)
-					psxNextCounter = psxCounters[6].CycleT;
+				if (psxCounters[8].CycleT < psxNextCounter)
+					psxNextCounter = psxCounters[8].CycleT;
 			}
 		}
 	}
@@ -545,18 +549,19 @@ __forceinline void TimeUpdate(u32 cClocks)
 		}
 		else
 		{
-			if (((psxCounters[6].sCycleT + psxCounters[6].CycleT) - psxRegs.cycle) > (u32)Cores[1].DMAICounter)
+			if (((psxCounters[8].sCycleT + psxCounters[8].CycleT) - psxRegs.cycle) > (u32)Cores[1].DMAICounter)
 			{
-				psxCounters[6].sCycleT = psxRegs.cycle;
-				psxCounters[6].CycleT = Cores[1].DMAICounter;
+				psxCounters[8].sCycleT = psxRegs.cycle;
+				psxCounters[8].CycleT = Cores[1].DMAICounter;
 
 				psxNextCounter -= (psxRegs.cycle - psxNextsCounter);
 				psxNextsCounter = psxRegs.cycle;
-				if (psxCounters[6].CycleT < psxNextCounter)
-					psxNextCounter = psxCounters[6].CycleT;
+				if (psxCounters[8].CycleT < psxNextCounter)
+					psxNextCounter = psxCounters[8].CycleT;
 			}
 		}
 	}
+
 }
 
 __forceinline void UpdateSpdifMode()

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -24,7 +24,7 @@
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A1F << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A20 << 16) | 0x0000;
 
 // this function is meant to be used in the place of GSfreeze, and provides a safe layer
 // between the GS saving function and the MTGS's needs. :)


### PR DESCRIPTION
I guess this is more of an RFC than a PR, but having this code here doesn't make much sense to me so let's figure out if it's still useful.

```
Run the SPU once per 768th IOP cycle. And stop adjusting the SPU's
target cycle in IopDma, doing this makes little sense the SPU2 is so eager
about running itself on interactions from the core.

If we need finer timing for DMA transfers we could just run the SPU2
more often than every 765th cycle, it should handle that fine as far as
I can tell.
```