### PR TITLE
Debugger & Core: Lighten IOP breakpoints and fix the memory search

### DIFF
--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -169,6 +169,4 @@ private:
 
 
 // called from the dynarec
-u32 __fastcall standardizeBreakpointAddress(BreakPointCpu cpu, u32 addr);
-u32 __fastcall standardizeBreakpointAddressEE(u32 addr);
-u32 __fastcall standardizeBreakpointAddressIop(u32 addr);
+u32 __fastcall standardizeBreakpointAddress(u32 addr);

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -43,13 +43,6 @@ static void intEventTest();
 
 // These macros are used to assemble the repassembler functions
 
-static void debugI()
-{
-	if( !IsDevBuild ) return;
-	if( cpuRegs.GPR.n.r0.UD[0] || cpuRegs.GPR.n.r0.UD[1] ) Console.Error("R0 is not zero!!!!");
-}
-
-
 void intBreakpoint(bool memcheck)
 {
 	u32 pc = cpuRegs.pc;
@@ -79,7 +72,7 @@ void intMemcheck(u32 op, u32 bits, bool store)
 	if (bits == 128)
 		start &= ~0x0F;
 
-	start = standardizeBreakpointAddress(BREAKPOINT_EE, start);
+	start = standardizeBreakpointAddress(start);
 	u32 end = start + bits/8;
 	
 	auto checks = CBreakPoints::GetMemChecks();
@@ -140,7 +133,7 @@ static void execI()
 	// Extra note: due to some cycle count issue PCSX2's internal debugger is
 	// not yet usable with the interpreter
 //#define EXTRA_DEBUG
-#ifdef EXTRA_DEBUG
+#if defined(EXTRA_DEBUG) || defined(PCSX2_DEVBUILD)
 	// check if any breakpoints or memchecks are triggered by this instruction
 	if (isBreakpointNeeded(cpuRegs.pc))
 		intBreakpoint(false);
@@ -155,11 +148,6 @@ static void execI()
 
 	// interprete instruction
 	cpuRegs.code = memRead32( pc );
-	// Honestly I think this code is useless nowadays.
-#ifdef EXTRA_DEBUG
-	if( IsDebugBuild )
-		debugI();
-#endif
 
 	const OPCODE& opcode = GetCurrentInstruction();
 #if 0

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -153,10 +153,7 @@ void psxMemcheck(u32 op, u32 bits, bool store)
 	u32 start = psxRegs.GPR.r[(op >> 21) & 0x1F];
 	if ((s16)op != 0)
 		start += (s16)op;
-	if (bits == 128)
-		start &= ~0x0F;
 
-	start = standardizeBreakpointAddress(BREAKPOINT_IOP, start);
 	u32 end = start + bits / 8;
 
 	auto checks = CBreakPoints::GetMemChecks();
@@ -204,9 +201,6 @@ void psxCheckMemcheck()
 	case MEMTYPE_DWORD:
 		psxMemcheck(op, 64, store);
 		break;
-	case MEMTYPE_QWORD:
-		psxMemcheck(op, 128, store);
-		break;
 	}
 }
 
@@ -218,7 +212,7 @@ static __fi void execI()
 	// This function is called for every instruction.
 	// Enabling the define below will probably, no, will cause the interpretor to be slower.
 //#define EXTRA_DEBUG
-#ifdef EXTRA_DEBUG
+#if defined(EXTRA_DEBUG) || defined(PCSX2_DEVBUILD)
 	if (psxIsBreakpointNeeded(psxRegs.pc))
 		psxBreakpoint(false);
 

--- a/pcsx2/gui/Debugger/CtrlMemSearch.cpp
+++ b/pcsx2/gui/Debugger/CtrlMemSearch.cpp
@@ -33,6 +33,7 @@ wxDEFINE_EVENT(pxEvt_SearchFinished, wxCommandEvent);
 wxBEGIN_EVENT_TABLE(CtrlMemSearch, wxWindow)
 	EVT_SET_FOCUS(CtrlMemSearch::focusEvent)
 	EVT_KILL_FOCUS(CtrlMemSearch::focusEvent)
+	EVT_SIZE(CtrlMemSearch::sizeEvent)
 wxEND_EVENT_TABLE()
 
 enum MemoryViewMenuIdentifiers {

--- a/pcsx2/gui/Debugger/CtrlMemSearch.h
+++ b/pcsx2/gui/Debugger/CtrlMemSearch.h
@@ -73,6 +73,13 @@ private:
 	void postEvent(wxEventType type, int value);
 	void onPopupClick(wxCommandEvent& evt);
 	void focusEvent(wxFocusEvent& evt) { Refresh(); };
+	void sizeEvent(wxSizeEvent& evt)
+	{
+		// Why in the world do I have to do this.
+		// Without this the window isn't redrawn during a size event
+		Refresh(); // Reloads the window, fixes the imporper drawing but ruins the layout
+		Layout(); // Fix the layout of the window
+	};
 	void onSearchFinished(wxCommandEvent& evt);
 	void onSearchNext(wxCommandEvent& evt);
 	void onSearchPrev(wxCommandEvent& evt);

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -116,9 +116,7 @@ CpuTabPage::CpuTabPage(wxWindow* parent, DebugInterface* _cpu)
 	wxBoxSizer *memorySizer = new wxBoxSizer(wxHORIZONTAL);
 	memorySizer->Add(memory, 1, wxEXPAND);
 
-	// Unfortuneately hacky, probably cause I'm bad at wxWidgets
-	// A max width of 360 ensures that the memory view will never be blocked by the memory search
-	memorySearch->SetMaxSize(wxSize(360, -1));
+	memorySearch->SetMaxSize(wxSize(310 * MSW_GetDPIScale(), -1));
 	memorySizer->Add(memorySearch, 1, wxEXPAND);
 	memoryPanel->SetSizer(memorySizer);
 	memoryPanel->SetBackgroundColour(wxTransparentColor);

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -115,8 +115,11 @@ CpuTabPage::CpuTabPage(wxWindow* parent, DebugInterface* _cpu)
 
 	wxBoxSizer *memorySizer = new wxBoxSizer(wxHORIZONTAL);
 	memorySizer->Add(memory, 1, wxEXPAND);
-
+#ifdef _WIN32
 	memorySearch->SetMaxSize(wxSize(310 * MSW_GetDPIScale(), -1));
+#else
+	memorySearch->SetMaxSize(wxSize(330, -1));
+#endif
 	memorySizer->Add(memorySearch, 1, wxEXPAND);
 	memoryPanel->SetSizer(memorySizer);
 	memoryPanel->SetBackgroundColour(wxTransparentColor);

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1162,12 +1162,8 @@ void psxRecMemcheck(u32 op, u32 bits, bool store)
 	_psxMoveGPRtoR(ecx, (op >> 21) & 0x1F);
 	if ((s16)op != 0)
 		xADD(ecx, (s16)op);
-	if (bits == 128)
-		xAND(ecx, ~0x0F);
 
-	xFastCall((void*)standardizeBreakpointAddressIop, ecx);
-	xMOV(ecx, eax);
-	xMOV(edx, eax);
+	xMOV(edx, ecx);
 	xADD(edx, bits / 8);
 
 	// ecx = access address
@@ -1187,11 +1183,11 @@ void psxRecMemcheck(u32 op, u32 bits, bool store)
 
 		// logic: memAddress < bpEnd && bpStart < memAddress+memSize
 
-		xMOV(eax, standardizeBreakpointAddress(BREAKPOINT_IOP, checks[i].end));
+		xMOV(eax, checks[i].end);
 		xCMP(ecx, eax);     // address < end
 		xForwardJGE8 next1; // if address >= end then goto next1
 
-		xMOV(eax, standardizeBreakpointAddress(BREAKPOINT_IOP, checks[i].start));
+		xMOV(eax, checks[i].start);
 		xCMP(eax, edx);     // start < address+size
 		xForwardJGE8 next2; // if start >= address+size then goto next2
 
@@ -1242,7 +1238,6 @@ void psxEncodeMemcheck()
 		case MEMTYPE_HALF:  psxRecMemcheck(op,  16, store); break;
 		case MEMTYPE_WORD:  psxRecMemcheck(op,  32, store); break;
 		case MEMTYPE_DWORD: psxRecMemcheck(op,  64, store); break;
-		case MEMTYPE_QWORD: psxRecMemcheck(op, 128, store); break;
 	}
 }
 

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1353,7 +1353,7 @@ void recMemcheck(u32 op, u32 bits, bool store)
 	if (bits == 128)
 		xAND(ecx, ~0x0F);
 
-	xFastCall((void*)standardizeBreakpointAddressEE, ecx);
+	xFastCall((void*)standardizeBreakpointAddress, ecx);
 	xMOV(ecx, eax);
 	xMOV(edx, eax);
 	xADD(edx, bits / 8);
@@ -1375,11 +1375,11 @@ void recMemcheck(u32 op, u32 bits, bool store)
 
 		// logic: memAddress < bpEnd && bpStart < memAddress+memSize
 
-		xMOV(eax, standardizeBreakpointAddress(BREAKPOINT_EE, checks[i].end));
+		xMOV(eax, standardizeBreakpointAddress(checks[i].end));
 		xCMP(ecx, eax); // address < end
 		xForwardJGE8 next1; // if address >= end then goto next1
 
-		xMOV(eax, standardizeBreakpointAddress(BREAKPOINT_EE, checks[i].start));
+		xMOV(eax, standardizeBreakpointAddress(checks[i].start));
 		xCMP(eax, edx); // start < address+size
 		xForwardJGE8 next2; // if start >= address+size then goto next2
 


### PR DESCRIPTION
### Description of Changes
- **Enables interpreter breakpoints and memchecks on dev & debug builds**
- Removes the unnecessary calls to standardizeBreakpointAddress

	standardizeBreakpointAddress is pointless on the IOP, and when a memcheck is active _any_ load / store instruction executed will call this pointless function.
- Fixes up the memory search window, it used to by default cover the memory view.

	I tried to make it DPI aware, but wx isn't very helpful and Qt is coming soon anyways. So expect non 100% DPIs to be less than optimal (but still functional).

- Fixes the memory search window getting screwed up on resize.

### Rationale behind Changes
Trying to get more familiar with the core. Oh and speed when debugging :)

### Suggested Testing Steps
Test memory checks on the IOP. Test the debugger resizing and stuff.
