### PR TITLE
SPU: Fix videos in Stolen

### DIFF
--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -283,7 +283,7 @@ static __forceinline void GetNextDataDummy(V_Core& thiscore, uint voiceidx)
 		vc.SCurrent = 0;
 	}
 
-	vc.SP -= 4096 * (4 - (vc.SCurrent & 3));
+	vc.SP -= 0x1000 * (4 - (vc.SCurrent & 3));
 	vc.SCurrent += 4 - (vc.SCurrent & 3);
 }
 
@@ -456,10 +456,10 @@ static __forceinline s32 GetVoiceValues(V_Core& thiscore, uint voiceidx)
 		}
 		vc.PV2 = vc.PV1;
 		vc.PV1 = GetNextDataBuffered(thiscore, voiceidx);
-		vc.SP -= 4096;
+		vc.SP -= 0x1000;
 	}
 
-	const s32 mu = vc.SP + 4096;
+	const s32 mu = vc.SP + 0x1000;
 
 	switch (InterpType)
 	{

--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -629,7 +629,7 @@ static __forceinline StereoOut32 MixVoice(uint coreidx, uint voiceidx)
 	}
 	else
 	{
-		while (vc.SP > 0)
+		while (vc.SP >= 0)
 			GetNextDataDummy(thiscore, voiceidx); // Dummy is enough
 	}
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -373,7 +373,12 @@ __forceinline bool StartQueuedVoice(uint coreidx, uint voiceidx)
 	vc.ADSR.Phase = 1;
 	vc.SCurrent = 28;
 	vc.LoopMode = 0;
-	vc.SP = 0;
+
+	// When SP >= 0 the next sample will be grabbed, we don't want this to happen
+	// instantly because in the case of pitch being 0 we want to delay getting
+	// the next block header.
+	vc.SP = -1;
+
 	vc.LoopFlags = 0;
 	vc.NextA = vc.StartA | 1;
 	vc.Prev1 = 0;


### PR DESCRIPTION
Stolen sets voice pitch to 0 to pause the voice, toggles key on, and only then DMA's the sample data to it. This means that grabbing the next sample must be delayed until the voice is unpaused by setting pitch to a non-zero value.

When i changed the comparisons for SP in order to fix the interpolation the behavior changed and it started grabbing the new block instantly on key on.

This restores the old behavior by initializing SP to -1 on key on.