### PR TITLE
Debugger: Purge 64 / 32 bit register view options

### DIFF
--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -76,7 +76,6 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 	}
 
 	SetDoubleBuffered(true);
-	SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 
 	const wxSize actualSize = getOptimalSize();
 	SetVirtualSize(actualSize);
@@ -467,34 +466,29 @@ void CtrlRegisterList::onPopupClick(wxCommandEvent& evt)
 		case ID_REGISTERLIST_DISPLAY32:
 			resolvePointerStrings = false;
 			maxBits = 32;
-			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 			postEvent(debEVT_UPDATELAYOUT, 0);
 			Refresh();
 			break;
 		case ID_REGISTERLIST_DISPLAY64:
 			resolvePointerStrings = false;
 			maxBits = 64;
-			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 			postEvent(debEVT_UPDATELAYOUT, 0);
 			Refresh();
 			break;
 		case ID_REGISTERLIST_DISPLAY128:
 			resolvePointerStrings = false;
 			maxBits = 128;
-			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 			postEvent(debEVT_UPDATELAYOUT, 0);
 			Refresh();
 			break;
 		case ID_REGISTERLIST_DISPLAY128STRINGS:
 			resolvePointerStrings = true;
 			maxBits = 128;
-			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 			postEvent(debEVT_UPDATELAYOUT, 0);
 			Refresh();
 			break;
 		case ID_REGISTERLIST_DISPLAYVU0FFLOATS:
 			displayVU0FAsFloat = !displayVU0FAsFloat;
-			SetInitialSize(ClientToWindowSize(GetMinClientSize()));
 			postEvent(debEVT_UPDATELAYOUT, 0);
 			Refresh();
 			break;
@@ -645,12 +639,6 @@ void CtrlRegisterList::mouseEvent(wxMouseEvent& evt)
 			if (cat != category)
 			{
 				category = cat;
-
-				// Requires the next two lines to check if we are rendering the vu0f category
-				// and if we need to make the window sized for 128 bits because we are displaying as float
-				SetInitialSize(ClientToWindowSize(GetMinClientSize()));
-				postEvent(debEVT_UPDATELAYOUT, 0);
-
 				Refresh();
 			}
 		}

--- a/pcsx2/gui/Debugger/CtrlRegisterList.h
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.h
@@ -78,7 +78,6 @@ private:
 	int rowHeight, charWidth;
 	u32 lastPc;
 	int category;
-	int maxBits;
 	bool resolvePointerStrings;
 	bool displayVU0FAsFloat;
 };


### PR DESCRIPTION
### Description of Changes
Remove the option to view > 32 bit registers as 32 bit or 64 bit and instead display the _entire_ register value

### Rationale behind Changes
There is no need to hide the upper bits of the registers, it also _greatly_ simplifies how the register list is drawn (or sized to be specific)

### Suggested Testing Steps
Launch a game, go to the debugger, and within the register view, play around with the categories, enabling and disabling resolving of string pointers and displaying VU0F registers as floats.
