### PR TITLE
GS-d3d11: Minor Blend changes

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -508,6 +508,7 @@ void GSRendererDX11::EmulateBlending()
 			// cannot output anything over 0x80 (== 1.0) blending with 0x80 or turning it off gives the same result
 
 			m_om_bsel.abe = 0;
+			m_om_bsel.blend_index = 0;
 		}
 		if (sw_blending)
 		{
@@ -545,6 +546,7 @@ void GSRendererDX11::EmulateBlending()
 		{
 			// Disable HW blending
 			m_om_bsel.abe = 0;
+			m_om_bsel.blend_index = 0;
 
 			// Only BLEND_NO_REC should hit this code path for now
 			ASSERT(blend_non_recursive);

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -346,11 +346,10 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, uin
 
 		memset(&bd, 0, sizeof(bd));
 
-		bd.RenderTarget[0].BlendEnable = bsel.abe;
-
 		if (bsel.abe)
 		{
-			HWBlend blend = GetBlend(bsel.blend_index);
+			const HWBlend blend = GetBlend(bsel.blend_index);
+			bd.RenderTarget[0].BlendEnable = TRUE;
 			bd.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
 			bd.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;
 			bd.RenderTarget[0].DestBlend = (D3D11_BLEND)blend.dst;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Set blend index to 0 when hw blending is enabled,
Move BlendEnable toggle inside the alpha blend check, cleaner this way.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimizations.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test blending on Direct3D 11.