### PR TITLE
GS: Misc fixes from refactoring/Vulkan renderer

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -316,7 +316,13 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 		return false;
 	}
 
-	return DoGSOpen(renderer, basemem);
+	if (!DoGSOpen(renderer, basemem))
+	{
+		Host::ReleaseHostDisplay();
+		return false;
+	}
+
+	return true;
 }
 
 void GSreset()

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -23,7 +23,7 @@ void Host::ReportFormattedErrorAsync(const std::string_view& title, const char* 
 	std::va_list ap;
 	va_start(ap, format);
 	FastFormatAscii fmt;
-	fmt.WriteV(fmt, ap);
+	fmt.WriteV(format, ap);
 	va_end(ap);
 	ReportErrorAsync(title, fmt.c_str());
 }


### PR DESCRIPTION
- Release host display when device creation fails (e.g. shader creation). Stops the assert firing when you try to start again.
- Fix formatted async error reporting back to the frontend.
- Ensure that all the required formats are supported by the Vulkan driver before going and using them. There shouldn't be anything out there that doesn't support the formats we need, but better to be safe than crashing with random allocation failures later on.