### PR TITLE
GS: Add hash based texture cache

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -133,7 +133,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.accurateDATE, "EmuCore/GS", "accurate_date", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.conservativeBufferAllocation, "EmuCore/GS", "conservative_framebuffer", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.preloadTexture, "EmuCore/GS", "preload_texture", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.texturePreloading, "EmuCore/GS", "texture_preloading",
+		static_cast<int>(TexturePreloadingLevel::Off));
 
 	//////////////////////////////////////////////////////////////////////////
 	// HW Renderer Fixes

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -560,12 +560,12 @@
          </item>
         </widget>
        </item>
-       <item row="8" column="0" colspan="2">
+       <item row="9" column="0" colspan="2">
         <layout class="QGridLayout" name="basicCheckboxGridLayout">
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="accurateDATE">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="gpuPaletteConversion">
            <property name="text">
-            <string>Accurate Destination Alpha Test</string>
+            <string>GPU Palette Conversion</string>
            </property>
           </widget>
          </item>
@@ -576,21 +576,14 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="gpuPaletteConversion">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="accurateDATE">
            <property name="text">
-            <string>GPU Palette Conversion</string>
+            <string>Accurate Destination Alpha Test</string>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QCheckBox" name="preloadTexture">
-           <property name="text">
-            <string>Preload Textures</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
           <widget class="QCheckBox" name="enableHWFixes">
            <property name="text">
             <string>Enable Hardware Renderer Fixes</string>
@@ -598,6 +591,32 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_20">
+         <property name="text">
+          <string>Texture Preloading:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QComboBox" name="texturePreloading">
+         <item>
+          <property name="text">
+           <string>None</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Partial</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Full (Hash Cache)</string>
+          </property>
+         </item>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -179,6 +179,13 @@ enum class AccBlendLevel : u8
 	Ultra,
 };
 
+enum class TexturePreloadingLevel : u8
+{
+	Off,
+	Partial,
+	Full,
+};
+
 // Template function for casting enumerations to their underlying type
 template <typename Enumeration>
 typename std::underlying_type<Enumeration>::type enum_cast(Enumeration E)
@@ -450,8 +457,7 @@ struct Pcsx2Config
 					SaveRT : 1,
 					SaveFrame : 1,
 					SaveTexture : 1,
-					SaveDepth : 1,
-					PreloadTexture : 1;
+					SaveDepth : 1;
 			};
 		};
 
@@ -490,6 +496,7 @@ struct Pcsx2Config
 		AccBlendLevel AccurateBlendingUnit{AccBlendLevel::Basic};
 		CRCHackLevel CRCHack{CRCHackLevel::Automatic};
 		BiFiltering TextureFiltering{BiFiltering::PS2};
+		TexturePreloadingLevel TexturePreloading{TexturePreloadingLevel::Off};
 		int Dithering{2};
 		int MaxAnisotropy{0};
 		int SWExtraThreads{2};

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -679,14 +679,29 @@ void GSgetStats(std::string& info)
 	}
 	else
 	{
-		info = format("%s HW | %d P | %d D | %d DC | %d RB | %d TC | %d TU",
-			api_name,
-			(int)pm.Get(GSPerfMon::Prim),
-			(int)pm.Get(GSPerfMon::Draw),
-			(int)std::ceil(pm.Get(GSPerfMon::DrawCalls)),
-			(int)std::ceil(pm.Get(GSPerfMon::Readbacks)),
-			(int)std::ceil(pm.Get(GSPerfMon::TextureCopies)),
-			(int)std::ceil(pm.Get(GSPerfMon::TextureUploads)));
+		if (GSConfig.TexturePreloading == TexturePreloadingLevel::Full)
+		{
+			info = format("%s HW | HC: %d MB | %d P | %d D | %d DC | %d RB | %d TC | %d TU",
+				api_name,
+				(int)std::ceil(static_cast<GSRendererHW*>(s_gs.get())->GetTextureCache()->GetHashCacheMemoryUsage() / 1048576.0f),
+				(int)pm.Get(GSPerfMon::Prim),
+				(int)pm.Get(GSPerfMon::Draw),
+				(int)std::ceil(pm.Get(GSPerfMon::DrawCalls)),
+				(int)std::ceil(pm.Get(GSPerfMon::Readbacks)),
+				(int)std::ceil(pm.Get(GSPerfMon::TextureCopies)),
+				(int)std::ceil(pm.Get(GSPerfMon::TextureUploads)));
+		}
+		else
+		{
+			info = format("%s HW | %d P | %d D | %d DC | %d RB | %d TC | %d TU",
+				api_name,
+				(int)pm.Get(GSPerfMon::Prim),
+				(int)pm.Get(GSPerfMon::Draw),
+				(int)std::ceil(pm.Get(GSPerfMon::DrawCalls)),
+				(int)std::ceil(pm.Get(GSPerfMon::Readbacks)),
+				(int)std::ceil(pm.Get(GSPerfMon::TextureCopies)),
+				(int)std::ceil(pm.Get(GSPerfMon::TextureUploads)));
+		}
 	}
 }
 

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -798,6 +798,7 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 
 	// reload texture cache when trilinear filtering or mipmap options change
 	if (GSConfig.HWMipmap != old_config.HWMipmap ||
+		GSConfig.TexturePreloading != old_config.TexturePreloading ||
 		GSConfig.UserHacks_TriFilter != old_config.UserHacks_TriFilter ||
 		GSConfig.GPUPaletteConversion != old_config.GPUPaletteConversion)
 	{
@@ -1208,6 +1209,10 @@ void GSApp::Init()
 	m_gs_trifilter.push_back(GSSetting(static_cast<u32>(TriFiltering::PS2), "Trilinear", ""));
 	m_gs_trifilter.push_back(GSSetting(static_cast<u32>(TriFiltering::Forced), "Trilinear", "Ultra/Slow"));
 
+	m_gs_texture_preloading.push_back(GSSetting(static_cast<u32>(TexturePreloadingLevel::Off), "None", "Default"));
+	m_gs_texture_preloading.push_back(GSSetting(static_cast<u32>(TexturePreloadingLevel::Partial), "Partial", ""));
+	m_gs_texture_preloading.push_back(GSSetting(static_cast<u32>(TexturePreloadingLevel::Full), "Full", "Hash Cache"));
+
 	m_gs_generic_list.push_back(GSSetting(-1, "Automatic", "Default"));
 	m_gs_generic_list.push_back(GSSetting(0, "Force-Disabled", ""));
 	m_gs_generic_list.push_back(GSSetting(1, "Force-Enabled", ""));
@@ -1321,7 +1326,6 @@ void GSApp::Init()
 	m_default_configuration["paltex"]                                     = "0";
 	m_default_configuration["png_compression_level"]                      = std::to_string(Z_BEST_SPEED);
 	m_default_configuration["preload_frame_with_gs_data"]                 = "0";
-	m_default_configuration["preload_texture"]                            = "0";
 	m_default_configuration["Renderer"]                                   = std::to_string(static_cast<int>(GSRendererType::Auto));
 	m_default_configuration["resx"]                                       = "1024";
 	m_default_configuration["resy"]                                       = "1024";
@@ -1339,6 +1343,7 @@ void GSApp::Init()
 	m_default_configuration["shaderfx_conf"]                              = "shaders/GS_FX_Settings.ini";
 	m_default_configuration["shaderfx_glsl"]                              = "shaders/GS.fx";
 	m_default_configuration["skip_duplicate_frames"]                      = "0";
+	m_default_configuration["texture_preloading"]                         = "0";
 	m_default_configuration["ThreadedPresentation"]                       = "0";
 	m_default_configuration["throttle_present_rate"]                      = "0";
 	m_default_configuration["TVShader"]                                   = "0";

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -133,6 +133,7 @@ public:
 	std::vector<GSSetting> m_gs_dithering;
 	std::vector<GSSetting> m_gs_bifilter;
 	std::vector<GSSetting> m_gs_trifilter;
+	std::vector<GSSetting> m_gs_texture_preloading;
 	std::vector<GSSetting> m_gs_hack;
 	std::vector<GSSetting> m_gs_generic_list;
 	std::vector<GSSetting> m_gs_offset_hack;

--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -110,13 +110,24 @@ static const GSVector2i default_rt_size(2048, 2048);
 static const GSVector2i default_rt_size(0, 0);
 #endif
 
+extern Pcsx2Config::GSOptions GSConfig;
+
 // Maximum texture size to skip preload/hash path.
 // This is the width/height from the registers, i.e. not the power of 2.
+__fi static bool CanCacheTextureSize(u32 tw, u32 th)
+{
+	static constexpr u32 MAXIMUM_CACHE_SIZE = 10; // 1024
+	return (GSConfig.TexturePreloading == TexturePreloadingLevel::Full && tw <= MAXIMUM_CACHE_SIZE && th <= MAXIMUM_CACHE_SIZE);
+}
+
 __fi static bool CanPreloadTextureSize(u32 tw, u32 th)
 {
 	static constexpr u32 MAXIMUM_SIZE_IN_ONE_DIRECTION = 10; // 1024
 	static constexpr u32 MAXIMUM_SIZE_IN_OTHER_DIRECTION = 8; // 256
 	static constexpr u32 MAXIMUM_SIZE_IN_BOTH_DIRECTIONS = 9; // 512
+
+	if (GSConfig.TexturePreloading < TexturePreloadingLevel::Partial)
+		return false;
 
 	// We use an area-based approach here. We want to hash long font maps,
 	// like 128x1024 (used in FFX), but skip 1024x512 textures (e.g. Xenosaga).

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -217,7 +217,6 @@ protected:
 	bool IsOpaque();
 	bool IsMipMapDraw();
 	bool IsMipMapActive();
-	GIFRegTEX0 GetTex0Layer(u32 lod);
 
 public:
 	GIFPath m_path[4];
@@ -303,4 +302,5 @@ public:
 	void SetFrameSkip(int skip);
 
 	PRIM_OVERLAP PrimitiveOverlap();
+	GIFRegTEX0 GetTex0Layer(u32 lod);
 };

--- a/pcsx2/GS/Renderers/Common/GSTexture.h
+++ b/pcsx2/GS/Renderers/Common/GSTexture.h
@@ -137,5 +137,5 @@ public:
 	float OffsetHack_mody;
 
 	// Typical size of a RGBA texture
-	virtual u32 GetMemUsage() { return m_size.x * m_size.y * 4; }
+	virtual u32 GetMemUsage() { return m_size.x * m_size.y * (m_format == Format::UNorm8 ? 1 : 4); }
 };

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -204,8 +204,9 @@ void GSRendererHW::SetGameCRC(u32 crc, int options)
 	m_hacks.SetGameCRC(m_game);
 
 	// Code for Automatic Mipmapping. Relies on game CRCs.
-	m_mipmap = (GSConfig.HWMipmap >= HWMipmapLevel::Basic);
-	if (GSConfig.HWMipmap == HWMipmapLevel::Automatic)
+	m_hw_mipmap = GSConfig.HWMipmap;
+	m_mipmap = (m_hw_mipmap >= HWMipmapLevel::Basic);
+	if (m_hw_mipmap == HWMipmapLevel::Automatic)
 	{
 		switch (CRC::Lookup(crc).title)
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -17,6 +17,7 @@
 
 #include "GSTextureCache.h"
 #include "GS/Renderers/Common/GSFunctionMap.h"
+#include "GS/Renderers/Common/GSRenderer.h"
 #include "GS/GSState.h"
 
 class GSRendererHW : public GSRenderer

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -164,6 +164,8 @@ public:
 	GSRendererHW();
 	virtual ~GSRendererHW() override;
 
+	__fi GSTextureCache* GetTextureCache() const { return m_tc; }
+
 	void Destroy() override;
 
 	void SetGameCRC(u32 crc, int options) override;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -19,6 +19,8 @@
 #include "GS/GSGL.h"
 #include "GS/GSIntrin.h"
 #include "GS/GSUtil.h"
+#include "common/Align.h"
+#include "common/HashCombine.h"
 
 #define XXH_STATIC_LINKING_ONLY 1
 #define XXH_INLINE_ALL 1
@@ -26,6 +28,7 @@
 
 bool GSTextureCache::m_disable_partial_invalidation = false;
 bool GSTextureCache::m_wrap_gs_mem = false;
+u8* GSTextureCache::m_temp;
 
 GSTextureCache::GSTextureCache(GSRenderer* r)
 	: m_renderer(r)
@@ -94,6 +97,10 @@ void GSTextureCache::RemoveAll()
 		m_dst[type].clear();
 	}
 
+	for (auto it : m_hash_cache)
+		g_gs_device->Recycle(it.second.texture);
+	m_hash_cache.clear();
+
 	m_palette_map.Clear();
 }
 
@@ -155,7 +162,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 			TEX0.TBP0, psm_str(psm));
 
 		// Create a shared texture source
-		src = new Source(m_renderer, TEX0, TEXA, m_temp, true);
+		src = new Source(m_renderer, TEX0, TEXA, true);
 		src->m_texture = dst->m_texture;
 		src->m_shared_texture = true;
 		src->m_target = true; // So renderer can check if a conversion is required
@@ -746,7 +753,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 
 				if (!s->m_target)
 				{
-					if (m_disable_partial_invalidation && s->m_repeating)
+					if (s->m_from_hash_cache || (m_disable_partial_invalidation && s->m_repeating))
 					{
 						m_src.RemoveAt(s);
 					}
@@ -1119,6 +1126,21 @@ void GSTextureCache::IncAge()
 		}
 	}
 
+	const u32 max_hash_cache_age = 30;
+	for (auto it = m_hash_cache.begin(); it != m_hash_cache.end();)
+	{
+		HashCacheEntry& e = it->second;
+		if (e.refcount == 0 && ++e.age > max_hash_cache_age)
+		{
+			g_gs_device->Recycle(e.texture);
+			m_hash_cache.erase(it++);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
 	m_src.m_used = false;
 
 	// Clearing of Rendertargets causes flickering in many scene transitions.
@@ -1165,7 +1187,7 @@ void GSTextureCache::IncAge()
 GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* dst, bool half_right, int x_offset, int y_offset, bool mipmap)
 {
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
-	Source* src = new Source(m_renderer, TEX0, TEXA, m_temp);
+	Source* src = new Source(m_renderer, TEX0, TEXA, false);
 
 	int tw = 1 << TEX0.TW;
 	int th = 1 << TEX0.TH;
@@ -1426,7 +1448,37 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	}
 	else
 	{
-		if (GSConfig.GPUPaletteConversion && psm.pal > 0)
+		// try the hash cache
+		if (!mipmap && CanCacheTextureSize(TEX0.TW, TEX0.TH))
+		{
+			const bool paltex = (GSConfig.GPUPaletteConversion && psm.pal > 0);
+			const u32* clut = (!paltex && psm.pal > 0) ? static_cast<const u32*>(m_renderer->m_mem.m_clut) : nullptr;
+			const HashCacheKey key{ HashCacheKey::Create(TEX0, TEXA, m_renderer, clut) };
+
+			auto it = m_hash_cache.find(key);
+			if (it == m_hash_cache.end())
+			{
+				// hash and upload texture
+				src->m_texture = g_gs_device->CreateTexture(tw, th, paltex ? false : mipmap, paltex ? GSTexture::Format::UNorm8 : GSTexture::Format::Color);
+				PreloadTexture(TEX0, TEXA, m_renderer->m_mem, paltex, src->m_texture, 0);
+
+				// insert it into the hash cache
+				HashCacheEntry entry{ src->m_texture, 1, 0 };
+				it = m_hash_cache.emplace(key, entry).first;
+			}
+			else
+			{
+				// use existing texture
+				src->m_texture = it->second.texture;
+				it->second.refcount++;
+			}
+
+			src->m_from_hash_cache = &it->second;
+
+			if (psm.pal > 0)
+				AttachPaletteToSource(src, psm.pal, paltex);
+		}
+		else if (GSConfig.GPUPaletteConversion && psm.pal > 0)
 		{
 			src->m_texture = g_gs_device->CreateTexture(tw, th, false, GSTexture::Format::UNorm8);
 			AttachPaletteToSource(src, psm.pal, true);
@@ -1452,7 +1504,7 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int
 {
 	ASSERT(type == RenderTarget || type == DepthStencil);
 
-	Target* t = new Target(m_renderer, TEX0, m_temp, m_can_convert_depth, type);
+	Target* t = new Target(m_renderer, TEX0, m_can_convert_depth, type);
 
 	// FIXME: initial data should be unswizzled from local mem in Update() if dirty
 
@@ -1605,11 +1657,11 @@ void GSTextureCache::PrintMemoryUsage()
 
 // GSTextureCache::Surface
 
-GSTextureCache::Surface::Surface(GSRenderer* r, u8* temp)
+GSTextureCache::Surface::Surface(GSRenderer* r)
 	: m_renderer(r)
 	, m_texture(NULL)
+	, m_from_hash_cache(NULL)
 	, m_age(0)
-	, m_temp(temp)
 	, m_32_bits_fmt(false)
 	, m_shared_texture(false)
 	, m_end_block(0)
@@ -1621,7 +1673,7 @@ GSTextureCache::Surface::~Surface()
 {
 	// Shared textures are pointers copy. Therefore no allocation
 	// to recycle.
-	if (!m_shared_texture && m_texture)
+	if (!m_shared_texture && !m_from_hash_cache && m_texture)
 		g_gs_device->Recycle(m_texture);
 }
 
@@ -1647,8 +1699,8 @@ bool GSTextureCache::Surface::Overlaps(u32 bp, u32 bw, u32 psm, const GSVector4i
 
 // GSTextureCache::Source
 
-GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, u8* temp, bool dummy_container)
-	: Surface(r, temp)
+GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, bool dummy_container)
+	: Surface(r)
 	, m_palette_obj(nullptr)
 	, m_palette(nullptr)
 	, m_valid_rect(0, 0)
@@ -1699,7 +1751,7 @@ void GSTextureCache::Source::Update(const GSVector4i& rect, int level)
 {
 	Surface::UpdateAge();
 
-	if (m_target || (m_complete_layers & (1u << level)))
+	if (m_target || m_from_hash_cache || (m_complete_layers & (1u << level)))
 		return;
 
 	if (CanPreload())
@@ -1906,28 +1958,6 @@ void GSTextureCache::Source::Flush(u32 count, int layer)
 	m_write.count -= count;
 }
 
-using BlockHashState = XXH3_state_t;
-
-__fi static void BlockHashReset(BlockHashState& st)
-{
-	XXH3_64bits_reset(&st);
-}
-
-__fi static void BlockHashAccumulate(BlockHashState& st, const u8* bp)
-{
-	XXH3_64bits_update(&st, bp, BLOCK_SIZE);
-}
-
-__fi static void BlockHashAccumulate(BlockHashState& st, const u8* bp, u32 size)
-{
-	XXH3_64bits_update(&st, bp, size);
-}
-
-__fi static GSTextureCache::Source::HashType FinishBlockHash(BlockHashState& st)
-{
-	return XXH3_64bits_digest(&st);
-}
-
 void GSTextureCache::Source::PreloadLevel(int level)
 {
 	// m_TEX0 is adjusted for mips (messy, should be changed).
@@ -1936,42 +1966,8 @@ void GSTextureCache::Source::PreloadLevel(int level)
 	const int tw = 1 << m_TEX0.TW;
 	const int th = 1 << m_TEX0.TH;
 
-	// For textures which are smaller than the block size, we expand and then hash.
-	// This is because otherwise we get the padding bytes, which can be random junk.
-	if (tw < bs.x || th < bs.y)
-	{
-		PreloadSmallLevel(level);
-		return;
-	}
-
-	// From GSLocalMemory foreachBlock(), used for reading textures.
-	// We want to hash the exact same blocks here.
-	const GSVector4i rect(0, 0, tw, th);
-	const GSVector4i block_rect(rect.ralign<Align_Outside>(bs));
-	const GSOffset& off = m_renderer->m_context->offset.tex;
-	GSLocalMemory& mem = m_renderer->m_mem;
-	HashType hash;
-	{
-		BlockHashState hash_st;
-		BlockHashReset(hash_st);
-
-		GSOffset::BNHelper bn = off.bnMulti(block_rect.left, block_rect.top);
-		const int right = block_rect.right >> off.blockShiftX();
-		const int bottom = block_rect.bottom >> off.blockShiftY();
-		const int xAdd = (1 << off.blockShiftX()) * (psm.bpp / 8);
-
-		for (; bn.blkY() < bottom; bn.nextBlockY())
-		{
-			for (int x = 0; bn.blkX() < right; bn.nextBlockX(), x += xAdd)
-			{
-				BlockHashAccumulate(hash_st, mem.BlockPtr(bn.value()));
-			}
-		}
-
-		hash = FinishBlockHash(hash_st);
-	}
-
 	// Layer is complete again, regardless of whether the hash matches or not (and we reupload).
+	const HashType hash = HashTexture(m_renderer, m_TEX0, m_TEXA);
 	const u8 layer_bit = static_cast<u8>(1) << level;
 	m_complete_layers |= layer_bit;
 
@@ -1982,91 +1978,8 @@ void GSTextureCache::Source::PreloadLevel(int level)
 	m_valid_hashes |= layer_bit;
 	m_layer_hash[level] = hash;
 
-	// Expand texture/apply palette.
-	const int read_width = std::max(tw, psm.bs.x);
-	u32 pitch = static_cast<u32>(read_width) * sizeof(u32);
-	u32 row_size = static_cast<u32>(tw) * sizeof(u32);
-	GSLocalMemory::readTexture rtx = psm.rtx;
-	if (m_palette)
-	{
-		pitch >>= 2;
-		row_size >>= 2;
-		rtx = psm.rtxP;
-	}
-
-	// If we can stream it directly to GPU memory, do so, otherwise go through a temp buffer.
-	GSTexture::GSMap map;
-	if (rect.eq(block_rect) && m_texture->Map(map, &rect, level))
-	{
-		(m_renderer->m_mem.*rtx)(off, block_rect, map.bits, map.pitch, m_TEXA);
-		m_texture->Unmap();
-	}
-	else
-	{
-		u8* buff = m_temp;
-		(m_renderer->m_mem.*rtx)(off, block_rect, buff, pitch, m_TEXA);
-		m_texture->Update(rect, buff, pitch, level);
-	}
-}
-
-void GSTextureCache::Source::PreloadSmallLevel(int level)
-{
-	// m_TEX0 is adjusted for mips (messy, should be changed).
-	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[m_TEX0.PSM];
-	const GSVector2i& bs = psm.bs;
-	const int tw = 1 << m_TEX0.TW;
-	const int th = 1 << m_TEX0.TH;
-	const GSVector4i rect(0, 0, tw, th);
-	const GSVector4i block_rect(rect.ralign<Align_Outside>(bs));
-	const GSOffset& off = m_renderer->m_context->offset.tex;
-	GSLocalMemory& mem = m_renderer->m_mem;
-
-	// Expand texture/apply palette.
-	u32 pitch = static_cast<u32>(block_rect.z) * sizeof(u32);
-	u32 row_size = static_cast<u32>(tw) * sizeof(u32);
-	GSLocalMemory::readTexture rtx = psm.rtx;
-	if (m_palette)
-	{
-		pitch >>= 2;
-		row_size >>= 2;
-		rtx = psm.rtxP;
-	}
-
-	// Use temp buffer for expanding, since we may not need to update.
-	u8* buff = m_temp;
-	(m_renderer->m_mem.*rtx)(off, block_rect, buff, pitch, m_TEXA);
-
-	// Hash the expanded texture.
-	HashType hash;
-	{
-		u8* ptr = buff;
-		BlockHashState state;
-		BlockHashReset(state);
-		if (pitch == row_size)
-		{
-			BlockHashAccumulate(state, ptr, pitch * static_cast<u32>(th));
-		}
-		else
-		{
-			for (int y = 0; y < th; y++, ptr += pitch)
-				BlockHashAccumulate(state, ptr, row_size);
-		}
-		hash = FinishBlockHash(state);
-	}
-
-	// Layer is complete again, regardless of whether the hash matches or not (and we reupload).
-	const u8 layer_bit = static_cast<u8>(1) << level;
-	m_complete_layers |= layer_bit;
-
-	// Check whether the hash matches. Black textures will be 0, so check the valid bit.
-	if ((m_valid_hashes & layer_bit) && m_layer_hash[level] == hash)
-		return;
-
-	m_valid_hashes |= layer_bit;
-	m_layer_hash[level] = hash;
-
-	// Upload to GPU.
-	m_texture->Update(rect, buff, pitch, level);
+	// And upload the texture.
+	PreloadTexture(m_TEX0, m_TEXA, m_renderer->m_mem, m_palette != nullptr, m_texture, level);
 }
 
 bool GSTextureCache::Source::ClutMatch(const PaletteKey& palette_key)
@@ -2076,8 +1989,8 @@ bool GSTextureCache::Source::ClutMatch(const PaletteKey& palette_key)
 
 // GSTextureCache::Target
 
-GSTextureCache::Target::Target(GSRenderer* r, const GIFRegTEX0& TEX0, u8* temp, const bool depth_supported, const int type)
-	: Surface(r, temp)
+GSTextureCache::Target::Target(GSRenderer* r, const GIFRegTEX0& TEX0, const bool depth_supported, const int type)
+	: Surface(r)
 	, m_type(type)
 	, m_used(false)
 	, m_depth_supported(depth_supported)
@@ -2219,7 +2132,16 @@ void GSTextureCache::SourceMap::Add(Source* s, const GIFRegTEX0& TEX0, const GSO
 void GSTextureCache::SourceMap::RemoveAll()
 {
 	for (auto s : m_surfaces)
+	{
+		if (s->m_from_hash_cache)
+		{
+			pxAssert(s->m_from_hash_cache->refcount > 0);
+			if ((--s->m_from_hash_cache->refcount) == 0)
+				s->m_from_hash_cache->age = 0;
+		}
+
 		delete s;
+	}
 
 	m_surfaces.clear();
 
@@ -2248,6 +2170,13 @@ void GSTextureCache::SourceMap::RemoveAt(Source* s)
 		{
 			m_map[page].EraseIndex(s->m_erase_it[page]);
 		});
+	}
+
+	if (s->m_from_hash_cache)
+	{
+		pxAssert(s->m_from_hash_cache->refcount > 0);
+		if ((--s->m_from_hash_cache->refcount) == 0)
+			s->m_from_hash_cache->age = 0;
 	}
 
 	delete s;
@@ -2639,4 +2568,160 @@ bool GSTextureCache::SurfaceOffsetKeyEqual::operator()(const GSTextureCache::Sur
 			return false;
 	}
 	return true;
+}
+
+using BlockHashState = XXH3_state_t;
+
+__fi static void BlockHashReset(BlockHashState& st)
+{
+	XXH3_64bits_reset(&st);
+}
+
+__fi static void BlockHashAccumulate(BlockHashState& st, const u8* bp)
+{
+	XXH3_64bits_update(&st, bp, BLOCK_SIZE);
+}
+
+__fi static void BlockHashAccumulate(BlockHashState& st, const u8* bp, u32 size)
+{
+	XXH3_64bits_update(&st, bp, size);
+}
+
+__fi static GSTextureCache::HashType FinishBlockHash(BlockHashState& st)
+{
+	return XXH3_64bits_digest(&st);
+}
+
+GSTextureCache::HashType GSTextureCache::HashTexture(GSRenderer* renderer, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA)
+{
+	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
+	const GSVector2i& bs = psm.bs;
+	const int tw = 1 << TEX0.TW;
+	const int th = 1 << TEX0.TH;
+
+	// From GSLocalMemory foreachBlock(), used for reading textures.
+	// We want to hash the exact same blocks here.
+	const GSVector4i rect(0, 0, tw, th);
+	const GSVector4i block_rect(rect.ralign<Align_Outside>(bs));
+	GSLocalMemory& mem = renderer->m_mem;
+	GSOffset off = mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM);
+
+	// For textures which are smaller than the block size, we expand and then hash.
+	// This is because otherwise we get the padding bytes, which can be random junk.
+	GSTextureCache::HashType hash;
+	BlockHashState hash_st;
+	if (tw < bs.x || th < bs.y)
+	{
+		// Expand texture indices. Align to 32 bytes for AVX2.
+		const u32 pitch = Common::AlignUpPow2(static_cast<u32>(block_rect.w), 32);
+		const u32 row_size = static_cast<u32>(tw);
+		const GSLocalMemory::readTexture rtx = psm.rtxP;
+
+		// Use temp buffer for expanding, since we may not need to update.
+		(renderer->m_mem.*rtx)(off, block_rect, m_temp, pitch, TEXA);
+
+		// Hash the expanded texture.
+		u8* ptr = m_temp;
+		BlockHashReset(hash_st);
+		if (pitch == row_size)
+		{
+			BlockHashAccumulate(hash_st, ptr, pitch * static_cast<u32>(th));
+		}
+		else
+		{
+			for (int y = 0; y < th; y++, ptr += pitch)
+				BlockHashAccumulate(hash_st, ptr, row_size);
+		}
+		hash = FinishBlockHash(hash_st);
+	}
+	else
+	{
+		BlockHashReset(hash_st);
+
+		GSOffset::BNHelper bn = off.bnMulti(block_rect.left, block_rect.top);
+		const int right = block_rect.right >> off.blockShiftX();
+		const int bottom = block_rect.bottom >> off.blockShiftY();
+		const int xAdd = (1 << off.blockShiftX()) * (psm.bpp / 8);
+
+		for (; bn.blkY() < bottom; bn.nextBlockY())
+		{
+			for (int x = 0; bn.blkX() < right; bn.nextBlockX(), x += xAdd)
+			{
+				BlockHashAccumulate(hash_st, mem.BlockPtr(bn.value()));
+			}
+		}
+
+		hash = FinishBlockHash(hash_st);
+	}
+
+	return hash;
+}
+
+void GSTextureCache::PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GSLocalMemory& mem, bool paltex, GSTexture* tex, u32 level)
+{
+	// m_TEX0 is adjusted for mips (messy, should be changed).
+	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
+	const GSVector2i& bs = psm.bs;
+	const int tw = 1 << TEX0.TW;
+	const int th = 1 << TEX0.TH;
+
+	// Expand texture/apply palette.
+	const GSVector4i rect(0, 0, tw, th);
+	const GSVector4i block_rect(rect.ralign<Align_Outside>(bs));
+	const GSOffset off(mem.GetOffset(TEX0.TBP0, TEX0.TBW, TEX0.PSM));
+	const int read_width = std::max(tw, psm.bs.x);
+	u32 pitch = static_cast<u32>(read_width) * sizeof(u32);
+	u32 row_size = static_cast<u32>(tw) * sizeof(u32);
+	GSLocalMemory::readTexture rtx = psm.rtx;
+	if (paltex)
+	{
+		pitch >>= 2;
+		row_size >>= 2;
+		rtx = psm.rtxP;
+	}
+
+	// If we can stream it directly to GPU memory, do so, otherwise go through a temp buffer.
+	GSTexture::GSMap map;
+	if (rect.eq(block_rect) && tex->Map(map, &rect, level))
+	{
+		(mem.*rtx)(off, block_rect, map.bits, map.pitch, TEXA);
+		tex->Unmap();
+	}
+	else
+	{
+		// Align pitch to 32 bytes for AVX2 if we're going through the temp buffer path.
+		pitch = Common::AlignUpPow2(pitch, 32);
+
+		u8* buff = m_temp;
+		(mem.*rtx)(off, block_rect, buff, pitch, TEXA);
+		tex->Update(rect, buff, pitch, level);
+	}
+}
+
+GSTextureCache::HashCacheKey::HashCacheKey()
+	: TEX0Hash(0)
+	, CLUTHash(0)
+{
+	TEX0.U64 = 0;
+	TEXA.U64 = 0;
+}
+
+GSTextureCache::HashCacheKey GSTextureCache::HashCacheKey::Create(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GSRenderer* renderer, const u32* clut)
+{
+	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
+
+	HashCacheKey ret;
+	ret.TEX0.U64 = TEX0.U64 & 0x00000007FFF00000ULL;
+	ret.TEXA.U64 = (psm.pal == 0 && psm.fmt > 0) ? (TEXA.U64 & 0x000000FF000080FFULL) : 0;
+	ret.CLUTHash = clut ? GSTextureCache::PaletteKeyHash{}({clut, psm.pal}) : 0;
+	ret.TEX0Hash = HashTexture(renderer, TEX0, TEXA);
+
+	return ret;
+}
+
+u64 GSTextureCache::HashCacheKeyHash::operator()(const HashCacheKey& key) const
+{
+	std::size_t h = 0;
+	HashCombine(h, key.TEX0Hash, key.CLUTHash, key.TEX0.U64, key.TEXA.U64);
+	return h;
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -760,9 +760,9 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 					}
 					else
 					{
-						u32* RESTRICT valid = s->m_valid;
+						u32* RESTRICT valid = s->m_valid.get();
 
-						if (!s->CanPreload())
+						if (valid && !s->CanPreload())
 						{
 							// Invalidate data of input texture
 							if (s->m_repeating)
@@ -1729,8 +1729,6 @@ GSTextureCache::Source::Source(GSRenderer* r, const GIFRegTEX0& TEX0, const GIFR
 		memset(m_layer_TEX0, 0, sizeof(m_layer_TEX0));
 		memset(m_layer_hash, 0, sizeof(m_layer_hash));
 
-		memset(m_valid, 0, sizeof(m_valid));
-
 		m_write.rect = (GSVector4i*)_aligned_malloc(3 * sizeof(GSVector4i), 32);
 		m_write.count = 0;
 
@@ -1775,6 +1773,9 @@ void GSTextureCache::Source::Update(const GSVector4i& rect, int level)
 	GSOffset::BNHelper bn = off.bnMulti(r.left, r.top);
 
 	u32 blocks = 0;
+
+	if (!m_valid)
+		m_valid = std::make_unique<u32[]>(MAX_PAGES);
 
 	if (m_repeating)
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -100,6 +100,7 @@ void GSTextureCache::RemoveAll()
 	for (auto it : m_hash_cache)
 		g_gs_device->Recycle(it.second.texture);
 	m_hash_cache.clear();
+	m_hash_cache_memory_usage = 0;
 
 	m_palette_map.Clear();
 }
@@ -1132,6 +1133,7 @@ void GSTextureCache::IncAge()
 		HashCacheEntry& e = it->second;
 		if (e.refcount == 0 && ++e.age > max_hash_cache_age)
 		{
+			m_hash_cache_memory_usage -= e.texture->GetMemUsage();
 			g_gs_device->Recycle(e.texture);
 			m_hash_cache.erase(it++);
 		}
@@ -1465,6 +1467,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 				// insert it into the hash cache
 				HashCacheEntry entry{ src->m_texture, 1, 0 };
 				it = m_hash_cache.emplace(key, entry).first;
+				m_hash_cache_memory_usage += src->m_texture->GetMemUsage();
 			}
 			else
 			{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -275,6 +275,7 @@ protected:
 	PaletteMap m_palette_map;
 	SourceMap m_src;
 	std::unordered_map<HashCacheKey, HashCacheEntry, HashCacheKeyHash> m_hash_cache;
+	u64 m_hash_cache_memory_usage = 0;
 	FastList<Target*> m_dst[2];
 	bool m_preload_frame;
 	static u8* m_temp;
@@ -298,6 +299,9 @@ protected:
 public:
 	GSTextureCache(GSRenderer* r);
 	~GSTextureCache();
+
+	__fi u64 GetHashCacheMemoryUsage() const { return m_hash_cache_memory_usage; }
+
 	void Read(Target* t, const GSVector4i& r);
 	void Read(Source* t, const GSVector4i& r);
 	void RemoveAll();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -153,8 +153,8 @@ public:
 
 	public:
 		std::shared_ptr<Palette> m_palette_obj;
+		std::unique_ptr<u32[]> m_valid;// each u32 bits map to the 32 blocks of that page
 		GSTexture* m_palette;
-		u32 m_valid[MAX_PAGES]; // each u32 bits map to the 32 blocks of that page
 		GSVector4i m_valid_rect;
 		u8 m_valid_hashes = 0;
 		u8 m_complete_layers = 0;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -50,7 +50,8 @@ public:
 
 		HashCacheKey();
 
-		static HashCacheKey Create(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GSRenderer* renderer, const u32* clut);
+		static HashCacheKey Create(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GSRenderer* renderer, const u32* clut,
+			const GSVector2i* lod);
 
 		__fi bool operator==(const HashCacheKey& e) const { return std::memcmp(this, &e, sizeof(*this)) == 0; }
 		__fi bool operator!=(const HashCacheKey& e) const { return std::memcmp(this, &e, sizeof(*this)) != 0; }
@@ -287,7 +288,7 @@ protected:
 	constexpr static size_t S_SURFACE_OFFSET_CACHE_MAX_SIZE = std::numeric_limits<u16>::max();
 	std::unordered_map<SurfaceOffsetKey, SurfaceOffset, SurfaceOffsetKeyHash, SurfaceOffsetKeyEqual> m_surface_offset_cache;
 
-	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false, int x_offset = 0, int y_offset = 0, bool mipmap = false);
+	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t = NULL, bool half_right = false, int x_offset = 0, int y_offset = 0, const GSVector2i* lod = nullptr);
 	Target* CreateTarget(const GIFRegTEX0& TEX0, int w, int h, int type, const bool clear);
 
 	static void PreloadTexture(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GSLocalMemory& mem, bool paltex, GSTexture* tex, u32 level);
@@ -307,7 +308,7 @@ public:
 	void RemoveAll();
 	void RemovePartial();
 
-	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, bool mipmap);
+	Source* LookupSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, const GSVector2i* lod);
 	Source* LookupDepthSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GSVector4i& r, bool palette = false);
 
 	Target* LookupTarget(const GIFRegTEX0& TEX0, const GSVector2i& size, int type, bool used, u32 fbmask = 0, const bool is_frame = false, const int real_h = 0);

--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
@@ -161,6 +161,37 @@ VkCommandBuffer GSTextureVK::GetCommandBufferForUpdate()
 	return g_vulkan_context->GetCurrentInitCommandBuffer();
 }
 
+static VkBuffer AllocateUploadStagingBuffer(const void* data, u32 size)
+{
+	const VkBufferCreateInfo bci = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, nullptr, 0,
+		static_cast<VkDeviceSize>(size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_SHARING_MODE_EXCLUSIVE, 0, nullptr};
+
+	// Don't worry about setting the coherent bit for this upload, the main reason we had
+	// that set in StreamBuffer was for MoltenVK, which would upload the whole buffer on
+	// smaller uploads, but we're writing to the whole thing anyway.
+	VmaAllocationCreateInfo aci = {};
+	aci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+	aci.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+
+	VmaAllocationInfo ai;
+	VkBuffer buffer;
+	VmaAllocation allocation;
+	VkResult res = vmaCreateBuffer(g_vulkan_context->GetAllocator(), &bci, &aci, &buffer, &allocation, &ai);
+	if (res != VK_SUCCESS)
+	{
+		LOG_VULKAN_ERROR(res, "(AllocateUploadStagingBuffer) vmaCreateBuffer() failed: ");
+		return VK_NULL_HANDLE;
+	}
+
+	// Immediately queue it for freeing after the command buffer finishes, since it's only needed for the copy.
+	g_vulkan_context->DeferBufferDestruction(buffer, allocation);
+
+	// And write the data.
+	std::memcpy(ai.pMappedData, data, size);
+	vmaFlushAllocation(g_vulkan_context->GetAllocator(), allocation, 0, size);
+	return buffer;
+}
+
 bool GSTextureVK::Update(const GSVector4i& r, const void* data, int pitch, int layer)
 {
 	if (layer >= m_mipmap_levels)
@@ -172,18 +203,37 @@ bool GSTextureVK::Update(const GSVector4i& r, const void* data, int pitch, int l
 	const u32 height = r.height();
 	const u32 row_length = static_cast<u32>(pitch) / Vulkan::Util::GetTexelSize(m_texture.GetFormat());
 	const u32 required_size = static_cast<u32>(pitch) * height;
-	Vulkan::StreamBuffer& buffer = g_vulkan_context->GetTextureUploadBuffer();
-	if (!buffer.ReserveMemory(required_size, g_vulkan_context->GetBufferImageGranularity()))
-	{
-		GSDeviceVK::GetInstance()->ExecuteCommandBuffer(
-			false, "While waiting for %u bytes in texture upload buffer", required_size);
-		if (!buffer.ReserveMemory(required_size, g_vulkan_context->GetBufferImageGranularity()))
-			pxFailRel("Failed to reserve texture upload memory");
-	}
 
-	const u32 buffer_offset = buffer.GetCurrentOffset();
-	std::memcpy(buffer.GetCurrentHostPointer(), data, required_size);
-	buffer.CommitMemory(required_size);
+	// If the texture is larger than half our streaming buffer size, use a separate buffer.
+	// Otherwise allocation will either fail, or require lots of cmdbuffer submissions.
+	VkBuffer buffer;
+	u32 buffer_offset;
+	if (required_size > (g_vulkan_context->GetTextureUploadBuffer().GetCurrentSize() / 2))
+	{
+		buffer_offset = 0;
+		buffer = AllocateUploadStagingBuffer(data, required_size);
+		if (buffer == VK_NULL_HANDLE)
+			return false;
+	}
+	else
+	{
+		Vulkan::StreamBuffer& sbuffer = g_vulkan_context->GetTextureUploadBuffer();
+		if (!sbuffer.ReserveMemory(required_size, g_vulkan_context->GetBufferImageGranularity()))
+		{
+			GSDeviceVK::GetInstance()->ExecuteCommandBuffer(
+				false, "While waiting for %u bytes in texture upload buffer", required_size);
+			if (!sbuffer.ReserveMemory(required_size, g_vulkan_context->GetBufferImageGranularity()))
+			{
+				Console.Error("Failed to reserve texture upload memory (%u bytes).", required_size);
+				return false;
+			}
+		}
+
+		buffer = sbuffer.GetBuffer();
+		buffer_offset = sbuffer.GetCurrentOffset();
+		std::memcpy(sbuffer.GetCurrentHostPointer(), data, required_size);
+		sbuffer.CommitMemory(required_size);
+	}
 
 	const VkCommandBuffer cmdbuf = GetCommandBufferForUpdate();
 	GL_PUSH("GSTextureVK::Update({%d,%d} %dx%d Lvl:%u", r.x, r.y, r.width(), r.height(), layer);
@@ -201,8 +251,7 @@ bool GSTextureVK::Update(const GSVector4i& r, const void* data, int pitch, int l
 			m_state = State::Dirty;
 	}
 
-	m_texture.UpdateFromBuffer(
-		cmdbuf, layer, 0, r.x, r.y, width, height, row_length, buffer.GetBuffer(), buffer_offset);
+	m_texture.UpdateFromBuffer(cmdbuf, layer, 0, r.x, r.y, width, height, row_length, buffer, buffer_offset);
 	m_texture.TransitionToLayout(cmdbuf, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 	if (m_type == Type::Texture)
@@ -222,8 +271,12 @@ bool GSTextureVK::Map(GSMap& m, const GSVector4i* r, int layer)
 
 	m.pitch = m_map_area.width() * Vulkan::Util::GetTexelSize(m_texture.GetFormat());
 
+	// see note in Update() for the reason why.
 	const u32 required_size = m.pitch * m_map_area.height();
 	Vulkan::StreamBuffer& buffer = g_vulkan_context->GetTextureUploadBuffer();
+	if (required_size >= (buffer.GetCurrentSize() / 2))
+		return false;
+
 	if (!buffer.ReserveMemory(required_size, g_vulkan_context->GetBufferImageGranularity()))
 	{
 		GSDeviceVK::GetInstance()->ExecuteCommandBuffer(

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -285,7 +285,6 @@ RendererTab::RendererTab(wxWindow* parent)
 
 	auto* paltex_prereq = m_ui.addCheckBox(hw_checks_box, "GPU Palette Conversion", "paltex", IDC_PALTEX, hw_prereq);
 	auto aniso_prereq = [this, paltex_prereq]{ return m_is_hardware && paltex_prereq->GetValue() == false; };
-	m_ui.addCheckBox(hw_checks_box, "Preload Textures", "preload_texture", IDC_PRELOAD_TEXTURES, hw_prereq);
 
 	auto* hw_choice_grid = new wxFlexGridSizer(2, space, space);
 
@@ -296,6 +295,7 @@ RendererTab::RendererTab(wxWindow* parent)
 	m_ui.addComboBoxAndLabel(hw_choice_grid, "Mipmapping:",            "mipmap_hw",              &theApp.m_gs_hw_mipmapping,   IDC_MIPMAP_HW,           hw_prereq);
 	m_ui.addComboBoxAndLabel(hw_choice_grid, "CRC Hack Level:",        "crc_hack_level",         &theApp.m_gs_crc_level,       IDC_CRC_LEVEL,           hw_prereq);
 	m_ui.addComboBoxAndLabel(hw_choice_grid, "Blending Accuracy:",     "accurate_blending_unit", &theApp.m_gs_acc_blend_level, IDC_ACCURATE_BLEND_UNIT, hw_prereq);
+	m_ui.addComboBoxAndLabel(hw_choice_grid, "Texture Preloading:",    "texture_preloading",     &theApp.m_gs_texture_preloading, IDC_PRELOAD_TEXTURES, hw_prereq);
 
 	hardware_box->Add(hw_checks_box, wxSizerFlags().Centre());
 	hardware_box->AddSpacer(space);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -359,6 +359,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		   OpEqu(AccurateBlendingUnit) &&
 		   OpEqu(CRCHack) &&
 		   OpEqu(TextureFiltering) &&
+		   OpEqu(TexturePreloading) &&
 		   OpEqu(Dithering) &&
 		   OpEqu(MaxAnisotropy) &&
 		   OpEqu(SWExtraThreads) &&
@@ -510,7 +511,6 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBoolEx(SaveFrame, "savef");
 	GSSettingBoolEx(SaveTexture, "savet");
 	GSSettingBoolEx(SaveDepth, "savez");
-	GSSettingBoolEx(PreloadTexture, "preload_texture");
 
 	GSSettingIntEnumEx(InterlaceMode, "interlace");
 
@@ -523,6 +523,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingIntEnumEx(AccurateBlendingUnit, "accurate_blending_unit");
 	GSSettingIntEnumEx(CRCHack, "crc_hack_level");
 	GSSettingIntEnumEx(TextureFiltering, "filter");
+	GSSettingIntEnumEx(TexturePreloading, "texture_preloading");
 	GSSettingIntEx(Dithering, "dithering_ps2");
 	GSSettingIntEx(MaxAnisotropy, "MaxAnisotropy");
 	GSSettingIntEx(SWExtraThreads, "extrathreads");


### PR DESCRIPTION
### Description of Changes

This PR adds a hash-based cache to the texture cache for sources, as addition to the existing TEX0-key-based-cache.

As the hash cache entries are based on the texture data and not the location in VRAM, it eliminates uploads in games that stream textures to different locations in VRAM across frames (e.g. GTA: SA). Some games like GTA: LCS are an extreme case of this, where texture uploads previously exceeded 1,000 per frame.

Since it's based on the texture data, this has another nice property; we can use them for texture replacements. I have already done a proof-of-concept and it works quite well.

### Rationale behind Changes

Making upload heavy GS games faster.

### Suggested Testing Steps

There should be no regressions in rendering or performance in the default config. Partial preloading is equivalent to the current preloading setting, and full uses the hash cache. Test this in games with heavy uploads (e.g. SA, LCS) and examine performance.
