### PR TITLE
CMake: Always default `CMAKE_BUILD_PO` off

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -121,15 +121,7 @@ endif()
 # It only cost several MB so disbable it by default
 option(CMAKE_BUILD_STRIP "Srip binaries to save a couple of MB (developer option)")
 
-if(NOT DEFINED CMAKE_BUILD_PO)
-	if(CMAKE_BUILD_TYPE STREQUAL "Release")
-		set(CMAKE_BUILD_PO TRUE)
-		message(STATUS "Enable the building of po files by default in ${CMAKE_BUILD_TYPE} build !!!")
-	else()
-		set(CMAKE_BUILD_PO FALSE)
-		message(STATUS "Disable the building of po files by default in ${CMAKE_BUILD_TYPE} build !!!")
-	endif()
-endif()
+option(CMAKE_BUILD_PO "Build po files (modifies git-tracked files)" OFF)
 
 #-------------------------------------------------------------------------------
 # Select the architecture


### PR DESCRIPTION
### Description of Changes
Defaults the `CMAKE_BUILD_PO` option to off for all build modes

### Rationale behind Changes
Git files getting modified by build is just as much of a pain in release builds as it is in devel builds

### Suggested Testing Steps
Build in release and see if it modifies files tracked by git