### PR TITLE
GS Debugger: Fix Length of dump.

### DIFF
--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -576,8 +576,8 @@ DebugTab::DebugTab(wxWindow* parent)
 
 		auto* dump_grid = new wxFlexGridSizer(2, space, space);
 
-		start_dump_spin = m_ui.addSpinAndLabel(dump_grid, "Start of Dump:", "saven", 0, pow(10, 9),    0).first;
-		end_dump_spin   = m_ui.addSpinAndLabel(dump_grid, "End of Dump:",   "savel", 0, pow(10, 5), 5000).first;
+		m_ui.addSpinAndLabel(dump_grid, "Start of Dump:",  "saven", 0, pow(10, 9),    0);
+		m_ui.addSpinAndLabel(dump_grid, "Length of Dump:", "savel", 1, pow(10, 5), 5000);
 
 		debug_box->AddSpacer(space);
 		debug_box->Add(dump_grid);
@@ -600,10 +600,6 @@ DebugTab::DebugTab(wxWindow* parent)
 void DebugTab::DoUpdate()
 {
 	m_ui.Update();
-	if (!end_dump_spin || !start_dump_spin)
-		return;
-	if (end_dump_spin->GetValue() < start_dump_spin->GetValue())
-		end_dump_spin->SetValue(start_dump_spin->GetValue());
 }
 
 Dialog::Dialog()

--- a/pcsx2/GS/Window/GSwxDialog.h
+++ b/pcsx2/GS/Window/GSwxDialog.h
@@ -139,8 +139,6 @@ namespace GSSettingsDialog
 	{
 	public:
 		GSUIElementHolder m_ui;
-		wxSpinCtrl* start_dump_spin = nullptr;
-		wxSpinCtrl* end_dump_spin = nullptr;
 		bool m_is_ogl_hw = false;
 
 		DebugTab(wxWindow* parent);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
End of Dump is actually Length of Dump, don't set minimum value of start of dump, it's annoying, don't want to dump 1k draw.
Set min value of 1 as 0 will create endless dumps.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Makes the GS debugger suck less.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
