### PR TITLE
GameDB: Add dynamic patching for Ratchet & Clank games

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -24,7 +24,6 @@ allowed_game_fixes = [
     "FpuMulHack",
     "FpuNegDivHack",
     "XGKickHack",
-    "IPUWaitHack",
     "EETimingHack",
     "SkipMPEGHack",
     "OPHFlagHack",
@@ -35,6 +34,7 @@ allowed_game_fixes = [
     "GoemonTlbHack",
     "VU0KickstartHack",
     "IbitHack",
+    "RatchetDynaHack",
 ]
 allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack"]
 # Patches are allowed to have a 'default' key or a crc-32 key, followed by

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -100,6 +100,7 @@ PBPX-95514:
   region: "PAL-M5"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS in Ratchet and Clank.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 PBPX-95517:
   name: "Network Adapter Start-Up Disc"
   region: "NTSC-U"
@@ -175,6 +176,7 @@ SCAJ-20001:
   region: "NTSC-Unk"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCAJ-20002:
   name: "Gallop Racer 6 - Revolution"
   region: "NTSC-Unk"
@@ -561,6 +563,7 @@ SCAJ-20109:
   region: "NTSC-Unk"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCAJ-20110:
   name: "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi"
   region: "NTSC-Unk"
@@ -765,6 +768,7 @@ SCAJ-20157:
   region: "NTSC-Unk"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCAJ-20158:
   name: "Ikusa Gami"
   region: "NTSC-Unk"
@@ -1080,8 +1084,6 @@ SCED-50642:
   region: "PAL-E"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCED-50748:
   name: "Official PlayStation 2 Magazine Demo 26"
   region: "PAL-M5"
@@ -1093,8 +1095,6 @@ SCED-50907:
   region: "PAL-Unk"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCED-51531:
   name: "Official PlayStation 2 Magazine Demo 33"
   region: "PAL-M5"
@@ -1333,37 +1333,27 @@ SCES-50490:
   compat: 5
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCES-50491:
   name: "Final Fantasy X"
   region: "PAL-F"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCES-50492:
   name: "Final Fantasy X"
   region: "PAL-G"
   compat: 5
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCES-50493:
   name: "Final Fantasy X"
   region: "PAL-I"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCES-50494:
   name: "Final Fantasy X"
   region: "PAL-S"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SCES-50499:
   name: "Ecco the Dolphin - Defender of the Future"
   region: "PAL-M5"
@@ -1505,6 +1495,7 @@ SCES-50916:
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCES-50917:
   name: "Sly Racoon"
   region: "PAL-M5"
@@ -1688,6 +1679,7 @@ SCES-51607:
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes DMA errors 
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters: # Reads Ratchet 1 data.
     - "SCES-51607"
     - "SCES-50916"
@@ -1954,6 +1946,7 @@ SCES-52456:
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
     - "SCES-51607"
@@ -2118,6 +2111,7 @@ SCES-53285:
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCES-53286:
   name: "Jak X - Combat Racing"
   region: "PAL-M7"
@@ -2681,6 +2675,7 @@ SCKA-20011:
   region: "NTSC-K"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters:
     - "SCKA-20011"
     - "SCKA-20120"
@@ -2772,6 +2767,7 @@ SCKA-20037:
   region: "NTSC-K"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters:
     - "SCKA-20037"
     - "SCKA-20011"
@@ -2859,6 +2855,7 @@ SCKA-20060:
   region: "NTSC-K"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCKA-20061:
   name: "Wanda to Kyozou (Shadow of the Colossus)"
   region: "NTSC-K"
@@ -2972,6 +2969,7 @@ SCKA-20120:
   region: "NTSC-K"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCKA-20132:
   name: "Shin Megami Tensei: Persona 4"
   region: "NTSC-K"
@@ -3276,6 +3274,7 @@ SCPS-15037:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-15038:
   name: "Operator's Side"
   region: "NTSC-J"
@@ -3354,6 +3353,7 @@ SCPS-15056:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters:
     - "SCPS-15056"
     - "SCPS-15037"
@@ -3538,11 +3538,13 @@ SCPS-15099:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-15100:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-15101:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-J"
@@ -3734,6 +3736,7 @@ SCPS-19211:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19213:
   name: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
   region: "NTSC-J"
@@ -3775,6 +3778,7 @@ SCPS-19302:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19303:
   name: "Boku no Natsuyasumi 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -3812,11 +3816,13 @@ SCPS-19309:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19310:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19311:
   name: "Saru Get You 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -3845,11 +3851,13 @@ SCPS-19316:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19317:
   name: "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19318:
   name: "Genji - Dawn of the Samurai [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -3872,6 +3880,7 @@ SCPS-19321:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19322:
   name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
@@ -3919,6 +3928,7 @@ SCPS-19328:
   region: "NTSC-J"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCPS-19329:
   name: "Bleach - Blade Battlers [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -4599,6 +4609,7 @@ SCUS-97199:
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97200:
   name: "Kiosk Demo Disc 2.05"
   region: "NTSC-U"
@@ -4632,6 +4643,7 @@ SCUS-97209:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
   region: "NTSC-U"
@@ -4734,6 +4746,7 @@ SCUS-97240:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97241:
   name: "Official U.S. PlayStation Magazine Demo Disc 066"
   region: "NTSC-U"
@@ -4822,11 +4835,12 @@ SCUS-97266:
   region: "NTSC-U"
   compat: 3
 SCUS-97268:
-  name: "Ratchet & Clank - Going Commando"
+  name: "Ratchet & Clank 2 - Going Commando"
   region: "NTSC-U"
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters:
     - "SCUS-97268"
     - "SCUS-97199"
@@ -4917,11 +4931,13 @@ SCUS-97322:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
   region: "NTSC-U"
@@ -5009,6 +5025,7 @@ SCUS-97353:
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
   memcardFilters:
     - "SCUS-97353"
     - "SCUS-97268"
@@ -5064,6 +5081,7 @@ SCUS-97374:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS (for both).
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
@@ -5082,6 +5100,7 @@ SCUS-97381:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97382:
   name: "NBA Shootout 2004 [Demo]"
   region: "NTSC-U"
@@ -5153,6 +5172,7 @@ SCUS-97411:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
@@ -5163,6 +5183,7 @@ SCUS-97413:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97414:
   name: "EyeToy - AntiGrav"
   region: "NTSC-U"
@@ -5326,6 +5347,7 @@ SCUS-97465:
   compat: 5
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97466:
   name: "Gretzky NHL '06"
   region: "NTSC-U"
@@ -5414,6 +5436,7 @@ SCUS-97485:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97486:
   name: "Jak X - Combat Racing [Regular Demo]"
   region: "NTSC-U"
@@ -5424,6 +5447,7 @@ SCUS-97487:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97488:
   name: "Jak X - Combat Racing [Public Beta v.1]"
   region: "NTSC-U"
@@ -5514,10 +5538,11 @@ SCUS-97512:
     - "SCUS-97512"
     - "SCUS-97102"
 SCUS-97513:
-  name: "Ratchet & Clank - Going Commando [Greatest Hits]"
+  name: "Ratchet & Clank 2 - Going Commando [Greatest Hits]"
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97514:
   name: "ATV Off-Road Fury 3 [Greatest Hits]"
   region: "NTSC-U"
@@ -5539,6 +5564,7 @@ SCUS-97518:
   region: "NTSC-U"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 SCUS-97519:
   name: "Sly 2 - Band of Thieves [Greatest Hits]"
   region: "NTSC-U"
@@ -17833,8 +17859,6 @@ SLKA-25214:
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLKA-25215:
   name: "Shining Wild"
   region: "NTSC-K"
@@ -20721,8 +20745,6 @@ SLPM-65115:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPM-65116:
   name: "Lilie no Atelier Plus: Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
@@ -23720,8 +23742,6 @@ SLPM-66124:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPM-66125:
   name: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
@@ -25483,8 +25503,6 @@ SLPM-66677:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPM-66678:
   name: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
@@ -26483,8 +26501,6 @@ SLPM-67513:
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPM-67514:
   name: "Kessen"
   region: "NTSC-K"
@@ -28041,8 +28057,6 @@ SLPS-25050:
   compat: 5
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPS-25051:
   name: "Missing Blue"
   region: "NTSC-J"
@@ -28155,8 +28169,6 @@ SLPS-25088:
   compat: 5
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPS-25094:
   name: "Reveal Fantasia"
   region: "NTSC-J"
@@ -30909,8 +30921,6 @@ SLPS-72501:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 1  # Fixes reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLPS-72502:
   name: "Tales of Destiny 2 [Mega Hits]"
   region: "NTSC-J"
@@ -32472,8 +32482,6 @@ SLUS-20312:
   compat: 5
   roundModes:
     eeRoundMode: 1  # Fix reverse control and boss in some places.
-  gameFixes:
-    - IPUWaitHack
 SLUS-20313:
   name: "Wave Rally"
   region: "NTSC-U"
@@ -40017,6 +40025,7 @@ TCES-52456:
   region: "PAL-E"
   gameFixes:
     - VU0KickstartHack # Fixes Character SPS.
+    - RatchetDynaHack # Dynamically patches bad COP2 code in Ratchet and Clank games
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
   region: "PAL-E"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -31,7 +31,6 @@ enum GamefixId
 	Fix_FpuMultiply,
 	Fix_FpuNegDiv,
 	Fix_XGKick,
-	Fix_IpuWait,
 	Fix_EETiming,
 	Fix_SkipMpeg,
 	Fix_OPHFlag,
@@ -42,6 +41,7 @@ enum GamefixId
 	Fix_GoemonTlbMiss,
 	Fix_Ibit,
 	Fix_VU0Kickstart,
+	Fix_RatchetDyna,
 
 	GamefixId_COUNT
 };
@@ -334,23 +334,23 @@ struct Pcsx2Config
 	// NOTE: The GUI's GameFixes panel is dependent on the order of bits in this structure.
 	struct GamefixOptions
 	{
-        BITFIELD32()
-        bool
-            VuAddSubHack : 1,           // Tri-ace games, they use an encryption algorithm that requires VU ADDI opcode to be bit-accurate.
-            FpuMulHack : 1,             // Tales of Destiny hangs.
-            FpuNegDivHack : 1,          // Gundam games messed up camera-view.
-            XgKickHack : 1,             // Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
-            IPUWaitHack : 1,            // FFX FMV, makes GIF flush before doing IPU work. Fixes bad graphics overlay.
-            EETimingHack : 1,           // General purpose timing hack.
-            SkipMPEGHack : 1,           // Skips MPEG videos (Katamari and other games need this)
-            OPHFlagHack : 1,            // Bleach Blade Battlers
-            DMABusyHack : 1,            // Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.
-            VIFFIFOHack : 1,            // Pretends to fill the non-existant VIF FIFO Buffer.
-            VIF1StallHack : 1,          // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
-            GIFFIFOHack : 1,            // Enabled the GIF FIFO (more correct but slower)
-            GoemonTlbHack : 1,          // Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
-            IbitHack : 1,               // I bit hack. Needed to stop constant VU recompilation in some games
-            VU0KickstartHack : 1;       // Speed up VU0 at start of program to avoid some VU1 sync issues
+		BITFIELD32()
+		bool
+			VuAddSubHack : 1,			// Tri-ace games, they use an encryption algorithm that requires VU ADDI opcode to be bit-accurate.
+			FpuMulHack : 1,				// Tales of Destiny hangs.
+			FpuNegDivHack : 1,			// Gundam games messed up camera-view.
+			XgKickHack : 1,				// Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
+			EETimingHack : 1,			// General purpose timing hack.
+			SkipMPEGHack : 1,			// Skips MPEG videos (Katamari and other games need this)
+			OPHFlagHack : 1,			// Bleach Blade Battlers
+			DMABusyHack : 1,			// Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.
+			VIFFIFOHack : 1,			// Pretends to fill the non-existant VIF FIFO Buffer.
+			VIF1StallHack : 1,			// Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
+			GIFFIFOHack : 1,			// Enabled the GIF FIFO (more correct but slower)
+			GoemonTlbHack : 1,			// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
+			IbitHack : 1,				// I bit hack. Needed to stop constant VU recompilation in some games
+			VU0KickstartHack : 1,		// Gives new VU programs a slight head start and runs VU's ahead of EE to avoid VU register reading/writing issues
+			RatchetDynaHack : 1;		// Dynamically patch bad COP2 timing in EE program as it cannot be patched traditionally
 		BITFIELD_END
 
 		GamefixOptions();
@@ -530,7 +530,6 @@ TraceLogFilters&				SetTraceConfig();
 #define CHECK_FPUMULHACK			(EmuConfig.Gamefixes.FpuMulHack)	 // Special Fix for Tales of Destiny hangs.
 #define CHECK_FPUNEGDIVHACK			(EmuConfig.Gamefixes.FpuNegDivHack)	 // Special Fix for Gundam games messed up camera-view.
 #define CHECK_XGKICKHACK			(EmuConfig.Gamefixes.XgKickHack)	 // Special Fix for Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics.
-#define CHECK_IPUWAITHACK			(EmuConfig.Gamefixes.IPUWaitHack)	 // Special Fix For FFX
 #define CHECK_EETIMINGHACK			(EmuConfig.Gamefixes.EETimingHack)	 // Fix all scheduled events to happen in 1 cycle.
 #define CHECK_SKIPMPEGHACK			(EmuConfig.Gamefixes.SkipMPEGHack)	 // Finds sceMpegIsEnd pattern to tell the game the mpeg is finished (Katamari and a lot of games need this)
 #define CHECK_OPHFLAGHACK			(EmuConfig.Gamefixes.OPHFlagHack)	 // Bleach Blade Battlers

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -276,7 +276,6 @@ const wxChar *const tbl_GamefixNames[] =
 	L"FpuMul",
 	L"FpuNegDiv",
 	L"XGKick",
-	L"IPUWait",
 	L"EETiming",
 	L"SkipMPEG",
 	L"OPHFlag",
@@ -286,7 +285,8 @@ const wxChar *const tbl_GamefixNames[] =
 	L"GIFFIFO",
 	L"GoemonTlb",
 	L"Ibit",
-	L"VU0Kickstart"
+	L"VU0Kickstart",
+	L"RatchetDyna"
 };
 
 const __fi wxChar* EnumToString( GamefixId id )
@@ -337,7 +337,6 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_FpuMultiply:	FpuMulHack			= enabled;	break;
 		case Fix_FpuNegDiv:		FpuNegDivHack		= enabled;	break;
 		case Fix_XGKick:		XgKickHack			= enabled;	break;
-		case Fix_IpuWait:		IPUWaitHack			= enabled;	break;
 		case Fix_EETiming:		EETimingHack		= enabled;	break;
 		case Fix_SkipMpeg:		SkipMPEGHack		= enabled;	break;
 		case Fix_OPHFlag:		OPHFlagHack			= enabled;  break;
@@ -348,6 +347,7 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;  break;
 		case Fix_Ibit:			IbitHack			= enabled;  break;
 		case Fix_VU0Kickstart:	VU0KickstartHack	= enabled; break;
+		case Fix_RatchetDyna:	RatchetDynaHack		= enabled; break;
 		jNO_DEFAULT;
 	}
 }
@@ -361,7 +361,6 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_FpuMultiply:	return FpuMulHack;
 		case Fix_FpuNegDiv:		return FpuNegDivHack;
 		case Fix_XGKick:		return XgKickHack;
-		case Fix_IpuWait:		return IPUWaitHack;
 		case Fix_EETiming:		return EETimingHack;
 		case Fix_SkipMpeg:		return SkipMPEGHack;
 		case Fix_OPHFlag:		return OPHFlagHack;
@@ -372,6 +371,7 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_GoemonTlbMiss: return GoemonTlbHack;
 		case Fix_Ibit:			return IbitHack;
 		case Fix_VU0Kickstart:	return VU0KickstartHack;
+		case Fix_RatchetDyna:	return RatchetDynaHack;
 		jNO_DEFAULT;
 	}
 	return false;		// unreachable, but we still need to suppress warnings >_<
@@ -385,7 +385,6 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( FpuMulHack );
 	IniBitBool( FpuNegDivHack );
 	IniBitBool( XgKickHack );
-	IniBitBool( IPUWaitHack );
 	IniBitBool( EETimingHack );
 	IniBitBool( SkipMPEGHack );
 	IniBitBool( OPHFlagHack );
@@ -396,6 +395,7 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( GoemonTlbHack );
 	IniBitBool( IbitHack );
 	IniBitBool( VU0KickstartHack );
+	IniBitBool( RatchetDynaHack );
 }
 
 

--- a/pcsx2/SPR.cpp
+++ b/pcsx2/SPR.cpp
@@ -390,16 +390,8 @@ int  _SPR1chain()
 __fi void SPR1chain()
 {
 	int cycles = 0;
-	if(!CHECK_IPUWAITHACK)
-	{
-		cycles =  _SPR1chain() * BIAS;
-		CPU_INT(DMAC_TO_SPR, cycles);
-	}
-	else
-	{
-		 _SPR1chain();
-		CPU_INT(DMAC_TO_SPR, 8);
-	}
+	cycles =  _SPR1chain() * BIAS;
+	CPU_INT(DMAC_TO_SPR, cycles);
 }
 
 void _SPR1interleave()

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -53,10 +53,6 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("FFX videos fix - Fixes bad graphics overlay in FFX videos."),
-			wxEmptyString
-		},
-		{
 			_("EE timing hack - Multi purpose hack. Try if all else fails."),
 			pxEt( L"Known to affect following games:\n * Digital Devil Saga (Fixes FMV and crashes)\n * SSX (Fixes bad graphics and crashes)\n * Resident Evil: Dead Aim (Causes garbled textures)"
 			)
@@ -97,7 +93,11 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("VU0 Kickstart to avoid sync problems with VU1"),
+			_("VU Kickstart (Run ahead) to avoid sync problems when reading or writing VU registers"),
+			wxEmptyString
+		},
+		{
+			_("Dynamically patch bad COP2 timing with Ratchet && Clank games"),
 			wxEmptyString
 		}
 	};

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1373,6 +1373,26 @@ void recompileNextInstruction(int delayslot)
 
 	cpuRegs.code = *(int *)s_pCode;
 
+	// Hardcoded Ratchet & Clank fixes since the game dyamically replaces memory for the program
+	// meaning it cannot be patched easily by traditional methods.
+	if (!EmuConfig.Gamefixes.RatchetDynaHack)
+	{
+		if (cpuRegs.code == 0x4B8123BC)
+		{
+			if (*(int*)PSM(pc + 0x4) == 0x4BE30858 && *(int*)PSM(pc + 0x8) == 0xF8610010 && *(int*)PSM(pc + 0xc) == 0x4A20009C)
+			{
+				DevCon.Warning("Patching Ratchet and Clank bad COP2 sequence at PC %x", cpuRegs.pc);
+				cpuRegs.code = 0x4A20009C;
+
+				memWrite32(pc, 0x4A20009C);
+				memWrite32(pc + 0x4, 0x4B8123BC);
+				memWrite32(pc + 0x8, 0x4BE30858);
+				memWrite32(pc + 0xc, 0xF8610010);
+				
+			}
+		}
+	}
+
 	if (!delayslot) {
 		pc += 4;
 		g_cpuFlushedPC = false;


### PR DESCRIPTION
Removed IPUWait hack as it is no longer required

### Description of Changes
Added dynamic patching system in the recompiler for Ratchet & Clank games toggled by gamefix. Fixes various shadow and SPS problems, improves spawn logic in Q9 station arena challenges, also problems with Ammu-nation in Up Your Arsenal.

### Rationale behind Changes
Ratchet & Clank dynamically allocates memory for the program to run from, so traditional patching is not possible and can cause TLB misses.

### Suggested Testing Steps
Play the Ratchet & Clank games (Aside from Size Matters), places where it went a bit loopy should be okay now.  Turret is still broken, but may be able to add a patch for that before this PR is merged.
