### PR TITLE
GS: Better support of dpi scaling

### DIFF
--- a/pcsx2/Frontend/ImGuiManager.cpp
+++ b/pcsx2/Frontend/ImGuiManager.cpp
@@ -66,7 +66,7 @@ bool ImGuiManager::Initialize()
 
 	s_global_scale = std::max(1.0f, display->GetWindowScale() * static_cast<float>(EmuConfig.GS.OsdScale / 100.0));
 
-	ImGui::GetIO().DisplayFramebufferScale = ImVec2(display->GetWindowScale(), display->GetWindowScale());
+	ImGui::GetIO().DisplayFramebufferScale = ImVec2(1, 1); // We already scale things ourselves, this would double-apply scaling
 	ImGui::GetIO().DisplaySize.x = static_cast<float>(display->GetWindowWidth());
 	ImGui::GetIO().DisplaySize.y = static_cast<float>(display->GetWindowHeight());
 	ImGui::GetStyle() = ImGuiStyle();
@@ -111,18 +111,18 @@ void ImGuiManager::WindowResized()
 
 	const u32 new_width = display ? display->GetWindowWidth() : 0;
 	const u32 new_height = display ? display->GetWindowHeight() : 0;
-	const float new_scale = (display ? display->GetWindowScale() : 1.0f);
 
 	ImGui::GetIO().DisplaySize = ImVec2(static_cast<float>(new_width), static_cast<float>(new_height));
-	ImGui::GetIO().DisplayFramebufferScale = ImVec2(new_scale, new_scale);
 
 	UpdateScale();
 }
 
 void ImGuiManager::UpdateScale()
 {
-	const float scale =
-		std::max(ImGui::GetIO().DisplayFramebufferScale.x * static_cast<float>(EmuConfig.GS.OsdScale / 100.0), 1.0f);
+	HostDisplay* display = Host::GetHostDisplay();
+	const float window_scale = display ? display->GetWindowScale() : 1.0f;
+	const float scale = std::max(window_scale * static_cast<float>(EmuConfig.GS.OsdScale / 100.0), 1.0f);
+
 	if (scale == s_global_scale)
 		return;
 
@@ -130,8 +130,6 @@ void ImGuiManager::UpdateScale()
 	ImGui::EndFrame();
 
 	s_global_scale = scale;
-
-	HostDisplay* display = Host::GetHostDisplay();
 
 	ImGui::GetStyle() = ImGuiStyle();
 	ImGui::GetStyle().WindowMinSize = ImVec2(1.0f, 1.0f);

--- a/pcsx2/gui/AppHost.cpp
+++ b/pcsx2/gui/AppHost.cpp
@@ -178,12 +178,14 @@ static std::atomic_bool s_gs_window_resized{false};
 static std::mutex s_gs_window_resized_lock;
 static int s_new_gs_window_width = 0;
 static int s_new_gs_window_height = 0;
+static float s_new_gs_window_scale = 1;
 
-void Host::GSWindowResized(int width, int height)
+void Host::GSWindowResized(int width, int height, float scale)
 {
 	std::unique_lock lock(s_gs_window_resized_lock);
 	s_new_gs_window_width = width;
 	s_new_gs_window_height = height;
+	s_new_gs_window_scale = scale;
 	s_gs_window_resized.store(true);
 }
 
@@ -193,17 +195,19 @@ void Host::CheckForGSWindowResize()
 		return;
 
 	int width, height;
+	float scale;
 	{
 		std::unique_lock lock(s_gs_window_resized_lock);
 		width = s_new_gs_window_width;
 		height = s_new_gs_window_height;
+		scale = s_new_gs_window_scale;
 		s_gs_window_resized.store(false);
 	}
 
 	if (!s_host_display)
 		return;
 
-	s_host_display->ResizeRenderWindow(width, height, s_host_display ? s_host_display->GetWindowScale() : 1.0f);
+	s_host_display->ResizeRenderWindow(width, height, scale);
 	ImGuiManager::WindowResized();
 }
 

--- a/pcsx2/gui/AppHost.h
+++ b/pcsx2/gui/AppHost.h
@@ -4,7 +4,7 @@
 namespace Host
 {
 	// UI thread
-	void GSWindowResized(int width, int height);
+	void GSWindowResized(int width, int height, float scale);
 
 	// MTGS thread
 	void CheckForGSWindowResize();

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -212,6 +212,9 @@ GSPanel::GSPanel( wxWindow* parent )
 	}
 
 	Bind(wxEVT_SIZE, &GSPanel::OnResize, this);
+#if wxCHECK_VERSION(3, 1, 3)
+	Bind(wxEVT_DPI_CHANGED, &GSPanel::OnResize, this);
+#endif
 	Bind(wxEVT_KEY_UP, &GSPanel::OnKeyDownOrUp, this);
 	Bind(wxEVT_KEY_DOWN, &GSPanel::OnKeyDownOrUp, this);
 
@@ -349,7 +352,7 @@ std::optional<WindowInfo> GSPanel::GetWindowInfo()
 	return ret;
 }
 
-void GSPanel::OnResize(wxSizeEvent& event)
+void GSPanel::OnResize(wxEvent& event)
 {
 	if( IsBeingDeleted() ) return;
 	event.Skip();

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -384,7 +384,7 @@ void GSPanel::OnResize(wxEvent& event)
 	g_gs_window_info.surface_height = height;
 	g_gs_window_info.surface_scale = scale;
 
-	Host::GSWindowResized(width, height);
+	Host::GSWindowResized(width, height, scale);
 }
 
 void GSPanel::OnMouseEvent( wxMouseEvent& evt )

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -340,6 +340,8 @@ std::optional<WindowInfo> GSPanel::GetWindowInfo()
 #endif // GTK_MAJOR_VERSION >= 3
 #elif defined(__WXOSX__)
 	ret.type = WindowInfo::Type::MacOS;
+	ret.surface_width  = static_cast<u32>(ret.surface_width  * ret.surface_scale);
+	ret.surface_height = static_cast<u32>(ret.surface_height * ret.surface_scale);
 	ret.window_handle = GetHandle();
 #endif
 
@@ -365,13 +367,18 @@ void GSPanel::OnResize(wxEvent& event)
 	int width = gs_vp_size.GetWidth();
 	int height = gs_vp_size.GetHeight();
 
+	if (false
 #ifdef __WXGTK__
-	if (g_gs_window_info.type == WindowInfo::Type::X11)
+		|| g_gs_window_info.type == WindowInfo::Type::X11
+#endif
+#ifdef __APPLE__
+		|| g_gs_window_info.type == WindowInfo::Type::MacOS
+#endif
+	)
 	{
 		width = static_cast<int>(width * scale);
 		height = static_cast<int>(height * scale);
 	}
-#endif
 
 	g_gs_window_info.surface_width = width;
 	g_gs_window_info.surface_height = height;

--- a/pcsx2/gui/GSFrame.h
+++ b/pcsx2/gui/GSFrame.h
@@ -61,7 +61,7 @@ public:
 protected:
 	void AppStatusEvent_OnSettingsApplied();
 
-	void OnResize(wxSizeEvent& event);
+	void OnResize(wxEvent& event);
 	void OnMouseEvent( wxMouseEvent& evt );
 	void OnHideMouseTimeout( wxTimerEvent& evt );
 	void OnKeyDownOrUp( wxKeyEvent& evt );


### PR DESCRIPTION
### Description of Changes
- Adds DPI change event support when available (wx 3.1.3+)
- Fixes double-applied DPI correction on GS OSD
- Fixes GS OSD not properly reacting to changes in DPI

### Rationale behind Changes
Note: None of this is applicable to Windows because wx is great there and doesn't realize DPI scaling is a thing.  It might be applicable on Linux (esp. Wayland).  It's definitely applicable on macOS.
- OSD isn't absolutely massive when running with 200% scaling
- Windows now notice when they're dragged between displays with different DPI scaling modes
- When windows notice that they were dragged between displays with different DPI scaling modes, the OSD properly rescales itself

### Suggested Testing Steps
Drag windows between displays with different DPI scaling settings
