### PR TITLE
SPU2: Adjust DMA timings for IRQ's and small packets

### DIFF
--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -463,14 +463,6 @@ __forceinline void TimeUpdate(u32 cClocks)
 
 		if (Cores[0].DMAICounter <= 0)
 		{
-			if (((Cores[0].AutoDMACtrl & 1) != 1) && Cores[0].ReadSize)
-			{
-				if (Cores[0].IsDMARead)
-					Cores[0].FinishDMAread();
-				else
-					Cores[0].FinishDMAwrite();
-			}
-
 			for (int i = 0; i < 2; i++)
 			{
 				if (has_to_call_irq_dma[i])
@@ -484,6 +476,15 @@ __forceinline void TimeUpdate(u32 cClocks)
 					}
 				}
 			}
+
+			if (((Cores[0].AutoDMACtrl & 1) != 1) && Cores[0].ReadSize)
+			{
+				if (Cores[0].IsDMARead)
+					Cores[0].FinishDMAread();
+				else
+					Cores[0].FinishDMAwrite();
+			}
+
 			if (Cores[0].DMAICounter <= 0)
 			{
 				HW_DMA4_MADR = HW_DMA4_TADR;
@@ -515,14 +516,6 @@ __forceinline void TimeUpdate(u32 cClocks)
 			HW_DMA7_MADR += amt / 2;
 		if (Cores[1].DMAICounter <= 0)
 		{
-			if (((Cores[1].AutoDMACtrl & 2) != 2) && Cores[1].ReadSize)
-			{
-				if (Cores[1].IsDMARead)
-					Cores[1].FinishDMAread();
-				else
-					Cores[1].FinishDMAwrite();
-			}
-
 			for (int i = 0; i < 2; i++)
 			{
 				if (has_to_call_irq_dma[i])
@@ -535,6 +528,14 @@ __forceinline void TimeUpdate(u32 cClocks)
 						spu2Irq();
 					}
 				}
+			}
+
+			if (((Cores[1].AutoDMACtrl & 2) != 2) && Cores[1].ReadSize)
+			{
+				if (Cores[1].IsDMARead)
+					Cores[1].FinishDMAread();
+				else
+					Cores[1].FinishDMAwrite();
 			}
 
 			if (Cores[1].DMAICounter <= 0)


### PR DESCRIPTION
This also gets rid of a little kinda hack thing that was in there.

### Description of Changes
Modifies the timing value used when doing a read/write to use the size of the data transferred, but also adjusted it so IRQ's don't happen immediately after the transfer, which was technically incorrect.  Also gets rid of a small hack that was added a while back, which wasn't even done correctly anyway! yay me.

### Rationale behind Changes
Fixes #4698 which was crashing on some PAL regions due to an IOP timing issue, probably caused by the DMA changes, but this should fix it.

### Suggested Testing Steps
Run games, make sure the sound works fine, especially if you know a game that's had audio problems in the past.
