### PR TITLE
GS-hw: Enable pabe bit only when sw blending is enabled

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -453,22 +453,6 @@ void GSRendererDX11::EmulateBlending()
 		return;
 
 	m_om_bsel.abe = 1;
-
-	if (m_env.PABE.PABE)
-	{
-		if (ALPHA.A == 0 && ALPHA.B == 1 && ALPHA.C == 0 && ALPHA.D == 1)
-		{
-			// this works because with PABE alpha blending is on when alpha >= 0x80, but since the pixel shader
-			// cannot output anything over 0x80 (== 1.0) blending with 0x80 or turning it off gives the same result
-
-			m_om_bsel.abe = 0;
-		}
-
-		// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars, Cartoon Network Racing.
-		// fprintf(stderr, "%d: PABE mode ENABLED\n", s_n);
-		m_ps_sel.pabe = 1;
-	}
-
 	m_om_bsel.blend_index = uint8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
 	const int blend_flag = m_dev->GetBlendFlags(m_om_bsel.blend_index);
 
@@ -510,6 +494,25 @@ void GSRendererDX11::EmulateBlending()
 		{
 			// fprintf(stderr, "%d: COLCLIP HDR mode ENABLED\n", s_n);
 			m_ps_sel.hdr = 1;
+		}
+	}
+
+	// Per pixel alpha blending
+	if (m_env.PABE.PABE)
+	{
+		// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars, Cartoon Network Racing.
+
+		if (ALPHA.A == 0 && ALPHA.B == 1 && ALPHA.C == 0 && ALPHA.D == 1)
+		{
+			// this works because with PABE alpha blending is on when alpha >= 0x80, but since the pixel shader
+			// cannot output anything over 0x80 (== 1.0) blending with 0x80 or turning it off gives the same result
+
+			m_om_bsel.abe = 0;
+		}
+		if (sw_blending)
+		{
+			// fprintf(stderr, "%d: PABE mode ENABLED\n", s_n);
+			m_ps_sel.pabe = 1;
 		}
 	}
 

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -474,13 +474,6 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 		return;
 	}
 
-	if (m_env.PABE.PABE)
-	{
-		// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars, Cartoon Network Racing.
-		GL_INS("PABE mode ENABLED");
-		m_ps_sel.pabe = 1;
-	}
-
 	// Compute the blending equation to detect special case
 	const uint8 blend_index = uint8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
 	const int blend_flag = m_dev->GetBlendFlags(blend_index);
@@ -558,6 +551,18 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 		{
 			GL_INS("COLCLIP HDR mode ENABLED");
 			m_ps_sel.hdr = 1;
+		}
+	}
+
+	// Per pixel alpha blending
+	if (m_env.PABE.PABE)
+	{
+		// Breath of Fire Dragon Quarter, Strawberry Shortcake, Super Robot Wars, Cartoon Network Racing.
+
+		if (sw_blending)
+		{
+			GL_INS("PABE mode ENABLED");
+			m_ps_sel.pabe = 1;
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Enable pabe bit only when sw blending is enabled.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Minor optimization, no need to enable pabe when sw blending is not detected.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
