### PR TITLE
DEV9: Fix Windows config saving/loading

### DIFF
--- a/pcsx2/DEV9/ConfigUI.cpp
+++ b/pcsx2/DEV9/ConfigUI.cpp
@@ -228,7 +228,7 @@ public:
 			const auto& list = m_adapter_list[static_cast<u32>(config.EthApi)];
 			for (size_t i = 0; i < list.size(); i++)
 			{
-				if (list[i].name == config.Eth)
+				if (list[i].guid == config.Eth)
 				{
 					m_eth_adapter->SetSelection(i + 1);
 					break;
@@ -259,7 +259,7 @@ public:
 		if (api && eth)
 		{
 			const AdapterEntry& adapter = m_adapter_list[static_cast<u32>(m_api_list[api - 1])][eth - 1];
-			wxStrncpy(config.Eth, adapter.name, std::size(config.Eth) - 1);
+			wxStrncpy(config.Eth, adapter.guid, std::size(config.Eth) - 1);
 			config.EthApi = adapter.type;
 		}
 		else


### PR DESCRIPTION
### Description of Changes
https://github.com/PCSX2/pcsx2/pull/4421 introduced a regression of saving the adapter name rather than the adapter GUID

Somehow this wasn't picked up in testing (admittedly I didn't get the chance to do a full test of that pr)

### Rationale behind Changes
On windows, this prevents pcap or tap from functioning as they rely on the GUID to identify an adapter.
Linux was unaffected as both are set to the same value

### Suggested Testing Steps
Test saving/loading settings on Windows and that you are able to connect online (or no errors reported when starting a game)
Test Linux to ensure nothing broke (I don't think it would)
