### PR TITLE
EERec: Remove zero-distance jmp in full fpu mode

### DIFF
--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -413,7 +413,6 @@ void FPU_ADD_SUB(int tempd, int tempt) //tempd and tempt are overwritten, they a
 	x86SetJ8(j8Ptr[3]);
 	//diff = -255 .. -25, expd < expt
 	xAND.PS(xRegisterSSE(tempd), ptr[s_const.neg]);
-	j8Ptr[7] = JMP8(0);
 
 	x86SetJ8(j8Ptr[2]);
 	//diff == 0
@@ -421,7 +420,6 @@ void FPU_ADD_SUB(int tempd, int tempt) //tempd and tempt are overwritten, they a
 	x86SetJ8(j8Ptr[4]);
 	x86SetJ8(j8Ptr[5]);
 	x86SetJ8(j8Ptr[6]);
-	x86SetJ8(j8Ptr[7]);
 
 	_freeXMMreg(xmmtemp);
 	_freeX86reg(temp2);


### PR DESCRIPTION
### Description of Changes
This was generating a 0-distance jmp at the end of the adjustment for add/sub insturctions.

### Rationale behind Changes
Useless code.

### Suggested Testing Steps
Make sure full FPU games are unaffected (e.g. Bully, NFS Carbon). But it was literally an `EB 00` encoding so it shouldn't have any negative effects.