### PR TITLE
microVU: Replace XGKick hack with synced XGKick option

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -15093,6 +15093,8 @@ SLES-54169:
 SLES-54170:
   name: "Jaws Unleashed"
   region: "PAL-M5"
+  gameFixes:
+    - XGKickHack # Fixes GS packet errors (and potential crash).
 SLES-54171:
   name: "Yakuza"
   region: "PAL-M5"
@@ -36516,6 +36518,8 @@ SLUS-21062:
   name: "Jaws Unleashed"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - XGKickHack # Fixes GS packet errors (and potential crash).
 SLUS-21063:
   name: "Shining Tears"
   region: "NTSC-U"

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -11349,6 +11349,8 @@ SLES-52392:
 SLES-52393:
   name: "Pinball Fun"
   region: "PAL-E"
+  gameFixes:
+    - XGKickHack # Fixes SPS and console spam (The Tennis).
 SLES-52394:
   name: "UFEA Euro 2004"
   region: "PAL-E"
@@ -19680,6 +19682,8 @@ SLPM-62218:
 SLPM-62219:
   name: "Simple 2000 Series Vol.08 - The Tennis"
   region: "NTSC-J"
+  gameFixes:
+    - XGKickHack # Fixes SPS and console spam.
 SLPM-62221:
   name: "Winning Post 5 - Max 2002"
   region: "NTSC-J"
@@ -19748,6 +19752,8 @@ SLPM-62247:
 SLPM-62248:
   name: "Simple 2000 Series Vol.05 - The Love Mahjong"
   region: "NTSC-J"
+  gameFixes:
+    - XGKickHack # Fixes SPS.
 SLPM-62249:
   name: "Hello Kitty Star Light - Isogasi Cube"
   region: "NTSC-J"
@@ -19891,8 +19897,10 @@ SLPM-62305:
   name: "Othello [SuperLite 2000]"
   region: "NTSC-J"
 SLPM-62307:
-  name: "Simple 2000 Series Vol.26 - The Paintball X 3"
+  name: "Simple 2000 Series Vol.26 - The Pinball X 3"
   region: "NTSC-J"
+  gameFixes:
+    - XGKickHack # Fixes SPS and console spam.
 SLPM-62308:
   name: "Simple 2000 Series Vol.24 - The Bowling"
   region: "NTSC-J"
@@ -20766,6 +20774,8 @@ SLPM-62635:
 SLPM-62636:
   name: "Simple 2000 Series 2-in-1 Vol.1 - The Tennis & The Snowboard [Disc1of2]"
   region: "NTSC-J"
+  gameFixes:
+    - XGKickHack # Fixes SPS and console spam (The Tennis).
 SLPM-62637:
   name: "Simple 2000 Series 2-in-1 Vol.1 - The Tennis & The Snowboard [Disc2of2]"
   region: "NTSC-J"
@@ -22315,6 +22325,8 @@ SLPM-65393:
 SLPM-65394:
   name: "Love Smash! 5"
   region: "NTSC-J"
+  gameFixes:
+    - XGKickHack # Fixes bad Geometry.
 SLPM-65395:
   name: "Digi-Charat Fantasy"
   region: "NTSC-J"
@@ -28504,6 +28516,8 @@ SLPS-20453:
   name: "Simple 2000 Series Ultimate Vol.29 - K-1 Premium 2005 Dynamite!!"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - XGKickHack # Fixes black and white fighters.
 SLPS-20454:
   name: "Simple 2000 Series Vol.93 - The Right Brain Drill"
   region: "NTSC-J"

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -10381,6 +10381,8 @@ SLES-51860:
   name: "Tennis Court Smash"
   region: "PAL-E"
   compat: 3
+  gameFixes:
+    - XGKickHack # Fixes bad Geometry.
 SLES-51861:
   name: "Bowling Xciting"
   region: "PAL-E"
@@ -20757,6 +20759,8 @@ SLPM-62634:
 SLPM-62635:
   name: "Simple 2000 Series Vol.26 - The Love Smash! 5.1"
   region: "NTSC-J"
+  gameFixes:
+    - XGKickHack # Fixes bad Geometry.
 SLPM-62636:
   name: "Simple 2000 Series 2-in-1 Vol.1 - The Tennis & The Snowboard [Disc1of2]"
   region: "NTSC-J"
@@ -33753,18 +33757,7 @@ SLUS-20419:
   roundModes:
     eeRoundMode: 0  # Fixes crash when using the Subaru.
   gameFixes:
-    - XGKickHack # Fixes SPS while ingame (with following patch)
-  patches:
-    5838E074:
-      content: |-
-        author=kozarovv
-        // Rearrange XGKick timing to fix SPS
-        patch=1,EE,0020efa0,word,8000033c
-        patch=1,EE,0020efd8,word,80004efc
-        patch=1,EE,0020f040,word,8000033c
-        patch=1,EE,0020f0b0,word,80004efc
-        patch=1,EE,0020f118,word,8000033c
-        patch=1,EE,0020f188,word,80004efc     
+    - XGKickHack # Fixes SPS while ingame     
 SLUS-20420:
   name: "Star Wars - Bounty Hunter"
   region: "NTSC-U"

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -561,7 +561,7 @@ struct Gif_Unit
 	}
 
 	// Returns GS Packet Size in bytes
-	u32 GetGSPacketSize(GIF_PATH pathIdx, u8* pMem, u32 offset = 0, u32 size = ~0u)
+	u32 GetGSPacketSize(GIF_PATH pathIdx, u8* pMem, u32 offset = 0, u32 size = ~0u, bool flush = false)
 	{
 		u32 memMask = pathIdx ? ~0u : 0x3fffu;
 		u32 curSize = 0;
@@ -576,7 +576,7 @@ struct Gif_Unit
 			}
 			if (curSize >= size)
 				return size;
-			if(!EmuConfig.Cpu.Recompiler.EnableVU1 && pathIdx == GIF_PATH_1)
+			if(((flush && gifTag.tag.EOP) || !flush) && (CHECK_XGKICKHACK || !EmuConfig.Cpu.Recompiler.EnableVU1))
 			{
 				return curSize | ((u32)gifTag.tag.EOP << 31);
 			}

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -174,13 +174,13 @@ struct __aligned16 VURegs
 	u8* Mem;
 	u8* Micro;
 
-	bool xgkickenable;
-	bool xgkickendpacket;
 	u32 xgkickaddr;
 	u32 xgkickdiff;
 	u32 xgkicksizeremaining;
 	u32 xgkicklastcycle;
 	u32 xgkickcyclecount;
+	u32 xgkickenable;
+	u32 xgkickendpacket;
 
 	u8 VIBackupCycles;
 	u32 VIOldValue;

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -215,7 +215,7 @@ __fi void _vuTestPipes(VURegs* VU)
 	{
 		if (VU1.xgkickenable)
 		{
-			_vuXGKICKTransfer((VU1.cycle - VU1.xgkicklastcycle), false);
+			_vuXGKICKTransfer((VU1.cycle - VU1.xgkicklastcycle) - 1, false);
 		}
 	}
 }
@@ -2618,7 +2618,7 @@ static __ri void _vuXITOP(VURegs* VU)
 		VU->VI[_It_].US[0] = VU->GetVifRegs().itop;
 }
 
-void _vuXGKICKTransfer(u32 cycles, bool flush)
+void _vuXGKICKTransfer(s32 cycles, bool flush)
 {
 	if (!VU1.xgkickenable)
 		return;

--- a/pcsx2/VUops.h
+++ b/pcsx2/VUops.h
@@ -59,4 +59,4 @@ extern void _vuTestUpperStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuTestLowerStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuAddUpperStalls(VURegs * VU, _VURegsNum *VUregsn);
 extern void _vuAddLowerStalls(VURegs * VU, _VURegsNum *VUregsn);
-extern void _vuXGKICKTransfer(u32 cycles, bool flush);
+extern void _vuXGKICKTransfer(s32 cycles, bool flush);

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -49,8 +49,9 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("VU XGkick Hack - For Erementar Gerad."),
-			wxEmptyString
+			_("VU XGkick Sync - Use accurate timing for VU XGKicks (Slower)"),
+			pxEt(L"Fixes graphical errors on WRC, Erementar Gerad, Tennis Court Smash and others."
+			)
 		},
 		{
 			_("EE timing hack - Multi purpose hack. Try if all else fails."),

--- a/pcsx2/x86/microVU_Analyze.inl
+++ b/pcsx2/x86/microVU_Analyze.inl
@@ -341,6 +341,7 @@ __fi void mVUanalyzeLQ(mV, int Ft, int Is, bool writeIs)
 
 __fi void mVUanalyzeSQ(mV, int Fs, int It, bool writeIt)
 {
+	mVUlow.isMemWrite = true;
 	analyzeReg1(mVU, Fs, mVUlow.VF_read[0]);
 	analyzeVIreg1(mVU, It, mVUlow.VI_read[0]);
 	if (writeIt)
@@ -477,9 +478,15 @@ __fi void mVUanalyzeCflag(mV, int It)
 
 __fi void mVUanalyzeXGkick(mV, int Fs, int xCycles)
 {
+	mVUlow.isKick = true;
+	mVUregs.xgkickcycles = 0;
+	mVUlow.kickcycles = 0;
 	analyzeVIreg1(mVU, Fs, mVUlow.VI_read[0]);
-	analyzeXGkick1(); // Stall will cause mVUincCycles() to trigger pending xgkick
-	analyzeXGkick2(xCycles);
+	if (!CHECK_XGKICKHACK)
+	{
+		analyzeXGkick1(); // Stall will cause mVUincCycles() to trigger pending xgkick
+		analyzeXGkick2(xCycles);
+	}
 	// Note: Technically XGKICK should stall on the next instruction,
 	// this code stalls on the same instruction. The only case where this
 	// will be a problem with, is if you have very-specifically placed

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -49,6 +49,7 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit)
 		mVUcycles -= 100;
 		qInst = mVU.q;
 		pInst = mVU.p;
+		mVUregs.xgkickcycles = 0;
 		if (mVUinfo.doDivFlag)
 		{
 			sFLAG.doFlag = true;
@@ -59,6 +60,11 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit)
 		if (mVUinfo.doXGKICK && xPC >= mVUinfo.XGKICKPC)
 		{
 			mVU_XGKICK_DELAY(mVU);
+		}
+		if (isVU1 && CHECK_XGKICKHACK)
+		{
+			mVUlow.kickcycles = 99;
+			mVU_XGKICK_SYNC(mVU, true);
 		}
 		if (!isVU1)
 			xFastCall((void*)mVU0clearlpStateJIT);
@@ -163,6 +169,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit)
 		mVUcycles -= 100;
 		qInst = mVU.q;
 		pInst = mVU.p;
+		mVUregs.xgkickcycles = 0;
 		if (mVUinfo.doDivFlag)
 		{
 			sFLAG.doFlag = true;
@@ -172,6 +179,11 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit)
 		if (mVUinfo.doXGKICK)
 		{
 			mVU_XGKICK_DELAY(mVU);
+		}
+		if (isVU1 && CHECK_XGKICKHACK)
+		{
+			mVUlow.kickcycles = 99;
+			mVU_XGKICK_SYNC(mVU, true);
 		}
 		if (!isVU1)
 			xFastCall((void*)mVU0clearlpStateJIT);

--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -49,11 +49,12 @@ union __aligned16 microRegInfo
 				u8 viBackUp;       // VI reg number that was written to on branch-delay slot
 				u8 blockType;      // 0 = Normal; 1,2 = Compile one instruction (E-bit/Branch Ending)
 				u8 r;
-				u8 mbitinblock;
 			};
-			u32 quick32[3];
+			u32 quick32[4];
 		};
 
+		u32 xgkickcycles;
+		u8 mbitinblock;
 		u8 vi15v; // 'vi15' constant is valid
 		u16 vi15; // Constant Prop Info for vi15
 
@@ -64,12 +65,12 @@ union __aligned16 microRegInfo
 		};
 	};
 
-	u128 full128[160 / sizeof(u128)];
-	u64  full64[160 / sizeof(u64)];
-	u32  full32[160 / sizeof(u32)];
+	u128 full128[176 / sizeof(u128)];
+	u64  full64[176 / sizeof(u64)];
+	u32  full32[176 / sizeof(u32)];
 };
 
-static_assert(sizeof(microRegInfo) == 160, "microRegInfo was not 160 bytes");
+static_assert(sizeof(microRegInfo) == 176, "microRegInfo was not 176 bytes");
 
 struct microProgram;
 struct microJumpCache
@@ -139,6 +140,7 @@ struct microLowerOp
 	microVIreg VI_read[2];    // VI regs read by this instruction
 	microConstInfo constJump; // Constant Reg Info for JR/JARL instructions
 	u32  branch;     // Branch Type (0 = Not a Branch, 1 = B. 2 = BAL, 3~8 = Conditional Branches, 9 = JR, 10 = JALR)
+	u32  kickcycles; // Number of xgkick cycles accumulated by this instruction
 	bool badBranch;  // This instruction is a Branch who has another branch in its Delay Slot
 	bool evilBranch; // This instruction is a Branch in a Branch Delay Slot (Instruction after badBranch)
 	bool isNOP;      // This instruction is a NOP
@@ -148,6 +150,8 @@ struct microLowerOp
 	bool memReadIs;  // Read Is (VI reg) from memory (used by branches)
 	bool memReadIt;  // Read If (VI reg) from memory (used by branches)
 	bool readFlags;  // Current Instruction reads Status, Mac, or Clip flags
+	bool isMemWrite; // Current Instruction writes to VU memory
+	bool isKick;     // Op is a kick so don't count kick cycles
 };
 
 struct microFlagInst
@@ -312,6 +316,14 @@ public:
 					mVUsaveReg(xmm(i), ptr[&getVF(mapX.VFreg)], mapX.xyzw, 1);
 			}
 		}
+	}
+
+	bool checkCachedReg(int regId)
+	{
+		if (regId < xmmTotal)
+			return xmmMap[regId].VFreg >= 0;
+		else
+			return false;
 	}
 
 	void clearReg(const xmm& reg) { clearReg(reg.Id); }

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -1634,15 +1634,19 @@ void __fastcall _vuXGKICKTransfermVU(bool flush)
 
 static __fi void mVU_XGKICK_SYNC(mV, bool flush)
 {
+	// Add the single cycle remainder after this instruction, some games do the store
+	// on the second instruction after the kick and that needs to go through first
+	// but that's VERY close..
 	xTEST(ptr32[&VU1.xgkickenable], 0x1);
 	xForwardJZ32 skipxgkick;
-	xADD(ptr32[&VU1.xgkickcyclecount], mVUlow.kickcycles);
+	xADD(ptr32[&VU1.xgkickcyclecount], mVUlow.kickcycles-1);
 	xCMP(ptr32[&VU1.xgkickcyclecount], 2);
 	xForwardJL32 needcycles;
 	mVUbackupRegs(mVU, true, true);
 	xFastCall(_vuXGKICKTransfermVU, flush);
 	mVUrestoreRegs(mVU, true, true);
 	needcycles.SetTarget();
+	xADD(ptr32[&VU1.xgkickcyclecount], 1);
 	skipxgkick.SetTarget();
 }
 

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -354,17 +354,6 @@ static const bool doDBitHandling = false;
 // This hack only updates the Status Flag on blocks that will read it.
 // Most blocks do not read status flags, so this is a big speedup.
 
-//------------------------------------------------------------------
-// Unknown Data
-//------------------------------------------------------------------
-
-// XG Kick Transfer Delay Amount
-#define mVU_XGKICK_CYCLES ((CHECK_XGKICKHACK) ? 6 : 1)
-// Its unknown at recompile time how long the xgkick transfer will take
-// so give it a value that makes games happy :) (SO3 is fine at 1 cycle delay)
-
-//------------------------------------------------------------------
-
 extern void mVUmergeRegs(const xmm& dest, const xmm& src, int xyzw, bool modXYZW = false);
 extern void mVUsaveReg(const xmm& reg, xAddressVoid ptr, int xyzw, bool modXYZW);
 extern void mVUloadReg(const xmm& reg, xAddressVoid ptr, int xyzw);

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -145,13 +145,14 @@ void mVUmergeRegs(const xmm& dest, const xmm& src, int xyzw, bool modXYZW)
 //------------------------------------------------------------------
 
 // Backup Volatile Regs (EAX, ECX, EDX, MM0~7, XMM0~7, are all volatile according to 32bit Win/Linux ABI)
-__fi void mVUbackupRegs(microVU& mVU, bool toMemory = false)
+__fi void mVUbackupRegs(microVU& mVU, bool toMemory = false, bool onlyNeeded = false)
 {
 	if (toMemory)
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			xMOVAPS(ptr128[&mVU.xmmBackup[i][0]], xmm(i));
+			if (!onlyNeeded || mVU.regAlloc->checkCachedReg(i) || xmmPQ.Id == i)
+				xMOVAPS(ptr128[&mVU.xmmBackup[i][0]], xmm(i));
 		}
 	}
 	else
@@ -162,13 +163,14 @@ __fi void mVUbackupRegs(microVU& mVU, bool toMemory = false)
 }
 
 // Restore Volatile Regs
-__fi void mVUrestoreRegs(microVU& mVU, bool fromMemory = false)
+__fi void mVUrestoreRegs(microVU& mVU, bool fromMemory = false, bool onlyNeeded = false)
 {
 	if (fromMemory)
 	{
 		for (int i = 0; i < 8; i++)
 		{
-			xMOVAPS(xmm(i), ptr128[&mVU.xmmBackup[i][0]]);
+			if (!onlyNeeded || mVU.regAlloc->checkCachedReg(i) || xmmPQ.Id == i)
+				xMOVAPS(xmm(i), ptr128[&mVU.xmmBackup[i][0]]);
 		}
 	}
 	else


### PR DESCRIPTION
### Description of Changes

Replaces XGKick hack option with an XGKick Sync option which provides accurate behaviour for the VU

Fixes Tennis Court Smash and Love Smash games which previously couldn't be fixed.
WRC no longer requires a patch, just the xgkickhack option.
Simple 2000 Series Vol.26 - The Pinball X 3 SPS and console spam.

Note: it's not a hack anymore, it just has to be called that in the gamedb :P

### Rationale behind Changes
Some games couldn't be fixes with the traditional hack.

### Suggested Testing Steps
Try games that require the XGKick hack, make sure they still work (you can search the gamedb for "XGKick" if you need an aid).

If you have games that have always experienced errors in the console (GS packet exceeds VU memory) or spikey polygons, give the new XGKick Sync option a try, it might fix it.
