### PR TITLE
CDVD: Adjust error timing and modify error used for high sector.

### DIFF
--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -111,6 +111,7 @@ enum cdvdActions
 	cdvdAction_Seek,
 	cdvdAction_Standby,
 	cdvdAction_Stop,
+	cdvdAction_Error,
 	cdvdAction_Read // note: not used yet.
 };
 


### PR DESCRIPTION
### Description of Changes
Add timing to error calls and modify error for reading past end of the disc

### Rationale behind Changes
Games do terrible, terrible things. I don't know if this is right, but it seems to mimic PS2 behaviour on the Silent Hill 2 Black Ribbon demo disc.

### Suggested Testing Steps
test stuff that tries to read past the end of the disc

Fixes #5280 
