### PR TITLE
GS: Prefer one-frame-old textures

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -125,7 +125,7 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int width, int height, i
 
 		if (t->GetType() == type && t->GetFormat() == format && t->GetSize() == size && t->GetMipmapLevels() == levels)
 		{
-			if (!prefer_new_texture)
+			if (!prefer_new_texture || t->last_frame_used != m_frame)
 			{
 				m_pool.erase(i);
 				break;


### PR DESCRIPTION
### Description of Changes
Prefer one-frame-old textures instead of new textures

### Rationale behind Changes
The main reason for preferring new textures is to prevent needing to split a render pass to upload to the texture (in Vulkan or Metal).  This split only happens if the texture was last written in the same frame it's being uploaded to.

By preferring one-frame-old textures we can improve texture reuse without affecting draw performance

### Suggested Testing Steps
Test Vulkan and watch memory usage (should hopefully be lower) and performance (should hopefully not be lower)
