### PR TITLE
GS: Cleanup ini ranges for some values.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSOsdManager.cpp
+++ b/pcsx2/GS/Renderers/Common/GSOsdManager.cpp
@@ -69,14 +69,14 @@ GSOsdManager::GSOsdManager()
 {
 	m_monitor_enabled       = theApp.GetConfigB("osd_monitor_enabled");
 	m_log_enabled           = theApp.GetConfigB("osd_log_enabled");
-	m_size                  = std::max(1, std::min(theApp.GetConfigI("osd_fontsize"), 100));
-	m_opacity               = std::max(0, std::min(theApp.GetConfigI("osd_color_opacity"), 100));
-	m_log_timeout           = std::max(2, std::min(theApp.GetConfigI("osd_log_timeout"), 10));
-	m_max_onscreen_messages = std::max(1, std::min(theApp.GetConfigI("osd_max_log_messages"), 20));
+	m_size                  = std::clamp(1, theApp.GetConfigI("osd_fontsize"), 100);
+	m_opacity               = std::clamp(0, theApp.GetConfigI("osd_color_opacity"), 100);
+	m_log_timeout           = std::clamp(2, theApp.GetConfigI("osd_log_timeout"), 10);
+	m_max_onscreen_messages = std::clamp(1, theApp.GetConfigI("osd_max_log_messages"), 20);
 
-	int r = std::max(0, std::min(theApp.GetConfigI("osd_color_r"), 255));
-	int g = std::max(0, std::min(theApp.GetConfigI("osd_color_g"), 255));
-	int b = std::max(0, std::min(theApp.GetConfigI("osd_color_b"), 255));
+	int r = std::clamp(0, theApp.GetConfigI("osd_color_r"), 255);
+	int g = std::clamp(0, theApp.GetConfigI("osd_color_g"), 255);
+	int b = std::clamp(0, theApp.GetConfigI("osd_color_b"), 255);
 
 	m_color = r | (g << 8) | (b << 16) | (255 << 24);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -29,7 +29,7 @@ GSDevice11::GSDevice11()
 	m_state.bf = -1;
 
 	m_mipmap = theApp.GetConfigI("mipmap");
-	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
+	m_upscale_multiplier = std::max(0, theApp.GetConfigI("upscale_multiplier"));
 
 	const BiFiltering nearest_filter = static_cast<BiFiltering>(theApp.GetConfigI("filter"));
 	const int aniso_level = theApp.GetConfigI("MaxAnisotropy");
@@ -306,9 +306,9 @@ bool GSDevice11::Create(const std::shared_ptr<GSWnd>& wnd)
 
 	ShaderMacro sm_sboost(m_shader.model);
 
-	sm_sboost.AddMacro("SB_SATURATION", std::max(0, std::min(theApp.GetConfigI("ShadeBoost_Saturation"), 100)));
-	sm_sboost.AddMacro("SB_BRIGHTNESS", std::max(0, std::min(theApp.GetConfigI("ShadeBoost_Brightness"), 100)));
-	sm_sboost.AddMacro("SB_CONTRAST", std::max(0, std::min(theApp.GetConfigI("ShadeBoost_Contrast"), 100)));
+	sm_sboost.AddMacro("SB_SATURATION", std::clamp(0, theApp.GetConfigI("ShadeBoost_Contrast"), 100));
+	sm_sboost.AddMacro("SB_BRIGHTNESS", std::clamp(0, theApp.GetConfigI("ShadeBoost_Brightness"), 100));
+	sm_sboost.AddMacro("SB_CONTRAST", std::clamp(0, theApp.GetConfigI("ShadeBoost_Saturation"), 100));
 
 	memset(&bd, 0, sizeof(bd));
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -34,7 +34,7 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_lod(GSVector2i(0, 0))
 {
 	m_mipmap = theApp.GetConfigI("mipmap_hw");
-	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
+	m_upscale_multiplier = std::max(0, theApp.GetConfigI("upscale_multiplier"));
 	m_conservative_framebuffer = theApp.GetConfigB("conservative_framebuffer");
 	m_accurate_date = theApp.GetConfigB("accurate_date");
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -471,9 +471,9 @@ bool GSDeviceOGL::Create(const std::shared_ptr<GSWnd>& wnd)
 	{
 		GL_PUSH("GSDeviceOGL::Shadeboost");
 
-		const int ShadeBoost_Contrast = std::max(0, std::min(theApp.GetConfigI("ShadeBoost_Contrast"), 100));
-		const int ShadeBoost_Brightness = std::max(0, std::min(theApp.GetConfigI("ShadeBoost_Brightness"), 100));
-		const int ShadeBoost_Saturation = std::max(0, std::min(theApp.GetConfigI("ShadeBoost_Saturation"), 100));
+		const int ShadeBoost_Contrast = std::clamp(0, theApp.GetConfigI("ShadeBoost_Contrast"), 100);
+		const int ShadeBoost_Brightness = std::clamp(0, theApp.GetConfigI("ShadeBoost_Brightness"), 100);
+		const int ShadeBoost_Saturation = std::clamp(0, theApp.GetConfigI("ShadeBoost_Saturation"), 100);
 		std::string shade_macro = format("#define SB_SATURATION %d.0\n", ShadeBoost_Saturation)
 			+ format("#define SB_BRIGHTNESS %d.0\n", ShadeBoost_Brightness)
 			+ format("#define SB_CONTRAST %d.0\n", ShadeBoost_Contrast);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Use clamp instead of min max for OSD and Shade Boost.
Don't allow negative value for upscale multiplier, avoids a black screen.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Cleaner code, avoids a black screen if upscale multiplier is negative.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure Shade boost, osd, upscaling still works.

Note: these changes are mostly for editing ini manually.