### PR TITLE
Gs-hw: Adjust/minor optimization on sw blend shader a bit

### DIFF
--- a/pcsx2/GS/res/glsl/tfx_fs.glsl
+++ b/pcsx2/GS/res/glsl/tfx_fs.glsl
@@ -627,7 +627,6 @@ void ps_blend(inout vec4 Color, float As)
 {
 #if SW_BLEND
     vec4 RT = trunc(texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0) * 255.0f + 0.1f);
-    vec4 Color_pabe = Color;
 
 #if PS_DFMT == FMT_24
     float Ad = 1.0f;
@@ -681,7 +680,7 @@ void ps_blend(inout vec4 Color, float As)
 
     // PABE
 #if PS_PABE
-    Color.rgb = (Color_pabe.a >= 128.0f) ? Color.rgb : Color_pabe.rgb;
+    Color.rgb = (As >= 1.0f) ? Color.rgb : Cs;
 #endif
 
     // Dithering

--- a/pcsx2/GS/res/tfx.fx
+++ b/pcsx2/GS/res/tfx.fx
@@ -677,33 +677,30 @@ void ps_blend(inout float4 Color, float As, float2 pos_xy)
 
 		float3 Cd = RT.rgb;
 		float3 Cs = Color.rgb;
-		float3 Cv;
 
 		float3 A = (PS_BLEND_A == 0) ? Cs : ((PS_BLEND_A == 1) ? Cd : (float3)0.0f);
 		float3 B = (PS_BLEND_B == 0) ? Cs : ((PS_BLEND_B == 1) ? Cd : (float3)0.0f);
 		float3 C = (PS_BLEND_C == 0) ? As : ((PS_BLEND_C == 1) ? Ad : Af);
 		float3 D = (PS_BLEND_D == 0) ? Cs : ((PS_BLEND_D == 1) ? Cd : (float3)0.0f);
 
-		Cv = (PS_BLEND_A == PS_BLEND_B) ? D : trunc(((A - B) * C) + D);
+		Color.rgb = (PS_BLEND_A == PS_BLEND_B) ? D : trunc(((A - B) * C) + D);
 
 		// PABE
 		if (PS_PABE)
-			Cv = (Color.a >= 128.0f) ? Cv : Color.rgb;
+			Color.rgb = (As >= 1.0f) ? Color.rgb : Cs;
 
 		// Dithering
-		ps_dither(Cv, pos_xy);
+		ps_dither(Color.rgb, pos_xy);
 
 		// Standard Clamp
 		if (PS_COLCLIP == 0 && PS_HDR == 0)
-			Cv = clamp(Cv, (float3)0.0f, (float3)255.0f);
+			Color.rgb = clamp(Color.rgb, (float3)0.0f, (float3)255.0f);
 
 		// In 16 bits format, only 5 bits of color are used. It impacts shadows computation of Castlevania
 		if (PS_DFMT == FMT_16)
-			Cv = (float3)((int3)Cv & (int3)0xF8);
+			Color.rgb = (float3)((int3)Color.rgb & (int3)0xF8);
 		else if (PS_COLCLIP == 1 && PS_HDR == 0)
-			Cv = (float3)((int3)Cv & (int3)0xFF);
-
-		Color.rgb = Cv;
+			Color.rgb = (float3)((int3)Color.rgb & (int3)0xFF);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
ogl:
Get rid of Color_pabe vector, makes more sense to use As and Cs in pabe code.

d3d11:
Use As and Cs in pabe code, makes more sense.
Get rid of Cv vector, use Color parameter for operations instead like on gl.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Minor optimization.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure hw renderer blending still works on both renderers.