### PR TITLE
GS: Fix region repeat bounds checking for zero crossings

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2664,6 +2664,15 @@ __forceinline void GSState::VertexKick(u32 skip)
 /// Also calculates the real min and max values seen after applying the region repeat to all values in min...max
 static bool UsesRegionRepeat(int fix, int msk, int min, int max, int* min_out, int* max_out)
 {
+	if ((min < 0) != (max < 0))
+	{
+		// Algorithm doesn't work properly if bits overflow when incrementing (happens on the -1 → 0 crossing)
+		// Conveniently, crossing zero guarantees you use the full range
+		*min_out = fix;
+		*max_out = (fix | msk) + 1;
+		return true;
+	}
+
 	const int cleared_bits = ~msk & ~fix; // Bits that are always cleared by applying msk and fix
 	const int set_bits = fix; // Bits that are always set by applying msk and fix
 	unsigned long msb;


### PR DESCRIPTION
### Description of Changes
Fixes a regression from #5387

### Rationale behind Changes
Less brokenness

### Suggested Testing Steps
Test [FFX-Flicker.zip](https://github.com/PCSX2/pcsx2/files/7976271/FFX-Flicker.zip)