### PR TITLE
Misc: Suppress a warning regarding GetVersionEx

### DIFF
--- a/common/src/Utilities/Windows/WinMisc.cpp
+++ b/common/src/Utilities/Windows/WinMisc.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -92,7 +92,8 @@ wxString GetOSVersionString()
     memzero(osvi);
 
     osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-
+// GetVersionEx is deprecated, but we don't use it for version checking anyways
+#pragma warning(suppress : 4996)
     if (!(bOsVersionInfoEx = GetVersionEx((OSVERSIONINFO *)&osvi)))
         return L"GetVersionEx Error!";
 


### PR DESCRIPTION
### Brief description
Microsoft has deprecated `GetVersionEx`.
We use `GetVersionEx` to print the current build number and _that's all_.
According to the docs [here](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversion).
`GetVersion may be altered or unavailable for releases after Windows 8.1. Instead, use the Version Helper functions. For Windows 10 apps, please see Targeting your applications for Windows.`
Unfortunately, the Version Helper Functions aren't a solution for us, and we aren't a UWP app (thank god).

This PR suppresses the warning for just that line.
If there's a sane, non-deprecated way to expose the current build version that'd be the best solution here.