### PR TITLE
IOP Interpreter: Warn on branches to zero

### DIFF
--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -250,6 +250,9 @@ static __fi void execI()
 }
 
 static void doBranch(s32 tar) {
+	if (tar == 0x0)
+		DevCon.Warning("[R3000 Interpreter] Warning: Branch to 0x0!");
+
 	branch2 = iopIsDelaySlot = true;
 	branchPC = tar;
 	execI();


### PR DESCRIPTION
### Description of Changes
Whenever there is a branch to zero, put a warning in the console. 

### Rationale behind Changes
The interpreter can start executing garbage, and this will tell us why.
(Also helps me debug my poor IOP code :P)

### Suggested Testing Steps
Make the IOP branch to zero.