### PR TITLE
GS: Check CLUT dirty write on vertex kick

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -155,8 +155,8 @@ void GSClut::Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	m_write.TEX0 = TEX0;
 	m_write.TEXCLUT = TEXCLUT;
-	m_write.dirty = false;
 	m_read.dirty = true;
+	m_write.dirty = false;
 
 	(this->*m_wc[TEX0.CSM][TEX0.CPSM][TEX0.PSM])(TEX0, TEXCLUT);
 }

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -148,7 +148,8 @@ bool GSClut::WriteTest(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 			__assume(0);
 	}
 
-	return m_write.IsDirty(TEX0, TEXCLUT);
+	// CLUT only reloads if PSM is a valid index type, avoid unnecessary flushes
+	return ((TEX0.PSM & 0x7) >= 3) && m_write.IsDirty(TEX0, TEXCLUT);
 }
 
 void GSClut::Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
@@ -157,7 +158,7 @@ void GSClut::Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 	m_write.TEXCLUT = TEXCLUT;
 	m_read.dirty = true;
 	m_write.dirty = false;
-
+	
 	(this->*m_wc[TEX0.CSM][TEX0.CPSM][TEX0.PSM])(TEX0, TEXCLUT);
 }
 

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2546,8 +2546,13 @@ __forceinline void GSState::VertexKick(u32 skip)
 			__assume(0);
 	}
 
-	if (auto_flush && PRIM->TME && (m_context->FRAME.Block() == m_context->TEX0.TBP0))
-		FlushPrim();
+	if (m_context->FRAME.FBMSK != 0xFFFFFFFF)
+	{
+		m_mem.m_clut.Invalidate(m_context->FRAME.Block());
+
+		if (auto_flush && PRIM->TME && (m_context->FRAME.Block() == m_context->TEX0.TBP0))
+			FlushPrim();
+	}
 }
 
 void GSState::GetTextureMinMax(GSVector4i& r, const GIFRegTEX0& TEX0, const GIFRegCLAMP& CLAMP, bool linear)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1009,7 +1009,6 @@ void GSRendererHW::SwSpriteRender()
 	}
 
 	m_tc->InvalidateVideoMem(dpo, m_r);
-	m_mem.m_clut.Invalidate();
 }
 
 bool GSRendererHW::CanUseSwSpriteRender()
@@ -2279,7 +2278,6 @@ bool GSRendererHW::OI_PointListPalette(GSTexture* rt, GSTexture* ds, GSTextureCa
 			m_mem.WritePixel32(x, y, c, FBP, FBW);
 		}
 		m_tc->InvalidateVideoMem(m_context->offset.fb, m_r);
-		m_mem.m_clut.Invalidate();
 		return false;
 	}
 	return true;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -578,8 +578,6 @@ void GSRendererSW::Queue(GSRingHeap::SharedPtr<GSRasterizerData>& item)
 	if (sd->global.sel.fwrite)
 	{
 		m_tc->InvalidatePages(sd->m_fb_pages, sd->m_fpsm);
-
-		m_mem.m_clut.Invalidate(m_context->FRAME.Block());
 	}
 
 	if (sd->global.sel.zwrite)


### PR DESCRIPTION
### Description of Changes
Check CLUT dirty write on vertex kick instead of during the actual draws.

### Rationale behind Changes
Previously the CLUT dirty check was done during the draw, however this is way too late and we're not *actually* invalidating memory at this point, just marking the CLUT as dirty, it will then flush the draws THEN invalidate the CLUT, meaning it is in the correct state for the upcoming draws.  Virtual On was modifying the CLUT in quick succession causing it to end up with an invalid version of the CLUT.

### Suggested Testing Steps
Test games with colour issues in the software renderer (Hardware maybe too, but that has other problems, especially with the Sega games).  General games worth testing too, just to make sure I didn't bust anything.

Fixes #4826