### PR TITLE
GS-hw: Don't write clamped depth test value to depth buffer when ZMSK is enabled.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -135,7 +135,7 @@ void GSRendererDX11::EmulateZbuffer()
 		{
 			vs_cb.MaxDepth = GSVector2i(max_z);
 		}
-		else
+		else if (!m_context->ZBUF.ZMSK)
 		{
 			ps_cb.Af_MaxDepth.y = max_z * ldexpf(1, -32);
 			m_ps_sel.zclamp = 1;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -146,7 +146,7 @@ void GSRendererOGL::EmulateZbuffer()
 		{
 			vs_cb.MaxDepth = GSVector2i(max_z);
 		}
-		else
+		else if (!m_context->ZBUF.ZMSK)
 		{
 			ps_cb.MaxDepth = GSVector4(0.0f, 0.0f, 0.0f, max_z * ldexpf(1, -32));
 			m_ps_sel.zclamp = 1;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Don't write clamped depth test value to depth buffer when ZMSK is enabled.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
We shouldn't write the clamped depth test value to the depth buffer when ZMSK is enabled.
Fixes missing shadows in Kingdom Hearts: Chain of Memories.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
https://forums.pcsx2.net/Thread-Kingdom-Hearts-Re-Chain-of-Memories-USA-shadow-and-black-line-bug