### PR TITLE
Hack for Megaturrets on Ratchet & Clank 2 (#354)

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -35,6 +35,7 @@ allowed_game_fixes = [
     "VUKickstartHack",
     "IbitHack",
     "VUOverflowHack",
+    "RC2MegaturretHack",
 ]
 allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack"]
 # Patches are allowed to have a 'default' key or a crc-32 key, followed by

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -108,6 +108,7 @@ PBPX-95514:
   region: "PAL-M5"
   gameFixes:
     - VUKickstartHack # Fixes Character SPS in Ratchet and Clank.
+    - RC2MegaturretHack # Fixes Megaturret deployment
 PBPX-95517:
   name: "Network Adapter Start-Up Disc"
   region: "NTSC-U"
@@ -2439,6 +2440,7 @@ SCES-51607:
   gameFixes:
     - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes DMA errors 
+    - RC2MegaturretHack # Fixes Megaturret deployment
   memcardFilters: # Reads Ratchet 1 data.
     - "SCES-51607"
     - "SCES-50916"

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -44,6 +44,7 @@ enum GamefixId
 	Fix_VUKickstart,
 	Fix_VUOverflow,
 	Fix_XGKick,
+	Fix_RC2Megaturret,
 
 	GamefixId_COUNT
 };
@@ -474,7 +475,8 @@ struct Pcsx2Config
 			IbitHack : 1, // I bit hack. Needed to stop constant VU recompilation in some games
 			VUKickstartHack : 1, // Gives new VU programs a slight head start and runs VU's ahead of EE to avoid VU register reading/writing issues
 			VUOverflowHack : 1, // Tries to simulate overflow flag checks (not really possible on x86 without soft floats)
-			XgKickHack : 1; // Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
+			XgKickHack : 1, // Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
+			RC2MegaturretHack : 1; // Ratchet & Clank 2 (PAL only) hack to tweak Megaturrent collision (?) for fixing deployment
 		BITFIELD_END
 
 		GamefixOptions();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -359,7 +359,9 @@ static const char* const tbl_GamefixNames[] =
 		"Ibit",
 		"VUKickstart",
 		"VUOverflow",
-		"XGKick"};
+		"XGKick",
+		"RC2Megaturret",
+	};
 
 const char* EnumToString(GamefixId id)
 {
@@ -452,6 +454,9 @@ void Pcsx2Config::GamefixOptions::Set(GamefixId id, bool enabled)
 		case Fix_VUOverflow:
 			VUOverflowHack = enabled;
 			break;
+		case Fix_RC2Megaturret:
+			RC2MegaturretHack = enabled;
+			break;
 			jNO_DEFAULT;
 	}
 }
@@ -491,6 +496,8 @@ bool Pcsx2Config::GamefixOptions::Get(GamefixId id) const
 			return VUKickstartHack;
 		case Fix_VUOverflow:
 			return VUOverflowHack;
+		case Fix_RC2Megaturret:
+			return RC2MegaturretHack;
 			jNO_DEFAULT;
 	}
 	return false; // unreachable, but we still need to suppress warnings >_<

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -100,6 +100,10 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			_("VU XGkick Sync - Use accurate timing for VU XGKicks (Slower)"),
 			pxEt(L"Fixes graphical errors on WRC, Erementar Gerad, Tennis Court Smash and others."
 			)
+		},
+		{
+			_("Ratchet && Clank 2 (PAL) hack to fix deployment of Megaturrets"),
+			wxEmptyString
 		}
 	};
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1461,6 +1461,16 @@ void recompileNextInstruction(int delayslot)
 
 	cpuRegs.code = *(int*)s_pCode;
 
+	if (EmuConfig.Gamefixes.RC2MegaturretHack && cpuRegs.code == 0x0280202d)
+	{
+		if (*(int*)PSM(pc + 0x4) == 0x3c0140d0 && *(int*)PSM(pc + 0x8) == 0x44810800 && *(int*)PSM(pc + 0x10) == 0x46000836)
+		{
+			DevCon.Warning("Fixing RC2 Mega Turret at PC %x", cpuRegs.pc);
+			// li.s $f1, 6.5 -> li.s $f1, 1.5
+			memWrite32(pc + 0x4, 0x3c013fc0);
+		}
+	}
+
 	if (!delayslot)
 	{
 		pc += 4;


### PR DESCRIPTION
Values found by @kozarovv

### Description of Changes
This adds a new gamefix/hack to fix deployment of Megaturrets in RC2.

I have absolutely no idea what the patched function does, but comparing against 1.5 instead of 6.5 fixes it...
Maybe it's somehow involved in collision detection?

### Rationale behind Changes
See #354

### Suggested Testing Steps
Throwing Megaturrets onto various surfaces on Ratchet & Clank 2 PAL edition.