### PR TITLE
gs: test for th for tex0 flush

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -908,7 +908,7 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 
 	// clut loading already covered with WriteTest, for drawing only have to check CPSM and CSA (MGS3 intro skybox would be drawn piece by piece without this)
 
-	uint64 mask = 0x1f78001c3fffffffull; // TBP0 TBW PSM TW TCC TFX CPSM CSA
+	uint64 mask = 0x1f78001fffffffffull; // TBP0 TBW PSM TW TH TCC TFX CPSM CSA
 
 	if (wt || PRIM->CTXT == i && ((TEX0.u64 ^ m_env.CTXT[i].TEX0.u64) & mask))
 	{


### PR DESCRIPTION
### Description of Changes
previous code didn't test TH which was a problem for vampire nights because they upload a c16 texture to the same address but with a different height

### Rationale behind Changes
fixes #4805

### Suggested Testing Steps
make sure nothing has any perf issues
