### PR TITLE
Replace opaque display pointer with window info struct and GS cleanups

### DIFF
--- a/common/build/Utilities/utilities.vcxproj
+++ b/common/build/Utilities/utilities.vcxproj
@@ -114,6 +114,7 @@
     <ClInclude Include="..\..\include\Utilities\EmbeddedImage.h" />
     <ClInclude Include="..\..\include\Utilities\boost_spsc_queue.hpp" />
     <ClInclude Include="..\..\include\Utilities\ScopedAlloc.h" />
+    <ClInclude Include="..\..\include\Utilities\WindowInfo.h" />
     <ClInclude Include="..\..\src\Utilities\ThreadingInternal.h" />
     <ClInclude Include="..\..\include\Utilities\Assertions.h" />
     <ClInclude Include="..\..\include\Utilities\CheckedStaticBox.h" />

--- a/common/build/Utilities/utilities.vcxproj.filters
+++ b/common/build/Utilities/utilities.vcxproj.filters
@@ -216,5 +216,8 @@
     <ClInclude Include="..\..\include\Utilities\EmbeddedImage.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\Utilities\WindowInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/common/include/Utilities/WindowInfo.h
+++ b/common/include/Utilities/WindowInfo.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "Pcsx2Defs.h"
+
+// Contains the information required to create a graphics context in a window.
+struct WindowInfo
+{
+  enum class Type
+  {
+    Surfaceless,
+    Win32,
+    X11,
+    Wayland,
+    MacOS
+  };
+
+  Type type = Type::Surfaceless;
+  void* display_connection = nullptr;
+  void* window_handle = nullptr;
+  u32 surface_width = 0;
+  u32 surface_height = 0;
+  float surface_scale = 1.0f;
+};

--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -68,6 +68,7 @@ set(UtilitiesHeaders
 	../../include/Utilities/Threading.h
 	../../include/Utilities/ThreadingDialogs.h
 	../../include/Utilities/TraceLog.h
+	../../include/Utilities/WindowInfo.h
 	../../include/Utilities/wxAppWithHelpers.h
 	../../include/Utilities/wxBaseTools.h
 	../../include/Utilities/wxGuiTools.h

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -186,7 +186,7 @@ void DEV9shutdown()
 	delete dev9.ata;
 }
 
-s32 DEV9open(void* pDsp)
+s32 DEV9open()
 {
 	DevCon.WriteLn("DEV9: DEV9open");
 	LoadConf();

--- a/pcsx2/DEV9/DEV9.h
+++ b/pcsx2/DEV9/DEV9.h
@@ -721,7 +721,7 @@ extern void DEV9configure();
 void FLASHinit();
 s32 DEV9init();
 void DEV9close();
-s32 DEV9open(void* pDsp);
+s32 DEV9open();
 void DEV9shutdown();
 u32 FLASHread32(u32 addr, int size);
 void FLASHwrite32(u32 addr, u32 value, int size);

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -210,9 +210,10 @@ int _GSopen(const WindowInfo& wi, const char* title, GSRendererType renderer, in
 			{
 				try
 				{
-					wnd->Attach(wi, false);
-					window = wnd; // Previous code will throw if window isn't supported
+					if (!wnd->Attach(wi))
+						continue;
 
+					window = wnd; // Previous code will throw if window isn't supported
 					break;
 				}
 				catch (GSRecoverableError)
@@ -531,23 +532,6 @@ void GSvsync(int field)
 {
 	try
 	{
-#ifdef _WIN32
-
-		if (s_gs->m_wnd->IsManaged())
-		{
-			MSG msg;
-
-			memset(&msg, 0, sizeof(msg));
-
-			while (msg.message != WM_QUIT && PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-			{
-				TranslateMessage(&msg);
-				DispatchMessage(&msg);
-			}
-		}
-
-#endif
-
 		s_gs->VSync(field);
 	}
 	catch (GSRecoverableError)

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -1776,6 +1776,8 @@ enum class CRCHackLevel : int8
 	Aggressive
 };
 
+struct WindowInfo;
+
 #ifdef ENABLE_ACCURATE_BUFFER_EMULATION
 const GSVector2i default_rt_size(2048, 2048);
 #else
@@ -1786,10 +1788,10 @@ void GSsetBaseMem(uint8* mem);
 int GSinit();
 void GSshutdown();
 void GSclose();
-int _GSopen(void** dsp, const char* title, GSRendererType renderer, int threads);
+int _GSopen(const WindowInfo& wi, const char* title, GSRendererType renderer, int threads);
 void GSosdLog(const char* utf8, uint32 color);
 void GSosdMonitor(const char* key, const char* value, uint32 color);
-int GSopen2(void** dsp, uint32 flags);
+int GSopen2(const WindowInfo & wi, uint32 flags);
 void GSreset();
 void GSgifSoftReset(uint32 mask);
 void GSwriteCSR(uint32 csr);

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -1790,7 +1790,6 @@ int _GSopen(void** dsp, const char* title, GSRendererType renderer, int threads)
 void GSosdLog(const char* utf8, uint32 color);
 void GSosdMonitor(const char* key, const char* value, uint32 color);
 int GSopen2(void** dsp, uint32 flags);
-int GSopen(void** dsp, const char* title, int mt);
 void GSreset();
 void GSgifSoftReset(uint32 mask);
 void GSwriteCSR(uint32 csr);

--- a/pcsx2/GS/Window/GSWnd.h
+++ b/pcsx2/GS/Window/GSWnd.h
@@ -22,32 +22,18 @@
 
 class GSWnd
 {
-protected:
-	bool m_managed; // set true when we're attached to a 3rdparty window that's amanged by the emulator
-
 public:
-	GSWnd()
-		: m_managed(false)
-	{
-	}
-	virtual ~GSWnd() {}
+	GSWnd() = default;
+	virtual ~GSWnd() = default;
 
-	virtual bool Create(const std::string& title, int w, int h) = 0;
-	virtual bool Attach(const WindowInfo& wi, bool managed = true) = 0;
+	virtual bool Attach(const WindowInfo& wi) = 0;
 	virtual void Detach() = 0;
-	bool IsManaged() const { return m_managed; }
 
-	virtual void* GetDisplay() = 0;
 	virtual void* GetHandle() = 0;
 	virtual GSVector4i GetClientRect() = 0;
-	virtual bool SetWindowText(const char* title) = 0;
 
 	virtual void AttachContext() {}
 	virtual void DetachContext() {}
-
-	virtual void Show() = 0;
-	virtual void Hide() = 0;
-	virtual void HideFrame() = 0;
 
 	virtual void Flip() {}
 	virtual void SetVSync(int vsync) {}
@@ -76,24 +62,9 @@ public:
 		, m_vsync(0)
 	{
 	}
-	virtual ~GSWndGL() {}
+	virtual ~GSWndGL() override = default;
 
-	virtual bool Create(const std::string& title, int w, int h) = 0;
-	virtual bool Attach(const WindowInfo& wi, bool managed = true) = 0;
-	virtual void Detach() = 0;
-
-	virtual void* GetDisplay() = 0;
-	virtual void* GetHandle() = 0;
-	virtual GSVector4i GetClientRect() = 0;
-	virtual bool SetWindowText(const char* title) = 0;
-
-	virtual void AttachContext() = 0;
-	virtual void DetachContext() = 0;
 	virtual void* GetProcAddress(const char* name, bool opt = false) = 0;
 
-	virtual void Show() = 0;
-	virtual void Hide() = 0;
-	virtual void HideFrame() = 0;
-	virtual void Flip() = 0;
-	virtual void SetVSync(int vsync) final;
+	void SetVSync(int vsync) final;
 };

--- a/pcsx2/GS/Window/GSWnd.h
+++ b/pcsx2/GS/Window/GSWnd.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "PrecompiledHeader.h"
+#include "Utilities/WindowInfo.h"
 #include "GS/GS.h"
 #include "GS/GSVector.h"
 
@@ -32,7 +33,7 @@ public:
 	virtual ~GSWnd() {}
 
 	virtual bool Create(const std::string& title, int w, int h) = 0;
-	virtual bool Attach(void* handle, bool managed = true) = 0;
+	virtual bool Attach(const WindowInfo& wi, bool managed = true) = 0;
 	virtual void Detach() = 0;
 	bool IsManaged() const { return m_managed; }
 
@@ -78,7 +79,7 @@ public:
 	virtual ~GSWndGL() {}
 
 	virtual bool Create(const std::string& title, int w, int h) = 0;
-	virtual bool Attach(void* handle, bool managed = true) = 0;
+	virtual bool Attach(const WindowInfo& wi, bool managed = true) = 0;
 	virtual void Detach() = 0;
 
 	virtual void* GetDisplay() = 0;

--- a/pcsx2/GS/Window/GSWndDX.cpp
+++ b/pcsx2/GS/Window/GSWndDX.cpp
@@ -19,7 +19,6 @@
 #ifdef _WIN32
 GSWndDX::GSWndDX()
 	: m_hWnd(NULL)
-	, m_frame(true)
 {
 }
 
@@ -27,115 +26,7 @@ GSWndDX::~GSWndDX()
 {
 }
 
-LRESULT CALLBACK GSWndDX::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	GSWndDX* wnd = NULL;
-
-	if (message == WM_NCCREATE)
-	{
-		wnd = (GSWndDX*)((LPCREATESTRUCT)lParam)->lpCreateParams;
-
-		SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)wnd);
-
-		wnd->m_hWnd = hWnd;
-	}
-	else
-	{
-		wnd = (GSWndDX*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
-	}
-
-	if (wnd == NULL)
-	{
-		return DefWindowProc(hWnd, message, wParam, lParam);
-	}
-
-	return wnd->OnMessage(message, wParam, lParam);
-}
-
-LRESULT GSWndDX::OnMessage(UINT message, WPARAM wParam, LPARAM lParam)
-{
-	switch (message)
-	{
-		case WM_CLOSE:
-			Hide();
-			// DestroyWindow(m_hWnd);
-			return 0;
-		case WM_DESTROY:
-			// This kills the emulator when GS is closed, which *really* isn't desired behavior,
-			// especially in STGS mode (worked in MTGS mode since it only quit the thread, but even
-			// that wasn't needed).
-			//PostQuitMessage(0);
-			return 0;
-		default:
-			break;
-	}
-
-	return DefWindowProc((HWND)m_hWnd, message, wParam, lParam);
-}
-
-bool GSWndDX::Create(const std::string& title, int w, int h)
-{
-	if (m_hWnd)
-		throw GSRecoverableError();
-
-	m_managed = true;
-
-	WNDCLASS wc;
-
-	memset(&wc, 0, sizeof(wc));
-
-	wc.style = CS_HREDRAW | CS_VREDRAW | CS_DBLCLKS;
-	wc.lpfnWndProc = WndProc;
-	wc.hInstance = theApp.GetModuleHandle();
-	// TODO: wc.hIcon = ;
-	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-	wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
-	wc.lpszClassName = L"GSWndDX";
-
-	if (!GetClassInfo(wc.hInstance, wc.lpszClassName, &wc))
-	{
-		if (!RegisterClass(&wc))
-		{
-			throw GSRecoverableError();
-		}
-	}
-
-	DWORD style = WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_OVERLAPPEDWINDOW | WS_BORDER;
-
-	GSVector4i r;
-
-	GetWindowRect(GetDesktopWindow(), r);
-
-	bool remote = !!GetSystemMetrics(SM_REMOTESESSION);
-
-	if (w <= 0 || h <= 0 || remote)
-	{
-		w = r.width() / 3;
-		h = r.width() / 4;
-
-		if (!remote)
-		{
-			w *= 2;
-			h *= 2;
-		}
-	}
-
-	r.left = (r.left + r.right - w) / 2;
-	r.top = (r.top + r.bottom - h) / 2;
-	r.right = r.left + w;
-	r.bottom = r.top + h;
-
-	AdjustWindowRect(r, style, FALSE);
-	std::wstring tmp = std::wstring(title.begin(), title.end());
-	m_hWnd = CreateWindow(wc.lpszClassName, tmp.c_str(), style, r.left, r.top, r.width(), r.height(), NULL, NULL, wc.hInstance, (LPVOID)this);
-
-	if (!m_hWnd)
-		throw GSRecoverableError();
-
-	return true;
-}
-
-bool GSWndDX::Attach(const WindowInfo& wi, bool managed)
+bool GSWndDX::Attach(const WindowInfo& wi)
 {
 	if (wi.type != WindowInfo::Type::Win32)
 		return false;
@@ -143,23 +34,12 @@ bool GSWndDX::Attach(const WindowInfo& wi, bool managed)
 	// TODO: subclass
 
 	m_hWnd = static_cast<HWND>(wi.window_handle);
-	m_managed = managed;
-
 	return true;
 }
 
 void GSWndDX::Detach()
 {
-	if (m_hWnd && m_managed)
-	{
-		// close the window, since it's under GS care.  It's not taking messages anyway, and
-		// that means its big, ugly, and in the way.
-
-		DestroyWindow(m_hWnd);
-	}
-
-	m_hWnd = NULL;
-	m_managed = true;
+	m_hWnd = {};
 }
 
 GSVector4i GSWndDX::GetClientRect()
@@ -169,51 +49,5 @@ GSVector4i GSWndDX::GetClientRect()
 	::GetClientRect(m_hWnd, r);
 
 	return r;
-}
-
-// Returns FALSE if the window has no title, or if th window title is under the strict
-// management of the emulator.
-
-bool GSWndDX::SetWindowText(const char* title)
-{
-	if (!m_managed)
-		return false;
-
-	const size_t tmp_size = strlen(title) + 1;
-	std::wstring tmp(tmp_size, L'#');
-	mbstowcs(&tmp[0], title, tmp_size);
-	::SetWindowText(m_hWnd, tmp.c_str());
-
-	return m_frame;
-}
-
-void GSWndDX::Show()
-{
-	if (!m_managed)
-		return;
-
-	SetForegroundWindow(m_hWnd);
-	ShowWindow(m_hWnd, SW_SHOWNORMAL);
-	UpdateWindow(m_hWnd);
-}
-
-void GSWndDX::Hide()
-{
-	if (!m_managed)
-		return;
-
-	ShowWindow(m_hWnd, SW_HIDE);
-}
-
-void GSWndDX::HideFrame()
-{
-	if (!m_managed)
-		return;
-
-	SetWindowLong(m_hWnd, GWL_STYLE, GetWindowLong(m_hWnd, GWL_STYLE) & ~(WS_CAPTION | WS_THICKFRAME));
-	SetWindowPos(m_hWnd, NULL, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-	SetMenu(m_hWnd, NULL);
-
-	m_frame = false;
 }
 #endif

--- a/pcsx2/GS/Window/GSWndDX.cpp
+++ b/pcsx2/GS/Window/GSWndDX.cpp
@@ -135,11 +135,14 @@ bool GSWndDX::Create(const std::string& title, int w, int h)
 	return true;
 }
 
-bool GSWndDX::Attach(void* handle, bool managed)
+bool GSWndDX::Attach(const WindowInfo& wi, bool managed)
 {
+	if (wi.type != WindowInfo::Type::Win32)
+		return false;
+
 	// TODO: subclass
 
-	m_hWnd = (HWND)handle;
+	m_hWnd = static_cast<HWND>(wi.window_handle);
 	m_managed = managed;
 
 	return true;

--- a/pcsx2/GS/Window/GSWndDX.h
+++ b/pcsx2/GS/Window/GSWndDX.h
@@ -17,30 +17,18 @@
 #include "GSWnd.h"
 
 #ifdef _WIN32
-class GSWndDX : public GSWnd
+class GSWndDX final : public GSWnd
 {
 	HWND m_hWnd;
 
-	bool m_frame;
-
-	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
-	virtual LRESULT OnMessage(UINT message, WPARAM wParam, LPARAM lParam);
-
 public:
 	GSWndDX();
-	virtual ~GSWndDX();
+	~GSWndDX() override;
 
-	bool Create(const std::string& title, int w, int h);
-	bool Attach(const WindowInfo& wi, bool managed = true);
-	void Detach();
+	bool Attach(const WindowInfo& wi) override;
+	void Detach() override;
 
-	void* GetDisplay() { return m_hWnd; }
-	void* GetHandle() { return m_hWnd; }
-	GSVector4i GetClientRect();
-	bool SetWindowText(const char* title);
-
-	void Show();
-	void Hide();
-	void HideFrame();
+	void* GetHandle() override { return m_hWnd; }
+	GSVector4i GetClientRect() override;
 };
 #endif

--- a/pcsx2/GS/Window/GSWndDX.h
+++ b/pcsx2/GS/Window/GSWndDX.h
@@ -31,7 +31,7 @@ public:
 	virtual ~GSWndDX();
 
 	bool Create(const std::string& title, int w, int h);
-	bool Attach(void* handle, bool managed = true);
+	bool Attach(const WindowInfo& wi, bool managed = true);
 	void Detach();
 
 	void* GetDisplay() { return m_hWnd; }

--- a/pcsx2/GS/Window/GSWndEGL.cpp
+++ b/pcsx2/GS/Window/GSWndEGL.cpp
@@ -167,10 +167,8 @@ void GSWndEGL::BindAPI()
 	}
 }
 
-bool GSWndEGL::Attach(const WindowInfo& wi, bool managed)
+bool GSWndEGL::Attach(const WindowInfo& wi)
 {
-	m_managed = managed;
-
 	m_native_window = AttachNativeWindow(wi);
 	if (!m_native_window)
 		return false;
@@ -196,25 +194,6 @@ void GSWndEGL::Detach()
 	CloseEGLDisplay();
 
 	DestroyNativeResources();
-}
-
-bool GSWndEGL::Create(const std::string& title, int w, int h)
-{
-	if (w <= 0 || h <= 0)
-	{
-		w = theApp.GetConfigI("ModeWidth");
-		h = theApp.GetConfigI("ModeHeight");
-	}
-
-	m_managed = true;
-
-	OpenEGLDisplay();
-
-	m_native_window = CreateNativeWindow(w, h);
-
-	FullContextInit();
-
-	return true;
 }
 
 void* GSWndEGL::GetProcAddress(const char* name, bool opt)
@@ -267,9 +246,7 @@ void GSWndEGL::OpenEGLDisplay()
 	// We only need a native display when we manage the window ourself.
 	// By default, EGL will create its own native display. This way the driver knows
 	// that display will be thread safe and so it can enable multithread optimization.
-	void* native_display = (m_managed) ? CreateNativeDisplay() : nullptr;
-
-	// Create an EGL display from the native display
+	void* native_display = nullptr;
 	m_eglDisplay = eglGetPlatformDisplay(m_platform, native_display, nullptr);
 	if (m_eglDisplay == EGL_NO_DISPLAY)
 	{
@@ -290,55 +267,8 @@ void GSWndEGL::OpenEGLDisplay()
 #if GS_EGL_X11
 
 GSWndEGL_X11::GSWndEGL_X11()
-	: GSWndEGL(EGL_PLATFORM_X11_KHR), m_NativeDisplay(nullptr), m_NativeWindow(0)
+	: GSWndEGL(EGL_PLATFORM_X11_KHR), m_NativeWindow(0)
 {
-}
-
-void* GSWndEGL_X11::CreateNativeDisplay()
-{
-	if (m_NativeDisplay == nullptr)
-		m_NativeDisplay = XOpenDisplay(nullptr);
-
-	return (void*)m_NativeDisplay;
-}
-
-void* GSWndEGL_X11::CreateNativeWindow(int w, int h)
-{
-	const int depth = 0, x = 0, y = 0, border_width = 1;
-#if 0
-	// Old X code in case future code will still require it
-	m_NativeWindow = XCreateSimpleWindow(m_NativeDisplay, DefaultRootWindow(m_NativeDisplay), 0, 0, w, h, 0, 0, 0);
-	XMapWindow (m_NativeDisplay, m_NativeWindow);
-#endif
-
-	if (m_NativeDisplay == nullptr)
-	{
-		fprintf(stderr, "EGL X11: display wasn't created before the window\n");
-		throw GSRecoverableError();
-	}
-
-	xcb_connection_t* c = XGetXCBConnection(m_NativeDisplay);
-
-	const xcb_setup_t* setup = xcb_get_setup(c);
-
-	xcb_screen_t* screen = (xcb_setup_roots_iterator(setup)).data;
-
-	m_NativeWindow = xcb_generate_id(c);
-
-	if (m_NativeWindow == 0)
-	{
-		fprintf(stderr, "EGL X11: failed to create the native window\n");
-		throw GSRecoverableError();
-	}
-
-	xcb_create_window(c, depth, m_NativeWindow, screen->root, x, y, w, h,
-		border_width, InputOutput, screen->root_visual, 0, nullptr);
-
-	xcb_map_window(c, m_NativeWindow);
-
-	xcb_flush(c);
-
-	return (void*)&m_NativeWindow;
 }
 
 void* GSWndEGL_X11::AttachNativeWindow(const WindowInfo& wi)
@@ -352,25 +282,6 @@ void* GSWndEGL_X11::AttachNativeWindow(const WindowInfo& wi)
 
 void GSWndEGL_X11::DestroyNativeResources()
 {
-	if (m_NativeDisplay)
-	{
-		XCloseDisplay(m_NativeDisplay);
-		m_NativeDisplay = nullptr;
-	}
-}
-
-bool GSWndEGL_X11::SetWindowText(const char* title)
-{
-	if (!m_managed)
-		return true;
-
-	xcb_connection_t* c = XGetXCBConnection(m_NativeDisplay);
-
-	xcb_change_property(c, XCB_PROP_MODE_REPLACE, m_NativeWindow,
-		XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8,
-		strlen(title), title);
-
-	return true;
 }
 
 #endif
@@ -381,21 +292,8 @@ bool GSWndEGL_X11::SetWindowText(const char* title)
 #if GS_EGL_WL
 
 GSWndEGL_WL::GSWndEGL_WL()
-	: GSWndEGL(EGL_PLATFORM_WAYLAND_KHR), m_NativeDisplay(nullptr), m_NativeWindow(nullptr)
+	: GSWndEGL(EGL_PLATFORM_WAYLAND_KHR), m_NativeWindow(nullptr)
 {
-}
-
-void* GSWndEGL_WL::CreateNativeDisplay()
-{
-	if (m_NativeDisplay == nullptr)
-		m_NativeDisplay = wl_display_connect(NULL);
-
-	return (void*)m_NativeDisplay;
-}
-
-void* GSWndEGL_WL::CreateNativeWindow(int w, int h)
-{
-	return nullptr;
 }
 
 void* GSWndEGL_WL::AttachNativeWindow(const WindowInfo& wi)
@@ -417,22 +315,11 @@ void* GSWndEGL_WL::AttachNativeWindow(const WindowInfo& wi)
 
 void GSWndEGL_WL::DestroyNativeResources()
 {
-	if (m_NativeDisplay)
-	{
-		wl_display_disconnect(m_NativeDisplay);
-		m_NativeDisplay = nullptr;
-	}
-
 	if (m_NativeWindow)
 	{
 		wl_egl_window_destroy(m_NativeWindow);
 		m_NativeWindow = nullptr;
 	}
-}
-
-bool GSWndEGL_WL::SetWindowText(const char* title)
-{
-	return true;
 }
 
 #endif

--- a/pcsx2/GS/Window/GSWndEGL.h
+++ b/pcsx2/GS/Window/GSWndEGL.h
@@ -46,13 +46,15 @@ public:
 	GSWndEGL(int platform);
 	virtual ~GSWndEGL(){};
 
+	static std::shared_ptr<GSWndEGL> CreateForPlatform(const WindowInfo& wi);
+
 	bool Create(const std::string& title, int w, int h) final;
-	bool Attach(void* handle, bool managed = true) final;
+	bool Attach(const WindowInfo& wi, bool managed = true) final;
 	void Detach() final;
 
 	virtual void* CreateNativeDisplay() = 0;
 	virtual void* CreateNativeWindow(int w, int h) = 0; // GSopen1/PSX API
-	virtual void* AttachNativeWindow(void* handle) = 0;
+	virtual void* AttachNativeWindow(const WindowInfo& wi) = 0;
 	virtual void DestroyNativeResources() = 0;
 
 	GSVector4i GetClientRect();
@@ -71,10 +73,6 @@ public:
 
 	virtual void* GetDisplay() = 0; // GSopen1 API
 	virtual void* GetHandle() = 0; // DX API
-
-	// Static to allow to query supported the platform
-	// before object creation
-	static int SelectPlatform();
 };
 
 #if GS_EGL_X11
@@ -97,7 +95,7 @@ public:
 
 	void* CreateNativeDisplay() final;
 	void* CreateNativeWindow(int w, int h) final;
-	void* AttachNativeWindow(void* handle) final;
+	void* AttachNativeWindow(const WindowInfo& wi) final;
 	void DestroyNativeResources() final;
 
 	bool SetWindowText(const char* title) final;
@@ -127,7 +125,7 @@ public:
 
 	void* CreateNativeDisplay() final;
 	void* CreateNativeWindow(int w, int h) final;
-	void* AttachNativeWindow(void* handle) final;
+	void* AttachNativeWindow(const WindowInfo& wi) final;
 	void DestroyNativeResources() final;
 
 	bool SetWindowText(const char* title) final;

--- a/pcsx2/GS/Window/GSWndEGL.h
+++ b/pcsx2/GS/Window/GSWndEGL.h
@@ -48,31 +48,19 @@ public:
 
 	static std::shared_ptr<GSWndEGL> CreateForPlatform(const WindowInfo& wi);
 
-	bool Create(const std::string& title, int w, int h) final;
-	bool Attach(const WindowInfo& wi, bool managed = true) final;
+	bool Attach(const WindowInfo& wi) final;
 	void Detach() final;
 
-	virtual void* CreateNativeDisplay() = 0;
-	virtual void* CreateNativeWindow(int w, int h) = 0; // GSopen1/PSX API
 	virtual void* AttachNativeWindow(const WindowInfo& wi) = 0;
 	virtual void DestroyNativeResources() = 0;
 
 	GSVector4i GetClientRect();
-	virtual bool SetWindowText(const char* title) = 0; // GSopen1/PSX API
 
 	void AttachContext() final;
 	void DetachContext() final;
 	void* GetProcAddress(const char* name, bool opt = false) final;
 
 	void Flip() final;
-
-	// Deprecated API
-	void Show() final {}
-	void Hide() final {}
-	void HideFrame() final {} // DX9 API
-
-	virtual void* GetDisplay() = 0; // GSopen1 API
-	virtual void* GetHandle() = 0; // DX API
 };
 
 #if GS_EGL_X11
@@ -81,24 +69,18 @@ public:
 #include <X11/Xlib.h>
 #include <X11/Xlib-xcb.h>
 
-class GSWndEGL_X11 : public GSWndEGL
+class GSWndEGL_X11 final : public GSWndEGL
 {
-	Display* m_NativeDisplay;
 	Window m_NativeWindow;
 
 public:
 	GSWndEGL_X11();
-	virtual ~GSWndEGL_X11(){};
+	virtual ~GSWndEGL_X11() final = default;
 
-	void* GetDisplay() final { return (void*)m_NativeDisplay; }
-	void* GetHandle() final { return (void*)&m_NativeWindow; }
+	void* GetHandle() final { return reinterpret_cast<void*>(m_NativeWindow); }
 
-	void* CreateNativeDisplay() final;
-	void* CreateNativeWindow(int w, int h) final;
 	void* AttachNativeWindow(const WindowInfo& wi) final;
 	void DestroyNativeResources() final;
-
-	bool SetWindowText(const char* title) final;
 };
 
 #endif
@@ -111,24 +93,18 @@ public:
 #include <wayland-client-protocol.h>
 #include <wayland-egl.h>
 
-class GSWndEGL_WL : public GSWndEGL
+class GSWndEGL_WL final : public GSWndEGL
 {
-	wl_display* m_NativeDisplay;
 	wl_egl_window* m_NativeWindow;
 
 public:
 	GSWndEGL_WL();
-	virtual ~GSWndEGL_WL(){};
+	virtual ~GSWndEGL_WL() final = default;
 
-	void* GetDisplay() final { return (void*)m_NativeDisplay; }
-	void* GetHandle() final { return (void*)m_NativeWindow; }
+	void* GetHandle() final { return reinterpret_cast<void*>(m_NativeWindow); }
 
-	void* CreateNativeDisplay() final;
-	void* CreateNativeWindow(int w, int h) final;
 	void* AttachNativeWindow(const WindowInfo& wi) final;
 	void DestroyNativeResources() final;
-
-	bool SetWindowText(const char* title) final;
 };
 
 #endif

--- a/pcsx2/GS/Window/GSWndWGL.cpp
+++ b/pcsx2/GS/Window/GSWndWGL.cpp
@@ -156,9 +156,12 @@ void GSWndWGL::PopulateWndGlFunction()
 	}
 }
 
-bool GSWndWGL::Attach(void* handle, bool managed)
+bool GSWndWGL::Attach(const WindowInfo& wi, bool managed)
 {
-	m_NativeWindow = (HWND)handle;
+	if (wi.type != WindowInfo::Type::Win32)
+		return false;
+
+	m_NativeWindow = static_cast<HWND>(wi.window_handle);
 	m_managed = managed;
 
 	OpenWGLDisplay();

--- a/pcsx2/GS/Window/GSWndWGL.h
+++ b/pcsx2/GS/Window/GSWndWGL.h
@@ -17,7 +17,7 @@
 
 #ifdef _WIN32
 
-class GSWndWGL : public GSWndGL
+class GSWndWGL final : public GSWndGL
 {
 	HWND  m_NativeWindow;
 	HDC   m_NativeDisplay;
@@ -35,29 +35,21 @@ class GSWndWGL : public GSWndGL
 	void SetSwapInterval();
 	bool HasLateVsyncSupport() { return m_has_late_vsync; }
 
-	static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
-
 public:
 	GSWndWGL();
-	virtual ~GSWndWGL() {}
+	~GSWndWGL() override = default;
 
-	bool Create(const std::string& title, int w, int h);
-	bool Attach(const WindowInfo& wi, bool managed = true);
-	void Detach();
+	bool Attach(const WindowInfo& wi) override;
+	void Detach() override;
 
-	void* GetDisplay() { return m_NativeWindow; }
-	void* GetHandle() { return m_NativeWindow; }
-	GSVector4i GetClientRect();
-	bool SetWindowText(const char* title);
+	void* GetHandle() override { return m_NativeWindow; }
+	GSVector4i GetClientRect() override;
 
-	void AttachContext();
-	void DetachContext();
-	void* GetProcAddress(const char* name, bool opt);
+	void AttachContext() override;
+	void DetachContext() override;
+	void* GetProcAddress(const char* name, bool opt) override;
 
-	void Show();
-	void Hide();
-	void HideFrame();
-	void Flip();
+	void Flip() override;
 };
 
 #endif

--- a/pcsx2/GS/Window/GSWndWGL.h
+++ b/pcsx2/GS/Window/GSWndWGL.h
@@ -42,7 +42,7 @@ public:
 	virtual ~GSWndWGL() {}
 
 	bool Create(const std::string& title, int w, int h);
-	bool Attach(void* handle, bool managed = true);
+	bool Attach(const WindowInfo& wi, bool managed = true);
 	void Detach();
 
 	void* GetDisplay() { return m_NativeWindow; }

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -250,7 +250,7 @@ void SysMtgsThread::OpenGS()
 	GSsetBaseMem(RingBuffer.Regs);
 	GSirqCallback(dummyIrqCallback);
 
-	pxAssertMsg((GSopen2((void**)pDsp, 1 | (renderswitch ? 4 : 0)) == 0), "GS failed to open!");
+	pxAssertMsg((GSopen2(g_gs_window_info, 1 | (renderswitch ? 4 : 0)) == 0), "GS failed to open!");
 
 	GSsetVsync(EmuConfig.GS.GetVsync());
 

--- a/pcsx2/PAD/Linux/PAD.cpp
+++ b/pcsx2/PAD/Linux/PAD.cpp
@@ -21,6 +21,7 @@
 #include "keyboard.h"
 #include "PAD.h"
 #include "state_management.h"
+#include "Utilities/WindowInfo.h"
 
 #if defined(__unix__) || defined(__APPLE__)
 #include "Device.h"
@@ -109,7 +110,7 @@ void PADshutdown()
 	CloseLogging();
 }
 
-s32 PADopen(void* pDsp)
+s32 PADopen(const WindowInfo& wi)
 {
 	memset(&event, 0, sizeof(event));
 	g_key_status.Init();
@@ -119,7 +120,7 @@ s32 PADopen(void* pDsp)
 #if defined(__unix__) || defined(__APPLE__)
 	EnumerateDevices();
 #endif
-	return _PADopen(pDsp);
+	return _PADopen(wi);
 }
 
 void PADsetLogDir(const char* dir)

--- a/pcsx2/PAD/Linux/PAD.h
+++ b/pcsx2/PAD/Linux/PAD.h
@@ -29,13 +29,15 @@ enum PadOptions
 	PADOPTION_MOUSE_R = 0x40,
 };
 
+struct WindowInfo;
+
 extern FILE* padLog;
 extern void initLogging();
 
 extern keyEvent event;
 extern MtQueue<keyEvent> g_ev_fifo;
 
-s32 _PADopen(void* pDsp);
+s32 _PADopen(const WindowInfo& wi);
 void _PADclose();
 void PADsetMode(int pad, int mode);
 
@@ -43,7 +45,7 @@ void SysMessage(char* fmt, ...);
 
 s32 PADinit();
 void PADshutdown();
-s32 PADopen(void* pDsp);
+s32 PADopen(const WindowInfo& wi);
 void PADsetLogDir(const char* dir);
 void PADclose();
 s32 PADsetSlot(u8 port, u8 slot);

--- a/pcsx2/PAD/Linux/keyboard.cpp
+++ b/pcsx2/PAD/Linux/keyboard.cpp
@@ -265,6 +265,9 @@ void UpdateKeyboardInput()
 	g_ev_fifo.consume_all(AnalyzeKeyEvent);
 
 	// keyboard input
+	if (!GSdsp)
+		return;
+
 	while (XPending(GSdsp) > 0)
 	{
 		XNextEvent(GSdsp, &E);

--- a/pcsx2/PAD/Linux/linux.cpp
+++ b/pcsx2/PAD/Linux/linux.cpp
@@ -18,6 +18,7 @@
 #include "Device.h"
 #include "keyboard.h"
 #include "state_management.h"
+#include "Utilities/WindowInfo.h"
 
 #include "wx_dialog/dialog.h"
 
@@ -42,11 +43,14 @@ static void SysMessage(const char* fmt, ...)
 	dialog.ShowModal();
 }
 
-s32 _PADopen(void* pDsp)
+s32 _PADopen(const WindowInfo& wi)
 {
 #ifndef __APPLE__
-	GSdsp = *(Display**)pDsp;
-	GSwin = (Window) * (((u32*)pDsp) + 1);
+	if (wi.type != WindowInfo::Type::X11)
+		return -1;
+
+	GSdsp = static_cast<Display*>(wi.display_connection);
+	GSwin = reinterpret_cast<Window>(wi.window_handle);
 #endif
 
 	return 0;

--- a/pcsx2/PAD/Windows/PAD.cpp
+++ b/pcsx2/PAD/Windows/PAD.cpp
@@ -45,11 +45,9 @@
 #define FORCE_UPDATE_WPARAM ((WPARAM)0x74328943)
 #define FORCE_UPDATE_LPARAM ((LPARAM)0x89437437)
 
-#ifdef __linux__
-Display* GSdsp;
-Window GSwin;
-#else
-HWND hWnd;
+static WindowInfo s_window_info;
+
+#ifdef _WIN32
 HWND hWndTop;
 
 WndProcEater hWndGSProc;
@@ -488,7 +486,8 @@ void Update(unsigned int port, unsigned int slot)
 			if (!updateQueued)
 			{
 				updateQueued = 1;
-				PostMessage(hWnd, WMA_FORCE_UPDATE, FORCE_UPDATE_WPARAM, FORCE_UPDATE_LPARAM);
+				PostMessage(static_cast<HWND>(s_window_info.window_handle),
+					WMA_FORCE_UPDATE, FORCE_UPDATE_WPARAM, FORCE_UPDATE_LPARAM);
 			}
 		}
 		else
@@ -985,73 +984,67 @@ ExtraWndProcResult HideCursorProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
 
 void PADconfigure()
 {
-	HWND tmp = hWnd;
+	const WindowInfo old_window_info(s_window_info);
+
 	PADclose();
 	ScopedCoreThreadPause paused_core;
 	Configure();
 	paused_core.AllowResume();
-	if(tmp != nullptr)
-		PADopen(tmp);
+	if(old_window_info.type != WindowInfo::Type::Surfaceless)
+		PADopen(old_window_info);
 }
 
-s32 PADopen(void* pDsp)
+s32 PADopen(const WindowInfo& wi)
 {
 	if (openCount++)
 		return 0;
 
 	miceEnabled = !config.mouseUnfocus;
 #ifdef _MSC_VER
-	if (!hWnd)
+	if (wi.type != WindowInfo::Type::Win32)
 	{
-		if (IsWindow((HWND)pDsp))
-		{
-			hWnd = (HWND)pDsp;
-		}
-		else if (pDsp && !IsBadReadPtr(pDsp, 4) && IsWindow(*(HWND*)pDsp))
-		{
-			hWnd = *(HWND*)pDsp;
-		}
-		else
-		{
-			openCount = 0;
-			MessageBoxA(GetActiveWindow(),
-						"Invalid Window handle passed to PAD.\n"
-						"\n"
-						"Either your emulator or gs plugin is buggy,\n"
-						"Despite the fact the emulator is about to\n"
-						"blame PAD for failing to initialize.",
-						"Non-PAD Error", MB_OK | MB_ICONERROR);
-			return -1;
-		}
-		hWndTop = GetAncestor(hWnd, GA_ROOT);
-
-		if (!hWndGSProc.SetWndHandle(hWnd))
-		{
-			openCount = 0;
-			return -1;
-		}
-
-		// Implements most hacks, as well as enabling/disabling mouse
-		// capture when focus changes.
-		updateQueued = 0;
-		hWndGSProc.Eat(StatusWndProc, 0);
-
-		if (hWnd != hWndTop)
-		{
-			if (!hWndTopProc.SetWndHandle(hWndTop))
-			{
-				openCount = 0;
-				return -1;
-			}
-		}
-
-		if (config.forceHide)
-		{
-			hWndGSProc.Eat(HideCursorProc, 0);
-		}
-
-		windowThreadId = GetWindowThreadProcessId(hWndTop, 0);
+		openCount = 0;
+		MessageBoxA(GetActiveWindow(),
+					"Invalid Window handle passed to PAD.\n"
+					"\n"
+					"Either your emulator or gs plugin is buggy,\n"
+					"Despite the fact the emulator is about to\n"
+					"blame PAD for failing to initialize.",
+					"Non-PAD Error", MB_OK | MB_ICONERROR);
+		return -1;
 	}
+
+	const HWND hWnd = static_cast<HWND>(wi.window_handle);
+	hWndTop = GetAncestor(hWnd, GA_ROOT);
+
+	if (!hWndGSProc.SetWndHandle(hWnd))
+	{
+		openCount = 0;
+		return -1;
+	}
+
+	// Implements most hacks, as well as enabling/disabling mouse
+	// capture when focus changes.
+	updateQueued = 0;
+	hWndGSProc.Eat(StatusWndProc, 0);
+
+	if (hWnd != hWndTop)
+	{
+		if (!hWndTopProc.SetWndHandle(hWndTop))
+		{
+			openCount = 0;
+			return -1;
+		}
+	}
+
+	s_window_info = wi;
+
+	if (config.forceHide)
+	{
+		hWndGSProc.Eat(HideCursorProc, 0);
+	}
+
+	windowThreadId = GetWindowThreadProcessId(hWndTop, 0);
 
 #endif
 	for (int port = 0; port < 2; port++)
@@ -1078,10 +1071,6 @@ s32 PADopen(void* pDsp)
 // activeWindow = GetActiveWindow() == hWnd;
 
 // activeWindow = (GetAncestor(hWnd, GA_ROOT) == GetAncestor(GetForegroundWindow(), GA_ROOT));
-#else
-	// Not used so far
-	GSdsp = *(Display**)pDsp;
-	GSwin = (Window) * (((uptr*)pDsp) + 1);
 #endif
 	activeWindow = 1;
 	UpdateEnabledDevices();
@@ -1097,8 +1086,7 @@ void PADclose()
 		hWndGSProc.Release();
 		hWndTopProc.Release();
 		dm->ReleaseInput();
-		hWnd = 0;
-		hWndTop = 0;
+		s_window_info = WindowInfo();
 #else
 		R_ClearKeyQueue();
 #endif

--- a/pcsx2/PAD/Windows/PAD.h
+++ b/pcsx2/PAD/Windows/PAD.h
@@ -47,7 +47,7 @@ typedef struct
 void PADupdate(int pad);
 void PADshutdown();
 s32 PADinit();
-s32 PADopen(void* pDsp);
+s32 PADopen(const WindowInfo& wi);
 void PADclose();
 u8 PADstartPoll(int pad);
 u8 PADpoll(u8 value);

--- a/pcsx2/SPU2/Windows/CfgHelpers.cpp
+++ b/pcsx2/SPU2/Windows/CfgHelpers.cpp
@@ -20,8 +20,6 @@
 
 #include "Utilities/StringHelpers.h"
 
-extern uptr gsWindowHandle;
-
 void SysMessage(const char* fmt, ...)
 {
 	va_list list;
@@ -32,8 +30,9 @@ void SysMessage(const char* fmt, ...)
 	vsprintf_s(tmp, fmt, list);
 	va_end(list);
 	swprintf_s(wtmp, L"%S", tmp);
-	MessageBox((!!gsWindowHandle) ? (HWND)gsWindowHandle : GetActiveWindow(), wtmp,
-			   L"SPU2 System Message", MB_OK | MB_SETFOREGROUND);
+
+	// TODO: Move this into app/host.
+	MessageBox(NULL, wtmp, L"SPU2 System Message", MB_OK | MB_SETFOREGROUND);
 }
 
 void SysMessage(const wchar_t* fmt, ...)
@@ -43,8 +42,7 @@ void SysMessage(const wchar_t* fmt, ...)
 	wxString wtmp;
 	wtmp.PrintfV(fmt, list);
 	va_end(list);
-	MessageBox((!!gsWindowHandle) ? (HWND)gsWindowHandle : GetActiveWindow(), wtmp,
-			   L"SPU2 System Message", MB_OK | MB_SETFOREGROUND);
+	MessageBox(NULL, wtmp, L"SPU2 System Message", MB_OK | MB_SETFOREGROUND);
 }
 
 //////

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -291,18 +291,13 @@ static INT_PTR CALLBACK DebugProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
 #endif
 uptr gsWindowHandle = 0;
 
-s32 SPU2open(void* pDsp)
+s32 SPU2open()
 {
 	ScopedLock lock(mtx_SPU2Status);
 	if (IsOpened)
 		return 0;
 
 	FileLog("[%10d] SPU2 Open\n", Cycles);
-
-	if (pDsp != nullptr)
-		gsWindowHandle = *(uptr*)pDsp;
-	else
-		gsWindowHandle = 0;
 
 #ifdef _MSC_VER
 #ifdef PCSX2_DEVBUILD // Define may not be needed but not tested yet. Better make sure.

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -24,7 +24,7 @@ extern Threading::MutexRecursive mtx_SPU2Status;
 s32 SPU2init();
 s32 SPU2reset();
 s32 SPU2ps1reset();
-s32 SPU2open(void* pDsp);
+s32 SPU2open();
 void SPU2close();
 void SPU2shutdown();
 void SPU2write(u32 mem, u16 value);

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -319,12 +319,12 @@ void SysCoreThread::OnResumeInThread(bool isSuspended)
 	GetMTGS().WaitForOpen();
 	if (isSuspended)
 	{
-		DEV9open((void*)pDsp);
-		USBopen((void*)pDsp);
+		DEV9open();
+		USBopen(g_gs_window_info);
 	}
 	FWopen();
-	SPU2open((void*)pDsp);
-	PADopen((void*)pDsp);
+	SPU2open();
+	PADopen(g_gs_window_info);
 	FileMcd_EmuOpen();
 }
 

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -21,6 +21,7 @@
 
 #include "PrecompiledHeader.h"
 #include "Utilities/pxStreams.h"
+#include "Utilities/WindowInfo.h"
 #include "USB.h"
 #include "qemu-usb/USBinternal.h"
 #include "qemu-usb/desc.h"
@@ -67,7 +68,7 @@ int64_t usb_bit_time;
 s64 clocks = 0;
 s64 remaining = 0;
 
-#if _WIN32
+#if defined(_WIN32)
 HWND gsWnd = nullptr;
 #elif defined(__linux__)
 #include "gtk.h"
@@ -243,7 +244,7 @@ void USBshutdown()
 	usb_opened = false;
 }
 
-s32 USBopen(void* pDsp)
+s32 USBopen(const WindowInfo& wi)
 {
 
 	if (conf.Log && !usbLog)
@@ -252,29 +253,25 @@ s32 USBopen(void* pDsp)
 		//if(usbLog) setvbuf(usbLog, NULL,  _IONBF, 0);
 	}
 
-#if _WIN32
-
-	HWND hWnd = 0;
-	if (IsWindow((HWND)pDsp))
+  void* window_handle_for_init = nullptr;
+#if defined(_WIN32)
+	if (wi.type == WindowInfo::Type::Win32)
 	{
-		hWnd = (HWND)pDsp;
+		gsWnd = static_cast<HWND>(wi.window_handle);
+		window_handle_for_init = wi.window_handle;
 	}
-	else if (pDsp && !IsBadReadPtr(pDsp, 4) && IsWindow(*(HWND*)pDsp))
-	{
-		hWnd = *(HWND*)pDsp;
-	}
-
-	gsWnd = hWnd;
-	pDsp = gsWnd;
 #elif defined(__linux__)
-
-	g_GSdsp = (Display*)((uptr*)pDsp)[0];
-	g_GSwin = (Window)((uptr*)pDsp)[1];
+	if (wi.type == WindowInfo::Type::X11)
+	{
+		g_GSdsp = static_cast<Display*>(wi.display_connection);
+		g_GSwin = reinterpret_cast<Window>(wi.window_handle);
+		window_handle_for_init = reinterpret_cast<void*>(g_GSwin);
+	}
 #endif
 
 	try
 	{
-		shared::Initialize(pDsp);
+		shared::Initialize(window_handle_for_init);
 	}
 	catch (std::runtime_error& e)
 	{
@@ -298,6 +295,12 @@ void USBclose()
 	CloseDevice(1);
 	shared::Uninitialize();
 	usb_opened = false;
+#if defined(_WIN32)
+	gsWnd = {};
+#elif defined(__linux__)
+  g_GSdsp = nullptr;
+	g_GSwin = {};
+#endif
 }
 
 u8 USBread8(u32 addr)

--- a/pcsx2/USB/USB.h
+++ b/pcsx2/USB/USB.h
@@ -22,6 +22,8 @@
 
 #include "SaveState.h"
 
+struct WindowInfo;
+
 // ---------------------------------------------------------------------
 #define USBdefs
 
@@ -38,7 +40,7 @@ s32 USBinit();
 void USBasync(u32 cycles);
 void USBshutdown();
 void USBclose();
-s32 USBopen(void* pDsp);
+s32 USBopen(const WindowInfo& wi);
 s32 USBfreeze(int mode, freezeData* data);
 
 u8 USBread8(u32 addr);

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "Utilities/wxAppWithHelpers.h"
+#include "Utilities/WindowInfo.h"
 
 #include <wx/fileconf.h>
 #include <wx/apptrait.h>
@@ -45,7 +46,8 @@ typedef struct _keyEvent
     u32 evt;
 } keyEvent;
 
-extern uptr pDsp[2];
+// TODO: Not the best location for this, but it needs to be accessed by MTGS etc.
+extern WindowInfo g_gs_window_info;
 
 typedef void FnType_OnThreadComplete(const wxCommandEvent& evt);
 typedef void (Pcsx2App::*FnPtr_Pcsx2App)();

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<AppConfig> g_Conf;
 AspectRatioType iniAR;
 bool switchAR;
 
-uptr pDsp[2];
+WindowInfo g_gs_window_info;
 
 // Returns a string message telling the user to consult guides for obtaining a legal BIOS.
 // This message is in a function because it's used as part of several dialogs in PCSX2 (there
@@ -871,39 +871,12 @@ void Pcsx2App::OpenGsPanel()
 
     pxAssertDev( !gsopen_done, "GS must be closed prior to opening a new Gs Panel!" );
 
-#ifdef __WXGTK__
-	// The x window/display are actually very deeper in the widget. You need both display and window
-	// because unlike window there are unrelated. One could think it would be easier to send directly the GdkWindow.
-	// Unfortunately there is a race condition between gui and gs threads when you called the
-	// GDK_WINDOW_* macro. To be safe I think it is best to do here. -- Gregory
+	gsFrame->ShowFullScreen(g_Conf->GSWindow.IsFullscreen);
+	wxApp::ProcessPendingEvents();
 
-	// GTK_PIZZA is an internal interface of wx, therefore they decide to
-	// remove it on wx 3. I tryed to replace it with gtk_widget_get_window but
-	// unfortunately it creates a gray box in the middle of the window on some
-	// users.
-
-	GtkWidget *child_window = GTK_WIDGET(gsFrame->GetViewport()->GetHandle());
-
-	gtk_widget_realize(child_window); // create the widget to allow to use GDK_WINDOW_* macro
-	gtk_widget_set_double_buffered(child_window, false); // Disable the widget double buffer, you will use the opengl one
-
-	GdkWindow* draw_window = gtk_widget_get_window(child_window);
-
-#if GTK_MAJOR_VERSION < 3
-	Window Xwindow = GDK_WINDOW_XWINDOW(draw_window);
-#else
-	Window Xwindow = GDK_WINDOW_XID(draw_window);
-#endif
-	Display* XDisplay = GDK_WINDOW_XDISPLAY(draw_window);
-
-	pDsp[0] = (uptr)XDisplay;
-	pDsp[1] = (uptr)Xwindow;
-#else
-	pDsp[0] = (uptr)gsFrame->GetViewport()->GetHandle();
-	pDsp[1] = NULL;
-#endif
-
-	gsFrame->ShowFullScreen( g_Conf->GSWindow.IsFullscreen );
+	std::optional<WindowInfo> wi = gsFrame->GetViewport()->GetWindowInfo();
+	pxAssertDev(wi.has_value(), "GS frame has a valid native window");
+	g_gs_window_info = std::move(wi.value());
 
 #ifndef DISABLE_RECORDING
 	// Enable New & Play after the first game load of the session

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -773,7 +773,7 @@ void Dialogs::GSDumpDialog::GSThread::ExecuteTaskInThread()
 	}
 
 	GSsetBaseMem((u8*)regs);
-	if (GSopen2((void**)pDsp, (renderer_override<<24)) != 0)
+	if (GSopen2(g_gs_window_info, (renderer_override<<24)) != 0)
 	{
 		OnStop();
 		return;

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -18,7 +18,9 @@
 
 #include "AppCommon.h"
 #include "CpuUsageProvider.h"
+#include "Utilities/WindowInfo.h"
 #include <memory>
+#include <optional>
 
 
 enum LimiterModeType
@@ -50,6 +52,8 @@ protected:
 public:
 	GSPanel( wxWindow* parent );
 	virtual ~GSPanel();
+
+	std::optional<WindowInfo> GetWindowInfo();
 
 	void DoResize();
 	void DoShowMouse();


### PR DESCRIPTION
### Description of Changes

The current setup for passing the GS window information to the subsystems was error-prone, especially on Linux where multiple window systems exist. Wrapping the information up into a window information structure makes this safer, as well as supporting multiple window systems within the same binary.

This PR also drops the "managed window" concept from GS, relying solely on the frontend to provide a window to handle into.

### Rationale behind Changes

Safer code, flexibility to support more platforms in the future, and removing unused functions.

### Suggested Testing Steps

I've tested Windows, and Linux with X11. Wayland is still not supported by default, I have another branch which removes GSWnd completely and does work with Wayland.