### PR TITLE
GS SW: Handle flat prims without float conversion

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSNewCodeGenerator.h
+++ b/pcsx2/GS/Renderers/SW/GSNewCodeGenerator.h
@@ -407,6 +407,7 @@ public:
 	AFORWARD(3, pinsrd,    ARGS_XOI)
 	AFORWARD(2, pmaxsw,    ARGS_XO)
 	AFORWARD(2, pminsd,    ARGS_XO)
+	AFORWARD(2, pminud,    ARGS_XO)
 	AFORWARD(2, pminsw,    ARGS_XO)
 	SFORWARD(2, pmovsxbd,  ARGS_XO)
 	SFORWARD(2, pmovmskb,  const Reg32e&, const Xmm&)

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -313,7 +313,7 @@ void GSRendererSW::ConvertVertexBuffer(GSVertexSW* RESTRICT dst, const GSVertex*
 			}
 		}
 
-		if (primclass == GS_SPRITE_CLASS)
+		if (primclass == GS_SPRITE_CLASS || m_vt.m_eq.z)
 		{
 			xyzuvf = xyzuvf.min_u32(z_max);
 			t = t.insert32<1, 3>(GSVector4::cast(xyzuvf));
@@ -1341,6 +1341,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 		gd.sel.zpsm = GSLocalMemory::m_psm[context->ZBUF.PSM].fmt;
 		gd.sel.ztst = ztest ? context->TEST.ZTST : (int)ZTST_ALWAYS;
+		gd.sel.zequal = !!m_vt.m_eq.z;
 		gd.sel.zoverflow = (u32)GSVector4i(m_vt.m_max.p).z == 0x80000000U;
 		gd.sel.zclamp = (u32)GSVector4i(m_vt.m_max.p).z > z_max;
 	}

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -64,7 +64,7 @@ union GSScanlineSelector
 		u32 mmin   : 2; // 54
 		u32 notest : 1; // 55 (no ztest, no atest, no date, no scissor test, and horizontally aligned to 4 pixels)
 		// TODO: 1D texture flag? could save 2 texture reads and 4 lerps with bilinear, and also the texture coordinate clamp/wrap code in one direction
-
+		u32 zequal : 1; // 56
 		u32 breakpoint : 1; // Insert a trap to stop the program, helpful to stop debugger on a program
 	};
 


### PR DESCRIPTION
### Description of Changes
Improve handling of large values for Z on the SW renderer by using integer Z for flat triangles.

### Rationale behind Changes
Large floats are not handled very well in the software renderer due to the range being limited by signed integers but also some precision is lost by being single floats which only have a precision of 24bits.  This PR makes it so flat triangles are treated like sprites and the Z values are passed as integer so no precision is lost, which fixes games which use flat triangles to draw UI/2D screens.

### Suggested Testing Steps
Test games in software mode, including 007: Agent Under Fire, make sure no graphics are missing or more broken than previous.

Fixes #3662
Fixes #4164
Also probably fixes issue with Raw Danger requiring integers on flat prims as mentioned in #1562 Fixes #2980
Also hugely improves the 2D UI in Hana to Taiyou to Ame to