### PR TITLE
GameDB: Adding a couple of demo discs.

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -1142,8 +1142,14 @@ SCED-52053:
 SCED-52057:
   name: "Official Playstation Magazine Demo Disc 40"
   region: "PAL-IT"
+SCED-52260:
+  name: "Forbidden Siren [Demo]"
+  region: "PAL-M5"
 SCED-52355:
   name: "Military Multi Demo"
+  region: "PAL-M5"
+SCED-52932:
+  name: "Bonus Demo 8 (old)"
   region: "PAL-M5"
 SCED-52436:
   name: "Playstation2 UK Demo 7-2004"


### PR DESCRIPTION
### Description of Changes
Adding Forbidden Siren (PAL demo disc) as well as the Bonus Demo 8 (old) demo disc, which was included with an updated Network Disc.

NOTE: The "(old)" part is written verbatim on the disc. Reference picture:

![IMG_0091](https://user-images.githubusercontent.com/5641681/125791141-d3a31026-8829-4338-b7c5-e2054d8ddd1d.JPG)