### PR TITLE
GS: Faster texture preloading

### DIFF
--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -111,7 +111,23 @@ static const GSVector2i default_rt_size(1280, 1024);
 #endif
 
 // Maximum texture size to skip preload/hash path.
-static constexpr int MAXIMUM_PRELOAD_TEXTURE_SIZE = 512;
+// This is the width/height from the registers, i.e. not the power of 2.
+__fi static bool CanPreloadTextureSize(u32 tw, u32 th)
+{
+	static constexpr u32 MAXIMUM_SIZE_IN_ONE_DIRECTION = 10; // 1024
+	static constexpr u32 MAXIMUM_SIZE_IN_OTHER_DIRECTION = 8; // 256
+	static constexpr u32 MAXIMUM_SIZE_IN_BOTH_DIRECTIONS = 9; // 512
+
+	// We use an area-based approach here. We want to hash long font maps,
+	// like 128x1024 (used in FFX), but skip 1024x512 textures (e.g. Xenosaga).
+	const u32 max_dimension = (tw > th) ? tw : th;
+	const u32 min_dimension = (tw > th) ? th : tw;
+	if (max_dimension <= MAXIMUM_SIZE_IN_BOTH_DIRECTIONS)
+		return true;
+
+	return (max_dimension <= MAXIMUM_SIZE_IN_ONE_DIRECTION &&
+			min_dimension <= MAXIMUM_SIZE_IN_OTHER_DIRECTION);
+}
 
 // Maximum number of mipmap levels for a texture.
 // PS2 has a max of 7 levels (1 base + 6 mips).

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2558,8 +2558,7 @@ void GSState::GetTextureMinMax(GSVector4i& r, const GIFRegTEX0& TEX0, const GIFR
 
 	// don't bother checking when preload is on, since we're going to test the whole thing anyway
 	if (GSConfig.PreloadTexture && GSConfig.UseHardwareRenderer() &&
-      (GSConfig.GPUPaletteConversion ||
-       (w <= MAXIMUM_PRELOAD_TEXTURE_SIZE && h <= MAXIMUM_PRELOAD_TEXTURE_SIZE)))
+		CanPreloadTextureSize(static_cast<u32>(tw), static_cast<u32>(th)))
 	{
 		r = tr;
 		return;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -100,16 +100,18 @@ public:
 
 	class Source : public Surface
 	{
+	public:
+		using HashType = u64;
+
+	private:
 		struct
 		{
 			GSVector4i* rect;
 			u32 count;
 		} m_write;
 
-		using HashType = u64;
-
-		HashType HashTexture(u8* buff, u32 row_size, u32 pitch, u32 height);
-		void PreloadUpdate(int tw, int th, int layer);
+		void PreloadLevel(int level);
+		void PreloadSmallLevel(int level);
 
 		void Write(const GSVector4i& r, int layer);
 		void Flush(u32 count, int layer);
@@ -120,8 +122,8 @@ public:
 		u32 m_valid[MAX_PAGES]; // each u32 bits map to the 32 blocks of that page
 		GSVector4i m_valid_rect;
 		u8 m_valid_hashes = 0;
+		u8 m_complete_layers = 0;
 		bool m_target;
-		bool m_complete;
 		bool m_repeating;
 		std::vector<GSVector2i>* m_p2t;
 		// Keep a trace of the target origin. There is no guarantee that pointer will
@@ -138,6 +140,8 @@ public:
 	public:
 		Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, u8* temp, bool dummy_container = false);
 		virtual ~Source();
+
+		__fi bool CanPreload() const { return (GSConfig.PreloadTexture && CanPreloadTextureSize(m_TEX0.TW, m_TEX0.TH)); }
 
 		void Update(const GSVector4i& rect, int layer = 0);
 		void UpdateLayer(const GIFRegTEX0& TEX0, const GSVector4i& rect, int layer = 0);


### PR DESCRIPTION
### Description of Changes

Currently, we expand the texture, then hash the RGBA8 texture (when paltex is off). This is a lot of extra work when the texture data potentially hasn't changed.

So, instead, let's hash the GS blocks which back the texture.

There is the *potential* to have a few false positives here, since for tiny textures, the padding bytes in the block may be different. But worst case scenario, this just means an extra upload, which for tiny textures isn't a huge deal. The CPU savings from not expanding are more than worth it.

Based on #5290 for ease of testing.

### Suggested Testing Steps

Test with preloading enabled, make sure performance is not worse (should be better in texture streaming heavy games, assuming no other bottlenecks).