### PR TITLE
SPU2: remove   unused variable

### DIFF
--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -41,8 +41,6 @@ int SampleRate = 48000;
 static bool IsOpened = false;
 static bool IsInitialized = false;
 
-static u32 pClocks = 0;
-
 u32 lClocks = 0;
 //static bool cpu_detected = false;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
remove   an unused variable in SPU2
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

it fixes  the cmake warning  `warning: pClocks’ defined but not used [-Wunused-variable]  44 | static u32 pClocks = 0;`

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
boot up a game and make sure Audio works 