### PR TITLE
PortAudio: Remove DirectSound backend

### DIFF
--- a/3rdparty/portaudio/build/msvc/portaudio.vcxproj
+++ b/3rdparty/portaudio/build/msvc/portaudio.vcxproj
@@ -31,7 +31,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\src\common;..\..\include;.\;..\..\src\os\win;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;PAWIN_USE_WDMKS_DEVICE_INFO;PA_USE_DS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;PAWIN_USE_WDMKS_DEVICE_INFO;PA_USE_DS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>PA_USE_WASAPI=1;PA_USE_WDMKS=1;PA_USE_WMME=0;PA_USE_ASIO=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PA_ENABLE_DEBUG_OUTPUT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>


### PR DESCRIPTION
### Description of Changes
Standalone DirectSound was removed a while ago, Portaudio one was still available and it seems broken. Since Portaudio API is backend agnostic, it's rather unlikely that PCSX2 is doing something wrong and more likely that DS is just crap.

### Rationale behind Changes
DirectSound is legacy and has zero advantages over WASAPI (offered via Portaudio) and XAudio2 (offered standalone).

### Suggested Testing Steps
Verify that sound on Windows works.
