### PR TITLE
GS: fully support target rescaling in TC.

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -203,7 +203,7 @@ const CRC::Game CRC::m_games[] =
 	{0xA3643EB1, GiTS, KO, 0},
 	{0x28557423, GiTS, RU, 0},
 	{0xBF6F101F, GiTS, EU, 0}, // same CRC as another US disc
-	{0xF442260C, MajokkoALaMode2, JP, 0},
+	{0xF442260C, MajokkoALaMode2, JP, PointListPalette},
 	{0xA616A6C2, TalesOfAbyss, US, 0},
 	{0x14FE77F7, TalesOfAbyss, US, 0},
 	{0xAA5EC3A3, TalesOfAbyss, JP, 0},

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -60,10 +60,8 @@ private:
 	bool OI_JakGames(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	bool OI_BurnoutGames(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
-	void OO_MajokkoALaMode2();
 	void OO_BurnoutGames();
 
-	bool CU_MajokkoALaMode2();
 	bool CU_TalesOfAbyss();
 
 	class Hacks

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -495,12 +495,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 	return src;
 }
 
-void GSTextureCache::ScaleTexture(GSTexture* texture)
-{
-	if (texture)
-		texture->SetScale(m_renderer->GetTextureScaleFactor());
-}
-
 bool GSTextureCache::ShallSearchTextureInsideRt()
 {
 	return m_texture_inside_rt || (m_renderer->m_game.flags & CRC::Flags::TextureInsideRt);
@@ -509,9 +503,25 @@ bool GSTextureCache::ShallSearchTextureInsideRt()
 GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int w, int h, int type, bool used, u32 fbmask)
 {
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
-	u32 bp = TEX0.TBP0;
+	const GSVector2& new_s = m_renderer->GetTextureScaleFactor();
+	const u32 bp = TEX0.TBP0;
+	float res_w = 0, res_h = 0;
+	int new_w = 0, new_h = 0;
+	bool clear = true;
+	const auto& calcRescale = [w, h, new_s, &res_w, &res_h, &new_w, &new_h, &clear](const GSTexture* tex)
+	{
+		const GSVector2& old_s = tex->GetScale();
+		const GSVector2 ratio{ new_s.x / old_s.x, new_s.y / old_s.y };
+		const int old_w = tex->GetWidth();
+		const int old_h = tex->GetHeight();
+		res_w = static_cast<float>(old_w) * ratio.x;
+		res_h = static_cast<float>(old_h) * ratio.y;
+		new_w = std::max(static_cast<int>(std::ceil(res_w)), w);
+		new_h = std::max(static_cast<int>(std::ceil(res_h)), h);
+		clear = new_w != res_w || new_h != res_h;
+	};
 
-	Target* dst = NULL;
+	Target* dst = nullptr;
 
 	auto& list = m_dst[type];
 	for (auto i = list.begin(); i != list.end(); ++i)
@@ -534,6 +544,19 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 	if (dst)
 	{
 		GL_CACHE("TC: Lookup Target(%s) %dx%d, hit: %d (0x%x, %s)", to_string(type), w, h, dst->m_texture->GetID(), bp, psm_str(TEX0.PSM));
+
+		const GSVector2& old_s = dst->m_texture->GetScale();
+		if (new_s != old_s)
+		{
+			calcRescale(dst->m_texture);
+			const GSVector4 sRect(0, 0, 1, 1);
+			const GSVector4 dRect(0.0f, 0.0f, res_w, res_h);
+			GSTexture* tex = type == RenderTarget ? g_gs_device->CreateSparseRenderTarget(new_w, new_h, GSTexture::Format::Color, clear) :
+				g_gs_device->CreateSparseDepthStencil(new_w, new_h, GSTexture::Format::DepthStencil, clear);
+			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, ShaderConvert::COPY, false);
+			g_gs_device->Recycle(dst->m_texture);
+			dst->m_texture = tex;
+		}
 
 		dst->Update();
 
@@ -565,19 +588,11 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 
 		if (dst_match)
 		{
-			const GSVector2& new_s = m_renderer->GetTextureScaleFactor();
-			const GSVector2& old_s = dst_match->m_texture->GetScale();
-			const GSVector2 ratio{ new_s.x / old_s.x, new_s.y / old_s.y };
-			const int old_w = dst_match->m_texture->GetWidth();
-			const int old_h = dst_match->m_texture->GetHeight();
-			const float res_w = static_cast<float>(old_w) * ratio.x;
-			const float res_h = static_cast<float>(old_h) * ratio.y;
-			const int new_w = std::max(static_cast<int>(std::ceil(res_w)), w);
-			const int new_h = std::max(static_cast<int>(std::ceil(res_h)), h);
+			calcRescale(dst_match->m_texture);
 			const GSVector4 sRect(0, 0, 1, 1);
 			const GSVector4 dRect(0.0f, 0.0f, res_w, res_h);
 
-			dst = CreateTarget(TEX0, new_w, new_h, type);
+			dst = CreateTarget(TEX0, new_w, new_h, type, clear);
 			dst->m_32_bits_fmt = dst_match->m_32_bits_fmt;
 
 			ShaderConvert shader;
@@ -596,11 +611,11 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 		}
 	}
 
-	if (dst == NULL)
+	if (!dst)
 	{
 		GL_CACHE("TC: Lookup Target(%s) %dx%d, miss (0x%x, %s)", to_string(type), w, h, bp, psm_str(TEX0.PSM));
 
-		dst = CreateTarget(TEX0, w, h, type);
+		dst = CreateTarget(TEX0, w, h, type, true);
 
 		// In theory new textures contain invalidated data. Still in theory a new target
 		// must contains the content of the GS memory.
@@ -638,7 +653,6 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 #endif
 		}
 	}
-	ScaleTexture(dst->m_texture);
 	if (used)
 	{
 		dst->m_used = true;
@@ -734,8 +748,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 	{
 		GL_CACHE("TC: Lookup Frame %dx%d, miss (0x%x %s)", w, h, bp, psm_str(TEX0.PSM));
 
-		dst = CreateTarget(TEX0, w, h, RenderTarget);
-		ScaleTexture(dst->m_texture);
+		dst = CreateTarget(TEX0, w, h, RenderTarget, true);
 
 		g_gs_device->ClearRenderTarget(dst->m_texture, 0); // new frame buffers after reset should be cleared, don't display memory garbage
 
@@ -1644,26 +1657,26 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	return src;
 }
 
-GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type)
+GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type, const bool clear)
 {
 	ASSERT(type == RenderTarget || type == DepthStencil);
 
-	Target* t = new Target(m_renderer, TEX0, m_temp, m_can_convert_depth);
+	Target* t = new Target(m_renderer, TEX0, m_temp, m_can_convert_depth, type);
 
 	// FIXME: initial data should be unswizzled from local mem in Update() if dirty
 
-	t->m_type = type;
-
 	if (type == RenderTarget)
 	{
-		t->m_texture = g_gs_device->CreateSparseRenderTarget(w, h, GSTexture::Format::Color);
+		t->m_texture = g_gs_device->CreateSparseRenderTarget(w, h, GSTexture::Format::Color, clear);
 
 		t->m_used = true; // FIXME
 	}
 	else if (type == DepthStencil)
 	{
-		t->m_texture = g_gs_device->CreateSparseDepthStencil(w, h, GSTexture::Format::DepthStencil);
+		t->m_texture = g_gs_device->CreateSparseDepthStencil(w, h, GSTexture::Format::DepthStencil, clear);
 	}
+
+	t->m_texture->SetScale(m_renderer->GetTextureScaleFactor());
 
 	m_dst[type].push_front(t);
 
@@ -2272,9 +2285,9 @@ bool GSTextureCache::Source::ClutMatch(const PaletteKey& palette_key)
 
 // GSTextureCache::Target
 
-GSTextureCache::Target::Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, bool depth_supported)
+GSTextureCache::Target::Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, const bool depth_supported, const int type)
 	: Surface(r, temp)
-	, m_type(-1)
+	, m_type(type)
 	, m_used(false)
 	, m_depth_supported(depth_supported)
 {

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -152,15 +152,15 @@ public:
 	class Target : public Surface
 	{
 	public:
-		int m_type;
+		const int m_type;
 		bool m_used;
 		GSDirtyRectList m_dirty;
 		GSVector4i m_valid;
-		bool m_depth_supported;
+		const bool m_depth_supported;
 		bool m_dirty_alpha;
 
 	public:
-		Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, bool depth_supported);
+		Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, const bool depth_supported, const int type);
 
 		void UpdateValidity(const GSVector4i& rect);
 
@@ -236,7 +236,7 @@ protected:
 	std::vector<TexInsideRtCacheEntry> m_texture_inside_rt_cache;
 
 	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false, int x_offset = 0, int y_offset = 0, bool mipmap = false);
-	Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type);
+	Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type, const bool clear);
 
 	// TODO: virtual void Write(Source* s, const GSVector4i& r) = 0;
 	// TODO: virtual void Write(Target* t, const GSVector4i& r) = 0;
@@ -262,7 +262,6 @@ public:
 
 	void IncAge();
 	bool UserHacks_HalfPixelOffset;
-	void ScaleTexture(GSTexture* texture);
 
 	bool ShallSearchTextureInsideRt();
 


### PR DESCRIPTION
### Description of Changes
Added full support for target rescaling in GS TC.
Previously only color to depth or depth to color rescaling was supported.
Also avoid redundant clears when the target is going to be completely drawn when rescaling.

EDIT: Bonus fix palette rendering in Majokko A-La-Mode 2, replacing CU+OO hack for nativeres palette rendering and downloading with direct palette rendering in gs local memory (point list draw).

### Rationale behind Changes
Improve TC behaviour when handling targets with different scaling, for example native res and upscaled, or potentially when changing internal resolution without flushing.
Avoid redundant target clears.

### Suggested Testing Steps
Test some games and check that no visual regression occurs, especially games with "CU" hacks that have native res draws even when upscaled (currently ~~"Majokko A La Mode 2" and~~ only "Tales Of Abyss").
Potentially appreciate performance improvement in depth to color and color to depth conversion due to clearing skip.

EDIT: Check that Burnout games do not have regressions due to improvements in point list palette "hack".
