### PR TITLE
DEV9: Check for null ifa_addr in PCAPGetIfAdapter

### DIFF
--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -125,7 +125,7 @@ bool PCAPGetIfAdapter(char* name, ifaddrs* adapter, ifaddrs** buffer)
 
 	do
 	{
-		if (pAdapter->ifa_addr->sa_family == AF_INET && strcmp(pAdapter->ifa_name, name) == 0)
+		if (pAdapter->ifa_addr != nullptr && pAdapter->ifa_addr->sa_family == AF_INET && strcmp(pAdapter->ifa_name, name) == 0)
 			break;
 
 		pAdapter = pAdapter->ifa_next;


### PR DESCRIPTION
### Description of Changes
Adds a null check for ifa_addr in PCAPGetIfAdapter()

### Rationale behind Changes
Some interface adapters will have this field set to null, as we try to match the specified adapter to the list of adapters returned in `getifaddrs()` we will crash if we encounter such an adapter

### Suggested Testing Steps
Test on Linux systems with multiple adapters, with at least one that is unconnected.
