### PR TITLE
CMake: Find SDL2 with find_package and mark as required

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -144,7 +144,7 @@ else()
 	check_lib(SOUNDTOUCH SoundTouch SoundTouch.h PATH_SUFFIXES soundtouch)
 	check_lib(SAMPLERATE samplerate samplerate.h)
 
-	check_lib(SDL2 SDL2 SDL.h PATH_SUFFIXES SDL2)
+	find_package(SDL2 2.0.12 REQUIRED)
 
 	if(UNIX AND NOT APPLE)
 		find_package(X11 REQUIRED)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -60,9 +60,9 @@ if(XDG_STD)
 	target_compile_definitions(PCSX2_FLAGS INTERFACE XDG_STD)
 endif()
 
-if(TARGET PkgConfig::SDL2)
+if(TARGET SDL2::SDL2)
 	target_compile_definitions(PCSX2_FLAGS INTERFACE SDL_BUILD)
-	target_link_libraries(PCSX2_FLAGS INTERFACE PkgConfig::SDL2)
+	target_link_libraries(PCSX2_FLAGS INTERFACE SDL2::SDL2)
 	if(PCSX2_CORE)
 		target_sources(PCSX2 PRIVATE
 			Frontend/SDLInputSource.cpp


### PR DESCRIPTION
### Description of Changes
Uses find_package to find SDL2 and marks it as required

### Rationale behind Changes
I didn't realize SDL2 provided a cmake configuration script but it does
Now properly validates the installed version and fails configuration if SDL2 isn't found (non-SDL2 builds are not supported on Linux/MacOS)

### Suggested Testing Steps
Make sure PCSX2 still builds
