### PR TITLE
GS-ogl: Remove checks for extensions we don't yet use.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1262,7 +1262,6 @@ void GSApp::Init()
 	m_default_configuration["osd_monitor_enabled"]                        = "0";
 	m_default_configuration["osd_max_log_messages"]                       = "2";
 	m_default_configuration["override_geometry_shader"]                   = "-1";
-	m_default_configuration["override_GL_ARB_compute_shader"]             = "-1";
 	m_default_configuration["override_GL_ARB_copy_image"]                 = "-1";
 	m_default_configuration["override_GL_ARB_clear_texture"]              = "-1";
 	m_default_configuration["override_GL_ARB_clip_control"]               = "-1";
@@ -1270,13 +1269,9 @@ void GSApp::Init()
 	m_default_configuration["override_GL_ARB_draw_buffers_blend"]         = "-1";
 	m_default_configuration["override_GL_ARB_get_texture_sub_image"]      = "-1";
 	m_default_configuration["override_GL_ARB_gpu_shader5"]                = "-1";
-	m_default_configuration["override_GL_ARB_multi_bind"]                 = "-1";
 	m_default_configuration["override_GL_ARB_shader_image_load_store"]    = "-1";
-	m_default_configuration["override_GL_ARB_shader_storage_buffer_object"] = "-1";
 	m_default_configuration["override_GL_ARB_sparse_texture"]             = "-1";
 	m_default_configuration["override_GL_ARB_sparse_texture2"]            = "-1";
-	m_default_configuration["override_GL_ARB_texture_view"]               = "-1";
-	m_default_configuration["override_GL_ARB_vertex_attrib_binding"]      = "-1";
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
 	m_default_configuration["paltex"]                                     = "0";
 	m_default_configuration["png_compression_level"]                      = std::to_string(Z_BEST_SPEED);

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1267,12 +1267,14 @@ void GSApp::Init()
 	m_default_configuration["override_GL_ARB_clip_control"]               = "-1";
 	m_default_configuration["override_GL_ARB_direct_state_access"]        = "-1";
 	m_default_configuration["override_GL_ARB_draw_buffers_blend"]         = "-1";
-	m_default_configuration["override_GL_ARB_get_texture_sub_image"]      = "-1";
 	m_default_configuration["override_GL_ARB_gpu_shader5"]                = "-1";
 	m_default_configuration["override_GL_ARB_shader_image_load_store"]    = "-1";
 	m_default_configuration["override_GL_ARB_sparse_texture"]             = "-1";
 	m_default_configuration["override_GL_ARB_sparse_texture2"]            = "-1";
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
+#ifdef GL_EXT_TEX_SUB_IMAGE
+	m_default_configuration["override_GL_ARB_get_texture_sub_image"]      = "-1";
+#endif
 	m_default_configuration["paltex"]                                     = "0";
 	m_default_configuration["png_compression_level"]                      = std::to_string(Z_BEST_SPEED);
 	m_default_configuration["preload_frame_with_gs_data"]                 = "0";

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -156,7 +156,6 @@ namespace GLLoader
 
 	bool found_geometry_shader = true; // we require GL3.3 so geometry must be supported by default
 	bool found_GL_ARB_clear_texture = false;
-	bool found_GL_ARB_get_texture_sub_image = false; // Not yet used
 	// DX11 GPU
 	bool found_GL_ARB_gpu_shader5 = false;             // Require IvyBridge
 	bool found_GL_ARB_shader_image_load_store = false; // Intel IB. Nvidia/AMD miss Mesa implementation.
@@ -164,6 +163,11 @@ namespace GLLoader
 	// In case sparse2 isn't supported
 	bool found_compatible_GL_ARB_sparse_texture2 = false;
 	bool found_compatible_sparse_depth = false;
+
+	// Not yet used
+#ifdef GL_EXT_TEX_SUB_IMAGE
+	bool found_GL_ARB_get_texture_sub_image = false;
+#endif
 
 	static void mandatory(const std::string& ext)
 	{
@@ -310,7 +314,10 @@ namespace GLLoader
 			// Mandatory for the advance HW renderer effect. Unfortunately Mesa LLVMPIPE/SWR renderers doesn't support this extension.
 			// Rendering might be corrupted but it could be good enough for test/virtual machine.
 			optional("GL_ARB_texture_barrier");
+			// Not yet used
+#ifdef GL_EXT_TEX_SUB_IMAGE
 			found_GL_ARB_get_texture_sub_image = optional("GL_ARB_get_texture_sub_image");
+#endif
 		}
 
 		if (vendor_id_amd)

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -160,13 +160,6 @@ namespace GLLoader
 	// DX11 GPU
 	bool found_GL_ARB_gpu_shader5 = false;             // Require IvyBridge
 	bool found_GL_ARB_shader_image_load_store = false; // Intel IB. Nvidia/AMD miss Mesa implementation.
-	bool found_GL_ARB_shader_storage_buffer_object = false;
-	bool found_GL_ARB_compute_shader = false;
-	bool found_GL_ARB_texture_view = false; // maybe older gpu can support it ?
-
-	// Mandatory in the future
-	bool found_GL_ARB_multi_bind = false;
-	bool found_GL_ARB_vertex_attrib_binding = false;
 
 	// In case sparse2 isn't supported
 	bool found_compatible_GL_ARB_sparse_texture2 = false;
@@ -310,14 +303,8 @@ namespace GLLoader
 			found_GL_ARB_gpu_shader5 = optional("GL_ARB_gpu_shader5");
 			// GL4.2
 			found_GL_ARB_shader_image_load_store = optional("GL_ARB_shader_image_load_store");
-			// GL4.3
-			found_GL_ARB_compute_shader = optional("GL_ARB_compute_shader");
-			found_GL_ARB_shader_storage_buffer_object = optional("GL_ARB_shader_storage_buffer_object");
-			found_GL_ARB_texture_view = optional("GL_ARB_texture_view");
-			found_GL_ARB_vertex_attrib_binding = optional("GL_ARB_vertex_attrib_binding");
 			// GL4.4
 			found_GL_ARB_clear_texture = optional("GL_ARB_clear_texture");
-			found_GL_ARB_multi_bind = optional("GL_ARB_multi_bind");
 			// GL4.5
 			optional("GL_ARB_direct_state_access");
 			// Mandatory for the advance HW renderer effect. Unfortunately Mesa LLVMPIPE/SWR renderers doesn't support this extension.

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -468,7 +468,7 @@ bool GSTextureOGL::Map(GSMap& m, const GSVector4i* _r, int layer)
 		// The fastest way will be to use a PBO to read the data asynchronously. Unfortunately GS
 		// architecture is waiting the data right now.
 
-#if 0
+#ifdef GL_EXT_TEX_SUB_IMAGE
 		// Maybe it is as good as the code below. I don't know
 		// With openGL 4.5 you can use glGetTextureSubImage
 

--- a/pcsx2/GS/config.h
+++ b/pcsx2/GS/config.h
@@ -28,6 +28,8 @@
 
 //#define DISABLE_DATE
 
+// Not yet used/experimental OpenGL extensions
+//#define GL_EXT_TEX_SUB_IMAGE
 
 #if !defined(NDEBUG) || defined(_DEBUG) || defined(_DEVEL)
 #define ENABLE_OGL_DEBUG // Create a debug context and check opengl command status. Allow also to dump various textures/states.


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Remove extension checks for:
GL_ARB_compute_shader,
GL_ARB_shader_storage_buffer_object,
GL_ARB_texture_view,
GL_ARB_vertex_attrib_binding,
GL_ARB_multi_bind

Put GL_ARB_get_texture_sub_image check under a define.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Not yet used, code debt.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Opengl just works, make sure extensions really aren't used.