### PR TITLE
CHD: Fix parent search on windows

### DIFF
--- a/pcsx2/CDVD/ChdFileReader.cpp
+++ b/pcsx2/CDVD/ChdFileReader.cpp
@@ -65,7 +65,7 @@ bool ChdFileReader::Open2(const wxString& fileName)
 		if (dir.IsOpened())
 		{
 			wxString parent_fileName;
-			bool cont = dir.GetFirst(&parent_fileName, wxString("*.", wxfilename.GetExt()), wxDIR_FILES | wxDIR_HIDDEN);
+			bool cont = dir.GetFirst(&parent_fileName, wxString("*.") + wxfilename.GetExt(), wxDIR_FILES | wxDIR_HIDDEN);
 			for (; cont; cont = dir.GetNext(&parent_fileName))
 			{
 				parent_fileName = wxFileName(dir_path, parent_fileName).GetFullPath();


### PR DESCRIPTION
It was crashing in some string conversion function.

Apparently you can't use the constructor to concat a literal and a wxString like that.
