### PR TITLE
Remove __rdtsc define. Gets rid of 30 million warnings on Linux while compiling.

### DIFF
--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -229,27 +229,6 @@
 #endif
 	}
 
-	#ifdef __GNUC__
-
-	// gcc 4.8 define __rdtsc but unfortunately the compiler crash...
-	// The redefine allow to skip the gcc __rdtsc version -- Gregory
-	#define __rdtsc _lnx_rdtsc
-	//static unsigned long long __rdtsc()
-	static unsigned long long _lnx_rdtsc()
-	{
-		#if defined(__amd64__) || defined(__x86_64__)
-		unsigned long long low, high;
-		__asm__ __volatile__("rdtsc" : "=a"(low), "=d"(high));
-		return low | (high << 32);
-		#else
-		unsigned long long retval;
-		__asm__ __volatile__("rdtsc" : "=A"(retval));
-		return retval;
-		#endif
-	}
-
-	#endif
-
 #endif
 
 extern std::string format(const char* fmt, ...);


### PR DESCRIPTION
### Description of Changes
It now checks if __rdtsc is defined before trying to define it.

### Rationale behind Changes
Since __rdtsc already *is* defined, GS.h is included a lot, and __rdtsc is brought in in the pch with the compiler's version, gcc isn't very happy about this situation.

### Suggested Testing Steps
If anyone has any idea when the gcc 4.8 crash mentioned in the comments happened, try to reproduce it?
