### PR TITLE
Core: Export recompiler offsets

### DIFF
--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -331,7 +331,13 @@ static wxString GetMemoryErrorVM()
 
 namespace HostMemoryMap {
 	// For debuggers
-	uptr EEmem, IOPmem, VUmem, EErec, IOPrec, VIF0rec, VIF1rec, mVU0rec, mVU1rec, bumpAllocator;
+	extern "C" {
+#ifdef _WIN32
+	_declspec(dllexport) uptr EEmem, IOPmem, VUmem, EErec, IOPrec, VIF0rec, VIF1rec, mVU0rec, mVU1rec, bumpAllocator;
+#else
+	__attribute__((visibility("default"), used)) uptr EEmem, IOPmem, VUmem, EErec, IOPrec, VIF0rec, VIF1rec, mVU0rec, mVU1rec, bumpAllocator;
+#endif
+	}
 }
 
 /// Attempts to find a spot near static variables for the main memory


### PR DESCRIPTION
### Description of Changes
Exports the recompiler base addresses as unmangled symbols that can be read by other third party tools.
Inspired by how we export NVidia Optimus and Amd PowerXPress settings in optimus.cpp.

### Rationale behind Changes
Some people don't want to use pine, and our base addresses are not fixed anymore.

### Suggested Testing Steps
You can use this:
https://github.com/F0bes/pcsx2_offsetreader/releases/tag/v1.0.0

The source for the above is here. It works when both PCSX2 and itself is 64 bit. I'm no win32 expert so it might be sloppy lol.
https://github.com/F0bes/pcsx2_offsetreader

Please no drama if this doesn't go through <3

Related: #3638 #3644 