### PR TITLE
PGIF: Remove force fifo clear on GP1 (00-01)

### DIFF
--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -310,8 +310,6 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 
 			mcase(HW_PS1_GPU_DATA) :
 				ret = psxGPUr(addr);
-				//ret = psxHu32(addr); // old
-				DevCon.Warning("GPU Data Read %x", ret);
 			break;
 			
 			mcase(HW_PS1_GPU_STATUS) :

--- a/pcsx2/ps2/pgif.cpp
+++ b/pcsx2/ps2/pgif.cpp
@@ -233,17 +233,10 @@ u32 immRespHndl(u32 cmd, u32 data)
 void handleGp1Command(u32 cmd)
 {
 	//Check GP1() command and configure PGIF accordingly.
-	//Commands 0x00 - 0x01 are partially handled in ps1drv, we should just clear fifo.
+	//Commands 0x00 - 0x01, 0x03, 0x05 - 0x08 are fully handled in ps1drv.
 	const u32 cmdNr = ((cmd >> 24) & 0xFF) & 0x3F;
 	switch (cmdNr)
 	{
-		case 0:
-			// Pgpu reset, mostly handled by ps1drv (00201D64 in ps1drv). Comment for case 1 apply here too.
-			ringBufferClear(&rb_gp0);
-			break;
-		case 1: //Reset GP0 fifo, seems to check that something is empty, so maybe we should do the same before clear?
-			ringBufferClear(&rb_gp0);
-			break;
 		case 2: //Acknowledge GPU IRQ
 			ackGpuIrq1();
 			break;
@@ -273,6 +266,8 @@ void handleGp1Command(u32 cmd)
 						pgpu.stat.bits.DREQ = pgpu.stat.bits.RSEND;
 						break;
 				}
+			break;
+		default:
 			break;
 	}
 }


### PR DESCRIPTION
### Description of Changes
Remove GP0 ringbuffer clear on commands GP1 (00), and GP1 (01). 
Additionally remove annoying log from devbuilds, this one can be read from pgifLogs now. 

### Rationale behind Changes
This is done internally in ps1drv. First fifo_GP0_ready_for_data bit is set to 0, then driver read GP0 fifo into void until fifo is empty. 

### Suggested Testing Steps
Test some PS1 games for eventual regressions. But this shouldn't affect too much in terms of compatibility. Castlevania SOTN, THPS2, and RE2 still work like before.
