### PR TITLE
GS: Only reload Auto MIPs on TEX base change

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -157,6 +157,7 @@ protected:
 	float m_q;
 	GSVector4i m_scissor;
 	GSVector4i m_ofxy;
+	bool tex_flushed;
 
 	struct
 	{

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -271,6 +271,9 @@
     <Filter Include="System\Ps2\GS\Window">
       <UniqueIdentifier>{eaa22029-6839-4c09-93e1-faea8d8c0d7c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="System\Ps2\GS\GIF">
+      <UniqueIdentifier>{78f5077b-255e-435e-9a51-352171dfaee8}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="Utilities\folderdesc.txt">
@@ -663,13 +666,13 @@
       <Filter>System\Ps2\IPU\mpeg2lib</Filter>
     </ClCompile>
     <ClCompile Include="GS.cpp">
-      <Filter>System\Ps2\GS</Filter>
+      <Filter>System\Ps2\GS\GIF</Filter>
     </ClCompile>
     <ClCompile Include="GSState.cpp">
-      <Filter>System\Ps2\GS</Filter>
+      <Filter>System\Ps2\GS\GIF</Filter>
     </ClCompile>
     <ClCompile Include="MTGS.cpp">
-      <Filter>System\Ps2\GS</Filter>
+      <Filter>System\Ps2\GS\GIF</Filter>
     </ClCompile>
     <ClCompile Include="DebugTools\DisR3000A.cpp">
       <Filter>System\Ps2\Debug</Filter>
@@ -888,7 +891,7 @@
       <Filter>AppHost\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Gif_Unit.cpp">
-      <Filter>System\Ps2\GS</Filter>
+      <Filter>System\Ps2\GS\GIF</Filter>
     </ClCompile>
     <ClCompile Include="Gif_Logger.cpp">
       <Filter>System\Ps2\GS</Filter>
@@ -2008,7 +2011,7 @@
       <Filter>AppHost\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Gif_Unit.h">
-      <Filter>System\Ps2\GS</Filter>
+      <Filter>System\Ps2\GS\GIF</Filter>
     </ClInclude>
     <ClInclude Include="x86\microVU_Profiler.h">
       <Filter>System\Ps2\EmotionEngine\VU\Dynarec\microVU</Filter>
@@ -2569,7 +2572,7 @@
       <Filter>System\Ps2\GS</Filter>
     </ClInclude>
     <ClInclude Include="GS.h">
-      <Filter>System\Ps2</Filter>
+      <Filter>System\Ps2\GIF</Filter>
     </ClInclude>
     <ClInclude Include="GS\Renderers\DX11\GSDevice11.h">
       <Filter>System\Ps2\GS\Renderers\Direct3D</Filter>


### PR DESCRIPTION
### Description of Changes
Only update the MIP addresses automatically if the texture address changes.

### Rationale behind Changes
Reloading every time TEX0 written when MTBA was enabled was causing false MIP level memory addresses to be set in Parappa the Rapper 2, this was due to a misunderstanding of how the MTBA bit worked.

### Suggested Testing Steps
Test games in software mode with mipmapping enabled, check the console for "MTBA reloading" messages and make sure no graphics are broken.

Fixes the roof/fog for Parappa The Rapper 2, the disco type room.
Fixes background texture flicker in Ape Escape 3

Parappa The Rapper 2:  (Look at the ceiling)

Before:

![image](https://user-images.githubusercontent.com/6278726/141593893-0d879b51-0dc2-4e6a-ab44-a1a0d779c3bc.png)

After:

![image](https://user-images.githubusercontent.com/6278726/141593906-7302b879-f70a-4c1e-af9b-f7f39b8fb6b3.png)


Ape Escape 3: (The field behind the fence is the most obvious place, and the bushes to the right just behind that)

Before:

![image](https://user-images.githubusercontent.com/6278726/141594081-97d79d30-7c37-431d-9510-3129ebbb9070.png)

After:

![image](https://user-images.githubusercontent.com/6278726/141594102-889db98f-b37f-4da2-bd88-33713ef7f010.png)
