### PR TITLE
Debugger: Format search hits with proper specifier

### DIFF
--- a/pcsx2/gui/Debugger/CtrlMemSearch.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemSearch.cpp
@@ -298,7 +298,7 @@ void CtrlMemSearch::onSearchFinished(wxCommandEvent& evt)
 
 	m_searchResultsMutex.lock();
 
-	lblSearchHits->SetLabelText(wxString::Format(L"Hits: %d", m_searchResults.size()));
+	lblSearchHits->SetLabelText(wxString::Format(L"Hits: %zu", m_searchResults.size()));
 	
 	// Enable the buttons only if we have results
 	// -1 indicates we haven't jumped to a result yet


### PR DESCRIPTION
### Description of Changes
Print size_t with %zu instead of %d

### Rationale behind Changes
There was a ghost assert complaining about the format not matching the type (Can't reproduce anymore)

### Suggested Testing Steps
Make sure the hit counter still works.
