### PR TITLE
UI: Select a bios by default

### DIFF
--- a/pcsx2/gui/Panels/BiosSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/BiosSelectorPanel.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -211,6 +211,13 @@ void Panels::BiosSelectorPanel::OnEnumComplete(wxCommandEvent& evt)
 		const int sel = m_ComboBox->Append(result.first, reinterpret_cast<void*>(result.second));
 		if (currentBios == wxFileName((*m_BiosList)[result.second]))
 			m_ComboBox->SetSelection(sel);
+	}
+	// Select a bios if one isn't selected. 
+	// This makes it so users don't _have_ to click on their bios,
+	// possibly reducing confusion.
+	if(m_ComboBox->GetSelection() == -1 && m_ComboBox->GetCount() > 0)
+	{
+		m_ComboBox->SetSelection(0);
 	}
 };
 


### PR DESCRIPTION
### Description of Changes
When you enumerate through your folder with your bios(es), highlight the first bios in the bios list, **UNLESS one of the bioses match the currently loaded one.** (The bold here is current behaviour and not new).

### Rationale behind Changes
Stops things like this from happening for first time users. (Not my picture)
![20210919_173236](https://user-images.githubusercontent.com/29295048/133937923-2d3da46b-4100-4afa-99c7-1c894955fdc9.jpg)

With this PR, that bios would be selected and they wouldn't have had to ask why their bios was invalid.

### Suggested Testing Steps
Delete your configuration, do a first time setup, and see if a bios is selected automatically.
