### PR TITLE
GS-gui: Change blending option from None to Minimum.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1161,14 +1161,14 @@ void GSApp::Init()
 		GSSetting(CRCHackLevel::Aggressive, "Aggressive", ""),
 	};
 
-	m_gs_acc_blend_level.push_back(GSSetting(0, "None", "Fastest"));
+	m_gs_acc_blend_level.push_back(GSSetting(0, "Minimum", "Fastest"));
 	m_gs_acc_blend_level.push_back(GSSetting(1, "Basic", "Recommended"));
 	m_gs_acc_blend_level.push_back(GSSetting(2, "Medium", ""));
 	m_gs_acc_blend_level.push_back(GSSetting(3, "High", ""));
 	m_gs_acc_blend_level.push_back(GSSetting(4, "Full", "Very Slow"));
 	m_gs_acc_blend_level.push_back(GSSetting(5, "Ultra", "Ultra Slow"));
 
-	m_gs_acc_blend_level_d3d11.push_back(GSSetting(0, "None", "Fastest"));
+	m_gs_acc_blend_level_d3d11.push_back(GSSetting(0, "Minimum", "Fastest"));
 	m_gs_acc_blend_level_d3d11.push_back(GSSetting(1, "Basic", "Recommended"));
 	m_gs_acc_blend_level_d3d11.push_back(GSSetting(2, "Medium", "Debug"));
 	m_gs_acc_blend_level_d3d11.push_back(GSSetting(3, "High", "Debug"));

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -97,13 +97,13 @@ const char* dialog_message(int ID, bool* updateText)
 				"Note: Direct3D 11 is less accurate.");
 		case IDC_ACCURATE_BLEND_UNIT:
 			return cvtString("Control the accuracy level of the GS blending unit emulation.\n\n"
-				"None:\nFast but introduces various rendering issues.\n"
+				"Minimum:\nFast but introduces various rendering issues.\n"
 				"It is intended for slow computer.\n\n"
 				"Basic:\nEmulate correctly most of the effects with a limited speed penalty.\n"
 				"This is the recommended setting.\n\n"
 				"Medium:\nExtend it to all sprites. Performance impact remains reasonable in 3D game.\n\n"
 				"High:\nExtend it to destination alpha blending and color wrapping (helps shadow and fog effects).\n"
-				"A good GPU is required.\n\n"
+				"A good CPU is required.\n\n"
 				"Full:\nExcept few cases, the blending unit will be fully emulated by the shader. It is ultra slow!\n"
 				"It is intended for debug.\n\n"
 				"Ultra:\nThe blending unit will be completely emulated by the shader. It is ultra slow!\n"
@@ -204,7 +204,7 @@ const char* dialog_message(int ID, bool* updateText)
 #ifdef _WIN32
 		case IDC_ACCURATE_BLEND_UNIT_D3D11:
 			return L"Control the accuracy level of the GS blending unit emulation.\n\n"
-				"None:\nFast but introduces various rendering issues.\n"
+				"Minimum:\nFast but introduces various rendering issues.\n"
 				"It is intended for slow computer.\n\n"
 				"Basic:\nEmulate correctly some of the effects with a limited speed penalty.\n"
 				"This is the recommended setting.\n\n"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Change blending option from None to Minimum, update tooltip.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accurate representation. None doesn't actually fully disable sw blending, so the option is a bit inaccurate, rename it to Minimum instead.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
