### PR TITLE
Qt: Resize default headersize BIOS + Adding 4 new themes

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -252,6 +252,125 @@ void MainWindow::setStyleFromSettings()
 		qApp->setStyleSheet(QString());
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 	}
+	else if (theme == "UntouchedLagoon")
+	{
+		// Custom pallete by RedDevilus, Tame (Light/Washed out) Green as main color and Grayish Blue as complimentary.
+		// Alternative white theme.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor lighterGray(75, 75, 75);
+		const QColor darkGray(53, 53, 53);
+		const QColor gray(128, 128, 128);
+		const QColor black(25, 25, 25);
+		const QColor teal(0, 128, 128);	
+		const QColor tameTeal(160, 190, 185);
+		const QColor grayBlue(160, 180, 190);
+
+		QPalette standardPalette;
+		standardPalette.setColor(QPalette::Window, tameTeal);
+		standardPalette.setColor(QPalette::WindowText, black);
+		standardPalette.setColor(QPalette::Base, grayBlue);
+		standardPalette.setColor(QPalette::AlternateBase, tameTeal);
+		standardPalette.setColor(QPalette::ToolTipBase, tameTeal);
+		standardPalette.setColor(QPalette::ToolTipText, grayBlue);
+		standardPalette.setColor(QPalette::Text, black);
+		standardPalette.setColor(QPalette::Button, tameTeal);
+		standardPalette.setColor(QPalette::ButtonText, Qt::white);
+		standardPalette.setColor(QPalette::Link, tameTeal);
+		standardPalette.setColor(QPalette::Highlight, teal);
+		standardPalette.setColor(QPalette::HighlightedText, Qt::white);
+
+		standardPalette.setColor(QPalette::Active, QPalette::Button, tameTeal.darker());
+		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::white);
+		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, Qt::white);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, Qt::white);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Light, tameTeal);
+
+		qApp->setPalette(standardPalette);
+
+		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+	}
+	else if (theme == "BabyPastel")
+	{
+		// Custom pallete by RedDevilus, Blue as main color and blue as complimentary.
+		// Alternative light theme.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor lighterGray(75, 75, 75);
+		const QColor gray(150, 150, 150);
+		const QColor black(25, 25, 25);
+		const QColor darkPink(180, 80, 200);
+		const QColor pink(255, 174, 201);
+		const QColor brightPink(255, 230, 255);
+		const QColor congoPink(255, 127, 121);
+		const QColor yellow(255, 235, 180);
+		const QColor darkGreen(161, 240, 183);
+		const QColor green(221, 239, 226);
+		const QColor blue(221, 225, 239);
+		const QColor darkBlue(100, 95, 250);
+
+		QPalette standardPalette;
+		standardPalette.setColor(QPalette::Window, pink);
+		standardPalette.setColor(QPalette::WindowText, black);
+		standardPalette.setColor(QPalette::Base, brightPink);
+		standardPalette.setColor(QPalette::AlternateBase, blue);
+		standardPalette.setColor(QPalette::ToolTipBase, pink);
+		standardPalette.setColor(QPalette::ToolTipText, brightPink);
+		standardPalette.setColor(QPalette::Text, black);
+		standardPalette.setColor(QPalette::Button, pink);
+		standardPalette.setColor(QPalette::ButtonText, black);
+		standardPalette.setColor(QPalette::Link, congoPink);
+		standardPalette.setColor(QPalette::Highlight, congoPink);
+		standardPalette.setColor(QPalette::HighlightedText, black);
+
+		standardPalette.setColor(QPalette::Active, QPalette::Button, pink);
+		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray);
+		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, congoPink);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, blue);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Light, gray);
+
+		qApp->setPalette(standardPalette);
+
+		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+	}
+	else if (theme == "PCSX2Blue")
+	{
+		// Custom pallete by RedDevilus, White as main color and Blue as complimentary.
+		// Alternative light theme.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor lighterGray(75, 75, 75);
+		const QColor gray(128, 128, 128);
+		const QColor black(25, 25, 25);
+		const QColor darkBlue(73, 97, 177);
+		const QColor blue(106, 156, 255);
+		const QColor lightBlue(130, 155, 241);
+		const QColor brightBlue(164, 184, 255);
+
+		QPalette standardPalette;
+		standardPalette.setColor(QPalette::Window, lightBlue);
+		standardPalette.setColor(QPalette::WindowText, black);
+		standardPalette.setColor(QPalette::Base, darkBlue);
+		standardPalette.setColor(QPalette::AlternateBase, lightBlue);
+		standardPalette.setColor(QPalette::ToolTipBase, lightBlue);
+		standardPalette.setColor(QPalette::ToolTipText, Qt::white);
+		standardPalette.setColor(QPalette::Text, Qt::white);
+		standardPalette.setColor(QPalette::Button, blue);
+		standardPalette.setColor(QPalette::ButtonText, Qt::white);
+		standardPalette.setColor(QPalette::Link, blue);
+		standardPalette.setColor(QPalette::Highlight, Qt::white);
+		standardPalette.setColor(QPalette::HighlightedText, black);
+
+		standardPalette.setColor(QPalette::Active, QPalette::Button, blue.darker());
+		standardPalette.setColor(QPalette::Disabled, QPalette::ButtonText, darkBlue);
+		standardPalette.setColor(QPalette::Disabled, QPalette::WindowText, darkBlue);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Text, black);
+		standardPalette.setColor(QPalette::Disabled, QPalette::Light, darkBlue);
+
+		qApp->setPalette(standardPalette);
+
+		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+	}
 	else if (theme == "darkfusion")
 	{
 		// adapted from https://gist.github.com/QuantumCD/6245215
@@ -323,6 +442,43 @@ void MainWindow::setStyleFromSettings()
 
 		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
 	}
+	else if (theme == "ScarletDevilRed")
+	{
+		// Custom pallete by RedDevilus, Red as main color and Purple as complimentary.
+		// Alternative dark theme.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor lighterGray(75, 75, 75);
+		const QColor gray(128, 128, 128);
+		const QColor black(25, 25, 25);
+		const QColor darkRed(80, 45, 69);
+		const QColor purplishRed(120, 45, 69);
+		const QColor brightRed(200, 45, 69);
+
+		QPalette darkPalette;
+		darkPalette.setColor(QPalette::Window, darkRed);
+		darkPalette.setColor(QPalette::WindowText, Qt::white);
+		darkPalette.setColor(QPalette::Base, purplishRed);
+		darkPalette.setColor(QPalette::AlternateBase, darkRed);
+		darkPalette.setColor(QPalette::ToolTipBase, darkRed);
+		darkPalette.setColor(QPalette::ToolTipText, Qt::white);
+		darkPalette.setColor(QPalette::Text, Qt::white);
+		darkPalette.setColor(QPalette::Button, darkRed);
+		darkPalette.setColor(QPalette::ButtonText, Qt::white);
+		darkPalette.setColor(QPalette::Link, darkRed);
+		darkPalette.setColor(QPalette::Highlight, brightRed);
+		darkPalette.setColor(QPalette::HighlightedText, Qt::white);
+
+		darkPalette.setColor(QPalette::Active, QPalette::Button, purplishRed.darker());
+		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, brightRed);
+		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, brightRed);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Text, brightRed);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Light, darkRed);
+
+		qApp->setPalette(darkPalette);
+
+		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+	}
 	else
 	{
 		qApp->setPalette(QApplication::style()->standardPalette());
@@ -336,7 +492,7 @@ void MainWindow::setIconThemeFromSettings()
 	const std::string theme(QtHost::GetBaseStringSettingValue("UI", "Theme", DEFAULT_THEME_NAME));
 	QString icon_theme;
 
-	if (theme == "darkfusion" || theme == "darkfusionblue")
+	if (theme == "darkfusion" || theme == "darkfusionblue" || theme == "dualtoneOrangeBlue" || theme == "ScarletDevilRed")
 		icon_theme = QStringLiteral("white");
 	else
 		icon_theme = QStringLiteral("black");

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -108,6 +108,12 @@
         <property name="rootIsDecorated">
          <bool>false</bool>
         </property>
+        <attribute name="headerMinimumSectionSize">
+         <number>250</number>
+        </attribute>
+        <attribute name="headerDefaultSectionSize">
+         <number>250</number>
+        </attribute>
         <column>
          <property name="text">
           <string>Filename</string>

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -20,12 +20,17 @@
 #include "SettingWidgetBinder.h"
 #include "SettingsDialog.h"
 
-static const char* THEME_NAMES[] = {QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Native"),
-	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Fusion"),
-	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Dark Fusion (Gray)"),
-	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Dark Fusion (Blue)"), nullptr};
+static const char* THEME_NAMES[] = {QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Native [Light]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Fusion [Light]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Dark Fusion (Gray) [Dark]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Dark Fusion (Blue) [Dark]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Untouched Lagoon (Grayish Green/-Blue ) [Light]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Baby Pastel (Pink) [Light]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "PCSX2 (White/Blue) [Light]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Scarlet Devil (Red/Purple) [Dark]"), nullptr};
 
-static const char* THEME_VALUES[] = {"", "fusion", "darkfusion", "darkfusionblue", nullptr};
+static const char* THEME_VALUES[] = {"", "fusion", "darkfusion", "darkfusionblue", 
+	"UntouchedLagoon", "BabyPastel", "PCSX2Blue", "ScarletDevilRed", nullptr};
 
 InterfaceSettingsWidget::InterfaceSettingsWidget(QWidget* parent, SettingsDialog* dialog)
 	: QWidget(parent)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
![image](https://user-images.githubusercontent.com/24227051/154299997-4c92fdf6-3341-4b56-ba4f-af34370b8c06.png)

Theme 1 (Untouched Lagoon - Light):
![image](https://user-images.githubusercontent.com/24227051/154374475-ae8d669f-a227-40c6-b0b4-9cdbe4479cee.png)

Theme 2 (Baby Pastel - Light):
![image](https://user-images.githubusercontent.com/24227051/154536791-2ffba9cf-a7ab-4328-8b26-a2dd259aec45.png)

Theme 3 (PCSX2 - Light):
![Theme4PCSX2Blue](https://user-images.githubusercontent.com/24227051/154374313-1a218fec-1ebf-4a55-a107-a89e20017c3b.png)

Theme 4 (Scarlet Devil - Dark):
![image](https://user-images.githubusercontent.com/24227051/154374579-605f9a6a-04d3-438e-921e-afb0f1f2c058.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
The BIOS width looked off visually for an enduser. Also adding color themes will add some personality and choice for all sorts of people along with 2 color themes for colorblind people.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Get the Qt build and test the themes. Not really concerned with how the BIOS selector looks.