### PR TITLE
mVU: Rework multiple branch chaining

### DIFF
--- a/pcsx2/x86/microVU.h
+++ b/pcsx2/x86/microVU.h
@@ -243,6 +243,7 @@ struct microVU
 	u32 branch;       // Holds branch compare result (IBxx) OR Holds address to Jump to (JALR/JR)
 	u32 badBranch;    // For Branches in Branch Delay Slots, holds Address the first Branch went to + 8
 	u32 evilBranch;   // For Branches in Branch Delay Slots, holds Address to Jump to
+	u32 evilevilBranch;// For Branches in Branch Delay Slots (chained), holds Address to Jump to
 	u32 p;            // Holds current P instance index
 	u32 q;            // Holds current Q instance index
 	u32 totalCycles;  // Total Cycles that mVU is expected to run for

--- a/pcsx2/x86/microVU_Analyze.inl
+++ b/pcsx2/x86/microVU_Analyze.inl
@@ -619,19 +619,7 @@ __ri int mVUbranchCheck(mV)
 			incPC(2);
 			mVUlow.evilBranch = true;
 
-			if (mVUlow.branch == 2 || mVUlow.branch == 10) // Needs linking, we can only guess this if the next is not conditional
-			{
-				// First branch is not conditional so we know what the link will be
-				// So we can let the existing evil block do its thing! We know where to get the addr :)
-				if (branchType <= 2 || branchType >= 9)
-				{
-					mVUregs.blockType = 2;
-				} // Else it is conditional, so we need to do some nasty processing later in microVU_Branch.inl
-			}
-			else
-			{
-				mVUregs.blockType = 2; // Second branch doesn't need linking, so can let it run its evil block course (MGS2 for testing)
-			}
+			mVUregs.blockType = 2; // Second branch doesn't need linking, so can let it run its evil block course (MGS2 for testing)
 
 			mVUregs.needExactMatch |= 7; // This might not be necessary, but w/e...
 			mVUregs.flagInfo = 0;
@@ -678,7 +666,8 @@ __fi void mVUanalyzeNormBranch(mV, int It, bool isBAL)
 	if (isBAL)
 	{
 		analyzeVIreg2(mVU, It, mVUlow.VI_write, 1);
-		setConstReg(It, bSaveAddr);
+		if(!mVUlow.evilBranch)
+			setConstReg(It, bSaveAddr);
 	}
 }
 
@@ -695,6 +684,7 @@ __ri void mVUanalyzeJump(mV, int Is, int It, bool isJALR)
 	if (isJALR)
 	{
 		analyzeVIreg2(mVU, It, mVUlow.VI_write, 1);
-		setConstReg(It, bSaveAddr);
+		if (!mVUlow.evilBranch)
+			setConstReg(It, bSaveAddr);
 	}
 }

--- a/pcsx2/x86/microVU_Analyze.inl
+++ b/pcsx2/x86/microVU_Analyze.inl
@@ -584,8 +584,29 @@ static void analyzeBranchVI(mV, int xReg, bool& infoVar)
 // Branch in Branch Delay-Slots
 __ri int mVUbranchCheck(mV)
 {
-	if (!mVUcount)
+	if (!mVUcount && !isEvilBlock)
 		return 0;
+
+	// This means we have jumped from an evil branch situation, so this is another branch in delay slot
+	if (isEvilBlock)
+	{
+		mVUlow.evilBranch = true;
+		mVUregs.blockType = 2;
+		mVUregs.needExactMatch |= 7; // This might not be necessary, but w/e...
+		mVUregs.flagInfo = 0;
+		
+		if (mVUlow.branch == 2 || mVUlow.branch == 10)
+		{
+			Console.Error("microVU%d: %s in branch, branch delay slot requires link [%04x] - If game broken report to PCSX2 Team", mVU.index,
+				branchSTR[mVUlow.branch & 0xf], xPC);
+		}
+		else
+		{
+			DevCon.Warning("microVU%d: %s in branch, branch delay slot! [%04x] - If game broken report to PCSX2 Team", mVU.index,
+				branchSTR[mVUlow.branch & 0xf], xPC);
+		}
+		return 1;
+	}
 
 	incPC(-2);
 

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -304,7 +304,11 @@ void normJumpCompile(mV, microFlagCycles& mFC, bool isEvilJump)
 	}
 
 	if (isEvilJump)
+	{
 		xMOV(arg1regd, ptr32[&mVU.evilBranch]);
+		xMOV(gprT1, ptr32[&mVU.evilevilBranch]);
+		xMOV(ptr32[&mVU.evilBranch], gprT1);
+	}
 	else
 		xMOV(arg1regd, ptr32[&mVU.branch]);
 	if (doJumpCaching)

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -17,7 +17,6 @@
 
 extern void mVUincCycles(microVU& mVU, int x);
 extern void* mVUcompile(microVU& mVU, u32 startPC, uptr pState);
-extern void* mVUcompileSingleInstruction(microVU& mVU, u32 startPC, uptr pState, microFlagCycles& mFC);
 __fi int getLastFlagInst(microRegInfo& pState, int* xFlag, int flagType, int isEbit)
 {
 	if (isEbit)
@@ -395,65 +394,11 @@ void normBranch(mV, microFlagCycles& mFC)
 		return;
 	}
 
-	if (mVUlow.badBranch)
-	{
-		u32 badBranchAddr = branchAddr(mVU) + 8;
-		incPC(3);
-		if (mVUlow.branch == 2 || mVUlow.branch == 10) //Delay slot branch needs linking
-		{
-			DevCon.Warning("Found %s in delay slot, linking - If game broken report to PCSX2 Team", mVUlow.branch == 2 ? "BAL" : "JALR");
-			xMOV(gprT3, badBranchAddr);
-			xSHR(gprT3, 3);
-			mVUallocVIb(mVU, gprT3, _It_);
-		}
-		incPC(-3);
-	}
-
 	// Normal Branch
 	mVUsetupBranch(mVU, mFC);
 	normBranchCompile(mVU, branchAddr(mVU));
 }
 
-//Messy handler warning!!
-//This handles JALR/BAL in the delay slot of a conditional branch.  We do this because the normal handling
-//Doesn't seem to work properly, even if the link is made to the correct address, so we do it manually instead.
-//Normally EvilBlock handles all this stuff, but something to do with conditionals and links don't quite work right :/
-void condJumpProcessingEvil(mV, microFlagCycles& mFC, int JMPcc)
-{
-
-	u32 bPC = iPC - 1; // mVUcompile can modify iPC, mVUpBlock, and mVUregs so back them up
-	u32 badBranchAddr;
-	iPC = bPC - 2;
-	setCode();
-	badBranchAddr = branchAddr(mVU);
-
-	xCMP(ptr16[&mVU.branch], 0);
-
-	xForwardJump32 eJMP(xInvertCond((JccComparisonType)JMPcc));
-
-	mVUcompileSingleInstruction(mVU, badBranchAddr, (uptr)&mVUregs, mFC);
-
-	xMOV(gprT3, badBranchAddr + 8);
-	iPC = bPC;
-	setCode();
-	xSHR(gprT3, 3);
-	mVUallocVIb(mVU, gprT3, _It_); //Link to branch addr + 8
-
-	normJumpCompile(mVU, mFC, true); //Compile evil branch, just in time!
-
-	eJMP.SetTarget();
-
-	incPC(2); // Point to delay slot of evil Branch (as the original branch isn't taken)
-	mVUcompileSingleInstruction(mVU, xPC, (uptr)&mVUregs, mFC);
-
-	xMOV(gprT3, xPC);
-	iPC = bPC;
-	setCode();
-	xSHR(gprT3, 3);
-	mVUallocVIb(mVU, gprT3, _It_);
-
-	normJumpCompile(mVU, mFC, true); //Compile evil branch, just in time!
-}
 void condBranch(mV, microFlagCycles& mFC, int JMPcc)
 {
 	mVUsetupBranch(mVU, mFC);
@@ -555,15 +500,6 @@ void condBranch(mV, microFlagCycles& mFC, int JMPcc)
 		xCMP(ptr16[&mVU.branch], 0);
 
 		incPC(3);
-		if (mVUlow.evilBranch) // We are dealing with an evil evil block, so we need to process this slightly differently
-		{
-			if (mVUlow.branch == 10 || mVUlow.branch == 2) // Evil branch is a jump of some measure
-			{
-				//Because of how it is linked, we need to make sure the target is recompiled if taken
-				condJumpProcessingEvil(mVU, mFC, JMPcc);
-				return;
-			}
-		}
 		microBlock* bBlock;
 		incPC2(1); // Check if Branch Non-Taken Side has already been recompiled
 		blockCreate(iPC / 2);
@@ -611,21 +547,6 @@ void normJump(mV, microFlagCycles& mFC)
 		mVUsetupBranch(mVU, mFC);
 		normBranchCompile(mVU, jumpAddr);
 		return;
-	}
-	if (mVUlow.badBranch)
-	{
-		incPC(3);
-		if (mVUlow.branch == 2 || mVUlow.branch == 10) //Delay slot BAL needs linking, only need to do BAL here, JALR done earlier
-		{
-			DevCon.Warning("Found %x in delay slot, linking - If game broken report to PCSX2 Team", mVUlow.branch == 2 ? "BAL" : "JALR");
-			incPC(-2);
-			mVUallocVIa(mVU, gprT1, _Is_);
-			xADD(gprT1, 8);
-			xSHR(gprT1, 3);
-			incPC(2);
-			mVUallocVIb(mVU, gprT1, _It_);
-		}
-		incPC(-3);
 	}
 	if (mVUup.dBit && doDBitHandling)
 	{

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -903,13 +903,13 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 			mVU_XGKICK_DELAY(mVU);
 		}
 
-		if (isEvilBlock && !isConditional)
+		if (isEvilBlock)
 		{
 			mVUsetupRange(mVU, xPC + 8, false);
 			normJumpCompile(mVU, mFC, true);
 			goto perf_and_return;
 		}
-		else if (!mVUinfo.isBdelay && !isEvilBlock)
+		else if (!mVUinfo.isBdelay)
 		{
 			// Handle range wrapping
 			if ((xPC + 8) == mVU.microMemSize)

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -1756,16 +1756,30 @@ void condEvilBranch(mV, int JMPcc)
 		cJMP.SetTarget();
 		return;
 	}
-	xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU));
-	xCMP(gprT1b, 0);
-	xForwardJump8 cJMP((JccComparisonType)JMPcc);
+	if (isEvilBlock)
+	{
+		xMOV(ptr32[&mVU.evilevilBranch], branchAddr(mVU));
+		xCMP(gprT1b, 0);
+		xForwardJump8 cJMP((JccComparisonType)JMPcc);
+		xMOV(gprT1, ptr32[&mVU.evilBranch]); // Branch Not Taken
+		xADD(gprT1, 8); // We have already executed 1 instruction from the original branch
+		xMOV(ptr32[&mVU.evilevilBranch], gprT1);
+		cJMP.SetTarget();
+	}
+	else
+	{
+		xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU));
+		xCMP(gprT1b, 0);
+		xForwardJump8 cJMP((JccComparisonType)JMPcc);
 		xMOV(gprT1, ptr32[&mVU.badBranch]); // Branch Not Taken
+		//xADD(gprT1, 8); // We have already executed 1 instruction from the original branch
 		xMOV(ptr32[&mVU.evilBranch], gprT1);
-	cJMP.SetTarget();
-	incPC(-2);
-	if (mVUlow.branch >= 9)
-		DevCon.Warning("Conditional in JALR/JR delay slot - If game broken report to PCSX2 Team");
-	incPC(2);
+		cJMP.SetTarget();
+		incPC(-2);
+		if (mVUlow.branch >= 9)
+			DevCon.Warning("Conditional in JALR/JR delay slot - If game broken report to PCSX2 Team");
+		incPC(2);
+	}
 }
 
 mVUop(mVU_B)
@@ -1774,8 +1788,8 @@ mVUop(mVU_B)
 	pass1 { mVUanalyzeNormBranch(mVU, 0, false); }
 	pass2
 	{
-		if (mVUlow.badBranch)  { xMOV(ptr32[&mVU.badBranch],  branchAddrN(mVU)); }
-		if (mVUlow.evilBranch) { xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU)); }
+		if (mVUlow.badBranch)  { xMOV(ptr32[&mVU.badBranch],  branchAddr(mVU)); }
+		if (mVUlow.evilBranch) { if(isEvilBlock) xMOV(ptr32[&mVU.evilevilBranch], branchAddr(mVU)); else xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU)); }
 		mVU.profiler.EmitOp(opB);
 	}
 	pass3 { mVUlog("B [<a href=\"#addr%04x\">%04x</a>]", branchAddr(mVU), branchAddr(mVU)); }
@@ -1792,9 +1806,23 @@ mVUop(mVU_BAL)
 			xMOV(gprT1, bSaveAddr);
 			mVUallocVIb(mVU, gprT1, _It_);
 		}
+		else
+		{
+			incPC(-2);
+			DevCon.Warning("Linking BAL from %s branch taken/nottaken target! - If game broken report to PCSX2 Team", branchSTR[mVUlow.branch & 0xf]);
+			incPC(2);
+			if (isEvilBlock)
+				xMOV(gprT1, ptr32[&mVU.evilBranch]);
+			else
+				xMOV(gprT1, ptr32[&mVU.badBranch]);
 
-		if (mVUlow.badBranch)  { xMOV(ptr32[&mVU.badBranch],  branchAddrN(mVU)); }
-		if (mVUlow.evilBranch) { xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU));}
+			xADD(gprT1, 8);
+			xSHR(gprT1, 3);
+			mVUallocVIb(mVU, gprT1, _It_);
+		}
+
+		if (mVUlow.badBranch)  { xMOV(ptr32[&mVU.badBranch],  branchAddr(mVU)); }
+		if (mVUlow.evilBranch) { if (isEvilBlock) xMOV(ptr32[&mVU.evilevilBranch], branchAddr(mVU)); else xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU)); }
 		mVU.profiler.EmitOp(opBAL);
 	}
 	pass3 { mVUlog("BAL vi%02d [<a href=\"#addr%04x\">%04x</a>]", _Ft_, branchAddr(mVU), branchAddr(mVU)); }
@@ -1946,7 +1974,10 @@ void normJumpPass2(mV)
 		}
 		else
 		{
-			xMOV(ptr32[&mVU.evilBranch], gprT1);
+			if(isEvilBlock)
+				xMOV(ptr32[&mVU.evilevilBranch], gprT1);
+			else
+				xMOV(ptr32[&mVU.evilBranch], gprT1);
 		}
 		//If delay slot is conditional, it uses badBranch to go to its target
 		if (mVUlow.badBranch)
@@ -1983,18 +2014,35 @@ mVUop(mVU_JALR)
 		}
 		if (mVUlow.evilBranch)
 		{
-			incPC(-2);
-			if (mVUlow.branch >= 9) // Previous branch is a jump of some type so we need to take the branch address from the register it uses.
+			if (isEvilBlock)
 			{
-				DevCon.Warning("Linking JALR from JALR/JR branch target! - If game broken report to PCSX2 Team");
-				mVUallocVIa(mVU, gprT1, _Is_);
+				xMOV(gprT1, ptr32[&mVU.evilBranch]);
 				xADD(gprT1, 8);
 				xSHR(gprT1, 3);
-				incPC(2);
 				mVUallocVIb(mVU, gprT1, _It_);
 			}
 			else
-				incPC(2);
+			{
+				incPC(-2);
+				if (mVUlow.branch >= 9) // Previous branch is a jump of some type so we need to take the branch address from the register it uses.
+				{
+					DevCon.Warning("Linking JALR from JALR/JR branch target! - If game broken report to PCSX2 Team");
+					mVUallocVIa(mVU, gprT1, _Is_);
+					xADD(gprT1, 8);
+					xSHR(gprT1, 3);
+					incPC(2);
+					mVUallocVIb(mVU, gprT1, _It_);
+				}
+				else // Else we take the branch target of the previous branch
+				{
+					DevCon.Warning("Linking JALR from %d branch taken/nottaken target! - If game broken report to PCSX2 Team", branchSTR[mVUlow.branch & 0xf]);
+					xMOV(gprT1, ptr32[&mVU.badBranch]);
+					xADD(gprT1, 8);
+					xSHR(gprT1, 3);
+					incPC(2);
+					mVUallocVIb(mVU, gprT1, _It_);
+				}
+			}
 		}
 
 		mVU.profiler.EmitOp(opJALR);

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -229,13 +229,6 @@ static void __fc mVUEBit()
 	vu1Thread.mtvuInterrupts.fetch_or(VU_Thread::InterruptFlagVUEBit, std::memory_order_release);
 }
 
-static inline u32 branchAddrN(const mV)
-{
-	pxAssumeDev(islowerOP, "MicroVU: Expected Lower OP code for valid branch addr.");
-	return ((((iPC + 4) + (_Imm11_ * 2)) & mVU.progMemMask) * 4);
-}
-
-
 static inline u32 branchAddr(const mV)
 {
 	pxAssumeDev(islowerOP, "MicroVU: Expected Lower OP code for valid branch addr.");


### PR DESCRIPTION
### Description of Changes
Reworks the handling of branches (with links) in delay slots and chains of 3 or more branches.

### Rationale behind Changes
Linking inside delay slots wasn't..right (or at least the flow is strange), but chaining 3 or more branches together just didn't work correctly, at all, the fact games worked was by sheer fluke.

### Suggested Testing Steps
Test any games that do branches/jumps (especially ones that link like BAL or JALR!) in delay slots, and especially games that to "branch, branch, branch!"

Fixes #5384
