### PR TITLE
[WIP] GS: improve write overlap detection in TC.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -302,7 +302,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 					break;
 				}
 				else if (GSConfig.UserHacks_TextureInsideRt && psm == PSM_PSMCT32 && t->m_TEX0.PSM == psm &&
-					((t->m_TEX0.TBP0 < bp && t->m_end_block >= bp) || t_wraps))
+					((t->m_TEX0.TBP0 <= bp && t->m_end_block >= bp) || t_wraps))
 				{
 					// Only PSMCT32 to limit false hits.
 					// PSM equality needed because CreateSource does not handle PSM conversion.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -355,8 +355,8 @@ public:
 	void PrintMemoryUsage();
 
 	void AttachPaletteToSource(Source* s, u16 pal, bool need_gs_texture);
-	SurfaceOffset ComputeSurfaceOffset(const GSOffset& off, const GSVector4i& r, const Target* t);
-	SurfaceOffset ComputeSurfaceOffset(const uint32_t bp, const uint32_t bw, const uint32_t psm, const GSVector4i& r, const Target* t);
+	SurfaceOffset ComputeSurfaceOffset(const GSOffset& off, const GSVector4i& r, const Target* t, bool& out_t_needs_udpate);
+	SurfaceOffset ComputeSurfaceOffset(const uint32_t bp, const uint32_t bw, const uint32_t psm, const GSVector4i& r, const Target* t, bool& out_t_needs_udpate);
 	SurfaceOffset ComputeSurfaceOffset(const SurfaceOffsetKey& sok);
 
 	/// Invalidates a temporary source, a partial copy only created from the current RT/DS for the current draw.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -187,12 +187,20 @@ public:
 		bool ClutMatch(const PaletteKey& palette_key);
 	};
 
+	struct SurfaceOffsetKeyElem
+	{
+		u32 psm;
+		u32 bp;
+		u32 bw;
+		GSVector4i rect;
+	};
+
 	class Target : public Surface
 	{
 	public:
 		const int m_type;
 		bool m_used;
-		GSDirtyRectList m_dirty;
+		std::vector<SurfaceOffsetKeyElem> m_dirty;
 		GSVector4i m_valid;
 		const bool m_depth_supported;
 		bool m_dirty_alpha;
@@ -201,11 +209,6 @@ public:
 		Target(const GIFRegTEX0& TEX0, const bool depth_supported, const int type);
 
 		void UpdateValidity(const GSVector4i& rect);
-
-		void Update();
-
-		/// Updates the target, if the dirty area intersects with the specified rectangle.
-		void UpdateIfDirtyIntersects(const GSVector4i& rc);
 	};
 
 	class PaletteMap
@@ -263,14 +266,6 @@ public:
 
 		u32 height;
 		u32 age;
-	};
-
-	struct SurfaceOffsetKeyElem
-	{
-		u32 psm;
-		u32 bp;
-		u32 bw;
-		GSVector4i rect;
 	};
 
 	struct SurfaceOffsetKey
@@ -369,4 +364,7 @@ public:
 
 	/// Injects a texture into the hash cache, by using GSTexture::Swap(), transitively applying to all sources. Ownership of tex is transferred.
 	void InjectHashCacheTexture(const HashCacheKey& key, GSTexture* tex);
+
+	void UpdateTarget(GSTextureCache::Target* target);
+	void UpdateTargetIfDirtyIntersects(GSTextureCache::Target* target, const GSTextureCache::SurfaceOffsetKeyElem& soke);
 };


### PR DESCRIPTION
### Description of Changes

Please, consider this WIP.

Improve the write overlap detection in GS HW TC.
Avoid overwriting target FBW on EE write.
Allow dirty rectangles to overlap tex in rt search (update target if needed).
Rewrite target update logic to preserve EE writes mapping with underlying GS memory region (EE write and target can have different BW).
Allow tex in rt logic to be applied on same BP case (this enables more accurate dirty target and wrapping targets handling, even if the resulting offset, if valid, will start from 0,0).

Fixes #5530.
Fixes #4858.
Fixes Indiana Jones and the Emperor's Tomb map.


### Rationale behind Changes
In Jak X, if the initial FMV is skipped before the Naughty Dog logo is shown, the writes for the X of the Jak X logo and the split screen config occur in the middle of an existing target.
Before this PR those writes were not correctly registered, causing a missing update of the texture which resulted in black X and black split screens.


### Suggested Testing Steps
Test Jak X, check the X of the Jak X logo and the split screen when skipping the initial FMV.
Do generic testing for other games.