### PR TITLE
IOP Recompiler: Fix BIOS trace logging on 64bit

### DIFF
--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -574,7 +574,12 @@ static void psxRecompileIrxImport()
 
 	if (SysTraceActive(IOP.Bios))
 	{
-		xPUSH((uptr)funcname);
+		#ifdef __M_X86_64
+			xMOV64(arg3reg, (uptr)funcname);
+		#else
+			xPUSH((uptr)funcname);
+		#endif
+
 		xFastCall((void*)irxImportLog_rec, import_table, index);
 	}
 


### PR DESCRIPTION
### Description of Changes
Fixes IOP BIOS trace logging on 64bit calling conventions.

### Rationale behind Changes
It was crashing before.

### Suggested Testing Steps
Check that trace logging works/doesn't crash
