### PR TITLE
Remove gui/ directory from target-wide includes

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -15,7 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "IopCommon.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include <memory>
 #include <ctype.h>

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -34,7 +34,7 @@
 #include "CDVDisoReader.h"
 
 #include "DebugTools/SymbolMap.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 CDVD_API* CDVD = NULL;
 

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "CDVDdiscReader.h"
 
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include <condition_variable>
 

--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 #include <fstream>
 #include <wx/stdpaths.h>
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "ChunksCache.h"
 #include "CompressedFileReaderUtils.h"
 #include "GzippedFileReader.h"

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1515,9 +1515,8 @@ endforeach()
 # additonal include directories
 target_include_directories(PCSX2 PRIVATE
 	.
-	gui
 	x86
-	${CMAKE_BINARY_DIR}/pcsx2/gui
+	${CMAKE_BINARY_DIR}/pcsx2
 	${CMAKE_BINARY_DIR}/common/include/
 	"${CMAKE_SOURCE_DIR}/3rdparty/jpgd/"
 	"${CMAKE_SOURCE_DIR}/3rdparty/xbyak/"

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -19,7 +19,7 @@
 #include <time.h>
 #include <cmath>
 
-#include "App.h"
+#include "gui/App.h"
 #include "Common.h"
 #include "R3000A.h"
 #include "Counters.h"

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "MemoryTypes.h"
+
 struct EECNT_MODE
 {
 	// 0 - BUSCLK

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -36,7 +36,7 @@
 #include "DEV9.h"
 #undef EXTERN
 #include "Config.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "smap.h"
 
 

--- a/pcsx2/DEV9/Linux/Config.cpp
+++ b/pcsx2/DEV9/Linux/Config.cpp
@@ -19,7 +19,7 @@
 #include <arpa/inet.h>
 
 #include "DEV9/DEV9.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include <unistd.h>
 #include <sys/types.h>

--- a/pcsx2/DEV9/Linux/Linux.cpp
+++ b/pcsx2/DEV9/Linux/Linux.cpp
@@ -36,7 +36,7 @@
 #include "DEV9/pcap_io.h"
 #include "DEV9/net.h"
 #include "DEV9/PacketReader/IP/IP_Address.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 
 #include "DEV9/ATA/HddCreate.h"
 

--- a/pcsx2/DEV9/Win32/DEV9WinConfig.cpp
+++ b/pcsx2/DEV9/Win32/DEV9WinConfig.cpp
@@ -19,8 +19,8 @@
 
 #include <fstream>
 
-#include "..\DEV9.h"
-#include "AppConfig.h"
+#include "DEV9/DEV9.h"
+#include "gui/AppConfig.h"
 
 #include "ws2tcpip.h"
 

--- a/pcsx2/DEV9/Win32/Win32.cpp
+++ b/pcsx2/DEV9/Win32/Win32.cpp
@@ -29,7 +29,7 @@
 #include "DEV9/net.h"
 #include "DEV9/PacketReader\IP\IP_Address.h"
 #include "tap.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 
 #include "DEV9/ATA/HddCreate.h"
 

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -408,8 +408,8 @@ const std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
 }
 
 // including them earlier causes some ambiguities
-#include "App.h"
-#include "Debugger/DisassemblyDialog.h"
+#include "gui/App.h"
+#include "gui/Debugger/DisassemblyDialog.h"
 
 void CBreakPoints::Update(BreakPointCpu cpu, u32 addr)
 {

--- a/pcsx2/DebugTools/Debug.h
+++ b/pcsx2/DebugTools/Debug.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "common/TraceLog.h"
+#include "Config.h"
 #include "Memory.h"
 
 extern FILE *emuLog;

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -18,7 +18,7 @@
 #include "DebugInterface.h"
 #include "Memory.h"
 #include "R5900.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 #include "Debug.h"
 #include "VU.h"
 #include "GS.h" // Required for gsNonMirroredRead()

--- a/pcsx2/Dump.cpp
+++ b/pcsx2/Dump.cpp
@@ -22,7 +22,7 @@
 #include "IPU/IPU.h"
 #include "DebugTools/SymbolMap.h"
 
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "Utilities/AsciiFile.h"
 
 using namespace R5900;

--- a/pcsx2/Elfheader.cpp
+++ b/pcsx2/Elfheader.cpp
@@ -19,7 +19,7 @@
 #include "GS.h"			// for sending game crc to mtgs
 #include "Elfheader.h"
 #include "DebugTools/SymbolMap.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 
 u32 ElfCRC;
 u32 ElfEntry;

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -21,7 +21,7 @@
 #include "GS.h"
 #include "Gif_Unit.h"
 #include "Counters.h"
-#include "GSFrame.h"
+#include "gui/GSFrame.h"
 
 using namespace Threading;
 using namespace R5900;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -23,7 +23,7 @@
 #include "Renderers/OpenGL/GSRendererOGL.h"
 #include "GSLzma.h"
 
-#include "gui/AppCoreThread.h"
+#include "gui/AppConfig.h"    // GetSettingsFolder()
 #include "common/pxStreams.h"
 
 #ifdef _WIN32

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -23,7 +23,7 @@
 #include "Renderers/OpenGL/GSRendererOGL.h"
 #include "GSLzma.h"
 
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 #include "common/pxStreams.h"
 
 #ifdef _WIN32

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -26,8 +26,6 @@
 #include "SPU2/spu2.h"
 #include "R3000A.h"
 
-#include "ConsoleLogger.h"
-
 using namespace R5900;
 
 // Shift the middle 8 bits (bits 4-12) into the lower 8 bits.

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -22,7 +22,7 @@
 #include "mpeg2lib/Mpeg.h"
 
 #include <limits.h>
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include "common/MemsetFast.inl"
 

--- a/pcsx2/Linux/LnxConsolePipe.cpp
+++ b/pcsx2/Linux/LnxConsolePipe.cpp
@@ -15,8 +15,8 @@
 
 #include "PrecompiledHeader.h"
 
-#include "App.h"
-#include "ConsoleLogger.h"
+#include "gui/App.h"
+#include "gui/ConsoleLogger.h"
 #include <unistd.h>
 
 using namespace Threading;

--- a/pcsx2/Linux/LnxKeyCodes.cpp
+++ b/pcsx2/Linux/LnxKeyCodes.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "ConsoleLogger.h"
+#include "gui/ConsoleLogger.h"
 
 #include <gdk/gdkkeysyms.h>
 

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -23,7 +23,6 @@
 #include "Gif_Unit.h"
 #include "MTVU.h"
 #include "Elfheader.h"
-#include "App.h"
 #include "gui/Dialogs/ModalPopups.h"
 #ifdef _WIN32
 #include "PAD/Windows/PAD.h"

--- a/pcsx2/PAD/Linux/Config.cpp
+++ b/pcsx2/PAD/Linux/Config.cpp
@@ -13,10 +13,10 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "gui/AppConfig.h"
 #include "Global.h"
 #include "Device.h"
 #include "keyboard.h"
-#include "AppConfig.h"
 #ifdef __APPLE__
 #include <Carbon/Carbon.h>
 #endif

--- a/pcsx2/PAD/Linux/Global.h
+++ b/pcsx2/PAD/Linux/Global.h
@@ -30,8 +30,8 @@
 
 #include "common/pxStreams.h"
 #include "common/Console.h"
-#include "App.h"
 #include "DebugTools/Debug.h"
+#include "gui/App.h"
 
 #define PADdefs
 

--- a/pcsx2/PAD/Linux/keyboard.h
+++ b/pcsx2/PAD/Linux/keyboard.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "common/Pcsx2Defs.h"
-#include "App.h"
+#include "gui/App.h"
 
 #if defined(__unix__) || defined(__APPLE__)
 

--- a/pcsx2/PAD/Linux/linux.cpp
+++ b/pcsx2/PAD/Linux/linux.cpp
@@ -13,8 +13,8 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "gui/AppCoreThread.h"
 #include "Global.h"
-#include "AppCoreThread.h"
 #include "Device.h"
 #include "keyboard.h"
 #include "state_management.h"

--- a/pcsx2/PAD/Windows/PAD.h
+++ b/pcsx2/PAD/Windows/PAD.h
@@ -33,7 +33,7 @@
 #include <mutex>
 #include <queue>
 
-#include "App.h"
+#include "gui/App.h"
 #include "SaveState.h"
 
 typedef struct

--- a/pcsx2/PAD/Windows/PADConfig.cpp
+++ b/pcsx2/PAD/Windows/PADConfig.cpp
@@ -30,7 +30,7 @@
 
 // Needed to know if raw input is available.  It requires XP or higher.
 #include "PADRawInput.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 //max len 24 wchar_t
 const wchar_t* padTypes[] = {

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -37,7 +37,7 @@
 
 #include "common/Pcsx2Defs.h"
 #include "SysForwardDefs.h"
-#include "AppGameDatabase.h"
+#include "gui/AppGameDatabase.h"
 
 enum patch_cpu_type {
 	NO_CPU,

--- a/pcsx2/PrecompiledHeader.h
+++ b/pcsx2/PrecompiledHeader.h
@@ -68,7 +68,7 @@
 // need a full recompile anyway, when modified (etc)
 
 #include "common/Pcsx2Defs.h"
-#include "i18n.h"
+#include "gui/i18n.h"
 
 #include "common/wxBaseTools.h"
 #include "common/Path.h"

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -16,7 +16,7 @@
 
 #include "PrecompiledHeader.h"
 #include "IopCommon.h"
-#include "App.h" // For host irx injection hack
+#include "gui/App.h" // For host irx injection hack
 
 #include "R5900OpcodeTables.h"
 #include "DebugTools/Breakpoints.h"

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -15,17 +15,19 @@
 
 #include "PrecompiledHeader.h"
 
-#include "AppSaveStates.h"
+#include "gui/AppSaveStates.h"
 #include "Counters.h"
 
 #ifndef DISABLE_RECORDING
 
-#include "AppGameDatabase.h"
+#include "gui/AppGameDatabase.h"
 #include "DebugTools/Debug.h"
 
 #include "InputRecording.h"
 #include "InputRecordingControls.h"
 #include "Utilities/InputRecordingLogger.h"
+
+#include <fmt/format.h>
 
 #endif
 

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -17,11 +17,11 @@
 
 #ifndef DISABLE_RECORDING
 
-#include "App.h"
 #include "Counters.h"
 #include "DebugTools/Debug.h"
-#include "MainFrame.h"
 #include "MemoryTypes.h"
+#include "gui/App.h"
+#include "gui/MainFrame.h"
 
 #include "InputRecording.h"
 #include "InputRecordingControls.h"

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -18,11 +18,13 @@
 #ifndef DISABLE_RECORDING
 
 #include "DebugTools/Debug.h"
-#include "MainFrame.h"
+#include "gui/MainFrame.h"
 #include "MemoryTypes.h"
 
 #include "InputRecordingFile.h"
 #include "Utilities/InputRecordingLogger.h"
+
+#include <fmt/format.h>
 
 void InputRecordingFileHeader::Init()
 {

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.cpp
@@ -17,6 +17,14 @@
 
 #include "InputRecordingLogger.h"
 
+#include "DebugTools/Debug.h"
+#include "common/Console.h"
+#include "GS.h"				// GSosdlog
+#include "gui/App.h"	// GetRGBA
+#include "gui/ConsoleLogger.h"
+
+#include <fmt/core.h>
+
 namespace inputRec
 {
 	void log(const std::string& log)

--- a/pcsx2/Recording/Utilities/InputRecordingLogger.h
+++ b/pcsx2/Recording/Utilities/InputRecordingLogger.h
@@ -15,13 +15,6 @@
 
 #pragma once
 
-#include "App.h"
-#include "ConsoleLogger.h"
-#include "DebugTools/Debug.h"
-#include "common/Console.h"
-
-#include <fmt/core.h>
-
 #include <memory>
 #include <string>
 #include <vector>

--- a/pcsx2/Recording/VirtualPad/VirtualPad.cpp
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.cpp
@@ -19,8 +19,8 @@
 
 #include <math.h>
 
-#include "App.h"
-#include "MSWstuff.h"
+#include "gui/App.h"
+#include "gui/MSWstuff.h"
 #include "common/EmbeddedImage.h"
 #include "wx/dcbuffer.h"
 #include "wx/display.h"

--- a/pcsx2/Recording/VirtualPad/VirtualPad.h
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.h
@@ -20,7 +20,7 @@
 #include <map>
 #include <queue>
 
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "common/Pcsx2Types.h"
 
 #include "wx/checkbox.h"

--- a/pcsx2/SPU2/Linux/CfgHelpers.cpp
+++ b/pcsx2/SPU2/Linux/CfgHelpers.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "Dialogs.h"
 #include <wx/fileconf.h>
 

--- a/pcsx2/SPU2/Windows/CfgHelpers.cpp
+++ b/pcsx2/SPU2/Windows/CfgHelpers.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "SPU2/Global.h"
 #include "Dialogs.h"
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -25,7 +25,7 @@
 #endif
 #include "R3000A.h"
 #include "common/pxStreams.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 
 using namespace Threading;
 

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -23,7 +23,7 @@
 #include "VUmicro.h"
 #include "MTVU.h"
 #include "Cache.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include "Elfheader.h"
 #include "Counters.h"

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -17,7 +17,6 @@
 #include "IopCommon.h"
 
 #include "Common.h"
-#include "ConsoleLogger.h"
 #include "Sio.h"
 #include "sio_internal.h"
 #ifdef _WIN32

--- a/pcsx2/Sio.h
+++ b/pcsx2/Sio.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "MemoryCardFile.h"
+#include "gui/MemoryCardFile.h"
 
 struct _mcd
 {

--- a/pcsx2/USB/Win32/Config_usb.cpp
+++ b/pcsx2/USB/Win32/Config_usb.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 #include "USB/USB.h"
 #include "resource_usb.h"
 #include "Config_usb.h"

--- a/pcsx2/USB/configuration.cpp
+++ b/pcsx2/USB/configuration.cpp
@@ -18,7 +18,7 @@
 #include "configuration.h"
 #include "shared/inifile_usb.h"
 #include "platcompat.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include <map>
 #include <vector>
 

--- a/pcsx2/USB/linux/config-gtk.cpp
+++ b/pcsx2/USB/linux/config-gtk.cpp
@@ -20,7 +20,7 @@
 #include <map>
 #include <vector>
 #include <string>
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 #include "USB/gtk.h"
 
 #include "USB/configuration.h"

--- a/pcsx2/ZipTools/thread_gzip.cpp
+++ b/pcsx2/ZipTools/thread_gzip.cpp
@@ -15,7 +15,7 @@
 
 #include "PrecompiledHeader.h"
 
-#include "App.h"
+#include "gui/App.h"
 #include "SaveState.h"
 #include "ThreadedZipTools.h"
 #include "common/SafeArray.inl"

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -21,8 +21,6 @@
 #include <wx/stdpaths.h>
 #include "fmt/core.h"
 
-#include "Debugger/DisassemblyDialog.h"
-
 #include "common/Threading.h"
 
 #include "ps2/BiosTools.h"

--- a/pcsx2/gui/AppRes.cpp
+++ b/pcsx2/gui/AppRes.cpp
@@ -25,19 +25,19 @@
 #include "MSWstuff.h"
 
 #include "common/EmbeddedImage.h"
-#include "Resources/BackgroundLogo.h"
-#include "Resources/ButtonIcon_Camera.h"
+#include "gui/Resources/BackgroundLogo.h"
+#include "gui/Resources/ButtonIcon_Camera.h"
 
-#include "Resources/ConfigIcon_Cpu.h"
-#include "Resources/ConfigIcon_Video.h"
-#include "Resources/ConfigIcon_Speedhacks.h"
-#include "Resources/ConfigIcon_Gamefixes.h"
-#include "Resources/ConfigIcon_Paths.h"
-#include "Resources/ConfigIcon_MemoryCard.h"
+#include "gui/Resources/ConfigIcon_Cpu.h"
+#include "gui/Resources/ConfigIcon_Video.h"
+#include "gui/Resources/ConfigIcon_Speedhacks.h"
+#include "gui/Resources/ConfigIcon_Gamefixes.h"
+#include "gui/Resources/ConfigIcon_Paths.h"
+#include "gui/Resources/ConfigIcon_MemoryCard.h"
 
-#include "Resources/AppIcon16.h"
-#include "Resources/AppIcon32.h"
-#include "Resources/AppIcon64.h"
+#include "gui/Resources/AppIcon16.h"
+#include "gui/Resources/AppIcon32.h"
+#include "gui/Resources/AppIcon64.h"
 
 RecentIsoList::RecentIsoList(int firstIdForMenuItems_or_wxID_ANY)
 {

--- a/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
+++ b/pcsx2/gui/Debugger/CtrlDisassemblyView.cpp
@@ -21,7 +21,7 @@
 
 #include "DebugEvents.h"
 #include "BreakpointWindow.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "System.h"
 #include "DisassemblyDialog.h"
 
@@ -29,8 +29,8 @@
 #include <wx/clipbrd.h>
 #include <wx/file.h>
 
-#include "Resources/Breakpoint_Active.h"
-#include "Resources/Breakpoint_Inactive.h"
+#include "gui/Resources/Breakpoint_Active.h"
+#include "gui/Resources/Breakpoint_Inactive.h"
 
 wxBEGIN_EVENT_TABLE(CtrlDisassemblyView, wxWindow)
 	EVT_PAINT(CtrlDisassemblyView::paintEvent)

--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "CtrlMemView.h"
 #include "DebugTools/Debug.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include "BreakpointWindow.h"
 #include "DebugEvents.h"

--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -18,7 +18,7 @@
 #include "DebugTools/Debug.h"
 
 #include "DebugEvents.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "DisassemblyDialog.h"
 
 wxBEGIN_EVENT_TABLE(CtrlRegisterList, wxWindow)

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -15,8 +15,8 @@
 
 #include "PrecompiledHeader.h"
 
-#include "App.h"
-#include "MainFrame.h"
+#include "gui/App.h"
+#include "gui/MainFrame.h"
 #include "DisassemblyDialog.h"
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/DisassemblyManager.h"

--- a/pcsx2/gui/Debugger/DisassemblyDialog.h
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.h
@@ -16,7 +16,7 @@
 #pragma once
 #include <wx/wx.h>
 #include <wx/notebook.h>
-#include "App.h"
+#include "gui/App.h"
 
 #include "CtrlDisassemblyView.h"
 #include "CtrlRegisterList.h"

--- a/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
+++ b/pcsx2/gui/Dialogs/AboutBoxDialog.cpp
@@ -14,14 +14,14 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
-#include "AppCommon.h"
-#include "MSWstuff.h"
+#include "gui/App.h"
+#include "gui/AppCommon.h"
+#include "gui/MSWstuff.h"
 
-#include "Dialogs/ModalPopups.h"
+#include "gui/Dialogs/ModalPopups.h"
 
 #include "common/EmbeddedImage.h"
-#include "Resources/Logo.h"
+#include "gui/Resources/Logo.h"
 
 #include <wx/mstream.h>
 #include <wx/hyperlink.h>

--- a/pcsx2/gui/Dialogs/AssertionDialog.cpp
+++ b/pcsx2/gui/Dialogs/AssertionDialog.cpp
@@ -14,9 +14,9 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
+#include "gui/App.h"
 #include "ModalPopups.h"
-#include "MSWstuff.h"
+#include "gui/MSWstuff.h"
 
 using namespace pxSizerFlags;
 

--- a/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
+++ b/pcsx2/gui/Dialogs/BaseConfigurationDialog.cpp
@@ -15,12 +15,12 @@
 
 #include "PrecompiledHeader.h"
 #include "System.h"
-#include "App.h"
-#include "MSWstuff.h"
+#include "gui/App.h"
+#include "gui/MSWstuff.h"
 
 #include "ConfigurationDialog.h"
 #include "ModalPopups.h"
-#include "Panels/ConfigurationPanels.h"
+#include "gui/Panels/ConfigurationPanels.h"
 
 #include <wx/artprov.h>
 #include <wx/filepicker.h>

--- a/pcsx2/gui/Dialogs/ConfigurationDialog.h
+++ b/pcsx2/gui/Dialogs/ConfigurationDialog.h
@@ -18,9 +18,9 @@
 #include <wx/wx.h>
 #include <wx/propdlg.h>
 
-#include "AppCommon.h"
-#include "ApplyState.h"
-#include "App.h"
+#include "gui/AppCommon.h"
+#include "gui/ApplyState.h"
+#include "gui/App.h"
 
 namespace Panels
 {

--- a/pcsx2/gui/Dialogs/ConfirmationDialogs.cpp
+++ b/pcsx2/gui/Dialogs/ConfirmationDialogs.cpp
@@ -15,8 +15,8 @@
 
 #include "PrecompiledHeader.h"
 #include "System.h"
-#include "App.h"
-#include "MSWstuff.h"
+#include "gui/App.h"
+#include "gui/MSWstuff.h"
 
 #include "ModalPopups.h"
 #include "common/StringHelpers.h"

--- a/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
@@ -17,10 +17,10 @@
 #include "ConfigurationDialog.h"
 #include "System.h"
 
-#include "MSWstuff.h"
+#include "gui/MSWstuff.h"
 
-#include "MemoryCardFile.h"
-#include "MemoryCardFolder.h"
+#include "gui/MemoryCardFile.h"
+#include "gui/MemoryCardFolder.h"
 #include <wx/ffile.h>
 
 enum MemoryCardConversionType {

--- a/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/CreateMemoryCardDialog.cpp
@@ -16,9 +16,9 @@
 #include "PrecompiledHeader.h"
 #include "ConfigurationDialog.h"
 #include "System.h"
-#include "MSWstuff.h"
+#include "gui/MSWstuff.h"
 
-#include "MemoryCardFile.h"
+#include "gui/MemoryCardFile.h"
 //#include <wx/filepicker.h>
 #include <wx/ffile.h>
 

--- a/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
+++ b/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
@@ -15,10 +15,10 @@
 
 #include "PrecompiledHeader.h"
 #include "System.h"
-#include "MSWstuff.h"
+#include "gui/MSWstuff.h"
 
 #include "ModalPopups.h"
-#include "Panels/ConfigurationPanels.h"
+#include "gui/Panels/ConfigurationPanels.h"
 #include <wx/file.h>
 #include <wx/filepicker.h>
 #include <wx/hyperlink.h>

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -14,20 +14,20 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
-#include "AppCommon.h"
-#include "MSWstuff.h"
+#include "gui/App.h"
+#include "gui/AppCommon.h"
+#include "gui/MSWstuff.h"
 
-#include "Dialogs/ModalPopups.h"
+#include "gui/Dialogs/ModalPopups.h"
 
 
 #include "common/EmbeddedImage.h"
-#include "Resources/NoIcon.h"
+#include "gui/Resources/NoIcon.h"
 #include "GS.h"
 
 #include "PathDefs.h"
-#include "AppConfig.h"
-#include "GSFrame.h"
+#include "gui/AppConfig.h"
+#include "gui/GSFrame.h"
 #include "Counters.h"
 
 #include <wx/mstream.h>

--- a/pcsx2/gui/Dialogs/IPCDialog.cpp
+++ b/pcsx2/gui/Dialogs/IPCDialog.cpp
@@ -14,16 +14,16 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
-#include "AppCommon.h"
-#include "MSWstuff.h"
+#include "gui/App.h"
+#include "gui/AppCommon.h"
+#include "gui/MSWstuff.h"
 
-#include "Dialogs/ModalPopups.h"
+#include "gui/Dialogs/ModalPopups.h"
 
 #include "System/SysThreads.h"
 
 #include "PathDefs.h"
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 using namespace pxSizerFlags;
 /* This dialog currently assumes the IPC server is started when launching a

--- a/pcsx2/gui/Dialogs/ImportSettingsDialog.cpp
+++ b/pcsx2/gui/Dialogs/ImportSettingsDialog.cpp
@@ -15,7 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "System.h"
-#include "MSWstuff.h"
+#include "gui/MSWstuff.h"
 
 #include "ModalPopups.h"
 

--- a/pcsx2/gui/Dialogs/LogOptionsDialog.cpp
+++ b/pcsx2/gui/Dialogs/LogOptionsDialog.cpp
@@ -15,7 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "LogOptionsDialog.h"
-#include "Panels/LogOptionsPanels.h"
+#include "gui/Panels/LogOptionsPanels.h"
 
 #include <wx/statline.h>
 

--- a/pcsx2/gui/Dialogs/LogOptionsDialog.h
+++ b/pcsx2/gui/Dialogs/LogOptionsDialog.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "App.h"
+#include "gui/App.h"
 #include "ConfigurationDialog.h"
 
 #include "common/wxGuiTools.h"

--- a/pcsx2/gui/Dialogs/McdConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/McdConfigDialog.cpp
@@ -18,10 +18,10 @@
 #include "ConfigurationDialog.h"
 #include "BaseConfigurationDialog.inl"
 #include "ModalPopups.h"
-#include "MSWstuff.h"
+#include "gui/MSWstuff.h"
 
-#include "Panels/ConfigurationPanels.h"
-#include "Panels/MemoryCardPanels.h"
+#include "gui/Panels/ConfigurationPanels.h"
+#include "gui/Panels/MemoryCardPanels.h"
 
 using namespace pxSizerFlags;
 

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include "App.h"
+#include "gui/App.h"
 #include "ConfigurationDialog.h"
-#include "Panels/ConfigurationPanels.h"
+#include "gui/Panels/ConfigurationPanels.h"
 #include "common/pxStreams.h"
 
 #include <wx/wizard.h>

--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -15,13 +15,13 @@
 
 #include "PrecompiledHeader.h"
 #include "System.h"
-#include "App.h"
+#include "gui/App.h"
 
 #include "ConfigurationDialog.h"
 #include "BaseConfigurationDialog.inl"
 #include "ModalPopups.h"
-#include "Panels/ConfigurationPanels.h"
-#include "MainFrame.h"
+#include "gui/Panels/ConfigurationPanels.h"
+#include "gui/MainFrame.h"
 
 using namespace Panels;
 using namespace pxSizerFlags;

--- a/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
+++ b/pcsx2/gui/Panels/BaseApplicableConfigPanel.cpp
@@ -14,10 +14,10 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
+#include "gui/App.h"
 
 #include "ConfigurationPanels.h"
-#include "Dialogs/ConfigurationDialog.h"
+#include "gui/Dialogs/ConfigurationDialog.h"
 
 #include <wx/bookctrl.h>
 

--- a/pcsx2/gui/Panels/BiosSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/BiosSelectorPanel.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
+#include "gui/App.h"
 #include "ConfigurationPanels.h"
 
 #include "ps2/BiosTools.h"

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -25,8 +25,8 @@
 #include <wx/dnd.h>
 #include <memory>
 
-#include "AppCommon.h"
-#include "ApplyState.h"
+#include "gui/AppCommon.h"
+#include "gui/ApplyState.h"
 
 
 namespace Panels

--- a/pcsx2/gui/Panels/DirPickerPanel.cpp
+++ b/pcsx2/gui/Panels/DirPickerPanel.cpp
@@ -15,7 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "ConfigurationPanels.h"
-#include "Dialogs/ModalPopups.h"
+#include "gui/Dialogs/ModalPopups.h"
 
 #include <wx/stdpaths.h>
 #include <wx/file.h>

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -17,8 +17,8 @@
 #include "ConfigurationPanels.h"
 
 #include "fmt/core.h"
-#include "App.h"
-#include "AppAccelerators.h"
+#include "gui/App.h"
+#include "gui/AppAccelerators.h"
 
 using namespace pxSizerFlags;
 

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
+#include "gui/App.h"
 #include "ConfigurationPanels.h"
 
 using namespace pxSizerFlags;

--- a/pcsx2/gui/Panels/LogOptionsPanels.h
+++ b/pcsx2/gui/Panels/LogOptionsPanels.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include "AppCommon.h"
-#include "ApplyState.h"
+#include "gui/AppCommon.h"
+#include "gui/ApplyState.h"
 #include <memory>
 
 namespace Panels

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -14,14 +14,14 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "AppCoreThread.h"
+#include "gui/AppCoreThread.h"
 #include "System.h"
-#include "MemoryCardFile.h"
+#include "gui/MemoryCardFile.h"
 
 #include "ConfigurationPanels.h"
 #include "MemoryCardPanels.h"
 
-#include "Dialogs/ConfigurationDialog.h"
+#include "gui/Dialogs/ConfigurationDialog.h"
 #include "common/IniInterface.h"
 #include "Sio.h"
 

--- a/pcsx2/gui/Panels/MemoryCardListView.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListView.cpp
@@ -17,7 +17,7 @@
 #include "ConfigurationPanels.h"
 #include "MemoryCardPanels.h"
 
-#include "Dialogs/ConfigurationDialog.h"
+#include "gui/Dialogs/ConfigurationDialog.h"
 
 #include "common/IniInterface.h"
 

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "AppCommon.h"
+#include "gui/AppCommon.h"
 
 #include <wx/dnd.h>
 #include <wx/listctrl.h>

--- a/pcsx2/gui/Panels/MiscPanelStuff.cpp
+++ b/pcsx2/gui/Panels/MiscPanelStuff.cpp
@@ -14,10 +14,10 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
+#include "gui/App.h"
 #include "ConfigurationPanels.h"
 
-#include "Dialogs/ConfigurationDialog.h"
+#include "gui/Dialogs/ConfigurationDialog.h"
 
 #include "ps2/BiosTools.h"
 

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
+#include "gui/App.h"
 #include "ConfigurationPanels.h"
 
 using namespace pxSizerFlags;

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -14,9 +14,9 @@
  */
 
 #include "PrecompiledHeader.h"
-#include "App.h"
-#include "AppAccelerators.h"
-#include "Dialogs/ConfigurationDialog.h"
+#include "gui/App.h"
+#include "gui/AppAccelerators.h"
+#include "gui/Dialogs/ConfigurationDialog.h"
 #include "ConfigurationPanels.h"
 
 #include <wx/spinctrl.h>

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -34,7 +34,6 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\gui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\xbyak;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\freetype\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\xz\xz\src\liblzma\api;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -22,7 +22,7 @@
 
 
 // FIXME: Temporary hack until we remove dependence on Pcsx2App.
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 #include "wx/mstream.h"
 #include "wx/wfstream.h"
 

--- a/pcsx2/windows/WinConsolePipe.cpp
+++ b/pcsx2/windows/WinConsolePipe.cpp
@@ -16,8 +16,8 @@
 #include "PrecompiledHeader.h"
 #include "Win32.h"
 
-#include "App.h"
-#include "ConsoleLogger.h"
+#include "gui/App.h"
+#include "gui/ConsoleLogger.h"
 
 // --------------------------------------------------------------------------------------
 //  Win32 Console Pipes

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -35,7 +35,7 @@
 #include "IopCommon.h"
 #include "iCore.h"
 
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 #include "common/Perf.h"
 #include "DebugTools/Breakpoints.h"

--- a/pcsx2/x86/microVU_Log.inl
+++ b/pcsx2/x86/microVU_Log.inl
@@ -46,7 +46,7 @@ _mVUt void __mVULog(const char* fmt, ...)
 		} \
 	}
 
-#include "AppConfig.h"
+#include "gui/AppConfig.h"
 
 void __mVUdumpProgram(microVU& mVU, microProgram& prog)
 {


### PR DESCRIPTION
### Description of Changes
Remove `gui/` from the target include directory, replacing includes in files outside of it with paths including `gui/`.

### Rationale behind Changes
There's a decent amount of dependence on GUI classes/functions in the emulation core. This PR removes `gui/` from the target's include path, to make it clearer where we need to look at moving things to make it less dependent on the UI, since we can simply search for `gui/` includes.

### Suggested Testing Steps
Make sure it builds on all platforms. I've checked Windows and Linux 64-bit.
