### PR TITLE
Misc: Remove windows build number in the version string

### DIFF
--- a/common/src/Utilities/Windows/WinMisc.cpp
+++ b/common/src/Utilities/Windows/WinMisc.cpp
@@ -25,31 +25,31 @@ static __aligned16 LARGE_INTEGER lfreq;
 
 void InitCPUTicks()
 {
-    QueryPerformanceFrequency(&lfreq);
+	QueryPerformanceFrequency(&lfreq);
 }
 
 u64 GetTickFrequency()
 {
-    return lfreq.QuadPart;
+	return lfreq.QuadPart;
 }
 
 u64 GetCPUTicks()
 {
-    LARGE_INTEGER count;
-    QueryPerformanceCounter(&count);
-    return count.QuadPart;
+	LARGE_INTEGER count;
+	QueryPerformanceCounter(&count);
+	return count.QuadPart;
 }
 
 u64 GetPhysicalMemory()
 {
-    MEMORYSTATUSEX status;
-    status.dwLength = sizeof(status);
-    GlobalMemoryStatusEx(&status);
-    return status.ullTotalPhys;
+	MEMORYSTATUSEX status;
+	status.dwLength = sizeof(status);
+	GlobalMemoryStatusEx(&status);
+	return status.ullTotalPhys;
 }
 
-typedef void(WINAPI *PGNSI)(LPSYSTEM_INFO);
-typedef BOOL(WINAPI *PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
+typedef void(WINAPI* PGNSI)(LPSYSTEM_INFO);
+typedef BOOL(WINAPI* PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
 
 // Win 10 SDK
 #ifndef PRODUCT_CORE_N
@@ -79,98 +79,98 @@ typedef BOOL(WINAPI *PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
 // (Handy function borrowed from Microsoft's MSDN Online, and reformatted to use wxString.)
 wxString GetOSVersionString()
 {
-    wxString retval;
+	wxString retval;
 
-    SYSTEM_INFO si;
-    PGNSI pGNSI;
-    PGPI pGPI;
-    BOOL bOsVersionInfoEx;
-    DWORD dwType;
+	SYSTEM_INFO si;
+	PGNSI pGNSI;
+	PGPI pGPI;
+	BOOL bOsVersionInfoEx;
+	DWORD dwType;
 
-    memzero(si);
+	memzero(si);
 
-    // Call GetNativeSystemInfo if supported or GetSystemInfo otherwise.
+	// Call GetNativeSystemInfo if supported or GetSystemInfo otherwise.
 
-    pGNSI = (PGNSI)GetProcAddress(GetModuleHandle(L"kernel32.dll"), "GetNativeSystemInfo");
-    if (NULL != pGNSI)
-        pGNSI(&si);
-    else
-        GetSystemInfo(&si);
+	pGNSI = (PGNSI)GetProcAddress(GetModuleHandle(L"kernel32.dll"), "GetNativeSystemInfo");
+	if (NULL != pGNSI)
+		pGNSI(&si);
+	else
+		GetSystemInfo(&si);
 
-    if (!IsWindows8Point1OrGreater())
-        return L"Unsupported Operating System!";
+	if (!IsWindows8Point1OrGreater())
+		return L"Unsupported Operating System!";
 
-    retval += L"Microsoft ";
+	retval += L"Microsoft ";
 
-    // Test for the specific product.
+	// Test for the specific product.
 
-    if (IsWindows10OrGreater())
-        retval += IsWindowsServer() ? L"Windows Server 2016 " : L"Windows 10 ";
-    else // IsWindows8Point1OrGreater()
-        retval += IsWindowsServer() ? L"Windows Server 2012 R2 " : L"Windows 8.1 ";
+	if (IsWindows10OrGreater())
+		retval += IsWindowsServer() ? L"Windows Server 2016 " : L"Windows 10 ";
+	else // IsWindows8Point1OrGreater()
+		retval += IsWindowsServer() ? L"Windows Server 2012 R2 " : L"Windows 8.1 ";
 
-    pGPI = (PGPI)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetProductInfo");
+	pGPI = (PGPI)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetProductInfo");
 
-    switch (dwType)
-    {
-        // Shared between Windows 8.1 and 10.
-        case PRODUCT_PROFESSIONAL:
-            retval += L"Pro";
-            break;
-        case PRODUCT_PROFESSIONAL_N:
-            retval += L"Pro N";
-            break;
-        case PRODUCT_PROFESSIONAL_WMC:
-            retval += L"Pro with Media Center";
-            break;
-        case PRODUCT_ENTERPRISE:
-            retval += L"Enterprise";
-            break;
-        case PRODUCT_ENTERPRISE_N:
-            retval += L"Enterprise N";
-            break;
-        case PRODUCT_SERVER_FOUNDATION:
-            retval += L"Foundation";
-            break;
-        case PRODUCT_STANDARD_SERVER:
-            retval += L"Standard";
-            break;
-        case PRODUCT_STANDARD_SERVER_CORE:
-            retval += L"Standard (core)";
-            break;
-        case PRODUCT_DATACENTER_SERVER:
-            retval += L"Datacenter";
-            break;
-        case PRODUCT_DATACENTER_SERVER_CORE:
-            retval += L"Datacenter (core)";
-            break;
-        // Windows 10 specific.
-        case PRODUCT_ENTERPRISE_S:
-            retval += L"Enterprise 2015 LTSB";
-            break;
-        case PRODUCT_ENTERPRISE_S_N:
-            retval += L"Enterprise 2015 LTSB N";
-            break;
-        case PRODUCT_EDUCATION:
-            retval += L"Education";
-            break;
-        case PRODUCT_CORE:
-            retval += L"Home";
-            break;
-        case PRODUCT_CORE_N:
-            retval += L"Home N";
-            break;
-        case PRODUCT_EDUCATION_N:
-            retval += L"Education N";
-            break;
-    }
+	switch (dwType)
+	{
+		// Shared between Windows 8.1 and 10.
+		case PRODUCT_PROFESSIONAL:
+			retval += L"Pro";
+			break;
+		case PRODUCT_PROFESSIONAL_N:
+			retval += L"Pro N";
+			break;
+		case PRODUCT_PROFESSIONAL_WMC:
+			retval += L"Pro with Media Center";
+			break;
+		case PRODUCT_ENTERPRISE:
+			retval += L"Enterprise";
+			break;
+		case PRODUCT_ENTERPRISE_N:
+			retval += L"Enterprise N";
+			break;
+		case PRODUCT_SERVER_FOUNDATION:
+			retval += L"Foundation";
+			break;
+		case PRODUCT_STANDARD_SERVER:
+			retval += L"Standard";
+			break;
+		case PRODUCT_STANDARD_SERVER_CORE:
+			retval += L"Standard (core)";
+			break;
+		case PRODUCT_DATACENTER_SERVER:
+			retval += L"Datacenter";
+			break;
+		case PRODUCT_DATACENTER_SERVER_CORE:
+			retval += L"Datacenter (core)";
+			break;
+		// Windows 10 specific.
+		case PRODUCT_ENTERPRISE_S:
+			retval += L"Enterprise 2015 LTSB";
+			break;
+		case PRODUCT_ENTERPRISE_S_N:
+			retval += L"Enterprise 2015 LTSB N";
+			break;
+		case PRODUCT_EDUCATION:
+			retval += L"Education";
+			break;
+		case PRODUCT_CORE:
+			retval += L"Home";
+			break;
+		case PRODUCT_CORE_N:
+			retval += L"Home N";
+			break;
+		case PRODUCT_EDUCATION_N:
+			retval += L"Education N";
+			break;
+	}
 
-    if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
-        retval += L"(64-bit)";
-    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL)
-        retval += L"(32-bit)";
+	if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+		retval += L"(64-bit)";
+	else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL)
+		retval += L"(32-bit)";
 
-    return retval;
+	return retval;
 }
 
 // --------------------------------------------------------------------------------------
@@ -178,37 +178,37 @@ wxString GetOSVersionString()
 // --------------------------------------------------------------------------------------
 Exception::WinApiError::WinApiError()
 {
-    ErrorId = GetLastError();
-    m_message_diag = L"Unspecified Windows API error.";
+	ErrorId = GetLastError();
+	m_message_diag = L"Unspecified Windows API error.";
 }
 
 wxString Exception::WinApiError::GetMsgFromWindows() const
 {
-    if (!ErrorId)
-        return L"No valid error number was assigned to this exception!";
+	if (!ErrorId)
+		return L"No valid error number was assigned to this exception!";
 
-    const DWORD BUF_LEN = 2048;
-    TCHAR t_Msg[BUF_LEN];
-    if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, 0, ErrorId, 0, t_Msg, BUF_LEN, 0))
-        return wxsFormat(L"Win32 Error #%d: %s", ErrorId, t_Msg);
+	const DWORD BUF_LEN = 2048;
+	TCHAR t_Msg[BUF_LEN];
+	if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, 0, ErrorId, 0, t_Msg, BUF_LEN, 0))
+		return wxsFormat(L"Win32 Error #%d: %s", ErrorId, t_Msg);
 
-    return wxsFormat(L"Win32 Error #%d (no text msg available)", ErrorId);
+	return wxsFormat(L"Win32 Error #%d (no text msg available)", ErrorId);
 }
 
 wxString Exception::WinApiError::FormatDisplayMessage() const
 {
-    return m_message_user + L"\n\n" + GetMsgFromWindows();
+	return m_message_user + L"\n\n" + GetMsgFromWindows();
 }
 
 wxString Exception::WinApiError::FormatDiagnosticMessage() const
 {
-    return m_message_diag + L"\n\t" + GetMsgFromWindows();
+	return m_message_diag + L"\n\t" + GetMsgFromWindows();
 }
 
 void ScreensaverAllow(bool allow)
 {
-    EXECUTION_STATE flags = ES_CONTINUOUS;
-    if (!allow)
-        flags |= ES_DISPLAY_REQUIRED;
-    SetThreadExecutionState(flags);
+	EXECUTION_STATE flags = ES_CONTINUOUS;
+	if (!allow)
+		flags |= ES_DISPLAY_REQUIRED;
+	SetThreadExecutionState(flags);
 }

--- a/common/src/Utilities/Windows/WinMisc.cpp
+++ b/common/src/Utilities/Windows/WinMisc.cpp
@@ -81,7 +81,6 @@ wxString GetOSVersionString()
 {
     wxString retval;
 
-    OSVERSIONINFOEX osvi;
     SYSTEM_INFO si;
     PGNSI pGNSI;
     PGPI pGPI;
@@ -89,13 +88,6 @@ wxString GetOSVersionString()
     DWORD dwType;
 
     memzero(si);
-    memzero(osvi);
-
-    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-// GetVersionEx is deprecated, but we don't use it for version checking anyways
-#pragma warning(suppress : 4996)
-    if (!(bOsVersionInfoEx = GetVersionEx((OSVERSIONINFO *)&osvi)))
-        return L"GetVersionEx Error!";
 
     // Call GetNativeSystemInfo if supported or GetSystemInfo otherwise.
 
@@ -118,7 +110,6 @@ wxString GetOSVersionString()
         retval += IsWindowsServer() ? L"Windows Server 2012 R2 " : L"Windows 8.1 ";
 
     pGPI = (PGPI)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetProductInfo");
-    pGPI(osvi.dwMajorVersion, osvi.dwMinorVersion, 0, 0, &dwType);
 
     switch (dwType)
     {
@@ -174,12 +165,10 @@ wxString GetOSVersionString()
             break;
     }
 
-    retval += wxsFormat(L" (build %d)", osvi.dwBuildNumber);
-
     if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
-        retval += L", 64-bit";
+        retval += L"(64-bit)";
     else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL)
-        retval += L", 32-bit";
+        retval += L"(32-bit)";
 
     return retval;
 }


### PR DESCRIPTION
### Description of Changes
No longer show the Windows build number on emulator launch.

### Rationale behind Changes
GetVersionEx was deprecated and we never use this number anyways.

### Suggested Testing Steps
Launch the emulator and look at the Windows version string.

`Operating System =  Microsoft Windows 10 (64-bit)` is mine