### PR TITLE
Debugger: Make memory dialog transparent

### DIFF
--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -121,6 +121,7 @@ CpuTabPage::CpuTabPage(wxWindow* parent, DebugInterface* _cpu)
 	memorySearch->SetMaxSize(wxSize(360, -1));
 	memorySizer->Add(memorySearch, 1, wxEXPAND);
 	memoryPanel->SetSizer(memorySizer);
+	memoryPanel->SetBackgroundColour(wxTransparentColor);
 
 	// create bottom section
 	bottomTabs->AddPage(memoryPanel, L"Memory");


### PR DESCRIPTION
Was supposed to do this in my initial memory search pr but ended up removing while fighting with git accidentally.

### Description of Changes
Makes the background of the memory area transparent

### Rationale behind Changes
![image](https://user-images.githubusercontent.com/29295048/142484152-12ecb35c-102a-476b-b8f3-4adeb770cf78.png)
Checkboxes / Labels are not the system colour in the memory search.

### Suggested Testing Steps
See if the check boxes are the system background colour for you.
