### PR TITLE
GHActions: Fix Mac build

### DIFF
--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           # To save time, only brew update if running the install without it fails
           function do-install() {
-            brew install sound-touch portaudio wxmac sdl2 libsamplerate
+            brew install sound-touch portaudio wxwidgets sdl2 libsamplerate glib
           }
           if ! do-install; then
             brew update


### PR DESCRIPTION
### Description of Changes
Adds glib to the list of packages installed on macOS

### Rationale behind Changes
GitHub Actions must have changed the set of preinstalled packages as glib is now missing

### Suggested Testing Steps
Make sure the CI works