### PR TITLE
iR5900: Use a signed multiply for MULT1 const prop

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
+++ b/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
@@ -254,9 +254,9 @@ EERECOMPILE_CODE0(MULTU, XMMINFO_READS|XMMINFO_READT|(_Rd_?XMMINFO_WRITED:0));
 ////////////////////////////////////////////////////
 void recMULT1_const()
 {
-	u64 res = (u64)g_cpuConstRegs[_Rs_].UL[0] * (u64)g_cpuConstRegs[_Rt_].UL[0];
+	s64 res = (s64)g_cpuConstRegs[_Rs_].SL[0] * (s64)g_cpuConstRegs[_Rt_].SL[0];
 
-	recWritebackConstHILO(res, 1, 1);
+	recWritebackConstHILO((u64)res, 1, 1);
 }
 
 void recMULT1_(int info)

--- a/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
+++ b/pcsx2/x86/ix86-32/iR5900MultDiv.cpp
@@ -159,7 +159,7 @@ void recWritebackConstHILO(u64 res, int writed, int upper)
 	}
 
 	if (!writed || !_Rd_) return;
-	g_cpuConstRegs[_Rd_].UD[0] = (s32)(res & 0xffffffff); //that is the difference
+	g_cpuConstRegs[_Rd_].SD[0] = (s32)(res & 0xffffffffULL); //that is the difference
 }
 
 //// MULT


### PR DESCRIPTION
### Description of Changes
MULT1 incorrectly uses an unsigned multiply when performing in-block constant propagation. This probably doesn't affect much, since it's unlikely that the inputs to the MULT1 will be constant anyway. The second commit makes it clearer that the assignment to the constant register is in fact sign extending.

### Rationale behind Changes
MULT1 incorrectly uses an unsigned multiply when performing in-block constant propagation.

### Suggested Testing Steps
Make sure games boot.
