### PR TITLE
GS: Don't propagate 24bit textures on download

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1096,7 +1096,8 @@ void GSTextureCache::InvalidateLocalMem(GSOffset* off, const GSVector4i& r)
 				// the game can then draw using 8H format
 				// in the case of silent hill blit 8H -> 8P
 				// this will matter later when the data ends up in GS memory in the wrong format
-				if (t->m_32_bits_fmt)
+				// Be careful to avoid 24 bit textures which are technically 32bit, as you could lose alpha (8H) data.
+				if (t->m_32_bits_fmt && t->m_TEX0.PSM > PSM_PSMCT24)
 					t->m_TEX0.PSM = PSM_PSMCT32;
 
 				if (GSTextureCache::m_disable_partial_invalidation)


### PR DESCRIPTION
### Description of Changes
Changes the texture propagation on GS download to not modify 24bit format avoiding alpha loss

### Rationale behind Changes
The previous change for Shattered Memories, while correct, didn't account for 24bit textures which have no alpha

### Suggested Testing Steps
Test Mana Khemia and Silent Hill games that had flashlight problems, make sure everything is still ok

Fixes #4928
Also fixes text on Fatal Frame 2 disappearing.
