### PR TITLE
Fix Patch file path check when default setting is not used

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -247,10 +247,7 @@ int LoadPatchesFromDir(wxString name, const wxDirName& folderName, const wxStrin
 	wxString filespec = name + L"*.pnach";
 	loaded += _LoadPatchFiles(folderName, filespec, friendlyName, numberFoundPatchFiles);
 
-	// This comment _might_ be buggy. This function (LoadPatchesFromDir) loads from an explicit folder.
-	// This folder can be cheats or cheats_ws at either the default location or a custom one.
-	// This check only tests the default cheats folder, so the message it produces is possibly misleading.
-	if (folderName.ToString().IsSameAs(PathDefs::GetCheats().ToString()) && numberFoundPatchFiles == 0)
+	if (folderName.ToString().IsSameAs(GetCheatsFolder().ToString()) && numberFoundPatchFiles == 0)
 	{
 		wxString pathName = Path::Combine(folderName, name.MakeUpper() + L".pnach");
 		PatchesCon->WriteLn(Color_Gray, L"Not found %s file: %s", WX_STR(friendlyName), WX_STR(pathName));


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
When PCSX2 cannot find a cheats file, `Not found Cheats file: C:\\pcsx2\cheats\xxxxxxxx.pnach` should be displayed.
On master, however, if you uncheck "Use default setting" and select a different folder in Folder Settings, that line will not be displayed.
<!-- This PR may affect #4005  -->
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
`PathDefs::GetCheats()` should be used only for default value initialization. 

### Suggested Testing Steps
Enable PCSX2 Program Log >Sources>Dev/verbose. Set non-default cheats folder, and make sure this folder is empty.
Run the game, enable cheats and check if the log `Not found Cheats file:<FILEPATH>.pnach` is displayed.
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
