### PR TITLE
CDVD: Simulate 1 sector read ahead

### DIFF
--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -124,6 +124,7 @@ struct cdvdStruct
 	int nSectors;
 	int Readed;  // change to bool. --arcum42
 	int Reading; // same here.
+	int WaitingDMA;
 	int ReadMode;
 	int BlockSize; // Total bytes transfered at 1x speed
 	int Speed;
@@ -150,6 +151,7 @@ struct cdvdStruct
 	bool Spinning;    // indicates if the Cdvd is spinning or needs a spinup delay
 	bool mediaChanged;
 	cdvdTrayTimer Tray;
+	bool nextSectorBuffered;
 };
 
 extern cdvdStruct cdvd;
@@ -159,6 +161,7 @@ extern void cdvdReadLanguageParams(u8* config);
 extern void cdvdReset();
 extern void cdvdVsync();
 extern void cdvdActionInterrupt();
+extern void cdvdSectorReady();
 extern void cdvdReadInterrupt();
 extern void cdvdDMAInterrupt();
 

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -72,11 +72,9 @@ enum cdvdStatus
 
 enum cdvdready
 {
-	CDVD_DRIVENOTREADY = 0x02,
-	CDVD_NCMDNOTREADY = 0x06,
-	CDVD_READY1 = 0x42,
-	CDVD_READY2 = 0x42 // This is used in a few places for some reason.
-					   //It would be worth checking if this was just a typo made at some point.
+	CDVD_DRIVE_DATARDY = 0x2,
+	CDVD_DRIVE_PWOFF = 0x20,
+	CDVD_DRIVE_READY = 0x40,
 };
 
 // Cdvd actions tell the emulator how and when to respond to certain requests.

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -1074,6 +1074,10 @@ void psxDma3(u32 madr, u32 bcr, u32 chcr)
 
 			break;
 		case 0x41000200:
+			if (cdvd.WaitingDMA)
+			{
+				PSX_INT(IopEvt_CdvdRead, cdvd.BlockSize / 4); //Data should be already buffered so simulate DMA time
+			}
 			//SysPrintf("unhandled cdrom dma3: madr: %x, bcr: %x, chcr %x\n", madr, bcr, chcr);
 			return;
 

--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -318,6 +318,7 @@ enum IopEventId
 	IopEvt_Cdrom,
 	IopEvt_CdromRead,
 	IopEvt_CdvdRead,
+	IopEvt_CdvdSectorReady,
 	IopEvt_DEV9,
 	IopEvt_USB,
 };

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -179,6 +179,7 @@ static __fi void _psxTestInterrupts()
 	// Originally controlled by a preprocessor define, now PSX dependent.
 	if (psxHu32(HW_ICFG) & (1 << 3)) IopTestEvent(IopEvt_SIO, sioInterruptR);
 	IopTestEvent(IopEvt_CdvdRead,	cdvdReadInterrupt);
+	IopTestEvent(IopEvt_CdvdSectorReady, cdvdSectorReady);
 
 	// Profile-guided Optimization (sorta)
 	// The following ints are rarely called.  Encasing them in a conditional


### PR DESCRIPTION
### Description of Changes
Adds 1 sector read ahead of drive (for DataReady emulation) used by Winning Eleven 8 and Star Ocean 3

### Rationale behind Changes
CDVD can read ahead by 1 sector and marks data as "ready" and can be used for future reads (this is the only way I can see CD Audio ever working properly) So this is now emulating the timings of it when reading sequential sectors.

### Suggested Testing Steps
Play games, make sure they work ok, if you had any games that did "Read Time Out(10000)", then please try this PR.

No, it won't fix Victorious boxers, Bob the builders (which works with EE cycle rate -1) or Ecco (which has a patch)

Fixes #4550
Fixes #4079
