### PR TITLE
GS Debugger: Show "D3D11 HW" only on windows.

### DIFF
--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -84,8 +84,10 @@ Dialogs::GSDumpDialog::GSDumpDialog(wxWindow* parent)
 	wxArrayString rdoverrides;
 	rdoverrides.Add("None");
 	rdoverrides.Add("OGL SW");
-	rdoverrides.Add("D3D11 HW");
 	rdoverrides.Add("OGL HW");
+#if defined(_WIN32)
+	rdoverrides.Add("D3D11 HW");
+#endif
 	m_renderer_overrides->Create(this, wxID_ANY, "Renderer overrides", wxDefaultPosition, wxDefaultSize, rdoverrides, 1);
 
 	dbg_tree->Add(new wxStaticText(this, wxID_ANY, _("GIF Packets")));
@@ -708,13 +710,13 @@ void Dialogs::GSDumpDialog::GSThread::ExecuteTaskInThread()
 		case 1:
 			renderer_override = 13;
 			break;
-		// D3D11 HW
-		case 2:
-			renderer_override = 3;
-			break;
 		// OGL HW
-		case 3:
+		case 2:
 			renderer_override = 12;
+			break;
+		// D3D11 HW
+		case 3:
+			renderer_override = 3;
 			break;
 		default:
 			break;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Show "D3D11 HW" only on windows.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
No need to show the option on Linux/Mac.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test GS Debugger if the options work properly and display on windows/linux.