### PR TITLE
CI: Label Qt into GUI/Qt

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,9 +27,11 @@
 'GUI/WX':
   - 'pcsx2/gui/*'
   - 'pcsx2/gui/**/*'
-'Qt':
+'GUI/Qt':
   - 'pcsx2-qt/*'
   - 'pcsx2-qt/**/*'
+  - '3rdparty/Qt/*'
+  - '3rdparty/Qt/**/*'
 'GameDB':
   - '**/GameIndex.*'
 'Installer | Package':


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The label has recently been changed into GUI/Qt for more clarity that it touches upon a GUI toolkit just like WX. Also added the 3rdparty for the binary.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
No need to diverge labels that are redundant.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Making a meaningful pull request that touches the Qt files.