### PR TITLE
GS-hw: Apply clamp/wrap when FBMask enabled

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -717,7 +717,7 @@ void ps_color_clamp_wrap(inout float3 C)
 {
 	// When dithering the bottom 3 bits become meaningless and cause lines in the picture
 	// so we need to limit the color depth on dithered items
-	if (SW_BLEND || PS_DITHER)
+	if (SW_BLEND || PS_DITHER || PS_FBMASK)
 	{
 		// Standard Clamp
 		if (PS_COLCLIP == 0 && PS_HDR == 0)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -633,7 +633,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 {
     // When dithering the bottom 3 bits become meaningless and cause lines in the picture
     // so we need to limit the color depth on dithered items
-#if SW_BLEND || PS_DITHER
+#if SW_BLEND || PS_DITHER || PS_FBMASK
 
     // Correct the Color value based on the output format
 #if PS_COLCLIP == 0 && PS_HDR == 0

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -966,7 +966,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 {
     // When dithering the bottom 3 bits become meaningless and cause lines in the picture
     // so we need to limit the color depth on dithered items
-#if SW_BLEND || PS_DITHER
+#if SW_BLEND || PS_DITHER || PS_FBMASK
 
     // Correct the Color value based on the output format
 #if PS_COLCLIP == 0 && PS_HDR == 0


### PR DESCRIPTION
### Description of Changes
Make sure any clamps (but most importantly 16bit colour masking) gets applied when FBMask is used.

### Rationale behind Changes
16 bit colours were incorrectly masked when FBMask was enabled, due to changes in #5471 it kind of made the problem rise to the surface and caused errors on Silent Hill 4, noticeable in the subway.

### Suggested Testing Steps
Test games which use 16bit colours (you can usually tell because they use Dithering)
