### PR TITLE
GS-hw: Implement hw, hw/sw, sw blending on Ad when alpha write is masked, and more optimizations

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -769,17 +769,16 @@ void ps_blend(inout float4 Color, float As, float2 pos_xy)
 
 			Color.rgb = (float3)255.0f;
 		}
-		else if (PS_CLR_HW == 2 || PS_CLR_HW == 3)
+		else if (PS_CLR_HW == 2)
 		{
-			// PS_CLR_HW 2 Af, PS_CLR_HW 3 As
 			// Cd*As or Cd*F
 
-			float Alpha = PS_CLR_HW == 2 ? Af : As;
+			float Alpha = PS_BLEND_C == 2 ? Af : As;
 
 			Color.rgb = max((float3)0.0f, (Alpha - (float3)1.0f));
 			Color.rgb *= (float3)255.0f;
 		}
-		else if (PS_CLR_HW == 4)
+		else if (PS_CLR_HW == 3)
 		{
 			// Needed for Cs*Ad, Cs*Ad + Cd, Cd - Cs*Ad
 			// Multiply Color.rgb by (255/128) to compensate for wrong Ad/255 value

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -763,15 +763,15 @@ void ps_blend(inout float4 Color, float As, float2 pos_xy)
 	}
 	else
 	{
-		if (PS_CLR_HW == 1)
+		if (PS_CLR_HW == 1 || PS_CLR_HW == 5)
 		{
 			// Needed for Cd * (As/Ad/F + 1) blending modes
 
 			Color.rgb = (float3)255.0f;
 		}
-		else if (PS_CLR_HW == 2)
+		else if (PS_CLR_HW == 2 || PS_CLR_HW == 4)
 		{
-			// Cd*As or Cd*F
+			// Cd*As,Cd*Ad or Cd*F
 
 			float Alpha = PS_BLEND_C == 2 ? Af : As;
 
@@ -829,7 +829,16 @@ PS_OUTPUT ps_main(PS_INPUT input)
 	}
 
 	// Must be done before alpha correction
-	float alpha_blend = C.a / 128.0f;
+	float alpha_blend;
+	if (PS_BLEND_C == 1 && PS_CLR_HW > 3)
+	{
+		float4 RT = trunc(RtTexture.Load(int3(input.p.xy, 0)) * 255.0f + 0.1f);
+		alpha_blend = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+	}
+	else
+	{
+		alpha_blend = C.a / 128.0f;
+	}
 
 	// Alpha correction
 	if (PS_DFMT == FMT_16)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -729,11 +729,10 @@ void ps_blend(inout vec4 Color, float As)
     // Needed for Cd * (As/Ad/F + 1) blending modes
 #if PS_CLR_HW == 1
     Color.rgb = vec3(255.0f);
-#elif PS_CLR_HW == 2 || PS_CLR_HW == 3
-    // PS_CLR_HW 2 Af, PS_CLR_HW 3 As
+#elif PS_CLR_HW == 2
     // Cd*As or Cd*F
 
-#if PS_CLR_HW == 2
+#if PS_BLEND_C == 2
     float Alpha = Af;
 #else
     float Alpha = As;
@@ -741,7 +740,7 @@ void ps_blend(inout vec4 Color, float As)
 
     Color.rgb = max(vec3(0.0f), (Alpha - vec3(1.0f)));
     Color.rgb *= vec3(255.0f);
-#elif PS_CLR_HW == 4
+#elif PS_CLR_HW == 3
     // Needed for Cs*Ad, Cs*Ad + Cd, Cd - Cs*Ad
     // Multiply Color.rgb by (255/128) to compensate for wrong Ad/255 value
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -727,10 +727,10 @@ void ps_blend(inout vec4 Color, float As)
 
 #else
     // Needed for Cd * (As/Ad/F + 1) blending modes
-#if PS_CLR_HW == 1
+#if PS_CLR_HW == 1 || PS_CLR_HW == 5
     Color.rgb = vec3(255.0f);
-#elif PS_CLR_HW == 2
-    // Cd*As or Cd*F
+#elif PS_CLR_HW == 2 || PS_CLR_HW == 4
+    // Cd*As,Cd*Ad or Cd*F
 
 #if PS_BLEND_C == 2
     float Alpha = Af;
@@ -853,7 +853,12 @@ void ps_main()
 #endif
 
     // Must be done before alpha correction
+#if (PS_BLEND_C == 1 && PS_CLR_HW > 3)
+    vec4 RT = trunc(texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0) * 255.0f + 0.1f);
+    float alpha_blend = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+#else
     float alpha_blend = C.a / 128.0f;
+#endif
 
     // Correct the ALPHA value based on the output format
 #if (PS_DFMT == FMT_16)

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1064,11 +1064,11 @@ void ps_blend(inout vec4 Color, float As)
 		#endif
 
 	#else
-		#if PS_CLR_HW == 1
+		#if PS_CLR_HW == 1 || PS_CLR_HW == 5
 			// Needed for Cd * (As/Ad/F + 1) blending modes
 			Color.rgb = vec3(255.0f);
-		#elif PS_CLR_HW == 2
-			// Cd*As or Cd*F
+		#elif PS_CLR_HW == 2 || PS_CLR_HW == 4
+			// Cd*As,Cd*Ad or Cd*F
 
 			#if PS_BLEND_C == 2
 				float Alpha = Af;
@@ -1163,7 +1163,12 @@ void main()
 	#endif
 
   // Must be done before alpha correction
+#if (PS_BLEND_C == 1 && PS_CLR_HW > 3)
+  vec4 RT = trunc(subpassLoad(RtSampler) * 255.0f + 0.1f);
+  float alpha_blend = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+#else
   float alpha_blend = C.a / 128.0f;
+#endif
 
   // Correct the ALPHA value based on the output format
 #if (PS_DFMT == FMT_16)

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1067,11 +1067,10 @@ void ps_blend(inout vec4 Color, float As)
 		#if PS_CLR_HW == 1
 			// Needed for Cd * (As/Ad/F + 1) blending modes
 			Color.rgb = vec3(255.0f);
-		#elif PS_CLR_HW == 2 || PS_CLR_HW == 3
-			// PS_CLR_HW 2 Af, PS_CLR_HW 3 As
+		#elif PS_CLR_HW == 2
 			// Cd*As or Cd*F
 
-			#if PS_CLR_HW == 2
+			#if PS_BLEND_C == 2
 				float Alpha = Af;
 			#else
 				float Alpha = As;
@@ -1079,7 +1078,7 @@ void ps_blend(inout vec4 Color, float As)
 
 			Color.rgb = max(vec3(0.0f), (Alpha - vec3(1.0f)));
 			Color.rgb *= vec3(255.0f);
-		#elif PS_CLR_HW == 4
+		#elif PS_CLR_HW == 3
 			// Needed for Cs*Ad, Cs*Ad + Cd, Cd - Cs*Ad
 			// Multiply Color.rgb by (255/128) to compensate for wrong Ad/255 value
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -534,8 +534,8 @@ std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
 	{ BLEND_ACCU                 , OP_ADD          , SRC1_ALPHA      , CONST_ONE}       , //?0201: (Cs -  0)*As + Cd ==> Cs*As + Cd
 	{ BLEND_NO_REC               , OP_ADD          , SRC1_ALPHA      , CONST_ZERO}      , // 0202: (Cs -  0)*As +  0 ==> Cs*As
 	{ BLEND_A_MAX                , OP_ADD          , CONST_ONE       , CONST_ZERO}      , //*0210: (Cs -  0)*Ad + Cs ==> Cs*(Ad + 1)
-	{ BLEND_C_CLR4               , OP_ADD          , DST_ALPHA       , CONST_ONE}       , // 0211: (Cs -  0)*Ad + Cd ==> Cs*Ad + Cd
-	{ BLEND_C_CLR4               , OP_ADD          , DST_ALPHA       , CONST_ZERO}      , // 0212: (Cs -  0)*Ad +  0 ==> Cs*Ad
+	{ BLEND_C_CLR3               , OP_ADD          , DST_ALPHA       , CONST_ONE}       , // 0211: (Cs -  0)*Ad + Cd ==> Cs*Ad + Cd
+	{ BLEND_C_CLR3               , OP_ADD          , DST_ALPHA       , CONST_ZERO}      , // 0212: (Cs -  0)*Ad +  0 ==> Cs*Ad
 	{ BLEND_NO_REC | BLEND_A_MAX , OP_ADD          , CONST_ONE       , CONST_ZERO}      , //*0220: (Cs -  0)*F  + Cs ==> Cs*(F + 1)
 	{ BLEND_ACCU                 , OP_ADD          , CONST_COLOR     , CONST_ONE}       , //?0221: (Cs -  0)*F  + Cd ==> Cs*F + Cd
 	{ BLEND_NO_REC               , OP_ADD          , CONST_COLOR     , CONST_ZERO}      , // 0222: (Cs -  0)*F  +  0 ==> Cs*F
@@ -559,7 +559,7 @@ std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
 	{ BLEND_NO_REC               , OP_ADD          , CONST_ZERO      , CONST_ZERO}      , // 1122: (Cd - Cd)*F  +  0 ==> 0
 	{ 0                          , OP_ADD          , CONST_ONE       , SRC1_ALPHA}      , // 1200: (Cd -  0)*As + Cs ==> Cs + Cd*As
 	{ BLEND_C_CLR1               , OP_ADD          , DST_COLOR       , SRC1_ALPHA}      , //#1201: (Cd -  0)*As + Cd ==> Cd*(1 + As)
-	{ BLEND_C_CLR3_AS            , OP_ADD          , DST_COLOR       , SRC1_ALPHA}      , // 1202: (Cd -  0)*As +  0 ==> Cd*As
+	{ BLEND_C_CLR2_AS            , OP_ADD          , DST_COLOR       , SRC1_ALPHA}      , // 1202: (Cd -  0)*As +  0 ==> Cd*As
 	{ 0                          , OP_ADD          , CONST_ONE       , DST_ALPHA}       , // 1210: (Cd -  0)*Ad + Cs ==> Cs + Cd*Ad
 	{ BLEND_C_CLR1               , OP_ADD          , DST_COLOR       , DST_ALPHA}       , //#1211: (Cd -  0)*Ad + Cd ==> Cd*(1 + Ad)
 	{ 0                          , OP_ADD          , CONST_ZERO      , DST_ALPHA}       , // 1212: (Cd -  0)*Ad +  0 ==> Cd*Ad
@@ -570,7 +570,7 @@ std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
 	{ BLEND_ACCU                 , OP_REV_SUBTRACT , SRC1_ALPHA      , CONST_ONE}       , //?2001: (0  - Cs)*As + Cd ==> Cd - Cs*As
 	{ BLEND_NO_REC               , OP_REV_SUBTRACT , SRC1_ALPHA      , CONST_ZERO}      , // 2002: (0  - Cs)*As +  0 ==> 0 - Cs*As
 	{ 0                          , OP_ADD          , INV_DST_ALPHA	 , CONST_ZERO}      , // 2010: (0  - Cs)*Ad + Cs ==> Cs*(1 - Ad)
-	{ BLEND_C_CLR4               , OP_REV_SUBTRACT , DST_ALPHA       , CONST_ONE}       , // 2011: (0  - Cs)*Ad + Cd ==> Cd - Cs*Ad
+	{ BLEND_C_CLR3               , OP_REV_SUBTRACT , DST_ALPHA       , CONST_ONE}       , // 2011: (0  - Cs)*Ad + Cd ==> Cd - Cs*Ad
 	{ 0                          , OP_REV_SUBTRACT , DST_ALPHA       , CONST_ZERO}      , // 2012: (0  - Cs)*Ad +  0 ==> 0 - Cs*Ad
 	{ BLEND_NO_REC               , OP_ADD          , INV_CONST_COLOR , CONST_ZERO}      , // 2020: (0  - Cs)*F  + Cs ==> Cs*(1 - F)
 	{ BLEND_ACCU                 , OP_REV_SUBTRACT , CONST_COLOR     , CONST_ONE}       , //?2021: (0  - Cs)*F  + Cd ==> Cd - Cs*F

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -122,8 +122,8 @@ enum HWBlendFlags
 	BLEND_A_MAX     = 0x80,   // Impossible blending uses coeff bigger than 1
 	BLEND_C_CLR1    = 0x100,  // Clear color blending (use directly the destination color as blending factor)
 	BLEND_C_CLR2_AF = 0x200,  // Clear color blending (use directly the destination color as blending factor)
-	BLEND_C_CLR3_AS = 0x400,  // Clear color blending (use directly the destination color as blending factor)
-	BLEND_C_CLR4    = 0x800,  // Multiply Cs by (255/128) to compensate for wrong Ad/255 value, should be Ad/128
+	BLEND_C_CLR2_AS = 0x400,  // Clear color blending (use directly the destination color as blending factor)
+	BLEND_C_CLR3    = 0x800,  // Multiply Cs by (255/128) to compensate for wrong Ad/255 value, should be Ad/128
 	BLEND_NO_REC    = 0x1000, // Doesn't require sampling of the RT as a texture
 	BLEND_ACCU      = 0x2000, // Allow to use a mix of SW and HW blending to keep the best of the 2 worlds
 };

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -573,7 +573,6 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		&& (ALPHA.C != 1)                                                // Make sure it isn't an Ad case
 		&& (m_env.COLCLAMP.CLAMP)                                        // Let's add a colclamp check too, hw blend will clamp to 0-1.
 		&& !(m_conf.require_one_barrier || m_conf.require_full_barrier); // Also don't run if there are barriers present.
-	const bool clr_blend3 = !!(blend_flag & BLEND_C_CLR3);
 
 	// Warning no break on purpose
 	// Note: the [[fallthrough]] attribute tell compilers not to complain about not having breaks.
@@ -640,8 +639,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 				// If prims don't overlap prefer full sw blend on blend_ad_alpha_masked cases.
-				// Exclude clr_blend3 as it can do hw blending partially.
-				if (blend_ad_alpha_masked && !clr_blend3 && m_prim_overlap == PRIM_OVERLAP_NO)
+				if (blend_ad_alpha_masked && m_prim_overlap == PRIM_OVERLAP_NO)
 				{
 					accumulation_blend = false;
 					sw_blending |= true;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -603,7 +603,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		// Blend can be done on hw. As and F cases should be accurate.
 		// BLEND_C_CLR1 with Ad, BLEND_C_CLR4  Cs > 0.5f will require sw blend.
 		// BLEND_C_CLR1 with As/F, BLEND_C_CLR2_AF, BLEND_C_CLR3_AS can be done in hw.
-		const bool clr_blend = !!(blend_flag & (BLEND_C_CLR1 | BLEND_C_CLR2_AF | BLEND_C_CLR3_AS | BLEND_C_CLR4));
+		const bool clr_blend = !!(blend_flag & (BLEND_C_CLR1 | BLEND_C_CLR2_AF | BLEND_C_CLR2_AS | BLEND_C_CLR3));
 		// FBMASK already reads the fb so it is safe to enable sw blend when there is no overlap.
 		const bool fbmask_no_overlap = m_conf.require_one_barrier && (m_prim_overlap == PRIM_OVERLAP_NO);
 
@@ -793,18 +793,19 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		{
 			m_conf.ps.clr_hw = 1;
 		}
-		else if (blend_flag & BLEND_C_CLR2_AF)
+		else if (blend_flag & (BLEND_C_CLR2_AF | BLEND_C_CLR2_AS))
 		{
-			m_conf.cb_ps.TA_MaxDepth_Af.a = static_cast<float>(ALPHA.FIX) / 128.0f;
+			if (ALPHA.C == 2)
+			{
+				m_conf.ps.blend_c = 2;
+				m_conf.cb_ps.TA_MaxDepth_Af.a = static_cast<float>(ALPHA.FIX) / 128.0f;
+			}
+
 			m_conf.ps.clr_hw = 2;
 		}
-		else if (blend_flag & BLEND_C_CLR3_AS)
+		else if (blend_flag & BLEND_C_CLR3)
 		{
 			m_conf.ps.clr_hw = 3;
-		}
-		else if (blend_flag & BLEND_C_CLR4)
-		{
-			m_conf.ps.clr_hw = 4;
 		}
 
 		if (m_conf.ps.dfmt == 1 && ALPHA.C == 1)

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -533,7 +533,18 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 
 	// Compute the blending equation to detect special case
 	const GIFRegALPHA& ALPHA = m_context->ALPHA;
-	u8 blend_index = u8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA.C) * 3 + ALPHA.D);
+	// Ad cases, alpha write is masked, one barrier is enough, for d3d11 read the fb
+	// Replace Ad with As, blend flags will be used from As since we are chaging the blend_index value.
+	bool blend_ad_alpha_masked = (ALPHA.C == 1) && (m_context->FRAME.FBMSK & 0xFF000000) == 0xFF000000;
+	u8 ALPHA_C = ALPHA.C;
+	if (!g_gs_device->Features().texture_barrier && (GSConfig.AccurateBlendingUnit >= AccBlendLevel::Medium) && blend_ad_alpha_masked)
+		ALPHA_C = 0;
+	else if (g_gs_device->Features().texture_barrier && blend_ad_alpha_masked)
+		ALPHA_C = 0;
+	else
+		blend_ad_alpha_masked = false;
+
+	u8 blend_index = u8(((ALPHA.A * 3 + ALPHA.B) * 3 + ALPHA_C) * 3 + ALPHA.D);
 	const int blend_flag = g_gs_device->GetBlendFlags(blend_index);
 
 	// HW blend can handle Cd output.
@@ -588,7 +599,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				// fixes shadows in Superman shadows of Apokolips.
 				// DATE_BARRIER already does full barrier so also makes more sense to do full sw blend.
 				color_dest_blend   &= !m_conf.require_full_barrier;
-				accumulation_blend &= !m_conf.require_full_barrier;
+				// If prims don't overlap prefer full sw blend on blend_ad_alpha_masked cases.
+				accumulation_blend &= !(m_conf.require_full_barrier || (blend_ad_alpha_masked && m_prim_overlap == PRIM_OVERLAP_NO));
 				sw_blending |= impossible_or_free_blend;
 				// Do not run BLEND MIX if sw blending is already present, it's less accurate
 				blend_mix &= !sw_blending;
@@ -619,8 +631,16 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				sw_blending |= (!(clr_blend || blend_mix) && (m_prim_overlap == PRIM_OVERLAP_NO));
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
+				// If prims don't overlap prefer full sw blend on blend_ad_alpha_masked cases.
+				if (blend_ad_alpha_masked && m_prim_overlap == PRIM_OVERLAP_NO)
+				{
+					accumulation_blend = false;
+					sw_blending |= true;
+				}
+				[[fallthrough]];
 			case AccBlendLevel::Basic:
 				// Disable accumulation blend when there is fbmask with no overlap, will be faster.
+				color_dest_blend   &= !fbmask_no_overlap;
 				accumulation_blend &= !fbmask_no_overlap;
 				sw_blending |= accumulation_blend || blend_non_recursive || fbmask_no_overlap;
 				// Do not run BLEND MIX if sw blending is already present, it's less accurate
@@ -746,7 +766,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 			// Remove the addition/substraction from the SW blending
 			m_conf.ps.blend_d = 2;
 
-			// Note accumulation_blend doesn't require a barrier
+			// Only Ad case will require one barrier
+			m_conf.require_one_barrier |= blend_ad_alpha_masked;
 		}
 		else if (blend_mix)
 		{
@@ -771,13 +792,24 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				m_conf.ps.blend_b = 0;
 				m_conf.ps.blend_d = 0;
 			}
+
+			// Only Ad case will require one barrier
+			if (blend_ad_alpha_masked)
+			{
+				m_conf.require_one_barrier |= true;
+				// Swap Ad with As for hw blend
+				m_conf.ps.clr_hw = 6;
+			}
 		}
 		else
 		{
 			// Disable HW blending
 			m_conf.blend = {};
 
-			if (g_gs_device->Features().texture_barrier)
+			const bool blend_non_recursive_one_barrier = blend_non_recursive && blend_ad_alpha_masked;
+			if (blend_non_recursive_one_barrier)
+				m_conf.require_one_barrier |= true;
+			else if (g_gs_device->Features().texture_barrier)
 				m_conf.require_full_barrier |= !blend_non_recursive;
 			else
 				m_conf.require_one_barrier |= !blend_non_recursive;
@@ -789,23 +821,50 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	}
 	else
 	{
+		// Care for clr_hw value, 6 is for hw/sw, sw blending used.
+
 		if (blend_flag & BLEND_C_CLR1)
 		{
-			m_conf.ps.clr_hw = 1;
+			if (blend_ad_alpha_masked)
+			{
+				m_conf.ps.blend_c = 1;
+				m_conf.ps.clr_hw = 5;
+				m_conf.require_one_barrier |= true;
+			}
+			else
+			{
+				m_conf.ps.clr_hw = 1;
+			}
 		}
 		else if (blend_flag & (BLEND_C_CLR2_AF | BLEND_C_CLR2_AS))
 		{
-			if (ALPHA.C == 2)
+			if (blend_ad_alpha_masked)
+			{
+				m_conf.ps.blend_c = 1;
+				m_conf.ps.clr_hw = 4;
+				m_conf.require_one_barrier |= true;
+			}
+			else if (ALPHA.C == 2)
 			{
 				m_conf.ps.blend_c = 2;
 				m_conf.cb_ps.TA_MaxDepth_Af.a = static_cast<float>(ALPHA.FIX) / 128.0f;
+				m_conf.ps.clr_hw = 2;
 			}
-
-			m_conf.ps.clr_hw = 2;
+			else // ALPHA.C == 0
+			{
+				m_conf.ps.blend_c = 0;
+				m_conf.ps.clr_hw = 2;
+			}
 		}
 		else if (blend_flag & BLEND_C_CLR3)
 		{
 			m_conf.ps.clr_hw = 3;
+		}
+		else if (blend_ad_alpha_masked)
+		{
+			m_conf.ps.blend_c = 1;
+			m_conf.ps.clr_hw = 6;
+			m_conf.require_one_barrier |= true;
 		}
 
 		if (m_conf.ps.dfmt == 1 && ALPHA.C == 1)

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -613,9 +613,10 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	else
 	{
 		// Blend can be done on hw. As and F cases should be accurate.
-		// BLEND_C_CLR1 with Ad, BLEND_C_CLR4  Cs > 0.5f will require sw blend.
-		// BLEND_C_CLR1 with As/F, BLEND_C_CLR2_AF, BLEND_C_CLR3_AS can be done in hw.
+		// BLEND_C_CLR1 with Ad, BLEND_C_CLR3  Cs > 0.5f will require sw blend.
+		// BLEND_C_CLR1 with As/F, BLEND_C_CLR2_AF, BLEND_C_CLR2_AS can be done in hw.
 		const bool clr_blend = !!(blend_flag & (BLEND_C_CLR1 | BLEND_C_CLR2_AF | BLEND_C_CLR2_AS | BLEND_C_CLR3));
+		const bool clr_blend3 = !!(blend_flag & BLEND_C_CLR3);
 		// FBMASK already reads the fb so it is safe to enable sw blend when there is no overlap.
 		const bool fbmask_no_overlap = m_conf.require_one_barrier && (m_prim_overlap == PRIM_OVERLAP_NO);
 
@@ -632,7 +633,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 				// If prims don't overlap prefer full sw blend on blend_ad_alpha_masked cases.
-				if (blend_ad_alpha_masked && m_prim_overlap == PRIM_OVERLAP_NO)
+				// Exclude clr_blend3 as it can do hw blending partially.
+				if (blend_ad_alpha_masked && !clr_blend3 && m_prim_overlap == PRIM_OVERLAP_NO)
 				{
 					accumulation_blend = false;
 					sw_blending |= true;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Implement hw, hw/sw, sw blending on Ad when alpha write is masked.
Idea is to replace Ad with As when alpha write is masked,
then expand/let blend mix, accumulation blend non recursive blend or hw clr blend to
do the blending with Ad swapped as As.

We are doing this to try to bring some originally higher blending modes to lower levels
where we can do the draws with less texture barriers instead (gl/vk),
as for d3d11 this allows to run blending on the draws since previously the cases weren't handled properly,
it will be slower on d3d11 since we will be reading the frame buffer but it's better than nothing.

D3D11: It is enabled on Medium blending or higher, if draw is fbmask then it will enable
it on basic blending too.

OpenGL/Vulkan:
It is enabled based on the previous blending modes:
accumulation blend -> either minimum or basic level, depending on colclamp.
non recursive blend -> either minimum or basic level, depending on colclamp.
blend mix -> basic and higher level.
hw clr blend -> minimum and higher level.

All:
Prefer full sw blend when primitives don't overlap, sw fbmask or full barrier is used, it is more accurate.

GS-hw: Combine BLEND_C_CLR2_AF and BLEND_C_CLR3_AS in one shader bit. 

Free a shader bit.

S-hw: Move the sw blend for BLEND_C_CLR3 to High level and upper. 
Reading the frame buffer is slow, let's allow hw blend to run, can partially handle it.


GS-hw: Allow to run clr_blend1 and clr_blend2 over sw blending.
As or F case only, no Ad.
Allow condition to run when there are no texture barriers (gl/vk),
or copying the fb (d3d11).
Run when colclamp is 1 as hw blend will clamp value to 0-1.
Check for texture barriers, don't run if any is enabled.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, optimizations.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test various blending levels on all hw renderers.