### PR TITLE
CDVD: Fix some read timing logic

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1038,7 +1038,7 @@ __fi void cdvdActionInterrupt()
 			cdvd.Spinning = true;
 			cdvd.Ready |= CDVD_DRIVE_READY; //check (rama)
 			cdvd.Sector = cdvd.SeekToSector;
-			cdvd.Status = CDVD_STATUS_READ;
+			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
 			cdvd.triggerDataReady = true;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
@@ -1049,7 +1049,7 @@ __fi void cdvdActionInterrupt()
 			cdvd.Spinning = true; //check (rama)
 			cdvd.Ready |= CDVD_DRIVE_READY; //check (rama)
 			cdvd.Sector = cdvd.SeekToSector;
-			cdvd.Status = CDVD_STATUS_READ;
+			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
 			cdvd.triggerDataReady = true;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
@@ -1103,18 +1103,8 @@ __fi void cdvdSectorReady()
 		}
 	}
 
-	if (cdvd.nextSectorsBuffered == 16 && (cdvd.Ready & CDVD_DRIVE_READY))
-	{
-		cdvd.Status = CDVD_STATUS_PAUSE; // Needed here but could be smth else than Pause (rama)
-	}
-	else
-	{
-		if (cdvd.nextSectorsBuffered < 16)
-		{
-			CDVDSECTORREADY_INT(cdvd.ReadTime);
-			cdvd.Status = CDVD_STATUS_READ;
-		}
-	}
+	if (cdvd.nextSectorsBuffered < 16)
+		CDVDSECTORREADY_INT(cdvd.ReadTime);
 }
 
 // inlined due to being referenced in only one place.
@@ -1213,10 +1203,7 @@ __fi void cdvdReadInterrupt()
 			iopIntcIrq(2);
 			cdvd.Ready |= CDVD_DRIVE_READY;
 
-			if (cdvd.nextSectorsBuffered < 16)
-				cdvd.Status = CDVD_STATUS_READ;
-			else
-				cdvd.Status = CDVD_STATUS_PAUSE;
+			cdvd.Status = CDVD_STATUS_PAUSE;
 
 			cdvd.nCommand = 0;
 			//DevCon.Warning("Scheduling interrupt in %d cycles", cdvd.ReadTime - ((cdvd.BlockSize / 4) * 12));
@@ -1623,7 +1610,7 @@ static void cdvdWrite04(u8 rt)
 			cdvdSetIrq();
 			cdvd.nCommand = 0;
 			//After Pausing needs to buffer the next sector
-			cdvd.Status = CDVD_STATUS_READ;
+			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
 			cdvd.triggerDataReady = true;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
@@ -1855,7 +1842,7 @@ static void cdvdWrite04(u8 rt)
 			HW_DMA3_CHCR &= ~0x01000000;
 			psxDmaInterrupt(3);
 			//After reading the TOC it needs to go back to buffer the next sector
-			cdvd.Status = CDVD_STATUS_READ;
+			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
 			cdvd.triggerDataReady = true;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
@@ -1872,7 +1859,7 @@ static void cdvdWrite04(u8 rt)
 			cdvdSetIrq();
 			cdvd.nCommand = 0;
 			//After reading the key it needs to go back to buffer the next sector
-			cdvd.Status = CDVD_STATUS_READ;
+			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
 			cdvd.triggerDataReady = true;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);


### PR DESCRIPTION
### Description of Changes
Adjusts some of the reading logic to correct the timing of some events
Also don't set "READ" state when buffering, doing this breaks Pro Yakyuu Spirits 5 which does CD Standby and expects it to not be reading.

### Rationale behind Changes
In some scenarios it would spend too long reading/seeking when it shouldn't do since we'd already accounted for it.

### Suggested Testing Steps
Check games, especially CDVD sensitive ones, make sure they're still okay, not actually expecting much change.

SH2 is still janky, seems okayish for me with MTVU off... but I don't know what the proper fix is for that, just to jump in there first.
