### PR TITLE
CDVD: Buffer up to 16 sectors

### DIFF
--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -152,7 +152,8 @@ struct cdvdStruct
 	bool Spinning;    // indicates if the Cdvd is spinning or needs a spinup delay
 	bool mediaChanged;
 	cdvdTrayTimer Tray;
-	bool nextSectorBuffered;
+	u8 nextSectorsBuffered;
+	bool triggerDataReady;
 };
 
 extern cdvdStruct cdvd;


### PR DESCRIPTION
### Description of Changes
Buffers up to 16 sectors on a DVD from its current position.

### Rationale behind Changes
Documentation from developers shows that the DVD drive will always read 16 sectors as a minimum, so this means if it reads in advance, it can buffer up a bunch of sectors to be read off quickly by the DMA.

### Suggested Testing Steps
Run games, make sure they work.

Bob the Builder and Silent Hill 2 (NTSC) videos seem to work fine with this.
Victorious Boxers also seems fine.

This PR does re-break Star Ocean 3 v1.1, but I don't know what's going on with that, it seems to want the DMA to end before the command completes, but this breaks PoP Warrior Within, and I don't think that's a solution.

It's not finished, need to do some hardware tests since the DataReady flag is a bit obscure, just right now I have it in a state that *works*