### PR TITLE
GS/OpenGL: Use shader+draw for CopyRectConv

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -82,12 +82,6 @@ namespace Emulate_DSA
 		glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, format, type, pixels);
 	}
 
-	void APIENTRY CopyTextureSubImage(GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height)
-	{
-		BindTextureUnit(7, texture);
-		glCopyTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, x, y, width, height);
-	}
-
 	void APIENTRY GetTexureImage(GLuint texture, GLint level, GLenum format, GLenum type, GLsizei bufSize, void* pixels)
 	{
 		BindTextureUnit(7, texture);
@@ -126,7 +120,6 @@ namespace Emulate_DSA
 		glCreateTextures = CreateTexture;
 		glTextureStorage2D = TextureStorage;
 		glTextureSubImage2D = TextureSubImage;
-		glCopyTextureSubImage2D = CopyTextureSubImage;
 		glGetTextureImage = GetTexureImage;
 		glTextureParameteri = TextureParameteri;
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -575,6 +575,8 @@ private:
 
 	u16 ConvertBlendEnum(u16 generic) final;
 
+	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
+
 public:
 	GSShaderOGL* m_shader;
 
@@ -606,7 +608,10 @@ public:
 	GSTexture* CopyOffscreen(GSTexture* src, const GSVector4& sRect, int w, int h, int format = 0, int ps_shader = 0) final;
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r) final;
-	void CopyRectConv(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, bool at_origin);
+
+	// BlitRect *does* mess with GL state, be sure to re-bind.
+	void BlitRect(GSTexture* sTex, const GSVector4i& r, const GSVector2i& dsize, bool at_origin, bool linear);
+
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, int shader = 0, bool linear = true) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, GLuint ps, bool linear = true);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) final;


### PR DESCRIPTION
### Description of Changes

Apparently using glCopyTextureSubImage2D was causing memory leaks in Evolution Snowboarding on NVIDIA and Intel drivers. For some reason it's fine for me on AMD...

Fixes #5017 

### Rationale behind Changes

Leaks bad

### Suggested Testing Steps

Make sure games which need colclip clamping off aren't affected (e.g. FFX-2 opening FMV).
