### PR TITLE
common: fix locale oversight in IniInterface

### DIFF
--- a/common/IniInterface.cpp
+++ b/common/IniInterface.cpp
@@ -194,12 +194,12 @@ int IniLoader::EntryBitfield(const wxString& var, int value, const int defvalue)
 
 void IniLoader::Entry(const wxString& var, double& value, const double defvalue)
 {
-	auto readval = wxString::FromDouble(value);
+	auto readval = wxString::FromCDouble(value);
 
 	if (m_Config)
 		m_Config->Read(var, &readval);
 
-	if (!readval.ToDouble(&value))
+	if (!readval.ToCDouble(&value))
 		value = 0.0;
 }
 
@@ -369,7 +369,7 @@ void IniSaver::Entry(const wxString& var, double& value, const double defvalue)
 	if (!m_Config)
 		return;
 
-	m_Config->Write(var, wxString::FromDouble(value));
+	m_Config->Write(var, wxString::FromCDouble(value));
 }
 
 void IniSaver::Entry(const wxString& var, wxPoint& value, const wxPoint defvalue)


### PR DESCRIPTION
### Description of Changes
fix a bug introduced by https://github.com/PCSX2/pcsx2/commit/38f1a9a762cea8e936351ae9e96384271d8abd90

### Rationale behind Changes
I made an oversight and saved the ini in locale specific format which broke when the system locale didn't match PCSX2 locale

### Suggested Testing Steps
make sure you can change zoom/NTSC and PAL base framerate adjust and not have any issues.

fixes #4713
