### PR TITLE
CMake: Pass -fsanitize=address as a link option when USE_ASAN is used

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -301,6 +301,7 @@ list(APPEND PCSX2_DEFS
 
 if (USE_ASAN)
 	add_compile_options(-fsanitize=address)
+	add_link_options(-fsanitize=address)
 	list(APPEND PCSX2_DEFS ASAN_WORKAROUND)
 endif()
 


### PR DESCRIPTION
Linking with the address sanitizer fails otherwise 
🤧