### PR TITLE
Pad: Fix connection of macOS GameController framework controllers

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -43,6 +43,10 @@
 #endif
 #endif	// __WXGTK__
 
+#ifdef SDL_BUILD
+#include <SDL.h>
+#endif
+
 using namespace pxSizerFlags;
 
 void Pcsx2App::DetectCpuAndUserMode()
@@ -501,6 +505,12 @@ bool Pcsx2App::OnInit()
 		CleanupOnExit();
 		return false;
 	}
+
+#ifdef SDL_BUILD
+	// MacOS Game Controller framework requires a few runs of the main event loop after interest in game controllers is first indicated to connect controllers
+	// Since OnePad doesn't currently handle connection/disconnection events and requires controllers to be connected on start, we need to initialize SDL before OnePad looks at the controller list
+	SDL_Init(SDL_INIT_GAMECONTROLLER);
+#endif
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes an issue where SDL's backend for the macOS native game controller framework wouldn't initialize its controller list in time for PCSX2 to pick it up

### Rationale behind Changes
Prevents issues where PCSX2 doesn't recognize controllers that should otherwise be recognized
Happens most frequently around OS updates as they tend to break SDL's lower level APIs that could otherwise handle the controllers

### Suggested Testing Steps
Make sure pad still works on Linux and I didn't somehow break anything there
