### PR TITLE
GS-ogl: Remove GL_ARB_get_texture_sub_image.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1318,9 +1318,6 @@ void GSApp::Init()
 	m_default_configuration["override_GL_ARB_sparse_texture"]             = "-1";
 	m_default_configuration["override_GL_ARB_sparse_texture2"]            = "-1";
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
-#ifdef GL_EXT_TEX_SUB_IMAGE
-	m_default_configuration["override_GL_ARB_get_texture_sub_image"]      = "-1";
-#endif
 	m_default_configuration["paltex"]                                     = "0";
 	m_default_configuration["png_compression_level"]                      = std::to_string(Z_BEST_SPEED);
 	m_default_configuration["preload_frame_with_gs_data"]                 = "0";

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -157,11 +157,6 @@ namespace GLLoader
 	bool found_compatible_GL_ARB_sparse_texture2 = false;
 	bool found_compatible_sparse_depth = false;
 
-	// Not yet used
-#ifdef GL_EXT_TEX_SUB_IMAGE
-	bool found_GL_ARB_get_texture_sub_image = false;
-#endif
-
 	static bool mandatory(const std::string& ext)
 	{
 		if (!GLExtension::Has(ext))
@@ -284,10 +279,6 @@ namespace GLLoader
 			// Mandatory for the advance HW renderer effect. Unfortunately Mesa LLVMPIPE/SWR renderers doesn't support this extension.
 			// Rendering might be corrupted but it could be good enough for test/virtual machine.
 			optional("GL_ARB_texture_barrier");
-			// Not yet used
-#ifdef GL_EXT_TEX_SUB_IMAGE
-			found_GL_ARB_get_texture_sub_image = optional("GL_ARB_get_texture_sub_image");
-#endif
 		}
 
 		if (vendor_id_amd)

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -550,12 +550,7 @@ GSTexture::GSMap GSTextureOGL::Read(const GSVector4i& r, AlignedBuffer<u8, 32>& 
 
 	// The fastest way will be to use a PBO to read the data asynchronously. Unfortunately GSdx
 	// architecture is waiting the data right now.
-#if 0
-	// Maybe it is as good as the code below. I don't know
-	// With openGL 4.5 you can use glGetTextureSubImage
 
-	glGetTextureSubImage(m_texture_id, GL_TEX_LEVEL_0, r.x, r.y, 0, r.width(), r.height(), 1, m_int_format, m_int_type, m_size.x * m_size.y * 4, m.bits);
-#else
 	// Bind the texture to the read framebuffer to avoid any disturbance
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo_read);
 	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture_id, 0);
@@ -566,7 +561,6 @@ GSTexture::GSMap GSTextureOGL::Read(const GSVector4i& r, AlignedBuffer<u8, 32>& 
 	glReadPixels(r.x, r.y, r.width(), r.height(), m_int_format, m_int_type, m.bits);
 
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-#endif
 
 	return m;
 }

--- a/pcsx2/GS/config.h
+++ b/pcsx2/GS/config.h
@@ -16,19 +16,9 @@
 #pragma once
 
 //#define ENABLE_VTUNE
-//#define ENABLE_PCRTC_DEBUG
 //#define ENABLE_ACCURATE_BUFFER_EMULATION
 #define ENABLE_JIT_RASTERIZER
 
 //#define DISABLE_HW_TEXTURE_CACHE // Slow but fixes a lot of bugs
-
-//#define DISABLE_BITMASKING
-
-//#define DISABLE_COLCLAMP
-
-//#define DISABLE_DATE
-
-// Not yet used/experimental OpenGL extensions
-//#define GL_EXT_TEX_SUB_IMAGE
 
 //#define DISABLE_PERF_MON // Burn cycle for nothing in release mode


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-ogl: Remove GL_ARB_get_texture_sub_image.
Not used.
Also remove some not used commented out defines.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Cleanup, not used code.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
It compiles.