### PR TITLE
CMake: add back HarfBuzz to fix build

### DIFF
--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -1,0 +1,181 @@
+
+# Copyright (c) 2012, Intel Corporation
+# Copyright (c) 2019 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Try to find Harfbuzz include and library directories.
+#
+# After successful discovery, this will set for inclusion where needed:
+# HarfBuzz_INCLUDE_DIRS - containg the HarfBuzz headers
+# HarfBuzz_LIBRARIES - containg the HarfBuzz library
+
+#[=======================================================================[.rst:
+FindHarfBuzz
+--------------
+
+Find HarfBuzz headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``HarfBuzz::HarfBuzz``
+  The HarfBuzz library, if found.
+
+``HarfBuzz::ICU``
+  The HarfBuzz ICU library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``HarfBuzz_FOUND``
+  true if (the requested version of) HarfBuzz is available.
+``HarfBuzz_VERSION``
+  the version of HarfBuzz.
+``HarfBuzz_LIBRARIES``
+  the libraries to link against to use HarfBuzz.
+``HarfBuzz_INCLUDE_DIRS``
+  where to find the HarfBuzz headers.
+``HarfBuzz_COMPILE_OPTIONS``
+  this should be passed to target_compile_options(), if the
+  target is not used for linking
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_HARFBUZZ QUIET harfbuzz)
+set(HarfBuzz_COMPILE_OPTIONS ${PC_HARFBUZZ_CFLAGS_OTHER})
+set(HarfBuzz_VERSION ${PC_HARFBUZZ_CFLAGS_VERSION})
+
+find_path(HarfBuzz_INCLUDE_DIR
+	NAMES hb.h
+	HINTS ${PC_HARFBUZZ_INCLUDEDIR} ${PC_HARFBUZZ_INCLUDE_DIRS}
+	PATH_SUFFIXES harfbuzz
+)
+
+find_library(HarfBuzz_LIBRARY
+	NAMES ${HarfBuzz_NAMES} harfbuzz
+	HINTS ${PC_HARFBUZZ_LIBDIR} ${PC_HARFBUZZ_LIBRARY_DIRS}
+)
+
+if (HarfBuzz_INCLUDE_DIR AND NOT HarfBuzz_VERSION)
+	if (EXISTS "${HarfBuzz_INCLUDE_DIR}/hb-version.h")
+		file(READ "${HarfBuzz_INCLUDE_DIR}/hb-version.h" _harfbuzz_version_content)
+
+		string(REGEX MATCH "#define +HB_VERSION_STRING +\"([0-9]+\\.[0-9]+\\.[0-9]+)\"" _dummy "${_harfbuzz_version_content}")
+		set(HarfBuzz_VERSION "${CMAKE_MATCH_1}")
+	endif ()
+endif ()
+
+if ("${HarfBuzz_FIND_VERSION}" VERSION_GREATER "${HarfBuzz_VERSION}")
+	message(FATAL_ERROR "Required version (" ${HarfBuzz_FIND_VERSION} ") is higher than found version (" ${HarfBuzz_VERSION} ")")
+endif ()
+
+# Find components
+if (HarfBuzz_INCLUDE_DIR AND HarfBuzz_LIBRARY)
+	set(_HarfBuzz_REQUIRED_LIBS_FOUND ON)
+	set(HarfBuzz_LIBS_FOUND "HarfBuzz (required): ${HarfBuzz_LIBRARY}")
+else ()
+	set(_HarfBuzz_REQUIRED_LIBS_FOUND OFF)
+	set(HarfBuzz_LIBS_NOT_FOUND "HarfBuzz (required)")
+endif ()
+
+if ("ICU" IN_LIST HarfBuzz_FIND_COMPONENTS)
+	pkg_check_modules(PC_HARFBUZZ_ICU QUIET harfbuzz-icu)
+	set(HarfBuzz_ICU_COMPILE_OPTIONS ${PC_HARFBUZZ_ICU_CFLAGS_OTHER})
+
+	find_library(HarfBuzz_ICU_LIBRARY
+		NAMES ${HarfBuzz_ICU_NAMES} harfbuzz-icu
+		HINTS ${PC_HARFBUZZ_ICU_LIBDIR} ${PC_HARFBUZZ_ICU_LIBRARY_DIRS}
+	)
+
+	if (HarfBuzz_ICU_LIBRARY)
+		if (HarfBuzz_FIND_REQUIRED_ICU)
+			list(APPEND HarfBuzz_LIBS_FOUND "ICU (required): ${HarfBuzz_ICU_LIBRARY}")
+		else ()
+			list(APPEND HarfBuzz_LIBS_FOUND "ICU (optional): ${HarfBuzz_ICU_LIBRARY}")
+		endif ()
+	else ()
+		if (HarfBuzz_FIND_REQUIRED_ICU)
+			set(_HarfBuzz_REQUIRED_LIBS_FOUND OFF)
+			list(APPEND HarfBuzz_LIBS_NOT_FOUND "ICU (required)")
+		else ()
+			list(APPEND HarfBuzz_LIBS_NOT_FOUND "ICU (optional)")
+		endif ()
+	endif ()
+endif ()
+
+if (NOT HarfBuzz_FIND_QUIETLY)
+	if (HarfBuzz_LIBS_FOUND)
+		message(STATUS "Found the following HarfBuzz libraries:")
+		foreach (found ${HarfBuzz_LIBS_FOUND})
+			message(STATUS " ${found}")
+		endforeach ()
+	endif ()
+	if (HarfBuzz_LIBS_NOT_FOUND)
+		message(STATUS "The following HarfBuzz libraries were not found:")
+		foreach (found ${HarfBuzz_LIBS_NOT_FOUND})
+			message(STATUS " ${found}")
+		endforeach ()
+	endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HarfBuzz
+	FOUND_VAR HarfBuzz_FOUND
+	REQUIRED_VARS HarfBuzz_INCLUDE_DIR HarfBuzz_LIBRARY _HarfBuzz_REQUIRED_LIBS_FOUND
+	VERSION_VAR HarfBuzz_VERSION
+)
+
+if (HarfBuzz_LIBRARY AND NOT TARGET HarfBuzz::HarfBuzz)
+	add_library(HarfBuzz::HarfBuzz UNKNOWN IMPORTED GLOBAL)
+	set_target_properties(HarfBuzz::HarfBuzz PROPERTIES
+		IMPORTED_LOCATION "${HarfBuzz_LIBRARY}"
+		INTERFACE_COMPILE_OPTIONS "${HarfBuzz_COMPILE_OPTIONS}"
+		INTERFACE_INCLUDE_DIRECTORIES "${HarfBuzz_INCLUDE_DIR}"
+	)
+endif ()
+
+if (HarfBuzz_ICU_LIBRARY AND NOT TARGET HarfBuzz::ICU)
+	add_library(HarfBuzz::ICU UNKNOWN IMPORTED GLOBAL)
+	set_target_properties(HarfBuzz::ICU PROPERTIES
+		IMPORTED_LOCATION "${HarfBuzz_ICU_LIBRARY}"
+		INTERFACE_COMPILE_OPTIONS "${HarfBuzz_ICU_COMPILE_OPTIONS}"
+		INTERFACE_INCLUDE_DIRECTORIES "${HarfBuzz_INCLUDE_DIR}"
+	)
+endif ()
+
+mark_as_advanced(
+	HarfBuzz_INCLUDE_DIR
+	HarfBuzz_LIBRARY
+	HarfBuzz_ICU_LIBRARY
+)
+
+if (HarfBuzz_FOUND)
+	set(HarfBuzz_LIBRARIES ${HarfBuzz_LIBRARY} ${HarfBuzz_ICU_LIBRARY})
+	set(HarfBuzz_INCLUDE_DIRS ${HarfBuzz_INCLUDE_DIR})
+endif ()

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -163,6 +163,8 @@ else()
 			check_lib(GTK3 gtk+-3.0 gtk/gtk.h)
 			alias_library(GTK::gtk PkgConfig::GTK3)
 		endif()
+		## Use pcsx2 package to find module
+		find_package(HarfBuzz)
 		endif()
 	endif()
 	if(WAYLAND_API)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1572,6 +1572,7 @@ else()
 	if (NOT PCSX2_CORE)
 		target_link_libraries(PCSX2_FLAGS INTERFACE
 			GTK::gtk
+			HarfBuzz::HarfBuzz
 		)
 	endif()
 	target_link_libraries(PCSX2_FLAGS INTERFACE


### PR DESCRIPTION
### Description of Changes
With the changes of https://github.com/PCSX2/pcsx2/pull/5221/commits/3b317ff1a4bf51820f6b45645169060690954d3f the HarfBuzz opts have been removed, but Pango needs the includes as in https://github.com/PCSX2/pcsx2/issues/3079 if GTK3 is build with Pango support.

### Rationale behind Changes
- pango relies on HarfBuzz & pulls in its headers, if they are not found compilations fails.

```
FAILED: pcsx2/CMakeFiles/PCSX2.dir/PAD/Linux/InputManager.cpp.o 
/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -DENABLE_VULKAN -DFMT_LOCALE -DPCSX2_APP_DATADIR=\"../share/PCSX2\" -DPCSX2_APP_DOCDIR=\"../share/doc\" -DSDL_BUILD -DSPU2X_CUBEB -DSPU2X_PULSEAUDIO -DVULKAN_USE_X11=1 -DWXUSINGDLL -DX11_API -DXDG_STD -D_ARCH_64=1 -D_M_X86=1 -D_M_X86_64=1 -D__M_X86_64=1 -D__WXGTK3__ -D__WXGTK__ -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/.x86_64-libreelec-linux-gnu/pcsx2/PAD/Linux -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/pcsx2/. -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/pcsx2/x86 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/.x86_64-libreelec-linux-gnu/pcsx2 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/.x86_64-libreelec-linux-gnu/common/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/jpgd -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/xbyak -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/cubeb/cubeb/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/.x86_64-libreelec-linux-gnu/exports -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/common/../3rdparty/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/common/.. -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/vulkan-headers/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/glslang/glslang -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/glslang/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/glad/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/imgui/imgui -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/imgui/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/3rdparty/libchdr/libchdr/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/wx/include/gtk3-unicode-3.1 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/wx-3.1 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/SDL2 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/soundtouch -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gtk-3.0 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/pango-1.0 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/glib-2.0 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/glib-2.0/include -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/cairo -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gdk-pixbuf-2.0 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/atk-1.0 -I/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/libxml2 -march=x86-64 -m64 -mmmx -msse -msse2 -mfpmath=sse -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -pthread -O3 -DNDEBUG -fPIE -msse -msse2 -msse4.1 -mfxsr -pipe -fvisibility=hidden -pthread -fno-builtin-strcmp -fno-builtin-memcmp -mfpmath=sse -fno-operator-names -Wall -Wextra -Wno-attributes -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations -Wno-format -Wno-format-security -Wno-overloaded-virtual -Wno-unused-value -Wno-stringop-truncation -Wno-stringop-overflow -Wstrict-aliasing -Wstrict-overflow=1 -fno-strict-aliasing -Wno-parentheses -Wno-missing-braces -Wno-unknown-pragmas -DWX_PRECOMP -Wno-packed-not-aligned -Wno-class-memaccess -std=gnu++17 -Winvalid-pch -include /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/.x86_64-libreelec-linux-gnu/pcsx2/CMakeFiles/PCSX2.dir/cmake_pch.hxx -MD -MT pcsx2/CMakeFiles/PCSX2.dir/PAD/Linux/InputManager.cpp.o -MF pcsx2/CMakeFiles/PCSX2.dir/PAD/Linux/InputManager.cpp.o.d -o pcsx2/CMakeFiles/PCSX2.dir/PAD/Linux/InputManager.cpp.o -c /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/pcsx2/PAD/Linux/InputManager.cpp
In file included from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/pango-1.0/pango/pango-font.h:25,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/pango-1.0/pango/pango-attributes.h:25,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/pango-1.0/pango/pango.h:25,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gtk-3.0/gdk/gdktypes.h:35,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gtk-3.0/gdk/gdkapplaunchcontext.h:30,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gtk-3.0/gdk/gdk.h:32,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gtk-3.0/gtk/gtk.h:30,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/pcsx2/PAD/Linux/keyboard.h:38,
                 from /build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/build/pcsx2-f009d6f9e75e90e6242c571d4e5f4c4fc797fa45/pcsx2/PAD/Linux/InputManager.cpp:18:
/build/LibreELEC-RR/build.LibreELEC-x11.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/pango-1.0/pango/pango-coverage.h:28:10: fatal error: hb.h: No such file or directory
   28 | #include <hb.h>
      |          ^~~~~~
compilation terminated.
[461/675] Building CXX object pcsx2/CMakeFiles/PCSX2.dir/DEV9/ConfigUI.cpp.o
ninja: build stopped: subcommand failed.
```