### PR TITLE
DEV9: Don't shadow return value of GetAdaptersAddresses (Pcap)

### DIFF
--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -83,7 +83,7 @@ bool PCAPGetWin32Adapter(const char* name, PIP_ADAPTER_ADDRESSES adapter, std::u
 		dwBufLen = sizeof(IP_ADAPTER_ADDRESSES) * neededSize;
 		DevCon.WriteLn("DEV9: New size %i", neededSize);
 
-		DWORD dwStatus = GetAdaptersAddresses(
+		dwStatus = GetAdaptersAddresses(
 			AF_UNSPEC,
 			GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_INCLUDE_GATEWAYS,
 			NULL,


### PR DESCRIPTION
### Description of Changes
Don't shadow dwStatus in PCAPGetWin32Adapter

### Rationale behind Changes
Shadowing dwStatus for the return value of GetAdaptersAddresses will prevent the return value of second call from being inspected in the following if statement

If the user had a large amount of network adapters, this would prevent the code from getting the adapter information of a the selected pcap adaptor.

The equivalent TAP adapter code is already correct.

### Suggested Testing Steps
Test pcap adaptor on a system with lots of adapters installed
