### PR TITLE
GS: improve targets clearing

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -154,6 +154,7 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int w, int h, bool mipma
 	switch (type)
 	{
 	case GSTexture::Type::RenderTarget:
+	case GSTexture::Type::SparseRenderTarget:
 		{
 			if (clear)
 				ClearRenderTarget(t, 0);
@@ -162,6 +163,7 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int w, int h, bool mipma
 		}
 		break;
 	case GSTexture::Type::DepthStencil:
+	case GSTexture::Type::SparseDepthStencil:
 		{
 			if (clear)
 				ClearDepth(t);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -627,16 +627,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 			dst->m_dirty.push_back(GSDirtyRect(GSVector4i(0, 0, TEX0.TBW * 64, max_h), TEX0.PSM));
 			dst->Update();
 		}
-		else
-		{
-#ifdef ENABLE_OGL_DEBUG
-			switch (type) {
-				case RenderTarget: g_gs_device->ClearRenderTarget(dst->m_texture, 0); break;
-				case DepthStencil: g_gs_device->ClearDepth(dst->m_texture); break;
-				default: break;
-			}
-#endif
-		}
 	}
 	ScaleTexture(dst->m_texture);
 	if (used)
@@ -736,8 +726,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 
 		dst = CreateTarget(TEX0, w, h, RenderTarget);
 		ScaleTexture(dst->m_texture);
-
-		g_gs_device->ClearRenderTarget(dst->m_texture, 0); // new frame buffers after reset should be cleared, don't display memory garbage
 
 		if (m_preload_frame)
 		{


### PR DESCRIPTION
### Description of Changes
Clearing on fetch is applied also to sparse render targets and depth stencils.
~~A slow invalidation path has been implemented for D3D11 (previously none were present) and for OGL as a fallback.~~
Redundant clears has been removed from TC, as the fetched surfaces are always clean.

### Rationale behind Changes
Increase correctness, remove redundant code.

### Suggested Testing Steps
Test some games and make sure that no visual regression occurs.
Test also the performances in terms of rendering speed and VRAM usage (let's make sure that the sparse targets sparsity is not killed by clearing).
VRAM usage should not differ at all regardless of this PR in D3D11 as it does not support sparse targets yet.
If a big VRAM usage difference is spotted in OGL or Vulkan, that's an issue.