### PR TITLE
Debugger: Add option to display VU0F registers as floats

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -375,13 +375,13 @@ DebugInterface::RegisterType R5900DebugInterface::getRegisterType(int cat)
 	{
 	case EECAT_GPR:
 	case EECAT_CP0:
-	case EECAT_VU0F:
 	case EECAT_VU0I:
 	case EECAT_FCR:
 	case EECAT_GSPRIV:
 	default:
 		return NORMAL;
 	case EECAT_FPR:
+	case EECAT_VU0F:
 		return SPECIAL;
 	}
 }
@@ -485,18 +485,19 @@ wxString R5900DebugInterface::getRegisterString(int cat, int num)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-	case EECAT_CP0:
-	case EECAT_FCR:
-		return getRegister(cat,num).ToString();
-	case EECAT_FPR:
+		case EECAT_GPR:
+		case EECAT_CP0:
+		case EECAT_FCR:
+		case EECAT_VU0F:
+			return getRegister(cat, num).ToString();
+		case EECAT_FPR:
 		{
 			char str[64];
 			sprintf(str,"%f",fpuRegs.fpr[num].f);
 			return wxString(str,wxConvUTF8);
 		}
-	default:
-		return L"";
+		default:
+			return L"";
 	}
 }
 

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -37,7 +37,8 @@ R3000DebugInterface r3000Debug;
 #define strcasecmp stricmp
 #endif
 
-enum ReferenceIndexType {
+enum ReferenceIndexType
+{
 	REF_INDEX_PC = 32,
 	REF_INDEX_HI = 33,
 	REF_INDEX_LO = 34,
@@ -49,10 +50,11 @@ enum ReferenceIndexType {
 };
 
 
-class MipsExpressionFunctions: public IExpressionFunctions
+class MipsExpressionFunctions : public IExpressionFunctions
 {
 public:
-	MipsExpressionFunctions(DebugInterface* cpu): cpu(cpu) { };
+	MipsExpressionFunctions(DebugInterface* cpu)
+		: cpu(cpu){};
 
 	virtual bool parseReference(char* str, u64& referenceIndex)
 	{
@@ -92,7 +94,7 @@ public:
 	virtual bool parseSymbol(char* str, u64& symbolValue)
 	{
 		u32 value;
-		bool result = symbolMap.GetLabelValue(str,value);
+		bool result = symbolMap.GetLabelValue(str, value);
 		symbolValue = value;
 		return result;
 	}
@@ -110,44 +112,49 @@ public:
 		return -1;
 	}
 
-	virtual ExpressionType getReferenceType(u64 referenceIndex) {
-		if (referenceIndex & REF_INDEX_IS_FLOAT) {
+	virtual ExpressionType getReferenceType(u64 referenceIndex)
+	{
+		if (referenceIndex & REF_INDEX_IS_FLOAT)
+		{
 			return EXPR_TYPE_FLOAT;
 		}
 		return EXPR_TYPE_UINT;
 	}
-	
+
 	virtual bool getMemoryValue(u32 address, int size, u64& dest, char* error)
 	{
 		switch (size)
 		{
-		case 1: case 2: case 4: case 8:
-			break;
-		default:
-			sprintf(error,"Invalid memory access size %d",size);
-			return false;
+			case 1:
+			case 2:
+			case 4:
+			case 8:
+				break;
+			default:
+				sprintf(error, "Invalid memory access size %d", size);
+				return false;
 		}
 
 		if (address % size)
 		{
-			sprintf(error,"Invalid memory access (unaligned)");
+			sprintf(error, "Invalid memory access (unaligned)");
 			return false;
 		}
 
 		switch (size)
 		{
-		case 1:
-			dest = cpu->read8(address);
-			break;
-		case 2:
-			dest = cpu->read16(address);
-			break;
-		case 4:
-			dest = cpu->read32(address);
-			break;
-		case 8:
-			dest = cpu->read64(address);
-			break;
+			case 1:
+				dest = cpu->read8(address);
+				break;
+			case 2:
+				dest = cpu->read16(address);
+				break;
+			case 4:
+				dest = cpu->read32(address);
+				break;
+			case 8:
+				dest = cpu->read64(address);
+				break;
 		}
 
 		return true;
@@ -189,26 +196,31 @@ void DebugInterface::resumeCpu()
 char* DebugInterface::stringFromPointer(u32 p)
 {
 	const int BUFFER_LEN = 25;
-	static char buf[BUFFER_LEN] = { 0 };
+	static char buf[BUFFER_LEN] = {0};
 
 	if (!isValidAddress(p))
 		return NULL;
 
-	try {
-		for (u32 i = 0; i < BUFFER_LEN; i++) {
+	try
+	{
+		for (u32 i = 0; i < BUFFER_LEN; i++)
+		{
 			char c = read8(p + i);
 			buf[i] = c;
 
-			if (c == 0) {
+			if (c == 0)
+			{
 				return i > 0 ? buf : NULL;
 			}
-			else if (c < 0x20 || c >= 0x7f) {
+			else if (c < 0x20 || c >= 0x7f)
+			{
 				// non printable character
 				return NULL;
 			}
 		}
 	}
-	catch (Exception::Ps2Generic&) {
+	catch (Exception::Ps2Generic&)
+	{
 		return NULL;
 	}
 	buf[BUFFER_LEN - 1] = 0;
@@ -219,13 +231,13 @@ char* DebugInterface::stringFromPointer(u32 p)
 bool DebugInterface::initExpression(const char* exp, PostfixExpression& dest)
 {
 	MipsExpressionFunctions funcs(this);
-	return initPostfixExpression(exp,&funcs,dest);
+	return initPostfixExpression(exp, &funcs, dest);
 }
 
 bool DebugInterface::parseExpression(PostfixExpression& exp, u64& dest)
 {
 	MipsExpressionFunctions funcs(this);
-	return parsePostfixExpression(exp,&funcs,dest);
+	return parsePostfixExpression(exp, &funcs, dest);
 }
 
 
@@ -268,7 +280,7 @@ u64 R5900DebugInterface::read64(u32 address)
 		return -1;
 
 	u64 result;
-	memRead64(address,result);
+	memRead64(address, result);
 	return result;
 }
 
@@ -281,7 +293,7 @@ u128 R5900DebugInterface::read128(u32 address)
 		return result;
 	}
 
-	memRead128(address,result);
+	memRead128(address, result);
 	return result;
 }
 
@@ -290,7 +302,7 @@ void R5900DebugInterface::write8(u32 address, u8 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite8(address,value);
+	memWrite8(address, value);
 }
 
 void R5900DebugInterface::write32(u32 address, u32 value)
@@ -298,7 +310,7 @@ void R5900DebugInterface::write32(u32 address, u32 value)
 	if (!isValidAddress(address))
 		return;
 
-	memWrite32(address,value);
+	memWrite32(address, value);
 }
 
 
@@ -311,22 +323,22 @@ const char* R5900DebugInterface::getRegisterCategoryName(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		return "GPR";
-	case EECAT_CP0:
-		return "CP0";
-	case EECAT_FPR:
-		return "FPR";
-	case EECAT_FCR:
-		return "FCR";
-	case EECAT_VU0F:
-		return "VU0f";
-	case EECAT_VU0I:
-		return "VU0i";
-	case EECAT_GSPRIV:
-		return "GS";
-	default:
-		return "Invalid";
+		case EECAT_GPR:
+			return "GPR";
+		case EECAT_CP0:
+			return "CP0";
+		case EECAT_FPR:
+			return "FPR";
+		case EECAT_FCR:
+			return "FCR";
+		case EECAT_VU0F:
+			return "VU0f";
+		case EECAT_VU0I:
+			return "VU0i";
+		case EECAT_GSPRIV:
+			return "GS";
+		default:
+			return "Invalid";
 	}
 }
 
@@ -334,18 +346,18 @@ int R5900DebugInterface::getRegisterSize(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-	case EECAT_VU0F:
-		return 128;
-	case EECAT_CP0:
-	case EECAT_FPR:
-	case EECAT_FCR:
-	case EECAT_VU0I:
-		return 32;
-	case EECAT_GSPRIV:
-		return 64;
-	default:
-		return 0;
+		case EECAT_GPR:
+		case EECAT_VU0F:
+			return 128;
+		case EECAT_CP0:
+		case EECAT_FPR:
+		case EECAT_FCR:
+		case EECAT_VU0I:
+			return 32;
+		case EECAT_GSPRIV:
+			return 64;
+		default:
+			return 0;
 	}
 }
 
@@ -353,19 +365,19 @@ int R5900DebugInterface::getRegisterCount(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		return 35;	// 32 + pc + hi + lo
-	case EECAT_CP0:
-	case EECAT_FPR:
-	case EECAT_FCR:
-	case EECAT_VU0I:
-		return 32;
-	case EECAT_VU0F:
-		return 33;  // 32 + ACC
-	case EECAT_GSPRIV:
-		return 19;
-	default:
-		return 0;
+		case EECAT_GPR:
+			return 35; // 32 + pc + hi + lo
+		case EECAT_CP0:
+		case EECAT_FPR:
+		case EECAT_FCR:
+		case EECAT_VU0I:
+			return 32;
+		case EECAT_VU0F:
+			return 33; // 32 + ACC
+		case EECAT_GSPRIV:
+			return 19;
+		default:
+			return 0;
 	}
 }
 
@@ -373,16 +385,16 @@ DebugInterface::RegisterType R5900DebugInterface::getRegisterType(int cat)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-	case EECAT_CP0:
-	case EECAT_VU0I:
-	case EECAT_FCR:
-	case EECAT_GSPRIV:
-	default:
-		return NORMAL;
-	case EECAT_FPR:
-	case EECAT_VU0F:
-		return SPECIAL;
+		case EECAT_GPR:
+		case EECAT_CP0:
+		case EECAT_VU0I:
+		case EECAT_FCR:
+		case EECAT_GSPRIV:
+		default:
+			return NORMAL;
+		case EECAT_FPR:
+		case EECAT_VU0F:
+			return SPECIAL;
 	}
 }
 
@@ -390,38 +402,38 @@ const char* R5900DebugInterface::getRegisterName(int cat, int num)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			return "pc";
-		case 33:	// hi
-			return "hi";
-		case 34:	// lo
-			return "lo";
+		case EECAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					return "pc";
+				case 33: // hi
+					return "hi";
+				case 34: // lo
+					return "lo";
+				default:
+					return R5900::GPR_REG[num];
+			}
+		case EECAT_CP0:
+			return R5900::COP0_REG[num];
+		case EECAT_FPR:
+			return R5900::COP1_REG_FP[num];
+		case EECAT_FCR:
+			return R5900::COP1_REG_FCR[num];
+		case EECAT_VU0F:
+			switch (num)
+			{
+				case 32: // ACC
+					return "ACC";
+				default:
+					return R5900::COP2_REG_FP[num];
+			}
+		case EECAT_VU0I:
+			return R5900::COP2_REG_CTL[num];
+		case EECAT_GSPRIV:
+			return R5900::GS_REG_PRIV[num];
 		default:
-			return R5900::GPR_REG[num];
-		}
-	case EECAT_CP0:
-		return R5900::COP0_REG[num];
-	case EECAT_FPR:
-		return R5900::COP1_REG_FP[num];
-	case EECAT_FCR:
-		return R5900::COP1_REG_FCR[num];
-	case EECAT_VU0F:
-		switch (num)
-		{
-		case 32:	// ACC
-			return "ACC";
-		default:
-			return R5900::COP2_REG_FP[num];
-		}
-	case EECAT_VU0I:
-		return R5900::COP2_REG_CTL[num];
-	case EECAT_GSPRIV:
-		return R5900::GS_REG_PRIV[num];
-	default:
-		return "Invalid";
+			return "Invalid";
 	}
 }
 
@@ -430,52 +442,52 @@ u128 R5900DebugInterface::getRegister(int cat, int num)
 	u128 result;
 	switch (cat)
 	{
-	case EECAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			result = u128::From32(cpuRegs.pc);
+		case EECAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					result = u128::From32(cpuRegs.pc);
+					break;
+				case 33: // hi
+					result = cpuRegs.HI.UQ;
+					break;
+				case 34: // lo
+					result = cpuRegs.LO.UQ;
+					break;
+				default:
+					result = cpuRegs.GPR.r[num].UQ;
+					break;
+			}
 			break;
-		case 33:	// hi
-			result = cpuRegs.HI.UQ;
+		case EECAT_CP0:
+			result = u128::From32(cpuRegs.CP0.r[num]);
 			break;
-		case 34:	// lo
-			result = cpuRegs.LO.UQ;
+		case EECAT_FPR:
+			result = u128::From32(fpuRegs.fpr[num].UL);
+			break;
+		case EECAT_FCR:
+			result = u128::From32(fpuRegs.fprc[num]);
+			break;
+		case EECAT_VU0F:
+			switch (num)
+			{
+				case 32: // ACC
+					result = VU0.ACC.UQ;
+					break;
+				default:
+					result = VU0.VF[num].UQ;
+					break;
+			}
+			break;
+		case EECAT_VU0I:
+			result = u128::From32(VU0.VI[num].UL);
+			break;
+		case EECAT_GSPRIV:
+			result = gsNonMirroredRead(0x12000000 | R5900::GS_REG_PRIV_ADDR[num]);
 			break;
 		default:
-			result = cpuRegs.GPR.r[num].UQ;
+			result = u128::From32(0);
 			break;
-		}
-		break;
-	case EECAT_CP0:
-		result = u128::From32(cpuRegs.CP0.r[num]);
-		break;
-	case EECAT_FPR:
-		result = u128::From32(fpuRegs.fpr[num].UL);
-		break;
-	case EECAT_FCR:
-		result = u128::From32(fpuRegs.fprc[num]);
-		break;
-	case EECAT_VU0F:
-		switch (num)
-		{
-		case 32:	// ACC
-			result = VU0.ACC.UQ;
-			break;
-		default:
-			result = VU0.VF[num].UQ;
-			break;
-		}
-		break;
-	case EECAT_VU0I:
-		result = u128::From32(VU0.VI[num].UL);
-		break;
-	case EECAT_GSPRIV:
-		result = gsNonMirroredRead(0x12000000 | R5900::GS_REG_PRIV_ADDR[num]);
-		break;
-	default:
-		result = u128::From32(0);
-		break;
 	}
 
 	return result;
@@ -493,8 +505,8 @@ wxString R5900DebugInterface::getRegisterString(int cat, int num)
 		case EECAT_FPR:
 		{
 			char str[64];
-			sprintf(str,"%f",fpuRegs.fpr[num].f);
-			return wxString(str,wxConvUTF8);
+			sprintf(str, "%f", fpuRegs.fpr[num].f);
+			return wxString(str, wxConvUTF8);
 		}
 		default:
 			return L"";
@@ -526,51 +538,51 @@ void R5900DebugInterface::setRegister(int cat, int num, u128 newValue)
 {
 	switch (cat)
 	{
-	case EECAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			cpuRegs.pc = newValue._u32[0];
+		case EECAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					cpuRegs.pc = newValue._u32[0];
+					break;
+				case 33: // hi
+					cpuRegs.HI.UQ = newValue;
+					break;
+				case 34: // lo
+					cpuRegs.LO.UQ = newValue;
+					break;
+				default:
+					cpuRegs.GPR.r[num].UQ = newValue;
+					break;
+			}
 			break;
-		case 33:	// hi
-			cpuRegs.HI.UQ = newValue;
+		case EECAT_CP0:
+			cpuRegs.CP0.r[num] = newValue._u32[0];
 			break;
-		case 34:	// lo
-			cpuRegs.LO.UQ = newValue;
+		case EECAT_FPR:
+			fpuRegs.fpr[num].UL = newValue._u32[0];
+			break;
+		case EECAT_FCR:
+			fpuRegs.fprc[num] = newValue._u32[0];
+			break;
+		case EECAT_VU0F:
+			switch (num)
+			{
+				case 32: // ACC
+					VU0.ACC.UQ = newValue;
+					break;
+				default:
+					VU0.VF[num].UQ = newValue;
+					break;
+			}
+			break;
+		case EECAT_VU0I:
+			VU0.VI[num].UL = newValue._u32[0];
+			break;
+		case EECAT_GSPRIV:
+			memWrite64(0x12000000 | R5900::GS_REG_PRIV_ADDR[num], newValue.lo);
 			break;
 		default:
-			cpuRegs.GPR.r[num].UQ = newValue;
 			break;
-		}
-		break;
-	case EECAT_CP0:
-		cpuRegs.CP0.r[num] = newValue._u32[0];
-		break;
-	case EECAT_FPR:
-		fpuRegs.fpr[num].UL = newValue._u32[0];
-		break;
-	case EECAT_FCR:
-		fpuRegs.fprc[num] = newValue._u32[0];
-		break;
-	case EECAT_VU0F:
-		switch (num)
-		{
-		case 32:	// ACC
-			VU0.ACC.UQ = newValue;
-			break;
-		default:
-			VU0.VF[num].UQ = newValue;
-			break;
-		}
-		break;
-	case EECAT_VU0I:
-		VU0.VI[num].UL = newValue._u32[0];
-		break;
-	case EECAT_GSPRIV:
-		memWrite64(0x12000000 | R5900::GS_REG_PRIV_ADDR[num], newValue.lo);
-		break;
-	default:
-		break;
 	}
 }
 
@@ -579,7 +591,7 @@ std::string R5900DebugInterface::disasm(u32 address, bool simplify)
 	std::string out;
 
 	u32 op = read32(address);
-	R5900::disR5900Fasm(out,op,address,simplify);
+	R5900::disR5900Fasm(out, op, address, simplify);
 	return out;
 }
 
@@ -590,51 +602,51 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 	// get rid of ee ram mirrors
 	switch (addr >> 28)
 	{
-	case 0:
-	case 2:
-		// case 3: throw exception (not mapped ?)
-		// [ 0000_8000 - 01FF_FFFF ] RAM
-		// [ 2000_8000 - 21FF_FFFF ] RAM MIRROR
-		// [ 3000_8000 - 31FF_FFFF ] RAM MIRROR
-		if (lopart >= 0x80000 && lopart <= 0x1ffFFff)
-			return !!vtlb_GetPhyPtr(lopart);
-		break;
-	case 1:
-		// [ 1000_0000 - 1000_CFFF ] EE register
-		if (lopart <= 0xcfff)
-			return true;
+		case 0:
+		case 2:
+			// case 3: throw exception (not mapped ?)
+			// [ 0000_8000 - 01FF_FFFF ] RAM
+			// [ 2000_8000 - 21FF_FFFF ] RAM MIRROR
+			// [ 3000_8000 - 31FF_FFFF ] RAM MIRROR
+			if (lopart >= 0x80000 && lopart <= 0x1ffFFff)
+				return !!vtlb_GetPhyPtr(lopart);
+			break;
+		case 1:
+			// [ 1000_0000 - 1000_CFFF ] EE register
+			if (lopart <= 0xcfff)
+				return true;
 
-		// [ 1100_0000 - 1100_FFFF ] VU mem
-		if (lopart >= 0x1000000 && lopart <= 0x100FFff)
-			return true;
+			// [ 1100_0000 - 1100_FFFF ] VU mem
+			if (lopart >= 0x1000000 && lopart <= 0x100FFff)
+				return true;
 
-		// [ 1200_0000 - 1200_FFFF ] GS regs
-		if (lopart >= 0x2000000 && lopart <= 0x20010ff)
-			return true;
+			// [ 1200_0000 - 1200_FFFF ] GS regs
+			if (lopart >= 0x2000000 && lopart <= 0x20010ff)
+				return true;
 
-		// [ 1E00_0000 - 1FFF_FFFF ] ROM
-		// if (lopart >= 0xe000000)
-		// 	return true; throw exception (not mapped ?)
-		break;
-	case 7:
-		// [ 7000_0000 - 7000_3FFF ] Scratchpad
-		if (lopart <= 0x3fff)
-			return true;
-		break;
-	case 8:
-	case 9:
-	case 0xA:
-	case 0xB:
-		// [ 8000_0000 - BFFF_FFFF ] kernel
-		// We only need to access the EE kernel (which is 1 MB large)
-		if (lopart < 0x100000)
-			return true;
-		break;
-	case 0xF:
-		// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
-		if (lopart >= 0xfff8000)
-			return true;
-		break;
+			// [ 1E00_0000 - 1FFF_FFFF ] ROM
+			// if (lopart >= 0xe000000)
+			// 	return true; throw exception (not mapped ?)
+			break;
+		case 7:
+			// [ 7000_0000 - 7000_3FFF ] Scratchpad
+			if (lopart <= 0x3fff)
+				return true;
+			break;
+		case 8:
+		case 9:
+		case 0xA:
+		case 0xB:
+			// [ 8000_0000 - BFFF_FFFF ] kernel
+			// We only need to access the EE kernel (which is 1 MB large)
+			if (lopart < 0x100000)
+				return true;
+			break;
+		case 0xF:
+			// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
+			if (lopart >= 0xfff8000)
+				return true;
+			break;
 	}
 
 	return false;
@@ -691,7 +703,7 @@ void R3000DebugInterface::write8(u32 address, u8 value)
 	if (!isValidAddress(address))
 		return;
 
-	iopMemWrite8(address,value);
+	iopMemWrite8(address, value);
 }
 
 void R3000DebugInterface::write32(u32 address, u32 value)
@@ -699,7 +711,7 @@ void R3000DebugInterface::write32(u32 address, u32 value)
 	if (!isValidAddress(address))
 		return;
 
-	iopMemWrite32(address,value);
+	iopMemWrite32(address, value);
 }
 
 int R3000DebugInterface::getRegisterCategoryCount()
@@ -711,10 +723,10 @@ const char* R3000DebugInterface::getRegisterCategoryName(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return "GPR";
-	default:
-		return "Invalid";
+		case IOPCAT_GPR:
+			return "GPR";
+		default:
+			return "Invalid";
 	}
 }
 
@@ -722,10 +734,10 @@ int R3000DebugInterface::getRegisterSize(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return 32;
-	default:
-		return 0;
+		case IOPCAT_GPR:
+			return 32;
+		default:
+			return 0;
 	}
 }
 
@@ -733,10 +745,10 @@ int R3000DebugInterface::getRegisterCount(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return 35;	// 32 + pc + hi + lo
-	default:
-		return 0;
+		case IOPCAT_GPR:
+			return 35; // 32 + pc + hi + lo
+		default:
+			return 0;
 	}
 }
 
@@ -744,9 +756,9 @@ DebugInterface::RegisterType R3000DebugInterface::getRegisterType(int cat)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-	default:
-		return DebugInterface::NORMAL;
+		case IOPCAT_GPR:
+		default:
+			return DebugInterface::NORMAL;
 	}
 }
 
@@ -754,49 +766,49 @@ const char* R3000DebugInterface::getRegisterName(int cat, int num)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			return "pc";
-		case 33:	// hi
-			return "hi";
-		case 34:	// lo
-			return "lo";
+		case IOPCAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					return "pc";
+				case 33: // hi
+					return "hi";
+				case 34: // lo
+					return "lo";
+				default:
+					return R5900::GPR_REG[num];
+			}
 		default:
-			return R5900::GPR_REG[num];
-		}
-	default:
-		return "Invalid";
+			return "Invalid";
 	}
 }
 
 u128 R3000DebugInterface::getRegister(int cat, int num)
 {
 	u32 value;
-	
+
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			value = psxRegs.pc;
-			break;
-		case 33:	// hi
-			value = psxRegs.GPR.n.hi;
-			break;
-		case 34:	// lo
-			value = psxRegs.GPR.n.lo;
+		case IOPCAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					value = psxRegs.pc;
+					break;
+				case 33: // hi
+					value = psxRegs.GPR.n.hi;
+					break;
+				case 34: // lo
+					value = psxRegs.GPR.n.lo;
+					break;
+				default:
+					value = psxRegs.GPR.r[num];
+					break;
+			}
 			break;
 		default:
-			value = psxRegs.GPR.r[num];
+			value = -1;
 			break;
-		}
-		break;
-	default:
-		value = -1;
-		break;
 	}
 
 	return u128::From32(value);
@@ -806,10 +818,10 @@ wxString R3000DebugInterface::getRegisterString(int cat, int num)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		return getRegister(cat,num).ToString();
-	default:
-		return L"Invalid";
+		case IOPCAT_GPR:
+			return getRegister(cat, num).ToString();
+		default:
+			return L"Invalid";
 	}
 }
 
@@ -837,25 +849,25 @@ void R3000DebugInterface::setRegister(int cat, int num, u128 newValue)
 {
 	switch (cat)
 	{
-	case IOPCAT_GPR:
-		switch (num)
-		{
-		case 32:	// pc
-			psxRegs.pc = newValue._u32[0];
-			break;
-		case 33:	// hi
-			psxRegs.GPR.n.hi = newValue._u32[0];
-			break;
-		case 34:	// lo
-			psxRegs.GPR.n.lo = newValue._u32[0];
+		case IOPCAT_GPR:
+			switch (num)
+			{
+				case 32: // pc
+					psxRegs.pc = newValue._u32[0];
+					break;
+				case 33: // hi
+					psxRegs.GPR.n.hi = newValue._u32[0];
+					break;
+				case 34: // lo
+					psxRegs.GPR.n.lo = newValue._u32[0];
+					break;
+				default:
+					psxRegs.GPR.r[num] = newValue._u32[0];
+					break;
+			}
 			break;
 		default:
-			psxRegs.GPR.r[num] = newValue._u32[0];
 			break;
-		}
-		break;
-	default:
-		break;
 	}
 }
 
@@ -864,7 +876,7 @@ std::string R3000DebugInterface::disasm(u32 address, bool simplify)
 	std::string out;
 
 	u32 op = read32(address);
-	R5900::disR5900Fasm(out,op,address,simplify);
+	R5900::disR5900Fasm(out, op, address, simplify);
 	return out;
 }
 

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -53,7 +53,7 @@ enum ReferenceIndexType
 class MipsExpressionFunctions : public IExpressionFunctions
 {
 public:
-	MipsExpressionFunctions(DebugInterface* cpu)
+	explicit MipsExpressionFunctions(DebugInterface* cpu)
 		: cpu(cpu){};
 
 	virtual bool parseReference(char* str, u64& referenceIndex)

--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -30,8 +30,7 @@ wxBEGIN_EVENT_TABLE(CtrlRegisterList, wxWindow)
 	EVT_KEY_DOWN(CtrlRegisterList::keydownEvent)
 wxEND_EVENT_TABLE()
 
-enum DisassemblyMenuIdentifiers
-{
+enum DisassemblyMenuIdentifiers {
 	ID_REGISTERLIST_DISPLAY32 = 1,
 	ID_REGISTERLIST_DISPLAY64,
 	ID_REGISTERLIST_DISPLAY128,
@@ -46,13 +45,14 @@ enum DisassemblyMenuIdentifiers
 
 
 CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
-	: wxScrolledWindow(parent,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxWANTS_CHARS|wxBORDER_NONE|wxVSCROLL), cpu(_cpu)
+	: wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxWANTS_CHARS | wxBORDER_NONE | wxVSCROLL)
+	, cpu(_cpu)
 {
-	rowHeight = getDebugFontHeight()+2;
+	rowHeight = getDebugFontHeight() + 2;
 	charWidth = getDebugFontWidth();
-	category  = 0;
-	maxBits   = 128;
-	lastPc    = 0xFFFFFFFF;
+	category = 0;
+	maxBits = 128;
+	lastPc = 0xFFFFFFFF;
 	resolvePointerStrings = false;
 	displayVU0FAsFloat = false;
 
@@ -61,16 +61,16 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 		const int count = cpu->getRegisterCount(i);
 
 		ChangedReg* regs = new ChangedReg[count];
-		memset(regs,0,sizeof(ChangedReg)*count);
+		memset(regs, 0, sizeof(ChangedReg) * count);
 		changedCategories.push_back(regs);
 
 		int maxLen = 0;
 		for (int k = 0; k < cpu->getRegisterCount(i); k++)
 		{
-			maxLen = std::max<int>(maxLen,strlen(cpu->getRegisterName(i,k)));
+			maxLen = std::max<int>(maxLen, strlen(cpu->getRegisterName(i, k)));
 		}
 
-		const int x = 17+(maxLen+2)*charWidth;
+		const int x = 17 + (maxLen + 2) * charWidth;
 		startPositions.push_back(x);
 		currentRows.push_back(0);
 	}
@@ -87,7 +87,6 @@ CtrlRegisterList::~CtrlRegisterList()
 {
 	for (auto& regs : changedCategories)
 		delete[] regs;
-
 }
 
 wxSize CtrlRegisterList::getOptimalSize() const
@@ -115,25 +114,25 @@ wxSize CtrlRegisterList::getOptimalSize() const
 		maxRows = std::max<int>(maxRows, cpu->getRegisterCount(i));
 	}
 
-	maxWidth = std::max<int>(columnChars*charWidth, maxWidth + 4);
+	maxWidth = std::max<int>(columnChars * charWidth, maxWidth + 4);
 
-	return wxSize(maxWidth, (maxRows + 1)*rowHeight);
+	return wxSize(maxWidth, (maxRows + 1) * rowHeight);
 }
 
 void CtrlRegisterList::postEvent(wxEventType type, wxString text)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetString(text);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetString(text);
+	wxPostEvent(this, event);
 }
 
 void CtrlRegisterList::postEvent(wxEventType type, int value)
 {
-   wxCommandEvent event( type, GetId() );
-   event.SetEventObject(this);
-   event.SetInt(value);
-   wxPostEvent(this,event);
+	wxCommandEvent event(type, GetId());
+	event.SetEventObject(this);
+	event.SetInt(value);
+	wxPostEvent(this, event);
 }
 
 void CtrlRegisterList::refreshChangedRegs()
@@ -149,9 +148,9 @@ void CtrlRegisterList::refreshChangedRegs()
 		for (int i = 0; i < cpu->getRegisterCount(cat); i++)
 		{
 			ChangedReg& reg = regs[i];
-			memset(&reg.changed,0,sizeof(reg.changed));
+			memset(&reg.changed, 0, sizeof(reg.changed));
 
-			const u128 newValue = cpu->getRegister(cat,i);
+			const u128 newValue = cpu->getRegister(cat, i);
 
 			if (reg.oldValue != newValue)
 			{
@@ -197,14 +196,14 @@ void CtrlRegisterList::sizeEvent(wxSizeEvent& evt)
 void drawU32Text(wxDC& dc, u32 value, int x, int y)
 {
 	char str[32];
-	sprintf(str,"%08X",value);
-	dc.DrawText(wxString(str,wxConvUTF8),x,y);
+	sprintf(str, "%08X", value);
+	dc.DrawText(wxString(str, wxConvUTF8), x, y);
 }
 
 void CtrlRegisterList::OnDraw(wxDC& dc)
 {
 	wxFont font = pxGetFixedFont(8);
-	font.SetPixelSize(wxSize(charWidth,rowHeight-2));
+	font.SetPixelSize(wxSize(charWidth, rowHeight - 2));
 	dc.SetFont(font);
 
 	refreshChangedRegs();
@@ -214,50 +213,52 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 	wxColor colorNormal = wxColor(0xFF600000);
 
 	int startRow;
-	GetViewStart(nullptr,&startRow);
+	GetViewStart(nullptr, &startRow);
 	int endRow = startRow + ceil(float(GetClientSize().y) / rowHeight);
 
 	// draw categories
 	const int width = GetClientSize().x;
 	if (startRow == 0)
 	{
-		int piece = width /cpu->getRegisterCategoryCount();
+		int piece = width / cpu->getRegisterCategoryCount();
 		for (int i = 0; i < cpu->getRegisterCategoryCount(); i++)
 		{
 			const char* name = cpu->getRegisterCategoryName(i);
 
-			int x = i*piece;
+			int x = i * piece;
 
 			if (i == category)
 			{
 				dc.SetBrush(wxBrush(wxColor(0xFF70FF70)));
 				dc.SetPen(wxPen(wxColor(0xFF000000)));
-			} else {
+			}
+			else
+			{
 				dc.SetBrush(wxBrush(wxColor(0xFFFFEFE8)));
 				dc.SetPen(wxPen(wxColor(0xFF000000)));
 			}
 
-			if (i == cpu->getRegisterCategoryCount()-1)
-				piece += width-piece*cpu->getRegisterCategoryCount()-1;
-		
-			dc.DrawRectangle(x,0,piece+1,rowHeight);
+			if (i == cpu->getRegisterCategoryCount() - 1)
+				piece += width - piece * cpu->getRegisterCategoryCount() - 1;
+
+			dc.DrawRectangle(x, 0, piece + 1, rowHeight);
 
 			// center text
-			x += (piece-strlen(name)*charWidth)/2;
-			dc.DrawText(wxString(name,wxConvUTF8),x,2);
+			x += (piece - strlen(name) * charWidth) / 2;
+			dc.DrawText(wxString(name, wxConvUTF8), x, 2);
 		}
 	}
 
 	// skip the tab row
-	startRow = std::max<int>(0,startRow-1);
-	endRow = std::min<int>(cpu->getRegisterCount(category)-1,endRow-1);
+	startRow = std::max<int>(0, startRow - 1);
+	endRow = std::min<int>(cpu->getRegisterCount(category) - 1, endRow - 1);
 
 	// Add a title to help identify registers W Z Y X
 	if (category == EECAT_VU0F)
 	{
 		const int piece = width / 5; // 4 registers + space for register name
 
-		const wxString titles[4] = { "W","Z","Y","X" };
+		const wxString titles[4] = {"W", "Z", "Y", "X"};
 		const int titleAmt = abs((maxBits / 32) - 4);
 
 		for (int iter = 4; iter > titleAmt; iter--)
@@ -265,8 +266,8 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 			dc.SetBrush(wxBrush(wxColor(0xFFFFEFE8)));
 			dc.SetPen(wxPen(wxColor(0xFF000000)));
 
-			dc.DrawRectangle((piece * iter) + 3, rowHeight,piece,rowHeight);
-			dc.DrawText(titles[iter - 1], (piece * iter) + piece / 2,rowHeight + 2);
+			dc.DrawRectangle((piece * iter) + 3, rowHeight, piece, rowHeight);
+			dc.DrawText(titles[iter - 1], (piece * iter) + piece / 2, rowHeight + 2);
 		}
 	}
 
@@ -282,7 +283,7 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 		int x = valueStart;
 		// Skip a row if we are showing our VU0f registers
 		// This makes room for the WZYX title
-		const int y = rowHeight*(i + (category == EECAT_VU0F ? 2 : 1));
+		const int y = rowHeight * (i + (category == EECAT_VU0F ? 2 : 1));
 
 		wxColor backgroundColor;
 		if (currentRows[category] == i)
@@ -296,118 +297,120 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 		dc.SetPen(backgroundColor);
 		dc.DrawRectangle(0, y, width, rowHeight);
 
-		const char* name = cpu->getRegisterName(category,i);
+		const char* name = cpu->getRegisterName(category, i);
 		dc.SetTextForeground(colorNormal);
-		dc.DrawText(wxString(name,wxConvUTF8),nameStart,y+2);
+		dc.DrawText(wxString(name, wxConvUTF8), nameStart, y + 2);
 
-		const u128 value = cpu->getRegister(category,i);
+		const u128 value = cpu->getRegister(category, i);
 		const ChangedReg& changed = changedRegs[i];
 
 		switch (type)
 		{
-		[[fallthrough]]; // If we fallthrough, display VU0f as hexadecimal 
-		case DebugInterface::SPECIAL:	// let debug interface format them and just display them
-		{
-			if (changed.changed[0] || changed.changed[1] || changed.changed[2] || changed.changed[3])
-				dc.SetTextForeground(colorChanged);
-			else
-				dc.SetTextForeground(colorUnchanged);
-
-			if (category == EECAT_VU0F)
+			[[fallthrough]]; // If we fallthrough, display VU0f as hexadecimal
+			case DebugInterface::SPECIAL: // let debug interface format them and just display them
 			{
-				if (displayVU0FAsFloat)
-				{
-					char str[256];
-					const u128 val = cpu->getRegister(category, i);
-					// Use std::bit_cast in C++20. The below is technically UB
-					sprintf(str, "%7.2f %7.2f %7.2f %7.2f", *(float*)&val._u32[3], *(float*)&val._u32[2], *(float*)&val._u32[1], *(float*)&val._u32[0]);
+				if (changed.changed[0] || changed.changed[1] || changed.changed[2] || changed.changed[3])
+					dc.SetTextForeground(colorChanged);
+				else
+					dc.SetTextForeground(colorUnchanged);
 
-					dc.DrawText(wxString(str), x, y + 2);
+				if (category == EECAT_VU0F)
+				{
+					if (displayVU0FAsFloat)
+					{
+						char str[256];
+						const u128 val = cpu->getRegister(category, i);
+						// Use std::bit_cast in C++20. The below is technically UB
+						sprintf(str, "%7.2f %7.2f %7.2f %7.2f", *(float*)&val._u32[3], *(float*)&val._u32[2], *(float*)&val._u32[1], *(float*)&val._u32[0]);
+
+						dc.DrawText(wxString(str), x, y + 2);
+						break;
+					}
+				}
+				else
+				{
+					dc.DrawText(cpu->getRegisterString(category, i), x, y + 2);
 					break;
 				}
-			}
-			else
-			{
-				dc.DrawText(cpu->getRegisterString(category, i), x, y + 2);
-				break;
-			}
-		case DebugInterface::NORMAL:	// display them in 32 bit parts
-			switch (registerBits)
-			{
-			case 128:
-				{
-					int startIndex = std::min<int>(3, maxBits / 32 - 1);
-
-					if (resolvePointerStrings && cpu->isAlive()) {
-						const char *strval = cpu->stringFromPointer(value._u32[0]);
-						if (strval) {
-							static wxColor clr = wxColor(0xFF228822);
-							dc.SetTextForeground(clr);
-							dc.DrawText(wxString(strval), width - (32 * charWidth + 12), y + 2);
-							startIndex = 0;
-						}
-					}
-
-					const int actualX = width-4-(startIndex+1)*(8*charWidth+2);
-					x = std::max<int>(actualX,x);
-
-					if (startIndex != 3)
+				case DebugInterface::NORMAL: // display them in 32 bit parts
+					switch (registerBits)
 					{
-						bool c = false;
-						for (int i = 3; i > startIndex; i--)
-							c = c || changed.changed[i];
-
-						if (c)
+						case 128:
 						{
-							dc.SetTextForeground(colorChanged);
-							dc.DrawText(L"+",x-charWidth,y+2);
+							int startIndex = std::min<int>(3, maxBits / 32 - 1);
+
+							if (resolvePointerStrings && cpu->isAlive())
+							{
+								const char* strval = cpu->stringFromPointer(value._u32[0]);
+								if (strval)
+								{
+									static wxColor clr = wxColor(0xFF228822);
+									dc.SetTextForeground(clr);
+									dc.DrawText(wxString(strval), width - (32 * charWidth + 12), y + 2);
+									startIndex = 0;
+								}
+							}
+
+							const int actualX = width - 4 - (startIndex + 1) * (8 * charWidth + 2);
+							x = std::max<int>(actualX, x);
+
+							if (startIndex != 3)
+							{
+								bool c = false;
+								for (int i = 3; i > startIndex; i--)
+									c = c || changed.changed[i];
+
+								if (c)
+								{
+									dc.SetTextForeground(colorChanged);
+									dc.DrawText(L"+", x - charWidth, y + 2);
+								}
+							}
+
+							for (int i = startIndex; i >= 0; i--)
+							{
+								if (changed.changed[i])
+									dc.SetTextForeground(colorChanged);
+								else
+									dc.SetTextForeground(colorUnchanged);
+
+								drawU32Text(dc, value._u32[i], x, y + 2);
+								x += charWidth * 8 + 2;
+							}
+							break;
+						}
+						case 64:
+						{
+							if (maxBits < 64 && changed.changed[1])
+							{
+								dc.SetTextForeground(colorChanged);
+								dc.DrawText(L"+", x - charWidth, y + 2);
+							}
+
+							for (int i = 1; i >= 0; i--)
+							{
+								if (changed.changed[i])
+									dc.SetTextForeground(colorChanged);
+								else
+									dc.SetTextForeground(colorUnchanged);
+
+								drawU32Text(dc, value._u32[i], x, y + 2);
+								x += charWidth * 8 + 2;
+							}
+							break;
+						}
+						case 32:
+						{
+							if (changed.changed[0])
+								dc.SetTextForeground(colorChanged);
+							else
+								dc.SetTextForeground(colorUnchanged);
+
+							drawU32Text(dc, value._u32[0], x, y + 2);
+							break;
 						}
 					}
-
-					for (int i = startIndex; i >= 0; i--)
-					{
-						if (changed.changed[i])
-							dc.SetTextForeground(colorChanged);
-						else
-							dc.SetTextForeground(colorUnchanged);
-
-						drawU32Text(dc,value._u32[i],x,y+2);
-						x += charWidth*8+2;
-					}
 					break;
-				}
-			case 64:
-				{
-					if (maxBits < 64 && changed.changed[1])
-					{
-						dc.SetTextForeground(colorChanged);
-						dc.DrawText(L"+",x-charWidth,y+2);
-					}
-
-					for (int i = 1; i >= 0; i--)
-					{
-						if (changed.changed[i])
-							dc.SetTextForeground(colorChanged);
-						else
-							dc.SetTextForeground(colorUnchanged);
-
-						drawU32Text(dc,value._u32[i],x,y+2);
-						x += charWidth*8+2;
-					}
-					break;
-				}
-			case 32:
-				{
-					if (changed.changed[0])
-						dc.SetTextForeground(colorChanged);
-					else
-						dc.SetTextForeground(colorUnchanged);
-
-					drawU32Text(dc,value._u32[0],x,y+2);
-					break;
-				}
-			}
-			break;
 			}
 		}
 	}
@@ -417,38 +420,38 @@ void CtrlRegisterList::changeValue(RegisterChangeMode mode)
 {
 	wchar_t str[64];
 
-	u128 oldValue = cpu->getRegister(category,currentRows[category]);
+	u128 oldValue = cpu->getRegister(category, currentRows[category]);
 
 	switch (mode)
 	{
-	case LOWER64:
-		swprintf(str,64,L"0x%016llX",oldValue._u64[0]);
-		break;
-	case UPPER64:
-		swprintf(str,64,L"0x%016llX",oldValue._u64[1]);
-		break;
-	case CHANGE32:
-		swprintf(str,64,L"0x%08X",oldValue._u32[0]);
-		break;
+		case LOWER64:
+			swprintf(str, 64, L"0x%016llX", oldValue._u64[0]);
+			break;
+		case UPPER64:
+			swprintf(str, 64, L"0x%016llX", oldValue._u64[1]);
+			break;
+		case CHANGE32:
+			swprintf(str, 64, L"0x%08X", oldValue._u32[0]);
+			break;
 	}
-	
+
 	u64 newValue;
-	if (executeExpressionWindow(this,cpu,newValue,str))
+	if (executeExpressionWindow(this, cpu, newValue, str))
 	{
 		switch (mode)
 		{
-		case LOWER64:
-			oldValue._u64[0] = newValue;
-			break;
-		case UPPER64:
-			oldValue._u64[1] = newValue;
-			break;
-		case CHANGE32:
-			oldValue._u32[0] = newValue;
-			break;
+			case LOWER64:
+				oldValue._u64[0] = newValue;
+				break;
+			case UPPER64:
+				oldValue._u64[1] = newValue;
+				break;
+			case CHANGE32:
+				oldValue._u32[0] = newValue;
+				break;
 		}
 
-		cpu->setRegister(category,currentRows[category],oldValue);
+		cpu->setRegister(category, currentRows[category], oldValue);
 	}
 }
 
@@ -457,102 +460,102 @@ void CtrlRegisterList::onPopupClick(wxCommandEvent& evt)
 {
 	switch (evt.GetId())
 	{
-	case ID_REGISTERLIST_DISPLAY32:
-		resolvePointerStrings = false;
-		maxBits = 32;
-		SetInitialSize(ClientToWindowSize(GetMinClientSize()));
-		postEvent(debEVT_UPDATELAYOUT,0);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_DISPLAY64:
-		resolvePointerStrings = false;
-		maxBits = 64;
-		SetInitialSize(ClientToWindowSize(GetMinClientSize()));
-		postEvent(debEVT_UPDATELAYOUT,0);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_DISPLAY128:
-		resolvePointerStrings = false;
-		maxBits = 128;
-		SetInitialSize(ClientToWindowSize(GetMinClientSize()));
-		postEvent(debEVT_UPDATELAYOUT,0);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_DISPLAY128STRINGS:
-		resolvePointerStrings = true;
-		maxBits = 128;
-		SetInitialSize(ClientToWindowSize(GetMinClientSize()));
-		postEvent(debEVT_UPDATELAYOUT, 0);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_DISPLAYVU0FFLOATS:
-		displayVU0FAsFloat = !displayVU0FAsFloat;
-		SetInitialSize(ClientToWindowSize(GetMinClientSize()));
-		postEvent(debEVT_UPDATELAYOUT, 0);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_CHANGELOWER:
-		changeValue(LOWER64);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_CHANGEUPPER:
-		changeValue(UPPER64);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_CHANGEVALUE:
-		if (cpu->getRegisterSize(category) == 32)
-			changeValue(CHANGE32);
-		else
+		case ID_REGISTERLIST_DISPLAY32:
+			resolvePointerStrings = false;
+			maxBits = 32;
+			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
+			postEvent(debEVT_UPDATELAYOUT, 0);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_DISPLAY64:
+			resolvePointerStrings = false;
+			maxBits = 64;
+			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
+			postEvent(debEVT_UPDATELAYOUT, 0);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_DISPLAY128:
+			resolvePointerStrings = false;
+			maxBits = 128;
+			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
+			postEvent(debEVT_UPDATELAYOUT, 0);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_DISPLAY128STRINGS:
+			resolvePointerStrings = true;
+			maxBits = 128;
+			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
+			postEvent(debEVT_UPDATELAYOUT, 0);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_DISPLAYVU0FFLOATS:
+			displayVU0FAsFloat = !displayVU0FAsFloat;
+			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
+			postEvent(debEVT_UPDATELAYOUT, 0);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_CHANGELOWER:
 			changeValue(LOWER64);
-		Refresh();
-		break;
-	case ID_REGISTERLIST_GOTOINMEMORYVIEW:
-		postEvent(debEVT_GOTOINMEMORYVIEW, cpu->getRegister(category, currentRows[category])._u32[0]);
-		break;
-	case ID_REGISTERLIST_GOTOINDISASM:
-		postEvent(debEVT_GOTOINDISASM, cpu->getRegister(category, currentRows[category])._u32[0]);
-		break;
-	default:
-		wxMessageBox( L"Unimplemented.",  L"Unimplemented.", wxICON_INFORMATION);
-		break;
+			Refresh();
+			break;
+		case ID_REGISTERLIST_CHANGEUPPER:
+			changeValue(UPPER64);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_CHANGEVALUE:
+			if (cpu->getRegisterSize(category) == 32)
+				changeValue(CHANGE32);
+			else
+				changeValue(LOWER64);
+			Refresh();
+			break;
+		case ID_REGISTERLIST_GOTOINMEMORYVIEW:
+			postEvent(debEVT_GOTOINMEMORYVIEW, cpu->getRegister(category, currentRows[category])._u32[0]);
+			break;
+		case ID_REGISTERLIST_GOTOINDISASM:
+			postEvent(debEVT_GOTOINDISASM, cpu->getRegister(category, currentRows[category])._u32[0]);
+			break;
+		default:
+			wxMessageBox(L"Unimplemented.", L"Unimplemented.", wxICON_INFORMATION);
+			break;
 	}
 }
 
 void CtrlRegisterList::setCurrentRow(int row)
 {
 	char str[256];
-	u128 value ;
+	u128 value;
 	wxString text;
 
-	const char* name = cpu->getRegisterName(category,row);
+	const char* name = cpu->getRegisterName(category, row);
 
 	switch (cpu->getRegisterType(category))
 	{
-	case DebugInterface::NORMAL:
-		value = cpu->getRegister(category,row);
-		postEvent(debEVT_REFERENCEMEMORYVIEW, value._u32[0]);
+		case DebugInterface::NORMAL:
+			value = cpu->getRegister(category, row);
+			postEvent(debEVT_REFERENCEMEMORYVIEW, value._u32[0]);
 
-		switch (cpu->getRegisterSize(category))
-		{
-		case 128:
-			sprintf(str,"%s = 0x%08X%08X%08X%08X",name,value._u32[3],value._u32[2],value._u32[1],value._u32[0]);
+			switch (cpu->getRegisterSize(category))
+			{
+				case 128:
+					sprintf(str, "%s = 0x%08X%08X%08X%08X", name, value._u32[3], value._u32[2], value._u32[1], value._u32[0]);
+					break;
+				case 64:
+					sprintf(str, "%s = 0x%08X%08X", name, value._u32[1], value._u32[0]);
+					break;
+				case 32:
+					sprintf(str, "%s = 0x%08X", name, value._u32[0]);
+					break;
+			}
+			text = wxString(str, wxConvUTF8);
 			break;
-		case 64:
-			sprintf(str,"%s = 0x%08X%08X",name,value._u32[1],value._u32[0]);
+		case DebugInterface::SPECIAL:
+			text = wxString(name, wxConvUTF8) + L" = " + cpu->getRegisterString(category, row);
 			break;
-		case 32:
-			sprintf(str,"%s = 0x%08X",name,value._u32[0]);
-			break;
-		}
-		text = wxString(str,wxConvUTF8);
-		break;
-	case DebugInterface::SPECIAL:
-		text = wxString(name,wxConvUTF8) + L" = " + cpu->getRegisterString(category,row);
-		break;
 	}
 
 	currentRows[category] = row;
-	postEvent(debEVT_SETSTATUSBARTEXT,text);
+	postEvent(debEVT_SETSTATUSBARTEXT, text);
 	ensureVisible(currentRows[category] + 1); //offset due to header at scroll position 0
 	Refresh();
 }
@@ -560,7 +563,7 @@ void CtrlRegisterList::setCurrentRow(int row)
 void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 {
 	int xOffset, yOffset;
-	((wxScrolledWindow*) this)->GetViewStart(&xOffset, &yOffset);
+	((wxScrolledWindow*)this)->GetViewStart(&xOffset, &yOffset);
 
 	wxClientDC dc(this);
 	wxPoint pos = evt.GetPosition();
@@ -571,7 +574,7 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 	{
 		if (y >= rowHeight)
 		{
-			const int row = (y-rowHeight)/rowHeight;
+			const int row = (y - rowHeight) / rowHeight;
 			if (row != currentRows[category] && row < cpu->getRegisterCount(category))
 				setCurrentRow(row);
 		}
@@ -588,18 +591,18 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 
 			switch (maxBits)
 			{
-			case 128:
-				if (resolvePointerStrings)
-					menu.Check(ID_REGISTERLIST_DISPLAY128STRINGS, true);
-				else
-					menu.Check(ID_REGISTERLIST_DISPLAY128, true);
-				break;
-			case 64:
-				menu.Check(ID_REGISTERLIST_DISPLAY64, true);
-				break;
-			case 32:
-				menu.Check(ID_REGISTERLIST_DISPLAY32, true);
-				break;
+				case 128:
+					if (resolvePointerStrings)
+						menu.Check(ID_REGISTERLIST_DISPLAY128STRINGS, true);
+					else
+						menu.Check(ID_REGISTERLIST_DISPLAY128, true);
+					break;
+				case 64:
+					menu.Check(ID_REGISTERLIST_DISPLAY64, true);
+					break;
+				case 32:
+					menu.Check(ID_REGISTERLIST_DISPLAY32, true);
+					break;
 			}
 		}
 
@@ -610,10 +613,12 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 
 		if (bits >= 64)
 		{
-			menu.Append(ID_REGISTERLIST_CHANGELOWER,	L"Change lower 64 bit");
-			menu.Append(ID_REGISTERLIST_CHANGEUPPER,	L"Change upper 64 bit");
-		} else {
-			menu.Append(ID_REGISTERLIST_CHANGEVALUE,	L"Change value");
+			menu.Append(ID_REGISTERLIST_CHANGELOWER, L"Change lower 64 bit");
+			menu.Append(ID_REGISTERLIST_CHANGEUPPER, L"Change upper 64 bit");
+		}
+		else
+		{
+			menu.Append(ID_REGISTERLIST_CHANGEVALUE, L"Change value");
 		}
 
 		menu.AppendSeparator();
@@ -621,7 +626,7 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 		menu.Append(ID_REGISTERLIST_GOTOINDISASM, L"Follow in Disasm");
 
 		menu.Bind(wxEVT_MENU, &CtrlRegisterList::onPopupClick, this);
-		PopupMenu(&menu,evt.GetPosition());
+		PopupMenu(&menu, evt.GetPosition());
 		return;
 	}
 
@@ -629,16 +634,18 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 	{
 		if (y < rowHeight)
 		{
-			const int piece = GetSize().x/cpu->getRegisterCategoryCount();
-			const int cat = std::min<int>(x/piece,cpu->getRegisterCategoryCount()-1);
+			const int piece = GetSize().x / cpu->getRegisterCategoryCount();
+			const int cat = std::min<int>(x / piece, cpu->getRegisterCategoryCount() - 1);
 
 			if (cat != category)
 			{
 				category = cat;
 				Refresh();
 			}
-		} else {
-			const int row = (y - (rowHeight * 2) )/rowHeight;
+		}
+		else
+		{
+			const int row = (y - (rowHeight * 2)) / rowHeight;
 			if (row != currentRows[category] && row < cpu->getRegisterCount(category))
 				setCurrentRow(row);
 		}
@@ -648,7 +655,8 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 	}
 }
 
-void CtrlRegisterList::ensureVisible(int index) {
+void CtrlRegisterList::ensureVisible(int index)
+{
 	//scroll vertically to keep a logical position visible
 	int x, y;
 	GetViewStart(&x, &y);
@@ -663,21 +671,21 @@ void CtrlRegisterList::keydownEvent(wxKeyEvent& evt)
 {
 	switch (evt.GetKeyCode())
 	{
-	case WXK_UP:
-		int x, y;
-		GetViewStart(&x, &y);
-		//If at top of rows allow scrolling an extra time to show tab header
-		if (currentRows[category] == 0 && y == 1)
-			Scroll(x, 0);
-		else
-			setCurrentRow(std::max<int>(currentRows[category]-1,0));
-		break;
-	case WXK_DOWN:
-		setCurrentRow(std::min<int>(currentRows[category]+1,cpu->getRegisterCount(category)-1));
-		break;
-	case WXK_TAB:
-		category = (category+1) % cpu->getRegisterCategoryCount();
-		Refresh();
-		break;
+		case WXK_UP:
+			int x, y;
+			GetViewStart(&x, &y);
+			//If at top of rows allow scrolling an extra time to show tab header
+			if (currentRows[category] == 0 && y == 1)
+				Scroll(x, 0);
+			else
+				setCurrentRow(std::max<int>(currentRows[category] - 1, 0));
+			break;
+		case WXK_DOWN:
+			setCurrentRow(std::min<int>(currentRows[category] + 1, cpu->getRegisterCount(category) - 1));
+			break;
+		case WXK_TAB:
+			category = (category + 1) % cpu->getRegisterCategoryCount();
+			Refresh();
+			break;
 	}
 }

--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021 PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -36,6 +36,7 @@ enum DisassemblyMenuIdentifiers
 	ID_REGISTERLIST_DISPLAY64,
 	ID_REGISTERLIST_DISPLAY128,
 	ID_REGISTERLIST_DISPLAY128STRINGS,
+	ID_REGISTERLIST_DISPLAYVU0FFLOATS,
 	ID_REGISTERLIST_CHANGELOWER,
 	ID_REGISTERLIST_CHANGEUPPER,
 	ID_REGISTERLIST_CHANGEVALUE,
@@ -53,10 +54,11 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 	maxBits   = 128;
 	lastPc    = 0xFFFFFFFF;
 	resolvePointerStrings = false;
+	displayVU0FAsFloat = false;
 
 	for (int i = 0; i < cpu->getRegisterCategoryCount(); i++)
 	{
-		int count = cpu->getRegisterCount(i);
+		const int count = cpu->getRegisterCount(i);
 
 		ChangedReg* regs = new ChangedReg[count];
 		memset(regs,0,sizeof(ChangedReg)*count);
@@ -68,7 +70,7 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 			maxLen = std::max<int>(maxLen,strlen(cpu->getRegisterName(i,k)));
 		}
 
-		int x = 17+(maxLen+2)*charWidth;
+		const int x = 17+(maxLen+2)*charWidth;
 		startPositions.push_back(x);
 		currentRows.push_back(0);
 	}
@@ -76,7 +78,7 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 	SetDoubleBuffered(true);
 	SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 
-	wxSize actualSize = getOptimalSize();
+	const wxSize actualSize = getOptimalSize();
 	SetVirtualSize(actualSize);
 	SetScrollbars(1, rowHeight, actualSize.x, actualSize.y / rowHeight, 0, 0);
 }
@@ -97,7 +99,12 @@ wxSize CtrlRegisterList::getOptimalSize() const
 	for (int i = 0; i < cpu->getRegisterCategoryCount(); i++)
 	{
 		int bits = std::min<u32>(maxBits, cpu->getRegisterSize(i));
-		int start = startPositions[i];
+
+		// Workaround for displaying VU0F registers as floats
+		if (i == EECAT_VU0F && displayVU0FAsFloat)
+			bits = 128;
+
+		const int start = startPositions[i];
 
 		int w = start + (bits / 4) * charWidth;
 		if (bits > 32)
@@ -137,14 +144,14 @@ void CtrlRegisterList::refreshChangedRegs()
 	for (size_t cat = 0; cat < changedCategories.size(); cat++)
 	{
 		ChangedReg* regs = changedCategories[cat];
-		int size = cpu->getRegisterSize(category);
+		const int size = cpu->getRegisterSize(category);
 
 		for (int i = 0; i < cpu->getRegisterCount(cat); i++)
 		{
 			ChangedReg& reg = regs[i];
 			memset(&reg.changed,0,sizeof(reg.changed));
 
-			u128 newValue = cpu->getRegister(cat,i);
+			const u128 newValue = cpu->getRegister(cat,i);
 
 			if (reg.oldValue != newValue)
 			{
@@ -211,7 +218,7 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 	int endRow = startRow + ceil(float(GetClientSize().y) / rowHeight);
 
 	// draw categories
-	int width = GetClientSize().x;
+	const int width = GetClientSize().x;
 	if (startRow == 0)
 	{
 		int piece = width /cpu->getRegisterCategoryCount();
@@ -245,17 +252,37 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 	startRow = std::max<int>(0,startRow-1);
 	endRow = std::min<int>(cpu->getRegisterCount(category)-1,endRow-1);
 
-	int nameStart = 17;
-	int valueStart = startPositions[category];
+	// Add a title to help identify registers W Z Y X
+	if (category == EECAT_VU0F)
+	{
+		const int piece = width / 5; // 4 registers + space for register name
+
+		const wxString titles[4] = { "W","Z","Y","X" };
+		const int titleAmt = abs((maxBits / 32) - 4);
+
+		for (int iter = 4; iter > titleAmt; iter--)
+		{
+			dc.SetBrush(wxBrush(wxColor(0xFFFFEFE8)));
+			dc.SetPen(wxPen(wxColor(0xFF000000)));
+
+			dc.DrawRectangle((piece * iter) + 3, rowHeight,piece,rowHeight);
+			dc.DrawText(titles[iter - 1], (piece * iter) + piece / 2,rowHeight + 2);
+		}
+	}
+
+	const int nameStart = 17;
+	const int valueStart = startPositions[category];
 
 	ChangedReg* changedRegs = changedCategories[category];
-	int registerBits = cpu->getRegisterSize(category);
+	const int registerBits = cpu->getRegisterSize(category);
 	DebugInterface::RegisterType type = cpu->getRegisterType(category);
 
 	for (int i = startRow; i <= endRow; i++)
 	{
 		int x = valueStart;
-		int y = rowHeight*(i+1);
+		// Skip a row if we are showing our VU0f registers
+		// This makes room for the WZYX title
+		const int y = rowHeight*(i + (category == EECAT_VU0F ? 2 : 1));
 
 		wxColor backgroundColor;
 		if (currentRows[category] == i)
@@ -273,11 +300,37 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 		dc.SetTextForeground(colorNormal);
 		dc.DrawText(wxString(name,wxConvUTF8),nameStart,y+2);
 
-		u128 value = cpu->getRegister(category,i);
-		ChangedReg& changed = changedRegs[i];
+		const u128 value = cpu->getRegister(category,i);
+		const ChangedReg& changed = changedRegs[i];
 
 		switch (type)
 		{
+		[[fallthrough]]; // If we fallthrough, display VU0f as hexadecimal 
+		case DebugInterface::SPECIAL:	// let debug interface format them and just display them
+		{
+			if (changed.changed[0] || changed.changed[1] || changed.changed[2] || changed.changed[3])
+				dc.SetTextForeground(colorChanged);
+			else
+				dc.SetTextForeground(colorUnchanged);
+
+			if (category == EECAT_VU0F)
+			{
+				if (displayVU0FAsFloat)
+				{
+					char str[256];
+					const u128 val = cpu->getRegister(category, i);
+					// Use std::bit_cast in C++20. The below is technically UB
+					sprintf(str, "%7.2f %7.2f %7.2f %7.2f", *(float*)&val._u32[3], *(float*)&val._u32[2], *(float*)&val._u32[1], *(float*)&val._u32[0]);
+
+					dc.DrawText(wxString(str), x, y + 2);
+					break;
+				}
+			}
+			else
+			{
+				dc.DrawText(cpu->getRegisterString(category, i), x, y + 2);
+				break;
+			}
 		case DebugInterface::NORMAL:	// display them in 32 bit parts
 			switch (registerBits)
 			{
@@ -286,7 +339,7 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 					int startIndex = std::min<int>(3, maxBits / 32 - 1);
 
 					if (resolvePointerStrings && cpu->isAlive()) {
-						char *strval = cpu->stringFromPointer(value._u32[0]);
+						const char *strval = cpu->stringFromPointer(value._u32[0]);
 						if (strval) {
 							static wxColor clr = wxColor(0xFF228822);
 							dc.SetTextForeground(clr);
@@ -295,7 +348,7 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 						}
 					}
 
-					int actualX = width-4-(startIndex+1)*(8*charWidth+2);
+					const int actualX = width-4-(startIndex+1)*(8*charWidth+2);
 					x = std::max<int>(actualX,x);
 
 					if (startIndex != 3)
@@ -355,15 +408,6 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 				}
 			}
 			break;
-		case DebugInterface::SPECIAL:		// let debug interface format them and just display them
-			{
-				if (changed.changed[0] || changed.changed[1] || changed.changed[2] || changed.changed[3])
-					dc.SetTextForeground(colorChanged);
-				else
-					dc.SetTextForeground(colorUnchanged);
-
-				dc.DrawText(cpu->getRegisterString(category,i),x,y+2);
-				break;
 			}
 		}
 	}
@@ -441,6 +485,12 @@ void CtrlRegisterList::onPopupClick(wxCommandEvent& evt)
 		postEvent(debEVT_UPDATELAYOUT, 0);
 		Refresh();
 		break;
+	case ID_REGISTERLIST_DISPLAYVU0FFLOATS:
+		displayVU0FAsFloat = !displayVU0FAsFloat;
+		SetInitialSize(ClientToWindowSize(GetMinClientSize()));
+		postEvent(debEVT_UPDATELAYOUT, 0);
+		Refresh();
+		break;
 	case ID_REGISTERLIST_CHANGELOWER:
 		changeValue(LOWER64);
 		Refresh();
@@ -514,25 +564,48 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 
 	wxClientDC dc(this);
 	wxPoint pos = evt.GetPosition();
-	int x = dc.DeviceToLogicalX(pos.x) + xOffset;
-	int y = dc.DeviceToLogicalY(pos.y) + yOffset * rowHeight;
+	const int x = dc.DeviceToLogicalX(pos.x) + xOffset;
+	const int y = dc.DeviceToLogicalY(pos.y) + yOffset * rowHeight;
 
 	if (evt.GetEventType() == wxEVT_RIGHT_UP)
 	{
 		if (y >= rowHeight)
 		{
-			int row = (y-rowHeight)/rowHeight;
+			const int row = (y-rowHeight)/rowHeight;
 			if (row != currentRows[category] && row < cpu->getRegisterCount(category))
 				setCurrentRow(row);
 		}
 
 		wxMenu menu;
-		int bits = cpu->getRegisterSize(category);
+		const int bits = cpu->getRegisterSize(category);
 
-		menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY32,		L"Display 32 bit");
-		menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY64,		L"Display 64 bit");
-		menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY128,	L"Display 128 bit");
-		menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY128STRINGS,	L"Display 128 bit + Resolve string pointers");
+		if (!(category == EECAT_VU0F && displayVU0FAsFloat))
+		{
+			menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY32, L"Display 32 bit");
+			menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY64, L"Display 64 bit");
+			menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY128, L"Display 128 bit");
+			menu.AppendRadioItem(ID_REGISTERLIST_DISPLAY128STRINGS, L"Display 128 bit + Resolve string pointers");
+
+			switch (maxBits)
+			{
+			case 128:
+				if (resolvePointerStrings)
+					menu.Check(ID_REGISTERLIST_DISPLAY128STRINGS, true);
+				else
+					menu.Check(ID_REGISTERLIST_DISPLAY128, true);
+				break;
+			case 64:
+				menu.Check(ID_REGISTERLIST_DISPLAY64, true);
+				break;
+			case 32:
+				menu.Check(ID_REGISTERLIST_DISPLAY32, true);
+				break;
+			}
+		}
+
+		if (category == EECAT_VU0F)
+			menu.AppendCheckItem(ID_REGISTERLIST_DISPLAYVU0FFLOATS, L"Display VU0f registers as floats")->Check(displayVU0FAsFloat);
+
 		menu.AppendSeparator();
 
 		if (bits >= 64)
@@ -547,22 +620,6 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 		menu.Append(ID_REGISTERLIST_GOTOINMEMORYVIEW, L"Follow in Memory view");
 		menu.Append(ID_REGISTERLIST_GOTOINDISASM, L"Follow in Disasm");
 
-		switch (maxBits)
-		{
-		case 128:
-			if (resolvePointerStrings)
-				menu.Check(ID_REGISTERLIST_DISPLAY128STRINGS, true);
-			else
-				menu.Check(ID_REGISTERLIST_DISPLAY128,true);
-			break;
-		case 64:
-			menu.Check(ID_REGISTERLIST_DISPLAY64,true);
-			break;
-		case 32:
-			menu.Check(ID_REGISTERLIST_DISPLAY32,true);
-			break;
-		}
-
 		menu.Bind(wxEVT_MENU, &CtrlRegisterList::onPopupClick, this);
 		PopupMenu(&menu,evt.GetPosition());
 		return;
@@ -572,8 +629,8 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 	{
 		if (y < rowHeight)
 		{
-			int piece = GetSize().x/cpu->getRegisterCategoryCount();
-			int cat = std::min<int>(x/piece,cpu->getRegisterCategoryCount()-1);
+			const int piece = GetSize().x/cpu->getRegisterCategoryCount();
+			const int cat = std::min<int>(x/piece,cpu->getRegisterCategoryCount()-1);
 
 			if (cat != category)
 			{
@@ -581,7 +638,7 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 				Refresh();
 			}
 		} else {
-			int row = (y-rowHeight)/rowHeight;
+			const int row = (y - (rowHeight * 2) )/rowHeight;
 			if (row != currentRows[category] && row < cpu->getRegisterCount(category))
 				setCurrentRow(row);
 		}
@@ -595,7 +652,7 @@ void CtrlRegisterList::ensureVisible(int index) {
 	//scroll vertically to keep a logical position visible
 	int x, y;
 	GetViewStart(&x, &y);
-	int visibleOffset = floor(float(GetClientSize().y) / rowHeight) - 1;
+	const int visibleOffset = floor(float(GetClientSize().y) / rowHeight) - 1;
 	if (index < y)
 		Scroll(x, index);
 	else if (index > y + visibleOffset)

--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -67,7 +67,7 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 		int maxLen = 0;
 		for (int k = 0; k < cpu->getRegisterCount(i); k++)
 		{
-			maxLen = std::max<int>(maxLen, strlen(cpu->getRegisterName(i, k)));
+			maxLen = std::max<int>(maxLen, strlen(cpu->getRegisterName(i, k))); /* Flawfinder: ignore */
 		}
 
 		const int x = 17 + (maxLen + 2) * charWidth;
@@ -244,7 +244,7 @@ void CtrlRegisterList::OnDraw(wxDC& dc)
 			dc.DrawRectangle(x, 0, piece + 1, rowHeight);
 
 			// center text
-			x += (piece - strlen(name) * charWidth) / 2;
+			x += (piece - strlen(name) * charWidth) / 2; /* Flawfinder: ignore */
 			dc.DrawText(wxString(name, wxConvUTF8), x, 2);
 		}
 	}

--- a/pcsx2/gui/Debugger/CtrlRegisterList.h
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2014  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -74,4 +74,5 @@ private:
 	int category;
 	int maxBits;
 	bool resolvePointerStrings;
+	bool displayVU0FAsFloat;
 };

--- a/pcsx2/gui/Debugger/CtrlRegisterList.h
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.h
@@ -19,7 +19,7 @@
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/DisassemblyManager.h"
 
-class CtrlRegisterList: public wxScrolledWindow
+class CtrlRegisterList : public wxScrolledWindow
 {
 public:
 	CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu);
@@ -38,15 +38,21 @@ public:
 		if (GetWindowStyle() & wxVSCROLL)
 			optimalSize.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
 
-		return wxSize(optimalSize.x,0);
+		return wxSize(optimalSize.x, 0);
 	}
 
 	virtual wxSize DoGetBestClientSize() const
 	{
 		return GetMinClientSize();
 	}
+
 private:
-	enum RegisterChangeMode { LOWER64, UPPER64, CHANGE32 };
+	enum RegisterChangeMode
+	{
+		LOWER64,
+		UPPER64,
+		CHANGE32
+	};
 
 	void OnDraw(wxDC& dc);
 	void refreshChangedRegs();
@@ -69,7 +75,7 @@ private:
 	std::vector<int> currentRows;
 
 	DebugInterface* cpu;
-	int rowHeight,charWidth;
+	int rowHeight, charWidth;
 	u32 lastPc;
 	int category;
 	int maxBits;


### PR DESCRIPTION
### Description of Changes
Add an option to the VU0f context menu that allows you to toggle the float view
Add a title to the VU0f register list that identifies the registers w/z/y/x subsections

### Rationale behind Changes
Reading float values as hex sucks

### Suggested Testing Steps
Play around with the VU0f register section

### Screenshots
New VU0F hex view
![image](https://user-images.githubusercontent.com/29295048/127799982-2a755021-8646-4e5b-b0d6-c73b3a2e8709.png)

New VU0F float view
![image](https://user-images.githubusercontent.com/29295048/127800694-48a39787-6657-401a-90aa-bf849cc60a56.png)

Display as float context menu
![image](https://user-images.githubusercontent.com/29295048/127800812-aade041c-ec74-4e31-acb6-8058b4f83267.png)

Display as float context menu (when display as float is disabled)
![image](https://user-images.githubusercontent.com/29295048/127800059-0d480885-301a-48a9-87e8-a3fa1383f1f0.png)

Also supports 32 and 64 bit views!
32 bit
![image](https://user-images.githubusercontent.com/29295048/127800149-74288d16-9b9d-46cf-b94f-83f986d01537.png)
64 bit
![image](https://user-images.githubusercontent.com/29295048/127800158-bcf19410-0e42-4f7c-8a9e-c0528b8808c0.png)


## Notes:
Also, large floating point numbers are kind of weird.
If anyone has a solution (maybe using %g as the format specifier?) I couldn't get a good result however.

Closes #2779 


