### PR TITLE
wx: make position validation multi-monitor aware

### DIFF
--- a/common/src/Utilities/wxGuiTools.cpp
+++ b/common/src/Utilities/wxGuiTools.cpp
@@ -19,6 +19,7 @@
 
 #include <wx/app.h>
 #include <wx/window.h>
+#include <wx/display.h>
 
 const pxAlignmentType
     pxCentre = {pxAlignmentType::Center}, // Horizontal centered alignment
@@ -199,8 +200,17 @@ bool pxIsValidWindowPosition(const wxWindow &window, const wxPoint &windowPos)
     // all we need visible for the user to be able to drag the window into view.  But
     // there's no way to get that info from wx, so we'll just have to guesstimate...
 
-    wxSize sizeMatters(window.GetSize().GetWidth(), 32); // if some gui has 32 pixels of undraggable title bar, the user deserves to suffer.
-    return wxGetDisplayArea().Contains(wxRect(windowPos, sizeMatters));
+    const wxSize sizeMatters(window.GetSize().GetWidth(), 32);
+
+    for (unsigned int i = 0; i < wxDisplay::GetCount(); i++)
+    {
+        const auto rect = wxDisplay(i).GetGeometry();
+
+        if (rect.Contains(wxRect(windowPos, sizeMatters)))
+            return true;
+    }
+
+    return false;
 }
 
 // Retrieves the area of the screen, which can be used to enforce a valid zone for


### PR DESCRIPTION
### Description of Changes
Makes the start up position validation multi-monitor aware. Just sort of a personal annoyance for me so I thought I would make an attempt to address it.

Fixes #2840

### Rationale behind Changes
Previously `pxIsValidWindowPosition` would only compare against a single display. This would cause a condition where the application could be closed on another monitor and would default to the primary display when opened.

~~I'm not 100 percent the way I've done it is the best way, but absent anything else it seems to work okay. There seems to be no function in wx for getting the area of both displays (as `GetScreenPosition` returns relative to)~~

Scratch that. Seems less wise to check the sum since the resolutions might be different. 

### Suggested Testing Steps
- Make sure you can close the main pcsx2 window on both displays and have it be remembered when you open it again.
- Make sure that closing the window on one display, disabling it, and then opening the app again has the expected behavior of not placing the window off screen.
- Make sure it works on all OS families.
