### PR TITLE
Revert GS-hw: Exclude triangles from no prim overlap fb read on dx11.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -598,21 +598,19 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		// BLEND_C_CLR1 with Ad, BLEND_C_CLR4  Cs > 0.5f will require sw blend.
 		// BLEND_C_CLR1 with As/F, BLEND_C_CLR2_AF, BLEND_C_CLR3_AS can be done in hw.
 		const bool clr_blend = !!(blend_flag & (BLEND_C_CLR1 | BLEND_C_CLR2_AF | BLEND_C_CLR3_AS | BLEND_C_CLR4));
-		// Exclude triangles, breaks mgs3 on ultra blending.
-		const bool no_overlap_no_triangles = (m_prim_overlap == PRIM_OVERLAP_NO) && (m_vt.m_primclass != GS_TRIANGLE_CLASS);
 		// FBMASK already reads the fb so it is safe to enable sw blend when there is no overlap.
-		const bool fbmask_no_overlap = m_conf.require_one_barrier && no_overlap_no_triangles;
+		const bool fbmask_no_overlap = m_conf.require_one_barrier && (m_prim_overlap == PRIM_OVERLAP_NO);
 
 		switch (GSConfig.AccurateBlendingUnit)
 		{
 			case AccBlendLevel::Ultra:
-				sw_blending |= no_overlap_no_triangles;
+				sw_blending |= (m_prim_overlap == PRIM_OVERLAP_NO);
 				[[fallthrough]];
 			case AccBlendLevel::Full:
-				sw_blending |= ((ALPHA.C == 1 || (blend_mix && (alpha_c2_high_one || alpha_c0_high_max_one))) && no_overlap_no_triangles);
+				sw_blending |= ((ALPHA.C == 1 || (blend_mix && (alpha_c2_high_one || alpha_c0_high_max_one))) && (m_prim_overlap == PRIM_OVERLAP_NO));
 				[[fallthrough]];
 			case AccBlendLevel::High:
-				sw_blending |= (!(clr_blend || blend_mix) && no_overlap_no_triangles);
+				sw_blending |= (!(clr_blend || blend_mix) && (m_prim_overlap == PRIM_OVERLAP_NO));
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 			case AccBlendLevel::Basic:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Revert GS-hw: Exclude triangles from no prim overlap fb read on dx11.
Issue fixed in #5422
Do note high and above blending levels don't work well with mgs3 as we are missing sw blending in other cases causing issues.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Initial issue was resolved, commit is no longer needed, accuracy.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test blending on d3d11.