### PR TITLE
Various GSBlock shuffle improvements

### DIFF
--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -19,10 +19,13 @@
 CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 8, 4, 12, 1, 9, 5, 13, 2, 10, 6, 14, 3, 11, 7, 15);
+CONSTINIT const GSVector4i GSBlock::m_w4mask(0, 4, 8, 12, 2, 6, 10, 14, 1, 5, 9, 13, 3, 7, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_palvec_mask(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
 
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask1(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask2(1, 5, 9, 13, 0, 4, 8, 12, 3, 7, 11, 15, 2, 6, 10, 14);
+CONSTINIT const GSVector4i GSBlock::m_avx2_w8mask1(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+CONSTINIT const GSVector4i GSBlock::m_avx2_w8mask2(4, 0, 12, 8, 5, 1, 13, 9, 6, 2, 14, 10, 7, 3, 15, 11);
 
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask0(0, 0, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8, 9, 9, 9, 9);
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask1(2, 2, 2, 2, 3, 3, 3, 3, 10, 10, 10, 10, 11, 11, 11, 11);

--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -18,7 +18,7 @@
 
 CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
-CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 8, 4, 12, 1, 9, 5, 13, 2, 10, 6, 14, 3, 11, 7, 15);
 
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask1(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask2(1, 5, 9, 13, 0, 4, 8, 12, 3, 7, 11, 15, 2, 6, 10, 14);

--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -19,6 +19,7 @@
 CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 8, 4, 12, 1, 9, 5, 13, 2, 10, 6, 14, 3, 11, 7, 15);
+CONSTINIT const GSVector4i GSBlock::m_palvec_mask(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
 
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask1(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask2(1, 5, 9, 13, 0, 4, 8, 12, 3, 7, 11, 15, 2, 6, 10, 14);

--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -16,21 +16,9 @@
 #include "PrecompiledHeader.h"
 #include "GSBlock.h"
 
-CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15);
+CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
-
-#if _M_SSE >= 0x501
-CONSTINIT const GSVector8i GSBlock::m_xxxa = GSVector8i::cxpr(0x00008000);
-CONSTINIT const GSVector8i GSBlock::m_xxbx = GSVector8i::cxpr(0x00007c00);
-CONSTINIT const GSVector8i GSBlock::m_xgxx = GSVector8i::cxpr(0x000003e0);
-CONSTINIT const GSVector8i GSBlock::m_rxxx = GSVector8i::cxpr(0x0000001f);
-#else
-CONSTINIT const GSVector4i GSBlock::m_xxxa = GSVector4i::cxpr(0x00008000);
-CONSTINIT const GSVector4i GSBlock::m_xxbx = GSVector4i::cxpr(0x00007c00);
-CONSTINIT const GSVector4i GSBlock::m_xgxx = GSVector4i::cxpr(0x000003e0);
-CONSTINIT const GSVector4i GSBlock::m_rxxx = GSVector4i::cxpr(0x0000001f);
-#endif
 
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask0(0, 0, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8, 9, 9, 9, 9);
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask1(2, 2, 2, 2, 3, 3, 3, 3, 10, 10, 10, 10, 11, 11, 11, 11);

--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -20,6 +20,9 @@ CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6,
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
 
+CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask1(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask2(1, 5, 9, 13, 0, 4, 8, 12, 3, 7, 11, 15, 2, 6, 10, 14);
+
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask0(0, 0, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8, 9, 9, 9, 9);
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask1(2, 2, 2, 2, 3, 3, 3, 3, 10, 10, 10, 10, 11, 11, 11, 11);
 CONSTINIT const GSVector4i GSBlock::m_uw8hmask2(4, 4, 4, 4, 5, 5, 5, 5, 12, 12, 12, 12, 13, 13, 13, 13);

--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -20,6 +20,8 @@ CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6,
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 8, 4, 12, 1, 9, 5, 13, 2, 10, 6, 14, 3, 11, 7, 15);
 CONSTINIT const GSVector4i GSBlock::m_w4mask(0, 4, 8, 12, 2, 6, 10, 14, 1, 5, 9, 13, 3, 7, 11, 15);
+CONSTINIT const GSVector4i GSBlock::m_r4hmask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+CONSTINIT const GSVector4i GSBlock::m_r4hmask_avx2(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
 CONSTINIT const GSVector4i GSBlock::m_palvec_mask(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
 
 CONSTINIT const GSVector4i GSBlock::m_avx2_r8mask1(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);

--- a/pcsx2/GS/GSBlock.cpp
+++ b/pcsx2/GS/GSBlock.cpp
@@ -16,11 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "GSBlock.h"
 
-#if _M_SSE >= 0x501
-CONSTINIT const GSVector8i GSBlock::m_r16mask(0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15, 0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15);
-#else
 CONSTINIT const GSVector4i GSBlock::m_r16mask(0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15);
-#endif
 CONSTINIT const GSVector4i GSBlock::m_r8mask(0, 4, 2, 6, 8, 12, 10, 14, 1, 5, 3, 7, 9, 13, 11, 15);
 CONSTINIT const GSVector4i GSBlock::m_r4mask(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
 

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -21,11 +21,7 @@
 
 class GSBlock
 {
-#if _M_SSE >= 0x501
-	static const GSVector8i m_r16mask;
-#else
 	static const GSVector4i m_r16mask;
-#endif
 	static const GSVector4i m_r8mask;
 	static const GSVector4i m_r4mask;
 
@@ -490,8 +486,10 @@ public:
 
 		const GSVector8i* s = (const GSVector8i*)src;
 
-		GSVector8i v0 = s[i * 2 + 0].shuffle8(m_r16mask);
-		GSVector8i v1 = s[i * 2 + 1].shuffle8(m_r16mask);
+		GSVector8i mask = GSVector8i::broadcast128(m_r16mask);
+
+		GSVector8i v0 = s[i * 2 + 0].shuffle8(mask);
+		GSVector8i v1 = s[i * 2 + 1].shuffle8(mask);
 
 		GSVector8i::sw128(v0, v1);
 		GSVector8i::sw32(v0, v1);
@@ -1637,10 +1635,12 @@ public:
 		GSVector8i TA0(TEXA.TA0 << 24);
 		GSVector8i TA1(TEXA.TA1 << 24);
 
+		GSVector8i mask = GSVector8i::broadcast128(m_r16mask);
+
 		for (int i = 0; i < 4; i++, dst += dstpitch * 2)
 		{
-			GSVector8i v0 = s[i * 2 + 0].shuffle8(m_r16mask);
-			GSVector8i v1 = s[i * 2 + 1].shuffle8(m_r16mask);
+			GSVector8i v0 = s[i * 2 + 0].shuffle8(mask);
+			GSVector8i v1 = s[i * 2 + 1].shuffle8(mask);
 
 			GSVector8i::sw128(v0, v1);
 			GSVector8i::sw32(v0, v1);

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -25,6 +25,8 @@ class GSBlock
 	static const GSVector4i m_r8mask;
 	static const GSVector4i m_r4mask;
 	static const GSVector4i m_w4mask;
+	static const GSVector4i m_r4hmask;
+	static const GSVector4i m_r4hmask_avx2;
 	static const GSVector4i m_palvec_mask;
 
 	static const GSVector4i m_avx2_r8mask1;
@@ -1865,6 +1867,7 @@ public:
 		GSVector8i p0, p1, p2, p3;
 		LoadPalVecs(pal, p0, p1, p2, p3);
 		GSVector8i maskvec(mask);
+		GSVector8i shufvec = GSVector8i::broadcast128(m_r4hmask_avx2);
 
 		GSVector8i v0, v1, v2, v3;
 
@@ -1880,12 +1883,7 @@ public:
 			v2 = s[i * 4 + 2] >> shift;
 			v3 = s[i * 4 + 3] >> shift;
 
-			GSVector8i::sw128(v0, v1);
-			GSVector8i::sw64(v0, v1);
-			GSVector8i::sw128(v2, v3);
-			GSVector8i::sw64(v2, v3);
-
-			GSVector8i all = v0.ps32(v1).pu16(v2.ps32(v3));
+			GSVector8i all = v0.ps32(v1).pu16(v2.ps32(v3)).xzyw().acbd().shuffle8(shufvec);
 			if (mask != 0xffffffff)
 				all = all & mask;
 
@@ -1914,9 +1912,7 @@ public:
 			v2 = s[i * 4 + 2] >> shift;
 			v3 = s[i * 4 + 3] >> shift;
 
-			GSVector4i::sw64(v0, v1, v2, v3);
-
-			GSVector4i all = v0.ps32(v1).pu16(v2.ps32(v3));
+			GSVector4i all = v0.ps32(v1).pu16(v2.ps32(v3)).shuffle8(m_r4hmask);
 			if (mask != 0xffffffff)
 				all = all & mask;
 

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -65,26 +65,10 @@ public:
 
 		GSVector8i::sw64(v0, v1);
 
-		if (mask == 0xffffffff)
-		{
-			((GSVector8i*)dst)[i * 2 + 0] = v0;
-			((GSVector8i*)dst)[i * 2 + 1] = v1;
-		}
-		else
-		{
-			GSVector8i v2((int)mask);
+		GSVector8i* d = reinterpret_cast<GSVector8i*>(dst);
 
-			if (mask == 0xff000000 || mask == 0x00ffffff)
-			{
-				((GSVector8i*)dst)[i * 2 + 0] = ((GSVector8i*)dst)[i * 2 + 0].blend8(v0, v2);
-				((GSVector8i*)dst)[i * 2 + 1] = ((GSVector8i*)dst)[i * 2 + 1].blend8(v1, v2);
-			}
-			else
-			{
-				((GSVector8i*)dst)[i * 2 + 0] = ((GSVector8i*)dst)[i * 2 + 0].blend(v0, v2);
-				((GSVector8i*)dst)[i * 2 + 1] = ((GSVector8i*)dst)[i * 2 + 1].blend(v1, v2);
-			}
-		}
+		d[i * 2 + 0] = d[i * 2 + 0].smartblend<mask>(v0);
+		d[i * 2 + 1] = d[i * 2 + 1].smartblend<mask>(v1);
 
 #else
 
@@ -120,32 +104,12 @@ public:
 
 #endif
 
-		if (mask == 0xffffffff)
-		{
-			((GSVector4i*)dst)[i * 4 + 0] = v0;
-			((GSVector4i*)dst)[i * 4 + 1] = v1;
-			((GSVector4i*)dst)[i * 4 + 2] = v2;
-			((GSVector4i*)dst)[i * 4 + 3] = v3;
-		}
-		else
-		{
-			GSVector4i v4((int)mask);
+		GSVector4i* d = reinterpret_cast<GSVector4i*>(dst);
 
-			if (mask == 0xff000000 || mask == 0x00ffffff)
-			{
-				((GSVector4i*)dst)[i * 4 + 0] = ((GSVector4i*)dst)[i * 4 + 0].blend8(v0, v4);
-				((GSVector4i*)dst)[i * 4 + 1] = ((GSVector4i*)dst)[i * 4 + 1].blend8(v1, v4);
-				((GSVector4i*)dst)[i * 4 + 2] = ((GSVector4i*)dst)[i * 4 + 2].blend8(v2, v4);
-				((GSVector4i*)dst)[i * 4 + 3] = ((GSVector4i*)dst)[i * 4 + 3].blend8(v3, v4);
-			}
-			else
-			{
-				((GSVector4i*)dst)[i * 4 + 0] = ((GSVector4i*)dst)[i * 4 + 0].blend(v0, v4);
-				((GSVector4i*)dst)[i * 4 + 1] = ((GSVector4i*)dst)[i * 4 + 1].blend(v1, v4);
-				((GSVector4i*)dst)[i * 4 + 2] = ((GSVector4i*)dst)[i * 4 + 2].blend(v2, v4);
-				((GSVector4i*)dst)[i * 4 + 3] = ((GSVector4i*)dst)[i * 4 + 3].blend(v3, v4);
-			}
-		}
+		d[i * 4 + 0] = d[i * 4 + 0].smartblend<mask>(v0);
+		d[i * 4 + 1] = d[i * 4 + 1].smartblend<mask>(v1);
+		d[i * 4 + 2] = d[i * 4 + 2].smartblend<mask>(v2);
+		d[i * 4 + 3] = d[i * 4 + 3].smartblend<mask>(v3);
 
 #endif
 	}

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -1795,6 +1795,68 @@ public:
 	{
 		//printf("ReadAndExpandBlock4_32\n");
 
+#if _M_SSE >= 0x501
+
+		const GSVector8i* s = (const GSVector8i*)src;
+
+		GSVector8i p0, p1, p2, p3;
+		LoadPalVecs(pal, p0, p1, p2, p3);
+		GSVector8i shuf = GSVector8i::broadcast128(m_palvec_mask);
+		GSVector8i mask(0x0f0f0f0f);
+
+		GSVector8i v0, v1;
+
+		for (int i = 0; i < 2; i++)
+		{
+			GSVector8i* d0 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 0);
+			GSVector8i* d1 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 1);
+			GSVector8i* d2 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 2);
+			GSVector8i* d3 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 3);
+
+			v0 = s[i * 4 + 0];
+			v1 = s[i * 4 + 1];
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+
+			v0 = v0.shuffle8(shuf);
+			v1 = v1.shuffle8(shuf);
+
+			ReadClut4AndWrite(p0, p1, p2, p3, v0 & mask, d0, 1);
+			ReadClut4AndWrite(p0, p1, p2, p3, v1 & mask, d1, 1);
+			v0 = v0.cdab() >> 4;
+			v1 = v1.cdab() >> 4;
+			ReadClut4AndWrite(p0, p1, p2, p3, v0 & mask, d2, 1);
+			ReadClut4AndWrite(p0, p1, p2, p3, v1 & mask, d3, 1);
+
+			dst += dstpitch * 4;
+
+			d0 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 0);
+			d1 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 1);
+			d2 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 2);
+			d3 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 3);
+
+			v1 = s[i * 4 + 2];
+			v0 = s[i * 4 + 3];
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+
+			v0 = v0.shuffle8(shuf);
+			v1 = v1.shuffle8(shuf);
+
+			ReadClut4AndWrite(p0, p1, p2, p3, v0 & mask, d0, 1);
+			ReadClut4AndWrite(p0, p1, p2, p3, v1 & mask, d1, 1);
+			v0 = v0.cdab() >> 4;
+			v1 = v1.cdab() >> 4;
+			ReadClut4AndWrite(p0, p1, p2, p3, v0 & mask, d2, 1);
+			ReadClut4AndWrite(p0, p1, p2, p3, v1 & mask, d3, 1);
+
+			dst += dstpitch * 4;
+		}
+
+#else
+
 		const GSVector4i* s = (const GSVector4i*)src;
 
 		GSVector4i p0, p1, p2, p3;
@@ -1861,6 +1923,8 @@ public:
 
 			dst += dstpitch * 4;
 		}
+
+#endif
 	}
 
 	// TODO: ReadAndExpandBlock4_16

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -1715,6 +1715,66 @@ public:
 	{
 		//printf("ReadAndExpandBlock8_32\n");
 
+#if _M_SSE >= 0x501
+
+		const GSVector8i* s = (const GSVector8i*)src;
+
+		GSVector8i v0, v1;
+		GSVector8i mask = GSVector8i::x000000ff();
+
+		for (int i = 0; i < 2; i++)
+		{
+			GSVector8i* d0 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 0);
+			GSVector8i* d1 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 1);
+			GSVector8i* d2 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 2);
+			GSVector8i* d3 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 3);
+
+			v0 = s[i * 4 + 0];
+			v1 = s[i * 4 + 1];
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+
+			d0[0] = ((v0      ) & mask).gather32_32(pal);
+			d0[1] = ((v0 >> 16) & mask).gather32_32(pal);
+			d1[0] = ((v1      ) & mask).gather32_32(pal);
+			d1[1] = ((v1 >> 16) & mask).gather32_32(pal);
+			v0 = v0.cdab();
+			v1 = v1.cdab();
+			d2[0] = ((v0 >>  8) & mask).gather32_32(pal);
+			d2[1] = ((v0 >> 24)       ).gather32_32(pal);
+			d3[0] = ((v1 >>  8) & mask).gather32_32(pal);
+			d3[1] = ((v1 >> 24)       ).gather32_32(pal);
+
+			dst += dstpitch * 4;
+
+			d0 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 0);
+			d1 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 1);
+			d2 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 2);
+			d3 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 3);
+
+			v1 = s[i * 4 + 2];
+			v0 = s[i * 4 + 3];
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+
+			d0[0] = ((v0      ) & mask).gather32_32(pal);
+			d0[1] = ((v0 >> 16) & mask).gather32_32(pal);
+			d1[0] = ((v1      ) & mask).gather32_32(pal);
+			d1[1] = ((v1 >> 16) & mask).gather32_32(pal);
+			v0 = v0.cdab();
+			v1 = v1.cdab();
+			d2[0] = ((v0 >>  8) & mask).gather32_32(pal);
+			d2[1] = ((v0 >> 24)       ).gather32_32(pal);
+			d3[0] = ((v1 >>  8) & mask).gather32_32(pal);
+			d3[1] = ((v1 >> 24)       ).gather32_32(pal);
+
+			dst += dstpitch * 4;
+		}
+
+#else
+
 		const GSVector4i* s = (const GSVector4i*)src;
 
 		GSVector4i v0, v1, v2, v3;
@@ -1756,6 +1816,8 @@ public:
 			v2.gather32_8<>(pal, (GSVector4i*)dst);
 			dst += dstpitch;
 		}
+
+#endif
 	}
 
 	// TODO: ReadAndExpandBlock8_16
@@ -1933,6 +1995,26 @@ public:
 	{
 		//printf("ReadAndExpandBlock8H_32\n");
 
+#if _M_SSE >= 0x501
+
+		const GSVector8i* s = (const GSVector8i*)src;
+		for (int i = 0; i < 4; i++)
+		{
+			GSVector8i v0 = s[i * 2 + 0];
+			GSVector8i v1 = s[i * 2 + 1];
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+
+			*reinterpret_cast<GSVector8i*>(dst) = (v0 >> 24).gather32_32(pal);
+			dst += dstpitch;
+
+			*reinterpret_cast<GSVector8i*>(dst) = (v1 >> 24).gather32_32(pal);
+			dst += dstpitch;
+		}
+
+#else
+
 		const GSVector4i* s = (const GSVector4i*)src;
 
 		GSVector4i v0, v1, v2, v3;
@@ -1956,6 +2038,8 @@ public:
 
 			dst += dstpitch;
 		}
+
+#endif
 	}
 
 	// TODO: ReadAndExpandBlock8H_16

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -504,20 +504,21 @@ public:
 
 		const GSVector4i* s = (const GSVector4i*)src;
 
-		GSVector4i v0 = s[i * 4 + 0].shuffle8(m_r16mask);
-		GSVector4i v1 = s[i * 4 + 1].shuffle8(m_r16mask);
-		GSVector4i v2 = s[i * 4 + 2].shuffle8(m_r16mask);
-		GSVector4i v3 = s[i * 4 + 3].shuffle8(m_r16mask);
+		GSVector4i v0 = s[i * 4 + 0];
+		GSVector4i v1 = s[i * 4 + 1];
+		GSVector4i v2 = s[i * 4 + 2];
+		GSVector4i v3 = s[i * 4 + 3];
 
+		GSVector4i::sw16(v0, v1, v2, v3);
 		GSVector4i::sw32(v0, v1, v2, v3);
-		GSVector4i::sw64(v0, v1, v2, v3);
+		GSVector4i::sw16(v0, v2, v1, v3);
 
 		GSVector4i* d0 = (GSVector4i*)&dst[dstpitch * 0];
 		GSVector4i* d1 = (GSVector4i*)&dst[dstpitch * 1];
 
 		GSVector4i::store<true>(&d0[0], v0);
-		GSVector4i::store<true>(&d0[1], v2);
-		GSVector4i::store<true>(&d1[0], v1);
+		GSVector4i::store<true>(&d0[1], v1);
+		GSVector4i::store<true>(&d1[0], v2);
 		GSVector4i::store<true>(&d1[1], v3);
 
 #endif

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -1325,43 +1325,26 @@ public:
 		GSVector8i v0, v1, v2, v3;
 		GSVector8i mask = GSVector8i::xff000000();
 
-		v4 = GSVector4i::loadl(&src[srcpitch * 0]);
-		v5 = GSVector4i::loadl(&src[srcpitch * 1]);
-		v6 = GSVector4i::loadl(&src[srcpitch * 2]);
-		v7 = GSVector4i::loadl(&src[srcpitch * 3]);
+		for (int i = 0; i < 2; i++, src += srcpitch * 4)
+		{
+			v4 = GSVector4i::loadl(&src[srcpitch * 0]);
+			v5 = GSVector4i::loadl(&src[srcpitch * 1]);
+			v6 = GSVector4i::loadl(&src[srcpitch * 2]);
+			v7 = GSVector4i::loadl(&src[srcpitch * 3]);
 
-		v2 = GSVector8i::cast(v4.upl16(v5));
-		v3 = GSVector8i::cast(v6.upl16(v7));
+			v4 = v4.upl16(v5);
+			v5 = v6.upl16(v7);
 
-		v0 = v2.u8to32c() << 24;
-		v1 = v2.bbbb().u8to32c() << 24;
-		v2 = v3.u8to32c() << 24;
-		v3 = v3.bbbb().u8to32c() << 24;
+			v0 = GSVector8i::u8to32(v4) << 24;
+			v1 = GSVector8i::u8to32(v4.zwzw()) << 24;
+			v2 = GSVector8i::u8to32(v5) << 24;
+			v3 = GSVector8i::u8to32(v5.zwzw()) << 24;
 
-		((GSVector8i*)dst)[0] = ((GSVector8i*)dst)[0].blend8(v0, mask);
-		((GSVector8i*)dst)[1] = ((GSVector8i*)dst)[1].blend8(v1, mask);
-		((GSVector8i*)dst)[2] = ((GSVector8i*)dst)[2].blend8(v2, mask);
-		((GSVector8i*)dst)[3] = ((GSVector8i*)dst)[3].blend8(v3, mask);
-
-		src += srcpitch * 4;
-
-		v4 = GSVector4i::loadl(&src[srcpitch * 0]);
-		v5 = GSVector4i::loadl(&src[srcpitch * 1]);
-		v6 = GSVector4i::loadl(&src[srcpitch * 2]);
-		v7 = GSVector4i::loadl(&src[srcpitch * 3]);
-
-		v2 = GSVector8i::cast(v4.upl16(v5));
-		v3 = GSVector8i::cast(v6.upl16(v7));
-
-		v0 = v2.u8to32c() << 24;
-		v1 = v2.bbbb().u8to32c() << 24;
-		v2 = v3.u8to32c() << 24;
-		v3 = v3.bbbb().u8to32c() << 24;
-
-		((GSVector8i*)dst)[4] = ((GSVector8i*)dst)[4].blend8(v0, mask);
-		((GSVector8i*)dst)[5] = ((GSVector8i*)dst)[5].blend8(v1, mask);
-		((GSVector8i*)dst)[6] = ((GSVector8i*)dst)[6].blend8(v2, mask);
-		((GSVector8i*)dst)[7] = ((GSVector8i*)dst)[7].blend8(v3, mask);
+			((GSVector8i*)dst)[i * 4 + 0] = ((GSVector8i*)dst)[i * 4 + 0].blend(v0, mask);
+			((GSVector8i*)dst)[i * 4 + 1] = ((GSVector8i*)dst)[i * 4 + 1].blend(v1, mask);
+			((GSVector8i*)dst)[i * 4 + 2] = ((GSVector8i*)dst)[i * 4 + 2].blend(v2, mask);
+			((GSVector8i*)dst)[i * 4 + 3] = ((GSVector8i*)dst)[i * 4 + 3].blend(v3, mask);
+		}
 
 #else
 
@@ -1404,47 +1387,31 @@ public:
 
 #if _M_SSE >= 0x501
 
-		GSVector4i v4, v5, v6;
+		GSVector4i v4, v5, v6, v7;
 		GSVector8i v0, v1, v2, v3;
 		GSVector8i mask(0x0f000000);
 
-		v6 = GSVector4i(*(u32*)&src[srcpitch * 0], *(u32*)&src[srcpitch * 2], *(u32*)&src[srcpitch * 1], *(u32*)&src[srcpitch * 3]);
+		for (int i = 0; i < 2; i++, src += srcpitch * 4)
+		{
+			v4 = GSVector4i::load(*(u32*)&src[srcpitch * 0]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 2]));
+			v5 = GSVector4i::load(*(u32*)&src[srcpitch * 1]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 3]));
 
-		v4 = v6.upl8(v6 >> 4);
-		v5 = v6.uph8(v6 >> 4);
+			v6 = v4.upl8(v4 >> 4);
+			v7 = v5.upl8(v5 >> 4);
 
-		v2 = GSVector8i::cast(v4.upl16(v5));
-		v3 = GSVector8i::cast(v4.uph16(v5));
+			v4 = v6.upl16(v7);
+			v5 = v6.uph16(v7);
 
-		v0 = v2.u8to32c() << 24;
-		v1 = v2.bbbb().u8to32c() << 24;
-		v2 = v3.u8to32c() << 24;
-		v3 = v3.bbbb().u8to32c() << 24;
+			v0 = GSVector8i::u8to32(v4) << 24;
+			v1 = GSVector8i::u8to32(v4.zwzw()) << 24;
+			v2 = GSVector8i::u8to32(v5) << 24;
+			v3 = GSVector8i::u8to32(v5.zwzw()) << 24;
 
-		((GSVector8i*)dst)[0] = ((GSVector8i*)dst)[0].blend(v0, mask);
-		((GSVector8i*)dst)[1] = ((GSVector8i*)dst)[1].blend(v1, mask);
-		((GSVector8i*)dst)[2] = ((GSVector8i*)dst)[2].blend(v2, mask);
-		((GSVector8i*)dst)[3] = ((GSVector8i*)dst)[3].blend(v3, mask);
-
-		src += srcpitch * 4;
-
-		v6 = GSVector4i(*(u32*)&src[srcpitch * 0], *(u32*)&src[srcpitch * 2], *(u32*)&src[srcpitch * 1], *(u32*)&src[srcpitch * 3]);
-
-		v4 = v6.upl8(v6 >> 4);
-		v5 = v6.uph8(v6 >> 4);
-
-		v2 = GSVector8i::cast(v4.upl16(v5));
-		v3 = GSVector8i::cast(v4.uph16(v5));
-
-		v0 = v2.u8to32c() << 24;
-		v1 = v2.bbbb().u8to32c() << 24;
-		v2 = v3.u8to32c() << 24;
-		v3 = v3.bbbb().u8to32c() << 24;
-
-		((GSVector8i*)dst)[4] = ((GSVector8i*)dst)[4].blend(v0, mask);
-		((GSVector8i*)dst)[5] = ((GSVector8i*)dst)[5].blend(v1, mask);
-		((GSVector8i*)dst)[6] = ((GSVector8i*)dst)[6].blend(v2, mask);
-		((GSVector8i*)dst)[7] = ((GSVector8i*)dst)[7].blend(v3, mask);
+			((GSVector8i*)dst)[i * 4 + 0] = ((GSVector8i*)dst)[i * 4 + 0].blend(v0, mask);
+			((GSVector8i*)dst)[i * 4 + 1] = ((GSVector8i*)dst)[i * 4 + 1].blend(v1, mask);
+			((GSVector8i*)dst)[i * 4 + 2] = ((GSVector8i*)dst)[i * 4 + 2].blend(v2, mask);
+			((GSVector8i*)dst)[i * 4 + 3] = ((GSVector8i*)dst)[i * 4 + 3].blend(v3, mask);
+		}
 
 #else
 
@@ -1457,10 +1424,11 @@ public:
 
 		for (int i = 0; i < 2; i++, src += srcpitch * 4)
 		{
-			GSVector4i v(*(u32*)&src[srcpitch * 0], *(u32*)&src[srcpitch * 1], *(u32*)&src[srcpitch * 2], *(u32*)&src[srcpitch * 3]);
+			v4 = GSVector4i::load(*(u32*)&src[srcpitch * 0]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 1]));
+			v5 = GSVector4i::load(*(u32*)&src[srcpitch * 2]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 3]));
 
-			v4 = v.upl8(v >> 4);
-			v5 = v.uph8(v >> 4);
+			v4 = v4.upl8(v4 >> 4);
+			v5 = v5.upl8(v5 >> 4);
 
 			v0 = v4.shuffle8(mask0);
 			v1 = v4.shuffle8(mask1);
@@ -1488,50 +1456,33 @@ public:
 
 	__forceinline static void UnpackAndWriteBlock4HH(const u8* RESTRICT src, int srcpitch, u8* RESTRICT dst)
 	{
-
 #if _M_SSE >= 0x501
 
-		GSVector4i v4, v5, v6;
+		GSVector4i v4, v5, v6, v7;
 		GSVector8i v0, v1, v2, v3;
 		GSVector8i mask = GSVector8i::xf0000000();
 
-		v6 = GSVector4i(*(u32*)&src[srcpitch * 0], *(u32*)&src[srcpitch * 2], *(u32*)&src[srcpitch * 1], *(u32*)&src[srcpitch * 3]);
+		for (int i = 0; i < 2; i++, src += srcpitch * 4)
+		{
+			v4 = GSVector4i::load(*(u32*)&src[srcpitch * 0]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 2]));
+			v5 = GSVector4i::load(*(u32*)&src[srcpitch * 1]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 3]));
 
-		v4 = (v6 << 4).upl8(v6);
-		v5 = (v6 << 4).uph8(v6);
+			v6 = (v4 << 4).upl8(v4);
+			v7 = (v5 << 4).upl8(v5);
 
-		v2 = GSVector8i::cast(v4.upl16(v5));
-		v3 = GSVector8i::cast(v4.uph16(v5));
+			v4 = v6.upl16(v7);
+			v5 = v6.uph16(v7);
 
-		v0 = v2.u8to32c() << 24;
-		v1 = v2.bbbb().u8to32c() << 24;
-		v2 = v3.u8to32c() << 24;
-		v3 = v3.bbbb().u8to32c() << 24;
+			v0 = GSVector8i::u8to32(v4) << 24;
+			v1 = GSVector8i::u8to32(v4.zwzw()) << 24;
+			v2 = GSVector8i::u8to32(v5) << 24;
+			v3 = GSVector8i::u8to32(v5.zwzw()) << 24;
 
-		((GSVector8i*)dst)[0] = ((GSVector8i*)dst)[0].blend(v0, mask);
-		((GSVector8i*)dst)[1] = ((GSVector8i*)dst)[1].blend(v1, mask);
-		((GSVector8i*)dst)[2] = ((GSVector8i*)dst)[2].blend(v2, mask);
-		((GSVector8i*)dst)[3] = ((GSVector8i*)dst)[3].blend(v3, mask);
-
-		src += srcpitch * 4;
-
-		v6 = GSVector4i(*(u32*)&src[srcpitch * 0], *(u32*)&src[srcpitch * 2], *(u32*)&src[srcpitch * 1], *(u32*)&src[srcpitch * 3]);
-
-		v4 = (v6 << 4).upl8(v6);
-		v5 = (v6 << 4).uph8(v6);
-
-		v2 = GSVector8i::cast(v4.upl16(v5));
-		v3 = GSVector8i::cast(v4.uph16(v5));
-
-		v0 = v2.u8to32c() << 24;
-		v1 = v2.bbbb().u8to32c() << 24;
-		v2 = v3.u8to32c() << 24;
-		v3 = v3.bbbb().u8to32c() << 24;
-
-		((GSVector8i*)dst)[4] = ((GSVector8i*)dst)[4].blend(v0, mask);
-		((GSVector8i*)dst)[5] = ((GSVector8i*)dst)[5].blend(v1, mask);
-		((GSVector8i*)dst)[6] = ((GSVector8i*)dst)[6].blend(v2, mask);
-		((GSVector8i*)dst)[7] = ((GSVector8i*)dst)[7].blend(v3, mask);
+			((GSVector8i*)dst)[i * 4 + 0] = ((GSVector8i*)dst)[i * 4 + 0].blend(v0, mask);
+			((GSVector8i*)dst)[i * 4 + 1] = ((GSVector8i*)dst)[i * 4 + 1].blend(v1, mask);
+			((GSVector8i*)dst)[i * 4 + 2] = ((GSVector8i*)dst)[i * 4 + 2].blend(v2, mask);
+			((GSVector8i*)dst)[i * 4 + 3] = ((GSVector8i*)dst)[i * 4 + 3].blend(v3, mask);
+		}
 
 #else
 
@@ -1544,10 +1495,11 @@ public:
 
 		for (int i = 0; i < 2; i++, src += srcpitch * 4)
 		{
-			GSVector4i v(*(u32*)&src[srcpitch * 0], *(u32*)&src[srcpitch * 1], *(u32*)&src[srcpitch * 2], *(u32*)&src[srcpitch * 3]);
+			v4 = GSVector4i::load(*(u32*)&src[srcpitch * 0]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 1]));
+			v5 = GSVector4i::load(*(u32*)&src[srcpitch * 2]).upl32(GSVector4i::load(*(u32*)&src[srcpitch * 3]));
 
-			v4 = (v << 4).upl8(v);
-			v5 = (v << 4).uph8(v);
+			v4 = (v4 << 4).upl8(v4);
+			v5 = (v5 << 4).upl8(v5);
 
 			v0 = v4.shuffle8(mask0);
 			v1 = v4.shuffle8(mask1);

--- a/pcsx2/GS/GSBlock.h
+++ b/pcsx2/GS/GSBlock.h
@@ -2054,6 +2054,42 @@ public:
 	{
 		//printf("ReadAndExpandBlock4HL_32\n");
 
+#if _M_SSE >= 0x501
+
+		const GSVector8i* s = (const GSVector8i*)src;
+
+		GSVector8i p0, p1, p2, p3;
+		LoadPalVecs(pal, p0, p1, p2, p3);
+		GSVector8i mask(0x0f0f0f0f);
+
+		GSVector8i v0, v1, v2, v3;
+
+		for (int i = 0; i < 2; i++)
+		{
+			GSVector8i* d0 = reinterpret_cast<GSVector8i*>(dst);
+			GSVector8i* d1 = reinterpret_cast<GSVector8i*>(dst + dstpitch);
+			GSVector8i* d2 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 2);
+			GSVector8i* d3 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 3);
+
+			v0 = s[i * 4 + 0] >> 24;
+			v1 = s[i * 4 + 1] >> 24;
+			v2 = s[i * 4 + 2] >> 24;
+			v3 = s[i * 4 + 3] >> 24;
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+			GSVector8i::sw128(v2, v3);
+			GSVector8i::sw64(v2, v3);
+
+			GSVector8i all = v0.ps32(v1).pu16(v2.ps32(v3)) & mask;
+
+			ReadClut4(p0, p1, p2, p3, all, *d0, *d1, *d2, *d3);
+
+			dst += dstpitch * 4;
+		}
+
+#else
+
 		const GSVector4i* s = (const GSVector4i*)src;
 
 		GSVector4i p0, p1, p2, p3;
@@ -2080,6 +2116,8 @@ public:
 
 			dst += dstpitch * 2;
 		}
+
+#endif
 	}
 
 	// TODO: ReadAndExpandBlock4HL_16
@@ -2087,6 +2125,41 @@ public:
 	__forceinline static void ReadAndExpandBlock4HH_32(const u8* RESTRICT src, u8* RESTRICT dst, int dstpitch, const u32* RESTRICT pal)
 	{
 		//printf("ReadAndExpandBlock4HH_32\n");
+
+#if _M_SSE >= 0x501
+
+		const GSVector8i* s = (const GSVector8i*)src;
+
+		GSVector8i p0, p1, p2, p3;
+		LoadPalVecs(pal, p0, p1, p2, p3);
+
+		GSVector8i v0, v1, v2, v3;
+
+		for (int i = 0; i < 2; i++)
+		{
+			GSVector8i* d0 = reinterpret_cast<GSVector8i*>(dst);
+			GSVector8i* d1 = reinterpret_cast<GSVector8i*>(dst + dstpitch);
+			GSVector8i* d2 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 2);
+			GSVector8i* d3 = reinterpret_cast<GSVector8i*>(dst + dstpitch * 3);
+
+			v0 = s[i * 4 + 0] >> 28;
+			v1 = s[i * 4 + 1] >> 28;
+			v2 = s[i * 4 + 2] >> 28;
+			v3 = s[i * 4 + 3] >> 28;
+
+			GSVector8i::sw128(v0, v1);
+			GSVector8i::sw64(v0, v1);
+			GSVector8i::sw128(v2, v3);
+			GSVector8i::sw64(v2, v3);
+
+			GSVector8i all = v0.ps32(v1).pu16(v2.ps32(v3));
+
+			ReadClut4(p0, p1, p2, p3, all, *d0, *d1, *d2, *d3);
+
+			dst += dstpitch * 4;
+		}
+
+#else
 
 		const GSVector4i* s = (const GSVector4i*)src;
 
@@ -2113,6 +2186,8 @@ public:
 
 			dst += dstpitch * 2;
 		}
+
+#endif
 	}
 
 	// TODO: ReadAndExpandBlock4HH_16

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -1442,7 +1442,7 @@ void GSLocalMemory::ReadTexture8(const GSOffset& off, const GSVector4i& r, u8* d
 
 void GSLocalMemory::ReadTexture4(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA)
 {
-	const u64* pal = m_clut;
+	const u32* pal = m_clut;
 
 	foreachBlock(off.assertSizesMatch(swizzle4), this, r, dst, dstpitch, 32, [&](u8* read_dst, const u8* src)
 	{

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -689,6 +689,9 @@ void GSLocalMemory::WriteImageTopBottom(int l, int r, int y, int h, const u8* sr
 
 		if (h2 > 0)
 		{
+#if FAST_UNALIGNED
+			WriteImageColumn<psm, bsx, bsy, 0>(l, r, y, h2, src, srcpitch, BITBLTBUF);
+#else
 			size_t addr = (size_t)&src[l * trbpp >> 3];
 
 			if ((addr & 31) == 0 && (srcpitch & 31) == 0)
@@ -703,6 +706,7 @@ void GSLocalMemory::WriteImageTopBottom(int l, int r, int y, int h, const u8* sr
 			{
 				WriteImageColumn<psm, bsx, bsy, 0>(l, r, y, h2, src, srcpitch, BITBLTBUF);
 			}
+#endif
 
 			src += srcpitch * h2;
 			y += h2;
@@ -839,6 +843,9 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const u8* src, int len, GIFRegB
 
 				if (h2 > 0)
 				{
+#if FAST_UNALIGNED
+					WriteImageBlock<psm, bsx, bsy, 0>(la, ra, ty, h2, s, srcpitch, BITBLTBUF);
+#else
 					size_t addr = (size_t)&s[la * trbpp >> 3];
 
 					if ((addr & 31) == 0 && (srcpitch & 31) == 0)
@@ -853,6 +860,7 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const u8* src, int len, GIFRegB
 					{
 						WriteImageBlock<psm, bsx, bsy, 0>(la, ra, ty, h2, s, srcpitch, BITBLTBUF);
 					}
+#endif
 
 					s += srcpitch * h2;
 					ty += h2;

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -1156,6 +1156,13 @@ public:
 	void ReadTextureBlock4HL(u32 bp, u8* dst, int dstpitch, const GIFRegTEXA& TEXA) const;
 	void ReadTextureBlock4HH(u32 bp, u8* dst, int dstpitch, const GIFRegTEXA& TEXA) const;
 
+#if _M_SSE == 0x501
+	void ReadTexture8HSW(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
+	void ReadTexture8HHSW(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);
+	void ReadTextureBlock8HSW(u32 bp, u8* dst, int dstpitch, const GIFRegTEXA& TEXA) const;
+	void ReadTextureBlock8HHSW(u32 bp, u8* dst, int dstpitch, const GIFRegTEXA& TEXA) const;
+#endif
+
 	// pal ? 8 : 32
 
 	void ReadTexture8P(const GSOffset& off, const GSVector4i& r, u8* dst, int dstpitch, const GIFRegTEXA& TEXA);

--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -118,6 +118,19 @@ gsforceinline GSVector4::GSVector4(const GSVector4i& v)
 	m = _mm_cvtepi32_ps(v);
 }
 
+gsforceinline void GSVector4i::sw32_inv(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d)
+{
+	GSVector4 af = GSVector4::cast(a);
+	GSVector4 bf = GSVector4::cast(b);
+	GSVector4 cf = GSVector4::cast(c);
+	GSVector4 df = GSVector4::cast(d);
+
+	a = GSVector4i::cast(af.xzxz(cf));
+	b = GSVector4i::cast(af.ywyw(cf));
+	c = GSVector4i::cast(bf.xzxz(df));
+	d = GSVector4i::cast(bf.ywyw(df));
+}
+
 #if _M_SSE >= 0x501
 
 gsforceinline GSVector8i::GSVector8i(const GSVector8& v, bool truncate)
@@ -128,6 +141,14 @@ gsforceinline GSVector8i::GSVector8i(const GSVector8& v, bool truncate)
 gsforceinline GSVector8::GSVector8(const GSVector8i& v)
 {
 	m = _mm256_cvtepi32_ps(v);
+}
+
+gsforceinline void GSVector8i::sw32_inv(GSVector8i& a, GSVector8i& b)
+{
+	GSVector8 af = GSVector8::cast(a);
+	GSVector8 bf = GSVector8::cast(b);
+	a = GSVector8i::cast(af.xzxz(bf));
+	b = GSVector8i::cast(af.ywyw(bf));
 }
 
 #endif

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -81,16 +81,7 @@ public:
 
 	__forceinline GSVector4i(int x, int y, int z, int w)
 	{
-		// 4 gprs
-
-		// m = _mm_set_epi32(w, z, y, x);
-
-		// 2 gprs
-
-		GSVector4i xz = load(x).upl32(load(z));
-		GSVector4i yw = load(y).upl32(load(w));
-
-		*this = xz.upl32(yw);
+		m = _mm_set_epi32(w, z, y, x);
 	}
 
 	__forceinline GSVector4i(int x, int y)

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -2005,6 +2005,13 @@ public:
 
 	// clang-format on
 
+	/// Noop, here so broadcast128 can be used generically over all vectors
+	__forceinline static GSVector4i broadcast128(const GSVector4i& v)
+	{
+		return v;
+	}
+
+
 	__forceinline static GSVector4i zero() { return GSVector4i(_mm_setzero_si128()); }
 
 	__forceinline static GSVector4i xffffffff() { return zero() == zero(); }

--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -1678,21 +1678,21 @@ public:
 		d = _mm_castps_si128(_mm_shuffle_ps(tmp2, tmp3, 0xDD));
 	}
 
+	__forceinline static void mix4(GSVector4i& a, GSVector4i& b)
+	{
+		GSVector4i mask(_mm_set1_epi32(0x0f0f0f0f));
+
+		GSVector4i c = (b << 4).blend(a, mask);
+		GSVector4i d = b.blend(a >> 4, mask);
+		a = c;
+		b = d;
+	}
+
 	__forceinline static void sw4(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d)
 	{
-		const __m128i epi32_0f0f0f0f = _mm_set1_epi32(0x0f0f0f0f);
-
-		GSVector4i mask(epi32_0f0f0f0f);
-
-		GSVector4i e = (b << 4).blend(a, mask);
-		GSVector4i f = b.blend(a >> 4, mask);
-		GSVector4i g = (d << 4).blend(c, mask);
-		GSVector4i h = d.blend(c >> 4, mask);
-
-		a = e.upl8(f);
-		c = e.uph8(f);
-		b = g.upl8(h);
-		d = g.uph8(h);
+		mix4(a, b);
+		mix4(c, d);
+		sw8(a, b, c, d);
 	}
 
 	__forceinline static void sw8(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d)
@@ -1749,6 +1749,8 @@ public:
 		b = f.upl32(d);
 		d = f.uph32(d);
 	}
+
+	__forceinline static void sw32_inv(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d);
 
 	__forceinline static void sw64(GSVector4i& a, GSVector4i& b, GSVector4i& c, GSVector4i& d)
 	{

--- a/pcsx2/GS/GSVector8i.h
+++ b/pcsx2/GS/GSVector8i.h
@@ -459,124 +459,124 @@ public:
 
 	// cross lane! from 128-bit to full 256-bit range
 
-	__forceinline GSVector8i i8to16c() const
+	static __forceinline GSVector8i i8to16(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepi8_epi16(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepi8_epi16(v.m));
 	}
 
-	__forceinline GSVector8i u8to16c() const
+	static __forceinline GSVector8i u8to16(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepu8_epi16(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepu8_epi16(v.m));
 	}
 
-	__forceinline GSVector8i i8to32c() const
+	static __forceinline GSVector8i i8to32(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepi8_epi32(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepi8_epi32(v.m));
 	}
 
-	__forceinline GSVector8i u8to32c() const
+	static __forceinline GSVector8i u8to32(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepu8_epi32(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepu8_epi32(v.m));
 	}
 
-	__forceinline GSVector8i i8to64c() const
+	static __forceinline GSVector8i i8to64(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepi8_epi64(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepi8_epi64(v.m));
 	}
 
-	__forceinline GSVector8i u8to64c() const
+	static __forceinline GSVector8i u8to64(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepu16_epi64(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepu16_epi64(v.m));
 	}
 
-	__forceinline GSVector8i i16to32c() const
+	static __forceinline GSVector8i i16to32(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepi16_epi32(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepi16_epi32(v.m));
 	}
 
-	__forceinline GSVector8i u16to32c() const
+	static __forceinline GSVector8i u16to32(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepu16_epi32(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepu16_epi32(v.m));
 	}
 
-	__forceinline GSVector8i i16to64c() const
+	static __forceinline GSVector8i i16to64(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepi16_epi64(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepi16_epi64(v.m));
 	}
 
-	__forceinline GSVector8i u16to64c() const
+	static __forceinline GSVector8i u16to64(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepu16_epi64(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepu16_epi64(v.m));
 	}
 
-	__forceinline GSVector8i i32to64c() const
+	static __forceinline GSVector8i i32to64(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepi32_epi64(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepi32_epi64(v.m));
 	}
 
-	__forceinline GSVector8i u32to64c() const
+	static __forceinline GSVector8i u32to64(const GSVector4i& v)
 	{
-		return GSVector8i(_mm256_cvtepu32_epi64(_mm256_castsi256_si128(m)));
+		return GSVector8i(_mm256_cvtepu32_epi64(v.m));
 	}
 
 	//
 
-	static __forceinline GSVector8i i8to16c(const void* p)
+	static __forceinline GSVector8i i8to16(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i u8to16c(const void* p)
+	static __forceinline GSVector8i u8to16(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepu8_epi16(_mm_load_si128((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i i8to32c(const void* p)
+	static __forceinline GSVector8i i8to32(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepi8_epi32(_mm_loadl_epi64((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i u8to32c(const void* p)
+	static __forceinline GSVector8i u8to32(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i i8to64c(int i)
+	static __forceinline GSVector8i i8to64(int i)
 	{
 		return GSVector8i(_mm256_cvtepi8_epi64(_mm_cvtsi32_si128(i)));
 	}
 
-	static __forceinline GSVector8i u8to64c(int i)
+	static __forceinline GSVector8i u8to64(int i)
 	{
 		return GSVector8i(_mm256_cvtepu8_epi64(_mm_cvtsi32_si128(i)));
 	}
 
-	static __forceinline GSVector8i i16to32c(const void* p)
+	static __forceinline GSVector8i i16to32(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepi16_epi32(_mm_load_si128((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i u16to32c(const void* p)
+	static __forceinline GSVector8i u16to32(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepu16_epi32(_mm_load_si128((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i i16to64c(const void* p)
+	static __forceinline GSVector8i i16to64(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepi16_epi64(_mm_loadl_epi64((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i u16to64c(const void* p)
+	static __forceinline GSVector8i u16to64(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepu16_epi64(_mm_loadl_epi64((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i i32to64c(const void* p)
+	static __forceinline GSVector8i i32to64(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepi32_epi64(_mm_load_si128((__m128i*)p)));
 	}
 
-	static __forceinline GSVector8i u32to64c(const void* p)
+	static __forceinline GSVector8i u32to64(const void* p)
 	{
 		return GSVector8i(_mm256_cvtepu32_epi64(_mm_load_si128((__m128i*)p)));
 	}

--- a/pcsx2/GS/GSVector8i.h
+++ b/pcsx2/GS/GSVector8i.h
@@ -1255,6 +1255,16 @@ public:
 
 	// TODO: swizzling
 
+	__forceinline static void mix4(GSVector8i& a, GSVector8i& b)
+	{
+		GSVector8i mask(_mm256_set1_epi32(0x0f0f0f0f));
+
+		GSVector8i c = (b << 4).blend(a, mask);
+		GSVector8i d = b.blend(a >> 4, mask);
+		a = c;
+		b = d;
+	}
+
 	__forceinline static void sw8(GSVector8i& a, GSVector8i& b)
 	{
 		GSVector8i c = a;
@@ -1281,6 +1291,8 @@ public:
 		a = c.upl32(d);
 		b = c.uph32(d);
 	}
+
+	__forceinline static void sw32_inv(GSVector8i& a, GSVector8i& b);
 
 	__forceinline static void sw64(GSVector8i& a, GSVector8i& b)
 	{

--- a/pcsx2/GS/GSVector8i.h
+++ b/pcsx2/GS/GSVector8i.h
@@ -1333,7 +1333,7 @@ public:
 		GSVector8i c = a;
 		GSVector8i d = b;
 
-		a = c.ac(d);
+		a = c.insert<1>(d.extract<0>()); // Should become a single vinserti128, faster on Zen+
 		b = c.bd(d);
 	}
 

--- a/pcsx2/GS/GSVector8i.h
+++ b/pcsx2/GS/GSVector8i.h
@@ -316,6 +316,12 @@ public:
 		return GSVector8i(_mm256_blend_epi16(m, a, mask));
 	}
 
+	template <int mask>
+	__forceinline GSVector8i blend32(const GSVector8i& a) const
+	{
+		return GSVector8i(_mm256_blend_epi32(m, a, mask));
+	}
+
 	__forceinline GSVector8i blend(const GSVector8i& a, const GSVector8i& mask) const
 	{
 		return GSVector8i(_mm256_or_si256(_mm256_andnot_si256(mask, m), _mm256_and_si256(mask, a)));

--- a/pcsx2/PCSX2Base.h
+++ b/pcsx2/PCSX2Base.h
@@ -35,3 +35,11 @@
 #elif _M_SSE < 0x401
 	#error PCSX2 requires compiling for at least SSE 4.1
 #endif
+
+// Starting with AVX, processors have fast unaligned loads
+// Reduce code duplication by not compiling multiple versions
+#if _M_SSE >= 0x500
+	#define FAST_UNALIGNED 1
+#else
+	#define FAST_UNALIGNED 0
+#endif

--- a/tests/ctest/GS/swizzle_test_main.cpp
+++ b/tests/ctest/GS/swizzle_test_main.cpp
@@ -432,7 +432,7 @@ TEST(ReadAndExpandTest, Read4)
 	{
 		TestData expected = swizzle4(&columnTable4[0][0], data, true);
 		expected = expand4(expected.prepareExpand());
-		GSBlock::ReadAndExpandBlock4_32(data.block, data.output, 128, data.clut64);
+		GSBlock::ReadAndExpandBlock4_32(data.block, data.output, 128, data.clut32);
 		assertEqual(expected, data, "ReadAndExpand4", 16, 32, 32);
 	});
 }


### PR DESCRIPTION
### Description of Changes
A bunch of minor improvements to GSBlock deswizzles
Nets fairly large improvements in GSBenchmark, much smaller improvements in actual games (since there's also everything else running).  Biggest improvement I noticed is in CPU palette conversion (a few percent in Baldur's Gate).  Intel Skylake+ may see larger improvements in those situations from the new use of `vpgatherdd`, but I don't have a Skylake+ CPU to test.

### Rationale behind Changes
speed

### Suggested Testing Steps
Test various games, make sure graphics aren't all glitchy, see if anything got any faster
Stare at the CI and make sure unit tests pass