### PR TITLE
EE: Fix JIT exits on 64-bit Windows

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(common PRIVATE
 	EventSource.cpp
 	Exceptions.cpp
 	FastFormatString.cpp
+	FastJmp.cpp
 	IniInterface.cpp
 	Mutex.cpp
 	PathUtils.cpp
@@ -63,6 +64,7 @@ target_sources(common PRIVATE
 	Dependencies.h
 	EventSource.h
 	Exceptions.h
+	FastJmp.h
 	General.h
 	MemcpyFast.h
 	MemsetFast.inl
@@ -114,6 +116,8 @@ if(USE_VTUNE)
 endif()
 
 if(WIN32)
+	enable_language(ASM_MASM)
+	target_sources(common PRIVATE FastJmp.asm)
 	target_link_libraries(common PUBLIC pthreads4w Winmm.lib)
 endif()
 

--- a/common/FastJmp.asm
+++ b/common/FastJmp.asm
@@ -1,0 +1,129 @@
+; PCSX2 - PS2 Emulator for PCs
+; Copyright (C) 2002-2021  PCSX2 Dev Team
+;
+; PCSX2 is free software: you can redistribute it and/or modify it under the terms
+; of the GNU Lesser General Public License as published by the Free Software Found-
+; ation, either version 3 of the License, or (at your option) any later version.
+;
+; PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+; PURPOSE.  See the GNU General Public License for more details.
+;
+; You should have received a copy of the GNU General Public License along with PCSX2.
+; If not, see <http://www.gnu.org/licenses/>.
+
+IFDEF _M_X86_32
+
+; -----------------------------------------
+; 32-bit X86
+; -----------------------------------------
+  .386
+  .model flat
+
+_TEXT         SEGMENT
+
+PUBLIC @fastjmp_set@4
+PUBLIC @fastjmp_jmp@8
+
+; void fastjmp_set(fastjmp_buf*)
+@fastjmp_set@4   PROC
+  mov eax, dword ptr [esp]
+  mov edx, esp                              ; fixup stack pointer, so it doesn't include the call to fastjmp_set
+  add edx, 4
+  mov dword ptr [ecx], eax                  ; actually eip
+  mov dword ptr [ecx + 4], ebx
+  mov dword ptr [ecx + 8], edx              ; actually esp
+  mov dword ptr [ecx + 12], ebp
+  mov dword ptr [ecx + 16], esi
+  mov dword ptr [ecx + 20], edi
+  xor eax, eax
+  ret
+@fastjmp_set@4   ENDP
+
+; void __fastcall fastjmp_jmp(fastjmp_buf*, int)
+@fastjmp_jmp@8   PROC
+  mov eax, edx                              ; return code
+  mov edx, dword ptr [ecx + 0]
+  mov ebx, dword ptr [ecx + 4]
+  mov esp, dword ptr [ecx + 8]
+  mov ebp, dword ptr [ecx + 12]
+  mov esi, dword ptr [ecx + 16]
+  mov edi, dword ptr [ecx + 20]
+  jmp edx
+@fastjmp_jmp@8   ENDP
+
+_TEXT         ENDS
+
+ENDIF      ; _M_X86_32
+
+IFDEF _M_X86_64
+; -----------------------------------------
+; 64-bit X86
+; -----------------------------------------
+_TEXT         SEGMENT
+
+PUBLIC fastjmp_set
+PUBLIC fastjmp_jmp
+
+; void fastjmp_set(fastjmp_buf*)
+fastjmp_set   PROC
+  mov rax, qword ptr [rsp]
+  mov rdx, rsp                              ; fixup stack pointer, so it doesn't include the call to fastjmp_set
+  add rdx, 8
+  mov qword ptr [rcx], rax                  ; actually rip
+  mov qword ptr [rcx + 8], rbx
+  mov qword ptr [rcx + 16], rdx             ; actually rsp
+  mov qword ptr [rcx + 24], rbp
+  mov qword ptr [rcx + 32], rsi
+  mov qword ptr [rcx + 40], rdi
+  mov qword ptr [rcx + 48], r12
+  mov qword ptr [rcx + 56], r13
+  mov qword ptr [rcx + 64], r14
+  mov qword ptr [rcx + 72], r15
+  movaps xmmword ptr [rcx + 80], xmm6
+  movaps xmmword ptr [rcx + 96], xmm7
+  movaps xmmword ptr [rcx + 112], xmm8
+  add rcx, 112                              ; split to two batches to fit displacement in a single byte
+  movaps xmmword ptr [rcx + 16], xmm9
+  movaps xmmword ptr [rcx + 32], xmm10
+  movaps xmmword ptr [rcx + 48], xmm11
+  movaps xmmword ptr [rcx + 64], xmm12
+  movaps xmmword ptr [rcx + 80], xmm13
+  movaps xmmword ptr [rcx + 96], xmm14
+  movaps xmmword ptr [rcx + 112], xmm15
+  xor eax, eax
+  ret
+fastjmp_set   ENDP
+
+; void fastjmp_jmp(fastjmp_buf*, int)
+fastjmp_jmp   PROC
+  mov eax, edx                              ; return code
+  mov rdx, qword ptr [rcx + 0]              ; actually rip
+  mov rbx, qword ptr [rcx + 8]
+  mov rsp, qword ptr [rcx + 16]
+  mov rbp, qword ptr [rcx + 24]
+  mov rsi, qword ptr [rcx + 32]
+  mov rdi, qword ptr [rcx + 40]
+  mov r12, qword ptr [rcx + 48]
+  mov r13, qword ptr [rcx + 56]
+  mov r14, qword ptr [rcx + 64]
+  mov r15, qword ptr [rcx + 72]
+  movaps xmm6, xmmword ptr [rcx + 80]
+  movaps xmm7, xmmword ptr [rcx + 96]
+  movaps xmm8, xmmword ptr [rcx + 112]
+  add rcx, 112                              ; split to two batches to fit displacement in a single byte
+  movaps xmm9, xmmword ptr [rcx + 16]
+  movaps xmm10, xmmword ptr [rcx + 32]
+  movaps xmm11, xmmword ptr [rcx + 48]
+  movaps xmm12, xmmword ptr [rcx + 64]
+  movaps xmm13, xmmword ptr [rcx + 80]
+  movaps xmm14, xmmword ptr [rcx + 96]
+  movaps xmm15, xmmword ptr [rcx + 112]
+  jmp rdx
+fastjmp_jmp   ENDP
+
+_TEXT         ENDS
+
+ENDIF     ; _M_X86_64
+
+END

--- a/common/FastJmp.cpp
+++ b/common/FastJmp.cpp
@@ -1,0 +1,92 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FastJmp.h"
+
+#ifndef _WIN32
+
+#if defined(__APPLE__)
+#define PREFIX "_"
+#else
+#define PREFIX ""
+#endif
+
+#if defined(_M_X86_64)
+
+asm(
+	"\t.global " PREFIX "fastjmp_set\n"
+	"\t.global " PREFIX "fastjmp_jmp\n"
+	"\t.text\n"
+	"\t" PREFIX "fastjmp_set:" R"(
+	movq 0(%rsp), %rax
+	movq %rsp, %rdx			# fixup stack pointer, so it doesn't include the call to fastjmp_set
+	addq $8, %rdx
+	movq %rax, 0(%rdi)	# actually rip
+	movq %rbx, 8(%rdi)
+	movq %rdx, 16(%rdi)	# actually rsp
+	movq %rbp, 24(%rdi)
+	movq %r12, 32(%rdi)
+	movq %r13, 40(%rdi)
+	movq %r14, 48(%rdi)
+	movq %r15, 56(%rdi)
+	xorl %eax, %eax
+	ret
+)"
+	"\t" PREFIX "fastjmp_jmp:" R"(
+	movl %esi, %eax
+	movq 0(%rdi), %rdx	# actually rip
+	movq 8(%rdi), %rbx
+	movq 16(%rdi), %rsp	# actually rsp
+	movq 24(%rdi), %rbp
+	movq 32(%rdi), %r12
+	movq 40(%rdi), %r13
+	movq 48(%rdi), %r14
+	movq 56(%rdi), %r15
+	jmp *%rdx
+)");
+
+#elif defined(_M_X86_32)
+
+asm(
+	"\t.global " PREFIX "fastjmp_set\n"
+	"\t.global " PREFIX "fastjmp_jmp\n"
+	"\t.text\n"
+	"\t" PREFIX "fastjmp_set:" R"(
+	movl %eax, 0(%esp)
+	movl %esp, %edx			# fixup stack pointer, so it doesn't include the call to fastjmp_set
+	addl $4, %edx
+	movl %eax, 0(%ecx)	# actually eip
+	movl %ebx, 4(%ecx)
+	movl %edx, 8(%ecx)	# actually esp
+	movl %ebp, 12(%ecx)
+	movl %esi, 16(%ecx)
+	movl %edi, 20(%ecx)
+	xorl %eax, %eax
+	ret
+)"
+	"\t" PREFIX "fastjmp_jmp:" R"(
+	movl %edx, %eax
+	movl 0(%ecx), %edx	# actually eip
+	movl 4(%ecx), %ebx
+	movl 8(%ecx), %esp	# actually esp
+	movl 12(%ecx), %ebp
+	movl 16(%ecx), %esi
+	movl 20(%ecx), %edi
+	jmp *%edx
+)");
+
+#endif
+
+#endif // __WIN32

--- a/common/FastJmp.h
+++ b/common/FastJmp.h
@@ -1,0 +1,39 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "Pcsx2Defs.h"
+#include <cstdint>
+#include <cstddef>
+
+struct fastjmp_buf
+{
+#if defined(_M_X86_64) && defined(_WIN32)
+	static constexpr std::size_t BUF_SIZE = 240;
+#elif defined(_M_X86_64)
+	static constexpr std::size_t BUF_SIZE = 64;
+#elif defined(_M_X86_32)
+	static constexpr std::size_t BUF_SIZE = 24;
+#else
+#error Unknown architecture.
+#endif
+
+	alignas(16) std::uint8_t buf[BUF_SIZE];
+};
+
+extern "C" {
+int __fastcall fastjmp_set(fastjmp_buf* buf);
+__noreturn void __fastcall fastjmp_jmp(const fastjmp_buf* buf, int ret);
+}

--- a/common/Pcsx2Defs.h
+++ b/common/Pcsx2Defs.h
@@ -118,6 +118,7 @@ static const int __pagesize = PCSX2_PAGESIZE;
 #define __pagealigned __declspec(align(PCSX2_PAGESIZE))
 
 #define __noinline __declspec(noinline)
+#define __noreturn __declspec(noreturn)
 
 // Don't know if there are Visual C++ equivalents of these.
 #define likely(x) (!!(x))
@@ -160,6 +161,9 @@ static const int __pagesize = PCSX2_PAGESIZE;
 #endif
 #ifndef __noinline
 #define __noinline __attribute__((noinline))
+#endif
+#ifndef __noreturn
+#define __noreturn __attribute__((noreturn))
 #endif
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -15,7 +15,9 @@
     <UseDebugLibraries Condition="!$(Configuration.Contains(Debug))">false</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="vsprops\CommonLibrary.props" />
     <Import Project="vsprops\3rdpartyDeps.props" />
@@ -43,6 +45,9 @@
     <ClCompile Include="Console.cpp" />
     <ClCompile Include="Exceptions.cpp" />
     <ClCompile Include="FastFormatString.cpp" />
+    <ClCompile Include="FastJmp.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="IniInterface.cpp" />
     <ClCompile Include="pxStreams.cpp" />
     <ClCompile Include="pxTranslate.cpp" />
@@ -83,10 +88,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="EventSource.inl" />
+    <MASM Include="FastJmp.asm">
+      <FileType>Document</FileType>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">_M_X86_32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">_M_X86_64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </MASM>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EmbeddedImage.h" />
     <ClInclude Include="boost_spsc_queue.hpp" />
+    <ClInclude Include="FastJmp.h" />
     <ClInclude Include="ScopedAlloc.h" />
     <ClInclude Include="ThreadingInternal.h" />
     <ClInclude Include="Assertions.h" />
@@ -146,5 +157,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  </ImportGroup>
 </Project>

--- a/common/common.vcxproj.filters
+++ b/common/common.vcxproj.filters
@@ -118,6 +118,9 @@
     <ClCompile Include="emitter\x86emitter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FastJmp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Assertions.h">
@@ -264,6 +267,9 @@
     <ClInclude Include="StringHelpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FastJmp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -277,5 +283,10 @@
     <None Include="EventSource.inl">
       <Filter>Source Files</Filter>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <MASM Include="FastJmp.asm">
+      <Filter>Source Files</Filter>
+    </MASM>
   </ItemGroup>
 </Project>

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -367,7 +367,7 @@ u32 g_nextEventCycle = 0;
 // and the recompiler.  (moved here to help alleviate redundant code)
 __fi void _cpuEventTest_Shared()
 {
-	ScopedBool etest(eeEventTestIsActive);
+	eeEventTestIsActive = true;
 	g_nextEventCycle = cpuRegs.cycle + eeWaitCycles;
 
 	// ---- INTC / DMAC (CPU-level Exceptions) -----------------
@@ -463,6 +463,8 @@ __fi void _cpuEventTest_Shared()
 
 	// Apply vsync and other counter nextCycles
 	cpuSetNextEvent( nextsCounter, nextCounter );
+
+	eeEventTestIsActive = false;
 }
 
 __ri void cpuTestINTCInts()

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -762,7 +762,7 @@ static void recExecute()
 	if (!setjmp(m_SetJmp_StateCheck))
 	{
 		eeRecIsReset = false;
-		ScopedBool executing(eeCpuExecuting);
+		eeCpuExecuting = true;
 
 		// Important! Most of the console logging and such has cancel points in it.  This is great
 		// in Windows, where SEH lets us safely kill a thread from anywhere we want.  This is bad
@@ -778,6 +778,8 @@ static void recExecute()
 	{
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &oldstate);
 	}
+
+	eeCpuExecuting = false;
 
 	if (m_cpuException)
 		m_cpuException->Rethrow();

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -36,7 +36,7 @@
 #include "Patch.h"
 
 #if !PCSX2_SEH
-	#include <csetjmp>
+	#include "common/FastJmp.h"
 #endif
 
 
@@ -703,7 +703,7 @@ void recStep()
 
 #if !PCSX2_SEH
 	#define SETJMP_CODE(x) x
-	static jmp_buf m_SetJmp_StateCheck;
+	static fastjmp_buf m_SetJmp_StateCheck;
 	static std::unique_ptr<BaseR5900Exception> m_cpuException;
 	static ScopedExcept m_Exception;
 #else
@@ -721,7 +721,7 @@ static void recExitExecution()
 	// creates.  However, the longjump is slow so we only want to do one when absolutely
 	// necessary:
 
-	longjmp(m_SetJmp_StateCheck, 1);
+	fastjmp_jmp(&m_SetJmp_StateCheck, 1);
 #endif
 }
 
@@ -759,7 +759,7 @@ static void recExecute()
 	// setjmp will save the register context and will return 0
 	// A call to longjmp will restore the context (included the eip/rip)
 	// but will return the longjmp 2nd parameter (here 1)
-	if (!setjmp(m_SetJmp_StateCheck))
+	if (!fastjmp_set(&m_SetJmp_StateCheck))
 	{
 		eeRecIsReset = false;
 		eeCpuExecuting = true;


### PR DESCRIPTION
### Description of Changes
Currently exiting the recompiler (e.g. toggling frame limiting) crashes the emulator in 64-bit Windows builds, as it attempts to longjmp across the recompiler stack frames, which don't have any unwind information.

> Unhandled exception at 0x00007FFB7D43042D (ntdll.dll) in pcsx2x64-dbg.exe: 0xC00000FF: A malformed function table was encountered during an unwind operation.

This PR adds a replacement implementation for longjmp which simply saves/restores registers, and doesn't care about unwinding the stack. You shouldn't be creating any complex C++ objects between the recompiler exit point and where the execution state is checked anyway.

I used inline asm for Linux, and a separate asm file for Windows, mainly just to avoid the headache of cmake and supporting .s files. Strictly speaking we don't need to replace longjmp on Linux, but consistency across platforms is never a bad thing. At some point that SEH nonsense for 32-bit Windows should be dropped too.

### Rationale behind Changes
It was broken and crashing.

### Suggested Testing Steps
Make sure all platforms still work. I haven't checked Linux 32-bit.
