### PR TITLE
GS: Manage draw rectangle in GS instead of wx

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -419,9 +419,6 @@ int GSopen2(void** dsp, uint32 flags)
 
 	int retval = _GSopen(dsp, "", current_renderer);
 
-	if (s_gs != NULL)
-		s_gs->SetAspectRatio(0); // PCSX2 manages the aspect ratios
-
 	gsopen_done = true;
 
 	return retval;
@@ -863,6 +860,19 @@ void GSsetExclusive(int enabled)
 	if (s_gs)
 	{
 		s_gs->SetVSync(s_vsync);
+	}
+}
+
+bool GSGetFMVSwitch()
+{
+	return s_gs ? s_gs->GetFMVSwitch() : false;
+}
+
+void GSSetFMVSwitch(bool enabled)
+{
+	if (s_gs)
+	{
+		s_gs->SetFMVSwitch(enabled);
 	}
 }
 
@@ -1510,10 +1520,6 @@ void GSApp::Init()
 	m_gs_interlace.push_back(GSSetting(5, "Blend tff", "slight blur, 1/2 fps"));
 	m_gs_interlace.push_back(GSSetting(6, "Blend bff", "slight blur, 1/2 fps"));
 	m_gs_interlace.push_back(GSSetting(7, "Automatic", "Default"));
-
-	m_gs_aspectratio.push_back(GSSetting(0, "Stretch", ""));
-	m_gs_aspectratio.push_back(GSSetting(1, "4:3", ""));
-	m_gs_aspectratio.push_back(GSSetting(2, "16:9", ""));
 
 	m_gs_upscale_multiplier.push_back(GSSetting(1, "Native", "PS2"));
 	m_gs_upscale_multiplier.push_back(GSSetting(2, "2x Native", "~720p"));

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -1817,6 +1817,8 @@ void GSgetTitleInfo2(char* dest, size_t length);
 void GSsetFrameSkip(int frameskip);
 void GSsetVsync(int vsync);
 void GSsetExclusive(int enabled);
+bool GSGetFMVSwitch();
+void GSSetFMVSwitch(bool enabled);
 
 class GSApp
 {
@@ -1871,7 +1873,6 @@ public:
 
 	std::vector<GSSetting> m_gs_renderers;
 	std::vector<GSSetting> m_gs_interlace;
-	std::vector<GSSetting> m_gs_aspectratio;
 	std::vector<GSSetting> m_gs_upscale_multiplier;
 	std::vector<GSSetting> m_gs_max_anisotropy;
 	std::vector<GSSetting> m_gs_dithering;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -34,13 +34,13 @@ class GSRenderer : public GSState
 protected:
 	int m_dithering;
 	int m_interlace;
-	int m_aspectratio;
 	int m_vsync;
 	bool m_aa1;
 	bool m_shaderfx;
 	bool m_fxaa;
 	bool m_shadeboost;
 	bool m_texture_shuffle;
+	bool m_fmv_switch;
 	GSVector2i m_real_size;
 
 	virtual GSTexture* GetOutput(int i, int& y_offset) = 0;
@@ -63,13 +63,17 @@ public:
 	virtual int GetUpscaleMultiplier() { return 1; }
 	virtual GSVector2i GetCustomResolution() { return GSVector2i(0, 0); }
 	GSVector2i GetInternalResolution();
-	void SetAspectRatio(int aspect) { m_aspectratio = aspect; }
 	void SetVSync(int vsync);
+
+	__fi bool GetFMVSwitch() const { return m_fmv_switch; }
+	__fi void SetFMVSwitch(bool enabled) { m_fmv_switch = enabled; }
 
 	virtual bool BeginCapture(std::string& filename);
 	virtual void EndCapture();
 
 	void PurgePool();
+
+	GSVector4i ComputeDrawRectangle(int width, int height) const;
 
 public:
 	std::mutex m_pGSsetTitle_Crit;

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -71,9 +71,6 @@ wxIMPLEMENT_APP(Pcsx2App);
 
 std::unique_ptr<AppConfig> g_Conf;
 
-AspectRatioType iniAR;
-bool switchAR;
-
 uptr pDsp[2];
 
 // Returns a string message telling the user to consult guides for obtaining a legal BIOS.
@@ -451,21 +448,6 @@ extern bool FMVstarted;
 extern bool EnableFMV;
 extern bool renderswitch;
 
-void DoFmvSwitch(bool on)
-{
-	if (g_Conf->GSWindow.FMVAspectRatioSwitch != FMV_AspectRatio_Switch_Off) {
-		if (on) {
-			switchAR = true;
-			iniAR = g_Conf->GSWindow.AspectRatio;
-		} else {
-			switchAR = false;
-		}
-		if (GSFrame* gsFrame = wxGetApp().GetGsFramePtr())
-			if (GSPanel* viewport = gsFrame->GetViewport())
-				viewport->DoResize();
-	}
-}
-
 void Pcsx2App::LogicalVsync()
 {
 	if( AppRpc_TryInvokeAsync( &Pcsx2App::LogicalVsync ) ) return;
@@ -479,7 +461,7 @@ void Pcsx2App::LogicalVsync()
 	if (g_Conf->GSWindow.FMVAspectRatioSwitch != FMV_AspectRatio_Switch_Off) {
 		if (EnableFMV) {
 			DevCon.Warning("FMV on");
-			DoFmvSwitch(true);
+			GSSetFMVSwitch(true);
 			EnableFMV = false;
 		}
 
@@ -487,7 +469,7 @@ void Pcsx2App::LogicalVsync()
 			int diff = cpuRegs.cycle - eecount_on_last_vdec;
 			if (diff > 60000000 ) {
 				DevCon.Warning("FMV off");
-				DoFmvSwitch(false);
+				GSSetFMVSwitch(false);
 				FMVstarted = false;
 			}
 		}

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -51,7 +51,6 @@ public:
 	GSPanel( wxWindow* parent );
 	virtual ~GSPanel();
 
-	void DoResize();
 	void DoShowMouse();
 	void DirectKeyCommand( wxKeyEvent& evt );
 	void DirectKeyCommand( const KeyAcceleratorCode& kac );

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -38,8 +38,6 @@
 // renderswitch - tells GS to go into dx9 sw if "renderswitch" is set.
 bool renderswitch = false;
 
-extern bool switchAR;
-
 static bool g_Pcsx2Recording = false; // true if recording video and sound
 
 
@@ -174,21 +172,11 @@ namespace Implementations
 		pauser.AllowResume();
 	}
 
-	void UpdateImagePosition()
-	{
-		//AppApplySettings() would have been nicer, since it also immidiately affects the GUI (if open).
-		//However, the events sequence it generates also "depresses" Shift/CTRL/etc, so consecutive zoom with CTRL down breaks.
-		//Since zoom only affects the window viewport anyway, we can live with directly calling it.
-		if (GSFrame* gsFrame = wxGetApp().GetGsFramePtr())
-			if (GSPanel* woot = gsFrame->GetViewport())
-				woot->DoResize();
-	}
-
 	void GSwindow_CycleAspectRatio()
 	{
 		AspectRatioType& art = g_Conf->GSWindow.AspectRatio;
 		const char* arts = "Not modified";
-		if (art == AspectRatio_Stretch && switchAR) //avoids a double 4:3 when coming from FMV aspect ratio switch
+		if (art == AspectRatio_Stretch && GSGetFMVSwitch()) //avoids a double 4:3 when coming from FMV aspect ratio switch
 			art = AspectRatio_4_3;
 		switch (art)
 		{
@@ -209,7 +197,9 @@ namespace Implementations
 		}
 
 		OSDlog(Color_StrongBlue, true, "(GSwindow) Aspect ratio: %s", arts);
-		UpdateImagePosition();
+
+		// Disable FMV mode if we were previously in it, so the user can override the AR.
+		GSSetFMVSwitch(false);
 	}
 
 	void SetOffset(float x, float y)
@@ -217,8 +207,6 @@ namespace Implementations
 		g_Conf->GSWindow.OffsetX = x;
 		g_Conf->GSWindow.OffsetY = y;
 		OSDlog(Color_StrongBlue, true, "(GSwindow) Offset: x=%f, y=%f", x, y);
-
-		UpdateImagePosition();
 	}
 
 	void GSwindow_OffsetYplus()
@@ -252,8 +240,6 @@ namespace Implementations
 			return;
 		g_Conf->GSWindow.StretchY = zoom;
 		OSDlog(Color_StrongBlue, true, "(GSwindow) Vertical stretch: %f", zoom);
-
-		UpdateImagePosition();
 	}
 
 	void GSwindow_ZoomInY()
@@ -279,8 +265,6 @@ namespace Implementations
 			OSDlog(Color_StrongBlue, true, "(GSwindow) Zoom: 0 (auto, no black bars)");
 		else
 			OSDlog(Color_StrongBlue, true, "(GSwindow) Zoom: %f", zoom);
-
-		UpdateImagePosition();
 	}
 
 


### PR DESCRIPTION
### Description of Changes

Instead of having a second subwindow inside the GS window which is rendered into, resulting in a mix of software/Win32 and hardware surfaces, this PR makes the GS panel take up the full client area of the window, and the renderer performs the aspect ratio correction instead.

### Rationale behind Changes

This is (imo) cleaner, as well as enabling fullscreen optimizations/directflip. It also removes the redundant code from GS.

### Suggested Testing Steps

Make sure all aspect ratios work, hotkey switching functions, ensure that FMV auto switching isn't broken.
