### PR TITLE
Config: Fix zoom/stretch options not updating on Apply

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -361,7 +361,15 @@ struct Pcsx2Config
 				   OpEqu(FrameratePAL) &&
 
 				   OpEqu(FramesToDraw) &&
-				   OpEqu(FramesToSkip);
+				   OpEqu(FramesToSkip) &&
+
+				   OpEqu(AspectRatio) &&
+				   OpEqu(FMVAspectRatioSwitch) &&
+
+				   OpEqu(Zoom) &&
+				   OpEqu(StretchY) &&
+				   OpEqu(OffsetX) &&
+				   OpEqu(OffsetY);
 		}
 
 		bool operator!=(const GSOptions& right) const


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

Another regression from the decoupling PR.

### Suggested Testing Steps

Make sure applying these settings at runtime works. It does for me.
