### PR TITLE
GS: Fix compiler warning

### DIFF
--- a/pcsx2/GS/GSAlignedClass.h
+++ b/pcsx2/GS/GSAlignedClass.h
@@ -38,6 +38,12 @@ public:
 		return ptr;
 	}
 
+	void operator delete(void* ptr, void* placement_ptr)
+	{
+		// Just here to satisfy compilers
+		// Person who calls in-place placement new must handle error case
+	}
+
 	void* operator new[](size_t size)
 	{
 		return _aligned_malloc(size, i);

--- a/pcsx2/GS/GSRingHeap.h
+++ b/pcsx2/GS/GSRingHeap.h
@@ -207,12 +207,12 @@ public:
 	SharedPtr<T> make_shared(Args&&... args)
 	{
 		using Header = typename SharedPtr<T>::AllocationHeader;
-		size_t alloc_size = sizeof(T) + sizeof(Header);
+		constexpr size_t alloc_size = sizeof(T) + sizeof(Header);
 		static_assert(alignof(Header) <= MIN_ALIGN, "Header alignment too high");
+		static_assert(alloc_size <= UINT32_MAX, "Allocation overflow");
 
 		void* ptr = alloc_internal(sizeof(T), getAlignMask(alignof(T)), sizeof(Header));
 		Header* header = static_cast<Header*>(ptr);
-		assert(alloc_size <= UINT32_MAX && "Allocation overflow");
 		header->size = static_cast<uint32_t>(alloc_size);
 		header->refcnt.store(1, std::memory_order_relaxed);
 

--- a/pcsx2/GS/GSRingHeap.h
+++ b/pcsx2/GS/GSRingHeap.h
@@ -64,18 +64,18 @@ public:
 	template <typename T, typename... Args>
 	T* make(Args&&... args)
 	{
-		void* ptr = alloc(sizeof(T), alignof(T));
-		new (ptr) T(std::forward<Args>(args)...);
-		return static_cast<T*>(ptr);
+		std::unique_ptr<void, void(*)(void*)> ptr(alloc(sizeof(T), alignof(T)), GSRingHeap::free);
+		new (ptr.get()) T(std::forward<Args>(args)...);
+		return static_cast<T*>(ptr.release());
 	}
 
 	/// Allocate and default-initialize `count` `T`s
 	template <typename T>
 	T* make_array(size_t count)
 	{
-		void* ptr = alloc(sizeof(T) * count, alignof(T));
-		new (ptr) T[count]();
-		return static_cast<T*>(ptr);
+		std::unique_ptr<void, void(*)(void*)> ptr(alloc(sizeof(T) * count, alignof(T)), GSRingHeap::free);
+		new (ptr.get()) T[count]();
+		return static_cast<T*>(ptr.release());
 	}
 
 	/// Free a pointer allocated with `alloc`
@@ -207,17 +207,19 @@ public:
 	SharedPtr<T> make_shared(Args&&... args)
 	{
 		using Header = typename SharedPtr<T>::AllocationHeader;
-		constexpr size_t alloc_size = sizeof(T) + sizeof(Header);
+		static constexpr size_t alloc_size = sizeof(T) + sizeof(Header);
 		static_assert(alignof(Header) <= MIN_ALIGN, "Header alignment too high");
 		static_assert(alloc_size <= UINT32_MAX, "Allocation overflow");
 
 		void* ptr = alloc_internal(sizeof(T), getAlignMask(alignof(T)), sizeof(Header));
+		std::unique_ptr<void, void(*)(void*)> guard(ptr, [](void* p){ free_internal(p, alloc_size); });
 		Header* header = static_cast<Header*>(ptr);
 		header->size = static_cast<uint32_t>(alloc_size);
 		header->refcnt.store(1, std::memory_order_relaxed);
 
 		T* tptr = reinterpret_cast<T*>(header + 1);
 		new (tptr) T(std::forward<Args>(args)...);
+		guard.release();
 		return SharedPtr<T>(tptr);
 	}
 


### PR DESCRIPTION
### Description of Changes
Fixes a memory leak we could have gotten if we used GSRingHeap::SharedPtr with exception-throwing constructors
(I don't think any of our constructors actually throw exceptions, but hey better safe than sorry)
Also clears an MSVC compiler warning

### Rationale behind Changes
Less compiler warnings

### Suggested Testing Steps
Look at CI, see if compiler warnings are gone
Run the SW renderer and make sure nothing breaks horribly