### PR TITLE
Build: Use git tag for the file version on windows

### DIFF
--- a/common/vsprops/preBuild.cmd
+++ b/common/vsprops/preBuild.cmd
@@ -55,6 +55,13 @@ if %ERRORLEVEL% NEQ 0 (
     echo #define SVN_REV 0ll >> "%CD%\svnrev.h"
     echo #define GIT_REV "" >> "%CD%\svnrev.h"
     echo #define GIT_TAG "%GIT_TAG%" >> "%CD%\svnrev.h"
+
+    for /F "tokens=1,2,3 delims=v." %%a in ("%GIT_TAG%") do (
+      echo #define GIT_TAG_HI %%a >> "%CD%\svnrev.h"
+      echo #define GIT_TAG_MID %%b >> "%CD%\svnrev.h"
+      echo #define GIT_TAG_LO %%c >> "%CD%\svnrev.h"
+    )
+
     echo #define GIT_TAGGED_COMMIT 1 >> "%CD%\svnrev.h"
   ) else (
     echo #define SVN_REV %REV%ll > "%CD%\svnrev.h"

--- a/pcsx2/SysForwardDefs.h
+++ b/pcsx2/SysForwardDefs.h
@@ -14,10 +14,19 @@
  */
 
 #pragma once
+#include "svnrev.h"
 
-#define PCSX2_VersionHi     1
-#define PCSX2_VersionMid    7
-#define PCSX2_VersionLo     0
+#define PCSX2_isReleaseVersion false
+
+#if PCSX2_isReleaseVersion == false && GIT_TAGGED_COMMIT
+#define PCSX2_VersionHi  GIT_TAG_HI
+#define PCSX2_VersionMid GIT_TAG_MID
+#define PCSX2_VersionLo  GIT_TAG_LO
+#else
+#define PCSX2_VersionHi  1
+#define PCSX2_VersionMid 7
+#define PCSX2_VersionLo  0
+#endif
 
 #define STRINGIZE2(s) #s
 #define STRINGIZE(s) STRINGIZE2(s)
@@ -35,8 +44,6 @@
 #define VER_ORIGINAL_FILENAME_STR   VER_PRODUCTNAME_STR ".exe"
 #define VER_INTERNAL_NAME_STR       VER_ORIGINAL_FILENAME_STR
 #define VER_COPYRIGHT_STR           "Copyright (C) 2021"
-
-static const bool PCSX2_isReleaseVersion = 0;
 
 class SysCoreThread;
 

--- a/pcsx2/SysForwardDefs.h
+++ b/pcsx2/SysForwardDefs.h
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2010  PCSX2 Dev Team
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -43,7 +43,7 @@
 #define VER_PRODUCT_VERSION_STR     VER_FILE_VERSION_STR
 #define VER_ORIGINAL_FILENAME_STR   VER_PRODUCTNAME_STR ".exe"
 #define VER_INTERNAL_NAME_STR       VER_ORIGINAL_FILENAME_STR
-#define VER_COPYRIGHT_STR           "Copyright (C) 2021"
+#define VER_COPYRIGHT_STR           "Copyright (C) 2022"
 
 class SysCoreThread;
 


### PR DESCRIPTION
### Description of Changes
Uses the Git tag for the file version (And anything else that uses PCSX2_VersionHi/Mid/Lo)

![image](https://user-images.githubusercontent.com/4604733/150025201-95bc5358-e13f-4673-8d93-d8986977ae1f.png)

### Rationale behind Changes
Have the Git tag visible in the file details pane on Windows

### Suggested Testing Steps
Hope nothing breaks
