### PR TITLE
[DEV9] pcap, check size of read packet

### DIFF
--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -298,6 +298,9 @@ int pcap_io_recv(void* packet, int max_len)
 
 	if ((pcap_next_ex(adhandle, &header, &pkt_data1)) > 0)
 	{
+		if (header->len > max_len)
+			return -1;
+
 		memcpy(packet, pkt_data1, header->len);
 
 		if (!pcap_io_switched)

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -188,12 +188,12 @@ int pcap_io_init(char* adapter, bool switched, mac_address virtual_mac)
 
 	/* Open the adapter */
 	if ((adhandle = pcap_open_live(adapter, // name of the device
-								   65536,   // portion of the packet to capture.
-								   // 65536 grants that the whole packet will be captured on all the MACs.
-								   switched ? 1 : 0,
-								   1,     // read timeout
-								   errbuf // error buffer
-								   )) == NULL)
+			 65536, // portion of the packet to capture.
+			 // 65536 grants that the whole packet will be captured on all the MACs.
+			 switched ? 1 : 0,
+			 1, // read timeout
+			 errbuf // error buffer
+			 )) == NULL)
 	{
 		Console.Error("DEV9: %s", errbuf);
 		Console.Error("DEV9: Unable to open the adapter. %s is not supported by pcap", adapter);


### PR DESCRIPTION
### Description of Changes
in pcap, check size of read packet. If the size exceeds the buffer we are using, drop the packet.

### Rationale behind Changes
Jumbo frames could exceed the size of the buffer, leading to an overflow.

### Suggested Testing Steps
Test networked games with the pcap backend

Fixes https://github.com/PCSX2/pcsx2/issues/4467