### PR TITLE
actions: increase max linux build times as well until cache-hit rate is reliable

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Linux builds are failing, 30minutes is not enough with a cache-miss. For example - https://github.com/PCSX2/pcsx2/runs/4128702348?check_suite_focus=true

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

We can't rely on the cache properly until the following issue is resolved - https://github.com/actions/cache/issues/342#issuecomment-673371329

Once we can, we should be able to dynamically set the timeout accordingly based on the cache-hit/miss

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Do builds still pass