### PR TITLE
actions: Only announce `pre-release` releases

### DIFF
--- a/.github/workflows/scripts/releases/announce-release/index.js
+++ b/.github/workflows/scripts/releases/announce-release/index.js
@@ -1,7 +1,14 @@
 import { MessageEmbed, WebhookClient } from "discord.js";
 import * as github from '@actions/github';
 
-const assets = github.context.payload.release.assets;
+const releaseInfo = github.context.payload.release;
+
+if (!releaseInfo.prerelease) {
+  console.log("Not announcing - release was not a pre-release (aka a Nightly)");
+  process.exit(0);
+}
+
+const assets = releaseInfo.assets;
 let windowsAssetLinks = "";
 let linuxAssetLinks = "";
 
@@ -34,10 +41,10 @@ const embed = new MessageEmbed()
   .setColor('#FF8000')
   .setTitle('New PCSX2 Nightly Build Available!')
   .addFields(
-    { name: 'Version', value: github.context.payload.release.tag_name, inline: true },
-    { name: 'Release Link', value: `[Github Release](${github.context.payload.release.html_url})`, inline: true },
+    { name: 'Version', value: releaseInfo.tag_name, inline: true },
+    { name: 'Release Link', value: `[Github Release](${releaseInfo.html_url})`, inline: true },
     { name: 'Installation Steps', value: '[See Here](https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide)', inline: true },
-    { name: 'Included Changes', value: github.context.payload.release.body, inline: false }
+    { name: 'Included Changes', value: releaseInfo.body, inline: false }
   );
 
 if (windowsAssetLinks != "") {


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

If the release is a stable release -- don't announce it to the discord.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

I want to flesh out some of the old tags in the repo into releases with artifacts, but I don't want them being announced and labelled as nightlies.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

A little bit inconvenient to test this unfortunately.  Sometime soon I should pull these out into individual actions that have unit-tests.  I'd say:
- Look at the code, i just did some basic cleanup with a new variable
- Ensure `prerelease` is a valid key in the release payload - https://docs.github.com/en/rest/reference/repos#get-a-release
