### PR TITLE
PCSX2-GUI: Restore Defaults button - speedhacks panel

### DIFF
--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -192,7 +192,7 @@ void Dialogs::SysConfigDialog::Cancel()
 }
 
 Dialogs::SysConfigDialog::SysConfigDialog(wxWindow* parent)
-	: BaseConfigurationDialog( parent, AddAppName(_("Emulation Settings - %s")), 580 )
+	: BaseConfigurationDialog( parent, AddAppName(_("General Settings - %s")), 580 )
 {
 	ScopedBusyCursor busy( Cursor_ReallyBusy );
 

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -229,10 +229,10 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	s_table->Add(miscHacksPanel, StdExpand());
 	s_table->Add(vuHacksPanel, StdExpand());
 	s_table->Add(new wxStaticText(this, -1, ""));
-	s_table->Add(m_button_Defaults, StdButton());
 
 	m_sizer = new wxBoxSizer(wxVERTICAL);
 	m_sizer->Add(m_check_Enable, StdExpand());
+	m_sizer->Add(m_button_Defaults, StdButton()); // Hackfix restore defaults from not vanishing when changing the sliders, SpeedhacksPanel is the worst panel as can't be fixed in current state.
 	m_sizer->Add(s_table);
 
 	SetSizer(m_sizer);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Move to higher position of Restore Defauls in speedhacks panel.
Master:
![BrokenMaster1](https://user-images.githubusercontent.com/24227051/126597011-a70371fc-c988-4e0d-83c6-a69f5145395e.png)
![BrokenMaster2RestoreBelowOtherButtons](https://user-images.githubusercontent.com/24227051/126597027-72e7780a-6104-4734-9855-93f701aec493.png)
![BrokenMaster3ResizeStdExpandSmall](https://user-images.githubusercontent.com/24227051/126597040-8317e8e1-db0f-4f77-8706-85139cf8002a.png)
PR:
<img width="652" alt="2021-07-22_08-18 HackFix SpeedHacks" src="https://user-images.githubusercontent.com/24227051/126597118-d23f00bf-b8ed-4028-b7ac-5fc36df7c1ff.png">

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Recent change to icon alignment made speedhacks panel act in odds with Restore Defaults. Presumably a DPI issue with combination of GUI issue.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Mess around with the sliders and the presets. Note this won't be perfect either way.