### PR TITLE
GS: revert target scaling.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -556,6 +556,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, int
 			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, ShaderConvert::COPY, false);
 			g_gs_device->Recycle(dst->m_texture);
 			dst->m_texture = tex;
+			dst->m_texture->SetScale(new_s);
 		}
 
 		dst->Update();


### PR DESCRIPTION
### Description of Changes
Fix a missing texture scale setting and then revert for now the target rescaling code introduced by #4094 and completed by #5285.

### Rationale behind Changes
The GS currently does allocate an upscaled target even for native resolution draws.
This was not taken into account in the recent changes and caused double upscaling of native resolution drawn targets (before the missing texture scale setting the target would be upscaled indefinitely).
Until the GS code is changed to allow native resolution targets for native resolution draws even with upscaling, this rescaling code must not be executed.

### Suggested Testing Steps
Check that the regressions spotted in #5285 are fixed.
No game was fixed by the cited PR in particular.