### PR TITLE
GameDB: Ratchet and Clank (EEtiming)

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -175,6 +175,7 @@ SCAJ-20001:
   region: "NTSC-Unk"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-20002:
   name: "Gallop Racer 6 - Revolution"
   region: "NTSC-Unk"
@@ -561,6 +562,7 @@ SCAJ-20109:
   region: "NTSC-Unk"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-20110:
   name: "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi"
   region: "NTSC-Unk"
@@ -765,6 +767,7 @@ SCAJ-20157:
   region: "NTSC-Unk"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-20158:
   name: "Ikusa Gami"
   region: "NTSC-Unk"
@@ -2193,6 +2196,7 @@ SCES-50916:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCES-50917:
   name: "Sly Racoon"
   region: "PAL-M5"
@@ -2642,6 +2646,7 @@ SCES-52456:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
     - "SCES-51607"
@@ -2806,6 +2811,7 @@ SCES-53285:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCES-53286:
   name: "Jak X - Combat Racing"
   region: "PAL-M7"
@@ -3369,6 +3375,7 @@ SCKA-20011:
   region: "NTSC-K"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCKA-20011"
     - "SCKA-20120"
@@ -3460,6 +3467,7 @@ SCKA-20037:
   region: "NTSC-K"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCKA-20037"
     - "SCKA-20011"
@@ -3547,6 +3555,7 @@ SCKA-20060:
   region: "NTSC-K"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCKA-20061:
   name: "Wanda to Kyozou (Shadow of the Colossus)"
   region: "NTSC-K"
@@ -3660,6 +3669,7 @@ SCKA-20120:
   region: "NTSC-K"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCKA-20132:
   name: "Shin Megami Tensei: Persona 4"
   region: "NTSC-K"
@@ -3964,6 +3974,7 @@ SCPS-15037:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-15038:
   name: "Operator's Side"
   region: "NTSC-J"
@@ -4042,6 +4053,7 @@ SCPS-15056:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCPS-15056"
     - "SCPS-15037"
@@ -4139,6 +4151,7 @@ SCPS-15084:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCPS-15084"
     - "SCPS-15056"
@@ -4226,11 +4239,13 @@ SCPS-15099:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-15100:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-15101:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-J"
@@ -4308,6 +4323,7 @@ SCPS-15120:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-17001:
   name: "Gran Turismo 4"
   region: "NTSC-J"
@@ -4422,6 +4438,7 @@ SCPS-19211:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19213:
   name: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
   region: "NTSC-J"
@@ -4463,6 +4480,7 @@ SCPS-19302:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19303:
   name: "Boku no Natsuyasumi 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -4500,11 +4518,13 @@ SCPS-19309:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19310:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19311:
   name: "Saru Get You 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -4533,11 +4553,13 @@ SCPS-19316:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19317:
   name: "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19318:
   name: "Genji - Dawn of the Samurai [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -4560,6 +4582,7 @@ SCPS-19321:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19322:
   name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
@@ -4607,6 +4630,7 @@ SCPS-19328:
   region: "NTSC-J"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19329:
   name: "Bleach - Blade Battlers [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5287,6 +5311,7 @@ SCUS-97199:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97200:
   name: "Kiosk Demo Disc 2.05"
   region: "NTSC-U"
@@ -5320,6 +5345,7 @@ SCUS-97209:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
   region: "NTSC-U"
@@ -5422,6 +5448,7 @@ SCUS-97240:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97241:
   name: "Official U.S. PlayStation Magazine Demo Disc 066"
   region: "NTSC-U"
@@ -5515,6 +5542,7 @@ SCUS-97268:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCUS-97268"
     - "SCUS-97199"
@@ -5605,11 +5633,13 @@ SCUS-97322:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
   region: "NTSC-U"
@@ -5697,6 +5727,7 @@ SCUS-97353:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCUS-97353"
     - "SCUS-97268"
@@ -5752,6 +5783,7 @@ SCUS-97374:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS (for both).
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
   region: "NTSC-U"
@@ -5770,6 +5802,7 @@ SCUS-97381:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97382:
   name: "NBA Shootout 2004 [Demo]"
   region: "NTSC-U"
@@ -5841,6 +5874,7 @@ SCUS-97411:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
@@ -5851,6 +5885,7 @@ SCUS-97413:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97414:
   name: "EyeToy - AntiGrav"
   region: "NTSC-U"
@@ -6014,6 +6049,7 @@ SCUS-97465:
   compat: 5
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97466:
   name: "Gretzky NHL '06"
   region: "NTSC-U"
@@ -6102,6 +6138,7 @@ SCUS-97485:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97486:
   name: "Jak X - Combat Racing [Regular Demo]"
   region: "NTSC-U"
@@ -6112,6 +6149,7 @@ SCUS-97487:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97488:
   name: "Jak X - Combat Racing [Public Beta v.1]"
   region: "NTSC-U"
@@ -6206,6 +6244,7 @@ SCUS-97513:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97514:
   name: "ATV Off-Road Fury 3 [Greatest Hits]"
   region: "NTSC-U"
@@ -6227,6 +6266,7 @@ SCUS-97518:
   region: "NTSC-U"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97519:
   name: "Sly 2 - Band of Thieves [Greatest Hits]"
   region: "NTSC-U"
@@ -40711,6 +40751,7 @@ TCES-52456:
   region: "PAL-E"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
+    - EETimingHack # Fixes SPR errors while going in-game.
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
   region: "PAL-E"


### PR DESCRIPTION
Fixes #4650
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add EETiming to Ratchet and clank to avoid TLB misses.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Improvements ofcourse.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Run the right serial with and without automatic gamefixes.