### PR TITLE
GS: Fix up CLUT offset handling in 32bit I8 mode

### DIFF
--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -78,7 +78,7 @@ class alignas(32) GSClut : public GSAlignedClass<32>
 	static void WriteCLUT_T32_I4_CSM1(const uint32* RESTRICT src, uint16* RESTRICT clut);
 	static void WriteCLUT_T16_I8_CSM1(const uint16* RESTRICT src, uint16* RESTRICT clut);
 	static void WriteCLUT_T16_I4_CSM1(const uint16* RESTRICT src, uint16* RESTRICT clut);
-	static void ReadCLUT_T32_I8(const uint16* RESTRICT clut, uint32* RESTRICT dst);
+	static void ReadCLUT_T32_I8(const uint16* RESTRICT clut, uint32* RESTRICT dst, int offset);
 	static void ReadCLUT_T32_I4(const uint16* RESTRICT clut, uint32* RESTRICT dst);
 	//static void ReadCLUT_T32_I4(const uint16* RESTRICT clut, uint32* RESTRICT dst32, uint64* RESTRICT dst64);
 	//static void ReadCLUT_T16_I8(const uint16* RESTRICT clut, uint32* RESTRICT dst);

--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -74,7 +74,7 @@ class alignas(32) GSClut : public GSAlignedClass<32>
 
 	void WriteCLUT_NULL(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT);
 
-	static void WriteCLUT_T32_I8_CSM1(const uint32* RESTRICT src, uint16* RESTRICT clut);
+	static void WriteCLUT_T32_I8_CSM1(const uint32* RESTRICT src, uint16* RESTRICT clut, uint16 offset);
 	static void WriteCLUT_T32_I4_CSM1(const uint32* RESTRICT src, uint16* RESTRICT clut);
 	static void WriteCLUT_T16_I8_CSM1(const uint16* RESTRICT src, uint16* RESTRICT clut);
 	static void WriteCLUT_T16_I4_CSM1(const uint16* RESTRICT src, uint16* RESTRICT clut);


### PR DESCRIPTION
### Description of Changes
Fixes CLUT writing for games which use an offset to write to sections of the CLUT in PSMCT32 mode with I8. Wraps CLUT memory when reading with an offset

### Rationale behind Changes
Writing with offset was broken and previously used the "clut_reload_on_draw" hack, which wasn't really the solution. Also remove CLUT memory wrapping code (by duplicating it) didn't really work, so now it properly wraps.

### Suggested Testing Steps
Test games mentioned, make sure the colours are correct. Test other games just to make sure nothing is broken.


Games which previously needed the load_clut_before_draw hack
Cabela's Hunting games
Harley Davidson
Fixes #1597

Also fixes Romance of the Three Kingdoms games colours.
Fixes #1628
Fixes #2390

The History Channel: Battle for the Pacific 
Fixes #4396 

Other games apparently fixed

NPPL Championship Paintball 2009
Spider-Man Friend or Foe 
Apparently fixes Rapala Pro Fishing also

Correctly clamping of CLUT reading with offset to repeat last CSA offset fixes GTA San Andreas dirt
Fixes #2650