### PR TITLE
GS/OpenGL: Use CreateRenderTarget() for temp HDR target

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -1381,7 +1381,7 @@ void GSRendererOGL::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 	if (m_ps_sel.hdr)
 	{
-		hdr_rt = dev->CreateTexture(rtsize.x, rtsize.y, GL_RGBA32F);
+		hdr_rt = dev->CreateRenderTarget(rtsize.x, rtsize.y, GL_RGBA32F);
 		dev->OMSetRenderTargets(hdr_rt, ds, &scissor);
 
 		// save blend state, since BlitRect destroys it


### PR DESCRIPTION
### Description of Changes
Probably won't change much, except maybe with sparse textures, where it'll use less video memory.

### Rationale behind Changes
It was wrong before.

### Suggested Testing Steps
Make sure colclip games are still fine (e.g. sly 2, ffx-2 opening)
