### PR TITLE
GS-GUI: Enable Software Edge-Aliasing by default

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1610,7 +1610,7 @@ void GSApp::Init()
 #else
 	m_default_configuration["linux_replay"]                               = "1";
 #endif
-	m_default_configuration["aa1"]                                        = "0";
+	m_default_configuration["aa1"]                                        = "1";
 	m_default_configuration["accurate_date"]                              = "1";
 	m_default_configuration["accurate_blending_unit"]                     = "1";
 	m_default_configuration["AspectRatio"]                                = "1";


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This will enable the checkbox for the software renderer, it has far more pros than cons (negligible performance hit)
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Some games got better visuals but not limited to;
**Trapt:**
Left is correct, Right is wrong
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=eb0d1130-0113-11ec-abb7-b9a7ff2ee17c
![image](https://user-images.githubusercontent.com/24227051/130149767-f4d7b497-b45b-4246-8e52-9b9069187e8f.png)
**Toro games:**
  Relevant: https://github.com/PCSX2/pcsx2/issues/4674
Wrong:
![image](https://user-images.githubusercontent.com/24227051/130150134-654b034d-a0de-414c-b71b-6c901ab0a8e5.png)
Correct:
![image](https://user-images.githubusercontent.com/24227051/130150153-f236dfb2-558c-4c7b-bbb8-0ee2dfe3aef4.png)
**FFX:**
  Relevant: https://github.com/PCSX2/pcsx2/issues/3341
Wrong:
![image](https://user-images.githubusercontent.com/24227051/130150398-a3308f66-a69a-4637-90c8-54fe86c1c643.png)
Correct:
![image](https://user-images.githubusercontent.com/24227051/130150409-a1ff7b63-6f82-4ef9-96e9-1436aeec5788.png)
There are multitude of areas broken like on the stairs of the forest boss:
   Relevant: https://github.com/PCSX2/pcsx2/issues/983
Wrong:
![image](https://user-images.githubusercontent.com/24227051/130151441-fae03f1e-ab6a-4ff4-aa2b-8fcef91fb1f5.png)
Correct:
![image](https://user-images.githubusercontent.com/24227051/130151303-3895e7b9-e691-4649-a8b2-03b566c06ab7.png)
And other games i don't know which are affected on SW.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test any games that have an effect on Edge anti-aliasing (Software renderer only)