### PR TITLE
GS-ogl: Fix regression that broke linux HW mode

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1930,12 +1930,16 @@ void GSDeviceOGL::SetupCBMisc(const GSVector4i& channel)
 void GSDeviceOGL::SetupPipeline(const VSSelector& vsel, const GSSelector& gsel, const PSSelector& psel)
 {
 	auto i = m_ps.find(psel);
-	GLuint ps = i->second;
+	GLuint ps;
 
 	if (i == m_ps.end())
 	{
 		ps = CompilePS(psel);
 		m_ps[psel] = ps;
+	}
+	else
+	{
+		ps = i->second;
 	}
 
 	{


### PR DESCRIPTION
### Description of Changes
Fix a minor regression that made the OGL renderer crash on linux (pr #4740 )

### Rationale behind Changes
It made OGL HW no longer useable, so it needed a fix.

### Suggested Testing Steps
See if it doesn't crash anymore.
