### PR TITLE
IPU: Fix SETTH threshold masks

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -659,9 +659,9 @@ static __ri bool ipuPACK(tIPU_CMD_CSC csc)
 
 static void ipuSETTH(u32 val)
 {
-	s_thresh[0] = (val & 0xff);
-	s_thresh[1] = ((val >> 16) & 0xff);
-	IPU_LOG("SETTH (Set threshold value)command %x.", val&0xff00ff);
+	s_thresh[0] = (val & 0x1ff);
+	s_thresh[1] = ((val >> 16) & 0x1ff);
+	IPU_LOG("SETTH (Set threshold value)command %x.", val&0x1ff01ff);
 }
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes
According to available sources its 8:0 for transparency, and 24:16 for translucency.
Currently pcsx2 is masking bits 8 and 24 making them always 0.

### Rationale behind Changes
Improve IPU color space conversion accuracy.
### Suggested Testing Steps
Testing FMVs for regressions/improvements. Possibly affect IPU texturing (rare thing afaik).