### PR TITLE
GameDB: Patches for 18 games (or 15 individual games)

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -1026,6 +1026,15 @@ SCCS-40003:
 SCCS-40005:
   name: "ICO"
   region: "NTSC-C"
+  clampModes:
+    eeClampMode: 2  # Game require EE clamping set to Extra + Preserve Sign to not freeze.
+  patches:
+    BF3A46DA:
+      content: |-
+        author=kozarovv
+        // Game expect sceCdStatPause at some point, but for some reason value is never set.
+        // So instead, set expected value to be sceCdStatSpin, to allow further modules loading.
+        patch=0,EE,0010EDD4,word,24100002
 SCCS-40006:
   name: "Shin Sangoku Musou 2"
   region: "NTSC-C"
@@ -7343,16 +7352,6 @@ SLES-50215:
   name: "Crazy Taxi"
   region: "PAL-M4"
   compat: 5
-  patches:
-    C9C145BF:
-      content: |-
-        comment=Patches by Nachbrenner
-        // Skip movie 'PlaySega'.
-        patch=0,EE,001a42d0,word,03e00008
-        patch=0,EE,001a42d4,word,00000000
-        // Skip movie 'PlayAcclaim'.
-        patch=0,EE,001a4468,word,03e00008
-        patch=0,EE,001a446c,word,00000000
 SLES-50217:
   name: "Dave Mirra Freestyle BMX 2"
   region: "PAL-E-S"
@@ -9507,17 +9506,6 @@ SLES-51341:
 SLES-51343:
   name: "Galerians - Ash"
   region: "PAL-M5"
-  patches:
-    1AE08CF5:
-      content: |-
-        author=kozarovv
-        // Floats workaround to make HW GSDX mode working.
-        // There is still overflow on GS, but this time GSDX can handle it just fine in HW mode.
-        patch=1,EE,001e7130,word,3c017e00
-        patch=1,EE,001e7138,word,44812800
-        patch=1,EE,001e7150,word,44813000
-        patch=1,EE,001e7160,word,44813800
-        patch=1,EE,001e7170,word,44810000
 SLES-51344:
   name: "Guilty Gear X2"
   region: "PAL-E"
@@ -9647,6 +9635,12 @@ SLES-51391:
 SLES-51392:
   name: "Evolution Snowboarding"
   region: "PAL-M3"
+  patches:
+    2B2E1535:
+      content: |-
+        author=kozarovv
+        // Skip PSS movies, workaround for EE Cache requirement.
+        patch=1,EE,001233e0,word,100000d7
 SLES-51393:
   name: "Syberia"
   region: "PAL-M5"
@@ -12535,6 +12529,13 @@ SLES-52965:
 SLES-52966:
   name: "ESPN NHL 2K5"
   region: "PAL-E"
+  patches:
+    EC301155:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Avoid hanging at loading screen.
+        patch=1,EE,003e4018,word,00000000
 SLES-52967:
   name: "Guilty Gear X2 Reloaded"
   region: "PAL-E"
@@ -13642,14 +13643,13 @@ SLES-53518:
 SLES-53521:
   name: "Musashi - Samurai Legend"
   region: "PAL-M4"
-  roundModes:
-    vuRoundMode: 0  # Fixes Red SPS while ingame.
-    eeRoundMode: 0  # Partially fixes wrong enemies eye rendering.
-  clampModes:
-    vuClampMode: 3  # Fixes White SPS while ingame.
-    eeClampMode: 3  # Fixes White SPS while ingame.
-  gameFixes:
-    - EETimingHack # Fixes garbled character animation.
+  patches:
+    BC897AC9:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Fixes almost all problems apart from little translucent fog effect in some areas.
+        patch=1,EE,00147828,word,00000000
 SLES-53523:
   name: "Gun"
   region: "PAL-M4"
@@ -14088,10 +14088,17 @@ SLES-53685:
   region: "PAL-E-G"
   compat: 5
 SLES-53686:
-  name: "NHL Hockey 2K6"
+  name: "NHL 2K6"
   region: "PAL-M3"
+  patches:
+    98ec4d86:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Avoid hanging at loading screen.
+        patch=1,EE,00433150,word,00000000
 SLES-53687:
-  name: "NHL Hockey 2K6"
+  name: "NBA 2K6"
   region: "PAL-M5"
 SLES-53689:
   name: "World Poker Tour 2K6"
@@ -15176,6 +15183,13 @@ SLES-54210:
 SLES-54211:
   name: "NHL 2K7"
   region: "PAL-M5"
+  patches:
+    1ad6efd1:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Avoid hanging at loading screen.
+        patch=1,EE,004412a8,word,00000000
 SLES-54212:
   name: "Agent Hugo - RoboRumble"
   region: "PAL-M11"
@@ -16559,8 +16573,15 @@ SLES-54880:
   name: "NBA 2K8"
   region: "PAL-M5"
 SLES-54881:
-  name: "NBA 2K8"
+  name: "NHL 2K8"
   region: "PAL-M5"
+  patches:
+    F2027778:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Avoid hanging at loading screen.
+        patch=1,EE,004323b8,word,00000000
 SLES-54882:
   name: "Gecko Blaster"
   region: "PAL-M5"
@@ -17350,10 +17371,17 @@ SLES-55251:
   region: "PAL-M5"
   compat: 5
 SLES-55252:
-  name: "NBA 2K5"
+  name: "NHL 2K9"
   region: "PAL-M5"
+  patches:
+    5d981df2:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Avoid hanging at loading screen.
+        patch=1,EE,00430d38,word,00000000
 SLES-55253:
-  name: "NBA 2K5"
+  name: "NBA 2K9"
   region: "PAL-M5"
 SLES-55254:
   name: "Incredible Hulk, The"
@@ -19074,6 +19102,15 @@ SLPM-60101:
 SLPM-60102:
   name: "From Software First Previews"
   region: "NTSC-J"
+  patches:
+    9E9AC9DC:
+      content: |-
+        author=kozarovv
+        // Patch for From Software First Preview, Evergrace demo. 
+        // Fix loading. Expected data is 2 bytes later than game trying to read it. 
+        // Patch force read from address where data is.
+        patch=1,EE,E0018447,extended,0023BB86
+        patch=1,EE,0023BB84,extended,00000006
 SLPM-60104:
   name: "Konami PlayStation 2 Taikeban"
   region: "NTSC-J"
@@ -24119,6 +24156,13 @@ SLPM-66008:
     eeClampMode: 3  # Fixes White SPS while ingame.
   gameFixes:
     - EETimingHack # Fixes garbled character animation.
+  patches:
+    F0E90890:
+      content: |-
+        author=Prafull
+        comment=patched by Prafull
+        // Fixes almost all problems apart from little translucent fog effect in some areas.
+        patch=1,EE,00147c38,word,00000000
 SLPM-66009:
   name: "World Soccer Winning Eleven 9 - Bonus Pack"
   region: "NTSC-J"
@@ -32725,25 +32769,6 @@ SLUS-20202:
   name: "Crazy Taxi"
   region: "NTSC-U"
   compat: 5
-  patches:
-    F00293CA:
-      content: |-
-        comment=Patches by Nachbrenner
-        // Skip movie 'PlaySega'.
-        patch=0,EE,001a0b50,word,03e00008
-        patch=0,EE,001a0b54,word,00000000
-        // Skip movie 'PlayAcclaim'.
-        patch=0,EE,001a0ce8,word,03e00008
-        patch=0,EE,001a0cec,word,00000000
-    4C9EE7DF:
-      content: |-
-        comment=Patches by Nachbrenner
-        // Skip movie 'PlaySega'.
-        patch=0,EE,001a1950,word,03e00008
-        patch=0,EE,001a1954,word,00000000
-        // Skip movie 'PlayAcclaim'.
-        patch=0,EE,001a1ae8,word,03e00008
-        patch=0,EE,001a1aec,word,00000000
 SLUS-20204:
   name: "Smuggler's Run 2 - Hostile Territory"
   region: "NTSC-U"
@@ -32816,6 +32841,12 @@ SLUS-20217:
   name: "Arctic Thunder"
   region: "NTSC-U"
   compat: 5
+  patches:
+    2B2E1535:
+      content: |-
+        author=kozarovv
+        // Set proper height for in game videos. Prevent videos being displayed doubled vertically.
+        patch=1,EE,0013345C,word,240701c0
 SLUS-20218:
   name: "Stunt GP"
   region: "NTSC-U"
@@ -33256,6 +33287,26 @@ SLUS-20323:
   name: "Virtua Fighter 4"
   region: "NTSC-U"
   compat: 5
+  patches:
+    EA131B57:
+      content: |-
+        author=kozarovv
+        // Fix for Virtua Fighter 4 SLUS-20323 hang while loading replays.
+        // Game interrupt required data read if break command is done too early.
+        // Hard to tell that it works by luck on PS2, or maybe something is missing on pcsx2 side.
+        // Also workaround to https://github.com/PCSX2/pcsx2/issues/2009. 
+        // Note: CDVD Break is used only in few places in that title, all of them break without patch.
+        // Delay Break CDVD command
+        // Fix replays / A.I replays loading
+        patch=1,IOP,0003d010,word,0807fff9
+        patch=1,IOP,0003d014,word,3c020004
+        patch=1,IOP,001fffe4,word,24180016
+        patch=1,IOP,001fffe8,word,14980003
+        patch=1,IOP,001fffec,word,3c190010
+        patch=1,IOP,001ffff0,word,1720ffff
+        patch=1,IOP,001ffff4,word,2739ffff
+        patch=1,IOP,001ffff8,word,0800f406
+        patch=1,IOP,001ffffc,word,8c42e36c
 SLUS-20324:
   name: "Paris Dakar Rally"
   region: "NTSC-U"
@@ -34211,10 +34262,12 @@ SLUS-20546:
   name: "Evolution Snowboarding"
   region: "NTSC-U"
   compat: 4
-  gameFixes:
-    - OPHFlagHack # Avoid hanging at the "press start" screen.
-  # Comments from old GameIndex.dbf for this Game
-  #  Needs EmotionEngine set to "Interpreter" and "Enable EE Cache" enabled.
+  patches:
+    2B2E1535:
+      content: |-
+        author=kozarovv
+        // Skip PSS movies, workaround for EE Cache requirement.
+        patch=1,EE,00122d00,word,100000d9
 SLUS-20547:
   name: "Cubix Showdown"
   region: "NTSC-U"
@@ -35090,6 +35143,11 @@ SLUS-20758:
   patches:
     03F9C6D1:
       content: |-
+        author=kozarovv
+        // Growlanser Generations (2 and 3), When game fail at sceCdReadClock due to bad sema/thread state, it will just use 0 as timestamp.
+        // That make issues with next saves, and finally lead to freeze. 
+        // Patch force game to use WaitSema instead of PollSema in problematic place, that force thread rescheduling. 
+        patch=1,EE,001153DC,word,0C042618
         comment=IPU freeze fix
         patch=0,EE,00109d04,word,00000000
 SLUS-20759:
@@ -35100,6 +35158,11 @@ SLUS-20759:
     default:
       content: |-
         // CRC 4AD529BB, 4CD3663F
+        author=kozarovv
+        // Growlanser Generations (2 and 3), When game fail at sceCdReadClock due to bad sema/thread state, it will just use 0 as timestamp.
+        // That make issues with next saves, and finally lead to freeze. 
+        // Patch force game to use WaitSema instead of PollSema in problematic place, that force thread rescheduling. 
+        patch=1,EE,00114CBC,word,0C042618
         comment=IPU freeze fix
         patch=0,EE,00109d04,word,00000000
 SLUS-20760:
@@ -36031,19 +36094,11 @@ SLUS-20983:
   name: "Musashi Samurai Legend"
   region: "NTSC-U"
   compat: 5
-  roundModes:
-    vuRoundMode: 0  # Fixes Red SPS while ingame.
-    eeRoundMode: 0  # Partially fixes wrong enemies eye rendering.
-  clampModes:
-    vuClampMode: 3  # Fixes White SPS while ingame.
-    eeClampMode: 3  # Fixes White SPS while ingame.
-  gameFixes:
-    - EETimingHack # Fixes garbled character animation.
   patches:
     675CEB8F:
       content: |-
         author=Prafull
-        // Fixes almost all problems apart from little translucent fog effect in some areas
+        // Fixes almost all problems apart from little translucent fog effect in some areas.
         patch=1,EE,001473b0,word,00000000
 SLUS-20984:
   name: "Resident Evil Outbreak - File #2"
@@ -36314,6 +36369,13 @@ SLUS-21034:
 SLUS-21035:
   name: "Major League Baseball 2K5"
   region: "NTSC-U"
+  patches:
+    2243ce1d:
+      content: |-
+        author=Prafull
+        comment=Patched by Prafull
+        // Skip hang at start.
+        patch=1,EE,00364080,word,00000000
 SLUS-21036:
   name: "Get On Da Mic"
   region: "NTSC-U"
@@ -39222,7 +39284,7 @@ SLUS-21729:
         // Note: This issue will only happen if the game
         // run on the inhouse Visual Concept engine.
         // My theory is on a deep timing issue.
-        patch=0,EE,003cc1a0,word,00000000
+        patch=1,EE,003cc1a0,word,00000000
 SLUS-21730:
   name: "Jumper: Griffin's Story"
   region: "NTSC-U"
@@ -39998,6 +40060,12 @@ SLUS-21928:
 SLUS-21929:
   name: "Major League Baseball 2K10"
   region: "NTSC-U"
+  patches:
+    2283765A:
+      content: |-
+        author=Prafull
+        // Avoid hanging at loading screen.
+        patch=1,EE,003cd6d8,word,00000000
 SLUS-21930:
   name: "Sakura Wars: So Long, My Love [Japanese - Disc 2]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GameDB: Patches for 18 games (or 15 individual games)

- Arctic Thunder (NTSC-U)
- Evolution Snowboarding (PAL, NTSC-J, NTSC-U)
- From Software First Previews (NTSC-J)
- Growlanser Generations (NTSC-U, NTSC-U)
- ICO (NTSC-C)
- Major League Baseball 2K5 (NTSC-U)
- Major League Baseball 2K10 (NTSC-U)
- Musashiden II - Blademaster (NTSC-J)
- Musashi Samurai Legend (PAL)
- NHL 2K5 (PAL)
- NHL 2K6 (PAL)
- NHL 2K7 (PAL)
- NHL 2K8 (PAL)
- NHL 2K9 (PAL)
- Virtua Fighter 4 (NTSC-U)

Also fixed some wrong serials and a wrong patch.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Needed game patches which improve emulation experience.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Run with correct serial.