### PR TITLE
GS-hw: Increase 32->16bit conversion accuracy

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -114,15 +114,12 @@ float4 ps_scanlines(PS_INPUT input, int i)
 	return sample_c(input.t) * saturate(mask[i] + 0.5f);
 }
 
+// Need to be careful with precision here, it can break games like Spider-Man 3 and Dogs Life
 uint ps_convert_rgba8_16bits(PS_INPUT input) : SV_Target0
 {
-	float4 c = sample_c(input.t);
+	uint4 i = sample_c(input.t) * float4(255.5f, 255.5f, 255.5f, 255.5f);
 
-	c.a *= 256.0f / 127; // hm, 0.5 won't give us 1.0 if we just multiply with 2
-
-	uint4 i = c * float4(0x001f, 0x03e0, 0x7c00, 0x8000);
-
-	return (i.x & 0x001f) | (i.y & 0x03e0) | (i.z & 0x7c00) | (i.w & 0x8000);	
+	return ((i.x & 0x00F8u) >> 3) | ((i.y & 0x00F8u) << 2) | ((i.z & 0x00f8u) << 7) | ((i.w & 0x80u) << 8);
 }
 
 PS_OUTPUT ps_datm1(PS_INPUT input)

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -87,15 +87,12 @@ void ps_filter_transparency()
 #endif
 
 #ifdef ps_convert_rgba8_16bits
+// Need to be careful with precision here, it can break games like Spider-Man 3 and Dogs Life
 void ps_convert_rgba8_16bits()
 {
-	vec4 c = sample_c(v_tex);
+	highp uvec4 i = uvec4(sample_c(v_tex) * vec4(255.5f, 255.5f, 255.5f, 255.5f));
 
-	c.a *= 256.0f / 127; // hm, 0.5 won't give us 1.0 if we just multiply with 2
-
-	uvec4 i = uvec4(c * vec4(0x001f, 0x03e0, 0x7c00, 0x8000));
-
-	o_col0 = (i.x & 0x001fu) | (i.y & 0x03e0u) | (i.z & 0x7c00u) | (i.w & 0x8000u);	
+	o_col0 = ((i.x & 0x00F8u) >> 3) | ((i.y & 0x00F8u) << 2) | ((i.z & 0x00f8u) << 7) | ((i.w & 0x80u) << 8);
 }
 #endif
 


### PR DESCRIPTION


### Description of Changes
Increases the accuracy of colour conversion from 32bit to 16bit

Improves Dogs life (no longer goes completely black right away, but has decal problems)
Vastly improves texture quality in Spider-Man 3 when using Framebuffer Conversion to fix the textures

### Rationale behind Changes
Previous algorithm for converting textures from 32bit to 16bit was losing some colour information due to fractional amounts of data, this improves things greatly for the above listed games.

### Suggested Testing Steps
Test games which had incorrect colours/brightness for things or slightly glitchy textures (not completely screwed like True Crime levels of broken)
