### PR TITLE
USB: dshow: Initialize multi-threaded COM libs

### DIFF
--- a/pcsx2/USB/usb-eyetoy/cam-windows.cpp
+++ b/pcsx2/USB/usb-eyetoy/cam-windows.cpp
@@ -467,7 +467,6 @@ namespace usb_eyetoy
 			pSourceConfig = nullptr;
 			samplegrabber = nullptr;
 			callbackhandler = new CallbackHandler();
-			CoInitialize(NULL);
 			mpeg_buffer.start = calloc(1, 640 * 480 * 2);
 		}
 
@@ -479,6 +478,8 @@ namespace usb_eyetoy
 
 		int DirectShow::Open(int width, int height, FrameFormat format, int mirror)
 		{
+			dshowCoInitialize = wil::CoInitializeEx_failfast(COINIT_MULTITHREADED);
+
 			frame_width = width;
 			frame_height = height;
 			frame_format = format;
@@ -520,6 +521,7 @@ namespace usb_eyetoy
 			safe_release(pGraphBuilder);
 			safe_release(pGraph);
 			safe_release(pControl);
+			dshowCoInitialize.reset();
 			return 0;
 		};
 

--- a/pcsx2/USB/usb-eyetoy/cam-windows.h
+++ b/pcsx2/USB/usb-eyetoy/cam-windows.h
@@ -21,6 +21,8 @@
 #include <windows.h>
 #include <dshow.h>
 
+#include <wil/com.h>
+
 extern "C" {
 extern GUID IID_ISampleGrabberCB;
 extern GUID CLSID_SampleGrabber;
@@ -109,6 +111,7 @@ namespace usb_eyetoy
 		private:
 			int mPort;
 
+			wil::unique_couninitialize_call dshowCoInitialize;
 			ICaptureGraphBuilder2* pGraphBuilder;
 			IFilterGraph2* pGraph;
 			IMediaControl* pControl;


### PR DESCRIPTION
### Description of Changes
Initialize multi-threaded COM using `wil` helpers.

### Rationale behind Changes
Fix crashing caused by single/multi-threaded CoInitialize conflict.

### Suggested Testing Steps
Set USB to EyeToy with directshow api and run a game.