### PR TITLE
GUI: remove presets 4,5,6

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -889,7 +889,7 @@ void AppConfig::UiTemplateOptions::LoadSave(IniInterface& ini)
 
 int AppConfig::GetMaxPresetIndex()
 {
-	return 5;
+	return 2;
 }
 
 bool AppConfig::isOkGetPresetTextAndColor(int n, wxString& label, wxColor& c)
@@ -898,12 +898,9 @@ bool AppConfig::isOkGetPresetTextAndColor(int n, wxString& label, wxColor& c)
 		{
 			{_t("Safest (No hacks)"), L"Blue"},
 			{_t("Safe (Default)"), L"Dark Green"},
-			{_t("Balanced"), L"Forest Green"},
-			{_t("Aggressive"), L"Orange"},
-			{_t("Very Aggressive"), L"Red"},
-			{_t("Mostly Harmful"), L"Purple"}};
-	if (n < 0 || n > GetMaxPresetIndex())
-		return false;
+			{_t("Balanced"), L"Forest Green"}
+		} ;
+		n  = std::clamp(n, 0, GetMaxPresetIndex());
 
 	label = wxsFormat(L"%d - ", n + 1) + presetNamesAndColors[n][0];
 	c = wxColor(presetNamesAndColors[n][1]);
@@ -973,22 +970,9 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 
 	// Actual application of current preset over the base settings which all presets use (mostly pcsx2's default values).
 
-	bool isRateSet = false, isSkipSet = false, isMTVUSet = ignoreMTVU ? true : false; // used to prevent application of specific lower preset values on fallthrough.
+	bool  isMTVUSet = ignoreMTVU ? true : false; // used to prevent application of specific lower preset values on fallthrough.
 	switch (n) // Settings will waterfall down to the Safe preset, then stop. So, Balanced and higher will inherit any settings through Safe.
 	{
-		case 5: // Mostly Harmful
-			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = 1); // +1 EE cyclerate
-			isSkipSet ? 0 : (isSkipSet = true, EmuOptions.Speedhacks.EECycleSkip = 1); // +1 EE cycle skip
-			[[fallthrough]];
-
-		case 4: // Very Aggressive
-			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = -2); // -2 EE cyclerate
-			[[fallthrough]];
-
-		case 3: // Aggressive
-			isRateSet ? 0 : (isRateSet = true, EmuOptions.Speedhacks.EECycleRate = -1); // -1 EE cyclerate
-			[[fallthrough]];
-
 		case 2: // Balanced
 			isMTVUSet ? 0 : (isMTVUSet = true, EmuOptions.Speedhacks.vuThread = true); // Enable MTVU
 			[[fallthrough]];

--- a/pcsx2/gui/Dialogs/SysConfigDialog.cpp
+++ b/pcsx2/gui/Dialogs/SysConfigDialog.cpp
@@ -108,7 +108,7 @@ void Dialogs::SysConfigDialog::AddPresetsControl()
 		wxDefaultPosition, wxDefaultSize, wxHORIZONTAL /*| wxSL_AUTOTICKS | wxSL_LABELS */);
 	m_slider_presets->SetMinSize(wxSize(100,25));
 
-	const wchar_t* presetTooltip = pxEt(L"Presets apply some speed hacks that may boost speed on underpowered systems, or speed up games that have unusual performance requirements. Uncheck this box to apply settings manually.\n\n1) Safest - No speed hacks. Most reliable, but possibly slow setting.\n2) Safe - Default. A few speed hacks known to provide boosts, with minimal to no side effects.\n3) Balanced - May help quad core CPUs.\n4) Aggressive - May help underpowered CPUs on less demanding games, but risks causing problems in other cases.\n5) Very Aggressive - May help underpowered CPUs on less demanding games, but is likely to cause problems in other cases.\n6) Mostly Harmful - Harsh application of speed hacks. May help a very small set of games that have unusual performance requirements, but have adverse effects on most others. Not recommended for underpowered PCs.");
+	const wchar_t* presetTooltip = pxEt(L"Presets apply some speed hacks that may boost speed on underpowered systems, or speed up games that have unusual performance requirements. Uncheck this box to apply settings manually.\n\n1) Safest - No speed hacks. Most reliable, but possibly slow setting.\n2) Safe - Default. A few speed hacks known to provide boosts, with minimal to no side effects.\n3) Balanced - May help quad core CPUs.");
 
 	m_slider_presets->SetToolTip(
 		presetTooltip
@@ -120,6 +120,9 @@ void Dialogs::SysConfigDialog::AddPresetsControl()
 		presetTooltip
 	);
 	m_check_presets->SetValue(!!g_Conf->EnablePresets);
+
+	g_Conf->PresetIndex = std::clamp(g_Conf->PresetIndex, 0, AppConfig::GetMaxPresetIndex());
+
 	//Console.WriteLn("--> SysConfigDialog::AddPresetsControl: EnablePresets: %s", g_Conf->EnablePresets?"true":"false");
 
 	wxString l; wxColor c(wxColour( L"Red" ));


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
removes presets 4-6 and leaves presets  1-3 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Preset 4-6 cause more issues than they help , so getting rid of them stops user error and user headache 

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
make sure the slider for the presets dont crash  