### PR TITLE
GS: remove bw equality check in tex in rt.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -329,10 +329,9 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					found_t = true;
 					break;
 				}
-				else if (texture_inside_rt && bw == t->m_TEX0.TBW && psm == PSM_PSMCT32 && t->m_TEX0.PSM == psm &&
+				else if (texture_inside_rt && psm == PSM_PSMCT32 && t->m_TEX0.PSM == psm &&
 					((t->m_TEX0.TBP0 < bp && t->m_end_block >= bp) || t_wraps))
 				{
-					// BW equality needed because CreateSource does not handle BW conversion.
 					// Only PSMCT32 to limit false hits.
 					// PSM equality needed because CreateSource does not handle PSM conversion.
 					// Only inclusive hit to limit false hits.


### PR DESCRIPTION
### Description of Changes
Remove bw equality check when looking for tex in rt in gs hw tc.
Should fix #5470.

### Rationale behind Changes
This check broke jak games mipmapping (#5470), and it was not present in the previous tex in rt version.
The creation of textures from previous render targets does not support bw conversion still, but it does not matter for jak mipmapping; hence bw conversion in texture creation can be added later if needed.

### Suggested Testing Steps
Test jak games and other tex in rt games.
