### PR TITLE
GS: Unify constant buffers between renderers

### DIFF
--- a/bin/resources/shaders/opengl/common_header.glsl
+++ b/bin/resources/shaders/opengl/common_header.glsl
@@ -48,7 +48,6 @@ out gl_PerVertex {
 layout(std140, binding = 15) uniform cb15
 {
     ivec4 ScalingFactor;
-    ivec4 ChannelShuffle;
 
     int EMODA;
     int EMODC;
@@ -91,8 +90,10 @@ layout(std140, binding = 21) uniform cb21
 
     vec4 MinMax;
 
-    vec2 pad_cb21;
+    ivec4 ChannelShuffle;
+
     vec2 TC_OffsetHack;
+    vec2 pad_cb21;
 
     mat4 DitherMatrix;
 };

--- a/bin/resources/shaders/opengl/common_header.glsl
+++ b/bin/resources/shaders/opengl/common_header.glsl
@@ -47,8 +47,6 @@ out gl_PerVertex {
 #ifdef FRAGMENT_SHADER
 layout(std140, binding = 15) uniform cb15
 {
-    ivec4 ScalingFactor;
-
     int EMODA;
     int EMODC;
     ivec2 pad_cb15;

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -226,9 +226,9 @@ void ps_convert_rgba_8i()
     int txN  = tb.x | (int(gl_FragCoord.x) & 7);
     int txH  = tb.x | ((int(gl_FragCoord.x) + 4) & 7);
 
-    txN *= ScalingFactor.x;
-    txH *= ScalingFactor.x;
-    ty  *= ScalingFactor.y;
+    txN *= PS_SCALE_FACTOR;
+    txH *= PS_SCALE_FACTOR;
+    ty  *= PS_SCALE_FACTOR;
 
     // TODO investigate texture gather
     vec4 cN = texelFetch(TextureSampler, ivec2(txN, ty), 0);

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -282,7 +282,7 @@ ivec2 clamp_wrap_uv_depth(ivec2 uv)
 
 vec4 sample_depth(vec2 st)
 {
-    vec2 uv_f = vec2(clamp_wrap_uv_depth(ivec2(st))) * vec2(ScalingFactor.xy) * vec2(1.0f/16.0f);
+    vec2 uv_f = vec2(clamp_wrap_uv_depth(ivec2(st))) * vec2(float(PS_SCALE_FACTOR)) * vec2(1.0f/16.0f);
     ivec2 uv = ivec2(uv_f);
 
     vec4 t = vec4(0.0f);
@@ -619,7 +619,7 @@ void ps_dither(inout vec3 C)
     #if PS_DITHER == 2
     ivec2 fpos = ivec2(gl_FragCoord.xy);
     #else
-    ivec2 fpos = ivec2(gl_FragCoord.xy / ScalingFactor.x);
+    ivec2 fpos = ivec2(gl_FragCoord.xy / float(PS_SCALE_FACTOR));
     #endif
     C += DitherMatrix[fpos.y&3][fpos.x&3];
 #endif

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -299,11 +299,6 @@ void GSDevice::StretchRect(GSTexture* sTex, GSTexture* dTex, const GSVector4& dR
 	StretchRect(sTex, GSVector4(0, 0, 1, 1), dTex, dRect, shader, linear);
 }
 
-GSTexture* GSDevice::GetCurrent()
-{
-	return m_current;
-}
-
 void GSDevice::Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, const GSVector2i& fs, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c)
 {
 	// KH:COM crashes at startup when booting *through the bios* due to m_merge being NULL.

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -485,7 +485,7 @@ struct GSHWDrawConfig
 		ColorMaskSelector colormask;
 		DepthStencilSelector depth;
 		PSSelector ps;
-		PSConstantBuffer cb_ps;
+		float ps_aref;
 	} alpha_second_pass;
 };
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -337,107 +337,80 @@ struct GSHWDrawConfig
 		GSVector2 texture_offset;
 		GSVector2 point_size;
 		GSVector2i max_depth;
-		VSConstantBuffer()
+		__fi VSConstantBuffer()
 		{
 			memset(this, 0, sizeof(*this));
 		}
-		VSConstantBuffer(const VSConstantBuffer& other)
+		__fi VSConstantBuffer(const VSConstantBuffer& other)
 		{
 			memcpy(this, &other, sizeof(*this));
 		}
-		VSConstantBuffer& operator=(const VSConstantBuffer& other)
+		__fi VSConstantBuffer& operator=(const VSConstantBuffer& other)
 		{
 			new (this) VSConstantBuffer(other);
 			return *this;
 		}
-		bool operator==(const VSConstantBuffer& other) const
+		__fi bool operator==(const VSConstantBuffer& other) const
 		{
 			return BitEqual(*this, other);
 		}
-		bool operator!=(const VSConstantBuffer& other) const
+		__fi bool operator!=(const VSConstantBuffer& other) const
 		{
 			return !(*this == other);
+		}
+		__fi bool Update(const VSConstantBuffer& other)
+		{
+			if (*this == other)
+				return false;
+
+			memcpy(this, &other, sizeof(*this));
+			return true;
 		}
 	};
 	struct alignas(16) PSConstantBuffer
 	{
-		union
-		{
-			struct
-			{
-				u8 fog_color[3];
-				u8 aref;
-			};
-			u32 fog_color_aref;
-		};
-		union
-		{
-			struct
-			{
-				u8 r, g, b, a;
-			} fbmask;
-			u32 fbmask_int;
-		};
-		u32 max_depth;
-		union
-		{
-			struct
-			{
-				u8 ta0;
-				u8 ta1;
-				u8 _pad;
-				u8 alpha_fix;
-			};
-			u32 ta_af;
-		};
-		union
-		{
-			struct
-			{
-				u8 blue_mask;
-				u8 blue_shift;
-				u8 green_mask;
-				u8 green_shift;
-			} channel_shuffle;
-			u32 channel_shuffle_int;
-		};
-		union
-		{
-			struct
-			{
-				u16 umsk;
-				u16 vmsk;
-				u16 ufix;
-				u16 vfix;
-			};
-			u64 uv_msk_fix;
-		};
-		GIFRegDIMX dither_matrix;
-		GSVector2 tc_offset;
-		GSVector4 texture_size; // xy → PS2 size, wz → emulator size
+		GSVector4 FogColor_AREF;
+		GSVector4 WH;
+		GSVector4 TA_MaxDepth_Af;
+		GSVector4i MskFix;
+		GSVector4i FbMask;
 
-		GSVector4 half_texel;
-		GSVector4 uv_min_max;
-		PSConstantBuffer()
+		GSVector4 HalfTexel;
+		GSVector4 MinMax;
+		GSVector4i ChannelShuffle;
+		GSVector2 TCOffsetHack;
+		float pad1[2];
+
+		GSVector4 DitherMatrix[4];
+
+		__fi PSConstantBuffer()
 		{
 			memset(this, 0, sizeof(*this));
 		}
-		PSConstantBuffer(const PSConstantBuffer& other)
+		__fi PSConstantBuffer(const PSConstantBuffer& other)
 		{
 			memcpy(this, &other, sizeof(*this));
 		}
-		PSConstantBuffer& operator=(const PSConstantBuffer& other)
+		__fi PSConstantBuffer& operator=(const PSConstantBuffer& other)
 		{
 			new (this) PSConstantBuffer(other);
 			return *this;
 		}
-		bool operator==(const PSConstantBuffer& other) const
+		__fi bool operator==(const PSConstantBuffer& other) const
 		{
 			return BitEqual(*this, other);
 		}
-		bool operator!=(const PSConstantBuffer& other) const
+		__fi bool operator!=(const PSConstantBuffer& other) const
 		{
 			return !(*this == other);
+		}
+		__fi bool Update(const PSConstantBuffer& other)
+		{
+			if (*this == other)
+				return false;
+
+			memcpy(this, &other, sizeof(*this));
+			return true;
 		}
 	};
 	struct BlendState

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -135,7 +135,7 @@ struct HWBlend
 	u16 flags, op, src, dst;
 };
 
-struct GSHWDrawConfig
+struct alignas(16) GSHWDrawConfig
 {
 	enum class Topology: u8
 	{
@@ -476,9 +476,6 @@ struct GSHWDrawConfig
 	DestinationAlphaMode destination_alpha;
 	bool datm;
 
-	VSConstantBuffer cb_vs;
-	PSConstantBuffer cb_ps;
-
 	struct AlphaSecondPass
 	{
 		bool enable;
@@ -487,6 +484,9 @@ struct GSHWDrawConfig
 		PSSelector ps;
 		float ps_aref;
 	} alpha_second_pass;
+
+	VSConstantBuffer cb_vs;
+	PSConstantBuffer cb_ps;
 };
 
 class GSDevice : public GSAlignedClass<32>

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -459,6 +459,7 @@ struct alignas(16) GSHWDrawConfig
 	u32 indices_per_prim; ///< Number of indices that make up one primitive
 	const std::vector<size_t>* drawlist; ///< For reducing barriers on sprites
 	GSVector4i scissor; ///< Scissor rect
+	GSVector4i drawarea; ///< Area in the framebuffer which will be modified.
 	Topology topology;  ///< Draw topology
 
 	GSSelector gs;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -616,8 +616,8 @@ public:
 
 	virtual void RenderHW(GSHWDrawConfig& config) {}
 
-	FeatureSupport Features() { return m_features; }
-	GSTexture* GetCurrent();
+	__fi FeatureSupport Features() const { return m_features; }
+	__fi GSTexture* GetCurrent() const { return m_current; }
 
 	void Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, const GSVector2i& fs, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c);
 	void Interlace(const GSVector2i& ds, int field, int mode, float yoffset);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1583,7 +1583,17 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	if (config.alpha_second_pass.enable)
 	{
 		preprocessSel(config.alpha_second_pass.ps);
-		SetupPS(config.alpha_second_pass.ps, &config.alpha_second_pass.cb_ps, config.sampler);
+		if (config.cb_ps.FogColor_AREF.a != config.alpha_second_pass.ps_aref)
+		{
+			config.cb_ps.FogColor_AREF.a = config.alpha_second_pass.ps_aref;
+			SetupPS(config.alpha_second_pass.ps, &config.cb_ps, config.sampler);
+		}
+		else
+		{
+			// ps cbuffer hasn't changed, so don't bother checking
+			SetupPS(config.alpha_second_pass.ps, nullptr, config.sampler);
+		}
+
 		SetupOM(config.alpha_second_pass.depth, convertSel(config.alpha_second_pass.colormask, config.blend), config.blend.factor);
 
 		DrawIndexedPrimitive();

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1514,7 +1514,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	if (config.destination_alpha != GSHWDrawConfig::DestinationAlphaMode::Off)
 	{
-		const GSVector4 src = GSVector4(config.scissor) / GSVector4(config.ds->GetSize()).xyxy();
+		const GSVector4 src = GSVector4(config.drawarea) / GSVector4(config.ds->GetSize()).xyxy();
 		const GSVector4 dst = src * 2.0f - 1.0f;
 
 		GSVertexPT1 vertices[] =
@@ -1532,10 +1532,10 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	if (config.ps.hdr)
 	{
 		const GSVector2i size = config.rt->GetSize();
-		const GSVector4 dRect(config.scissor);
+		const GSVector4 dRect(config.drawarea);
 		const GSVector4 sRect = dRect / GSVector4(size.x, size.y).xyxy();
 		hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::FloatColor);
-		hdr_rt->CommitRegion(GSVector2i(config.scissor.z, config.scissor.w));
+		hdr_rt->CommitRegion(GSVector2i(config.drawarea.z, config.drawarea.w));
 		// Warning: StretchRect must be called before BeginScene otherwise
 		// vertices will be overwritten. Trust me you don't want to do that.
 		StretchRect(config.rt, sRect, hdr_rt, dRect, ShaderConvert::COPY, false);
@@ -1604,7 +1604,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	if (hdr_rt)
 	{
 		const GSVector2i size = config.rt->GetSize();
-		const GSVector4 dRect(config.scissor);
+		const GSVector4 dRect(config.drawarea);
 		const GSVector4 sRect = dRect / GSVector4(size.x, size.y).xyxy();
 		StretchRect(hdr_rt, sRect, config.rt, dRect, ShaderConvert::MOD_256, false);
 		Recycle(hdr_rt);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -31,129 +31,13 @@ struct GSVertexShader11
 class GSDevice11 final : public GSDevice
 {
 public:
-#pragma pack(push, 1)
-
-	struct alignas(32) VSConstantBuffer
-	{
-		GSVector4 VertexScale;
-		GSVector4 VertexOffset;
-		GSVector4 Texture_Scale_Offset;
-		GSVector2i MaxDepth;
-		GSVector2i pad_vscb;
-
-		VSConstantBuffer()
-		{
-			VertexScale          = GSVector4::zero();
-			VertexOffset         = GSVector4::zero();
-			Texture_Scale_Offset = GSVector4::zero();
-			MaxDepth             = GSVector2i(0);
-			pad_vscb             = GSVector2i(0);
-		}
-
-		__forceinline bool Update(const VSConstantBuffer* cb)
-		{
-			GSVector4i* a = (GSVector4i*)this;
-			GSVector4i* b = (GSVector4i*)cb;
-
-			if (!((a[0] == b[0]) & (a[1] == b[1]) & (a[2] == b[2]) & (a[3] == b[3])).alltrue())
-			{
-				a[0] = b[0];
-				a[1] = b[1];
-				a[2] = b[2];
-				a[3] = b[3];
-
-				return true;
-			}
-
-			return false;
-		}
-	};
-
-	struct alignas(32) PSConstantBuffer
-	{
-		GSVector4 FogColor_AREF;
-		GSVector4 HalfTexel;
-		GSVector4 WH;
-		GSVector4 MinMax;
-		GSVector4 MinF_TA;
-		GSVector4i MskFix;
-		GSVector4i ChannelShuffle;
-		GSVector4i FbMask;
-
-		GSVector4 TC_OffsetHack;
-		GSVector4 Af_MaxDepth;
-		GSVector4 DitherMatrix[4];
-
-		PSConstantBuffer()
-		{
-			FogColor_AREF = GSVector4::zero();
-			HalfTexel = GSVector4::zero();
-			WH = GSVector4::zero();
-			MinMax = GSVector4::zero();
-			MinF_TA = GSVector4::zero();
-			MskFix = GSVector4i::zero();
-			ChannelShuffle = GSVector4i::zero();
-			FbMask = GSVector4i::zero();
-			Af_MaxDepth = GSVector4::zero();
-
-			DitherMatrix[0] = GSVector4::zero();
-			DitherMatrix[1] = GSVector4::zero();
-			DitherMatrix[2] = GSVector4::zero();
-			DitherMatrix[3] = GSVector4::zero();
-		}
-
-		__forceinline bool Update(const PSConstantBuffer* cb)
-		{
-			GSVector4i* a = (GSVector4i*)this;
-			GSVector4i* b = (GSVector4i*)cb;
-
-			if (!((a[0] == b[0]) /*& (a[1] == b1)*/ & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4]) & (a[5] == b[5]) &
-				(a[6] == b[6]) & (a[7] == b[7]) & (a[9] == b[9]) & // if WH matches HalfTexel does too
-				(a[10] == b[10]) & (a[11] == b[11]) & (a[12] == b[12]) & (a[13] == b[13])).alltrue())
-			{
-				a[0] = b[0];
-				a[1] = b[1];
-				a[2] = b[2];
-				a[3] = b[3];
-				a[4] = b[4];
-				a[5] = b[5];
-				a[6] = b[6];
-				a[7] = b[7];
-				a[9] = b[9];
-
-				a[10] = b[10];
-				a[11] = b[11];
-				a[12] = b[12];
-				a[13] = b[13];
-
-				return true;
-			}
-
-			return false;
-		}
-	};
-
-	struct alignas(32) GSConstantBuffer
-	{
-		GSVector2 PointSize;
-
-		GSConstantBuffer()
-		{
-			PointSize = GSVector2(0);
-		}
-
-		__forceinline bool Update(const GSConstantBuffer* cb)
-		{
-			return true;
-		}
-	};
-
 	using VSSelector = GSHWDrawConfig::VSSelector;
 	using GSSelector = GSHWDrawConfig::GSSelector;
 	using PSSelector = GSHWDrawConfig::PSSelector;
 	using PSSamplerSelector = GSHWDrawConfig::SamplerSelector;
 	using OMDepthStencilSelector = GSHWDrawConfig::DepthStencilSelector;
 
+#pragma pack(push, 1)
 	struct OMBlendSelector
 	{
 		union
@@ -332,7 +216,6 @@ private:
 	std::unordered_map<u32, GSVertexShader11> m_vs;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_vs_cb;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11GeometryShader>> m_gs;
-	wil::com_ptr_nothrow<ID3D11Buffer> m_gs_cb;
 	std::unordered_map<u64, wil::com_ptr_nothrow<ID3D11PixelShader>> m_ps;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ps_cb;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11SamplerState>> m_ps_ss;
@@ -340,9 +223,8 @@ private:
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11DepthStencilState>> m_om_dss;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11BlendState>> m_om_bs;
 
-	VSConstantBuffer m_vs_cb_cache;
-	GSConstantBuffer m_gs_cb_cache;
-	PSConstantBuffer m_ps_cb_cache;
+	GSHWDrawConfig::VSConstantBuffer m_vs_cb_cache;
+	GSHWDrawConfig::PSConstantBuffer m_ps_cb_cache;
 
 	std::unique_ptr<GSTexture> m_font;
 	std::unique_ptr<GSTexture11> m_download_tex;
@@ -415,9 +297,9 @@ public:
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL);
 
 	bool CreateTextureFX();
-	void SetupVS(VSSelector sel, const VSConstantBuffer* cb);
-	void SetupGS(GSSelector sel, const GSConstantBuffer* cb);
-	void SetupPS(PSSelector sel, const PSConstantBuffer* cb, PSSamplerSelector ssel);
+	void SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer* cb);
+	void SetupGS(GSSelector sel);
+	void SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel);
 	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 afix);
 
 	void RenderHW(GSHWDrawConfig& config) final;

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -196,7 +196,7 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 		i = m_ps.try_emplace(sel.key, std::move(ps)).first;
 	}
 
-	if (m_ps_cb_cache.Update(*cb))
+	if (cb && m_ps_cb_cache.Update(*cb))
 	{
 		m_ctx->UpdateSubresource(m_ps_cb.get(), 0, NULL, cb, 0, 0);
 	}

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -1494,16 +1494,16 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	const GSVector4& hacked_scissor = m_channel_shuffle ? GSVector4(0, 0, 1024, 1024) : m_context->scissor.in;
 	const GSVector4i scissor = GSVector4i(GSVector4(rtscale).xyxy() * hacked_scissor).rintersect(GSVector4i(rtsize).zwxy());
 
-	const GSVector4i commitRect = ComputeBoundingBox(rtscale, rtsize);
-	m_conf.scissor = (DATE && !DATE_GL45) ? scissor.rintersect(commitRect) : scissor;
+	m_conf.drawarea = scissor.rintersect(ComputeBoundingBox(rtscale, rtsize));
+	m_conf.scissor = (DATE && !DATE_GL45) ? m_conf.drawarea : scissor;
 
 	SetupIA(sx, sy);
 
 	if (rt)
-		rt->CommitRegion(GSVector2i(commitRect.z, commitRect.w));
+		rt->CommitRegion(GSVector2i(m_conf.drawarea.z, m_conf.drawarea.w));
 
 	if (ds)
-		ds->CommitRegion(GSVector2i(commitRect.z, commitRect.w));
+		ds->CommitRegion(GSVector2i(m_conf.drawarea.z, m_conf.drawarea.w));
 
 	m_conf.alpha_second_pass.enable = ate_second_pass;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -165,7 +165,7 @@ void GSRendererNew::EmulateZbuffer()
 		}
 		else if (!m_context->ZBUF.ZMSK)
 		{
-			m_conf.cb_ps.max_depth = max_z;
+			m_conf.cb_ps.TA_MaxDepth_Af.z = static_cast<float>(max_z) * 0x1p-32f;
 			m_conf.ps.zclamp = 1;
 		}
 	}
@@ -282,10 +282,10 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 
 		if (m_conf.ps.fbmask && enable_fbmask_emulation)
 		{
-			m_conf.cb_ps.fbmask.r = rg_mask;
-			m_conf.cb_ps.fbmask.g = rg_mask;
-			m_conf.cb_ps.fbmask.b = ba_mask;
-			m_conf.cb_ps.fbmask.a = ba_mask;
+			m_conf.cb_ps.FbMask.r = rg_mask;
+			m_conf.cb_ps.FbMask.g = rg_mask;
+			m_conf.cb_ps.FbMask.b = ba_mask;
+			m_conf.cb_ps.FbMask.a = ba_mask;
 
 			// No blending so hit unsafe path.
 			if (!PRIM->ABE || !m_dev->Features().texture_barrier)
@@ -318,7 +318,7 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 
 		if (m_conf.ps.fbmask)
 		{
-			m_conf.cb_ps.fbmask_int = m_context->FRAME.FBMSK;
+			m_conf.cb_ps.FbMask = fbmask_v.u8to32();
 			// Only alpha is special here, I think we can take a very unsafe shortcut
 			// Alpha isn't blended on the GS but directly copyied into the RT.
 			//
@@ -456,10 +456,7 @@ void GSRendererNew::EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::
 					const int green_shift = 8 - blue_shift;
 
 					GL_INS("Green/Blue channel (%d, %d)", blue_shift, green_shift);
-					m_conf.cb_ps.channel_shuffle.blue_mask   = blue_mask;
-					m_conf.cb_ps.channel_shuffle.blue_shift  = blue_shift;
-					m_conf.cb_ps.channel_shuffle.green_mask  = green_mask;
-					m_conf.cb_ps.channel_shuffle.green_shift = green_shift;
+					m_conf.cb_ps.ChannelShuffle = GSVector4i(blue_mask, blue_shift, green_mask, green_shift);
 					m_conf.ps.channel = ChannelFetch_GXBY;
 					m_context->FRAME.FBMSK = 0x00FFFFFF;
 				}
@@ -741,7 +738,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_GL42, bool& DATE_GL45)
 
 		// Require the fix alpha vlaue
 		if (ALPHA.C == 2)
-			m_conf.cb_ps.alpha_fix = ALPHA.FIX;
+			m_conf.cb_ps.TA_MaxDepth_Af.a = static_cast<float>(ALPHA.FIX) / 128.0f;
 	}
 	else
 	{
@@ -822,8 +819,10 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 		}
 
 		// Shuffle is a 16 bits format, so aem is always required
-		m_conf.cb_ps.ta0 = m_env.TEXA.TA0;
-		m_conf.cb_ps.ta1 = m_env.TEXA.TA1;
+		GSVector4 ta(m_env.TEXA & GSVector4i::x000000ff());
+		ta /= 255.0f;
+		m_conf.cb_ps.TA_MaxDepth_Af.x = ta.x;
+		m_conf.cb_ps.TA_MaxDepth_Af.y = ta.y;
 
 		// The purpose of texture shuffle is to move color channel. Extra interpolation is likely a bad idea.
 		bilinear &= m_vt.IsLinear();
@@ -843,8 +842,10 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 		// Don't upload AEM if format is 32 bits
 		if (cpsm.fmt)
 		{
-			m_conf.cb_ps.ta0 = m_env.TEXA.TA0;
-			m_conf.cb_ps.ta1 = m_env.TEXA.TA1;
+			GSVector4 ta(m_env.TEXA & GSVector4i::x000000ff());
+			ta /= 255.0f;
+			m_conf.cb_ps.TA_MaxDepth_Af.x = ta.x;
+			m_conf.cb_ps.TA_MaxDepth_Af.y = ta.y;
 		}
 
 		// Select the index format
@@ -926,23 +927,20 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 
 	m_conf.ps.fst = !!PRIM->FST;
 
-	m_conf.cb_ps.texture_size = WH;
-	m_conf.cb_ps.half_texel = GSVector4(-0.5f, 0.5f).xxyy() / WH.zwzw();
+	m_conf.cb_ps.WH = WH;
+	m_conf.cb_ps.HalfTexel = GSVector4(-0.5f, 0.5f).xxyy() / WH.zwzw();
 	if (complex_wms_wmt)
 	{
-		m_conf.cb_ps.umsk = m_context->CLAMP.MINU;
-		m_conf.cb_ps.vmsk = m_context->CLAMP.MINV;
-		m_conf.cb_ps.ufix = m_context->CLAMP.MAXU;
-		m_conf.cb_ps.vfix = m_context->CLAMP.MAXV;
-		m_conf.cb_ps.uv_min_max = GSVector4(GSVector4i::loadl(&m_conf.cb_ps.uv_msk_fix).u16to32()) / WH.xyxy();
+		m_conf.cb_ps.MskFix = GSVector4i(m_context->CLAMP.MINU, m_context->CLAMP.MINV, m_context->CLAMP.MAXU, m_context->CLAMP.MAXV);;
+		m_conf.cb_ps.MinMax = GSVector4(m_conf.cb_ps.MskFix) / WH.xyxy();
 	}
 	else if (trilinear_manual)
 	{
 		// Reuse uv_min_max for mipmap parameter to avoid an extension of the UBO
-		m_conf.cb_ps.uv_min_max.x = (float)m_context->TEX1.K / 16.0f;
-		m_conf.cb_ps.uv_min_max.y = float(1 << m_context->TEX1.L);
-		m_conf.cb_ps.uv_min_max.z = float(m_lod.x); // Offset because first layer is m_lod, dunno if we can do better
-		m_conf.cb_ps.uv_min_max.w = float(m_lod.y);
+		m_conf.cb_ps.MinMax.x = (float)m_context->TEX1.K / 16.0f;
+		m_conf.cb_ps.MinMax.y = float(1 << m_context->TEX1.L);
+		m_conf.cb_ps.MinMax.z = float(m_lod.x); // Offset because first layer is m_lod, dunno if we can do better
+		m_conf.cb_ps.MinMax.w = float(m_lod.y);
 	}
 	else if (trilinear_auto)
 	{
@@ -952,16 +950,16 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	// TC Offset Hack
 	m_conf.ps.tcoffsethack = m_userhacks_tcoffset;
 	GSVector4 tc_oh_ts = GSVector4(1 / 16.0f, 1 / 16.0f, m_userhacks_tcoffset_x, m_userhacks_tcoffset_y) / WH.xyxy();
+	m_conf.cb_ps.TCOffsetHack = GSVector2(tc_oh_ts.z, tc_oh_ts.w);
 	m_conf.cb_vs.texture_scale = GSVector2(tc_oh_ts.x, tc_oh_ts.y);
-	m_conf.cb_ps.tc_offset = GSVector2(tc_oh_ts.z, tc_oh_ts.w);
 
 	// Must be done after all coordinates math
 	if (m_context->HasFixedTEX0() && !PRIM->FST)
 	{
 		m_conf.ps.invalid_tex0 = 1;
 		// Use invalid size to denormalize ST coordinate
-		m_conf.cb_ps.texture_size.x = (float)(1 << m_context->stack.TEX0.TW);
-		m_conf.cb_ps.texture_size.y = (float)(1 << m_context->stack.TEX0.TH);
+		m_conf.cb_ps.WH.x = (float)(1 << m_context->stack.TEX0.TW);
+		m_conf.cb_ps.WH.y = (float)(1 << m_context->stack.TEX0.TH);
 
 		// We can't handle m_target with invalid_tex0 atm due to upscaling
 		ASSERT(!tex->m_target);
@@ -1115,27 +1113,27 @@ void GSRendererNew::EmulateATST(GSHWDrawConfig::PSConstantBuffer& cb, GSHWDrawCo
 	switch (atst)
 	{
 		case ATST_LESS:
-			cb.aref = m_context->TEST.AREF;
+			cb.FogColor_AREF.a = (float)m_context->TEST.AREF - 0.1f;
 			ps.atst = 1;
 			break;
 		case ATST_LEQUAL:
-			cb.aref = m_context->TEST.AREF + 1;
+			cb.FogColor_AREF.a = (float)m_context->TEST.AREF - 0.1f + 1.0f;
 			ps.atst = 1;
 			break;
 		case ATST_GEQUAL:
-			cb.aref = m_context->TEST.AREF;
+			cb.FogColor_AREF.a = (float)m_context->TEST.AREF - 0.1f;
 			ps.atst = 2;
 			break;
 		case ATST_GREATER:
-			cb.aref = m_context->TEST.AREF + 1;
+			cb.FogColor_AREF.a = (float)m_context->TEST.AREF - 0.1f + 1.0f;
 			ps.atst = 2;
 			break;
 		case ATST_EQUAL:
-			cb.aref = m_context->TEST.AREF;
+			cb.FogColor_AREF.a = (float)m_context->TEST.AREF;
 			ps.atst = 3;
 			break;
 		case ATST_NOTEQUAL:
-			cb.aref = m_context->TEST.AREF;
+			cb.FogColor_AREF.a = (float)m_context->TEST.AREF;
 			ps.atst = 4;
 			break;
 		case ATST_NEVER: // Draw won't be done so no need to implement it in shader
@@ -1395,16 +1393,19 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 		GL_DBG("DITHERING mode ENABLED (%d)", m_dithering);
 
 		m_conf.ps.dither = m_dithering;
-		m_conf.cb_ps.dither_matrix.U64 = m_env.DIMX.U64 & 0x7777777777777777ull;
+		m_conf.cb_ps.DitherMatrix[0] = GSVector4(m_env.DIMX.DM00, m_env.DIMX.DM01, m_env.DIMX.DM02, m_env.DIMX.DM03);
+		m_conf.cb_ps.DitherMatrix[1] = GSVector4(m_env.DIMX.DM10, m_env.DIMX.DM11, m_env.DIMX.DM12, m_env.DIMX.DM13);
+		m_conf.cb_ps.DitherMatrix[2] = GSVector4(m_env.DIMX.DM20, m_env.DIMX.DM21, m_env.DIMX.DM22, m_env.DIMX.DM23);
+		m_conf.cb_ps.DitherMatrix[3] = GSVector4(m_env.DIMX.DM30, m_env.DIMX.DM31, m_env.DIMX.DM32, m_env.DIMX.DM33);
 	}
 
 	if (PRIM->FGE)
 	{
 		m_conf.ps.fog = 1;
 
-		m_conf.cb_ps.fog_color[0] = m_env.FOGCOL.FCR;
-		m_conf.cb_ps.fog_color[1] = m_env.FOGCOL.FCG;
-		m_conf.cb_ps.fog_color[2] = m_env.FOGCOL.FCB;
+		const GSVector4 fc = GSVector4::rgba32(m_env.FOGCOL.U32[0]);
+		// Blend AREF to avoid to load a random value for alpha (dirty cache)
+		m_conf.cb_ps.FogColor_AREF = fc.blend32<8>(m_conf.cb_ps.FogColor_AREF);
 	}
 
 	// Warning must be done after EmulateZbuffer

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.h
@@ -43,7 +43,7 @@ private:
 	inline void EmulateBlending(bool& DATE_GL42, bool& DATE_GL45);
 	inline void EmulateTextureSampler(const GSTextureCache::Source* tex);
 	inline void EmulateZbuffer();
-	inline void EmulateATST(GSHWDrawConfig::PSConstantBuffer& cb, GSHWDrawConfig::PSSelector& ps, bool pass_2);
+	inline void EmulateATST(float& AREF, GSHWDrawConfig::PSSelector& ps, bool pass_2);
 
 public:
 	GSRendererNew();

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2018,14 +2018,14 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		case GSHWDrawConfig::DestinationAlphaMode::Full:
 			break; // No setup
 		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking:
-			InitPrimDateTexture(config.rt, config.scissor);
+			InitPrimDateTexture(config.rt, config.drawarea);
 			break;
 		case GSHWDrawConfig::DestinationAlphaMode::StencilOne:
 			ClearStencil(config.ds, 1);
 			break;
 		case GSHWDrawConfig::DestinationAlphaMode::Stencil:
 		{
-			const GSVector4 src = GSVector4(config.scissor) / GSVector4(config.ds->GetSize()).xyxy();
+			const GSVector4 src = GSVector4(config.drawarea) / GSVector4(config.ds->GetSize()).xyxy();
 			const GSVector4 dst = src * 2.f - 1.f;
 			GSVertexPT1 vertices[] =
 			{
@@ -2043,12 +2043,12 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	{
 		GSVector2i size = config.rt->GetSize();
 		hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::FloatColor);
-		hdr_rt->CommitRegion(GSVector2i(config.scissor.z, config.scissor.w));
+		hdr_rt->CommitRegion(GSVector2i(config.drawarea.z, config.drawarea.w));
 		OMSetRenderTargets(hdr_rt, config.ds, &config.scissor);
 
 		// save blend state, since BlitRect destroys it
 		const bool old_blend = GLState::blend;
-		BlitRect(config.rt, config.scissor, config.rt->GetSize(), false, false);
+		BlitRect(config.rt, config.drawarea, config.rt->GetSize(), false, false);
 		if (old_blend)
 		{
 			GLState::blend = old_blend;
@@ -2167,7 +2167,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	if (hdr_rt)
 	{
 		GSVector2i size = config.rt->GetSize();
-		GSVector4 dRect(config.scissor);
+		GSVector4 dRect(config.drawarea);
 		const GSVector4 sRect = dRect / GSVector4(size.x, size.y).xyxy();
 		StretchRect(hdr_rt, sRect, config.rt, dRect, ShaderConvert::MOD_256, false);
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2005,8 +2005,11 @@ static GSDeviceOGL::VSSelector convertSel(const GSHWDrawConfig::VSSelector sel)
 
 void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 {
-	glScissor(config.scissor.x, config.scissor.y, config.scissor.width(), config.scissor.height());
-	GLState::scissor = config.scissor;
+	if (!GLState::scissor.eq(config.scissor))
+	{
+		glScissor(config.scissor.x, config.scissor.y, config.scissor.width(), config.scissor.height());
+		GLState::scissor = config.scissor;
+	}
 
 	// Destination Alpha Setup
 	switch (config.destination_alpha)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -183,7 +183,6 @@ public:
 
 	struct alignas(32) MiscConstantBuffer
 	{
-		GSVector4i ScalingFactor;
 		GSVector4i EMOD_AC;
 
 		MiscConstantBuffer() { memset(this, 0, sizeof(*this)); }
@@ -195,6 +194,7 @@ public:
 private:
 	std::unique_ptr<GL::Context> m_gl_context;
 	int m_mipmap;
+	int m_upscale_multiplier;
 	TriFiltering m_filter;
 
 	static bool m_debug_gl_call;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -123,41 +123,6 @@ public:
 class GSDeviceOGL final : public GSDevice
 {
 public:
-	struct alignas(32) VSConstantBuffer
-	{
-		GSVector4 Vertex_Scale_Offset;
-
-		GSVector4 Texture_Scale_Offset;
-
-		GSVector2 PointSize;
-		GSVector2i MaxDepth;
-
-		VSConstantBuffer()
-		{
-			Vertex_Scale_Offset  = GSVector4::zero();
-			Texture_Scale_Offset = GSVector4::zero();
-			PointSize            = GSVector2(0);
-			MaxDepth             = GSVector2i(0);
-		}
-
-		__forceinline bool Update(const VSConstantBuffer* cb)
-		{
-			GSVector4i* a = (GSVector4i*)this;
-			GSVector4i* b = (GSVector4i*)cb;
-
-			if (!((a[0] == b[0]) & (a[1] == b[1]) & (a[2] == b[2])).alltrue())
-			{
-				a[0] = b[0];
-				a[1] = b[1];
-				a[2] = b[2];
-
-				return true;
-			}
-
-			return false;
-		}
-	};
-
 	struct VSSelector
 	{
 		union
@@ -211,67 +176,6 @@ public:
 		}
 	};
 
-	struct alignas(32) PSConstantBuffer
-	{
-		GSVector4 FogColor_AREF;
-		GSVector4 WH;
-		GSVector4 TA_MaxDepth_Af;
-		GSVector4i MskFix;
-		GSVector4i FbMask;
-
-		GSVector4 HalfTexel;
-		GSVector4 MinMax;
-		GSVector4 TC_OH;
-
-		GSVector4 DitherMatrix[4];
-
-		PSConstantBuffer()
-		{
-			FogColor_AREF  = GSVector4::zero();
-			HalfTexel      = GSVector4::zero();
-			WH             = GSVector4::zero();
-			TA_MaxDepth_Af = GSVector4::zero();
-			MinMax         = GSVector4::zero();
-			MskFix         = GSVector4i::zero();
-			TC_OH          = GSVector4::zero();
-			FbMask         = GSVector4i::zero();
-
-			DitherMatrix[0] = GSVector4::zero();
-			DitherMatrix[1] = GSVector4::zero();
-			DitherMatrix[2] = GSVector4::zero();
-			DitherMatrix[3] = GSVector4::zero();
-		}
-
-		__forceinline bool Update(const PSConstantBuffer* cb)
-		{
-			GSVector4i* a = (GSVector4i*)this;
-			GSVector4i* b = (GSVector4i*)cb;
-
-			// if WH matches both HalfTexel and TC_OH_TS do too
-			if (!((a[0] == b[0]) & (a[1] == b[1]) & (a[2] == b[2]) & (a[3] == b[3]) & (a[4] == b[4]) & (a[6] == b[6])
-				& (a[8] == b[8]) & (a[9] == b[9]) & (a[10] == b[10]) & (a[11] == b[11])).alltrue())
-			{
-				// Note previous check uses SSE already, a plain copy will be faster than any memcpy
-				a[0] = b[0];
-				a[1] = b[1];
-				a[2] = b[2];
-				a[3] = b[3];
-				a[4] = b[4];
-				a[5] = b[5];
-				a[6] = b[6];
-
-				a[8] = b[8];
-				a[9] = b[9];
-				a[10] = b[10];
-				a[11] = b[11];
-
-				return true;
-			}
-
-			return false;
-		}
-	};
-
 	using PSSelector = GSHWDrawConfig::PSSelector;
 	using PSSamplerSelector = GSHWDrawConfig::SamplerSelector;
 	using OMDepthStencilSelector = GSHWDrawConfig::DepthStencilSelector;
@@ -280,7 +184,6 @@ public:
 	struct alignas(32) MiscConstantBuffer
 	{
 		GSVector4i ScalingFactor;
-		GSVector4i ChannelShuffle;
 		GSVector4i EMOD_AC;
 
 		MiscConstantBuffer() { memset(this, 0, sizeof(*this)); }
@@ -379,8 +282,8 @@ private:
 
 	GLuint m_palette_ss;
 
-	VSConstantBuffer m_vs_cb_cache;
-	PSConstantBuffer m_ps_cb_cache;
+	GSHWDrawConfig::VSConstantBuffer m_vs_cb_cache;
+	GSHWDrawConfig::PSConstantBuffer m_ps_cb_cache;
 	MiscConstantBuffer m_misc_cb_cache;
 
 	std::unique_ptr<GSTexture> m_font;
@@ -476,7 +379,7 @@ public:
 	void SelfShaderTest();
 
 	void SetupPipeline(const VSSelector& vsel, const GSSelector& gsel, const PSSelector& psel);
-	void SetupCB(const VSConstantBuffer* vs_cb, const PSConstantBuffer* ps_cb);
+	void SetupCB(const GSHWDrawConfig::VSConstantBuffer* vs_cb, const GSHWDrawConfig::PSConstantBuffer* ps_cb);
 	void SetupCBMisc(const GSVector4i& channel);
 	void SetupSampler(PSSamplerSelector ssel);
 	void SetupOM(OMDepthStencilSelector dssel);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -379,8 +379,6 @@ public:
 	void SelfShaderTest();
 
 	void SetupPipeline(const VSSelector& vsel, const GSSelector& gsel, const PSSelector& psel);
-	void SetupCB(const GSHWDrawConfig::VSConstantBuffer* vs_cb, const GSHWDrawConfig::PSConstantBuffer* ps_cb);
-	void SetupCBMisc(const GSVector4i& channel);
 	void SetupSampler(PSSamplerSelector ssel);
 	void SetupOM(OMDepthStencilSelector dssel);
 	GLuint GetSamplerID(PSSamplerSelector ssel);


### PR DESCRIPTION
### Description of Changes

Trying to claw back some of the performance loss (~5% in extreme cases) from #5138. Copying all those structs around up to 20,000 times a second isn't free. Brief testing suggests a 10% performance uplift in draw call bound scenarios when running GSDumps.

### Rationale behind Changes

Better performance, less code.

### Suggested Testing Steps

Test a range of games to make sure no regressions were introduced. GS dumps would be fine too.
