### PR TITLE
InputManager/XInput: Fix inverted/incorrect axes

### DIFF
--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -54,6 +54,7 @@ void ControllerGlobalSettingsWidget::removeDeviceFromList(const QString& identif
 			continue;
 
 		delete m_ui.deviceList->takeItem(i);
+		break;
 	}
 }
 

--- a/pcsx2-qt/Settings/InputBindingDialog.cpp
+++ b/pcsx2-qt/Settings/InputBindingDialog.cpp
@@ -193,11 +193,13 @@ void InputBindingDialog::saveListToSettings()
 
 void InputBindingDialog::inputManagerHookCallback(InputBindingKey key, float value)
 {
+	const float abs_value = std::abs(value);
+
 	for (InputBindingKey other_key : m_new_bindings)
 	{
 		if (other_key.MaskDirection() == key.MaskDirection())
 		{
-			if (value < 0.25f)
+			if (abs_value < 0.5f)
 			{
 				// if this key is in our new binding list, it's a "release", and we're done
 				addNewBinding();
@@ -211,8 +213,12 @@ void InputBindingDialog::inputManagerHookCallback(InputBindingKey key, float val
 	}
 
 	// new binding, add it to the list, but wait for a decent distance first, and then wait for release
-	if (value >= 0.25f)
+	if (abs_value >= 0.5f)
+	{
+		InputBindingKey key_to_add = key;
+		key_to_add.negative = (value < 0.0f);
 		m_new_bindings.push_back(key);
+	}
 }
 
 void InputBindingDialog::hookInputManager()

--- a/pcsx2/Frontend/XInputSource.cpp
+++ b/pcsx2/Frontend/XInputSource.cpp
@@ -331,12 +331,13 @@ void XInputSource::CheckForStateChanges(u32 index, const XINPUT_STATE& new_state
 		ogp.field = ngp.field; \
 	}
 
-	CHECK_AXIS(sThumbLX, AXIS_LEFTX, -32768, 32767);
-	CHECK_AXIS(sThumbLY, AXIS_LEFTY, -32768, 32767);
-	CHECK_AXIS(sThumbRX, AXIS_RIGHTX, -32768, 32767);
-	CHECK_AXIS(sThumbRY, AXIS_RIGHTY, -32768, 32767);
-	CHECK_AXIS(bLeftTrigger, AXIS_LEFTTRIGGER, -128, 127);
-	CHECK_AXIS(bRightTrigger, AXIS_RIGHTTRIGGER, -128, 127);
+	// Y axes is inverted in XInput when compared to SDL.
+	CHECK_AXIS(sThumbLX, AXIS_LEFTX, 32768, 32767);
+	CHECK_AXIS(sThumbLY, AXIS_LEFTY, -32768, -32767);
+	CHECK_AXIS(sThumbRX, AXIS_RIGHTX, 32768, 32767);
+	CHECK_AXIS(sThumbRY, AXIS_RIGHTY, -32768, -32767);
+	CHECK_AXIS(bLeftTrigger, AXIS_LEFTTRIGGER, 128, 127);
+	CHECK_AXIS(bRightTrigger, AXIS_RIGHTTRIGGER, 128, 127);
 
 #undef CHECK_AXIS
 


### PR DESCRIPTION
Makes the input binding dialog (multiple bindings) behaviour match the in-window buttons.

Fixes Y axis being inverted in XInput vs SDL (and in XInput's case, negative values not going through).