### PR TITLE
Stdio console on mac

### DIFF
--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -26,7 +26,21 @@ static DeclareTls(int) conlog_Indent(0);
 static DeclareTls(ConsoleColors) conlog_Color(DefaultConsoleColor);
 
 #ifdef __POSIX__
+#include <unistd.h>
+
 static FILE* stdout_fp = stdout;
+
+static bool checkSupportsColor()
+{
+	if (!isatty(fileno(stdout_fp)))
+		return false;
+	char* term = getenv("TERM");
+	if (!term || (0 == strcmp(term, "dumb")))
+		return false;
+	return true; // Probably supports color
+}
+
+static bool supports_color = checkSupportsColor();
 
 void Console_SetStdout(FILE* fp)
 {
@@ -177,6 +191,8 @@ static void __concall ConsoleStdout_Newline()
 static void __concall ConsoleStdout_DoSetColor(ConsoleColors color)
 {
 #if defined(__POSIX__)
+	if (!supports_color)
+		return;
 	fprintf(stdout_fp, "\033[0m%s", GetLinuxConsoleColor(color));
 	fflush(stdout_fp);
 #endif
@@ -185,9 +201,11 @@ static void __concall ConsoleStdout_DoSetColor(ConsoleColors color)
 static void __concall ConsoleStdout_SetTitle(const wxString& title)
 {
 #if defined(__POSIX__)
-	fputs("\033]0;", stdout_fp);
+	if (supports_color)
+		fputs("\033]0;", stdout_fp);
 	fputs(title.utf8_str(), stdout_fp);
-	fputs("\007", stdout_fp);
+	if (supports_color)
+		fputs("\007", stdout_fp);
 #endif
 }
 

--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -99,7 +99,7 @@ const IConsoleWriter ConsoleWriter_Null =
 //  Console_Stdout
 // --------------------------------------------------------------------------------------
 
-#if defined(__unix__)
+#if defined(__POSIX__)
 static __fi const char* GetLinuxConsoleColor(ConsoleColors color)
 {
 	switch (color)
@@ -176,7 +176,7 @@ static void __concall ConsoleStdout_Newline()
 
 static void __concall ConsoleStdout_DoSetColor(ConsoleColors color)
 {
-#if defined(__unix__)
+#if defined(__POSIX__)
 	fprintf(stdout_fp, "\033[0m%s", GetLinuxConsoleColor(color));
 	fflush(stdout_fp);
 #endif
@@ -184,7 +184,7 @@ static void __concall ConsoleStdout_DoSetColor(ConsoleColors color)
 
 static void __concall ConsoleStdout_SetTitle(const wxString& title)
 {
-#if defined(__unix__)
+#if defined(__POSIX__)
 	fputs("\033]0;", stdout_fp);
 	fputs(title.utf8_str(), stdout_fp);
 	fputs("\007", stdout_fp);

--- a/common/Console.h
+++ b/common/Console.h
@@ -234,7 +234,7 @@ public:
 
 extern IConsoleWriter Console;
 
-#if defined(__unix__) || defined(__APPLE__)
+#if defined(__POSIX__)
 extern void Console_SetStdout(FILE* fp);
 #endif
 extern void Console_SetActiveHandler(const IConsoleWriter& writer, FILE* flushfp = NULL);

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -1071,11 +1071,11 @@ void Pcsx2App::ProgramLog_PostEvent( wxEvent& evt )
 
 static void __concall ConsoleToFile_Newline()
 {
-#if defined(__unix__)
+#if defined(__POSIX__)
 	if ((g_Conf) && (g_Conf->EmuOptions.ConsoleToStdio)) ConsoleWriter_Stdout.Newline();
 #endif
 
-#if defined(__unix__)
+#if defined(__POSIX__)
 	fputc( '\n', emuLog );
 #else
 	fputs( "\r\n", emuLog );
@@ -1084,7 +1084,7 @@ static void __concall ConsoleToFile_Newline()
 
 static void __concall ConsoleToFile_DoWrite( const wxString& fmt )
 {
-#if defined(__unix__)
+#if defined(__POSIX__)
 	if ((g_Conf) && (g_Conf->EmuOptions.ConsoleToStdio)) ConsoleWriter_Stdout.WriteRaw(fmt);
 #endif
 

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -293,7 +293,7 @@ void MainEmuFrame::ConnectMenus()
 
 	// Misc
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ShowConsole, this, MenuId_Console);
-#if defined(__unix__)
+#if defined(__POSIX__)
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_ShowConsole_Stdio, this, MenuId_Console_Stdio);
 #endif
 
@@ -475,7 +475,7 @@ void MainEmuFrame::CreateWindowsMenu()
 #endif
 
 	m_menuWindow.Append(&m_MenuItem_Console);
-#if defined(__unix__)
+#if defined(__POSIX__)
 	m_menuWindow.AppendSeparator();
 	m_menuWindow.Append(&m_MenuItem_Console_Stdio);
 #endif
@@ -574,7 +574,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	, m_GameSettingsSubmenu(*new wxMenu())
 
 	, m_MenuItem_Console(*new wxMenuItem(&m_menuWindow, MenuId_Console, _("&Show Program Log"), wxEmptyString, wxITEM_CHECK))
-#if defined(__unix__)
+#if defined(__POSIX__)
 	, m_MenuItem_Console_Stdio(*new wxMenuItem(&m_menuWindow, MenuId_Console_Stdio, _("&Program Log to Stdio"), wxEmptyString, wxITEM_CHECK))
 #endif
 
@@ -830,7 +830,7 @@ void MainEmuFrame::ApplyConfigToGui(AppConfig& configToApply, int flags)
 #endif
 		menubar.Check(MenuId_EnableHostFs, configToApply.EmuOptions.HostFs);
 		menubar.Check(MenuId_Debug_CreateBlockdump, configToApply.EmuOptions.CdvdDumpBlocks);
-#if defined(__unix__)
+#if defined(__POSIX__)
 		menubar.Check(MenuId_Console_Stdio, configToApply.EmuOptions.ConsoleToStdio);
 #endif
 

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -85,7 +85,7 @@ protected:
 	wxMenuItem* m_menuItem_RecentIsoMenu;
 	wxMenuItem* m_menuItem_DriveListMenu;
 	wxMenuItem& m_MenuItem_Console;
-#if defined(__unix__)
+#if defined(__POSIX__)
 	wxMenuItem& m_MenuItem_Console_Stdio;
 #endif
 


### PR DESCRIPTION
### Description of Changes
Enables the "Program Log to Stdio" menu option on macOS
Also makes it check the console for color support before trying to use color escapes

### Rationale behind Changes
It's useful on macOS too

### Suggested Testing Steps
Make sure option works on macOS and Linux
