### PR TITLE
Debugger: add register name patterns

### DIFF
--- a/pcsx2/DebugTools/MipsAssembler.cpp
+++ b/pcsx2/DebugTools/MipsAssembler.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2014-2014  PCSX2 Dev Team
+ *  Copyright (C) 2014-2022  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -84,6 +84,16 @@ const tMipsRegister MipsFloatRegister[] = {
 	{ "f7", 7, 2},		{ "$f7", 7, 3 },
 	{ "f8", 8, 2},		{ "$f8", 8, 3 },
 	{ "f9", 9, 2},		{ "$f9", 9, 3 },
+	{ "f00", 0, 3},		{ "$f00", 0, 4 },
+	{ "f01", 1, 3},		{ "$f01", 1, 4 },
+	{ "f02", 2, 3},		{ "$f02", 2, 4 },
+	{ "f03", 3, 3},		{ "$f03", 3, 4 },
+	{ "f04", 4, 3},		{ "$f04", 4, 4 },
+	{ "f05", 5, 3},		{ "$f05", 5, 4 },
+	{ "f06", 6, 3},		{ "$f06", 6, 4 },
+	{ "f07", 7, 3},		{ "$f07", 7, 4 },
+	{ "f08", 8, 3},		{ "$f08", 8, 4 },
+	{ "f09", 9, 3},		{ "$f09", 9, 4 },
 	{ "f10", 10, 3},	{ "$f10", 10, 4 },
 	{ "f11", 11, 3},	{ "$f11", 11, 4 },
 	{ "f12", 12, 3},	{ "$f12", 12, 4 },


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The debugger uses 2 digits for floating point number registers' number (f00, f01... f31), but you can't use this format in ``Assemble Opcode(s)`` when the register's number is less than 10.
This PR adds ``f00`` - ``f09`` pattern so that debugger will be able to handle them correctly.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less confusing

For example, instruction code 0x46140800 is shown as ``add.s f00,f01,f20`` in debugger.
However, when you open ``Assemble Opcode(s)`` and type the same ``add.s f00,f01,f20`` opcode, you will get parameter failure error because PCSX2 can only find ``f0`` - ``f9`` for registers' name.
You should input ``add.s f0,f1,f20`` instead on master.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Try new opcodes which include ``f00`` - ``f09`` register.
