### PR TITLE
GS-hw: More blend work

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -230,23 +230,6 @@ const CRC::Game CRC::m_games[] =
 	{0xD3FFC263, SMTNocturne, KO, 0},
 	{0x84D1A8DA, SMTNocturne, KO, 0},
 	{0x0B8AB37B, RozenMaidenGebetGarden, JP, 0},
-	{0xA33AF77A, TenchuFS, US, 0},
-	{0x64C58FB4, TenchuFS, US, 0},
-	{0xE7CCCB1E, TenchuFS, EU, 0},
-	{0x89E63B40, TenchuFS, RU, 0}, // Beta
-	{0x1969B19A, TenchuFS, ES, 0}, // PAL Spanish
-	{0xBF0DC4CE, TenchuFS, DE, 0},
-	{0x696BBEC3, TenchuFS, KO, 0},
-	{0x525C1994, TenchuFS, ASIA, 0},
-	{0x0D73BBCD, TenchuFS, KO, 0},
-	{0x735A10C2, TenchuFS, JP, 0}, // Tenchu Kurenai
-	{0xAFBFB287, TenchuWoH, KO, 0},
-	{0xAFBEC8B7, TenchuWoH, KO, 0},
-	{0x767E383D, TenchuWoH, US, 0},
-	{0x83261085, TenchuWoH, DE, 0}, // PAL German
-	{0x7FA1510D, TenchuWoH, EU, 0}, // PAL ES, IT
-	{0xC8DADF58, TenchuWoH, EU, 0},
-	{0x13DD9957, TenchuWoH, JP, 0},
 	{0x506644B3, BigMuthaTruckers, EU, 0},
 	{0x90F0D852, BigMuthaTruckers, US, 0},
 	{0x92624842, BigMuthaTruckers, US, 0},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -126,8 +126,6 @@ public:
 		TalesOfLegendia,
 		TalesofSymphonia,
 		Tekken5,
-		TenchuFS,
-		TenchuWoH,
 		TheIncredibleHulkUD,
 		TombRaiderAnniversary,
 		TombRaiderLegend,

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -802,20 +802,6 @@ bool GSC_TriAceGames(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_TenchuGames(const GSFrameInfo& fi, int& skip)
-{
-	if (skip == 0)
-	{
-		if (fi.TME && fi.TPSM == PSM_PSMZ16 && fi.FPSM == PSM_PSMCT16 && fi.FBMSK == 0x03FFF)
-		{
-			// Depth is fine, blending issues remain, crc hack can be adjusted to skip blend wall/fog only.
-			skip = 3;
-		}
-	}
-
-	return true;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Aggressive only hack
 ////////////////////////////////////////////////////////////////////////////////
@@ -1048,8 +1034,6 @@ void GSState::SetupCrcHack()
 		// Accurate Blending
 		lut[CRC::GetaWay] = GSC_GetaWayGames;            // Blending High
 		lut[CRC::GetaWayBlackMonday] = GSC_GetaWayGames; // Blending High
-		lut[CRC::TenchuFS] = GSC_TenchuGames;
-		lut[CRC::TenchuWoH] = GSC_TenchuGames;
 
 		// These games emulate a stencil buffer with the alpha channel of the RT (too slow to move to Aggressive)
 		// Needs at least Basic Blending,

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -206,13 +206,13 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 			case AccBlendLevel::Medium:
 				// Enable Fbmask emulation excluding triangle class because it is quite slow.
 				// Exclude 0x80000000 because Genji needs sw blending, otherwise it breaks some effects.
-				enable_fbmask_emulation = ((m_vt.m_primclass != GS_TRIANGLE_CLASS) && (m_context->FRAME.FBMSK != 0x80000000));
+				enable_fbmask_emulation = (m_vt.m_primclass != GS_TRIANGLE_CLASS);
 				break;
 			case AccBlendLevel::Basic:
 				// Enable Fbmask emulation excluding triangle class because it is quite slow.
 				// Exclude 0x80000000 because Genji needs sw blending, otherwise it breaks some effects.
 				// Also exclude fbmask emulation on texture shuffle just in case, it is probably safe tho.
-				enable_fbmask_emulation = (!m_texture_shuffle && (m_vt.m_primclass != GS_TRIANGLE_CLASS) && (m_context->FRAME.FBMSK != 0x80000000));
+				enable_fbmask_emulation = !m_texture_shuffle && (m_vt.m_primclass != GS_TRIANGLE_CLASS);
 				break;
 			case AccBlendLevel::Minimum:
 				break;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -588,6 +588,9 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	}
 	else
 	{
+		// FBMASK already reads the fb so it is safe to enable sw blend when there is no overlap.
+		const bool fbmask_no_overlap = !accumulation_blend && m_conf.require_one_barrier
+			&& m_conf.ps.fbmask && m_prim_overlap == PRIM_OVERLAP_NO;
 		switch (GSConfig.AccurateBlendingUnit)
 		{
 			case AccBlendLevel::Ultra:
@@ -601,7 +604,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 			case AccBlendLevel::Basic:
-				sw_blending |= accumulation_blend || blend_non_recursive;
+				sw_blending |= accumulation_blend || blend_non_recursive || fbmask_no_overlap;
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:
 				break;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -589,8 +589,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	else
 	{
 		// FBMASK already reads the fb so it is safe to enable sw blend when there is no overlap.
-		const bool fbmask_no_overlap = !accumulation_blend && m_conf.require_one_barrier
-			&& m_conf.ps.fbmask && m_prim_overlap == PRIM_OVERLAP_NO;
+		const bool fbmask_no_overlap = !accumulation_blend && m_conf.require_one_barrier && m_conf.ps.fbmask && m_prim_overlap == PRIM_OVERLAP_NO;
+
 		switch (GSConfig.AccurateBlendingUnit)
 		{
 			case AccBlendLevel::Ultra:
@@ -604,6 +604,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 			case AccBlendLevel::Basic:
+				// Disable accumulation blend when there is fbmask with no overlap, will be faster.
+				accumulation_blend &= !fbmask_no_overlap;
 				sw_blending |= accumulation_blend || blend_non_recursive || fbmask_no_overlap;
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -199,20 +199,12 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 			case AccBlendLevel::Ultra:
 			case AccBlendLevel::Full:
 			case AccBlendLevel::High:
-				// Fully enable Fbmask emulation like on opengl, note misses sw blending to work as opengl on some games (Genji).
-				// Debug
-				enable_fbmask_emulation = true;
-				break;
 			case AccBlendLevel::Medium:
-				// Enable Fbmask emulation excluding triangle class because it is quite slow.
-				// Exclude 0x80000000 because Genji needs sw blending, otherwise it breaks some effects.
-				enable_fbmask_emulation = (m_vt.m_primclass != GS_TRIANGLE_CLASS);
+				enable_fbmask_emulation = true;
 				break;
 			case AccBlendLevel::Basic:
 				// Enable Fbmask emulation excluding triangle class because it is quite slow.
-				// Exclude 0x80000000 because Genji needs sw blending, otherwise it breaks some effects.
-				// Also exclude fbmask emulation on texture shuffle just in case, it is probably safe tho.
-				enable_fbmask_emulation = !m_texture_shuffle && (m_vt.m_primclass != GS_TRIANGLE_CLASS);
+				enable_fbmask_emulation = (m_vt.m_primclass != GS_TRIANGLE_CLASS);
 				break;
 			case AccBlendLevel::Minimum:
 				break;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -581,6 +581,9 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				[[fallthrough]];
 			case AccBlendLevel::Basic:
 				sw_blending |= impossible_or_free_blend;
+				// Do not run BLEND MIX if sw blending is already present, it's less accurate
+				blend_mix &= !sw_blending;
+				sw_blending |= blend_mix;
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:
 				break;
@@ -607,17 +610,13 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				// Disable accumulation blend when there is fbmask with no overlap, will be faster.
 				accumulation_blend &= !fbmask_no_overlap;
 				sw_blending |= accumulation_blend || blend_non_recursive || fbmask_no_overlap;
+				// Do not run BLEND MIX if sw blending is already present, it's less accurate
+				blend_mix &= !sw_blending;
+				sw_blending |= blend_mix;
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:
 				break;
 		}
-	}
-
-	// Do not run BLEND MIX if sw blending is already present, it's less accurate
-	if (GSConfig.AccurateBlendingUnit != AccBlendLevel::Minimum)
-	{
-		blend_mix &= !sw_blending;
-		sw_blending |= blend_mix;
 	}
 
 	// Color clip


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Allow to sample the framebuffer when primitives don't overlap on d3d11.
All: check when prims don't overlap.

High: When there is no blend mix, accu blend, recursive.

Full: When there is no accu blend, or recursive.
alpha is higher than 1.

Ultra: When there is no accu blend or recursive blend.

Allow to check for overlap on d3d11.
Support sw colclip when prims don't overlap on d3d11.
Support sw pabe when prims don't overlap on d3d11.

GS-hw: Remove fbmask check for Genji. 
Fb will be read when primitives don't overlap, no need for the mask check now.

GS-hw: Enable sw blend when prims don't overlap on basic blend with fbmask.
FBMASK already reads the fb so let's allow it to run sw blending since there will be no cost, only if fbmask is already running.

GS-hw: Disable accumulation blend when there is fbmask with no overlap. 
Using a mix of hw/sw will be slower, so let's just do full sw blend, we already read the fb.

GS-hw: Move blend mix condition to blend switch case. 
Cleaner.

GS-hw: Move fbmask for texture shuffle on Basic level.
Shouldn't be that slow, right?
Also update comments.

Previous High level is now Medium.

GS-hw: Always enable full sw blend on full barrier, disable accumulation mode (hw/sw blend).

Full barrier requires full sw blend, disable accumulation mode for it (sw fbmask, date_barrier).
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, especially dx11.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test blending, mostly dx11 levels.