### PR TITLE
Fix crashes in pad with libc++

### DIFF
--- a/pcsx2/PAD/Linux/Device.cpp
+++ b/pcsx2/PAD/Linux/Device.cpp
@@ -30,13 +30,13 @@ void Device::DoRumble(unsigned type, unsigned pad)
 {
 	int index = uid_to_index(pad);
 	if (index >= 0)
-		device_manager->devices[index]->Rumble(type, pad);
+		device_manager.devices[index]->Rumble(type, pad);
 }
 
 size_t Device::index_to_uid(int index)
 {
-	if ((index >= 0) && (index < (int)device_manager->devices.size()))
-		return device_manager->devices[index]->GetUniqueIdentifier();
+	if ((index >= 0) && (index < (int)device_manager.devices.size()))
+		return device_manager.devices[index]->GetUniqueIdentifier();
 	else
 		return 0;
 }
@@ -45,16 +45,16 @@ int Device::uid_to_index(int pad)
 {
 	size_t uid = g_conf.get_joy_uid(pad);
 
-	for (int i = 0; i < (int)device_manager->devices.size(); ++i)
+	for (int i = 0; i < (int)device_manager.devices.size(); ++i)
 	{
-		if (device_manager->devices[i]->GetUniqueIdentifier() == uid)
+		if (device_manager.devices[i]->GetUniqueIdentifier() == uid)
 			return i;
 	}
 
 	// Current uid wasn't found maybe the pad was unplugged. Or
 	// user didn't select it. Fallback to 1st pad for
 	// 1st player. And 2nd pad for 2nd player.
-	if ((int)device_manager->devices.size() > pad)
+	if ((int)device_manager.devices.size() > pad)
 		return pad;
 
 	return -1;

--- a/pcsx2/PAD/Linux/Global.h
+++ b/pcsx2/PAD/Linux/Global.h
@@ -69,32 +69,31 @@ enum gamePadValues
 };
 
 static const std::array<gamePadValues, MAX_KEYS> all_keys =
-	{
-		PAD_L2,       // L2 button
-		PAD_R2,       // R2 button
-		PAD_L1,       // L1 button
-		PAD_R1,       // R1 button
-		PAD_TRIANGLE, // Triangle button ▲
-		PAD_CIRCLE,   // Circle button ●
-		PAD_CROSS,    // Cross button ✖
-		PAD_SQUARE,   // Square button ■
-		PAD_SELECT,   // Select button
-		PAD_L3,       // Left joystick button (L3)
-		PAD_R3,       // Right joystick button (R3)
-		PAD_START,    // Start button
-		PAD_UP,       // Directional pad ↑
-		PAD_RIGHT,    // Directional pad →
-		PAD_DOWN,     // Directional pad ↓
-		PAD_LEFT,     // Directional pad ←
-		PAD_L_UP,     // Left joystick (Up) ↑
-		PAD_L_RIGHT,  // Left joystick (Right) →
-		PAD_L_DOWN,   // Left joystick (Down) ↓
-		PAD_L_LEFT,   // Left joystick (Left) ←
-		PAD_R_UP,     // Right joystick (Up) ↑
-		PAD_R_RIGHT,  // Right joystick (Right) →
-		PAD_R_DOWN,   // Right joystick (Down) ↓
-		PAD_R_LEFT    // Right joystick (Left) ←
-
+{
+	PAD_L2,       // L2 button
+	PAD_R2,       // R2 button
+	PAD_L1,       // L1 button
+	PAD_R1,       // R1 button
+	PAD_TRIANGLE, // Triangle button ▲
+	PAD_CIRCLE,   // Circle button ●
+	PAD_CROSS,    // Cross button ✖
+	PAD_SQUARE,   // Square button ■
+	PAD_SELECT,   // Select button
+	PAD_L3,       // Left joystick button (L3)
+	PAD_R3,       // Right joystick button (R3)
+	PAD_START,    // Start button
+	PAD_UP,       // Directional pad ↑
+	PAD_RIGHT,    // Directional pad →
+	PAD_DOWN,     // Directional pad ↓
+	PAD_LEFT,     // Directional pad ←
+	PAD_L_UP,     // Left joystick (Up) ↑
+	PAD_L_RIGHT,  // Left joystick (Right) →
+	PAD_L_DOWN,   // Left joystick (Down) ↓
+	PAD_L_LEFT,   // Left joystick (Left) ←
+	PAD_R_UP,     // Right joystick (Up) ↑
+	PAD_R_RIGHT,  // Right joystick (Right) →
+	PAD_R_DOWN,   // Right joystick (Down) ↓
+	PAD_R_LEFT    // Right joystick (Left) ←
 };
 
 static bool IsAnalogKey(int index)

--- a/pcsx2/PAD/Linux/InputManager.cpp
+++ b/pcsx2/PAD/Linux/InputManager.cpp
@@ -22,16 +22,7 @@
 #include "SDL/joystick.h"
 #endif
 
-std::unique_ptr<InputDeviceManager> device_manager(new InputDeviceManager);
-
-InputDeviceManager::InputDeviceManager()
-{
-}
-
-InputDeviceManager::~InputDeviceManager()
-{
-	device_manager->devices.clear();
-}
+InputDeviceManager device_manager;
 
 // Needs to be moved to individual device code, as does the keyboard input.
 void PollForJoystickInput(int cpad)
@@ -40,7 +31,7 @@ void PollForJoystickInput(int cpad)
 	if (index < 0)
 		return;
 
-	auto& gamePad = device_manager->devices[index];
+	auto& gamePad = device_manager.devices[index];
 
 	gamePad->UpdateDeviceState();
 
@@ -83,6 +74,6 @@ void InputDeviceManager::Update()
 void EnumerateDevices()
 {
 #ifdef SDL_BUILD
-	JoystickInfo::EnumerateJoysticks(device_manager->devices);
+	JoystickInfo::EnumerateJoysticks(device_manager.devices);
 #endif
 }

--- a/pcsx2/PAD/Linux/InputManager.h
+++ b/pcsx2/PAD/Linux/InputManager.h
@@ -23,14 +23,12 @@ class Device;
 class InputDeviceManager
 {
 public:
-	InputDeviceManager();
-	~InputDeviceManager();
 	void Update();
 
 	std::vector<std::unique_ptr<Device>> devices;
 };
 
-extern std::unique_ptr<InputDeviceManager> device_manager;
+extern InputDeviceManager device_manager;
 
 /*
  * Find every interesting device and create right structure for them(depends on backend)

--- a/pcsx2/PAD/Linux/linux.cpp
+++ b/pcsx2/PAD/Linux/linux.cpp
@@ -54,7 +54,7 @@ s32 _PADopen(void* pDsp)
 
 void _PADclose()
 {
-	device_manager->devices.clear();
+	device_manager.devices.clear();
 }
 
 void PADupdate(int pad)
@@ -74,7 +74,7 @@ void PADupdate(int pad)
 
 	// Actually PADupdate is always call with pad == 0. So you need to update both
 	// pads -- Gregory
-	device_manager->Update();
+	device_manager.Update();
 }
 
 void PADconfigure()

--- a/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/GamepadConfiguration.cpp
@@ -24,7 +24,7 @@ GamepadConfiguration::GamepadConfiguration(int pad, wxWindow* parent)
 	wxBoxSizer* gamepad_box = new wxBoxSizer(wxVERTICAL);
 
 	wxArrayString choices;
-	for (const auto& j : device_manager->devices)
+	for (const auto& j : device_manager.devices)
 	{
 		choices.Add(j->GetName());
 	}
@@ -72,7 +72,7 @@ void GamepadConfiguration::InitGamepadConfiguration()
 	 * if the pad id is 1, you need at least 2 gamepads connected,
 	 * Prevent to use a non-initialized value (core dump)
 	 */
-	if (device_manager->devices.size() >= m_pad_id + 1)
+	if (device_manager.devices.size() >= m_pad_id + 1)
 	{
 		/*
 		 * Determine if the device can use rumble
@@ -81,7 +81,7 @@ void GamepadConfiguration::InitGamepadConfiguration()
 		 */
 
 		// Bad idea. Some connected devices might support rumble but not all connected devices.
-		//        if (!device_manager->devices[m_pad_id]->TestForce(0.001f)) {
+		//        if (!device_manager.devices[m_pad_id]->TestForce(0.001f)) {
 		//            wxMessageBox(L"Rumble is not available for your device.");
 		//            m_cb_rumble->Disable();           // disable the rumble checkbox
 		//            m_sl_rumble_intensity->Disable(); // disable the rumble intensity slider
@@ -114,7 +114,7 @@ void GamepadConfiguration::OnSliderReleased(wxCommandEvent& event)
 
 		// convert in a float value between 0 and 1, and run rumble feedback.
 		// 0 to 1 scales to 0x0 to 0x7FFF
-		device_manager->devices[m_pad_id]->TestForce(m_sl_rumble_intensity->GetValue() / (float)0x7FFF);
+		device_manager.devices[m_pad_id]->TestForce(m_sl_rumble_intensity->GetValue() / (float)0x7FFF);
 	}
 	else if (sl_id == joy_slider_id)
 	{
@@ -135,7 +135,7 @@ void GamepadConfiguration::OnCheckboxChange(wxCommandEvent& event)
 		g_conf.pad_options[m_pad_id].forcefeedback = (m_cb_rumble->GetValue()) ? (u32)1 : (u32)0;
 		if (m_cb_rumble->GetValue())
 		{
-			device_manager->devices[m_pad_id]->TestForce();
+			device_manager.devices[m_pad_id]->TestForce();
 			m_sl_rumble_intensity->Enable();
 		}
 		else

--- a/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.cpp
+++ b/pcsx2/PAD/Linux/wx_dialog/JoystickConfiguration.cpp
@@ -64,9 +64,9 @@ void JoystickConfiguration::InitJoystickConfiguration()
 	 * if the pad id is 1, you need at least 2 gamepads connected,
 	 * Prevent using a non-initialized value (core dump)
 	 */
-	if (device_manager->devices.size() < m_pad_id + 1)
+	if (device_manager.devices.size() < m_pad_id + 1)
 	{
-		if (device_manager->devices.empty())
+		if (device_manager.devices.empty())
 			wxMessageBox(L"No gamepad detected.");
 		else
 			wxMessageBox(L"No second gamepad detected.");


### PR DESCRIPTION
### Description of Changes
Fixes crash on PAD shutdown when using libc++

### Rationale behind Changes
Crashes are not fun, even if they happen when the emulator is shutting down

### Suggested Testing Steps
Compile with libc++, and try to close the emulator
