### PR TITLE
cdvd: Fix disc drive path issues on Windows

### DIFF
--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -189,6 +189,8 @@ s32 CALLBACK DISCopen(const char* pTitle)
 	std::string drive = g_Conf->Folders.RunDisc.GetPath().ToStdString();
 #endif
 	GetValidDrive(drive);
+	if (drive.empty())
+		return -1;
 
 	// open device file
 	try

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -184,9 +184,9 @@ void StopKeepAliveThread()
 s32 CALLBACK DISCopen(const char* pTitle)
 {
 #if defined(_WIN32)
-	std::wstring drive = g_Conf->Folders.RunDisc.GetPath().ToStdWstring();
+	std::wstring drive = g_Conf->Folders.RunDisc.ToStdWstring();
 #else
-	std::string drive = g_Conf->Folders.RunDisc.GetPath().ToStdString();
+	std::string drive = g_Conf->Folders.RunDisc.ToStdString();
 #endif
 	GetValidDrive(drive);
 	if (drive.empty())

--- a/pcsx2/CDVD/Windows/DriveUtility.cpp
+++ b/pcsx2/CDVD/Windows/DriveUtility.cpp
@@ -41,23 +41,19 @@ void GetValidDrive(std::wstring& drive)
 		auto drives = GetOpticalDriveList();
 		if (drives.empty())
 		{
-			drive = {};
+			drive.clear();
+			return;
 		}
-		else
-		{
-			drive = drives.front();
-		}
+		drive = drives.front();
 	}
-	else
-	{
-		int size = WideCharToMultiByte(CP_UTF8, 0, drive.c_str(), -1, nullptr, 0, nullptr, nullptr);
-		std::vector<char> converted_string(size);
-		WideCharToMultiByte(CP_UTF8, 0, drive.c_str(), -1, converted_string.data(), converted_string.size(), nullptr, nullptr);
-		printf(" * CDVD: Opening drive '%s'...\n", converted_string.data());
 
-		// The drive string has the form "X:\", but to open the drive, the string
-		// has to be in the form "\\.\X:"
-		drive.pop_back();
-		drive.insert(0, L"\\\\.\\");
-	}
+	int size = WideCharToMultiByte(CP_UTF8, 0, drive.c_str(), -1, nullptr, 0, nullptr, nullptr);
+	std::vector<char> converted_string(size);
+	WideCharToMultiByte(CP_UTF8, 0, drive.c_str(), -1, converted_string.data(), converted_string.size(), nullptr, nullptr);
+	printf(" * CDVD: Opening drive '%s'...\n", converted_string.data());
+
+	// The drive string has the form "X:\", but to open the drive, the string
+	// has to be in the form "\\.\X:"
+	drive.pop_back();
+	drive.insert(0, L"\\\\.\\");
 }

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -737,7 +737,7 @@ AppConfig::FolderOptions::FolderOptions()
 
 	, RunIso	( PathDefs::GetDocuments() )			// raw default is always the Documents folder.
 	, RunELF	( PathDefs::GetDocuments() )			// raw default is always the Documents folder.
-	, RunDisc	( PathDefs::GetDocuments().GetFilename() )
+	, RunDisc()
 {
 	bitset = 0xffffffff;
 }
@@ -777,7 +777,7 @@ void AppConfig::FolderOptions::LoadSave( IniInterface& ini )
 
 	IniEntryDirFile( RunIso, rel );
 	IniEntryDirFile( RunELF, rel );
-	IniEntryDirFile( RunDisc, rel );
+	IniEntry(RunDisc);
 
 	if( ini.IsLoading() )
 	{
@@ -1303,18 +1303,6 @@ static void LoadUiSettings()
 		g_Conf->CurrentIso.clear();
 	}
 
-#if defined(_WIN32)
-	if( !g_Conf->Folders.RunDisc.DirExists() )
-	{
-		g_Conf->Folders.RunDisc.Clear();
-	}
-#else
-	if (!g_Conf->Folders.RunDisc.Exists())
-	{
-		g_Conf->Folders.RunDisc.Clear();
-	}
-#endif
-
 	sApp.DispatchUiSettingsEvent( loader );
 }
 
@@ -1349,18 +1337,6 @@ static void SaveUiSettings()
 	{
 		g_Conf->CurrentIso.clear();
 	}
-
-#if defined(_WIN32)
-	if (!g_Conf->Folders.RunDisc.DirExists())
-	{
-		g_Conf->Folders.RunDisc.Clear();
-	}
-#else
-	if (!g_Conf->Folders.RunDisc.Exists())
-	{
-		g_Conf->Folders.RunDisc.Clear();
-	}
-#endif
 
 	sApp.GetRecentIsoManager().Add( g_Conf->CurrentIso );
 

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -172,7 +172,7 @@ public:
 
 		wxDirName RunIso;		// last used location for Iso loading.
 		wxDirName RunELF;		// last used location for ELF loading.
-		wxFileName RunDisc;		// last used location for Disc loading.
+		wxString RunDisc;		// last used location for Disc loading.
 
 		FolderOptions();
 		void LoadSave( IniInterface& conf );

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1218,11 +1218,7 @@ void SysUpdateIsoSrcFile( const wxString& newIsoFile )
 
 void SysUpdateDiscSrcDrive( const wxString& newDiscDrive )
 {
-#if defined(_WIN32)
-	g_Conf->Folders.RunDisc = wxFileName::DirName(newDiscDrive);
-#else
-	g_Conf->Folders.RunDisc = wxFileName(newDiscDrive);
-#endif
+	g_Conf->Folders.RunDisc = newDiscDrive;
 	AppSaveSettings();
 	sMainFrame.UpdateCdvdSrcSelection();
 }

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -237,7 +237,7 @@ wxWindowID SwapOrReset_Disc(wxWindow* owner, IScopedCoreThread& core, const wxSt
 	}
 	wxWindowID result = wxID_CANCEL;
 
-	if ((g_Conf->CdvdSource == CDVD_SourceType::Disc) && (driveLetter == g_Conf->Folders.RunDisc.GetPath()))
+	if ((g_Conf->CdvdSource == CDVD_SourceType::Disc) && (driveLetter == g_Conf->Folders.RunDisc))
 	{
 		core.AllowResume();
 		return result;


### PR DESCRIPTION
### Description of Changes
* Fixes the disc path handling on Windows, where the path is not always converted to the correct format.
* Simplifies how the disc path stuff is handled.

### Rationale behind Changes
* Fixes #3910 (Regression only affects Windows).
* Fixes an issue where the drive choice is cleared if there is no disc in the selected drive when PCSX2 is first opened (Should only affect Windows, but non-Windows only code is touched too).

### Suggested Testing Steps
* Start PCSX2 without a disc in the optical drive.
* Insert Disc
* Boot from Disc

or

* Start PCSX2 without a disc in the optical drive.
* Boot from Disc
* Insert Disc