### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/linux_various/PCSX2.desktop.in
+++ b/linux_various/PCSX2.desktop.in
@@ -3,6 +3,7 @@ Version=1.0
 Terminal=false
 Type=Application
 Name=PCSX2
+StartupWMClass=PCSX2
 GenericName=PlayStation 2 Emulator
 GenericName[zh_CN]=PlayStation 2 模拟器
 Comment=Sony PlayStation 2 emulator


### PR DESCRIPTION
### Description of Changes
In certain Linux desktop environments, in order to pin application to a task bar, presence of StartupWMClass= line is expected in .desktop file. (Reference: solus-project/budgie-desktop#750)

### Rationale behind Changes
This change allows pinning of PCSX2 application to Budgie Desktop Environment, but I think that having this is generally a good thing.

### Suggested Testing Steps
Use Linux Budgie Desktop and experiment with if pinning PCSX2 of possible in task bar. (task bar feature being called "Task List Applet")
