### PR TITLE
COP2: smart register allocation for COP2 commands

### DIFF
--- a/pcsx2/x86/iCore.cpp
+++ b/pcsx2/x86/iCore.cpp
@@ -801,20 +801,23 @@ u16 _freeXMMregsCOP2(int requiredcount)
 	// Finally Get rid of registers which are gonna be needed, they'll need to be reloaded
 	int maxcount = 9999; // The lower this value the more towards the end of the block it'll need flushing
 	int regtoclear = -1;
+
 	while (count > 0)
 	{
 		for (int i = 0; i < iREGCNT_XMM - 1; i++)
 		{
 			if (xmmregs[i].inuse && xmmregs[i].counter < maxcount)
 			{
-				int regtoclear = i;
+				regtoclear = i;
 				maxcount = xmmregs[i].counter;
 			}
 		}
-
-		_freeXMMreg(regtoclear);
-		count--;
-		regs |= (1 << regtoclear);
+		if (regtoclear != -1)
+		{
+			_freeXMMreg(regtoclear);
+			count--;
+			regs |= (1 << regtoclear);
+		}
 	}
 
 	pxAssert(count <= 0);

--- a/pcsx2/x86/iCore.h
+++ b/pcsx2/x86/iCore.h
@@ -159,6 +159,8 @@ struct _xmmregs
 	u16 counter;
 };
 
+void _cop2BackupRegs();
+void _cop2RestoreRegs();
 void _initXMMregs();
 int _getFreeXMMreg();
 int _allocTempXMMreg(XMMSSEType type, int xmmreg);

--- a/pcsx2/x86/iCore.h
+++ b/pcsx2/x86/iCore.h
@@ -176,6 +176,7 @@ void _clearNeededXMMregs();
 void _deleteGPRtoXMMreg(int reg, int flush);
 void _deleteFPtoXMMreg(int reg, int flush);
 void _freeXMMreg(u32 xmmreg);
+u16 _freeXMMregsCOP2(int requiredcount);
 //void _moveXMMreg(int xmmreg); // instead of freeing, moves it to a diff location
 void _flushXMMregs();
 u8 _hasFreeXMMreg();

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -127,7 +127,7 @@ void _eeOnWriteReg(int reg, int signext);
 // if 0, only flushes if not an xmm reg (used when overwriting lower 64bits of reg)
 void _deleteEEreg(int reg, int flush);
 
-void _flushEEreg(int reg);
+void _flushEEreg(int reg, bool clear = false);
 
 // allocates memory on the instruction size and returns the pointer
 u32* recGetImm64(u32 hi, u32 lo);

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -920,19 +920,21 @@ void recSWC1()
 
 void recLQC2()
 {
-	iFlushCall(FLUSH_EVERYTHING);
-
+	_freeX86reg(eax);
 	xMOV(eax, ptr32[&cpuRegs.cycle]);
 	xADD(eax, scaleblockcycles_clear());
 	xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
+
 	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x1);
 	xForwardJZ32 skipvuidle;
 	xSUB(eax, ptr32[&VU0.cycle]);
 	xSUB(eax, ptr32[&VU0.nextBlockCycles]);
 	xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 8 : 0);
 	xForwardJL32 skip;
+	_cop2BackupRegs();
 	xLoadFarAddr(arg1reg, CpuVU0);
 	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+	_cop2RestoreRegs();
 	skip.SetTarget();
 	skipvuidle.SetTarget();
 
@@ -965,20 +967,21 @@ void recLQC2()
 
 void recSQC2()
 {
-	iFlushCall(FLUSH_EVERYTHING);
-
-
+	_freeX86reg(eax);
 	xMOV(eax, ptr32[&cpuRegs.cycle]);
 	xADD(eax, scaleblockcycles_clear());
 	xMOV(ptr32[&cpuRegs.cycle], eax); // update cycles
+
 	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x1);
 	xForwardJZ32 skipvuidle;
 	xSUB(eax, ptr32[&VU0.cycle]);
 	xSUB(eax, ptr32[&VU0.nextBlockCycles]);
 	xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 8 : 0);
 	xForwardJL32 skip;
+	_cop2BackupRegs();
 	xLoadFarAddr(arg1reg, CpuVU0);
 	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+	_cop2RestoreRegs();
 	skip.SetTarget();
 	skipvuidle.SetTarget();
 

--- a/pcsx2/x86/ix86-32/iR5900Templates.cpp
+++ b/pcsx2/x86/ix86-32/iR5900Templates.cpp
@@ -50,7 +50,7 @@ void _deleteEEreg(int reg, int flush)
 	_deleteGPRtoXMMreg(reg, flush ? 0 : 2);
 }
 
-void _flushEEreg(int reg)
+void _flushEEreg(int reg, bool clear)
 {
 	if (!reg)
 		return;
@@ -59,7 +59,7 @@ void _flushEEreg(int reg)
 		_flushConstReg(reg);
 		return;
 	}
-	_deleteGPRtoXMMreg(reg, 1);
+	_deleteGPRtoXMMreg(reg, clear ? 2 : 1);
 }
 
 int eeProcessHILO(int reg, int mode, int mmx)

--- a/pcsx2/x86/microVU_IR.h
+++ b/pcsx2/x86/microVU_IR.h
@@ -291,6 +291,19 @@ public:
 		counter = 0;
 	}
 
+	void reserveCOP2(u16 regs)
+	{
+		u16 regmask = ~regs;
+		for (int i = 0; i < xmmTotal; i++)
+		{
+			if (regmask & (1 << i))
+			{
+				xmmMap[i].isNeeded = true;
+				xmmMap[i].xyzw = 1; // Not really, but it tricks the allocator in to thinking it's needed
+			}
+		}
+	}
+
 	int getXmmCount()
 	{
 		return xmmTotal + 1;

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -105,7 +105,16 @@ static const char branchSTR[16][8] = {
 #define _Z ((mVU.code >> 22) & 0x1)
 #define _W ((mVU.code >> 21) & 0x1)
 
+#define _cX ((cpuRegs.code >> 24) & 0x1)
+#define _cY ((cpuRegs.code >> 23) & 0x1)
+#define _cZ ((cpuRegs.code >> 22) & 0x1)
+#define _cW ((cpuRegs.code >> 21) & 0x1)
+
 #define _X_Y_Z_W   (((mVU.code >> 21) & 0xF))
+#define _cX_Y_Z_W   (((cpuRegs.code >> 21) & 0xF))
+#define _cXYZW_SS  (_cX + _cY + _cZ + _cW == 1)
+#define _cXYZW_SS2  (_cXYZW_SS && (_cX_Y_Z_W != 8))
+
 #define _XYZW_SS   (_X + _Y + _Z + _W == 1)
 #define _XYZW_SS2  (_XYZW_SS && (_X_Y_Z_W != 8))
 #define _XYZW_PS   (_X_Y_Z_W == 0xf)

--- a/pcsx2/x86/microVU_Upper.inl
+++ b/pcsx2/x86/microVU_Upper.inl
@@ -270,7 +270,7 @@ static void mVU_FMACa(microVU& mVU, int recPass, int opCase, int opType, bool is
 				xPSHUF.D(ACC, ACC, shuffleSS(_X_Y_Z_W));
 			mVU.regAlloc->clearNeeded(ACC);
 		}
-		else
+		else if (opType < 3)
 			mVUupdateFlags(mVU, Fs, tempFt);
 
 		mVU.regAlloc->clearNeeded(Fs); // Always Clear Written Reg First

--- a/pcsx2/x86/microVU_Upper.inl
+++ b/pcsx2/x86/microVU_Upper.inl
@@ -179,7 +179,7 @@ static bool doSafeSub(microVU& mVU, int opCase, int opType, bool isACC)
 {
 	opCase1
 	{
-		if ((opType == 1) && (_Ft_ == _Fs_))
+		if ((opType == 1) && (_Ft_ == _Fs_) && (opCase == 1)) // Don't do this with BC's!
 		{
 			const xmm& Fs = mVU.regAlloc->allocReg(-1, isACC ? 32 : _Fd_, _X_Y_Z_W);
 			xPXOR(Fs, Fs); // Set to Positive 0


### PR DESCRIPTION
### Description of Changes
Removes the flushes from COP2 calls and instead backs up the registers the EE is using

### Rationale behind Changes
Flushing kind of destroys EE optimisations, we could possibly do this better, but it's a start point.

### Suggested Testing Steps
just make sure games still work and don't glitch out.
