### PR TITLE
CDVD: set the correct RTC year when input recording

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -797,7 +797,7 @@ void cdvdReset()
 		cdvd.RTC.hour = 0;
 		cdvd.RTC.day = 4;
 		cdvd.RTC.month = 3;
-		cdvd.RTC.year = 2;
+		cdvd.RTC.year = 20;
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

I committed the wrong year...oops

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

The current code most likely would prevent booting on certain games (MGS3 for example), as the year would always be 2002.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Double check that im not lying this time.