### PR TITLE
GS: Enable small framebuffers at 1x

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -137,7 +137,7 @@ cbuffer cb1
 	float4 MinMax;
 	int4 ChannelShuffle;
 	float2 TC_OffsetHack;
-	float2 pad_cb1;
+	float2 STScale;
 	float4x4 DitherMatrix;
 };
 
@@ -156,6 +156,7 @@ float4 sample_c(float2 uv, float uv_w)
 		// As of 2018 this issue is still present.
 		uv = (trunc(uv * WH.zw) + float2(0.5, 0.5)) / WH.zw;
 	}
+	uv *= STScale;
 
 #if PS_AUTOMATIC_LOD == 1
 	return Texture.Sample(TextureSampler, uv);

--- a/bin/resources/shaders/opengl/common_header.glsl
+++ b/bin/resources/shaders/opengl/common_header.glsl
@@ -82,7 +82,7 @@ layout(std140, binding = 0) uniform cb21
     ivec4 ChannelShuffle;
 
     vec2 TC_OffsetHack;
-    vec2 pad_cb21;
+    vec2 STScale;
 
     mat4 DitherMatrix;
 };

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -91,6 +91,7 @@ vec4 sample_c(vec2 uv)
     // As of 2018 this issue is still present.
     uv = (trunc(uv * WH.zw) + vec2(0.5, 0.5)) / WH.zw;
 #endif
+    uv *= STScale;
 
 #if PS_AUTOMATIC_LOD == 1
     return texture(TextureSampler, uv);

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -363,7 +363,7 @@ layout(std140, set = 0, binding = 1) uniform cb1
 	vec4 MinMax;
 	ivec4 ChannelShuffle;
 	vec2 TC_OffsetHack;
-	vec2 pad_cb1;
+	vec2 STScale;
 	mat4 DitherMatrix;
 };
 
@@ -410,6 +410,7 @@ vec4 sample_c(vec2 uv)
 		// As of 2018 this issue is still present.
 		uv = (trunc(uv * WH.zw) + vec2(0.5, 0.5)) / WH.zw;
 #endif
+	uv *= STScale;
 
 #if PS_AUTOMATIC_LOD == 1
     return texture(Texture, uv);

--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -107,7 +107,7 @@ inline FILE* px_fopen(const std::string& filename, const std::string& mode)
 #ifdef ENABLE_ACCURATE_BUFFER_EMULATION
 static const GSVector2i default_rt_size(2048, 2048);
 #else
-static const GSVector2i default_rt_size(1280, 1024);
+static const GSVector2i default_rt_size(0, 0);
 #endif
 
 // Maximum texture size to skip preload/hash path.

--- a/pcsx2/GS/GSIntrin.h
+++ b/pcsx2/GS/GSIntrin.h
@@ -30,15 +30,26 @@
 
 static int _BitScanForward(unsigned long* const Index, const unsigned long Mask)
 {
-#if __has_builtin(__builtin_ctz)
 	if (Mask == 0)
 		return 0;
+#if __has_builtin(__builtin_ctz)
 	*Index = __builtin_ctz(Mask);
-	return 1;
 #else
 	__asm__("bsfl %k[Mask], %k[Index]" : [Index] "=r" (*Index) : [Mask] "mr" (Mask) : "cc");
-	return Mask ? 1 : 0;
 #endif
+	return 1;
+}
+
+static int _BitScanReverse(unsigned long* const Index, const unsigned long Mask)
+{
+	if (Mask == 0)
+		return 0;
+#if __has_builtin(__builtin_clz)
+	*Index = 31 - __builtin_clz(Mask);
+#else
+	__asm__("bsrl %k[Mask], %k[Index]" : [Index] "=r" (*Index) : [Mask] "mr" (Mask) : "cc");
+#endif
+	return 1;
 }
 
 #endif

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2704,7 +2704,7 @@ void GSState::GetTextureMinMax(GSVector4i& r, const GIFRegTEX0& TEX0, const GIFR
 			break;
 		case CLAMP_REGION_REPEAT:
 			vr.x = maxu;
-			vr.z = vr.x + (minu + 1);
+			vr.z = (maxu | minu) + 1;
 			break;
 		default:
 			__assume(0);
@@ -2724,7 +2724,7 @@ void GSState::GetTextureMinMax(GSVector4i& r, const GIFRegTEX0& TEX0, const GIFR
 			break;
 		case CLAMP_REGION_REPEAT:
 			vr.y = maxv;
-			vr.w = vr.y + (minv + 1);
+			vr.w = (maxv | minv) + 1;
 			break;
 		default:
 			__assume(0);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -198,7 +198,21 @@ protected:
 			CalcAlphaMinMax();
 		return m_vt.m_alpha;
 	}
-	void GetTextureMinMax(GSVector4i& r, const GIFRegTEX0& TEX0, const GIFRegCLAMP& CLAMP, bool linear);
+	struct TextureMinMaxResult
+	{
+		enum UsesBoundary
+		{
+			USES_BOUNDARY_LEFT   = 1 << 0,
+			USES_BOUNDARY_TOP    = 1 << 1,
+			USES_BOUNDARY_RIGHT  = 1 << 2,
+			USES_BOUNDARY_BOTTOM = 1 << 3,
+			USES_BOUNDARY_U = USES_BOUNDARY_LEFT | USES_BOUNDARY_RIGHT,
+			USES_BOUNDARY_V = USES_BOUNDARY_TOP | USES_BOUNDARY_BOTTOM,
+		};
+		GSVector4i coverage; ///< Part of the texture used
+		u8 uses_boundary;    ///< Whether or not the usage touches the left, top, right, or bottom edge (and therefore needs wrap modes preserved)
+	};
+	TextureMinMaxResult GetTextureMinMax(const GIFRegTEX0& TEX0, const GIFRegCLAMP& CLAMP, bool linear);
 	bool TryAlphaTest(u32& fm, u32& zm);
 	bool IsOpaque();
 	bool IsMipMapDraw();

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -154,6 +154,7 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int width, int height, i
 		}
 	}
 
+	t->SetScale(GSVector2(1, 1)); // Things seem to assume that all textures come out of here with scale 1...
 	t->Commit(); // Clear won't be done if the texture isn't committed.
 
 	switch (type)

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -417,7 +417,7 @@ struct alignas(16) GSHWDrawConfig
 		GSVector4 MinMax;
 		GSVector4i ChannelShuffle;
 		GSVector2 TCOffsetHack;
-		float pad1[2];
+		GSVector2 STScale;
 
 		GSVector4 DitherMatrix[4];
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -135,7 +135,7 @@ void GSRendererHW::SetScaling()
 
 	// No need to resize for native/custom resolutions as default size will be enough for native and we manually get RT Buffer size for custom.
 	// don't resize until the display rectangle and register states are stabilized.
-	if (GSConfig.UpscaleMultiplier <= 1 || good_rt_size)
+	if (good_rt_size)
 		return;
 
 	m_tc->RemovePartial();
@@ -293,9 +293,6 @@ void GSRendererHW::Reset()
 
 void GSRendererHW::VSync(u32 field, bool registers_written)
 {
-	//Check if the frame buffer width or display width has changed
-	SetScaling();
-
 	if (m_reset)
 	{
 		m_tc->RemoveAll();
@@ -307,6 +304,9 @@ void GSRendererHW::VSync(u32 field, bool registers_written)
 
 		m_reset = false;
 	}
+
+	//Check if the frame buffer width or display width has changed
+	SetScaling();
 
 	GSRenderer::VSync(field, registers_written);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1384,9 +1384,7 @@ void GSRendererHW::Draw()
 
 		m_context->offset.tex = m_mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
 
-		GSVector4i r;
-
-		GetTextureMinMax(r, TEX0, MIP_CLAMP, m_vt.IsLinear());
+		GSVector4i r = GetTextureMinMax(TEX0, MIP_CLAMP, m_vt.IsLinear()).coverage;
 
 		m_src = tex_psm.depth ? m_tc->LookupDepthSource(TEX0, env.TEXA, r) :
 			m_tc->LookupSource(TEX0, env.TEXA, r, m_hw_mipmap >= HWMipmapLevel::Basic ||
@@ -1413,7 +1411,7 @@ void GSRendererHW::Draw()
 				m_vt.m_min.t *= 0.5f;
 				m_vt.m_max.t *= 0.5f;
 
-				GetTextureMinMax(r, MIP_TEX0, MIP_CLAMP, m_vt.IsLinear());
+				r = GetTextureMinMax(MIP_TEX0, MIP_CLAMP, m_vt.IsLinear()).coverage;
 
 				m_src->UpdateLayer(MIP_TEX0, r, layer - m_lod.x);
 			}

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -993,13 +993,18 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	m_conf.ps.ltf = bilinear && shader_emulated_sampler;
 	m_conf.ps.point_sampler = g_gs_device->Features().broken_point_sampler && (!bilinear || shader_emulated_sampler);
 
+	const GSVector2 scale = tex->m_texture->GetScale();
 	const int w = tex->m_texture->GetWidth();
 	const int h = tex->m_texture->GetHeight();
 
 	const int tw = (int)(1 << m_context->TEX0.TW);
 	const int th = (int)(1 << m_context->TEX0.TH);
+	const int miptw = 1 << tex->m_TEX0.TW;
+	const int mipth = 1 << tex->m_TEX0.TH;
 
-	const GSVector4 WH(tw, th, w, h);
+	const GSVector4 WH(static_cast<float>(tw), static_cast<float>(th), miptw * scale.x, mipth * scale.y);
+	const GSVector4 st_scale = WH.zwzw() / GSVector4(w, h).xyxy();
+	m_conf.cb_ps.STScale = GSVector2(st_scale.x, st_scale.y);
 
 	m_conf.ps.fst = !!PRIM->FST;
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2243,15 +2243,8 @@ void GSTextureCache::Target::Update()
 	// Alternate
 	// 1/ uses multiple vertex rectangle
 
-	GSVector2i t_size = default_rt_size;
-
-	// Ensure buffer width is at least of the minimum required value.
-	// Probably not necessary but doesn't hurt to be on the safe side.
-	// I've seen some games use buffer sizes over 1024, which might bypass our default limit
-	int buffer_width = m_TEX0.TBW << 6;
-	t_size.x = std::max(buffer_width, t_size.x);
-
-	GSVector4i r = m_dirty.GetDirtyRectAndClear(m_TEX0, t_size);
+	GSVector4i unscaled_size = GSVector4i(GSVector4(m_texture->GetSize()) / GSVector4(m_texture->GetScale()));
+	GSVector4i r = m_dirty.GetDirtyRectAndClear(m_TEX0, GSVector2i(unscaled_size.x, unscaled_size.y));
 
 	if (r.rempty())
 		return;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -1057,9 +1057,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 
 			GIFRegTEX0 TEX0 = m_context->GetSizeFixedTEX0(m_vt.m_min.t.xyxy(m_vt.m_max.t), m_vt.IsLinear(), mipmap);
 
-			GSVector4i r;
-
-			GetTextureMinMax(r, TEX0, context->CLAMP, gd.sel.ltf);
+			GSVector4i r = GetTextureMinMax(TEX0, context->CLAMP, gd.sel.ltf).coverage;
 
 			GSTextureCacheSW::Texture* t = m_tc->Lookup(TEX0, env.TEXA);
 
@@ -1167,9 +1165,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 						return false;
 					}
 
-					GSVector4i r;
-
-					GetTextureMinMax(r, MIP_TEX0, MIP_CLAMP, gd.sel.ltf);
+					GSVector4i r = GetTextureMinMax(MIP_TEX0, MIP_CLAMP, gd.sel.ltf).coverage;
 
 					data->SetSource(t, r, i);
 				}


### PR DESCRIPTION
### Description of Changes
- Stops the texture cache from downscaling targets when used as a source
- Enables smaller framebuffers even when rendering at 1x (previously only enabled at 2x+)
- Adds some optimizations to move sampling to hardware when possible (minor perf improvement on GT4)

Note: I did this by editing the vertex and fragment shaders to support rescaling normalized coordinates.  An alternative way to do it would be to just allocate full scale textures in this case.  Preferences?  (sampling the target directly mentioned below would need this approach)
Note2: This changes the renderer's interpretation of a texture whose `size / scale` does not match `tw` and `th` from "stretch to fit" to "use a 1-1 pixel scale".  Not sure if this breaks anything?  If it does, maybe those things should have set their scale properly...

### Rationale behind Changes
- Improves speed of Burnout at 1x on integrated GPUs with low memory bandwidth due to its access patterns making TC convert framebuffers to and from depth formats constantly (by reducing the size of those framebuffers).
- Improves the image quality of Burnout when upscaled to be the multiplier you selected and not that times 80% or so then nearest-neighbor upscaled back to 100%
- Should make removing the extra copies we do when using a target as a source a bit easier (future improvements, not included in this PR)

Example at 2x upscale:
<img width="640" alt="ExampleA" src="https://user-images.githubusercontent.com/3315070/149651911-0406adae-97f1-412f-858f-14c5726ac487.png">
<img width="640" alt="ExampleB" src="https://user-images.githubusercontent.com/3315070/149651913-6539a19d-3571-4745-a346-782b7c44c537.png">

### Suggested Testing Steps
Test 1x and 2x upscale for lots of games