### PR TITLE
GS-d3d11: Properly set afix in EmulateBlending.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -438,7 +438,7 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 	}
 }
 
-void GSRendererDX11::EmulateBlending()
+void GSRendererDX11::EmulateBlending(u8& afix)
 {
 	// Partial port of OGL SW blending. Currently only works for accumulation and non recursive blend.
 
@@ -529,8 +529,9 @@ void GSRendererDX11::EmulateBlending()
 
 		if (accumulation_blend)
 		{
+			// Keep HW blending to do the addition/subtraction
 			m_om_bsel.accu_blend = 1;
-
+			afix = 0;
 			if (ALPHA.A == 2)
 			{
 				// The blend unit does a reverse subtraction so it means
@@ -547,6 +548,7 @@ void GSRendererDX11::EmulateBlending()
 			// Disable HW blending
 			m_om_bsel.abe = 0;
 			m_om_bsel.blend_index = 0;
+			afix = 0;
 
 			// Only BLEND_NO_REC should hit this code path for now
 			ASSERT(blend_non_recursive);
@@ -559,6 +561,7 @@ void GSRendererDX11::EmulateBlending()
 	else
 	{
 		m_ps_sel.clr1 = !!(blend_flag & BLEND_C_CLR);
+		afix = (ALPHA.C == 2) ? ALPHA.FIX : 0;
 		// FIXME: When doing HW blending with a 24 bit frambuffer and ALPHA.C == 1 (Ad) it should be handled
 		// as if Ad = 1.0f. As with OGL side it is probably best to set m_om_bsel.c = 1 (Af) and use
 		// AFIX = 0x80 (Af = 1.0f).
@@ -835,9 +838,10 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 	}
 
 	// Blend
+	u8 afix = 0;
 	if (!IsOpaque() && rt)
 	{
-		EmulateBlending();
+		EmulateBlending(afix);
 	}
 
 	if (m_ps_sel.hdr)
@@ -1050,7 +1054,6 @@ void GSRendererDX11::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sou
 
 	SetupIA(sx, sy);
 
-	const u8 afix = m_context->ALPHA.FIX;
 	dev->SetupOM(m_om_dssel, m_om_bsel, afix);
 	dev->SetupVS(m_vs_sel, &vs_cb);
 	dev->SetupGS(m_gs_sel, &gs_cb);

--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.h
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.h
@@ -36,7 +36,7 @@ private:
 	inline void ResetStates();
 	inline void SetupIA(const float& sx, const float& sy);
 	inline void EmulateZbuffer();
-	inline void EmulateBlending();
+	inline void EmulateBlending(u8& afix);
 	inline void EmulateTextureShuffleAndFbmask();
 	inline void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
 	inline void EmulateTextureSampler(const GSTextureCache::Source* tex);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Accumulation blend -> afix is already handled in shader, no need to set it for hw blending too.
SW blending -> done in shader.
HW blending - > set only when it is actually used, Alpha C.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Proper handling, optimization.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games on hw (minimum blending) and sw (basic+ blending) on Direct3D11 to make sure everything still works.