### PR TITLE
Don't update homebrew when not necessary

### DIFF
--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -99,8 +99,14 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
-          brew update
-          brew install sound-touch portaudio wxmac gtk+3 sdl2 libsamplerate
+          # To save time, only brew update if running the install without it fails
+          function do-install() {
+            brew install sound-touch portaudio wxmac gtk+3 sdl2 libsamplerate
+          }
+          if ! do-install; then
+            brew update
+            do-install
+          fi
 
       - name: Generate CMake Files
         run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PO=FALSE -B build .


### PR DESCRIPTION
### Description of Changes
Attempts to install packages without updating package lists and only updates package lists if that fails

### Rationale behind Changes
Updating package lists was done to fix issues during the Homebrew package provider transition, but it adds anywhere from 30s to 3-4m to the build depending on how recently GitHub updated Homebrew in its images, since you can end up with things like "GTK requires Python" → "Python has update" → "Updating python requires all dependents of Python also get updated" → "Update LLVM" → takes forever.

Most of the time, old versions of packages still remain on the package servers and there are no problems with skipping the package list update

### Suggested Testing Steps
Make sure CI works