### PR TITLE
System | Windows: Print active power profile on application launch

### DIFF
--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -266,6 +266,10 @@ void SysLogMachineCaps()
 #endif
 
 	Console.Newline();
+
+#ifdef _WIN32
+	CheckIsUserOnHighPerfPowerPlan();
+#endif
 }
 
 template< typename CpuType >

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -215,3 +215,6 @@ namespace Msgbox
 	extern int	Assertion( const wxString& text, const wxString& stacktrace );
 }
 
+#ifdef _WIN32
+extern void CheckIsUserOnHighPerfPowerPlan();
+#endif

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -113,7 +113,7 @@
     <Link>
       <LargeAddressAware>Yes</LargeAddressAware>
       <AdditionalDependencies>comctl32.lib;ws2_32.lib;shlwapi.lib;winmm.lib;rpcrt4.lib;iphlpapi.lib;dsound.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;PowrProf.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -719,6 +719,7 @@
     <ClCompile Include="gui\Panels\VideoPanel.cpp" />
     <ClCompile Include="windows\WinCompressNTFS.cpp" />
     <ClCompile Include="windows\WinConsolePipe.cpp" />
+    <ClCompile Include="windows\WinPowerProfile.cpp" />
     <ClCompile Include="Linux\LnxKeyCodes.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -785,6 +785,9 @@
     <ClCompile Include="windows\WinConsolePipe.cpp">
       <Filter>AppHost\Win32</Filter>
     </ClCompile>
+    <ClCompile Include="windows\WinPowerProfile.cpp">
+	  <Filter>AppHost\Win32</Filter>
+    </ClCompile>
     <ClCompile Include="Linux\LnxKeyCodes.cpp">
       <Filter>AppHost\Linux</Filter>
     </ClCompile>

--- a/pcsx2/windows/WinPowerProfile.cpp
+++ b/pcsx2/windows/WinPowerProfile.cpp
@@ -1,0 +1,48 @@
+/*  PCSX2 - PS2 Emulator for PCs
+*  Copyright (C) 2002-2021  PCSX2 Dev Team
+*
+*  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+*  of the GNU Lesser General Public License as published by the Free Software Found-
+*  ation, either version 3 of the License, or (at your option) any later version.
+*
+*  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+*  PURPOSE.  See the GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along with PCSX2.
+*  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PrecompiledHeader.h"
+#include <powrprof.h>
+
+// Checks the current active power plan
+// If the power plan isn't named 'high performance', put a little message in the console
+// This function fails silently
+void CheckIsUserOnHighPerfPowerPlan()
+{
+	GUID* pPwrGUID;
+	DWORD ret = PowerGetActiveScheme(NULL, &pPwrGUID);
+	if (ret != ERROR_SUCCESS)
+		return;
+
+	UCHAR aBuffer[2048];
+	DWORD aBufferSize = sizeof(aBuffer);
+	ret = PowerReadFriendlyName(NULL, pPwrGUID, &NO_SUBGROUP_GUID, NULL, aBuffer, &aBufferSize);
+	if (ret != ERROR_SUCCESS)
+		goto cleanup;
+
+	DWORD acMax = 0,acMin = 0,dcMax = 0,dcMin = 0;
+
+	if (PowerReadACValueIndex(NULL, pPwrGUID, &GUID_PROCESSOR_SETTINGS_SUBGROUP, &GUID_PROCESSOR_THROTTLE_MAXIMUM, &acMax) ||
+		PowerReadACValueIndex(NULL, pPwrGUID, &GUID_PROCESSOR_SETTINGS_SUBGROUP, &GUID_PROCESSOR_THROTTLE_MINIMUM, &acMin) ||
+		PowerReadDCValueIndex(NULL, pPwrGUID, &GUID_PROCESSOR_SETTINGS_SUBGROUP, &GUID_PROCESSOR_THROTTLE_MAXIMUM, &dcMax) ||
+		PowerReadDCValueIndex(NULL, pPwrGUID, &GUID_PROCESSOR_SETTINGS_SUBGROUP, &GUID_PROCESSOR_THROTTLE_MINIMUM, &dcMin))
+		goto cleanup;
+
+	Console.WriteLn("The current power profile is '%S'.\nThe current min / max processor states\nAC: %d%% / %d%%\nBattery: %d%% / %d%%\n", aBuffer,acMin,acMax,dcMin,dcMax);
+
+cleanup:
+	LocalFree(pPwrGUID);
+	return;
+}


### PR DESCRIPTION
### Description of Changes
Print the current power profile and the current min/max processor state

### Rationale behind Changes
This can help aid users who are experiencing slowdowns and can aid helpers in diagnosing possible slowdown reasons.

### Suggested Testing Steps
You should get a message stating your current power profile and processor min/max states.

### Example
![image](https://user-images.githubusercontent.com/29295048/123167884-2c89ea80-d445-11eb-953f-ecfdb528fae2.png)