### PR TITLE
CDVD: Some Error handling, Status+Ready Flag changes and fix CdStop

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -618,7 +618,7 @@ s32 cdvdCtrlTrayOpen()
 
 	DiscSwapTimerSeconds = cdvd.RTC.second; // remember the PS2 time when this happened
 	cdvd.Status = CDVD_STATUS_TRAY_OPEN;
-	cdvd.Ready &= ~CDVD_DRIVE_READY;
+	cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 
 	cdvd.mediaChanged = true;
 
@@ -639,7 +639,7 @@ s32 cdvdCtrlTrayClose()
 	if (!g_GameStarted && g_SkipBiosHack)
 	{
 		DevCon.WriteLn(Color_Green, L"Media already loaded (fast boot)");
-		cdvd.Ready |= CDVD_DRIVE_READY;
+		cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 		cdvd.Status = CDVD_STATUS_PAUSE;
 		cdvd.Tray.trayState = CDVD_DISC_ENGAGED;
 		cdvd.Tray.cdvdActionSeconds = 0;
@@ -647,7 +647,7 @@ s32 cdvdCtrlTrayClose()
 	else
 	{
 		DevCon.WriteLn(Color_Green, L"Detecting media");
-		cdvd.Ready &= ~CDVD_DRIVE_READY;
+		cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 		cdvd.Status = CDVD_STATUS_SEEK;
 		cdvd.Tray.trayState = CDVD_DISC_DETECTING;
 		cdvd.Tray.cdvdActionSeconds = 3;
@@ -795,7 +795,7 @@ void cdvdReset()
 	cdvd.Spinning = false;
 
 	cdvd.sDataIn = 0x40;
-	cdvd.Ready |= CDVD_DRIVE_READY;
+	cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 	cdvd.Status = CDVD_STATUS_PAUSE;
 	cdvd.Speed = 4;
 	cdvd.BlockSize = 2064;
@@ -889,7 +889,7 @@ void cdvdNewDiskCB()
 	{
 		DevCon.WriteLn(Color_Green, L"Ejecting media");
 		cdvd.Status = CDVD_STATUS_TRAY_OPEN;
-		cdvd.Ready &= ~CDVD_DRIVE_READY;
+		cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 		cdvd.Tray.trayState = CDVD_DISC_EJECT;
 		cdvd.mediaChanged = true;
 
@@ -900,7 +900,7 @@ void cdvdNewDiskCB()
 	else if (cdvd.Type > 0)
 	{
 		DevCon.WriteLn(Color_Green, L"Seeking new media");
-		cdvd.Ready &= ~CDVD_DRIVE_READY;
+		cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 		cdvd.Status = CDVD_STATUS_SEEK;
 		cdvd.Tray.trayState = CDVD_DISC_DETECTING;
 		cdvd.Tray.cdvdActionSeconds = 3;
@@ -1043,7 +1043,7 @@ __fi void cdvdActionInterrupt()
 	{
 		case cdvdAction_Seek:
 			cdvd.Spinning = true;
-			cdvd.Ready |= CDVD_DRIVE_READY; //check (rama)
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			cdvd.Sector = cdvd.SeekToSector;
 			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
@@ -1053,7 +1053,7 @@ __fi void cdvdActionInterrupt()
 		case cdvdAction_Standby:
 			DevCon.Warning("CDVD Standby Call");
 			cdvd.Spinning = true; //check (rama)
-			cdvd.Ready |= CDVD_DRIVE_READY; //check (rama)
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			cdvd.Sector = cdvd.SeekToSector;
 			cdvd.Status = CDVD_STATUS_PAUSE;
 			cdvd.nextSectorsBuffered = 0;
@@ -1062,7 +1062,7 @@ __fi void cdvdActionInterrupt()
 
 		case cdvdAction_Stop:
 			cdvd.Spinning = false;
-			cdvd.Ready |= CDVD_DRIVE_READY;
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			cdvd.Sector = 0;
 			cdvd.Status = CDVD_STATUS_STOP;
 			break;
@@ -1070,12 +1070,12 @@ __fi void cdvdActionInterrupt()
 		case cdvdAction_Break:
 			// Make sure the cdvd action state is pretty well cleared:
 			DevCon.WriteLn("CDVD Break Call");
-			if (!(cdvd.Ready & 0x40))
+			if ((cdvd.Ready & 0x80))
 				cdvd.Error = 1; // Abort
 
 			cdvd.Reading = 0;
 			cdvd.Readed = 0;
-			cdvd.Ready |= CDVD_DRIVE_READY; // should be CDVD_READY1 or something else?
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON | CDVD_DRIVE_ERROR; // should be CDVD_READY1 or something else?
 			cdvd.Status = CDVD_STATUS_PAUSE; //Break stops the command in progress it doesn't stop the drive. Formula 2001
 			cdvd.RErr = 0;
 			break;
@@ -1102,7 +1102,7 @@ __fi void cdvdReadInterrupt()
 {
 	//Console.WriteLn("cdvdReadInterrupt %x %x %x %x %x", cpuRegs.interrupt, cdvd.Readed, cdvd.Reading, cdvd.nSectors, (HW_DMA3_BCR_H16 * HW_DMA3_BCR_L16) *4);
 
-	cdvd.Ready &= ~CDVD_DRIVE_READY;
+	cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 	cdvd.Status = CDVD_STATUS_READ;
 	cdvd.WaitingDMA = false;
 	
@@ -1189,7 +1189,7 @@ __fi void cdvdReadInterrupt()
 			// Setting the data ready flag fixes a black screen loading issue in
 			// Street Fighter Ex3 (NTSC-J version).
 			cdvdSetIrq();
-			cdvd.Ready |= CDVD_DRIVE_READY;
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 
 			cdvd.Status = CDVD_STATUS_PAUSE;
 			//DevCon.Warning("Scheduling interrupt in %d cycles", cdvd.ReadTime - ((cdvd.BlockSize / 4) * 12));
@@ -1208,7 +1208,7 @@ __fi void cdvdReadInterrupt()
 			cdvdSetIrq();
 			//psxHu32(0x1070) |= 0x4;
 			iopIntcIrq(2);
-			cdvd.Ready |= CDVD_DRIVE_READY;
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 
 			cdvd.Status = CDVD_STATUS_PAUSE;
 			return;
@@ -1235,7 +1235,7 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode)
 	uint seektime;
 	bool isSeeking = cdvd.nCommand == N_CD_SEEK;
 
-	cdvd.Ready &= ~(CDVD_DRIVE_READY | CDVD_DRIVE_DATARDY);
+	cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 	cdvd.Reading = 1;
 	cdvd.Readed = 0;
 	// Okay so let's explain this, since people keep messing with it in the past and just poking it.
@@ -1352,7 +1352,7 @@ void cdvdUpdateTrayState()
 				case CDVD_DISC_SEEKING:
 				case CDVD_DISC_ENGAGED:
 					cdvd.Tray.trayState = CDVD_DISC_ENGAGED;
-					cdvd.Ready |= CDVD_DRIVE_READY;
+					cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 					if (CDVDsys_GetSourceType() != CDVD_SourceType::NoDisc)
 					{
 						DevCon.WriteLn(Color_Green, L"Media ready to read");
@@ -1570,6 +1570,7 @@ static bool cdvdReadErrorHandler()
 	{
 		DevCon.Warning("Bad Sector Count Error");
 		cdvd.Error = 0x21; // Number of read sectors abnormal
+		cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON | CDVD_DRIVE_ERROR;
 		cdvdSetIrq();
 		return false;
 	}
@@ -1578,6 +1579,7 @@ static bool cdvdReadErrorHandler()
 	{
 		DevCon.Warning("Invalid Sector Error");
 		cdvd.Error = 0x20; // Sector position is abnormal
+		cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON | CDVD_DRIVE_ERROR;
 		cdvdSetIrq();
 		return false;
 	}
@@ -1625,7 +1627,7 @@ static void cdvdWrite04(u8 rt)
 			// A few games rely on PAUSE setting the Status correctly.
 			// However we should probably stop any read in progress too, just to be safe
 			psxRegs.interrupt &= ~(1 << IopEvt_Cdvd);
-			cdvd.Ready |= CDVD_DRIVE_READY;
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			cdvdSetIrq();
 			//After Pausing needs to buffer the next sector
 			cdvd.Status = CDVD_STATUS_PAUSE;

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1652,6 +1652,7 @@ static void cdvdWrite04(u8 rt)
 	{
 		case N_CD_SYNC: // CdSync
 		case N_CD_NOP: // CdNop_
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			cdvdSetIrq();
 			break;
 
@@ -1659,7 +1660,7 @@ static void cdvdWrite04(u8 rt)
 
 			// Seek to sector zero.  The cdvdStartSeek function will simulate
 			// spinup times if needed.
-
+			cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 			DevCon.Warning("CdStandby : %d", rt);
 			cdvd.Action = cdvdAction_Standby;
 			cdvd.ReadTime = cdvdBlockReadTime((CDVD_MODE_TYPE)cdvdIsDVD());
@@ -1672,6 +1673,7 @@ static void cdvdWrite04(u8 rt)
 		case N_CD_STOP: // CdStop
 			DevCon.Warning("CdStop : %d", rt);
 			cdvd.Action = cdvdAction_Stop;
+			cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 			cdvd.nextSectorsBuffered = 0;
 			psxRegs.interrupt &= ~(1 << IopEvt_CdvdSectorReady);
 			cdvdUpdateStatus(CDVD_STATUS_SPIN);
@@ -1692,6 +1694,7 @@ static void cdvdWrite04(u8 rt)
 
 		case N_CD_SEEK: // CdSeek
 			cdvd.Action = cdvdAction_Seek;
+			cdvd.Ready = CDVD_DRIVE_BUSY | CDVD_DRIVE_DEV9CON;
 			cdvd.ReadTime = cdvdBlockReadTime((CDVD_MODE_TYPE)cdvdIsDVD());
 			CDVD_INT(cdvdStartSeek(*(uint*)(cdvd.Param + 0), (CDVD_MODE_TYPE)cdvdIsDVD()));
 			cdvdUpdateStatus(CDVD_STATUS_SEEK);
@@ -1920,6 +1923,7 @@ static void cdvdWrite04(u8 rt)
 			cdvdSetIrq();
 			HW_DMA3_CHCR &= ~0x01000000;
 			psxDmaInterrupt(3);
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			//After reading the TOC it needs to go back to buffer the next sector
 			cdvdUpdateStatus(CDVD_STATUS_PAUSE);
 			cdvd.nextSectorsBuffered = 0;
@@ -1937,6 +1941,7 @@ static void cdvdWrite04(u8 rt)
 			cdvdSetIrq();
 			//After reading the key it needs to go back to buffer the next sector
 			cdvdUpdateStatus(CDVD_STATUS_PAUSE);
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
 			cdvd.nextSectorsBuffered = 0;
 			CDVDSECTORREADY_INT(cdvd.ReadTime);
 		}

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1128,6 +1128,17 @@ __fi void cdvdReadInterrupt()
 		cdvd.Sector = cdvd.SeekToSector;
 		CDVD_LOG("Cdvd Seek Complete at iopcycle=%8.8x.", psxRegs.cycle);
 	}
+
+	if (cdvd.Sector > cdvd.MaxSector)
+	{
+		DevCon.Warning("Read past end of disc Sector %d Max Sector %d", cdvd.Sector, cdvd.MaxSector);
+		cdvd.Error = 0x32; // Outermost track reached during playback
+		cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON | CDVD_DRIVE_ERROR;
+		cdvdUpdateStatus(CDVD_STATUS_PAUSE);
+		cdvd.WaitingDMA = false;
+		cdvdSetIrq();
+		return;
+	}
 	
 	if (cdvd.Reading)
 	{
@@ -1251,7 +1262,7 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode)
 	// Update - Apparently all that was rubbish and some games don't like it. WRC was the one in this scenario which hated SEEK |ZPAUSE, so just putting it back to pause for now.
 	// We should really run some tests for this behaviour.
 	
-	cdvdUpdateStatus(CDVD_STATUS_PAUSE);
+	cdvdUpdateStatus(CDVD_STATUS_SEEK);
 
 	if (!cdvd.Spinning)
 	{
@@ -1650,9 +1661,18 @@ static void cdvdWrite04(u8 rt)
 
 	switch (rt)
 	{
-		case N_CD_SYNC: // CdSync
 		case N_CD_NOP: // CdNop_
 			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
+			cdvdSetIrq();
+			break;
+		case N_CD_RESET: // CdSync
+			Console.WriteLn("CDVD: Reset NCommand");
+			cdvd.Ready = CDVD_DRIVE_READY | CDVD_DRIVE_DEV9CON;
+			cdvd.SCMDParamP = 0;
+			cdvd.SCMDParamC = 0;
+			cdvdUpdateStatus(CDVD_STATUS_STOP);
+			cdvd.Spinning = false;
+			memzero(cdvd.SCMDResult);
 			cdvdSetIrq();
 			break;
 
@@ -2051,7 +2071,7 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 		CDVD_LOG("cdvdWrite16: SCMD %s (%x) (ParamP = %x)", sCmdName[rt], rt, cdvd.SCMDParamP);
 
 		cdvd.sCommand = rt;
-		cdvd.SCMDResult[0] = 0; // assume success -- failures will overwrite this with an error code.
+		memzero(cdvd.SCMDResult);
 
 		switch (rt)
 		{

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -97,6 +97,7 @@ struct cdvdStruct
 	u8 Error;
 	u8 PwOff;
 	u8 Status;
+	u8 StatusSticky;
 	u8 Type;
 	u8 sCommand;
 	u8 sDataIn;
@@ -151,7 +152,6 @@ struct cdvdStruct
 	u32 MaxSector;    // Current disc max sector.
 	u32 ReadTime;     // Avg. time to read one block of data (in Iop cycles)
 	bool Spinning;    // indicates if the Cdvd is spinning or needs a spinup delay
-	bool mediaChanged;
 	cdvdTrayTimer Tray;
 	u8 nextSectorsBuffered;
 };

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -148,12 +148,12 @@ struct cdvdStruct
 	u8 TrayTimeout;
 	u8 Action;        // the currently scheduled emulated action
 	u32 SeekToSector; // Holds the destination sector during seek operations.
+	u32 MaxSector;    // Current disc max sector.
 	u32 ReadTime;     // Avg. time to read one block of data (in Iop cycles)
 	bool Spinning;    // indicates if the Cdvd is spinning or needs a spinup delay
 	bool mediaChanged;
 	cdvdTrayTimer Tray;
 	u8 nextSectorsBuffered;
-	bool triggerDataReady;
 };
 
 extern cdvdStruct cdvd;

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -104,13 +104,16 @@ struct cdvdStruct
 	u8 sDataOut;
 	u8 HowTo;
 
-	u8 Param[32];
-	u8 Result[32];
+	u8 NCMDParam[16];
+	u8 SCMDParam[16];
+	u8 SCMDResult[16];
 
-	u8 ParamC;
-	u8 ParamP;
-	u8 ResultC;
-	u8 ResultP;
+	u8 NCMDParamC;
+	u8 NCMDParamP;
+	u8 SCMDParamC;
+	u8 SCMDParamP;
+	u8 SCMDResultC;
+	u8 SCMDResultP;
 
 	u8 CBlockIndex;
 	u8 COffset;

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -95,7 +95,7 @@ struct cdvdStruct
 	u8 nCommand;
 	u8 Ready;
 	u8 Error;
-	u8 PwOff;
+	u8 IntrStat;
 	u8 Status;
 	u8 StatusSticky;
 	u8 Type;

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -82,11 +82,25 @@ enum cdvdStatus
 	CDVD_STATUS_EMERGENCY = 0x20,
 };
 
+/* from PS2Tek https://psi-rockin.github.io/ps2tek/#cdvdioports
+1F402005h N command status (R)
+  0     Error (1=error occurred)
+  1     Unknown/unused
+  2     DEV9 device connected (1=HDD/network adapter connected)
+  3     Unknown/unused
+  4     Test mode
+  5     Power off ready
+  6     Drive status (1=ready)
+  7     Busy executing NCMD
+
+*/
 enum cdvdready
 {
-	CDVD_DRIVE_DATARDY = 0x2,
+	CDVD_DRIVE_ERROR = 0x01,
+	CDVD_DRIVE_DEV9CON = 0x04,
 	CDVD_DRIVE_PWOFF = 0x20,
 	CDVD_DRIVE_READY = 0x40,
+	CDVD_DRIVE_BUSY = 0x80,
 };
 
 // Cdvd actions tell the emulator how and when to respond to certain requests.

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -38,6 +38,8 @@ without proper emulation of the cdvd status flag it also tends to break things.
 
 */
 
+/* Old IRQ structure
+
 enum CdvdIrqId
 {
 	Irq_None = 0,
@@ -48,6 +50,16 @@ enum CdvdIrqId
 	Irq_Error,
 	Irq_NotReady
 
+};
+*/
+
+enum CdvdIrqId
+{
+	Irq_None = 0,
+	Irq_CommandComplete = 0,
+	Irq_POffReady = 2,
+	Irq_Eject,
+	Irq_BSPower, //PS1 IRQ not used
 };
 
 /* Cdvd.Status bits and their meaning

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -196,8 +196,8 @@ static const char* nCmdName[0x100] = {
 
 enum nCmds
 {
-	N_CD_SYNC = 0x00,          // CdSync
-	N_CD_NOP = 0x01,           // CdNop
+	N_CD_NOP = 0x00,           // CdNop
+	N_CD_RESET = 0x01,         // CdReset
 	N_CD_STANDBY = 0x02,       // CdStandby
 	N_CD_STOP = 0x03,          // CdStop
 	N_CD_PAUSE = 0x04,         // CdPause

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -107,6 +107,16 @@ static int CheckDiskTypeFS(int baseType)
 		{
 		}
 
+		// PS2 Linux disc 2, doesn't have a System.CNF or a normal ELF
+		try
+		{
+			IsoFile file(rootdir, L"P2L_0100.02;1");
+			return CDVD_TYPE_PS2DVD;
+		}
+		catch (Exception::FileNotFound&)
+		{
+		}
+
 		try
 		{
 			IsoFile file(rootdir, L"PSX.EXE;1");

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -1074,6 +1074,9 @@ void psxDma3(u32 madr, u32 bcr, u32 chcr)
 
 			break;
 		case 0x41000200:
+			if (HW_DMA3_BCR_H16 == 0)
+				break;
+
 			if (cdvd.WaitingDMA)
 			{
 				PSX_INT(IopEvt_CdvdRead, (cdvd.BlockSize / 4) * 12); //Data should be already buffered so simulate DMA time

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -31,7 +31,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A2A << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A2B << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin


### PR DESCRIPTION
### Description of Changes
Adjusts the behaviour if the game request 0 or < 0 sectors

### Rationale behind Changes
This isn't right, but Armored Core 3 and Spyro Enter the Dragonfly kinda screw everything up, so this seems to resolve it.

### Suggested Testing Steps
boot games, if they work, we're good :)

Fixes #5155
Fixes issue with Spyro - Enter the Dragonfly TLB misses/failure to boot, patch still required however.
Fixes issue with bad sector LSN on Aberanbou Princess trial 
Animation Battle - Recca no Honou improved, still hangs in later FMV's without patch
Handling of bad sector counts in Evergrace demo and Armored Core 3

Savestate bump required, sorry