### PR TITLE
EE Syscalls: Change syscall type to u32 instead of u8

### DIFF
--- a/pcsx2/R5900OpcodeTables.h
+++ b/pcsx2/R5900OpcodeTables.h
@@ -17,7 +17,7 @@
 
 #include "common/Pcsx2Defs.h"
 
-enum Syscall : u8
+enum Syscall : u32
 {
 	SetGsCrt = 2,
 	SetVTLBRefillHandler = 13,


### PR DESCRIPTION
### Description of Changes
Syscalls have no theoretical limit (well, 20 bits according to the instruction). Currently, 0x102 would overflow to 0x02 and invoke our HLE stuff (in this example SetGsCrt).

### Rationale behind Changes
It prevents triggering our HLE syscall handlers when games or homebrew use really high syscalls (even though they shouldn't)

### Suggested Testing Steps
Not really applicable.
