### PR TITLE
DEV9: DNS Logger Crash fix

### DIFF
--- a/pcsx2/DEV9/InternalServers/DNS_Logger.cpp
+++ b/pcsx2/DEV9/InternalServers/DNS_Logger.cpp
@@ -155,7 +155,7 @@ namespace InternalServers
 		}
 		for (size_t i = 0; i < dns->additional.size(); i++)
 		{
-			DNS_ResponseEntry entry = dns->authorities[i];
+			DNS_ResponseEntry entry = dns->additional[i];
 			Console.WriteLn("DEV9: DNS: Add%i Name %s", i, entry.name.c_str());
 			Console.WriteLn("DEV9: DNS: Add%i Type %i", i, entry.entryType);
 			Console.WriteLn("DEV9: DNS: Add%i Class %i", i, entry.entryClass);


### PR DESCRIPTION
### Description of Changes
Access the correct array for additional information when logging DNS packets

### Rationale behind Changes
Was previously logging the wrong information for additional information.
If the DNS server does not include additional information, but did provide authorities information a crash would occur.
This wasn't picked up before as DNS logging is disabled by default.

### Suggested Testing Steps
Set EthLogDNS to 1 in DEV9.cfg
Connect to an online server (via a online multiplayer game, or with the Network access disc)
Christian's DNS server (45.7.228.197) would crash the DNS logger in master, but gets logged correctly in this PR
