### PR TITLE
CI - Remove 32bit Builds

### DIFF
--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -45,19 +45,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-18.04
-            platform: x86
-            compiler: gcc
-            cmakeflags: -DLTO_PCSX2_CORE=ON
-            appimage: true
-            experimental: false
-          - os: ubuntu-18.04
             platform: x64
             compiler: gcc
             cmakeflags: -DLTO_PCSX2_CORE=ON
             appimage: true
             experimental: false
           - os: ubuntu-18.04
-            platform: x86
+            platform: x64
             compiler: clang
             # Need to disable PCH until cmake 3.17
             # (PCH conflicts with ccache, fixed by https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4400)
@@ -66,14 +60,14 @@ jobs:
             appimage: false
             experimental: false
           - os: ubuntu-18.04
-            platform: x86
+            platform: x64
             compiler: gcc
             cmakeflags: -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
             detail: " nopch"
             appimage: false
             experimental: false
           - os: ubuntu-18.04
-            platform: x86
+            platform: x64
             compiler: gcc
             cmakeflags: -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DARCH_FLAG=-march=haswell
             detail: " avx2 nopch"

--- a/.github/workflows/linux-workflow.yml
+++ b/.github/workflows/linux-workflow.yml
@@ -74,7 +74,7 @@ jobs:
             appimage: false
             experimental: false
 
-    name: ${{ matrix.platform }} | ${{ matrix.compiler }}${{ matrix.detail }}
+    name: ${{ matrix.compiler }}${{ matrix.detail }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.

--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -70,7 +70,6 @@ jobs:
         platform: [x64]
         experimental: [false]
 
-    name: ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.

--- a/.github/workflows/scripts/releases/announce-release/index.js
+++ b/.github/workflows/scripts/releases/announce-release/index.js
@@ -44,7 +44,8 @@ const embed = new MessageEmbed()
     { name: 'Version', value: releaseInfo.tag_name, inline: true },
     { name: 'Release Link', value: `[Github Release](${releaseInfo.html_url})`, inline: true },
     { name: 'Installation Steps', value: '[See Here](https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide)', inline: true },
-    { name: 'Included Changes', value: releaseInfo.body, inline: false }
+    { name: 'Included Changes', value: releaseInfo.body, inline: false },
+    { name: 'Previous Builds', value: "[See Here](https://pcsx2.github.io/downloads.html#nightly-anchor)", inline: false }
   );
 
 if (windowsAssetLinks != "") {

--- a/.github/workflows/scripts/releases/upload-release-artifacts/index.js
+++ b/.github/workflows/scripts/releases/upload-release-artifacts/index.js
@@ -111,11 +111,8 @@ const { data: releaseAssetsPost } = await octokit.rest.repos.listReleaseAssets({
 
 // Expected Assets, if we have all of them, we will publish it
 let expectedAssets = {
-  "windows-32bit-sse4": false,
-  "windows-32bit-avx2": false,
   "windows-64bit-sse4": false,
   "windows-64bit-avx2": false,
-  "linux-appimage-32bit": false,
   "linux-appimage-64bit": false
 }
 

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -41,12 +41,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        platform: [Win32, x64]
+        platform: [x64]
         configuration: [Release, Release AVX2, CMake, Qt]
         experimental: [false]
-        exclude:
-          - platform: win32
-            configuration: Qt
 
     name: ${{ matrix.platform }} | ${{ matrix.configuration }}
     runs-on: ${{ matrix.os }}
@@ -70,18 +67,18 @@ jobs:
         run: git submodule update --init --recursive -j $env:NUMBER_OF_PROCESSORS
 
       - name: Setup Buildcache
+        if: matrix.configuration == 'CMake' # TODO: buildcache on VS
         uses: mikehardy/buildcache-action@v1.2.2
         with:
           cache_key: ${{ matrix.os }} ${{ matrix.platform }} ${{ matrix.configuration }}
-        if: matrix.configuration == 'CMake' # TODO: buildcache on VS
 
       - name: Verify VS Project Files
-        run: .github\workflows\scripts\windows\validate-vs-filters.ps1
         if: matrix.configuration != 'CMake'
+        run: .github\workflows\scripts\windows\validate-vs-filters.ps1
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1
         if: matrix.configuration != 'CMake'
+        uses: microsoft/setup-msbuild@v1
 
       - name: Download Qt build files
         if: matrix.configuration == 'Qt'
@@ -93,6 +90,7 @@ jobs:
           del qt-6.2.2-x64.7z
 
       - name: Generate CMake
+        if: matrix.configuration == 'CMake'
         id: cmake
         shell: cmd
         run: |
@@ -102,7 +100,6 @@ jobs:
           echo ::set-output name=buildtype::%type%
           echo ::set-output name=vcvars::%vcvars%
           cmake . -B build -DCMAKE_BUILD_TYPE=%type% -DLTO_PCSX2_CORE=ON -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=..\buildcache\bin\buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER=..\buildcache\bin\buildcache.exe -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
-        if: matrix.configuration == 'CMake'
 
       - name: Build PCSX2
         shell: cmd
@@ -123,11 +120,11 @@ jobs:
           )
 
       - name: Run Tests
+        if: matrix.configuration == 'CMake'
         shell: cmd
         run: |
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\${{ steps.cmake.outputs.vcvars }}"
           cmake --build build --config ${{ steps.cmake.outputs.buildtype }} --target unittests
-        if: matrix.configuration == 'CMake'
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata

--- a/.github/workflows/windows-workflow.yml
+++ b/.github/workflows/windows-workflow.yml
@@ -45,7 +45,7 @@ jobs:
         configuration: [Release, Release AVX2, CMake, Qt]
         experimental: [false]
 
-    name: ${{ matrix.platform }} | ${{ matrix.configuration }}
+    name: ${{ matrix.configuration }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Removes 32bit builds from CI via the smallest possible change to do so.  There is still 32bit scaffolding and code throughout the repo, so until this is all removed, let's start small.

Also added a link to the new build page to the announcement / updated the scripts to no longer care about 32bit artifacts

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

The time has come.

The next release is slated to be 64bit only, this is the first stepping stone in removing 32bit support.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Workflows work on my fork:
- https://github.com/xTVaser/pcsx2-rr/actions/runs/1561333647
- https://github.com/xTVaser/pcsx2-rr/actions/runs/1561333646
