### PR TITLE
CDVD: Adjust DMA timing based on PS1 timings.

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1243,7 +1243,7 @@ __fi void cdvdReadInterrupt()
 				cdvd.Status = CDVD_STATUS_PAUSE;
 
 			cdvd.nCommand = 0;
-			//DevCon.Warning("Scheduling interrupt in %d cycles", cdvd.ReadTime - (cdvd.BlockSize / 4));
+			//DevCon.Warning("Scheduling interrupt in %d cycles", cdvd.ReadTime - ((cdvd.BlockSize / 4) * 12));
 			// Timing issues on command end
 			// Star Ocean (1.1 Japan) expects the DMA to end and interrupt at least 128 or more cycles before the CDVD command ends.
 			// However the time required seems to increase slowly, so delaying the end of the command is not the solution.
@@ -1254,7 +1254,7 @@ __fi void cdvdReadInterrupt()
 	}
 	else
 	{
-		CDVDREAD_INT((cdvd.BlockSize / 4));
+		CDVDREAD_INT((cdvd.BlockSize / 4) * 12);
 		return;
 	}
 
@@ -1262,9 +1262,9 @@ __fi void cdvdReadInterrupt()
 	cdvd.Reading = 1;
 	cdvd.RErr = DoCDVDreadTrack(cdvd.Sector, cdvd.ReadMode);
 	if (cdvd.nextSectorsBuffered)
-		CDVDREAD_INT((cdvd.BlockSize / 4));
+		CDVDREAD_INT((cdvd.BlockSize / 4) * 12);
 	else
-		CDVDREAD_INT(cdvd.ReadTime + (cdvd.BlockSize / 4));
+		CDVDREAD_INT(cdvd.ReadTime + ((cdvd.BlockSize / 4) * 12));
 }
 
 // Returns the number of IOP cycles until the event completes.
@@ -1338,16 +1338,16 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode)
 				if (psxRegs.interrupt & (1 << IopEvt_CdvdSectorReady))
 				{
 					//DevCon.Warning("coming back from ready sector early reducing %d cycles by %d cycles", seektime, psxRegs.cycle - psxRegs.sCycle[IopEvt_CdvdSectorReady]);
-					seektime = (psxRegs.cycle - psxRegs.sCycle[IopEvt_CdvdSectorReady]) + (cdvd.BlockSize / 4);
+					seektime = (psxRegs.cycle - psxRegs.sCycle[IopEvt_CdvdSectorReady]) + ((cdvd.BlockSize / 4) * 12);
 				}
 				else
 				{
 					CDVDSECTORREADY_INT(cdvd.ReadTime);
-					seektime = cdvd.ReadTime + (cdvd.BlockSize / 4);
+					seektime = cdvd.ReadTime + ((cdvd.BlockSize / 4) * 12);
 				}
 			}
 			else
-				seektime = (cdvd.BlockSize / 4);
+				seektime = (cdvd.BlockSize / 4) * 12;
 		}
 		else
 		{
@@ -1363,7 +1363,7 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode)
 		//DevCon.Warning("%s rotational latency at sector %d is %d cycles", (cdvd.SpindlCtrl & CDVD_SPINDLE_CAV) ? "CAV" : "CLV", cdvd.SeekToSector, rotationalLatency);
 		seektime += rotationalLatency + cdvd.ReadTime;
 		CDVDSECTORREADY_INT(seektime);
-		seektime += (cdvd.BlockSize / 4);
+		seektime += (cdvd.BlockSize / 4) * 12;
 	}
 	return seektime;
 }

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -1076,7 +1076,7 @@ void psxDma3(u32 madr, u32 bcr, u32 chcr)
 		case 0x41000200:
 			if (cdvd.WaitingDMA)
 			{
-				PSX_INT(IopEvt_CdvdRead, cdvd.BlockSize / 4); //Data should be already buffered so simulate DMA time
+				PSX_INT(IopEvt_CdvdRead, (cdvd.BlockSize / 4) * 12); //Data should be already buffered so simulate DMA time
 			}
 			//SysPrintf("unhandled cdrom dma3: madr: %x, bcr: %x, chcr %x\n", madr, bcr, chcr);
 			return;


### PR DESCRIPTION
### Description of Changes
Adjusts the CDVD DMA (3) timing to that based on PS1 tested numbers.

### Rationale behind Changes
Bus width is 16bit on the PS2 between the DVD drive and the DSP, it is 8bit on PS1, so serves to reason the DMA would be twice the speed. (PS1 is 24 cycle per word)

### Suggested Testing Steps
test games, make sure they still work and don't die horribly.

Fixes Spongebob Lights, Camera, Pants!