### PR TITLE
GS: Partial revert of #5061

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -446,8 +446,8 @@ void GSRendererDX11::EmulateBlending()
 	// it requires coverage sample so it's safer to turn it off instead.
 	const bool aa1 = PRIM->AA1 && (m_vt.m_primclass == GS_LINE_CLASS);
 
-	// No blending so early exit
-	if (aa1 || !(PRIM->ABE || m_env.PABE.PABE))
+	// No blending or coverage anti-aliasing so early exit
+	if (!(PRIM->ABE || m_env.PABE.PABE || aa1))
 		return;
 
 	m_om_bsel.abe = 1;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -468,8 +468,8 @@ void GSRendererOGL::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 	// it requires coverage sample so it's safer to turn it off instead.
 	const bool aa1 = PRIM->AA1 && (m_vt.m_primclass == GS_LINE_CLASS);
 
-	// No blending so early exit
-	if (aa1 || !(PRIM->ABE || m_env.PABE.PABE))
+	// No blending or coverage anti-aliasing so early exit
+	if (!(PRIM->ABE || m_env.PABE.PABE || aa1))
 	{
 		dev->OMSetBlendState();
 		return;


### PR DESCRIPTION
### Description of Changes
Partially reverts the AA blending change in #5061

### Rationale behind Changes
The BIOS light trails broke with this change and weren't needed, the Z Writes were the important part of the PR.

### Suggested Testing Steps
Make sure the AA'd games still look as good as they do on master
