### PR TITLE
GS-hw: Sample depth on green channel

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -361,11 +361,10 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 			{
 				// Typically used in Terminator 3
 				const int blue_mask = m_context->FRAME.FBMSK >> 24;
-				const int green_mask = ~blue_mask & 0xFF;
 				int blue_shift = -1;
 
 				// Note: potentially we could also check the value of the clut
-				switch (m_context->FRAME.FBMSK >> 24)
+				switch (blue_mask)
 				{
 					case 0xFF: ASSERT(0);      break;
 					case 0xFE: blue_shift = 1; break;
@@ -378,18 +377,19 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 					default:                   break;
 				}
 
-				const int green_shift = 8 - blue_shift;
-				ps_cb.ChannelShuffle = GSVector4i(blue_mask, blue_shift, green_mask, green_shift);
-
 				if (blue_shift >= 0)
 				{
+					const int green_mask = ~blue_mask & 0xFF;
+					const int green_shift = 8 - blue_shift;
+
 					// fprintf(stderr, "%d: Green/Blue channel (%d, %d)\n", s_n, blue_shift, green_shift);
+					ps_cb.ChannelShuffle = GSVector4i(blue_mask, blue_shift, green_mask, green_shift);
 					m_ps_sel.channel = ChannelFetch_GXBY;
 					m_context->FRAME.FBMSK = 0x00FFFFFF;
 				}
 				else
 				{
-					// fprintf(stderr, "%d: Green channel (wrong mask) (fbmask %x)\n", s_n, m_context->FRAME.FBMSK >> 24);
+					// fprintf(stderr, "%d: Green channel (wrong mask) (fbmask %x)\n", s_n, blue_mask);
 					m_ps_sel.channel = ChannelFetch_GREEN;
 				}
 			}

--- a/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -375,7 +375,7 @@ void GSRendererDX11::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache:
 					case 0xE0: blue_shift = 5; break;
 					case 0xC0: blue_shift = 6; break;
 					case 0x80: blue_shift = 7; break;
-					default:   ASSERT(0);      break;
+					default:                   break;
 				}
 
 				const int green_shift = 8 - blue_shift;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -395,7 +395,7 @@ void GSRendererOGL::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::
 					case 0xE0: blue_shift = 5; break;
 					case 0xC0: blue_shift = 6; break;
 					case 0x80: blue_shift = 7; break;
-					default:   ASSERT(0);      break;
+					default:                   break;
 				}
 
 				const int green_shift = 8 - blue_shift;

--- a/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSRendererOGL.cpp
@@ -381,11 +381,10 @@ void GSRendererOGL::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::
 			{
 				// Typically used in Terminator 3
 				const int blue_mask = m_context->FRAME.FBMSK >> 24;
-				const int green_mask = ~blue_mask & 0xFF;
 				int blue_shift = -1;
 
 				// Note: potentially we could also check the value of the clut
-				switch (m_context->FRAME.FBMSK >> 24)
+				switch (blue_mask)
 				{
 					case 0xFF: ASSERT(0);      break;
 					case 0xFE: blue_shift = 1; break;
@@ -398,18 +397,19 @@ void GSRendererOGL::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::
 					default:                   break;
 				}
 
-				const int green_shift = 8 - blue_shift;
-				dev->SetupCBMisc(GSVector4i(blue_mask, blue_shift, green_mask, green_shift));
-
 				if (blue_shift >= 0)
 				{
+					const int green_mask = ~blue_mask & 0xFF;
+					const int green_shift = 8 - blue_shift;
+
 					GL_INS("Green/Blue channel (%d, %d)", blue_shift, green_shift);
+					dev->SetupCBMisc(GSVector4i(blue_mask, blue_shift, green_mask, green_shift));
 					m_ps_sel.channel = ChannelFetch_GXBY;
 					m_context->FRAME.FBMSK = 0x00FFFFFF;
 				}
 				else
 				{
-					GL_INS("Green channel (wrong mask) (fbmask %x)", m_context->FRAME.FBMSK >> 24);
+					GL_INS("Green channel (wrong mask) (fbmask %x)", blue_mask);
 					m_ps_sel.channel = ChannelFetch_GREEN;
 				}
 			}

--- a/pcsx2/GS/res/glsl/tfx_fs.glsl
+++ b/pcsx2/GS/res/glsl/tfx_fs.glsl
@@ -369,6 +369,17 @@ vec4 fetch_red()
     return sample_p(rt.r) * 255.0f;
 }
 
+vec4 fetch_green()
+{
+#if PS_DEPTH_FMT == 1 || PS_DEPTH_FMT == 2
+    int depth = (fetch_raw_depth() >> 8) & 0xFF;
+    vec4 rt = vec4(depth) / 255.0f;
+#else
+    vec4 rt = fetch_raw_color();
+#endif
+    return sample_p(rt.g) * 255.0f;
+}
+
 vec4 fetch_blue()
 {
 #if PS_DEPTH_FMT == 1 || PS_DEPTH_FMT == 2
@@ -378,12 +389,6 @@ vec4 fetch_blue()
     vec4 rt = fetch_raw_color();
 #endif
     return sample_p(rt.b) * 255.0f;
-}
-
-vec4 fetch_green()
-{
-    vec4 rt = fetch_raw_color();
-    return sample_p(rt.g) * 255.0f;
 }
 
 vec4 fetch_alpha()

--- a/pcsx2/GS/res/tfx.fx
+++ b/pcsx2/GS/res/tfx.fx
@@ -410,6 +410,23 @@ float4 fetch_red(int2 xy)
 	return sample_p(rt.r) * 255.0f;
 }
 
+float4 fetch_green(int2 xy)
+{
+	float4 rt;
+
+	if ((PS_DEPTH_FMT == 1) || (PS_DEPTH_FMT == 2))
+	{
+		int depth = (fetch_raw_depth(xy) >> 8) & 0xFF;
+		rt = (float4)(depth) / 255.0f;
+	}
+	else
+	{
+		rt = fetch_raw_color(xy);
+	}
+
+	return sample_p(rt.g) * 255.0f;
+}
+
 float4 fetch_blue(int2 xy)
 {
 	float4 rt;
@@ -425,12 +442,6 @@ float4 fetch_blue(int2 xy)
 	}
 
 	return sample_p(rt.b) * 255.0f;
-}
-
-float4 fetch_green(int2 xy)
-{
-	float4 rt = fetch_raw_color(xy);
-	return sample_p(rt.g) * 255.0f;
 }
 
 float4 fetch_alpha(int2 xy)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Sample depth on green channel.
Update channel buffer only when GXBY channel is used, and cleanup some variables.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes #4540
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test #4540, maybe Stolen and other games that hit the same code path.