### PR TITLE
GS: Get rid of extra binding for channel shuffle

### DIFF
--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -43,8 +43,7 @@ layout(location = 0, index = 0) out vec4 SV_Target0;
 layout(location = 0, index = 1) out vec4 SV_Target1;
 
 layout(binding = 1) uniform sampler2D PaletteSampler;
-layout(binding = 3) uniform sampler2D RtSampler; // note 2 already use by the image below
-layout(binding = 4) uniform sampler2D RawTextureSampler;
+layout(binding = 2) uniform sampler2D RtSampler; // note 2 already use by the image below
 
 #ifndef DISABLE_GL42_image
 #if PS_DATE > 0
@@ -52,7 +51,7 @@ layout(binding = 4) uniform sampler2D RawTextureSampler;
 // require extra shader validation.
 
 // FIXME how to declare memory access
-layout(r32i, binding = 2) uniform iimage2D img_prim_min;
+layout(r32i, binding = 3) uniform iimage2D img_prim_min;
 // WARNING:
 // You can't enable it if you discard the fragment. The depth is still
 // updated (shadow in Shin Megami Tensei Nocturne)
@@ -233,12 +232,20 @@ mat4 sample_4p(vec4 u)
 
 int fetch_raw_depth()
 {
-    return int(texelFetch(RawTextureSampler, ivec2(gl_FragCoord.xy), 0).r * exp2(32.0f));
+#if PS_TEX_IS_FB == 1
+    return int(texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0).r * exp2(32.0f));
+#else
+    return int(texelFetch(TextureSampler, ivec2(gl_FragCoord.xy), 0).r * exp2(32.0f));
+#endif
 }
 
 vec4 fetch_raw_color()
 {
-    return texelFetch(RawTextureSampler, ivec2(gl_FragCoord.xy), 0);
+#if PS_TEX_IS_FB == 1
+    return texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0);
+#else
+    return texelFetch(TextureSampler, ivec2(gl_FragCoord.xy), 0);
+#endif
 }
 
 vec4 fetch_c(ivec2 uv)

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -489,7 +489,6 @@ struct alignas(16) GSHWDrawConfig
 	GSTexture* ds;        ///< Depth stencil
 	GSTexture* tex;       ///< Source texture
 	GSTexture* pal;       ///< Palette texture
-	GSTexture* raw_tex;   ///< Used by channel shuffles
 	GSVertex* verts;      ///< Vertices to draw
 	u32* indices;         ///< Indices to draw
 	u32 nverts;           ///< Number of vertices

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1360,8 +1360,9 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	}
 	IASetPrimitiveTopology(topology);
 
+	OMSetRenderTargets(hdr_rt ? hdr_rt : config.rt, config.ds, &config.scissor);
+
 	PSSetShaderResources(config.tex, config.pal);
-	PSSetShaderResource(4, config.raw_tex);
 
 	if (config.require_one_barrier) // Used as "bind rt" flag when texture barrier is unsupported
 	{
@@ -1369,15 +1370,13 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		// Do not always bind the rt when it's not needed,
 		// only bind it when effects use it such as fbmask emulation currently
 		// because we copy the frame buffer and it is quite slow.
-		PSSetShaderResource(3, config.rt);
+		PSSetShaderResource(2, config.rt);
 	}
 
 	SetupOM(config.depth, convertSel(config.colormask, config.blend), config.blend.factor);
 	SetupVS(config.vs, &config.cb_vs);
 	SetupGS(config.gs);
 	SetupPS(config.ps, &config.cb_ps, config.sampler);
-
-	OMSetRenderTargets(hdr_rt ? hdr_rt : config.rt, config.ds, &config.scissor);
 
 	DrawIndexedPrimitive();
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -365,79 +365,26 @@ void GSDevice11::RestoreAPIState()
 		m_ctx->OMSetRenderTargets(0, nullptr, m_state.dsv);
 }
 
-void GSDevice11::BeforeDraw()
-{
-	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
-
-	// DX can't read from the FB
-	// So let's copy it and send that to the shader instead
-
-	auto bits = m_state.ps_sr_bitfield;
-	m_state.ps_sr_bitfield = 0;
-
-	unsigned long i;
-	while (_BitScanForward(&i, bits))
-	{
-		GSTexture11* tex = m_state.ps_sr_texture[i];
-
-		if (tex->Equal(m_state.rt_texture) || tex->Equal(m_state.rt_ds))
-		{
-#ifdef _DEBUG
-			OutputDebugStringA(format("WARNING: Cleaning up copied texture on slot %i", i).c_str());
-#endif
-			GSTexture* cp = nullptr;
-
-			CloneTexture(tex, &cp);
-
-			PSSetShaderResource(i, cp);
-		}
-
-		bits ^= 1u << i;
-	}
-
-	PSUpdateShaderState();
-}
-
-void GSDevice11::AfterDraw()
-{
-	unsigned long i;
-	while (_BitScanForward(&i, m_state.ps_sr_bitfield))
-	{
-#ifdef _DEBUG
-		OutputDebugStringA(format("WARNING: FB read detected on slot %i, copying...", i).c_str());
-#endif
-		Recycle(m_state.ps_sr_texture[i]);
-		PSSetShaderResource(i, nullptr);
-	}
-}
-
 void GSDevice11::DrawPrimitive()
 {
-	BeforeDraw();
-
+	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
+	PSUpdateShaderState();
 	m_ctx->Draw(m_vertex.count, m_vertex.start);
-
-	AfterDraw();
 }
 
 void GSDevice11::DrawIndexedPrimitive()
 {
-	BeforeDraw();
-
+	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
+	PSUpdateShaderState();
 	m_ctx->DrawIndexed(m_index.count, m_index.start, m_vertex.start);
-
-	AfterDraw();
 }
 
 void GSDevice11::DrawIndexedPrimitive(int offset, int count)
 {
 	ASSERT(offset + count <= (int)m_index.count);
-
-	BeforeDraw();
-
+	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
+	PSUpdateShaderState();
 	m_ctx->DrawIndexed(count, m_index.start + offset, m_vertex.start);
-
-	AfterDraw();
 }
 
 void GSDevice11::ClearRenderTarget(GSTexture* t, const GSVector4& c)
@@ -567,9 +514,14 @@ void GSDevice11::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r)
 		return;
 	}
 
+	CopyRect(sTex, r, dTex, 0, 0);
+}
+
+void GSDevice11::CopyRect(GSTexture* sTex, const GSVector4i& sRect, GSTexture* dTex, u32 destX, u32 destY)
+{
 	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
-	D3D11_BOX box = {(UINT)r.left, (UINT)r.top, 0U, (UINT)r.right, (UINT)r.bottom, 1U};
+	D3D11_BOX box = {(UINT)sRect.left, (UINT)sRect.top, 0U, (UINT)sRect.right, (UINT)sRect.bottom, 1U};
 
 	// DX api isn't happy if we pass a box for depth copy
 	// It complains that depth/multisample must be a full copy
@@ -577,26 +529,27 @@ void GSDevice11::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r)
 	const bool depth = (sTex->GetType() == GSTexture::Type::DepthStencil);
 	auto pBox = depth ? nullptr : &box;
 
-	m_ctx->CopySubresourceRegion(*(GSTexture11*)dTex, 0, 0, 0, 0, *(GSTexture11*)sTex, 0, pBox);
+	m_ctx->CopySubresourceRegion(*(GSTexture11*)dTex, 0, destX, destY, 0, *(GSTexture11*)sTex, 0, pBox);
 }
 
-void GSDevice11::CloneTexture(GSTexture* src, GSTexture** dest)
+void GSDevice11::CloneTexture(GSTexture* src, GSTexture** dest, const GSVector4i& rect)
 {
-	if (!src || !(src->GetType() == GSTexture::Type::DepthStencil || src->GetType() == GSTexture::Type::RenderTarget))
-	{
-		ASSERT(0);
-		return;
-	}
+	pxAssertMsg(src->GetType() == GSTexture::Type::DepthStencil || src->GetType() == GSTexture::Type::RenderTarget, "Source is RT or DS.");
 
 	const int w = src->GetWidth();
 	const int h = src->GetHeight();
 
 	if (src->GetType() == GSTexture::Type::DepthStencil)
-		*dest = CreateDepthStencil(w, h, src->GetFormat());
+	{
+		// DX11 requires that you copy the entire depth buffer.
+		*dest = CreateDepthStencil(w, h, src->GetFormat(), false);
+		CopyRect(src, GSVector4i(0, 0, w, h), *dest, 0, 0);
+	}
 	else
-		*dest = CreateRenderTarget(w, h, src->GetFormat());
-
-	CopyRect(src, *dest, GSVector4i(0, 0, w, h));
+	{
+		*dest = CreateRenderTarget(w, h, src->GetFormat(), false);
+		CopyRect(src, rect, *dest, rect.left, rect.top);
+	}
 }
 
 void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader, bool linear)
@@ -1146,7 +1099,6 @@ void GSDevice11::PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, G
 	{
 		m_state.ps_sr_views[i] = srv;
 		m_state.ps_sr_texture[i] = (GSTexture11*)sr;
-		srv ? m_state.ps_sr_bitfield |= 1u << i : m_state.ps_sr_bitfield &= ~(1u << i);
 	}
 }
 
@@ -1305,7 +1257,6 @@ static void preprocessSel(GSDevice11::PSSelector& sel)
 {
 	ASSERT(sel.date      == 0); // In-shader destination alpha not supported and shouldn't be sent
 	ASSERT(sel.write_rg  == 0); // Not supported, shouldn't be sent
-	ASSERT(sel.tex_is_fb == 0); // Not supported, shouldn't be sent
 }
 
 void GSDevice11::RenderHW(GSHWDrawConfig& config)
@@ -1364,13 +1315,23 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	PSSetShaderResources(config.tex, config.pal);
 
-	if (config.require_one_barrier) // Used as "bind rt" flag when texture barrier is unsupported
+	GSTexture* rt_copy = nullptr;
+	if (config.require_one_barrier || (config.tex && config.tex == config.rt)) // Used as "bind rt" flag when texture barrier is unsupported
 	{
 		// Bind the RT.This way special effect can use it.
 		// Do not always bind the rt when it's not needed,
 		// only bind it when effects use it such as fbmask emulation currently
 		// because we copy the frame buffer and it is quite slow.
-		PSSetShaderResource(2, config.rt);
+		CloneTexture(config.rt, &rt_copy, config.drawarea);
+		if (rt_copy)
+			PSSetShaderResource(config.require_one_barrier ? 2 : 0, rt_copy);
+	}
+	else if (config.tex && config.tex == config.ds)
+	{
+		// mainly for ico (depth buffer used as texture)
+		CloneTexture(config.ds, &rt_copy, config.drawarea);
+		if (rt_copy)
+			PSSetShaderResource(0, rt_copy);
 	}
 
 	SetupOM(config.depth, convertSel(config.colormask, config.blend), config.blend.factor);
@@ -1400,6 +1361,9 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	}
 
 	EndScene();
+
+	if (rt_copy)
+		Recycle(rt_copy);
 
 	if (hdr_rt)
 	{

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1074,41 +1074,18 @@ void GSDevice11::PSSetShaderResources(GSTexture* sr0, GSTexture* sr1)
 {
 	PSSetShaderResource(0, sr0);
 	PSSetShaderResource(1, sr1);
-
-	for (size_t i = 2; i < m_state.ps_sr_views.size(); i++)
-	{
-		PSSetShaderResource(i, nullptr);
-	}
+	PSSetShaderResource(2, nullptr);
 }
 
 void GSDevice11::PSSetShaderResource(int i, GSTexture* sr)
 {
-	ID3D11ShaderResourceView* srv = nullptr;
-
-	if (sr)
-		srv = *(GSTexture11*)sr;
-
-	PSSetShaderResourceView(i, srv, sr);
-}
-
-void GSDevice11::PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, GSTexture* sr)
-{
-	ASSERT(i < (int)m_state.ps_sr_views.size());
-
-	if (m_state.ps_sr_views[i] != srv)
-	{
-		m_state.ps_sr_views[i] = srv;
-		m_state.ps_sr_texture[i] = (GSTexture11*)sr;
-	}
+	m_state.ps_sr_views[i] = sr ? static_cast<ID3D11ShaderResourceView*>(*static_cast<GSTexture11*>(sr)) : nullptr;
 }
 
 void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1)
 {
-	if (m_state.ps_ss[0] != ss0 || m_state.ps_ss[1] != ss1)
-	{
-		m_state.ps_ss[0] = ss0;
-		m_state.ps_ss[1] = ss1;
-	}
+	m_state.ps_ss[0] = ss0;
+	m_state.ps_ss[1] = ss1;
 }
 
 void GSDevice11::PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb)
@@ -1131,7 +1108,7 @@ void GSDevice11::PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb)
 void GSDevice11::PSUpdateShaderState()
 {
 	m_ctx->PSSetShaderResources(0, m_state.ps_sr_views.size(), m_state.ps_sr_views.data());
-	m_ctx->PSSetSamplers(0, std::size(m_state.ps_ss), m_state.ps_ss);
+	m_ctx->PSSetSamplers(0, m_state.ps_ss.size(), m_state.ps_ss.data());
 }
 
 void GSDevice11::OMSetDepthStencilState(ID3D11DepthStencilState* dss, u8 sref)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -121,8 +121,6 @@ private:
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex) final;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) final;
-	void BeforeDraw();
-	void AfterDraw();
 
 	u16 ConvertBlendEnum(u16 generic) final;
 
@@ -158,7 +156,6 @@ private:
 		GSTexture11* rt_texture;
 		GSTexture11* rt_ds;
 		ID3D11DepthStencilView* dsv;
-		uint16_t ps_sr_bitfield;
 	} m_state;
 
 
@@ -253,9 +250,10 @@ public:
 	bool DownloadTexture(GSTexture* src, const GSVector4i& rect, GSTexture::GSMap& out_map) final;
 	void DownloadTextureComplete() final;
 
-	void CloneTexture(GSTexture* src, GSTexture** dest);
+	void CloneTexture(GSTexture* src, GSTexture** dest, const GSVector4i& rect);
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r);
+	void CopyRect(GSTexture* sTex, const GSVector4i& sRect, GSTexture* dTex, u32 destX, u32 destY);
 
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader = ShaderConvert::COPY, bool linear = true) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, bool linear = true);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -111,6 +111,9 @@ private:
 	// Increment this constant whenever shaders change, to invalidate user's shader cache.
 	static constexpr u32 SHADER_VERSION = 1;
 
+	static constexpr u32 MAX_TEXTURES = 3;
+	static constexpr u32 MAX_SAMPLERS = 2;
+
 	float m_hack_topleft_offset;
 	int m_d3d_texsize;
 
@@ -141,11 +144,10 @@ private:
 		ID3D11Buffer* vs_cb;
 		ID3D11GeometryShader* gs;
 		ID3D11Buffer* gs_cb;
-		std::array<ID3D11ShaderResourceView*, 16> ps_sr_views;
-		std::array<GSTexture11*, 16> ps_sr_texture;
+		std::array<ID3D11ShaderResourceView*, MAX_TEXTURES> ps_sr_views;
 		ID3D11PixelShader* ps;
 		ID3D11Buffer* ps_cb;
-		ID3D11SamplerState* ps_ss[3];
+		std::array<ID3D11SamplerState*, MAX_SAMPLERS> ps_ss;
 		GSVector2i viewport;
 		GSVector4i scissor;
 		ID3D11DepthStencilState* dss;
@@ -276,7 +278,6 @@ public:
 
 	void PSSetShaderResources(GSTexture* sr0, GSTexture* sr1);
 	void PSSetShaderResource(int i, GSTexture* sr);
-	void PSSetShaderResourceView(int i, ID3D11ShaderResourceView* srv, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState();
 	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1);

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -194,6 +194,7 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 		sm.AddMacro("PS_SCANMSK", sel.scanmsk);
 		sm.AddMacro("PS_AUTOMATIC_LOD", sel.automatic_lod);
 		sm.AddMacro("PS_MANUAL_LOD", sel.manual_lod);
+		sm.AddMacro("PS_TEX_IS_FB", sel.tex_is_fb);
 
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps = m_shader_cache.GetPixelShader(m_dev.get(), m_tfx_source, sm.GetPtr(), "ps_main");
 		i = m_ps.try_emplace(sel.key, std::move(ps)).first;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.h
@@ -27,7 +27,7 @@ private:
 	inline void ResetStates();
 	inline void SetupIA(const float& sx, const float& sy);
 	inline void EmulateTextureShuffleAndFbmask();
-	inline void EmulateChannelShuffle(GSTexture** rt, const GSTextureCache::Source* tex);
+	inline void EmulateChannelShuffle(const GSTextureCache::Source* tex);
 	inline void EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER);
 	inline void EmulateTextureSampler(const GSTextureCache::Source* tex);
 	inline void EmulateZbuffer();

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -949,10 +949,10 @@ void GSDeviceOGL::InitPrimDateTexture(GSTexture* rt, const GSVector4i& area)
 	const int max_int = 0x7FFFFFFF;
 	static_cast<GSTextureOGL*>(m_date.t)->Clear(&max_int, area);
 
-	glBindImageTexture(2, static_cast<GSTextureOGL*>(m_date.t)->GetID(), 0, false, 0, GL_READ_WRITE, GL_R32I);
+	glBindImageTexture(3, static_cast<GSTextureOGL*>(m_date.t)->GetID(), 0, false, 0, GL_READ_WRITE, GL_R32I);
 #ifdef ENABLE_OGL_DEBUG
 	// Help to see the texture in apitrace
-	PSSetShaderResource(2, m_date.t);
+	PSSetShaderResource(3, m_date.t);
 #endif
 }
 
@@ -1880,9 +1880,8 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	IASetPrimitiveTopology(topology);
 
 	PSSetShaderResources(config.tex, config.pal);
-	PSSetShaderResource(4, config.raw_tex);
 	// Always bind the RT. This way special effect can use it.
-	PSSetShaderResource(3, config.rt);
+	PSSetShaderResource(2, config.rt);
 
 	SetupSampler(config.sampler);
 	OMSetBlendState(config.blend.index, config.blend.factor, config.blend.is_constant, config.blend.is_accumulation, config.blend.is_mixed_hw_sw);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -82,7 +82,7 @@ public:
 		NUM_TFX_DESCRIPTOR_SETS = 3,
 		NUM_TFX_DYNAMIC_OFFSETS = 2,
 		NUM_TFX_SAMPLERS = 2,
-		NUM_TFX_RT_TEXTURES = 3,
+		NUM_TFX_RT_TEXTURES = 2,
 		NUM_TFX_TEXTURES = NUM_TFX_SAMPLERS + NUM_TFX_RT_TEXTURES,
 		NUM_CONVERT_TEXTURES = 1,
 		NUM_CONVERT_SAMPLERS = 1,
@@ -253,7 +253,7 @@ public:
 	void IAUnmapVertexBuffer();
 	void IASetIndexBuffer(const void* index, size_t count);
 
-	void PSSetShaderResource(int i, GSTexture* sr);
+	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);
 	void PSSetSampler(u32 index, GSHWDrawConfig::SamplerSelector sel);
 
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor, bool feedback_loop);


### PR DESCRIPTION
### Description of Changes

Having this binding was redundant, as there's no "normal" texture sampled when we're doing a channel shuffle, and it caused issues in Vulkan when the render target or depth buffer the source.

Also fixes the Urban Chaos HLE shader.

Fixes validation errors in GT4, NFS: Carbon, Urban Chaos, probably others too.

For DX11, does a smaller copy for the RT when it's copied for sampling, which is a significant improvement (9fps->25fps with ultra blending in xenosaga, 3fps->25fps at 4x).

### Suggested Testing Steps

Test blending and channel shuffle games.
