### PR TITLE
GS: Fix looping over pages of textures with massive strides

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -1819,6 +1819,8 @@ GSOffset::PageLooper GSOffset::pageLooperForRect(const GSVector4i& rect) const
 	out.yCnt = botPg - topPg;
 	out.firstRowPgXStart = out.midRowPgXStart = out.lastRowPgXStart = rect.left >> m_pageShiftX;
 	out.firstRowPgXEnd = out.midRowPgXEnd = out.lastRowPgXEnd = ((rect.right + m_pageMask.x) >> m_pageShiftX) + !aligned;
+	out.slowPath = static_cast<u32>(out.yCnt * out.yInc + out.midRowPgXEnd - out.midRowPgXStart) > MAX_PAGES;
+
 	// Page-aligned bp is easy, all tiles touch their lower page but not the upper
 	if (aligned)
 		return out;


### PR DESCRIPTION
### Description of Changes
Fixes an issue where GS crashed with games that used textures that wrapped around GS memory multiple times
Fixes #5143 

### Rationale behind Changes
Less crashy more runny

### Suggested Testing Steps
[Test this GSdump](https://github.com/PCSX2/pcsx2/files/7738567/gs_20211217165447.zip) (and yes it's compressed twice because GitHub doesn't let you upload xz files)
Test the actual game in #5143
Test other games listed in #5179 (who knows, maybe they had this issue too)

