### PR TITLE
GS: update target pitch on frame lookup.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -502,13 +502,15 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 
 		// 3rd try ! Try to find a frame that doesn't contain valid data (honestly I'm not sure we need to do it)
 		if (!dst)
-			for (auto t :list)
+			for (auto t : list)
 				if (bp == t->m_TEX0.TBP0)
 				{
 					dst = t;
 					GL_CACHE("TC: Lookup Frame %dx%d, empty hit: %d (0x%x -> 0x%x %s)", size.x, size.y, dst->m_texture->GetID(), bp, t->m_end_block, psm_str(TEX0.PSM));
 					break;
 				}
+		if (dst)
+			dst->m_TEX0.TBW = TEX0.TBW; // Fix Jurassic Park - Operation Genesis loading disk logo.
 	}
 
 	if (dst)


### PR DESCRIPTION
### Description of Changes
As done for the target lookup for draws, update the target pitch also on frame lookup.

### Rationale behind Changes
Fixes a regression from #5419, which introduced upload of dirty rectangles also on frame lookup (previously done only on draws).
Actually, thanks to dirty data upload in frames, the loading disk logo in Jurassic Park - Operation Genesis (the game which shown the regression) is shown much earlier than before, and now correctly with this change.

### Suggested Testing Steps
Boot Jurassic Park - Operation Genesis and check the loading disk logo.
Test other games especially on boot and check that no regression occurred.
