### PR TITLE
GS-GUI: Add 7xMultiplier

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1525,9 +1525,10 @@ void GSApp::Init()
 	m_gs_upscale_multiplier.push_back(GSSetting(2, "2x Native", "~720p"));
 	m_gs_upscale_multiplier.push_back(GSSetting(3, "3x Native", "~1080p"));
 	m_gs_upscale_multiplier.push_back(GSSetting(4, "4x Native", "~1440p 2K"));
-	m_gs_upscale_multiplier.push_back(GSSetting(5, "5x Native", "~1620p 3K"));
+	m_gs_upscale_multiplier.push_back(GSSetting(5, "5x Native", "~1620p"));
 	m_gs_upscale_multiplier.push_back(GSSetting(6, "6x Native", "~2160p 4K"));
-	m_gs_upscale_multiplier.push_back(GSSetting(8, "8x Native", "~2880p 5K"));
+	m_gs_upscale_multiplier.push_back(GSSetting(7, "7x Native", "~2520p"));
+	m_gs_upscale_multiplier.push_back(GSSetting(8, "8x Native", "~2880p"));
 
 	m_gs_max_anisotropy.push_back(GSSetting(0, "Off", "Default"));
 	m_gs_max_anisotropy.push_back(GSSetting(2, "2x", ""));


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
7x was bullied for far too long (2520P / 4.5K resolution) is added for end-users.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Beyond 8x is debatable if there is a benefit or maximum framebuffer sizes that the API/PC/emulator can allow.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Open GS settings and change to 7x, then boot a game. Watching titlebar resolution or even the program log will help.
