### PR TITLE
CDVD: Implement SCMD 0x27

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1790,8 +1790,24 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				//		case 0x26: // cdvdman_call128 (0,3) - In V10 Bios
 				//			break;
 
-				//		case 0x27: // cdvdman_call148 (0:13) - In V10 Bios
-				//			break;
+			case 0x27: // GetPS1BootParam (0:13) - called only by China region PS2 models
+
+				// Return Disc Serial which is passed to PS1DRV and later used to find matching config.			
+				SetResultSize(13);
+				cdvd.Result[0] = 0;
+				cdvd.Result[1] = DiscSerial[0];
+				cdvd.Result[2] = DiscSerial[1];
+				cdvd.Result[3] = DiscSerial[2];
+				cdvd.Result[4] = DiscSerial[3];
+				cdvd.Result[5] = DiscSerial[4];
+				cdvd.Result[6] = DiscSerial[5];
+				cdvd.Result[7] = DiscSerial[6];
+				cdvd.Result[8] = DiscSerial[7];
+				cdvd.Result[9] = DiscSerial[9]; // Skipping dot here is required.
+				cdvd.Result[10] = DiscSerial[10];
+				cdvd.Result[11] = DiscSerial[11];
+				cdvd.Result[12] = DiscSerial[12];
+				break;
 
 				//		case 0x28: // cdvdman_call150 (1:1) - In V10 Bios
 				//			break;


### PR DESCRIPTION
### Description of Changes
Implement SCMD 0x27 to allow PS1 games to boot on SCPH-50009, and DTL-H50009 bios.
According to krat0s this command should return PS1 Disc Serial.
Disc Serial is later used by ps1drv itself to find matching game config. 

Note: While DTL consoles are known to use region free PS1 bios, SCPH-50009 use Asia/Japan PS1 bios, and region lock apply here.
### Rationale behind Changes
Fix PS1 mode for SCPH-50009, and DTL-H50009.

### Suggested Testing Steps
Launch PS1 game using BIOS dumped from SCPH-50009, or DTL-H50009.