### PR TITLE
vs: fix an oversight

### DIFF
--- a/common/vsprops/CommonLibrary.props
+++ b/common/vsprops/CommonLibrary.props
@@ -1,12 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Label="UserMacros">
-    <ProjectRootDir>$(ProjectDir)..\..</ProjectRootDir>
-    <SvnRootDir>$(ProjectRootDir)\..</SvnRootDir>
-  </PropertyGroup>
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30128.1</_ProjectFileVersion>
-    <OutDir>$(SvnRootDir)\deps\$(PlatformName)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)deps\$(PlatformName)\$(Configuration)\</OutDir>
     <IntDir>$(PlatformName)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -25,12 +21,4 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <BuildMacro Include="ProjectRootDir">
-      <Value>$(ProjectRootDir)</Value>
-    </BuildMacro>
-    <BuildMacro Include="SvnRootDir">
-      <Value>$(SvnRootDir)</Value>
-    </BuildMacro>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes
when I merged the utils and emitter project in #4707 I neglected to update the SVNRootDir macro so it was causing common libraries to not be written to the correct directory.

don't use this macro anymore so just remove it make output relative to solution dir instead

### Rationale behind Changes
fixes bug

### Suggested Testing Steps
build
