### PR TITLE
cmake: copy resources in build folder.

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1633,6 +1633,10 @@ function(pcsx2_resource path basedir)
 		set_source_files_properties(${path} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/${subdir})
 	elseif(PACKAGE_MODE)
 		install(FILES ${path} DESTINATION ${CMAKE_INSTALL_DATADIR}/PCSX2/resources/${subdir})
+	else()
+		add_custom_command(TARGET PCSX2 POST_BUILD
+			COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:PCSX2>/resources/${subdir}"
+			COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${path}" "$<TARGET_FILE_DIR:PCSX2>/resources/${subdir}")
 	endif()
 	source_group(Resources/${subdir} FILES ${path})
 endfunction()


### PR DESCRIPTION
### Description of Changes
copy resources from bin to pcsx2 target build folder when building with cmake.

### Rationale behind Changes
make it easier to run the pcsx2 target via vscode cmake integration on windows.

### Suggested Testing Steps
check that building and running an all platforms is not broken.
on windows, check that you can run the pcsx2 target via vscode cmake integration and it finds the resources folder.
