### PR TITLE
rapid-yaml should not be required by find_package, as we compile it o…

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -229,7 +229,7 @@ else()
 endif()
 
 if(USE_SYSTEM_YAML)
-	find_package(ryml REQUIRED)
+	find_package(ryml QUIET)
 	if(NOT ryml_FOUND)
 		message(STATUS "No system rapidyaml was found, using the submodule in the 3rdparty directory")
 		set(USE_SYSTEM_YAML OFF)


### PR DESCRIPTION
…urselves if it is not there.

### Description of Changes
Changed the REQUIRED keyword to QUIET instead.

### Rationale behind Changes
REQUIRED is intended for if you want compiling to abort if it is not found on the system. We do not want compilation to abort.

### Suggested Testing Steps
Compile pcsx2.
