### PR TITLE
GHActions: Don't shallow clone submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,23 +1,18 @@
 [submodule "3rdparty/xz/xz"]
 	path = 3rdparty/xz/xz
 	url = https://github.com/PCSX2/xz.git
-	shallow = true
 [submodule "3rdparty/gtest"]
 	path = 3rdparty/gtest
 	url = https://github.com/google/googletest.git
-	shallow = true
 [submodule "3rdparty/fmt/fmt"]
 	path = 3rdparty/fmt/fmt
 	url = https://github.com/fmtlib/fmt.git
-	shallow = true
 [submodule "3rdparty/yaml-cpp/yaml-cpp"]
 	path = 3rdparty/yaml-cpp/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git
-	shallow = true
 [submodule "3rdparty/libchdr/libchdr"]
 	path = 3rdparty/libchdr/libchdr
 	url = https://github.com/rtissera/libchdr.git
-	shallow = true
 [submodule "3rdparty/wil"]
 	path = 3rdparty/wil
 	url = https://github.com/microsoft/wil.git


### PR DESCRIPTION
### Description of Changes
Shallow clones tend to be 5-10s slower

GHActions Windows submodule checkout run time (seconds):
![image](https://user-images.githubusercontent.com/3315070/140460721-09dfc6af-36d3-4f71-8093-3987f6296967.png)

Linux:
![image](https://user-images.githubusercontent.com/3315070/140461433-198034b5-3593-44c9-815f-e123d14ab049.png)

macOS (never used GH cache on submodules):
![image](https://user-images.githubusercontent.com/3315070/140461758-a8218b9a-4318-4661-85af-6cf1103e2789.png)

### Rationale behind Changes
Why waste 10 seconds when you don't have to?

### Suggested Testing Steps
Watch the CI run