### PR TITLE
IOPBios: Fix OOB read when IRQ line is invalid.

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -863,7 +863,14 @@ namespace R3000A
 
 		void RegisterIntrHandler_DEBUG()
 		{
-			DevCon.WriteLn(Color_Gray, "RegisterIntrHandler: intr %s, handler %x", intrname[a0], a2);
+			if(a0 < std::size(intrname) - 1)
+			{
+				DevCon.WriteLn(Color_Gray, "RegisterIntrHandler: intr %s, handler %x", intrname[a0], a2);
+			}
+			else
+			{
+				DevCon.WriteLn(Color_Gray, "RegisterIntrHandler: intr UNKNOWN (%d), handler %x",a0,a2);
+			}
 		}
 	} // namespace intrman
 


### PR DESCRIPTION
### Description of Changes
Instead of blindly trusting whatever is given to us when RegisterIntrHandler is called, check to see if the IRQ line is in bounds with the `intrname` array.

### Rationale behind Changes
Fixes the `kernel/iop/interrupt/register` ps2autotest.

The test would create an interrupt handler on line -1 and we would therefore index into `intrname[-1]`.
### Suggested Testing Steps
None.

### Example

![image](https://user-images.githubusercontent.com/29295048/129814718-f152cbe4-b8a0-4e9d-98a8-fd860434dc02.png)
