### PR TITLE
GIF: Reimplement GIF FIFO to enable only when it is needed.

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -31,8 +31,6 @@ GUST-00009:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0  # Fixes jump issue.
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering sprites.
 PAPX-90203:
   name: "Gran Turismo 2000 [Trial]"
   region: "NTSC-J"
@@ -2201,8 +2199,6 @@ SCES-50928:
   region: "PAL-M6"
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCES-50934:
   name: "WRC II Extreme"
   region: "PAL-M7"
@@ -2410,8 +2406,6 @@ SCES-51618:
   region: "PAL-M5"
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCES-51635:
   name: "Brave - The Search for Spirit Dancer"
   region: "PAL-M5"
@@ -3669,8 +3663,6 @@ SCKA-24008:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCKA-30001:
   name: "Gran Turismo 4"
   region: "NTSC-K"
@@ -3988,8 +3980,6 @@ SCPS-15044:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCPS-15045:
   name: "Ka (Mosquito) - Let's Go Hawaiian"
   region: "NTSC-J"
@@ -5068,8 +5058,6 @@ SCUS-97134:
   compat: 5
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCUS-97136:
   name: "NCAA Final Four 2002"
   region: "NTSC-U"
@@ -5305,8 +5293,6 @@ SCUS-97205:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCUS-97206:
   name: "PlayStation Underground Jampack Summer 2002"
   region: "NTSC-U"
@@ -5390,8 +5376,6 @@ SCUS-97230:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2  # Fixes bad shadows.
-  gameFixes:
-    - GIFFIFOHack # Resolves random sprite/HUD corruption.
 SCUS-97231:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "NTSC-U"
@@ -8787,13 +8771,9 @@ SLES-51011:
 SLES-51013:
   name: "Blade II"
   region: "PAL-E"
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering HUD. (originally was EE Timing Hack but required since r4821)
 SLES-51014:
   name: "Blade II"
   region: "PAL-F"
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering HUD. (originally was EE Timing Hack but required since r4821)
 SLES-51017:
   name: "Scooby-Doo! and The Night of 100 Frights"
   region: "PAL-E"
@@ -9549,8 +9529,6 @@ SLES-51372:
   compat: 5
   clampModes:
     vuClampMode: 3  # Fixes minor SPS on characters.
-  gameFixes:
-    - GIFFIFOHack
 SLES-51374:
   name: "RoboCop"
   region: "PAL-M5"
@@ -10415,8 +10393,6 @@ SLES-51877:
 SLES-51879:
   name: "Hot Wheels World Race"
   region: "PAL-E"
-  gameFixes:
-    - GIFFIFOHack
 SLES-51881:
   name: "Mercedes Bens World Racing"
   region: "PAL-F-G"
@@ -10655,8 +10631,6 @@ SLES-51989:
   compat: 5
   clampModes:
     vuClampMode: 3  # Fixes minor SPS on characters.
-  gameFixes:
-    - GIFFIFOHack
 SLES-51991:
   name: "Dance UK"
   region: "PAL-E"
@@ -10732,8 +10706,6 @@ SLES-52026:
   compat: 5
   clampModes:
     vuClampMode: 3  # Fixes minor SPS on characters.
-  gameFixes:
-    - GIFFIFOHack
 SLES-52028:
   name: "Junior Sports Basketball"
   region: "PAL-M5"
@@ -14510,7 +14482,6 @@ SLES-53904:
   name: "DT Racer"
   region: "PAL-M5"
   gameFixes:
-    - GIFFIFOHack # Fixes corrupted graphics in the menus.
     - VUKickstartHack # Fixes TLB misses and collision bugs.
 SLES-53906:
   name: "50cent - Bulletproof"
@@ -14660,8 +14631,6 @@ SLES-53979:
 SLES-53982:
   name: "Fight Night Round 3"
   region: "PAL-E-F"
-  gameFixes:
-  - GIFFIFOHack # Fixes corrupt textures.
 SLES-53984:
   name: "Ice Age 2 - The Meltdown"
   region: "PAL-M6"
@@ -15518,8 +15487,6 @@ SLES-54396:
 SLES-54400:
   name: "SpongeBob SquarePants - Creature from the Krusty Krab"
   region: "PAL-M7"
-  gameFixes:
-    - GIFFIFOHack # Fixes bad graphics.
 SLES-54402:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-F"
@@ -16781,8 +16748,6 @@ SLES-54995:
   name: "Puzzle Quest - Challenge of the Warlords"
   region: "PAL-M5"
   compat: 5
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering black and white sprites.
 SLES-54996:
   name: "Golden Compass, The"
   region: "PAL-M5"
@@ -17640,8 +17605,6 @@ SLES-55443:
   compat: 5
   roundModes:
     eeRoundMode: 0  # Fixes jump issue.
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering sprites.
 SLES-55444:
   name: "Ar tonelico II: Melody of Metafalica"
   region: "PAL-E"
@@ -17847,8 +17810,6 @@ SLES-55576:
 SLES-55577:
   name: "DJ Hero"
   region: "PAL-M5"
-  gameFixes:
-    - GIFFIFOHack
 SLES-55578:
   name: "Band Hero"
   region: "PAL-M5"
@@ -18879,8 +18840,6 @@ SLPM-20436:
 SLPM-55005:
   name: "Mana Khemia 2: Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering sprites.
 SLPM-55008:
   name: "Sengoku Basara X"
   region: "NTSC-J"
@@ -18925,8 +18884,6 @@ SLPM-55110:
 SLPM-55114:
   name: "Mana Khemia 2: Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering sprites.
 SLPM-55118:
   name: "Galaxy Angel II - Eigou Kaiki no Koku [Disc1of2]"
   region: "NTSC-J"
@@ -26258,8 +26215,6 @@ SLPM-66693:
 SLPM-66694:
   name: "Spongebob"
   region: "NTSC-J"
-  gameFixes:
-    - GIFFIFOHack # Fixes bad graphics.
 SLPM-66695:
   name: "Kono Aozora ni Yakusoku o - Melody of the Sun and Sea"
   region: "NTSC-J"
@@ -33355,8 +33310,6 @@ SLUS-20360:
   name: "Blade II"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering HUD. (originally was EE Timing Hack but required since r4821)
 SLUS-20361:
   name: "Rally Fusion - Race of Champions"
   region: "NTSC-U"
@@ -34612,8 +34565,6 @@ SLUS-20647:
   compat: 5
   clampModes:
     vuClampMode: 3  # Fixes minor SPS on characters.
-  gameFixes:
-    - GIFFIFOHack
 SLUS-20648:
   name: "NBA Jam 2004"
   region: "NTSC-U"
@@ -34964,8 +34915,6 @@ SLUS-20737:
   name: "Hot Wheels - World Race"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - GIFFIFOHack
 SLUS-20738:
   name: "Van Helsing"
   region: "NTSC-U"
@@ -36501,7 +36450,6 @@ SLUS-21095:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - GIFFIFOHack # Fixes corrupted graphics in the menus.
     - VUKickstartHack # Fixes TLB misses and collision bugs.
 SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
@@ -37816,8 +37764,6 @@ SLUS-21383:
   name: "Fight Night - Round 3"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-  - GIFFIFOHack # Fixes corrupt textures.
 SLUS-21384:
   name: "Cabela's Alaskan Adventures"
   region: "NTSC-U"
@@ -37853,8 +37799,6 @@ SLUS-21391:
   name: "SpongeBob SquarePants - Creature from the Krusty Krab"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - GIFFIFOHack # Fixes bad graphics.
 SLUS-21392:
   name: "Shrek Smash and Crash"
   region: "NTSC-U"
@@ -39019,8 +38963,6 @@ SLUS-21692:
   name: "Puzzle Quest - Challenge of the Warlords"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering black and white sprites.
 SLUS-21693:
   name: "7 Wonders of the Ancient World"
   region: "NTSC-U"
@@ -39207,8 +39149,6 @@ SLUS-21735:
   compat: 5
   roundModes:
     eeRoundMode: 0  # Fixes jump issue.
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering sprites.
 SLUS-21736:
   name: "Wall-E"
   region: "NTSC-U"
@@ -39814,8 +39754,6 @@ SLUS-21890:
   name: "Mana Khemia 2: Fall Of Alchemy"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - GIFFIFOHack # Fixes flickering sprites.
 SLUS-21891:
   name: "G-Force"
   region: "NTSC-U"
@@ -39888,8 +39826,6 @@ SLUS-21908:
 SLUS-21909:
   name: "DJ Hero"
   region: "NTSC-U"
-  gameFixes:
-    - GIFFIFOHack
 SLUS-21910:
   name: "Marvel Super Hero Squad"
   region: "NTSC-U"

--- a/pcsx2/FiFo.cpp
+++ b/pcsx2/FiFo.cpp
@@ -125,10 +125,10 @@ void __fastcall WriteFIFO_VIF1(const mem128_t *value)
 void __fastcall WriteFIFO_GIF(const mem128_t *value)
 {
 	GUNIT_LOG("WriteFIFO_GIF()");
-	if (CHECK_GIFFIFOHACK) {
-		gif_fifo.write((u32*)value, 1);
-
-		gif_fifo.read(true);		
+	if ((!gifUnit.CanDoPath3() || gif_fifo.fifoSize > 0)) {
+		//DevCon.Warning("GIF FIFO HW Write");
+		gif_fifo.write_fifo((u32*)value, 1);
+		gif_fifo.read_fifo();
 	}
 	else {
 		gifUnit.TransferGSPacketData(GIF_TRANS_FIFO, (u8*)value, 16);

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -57,12 +57,24 @@ static __fi void CalculateFIFOCSR() {
 	}
 }
 
+
+bool CheckPaths() {
+	// Can't do Path 3, so try dma again later...
+	if (!gifUnit.CanDoPath3()) {
+		if (!gifUnit.Path3Masked())
+		{
+			//DevCon.Warning("Path3 stalled APATH %x PSE %x DIR %x Signal %x", gifRegs.stat.APATH, gifRegs.stat.PSE, gifRegs.stat.DIR, gifUnit.gsSIGNAL.queued);
+			GifDMAInt(128);
+		}
+		return false;
+	}
+	return true;
+}
+
 void GIF_Fifo::init()
 {
-	readpos = 0;
-	writepos = 0;
 	memzero(data);
-	memzero(readdata);
+	fifoSize = 0;
 	gifRegs.stat.FQC = 0;
 	CSRreg.FIFO = CSR_FIFO_EMPTY;
 	gif.gifstate = GIF_STATE_READY;
@@ -71,73 +83,81 @@ void GIF_Fifo::init()
 	gif.gscycles = 0;
 	gif.prevcycles = 0;
 	gif.mfifocycles = 0;
-	gif.gifqwc = 0;
 
 }
 
 
-int GIF_Fifo::write(u32* pMem, int size)
+int GIF_Fifo::write_fifo(u32* pMem, int size)
 {
-	if (gifRegs.stat.FQC == 16) {
-		//DevCon.Warning("Full");
+	if (fifoSize == 16) {
+		//GIF_LOG("GIF FIFO Full");
 		return 0;
 	}
-	int transsize;
-	int firsttrans = std::min(size, 16 - (int)gifRegs.stat.FQC);
 
-	gifRegs.stat.FQC += firsttrans;
-	transsize = firsttrans;
-	
-	
-	while (transsize-- > 0)
-	{
-		CopyQWC(&data[writepos], pMem);
-		writepos = (writepos + 4) & 63;
-		pMem += 4;
-	}
-	
+	int transferSize = std::min(size, 16 - (int)fifoSize);
+
+	int writePos = fifoSize * 4;
+
+	GIF_LOG("GIF FIFO Adding %d QW to GIF FIFO at offset %d FIFO now contains %d QW", transferSize, writePos, fifoSize);
+
+	memcpy(&data[writePos], pMem, transferSize * 16);
+
+	fifoSize += transferSize;
+	gifRegs.stat.FQC = fifoSize;
 	CalculateFIFOCSR();
-	return firsttrans;
+
+	return transferSize;
 }
 
-int GIF_Fifo::read(bool calledFromDMA)
+int GIF_Fifo::read_fifo()
 {
-
-	if (!gifUnit.CanDoPath3() || gifRegs.stat.FQC == 0)
+	if (!fifoSize || !gifUnit.CanDoPath3())
 	{
-		//DevCon.Warning("Path3 not masked");
-		if (gifch.chcr.STR == true && !(cpuRegs.interrupt & (1 << DMAC_GIF)) && calledFromDMA == false) {
-			GifDMAInt(16);
+		gifRegs.stat.FQC = fifoSize;
+		CalculateFIFOCSR();
+		if (fifoSize)
+		{
+			GIF_LOG("GIF FIFO Can't read, GIF paused/busy. Waiting");
+			GifDMAInt(128);
 		}
-		//DevCon.Warning("P3 Masked");
 		return 0;
 	}
 
-	int valueWritePos = 0;
-	uint sizeRead;
-	uint fifoSize = gifRegs.stat.FQC;
-	int oldReadPos = readpos;
+	int readpos = 0;
+	int sizeRead = 0;
 
-	while (gifRegs.stat.FQC) {
-		CopyQWC(&readdata[valueWritePos], &data[readpos]);
-		readpos = (readpos + 4) & 63;
-		valueWritePos = (valueWritePos + 4) & 63;
-		gifRegs.stat.FQC--;
-	}
+	sizeRead = gifUnit.TransferGSPacketData(GIF_TRANS_DMA, (u8*)&data, fifoSize * 16) / 16; //returns the size actually read
 
-	sizeRead = gifUnit.TransferGSPacketData(GIF_TRANS_DMA, (u8*)&readdata[0], fifoSize * 16) / 16; //returns the size actually read
+	GIF_LOG("GIF FIFO Read %d QW from FIFO Current Size %d", sizeRead, fifoSize);
 
 	if (sizeRead < fifoSize) {
-		readpos = (oldReadPos + (sizeRead * 4)) & 63; //if we read less than what was in the fifo, move the read position back
-		gifRegs.stat.FQC = fifoSize - sizeRead;
+		if (sizeRead > 0)
+		{
+			int copyAmount = fifoSize - sizeRead;
+			readpos = sizeRead * 4;
+
+			for (int i = 0; i < copyAmount; i++)
+				CopyQWC(&data[i * 4], &data[readpos + (i * 4)]);
+
+			fifoSize = copyAmount;
+
+			GIF_LOG("GIF FIFO rearranged to now only contain %d QW", fifoSize);
+		}
+		else
+		{
+			GIF_LOG("GIF FIFO not read");
+		}
 	}
-		
-	if (calledFromDMA == false) {
-		GifDMAInt(sizeRead * BIAS);
+	else
+	{
+		GIF_LOG("GIF FIFO now empty");
+		fifoSize = 0;
 	}
 
+	gifRegs.stat.FQC = fifoSize;
 	CalculateFIFOCSR();
-	return gifRegs.stat.FQC;
+
+	return sizeRead;
 }
 
 void incGifChAddr(u32 qwc) {
@@ -161,7 +181,7 @@ __fi void gifCheckPathStatus() {
 		}
 	}
 
-	//Required for Path3 Masking timing!
+	// Required for Path3 Masking timing!
 	if (gifUnit.gifPath[GIF_PATH_3].state == GIF_PATH_WAIT)
 		gifUnit.gifPath[GIF_PATH_3].state = GIF_PATH_IDLE;
 }
@@ -175,143 +195,132 @@ __fi void gifInterrupt()
 	{
 		if(vif1Regs.stat.VGW)
 		{
-			//Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
+			// Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
 			if(!(cpuRegs.interrupt & (1<<DMAC_VIF1)))
 				CPU_INT(DMAC_VIF1, 1);
 
-			//Make sure it loops if the GIF packet is empty to prepare for the next packet
-			//or end if it was the end of a packet.
-			//This must trigger after VIF retriggers as VIf might instantly mask Path3
+			// Make sure it loops if the GIF packet is empty to prepare for the next packet
+			// or end if it was the end of a packet.
+			// This must trigger after VIF retriggers as VIf might instantly mask Path3
 			if (!gifUnit.Path3Masked() || gifch.qwc == 0) {
 				GifDMAInt(16);
 			}
 			return;
 		}
-		
 	}
 
 	if (dmacRegs.ctrl.MFD == MFD_GIF) { // GIF MFIFO
 		//Console.WriteLn("GIF MFIFO");
 		gifMFIFOInterrupt();
 		return;
-	}	
-
-	if (CHECK_GIFFIFOHACK) {
-
-		if (int amtRead = gif_fifo.read(true)) {
-
-			if (!gifUnit.Path3Masked() || gifRegs.stat.FQC < 16) {
-				GifDMAInt(amtRead * BIAS);
-				return;
-			}
-		}
-		else {
-
-			if (!gifUnit.CanDoPath3() && gifRegs.stat.FQC == 16)
-			{
-				if (gifch.qwc > 0 || gif.gspath3done == false) {
-					if (!gifUnit.Path3Masked()) {
-						GifDMAInt(128);
-					}
-					return;
-				}
-			}
-		}
 	}
-	
 
 	if (gifUnit.gsSIGNAL.queued) {
 		GIF_LOG("Path 3 Paused");
 		GifDMAInt(128);
-		return;
+		if(gif_fifo.fifoSize == 16)
+			return;
 	}
 
-	gifCheckPathStatus();
-
-	//Double check as we might have read the fifo as it's ending the DMA
-	if (gifUnit.gifPath[GIF_PATH_3].state == GIF_PATH_IDLE)
+	// If there's something in the FIFO and we can do PATH3, empty the FIFO.
+	if (gif_fifo.fifoSize > 0)
 	{
-		if (vif1Regs.stat.VGW)
+		const int readSize = gif_fifo.read_fifo();
+
+		if (readSize)
+			GifDMAInt(readSize * BIAS);
+
+		gifCheckPathStatus();
+		// Double check as we might have read the fifo as it's ending the DMA
+		if (gifUnit.gifPath[GIF_PATH_3].state == GIF_PATH_IDLE)
 		{
-			//Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
-			if (!(cpuRegs.interrupt & (1 << DMAC_VIF1))) {
-				CPU_INT(DMAC_VIF1, 1);
+			if (vif1Regs.stat.VGW)
+			{
+				// Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
+				if (!(cpuRegs.interrupt & (1 << DMAC_VIF1))) {
+					CPU_INT(DMAC_VIF1, 1);
+				}
 			}
 		}
+
+		if (((gifch.qwc > 0) || (!gif.gspath3done)) && gif_fifo.fifoSize)
+			return;
 	}
-	
+
 	if (!(gifch.chcr.STR)) return;
 
 	if ((gifch.qwc > 0) || (!gif.gspath3done)) {
 		if (!dmacRegs.ctrl.DMAE) {
 			Console.Warning("gs dma masked, re-scheduling...");
-			// re-raise the int shortly in the future
+			// Re-raise the int shortly in the future
 			GifDMAInt( 64 );
 			return;
 		}
 		GIFdma();
-		
+
 		return;
 	}
 
-	
-	
-	if (!CHECK_GIFFIFOHACK)
-	{
-		gifRegs.stat.FQC = 0;
-		clearFIFOstuff(false);
-	}
 	gif.gscycles = 0;
 	gifch.chcr.STR	 = false;
-
+	gifRegs.stat.FQC = gif_fifo.fifoSize;
+	CalculateFIFOCSR();
 	hwDmacIrq(DMAC_GIF);
+
+	if(gif_fifo.fifoSize) 
+		GifDMAInt(8 * BIAS);
 	GIF_LOG("GIF DMA End QWC in fifo %x APATH = %x OPH = %x state = %x", gifRegs.stat.FQC, gifRegs.stat.APATH, gifRegs.stat.OPH, gifUnit.gifPath[GIF_PATH_3].state);
 }
 
 static u32 WRITERING_DMA(u32 *pMem, u32 qwc) {
+	u32 originalQwc = qwc;
+
 	if (gifRegs.stat.IMT)
 	{
-		//Splitting by 8qw can be really slow, so on bigger packets be less picky.
-		//Some games like Wallace & Gromit like smaller packets to be split correctly, hopefully with little impact on speed.
-		//68 works for W&G but 128 is more of a safe point.
+		// Splitting by 8qw can be really slow, so on bigger packets be less picky.
+		// Some games like Wallace & Gromit like smaller packets to be split correctly, hopefully with little impact on speed.
+		// 68 works for W&G but 128 is more of a safe point.
 		if (qwc > 128)
 			qwc = std::min(qwc, 1024u);
 		else
 			qwc = std::min(qwc, 8u);
 	}
+	
 	uint size;
-	if (CHECK_GIFFIFOHACK) {
-		size = gif_fifo.write(pMem, qwc);
+
+	if (CheckPaths() == false || ((qwc < 8 || gif_fifo.fifoSize > 0) && CHECK_GIFFIFOHACK))
+	{
+		if (gif_fifo.fifoSize < 16)
+		{
+			size = gif_fifo.write_fifo((u32*)pMem, originalQwc); // Use original QWC here, the intermediate mode is for the GIF unit, not DMA
+			incGifChAddr(size);
+			return size;
+		}
+		return 4; // Arbitrary value, probably won't schedule a DMA anwyay since the FIFO is full and GIF is paused
 	}
-	else {
-		size = gifUnit.TransferGSPacketData(GIF_TRANS_DMA, (u8*)pMem, qwc * 16) / 16;
-	}
+
+	size = gifUnit.TransferGSPacketData(GIF_TRANS_DMA, (u8*)pMem, qwc * 16) / 16;
 	incGifChAddr(size);
 	return size;
 }
 
-int  _GIFchain()
-{
-	tDMA_TAG *pMem;
+static __fi void GIFchain() {
+	tDMA_TAG* pMem;
 
 	pMem = dmaGetAddr(gifch.madr, false);
 	if (pMem == NULL) {
-		//must increment madr and clear qwc, else it loops
+		// Must increment madr and clear qwc, else it loops
 		gifch.madr += gifch.qwc * 16;
 		gifch.qwc = 0;
 		Console.Warning("Hackfix - NULL GIFchain");
-		return -1;
+		return;
 	}
 
-	return WRITERING_DMA((u32*)pMem, gifch.qwc);
-}
+	int transferred= WRITERING_DMA((u32*)pMem, gifch.qwc);
+	gif.gscycles += transferred * BIAS;
 
-static __fi void GIFchain() {
-	// qwc check now done outside this function
-	// Voodoocycles
-	// >> 2 so Drakan and Tekken 5 don't mess up in some PATH3 transfer. Cycles to interrupt were getting huge..
-	/*if (gifch.qwc)*/
-	gif.gscycles+= _GIFchain() * BIAS; /* guessing */
+	if (!gifUnit.Path3Masked() || (gif_fifo.fifoSize < 16))
+		GifDMAInt(gif.gscycles);
 }
 
 static __fi bool checkTieBit(tDMA_TAG* &ptag)
@@ -326,12 +335,12 @@ static __fi bool checkTieBit(tDMA_TAG* &ptag)
 
 static __fi tDMA_TAG* ReadTag()
 {
-	tDMA_TAG* ptag = dmaGetAddr(gifch.tadr, false);  //Set memory pointer to TADR
+	tDMA_TAG* ptag = dmaGetAddr(gifch.tadr, false);  // Set memory pointer to TADR
 
 	if (!(gifch.transfer("Gif", ptag))) return NULL;
 
-	gifch.madr = ptag[1]._u32;	//MADR = ADDR field + SPR
-	gif.gscycles += 2;				// Add 1 cycles from the QW read for the tag
+	gifch.madr = ptag[1]._u32;	// MADR = ADDR field + SPR
+	gif.gscycles += 2;			// Add 1 cycles from the QW read for the tag
 
 	gif.gspath3done = hwDmacSrcChainWithStack(gifch, ptag->ID);
 	return ptag;
@@ -339,7 +348,7 @@ static __fi tDMA_TAG* ReadTag()
 
 static __fi tDMA_TAG* ReadTag2()
 {
-	tDMA_TAG* ptag = dmaGetAddr(gifch.tadr, false);  //Set memory pointer to TADR
+	tDMA_TAG* ptag = dmaGetAddr(gifch.tadr, false);  // Set memory pointer to TADR
 
 	gifch.unsafeTransfer(ptag);
 	gifch.madr = ptag[1]._u32;
@@ -348,28 +357,13 @@ static __fi tDMA_TAG* ReadTag2()
 	return ptag;
 }
 
-bool CheckPaths() {
-	// Can't do Path 3, so try dma again later...
-	if (!CHECK_GIFFIFOHACK) {
-		if (!gifUnit.CanDoPath3()) {
-			if (!gifUnit.Path3Masked())
-			{
-				GIF_LOG("Path3 stalled");
-				GifDMAInt(128);
-			}
-			return false;
-		}
-	}
-	return true;
-}
-
 void GIFdma()
 {
 	while (gifch.qwc > 0 || !gif.gspath3done) {
 		tDMA_TAG* ptag;
 		gif.gscycles = gif.prevcycles;
 
-		if (gifRegs.ctrl.PSE) { // temporarily stop
+		if (gifRegs.ctrl.PSE) { // Temporarily stop
 			Console.WriteLn("Gif dma temp paused? (non MFIFO GIF)");
 			GifDMAInt(16);
 			return;
@@ -392,7 +386,9 @@ void GIFdma()
 			if (ptag == NULL) return;
 			//DevCon.Warning("GIF Reading Tag MSK = %x", vif1Regs.mskpath3);
 			GIF_LOG("gifdmaChain %8.8x_%8.8x size=%d, id=%d, addr=%lx tadr=%lx", ptag[1]._u32, ptag[0]._u32, gifch.qwc, ptag->ID, gifch.madr, gifch.tadr);
-			if (!CHECK_GIFFIFOHACK)gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
+			gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);
+			CalculateFIFOCSR();
+
 			if (dmacRegs.ctrl.STD == STD_GIF)
 			{
 				// there are still bugs, need to also check if gifch.madr +16*qwc >= stadr, if not, stall
@@ -418,47 +414,27 @@ void GIFdma()
 			Console.WriteLn("GIF DMA Stall in Normal mode not implemented - Report which game to PCSX2 Team");
 		}
 
-
-		if (!CHECK_GIFFIFOHACK) {
-			gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
-			clearFIFOstuff(true);
-		}
-
 		// Transfer Dn_QWC from Dn_MADR to GIF
 		if (gifch.qwc > 0) // Normal Mode
 		{
-			if (CheckPaths() == false) return;
-
-			GIFchain();	//Transfers the data set by the switch
-			//if (gscycles < 8) DevCon.Warning("GSCycles = %d", gscycles);
-			GifDMAInt(gif.gscycles);
+			GIFchain();	// Transfers the data set by the switch
 			return;
 		}
 	}
 
-	//QWC == 0 && gspath3done == true - End of DMA
 	gif.prevcycles = 0;
-	//if (gscycles < 8) DevCon.Warning("1 GSCycles = %d", gscycles);
 	GifDMAInt(16);
 }
 
 void dmaGIF()
 {
-	 //We used to add wait time for the buffer to fill here, fixing some timing problems in path 3 masking
-	//It takes the time of 24 QW for the BUS to become ready - The Punisher And Streetball
-	//DevCon.Warning("dmaGIFstart chcr = %lx, madr = %lx, qwc  = %lx\n tadr = %lx, asr0 = %lx, asr1 = %lx", gifch.chcr._u32, gifch.madr, gifch.qwc, gifch.tadr, gifch.asr0, gifch.asr1);
+	// DevCon.Warning("dmaGIFstart chcr = %lx, madr = %lx, qwc  = %lx\n tadr = %lx, asr0 = %lx, asr1 = %lx", gifch.chcr._u32, gifch.madr, gifch.qwc, gifch.tadr, gifch.asr0, gifch.asr1);
 
 	gif.gspath3done = false; // For some reason this doesn't clear? So when the system starts the thread, we will clear it :)
 
-	if (!CHECK_GIFFIFOHACK) {
-		gifRegs.stat.FQC |= 0x10; // hack ;)
-		clearFIFOstuff(true);
-	}
-
-	if (gifch.chcr.MOD == NORMAL_MODE) { //Else it really is a normal transfer and we want to quit, else it gets confused with chains
+	if (gifch.chcr.MOD == NORMAL_MODE) { // Else it really is a normal transfer and we want to quit, else it gets confused with chains
 		gif.gspath3done = true;
 	}
-
 
 	if(gifch.chcr.MOD == CHAIN_MODE && gifch.qwc > 0) {
 		//DevCon.Warning(L"GIF QWC on Chain " + gifch.chcr.desc());
@@ -475,19 +451,19 @@ static u32 QWCinGIFMFIFO(u32 DrainADDR)
 	u32 ret;
 
 	SPR_LOG("GIF MFIFO Requesting %x QWC from the MFIFO Base %x, SPR MADR %x Drain %x", gifch.qwc, dmacRegs.rbor.ADDR, spr0ch.madr, DrainADDR);
-	//Calculate what we have in the fifo.
+	// Calculate what we have in the fifo.
 	if (DrainADDR <= spr0ch.madr) {
-		//Drain is below the write position, calculate the difference between them
+		// Drain is below the write position, calculate the difference between them
 		ret = (spr0ch.madr - DrainADDR) >> 4;
 	}
 	else {
 		u32 limit = dmacRegs.rbor.ADDR + dmacRegs.rbsr.RMSK + 16;
-		//Drain is higher than SPR so it has looped round, 
-		//calculate from base to the SPR tag addr and what is left in the top of the ring
+		// Drain is higher than SPR so it has looped round, 
+		// calculate from base to the SPR tag addr and what is left in the top of the ring
 		ret = ((spr0ch.madr - dmacRegs.rbor.ADDR) + (limit - DrainADDR)) >> 4;
 	}
 	if (ret == 0) 
-		gif.gifstate |= GIF_STATE_EMPTY;
+		gif.gifstate = GIF_STATE_EMPTY;
 
 	SPR_LOG("%x Available of the %x requested", ret, gifch.qwc);
 	return ret;
@@ -496,9 +472,9 @@ static u32 QWCinGIFMFIFO(u32 DrainADDR)
 static __fi bool mfifoGIFrbTransfer()
 {
 	u32 qwc = std::min(QWCinGIFMFIFO(gifch.madr), gifch.qwc);
-	if (qwc == 0) {
-		DevCon.Warning("GIF FIFO EMPTY before transfer (how?)");
-	}
+
+	if (qwc == 0) // Either gifch.qwc is 0 (shouldn't get here) or the FIFO is empty.
+		return true;
 
 	u8* src = (u8*)PSM(gifch.madr);
 	if (src == NULL) return false;
@@ -508,84 +484,76 @@ static __fi bool mfifoGIFrbTransfer()
 	u32 firstTransQWC = needWrap ? MFIFOUntilEnd : qwc;
 	u32 transferred;
 
-	if (!CHECK_GIFFIFOHACK) 
-	{
-		transferred = gifUnit.TransferGSPacketData(GIF_TRANS_DMA, src, firstTransQWC * 16) / 16; // First part
-	}
-	else 
-	{
-		transferred = gif_fifo.write((u32*)src, firstTransQWC);
-	}
-
-	incGifChAddr(transferred);
+	transferred = WRITERING_DMA((u32*)src, firstTransQWC); // First part
 
 	gifch.madr = dmacRegs.rbor.ADDR + (gifch.madr & dmacRegs.rbsr.RMSK);
 	gifch.tadr = dmacRegs.rbor.ADDR + (gifch.tadr & dmacRegs.rbsr.RMSK);
 
-	if (needWrap && transferred == MFIFOUntilEnd) 
-	{ // Need to do second transfer to wrap around
+	if (needWrap && transferred == MFIFOUntilEnd)
+	{
+		// Need to do second transfer to wrap around
 		u32 transferred2;
 		uint secondTransQWC = qwc - MFIFOUntilEnd;
 
 		src = (u8*)PSM(dmacRegs.rbor.ADDR);
 		if (src == NULL) return false;
 
-		if (!CHECK_GIFFIFOHACK) {
-			transferred2 = gifUnit.TransferGSPacketData(GIF_TRANS_DMA, src, secondTransQWC * 16) / 16; // Second part
-		}
-		else {
-			transferred2 = gif_fifo.write((u32*)src, secondTransQWC);
-		}
+		transferred2 = WRITERING_DMA((u32*)src, secondTransQWC); // Second part
 
-		incGifChAddr(transferred2);
-		gif.mfifocycles += (transferred2 + transferred) * 2; // guessing
+		gif.mfifocycles += (transferred2 + transferred) * 2;
 	}
-	else 
-	{
-		gif.mfifocycles += transferred * 2; // guessing
-	}
+	else
+		gif.mfifocycles += transferred * 2;
 
 	return true;
 }
 
-static __fi bool mfifoGIFchain()
+static __fi void mfifoGIFchain()
 {
-	/* Is QWC = 0? if so there is nothing to transfer */
-	if (gifch.qwc == 0) return true;
+	// Is QWC = 0? if so there is nothing to transfer
+	if (gifch.qwc == 0)
+	{
+		gif.mfifocycles += 4;
+		return;
+	}
 
 	if ((gifch.madr & ~dmacRegs.rbsr.RMSK) == dmacRegs.rbor.ADDR)
 	{
-		bool ret = true;
-
 		if (QWCinGIFMFIFO(gifch.madr) == 0) {
 			SPR_LOG("GIF FIFO EMPTY before transfer");
 			gif.gifstate = GIF_STATE_EMPTY;
 			gif.mfifocycles += 4;
-			if (CHECK_GIFFIFOHACK)
-				GifDMAInt(128);
-			return true;
+			return;
 		}
 
-		if (!mfifoGIFrbTransfer()) ret = false;
+		if (!mfifoGIFrbTransfer())
+		{
+			gif.mfifocycles += 4;
+			gifch.qwc = 0;
+			gif.gspath3done = true;
+			return;
+		}
 
-		//This ends up being done more often but it's safer :P
-		//Make sure we wrap the addresses, dont want it being stuck outside the ring when reading from the ring!
+		// This ends up being done more often but it's safer :P
+		// Make sure we wrap the addresses, dont want it being stuck outside the ring when reading from the ring!
 		gifch.madr = dmacRegs.rbor.ADDR + (gifch.madr & dmacRegs.rbsr.RMSK);
 		gifch.tadr = gifch.madr;
-
-		return ret;
 	}
 	else {
-		int mfifoqwc;
 		SPR_LOG("Non-MFIFO Location transfer doing %x Total QWC", gifch.qwc);
 		tDMA_TAG *pMem = dmaGetAddr(gifch.madr, false);
-		if (pMem == NULL) return false;
+		if (pMem == NULL) 
+		{
+			gif.mfifocycles += 4;
+			gifch.qwc = 0;
+			gif.gspath3done = true;
+			return;
+		}
 
-		mfifoqwc = WRITERING_DMA((u32*)pMem, gifch.qwc);
-		gif.mfifocycles += (mfifoqwc) * 2; /* guessing */
+		gif.mfifocycles += WRITERING_DMA((u32*)pMem, gifch.qwc) * 2;
 	}
 
-	return true;
+	return;
 }
 
 static u32 qwctag(u32 mask) {
@@ -595,25 +563,25 @@ static u32 qwctag(u32 mask) {
 void mfifoGifMaskMem(int id)
 {
 	switch (id) {
-		//These five transfer data following the tag, need to check its within the buffer (Front Mission 4)
+		// These five transfer data following the tag, need to check its within the buffer (Front Mission 4)
 		case TAG_CNT:
 		case TAG_NEXT:
 		case TAG_CALL: 
 		case TAG_RET:
 		case TAG_END:
-			if(gifch.madr < dmacRegs.rbor.ADDR) //probably not needed but we will check anyway.
+			if(gifch.madr < dmacRegs.rbor.ADDR) // Probably not needed but we will check anyway.
 			{
 				SPR_LOG("GIF MFIFO MADR below bottom of ring buffer, wrapping GIF MADR = %x Ring Bottom %x", gifch.madr, dmacRegs.rbor.ADDR);
 				gifch.madr = qwctag(gifch.madr);
 			} else
-			if(gifch.madr > (dmacRegs.rbor.ADDR + (u32)dmacRegs.rbsr.RMSK)) //Usual scenario is the tag is near the end (Front Mission 4)
+			if(gifch.madr > (dmacRegs.rbor.ADDR + (u32)dmacRegs.rbsr.RMSK)) // Usual scenario is the tag is near the end (Front Mission 4)
 			{
 				SPR_LOG("GIF MFIFO MADR outside top of ring buffer, wrapping GIF MADR = %x Ring Top %x", gifch.madr, (dmacRegs.rbor.ADDR + dmacRegs.rbsr.RMSK)+16);
 				gifch.madr = qwctag(gifch.madr);
 			}
 			break;
 		default:
-			//Do nothing as the MADR could be outside
+			// Do nothing as the MADR could be outside
 			break;
 	}
 }
@@ -622,9 +590,8 @@ void mfifoGIFtransfer()
 {
 	tDMA_TAG *ptag;
 	gif.mfifocycles = 0;
-	
 
-	if (gifRegs.ctrl.PSE) { // temporarily stop
+	if (gifRegs.ctrl.PSE) { // Temporarily stop
 		Console.WriteLn("Gif dma temp paused?");
 		CPU_INT(DMAC_MFIFO_GIF, 16);
 		return;
@@ -637,14 +604,15 @@ void mfifoGIFtransfer()
 			SPR_LOG("GIF FIFO EMPTY before tag read");
 			gif.gifstate = GIF_STATE_EMPTY;
 			GifDMAInt(4);
-			if (CHECK_GIFFIFOHACK)
-				GifDMAInt(128);
 			return;
 		}
 
 		ptag = dmaGetAddr(gifch.tadr, false);
 		gifch.unsafeTransfer(ptag);
 		gifch.madr = ptag[1]._u32;
+
+		gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);
+		CalculateFIFOCSR();
 
 		gif.mfifocycles += 2;
 
@@ -667,12 +635,8 @@ void mfifoGIFtransfer()
 		}
 	 }
 
-	if (!mfifoGIFchain()) {
-		Console.WriteLn("mfifoGIF dmaChain error size=%d, madr=%lx, tadr=%lx", gifch.qwc, gifch.madr, gifch.tadr);
-		gif.gspath3done = true;
-		gifch.qwc = 0; //Sanity
-	}
-
+	mfifoGIFchain();
+		
 	GifDMAInt(std::max(gif.mfifocycles, (u32)4));
 
 	SPR_LOG("mfifoGIFtransfer end %x madr %x, tadr %x", gifch.chcr._u32, gifch.madr, gifch.tadr);
@@ -680,7 +644,7 @@ void mfifoGIFtransfer()
 
 void gifMFIFOInterrupt()
 {
-    GIF_LOG("gifMFIFOInterrupt");
+	//DevCon.Warning("gifMFIFOInterrupt");
 	gif.mfifocycles = 0;
 
 	if (dmacRegs.ctrl.MFD != MFD_GIF) { // GIF not in MFIFO anymore, come out.
@@ -695,19 +659,18 @@ void gifMFIFOInterrupt()
 	{
 		if (vif1Regs.stat.VGW)
 		{
-			//Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
+			// Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
 			if (!(cpuRegs.interrupt & (1 << DMAC_VIF1)))
 				CPU_INT(DMAC_VIF1, 1);
 
-			//Make sure it loops if the GIF packet is empty to prepare for the next packet
-			//or end if it was the end of a packet.
-			//This must trigger after VIF retriggers as VIf might instantly mask Path3
+			// Make sure it loops if the GIF packet is empty to prepare for the next packet
+			// or end if it was the end of a packet.
+			// This must trigger after VIF retriggers as VIf might instantly mask Path3
 			if (!gifUnit.Path3Masked() || gifch.qwc == 0) {
 				GifDMAInt(16);
 			}
 			return;
 		}
-
 	}
 
 	if (gifUnit.gsSIGNAL.queued) {
@@ -715,40 +678,19 @@ void gifMFIFOInterrupt()
 		return;
 	}
 
-	if (CHECK_GIFFIFOHACK) 
-	{
-		if (int amtRead = gif_fifo.read(true))
-		{
-			if (!gifUnit.Path3Masked() || gifRegs.stat.FQC < 16) {
-				GifDMAInt(amtRead * BIAS);
-				return;
-			}
-		}
-		else {
-			if (!gifUnit.CanDoPath3() && gifRegs.stat.FQC == 16)
-			{
-				if (gifch.qwc > 0 || gif.gspath3done == false) {
-					if (!gifUnit.Path3Masked()) {
-						GifDMAInt(128);
-					}
-					return;
-				}
-			}
-		}
-	}
 	gifCheckPathStatus();
 
 	if (gifUnit.gifPath[GIF_PATH_3].state == GIF_PATH_IDLE)
 	{
 		if (vif1Regs.stat.VGW)
 		{
-			//Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
+			// Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
 			if (!(cpuRegs.interrupt & (1 << DMAC_VIF1)))
 				CPU_INT(DMAC_VIF1, 1);
 
-			//Make sure it loops if the GIF packet is empty to prepare for the next packet
-			//or end if it was the end of a packet.
-			//This must trigger after VIF retriggers as VIf might instantly mask Path3
+			// Make sure it loops if the GIF packet is empty to prepare for the next packet
+			// or end if it was the end of a packet.
+			// This must trigger after VIF retriggers as VIf might instantly mask Path3
 			if (!gifUnit.Path3Masked() || gifch.qwc == 0) {
 				GifDMAInt(16);
 			}
@@ -756,41 +698,58 @@ void gifMFIFOInterrupt()
 		}
 	}
 
-	if (!gifch.chcr.STR) {
-		Console.WriteLn("WTF GIFMFIFO");
-		cpuRegs.interrupt &= ~(1 << 11);
-		return;
+	// If there's something in the FIFO and we can do PATH3, empty the FIFO.
+	if (gif_fifo.fifoSize > 0)
+	{
+		const int readSize = gif_fifo.read_fifo();
+
+		if (readSize)
+			GifDMAInt(readSize * BIAS);
+
+		gifCheckPathStatus();
+		// Double check as we might have read the fifo as it's ending the DMA
+		if (gifUnit.gifPath[GIF_PATH_3].state == GIF_PATH_IDLE)
+		{
+			if (vif1Regs.stat.VGW)
+			{
+				//Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
+				if (!(cpuRegs.interrupt & (1 << DMAC_VIF1))) {
+					CPU_INT(DMAC_VIF1, 1);
+				}
+			}
+		}
+
+		if (((gifch.qwc > 0) || (!gif.gspath3done)) && gif_fifo.fifoSize)
+			return;
 	}
 
-	if ((gif.gifstate & GIF_STATE_EMPTY)) {
-		FireMFIFOEmpty();
-		if (CHECK_GIFFIFOHACK)
-			GifDMAInt(128);
+	if (!gifch.chcr.STR)
 		return;
+
+	if (spr0ch.madr == gifch.tadr || (gif.gifstate & GIF_STATE_EMPTY)) {
+		gif.gifstate = GIF_STATE_EMPTY; // In case of madr = tadr we need to set it
+		FireMFIFOEmpty();
+
+		if (gifch.qwc > 0 || !gif.gspath3done)
+			return;
 	}
 
 	if (gifch.qwc > 0 || !gif.gspath3done) {
 
-		if (!CheckPaths()) return;
 		mfifoGIFtransfer();
 		return;
-	}
-
-	if (!CHECK_GIFFIFOHACK)
-	{
-		gifRegs.stat.FQC = 0;
-		clearFIFOstuff(false);
-	}
-	
-	if (spr0ch.madr == gifch.tadr) {
-		FireMFIFOEmpty();
 	}
 
 	gif.gscycles = 0;
 	
 	gifch.chcr.STR = false;
 	gif.gifstate = GIF_STATE_READY;
+	gifRegs.stat.FQC = gif_fifo.fifoSize;
+	CalculateFIFOCSR();
 	hwDmacIrq(DMAC_GIF);
+
+	if (gif_fifo.fifoSize)
+		GifDMAInt(8 * BIAS);
 	DMA_LOG("GIF MFIFO DMA End");
 }
 

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -278,14 +278,15 @@ static u32 WRITERING_DMA(u32 *pMem, u32 qwc) {
 	if (gifRegs.stat.IMT)
 	{
 		// Splitting by 8qw can be really slow, so on bigger packets be less picky.
-		// Some games like Wallace & Gromit like smaller packets to be split correctly, hopefully with little impact on speed.
-		// 68 works for W&G but 128 is more of a safe point.
-		if (qwc > 128)
-			qwc = std::min(qwc, 1024u);
+		// Games seem to be more concerned with other channels finishing before PATH 3 finishes
+		// so we can get away with transferring "most" of it when it's a big packet.
+		// Use Wallace and Gromit Project Zoo or The Suffering for testing
+		if (qwc > 64)
+			qwc = qwc-64;
 		else
 			qwc = std::min(qwc, 8u);
 	}
-	
+
 	uint size;
 
 	if (CheckPaths() == false || ((qwc < 8 || gif_fifo.fifoSize > 0) && CHECK_GIFFIFOHACK))

--- a/pcsx2/Gif.h
+++ b/pcsx2/Gif.h
@@ -80,11 +80,10 @@ extern __aligned16 gifStruct gif;
 struct GIF_Fifo
 {
 	unsigned int data[64]; //16 QW FIFO
-	unsigned int readdata[64]; //16 QW Inline for reading
-	int readpos, writepos;
+	unsigned int fifoSize;
 
-	int write(u32* pMem, int size);
-	int read(bool calledFromDMA = false);
+	int write_fifo(u32* pMem, int size);
+	int read_fifo();
 
 	void init();
 };

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -538,6 +538,7 @@ struct Gif_Unit
 		gifRegs.stat.reset();
 		gifRegs.ctrl.reset();
 		gifRegs.mode.reset();
+		gif_fifo.init();
 	}
 
 	// Adds a finished GS Packet to the MTGS ring buffer

--- a/pcsx2/Hw.cpp
+++ b/pcsx2/Hw.cpp
@@ -216,12 +216,6 @@ __ri void hwMFIFOResume(u32 transferred) {
 				CPU_INT(DMAC_MFIFO_GIF, transferred * BIAS);
 				gif.gifstate = GIF_STATE_READY;
 			}
-			if (!CHECK_GIFFIFOHACK)
-			{
-				gifRegs.stat.FQC = 16;
-				//GIF FIFO
-				clearFIFOstuff(true);
-			}			
 			break;
 		}
 		default:

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -111,9 +111,8 @@ void __fastcall _hwWrite32( u32 mem, u32 value )
 				icase(GIF_MODE)
 				{
 					gifRegs.mode.write(value);
-
 					//Need to kickstart the GIF if the M3R mask comes off
-					if (gifRegs.stat.M3R == 1 && gifRegs.mode.M3R == 0 && gifch.chcr.STR)
+					if (gifRegs.stat.M3R == 1 && gifRegs.mode.M3R == 0 && (gifch.chcr.STR || gif_fifo.fifoSize))
 					{
 						DevCon.Warning("GIF Mode cancelling P3 Disable");
 						CPU_INT(DMAC_GIF, 8);

--- a/pcsx2/SPR.cpp
+++ b/pcsx2/SPR.cpp
@@ -313,12 +313,13 @@ void SPRFROMinterrupt()
 					spr0ch.madr = dmacRegs.rbor.ADDR + (spr0ch.madr & dmacRegs.rbsr.RMSK);
 					//Console.WriteLn("mfifoGIFtransfer %x madr %x, tadr %x", gif->chcr._u32, gif->madr, gif->tadr);
 					hwMFIFOResume(mfifotransferred);
-					mfifotransferred = 0;
 					break;
 				}
 				default:
 					break;
 			}
+
+			mfifotransferred = 0;
 		}
 
 		return;

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A21 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A22 << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -222,14 +222,14 @@ __fi void vif1FBRST(u32 value) {
 				    case MFD_VIF1:
                         //Console.WriteLn("MFIFO Stall");
 						//MFIFO active and not empty
-                        if(vif1ch.chcr.STR) CPU_INT(DMAC_MFIFO_VIF, 0);
+                        if(vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_FDR)) CPU_INT(DMAC_MFIFO_VIF, 0);
                         break;
 
                     case NO_MFD:
                     case MFD_RESERVED:
                     case MFD_GIF: // Wonder if this should be with VIF?
                         // Gets the timing right - Flatout
-                        if(vif1ch.chcr.STR) CPU_INT(DMAC_VIF1, 0);
+                        if(vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_FDR)) CPU_INT(DMAC_VIF1, 0);
                         break;
 				}
 
@@ -256,6 +256,8 @@ __fi void vif1STAT(u32 value) {
 		//position, as we clear it and set it to the end well before the interrupt, the game assumes it's finished,
 		//then proceeds to reverse the dma before we have even done it ourselves. So lets just make sure VIF is ready :)
 		if (vif1ch.qwc > 0 || isStalled == false){
+			vif1ch.qwc = 0;
+			hwDmacIrq(DMAC_VIF1);
 			vif1ch.chcr.STR = false;
 			cpuRegs.interrupt &= ~((1 << DMAC_VIF1) | (1 << DMAC_MFIFO_VIF));
 		}

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -23,7 +23,7 @@
 #include "MTVU.h"
 #include "Gif_Unit.h"
 
-__aligned16 vifStruct  vif0, vif1;
+__aligned16 vifStruct vif0, vif1;
 
 void vif0Reset()
 {
@@ -46,7 +46,7 @@ void vif1Reset()
 void SaveStateBase::vif0Freeze()
 {
 	FreezeTag("VIF0dma");
-	
+
 	Freeze(g_vif0Cycles);
 
 	Freeze(vif0);
@@ -58,7 +58,7 @@ void SaveStateBase::vif0Freeze()
 void SaveStateBase::vif1Freeze()
 {
 	FreezeTag("VIF1dma");
-	
+
 	Freeze(g_vif1Cycles);
 
 	Freeze(vif1);
@@ -71,7 +71,8 @@ void SaveStateBase::vif1Freeze()
 // Vif0/Vif1 Write32
 //------------------------------------------------------------------
 
-__fi void vif0FBRST(u32 value) {
+__fi void vif0FBRST(u32 value)
+{
 	VIF_LOG("VIF0_FBRST write32 0x%8.8x", value);
 
 	if (value & 0x1) // Reset Vif.
@@ -80,7 +81,7 @@ __fi void vif0FBRST(u32 value) {
 		u128 SaveCol;
 		u128 SaveRow;
 
-	//	if(vif0ch.chcr.STR) DevCon.Warning("FBRST While Vif0 active");
+		//	if(vif0ch.chcr.STR) DevCon.Warning("FBRST While Vif0 active");
 		//Must Preserve Row/Col registers! (Downhill Domination for testing)
 		SaveCol._u64[0] = vif0.MaskCol._u64[0];
 		SaveCol._u64[1] = vif0.MaskCol._u64[1];
@@ -135,19 +136,21 @@ __fi void vif0FBRST(u32 value) {
 			cancel = true;
 
 		vif0Regs.stat.clear_flags(VIF0_STAT_VSS | VIF0_STAT_VFS | VIF0_STAT_VIS |
-				    VIF0_STAT_INT | VIF0_STAT_ER0 | VIF0_STAT_ER1);
+								  VIF0_STAT_INT | VIF0_STAT_ER0 | VIF0_STAT_ER1);
 		if (cancel)
-		{			
-				g_vif0Cycles = 0;
-				// loop necessary for spiderman
-				 if(vif0ch.chcr.STR) CPU_INT(DMAC_VIF0, 0); // Gets the timing right - Flatout
+		{
+			g_vif0Cycles = 0;
+			// loop necessary for spiderman
+			if (vif0ch.chcr.STR)
+				CPU_INT(DMAC_VIF0, 0); // Gets the timing right - Flatout
 		}
 	}
 }
 
-__fi void vif1FBRST(u32 value) {
+__fi void vif1FBRST(u32 value)
+{
 	VIF_LOG("VIF1_FBRST write32 0x%8.8x", value);
-	
+
 	if (FBRST(value).RST) // Reset Vif.
 	{
 		u128 SaveCol;
@@ -168,7 +171,7 @@ __fi void vif1FBRST(u32 value) {
 
 		GUNIT_WARN(Color_Red, "VIF FBRST Reset MSK = %x", vif1Regs.mskpath3);
 		vif1Regs.mskpath3 = false;
-		gifRegs.stat.M3P  = 0;
+		gifRegs.stat.M3P = 0;
 		vif1Regs.err.reset();
 		vif1.inprogress = mfifo_empty;
 		vif1.cmd = 0;
@@ -211,41 +214,46 @@ __fi void vif1FBRST(u32 value) {
 		}
 
 		vif1Regs.stat.clear_flags(VIF1_STAT_VSS | VIF1_STAT_VFS | VIF1_STAT_VIS |
-				VIF1_STAT_INT | VIF1_STAT_ER0 | VIF1_STAT_ER1);
+								  VIF1_STAT_INT | VIF1_STAT_ER0 | VIF1_STAT_ER1);
 
 		if (cancel)
 		{
-				g_vif1Cycles = 0;
-				// loop necessary for spiderman
-				switch(dmacRegs.ctrl.MFD)
-				{
-				    case MFD_VIF1:
-                        //Console.WriteLn("MFIFO Stall");
-						//MFIFO active and not empty
-                        if(vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_FDR)) CPU_INT(DMAC_MFIFO_VIF, 0);
-                        break;
+			g_vif1Cycles = 0;
+			// loop necessary for spiderman
+			switch (dmacRegs.ctrl.MFD)
+			{
+				case MFD_VIF1:
+					//Console.WriteLn("MFIFO Stall");
+					//MFIFO active and not empty
+					if (vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_FDR))
+						CPU_INT(DMAC_MFIFO_VIF, 0);
+					break;
 
-                    case NO_MFD:
-                    case MFD_RESERVED:
-                    case MFD_GIF: // Wonder if this should be with VIF?
-                        // Gets the timing right - Flatout
-                        if(vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_FDR)) CPU_INT(DMAC_VIF1, 0);
-                        break;
-				}
+				case NO_MFD:
+				case MFD_RESERVED:
+				case MFD_GIF: // Wonder if this should be with VIF?
+					// Gets the timing right - Flatout
+					if (vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_FDR))
+						CPU_INT(DMAC_VIF1, 0);
+					break;
+			}
 
-				//vif1ch.chcr.STR = true;
+			//vif1ch.chcr.STR = true;
 		}
 	}
 }
 
-__fi void vif1STAT(u32 value) {
+__fi void vif1STAT(u32 value)
+{
 	VIF_LOG("VIF1_STAT write32 0x%8.8x", value);
 
 	/* Only FDR bit is writable, so mask the rest */
-	if ((vif1Regs.stat.FDR) ^ ((tVIF_STAT&)value).FDR) {
+	if ((vif1Regs.stat.FDR) ^ ((tVIF_STAT&)value).FDR)
+	{
 		bool isStalled = false;
 		// different so can't be stalled
-		if (vif1Regs.stat.test(VIF1_STAT_INT | VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS)) {
+		if (vif1Regs.stat.test(VIF1_STAT_INT | VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
+		{
 			DbgCon.WriteLn("changing dir when vif1 fifo stalled done = %x qwc = %x stat = %x", vif1.done, vif1ch.qwc, vif1Regs.stat._u32);
 			isStalled = true;
 		}
@@ -255,7 +263,8 @@ __fi void vif1STAT(u32 value) {
 		//Hotwheels had this in the "direction when stalled" area, however Sled Storm seems to keep an eye on the dma
 		//position, as we clear it and set it to the end well before the interrupt, the game assumes it's finished,
 		//then proceeds to reverse the dma before we have even done it ourselves. So lets just make sure VIF is ready :)
-		if (vif1ch.qwc > 0 || isStalled == false){
+		if (vif1ch.qwc > 0 || isStalled == false)
+		{
 			vif1ch.qwc = 0;
 			hwDmacIrq(DMAC_VIF1);
 			vif1ch.chcr.STR = false;
@@ -268,7 +277,7 @@ __fi void vif1STAT(u32 value) {
 
 	if (vif1Regs.stat.FDR) // Vif transferring to memory.
 	{
-	    // Hack but it checks this is true before transfer? (fatal frame)
+		// Hack but it checks this is true before transfer? (fatal frame)
 		// Update Refraction: Use of this function has been investigated and understood.
 		// Before this ever happens, a DIRECT/HL command takes place sending the transfer info to the GS
 		// One of the registers told about this is TRXREG which tells us how much data is going to transfer (th x tw) in words
@@ -277,74 +286,137 @@ __fi void vif1STAT(u32 value) {
 
 		vif1Regs.stat.FQC = std::min((u32)16, vif1.GSLastDownloadSize);
 		//Console.Warning("Reversing VIF Transfer for %x QWC", vif1.GSLastDownloadSize);
-
 	}
 	else // Memory transferring to Vif.
 	{
 		//Sometimes the value from the GS is bigger than vif wanted, so it just sets it back and cancels it.
 		//Other times it can read it off ;)
 		vif1Regs.stat.FQC = 0;
-		if (vif1ch.chcr.STR) CPU_INT(DMAC_VIF1, 0);
+		if (vif1ch.chcr.STR)
+			CPU_INT(DMAC_VIF1, 0);
 	}
 }
 
 #define caseVif(x) (idx ? VIF1_##x : VIF0_##x)
 
-_vifT __fi u32 vifRead32(u32 mem) {
+_vifT __fi u32 vifRead32(u32 mem)
+{
 	vifStruct& vif = MTVU_VifX;
 	bool wait = idx && THREAD_VU1;
-	switch (mem) {
-		case caseVif(ROW0): if (wait) vu1Thread.WaitVU(); return vif.MaskRow._u32[0];
-		case caseVif(ROW1): if (wait) vu1Thread.WaitVU(); return vif.MaskRow._u32[1];
-		case caseVif(ROW2): if (wait) vu1Thread.WaitVU(); return vif.MaskRow._u32[2];
-		case caseVif(ROW3): if (wait) vu1Thread.WaitVU(); return vif.MaskRow._u32[3];
+	switch (mem)
+	{
+		case caseVif(ROW0):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskRow._u32[0];
+		case caseVif(ROW1):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskRow._u32[1];
+		case caseVif(ROW2):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskRow._u32[2];
+		case caseVif(ROW3):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskRow._u32[3];
 
-		case caseVif(COL0): if (wait) vu1Thread.WaitVU(); return vif.MaskCol._u32[0];
-		case caseVif(COL1): if (wait) vu1Thread.WaitVU(); return vif.MaskCol._u32[1];
-		case caseVif(COL2): if (wait) vu1Thread.WaitVU(); return vif.MaskCol._u32[2];
-		case caseVif(COL3): if (wait) vu1Thread.WaitVU(); return vif.MaskCol._u32[3];
+		case caseVif(COL0):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskCol._u32[0];
+		case caseVif(COL1):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskCol._u32[1];
+		case caseVif(COL2):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskCol._u32[2];
+		case caseVif(COL3):
+			if (wait)
+				vu1Thread.WaitVU();
+			return vif.MaskCol._u32[3];
 	}
-	
+
 	return psHu32(mem);
 }
 
 // returns FALSE if no writeback is needed (or writeback is handled internally)
 // returns TRUE if the caller should writeback the value to the eeHw register map.
-_vifT __fi bool vifWrite32(u32 mem, u32 value) {
+_vifT __fi bool vifWrite32(u32 mem, u32 value)
+{
 	vifStruct& vif = GetVifX;
 
-	switch (mem) {
+	switch (mem)
+	{
 		case caseVif(MARK):
 			VIF_LOG("VIF%d_MARK write32 0x%8.8x", idx, value);
 			vifXRegs.stat.MRK = false;
 			//vifXRegs.mark	   = value;
-		break;
+			break;
 
 		case caseVif(FBRST):
-			if (!idx) vif0FBRST(value);
-			else	  vif1FBRST(value);
-		return false;
+			if (!idx)
+				vif0FBRST(value);
+			else
+				vif1FBRST(value);
+			return false;
 
 		case caseVif(STAT):
-			if (idx) { // Only Vif1 does this stuff?
+			if (idx)
+			{ // Only Vif1 does this stuff?
 				vif1STAT(value);
 			}
-		return false;
+			return false;
 
 		case caseVif(ERR):
 		case caseVif(MODE):
 			// standard register writes -- handled by caller.
-		break;
+			break;
 
-		case caseVif(ROW0): vif.MaskRow._u32[0] = value; if (idx && THREAD_VU1) vu1Thread.WriteRow(vif); return false;
-		case caseVif(ROW1): vif.MaskRow._u32[1] = value; if (idx && THREAD_VU1) vu1Thread.WriteRow(vif); return false;
-		case caseVif(ROW2): vif.MaskRow._u32[2] = value; if (idx && THREAD_VU1) vu1Thread.WriteRow(vif); return false;
-		case caseVif(ROW3): vif.MaskRow._u32[3] = value; if (idx && THREAD_VU1) vu1Thread.WriteRow(vif); return false;
+		case caseVif(ROW0):
+			vif.MaskRow._u32[0] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteRow(vif);
+			return false;
+		case caseVif(ROW1):
+			vif.MaskRow._u32[1] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteRow(vif);
+			return false;
+		case caseVif(ROW2):
+			vif.MaskRow._u32[2] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteRow(vif);
+			return false;
+		case caseVif(ROW3):
+			vif.MaskRow._u32[3] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteRow(vif);
+			return false;
 
-		case caseVif(COL0): vif.MaskCol._u32[0] = value; if (idx && THREAD_VU1) vu1Thread.WriteCol(vif); return false;
-		case caseVif(COL1): vif.MaskCol._u32[1] = value; if (idx && THREAD_VU1) vu1Thread.WriteCol(vif); return false;
-		case caseVif(COL2): vif.MaskCol._u32[2] = value; if (idx && THREAD_VU1) vu1Thread.WriteCol(vif); return false;
-		case caseVif(COL3): vif.MaskCol._u32[3] = value; if (idx && THREAD_VU1) vu1Thread.WriteCol(vif); return false;
+		case caseVif(COL0):
+			vif.MaskCol._u32[0] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteCol(vif);
+			return false;
+		case caseVif(COL1):
+			vif.MaskCol._u32[1] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteCol(vif);
+			return false;
+		case caseVif(COL2):
+			vif.MaskCol._u32[2] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteCol(vif);
+			return false;
+		case caseVif(COL3):
+			vif.MaskCol._u32[3] = value;
+			if (idx && THREAD_VU1)
+				vu1Thread.WriteCol(vif);
+			return false;
 	}
 
 	// fall-through case: issue standard writeback behavior.

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -288,7 +288,7 @@ __fi void vif1Interrupt()
 
 	g_vif1Cycles = 0;
 
-	if( gifRegs.stat.APATH == 2  && gifUnit.gifPath[GIF_PATH_2].isDone())
+	if( gifRegs.stat.APATH == 2 && gifUnit.gifPath[GIF_PATH_2].isDone())
 	{
 		gifRegs.stat.APATH = 0;
 		gifRegs.stat.OPH = 0;
@@ -427,7 +427,7 @@ __fi void vif1Interrupt()
 	vif1.irqoffset.enabled = false;
 	if(vif1.queued_program) vifExecQueue(1);
 	g_vif1Cycles = 0;
-	DMA_LOG("VIF1 DMA End");
+	VIF_LOG("VIF1 DMA End");
 	hwDmacIrq(DMAC_VIF1);
 
 }

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -22,12 +22,16 @@
 #include "VUmicro.h"
 #include "MTVU.h"
 
-#define vifOp(vifCodeName) _vifT int __fastcall vifCodeName(int pass, const u32 *data)
-#define pass1    if (pass == 0)
-#define pass2    if (pass == 1)
-#define pass3    if (pass == 2)
+#define vifOp(vifCodeName) _vifT int __fastcall vifCodeName(int pass, const u32* data)
+#define pass1 if (pass == 0)
+#define pass2 if (pass == 1)
+#define pass3 if (pass == 2)
 #define pass1or2 if (pass == 0 || pass == 1)
-#define vif1Only() { if (!idx) return vifCode_Null<idx>(pass, (u32*)data); }
+#define vif1Only() \
+	{ \
+		if (!idx) \
+			return vifCode_Null<idx>(pass, (u32*)data); \
+	}
 vifOp(vifCode_Null);
 
 //------------------------------------------------------------------
@@ -41,8 +45,10 @@ __ri void vifExecQueue(int idx)
 
 	GetVifX.queued_program = false;
 
-	if (!idx) vu0ExecMicro(vif0.queued_pc);
-	else	  vu1ExecMicro(vif1.queued_pc);
+	if (!idx)
+		vu0ExecMicro(vif0.queued_pc);
+	else
+		vu1ExecMicro(vif1.queued_pc);
 
 	// Hack for Wakeboarding Unleashed, game runs a VU program in parallel with a VIF unpack list.
 	// The start of the VU program clears the VU memory, while VIF populates it from behind, so we need to get the clear out of the way.
@@ -53,40 +59,48 @@ __ri void vifExecQueue(int idx)
 	}*/
 }
 
-static __fi void vifFlush(int idx) {
+static __fi void vifFlush(int idx)
+{
 	vifExecQueue(idx);
 
-	if (!idx) vif0FLUSH();
-	else      vif1FLUSH();
+	if (!idx)
+		vif0FLUSH();
+	else
+		vif1FLUSH();
 
 	vifExecQueue(idx);
 }
 
-static __fi void vuExecMicro(int idx, u32 addr) {
+static __fi void vuExecMicro(int idx, u32 addr)
+{
 	VIFregisters& vifRegs = vifXRegs;
 
 	vifFlush(idx);
-	if(GetVifX.waitforvu)
+	if (GetVifX.waitforvu)
 		return;
 
-	if (vifRegs.itops  > (idx ? 0x3ffu : 0xffu)) {
+	if (vifRegs.itops > (idx ? 0x3ffu : 0xffu))
+	{
 		Console.WriteLn("VIF%d ITOP overrun! %x", idx, vifRegs.itops);
 		vifRegs.itops &= (idx ? 0x3ffu : 0xffu);
 	}
 
 	vifRegs.itop = vifRegs.itops;
 
-	if (idx) {
+	if (idx)
+	{
 		// in case we're handling a VIF1 execMicro, set the top with the tops value
 		vifRegs.top = vifRegs.tops & 0x3ff;
 
 		// is DBF flag set in VIF_STAT?
-		if (vifRegs.stat.DBF) {
+		if (vifRegs.stat.DBF)
+		{
 			// it is, so set tops with base, and clear the stat DBF flag
 			vifRegs.tops = vifRegs.base;
 			vifRegs.stat.DBF = false;
 		}
-		else {
+		else
+		{
 			// it is not, so set tops with base + offset, and set stat DBF flag
 			vifRegs.tops = vifRegs.base + vifRegs.ofst;
 			vifRegs.stat.DBF = true;
@@ -108,13 +122,13 @@ void ExecuteVU(int idx)
 {
 	vifStruct& vifX = GetVifX;
 
-	if((vifX.cmd & 0x7f) == 0x17)
+	if ((vifX.cmd & 0x7f) == 0x17)
 	{
 		vuExecMicro(idx, -1);
 		vifX.cmd = 0;
 		vifX.pass = 0;
 	}
-	else if((vifX.cmd & 0x7f) == 0x14 || (vifX.cmd & 0x7f) == 0x15)
+	else if ((vifX.cmd & 0x7f) == 0x14 || (vifX.cmd & 0x7f) == 0x15)
 	{
 		vuExecMicro(idx, (u16)(vifXRegs.code));
 		vifX.cmd = 0;
@@ -127,44 +141,58 @@ void ExecuteVU(int idx)
 // Vif0/Vif1 Code Implementations
 //------------------------------------------------------------------
 
-vifOp(vifCode_Base) {
+vifOp(vifCode_Base)
+{
 	vif1Only();
-	pass1 { vif1Regs.base = vif1Regs.code & 0x3ff; vif1.cmd = 0; vif1.pass = 0; }
+	pass1
+	{
+		vif1Regs.base = vif1Regs.code & 0x3ff;
+		vif1.cmd = 0;
+		vif1.pass = 0;
+	}
 	pass3 { VifCodeLog("Base"); }
 	return 1;
 }
 
-template<int idx> __fi int _vifCode_Direct(int pass, const u8* data, bool isDirectHL) {
+template <int idx>
+__fi int _vifCode_Direct(int pass, const u8* data, bool isDirectHL)
+{
 	vif1Only();
-	pass1 {
-		int vifImm    = (u16)vif1Regs.code;
-		vif1.tag.size = vifImm ? (vifImm*4) : (65536*4);
+	pass1
+	{
+		int vifImm = (u16)vif1Regs.code;
+		vif1.tag.size = vifImm ? (vifImm * 4) : (65536 * 4);
 		vif1.pass = 1;
 		return 1;
 	}
-	pass2 {
+	pass2
+	{
 		const char* name = isDirectHL ? "DirectHL" : "Direct";
 		GIF_TRANSFER_TYPE tranType = isDirectHL ? GIF_TRANS_DIRECTHL : GIF_TRANS_DIRECT;
 		uint size = std::min(vif1.vifpacketsize, vif1.tag.size) * 4; // Get size in bytes
-		uint ret  = gifUnit.TransferGSPacketData(tranType, (u8*)data, size);
+		uint ret = gifUnit.TransferGSPacketData(tranType, (u8*)data, size);
 
-		vif1.tag.size    -= ret/4; // Convert to u32's
+		vif1.tag.size -= ret / 4; // Convert to u32's
 		vif1Regs.stat.VGW = false;
 
-		if (ret  &  3) DevCon.Warning("Vif %s: Ret wasn't a multiple of 4!", name); // Shouldn't happen
-		if (size == 0) DevCon.Warning("Vif %s: No Data Transfer?", name); // Can this happen?
-		if (size != ret) { // Stall if gif didn't process all the data (path2 queued)
+		if (ret & 3)
+			DevCon.Warning("Vif %s: Ret wasn't a multiple of 4!", name); // Shouldn't happen
+		if (size == 0)
+			DevCon.Warning("Vif %s: No Data Transfer?", name); // Can this happen?
+		if (size != ret)
+		{ // Stall if gif didn't process all the data (path2 queued)
 			GUNIT_WARN("Vif %s: Stall! [size=%d][ret=%d]", name, size, ret);
 			//gifUnit.PrintInfo();
-			vif1.vifstalled.enabled   = VifStallEnable(vif1ch);
+			vif1.vifstalled.enabled = VifStallEnable(vif1ch);
 			vif1.vifstalled.value = VIF_TIMING_BREAK;
 			vif1Regs.stat.VGW = true;
 			return 0;
 		}
-		if (vif1.tag.size == 0) {
+		if (vif1.tag.size == 0)
+		{
 			vif1.cmd = 0;
 			vif1.pass = 0;
-			vif1.vifstalled.enabled   = VifStallEnable(vif1ch);
+			vif1.vifstalled.enabled = VifStallEnable(vif1ch);
 			vif1.vifstalled.value = VIF_TIMING_BREAK;
 		}
 		return ret / 4;
@@ -172,56 +200,63 @@ template<int idx> __fi int _vifCode_Direct(int pass, const u8* data, bool isDire
 	return 0;
 }
 
-vifOp(vifCode_Direct) {
+vifOp(vifCode_Direct)
+{
 	pass3 { VifCodeLog("Direct"); }
 	return _vifCode_Direct<idx>(pass, (u8*)data, 0);
 }
 
-vifOp(vifCode_DirectHL) {
+vifOp(vifCode_DirectHL)
+{
 	pass3 { VifCodeLog("DirectHL"); }
 	return _vifCode_Direct<idx>(pass, (u8*)data, 1);
 }
 
-vifOp(vifCode_Flush) {
+vifOp(vifCode_Flush)
+{
 	vif1Only();
 	//vifStruct& vifX = GetVifX;
-	pass1or2 {
+	pass1or2
+	{
 		bool p1or2 = (gifRegs.stat.APATH != 0 && gifRegs.stat.APATH != 3);
 		vif1Regs.stat.VGW = false;
 		vifFlush(idx);
-		if (gifUnit.checkPaths(1,1,0) || p1or2) {
+		if (gifUnit.checkPaths(1, 1, 0) || p1or2)
+		{
 			GUNIT_WARN("Vif Flush: Stall!");
 			//gifUnit.PrintInfo();
 			vif1Regs.stat.VGW = true;
-			vif1.vifstalled.enabled   = VifStallEnable(vif1ch);
+			vif1.vifstalled.enabled = VifStallEnable(vif1ch);
 			vif1.vifstalled.value = VIF_TIMING_BREAK;
 			return 0;
 		}
-		else vif1.cmd = 0;
+		else
+			vif1.cmd = 0;
 		vif1.pass = 0;
 	}
 	pass3 { VifCodeLog("Flush"); }
 	return 1;
 }
 
-vifOp(vifCode_FlushA) {
+vifOp(vifCode_FlushA)
+{
 	vif1Only();
 	//vifStruct& vifX = GetVifX;
-	pass1or2 {
+	pass1or2
+	{
 		//Gif_Path& p3      = gifUnit.gifPath[GIF_PATH_3];
-		u32       gifBusy   = gifUnit.checkPaths(1,1,1) || (gifRegs.stat.APATH != 0);
+		u32 gifBusy = gifUnit.checkPaths(1, 1, 1) || (gifRegs.stat.APATH != 0);
 		//bool      doStall = false;
 		vif1Regs.stat.VGW = false;
 		vifFlush(idx);
 
-		if (gifBusy) 
+		if (gifBusy)
 		{
 			GUNIT_WARN("Vif FlushA: Stall!");
 			vif1Regs.stat.VGW = true;
-			vif1.vifstalled.enabled   = VifStallEnable(vif1ch);
+			vif1.vifstalled.enabled = VifStallEnable(vif1ch);
 			vif1.vifstalled.value = VIF_TIMING_BREAK;
 			return 0;
-			
 		}
 		vif1.cmd = 0;
 		vif1.pass = 0;
@@ -231,32 +266,47 @@ vifOp(vifCode_FlushA) {
 }
 
 // ToDo: FixMe
-vifOp(vifCode_FlushE) {
+vifOp(vifCode_FlushE)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 { vifFlush(idx); vifX.cmd = 0; vifX.pass = 0;}
+	pass1
+	{
+		vifFlush(idx);
+		vifX.cmd = 0;
+		vifX.pass = 0;
+	}
 	pass3 { VifCodeLog("FlushE"); }
 	return 1;
 }
 
-vifOp(vifCode_ITop) {
-	pass1 { vifXRegs.itops = vifXRegs.code & 0x3ff; GetVifX.cmd = 0; GetVifX.pass = 0; }
+vifOp(vifCode_ITop)
+{
+	pass1
+	{
+		vifXRegs.itops = vifXRegs.code & 0x3ff;
+		GetVifX.cmd = 0;
+		GetVifX.pass = 0;
+	}
 	pass3 { VifCodeLog("ITop"); }
 	return 1;
 }
 
-vifOp(vifCode_Mark) {
+vifOp(vifCode_Mark)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 {
-		vifXRegs.mark     = (u16)vifXRegs.code;
+	pass1
+	{
+		vifXRegs.mark = (u16)vifXRegs.code;
 		vifXRegs.stat.MRK = true;
-		vifX.cmd          = 0;
-		vifX.pass		  = 0;
+		vifX.cmd = 0;
+		vifX.pass = 0;
 	}
 	pass3 { VifCodeLog("Mark"); }
 	return 1;
 }
 
-static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
+static __fi void _vifCode_MPG(int idx, u32 addr, const u32* data, int size)
+{
 	VURegs& VUx = idx ? VU1 : VU0;
 	vifStruct& vifX = GetVifX;
 	u16 vuMemSize = idx ? 0x4000 : 0x1000;
@@ -264,7 +314,8 @@ static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
 
 	vifExecQueue(idx);
 
-	if (idx && THREAD_VU1) {
+	if (idx && THREAD_VU1)
+	{
 		if ((addr + size * 4) > vuMemSize)
 		{
 			vu1Thread.WriteMicroMem(addr, (u8*)data, vuMemSize - addr);
@@ -282,12 +333,14 @@ static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
 	}
 
 	// Don't forget the Unsigned designator for these checks
-	if((addr + size *4) > vuMemSize)
+	if ((addr + size * 4) > vuMemSize)
 	{
 		//DevCon.Warning("Handling split MPG");
-		if (!idx)  CpuVU0->Clear(addr, vuMemSize - addr);
-		else	   CpuVU1->Clear(addr, vuMemSize - addr);
-		
+		if (!idx)
+			CpuVU0->Clear(addr, vuMemSize - addr);
+		else
+			CpuVU1->Clear(addr, vuMemSize - addr);
+
 		memcpy(VUx.Micro + addr, data, vuMemSize - addr);
 		size -= (vuMemSize - addr) / 4;
 		data += (vuMemSize - addr) / 4;
@@ -297,51 +350,61 @@ static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
 	}
 	else
 	{
-	//The compare is pretty much a waste of time, likelyhood is that the program isnt there, thats why its copying it.
-	//Faster without.
-	//if (memcmp_mmx(VUx.Micro + addr, data, size*4)) {
+		//The compare is pretty much a waste of time, likelyhood is that the program isnt there, thats why its copying it.
+		//Faster without.
+		//if (memcmp_mmx(VUx.Micro + addr, data, size*4)) {
 		// Clear VU memory before writing!
-		if (!idx)  CpuVU0->Clear(addr, size*4);
-		else	   CpuVU1->Clear(addr, size*4);
-		memcpy(VUx.Micro + addr, data, size*4); //from tests, memcpy is 1fps faster on Grandia 3 than memcpy
+		if (!idx)
+			CpuVU0->Clear(addr, size * 4);
+		else
+			CpuVU1->Clear(addr, size * 4);
+		memcpy(VUx.Micro + addr, data, size * 4); //from tests, memcpy is 1fps faster on Grandia 3 than memcpy
 
 		vifX.tag.addr += size * 4;
 	}
 }
 
-vifOp(vifCode_MPG) {
+vifOp(vifCode_MPG)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 {
-		int    vifNum =  (u8)(vifXRegs.code >> 16);
-		vifX.tag.addr = (u16)(vifXRegs.code <<  3) & (idx ? 0x3fff : 0xfff);
-		vifX.tag.size = vifNum ? (vifNum*2) : 512;
+	pass1
+	{
+		int vifNum = (u8)(vifXRegs.code >> 16);
+		vifX.tag.addr = (u16)(vifXRegs.code << 3) & (idx ? 0x3fff : 0xfff);
+		vifX.tag.size = vifNum ? (vifNum * 2) : 512;
 		vifFlush(idx);
 
-		if(vifX.vifstalled.enabled) return 0;
+		if (vifX.vifstalled.enabled)
+			return 0;
 		else
 		{
 			vifX.pass = 1;
 			return 1;
 		}
 	}
-	pass2 {
-		if (vifX.vifpacketsize < vifX.tag.size) { // Partial Transfer
-			if((vifX.tag.addr + vifX.vifpacketsize*4) > (idx ? 0x4000 : 0x1000)) {
+	pass2
+	{
+		if (vifX.vifpacketsize < vifX.tag.size)
+		{ // Partial Transfer
+			if ((vifX.tag.addr + vifX.vifpacketsize * 4) > (idx ? 0x4000 : 0x1000))
+			{
 				//DevCon.Warning("Vif%d MPG Split Overflow", idx);
 			}
-			_vifCode_MPG(idx,    vifX.tag.addr, data, vifX.vifpacketsize);
+			_vifCode_MPG(idx, vifX.tag.addr, data, vifX.vifpacketsize);
 			vifX.tag.size -= vifX.vifpacketsize; //We can do this first as its passed as a pointer
 			return vifX.vifpacketsize;
 		}
-		else { // Full Transfer
-			if((vifX.tag.addr + vifX.tag.size*4) > (idx ? 0x4000 : 0x1000)) {
+		else
+		{ // Full Transfer
+			if ((vifX.tag.addr + vifX.tag.size * 4) > (idx ? 0x4000 : 0x1000))
+			{
 				//DevCon.Warning("Vif%d MPG Split Overflow full %x", idx, vifX.tag.addr + vifX.tag.size*4);
 			}
-			_vifCode_MPG(idx,  vifX.tag.addr, data, vifX.tag.size);
+			_vifCode_MPG(idx, vifX.tag.addr, data, vifX.tag.size);
 			int ret = vifX.tag.size;
 			vifX.tag.size = 0;
-			vifX.cmd      = 0;
-			vifX.pass		= 0;
+			vifX.cmd = 0;
+			vifX.pass = 0;
 			return ret;
 		}
 	}
@@ -349,43 +412,48 @@ vifOp(vifCode_MPG) {
 	return 0;
 }
 
-vifOp(vifCode_MSCAL) {
+vifOp(vifCode_MSCAL)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 { 
-		vifFlush(idx); 
+	pass1
+	{
+		vifFlush(idx);
 
-		if(!vifX.waitforvu)
+		if (!vifX.waitforvu)
 		{
-			vuExecMicro(idx, (u16)(vifXRegs.code)); 
+			vuExecMicro(idx, (u16)(vifXRegs.code));
 			vifX.cmd = 0;
 			vifX.pass = 0;
-			if(GetVifX.vifpacketsize > 1)
+			if (GetVifX.vifpacketsize > 1)
 			{
 				//Warship Gunner 2 has a rather big dislike for the delays
-				if(((data[1] >> 24) & 0x60) == 0x60) // Immediate following Unpack
-				{ 
+				if (((data[1] >> 24) & 0x60) == 0x60) // Immediate following Unpack
+				{
 					//Snowblind games only use MSCAL, so other MS kicks force the program directly.
 					vifExecQueue(idx);
 				}
 			}
-		} 
+		}
 	}
 	pass3 { VifCodeLog("MSCAL"); }
 	return 1;
 }
 
-vifOp(vifCode_MSCALF) {
+vifOp(vifCode_MSCALF)
+{
 	vifStruct& vifX = GetVifX;
-	pass1or2 {
+	pass1or2
+	{
 		vifXRegs.stat.VGW = false;
 		vifFlush(idx);
-		if (u32 a = gifUnit.checkPaths(1,1,0)) {
-			GUNIT_WARN("Vif MSCALF: Stall! [%d,%d]", !!(a&1), !!(a&2));
+		if (u32 a = gifUnit.checkPaths(1, 1, 0))
+		{
+			GUNIT_WARN("Vif MSCALF: Stall! [%d,%d]", !!(a & 1), !!(a & 2));
 			vif1Regs.stat.VGW = true;
-			vifX.vifstalled.enabled   = VifStallEnable(vifXch);
+			vifX.vifstalled.enabled = VifStallEnable(vifXch);
 			vifX.vifstalled.value = VIF_TIMING_BREAK;
 		}
-		if(!vifX.waitforvu)
+		if (!vifX.waitforvu)
 		{
 			vuExecMicro(idx, (u16)(vifXRegs.code));
 			vifX.cmd = 0;
@@ -397,11 +465,13 @@ vifOp(vifCode_MSCALF) {
 	return 1;
 }
 
-vifOp(vifCode_MSCNT) {
+vifOp(vifCode_MSCNT)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 { 
-		vifFlush(idx); 
-		if(!vifX.waitforvu)
+	pass1
+	{
+		vifFlush(idx);
+		if (!vifX.waitforvu)
 		{
 			vuExecMicro(idx, -1);
 			vifX.cmd = 0;
@@ -420,13 +490,16 @@ vifOp(vifCode_MSCNT) {
 }
 
 // ToDo: FixMe
-vifOp(vifCode_MskPath3) {
+vifOp(vifCode_MskPath3)
+{
 	vif1Only();
-	pass1 {
+	pass1
+	{
 		vif1Regs.mskpath3 = (vif1Regs.code >> 15) & 0x1;
-		gifRegs.stat.M3P  = (vif1Regs.code >> 15) & 0x1;
+		gifRegs.stat.M3P = (vif1Regs.code >> 15) & 0x1;
 		GUNIT_LOG("Vif1 - MskPath3 [p3 = %s]", vif1Regs.mskpath3 ? "masked" : "enabled");
-		if(!vif1Regs.mskpath3) {
+		if (!vif1Regs.mskpath3)
+		{
 			GUNIT_WARN("VIF MSKPATH3 off Path3 triggering!");
 			gifInterrupt();
 		}
@@ -437,17 +510,19 @@ vifOp(vifCode_MskPath3) {
 	return 1;
 }
 
-vifOp(vifCode_Nop) {
-	pass1 { 
+vifOp(vifCode_Nop)
+{
+	pass1
+	{
 		GetVifX.cmd = 0;
 		GetVifX.pass = 0;
 		vifExecQueue(idx);
 
 		if (GetVifX.vifpacketsize > 1)
 		{
-			if(((data[1] >> 24) & 0x7f) == 0x6 && (data[1] & 0x1)) //is mskpath3 next
-			{ 
-				GetVifX.vifstalled.enabled   = VifStallEnable(vifXch);
+			if (((data[1] >> 24) & 0x7f) == 0x6 && (data[1] & 0x1)) //is mskpath3 next
+			{
+				GetVifX.vifstalled.enabled = VifStallEnable(vifXch);
 				GetVifX.vifstalled.value = VIF_TIMING_BREAK;
 			}
 		}
@@ -457,11 +532,14 @@ vifOp(vifCode_Nop) {
 }
 
 // ToDo: Review Flags
-vifOp(vifCode_Null) {
+vifOp(vifCode_Null)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 {
+	pass1
+	{
 		// if ME1, then force the vif to interrupt
-		if (!(vifXRegs.err.ME1)) { // Ignore vifcode and tag mismatch error
+		if (!(vifXRegs.err.ME1))
+		{ // Ignore vifcode and tag mismatch error
 			Console.WriteLn("Vif%d: Unknown VifCmd! [%x]", idx, vifX.cmd);
 			vifXRegs.stat.ER1 = true;
 			vifX.vifstalled.enabled = VifStallEnable(vifXch);
@@ -472,34 +550,40 @@ vifOp(vifCode_Null) {
 		vifX.pass = 0;
 
 		//If the top bit was set to interrupt, we don't want it to take commands from a bad code
-		if (vifXRegs.code & 0x80000000) vifX.irq = 0;
+		if (vifXRegs.code & 0x80000000)
+			vifX.irq = 0;
 	}
 	pass2 { Console.Error("Vif%d bad vifcode! [CMD = %x]", idx, vifX.cmd); }
 	pass3 { VifCodeLog("Null"); }
 	return 1;
 }
 
-vifOp(vifCode_Offset) {
+vifOp(vifCode_Offset)
+{
 	vif1Only();
-	pass1 {
-		vif1Regs.stat.DBF	= false;
-		vif1Regs.ofst		= vif1Regs.code & 0x3ff;
-		vif1Regs.tops		= vif1Regs.base;
-		vif1.cmd			= 0;
-		vif1.pass			= 0;
+	pass1
+	{
+		vif1Regs.stat.DBF = false;
+		vif1Regs.ofst = vif1Regs.code & 0x3ff;
+		vif1Regs.tops = vif1Regs.base;
+		vif1.cmd = 0;
+		vif1.pass = 0;
 	}
 	pass3 { VifCodeLog("Offset"); }
 	return 1;
 }
 
-template<int idx> static __fi int _vifCode_STColRow(const u32* data, u32* pmem2) {
+template <int idx>
+static __fi int _vifCode_STColRow(const u32* data, u32* pmem2)
+{
 	vifStruct& vifX = GetVifX;
 
 	int ret = std::min(4 - vifX.tag.addr, vifX.vifpacketsize);
 	pxAssume(vifX.tag.addr < 4);
 	pxAssume(ret > 0);
 
-	switch (ret) {
+	switch (ret)
+	{
 		case 4:
 			pmem2[3] = data[3];
 			[[fallthrough]];
@@ -511,8 +595,8 @@ template<int idx> static __fi int _vifCode_STColRow(const u32* data, u32* pmem2)
 			[[fallthrough]];
 		case 1:
 			pmem2[0] = data[0];
-				break;
-		jNO_DEFAULT
+			break;
+			jNO_DEFAULT
 	}
 
 	vifX.tag.addr += ret;
@@ -523,20 +607,23 @@ template<int idx> static __fi int _vifCode_STColRow(const u32* data, u32* pmem2)
 		vifX.cmd = 0;
 	}
 
-	
+
 
 	return ret;
 }
 
-vifOp(vifCode_STCol) {
+vifOp(vifCode_STCol)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 {
+	pass1
+	{
 		vifX.tag.addr = 0;
 		vifX.tag.size = 4;
 		vifX.pass = 1;
 		return 1;
 	}
-	pass2 {
+	pass2
+	{
 		u32 ret = _vifCode_STColRow<idx>(data, &vifX.MaskCol._u32[vifX.tag.addr]);
 		if (idx && vifX.tag.size == 0)
 			vu1Thread.WriteCol(vifX);
@@ -546,15 +633,18 @@ vifOp(vifCode_STCol) {
 	return 0;
 }
 
-vifOp(vifCode_STRow) {
+vifOp(vifCode_STRow)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 {
+	pass1
+	{
 		vifX.tag.addr = 0;
 		vifX.tag.size = 4;
 		vifX.pass = 1;
 		return 1;
 	}
-	pass2 {
+	pass2
+	{
 		u32 ret = _vifCode_STColRow<idx>(data, &vifX.MaskRow._u32[vifX.tag.addr]);
 		if (idx && vifX.tag.size == 0)
 			vu1Thread.WriteRow(vifX);
@@ -564,65 +654,89 @@ vifOp(vifCode_STRow) {
 	return 1;
 }
 
-vifOp(vifCode_STCycl) {
+vifOp(vifCode_STCycl)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 {
+	pass1
+	{
 		vifXRegs.cycle.cl = (u8)(vifXRegs.code);
 		vifXRegs.cycle.wl = (u8)(vifXRegs.code >> 8);
-		vifX.cmd		   = 0;
-		vifX.pass		   = 0;
+		vifX.cmd = 0;
+		vifX.pass = 0;
 	}
 	pass3 { VifCodeLog("STCycl"); }
 	return 1;
 }
 
-vifOp(vifCode_STMask) {
+vifOp(vifCode_STMask)
+{
 	vifStruct& vifX = GetVifX;
-	pass1 { vifX.tag.size = 1; vifX.pass = 1; return 1; }
-	pass2 { vifXRegs.mask = data[0]; vifX.tag.size = 0; vifX.cmd = 0; vifX.pass = 0;}
+	pass1
+	{
+		vifX.tag.size = 1;
+		vifX.pass = 1;
+		return 1;
+	}
+	pass2
+	{
+		vifXRegs.mask = data[0];
+		vifX.tag.size = 0;
+		vifX.cmd = 0;
+		vifX.pass = 0;
+	}
 	pass3 { VifCodeLog("STMask"); }
 	return 1;
 }
 
-vifOp(vifCode_STMod) {
-	pass1 { vifXRegs.mode = vifXRegs.code & 0x3; GetVifX.cmd = 0; GetVifX.pass = 0;}
+vifOp(vifCode_STMod)
+{
+	pass1
+	{
+		vifXRegs.mode = vifXRegs.code & 0x3;
+		GetVifX.cmd = 0;
+		GetVifX.pass = 0;
+	}
 	pass3 { VifCodeLog("STMod"); }
 	return 1;
 }
 
-template< uint idx >
+template <uint idx>
 static uint calc_addr(bool flg)
 {
 	VIFregisters& vifRegs = vifXRegs;
 
 	uint retval = vifRegs.code;
-	if (idx && flg) retval += vifRegs.tops;
+	if (idx && flg)
+		retval += vifRegs.tops;
 	return retval & (idx ? 0x3ff : 0xff);
 }
 
-vifOp(vifCode_Unpack) {
-	pass1 {
+vifOp(vifCode_Unpack)
+{
+	pass1
+	{
 		vifUnpackSetup<idx>(data);
-		
+
 		return 1;
 	}
-	pass2 { 
+	pass2
+	{
 		return nVifUnpack<idx>((u8*)data);
 	}
-	pass3 {
+	pass3
+	{
 		vifStruct& vifX = GetVifX;
 		VIFregisters& vifRegs = vifXRegs;
 		uint vl = vifX.cmd & 0x03;
 		uint vn = (vifX.cmd >> 2) & 0x3;
 		bool flg = (vifRegs.code >> 15) & 1;
-		static const char* const	vntbl[] = { "S", "V2", "V3", "V4" };
-		static const uint			vltbl[] = { 32,	  16,   8,    5   };
+		static const char* const vntbl[] = {"S", "V2", "V3", "V4"};
+		static const uint vltbl[] = {32, 16, 8, 5};
 
 		VifCodeLog("Unpack %s_%u (%s) @ 0x%04X%s (cl=%u  wl=%u  num=0x%02X)",
 			vntbl[vn], vltbl[vl], (vifX.cmd & 0x10) ? "masked" : "unmasked",
 			calc_addr<idx>(flg), flg ? "(FLG)" : "",
-			vifRegs.cycle.cl, vifRegs.cycle.wl, (vifXRegs.code >> 16) & 0xff
-		);
+			vifRegs.cycle.cl, vifRegs.cycle.wl, (vifXRegs.code >> 16) & 0xff);
 	}
 	return 0;
 }

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -422,14 +422,13 @@ vifOp(vifCode_MSCNT) {
 // ToDo: FixMe
 vifOp(vifCode_MskPath3) {
 	vif1Only();
-	pass1 {		
+	pass1 {
 		vif1Regs.mskpath3 = (vif1Regs.code >> 15) & 0x1;
 		gifRegs.stat.M3P  = (vif1Regs.code >> 15) & 0x1;
 		GUNIT_LOG("Vif1 - MskPath3 [p3 = %s]", vif1Regs.mskpath3 ? "masked" : "enabled");
 		if(!vif1Regs.mskpath3) {
-			GUNIT_WARN("Path3 triggering!");
-			if(CHECK_GIFFIFOHACK)gif_fifo.read(false);
-			else gifInterrupt();
+			GUNIT_WARN("VIF MSKPATH3 off Path3 triggering!");
+			gifInterrupt();
 		}
 		vif1.cmd = 0;
 		vif1.pass = 0;

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -81,7 +81,7 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("Enable the GIF FIFO (slower but needed for Hotwheels, Wallace and Gromit, DJ Hero)"),
+			_("Force GIF PATH3 transfers through FIFO (Fifa Street 2)"),
 			wxEmptyString
 		},
 		{


### PR DESCRIPTION
### Description of Changes
Reworks the GIF FIFO to always be enabled and only kick in when needed.  Savestate version bumped

### Rationale behind Changes
The old GIF FIFO was a bit janky/broken and it was quite slow when used, the new changes allow it to always be on without impacting performance.

### Suggested Testing Steps
Test mainly games which used to have the GIF FIFO hack entry in the GameDB, or games which use PATH3 masking, these will be impacted the most
