### PR TITLE
Qt: Fix type table sizing + spaces

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -320,7 +320,7 @@ void GameListWidget::resizeEvent(QResizeEvent* event)
 void GameListWidget::resizeTableViewColumnsToFit()
 {
 	QtUtils::ResizeColumnsForTableView(m_table_view, {
-														 32, // type
+														 45, // type
 														 80, // code
 														 -1, // title
 														 -1, // file title

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -46,7 +46,7 @@
      </property>
      <property name="icon">
       <iconset theme="dvd-line"/>
-     </property>         
+     </property>
      <actiongroup name="actionGroupChangeDiscSubImages"/>
      <addaction name="actionChangeDiscFromFile"/>
      <addaction name="actionChangeDiscFromDevice"/>
@@ -60,7 +60,7 @@
      </property>
      <property name="icon">
       <iconset theme="flask-line"/>
-     </property>         
+     </property>
     </widget>
     <widget class="QMenu" name="menuLoadState">
      <property name="title">
@@ -68,7 +68,7 @@
      </property>
      <property name="icon">
       <iconset theme="folder-open-line"/>
-     </property>       
+     </property>
     </widget>
     <widget class="QMenu" name="menuSaveState">
      <property name="title">
@@ -76,7 +76,7 @@
      </property>
      <property name="icon">
       <iconset theme="save-3-line"/>
-     </property>             
+     </property>
     </widget>
     <addaction name="actionStartFile"/>
     <addaction name="actionStartDisc"/>
@@ -152,10 +152,10 @@
      </property>
      <property name="icon">
       <iconset theme="window-2-line"/>
-     </property>       
+     </property>
     </widget>
     <addaction name="actionViewToolbar"/>
-    <addaction name="actionViewLockToolbar"/>     
+    <addaction name="actionViewLockToolbar"/>
     <addaction name="actionViewStatusBar"/>
     <addaction name="separator"/>
     <addaction name="actionViewGameList"/>
@@ -224,7 +224,7 @@
    <addaction name="separator"/>
    <addaction name="actionSettings"/>
    <addaction name="actionControllerSettings"/>
-  </widget>   
+  </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionStartFile">
    <property name="text">
@@ -232,7 +232,7 @@
    </property>
    <property name="icon">
     <iconset theme="file-line"/>
-   </property>      
+   </property>
   </action>
   <action name="actionStartDisc">
    <property name="text">
@@ -240,7 +240,7 @@
    </property>
    <property name="icon">
     <iconset theme="disc-line"/>
-   </property>            
+   </property>
   </action>
   <action name="actionStartBios">
    <property name="text">
@@ -248,7 +248,7 @@
    </property>
    <property name="icon">
     <iconset theme="hard-drive-2-line"/>
-   </property>        
+   </property>
   </action>
   <action name="actionScanForNewGames">
    <property name="text">
@@ -256,7 +256,7 @@
    </property>
    <property name="icon">
     <iconset theme="file-search-line"/>
-   </property>    
+   </property>
   </action>
   <action name="actionRescanAllGames">
    <property name="text">
@@ -272,7 +272,7 @@
    </property>
    <property name="icon">
     <iconset theme="shut-down-line"/>
-   </property>     
+   </property>
   </action>
   <action name="actionReset">
    <property name="text">
@@ -280,7 +280,7 @@
    </property>
    <property name="icon">
     <iconset theme="restart-line"/>
-   </property>    
+   </property>
   </action>
   <action name="actionPause">
    <property name="checkable">
@@ -291,7 +291,7 @@
    </property>
    <property name="icon">
     <iconset theme="pause-line"/>
-   </property>  
+   </property>
   </action>
   <action name="actionLoadState">
    <property name="text">
@@ -299,7 +299,7 @@
    </property>
    <property name="icon">
     <iconset theme="folder-open-line"/>
-   </property>      
+   </property>
   </action>
   <action name="actionSaveState">
    <property name="text">
@@ -307,7 +307,7 @@
    </property>
    <property name="icon">
     <iconset theme="save-3-line"/>
-   </property>  
+   </property>
   </action>
   <action name="actionExit">
    <property name="text">
@@ -315,7 +315,7 @@
    </property>
    <property name="icon">
     <iconset theme="door-open-line"/>
-   </property>     
+   </property>
   </action>
   <action name="actionBIOSSettings">
    <property name="text">
@@ -347,7 +347,7 @@
    </property>
    <property name="icon">
     <iconset theme="gamepad-line"/>
-   </property>    
+   </property>
   </action>
   <action name="actionHotkeySettings">
    <property name="text">
@@ -376,7 +376,7 @@
    </property>
    <property name="icon">
     <iconset theme="fullscreen-line"/>
-   </property>    
+   </property>
   </action>
   <action name="actionResolution_Scale">
    <property name="text">
@@ -401,7 +401,7 @@
   <action name="actionCheckForUpdates">
    <property name="icon">
     <iconset theme="download-2-line"/>
-   </property>    
+   </property>
    <property name="text">
     <string>Check for &amp;Updates...</string>
    </property>
@@ -426,7 +426,7 @@
    </property>
    <property name="icon">
     <iconset theme="dvd-line"/>
-   </property>             
+   </property>
   </action>
   <action name="actionCheats">
    <property name="text">
@@ -434,7 +434,7 @@
    </property>
    <property name="icon">
     <iconset theme="flask-line"/>
-   </property>   
+   </property>
   </action>
   <action name="actionAudioSettings">
    <property name="text">
@@ -507,7 +507,7 @@
    </property>
    <property name="icon">
     <iconset theme="screenshot-2-line"/>
-   </property>    
+   </property>
   </action>
   <action name="actionMemoryCardSettings">
    <property name="text">
@@ -538,7 +538,7 @@
    <property name="text">
     <string>Lock Toolbar</string>
    </property>
-  </action>   
+  </action>
   <action name="actionViewStatusBar">
    <property name="checkable">
     <bool>true</bool>
@@ -567,7 +567,7 @@
    </property>
    <property name="icon">
     <iconset theme="tv-2-line"/>
-   </property>     
+   </property>
   </action>
   <action name="actionViewGameProperties">
    <property name="enabled">
@@ -578,7 +578,7 @@
    </property>
    <property name="icon">
     <iconset theme="file-settings-line"/>
-   </property>      
+   </property>
   </action>
   <action name="actionViewGameGrid">
    <property name="text">

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -37,7 +37,7 @@
         <item>
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>The SDL input source supports most controllers, and provides advanced functionality for Dualshock 4/Dualsense pads in Bluetooth mode (Vibration/LED Control).</string>
+           <string>The SDL input source supports most controllers, and provides advanced functionality for DualShock 4 / DualSense pads in Bluetooth mode (Vibration / LED Control).</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -54,7 +54,7 @@
         <item>
          <widget class="QCheckBox" name="enableSDLEnhancedMode">
           <property name="text">
-           <string>Dualshock 4/Dualsense Enhanced Mode</string>
+           <string>Dualshock 4 / Dualsense Enhanced Mode</string>
           </property>
          </widget>
         </item>
@@ -70,7 +70,7 @@
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>The XInput source provides support for XBox 360/XBox One/XBox Series controllers, and third party controllers which implement the XInput protocol.</string>
+           <string>The XInput source provides support for XBox 360 / XBox One / XBox Series controllers, and third party controllers which implement the XInput protocol.</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Type table in the main window was wide enough by default however the filter pushed away the string. Also adding spaces in some strings.
Master with filtering:
![image](https://user-images.githubusercontent.com/24227051/152257246-dd9d6656-80b9-4362-a816-cc2a93354f73.png)
Master without filtering:
![image](https://user-images.githubusercontent.com/24227051/152257362-5256c3bb-fc8d-47a1-92ff-9735cf672b7a.png)

PR with filtering:
![image](https://user-images.githubusercontent.com/24227051/152257478-c5992a05-8800-43b6-8cc4-31321301876f.png)



### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Just making it look nicer to users.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check main window, click on type and see if the text is fine. 