### PR TITLE
Cmake: Fix ENABLE_VTUNE build.

### DIFF
--- a/cmake/FindVtune.cmake
+++ b/cmake/FindVtune.cmake
@@ -6,6 +6,7 @@
 # VTUNE_LIBRARIES    path to vtune libs
 
 find_path(VTUNE_INCLUDE_DIRS NAMES jitprofiling.h PATHS
+	/opt/intel/oneapi/vtune/latest/include
 	/opt/intel/vtune_amplifier_xe_2018/include
 	/opt/intel/vtune_amplifier_xe_2017/include
 	/opt/intel/vtune_amplifier_xe_2016/include
@@ -13,12 +14,14 @@ find_path(VTUNE_INCLUDE_DIRS NAMES jitprofiling.h PATHS
 
 if(${PCSX2_TARGET_ARCHITECTURES} MATCHES "i386")
 	find_library(VTUNE_LIBRARIES NAMES libjitprofiling.a PATHS
+		/opt/intel/oneapi/vtune/latest/lib32
 		/opt/intel/vtune_amplifier_xe_2018/lib32
 		/opt/intel/vtune_amplifier_xe_2017/lib32
 		/opt/intel/vtune_amplifier_xe_2016/lib32
 	)
 else()
 	find_library(VTUNE_LIBRARIES NAMES libjitprofiling.a PATHS
+		/opt/intel/oneapi/vtune/latest/lib64
 		/opt/intel/vtune_amplifier_xe_2018/lib64
 		/opt/intel/vtune_amplifier_xe_2017/lib64
 		/opt/intel/vtune_amplifier_xe_2016/lib64

--- a/common/src/Utilities/CMakeLists.txt
+++ b/common/src/Utilities/CMakeLists.txt
@@ -98,6 +98,10 @@ else()
 	)
 endif()
 
+if(USE_VTUNE)
+	target_link_libraries(Utilities PUBLIC Vtune::Vtune)
+endif()
+
 target_link_libraries(Utilities PRIVATE ${LIBC_LIBRARIES} PUBLIC wxWidgets::all)
 target_compile_features(Utilities PUBLIC cxx_std_17)
 target_include_directories(Utilities PUBLIC ../../../3rdparty/include ../../include PRIVATE ../../include/Utilities .)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1279,10 +1279,6 @@ foreach(res_file IN ITEMS
 	add_custom_command(OUTPUT "${res_rec_vp_src}/${res_file}.h" COMMAND ${BIN2CPP} "${res_rec_vp_src}/${res_file}.png" "${res_rec_vp_src}/${res_file}" )
 endforeach()
 
-if(USE_VTUNE)
-	target_link_libraries(PCSX2 PRIVATE Vtune::Vtune)
-endif()
-
 # additonal include directories
 target_include_directories(PCSX2 PRIVATE
 	.


### PR DESCRIPTION
Utilities needs to include/link Vtune. 

Also update the search paths to the modern setup for intel tools.
