### PR TITLE
Only pass C++ flags to C++ files.

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -215,7 +215,10 @@ option(USE_PGO_OPTIMIZE "Enable PGO optimization (use profile)")
 if(MSVC)
 	add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/Zc:externConstexpr>")
 else()
-	add_compile_options(-pipe -fvisibility=hidden -pthread -fno-builtin-strcmp -fno-builtin-memcmp -mfpmath=sse -fno-operator-names)
+	add_compile_options(-pipe -fvisibility=hidden -pthread -fno-builtin-strcmp -fno-builtin-memcmp -mfpmath=sse)
+
+	# -fno-operator-names should only be for C++ files, not C files.
+	add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-operator-names>)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
### Description of Changes
Changed -fno-operator-names to only be passed to C++ files.

### Rationale behind Changes
3rd party libraries we compile no longer spew out a bunch of warnings that C files don't use that flag.

### Suggested Testing Steps
Compile pcsx2.