### PR TITLE
Fix crash on assertion in newer wx

### DIFF
--- a/pcsx2/gui/AppAssert.cpp
+++ b/pcsx2/gui/AppAssert.cpp
@@ -79,7 +79,7 @@ protected:
 			wxFileName wxfn(frame.GetFileName());
 
 			wxfn.SetVolume( wxEmptyString );
-			for( int i=0; i<2; ++i )
+			for (int i = 0; i < 2 && wxfn.GetDirCount() > 0; ++i)
 				wxfn.RemoveDir(0);
 
 			m_stackTrace.Write( L" %s:%d", WX_STR(wxfn.GetFullPath()), frame.GetLine() );

--- a/pcsx2/gui/Dialogs/ConfirmationDialogs.cpp
+++ b/pcsx2/gui/Dialogs/ConfirmationDialogs.cpp
@@ -309,7 +309,7 @@ void ModalButtonPanel::OnActionButtonClicked( wxCommandEvent& evt )
 
 void ModalButtonPanel::AddCustomButton( wxWindowID id, const wxString& label )
 {
-	*this += new wxButton( this, id, label ) | StdButton().Proportion(6);
+	*this += new wxButton( this, id, label ) | pxBorder().Proportion(6);
 	Bind(wxEVT_BUTTON, &ModalButtonPanel::OnActionButtonClicked, this, id);
 }
 
@@ -317,6 +317,6 @@ void ModalButtonPanel::AddCustomButton( wxWindowID id, const wxString& label )
 // wxWidgets will assign the labels and stuff for us. :D
 void ModalButtonPanel::AddActionButton( wxWindowID id )
 {
-	*this += new wxButton( this, id ) | StdButton().Proportion(6);
+	*this += new wxButton( this, id ) | pxBorder().Proportion(6);
 	Bind(wxEVT_BUTTON, &ModalButtonPanel::OnActionButtonClicked, this, id);
 }


### PR DESCRIPTION
### Description of Changes
- Prevents a crash caused by our stack trace code not being equipped to handle stack traces outside of PCSX2
- Removes ineffective right alignment flags that cause an assertion failure when displaying our assertion failure dialog on wx 3.1.5

### Rationale behind Changes
If I wanted PCSX2 to crash on assertion failure I could have used libc `assert()`

### Suggested Testing Steps
Compile with wx 3.1.5 and trigger an assertion, PCSX2 should display an assertion dialog and not crash
