### PR TITLE
CMake: Remove gio dependency on macOS

### DIFF
--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           # To save time, only brew update if running the install without it fails
           function do-install() {
-            brew install sound-touch portaudio wxwidgets sdl2 libsamplerate glib
+            brew install sound-touch portaudio wxwidgets sdl2 libsamplerate
           }
           if ! do-install; then
             brew update

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -162,11 +162,7 @@ else()
 	if(UNIX AND NOT APPLE)
 		find_package(X11 REQUIRED)
 		make_imported_target_if_missing(X11::X11 X11)
-	endif()
-	if(APPLE)
-		check_lib(GIO gio-2.0 gio/gio.h)
-	elseif(UNIX)
-		# Most plugins (if not all) and PCSX2 core need gtk2, so set the required flags
+
 		if (GTK2_API)
 			find_package(GTK2 REQUIRED gtk)
 			alias_library(GTK::gtk GTK2::gtk)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1414,7 +1414,6 @@ if(WIN32)
 	)
 elseif(APPLE)
 	target_link_libraries(PCSX2_FLAGS INTERFACE
-		PkgConfig::GIO
 		PCAP::PCAP
 		LibXml2::LibXml2
 	)


### PR DESCRIPTION
### Description of Changes
Remove gio dependency on macOS

### Rationale behind Changes
gio is no longer needed on macOS

### Suggested Testing Steps
Make sure the CI builds
