### PR TITLE
Revert "GS: Remove Unofficial CRCs (#4082)"

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -22,6 +22,8 @@ const CRC::Game CRC::m_games[] =
 {
 	// Note: IDs 0x7ACF7E03, 0x7D4EA48F, 0x37C53760 - shouldn't be added as it's from the multiloaders when packing games.
 	{0x00000000, NoTitle, NoRegion, 0},
+	{0xF46142D3, ArTonelico2, NoRegion, 0},
+	{0xC38067F4, ArTonelico2, NoRegion, 0}, // project metafalica 1.0
 	{0xF95F37EE, ArTonelico2, US, 0},
 	{0x68CE6801, ArTonelico2, JP, 0},
 	{0xCE2C1DBF, ArTonelico2, EU, 0},
@@ -138,6 +140,7 @@ const CRC::Game CRC::m_games[] =
 	{0x32A1C752, GT4, US, 0}, // GT4 Online Beta
 	{0x2A84A1E2, GT4, US, 0}, // Mazda MX-5 Edition
 	{0x0087EEC4, GT4, NoRegion, 0}, // JP and US versions have the same CRC - GT4 Online Beta
+	{0xC164550A, WildArms5, JPUNDUB, 0},
 	{0xC1640D2C, WildArms5, US, 0},
 	{0x0FCF8FE4, WildArms5, EU, 0},
 	{0x2294D322, WildArms5, JP, 0},
@@ -210,6 +213,8 @@ const CRC::Game CRC::m_games[] =
 	{0xF442260C, MajokkoALaMode2, JP, 0},
 	{0xA616A6C2, TalesOfAbyss, US, 0},
 	{0x14FE77F7, TalesOfAbyss, US, 0},
+	{0x045D77E9, TalesOfAbyss, JPUNDUB, 0},
+	{0x14FD77F7, TalesOfAbyss, JPUNDUB, 0},
 	{0xAA5EC3A3, TalesOfAbyss, JP, 0},
 	{0xFB236A46, SonicUnleashed, US, 0},
 	{0x8C913264, SonicUnleashed, EU, 0},
@@ -217,6 +222,7 @@ const CRC::Game CRC::m_games[] =
 	{0x23A97857, StarOcean3, US, 0},
 	{0xBEC32D49, StarOcean3, JP, 0},
 	{0x8192A241, StarOcean3, JP, 0}, // NTSC JP special directors cut limited extra sugar on top edition (the special one :p)
+	// it's the US version with speach files from JP... {0x23A97857, StarOcean3, JPUNDUB, 0},
 	{0xCC96CE93, ValkyrieProfile2, US, 0},
 	{0x774DE8E2, ValkyrieProfile2, JP, 0},
 	{0x04CCB600, ValkyrieProfile2, EU, 0},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -153,6 +153,7 @@ public:
 		US,
 		EU,
 		JP,
+		JPUNDUB,
 		RU,
 		FR,
 		DE,


### PR DESCRIPTION
### Description of Changes
This reverts commit 6bcdb55f22d468b2eb8b95fd35bd071f9272a89c.

### Rationale behind Changes
These games hacks are still used and can be removed again when a better solution is available. Removing them before that is the case only regresses users.

### Suggested Testing Steps
N/A
