### PR TITLE
GS: Add depth copy convert shader

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -72,6 +72,11 @@ PS_OUTPUT ps_copy(PS_INPUT input)
 	return output;
 }
 
+float ps_depth_copy(PS_INPUT input) : SV_Depth
+{
+	return sample_c(input.t).r;
+}
+
 PS_OUTPUT ps_filter_transparency(PS_INPUT input)
 {
 	PS_OUTPUT output;

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -66,6 +66,13 @@ void ps_copy()
 }
 #endif
 
+#ifdef ps_depth_copy
+void ps_depth_copy()
+{
+  gl_FragDepth = sample_c().r;
+}
+#endif
+
 #ifdef ps_convert_rgba8_16bits
 void ps_convert_rgba8_16bits()
 {

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -68,6 +68,13 @@ void ps_copy()
 }
 #endif
 
+#ifdef ps_depth_copy
+void ps_depth_copy()
+{
+  gl_FragDepth = sample_c(v_tex).r;
+}
+#endif
+
 #ifdef ps_filter_transparency
 void ps_filter_transparency()
 {

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -40,6 +40,7 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::RGBA8_TO_FLOAT24:    return "ps_convert_rgba8_float24";
 		case ShaderConvert::RGBA8_TO_FLOAT16:    return "ps_convert_rgba8_float16";
 		case ShaderConvert::RGB5A1_TO_FLOAT16:   return "ps_convert_rgb5a1_float16";
+		case ShaderConvert::DEPTH_COPY:          return "ps_depth_copy";
 		case ShaderConvert::RGBA_TO_8I:          return "ps_convert_rgba_8i";
 		case ShaderConvert::YUV:                 return "ps_yuv";
 		default:

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -48,6 +48,7 @@ enum class ShaderConvert
 	RGBA8_TO_FLOAT24,
 	RGBA8_TO_FLOAT16,
 	RGB5A1_TO_FLOAT16,
+	DEPTH_COPY,
 	RGBA_TO_8I,
 	YUV,
 	Count

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -585,7 +585,8 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 {
 	ASSERT(sTex);
 
-	const bool draw_in_depth = ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT32)]
+	const bool draw_in_depth = ps == m_convert.ps[static_cast<int>(ShaderConvert::DEPTH_COPY)]
+	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT32)]
 	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT24)]
 	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT16)]
 	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGB5A1_TO_FLOAT16)];

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -538,7 +538,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 			calcRescale(dst->m_texture);
 			GSTexture* tex = type == RenderTarget ? g_gs_device->CreateSparseRenderTarget(new_size.x, new_size.y, GSTexture::Format::Color, clear) :
 				g_gs_device->CreateSparseDepthStencil(new_size.x, new_size.y, GSTexture::Format::DepthStencil, clear);
-			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, ShaderConvert::COPY, false);
+			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, (type == RenderTarget) ? ShaderConvert::COPY : ShaderConvert::DEPTH_COPY, false);
 			g_gs_device->Recycle(dst->m_texture);
 			tex->SetScale(new_s);
 			dst->m_texture = tex;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -37,9 +37,10 @@ static u32 s_debug_scope_depth = 0;
 
 static bool IsDepthConvertShader(ShaderConvert i)
 {
-	return (i == ShaderConvert::RGBA8_TO_FLOAT32 || i == ShaderConvert::RGBA8_TO_FLOAT24 ||
-			i == ShaderConvert::RGBA8_TO_FLOAT16 || i == ShaderConvert::RGB5A1_TO_FLOAT16 ||
-			i == ShaderConvert::DATM_0 || i == ShaderConvert::DATM_1);
+	return (i == ShaderConvert::DEPTH_COPY || i == ShaderConvert::RGBA8_TO_FLOAT32 ||
+			i == ShaderConvert::RGBA8_TO_FLOAT24 || i == ShaderConvert::RGBA8_TO_FLOAT16 ||
+			i == ShaderConvert::RGB5A1_TO_FLOAT16 || i == ShaderConvert::DATM_0 ||
+			i == ShaderConvert::DATM_1);
 }
 
 static bool IsIntConvertShader(ShaderConvert i)


### PR DESCRIPTION
### Description of Changes

Regression from the target rescaling stuff - it was using the copy shader on a depth target, which would have no effect, and in the case of Vulkan, trigger an assertion.

### Suggested Testing Steps

Test Midnight Club 3 with upscaling, was affected by this.
