### PR TITLE
GS: target rescaling take 2.

### DIFF
--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -72,6 +72,16 @@ public:
 	{
 		return x != v.x || y != v.y;
 	}
+
+	constexpr GSVector2T operator*(const GSVector2T& v) const
+	{
+		return { x * v.x, y * v.y };
+	}
+
+	constexpr GSVector2T operator/(const GSVector2T& v) const
+	{
+		return { x / v.x, y / v.y };
+	}
 };
 
 typedef GSVector2T<float> GSVector2;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -177,7 +177,9 @@ public:
 	GSVector4 RealignTargetTextureCoordinate(const GSTextureCache::Source* tex);
 	GSVector4i ComputeBoundingBox(const GSVector2& rtscale, const GSVector2i& rtsize);
 	void MergeSprite(GSTextureCache::Source* tex);
+	GSVector2 GetTextureScaleFactor(const bool force_upscaling);
 	GSVector2 GetTextureScaleFactor() override;
+	GSVector2i GetTargetSize();
 
 	void Reset() override;
 	void VSync(u32 field, bool registers_written) override;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -163,15 +163,15 @@ public:
 	class Target : public Surface
 	{
 	public:
-		int m_type;
+		const int m_type;
 		bool m_used;
 		GSDirtyRectList m_dirty;
 		GSVector4i m_valid;
-		bool m_depth_supported;
+		const bool m_depth_supported;
 		bool m_dirty_alpha;
 
 	public:
-		Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, bool depth_supported);
+		Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, const bool depth_supported, const int type);
 
 		void UpdateValidity(const GSVector4i& rect);
 
@@ -263,7 +263,7 @@ protected:
 	std::unordered_map<SurfaceOffsetKey, SurfaceOffset, SurfaceOffsetKeyHash, SurfaceOffsetKeyEqual> m_surface_offset_cache;
 
 	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false, int x_offset = 0, int y_offset = 0, bool mipmap = false);
-	Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type);
+	Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type, const bool clear);
 
 	// TODO: virtual void Write(Source* s, const GSVector4i& r) = 0;
 	// TODO: virtual void Write(Target* t, const GSVector4i& r) = 0;
@@ -279,8 +279,8 @@ public:
 	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, bool mipmap);
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, bool palette = false);
 
-	Target* LookupTarget(const GIFRegTEX0& TEX0, int w, int h, int type, bool used, u32 fbmask = 0);
-	Target* LookupTarget(const GIFRegTEX0& TEX0, int w, int h, int real_h);
+	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask = 0, const bool is_frame = false, const int real_h = 0);
+	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, const int real_h);
 
 	void InvalidateVideoMemType(int type, u32 bp);
 	void InvalidateVideoMemSubTarget(GSTextureCache::Target* rt);
@@ -289,7 +289,6 @@ public:
 
 	void IncAge();
 	bool UserHacks_HalfPixelOffset;
-	void ScaleTexture(GSTexture* texture);
 
 	bool ShallSearchTextureInsideRt();
 


### PR DESCRIPTION
### Description of Changes
#5285 take 2.
Added full support for target rescaling in GS TC, respecting the texture aspect ratio.
Avoid redundant clears when the target is going to be completely drawn when rescaling/converting.
Merge the two ways to lookup render targets (for draw and frame) into a single slightly more complex method, to recycle the rescaling logic and other code.
Avoid using upscaled size for targets requested at native resolution when upscaling.
Correctly set texture scale for targets created in a frame lookup.
Update targets from GS memory before converting color to depth.
Update targets validity region when uploading dirty data from GS memory (especially useful in combination with preload frame data, which makes the initial validity region of the target non empty).

### Rationale behind Changes
Improve TC behaviour when handling targets with different scaling, for example native res and upscaled, or potentially when changing internal resolution without flushing the TC.

### Suggested Testing Steps
Test some games and check that no visual regression occurs, especially games with "CU" hacks that have explicit native res draws even when upscaled (currently only "Tales Of Abyss").
Potentially appreciate performance improvement due to less target clearing and smaller render targets when big ones are not required.
Maybe some visual bug is fixed by updating the color targets before converting to depth, or by correctly setting texture scale for targets created in a frame lookup, or by updating the target validity region on dirty data upload from GS memory.
Test Manhunt 2 and Dynasty Warriors 5 which had severe regressions with #5285.
