### PR TITLE
GameDB: add EE clamping to 'Shadow of Zorro' and 'Evil Twin - Cyprien's Chronicles'

### DIFF
--- a/bin/GameIndex.yaml
+++ b/bin/GameIndex.yaml
@@ -7565,6 +7565,8 @@ SLES-50201:
   name: "Evil Twin - Cyprien's Chronicles"
   region: "PAL-M5"
   compat: 5
+  clampModes:
+    eeClampMode: 2  # Fixes texture mipmapping.
 SLES-50202:
   name: "DNA - Dark Native Apostle"
   region: "PAL-M5"
@@ -8422,6 +8424,8 @@ SLES-50662:
   name: "Shadow of Zorro, The"
   region: "PAL-M5"
   compat: 4
+  clampModes:
+    eeClampMode: 2  # Fixes texture mipmapping.
 SLES-50670:
   name: "ESPN Winter X-Games Snowboarding 2"
   region: "PAL-M3"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
adds EE clamping to 'Shadow of Zorro' and 'Evil Twin - Cyprien's Chronicles'
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
fixes said games
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
look at the CI 