### PR TITLE
GS/OpenGL: Fix incorrect VAO cleanup

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -103,7 +103,7 @@ GSDeviceOGL::~GSDeviceOGL()
 
 	// Clean vertex buffer state
 	if (m_vertex_array_object)
-		glDeleteVertexArrays(0, &m_vertex_array_object);
+		glDeleteVertexArrays(1, &m_vertex_array_object);
 	m_vertex_stream_buffer.reset();
 	m_index_stream_buffer.reset();
 

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -100,10 +100,18 @@ namespace PboPool
 
 		for (GLsync fence : m_fence)
 		{
-			glDeleteSync(fence);
+			if (fence != 0)
+			{
+				glDeleteSync(fence);
+				fence = 0;
+			}
 		}
 
-		glDeleteBuffers(1, &m_buffer);
+		if (m_buffer != 0)
+		{
+			glDeleteBuffers(1, &m_buffer);
+			m_buffer = 0;
+		}
 	}
 
 	void BindPbo()


### PR DESCRIPTION
This wasn't an issue in wx, since the whole context/device gets torn down and recreated when you pause/unpause, or change settings.

But on Qt it is, since the context/device is preserved for a faster/lighter settings apply.