### PR TITLE
SysThreadBase: Fix double init of SPU2 etc

### DIFF
--- a/pcsx2/System/SysThreadBase.cpp
+++ b/pcsx2/System/SysThreadBase.cpp
@@ -333,15 +333,11 @@ bool SysThreadBase::StateCheckInThread()
 			if (m_ExecMode != ExecMode_Closing)
 			{
 #ifndef PCSX2_CORE
-				if (g_CDVDReset)
-					// AppCoreThread deals with Reseting CDVD
-					// Reinit all but GS, USB, DEV9, CDVD (just like with isSuspend = false previously)
-					OnResumeInThread(static_cast<SystemsMask>(~(System_GS|System_USB|System_DEV9|System_CDVD)));
-				else
-					// Reinit previously torn down systems
-					OnResumeInThread(systemsToTearDown);
-					
+				// AppCoreThread deals with Reseting CDVD
+				OnResumeInThread(g_CDVDReset ? static_cast<SystemsMask>(systemsToTearDown & ~(System_CDVD)) : systemsToTearDown);
 				g_CDVDReset = false;
+#else
+				OnResumeInThread(systemsToTearDown);
 #endif
 				break;
 			}


### PR DESCRIPTION
### Description of Changes

Typical pcsx2 threading nonsense.

Changing discs sets g_CDVDReset, which ends up double-opening PAD. So,
 1) it never gets closed properly, and
 2) when you change renderers, it should get reinitalized due to the window change (because it's nasty and hijacks the window thread), but because it has a gross "openCount" which never reaches zero, that never happens
 3) hotkeys don't work

### Rationale behind Changes
:rage:

Fixes #5267

### Suggested Testing Steps
Cry in a corner
