### PR TITLE
GS/Vulkan: Buffer flag changes, HostDisplay cleanup

### DIFF
--- a/common/Vulkan/StreamBuffer.cpp
+++ b/common/Vulkan/StreamBuffer.cpp
@@ -73,6 +73,7 @@ namespace Vulkan
 		VmaAllocationCreateInfo aci = {};
 		aci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
 		aci.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+		aci.preferredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
 		VmaAllocationInfo ai = {};
 		VkBuffer new_buffer = VK_NULL_HANDLE;

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -58,10 +58,8 @@ public:
 	void DestroyRenderSurface() override;
 	std::string GetDriverInfo() const override;
 
-	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, u32 layers, u32 levels,
-		const void* data, u32 data_stride, bool dynamic = false) override;
-	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data,
-		u32 texture_data_stride) override;
+	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;
+	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data, u32 texture_data_stride) override;
 
 	bool GetHostRefreshRate(float* refresh_rate) override;
 

--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -29,12 +29,10 @@
 class OpenGLHostDisplayTexture : public HostDisplayTexture
 {
 public:
-	OpenGLHostDisplayTexture(GLuint texture, u32 width, u32 height, u32 layers, u32 levels)
+	OpenGLHostDisplayTexture(GLuint texture, u32 width, u32 height)
 		: m_texture(texture)
 		, m_width(width)
 		, m_height(height)
-		, m_layers(layers)
-		, m_levels(levels)
 	{
 	}
 	~OpenGLHostDisplayTexture() override = default;
@@ -42,8 +40,6 @@ public:
 	void* GetHandle() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_texture)); }
 	u32 GetWidth() const override { return m_width; }
 	u32 GetHeight() const override { return m_height; }
-	u32 GetLayers() const override { return m_layers; }
-	u32 GetLevels() const override { return m_levels; }
 
 	GLuint GetGLID() const { return m_texture; }
 
@@ -82,8 +78,7 @@ void* OpenGLHostDisplay::GetRenderSurface() const
 	return nullptr;
 }
 
-std::unique_ptr<HostDisplayTexture> OpenGLHostDisplay::CreateTexture(u32 width, u32 height, u32 layers, u32 levels,
-	const void* data, u32 data_stride, bool dynamic /* = false */)
+std::unique_ptr<HostDisplayTexture> OpenGLHostDisplay::CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic /* = false */)
 {
 	// clear error
 	glGetError();
@@ -105,11 +100,10 @@ std::unique_ptr<HostDisplayTexture> OpenGLHostDisplay::CreateTexture(u32 width, 
 		return nullptr;
 	}
 
-	return std::make_unique<OpenGLHostDisplayTexture>(id, width, height, layers, levels);
+	return std::make_unique<OpenGLHostDisplayTexture>(id, width, height);
 }
 
-void OpenGLHostDisplay::UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height,
-	const void* texture_data, u32 texture_data_stride)
+void OpenGLHostDisplay::UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data, u32 texture_data_stride)
 {
 	OpenGLHostDisplayTexture* tex = static_cast<OpenGLHostDisplayTexture*>(texture);
 

--- a/pcsx2/Frontend/OpenGLHostDisplay.h
+++ b/pcsx2/Frontend/OpenGLHostDisplay.h
@@ -52,10 +52,8 @@ public:
 	void DestroyRenderSurface() override;
 	std::string GetDriverInfo() const override;
 
-	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, u32 layers, u32 levels, const void* data,
-		u32 data_stride, bool dynamic) override;
-	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data,
-		u32 texture_data_stride) override;
+	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic) override;
+	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data, u32 texture_data_stride) override;
 
 	void SetVSync(VsyncMode mode) override;
 

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -28,8 +28,6 @@ public:
 	void* GetHandle() const override { return const_cast<Vulkan::Texture*>(&m_texture); }
 	u32 GetWidth() const override { return m_texture.GetWidth(); }
 	u32 GetHeight() const override { return m_texture.GetHeight(); }
-	u32 GetLayers() const override { return m_texture.GetLayers(); }
-	u32 GetLevels() const override { return m_texture.GetLevels(); }
 
 	const Vulkan::Texture& GetTexture() const { return m_texture; }
 	Vulkan::Texture& GetTexture() { return m_texture; }
@@ -178,19 +176,15 @@ static bool UploadBufferToTexture(Vulkan::Texture* texture, u32 width, u32 heigh
 	return true;
 }
 
-std::unique_ptr<HostDisplayTexture> VulkanHostDisplay::CreateTexture(
-	u32 width, u32 height, u32 layers, u32 levels, const void* data, u32 data_stride, bool dynamic /* = false */)
+std::unique_ptr<HostDisplayTexture> VulkanHostDisplay::CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic /* = false */)
 {
 	static constexpr VkFormat vk_format = VK_FORMAT_R8G8B8A8_UNORM;
 	static constexpr VkImageUsageFlags usage =
 		VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 
 	Vulkan::Texture texture;
-	if (!texture.Create(width, height, levels, layers, vk_format, VK_SAMPLE_COUNT_1_BIT,
-			(layers > 1) ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, usage))
-	{
+	if (!texture.Create(width, height, 1, 1, vk_format, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, usage))
 		return {};
-	}
 
 	texture.TransitionToLayout(g_vulkan_context->GetCurrentCommandBuffer(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 

--- a/pcsx2/Frontend/VulkanHostDisplay.h
+++ b/pcsx2/Frontend/VulkanHostDisplay.h
@@ -43,10 +43,8 @@ public:
 	void DestroyRenderSurface() override;
 	std::string GetDriverInfo() const override;
 
-	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, u32 layers, u32 levels,
-		const void* data, u32 data_stride, bool dynamic = false) override;
-	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data,
-		u32 texture_data_stride) override;
+	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;
+	void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* texture_data, u32 texture_data_stride) override;
 
 	void SetVSync(VsyncMode mode) override;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1617,6 +1617,7 @@ bool GSDeviceVK::CheckStagingBufferSize(u32 required_size)
 	VmaAllocationCreateInfo aci = {};
 	aci.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
 	aci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+	aci.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
 
 	VmaAllocationInfo ai = {};
 	VkResult res = vmaCreateBuffer(

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -609,6 +609,11 @@ void GSDeviceVK::DoStretchRect(GSTextureVK* sTex, const GSVector4& sRect, GSText
 		if (InRenderPass() && !CheckRenderPassArea(dst_rc))
 			EndRenderPass();
 	}
+	else
+	{
+		// this is for presenting, we don't want to screw with the viewport/scissor set by display
+		m_dirty_flags &= ~(DIRTY_FLAG_VIEWPORT | DIRTY_FLAG_SCISSOR);
+	}
 
 	const bool drawing_to_current_rt = (is_present || InRenderPass());
 	if (!drawing_to_current_rt)

--- a/pcsx2/HostDisplay.h
+++ b/pcsx2/HostDisplay.h
@@ -36,8 +36,6 @@ public:
 	virtual void* GetHandle() const = 0;
 	virtual u32 GetWidth() const = 0;
 	virtual u32 GetHeight() const = 0;
-	virtual u32 GetLayers() const = 0;
-	virtual u32 GetLevels() const = 0;
 };
 
 /// Interface to the frontend's renderer.
@@ -114,10 +112,8 @@ public:
 	virtual void ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) = 0;
 
 	/// Creates an abstracted RGBA8 texture. If dynamic, the texture can be updated with UpdateTexture() below.
-	virtual std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, u32 layers, u32 levels, const void* data,
-		u32 data_stride, bool dynamic = false) = 0;
-	virtual void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* data,
-		u32 data_stride) = 0;
+	virtual std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) = 0;
+	virtual void UpdateTexture(HostDisplayTexture* texture, u32 x, u32 y, u32 width, u32 height, const void* data, u32 data_stride) = 0;
 
 	/// Returns false if the window was completely occluded. If frame_skip is set, the frame won't be
 	/// displayed, but the GPU command queue will still be flushed.


### PR DESCRIPTION
### Description of Changes

Few commits from my Qt branch which are nice and isolated and worth pulling in.

### Rationale behind Changes

The buffer flags may make a difference to performance on AMD, enabling PCSX2 to use the 256MB GPU-memory heap instead of system memory for buffer streaming. It also improves significantly performance with MoltenVK (tested by Tellow).

### Suggested Testing Steps

Make sure Vulkan isn't broken on any strange configurations (e.g. dual GPU).
