### PR TITLE
Remove 30-day artifact retention on windows builds

### DIFF
--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -196,4 +196,3 @@ jobs:
         with:
           name: ${{ steps.artifact-metadata.outputs.name }}
           path: bin
-          retention-days: 30 # https://docs.github.com/en/free-pro-team@latest/actions/reference/usage-limits-billing-and-administration#artifact-and-log-retention-policy


### PR DESCRIPTION
### Description of Changes
Removes the line limiting artifact retention on windows builds to 30 days, which should revert it to default of 90 days

### Rationale behind Changes
Reduces the frequency we have to rerun builds to un-expire the artifacts
I couldn't find anything indicating limits on artifacts for public repos, if we end up hitting one we can put this back on

### Suggested Testing Steps
~~Wait 30 days and see if the artifacts are still there~~  Probably don't want to wait that long, so none