### PR TITLE
CDVD: Check file actually opened before proceeding

### DIFF
--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -221,7 +221,8 @@ bool InputIsoFile::Open(std::string srcfile, bool testOnly)
 		m_reader = new FlatFileReader(EmuConfig.CdvdShareWrite);
 	}
 
-	m_reader->Open(m_filename);
+	if (!m_reader->Open(m_filename))
+		return false;
 
 	// It might actually be a blockdump file.
 	// Check that before continuing with the FlatFileReader.


### PR DESCRIPTION
If you loaded an invalid file, particularly with compression, the file open may fail, leading to a division by zero (on block size), or trying to read from nothing.
