### PR TITLE
ci: Split avx2 and non-avx2 windows builds

### DIFF
--- a/.github/workflows/lint-gamedb.yml
+++ b/.github/workflows/lint-gamedb.yml
@@ -1,4 +1,4 @@
-name: Validate GameDB
+name: 📝 Validate GameDB
 
 on:
   push:

--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux Build
+name: 🐧 Linux Build
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -60,7 +60,7 @@ jobs:
             detail: -avx2-nopch
             experimental: false
 
-    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.compiler }}${{ matrix.detail }}
+    name: "${{ matrix.platform }} | ${{ matrix.compiler }} ${{ matrix.detail }}"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.

--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -1,4 +1,4 @@
-name: 🐧 Linux Build
+name: 🐧 Linux Builds
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -1,4 +1,4 @@
-name: MacOS Build
+name: 🍎 MacOS Builds
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -34,7 +34,7 @@ jobs:
         platform: [x64]
         experimental: [false]
 
-    name: ${{ matrix.os }}-${{ matrix.platform }}
+    name: ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,5 +1,5 @@
 # Runs steps to triage an incoming Pull Request, for example - applying labels.
-name: "Pull Request Triage"
+name: 🤔 Pull Request Triage
 
 on:
   pull_request_target:

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -108,6 +108,11 @@ jobs:
         shell: bash
         working-directory: ./bin
         run: |
+          retainDebugArtifacts=$([ "${{ github.event.inputs.retainDebugArtifacts }}" == "true" ] && echo "true" || echo "false")
+          if [ "${retainDebugArtifacts}" == "false" ]; then
+            ls ./
+            rm -f *.bsc *.exp *.ilk *.iobj *.ipdb *.lib *.pdb
+          fi
           shopt -s extglob dotglob
           mkdir "${{ steps.artifact-metadata.outputs.name }}"
           mv !("${{ steps.artifact-metadata.outputs.name }}") "${{ steps.artifact-metadata.outputs.name }}"

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -1,4 +1,4 @@
-name: Windows Build
+name: 🪟 Windows Builds
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -41,7 +41,7 @@ jobs:
         config: [Release, Release AVX2]
         experimental: [false]
 
-    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.config }}
+    name: "${{ matrix.platform }} | ${{ matrix.config }}"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: |
           ARCH=$([ "${{ matrix.platform }}" == Win32 ] && echo "32bit" || echo "64bit")
-          SIMD=$([ "${{ matrix.platform }}" == Release ] && echo "SSE4" || echo "AVX2")
+          SIMD=$([ "${{ matrix.config }}" == Release ] && echo "SSE4" || echo "AVX2")
           ARTIFACT_NAME=""
           if [ ${{ github.event_name }} == "pull_request" ]; then
             PR_SHA=$(git rev-parse --short "${{ github.event.pull_request.head.sha }}")

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -38,9 +38,10 @@ jobs:
       matrix:
         os: [windows-2019]
         platform: [Win32, x64]
+        config: [Release, Release AVX2]
         experimental: [false]
 
-    name: ${{ matrix.os }}-${{ matrix.platform }}
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.config }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
@@ -74,17 +75,18 @@ jobs:
         env:
           # Set to 'true' to retain the .pdb / .exp / .lib, etc files which can be useful for repro'ing issues that only occur in the compiled .exe
           RetainDebuggingArtifacts: ${{ github.event.inputs.retainDebugArtifacts == 'true' }}
-        run: msbuild "buildbot.xml" /m /v:n /t:ReleaseAll /p:Platform=${{ matrix.platform }}
+        run: msbuild "PCSX2_suite.sln" /m /v:m /p:Configuration="${{ matrix.config }}" /p:Platform="${{ matrix.platform }}"
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata
         shell: bash
         run: |
           ARCH=$([ "${{ matrix.platform }}" == Win32 ] && echo "32bit" || echo "64bit")
+          SIMD=$([ "${{ matrix.platform }}" == Release ] && echo "SSE4" || echo "AVX2")
           ARTIFACT_NAME=""
           if [ ${{ github.event_name }} == "pull_request" ]; then
             PR_SHA=$(git rev-parse --short "${{ github.event.pull_request.head.sha }}")
-            ARTIFACT_NAME="PCSX2-${ARCH}"
+            ARTIFACT_NAME="PCSX2-${ARCH}-${SIMD}"
             if [ ! -z "${{ github.event.pull_request.number }}" ]; then
               PR_NUM=${{ github.event.pull_request.number }}
               ARTIFACT_NAME="${ARTIFACT_NAME}-pr[${PR_NUM}]"
@@ -96,7 +98,7 @@ jobs:
             fi
           else
             SHA=$(git rev-parse --short "$GITHUB_SHA")
-            ARTIFACT_NAME="PCSX2-${ARCH}-sha[${SHA}"
+            ARTIFACT_NAME="PCSX2-${ARCH}-${SIMD}-sha[${SHA}"
           fi
           TRIMMED_ARTIFACT_NAME=$(printf "%.199s]" "$ARTIFACT_NAME")
           echo "name=$TRIMMED_ARTIFACT_NAME"

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -1,4 +1,4 @@
-name: 🪟 Windows Builds
+name: 🖥️ Windows Builds
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PCSX2
 
-![Windows Build](https://github.com/PCSX2/pcsx2/workflows/Windows%20Build/badge.svg)
-![Linux Build](https://github.com/PCSX2/pcsx2/workflows/Linux%20Build/badge.svg)
+![Windows Build Status](https://img.shields.io/github/workflow/status/PCSX2/pcsx2/%F0%9F%96%A5%EF%B8%8F%20Windows%20Builds/master?label=Windows%20Builds)
+![Linux Build Status](https://img.shields.io/github/workflow/status/PCSX2/pcsx2/%F0%9F%90%A7%20Linux%20Builds/master?label=Linux%20Builds)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1f7c0d75fec74d6daa6adb084e5b4f71)](https://www.codacy.com/gh/PCSX2/pcsx2/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=PCSX2/pcsx2&amp;utm_campaign=Badge_Grade)
 [![Discord Server](https://img.shields.io/discord/309643527816609793?color=%235CA8FA&label=PCSX2%20Discord&logo=discord&logoColor=white)](https://discord.com/invite/TCz3t9k)
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Doubles our windows builds, but increases parallelism.  A good interim solution until we can truly improve the compile times and remove unnecessary builds.

I also adjusted the naming of the Workflows a bit to make them categorized (via emojis) and reduces unnecessary words (ex. obviously windows builds are running on windows) since we now have a substantial number of them.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
