### PR TITLE
GSRenderer: Remove anti-blur hacks for altering display height

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -205,34 +205,6 @@ bool GSRenderer::Merge(int field)
 		src_hw[i] = (GSVector4(r) + GSVector4(0, y_offset[i], 0, y_offset[i])) * scale / GSVector4(tex[i]->GetSize()).xyxy();
 
 		GSVector2 off(0);
-		GSVector2i display_diff(dr[i].left - display_baseline.x, dr[i].top - display_baseline.y);
-		GSVector2i frame_diff(fr[i].left - frame_baseline.x, fr[i].top - frame_baseline.y);
-
-		// Time Crisis 2/3 uses two side by side images when in split screen mode.
-		// Though ignore cases where baseline and display rectangle offsets only differ by 1 pixel, causes blurring and wrong resolution output on FFXII
-		if (display_diff.x > 2)
-		{
-			off.x = tex[i]->GetScale().x * display_diff.x;
-		}
-		// If the DX offset is too small then consider the status of frame memory offsets, prevents blurring on Tenchu: Fatal Shadows, Worms 3D
-		else if (display_diff.x != frame_diff.x)
-		{
-			off.x = tex[i]->GetScale().x * frame_diff.x;
-		}
-
-		if (display_diff.y >= 4) // Shouldn't this be >= 2?
-		{
-			off.y = tex[i]->GetScale().y * display_diff.y;
-
-			if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD)
-			{
-				off.y /= 2;
-			}
-		}
-		else if (display_diff.y != frame_diff.y)
-		{
-			off.y = tex[i]->GetScale().y * frame_diff.y;
-		}
 
 		dst[i] = GSVector4(off).xyxy() + scale * GSVector4(r.rsize());
 


### PR DESCRIPTION
### Description of Changes
Removes hacks that affect display height.

### Rationale behind Changes
Remove upscaling hacks from core code. Fixes "bouncing image" bug in The Suffering series when viewing security cameras.

### Suggested Testing Steps
Test games for bugs with native res and upscaling, specifically Time Crisis 2/3 (splitscreen), FFXII, Tenchu: Fatal Shadows, Worms 3D

Master:
![pcsx2-dbg_2021_12_12_13_27_21_209](https://user-images.githubusercontent.com/16314399/145726594-113992d7-59bc-4c04-96d0-0890cb53d470.png)


PR:
![pcsx2-dev_2021_12_12_13_32_16_103](https://user-images.githubusercontent.com/16314399/145726600-209f4644-d9c1-4ba8-9da9-2f3f8889250b.png)

