### PR TITLE
VS: Fix location of shaders in project

### DIFF
--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -71,19 +71,19 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="GS\res\glsl\common_header.glsl" />
-    <None Include="GS\res\glsl\convert.glsl" />
-    <None Include="GS\res\glsl\interlace.glsl" />
-    <None Include="GS\res\glsl\merge.glsl" />
-    <None Include="GS\res\glsl\shadeboost.glsl" />
-    <None Include="GS\res\glsl\tfx_fs.glsl" />
-    <None Include="GS\res\glsl\tfx_vgs.glsl" />
-    <None Include="GS\res\convert.fx" />
-    <None Include="GS\res\fxaa.fx" />
-    <None Include="GS\res\interlace.fx" />
-    <None Include="GS\res\merge.fx" />
-    <None Include="GS\res\shadeboost.fx" />
-    <None Include="GS\res\tfx.fx" />
+    <None Include="..\bin\resources\shaders\opengl\common_header.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\convert.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\interlace.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\merge.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\shadeboost.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\tfx_fs.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl" />
+    <None Include="..\bin\resources\shaders\dx11\convert.fx" />
+    <None Include="..\bin\resources\shaders\common\fxaa.fx" />
+    <None Include="..\bin\resources\shaders\dx11\interlace.fx" />
+    <None Include="..\bin\resources\shaders\dx11\merge.fx" />
+    <None Include="..\bin\resources\shaders\dx11\shadeboost.fx" />
+    <None Include="..\bin\resources\shaders\dx11\tfx.fx" />
     <None Include="PAD\Windows\Default.ini" />
     <None Include="Utilities\folderdesc.txt" />
     <None Include="Docs\License.txt" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -330,43 +330,43 @@
     <None Include="PAD\Windows\Default.ini">
       <Filter>System\Ps2\PAD</Filter>
     </None>
-    <None Include="GS\res\glsl\common_header.glsl">
+    <None Include="..\bin\resources\shaders\opengl\common_header.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\glsl\convert.glsl">
+    <None Include="..\bin\resources\shaders\opengl\convert.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\glsl\interlace.glsl">
+    <None Include="..\bin\resources\shaders\opengl\interlace.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\glsl\merge.glsl">
+    <None Include="..\bin\resources\shaders\opengl\merge.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\glsl\shadeboost.glsl">
+    <None Include="..\bin\resources\shaders\opengl\shadeboost.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\glsl\tfx_fs.glsl">
+    <None Include="..\bin\resources\shaders\opengl\tfx_fs.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\glsl\tfx_vgs.glsl">
+    <None Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\convert.fx">
+    <None Include="..\bin\resources\shaders\dx11\convert.fx">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\fxaa.fx">
+    <None Include="..\bin\resources\shaders\common\fxaa.fx">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\interlace.fx">
+    <None Include="..\bin\resources\shaders\dx11\interlace.fx">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\merge.fx">
+    <None Include="..\bin\resources\shaders\dx11\merge.fx">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\shadeboost.fx">
+    <None Include="..\bin\resources\shaders\dx11\shadeboost.fx">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
-    <None Include="GS\res\tfx.fx">
+    <None Include="..\bin\resources\shaders\dx11\tfx.fx">
       <Filter>System\Ps2\GS\Shaders</Filter>
     </None>
   </ItemGroup>


### PR DESCRIPTION
### Description of Changes
Fixes the shaders in VS project so they can be open

### Rationale behind Changes
Nobody updated it when the shaders were moved, this resolves that.

### Suggested Testing Steps
Open VS and make sure you can open all the shader files from the solution tree
