### PR TITLE
Vu int improve

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -11696,7 +11696,6 @@ SLES-52568:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
-    - VUKickstartHack # Fixes loading hang.
 SLES-52569:
   name: "Spyro - A Hero's Tail"
   region: "PAL-M6"
@@ -35789,7 +35788,6 @@ SLUS-20909:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad geometry.
-    - VUKickstartHack # Fixes loading hang.
 SLUS-20910:
   name: "Test Drive - Eve of Destruction"
   region: "NTSC-U"

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -292,7 +292,7 @@ __fi void gifInterrupt()
 		}
 		// If the dma has data waiting and there's something in the fifo, drain the fifo
 		// If the GIF is currently paused, check if the FIFO is full, otherwise fill it
-		if (((gifch.qwc > 0) || (!gif.gspath3done)) && (CheckPaths() || gif_fifo.fifoSize == 16 || readSize))
+		if ((!CheckPaths() && gif_fifo.fifoSize == 16) || (readSize && gif_fifo.fifoSize > 0))
 			return;
 	}
 
@@ -804,7 +804,7 @@ void gifMFIFOInterrupt()
 
 		// If the dma has data waiting and there's something in the fifo, drain the fifo
 		// If the GIF is currently paused, check if the FIFO is full, otherwise fill it
-		if (((gifch.qwc > 0) || (!gif.gspath3done)) && (CheckPaths() || gif_fifo.fifoSize == 16 || readSize))
+		if ((!CheckPaths() && gif_fifo.fifoSize == 16) || (readSize && gif_fifo.fifoSize > 0))
 			return;
 	}
 

--- a/pcsx2/Gif.h
+++ b/pcsx2/Gif.h
@@ -287,3 +287,4 @@ extern void dmaGIF();
 extern void mfifoGIFtransfer();
 extern void gifMFIFOInterrupt();
 extern void clearFIFOstuff(bool full);
+extern void gifCheckPathStatus(bool calledFromGIF);

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -775,6 +775,9 @@ struct Gif_Unit
 			}
 			else
 			{
+				// If PATH3 was stalled due to another transfer but the DMA ended, it'll never check this
+				// So lets quickly check if it's currently set to path3
+				gifCheckPathStatus(true);
 				if (isResume || curPath == 0)
 				{
 					stat.APATH = 0;

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -568,8 +568,14 @@ struct Gif_Unit
 			}
 			if (curSize >= size)
 				return size;
-			if (gifTag.tag.EOP)
+			if(!EmuConfig.Cpu.Recompiler.EnableVU1 && pathIdx == GIF_PATH_1)
+			{
+				return curSize | ((u32)gifTag.tag.EOP << 31);
+			}
+			if (gifTag.tag.EOP )
+			{
 				return curSize;
+			}
 		}
 	}
 

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -327,6 +327,7 @@ struct Gif_Path
 				if (curOffset + 16 > curSize)
 				{
 					//GUNIT_LOG("Path Buffer: Not enough data for gif tag! [%d]", curSize-curOffset);
+					GUNIT_WARN("PATH %d not enough data pre tag, available %d wanted %d", gifRegs.stat.APATH, curSize - curOffset, 16);
 					return gsPack;
 				}
 
@@ -339,11 +340,12 @@ struct Gif_Path
 				gifTag.setTag(&buffer[curOffset], 1);
 
 				state = (GIF_PATH_STATE)(gifTag.tag.FLG + 1);
-
+				GUNIT_WARN("PATH %d New tag State %d FLG %d EOP %d NLOOP %d", gifRegs.stat.APATH, gifRegs.stat.APATH, state, gifTag.tag.FLG, gifTag.tag.EOP, gifTag.tag.NLOOP);
 				// We don't have enough data for a complete GS packet
 				if (!gifTag.hasAD && curOffset + 16 + gifTag.len > curSize)
 				{
 					gifTag.isValid = false; // So next time we test again
+					GUNIT_WARN("PATH %d not enough data, available %d wanted %d", gifRegs.stat.APATH, curSize - curOffset, 16 + gifTag.len);
 					return gsPack;
 				}
 
@@ -357,7 +359,10 @@ struct Gif_Path
 				while (gifTag.nLoop && !dblSIGNAL)
 				{
 					if (curOffset + 16 > curSize)
+					{
+						GUNIT_WARN("PATH %d not enough data AD, available %d wanted %d", gifRegs.stat.APATH, curSize - curOffset, 16);
 						return gsPack; // Exit Early
+					}
 					if (gifTag.curReg() == GIF_REG_A_D)
 					{
 						if (!isMTVU())
@@ -367,7 +372,10 @@ struct Gif_Path
 					gifTag.packedStep();
 				}
 				if (dblSIGNAL && !(gifTag.tag.EOP && !gifTag.nLoop))
+				{
+					GUNIT_WARN("PATH %d early exit (double signal)", gifRegs.stat.APATH);
 					return gsPack; // Exit Early
+				}
 			}
 			else
 				incTag(curOffset, gsPack.size, gifTag.len); // Data length
@@ -384,7 +392,7 @@ struct Gif_Path
 
 				gsPack.Reset();
 				gsPack.offset = curOffset;
-
+				GUNIT_WARN("EOP PATH %d", gifRegs.stat.APATH);
 				//Path 3 Masking is timing sensitive, we need to simulate its length! (NFSU2/Outrun 2006)
 
 				if ((gifRegs.stat.APATH - 1) == GIF_PATH_3)
@@ -707,6 +715,7 @@ struct Gif_Unit
 			return 0;
 		}
 		bool didPath3 = false;
+		bool path3Check = isPath3;
 		int curPath = stat.APATH > 0 ? stat.APATH - 1 : 0; //Init to zero if no path is already set.
 		gifPath[2].dmaRewind = 0;
 		stat.OPH = 1;
@@ -756,30 +765,43 @@ struct Gif_Unit
 			}
 			if (!gsSIGNAL.queued && !gifPath[0].isDone())
 			{
+				GUNIT_WARN("Swapping to PATH 1");
 				stat.APATH = 1;
 				stat.P1Q = 0;
 				curPath = 0;
 			}
 			else if (!gsSIGNAL.queued && !gifPath[1].isDone())
 			{
+				GUNIT_WARN("Swapping to PATH 2");
 				stat.APATH = 2;
 				stat.P2Q = 0;
 				curPath = 1;
 			}
 			else if (!gsSIGNAL.queued && !gifPath[2].isDone() && !Path3Masked())
 			{
+				GUNIT_WARN("Swapping to PATH 3");
 				stat.APATH = 3;
 				stat.P3Q = 0;
 				stat.IP3 = 0;
 				curPath = 2;
+				path3Check = true;
 			}
 			else
 			{
+				GUNIT_WARN("Finished Processing");
 				// If PATH3 was stalled due to another transfer but the DMA ended, it'll never check this
 				// So lets quickly check if it's currently set to path3
-				gifCheckPathStatus(true);
-				if (isResume || curPath == 0)
+				if (stat.APATH == 3 || path3Check)
+					gifCheckPathStatus(true);
+				else
 				{
+					if (vif1Regs.stat.VGW)
+					{
+						// Check if VIF is in a cycle or is currently "idle" waiting for GIF to come back.
+						if (!(cpuRegs.interrupt & (1 << DMAC_VIF1)))
+							CPU_INT(DMAC_VIF1, 1);
+					}
+
 					stat.APATH = 0;
 					stat.OPH = 0;
 				}

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A23 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A24 << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -180,6 +180,7 @@ struct __aligned16 VURegs
 	u32 xgkickdiff;
 	u32 xgkicksizeremaining;
 	u32 xgkicklastcycle;
+	u32 xgkickcyclecount;
 
 	u8 VIBackupCycles;
 	u32 VIOldValue;

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -108,7 +108,6 @@ struct efuPipe
 
 struct fmacPipe
 {
-	int enable;
 	u32 regupper;
 	u32 reglower;
 	int flagreg;
@@ -123,7 +122,6 @@ struct fmacPipe
 
 struct ialuPipe
 {
-	int enable;
 	int reg;
 	u32 sCycle;
 	u32 Cycle;
@@ -156,6 +154,7 @@ struct __aligned16 VURegs
 	u32 branchpc;
 	u32 delaybranchpc;
 	bool takedelaybranch;
+	u32 ebit;
 	u32 pending_q;
 	u32 pending_p;
 
@@ -174,13 +173,12 @@ struct __aligned16 VURegs
 	u8* Mem;
 	u8* Micro;
 
-	u32 xgkickenable;
+	bool xgkickenable;
+	bool xgkickendpacket;
 	u32 xgkickaddr;
 	u32 xgkickdiff;
 	u32 xgkicksizeremaining;
 	u32 xgkicklastcycle;
-	u32 xgkickendpacket;
-	u32 ebit;
 
 	u8 VIBackupCycles;
 	u32 VIOldValue;

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -109,9 +109,11 @@ struct efuPipe
 struct fmacPipe
 {
 	int enable;
-	int reg;
+	u32 regupper;
+	u32 reglower;
 	int flagreg;
-	int xyzw;
+	u32 xyzwupper;
+	u32 xyzwlower;
 	u32 sCycle;
 	u32 Cycle;
 	u32 macflag;
@@ -184,10 +186,16 @@ struct __aligned16 VURegs
 	u32 VIOldValue;
 	u32 VIRegNumber;
 
-	fmacPipe fmac[8];
+	fmacPipe fmac[4];
+	u32 fmacreadpos;
+	u32 fmacwritepos;
+	u32 fmaccount;
 	fdivPipe fdiv;
 	efuPipe efu;
-	ialuPipe ialu[8];
+	ialuPipe ialu[4];
+	u32 ialureadpos;
+	u32 ialuwritepos;
+	u32 ialucount;
 
 	VURegs()
 	{

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -110,6 +110,7 @@ struct fmacPipe
 {
 	int enable;
 	int reg;
+	int flagreg;
 	int xyzw;
 	u32 sCycle;
 	u32 Cycle;
@@ -171,6 +172,12 @@ struct __aligned16 VURegs
 	u8* Mem;
 	u8* Micro;
 
+	u32 xgkickenable;
+	u32 xgkickaddr;
+	u32 xgkickdiff;
+	u32 xgkicksizeremaining;
+	u32 xgkicklastcycle;
+	u32 xgkickendpacket;
 	u32 ebit;
 
 	u8 VIBackupCycles;

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -157,6 +157,7 @@ struct __aligned16 VURegs
 	u32 ebit;
 	u32 pending_q;
 	u32 pending_p;
+	u32 blockhasmbit;
 
 	__aligned16 u32 micro_macflags[4];
 	__aligned16 u32 micro_clipflags[4];

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -65,7 +65,7 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 		return;
 	}
 
-	u32 startcycle = VU0.cycle;
+	u32 startcycle = cpuRegs.cycle;
 	u32 runCycles  = 0x7fffffff;
 
 	do { // Run VU until it finishes or M-Bit
@@ -77,7 +77,6 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 	if (addCycles)
 	{
 		cpuRegs.cycle += (VU0.cycle - startcycle);
-		VU0.cycle = cpuRegs.cycle;
 		CpuVU1->ExecuteBlock(0); // Catch up VU1 as it's likely fallen behind
 	}
 }

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -59,7 +59,7 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 	if (!(VU0.VI[REG_VPU_STAT].UL & 1)) return;
 
 	//VU0 is ahead of the EE and M-Bit is already encountered, so no need to wait for it, just catch up the EE
-	if ((VU0.flags & VUFLAG_MFLAGSET) && breakOnMbit && VU0.cycle >= cpuRegs.cycle)
+	if ((VU0.flags & VUFLAG_MFLAGSET) && breakOnMbit && (s32)(cpuRegs.cycle - VU0.cycle) < 0)
 	{
 		cpuRegs.cycle = VU0.cycle;
 		return;
@@ -71,7 +71,7 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 	do { // Run VU until it finishes or M-Bit
 		CpuVU0->Execute(runCycles);
 	} while ((VU0.VI[REG_VPU_STAT].UL & 1)						// E-bit Termination
-	  &&	(!breakOnMbit || !(VU0.flags & VUFLAG_MFLAGSET)));	// M-bit Break
+	  &&	(!breakOnMbit || !(VU0.flags & VUFLAG_MFLAGSET) || (s32)(cpuRegs.cycle - VU0.cycle) > 0));	// M-bit Break
 
 	// Add cycles if called from EE's COP2
 	if (addCycles)

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -44,6 +44,8 @@ void __fastcall vu0ExecMicro(u32 addr) {
 
 	// Need to copy the clip flag back to the interpreter in case COP2 has edited it
 	VU0.clipflag = VU0.VI[REG_CLIP_FLAG].UL;
+	VU0.macflag = VU0.VI[REG_MAC_FLAG].UL;
+	VU0.statusflag = VU0.VI[REG_STATUS_FLAG].UL;
 	VU0.VI[REG_VPU_STAT].UL &= ~0xFF;
 	VU0.VI[REG_VPU_STAT].UL |=  0x01;
 	VU0.cycle = cpuRegs.cycle;

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -154,9 +154,7 @@ static void _vu0Exec(VURegs* VU)
 		}
 	}
 	_vuAddUpperStalls(VU, &uregs);
-
-	if (!(ptr[1] & 0x80000000))
-		_vuAddLowerStalls(VU, &lregs);
+	_vuAddLowerStalls(VU, &lregs);
 
 	if (VU->branch > 0) {
 		if (VU->branch-- == 1) {
@@ -222,7 +220,8 @@ void InterpVU0::Execute(u32 cycles)
 
 	VU0.VI[REG_TPC].UL <<= 3;
 	VU0.flags &= ~VUFLAG_MFLAGSET;
-	for (int i = (int)cycles; i > 0; i--) {
+	u32 startcycles = VU0.cycle;
+	while((VU0.cycle - startcycles) < cycles) {
 		if (!(VU0.VI[REG_VPU_STAT].UL & 0x1) || (VU0.flags & VUFLAG_MFLAGSET)) {
 			if (VU0.branch || VU0.ebit) {
 				vu0Exec(&VU0); // run branch delay slot?

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -78,6 +78,9 @@ static void _vu0Exec(VURegs* VU)
 
 	VU->code = ptr[1];
 	VU0regs_UPPER_OPCODE[VU->code & 0x3f](&uregs);
+	lregs.cycles = 0;
+	u32 cyclesBeforeOp = VU0.cycle-1;
+
 #ifndef INT_VUSTALLHACK
 	_vuTestUpperStalls(VU, &uregs);
 #endif
@@ -85,18 +88,23 @@ static void _vu0Exec(VURegs* VU)
 	/* check upper flags */
 	if (ptr[1] & 0x80000000) { /* I flag */
 		_vuTestPipes(VU);
-
+		if (VU->VIBackupCycles > 0)
+			VU->VIBackupCycles -= std::min((u8)(VU0.cycle - cyclesBeforeOp), VU->VIBackupCycles);
 		_vu0ExecUpper(VU, ptr);
 
 		VU->VI[REG_I].UL = ptr[0];
 		memset(&lregs, 0, sizeof(lregs));
 	} else {
 		VU->code = ptr[0];
+
+		
 		VU0regs_LOWER_OPCODE[VU->code >> 25](&lregs);
 #ifndef INT_VUSTALLHACK
 		_vuTestLowerStalls(VU, &lregs);
 #endif
 		_vuTestPipes(VU);
+		if (VU->VIBackupCycles > 0)
+			VU->VIBackupCycles -= std::min((u8)(VU0.cycle - cyclesBeforeOp), VU->VIBackupCycles);
 		vu0branch = lregs.pipe == VUPIPE_BRANCH;
 
 		vfreg = 0; vireg = 0;
@@ -149,9 +157,6 @@ static void _vu0Exec(VURegs* VU)
 
 	if (!(ptr[1] & 0x80000000))
 		_vuAddLowerStalls(VU, &lregs);
-
-	if(VU->VIBackupCycles > 0) 
-		VU->VIBackupCycles--;
 
 	if (VU->branch > 0) {
 		if (VU->branch-- == 1) {

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -207,8 +207,12 @@ static void _vu1Exec(VURegs* VU)
 			_vuFlushAll(VU);
 			VU0.VI[REG_VPU_STAT].UL &= ~0x100;
 			vif1Regs.stat.VEW = false;
+
+			if(VU1.xgkickenable)
+				_vuXGKICKTransfer(VU, 0, true);
 			// In instant VU mode, VU1 goes WAY ahead of the CPU, making the XGKick fall way behind
 			// We also have some code to update it in VIF Unpacks too, since in some games (Aggressive Inline) overwrite the XGKick data
+			// VU currently flushes XGKICK on end, so this isn't needed, yet
 			if (INSTANT_VU1)
 				VU1.xgkicklastcycle = cpuRegs.cycle;
 		}

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -297,7 +297,8 @@ void InterpVU1::Execute(u32 cycles)
 	fesetround(g_sseVUMXCSR.RoundingControl << 8);
 
 	VU1.VI[REG_TPC].UL <<= 3;
-	for (int i = (int)cycles; i > 0; i--)
+	u32 startcycles = VU1.cycle;
+	while ((VU1.cycle - startcycles) < cycles)
 	{
 		if (!(VU0.VI[REG_VPU_STAT].UL & 0x100))
 		{

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -328,6 +328,6 @@ void InterpVU1::Execute(u32 cycles)
 		Step();
 	}
 	VU1.VI[REG_TPC].UL >>= 3;
-
+	VU1.nextBlockCycles = (VU1.cycle - cpuRegs.cycle) + 1;
 	fesetround(originalRounding);
 }

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -214,6 +214,8 @@ static void _vu1Exec(VURegs* VU)
 			IPU_LOG("Banana New packet size %x", VU->xgkicksizeremaining);
 		}
 		u32 transfersize = std::min(VU->xgkicksizeremaining / 0x10, (VU1.cycle - VU->xgkicklastcycle) / 2);
+		transfersize = std::min(transfersize, VU->xgkickdiff / 0x10);
+
 		if (transfersize)
 		{
 			IPU_LOG("Banana Transferring %x bytes from %x size left %x", transfersize * 0x10, VU->xgkickaddr, VU->xgkicksizeremaining);

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -18,17 +18,24 @@
 #include "Common.h"
 
 #include "VUmicro.h"
+#include "GS.h"
+#include "Gif_Unit.h"
 #include "MTVU.h"
 
-extern void _vuFlushAll(VURegs* VU);
+#include <cfenv>
 
-void _vu1ExecUpper(VURegs* VU, u32 *ptr) {
+extern void _vuFlushAll(VURegs* VU);
+extern void _vuXGKICKFlush(VURegs* VU);
+
+void _vu1ExecUpper(VURegs* VU, u32* ptr)
+{
 	VU->code = ptr[1];
-	//IdebugUPPER(VU1);
+	IdebugUPPER(VU1);
 	VU1_UPPER_OPCODE[VU->code & 0x3f]();
 }
 
-void _vu1ExecLower(VURegs* VU, u32 *ptr) {
+void _vu1ExecLower(VURegs* VU, u32* ptr)
+{
 	VU->code = ptr[0];
 	IdebugLOWER(VU1);
 	VU1_LOWER_OPCODE[VU->code >> 25]();
@@ -44,78 +51,89 @@ static void _vu1Exec(VURegs* VU)
 	VECTOR _VFc;
 	REG_VI _VI;
 	REG_VI _VIc;
-	u32 *ptr;
+	u32* ptr;
 	int vfreg;
 	int vireg;
-	int discard=0;
+	int discard = 0;
 
 	ptr = (u32*)&VU->Micro[VU->VI[REG_TPC].UL];
-	VU->VI[REG_TPC].UL+=8;
+	VU->VI[REG_TPC].UL += 8;
 
-	if (ptr[1] & 0x40000000) { /* E flag */
+	if (ptr[1] & 0x40000000)
+	{ /* E flag */
 		VU->ebit = 2;
 	}
-	if (ptr[1] & 0x10000000) { /* D flag */
-		if (VU0.VI[REG_FBRST].UL & 0x400) {
-			VU0.VI[REG_VPU_STAT].UL|= 0x200;
+	if (ptr[1] & 0x10000000)
+	{ /* D flag */
+		if (VU0.VI[REG_FBRST].UL & 0x400)
+		{
+			VU0.VI[REG_VPU_STAT].UL |= 0x200;
 			hwIntcIrq(INTC_VU1);
 			VU->ebit = 1;
 		}
-		
 	}
-	if (ptr[1] & 0x08000000) { /* T flag */
-		if (VU0.VI[REG_FBRST].UL & 0x800) {
-			VU0.VI[REG_VPU_STAT].UL|= 0x400;
+	if (ptr[1] & 0x08000000)
+	{ /* T flag */
+		if (VU0.VI[REG_FBRST].UL & 0x800)
+		{
+			VU0.VI[REG_VPU_STAT].UL |= 0x400;
 			hwIntcIrq(INTC_VU1);
 			VU->ebit = 1;
 		}
-		
 	}
 
 	//VUM_LOG("VU->cycle = %d (flags st=%x;mac=%x;clip=%x,q=%f)", VU->cycle, VU->statusflag, VU->macflag, VU->clipflag, VU->q.F);
 
 	VU->code = ptr[1];
 	VU1regs_UPPER_OPCODE[VU->code & 0x3f](&uregs);
-#ifndef INT_VUSTALLHACK
 	_vuTestUpperStalls(VU, &uregs);
-#endif
 
 	/* check upper flags */
-	if (ptr[1] & 0x80000000) { /* I flag */
+	if (ptr[1] & 0x80000000)
+	{ /* I flag */
+		_vuTestPipes(VU);
+
 		_vu1ExecUpper(VU, ptr);
 
 		VU->VI[REG_I].UL = ptr[0];
 		//Lower not used, set to 0 to fill in the FMAC stall gap
 		//Could probably get away with just running upper stalls, but lets not tempt fate.
-		memset(&lregs, 0, sizeof(lregs));		
-	} else {
+		memset(&lregs, 0, sizeof(lregs));
+	}
+	else
+	{
 		VU->code = ptr[0];
 		VU1regs_LOWER_OPCODE[VU->code >> 25](&lregs);
-#ifndef INT_VUSTALLHACK
+
 		_vuTestLowerStalls(VU, &lregs);
-#endif
+		_vuTestPipes(VU);
 
-		vu1branch = lregs.pipe == VUPIPE_BRANCH;
-
-		vfreg = 0; vireg = 0;
-		if (uregs.VFwrite) {
-			if (lregs.VFwrite == uregs.VFwrite) {
-//				Console.Warning("*PCSX2*: Warning, VF write to the same reg in both lower/upper cycle");
+		vfreg = 0;
+		vireg = 0;
+		if (uregs.VFwrite)
+		{
+			if (lregs.VFwrite == uregs.VFwrite)
+			{
+				//Console.Warning("*PCSX2*: Warning, VF write to the same reg in both lower/upper cycle");
 				discard = 1;
 			}
 			if (lregs.VFread0 == uregs.VFwrite ||
-				lregs.VFread1 == uregs.VFwrite) {
-//				Console.WriteLn("saving reg %d at pc=%x", i, VU->VI[REG_TPC].UL);
+				lregs.VFread1 == uregs.VFwrite)
+			{
+				//Console.WriteLn("saving reg %d at pc=%x", i, VU->VI[REG_TPC].UL);
 				_VF = VU->VF[uregs.VFwrite];
 				vfreg = uregs.VFwrite;
 			}
 		}
-		if (uregs.VIread & (1 << REG_CLIP_FLAG)) {
-			if (lregs.VIwrite & (1 << REG_CLIP_FLAG)) {
+		if (uregs.VIwrite & (1 << REG_CLIP_FLAG))
+		{
+			if (lregs.VIwrite & (1 << REG_CLIP_FLAG))
+			{
 				Console.Warning("*PCSX2*: Warning, VI write to the same reg in both lower/upper cycle");
 				discard = 1;
 			}
-			if (lregs.VIread & (1 << REG_CLIP_FLAG)) {
+			if (lregs.VIread & (1 << REG_CLIP_FLAG))
+			{
 				_VI = VU->VI[REG_CLIP_FLAG];
 				vireg = REG_CLIP_FLAG;
 			}
@@ -123,69 +141,120 @@ static void _vu1Exec(VURegs* VU)
 
 		_vu1ExecUpper(VU, ptr);
 
-		if (discard == 0) {
-			if (vfreg) {
+		if (discard == 0)
+		{
+			if (vfreg)
+			{
 				_VFc = VU->VF[vfreg];
 				VU->VF[vfreg] = _VF;
 			}
-			if (vireg) {
+			if (vireg)
+			{
 				_VIc = VU->VI[vireg];
 				VU->VI[vireg] = _VI;
 			}
 
 			_vu1ExecLower(VU, ptr);
 
-			if (vfreg) {
+			if (vfreg)
+			{
 				VU->VF[vfreg] = _VFc;
 			}
-			if (vireg) {
+			if (vireg)
+			{
 				VU->VI[vireg] = _VIc;
 			}
 		}
 	}
 	_vuAddUpperStalls(VU, &uregs);
-	_vuAddLowerStalls(VU, &lregs);
 
-	_vuTestPipes(VU);
-	
-	if(VU->VIBackupCycles > 0) 
+	//if (!(ptr[1] & 0x80000000))
+		_vuAddLowerStalls(VU, &lregs);
+
+	if (VU->VIBackupCycles > 0)
 		VU->VIBackupCycles--;
-	
-	if (VU->branch > 0) {
-		if (VU->branch-- == 1) {
+
+	if (VU->branch > 0)
+	{
+		if (VU->branch-- == 1)
+		{
 			VU->VI[REG_TPC].UL = VU->branchpc;
 
-			if(VU->takedelaybranch)
-			{				
+			if (VU->takedelaybranch)
+			{
 				VU->branch = 1;
-				//DevCon.Warning("VU1 - Branch/Jump in Delay Slot");			
+				//DevCon.Warning("VU1 - Branch/Jump in Delay Slot");
 				VU->branchpc = VU->delaybranchpc;
 				VU->delaybranchpc = 0;
 				VU->takedelaybranch = false;
-			}			
+			}
 		}
 	}
 
-	if( VU->ebit > 0 ) {
-		if( VU->ebit-- == 1 ) {
+	if (VU->ebit > 0)
+	{
+		if (VU->ebit-- == 1)
+		{
 			VU->VIBackupCycles = 0;
 			_vuFlushAll(VU);
 			VU0.VI[REG_VPU_STAT].UL &= ~0x100;
 			vif1Regs.stat.VEW = false;
 		}
 	}
+	if (VU->xgkickenable && (VU1.cycle - VU->xgkicklastcycle) >= 2)
+	{
+		if (VU->xgkicksizeremaining == 0)
+		{
+			IPU_LOG("Banana Reading next packet from %x", VU->xgkickaddr);
+			u32 size = gifUnit.GetGSPacketSize(GIF_PATH_1, VU->Mem, VU->xgkickaddr);
+			VU->xgkicksizeremaining = size & 0xFFFF;
+			VU->xgkickendpacket = size >> 31;
+			if (VU->xgkicksizeremaining == 0)
+				VU->xgkickenable = 0;
+			IPU_LOG("Banana New packet size %x", VU->xgkicksizeremaining);
+		}
+		u32 transfersize = std::min(VU->xgkicksizeremaining / 0x10, (VU1.cycle - VU->xgkicklastcycle) / 2);
+		if (transfersize)
+		{
+			IPU_LOG("Banana Transferring %x bytes from %x size left %x", transfersize * 0x10, VU->xgkickaddr, VU->xgkicksizeremaining);
+			if ((transfersize * 0x10) > VU->xgkicksizeremaining)
+				gifUnit.gifPath[GIF_PATH_1].CopyGSPacketData(&VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
+			else
+				gifUnit.TransferGSPacketData(GIF_TRANS_XGKICK, &VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
+
+			VU->xgkickaddr = (VU->xgkickaddr + (transfersize * 0x10)) & 0x3FFF;
+			VU->xgkicksizeremaining -= (transfersize * 0x10);
+			VU->xgkickdiff = 0x4000 - VU->xgkickaddr;
+			IPU_LOG("Banana next addr %x left size %x EOP %d", VU->xgkickaddr, VU->xgkicksizeremaining, VU->xgkickendpacket);
+			VU->xgkicklastcycle += std::max(transfersize * 2, 2U);
+
+			if (VU->xgkicksizeremaining || !VU->xgkickendpacket)
+				VU->xgkickenable = 1;
+			else
+			{
+
+				VU->xgkickenable = 0;
+				IPU_LOG("Banana transfer finished");
+			}
+		}
+	}
 }
 
 void vu1Exec(VURegs* VU)
 {
-	_vu1Exec(VU);
 	VU->cycle++;
+	_vu1Exec(VU);
 
-	if (VU->VI[0].UL != 0) DbgCon.Error("VI[0] != 0!!!!\n");
-	if (VU->VF[0].f.x != 0.0f) DbgCon.Error("VF[0].x != 0.0!!!!\n");
-	if (VU->VF[0].f.y != 0.0f) DbgCon.Error("VF[0].y != 0.0!!!!\n");
-	if (VU->VF[0].f.z != 0.0f) DbgCon.Error("VF[0].z != 0.0!!!!\n");
-	if (VU->VF[0].f.w != 1.0f) DbgCon.Error("VF[0].w != 1.0!!!!\n");
+	if (VU->VI[0].UL != 0)
+		DbgCon.Error("VI[0] != 0!!!!\n");
+	if (VU->VF[0].f.x != 0.0f)
+		DbgCon.Error("VF[0].x != 0.0!!!!\n");
+	if (VU->VF[0].f.y != 0.0f)
+		DbgCon.Error("VF[0].y != 0.0!!!!\n");
+	if (VU->VF[0].f.z != 0.0f)
+		DbgCon.Error("VF[0].z != 0.0!!!!\n");
+	if (VU->VF[0].f.w != 1.0f)
+		DbgCon.Error("VF[0].w != 1.0!!!!\n");
 }
 
 InterpVU1::InterpVU1()
@@ -194,11 +263,13 @@ InterpVU1::InterpVU1()
 	IsInterpreter = true;
 }
 
-void InterpVU1::Reset() {
+void InterpVU1::Reset()
+{
 	vu1Thread.WaitVU();
 }
 
-void InterpVU1::Shutdown() noexcept {
+void InterpVU1::Shutdown() noexcept
+{
 	vu1Thread.WaitVU();
 }
 
@@ -210,15 +281,21 @@ void InterpVU1::SetStartPC(u32 startPC)
 void InterpVU1::Step()
 {
 	VU1.VI[REG_TPC].UL &= VU1_PROGMASK;
-	vu1Exec( &VU1 );
+	vu1Exec(&VU1);
 }
 
 void InterpVU1::Execute(u32 cycles)
 {
+	const int originalRounding = fegetround();
+	fesetround(g_sseVUMXCSR.RoundingControl << 8);
+
 	VU1.VI[REG_TPC].UL <<= 3;
-	for (int i = (int)cycles; i > 0; i--) {
-		if (!(VU0.VI[REG_VPU_STAT].UL & 0x100)) {
-			if (VU1.branch || VU1.ebit) {
+	for (int i = (int)cycles; i > 0; i--)
+	{
+		if (!(VU0.VI[REG_VPU_STAT].UL & 0x100))
+		{
+			if (VU1.branch || VU1.ebit)
+			{
 				Step(); // run branch delay slot?
 			}
 			break;
@@ -226,5 +303,6 @@ void InterpVU1::Execute(u32 cycles)
 		Step();
 	}
 	VU1.VI[REG_TPC].UL >>= 3;
-}
 
+	fesetround(originalRounding);
+}

--- a/pcsx2/VUflags.cpp
+++ b/pcsx2/VUflags.cpp
@@ -103,5 +103,5 @@ __ri void VU_STAT_UPDATE(VURegs * VU) {
 	if (VU->macflag & 0x0F00) newflag |= 0x4;
 	if (VU->macflag & 0xF000) newflag |= 0x8;
 	// Save old sticky flags and D/I settings, everthing else is the new flags only
-	VU->statusflag = (VU->statusflag&0xff0)| newflag | (newflag<<6);
+	VU->statusflag = newflag;
 }

--- a/pcsx2/VUflags.cpp
+++ b/pcsx2/VUflags.cpp
@@ -25,22 +25,6 @@
 /*          NEW FLAGS                    */ //By asadr. Thnkx F|RES :p
 /*****************************************/
 
-
-void vuUpdateDI(VURegs * VU) {
-//	u32 Flag_S = 0;
-//	u32 Flag_I = 0;
-//	u32 Flag_D = 0;
-//
-//	/*
-//	FLAG D - I
-//	*/
-//	Flag_I = (VU->statusflag >> 4) & 0x1;
-//	Flag_D = (VU->statusflag >> 5) & 0x1;
-//
-//	VU->statusflag|= (Flag_I | (VU0.VI[REG_STATUS_FLAG].US[0] >> 4)) << 10;
-//	VU->statusflag|= (Flag_D | (VU0.VI[REG_STATUS_FLAG].US[0] >> 5)) << 11;
-}
-
 static __ri u32 VU_MAC_UPDATE( int shift, VURegs * VU, float f )
 {
 	u32 v = *(u32*)&f;
@@ -64,7 +48,7 @@ static __ri u32 VU_MAC_UPDATE( int shift, VURegs * VU, float f )
 			VU->macflag = (VU->macflag&~(0x1000<<shift)) | (0x0101<<shift);
 			return s;
 		case 255:
-			VU->macflag = (VU->macflag&~(0x0100<<shift)) | (0x1000<<shift);
+			VU->macflag = (VU->macflag&~(0x0101<<shift)) | (0x1000<<shift);
 			return s|0x7f7fffff; /* max allowed */
 		default:
 			VU->macflag = (VU->macflag & ~(0x1101<<shift));
@@ -118,5 +102,6 @@ __ri void VU_STAT_UPDATE(VURegs * VU) {
 	if (VU->macflag & 0x00F0) newflag |= 0x2;
 	if (VU->macflag & 0x0F00) newflag |= 0x4;
 	if (VU->macflag & 0xF000) newflag |= 0x8;
-	VU->statusflag = (VU->statusflag&0xc30)|newflag|((VU->statusflag&0xf)<<6);
+	// Save old sticky flags and D/I settings, everthing else is the new flags only
+	VU->statusflag = (VU->statusflag&0xff0)| newflag | (newflag<<6);
 }

--- a/pcsx2/VUflags.cpp
+++ b/pcsx2/VUflags.cpp
@@ -49,7 +49,10 @@ static __ri u32 VU_MAC_UPDATE( int shift, VURegs * VU, float f )
 			return s;
 		case 255:
 			VU->macflag = (VU->macflag&~(0x0101<<shift)) | (0x1000<<shift);
-			return s|0x7f7fffff; /* max allowed */
+			if (CHECK_VU_OVERFLOW)
+				return s | 0x7f7fffff; /* max allowed */
+			else
+				return v;
 		default:
 			VU->macflag = (VU->macflag & ~(0x1101<<shift));
 			return v;

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -82,11 +82,15 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 		return;
 	}
 
-	if (startUp && s) // Start Executing a microprogram (When kickstarted)
+	// You might be looking at this and thinking, what the hell is going on? What's with all these conditions?
+	// Well, basically M-Bit timed games are REALLY picky, so we need some extra checks in to make sure the VU
+	// doesn't go too long without updating/syncing as games will wait for an M-Bit then transfer a bunch of stuff
+	// since they will know what the timing is going to be on them, so we need to keep it somewhat tight.
+	// For everything else (Especially stuff that needs kickstart), they can do what they like.
+	if (startUp) // Start Executing a microprogram (When kickstarted)
 	{
 		Execute(s); // Kick start VU
 
-		// I don't like doing this, but Crash Twinsanity seems to be upset without it
 		if (stat & test)
 		{
 			if (m_Idx)
@@ -94,7 +98,12 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 			else
 				cpuRegs.cycle = VU0.cycle;
 
-			cpuSetNextEventDelta(s);
+			u32 nextblockcycles = m_Idx ? VU1.nextBlockCycles : VU0.nextBlockCycles;
+
+			if((VU0.flags & VUFLAG_MFLAGSET) || VU0.blockhasmbit)
+				cpuSetNextEventDelta(nextblockcycles);
+			else if(s)
+				cpuSetNextEventDelta(s);
 		}
 	}
 	else // Continue Executing
@@ -110,19 +119,21 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 		}
 		else
 		{
-			if (delta >= nextblockcycles) // When running behind, make sure we have enough cycles passed for the block to run
+			if (delta >= nextblockcycles && delta > 0) // When running behind, make sure we have enough cycles passed for the block to run
 				Execute(delta);
 		}
 
-		if (stat & test)
+		if ((stat & test) && !EmuConfig.Gamefixes.VUKickstartHack)
 		{
 			// Queue up next required time to run a block
 			nextblockcycles = m_Idx ? VU1.nextBlockCycles : VU0.nextBlockCycles;
 			cycle = m_Idx ? VU1.cycle : VU0.cycle;
-			nextblockcycles = EmuConfig.Gamefixes.VUKickstartHack ? (cycle - cpuRegs.cycle) : nextblockcycles;
+			nextblockcycles = nextblockcycles - (cycle - cpuRegs.cycle);
 
-			if(nextblockcycles)
+			if (nextblockcycles > 0 || (VU0.flags & VUFLAG_MFLAGSET) || VU0.blockhasmbit)
+			{
 				cpuSetNextEventDelta(nextblockcycles);
+			}
 		}
 	}
 }
@@ -136,12 +147,13 @@ void BaseVUmicroCPU::ExecuteBlockJIT(BaseVUmicroCPU* cpu)
 	const u32& stat = VU0.VI[REG_VPU_STAT].UL;
 	const int test = 1;
 
+	//DevCon.Warning("Was set %d cycles ago", cpuRegs.cycle - setcycle);
 	if (stat & test)
 	{ // VU is running
 		s32 delta = (s32)(u32)(cpuRegs.cycle - VU0.cycle);
 
 		if (delta > 0)
-		{ // Enough time has passed
+		{
 			cpu->Execute(delta); // Execute the time since the last call
 		}
 	}

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -41,18 +41,24 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 			{
 				if (VU1.xgkicksizeremaining == 0)
 				{
-					IPU_LOG("Banana Reading next packet from %x", VU1.xgkickaddr);
 					u32 size = gifUnit.GetGSPacketSize(GIF_PATH_1, VU1.Mem, VU1.xgkickaddr);
 					VU1.xgkicksizeremaining = size & 0xFFFF;
 					VU1.xgkickendpacket = size >> 31;
-					IPU_LOG("Banana New packet size %x", VU1.xgkicksizeremaining);
+					VUM_LOG("XGKICK New packet size %x", VU1.xgkicksizeremaining);
+
+					if (VU1.xgkicksizeremaining == 0)
+					{
+						VUM_LOG("Invalid GS packet size returned, cancelling XGKick");
+						VU1.xgkickenable = false;
+						return;
+					}
 				}
 				u32 transfersize = std::min(VU1.xgkicksizeremaining / 0x10, (cpuRegs.cycle - VU1.xgkicklastcycle) / 2);
 				transfersize = std::min(transfersize, VU1.xgkickdiff / 0x10);
 
 				if (transfersize)
 				{
-					IPU_LOG("Banana Transferring %x bytes from %x size left %x", transfersize * 0x10, VU1.xgkickaddr, VU1.xgkicksizeremaining);
+					VUM_LOG("XGKICK Transferring %x bytes from %x size left %x", transfersize * 0x10, VU1.xgkickaddr, VU1.xgkicksizeremaining);
 					if ((transfersize * 0x10) > VU1.xgkicksizeremaining)
 						gifUnit.gifPath[GIF_PATH_1].CopyGSPacketData(&VU1.Mem[VU1.xgkickaddr], transfersize * 0x10, true);
 					else
@@ -61,20 +67,16 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 					VU1.xgkickaddr = (VU1.xgkickaddr + (transfersize * 0x10)) & 0x3FFF;
 					VU1.xgkicksizeremaining -= (transfersize * 0x10);
 					VU1.xgkickdiff = 0x4000 - VU1.xgkickaddr;
-					IPU_LOG("Banana next addr %x left size %x EOP %d", VU1.xgkickaddr, VU1.xgkicksizeremaining, VU1.xgkickendpacket);
 					VU1.xgkicklastcycle += std::max(transfersize * 2, 2U);
 
 					if (VU1.xgkicksizeremaining || !VU1.xgkickendpacket)
-						VU1.xgkickenable = 1;
+						VUM_LOG("XGKICK next addr %x left size %x", VU1.xgkickaddr, VU1.xgkicksizeremaining);
 					else
 					{
-
-						VU1.xgkickenable = 0;
-						IPU_LOG("Banana transfer finished");
+						VU1.xgkickenable = false;
+						VUM_LOG("XGKICK transfer finished");
 					}
 				}
-				else
-					VU1.xgkickenable = 1;
 			}
 		}
 		return;

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -87,12 +87,12 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 		// I don't like doing this, but Crash Twinsanity seems to be upset without it
 		if (stat & test)
 		{
-			cpuSetNextEventDelta(s);
-
 			if (m_Idx)
-				VU1.cycle = cpuRegs.cycle;
+				cpuRegs.cycle = VU1.cycle;
 			else
-				VU0.cycle = cpuRegs.cycle;
+				cpuRegs.cycle = VU0.cycle;
+
+			cpuSetNextEventDelta(s);
 		}
 	}
 	else // Continue Executing

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -48,6 +48,8 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 					IPU_LOG("Banana New packet size %x", VU1.xgkicksizeremaining);
 				}
 				u32 transfersize = std::min(VU1.xgkicksizeremaining / 0x10, (cpuRegs.cycle - VU1.xgkicklastcycle) / 2);
+				transfersize = std::min(transfersize, VU1.xgkickdiff / 0x10);
+
 				if (transfersize)
 				{
 					IPU_LOG("Banana Transferring %x bytes from %x size left %x", transfersize * 0x10, VU1.xgkickaddr, VU1.xgkicksizeremaining);

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -33,14 +33,15 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 		return;
 	}
 
-	if (!(stat & test))
+	// VU currently flushes XGKICK on VU1 end so no need for this, yet
+	/*if (!(stat & test))
 	{
 		if (m_Idx == 1 && VU1.xgkickenable)
 		{
 			_vuXGKICKTransfer(&VU1, (cpuRegs.cycle - VU1.xgkicklastcycle), false);
 		}
 		return;
-	}
+	}*/
 
 	// You might be looking at this and thinking, what the hell is going on? What's with all these conditions?
 	// Well, basically M-Bit timed games are REALLY picky, so we need some extra checks in to make sure the VU

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -170,7 +170,7 @@ public:
 
 	void Reserve() { }
 	void Shutdown() noexcept { }
-	void Reset() { }
+	void Reset();
 
 	void Step();
 	void SetStartPC(u32 startPC);

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -273,11 +273,11 @@ extern void iDumpVU1Registers();
 #ifdef VUM_LOG
 
 #define IdebugUPPER(VU) \
-	VUM_LOG("%s", dis##VU##MicroUF(VU.code, VU.VI[REG_TPC].UL));
+	VUM_LOG("(VU%d) %s", VU.IsVU1(), dis##VU##MicroUF(VU.code, VU.VI[REG_TPC].UL));
 #define IdebugLOWER(VU) \
-	VUM_LOG("%s", dis##VU##MicroLF(VU.code, VU.VI[REG_TPC].UL));
+	VUM_LOG("(VU%d) %s", VU.IsVU1(), dis##VU##MicroLF(VU.code, VU.VI[REG_TPC].UL));
 #define _vuExecMicroDebug(VU) \
-	VUM_LOG("_vuExecMicro: %8.8x", VU.VI[REG_TPC].UL);
+	VUM_LOG("(VU%d) _vuExecMicro: %8.8x", VU.IsVU1(), VU.VI[REG_TPC].UL);
 
 #else
 

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -449,18 +449,19 @@ __fi void _vuBackupVI(VURegs* VU, int reg)
 #ifndef INT_VUDOUBLEHACK
 static float __fastcall vuDouble(u32 f)
 {
-	switch(f & 0x7f800000)
+	switch (f & 0x7f800000)
 	{
 		case 0x0:
 			f &= 0x80000000;
 			return *(float*)&f;
 			break;
 		case 0x7f800000:
-		{
-			u32 d = (f & 0x80000000)|0x7f7fffff;
-			return *(float*)&d;
+			if (CHECK_VU_OVERFLOW)
+			{
+				u32 d = (f & 0x80000000) | 0x7f7fffff;
+				return *(float*)&d;
+			}
 			break;
-		}
 	}
 	return *(float*)&f;
 }

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -1450,40 +1450,49 @@ static __fi void _vuOPMSUB(VURegs * VU) {
 static __fi void _vuNOP(VURegs * VU) {
 }
 
+static __fi s32 float_to_int(float value)
+{
+	if (value >= 2147483647.0)
+		return 2147483647LL;
+	if (value <= -2147483648.0)
+		return -2147483648LL;
+	return value;
+}
+
 static __fi void _vuFTOI0(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = (s32)vuDouble(VU->VF[_Fs_].i.x);
-	if (_Y) VU->VF[_Ft_].SL[1] = (s32)vuDouble(VU->VF[_Fs_].i.y);
-	if (_Z) VU->VF[_Ft_].SL[2] = (s32)vuDouble(VU->VF[_Fs_].i.z);
-	if (_W) VU->VF[_Ft_].SL[3] = (s32)vuDouble(VU->VF[_Fs_].i.w);
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(vuDouble(VU->VF[_Fs_].i.x));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(vuDouble(VU->VF[_Fs_].i.y));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(vuDouble(VU->VF[_Fs_].i.z));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(vuDouble(VU->VF[_Fs_].i.w));
 }
 
 static __fi void _vuFTOI4(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = float_to_int4(vuDouble(VU->VF[_Fs_].i.x));
-	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int4(vuDouble(VU->VF[_Fs_].i.y));
-	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int4(vuDouble(VU->VF[_Fs_].i.z));
-	if (_W) VU->VF[_Ft_].SL[3] = float_to_int4(vuDouble(VU->VF[_Fs_].i.w));
-}
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.x)));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.y)));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.z)));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.w)));
+}											    
 
 static __fi void _vuFTOI12(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = float_to_int12(vuDouble(VU->VF[_Fs_].i.x));
-	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int12(vuDouble(VU->VF[_Fs_].i.y));
-	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int12(vuDouble(VU->VF[_Fs_].i.z));
-	if (_W) VU->VF[_Ft_].SL[3] = float_to_int12(vuDouble(VU->VF[_Fs_].i.w));
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.x)));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.y)));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.z)));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
 static __fi void _vuFTOI15(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = float_to_int15(vuDouble(VU->VF[_Fs_].i.x));
-	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int15(vuDouble(VU->VF[_Fs_].i.y));
-	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int15(vuDouble(VU->VF[_Fs_].i.z));
-	if (_W) VU->VF[_Ft_].SL[3] = float_to_int15(vuDouble(VU->VF[_Fs_].i.w));
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.x)));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.y)));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.z)));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
 static __fi void _vuITOF0(VURegs * VU) {
@@ -1694,7 +1703,7 @@ static __fi void _vuMTIR(VURegs * VU) {
 
 	_vuBackupVI(VU, _It_);
 
-	VU->VI[_It_].US[0] =  *(u16*)&VU->VF[_Fs_].F[_Fsf_];
+	VU->VI[_It_].US[0] = *(u16*)&VU->VF[_Fs_].F[_Fsf_];
 }
 
 static __fi void _vuMR32(VURegs * VU) {

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -2356,9 +2356,11 @@ void _vuXGKICKTransfer(VURegs* VU, u32 cycles, bool flush)
 
 		VUM_LOG("XGKICK Transferring %x bytes from %x size %x", transfersize * 0x10, VU->xgkickaddr, VU->xgkicksizeremaining);
 
-		if ((transfersize * 0x10) < VU->xgkicksizeremaining)
+		// Would be "nicer" to do the copy until it's all up, however this really screws up PATH3 masking stuff
+		// So lets just do it the other way :)
+		/*if ((transfersize * 0x10) < VU->xgkicksizeremaining)
 			gifUnit.gifPath[GIF_PATH_1].CopyGSPacketData(&VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
-		else
+		else*/
 			gifUnit.TransferGSPacketData(GIF_TRANS_XGKICK, &VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
 
 		if ((VU0.VI[REG_VPU_STAT].UL & 0x100) && flush)
@@ -2409,7 +2411,7 @@ static __ri void _vuXGKICK(VURegs * VU)
 	VU->xgkicksizeremaining = 0;
 	VU->xgkickendpacket = false;
 	VU->xgkicklastcycle = VU->cycle;
-	VUM_LOG("XGKICK size %x EOP %d addr %x", VU->xgkicksizeremaining, VU->xgkickendpacket, addr);
+	IPU_LOG("XGKICK size %x EOP %d addr %x", VU->xgkicksizeremaining, VU->xgkickendpacket, addr);
 }
 
 static __ri void _vuXTOP(VURegs * VU) {

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -83,27 +83,24 @@ static __ri bool _vuFMACflush(VURegs * VU) {
 
 			VU->fmac[currentpipe].enable = 0;
 
-			if ((VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle) >= cycle)
+			VUM_LOG("Writing back flags");
+			if (VU->fmac[currentpipe].flagreg & (1 << REG_STATUS_FLAG))
 			{
-				VUM_LOG("Writing back flags");
-				if (VU->fmac[currentpipe].flagreg & (1 << REG_STATUS_FLAG))
-				{
-					VUM_LOG("flushing FMAC Status Write pipe[%d] (status=%x) Cur Cycle %d Expected cycle %d", currentpipe, (VU->VI[REG_STATUS_FLAG].UL & 0xF30) | (VU->fmac[currentpipe].statusflag & 0x3CF), VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
-					VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0x3F) | (VU->fmac[currentpipe].statusflag & 0xFC0);
-				}
-				else if (VU->fmac[currentpipe].flagreg & (1 << REG_CLIP_FLAG))
-				{
-					VUM_LOG("flushing FMAC Clip Write pipe[%d] (clip=%x) Cur Cycle %d Expected cycle %d", currentpipe, VU->fmac[currentpipe].clipflag, VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
-					VU->VI[REG_CLIP_FLAG].UL = VU->fmac[currentpipe].clipflag;
-				}
-				else
-				{
-					VUM_LOG("flushing FMAC pipe[%d] (macflag=%x status=%x) Cur Cycle %d Expected cycle %d", currentpipe, VU->fmac[currentpipe].macflag, (VU->VI[REG_STATUS_FLAG].UL & 0xF30) | (VU->fmac[currentpipe].statusflag & 0x3CF), VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
-					// FMAC only affectx Z/S/I/O
-					VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0xFF0) | (VU->fmac[currentpipe].statusflag & 0x3CF);
-					VU->VI[REG_MAC_FLAG].UL = VU->fmac[currentpipe].macflag;
+				VUM_LOG("flushing FMAC Status Write pipe[%d] (status=%x) Cur Cycle %d Expected cycle %d", currentpipe, (VU->VI[REG_STATUS_FLAG].UL & 0xF30) | (VU->fmac[currentpipe].statusflag & 0x3CF), VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
+				VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0x3F) | (VU->fmac[currentpipe].statusflag & 0xFC0);
+			}
+			else if (VU->fmac[currentpipe].flagreg & (1 << REG_CLIP_FLAG))
+			{
+				VUM_LOG("flushing FMAC Clip Write pipe[%d] (clip=%x) Cur Cycle %d Expected cycle %d", currentpipe, VU->fmac[currentpipe].clipflag, VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
+				VU->VI[REG_CLIP_FLAG].UL = VU->fmac[currentpipe].clipflag;
+			}
+			else
+			{
+				VUM_LOG("flushing FMAC pipe[%d] (macflag=%x status=%x) Cur Cycle %d Expected cycle %d", currentpipe, VU->fmac[currentpipe].macflag, (VU->VI[REG_STATUS_FLAG].UL & 0xF30) | (VU->fmac[currentpipe].statusflag & 0x3CF), VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
+				// FMAC only affectx Z/S/I/O
+				VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0xFF0) | (VU->fmac[currentpipe].statusflag & 0x3CF);
+				VU->VI[REG_MAC_FLAG].UL = VU->fmac[currentpipe].macflag;
 
-				}
 			}
 			didflush = true;
 		}
@@ -2195,7 +2192,7 @@ static __ri void _vuELENG(VURegs * VU) {
 }
 
 static __ri void _vuERLENG(VURegs * VU) {
-	DevCon.Warning("ERLENG");
+	//DevCon.Warning("ERLENG");
 	float p = vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Fs_].i.z);
 	if (p >= 0) {
 		p = sqrt(p);

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -106,8 +106,8 @@ static __ri bool _vuFMACflush(VURegs * VU) {
 			{
 				if ((VU->cycle - VU->fmac[currentpipe].sCycle) < lastmac)
 				{
-				VUM_LOG("flushing FMAC pipe[%d] (macflag=%x status=%x) Cur Cycle %d Expected cycle %d", currentpipe, VU->fmac[currentpipe].macflag, (VU->VI[REG_STATUS_FLAG].UL & 0xF30) | (VU->fmac[currentpipe].statusflag & 0x3CF), VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
-				// FMAC only affectx Z/S/I/O
+					VUM_LOG("flushing FMAC pipe[%d] (macflag=%x status=%x) Cur Cycle %d Expected cycle %d", currentpipe, VU->fmac[currentpipe].macflag, (VU->VI[REG_STATUS_FLAG].UL & 0xF30) | (VU->fmac[currentpipe].statusflag & 0x3CF), VU->cycle, VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle);
+					// FMAC only affectx Z/S/I/O
 					VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0xFF0) | ((VU->fmac[currentpipe].statusflag & 0xF) | ((VU->fmac[currentpipe].statusflag & 0xF) << 6));
 					VU->VI[REG_MAC_FLAG].UL = VU->fmac[currentpipe].macflag;
 					lastmac = (VU->cycle - VU->fmac[currentpipe].sCycle);
@@ -263,7 +263,7 @@ void _vuFlushAll(VURegs* VU)
 
 __fi void _vuTestPipes(VURegs * VU) {
 	bool flushed;
-	u32 startcycle = VU->cycle;
+
 	do {
 		flushed = false;
 		flushed |= _vuFMACflush(VU);

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -30,12 +30,12 @@ u32 laststall = 0;
 #define _Is_ (_Fs_ & 0xF)
 #define _Id_ (_Fd_ & 0xF)
 
-#define _X ((VU->code>>24) & 0x1)
-#define _Y ((VU->code>>23) & 0x1)
-#define _Z ((VU->code>>22) & 0x1)
-#define _W ((VU->code>>21) & 0x1)
+#define _X ((VU->code >> 24) & 0x1)
+#define _Y ((VU->code >> 23) & 0x1)
+#define _Z ((VU->code >> 22) & 0x1)
+#define _W ((VU->code >> 21) & 0x1)
 
-#define _XYZW ((VU->code>>21) & 0xF)
+#define _XYZW ((VU->code >> 21) & 0xF)
 
 #define _Fsf_ ((VU->code >> 21) & 0x03)
 #define _Ftf_ ((VU->code >> 23) & 0x03)
@@ -47,7 +47,7 @@ u32 laststall = 0;
 
 static __aligned16 VECTOR RDzero;
 
-static __ri bool _vuFMACflush(VURegs * VU)
+static __ri bool _vuFMACflush(VURegs* VU)
 {
 	bool didflush = false;
 
@@ -92,7 +92,8 @@ static __ri bool _vuIALUflush(VURegs* VU)
 
 	for (int i = VU->ialureadpos; VU->ialucount > 0; i = (i + 1) & 3)
 	{
-		if ((VU->cycle - VU->ialu[i].sCycle) < VU->ialu[i].Cycle) return didflush;
+		if ((VU->cycle - VU->ialu[i].sCycle) < VU->ialu[i].Cycle)
+			return didflush;
 
 		VU->ialureadpos = ++VU->ialureadpos & 3;
 		VU->ialucount--;
@@ -101,9 +102,10 @@ static __ri bool _vuIALUflush(VURegs* VU)
 	return didflush;
 }
 
-static __ri bool _vuFDIVflush(VURegs * VU)
+static __ri bool _vuFDIVflush(VURegs* VU)
 {
-	if (VU->fdiv.enable == 0) return false;
+	if (VU->fdiv.enable == 0)
+		return false;
 
 	if ((VU->cycle - VU->fdiv.sCycle) >= VU->fdiv.Cycle)
 	{
@@ -119,9 +121,10 @@ static __ri bool _vuFDIVflush(VURegs * VU)
 	return false;
 }
 
-static __ri bool _vuEFUflush(VURegs * VU)
+static __ri bool _vuEFUflush(VURegs* VU)
 {
-	if (VU->efu.enable == 0) return false;
+	if (VU->efu.enable == 0)
+		return false;
 
 	if ((VU->cycle - VU->efu.sCycle) >= VU->efu.Cycle)
 	{
@@ -160,7 +163,7 @@ void _vuFlushAll(VURegs* VU)
 			VU->cycle = VU->efu.sCycle + VU->efu.Cycle;
 	}
 
-	for (i=VU->fmacreadpos; VU->fmaccount > 0; i = (i + 1) & 3)
+	for (i = VU->fmacreadpos; VU->fmaccount > 0; i = (i + 1) & 3)
 	{
 		VUM_LOG("flushing FMAC pipe[%d] (macflag=%x)", i, VU->fmac[i].macflag);
 
@@ -178,7 +181,7 @@ void _vuFlushAll(VURegs* VU)
 
 		VU->fmacreadpos = ++VU->fmacreadpos & 3;
 
-		if((VU->cycle - VU->fmac[i].sCycle) < VU->fmac[i].Cycle)
+		if ((VU->cycle - VU->fmac[i].sCycle) < VU->fmac[i].Cycle)
 			VU->cycle = VU->fmac[i].sCycle + VU->fmac[i].Cycle;
 
 		VU->fmaccount--;
@@ -195,7 +198,7 @@ void _vuFlushAll(VURegs* VU)
 	}
 }
 
-__fi void _vuTestPipes(VURegs * VU)
+__fi void _vuTestPipes(VURegs* VU)
 {
 	bool flushed;
 
@@ -224,7 +227,8 @@ static void __fastcall _vuFMACTestStall(VURegs* VU, int reg, int xyzw)
 	for (int currentpipe = VU->fmacreadpos; i < VU->fmaccount; currentpipe = (currentpipe + 1) & 3, i++)
 	{
 		//Check if enough cycles have passed for this fmac position
-		if ((VU->cycle - VU->fmac[currentpipe].sCycle) >= VU->fmac[currentpipe].Cycle) continue;
+		if ((VU->cycle - VU->fmac[currentpipe].sCycle) >= VU->fmac[currentpipe].Cycle)
+			continue;
 
 		// Check if the regs match
 		if ((VU->fmac[currentpipe].regupper == reg &&
@@ -253,7 +257,7 @@ static __fi void _vuTestFMACStalls(VURegs* VU, _VURegsNum* VUregsn)
 	}
 }
 
-static __fi void _vuTestFDIVStalls(VURegs * VU, _VURegsNum *VUregsn)
+static __fi void _vuTestFDIVStalls(VURegs* VU, _VURegsNum* VUregsn)
 {
 	_vuTestFMACStalls(VU, VUregsn);
 
@@ -292,7 +296,8 @@ static __fi void _vuTestALUStalls(VURegs* VU, _VURegsNum* VUregsn)
 
 	for (int currentpipe = VU->ialureadpos; i < VU->ialucount; currentpipe = (currentpipe + 1) & 3, i++)
 	{
-		if ((VU->cycle - VU->ialu[currentpipe].sCycle) >= VU->ialu[currentpipe].Cycle) continue;
+		if ((VU->cycle - VU->ialu[currentpipe].sCycle) >= VU->ialu[currentpipe].Cycle)
+			continue;
 
 		if (VU->ialu[currentpipe].reg & VUregsn->VIread) // Read and written VI regs share the same register
 		{
@@ -397,13 +402,13 @@ static __ri void __fastcall _vuAddIALUStalls(VURegs* VU, _VURegsNum* VUregsn)
 	VU->ialucount++;
 }
 
-static __fi void _vuAddFDIVStalls(VURegs * VU, _VURegsNum *VUregsn)
+static __fi void _vuAddFDIVStalls(VURegs* VU, _VURegsNum* VUregsn)
 {
 	if (VUregsn->VIwrite & (1 << REG_Q))
 		_vuFDIVAdd(VU, VUregsn->cycles);
 }
 
-static __fi void _vuAddEFUStalls(VURegs * VU, _VURegsNum *VUregsn)
+static __fi void _vuAddEFUStalls(VURegs* VU, _VURegsNum* VUregsn)
 {
 	if (VUregsn->VIwrite & (1 << REG_P))
 		_vuEFUAdd(VU, VUregsn->cycles);
@@ -472,7 +477,8 @@ static __fi float vuDouble(u32 f)
 }
 #endif
 
-static __fi float vuADD_TriAceHack(u32 a, u32 b) {
+static __fi float vuADD_TriAceHack(u32 a, u32 b)
+{
 	// On VU0 TriAce Games use ADDi and expects these bit-perfect results:
 	//if (a == 0xb3e2a619 && b == 0x42546666) return vuDouble(0x42546666);
 	//if (a == 0x8b5b19e9 && b == 0xc7f079b3) return vuDouble(0xc7f079b3);
@@ -501,8 +507,10 @@ static __fi float vuADD_TriAceHack(u32 a, u32 b) {
 	return ret;
 }
 
-void _vuABS(VURegs * VU) {
-	if (_Ft_ == 0) return;
+void _vuABS(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X){ VU->VF[_Ft_].f.x = fabs(vuDouble(VU->VF[_Fs_].i.x)); }
 	if (_Y){ VU->VF[_Ft_].f.y = fabs(vuDouble(VU->VF[_Fs_].i.y)); }
@@ -511,10 +519,13 @@ void _vuABS(VURegs * VU) {
 }
 
 
-static __fi void _vuADD(VURegs * VU) {
-	VECTOR * dst;
-	if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuADD(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACy_CLEAR(VU);
@@ -524,10 +535,13 @@ static __fi void _vuADD(VURegs * VU) {
 }
 
 
-static __fi void _vuADDi(VURegs * VU) {
-	VECTOR * dst;
-	if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuADDi(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (!CHECK_VUADDSUBHACK) {
 		if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VI[REG_I].UL));} else VU_MACx_CLEAR(VU);
@@ -543,13 +557,15 @@ static __fi void _vuADDi(VURegs * VU) {
 		if (_W){ dst->i.w = VU_MACw_UPDATE(VU, vuADD_TriAceHack(VU->VF[_Fs_].i.w, VU->VI[REG_I].UL));} else VU_MACw_CLEAR(VU);
 		VU_STAT_UPDATE(VU);
 	}
-	
 }
 
-static __fi void _vuADDq(VURegs * VU) {
-	VECTOR * dst;
-	if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuADDq(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VI[REG_Q].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VI[REG_Q].UL)); } else VU_MACy_CLEAR(VU);
@@ -559,11 +575,14 @@ static __fi void _vuADDq(VURegs * VU) {
 }
 
 
-static __fi void _vuADDx(VURegs * VU) {
+static __fi void _vuADDx(VURegs* VU)
+{
 	float ftx;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftx=vuDouble(VU->VF[_Ft_].i.x);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + ftx); } else VU_MACx_CLEAR(VU);
@@ -573,11 +592,14 @@ static __fi void _vuADDx(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDy(VURegs * VU) {
+static __fi void _vuADDy(VURegs* VU)
+{
 	float fty;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	fty=vuDouble(VU->VF[_Ft_].i.y);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + fty);} else VU_MACx_CLEAR(VU);
@@ -587,11 +609,14 @@ static __fi void _vuADDy(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDz(VURegs * VU) {
+static __fi void _vuADDz(VURegs* VU)
+{
 	float ftz;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftz=vuDouble(VU->VF[_Ft_].i.z);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + ftz); } else VU_MACx_CLEAR(VU);
@@ -601,11 +626,14 @@ static __fi void _vuADDz(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDw(VURegs * VU) {
+static __fi void _vuADDw(VURegs* VU)
+{
 	float ftw;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftw=vuDouble(VU->VF[_Ft_].i.w);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + ftw); } else VU_MACx_CLEAR(VU);
@@ -615,7 +643,7 @@ static __fi void _vuADDw(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDA(VURegs * VU) {
+static __fi void _vuADDA(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) + vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACz_CLEAR(VU);
@@ -623,7 +651,8 @@ static __fi void _vuADDA(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDAi(VURegs * VU) {
+static __fi void _vuADDAi(VURegs* VU)
+{
 	float ti = vuDouble(VU->VI[REG_I].UL);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + ti); } else VU_MACx_CLEAR(VU);
@@ -633,7 +662,8 @@ static __fi void _vuADDAi(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDAq(VURegs * VU) {
+static __fi void _vuADDAq(VURegs* VU)
+{
 	float tf = vuDouble(VU->VI[REG_Q].UL);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + tf); } else VU_MACx_CLEAR(VU);
@@ -643,7 +673,8 @@ static __fi void _vuADDAq(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDAx(VURegs * VU) {
+static __fi void _vuADDAx(VURegs* VU)
+{
 	float tx = vuDouble(VU->VF[_Ft_].i.x);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + tx); } else VU_MACx_CLEAR(VU);
@@ -653,7 +684,8 @@ static __fi void _vuADDAx(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDAy(VURegs * VU) {
+static __fi void _vuADDAy(VURegs* VU)
+{
 	float ty = vuDouble(VU->VF[_Ft_].i.y);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + ty); } else VU_MACx_CLEAR(VU);
@@ -663,7 +695,8 @@ static __fi void _vuADDAy(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDAz(VURegs * VU) {
+static __fi void _vuADDAz(VURegs* VU)
+{
 	float tz = vuDouble(VU->VF[_Ft_].i.z);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + tz); } else VU_MACx_CLEAR(VU);
@@ -673,7 +706,8 @@ static __fi void _vuADDAz(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuADDAw(VURegs * VU) {
+static __fi void _vuADDAw(VURegs* VU)
+{
 	float tw = vuDouble(VU->VF[_Ft_].i.w);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) + tw); } else VU_MACx_CLEAR(VU);
@@ -684,10 +718,13 @@ static __fi void _vuADDAw(VURegs * VU) {
 }
 
 
-static __fi void _vuSUB(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuSUB(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - vuDouble(VU->VF[_Ft_].i.x));  } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) - vuDouble(VU->VF[_Ft_].i.y));  } else VU_MACy_CLEAR(VU);
@@ -696,10 +733,13 @@ static __fi void _vuSUB(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBi(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuSUBi(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - vuDouble(VU->VI[REG_I].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) - vuDouble(VU->VI[REG_I].UL)); } else VU_MACy_CLEAR(VU);
@@ -708,10 +748,13 @@ static __fi void _vuSUBi(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBq(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuSUBq(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - vuDouble(VU->VI[REG_Q].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) - vuDouble(VU->VI[REG_Q].UL)); } else VU_MACy_CLEAR(VU);
@@ -720,11 +763,14 @@ static __fi void _vuSUBq(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBx(VURegs * VU) {
+static __fi void _vuSUBx(VURegs* VU)
+{
 	float ftx;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftx=vuDouble(VU->VF[_Ft_].i.x);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - ftx); } else VU_MACx_CLEAR(VU);
@@ -734,11 +780,14 @@ static __fi void _vuSUBx(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBy(VURegs * VU) {
+static __fi void _vuSUBy(VURegs* VU)
+{
 	float fty;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	fty=vuDouble(VU->VF[_Ft_].i.y);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - fty); } else VU_MACx_CLEAR(VU);
@@ -748,11 +797,14 @@ static __fi void _vuSUBy(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBz(VURegs * VU) {
+static __fi void _vuSUBz(VURegs* VU)
+{
 	float ftz;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftz=vuDouble(VU->VF[_Ft_].i.z);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - ftz); } else VU_MACx_CLEAR(VU);
@@ -762,11 +814,14 @@ static __fi void _vuSUBz(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBw(VURegs * VU) {
+static __fi void _vuSUBw(VURegs* VU)
+{
 	float ftw;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
     ftw=vuDouble(VU->VF[_Ft_].i.w);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - ftw); } else VU_MACx_CLEAR(VU);
@@ -777,7 +832,7 @@ static __fi void _vuSUBw(VURegs * VU) {
 }
 
 
-static __fi void _vuSUBA(VURegs * VU) {
+static __fi void _vuSUBA(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) - vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) - vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACz_CLEAR(VU);
@@ -785,7 +840,7 @@ static __fi void _vuSUBA(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBAi(VURegs * VU) {
+static __fi void _vuSUBAi(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - vuDouble(VU->VI[REG_I].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) - vuDouble(VU->VI[REG_I].UL)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) - vuDouble(VU->VI[REG_I].UL)); } else VU_MACz_CLEAR(VU);
@@ -793,7 +848,7 @@ static __fi void _vuSUBAi(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBAq(VURegs * VU) {
+static __fi void _vuSUBAq(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - vuDouble(VU->VI[REG_Q].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) - vuDouble(VU->VI[REG_Q].UL)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) - vuDouble(VU->VI[REG_Q].UL)); } else VU_MACz_CLEAR(VU);
@@ -801,7 +856,8 @@ static __fi void _vuSUBAq(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBAx(VURegs * VU) {
+static __fi void _vuSUBAx(VURegs* VU)
+{
 	float tx = vuDouble(VU->VF[_Ft_].i.x);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - tx); } else VU_MACx_CLEAR(VU);
@@ -811,7 +867,8 @@ static __fi void _vuSUBAx(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBAy(VURegs * VU) {
+static __fi void _vuSUBAy(VURegs* VU)
+{
 	float ty = vuDouble(VU->VF[_Ft_].i.y);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - ty); } else VU_MACx_CLEAR(VU);
@@ -821,7 +878,8 @@ static __fi void _vuSUBAy(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBAz(VURegs * VU) {
+static __fi void _vuSUBAz(VURegs* VU)
+{
 	float tz = vuDouble(VU->VF[_Ft_].i.z);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - tz); } else VU_MACx_CLEAR(VU);
@@ -831,7 +889,8 @@ static __fi void _vuSUBAz(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuSUBAw(VURegs * VU) {
+static __fi void _vuSUBAw(VURegs* VU)
+{
 	float tw = vuDouble(VU->VF[_Ft_].i.w);
 
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) - tw); } else VU_MACx_CLEAR(VU);
@@ -841,10 +900,13 @@ static __fi void _vuSUBAw(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMUL(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMUL(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACy_CLEAR(VU);
@@ -853,10 +915,13 @@ static __fi void _vuMUL(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULi(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMULi(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_I].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_I].UL)); } else VU_MACy_CLEAR(VU);
@@ -865,10 +930,13 @@ static __fi void _vuMULi(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULq(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMULq(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_Q].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_Q].UL)); } else VU_MACy_CLEAR(VU);
@@ -877,11 +945,14 @@ static __fi void _vuMULq(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULx(VURegs * VU) {
+static __fi void _vuMULx(VURegs* VU)
+{
 	float ftx;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
  	ftx=vuDouble(VU->VF[_Ft_].i.x);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * ftx); } else VU_MACx_CLEAR(VU);
@@ -892,11 +963,14 @@ static __fi void _vuMULx(VURegs * VU) {
 }
 
 
-static __fi void _vuMULy(VURegs * VU) {
+static __fi void _vuMULy(VURegs* VU)
+{
 	float fty;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
  	fty=vuDouble(VU->VF[_Ft_].i.y);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * fty); } else VU_MACx_CLEAR(VU);
@@ -906,11 +980,14 @@ static __fi void _vuMULy(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULz(VURegs * VU) {
+static __fi void _vuMULz(VURegs* VU)
+{
 	float ftz;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
  	ftz=vuDouble(VU->VF[_Ft_].i.z);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * ftz); } else VU_MACx_CLEAR(VU);
@@ -920,11 +997,14 @@ static __fi void _vuMULz(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULw(VURegs * VU) {
+static __fi void _vuMULw(VURegs* VU)
+{
 	float ftw;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftw=vuDouble(VU->VF[_Ft_].i.w);
 	if (_X){ dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * ftw); } else VU_MACx_CLEAR(VU);
@@ -935,7 +1015,7 @@ static __fi void _vuMULw(VURegs * VU) {
 }
 
 
-static __fi void _vuMULA(VURegs * VU) {
+static __fi void _vuMULA(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACz_CLEAR(VU);
@@ -943,7 +1023,7 @@ static __fi void _vuMULA(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULAi(VURegs * VU) {
+static __fi void _vuMULAi(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_I].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_I].UL)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VI[REG_I].UL)); } else VU_MACz_CLEAR(VU);
@@ -951,7 +1031,7 @@ static __fi void _vuMULAi(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULAq(VURegs * VU) {
+static __fi void _vuMULAq(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_Q].UL)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_Q].UL)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VI[REG_Q].UL)); } else VU_MACz_CLEAR(VU);
@@ -959,7 +1039,7 @@ static __fi void _vuMULAq(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULAx(VURegs * VU) {
+static __fi void _vuMULAx(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.x)); } else VU_MACz_CLEAR(VU);
@@ -967,7 +1047,7 @@ static __fi void _vuMULAx(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULAy(VURegs * VU) {
+static __fi void _vuMULAy(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.y)); } else VU_MACz_CLEAR(VU);
@@ -975,15 +1055,16 @@ static __fi void _vuMULAy(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULAz(VURegs * VU) {
+static __fi void _vuMULAz(VURegs* VU)
+{
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACz_CLEAR(VU);
 	if (_W){ VU->ACC.i.w = VU_MACw_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.w) * vuDouble(VU->VF[_Ft_].i.z)); } else VU_MACw_CLEAR(VU);
-    VU_STAT_UPDATE(VU);
+	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMULAw(VURegs * VU) {
+static __fi void _vuMULAw(VURegs*  VU) {
 	if (_X){ VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.w)); } else VU_MACx_CLEAR(VU);
 	if (_Y){ VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.w)); } else VU_MACy_CLEAR(VU);
 	if (_Z){ VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.w)); } else VU_MACz_CLEAR(VU);
@@ -991,10 +1072,13 @@ static __fi void _vuMULAw(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADD(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMADD(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACx_CLEAR(VU);
     if (_Y) dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACy_CLEAR(VU);
@@ -1004,10 +1088,13 @@ static __fi void _vuMADD(VURegs * VU) {
 }
 
 
-static __fi void _vuMADDi(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMADDi(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_I].UL))); else VU_MACx_CLEAR(VU);
     if (_Y) dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + (vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_I].UL))); else VU_MACy_CLEAR(VU);
@@ -1016,10 +1103,13 @@ static __fi void _vuMADDi(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDq(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMADDq(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_Q].UL))); else VU_MACx_CLEAR(VU);
     if (_Y) dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + (vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_Q].UL))); else VU_MACy_CLEAR(VU);
@@ -1028,11 +1118,14 @@ static __fi void _vuMADDq(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDx(VURegs * VU) {
+static __fi void _vuMADDx(VURegs* VU)
+{
 	float ftx;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftx=vuDouble(VU->VF[_Ft_].i.x);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * ftx)); else VU_MACx_CLEAR(VU);
@@ -1042,11 +1135,14 @@ static __fi void _vuMADDx(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDy(VURegs * VU) {
+static __fi void _vuMADDy(VURegs* VU)
+{
 	float fty;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	fty=vuDouble(VU->VF[_Ft_].i.y);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * fty)); else VU_MACx_CLEAR(VU);
@@ -1056,11 +1152,14 @@ static __fi void _vuMADDy(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDz(VURegs * VU) {
+static __fi void _vuMADDz(VURegs* VU)
+{
 	float ftz;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftz=vuDouble(VU->VF[_Ft_].i.z);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * ftz)); else VU_MACx_CLEAR(VU);
@@ -1070,11 +1169,14 @@ static __fi void _vuMADDz(VURegs * VU) {
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDw(VURegs * VU) {
+static __fi void _vuMADDw(VURegs* VU)
+{
 	float ftw;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftw=vuDouble(VU->VF[_Ft_].i.w);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * ftw)); else VU_MACx_CLEAR(VU);
@@ -1084,7 +1186,7 @@ static __fi void _vuMADDw(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDA(VURegs * VU) {
+static __fi void _vuMADDA(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + (vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + (vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) + (vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.z))); else VU_MACz_CLEAR(VU);
@@ -1092,7 +1194,8 @@ static __fi void _vuMADDA(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDAi(VURegs * VU) {
+static __fi void _vuMADDAi(VURegs* VU)
+{
 	float ti = vuDouble(VU->VI[REG_I].UL);
 
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * ti)); else VU_MACx_CLEAR(VU);
@@ -1102,7 +1205,8 @@ static __fi void _vuMADDAi(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDAq(VURegs * VU) {
+static __fi void _vuMADDAq(VURegs* VU)
+{
 	float tq = vuDouble(VU->VI[REG_Q].UL);
 
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * tq)); else VU_MACx_CLEAR(VU);
@@ -1112,7 +1216,7 @@ static __fi void _vuMADDAq(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDAx(VURegs * VU) {
+static __fi void _vuMADDAx(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) + ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACz_CLEAR(VU);
@@ -1120,7 +1224,7 @@ static __fi void _vuMADDAx(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDAy(VURegs * VU) {
+static __fi void _vuMADDAy(VURegs*  VU) {
 	if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) + ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACz_CLEAR(VU);
@@ -1128,7 +1232,7 @@ static __fi void _vuMADDAy(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDAz(VURegs * VU) {
+static __fi void _vuMADDAz(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.z))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.z))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) + ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.z))); else VU_MACz_CLEAR(VU);
@@ -1136,7 +1240,7 @@ static __fi void _vuMADDAz(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMADDAw(VURegs * VU) {
+static __fi void _vuMADDAw(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) + ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.w))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) + ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.w))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) + ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.w))); else VU_MACz_CLEAR(VU);
@@ -1144,10 +1248,13 @@ static __fi void _vuMADDAw(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUB(VURegs * VU) {
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+static __fi void _vuMSUB(VURegs* VU)
+{
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACx_CLEAR(VU);
     if (_Y) dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) - ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACy_CLEAR(VU);
@@ -1156,11 +1263,14 @@ static __fi void _vuMSUB(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBi(VURegs * VU) {
+static __fi void _vuMSUBi(VURegs* VU)
+{
 	float ti = vuDouble(VU->VI[REG_I].UL);
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * ti  ) ); else VU_MACx_CLEAR(VU);
     if (_Y) dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) - ( vuDouble(VU->VF[_Fs_].i.y) * ti  ) ); else VU_MACy_CLEAR(VU);
@@ -1169,11 +1279,14 @@ static __fi void _vuMSUBi(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBq(VURegs * VU) {
+static __fi void _vuMSUBq(VURegs* VU)
+{
 	float tq = vuDouble(VU->VI[REG_Q].UL);
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x)  - ( vuDouble(VU->VF[_Fs_].i.x) * tq  ) ); else VU_MACx_CLEAR(VU);
     if (_Y) dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y)  - ( vuDouble(VU->VF[_Fs_].i.y) * tq  ) ); else VU_MACy_CLEAR(VU);
@@ -1183,11 +1296,14 @@ static __fi void _vuMSUBq(VURegs * VU) {
 }
 
 
-static __fi void _vuMSUBx(VURegs * VU) {
+static __fi void _vuMSUBx(VURegs* VU)
+{
 	float ftx;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftx=vuDouble(VU->VF[_Ft_].i.x);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x)  - ( vuDouble(VU->VF[_Fs_].i.x) * ftx  ) ); else VU_MACx_CLEAR(VU);
@@ -1198,11 +1314,14 @@ static __fi void _vuMSUBx(VURegs * VU) {
 }
 
 
-static __fi void _vuMSUBy(VURegs * VU) {
+static __fi void _vuMSUBy(VURegs* VU)
+{
 	float fty;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	fty=vuDouble(VU->VF[_Ft_].i.y);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x)  - ( vuDouble(VU->VF[_Fs_].i.x) * fty  ) ); else VU_MACx_CLEAR(VU);
@@ -1213,11 +1332,14 @@ static __fi void _vuMSUBy(VURegs * VU) {
 }
 
 
-static __fi void _vuMSUBz(VURegs * VU) {
+static __fi void _vuMSUBz(VURegs* VU)
+{
 	float ftz;
-	VECTOR * dst;
-    if (_Fd_ == 0) dst = &RDzero;
-	else dst = &VU->VF[_Fd_];
+	VECTOR* dst;
+	if (_Fd_ == 0)
+		dst = &RDzero;
+	else
+		dst = &VU->VF[_Fd_];
 
 	ftz=vuDouble(VU->VF[_Ft_].i.z);
     if (_X) dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x)  - ( vuDouble(VU->VF[_Fs_].i.x) * ftz  ) ); else VU_MACx_CLEAR(VU);
@@ -1227,7 +1349,8 @@ static __fi void _vuMSUBz(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBw(VURegs * VU) {
+static __fi void _vuMSUBw(VURegs* VU)
+{
 	float ftw;
 	VECTOR * dst;
     if (_Fd_ == 0) dst = &RDzero;
@@ -1242,7 +1365,7 @@ static __fi void _vuMSUBw(VURegs * VU) {
 }
 
 
-static __fi void _vuMSUBA(VURegs * VU) {
+static __fi void _vuMSUBA(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.x))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) - ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.y))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) - ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.z))); else VU_MACz_CLEAR(VU);
@@ -1250,7 +1373,7 @@ static __fi void _vuMSUBA(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBAi(VURegs * VU) {
+static __fi void _vuMSUBAi(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_I].UL))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) - ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_I].UL))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) - ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VI[REG_I].UL))); else VU_MACz_CLEAR(VU);
@@ -1258,7 +1381,7 @@ static __fi void _vuMSUBAi(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBAq(VURegs * VU) {
+static __fi void _vuMSUBAq(VURegs*  VU) {
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VI[REG_Q].UL))); else VU_MACx_CLEAR(VU);
     if (_Y) VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) - ( vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VI[REG_Q].UL))); else VU_MACy_CLEAR(VU);
     if (_Z) VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) - ( vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VI[REG_Q].UL))); else VU_MACz_CLEAR(VU);
@@ -1266,7 +1389,8 @@ static __fi void _vuMSUBAq(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBAx(VURegs * VU) {
+static __fi void _vuMSUBAx(VURegs* VU)
+{
 	float tx = vuDouble(VU->VF[_Ft_].i.x);
 
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * tx)); else VU_MACx_CLEAR(VU);
@@ -1276,7 +1400,8 @@ static __fi void _vuMSUBAx(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBAy(VURegs * VU) {
+static __fi void _vuMSUBAy(VURegs* VU)
+{
 	float ty = vuDouble(VU->VF[_Ft_].i.y);
 
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * ty)); else VU_MACx_CLEAR(VU);
@@ -1286,7 +1411,8 @@ static __fi void _vuMSUBAy(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBAz(VURegs * VU) {
+static __fi void _vuMSUBAz(VURegs* VU)
+{
 	float tz = vuDouble(VU->VF[_Ft_].i.z);
 
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * tz)); else VU_MACx_CLEAR(VU);
@@ -1296,7 +1422,8 @@ static __fi void _vuMSUBAz(VURegs * VU) {
     VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuMSUBAw(VURegs * VU) {
+static __fi void _vuMSUBAw(VURegs* VU)
+{
 	float tw = vuDouble(VU->VF[_Ft_].i.w);
 
     if (_X) VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - ( vuDouble(VU->VF[_Fs_].i.x) * tw)); else VU_MACx_CLEAR(VU);
@@ -1309,15 +1436,18 @@ static __fi void _vuMSUBAw(VURegs * VU) {
 // The functions below are floating point semantics min/max on integer representations to get
 // the effect of a floating point min/max without issues with denormal and special numbers.
 
-static __fi u32 fp_max(u32 a, u32 b) {
+static __fi u32 fp_max(u32 a, u32 b)
+{
 	return ((s32)a < 0 && (s32)b < 0) ? std::min<s32>(a, b) : std::max<s32>(a, b);
 }
 
-static __fi u32 fp_min(u32 a, u32 b) {
+static __fi u32 fp_min(u32 a, u32 b)
+{
 	return ((s32)a < 0 && (s32)b < 0) ? std::max<s32>(a, b) : std::min<s32>(a, b);
 }
 
-static __fi void _vuMAX(VURegs * VU) {
+static __fi void _vuMAX(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1327,7 +1457,8 @@ static __fi void _vuMAX(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_max(VU->VF[_Fs_].i.w, VU->VF[_Ft_].i.w);
 }
 
-static __fi void _vuMAXi(VURegs * VU) {
+static __fi void _vuMAXi(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1337,7 +1468,8 @@ static __fi void _vuMAXi(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_max(VU->VF[_Fs_].i.w, VU->VI[REG_I].UL);
 }
 
-static __fi void _vuMAXx(VURegs * VU) {
+static __fi void _vuMAXx(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1348,7 +1480,8 @@ static __fi void _vuMAXx(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_max(VU->VF[_Fs_].i.w, ftx);
 }
 
-static __fi void _vuMAXy(VURegs * VU) {
+static __fi void _vuMAXy(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1359,7 +1492,8 @@ static __fi void _vuMAXy(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_max(VU->VF[_Fs_].i.w, fty);
 }
 
-static __fi void _vuMAXz(VURegs * VU) {
+static __fi void _vuMAXz(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1370,7 +1504,8 @@ static __fi void _vuMAXz(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_max(VU->VF[_Fs_].i.w, ftz);
 }
 
-static __fi void _vuMAXw(VURegs * VU) {
+static __fi void _vuMAXw(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1381,7 +1516,8 @@ static __fi void _vuMAXw(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_max(VU->VF[_Fs_].i.w, ftw);
 }
 
-static __fi void _vuMINI(VURegs * VU) {
+static __fi void _vuMINI(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1392,7 +1528,8 @@ static __fi void _vuMINI(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_min(VU->VF[_Fs_].i.w, VU->VF[_Ft_].i.w);
 }
 
-static __fi void _vuMINIi(VURegs * VU) {
+static __fi void _vuMINIi(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1403,7 +1540,8 @@ static __fi void _vuMINIi(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_min(VU->VF[_Fs_].i.w, VU->VI[REG_I].UL);
 }
 
-static __fi void _vuMINIx(VURegs * VU) {
+static __fi void _vuMINIx(VURegs* VU)
+{
 	if (_Fd_ == 0)
 		return;
 
@@ -1414,8 +1552,10 @@ static __fi void _vuMINIx(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_min(VU->VF[_Fs_].i.w, ftx);
 }
 
-static __fi void _vuMINIy(VURegs * VU) {
-	if (_Fd_ == 0) return;
+static __fi void _vuMINIy(VURegs* VU)
+{
+	if (_Fd_ == 0)
+		return;
 
 	u32 fty = VU->VF[_Ft_].i.y;
 	if (_X) VU->VF[_Fd_].i.x = fp_min(VU->VF[_Fs_].i.x, fty);
@@ -1424,8 +1564,10 @@ static __fi void _vuMINIy(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_min(VU->VF[_Fs_].i.w, fty);
 }
 
-static __fi void _vuMINIz(VURegs * VU) {
-	if (_Fd_ == 0) return;
+static __fi void _vuMINIz(VURegs* VU)
+{
+	if (_Fd_ == 0)
+		return;
 
 	u32 ftz = VU->VF[_Ft_].i.z;
 	if (_X) VU->VF[_Fd_].i.x = fp_min(VU->VF[_Fs_].i.x, ftz);
@@ -1434,8 +1576,10 @@ static __fi void _vuMINIz(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_min(VU->VF[_Fs_].i.w, ftz);
 }
 
-static __fi void _vuMINIw(VURegs * VU) {
-	if (_Fd_ == 0) return;
+static __fi void _vuMINIw(VURegs* VU)
+{
+	if (_Fd_ == 0)
+		return;
 
 	u32 ftw = VU->VF[_Ft_].i.w;
 	if (_X) VU->VF[_Fd_].i.x = fp_min(VU->VF[_Fs_].i.x, ftw);
@@ -1444,15 +1588,17 @@ static __fi void _vuMINIw(VURegs * VU) {
 	if (_W) VU->VF[_Fd_].i.w = fp_min(VU->VF[_Fs_].i.w, ftw);
 }
 
-static __fi void _vuOPMULA(VURegs * VU) {
+static __fi void _vuOPMULA(VURegs* VU)
+{
 	VU->ACC.i.x = VU_MACx_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Ft_].i.z));
 	VU->ACC.i.y = VU_MACy_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Ft_].i.x));
 	VU->ACC.i.z = VU_MACz_UPDATE(VU, vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Ft_].i.y));
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuOPMSUB(VURegs * VU) {
-	VECTOR * dst;
+static __fi void _vuOPMSUB(VURegs* VU)
+{
+	VECTOR* dst;
 	float ftx, fty, ftz;
 	float fsx, fsy, fsz;
 	if (_Fd_ == 0)
@@ -1460,15 +1606,21 @@ static __fi void _vuOPMSUB(VURegs * VU) {
 	else
 		dst = &VU->VF[_Fd_];
 
-	ftx = vuDouble(VU->VF[_Ft_].i.x); fty = vuDouble(VU->VF[_Ft_].i.y); ftz = vuDouble(VU->VF[_Ft_].i.z);
-	fsx = vuDouble(VU->VF[_Fs_].i.x); fsy = vuDouble(VU->VF[_Fs_].i.y); fsz = vuDouble(VU->VF[_Fs_].i.z);
+	ftx = vuDouble(VU->VF[_Ft_].i.x);
+	fty = vuDouble(VU->VF[_Ft_].i.y);
+	ftz = vuDouble(VU->VF[_Ft_].i.z);
+	fsx = vuDouble(VU->VF[_Fs_].i.x);
+	fsy = vuDouble(VU->VF[_Fs_].i.y);
+	fsz = vuDouble(VU->VF[_Fs_].i.z);
+
 	dst->i.x = VU_MACx_UPDATE(VU, vuDouble(VU->ACC.i.x) - fsy * ftz);
 	dst->i.y = VU_MACy_UPDATE(VU, vuDouble(VU->ACC.i.y) - fsz * ftx);
 	dst->i.z = VU_MACz_UPDATE(VU, vuDouble(VU->ACC.i.z) - fsx * fty);
 	VU_STAT_UPDATE(VU);
 }
 
-static __fi void _vuNOP(VURegs * VU) {
+static __fi void _vuNOP(VURegs* VU)
+{
 }
 
 static __fi s32 float_to_int(float value)
@@ -1480,7 +1632,7 @@ static __fi s32 float_to_int(float value)
 	return value;
 }
 
-static __fi void _vuFTOI0(VURegs * VU) {
+static __fi void _vuFTOI0(VURegs*  VU) {
 	if (_Ft_ == 0) return;
 
 	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(vuDouble(VU->VF[_Fs_].i.x));
@@ -1489,7 +1641,7 @@ static __fi void _vuFTOI0(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(vuDouble(VU->VF[_Fs_].i.w));
 }
 
-static __fi void _vuFTOI4(VURegs * VU) {
+static __fi void _vuFTOI4(VURegs*  VU) {
 	if (_Ft_ == 0) return;
 
 	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.x)));
@@ -1498,8 +1650,10 @@ static __fi void _vuFTOI4(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.w)));
 }											    
 
-static __fi void _vuFTOI12(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuFTOI12(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.x)));
 	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.y)));
@@ -1507,8 +1661,10 @@ static __fi void _vuFTOI12(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
-static __fi void _vuFTOI15(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuFTOI15(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.x)));
 	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.y)));
@@ -1516,8 +1672,10 @@ static __fi void _vuFTOI15(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
-static __fi void _vuITOF0(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuITOF0(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].f.x = (float)VU->VF[_Fs_].SL[0];
 	if (_Y) VU->VF[_Ft_].f.y = (float)VU->VF[_Fs_].SL[1];
@@ -1525,8 +1683,10 @@ static __fi void _vuITOF0(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].f.w = (float)VU->VF[_Fs_].SL[3];
 }
 
-static __fi void _vuITOF4(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuITOF4(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].f.x = int4_to_float(VU->VF[_Fs_].SL[0]);
 	if (_Y) VU->VF[_Ft_].f.y = int4_to_float(VU->VF[_Fs_].SL[1]);
@@ -1534,8 +1694,10 @@ static __fi void _vuITOF4(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].f.w = int4_to_float(VU->VF[_Fs_].SL[3]);
 }
 
-static __fi void _vuITOF12(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuITOF12(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].f.x = int12_to_float(VU->VF[_Fs_].SL[0]);
 	if (_Y) VU->VF[_Ft_].f.y = int12_to_float(VU->VF[_Fs_].SL[1]);
@@ -1543,8 +1705,10 @@ static __fi void _vuITOF12(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].f.w = int12_to_float(VU->VF[_Fs_].SL[3]);
 }
 
-static __fi void _vuITOF15(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuITOF15(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].f.x = int15_to_float(VU->VF[_Fs_].SL[0]);
 	if (_Y) VU->VF[_Ft_].f.y = int15_to_float(VU->VF[_Fs_].SL[1]);
@@ -1552,7 +1716,8 @@ static __fi void _vuITOF15(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].f.w = int15_to_float(VU->VF[_Fs_].SL[3]);
 }
 
-static __fi void _vuCLIP(VURegs * VU) {
+static __fi void _vuCLIP(VURegs* VU)
+{
 	float value = fabs(vuDouble(VU->VF[_Ft_].i.w));
 
 	VU->clipflag <<= 6;
@@ -1569,71 +1734,80 @@ static __fi void _vuCLIP(VURegs * VU) {
 /*   VU Lower instructions    */
 /******************************/
 
-static __fi void _vuDIV(VURegs * VU) {
+static __fi void _vuDIV(VURegs* VU)
+{
 	float ft = vuDouble(VU->VF[_Ft_].UL[_Ftf_]);
 	float fs = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
 
 	VU->statusflag &= ~0x30;
 
-	if (ft == 0.0) {
-		if (fs == 0.0) {
+	if (ft == 0.0)
+	{
+		if (fs == 0.0)
 			VU->statusflag |= 0x10;
-		} else {
+		else
 			VU->statusflag |= 0x20;
-		}
+
 		if ((VU->VF[_Ft_].UL[_Ftf_] & 0x80000000) ^
-			(VU->VF[_Fs_].UL[_Fsf_] & 0x80000000)) {
+			(VU->VF[_Fs_].UL[_Fsf_] & 0x80000000))
 			VU->q.UL = 0xFF7FFFFF;
-		} else {
+		else
 			VU->q.UL = 0x7F7FFFFF;
-		}
-	} else {
+	}
+	else
+	{
 		VU->q.F = fs / ft;
 		VU->q.F = vuDouble(VU->q.UL);
 	}
 }
 
-static __fi void _vuSQRT(VURegs * VU) {
+static __fi void _vuSQRT(VURegs* VU)
+{
 	float ft = vuDouble(VU->VF[_Ft_].UL[_Ftf_]);
 
 	VU->statusflag &= ~0x30;
 
-	if (ft < 0.0 ) VU->statusflag |= 0x10;
+	if (ft < 0.0)
+		VU->statusflag |= 0x10;
 	VU->q.F = sqrt(fabs(ft));
 	VU->q.F = vuDouble(VU->q.UL);
 }
 
-static __fi void _vuRSQRT(VURegs * VU) {
+static __fi void _vuRSQRT(VURegs* VU)
+{
 	float ft = vuDouble(VU->VF[_Ft_].UL[_Ftf_]);
 	float fs = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
 	float temp;
 
 	VU->statusflag &= ~0x30;
 
-	if ( ft == 0.0 ) {
+	if (ft == 0.0)
+	{
 		VU->statusflag |= 0x20;
 
-		if( fs != 0 ) {
+		if (fs != 0)
+		{
 			if ((VU->VF[_Ft_].UL[_Ftf_] & 0x80000000) ^
-				(VU->VF[_Fs_].UL[_Fsf_] & 0x80000000)) {
+				(VU->VF[_Fs_].UL[_Fsf_] & 0x80000000))
 				VU->q.UL = 0xFF7FFFFF;
-			} else {
+			else
 				VU->q.UL = 0x7F7FFFFF;
-			}
 		}
-		else {
+		else
+		{
 			if ((VU->VF[_Ft_].UL[_Ftf_] & 0x80000000) ^
-				(VU->VF[_Fs_].UL[_Fsf_] & 0x80000000)) {
+				(VU->VF[_Fs_].UL[_Fsf_] & 0x80000000))
 				VU->q.UL = 0x80000000;
-			} else {
+			else
 				VU->q.UL = 0;
-			}
 
 			VU->statusflag |= 0x10;
 		}
-
-	} else {
-		if (ft < 0.0) {
+	}
+	else
+	{
+		if (ft < 0.0)
+		{
 			VU->statusflag |= 0x10;
 		}
 
@@ -1643,66 +1817,82 @@ static __fi void _vuRSQRT(VURegs * VU) {
 	}
 }
 
-static __fi void _vuIADDI(VURegs * VU) {
+static __fi void _vuIADDI(VURegs* VU)
+{
 	s16 imm = ((VU->code >> 6) & 0x1f);
 	imm = ((imm & 0x10 ? 0xfff0 : 0) | (imm & 0xf));
-	if(_It_ == 0) return;
+	if (_It_ == 0)
+		return;
 
 	_vuBackupVI(VU, _It_);
 
 	VU->VI[_It_].SS[0] = VU->VI[_Is_].SS[0] + imm;
 }
 
-static __fi void _vuIADDIU(VURegs * VU) {
-	if(_It_ == 0) return;
+static __fi void _vuIADDIU(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	_vuBackupVI(VU, _It_);
 
 	VU->VI[_It_].SS[0] = VU->VI[_Is_].SS[0] + (((VU->code >> 10) & 0x7800) | (VU->code & 0x7ff));
 }
 
-static __fi void _vuIADD(VURegs * VU) {
-	if(_Id_ == 0) return;
+static __fi void _vuIADD(VURegs* VU)
+{
+	if (_Id_ == 0)
+		return;
 
 	_vuBackupVI(VU, _Id_);
 
 	VU->VI[_Id_].SS[0] = VU->VI[_Is_].SS[0] + VU->VI[_It_].SS[0];
 }
 
-static __fi void _vuIAND(VURegs * VU) {
-	if(_Id_ == 0) return;
+static __fi void _vuIAND(VURegs* VU)
+{
+	if (_Id_ == 0)
+		return;
 
 	_vuBackupVI(VU, _Id_);
 
 	VU->VI[_Id_].US[0] = VU->VI[_Is_].US[0] & VU->VI[_It_].US[0];
 }
 
-static __fi void _vuIOR(VURegs * VU) {
-	if(_Id_ == 0) return;
+static __fi void _vuIOR(VURegs* VU)
+{
+	if (_Id_ == 0)
+		return;
 
 	_vuBackupVI(VU, _Id_);
 
 	VU->VI[_Id_].US[0] = VU->VI[_Is_].US[0] | VU->VI[_It_].US[0];
 }
 
-static __fi void _vuISUB(VURegs * VU) {
-	if(_Id_ == 0) return;
+static __fi void _vuISUB(VURegs* VU)
+{
+	if (_Id_ == 0)
+		return;
 
 	_vuBackupVI(VU, _Id_);
 
 	VU->VI[_Id_].SS[0] = VU->VI[_Is_].SS[0] - VU->VI[_It_].SS[0];
 }
 
-static __fi void _vuISUBIU(VURegs * VU) {
-	if(_It_ == 0) return;
+static __fi void _vuISUBIU(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	_vuBackupVI(VU, _It_);
 
 	VU->VI[_It_].SS[0] = VU->VI[_Is_].SS[0] - (((VU->code >> 10) & 0x7800) | (VU->code & 0x7ff));
 }
 
-static __fi void _vuMOVE(VURegs * VU) {
-	if(_Ft_ == 0) return;
+static __fi void _vuMOVE(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].UL[0] = VU->VF[_Fs_].UL[0];
 	if (_Y) VU->VF[_Ft_].UL[1] = VU->VF[_Fs_].UL[1];
@@ -1710,8 +1900,10 @@ static __fi void _vuMOVE(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].UL[3] = VU->VF[_Fs_].UL[3];
 }
 
-static __fi void _vuMFIR(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __fi void _vuMFIR(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].SL[0] = (s32)VU->VI[_Is_].SS[0];
 	if (_Y) VU->VF[_Ft_].SL[1] = (s32)VU->VI[_Is_].SS[0];
@@ -1719,17 +1911,21 @@ static __fi void _vuMFIR(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].SL[3] = (s32)VU->VI[_Is_].SS[0];
 }
 
-static __fi void _vuMTIR(VURegs * VU) {
-	if(_It_ == 0) return;
+static __fi void _vuMTIR(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	_vuBackupVI(VU, _It_);
 
 	VU->VI[_It_].US[0] = *(u16*)&VU->VF[_Fs_].F[_Fsf_];
 }
 
-static __fi void _vuMR32(VURegs * VU) {
+static __fi void _vuMR32(VURegs* VU)
+{
 	u32 tx;
-	if (_Ft_ == 0) return;
+	if (_Ft_ == 0)
+		return;
 
 	tx = VU->VF[_Fs_].i.x;
 	if (_X) VU->VF[_Ft_].i.x = VU->VF[_Fs_].i.y;
@@ -1742,7 +1938,7 @@ static __fi void _vuMR32(VURegs * VU) {
 //  Load / Store Instructions (VU Interpreter)
 // --------------------------------------------------------------------------------------
 
-__fi u32* GET_VU_MEM(VURegs* VU, u32 addr)		// non-static, also used by sVU for now.
+__fi u32* GET_VU_MEM(VURegs* VU, u32 addr) // non-static, also used by sVU for now.
 {
 	if (VU == &vuRegs[1])
 		return (u32*)(vuRegs[1].Mem + (addr & 0x3fff));
@@ -1752,8 +1948,10 @@ __fi u32* GET_VU_MEM(VURegs* VU, u32 addr)		// non-static, also used by sVU for 
 		return (u32*)(vuRegs[0].Mem + (addr & 0xfff)); // for addr 0x0000 to 0x4000 just wrap around
 }
 
-static __ri void _vuLQ(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __ri void _vuLQ(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	s16 imm = (VU->code & 0x400) ? (VU->code & 0x3ff) | 0xfc00 : (VU->code & 0x3ff);
 	u16 addr = ((imm + VU->VI[_Is_].SS[0]) * 16);
@@ -1765,10 +1963,13 @@ static __ri void _vuLQ(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].UL[3] = ptr[3];
 }
 
-static __ri void _vuLQD( VURegs * VU ) {
+static __ri void _vuLQD(VURegs* VU)
+{
 	_vuBackupVI(VU, _Is_);
-	if (_Is_ != 0) VU->VI[_Is_].US[0]--;
-	if (_Ft_ == 0) return;
+	if (_Is_ != 0)
+		VU->VI[_Is_].US[0]--;
+	if (_Ft_ == 0)
+		return;
 
 	u32 addr = (VU->VI[_Is_].US[0] * 16);
 	u32* ptr = (u32*)GET_VU_MEM(VU, addr);
@@ -1778,9 +1979,11 @@ static __ri void _vuLQD( VURegs * VU ) {
 	if (_W) VU->VF[_Ft_].UL[3] = ptr[3];
 }
 
-static __ri void _vuLQI(VURegs * VU) {
+static __ri void _vuLQI(VURegs* VU)
+{
 	_vuBackupVI(VU, _Is_);
-	if (_Ft_) {
+	if (_Ft_)
+	{
 		u32 addr = (VU->VI[_Is_].US[0] * 16);
 		u32* ptr = (u32*)GET_VU_MEM(VU, addr);
 		if (_X) VU->VF[_Ft_].UL[0] = ptr[0];
@@ -1788,10 +1991,12 @@ static __ri void _vuLQI(VURegs * VU) {
 		if (_Z) VU->VF[_Ft_].UL[2] = ptr[2];
 		if (_W) VU->VF[_Ft_].UL[3] = ptr[3];
 	}
-	if (_Fs_ != 0) VU->VI[_Is_].US[0]++;
+	if (_Fs_ != 0)
+		VU->VI[_Is_].US[0]++;
 }
 
-static __ri void _vuSQ(VURegs * VU) {
+static __ri void _vuSQ(VURegs* VU)
+{
 	s16 imm = (VU->code & 0x400) ? (VU->code & 0x3ff) | 0xfc00 : (VU->code & 0x3ff);
 	u16 addr = ((imm + VU->VI[_It_].SS[0]) * 16);
 	u32* ptr = (u32*)GET_VU_MEM(VU, addr);
@@ -1801,9 +2006,11 @@ static __ri void _vuSQ(VURegs * VU) {
 	if (_W) ptr[3] = VU->VF[_Fs_].UL[3];
 }
 
-static __ri void _vuSQD(VURegs * VU) {
+static __ri void _vuSQD(VURegs* VU)
+{
 	_vuBackupVI(VU, _It_);
-	if(_Ft_ != 0) VU->VI[_It_].US[0]--;
+	if (_Ft_ != 0)
+		VU->VI[_It_].US[0]--;
 	u32 addr = (VU->VI[_It_].US[0] * 16);
 	u32* ptr = (u32*)GET_VU_MEM(VU, addr);
 	if (_X) ptr[0] = VU->VF[_Fs_].UL[0];
@@ -1812,7 +2019,8 @@ static __ri void _vuSQD(VURegs * VU) {
 	if (_W) ptr[3] = VU->VF[_Fs_].UL[3];
 }
 
-static __ri void _vuSQI(VURegs * VU) {
+static __ri void _vuSQI(VURegs* VU)
+{
 	_vuBackupVI(VU, _It_);
 	u32 addr = (VU->VI[_It_].US[0] * 16);
 	u32* ptr = (u32*)GET_VU_MEM(VU, addr);
@@ -1823,10 +2031,12 @@ static __ri void _vuSQI(VURegs * VU) {
 	if(_Ft_ != 0) VU->VI[_It_].US[0]++;
 }
 
-static __ri void _vuILW(VURegs * VU) {
-	if (_It_ == 0) return;
+static __ri void _vuILW(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
- 	s16 imm = (VU->code & 0x400) ? (VU->code & 0x3ff) | 0xfc00 : (VU->code & 0x3ff);
+	s16 imm = (VU->code & 0x400) ? (VU->code & 0x3ff) | 0xfc00 : (VU->code & 0x3ff);
 	u16 addr = ((imm + VU->VI[_Is_].SS[0]) * 16);
 	u16* ptr = (u16*)GET_VU_MEM(VU, addr);
 
@@ -1836,8 +2046,9 @@ static __ri void _vuILW(VURegs * VU) {
 	if (_W) VU->VI[_It_].US[0] = ptr[6];
 }
 
-static __fi void _vuISW(VURegs * VU) {
- 	s16 imm = (VU->code & 0x400) ? (VU->code & 0x3ff) | 0xfc00 : (VU->code & 0x3ff);
+static __fi void _vuISW(VURegs* VU)
+{
+	s16 imm = (VU->code & 0x400) ? (VU->code & 0x3ff) | 0xfc00 : (VU->code & 0x3ff);
 	u16 addr = ((imm + VU->VI[_Is_].SS[0]) * 16);
 	u16* ptr = (u16*)GET_VU_MEM(VU, addr);
 	if (_X) { ptr[0] = VU->VI[_It_].US[0]; ptr[1] = 0; }
@@ -1846,8 +2057,10 @@ static __fi void _vuISW(VURegs * VU) {
 	if (_W) { ptr[6] = VU->VI[_It_].US[0]; ptr[7] = 0; }
 }
 
-static __ri void _vuILWR(VURegs * VU) {
-	if (_It_ == 0) return;
+static __ri void _vuILWR(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	u32 addr = (VU->VI[_Is_].US[0] * 16);
 	u16* ptr = (u16*)GET_VU_MEM(VU, addr);
@@ -1858,7 +2071,8 @@ static __ri void _vuILWR(VURegs * VU) {
 	if (_W) VU->VI[_It_].US[0] = ptr[6];
 }
 
-static __ri void _vuISWR(VURegs * VU) {
+static __ri void _vuISWR(VURegs* VU)
+{
 	u32 addr = (VU->VI[_Is_].US[0] * 16);
 	u16* ptr = (u16*)GET_VU_MEM(VU, addr);
 	if (_X) { ptr[0] = VU->VI[_It_].US[0]; ptr[1] = 0; }
@@ -1882,25 +2096,30 @@ As an example for setting the polynomial variable correctly, the 23-bit M-series
 //The reverse sequences can be generated by x23+x(23-18) and x23+x(23-14) ((1 << 9) and (1 << 5), respectively)
 static u32 poly = 1 << 5;
 
-static __ri void SetPoly(u32 newPoly) {
+static __ri void SetPoly(u32 newPoly)
+{
 	poly = poly & ~1;
 }
 
-static __ri void AdvanceLFSR(VURegs * VU) {
+static __ri void AdvanceLFSR(VURegs* VU)
+{
 	// code from www.project-fao.org (which is no longer there)
 	int x = (VU->VI[REG_R].UL >> 4) & 1;
 	int y = (VU->VI[REG_R].UL >> 22) & 1;
 	VU->VI[REG_R].UL <<= 1;
 	VU->VI[REG_R].UL ^= x ^ y;
-	VU->VI[REG_R].UL = (VU->VI[REG_R].UL&0x7fffff)|0x3f800000;
+	VU->VI[REG_R].UL = (VU->VI[REG_R].UL & 0x7fffff) | 0x3f800000;
 }
 
-static __ri void _vuRINIT(VURegs * VU) {
+static __ri void _vuRINIT(VURegs* VU)
+{
 	VU->VI[REG_R].UL = 0x3F800000 | (VU->VF[_Fs_].UL[_Fsf_] & 0x007FFFFF);
 }
 
-static __ri void _vuRGET(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __ri void _vuRGET(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].UL[0] = VU->VI[REG_R].UL;
 	if (_Y) VU->VF[_Ft_].UL[1] = VU->VI[REG_R].UL;
@@ -1908,8 +2127,11 @@ static __ri void _vuRGET(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].UL[3] = VU->VI[REG_R].UL;
 }
 
-static __ri void _vuRNEXT(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __ri void _vuRNEXT(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
+		
 	AdvanceLFSR(VU);
 	if (_X) VU->VF[_Ft_].UL[0] = VU->VI[REG_R].UL;
 	if (_Y) VU->VF[_Ft_].UL[1] = VU->VI[REG_R].UL;
@@ -1917,98 +2139,133 @@ static __ri void _vuRNEXT(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].UL[3] = VU->VI[REG_R].UL;
 }
 
-static __ri void _vuRXOR(VURegs * VU) {
+static __ri void _vuRXOR(VURegs* VU)
+{
 	VU->VI[REG_R].UL = 0x3F800000 | ((VU->VI[REG_R].UL ^ VU->VF[_Fs_].UL[_Fsf_]) & 0x007FFFFF);
 }
 
-static __ri void _vuWAITQ(VURegs * VU) {
+static __ri void _vuWAITQ(VURegs* VU)
+{
 }
 
-static __ri void _vuFSAND(VURegs * VU) {
+static __ri void _vuFSAND(VURegs* VU)
+{
 	u16 imm;
 
-	imm = (((VU->code >> 21 ) & 0x1) << 11) | (VU->code & 0x7ff);
-	if(_It_ == 0) return;
+	imm = (((VU->code >> 21) & 0x1) << 11) | (VU->code & 0x7ff);
+	if (_It_ == 0)
+		return;
+		
 	VU->VI[_It_].US[0] = (VU->VI[REG_STATUS_FLAG].US[0] & 0xFFF) & imm;
 }
 
-static __ri void _vuFSEQ(VURegs * VU) {
+static __ri void _vuFSEQ(VURegs* VU)
+{
 	u16 imm;
 
-	imm = (((VU->code >> 21 ) & 0x1) << 11) | (VU->code & 0x7ff);
-	if(_It_ == 0) return;
-	if((VU->VI[REG_STATUS_FLAG].US[0] & 0xFFF) == imm) VU->VI[_It_].US[0] = 1;
-	else VU->VI[_It_].US[0] = 0;
+	imm = (((VU->code >> 21) & 0x1) << 11) | (VU->code & 0x7ff);
+	if (_It_ == 0)
+		return;
+		
+	if ((VU->VI[REG_STATUS_FLAG].US[0] & 0xFFF) == imm)
+		VU->VI[_It_].US[0] = 1;
+	else
+		VU->VI[_It_].US[0] = 0;
 }
 
-static __ri void _vuFSOR(VURegs * VU) {
+static __ri void _vuFSOR(VURegs* VU)
+{
 	u16 imm;
 
-	imm = (((VU->code >> 21 ) & 0x1) << 11) | (VU->code & 0x7ff);
-	if(_It_ == 0) return;
+	imm = (((VU->code >> 21) & 0x1) << 11) | (VU->code & 0x7ff);
+	if (_It_ == 0)
+		return;
 	VU->VI[_It_].US[0] = (VU->VI[REG_STATUS_FLAG].US[0] & 0xFFF) | imm;
 }
 
-static __ri void _vuFSSET(VURegs * VU) {
+static __ri void _vuFSSET(VURegs* VU)
+{
 	u16 imm = 0;
 
-	imm = (((VU->code >> 21 ) & 0x1) << 11) | (VU->code & 0x7FF);
+	imm = (((VU->code >> 21) & 0x1) << 11) | (VU->code & 0x7FF);
 	VU->statusflag = (imm & 0xFC0) | (VU->statusflag & 0x3F);
 }
 
-static __ri void _vuFMAND(VURegs * VU) {
-	if(_It_ == 0) return;
+static __ri void _vuFMAND(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	VU->VI[_It_].US[0] = VU->VI[_Is_].US[0] & (VU->VI[REG_MAC_FLAG].UL & 0xFFFF);
 }
 
-static __fi void _vuFMEQ(VURegs * VU) {
-	if(_It_ == 0) return;
+static __fi void _vuFMEQ(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
-	if((VU->VI[REG_MAC_FLAG].UL & 0xFFFF) == VU->VI[_Is_].US[0]){
-	VU->VI[_It_].US[0] =1;} else { VU->VI[_It_].US[0] =0; }
+	if ((VU->VI[REG_MAC_FLAG].UL & 0xFFFF) == VU->VI[_Is_].US[0])
+		VU->VI[_It_].US[0] = 1;
+	else
+		VU->VI[_It_].US[0] = 0;
 }
 
-static __fi void _vuFMOR(VURegs * VU) {
-	if(_It_ == 0) return;
+static __fi void _vuFMOR(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	VU->VI[_It_].US[0] = (VU->VI[REG_MAC_FLAG].UL & 0xFFFF) | VU->VI[_Is_].US[0];
 }
 
-static __fi void _vuFCAND(VURegs * VU) {
-	if((VU->VI[REG_CLIP_FLAG].UL & 0xFFFFFF) & (VU->code & 0xFFFFFF)) VU->VI[1].US[0] = 1;
-	else VU->VI[1].US[0] = 0;
+static __fi void _vuFCAND(VURegs* VU)
+{
+	if ((VU->VI[REG_CLIP_FLAG].UL & 0xFFFFFF) & (VU->code & 0xFFFFFF))
+		VU->VI[1].US[0] = 1;
+	else
+		VU->VI[1].US[0] = 0;
 }
 
-static __fi void _vuFCEQ(VURegs * VU) {
-	if((VU->VI[REG_CLIP_FLAG].UL & 0xFFFFFF) == (VU->code & 0xFFFFFF)) VU->VI[1].US[0] = 1;
-	else VU->VI[1].US[0] = 0;
+static __fi void _vuFCEQ(VURegs* VU)
+{
+	if ((VU->VI[REG_CLIP_FLAG].UL & 0xFFFFFF) == (VU->code & 0xFFFFFF))
+		VU->VI[1].US[0] = 1;
+	else
+		VU->VI[1].US[0] = 0;
 }
 
-static __fi void _vuFCOR(VURegs * VU) {
-	u32 hold = (VU->VI[REG_CLIP_FLAG].UL & 0xFFFFFF) | ( VU->code & 0xFFFFFF);
-	if(hold == 0xFFFFFF) VU->VI[1].US[0] = 1;
-	else VU->VI[1].US[0] = 0;
+static __fi void _vuFCOR(VURegs* VU)
+{
+	u32 hold = (VU->VI[REG_CLIP_FLAG].UL & 0xFFFFFF) | (VU->code & 0xFFFFFF);
+	if (hold == 0xFFFFFF)
+		VU->VI[1].US[0] = 1;
+	else
+		VU->VI[1].US[0] = 0;
 }
 
-static __fi void _vuFCSET(VURegs * VU) {
-	VU->clipflag = (u32) (VU->code & 0xFFFFFF);
+static __fi void _vuFCSET(VURegs* VU)
+{
+	VU->clipflag = (u32)(VU->code & 0xFFFFFF);
 }
 
-static __fi void _vuFCGET(VURegs * VU) {
-	if(_It_ == 0) return;
+static __fi void _vuFCGET(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
 
 	VU->VI[_It_].US[0] = VU->VI[REG_CLIP_FLAG].UL & 0x0FFF;
 }
 
-s32 _branchAddr(VURegs * VU) {
-	s32 bpc = VU->VI[REG_TPC].SL + ( _Imm11_ * 8 );
-	bpc&= (VU == &VU1) ? 0x3fff : 0x0fff;
+s32 _branchAddr(VURegs* VU)
+{
+	s32 bpc = VU->VI[REG_TPC].SL + (_Imm11_ * 8);
+	bpc &= (VU == &VU1) ? 0x3fff : 0x0fff;
 	return bpc;
 }
 
-static __fi void _setBranch(VURegs * VU, u32 bpc) {
-	if(VU->branch == 1) 
+static __fi void _setBranch(VURegs* VU, u32 bpc)
+{
+	if (VU->branch == 1)
 	{
 		//DevCon.Warning("Branch in Branch Delay slot!");
 		VU->delaybranchpc = bpc;
@@ -2021,173 +2278,169 @@ static __fi void _setBranch(VURegs * VU, u32 bpc) {
 	}
 }
 
-static __ri void _vuIBEQ(VURegs * VU) {
-	s16 dest = VU->VI[_It_].US[0] ;
+static __ri void _vuIBEQ(VURegs* VU)
+{
+	s16 dest = VU->VI[_It_].US[0];
 	s16 src = VU->VI[_Is_].US[0];
 #ifdef VI_BACKUP
-	if(VU->VIBackupCycles > 0)
+	if (VU->VIBackupCycles > 0)
 	{
-		if(VU->VIRegNumber == _It_)
-		{
+		if (VU->VIRegNumber == _It_)
 			dest = VU->VIOldValue;
-		}
-		if(VU->VIRegNumber == _Is_)
-		{
+
+		if (VU->VIRegNumber == _Is_)
 			src = VU->VIOldValue;
-		}
 	}
 #endif
-	if (dest == src) {
+	if (dest == src)
+	{
 		s32 bpc = _branchAddr(VU);
 		_setBranch(VU, bpc);
 	}
 }
 
-static __ri void _vuIBGEZ(VURegs * VU) {
+static __ri void _vuIBGEZ(VURegs* VU)
+{
 	s16 src = VU->VI[_Is_].US[0];
 #ifdef VI_BACKUP
-	if(VU->VIBackupCycles > 0)
+	if (VU->VIBackupCycles > 0)
 	{
-		if(VU->VIRegNumber == _Is_)
-		{
+		if (VU->VIRegNumber == _Is_)
 			src = VU->VIOldValue;
-		}
 	}
 #endif
-	if (src >= 0) {
+	if (src >= 0)
+	{
 		s32 bpc = _branchAddr(VU);
 		_setBranch(VU, bpc);
 	}
 }
 
-static __ri void _vuIBGTZ(VURegs * VU) {
+static __ri void _vuIBGTZ(VURegs* VU)
+{
 	s16 src = VU->VI[_Is_].US[0];
 #ifdef VI_BACKUP
-	if(VU->VIBackupCycles > 0)
+	if (VU->VIBackupCycles > 0)
 	{
-		if(VU->VIRegNumber == _Is_)
-		{
+		if (VU->VIRegNumber == _Is_)
 			src = VU->VIOldValue;
-		}
 	}
 #endif
 
-	if (src > 0) {
+	if (src > 0)
+	{
 		s32 bpc = _branchAddr(VU);
 		_setBranch(VU, bpc);
 	}
 }
 
-static __ri void _vuIBLEZ(VURegs * VU) {
+static __ri void _vuIBLEZ(VURegs* VU)
+{
 	s16 src = VU->VI[_Is_].US[0];
 #ifdef VI_BACKUP
-	if(VU->VIBackupCycles > 0)
+	if (VU->VIBackupCycles > 0)
 	{
-		if(VU->VIRegNumber == _Is_)
-		{
+		if (VU->VIRegNumber == _Is_)
 			src = VU->VIOldValue;
-		}
 	}
 #endif
-	if (src <= 0) {
+	if (src <= 0)
+	{
 		s32 bpc = _branchAddr(VU);
 		_setBranch(VU, bpc);
 	}
 }
 
-static __ri void _vuIBLTZ(VURegs * VU) {
+static __ri void _vuIBLTZ(VURegs* VU)
+{
 	s16 src = VU->VI[_Is_].US[0];
 #ifdef VI_BACKUP
-	if(VU->VIBackupCycles > 0)
+	if (VU->VIBackupCycles > 0)
 	{
-		if(VU->VIRegNumber == _Is_)
-		{
+		if (VU->VIRegNumber == _Is_)
 			src = VU->VIOldValue;
-		}
 	}
 #endif
-	if (src < 0) {
+	if (src < 0)
+	{
 		s32 bpc = _branchAddr(VU);
 		_setBranch(VU, bpc);
 	}
 }
 
-static __ri void _vuIBNE(VURegs * VU) {
-	s16 dest = VU->VI[_It_].US[0] ;
+static __ri void _vuIBNE(VURegs* VU)
+{
+	s16 dest = VU->VI[_It_].US[0];
 	s16 src = VU->VI[_Is_].US[0];
 #ifdef VI_BACKUP
-	if(VU->VIBackupCycles > 0)
+	if (VU->VIBackupCycles > 0)
 	{
-		if(VU->VIRegNumber == _It_)
-		{
+		if (VU->VIRegNumber == _It_)
 			dest = VU->VIOldValue;
-		}
-		if(VU->VIRegNumber == _Is_)
-		{
+
+		if (VU->VIRegNumber == _Is_)
 			src = VU->VIOldValue;
-		}
 	}
 #endif
-	if (dest != src) {
+	if (dest != src)
+	{
 		s32 bpc = _branchAddr(VU);
 		_setBranch(VU, bpc);
 	}
 }
 
-static __ri void _vuB(VURegs * VU) {
+static __ri void _vuB(VURegs* VU)
+{
 	s32 bpc = _branchAddr(VU);
 	_setBranch(VU, bpc);
 }
 
-static __ri void _vuBAL(VURegs * VU) {
+static __ri void _vuBAL(VURegs* VU)
+{
 	s32 bpc = _branchAddr(VU);
 
-	
-	if(_It_)
+
+	if (_It_)
 	{
 		//If we are in the branch delay slot, the instruction after the first
 		//instruction in the first branches target becomes the linked reg.
-		if(VU->branch == 1) 
-		{
-			VU->VI[_It_].US[0] = (VU->branchpc + 8)/8;
-		}
+		if (VU->branch == 1)
+			VU->VI[_It_].US[0] = (VU->branchpc + 8) / 8;
 		else
-		{
-			VU->VI[_It_].US[0] = (VU->VI[REG_TPC].UL+8)/8;
-		}
+			VU->VI[_It_].US[0] = (VU->VI[REG_TPC].UL + 8) / 8;
 	}
 
 	_setBranch(VU, bpc);
 }
 
-static __ri void _vuJR(VURegs * VU) {
-    u32 bpc = VU->VI[_Is_].US[0] * 8;
+static __ri void _vuJR(VURegs* VU)
+{
+	u32 bpc = VU->VI[_Is_].US[0] * 8;
 	_setBranch(VU, bpc);
 }
 
 //If this is in a branch delay, the jump isn't taken ( Evil Dead - Fistfull of Boomstick )
-static __ri void _vuJALR(VURegs * VU) {
-    u32 bpc = VU->VI[_Is_].US[0] * 8;
-	
-	if(_It_)
+static __ri void _vuJALR(VURegs* VU)
+{
+	u32 bpc = VU->VI[_Is_].US[0] * 8;
+
+	if (_It_)
 	{
 		//If we are in the branch delay slot, the instruction after the first
 		//instruction in the first branches target becomes the linked reg.
-		if(VU->branch == 1) 
-		{
-			VU->VI[_It_].US[0] = (VU->branchpc + 8)/8;
-		}
+		if (VU->branch == 1)
+			VU->VI[_It_].US[0] = (VU->branchpc + 8) / 8;
 		else
-		{
-			VU->VI[_It_].US[0] = (VU->VI[REG_TPC].UL+8)/8;
-		}
+			VU->VI[_It_].US[0] = (VU->VI[REG_TPC].UL + 8) / 8;
 	}
 
 	_setBranch(VU, bpc);
 }
 
-static __ri void _vuMFP(VURegs * VU) {
-	if (_Ft_ == 0) return;
+static __ri void _vuMFP(VURegs* VU)
+{
+	if (_Ft_ == 0)
+		return;
 
 	if (_X) VU->VF[_Ft_].i.x = VU->VI[REG_P].UL;
 	if (_Y) VU->VF[_Ft_].i.y = VU->VI[REG_P].UL;
@@ -2195,34 +2448,47 @@ static __ri void _vuMFP(VURegs * VU) {
 	if (_W) VU->VF[_Ft_].i.w = VU->VI[REG_P].UL;
 }
 
-static __ri void _vuWAITP(VURegs * VU) {
+static __ri void _vuWAITP(VURegs* VU)
+{
 }
 
-static __ri void _vuESADD(VURegs * VU) {
+static __ri void _vuESADD(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Fs_].i.z);
+
 	VU->p.F = p;
 }
 
-static __ri void _vuERSADD(VURegs * VU) {
+static __ri void _vuERSADD(VURegs* VU)
+{
 	float p = (vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Fs_].i.x)) + (vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Fs_].i.y)) + (vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Fs_].i.z));
+
 	if (p != 0.0)
 		p = 1.0f / p;
+
 	VU->p.F = p;
 }
 
-static __ri void _vuELENG(VURegs * VU) {
+static __ri void _vuELENG(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Fs_].i.z);
-	if(p >= 0){
+
+	if (p >= 0)
+	{
 		p = sqrt(p);
 	}
 	VU->p.F = p;
 }
 
-static __ri void _vuERLENG(VURegs * VU) {
+static __ri void _vuERLENG(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Fs_].i.z);
-	if (p >= 0) {
+
+	if (p >= 0)
+	{
 		p = sqrt(p);
-		if (p != 0) {
+		if (p != 0)
+		{
 			p = 1.0f / p;
 		}
 	}
@@ -2232,12 +2498,12 @@ static __ri void _vuERLENG(VURegs * VU) {
 
 static __ri float _vuCalculateEATAN(float inputvalue) {
 	float eatanconst[9] = { 0.999999344348907f, -0.333298563957214f, 0.199465364217758f, -0.13085337519646f,
-						0.096420042216778f, -0.055909886956215f, 0.021861229091883f, -0.004054057877511f,
-						0.785398185253143f };
+							0.096420042216778f, -0.055909886956215f, 0.021861229091883f, -0.004054057877511f,
+							0.785398185253143f };
 
 	float result = (eatanconst[0] * inputvalue) + (eatanconst[1] * pow(inputvalue, 3)) + (eatanconst[2] * pow(inputvalue, 5))
-		+ (eatanconst[3] * pow(inputvalue, 7)) + (eatanconst[4] * pow(inputvalue, 9)) + (eatanconst[5] * pow(inputvalue, 11))
-		+ (eatanconst[6] * pow(inputvalue, 13)) + (eatanconst[7] * pow(inputvalue, 15));
+					+ (eatanconst[3] * pow(inputvalue, 7)) + (eatanconst[4] * pow(inputvalue, 9)) + (eatanconst[5] * pow(inputvalue, 11))
+					+ (eatanconst[6] * pow(inputvalue, 13)) + (eatanconst[7] * pow(inputvalue, 15));
 
 	result += eatanconst[8];
 
@@ -2246,70 +2512,91 @@ static __ri float _vuCalculateEATAN(float inputvalue) {
 	return result;
 }
 
-static __ri void _vuEATAN(VURegs* VU) {
+static __ri void _vuEATAN(VURegs* VU)
+{
 	float p = _vuCalculateEATAN(vuDouble(VU->VF[_Fs_].UL[_Fsf_]));
 	VU->p.F = p;
 }
 
-static __ri void _vuEATANxy(VURegs * VU) {
+static __ri void _vuEATANxy(VURegs* VU)
+{
 	float p = 0;
-	if(vuDouble(VU->VF[_Fs_].i.x) != 0) {
+	if (vuDouble(VU->VF[_Fs_].i.x) != 0)
+	{
 		p = _vuCalculateEATAN(vuDouble(VU->VF[_Fs_].i.y) / vuDouble(VU->VF[_Fs_].i.x));
 	}
 	VU->p.F = p;
 }
 
-static __ri void _vuEATANxz(VURegs * VU) {
+static __ri void _vuEATANxz(VURegs* VU)
+{
 	float p = 0;
-	if(vuDouble(VU->VF[_Fs_].i.x) != 0) {
+	if (vuDouble(VU->VF[_Fs_].i.x) != 0)
+	{
 		p = _vuCalculateEATAN(vuDouble(VU->VF[_Fs_].i.z) / vuDouble(VU->VF[_Fs_].i.x));
 	}
 	VU->p.F = p;
 }
 
-static __ri void _vuESUM(VURegs * VU) {
+static __ri void _vuESUM(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Fs_].i.z) + vuDouble(VU->VF[_Fs_].i.w);
 	VU->p.F = p;
 }
 
-static __ri void _vuERCPR(VURegs * VU) {
+static __ri void _vuERCPR(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
-	if (p != 0){
+
+	if (p != 0)
+	{
 		p = 1.0 / p;
 	}
+
 	VU->p.F = p;
 }
 
-static __ri void _vuESQRT(VURegs * VU) {
+static __ri void _vuESQRT(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
-	if (p >= 0){
+
+	if (p >= 0)
+	{
 		p = sqrt(p);
 	}
+
 	VU->p.F = p;
 }
 
-static __ri void _vuERSQRT(VURegs * VU) {
+static __ri void _vuERSQRT(VURegs* VU)
+{
 	float p = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
-	if (p >= 0) {
+
+	if (p >= 0)
+	{
 		p = sqrt(p);
-		if (p) {
+		if (p)
+		{
 			p = 1.0f / p;
 		}
 	}
+
 	VU->p.F = p;
 }
 
-static __ri void _vuESIN(VURegs * VU) {
-	float sinconsts[5] = { 1.0f, -0.166666567325592f, 0.008333025500178f, -0.000198074136279f, 0.000002601886990f };
+static __ri void _vuESIN(VURegs* VU)
+{
+	float sinconsts[5] = {1.0f, -0.166666567325592f, 0.008333025500178f, -0.000198074136279f, 0.000002601886990f};
 	float p = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
 
 	p = (sinconsts[0] * p) + (sinconsts[1] * pow(p, 3)) + (sinconsts[2] * pow(p, 5)) + (sinconsts[3] * pow(p, 7)) + (sinconsts[4] * pow(p, 9));
 	VU->p.F = vuDouble(*(u32*)&p);
 }
 
-static __ri void _vuEEXP(VURegs * VU) {
-	float consts[6] = { 0.249998688697815f, 0.031257584691048f, 0.002591371303424f,
-						0.000171562001924f, 0.000005430199963f, 0.000000690600018f };
+static __ri void _vuEEXP(VURegs* VU)
+{
+	float consts[6] = {0.249998688697815f, 0.031257584691048f, 0.002591371303424f,
+						0.000171562001924f, 0.000005430199963f, 0.000000690600018f};
 	float p = vuDouble(VU->VF[_Fs_].UL[_Fsf_]);
 
 	p = 1.0f + (consts[0] * p) + (consts[1] * pow(p, 2)) + (consts[2] * pow(p, 3)) + (consts[3] * pow(p, 4)) + (consts[4] * pow(p, 5)) + (consts[5] * pow(p, 6));
@@ -2320,10 +2607,15 @@ static __ri void _vuEEXP(VURegs * VU) {
 	VU->p.F = p;
 }
 
-static __ri void _vuXITOP(VURegs * VU) {
-	if (_It_ == 0) return;
-	if (VU==&VU1 && THREAD_VU1) VU->VI[_It_].US[0] = vu1Thread.vifRegs.itop;
-	else                        VU->VI[_It_].US[0] = VU->GetVifRegs().itop;
+static __ri void _vuXITOP(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
+		
+	if (VU == &VU1 && THREAD_VU1)
+		VU->VI[_It_].US[0] = vu1Thread.vifRegs.itop;
+	else
+		VU->VI[_It_].US[0] = VU->GetVifRegs().itop;
 }
 
 void _vuXGKICKTransfer(VURegs* VU, u32 cycles, bool flush)
@@ -2374,7 +2666,7 @@ void _vuXGKICKTransfer(VURegs* VU, u32 cycles, bool flush)
 		/*if ((transfersize * 0x10) < VU->xgkicksizeremaining)
 			gifUnit.gifPath[GIF_PATH_1].CopyGSPacketData(&VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
 		else*/
-			gifUnit.TransferGSPacketData(GIF_TRANS_XGKICK, &VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
+		gifUnit.TransferGSPacketData(GIF_TRANS_XGKICK, &VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
 
 		if ((VU0.VI[REG_VPU_STAT].UL & 0x100) && flush)
 			VU->cycle += transfersize * 2;
@@ -2384,7 +2676,7 @@ void _vuXGKICKTransfer(VURegs* VU, u32 cycles, bool flush)
 		VU->xgkickaddr = (VU->xgkickaddr + (transfersize * 0x10)) & 0x3FFF;
 		VU->xgkicksizeremaining -= (transfersize * 0x10);
 		VU->xgkickdiff = 0x4000 - VU->xgkickaddr;
-		
+
 		if (VU->xgkicksizeremaining || !VU->xgkickendpacket)
 			VUM_LOG("XGKICK next addr %x left size %x", VU->xgkickaddr, VU->xgkicksizeremaining);
 		else
@@ -2407,12 +2699,10 @@ void _vuXGKICKTransfer(VURegs* VU, u32 cycles, bool flush)
 	}
 }
 
-static __ri void _vuXGKICK(VURegs * VU)
+static __ri void _vuXGKICK(VURegs* VU)
 {
 	if (VU->xgkickenable)
-	{
 		_vuXGKICKTransfer(VU, 0, true);
-	}
 
 	u32 addr = (VU->VI[_Is_].US[0] & 0x3ff) * 16;
 	u32 diff = 0x4000 - addr;
@@ -2428,13 +2718,18 @@ static __ri void _vuXGKICK(VURegs * VU)
 	VUM_LOG("XGKICK addr %x", addr);
 }
 
-static __ri void _vuXTOP(VURegs * VU) {
-	if(_It_ == 0) return;
-	if (VU==&VU1 && THREAD_VU1) VU->VI[_It_].US[0] = (u16)vu1Thread.vifRegs.top;
-	else                        VU->VI[_It_].US[0] = (u16)VU->GetVifRegs().top;
+static __ri void _vuXTOP(VURegs* VU)
+{
+	if (_It_ == 0)
+		return;
+		
+	if (VU == &VU1 && THREAD_VU1)
+		VU->VI[_It_].US[0] = (u16)vu1Thread.vifRegs.top;
+	else
+		VU->VI[_It_].US[0] = (u16)VU->GetVifRegs().top;
 }
 
-#define GET_VF0_FLAG(reg) (((reg)==0)?(1<<REG_VF0_FLAG):0)
+#define GET_VF0_FLAG(reg) (((reg) == 0) ? (1 << REG_VF0_FLAG) : 0)
 
 #define VUREGS_FDFSI(OP, ACC) \
 static __ri void _vuRegs##OP(const VURegs* VU, _VURegsNum *VUregsn) { \
@@ -2690,7 +2985,8 @@ VUREGS_FDFSFT_0_xyzw(MADDx, 8);
 VUREGS_FDFSFT_0_xyzw(MADDy, 4);
 VUREGS_FDFSFT_0_xyzw(MADDz, 2);
 
-static __ri void _vuRegsMADDw(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMADDw(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
 	VUregsn->VFwrite = _Fd_;
 	VUregsn->VFwxyzw = _XYZW;
@@ -2733,16 +3029,20 @@ VUREGS_FDFSFTy(MAXy_, 0);
 VUREGS_FDFSFTz(MAXz_, 0);
 VUREGS_FDFSFTw(MAXw_, 0);
 
-static __ri void _vuRegsMAXx(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMAXx(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	_vuRegsMAXx_(VU, VUregsn);
 }
-static __ri void _vuRegsMAXy(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMAXy(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	_vuRegsMAXy_(VU, VUregsn);
 }
-static __ri void _vuRegsMAXz(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMAXz(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	_vuRegsMAXz_(VU, VUregsn);
 }
-static __ri void _vuRegsMAXw(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMAXw(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	_vuRegsMAXw_(VU, VUregsn);
 }
 
@@ -2753,7 +3053,8 @@ VUREGS_FDFSFTy(MINIy, 0);
 VUREGS_FDFSFTz(MINIz, 0);
 VUREGS_FDFSFTw(MINIw, 0);
 
-static __ri void _vuRegsOPMULA(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsOPMULA(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
 	VUregsn->VFwrite = 0;
 	VUregsn->VFwxyzw= 0xE;
@@ -2765,7 +3066,8 @@ static __ri void _vuRegsOPMULA(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_)|(1<<REG_ACC_FLAG);
 }
 
-static __ri void _vuRegsOPMSUB(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsOPMSUB(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
 	VUregsn->VFwrite = _Fd_;
 	VUregsn->VFwxyzw= 0xE;
@@ -2777,7 +3079,8 @@ static __ri void _vuRegsOPMSUB(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = GET_VF0_FLAG(_Fs_)|GET_VF0_FLAG(_Ft_)|(1<<REG_ACC_FLAG);
 }
 
-static __ri void _vuRegsNOP(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsNOP(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_NONE;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -2795,7 +3098,8 @@ VUREGS_FTFS(ITOF4);
 VUREGS_FTFS(ITOF12);
 VUREGS_FTFS(ITOF15);
 
-static __ri void _vuRegsCLIP(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsCLIP(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2810,7 +3114,8 @@ static __ri void _vuRegsCLIP(const VURegs* VU, _VURegsNum *VUregsn) {
 /*   VU Lower instructions    */
 /******************************/
 
-static __ri void _vuRegsDIV(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsDIV(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FDIV;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2822,7 +3127,8 @@ static __ri void _vuRegsDIV(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->cycles  = 7;
 }
 
-static __ri void _vuRegsSQRT(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsSQRT(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FDIV;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = 0;
@@ -2834,7 +3140,8 @@ static __ri void _vuRegsSQRT(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->cycles  = 7;
 }
 
-static __ri void _vuRegsRSQRT(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsRSQRT(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FDIV;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2854,7 +3161,8 @@ VUREGS_IDISIT(IOR);
 VUREGS_IDISIT(ISUB);
 VUREGS_ITIS(ISUBIU);
 
-static __ri void _vuRegsMOVE(const VURegs* VU, _VURegsNum* VUregsn) {
+static __ri void _vuRegsMOVE(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = _Ft_ == 0 ? VUPIPE_NONE : VUPIPE_FMAC;
 	VUregsn->VFwrite = _Ft_;
 	VUregsn->VFwxyzw = _XYZW;
@@ -2865,7 +3173,8 @@ static __ri void _vuRegsMOVE(const VURegs* VU, _VURegsNum* VUregsn) {
 	VUregsn->VIwrite = 0;
 	VUregsn->VIread = (_Ft_ ? GET_VF0_FLAG(_Fs_) : 0);
 }
-static __ri void _vuRegsMFIR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMFIR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -2875,7 +3184,8 @@ static __ri void _vuRegsMFIR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsMTIR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMTIR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2885,7 +3195,8 @@ static __ri void _vuRegsMTIR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = GET_VF0_FLAG(_Fs_);
 }
 
-static __ri void _vuRegsMR32(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMR32(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
 	VUregsn->VFwrite = _Ft_;
 	VUregsn->VFwxyzw = _XYZW;
@@ -2897,7 +3208,8 @@ static __ri void _vuRegsMR32(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = (_Ft_ ? GET_VF0_FLAG(_Fs_) : 0);
 }
 
-static __ri void _vuRegsLQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsLQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -2907,7 +3219,8 @@ static __ri void _vuRegsLQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsLQD(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsLQD(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -2917,7 +3230,8 @@ static __ri void _vuRegsLQD(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsLQI(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsLQI(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -2927,7 +3241,8 @@ static __ri void _vuRegsLQI(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsSQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsSQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2937,7 +3252,8 @@ static __ri void _vuRegsSQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _It_;
 }
 
-static __ri void _vuRegsSQD(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsSQD(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2947,7 +3263,8 @@ static __ri void _vuRegsSQD(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _It_;
 }
 
-static __ri void _vuRegsSQI(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsSQI(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -2957,7 +3274,8 @@ static __ri void _vuRegsSQI(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _It_;
 }
 
-static __ri void _vuRegsILW(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsILW(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_IALU;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = 0;
@@ -2967,7 +3285,8 @@ static __ri void _vuRegsILW(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->cycles  = 4;
 }
 
-static __ri void _vuRegsISW(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsISW(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_IALU;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = 0;
@@ -2976,7 +3295,8 @@ static __ri void _vuRegsISW(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << _Is_) | (1 << _It_);
 }
 
-static __ri void _vuRegsILWR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsILWR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_IALU;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = 0;
@@ -2986,7 +3306,8 @@ static __ri void _vuRegsILWR(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->cycles  = 4;
 }
 
-static __ri void _vuRegsISWR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsISWR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_IALU;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = 0;
@@ -2995,7 +3316,8 @@ static __ri void _vuRegsISWR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << _Is_) | (1 << _It_);
 }
 
-static __ri void _vuRegsRINIT(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsRINIT(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -3005,7 +3327,8 @@ static __ri void _vuRegsRINIT(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = GET_VF0_FLAG(_Fs_);
 }
 
-static __ri void _vuRegsRGET(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsRGET(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -3015,7 +3338,8 @@ static __ri void _vuRegsRGET(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_R;
 }
 
-static __ri void _vuRegsRNEXT(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsRNEXT(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -3025,7 +3349,8 @@ static __ri void _vuRegsRNEXT(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_R;
 }
 
-static __ri void _vuRegsRXOR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsRXOR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
 	VUregsn->VFread0 = _Fs_;
@@ -3035,7 +3360,8 @@ static __ri void _vuRegsRXOR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << REG_R)|GET_VF0_FLAG(_Fs_);
 }
 
-static __ri void _vuRegsWAITQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsWAITQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FDIV;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3044,7 +3370,8 @@ static __ri void _vuRegsWAITQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 0;
 }
 
-static __ri void _vuRegsFSAND(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFSAND(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3053,7 +3380,8 @@ static __ri void _vuRegsFSAND(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_STATUS_FLAG;
 }
 
-static __ri void _vuRegsFSEQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFSEQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3062,7 +3390,8 @@ static __ri void _vuRegsFSEQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_STATUS_FLAG;
 }
 
-static __ri void _vuRegsFSOR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFSOR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3071,7 +3400,8 @@ static __ri void _vuRegsFSOR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_STATUS_FLAG;
 }
 
-static __ri void _vuRegsFSSET(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFSSET(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3080,7 +3410,8 @@ static __ri void _vuRegsFSSET(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 0;
 }
 
-static __ri void _vuRegsFMAND(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFMAND(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3089,7 +3420,8 @@ static __ri void _vuRegsFMAND(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << REG_MAC_FLAG) | (1 << _Is_);
 }
 
-static __ri void _vuRegsFMEQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFMEQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3098,7 +3430,8 @@ static __ri void _vuRegsFMEQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << REG_MAC_FLAG) | (1 << _Is_);
 }
 
-static __ri void _vuRegsFMOR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFMOR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3107,7 +3440,8 @@ static __ri void _vuRegsFMOR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << REG_MAC_FLAG) | (1 << _Is_);
 }
 
-static __ri void _vuRegsFCAND(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFCAND(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3116,7 +3450,8 @@ static __ri void _vuRegsFCAND(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_CLIP_FLAG;
 }
 
-static __ri void _vuRegsFCEQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFCEQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3125,7 +3460,8 @@ static __ri void _vuRegsFCEQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_CLIP_FLAG;
 }
 
-static __ri void _vuRegsFCOR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFCOR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3134,7 +3470,8 @@ static __ri void _vuRegsFCOR(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_CLIP_FLAG;
 }
 
-static __ri void _vuRegsFCSET(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFCSET(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3143,7 +3480,8 @@ static __ri void _vuRegsFCSET(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 0;
 }
 
-static __ri void _vuRegsFCGET(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsFCGET(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3152,7 +3490,8 @@ static __ri void _vuRegsFCGET(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << REG_CLIP_FLAG;
 }
 
-static __ri void _vuRegsIBEQ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsIBEQ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3161,7 +3500,8 @@ static __ri void _vuRegsIBEQ(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << _Is_) | (1 << _It_);
 }
 
-static __ri void _vuRegsIBGEZ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsIBGEZ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3170,7 +3510,8 @@ static __ri void _vuRegsIBGEZ(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsIBGTZ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsIBGTZ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3179,7 +3520,8 @@ static __ri void _vuRegsIBGTZ(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsIBLEZ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsIBLEZ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3188,7 +3530,8 @@ static __ri void _vuRegsIBLEZ(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsIBLTZ(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsIBLTZ(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3197,7 +3540,8 @@ static __ri void _vuRegsIBLTZ(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsIBNE(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsIBNE(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3206,7 +3550,8 @@ static __ri void _vuRegsIBNE(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = (1 << _Is_) | (1 << _It_);
 }
 
-static __ri void _vuRegsB(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsB(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3215,7 +3560,8 @@ static __ri void _vuRegsB(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 0;
 }
 
-static __ri void _vuRegsBAL(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsBAL(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3224,7 +3570,8 @@ static __ri void _vuRegsBAL(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 0;
 }
 
-static __ri void _vuRegsJR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsJR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3233,7 +3580,8 @@ static __ri void _vuRegsJR(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsJALR(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsJALR(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_BRANCH;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3242,7 +3590,8 @@ static __ri void _vuRegsJALR(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsMFP(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsMFP(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_FMAC;
     VUregsn->VFwrite = _Ft_;
     VUregsn->VFwxyzw = _XYZW;
@@ -3252,7 +3601,8 @@ static __ri void _vuRegsMFP(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->VIread  = 1 << REG_P;
 }
 
-static __ri void _vuRegsWAITP(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsWAITP(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_EFU;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3276,7 +3626,8 @@ VUREGS_PFS_fsf(ESIN, 29);
 VUREGS_PFS_fsf(EATAN, 54);
 VUREGS_PFS_fsf(EEXP, 44);
 
-static __ri void _vuRegsXITOP(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsXITOP(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_IALU;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3286,7 +3637,8 @@ static __ri void _vuRegsXITOP(const VURegs* VU, _VURegsNum *VUregsn) {
 	VUregsn->cycles  = 0;
 }
 
-static __ri void _vuRegsXGKICK(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsXGKICK(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_XGKICK;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3295,7 +3647,8 @@ static __ri void _vuRegsXGKICK(const VURegs* VU, _VURegsNum *VUregsn) {
     VUregsn->VIread  = 1 << _Is_;
 }
 
-static __ri void _vuRegsXTOP(const VURegs* VU, _VURegsNum *VUregsn) {
+static __ri void _vuRegsXTOP(const VURegs* VU, _VURegsNum* VUregsn)
+{
 	VUregsn->pipe = VUPIPE_IALU;
     VUregsn->VFwrite = 0;
     VUregsn->VFread0 = 0;
@@ -3487,182 +3840,184 @@ static void VU0MI_XTOP() {}
 /*   VU Micromode Upper instructions    */
 /****************************************/
 
-static void __vuRegsCall VU0regsMI_ABS(_VURegsNum *VUregsn)  { _vuRegsABS(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADD(_VURegsNum *VUregsn)  { _vuRegsADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDi(_VURegsNum *VUregsn) { _vuRegsADDi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDq(_VURegsNum *VUregsn) { _vuRegsADDq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDx(_VURegsNum *VUregsn) { _vuRegsADDx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDy(_VURegsNum *VUregsn) { _vuRegsADDy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDz(_VURegsNum *VUregsn) { _vuRegsADDz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDw(_VURegsNum *VUregsn) { _vuRegsADDw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDA(_VURegsNum *VUregsn) { _vuRegsADDA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAi(_VURegsNum *VUregsn) { _vuRegsADDAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAq(_VURegsNum *VUregsn) { _vuRegsADDAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAx(_VURegsNum *VUregsn) { _vuRegsADDAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAy(_VURegsNum *VUregsn) { _vuRegsADDAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAz(_VURegsNum *VUregsn) { _vuRegsADDAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAw(_VURegsNum *VUregsn) { _vuRegsADDAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUB(_VURegsNum *VUregsn)  { _vuRegsSUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBi(_VURegsNum *VUregsn) { _vuRegsSUBi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBq(_VURegsNum *VUregsn) { _vuRegsSUBq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBx(_VURegsNum *VUregsn) { _vuRegsSUBx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBy(_VURegsNum *VUregsn) { _vuRegsSUBy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBz(_VURegsNum *VUregsn) { _vuRegsSUBz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBw(_VURegsNum *VUregsn) { _vuRegsSUBw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBA(_VURegsNum *VUregsn)  { _vuRegsSUBA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAi(_VURegsNum *VUregsn) { _vuRegsSUBAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAq(_VURegsNum *VUregsn) { _vuRegsSUBAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAx(_VURegsNum *VUregsn) { _vuRegsSUBAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAy(_VURegsNum *VUregsn) { _vuRegsSUBAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAz(_VURegsNum *VUregsn) { _vuRegsSUBAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAw(_VURegsNum *VUregsn) { _vuRegsSUBAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MUL(_VURegsNum *VUregsn)  { _vuRegsMUL(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULi(_VURegsNum *VUregsn) { _vuRegsMULi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULq(_VURegsNum *VUregsn) { _vuRegsMULq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULx(_VURegsNum *VUregsn) { _vuRegsMULx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULy(_VURegsNum *VUregsn) { _vuRegsMULy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULz(_VURegsNum *VUregsn) { _vuRegsMULz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULw(_VURegsNum *VUregsn) { _vuRegsMULw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULA(_VURegsNum *VUregsn)  { _vuRegsMULA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAi(_VURegsNum *VUregsn) { _vuRegsMULAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAq(_VURegsNum *VUregsn) { _vuRegsMULAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAx(_VURegsNum *VUregsn) { _vuRegsMULAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAy(_VURegsNum *VUregsn) { _vuRegsMULAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAz(_VURegsNum *VUregsn) { _vuRegsMULAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAw(_VURegsNum *VUregsn) { _vuRegsMULAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADD(_VURegsNum *VUregsn)  { _vuRegsMADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDi(_VURegsNum *VUregsn) { _vuRegsMADDi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDq(_VURegsNum *VUregsn) { _vuRegsMADDq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDx(_VURegsNum *VUregsn) { _vuRegsMADDx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDy(_VURegsNum *VUregsn) { _vuRegsMADDy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDz(_VURegsNum *VUregsn) { _vuRegsMADDz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDw(_VURegsNum *VUregsn) { _vuRegsMADDw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDA(_VURegsNum *VUregsn)  { _vuRegsMADDA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAi(_VURegsNum *VUregsn) { _vuRegsMADDAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAq(_VURegsNum *VUregsn) { _vuRegsMADDAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAx(_VURegsNum *VUregsn) { _vuRegsMADDAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAy(_VURegsNum *VUregsn) { _vuRegsMADDAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAz(_VURegsNum *VUregsn) { _vuRegsMADDAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAw(_VURegsNum *VUregsn) { _vuRegsMADDAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUB(_VURegsNum *VUregsn)  { _vuRegsMSUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBi(_VURegsNum *VUregsn) { _vuRegsMSUBi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBq(_VURegsNum *VUregsn) { _vuRegsMSUBq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBx(_VURegsNum *VUregsn) { _vuRegsMSUBx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBy(_VURegsNum *VUregsn) { _vuRegsMSUBy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBz(_VURegsNum *VUregsn) { _vuRegsMSUBz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBw(_VURegsNum *VUregsn) { _vuRegsMSUBw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBA(_VURegsNum *VUregsn)  { _vuRegsMSUBA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAi(_VURegsNum *VUregsn) { _vuRegsMSUBAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAq(_VURegsNum *VUregsn) { _vuRegsMSUBAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAx(_VURegsNum *VUregsn) { _vuRegsMSUBAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAy(_VURegsNum *VUregsn) { _vuRegsMSUBAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAz(_VURegsNum *VUregsn) { _vuRegsMSUBAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAw(_VURegsNum *VUregsn) { _vuRegsMSUBAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAX(_VURegsNum *VUregsn)  { _vuRegsMAX(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXi(_VURegsNum *VUregsn) { _vuRegsMAXi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXx(_VURegsNum *VUregsn) { _vuRegsMAXx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXy(_VURegsNum *VUregsn) { _vuRegsMAXy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXz(_VURegsNum *VUregsn) { _vuRegsMAXz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXw(_VURegsNum *VUregsn) { _vuRegsMAXw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINI(_VURegsNum *VUregsn)  { _vuRegsMINI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIi(_VURegsNum *VUregsn) { _vuRegsMINIi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIx(_VURegsNum *VUregsn) { _vuRegsMINIx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIy(_VURegsNum *VUregsn) { _vuRegsMINIy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIz(_VURegsNum *VUregsn) { _vuRegsMINIz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIw(_VURegsNum *VUregsn) { _vuRegsMINIw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_OPMULA(_VURegsNum *VUregsn) { _vuRegsOPMULA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_OPMSUB(_VURegsNum *VUregsn) { _vuRegsOPMSUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_NOP(_VURegsNum *VUregsn) { _vuRegsNOP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI0(_VURegsNum *VUregsn)  { _vuRegsFTOI0(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI4(_VURegsNum *VUregsn)  { _vuRegsFTOI4(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI12(_VURegsNum *VUregsn) { _vuRegsFTOI12(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI15(_VURegsNum *VUregsn) { _vuRegsFTOI15(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF0(_VURegsNum *VUregsn)  { _vuRegsITOF0(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF4(_VURegsNum *VUregsn)  { _vuRegsITOF4(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF12(_VURegsNum *VUregsn) { _vuRegsITOF12(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF15(_VURegsNum *VUregsn) { _vuRegsITOF15(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_CLIP(_VURegsNum *VUregsn) { _vuRegsCLIP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ABS(_VURegsNum* VUregsn) { _vuRegsABS(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADD(_VURegsNum* VUregsn) { _vuRegsADD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDi(_VURegsNum* VUregsn) { _vuRegsADDi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDq(_VURegsNum* VUregsn) { _vuRegsADDq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDx(_VURegsNum* VUregsn) { _vuRegsADDx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDy(_VURegsNum* VUregsn) { _vuRegsADDy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDz(_VURegsNum* VUregsn) { _vuRegsADDz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDw(_VURegsNum* VUregsn) { _vuRegsADDw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDA(_VURegsNum* VUregsn) { _vuRegsADDA(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDAi(_VURegsNum* VUregsn) { _vuRegsADDAi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDAq(_VURegsNum* VUregsn) { _vuRegsADDAq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDAx(_VURegsNum* VUregsn) { _vuRegsADDAx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDAy(_VURegsNum* VUregsn) { _vuRegsADDAy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDAz(_VURegsNum* VUregsn) { _vuRegsADDAz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ADDAw(_VURegsNum* VUregsn) { _vuRegsADDAw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUB(_VURegsNum* VUregsn) { _vuRegsSUB(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBi(_VURegsNum* VUregsn) { _vuRegsSUBi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBq(_VURegsNum* VUregsn) { _vuRegsSUBq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBx(_VURegsNum* VUregsn) { _vuRegsSUBx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBy(_VURegsNum* VUregsn) { _vuRegsSUBy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBz(_VURegsNum* VUregsn) { _vuRegsSUBz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBw(_VURegsNum* VUregsn) { _vuRegsSUBw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBA(_VURegsNum* VUregsn) { _vuRegsSUBA(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBAi(_VURegsNum* VUregsn) { _vuRegsSUBAi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBAq(_VURegsNum* VUregsn) { _vuRegsSUBAq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBAx(_VURegsNum* VUregsn) { _vuRegsSUBAx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBAy(_VURegsNum* VUregsn) { _vuRegsSUBAy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBAz(_VURegsNum* VUregsn) { _vuRegsSUBAz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SUBAw(_VURegsNum* VUregsn) { _vuRegsSUBAw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MUL(_VURegsNum* VUregsn) { _vuRegsMUL(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULi(_VURegsNum* VUregsn) { _vuRegsMULi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULq(_VURegsNum* VUregsn) { _vuRegsMULq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULx(_VURegsNum* VUregsn) { _vuRegsMULx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULy(_VURegsNum* VUregsn) { _vuRegsMULy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULz(_VURegsNum* VUregsn) { _vuRegsMULz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULw(_VURegsNum* VUregsn) { _vuRegsMULw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULA(_VURegsNum* VUregsn) { _vuRegsMULA(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULAi(_VURegsNum* VUregsn) { _vuRegsMULAi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULAq(_VURegsNum* VUregsn) { _vuRegsMULAq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULAx(_VURegsNum* VUregsn) { _vuRegsMULAx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULAy(_VURegsNum* VUregsn) { _vuRegsMULAy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULAz(_VURegsNum* VUregsn) { _vuRegsMULAz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MULAw(_VURegsNum* VUregsn) { _vuRegsMULAw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADD(_VURegsNum* VUregsn) { _vuRegsMADD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDi(_VURegsNum* VUregsn) { _vuRegsMADDi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDq(_VURegsNum* VUregsn) { _vuRegsMADDq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDx(_VURegsNum* VUregsn) { _vuRegsMADDx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDy(_VURegsNum* VUregsn) { _vuRegsMADDy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDz(_VURegsNum* VUregsn) { _vuRegsMADDz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDw(_VURegsNum* VUregsn) { _vuRegsMADDw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDA(_VURegsNum* VUregsn) { _vuRegsMADDA(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDAi(_VURegsNum* VUregsn) { _vuRegsMADDAi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDAq(_VURegsNum* VUregsn) { _vuRegsMADDAq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDAx(_VURegsNum* VUregsn) { _vuRegsMADDAx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDAy(_VURegsNum* VUregsn) { _vuRegsMADDAy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDAz(_VURegsNum* VUregsn) { _vuRegsMADDAz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MADDAw(_VURegsNum* VUregsn) { _vuRegsMADDAw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUB(_VURegsNum* VUregsn) { _vuRegsMSUB(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBi(_VURegsNum* VUregsn) { _vuRegsMSUBi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBq(_VURegsNum* VUregsn) { _vuRegsMSUBq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBx(_VURegsNum* VUregsn) { _vuRegsMSUBx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBy(_VURegsNum* VUregsn) { _vuRegsMSUBy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBz(_VURegsNum* VUregsn) { _vuRegsMSUBz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBw(_VURegsNum* VUregsn) { _vuRegsMSUBw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBA(_VURegsNum* VUregsn) { _vuRegsMSUBA(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBAi(_VURegsNum* VUregsn) { _vuRegsMSUBAi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBAq(_VURegsNum* VUregsn) { _vuRegsMSUBAq(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBAx(_VURegsNum* VUregsn) { _vuRegsMSUBAx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBAy(_VURegsNum* VUregsn) { _vuRegsMSUBAy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBAz(_VURegsNum* VUregsn) { _vuRegsMSUBAz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MSUBAw(_VURegsNum* VUregsn) { _vuRegsMSUBAw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MAX(_VURegsNum* VUregsn) { _vuRegsMAX(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MAXi(_VURegsNum* VUregsn) { _vuRegsMAXi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MAXx(_VURegsNum* VUregsn) { _vuRegsMAXx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MAXy(_VURegsNum* VUregsn) { _vuRegsMAXy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MAXz(_VURegsNum* VUregsn) { _vuRegsMAXz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MAXw(_VURegsNum* VUregsn) { _vuRegsMAXw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MINI(_VURegsNum* VUregsn) { _vuRegsMINI(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MINIi(_VURegsNum* VUregsn) { _vuRegsMINIi(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MINIx(_VURegsNum* VUregsn) { _vuRegsMINIx(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MINIy(_VURegsNum* VUregsn) { _vuRegsMINIy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MINIz(_VURegsNum* VUregsn) { _vuRegsMINIz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MINIw(_VURegsNum* VUregsn) { _vuRegsMINIw(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_OPMULA(_VURegsNum* VUregsn) { _vuRegsOPMULA(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_OPMSUB(_VURegsNum* VUregsn) { _vuRegsOPMSUB(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_NOP(_VURegsNum* VUregsn) { _vuRegsNOP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FTOI0(_VURegsNum* VUregsn) { _vuRegsFTOI0(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FTOI4(_VURegsNum* VUregsn) { _vuRegsFTOI4(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FTOI12(_VURegsNum* VUregsn) { _vuRegsFTOI12(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FTOI15(_VURegsNum* VUregsn) { _vuRegsFTOI15(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ITOF0(_VURegsNum* VUregsn) { _vuRegsITOF0(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ITOF4(_VURegsNum* VUregsn) { _vuRegsITOF4(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ITOF12(_VURegsNum* VUregsn) { _vuRegsITOF12(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ITOF15(_VURegsNum* VUregsn) { _vuRegsITOF15(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_CLIP(_VURegsNum* VUregsn) { _vuRegsCLIP(&VU0, VUregsn); }
 
 /*****************************************/
 /*   VU Micromode Lower instructions    */
 /*****************************************/
 
-static void __vuRegsCall VU0regsMI_DIV(_VURegsNum *VUregsn) { _vuRegsDIV(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQRT(_VURegsNum *VUregsn) { _vuRegsSQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RSQRT(_VURegsNum *VUregsn) { _vuRegsRSQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IADD(_VURegsNum *VUregsn) { _vuRegsIADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IADDI(_VURegsNum *VUregsn) { _vuRegsIADDI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IADDIU(_VURegsNum *VUregsn) { _vuRegsIADDIU(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IAND(_VURegsNum *VUregsn) { _vuRegsIAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IOR(_VURegsNum *VUregsn) { _vuRegsIOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISUB(_VURegsNum *VUregsn) { _vuRegsISUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISUBIU(_VURegsNum *VUregsn) { _vuRegsISUBIU(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MOVE(_VURegsNum *VUregsn) { _vuRegsMOVE(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MFIR(_VURegsNum *VUregsn) { _vuRegsMFIR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MTIR(_VURegsNum *VUregsn) { _vuRegsMTIR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MR32(_VURegsNum *VUregsn) { _vuRegsMR32(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_LQ(_VURegsNum *VUregsn) { _vuRegsLQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_LQD(_VURegsNum *VUregsn) { _vuRegsLQD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_LQI(_VURegsNum *VUregsn) { _vuRegsLQI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQ(_VURegsNum *VUregsn) { _vuRegsSQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQD(_VURegsNum *VUregsn) { _vuRegsSQD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQI(_VURegsNum *VUregsn) { _vuRegsSQI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ILW(_VURegsNum *VUregsn) { _vuRegsILW(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISW(_VURegsNum *VUregsn) { _vuRegsISW(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ILWR(_VURegsNum *VUregsn) { _vuRegsILWR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISWR(_VURegsNum *VUregsn) { _vuRegsISWR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RINIT(_VURegsNum *VUregsn) { _vuRegsRINIT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RGET(_VURegsNum *VUregsn)  { _vuRegsRGET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RNEXT(_VURegsNum *VUregsn) { _vuRegsRNEXT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RXOR(_VURegsNum *VUregsn)  { _vuRegsRXOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_WAITQ(_VURegsNum *VUregsn) { _vuRegsWAITQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSAND(_VURegsNum *VUregsn) { _vuRegsFSAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSEQ(_VURegsNum *VUregsn)  { _vuRegsFSEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSOR(_VURegsNum *VUregsn)  { _vuRegsFSOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSSET(_VURegsNum *VUregsn) { _vuRegsFSSET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FMAND(_VURegsNum *VUregsn) { _vuRegsFMAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FMEQ(_VURegsNum *VUregsn)  { _vuRegsFMEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FMOR(_VURegsNum *VUregsn)  { _vuRegsFMOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCAND(_VURegsNum *VUregsn) { _vuRegsFCAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCEQ(_VURegsNum *VUregsn)  { _vuRegsFCEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCOR(_VURegsNum *VUregsn)  { _vuRegsFCOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCSET(_VURegsNum *VUregsn) { _vuRegsFCSET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCGET(_VURegsNum *VUregsn) { _vuRegsFCGET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBEQ(_VURegsNum *VUregsn) { _vuRegsIBEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBGEZ(_VURegsNum *VUregsn) { _vuRegsIBGEZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBGTZ(_VURegsNum *VUregsn) { _vuRegsIBGTZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBLTZ(_VURegsNum *VUregsn) { _vuRegsIBLTZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBLEZ(_VURegsNum *VUregsn) { _vuRegsIBLEZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBNE(_VURegsNum *VUregsn) { _vuRegsIBNE(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_B(_VURegsNum *VUregsn)   { _vuRegsB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_BAL(_VURegsNum *VUregsn) { _vuRegsBAL(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_JR(_VURegsNum *VUregsn)   { _vuRegsJR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_JALR(_VURegsNum *VUregsn) { _vuRegsJALR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MFP(_VURegsNum *VUregsn) { _vuRegsMFP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_WAITP(_VURegsNum *VUregsn) { _vuRegsWAITP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESADD(_VURegsNum *VUregsn)   { _vuRegsESADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERSADD(_VURegsNum *VUregsn)  { _vuRegsERSADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ELENG(_VURegsNum *VUregsn)   { _vuRegsELENG(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERLENG(_VURegsNum *VUregsn)  { _vuRegsERLENG(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EATANxy(_VURegsNum *VUregsn) { _vuRegsEATANxy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EATANxz(_VURegsNum *VUregsn) { _vuRegsEATANxz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESUM(_VURegsNum *VUregsn)    { _vuRegsESUM(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERCPR(_VURegsNum *VUregsn)   { _vuRegsERCPR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESQRT(_VURegsNum *VUregsn)   { _vuRegsESQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERSQRT(_VURegsNum *VUregsn)  { _vuRegsERSQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESIN(_VURegsNum *VUregsn)    { _vuRegsESIN(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EATAN(_VURegsNum *VUregsn)   { _vuRegsEATAN(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EEXP(_VURegsNum *VUregsn)    { _vuRegsEEXP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_XITOP(_VURegsNum *VUregsn)   { _vuRegsXITOP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_XGKICK(_VURegsNum *VUregsn)  { _vuRegsXGKICK(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_XTOP(_VURegsNum *VUregsn)    { _vuRegsXTOP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_DIV(_VURegsNum* VUregsn) { _vuRegsDIV(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SQRT(_VURegsNum* VUregsn) { _vuRegsSQRT(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_RSQRT(_VURegsNum* VUregsn) { _vuRegsRSQRT(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IADD(_VURegsNum* VUregsn) { _vuRegsIADD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IADDI(_VURegsNum* VUregsn) { _vuRegsIADDI(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IADDIU(_VURegsNum* VUregsn) { _vuRegsIADDIU(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IAND(_VURegsNum* VUregsn) { _vuRegsIAND(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IOR(_VURegsNum* VUregsn) { _vuRegsIOR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ISUB(_VURegsNum* VUregsn) { _vuRegsISUB(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ISUBIU(_VURegsNum* VUregsn) { _vuRegsISUBIU(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MOVE(_VURegsNum* VUregsn) { _vuRegsMOVE(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MFIR(_VURegsNum* VUregsn) { _vuRegsMFIR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MTIR(_VURegsNum* VUregsn) { _vuRegsMTIR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MR32(_VURegsNum* VUregsn) { _vuRegsMR32(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_LQ(_VURegsNum* VUregsn) { _vuRegsLQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_LQD(_VURegsNum* VUregsn) { _vuRegsLQD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_LQI(_VURegsNum* VUregsn) { _vuRegsLQI(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SQ(_VURegsNum* VUregsn) { _vuRegsSQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SQD(_VURegsNum* VUregsn) { _vuRegsSQD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_SQI(_VURegsNum* VUregsn) { _vuRegsSQI(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ILW(_VURegsNum* VUregsn) { _vuRegsILW(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ISW(_VURegsNum* VUregsn) { _vuRegsISW(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ILWR(_VURegsNum* VUregsn) { _vuRegsILWR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ISWR(_VURegsNum* VUregsn) { _vuRegsISWR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_RINIT(_VURegsNum* VUregsn) { _vuRegsRINIT(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_RGET(_VURegsNum* VUregsn) { _vuRegsRGET(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_RNEXT(_VURegsNum* VUregsn) { _vuRegsRNEXT(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_RXOR(_VURegsNum* VUregsn) { _vuRegsRXOR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_WAITQ(_VURegsNum* VUregsn) { _vuRegsWAITQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FSAND(_VURegsNum* VUregsn) { _vuRegsFSAND(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FSEQ(_VURegsNum* VUregsn) { _vuRegsFSEQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FSOR(_VURegsNum* VUregsn) { _vuRegsFSOR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FSSET(_VURegsNum* VUregsn) { _vuRegsFSSET(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FMAND(_VURegsNum* VUregsn) { _vuRegsFMAND(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FMEQ(_VURegsNum* VUregsn) { _vuRegsFMEQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FMOR(_VURegsNum* VUregsn) { _vuRegsFMOR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FCAND(_VURegsNum* VUregsn) { _vuRegsFCAND(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FCEQ(_VURegsNum* VUregsn) { _vuRegsFCEQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FCOR(_VURegsNum* VUregsn) { _vuRegsFCOR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FCSET(_VURegsNum* VUregsn) { _vuRegsFCSET(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_FCGET(_VURegsNum* VUregsn) { _vuRegsFCGET(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IBEQ(_VURegsNum* VUregsn) { _vuRegsIBEQ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IBGEZ(_VURegsNum* VUregsn) { _vuRegsIBGEZ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IBGTZ(_VURegsNum* VUregsn) { _vuRegsIBGTZ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IBLTZ(_VURegsNum* VUregsn) { _vuRegsIBLTZ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IBLEZ(_VURegsNum* VUregsn) { _vuRegsIBLEZ(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_IBNE(_VURegsNum* VUregsn) { _vuRegsIBNE(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_B(_VURegsNum* VUregsn) { _vuRegsB(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_BAL(_VURegsNum* VUregsn) { _vuRegsBAL(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_JR(_VURegsNum* VUregsn) { _vuRegsJR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_JALR(_VURegsNum* VUregsn) { _vuRegsJALR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_MFP(_VURegsNum* VUregsn) { _vuRegsMFP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_WAITP(_VURegsNum* VUregsn) { _vuRegsWAITP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ESADD(_VURegsNum* VUregsn) { _vuRegsESADD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ERSADD(_VURegsNum* VUregsn) { _vuRegsERSADD(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ELENG(_VURegsNum* VUregsn) { _vuRegsELENG(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ERLENG(_VURegsNum* VUregsn) { _vuRegsERLENG(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_EATANxy(_VURegsNum* VUregsn) { _vuRegsEATANxy(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_EATANxz(_VURegsNum* VUregsn) { _vuRegsEATANxz(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ESUM(_VURegsNum* VUregsn) { _vuRegsESUM(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ERCPR(_VURegsNum* VUregsn) { _vuRegsERCPR(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ESQRT(_VURegsNum* VUregsn) { _vuRegsESQRT(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ERSQRT(_VURegsNum* VUregsn) { _vuRegsERSQRT(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_ESIN(_VURegsNum* VUregsn) { _vuRegsESIN(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_EATAN(_VURegsNum* VUregsn) { _vuRegsEATAN(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_EEXP(_VURegsNum* VUregsn) { _vuRegsEEXP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_XITOP(_VURegsNum* VUregsn) { _vuRegsXITOP(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_XGKICK(_VURegsNum* VUregsn) { _vuRegsXGKICK(&VU0, VUregsn); }
+static void __vuRegsCall VU0regsMI_XTOP(_VURegsNum* VUregsn) { _vuRegsXTOP(&VU0, VUregsn); }
 
-void VU0unknown() {
+void VU0unknown()
+{
 	pxFailDev("Unknown VU micromode opcode called");
 	CPU_LOG("Unknown VU micromode opcode called");
 }
 
-static void __vuRegsCall VU0regsunknown(_VURegsNum *VUregsn) {
+static void __vuRegsCall VU0regsunknown(_VURegsNum* VUregsn)
+{
 	pxFailDev("Unknown VU micromode opcode called");
 	CPU_LOG("Unknown VU micromode opcode called");
 }
@@ -3851,182 +4206,184 @@ static void VU1MI_XTOP()    { _vuXTOP(&VU1); }
 /*   VU Micromode Upper instructions    */
 /****************************************/
 
-static void __vuRegsCall VU1regsMI_ABS(_VURegsNum *VUregsn)  { _vuRegsABS(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADD(_VURegsNum *VUregsn)  { _vuRegsADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDi(_VURegsNum *VUregsn) { _vuRegsADDi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDq(_VURegsNum *VUregsn) { _vuRegsADDq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDx(_VURegsNum *VUregsn) { _vuRegsADDx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDy(_VURegsNum *VUregsn) { _vuRegsADDy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDz(_VURegsNum *VUregsn) { _vuRegsADDz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDw(_VURegsNum *VUregsn) { _vuRegsADDw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDA(_VURegsNum *VUregsn) { _vuRegsADDA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAi(_VURegsNum *VUregsn) { _vuRegsADDAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAq(_VURegsNum *VUregsn) { _vuRegsADDAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAx(_VURegsNum *VUregsn) { _vuRegsADDAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAy(_VURegsNum *VUregsn) { _vuRegsADDAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAz(_VURegsNum *VUregsn) { _vuRegsADDAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAw(_VURegsNum *VUregsn) { _vuRegsADDAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUB(_VURegsNum *VUregsn)  { _vuRegsSUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBi(_VURegsNum *VUregsn) { _vuRegsSUBi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBq(_VURegsNum *VUregsn) { _vuRegsSUBq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBx(_VURegsNum *VUregsn) { _vuRegsSUBx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBy(_VURegsNum *VUregsn) { _vuRegsSUBy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBz(_VURegsNum *VUregsn) { _vuRegsSUBz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBw(_VURegsNum *VUregsn) { _vuRegsSUBw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBA(_VURegsNum *VUregsn)  { _vuRegsSUBA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAi(_VURegsNum *VUregsn) { _vuRegsSUBAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAq(_VURegsNum *VUregsn) { _vuRegsSUBAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAx(_VURegsNum *VUregsn) { _vuRegsSUBAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAy(_VURegsNum *VUregsn) { _vuRegsSUBAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAz(_VURegsNum *VUregsn) { _vuRegsSUBAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAw(_VURegsNum *VUregsn) { _vuRegsSUBAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MUL(_VURegsNum *VUregsn)  { _vuRegsMUL(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULi(_VURegsNum *VUregsn) { _vuRegsMULi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULq(_VURegsNum *VUregsn) { _vuRegsMULq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULx(_VURegsNum *VUregsn) { _vuRegsMULx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULy(_VURegsNum *VUregsn) { _vuRegsMULy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULz(_VURegsNum *VUregsn) { _vuRegsMULz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULw(_VURegsNum *VUregsn) { _vuRegsMULw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULA(_VURegsNum *VUregsn)  { _vuRegsMULA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAi(_VURegsNum *VUregsn) { _vuRegsMULAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAq(_VURegsNum *VUregsn) { _vuRegsMULAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAx(_VURegsNum *VUregsn) { _vuRegsMULAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAy(_VURegsNum *VUregsn) { _vuRegsMULAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAz(_VURegsNum *VUregsn) { _vuRegsMULAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAw(_VURegsNum *VUregsn) { _vuRegsMULAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADD(_VURegsNum *VUregsn)  { _vuRegsMADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDi(_VURegsNum *VUregsn) { _vuRegsMADDi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDq(_VURegsNum *VUregsn) { _vuRegsMADDq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDx(_VURegsNum *VUregsn) { _vuRegsMADDx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDy(_VURegsNum *VUregsn) { _vuRegsMADDy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDz(_VURegsNum *VUregsn) { _vuRegsMADDz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDw(_VURegsNum *VUregsn) { _vuRegsMADDw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDA(_VURegsNum *VUregsn)  { _vuRegsMADDA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAi(_VURegsNum *VUregsn) { _vuRegsMADDAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAq(_VURegsNum *VUregsn) { _vuRegsMADDAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAx(_VURegsNum *VUregsn) { _vuRegsMADDAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAy(_VURegsNum *VUregsn) { _vuRegsMADDAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAz(_VURegsNum *VUregsn) { _vuRegsMADDAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAw(_VURegsNum *VUregsn) { _vuRegsMADDAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUB(_VURegsNum *VUregsn)  { _vuRegsMSUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBi(_VURegsNum *VUregsn) { _vuRegsMSUBi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBq(_VURegsNum *VUregsn) { _vuRegsMSUBq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBx(_VURegsNum *VUregsn) { _vuRegsMSUBx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBy(_VURegsNum *VUregsn) { _vuRegsMSUBy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBz(_VURegsNum *VUregsn) { _vuRegsMSUBz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBw(_VURegsNum *VUregsn) { _vuRegsMSUBw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBA(_VURegsNum *VUregsn)  { _vuRegsMSUBA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAi(_VURegsNum *VUregsn) { _vuRegsMSUBAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAq(_VURegsNum *VUregsn) { _vuRegsMSUBAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAx(_VURegsNum *VUregsn) { _vuRegsMSUBAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAy(_VURegsNum *VUregsn) { _vuRegsMSUBAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAz(_VURegsNum *VUregsn) { _vuRegsMSUBAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAw(_VURegsNum *VUregsn) { _vuRegsMSUBAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAX(_VURegsNum *VUregsn)  { _vuRegsMAX(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXi(_VURegsNum *VUregsn) { _vuRegsMAXi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXx(_VURegsNum *VUregsn) { _vuRegsMAXx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXy(_VURegsNum *VUregsn) { _vuRegsMAXy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXz(_VURegsNum *VUregsn) { _vuRegsMAXz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXw(_VURegsNum *VUregsn) { _vuRegsMAXw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINI(_VURegsNum *VUregsn)  { _vuRegsMINI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIi(_VURegsNum *VUregsn) { _vuRegsMINIi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIx(_VURegsNum *VUregsn) { _vuRegsMINIx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIy(_VURegsNum *VUregsn) { _vuRegsMINIy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIz(_VURegsNum *VUregsn) { _vuRegsMINIz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIw(_VURegsNum *VUregsn) { _vuRegsMINIw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_OPMULA(_VURegsNum *VUregsn) { _vuRegsOPMULA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_OPMSUB(_VURegsNum *VUregsn) { _vuRegsOPMSUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_NOP(_VURegsNum *VUregsn) { _vuRegsNOP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI0(_VURegsNum *VUregsn)  { _vuRegsFTOI0(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI4(_VURegsNum *VUregsn)  { _vuRegsFTOI4(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI12(_VURegsNum *VUregsn) { _vuRegsFTOI12(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI15(_VURegsNum *VUregsn) { _vuRegsFTOI15(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF0(_VURegsNum *VUregsn)  { _vuRegsITOF0(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF4(_VURegsNum *VUregsn)  { _vuRegsITOF4(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF12(_VURegsNum *VUregsn) { _vuRegsITOF12(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF15(_VURegsNum *VUregsn) { _vuRegsITOF15(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_CLIP(_VURegsNum *VUregsn) { _vuRegsCLIP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ABS(_VURegsNum* VUregsn) { _vuRegsABS(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADD(_VURegsNum* VUregsn) { _vuRegsADD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDi(_VURegsNum* VUregsn) { _vuRegsADDi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDq(_VURegsNum* VUregsn) { _vuRegsADDq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDx(_VURegsNum* VUregsn) { _vuRegsADDx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDy(_VURegsNum* VUregsn) { _vuRegsADDy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDz(_VURegsNum* VUregsn) { _vuRegsADDz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDw(_VURegsNum* VUregsn) { _vuRegsADDw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDA(_VURegsNum* VUregsn) { _vuRegsADDA(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDAi(_VURegsNum* VUregsn) { _vuRegsADDAi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDAq(_VURegsNum* VUregsn) { _vuRegsADDAq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDAx(_VURegsNum* VUregsn) { _vuRegsADDAx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDAy(_VURegsNum* VUregsn) { _vuRegsADDAy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDAz(_VURegsNum* VUregsn) { _vuRegsADDAz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ADDAw(_VURegsNum* VUregsn) { _vuRegsADDAw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUB(_VURegsNum* VUregsn) { _vuRegsSUB(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBi(_VURegsNum* VUregsn) { _vuRegsSUBi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBq(_VURegsNum* VUregsn) { _vuRegsSUBq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBx(_VURegsNum* VUregsn) { _vuRegsSUBx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBy(_VURegsNum* VUregsn) { _vuRegsSUBy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBz(_VURegsNum* VUregsn) { _vuRegsSUBz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBw(_VURegsNum* VUregsn) { _vuRegsSUBw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBA(_VURegsNum* VUregsn) { _vuRegsSUBA(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBAi(_VURegsNum* VUregsn) { _vuRegsSUBAi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBAq(_VURegsNum* VUregsn) { _vuRegsSUBAq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBAx(_VURegsNum* VUregsn) { _vuRegsSUBAx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBAy(_VURegsNum* VUregsn) { _vuRegsSUBAy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBAz(_VURegsNum* VUregsn) { _vuRegsSUBAz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SUBAw(_VURegsNum* VUregsn) { _vuRegsSUBAw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MUL(_VURegsNum* VUregsn) { _vuRegsMUL(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULi(_VURegsNum* VUregsn) { _vuRegsMULi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULq(_VURegsNum* VUregsn) { _vuRegsMULq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULx(_VURegsNum* VUregsn) { _vuRegsMULx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULy(_VURegsNum* VUregsn) { _vuRegsMULy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULz(_VURegsNum* VUregsn) { _vuRegsMULz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULw(_VURegsNum* VUregsn) { _vuRegsMULw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULA(_VURegsNum* VUregsn) { _vuRegsMULA(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULAi(_VURegsNum* VUregsn) { _vuRegsMULAi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULAq(_VURegsNum* VUregsn) { _vuRegsMULAq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULAx(_VURegsNum* VUregsn) { _vuRegsMULAx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULAy(_VURegsNum* VUregsn) { _vuRegsMULAy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULAz(_VURegsNum* VUregsn) { _vuRegsMULAz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MULAw(_VURegsNum* VUregsn) { _vuRegsMULAw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADD(_VURegsNum* VUregsn) { _vuRegsMADD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDi(_VURegsNum* VUregsn) { _vuRegsMADDi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDq(_VURegsNum* VUregsn) { _vuRegsMADDq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDx(_VURegsNum* VUregsn) { _vuRegsMADDx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDy(_VURegsNum* VUregsn) { _vuRegsMADDy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDz(_VURegsNum* VUregsn) { _vuRegsMADDz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDw(_VURegsNum* VUregsn) { _vuRegsMADDw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDA(_VURegsNum* VUregsn) { _vuRegsMADDA(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDAi(_VURegsNum* VUregsn) { _vuRegsMADDAi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDAq(_VURegsNum* VUregsn) { _vuRegsMADDAq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDAx(_VURegsNum* VUregsn) { _vuRegsMADDAx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDAy(_VURegsNum* VUregsn) { _vuRegsMADDAy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDAz(_VURegsNum* VUregsn) { _vuRegsMADDAz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MADDAw(_VURegsNum* VUregsn) { _vuRegsMADDAw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUB(_VURegsNum* VUregsn) { _vuRegsMSUB(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBi(_VURegsNum* VUregsn) { _vuRegsMSUBi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBq(_VURegsNum* VUregsn) { _vuRegsMSUBq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBx(_VURegsNum* VUregsn) { _vuRegsMSUBx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBy(_VURegsNum* VUregsn) { _vuRegsMSUBy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBz(_VURegsNum* VUregsn) { _vuRegsMSUBz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBw(_VURegsNum* VUregsn) { _vuRegsMSUBw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBA(_VURegsNum* VUregsn) { _vuRegsMSUBA(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBAi(_VURegsNum* VUregsn) { _vuRegsMSUBAi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBAq(_VURegsNum* VUregsn) { _vuRegsMSUBAq(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBAx(_VURegsNum* VUregsn) { _vuRegsMSUBAx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBAy(_VURegsNum* VUregsn) { _vuRegsMSUBAy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBAz(_VURegsNum* VUregsn) { _vuRegsMSUBAz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MSUBAw(_VURegsNum* VUregsn) { _vuRegsMSUBAw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MAX(_VURegsNum* VUregsn) { _vuRegsMAX(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MAXi(_VURegsNum* VUregsn) { _vuRegsMAXi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MAXx(_VURegsNum* VUregsn) { _vuRegsMAXx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MAXy(_VURegsNum* VUregsn) { _vuRegsMAXy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MAXz(_VURegsNum* VUregsn) { _vuRegsMAXz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MAXw(_VURegsNum* VUregsn) { _vuRegsMAXw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MINI(_VURegsNum* VUregsn) { _vuRegsMINI(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MINIi(_VURegsNum* VUregsn) { _vuRegsMINIi(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MINIx(_VURegsNum* VUregsn) { _vuRegsMINIx(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MINIy(_VURegsNum* VUregsn) { _vuRegsMINIy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MINIz(_VURegsNum* VUregsn) { _vuRegsMINIz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MINIw(_VURegsNum* VUregsn) { _vuRegsMINIw(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_OPMULA(_VURegsNum* VUregsn) { _vuRegsOPMULA(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_OPMSUB(_VURegsNum* VUregsn) { _vuRegsOPMSUB(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_NOP(_VURegsNum* VUregsn) { _vuRegsNOP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FTOI0(_VURegsNum* VUregsn) { _vuRegsFTOI0(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FTOI4(_VURegsNum* VUregsn) { _vuRegsFTOI4(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FTOI12(_VURegsNum* VUregsn) { _vuRegsFTOI12(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FTOI15(_VURegsNum* VUregsn) { _vuRegsFTOI15(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ITOF0(_VURegsNum* VUregsn) { _vuRegsITOF0(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ITOF4(_VURegsNum* VUregsn) { _vuRegsITOF4(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ITOF12(_VURegsNum* VUregsn) { _vuRegsITOF12(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ITOF15(_VURegsNum* VUregsn) { _vuRegsITOF15(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_CLIP(_VURegsNum* VUregsn) { _vuRegsCLIP(&VU1, VUregsn); }
 
 /*****************************************/
 /*   VU Micromode Lower instructions    */
 /*****************************************/
 
-static void __vuRegsCall VU1regsMI_DIV(_VURegsNum *VUregsn) { _vuRegsDIV(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQRT(_VURegsNum *VUregsn) { _vuRegsSQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RSQRT(_VURegsNum *VUregsn) { _vuRegsRSQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IADD(_VURegsNum *VUregsn) { _vuRegsIADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IADDI(_VURegsNum *VUregsn) { _vuRegsIADDI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IADDIU(_VURegsNum *VUregsn) { _vuRegsIADDIU(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IAND(_VURegsNum *VUregsn) { _vuRegsIAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IOR(_VURegsNum *VUregsn) { _vuRegsIOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISUB(_VURegsNum *VUregsn) { _vuRegsISUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISUBIU(_VURegsNum *VUregsn) { _vuRegsISUBIU(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MOVE(_VURegsNum *VUregsn) { _vuRegsMOVE(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MFIR(_VURegsNum *VUregsn) { _vuRegsMFIR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MTIR(_VURegsNum *VUregsn) { _vuRegsMTIR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MR32(_VURegsNum *VUregsn) { _vuRegsMR32(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_LQ(_VURegsNum *VUregsn) { _vuRegsLQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_LQD(_VURegsNum *VUregsn) { _vuRegsLQD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_LQI(_VURegsNum *VUregsn) { _vuRegsLQI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQ(_VURegsNum *VUregsn) { _vuRegsSQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQD(_VURegsNum *VUregsn) { _vuRegsSQD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQI(_VURegsNum *VUregsn) { _vuRegsSQI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ILW(_VURegsNum *VUregsn) { _vuRegsILW(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISW(_VURegsNum *VUregsn) { _vuRegsISW(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ILWR(_VURegsNum *VUregsn) { _vuRegsILWR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISWR(_VURegsNum *VUregsn) { _vuRegsISWR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RINIT(_VURegsNum *VUregsn) { _vuRegsRINIT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RGET(_VURegsNum *VUregsn)  { _vuRegsRGET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RNEXT(_VURegsNum *VUregsn) { _vuRegsRNEXT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RXOR(_VURegsNum *VUregsn)  { _vuRegsRXOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_WAITQ(_VURegsNum *VUregsn) { _vuRegsWAITQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSAND(_VURegsNum *VUregsn) { _vuRegsFSAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSEQ(_VURegsNum *VUregsn)  { _vuRegsFSEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSOR(_VURegsNum *VUregsn)  { _vuRegsFSOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSSET(_VURegsNum *VUregsn) { _vuRegsFSSET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FMAND(_VURegsNum *VUregsn) { _vuRegsFMAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FMEQ(_VURegsNum *VUregsn)  { _vuRegsFMEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FMOR(_VURegsNum *VUregsn)  { _vuRegsFMOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCAND(_VURegsNum *VUregsn) { _vuRegsFCAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCEQ(_VURegsNum *VUregsn)  { _vuRegsFCEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCOR(_VURegsNum *VUregsn)  { _vuRegsFCOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCSET(_VURegsNum *VUregsn) { _vuRegsFCSET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCGET(_VURegsNum *VUregsn) { _vuRegsFCGET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBEQ(_VURegsNum *VUregsn) { _vuRegsIBEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBGEZ(_VURegsNum *VUregsn) { _vuRegsIBGEZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBGTZ(_VURegsNum *VUregsn) { _vuRegsIBGTZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBLTZ(_VURegsNum *VUregsn) { _vuRegsIBLTZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBLEZ(_VURegsNum *VUregsn) { _vuRegsIBLEZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBNE(_VURegsNum *VUregsn) { _vuRegsIBNE(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_B(_VURegsNum *VUregsn)   { _vuRegsB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_BAL(_VURegsNum *VUregsn) { _vuRegsBAL(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_JR(_VURegsNum *VUregsn)   { _vuRegsJR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_JALR(_VURegsNum *VUregsn) { _vuRegsJALR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MFP(_VURegsNum *VUregsn) { _vuRegsMFP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_WAITP(_VURegsNum *VUregsn) { _vuRegsWAITP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESADD(_VURegsNum *VUregsn)   { _vuRegsESADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERSADD(_VURegsNum *VUregsn)  { _vuRegsERSADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ELENG(_VURegsNum *VUregsn)   { _vuRegsELENG(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERLENG(_VURegsNum *VUregsn)  { _vuRegsERLENG(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EATANxy(_VURegsNum *VUregsn) { _vuRegsEATANxy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EATANxz(_VURegsNum *VUregsn) { _vuRegsEATANxz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESUM(_VURegsNum *VUregsn)    { _vuRegsESUM(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERCPR(_VURegsNum *VUregsn)   { _vuRegsERCPR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESQRT(_VURegsNum *VUregsn)   { _vuRegsESQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERSQRT(_VURegsNum *VUregsn)  { _vuRegsERSQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESIN(_VURegsNum *VUregsn)    { _vuRegsESIN(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EATAN(_VURegsNum *VUregsn)   { _vuRegsEATAN(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EEXP(_VURegsNum *VUregsn)    { _vuRegsEEXP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_XITOP(_VURegsNum *VUregsn)   { _vuRegsXITOP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_XGKICK(_VURegsNum *VUregsn)  { _vuRegsXGKICK(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_XTOP(_VURegsNum *VUregsn)    { _vuRegsXTOP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_DIV(_VURegsNum* VUregsn) { _vuRegsDIV(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SQRT(_VURegsNum* VUregsn) { _vuRegsSQRT(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_RSQRT(_VURegsNum* VUregsn) { _vuRegsRSQRT(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IADD(_VURegsNum* VUregsn) { _vuRegsIADD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IADDI(_VURegsNum* VUregsn) { _vuRegsIADDI(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IADDIU(_VURegsNum* VUregsn) { _vuRegsIADDIU(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IAND(_VURegsNum* VUregsn) { _vuRegsIAND(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IOR(_VURegsNum* VUregsn) { _vuRegsIOR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ISUB(_VURegsNum* VUregsn) { _vuRegsISUB(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ISUBIU(_VURegsNum* VUregsn) { _vuRegsISUBIU(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MOVE(_VURegsNum* VUregsn) { _vuRegsMOVE(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MFIR(_VURegsNum* VUregsn) { _vuRegsMFIR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MTIR(_VURegsNum* VUregsn) { _vuRegsMTIR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MR32(_VURegsNum* VUregsn) { _vuRegsMR32(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_LQ(_VURegsNum* VUregsn) { _vuRegsLQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_LQD(_VURegsNum* VUregsn) { _vuRegsLQD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_LQI(_VURegsNum* VUregsn) { _vuRegsLQI(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SQ(_VURegsNum* VUregsn) { _vuRegsSQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SQD(_VURegsNum* VUregsn) { _vuRegsSQD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_SQI(_VURegsNum* VUregsn) { _vuRegsSQI(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ILW(_VURegsNum* VUregsn) { _vuRegsILW(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ISW(_VURegsNum* VUregsn) { _vuRegsISW(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ILWR(_VURegsNum* VUregsn) { _vuRegsILWR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ISWR(_VURegsNum* VUregsn) { _vuRegsISWR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_RINIT(_VURegsNum* VUregsn) { _vuRegsRINIT(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_RGET(_VURegsNum* VUregsn) { _vuRegsRGET(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_RNEXT(_VURegsNum* VUregsn) { _vuRegsRNEXT(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_RXOR(_VURegsNum* VUregsn) { _vuRegsRXOR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_WAITQ(_VURegsNum* VUregsn) { _vuRegsWAITQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FSAND(_VURegsNum* VUregsn) { _vuRegsFSAND(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FSEQ(_VURegsNum* VUregsn) { _vuRegsFSEQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FSOR(_VURegsNum* VUregsn) { _vuRegsFSOR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FSSET(_VURegsNum* VUregsn) { _vuRegsFSSET(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FMAND(_VURegsNum* VUregsn) { _vuRegsFMAND(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FMEQ(_VURegsNum* VUregsn) { _vuRegsFMEQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FMOR(_VURegsNum* VUregsn) { _vuRegsFMOR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FCAND(_VURegsNum* VUregsn) { _vuRegsFCAND(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FCEQ(_VURegsNum* VUregsn) { _vuRegsFCEQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FCOR(_VURegsNum* VUregsn) { _vuRegsFCOR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FCSET(_VURegsNum* VUregsn) { _vuRegsFCSET(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_FCGET(_VURegsNum* VUregsn) { _vuRegsFCGET(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IBEQ(_VURegsNum* VUregsn) { _vuRegsIBEQ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IBGEZ(_VURegsNum* VUregsn) { _vuRegsIBGEZ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IBGTZ(_VURegsNum* VUregsn) { _vuRegsIBGTZ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IBLTZ(_VURegsNum* VUregsn) { _vuRegsIBLTZ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IBLEZ(_VURegsNum* VUregsn) { _vuRegsIBLEZ(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_IBNE(_VURegsNum* VUregsn) { _vuRegsIBNE(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_B(_VURegsNum* VUregsn) { _vuRegsB(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_BAL(_VURegsNum* VUregsn) { _vuRegsBAL(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_JR(_VURegsNum* VUregsn) { _vuRegsJR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_JALR(_VURegsNum* VUregsn) { _vuRegsJALR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_MFP(_VURegsNum* VUregsn) { _vuRegsMFP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_WAITP(_VURegsNum* VUregsn) { _vuRegsWAITP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ESADD(_VURegsNum* VUregsn) { _vuRegsESADD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ERSADD(_VURegsNum* VUregsn) { _vuRegsERSADD(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ELENG(_VURegsNum* VUregsn) { _vuRegsELENG(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ERLENG(_VURegsNum* VUregsn) { _vuRegsERLENG(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_EATANxy(_VURegsNum* VUregsn) { _vuRegsEATANxy(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_EATANxz(_VURegsNum* VUregsn) { _vuRegsEATANxz(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ESUM(_VURegsNum* VUregsn) { _vuRegsESUM(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ERCPR(_VURegsNum* VUregsn) { _vuRegsERCPR(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ESQRT(_VURegsNum* VUregsn) { _vuRegsESQRT(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ERSQRT(_VURegsNum* VUregsn) { _vuRegsERSQRT(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_ESIN(_VURegsNum* VUregsn) { _vuRegsESIN(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_EATAN(_VURegsNum* VUregsn) { _vuRegsEATAN(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_EEXP(_VURegsNum* VUregsn) { _vuRegsEEXP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_XITOP(_VURegsNum* VUregsn) { _vuRegsXITOP(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_XGKICK(_VURegsNum* VUregsn) { _vuRegsXGKICK(&VU1, VUregsn); }
+static void __vuRegsCall VU1regsMI_XTOP(_VURegsNum* VUregsn) { _vuRegsXTOP(&VU1, VUregsn); }
 
-static void VU1unknown() {
+static void VU1unknown()
+{
 	pxFailDev("Unknown VU micromode opcode called");
 	CPU_LOG("Unknown VU micromode opcode called");
 }
 
-static void __vuRegsCall VU1regsunknown(_VURegsNum *VUregsn) {
+static void __vuRegsCall VU1regsunknown(_VURegsNum* VUregsn)
+{
 	pxFailDev("Unknown VU micromode opcode called");
 	CPU_LOG("Unknown VU micromode opcode called");
 }

--- a/pcsx2/VUops.h
+++ b/pcsx2/VUops.h
@@ -53,7 +53,7 @@ extern __aligned16 const Fnptr_Void VU1_LOWER_OPCODE[128];
 extern __aligned16 const Fnptr_Void VU1_UPPER_OPCODE[64];
 extern __aligned16 const Fnptr_VuRegsN VU1regs_LOWER_OPCODE[128];
 extern __aligned16 const Fnptr_VuRegsN VU1regs_UPPER_OPCODE[64];
-
+extern void _vuClearFMAC(VURegs * VU);
 extern void _vuTestPipes(VURegs * VU);
 extern void _vuTestUpperStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuTestLowerStalls(VURegs * VU, _VURegsNum *VUregsn);

--- a/pcsx2/VUops.h
+++ b/pcsx2/VUops.h
@@ -17,9 +17,9 @@
 #include "VU.h"
 #include "VUflags.h"
 
-#define float_to_int4(x)	(s32)((float)x * (1.0f / 0.0625f))
-#define float_to_int12(x)	(s32)((float)x * (1.0f / 0.000244140625f))
-#define float_to_int15(x)	(s32)((float)x * (1.0f / 0.000030517578125))
+#define float_to_int4(x)	((float)x * (1.0f / 0.0625f))
+#define float_to_int12(x)	((float)x * (1.0f / 0.000244140625f))
+#define float_to_int15(x)	((float)x * (1.0f / 0.000030517578125))
 
 #define int4_to_float(x)	(float)((float)x * 0.0625f)
 #define int12_to_float(x)	(float)((float)x * 0.000244140625f)

--- a/pcsx2/VUops.h
+++ b/pcsx2/VUops.h
@@ -59,3 +59,4 @@ extern void _vuTestUpperStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuTestLowerStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuAddUpperStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuAddLowerStalls(VURegs * VU, _VURegsNum *VUregsn);
+extern void _vuXGKICKTransfer(VURegs* VU, u32 cycles, bool flush);

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -157,7 +157,6 @@ __fi void vif0VUFinish()
 	if(vif0.waitforvu)
 	{
 		vif0.waitforvu = false;
-		ExecuteVU(0);
 		//Make sure VIF0 isnt already scheduled to spin.
 		if(!(cpuRegs.interrupt & 0x1) && vif0ch.chcr.STR && !vif0Regs.stat.test(VIF0_STAT_VSS | VIF0_STAT_VIS | VIF0_STAT_VFS))
 			vif0Interrupt();
@@ -179,6 +178,10 @@ __fi void vif0Interrupt()
 	{
 		CPU_INT(VIF_VU0_FINISH, 16);
 		return;
+	}
+	if (vif0Regs.stat.VGW)
+	{
+		DevCon.Warning("VIF0 waiting for path");
 	}
 
 	if (vif0.irq && vif0.vifstalled.enabled && vif0.vifstalled.value == VIF_IRQ_STALL)

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -252,27 +252,13 @@ __fi void vif1VUFinish()
 	vif1Regs.stat.VEW = false;
 	VIF_LOG("VU1 finished");
 
-	if( gifRegs.stat.APATH == 1 )
-	{
-		VIF_LOG("Clear APATH1");
-		gifRegs.stat.APATH = 0;
-		gifRegs.stat.OPH = 0;
-		vif1Regs.stat.VGW = false; //Let vif continue if it's stuck on a flush
-
-		if(!vif1.waitforvu) 
-		{
-			if(gifUnit.checkPaths(0,1,1)) gifUnit.Execute(false, true);
-		}
-
-	}
 	if(vif1.waitforvu)
 	{
 		vif1.waitforvu = false;
-		ExecuteVU(1);
 		//Check if VIF is already scheduled to interrupt, if it's waiting, kick it :P
-		if((cpuRegs.interrupt & ((1<<DMAC_VIF1) | (1 << DMAC_MFIFO_VIF))) == 0 && vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
+		if ((cpuRegs.interrupt & ((1 << DMAC_VIF1) | (1 << DMAC_MFIFO_VIF))) == 0 && vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
 		{
-			if(dmacRegs.ctrl.MFD == MFD_VIF1)
+			if (dmacRegs.ctrl.MFD == MFD_VIF1)
 				vifMFIFOInterrupt();
 			else
 				vif1Interrupt();
@@ -330,6 +316,10 @@ __fi void vif1Interrupt()
 		CPU_INT(VIF_VU1_FINISH, 16);
 		return;
 	}
+	
+	if (vif1Regs.stat.VGW)
+		return;
+		
 	if (!vif1ch.chcr.STR) Console.WriteLn("Vif1 running when CHCR == %x", vif1ch.chcr._u32);
 
 	if (vif1.irq && vif1.vifstalled.enabled && vif1.vifstalled.value == VIF_IRQ_STALL)

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -230,8 +230,11 @@ vifOp(vifCode_Flush)
 			vif1.vifstalled.value = VIF_TIMING_BREAK;
 			return 0;
 		}
-		else
-			vif1.cmd = 0;
+
+		if (vif1.waitforvu)
+			return 0;
+		
+		vif1.cmd = 0;
 		vif1.pass = 0;
 	}
 	pass3 { VifCodeLog("Flush"); }
@@ -258,6 +261,10 @@ vifOp(vifCode_FlushA)
 			vif1.vifstalled.value = VIF_TIMING_BREAK;
 			return 0;
 		}
+
+		if (vif1.waitforvu)
+			return 0;
+
 		vif1.cmd = 0;
 		vif1.pass = 0;
 	}

--- a/pcsx2/Vif_Dma.h
+++ b/pcsx2/Vif_Dma.h
@@ -94,15 +94,13 @@ struct vifStruct {
 
 	bool queued_program;
 	u32 queued_pc;
-
-	
+	bool queued_gif_wait;
 };
 
 extern __aligned16 vifStruct  vif0, vif1;
 
 _vifT extern u32 vifRead32(u32 mem);
 _vifT extern bool vifWrite32(u32 mem, u32 value);
-void ExecuteVU(int idx);
 extern void vif0Interrupt();
 extern void vif0VUFinish();
 extern void vif0Reset();

--- a/pcsx2/Vif_Transfer.cpp
+++ b/pcsx2/Vif_Transfer.cpp
@@ -59,6 +59,12 @@ _vifT void vifTransferLoop(u32* &data) {
 		ret = vifCmdHandler[idx][vifX.cmd & 0x7f](vifX.pass, data);
 		data   += ret;
 		pSize  -= ret;
+		if (vifX.vifstalled.enabled)
+		{
+			int current_STR = idx ? vif1ch.chcr.STR : vif0ch.chcr.STR;
+			if (!current_STR)
+				DevCon.Warning("Warning! VIF%d stalled during FIFO transfer!", idx);
+		}
 	}
 }
 

--- a/pcsx2/Vif_Transfer.cpp
+++ b/pcsx2/Vif_Transfer.cpp
@@ -32,7 +32,7 @@ _vifT void vifTransferLoop(u32* &data) {
 
 	vifXRegs.stat.VPS |= VPS_TRANSFERRING;
 	vifXRegs.stat.ER1  = false;
-	if(!idx)VIF_LOG("Starting VIF0 loop, pSize = %x, stalled = %x", pSize, vifX.vifstalled.enabled );
+	//VIF_LOG("Starting VIF%d loop, pSize = %x, stalled = %x", idx, pSize, vifX.vifstalled.enabled );
 	while (pSize > 0 && !vifX.vifstalled.enabled) {
 
 		if(!vifX.cmd) { // Get new VifCode

--- a/pcsx2/Vif_Unpack.cpp
+++ b/pcsx2/Vif_Unpack.cpp
@@ -205,6 +205,16 @@ _vifT void vifUnpackSetup(const u32 *data) {
 	if (vifNum == 0) vifNum = 256;
 	vifXRegs.num =  vifNum;
 
+	// This is for use when XGKick is synced as VIF can overwrite XG Kick data as it's transferring out
+	// Test with Aggressive Inline Skating, or K-1 Premium 2005 Dynamite!
+	// VU currently flushes XGKICK on VU1 end so no need for this, yet
+	/*if (idx == 1 && VU1.xgkickenable && !(VU0.VI[REG_TPC].UL & 0x100))
+	{
+		// Catch up first, then the unpack cycles
+		_vuXGKICKTransfer(&VU1, cpuRegs.cycle - VU1.xgkicklastcycle, false);
+		_vuXGKICKTransfer(&VU1, vifNum * 2, false);
+	}*/
+
 	// Traditional-style way of calculating the gsize, based on VN/VL parameters.
 	// Useful when VN/VL are known template params, but currently they are not so we use
 	// the LUT instead (for now).

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -580,11 +580,11 @@ void recLQC2()
 {
 	iFlushCall(FLUSH_EVERYTHING);
 
-	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x1);
-	xForwardJZ32 skipvuidle;
 	xMOV(eax, ptr32[&cpuRegs.cycle]);
 	xADD(eax, scaleblockcycles_clear());
 	xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
+	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x1);
+	xForwardJZ32 skipvuidle;
 	xSUB(eax, ptr32[&VU0.cycle]);
 	xSUB(eax, ptr32[&VU0.nextBlockCycles]);
 	xCMP(eax, 8);
@@ -625,11 +625,11 @@ void recSQC2()
 {
 	iFlushCall(FLUSH_EVERYTHING);
 
-	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x1);
-	xForwardJZ32 skipvuidle;
 	xMOV(eax, ptr32[&cpuRegs.cycle]);
 	xADD(eax, scaleblockcycles_clear());
 	xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
+	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x1);
+	xForwardJZ32 skipvuidle;
 	xSUB(eax, ptr32[&VU0.cycle]);
 	xSUB(eax, ptr32[&VU0.nextBlockCycles]);
 	xCMP(eax, 8);

--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -49,8 +49,9 @@ union __aligned16 microRegInfo
 				u8 viBackUp;       // VI reg number that was written to on branch-delay slot
 				u8 blockType;      // 0 = Normal; 1,2 = Compile one instruction (E-bit/Branch Ending)
 				u8 r;
+				u8 mbitinblock;
 			};
-			u32 quick32[2];
+			u32 quick32[3];
 		};
 
 		u8 vi15v; // 'vi15' constant is valid

--- a/pcsx2/x86/newVif_Unpack.cpp
+++ b/pcsx2/x86/newVif_Unpack.cpp
@@ -113,15 +113,6 @@ _vifT int nVifUnpack(const u8* data)
 	const bool isFill = (vifRegs.cycle.cl < wl);
 	s32        size   = ret << 2;
 
-	// This is for use when XGKick is synced as VIF can overwrite XG Kick data as it's transferring out
-	// Test with Aggressive Inline Skating, or K-1 Premium 2005 Dynamite!
-	if (idx == 1 && VU1.xgkickenable && !(VU0.VI[REG_TPC].UL & 0x100))
-	{
-		// Catch up first, then the unpack cycles
-		_vuXGKICKTransfer(&VU1, cpuRegs.cycle - VU1.xgkicklastcycle, false);
-		_vuXGKICKTransfer(&VU1, ret/2, false);
-	}
-
 	if (ret == vif.tag.size) // Full Transfer
 	{
 		if (v.bSize) // Last transfer was partial

--- a/pcsx2/x86/newVif_Unpack.cpp
+++ b/pcsx2/x86/newVif_Unpack.cpp
@@ -113,6 +113,15 @@ _vifT int nVifUnpack(const u8* data)
 	const bool isFill = (vifRegs.cycle.cl < wl);
 	s32        size   = ret << 2;
 
+	// This is for use when XGKick is synced as VIF can overwrite XG Kick data as it's transferring out
+	// Test with Aggressive Inline Skating, or K-1 Premium 2005 Dynamite!
+	if (idx == 1 && VU1.xgkickenable && !(VU0.VI[REG_TPC].UL & 0x100))
+	{
+		// Catch up first, then the unpack cycles
+		_vuXGKICKTransfer(&VU1, cpuRegs.cycle - VU1.xgkicklastcycle, false);
+		_vuXGKICKTransfer(&VU1, ret/2, false);
+	}
+
 	if (ret == vif.tag.size) // Full Transfer
 	{
 		if (v.bSize) // Last transfer was partial


### PR DESCRIPTION
### Description of Changes
Overhauls the VU interpreters to be as accurate as microVU, and then some.  Still some clean up work to do (could make the new XGKick stuff one function, for example), but should be head and shoulders above master and be twice as fast too.

### Rationale behind Changes
Our interpreters were old, unfinished, broken and slow, this PR aims to resolve all of that.

### Suggested Testing Steps
Just test any games, compare them to microVU in terms of compatibility, make sure they are as good or better.

Games fixes by this (only in the interpreters currently)
WRC World Championship no longer needs patches
Tennis Court Smash no longer has SPS

Fixes #1851