### PR TITLE
GS/HW: Don't disable depth testing for channel shuffle

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2043,9 +2043,10 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config)
 			DrawIndexedPrimitive(p, config.indices_per_prim);
 		}
 	}
-	else if (config.require_one_barrier)
+	else if (config.require_one_barrier || (config.tex && config.tex == config.ds))
 	{
-		// One barrier needed
+		// The common renderer code doesn't put a barrier here because D3D/VK need to copy the DS, so we need to check it.
+		// One barrier needed for non-overlapping draw.
 		glTextureBarrier();
 		DrawIndexedPrimitive();
 	}

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -231,6 +231,7 @@ public:
 	bool ReadbackTexture(GSTexture* src, const GSVector4i& rect, u32 level, GSTexture::GSMap* dst);
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r) override;
+	void DoCopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, const GSVector4i& dst_rc);
 
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		ShaderConvert shader = ShaderConvert::COPY, bool linear = true) override;


### PR DESCRIPTION
### Description of Changes

Regression from #5422.

Mercenaries needs it. But we can skip it when z testing is off.

Handles this case in Vulkan, which would otherwise be a validation error (also affects Ico).

Technically we can handle this as another feedback loop, but in my opinion it's not worth it, since there's only two games I've seen which do this - Ico and Mercenaries.

### Suggested Testing Steps

Test Mercenaries and Ico. Nothing else seems affected that we know of.
