### PR TITLE
SPU2: Don't cap pitch setting on register write.

### DIFF
--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -328,6 +328,7 @@ static void __forceinline UpdatePitch(uint coreidx, uint voiceidx)
 	else
 		pitch = GetClamped((vc.Pitch * (32768 + Cores[coreidx].Voices[voiceidx - 1].OutX)) >> 15, 0, 0x3fff);
 
+	pitch = std::min(pitch, 0x3FFF);
 	vc.SP += pitch;
 }
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -662,9 +662,7 @@ void V_Core::WriteRegPS1(u32 mem, u16 value)
 				break;
 			}
 			case 0x4:
-				if (value > 0x3fff)
-					ConLog("* SPU2: Pitch setting too big: 0x%x\n", value);
-				Voices[voice].Pitch = value & 0x3fff;
+				Voices[voice].Pitch = value;
 				//ConLog("voice %x Pitch write: %x\n", voice, Voices[voice].Pitch);
 				break;
 			case 0x6:
@@ -1160,9 +1158,7 @@ static void __fastcall RegWrite_VoiceParams(u16 value)
 		break;
 
 		case 2:
-			if (value > 0x3fff)
-				ConLog("* SPU2: Pitch setting too big: 0x%x\n", value);
-			thisvoice.Pitch = value & 0x3fff;
+			thisvoice.Pitch = value;
 			break;
 
 		case 3: // ADSR1 (Envelope)


### PR DESCRIPTION
While 0x3FFF is indeed the highest playable pitch I think that the
register is 16 bits wide and that the cap is enforced by the pitch
counter algorithm.

This fixes the air time ticking sound in Jak X.

### Suggested Testing Steps
Test to make sure there where no adverse affects in other titles, this code is used by everything.