### PR TITLE
Fix _BitScanForward and _BitScanReverse on LP64 platforms.

### DIFF
--- a/pcsx2/GS/GSIntrin.h
+++ b/pcsx2/GS/GSIntrin.h
@@ -28,7 +28,7 @@
 #if !defined(_MSC_VER)
 // http://svn.reactos.org/svn/reactos/trunk/reactos/include/crt/mingw32/intrin_x86.h?view=markup
 
-static int _BitScanForward(unsigned long* const Index, const unsigned long Mask)
+static int _BitScanForward(unsigned int* const Index, const unsigned int Mask)
 {
 	if (Mask == 0)
 		return 0;
@@ -40,7 +40,7 @@ static int _BitScanForward(unsigned long* const Index, const unsigned long Mask)
 	return 1;
 }
 
-static int _BitScanReverse(unsigned long* const Index, const unsigned long Mask)
+static int _BitScanReverse(unsigned int* const Index, const unsigned int Mask)
 {
 	if (Mask == 0)
 		return 0;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2675,7 +2675,7 @@ static bool UsesRegionRepeat(int fix, int msk, int min, int max, int* min_out, i
 
 	const int cleared_bits = ~msk & ~fix; // Bits that are always cleared by applying msk and fix
 	const int set_bits = fix; // Bits that are always set by applying msk and fix
-	unsigned long msb;
+	unsigned int msb;
 	int variable_bits = min ^ max;
 	if (_BitScanReverse(&msb, variable_bits))
 		variable_bits |= (1 << msb) - 1; // Fill in all lower bits


### PR DESCRIPTION
### Description of Changes
This changes `_BitScanForward` and `_BitScanReverse` to take in `unsigned int`s instead of `unsigned long`s.

### Rationale behind Changes
This quiets a warning for compilers where `-Wshorten-64-to-32` is enabled by default.

### Suggested Testing Steps
None come to mind.