### PR TITLE
COP2: Simplify reg allocation

### DIFF
--- a/pcsx2/x86/iCore.h
+++ b/pcsx2/x86/iCore.h
@@ -176,7 +176,8 @@ void _clearNeededXMMregs();
 void _deleteGPRtoXMMreg(int reg, int flush);
 void _deleteFPtoXMMreg(int reg, int flush);
 void _freeXMMreg(u32 xmmreg);
-u16 _freeXMMregsCOP2(int requiredcount);
+void _clearNeededCOP2Regs();
+u16 _freeXMMregsCOP2();
 //void _moveXMMreg(int xmmreg); // instead of freeing, moves it to a diff location
 void _flushXMMregs();
 u8 _hasFreeXMMreg();

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -674,7 +674,7 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 	// First Pass
 	iPC = startPC / 4;
 	mVUsetupRange(mVU, startPC, 1); // Setup Program Bounds/Range
-	mVU.regAlloc->reset();          // Reset regAlloc
+	mVU.regAlloc->reset(false);          // Reset regAlloc
 	mVUinitFirstPass(mVU, pState, thisPtr);
 	mVUbranch = 0;
 	for (int branch = 0; mVUcount < endCount;)


### PR DESCRIPTION
### Description of Changes
Simplifies how the registers are allocated for COP2 so we don't need to know how many regs in advance.

### Rationale behind Changes
When I changed it to not flush everything on COP2, I made a stupid decision to make note of the regs we needed in advance and that just made problems for any future modification, this dynamically allocates it so we don't need to know in advance.

### Suggested Testing Steps
Run games, make sure the 3D isn't broken or exhibiting glitches that aren't in master
