### PR TITLE
Various GSDumpGUI Improvements

### DIFF
--- a/pcsx2/GS/GSLzma.cpp
+++ b/pcsx2/GS/GSLzma.cpp
@@ -34,6 +34,11 @@ GSDumpFile::GSDumpFile(char* filename, const char* repack_filename)
 	}
 }
 
+GSDumpFile::GSDumpFile(FILE* file, FILE* repack_file)
+	: m_repack_fp(repack_file), m_fp(file)
+{
+}
+
 void GSDumpFile::Repack(void* ptr, size_t size)
 {
 	if (m_repack_fp == nullptr)
@@ -56,7 +61,17 @@ GSDumpFile::~GSDumpFile()
 GSDumpLzma::GSDumpLzma(char* filename, const char* repack_filename)
 	: GSDumpFile(filename, repack_filename)
 {
+	Initialize();
+}
 
+GSDumpLzma::GSDumpLzma(FILE* file, FILE* repack_file)
+	: GSDumpFile(file, repack_file)
+{
+	Initialize();
+}
+
+void GSDumpLzma::Initialize()
+{
 	memset(&m_strm, 0, sizeof(lzma_stream));
 
 	lzma_ret ret = lzma_stream_decoder(&m_strm, UINT32_MAX, 0);
@@ -166,11 +181,11 @@ GSDumpLzma::~GSDumpLzma()
 GSDumpRaw::GSDumpRaw(char* filename, const char* repack_filename)
 	: GSDumpFile(filename, repack_filename)
 {
-	m_buff_size = 0;
-	m_area      = nullptr;
-	m_inbuf     = nullptr;
-	m_avail     = 0;
-	m_start     = 0;
+}
+
+GSDumpRaw::GSDumpRaw(FILE* file, FILE* repack_file)
+	: GSDumpFile(file, repack_file)
+{
 }
 
 bool GSDumpRaw::IsEof()

--- a/pcsx2/GS/GSLzma.h
+++ b/pcsx2/GS/GSLzma.h
@@ -29,6 +29,7 @@ public:
 	virtual bool Read(void* ptr, size_t size) = 0;
 
 	GSDumpFile(char* filename, const char* repack_filename);
+	GSDumpFile(FILE* file, FILE* repack_file);
 	virtual ~GSDumpFile();
 };
 
@@ -44,9 +45,11 @@ class GSDumpLzma : public GSDumpFile
 	size_t m_start;
 
 	void Decompress();
+	void Initialize();
 
 public:
 	GSDumpLzma(char* filename, const char* repack_filename);
+	GSDumpLzma(FILE* file, FILE* repack_file);
 	virtual ~GSDumpLzma();
 
 	bool IsEof() final;
@@ -55,15 +58,9 @@ public:
 
 class GSDumpRaw : public GSDumpFile
 {
-	size_t m_buff_size;
-	uint8_t* m_area;
-	uint8_t* m_inbuf;
-
-	size_t m_avail;
-	size_t m_start;
-
 public:
 	GSDumpRaw(char* filename, const char* repack_filename);
+	GSDumpRaw(FILE* file, FILE* repack_file);
 	virtual ~GSDumpRaw() = default;
 
 	bool IsEof() final;

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -277,25 +277,34 @@ void Dialogs::GSDumpDialog::GetDumpsList()
 	m_dump_list->ClearAll();
 	wxDir snaps(g_Conf->Folders.Snapshots.ToAscii());
 	wxString filename;
-	bool cont = snaps.GetFirst(&filename, "*.gs", wxDIR_DEFAULT);
-	int i = 0, h = 0, j = 0;
+	bool cont = snaps.GetFirst(&filename);
+	int h = 0, j = 0;
 	m_dump_list->AppendColumn("Dumps");
 	// set the column size to be exactly of the size of our list
 	m_dump_list->GetSize(&h, &j);
 	m_dump_list->SetColumnWidth(0, h);
+	std::vector<wxString> dumps;
 
 	while (cont)
 	{
-		m_dump_list->InsertItem(i, filename.substr(0, filename.find_last_of(".")));
-		i++;
+		if (filename.EndsWith(".gs"))
+			dumps.push_back(filename.substr(0, filename.length() - 3));
+		else if (filename.EndsWith(".gs.xz"))
+			dumps.push_back(filename.substr(0, filename.length() - 6));
 		cont = snaps.GetNext(&filename);
 	}
+	std::sort(dumps.begin(), dumps.end(), [](const wxString& a, const wxString& b) { return a.CmpNoCase(b) < 0; });
+	dumps.erase(std::unique(dumps.begin(), dumps.end()), dumps.end()); // In case there was both .gs and .gs.xz
+	for (size_t i = 0; i < dumps.size(); i++)
+		m_dump_list->InsertItem(i, dumps[i]);
 }
 
 void Dialogs::GSDumpDialog::SelectedDump(wxListEvent& evt)
 {
 	wxString filename_preview = g_Conf->Folders.Snapshots.ToAscii() + ("/" + evt.GetText()) + ".png";
 	wxString filename = g_Conf->Folders.Snapshots.ToAscii() + ("/" + evt.GetText()) + ".gs";
+	if (!wxFileExists(filename))
+		filename.append(".xz");
 	if (wxFileExists(filename_preview))
 	{
 		auto img = wxImage(filename_preview);
@@ -337,15 +346,18 @@ void Dialogs::GSDumpDialog::RunDump(wxCommandEvent& event)
 {
 	if (!m_run->IsEnabled())
 		return;
-	m_thread->m_dump_file = std::make_unique<pxInputStream>(m_selected_dump, new wxFFileInputStream(m_selected_dump));
-
-	if (!(m_thread->m_dump_file)->IsOk())
+	FILE* dumpfile = wxFopen(m_selected_dump, L"rb");
+	if (!dumpfile)
 	{
 		wxString s;
 		s.Printf(_("Failed to load the dump %s !"), m_selected_dump);
 		wxMessageBox(s, _("GS Debugger"), wxICON_ERROR);
 		return;
 	}
+	if (m_selected_dump.EndsWith(".xz"))
+		m_thread->m_dump_file = std::make_unique<GSDumpLzma>(dumpfile, nullptr);
+	else
+		m_thread->m_dump_file = std::make_unique<GSDumpRaw >(dumpfile, nullptr);
 	m_run->Disable();
 	m_settings->Disable();
 	m_debug_mode->Enable();
@@ -851,7 +863,7 @@ Dialogs::GSDumpDialog::GSThread::~GSThread()
 void Dialogs::GSDumpDialog::GSThread::OnStop()
 {
 	m_root_window->m_button_events.clear();
-	m_dump_file->Close();
+	m_dump_file = nullptr;
 
 	wxCommandEvent event(EVT_CLOSE_DUMP);
 	wxPostEvent(m_root_window, event);
@@ -900,29 +912,17 @@ void Dialogs::GSDumpDialog::GSThread::ExecuteTaskInThread()
 	freezeData fd = {(int)ss, (u8*)state_data.get()};
 	m_root_window->m_dump_packets.clear();
 
-	// Calling Length() internally does fseek() -> ftell() -> fseek(). Slow.
-	// Calling ftell() for Tell() doesn't seem to be very cheap either.
-	// So we track the position ourselves.
-	const wxFileOffset length = m_dump_file->Length();
-	wxFileOffset pos = m_dump_file->Tell();
-#define READ_FROM_DUMP_FILE(var, size) \
-	do \
-	{ \
-		m_dump_file->Read(var, size); \
-		pos += size; \
-	} while (0)
-
-	while (pos < length)
+	while (!m_dump_file->IsEof())
 	{
 		GSType id;
 		GSTransferPath id_transfer = GSTransferPath::Dummy;
-		READ_FROM_DUMP_FILE(&id, 1);
+		m_dump_file->Read(&id, 1);
 		s32 size = 0;
 		switch (id)
 		{
 			case GSType::Transfer:
-				READ_FROM_DUMP_FILE(&id_transfer, 1);
-				READ_FROM_DUMP_FILE(&size, 4);
+				m_dump_file->Read(&id_transfer, 1);
+				m_dump_file->Read(&size, 4);
 				break;
 			case GSType::VSync:
 				size = 1;
@@ -935,10 +935,9 @@ void Dialogs::GSDumpDialog::GSThread::ExecuteTaskInThread()
 				break;
 		}
 		std::unique_ptr<char[]> data(new char[size]);
-		READ_FROM_DUMP_FILE(data.get(), size);
+		m_dump_file->Read(data.get(), size);
 		m_root_window->m_dump_packets.push_back({id, std::move(data), size, id_transfer});
 	}
-#undef READ_FROM_DUMP_FILE
 
 	GSinit();
 	sApp.OpenGsPanel();

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -568,7 +568,7 @@ void Dialogs::GSDumpDialog::ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data
 				rgb_infos[1].Printf("G = %u", GetBits(data, 32, 8));
 				rgb_infos[2].Printf("B = %u", GetBits(data, 64, 8));
 				rgb_infos[3].Printf("A = %u", GetBits(data, 96, 8));;
-				rgb_infos[4].Printf("Q = %f", m_stored_q);
+				rgb_infos[4].Printf("Q = %g", m_stored_q);
 			}
 			else
 			{
@@ -576,7 +576,7 @@ void Dialogs::GSDumpDialog::ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data
 				rgb_infos[1].Printf("G = %u", GetBits(data,  8, 8));
 				rgb_infos[2].Printf("B = %u", GetBits(data, 16, 8));
 				rgb_infos[3].Printf("A = %u", GetBits(data, 24, 8));
-				rgb_infos[4].Printf("Q = %f", BitCast<float>(data._u32[1]));
+				rgb_infos[4].Printf("Q = %g", BitCast<float>(data._u32[1]));
 			}
 
 			for (auto& el : rgb_infos)
@@ -584,17 +584,17 @@ void Dialogs::GSDumpDialog::ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data
 			break;
 		}
 		case GIFReg::ST:
-			m_gif_packet->AppendItem(rootId, wxString::Format("S = %f", BitCast<float>(data._u32[0])));
-			m_gif_packet->AppendItem(rootId, wxString::Format("T = %f", BitCast<float>(data._u32[1])));
+			m_gif_packet->AppendItem(rootId, wxString::Format("S = %g", BitCast<float>(data._u32[0])));
+			m_gif_packet->AppendItem(rootId, wxString::Format("T = %g", BitCast<float>(data._u32[1])));
 			if (packed)
 			{
 				m_stored_q = BitCast<float>(data._u32[2]);
-				m_gif_packet->AppendItem(rootId, wxString::Format("Q = %f", m_stored_q));
+				m_gif_packet->AppendItem(rootId, wxString::Format("Q = %g", m_stored_q));
 			}
 			break;
 		case GIFReg::UV:
-			m_gif_packet->AppendItem(rootId, wxString::Format("U = %f", static_cast<float>(GetBits(data, 0, 14)) / 16.f));
-			m_gif_packet->AppendItem(rootId, wxString::Format("V = %f", static_cast<float>(GetBits(data, packed ? 32 : 16, 14)) / 16.f));
+			m_gif_packet->AppendItem(rootId, wxString::Format("U = %g", static_cast<float>(GetBits(data, 0, 14)) / 16.f));
+			m_gif_packet->AppendItem(rootId, wxString::Format("V = %g", static_cast<float>(GetBits(data, packed ? 32 : 16, 14)) / 16.f));
 			break;
 		case GIFReg::XYZF2:
 		case GIFReg::XYZF3:
@@ -605,15 +605,15 @@ void Dialogs::GSDumpDialog::ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data
 			std::array<wxString, 4> xyzf_infos;
 			if (packed)
 			{
-				xyzf_infos[0].Printf("X = %f", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
-				xyzf_infos[1].Printf("Y = %f", static_cast<float>(GetBits(data, 32, 16)) / 16.0);
+				xyzf_infos[0].Printf("X = %g", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
+				xyzf_infos[1].Printf("Y = %g", static_cast<float>(GetBits(data, 32, 16)) / 16.0);
 				xyzf_infos[2].Printf("Z = %u", GetBits(data, 68, 24));
 				xyzf_infos[3].Printf("F = %u", GetBits(data, 100, 8));
 			}
 			else
 			{
-				xyzf_infos[0].Printf("X = %f", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
-				xyzf_infos[1].Printf("Y = %f", static_cast<float>(GetBits(data, 16, 16)) / 16.0);
+				xyzf_infos[0].Printf("X = %g", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
+				xyzf_infos[1].Printf("Y = %g", static_cast<float>(GetBits(data, 16, 16)) / 16.0);
 				xyzf_infos[2].Printf("Z = %u", GetBits(data, 32, 24));
 				xyzf_infos[3].Printf("F = %u", GetBits(data, 56, 8));
 			}
@@ -631,14 +631,14 @@ void Dialogs::GSDumpDialog::ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data
 			std::vector<wxString> xyz_infos(3);
 			if (packed)
 			{
-				xyz_infos[0].Printf("X = %f", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
-				xyz_infos[1].Printf("Y = %f", static_cast<float>(GetBits(data, 32, 16)) / 16.0);
+				xyz_infos[0].Printf("X = %g", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
+				xyz_infos[1].Printf("Y = %g", static_cast<float>(GetBits(data, 32, 16)) / 16.0);
 				xyz_infos[2].Printf("Z = %u", data._u32[2]);
 			}
 			else
 			{
-				xyz_infos[0].Printf("X = %f", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
-				xyz_infos[1].Printf("Y = %f", static_cast<float>(GetBits(data, 16, 16)) / 16.0);
+				xyz_infos[0].Printf("X = %g", static_cast<float>(GetBits(data,  0, 16)) / 16.0);
+				xyz_infos[1].Printf("Y = %g", static_cast<float>(GetBits(data, 16, 16)) / 16.0);
 				xyz_infos[2].Printf("Z = %u", data._u32[1]);
 			}
 

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -524,6 +524,8 @@ void Dialogs::GSDumpDialog::GenPacketInfo(GSData& dump)
 					m_gif_packet->AppendItem(regId, wxString::Format("IMAGE %d bytes", nloop * 16));
 					break;
 			}
+			m_gif_packet->Expand(trootId);
+			m_gif_packet->Expand(regId);
 			break;
 		}
 		case GSType::VSync:
@@ -544,7 +546,6 @@ void Dialogs::GSDumpDialog::GenPacketInfo(GSData& dump)
 			m_gif_packet->AppendItem(rootId, "Registers");
 			break;
 	}
-	m_gif_packet->ExpandAll();
 }
 
 void Dialogs::GSDumpDialog::ParsePacket(wxTreeEvent& event)
@@ -742,6 +743,7 @@ void Dialogs::GSDumpDialog::ParseTreePrim(wxTreeItemId& id, u32 prim)
 
 	for (auto& el : prim_infos)
 		m_gif_packet->AppendItem(id, el);
+	m_gif_packet->Expand(id);
 }
 
 void Dialogs::GSDumpDialog::ProcessDumpEvent(const GSData& event, char* regs)

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -179,7 +179,7 @@ using namespace pxSizerFlags;
 // --------------------------------------------------------------------------------------
 
 Dialogs::GSDumpDialog::GSDumpDialog(wxWindow* parent)
-	: wxDialogWithHelpers(parent, _("GS Debugger"), pxDialogFlags().SetMinimize())
+	: wxDialogWithHelpers(parent, _("GS Debugger"), pxDialogFlags().SetMinimize().SetResize())
 	, m_dump_list(new wxListView(this, ID_DUMP_LIST, wxDefaultPosition, wxSize(400, 300), wxLC_NO_HEADER | wxLC_REPORT | wxLC_SINGLE_SEL))
 	, m_preview_image(new wxStaticBitmap(this, wxID_ANY, wxBitmap(EmbeddedImage<res_NoIcon>().Get()), wxDefaultPosition, wxSize(400,250)))
 	, m_debug_mode(new wxCheckBox(this, ID_DEBUG_MODE, _("Debug Mode")))
@@ -196,8 +196,7 @@ Dialogs::GSDumpDialog::GSDumpDialog(wxWindow* parent)
 {
 	wxBoxSizer* dump_info = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* dump_preview = new wxBoxSizer(wxVERTICAL);
-	wxFlexGridSizer* debugger = new wxFlexGridSizer(3, StdPadding, StdPadding);
-	wxBoxSizer* dumps = new wxBoxSizer(wxHORIZONTAL);
+	wxFlexGridSizer* grid = new wxFlexGridSizer(3, StdPadding, StdPadding);
 	wxBoxSizer* dbg_tree = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* dbg_actions = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* gif = new wxBoxSizer(wxVERTICAL);
@@ -217,14 +216,14 @@ Dialogs::GSDumpDialog::GSDumpDialog(wxWindow* parent)
 	m_renderer_overrides->Create(this, wxID_ANY, "Renderer overrides", wxDefaultPosition, wxDefaultSize, rdoverrides, 1);
 
 	dbg_tree->Add(new wxStaticText(this, wxID_ANY, _("GIF Packets")));
-	dbg_tree->Add(m_gif_list, StdExpand());
+	dbg_tree->Add(m_gif_list, StdExpand().Proportion(1));
 	dbg_actions->Add(m_debug_mode);
 	dbg_actions->Add(m_start, StdExpand());
 	dbg_actions->Add(m_step, StdExpand());
 	dbg_actions->Add(m_selection, StdExpand());
 	dbg_actions->Add(m_vsync, StdExpand());
 	gif->Add(new wxStaticText(this, wxID_ANY, _("Packet Content")));
-	gif->Add(m_gif_packet, StdExpand());
+	gif->Add(m_gif_packet, StdExpand().Proportion(1));
 
 	dumps_list->Add(new wxStaticText(this, wxID_ANY, _("GS Dumps List")), StdExpand());
 	dumps_list->Add(m_dump_list, StdExpand());
@@ -234,16 +233,19 @@ Dialogs::GSDumpDialog::GSDumpDialog(wxWindow* parent)
 	dump_preview->Add(new wxStaticText(this, wxID_ANY, _("Preview")), StdExpand());
 	dump_preview->Add(m_preview_image, StdCenter());
 
-	dumps->Add(dumps_list);
-	dumps->Add(dump_info);
-	dumps->Add(dump_preview);
+	grid->Add(dumps_list, StdExpand());
+	grid->Add(dump_info, StdExpand());
+	grid->Add(dump_preview, StdExpand());
 
-	debugger->Add(dbg_tree);
-	debugger->Add(dbg_actions);
-	debugger->Add(gif);
-	
-	*this += dumps;
-	*this += debugger;
+	grid->Add(dbg_tree, StdExpand());
+	grid->Add(dbg_actions, StdExpand());
+	grid->Add(gif, StdExpand());
+
+	grid->AddGrowableCol(0);
+	grid->AddGrowableCol(2);
+	grid->AddGrowableRow(1);
+
+	SetSizerAndFit(grid);
 
 	// populate UI and setup state
 	m_debug_mode->Disable();

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -108,6 +108,7 @@ namespace Dialogs
 		wxString m_selected_dump;
 		wxCheckBox* m_debug_mode;
 		wxRadioBox* m_renderer_overrides;
+		wxSpinCtrl* m_framerate_selector;
 		wxTreeCtrl* m_gif_list;
 		wxTreeCtrl* m_gif_packet;
 		wxButton* m_start;
@@ -120,6 +121,8 @@ namespace Dialogs
 		wxFileSystemWatcher m_fs_watcher;
 
 		void GetDumpsList();
+		void UpdateFramerate(int val);
+		void UpdateFramerate(wxCommandEvent& evt);
 		void SelectedDump(wxListEvent& evt);
 		void RunDump(wxCommandEvent& event);
 		void ToStart(wxCommandEvent& event);
@@ -140,7 +143,8 @@ namespace Dialogs
 			ID_RUN_VSYNC,
 			ID_SEL_PACKET,
 			ID_DEBUG_MODE,
-			ID_SETTINGS
+			ID_SETTINGS,
+			ID_FRAMERATE,
 		};
 
 		// clang-format off
@@ -275,6 +279,8 @@ namespace Dialogs
 
 		public:
 			int m_renderer = 0;
+			u64 m_frame_ticks = 0;
+			u64 m_next_frame_time = 0;
 			bool m_debug = false;
 			size_t m_debug_index;
 			std::unique_ptr<GSDumpFile> m_dump_file;

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -24,68 +24,27 @@
 #include <wx/treectrl.h>
 #include <wx/fswatcher.h>
 
-// clang-format off
-#define GSDUMP_GIFREG(X) \
-	X(PRIM, 0x00)        \
-	X(RGBAQ, 0x01)       \
-	X(ST, 0x02)          \
-	X(UV, 0x03)          \
-	X(XYZF2, 0x04)       \
-	X(XYZ2, 0x05)        \
-	X(TEX0_1, 0x06)      \
-	X(TEX0_2, 0x07)      \
-	X(CLAMP_1, 0x08)     \
-	X(CLAMP_2, 0x09)     \
-	X(FOG, 0x0a)         \
-	X(XYZF3, 0x0c)       \
-	X(XYZ3, 0x0d)        \
-	X(AD, 0x0e)          \
-	X(NOP, 0x0f)         \
-	X(TEX1_1, 0x14)      \
-	X(TEX1_2, 0x15)      \
-	X(TEX2_1, 0x16)      \
-	X(TEX2_2, 0x17)      \
-	X(XYOFFSET_1, 0x18)  \
-	X(XYOFFSET_2, 0x19)  \
-	X(PRMODECONT, 0x1a)  \
-	X(PRMODE, 0x1b)      \
-	X(TEXCLUT, 0x1c)     \
-	X(SCANMSK, 0x22)     \
-	X(MIPTBP1_1, 0x34)   \
-	X(MIPTBP1_2, 0x35)   \
-	X(MIPTBP2_1, 0x36)   \
-	X(MIPTBP2_2, 0x37)   \
-	X(TEXA, 0x3b)        \
-	X(FOGCOL, 0x3d)      \
-	X(TEXFLUSH, 0x3f)    \
-	X(SCISSOR_1, 0x40)   \
-	X(SCISSOR_2, 0x41)   \
-	X(ALPHA_1, 0x42)     \
-	X(ALPHA_2, 0x43)     \
-	X(DIMX, 0x44)        \
-	X(DTHE, 0x45)        \
-	X(COLCLAMP, 0x46)    \
-	X(TEST_1, 0x47)      \
-	X(TEST_2, 0x48)      \
-	X(PABE, 0x49)        \
-	X(FBA_1, 0x4a)       \
-	X(FBA_2, 0x4b)       \
-	X(FRAME_1, 0x4c)     \
-	X(FRAME_2, 0x4d)     \
-	X(ZBUF_1, 0x4e)      \
-	X(ZBUF_2, 0x4f)      \
-	X(BITBLTBUF, 0x50)   \
-	X(TRXPOS, 0x51)      \
-	X(TRXREG, 0x52)      \
-	X(TRXDIR, 0x53)      \
-	X(HWREG, 0x54)       \
-	X(SIGNAL, 0x60)      \
-	X(FINISH, 0x61)      \
-	X(LABEL, 0x62)
-// clang-format on
+#define GEN_REG_ENUM_CLASS_CONTENT(ClassName, EntryName, Value) \
+	EntryName = Value,
 
-#define GSDUMP_GIFREG_NAME GIFReg
-#define GSDUMP_GIFREG_TYPE u8
+#define GEN_REG_GETNAME_CONTENT(ClassName, EntryName, Value) \
+	case ClassName::EntryName: \
+		return #EntryName;
+
+#define GEN_REG_ENUM_CLASS_AND_GETNAME(Macro, ClassName, Type, DefaultString) \
+	enum class ClassName : Type \
+	{ \
+		Macro(GEN_REG_ENUM_CLASS_CONTENT) \
+	}; \
+	static constexpr const char* GetName(ClassName reg) \
+	{ \
+		switch (reg) \
+		{ \
+			Macro(GEN_REG_GETNAME_CONTENT) \
+			default: \
+				return DefaultString; \
+		} \
+	}
 
 class FirstTimeWizard : public wxWizard
 {
@@ -182,27 +141,96 @@ namespace Dialogs
 			ID_DEBUG_MODE,
 			ID_SETTINGS
 		};
-		enum GSType : u8
-		{
-			Transfer = 0,
-			VSync = 1,
-			ReadFIFO2 = 2,
-			Registers = 3
-		};
-		static constexpr const char* GSTypeNames[256] = {
-			"Transfer",
-			"VSync",
-			"ReadFIFO2",
-			"Registers"
-		};
-		enum GSTransferPath : u8
-		{
-			Path1Old = 0,
-			Path2 = 1,
-			Path3 = 2,
-			Path1New = 3,
-			Dummy = 4
-		};
+
+		// clang-format off
+
+#define DEF_GSType(X) \
+	X(GSType, Transfer,  0) \
+	X(GSType, VSync,     1) \
+	X(GSType, ReadFIFO2, 2) \
+	X(GSType, Registers, 3)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GSType, GSType, u8, "UnknownType")
+#undef DEF_GSType
+
+#define DEF_GSTransferPath(X) \
+	X(GSTransferPath, Path1Old, 0) \
+	X(GSTransferPath, Path2,    1) \
+	X(GSTransferPath, Path3,    2) \
+	X(GSTransferPath, Path1New, 3) \
+	X(GSTransferPath, Dummy,    4)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GSTransferPath, GSTransferPath, u8, "UnknownPath")
+#undef DEF_GSTransferPath
+
+#define DEF_GIFFlag(X) \
+	X(GIFFlag, PACKED,  0) \
+	X(GIFFlag, REGLIST, 1) \
+	X(GIFFlag, IMAGE,   2) \
+	X(GIFFlag, IMAGE2,  3)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GIFFlag, GIFFlag, u8, "UnknownFlag")
+#undef DEF_GifFlag
+
+#define DEF_GIFReg(X) \
+	X(GIFReg, PRIM,       0x00) \
+	X(GIFReg, RGBAQ,      0x01) \
+	X(GIFReg, ST,         0x02) \
+	X(GIFReg, UV,         0x03) \
+	X(GIFReg, XYZF2,      0x04) \
+	X(GIFReg, XYZ2,       0x05) \
+	X(GIFReg, TEX0_1,     0x06) \
+	X(GIFReg, TEX0_2,     0x07) \
+	X(GIFReg, CLAMP_1,    0x08) \
+	X(GIFReg, CLAMP_2,    0x09) \
+	X(GIFReg, FOG,        0x0a) \
+	X(GIFReg, XYZF3,      0x0c) \
+	X(GIFReg, XYZ3,       0x0d) \
+	X(GIFReg, AD,         0x0e) \
+	X(GIFReg, NOP,        0x0f) \
+	X(GIFReg, TEX1_1,     0x14) \
+	X(GIFReg, TEX1_2,     0x15) \
+	X(GIFReg, TEX2_1,     0x16) \
+	X(GIFReg, TEX2_2,     0x17) \
+	X(GIFReg, XYOFFSET_1, 0x18) \
+	X(GIFReg, XYOFFSET_2, 0x19) \
+	X(GIFReg, PRMODECONT, 0x1a) \
+	X(GIFReg, PRMODE,     0x1b) \
+	X(GIFReg, TEXCLUT,    0x1c) \
+	X(GIFReg, SCANMSK,    0x22) \
+	X(GIFReg, MIPTBP1_1,  0x34) \
+	X(GIFReg, MIPTBP1_2,  0x35) \
+	X(GIFReg, MIPTBP2_1,  0x36) \
+	X(GIFReg, MIPTBP2_2,  0x37) \
+	X(GIFReg, TEXA,       0x3b) \
+	X(GIFReg, FOGCOL,     0x3d) \
+	X(GIFReg, TEXFLUSH,   0x3f) \
+	X(GIFReg, SCISSOR_1,  0x40) \
+	X(GIFReg, SCISSOR_2,  0x41) \
+	X(GIFReg, ALPHA_1,    0x42) \
+	X(GIFReg, ALPHA_2,    0x43) \
+	X(GIFReg, DIMX,       0x44) \
+	X(GIFReg, DTHE,       0x45) \
+	X(GIFReg, COLCLAMP,   0x46) \
+	X(GIFReg, TEST_1,     0x47) \
+	X(GIFReg, TEST_2,     0x48) \
+	X(GIFReg, PABE,       0x49) \
+	X(GIFReg, FBA_1,      0x4a) \
+	X(GIFReg, FBA_2,      0x4b) \
+	X(GIFReg, FRAME_1,    0x4c) \
+	X(GIFReg, FRAME_2,    0x4d) \
+	X(GIFReg, ZBUF_1,     0x4e) \
+	X(GIFReg, ZBUF_2,     0x4f) \
+	X(GIFReg, BITBLTBUF,  0x50) \
+	X(GIFReg, TRXPOS,     0x51) \
+	X(GIFReg, TRXREG,     0x52) \
+	X(GIFReg, TRXDIR,     0x53) \
+	X(GIFReg, HWREG,      0x54) \
+	X(GIFReg, SIGNAL,     0x60) \
+	X(GIFReg, FINISH,     0x61) \
+	X(GIFReg, LABEL,      0x62)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GIFReg, GIFReg, u8, "UnknownReg")
+#undef DEF_GIFReg
+
+		// clang-format on
+
 		struct GSData
 		{
 			GSType id;
@@ -216,120 +244,7 @@ namespace Dialogs
 			RunCursor,
 			RunVSync
 		};
-		static constexpr const char* GSTransferPathNames[256] = {
-			"Path1Old",
-			"Path2",
-			"Path3",
-			"Path1New",
-			"Dummy"
-		};
-		enum GifFlag : u8
-		{
-			GIF_FLG_PACKED = 0,
-			GIF_FLG_REGLIST = 1,
-			GIF_FLG_IMAGE = 2,
-			GIF_FLG_IMAGE2 = 3
-		};
-		static constexpr const char* GifFlagNames[256] = {
-			"GIF_FLG_PACKED",
-			"GIF_FLG_REGLIST",
-			"GIF_FLG_IMAGE",
-			"GIF_FLG_IMAGE2"
-		};
-		static constexpr const char* GsPrimNames[256] = {
-			"GS_POINTLIST",
-			"GS_LINELIST",
-			"GS_LINESTRIP",
-			"GS_TRIANGLELIST",
-			"GS_TRIANGLESTRIP",
-			"GS_TRIANGLEFAN",
-			"GS_SPRITE",
-			"GS_INVALID"
-		};
-		static constexpr const char* GsIIPNames[256] = {
-			"FlatShading",
-			"Gouraud"
-		};
-		static constexpr const char* GsFSTNames[256] = {
-			"STQValue",
-			"UVValue"
-		};
-		static constexpr const char* GsCTXTNames[256] = {
-			"Context1",
-			"Context2"
-		};
-		static constexpr const char* GsFIXNames[256] = {
-			"Unfixed",
-			"Fixed"
-		};
-		static constexpr const char* TEXTCCNames[256] = {
-			"RGB",
-			"RGBA"
-		};
-		static constexpr const char* TEXTFXNames[256] = {
-			"MODULATE",
-			"DECAL",
-			"HIGHLIGHT",
-			"HIGHLIGHT2"
-		};
-		static constexpr const char* TEXCSMNames[256] = {
-			"CSM1",
-			"CSM2"
-		};
-		// a GNU extension exists to initialize array at given indices which would be 
-		// exactly what we need here but, obviously, MSVC is at it again to make our 
-		// life harder than sandpaper on your skin, so we make do
-		// clang-format off
-		static constexpr const char* TEXCPSMNames[256] = {
-			"PSMCT32",
-			"",
-			"PSMCT16",
-			"","","","","","","",
-			"PSMCT16S"
-		};
-		static constexpr const char* TEXPSMNames[256] = {
-			"PSMCT32",
-			"PSMCT24",
-			"PSMCT16",
-			"","","","","","","",
-			"PSMCT16S",
-			"","","","","","","","",
-			"PSMT8",
-			"PSMT4",
-			"","","","","","",
-			"PSMT8H",
-			"","","","","","","","",
-			"PSMT4HL",
-			"","","","","","","",
-			"PSMT4HH",
-			"","","",
-			"PSMZ32",
-			"PSMZ24",
-			"PSMZ16",
-			"","","","","","","",
-			"PSMZ16S"
-		};
-		// clang-format on
 
-		// the actual type is defined above thanks to preprocessing magic
-		enum GSDUMP_GIFREG_NAME : GSDUMP_GIFREG_TYPE
-		{
-#define X(name, value) name = value,
-			GSDUMP_GIFREG(X)
-#undef X
-		};
-		constexpr auto GIFRegName(GSDUMP_GIFREG_NAME e) noexcept
-		{
-#define X(name, value)               \
-	case (GSDUMP_GIFREG_NAME::name): \
-		return #name;
-			switch (e)
-			{
-				GSDUMP_GIFREG(X)
-			}
-#undef X
-			return "UNKNOWN";
-		};
 		struct GSEvent
 		{
 			ButtonState btn;

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -256,8 +256,10 @@ namespace Dialogs
 
 		float m_stored_q = 1.0;
 		void ProcessDumpEvent(const GSData& event, char* regs);
+		u32 ReadPacketSize(const void* packet);
 		void GenPacketList();
 		void GenPacketInfo(GSData& dump);
+		void ParseTransfer(wxTreeItemId& id, char* data);
 		void ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data, bool packed);
 		void ParseTreePrim(wxTreeItemId& id, u32 prim);
 		void CloseDump(wxCommandEvent& event);

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -19,6 +19,7 @@
 #include "ConfigurationDialog.h"
 #include "gui/Panels/ConfigurationPanels.h"
 #include "common/pxStreams.h"
+#include "GS/GSLzma.h"
 
 #include <wx/wizard.h>
 #include <wx/treectrl.h>
@@ -276,7 +277,7 @@ namespace Dialogs
 			int m_renderer = 0;
 			bool m_debug = false;
 			size_t m_debug_index;
-			std::unique_ptr<pxInputStream> m_dump_file;
+			std::unique_ptr<GSDumpFile> m_dump_file;
 			GSThread(GSDumpDialog* dlg);
 			virtual ~GSThread();
 		};

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -475,9 +475,11 @@ void MainEmuFrame::CreateWindowsMenu()
 {
 	m_menuWindow.Append(MenuId_Debug_CreateBlockdump, _("Create &Blockdump"), _("Creates a block dump for debugging purposes."), wxITEM_CHECK);
 	m_menuWindow.Append(MenuId_Debug_Open, _("&Show Debugger"), wxEmptyString, wxITEM_CHECK);
-#if defined(PCSX2_DEVBUILD) || defined(PCSX2_CI)
-	m_menuWindow.Append(MenuId_GSDump, _("Show &GS Debugger"));
+
+#ifndef PCSX2_CI
+	if (IsDevBuild || g_Conf->DevMode)
 #endif
+		m_menuWindow.Append(MenuId_GSDump, _("Show &GS Debugger"));
 
 	m_menuWindow.Append(&m_MenuItem_Console);
 #if defined(__POSIX__)


### PR DESCRIPTION
### Description of Changes
- Window is now resizable (bottom debug section grows)
- No longer prints integer numbers with 6 decimal places
- Now shows entire transfer instead of just the first packet
- Most entries have a summary line and default unexpanded, greatly increasing the information that fits on screen
- Adds support for xz-compressed gsdumps

### Rationale behind Changes
Less annoying

### Suggested Testing Steps
xz your gsdumps, try running them, try checking the debug box and looking at the debug views
