### PR TITLE
Add partial LTO to CMake

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -70,11 +70,13 @@ jobs:
           - os: ubuntu-18.04
             platform: x86
             compiler: gcc
+            cmakeflags: -DLTO_PCSX2_CORE=ON
             appimage: true
             experimental: false
           - os: ubuntu-18.04
             platform: x64
             compiler: gcc
+            cmakeflags: -DLTO_PCSX2_CORE=ON
             appimage: true
             experimental: false
           - os: ubuntu-18.04

--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -107,7 +107,7 @@ jobs:
           fi
 
       - name: Generate CMake Files
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PO=FALSE -B build .
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PO=FALSE -DLTO_PCSX2_CORE=ON -B build .
 
       - name: Build PCSX2
         working-directory: build

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -80,8 +80,8 @@ jobs:
     env:
       POWERSHELL_TELEMETRY_OPTOUT: 1
       BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_MAX_CACHE_SIZE: 134217728 # 128MB
+      BUILDCACHE_COMPRESS_LEVEL: 9
+      BUILDCACHE_MAX_CACHE_SIZE: 536870912 # 512MB
       BUILDCACHE_DIRECT_MODE: true
       BUILDCACHE_LOG_FILE: ${{ github.workspace }}\buildcache.log
 
@@ -121,7 +121,7 @@ jobs:
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\%vcvars%"
           echo ::set-output name=buildtype::%type%
           echo ::set-output name=vcvars::%vcvars%
-          cmake . -B build -DCMAKE_BUILD_TYPE=%type% -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=..\buildcache\bin\buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER=..\buildcache\bin\buildcache.exe -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+          cmake . -B build -DCMAKE_BUILD_TYPE=%type% -DLTO_PCSX2_CORE=ON -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=..\buildcache\bin\buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER=..\buildcache\bin\buildcache.exe -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
         if: matrix.configuration == 'CMake'
 
       - name: Build PCSX2

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -18,6 +18,7 @@ set(PCSX2_DEFS "")
 option(DISABLE_BUILD_DATE "Disable including the binary compile date")
 option(ENABLE_TESTS "Enables building the unit tests" ON)
 option(USE_SYSTEM_YAML "Uses a system version of yaml, if found")
+option(LTO_PCSX2_CORE "Enable LTO/IPO/LTCG on the subset of pcsx2 that benefits most from it but not anything else")
 
 if(WIN32)
 	set(DEFAULT_NATIVE_TOOLS ON)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1359,10 +1359,27 @@ set(pcsx2x86Headers
 	x86/R5900_Profiler.h
 	)
 
-# common Sources
-target_sources(PCSX2 PRIVATE
+# These ones benefit a lot from LTO
+set(pcsx2LTOSources
 	${pcsx2Sources}
 	${pcsx2Headers}
+	${pcsx2IPUSources}
+	${pcsx2IPUHeaders}
+	${pcsx2x86Sources}
+	${pcsx2x86Headers}
+)
+
+if(LTO_PCSX2_CORE)
+	add_library(PCSX2_LTO ${pcsx2LTOSources})
+	target_link_libraries(PCSX2_LTO PRIVATE PCSX2_FLAGS)
+	target_link_libraries(PCSX2 PRIVATE PCSX2_LTO)
+	set_target_properties(PCSX2_LTO PROPERTIES INTERPROCEDURAL_OPTIMIZATION true)
+else()
+	target_sources(PCSX2 PRIVATE ${pcsx2LTOSources})
+endif()
+
+# common Sources
+target_sources(PCSX2 PRIVATE
 	${pcsx2CDVDSources}
 	${pcsx2CDVDHeaders}
 	${pcsx2SPU2Sources}
@@ -1378,8 +1395,6 @@ target_sources(PCSX2 PRIVATE
 	${pcsx2GuiSources}
 	${pcsx2GuiResources}
 	${pcsx2GuiHeaders}
-	${pcsx2IPUSources}
-	${pcsx2IPUHeaders}
 	${pcsx2ps2Sources}
 	${pcsx2ps2Headers}
 	${pcsx2RecordingSources}
@@ -1389,8 +1404,6 @@ target_sources(PCSX2 PRIVATE
 	${pcsx2SystemHeaders}
 	${pcsx2UtilitiesSources}
 	${pcsx2UtilitiesHeaders}
-	${pcsx2x86Sources}
-	${pcsx2x86Headers}
 	${pcsx2ZipToolsSources}
 	${pcsx2ZipToolsHeaders})
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1,10 +1,14 @@
 include(macros/GlibCompileResourcesSupport)
 
-add_executable(PCSX2)
+# All flags, libraries, etc, that are shared between PCSX2 compilation files
+add_library(PCSX2_FLAGS INTERFACE)
 
-target_compile_features(PCSX2 PRIVATE cxx_std_17)
-target_compile_definitions(PCSX2 PUBLIC "${PCSX2_DEFS}")
-target_compile_options(PCSX2 PRIVATE "${PCSX2_WARNINGS}")
+add_executable(PCSX2)
+target_link_libraries(PCSX2 PRIVATE PCSX2_FLAGS)
+
+target_compile_features(PCSX2_FLAGS INTERFACE cxx_std_17)
+target_compile_definitions(PCSX2_FLAGS INTERFACE "${PCSX2_DEFS}")
+target_compile_options(PCSX2_FLAGS INTERFACE "${PCSX2_WARNINGS}")
 
 if (PACKAGE_MODE)
 	install(TARGETS PCSX2 DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -25,10 +29,8 @@ if(NOT TOP_CMAKE_WAS_SOURCED)
 	It is advice to delete all wrongly generated cmake stuff => CMakeFiles & CMakeCache.txt")
 endif()
 
-if(MSVC)
-	set(CommonFlags)
-else()
-	set(CommonFlags
+if(NOT MSVC)
+	target_compile_options(PCSX2_FLAGS INTERFACE
 		-fno-strict-aliasing
 		-Wstrict-aliasing # Allow to track strict aliasing issue.
 		-Wno-parentheses
@@ -40,34 +42,32 @@ endif()
 
 if(GCC_VERSION VERSION_EQUAL "8.0" OR GCC_VERSION VERSION_GREATER "8.0")
 	# gs is pretty bad at this
-	list(APPEND CommonFlags -Wno-packed-not-aligned -Wno-class-memaccess)
+	target_compile_options(PCSX2_FLAGS INTERFACE -Wno-packed-not-aligned -Wno-class-memaccess)
 endif()
 
-target_compile_options(PCSX2 PRIVATE ${CommonFlags})
-
 if ("${PGO}" STREQUAL "generate")
-	target_compile_options(PCSX2 PRIVATE -fprofile-generate)
+	target_compile_options(PCSX2_FLAGS INTERFACE -fprofile-generate)
 elseif("${PGO}" STREQUAL "use")
-	target_compile_options(PCSX2 PRIVATE -fprofile-use)
+	target_compile_options(PCSX2_FLAGS INTERFACE -fprofile-use)
 endif()
 
 if(TARGET PkgConfig::PORTAUDIO)
-	target_compile_definitions(PCSX2 PRIVATE SPU2X_PORTAUDIO)
-	target_link_libraries(PCSX2 PRIVATE PkgConfig::PORTAUDIO)
+	target_compile_definitions(PCSX2_FLAGS INTERFACE SPU2X_PORTAUDIO)
+	target_link_libraries(PCSX2_FLAGS INTERFACE PkgConfig::PORTAUDIO)
 endif()
 
 if(TARGET PulseAudio::PulseAudio)
-	target_compile_definitions(PCSX2 PRIVATE SPU2X_PULSEAUDIO)
-	target_link_libraries(PCSX2 PRIVATE PulseAudio::PulseAudio)
+	target_compile_definitions(PCSX2_FLAGS INTERFACE SPU2X_PULSEAUDIO)
+	target_link_libraries(PCSX2_FLAGS INTERFACE PulseAudio::PulseAudio)
 endif()
 
 if(XDG_STD)
-	target_compile_definitions(PCSX2 PRIVATE XDG_STD)
+	target_compile_definitions(PCSX2_FLAGS INTERFACE XDG_STD)
 endif()
 
 if(TARGET SDL::SDL)
-	target_compile_definitions(PCSX2 PRIVATE SDL_BUILD)
-	target_link_libraries(PCSX2 PRIVATE SDL::SDL)
+	target_compile_definitions(PCSX2_FLAGS INTERFACE SDL_BUILD)
+	target_link_libraries(PCSX2_FLAGS INTERFACE SDL::SDL)
 endif()
 
 if(WIN32)
@@ -83,7 +83,7 @@ if(WIN32)
 		windows/wxResources.rc
 		windows/PCSX2.manifest
 	)
-	target_compile_definitions(PCSX2 PRIVATE
+	target_compile_definitions(PCSX2_FLAGS INTERFACE
 		_M_SSE=0x401 # TODO: Multiple ISA
 		DIRECTINPUT_VERSION=0x0800
 		WINVER=0x0603
@@ -92,7 +92,7 @@ if(WIN32)
 		LZMA_API_STATIC
 		WIL_SUPPRESS_EXCEPTIONS
 	)
-	target_include_directories(PCSX2 PRIVATE
+	target_include_directories(PCSX2_FLAGS INTERFACE
 		../3rdparty # GL headers
 	)
 	set_target_properties(PCSX2 PROPERTIES WIN32_EXECUTABLE TRUE)
@@ -531,7 +531,7 @@ else(WIN32)
 	# PAD resources pre-compilation
 	set(PADImgHeader "${CMAKE_BINARY_DIR}/pcsx2/PAD/Linux/ImgHeader")
 	set(PADImg "${CMAKE_SOURCE_DIR}/pcsx2/PAD/Linux/Img")
-	target_include_directories(PCSX2 PRIVATE "${CMAKE_BINARY_DIR}/pcsx2/PAD/Linux/")
+	target_include_directories(PCSX2_FLAGS INTERFACE "${CMAKE_BINARY_DIR}/pcsx2/PAD/Linux/")
 
 	file(MAKE_DIRECTORY ${PADImgHeader})
 
@@ -900,7 +900,7 @@ else(WIN32)
 		GS/res/glsl/tfx_vgs.glsl)
 
 	set(GSBin "${CMAKE_BINARY_DIR}/pcsx2/GS")
-	target_include_directories(PCSX2 PRIVATE "${GSBin}")
+	target_include_directories(PCSX2_FLAGS INTERFACE "${GSBin}")
 	file(MAKE_DIRECTORY "${GSBin}")
 
 	add_custom_command(
@@ -1402,7 +1402,7 @@ if(Linux)
 		${pcsx2LinuxHeaders}
 		)
 
-	target_link_libraries(PCSX2 PRIVATE
+	target_link_libraries(PCSX2_FLAGS INTERFACE
 		PkgConfig::AIO
 		PkgConfig::EGL
 		PkgConfig::LIBUDEV
@@ -1412,7 +1412,7 @@ if(Linux)
 		ALSA::ALSA
 		)
 elseif(UNIX AND NOT APPLE)
-	target_link_libraries(PCSX2 PRIVATE X11::X11)
+	target_link_libraries(PCSX2_FLAGS INTERFACE X11::X11)
 endif()
 
 # Windows
@@ -1441,7 +1441,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "NetBS
 		${pcsx2LinuxHeaders})
 endif()
 
-target_link_libraries(PCSX2 PRIVATE
+target_link_libraries(PCSX2_FLAGS INTERFACE
 	common
 	fmt::fmt
 	yaml-cpp
@@ -1457,7 +1457,7 @@ target_link_libraries(PCSX2 PRIVATE
 )
 
 if(WIN32)
-	target_link_libraries(PCSX2 PRIVATE
+	target_link_libraries(PCSX2_FLAGS INTERFACE
 		baseclasses
 		pthreads4w
 		WIL::WIL
@@ -1478,7 +1478,7 @@ if(WIN32)
 		comsuppw.lib
 	)
 else()
-	target_link_libraries(PCSX2 PRIVATE
+	target_link_libraries(PCSX2_FLAGS INTERFACE
 		GTK::gtk
 		HarfBuzz::HarfBuzz
 		OpenGL::GL
@@ -1514,7 +1514,7 @@ foreach(res_file IN ITEMS
 endforeach()
 
 # additonal include directories
-target_include_directories(PCSX2 PRIVATE
+target_include_directories(PCSX2_FLAGS INTERFACE
 	.
 	x86
 	${CMAKE_BINARY_DIR}/pcsx2
@@ -1525,7 +1525,7 @@ target_include_directories(PCSX2 PRIVATE
 
 if(COMMAND target_precompile_headers)
 	message("Using precompiled headers.")
-	target_precompile_headers(PCSX2 PRIVATE PrecompiledHeader.h)
+	target_precompile_headers(PCSX2_FLAGS INTERFACE PrecompiledHeader.h)
 endif()
 
 if (APPLE)


### PR DESCRIPTION
### Description of Changes
Add option to cmake that runs LTO on the core emulator but nothing else, and enable it in the CI

### Rationale behind Changes
The intermediate files for LTO on everything on Windows+Ninja manage to take up so much disk space we fill up the entire CI runner, which isn't great.  Running LTO on core only uses up about 230MB of (zstd-compressed) buildcache, so I assume 1-2gb of disk, which isn't anywhere close to the ~12GB we're allotted, so I don't expect to run out of space any time soon.

### Suggested Testing Steps
Test CMake binary and compare to msbuild SSE4 binaries, make sure performance is similar
