### PR TITLE
GS: Remove upscaling dependency on PCTRC enabling.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1241,6 +1241,12 @@ void GSRendererHW::Draw()
 	GSDrawingContext* context = m_context;
 	const GSLocalMemory::psm_t& tex_psm = GSLocalMemory::m_psm[m_context->TEX0.PSM];
 
+	if (!context->FRAME.FBW)
+	{
+		GL_CACHE("Skipping draw with FRAME.FBW = 0.");
+		return;
+	}
+
 	// Fix TEX0 size
 	if (PRIM->TME && !IsMipMapActive())
 		m_context->ComputeFixedTEX0(m_vt.m_min.t.xyxy(m_vt.m_max.t));
@@ -1278,6 +1284,12 @@ void GSRendererHW::Draw()
 			// Depth will be written through the RT
 			(context->FRAME.FBP == context->ZBUF.ZBP && !PRIM->TME && zm == 0 && fm == 0 && context->TEST.ZTE)
 			);
+
+	if (no_rt && no_ds)
+	{
+		GL_CACHE("Skipping draw with no color nor depth output.");
+		return;
+	}
 
 	const bool draw_sprite_tex = PRIM->TME && (m_vt.m_primclass == GS_SPRITE_CLASS);
 	const GSVector4 delta_p = m_vt.m_max.p - m_vt.m_min.p;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -267,8 +267,7 @@ bool GSRendererHW::CanUpscale()
 		return false;
 	}
 
-	 // upscale ratio depends on the display size, with no output it may not be set correctly (ps2 logo to game transition)
-	return GSConfig.UpscaleMultiplier != 1 && m_regs->PMODE.EN != 0;
+	return GSConfig.UpscaleMultiplier != 1;
 }
 
 int GSRendererHW::GetUpscaleMultiplier()


### PR DESCRIPTION
### Description of Changes
Remove the dependency of the GS upscaling from the PCRTC enabling (`PRMODE.EN1 | PRMODE.EN2`).
Skip draws where the frame buffer width is set to 0 or where it is detected that no color nor depth write is going to happen.

### Rationale behind Changes
The GS draw processing is not related to the PCRTC display.
A comment in the code that added the dependency of the upscaling to the PCRTC cited that when in the "ps2 logo to game transition" the display size may not be set correctly, so the draws where the frame buffer width is not defined or there is no output are now skipped.

### Suggested Testing Steps
Test various games at upscaled resolution, check that no visual regression occur.
Potentially some upscaled draws may have been improved (if the game renderered them without the PCRTC output buffer enabled, ref cited an homebrew which may have applied some texture decompression algorithm in this way).
Test the "ps2 logo to game transition" that was reported to have issues if allowed to render with upscaling.
