### PR TITLE
GUI: Convert Power plan name to UTF-8

### DIFF
--- a/pcsx2/windows/WinPowerProfile.cpp
+++ b/pcsx2/windows/WinPowerProfile.cpp
@@ -14,13 +14,13 @@
 */
 
 #include "PrecompiledHeader.h"
+#include "common/StringUtil.h"
 #include <powrprof.h>
 #include <wil/com.h>
 
 using unique_any_guidptr = wil::unique_any<GUID*, decltype(&::LocalFree), ::LocalFree>;
 
 // Checks the current active power plan
-// If the power plan isn't named 'high performance', put a little message in the console
 // This function fails silently
 void CheckIsUserOnHighPerfPowerPlan()
 {
@@ -32,6 +32,7 @@ void CheckIsUserOnHighPerfPowerPlan()
 	UCHAR aBuffer[2048];
 	DWORD aBufferSize = sizeof(aBuffer);
 	ret = PowerReadFriendlyName(NULL, pPwrGUID.get(), &NO_SUBGROUP_GUID, NULL, aBuffer, &aBufferSize);
+	std::string friendlyName(StringUtil::WideStringToUTF8String((wchar_t*)aBuffer));
 	if (ret != ERROR_SUCCESS)
 		return;
 
@@ -43,5 +44,5 @@ void CheckIsUserOnHighPerfPowerPlan()
 		PowerReadDCValueIndex(NULL, pPwrGUID.get(), &GUID_PROCESSOR_SETTINGS_SUBGROUP, &GUID_PROCESSOR_THROTTLE_MINIMUM, &dcMin))
 		return;
 
-	Console.WriteLn("The current power profile is '%S'.\nThe current min / max processor states\nAC: %d%% / %d%%\nBattery: %d%% / %d%%\n", aBuffer,acMin,acMax,dcMin,dcMax);
+	Console.WriteLn("The current power profile is '%s'.\nThe current min / max processor states\nAC: %d%% / %d%%\nBattery: %d%% / %d%%\n", friendlyName.c_str(), acMin, acMax, dcMin, dcMax);
 }


### PR DESCRIPTION
### Description of Changes
Converts the string returned by the "Get friendly power plan name" to UTF-8 from wide string

### Rationale behind Changes
Trying to print funny characters from a wide string does not work very well, at least for us, and it was causing the entire string not to be printed at all.

### Suggested Testing Steps
On windows only, start PCSX2, see if it says your power plan settings in the console window.
