### PR TITLE
Build: Use git tag for file version on windows, attempt 2

### DIFF
--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -77,9 +77,31 @@ endfunction()
 
 function(write_svnrev_h)
 	if(PCSX2_GIT_TAG)
-		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h "#define SVN_REV ${PCSX2_WC_TIME}ll \n#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n#define GIT_TAGGED_COMMIT 1\n#define GIT_REV \"\"\n")
+		if ("${PCSX2_GIT_TAG}" MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+			file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h
+				"#define SVN_REV ${PCSX2_WC_TIME}ll\n"
+				"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
+				"#define GIT_TAGGED_COMMIT 1\n"
+				"#define GIT_TAG_HI  ${CMAKE_MATCH_1}\n"
+				"#define GIT_TAG_MID ${CMAKE_MATCH_2}\n"
+				"#define GIT_TAG_LO  ${CMAKE_MATCH_3}\n"
+				"#define GIT_REV \"\"\n"
+			)
+		else()
+			file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h
+				"#define SVN_REV ${PCSX2_WC_TIME}ll\n"
+				"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
+				"#define GIT_TAGGED_COMMIT 1\n"
+				"#define GIT_REV \"\"\n"
+			)
+		endif()
 	else()
-		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h "#define SVN_REV ${PCSX2_WC_TIME}ll \n#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n#define GIT_TAGGED_COMMIT 0\n#define GIT_REV \"${PCSX2_GIT_REV}\"\n")
+		file(WRITE ${CMAKE_BINARY_DIR}/common/include/svnrev.h 
+			"#define SVN_REV ${PCSX2_WC_TIME}ll\n"
+			"#define GIT_TAG \"${PCSX2_GIT_TAG}\"\n"
+			"#define GIT_TAGGED_COMMIT 0\n"
+			"#define GIT_REV \"${PCSX2_GIT_REV}\"\n"
+		)
 	endif()
 endfunction()
 

--- a/common/vsprops/preBuild.cmd
+++ b/common/vsprops/preBuild.cmd
@@ -11,7 +11,7 @@
 ::
 ::    ProjectSrcDir - $(ProjectDir)\.. - Top-level Directory of project source code.
 
-SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEDELAYEDEXPANSION ENABLEEXTENSIONS
 
 IF EXIST "%ProgramFiles(x86)%\Git\bin\git.exe" SET "GITPATH=%ProgramFiles(x86)%\Git\bin"
 IF EXIST "%ProgramFiles%\Git\bin\git.exe" SET "GITPATH=%ProgramFiles%\Git\bin"
@@ -55,6 +55,16 @@ if %ERRORLEVEL% NEQ 0 (
     echo #define SVN_REV 0ll >> "%CD%\svnrev.h"
     echo #define GIT_REV "" >> "%CD%\svnrev.h"
     echo #define GIT_TAG "%GIT_TAG%" >> "%CD%\svnrev.h"
+
+    echo %GIT_TAG%|FINDSTR /R "^v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$" > NUL
+    if !ERRORLEVEL! EQU 0 (
+        FOR /F "tokens=1,2,3 delims=v." %%a in ("%GIT_TAG%") DO (
+          echo #define GIT_TAG_HI %%a >> "%CD%\svnrev.h"
+          echo #define GIT_TAG_MID %%b >> "%CD%\svnrev.h"
+          echo #define GIT_TAG_LO %%c >> "%CD%\svnrev.h"
+        )
+    )
+
     echo #define GIT_TAGGED_COMMIT 1 >> "%CD%\svnrev.h"
   ) else (
     echo #define SVN_REV %REV%ll > "%CD%\svnrev.h"

--- a/pcsx2/PCSX2.rc
+++ b/pcsx2/PCSX2.rc
@@ -2,6 +2,7 @@
 //
 #include "resource.h"
 #include "SysForwardDefs.h"
+#include "svnrev.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -31,7 +32,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 1 TEXTINCLUDE 
 BEGIN
     "resource.h\r\n"
-    "SysForwardDefs.h\0"
+    "SysForwardDefs.h\r\n"
+    "svnrev.h\0"
 END
 
 2 TEXTINCLUDE 
@@ -51,8 +53,13 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
+#if PCSX2_isReleaseVersion == false && GIT_TAGGED_COMMIT && defined(GIT_TAG_HI)
+ FILEVERSION        GIT_TAG_HI, GIT_TAG_MID, GIT_TAG_LO, 0 
+ PRODUCTVERSION     GIT_TAG_HI, GIT_TAG_MID, GIT_TAG_LO, 0
+#else
  FILEVERSION        VER_FILE_VERSION
  PRODUCTVERSION     VER_PRODUCT_VERSION
+#endif
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +75,20 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", VER_FILE_DESCRIPTION_STR "\0"
+#if PCSX2_isReleaseVersion == false && GIT_TAGGED_COMMIT && defined(GIT_TAG_HI)
+	        VALUE "FileVersion", STRINGIZE(GIT_TAG_HI) "." STRINGIZE(GIT_TAG_MID) "." STRINGIZE(GIT_TAG_LO) "." STRINGIZE(0) "\0"
+#else
             VALUE "FileVersion", VER_FILE_VERSION_STR "\0"
+#endif
             VALUE "InternalName", VER_INTERNAL_NAME_STR "\0"
             VALUE "LegalCopyright", VER_COPYRIGHT_STR "\0"
             VALUE "OriginalFilename", VER_ORIGINAL_FILENAME_STR "\0"
             VALUE "ProductName", VER_PRODUCTNAME_STR "\0"
+#if PCSX2_isReleaseVersion == false && GIT_TAGGED_COMMIT && defined(GIT_TAG_HI)
+		    VALUE "ProductVersion", STRINGIZE(GIT_TAG_HI) "." STRINGIZE(GIT_TAG_MID) "." STRINGIZE(GIT_TAG_LO) "." STRINGIZE(0) "\0"
+#else
             VALUE "ProductVersion", VER_PRODUCT_VERSION_STR "\0"
+#endif
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
### Description of Changes
Uses the Git tag for the file version, this is a second attempt at https://github.com/PCSX2/pcsx2/pull/5355

Differences in this attempt are;
I remember CMake exists (Thanks @tellowkrinkle for the CMake code), which fixes https://github.com/PCSX2/pcsx2/issues/5364 (Note, Master reverted the breaking commit already)

The preBuild batch script will now ignore Git tags that aren't versioned (I.e. on tellowkrinkle's Mac fork where tags such as `macos-20220107`), matching the tellowkrinkle's CMake code.
I had to adapt the regex used as `FINDSTR` only supports a limited subset of the regex features.

The switching between the hardcoded `PCSX2_Version*` and `GIT_TAG_*` is now done in `pcsx2/PCSX2.rc`
This is similar to how Git tags are handled in other parts of the codebase, see; `PINE.cpp`, `System.cpp` and `MainFrame.cpp`, although I've purely used preprocessor logic.
Doing this inside `PCSX2.rc` avoids including `svnrev.h` throughout large sections of the codebase (which would mess with incremental builds or the cache)

![image](https://user-images.githubusercontent.com/4604733/150594974-d4bae9c2-fe7d-45b6-90b0-9cb1ea28089c.png)

### Rationale behind Changes
Have the Git tag (when it is a version) visible in the file details pane on Windows

### Suggested Testing Steps
Clone this branch
Use `git tag <tag>` to add and `git tag -d <tag>` to add and remove tags to the head commit of the branch locally.
Try to compile PCSX2 with different tags, on windows and Linux

I've tested the tags `v1.2.3456`, `macos-20220107` and an untagged commit
