### PR TITLE
GS: More mipmapping fixes

### DIFF
--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -113,6 +113,10 @@ static const GSVector2i default_rt_size(1280, 1024);
 // Maximum texture size to skip preload/hash path.
 static constexpr int MAXIMUM_PRELOAD_TEXTURE_SIZE = 512;
 
+// Maximum number of mipmap levels for a texture.
+// PS2 has a max of 7 levels (1 base + 6 mips).
+static constexpr int MAXIMUM_TEXTURE_MIPMAP_LEVELS = 7;
+
 // Helper path to dump texture
 extern const std::string root_sw;
 extern const std::string root_hw;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3014,12 +3014,12 @@ GIFRegTEX0 GSState::GetTex0Layer(u32 lod)
 
 	// Correct the texture size
 	if (TEX0.TH <= lod)
-		TEX0.TH = 1;
+		TEX0.TH = 0;
 	else
 		TEX0.TH -= lod;
 
 	if (TEX0.TW <= lod)
-		TEX0.TW = 1;
+		TEX0.TW = 0;
 	else
 		TEX0.TW -= lod;
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -593,8 +593,8 @@ protected:
 	bool m_rbswapped;
 	FeatureSupport m_features;
 
-	virtual GSTexture* CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format) = 0;
-	GSTexture* FetchSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format, bool clear, bool prefer_reuse);
+	virtual GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) = 0;
+	GSTexture* FetchSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format, bool clear, bool prefer_reuse);
 
 	virtual void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) = 0;
 	virtual void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset) = 0;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -269,13 +269,12 @@ struct alignas(16) GSHWDrawConfig
 		{
 			struct
 			{
-				u8 tau   : 1;
-				u8 tav   : 1;
-				u8 biln  : 1;
-				u8 triln : 3;
-				u8 aniso : 1;
-
-				u8 _free : 1;
+				u8 tau      : 1;
+				u8 tav      : 1;
+				u8 biln     : 1;
+				u8 triln    : 3;
+				u8 aniso    : 1;
+				u8 lodclamp : 1;
 			};
 			u8 key;
 		};
@@ -316,14 +315,6 @@ struct alignas(16) GSHWDrawConfig
 		{
 			return (triln == static_cast<u8>(GS_MIN_FILTER::Nearest_Mipmap_Linear) ||
 					triln == static_cast<u8>(GS_MIN_FILTER::Linear_Mipmap_Linear));
-		}
-
-		/// Returns the maximum LOD for this sampler (0 if mipmapping is disabled).
-		__fi float GetMaxLOD() const
-		{
-			// See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerCreateInfo.html#_description
-			// for the reasoning behind 0.25f here.
-			return triln >= static_cast<u8>(GS_MIN_FILTER::Nearest_Mipmap_Nearest) ? 1000.0f : 0.25f;
 		}
 	};
 	struct DepthStencilSelector

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -288,6 +288,43 @@ struct alignas(16) GSHWDrawConfig
 			out.biln = 1;
 			return out;
 		}
+
+		/// Returns true if the effective minification filter is linear.
+		__fi bool IsMinFilterLinear() const
+		{
+			if (triln < static_cast<u8>(GS_MIN_FILTER::Nearest_Mipmap_Nearest))
+			{
+				// use the same filter as mag when mipmapping is off
+				return biln;
+			}
+			else
+			{
+				// Linear_Mipmap_Nearest or Linear_Mipmap_Linear
+				return (triln >= static_cast<u8>(GS_MIN_FILTER::Linear_Mipmap_Nearest));
+			}
+		}
+
+		/// Returns true if the effective magnification filter is linear.
+		__fi bool IsMagFilterLinear() const
+		{
+			// magnification uses biln regardless of mip mode (they're only used for minification)
+			return biln;
+		}
+
+		/// Returns true if the effective mipmap filter is linear.
+		__fi bool IsMipFilterLinear() const
+		{
+			return (triln == static_cast<u8>(GS_MIN_FILTER::Nearest_Mipmap_Linear) ||
+					triln == static_cast<u8>(GS_MIN_FILTER::Linear_Mipmap_Linear));
+		}
+
+		/// Returns the maximum LOD for this sampler (0 if mipmapping is disabled).
+		__fi float GetMaxLOD() const
+		{
+			// See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerCreateInfo.html#_description
+			// for the reasoning behind 0.25f here.
+			return triln >= static_cast<u8>(GS_MIN_FILTER::Nearest_Mipmap_Nearest) ? 1000.0f : 0.25f;
+		}
 	};
 	struct DepthStencilSelector
 	{

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -537,7 +537,7 @@ GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int width, int height
 
 	if (SUCCEEDED(hr))
 	{
-		t = new GSTexture11(std::move(texture), type, format);
+		t = new GSTexture11(std::move(texture), desc, type, format);
 		assert(type == t->GetType());
 	}
 	else

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -481,7 +481,7 @@ void GSDevice11::ClearStencil(GSTexture* t, u8 c)
 	m_ctx->ClearDepthStencilView(*(GSTexture11*)t, D3D11_CLEAR_STENCIL, 0, c);
 }
 
-GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format)
+GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format)
 {
 	D3D11_TEXTURE2D_DESC desc;
 
@@ -503,10 +503,10 @@ GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int w, int h, bool mi
 	}
 
 	// Texture limit for D3D10/11 min 1, max 8192 D3D10, max 16384 D3D11.
-	desc.Width = std::max(1, std::min(w, m_d3d_texsize));
-	desc.Height = std::max(1, std::min(h, m_d3d_texsize));
+	desc.Width = std::clamp(width, 1, m_d3d_texsize);
+	desc.Height = std::clamp(height, 1, m_d3d_texsize);
 	desc.Format = dxformat;
-	desc.MipLevels = mipmap ? (int)log2(std::max(desc.Width, desc.Height)) : 1;
+	desc.MipLevels = levels;
 	desc.ArraySize = 1;
 	desc.SampleDesc.Count = 1;
 	desc.SampleDesc.Quality = 0;
@@ -521,8 +521,8 @@ GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int w, int h, bool mi
 			desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
 			break;
 		case GSTexture::Type::Texture:
-			desc.BindFlags = mipmap ? (D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE) : D3D11_BIND_SHADER_RESOURCE;
-			desc.MiscFlags = mipmap ? D3D11_RESOURCE_MISC_GENERATE_MIPS : 0;
+			desc.BindFlags = (levels > 1) ? (D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE) : D3D11_BIND_SHADER_RESOURCE;
+			desc.MiscFlags = (levels > 1) ? D3D11_RESOURCE_MISC_GENERATE_MIPS : 0;
 			break;
 		case GSTexture::Type::Offscreen:
 			desc.Usage = D3D11_USAGE_STAGING;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1383,8 +1383,6 @@ static void preprocessSel(GSDevice11::PSSelector& sel)
 	ASSERT(sel.date      == 0); // In-shader destination alpha not supported and shouldn't be sent
 	ASSERT(sel.write_rg  == 0); // Not supported, shouldn't be sent
 	ASSERT(sel.tex_is_fb == 0); // Not supported, shouldn't be sent
-	sel.automatic_lod = 0; // Not currently supported in DX11
-	sel.manual_lod    = 0; // Not currently supported in DX11
 }
 
 void GSDevice11::RenderHW(GSHWDrawConfig& config)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -111,7 +111,7 @@ private:
 	int m_upscale_multiplier;
 	int m_d3d_texsize;
 
-	GSTexture* CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format) final;
+	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
 	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -235,6 +235,10 @@ public:
 	GSDevice11();
 	virtual ~GSDevice11() {}
 
+	__fi static GSDevice11* GetInstance() { return static_cast<GSDevice11*>(g_gs_device.get()); }
+	__fi ID3D11Device* GetD3DDevice() const { return m_dev.get(); }
+	__fi ID3D11DeviceContext* GetD3DContext() const { return m_ctx.get(); }
+
 	bool SetFeatureLevel(D3D_FEATURE_LEVEL level, bool compat_mode);
 	void GetFeatureLevel(D3D_FEATURE_LEVEL& level) const { level = m_shader.level; }
 

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.h
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.h
@@ -22,18 +22,16 @@
 
 class GSTexture11 final : public GSTexture
 {
-	wil::com_ptr_nothrow<ID3D11Device> m_dev;
-	wil::com_ptr_nothrow<ID3D11DeviceContext> m_ctx;
 	wil::com_ptr_nothrow<ID3D11Texture2D> m_texture;
-	D3D11_TEXTURE2D_DESC m_desc;
 	wil::com_ptr_nothrow<ID3D11ShaderResourceView> m_srv;
 	wil::com_ptr_nothrow<ID3D11RenderTargetView> m_rtv;
 	wil::com_ptr_nothrow<ID3D11DepthStencilView> m_dsv;
-
-	int m_layer;
+	D3D11_TEXTURE2D_DESC m_desc;
+	int m_mapped_subresource;
 
 public:
-	explicit GSTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> texture, GSTexture::Type type, GSTexture::Format format);
+	explicit GSTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> texture, const D3D11_TEXTURE2D_DESC& desc,
+		GSTexture::Type type, GSTexture::Format format);
 
 	void* GetNativeHandle() const override;
 

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.h
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.h
@@ -20,7 +20,7 @@
 #include <wil/com.h>
 #include <d3d11.h>
 
-class GSTexture11 : public GSTexture
+class GSTexture11 final : public GSTexture
 {
 	wil::com_ptr_nothrow<ID3D11Device> m_dev;
 	wil::com_ptr_nothrow<ID3D11DeviceContext> m_ctx;
@@ -31,17 +31,17 @@ class GSTexture11 : public GSTexture
 	wil::com_ptr_nothrow<ID3D11DepthStencilView> m_dsv;
 
 	int m_layer;
-	int m_max_layer;
 
 public:
-	explicit GSTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> texture, GSTexture::Format format);
+	explicit GSTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> texture, GSTexture::Type type, GSTexture::Format format);
 
 	void* GetNativeHandle() const override;
 
-	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0);
-	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0);
-	void Unmap();
-	bool Save(const std::string& fn);
+	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0) override;
+	bool Map(GSMap& m, const GSVector4i* r = NULL, int layer = 0) override;
+	void Unmap() override;
+	bool Save(const std::string& fn) override;
+	void GenerateMipmap() override;
 	bool Equal(GSTexture11* tex);
 
 	operator ID3D11Texture2D*();

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -192,6 +192,8 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 		sm.AddMacro("PS_DITHER", sel.dither);
 		sm.AddMacro("PS_ZCLAMP", sel.zclamp);
 		sm.AddMacro("PS_SCANMSK", sel.scanmsk);
+		sm.AddMacro("PS_AUTOMATIC_LOD", sel.automatic_lod);
+		sm.AddMacro("PS_MANUAL_LOD", sel.manual_lod);
 
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps;
 		CreateShader(m_tfx_source, "tfx.fx", nullptr, "ps_main", sm.GetPtr(), ps.put());

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -253,7 +253,7 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 			sd.AddressV = ssel.tav ? D3D11_TEXTURE_ADDRESS_WRAP : D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.MinLOD = 0.0f;
-			sd.MaxLOD = ssel.GetMaxLOD();
+			sd.MaxLOD = ssel.lodclamp ? 0.0f : FLT_MAX;
 			sd.MaxAnisotropy = std::clamp(anisotropy, 1, 16);
 			sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -996,6 +996,10 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 		}
 	}
 
+	// clamp to base level if we're not providing or generating mipmaps
+	// manual trilinear causes the chain to be uploaded, auto causes it to be generated
+	m_conf.sampler.lodclamp = !(trilinear_manual || trilinear_auto);
+
 	m_conf.tex = tex->m_texture;
 	m_conf.pal = tex->m_palette;
 }

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -879,8 +879,8 @@ GLuint GSDeviceOGL::CreateSampler(PSSamplerSelector sel)
 			break;
 	}
 
-	//glSamplerParameterf(sampler, GL_TEXTURE_MIN_LOD, 0);
-	//glSamplerParameterf(sampler, GL_TEXTURE_MAX_LOD, 6);
+	glSamplerParameterf(sampler, GL_TEXTURE_MIN_LOD, -1000.0f);
+	glSamplerParameterf(sampler, GL_TEXTURE_MAX_LOD, sel.lodclamp ? 0.0f : 1000.0f);
 
 	if (sel.tau)
 		glSamplerParameteri(sampler, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -198,14 +198,10 @@ void GSDeviceOGL::GenerateProfilerData()
 	}
 }
 
-GSTexture* GSDeviceOGL::CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format fmt)
+GSTexture* GSDeviceOGL::CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format)
 {
 	GL_PUSH("Create surface");
-
-	// A wrapper to call GSTextureOGL, with the different kind of parameters.
-	GSTextureOGL* t = new GSTextureOGL(type, w, h, fmt, m_fbo_read, mipmap);
-
-	return t;
+	return new GSTextureOGL(type, width, height, levels, format, m_fbo_read);
 }
 
 bool GSDeviceOGL::Create(HostDisplay* display)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -288,7 +288,7 @@ private:
 		GLuint timer() { return timer_query[last_query]; }
 	} m_profiler;
 
-	GLuint m_ps_ss[1 << 7];
+	GLuint m_ps_ss[1 << 8];
 	GSDepthStencilOGL* m_om_dss[1 << 5];
 	std::unordered_map<ProgramSelector, GL::Program, ProgramSelectorHash> m_programs;
 	GL::ShaderCache m_shader_cache;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -300,7 +300,7 @@ private:
 
 	AlignedBuffer<u8, 32> m_download_buffer;
 
-	GSTexture* CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format) final;
+	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) final;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
 	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -171,12 +171,12 @@ namespace PboPool
 	}
 } // namespace PboPool
 
-GSTextureOGL::GSTextureOGL(Type type, int w, int h, Format format, GLuint fbo_read, bool mipmap)
+GSTextureOGL::GSTextureOGL(Type type, int width, int height, int levels, Format format, GLuint fbo_read)
 	: m_clean(false), m_r_x(0), m_r_y(0), m_r_w(0), m_r_h(0), m_layer(0)
 {
 	// OpenGL didn't like dimensions of size 0
-	m_size.x = std::max(1, w);
-	m_size.y = std::max(1, h);
+	m_size.x = std::max(1, width);
+	m_size.y = std::max(1, height);
 	m_format = format;
 	m_type   = type;
 	m_fbo_read = fbo_read;
@@ -251,7 +251,7 @@ GSTextureOGL::GSTextureOGL(Type type, int w, int h, Format format, GLuint fbo_re
 	{
 		case Type::Texture:
 			// Only 32 bits input texture will be supported for mipmap
-			m_mipmap_levels = mipmap && m_format == Format::Color ? (int)log2(std::max(w, h)) : 1;
+			m_mipmap_levels = levels;
 			break;
 		case Type::SparseRenderTarget:
 		case Type::SparseDepthStencil:

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
@@ -58,7 +58,7 @@ private:
 	u32 m_mem_usage;
 
 public:
-	explicit GSTextureOGL(Type type, int w, int h, Format format, GLuint fbo_read, bool mipmap);
+	explicit GSTextureOGL(Type type, int width, int height, int levels, Format format, GLuint fbo_read);
 	virtual ~GSTextureOGL();
 
 	void* GetNativeHandle() const override;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -952,20 +952,11 @@ VkSampler GSDeviceVK::GetSampler(GSHWDrawConfig::SamplerSelector ss)
 
 	const bool aniso = (ss.aniso && GSConfig.MaxAnisotropy > 1);
 
-	static constexpr std::array<VkSamplerMipmapMode, 6> mipmap_modes = {{
-		VK_SAMPLER_MIPMAP_MODE_NEAREST, // Nearest
-		VK_SAMPLER_MIPMAP_MODE_NEAREST, // Linear
-		VK_SAMPLER_MIPMAP_MODE_NEAREST, // Nearest_Mipmap_Nearest
-		VK_SAMPLER_MIPMAP_MODE_LINEAR, // Nearest_Mipmap_Linear
-		VK_SAMPLER_MIPMAP_MODE_NEAREST, // Linear_Mipmap_Nearest
-		VK_SAMPLER_MIPMAP_MODE_LINEAR, // Linear_Mipmap_Linear
-	}};
-
 	const VkSamplerCreateInfo ci = {
 		VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO, nullptr, 0,
-		ss.biln ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, // min
-		ss.biln ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, // max
-		mipmap_modes[ss.triln], // mip
+		ss.IsMinFilterLinear() ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, // min
+		ss.IsMagFilterLinear() ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, // mag
+		ss.IsMipFilterLinear() ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST, // mip
 		static_cast<VkSamplerAddressMode>(
 			ss.tau ? VK_SAMPLER_ADDRESS_MODE_REPEAT : VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE), // u
 		static_cast<VkSamplerAddressMode>(
@@ -976,8 +967,8 @@ VkSampler GSDeviceVK::GetSampler(GSHWDrawConfig::SamplerSelector ss)
 		aniso ? static_cast<float>(GSConfig.MaxAnisotropy) : 1.0f, // anisotropy
 		VK_FALSE, // compare enable
 		VK_COMPARE_OP_ALWAYS, // compare op
-		-1000.0f, // min lod
-		(ss.triln >= static_cast<u8>(GS_MIN_FILTER::Nearest_Mipmap_Nearest)) ? 1000.0f : 0.0f, // max lod
+		0.0f, // min lod
+		ss.GetMaxLOD(), // max lod
 		VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK, // border
 		VK_FALSE // unnormalized coordinates
 	};

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -951,6 +951,8 @@ VkSampler GSDeviceVK::GetSampler(GSHWDrawConfig::SamplerSelector ss)
 
 	const bool aniso = (ss.aniso && GSConfig.MaxAnisotropy > 1);
 
+	// See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerCreateInfo.html#_description
+	// for the reasoning behind 0.25f here.
 	const VkSamplerCreateInfo ci = {
 		VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO, nullptr, 0,
 		ss.IsMinFilterLinear() ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, // min
@@ -967,7 +969,7 @@ VkSampler GSDeviceVK::GetSampler(GSHWDrawConfig::SamplerSelector ss)
 		VK_FALSE, // compare enable
 		VK_COMPARE_OP_ALWAYS, // compare op
 		0.0f, // min lod
-		ss.GetMaxLOD(), // max lod
+		ss.lodclamp ? 0.25f : VK_LOD_CLAMP_NONE, // max lod
 		VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK, // border
 		VK_FALSE // unnormalized coordinates
 	};

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -338,16 +338,15 @@ void GSDeviceVK::ClearStencil(GSTexture* t, u8 c)
 	static_cast<GSTextureVK*>(t)->TransitionToLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 }
 
-GSTexture* GSDeviceVK::CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format)
+GSTexture* GSDeviceVK::CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format)
 {
 	pxAssert(type != GSTexture::Type::Offscreen && type != GSTexture::Type::SparseRenderTarget &&
 			 type != GSTexture::Type::SparseDepthStencil);
 
-	const u32 width = std::max<u32>(1, std::min<u32>(w, g_vulkan_context->GetMaxImageDimension2D()));
-	const u32 height = std::max<u32>(1, std::min<u32>(h, g_vulkan_context->GetMaxImageDimension2D()));
-	const u32 layers = mipmap ? static_cast<u32>(log2(std::max(w, h))) : 1u;
+	const u32 clamped_width = static_cast<u32>(std::clamp<int>(1, width, g_vulkan_context->GetMaxImageDimension2D()));
+	const u32 clamped_height = static_cast<u32>(std::clamp<int>(1, height, g_vulkan_context->GetMaxImageDimension2D()));
 
-	return GSTextureVK::Create(type, width, height, layers, format).release();
+	return GSTextureVK::Create(type, clamped_width, clamped_height, levels, format).release();
 }
 
 bool GSDeviceVK::DownloadTexture(GSTexture* src, const GSVector4i& rect, GSTexture::GSMap& out_map)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -158,7 +158,7 @@ private:
 
 	std::string m_tfx_source;
 
-	GSTexture* CreateSurface(GSTexture::Type type, int w, int h, bool mipmap, GSTexture::Format format) override;
+	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) override;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE,
 		const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -354,7 +354,6 @@ HacksTab::HacksTab(wxWindow* parent)
 	auto hw_prereq = [this]{ return m_is_hardware; };
 	auto* hacks_check_box = m_ui.addCheckBox(tab_box.inner, "Enable HW Hacks", "UserHacks", -1, hw_prereq);
 	auto hacks_prereq = [this, hacks_check_box]{ return m_is_hardware && hacks_check_box->GetValue(); };
-	auto gl_or_vk_hacks_prereq = [this, hacks_check_box]{ return (m_is_ogl_hw || m_is_vk_hw) && hacks_check_box->GetValue(); };
 	auto upscale_hacks_prereq = [this, hacks_check_box]{ return !m_is_native_res && hacks_check_box->GetValue(); };
 
 	PaddedBoxSizer<wxStaticBoxSizer> rend_hacks_box   (wxVERTICAL, this, "Renderer Hacks");
@@ -384,7 +383,7 @@ HacksTab::HacksTab(wxWindow* parent)
 
 	// Renderer Hacks:
 	m_ui.addComboBoxAndLabel(rend_hack_choice_grid, "Half Screen Fix:",     "UserHacks_Half_Bottom_Override", &theApp.m_gs_generic_list, IDC_HALF_SCREEN_TS, hacks_prereq);
-	m_ui.addComboBoxAndLabel(rend_hack_choice_grid, "Trilinear Filtering:", "UserHacks_TriFilter",            &theApp.m_gs_trifilter,    IDC_TRI_FILTER,     gl_or_vk_hacks_prereq);
+	m_ui.addComboBoxAndLabel(rend_hack_choice_grid, "Trilinear Filtering:", "UserHacks_TriFilter",            &theApp.m_gs_trifilter,    IDC_TRI_FILTER,     hacks_prereq);
 
 	// Skipdraw Range
 	add_label(this, rend_hack_choice_grid, "Skipdraw Range:", IDC_SKIPDRAWHACK);


### PR DESCRIPTION
### Description of Changes

More fixes to the mess that mipmapping is in the hardware renderers.

 - Out of bounds uploads were occurring, probably the cause of device loss in #5286.
 - DX11 wasn't clamping the LOD, leading to undefined texels being loaded when mipmapping was enabled (e.g. SOTC).
 - Enables trilinear filtering in DX11.

### Suggested Testing Steps

Test Jak II, SOTC, other games which currently have issues.
