### PR TITLE
wx: Fix `pxExplore` on macOS

### DIFF
--- a/pcsx2/gui/Panels/DirPickerPanel.cpp
+++ b/pcsx2/gui/Panels/DirPickerPanel.cpp
@@ -78,7 +78,7 @@ void Panels::DirPickerPanel::Explore_Click( wxCommandEvent &evt )
 		path.Mkdir();
 	}
 
-	pxExplore( path.ToString() );
+	wxLaunchDefaultApplication(path.ToString());
 }
 
 // There are two constructors.  See the details for the 'label' parameter below for details.

--- a/pcsx2/gui/wxGuiTools.cpp
+++ b/pcsx2/gui/wxGuiTools.cpp
@@ -666,14 +666,11 @@ void pxLaunch(const char* filename)
 }
 
 // ------------------------------------------------------------------------
-// Launches a file explorer window on the specified path.  If the given path is not
-// a qualified URI (with a prefix:// ), file:// is automatically prepended.  This
-// bypasses wxWidgets internal filename checking, which can end up launching things
-// through browser more often than desired.
+// Launches a file explorer window on the specified path.
 //
 void pxExplore(const wxString& path)
 {
-	wxLaunchDefaultBrowser(!path.Contains(L"://") ? L"file://" + path : path);
+	wxLaunchDefaultApplication(path);
 }
 
 void pxExplore(const char* path)

--- a/pcsx2/gui/wxGuiTools.cpp
+++ b/pcsx2/gui/wxGuiTools.cpp
@@ -650,30 +650,3 @@ wxString pxGetAppName()
 	pxAssert(wxTheApp);
 	return wxTheApp->GetAppName();
 }
-
-
-// ------------------------------------------------------------------------
-// Launches the specified file according to its mime type
-//
-void pxLaunch(const wxString& filename)
-{
-	wxLaunchDefaultBrowser(filename);
-}
-
-void pxLaunch(const char* filename)
-{
-	pxLaunch(fromUTF8(filename));
-}
-
-// ------------------------------------------------------------------------
-// Launches a file explorer window on the specified path.
-//
-void pxExplore(const wxString& path)
-{
-	wxLaunchDefaultApplication(path);
-}
-
-void pxExplore(const char* path)
-{
-	pxExplore(fromUTF8(path));
-}

--- a/pcsx2/gui/wxGuiTools.h
+++ b/pcsx2/gui/wxGuiTools.h
@@ -802,9 +802,3 @@ extern void pxSetToolTip(wxWindow& wind, const wxString& src);
 extern wxFont pxGetFixedFont(int ptsize = 8, wxFontWeight weight = wxFONTWEIGHT_NORMAL, bool underline = false);
 
 extern pxDialogCreationFlags pxDialogFlags();
-
-extern void pxExplore(const wxString& path);
-extern void pxExplore(const char* path);
-
-extern void pxLaunch(const wxString& path);
-extern void pxLaunch(const char* path);


### PR DESCRIPTION
### Description of Changes
Makes `pxExplore` work correctly on macOS

### Rationale behind Changes
It didn't work

### Suggested Testing Steps
Make sure you can still use the "Open in Explorer" buttons in the settings window

I would think `wxLaunchDefaultApplication` will work at least as well as the old solution on all platforms but who knows
