### PR TITLE
GHActions:Linux: Make ccache config global

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -104,6 +104,13 @@ jobs:
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
     timeout-minutes: 30
 
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 9
+      CCACHE_MAXSIZE: 100M
+
     steps:
       # NOTE - useful for debugging
       # - name: Dump GitHub context

--- a/.github/workflows/scripts/linux/compile.sh
+++ b/.github/workflows/scripts/linux/compile.sh
@@ -6,12 +6,6 @@ if [ -n "${GITHUB_ACTIONS}" ]; then
     echo "Warning: Running this script outside of GitHub Actions isn't recommended."
 fi
 
-export CCACHE_BASEDIR=${GITHUB_WORKSPACE}
-export CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache
-export CCACHE_COMPRESS="true"
-export CCACHE_COMPRESSLEVEL="6"
-export CCACHE_MAXSIZE="400M"
-
 # Prepare the Cache
 ccache -p
 ccache -z


### PR DESCRIPTION
### Description of Changes
Moves ccache config environment variables from the build script to global across all CI steps

Also lowers the maximum cache size as one build is only 17mb of cache max

### Rationale behind Changes
New testing step was missing the config, and causing ccache to complain and fail CI builds every now and then (no clue why it was so sporadic though)

### Suggested Testing Steps
Make sure CI builds
