### PR TITLE
GS-hw-tc: Remove JackieChanAdv crc hack.

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -197,8 +197,6 @@ const CRC::Game CRC::m_games[] =
 	{0xDCD9A9F7, GodOfWar2, EU, 0},
 	{0xFA0DF523, GodOfWar2, CH, 0}, // cutie comment
 	{0x9FEE3466, GodOfWar2, CH, 0}, // cutie comment
-	{0x5D482F18, JackieChanAdv, EU, 0},
-	{0xAC4DFD5A, JackieChanAdv, EU, 0},
 	{0x95CC86EF, GiTS, US, 0}, // same CRC also reported as EU
 	{0x2C5BF134, GiTS, US, 0}, // Demo
 	{0xA5768F53, GiTS, JP, 0},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -72,7 +72,6 @@ public:
 		ICO,
 		IkkiTousen,
 		IndianaJonesAndTheEmperorsTomb,
-		JackieChanAdv,
 		Jak1,
 		Jak2,
 		Jak3,

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -102,16 +102,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 	if (!m_can_convert_depth)
 	{
 		GL_CACHE("LookupDepthSource not supported (0x%x, F:0x%x)", TEX0.TBP0, TEX0.PSM);
-		if (m_renderer->m_game.title == CRC::JackieChanAdv || m_renderer->m_game.title == CRC::SVCChaos)
-		{
-			// JackieChan and SVCChaos cause regressions when skipping the draw calls when depth is disabled/not supported.
-			// This way we make sure there are no regressions on D3D as well.
-			return LookupSource(TEX0, TEXA, r, false);
-		}
-		else
-		{
-			throw GSRecoverableError();
-		}
+		throw GSRecoverableError();
 	}
 
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
@@ -120,8 +111,8 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 	Target* dst = NULL;
 
 	// Check only current frame, I guess it is only used as a postprocessing effect
-	u32 bp = TEX0.TBP0;
-	u32 psm = TEX0.PSM;
+	const u32 bp = TEX0.TBP0;
+	const u32 psm = TEX0.PSM;
 
 	for (auto t : m_dst[DepthStencil])
 	{
@@ -185,6 +176,11 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 
 		m_src.m_surfaces.insert(src);
 	}
+	else if (m_renderer->m_game.title == CRC::SVCChaos)
+	{
+		// SVCChaos black screen on main menu, regardless of depth enabled or disabled.
+		return LookupSource(TEX0, TEXA, r, false);
+	}
 	else
 	{
 		GL_CACHE("TC depth: ERROR miss (0x%x, %s)", TEX0.TBP0, psm_str(psm));
@@ -196,21 +192,11 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		// Note: might worth to check previous frame
 		// Note: otherwise return NULL and skip the draw
 
-		if (m_renderer->m_game.title == CRC::JackieChanAdv || m_renderer->m_game.title == CRC::SVCChaos)
-		{
-			// JackieChan and SVCChaos cause regressions when skipping the draw calls so we reuse the old code for these two.
-			return LookupSource(TEX0, TEXA, r, false);
-		}
-		else
-		{
-			// Full Spectrum Warrior: first draw call of cut-scene rendering
-			// The game tries to emulate a texture shuffle with an old depth buffer
-			// (don't exists yet for us due to the cache)
-			// Rendering is nicer (less garbage) if we skip the draw call.
-			throw GSRecoverableError();
-		}
-
-		//ASSERT(0);
+		// Full Spectrum Warrior: first draw call of cut-scene rendering
+		// The game tries to emulate a texture shuffle with an old depth buffer
+		// (don't exists yet for us due to the cache)
+		// Rendering is nicer (less garbage) if we skip the draw call.
+		throw GSRecoverableError();
 	}
 
 	return src;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -214,7 +214,6 @@ public:
 
 		void Add(Source* s, const GIFRegTEX0& TEX0, const GSOffset& off);
 		void RemoveAll();
-		void RemovePartial();
 		void RemoveAt(Source* s);
 	};
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw-tc: Remove JackieChanAdv crc hack.
Game seems to work fine currently.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less hacks, not needed.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
[JA_Halfscreen_Flicker_hitolddepthbuffer.zip](https://github.com/PCSX2/pcsx2/files/8010057/JA_Halfscreen_Flicker_hitolddepthbuffer.zip)

#1838
