### PR TITLE
Savestates: Small refactoring

### DIFF
--- a/pcsx2/Elfheader.cpp
+++ b/pcsx2/Elfheader.cpp
@@ -25,36 +25,40 @@ u32 ElfCRC;
 u32 ElfEntry;
 std::pair<u32,u32> ElfTextRange;
 wxString LastELF;
+bool isPSXElf;
 
 // All of ElfObjects functions.
-ElfObject::ElfObject(const wxString& srcfile, IsoFile& isofile)
+ElfObject::ElfObject(const wxString& srcfile, IsoFile& isofile, bool isPSXElf)
 	: data( wxULongLong(isofile.getLength()).GetLo(), L"ELF headers" )
 	, proghead( NULL )
 	, secthead( NULL )
 	, filename( srcfile )
 	, header( *(ELF_HEADER*)data.GetPtr() )
 {
-	isCdvd = true;
 	checkElfSize(data.GetSizeInBytes());
 	readIso(isofile);
-	initElfHeaders();
+	initElfHeaders(isPSXElf);
 }
 
-ElfObject::ElfObject( const wxString& srcfile, uint hdrsize )
+ElfObject::ElfObject( const wxString& srcfile, uint hdrsize, bool isPSXElf )
 	: data( wxULongLong(hdrsize).GetLo(), L"ELF headers" )
 	, proghead( NULL )
 	, secthead( NULL )
 	, filename( srcfile )
 	, header( *(ELF_HEADER*)data.GetPtr() )
 {
-	isCdvd = false;
 	checkElfSize(data.GetSizeInBytes());
 	readFile();
-	initElfHeaders();
+	initElfHeaders(isPSXElf);
 }
 
-void ElfObject::initElfHeaders()
+void ElfObject::initElfHeaders(bool isPSXElf)
 {
+	if (isPSXElf)
+	{
+		return;
+	}
+
 	DevCon.WriteLn( L"Initializing Elf: %d bytes", data.GetSizeInBytes());
 
 	if ( header.e_phnum > 0 )

--- a/pcsx2/Elfheader.h
+++ b/pcsx2/Elfheader.h
@@ -19,12 +19,6 @@
 #include "CDVD/IsoFS/IsoFSCDVD.h"
 #include "CDVD/IsoFS/IsoFS.h"
 
-#if 0
-//2002-09-20 (Florin)
-extern char args[256];		//to be filled by GUI
-extern unsigned int args_ptr;
-#endif
-
 struct ELF_HEADER {
 	u8	e_ident[16];	//0x7f,"ELF"  (ELF file identifier)
 	u16	e_type;			//ELF type: 0=NONE, 1=REL, 2=EXEC, 3=SHARED, 4=CORE
@@ -131,21 +125,20 @@ class ElfObject
 		ELF_SHR* secthead;
 		wxString filename;
 
-		void initElfHeaders();
+		void initElfHeaders(bool isPSXElf);
 		void readIso(IsoFile& file);
 		void readFile();
 		void checkElfSize(s64 elfsize);
 
 	public:
-		bool isCdvd;
 		ELF_HEADER& header;
 
 		// Destructor!
 		// C++ does all the cleanup automagically for us.
 		virtual ~ElfObject() = default;
 
-		ElfObject(const wxString& srcfile, IsoFile& isofile);
-		ElfObject( const wxString& srcfile, uint hdrsize );
+		ElfObject(const wxString& srcfile, IsoFile& isofile, bool isPSXElf);
+		ElfObject( const wxString& srcfile, uint hdrsize, bool isPSXElf );
 
 		void loadProgramHeaders();
 		void loadSectionHeaders();
@@ -168,5 +161,6 @@ extern u32 ElfCRC;
 extern u32 ElfEntry;
 extern std::pair<u32,u32> ElfTextRange;
 extern wxString LastELF;
+extern bool isPSXElf;
 
 #endif

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -715,7 +715,7 @@ void __fastcall eeloadHook()
 		}
 	}
 
-	if (!g_GameStarted && (disctype == 2 || disctype == 1) && fromUTF8(elfname) == discelf)
+	if (!g_GameStarted && ((disctype == 2 && elfname == discelf.ToStdString()) || disctype == 1))
 		g_GameLoading = true;
 }
 

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -77,16 +77,56 @@ static void PostLoadPrep()
 // --------------------------------------------------------------------------------------
 //  SaveStateBase  (implementations)
 // --------------------------------------------------------------------------------------
-wxString SaveStateBase::GetFilename( int slot )
+wxString SaveStateBase::GetSavestateFolder( int slot, bool isSavingOrLoading )
 {
-	wxString serialName( DiscSerial );
-	if (serialName.IsEmpty()) serialName = L"BIOS";
+	wxString CRCvalue = wxString::Format(wxT("%08X"), ElfCRC);
+	wxString serialName(DiscSerial);
 
-	return (EmuFolders::Savestates +
-		pxsFmt( L"%s (%08X).%02d.p2s", WX_STR(serialName), ElfCRC, slot )).GetFullPath();
+	if (g_GameStarted || g_GameLoading)
+	{
+		if (DiscSerial.IsEmpty())
+		{
+			std::string ElfString = LastELF.ToStdString();
+			std::string ElfString_delimiter = "/";
 
-	//return (g_Conf->Folders.Savestates +
-	//	pxsFmt( L"%08X.%03d", ElfCRC, slot )).GetFullPath();
+#ifndef _UNIX_
+			std::replace(ElfString.begin(), ElfString.end(), '\\', '/');
+#endif
+			size_t pos = 0;
+			while ((pos = ElfString.find(ElfString_delimiter)) != std::string::npos)
+			{
+				// Running homebrew/standalone ELF, return only the ELF name.
+				ElfString.erase(0, pos + ElfString_delimiter.length());
+			}
+			wxString ElfString_toWxString(ElfString.c_str(), wxConvUTF8);
+			serialName = ElfString_toWxString;
+		}
+		else
+		{
+			// Running a normal retail game
+			// Folder format is "SLXX-XXXX - (00000000)"
+			serialName = DiscSerial;
+		}
+	}
+	else
+	{
+		// Still inside the BIOS/not running a game (why would anyone want to do this?)
+		wxString biosString = (pxsFmt(L"BIOS (%s v%u.%u)", WX_STR(biosZone), (BiosVersion >> 8), BiosVersion & 0xff));
+		serialName = biosString;
+		CRCvalue = L"None";
+	}
+
+	wxFileName dirname = wxFileName::DirName(g_Conf->FullpathToSaveState(serialName, CRCvalue));
+
+	if (isSavingOrLoading)
+	{
+		if (!wxDirExists(g_Conf->FullpathToSaveState(serialName, CRCvalue)))
+		{
+			wxMkdir(g_Conf->FullpathToSaveState(serialName, CRCvalue));
+		}
+	}
+	return (dirname.GetPath() + "/" +
+			pxsFmt( L"%s (%s).%02d.p2s", WX_STR(serialName), WX_STR(CRCvalue), slot ));
 }
 
 SaveStateBase::SaveStateBase( SafeArray<u8>& memblock )

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A28 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A29 << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin
@@ -74,7 +74,7 @@ public:
 	SaveStateBase( VmStateBuffer* memblock );
 	virtual ~SaveStateBase() { }
 
-	static wxString GetFilename( int slot );
+	static wxString GetSavestateFolder( int slot, bool isSavingOrLoading = false );
 
 	// Gets the version of savestate that this object is acting on.
 	// The version refers to the low 16 bits only (high 16 bits classifies Pcsx2 build types)
@@ -349,3 +349,4 @@ namespace Exception
 	};
 }; // namespace Exception
 
+extern wxString GetSavestateFolder( int slot );

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -453,6 +453,9 @@ void SysMainMemory::DecommitAll()
 	closeNewVif(0);
 	closeNewVif(1);
 
+	g_GameStarted = false;
+	g_GameLoading = false;
+
 	vtlb_Core_Free();
 }
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -485,6 +485,12 @@ void AppConfig::FolderOptions::Set(FoldersEnum_t folderidx, const wxString& src,
 	}
 }
 
+wxString AppConfig::FullpathToSaveState(wxString serialName, wxString CRCvalue) const
+{
+	wxString Sstate_append = serialName + " - " + "(" + CRCvalue + ")";
+	return Path::Combine(Folders.Savestates, Sstate_append);
+}
+
 bool IsPortable()
 {
 	return InstallationMode == InstallMode_Portable;

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -294,7 +294,7 @@ public:
 
 public:
 	AppConfig();
-
+	wxString FullpathToSaveState(wxString serialName, wxString CRCvalue) const;
 	void LoadSave(IniInterface& ini, SettingsWrapper& wrap);
 	void LoadSaveRootItems(IniInterface& ini);
 

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -460,6 +460,11 @@ static void _ApplySettings(const Pcsx2Config& src, Pcsx2Config& fixup)
 				gameCompat = L" [Status = " + compatToStringWX(game.compat) + L"]";
 				gameMemCardFilter = fromUTF8(game.memcardFiltersAsString());
 			}
+			else
+			{
+				// Set correct title for loading standalone/homebrew ELFs
+				GameInfo::gameName = LastELF.AfterLast('\\');
+			}
 
 			if (fixup.EnablePatches)
 			{

--- a/pcsx2/gui/Saveslots.cpp
+++ b/pcsx2/gui/Saveslots.cpp
@@ -116,7 +116,7 @@ void States_DefrostCurrentSlotBackup()
 
 void States_updateLoadBackupMenuItem()
 {
-	wxString file = SaveStateBase::GetFilename(StatesC) + ".backup";
+	wxString file(SaveStateBase::GetSavestateFolder(StatesC) + ".backup");
 
 	sMainFrame.EnableMenuItem(MenuId_State_LoadBackup, wxFileExists(file));
 	sMainFrame.SetMenuItemLabel(MenuId_State_LoadBackup, wxsFormat(L"%s %d", _("Backup"), StatesC));

--- a/pcsx2/gui/Saveslots.h
+++ b/pcsx2/gui/Saveslots.h
@@ -68,14 +68,14 @@ public:
 
 	bool isUsed()
 	{
-		return wxFileExists(SaveStateBase::GetFilename(slot_num));
+		return wxFileExists(SaveStateBase::GetSavestateFolder(slot_num, false));
 	}
 
 	wxDateTime GetTimestamp()
 	{
 		if (!isUsed()) return wxInvalidDateTime;
 
-		return wxDateTime(wxFileModificationTime(SaveStateBase::GetFilename(slot_num)));
+		return wxDateTime(wxFileModificationTime(SaveStateBase::GetSavestateFolder(slot_num, false)));
 	}
 
 	void UpdateCache()

--- a/pcsx2/gui/SysState.cpp
+++ b/pcsx2/gui/SysState.cpp
@@ -37,6 +37,11 @@
 
 #include "Patch.h"
 
+// Required for savestate folder creation
+#include "CDVD/CDVD.h"
+#include "ps2/BiosTools.h"
+#include "Elfheader.h"
+
 // --------------------------------------------------------------------------------------
 //  SysExecEvent_DownloadState
 // --------------------------------------------------------------------------------------
@@ -180,12 +185,12 @@ void StateCopy_LoadFromFile(const wxString& file)
 // the one in the memory save. :)
 void StateCopy_SaveToSlot(uint num)
 {
-	const wxString file(SaveStateBase::GetFilename(num));
+	const wxString file(SaveStateBase::GetSavestateFolder(num, true));
 
 	// Backup old Savestate if one exists.
 	if (wxFileExists(file) && EmuConfig.BackupSavestate)
 	{
-		const wxString copy(SaveStateBase::GetFilename(num) + pxsFmt(L".backup"));
+		const wxString copy(SaveStateBase::GetSavestateFolder(num, true) + pxsFmt(L".backup"));
 
 		Console.Indent().WriteLn(Color_StrongGreen, L"Backing up existing state in slot %d.", num);
 		wxRenameFile(file, copy);
@@ -202,7 +207,7 @@ void StateCopy_SaveToSlot(uint num)
 
 void StateCopy_LoadFromSlot(uint slot, bool isFromBackup)
 {
-	wxString file(SaveStateBase::GetFilename(slot) + wxString(isFromBackup ? L".backup" : L""));
+	wxString file(SaveStateBase::GetSavestateFolder(slot, true) + wxString(isFromBackup ? L".backup" : L""));
 
 	if (!wxFileExists(file))
 	{

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -56,7 +56,8 @@ static void _SaveLoadStuff(bool enabled)
 	for (Saveslot &slot : saveslot_cache)
 	{
 		// We need to reload the file information if the crc or serial # changed.
-		if ((slot.crc != ElfCRC)|| (slot.serialName != DiscSerial))
+		// Invalidate slot cache when using full boot (g_GameLoading) otherwise it won't see the new folder path
+		if ((g_GameLoading || slot.crc != ElfCRC) || (slot.serialName != DiscSerial))
 		{
 			slot.invalid_cache = true;
 			crcChanged = true;

--- a/pcsx2/gui/UpdateUI.cpp
+++ b/pcsx2/gui/UpdateUI.cpp
@@ -55,6 +55,11 @@ static void _SaveLoadStuff(bool enabled)
 	// Run though all the slots. Update if they need updating or the crc changed.
 	for (Saveslot &slot : saveslot_cache)
 	{
+		if (!SysHasValidState())
+		{
+			return;
+		}
+
 		// We need to reload the file information if the crc or serial # changed.
 		// Invalidate slot cache when using full boot (g_GameLoading) otherwise it won't see the new folder path
 		if ((g_GameLoading || slot.crc != ElfCRC) || (slot.serialName != DiscSerial))

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -50,6 +50,7 @@ static_assert( sizeof(romdir) == DIRENTRY_SIZE, "romdir struct not packed to 16 
 u32 BiosVersion;
 u32 BiosChecksum;
 u32 BiosRegion;
+wxString biosZone;
 bool NoOSD;
 bool AllowParams1;
 bool AllowParams2;
@@ -276,7 +277,6 @@ void LoadBIOS()
 
 		BiosChecksum = 0;
 
-		wxString biosZone;
 		wxFFile fp( Bios , "rb");
 		fp.Read( eeMem->ROM, std::min<s64>( Ps2MemSize::Rom, filesize ) );
 

--- a/pcsx2/ps2/BiosTools.h
+++ b/pcsx2/ps2/BiosTools.h
@@ -48,5 +48,6 @@ extern bool AllowParams1;
 extern bool AllowParams2;
 extern u32 BiosChecksum;
 extern wxString BiosDescription;
+extern wxString biosZone;
 extern void LoadBIOS();
 extern bool IsBIOS(const wxString& filename, wxString& description);


### PR DESCRIPTION
### Description of Changes
- Organized user-created savestates by saving into subfolders with game name and serial.
- Detect PSX CRC properly, format console titlebar.

- Fix bug with g_GameStarted and g_GameLoading not being reset on recompiler shutdown.
- Fix bug with g_GameStarted and g_GameLoading not being set to proper status when loading savestate.

### Rationale behind Changes
Cleaner directory for savestates, improve ease of saveestate management. Improve management of game state variables in regards to functionality.

### Suggested testing steps
Save/load savestates, look for errors in directory/savestate creation or directory naming. Check for errors/crashes switching games.

Closes #4625, #4744 
