### PR TITLE
Common/StringHelpers: Fix printing of 64-bit pointers

### DIFF
--- a/common/StringHelpers.h
+++ b/common/StringHelpers.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cinttypes>
 #include <wx/tokenzr.h>
 #include "common/Dependencies.h"
 #include "common/SafeArray.h"
@@ -225,7 +226,11 @@ extern bool pxParseAssignmentString(const wxString& src, wxString& ldest, wxStri
 #define pxsFmt FastFormatUnicode().Write
 #define pxsFmtV FastFormatUnicode().WriteV
 
-#define pxsPtr(ptr) pxsFmt("0x%08X", (ptr)).c_str()
+#ifdef _M_X86_64
+#define pxsPtr(ptr) pxsFmt("0x%016" PRIXPTR, (ptr)).c_str()
+#else
+#define pxsPtr(ptr) pxsFmt("0x%08" PRIXPTR, (ptr)).c_str()
+#endif
 
 extern wxString& operator+=(wxString& str1, const FastFormatUnicode& str2);
 extern wxString operator+(const wxString& str1, const FastFormatUnicode& str2);


### PR DESCRIPTION
### Description of Changes

`pxsPtr` currently truncates 64-bit pointers to 32-bit. This is noticeable when printing the virtual addresses on startup, for example.

Long term I want to get rid of all this wxString nonsense, but this is a stopgap solution for now.

### Rationale behind Changes

It's displaying truncated/incorrect values.

### Suggested Testing Steps

Nothing to really test here, it's just debugging as far as I'm aware.
