### PR TITLE
3rd Party: Update rogue file to correct BSD license

### DIFF
--- a/3rdparty/libsamplerate/config.h
+++ b/3rdparty/libsamplerate/config.h
@@ -1,19 +1,9 @@
 /*
-** Copyright (C) 2002-2011 Erik de Castro Lopo <erikd@mega-nerd.com>
+** Copyright (c) 2002-2016, Erik de Castro Lopo <erikd@mega-nerd.com>
+** All rights reserved.
 **
-** This program is free software; you can redistribute it and/or modify
-** it under the terms of the GNU General Public License as published by
-** the Free Software Foundation; either version 2 of the License, or
-** (at your option) any later version.
-**
-** This program is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-** GNU General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with this program; if not, write to the Free Software
-** Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+** This code is released under 2-clause BSD license. Please see the
+** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
 /*
@@ -37,6 +27,7 @@
 ** src/src_sinc.c this slows down compile times considerably. The
 ** following #pragma disables the warning.
 */
+
 
 #pragma warning(disable: 4305)
 


### PR DESCRIPTION
### Description of Changes
Correct the license header on the config.h file in libsamplerate

### Rationale behind Changes
Got missed in an update as they switched to auto generation of the config.h file, but the license was switched prior to us last updating the library. See this commit: https://github.com/libsndfile/libsamplerate/commit/819c6a8d680d7385ce54f5e0d4ff62266d349d05#diff-dcf9d0451a6397210424fc9699e209255660a4d3b3072c2f1b35048df8df4092

### Suggested Testing Steps
Look at the file, make sure the license says BSD.
