### PR TITLE
VU: Adjust path for conditional evil blocks

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -38776,6 +38776,15 @@ SLUS-21328:
   compat: 5
   clampModes:
     vuClampMode: 3  # Fixes bad geometry.
+  patches:
+    default:
+      content: |-
+        comment=Patch by Refraction
+        // Fix bad geometry
+        patch=1,EE,0016DDE4,word,4A80AADC
+        patch=1,EE,0016DDEC,word,4B7103BC
+        patch=1,EE,0016DDD0,word,4B00A29C
+        patch=1,EE,0016DDD8,word,4AF103BC
 SLUS-21329:
   name: "Karaoke Revolution Country - CMT Presents"
   region: "NTSC-U"

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -903,13 +903,13 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 			mVU_XGKICK_DELAY(mVU);
 		}
 
-		if (isEvilBlock)
+		if (isEvilBlock && !isConditional)
 		{
 			mVUsetupRange(mVU, xPC + 8, false);
 			normJumpCompile(mVU, mFC, true);
 			goto perf_and_return;
 		}
-		else if (!mVUinfo.isBdelay)
+		else if (!mVUinfo.isBdelay && !isEvilBlock)
 		{
 			// Handle range wrapping
 			if ((xPC + 8) == mVU.microMemSize)

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -242,6 +242,7 @@ typedef u32(__fastcall* mVUCall)(void*, void*);
 #define mVUrange     (mVUcurProg.ranges[0])[0]
 #define isEvilBlock  (mVUpBlock->pState.blockType == 2)
 #define isBadOrEvil  (mVUlow.badBranch || mVUlow.evilBranch)
+#define isConditional (mVUlow.branch > 2 && mVUlow.branch < 9)
 #define xPC          ((iPC / 2) * 8)
 #define curI         ((u32*)mVU.regs().Micro)[iPC] //mVUcurProg.data[iPC]
 #define setCode()    { mVU.code = curI; }


### PR DESCRIPTION
Also Add patch for Pac-man World Rally

### Description of Changes
Corrects path for conditional evil blocks so it doesn't get treated like a jump

### Rationale behind Changes
In some cases, conditional evil branches were being controls but treated like jumps (no condition)

### Suggested Testing Steps
Look for games that do Branch in delay slot stuff or Branch, Branch, Branch! warning games

Fixes #5372