### PR TITLE
Disable gl threaded optimization

### DIFF
--- a/linux_various/PCSX2.desktop.in
+++ b/linux_various/PCSX2.desktop.in
@@ -9,7 +9,7 @@ GenericName[zh_CN]=PlayStation 2 模拟器
 Comment=Sony PlayStation 2 emulator
 Comment[ru]=Эмулятор Sony PlayStation 2
 Comment[zh_CN]=索尼 PlayStation 2 模拟器
-Exec=env GDK_BACKEND=x11 __GL_THREADED_OPTIMIZATIONS=1 mesa_glthread=true MESA_NO_ERROR=1 PCSX2
+Exec=env GDK_BACKEND=x11 MESA_NO_ERROR=1 PCSX2
 Icon=PCSX2
 Keywords=game;emulator;
 Categories=@PCSX2_MENU_CATEGORIES@


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Disable gl threaded optimizations in Linux

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Due to recent issues with Nvidia driver in Linux breaking the optimization. Pcsx2 has not run correctly with it enabled

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Run Nvidia Linux and compare master to this performance-wise. Preferably in rolling release distros with the latest drivers