### PR TITLE
AppCoreThread: remove unneeded includes & unneeded double init call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,6 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/pcsx2" AND pcsx2_core)
     add_subdirectory(pcsx2)
 endif()
 
-# make plugins
-if(EXISTS "${CMAKE_SOURCE_DIR}/plugins")
-    add_subdirectory(plugins)
-endif()
-
 # tests
 if(ACTUALLY_ENABLE_TESTS)
     add_subdirectory(3rdparty/gtest EXCLUDE_FROM_ALL)

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -29,17 +29,11 @@
 #include "GS.h"
 
 #include "CDVD/CDVD.h"
-#include "SPU2/spu2.h"
 #include "USB/USB.h"
 #include "Elfheader.h"
 #include "Patch.h"
 #include "R5900Exceptions.h"
 #include "Sio.h"
-#ifdef _WIN32
-#include "PAD/Windows/PAD.h"
-#else
-#include "PAD/Linux/PAD.h"
-#endif
 
 #ifndef DISABLE_RECORDING
 #include "Recording/InputRecordingControls.h"
@@ -184,8 +178,6 @@ void AppCoreThread::Resume()
 		GetSysExecutorThread().PostEvent(SysExecEvent_InvokeCoreThreadMethod(&AppCoreThread::Resume));
 		return;
 	}
-
-	SPU2init();
 	_parent::Resume();
 }
 


### PR DESCRIPTION
Leftovers from the plugin merge, SPU2init call was redundant, we might want some light testing through some SPU2 lifecycles to ensure this doesn't break anything