### PR TITLE
Debugger: Modify hotkeys and add delete breakpoint context action

### DIFF
--- a/pcsx2/Docs/Debugger.md
+++ b/pcsx2/Docs/Debugger.md
@@ -8,10 +8,11 @@ urlcolor: "cyan"
 # Debugger Key Bindings
 
 ## Disassembly View
--   `Ctrl+G`   -   goto
--   `Ctrl+E`   -   edit breakpoint
--   `Ctrl+D`   -   enable/disable breakpoint
--   `Ctrl+B`   -   add breakpoint
+-   `G`   -   goto
+-   `E`   -   edit breakpoint
+-   `D`   -   enable/disable breakpoint
+-   `B`   -   add breakpoint
+-   `M`   -   assemble opcode
 -   `Right Arrow`   -   follow branch/position memory view to accessed address
 -   `Left Arrow`   -   go back one branch level/goto pc
 -   `Up Arrow`   -   move cursor up one line
@@ -26,7 +27,7 @@ urlcolor: "cyan"
 
 ## Memory View
 
--   `Ctrl+G`   -   goto
+-   `G`   -   goto
 -   `Ctrl+B`   -   add breakpoint
 -   `Left Arrow`   -   move cursor back one byte/nibble
 -   `Right Arrow`   -   move cursor ahead one byte/nibble

--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -70,28 +70,27 @@ enum DisassemblyMenuIdentifiers
 	ID_DISASM_ADDFUNCTION
 };
 
-class NonAutoSelectTextCtrl: public wxTextCtrl
+class NonAutoSelectTextCtrl : public wxTextCtrl
 {
 public:
-	NonAutoSelectTextCtrl(wxWindow *parent, wxWindowID id,
+	NonAutoSelectTextCtrl(wxWindow* parent, wxWindowID id,
 		const wxString& value = wxEmptyString,
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,
 		long style = 0,
 		const wxValidator& validator = wxDefaultValidator,
 		const wxString& name = wxTextCtrlNameStr)
-		 : wxTextCtrl(parent,id,value,pos,size,style,validator,name)
+		: wxTextCtrl(parent, id, value, pos, size, style, validator, name)
 	{
-
 	}
 #ifdef _WIN32
 
-#define WM_GETDLGCODE		0x0087
-#define DLGC_HASSETSEL		0x0008
+#define WM_GETDLGCODE 0x0087
+#define DLGC_HASSETSEL 0x0008
 
 	virtual WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 	{
-		WXLRESULT result = wxTextCtrl::MSWWindowProc(nMsg,wParam,lParam);
+		WXLRESULT result = wxTextCtrl::MSWWindowProc(nMsg, wParam, lParam);
 		if (nMsg == WM_GETDLGCODE)
 			result &= ~DLGC_HASSETSEL;
 		return result;
@@ -99,28 +98,28 @@ public:
 #endif
 };
 
-class TextEntryDialog: public wxDialog
+class TextEntryDialog : public wxDialog
 {
 public:
 	TextEntryDialog(wxWindow* parent, wxString title, wxString defaultText)
-		: wxDialog(parent,wxID_ANY,title)
+		: wxDialog(parent, wxID_ANY, title)
 	{
 		wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-	
-		textControl = new NonAutoSelectTextCtrl(this,wxID_ANY,L"",wxDefaultPosition,wxDefaultSize,0);
+
+		textControl = new NonAutoSelectTextCtrl(this, wxID_ANY, L"", wxDefaultPosition, wxDefaultSize, 0);
 		textControl->SetValue(defaultText);
-		textControl->SetSelection(textControl->GetLastPosition(),textControl->GetLastPosition());
-		sizer->Add(textControl,0,wxEXPAND);
+		textControl->SetSelection(textControl->GetLastPosition(), textControl->GetLastPosition());
+		sizer->Add(textControl, 0, wxEXPAND);
 
 		wxBoxSizer* buttons = new wxBoxSizer(wxHORIZONTAL);
-		okButton = new wxButton(this,wxID_OK,L"OK");
+		okButton = new wxButton(this, wxID_OK, L"OK");
 		okButton->SetDefault();
-		cancelButton = new wxButton(this,wxID_CANCEL,L"Cancel");
+		cancelButton = new wxButton(this, wxID_CANCEL, L"Cancel");
 
 		buttons->Add(okButton);
 		buttons->Add(cancelButton);
-		sizer->Add(buttons,0,wxEXPAND);
-	
+		sizer->Add(buttons, 0, wxEXPAND);
+
 		SetSizer(sizer);
 		sizer->Layout();
 		sizer->Fit(this);
@@ -136,48 +135,50 @@ private:
 	wxButton* cancelButton;
 };
 
-inline wxIcon _wxGetIconFromMemory(const unsigned char *data, int length) {
-   wxMemoryInputStream is(data, length);
-   wxBitmap b = wxBitmap(wxImage(is, wxBITMAP_TYPE_ANY, -1), -1);
-   wxIcon icon;
-   icon.CopyFromBitmap(b);
-   return icon;
+inline wxIcon _wxGetIconFromMemory(const unsigned char* data, int length)
+{
+	wxMemoryInputStream is(data, length);
+	wxBitmap b = wxBitmap(wxImage(is, wxBITMAP_TYPE_ANY, -1), -1);
+	wxIcon icon;
+	icon.CopyFromBitmap(b);
+	return icon;
 }
 
 CtrlDisassemblyView::CtrlDisassemblyView(wxWindow* parent, DebugInterface* _cpu)
-	: wxWindow(parent,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxWANTS_CHARS|wxBORDER_SIMPLE|wxVSCROLL), cpu(_cpu)
+	: wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxWANTS_CHARS | wxBORDER_SIMPLE | wxVSCROLL)
+	, cpu(_cpu)
 {
 	manager.setCpu(cpu);
 	windowStart = 0x100000;
-	rowHeight = getDebugFontHeight()+2;
+	rowHeight = getDebugFontHeight() + 2;
 	charWidth = getDebugFontWidth();
 	displaySymbols = true;
 	visibleRows = 1;
 
-	bpEnabled = _wxGetIconFromMemory(res_Breakpoint_Active::Data,res_Breakpoint_Active::Length);
-	bpDisabled = _wxGetIconFromMemory(res_Breakpoint_Inactive::Data,res_Breakpoint_Inactive::Length);
+	bpEnabled = _wxGetIconFromMemory(res_Breakpoint_Active::Data, res_Breakpoint_Active::Length);
+	bpDisabled = _wxGetIconFromMemory(res_Breakpoint_Inactive::Data, res_Breakpoint_Inactive::Length);
 
-	menu.Append(ID_DISASM_COPYADDRESS,				L"Copy Address");
-	menu.Append(ID_DISASM_COPYINSTRUCTIONHEX,		L"Copy Instruction (Hex)");
-	menu.Append(ID_DISASM_COPYINSTRUCTIONDISASM,	L"Copy Instruction (Disasm)");
-	menu.Append(ID_DISASM_DISASSEMBLETOFILE,		L"Disassemble to File");
+	menu.Append(ID_DISASM_COPYADDRESS, L"Copy Address");
+	menu.Append(ID_DISASM_COPYINSTRUCTIONHEX, L"Copy Instruction (Hex)");
+	menu.Append(ID_DISASM_COPYINSTRUCTIONDISASM, L"Copy Instruction (Disasm)");
+	menu.Append(ID_DISASM_DISASSEMBLETOFILE, L"Disassemble to File");
 	menu.AppendSeparator();
-	menu.Append(ID_DISASM_ASSEMBLE,					L"Assemble Opcode");
+	menu.Append(ID_DISASM_ASSEMBLE, L"Assemble Opcode");
 	menu.AppendSeparator();
-	menu.Append(ID_DISASM_RUNTOHERE,				L"Run to Cursor");
-	menu.Append(ID_DISASM_SETPCTOHERE,				L"Jump to Cursor");
-	menu.Append(ID_DISASM_TOGGLEBREAKPOINT,			L"Toggle Breakpoint");
-	menu.Append(ID_DISASM_FOLLOWBRANCH,				L"Follow Branch");
+	menu.Append(ID_DISASM_RUNTOHERE, L"Run to Cursor");
+	menu.Append(ID_DISASM_SETPCTOHERE, L"Jump to Cursor");
+	menu.Append(ID_DISASM_TOGGLEBREAKPOINT, L"Toggle Breakpoint");
+	menu.Append(ID_DISASM_FOLLOWBRANCH, L"Follow Branch");
 	menu.AppendSeparator();
-	menu.Append(ID_DISASM_GOTOADDRESS,				L"Go to Address");
-	menu.Append(ID_DISASM_GOTOINMEMORYVIEW,			L"Go to in Memory View");
+	menu.Append(ID_DISASM_GOTOADDRESS, L"Go to Address");
+	menu.Append(ID_DISASM_GOTOINMEMORYVIEW, L"Go to in Memory View");
 	menu.AppendSeparator();
-	menu.Append(ID_DISASM_ADDFUNCTION,				L"Add Function Here");
-	menu.Append(ID_DISASM_RENAMEFUNCTION,			L"Rename Function");
-	menu.Append(ID_DISASM_REMOVEFUNCTION,			L"Remove Function");
+	menu.Append(ID_DISASM_ADDFUNCTION, L"Add Function Here");
+	menu.Append(ID_DISASM_RENAMEFUNCTION, L"Rename Function");
+	menu.Append(ID_DISASM_REMOVEFUNCTION, L"Remove Function");
 	menu.Bind(wxEVT_MENU, &CtrlDisassemblyView::onPopupClick, this);
 
-	SetScrollbar(wxVERTICAL,100,1,201,true);
+	SetScrollbar(wxVERTICAL, 100, 1, 201, true);
 	SetDoubleBuffered(true);
 	calculatePixelPositions();
 	setCurAddress(windowStart);
@@ -188,16 +189,16 @@ WXLRESULT CtrlDisassemblyView::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPA
 {
 	switch (nMsg)
 	{
-	case 0x0104:		// WM_SYSKEYDOWN, make f10 usable
-		if (wParam == 0x79)	// f10
-		{
-			postEvent(debEVT_STEPOVER,0);
-			return 0;
-		}
-		break;
+		case 0x0104: // WM_SYSKEYDOWN, make f10 usable
+			if (wParam == 0x79) // f10
+			{
+				postEvent(debEVT_STEPOVER, 0);
+				return 0;
+			}
+			break;
 	}
 
-	return wxWindow::MSWWindowProc(nMsg,wParam,lParam);
+	return wxWindow::MSWWindowProc(nMsg, wParam, lParam);
 }
 #endif
 
@@ -206,28 +207,28 @@ void CtrlDisassemblyView::scanFunctions()
 	if (!cpu->isAlive())
 		return;
 
-	manager.analyze(windowStart,manager.getNthNextAddress(windowStart,visibleRows)-windowStart);
+	manager.analyze(windowStart, manager.getNthNextAddress(windowStart, visibleRows) - windowStart);
 }
 
 void CtrlDisassemblyView::postEvent(wxEventType type, wxString text)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetClientData(cpu);
-   event.SetString(text);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetClientData(cpu);
+	event.SetString(text);
+	wxPostEvent(this, event);
 }
 
 void CtrlDisassemblyView::postEvent(wxEventType type, int value)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetClientData(cpu);
-   event.SetInt(value);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetClientData(cpu);
+	event.SetInt(value);
+	wxPostEvent(this, event);
 }
 
-void CtrlDisassemblyView::paintEvent(wxPaintEvent & evt)
+void CtrlDisassemblyView::paintEvent(wxPaintEvent& evt)
 {
 	wxPaintDC dc(this);
 	render(dc);
@@ -249,7 +250,7 @@ bool CtrlDisassemblyView::getDisasmAddressText(u32 address, char* dest, bool abb
 			for (int k = 0; addressSymbol[k] != 0; k++)
 			{
 				// abbreviate long names
-				if (abbreviateLabels && k == 16 && addressSymbol[k+1] != 0)
+				if (abbreviateLabels && k == 16 && addressSymbol[k + 1] != 0)
 				{
 					*dest++ = '+';
 					break;
@@ -259,15 +260,19 @@ bool CtrlDisassemblyView::getDisasmAddressText(u32 address, char* dest, bool abb
 			*dest++ = ':';
 			*dest = 0;
 			return true;
-		} else {
-			sprintf(dest,"    %08X",address);
+		}
+		else
+		{
+			sprintf(dest, "    %08X", address);
 			return false;
 		}
-	} else {
+	}
+	else
+	{
 		if (showData)
-			sprintf(dest,"%08X %08X",address,cpu->read32(address));
+			sprintf(dest, "%08X %08X", address, cpu->read32(address));
 		else
-			sprintf(dest,"%08X",address);
+			sprintf(dest, "%08X", address);
 		return false;
 	}
 }
@@ -279,17 +284,17 @@ wxColor scaleColor(wxColor color, float factor)
 	unsigned char b = color.Blue();
 	unsigned char a = color.Alpha();
 
-	r = std::min(255,std::max((int)(r*factor),0));
-	g = std::min(255,std::max((int)(g*factor),0));
-	b = std::min(255,std::max((int)(b*factor),0));
+	r = std::min(255, std::max((int)(r * factor), 0));
+	g = std::min(255, std::max((int)(g * factor), 0));
+	b = std::min(255, std::max((int)(b * factor), 0));
 
-	return wxColor(r,g,b,a);
+	return wxColor(r, g, b, a);
 }
 
-void CtrlDisassemblyView::drawBranchLine(wxDC& dc, std::map<u32,int>& addressPositions, BranchLine& line)
+void CtrlDisassemblyView::drawBranchLine(wxDC& dc, std::map<u32, int>& addressPositions, BranchLine& line)
 {
-	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
-	
+	u32 windowEnd = manager.getNthNextAddress(windowStart, visibleRows);
+
 	int winBottom = GetSize().GetHeight();
 
 	int topY;
@@ -297,21 +302,27 @@ void CtrlDisassemblyView::drawBranchLine(wxDC& dc, std::map<u32,int>& addressPos
 	if (line.first < windowStart)
 	{
 		topY = -1;
-	} else if (line.first >= windowEnd)
-	{
-		topY = GetSize().GetHeight()+1;
-	} else {
-		topY = addressPositions[line.first] + rowHeight/2;
 	}
-			
+	else if (line.first >= windowEnd)
+	{
+		topY = GetSize().GetHeight() + 1;
+	}
+	else
+	{
+		topY = addressPositions[line.first] + rowHeight / 2;
+	}
+
 	if (line.second < windowStart)
 	{
 		bottomY = -1;
-	} else if (line.second >= windowEnd)
+	}
+	else if (line.second >= windowEnd)
 	{
-		bottomY = GetSize().GetHeight()+1;
-	} else {
-		bottomY = addressPositions[line.second] + rowHeight/2;
+		bottomY = GetSize().GetHeight() + 1;
+	}
+	else
+	{
+		bottomY = addressPositions[line.second] + rowHeight / 2;
 	}
 
 	if ((topY < 0 && bottomY < 0) || (topY > winBottom && bottomY > winBottom))
@@ -324,95 +335,107 @@ void CtrlDisassemblyView::drawBranchLine(wxDC& dc, std::map<u32,int>& addressPos
 	if (line.first == curAddress || line.second == curAddress)
 	{
 		color = wxColor(0xFF257AFA);
-	} else {
+	}
+	else
+	{
 		color = wxColor(0xFFFF3020);
 	}
-	
+
 	wxPen pen = wxPen(color);
 	dc.SetBrush(wxBrush(color));
 	dc.SetPen(wxPen(color));
 
-	int x = pixelPositions.arrowsStart+line.laneIndex*8;
+	int x = pixelPositions.arrowsStart + line.laneIndex * 8;
 
-	if (topY < 0)	// first is not visible, but second is
+	if (topY < 0) // first is not visible, but second is
 	{
-		dc.DrawLine(x-2,bottomY,x+2,bottomY);
-		dc.DrawLine(x+2,bottomY,x+2,0);
+		dc.DrawLine(x - 2, bottomY, x + 2, bottomY);
+		dc.DrawLine(x + 2, bottomY, x + 2, 0);
 
 		if (line.type == LINE_DOWN)
 		{
-			dc.DrawLine(x,bottomY-4,x-4,bottomY);
-			dc.DrawLine(x-4,bottomY,x+1,bottomY+5);
+			dc.DrawLine(x, bottomY - 4, x - 4, bottomY);
+			dc.DrawLine(x - 4, bottomY, x + 1, bottomY + 5);
 		}
-	} else if (bottomY > winBottom) // second is not visible, but first is
+	}
+	else if (bottomY > winBottom) // second is not visible, but first is
 	{
-		dc.DrawLine(x-2,topY,x+2,topY);
-		dc.DrawLine(x+2,topY,x+2,winBottom);
-				
+		dc.DrawLine(x - 2, topY, x + 2, topY);
+		dc.DrawLine(x + 2, topY, x + 2, winBottom);
+
 		if (line.type == LINE_UP)
 		{
-			dc.DrawLine(x,topY-4,x-4,topY);
-			dc.DrawLine(x-4,topY,x+1,topY+5);
+			dc.DrawLine(x, topY - 4, x - 4, topY);
+			dc.DrawLine(x - 4, topY, x + 1, topY + 5);
 		}
-	} else { // both are visible
+	}
+	else
+	{ // both are visible
 		if (line.type == LINE_UP)
 		{
-			dc.DrawLine(x-2,bottomY,x+2,bottomY);
-			dc.DrawLine(x+2,bottomY,x+2,topY);
-			dc.DrawLine(x+2,topY,x-4,topY);
-			
-			dc.DrawLine(x,topY-4,x-4,topY);
-			dc.DrawLine(x-4,topY,x+1,topY+5);
-		} else {
-			dc.DrawLine(x-2,topY,x+2,topY);
-			dc.DrawLine(x+2,topY,x+2,bottomY);
-			dc.DrawLine(x+2,bottomY,x-4,bottomY);
-			
-			dc.DrawLine(x,bottomY-4,x-4,bottomY);
-			dc.DrawLine(x-4,bottomY,x+1,bottomY+5);
+			dc.DrawLine(x - 2, bottomY, x + 2, bottomY);
+			dc.DrawLine(x + 2, bottomY, x + 2, topY);
+			dc.DrawLine(x + 2, topY, x - 4, topY);
+
+			dc.DrawLine(x, topY - 4, x - 4, topY);
+			dc.DrawLine(x - 4, topY, x + 1, topY + 5);
+		}
+		else
+		{
+			dc.DrawLine(x - 2, topY, x + 2, topY);
+			dc.DrawLine(x + 2, topY, x + 2, bottomY);
+			dc.DrawLine(x + 2, bottomY, x - 4, bottomY);
+
+			dc.DrawLine(x, bottomY - 4, x - 4, bottomY);
+			dc.DrawLine(x - 4, bottomY, x + 1, bottomY + 5);
 		}
 	}
 }
 
 int getBackgroundColor(unsigned int address)
 {
-	u32 colors[6] = {0xFFe0FFFF,0xFFFFe0e0,0xFFe8e8FF,0xFFFFe0FF,0xFFe0FFe0,0xFFFFFFe0};
-	int n=symbolMap.GetFunctionNum(address);
-	if (n==-1) return 0xFFFFFFFF;
-	return colors[n%6];
+	u32 colors[6] = {0xFFe0FFFF, 0xFFFFe0e0, 0xFFe8e8FF, 0xFFFFe0FF, 0xFFe0FFe0, 0xFFFFFFe0};
+	int n = symbolMap.GetFunctionNum(address);
+	if (n == -1)
+		return 0xFFFFFFFF;
+	return colors[n % 6];
 }
 
-std::set<std::string> CtrlDisassemblyView::getSelectedLineArguments() {
+std::set<std::string> CtrlDisassemblyView::getSelectedLineArguments()
+{
 	std::set<std::string> args;
 
 	DisassemblyLineInfo line = DisassemblyLineInfo();
-	for (u32 addr = selectRangeStart; addr < selectRangeEnd; addr += 4) {
+	for (u32 addr = selectRangeStart; addr < selectRangeEnd; addr += 4)
+	{
 		manager.getLine(addr, displaySymbols, line);
 		size_t p = 0, nextp = line.params.find(',');
-		while (nextp != line.params.npos) {
+		while (nextp != line.params.npos)
+		{
 			args.insert(line.params.substr(p, nextp - p));
 			p = nextp + 1;
 			nextp = line.params.find(',', p);
 		}
 
-		if (p < line.params.size()) {
+		if (p < line.params.size())
+		{
 			args.insert(line.params.substr(p));
 		}
 
 		// check for registers in memory opcodes
 		p = line.params.find('(');
 		nextp = line.params.find(')');
-		if (p != line.params.npos && nextp != line.params.npos && nextp > p) {
-			args.insert(line.params.substr(p+1, nextp - p - 1));
+		if (p != line.params.npos && nextp != line.params.npos && nextp > p)
+		{
+			args.insert(line.params.substr(p + 1, nextp - p - 1));
 		}
-
 	}
 
 	return args;
 }
 
-void CtrlDisassemblyView::drawArguments(wxDC& dc, const DisassemblyLineInfo &line, int x, int y, wxColor& textColor,
-	const std::set<std::string> &currentArguments)
+void CtrlDisassemblyView::drawArguments(wxDC& dc, const DisassemblyLineInfo& line, int x, int y, wxColor& textColor,
+	const std::set<std::string>& currentArguments)
 {
 	if (line.params.empty())
 		return;
@@ -420,36 +443,38 @@ void CtrlDisassemblyView::drawArguments(wxDC& dc, const DisassemblyLineInfo &lin
 	// Don't highlight the selected lines.
 	if (isInInterval(selectRangeStart, selectRangeEnd - selectRangeStart, line.info.opcodeAddress))
 	{
-		dc.DrawText(wxString(line.params.c_str(),wxConvUTF8),x,y);
+		dc.DrawText(wxString(line.params.c_str(), wxConvUTF8), x, y);
 		return;
 	}
 
 	wxColor highlightedColor = wxColor(textColor == 0xFF0000FF ? 0xFFAABB77 : 0xFFAABB00);
 
 	size_t p = 0, nextp = line.params.find(',');
-	while (nextp != line.params.npos) {
+	while (nextp != line.params.npos)
+	{
 		const std::string arg = line.params.substr(p, nextp - p);
 		if (currentArguments.find(arg) != currentArguments.end() && textColor != 0xFFFFFFFF)
 		{
 			dc.SetTextForeground(highlightedColor);
 		}
-		dc.DrawText(wxString(arg.c_str(),wxConvUTF8),x,y);
-		x += arg.size()*charWidth;
+		dc.DrawText(wxString(arg.c_str(), wxConvUTF8), x, y);
+		x += arg.size() * charWidth;
 
 		p = nextp + 1;
 		nextp = line.params.find(',', p);
 
 		dc.SetTextForeground(textColor);
-		dc.DrawText(L",",x,y);
+		dc.DrawText(L",", x, y);
 		x += charWidth;
 	}
-	if (p < line.params.size()) {
+	if (p < line.params.size())
+	{
 		const std::string arg = line.params.substr(p);
 		if (currentArguments.find(arg) != currentArguments.end() && textColor != 0xFFFFFFFF)
 		{
 			dc.SetTextForeground(highlightedColor);
 		}
-		dc.DrawText(wxString(arg.c_str(),wxConvUTF8),x,y);
+		dc.DrawText(wxString(arg.c_str(), wxConvUTF8), x, y);
 		dc.SetTextForeground(textColor);
 	}
 }
@@ -458,7 +483,7 @@ void CtrlDisassemblyView::render(wxDC& dc)
 {
 	// init stuff
 	int totalWidth, totalHeight;
-	GetSize(&totalWidth,&totalHeight);
+	GetSize(&totalWidth, &totalHeight);
 	visibleRows = totalHeight / rowHeight;
 
 	// clear background
@@ -467,8 +492,8 @@ void CtrlDisassemblyView::render(wxDC& dc)
 	dc.SetBrush(wxBrush(white));
 	dc.SetPen(wxPen(white));
 
-	int width,height;
-	dc.GetSize(&width,&height);
+	int width, height;
+	dc.GetSize(&width, &height);
 	dc.DrawRectangle(0, 0, width, height);
 
 	if (!cpu->isAlive())
@@ -476,31 +501,31 @@ void CtrlDisassemblyView::render(wxDC& dc)
 
 	wxFont font = pxGetFixedFont(8);
 	wxFont boldFont = pxGetFixedFont(8, wxFONTWEIGHT_BOLD);
-	font.SetPixelSize(wxSize(charWidth,rowHeight-2));
-	boldFont.SetPixelSize(wxSize(charWidth,rowHeight-2));
+	font.SetPixelSize(wxSize(charWidth, rowHeight - 2));
+	boldFont.SetPixelSize(wxSize(charWidth, rowHeight - 2));
 
 	bool hasFocus = wxWindow::FindFocus() == this;
 
-	std::map<u32,int> addressPositions;
+	std::map<u32, int> addressPositions;
 
 	unsigned int address = windowStart;
 
 	const std::set<std::string> currentArguments = getSelectedLineArguments();
 	DisassemblyLineInfo line = DisassemblyLineInfo();
-	for (int i = 0; i < visibleRows+1; i++)
+	for (int i = 0; i < visibleRows + 1; i++)
 	{
-		manager.getLine(address,displaySymbols,line);
+		manager.getLine(address, displaySymbols, line);
 
-		int rowY1 = rowHeight*i;
+		int rowY1 = rowHeight * i;
 
 		addressPositions[address] = rowY1;
 
 		wxColor backgroundColor = wxColor(getBackgroundColor(address));
 		wxColor textColor = wxColor(0xFF000000);
-		
-		if (isInInterval(address,line.totalSize,cpu->getPC()))
+
+		if (isInInterval(address, line.totalSize, cpu->getPC()))
 		{
-			backgroundColor = scaleColor(backgroundColor,1.05f);
+			backgroundColor = scaleColor(backgroundColor, 1.05f);
 		}
 
 		if (address >= selectRangeStart && address < selectRangeEnd)
@@ -509,7 +534,9 @@ void CtrlDisassemblyView::render(wxDC& dc)
 			{
 				backgroundColor = address == curAddress ? 0xFFFF8822 : 0xFFFF9933;
 				textColor = 0xFFFFFFFF;
-			} else {
+			}
+			else
+			{
 				backgroundColor = 0xFFC0C0C0;
 			}
 		}
@@ -523,52 +550,51 @@ void CtrlDisassemblyView::render(wxDC& dc)
 		// draw background
 		dc.SetBrush(wxBrush(backgroundColor));
 		dc.SetPen(wxPen(backgroundColor));
-		dc.DrawRectangle(0,rowY1,totalWidth,rowHeight);
-		
+		dc.DrawRectangle(0, rowY1, totalWidth, rowHeight);
+
 		// display address/symbol
 		bool enabled;
-		if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(),address,&enabled))
+		if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(), address, &enabled))
 		{
 			if (enabled)
 				textColor = 0x0000FF;
-			int yOffset = std::max(-1,(rowHeight-14+1)/2);
-			dc.DrawIcon(enabled ? bpEnabled : bpDisabled,2,rowY1+1+yOffset);
+			int yOffset = std::max(-1, (rowHeight - 14 + 1) / 2);
+			dc.DrawIcon(enabled ? bpEnabled : bpDisabled, 2, rowY1 + 1 + yOffset);
 		}
-		
+
 		dc.SetTextForeground(textColor);
 
 		char addressText[64];
-		getDisasmAddressText(address,addressText,true,line.type == DISTYPE_OPCODE);
+		getDisasmAddressText(address, addressText, true, line.type == DISTYPE_OPCODE);
 
 		dc.SetFont(font);
-		dc.DrawText(wxString(addressText,wxConvUTF8),pixelPositions.addressStart,rowY1+2);
+		dc.DrawText(wxString(addressText, wxConvUTF8), pixelPositions.addressStart, rowY1 + 2);
 		drawArguments(dc, line, pixelPositions.argumentsStart, rowY1 + 2, textColor, currentArguments);
-		
-		if (isInInterval(address,line.totalSize,cpu->getPC()))
-			dc.DrawText(L"\u25A0",pixelPositions.opcodeStart-(charWidth+1),rowY1);
+
+		if (isInInterval(address, line.totalSize, cpu->getPC()))
+			dc.DrawText(L"\u25A0", pixelPositions.opcodeStart - (charWidth + 1), rowY1);
 
 		dc.SetFont(boldFont);
-		dc.DrawText(wxString(line.name.c_str(),wxConvUTF8),pixelPositions.opcodeStart,rowY1+2);
-		
+		dc.DrawText(wxString(line.name.c_str(), wxConvUTF8), pixelPositions.opcodeStart, rowY1 + 2);
+
 		address += line.totalSize;
 	}
 
-	std::vector<BranchLine> branchLines = manager.getBranchLines(windowStart,address-windowStart);
+	std::vector<BranchLine> branchLines = manager.getBranchLines(windowStart, address - windowStart);
 	for (size_t i = 0; i < branchLines.size(); i++)
 	{
-		drawBranchLine(dc,addressPositions,branchLines[i]);
+		drawBranchLine(dc, addressPositions, branchLines[i]);
 	}
-	
 }
 
 void CtrlDisassemblyView::gotoAddress(u32 addr)
 {
-	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+	u32 windowEnd = manager.getNthNextAddress(windowStart, visibleRows);
 	u32 newAddress = manager.getStartAddress(addr);
 
 	if (newAddress < windowStart || newAddress >= windowEnd)
 	{
-		windowStart = manager.getNthPreviousAddress(newAddress,visibleRows/2);
+		windowStart = manager.getNthPreviousAddress(newAddress, visibleRows / 2);
 	}
 
 	setCurAddress(addr);
@@ -578,29 +604,29 @@ void CtrlDisassemblyView::gotoAddress(u32 addr)
 
 void CtrlDisassemblyView::scrollAddressIntoView()
 {
-	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+	u32 windowEnd = manager.getNthNextAddress(windowStart, visibleRows);
 
 	if (curAddress < windowStart)
 		windowStart = curAddress;
 	else if (curAddress >= windowEnd)
-		windowStart =  manager.getNthPreviousAddress(curAddress,visibleRows-1);
-	
+		windowStart = manager.getNthPreviousAddress(curAddress, visibleRows - 1);
+
 	scanFunctions();
 }
 
 void CtrlDisassemblyView::calculatePixelPositions()
 {
 	pixelPositions.addressStart = 16;
-	pixelPositions.opcodeStart = pixelPositions.addressStart + 18*charWidth;
-	pixelPositions.argumentsStart = pixelPositions.opcodeStart + 9*charWidth;
-	pixelPositions.arrowsStart = pixelPositions.argumentsStart + 30*charWidth;
+	pixelPositions.opcodeStart = pixelPositions.addressStart + 18 * charWidth;
+	pixelPositions.argumentsStart = pixelPositions.opcodeStart + 9 * charWidth;
+	pixelPositions.arrowsStart = pixelPositions.argumentsStart + 30 * charWidth;
 }
 
 
 void CtrlDisassemblyView::followBranch()
 {
 	DisassemblyLineInfo line = DisassemblyLineInfo();
-	manager.getLine(curAddress,true,line);
+	manager.getLine(curAddress, true, line);
 
 	if (line.type == DISTYPE_OPCODE || line.type == DISTYPE_MACRO)
 	{
@@ -608,15 +634,17 @@ void CtrlDisassemblyView::followBranch()
 		{
 			jumpStack.push_back(curAddress);
 			gotoAddress(line.info.branchTarget);
-		} else if (line.info.hasRelevantAddress)
-		{
-			// well, not  exactly a branch, but we can do something anyway	
-			postEvent(debEVT_GOTOINMEMORYVIEW,line.info.releventAddress);
 		}
-	} else if (line.type == DISTYPE_DATA)
+		else if (line.info.hasRelevantAddress)
+		{
+			// well, not  exactly a branch, but we can do something anyway
+			postEvent(debEVT_GOTOINMEMORYVIEW, line.info.releventAddress);
+		}
+	}
+	else if (line.type == DISTYPE_DATA)
 	{
 		// jump to the start of the current line
-		postEvent(debEVT_GOTOINMEMORYVIEW,curAddress);
+		postEvent(debEVT_GOTOINMEMORYVIEW, curAddress);
 	}
 }
 
@@ -626,11 +654,11 @@ void CtrlDisassemblyView::assembleOpcode(u32 address, std::string defaultText)
 
 	if (!cpu->isCpuPaused())
 	{
-		wxMessageBox( L"Cannot change code while the core is running",  L"Error.", wxICON_ERROR);
+		wxMessageBox(L"Cannot change code while the core is running", L"Error.", wxICON_ERROR);
 		return;
 	}
 
-	TextEntryDialog entry(this,L"Assemble opcode",wxString(defaultText.c_str(),wxConvUTF8));
+	TextEntryDialog entry(this, L"Assemble opcode", wxString(defaultText.c_str(), wxConvUTF8));
 	entry.Layout();
 
 	if (entry.ShowModal() != wxID_OK)
@@ -638,18 +666,20 @@ void CtrlDisassemblyView::assembleOpcode(u32 address, std::string defaultText)
 
 	wxString op = entry.getText();
 	std::string errorText;
-	bool result = MipsAssembleOpcode(op.To8BitData(),cpu,address,encoded,errorText);
+	bool result = MipsAssembleOpcode(op.To8BitData(), cpu, address, encoded, errorText);
 	if (result)
 	{
 		SysClearExecutionCache();
-		cpu->write32(address,encoded);
+		cpu->write32(address, encoded);
 
 		if (address == curAddress)
-			gotoAddress(manager.getNthNextAddress(curAddress,1));
+			gotoAddress(manager.getNthNextAddress(curAddress, 1));
 
 		redraw();
-	} else {
-		wxMessageBox( wxString(errorText.c_str(),wxConvUTF8), L"Error.", wxICON_ERROR);
+	}
+	else
+	{
+		wxMessageBox(wxString(errorText.c_str(), wxConvUTF8), L"Error.", wxICON_ERROR);
 	}
 }
 
@@ -658,117 +688,117 @@ void CtrlDisassemblyView::onPopupClick(wxCommandEvent& evt)
 {
 	switch (evt.GetId())
 	{
-	case ID_DISASM_FOLLOWBRANCH:
-		followBranch();
-		break;
-	case ID_DISASM_COPYADDRESS:
-		if (wxTheClipboard->Open())
-		{
-			wchar_t text[64];
-			swprintf(text,64,L"%08X",curAddress);
+		case ID_DISASM_FOLLOWBRANCH:
+			followBranch();
+			break;
+		case ID_DISASM_COPYADDRESS:
+			if (wxTheClipboard->Open())
+			{
+				wchar_t text[64];
+				swprintf(text, 64, L"%08X", curAddress);
 
-			wxTheClipboard->SetData(new wxTextDataObject(text));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_DISASM_GOTOADDRESS:
-		postEvent(debEVT_GOTOADDRESS, 0);
-		break;
-	case ID_DISASM_GOTOINMEMORYVIEW:
-		postEvent(debEVT_GOTOINMEMORYVIEW,curAddress);
-		break;
-	case ID_DISASM_COPYINSTRUCTIONHEX:
-		copyInstructions(selectRangeStart,selectRangeEnd,false);
-		break;
-	case ID_DISASM_COPYINSTRUCTIONDISASM:
-		copyInstructions(selectRangeStart,selectRangeEnd,true);
-		break;
-	case ID_DISASM_SETPCTOHERE:
-		cpu->setPc(curAddress);
-		redraw();
-		break;
-	case ID_DISASM_RUNTOHERE:
-		postEvent(debEVT_RUNTOPOS,curAddress);
-		break;
-	case ID_DISASM_TOGGLEBREAKPOINT:
-		toggleBreakpoint(false);
-		break;
-	case ID_DISASM_DISASSEMBLETOFILE:
-		disassembleToFile();
-		break;
-	case ID_DISASM_RENAMEFUNCTION:
-		{		
+				wxTheClipboard->SetData(new wxTextDataObject(text));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_DISASM_GOTOADDRESS:
+			postEvent(debEVT_GOTOADDRESS, 0);
+			break;
+		case ID_DISASM_GOTOINMEMORYVIEW:
+			postEvent(debEVT_GOTOINMEMORYVIEW, curAddress);
+			break;
+		case ID_DISASM_COPYINSTRUCTIONHEX:
+			copyInstructions(selectRangeStart, selectRangeEnd, false);
+			break;
+		case ID_DISASM_COPYINSTRUCTIONDISASM:
+			copyInstructions(selectRangeStart, selectRangeEnd, true);
+			break;
+		case ID_DISASM_SETPCTOHERE:
+			cpu->setPc(curAddress);
+			redraw();
+			break;
+		case ID_DISASM_RUNTOHERE:
+			postEvent(debEVT_RUNTOPOS, curAddress);
+			break;
+		case ID_DISASM_TOGGLEBREAKPOINT:
+			toggleBreakpoint(false);
+			break;
+		case ID_DISASM_DISASSEMBLETOFILE:
+			disassembleToFile();
+			break;
+		case ID_DISASM_RENAMEFUNCTION:
+		{
 			u32 funcBegin = symbolMap.GetFunctionStart(curAddress);
 			if (funcBegin != 0xFFFFFFFF)
 			{
-				wxString newName = wxGetTextFromUser(L"Enter the new function name",L"New function name",
-					wxString(symbolMap.GetLabelString(funcBegin).c_str(),wxConvUTF8),this);
+				wxString newName = wxGetTextFromUser(L"Enter the new function name", L"New function name",
+					wxString(symbolMap.GetLabelString(funcBegin).c_str(), wxConvUTF8), this);
 
 				if (!newName.empty())
 				{
 					const wxCharBuffer converted = newName.ToUTF8();
-					symbolMap.SetLabelName(converted,funcBegin);
-					postEvent(debEVT_MAPLOADED,0);
+					symbolMap.SetLabelName(converted, funcBegin);
+					postEvent(debEVT_MAPLOADED, 0);
 					redraw();
 				}
 			}
 			else
 			{
-				wxMessageBox(L"No symbol selected",L"Error",wxICON_ERROR);
+				wxMessageBox(L"No symbol selected", L"Error", wxICON_ERROR);
 			}
 			break;
 		}
-	case ID_DISASM_REMOVEFUNCTION:
+		case ID_DISASM_REMOVEFUNCTION:
 		{
 			u32 funcBegin = symbolMap.GetFunctionStart(curAddress);
 			if (funcBegin != 0xFFFFFFFF)
 			{
-				u32 prevBegin = symbolMap.GetFunctionStart(funcBegin-1);
+				u32 prevBegin = symbolMap.GetFunctionStart(funcBegin - 1);
 				if (prevBegin != 0xFFFFFFFF)
 				{
-					u32 expandedSize = symbolMap.GetFunctionSize(prevBegin)+symbolMap.GetFunctionSize(funcBegin);
-					symbolMap.SetFunctionSize(prevBegin,expandedSize);
+					u32 expandedSize = symbolMap.GetFunctionSize(prevBegin) + symbolMap.GetFunctionSize(funcBegin);
+					symbolMap.SetFunctionSize(prevBegin, expandedSize);
 				}
-					
-				symbolMap.RemoveFunction(funcBegin,true);
+
+				symbolMap.RemoveFunction(funcBegin, true);
 				symbolMap.SortSymbols();
 				symbolMap.UpdateActiveSymbols();
 				manager.clear();
-					
-				postEvent(debEVT_MAPLOADED,0);
+
+				postEvent(debEVT_MAPLOADED, 0);
 			}
 			else
 			{
-				postEvent(debEVT_SETSTATUSBARTEXT,L"WARNING: unable to find function symbol here");
+				postEvent(debEVT_SETSTATUSBARTEXT, L"WARNING: unable to find function symbol here");
 			}
 
 			redraw();
 			break;
 		}
-	case ID_DISASM_ADDFUNCTION:
+		case ID_DISASM_ADDFUNCTION:
 		{
 			u32 prevBegin = symbolMap.GetFunctionStart(curAddress);
 			if (prevBegin != 0xFFFFFFFF)
 			{
 				if (prevBegin == curAddress)
 				{
-					postEvent(debEVT_SETSTATUSBARTEXT,L"WARNING: There's already a function entry point at this adress");
+					postEvent(debEVT_SETSTATUSBARTEXT, L"WARNING: There's already a function entry point at this adress");
 				}
 				else
 				{
 					char symname[128];
 					u32 prevSize = symbolMap.GetFunctionSize(prevBegin);
-					u32 newSize = curAddress-prevBegin;
-					symbolMap.SetFunctionSize(prevBegin,newSize);
+					u32 newSize = curAddress - prevBegin;
+					symbolMap.SetFunctionSize(prevBegin, newSize);
 
-					newSize = prevSize-newSize;
-					sprintf(symname,"u_un_%08X",curAddress);
-					symbolMap.AddFunction(symname,curAddress,newSize);
+					newSize = prevSize - newSize;
+					sprintf(symname, "u_un_%08X", curAddress);
+					symbolMap.AddFunction(symname, curAddress, newSize);
 					symbolMap.SortSymbols();
 					symbolMap.UpdateActiveSymbols();
 					manager.clear();
-						
-					postEvent(debEVT_MAPLOADED,0);
+
+					postEvent(debEVT_MAPLOADED, 0);
 				}
 			}
 			else
@@ -779,37 +809,37 @@ void CtrlDisassemblyView::onPopupClick(wxCommandEvent& evt)
 				symbolMap.AddFunction(symname, selectRangeStart, newSize);
 				symbolMap.SortSymbols();
 				symbolMap.UpdateActiveSymbols();
-					
-				postEvent(debEVT_MAPLOADED,0);
+
+				postEvent(debEVT_MAPLOADED, 0);
 			}
 
 			redraw();
 			break;
 		}
-	case ID_DISASM_ASSEMBLE:
-		assembleOpcode(curAddress, disassembleCurAddress());
-		break;
-	default:
-		wxMessageBox( L"Unimplemented.",  L"Unimplemented.", wxICON_INFORMATION);
-		break;
+		case ID_DISASM_ASSEMBLE:
+			assembleOpcode(curAddress, disassembleCurAddress());
+			break;
+		default:
+			wxMessageBox(L"Unimplemented.", L"Unimplemented.", wxICON_INFORMATION);
+			break;
 	}
 }
 
 void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 {
-	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+	u32 windowEnd = manager.getNthNextAddress(windowStart, visibleRows);
 
 	switch (evt.GetKeyCode())
-		{
+	{
 		case 'g':
 		case 'G':
-			{
-				u64 addr;
-				if (!executeExpressionWindow(this, cpu, addr))
-					return;
-				gotoAddress(addr);
-			}
-			break;
+		{
+			u64 addr;
+			if (!executeExpressionWindow(this, cpu, addr))
+				return;
+			gotoAddress(addr);
+		}
+		break;
 		case 'd':
 		case 'D':
 			toggleBreakpoint(true);
@@ -839,8 +869,10 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 			if (jumpStack.empty())
 			{
 				gotoAddress(cpu->getPC());
-			} else {
-				u32 addr = jumpStack[jumpStack.size()-1];
+			}
+			else
+			{
+				u32 addr = jumpStack[jumpStack.size() - 1];
 				jumpStack.pop_back();
 				gotoAddress(addr);
 			}
@@ -849,12 +881,12 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 			followBranch();
 			break;
 		case WXK_UP:
-			setCurAddress(manager.getNthPreviousAddress(curAddress,1), wxGetKeyState(WXK_SHIFT));
+			setCurAddress(manager.getNthPreviousAddress(curAddress, 1), wxGetKeyState(WXK_SHIFT));
 			scrollAddressIntoView();
 			scanFunctions();
 			break;
 		case WXK_DOWN:
-			setCurAddress(manager.getNthNextAddress(curAddress,1), wxGetKeyState(WXK_SHIFT));
+			setCurAddress(manager.getNthNextAddress(curAddress, 1), wxGetKeyState(WXK_SHIFT));
 			scrollAddressIntoView();
 			scanFunctions();
 			break;
@@ -862,41 +894,47 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 			displaySymbols = !displaySymbols;
 			break;
 		case WXK_PAGEUP:
-			if (curAddress != windowStart && curAddressIsVisible()) {
+			if (curAddress != windowStart && curAddressIsVisible())
+			{
 				setCurAddress(windowStart, wxGetKeyState(WXK_SHIFT));
 				scrollAddressIntoView();
-			} else {
-				setCurAddress(manager.getNthPreviousAddress(windowStart,visibleRows), wxGetKeyState(WXK_SHIFT));
+			}
+			else
+			{
+				setCurAddress(manager.getNthPreviousAddress(windowStart, visibleRows), wxGetKeyState(WXK_SHIFT));
 				scrollAddressIntoView();
 			}
 			scanFunctions();
 			break;
 		case WXK_PAGEDOWN:
-			if (manager.getNthNextAddress(curAddress,1) != windowEnd && curAddressIsVisible()) {
-				setCurAddress(manager.getNthPreviousAddress(windowEnd,1), wxGetKeyState(WXK_SHIFT));
+			if (manager.getNthNextAddress(curAddress, 1) != windowEnd && curAddressIsVisible())
+			{
+				setCurAddress(manager.getNthPreviousAddress(windowEnd, 1), wxGetKeyState(WXK_SHIFT));
 				scrollAddressIntoView();
-			} else {
-				setCurAddress(manager.getNthNextAddress(windowEnd,visibleRows-1), wxGetKeyState(WXK_SHIFT));
+			}
+			else
+			{
+				setCurAddress(manager.getNthNextAddress(windowEnd, visibleRows - 1), wxGetKeyState(WXK_SHIFT));
 				scrollAddressIntoView();
 			}
 			scanFunctions();
 			break;
 		case WXK_F8:
-			postEvent(debEVT_STEPOUT,0);
+			postEvent(debEVT_STEPOUT, 0);
 			break;
 		case WXK_F10:
-			postEvent(debEVT_STEPOVER,0);
+			postEvent(debEVT_STEPOVER, 0);
 			return;
 		case WXK_F11:
 			if (evt.ShiftDown())
-				postEvent(debEVT_STEPOUT,0);
+				postEvent(debEVT_STEPOUT, 0);
 			else
-				postEvent(debEVT_STEPINTO,0);
+				postEvent(debEVT_STEPINTO, 0);
 			return;
 		default:
 			evt.Skip();
 			break;
-		}
+	}
 
 	redraw();
 }
@@ -906,19 +944,22 @@ void CtrlDisassemblyView::scrollbarEvent(wxScrollWinEvent& evt)
 	int type = evt.GetEventType();
 	if (type == wxEVT_SCROLLWIN_LINEUP)
 	{
-		windowStart = manager.getNthPreviousAddress(windowStart,1);
+		windowStart = manager.getNthPreviousAddress(windowStart, 1);
 		scanFunctions();
-	} else if (type == wxEVT_SCROLLWIN_LINEDOWN)
+	}
+	else if (type == wxEVT_SCROLLWIN_LINEDOWN)
 	{
-		windowStart = manager.getNthNextAddress(windowStart,1);
+		windowStart = manager.getNthNextAddress(windowStart, 1);
 		scanFunctions();
-	} else if (type == wxEVT_SCROLLWIN_PAGEUP)
+	}
+	else if (type == wxEVT_SCROLLWIN_PAGEUP)
 	{
-		windowStart = manager.getNthPreviousAddress(windowStart,visibleRows);
+		windowStart = manager.getNthPreviousAddress(windowStart, visibleRows);
 		scanFunctions();
-	} else if (type == wxEVT_SCROLLWIN_PAGEDOWN)
+	}
+	else if (type == wxEVT_SCROLLWIN_PAGEDOWN)
 	{
-		windowStart = manager.getNthNextAddress(windowStart,visibleRows);
+		windowStart = manager.getNthNextAddress(windowStart, visibleRows);
 		scanFunctions();
 	}
 
@@ -928,25 +969,31 @@ void CtrlDisassemblyView::scrollbarEvent(wxScrollWinEvent& evt)
 void CtrlDisassemblyView::toggleBreakpoint(bool toggleEnabled)
 {
 	bool enabled;
-	if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(), curAddress,&enabled))
+	if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(), curAddress, &enabled))
 	{
 		if (!enabled)
 		{
 			// enable disabled breakpoints
-			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), curAddress,true);
-		} else if (!toggleEnabled && CBreakPoints::GetBreakPointCondition(cpu->getCpuType(), curAddress) != NULL)
+			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), curAddress, true);
+		}
+		else if (!toggleEnabled && CBreakPoints::GetBreakPointCondition(cpu->getCpuType(), curAddress) != NULL)
 		{
 			// don't just delete a breakpoint with a custom condition
 			CBreakPoints::RemoveBreakPoint(cpu->getCpuType(), curAddress);
-		} else if (toggleEnabled)
+		}
+		else if (toggleEnabled)
 		{
 			// disable breakpoint
-			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), curAddress,false);
-		} else {
+			CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), curAddress, false);
+		}
+		else
+		{
 			// otherwise just remove breakpoint
 			CBreakPoints::RemoveBreakPoint(cpu->getCpuType(), curAddress);
 		}
-	} else {
+	}
+	else
+	{
 		CBreakPoints::AddBreakPoint(cpu->getCpuType(), curAddress);
 	}
 }
@@ -956,8 +1003,8 @@ void CtrlDisassemblyView::updateStatusBarText()
 {
 	char text[512];
 	DisassemblyLineInfo line = DisassemblyLineInfo();
-	manager.getLine(curAddress,true,line);
-	
+	manager.getLine(curAddress, true, line);
+
 	text[0] = 0;
 	if (line.type == DISTYPE_OPCODE || line.type == DISTYPE_MACRO)
 	{
@@ -965,20 +1012,23 @@ void CtrlDisassemblyView::updateStatusBarText()
 		{
 			if (!cpu->isValidAddress(line.info.dataAddress))
 			{
-				sprintf(text,"Invalid address %08X",line.info.dataAddress);
-			} else if (line.info.lrType == MIPSAnalyst::LOADSTORE_NORMAL && line.info.dataAddress % line.info.dataSize)
+				sprintf(text, "Invalid address %08X", line.info.dataAddress);
+			}
+			else if (line.info.lrType == MIPSAnalyst::LOADSTORE_NORMAL && line.info.dataAddress % line.info.dataSize)
 			{
-				sprintf(text,"Unaligned address %08X",line.info.dataAddress);
-			} else {
+				sprintf(text, "Unaligned address %08X", line.info.dataAddress);
+			}
+			else
+			{
 				switch (line.info.dataSize)
 				{
-				case 1:
-					sprintf(text,"[%08X] = %02X",line.info.dataAddress,cpu->read8(line.info.dataAddress));
-					break;
-				case 2:
-					sprintf(text,"[%08X] = %04X",line.info.dataAddress,cpu->read16(line.info.dataAddress));
-					break;
-				case 4:
+					case 1:
+						sprintf(text, "[%08X] = %02X", line.info.dataAddress, cpu->read8(line.info.dataAddress));
+						break;
+					case 2:
+						sprintf(text, "[%08X] = %04X", line.info.dataAddress, cpu->read16(line.info.dataAddress));
+						break;
+					case 4:
 					{
 						u32 data;
 						if (line.info.lrType != MIPSAnalyst::LOADSTORE_NORMAL)
@@ -986,20 +1036,24 @@ void CtrlDisassemblyView::updateStatusBarText()
 							u32 address = line.info.dataAddress;
 							data = cpu->read32(address & ~3) >> (address & 3) * 8;
 							data |= cpu->read32((address + 3) & ~3) << (4 - (address & 3)) * 8;
-						} else {
+						}
+						else
+						{
 							data = cpu->read32(line.info.dataAddress);
 						}
 
 						const std::string addressSymbol = symbolMap.GetLabelString(data);
 						if (!addressSymbol.empty())
 						{
-							sprintf(text,"[%08X] = %s (%08X)",line.info.dataAddress,addressSymbol.c_str(),data);
-						} else {
-							sprintf(text,"[%08X] = %08X",line.info.dataAddress,data);
+							sprintf(text, "[%08X] = %s (%08X)", line.info.dataAddress, addressSymbol.c_str(), data);
+						}
+						else
+						{
+							sprintf(text, "[%08X] = %08X", line.info.dataAddress, data);
 						}
 						break;
 					}
-				case 8:
+					case 8:
 					{
 						u64 data;
 						if (line.info.lrType != MIPSAnalyst::LOADSTORE_NORMAL)
@@ -1007,17 +1061,19 @@ void CtrlDisassemblyView::updateStatusBarText()
 							u32 address = line.info.dataAddress;
 							data = cpu->read64(address & ~7) >> (address & 7) * 8;
 							data |= cpu->read64((address + 7) & ~7) << (8 - (address & 7)) * 8;
-						} else {
+						}
+						else
+						{
 							data = cpu->read64(line.info.dataAddress);
 						}
 
-						sprintf(text,"[%08X] = %016" PRIX64,line.info.dataAddress,data);
+						sprintf(text, "[%08X] = %016" PRIX64, line.info.dataAddress, data);
 						break;
 					}
-				case 16:
+					case 16:
 					{
 						__aligned16 u128 data = cpu->read128(line.info.dataAddress);
-						sprintf(text,"[%08X] = %016" PRIX64 "%016" PRIX64,line.info.dataAddress,data._u64[1],data._u64[0]);
+						sprintf(text, "[%08X] = %016" PRIX64 "%016" PRIX64, line.info.dataAddress, data._u64[1], data._u64[0]);
 						break;
 					}
 				}
@@ -1029,35 +1085,40 @@ void CtrlDisassemblyView::updateStatusBarText()
 			const std::string addressSymbol = symbolMap.GetLabelString(line.info.branchTarget);
 			if (addressSymbol.empty())
 			{
-				sprintf(text,"%08X",line.info.branchTarget);
-			} else {
-				sprintf(text,"%08X = %s",line.info.branchTarget,addressSymbol.c_str());
+				sprintf(text, "%08X", line.info.branchTarget);
+			}
+			else
+			{
+				sprintf(text, "%08X = %s", line.info.branchTarget, addressSymbol.c_str());
 			}
 		}
-	} else if (line.type == DISTYPE_DATA)
+	}
+	else if (line.type == DISTYPE_DATA)
 	{
 		u32 start = symbolMap.GetDataStart(curAddress);
 		if (start == 0xFFFFFFFF)
 			start = curAddress;
 
-		u32 diff = curAddress-start;
+		u32 diff = curAddress - start;
 		const std::string label = symbolMap.GetLabelString(start);
 
 		if (!label.empty())
 		{
 			if (diff != 0)
-				sprintf(text,"%08X (%s) + %08X",start,label.c_str(),diff);
+				sprintf(text, "%08X (%s) + %08X", start, label.c_str(), diff);
 			else
-				sprintf(text,"%08X (%s)",start,label.c_str());
-		} else {
+				sprintf(text, "%08X (%s)", start, label.c_str());
+		}
+		else
+		{
 			if (diff != 0)
-				sprintf(text,"%08X + %08X",start,diff);
+				sprintf(text, "%08X + %08X", start, diff);
 			else
-				sprintf(text,"%08X",start);
+				sprintf(text, "%08X", start);
 		}
 	}
 
-	postEvent(debEVT_SETSTATUSBARTEXT,wxString(text,wxConvUTF8));
+	postEvent(debEVT_SETSTATUSBARTEXT, wxString(text, wxConvUTF8));
 }
 
 void CtrlDisassemblyView::mouseEvent(wxMouseEvent& evt)
@@ -1066,7 +1127,7 @@ void CtrlDisassemblyView::mouseEvent(wxMouseEvent& evt)
 	wxEventType type = evt.GetEventType();
 	bool hasFocus = wxWindow::FindFocus() == this;
 
-	if (type == wxEVT_LEFT_DOWN || type == wxEVT_LEFT_DCLICK || type == wxEVT_RIGHT_DOWN )
+	if (type == wxEVT_LEFT_DOWN || type == wxEVT_LEFT_DCLICK || type == wxEVT_RIGHT_DOWN)
 	{
 		u32 newAddress = yToAddress(evt.GetY());
 		bool extend = wxGetKeyState(WXK_SHIFT);
@@ -1076,37 +1137,47 @@ void CtrlDisassemblyView::mouseEvent(wxMouseEvent& evt)
 			// Maintain the current selection if right clicking into it.
 			if (newAddress >= selectRangeStart && newAddress < selectRangeEnd)
 				extend = true;
-		} else {
+		}
+		else
+		{
 			if (curAddress == newAddress && hasFocus)
 				toggleBreakpoint(false);
 		}
 
-		setCurAddress(newAddress,extend);
+		setCurAddress(newAddress, extend);
 		SetFocus();
 		SetFocusFromKbd();
-	} else if (evt.GetEventType() == wxEVT_RIGHT_UP)
+	}
+	else if (evt.GetEventType() == wxEVT_RIGHT_UP)
 	{
-		PopupMenu(&menu,evt.GetPosition());
+		PopupMenu(&menu, evt.GetPosition());
 		return;
-	} else if (evt.GetEventType() == wxEVT_MOUSEWHEEL)
+	}
+	else if (evt.GetEventType() == wxEVT_MOUSEWHEEL)
 	{
 		if (evt.GetWheelRotation() > 0)
 		{
-			windowStart = manager.getNthPreviousAddress(windowStart,3);
-			scanFunctions();
-		} else if (evt.GetWheelRotation() < 0) {
-			windowStart = manager.getNthNextAddress(windowStart,3);
+			windowStart = manager.getNthPreviousAddress(windowStart, 3);
 			scanFunctions();
 		}
-	} else if (evt.GetEventType() == wxEVT_MOTION)
+		else if (evt.GetWheelRotation() < 0)
+		{
+			windowStart = manager.getNthNextAddress(windowStart, 3);
+			scanFunctions();
+		}
+	}
+	else if (evt.GetEventType() == wxEVT_MOTION)
 	{
 		if (evt.ButtonIsDown(wxMOUSE_BTN_LEFT))
 		{
 			int newAddress = yToAddress(evt.GetY());
-			setCurAddress(newAddress,wxGetKeyState(WXK_SHIFT));
-		} else
+			setCurAddress(newAddress, wxGetKeyState(WXK_SHIFT));
+		}
+		else
 			return;
-	} else {
+	}
+	else
+	{
 		evt.Skip();
 		return;
 	}
@@ -1117,29 +1188,29 @@ void CtrlDisassemblyView::mouseEvent(wxMouseEvent& evt)
 void CtrlDisassemblyView::sizeEvent(wxSizeEvent& evt)
 {
 	wxSize s = evt.GetSize();
-	visibleRows = s.GetWidth()/rowHeight;
+	visibleRows = s.GetWidth() / rowHeight;
 }
 
 u32 CtrlDisassemblyView::yToAddress(int y)
 {
-	int line = y/rowHeight;
-	return manager.getNthNextAddress(windowStart,line);
+	int line = y / rowHeight;
+	return manager.getNthNextAddress(windowStart, line);
 }
 
 bool CtrlDisassemblyView::curAddressIsVisible()
 {
-	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+	u32 windowEnd = manager.getNthNextAddress(windowStart, visibleRows);
 	return curAddress >= windowStart && curAddress < windowEnd;
 }
 
 void CtrlDisassemblyView::scrollStepping(u32 newPc)
 {
-	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
+	u32 windowEnd = manager.getNthNextAddress(windowStart, visibleRows);
 
 	newPc = manager.getStartAddress(newPc);
-	if (newPc >= windowEnd || newPc >= manager.getNthPreviousAddress(windowEnd,1))
+	if (newPc >= windowEnd || newPc >= manager.getNthPreviousAddress(windowEnd, 1))
 	{
-		windowStart = manager.getNthPreviousAddress(newPc,visibleRows-2);
+		windowStart = manager.getNthPreviousAddress(newPc, visibleRows - 2);
 	}
 }
 
@@ -1151,7 +1222,7 @@ std::string CtrlDisassemblyView::disassembleRange(u32 start, u32 size)
 	std::set<u32> branchAddresses;
 	for (u32 i = 0; i < size; i += 4)
 	{
-		MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(cpu,start+i);
+		MIPSAnalyst::MipsOpcodeInfo info = MIPSAnalyst::GetOpcodeInfo(cpu, start + i);
 
 		if (info.isBranch && symbolMap.GetLabelString(info.branchTarget).empty())
 		{
@@ -1165,34 +1236,35 @@ std::string CtrlDisassemblyView::disassembleRange(u32 start, u32 size)
 	u32 disAddress = start;
 	bool previousLabel = true;
 	DisassemblyLineInfo line = DisassemblyLineInfo();
-	while (disAddress < start+size)
+	while (disAddress < start + size)
 	{
-		char addressText[64],buffer[512];
+		char addressText[64], buffer[512];
 
-		manager.getLine(disAddress,displaySymbols,line);
-		bool isLabel = getDisasmAddressText(disAddress,addressText,false,line.type == DISTYPE_OPCODE);
+		manager.getLine(disAddress, displaySymbols, line);
+		bool isLabel = getDisasmAddressText(disAddress, addressText, false, line.type == DISTYPE_OPCODE);
 
 		if (isLabel)
 		{
-			if (!previousLabel) result += "\r\n";
-			sprintf(buffer,"%s\r\n\r\n",addressText);
+			if (!previousLabel)
+				result += "\r\n";
+			sprintf(buffer, "%s\r\n\r\n", addressText);
 			result += buffer;
-		} else if (branchAddresses.find(disAddress) != branchAddresses.end())
+		}
+		else if (branchAddresses.find(disAddress) != branchAddresses.end())
 		{
-			if (!previousLabel) result += "\r\n";
-			sprintf(buffer,"pos_%08X:\r\n\r\n",disAddress);
+			if (!previousLabel)
+				result += "\r\n";
+			sprintf(buffer, "pos_%08X:\r\n\r\n", disAddress);
 			result += buffer;
 		}
 
-		if (line.info.isBranch && !line.info.isBranchToRegister
-			&& symbolMap.GetLabelString(line.info.branchTarget).empty()
-			&& branchAddresses.find(line.info.branchTarget) != branchAddresses.end())
+		if (line.info.isBranch && !line.info.isBranchToRegister && symbolMap.GetLabelString(line.info.branchTarget).empty() && branchAddresses.find(line.info.branchTarget) != branchAddresses.end())
 		{
-			sprintf(buffer,"pos_%08X",line.info.branchTarget);
-			line.params = line.params.substr(0,line.params.find("0x")) + buffer;
+			sprintf(buffer, "pos_%08X", line.info.branchTarget);
+			line.params = line.params.substr(0, line.params.find("0x")) + buffer;
 		}
 
-		sprintf(buffer,"\t%s\t%s\r\n",line.name.c_str(),line.params.c_str());
+		sprintf(buffer, "\t%s\t%s\r\n", line.name.c_str(), line.params.c_str());
 		result += buffer;
 		previousLabel = isLabel;
 		disAddress += line.totalSize;
@@ -1212,7 +1284,7 @@ void CtrlDisassemblyView::copyInstructions(u32 startAddr, u32 endAddr, bool with
 {
 	if (!wxTheClipboard->Open())
 	{
-		wxMessageBox( L"Could not open clipboard.",  L"Error", wxICON_ERROR);
+		wxMessageBox(L"Could not open clipboard.", L"Error", wxICON_ERROR);
 		return;
 	}
 
@@ -1221,24 +1293,25 @@ void CtrlDisassemblyView::copyInstructions(u32 startAddr, u32 endAddr, bool with
 		int instructionSize = 4;
 		int count = (endAddr - startAddr) / instructionSize;
 		int space = count * 32;
-		char *temp = new char[space];
+		char* temp = new char[space];
 
-		char *p = temp;
+		char* p = temp;
 		for (u32 pos = startAddr; pos < endAddr; pos += instructionSize)
 		{
 			p += sprintf(p, "%08X", cpu->read32(pos));
 
 			// Don't leave a trailing newline.
 			if (pos + instructionSize < endAddr)
-				p += sprintf(p,"\r\n");
+				p += sprintf(p, "\r\n");
 		}
-		
-		wxTheClipboard->SetData(new wxTextDataObject(wxString(temp,wxConvUTF8)));
-		delete [] temp;
-	} else
+
+		wxTheClipboard->SetData(new wxTextDataObject(wxString(temp, wxConvUTF8)));
+		delete[] temp;
+	}
+	else
 	{
-		std::string disassembly = disassembleRange(startAddr,endAddr-startAddr);
-		wxTheClipboard->SetData(new wxTextDataObject(wxString(disassembly.c_str(),wxConvUTF8)));
+		std::string disassembly = disassembleRange(startAddr, endAddr - startAddr);
+		wxTheClipboard->SetData(new wxTextDataObject(wxString(disassembly.c_str(), wxConvUTF8)));
 	}
 
 	wxTheClipboard->Close();
@@ -1246,19 +1319,19 @@ void CtrlDisassemblyView::copyInstructions(u32 startAddr, u32 endAddr, bool with
 
 void CtrlDisassemblyView::disassembleToFile()
 {
-	wxFileDialog dlg(this,wxEmptyString,wxEmptyString,wxEmptyString,L"*.*",wxFD_SAVE);
+	wxFileDialog dlg(this, wxEmptyString, wxEmptyString, wxEmptyString, L"*.*", wxFD_SAVE);
 
 	if (dlg.ShowModal() == wxID_CANCEL)
 		return;
-	
-	std::string disassembly = disassembleRange(selectRangeStart,selectRangeEnd-selectRangeStart);
-	wxFile output(dlg.GetPath(),wxFile::write);
-	output.Write(wxString(disassembly.c_str(),wxConvUTF8));
+
+	std::string disassembly = disassembleRange(selectRangeStart, selectRangeEnd - selectRangeStart);
+	wxFile output(dlg.GetPath(), wxFile::write);
+	output.Write(wxString(disassembly.c_str(), wxConvUTF8));
 }
 
 void CtrlDisassemblyView::editBreakpoint()
 {
-	BreakpointWindow win(this,cpu);
+	BreakpointWindow win(this, cpu);
 
 	bool exists = false;
 	if (CBreakPoints::IsAddressBreakPoint(cpu->getCpuType(), curAddress))
@@ -1282,8 +1355,8 @@ void CtrlDisassemblyView::editBreakpoint()
 	{
 		if (exists)
 			CBreakPoints::RemoveBreakPoint(cpu->getCpuType(), curAddress);
-		win.addBreakpoint();	
-		postEvent(debEVT_UPDATE,0);
+		win.addBreakpoint();
+		postEvent(debEVT_UPDATE, 0);
 	}
 }
 
@@ -1291,6 +1364,6 @@ void CtrlDisassemblyView::getOpcodeText(u32 address, char* dest)
 {
 	DisassemblyLineInfo line = DisassemblyLineInfo();
 	address = manager.getStartAddress(address);
-	manager.getLine(address,displaySymbols,line);
-	sprintf(dest,"%s  %s",line.name.c_str(),line.params.c_str());
+	manager.getLine(address, displaySymbols, line);
+	sprintf(dest, "%s  %s", line.name.c_str(), line.params.c_str());
 }

--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -1,5 +1,5 @@
 ﻿/*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -799,10 +799,17 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 {
 	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
 
-	if (evt.ControlDown())
-	{
-		switch (evt.GetKeyCode())
+	switch (evt.GetKeyCode())
 		{
+		case 'g':
+		case 'G':
+			{
+				u64 addr;
+				if (!executeExpressionWindow(this, cpu, addr))
+					return;
+				gotoAddress(addr);
+			}
+			break;
 		case 'd':
 		case 'D':
 			toggleBreakpoint(true);
@@ -813,40 +820,21 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 			break;
 		case 'b':
 		case 'B':
-			{
-				BreakpointWindow bpw(this,cpu);
-				if (bpw.ShowModal() == wxID_OK)
-				{
-					bpw.addBreakpoint();
-					postEvent(debEVT_UPDATE,0);
-				}
-			}
-			break;
-		case 'g':
-		case 'G':
-			{
-				u64 addr;
-				if (!executeExpressionWindow(this,cpu,addr))
-					return;
-				gotoAddress(addr);
-			}
-			break;
-		default:
-			evt.Skip();
-			break;
-		}
-	} else {
-		if (evt.GetEventType() == wxEVT_CHAR && evt.GetKeyCode() >= 0x20 && evt.GetKeyCode() < 0x80)
 		{
-			std::string str;
-			str += (char) evt.GetKeyCode();
-
-			assembleOpcode(curAddress,str);
-			return;
+			BreakpointWindow bpw(this, cpu);
+			if (bpw.ShowModal() == wxID_OK)
+			{
+				bpw.addBreakpoint();
+				postEvent(debEVT_UPDATE, 0);
+			}
 		}
-
-		switch (evt.GetKeyCode())
+		break;
+		case 'm':
+		case 'M':
 		{
+			assembleOpcode(curAddress, "");
+		}
+		break;
 		case WXK_LEFT:
 			if (jumpStack.empty())
 			{
@@ -909,7 +897,6 @@ void CtrlDisassemblyView::keydownEvent(wxKeyEvent& evt)
 			evt.Skip();
 			break;
 		}
-	}
 
 	redraw();
 }

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -504,6 +504,15 @@ void CtrlMemView::keydownEvent(wxKeyEvent& evt)
 
 	switch (evt.GetKeyCode())
 	{
+	case 'g':
+	case 'G':
+		{
+			u64 addr;
+			if (!executeExpressionWindow(this, cpu, addr))
+				return;
+			gotoAddress(addr, true);
+		}
+	break;
 	case WXK_LEFT:
 		scrollCursor(-1);
 		break;

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -62,7 +62,8 @@ enum MemoryViewMenuIdentifiers
 };
 
 CtrlMemView::CtrlMemView(wxWindow* parent, DebugInterface* _cpu)
-	: wxWindow(parent,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxWANTS_CHARS|wxVSCROLL), cpu(_cpu)
+	: wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxWANTS_CHARS | wxVSCROLL)
+	, cpu(_cpu)
 {
 	rowHeight = getDebugFontHeight();
 	charWidth = getDebugFontWidth();
@@ -73,65 +74,66 @@ CtrlMemView::CtrlMemView(wxWindow* parent, DebugInterface* _cpu)
 	asciiSelected = false;
 	selectedNibble = 0;
 	addressStart = charWidth;
-	hexStart = addressStart + 9*charWidth;
+	hexStart = addressStart + 9 * charWidth;
 
 	setRowSize(g_Conf->EmuOptions.Debugger.MemoryViewBytesPerRow);
 
 	font = pxGetFixedFont(8);
 	underlineFont = pxGetFixedFont(8, wxFONTWEIGHT_NORMAL, true);
-	font.SetPixelSize(wxSize(charWidth,rowHeight));
-	underlineFont.SetPixelSize(wxSize(charWidth,rowHeight));
+	font.SetPixelSize(wxSize(charWidth, rowHeight));
+	underlineFont.SetPixelSize(wxSize(charWidth, rowHeight));
 
-	menu.Append(ID_MEMVIEW_GOTOINDISASM,		L"Go to in Disasm");
-	menu.Append(ID_MEMVIEW_GOTOADDRESS,			L"Go to address");
-	menu.Append(ID_MEMVIEW_COPYADDRESS,			L"Copy address");
-	menu.Append(ID_MEMVIEW_FOLLOWADDRESS,		L"Follow address");
+	menu.Append(ID_MEMVIEW_GOTOINDISASM, L"Go to in Disasm");
+	menu.Append(ID_MEMVIEW_GOTOADDRESS, L"Go to address");
+	menu.Append(ID_MEMVIEW_COPYADDRESS, L"Copy address");
+	menu.Append(ID_MEMVIEW_FOLLOWADDRESS, L"Follow address");
 	menu.AppendSeparator();
-	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_8,		L"Display as 1 byte");
-	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_16,	L"Display as 2 byte");
-	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_32,	L"Display as 4 byte");
-	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_64,	L"Display as 8 byte");
-	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_128,	L"Display as 16 byte");
+	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_8, L"Display as 1 byte");
+	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_16, L"Display as 2 byte");
+	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_32, L"Display as 4 byte");
+	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_64, L"Display as 8 byte");
+	menu.AppendRadioItem(ID_MEMVIEW_DISPLAYVALUE_128, L"Display as 16 byte");
 	menu.Check(ID_MEMVIEW_DISPLAYVALUE_8, true);
 	menu.AppendSeparator();
-	menu.Append(ID_MEMVIEW_COPYVALUE_8,			L"Copy Value (8 bit)");
-	menu.Append(ID_MEMVIEW_COPYVALUE_16,		L"Copy Value (16 bit)");
-	menu.Append(ID_MEMVIEW_COPYVALUE_32,		L"Copy Value (32 bit)");
-	menu.Append(ID_MEMVIEW_COPYVALUE_64,		L"Copy Value (64 bit)");
-	menu.Append(ID_MEMVIEW_COPYVALUE_128,		L"Copy Value (128 bit)");
+	menu.Append(ID_MEMVIEW_COPYVALUE_8, L"Copy Value (8 bit)");
+	menu.Append(ID_MEMVIEW_COPYVALUE_16, L"Copy Value (16 bit)");
+	menu.Append(ID_MEMVIEW_COPYVALUE_32, L"Copy Value (32 bit)");
+	menu.Append(ID_MEMVIEW_COPYVALUE_64, L"Copy Value (64 bit)");
+	menu.Append(ID_MEMVIEW_COPYVALUE_128, L"Copy Value (128 bit)");
 	menu.AppendSeparator();
 	menu.AppendCheckItem(ID_MEMVIEW_ALIGNWINDOW, L"Align window to row size");
 	menu.Check(ID_MEMVIEW_ALIGNWINDOW, g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart);
 	menu.Bind(wxEVT_MENU, &CtrlMemView::onPopupClick, this);
 
-	SetScrollbar(wxVERTICAL,100,1,201,true);
+	SetScrollbar(wxVERTICAL, 100, 1, 201, true);
 	SetDoubleBuffered(true);
 }
 
-void CtrlMemView::setRowSize(int bytesInRow) {
+void CtrlMemView::setRowSize(int bytesInRow)
+{
 	rowSize = (std::max(16, std::min(256, bytesInRow)) / 16) * 16;
-	asciiStart = hexStart + (rowSize * 3 + 1)*charWidth;
+	asciiStart = hexStart + (rowSize * 3 + 1) * charWidth;
 }
 
 void CtrlMemView::postEvent(wxEventType type, wxString text)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetClientData(cpu);
-   event.SetString(text);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetClientData(cpu);
+	event.SetString(text);
+	wxPostEvent(this, event);
 }
 
 void CtrlMemView::postEvent(wxEventType type, int value)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetClientData(cpu);
-   event.SetInt(value);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetClientData(cpu);
+	event.SetInt(value);
+	wxPostEvent(this, event);
 }
 
-void CtrlMemView::paintEvent(wxPaintEvent & evt)
+void CtrlMemView::paintEvent(wxPaintEvent& evt)
 {
 	wxPaintDC dc(this);
 	render(dc);
@@ -192,7 +194,7 @@ void CtrlMemView::render(wxDC& dc)
 		u32 rowAddress = windowStart + i * rowSize;
 		int rowY = rowHeight * i;
 
-		swprintf(temp, TEMP_SIZE, L"%08X" , rowAddress);
+		swprintf(temp, TEMP_SIZE, L"%08X", rowAddress);
 		dc.SetFont(font);
 		dc.SetTextForeground(COLOR_ADDRESS);
 		dc.DrawText(temp, addressStart, rowY);
@@ -203,13 +205,15 @@ void CtrlMemView::render(wxDC& dc)
 			u8 byteCurrent = 0;
 			bool byteValid = false;
 
-			try {
+			try
+			{
 				byteValid = validCpu && cpu->isValidAddress(byteAddress);
 
 				if (byteValid)
 					byteCurrent = cpu->read8(byteAddress);
 			}
-			catch (Exception::Ps2Generic &) {
+			catch (Exception::Ps2Generic&)
+			{
 				byteValid = false;
 			}
 
@@ -218,7 +222,7 @@ void CtrlMemView::render(wxDC& dc)
 			// calculate group position
 			int groupNum = j / byteGroupSize;
 			int groupPosX = hexStart + groupNum * byteGroupSize * 3 * charWidth;
-			
+
 			// calculate symbol position in group
 			int groupIndex = j % byteGroupSize;
 
@@ -230,12 +234,15 @@ void CtrlMemView::render(wxDC& dc)
 			if (curAddress >= groupAddress && curAddress < groupAddress + byteGroupSize)
 			{
 				// if group selected, draw rectangle behind
-				if (groupIndex == 0) {
-					if (hasFocus && !asciiSelected) {
+				if (groupIndex == 0)
+				{
+					if (hasFocus && !asciiSelected)
+					{
 						dc.SetPen(COLOR_SELECTED_BG);
 						dc.SetBrush(COLOR_SELECTED_BG);
 					}
-					else {
+					else
+					{
 						dc.SetPen(COLOR_SELECTED_INACTIVE_BG);
 						dc.SetBrush(COLOR_SELECTED_INACTIVE_BG);
 					}
@@ -245,10 +252,11 @@ void CtrlMemView::render(wxDC& dc)
 
 				backgroundIsDark = hasFocus && !asciiSelected;
 			}
-			if (groupAddress + groupIndex == referencedAddress) {
+			if (groupAddress + groupIndex == referencedAddress)
+			{
 				dc.SetPen(COLOR_REFRENCE_BG);
 				dc.SetBrush(COLOR_REFRENCE_BG);
-				dc.DrawRectangle(symbolPosX, rowY, charWidth*2, rowHeight);
+				dc.DrawRectangle(symbolPosX, rowY, charWidth * 2, rowHeight);
 				backgroundIsDark = false;
 			}
 
@@ -256,7 +264,8 @@ void CtrlMemView::render(wxDC& dc)
 
 			swprintf(temp, TEMP_SIZE, byteValid ? L"%02X" : L"??", byteCurrent);
 			// if selected byte, need hint current nibble
-			if (byteAddress == curAddress) {
+			if (byteAddress == curAddress)
+			{
 				if (selectedNibble == 1)
 					dc.SetFont(underlineFont);
 
@@ -273,38 +282,43 @@ void CtrlMemView::render(wxDC& dc)
 				if (selectedNibble == 0)
 					dc.SetFont(font);
 			}
-			else {
+			else
+			{
 				dc.DrawText(temp, symbolPosX, rowY);
 			}
-						
+
 			// draw in ansii text representation table
 			temp[1] = 0;
 			temp[0] = (!byteValid || byteCurrent < 32 || byteCurrent > 128) ? '.' : byteCurrent;
 
-			if (byteAddress == curAddress) {
-				if (hasFocus && asciiSelected) {
+			if (byteAddress == curAddress)
+			{
+				if (hasFocus && asciiSelected)
+				{
 					dc.SetPen(COLOR_SELECTED_BG);
 					dc.SetBrush(COLOR_SELECTED_BG);
 					dc.SetTextForeground(COLOR_WHITE);
 				}
-				else {
+				else
+				{
 					dc.SetPen(COLOR_SELECTED_INACTIVE_BG);
 					dc.SetBrush(COLOR_SELECTED_INACTIVE_BG);
 					dc.SetTextForeground(COLOR_BLACK);
 				}
-				dc.DrawRectangle(asciiStart + j*(charWidth + 2), rowY, charWidth, rowHeight);
+				dc.DrawRectangle(asciiStart + j * (charWidth + 2), rowY, charWidth, rowHeight);
 			}
-			else {
+			else
+			{
 				dc.SetTextForeground(COLOR_BLACK);
 			}
-			
-			dc.DrawText(temp, asciiStart + j*(charWidth + 2), rowY);
+
+			dc.DrawText(temp, asciiStart + j * (charWidth + 2), rowY);
 		}
 	}
 
 	dc.SetPen(COLOR_DELIMETER);
 	dc.SetBrush(COLOR_DELIMETER);
-	int linestep = std::max((u32) 4, byteGroupSize);
+	int linestep = std::max((u32)4, byteGroupSize);
 	for (int i = linestep; i < rowSize; i += linestep)
 	{
 		int x = hexStart + i * 3 * charWidth - charWidth / 2;
@@ -319,104 +333,105 @@ void CtrlMemView::onPopupClick(wxCommandEvent& evt)
 
 	switch (evt.GetId())
 	{
-	case ID_MEMVIEW_COPYADDRESS:
-		if (wxTheClipboard->Open())
-		{
-			swprintf(str,64,L"%08X",curAddress);
-			wxTheClipboard->SetData(new wxTextDataObject(str));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_MEMVIEW_GOTOINDISASM:
-		postEvent(debEVT_GOTOINDISASM,1);
-		break;
-	case ID_MEMVIEW_GOTOADDRESS:
-		postEvent(debEVT_GOTOADDRESS, curAddress);
-		break;
-	case ID_MEMVIEW_FOLLOWADDRESS:
-		gotoAddress(cpu->read32(curAddress), true);
-		break;
-	case ID_MEMVIEW_DISPLAYVALUE_8:
-		byteGroupSize = 1;
-		Refresh();
-		break;
-	case ID_MEMVIEW_DISPLAYVALUE_16:
-		byteGroupSize = 2;
-		Refresh();
-		break;
-	case ID_MEMVIEW_DISPLAYVALUE_32:
-		byteGroupSize = 4;
-		Refresh();
-		break;
-	case ID_MEMVIEW_DISPLAYVALUE_64:
-		byteGroupSize = 8;
-		Refresh();
-		break;
-	case ID_MEMVIEW_DISPLAYVALUE_128:
-		byteGroupSize = 16;
-		Refresh();
-		break;
-	case ID_MEMVIEW_COPYVALUE_8:
-		if (wxTheClipboard->Open())
-		{
-			swprintf(str,64,L"%02X",cpu->read8(curAddress));
-			wxTheClipboard->SetData(new wxTextDataObject(str));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_MEMVIEW_COPYVALUE_16:
-		if (wxTheClipboard->Open())
-		{
-			swprintf(str,64,L"%04X",cpu->read16(curAddress));
-			wxTheClipboard->SetData(new wxTextDataObject(str));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_MEMVIEW_COPYVALUE_32:
-		if (wxTheClipboard->Open())
-		{
-			swprintf(str,64,L"%08X",cpu->read32(curAddress));
-			wxTheClipboard->SetData(new wxTextDataObject(str));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_MEMVIEW_COPYVALUE_64:
-		if (wxTheClipboard->Open())
-		{
-			swprintf(str,64,L"%016llX",cpu->read64(curAddress));
-			wxTheClipboard->SetData(new wxTextDataObject(str));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_MEMVIEW_COPYVALUE_128:
-		if (wxTheClipboard->Open())
-		{
-			u128 value = cpu->read128(curAddress);
-			swprintf(str,64,L"%016llX%016llX",value._u64[1],value._u64[0]);
-			wxTheClipboard->SetData(new wxTextDataObject(str));
-			wxTheClipboard->Close();
-		}
-		break;
-	case ID_MEMVIEW_ALIGNWINDOW:
-		g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart = evt.IsChecked();
-		if (g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart) {
-			windowStart -= windowStart % rowSize;
-			redraw();
-		}
-		break;
+		case ID_MEMVIEW_COPYADDRESS:
+			if (wxTheClipboard->Open())
+			{
+				swprintf(str, 64, L"%08X", curAddress);
+				wxTheClipboard->SetData(new wxTextDataObject(str));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_MEMVIEW_GOTOINDISASM:
+			postEvent(debEVT_GOTOINDISASM, 1);
+			break;
+		case ID_MEMVIEW_GOTOADDRESS:
+			postEvent(debEVT_GOTOADDRESS, curAddress);
+			break;
+		case ID_MEMVIEW_FOLLOWADDRESS:
+			gotoAddress(cpu->read32(curAddress), true);
+			break;
+		case ID_MEMVIEW_DISPLAYVALUE_8:
+			byteGroupSize = 1;
+			Refresh();
+			break;
+		case ID_MEMVIEW_DISPLAYVALUE_16:
+			byteGroupSize = 2;
+			Refresh();
+			break;
+		case ID_MEMVIEW_DISPLAYVALUE_32:
+			byteGroupSize = 4;
+			Refresh();
+			break;
+		case ID_MEMVIEW_DISPLAYVALUE_64:
+			byteGroupSize = 8;
+			Refresh();
+			break;
+		case ID_MEMVIEW_DISPLAYVALUE_128:
+			byteGroupSize = 16;
+			Refresh();
+			break;
+		case ID_MEMVIEW_COPYVALUE_8:
+			if (wxTheClipboard->Open())
+			{
+				swprintf(str, 64, L"%02X", cpu->read8(curAddress));
+				wxTheClipboard->SetData(new wxTextDataObject(str));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_MEMVIEW_COPYVALUE_16:
+			if (wxTheClipboard->Open())
+			{
+				swprintf(str, 64, L"%04X", cpu->read16(curAddress));
+				wxTheClipboard->SetData(new wxTextDataObject(str));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_MEMVIEW_COPYVALUE_32:
+			if (wxTheClipboard->Open())
+			{
+				swprintf(str, 64, L"%08X", cpu->read32(curAddress));
+				wxTheClipboard->SetData(new wxTextDataObject(str));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_MEMVIEW_COPYVALUE_64:
+			if (wxTheClipboard->Open())
+			{
+				swprintf(str, 64, L"%016llX", cpu->read64(curAddress));
+				wxTheClipboard->SetData(new wxTextDataObject(str));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_MEMVIEW_COPYVALUE_128:
+			if (wxTheClipboard->Open())
+			{
+				u128 value = cpu->read128(curAddress);
+				swprintf(str, 64, L"%016llX%016llX", value._u64[1], value._u64[0]);
+				wxTheClipboard->SetData(new wxTextDataObject(str));
+				wxTheClipboard->Close();
+			}
+			break;
+		case ID_MEMVIEW_ALIGNWINDOW:
+			g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart = evt.IsChecked();
+			if (g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart)
+			{
+				windowStart -= windowStart % rowSize;
+				redraw();
+			}
+			break;
 	}
 }
 
 void CtrlMemView::mouseEvent(wxMouseEvent& evt)
 {
 	// left button
-	if (evt.GetEventType() == wxEVT_LEFT_DOWN || evt.GetEventType() == wxEVT_LEFT_DCLICK
-		|| evt.GetEventType() == wxEVT_RIGHT_DOWN || evt.GetEventType() == wxEVT_RIGHT_DCLICK)
+	if (evt.GetEventType() == wxEVT_LEFT_DOWN || evt.GetEventType() == wxEVT_LEFT_DCLICK || evt.GetEventType() == wxEVT_RIGHT_DOWN || evt.GetEventType() == wxEVT_RIGHT_DCLICK)
 	{
-		gotoPoint(evt.GetPosition().x,evt.GetPosition().y);
+		gotoPoint(evt.GetPosition().x, evt.GetPosition().y);
 		SetFocus();
 		SetFocusFromKbd();
-	} else if (evt.GetEventType() == wxEVT_RIGHT_UP)
+	}
+	else if (evt.GetEventType() == wxEVT_RIGHT_UP)
 	{
 		curAddress -= (curAddress - windowStart) % byteGroupSize;
 
@@ -428,35 +443,43 @@ void CtrlMemView::mouseEvent(wxMouseEvent& evt)
 		menu.Check(ID_MEMVIEW_DISPLAYVALUE_64, byteGroupSize == 8);
 		menu.Check(ID_MEMVIEW_DISPLAYVALUE_128, byteGroupSize == 16);
 
-		menu.Enable(ID_MEMVIEW_COPYVALUE_128,(curAddress & 15) == 0);
-		menu.Enable(ID_MEMVIEW_COPYVALUE_64,(curAddress & 7) == 0);
-		menu.Enable(ID_MEMVIEW_COPYVALUE_32,(curAddress & 3) == 0);
-		menu.Enable(ID_MEMVIEW_COPYVALUE_16,(curAddress & 1) == 0);
+		menu.Enable(ID_MEMVIEW_COPYVALUE_128, (curAddress & 15) == 0);
+		menu.Enable(ID_MEMVIEW_COPYVALUE_64, (curAddress & 7) == 0);
+		menu.Enable(ID_MEMVIEW_COPYVALUE_32, (curAddress & 3) == 0);
+		menu.Enable(ID_MEMVIEW_COPYVALUE_16, (curAddress & 1) == 0);
 
 		menu.Check(ID_MEMVIEW_ALIGNWINDOW, g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart);
 
 		PopupMenu(&menu);
 		return;
-	} else if (evt.GetEventType() == wxEVT_MOUSEWHEEL)
+	}
+	else if (evt.GetEventType() == wxEVT_MOUSEWHEEL)
 	{
-		if (evt.ControlDown()) {
-			if (evt.GetWheelRotation() > 0) {
+		if (evt.ControlDown())
+		{
+			if (evt.GetWheelRotation() > 0)
+			{
 				setRowSize(rowSize + 16);
 			}
-			else {
+			else
+			{
 				setRowSize(rowSize - 16);
 			}
 		}
-		else {
+		else
+		{
 			if (evt.GetWheelRotation() > 0)
 			{
 				scrollWindow(-3);
 			}
-			else if (evt.GetWheelRotation() < 0) {
+			else if (evt.GetWheelRotation() < 0)
+			{
 				scrollWindow(3);
 			}
 		}
-	} else {
+	}
+	else
+	{
 		evt.Skip();
 		return;
 	}
@@ -470,76 +493,77 @@ void CtrlMemView::keydownEvent(wxKeyEvent& evt)
 	{
 		switch (evt.GetKeyCode())
 		{
-		case 'g':
-		case 'G':
+			case 'g':
+			case 'G':
 			{
 				u64 addr;
-				if (!executeExpressionWindow(this,cpu,addr))
+				if (!executeExpressionWindow(this, cpu, addr))
 					return;
 
 				gotoAddress(addr, true);
 			}
 			break;
-		case 'b':
-		case 'B':
+			case 'b':
+			case 'B':
 			{
-				BreakpointWindow bpw(this,cpu);
+				BreakpointWindow bpw(this, cpu);
 				if (bpw.ShowModal() == wxID_OK)
 				{
 					bpw.addBreakpoint();
-					postEvent(debEVT_UPDATE,0);
+					postEvent(debEVT_UPDATE, 0);
 				}
 			}
 			break;
-		case 'v':
-		case 'V':
-			pasteHex();
-			break;
-		default:
-			evt.Skip();
-			break;
+			case 'v':
+			case 'V':
+				pasteHex();
+				break;
+			default:
+				evt.Skip();
+				break;
 		}
 		return;
 	}
 
 	switch (evt.GetKeyCode())
 	{
-	case 'g':
-	case 'G':
+		case 'g':
+		case 'G':
 		{
 			u64 addr;
 			if (!executeExpressionWindow(this, cpu, addr))
 				return;
 			gotoAddress(addr, true);
 		}
-	break;
-	case WXK_LEFT:
-		scrollCursor(-1);
 		break;
-	case WXK_RIGHT:
-		scrollCursor(1);
-		break;
-	case WXK_UP:
-		scrollCursor(-rowSize);
-		break;
-	case WXK_DOWN:
-		scrollCursor(rowSize);
-		break;
-	case WXK_PAGEUP:
-		scrollWindow(-GetClientSize().y/rowHeight);
-		break;
-	case WXK_PAGEDOWN:
-		scrollWindow(GetClientSize().y/rowHeight);
-		break;
-	case WXK_ESCAPE:
-		if (!history.empty()) {
-			gotoAddress(history.top());
-			history.pop();
-		}
-		break;
-	default:
-		evt.Skip();
-		break;
+		case WXK_LEFT:
+			scrollCursor(-1);
+			break;
+		case WXK_RIGHT:
+			scrollCursor(1);
+			break;
+		case WXK_UP:
+			scrollCursor(-rowSize);
+			break;
+		case WXK_DOWN:
+			scrollCursor(rowSize);
+			break;
+		case WXK_PAGEUP:
+			scrollWindow(-GetClientSize().y / rowHeight);
+			break;
+		case WXK_PAGEDOWN:
+			scrollWindow(GetClientSize().y / rowHeight);
+			break;
+		case WXK_ESCAPE:
+			if (!history.empty())
+			{
+				gotoAddress(history.top());
+				history.pop();
+			}
+			break;
+		default:
+			evt.Skip();
+			break;
 	}
 }
 
@@ -561,23 +585,27 @@ void CtrlMemView::charEvent(wxKeyEvent& evt)
 	if (asciiSelected)
 	{
 		u8 newValue = evt.GetKeyCode();
-		cpu->write8(curAddress,newValue);
+		cpu->write8(curAddress, newValue);
 		scrollCursor(1);
-	} else {
+	}
+	else
+	{
 		u8 key = tolower(evt.GetKeyCode());
 		int inputValue = -1;
 
-		if (key >= '0' && key <= '9') inputValue = key - '0';
-		if (key >= 'a' && key <= 'f') inputValue = key -'a' + 10;
+		if (key >= '0' && key <= '9')
+			inputValue = key - '0';
+		if (key >= 'a' && key <= 'f')
+			inputValue = key - 'a' + 10;
 
 		if (inputValue >= 0)
 		{
-			int shiftAmount = (1-selectedNibble)*4;
+			int shiftAmount = (1 - selectedNibble) * 4;
 
 			u8 oldValue = cpu->read8(curAddress);
 			oldValue &= ~(0xF << shiftAmount);
 			u8 newValue = oldValue | (inputValue << shiftAmount);
-			cpu->write8(curAddress,newValue);
+			cpu->write8(curAddress, newValue);
 			scrollCursor(1);
 		}
 	}
@@ -593,24 +621,27 @@ void CtrlMemView::scrollbarEvent(wxScrollWinEvent& evt)
 	if (type == wxEVT_SCROLLWIN_LINEUP)
 	{
 		scrollCursor(-rowSize);
-	} else if (type == wxEVT_SCROLLWIN_LINEDOWN)
+	}
+	else if (type == wxEVT_SCROLLWIN_LINEDOWN)
 	{
 		scrollCursor(rowSize);
-	} else if (type == wxEVT_SCROLLWIN_PAGEUP)
-	{
-		scrollWindow(-GetClientSize().y/rowHeight);
-	} else if (type == wxEVT_SCROLLWIN_PAGEDOWN)
-	{
-		scrollWindow(GetClientSize().y/rowHeight);
 	}
-	
+	else if (type == wxEVT_SCROLLWIN_PAGEUP)
+	{
+		scrollWindow(-GetClientSize().y / rowHeight);
+	}
+	else if (type == wxEVT_SCROLLWIN_PAGEDOWN)
+	{
+		scrollWindow(GetClientSize().y / rowHeight);
+	}
+
 	redraw();
 }
 
 void CtrlMemView::scrollWindow(int lines)
 {
-	windowStart += lines*rowSize;
-	curAddress += lines*rowSize;
+	windowStart += lines * rowSize;
+	curAddress += lines * rowSize;
 	redraw();
 }
 
@@ -622,34 +653,40 @@ void CtrlMemView::scrollCursor(int bytes)
 		{
 			selectedNibble = 1;
 			bytes = 0;
-		} else {
+		}
+		else
+		{
 			selectedNibble = 0;
 		}
-	} else if (!asciiSelected && bytes == -1)
+	}
+	else if (!asciiSelected && bytes == -1)
 	{
 		if (selectedNibble == 0)
 		{
 			selectedNibble = 1;
-		} else {
+		}
+		else
+		{
 			selectedNibble = 0;
 			bytes = 0;
 		}
-	} 
+	}
 
 	curAddress += bytes;
-	
-	int visibleRows = GetClientSize().y/rowHeight;
-	u32 windowEnd = windowStart+visibleRows*rowSize;
+
+	int visibleRows = GetClientSize().y / rowHeight;
+	u32 windowEnd = windowStart + visibleRows * rowSize;
 
 	if (curAddress < windowStart)
 	{
 		windowStart = (curAddress / rowSize) * rowSize;
-	} else if (curAddress >= windowEnd)
+	}
+	else if (curAddress >= windowEnd)
 	{
-		windowStart = curAddress - (visibleRows - 1)*rowSize;
+		windowStart = curAddress - (visibleRows - 1) * rowSize;
 		windowStart = (windowStart / rowSize) * rowSize;
 	}
-	
+
 	updateStatusBarText();
 	redraw();
 }
@@ -663,7 +700,7 @@ void CtrlMemView::updateStatusBarText()
 
 	swprintf(text, 64, L"%08X %08X", curAddress, addr);
 
-	postEvent(debEVT_SETSTATUSBARTEXT,text);
+	postEvent(debEVT_SETSTATUSBARTEXT, text);
 }
 
 void CtrlMemView::gotoAddress(u32 addr, bool pushInHistory)
@@ -674,13 +711,16 @@ void CtrlMemView::gotoAddress(u32 addr, bool pushInHistory)
 	curAddress = addr;
 	selectedNibble = 0;
 
-	if (g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart) {
+	if (g_Conf->EmuOptions.Debugger.AlignMemoryWindowStart)
+	{
 		int visibleRows = GetClientSize().y / rowHeight;
-		u32 windowEnd = windowStart + visibleRows*rowSize;
+		u32 windowEnd = windowStart + visibleRows * rowSize;
 
 		if (curAddress < windowStart || curAddress >= windowEnd)
 			windowStart = (curAddress / rowSize) * rowSize;
-	} else {
+	}
+	else
+	{
 		windowStart = curAddress;
 	}
 
@@ -690,22 +730,24 @@ void CtrlMemView::gotoAddress(u32 addr, bool pushInHistory)
 
 void CtrlMemView::gotoPoint(int x, int y)
 {
-	int line = y/rowHeight;
-	int lineAddress = windowStart+line*rowSize;
+	int line = y / rowHeight;
+	int lineAddress = windowStart + line * rowSize;
 
 	if (x >= asciiStart)
 	{
-		int col = (x-asciiStart) / (charWidth+2);
-		if (col >= rowSize) return;
-		
+		int col = (x - asciiStart) / (charWidth + 2);
+		if (col >= rowSize)
+			return;
+
 		asciiSelected = true;
-		curAddress = lineAddress+col;
+		curAddress = lineAddress + col;
 		selectedNibble = 0;
 		updateStatusBarText();
 		redraw();
-	} else if (x >= hexStart)
+	}
+	else if (x >= hexStart)
 	{
-		int col = (x-hexStart);
+		int col = (x - hexStart);
 
 		int groupWidth = byteGroupSize * charWidth * 3;
 		int group = col / groupWidth;
@@ -713,10 +755,11 @@ void CtrlMemView::gotoPoint(int x, int y)
 		int posInGroup = col % groupWidth;
 
 		int indexInGroup = -1;
-		
-		for (int i = 0; i < int(byteGroupSize); i++) {
+
+		for (int i = 0; i < int(byteGroupSize); i++)
+		{
 			int start = hexGroupPositionFromIndex(i);
-			int end = start + 2 * charWidth -1;
+			int end = start + 2 * charWidth - 1;
 			if (posInGroup < start)
 			{
 				return;
@@ -740,7 +783,8 @@ void CtrlMemView::gotoPoint(int x, int y)
 	}
 }
 
-void CtrlMemView::updateReference(u32 address) {
+void CtrlMemView::updateReference(u32 address)
+{
 	referencedAddress = address;
 	redraw();
 }
@@ -771,13 +815,14 @@ void CtrlMemView::pasteHex()
 				{
 					cpu->write8(curAddress + i, static_cast<u8>(byte));
 				}
-				else {
+				else
+				{
 					break;
 				}
 			}
 			scrollCursor(i);
 
-			if(active)
+			if (active)
 				cpu->resumeCpu();
 		}
 		wxTheClipboard->Close();

--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -169,6 +169,7 @@ enum BreakpointListMenuIdentifiers
 {
 	ID_BREAKPOINTLIST_ENABLE = 1,
 	ID_BREAKPOINTLIST_EDIT,
+	ID_BREAKPOINTLIST_DELETE,
 	ID_BREAKPOINTLIST_ADDNEW,
 };
 
@@ -458,6 +459,9 @@ void BreakpointList::onPopupClick(wxCommandEvent& evt)
 	case ID_BREAKPOINTLIST_EDIT:
 		editBreakpoint(index);
 		break;
+	case ID_BREAKPOINTLIST_DELETE:
+		removeBreakpoint(index);
+		break;
 	case ID_BREAKPOINTLIST_ADDNEW:
 		postEvent(debEVT_BREAKPOINTWINDOW,0);
 		break;
@@ -477,6 +481,7 @@ void BreakpointList::showMenu(const wxPoint& pos)
 	{
 		menu.AppendCheckItem(ID_BREAKPOINTLIST_ENABLE,	L"Enable");
 		menu.Append(ID_BREAKPOINTLIST_EDIT,				L"Edit");
+		menu.Append(ID_BREAKPOINTLIST_DELETE,			L"Delete");
 		menu.AppendSeparator();
 
 		// check if the breakpoint is enabled

--- a/pcsx2/gui/Debugger/DebuggerLists.cpp
+++ b/pcsx2/gui/Debugger/DebuggerLists.cpp
@@ -24,11 +24,11 @@ wxBEGIN_EVENT_TABLE(GenericListView, wxWindow)
 	EVT_RIGHT_DOWN(GenericListView::mouseEvent)
 	EVT_RIGHT_UP(GenericListView::mouseEvent)
 	EVT_LEFT_DCLICK(GenericListView::mouseEvent)
-	EVT_LIST_ITEM_RIGHT_CLICK(wxID_ANY,GenericListView::listEvent)
+	EVT_LIST_ITEM_RIGHT_CLICK(wxID_ANY, GenericListView::listEvent)
 wxEND_EVENT_TABLE()
 
 GenericListView::GenericListView(wxWindow* parent, GenericListViewColumn* columns, int columnCount)
-	: wxListView(parent,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxLC_VIRTUAL|wxLC_REPORT|wxLC_SINGLE_SEL|wxNO_BORDER)
+	: wxListView(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_VIRTUAL | wxLC_REPORT | wxLC_SINGLE_SEL | wxNO_BORDER)
 {
 	m_isInResizeColumn = false;
 	dontResizeColumnsInSizeEventHandler = false;
@@ -46,7 +46,7 @@ void GenericListView::insertColumns(GenericListViewColumn* columns, int count)
 		column.SetText(columns[i].name);
 		column.SetWidth(totalWidth * columns[i].size);
 
-		InsertColumn(i,column);
+		InsertColumn(i, column);
 	}
 
 	this->columns = columns;
@@ -54,7 +54,8 @@ void GenericListView::insertColumns(GenericListViewColumn* columns, int count)
 
 void GenericListView::resizeColumn(int col, int width)
 {
-	if (!m_isInResizeColumn) {
+	if (!m_isInResizeColumn)
+	{
 		m_isInResizeColumn = true;
 
 		SetColumnWidth(col, width);
@@ -87,18 +88,20 @@ void GenericListView::keydownEvent(wxKeyEvent& evt)
 	int sel = GetFirstSelected();
 	switch (evt.GetKeyCode())
 	{
-	case WXK_UP:
-		if (sel > 0) {
-			Select(sel-1);
-			Focus(sel-1);
-		}
-		break;
-	case WXK_DOWN:
-		if (sel+1 < GetItemCount()) {
-			Select(sel+1);
-			Focus(sel+1);
-		}
-		break;
+		case WXK_UP:
+			if (sel > 0)
+			{
+				Select(sel - 1);
+				Focus(sel - 1);
+			}
+			break;
+		case WXK_DOWN:
+			if (sel + 1 < GetItemCount())
+			{
+				Select(sel + 1);
+				Focus(sel + 1);
+			}
+			break;
 	}
 
 	onKeyDown(evt.GetKeyCode());
@@ -126,15 +129,15 @@ void GenericListView::update()
 
 wxString GenericListView::OnGetItemText(long item, long col) const
 {
-	return getColumnText(item,col);
+	return getColumnText(item, col);
 }
 
 void GenericListView::postEvent(wxEventType type, int value)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetInt(value);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetInt(value);
+	wxPostEvent(this, event);
 }
 
 void GenericListView::mouseEvent(wxMouseEvent& evt)
@@ -145,25 +148,37 @@ void GenericListView::mouseEvent(wxMouseEvent& evt)
 	{
 		clickPos = evt.GetPosition();
 		evt.Skip();
-	} else if (type == wxEVT_RIGHT_UP)
+	}
+	else if (type == wxEVT_RIGHT_UP)
 	{
-		onRightClick(GetFirstSelected(),evt.GetPosition());
-	} else if (type == wxEVT_LEFT_DCLICK)
+		onRightClick(GetFirstSelected(), evt.GetPosition());
+	}
+	else if (type == wxEVT_LEFT_DCLICK)
 	{
-		onDoubleClick(GetFirstSelected(),evt.GetPosition());
+		onDoubleClick(GetFirstSelected(), evt.GetPosition());
 	}
 }
 
 void GenericListView::listEvent(wxListEvent& evt)
 {
-	onRightClick(GetFirstSelected(),clickPos);
+	onRightClick(GetFirstSelected(), clickPos);
 }
 
 //
 // BreakpointList
 //
 
-enum { BPL_TYPE, BPL_OFFSET, BPL_SIZELABEL, BPL_OPCODE, BPL_CONDITION, BPL_HITS, BPL_ENABLED, BPL_COLUMNCOUNT };
+enum
+{
+	BPL_TYPE,
+	BPL_OFFSET,
+	BPL_SIZELABEL,
+	BPL_OPCODE,
+	BPL_CONDITION,
+	BPL_HITS,
+	BPL_ENABLED,
+	BPL_COLUMNCOUNT
+};
 
 enum BreakpointListMenuIdentifiers
 {
@@ -174,17 +189,18 @@ enum BreakpointListMenuIdentifiers
 };
 
 GenericListViewColumn breakpointColumns[BPL_COLUMNCOUNT] = {
-	{ L"Type",			0.12f },
-	{ L"Offset",		0.12f },
-	{ L"Size/Label",	0.18f },
-	{ L"Opcode",		0.28f },
-	{ L"Condition",		0.17f },
-	{ L"Hits",			0.05f },
-	{ L"Enabled",		0.08f }
-};
+	{L"Type", 0.12f},
+	{L"Offset", 0.12f},
+	{L"Size/Label", 0.18f},
+	{L"Opcode", 0.28f},
+	{L"Condition", 0.17f},
+	{L"Hits", 0.05f},
+	{L"Enabled", 0.08f}};
 
 BreakpointList::BreakpointList(wxWindow* parent, DebugInterface* _cpu, CtrlDisassemblyView* _disassembly)
-	: GenericListView(parent,breakpointColumns,BPL_COLUMNCOUNT), cpu(_cpu),disasm(_disassembly)
+	: GenericListView(parent, breakpointColumns, BPL_COLUMNCOUNT)
+	, cpu(_cpu)
+	, disasm(_disassembly)
 {
 }
 
@@ -193,11 +209,13 @@ int BreakpointList::getRowCount()
 	int count = 0;
 	for (size_t i = 0; i < CBreakPoints::GetMemChecks().size(); i++)
 	{
-		if (displayedMemChecks_[i].cpu == cpu->getCpuType()) count++;
+		if (displayedMemChecks_[i].cpu == cpu->getCpuType())
+			count++;
 	}
 	for (size_t i = 0; i < CBreakPoints::GetBreakpoints().size(); i++)
 	{
-		if (!displayedBreakPoints_[i].temporary && displayedBreakPoints_[i].cpu == cpu->getCpuType()) count++;
+		if (!displayedBreakPoints_[i].temporary && displayedBreakPoints_[i].cpu == cpu->getCpuType())
+			count++;
 	}
 
 	return count;
@@ -207,106 +225,131 @@ wxString BreakpointList::getColumnText(int item, int col) const
 {
 	FastFormatUnicode dest;
 	bool isMemory;
-	int index = getBreakpointIndex(item,isMemory);
-	if (index == -1) return L"Invalid";
-		
+	int index = getBreakpointIndex(item, isMemory);
+	if (index == -1)
+		return L"Invalid";
+
 	switch (col)
 	{
-	case BPL_TYPE:
+		case BPL_TYPE:
 		{
-			if (isMemory) {
-				switch ((int)displayedMemChecks_[index].cond) {
-				case MEMCHECK_READ:
-					dest.Write("Read");
-					break;
-				case MEMCHECK_WRITE:
-					dest.Write("Write");
-					break;
-				case MEMCHECK_READWRITE:
-					dest.Write("Read/Write");
-					break;
-				case MEMCHECK_WRITE | MEMCHECK_WRITE_ONCHANGE:
-					dest.Write("Write Change");
-					break;
-				case MEMCHECK_READWRITE | MEMCHECK_WRITE_ONCHANGE:
-					dest.Write("Read/Write Change");
-					break;
+			if (isMemory)
+			{
+				switch ((int)displayedMemChecks_[index].cond)
+				{
+					case MEMCHECK_READ:
+						dest.Write("Read");
+						break;
+					case MEMCHECK_WRITE:
+						dest.Write("Write");
+						break;
+					case MEMCHECK_READWRITE:
+						dest.Write("Read/Write");
+						break;
+					case MEMCHECK_WRITE | MEMCHECK_WRITE_ONCHANGE:
+						dest.Write("Write Change");
+						break;
+					case MEMCHECK_READWRITE | MEMCHECK_WRITE_ONCHANGE:
+						dest.Write("Read/Write Change");
+						break;
 				}
-			} else {
+			}
+			else
+			{
 				dest.Write(L"Execute");
 			}
 		}
 		break;
-	case BPL_OFFSET:
+		case BPL_OFFSET:
 		{
-			if (isMemory) {
-				dest.Write("0x%08X",displayedMemChecks_[index].start);
-			} else {
-				dest.Write("0x%08X",displayedBreakPoints_[index].addr);
+			if (isMemory)
+			{
+				dest.Write("0x%08X", displayedMemChecks_[index].start);
+			}
+			else
+			{
+				dest.Write("0x%08X", displayedBreakPoints_[index].addr);
 			}
 		}
 		break;
-	case BPL_SIZELABEL:
+		case BPL_SIZELABEL:
 		{
-			if (isMemory) {
+			if (isMemory)
+			{
 				auto mc = displayedMemChecks_[index];
 				if (mc.end == 0)
-					dest.Write("0x%08X",1);
+					dest.Write("0x%08X", 1);
 				else
-					dest.Write("0x%08X",mc.end-mc.start);
-			} else {
+					dest.Write("0x%08X", mc.end - mc.start);
+			}
+			else
+			{
 				const std::string sym = symbolMap.GetLabelString(displayedBreakPoints_[index].addr);
 				if (!sym.empty())
 				{
-					dest.Write("%s",sym.c_str());
-				} else {
+					dest.Write("%s", sym.c_str());
+				}
+				else
+				{
 					dest.Write("-");
 				}
 			}
 		}
 		break;
-	case BPL_OPCODE:
+		case BPL_OPCODE:
 		{
-			if (isMemory) {
+			if (isMemory)
+			{
 				dest.Write(L"-");
-			} else {
+			}
+			else
+			{
 				if (!cpu->isAlive())
 					break;
 				char temp[256];
 				disasm->getOpcodeText(displayedBreakPoints_[index].addr, temp);
-				dest.Write("%s",temp);
+				dest.Write("%s", temp);
 			}
 		}
 		break;
-	case BPL_CONDITION:
+		case BPL_CONDITION:
 		{
-			if (isMemory || !displayedBreakPoints_[index].hasCond) {
-				dest.Write("-");
-			} else {
-				dest.Write("%s",displayedBreakPoints_[index].cond.expressionString);
-			}
-		}
-		break;
-	case BPL_HITS:
-		{
-			if (isMemory) {
-				dest.Write("%d",displayedMemChecks_[index].numHits);
-			} else {
+			if (isMemory || !displayedBreakPoints_[index].hasCond)
+			{
 				dest.Write("-");
 			}
-		}
-		break;
-	case BPL_ENABLED:
-		{
-			if (isMemory) {
-				dest.Write("%s",displayedMemChecks_[index].result & MEMCHECK_BREAK ? "true" : "false");
-			} else {
-				dest.Write("%s",displayedBreakPoints_[index].enabled ? "true" : "false");
+			else
+			{
+				dest.Write("%s", displayedBreakPoints_[index].cond.expressionString);
 			}
 		}
 		break;
-	default:
-		return L"Invalid";
+		case BPL_HITS:
+		{
+			if (isMemory)
+			{
+				dest.Write("%d", displayedMemChecks_[index].numHits);
+			}
+			else
+			{
+				dest.Write("-");
+			}
+		}
+		break;
+		case BPL_ENABLED:
+		{
+			if (isMemory)
+			{
+				dest.Write("%s", displayedMemChecks_[index].result & MEMCHECK_BREAK ? "true" : "false");
+			}
+			else
+			{
+				dest.Write("%s", displayedBreakPoints_[index].enabled ? "true" : "false");
+			}
+		}
+		break;
+		default:
+			return L"Invalid";
 	}
 
 	return dest;
@@ -317,15 +360,15 @@ void BreakpointList::onKeyDown(int key)
 	int sel = GetFirstSelected();
 	switch (key)
 	{
-	case WXK_DELETE:
-		removeBreakpoint(sel);
-		break;
-	case WXK_RETURN:
-		editBreakpoint(sel);
-		break;
-	case WXK_SPACE:
-		toggleEnabled(sel);
-		break;
+		case WXK_DELETE:
+			removeBreakpoint(sel);
+			break;
+		case WXK_RETURN:
+			editBreakpoint(sel);
+			break;
+		case WXK_SPACE:
+			toggleEnabled(sel);
+			break;
 	}
 }
 
@@ -334,7 +377,8 @@ int BreakpointList::getBreakpointIndex(int itemIndex, bool& isMemory) const
 	// memory breakpoints first
 	for (size_t i = 0; i < displayedMemChecks_.size(); i++)
 	{
-		if (displayedMemChecks_[i].cpu != cpu->getCpuType()) continue;
+		if (displayedMemChecks_[i].cpu != cpu->getCpuType())
+			continue;
 		if (itemIndex == 0)
 		{
 			isMemory = true;
@@ -370,7 +414,7 @@ void BreakpointList::reloadBreakpoints()
 {
 	// Update the items we're displaying from the debugger.
 	displayedBreakPoints_ = CBreakPoints::GetBreakpoints();
-	displayedMemChecks_= CBreakPoints::GetMemChecks();
+	displayedMemChecks_ = CBreakPoints::GetMemChecks();
 	update();
 }
 
@@ -378,19 +422,22 @@ void BreakpointList::editBreakpoint(int itemIndex)
 {
 	bool isMemory;
 	int index = getBreakpointIndex(itemIndex, isMemory);
-	if (index == -1) return;
+	if (index == -1)
+		return;
 
-	BreakpointWindow win(this,cpu);
+	BreakpointWindow win(this, cpu);
 	if (isMemory)
 	{
 		auto mem = displayedMemChecks_[index];
 		win.loadFromMemcheck(mem);
 		if (win.ShowModal() == wxID_OK)
 		{
-			CBreakPoints::RemoveMemCheck(cpu->getCpuType(), mem.start,mem.end);
+			CBreakPoints::RemoveMemCheck(cpu->getCpuType(), mem.start, mem.end);
 			win.addBreakpoint();
 		}
-	} else {
+	}
+	else
+	{
 		auto bp = displayedBreakPoints_[index];
 		win.loadFromBreakpoint(bp);
 		if (win.ShowModal() == wxID_OK)
@@ -405,12 +452,16 @@ void BreakpointList::toggleEnabled(int itemIndex)
 {
 	bool isMemory;
 	int index = getBreakpointIndex(itemIndex, isMemory);
-	if (index == -1) return;
+	if (index == -1)
+		return;
 
-	if (isMemory) {
+	if (isMemory)
+	{
 		MemCheck mcPrev = displayedMemChecks_[index];
 		CBreakPoints::ChangeMemCheck(cpu->getCpuType(), mcPrev.start, mcPrev.end, mcPrev.cond, MemCheckResult(mcPrev.result ^ MEMCHECK_BREAK));
-	} else {
+	}
+	else
+	{
 		BreakPoint bpPrev = displayedBreakPoints_[index];
 		CBreakPoints::ChangeBreakPoint(cpu->getCpuType(), bpPrev.addr, !bpPrev.enabled);
 	}
@@ -419,30 +470,36 @@ void BreakpointList::toggleEnabled(int itemIndex)
 void BreakpointList::gotoBreakpointAddress(int itemIndex)
 {
 	bool isMemory;
-	int index = getBreakpointIndex(itemIndex,isMemory);
-	if (index == -1) return;
+	int index = getBreakpointIndex(itemIndex, isMemory);
+	if (index == -1)
+		return;
 
 	if (isMemory)
 	{
 		u32 address = displayedMemChecks_[index].start;
-		postEvent(debEVT_GOTOINMEMORYVIEW,address);
-	} else {
+		postEvent(debEVT_GOTOINMEMORYVIEW, address);
+	}
+	else
+	{
 		u32 address = displayedBreakPoints_[index].addr;
-		postEvent(debEVT_GOTOINDISASM,address);
+		postEvent(debEVT_GOTOINDISASM, address);
 	}
 }
 
 void BreakpointList::removeBreakpoint(int itemIndex)
 {
 	bool isMemory;
-	int index = getBreakpointIndex(itemIndex,isMemory);
-	if (index == -1) return;
+	int index = getBreakpointIndex(itemIndex, isMemory);
+	if (index == -1)
+		return;
 
 	if (isMemory)
 	{
 		auto mc = displayedMemChecks_[index];
 		CBreakPoints::RemoveMemCheck(cpu->getCpuType(), mc.start, mc.end);
-	} else {
+	}
+	else
+	{
 		u32 address = displayedBreakPoints_[index].addr;
 		CBreakPoints::RemoveBreakPoint(displayedBreakPoints_[index].cpu, address);
 	}
@@ -453,51 +510,51 @@ void BreakpointList::onPopupClick(wxCommandEvent& evt)
 	int index = GetFirstSelected();
 	switch (evt.GetId())
 	{
-	case ID_BREAKPOINTLIST_ENABLE:
-		toggleEnabled(index);
-		break;
-	case ID_BREAKPOINTLIST_EDIT:
-		editBreakpoint(index);
-		break;
-	case ID_BREAKPOINTLIST_DELETE:
-		removeBreakpoint(index);
-		break;
-	case ID_BREAKPOINTLIST_ADDNEW:
-		postEvent(debEVT_BREAKPOINTWINDOW,0);
-		break;
-	default:
-		wxMessageBox( L"Unimplemented.",  L"Unimplemented.", wxICON_INFORMATION);
-		break;
+		case ID_BREAKPOINTLIST_ENABLE:
+			toggleEnabled(index);
+			break;
+		case ID_BREAKPOINTLIST_EDIT:
+			editBreakpoint(index);
+			break;
+		case ID_BREAKPOINTLIST_DELETE:
+			removeBreakpoint(index);
+			break;
+		case ID_BREAKPOINTLIST_ADDNEW:
+			postEvent(debEVT_BREAKPOINTWINDOW, 0);
+			break;
+		default:
+			wxMessageBox(L"Unimplemented.", L"Unimplemented.", wxICON_INFORMATION);
+			break;
 	}
 }
 
 void BreakpointList::showMenu(const wxPoint& pos)
 {
 	bool isMemory;
-	int index = getBreakpointIndex(GetFirstSelected(),isMemory);
+	int index = getBreakpointIndex(GetFirstSelected(), isMemory);
 
 	wxMenu menu;
 	if (index != -1)
 	{
-		menu.AppendCheckItem(ID_BREAKPOINTLIST_ENABLE,	L"Enable");
-		menu.Append(ID_BREAKPOINTLIST_EDIT,				L"Edit");
-		menu.Append(ID_BREAKPOINTLIST_DELETE,			L"Delete");
+		menu.AppendCheckItem(ID_BREAKPOINTLIST_ENABLE, L"Enable");
+		menu.Append(ID_BREAKPOINTLIST_EDIT, L"Edit");
+		menu.Append(ID_BREAKPOINTLIST_DELETE, L"Delete");
 		menu.AppendSeparator();
 
 		// check if the breakpoint is enabled
 		bool enabled;
 		if (isMemory)
 			enabled = (displayedMemChecks_[index].result & MEMCHECK_BREAK) != 0;
-		else 
+		else
 			enabled = displayedBreakPoints_[index].enabled;
 
-		menu.Check(ID_BREAKPOINTLIST_ENABLE,enabled);
+		menu.Check(ID_BREAKPOINTLIST_ENABLE, enabled);
 	}
 
-	menu.Append(ID_BREAKPOINTLIST_ADDNEW,			L"Add new");
+	menu.Append(ID_BREAKPOINTLIST_ADDNEW, L"Add new");
 
 	menu.Bind(wxEVT_MENU, &BreakpointList::onPopupClick, this);
-	PopupMenu(&menu,pos);
+	PopupMenu(&menu, pos);
 }
 
 void BreakpointList::onRightClick(int itemIndex, const wxPoint& point)
@@ -515,19 +572,29 @@ void BreakpointList::onDoubleClick(int itemIndex, const wxPoint& point)
 // ThreadList
 //
 
-enum { TL_TID, TL_PROGRAMCOUNTER, TL_ENTRYPOINT, TL_PRIORITY, TL_STATE, TL_WAITTYPE, TL_COLUMNCOUNT };
+enum
+{
+	TL_TID,
+	TL_PROGRAMCOUNTER,
+	TL_ENTRYPOINT,
+	TL_PRIORITY,
+	TL_STATE,
+	TL_WAITTYPE,
+	TL_COLUMNCOUNT
+};
 
 GenericListViewColumn threadColumns[TL_COLUMNCOUNT] = {
-	{ L"TID",			0.08f },
-	{ L"PC",			0.21f },
-	{ L"Entry Point",	0.21f },
-	{ L"Priority",		0.08f },
-	{ L"State",			0.21f },
-	{ L"Wait type",		0.21f },
+	{L"TID", 0.08f},
+	{L"PC", 0.21f},
+	{L"Entry Point", 0.21f},
+	{L"Priority", 0.08f},
+	{L"State", 0.21f},
+	{L"Wait type", 0.21f},
 };
 
 ThreadList::ThreadList(wxWindow* parent, DebugInterface* _cpu)
-	: GenericListView(parent,threadColumns,TL_COLUMNCOUNT), cpu(_cpu)
+	: GenericListView(parent, threadColumns, TL_COLUMNCOUNT)
+	, cpu(_cpu)
 {
 }
 
@@ -553,63 +620,63 @@ wxString ThreadList::getColumnText(int item, int col) const
 
 	switch (col)
 	{
-	case TL_TID:
-		dest.Write("%d",thread.tid);
-		break;
-	case TL_PROGRAMCOUNTER:
-		if (thread.data.status == THS_RUN)
-			dest.Write("0x%08X", cpu->getPC());
-		else
-			dest.Write("0x%08X", thread.data.entry);
-		break;
-	case TL_ENTRYPOINT:
-		dest.Write("0x%08X", thread.data.entry_init);
-		break;
-	case TL_PRIORITY:
-		dest.Write("0x%02X", thread.data.currentPriority);
-		break;
-	case TL_STATE:
-		switch (thread.data.status)
-		{
-		case THS_BAD:
-			dest.Write("Bad");
+		case TL_TID:
+			dest.Write("%d", thread.tid);
 			break;
-		case THS_RUN:
-			dest.Write("Running");
+		case TL_PROGRAMCOUNTER:
+			if (thread.data.status == THS_RUN)
+				dest.Write("0x%08X", cpu->getPC());
+			else
+				dest.Write("0x%08X", thread.data.entry);
 			break;
-		case THS_READY:
-			dest.Write("Ready");
+		case TL_ENTRYPOINT:
+			dest.Write("0x%08X", thread.data.entry_init);
 			break;
-		case THS_WAIT:
-			dest.Write("Waiting");
+		case TL_PRIORITY:
+			dest.Write("0x%02X", thread.data.currentPriority);
 			break;
-		case THS_SUSPEND:
-			dest.Write("Suspended");
+		case TL_STATE:
+			switch (thread.data.status)
+			{
+				case THS_BAD:
+					dest.Write("Bad");
+					break;
+				case THS_RUN:
+					dest.Write("Running");
+					break;
+				case THS_READY:
+					dest.Write("Ready");
+					break;
+				case THS_WAIT:
+					dest.Write("Waiting");
+					break;
+				case THS_SUSPEND:
+					dest.Write("Suspended");
+					break;
+				case THS_WAIT_SUSPEND:
+					dest.Write("Waiting/Suspended");
+					break;
+				case THS_DORMANT:
+					dest.Write("Dormant");
+					break;
+			}
 			break;
-		case THS_WAIT_SUSPEND:
-			dest.Write("Waiting/Suspended");
+		case TL_WAITTYPE:
+			switch (thread.data.waitType)
+			{
+				case WAIT_NONE:
+					dest.Write("None");
+					break;
+				case WAIT_WAKEUP_REQ:
+					dest.Write("Wakeup request");
+					break;
+				case WAIT_SEMA:
+					dest.Write("Semaphore");
+					break;
+			}
 			break;
-		case THS_DORMANT:
-			dest.Write("Dormant");
-			break;
-		}
-		break;
-	case TL_WAITTYPE:
-		switch (thread.data.waitType)
-		{
-		case WAIT_NONE:
-			dest.Write("None");
-			break;
-		case WAIT_WAKEUP_REQ:
-			dest.Write("Wakeup request");
-			break;
-		case WAIT_SEMA:
-			dest.Write("Semaphore");
-			break;
-		}
-		break;
-	default:
-		return L"Invalid";
+		default:
+			return L"Invalid";
 	}
 
 	return dest;
@@ -624,16 +691,16 @@ void ThreadList::onDoubleClick(int itemIndex, const wxPoint& point)
 
 	switch (thread.data.status)
 	{
-	case THS_DORMANT:
-	case THS_BAD:
-		postEvent(debEVT_GOTOINDISASM,thread.data.entry_init);
-		break;
-	case THS_RUN:
-		postEvent(debEVT_GOTOINDISASM,cpu->getPC());
-		break;
-	default:
-		postEvent(debEVT_GOTOINDISASM,thread.data.entry);
-		break;
+		case THS_DORMANT:
+		case THS_BAD:
+			postEvent(debEVT_GOTOINDISASM, thread.data.entry_init);
+			break;
+		case THS_RUN:
+			postEvent(debEVT_GOTOINDISASM, cpu->getPC());
+			break;
+		default:
+			postEvent(debEVT_GOTOINDISASM, thread.data.entry);
+			break;
 	}
 }
 
@@ -646,7 +713,7 @@ EEThread ThreadList::getRunningThread()
 	}
 
 	EEThread thread;
-	memset(&thread,0,sizeof(thread));
+	memset(&thread, 0, sizeof(thread));
 	thread.tid = -1;
 	return thread;
 }
@@ -655,26 +722,36 @@ EEThread ThreadList::getRunningThread()
 // StackFramesList
 //
 
-enum { SF_ENTRY, SF_ENTRYNAME, SF_CURPC, SF_CUROPCODE, SF_CURSP, SF_FRAMESIZE, SF_COLUMNCOUNT };
-
-GenericListViewColumn stackFrameolumns[SF_COLUMNCOUNT] = {
-	{ L"Entry",			0.12f },
-	{ L"Name",			0.24f },
-	{ L"PC",			0.12f },
-	{ L"Opcode",		0.28f },
-	{ L"SP",			0.12f },
-	{ L"Frame Size",	0.12f }
+enum
+{
+	SF_ENTRY,
+	SF_ENTRYNAME,
+	SF_CURPC,
+	SF_CUROPCODE,
+	SF_CURSP,
+	SF_FRAMESIZE,
+	SF_COLUMNCOUNT
 };
 
+GenericListViewColumn stackFrameolumns[SF_COLUMNCOUNT] = {
+	{L"Entry", 0.12f},
+	{L"Name", 0.24f},
+	{L"PC", 0.12f},
+	{L"Opcode", 0.28f},
+	{L"SP", 0.12f},
+	{L"Frame Size", 0.12f}};
+
 StackFramesList::StackFramesList(wxWindow* parent, DebugInterface* _cpu, CtrlDisassemblyView* _disassembly)
-	: GenericListView(parent,stackFrameolumns,SF_COLUMNCOUNT), cpu(_cpu), disassembly(_disassembly)
+	: GenericListView(parent, stackFrameolumns, SF_COLUMNCOUNT)
+	, cpu(_cpu)
+	, disassembly(_disassembly)
 {
 }
 
 void StackFramesList::loadStackFrames(EEThread& currentThread)
 {
-	frames = MipsStackWalk::Walk(cpu,cpu->getPC(),cpu->getRegister(0,31),cpu->getRegister(0,29),
-			currentThread.data.entry_init,currentThread.data.stack);
+	frames = MipsStackWalk::Walk(cpu, cpu->getPC(), cpu->getRegister(0, 31), cpu->getRegister(0, 29),
+		currentThread.data.entry_init, currentThread.data.stack);
 	update();
 }
 
@@ -693,39 +770,42 @@ wxString StackFramesList::getColumnText(int item, int col) const
 
 	switch (col)
 	{
-	case SF_ENTRY:
-		dest.Write("0x%08X",frame.entry);
-		break;
-	case SF_ENTRYNAME:
+		case SF_ENTRY:
+			dest.Write("0x%08X", frame.entry);
+			break;
+		case SF_ENTRYNAME:
 		{
 			const std::string sym = symbolMap.GetLabelString(frame.entry);
-			if (!sym.empty()) {
-				dest.Write("%s",sym.c_str());
-			} else {
+			if (!sym.empty())
+			{
+				dest.Write("%s", sym.c_str());
+			}
+			else
+			{
 				dest.Write("-");
 			}
 		}
 		break;
-	case SF_CURPC:
-		dest.Write("0x%08X",frame.pc);
-		break;
-	case SF_CUROPCODE:
+		case SF_CURPC:
+			dest.Write("0x%08X", frame.pc);
+			break;
+		case SF_CUROPCODE:
 		{
 			if (!cpu->isAlive())
 				break;
 			char temp[512];
-			disassembly->getOpcodeText(frame.pc,temp);
-			dest.Write("%s",temp);
+			disassembly->getOpcodeText(frame.pc, temp);
+			dest.Write("%s", temp);
 		}
 		break;
-	case SF_CURSP:
-		dest.Write("0x%08X",frame.sp);
-		break;
-	case SF_FRAMESIZE:
-		dest.Write("0x%08X",frame.stackSize);
-		break;
-	default:
-		return L"Invalid";
+		case SF_CURSP:
+			dest.Write("0x%08X", frame.sp);
+			break;
+		case SF_FRAMESIZE:
+			dest.Write("0x%08X", frame.stackSize);
+			break;
+		default:
+			return L"Invalid";
 	}
 
 	return dest;
@@ -735,6 +815,6 @@ void StackFramesList::onDoubleClick(int itemIndex, const wxPoint& point)
 {
 	if (itemIndex < 0 || itemIndex >= (int)frames.size())
 		return;
-	
-	postEvent(debEVT_GOTOINDISASM,frames[itemIndex].pc);
+
+	postEvent(debEVT_GOTOINDISASM, frames[itemIndex].pc);
 }


### PR DESCRIPTION
### Description of Changes

- Disassembly view:  hotkeys don't need to be used with CTRL (they are still usable with CTRL, however)
- Memory view: Goto address hotkey (G) doesn't need to be used with CTRL
- Disassembly view: To reassemble an opcode, you  can press `M` or go through the context menu, pressing any non-hotkey letter won't trigger this anymore.
- You can now delete a breakpoint through its context menu. (See image)
![image](https://user-images.githubusercontent.com/29295048/121398770-b4d79e00-c923-11eb-941c-6005ad3f7ac1.png)

### Rationale behind Changes
If you use Ghidra for example, you'd know that depending on CTRL for goto is odd.

Why not have delete as a context menu option for breakpoints?

### Suggested Testing Steps
Use the various debugger hotkeys, see if they work.

Make sure the delete breakpoint button works properly.

## Note
~~The debugger pdf is outdated. Sorry, but why use pdfs when they are probably the worst format to edit?~~
