### PR TITLE
macOS: Fix async file reader error handling

### DIFF
--- a/pcsx2/AsyncFileReader.h
+++ b/pcsx2/AsyncFileReader.h
@@ -79,7 +79,7 @@ class FlatFileReader : public AsyncFileReader
 #elif defined(__POSIX__)
 	int m_fd; // TODO OSX don't know if overlap as an equivalent on OSX
 	struct aiocb m_aiocb;
-	bool m_read_in_progress;
+	bool m_async_read_in_progress;
 #endif
 
 	bool shareWrite;


### PR DESCRIPTION
### Description of Changes
Updates DarwinFlatFileReader to fall back to a synchronous read if the aio read fails for any reason

### Rationale behind Changes
Even on systems where everything is working, it's possible to get an `EAGAIN` if the system is out of async reading resources.  We've had one report so far of such a thing happening.

### Suggested Testing Steps
Test on macOS or BSD and make sure things still work.  I don't expect to get much testing of the failure case as I have yet to see an `EAGAIN` on my computer, but it does still work for me if I define `DISABLE_AIO`
