### PR TITLE
Fix unparenthesized macro input

### DIFF
--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -116,8 +116,9 @@ void endMacroOp(int mode)
 #define REC_COP2_mVU0(f, opName, mode) \
 	void recV##f() \
 	{ \
-		setupMacroOp(mode, opName); \
-		if (mode & 4) \
+		int _mode = (mode); \
+		setupMacroOp(_mode, opName); \
+		if (_mode & 4) \
 		{ \
 			mVU_##f(microVU0, 0); \
 			if (!microVU0.prog.IRinfo.info[0].lOp.isNOP) \
@@ -129,7 +130,7 @@ void endMacroOp(int mode)
 		{ \
 			mVU_##f(microVU0, 1); \
 		} \
-		endMacroOp(mode); \
+		endMacroOp(_mode); \
 	}
 
 #define INTERPRETATE_COP2_FUNC(f) \


### PR DESCRIPTION
### Description of Changes
Parenthesize all the things

Also fixes a clang warning that `converting the result of '?:' with integer constants to a boolean always evaluates to 'true'`

### Rationale behind Changes
Unparenthesized macros are very confusing

### Suggested Testing Steps
I think this turns off pass1 for a bunch of microVU things, so make sure nothing was relying on it running (and if it was, signal it by actually including 4 in the bitflags instead of relying on weird macro operator precedence things)