### PR TITLE
GS-hw: Move PABE shader bit to the top of sw blending.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -707,6 +707,14 @@ void ps_blend(inout float4 Color, float As, float2 pos_xy)
 {
 	if (SW_BLEND)
 	{
+		// PABE
+		if (PS_PABE)
+		{
+			// No blending so early exit
+			if (As < 1.0f)
+				return;
+		}
+
 		float4 RT = trunc(RtSampler.Load(int3(pos_xy, 0)) * 255.0f + 0.1f);
 
 		float Ad = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
@@ -724,10 +732,6 @@ void ps_blend(inout float4 Color, float As, float2 pos_xy)
 			C = min(C, (float)1.0f);
 
 		Color.rgb = (PS_BLEND_A == PS_BLEND_B) ? D : trunc(((A - B) * C) + D);
-
-		// PABE
-		if (PS_PABE)
-			Color.rgb = (As >= 1.0f) ? Color.rgb : Cs;
 	}
 }
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -656,6 +656,14 @@ void ps_color_clamp_wrap(inout vec3 C)
 void ps_blend(inout vec4 Color, float As)
 {
 #if SW_BLEND
+
+    // PABE
+#if PS_PABE
+    // No blending so early exit
+    if (As < 1.0f)
+        return;
+#endif
+
     vec4 RT = trunc(texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0) * 255.0f + 0.1f);
 
 #if PS_DFMT == FMT_24
@@ -711,11 +719,6 @@ void ps_blend(inout vec4 Color, float As)
     Color.rgb = D;
 #else
     Color.rgb = trunc((A - B) * C + D);
-#endif
-
-    // PABE
-#if PS_PABE
-    Color.rgb = (As >= 1.0f) ? Color.rgb : Cs;
 #endif
 
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -989,11 +989,19 @@ void ps_color_clamp_wrap(inout vec3 C)
 void ps_blend(inout vec4 Color, float As)
 {
 	#if SW_BLEND
+
+		// PABE
+		#if PS_PABE
+				// No blending so early exit
+				if (As < 1.0f)
+					return;
+		#endif
+
 		#if PS_FEEDBACK_LOOP_IS_NEEDED
-			vec4 RT = trunc(subpassLoad(RtSampler) * 255.0f + 0.1f);
+				vec4 RT = trunc(subpassLoad(RtSampler) * 255.0f + 0.1f);
 		#else
-			// Not used, but we define it to make the selection below simpler.
-			vec4 RT = vec4(0.0f);
+				// Not used, but we define it to make the selection below simpler.
+				vec4 RT = vec4(0.0f);
 		#endif
 
 		#if PS_DFMT == FMT_24
@@ -1049,11 +1057,6 @@ void ps_blend(inout vec4 Color, float As)
 				Color.rgb = D;
 		#else
 				Color.rgb = trunc((A - B) * C + D);
-		#endif
-
-				// PABE
-		#if PS_PABE
-				Color.rgb = (As >= 1.0f) ? Color.rgb : Cs;
 		#endif
 
 	#endif


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Early return when there is no sw blending, no need to run the blend code.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games that use PABE.