### PR TITLE
CMake: Prevent people from doing in-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 # versions as well, avoiding setting policies.
 cmake_minimum_required(VERSION 3.11...3.22)
 
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+	message(FATAL_ERROR "PCSX2 does not support in-tree builds.  Please make a build directory that is not the PCSX2 source directory and generate your CMake project there using either `cmake -B build_directory` or by running cmake from the build directory.")
+endif()
+
 # Project Name
 project(Pcsx2)
 


### PR DESCRIPTION
### Description of Changes
Adds a very obvious error if you try to build in the same directory as the source code

### Rationale behind Changes
We generate files into build directories and then add those directories as include paths, and if those are also source directories, this can mess up includes of things like "Config.h" which exist in multiple directories

(Yes we should really try to avoid having 6 different "Config.h"s but that won't stop me from disliking in-tree builds and not wanting to deal with any other weird problems they might cause)

### Suggested Testing Steps
Make sure builds still work
Make sure in-tree builds error immediately