### PR TITLE
GIF: Separate GIF Reset and GIF DMA Reset

### DIFF
--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -86,9 +86,9 @@ void GIF_Fifo::init()
 	memzero(data);
 	fifoSize = 0;
 	gifRegs.stat.FQC = 0;
-	CSRreg.FIFO = CSR_FIFO_EMPTY;
+
 	gif.gifstate = GIF_STATE_READY;
-	gif.gspath3done = false;
+	gif.gspath3done = true;
 
 	gif.gscycles = 0;
 	gif.prevcycles = 0;

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -542,12 +542,13 @@ struct Gif_Unit
 	}
 
 	// Resets Gif HW Regs
+	// Warning: Do not mess with the DMA here, the reset does *NOT* touch this.
 	void ResetRegs()
 	{
 		gifRegs.stat.reset();
 		gifRegs.ctrl.reset();
 		gifRegs.mode.reset();
-		gif_fifo.init();
+		CSRreg.FIFO = CSR_FIFO_EMPTY; // This is the GIF unit side FIFO, not DMA!
 	}
 
 	// Adds a finished GS Packet to the MTGS ring buffer


### PR DESCRIPTION
### Description of Changes
Removes DMA reset stuff from a GIF reset.

### Rationale behind Changes
The two shouldn't be reset together anyway, the GIF has no control over the DMA, it was incorrect and causing currently running DMA's to get stuck in an infinite loop.

### Suggested Testing Steps
Run games, make sure they still work, no specific games here (Except Air Ranger 2) was known to be affected directly, but the adverse is unknown.

Fixes Air Ranger 2 - Rescue Helicopter infinite loop on boot.
