### PR TITLE
Fix some gcc warnings.

### DIFF
--- a/pcsx2/USB/usb-pad/usb-pad.h
+++ b/pcsx2/USB/usb-pad/usb-pad.h
@@ -1516,7 +1516,7 @@ namespace usb_pad
 	// 0x0982 - PlayStation 2
 	// 0x0984 - ???
 
-	static uint8_t gametrak_dev_descriptor[] = {
+	[[maybe_unused]] static uint8_t gametrak_dev_descriptor[] = {
 		0x12,       // bLength
 		0x01,       // bDescriptorType (Device)
 		0x10, 0x01, // bcdUSB 1.10

--- a/pcsx2/USB/usb-printer/usb-printer.cpp
+++ b/pcsx2/USB/usb-printer/usb-printer.cpp
@@ -192,8 +192,8 @@ namespace usb_printer
 		const uint8_t print_compl[] = {0x1b, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 		PrinterState* s = (PrinterState*)dev;
-		const uint8_t ep_nr = p->ep->nr;
-		const uint8_t ep_type = p->ep->type;
+		//const uint8_t ep_nr = p->ep->nr;
+		//const uint8_t ep_type = p->ep->type;
 
 		switch (p->pid)
 		{
@@ -233,7 +233,7 @@ namespace usb_printer
 			case USB_TOKEN_IN:
 				if (s->cmd_state == 0 && s->last_command_size > 0)
 				{
-					for (int i = 0; i < sizeof(commands) / sizeof(commands[0]); i++)
+					for (uint32_t i = 0; i < sizeof(commands) / sizeof(commands[0]); i++)
 					{
 						if (s->last_command[1] == 0xCF)
 						{
@@ -272,7 +272,7 @@ namespace usb_printer
 	{
 		PrinterState* s = new PrinterState();
 		std::string api = *PrinterDevice::ListAPIs().begin();
-		int subtype = GetSelectedSubtype(std::make_pair(port, TypeName()));
+		uint32_t subtype = GetSelectedSubtype(std::make_pair(port, TypeName()));
 		if (subtype >= sizeof(sPrinters) / sizeof(sPrinters[0])) {
 			subtype = 0;
 		}

--- a/pcsx2/USB/usb-printer/usb-printer.h
+++ b/pcsx2/USB/usb-printer/usb-printer.h
@@ -98,15 +98,15 @@ namespace usb_printer
 
 	struct PrinterData
 	{
-		PrinterModel model;
-		char* commercial_name;
+		const PrinterModel model;
+		const char* commercial_name;
 		const uint8_t* device_descriptor;
 		const int device_descriptor_size;
 		const uint8_t* config_descriptor;
 		const int config_descriptor_size;
 		const USBDescStrings usb_strings;
-		char* device_id;
-		PrinterProtocol protocol;
+		const char* device_id;
+		const PrinterProtocol protocol;
 	};
 
 	static const PrinterData sPrinters[] = {
@@ -149,7 +149,7 @@ namespace usb_printer
 		static std::vector<std::string> SubTypes()
 		{
 			std::vector<std::string> ret;
-			for (int i = 0; i < sizeof(sPrinters) / sizeof(sPrinters[0]); i++)
+			for (uint32_t i = 0; i < sizeof(sPrinters) / sizeof(sPrinters[0]); i++)
 			{
 				ret.push_back(sPrinters[i].commercial_name);
 			}


### PR DESCRIPTION
### Description of Changes
Got rid of some warnings in gcc over in the usb code. I decided clang warnings could wait for another time.

### Rationale behind Changes
Less warnings while compiling.

### Suggested Testing Steps
Compile pcsx2.
