### PR TITLE
GS-hw: Properly disable skipdraw when userhacks are disabled.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1083,7 +1083,7 @@ bool GSState::IsBadFrame()
 		return false;
 	}
 
-	if (m_skip == 0 && (GSConfig.SkipDraw > 0))
+	if (m_skip == 0 && GSConfig.UserHacks && (GSConfig.SkipDraw > 0))
 	{
 		if (fi.TME)
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Properly disable skipdraw when userhacks are disabled.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes #5416
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure skipdraw is properly disabled when hw hacks are off.