### PR TITLE
Make Xcode Happy

### DIFF
--- a/common/StringUtil.h
+++ b/common/StringUtil.h
@@ -192,20 +192,20 @@ namespace StringUtil
 	std::vector<std::string> splitOnNewLine(const std::string& str);
 
 	/// Converts a wxString to a UTF-8 std::string.
-	static std::string wxStringToUTF8String(const wxString& str)
+	static inline std::string wxStringToUTF8String(const wxString& str)
 	{
 		const wxScopedCharBuffer buf(str.ToUTF8());
 		return std::string(buf.data(), buf.length());
 	}
 
 	/// Converts a UTF-8 std::string to a wxString.
-	static wxString UTF8StringToWxString(const std::string_view& str)
+	static inline wxString UTF8StringToWxString(const std::string_view& str)
 	{
 		return wxString::FromUTF8(str.data(), str.length());
 	}
 
 	/// Converts a UTF-8 std::string to a wxString.
-	static wxString UTF8StringToWxString(const std::string& str)
+	static inline wxString UTF8StringToWxString(const std::string& str)
 	{
 		return wxString::FromUTF8(str.data(), str.length());
 	}

--- a/pcsx2/GS/GSIntrin.h
+++ b/pcsx2/GS/GSIntrin.h
@@ -28,7 +28,7 @@
 #if !defined(_MSC_VER)
 // http://svn.reactos.org/svn/reactos/trunk/reactos/include/crt/mingw32/intrin_x86.h?view=markup
 
-static int _BitScanForward(unsigned long* const Index, const unsigned long Mask)
+static inline int _BitScanForward(unsigned long* const Index, const unsigned long Mask)
 {
 	if (Mask == 0)
 		return 0;
@@ -40,7 +40,7 @@ static int _BitScanForward(unsigned long* const Index, const unsigned long Mask)
 	return 1;
 }
 
-static int _BitScanReverse(unsigned long* const Index, const unsigned long Mask)
+static inline int _BitScanReverse(unsigned long* const Index, const unsigned long Mask)
 {
 	if (Mask == 0)
 		return 0;

--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -22,7 +22,7 @@
 #include "System.h"
 #include "Config.h"
 
-#include <common/FileSystem.h>
+#include "common/FileSystem.h"
 #include "common/StringUtil.h"
 
 #include "fmt/core.h"

--- a/pcsx2/PAD/Host/Global.h
+++ b/pcsx2/PAD/Host/Global.h
@@ -58,7 +58,7 @@ enum gamePadValues
 	PAD_R_LEFT    // Right joystick (Left) ←
 };
 
-static bool IsAnalogKey(int index)
+static inline bool IsAnalogKey(int index)
 {
 	return ((index >= PAD_L_UP) && (index <= PAD_R_LEFT));
 }

--- a/pcsx2/PAD/Linux/Global.h
+++ b/pcsx2/PAD/Linux/Global.h
@@ -107,7 +107,7 @@ enum PadOptions
 	PADOPTION_MOUSE_R = 0x40,
 };
 
-static bool IsAnalogKey(int index)
+static inline bool IsAnalogKey(int index)
 {
 	return ((index >= PAD_L_UP) && (index <= PAD_R_LEFT));
 }

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -29,7 +29,7 @@
 #include <wx/txtstrm.h>
 #include <wx/zipstrm.h>
 #include <wx/wfstream.h>
-#include <PathDefs.h>
+#include "PathDefs.h"
 
 // This is a declaration for PatchMemory.cpp::_ApplyPatch where we're (patch.cpp)
 // the only consumer, so it's not made public via Patch.h

--- a/pcsx2/x86/BaseblockEx.h
+++ b/pcsx2/x86/BaseblockEx.h
@@ -243,8 +243,8 @@ public:
  * Will associate `reclut[pagebase + pageidx]` with `mapbase[mappage << 14]`
  * Will associate `hwlut[pagebase + pageidx]` with `pageidx << 16`
  */
-static void recLUT_SetPage(uptr reclut[0x10000], u32 hwlut[0x10000],
-                           BASEBLOCK* mapbase, uint pagebase, uint pageidx, uint mappage)
+static inline void recLUT_SetPage(uptr reclut[0x10000], u32 hwlut[0x10000],
+                                  BASEBLOCK* mapbase, uint pagebase, uint pageidx, uint mappage)
 {
 	// this value is in 64k pages!
 	uint page = pagebase + pageidx;

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -19,12 +19,12 @@
 // Messages Called at Execution Time...
 //------------------------------------------------------------------
 
-static void __fc mVUbadOp0  (u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
-static void __fc mVUbadOp1  (u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
-static void __fc mVUwarning0(u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
-static void __fc mVUwarning1(u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
-static void __fc mVUprintPC1(u32 pc) { Console.WriteLn("Block Start PC = 0x%04x", pc); }
-static void __fc mVUprintPC2(u32 pc) { Console.WriteLn("Block End PC   = 0x%04x", pc); }
+static inline void __fc mVUbadOp0  (u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
+static inline void __fc mVUbadOp1  (u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
+static inline void __fc mVUwarning0(u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
+static inline void __fc mVUwarning1(u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
+static inline void __fc mVUprintPC1(u32 pc) { Console.WriteLn("Block Start PC = 0x%04x", pc); }
+static inline void __fc mVUprintPC2(u32 pc) { Console.WriteLn("Block End PC   = 0x%04x", pc); }
 
 //------------------------------------------------------------------
 // Program Range Checking and Setting up Ranges


### PR DESCRIPTION
### Description of Changes
Changes a couple of includes from angle brackets (`<header.h>`) to quotes (`"header.h"`) to make Xcode happy. This also marks some `inline` functions in headers as `static inline` to quiet warnings about unused functions in every source file that includes the header and doesn't use the function.

### Rationale behind Changes
These changes were made because I want to make a plug-in for OpenEmu and want Xcode to be happy.

### Suggested Testing Steps
None come to mind…