### PR TITLE
GameDB: Urban Reign

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -763,7 +763,9 @@ SCAJ-20151:
   region: "NTSC-Unk"
 SCAJ-20152:
   name: "Urban Reign"
-  region: "NTSC-Unk"
+  region: "NTSC-J"
+  gameFixes:
+    - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
 SCAJ-20153:
   name: "Code Age Commanders"
   region: "NTSC-J"
@@ -3012,6 +3014,8 @@ SCES-53688:
   name: "Urban Reign"
   region: "PAL-M5"
   compat: 5
+  gameFixes:
+    - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
 SCES-53795:
   name: "SingStar '80s"
   region: "PAL-Unk"
@@ -31328,6 +31332,8 @@ SLPS-25556:
 SLPS-25557:
   name: "Urban Reign"
   region: "NTSC-J"
+  gameFixes:
+    - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
 SLPS-25558:
   name: "NeoGeo Battle Coliseum"
   region: "NTSC-J"
@@ -38045,6 +38051,8 @@ SLUS-21209:
   name: "Urban Reign"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
 SLUS-21212:
   name: "Spartan - Total Warrior"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
EE cyclerate +1 will fix the issue but a compromise on default is to enable EE-Timing-hack. Ee cyclerate +1 can be combined with or without EETiming.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
It's a compromise to improve users by default even if it's the best fix)
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check the menus and in-game without changing settings for vertical shaking (like similar on other games that shake the screen on different interlacing settings.) Urban Reign shake is very severe on None Interlacing so maybe check there too (yeah It's not the correct naming for it)