### PR TITLE
GS: Add dedicated functions for choosing renderers and adapters

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1189,7 +1189,6 @@ void GSApp::Init()
 	// Avoid to clutter the ini file with useless options
 #ifdef _WIN32
 	// Per OS option.
-	m_default_configuration["adapter_index"]                              = "0";
 	m_default_configuration["CaptureFileName"]                            = "";
 	m_default_configuration["CaptureVideoCodecDisplayName"]               = "";
 	m_default_configuration["debug_d3d"]                                  = "0";
@@ -1199,6 +1198,7 @@ void GSApp::Init()
 #else
 	m_default_configuration["linux_replay"]                               = "1";
 #endif
+	m_default_configuration["adapter_index"]                              = "-1";
 	m_default_configuration["aa1"]                                        = "1";
 	m_default_configuration["accurate_date"]                              = "1";
 	m_default_configuration["accurate_blending_unit"]                     = "1";

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -147,15 +147,8 @@ int _GSopen(const WindowInfo& wi, const char* title, GSRendererType renderer, in
 	if (renderer == GSRendererType::Undefined)
 	{
 		renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
-#ifdef _WIN32
 		if (renderer == GSRendererType::Default)
-		{
-			if (D3D::ShouldPreferD3D())
-				renderer = GSRendererType::DX1011_HW;
-			else
-				renderer = GSRendererType::OGL_HW;
-		}
-#endif
+			renderer = GSUtil::GetPreferredRenderer();
 	}
 
 	if (threads == -1)
@@ -299,23 +292,14 @@ int GSopen2(const WindowInfo& wi, u32 flags)
 				break;
 #endif
 			case GSRendererType::OGL_SW:
-#ifdef _WIN32
 			{
 				const auto config_renderer = static_cast<GSRendererType>(theApp.GetConfigI("Renderer"));
 
 				if (current_renderer == config_renderer)
-				{
-					if (D3D::ShouldPreferD3D())
-						current_renderer = GSRendererType::DX1011_HW;
-					else
-						current_renderer = GSRendererType::OGL_HW;
-				}
+					current_renderer = GSUtil::GetPreferredRenderer();
 				else
 					current_renderer = config_renderer;
 			}
-#else
-				current_renderer = GSRendererType::OGL_HW;
-#endif
 			break;
 			case GSRendererType::OGL_HW:
 				current_renderer = GSRendererType::OGL_SW;

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -36,13 +36,7 @@ enum class GSRendererType : int8_t
 	OGL_HW = 12,
 	OGL_SW = 13,
 
-#ifdef _WIN32
 	Default = Undefined
-#else
-	// Use ogl renderer as default otherwise it crash at startup
-	// GSRenderOGL only GSDeviceOGL (not GSDeviceNULL)
-	Default = OGL_HW
-#endif
 };
 
 // ST_WRITE is defined in libc, avoid this

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -23,6 +23,7 @@
 #ifdef _WIN32
 #include <VersionHelpers.h>
 #include "svnrev.h"
+#include "Renderers/DX11/D3D.h"
 #include <wil/com.h>
 #else
 #define SVN_REV 0
@@ -185,6 +186,28 @@ bool GSUtil::CheckSSE()
 CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
 {
 	return type == GSRendererType::OGL_HW ? CRCHackLevel::Partial : CRCHackLevel::Full;
+}
+
+GSRendererType GSUtil::GetPreferredRenderer()
+{
+#ifdef _WIN32
+	if (D3D::ShouldPreferD3D())
+		return GSRendererType::DX1011_HW;
+#endif
+	return GSRendererType::OGL_HW;
+}
+
+std::vector<std::string> GSUtil::GetAdapterList(GSRendererType renderer, size_t& default_adapter)
+{
+#ifdef _WIN32
+	if (renderer == GSRendererType::DX1011_HW)
+	{
+		default_adapter = 0;
+		auto factory = D3D::CreateFactory(false);
+		return D3D::GetAdapterList(factory.get());
+	}
+#endif
+	return {};
 }
 
 #ifdef _WIN32

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -197,12 +197,11 @@ GSRendererType GSUtil::GetPreferredRenderer()
 	return GSRendererType::OGL_HW;
 }
 
-std::vector<std::string> GSUtil::GetAdapterList(GSRendererType renderer, size_t& default_adapter)
+std::vector<std::string> GSUtil::GetAdapterList(GSRendererType renderer)
 {
 #ifdef _WIN32
 	if (renderer == GSRendererType::DX1011_HW)
 	{
-		default_adapter = 0;
 		auto factory = D3D::CreateFactory(false);
 		return D3D::GetAdapterList(factory.get());
 	}

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -41,6 +41,8 @@ public:
 
 	static bool CheckSSE();
 	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
+	static GSRendererType GetPreferredRenderer();
+	static std::vector<std::string> GetAdapterList(GSRendererType renderer, size_t& default_adapter);
 };
 
 #ifdef _WIN32

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -42,7 +42,7 @@ public:
 	static bool CheckSSE();
 	static CRCHackLevel GetRecommendedCRCHackLevel(GSRendererType type);
 	static GSRendererType GetPreferredRenderer();
-	static std::vector<std::string> GetAdapterList(GSRendererType renderer, size_t& default_adapter);
+	static std::vector<std::string> GetAdapterList(GSRendererType renderer);
 };
 
 #ifdef _WIN32

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -78,10 +78,11 @@ namespace D3D
 		ASSERT(factory);
 
 		wil::com_ptr_nothrow<IDXGIAdapter1> adapter;
-		if (factory->EnumAdapters1(index, adapter.put()) == DXGI_ERROR_NOT_FOUND)
+		if (index < 0 || factory->EnumAdapters1(index, adapter.put()) == DXGI_ERROR_NOT_FOUND)
 		{
 			// try index 0 (default adapter)
-			fprintf(stderr, "D3D: adapter not found, falling back to the default\n");
+			if (index >= 0)
+				fprintf(stderr, "D3D: adapter not found, falling back to the default\n");
 			if (FAILED(factory->EnumAdapters1(0, adapter.put())))
 			{
 				// either there are no adapters connected or something major is wrong with the system

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -16,11 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "GSwxDialog.h"
 #include "gui/AppConfig.h"
-
-#ifdef _WIN32
-#include "GS/GSExtra.h"
-#include "GS/Renderers/DX11/D3D.h"
-#endif
+#include "GS/GSUtil.h"
 
 using namespace GSSettingsDialog;
 
@@ -620,11 +616,9 @@ Dialog::Dialog()
 	m_renderer_select = m_ui.addComboBoxAndLabel(top_grid, "Renderer:", "Renderer", &theApp.m_gs_renderers).first;
 	m_renderer_select->Bind(wxEVT_CHOICE, &Dialog::OnRendererChange, this);
 
-#ifdef _WIN32
 	add_label(this, top_grid, "Adapter:");
 	m_adapter_select = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, {});
 	top_grid->Add(m_adapter_select, wxSizerFlags().Expand());
-#endif
 
 	m_ui.addComboBoxAndLabel(top_grid, "Interlacing (F5):", "interlace", &theApp.m_gs_interlace);
 
@@ -691,33 +685,37 @@ GSRendererType Dialog::GetSelectedRendererType()
 
 void Dialog::RendererChange()
 {
-#ifdef _WIN32
 	GSRendererType renderer = GetSelectedRendererType();
+	std::string current;
+	int current_sel = m_adapter_select->GetSelection();
+	if (current_sel >= 0 && current_sel < static_cast<int>(m_adapter_arr_string.Count()))
+		current = m_adapter_arr_string[current_sel].ToUTF8();
+
+	size_t default_adapter = 0;
+	std::vector<std::string> adapters = GSUtil::GetAdapterList(renderer, default_adapter);
+
 	m_adapter_select->Clear();
-
-	if (renderer == GSRendererType::DX1011_HW)
-	{
-		auto factory = D3D::CreateFactory(false);
-		auto adapter_list = D3D::GetAdapterList(factory.get());
-
-		wxArrayString adapter_arr_string;
-		for (const auto name : adapter_list)
-		{
-			adapter_arr_string.push_back(
-				convert_utf8_to_utf16(name)
-			);
-		}
-
-		m_adapter_select->Insert(adapter_arr_string, 0);
-		m_adapter_select->Enable();
-		m_adapter_select->SetSelection(
-			theApp.GetConfigI("adapter_index")
-		);
-	}
-	else
+	if (adapters.empty())
 	{
 		m_adapter_select->Disable();
 	}
+	else
+	{
+		m_adapter_arr_string.Clear();
+		int new_sel = theApp.GetConfigI("adapter_index");
+		if (new_sel < 0 || new_sel >= static_cast<int>(adapters.size()))
+			new_sel = default_adapter;
+		for (std::string& adapter : adapters)
+		{
+			if (adapter == current)
+				new_sel = m_adapter_arr_string.Count();
+			m_adapter_arr_string.Add(fromUTF8(adapter));
+		}
+		m_adapter_select->Set(m_adapter_arr_string);
+		m_adapter_select->SetSelection(new_sel);
+		m_adapter_select->Enable();
+	}
+#ifdef _WIN32
 	m_renderer_panel->UpdateBlendMode(renderer);
 
 	m_renderer_panel->Layout(); // The version of wx we use on Windows is dumb and something prevents relayout from happening to notebook pages
@@ -727,12 +725,10 @@ void Dialog::RendererChange()
 void Dialog::Load()
 {
 	m_ui.Load();
-#ifdef _WIN32
 	GSRendererType renderer = GSRendererType(theApp.GetConfigI("Renderer"));
 	if (renderer == GSRendererType::Undefined)
-		renderer = D3D::ShouldPreferD3D() ? GSRendererType::DX1011_HW : GSRendererType::OGL_HW;
+		renderer = GSUtil::GetPreferredRenderer();
 	m_renderer_select->SetSelection(get_config_index(theApp.m_gs_renderers, static_cast<int>(renderer)));
-#endif
 
 	RendererChange();
 
@@ -747,17 +743,10 @@ void Dialog::Load()
 void Dialog::Save()
 {
 	m_ui.Save();
-#ifdef _WIN32
 	// only save the adapter when it makes sense to
 	// prevents changing the adapter, switching to another renderer and saving
-	if (GetSelectedRendererType() == GSRendererType::DX1011_HW)
-	{
-		const int current_adapter =
-			m_adapter_select->GetSelection();
-
-		theApp.SetConfig("adapter_index", current_adapter);
-	}
-#endif
+	if (m_adapter_select->GetCount())
+		theApp.SetConfig("adapter_index", m_adapter_select->GetSelection());
 
 	m_hacks_panel->Save();
 	m_renderer_panel->Save();

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -641,6 +641,7 @@ Dialog::Dialog()
 	book->AddPage(m_debug_panel, "Advanced");
 
 	m_top_box->Add(top_grid, wxSizerFlags().Centre());
+	m_top_box->AddSpacer(space);
 	m_top_box->Add(book, wxSizerFlags(1).Expand());
 
 	padding->Add(m_top_box, wxSizerFlags(1).Expand().Border());

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -59,7 +59,7 @@ namespace
 		theApp.SetConfig(str, s[idx].value);
 	}
 
-	void add_label(wxWindow* parent, wxSizer* sizer, const char* str, int tooltip = -1, wxSizerFlags flags = wxSizerFlags().Centre().Right(), long style = wxALIGN_RIGHT | wxALIGN_CENTRE_HORIZONTAL)
+	void add_label(wxWindow* parent, wxSizer* sizer, const char* str, int tooltip = -1, wxSizerFlags flags = wxSizerFlags().Centre().Right(), long style = wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL)
 	{
 		auto* temp_text = new wxStaticText(parent, wxID_ANY, str, wxDefaultPosition, wxDefaultSize, style);
 		add_tooltip(temp_text, tooltip);

--- a/pcsx2/GS/Window/GSwxDialog.h
+++ b/pcsx2/GS/Window/GSwxDialog.h
@@ -188,9 +188,7 @@ namespace GSSettingsDialog
 
 		wxBoxSizer* m_top_box;
 		wxChoice* m_renderer_select;
-#ifdef _WIN32
 		wxChoice* m_adapter_select;
-#endif
 		wxChoice* m_bifilter_select;
 		wxArrayString m_adapter_arr_string;
 		RendererTab* m_renderer_panel;


### PR DESCRIPTION
### Description of Changes
- Moves adapter list and default renderer selection to GSUtil.cpp, and out of GSwxDialog.cpp+GS.cpp
- Adds a separate option to be the default-selected adapter, rather than defaulting to adapter 0
- Enables the adapter selector list on all platforms.  I can disable this on platforms with no adapter-supporting graphics APIs if we'd prefer that.

### Rationale behind Changes
- This will be important for non-DX11, non-OGL APIs.
- On dual-gpu Macs, adapter 0 is the integrated GPU while adapter 1 is the discrete GPU, so it's probably better to let the API tell us what should be the default instead of picking 0 for ourselves

### Suggested Testing Steps
- Look at the graphics settings dialog and make sure everything still works
- Make sure F9 renderer switching still works