### PR TITLE
Debugger: Allow access to all of 0xBXXXXXXX

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -635,10 +635,7 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 		case 0xA:
 		case 0xB:
 			// [ 8000_0000 - BFFF_FFFF ] kernel
-			// We only need to access the EE kernel (which is 1 MB large)
-			if (lopart < 0x100000)
-				return true;
-			break;
+			return true;
 		case 0xF:
 			// [ 8000_0000 - BFFF_FFFF ] IOP or kernel stack
 			if (lopart >= 0xfff8000)


### PR DESCRIPTION
### Description of Changes
Show more of the kernel in the debugger memory view and disassembly views

### Rationale behind Changes
Give @Nobbs66 their sanity back
What is the point of blocking this memory anyways?

### Suggested Testing Steps
Try to access previously 'invalid' addresses such as ` 0xBFC000000`
