### PR TITLE
GameDB: Add missing Gran Turismo demos

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -48,6 +48,9 @@ PAPX-90223:
 PAPX-90231:
   name: "Kaitou Sly Cooper [Demo, Taikenban]"
   region: "NTSC-J"
+PAPX-90504:
+  name: "Gran Turismo Concept - Airtrek Turbo Special Edition [Demo]"
+  region: "NTSC-J"
 PAPX-90506:
   name: "Dark Chronicle[Demo, Taikenban]"
   region: "NTSC-J"
@@ -1321,6 +1324,9 @@ SCED-51279:
 SCED-51319:
   name: "Official PlayStation 2 Magazine Demo 27" # German
   region: "PAL-E-G"
+SCED-51352:
+  name: "Gran Turismo: Nissan Micra Edition"
+  region: "PAL-E"
 SCED-51359:
   name: "Official PlayStation 2 Magazine Demo 27"
   region: "PAL-M5"
@@ -1599,11 +1605,14 @@ SCED-52461:
 SCED-52549:
   name: "Official PlayStation 2 Magazine Demo 47"
   region: "PAL-M5"
+SCED-52578:
+  name: "Gran Turismo 4 BMW 1 Series Virtual Drive Dealership [Demo]"
+  region: "PAL-M5"
 SCED-52619:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
 SCED-52681:
-  name: "Gran Turismo 4 BMW 1 Series [Demo]"
+  name: "Gran Turismo 4 BMW 1 Series Virtual Drive [Demo]"
   region: "PAL-M11"
 SCED-52728:
   name: "Official PlayStation 2 Magazine Demo 49"
@@ -4100,6 +4109,9 @@ SCKA-30006:
   compat: 5
 SCPM-85101:
   name: "McDonald's Original Happy Disc"
+  region: "NTSC-J"
+SCPM-85301:
+  name: "Gran Turismo Concept - Copen Special Edition [Demo]"
   region: "NTSC-J"
 SCPS-11001:
   name: "I.Q. Remix"


### PR DESCRIPTION
Also changed the name of **BMW 1 Series** for consistency. It's the name redump uses too.