### PR TITLE
Common: Fix GetWorkingDirectory on unix

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1557,6 +1557,7 @@ std::string FileSystem::GetWorkingDirectory()
 		buffer.resize(buffer.size() * 2);
 	}
 
+	buffer.resize(std::strlen(buffer.c_str())); // Remove excess nulls
 	return buffer;
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes an issue where `GetWorkingDirectory` would return a `std::string` containing null characters at the end
Fixes #5163

### Rationale behind Changes
When you concatenated those strings with other strings, the null characters would make most C utilities not notice the concatenation

### Suggested Testing Steps
Attempt to make a block dump in Linux
