### PR TITLE
Qt: Misc graphics settings fixes

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -251,6 +251,9 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 
 	const bool is_hardware = (type == GSRendererType::DX11 || type == GSRendererType::OGL || type == GSRendererType::VK);
 	const bool is_software = (type == GSRendererType::SW);
+	const int current_tab = m_hardware_renderer_visible ?
+                                m_ui.hardwareRendererGroup->currentIndex() :
+                                m_ui.softwareRendererGroup->currentIndex();
 
 	// move advanced tab to the correct parent
 	static constexpr std::array<const char*, 3> move_tab_names = {{"Display", "On-Screen Display", "Advanced"}};
@@ -269,21 +272,19 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 			m_ui.softwareRendererGroup->insertTab((i == 0) ? 0 : m_ui.softwareRendererGroup->count(), tab, tab_label);
 	}
 
-	if (is_hardware != is_software)
-	{
-		if (is_hardware)
-			m_ui.hardwareRendererGroup->setCurrentIndex(0);
-		else
-			m_ui.softwareRendererGroup->setCurrentIndex(0);
-	}
-
 	if (m_hardware_renderer_visible != is_hardware)
 	{
 		m_ui.hardwareRendererGroup->setVisible(is_hardware);
 		if (!is_hardware)
+		{
 			m_ui.verticalLayout->removeWidget(m_ui.hardwareRendererGroup);
+		}
 		else
+		{
+			// map first two tabs over, skip hacks
 			m_ui.verticalLayout->insertWidget(1, m_ui.hardwareRendererGroup);
+			m_ui.hardwareRendererGroup->setCurrentIndex((current_tab < 2) ? current_tab : (current_tab + 2));
+		}
 
 		m_hardware_renderer_visible = is_hardware;
 	}
@@ -291,10 +292,16 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 	if (m_software_renderer_visible != is_software)
 	{
 		m_ui.softwareRendererGroup->setVisible(is_software);
-		if (!is_hardware)
+		if (is_hardware)
+		{
 			m_ui.verticalLayout->removeWidget(m_ui.softwareRendererGroup);
+		}
 		else
+		{
+			// software has no hacks tabs
 			m_ui.verticalLayout->insertWidget(1, m_ui.softwareRendererGroup);
+			m_ui.softwareRendererGroup->setCurrentIndex((current_tab >= 4) ? (current_tab - 2) : (current_tab >= 2 ? 1 : current_tab));
+		}
 
 		m_software_renderer_visible = is_software;
 	}

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -594,17 +594,17 @@ void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, const ch
 		{
 			case PAD::VibrationCapabilities::LargeSmallMotors:
 			{
-				const std::string large_binding(si.GetStringValue(section.c_str(), "LargeMotor"));
-				const std::string small_binding(si.GetStringValue(section.c_str(), "SmallMotor"));
-				has_any_bindings |= ParseBindingAndGetSource(large_binding, &vib.motors[0].binding, &vib.motors[0].source);
-				has_any_bindings |= ParseBindingAndGetSource(small_binding, &vib.motors[1].binding, &vib.motors[1].source);
+				if (const std::string large_binding(si.GetStringValue(section.c_str(), "LargeMotor")); !large_binding.empty())
+					has_any_bindings |= ParseBindingAndGetSource(large_binding, &vib.motors[0].binding, &vib.motors[0].source);
+				if (const std::string small_binding(si.GetStringValue(section.c_str(), "SmallMotor")); !small_binding.empty())
+					has_any_bindings |= ParseBindingAndGetSource(small_binding, &vib.motors[1].binding, &vib.motors[1].source);
 			}
 			break;
 
 			case PAD::VibrationCapabilities::SingleMotor:
 			{
-				const std::string binding(si.GetStringValue(section.c_str(), "Motor"));
-				has_any_bindings |= ParseBindingAndGetSource(binding, &vib.motors[0].binding, &vib.motors[0].source);
+				if (const std::string binding(si.GetStringValue(section.c_str(), "Motor")); !binding.empty())
+					has_any_bindings |= ParseBindingAndGetSource(binding, &vib.motors[0].binding, &vib.motors[0].source);
 			}
 			break;
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -297,6 +297,9 @@ Pcsx2Config::GSOptions::GSOptions()
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
 	WrapGSMem = false;
+	Mipmap = true;
+	AA1 = true;
+
 	UserHacks = false;
 	UserHacks_AlignSpriteX = false;
 	UserHacks_AutoFlush = false;


### PR DESCRIPTION
 - Qt: Fix default values for software mipmap/AA1
 - Qt: Fix current tab resetting when switching renderers
 - InputManager: Missing motor bindings are not errors

