### PR TITLE
CDVD: Implement Disc Swapping

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -598,9 +598,6 @@ static void cdvdDetectDisk()
 			DevCon.Warning("Seeking");
 		}
 	}
-
-	if (cdvd.Type > 0 && cdvd.Type < 0x20)
-		cdvdReloadElfInfo();
 }
 
 // Note: Is tray status being kept as a var here somewhere?
@@ -667,7 +664,6 @@ s32 cdvdCtrlTrayClose()
 {
 	DevCon.WriteLn(Color_Green, L"Close virtual disk tray");
 
-	
 	if (!g_GameStarted && g_SkipBiosHack)
 	{
 		DevCon.WriteLn(Color_Green, L"Drive Engaging instantly");
@@ -776,6 +772,7 @@ void cdvdReset()
 
 	cdvd.sDataIn = 0x40;
 	cdvd.Ready = CDVD_READY2;
+	cdvd.Status = CDVD_STATUS_PAUSE;
 	cdvd.Speed = 4;
 	cdvd.BlockSize = 2064;
 	cdvd.Action = cdvdAction_None;
@@ -790,6 +787,12 @@ void cdvdReset()
 	cdvd.RTC.day = (u8)curtime.GetDay(wxDateTime::GMT9);
 	cdvd.RTC.month = (u8)curtime.GetMonth(wxDateTime::GMT9) + 1; // WX returns Jan as "0"
 	cdvd.RTC.year = (u8)(curtime.GetYear(wxDateTime::GMT9) - 2000);
+
+	g_GameStarted = false;
+	g_GameLoading = false;
+	g_SkipBiosHack = EmuConfig.UseBOOT2Injection;
+
+	cdvdCtrlTrayClose();
 }
 
 struct Freeze_v10Compat

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -76,6 +76,19 @@ struct cdvdRTC
 	u8 year;
 };
 
+enum TrayStates
+{
+	CDVD_DISC_ENGAGED,
+	CDVD_DISC_SEEKING,
+	CDVD_DISC_EJECT
+};
+
+struct cdvdTrayTimer
+{
+	u32 cdvdActionSeconds;
+	TrayStates trayState;
+};
+
 struct cdvdStruct
 {
 	u8 nCommand;
@@ -135,6 +148,8 @@ struct cdvdStruct
 	u32 SeekToSector; // Holds the destination sector during seek operations.
 	u32 ReadTime;     // Avg. time to read one block of data (in Iop cycles)
 	bool Spinning;    // indicates if the Cdvd is spinning or needs a spinup delay
+	bool mediaChanged;
+	cdvdTrayTimer Tray;
 };
 
 extern cdvdStruct cdvd;

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -72,7 +72,8 @@ enum cdvdStatus
 
 enum cdvdready
 {
-	CDVD_NOTREADY = 0x06,
+	CDVD_DRIVENOTREADY = 0x02,
+	CDVD_NCMDNOTREADY = 0x06,
 	CDVD_READY1 = 0x42,
 	CDVD_READY2 = 0x42 // This is used in a few places for some reason.
 					   //It would be worth checking if this was just a typo made at some point.

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -101,8 +101,6 @@ void cpuReset()
 	extern void Deci2Reset();		// lazy, no good header for it yet.
 	Deci2Reset();
 
-	g_GameStarted = false;
-	g_GameLoading = false;
 	g_SkipBiosHack = EmuConfig.UseBOOT2Injection;
 
 	ElfCRC = 0;
@@ -606,16 +604,11 @@ void __fastcall eeloadHook()
 {
 	const wxString &elf_override = GetCoreThread().GetElfOverride();
 
-	if (!cdvd.Type)
-	{
-		DoCDVDopen();
-		cdvdCtrlTrayClose();
-	
-		if (!elf_override.IsEmpty())
-			cdvdReloadElfInfo(L"host:" + elf_override);
-		else
-			cdvdReloadElfInfo();
-	}
+	if (!elf_override.IsEmpty())
+		cdvdReloadElfInfo(L"host:" + elf_override);
+	else
+		cdvdReloadElfInfo();
+
 	wxString discelf;
 	int disctype = GetPS2ElfName(discelf);
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -606,13 +606,16 @@ void __fastcall eeloadHook()
 {
 	const wxString &elf_override = GetCoreThread().GetElfOverride();
 
-	DoCDVDopen();
-	cdvdCtrlTrayClose();
-	if (!elf_override.IsEmpty())
-		cdvdReloadElfInfo(L"host:" + elf_override);
-	else
-		cdvdReloadElfInfo();
-
+	if (!cdvd.Type)
+	{
+		DoCDVDopen();
+		cdvdCtrlTrayClose();
+	
+		if (!elf_override.IsEmpty())
+			cdvdReloadElfInfo(L"host:" + elf_override);
+		else
+			cdvdReloadElfInfo();
+	}
 	wxString discelf;
 	int disctype = GetPS2ElfName(discelf);
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -606,6 +606,8 @@ void __fastcall eeloadHook()
 {
 	const wxString &elf_override = GetCoreThread().GetElfOverride();
 
+	DoCDVDopen();
+	cdvdCtrlTrayClose();
 	if (!elf_override.IsEmpty())
 		cdvdReloadElfInfo(L"host:" + elf_override);
 	else

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -692,6 +692,8 @@ void __fastcall eeloadHook()
 		{
 			if (disctype == 2)
 				elftoload = discelf.ToUTF8();
+			else
+				g_SkipBiosHack = false; // We're not fast booting, so disable it (Fixes some weirdness with the BIOS)
 		}
 
 		// When fast-booting, we insert the game's ELF name into EELOAD so that the game is called instead of the default call of

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -597,8 +597,8 @@ void AppCoreThread::OnResumeInThread(SystemsMask systemsToReinstate)
 	if (m_resetCdvd)
 	{
 		CDVDsys_ChangeSource(g_Conf->CdvdSource);
-		cdvdCtrlTrayOpen();
 		DoCDVDopen();
+		cdvdCtrlTrayOpen();
 		m_resetCdvd = false;
 	}
 	else if (systemsToReinstate & System_CDVD)


### PR DESCRIPTION
### Description of Changes
Inspired by the work by fldef in the repo here https://github.com/fldef/pcsx2-fldef and extended to work well with physical discs too

### Rationale behind Changes
Disc Swapping was completely broken in games which required it. This should hopefully resolve that.

### Suggested Testing Steps
Test swapping discs in games which need it, or the BIOS.  Dance Factory kinda works, but it doesn't display the track names, or something.

Fixes #3533
Fixes #3355
Fixes #91
Fixes Dance Factory (kinda, track names kinda freak out but not sure why that is, could be an issue with the DVD reader code, or just lack of track names)
Hopefully fixes everything on #4851