### PR TITLE
GS-wx: Fix some gui interaction.

### DIFF
--- a/pcsx2/GS/Window/GSwxDialog.h
+++ b/pcsx2/GS/Window/GSwxDialog.h
@@ -100,7 +100,6 @@ public:
 
 namespace GSSettingsDialog
 {
-
 	class RendererTab : public wxPanel
 	{
 	public:
@@ -111,6 +110,8 @@ namespace GSSettingsDialog
 		std::pair<wxChoice*, wxStaticText*> m_blend_mode_d3d11;
 #endif
 		bool m_is_hardware = false;
+		bool m_is_native_res = false;
+		bool m_is_nearest_filter = false;
 
 		RendererTab(wxWindow* parent);
 		void Load() { m_ui.Load(); }
@@ -126,6 +127,7 @@ namespace GSSettingsDialog
 		wxSpinCtrl *skip_x_spin, *skip_y_spin;
 		bool m_is_hardware = false;
 		bool m_is_native_res = false;
+		bool m_is_ogl_hw = false;
 
 		HacksTab(wxWindow* parent);
 		void Load() { m_ui.Load(); }
@@ -189,6 +191,7 @@ namespace GSSettingsDialog
 #ifdef _WIN32
 		wxChoice* m_adapter_select;
 #endif
+		wxChoice* m_bifilter_select;
 		wxArrayString m_adapter_arr_string;
 		RendererTab* m_renderer_panel;
 		HacksTab* m_hacks_panel;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Fix interaction of Anisotropic filtering with Nearest Texture Filtering and GPU Palette Conversion.
Fix interaction of Trilinear Filtering with selected renderer.

Options should gray out properly now.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes #5071
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the GS options if they gray out properly now as described in the linked issue.