### PR TITLE
Debugger: Fix breakpoint edit window on linux

### DIFF
--- a/pcsx2/gui/Debugger/BreakpointWindow.cpp
+++ b/pcsx2/gui/Debugger/BreakpointWindow.cpp
@@ -149,12 +149,12 @@ void BreakpointWindow::setDefaultValues()
 	if (address != 0xFFFFFFFF)
 	{
 		swprintf(str,64,L"0x%08X",address);
-		editAddress->SetLabel(str);
+		editAddress->SetValue(str);
 	}
 	
 	swprintf(str,64,L"0x%08X",size);
-	editSize->SetLabel(str);
-	editCondition->SetLabel(wxString(condition,wxConvUTF8));	
+	editSize->SetValue(str);
+	editCondition->SetValue(wxString(condition,wxConvUTF8));	
 }
 
 void BreakpointWindow::loadFromMemcheck(MemCheck& memcheck)


### PR DESCRIPTION
### Description of Changes
Using SetLabel on a wxTextCtrl doesn't set the value of the text control on linux.

### Rationale behind Changes
The breakpoint window was not working properly on linux

### Suggested Testing Steps
Edit breakpoints, create breakpoints. Make sure the text boxes are not blank.
