### PR TITLE
GS: Get rid of a bunch of warnings in GSDeviceOGL

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -666,44 +666,28 @@ void GSDeviceOGL::Flip()
 	}
 }
 
-void GSDeviceOGL::BeforeDraw()
-{
-}
-
-void GSDeviceOGL::AfterDraw()
-{
-}
-
 void GSDeviceOGL::DrawPrimitive()
 {
-	BeforeDraw();
 	m_va->DrawPrimitive();
-	AfterDraw();
 }
 
 void GSDeviceOGL::DrawPrimitive(int offset, int count)
 {
-	BeforeDraw();
 	m_va->DrawPrimitive(offset, count);
-	AfterDraw();
 }
 
 void GSDeviceOGL::DrawIndexedPrimitive()
 {
-	BeforeDraw();
 	if (!m_disable_hw_gl_draw)
 		m_va->DrawIndexedPrimitive();
-	AfterDraw();
 }
 
 void GSDeviceOGL::DrawIndexedPrimitive(int offset, int count)
 {
 	//ASSERT(offset + count <= (int)m_index.count);
 
-	BeforeDraw();
 	if (!m_disable_hw_gl_draw)
 		m_va->DrawIndexedPrimitive(offset, count);
-	AfterDraw();
 }
 
 void GSDeviceOGL::ClearRenderTarget(GSTexture* t, const GSVector4& c)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -554,15 +554,15 @@ private:
 
 	std::unique_ptr<GSTexture> m_font;
 
-	GSTexture* CreateSurface(int type, int w, int h, int format);
-	GSTexture* FetchSurface(int type, int w, int h, int format);
+	GSTexture* CreateSurface(int type, int w, int h, int format) final;
+	GSTexture* FetchSurface(int type, int w, int h, int format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
 	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex) final;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) final;
-	void RenderOsd(GSTexture* dt);
+	void RenderOsd(GSTexture* dt) final;
 
 	void OMAttachRt(GSTextureOGL* rt = NULL);
 	void OMAttachDs(GSTextureOGL* ds = NULL);
@@ -590,8 +590,6 @@ public:
 	void DrawPrimitive(int offset, int count);
 	void DrawIndexedPrimitive() final;
 	void DrawIndexedPrimitive(int offset, int count) final;
-	inline void BeforeDraw();
-	inline void AfterDraw();
 
 	void ClearRenderTarget(GSTexture* t, const GSVector4& c) final;
 	void ClearRenderTarget(GSTexture* t, uint32 c) final;
@@ -607,7 +605,7 @@ public:
 	void CopyRectConv(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, bool at_origin);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, int shader = 0, bool linear = true) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, GLuint ps, bool linear = true);
-	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha);
+	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, GLuint ps, int bs, OMColorMaskSelector cms, bool linear = true);
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm);
@@ -628,8 +626,8 @@ public:
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL) final;
 	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector());
 
-	virtual bool HasColorSparse() { return GLLoader::found_compatible_GL_ARB_sparse_texture2; }
-	virtual bool HasDepthSparse() { return GLLoader::found_compatible_sparse_depth; }
+	bool HasColorSparse() final { return GLLoader::found_compatible_GL_ARB_sparse_texture2; }
+	bool HasDepthSparse() final { return GLLoader::found_compatible_sparse_depth; }
 
 	void CreateTextureFX();
 	GLuint CompileVS(VSSelector sel);


### PR DESCRIPTION
### Description of Changes
What the title says.

### Rationale behind Changes
Compiler warnings are annoying. Especially those which are in header files and spam the build log.

### Suggested Testing Steps
Shouldn't be any functional changes.