### PR TITLE
GS: update target pitch on write.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -816,6 +816,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 					GL_CACHE("TC: Dirty Target(%s) %d (0x%x) r(%d,%d,%d,%d)", to_string(type),
 						t->m_texture ? t->m_texture->GetID() : 0,
 						t->m_TEX0.TBP0, r.x, r.y, r.z, r.w);
+					t->m_TEX0.TBW = bw;
 					t->m_dirty.push_back(GSDirtyRect(r, psm, bw));
 				}
 				else
@@ -855,6 +856,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 								t->m_texture ? t->m_texture->GetID() : 0,
 								t->m_TEX0.TBP0);
 							// TODO: do not add this rect above too
+							t->m_TEX0.TBW = bw;
 							t->m_dirty.push_back(GSDirtyRect(GSVector4i(r.left, r.top - y, r.right, r.bottom - y), psm, bw));
 							continue;
 						}
@@ -882,6 +884,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 							t->m_TEX0.TBP0, t->m_end_block,
 							r.left, r.top + y, r.right, r.bottom + y, bw);
 
+						t->m_TEX0.TBW = bw;
 						t->m_dirty.push_back(GSDirtyRect(GSVector4i(r.left, r.top + y, r.right, r.bottom + y), psm, bw));
 						continue;
 					}


### PR DESCRIPTION
### Description of Changes
Overwrite the target pitch when an overlapping write is detected with the write pitch itself.
Partially reverts c1e5e45431863bc206686c49b8fb4fa2775be9a2 (part of #3895), the commit which fixed Indiana Jones and the Emperor's Tomb.

### Rationale behind Changes
fixes the broken splashscreen in This is Football 2002 (#5426).

### Suggested Testing Steps
Check the This is Football 2002 splashcreen (#5426).
Check that Indiana Jones and the Emperor's Tomb is not broken (initial castle FMV and in game textures, especially the map texture).
