### PR TITLE
PAD: Clean up the remains of the old logging code from when this was Onepad.

### DIFF
--- a/pcsx2/PAD/Linux/Config.cpp
+++ b/pcsx2/PAD/Linux/Config.cpp
@@ -65,12 +65,11 @@ void PADSaveConfig()
 	f = fopen(iniFile.c_str(), "w");
 	if (f == NULL)
 	{
-		printf("PAD: failed to save ini %s\n", iniFile.c_str());
+		Console.Warning("PAD: failed to save ini %s", iniFile.c_str());
 		return;
 	}
 
 	fprintf(f, "first_time_wizard = %d\n", g_conf.ftw);
-	fprintf(f, "log = %d\n", g_conf.log);
 	fprintf(f, "options = %d\n", g_conf.packed_options);
 	fprintf(f, "mouse_sensibility = %d\n", g_conf.get_sensibility());
 	fprintf(f, "ff_intensity = %g\n", g_conf.get_ff_intensity());
@@ -103,7 +102,7 @@ void PADLoadConfig()
 	f = fopen(iniFile.c_str(), "r");
 	if (f == nullptr)
 	{
-		printf("OnePAD: failed to load ini %s\n", iniFile.c_str());
+		Console.Warning("PAD: failed to load ini %s", iniFile.c_str());
 		PADSaveConfig(); //save and return
 		return;
 	}
@@ -113,9 +112,6 @@ void PADLoadConfig()
 
 	if (fscanf(f, "first_time_wizard = %u\n", &value) == 1)
 		g_conf.ftw = value;
-
-	if (fscanf(f, "log = %u\n", &value) == 1)
-		g_conf.log = value;
 
 	if (fscanf(f, "options = %u\n", &value) == 1)
 		g_conf.packed_options = value;

--- a/pcsx2/PAD/Linux/Config.h
+++ b/pcsx2/PAD/Linux/Config.h
@@ -39,7 +39,6 @@ public:
 		u32 packed_options;            // Only first 8 bits of each 16 bits series are really used, rest is padding
 	};
 
-	u32 log;
 	u32 ftw;
 	std::map<u32, u32> keysym_map[GAMEPAD_NUMBER];
 	std::array<size_t, GAMEPAD_NUMBER> unique_id;
@@ -50,7 +49,6 @@ public:
 
 	void init()
 	{
-		log = 0;
 		ftw = 1;
 		packed_options = 0;
 		ff_intensity = 1.0; // set it at max value by default

--- a/pcsx2/PAD/Linux/Global.h
+++ b/pcsx2/PAD/Linux/Global.h
@@ -114,6 +114,5 @@ static bool IsAnalogKey(int index)
 
 #include "KeyStatus.h"
 
-void __LogToConsole(const char* fmt, ...);
 void PADLoadConfig();
 void PADSaveConfig();

--- a/pcsx2/PAD/Linux/PAD.cpp
+++ b/pcsx2/PAD/Linux/PAD.cpp
@@ -51,58 +51,12 @@ HostKeyEvent event;
 static HostKeyEvent s_event;
 std::string s_padstrLogPath("logs/");
 
-FILE* padLog = NULL;
-
 KeyStatus g_key_status;
 
 MtQueue<HostKeyEvent> g_ev_fifo;
 
-
-void __LogToConsole(const char* fmt, ...)
-{
-	va_list list;
-
-	va_start(list, fmt);
-
-	if (padLog != NULL)
-		vfprintf(padLog, fmt, list);
-
-	printf("PAD: ");
-	vprintf(fmt, list);
-	va_end(list);
-}
-
-void initLogging()
-{
-#ifdef PAD_LOG
-	if (padLog)
-		return;
-
-	const std::string LogFile(s_padstrLogPath + "padLog.txt");
-	padLog = fopen(LogFile.c_str(), "w");
-
-	if (padLog)
-		setvbuf(padLog, NULL, _IONBF, 0);
-
-	PAD_LOG("PADinit\n");
-#endif
-}
-
-void CloseLogging()
-{
-#ifdef PAD_LOG
-	if (padLog)
-	{
-		fclose(padLog);
-		padLog = NULL;
-	}
-#endif
-}
-
 s32 PADinit()
 {
-	initLogging();
-
 	PADLoadConfig();
 
 	Pad::reset_all();
@@ -117,7 +71,6 @@ s32 PADinit()
 
 void PADshutdown()
 {
-	CloseLogging();
 }
 
 s32 PADopen(const WindowInfo& wi)
@@ -270,7 +223,7 @@ HostKeyEvent* PADkeyEvent()
 #ifdef __unix__
 	if (g_ev_fifo.size() == 0)
 	{
-		// PAD_LOG("No events in queue, returning empty event\n");
+		//PAD_LOG("No events in queue, returning empty event");
 		s_event = event;
 		event.type = HostKeyEvent::Type::NoEvent;
 		event.key = 0;
@@ -279,7 +232,7 @@ HostKeyEvent* PADkeyEvent()
 	s_event = g_ev_fifo.dequeue();
 
 	AnalyzeKeyEvent(s_event);
-	// PAD_LOG("Returning Event. Event Type: %d, Key: %d\n", s_event.evt, s_event.key);
+	//PAD_LOG("Returning Event. Event Type: %d, Key: %d", s_event.type, s_event.key);
 	return &s_event;
 #else // MacOS
 	s_event = event;
@@ -293,7 +246,7 @@ HostKeyEvent* PADkeyEvent()
 void PADWriteEvent(HostKeyEvent& evt)
 {
 	// if (evt.evt != 6) { // Skip mouse move events for logging
-	//     PAD_LOG("Pushing Event. Event Type: %d, Key: %d\n", evt.evt, evt.key);
+	//     PAD_LOG("Pushing Event. Event Type: %d, Key: %d", evt.type, evt.key);
 	// }
 	g_ev_fifo.push(evt);
 }

--- a/pcsx2/PAD/Linux/SDL/joystick.cpp
+++ b/pcsx2/PAD/Linux/SDL/joystick.cpp
@@ -177,7 +177,7 @@ JoystickInfo::JoystickInfo(int id)
 
 	if (joy == nullptr)
 	{
-		fprintf(stderr, "PAD: failed to open joystick %d\n", id);
+		Console.Warning("PAD: failed to open joystick %d", id);
 		return;
 	}
 
@@ -188,7 +188,7 @@ JoystickInfo::JoystickInfo(int id)
 
 	if (m_controller == nullptr)
 	{
-		fprintf(stderr, "PAD: Joystick (%s,GUID:%s) isn't yet supported by the SDL2 game controller API\n"
+		Console.Warning("PAD: Joystick (%s,GUID:%s) isn't yet supported by the SDL2 game controller API\n"
 		                "You can use SDL2 Gamepad Tool (https://www.generalarcade.com/gamepadtool/) or Steam to configure your joystick\n"
 		                "The mapping can be stored in PAD.ini as 'SDL2 = <...mapping description...>'\n"
 		                "Please post the new generated mapping to (https://github.com/gabomdq/SDL_GameControllerDB) so it can be added to the database.",
@@ -204,7 +204,7 @@ JoystickInfo::JoystickInfo(int id)
 
 	bool rumble_support = SDL_GameControllerRumble(m_controller, 0, 0, 1) >= 0;
 
-	fprintf(stdout, "PAD: controller (%s) detected%s, GUID:%s\n",
+	Console.WriteLn("PAD: controller (%s) detected%s, GUID:%s",
 			m_device_name.c_str(), rumble_support ? " with rumble support" : "", guid);
 
 	m_no_error = true;

--- a/pcsx2/PAD/Linux/keyboard.cpp
+++ b/pcsx2/PAD/Linux/keyboard.cpp
@@ -162,7 +162,7 @@ void AnalyzeKeyEvent(HostKeyEvent& evt)
 			if (index != -1)
 				PressButton(pad, index);
 
-			//PAD_LOG("Key pressed:%d\n", index);
+			//PAD_LOG("Key pressed:%d", index);
 
 			event.type = HostKeyEvent::Type::KeyPressed;
 			event.key = key;


### PR DESCRIPTION
### Description of Changes
Removed code for opening a log file and the option for it in the ini. I also changed some occurrences of printf to use Console, and fixed the commented out code.

### Rationale behind Changes
Since PAD_LOG is just the built-in tracing now, the code for creating a log file wasn't needed, and was creating an unused file. The removed option didn't have anything in the dialog box controlling it.

### Suggested Testing Steps
Make sure the logging still works and that the log file it was creating is no longer there.
