### PR TITLE
CDVD: Fix CdlReadS for PS1 games with CDDA.

### DIFF
--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -926,7 +926,7 @@ void cdrWrite1(u8 rt)
 			break;
 
 		case CdlReadS:
-			if (cdvd.Type == CDVD_TYPE_CDDA) // Taken from pcsxr
+			if (cdvd.Type == CDVD_TYPE_PSCDDA) // Taken from pcsxr
 				goto do_CdlPlay;
 			cdr.Irq = 0;
 			StopReading();


### PR DESCRIPTION
### Description of Changes
Fix mistake from https://github.com/PCSX2/pcsx2/pull/3899 , where path for PS1 games with CDDA was changed to real CD audio path. PR should affect only PS1 games.
### Rationale behind Changes
Fix Legend of Dragoon (PS1), combined with (#4642) fix Tenchu. Maybe more.

### Suggested Testing Steps
Testing PS1 games