### PR TITLE
Fix compilation with LTO on GCC

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -170,6 +170,11 @@ else()
 	endif()
 endif()
 
+if (USE_GCC AND CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+	# GCC LTO doesn't work with asm statements
+	set_source_files_properties(FastJmp.cpp PROPERTIES COMPILE_FLAGS -fno-lto)
+endif()
+
 target_link_libraries(common PRIVATE ${LIBC_LIBRARIES} PUBLIC wxWidgets::all glad)
 target_compile_features(common PUBLIC cxx_std_17)
 target_include_directories(common PUBLIC ../3rdparty/include ../)


### PR DESCRIPTION
### Description of Changes
Makes GCC link it correctly in LTO mode

### Rationale behind Changes
Vroom vroom

### Suggested Testing Steps
Build with LTO if you want