### PR TITLE
AppMain: Fix no$ symbol loading for elfs

### DIFF
--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -1001,8 +1001,10 @@ protected:
 		symbolMap.Clear();
 		CBreakPoints::SetSkipFirst(BREAKPOINT_EE, 0);
 		CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, 0);
-
-		CDVDsys_SetFile(CDVD_SourceType::Iso, g_Conf->CurrentIso );
+		// This function below gets called again from AppCoreThread.cpp and will pass the current ISO regardless if we
+		// are starting an ELF. In terms of symbol loading this doesn't matter because AppCoreThread.cpp doesn't clear the symbol map
+		// and we _only_ read symbols if the map is empty
+		CDVDsys_SetFile(CDVD_SourceType::Iso, m_UseELFOverride ? m_elf_override : g_Conf->CurrentIso );
 		if( m_UseCDVDsrc )
 			CDVDsys_ChangeSource( m_cdvdsrc_type );
 		else if( CDVD == NULL )


### PR DESCRIPTION
### Description of Changes
Pass the ELF we are loading instead of whatever is in g_conf->CurrentIso if we are booting an ELF

### Rationale behind Changes
This prevented no$ .sym files from being loaded for elfs and instead it would look for ones for whatever is in g_conf->CurrentIso

### Suggested Testing Steps
Try loading no$ symbols from elfs and isos

### Notes
An easy format for a .sym file is
\<address> \<function name>
\<address> \<function name>

Name the .sym file <isoname>.sym or <elfname>.sym and have it in a folder _with the iso or elf_
MyShinyHomebrew.elf -> MyShinyHomebrew.sym
MyRippedGame.iso -> MyRippedGame.sym

