### PR TITLE
Qt: More sizing + improve hotkeys code

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -324,9 +324,9 @@ void GameListWidget::resizeTableViewColumnsToFit()
 														 80, // code
 														 -1, // title
 														 -1, // file title
-														 50, // crc
+														 60, // crc
 														 80, // size
-														 50, // region
+														 60, // region
 														 100 // compatibility
 													 });
 }

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -186,7 +186,7 @@
   </widget>
   <widget class="QToolBar" name="toolBar">
    <property name="windowTitle">
-    <string>toolBar</string>
+    <string>Toolbar</string>
    </property>
    <property name="iconSize">
     <size>

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -54,7 +54,7 @@
         <item>
          <widget class="QCheckBox" name="enableSDLEnhancedMode">
           <property name="text">
-           <string>Dualshock 4 / Dualsense Enhanced Mode</string>
+           <string>DualShock 4 / DualSense Enhanced Mode</string>
           </property>
          </widget>
         </item>

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -184,11 +184,13 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 		si.ClearSection(StringUtil::StdStringFromFormat("Pad%u", i + 1).c_str());
 
 	si.ClearSection("Hotkeys");
-
+	
+	// PCSX2 Controller Settings - Global Settings
 	si.SetBoolValue("InputSources", "SDL", true);
 	si.SetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
 	si.SetBoolValue("InputSources", "XInput", false);
-
+	
+	// PCSX2 Controller Settings - Controller 1 / Controller 2 / ...
 	si.SetStringValue("Pad1", "Type", "DualShock2");
 	si.SetStringValue("Pad1", "Up", "Keyboard/Up");
 	si.SetStringValue("Pad1", "Right", "Keyboard/Right");
@@ -214,16 +216,37 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 	si.SetStringValue("Pad1", "R3", "Keyboard/4");
 	si.SetStringValue("Pad1", "Start", "Keyboard/Return");
 	si.SetStringValue("Pad1", "Select", "Keyboard/Backspace");
-
-	si.SetStringValue("Hotkeys", "ToggleTurbo", "Keyboard/Tab");
-	si.SetStringValue("Hotkeys", "ToggleFrameLimit", "Keyboard/F4");
-	si.SetStringValue("Hotkeys", "ToggleSoftwareRendering", "Keyboard/F9");
-	si.SetStringValue("Hotkeys", "TogglePause", "Keyboard/Space");
-	si.SetStringValue("Hotkeys", "ToggleFullscreen", "Keyboard/Alt & Keyboard/Return");
+	
+	// PCSX2 Controller Settings - Hotkeys
+	
+	// PCSX2 Controller Settings - Hotkeys - General
 	si.SetStringValue("Hotkeys", "Screenshot", "Keyboard/F8");
+	si.SetStringValue("Hotkeys", "ToggleFullscreen", "Keyboard/Alt & Keyboard/Return");
+	
+	// PCSX2 Controller Settings - Hotkeys - Graphics
+	si.SetStringValue("Hotkeys", "CycleAspectRatio", "Keyboard/F6");
+	si.SetStringValue("Hotkeys", "CycleMipmapMode", "Keyboard/Insert");
+	si.SetStringValue("Hotkeys", "CycleInterlaceMode", "Keyboard/F5");
+//	si.SetStringValue("Hotkeys", "DecreaseUpscaleMultiplier", "Keyboard"); TBD 
+//	si.SetStringValue("Hotkeys", "IncreaseUpscaleMultiplier", "Keyboard"); TBD 
+	si.SetStringValue("Hotkeys", "ToggleSoftwareRendering", "Keyboard/F9");
+	si.SetStringValue("Hotkeys", "ZoomIn", "Keyboard/Control & Keyboard/Plus");
+	si.SetStringValue("Hotkeys", "ZoomOut", "Keyboard/Control & Keyboard/Minus");
+// Missing hotkey for resetting zoom back to 100 with Keyboard/Control & Keyboard/Asterisk
+
+	// PCSX2 Controller Settings - Hotkeys - Save States
+	si.SetStringValue("Hotkeys", "LoadStateFromSlot", "Keyboard/F3");
 	si.SetStringValue("Hotkeys", "SaveStateToSlot", "Keyboard/F1");
 	si.SetStringValue("Hotkeys", "NextSaveStateSlot", "Keyboard/F2");
-	si.SetStringValue("Hotkeys", "LoadStateFromSlot", "Keyboard/F3");
+	si.SetStringValue("Hotkeys", "PreviousSaveStateSlot", "Keyboard/Shift & Keyboard/F2");
+
+	// PCSX2 Controller Settings - Hotkeys - System
+//	si.SetStringValue("Hotkeys", "DecreaseSpeed", "Keyboard"); TBD 
+//	si.SetStringValue("Hotkeys", "IncreaseSpeed", "Keyboard"); TBD 
+	si.SetStringValue("Hotkeys", "ToggleFrameLimit", "Keyboard/F4");
+	si.SetStringValue("Hotkeys", "TogglePause", "Keyboard/Space");	
+	si.SetStringValue("Hotkeys", "ToggleSlowMotion", "Keyboard/Shift & Keyboard/Backtab");	
+	si.SetStringValue("Hotkeys", "ToggleTurbo", "Keyboard/Tab");
 }
 
 void PAD::Update()


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
There were other sizing issues with region and CRC that are now have better width. Taking the liberty to organise the hotkeys as it is laid on the GUI-level + adding missing hotkeys. There is still much work to be done.

![image](https://user-images.githubusercontent.com/24227051/152449032-bc1a1b9c-ff85-43df-8e73-51c9dc248db2.png)

Added all the default hotkeys that were possible at this time:
![image](https://user-images.githubusercontent.com/24227051/152449193-2a498620-5db4-4f51-802f-c3e2a4aaccdd.png)
![image](https://user-images.githubusercontent.com/24227051/152449175-88bbba94-f586-4b95-989e-8758898aedea.png)
![image](https://user-images.githubusercontent.com/24227051/152450799-3d059502-9f49-4e45-9c85-dccb16b2398e.png)
![image](https://user-images.githubusercontent.com/24227051/152450814-582ab5bc-c707-44b1-8886-c9959e1fad78.png)

Though there are new hotkeys and some old ones aren't in here.

WX: https://wiki.pcsx2.net/Hotkeys

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
It looks better than before and is now a bit more feature complete.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Not needed atm.