### PR TITLE
Disable warnings on several third party libraries.

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -250,6 +250,7 @@ if(QT_BUILD)
 endif()
 
 add_subdirectory(3rdparty/libchdr/libchdr EXCLUDE_FROM_ALL)
+target_compile_options(chdr-static PRIVATE "-w")
 
 if(USE_NATIVE_TOOLS)
 	add_subdirectory(tools/bin2cpp EXCLUDE_FROM_ALL)
@@ -271,5 +272,7 @@ endif()
 
 if(CUBEB_API)
 	add_subdirectory(3rdparty/cubeb EXCLUDE_FROM_ALL)
+	target_compile_options(cubeb PRIVATE "-w")
+	target_compile_options(speex PRIVATE "-w")
 endif()
 


### PR DESCRIPTION
### Description of Changes
Disables warnings on chdr, cubeb, & speex. While Vulkan-Headers also spams warnings, my attempts to disable those warnings disabled all warnings in pcsx2, so I'm leaving those as is.

### Rationale behind Changes
Having warnings while compiling from third party libraries adds noise when looking for warnings from our project. I'd rather not make local changes to get rid of the warnings, and while putting in pull requests upsteam would ultimately be a good idea, there's no telling when or if they would be approved.

### Suggested Testing Steps
Make sure pcsx2 compiles successfully, with less errors.
