### PR TITLE
Disallow CLUT load condition processing on invalid format

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -118,6 +118,11 @@ void GSClut::Invalidate(u32 block)
 
 bool GSClut::WriteTest(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
+	// Check if PSM is an indexed format BEFORE the load condition, updating CBP0/1 on an invalid format is not allowed
+	// and can break games. Corvette (NTSC) is a good example of this.
+	if ((TEX0.PSM & 0x7) < 3)
+		return false;
+
 	switch (TEX0.CLD)
 	{
 		case 0:
@@ -149,7 +154,7 @@ bool GSClut::WriteTest(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 	}
 
 	// CLUT only reloads if PSM is a valid index type, avoid unnecessary flushes
-	return ((TEX0.PSM & 0x7) >= 3) && m_write.IsDirty(TEX0, TEXCLUT);
+	return m_write.IsDirty(TEX0, TEXCLUT);
 }
 
 void GSClut::Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)


### PR DESCRIPTION
### Description of Changes
GS: Don't process CLUT load condition on invalid (non-indexed) PSM

### Rationale behind Changes
Corvette was messing around with different formats and keeping the CLUT load condition on 4 (save new CBP if it's different) on conditions where the CLUT doesn't reload, causing some scenarios to miss CLUT reloads.

### Suggested Testing Steps
Test Corvette, or any game that used to have CLUT problems, make sure they're still ok.

Fixes #5435
