### PR TITLE
MTVU: Try to make T-Bit more reliable + Add MTVU option to GameDB

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -36,7 +36,7 @@ allowed_game_fixes = [
     "IbitHack",
     "VUOverflowHack",
 ]
-allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack"]
+allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack", "MTVUSpeedHack"]
 # Patches are allowed to have a 'default' key or a crc-32 key, followed by
 allowed_patch_options = ["author", "content"]
 

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2215,6 +2215,7 @@ SCES-50408:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes noodles.
+    MTVUSpeedHack: 0
 SCES-50409:
   name: "MotoGP 2"
   region: "PAL-M5"
@@ -2232,6 +2233,7 @@ SCES-50459:
   compat: 2
   speedHacks:
     InstantVU1SpeedHack: 0
+    MTVUSpeedHack: 0
 SCES-50490:
   name: "Final Fantasy X"
   region: "PAL-E"
@@ -4152,6 +4154,7 @@ SCKA-20092:
   region: "NTSC-K"
   speedHacks: 
     InstantVU1SpeedHack: 0  # Fixes random black frames from happening when in a fight session.
+    MTVUSpeedHack: 0
   gameFixes:
     - XGKickHack # Fixes grey fighters problem.
 SCKA-20096:
@@ -4411,6 +4414,7 @@ SCPS-15017:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes noodles.
+    MTVUSpeedHack: 0
 SCPS-15018:
   name: "Train Simulator Real, The - Yamanote Sen"
   region: "NTSC-J"
@@ -4955,6 +4959,7 @@ SCPS-19201:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes noodles.
+    MTVUSpeedHack: 0
 SCPS-19202:
   name: "Extermination [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5763,6 +5768,7 @@ SCUS-97167:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes noodles.
+    MTVUSpeedHack: 0
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
   region: "NTSC-U"
@@ -5893,6 +5899,7 @@ SCUS-97208:
   region: "NTSC-U"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes noodles on Parappa 2.
+    MTVUSpeedHack: 0
 SCUS-97209:
   name: "Ratchet & Clank [E3 Demo]"
   region: "NTSC-U"
@@ -8313,6 +8320,7 @@ SLES-50382:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLES-50383:
   name: "Metal Gear Solid 2 - Sons of Liberty"
   region: "PAL-M3"
@@ -8444,6 +8452,7 @@ SLES-50446:
     - EETimingHack # Fixes cutscene freezes. 
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes SPS.
+    MTVUSpeedHack: 0
 SLES-50447:
   name: "All-Star Baseball 2003"
   region: "PAL-E"
@@ -8705,6 +8714,7 @@ SLES-50608:
     - EETimingHack # Fixes cutscene freezes. 
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes SPS.
+    MTVUSpeedHack: 0
 SLES-50613:
   name: "Woody Woodpecker"
   region: "PAL-M5"
@@ -9822,6 +9832,7 @@ SLES-51156:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLES-51157:
   name: "Silent Scope 3"
   region: "PAL-M5"
@@ -20211,6 +20222,7 @@ SLPM-61009:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLPM-61010:
   name: "Devil May Cry [Trial Version]"
   region: "NTSC-J"
@@ -20219,6 +20231,7 @@ SLPM-61011:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLPM-61018:
   name: "Abarenbou Princess [Trial]"
   region: "NTSC-J"
@@ -22423,6 +22436,7 @@ SLPM-65051:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLPM-65052:
   name: "GUITAR FREAKS 4thMIX & drummania 3rdMIX"
   region: "NTSC-J"
@@ -22592,6 +22606,7 @@ SLPM-65098:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLPM-65100:
   name: "Onimusha 2"
   region: "NTSC-J"
@@ -23316,6 +23331,7 @@ SLPM-65341:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLPM-65342:
   name: "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File"
   region: "NTSC-J"
@@ -23400,6 +23416,7 @@ SLPM-65374:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hanging while going ingame.
+    MTVUSpeedHack: 0
 SLPM-65375:
   name: "Shin Sangoku Musou 3 - Mushoden [Premium Pack]"
   region: "NTSC-J"
@@ -24173,6 +24190,7 @@ SLPM-65631:
   region: "NTSC-J"
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLPM-65632:
   name: "Virtua Fighter Cyber Generation - Ambition of the Judgement Six"
   region: "NTSC-J"
@@ -32320,6 +32338,7 @@ SLPS-25710:
   compat: 4
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes random black frames from happening when in a fight session.
+    MTVUSpeedHack: 0
   gameFixes:
     - XGKickHack # Fixes grey fighters problem.
   patches:
@@ -34308,6 +34327,7 @@ SLUS-20228:
   compat: 5
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    MTVUSpeedHack: 0
 SLUS-20229:
   name: "Jonny Moseley - Mad Trix"
   region: "NTSC-U"
@@ -35066,6 +35086,7 @@ SLUS-20413:
     - EETimingHack # Fixes cutscene freezes. 
   speedHacks:
     InstantVU1SpeedHack: 0  # Fixes SPS.
+    MTVUSpeedHack: 0
 SLUS-20414:
   name: "Legaia 2 - Duel Saga"
   region: "NTSC-U"
@@ -35282,6 +35303,7 @@ SLUS-20463:
   compat: 2
   speedHacks:
     InstantVU1SpeedHack: 0
+    MTVUSpeedHack: 0
 SLUS-20464:
   name: "Fugitive Hunter - War on Terror"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10042,6 +10042,8 @@ SLES-51257:
   name: "Sims, The (Die Sims)"
   region: "PAL-G"
   compat: 3
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-51258:
   name: "James Bond 007 - Nightfire"
   region: "PAL-M5"
@@ -10745,18 +10747,28 @@ SLES-51686:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-E"
   compat: 4
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-51687:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-F"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-51688:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-G"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-51689:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-I"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-51690:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-S"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-51693:
   name: "Suffering, The"
   region: "PAL-E-F-G"
@@ -12354,12 +12366,18 @@ SLES-52536:
   name: "Shark Tale"
   region: "PAL-E"
   compat: 2
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-52537:
   name: "Shark Tale"
   region: "PAL-M3"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-52539:
   name: "Shark Tale"
   region: "PAL-I"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-52541:
   name: "Grand Theft Auto - San Andreas"
   region: "PAL-M5"
@@ -13148,6 +13166,8 @@ SLES-52913:
 SLES-52915:
   name: "Shark Tale"
   region: "PAL-SW"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-52917:
   name: "Scaler"
   region: "PAL-E-F"
@@ -15294,6 +15314,8 @@ SLES-53863:
 SLES-53866:
   name: "Over the Hedge"
   region: "PAL-E"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-53867:
   name: "Ski Alpin 2006"
   region: "PAL-E-G"
@@ -15530,15 +15552,23 @@ SLES-53984:
 SLES-53986:
   name: "Over the Hedge"
   region: "PAL-I"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-53987:
   name: "Over the Hedge"
   region: "PAL-S"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-53988:
   name: "Over the Hedge"
   region: "PAL-E-G"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-53989:
   name: "Over the Hedge"
   region: "PAL-DU"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-53991:
   name: "Urban Chaos - Riot Response"
   region: "PAL-M5"
@@ -15908,6 +15938,8 @@ SLES-54172:
 SLES-54173:
   name: "Over The Hedge"
   region: "PAL-SW"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLES-54174:
   name: "ZooCube"
   region: "PAL-E"
@@ -24973,6 +25005,8 @@ SLPM-65900:
 SLPM-65901:
   name: "Shark Tale"
   region: "NTSC-J"
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLPM-65902:
   name: "Memories Off - After Rain Vol.2 Souen [Special Edition]"
   region: "NTSC-J"
@@ -35006,6 +35040,8 @@ SLUS-20408:
   name: "Pitfall - The Lost Expedition"
   region: "NTSC-U"
   compat: 4
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLUS-20409:
   name: "Total Immersion Racing"
   region: "NTSC-U"
@@ -35732,6 +35768,8 @@ SLUS-20573:
   name: "Sims, The"
   region: "NTSC-U"
   compat: 4
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLUS-20574:
   name: "NCAA March Madness 2003"
   region: "NTSC-U"
@@ -37182,6 +37220,8 @@ SLUS-20925:
   name: "Shark Tale"
   region: "NTSC-U"
   compat: 2
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLUS-20926:
   name: "Harry Potter and The Prisoner of Azkaban"
   region: "NTSC-U"
@@ -38915,6 +38955,8 @@ SLUS-21300:
   name: "Over the Hedge"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
 SLUS-21301:
   name: "World Series of Poker"
   region: "NTSC-U"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -58,6 +58,7 @@ enum SpeedhackId
 
 	Speedhack_mvuFlag = SpeedhackId_FIRST,
 	Speedhack_InstantVU1,
+	Speedhack_MTVU,
 
 	SpeedhackId_COUNT
 };

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -47,6 +47,7 @@ public:
 	Semaphore semaXGkick;
 	std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
 	u32 vuCycleIdx;  // Used for VU cycle stealing hack
+	u32 vuFBRST;
 
 	enum InterruptFlag {
 		InterruptFlagFinish = 1 << 0,
@@ -76,7 +77,7 @@ public:
 
 	void Get_MTVUChanges();
 
-	void ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop);
+	void ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop, u32 fbrst);
 
 	void VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, u8* data, u32 size);
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -65,9 +65,11 @@ void TraceLogFilters::LoadSave(SettingsWrapper& wrap)
 }
 
 const char* const tbl_SpeedhackNames[] =
-	{
-		"mvuFlag",
-		"InstantVU1"};
+{
+	"mvuFlag",
+	"InstantVU1",
+	"MTVU"
+};
 
 const char* EnumToString(SpeedhackId id)
 {
@@ -84,6 +86,9 @@ void Pcsx2Config::SpeedhackOptions::Set(SpeedhackId id, bool enabled)
 			break;
 		case Speedhack_InstantVU1:
 			vu1Instant = enabled;
+			break;
+		case Speedhack_MTVU:
+			vuThread = enabled;
 			break;
 			jNO_DEFAULT;
 	}

--- a/pcsx2/SPR.cpp
+++ b/pcsx2/SPR.cpp
@@ -37,9 +37,12 @@ static void TestClearVUs(u32 madr, u32 qwc, bool isWrite)
 			//Catch up VU1 too
 			CpuVU1->ExecuteBlock(0);
 		}
-		if ((madr >= 0x11008000) && (VU0.VI[REG_VPU_STAT].UL & 0x100) && !THREAD_VU1)
+		if ((madr >= 0x11008000) && (VU0.VI[REG_VPU_STAT].UL & 0x100) && (!THREAD_VU1 || !isWrite))
 		{
-			CpuVU1->Execute(vu1RunCycles);
+			if (THREAD_VU1)
+				vu1Thread.WaitVU();
+			else
+				CpuVU1->Execute(vu1RunCycles);
 			cpuRegs.cycle = VU1.cycle;
 			//Catch up VU0 too
 			CpuVU0->ExecuteBlock(0);

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -30,6 +30,7 @@
 #include "R5900OpcodeTables.h"
 #include "VUmicro.h"
 #include "Vif_Dma.h"
+#include "MTVU.h"
 
 #define _Ft_ _Rt_
 #define _Fs_ _Rd_

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -61,15 +61,16 @@ void __fastcall vu1ExecMicro(u32 addr)
 {
 	if (THREAD_VU1) {
 		VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
-
 		// Okay this is a little bit of a hack, but with good reason.
 		// Most of the time with MTVU we want to pretend the VU has finished quickly as to gain the benefit from running another thread
 		// however with T-Bit games when the T-Bit is enabled, it needs to wait in case a T-Bit happens, so we need to set "Busy"
 		// We shouldn't do this all the time as it negates the extra thread and causes games like Ratchet & Clank to be no faster.
-		if(VU0.VI[REG_FBRST].UL & 0x800)
+		if (VU0.VI[REG_FBRST].UL & 0x800)
+		{
 			VU0.VI[REG_VPU_STAT].UL |= 0x0100;
+		}
 
-		vu1Thread.ExecuteVU(addr, vif1Regs.top, vif1Regs.itop);
+		vu1Thread.ExecuteVU(addr, vif1Regs.top, vif1Regs.itop, VU0.VI[REG_FBRST].UL);
 		return;
 	}
 	static int count = 0;

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -33,7 +33,6 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp)
 		return;
 	}
 
-	
 	if (!(stat & test))
 	{
 		// VU currently flushes XGKICK on VU1 end so no need for this, yet

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -305,6 +305,7 @@ _vifT __fi u32 vifRead32(u32 mem)
 {
 	vifStruct& vif = MTVU_VifX;
 	bool wait = idx && THREAD_VU1;
+
 	switch (mem)
 	{
 		case caseVif(ROW0):
@@ -380,44 +381,36 @@ _vifT __fi bool vifWrite32(u32 mem, u32 value)
 
 		case caseVif(ROW0):
 			vif.MaskRow._u32[0] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteRow(vif);
+			vu1Thread.WriteRow(vif);
 			return false;
 		case caseVif(ROW1):
 			vif.MaskRow._u32[1] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteRow(vif);
+			vu1Thread.WriteRow(vif);
 			return false;
 		case caseVif(ROW2):
 			vif.MaskRow._u32[2] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteRow(vif);
+			vu1Thread.WriteRow(vif);
 			return false;
 		case caseVif(ROW3):
 			vif.MaskRow._u32[3] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteRow(vif);
+			vu1Thread.WriteRow(vif);
 			return false;
 
 		case caseVif(COL0):
 			vif.MaskCol._u32[0] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteCol(vif);
+			vu1Thread.WriteCol(vif);
 			return false;
 		case caseVif(COL1):
 			vif.MaskCol._u32[1] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteCol(vif);
+			vu1Thread.WriteCol(vif);
 			return false;
 		case caseVif(COL2):
 			vif.MaskCol._u32[2] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteCol(vif);
+			vu1Thread.WriteCol(vif);
 			return false;
 		case caseVif(COL3):
 			vif.MaskCol._u32[3] = value;
-			if (idx && THREAD_VU1)
-				vu1Thread.WriteCol(vif);
+			vu1Thread.WriteCol(vif);
 			return false;
 	}
 

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -173,9 +173,6 @@ __fi void vif1SetupTransfer()
 		}
 	}
 
-			
-			
-
 	if (vif1ch.chcr.TTE)
 	{
 		// Transfer dma tag if tte is set
@@ -203,7 +200,7 @@ __fi void vif1SetupTransfer()
 			ret = VIF1transfer((u32*)&masked_tag + 2, 2, true);  //Transfer Tag
 			//ret = VIF1transfer((u32*)ptag + 2, 2);  //Transfer Tag
 		}
-				
+
 		if (!ret && vif1.irqoffset.enabled)
 		{
 			vif1.inprogress &= ~1; // Better clear this so it has to do it again (Jak 1)
@@ -233,8 +230,7 @@ __fi void vif1VUFinish()
 {
 	if (VU0.VI[REG_VPU_STAT].UL & 0x500)
 	{
-		if(THREAD_VU1)
-			vu1Thread.Get_MTVUChanges();
+		vu1Thread.Get_MTVUChanges();
 
 		CPU_INT(VIF_VU1_FINISH, 128);
 		return;
@@ -355,11 +351,11 @@ __fi void vif1Interrupt()
 	vif1.vifstalled.enabled = false;
 
 	//Mirroring change to VIF0
-	if (vif1.cmd) 
+	if (vif1.cmd)
 	{
 		if (vif1.done && (vif1ch.qwc == 0)) vif1Regs.stat.VPS = VPS_WAITING;
 	}
-	else		 
+	else
 	{
 		vif1Regs.stat.VPS = VPS_IDLE;
 	}

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -549,7 +549,10 @@ __fi void mVUinitFirstPass(microVU& mVU, uptr pState, u8* thisPtr)
 
 void mVUDoDBit(microVU& mVU, microFlagCycles* mFC)
 {
-	xTEST(ptr32[&VU0.VI[REG_FBRST].UL], (isVU1 ? 0x400 : 0x4));
+	if (mVU.index && THREAD_VU1)
+		xTEST(ptr32[&vu1Thread.vuFBRST], (isVU1 ? 0x400 : 0x4));
+	else
+		xTEST(ptr32[&VU0.VI[REG_FBRST].UL], (isVU1 ? 0x400 : 0x4));
 	xForwardJump32 eJMP(Jcc_Zero);
 	if (!isVU1 || !THREAD_VU1)
 	{
@@ -564,7 +567,10 @@ void mVUDoDBit(microVU& mVU, microFlagCycles* mFC)
 
 void mVUDoTBit(microVU& mVU, microFlagCycles* mFC)
 {
-	xTEST(ptr32[&VU0.VI[REG_FBRST].UL], (isVU1 ? 0x800 : 0x8));
+	if (mVU.index && THREAD_VU1)
+		xTEST(ptr32[&vu1Thread.vuFBRST], (isVU1 ? 0x800 : 0x8));
+	else
+		xTEST(ptr32[&VU0.VI[REG_FBRST].UL], (isVU1 ? 0x800 : 0x8));
 	xForwardJump32 eJMP(Jcc_Zero);
 	if (!isVU1 || !THREAD_VU1)
 	{

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -14,7 +14,6 @@
  */
 
 #pragma once
-
 extern void _vu0WaitMicro();
 extern void _vu0FinishMicro();
 


### PR DESCRIPTION
### Description of Changes
Tries to make T-Bit more reliable in MTVU, but it is slow and probably shouldn't be used. Also added option to disable MTVU in the GameDB, it seems reliable, hopefully :/

### Rationale behind Changes
T-bit is just broken in MTVU, since the EE thread needs to know when the VU program has finished and if it was a T-Bit finish or E-Bit finish, and the threading makings this a total mess.  Plus it turns out a bunch of games which use this actually have DMA problems which are masked with MTVU off.

### Suggested Testing Steps
just test games, make sure they work still since I had to move some VU stuff around a bit. you can try disabling some stuff in the GameDB if you wish with MTVUSpeedHack: 0

Games which are affected and have MTVU forcefully disabled in the DB (known):
The Sims
Spiderman 3
Sharks Tale
Over the Hedge
Pitfall: The Lost Expedition