### PR TITLE
Improved stats printout from sw renderer

### DIFF
--- a/common/emitter/tools.h
+++ b/common/emitter/tools.h
@@ -116,6 +116,7 @@ public:
 	void CountCores();
 	wxString GetTypeName() const;
 
+	static u32 CachedMHz();
 	u32 CalculateMHz() const;
 
 	void SIMD_EstablishMXCSRmask();

--- a/pcsx2/GS/Renderers/Common/GSFunctionMap.h
+++ b/pcsx2/GS/Renderers/Common/GSFunctionMap.h
@@ -19,7 +19,7 @@
 #include "GS/GSCodeBuffer.h"
 
 #include "GS/Renderers/SW/GSScanlineEnvironment.h"
-#include "common/General.h"
+#include "common/emitter/tools.h"
 
 #include <xbyak/xbyak_util.h>
 
@@ -109,9 +109,9 @@ public:
 			totalTicks += p->ticks;
 		}
 
-		double tick_secs = 1.0 / GetTickFrequency();
-		double tick_ms = tick_secs * 1000;
-		double tick_ns = tick_secs * (1000 * 1000 * 1000);
+		double tick_us = 1.0 / x86capabilities::CachedMHz();
+		double tick_ms = tick_us / 1000;
+		double tick_ns = tick_us * 1000;
 
 		printf("GS stats\n");
 

--- a/pcsx2/GS/Renderers/Common/GSFunctionMap.h
+++ b/pcsx2/GS/Renderers/Common/GSFunctionMap.h
@@ -80,7 +80,7 @@ public:
 		return m_active->f;
 	}
 
-	void UpdateStats(uint64 frame, uint64 ticks, int actual, int total)
+	void UpdateStats(uint64 frame, uint64 ticks, int actual, int total, int prims)
 	{
 		if (m_active)
 		{
@@ -90,7 +90,7 @@ public:
 				m_active->frames++;
 			}
 
-			m_active->prims++;
+			m_active->prims += prims;
 			m_active->ticks += ticks;
 			m_active->actual += actual;
 			m_active->total += total;

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -103,9 +103,9 @@ void GSDrawScanline::BeginDraw(const GSRasterizerData* data)
 	m_sp = m_sp_map[sel];
 }
 
-void GSDrawScanline::EndDraw(uint64 frame, uint64 ticks, int actual, int total)
+void GSDrawScanline::EndDraw(uint64 frame, uint64 ticks, int actual, int total, int prims)
 {
-	m_ds_map.UpdateStats(frame, ticks, actual, total);
+	m_ds_map.UpdateStats(frame, ticks, actual, total, prims);
 }
 
 #ifndef ENABLE_JIT_RASTERIZER

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.h
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.h
@@ -62,7 +62,7 @@ public:
 	// IDrawScanline
 
 	void BeginDraw(const GSRasterizerData* data);
-	void EndDraw(uint64 frame, uint64 ticks, int actual, int total);
+	void EndDraw(uint64 frame, uint64 ticks, int actual, int total, int prims);
 
 	void DrawRect(const GSVector4i& r, const GSVertexSW& v);
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -17,6 +17,7 @@
 
 #include "PrecompiledHeader.h"
 #include "GSRasterizer.h"
+#include "common/General.h"
 
 int GSRasterizerData::s_counter = 0;
 
@@ -138,7 +139,7 @@ void GSRasterizer::Draw(GSRasterizerData* data)
 	m_pixels.actual = 0;
 	m_pixels.total = 0;
 
-	data->start = __rdtsc();
+	data->start = GetCPUTicks();
 
 	m_ds->BeginDraw(data);
 
@@ -244,7 +245,7 @@ void GSRasterizer::Draw(GSRasterizerData* data)
 
 	data->pixels = m_pixels.actual;
 
-	uint64 ticks = __rdtsc() - data->start;
+	uint64 ticks = GetCPUTicks() - data->start;
 
 	m_pixels.sum += m_pixels.actual;
 
@@ -1146,7 +1147,7 @@ void GSRasterizer::Flush(const GSVertexSW* vertex, const uint32* index, const GS
 void GSRasterizer::DrawScanline(int pixels, int left, int top, const GSVertexSW& scan)
 {
 	m_pixels.actual += pixels;
-	m_pixels.total += ((left + pixels + (PIXELS_PER_LOOP - 1)) & ~(PIXELS_PER_LOOP - 1)) - (left & (PIXELS_PER_LOOP - 1));
+	m_pixels.total += ((left + pixels + (PIXELS_PER_LOOP - 1)) & ~(PIXELS_PER_LOOP - 1)) - (left & ~(PIXELS_PER_LOOP - 1));
 	//m_pixels.total += ((left + pixels + (PIXELS_PER_LOOP - 1)) & ~(PIXELS_PER_LOOP - 1)) - left;
 
 	ASSERT(m_pixels.actual <= m_pixels.total);

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -141,7 +141,7 @@ void GSRasterizer::Draw(GSRasterizerData* data)
 	m_pixels.total = 0;
 	m_primcount = 0;
 
-	data->start = GetCPUTicks();
+	data->start = __rdtsc();
 
 	m_ds->BeginDraw(data);
 
@@ -247,7 +247,7 @@ void GSRasterizer::Draw(GSRasterizerData* data)
 
 	data->pixels = m_pixels.actual;
 
-	uint64 ticks = GetCPUTicks() - data->start;
+	uint64 ticks = __rdtsc() - data->start;
 
 	m_pixels.sum += m_pixels.actual;
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -42,6 +42,7 @@ GSRasterizer::GSRasterizer(IDrawScanline* ds, int id, int threads, GSPerfMon* pe
 	, m_threads(threads)
 {
 	memset(&m_pixels, 0, sizeof(m_pixels));
+	m_primcount = 0;
 
 	m_thread_height = compute_best_thread_height(threads);
 
@@ -138,6 +139,7 @@ void GSRasterizer::Draw(GSRasterizerData* data)
 
 	m_pixels.actual = 0;
 	m_pixels.total = 0;
+	m_primcount = 0;
 
 	data->start = GetCPUTicks();
 
@@ -249,12 +251,14 @@ void GSRasterizer::Draw(GSRasterizerData* data)
 
 	m_pixels.sum += m_pixels.actual;
 
-	m_ds->EndDraw(data->frame, ticks, m_pixels.actual, m_pixels.total);
+	m_ds->EndDraw(data->frame, ticks, m_pixels.actual, m_pixels.total, m_primcount);
 }
 
 template <bool scissor_test>
 void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const uint32* index, int index_count)
 {
+	m_primcount++;
+
 	if (index != NULL)
 	{
 		for (int i = 0; i < index_count; i++, index++)
@@ -299,6 +303,8 @@ void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const u
 
 void GSRasterizer::DrawLine(const GSVertexSW* vertex, const uint32* index)
 {
+	m_primcount++;
+
 	const GSVertexSW& v0 = vertex[index[0]];
 	const GSVertexSW& v1 = vertex[index[1]];
 
@@ -415,6 +421,8 @@ static const uint8 s_ysort[8][4] =
 
 void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const uint32* index)
 {
+	m_primcount++;
+
 	GSVertexSW2 dv[3];
 	GSVertexSW2 edge;
 	GSVertexSW2 dedge;
@@ -606,6 +614,8 @@ void GSRasterizer::DrawTriangleSection(int top, int bottom, GSVertexSW2& edge, c
 
 void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const uint32* index)
 {
+	m_primcount++;
+
 	GSVertexSW dv[3];
 	GSVertexSW edge;
 	GSVertexSW dedge;
@@ -799,6 +809,8 @@ void GSRasterizer::DrawTriangleSection(int top, int bottom, GSVertexSW& edge, co
 
 void GSRasterizer::DrawSprite(const GSVertexSW* vertex, const uint32* index)
 {
+	m_primcount++;
+
 	const GSVertexSW& v0 = vertex[index[0]];
 	const GSVertexSW& v1 = vertex[index[1]];
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -87,7 +87,7 @@ public:
 	virtual ~IDrawScanline() {}
 
 	virtual void BeginDraw(const GSRasterizerData* data) = 0;
-	virtual void EndDraw(uint64 frame, uint64 ticks, int actual, int total) = 0;
+	virtual void EndDraw(uint64 frame, uint64 ticks, int actual, int total, int prims) = 0;
 
 #ifdef ENABLE_JIT_RASTERIZER
 
@@ -137,6 +137,7 @@ protected:
 	GSVector4 m_fscissor_y;
 	struct { GSVertexSW* buff; int count; } m_edge;
 	struct { int sum, actual, total; } m_pixels;
+	int m_primcount;
 
 	typedef void (GSRasterizer::*DrawPrimPtr)(const GSVertexSW* v, int count);
 


### PR DESCRIPTION
### Description of Changes
Makes the printout made by this line easier to read https://github.com/PCSX2/pcsx2/blob/ab64023e56ea31164396148272da721559888bbc/pcsx2/GS/Renderers/SW/GSRendererSW.cpp#L140

<details>
<summary>Before</summary>

```
GS stats
[0d1515112e8864]*   0.00%  0.00% f   60 t       131380 p            0 w            0 tpp    0 tpf      2189 ppf         0
[11151b3fce8164]*   0.01%  0.00% f   60 t       287660 p          180 w        60660 tpp 1598 tpf      4794 ppf         3
[0910193fce8064]*   0.01%  0.00% f   60 t       315968 p          240 w        21300 tpp 1316 tpf      5266 ppf         4
[0d181b3fce8164]*   0.00%  0.00% f  120 t       214132 p            0 w            0 tpp    0 tpf      1784 ppf         0
[09181f112e8764]*   0.01%  0.01% f   60 t       350288 p           60 w          780 tpp 5838 tpf      5838 ppf         1
[0115051123804d]*   0.00%  0.00% f  120 t       306132 p          960 w       173400 tpp  318 tpf      2551 ppf         8
[0d15051127804d]*   0.15%  0.09% f  120 t      6419836 p       211740 w      3877800 tpp   30 tpf     53498 ppf      1764
[0d151b3fce8964]*   0.00%  0.00% f  120 t       336972 p           60 w        20160 tpp 5616 tpf      2808 ppf         0
[0110051920404d]*   0.02%  0.01% f  120 t      1178528 p        43020 w      2466600 tpp   27 tpf      9821 ppf       358
[1515051127804d]*   0.82%  0.49% f  120 t     33773420 p      1389960 w      7641240 tpp   24 tpf    281445 ppf     11583
[0190013fc0404d]*   0.00%  0.00% f  120 t       224536 p     17203200 w            0 tpp    0 tpf      1871 ppf    143360
[0915051127804d]*   0.13%  0.08% f  120 t      5430284 p       107100 w      3544140 tpp   50 tpf     45252 ppf       892
[10990013fc5904d]*   5.28%  3.17% f  120 t    215450592 p     17203200 w    679526400 tpp   12 tpf   1795421 ppf    143360
[091d193fce8064]*   0.02%  0.01% f  120 t      1104884 p         2520 w       748620 tpp  438 tpf      9207 ppf        21
[0110051920484d]*   0.16%  0.09% f  120 t      6567300 p       135180 w     16538340 tpp   48 tpf     54727 ppf      1126
[11191851a25804c]*   4.95%  2.98% f  120 t    202367188 p     17203200 w     60211200 tpp   11 tpf   1686393 ppf    143360
[11190051a25804c]*   4.82%  2.90% f  120 t    196837676 p     17203200 w     60211200 tpp   11 tpf   1640313 ppf    143360
[091d193fce8864]*   0.00%  0.00% f  120 t       389352 p          180 w        63360 tpp 2163 tpf      3244 ppf         1
[11190053fc5804c]*   4.24%  2.55% f  120 t    173308112 p     17203200 w     60211200 tpp   10 tpf   1444234 ppf    143360
[1d9d013fc1904d]*   5.79%  3.48% f  120 t    236312804 p     17203200 w    163430400 tpp   13 tpf   1969273 ppf    143360
[111d1b3fce8964]*   0.01%  0.00% f   60 t       225960 p           60 w        20160 tpp 3766 tpf      3766 ppf         1
[091515112e8864]*   0.01%  0.00% f  120 t       454768 p          240 w        85860 tpp 1894 tpf      3789 ppf         2
[0d18193fce9064]*   0.81%  0.49% f  120 t     33321844 p      1018980 w     15926940 tpp   32 tpf    277682 ppf      8491
[1115193fce8064]*   0.00%  0.00% f   60 t       118372 p            0 w            0 tpp    0 tpf      1972 ppf         0
[0d1515112e8064]*   0.00%  0.00% f  120 t       365696 p          480 w       146760 tpp  761 tpf      3047 ppf         4
[0d1517163a8864]*   0.09%  0.05% f  120 t      4029444 p         8400 w      1999200 tpp  479 tpf     33578 ppf        70
[111d1b3fce8164]*   0.00%  0.00% f   60 t       178384 p          180 w        40380 tpp  991 tpf      2973 ppf         3
[09151d112e8864]*   0.01%  0.00% f  120 t       491456 p          180 w        64380 tpp 2730 tpf      4095 ppf         1
[0d9d051623904c]*  16.95% 10.20% f  120 t    691642664 p     34406400 w    326860800 tpp   20 tpf   5763688 ppf    286720
[091515112e8064]*   0.02%  0.01% f  120 t       895964 p         1200 w       238500 tpp  746 tpf      7466 ppf        10
[0915071127814d]*   0.02%  0.01% f  120 t       962832 p        20160 w       253620 tpp   47 tpf      8023 ppf       168
[0d1515162a8864]*   0.01%  0.00% f  120 t       524780 p          180 w        64380 tpp 2915 tpf      4373 ppf         1
[01900d3fc04054]*   1.58%  0.95% f  120 t     64746944 p     34406400 w            0 tpp    1 tpf    539557 ppf    286720
[0915193fce8064]*   0.04%  0.02% f  120 t      1760952 p         6480 w      1293360 tpp  271 tpf     14674 ppf        54
[0d181f112e8f64]*   0.07%  0.04% f  120 t      3262968 p        11280 w       619200 tpp  289 tpf     27191 ppf        94
[01181511284064]*   0.01%  0.00% f   60 t       267416 p          660 w        91020 tpp  405 tpf      4456 ppf        11
[01181511284864]*   0.01%  0.00% f  120 t       614604 p          720 w       160440 tpp  853 tpf      5121 ppf         6
[1915051127904d]*   0.77%  0.46% f  120 t     31555344 p      1436400 w      2925360 tpp   21 tpf    262961 ppf     11970
[1918193fce8864]*   0.35%  0.21% f  120 t     14431508 p        61620 w      8560500 tpp  234 tpf    120262 ppf       513
[0190053fc0404c]*   0.83%  0.50% f  120 t     33976004 p     34897920 w            0 tpp    0 tpf    283133 ppf    290816
[111815112e8864]*   0.42%  0.25% f  120 t     17481736 p        87840 w      8588640 tpp  199 tpf    145681 ppf       732
[1d95013fc3804d]*  12.06%  7.26% f  120 t    492085640 p     17203200 w    163430400 tpp   28 tpf   4100713 ppf    143360
[6d181f112e8764]*   0.99%  0.59% f  120 t     40619660 p       260700 w     50199960 tpp  155 tpf    338497 ppf      2172
[09181b3fce8164]*   0.01%  0.00% f  120 t       489524 p          360 w        24180 tpp 1359 tpf      4079 ppf         3
[15181b3fce8964]*   1.69%  1.02% f  120 t     69127904 p      1959720 w     38250240 tpp   35 tpf    576065 ppf     16331
[11181f112e8f64]*   0.01%  0.00% f  120 t       586336 p        13320 w       331080 tpp   44 tpf      4886 ppf       111
[0915051125904d]*   0.01%  0.01% f  120 t       806868 p        25920 w       889980 tpp   31 tpf      6723 ppf       216
[0190013fc0404e]*   0.01%  0.00% f  120 t       640476 p       491520 w            0 tpp    1 tpf      5337 ppf      4096
[8d181f112e8764]*   2.18%  1.31% f  120 t     89278836 p      1827900 w     78829860 tpp   48 tpf    743990 ppf     15232
[0118193fc84864]*   0.06%  0.03% f  120 t      2522900 p        11220 w      2514540 tpp  224 tpf     21024 ppf        93
[119d0e112181d4]*   0.55%  0.33% f  120 t     22458988 p      3440640 w      5160960 tpp    6 tpf    187158 ppf     28672
[111d193fce8064]*   0.01%  0.00% f  120 t       613996 p          300 w       107340 tpp 2046 tpf      5116 ppf         2
[1118193fcc8864]*   0.01%  0.00% f  120 t       661760 p          960 w        11400 tpp  689 tpf      5514 ppf         8
[1195051127804d]*   0.51%  0.31% f  121 t     21324676 p       625260 w     20680080 tpp   34 tpf    176236 ppf      5167
[09181b3fce8964]*   0.06%  0.04% f  120 t      2845280 p         3840 w       185280 tpp  740 tpf     23710 ppf        32
[0d181b3fce8964]*   0.08%  0.04% f  120 t      3377980 p        11280 w       411720 tpp  299 tpf     28149 ppf        94
[159d0e112181d4]*   1.22%  0.73% f  120 t     50134148 p      6881280 w     30965760 tpp    7 tpf    417784 ppf     57344
[09101b3fce8164]*   0.00%  0.00% f  120 t       367796 p          180 w        64200 tpp 2043 tpf      3064 ppf         1
[0d181f112c8f64]*   0.11%  0.06% f  120 t      4586896 p        52620 w      1003740 tpp   87 tpf     38224 ppf       438
[15181b3fce9164]*   0.34%  0.20% f  120 t     13964608 p       404640 w      1566540 tpp   34 tpf    116371 ppf      3372
[1115193fce8864]*   0.02%  0.01% f  120 t       824768 p         2460 w       478320 tpp  335 tpf      6873 ppf        20
[1118193fce8064]*   0.54%  0.32% f  120 t     22216680 p       141420 w      7296900 tpp  157 tpf    185139 ppf      1178
[09151b3fcc8164]*   0.01%  0.00% f  120 t       439424 p         2520 w       267960 tpp  174 tpf      3661 ppf        21
[0d15051127904d]*   0.17%  0.10% f  120 t      7193708 p       221520 w      1753080 tpp   32 tpf     59947 ppf      1846
[0110051120404d]*   0.24%  0.14% f  120 t     10087464 p      1332480 w     10774680 tpp    7 tpf     84062 ppf     11104
[6d181f112e8f64]*   0.59%  0.35% f  120 t     24089468 p       198540 w      9571920 tpp  121 tpf    200745 ppf      1654
[0d15193fce8864]*   0.01%  0.00% f  120 t       555552 p          240 w        85080 tpp 2314 tpf      4629 ppf         2
[111d053fc3904c]*   7.01%  4.22% f  120 t    286237140 p      6848040 w    150588600 tpp   41 tpf   2385309 ppf     57067
[0d18193fce8064]*   0.25%  0.15% f  120 t     10360292 p        74370 w      4599540 tpp  139 tpf     86335 ppf       619
[1d95051923804d]*  11.23%  6.76% f  120 t    458201008 p     17203200 w    163430400 tpp   26 tpf   3818341 ppf    143360
[0915193fce8864]*   0.04%  0.02% f  120 t      1952256 p         3540 w       792720 tpp  551 tpf     16268 ppf        29
[0918193fce8064]*   0.21%  0.12% f  120 t      8792536 p        89460 w      2292360 tpp   98 tpf     73271 ppf       745
[0d9d0e112181d4]*   0.26%  0.15% f  120 t     10799300 p      1720320 w            0 tpp    6 tpf     89994 ppf     14336
[09151b3fce8164]*   0.02%  0.01% f  120 t      1070204 p          900 w       348780 tpp 1189 tpf      8918 ppf         7
[15181b3fce8164]*   0.29%  0.17% f  120 t     12166720 p       367560 w      6389700 tpp   33 tpf    101389 ppf      3063
[1115051127904d]*   0.14%  0.09% f  120 t      6114544 p       213180 w      2541300 tpp   28 tpf     50954 ppf      1776
[1118193fce8864]*   4.20%  2.53% f  120 t    171456240 p      2678340 w     90205860 tpp   64 tpf   1428802 ppf     22319
[0190093fc04054]*   2.73%  1.64% f  120 t    111510116 p     48504000 w            0 tpp    2 tpf    929250 ppf    404200
[0915153fce8064]*   0.01%  0.00% f  120 t       437420 p          180 w        64380 tpp 2430 tpf      3645 ppf         1
[11151b3fce8964]*   0.03%  0.01% f  120 t      1306040 p         1380 w       423420 tpp  946 tpf     10883 ppf        11
[0d181f112e8764]*   0.02%  0.01% f  120 t       863504 p         2160 w       681660 tpp  399 tpf      7195 ppf        18
[11181b3fce8164]*   0.03%  0.01% f  120 t      1277352 p         2940 w       137400 tpp  434 tpf     10644 ppf        24
[0d18193fce8864]*   4.35%  2.62% f  120 t    177649732 p      3038490 w    114385020 tpp   58 tpf   1480414 ppf     25320
[0098013fc0404c]*   0.01%  0.01% f  120 t       707452 p        37920 w      3107760 tpp   18 tpf      5895 ppf       316
[1518153fce8864]*  11.61%  6.99% f  120 t    473963852 p     16473780 w     38396880 tpp   28 tpf   3949698 ppf    137281
[199d0e112181d4]*   2.86%  1.72% f  120 t    117004280 p     13762560 w    144506880 tpp    8 tpf    975035 ppf    114688
[1518193fce8064]*   1.56%  0.94% f  120 t     63749140 p       696360 w     30733260 tpp   91 tpf    531242 ppf      5803
[1118193fce9064]*   5.50%  3.31% f  120 t    224744920 p      6110040 w     29727000 tpp   36 tpf   1872874 ppf     50917
[0915051127904d]*   0.07%  0.04% f  120 t      3086784 p        56400 w      1612200 tpp   54 tpf     25723 ppf       470
[0918193fce8864]*   6.99%  4.21% f  120 t    285468336 p      5923140 w    144291060 tpp   48 tpf   2378902 ppf     49359
[0180083fc04057]*   1.80%  1.08% f  120 t     73672152 p     84228480 w            0 tpp    0 tpf    613934 ppf    701904
[0198052a60404c]*   4.22%  2.54% f  120 t    172353240 p     36216000 w    165895200 tpp    4 tpf   1436277 ppf    301800
[1d9d0e112181d4]*   1.96%  1.18% f  120 t     80153584 p      8601600 w    146227200 tpp    9 tpf    667946 ppf     71680
[09151d112e8064]*   0.00%  0.00% f   60 t       151224 p            0 w            0 tpp    0 tpf      2520 ppf         0
[7118193fce8864]*   0.01%  0.01% f  120 t       768664 p         2160 w         1500 tpp  355 tpf      6405 ppf        18
[1515051127904d]*   1.57%  0.94% f  120 t     64215836 p      2872320 w      6463500 tpp   22 tpf    535131 ppf     23936
[0118193fc84064]*   0.07%  0.04% f  120 t      2898500 p         8580 w      2815320 tpp  337 tpf     24154 ppf        71
[1518193fce8864]*  26.32% 15.84% f  120 t   1073935820 p     35124720 w    157161780 tpp   30 tpf   8949465 ppf    292706
[0198013fc0404c]*   0.00%  0.00% f  120 t       218376 p          120 w            0 tpp 1819 tpf      1819 ppf         1
[0190013fc0404c]*   0.30%  0.18% f  120 t     12587004 p      7864320 w            0 tpp    1 tpf    104891 ppf     65536
```
</details>
<details>
<summary>After</summary>

```
GS stats
       key       | frames | prims |       runtime       |          pixels
                 |        |  #/f  |   pct   ms/f  ns/px |    #/f   #/prim overdraw
001518193fce8864 |    120 |  1685 | 16.13%   3.4   11.6 |   292706    173  4.45%
000d9d051623904c |    120 |    20 | 10.35%   2.2    7.6 |   286720  14336  0.00%
001518153fce8864 |    120 |   387 |  7.49%   1.6   11.4 |   137281    354  2.55%
001d95013fc3804d |    120 |    20 |  6.59%   1.4    9.6 |   143360   7168  0.00%
001d95051923804d |    120 |    20 |  6.43%   1.3    9.4 |   143360   7168  0.00%
00111d053fc3904c |    120 |  1006 |  4.41%   0.9   16.2 |    57067     56 33.81%
000918193fce8864 |    120 |   925 |  4.34%   0.9   18.4 |    49359     53 25.57%
001118193fce9064 |    120 |   123 |  3.38%   0.7   13.9 |    50917    413 19.48%
010990013fc5904d |    120 |   560 |  3.26%   0.7    4.8 |   143360    256  0.00%
001d9d013fc1904d |    120 |    20 |  3.02%   0.6    4.4 |   143360   7168  0.00%
011191851a25804c |    120 |  1120 |  3.00%   0.6    4.4 |   143360    128  0.00%
011190051a25804c |    120 |  1120 |  2.96%   0.6    4.3 |   143360    128  0.00%
000d18193fce8864 |    120 |  1711 |  2.62%   0.5   21.7 |    25320     14 34.02%
000198052a60404c |    120 |    15 |  2.61%   0.5    1.8 |   301800  20120  0.38%
011190053fc5804c |    120 |  1120 |  2.59%   0.5    3.8 |   143360    128  0.00%
001118193fce8864 |    120 |  1969 |  2.58%   0.5   24.2 |    22319     11 29.11%
000190093fc04054 |    120 |    23 |  1.62%   0.3    0.8 |   404200  17573  0.00%
00199d0e112181d4 |    120 |     8 |  1.51%   0.3    2.8 |   114688  14336  0.00%
008d181f112e8764 |    120 |    67 |  1.33%   0.3   18.3 |    15232    227 20.19%
0015181b3fce8964 |    120 |    28 |  1.06%   0.2   13.6 |    16331    583 10.92%
000180083fc04057 |    120 |    38 |  1.04%   0.2    0.3 |   701904  18471  0.00%
001d9d0e112181d4 |    120 |     5 |  0.99%   0.2    2.9 |    71680  14336  0.00%
0001900d3fc04054 |    120 |    10 |  0.99%   0.2    0.7 |   286720  28672  0.00%
001515051127904d |    120 |    18 |  0.96%   0.2    8.4 |    23936   1329  4.69%
001518193fce8064 |    120 |   289 |  0.92%   0.2   33.3 |     5803     20 38.64%
000190053fc0404c |    120 |    11 |  0.80%   0.2    0.6 |   290816  26437  0.00%
00159d0e112181d4 |    120 |     4 |  0.71%   0.1    2.6 |    57344  14336  0.00%
006d181f112e8764 |    120 |   398 |  0.61%   0.1   59.3 |     2172      5 61.54%
000d18193fce9064 |    120 |    22 |  0.51%   0.1   12.5 |     8491    385 12.93%
001515051127804d |    120 |     8 |  0.50%   0.1    9.1 |    11583   1447  5.07%
001915051127904d |    120 |     2 |  0.45%   0.1    8.0 |    11970   5985  2.68%
006d181f112e8f64 |    120 |   373 |  0.36%   0.1   45.0 |     1654      4 54.89%
001118193fce8064 |    120 |   168 |  0.33%   0.1   58.8 |     1178      7 61.98%
00119d0e112181d4 |    120 |     2 |  0.33%   0.1    2.4 |    28672  14336  0.00%
001195051127804d |    121 |    74 |  0.32%   0.1   13.0 |     5167     69 22.97%
00111815112e8864 |    120 |   341 |  0.27%   0.1   78.4 |      732      2 62.61%
0015181b3fce9164 |    120 |    10 |  0.21%   0.0   13.1 |     3372    337 18.55%
001918193fce8864 |    120 |   126 |  0.20%   0.0   80.0 |      513      4 66.35%
0015181b3fce8164 |    120 |    16 |  0.18%   0.0   12.5 |     3063    191 19.82%
000190013fc0404c |    120 |     4 |  0.17%   0.0    0.5 |    65536  16384  0.00%
000d9d0e112181d4 |    120 |     1 |  0.16%   0.0    2.4 |    14336  14336  0.00%
000110051120404d |    120 |    15 |  0.15%   0.0    2.9 |    11104    740  6.36%
000d18193fce8064 |    120 |    59 |  0.15%   0.0   51.0 |      619     10 56.54%
000918193fce8064 |    120 |    37 |  0.14%   0.0   38.8 |      745     19 47.05%
000d15051127904d |    120 |     6 |  0.11%   0.0   13.0 |     1846    307 17.37%
000110051920484d |    120 |    72 |  0.10%   0.0   19.5 |     1126     15 49.17%
000d15051127804d |    120 |     4 |  0.09%   0.0   11.3 |     1764    441 14.84%
001115051127904d |    120 |     6 |  0.09%   0.0   11.0 |     1776    296  8.62%
000915051127804d |    120 |    20 |  0.08%   0.0   19.2 |      892     44 24.49%
000d181f112c8f64 |    120 |    34 |  0.07%   0.0   31.4 |      438     12 49.48%
000d1517163a8864 |    120 |   107 |  0.06%   0.0  181.3 |       70      0 66.98%
000d181f112e8f64 |    120 |    21 |  0.05%   0.0  114.9 |       94      4 72.51%
000118193fc84064 |    120 |    91 |  0.05%   0.0  137.4 |       71      0 70.21%
000915051127904d |    120 |    14 |  0.05%   0.0   20.6 |      470     33 34.36%
000d181b3fce8964 |    120 |    29 |  0.04%   0.0   96.1 |       94      3 66.19%
000118193fc84864 |    120 |    26 |  0.04%   0.0   86.1 |       93      3 67.31%
000915193fce8864 |    120 |    45 |  0.03%   0.0  211.8 |       29      0 66.48%
000915193fce8064 |    120 |    18 |  0.03%   0.0  100.6 |       54      3 59.09%
0009181b3fce8964 |    120 |    15 |  0.02%   0.0  151.8 |       32      2 69.81%
0011181b3fce8164 |    120 |    13 |  0.02%   0.0  162.9 |       24      1 59.17%
000110051920404d |    120 |    12 |  0.02%   0.0   10.9 |      358     29 31.06%
00091d193fce8064 |    120 |    15 |  0.02%   0.0  181.4 |       21      1 67.19%
0011151b3fce8964 |    120 |    26 |  0.02%   0.0  325.5 |       11      0 75.00%
0009151b3fce8164 |    120 |    12 |  0.02%   0.0  463.3 |        7      0 73.21%
000915071127814d |    120 |     2 |  0.01%   0.0   18.2 |      168     84 29.41%
00091515112e8064 |    120 |    10 |  0.01%   0.0  286.3 |       10      1 61.54%
000915051125904d |    120 |     2 |  0.01%   0.0   11.3 |      216    108 32.50%
000d181f112e8764 |    120 |    16 |  0.01%   0.0  134.9 |       18      1 75.00%
001115193fce8864 |    120 |     8 |  0.01%   0.0  113.9 |       20      2 60.58%
007118193fce8864 |    120 |     4 |  0.01%   0.0  123.5 |       18      4 40.00%
0011181f112e8f64 |    120 |     2 |  0.01%   0.0   19.0 |      111     55 22.92%
0001181511284864 |    120 |    11 |  0.01%   0.0  336.2 |        6      0 70.00%
001118193fcc8864 |    120 |    10 |  0.01%   0.0  250.7 |        8      0 69.23%
000098013fc0404c |    120 |     2 |  0.01%   0.0    6.3 |      316    158 35.77%
000190013fc0404e |    120 |     1 |  0.01%   0.0    0.5 |     4096   4096  0.00%
0009181b3fce8164 |    120 |     5 |  0.01%   0.0  618.7 |        3      0 70.00%
00111d193fce8064 |    120 |     7 |  0.01%   0.0  666.8 |        2      0 75.00%
000d1515162a8864 |    120 |    12 |  0.01%   0.0 1107.2 |        1      0 75.00%
0009151d112e8864 |    120 |    12 |  0.01%   0.0 1009.1 |        1      0 75.00%
000d15193fce8864 |    120 |     5 |  0.01%   0.0  751.5 |        2      0 75.00%
0009151b3fcc8164 |    120 |     7 |  0.01%   0.0   70.9 |       21      3 41.67%
000915153fce8064 |    120 |    12 |  0.01%   0.0  891.1 |        1      0 75.00%
00091515112e8864 |    120 |     4 |  0.01%   0.0  664.5 |        2      0 75.00%
00091d193fce8864 |    120 |     3 |  0.01%   0.0  837.6 |        1      0 75.00%
0009101b3fce8164 |    120 |     4 |  0.01%   0.0  770.9 |        1      0 75.00%
000d1515112e8064 |    120 |     4 |  0.01%   0.0  282.6 |        4      1 71.43%
0009181f112e8764 |     60 |     2 |  0.00%   0.0 1813.7 |        1      0 75.00%
000d151b3fce8964 |    120 |     2 |  0.00%   0.0 1748.0 |        0      0 75.00%
000115051123804d |    120 |     2 |  0.00%   0.0  108.5 |        8      4 42.86%
0001181511284064 |     60 |     7 |  0.00%   0.0  152.2 |       11      1 60.71%
000910193fce8064 |     60 |     3 |  0.00%   0.0  417.3 |        4      1 50.00%
0011151b3fce8164 |     60 |     6 |  0.00%   0.0  548.1 |        3      0 75.00%
000190013fc0404d |    120 |    10 |  0.00%   0.0    0.0 |   143360  14336  0.00%
00111d1b3fce8964 |     60 |     4 |  0.00%   0.0 1280.8 |        1      0 75.00%
00111d1b3fce8164 |     60 |     2 |  0.00%   0.0  375.2 |        3      1 62.50%
000198013fc0404c |    120 |     1 |  0.00%   0.0  440.2 |        1      1  0.00%
```
</details>

### Rationale behind Changes
Old one was pretty hard to read

### Suggested Testing Steps
Uncomment that line and look at the printouts
Also make sure I didn't slow down the software renderer when not in use