### PR TITLE
GS: add warning if skipdraw is enabled

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -217,6 +217,9 @@ void GSState::Reset()
 	m_vertex.tail = 0;
 	m_vertex.next = 0;
 	m_index.tail = 0;
+
+	if (m_userhacks_skipdraw) 
+		Console.Warning("Skipdraw is active! Please disable before reporting graphics bugs!");
 }
 
 void GSState::ResetHandlers()
@@ -1757,6 +1760,10 @@ void GSState::Move()
 
 void GSState::SoftReset(uint32 mask)
 {
+
+	if (m_userhacks_skipdraw) 
+		Console.Warning("Skipdraw is active! Please disable before reporting graphics bugs!");
+
 	if (mask & 1)
 	{
 		memset(&m_path[0], 0, sizeof(GIFPath));


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Adds warning  if  skipdraw is enables since it can casuse bugs 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
 let the user know that s its enabled and anyone looking at the log 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
boot  with skipdraw enabled and see the warning ,  enable skipdraw   mid game and see the  warning 