### PR TITLE
Move Vu overflow flag checks to a Gamefix + reorganise panel

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -34,7 +34,7 @@ allowed_game_fixes = [
     "GoemonTlbHack",
     "VUKickstartHack",
     "IbitHack",
-    "RatchetDynaHack",
+    "VUOverflowHack",
 ]
 allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack"]
 # Patches are allowed to have a 'default' key or a crc-32 key, followed by

--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -14344,6 +14344,8 @@ SLES-53744:
 SLES-53746:
   name: "Superman Returns"
   region: "PAL-E"
+  gameFixes:
+    - VUOverflowHack # Fixes SPS.
 SLES-53747:
   name: "Ed, Edd, 'n Eddy - The Misadventure"
   region: "PAL-E"
@@ -15535,15 +15537,23 @@ SLES-54347:
 SLES-54348:
   name: "Superman Returns"
   region: "PAL-F"
+  gameFixes:
+    - VUOverflowHack # Fixes SPS.
 SLES-54349:
   name: "Superman Returns"
   region: "PAL-I"
+  gameFixes:
+    - VUOverflowHack # Fixes SPS.
 SLES-54350:
   name: "Superman Returns"
   region: "PAL-G"
+  gameFixes:
+    - VUOverflowHack # Fixes SPS.
 SLES-54351:
   name: "Superman Returns"
   region: "PAL-S"
+  gameFixes:
+    - VUOverflowHack # Fixes SPS.
 SLES-54354:
   name: "Final Fantasy XII"
   region: "PAL-E"
@@ -38365,6 +38375,8 @@ SLUS-21434:
   name: "Superman Returns - The Video Game"
   region: "NTSC-U"
   compat: 4
+  gameFixes:
+    - VUOverflowHack # Fixes SPS.
 SLUS-21435:
   name: "One Piece - Grand Adventure"
   region: "NTSC-U"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -39,6 +39,7 @@ enum GamefixId
 	Fix_GoemonTlbMiss,
 	Fix_Ibit,
 	Fix_VUKickstart,
+	Fix_VUOverflow,
 
 	GamefixId_COUNT
 };
@@ -345,7 +346,8 @@ struct Pcsx2Config
 			GIFFIFOHack : 1,			// Enabled the GIF FIFO (more correct but slower)
 			GoemonTlbHack : 1,			// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
 			IbitHack : 1,				// I bit hack. Needed to stop constant VU recompilation in some games
-			VUKickstartHack : 1;		// Gives new VU programs a slight head start and runs VU's ahead of EE to avoid VU register reading/writing issues
+			VUKickstartHack : 1,		// Gives new VU programs a slight head start and runs VU's ahead of EE to avoid VU register reading/writing issues
+			VUOverflowHack : 1;			// Tries to simulate overflow flag checks (not really possible on x86 without soft floats)
 		BITFIELD_END
 
 		GamefixOptions();
@@ -532,6 +534,7 @@ TraceLogFilters&				SetTraceConfig();
 #define CHECK_VIFFIFOHACK			(EmuConfig.Gamefixes.VIFFIFOHack)    // Pretends to fill the non-existant VIF FIFO Buffer.
 #define CHECK_VIF1STALLHACK			(EmuConfig.Gamefixes.VIF1StallHack)  // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
 #define CHECK_GIFFIFOHACK			(EmuConfig.Gamefixes.GIFFIFOHack)	 // Enabled the GIF FIFO (more correct but slower)
+#define CHECK_VUOVERFLOWHACK		(EmuConfig.Gamefixes.VUOverflowHack) // Special Fix for Superman Returns, they check for overflows on PS2 floats which we can't do without soft floats.
 
 //------------ Advanced Options!!! ---------------
 #define CHECK_VU_OVERFLOW			(EmuConfig.Cpu.Recompiler.vuOverflow)

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -25,21 +25,21 @@ enum GamefixId
 {
 	GamefixId_FIRST = 0,
 
-	Fix_VuAddSub = GamefixId_FIRST,
-	Fix_FpuMultiply,
+	Fix_FpuMultiply = GamefixId_FIRST,
 	Fix_FpuNegDiv,
-	Fix_XGKick,
-	Fix_EETiming,
+	Fix_GoemonTlbMiss,
 	Fix_SkipMpeg,
 	Fix_OPHFlag,
+	Fix_EETiming,
 	Fix_DMABusy,
+	Fix_GIFFIFO,
 	Fix_VIFFIFO,
 	Fix_VIF1Stall,
-	Fix_GIFFIFO,
-	Fix_GoemonTlbMiss,
+	Fix_VuAddSub,
 	Fix_Ibit,
 	Fix_VUKickstart,
 	Fix_VUOverflow,
+	Fix_XGKick,
 
 	GamefixId_COUNT
 };
@@ -333,21 +333,21 @@ struct Pcsx2Config
 	{
 		BITFIELD32()
 			bool
-			VuAddSubHack : 1,			// Tri-ace games, they use an encryption algorithm that requires VU ADDI opcode to be bit-accurate.
 			FpuMulHack : 1,				// Tales of Destiny hangs.
 			FpuNegDivHack : 1,			// Gundam games messed up camera-view.
-			XgKickHack : 1,				// Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
-			EETimingHack : 1,			// General purpose timing hack.
+			GoemonTlbHack : 1,			// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
 			SkipMPEGHack : 1,			// Skips MPEG videos (Katamari and other games need this)
 			OPHFlagHack : 1,			// Bleach Blade Battlers
+			EETimingHack : 1,			// General purpose timing hack.
 			DMABusyHack : 1,			// Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.
+			GIFFIFOHack : 1,			// Enabled the GIF FIFO (more correct but slower)
 			VIFFIFOHack : 1,			// Pretends to fill the non-existant VIF FIFO Buffer.
 			VIF1StallHack : 1,			// Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
-			GIFFIFOHack : 1,			// Enabled the GIF FIFO (more correct but slower)
-			GoemonTlbHack : 1,			// Gomeon tlb miss hack. The game need to access unmapped virtual address. Instead to handle it as exception, tlb are preloaded at startup
+			VuAddSubHack : 1,			// Tri-ace games, they use an encryption algorithm that requires VU ADDI opcode to be bit-accurate.
 			IbitHack : 1,				// I bit hack. Needed to stop constant VU recompilation in some games
 			VUKickstartHack : 1,		// Gives new VU programs a slight head start and runs VU's ahead of EE to avoid VU register reading/writing issues
-			VUOverflowHack : 1;			// Tries to simulate overflow flag checks (not really possible on x86 without soft floats)
+			VUOverflowHack : 1,			// Tries to simulate overflow flag checks (not really possible on x86 without soft floats)
+			XgKickHack : 1;				// Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
 		BITFIELD_END
 
 		GamefixOptions();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -256,21 +256,21 @@ int Pcsx2Config::GSOptions::GetVsync() const
 
 const wxChar *const tbl_GamefixNames[] =
 {
-	L"VuAddSub",
 	L"FpuMul",
 	L"FpuNegDiv",
-	L"XGKick",
-	L"EETiming",
+	L"GoemonTlb",
 	L"SkipMPEG",
 	L"OPHFlag",
+	L"EETiming",
 	L"DMABusy",
+	L"GIFFIFO",
 	L"VIFFIFO",
 	L"VIF1Stall",
-	L"GIFFIFO",
-	L"GoemonTlb",
+	L"VuAddSub",
 	L"Ibit",
 	L"VUKickstart",
-	L"VUOverflow"
+	L"VUOverflow",
+	L"XGKick"
 };
 
 const __fi wxChar* EnumToString( GamefixId id )

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -269,7 +269,8 @@ const wxChar *const tbl_GamefixNames[] =
 	L"GIFFIFO",
 	L"GoemonTlb",
 	L"Ibit",
-	L"VUKickstart"
+	L"VUKickstart",
+	L"VUOverflow"
 };
 
 const __fi wxChar* EnumToString( GamefixId id )
@@ -329,7 +330,8 @@ void Pcsx2Config::GamefixOptions::Set( GamefixId id, bool enabled )
 		case Fix_GIFFIFO:		GIFFIFOHack			= enabled;  break;
 		case Fix_GoemonTlbMiss: GoemonTlbHack		= enabled;  break;
 		case Fix_Ibit:			IbitHack			= enabled;  break;
-		case Fix_VUKickstart:	VUKickstartHack		= enabled; break;
+		case Fix_VUKickstart:	VUKickstartHack		= enabled;  break;
+		case Fix_VUOverflow:	VUOverflowHack		= enabled;  break;
 		jNO_DEFAULT;
 	}
 }
@@ -353,6 +355,7 @@ bool Pcsx2Config::GamefixOptions::Get( GamefixId id ) const
 		case Fix_GoemonTlbMiss: return GoemonTlbHack;
 		case Fix_Ibit:			return IbitHack;
 		case Fix_VUKickstart:	return VUKickstartHack;
+		case Fix_VUOverflow:	return VUOverflowHack;
 		jNO_DEFAULT;
 	}
 	return false;		// unreachable, but we still need to suppress warnings >_<
@@ -376,6 +379,7 @@ void Pcsx2Config::GamefixOptions::LoadSave( IniInterface& ini )
 	IniBitBool( GoemonTlbHack );
 	IniBitBool( IbitHack );
 	IniBitBool( VUKickstartHack );
+	IniBitBool( VUOverflowHack );
 }
 
 

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -37,10 +37,6 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 	const CheckTextMess check_text[GamefixId_COUNT] =
 	{
 		{
-			_("VU Add Hack - Fixes Tri-Ace games boot crash."),
-			_("Games that need this hack to boot:\n * Star Ocean 3\n * Radiata Stories\n * Valkyrie Profile 2")
-		},
-		{
 			_("FPU Multiply Hack - For Tales of Destiny."),
 			wxEmptyString
 		},
@@ -49,14 +45,8 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("VU XGkick Sync - Use accurate timing for VU XGKicks (Slower)"),
-			pxEt(L"Fixes graphical errors on WRC, Erementar Gerad, Tennis Court Smash and others."
-			)
-		},
-		{
-			_("EE timing hack - Multi purpose hack. Try if all else fails."),
-			pxEt( L"Known to affect following games:\n * Digital Devil Saga (Fixes FMV and crashes)\n * SSX (Fixes bad graphics and crashes)\n * Resident Evil: Dead Aim (Causes garbled textures)"
-			)
+			_("Preload TLB hack to avoid tlb miss on Goemon"),
+			wxEmptyString
 		},
 		{
 			_("Skip MPEG hack - Skips videos/FMVs in games to avoid game hanging/freezes."),
@@ -68,9 +58,18 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			)
 		},
 		{
+			_("EE timing hack - Multi purpose hack. Try if all else fails."),
+			pxEt(L"Known to affect following games:\n * Digital Devil Saga (Fixes FMV and crashes)\n * SSX (Fixes bad graphics and crashes)\n * Resident Evil: Dead Aim (Causes garbled textures)"
+			)
+		},
+		{
 			_("Handle DMAC writes when it is busy."),
 			pxEt( L"Known to affect following games:\n * Mana Khemia 1 (Going \"off campus\"), Metal Saga (Intro FMV), Pilot Down Behind Enemy Lines\n"
 			)
+		},
+		{
+			_("Force GIF PATH3 transfers through FIFO (Fifa Street 2)"),
+			wxEmptyString
 		},
 		{
 			_("Simulate VIF1 FIFO read ahead. Fixes slow loading games."),
@@ -82,12 +81,8 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("Force GIF PATH3 transfers through FIFO (Fifa Street 2)"),
-			wxEmptyString
-		},
-		{
-			_("Preload TLB hack to avoid tlb miss on Goemon"),
-			wxEmptyString
+			_("VU Add Hack - Fixes Tri-Ace games boot crash."),
+			_("Games that need this hack to boot:\n * Star Ocean 3\n * Radiata Stories\n * Valkyrie Profile 2")
 		},
 		{
 			_("VU I bit Hack avoid constant recompilation in some games (Scarface The World Is Yours, Crash Tag Team Racing)"),
@@ -100,6 +95,11 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 		{
 			_("VU Overflow hack to check for possible float overflows (Superman Returns)"),
 			wxEmptyString
+		},
+		{
+			_("VU XGkick Sync - Use accurate timing for VU XGKicks (Slower)"),
+			pxEt(L"Fixes graphical errors on WRC, Erementar Gerad, Tennis Court Smash and others."
+			)
 		}
 	};
 

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -96,6 +96,10 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 		{
 			_("VU Kickstart (Run ahead) to avoid sync problems when reading or writing VU registers"),
 			wxEmptyString
+		},
+		{
+			_("VU Overflow hack to check for possible float overflows (Superman Returns)"),
+			wxEmptyString
 		}
 	};
 


### PR DESCRIPTION
### Description of Changes
Moves the VU Overflow checks for MAC and Status flags to a game fix so it can be optionally enabled. Also rearranged the game fixes panel to make a bit more sense by grouping fixes together.

### Rationale behind Changes
x86 can't really check for overflowed PS2 floats because we don't have the range and it's not really possible to guess. Turns out our implementation breaks Chronicles or Narnia - Prince Caspian, but it's required for Superman Returns.
Fixes #4841

### Suggested Testing Steps
Not really much needs testing beyond Superman Returns and Chronicles of Narnia - Prince Caspian. I guess make sure the UI doesn't explode and the hacks turn on the correct hack when you manually enable them.
