### PR TITLE
Gamedb: remove EETimingHack  from 'Paris-Dakar 2'

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -9127,7 +9127,6 @@ SLES-50879:
   compat: 5
   gameFixes:
     - FpuNegDivHack # Fixes sky being shown over the 3d.
-    - EETimingHack # Flickery videos without it.
 SLES-50880:
   name: "BMX XXX"
   region: "PAL-M4"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
removes EETimingHack form Dakar 2 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
no longer needed as mentioned in  #5308 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
make sure CI passes 