### PR TITLE
GS: Support wrapping off-the-end offsets in new GSOffset

### DIFF
--- a/pcsx2/GS/GSTables.cpp
+++ b/pcsx2/GS/GSTables.cpp
@@ -320,9 +320,9 @@ constexpr GSSizedPixelRowOffsetTable<BlocksWide * ColWidth> makeRowOffsetTable(c
 {
 	int base = pxOffset(blockTable, colTable, 0, y);
 	GSSizedPixelRowOffsetTable<BlocksWide * ColWidth> table = {};
-	for (int x = 0; x < 2048; x++) 
+	for (size_t x = 0; x < std::size(table.value); x++)
 	{
-		table.value[x] = pxOffset(blockTable, colTable, x, y) - base;
+		table.value[x] = pxOffset(blockTable, colTable, x % 2048, y) - base;
 	}
 	return table;
 }

--- a/pcsx2/GS/GSTables.h
+++ b/pcsx2/GS/GSTables.h
@@ -50,11 +50,11 @@ struct alignas(128) GSPixelColOffsetTable
 /// Unlike ColOffsets, this table stretches to the maximum size of a texture so no masking is needed
 struct alignas(128) GSPixelRowOffsetTable
 {
-	int value[2048] = {};
+	int value[4096] = {};
 
 	int operator[](size_t x) const
 	{
-		ASSERT(x < 2048);
+		ASSERT(x < 4096);
 		return value[x];
 	}
 };


### PR DESCRIPTION
### Description of Changes
Extends GS row offset tables to 4096 entries for wrapping

### Rationale behind Changes
Fixes issue introduced by new GSOffset

### Suggested Testing Steps
Test WWE SmackDown vs. Raw 2008
