### PR TITLE
GS: Add sync to host refresh rate option

### DIFF
--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -27,6 +27,7 @@
 #include "common/StringUtil.h"
 
 #include "pcsx2/CDVD/CDVD.h"
+#include "pcsx2/Counters.h"
 #include "pcsx2/Frontend/InputManager.h"
 #include "pcsx2/Frontend/ImGuiManager.h"
 #include "pcsx2/GS.h"
@@ -361,6 +362,9 @@ void EmuThread::setFullscreen(bool fullscreen)
 	m_is_fullscreen = fullscreen;
 	GetMTGS().UpdateDisplayWindow();
 	GetMTGS().WaitGS();
+
+	// If we're using exclusive fullscreen, the refresh rate may have changed.
+	UpdateVSyncRate();
 }
 
 void EmuThread::setSurfaceless(bool surfaceless)

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -435,6 +435,7 @@ struct Pcsx2Config
 					PCRTCOffsets : 1,
 					IntegerScaling : 1,
 					LinearPresent : 1,
+					SyncToHostRefreshRate : 1,
 					UseDebugDevice : 1,
 					UseBlitSwapChain : 1,
 					DisableShaderCache : 1,

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1331,6 +1331,7 @@ void GSApp::Init()
 	m_default_configuration["extrathreads_height"]                        = "4";
 	m_default_configuration["filter"]                                     = std::to_string(static_cast<s8>(BiFiltering::PS2));
 	m_default_configuration["FMVSoftwareRendererSwitch"]                  = "0";
+	m_default_configuration["FullscreenMode"]                             = "";
 	m_default_configuration["fxaa"]                                       = "0";
 	m_default_configuration["GSDumpCompression"]                          = "0";
 	m_default_configuration["HWDisableReadbacks"]                         = "0";

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -502,7 +502,6 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 
 	const int fb_sprite_blits = g_perfmon.GetDisplayFramebufferSpriteBlits();
 	const bool fb_sprite_frame = (fb_sprite_blits > 0);
-	PerformanceMetrics::Update(registers_written, fb_sprite_frame);
 
 	bool skip_frame = m_frameskip;
 	if (GSConfig.SkipDuplicateFrames)
@@ -540,6 +539,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 		if (Host::BeginPresentFrame(true))
 			Host::EndPresentFrame();
 		g_gs_device->RestoreAPIState();
+		PerformanceMetrics::Update(registers_written, fb_sprite_frame);
 		return;
 	}
 
@@ -572,6 +572,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 			PerformanceMetrics::OnGPUPresent(Host::GetHostDisplay()->GetAndResetAccumulatedGPUTime());
 	}
 	g_gs_device->RestoreAPIState();
+	PerformanceMetrics::Update(registers_written, fb_sprite_frame);
 
 	// snapshot
 	// wx is dumb and call this from the UI thread...

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -300,6 +300,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	PCRTCOffsets = false;
 	IntegerScaling = false;
 	LinearPresent = true;
+	SyncToHostRefreshRate = false;
 	UseDebugDevice = false;
 	UseBlitSwapChain = false;
 	DisableShaderCache = false;
@@ -463,6 +464,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 #ifdef PCSX2_CORE
 	// These are loaded from GSWindow in wx.
+	SettingsWrapBitBool(SyncToHostRefreshRate);
 	SettingsWrapEnumEx(AspectRatio, "AspectRatio", AspectRatioNames);
 	SettingsWrapEnumEx(FMVAspectRatioSwitch, "FMVAspectRatioSwitch", FMVAspectRatioSwitchNames);
 

--- a/pcsx2/SPU2/SndOut.cpp
+++ b/pcsx2/SPU2/SndOut.cpp
@@ -149,14 +149,6 @@ bool SndBuffer::CheckUnderrunStatus(int& nSamples, int& quietSampleCount)
 	return true;
 }
 
-void SndBuffer::_InitFail()
-{
-	// If a failure occurs, just initialize the NoSound driver.  This'll allow
-	// the game to emulate properly (hopefully), albeit without sound.
-	OutputModule = FindOutputModuleById(NullOut->GetIdent());
-	mods[OutputModule]->Init();
-}
-
 int SndBuffer::_GetApproximateDataInBuffer()
 {
 	// WARNING: not necessarily 100% up to date by the time it's used, but it will have to do.
@@ -357,13 +349,10 @@ void SndBuffer::_WriteSamples(StereoOut32* bData, int nSamples)
 	_WriteSamples_Safe(bData, nSamples);
 }
 
-void SndBuffer::Init()
+bool SndBuffer::Init()
 {
-	if (mods[OutputModule] == nullptr)
-	{
-		_InitFail();
-		return;
-	}
+	if (!mods[OutputModule])
+		return false;
 
 	// initialize sound buffer
 	// Buffer actually attempts to run ~50%, so allocate near double what
@@ -372,33 +361,25 @@ void SndBuffer::Init()
 	m_rpos = 0;
 	m_wpos = 0;
 
-	try
-	{
-		const float latencyMS = SndOutLatencyMS * 16;
-		m_size = GetAlignedBufferSize((int)(latencyMS * SampleRate / 1000.0f));
-		printf("%d SampleRate: \n", SampleRate);
-		m_buffer = new StereoOut32[m_size];
-		m_underrun_freeze = false;
+	const float latencyMS = SndOutLatencyMS * 16;
+	m_size = GetAlignedBufferSize((int)(latencyMS * SampleRate / 1000.0f));
+	m_buffer = new StereoOut32[m_size];
+	m_underrun_freeze = false;
 
-		sndTempBuffer = new StereoOut32[SndOutPacketSize];
-		sndTempBuffer16 = new StereoOut16[SndOutPacketSize * 2]; // in case of leftovers.
-	}
-	catch (std::bad_alloc&)
-	{
-		// out of memory exception (most likely)
-
-		SysMessage("Out of memory error occurred while initializing SPU2.");
-		_InitFail();
-		return;
-	}
-
+	sndTempBuffer = new StereoOut32[SndOutPacketSize];
+	sndTempBuffer16 = new StereoOut16[SndOutPacketSize * 2]; // in case of leftovers.
 	sndTempProgress = 0;
 
 	soundtouchInit(); // initializes the timestretching
 
 	// initialize module
 	if (!mods[OutputModule]->Init())
-		_InitFail();
+	{
+		Cleanup();
+		return false;
+	}
+
+	return true;
 }
 
 void SndBuffer::Cleanup()

--- a/pcsx2/SPU2/SndOut.h
+++ b/pcsx2/SPU2/SndOut.h
@@ -586,7 +586,6 @@ private:
 	static float eTempo;
 	static int ssFreeze;
 
-	static void _InitFail();
 	static bool CheckUnderrunStatus(int& nSamples, int& quietSampleCount);
 
 	static void soundtouchInit();
@@ -614,7 +613,7 @@ private:
 
 public:
 	static void UpdateTempoChangeAsyncMixing();
-	static void Init();
+	static bool Init();
 	static void Cleanup();
 	static void Write(const StereoOut32& Sample);
 	static void ClearContents();

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -33,6 +33,7 @@ s32 SPU2open();
 void SPU2close();
 void SPU2shutdown();
 void SPU2SetOutputPaused(bool paused);
+void SPU2SetDeviceSampleRateMultiplier(double multiplier);
 void SPU2write(u32 mem, u16 value);
 u16 SPU2read(u32 mem);
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -886,6 +886,7 @@ void AppConfig::GSWindowOptions::LoadSave(IniInterface& ini)
 			// WARNING: array must be NULL terminated to compute it size
 			NULL};
 
+	g_Conf->EmuOptions.GS.SyncToHostRefreshRate = ini.EntryBitBool(L"SyncToHostRefreshRate", g_Conf->EmuOptions.GS.SyncToHostRefreshRate, g_Conf->EmuOptions.GS.SyncToHostRefreshRate);
 	ini.EnumEntry(L"AspectRatio", g_Conf->EmuOptions.GS.AspectRatio, AspectRatioNames, g_Conf->EmuOptions.GS.AspectRatio);
 	if (ini.IsLoading())
 		EmuConfig.CurrentAspectRatio = g_Conf->EmuOptions.GS.AspectRatio;

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -285,6 +285,7 @@ namespace Panels
 
 		pxCheckBox* m_check_HideMouse;
 		pxCheckBox* m_check_DclickFullscreen;
+		pxCheckBox* m_check_SyncToHostRefreshRate;
 
 		wxTextCtrl* m_text_WindowWidth;
 		wxTextCtrl* m_text_WindowHeight;

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -74,6 +74,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 	// Implement custom hotkeys (Alt + Enter) with translatable string intact + not blank in GUI.
 	m_check_Fullscreen = new pxCheckBox(this, _("Start in fullscreen mode by default") + wxString(" (") + wxGetApp().GlobalAccels->findKeycodeWithCommandId("FullscreenToggle").toTitleizedString() + wxString(")"));
 	m_check_DclickFullscreen = new pxCheckBox(this, _("Double-click toggles fullscreen mode"));
+	m_check_SyncToHostRefreshRate = new pxCheckBox(this, _("Sync To Host Refresh Rate"));
 
 	m_combo_FMVAspectRatioSwitch->SetToolTip(pxEt(L"Off: Disables temporary aspect ratio switch. (It will use the above setting from Aspect Ratio instead of FMV Aspect Ratio Override.)\n\n"
 												  L"Auto 4:3/3:2: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display a 4:3 FMV. Will use 3:2 is the resolution is 480P\n\n"
@@ -136,6 +137,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 
 	*this += m_check_Fullscreen;
 	*this += m_check_DclickFullscreen;
+	*this += m_check_SyncToHostRefreshRate;
 	*this += new wxStaticLine(this) | StdExpand();
 
 	*this += s_vsync | StdExpand();
@@ -169,6 +171,7 @@ void Panels::GSWindowSettingsPanel::ApplyConfigToGui(AppConfig& configToApply, i
 		m_text_Zoom->ChangeValue(wxString::FromDouble(gsconf.Zoom, 2));
 
 		m_check_DclickFullscreen->SetValue(conf.IsToggleFullscreenOnDoubleClick);
+		m_check_SyncToHostRefreshRate->SetValue(gsconf.SyncToHostRefreshRate);
 
 		m_text_WindowWidth->ChangeValue(wxsFormat(L"%d", conf.WindowSize.GetWidth()));
 		m_text_WindowHeight->ChangeValue(wxsFormat(L"%d", conf.WindowSize.GetHeight()));
@@ -199,6 +202,7 @@ void Panels::GSWindowSettingsPanel::Apply()
 	gsconf.VsyncEnable = static_cast<VsyncMode>(m_combo_vsync->GetSelection());
 
 	appconf.IsToggleFullscreenOnDoubleClick = m_check_DclickFullscreen->GetValue();
+	gsconf.SyncToHostRefreshRate = m_check_SyncToHostRefreshRate->GetValue();
 
 	long xr, yr = 1;
 


### PR DESCRIPTION
### Description of Changes

This PR implements an option I had in DuckStation - to run the emulation approximately 0.1% faster, so that the guest vertical frequency matches the host refresh rate. It gets rid of the duplicate frames you would otherwise get around every 18 seconds or so.

Since we're running the emulation ever-so-slightly faster, the SPU output rate also changes to ~48048hz. Because we're using cubeb now, we just forward that through, and it takes care of resampling it for us.

In addition, when the host vsync and guest vsync queue size is set to 0, we can get rid of sleep-based frame pacing completely, relying exclusively on the host vsync. Polling controllers after host vsync should result in the lowest possible input latency, and the most stable frame times since we're not at the mercy of the OS scheduler so much.

For best results, use with exclusive fullscreen on D3D. This is only available in Qt, I mostly implemented it in Wx, only to find that it's still using that parent/child window mess, which prevents it, and I don't feel like rewriting that disgustingness.

To enable vsync-based pacing:
 - Set your host to 60hz or 59.94hz (for NTSC games), or 50hz (for PAL games). I'm considering making this switch automatic in the future.
 - Enable sync to refresh rate (GS window in wx, emulation settings in qt).
 - Set the vsync queue size to 0 (GS in wx, emulation settings -> optimal frame pacing in qt).
 - Enable vsync on the host (GS window in wx, graphics settings -> display in qt).

If it's working, it should display a message in the OSD saying it's using vsync for frame pacing.

I'm curious if anyone sensitive to input latency can notice an improvement here. Because I sure as heck can't :D

### Rationale behind Changes

Getting rid of the meme that pcsx2 sucks for input latency, when it doesn't.
