### PR TITLE
Debugger: Make the register list DPI aware (Windows)

### DIFF
--- a/pcsx2/gui/Debugger/CtrlRegisterList.cpp
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.cpp
@@ -74,8 +74,8 @@ CtrlRegisterList::CtrlRegisterList(wxWindow* parent, DebugInterface* _cpu)
 	SetDoubleBuffered(true);
 
 	const wxSize optSize = getOptimalSize();
-	SetVirtualSize(optSize);
-	SetScrollbars(1, rowHeight, optSize.x, optSize.y / rowHeight, 0, 0);
+	SetVirtualSize(optSize.x,optSize.y);
+	SetScrollbars(1, rowHeight, optSize.x, optSize.y * MSW_GetDPIScale() / rowHeight, 0, 0);
 }
 
 CtrlRegisterList::~CtrlRegisterList()

--- a/pcsx2/gui/Debugger/CtrlRegisterList.h
+++ b/pcsx2/gui/Debugger/CtrlRegisterList.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <wx/wx.h>
 
+#include "gui/MSWstuff.h" // Required for MSW_GetDPIScale()
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/DisassemblyManager.h"
 
@@ -38,7 +39,7 @@ public:
 		if (GetWindowStyle() & wxVSCROLL)
 			optimalSize.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
 
-		return wxSize(optimalSize.x, 0);
+		return wxSize(optimalSize.x * MSW_GetDPIScale(), 0);
 	}
 
 	virtual wxSize DoGetBestClientSize() const


### PR DESCRIPTION
### Description of Changes
On DPIs that weren't 100%, the register list would be cut off. 

This was 125% dpi for example

![image](https://user-images.githubusercontent.com/29295048/140463292-eeaafbc9-1669-4b66-a29b-a6adf9f19a98.png)

Note how you're missing the X column

This is the fixed version:

![image](https://user-images.githubusercontent.com/29295048/140463386-18ad09ff-bafc-48df-a9dd-ff1994ae7a79.png)

### Rationale behind Changes
The debugger was unusable for people running things other than 100% DPI

### Suggested Testing Steps
Test different DPIs and make sure the register list isn't cut off.
