### PR TITLE
config: normalize limiter values before saving

### DIFF
--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -51,13 +51,13 @@ void gsUpdateFrequency(Pcsx2Config& config)
 	switch (g_LimiterMode)
 	{
 	case LimiterModeType::Limit_Nominal:
-		config.GS.LimitScalar = g_Conf->Framerate.NominalScalar / 100.0;
+		config.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
 		break;
 	case LimiterModeType::Limit_Slomo:
-		config.GS.LimitScalar = g_Conf->Framerate.SlomoScalar / 100.0;
+		config.GS.LimitScalar = g_Conf->Framerate.SlomoScalar;
 		break;
 	case LimiterModeType::Limit_Turbo:
-		config.GS.LimitScalar = g_Conf->Framerate.TurboScalar / 100.0;
+		config.GS.LimitScalar = g_Conf->Framerate.TurboScalar;
 		break;
 	default:
 		pxAssert("Unknown framelimiter mode!");

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -865,9 +865,9 @@ void AppConfig::FramerateOptions::SanityCheck()
 {
 	// Ensure Conformation of various options...
 
-	NominalScalar = std::clamp(NominalScalar, 5.0, 1000.0);
-	TurboScalar = std::clamp(TurboScalar, 5.0, 1000.0);
-	SlomoScalar = std::clamp(SlomoScalar, 5.0, 1000.0);
+	NominalScalar = std::clamp(NominalScalar, 0.05, 10.0);
+	TurboScalar = std::clamp(TurboScalar, 0.05, 10.0);
+	SlomoScalar = std::clamp(SlomoScalar, 0.05, 10.0);
 }
 
 void AppConfig::FramerateOptions::LoadSave( IniInterface& ini )

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -239,9 +239,9 @@ public:
 		bool SkipOnLimit{ false };
 		bool SkipOnTurbo{ false };
 
-		double NominalScalar{ 100.0 };
-		double TurboScalar{ 200.0 };
-		double SlomoScalar{ 50.0 };
+		double NominalScalar{ 1.0 };
+		double TurboScalar{ 2.0 };
+		double SlomoScalar{ 0.5 };
 
 		void LoadSave( IniInterface& conf );
 		void SanityCheck();

--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -111,12 +111,13 @@ void Panels::FramelimiterPanel::ApplyConfigToGui( AppConfig& configToApply, int 
 	const AppConfig::FramerateOptions& appfps( configToApply.Framerate );
 	const Pcsx2Config::GSOptions& gsconf( configToApply.EmuOptions.GS );
 
-	if( ! (flags & AppConfig::APPLY_FLAG_FROM_PRESET) ){	//Presets don't control these: only change if config doesn't come from preset.
+	if( ! (flags & AppConfig::APPLY_FLAG_FROM_PRESET) )
+	{	//Presets don't control these: only change if config doesn't come from preset.
 	
 		m_check_LimiterDisable->SetValue(!gsconf.FrameLimitEnable);
 
-		m_spin_TurboPct->SetValue(appfps.TurboScalar);
-		m_spin_SlomoPct->SetValue(appfps.SlomoScalar);
+		m_spin_TurboPct->SetValue(appfps.TurboScalar * 100.0);
+		m_spin_SlomoPct->SetValue(appfps.SlomoScalar * 100.0);
 
 		m_spin_TurboPct->Enable(true);
 		m_spin_SlomoPct->Enable(true);
@@ -125,7 +126,7 @@ void Panels::FramelimiterPanel::ApplyConfigToGui( AppConfig& configToApply, int 
 	m_text_BaseNtsc->ChangeValue(wxString::FromDouble(gsconf.FramerateNTSC, 2));
 	m_text_BasePal->ChangeValue(wxString::FromDouble(gsconf.FrameratePAL, 2));
 
-	m_spin_NominalPct->SetValue(appfps.NominalScalar);
+	m_spin_NominalPct->SetValue(appfps.NominalScalar * 100.0);
 	m_spin_NominalPct->Enable(!configToApply.EnablePresets);
 
 	m_text_BaseNtsc->Enable(!configToApply.EnablePresets);
@@ -139,9 +140,9 @@ void Panels::FramelimiterPanel::Apply()
 
 	gsconf.FrameLimitEnable	= !m_check_LimiterDisable->GetValue();
 
-	appfps.NominalScalar = m_spin_NominalPct->GetValue();
-	appfps.TurboScalar = m_spin_TurboPct->GetValue();
-	appfps.SlomoScalar = m_spin_SlomoPct->GetValue();
+	appfps.NominalScalar = static_cast<double>(m_spin_NominalPct->GetValue()) / 100.0;
+	appfps.TurboScalar = static_cast<double>(m_spin_TurboPct->GetValue()) / 100.0;
+	appfps.SlomoScalar = static_cast<double>(m_spin_SlomoPct->GetValue()) / 100.0;
 
 	wxString ntsc_framerate_string = m_text_BaseNtsc->GetValue();
 	wxString pal_framerate_string = m_text_BasePal->GetValue();


### PR DESCRIPTION
### Description of Changes
Changes the way the limiter values are saved and stored such that they match the stored values from before https://github.com/PCSX2/pcsx2/commit/38f1a9a762cea8e936351ae9e96384271d8abd90.

### Rationale behind Changes
After an internal discussion, it has been decided to drop the policy that we don't support using older configs between versions and making recommendations against it as it has proved too impractical and an unreasonable burden to our users. As such, moving forward we will support them doing so and maintain backwards compatibility with older inis (at least until such time that doing so becomes impossible due to a change to a different system such as yaml). This PR makes the limiter settings backwards compatible with settings before https://github.com/PCSX2/pcsx2/commit/38f1a9a762cea8e936351ae9e96384271d8abd90. Hopefully the last hiccup with regards to this commit.

### Suggested Testing Steps
Make sure you can still use an ini with pcsx2 from before https://github.com/PCSX2/pcsx2/commit/38f1a9a762cea8e936351ae9e96384271d8abd90 (build number 1676) and not have everything be slow.
