### PR TITLE
X86Emitter: Use __rdtsc define on non-msvc compilers

### DIFF
--- a/common/src/x86emitter/cpudetect.cpp
+++ b/common/src/x86emitter/cpudetect.cpp
@@ -1,5 +1,5 @@
 /*  Cpudetection lib
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -112,35 +112,14 @@ s64 x86capabilities::_CPUSpeedHz(u64 time) const
 
     // Align the cpu execution to a cpuTick boundary.
 
-    // GCC 4.8 has __rdtsc but apparently it causes a crash. Only known working on MSVC
     do {
         timeStart = GetCPUTicks();
-#ifdef _MSC_VER
         startCycle = __rdtsc();
-#elif defined(_M_X86_64)
-        unsigned long long low, high;
-        __asm__ __volatile__("rdtsc"
-                             : "=a"(low), "=d"(high));
-        startCycle = low | (high << 32);
-#else
-        __asm__ __volatile__("rdtsc"
-                             : "=A"(startCycle));
-#endif
     } while (GetCPUTicks() == timeStart);
 
     do {
         timeStop = GetCPUTicks();
-#ifdef _MSC_VER
         endCycle = __rdtsc();
-#elif defined(_M_X86_64)
-        unsigned long long low, high;
-        __asm__ __volatile__("rdtsc"
-                             : "=a"(low), "=d"(high));
-        endCycle = low | (high << 32);
-#else
-        __asm__ __volatile__("rdtsc"
-                             : "=A"(endCycle));
-#endif
     } while ((timeStop - timeStart) < time);
 
     s64 cycleCount = endCycle - startCycle;


### PR DESCRIPTION
### Description of Changes
Use __rdtsc compiler extension on all compilers

### Rationale behind Changes
GCC 4.8 isn't supported anymore (we are c++ 17 now), the supposed crash related to it is not a problem anymore.

### Suggested Testing Steps
Compile using gcc / clang and see if there is a crash.

I tested this on clang 12.0.1 and gcc 11.1.0 (64-bit) with no apparent crashes.