### PR TITLE
GS:HW: Fix scale of color → 8 bit converted textures

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1345,7 +1345,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		}
 		// width/height conversion
 
-		GSVector2 scale = dst->m_texture->GetScale();
+		GSVector2 scale = is_8bits ? GSVector2(1, 1) : dst->m_texture->GetScale();
 
 		GSVector4i sRect(0, 0, w, h);
 		const bool use_texture = shader == ShaderConvert::COPY;


### PR DESCRIPTION
### Description of Changes
Fixes a bug surfaced by #5387

### Rationale behind Changes
We currently convert back to 1x when converting color textures to RGBA8 but we still marked the textures as being upscaled even though they no longer were.  This was okay before, because almost everything ignored the texture scale property, but texture scale is now used and things break when it's wrong.

### Suggested Testing Steps
Test [this GSdump](https://github.com/PCSX2/pcsx2/files/8009254/vp2_forest.gs.xz.zip)

