### PR TITLE
DEV9: Allow Internal DHCP Server to find Gateway on Mac and FreeBSD

### DIFF
--- a/pcsx2/DEV9/InternalServers/DHCP_Server.h
+++ b/pcsx2/DEV9/InternalServers/DHCP_Server.h
@@ -63,6 +63,8 @@ namespace InternalServers
 
 #ifdef __linux__
 		static std::vector<PacketReader::IP::IP_Address> GetGatewaysLinux(char* interfaceName);
+#elif defined(__FreeBSD__) || (__APPLE__)
+		static std::vector<PacketReader::IP::IP_Address> GetGatewaysBSD(char* interfaceName);
 #endif
 
 		~DHCP_Server();

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -493,6 +493,13 @@ bool SocketAdapter::GetIfAutoAdapter(ifaddrs* adapter, ifaddrs** buffer)
 
 			if (gateways.size() > 0)
 				hasGateway = true;
+
+#elif defined(__FreeBSD__) || (__APPLE__)
+			std::vector<IP_Address> gateways = InternalServers::DHCP_Server::GetGatewaysBSD(pAdapter->ifa_name);
+
+			if (gateways.size() > 0)
+				hasGateway = true;
+
 #else
 			Console.Error("DHCP: Unsupported OS, can't find Gateway");
 #endif


### PR DESCRIPTION
### Description of Changes
Allows Auto Gateway to function on Mac/FreeBSD

### Rationale behind Changes
Previously this would not function on those systems

### Suggested Testing Steps
Retracing the steps in issue #4828, except using FreeBSD or Mac as the operating system

Using the network access disc to test network connectivity while DHCP intercept is set & Gateway is set to auto

Testing other online games while DHCP intercept is set & Gateway is set to auto

Using the network setup utility found in various other games while DHCP intercept is set & auto Gateway is set

My testing ability on these OS is limited, so further testing is appreciated