### PR TITLE
Load 64-bit/128-bit values through xmm registers

### DIFF
--- a/common/Pcsx2Defs.h
+++ b/common/Pcsx2Defs.h
@@ -151,6 +151,7 @@ static const int __pagesize = PCSX2_PAGESIZE;
 #ifndef __fastcall
 #define __fastcall __attribute__((fastcall))
 #endif
+#define __vectorcall __fastcall
 #define _inline __inline__ __attribute__((unused))
 #ifdef NDEBUG
 #define __forceinline __attribute__((always_inline, unused))

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -215,6 +215,7 @@ set(pcsx2Headers
 	SaveState.h
 	Sifcmd.h
 	Sif.h
+	SingleRegisterTypes.h
 	Sio.h
 	sio_internal.h
 	SPR.h

--- a/pcsx2/Cache.h
+++ b/pcsx2/Cache.h
@@ -17,6 +17,7 @@
 #define __CACHE_H__
 
 #include "Common.h"
+#include "SingleRegisterTypes.h"
 
 void resetCache();
 void writeCache8(u32 mem, u8 value);
@@ -27,6 +28,7 @@ void writeCache128(u32 mem, const mem128_t* value);
 u8 readCache8(u32 mem);
 u16 readCache16(u32 mem);
 u32 readCache32(u32 mem);
-u64 readCache64(u32 mem);
+RETURNS_R64  readCache64(u32 mem);
+RETURNS_R128 readCache128(u32 mem);
 
 #endif /* __CACHE_H__ */

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -241,7 +241,7 @@ __fi u32 ipuRead32(u32 mem)
 	return psHu32(IPU_CMD + mem);
 }
 
-__fi u64 ipuRead64(u32 mem)
+__fi RETURNS_R64 ipuRead64(u32 mem)
 {
 	// Note: It's assumed that mem's input value is always in the 0x10002000 page
 	// of memory (if not, it's probably bad code).
@@ -263,7 +263,7 @@ __fi u64 ipuRead64(u32 mem)
 			
 			if (ipuRegs.cmd.DATA & 0xffffff)
 				IPU_LOG("read64: IPU_CMD=BUSY=%x, DATA=%08X", ipuRegs.cmd.BUSY ? 1 : 0, ipuRegs.cmd.DATA);
-			return ipuRegs.cmd._u64;
+			return r64_load(&ipuRegs.cmd._u64);
 		}
 
 		ipucase(IPU_CTRL):
@@ -282,7 +282,7 @@ __fi u64 ipuRead64(u32 mem)
 			IPU_LOG("read64: Unknown=%x", mem);
 			break;
 	}
-	return psHu64(IPU_CMD + mem);
+	return r64_load(&psHu64(IPU_CMD + mem));
 }
 
 void ipuSoftReset()

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -289,7 +289,7 @@ extern int coded_block_pattern;
 extern void ipuReset();
 
 extern u32 ipuRead32(u32 mem);
-extern u64 ipuRead64(u32 mem);
+extern RETURNS_R64 ipuRead64(u32 mem);
 extern bool ipuWrite32(u32 mem,u32 value);
 extern bool ipuWrite64(u32 mem,u64 value);
 

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -220,13 +220,13 @@ static mem32_t __fastcall nullRead32(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
 	return 0;
 }
-static void __fastcall nullRead64(u32 mem, mem64_t *out) {
+static RETURNS_R64 nullRead64(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
-	*out = 0;
+	return r64_zero();
 }
-static void __fastcall nullRead128(u32 mem, mem128_t *out) {
+static RETURNS_R128 nullRead128(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
-	ZeroQWC(out);
+	return r128_zero();
 }
 static void __fastcall nullWrite8(u32 mem, mem8_t value)
 {
@@ -324,12 +324,12 @@ static mem32_t __fastcall _ext_memRead32(u32 mem)
 }
 
 template<int p>
-static void __fastcall _ext_memRead64(u32 mem, mem64_t *out)
+static RETURNS_R64 _ext_memRead64(u32 mem)
 {
 	switch (p)
 	{
 		case 6: // gsm
-			*out = gsRead64(mem); return;
+			return r64_from_u64(gsRead64(mem));
 		default: break;
 	}
 
@@ -338,15 +338,14 @@ static void __fastcall _ext_memRead64(u32 mem, mem64_t *out)
 }
 
 template<int p>
-static void __fastcall _ext_memRead128(u32 mem, mem128_t *out)
+static RETURNS_R128 _ext_memRead128(u32 mem)
 {
 	switch (p)
 	{
 		//case 1: // hwm
-		//	hwRead128(mem & ~0xa0000000, out); return;
+		//	return hwRead128(mem & ~0xa0000000);
 		case 6: // gsm
-			CopyQWC(out,PS2GS_BASE(mem));
-		return;
+			return r128_load(PS2GS_BASE(mem));
 		default: break;
 	}
 
@@ -475,19 +474,19 @@ template<int vunum> static mem32_t __fc vuMicroRead32(u32 addr) {
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	return *(u32*)&vu->Micro[addr];
 }
-template<int vunum> static void __fc vuMicroRead64(u32 addr,mem64_t* data) {
+template<int vunum> static RETURNS_R64 vuMicroRead64(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
-	*data=*(u64*)&vu->Micro[addr];
+	return r64_load(&vu->Micro[addr]);
 }
-template<int vunum> static void __fc vuMicroRead128(u32 addr,mem128_t* data) {
+template<int vunum> static RETURNS_R128 vuMicroRead128(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	
-	CopyQWC(data,&vu->Micro[addr]);
+	return r128_load(&vu->Micro[addr]);
 }
 
 // Profiled VU writes: Happen very infrequently, with exception of BIOS initialization (at most twice per
@@ -578,17 +577,17 @@ template<int vunum> static mem32_t __fc vuDataRead32(u32 addr) {
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	return *(u32*)&vu->Mem[addr];
 }
-template<int vunum> static void __fc vuDataRead64(u32 addr, mem64_t* data) {
+template<int vunum> static RETURNS_R64 vuDataRead64(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
-	*data=*(u64*)&vu->Mem[addr];
+	return r64_load(&vu->Mem[addr]);
 }
-template<int vunum> static void __fc vuDataRead128(u32 addr, mem128_t* data) {
+template<int vunum> static RETURNS_R128 vuDataRead128(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
-	CopyQWC(data,&vu->Mem[addr]);
+	return r128_load(&vu->Mem[addr]);
 }
 
 // VU Data Memory Writes...

--- a/pcsx2/Memory.h
+++ b/pcsx2/Memory.h
@@ -136,11 +136,11 @@ extern void mmap_ResetBlockTracking();
 #define memWrite16 vtlb_memWrite<mem16_t>
 #define memWrite32 vtlb_memWrite<mem32_t>
 
-static __fi void memRead64(u32 mem, mem64_t* out)	{ vtlb_memRead64(mem, out); }
-static __fi void memRead64(u32 mem, mem64_t& out)	{ vtlb_memRead64(mem, &out); }
+static __fi void memRead64(u32 mem, mem64_t* out)	{ _mm_storel_epi64((__m128i*)out, vtlb_memRead64(mem)); }
+static __fi void memRead64(u32 mem, mem64_t& out)	{ memRead64(mem, &out); }
 
-static __fi void memRead128(u32 mem, mem128_t* out) { vtlb_memRead128(mem, out); }
-static __fi void memRead128(u32 mem, mem128_t& out) { vtlb_memRead128(mem, &out); }
+static __fi void memRead128(u32 mem, mem128_t* out) { _mm_store_si128((__m128i*)out, vtlb_memRead128(mem)); }
+static __fi void memRead128(u32 mem, mem128_t& out) { memRead128(mem, &out); }
 
 static __fi void memWrite64(u32 mem, const mem64_t* val)	{ vtlb_memWrite64(mem, val); }
 static __fi void memWrite64(u32 mem, const mem64_t& val)	{ vtlb_memWrite64(mem, &val); }

--- a/pcsx2/SingleRegisterTypes.h
+++ b/pcsx2/SingleRegisterTypes.h
@@ -1,0 +1,107 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// --------------------------------------------------------------------------------------
+//  r64 / r128 - Types that are guaranteed to fit in one register
+// --------------------------------------------------------------------------------------
+// Note: Recompilers rely on some of these types and the registers they allocate to,
+// so be careful if you want to change them
+
+#pragma once
+
+#include <immintrin.h>
+// Can't stick them in structs because it breaks calling convention things, yay
+using r64  = __m128i;
+using r128 = __m128i;
+
+// Calling convention setting, yay
+#define RETURNS_R64  r64  __vectorcall
+#define RETURNS_R128 r128 __vectorcall
+#define TAKES_R64  __vectorcall
+#define TAKES_R128 __vectorcall
+
+// And since we can't stick them in structs, we get lots of static methods, yay!
+
+__forceinline static r64 r64_load(const void* ptr)
+{
+	return _mm_loadl_epi64(reinterpret_cast<const r64*>(ptr));
+}
+
+__forceinline static r64 r64_zero()
+{
+	return _mm_setzero_si128();
+}
+
+__forceinline static r64 r64_from_u32(u32 val)
+{
+	return _mm_cvtsi32_si128(val);
+}
+
+__forceinline static r64 r64_from_u32x2(u32 lo, u32 hi)
+{
+	return _mm_unpacklo_epi32(_mm_cvtsi32_si128(lo), _mm_cvtsi32_si128(hi));
+}
+
+__forceinline static r64 r64_from_u64(u64 val)
+{
+#ifdef _M_X86_64
+	return _mm_cvtsi64_si128(val);
+#else
+	return r64_from_u32x2(val, val >> 64);
+#endif
+}
+
+__forceinline static r128 r128_load(const void* ptr)
+{
+	return _mm_load_si128(reinterpret_cast<const r128*>(ptr));
+}
+
+__forceinline static r128 r128_zero()
+{
+	return _mm_setzero_si128();
+}
+
+/// Expects that r64 came from r64-handling code, and not from a recompiler or something
+__forceinline static r128 r128_from_r64_clean(r64 val)
+{
+	return val;
+}
+
+__forceinline static r128 r128_from_u32x4(u32 lo0, u32 lo1, u32 hi0, u32 hi1)
+{
+	return _mm_setr_epi32(lo0, lo1, hi0, hi1);
+}
+
+template <typename u>
+struct rhelper;
+
+template <>
+struct rhelper<u64>
+{
+	using r = r64;
+	__forceinline static r load(void* ptr) { return r64_load(ptr); }
+	__forceinline static r zero() { return r64_zero(); }
+};
+
+template <>
+struct rhelper<u128>
+{
+	using r = r128;
+	__forceinline static r load(void* ptr) { return r128_load(ptr); }
+	__forceinline static r zero() { return r128_zero(); }
+};
+
+template <typename u>
+using u_to_r = typename rhelper<u>::r;

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -952,6 +952,7 @@
     <ClInclude Include="Dump.h" />
     <ClInclude Include="IopCommon.h" />
     <ClInclude Include="SaveState.h" />
+    <ClInclude Include="SingleRegisterTypes.h" />
     <ClInclude Include="System.h" />
     <ClInclude Include="System\SysThreads.h" />
     <ClInclude Include="System\RecTypes.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1687,6 +1687,9 @@
     <ClInclude Include="SaveState.h">
       <Filter>System\Include</Filter>
     </ClInclude>
+    <ClInclude Include="SingleRegisterTypes.h">
+      <Filter>System\Include</Filter>
+    </ClInclude>
     <ClInclude Include="System.h">
       <Filter>System\Include</Filter>
     </ClInclude>

--- a/pcsx2/ps2/HwInternal.h
+++ b/pcsx2/ps2/HwInternal.h
@@ -41,8 +41,8 @@
 template< uint page > extern mem8_t  __fastcall hwRead8  (u32 mem);
 template< uint page > extern mem16_t __fastcall hwRead16 (u32 mem);
 template< uint page > extern mem32_t __fastcall hwRead32 (u32 mem);
-template< uint page > extern void    __fastcall hwRead64 (u32 mem, mem64_t* out );
-template< uint page > extern void    __fastcall hwRead128(u32 mem, mem128_t* out);
+template< uint page > extern RETURNS_R64        hwRead64 (u32 mem);
+template< uint page > extern RETURNS_R128       hwRead128(u32 mem);
 
 // Internal hwRead32 which does not log reads, used by hwWrite8/16 to perform
 // read-modify-write operations.

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "MemoryTypes.h"
+#include "SingleRegisterTypes.h"
 
 #include "common/PageFaultSource.h"
 
@@ -25,8 +26,8 @@ static const uptr VTLB_AllocUpperBounds = _1gb * 2;
 typedef  mem8_t __fastcall vtlbMemR8FP(u32 addr);
 typedef  mem16_t __fastcall vtlbMemR16FP(u32 addr);
 typedef  mem32_t __fastcall vtlbMemR32FP(u32 addr);
-typedef  void __fastcall vtlbMemR64FP(u32 addr,mem64_t* data);
-typedef  void __fastcall vtlbMemR128FP(u32 addr,mem128_t* data);
+typedef  RETURNS_R64 vtlbMemR64FP(u32 addr);
+typedef  RETURNS_R128 vtlbMemR128FP(u32 addr);
 
 // Specialized function pointers for each write type
 typedef  void __fastcall vtlbMemW8FP(u32 addr,mem8_t data);
@@ -87,8 +88,8 @@ extern void vtlb_VMapUnmap(u32 vaddr,u32 sz);
 
 template< typename DataType >
 extern DataType __fastcall vtlb_memRead(u32 mem);
-extern void __fastcall vtlb_memRead64(u32 mem, mem64_t *out);
-extern void __fastcall vtlb_memRead128(u32 mem, mem128_t *out);
+extern RETURNS_R64 vtlb_memRead64(u32 mem);
+extern RETURNS_R128 vtlb_memRead128(u32 mem);
 
 template< typename DataType >
 extern void __fastcall vtlb_memWrite(u32 mem, DataType value);
@@ -97,10 +98,10 @@ extern void __fastcall vtlb_memWrite128(u32 mem, const mem128_t* value);
 
 extern void vtlb_DynGenWrite(u32 sz);
 extern void vtlb_DynGenRead32(u32 bits, bool sign);
-extern void vtlb_DynGenRead64(u32 sz);
+extern int  vtlb_DynGenRead64(u32 sz, int gpr);
 
 extern void vtlb_DynGenWrite_Const( u32 bits, u32 addr_const );
-extern void vtlb_DynGenRead64_Const( u32 bits, u32 addr_const );
+extern int  vtlb_DynGenRead64_Const( u32 bits, u32 addr_const, int gpr );
 extern void vtlb_DynGenRead32_Const( u32 bits, bool sign, u32 addr_const );
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -452,11 +452,6 @@ void recSWR()
 
 ////////////////////////////////////////////////////
 
-alignas(16) const u32 SHIFT_MASKS[2][4] = {
-	{ 0xffffffff, 0xffffffff, 0x00000000, 0x00000000 },
-	{ 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff }
-};
-
 void recLDL()
 {
 	if (!_Rt_)
@@ -514,22 +509,21 @@ void recLDL()
 	xSUB(edx, eax);
 
 	xMOVDZX(xRegisterSSE(t1reg), eax);
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&SHIFT_MASKS[0][0]]);
+	xPCMP.EQD(xRegisterSSE(t0reg), xRegisterSSE(t0reg));
 	xPSRL.Q(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
 	xPAND(xRegisterSSE(t0reg), xRegisterSSE(rtreg));
 	xMOVDQA(xRegisterSSE(t2reg), xRegisterSSE(t0reg));
 
 	xMOVDZX(xRegisterSSE(t1reg), edx);
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&dummyValue[0]]);
+	xMOVQZX(xRegisterSSE(t0reg), ptr64[&dummyValue[0]]);
 	xPSLL.Q(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
 	xPOR(xRegisterSSE(t0reg), xRegisterSSE(t2reg));
+	xMOVSD(xRegisterSSE(rtreg), xRegisterSSE(t0reg));
 	xForwardJump32 full;
 	skip.SetTarget();
 
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&dummyValue[0]]);
+	xMOVL.PS(xRegisterSSE(rtreg), ptr128[&dummyValue[0]]);
 	full.SetTarget();
-
-	xBLEND.PS(xRegisterSSE(rtreg), xRegisterSSE(t0reg), 0x3);
 
 	_freeXMMreg(t0reg);
 	_freeXMMreg(t1reg);
@@ -602,22 +596,21 @@ void recLDR()
 	xSUB(edx, eax);
 
 	xMOVDZX(xRegisterSSE(t1reg), edx); //64-shift*8
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&SHIFT_MASKS[0][0]]);
+	xPCMP.EQD(xRegisterSSE(t0reg), xRegisterSSE(t0reg));
 	xPSLL.Q(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
 	xPAND(xRegisterSSE(t0reg), xRegisterSSE(rtreg));
 	xMOVQZX(xRegisterSSE(t2reg), xRegisterSSE(t0reg));
 
 	xMOVDZX(xRegisterSSE(t1reg), eax); //shift*8
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&dummyValue[0]]);
+	xMOVQZX(xRegisterSSE(t0reg), ptr64[&dummyValue[0]]);
 	xPSRL.Q(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
 	xPOR(xRegisterSSE(t0reg), xRegisterSSE(t2reg));
+	xMOVSD(xRegisterSSE(rtreg), xRegisterSSE(t0reg));
 	xForwardJump32 full;
 	skip.SetTarget();
 
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&dummyValue[0]]);
+	xMOVL.PS(xRegisterSSE(rtreg), ptr128[&dummyValue[0]]);
 	full.SetTarget();
-
-	xBLEND.PS(xRegisterSSE(rtreg), xRegisterSSE(t0reg), 0x3);
 
 	_freeXMMreg(t0reg);
 	_freeXMMreg(t1reg);
@@ -689,9 +682,9 @@ void recSDL()
 	xSUB(edx, eax);
 	// Generate mask 128-(shiftx8) xPSRA.W does bit for bit
 	xMOVDZX(xRegisterSSE(t1reg), eax);
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&SHIFT_MASKS[0][0]]);
+	xPCMP.EQD(xRegisterSSE(t0reg), xRegisterSSE(t0reg));
 	xPSLL.Q(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
-	xMOVQZX(xRegisterSSE(t1reg), ptr128[&dummyValue[0]]); // This line is super slow, but using MOVDQA/MOVAPS is even slower!
+	xMOVQZX(xRegisterSSE(t1reg), ptr64[&dummyValue[0]]); // This line is super slow, but using MOVDQA/MOVAPS is even slower!
 	xPAND(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
 
 	// Shift over reg value (shift, PSLL.Q multiplies by 8)
@@ -700,7 +693,7 @@ void recSDL()
 	xPOR(xRegisterSSE(rtreg), xRegisterSSE(t0reg));
 	skip.SetTarget();
 
-	xMOVQ(ptr128[&dummyValue[0]], xRegisterSSE(rtreg));
+	xMOVQ(ptr64[&dummyValue[0]], xRegisterSSE(rtreg));
 
 	_deleteGPRtoXMMreg(_Rt_, 3);
 	_freeXMMreg(t0reg);
@@ -790,9 +783,9 @@ void recSDR()
 	xSUB(edx, eax);
 	// Generate mask 128-(shiftx8) xPSRA.W does bit for bit
 	xMOVDZX(xRegisterSSE(t1reg), edx);
-	xMOVQZX(xRegisterSSE(t0reg), ptr128[&SHIFT_MASKS[0][0]]);
+	xPCMP.EQD(xRegisterSSE(t0reg), xRegisterSSE(t0reg));
 	xPSRL.Q(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
-	xMOVQZX(xRegisterSSE(t1reg), ptr128[&dummyValue[0]]); // This line is super slow, but using MOVDQA/MOVAPS is even slower!
+	xMOVQZX(xRegisterSSE(t1reg), ptr64[&dummyValue[0]]); // This line is super slow, but using MOVDQA/MOVAPS is even slower!
 	xPAND(xRegisterSSE(t0reg), xRegisterSSE(t1reg));
 
 	// Shift over reg value (shift, PSLL.Q multiplies by 8)
@@ -801,7 +794,7 @@ void recSDR()
 	xPOR(xRegisterSSE(rtreg), xRegisterSSE(t0reg));
 	skip.SetTarget();
 
-	xMOVQ(ptr128[&dummyValue[0]], xRegisterSSE(rtreg));
+	xMOVQ(ptr64[&dummyValue[0]], xRegisterSSE(rtreg));
 	
 	_deleteGPRtoXMMreg(_Rt_, 3);
 	_freeXMMreg(t0reg);


### PR DESCRIPTION
### Description of Changes
Switches loading of large memory values to go through xmm registers instead of pointers
Also adds a few optimizations for swl/swr/sdl/sdr that skips loading the previous value if it won't be needed

### Rationale behind Changes
Slightly faster in some cases, especially for the newly added ldl/ldr/sdl/sdr which previously had to store to memory and then immediately reload

### Suggested Testing Steps
Make sure things still work
