### PR TITLE
SPU2: Don't initialise sound buffer if it's not open

### DIFF
--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -46,15 +46,18 @@ void SPU2configure()
 
 	configure();
 
-	try
+	if (IsOpened)
 	{
-		Console.Warning("SPU2: Sound output module reset");
-		SndBuffer::Init();
-	}
-	catch (std::exception& ex)
-	{
-		fprintf(stderr, "SPU2 Error: Could not initialize device, or something.\nReason: %s", ex.what());
-		SPU2close();
+		try
+		{
+			Console.Warning("SPU2: Sound output module reset");
+			SndBuffer::Init();
+		}
+		catch (std::exception& ex)
+		{
+			fprintf(stderr, "SPU2 Error: Could not initialize device, or something.\nReason: %s", ex.what());
+			SPU2close();
+		}
 	}
 	paused_core.AllowResume();
 }


### PR DESCRIPTION
### Description of Changes
When changing the configuration for Audio when the emulator wasn't running caused the output modules (mainly port audio) to freak out.

### Rationale behind Changes
Sound was going to hell if you went in to the sound config without the GS window being open causing a bit of mess with the output modules.

### Suggested Testing Steps
try changing SPU settings, output modules etc in different scenarios, like the game running, escaped from the game, before you start any game, after starting a new game, stuff like that.
