### PR TITLE
SPU2: Disallow KeyOn within 2T of last KeyOn

### DIFF
--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1979,6 +1979,12 @@ void StartVoices(int core, u32 value)
 		if (!((value >> vc) & 1))
 			continue;
 
+		if ((Cycles - Cores[core].Voices[vc].PlayCycle) < 2)
+		{
+			ConLog("Attempt to start voice %d on core %d in less than 2T since last KeyOn\n", vc, core);
+			continue;
+		}
+
 		Cores[core].Voices[vc].Start();
 
 		if (IsDevBuild)


### PR DESCRIPTION
### Description of Changes
Disallow KeyOn less than 2T (768x2 cycles) of the previous KeyOn for a voice.
Fixes Legend of Spyro New Beginning hang

### Rationale behind Changes
KeyOn/Off events shouldn't happen within 2T's of the last one for each voice (possibly the whole register, but unsure on that, per voice seems okay)

### Suggested Testing Steps
uhh, any games you know had problems previously with delay cycles, that would be great.
