### PR TITLE
FreeBSD: fix compilation

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1534,7 +1534,7 @@ std::string FileSystem::GetProgramPath()
 	int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
 	char buffer[PATH_MAX];
 	size_t cb = sizeof(buffer) - 1;
-	int res = sysctl(mib, countof(mib), buffer, &cb, nullptr, 0);
+	int res = sysctl(mib, std::size(mib), buffer, &cb, nullptr, 0);
 	if (res != 0)
 		return {};
 


### PR DESCRIPTION
Following changes should fix FreeBSD build after [a083343](https://github.com/PCSX2/pcsx2/commit/a083343c6e918b890395ab463de1e0c1b030ddf2) and [9533fa2](https://github.com/PCSX2/pcsx2/commit/9533fa25c3f0c93a71d20c2fe5289ce94997bae2):

### Summary:
#### ryml:
Imported version of Rapid YAML doesn't build on Unices without `CLOCK_MONOTONIC_RAW`, which [should be Linux specific](https://linux.die.net/man/2/clock_gettime).
[450a27f](https://github.com/biojppm/c4core/commit/450a27f8b18ee23b18a3b102be90d542bc887b68) addresses this issue, so it is the current target.

#### FileSystem:
Fixes FreeBSD `ifdef` so it doesn't use `countof`. Instead, follow c++17 and use `std::count`, which is available in base clang compiler for all supported releases, and fits perfectly according to [`sysctl(3)`](https://www.freebsd.org/cgi/man.cgi?query=sysctl&apropos=0&sektion=3&manpath=FreeBSD+14.0-current&arch=default&format=html) manual page.

### Test environment:
FreeBSD 14.0-CURRENT main-c78058efb (fairly close to ^HEAD) with base clang 13 compiler. [Build log](https://reviews.freebsd.org/P532)
