### PR TITLE
GS-hw: Improve DATE selection

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -1226,16 +1226,23 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	// DATE: selection of the algorithm. Must be done before blending because GL42 is not compatible with blending
 	if (DATE)
 	{
-		if (m_prim_overlap == PRIM_OVERLAP_NO || m_texture_shuffle)
+		// It is way too complex to emulate texture shuffle with DATE. So just use
+		// the slow but accurate algo
+		const bool fbmask = (m_context->FRAME.FBMSK & 0x80000000);
+		const bool no_overlap = (m_prim_overlap == PRIM_OVERLAP_NO);
+		if (fbmask || no_overlap || m_texture_shuffle)
 		{
-			// It is way too complex to emulate texture shuffle with DATE. So just use
-			// the slow but accurate algo
-			GL_PERF("DATE: With %s", m_texture_shuffle ? "texture shuffle" : "no prim overlap");
+			GL_PERF("DATE: Accurate with %s", m_texture_shuffle ? "texture shuffle" : no_overlap ? "no overlap" : "FBMASK");
 			if (g_gs_device->Features().texture_barrier)
 			{
 				m_conf.require_full_barrier = true;
 				DATE_GL45 = true;
 			}
+		}
+		else if (m_context->FBA.FBA)
+		{
+			DATE_one = !m_context->TEST.DATM;
+			GL_PERF("DATE: Fast with FBA, all pixels will be >= 128");
 		}
 		else if (m_conf.colormask.wa && !m_context->TEST.ATE)
 		{
@@ -1258,7 +1265,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			{
 				// texture barrier will split the draw call into n draw call. It is very efficient for
 				// few primitive draws. Otherwise it sucks.
-				GL_PERF("DATE: Slow with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
+				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 				if (g_gs_device->Features().texture_barrier)
 				{
 					m_conf.require_full_barrier = true;
@@ -1268,7 +1275,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			else if (GSConfig.AccurateDATE)
 			{
 				// Note: Fast level (DATE_one) was removed as it's less accurate.
-				GL_PERF("DATE: Full AD with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
+				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 				if (g_gs_device->Features().image_load_store)
 				{
 					DATE_GL42 = true;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
OpenGL:
Check for fbmask and do accurate path DATE_GL45.
Check for FBA, all pixels will be 128 or more so use Fast path DATE_one.

Direct3D:
Check for fbmask, accurate path isn't supported so just to DATE.
Check for FBA, all pixels will be 128 or more so use Fast path DATE_one.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test shadows, transparency.