### PR TITLE
GS-d3d11: Cleanup fxaa and external shader.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -400,8 +400,6 @@ private:
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex) final;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) final;
-	void InitExternalFX();
-	void InitFXAA(); // Bug workaround! Stack corruption? Heap corruption? No idea
 	void RenderOsd(GSTexture* dt);
 	void BeforeDraw();
 	void AfterDraw();
@@ -447,9 +445,6 @@ private:
 	} m_state;
 
 	CComPtr<ID3D11RasterizerState> m_rs;
-
-	bool FXAA_Compiled;
-	bool ExShader_Compiled;
 
 	struct
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Instead of relying on bools for checks rely on the pixel shader pointer, also merge the functions.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Clean stuff up.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure FXAA and External shader work properly  on Direct3D11