### PR TITLE
App: Add Windows exe version information

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 if(WIN32)
 	# Resources
 	target_sources(PCSX2 PRIVATE
+		PCSX2.rc
 		GS/GS.rc
 		PAD/Windows/PAD.rc
 		SPU2/Windows/SPU2.rc

--- a/pcsx2/PCSX2.rc
+++ b/pcsx2/PCSX2.rc
@@ -1,0 +1,121 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#define APSTUDIO_HIDDEN_SYMBOLS
+#include "windows.h"
+#undef APSTUDIO_HIDDEN_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#define APSTUDIO_HIDDEN_SYMBOLS\r\n"
+    "#include ""windows.h""\r\n"
+    "#undef APSTUDIO_HIDDEN_SYMBOLS\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,7,0,0
+ PRODUCTVERSION 1,7,0,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "080904b0"
+        BEGIN
+            VALUE "CompanyName", "PCSX2"
+            VALUE "FileDescription", "PCSX2 PS2 Emulator"
+            VALUE "FileVersion", "1.7.0.0"
+            VALUE "LegalCopyright", "Copyright (C) 2021"
+            VALUE "ProductName", "PCSX2"
+            VALUE "ProductVersion", "1.7.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x809, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United Kingdom) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (United Kingdom) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/pcsx2/PCSX2.rc
+++ b/pcsx2/PCSX2.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
+#include "SysForwardDefs.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -29,7 +30,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 1 TEXTINCLUDE 
 BEGIN
-    "resource.h\0"
+    "resource.h\r\n"
+    "SysForwardDefs.h\0"
 END
 
 2 TEXTINCLUDE 
@@ -49,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,7,0,0
- PRODUCTVERSION 1,7,0,0
+ FILEVERSION        VER_FILE_VERSION
+ PRODUCTVERSION     VER_PRODUCT_VERSION
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -63,14 +65,15 @@ VS_VERSION_INFO VERSIONINFO
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
-        BLOCK "080904b0"
+        BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "PCSX2"
-            VALUE "FileDescription", "PCSX2 PS2 Emulator"
-            VALUE "FileVersion", "1.7.0.0"
-            VALUE "LegalCopyright", "Copyright (C) 2021"
-            VALUE "ProductName", "PCSX2"
-            VALUE "ProductVersion", "1.7.0.0"
+            VALUE "FileDescription", VER_FILE_DESCRIPTION_STR "\0"
+            VALUE "FileVersion", VER_FILE_VERSION_STR "\0"
+            VALUE "InternalName", VER_INTERNAL_NAME_STR "\0"
+            VALUE "LegalCopyright", VER_COPYRIGHT_STR "\0"
+            VALUE "OriginalFilename", VER_ORIGINAL_FILENAME_STR "\0"
+            VALUE "ProductName", VER_PRODUCTNAME_STR "\0"
+            VALUE "ProductVersion", VER_PRODUCT_VERSION_STR "\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/pcsx2/SysForwardDefs.h
+++ b/pcsx2/SysForwardDefs.h
@@ -15,9 +15,27 @@
 
 #pragma once
 
-static const int PCSX2_VersionHi	= 1;
-static const int PCSX2_VersionMid	= 7;
-static const int PCSX2_VersionLo	= 0;
+#define PCSX2_VersionHi     1
+#define PCSX2_VersionMid    7
+#define PCSX2_VersionLo     0
+
+#define STRINGIZE2(s) #s
+#define STRINGIZE(s) STRINGIZE2(s)
+
+#define VER_FILE_DESCRIPTION_STR    "PCSX2 PS2 Emulator"
+#define VER_FILE_VERSION            PCSX2_VersionHi, PCSX2_VersionMid, PCSX2_VersionLo, 0
+#define VER_FILE_VERSION_STR        STRINGIZE(PCSX2_VersionHi)        \
+                                    "." STRINGIZE(PCSX2_VersionMid)    \
+                                    "." STRINGIZE(PCSX2_VersionLo) \
+                                    "." STRINGIZE(0)    \
+
+#define VER_PRODUCTNAME_STR         "PCSX2"
+#define VER_PRODUCT_VERSION         VER_FILE_VERSION
+#define VER_PRODUCT_VERSION_STR     VER_FILE_VERSION_STR
+#define VER_ORIGINAL_FILENAME_STR   VER_PRODUCTNAME_STR ".exe"
+#define VER_INTERNAL_NAME_STR       VER_ORIGINAL_FILENAME_STR
+#define VER_COPYRIGHT_STR           "Copyright (C) 2021"
+
 static const bool PCSX2_isReleaseVersion = 0;
 
 class SysCoreThread;

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -936,6 +936,7 @@
     <ClInclude Include="Utilities\AsciiFile.h" />
     <ClInclude Include="Elfheader.h" />
     <ClInclude Include="CDVD\IsoFileFormats.h" />
+    <ClInclude Include="resource.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="Dump.h" />
@@ -1078,6 +1079,7 @@
     <ResourceCompile Include="$(SolutionDir)3rdparty\wxwidgets3.0\include\wx\msw\wx.rc">
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\wxwidgets3.0\$(PlatformName);$(SolutionDir)3rdparty\wxwidgets3.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
+    <ResourceCompile Include="PCSX2.rc" />
     <ResourceCompile Include="GS\GS.rc" />
     <ResourceCompile Include="PAD\Windows\PAD.rc" />
     <ResourceCompile Include="SPU2\Windows\SPU2.rc" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -371,6 +371,9 @@
     <ClCompile Include="PrecompiledHeader.cpp">
       <Filter>Misc</Filter>
     </ClCompile>
+	<ClInclude Include="resource.h">
+	  <Filter>Misc</Filter>
+	</ClInclude>
     <ClCompile Include="ShiftJisToUnicode.cpp">
       <Filter>Misc</Filter>
     </ClCompile>
@@ -2563,7 +2566,9 @@
     <ClInclude Include="GS\Renderers\Common\GSFastList.h">
       <Filter>System\Ps2\GS</Filter>
     </ClInclude>
-    <ClInclude Include="GS\resource.h" />
+    <ClInclude Include="GS\resource.h">
+	  <Filter>System\Ps2\GS</Filter>
+	</ClInclude>
     <ClInclude Include="GS.h">
       <Filter>System\Ps2</Filter>
     </ClInclude>
@@ -2717,6 +2722,9 @@
       <Filter>AppHost\Resources</Filter>
     </ResourceCompile>
     <ResourceCompile Include="$(SolutionDir)3rdparty\wxwidgets3.0\include\wx\msw\wx.rc">
+      <Filter>AppHost\Resources</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="PCSX2.rc">
       <Filter>AppHost\Resources</Filter>
     </ResourceCompile>
     <ResourceCompile Include="SPU2\Windows\SPU2.rc">

--- a/pcsx2/resource.h
+++ b/pcsx2/resource.h
@@ -1,0 +1,15 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by PCSX2.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        120
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1074
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif


### PR DESCRIPTION
### Description of Changes
Adds PCSX2 version information to windows executables

### Rationale behind Changes
Windows gets kinda fussy about exe's with no signature and no version information or description, this makes it a little less fussy.

Right now it shares version number with the rest of the app, but it cannot get the GIT revision because linux hates me and I can't think of a way to do it, but honestly 1.7.0 is enough information for the EXE properties.

### Suggested Testing Steps
Make sure it compiles, make sure the exe loads, check the windows properties->details for the exe, make sure it says PCSX2 PS2 emulator and version 1.7, all that fun stuff
