### PR TITLE
Miscellaneous fixes for macOS

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -328,9 +328,9 @@ endif()
 # MacOS-specific things
 #-------------------------------------------------------------------------------
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 
-if (APPLE AND ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_LESS 10.14 AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 10)
+if (APPLE AND ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_LESS 10.14 AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 9)
 	# Older versions of the macOS stdlib don't have operator new(size_t, align_val_t)
 	# Disable use of them with this flag
 	# Not great, but also no worse that what we were getting before we turned on C++17

--- a/common/Darwin/DarwinThreads.cpp
+++ b/common/Darwin/DarwinThreads.cpp
@@ -82,11 +82,7 @@ static u64 getthreadtime(thread_port_t thread)
 		   (u64)info.system_time.microseconds;
 }
 
-// Returns the current timestamp (not relative to a real world clock) in
-// units of 100 nanoseconds. The weird units are to mirror the Windows
-// counterpart in WinThreads.cpp, which uses the GetThreadTimes() API.  On
-// OSX/Darwin, this is only accurate up until 1ms (and possibly less), so
-// not very good.
+// Returns the current timestamp (not relative to a real world clock) in microseconds
 u64 Threading::GetThreadCpuTime()
 {
 	// we could also use mach_thread_self() and mach_port_deallocate(), but
@@ -95,7 +91,7 @@ u64 Threading::GetThreadCpuTime()
 	// to be user-space instead. In contract,
 	// pthread_mach_thread_np(pthread_self()) is entirely in user-space.
 	u64 us = getthreadtime(pthread_mach_thread_np(pthread_self()));
-	return us * 10ULL;
+	return us;
 }
 
 u64 Threading::pxThread::GetCpuTime() const
@@ -109,7 +105,7 @@ u64 Threading::pxThread::GetCpuTime() const
 		return 0;
 	}
 
-	return getthreadtime((thread_port_t)m_native_id) * 10ULL;
+	return getthreadtime((thread_port_t)m_native_id);
 }
 
 void Threading::pxThread::_platform_specific_OnStartInThread()

--- a/pcsx2/GS/GSPerfMon.cpp
+++ b/pcsx2/GS/GSPerfMon.cpp
@@ -34,10 +34,12 @@ void GSPerfMon::Put(counter_t c, double val)
 	if (c == Frame)
 	{
 #if defined(__unix__) || defined(__APPLE__)
-		// clock on linux will return CLOCK_PROCESS_CPUTIME_ID.
-		// CLOCK_THREAD_CPUTIME_ID is much more useful to measure the fps
 		struct timespec ts;
-		clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+# ifdef CLOCK_MONOTONIC_RAW
+		clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+# else
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+# endif
 		uint64 now = (uint64)ts.tv_sec * (uint64)1e6 + (uint64)ts.tv_nsec / (uint64)1e3;
 #else
 		clock_t now = clock();

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -611,7 +611,7 @@ public:
 	wxString GetFilename() const { return L"USB.bin"; }
 	void FreezeIn(pxInputStream& reader) const { return SysState_ComponentFreezeIn(reader, USB); }
 	void FreezeOut(SaveStateBase& writer) const { return SysState_ComponentFreezeOut(writer, USB); }
-	bool IsRequired() const { return true; }
+	bool IsRequired() const { return false; }
 };
 
 class SavestateEntry_PAD : public BaseSavestateEntry


### PR DESCRIPTION
### Description of Changes
Fixes a number of random minor issues on macOS
Also increases the macOS deployment target so the CI stops complaining at people who use `std::optional`'s `value()` method

### Rationale behind Changes
Fixes things

### Suggested Testing Steps
Nothing in particular