### PR TITLE
gs-tc: propagate texture shuffle format on readback

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1089,6 +1089,16 @@ void GSTextureCache::InvalidateLocalMem(GSOffset* off, const GSVector4i& r)
 
 				// note: r.rintersect breaks Wizardry and Chaos Legion
 				// Read(t, t->m_valid) works in all tested games but is very slow in GUST titles ><
+
+				// propagate the format from the result of a channel effect
+				// texture is 16/8 bit but the real data is 32
+				// common use for shuffling is moving data into the alpha channel
+				// the game can then draw using 8H format
+				// in the case of silent hill blit 8H -> 8P
+				// this will matter later when the data ends up in GS memory in the wrong format
+				if (t->m_32_bits_fmt)
+					t->m_TEX0.PSM = PSM_PSMCT32;
+
 				if (GSTextureCache::m_disable_partial_invalidation)
 				{
 					Read(t, r.rintersect(t->m_valid));


### PR DESCRIPTION
### Description of Changes
Read back PSMCT32 when the texture being blit is the result of a channel effect. This is not exactly right but there's no harm in having the extra data in cpu memory since it's supposed to be there anyway. The only issue is it gets unscaled.

fixes https://github.com/PCSX2/pcsx2/issues/1326
fixes https://github.com/PCSX2/pcsx2/issues/2732

### Rationale behind Changes
Fixes silent hill flashlight.
![image](https://user-images.githubusercontent.com/26046960/136491755-b335cd77-5221-4908-ad8c-e6201f342252.png)


### Suggested Testing Steps
If you plan on testing silent hill, the game still needs fast texture invalidation.
