### PR TITLE
GS: fix loopPagesWithBreak last iteration logic.

### DIFF
--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -345,8 +345,9 @@ public:
 						touched[idx] |= mask;
 					}
 
-					if (y < yCnt - 1)
+					if (y < yCnt - 2)
 					{
+						// Next iteration is not last (y + 1 < yCnt - 1).
 						startOff = midRowPgXStart;
 						endOff   = midRowPgXEnd;
 					}
@@ -371,8 +372,9 @@ public:
 						if (!fn(pos % MAX_PAGES))
 							return;
 
-					if (y < yCnt - 1)
+					if (y < yCnt - 2)
 					{
+						// Next iteration is not last (y + 1 < yCnt - 1).
 						startOff = midRowPgXStart;
 						endOff   = midRowPgXEnd;
 					}


### PR DESCRIPTION
### Description of Changes

Fix the last iteration detection logic in `GSOffset::PageLooper::loopPagesWithBreak`.
Thanks to @tellowkrinkle for pointing out where the issue was (I just did the testing here, speaking of which, unit testing for these functions may be suggested in the future).

### Rationale behind Changes

The GS page looping was seldom buggy.
This fix will correct it.
SW and HW GS texture caches will benefit from the fix. 

### Suggested Testing Steps

Test some games and check that nothing regressed.
I'm not aware of any regression induced by this bug.
