### PR TITLE
Misc: Fix lastpath updating when using the --elf cmdline arg

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -472,8 +472,24 @@ bool Pcsx2App::OnInit()
 		else if (Startup.SysAutoRunElf)
 		{
 			g_Conf->EmuOptions.UseBOOT2Injection = true;
-			g_Conf->Folders.RunELF = wxFileName(Startup.ElfFile).GetPath();
-			sApp.SysExecute(Startup.CdvdSource, Startup.ElfFile);
+
+			// wxPATH_NATIVE is broken on msw, it can delete the first directory after the volume
+			// EX: P://dir1/dir2/elf.elf -> P://dir2/ ???
+#ifdef _WIN32
+			wxFileName elfFile = wxFileName(Startup.ElfFile, wxPATH_WIN);
+#else
+			wxFileName elfFile = wxFileName(Startup.ElfFile, wxPATH_NATIVE);
+#endif
+
+			if (!elfFile.FileExists())
+			{
+				wxMessageBox(wxString::Format(_("Specified elf file %s does not exist!"), Startup.ElfFile), "PCSX2", wxICON_ERROR);
+			}
+			else
+			{
+				g_Conf->Folders.RunELF = elfFile.GetPath();
+				sApp.SysExecute(Startup.CdvdSource, Startup.ElfFile);
+			}
 		}
 		else if (Startup.SysAutoRunIrx)
 		{


### PR DESCRIPTION
### Description of Changes
There was a chance that doing `--elf="P://dir1/dir2/elf.elf"` would save the last path as `P://dir2/elf.elf`, completely voiding the functionality of #4444 
Also verify that an ELF file exists before trying to execute it.

### Rationale behind Changes
#4444 was no longer working in certain scenarios 
Currently, running an invalid ELF (one that doesn't exist for example) would put the emulator in a strange state with no immediate explanation for the user.

### Suggested Testing Steps
Run ELF files from the command line and see if opening an elf file via gui brings you to the directory specified in the command line.

Try running non-existent ELF files and verify that PCSX2 no longer breaks.

