### PR TITLE
Config: Fix folder memory cards initial load

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -84,12 +84,12 @@ enum class FMVAspectRatioSwitchType : u8
 	MaxCount
 };
 
-enum MemoryCardType
+enum class MemoryCardType
 {
-	MemoryCard_None,
-	MemoryCard_File,
-	MemoryCard_Folder,
-	MemoryCard_MaxCount
+	Empty,
+	File,
+	Folder,
+	MaxCount
 };
 
 enum class LimiterModeType : u8

--- a/pcsx2/MemoryCardFile.cpp
+++ b/pcsx2/MemoryCardFile.cpp
@@ -297,7 +297,7 @@ void FileMemoryCard::Open()
 			cont = true;
 		}
 
-		if (EmuConfig.Mcd[slot].Type != MemoryCardType::MemoryCard_File)
+		if (EmuConfig.Mcd[slot].Type != MemoryCardType::File)
 		{
 			str = L"[is not memcard file]";
 			cont = true;
@@ -607,16 +607,16 @@ void FileMcd_EmuOpen()
 	{
 		if (EmuConfig.Mcd[slot].Enabled)
 		{
-			MemoryCardType type = MemoryCardType::MemoryCard_File; // default to file if we can't find anything at the path so it gets auto-generated
+			MemoryCardType type = MemoryCardType::File; // default to file if we can't find anything at the path so it gets auto-generated
 
 			const wxString path = EmuConfig.FullpathToMcd(slot);
 			if (wxFileExists(path))
 			{
-				type = MemoryCardType::MemoryCard_File;
+				type = MemoryCardType::File;
 			}
 			else if (wxDirExists(path))
 			{
-				type = MemoryCardType::MemoryCard_Folder;
+				type = MemoryCardType::Folder;
 			}
 
 			EmuConfig.Mcd[slot].Type = type;
@@ -642,9 +642,9 @@ s32 FileMcd_IsPresent(uint port, uint slot)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			return Mcd::impl.IsPresent(combinedSlot);
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.IsPresent(combinedSlot);
 		default:
 			return false;
@@ -656,10 +656,10 @@ void FileMcd_GetSizeInfo(uint port, uint slot, McdSizeInfo* outways)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			Mcd::impl.GetSizeInfo(combinedSlot, *outways);
 			break;
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			Mcd::implFolder.GetSizeInfo(combinedSlot, *outways);
 			break;
 		default:
@@ -672,9 +672,9 @@ bool FileMcd_IsPSX(uint port, uint slot)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			return Mcd::impl.IsPSX(combinedSlot);
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.IsPSX(combinedSlot);
 		default:
 			return false;
@@ -686,9 +686,9 @@ s32 FileMcd_Read(uint port, uint slot, u8* dest, u32 adr, int size)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			return Mcd::impl.Read(combinedSlot, dest, adr, size);
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.Read(combinedSlot, dest, adr, size);
 		default:
 			return 0;
@@ -700,9 +700,9 @@ s32 FileMcd_Save(uint port, uint slot, const u8* src, u32 adr, int size)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			return Mcd::impl.Save(combinedSlot, src, adr, size);
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.Save(combinedSlot, src, adr, size);
 		default:
 			return 0;
@@ -714,9 +714,9 @@ s32 FileMcd_EraseBlock(uint port, uint slot, u32 adr)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			return Mcd::impl.EraseBlock(combinedSlot, adr);
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.EraseBlock(combinedSlot, adr);
 		default:
 			return 0;
@@ -728,9 +728,9 @@ u64 FileMcd_GetCRC(uint port, uint slot)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			return Mcd::impl.GetCRC(combinedSlot);
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.GetCRC(combinedSlot);
 		default:
 			return 0;
@@ -745,7 +745,7 @@ void FileMcd_NextFrame(uint port, uint slot)
 		//case MemoryCardType::MemoryCard_File:
 		//	Mcd::impl.NextFrame( combinedSlot );
 		//	break;
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			Mcd::implFolder.NextFrame(combinedSlot);
 			break;
 		default:
@@ -758,10 +758,10 @@ bool FileMcd_ReIndex(uint port, uint slot, const wxString& filter)
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
 	switch (EmuConfig.Mcd[combinedSlot].Type)
 	{
-		//case MemoryCardType::MemoryCard_File:
+		//case MemoryCardType::File:
 		//	return Mcd::impl.ReIndex( combinedSlot, filter );
 		//	break;
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			return Mcd::implFolder.ReIndex(combinedSlot, EmuConfig.McdFolderAutoManage, filter);
 			break;
 		default:

--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -104,7 +104,7 @@ void FolderMemoryCard::Open(const wxString& fullPath, const Pcsx2Config::McdOpti
 	wxString str(configuredFileName.GetFullPath());
 	bool disabled = false;
 
-	if (mcdOptions.Enabled && mcdOptions.Type == MemoryCardType::MemoryCard_Folder)
+	if (mcdOptions.Enabled && mcdOptions.Type == MemoryCardType::Folder)
 	{
 		if (configuredFileName.GetFullName().IsEmpty())
 		{

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -622,7 +622,12 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	BaseFilenames = cfg.BaseFilenames;
 	Framerate = cfg.Framerate;
 	for (u32 i = 0; i < sizeof(Mcd) / sizeof(Mcd[0]); i++)
-		Mcd[i] = cfg.Mcd[i];
+	{
+		// Type will be File here, even if it's a folder, so we preserve the old value.
+		// When the memory card is re-opened, it should redetect anyway.
+		Mcd[i].Enabled = cfg.Mcd[i].Enabled;
+		Mcd[i].Filename = cfg.Mcd[i].Filename;
+	}
 
 	GzipIsoIndexTemplate = cfg.GzipIsoIndexTemplate;
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -511,7 +511,7 @@ Pcsx2Config::Pcsx2Config()
 		Mcd[slot].Filename = FileMcd_GetDefaultName(slot);
 
 		// Folder memory card is autodetected later.
-		Mcd[slot].Type = MemoryCardType::MemoryCard_File;
+		Mcd[slot].Type = MemoryCardType::File;
 	}
 
 	GzipIsoIndexTemplate = "$(f).pindex.tmp";

--- a/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
+++ b/pcsx2/gui/Dialogs/ConvertMemoryCardDialog.cpp
@@ -62,7 +62,7 @@ Dialogs::ConvertMemoryCardDialog::ConvertMemoryCardDialog( wxWindow* parent, con
 
 	s_padding += m_radio_CardType | pxSizerFlags::StdExpand();
 
-	if ( type != MemoryCardType::MemoryCard_File ) {
+	if ( type != MemoryCardType::File ) {
 		s_padding += Heading( pxE( L"Please note that the resulting file may not actually contain all saves, depending on how many are in the source memory card." ) );
 	}
 	s_padding += Heading( pxE( L"WARNING: Converting a memory card may take a while! Please do not close the emulator during the conversion process, even if the emulator is no longer responding to input." ) );
@@ -102,10 +102,10 @@ void Dialogs::ConvertMemoryCardDialog::CreateControls( const MemoryCardType sour
 	const RadioPanelItem tblForFolder[] = { toFile8MB, toFile16MB, toFile32MB, toFile64MB };
 
 	switch ( sourceType ) {
-		case MemoryCardType::MemoryCard_File:
+		case MemoryCardType::File:
 			m_radio_CardType = new pxRadioPanel( this, tblForFile );
 			break;
-		case MemoryCardType::MemoryCard_Folder:
+		case MemoryCardType::Folder:
 			m_radio_CardType = new pxRadioPanel( this, tblForFolder );
 			break;
 		default:
@@ -177,7 +177,7 @@ bool Dialogs::ConvertMemoryCardDialog::ConvertToFile( const wxFileName& sourcePa
 	FolderMemoryCard sourceFolderMemoryCard;
 	Pcsx2Config::McdOptions config;
 	config.Enabled = true;
-	config.Type = MemoryCardType::MemoryCard_Folder;
+	config.Type = MemoryCardType::Folder;
 	sourceFolderMemoryCard.Open( sourcePath.GetFullPath(), config, ( sizeInMB * 1024 * 1024 ) / FolderMemoryCard::ClusterSize, false, L"" );
 
 	u8 buffer[FolderMemoryCard::PageSizeRaw];
@@ -206,7 +206,7 @@ bool Dialogs::ConvertMemoryCardDialog::ConvertToFolder( const wxFileName& source
 	FolderMemoryCard targetFolderMemoryCard;
 	Pcsx2Config::McdOptions config;
 	config.Enabled = true;
-	config.Type = MemoryCardType::MemoryCard_Folder;
+	config.Type = MemoryCardType::Folder;
 	u32 adr = 0;
 
 	for ( int i = 0; i < 2; ++i ) {

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -62,7 +62,7 @@ bool EnumerateMemoryCard(McdSlotItem& dest, const wxFileName& filename, const wx
 	dest.IsFormatted = false;
 	dest.IsPresent = false;
 	dest.IsPSX = false;
-	dest.Type = MemoryCardType::MemoryCard_None;
+	dest.Type = MemoryCardType::Empty;
 
 	const wxString fullpath(filename.GetFullPath());
 	//DevCon.WriteLn( fullpath );
@@ -93,7 +93,7 @@ bool EnumerateMemoryCard(McdSlotItem& dest, const wxFileName& filename, const wx
 			dest.SizeInMB = 1; // MegaBIT
 		}
 
-		dest.Type = MemoryCardType::MemoryCard_File;
+		dest.Type = MemoryCardType::File;
 		dest.IsFormatted = IsMcdFormatted(mcdFile);
 		filename.GetTimes(NULL, &dest.DateModified, &dest.DateCreated);
 	}
@@ -113,7 +113,7 @@ bool EnumerateMemoryCard(McdSlotItem& dest, const wxFileName& filename, const wx
 
 		dest.SizeInMB = 0;
 
-		dest.Type = MemoryCardType::MemoryCard_Folder;
+		dest.Type = MemoryCardType::Folder;
 		dest.IsFormatted = IsMcdFormatted(mcdFile);
 		superBlockFileName.GetTimes(NULL, &dest.DateModified, &dest.DateCreated);
 	}

--- a/pcsx2/gui/Panels/MemoryCardPanels.h
+++ b/pcsx2/gui/Panels/MemoryCardPanels.h
@@ -64,7 +64,7 @@ struct McdSlotItem
 	{
 		Slot = -1;
 		SizeInMB = 0;
-		Type = MemoryCard_None;
+		Type = MemoryCardType::Empty;
 		
 		IsPSX = false;
 		IsPresent = false;


### PR DESCRIPTION
### Description of Changes

Fixed memory card folders being flagged as a non-present memory card if booting without opening the config dialog.

Also converted the type enum to a scoped enum, since I missed this in the other PR.

### Rationale behind Changes

Regression from #4786.

### Suggested Testing Steps

Make sure memory card folders load on a clean boot. I've checked it myself and they seem okay now.

Fixes #4862