### PR TITLE
gitignore: update gs debug gl filename.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,7 @@ Thumbs.db
 Debug.txt
 install_log.txt
 padLog.txt
-GS_opengl_debug_hw.txt
-GS_opengl_debug_sw.txt
+GS_opengl_debug.txt
 
 Debug
 Release


### PR DESCRIPTION
### Description of Changes
Add to gitignore the new GS debug OpenGL filename and remove the old ones.

### Rationale behind Changes
The GS debug OpenGL filename has been changed but the gitignore not, this fixes that.

### Suggested Testing Steps
Just compile and run in debug mode with the OpenGL renderer, check that the `GS_opengl_debug.txt` is ignored by git.
