### PR TITLE
GS:SW: Fix crash when scanline count wasn't divisible by thread count

### DIFF
--- a/pcsx2/GS/GSPerfMon.h
+++ b/pcsx2/GS/GSPerfMon.h
@@ -22,9 +22,8 @@ public:
 	{
 		Main,
 		Sync,
-		WorkerDraw0, WorkerDraw1, WorkerDraw2, WorkerDraw3, WorkerDraw4, WorkerDraw5, WorkerDraw6, WorkerDraw7,
-		WorkerDraw8, WorkerDraw9, WorkerDraw10, WorkerDraw11, WorkerDraw12, WorkerDraw13, WorkerDraw14, WorkerDraw15,
-		TimerLast,
+		WorkerDraw0,
+		TimerLast = WorkerDraw0 + 32, // Enough space for 32 GS worker threads
 	};
 
 	enum counter_t

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -53,14 +53,9 @@ GSRasterizer::GSRasterizer(IDrawScanline* ds, int id, int threads, GSPerfMon* pe
 	int rows = (2048 >> m_thread_height) + 16;
 	m_scanline = (u8*)_aligned_malloc(rows, 64);
 
-	int row = 0;
-
-	while (row < rows)
+	for (int i = 0; i < rows; i++)
 	{
-		for (int i = 0; i < threads; i++, row++)
-		{
-			m_scanline[row] = i == id ? 1 : 0;
-		}
+		m_scanline[i] = (i % threads) == id ? 1 : 0;
 	}
 }
 
@@ -1191,14 +1186,9 @@ GSRasterizerList::GSRasterizerList(int threads, GSPerfMon* perfmon)
 	int rows = (2048 >> m_thread_height) + 16;
 	m_scanline = (u8*)_aligned_malloc(rows, 64);
 
-	int row = 0;
-
-	while (row < rows)
+	for (int i = 0; i < rows; i++)
 	{
-		for (int i = 0; i < threads; i++, row++)
-		{
-			m_scanline[row] = (u8)i;
-		}
+		m_scanline[i] = static_cast<u8>(i % threads);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes crash when scanline count wasn't divisible by thread count (common with odd thread counts like 5)

### Rationale behind Changes
Less crashy more runny

### Suggested Testing Steps
Run SW renderer with weird thread counts
