### PR TITLE
Perf: Fix missing include breaking builds with USE_VTUNE enabled

### DIFF
--- a/common/Perf.cpp
+++ b/common/Perf.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2015  PCSX2 Dev Team
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -15,6 +15,7 @@
 
 #include "common/Perf.h"
 #include "common/Pcsx2Types.h"
+#include "common/Dependencies.h"
 #ifdef __unix__
 #include <unistd.h>
 #endif


### PR DESCRIPTION
### Description of Changes
Perf.cpp relies on the _1kb,_4kb, etc constants defined in common/Dependencies.h

### Rationale behind Changes
Building with USE_VTUNE defined were broken
(ENABLE_VTUNE is set when USE_VTUNE is defined)

### Suggested Testing Steps
Try to build with vtune stupport
On linux it would be `cmake <your cmake params> -DUSE_VTUNE=1`

Works for me(tm)