### PR TITLE
common: add DynamicLibrary

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(common)
 # x86emitter sources
 target_sources(common PRIVATE
 	AlignedMalloc.cpp
+	DynamicLibrary.cpp
 	VirtualMemory.cpp
 	EventSource.inl
 	SafeArray.inl
@@ -60,6 +61,7 @@ target_sources(common PRIVATE
 	boost_spsc_queue.hpp
 	Console.h
 	Dependencies.h
+	DynamicLibrary.h
 	EventSource.h
 	Exceptions.h
 	FastJmp.h
@@ -117,10 +119,10 @@ endif()
 if(WIN32)
 	enable_language(ASM_MASM)
 	target_sources(common PRIVATE FastJmp.asm)
-	target_link_libraries(common PUBLIC pthreads4w Winmm.lib)
+	target_link_libraries(common PUBLIC pthreads4w WIL::WIL Winmm.lib)
 endif()
 
-target_link_libraries(common PRIVATE ${LIBC_LIBRARIES} PUBLIC wxWidgets::all)
+target_link_libraries(common PRIVATE ${LIBC_LIBRARIES} PUBLIC wxWidgets::all fmt)
 target_compile_features(common PUBLIC cxx_std_17)
 target_include_directories(common PUBLIC ../3rdparty/include ../)
 target_compile_definitions(common PUBLIC "${PCSX2_DEFS}")

--- a/common/DynamicLibrary.cpp
+++ b/common/DynamicLibrary.cpp
@@ -1,0 +1,168 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef _WIN32
+#include <Windows.h>
+#include <wil/com.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#include <fmt/core.h>
+#include "common/DynamicLibrary.h"
+
+namespace Common
+{
+#if defined(_WIN32)
+	struct DynamicLibrary::Impl
+	{
+		static constexpr const char* ExtName()
+		{
+			return "dll";
+		}
+
+		bool Open(const char* name)
+		{
+			constexpr DWORD flags =
+				LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
+				LOAD_LIBRARY_SEARCH_SYSTEM32;
+
+			m_handle.reset(LoadLibraryExA(name, nullptr, flags));
+
+			return IsOpen();
+		}
+
+		void Close()
+		{
+			m_handle.reset();
+		}
+
+		void* GetSymbolByName(const char* name)
+		{
+			auto sym = GetProcAddress(m_handle.get(), name);
+
+			return reinterpret_cast<void*>(sym);
+		}
+
+		void* GetSymbolByOrdinal(const uint ordinal)
+		{
+			auto sym = GetProcAddress(m_handle.get(), reinterpret_cast<LPCSTR>(ordinal));
+
+			return reinterpret_cast<void*>(sym);
+		}
+
+		bool IsOpen() const
+		{
+			return m_handle != nullptr;
+		}
+
+		wil::unique_hmodule m_handle{ nullptr };
+	};
+#else
+	struct DynamicLibrary::Impl
+	{
+		static constexpr const char* ExtName()
+		{
+#if defined(__APPLE__)
+			return "dylib";
+#else
+			return "so";
+#endif
+		}
+
+		bool Open(const char* name)
+		{
+			m_handle = dlopen(name, RTLD_NOW);
+
+			return IsOpen();
+		}
+
+		void Close()
+		{
+			if (m_handle)
+				dlclose(m_handle);
+
+			m_handle = nullptr;
+		}
+
+		void* GetSymbolByName(const char* name)
+		{
+			return dlsym(m_handle, name);
+		}
+
+		void* GetSymbolByOrdinal(const int /*ordinal*/)
+		{
+			return nullptr;
+		}
+
+		bool IsOpen() const
+		{
+			return m_handle != nullptr;
+		}
+
+		void* m_handle{ nullptr };
+	};
+#endif
+
+	DynamicLibrary::DynamicLibrary()
+		: m_impl(std::make_unique<Impl>())
+	{
+	}
+
+	DynamicLibrary::DynamicLibrary(const char* path)
+		: m_impl(std::make_unique<Impl>())
+	{
+		Open(path);
+	}
+
+	DynamicLibrary::~DynamicLibrary()
+	{
+		m_impl->Close();
+	}
+
+	bool DynamicLibrary::Open(const char* path)
+	{
+		const std::string full_name =
+			fmt::format("{}.{}", path, Impl::ExtName());
+
+		return m_impl->Open(full_name.data());
+	}
+
+	void DynamicLibrary::Close()
+	{
+		m_impl->Close();
+	}
+
+	bool DynamicLibrary::IsOpen() const
+	{
+		return m_impl->IsOpen();
+	}
+
+	void* DynamicLibrary::GetSymbolByName(const char* name) const
+	{
+		if (!IsOpen())
+			return nullptr;
+
+		return m_impl->GetSymbolByName(name);
+	}
+
+	void* DynamicLibrary::GetSymbolByOrdinal(const uint id) const
+	{
+		if (!IsOpen())
+			return nullptr;
+
+		return m_impl->GetSymbolByOrdinal(id);
+	}
+}

--- a/common/DynamicLibrary.h
+++ b/common/DynamicLibrary.h
@@ -1,0 +1,75 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <string_view>
+#include <memory>
+
+#include "common/Pcsx2Types.h"
+
+namespace Common
+{
+	// This is a small uility class for loading dynamic libraries (DLL on windows, dynlib on mac, so on linux)
+	// ex:
+	// auto lib = Common::Dynalib("xinput1_4"); // alternatively lib.Open("xinput1_4");
+	//
+	// //  make sure it's open
+	// if(!lib.IsOpen())
+	//     // error
+	//
+	// auto sym = lib.GetSymbol<_XInputEnable>("XInputEnable");
+	// if(!sym)
+	//     // error
+	//
+	// lib.Close(); // will be done automatically when lib falls out of scope
+	class DynamicLibrary
+	{
+	public:
+		DynamicLibrary();
+		// same as Open
+		DynamicLibrary(const char* path);
+		~DynamicLibrary();
+
+		// open a dynalib using it's name minus ext
+		bool Open(const char* path);
+		// close the dynalib
+		void Close();
+
+		// check if the dynalib was successfully loaded
+		bool IsOpen() const;
+
+		// get a symbol automatically casted to the correct type
+		template<typename T>
+		T GetSymbol(const char* name)
+		{
+			return reinterpret_cast<T>(GetSymbolByName(name));
+		}
+
+		// get a symbol by it's ordinal value
+		// this is needed for some xinput features
+		// note: win32 only, everything else returns nullptr
+		template <typename T>
+		T GetSymbolOrdinal(const uint id)
+		{
+			return reinterpret_cast<T>(GetSymbolByOrdinal(id));
+		}
+	private:
+		void* GetSymbolByName(const char* name) const;
+		void* GetSymbolByOrdinal(const uint ordinal) const;
+
+		struct Impl;
+		std::unique_ptr<Impl> m_impl;
+	};
+}

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <ClCompile Include="AlignedMalloc.cpp" />
     <ClCompile Include="Console.cpp" />
+    <ClCompile Include="DynamicLibrary.cpp" />
     <ClCompile Include="Exceptions.cpp" />
     <ClCompile Include="FastFormatString.cpp" />
     <ClCompile Include="FastJmp.cpp">
@@ -93,6 +94,7 @@
     </MASM>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="DynamicLibrary.h" />
     <ClInclude Include="EmbeddedImage.h" />
     <ClInclude Include="boost_spsc_queue.hpp" />
     <ClInclude Include="FastJmp.h" />

--- a/common/common.vcxproj.filters
+++ b/common/common.vcxproj.filters
@@ -115,6 +115,9 @@
     <ClCompile Include="SettingsWrapper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DynamicLibrary.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Assertions.h">
@@ -265,6 +268,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SettingsWrapper.h">
+          <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DynamicLibrary.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "PrecompiledHeader.h"
+#include "common/DynamicLibrary.h"
 #include "GSUtil.h"
 #include <locale>
 #include <codecvt>
@@ -201,10 +202,9 @@ bool GSUtil::CheckDXGI()
 {
 	if (0 == s_DXGI)
 	{
-		HMODULE hmod = LoadLibrary(L"dxgi.dll");
-		s_DXGI = hmod ? 1 : -1;
-		if (hmod)
-			FreeLibrary(hmod);
+		Common::DynamicLibrary lib("dxgi");
+
+		s_DXGI = lib.IsOpen();
 	}
 
 	return s_DXGI > 0;
@@ -217,10 +217,9 @@ bool GSUtil::CheckD3D11()
 
 	if (0 == s_D3D11)
 	{
-		HMODULE hmod = LoadLibrary(L"d3d11.dll");
-		s_D3D11 = hmod ? 1 : -1;
-		if (hmod)
-			FreeLibrary(hmod);
+		Common::DynamicLibrary lib("d3d11");
+
+		s_D3D11 = lib.IsOpen();
 	}
 
 	return s_D3D11 > 0;

--- a/pcsx2/USB/shared/hidapi.cpp
+++ b/pcsx2/USB/shared/hidapi.cpp
@@ -14,62 +14,87 @@
  */
 
 #include "PrecompiledHeader.h"
+#include "common/DynamicLibrary.h"
 #include <windows.h>
 #include <setupapi.h>
 #include "hidapi.h"
 
-_HidD_GetHidGuid HidD_GetHidGuid = NULL;
-_HidD_GetAttributes HidD_GetAttributes = NULL;
-_HidD_GetPreparsedData HidD_GetPreparsedData = NULL;
-_HidP_GetCaps HidP_GetCaps = NULL;
-_HidD_FreePreparsedData HidD_FreePreparsedData = NULL;
-_HidD_GetFeature HidD_GetFeature = NULL;
-_HidD_SetFeature HidD_SetFeature = NULL;
-_HidP_GetSpecificButtonCaps HidP_GetSpecificButtonCaps = NULL;
-_HidP_GetButtonCaps HidP_GetButtonCaps = NULL;
-_HidP_GetUsages HidP_GetUsages = NULL;
-_HidP_GetValueCaps HidP_GetValueCaps = NULL;
-_HidP_GetUsageValue HidP_GetUsageValue = NULL;
-_HidD_GetProductString HidD_GetProductString = NULL;
+_HidD_GetHidGuid HidD_GetHidGuid = nullptr;
+_HidD_GetAttributes HidD_GetAttributes = nullptr;
+_HidD_GetPreparsedData HidD_GetPreparsedData = nullptr;
+_HidP_GetCaps HidP_GetCaps = nullptr;
+_HidD_FreePreparsedData HidD_FreePreparsedData = nullptr;
+_HidD_GetFeature HidD_GetFeature = nullptr;
+_HidD_SetFeature HidD_SetFeature = nullptr;
+_HidP_GetSpecificButtonCaps HidP_GetSpecificButtonCaps = nullptr;
+_HidP_GetButtonCaps HidP_GetButtonCaps = nullptr;
+_HidP_GetUsages HidP_GetUsages = nullptr;
+_HidP_GetValueCaps HidP_GetValueCaps = nullptr;
+_HidP_GetUsageValue HidP_GetUsageValue = nullptr;
+_HidD_GetProductString HidD_GetProductString = nullptr;
 
-static HMODULE hModHid = 0;
+static Common::DynamicLibrary s_hid_lib;
 
 int InitHid()
 {
-	if (hModHid)
-	{
+	if (s_hid_lib.IsOpen())
 		return 1;
-	}
-	hModHid = LoadLibraryA("hid.dll");
-	if (hModHid)
-	{
-		if ((HidD_GetHidGuid = (_HidD_GetHidGuid)GetProcAddress(hModHid, "HidD_GetHidGuid")) &&
-			(HidD_GetAttributes = (_HidD_GetAttributes)GetProcAddress(hModHid, "HidD_GetAttributes")) &&
-			(HidD_GetPreparsedData = (_HidD_GetPreparsedData)GetProcAddress(hModHid, "HidD_GetPreparsedData")) &&
-			(HidP_GetCaps = (_HidP_GetCaps)GetProcAddress(hModHid, "HidP_GetCaps")) &&
-			(HidD_FreePreparsedData = (_HidD_FreePreparsedData)GetProcAddress(hModHid, "HidD_FreePreparsedData")) &&
-			(HidP_GetSpecificButtonCaps = (_HidP_GetSpecificButtonCaps)GetProcAddress(hModHid, "HidP_GetSpecificButtonCaps")) &&
-			(HidP_GetButtonCaps = (_HidP_GetButtonCaps)GetProcAddress(hModHid, "HidP_GetButtonCaps")) &&
-			(HidP_GetUsages = (_HidP_GetUsages)GetProcAddress(hModHid, "HidP_GetUsages")) &&
-			(HidP_GetValueCaps = (_HidP_GetValueCaps)GetProcAddress(hModHid, "HidP_GetValueCaps")) &&
-			(HidP_GetUsageValue = (_HidP_GetUsageValue)GetProcAddress(hModHid, "HidP_GetUsageValue")) &&
-			(HidD_GetProductString = (_HidD_GetProductString)GetProcAddress(hModHid, "HidD_GetProductString")) &&
-			(HidD_GetFeature = (_HidD_GetFeature)GetProcAddress(hModHid, "HidD_GetFeature")) &&
-			(HidD_SetFeature = (_HidD_SetFeature)GetProcAddress(hModHid, "HidD_SetFeature")))
-		{
-			//pHidD_GetHidGuid(&GUID_DEVINTERFACE_HID);
-			return 1;
-		}
-		UninitHid();
-	}
+
+	if (!s_hid_lib.Open("hid"))
+		return 0;
+
+	HidP_GetUsages = s_hid_lib.GetSymbol<_HidP_GetUsages>("HidP_GetUsages");
+	HidP_GetCaps   = s_hid_lib.GetSymbol<_HidP_GetCaps>("HidP_GetCaps");
+
+	HidD_GetHidGuid     = s_hid_lib.GetSymbol<_HidD_GetHidGuid>("HidD_GetHidGuid");
+	HidD_GetAttributes  = s_hid_lib.GetSymbol<_HidD_GetAttributes>("HidD_GetAttributes");
+
+	HidP_GetButtonCaps = s_hid_lib.GetSymbol<_HidP_GetButtonCaps>("HidP_GetButtonCaps");
+	HidP_GetValueCaps = s_hid_lib.GetSymbol<_HidP_GetValueCaps>("HidP_GetValueCaps");
+
+	HidD_GetPreparsedData  = s_hid_lib.GetSymbol<_HidD_GetPreparsedData>("HidD_GetPreparsedData");
+	HidD_FreePreparsedData = s_hid_lib.GetSymbol<_HidD_FreePreparsedData>("HidD_FreePreparsedData");
+
+	HidP_GetSpecificButtonCaps = s_hid_lib.GetSymbol<_HidP_GetSpecificButtonCaps>("HidP_GetSpecificButtonCaps");
+
+	HidP_GetUsageValue    = s_hid_lib.GetSymbol<_HidP_GetUsageValue>("HidP_GetUsageValue");
+	HidD_GetProductString = s_hid_lib.GetSymbol<_HidD_GetProductString>("HidD_GetProductString");
+
+	HidD_GetFeature = s_hid_lib.GetSymbol<_HidD_GetFeature>("HidD_GetFeature");
+	HidD_SetFeature = s_hid_lib.GetSymbol<_HidD_SetFeature>("HidD_SetFeature");
+
+	const bool loaded =
+		HidP_GetUsages && HidP_GetCaps && HidD_GetHidGuid &&
+		HidD_GetAttributes && HidP_GetButtonCaps && HidP_GetValueCaps &&
+		HidD_GetPreparsedData && HidD_FreePreparsedData && HidP_GetSpecificButtonCaps &&
+		HidP_GetUsageValue && HidD_GetProductString && HidD_GetFeature && HidD_SetFeature;
+
+	if(loaded)
+		return 1;
+
+	UninitHid();
+
 	return 0;
 }
 
 void UninitHid()
 {
-	if (hModHid)
-	{
-		FreeLibrary(hModHid);
-		hModHid = 0;
-	}
+	HidP_GetUsages = nullptr;
+	HidP_GetCaps = nullptr;
+	HidD_GetHidGuid = nullptr;
+
+	HidD_GetAttributes = nullptr;
+	HidP_GetButtonCaps = nullptr;
+	HidP_GetValueCaps = nullptr;
+	HidD_GetPreparsedData = nullptr;
+
+	HidD_FreePreparsedData = nullptr;
+	HidP_GetSpecificButtonCaps = nullptr;
+	HidP_GetUsageValue = nullptr;
+	HidD_GetProductString = nullptr;
+
+	HidD_GetFeature = nullptr;
+	HidD_SetFeature = nullptr;
+
+	s_hid_lib.Close();
 }


### PR DESCRIPTION
### Description of Changes
Adds a wrapper for optional library dependencies that deals with OS-specific details so users don't have to.

### Rationale behind Changes
It's better than using something like `wxDynamicLibrary` which depends on a large gui toolkit to function. As it stands this isn't much of an issue now due to the fact that we no longer use plugins and macos/linux has no optional dependencies that I can find. I implemented UNIX anyway for the future.

### Suggested Testing Steps
TBD
