### PR TITLE
Linux and Windows CMake Builds: Change output executable to lowercase

### DIFF
--- a/.github/workflows/scripts/linux/appimage.sh
+++ b/.github/workflows/scripts/linux/appimage.sh
@@ -25,8 +25,8 @@ sudo cp /usr/local/bin/patchelf /tmp/squashfs-root/usr/bin/patchelf
 cd "$GITHUB_WORKSPACE"
 mkdir -p squashfs-root/usr/bin
 ls -al "$BUILDBIN"
-cp -P "$BUILDBIN"/PCSX2 "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/
-patchelf --set-rpath /tmp/PCSX2 "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/PCSX2
+cp -P "$BUILDBIN"/pcsx2 "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/
+patchelf --set-rpath /tmp/PCSX2 "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/pcsx2
 cp ./pcsx2/gui/Resources/AppIcon64.png ./squashfs-root/PCSX2.png
 cp ./linux_various/PCSX2.desktop.in ./squashfs-root/PCSX2.desktop 
 sed -i -e 's|Categories=@PCSX2_MENU_CATEGORIES@|Categories=Game;Emulator;|g' ./squashfs-root/PCSX2.desktop

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -121,7 +121,7 @@ jobs:
             Release) SIMD="SSE4";;
             *AVX2)   SIMD="AVX2";;
             CMake)   SIMD="CMake"
-                     cp build/pcsx2/PCSX2* bin/ ;;
+                     cp build/pcsx2/pcsx2* bin/ ;;
             *)       SIMD="UNKNOWN";;
           esac
           if [ ${{ github.event_name }} == "pull_request" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,9 @@ oprofile_data/
 /bin/**/*.ilk
 /bin/**/*.lib
 /bin/**/*.pdb
-/bin/PCSX2
+/bin/pcsx2
 /bin/PCSX2-linux.sh
 /bin/*ReplayLoader
-/bin/PCSX2-linux.sh
 /bin/GS*.txt
 /bin/bios
 /bin/cache

--- a/linux_various/PCSX2-linux.sh
+++ b/linux_various/PCSX2-linux.sh
@@ -43,7 +43,7 @@ fi
 DIR=`dirname $current_script`
 MY_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
-if [ ! -x "$DIR/PCSX2" ]
+if [ ! -x "$DIR/pcsx2" ]
 then
     echo "Error PCSX2 not found in $DIR"
     echo "Maybe the script was directly 'called'"

--- a/linux_various/PCSX2.desktop.in
+++ b/linux_various/PCSX2.desktop.in
@@ -9,7 +9,7 @@ GenericName[zh_CN]=PlayStation 2 模拟器
 Comment=Sony PlayStation 2 emulator
 Comment[ru]=Эмулятор Sony PlayStation 2
 Comment[zh_CN]=索尼 PlayStation 2 模拟器
-Exec=env GDK_BACKEND=x11 MESA_NO_ERROR=1 PCSX2
+Exec=env GDK_BACKEND=x11 MESA_NO_ERROR=1 pcsx2
 Icon=PCSX2
 Keywords=game;emulator;
 Categories=@PCSX2_MENU_CATEGORIES@

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1483,6 +1483,12 @@ foreach(path IN LISTS RESOURCE_FILES)
 	pcsx2_resource(${path} ${CMAKE_SOURCE_DIR}/bin/resources/)
 endforeach()
 
+if (NOT APPLE)
+	set_target_properties(PCSX2 PROPERTIES
+		OUTPUT_NAME pcsx2
+	)
+endif()
+
 if (APPLE)
 	# MacOS defaults to having a maximum protection of the __DATA segment of rw (non-executable)
 	# We have a bunch of page-sized arrays in bss that we use for jit
@@ -1522,9 +1528,9 @@ endif()
 
 if(NOT DISABLE_SETCAP)
 	if(PACKAGE_MODE)
-		install(CODE "execute_process(COMMAND /bin/bash -c \"echo 'Enabling networking capability on Linux...';set -x; [ -f '${CMAKE_INSTALL_FULL_BINDIR}/PCSX2' ] && sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' '${CMAKE_INSTALL_FULL_BINDIR}/PCSX2'; set +x\")")
+		install(CODE "execute_process(COMMAND /bin/bash -c \"echo 'Enabling networking capability on Linux...';set -x; [ -f '${CMAKE_INSTALL_FULL_BINDIR}/pcsx2' ] && sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' '${CMAKE_INSTALL_FULL_BINDIR}/pcsx2'; set +x\")")
 	else()
-		install(CODE "execute_process(COMMAND /bin/bash -c \"echo 'Enabling networking capability on Linux...';set -x; [ -f '${CMAKE_SOURCE_DIR}/bin/PCSX2' ] && sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' '${CMAKE_SOURCE_DIR}/bin/PCSX2'; set +x\")")
+		install(CODE "execute_process(COMMAND /bin/bash -c \"echo 'Enabling networking capability on Linux...';set -x; [ -f '${CMAKE_SOURCE_DIR}/bin/pcsx2' ] && sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' '${CMAKE_SOURCE_DIR}/bin/pcsx2'; set +x\")")
 	endif()
 endif()
 


### PR DESCRIPTION
### Description of Changes
bin/PCSX2 is now bin/pcsx2 -- update your scripts!

### Rationale behind Changes
Everything in Linux land is lowercase

### Suggested Testing Steps
Build PCSX2 and see if it is lowercase


-- I believe I got everything covered for this change? PCSX2-Linux.sh still works
