### PR TITLE
VSProps: Set MultiProcessorCompilation in CodeGen props

### DIFF
--- a/common/vsprops/CodeGen_Debug.props
+++ b/common/vsprops/CodeGen_Debug.props
@@ -10,6 +10,7 @@
       <PreprocessorDefinitions>PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/common/vsprops/CodeGen_Devel.props
+++ b/common/vsprops/CodeGen_Devel.props
@@ -14,6 +14,7 @@
       <PreprocessorDefinitions>PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/common/vsprops/CodeGen_Release.props
+++ b/common/vsprops/CodeGen_Release.props
@@ -19,6 +19,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <OptimizeReferences>true</OptimizeReferences>

--- a/common/vsprops/IncrementalLinking.props
+++ b/common/vsprops/IncrementalLinking.props
@@ -8,7 +8,6 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <StringPooling>true</StringPooling>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>


### PR DESCRIPTION
### Description of Changes

Enables /MP for all build types, on all projects. Previously, Release builds of non-core projects were built serially.

### Rationale behind Changes

Faster build times. But probably not too much difference for CI.

### Suggested Testing Steps

Make sure CI doesn't get upset.
