### PR TITLE
Log: Restore BIOS Found message

### DIFF
--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -119,6 +119,8 @@ static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& descriptio
 			version = strtol(vermaj, (char**)NULL, 0) << 8;
 			version |= strtol(vermin, (char**)NULL, 0);
 			foundRomVer = true;
+
+			Console.WriteLn("Bios Found: %s", description.c_str());
 		}
 
 		if ((rd.fileSize % 0x10) == 0)


### PR DESCRIPTION
### Description of Changes
Restore "BIOS Found:" message in console log window

### Rationale behind Changes
It got removed, probably by accident, but it's good for support

### Suggested Testing Steps
boot a game or go in to your settings, make sure the BIOS prints the found BIOS file.
