### PR TITLE
GS: Further state cleanup + fixes for older dump compatibility

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -23,7 +23,7 @@
 int GSState::s_n = 0;
 
 GSState::GSState()
-	: m_version(6)
+	: m_version(7)
 	, m_gsc(NULL)
 	, m_skip(0)
 	, m_skip_offset(0)
@@ -87,7 +87,6 @@ GSState::GSState()
 
 	m_sssize += sizeof(m_version);
 	m_sssize += sizeof(m_env.PRIM);
-	m_sssize += sizeof(m_env.PRMODE);
 	m_sssize += sizeof(m_env.PRMODECONT);
 	m_sssize += sizeof(m_env.TEXCLUT);
 	m_sssize += sizeof(m_env.SCANMSK);
@@ -2087,7 +2086,6 @@ int GSState::Freeze(freezeData* fd, bool sizeonly)
 
 	WriteState(data, &m_version);
 	WriteState(data, &m_env.PRIM);
-	WriteState(data, &m_env.PRMODE);
 	WriteState(data, &m_env.PRMODECONT);
 	WriteState(data, &m_env.TEXCLUT);
 	WriteState(data, &m_env.SCANMSK);
@@ -2174,7 +2172,10 @@ int GSState::Defrost(const freezeData* fd)
 	Reset();
 
 	ReadState(&m_env.PRIM, data);
-	ReadState(&m_env.PRMODE, data);
+
+	if (version <= 6)
+		data += sizeof(GIFRegPRMODE);
+
 	ReadState(&m_env.PRMODECONT, data);
 	ReadState(&m_env.TEXCLUT, data);
 	ReadState(&m_env.SCANMSK, data);
@@ -2201,6 +2202,10 @@ int GSState::Defrost(const freezeData* fd)
 		ReadState(&m_env.CTXT[i].XYOFFSET, data);
 		ReadState(&m_env.CTXT[i].TEX0, data);
 		ReadState(&m_env.CTXT[i].TEX1, data);
+
+		if (version <= 6)
+			data += sizeof(GIFRegTEX2);
+
 		ReadState(&m_env.CTXT[i].CLAMP, data);
 		ReadState(&m_env.CTXT[i].MIPTBP1, data);
 		ReadState(&m_env.CTXT[i].MIPTBP2, data);

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A27 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A28 << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin


### PR DESCRIPTION
### Description of Changes
Fixes compatibility with old savestates + remove PRMODE which is no longer used.  Also bumps savestate version.

### Rationale behind Changes
Recent changes temporarily broke compat with older states since it was merged before the PR was completely ready.

### Suggested Testing Steps
Test GS Dumps and savestates from PCSX2 to make sure they all work ok.
