### PR TITLE
COP2: Move COP2 timing messages to release builds.

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -1174,7 +1174,6 @@ static void iBranchTest(u32 newpc)
 	}
 }
 
-#ifdef PCSX2_DEVBUILD
 // opcode 'code' modifies:
 // 1: status
 // 2: MAC
@@ -1283,7 +1282,6 @@ bool COP2IsQOP(u32 code)
 
 	return false;
 }
-#endif
 
 
 void dynarecCheckBreakpoint()
@@ -1574,7 +1572,6 @@ void recompileNextInstruction(int delayslot)
 
 	g_maySignalException = false;
 
-#if PCSX2_DEVBUILD
 	// Stalls normally occur as necessary on the R5900, but when using COP2 (VU0 macro mode),
 	// there are some exceptions to this.  We probably don't even know all of them.
 	// We emulate the R5900 as if it was fully interlocked (which is mostly true), and
@@ -1612,12 +1609,12 @@ void recompileNextInstruction(int delayslot)
 				else if (COP2IsQOP(cpuRegs.code))
 				{
 					std::string disasm;
-					DevCon.Warning("Possible incorrect Q value used in COP2");
+					Console.Warning("Possible incorrect Q value used in COP2. If the game is broken, please report to http://github.com/pcsx2/pcsx2.");
 					for (u32 i = s_pCurBlockEx->startpc; i < s_nEndBlock; i += 4)
 					{
 						disasm = "";
 						disR5900Fasm(disasm, memRead32(i), i, false);
-						DevCon.Warning("%x %s%08X %s", i, i == pc - 4 ? "*" : i == p ? "=" : " ", memRead32(i), disasm.c_str());
+						Console.Warning("%x %s%08X %s", i, i == pc - 4 ? "*" : i == p ? "=" : " ", memRead32(i), disasm.c_str());
 					}
 					break;
 				}
@@ -1636,12 +1633,12 @@ void recompileNextInstruction(int delayslot)
 					if (_Rd_ == 16 && s & 1 || _Rd_ == 17 && s & 2 || _Rd_ == 18 && s & 4)
 					{
 						std::string disasm;
-						DevCon.Warning("Possible old value used in COP2 code");
+						Console.Warning("Possible old value used in COP2 code. If the game is broken, please report to http://github.com/pcsx2/pcsx2.");
 						for (u32 i = s_pCurBlockEx->startpc; i < s_nEndBlock; i += 4)
 						{
 							disasm = "";
 							disR5900Fasm(disasm, memRead32(i), i,false);
-							DevCon.Warning("%x %s%08X %s", i, i == pc - 4 ? "*" : i == p ? "=" : " ", memRead32(i), disasm.c_str());
+							Console.Warning("%x %s%08X %s", i, i == pc - 4 ? "*" : i == p ? "=" : " ", memRead32(i), disasm.c_str());
 						}
 						break;
 					}
@@ -1657,7 +1654,6 @@ void recompileNextInstruction(int delayslot)
 		}
 	}
 	cpuRegs.code = *s_pCode;
-#endif
 
 	if (!delayslot && (xGetPtr() - recPtr > 0x1000))
 		s_nEndBlock = pc;


### PR DESCRIPTION
### Description of Changes
The COP2 pipeline isn't fully emulated. A way to fix games that depend on the pipelined behaviour is to patch them. In order to find out what games need patching we can look at the EE code we are compiling and do some heuristics.

#5388 requested to allow this code to run in release builds as well.

### Rationale behind Changes
Allowing this extra logging can help us find what games need patching, not everyone is going to test their games with devel builds and this information can prove to be useful.

### Suggested Testing Steps
This needs to be bench marked against a release build with this disabled. This code is run during recompilation, so a game that likes to do a lot of self modifying code would be a great candidate. 
You can compare against this build: https://github.com/PCSX2/pcsx2/actions/runs/1799763630

---
fixes: #5388