### PR TITLE
GS-hw: Improve how we handle AA1 draws

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -441,14 +441,13 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 void GSRendererDX11::EmulateBlending()
 {
 	// Partial port of OGL SW blending. Currently only works for accumulation and non recursive blend.
-	const GIFRegALPHA& ALPHA = m_context->ALPHA;
-	bool sw_blending = false;
 
 	// No blending so early exit
 	if (!(PRIM->ABE || m_env.PABE.PABE))
 		return;
 
 	m_om_bsel.abe = 1;
+	const GIFRegALPHA& ALPHA = m_context->ALPHA;
 	m_om_bsel.blend_index = u8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
 	const int blend_flag = m_dev->GetBlendFlags(m_om_bsel.blend_index);
 
@@ -458,6 +457,7 @@ void GSRendererDX11::EmulateBlending()
 	// Blending doesn't require sampling of the rt
 	const bool blend_non_recursive = !!(blend_flag & BLEND_NO_REC);
 
+	bool sw_blending = false;
 	switch (m_sw_blending)
 	{
 		case ACC_BLEND_HIGH_D3D11:

--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -108,7 +108,8 @@ void GSRendererDX11::EmulateZbuffer()
 	if (m_context->TEST.ZTE)
 	{
 		m_om_dssel.ztst = m_context->TEST.ZTST;
-		m_om_dssel.zwe = !m_context->ZBUF.ZMSK;
+		// AA1: Z is not written on lines since coverage is always less than 0x80.
+		m_om_dssel.zwe = (m_context->ZBUF.ZMSK || (PRIM->AA1 && m_vt.m_primclass == GS_LINE_CLASS)) ? 0 : 1;
 	}
 	else
 	{

--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -442,8 +442,12 @@ void GSRendererDX11::EmulateBlending()
 {
 	// Partial port of OGL SW blending. Currently only works for accumulation and non recursive blend.
 
+	// AA1: Don't enable blending on AA1, not yet implemented on hardware mode,
+	// it requires coverage sample so it's safer to turn it off instead.
+	const bool aa1 = PRIM->AA1 && (m_vt.m_primclass == GS_LINE_CLASS);
+
 	// No blending so early exit
-	if (!(PRIM->ABE || m_env.PABE.PABE))
+	if (aa1 || !(PRIM->ABE || m_env.PABE.PABE))
 		return;
 
 	m_om_bsel.abe = 1;

--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -444,7 +444,7 @@ void GSRendererDX11::EmulateBlending()
 	bool sw_blending = false;
 
 	// No blending so early exit
-	if (!(PRIM->ABE || m_env.PABE.PABE || (PRIM->AA1 && m_vt.m_primclass == GS_LINE_CLASS)))
+	if (!(PRIM->ABE || m_env.PABE.PABE))
 		return;
 
 	m_om_bsel.abe = 1;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -463,8 +463,6 @@ void GSRendererOGL::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::
 void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 {
 	GSDeviceOGL* dev = (GSDeviceOGL*)m_dev;
-	const GIFRegALPHA& ALPHA = m_context->ALPHA;
-	bool sw_blending = false;
 
 	// No blending so early exit
 	if (!(PRIM->ABE || m_env.PABE.PABE))
@@ -474,6 +472,7 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 	}
 
 	// Compute the blending equation to detect special case
+	const GIFRegALPHA& ALPHA = m_context->ALPHA;
 	const u8 blend_index = u8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
 	const int blend_flag = m_dev->GetBlendFlags(blend_index);
 
@@ -490,6 +489,7 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 
 	// Warning no break on purpose
 	// Note: the [[fallthrough]] attribute tell compilers not to complain about not having breaks.
+	bool sw_blending = false;
 	switch (m_sw_blending)
 	{
 		case ACC_BLEND_ULTRA:

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -464,8 +464,12 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 {
 	GSDeviceOGL* dev = (GSDeviceOGL*)m_dev;
 
+	// AA1: Don't enable blending on AA1, not yet implemented on hardware mode,
+	// it requires coverage sample so it's safer to turn it off instead.
+	const bool aa1 = PRIM->AA1 && (m_vt.m_primclass == GS_LINE_CLASS);
+
 	// No blending so early exit
-	if (!(PRIM->ABE || m_env.PABE.PABE))
+	if (aa1 || !(PRIM->ABE || m_env.PABE.PABE))
 	{
 		dev->OMSetBlendState();
 		return;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -466,7 +466,7 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 	bool sw_blending = false;
 
 	// No blending so early exit
-	if (!(PRIM->ABE || m_env.PABE.PABE || (PRIM->AA1 && m_vt.m_primclass == GS_LINE_CLASS)))
+	if (!(PRIM->ABE || m_env.PABE.PABE))
 	{
 		dev->OMSetBlendState();
 		return;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -122,7 +122,8 @@ void GSRendererOGL::EmulateZbuffer()
 	if (m_context->TEST.ZTE)
 	{
 		m_om_dssel.ztst = m_context->TEST.ZTST;
-		m_om_dssel.zwe = !m_context->ZBUF.ZMSK;
+		// AA1: Z is not written on lines since coverage is always less than 0x80.
+		m_om_dssel.zwe = (m_context->ZBUF.ZMSK || (PRIM->AA1 && m_vt.m_primclass == GS_LINE_CLASS)) ? 0 : 1;
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
There is no hw implementation of AA1.
Alpha blending shouldn't be enabled by AA1 flag, only ABE and PABE flags.
This caused alpha blending to be enabled when it shouldn't have.
Also disable Blending when AA1 and ABE or PABE are on on lines.
Lines aren't drawn so no need to do blending on them.


Mask out AA1 on triangles in GSState
AA1 is not supported on hw renderers so ignore flushing the prims on triangles.
Should provide a nice speed boost on games that use AA1 on triangle prims.
When AA1 flag is enabled Z is not written on lines since coverage is always less than 0x80.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Accuracy, improves how we handle aa1 draws, while there's no actual aa1 hw implementation yet we can make sure the draws are handled properly.
Improves #4674
Master
![image](https://user-images.githubusercontent.com/18107717/143020042-c47678e2-dc8b-4284-a63a-315b9ee36853.png)
PR
![image](https://user-images.githubusercontent.com/18107717/143020287-6111867b-3669-429e-8452-69bf761464a6.png)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games which use AA1.