### PR TITLE
actions: cleanup discord embed links and add release body

### DIFF
--- a/.github/workflows/scripts/releases/announce-release/index.js
+++ b/.github/workflows/scripts/releases/announce-release/index.js
@@ -11,9 +11,21 @@ for (var i = 0; i < assets.length; i++) {
     continue;
   }
   if (asset.name.includes("windows")) {
-    windowsAssetLinks += `- [${asset.name}](${asset.browser_download_url})\n`
+    let friendlyName = asset.name;
+    try {
+      friendlyName = asset.name.split("windows-")[1].split(".7z")[0].replace("-", " ");
+    } catch (e) {
+      console.log(e);
+    }
+    windowsAssetLinks += `- [${friendlyName}](${asset.browser_download_url})\n`
   } else if (asset.name.includes("linux")) {
-    linuxAssetLinks += `- [${asset.name}](${asset.browser_download_url})\n`
+    let friendlyName = asset.name;
+    try {
+      friendlyName = asset.name.split("linux-")[1].split(".AppImage")[0].replace("-", " ");
+    } catch (e) {
+      console.log(e);
+    }
+    linuxAssetLinks += `- [${friendlyName}](${asset.browser_download_url})\n`
   }
 }
 
@@ -24,7 +36,8 @@ const embed = new MessageEmbed()
   .addFields(
     { name: 'Version', value: github.context.payload.release.tag_name, inline: true },
     { name: 'Release Link', value: `[Github Release](${github.context.payload.release.html_url})`, inline: true },
-    { name: 'Installation Steps', value: '[See Here](https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide)', inline: true }
+    { name: 'Installation Steps', value: '[See Here](https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide)', inline: true },
+    { name: 'Included Changes', value: github.context.payload.release.body, inline: false }
   );
 
 if (windowsAssetLinks != "") {


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Some polish on the new webhook:
- remove redundant text from the link text (its obvious it's pcsx2, and the version number is already stated, its under a platform header, and the file extension will be apparent when its clicked)
- add the release notes to the announcement which are:
  - links to relevant PRs
  - in the absence of a PR (direct commit) it uses the commit message.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Better is better

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

I ran it locally with the payload from here https://api.github.com/repos/PCSX2/pcsx2/releases/tags/v1.7.2010

Before:
![image](https://user-images.githubusercontent.com/13153231/140233927-d5bbb3d9-ada3-4073-98f5-9727f3ee3540.png)

After
![image](https://user-images.githubusercontent.com/13153231/140233940-fb9b2f2c-a128-41f2-ac3a-1ddf46154305.png)
