### PR TITLE
Qt: Resize Windows + Change Framerate Presets + Lower OSD time

### DIFF
--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>700</height>
+    <width>950</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -32,7 +32,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
+     <width>950</width>
      <height>22</height>
     </rect>
    </property>

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>880</width>
-    <height>712</height>
+    <width>900</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -27,10 +27,12 @@ static constexpr u32 DEFAULT_FRAME_LATENCY = 2;
 
 static void FillComboBoxWithEmulationSpeeds(QComboBox* cb)
 {
+//	cb->addItem(qApp->translate("GeneralSettingsWidget", "Custom"),;// TODO: Make use of getInteger to get manual overrides from users 
+																	// for speed choice along with dropdown presets.
 	cb->addItem(qApp->translate("GeneralSettingsWidget", "Unlimited"), QVariant(0.0f));
 
-	static const int speeds[] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175,
-		200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000};
+	static const int speeds[] = {1, 10, 25, 50, 75, 90, 100, 110,
+		120, 150, 175, 200, 300, 400, 500, 1000};
 	for (const int speed : speeds)
 	{
 		cb->addItem(qApp->translate("EmulationSettingsWidget", "%1% [%2 FPS (NTSC) / %3 FPS (PAL)]")

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -75,7 +75,7 @@
    <item>
     <widget class="QGroupBox" name="basicGroupBox">
      <property name="title">
-      <string>Frame Pacing/Latency Control</string>
+      <string>Frame Pacing / Latency Control</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -70,7 +70,7 @@
       <item row="3" column="1">
        <widget class="QCheckBox" name="saveStateOnExit">
         <property name="text">
-         <string>Save/Load State On Exit/Resume</string>
+         <string>Save Or Load State On Exit / Resume</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/SettingsDialog.ui
+++ b/pcsx2-qt/Settings/SettingsDialog.ui
@@ -9,12 +9,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>780</width>
-    <height>650</height>
+    <width>800</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -26,7 +26,7 @@
    <item row="0" column="0">
     <widget class="QListWidget" name="settingsCategory">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -151,7 +151,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>120</height>
+       <height>100</height>
       </size>
      </property>
      <property name="maximumSize">

--- a/pcsx2-qt/Settings/SystemSettingsWidget.ui
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.ui
@@ -135,7 +135,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Chop/Zero (Default)</string>
+          <string>Chop / Zero (Default)</string>
          </property>
         </item>
        </widget>
@@ -206,7 +206,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Chop/Zero (Default)</string>
+          <string>Chop / Zero (Default)</string>
          </property>
         </item>
        </widget>

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -431,11 +431,11 @@ static void LoadPatches(const std::string& crc_string, bool show_messages, bool 
 		if (cheat_count > 0 || ws_patch_count > 0)
 		{
 			message.Write(" are active.");
-			Host::AddKeyedOSDMessage("LoadPatches", message.GetString().ToStdString(), 10.0f);
+			Host::AddKeyedOSDMessage("LoadPatches", message.GetString().ToStdString(), 5.0f);
 		}
 		else if (show_messages_when_disabled)
 		{
-			Host::AddKeyedOSDMessage("LoadPatches", "No cheats or widescreen patches are found/enabled.", 10.0f);
+			Host::AddKeyedOSDMessage("LoadPatches", "No cheats or patches (widescreen, compatibility or others) are found / enabled.", 8.0f);
 		}
 	}
 }
@@ -831,11 +831,11 @@ bool VMManager::LoadStateFromSlot(s32 slot)
 	const std::string filename(GetCurrentSaveStateFileName(slot));
 	if (filename.empty())
 	{
-		Host::AddKeyedFormattedOSDMessage("LoadStateFromSlot", 10.0f, "There is no save state in slot %d.", slot);
+		Host::AddKeyedFormattedOSDMessage("LoadStateFromSlot", 5.0f, "There is no save state in slot %d.", slot);
 		return false;
 	}
 
-	Host::AddKeyedFormattedOSDMessage("LoadStateFromSlot", 10.0f, "Loading state from slot %d...", slot);
+	Host::AddKeyedFormattedOSDMessage("LoadStateFromSlot", 5.0f, "Loading state from slot %d...", slot);
 	return DoLoadState(filename.c_str());
 }
 
@@ -883,7 +883,7 @@ bool VMManager::ChangeDisc(std::string path)
 	const bool result = DoCDVDopen();
 	if (result)
 	{
-		Host::AddFormattedOSDMessage(10.0f, "Disc changed to '%s'.", display_name.c_str());
+		Host::AddFormattedOSDMessage(5.0f, "Disc changed to '%s'.", display_name.c_str());
 	}
 	else
 	{
@@ -1158,7 +1158,7 @@ static void HotkeyAdjustTargetSpeed(double delta)
 	VMManager::SetLimiterMode(LimiterModeType::Nominal);
 	gsUpdateFrequency(EmuConfig);
 	GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
-	Host::AddKeyedFormattedOSDMessage("SpeedChanged", 10.0f, "Target speed set to %.0f%%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0));
+	Host::AddKeyedFormattedOSDMessage("SpeedChanged", 5.0f, "Target speed set to %.0f%%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0));
 }
 
 static constexpr s32 CYCLE_SAVE_STATE_SLOTS = 10;
@@ -1188,11 +1188,11 @@ static void HotkeyCycleSaveSlot(s32 delta)
 		if (len > 0 && date_buf[len - 1] == '\n')
 			date_buf[len - 1] = 0;
 
-		Host::AddKeyedFormattedOSDMessage("CycleSaveSlot", 10.0f, "Save slot %d selected (last save: %s).", s_current_save_slot, date_buf);
+		Host::AddKeyedFormattedOSDMessage("CycleSaveSlot", 5.0f, "Save slot %d selected (last save: %s).", s_current_save_slot, date_buf);
 	}
 	else
 	{
-		Host::AddKeyedFormattedOSDMessage("CycleSaveSlot", 10.0f, "Save slot %d selected (no save yet).", s_current_save_slot);
+		Host::AddKeyedFormattedOSDMessage("CycleSaveSlot", 5.0f, "Save slot %d selected (no save yet).", s_current_save_slot);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The main window will now correctly display the full Toolbar. Interface Settings will not go out of bounds. The OSD message for cheats and patches has been changed and the overall timing of the static (not dynamic) OSD messages are now 3 seconds instead of 10 seconds which is pretty long. Tested on 1920 x 1080 + 2560 x 1080 on 125% and 150% DPI scaling.


Main Window;
Before (Master):
![Master](https://user-images.githubusercontent.com/24227051/152621750-420c32f1-d0a7-4700-94af-ebeaa600c9b8.png)
After (PR):
![PR](https://user-images.githubusercontent.com/24227051/152621752-aba8a508-fe4a-4262-bc58-69f15610378c.png)

Don't worry about the bad scaling, it's a Qt bug with 125% DPI.
<img width="710" alt="150%1080P" src="https://user-images.githubusercontent.com/24227051/152621772-66491263-19f8-49b0-817b-1e5995742bf7.png">

Speed percentage steps (presets);
Before (Master):
<img width="214" alt="Master2" src="https://user-images.githubusercontent.com/24227051/152621621-5a76c2b3-237b-49b4-8956-a91584113e97.png">
After (PR):
<img width="220" alt="PR2" src="https://user-images.githubusercontent.com/24227051/152621625-0c1f359a-8a39-4db9-a9b2-e294a8f29b7b.png">

OSD naming change:
Before (Master):
<img width="252" alt="Master3" src="https://user-images.githubusercontent.com/24227051/152621905-4e1e6549-dbe6-440e-af09-bfc38b738a97.png">
After (PR):
![PR3](https://user-images.githubusercontent.com/24227051/152622289-d3bd97eb-bc1c-4fc5-acc2-be01dd49ca6e.png)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Keeping the end-user in mind with uncommon preferences without breaking the common preferences.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Get Qt to work and check all the window and if everything is visible and legible.