### PR TITLE
Debugger: Fix Goto in Disasm option for memory view

### DIFF
--- a/pcsx2/gui/Debugger/CtrlMemView.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemView.cpp
@@ -342,7 +342,7 @@ void CtrlMemView::onPopupClick(wxCommandEvent& evt)
 			}
 			break;
 		case ID_MEMVIEW_GOTOINDISASM:
-			postEvent(debEVT_GOTOINDISASM, 1);
+			postEvent(debEVT_GOTOINDISASM, curAddress);
 			break;
 		case ID_MEMVIEW_GOTOADDRESS:
 			postEvent(debEVT_GOTOADDRESS, curAddress);


### PR DESCRIPTION
Was I drunk?

### Description of Changes
I was going to address 1 when you click "Goto in Disasm" in the memory view

### Rationale behind Changes
It's wrong and broken

### Suggested Testing Steps
Try the "Goto In Disasm" Context menu option in the memory viewer.

Fixes #4864 