### PR TITLE
Add crc hack for project metafalica (Again)

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -25,6 +25,7 @@ const CRC::Game CRC::m_games[] =
 	{0xF95F37EE, ArTonelico2, US, 0},
 	{0x68CE6801, ArTonelico2, JP, 0},
 	{0xCE2C1DBF, ArTonelico2, EU, 0},
+	{0xC38067F4, ArTonelico2, NoRegion, 0}, // project metafalica 1.0
 	{0x2113EA2E, MetalSlug6, JP, 0},
 	{0x42E05BAF, TomoyoAfter, JP, PointListPalette},
 	{0x7800DC84, Clannad, JP, PointListPalette},


### PR DESCRIPTION
### Description of Changes
Adds a crc for Project Metafalica which is a Ar Tonelico II relocalization. I am unsure why it was removed, but its still needed.

### Rationale behind Changes
Fixes https://github.com/PCSX2/pcsx2/issues/1762
See https://github.com/PCSX2/pcsx2/pull/1872

### Suggested Testing Steps
* Test that the world map is not broken in Project Metafalica (I did locally).
