### PR TITLE
Add "Clear missing files" option to recent ISO list

### DIFF
--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -102,6 +102,7 @@ enum MenuIdentifiers
 	MenuId_RecentIsos_reservedStart,
 	MenuId_IsoBrowse = MenuId_RecentIsos_reservedStart + 100, // Open dialog, runs selected iso.
 	MenuId_IsoClear,
+	MenuId_IsoClearMissing,
 	MenuId_DriveSelector,
 	MenuId_DriveListRefresh,
 	MenuId_Ask_On_Booting,

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -275,6 +275,7 @@ void MainEmuFrame::ConnectMenus()
 	// CDVD
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IsoBrowse_Click, this, MenuId_IsoBrowse);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IsoClear_Click, this, MenuId_IsoClear);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_IsoClearMissing_Click, this, MenuId_IsoClearMissing);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_Iso);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_Disc);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_CdvdSource_Click, this, MenuId_Src_NoDisc);

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -162,6 +162,7 @@ protected:
 
 	void Menu_IsoBrowse_Click(wxCommandEvent& event);
 	void Menu_IsoClear_Click(wxCommandEvent& event);
+	void Menu_IsoClearMissing_Click(wxCommandEvent& event);
 	void Menu_EnableBackupStates_Click(wxCommandEvent& event);
 	void Menu_EnablePatches_Click(wxCommandEvent& event);
 	void Menu_EnableCheats_Click(wxCommandEvent& event);

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -579,6 +579,23 @@ void MainEmuFrame::Menu_IsoClear_Click(wxCommandEvent& event)
 	}
 }
 
+void MainEmuFrame::Menu_IsoClearMissing_Click(wxCommandEvent& event)
+{
+	wxDialogWithHelpers dialog(this, _("Confirm clearing ISO list"));
+	dialog += dialog.Heading(_("This will remove all missing ISO files from the list. If an ISO is running it will remain in the list. Continue?"));
+
+	bool confirmed = pxIssueConfirmation(dialog, MsgButtons().YesNo()) == wxID_YES;
+
+	if (confirmed)
+	{
+		// If the CDVD mode is not ISO, or the system isn't running, wipe the CurrentIso field in INI file
+		if (g_Conf->CdvdSource != CDVD_SourceType::Iso || !SysHasValidState())
+			SysUpdateIsoSrcFile("");
+		wxGetApp().GetRecentIsoManager().ClearMissing();
+		AppSaveSettings();
+	}
+}
+
 void MainEmuFrame::Menu_Ask_On_Boot_Click(wxCommandEvent& event)
 {
 	g_Conf->AskOnBoot = event.IsChecked();

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -38,6 +38,7 @@ RecentIsoManager::RecentIsoManager( wxMenu* menu, int firstIdForMenuItems_or_wxI
 	m_Separator	= nullptr;
 	m_ClearSeparator = nullptr;
 	m_Clear = nullptr;
+	m_Prune = nullptr;
 
 	IniLoader loader;
 	LoadListFrom(loader);
@@ -116,12 +117,37 @@ void RecentIsoManager::RemoveAllFromMenu()
 		m_Menu->Destroy( m_Clear );
 		m_Clear = nullptr;
 	}
+
+	if (m_Prune != nullptr)
+	{
+		m_Menu->Destroy(m_Prune);
+		m_Prune = nullptr;
+	}
 }
 
 void RecentIsoManager::Clear()
 {
 	RemoveAllFromMenu();
 	m_Items.clear();
+	Repopulate();
+}
+
+void RecentIsoManager::ClearMissing()
+{
+	RemoveAllFromMenu();
+
+	std::vector<RecentItem> existing_items;
+	
+	for (const auto& recent_iso : m_Items)
+	{
+		if (wxFileExists(recent_iso.Filename))
+		{
+			existing_items.push_back(recent_iso);
+		}
+	}
+
+	m_Items = existing_items;
+
 	Repopulate();
 }
 
@@ -138,6 +164,7 @@ void RecentIsoManager::Repopulate()
 		InsertIntoMenu( i );
 
 	m_ClearSeparator = m_Menu->AppendSeparator();
+	m_Prune = m_Menu->Append(MenuIdentifiers::MenuId_IsoClearMissing, _("Clear missing files"));
 	m_Clear = m_Menu->Append(MenuIdentifiers::MenuId_IsoClear, _("Clear ISO list"));
 }
 

--- a/pcsx2/gui/RecentIsoList.h
+++ b/pcsx2/gui/RecentIsoList.h
@@ -49,6 +49,7 @@ protected:
 	wxMenuItem* m_Separator;
 	wxMenuItem* m_ClearSeparator;
 	wxMenuItem* m_Clear;
+	wxMenuItem* m_Prune;
 
 public:
 	RecentIsoManager( wxMenu* menu , int firstIdForMenuItems_or_wxID_ANY );
@@ -58,6 +59,7 @@ public:
 	void EnableItems(bool display);
 	void Repopulate();
 	void Clear();
+	void ClearMissing();
 	void Add( const wxString& src );
 
 protected:

--- a/pcsx2/gui/RecentIsoList.h
+++ b/pcsx2/gui/RecentIsoList.h
@@ -38,7 +38,11 @@ protected:
 		}
 	};
 
-	std::vector<RecentItem> m_Items;
+public:
+	using VectorType = std::vector<RecentItem>;
+
+protected:
+	VectorType m_Items;
 
 	wxMenu*		m_Menu;
 	uint		m_MaxLength;
@@ -49,11 +53,13 @@ protected:
 	wxMenuItem* m_Separator;
 	wxMenuItem* m_ClearSeparator;
 	wxMenuItem* m_Clear;
-	wxMenuItem* m_Prune;
+	wxMenuItem* m_ClearMissing;
 
 public:
 	RecentIsoManager( wxMenu* menu , int firstIdForMenuItems_or_wxID_ANY );
 	virtual ~RecentIsoManager();
+
+	VectorType GetMissingFiles() const;
 
 	void RemoveAllFromMenu();
 	void EnableItems(bool display);


### PR DESCRIPTION
### Description of Changes
Adds an option to the recent ISO list to remove all entries that can no longer be found in their original location.

### Rationale behind Changes
Solution for #4963. I decided on using the term "prune" instead of "clean" because it sounds too similar to the existing "clear". Would welcome input on what the terminology for this function should be.

### Suggested Testing Steps
1. Load an ISO file into PCSX2
2. In a separate file browser window, move that file to a different location on disk
3. Click the "Prune ISO list" option and the file will be removed from the list
