### PR TITLE
pad-windows: Always use Xinput 1.4.

### DIFF
--- a/pcsx2/PAD/Windows/XInputEnum.cpp
+++ b/pcsx2/PAD/Windows/XInputEnum.cpp
@@ -292,15 +292,8 @@ void EnumXInputDevices()
 		if (xinputNotInstalled)
 			return;
 
-		// Prefer XInput 1.3 since SCP only has an XInput 1.3 wrapper right now.
-		// Also use LoadLibrary and not LoadLibraryEx for XInput 1.3, since some
-		// Windows 7 systems have issues with it.
-		// FIXME: Missing FreeLibrary call.
-		HMODULE hMod = LoadLibrary(L"xinput1_3.dll");
-		if (hMod == nullptr && IsWindows8OrGreater())
-		{
-			hMod = LoadLibraryEx(L"XInput1_4.dll", nullptr, LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
-		}
+
+		HMODULE hMod = LoadLibraryEx(L"XInput1_4.dll", nullptr, LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
 
 		if (hMod)
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Removes Xinput 1.3 alternative for W7.
This also removes compatibility with SCP Toolkit.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Windows 7 is no longer supported.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test pad if it still works on windows.