### PR TITLE
IPU: Overhaul DMA transfers

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2226,14 +2226,6 @@ SCES-50878:
   name: "Tekken 4"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        // CRC 2251E14D, F48F994A
-        comment=patches by Shadow Lady
-        // IPU BUSY! fix...
-        patch=0,EE,00292424,word,24200001
-        patch=0,EE,00292624,word,00000000
 SCES-50885:
   name: "Ape Escape 2"
   region: "PAL-E"
@@ -4337,12 +4329,6 @@ SCPS-15050:
   name: "Flipnic"
   region: "NTSC-J"
   compat: 5
-  patches:
-    25433CBD:
-      content: |-
-        comment=Patch by Prafull
-        //Fixes hang in some stages due to ipu issues
-        patch=1,EE,0011c000,word,000000000
 SCPS-15051:
   name: "MLB 2003"
   region: "NTSC-J"
@@ -5246,13 +5232,6 @@ SCPS-56006:
   name: "Tekken 4"
   region: "NTSC-K"
   compat: 5
-  patches:
-    35B4028B:
-      content: |-
-        comment=Patches by Shadow Lady
-        // IPU BUSY! fix...
-        patch=0,EE,00290b24,word,24200001
-        patch=0,EE,00290d24,word,00000000
 SCPS-56008:
   name: "Fatal Frame"
   region: "NTSC-K"
@@ -9413,12 +9392,6 @@ SLES-51101:
   name: "Eggo Mania"
   region: "PAL-M3"
   compat: 5
-  patches:
-    30b27954:
-      content: |-
-        comment=Patches by Nachbrenner
-        // Skip IPU synchronisation.
-        patch=0,EE,00111100,word,00000000
 SLES-51107:
   name: "Hitman 2 - Silent Assassin"
   region: "PAL-I"
@@ -29798,14 +29771,6 @@ SLPS-25100:
   name: "Tekken 4"
   region: "NTSC-J"
   compat: 5
-  patches:
-    default:
-      content: |-
-        // CRC 26173F9A, 7c359c94
-        comment=Patches by Shadow Lady
-        // IPU BUSY! fix...
-        patch=0,EE,00291764,word,24200001
-        patch=0,EE,00291964,word,00000000
 SLPS-25102:
   name: "Project Arms"
   region: "NTSC-J"
@@ -34188,13 +34153,6 @@ SLUS-20328:
   name: "Tekken 4"
   region: "NTSC-U"
   compat: 5
-  patches:
-    833FE0A4:
-      content: |-
-        comment=Patches by Shadow Lady
-        // IPU BUSY! fix...
-        patch=0,EE,002917e4,word,24200001
-        patch=0,EE,002919e4,word,00000000
 SLUS-20329:
   name: "Pro Race Driver"
   region: "NTSC-U"
@@ -36142,14 +36100,6 @@ SLUS-20793:
   name: "Gladiator - Sword of Vengeance"
   region: "NTSC-U"
   compat: 5
-  patches:
-    C5DAD771:
-      content: |-
-        author=Prafull
-        // Fix hang before menu screen
-        // The patch causes few artifacts in FMV
-        // Skips part of IPU
-        patch=1,EE,00286674,word,00000000
 SLUS-20794:
   name: "ESPN - Major League Baseball"
   region: "NTSC-U"
@@ -37730,12 +37680,6 @@ SLUS-21157:
   name: "Flipnic - Ultimate Pinball"
   region: "NTSC-U"
   compat: 5
-  patches:
-    EADDB48E:
-      content: |-
-        comment=Patch by Prafull
-        // Fixes ufo shootdown mission hang 
-        patch=1,EE,0011c310,word,00000000
 SLUS-21158:
   name: "Rugby 2005"
   region: "NTSC-U"

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -998,6 +998,7 @@ __noinline void IPUWorker()
 			}
 
 	// success
+	IPU_LOG("IPU Command finished");
 	ipuRegs.ctrl.BUSY = 0;
 	//ipu_cmd.current = 0xffffffff;
 	hwIntcIrq(INTC_IPU);

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -72,7 +72,7 @@ union tIPU_CTRL {
 	bool test(u32 flags) const { return !!(_u32 & flags); }
 	void set_flags(u32 flags) { _u32 |= flags; }
 	void clear_flags(u32 flags) { _u32 &= ~flags; }
-	void reset() { _u32 = 0; }
+	void reset() { _u32 &= 0x7F33F00; }
 };
 
 struct alignas(16) tIPU_BP {

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -121,15 +121,16 @@ struct alignas(16) tIPU_BP {
 
 	__fi bool FillBuffer(u32 bits)
 	{
-		while (FP <= ((BP + bits) / 128))
+		while ((FP * 128) < (BP + bits))
 		{
 			if (ipu_fifo.in.read(&internal_qwc[FP]) == 0)
 			{
 				// Here we *try* to fill the entire internal QWC buffer; however that may not necessarily
 				// be possible -- so if the fill fails we'll only return 0 if we don't have enough
 				// remaining bits in the FIFO to fill the request.
+				// Used to do ((FP!=0) && (BP + bits) <= 128) if we get here there's defo not enough data now though
 
-				return ((FP!=0) && (BP + bits) <= 128);
+				return false;
 			}
 
 			++FP;

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "IPU_Fifo.h"
+#include "IPUdma.h"
 
 #define ipumsk( src ) ( (src) & 0xff )
 #define ipucase( src ) case ipumsk(src)

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -121,7 +121,7 @@ struct alignas(16) tIPU_BP {
 
 	__fi bool FillBuffer(u32 bits)
 	{
-		while (FP < 2)
+		while (FP <= ((BP + bits) / 128))
 		{
 			if (ipu_fifo.in.read(&internal_qwc[FP]) == 0)
 			{

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -38,6 +38,13 @@ void IPU_Fifo_Input::clear()
 	ipuRegs.ctrl.IFC = 0;
 	readpos = 0;
 	writepos = 0;
+
+	// Because the FIFO is drained it will request more data immediately
+	IPU1Status.DataRequested = true;
+	if (ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
+	{
+		CPU_INT(DMAC_TO_IPU, 32);
+	}
 }
 
 void IPU_Fifo_Output::clear()
@@ -88,9 +95,10 @@ int IPU_Fifo_Input::read(void *value)
 	if (g_BP.IFC <= 1)
 	{
 		// IPU FIFO is empty and DMA is waiting so lets tell the DMA we are ready to put data in the FIFO
-		if(cpuRegs.eCycle[4] == 0x9999)
+		IPU1Status.DataRequested = true;
+
+		if(ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
 		{
-			IPU1Status.DataRequested = true;
 			CPU_INT( DMAC_TO_IPU, 32 );
 		}
 

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -85,11 +85,12 @@ int IPU_Fifo_Input::write(u32* pMem, int size)
 int IPU_Fifo_Input::read(void *value)
 {
 	// wait until enough data to ensure proper streaming.
-	if (g_BP.IFC < 3)
+	if (g_BP.IFC <= 1)
 	{
 		// IPU FIFO is empty and DMA is waiting so lets tell the DMA we are ready to put data in the FIFO
 		if(cpuRegs.eCycle[4] == 0x9999)
 		{
+			IPU1Status.DataRequested = true;
 			CPU_INT( DMAC_TO_IPU, 32 );
 		}
 

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -260,15 +260,8 @@ void IPU0dma()
 				break;
 		}
 	}
-	//Fixme ( voodoocycles ):
-	//This was IPU_INT_FROM(readsize*BIAS );
-	//This broke vids in Digital Devil Saga
-	//Note that interrupting based on totalsize is just guessing..
-	
-	IPU_INT_FROM( readsize * BIAS );
-	if (ipuRegs.ctrl.IFC > 0) { IPUProcessInterrupt(); }
 
-	//return readsize;
+	IPU_INT_FROM( readsize * BIAS );
 }
 
 __fi void dmaIPU0() // fromIPU
@@ -282,7 +275,9 @@ __fi void dmaIPU0() // fromIPU
 	// This is because the game sends bad DMA information, starts an IDEC, then sets it to the correct values
 	// but because our IPU is too quick, it messes up the sync between the DMA and IPU.
 	// So this will do until (if) we sort the timing out of IPU, shouldn't cause any problems for games for now.
-	IPU_INT_FROM( 160 );
+	//IPU_INT_FROM( 160 );
+	// Update 22/12/2021 - Doesn't seem to need this now after fixing some FIFO/DMA behaviour
+	IPU0dma();
 }
 
 __fi void dmaIPU1() // toIPU
@@ -314,7 +309,7 @@ __fi void dmaIPU1() // toIPU
 		}
 
 		IPU1Status.DMAMode = DMA_MODE_CHAIN;
-		if(ipuRegs.ctrl.BUSY || IPU1Status.DataRequested)
+		if(IPU1Status.DataRequested)
 			IPU1dma();
 		else
 			cpuRegs.eCycle[4] = 0x9999;
@@ -325,7 +320,7 @@ __fi void dmaIPU1() // toIPU
 			IPU1Status.InProgress = true;
 			IPU1Status.DMAFinished = true;
 			IPU1Status.DMAMode = DMA_MODE_NORMAL;
-			if (ipuRegs.ctrl.BUSY || IPU1Status.DataRequested)
+			if (IPU1Status.DataRequested)
 				IPU1dma();
 			else
 				cpuRegs.eCycle[4] = 0x9999;

--- a/pcsx2/IPU/IPUdma.h
+++ b/pcsx2/IPU/IPUdma.h
@@ -29,6 +29,7 @@ struct IPUStatus {
 	bool stalled;
 	u8 ChainMode;
 	u32 NextMem;
+	bool DataRequested;
 };
 
 #define DMA_MODE_NORMAL 0
@@ -91,3 +92,4 @@ extern void IPU0dma();
 extern int IPU1dma();
 
 extern void ipuDmaReset();
+extern IPUStatus IPU1Status;

--- a/pcsx2/IPU/IPUdma.h
+++ b/pcsx2/IPU/IPUdma.h
@@ -17,70 +17,10 @@
 
 #include "IPU.h"
 
-
-
 struct IPUStatus {
 	bool InProgress;
-	u8 DMAMode;
 	bool DMAFinished;
-	bool IRQTriggered;
-	u8 TagFollow;
-	u32 TagAddr;
-	bool stalled;
-	u8 ChainMode;
-	u32 NextMem;
 	bool DataRequested;
-};
-
-#define DMA_MODE_NORMAL 0
-#define DMA_MODE_CHAIN 1
-#define DMA_MODE_INTERLEAVE 2
-
-#define IPU1_TAG_FOLLOW 0
-#define IPU1_TAG_QWC 1
-#define IPU1_TAG_ADDR 2
-#define IPU1_TAG_NONE 3
-
-union tIPU_DMA
-{
-	struct
-	{
-		bool GIFSTALL  : 1;
-		bool TIE0 :1;
-		bool TIE1 : 1;
-		bool ACTV1 : 1;
-		bool DOTIE1  : 1;
-		bool FIREINT0 : 1;
-		bool FIREINT1 : 1;
-		bool VIFSTALL : 1;
-		bool SIFSTALL : 1;
-	};
-	u32 _u32;
-
-	tIPU_DMA( u32 val ){ _u32 = val; }
-	tIPU_DMA() { }
-
-	bool test(u32 flags) const { return !!(_u32 & flags); }
-	void set_flags(u32 flags) { _u32 |= flags; }
-	void clear_flags(u32 flags) { _u32 &= ~flags; }
-	void reset() { _u32 = 0; }
-	wxString desc() const
-	{
-		wxString temp(L"g_nDMATransfer[");
-
-		if (GIFSTALL) temp += L" GIFSTALL ";
-		if (TIE0) temp += L" TIE0 ";
-		if (TIE1) temp += L" TIE1 ";
-		if (ACTV1) temp += L" ACTV1 ";
-		if (DOTIE1) temp += L" DOTIE1 ";
-		if (FIREINT0) temp += L" FIREINT0 ";
-		if (FIREINT1) temp += L" FIREINT1 ";
-		if (VIFSTALL) temp += L" VIFSTALL ";
-		if (SIFSTALL) temp += L" SIFSTALL ";
-
-		temp += L"]";
-		return temp;
-	}
 };
 
 extern void ipu0Interrupt();
@@ -89,7 +29,7 @@ extern void ipu1Interrupt();
 extern void dmaIPU0();
 extern void dmaIPU1();
 extern void IPU0dma();
-extern int IPU1dma();
+extern void IPU1dma();
 
 extern void ipuDmaReset();
 extern IPUStatus IPU1Status;

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A29 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A2A << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin


### PR DESCRIPTION
### Description of Changes
Change IPU DMA to only refill on request, also tidied up and bugfixed.  Also changed the internal FIFO to only contain the amount of data required to complete the currently in process command. 

Savestate bump required

### Rationale behind Changes
Some games expect the DMA to be in an exact state in order for it to clear itself and continue, else they hang. Top Trumps being one of the said games, but also Test Drive (Had to change how this functions). Additionally previously the internal fifo was always kept at 2 quadwords, even when it didn't need it, this caused some strange/bad behaviour when pausing/resuming the IPU, so it now only keeps enough data to process the command.

Also the DMA design was kind of terrible, so I rewrote it and it fixed some bugs, so that's cool!

### Suggested Testing Steps
Test videos, make sure ones that are known to work still work. Tekken 4, Fuuraiki, Tiger Woods 06 and Onimusha still are broken as much as before.

Fixes #5168 (Top Trumps)
Fixes #4063 (Phase Paradox)
Improves the moving billboard quality in Test Drive (Master has corruption)
Fixes video hang in Eggo Mania/Egg Mania - Eggstreme Madess (ptch no longer required)
Fixes Smackdown Shut Your Mouth Titantrons
Fixes Gladiator - Sword of Vengeance videos (patch no longer required) Partial #3489
Fixes #4360 (Flipnic UFO mission hang)

Also means Mana Khemia and Metal Saga no longer need a gamefix, however I'm leaving it on to be safe, it does no harm.