### PR TITLE
Restore Decode_XA.h

### DIFF
--- a/pcsx2/CDVD/CdRom.h
+++ b/pcsx2/CDVD/CdRom.h
@@ -19,23 +19,6 @@
 #include "IopCommon.h"
 #include "CDVDaccess.h"
 
-// Not used.
-typedef struct
-{
-	s32 y0, y1;
-} ADPCM_Decode_t;
-
-// Not used.
-typedef struct
-{
-	s32 freq;
-	s32 nbits;
-	s32 stereo;
-	s32 nsamples;
-	ADPCM_Decode_t left, right;
-	s16 pcm[16384];
-} xa_decode_t;
-
 struct cdrStruct
 {
 	u8 OCUP;
@@ -75,7 +58,6 @@ struct cdrStruct
 	int Reset;
 	int RErr;
 	int FirstSector;
-	xa_decode_t Xa;
 
 	int Init;
 

--- a/pcsx2/CDVD/Decode_XA.h
+++ b/pcsx2/CDVD/Decode_XA.h
@@ -13,7 +13,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DECODEXA_H
+/*#ifndef DECODEXA_H
 #define DECODEXA_H
 
 typedef struct
@@ -31,8 +31,8 @@ typedef struct
 	s16 pcm[16384];
 } xa_decode_t;
 
-/*long xa_decode_sector(xa_decode_t* xdp,
+long xa_decode_sector(xa_decode_t* xdp,
 	unsigned char* sectorp,
-	int is_first_sector);*/
+	int is_first_sector);
 
-#endif
+#endif*/

--- a/pcsx2/CDVD/Decode_XA.h
+++ b/pcsx2/CDVD/Decode_XA.h
@@ -1,0 +1,38 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DECODEXA_H
+#define DECODEXA_H
+
+typedef struct
+{
+	s32 y0, y1;
+} ADPCM_Decode_t;
+
+typedef struct
+{
+	s32 freq;
+	s32 nbits;
+	s32 stereo;
+	s32 nsamples;
+	ADPCM_Decode_t left, right;
+	s16 pcm[16384];
+} xa_decode_t;
+
+/*long xa_decode_sector(xa_decode_t* xdp,
+	unsigned char* sectorp,
+	int is_first_sector);*/
+
+#endif

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -271,7 +271,7 @@ set(pcsx2CDVDHeaders
 	CDVD/CompressedFileReaderUtils.h
 	CDVD/ChdFileReader.h
 	CDVD/CsoFileReader.h
-	CDVD/Decode_XA.h
+	#CDVD/Decode_XA.h
 	CDVD/GzippedFileReader.h
 	CDVD/ThreadedFileReader.h
 	CDVD/IsoFileFormats.h

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -271,6 +271,7 @@ set(pcsx2CDVDHeaders
 	CDVD/CompressedFileReaderUtils.h
 	CDVD/ChdFileReader.h
 	CDVD/CsoFileReader.h
+	CDVD/Decode_XA.h
 	CDVD/GzippedFileReader.h
 	CDVD/ThreadedFileReader.h
 	CDVD/IsoFileFormats.h

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -703,6 +703,7 @@
     <ClInclude Include="CDVD\CompressedFileReaderUtils.h" />
     <ClInclude Include="CDVD\CsoFileReader.h" />
     <ClInclude Include="CDVD\ChdFileReader.h" />
+    <ClInclude Include="CDVD\Decode_XA.h" />
     <ClInclude Include="CDVD\GzippedFileReader.h" />
     <ClInclude Include="CDVD\ThreadedFileReader.h" />
     <ClInclude Include="CDVD\zlib_indexed.h" />


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Restores a file from pcsx. The structures were still in our code but had been strangely moved to cdrom.h where they don't belong
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better code placement.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
N/A
