### PR TITLE
GS: fix overlap check in hw tc.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -35,7 +35,7 @@ public:
 
 	constexpr static bool CheckOverlap(const u32 a_bp, const u32 a_bp_end, const u32 b_bp, const u32 b_bp_end) noexcept
 	{
-		const bool valid = a_bp < a_bp_end && b_bp < b_bp_end;
+		const bool valid = a_bp <= a_bp_end && b_bp <= b_bp_end;
 		const bool overlap = a_bp <= b_bp_end && a_bp_end >= b_bp;
 		return valid && overlap;
 	}


### PR DESCRIPTION
### Description of Changes
Fix the surfaces overlap check in the gs hw tc when any of the two compared surfaces span a single block (a very small texture).
Fixes #5429.

### Rationale behind Changes
Textures can span a single block indeed.

### Suggested Testing Steps
Test Jak 3 and check that the desert rendering is fine.
