### PR TITLE
IPU: Store thresholds for color conversions in u16, bump savestate version.

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -41,7 +41,7 @@ void IPUWorker();
 
 // Quantization matrix
 static rgb16_t vqclut[16];			//clut conversion table
-static u8 s_thresh[2];				//thresholds for color conversions
+static u16 s_thresh[2];				//thresholds for color conversions
 int coded_block_pattern = 0;
 
 alignas(16) static u8 indx4[16*16/2];

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A20 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A21 << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin


### PR DESCRIPTION
### Description of Changes
Store color conversion thresholds in u16 instead of u8. Bump save state version.
Fix accidentally created UB from my previous PR.
### Rationale behind Changes
While SETTH command was accepting 8:0 and 24:16 bits after merging #4526 , I didn't noticed that variable is declared to store only 8 bit values. So SETTH in result still masked bit 8, and 24, additionally creating risk of overflow.
This PR fix it.
### Suggested Testing Steps
Testing FMVs for regressions/improvements. Possibly affect IPU texturing (rare thing afaik).