### PR TITLE
GitHub: Update and add new issue template for non-game related bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -59,8 +59,7 @@ body:
     attributes:
       label: Operating System
       options:
-      - Windows 11 (32bit)
-      - Windows 11 (64bit)
+      - Windows 11
       - Windows 10 (32bit)
       - Windows 10 (64bit)
       - Windows 8.1 (32bit)

--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -1,0 +1,82 @@
+# Docs - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Application Bug Report
+description: Found a problem with the application itself (ie. bad file path handling, UX issue)? Help us improve it.
+title: "[BUG]: "
+labels: [Bug]
+# assignees:
+#   - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Important: Read First
+
+        Please do not make support requests on GitHub. Our issue tracker is for tracking bugs and feature requests only
+        If you need help configuring the emulator please make a request on our forums or contact us on discord
+
+        If you are unsure, start with [discord](https://discord.com/invite/TCz3t9k) or the [forums](https://forums.pcsx2.net/index.php)
+
+        Please make an effort to make sure your issue isn't already reported
+
+        ### Please Avoid Issues Pertaining to the Following:
+        - We are **not** accepting bug reports for **PSX mode** at this time
+          - If you are interested in helping contribute to PSX mode please do so on the forums. Otherwise our recommendation is that you use a [proper PSX emulator](https://emulation.gametechwiki.com/index.php/PlayStation_emulators)
+        - We do **not** accept issues relating to **upscaling** at this time
+          - We are aware of the various problems with upscaling. The issue spans many games and having hundreds of issues for the same fundamental issues isn't particularly helpful. There are several workarounds for graphical problems that come as a result of upscaling
+          - Please try your game at native resolution before creating an issue
+          - If your bug is the result of upscaling please use the forums or discord for assistance with various upscaling workarounds. Additionally, the unofficial PCSX2 [Wiki](https://wiki.pcsx2.net/Main_Page) often lists various fixes for upscaling issues
+  - type: textarea
+    id: desc
+    attributes:
+      label: Describe the Bug
+      description: "A clear and concise description of what the bug is"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction Steps
+      description: "Steps to reproduce the behavior"
+    validations:
+      required: true
+  - type: textarea
+    id: expect
+    attributes:
+      label: Expected Behavior
+      description: "A clear and concise description of what you expected to happen"
+    validations:
+      required: false
+  - type: input
+    id: rev
+    attributes:
+      label: PCSX2 Revision
+      description: "Please ensure you are on the latest version before making an issue"
+      placeholder: "Example: v1.7.1337"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+      - Windows 11 (32bit)
+      - Windows 11 (64bit)
+      - Windows 10 (32bit)
+      - Windows 10 (64bit)
+      - Windows 8.1 (32bit)
+      - Windows 8.1 (64bit)
+      - Linux (32bit) - Specify Distro Below
+      - Linux (64bit) - Specify Distro Below
+      - macOS (Monteray)
+      - macOS (BigSur)
+      - macOS (Catalina)
+      - macOS (Mojave)
+    validations:
+      required: true
+  - type: input
+    id: os-distro
+    attributes:
+      label: If Linux - Specify Distro
+      placeholder: "Example: Arch"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -1,6 +1,6 @@
 # Docs - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
-name: Bug Report
-description: Found a problem? Help us improve.
+name: Emulation Bug Report
+description: Problem in a game (ie. graphical artifacts, crashes)? Help us improve it.
 title: "[BUG]: "
 labels: [Bug]
 # assignees:
@@ -69,7 +69,7 @@ body:
     attributes:
       label: PCSX2 Revision
       description: "We only accept bug reports for the latest dev version. Please try upgrading before making an issue."
-      placeholder: "Example: dev-525"
+      placeholder: "Example: v1.7.1337"
     validations:
       required: true
   - type: dropdown
@@ -77,6 +77,8 @@ body:
     attributes:
       label: Operating System
       options:
+      - Windows 11 (32bit)
+      - Windows 11 (64bit)
       - Windows 10 (32bit)
       - Windows 10 (64bit)
       - Windows 8.1 (32bit)

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -77,8 +77,7 @@ body:
     attributes:
       label: Operating System
       options:
-      - Windows 11 (32bit)
-      - Windows 11 (64bit)
+      - Windows 11
       - Windows 10 (32bit)
       - Windows 10 (64bit)
       - Windows 8.1 (32bit)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

- Added Windows 11 to the issue templates
- Changed version example to match what we have going on now
- Made a new template for when the bug is unrelated to emulating a game.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

I noticed a few things when making an issue, also that if you aren't making a bug report pertaining to a game, a lot of the fields are irrelevant, so a stripped down template would be ideal.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

See my fork - https://github.com/xTVaser/pcsx2-rr/issues/new/choose
