### PR TITLE
CDVD: Time reads by sectors per second instead of bytes + Some rotational latency

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -689,11 +689,13 @@ static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode)
 	
 		const float sectorSpeed = (((float)(cdvd.SeekToSector - offset) / numSectors) * 0.60f) + 0.40f;
 
-		return ((PSXCLK * cdvd.BlockSize) / ((float)(((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed) * sectorSpeed));
+		return (PSXCLK / ((((mode == MODE_CDROM) ? CD_SECTORS_PERSECOND : DVD_SECTORS_PERSECOND) * cdvd.Speed) * sectorSpeed));
+		//return ((PSXCLK * cdvd.BlockSize) / ((float)(((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed) * sectorSpeed));
 	}
 	
 	// CLV Read Speed is constant
-	return ((PSXCLK * cdvd.BlockSize) / (float)(((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed));
+	//return ((PSXCLK * cdvd.BlockSize) / (float)(((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed));
+	return (PSXCLK / (((mode == MODE_CDROM) ? CD_SECTORS_PERSECOND : DVD_SECTORS_PERSECOND) * cdvd.Speed));
 }
 
 void cdvdReset()

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -135,6 +135,12 @@ static const uint PSX_DVD_READSPEED = 1382400; // Bytes per second, rough values
 static const uint CD_SECTORS_PERSECOND = 75;
 static const uint DVD_SECTORS_PERSECOND = 675;
 
+static const uint CD_MIN_ROTATION_X1 = 214;
+static const uint CD_MAX_ROTATION_X1 = 497;
+
+static const uint DVD_MIN_ROTATION_X1 = 570;
+static const uint DVD_MAX_ROTATION_X1 = 1515;
+
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".
 

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -132,6 +132,9 @@ static const uint tbl_ContigiousSeekDelta[3] =
 static const uint PSX_CD_READSPEED = 153600;   // Bytes per second, rough values from outer CD (CAV).
 static const uint PSX_DVD_READSPEED = 1382400; // Bytes per second, rough values from outer DVD (CAV).
 
+static const uint CD_SECTORS_PERSECOND = 75;
+static const uint DVD_SECTORS_PERSECOND = 675;
+
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".
 

--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -320,7 +320,6 @@ enum IopEventId
 	IopEvt_CdvdRead,
 	IopEvt_DEV9,
 	IopEvt_USB,
-	IopEvt_CdvdDMA,
 };
 
 extern void PSX_INT( IopEventId n, s32 ecycle);

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -178,7 +178,6 @@ static __fi void _psxTestInterrupts()
 	IopTestEvent(IopEvt_SIF2,		sif2Interrupt);	// SIF2
 	// Originally controlled by a preprocessor define, now PSX dependent.
 	if (psxHu32(HW_ICFG) & (1 << 3)) IopTestEvent(IopEvt_SIO, sioInterruptR);
-	IopTestEvent(IopEvt_CdvdDMA, 	cdvdDMAInterrupt);
 	IopTestEvent(IopEvt_CdvdRead,	cdvdReadInterrupt);
 
 	// Profile-guided Optimization (sorta)


### PR DESCRIPTION
### Description of Changes
Changes the block/sector timing to be based on sector per second instead of bytes per second
Also added rotational latency for reads which are not sequential to simulate waiting for the disc to go around, it's probably slower than it needs to be, but better safe than sorry (Shadowman)

### Rationale behind Changes
Doing timing by sectors per second is pretty much staple for PS1 emulators, but also calculating by the sector size based on a base CD speed (specifically) is incorrect, as a CD can read 75 sectors per second if in Data mode or CD Audio mode, despite CD Audio sectors being bigger.  This eradicates that problem.  The rotational latency adjusts the read timings for games such as Shadowman.  Also removed the DMA timing after the read, that probably isn't really needed.

### Suggested Testing Steps
Uhh test timing sensitive games I guess (SH2 still needs FastCDVD), CD Audio playback should be slightly smoother, but it still kinda sucks.

Games I don't care about:

Silent Hill 2
Victorious Boxers
Bob the fucking builder
Ecco the Dolphin (This is patched and that's all it will ever have)