### PR TITLE
Replace scalar variable names with percent variable names

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -293,7 +293,7 @@ struct Pcsx2Config
 		int FramesToDraw{ 2 }; // number of consecutive frames (fields) to render
 		int FramesToSkip{ 2 }; // number of consecutive frames (fields) to skip
 
-		double LimitScalar{ 1.0 };
+		double LimitPercent{ 1.0 };
 		double FramerateNTSC{ 59.94 };
 		double FrameratePAL{ 50.00 };
 
@@ -311,7 +311,7 @@ struct Pcsx2Config
 				OpEqu( FrameLimitEnable )		&&
 				OpEqu( VsyncEnable )			&&
 
-				OpEqu( LimitScalar )			&&
+				OpEqu( LimitPercent )			&&
 				OpEqu( FramerateNTSC )			&&
 				OpEqu( FrameratePAL )			&&
 

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -339,7 +339,7 @@ u32 UpdateVSyncRate()
 	const double vertical_frequency = GetVerticalFrequency();
 
 	const double frames_per_second = vertical_frequency / 2.0;
-	const double frame_limit = frames_per_second * EmuConfig.GS.LimitScalar;
+	const double frame_limit = frames_per_second * EmuConfig.GS.LimitPercent;
 
 	const double tick_rate = GetTickFrequency() / 2.0;
 	const s64 ticks = static_cast<s64>(tick_rate / std::max(frame_limit, 1.0));

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -51,13 +51,13 @@ void gsUpdateFrequency(Pcsx2Config& config)
 	switch (g_LimiterMode)
 	{
 	case LimiterModeType::Limit_Nominal:
-		config.GS.LimitScalar = g_Conf->Framerate.NominalScalar / 100.0;
+		config.GS.LimitPercent = g_Conf->Framerate.NominalPercent / 100.0;
 		break;
 	case LimiterModeType::Limit_Slomo:
-		config.GS.LimitScalar = g_Conf->Framerate.SlomoScalar / 100.0;
+		config.GS.LimitPercent = g_Conf->Framerate.SlomoPercent / 100.0;
 		break;
 	case LimiterModeType::Limit_Turbo:
-		config.GS.LimitScalar = g_Conf->Framerate.TurboScalar / 100.0;
+		config.GS.LimitPercent = g_Conf->Framerate.TurboPercent / 100.0;
 		break;
 	default:
 		pxAssert("Unknown framelimiter mode!");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -228,7 +228,7 @@ void Pcsx2Config::GSOptions::LoadSave( IniInterface& ini )
 	IniEntry( FrameSkipEnable );
 	ini.EnumEntry( L"VsyncEnable", VsyncEnable, NULL, VsyncEnable );
 
-	IniEntry( LimitScalar );
+	IniEntry( LimitPercent );
 	IniEntry( FramerateNTSC );
 	IniEntry( FrameratePAL );
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -865,18 +865,18 @@ void AppConfig::FramerateOptions::SanityCheck()
 {
 	// Ensure Conformation of various options...
 
-	NominalScalar = std::clamp(NominalScalar, 5.0, 1000.0);
-	TurboScalar = std::clamp(TurboScalar, 5.0, 1000.0);
-	SlomoScalar = std::clamp(SlomoScalar, 5.0, 1000.0);
+	NominalPercent = std::clamp(NominalPercent, 5.0, 1000.0);
+	TurboPercent = std::clamp(TurboPercent, 5.0, 1000.0);
+	SlomoPercent = std::clamp(SlomoPercent, 5.0, 1000.0);
 }
 
 void AppConfig::FramerateOptions::LoadSave( IniInterface& ini )
 {
 	ScopedIniGroup path( ini, L"Framerate" );
 
-	IniEntry( NominalScalar );
-	IniEntry( TurboScalar );
-	IniEntry( SlomoScalar );
+	IniEntry( NominalPercent );
+	IniEntry( TurboPercent );
+	IniEntry( SlomoPercent );
 
 	IniEntry( SkipOnLimit );
 	IniEntry( SkipOnTurbo );
@@ -995,8 +995,8 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 	//Force some settings as a (current) base for all presets.
 
 	Framerate			= default_AppConfig.Framerate;
-	Framerate.SlomoScalar = original_Framerate.SlomoScalar;
-	Framerate.TurboScalar = original_Framerate.TurboScalar;
+	Framerate.SlomoPercent = original_Framerate.SlomoPercent;
+	Framerate.TurboPercent = original_Framerate.TurboPercent;
 
 	EnableGameFixes		= false;
 
@@ -1237,7 +1237,7 @@ static void LoadVmSettings()
 	std::unique_ptr<wxFileConfig> vmini( OpenFileConfig( GetVmSettingsFilename() ) );
 	IniLoader vmloader( vmini.get() );
 	g_Conf->EmuOptions.LoadSave( vmloader );
-	g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
+	g_Conf->EmuOptions.GS.LimitPercent = g_Conf->Framerate.NominalPercent;
 
 	if (g_Conf->EnablePresets){
 		g_Conf->IsOkApplyPreset(g_Conf->PresetIndex, true);

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -239,9 +239,9 @@ public:
 		bool SkipOnLimit{ false };
 		bool SkipOnTurbo{ false };
 
-		double NominalScalar{ 100.0 };
-		double TurboScalar{ 200.0 };
-		double SlomoScalar{ 50.0 };
+		double NominalPercent{ 100.0 };
+		double TurboPercent{ 200.0 };
+		double SlomoPercent{ 50.0 };
 
 		void LoadSave( IniInterface& conf );
 		void SanityCheck();

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -115,8 +115,8 @@ void Panels::FramelimiterPanel::ApplyConfigToGui( AppConfig& configToApply, int 
 	
 		m_check_LimiterDisable->SetValue(!gsconf.FrameLimitEnable);
 
-		m_spin_TurboPct->SetValue(appfps.TurboScalar);
-		m_spin_SlomoPct->SetValue(appfps.SlomoScalar);
+		m_spin_TurboPct->SetValue(appfps.TurboPercent);
+		m_spin_SlomoPct->SetValue(appfps.SlomoPercent);
 
 		m_spin_TurboPct->Enable(true);
 		m_spin_SlomoPct->Enable(true);
@@ -125,7 +125,7 @@ void Panels::FramelimiterPanel::ApplyConfigToGui( AppConfig& configToApply, int 
 	m_text_BaseNtsc->ChangeValue(wxString::FromDouble(gsconf.FramerateNTSC, 2));
 	m_text_BasePal->ChangeValue(wxString::FromDouble(gsconf.FrameratePAL, 2));
 
-	m_spin_NominalPct->SetValue(appfps.NominalScalar);
+	m_spin_NominalPct->SetValue(appfps.NominalPercent);
 	m_spin_NominalPct->Enable(!configToApply.EnablePresets);
 
 	m_text_BaseNtsc->Enable(!configToApply.EnablePresets);
@@ -139,9 +139,9 @@ void Panels::FramelimiterPanel::Apply()
 
 	gsconf.FrameLimitEnable	= !m_check_LimiterDisable->GetValue();
 
-	appfps.NominalScalar = m_spin_NominalPct->GetValue();
-	appfps.TurboScalar = m_spin_TurboPct->GetValue();
-	appfps.SlomoScalar = m_spin_SlomoPct->GetValue();
+	appfps.NominalPercent = m_spin_NominalPct->GetValue();
+	appfps.TurboPercent = m_spin_TurboPct->GetValue();
+	appfps.SlomoPercent = m_spin_SlomoPct->GetValue();
 
 	wxString ntsc_framerate_string = m_text_BaseNtsc->GetValue();
 	wxString pal_framerate_string = m_text_BasePal->GetValue();


### PR DESCRIPTION
Storage format for these variables was changed, so old configs would cause framelimiter lockup with incredibly low values.

### Description of Changes
Changes *Scalar variables to *Percent

### Rationale behind Changes
Prevents framelimiter lockup when importing old settings.

### Suggested Testing Steps
Validate framelimiter runs at 100% normally, and the configured slowmo and turbo speeds.
