### PR TITLE
GS-hw: Mirror anisotropic filtering behavior on Direct3D11 like OpenGL, and allow it to run on Nearest texture filtering

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -374,7 +374,7 @@ bool GSDevice11::Create(const WindowInfo& wi)
 	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.MinLOD = -FLT_MAX;
 	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = D3D11_MIN_MAXANISOTROPY;
+	sd.MaxAnisotropy = 1;
 	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 	m_dev->CreateSamplerState(&sd, m_convert.ln.put());

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -35,13 +35,6 @@ GSDevice11::GSDevice11()
 	m_mipmap = theApp.GetConfigI("mipmap");
 	m_upscale_multiplier = std::max(0, theApp.GetConfigI("upscale_multiplier"));
 
-	const BiFiltering nearest_filter = static_cast<BiFiltering>(theApp.GetConfigI("filter"));
-	const int aniso_level = theApp.GetConfigI("MaxAnisotropy");
-	if ((nearest_filter != BiFiltering::Nearest && !theApp.GetConfigB("paltex") && aniso_level))
-		m_aniso_filter = aniso_level;
-	else
-		m_aniso_filter = 0;
-
 	m_features.broken_point_sampler = true; // Not technically the case but the most common reason to use DX11 is because you're on AMD
 	m_features.geometry_shader = true;
 	m_features.image_load_store = false;
@@ -375,18 +368,18 @@ bool GSDevice11::Create(const WindowInfo& wi)
 
 	memset(&sd, 0, sizeof(sd));
 
-	sd.Filter = m_aniso_filter ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+	sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
 	sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.MinLOD = -FLT_MAX;
 	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = m_aniso_filter;
+	sd.MaxAnisotropy = D3D11_MIN_MAXANISOTROPY;
 	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 	m_dev->CreateSamplerState(&sd, m_convert.ln.put());
 
-	sd.Filter = m_aniso_filter ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_MIP_POINT;
+	sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
 
 	m_dev->CreateSamplerState(&sd, m_convert.pt.put());
 
@@ -1485,7 +1478,6 @@ static void preprocessSel(GSDevice11::PSSelector& sel)
 
 static void preprocessSel(GSDevice11::PSSamplerSelector& sel)
 {
-	sel.aniso = 0; // Not currently supported
 	sel.triln = 0; // Not currently supported
 }
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -109,7 +109,6 @@ public:
 private:
 	float m_hack_topleft_offset;
 	int m_upscale_multiplier;
-	int m_aniso_filter;
 	int m_mipmap;
 	int m_d3d_texsize;
 

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -220,19 +220,24 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 		}
 		else
 		{
-			D3D11_SAMPLER_DESC sd, af;
+			D3D11_SAMPLER_DESC sd;
 
 			memset(&sd, 0, sizeof(sd));
 
-			af.Filter = m_aniso_filter ? D3D11_FILTER_ANISOTROPIC : D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
-			sd.Filter = ssel.biln ? af.Filter : D3D11_FILTER_MIN_MAG_MIP_POINT;
+			const int anisotropy = theApp.GetConfigI("MaxAnisotropy");
+			if (anisotropy && ssel.aniso)
+				sd.Filter = D3D11_FILTER_ANISOTROPIC;
+			else if (ssel.biln)
+				sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+			else
+				sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
 
 			sd.AddressU = ssel.tau ? D3D11_TEXTURE_ADDRESS_WRAP : D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.AddressV = ssel.tav ? D3D11_TEXTURE_ADDRESS_WRAP : D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.MinLOD = -FLT_MAX;
 			sd.MaxLOD = FLT_MAX;
-			sd.MaxAnisotropy = m_aniso_filter;
+			sd.MaxAnisotropy = anisotropy;
 			sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 			m_dev->CreateSamplerState(&sd, &ss0);

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -56,7 +56,7 @@ bool GSDevice11::CreateTextureFX()
 	sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 	sd.MinLOD = -FLT_MAX;
 	sd.MaxLOD = FLT_MAX;
-	sd.MaxAnisotropy = D3D11_MIN_MAXANISOTROPY;
+	sd.MaxAnisotropy = 1;
 	sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 	hr = m_dev->CreateSamplerState(&sd, m_palette_ss.put());
@@ -237,7 +237,7 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.MinLOD = -FLT_MAX;
 			sd.MaxLOD = FLT_MAX;
-			sd.MaxAnisotropy = anisotropy;
+			sd.MaxAnisotropy = std::clamp(anisotropy, 1, 16);
 			sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 
 			m_dev->CreateSamplerState(&sd, &ss0);

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -279,7 +279,7 @@ RendererTab::RendererTab(wxWindow* parent)
 	m_ui.addCheckBox(hw_checks_box, "Conservative Buffer Allocation",  "conservative_framebuffer", IDC_CONSERVATIVE_FB, upscale_prereq);
 
 	auto* paltex_prereq = m_ui.addCheckBox(hw_checks_box, "GPU Palette Conversion", "paltex", IDC_PALTEX, hw_prereq);
-	auto aniso_prereq = [this, paltex_prereq]{ return m_is_hardware && !m_is_nearest_filter && paltex_prereq->GetValue() == false; };
+	auto aniso_prereq = [this, paltex_prereq]{ return m_is_hardware && paltex_prereq->GetValue() == false; };
 
 	auto* hw_choice_grid = new wxFlexGridSizer(2, space, space);
 
@@ -782,13 +782,11 @@ void Dialog::Update()
 		// cross-tab dependencies yay
 		const bool is_hw = renderer == GSRendererType::OGL_HW || renderer == GSRendererType::DX1011_HW;
 		const bool is_upscale = m_renderer_panel->m_internal_resolution->GetSelection() != 0;
-		const bool is_nearest_filter = m_bifilter_select->GetSelection() == static_cast<int>(BiFiltering::Nearest);
 		m_hacks_panel->m_is_native_res = !is_hw || !is_upscale;
 		m_hacks_panel->m_is_hardware = is_hw;
 		m_hacks_panel->m_is_ogl_hw = renderer == GSRendererType::OGL_HW;
 		m_renderer_panel->m_is_hardware = is_hw;
 		m_renderer_panel->m_is_native_res = !is_hw || !is_upscale;
-		m_renderer_panel->m_is_nearest_filter = is_nearest_filter;
 		m_debug_panel->m_is_ogl_hw = renderer == GSRendererType::OGL_HW;
 
 		m_ui.Update();

--- a/pcsx2/GS/Window/GSwxDialog.h
+++ b/pcsx2/GS/Window/GSwxDialog.h
@@ -111,7 +111,6 @@ namespace GSSettingsDialog
 #endif
 		bool m_is_hardware = false;
 		bool m_is_native_res = false;
-		bool m_is_nearest_filter = false;
 
 		RendererTab(wxWindow* parent);
 		void Load() { m_ui.Load(); }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-d3d11: Mirror anisotropic filtering behavior on Direct3D11. 
Don't run aniso filter on m_convert.pt and m_convert.ln samplers.
Running m_convert.pt broke shadows on color clipping.
Also use the aniso bit from hw renderer.
Aniso will now behave the same as on OpenGL.

GS-wx: Aniso can run with nearest texture filtering so let's leave it. 
Option just disabled the toggle, it would still run on opengl.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes issues with color clipping when using aniso, accuracy.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test and make sure anisotropic filtering still works on Direct3D11, also make sure you can still toggle Ansiso filter even on nearest texture filtering.