### PR TITLE
GS:SW: Fix fog on x64 avx2

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
@@ -808,7 +808,7 @@ void GSDrawScanlineCodeGenerator2::Init()
 		}
 
 		if (m_sel.fwrite && m_sel.fge && is64)
-			pbroadcastdLocal(_f, _rip_local(p.f));
+			pbroadcastwLocal(_f, _rip_local(p.f));
 	}
 
 	const XYm& vt = xym4;


### PR DESCRIPTION
### Description of Changes
Fixes a bug where `f` would be incorrect for the blue channel when fogging was enabled on the rendering of a sprite on avx2 x64

Fixes #4996

### Rationale behind Changes
Makes things less broken

### Suggested Testing Steps
Look at grass in the background of Hitman Blood Money title screen and see if it's blue
