### PR TITLE
Fixup a bunch of warning spam

### DIFF
--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -381,19 +381,19 @@ protected:
 	void OpenGS();
 	void CloseGS();
 
-	void OnStart();
-	void OnResumeReady();
+	void OnStart() override;
+	void OnResumeReady() override;
 
-	void OnSuspendInThread();
+	void OnSuspendInThread() override;
 	void OnPauseInThread(SystemsMask systemsToTearDown) override {}
 	void OnResumeInThread(SystemsMask systemsToReinstate) override;
-	void OnCleanupInThread();
+	void OnCleanupInThread() override;
 
 	void GenericStall( uint size );
 
 	// Used internally by SendSimplePacket type functions
 	void _FinishSimplePacket();
-	void ExecuteTaskInThread();
+	void ExecuteTaskInThread() override;
 };
 
 // GetMTGS() is a required external implementation. This function is *NOT* provided

--- a/pcsx2/System/SysThreads.h
+++ b/pcsx2/System/SysThreads.h
@@ -212,13 +212,13 @@ public:
 
 	bool HasPendingStateChangeRequest() const;
 
-	virtual void OnResumeReady();
+	virtual void OnResumeReady() override;
 	virtual void Reset();
 	virtual void ResetQuick();
-	virtual void Cancel(bool isBlocking = true);
-	virtual bool Cancel(const wxTimeSpan& timeout);
+	virtual void Cancel(bool isBlocking = true) override;
+	virtual bool Cancel(const wxTimeSpan& timeout) override;
 
-	virtual bool StateCheckInThread();
+	virtual bool StateCheckInThread() override;
 	virtual void VsyncInThread();
 	virtual void GameStartingInThread();
 
@@ -232,13 +232,13 @@ public:
 protected:
 	void _reset_stuff_as_needed();
 
-	virtual void Start();
-	virtual void OnStart();
+	virtual void Start() override;
+	virtual void OnStart() override;
 	virtual void OnSuspendInThread() override;
 	virtual void OnPauseInThread(SystemsMask systemsToTearDown) override { TearDownSystems(systemsToTearDown); }
 	virtual void OnResumeInThread(SystemsMask systemsToReinstate) override;
-	virtual void OnCleanupInThread();
-	virtual void ExecuteTaskInThread();
+	virtual void OnCleanupInThread() override;
+	virtual void ExecuteTaskInThread() override;
 	virtual void DoCpuReset();
 	virtual void DoCpuExecute();
 

--- a/pcsx2/gui/AppCoreThread.h
+++ b/pcsx2/gui/AppCoreThread.h
@@ -148,29 +148,29 @@ public:
 
 	void ResetCdvd() { m_resetCdvd = true; }
 
-	virtual void Suspend(bool isBlocking = false);
-	virtual void Resume();
-	virtual void Reset();
-	virtual void ResetQuick();
-	virtual void Cancel(bool isBlocking = true);
-	virtual bool StateCheckInThread();
+	virtual void Suspend(bool isBlocking = false) override;
+	virtual void Resume() override;
+	virtual void Reset() override;
+	virtual void ResetQuick() override;
+	virtual void Cancel(bool isBlocking = true) override;
+	virtual bool StateCheckInThread() override;
 	virtual void ChangeCdvdSource();
 
-	virtual void ApplySettings(const Pcsx2Config& src);
+	virtual void ApplySettings(const Pcsx2Config& src) override;
 
 protected:
-	virtual void DoCpuExecute();
+	virtual void DoCpuExecute() override;
 
-	virtual void OnResumeReady();
-	virtual void OnPause();
-	virtual void OnPauseDebug();
+	virtual void OnResumeReady() override;
+	virtual void OnPause() override;
+	virtual void OnPauseDebug() override;
 	virtual void OnResumeInThread(SystemsMask systemsToReinstate) override;
-	virtual void OnSuspendInThread();
-	virtual void OnCleanupInThread();
-	virtual void VsyncInThread();
-	virtual void GameStartingInThread();
-	virtual void ExecuteTaskInThread();
-	virtual void DoCpuReset();
+	virtual void OnSuspendInThread() override;
+	virtual void OnCleanupInThread() override;
+	virtual void VsyncInThread() override;
+	virtual void GameStartingInThread() override;
+	virtual void ExecuteTaskInThread() override;
+	virtual void DoCpuReset() override;
 };
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes
fixes warning spam on gcc

### Rationale behind Changes
be nice to see warnings we actually care about instead of a bunch of spam about not using `override`

### Suggested Testing Steps
if it builds it builds
