### PR TITLE
GameDB:adds VU clamping mode extra to 'Enthusia Professional Racing'

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -23149,7 +23149,7 @@ SLPM-65948:
   name: "Enthusia Professional Racing"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3
+    eeClampMode: 3 # Fixes Freezing at the start of the race
     vuClampMode: 3 # Fixes Freezing at the start of the race
 SLPM-65949:
   name: "Get Ride! AM Driver - The Truth of Xiangke"

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -23150,6 +23150,7 @@ SLPM-65948:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3
+    vuClampMode: 3 # Fixes Freezing at the start of the race
 SLPM-65949:
   name: "Get Ride! AM Driver - The Truth of Xiangke"
   region: "NTSC-J"


### PR DESCRIPTION

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GameDB:adds VU clamping mode extra to 'Enthusia Professional Racing'

i have no idea if other version of 'Enthusia Professional Racing' needs the same VU clamping 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Fixes #4386
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

boot up the game in question and see if it works fine and complete a race  ( it dosent freeze )
