### PR TITLE
CI:Add build date to program log of nightly builds

### DIFF
--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -161,7 +161,7 @@ void SysLogMachineCaps()
 			// tagged commit - more modern implementation of dev build versioning
 			// - there is no need to include the commit - that is associated with the tag, 
 			// - git is implied and the tag is timestamped
-			Console.WriteLn(Color_StrongGreen, "\nPCSX2 Nightly - %s", GIT_TAG);
+			Console.WriteLn(Color_StrongGreen, "\nPCSX2 Nightly - %s Compiled on %s", GIT_TAG, __DATE__);
 		} else {
 			Console.WriteLn(Color_StrongGreen, "\nPCSX2 %u.%u.%u-%lld"
 #ifndef DISABLE_BUILD_DATE


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
adds  compile date to the  program log of nightly builds
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
to make it  easier for users to find when the nightly build was built 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
