### PR TITLE
GS:OGL: Don't memset C++ objects

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -51,18 +51,6 @@ GSDeviceOGL::GSDeviceOGL()
 	, m_fbo_read(0)
 	, m_palette_ss(0)
 {
-	memset(&m_merge_obj, 0, sizeof(m_merge_obj));
-	memset(&m_interlace, 0, sizeof(m_interlace));
-	memset(&m_convert, 0, sizeof(m_convert));
-	memset(&m_fxaa, 0, sizeof(m_fxaa));
-#ifndef PCSX2_CORE
-	memset(&m_shaderfx, 0, sizeof(m_shaderfx));
-#endif
-	memset(&m_date, 0, sizeof(m_date));
-	memset(&m_shadeboost, 0, sizeof(m_shadeboost));
-	memset(&m_om_dss, 0, sizeof(m_om_dss));
-	memset(&m_profiler, 0, sizeof(m_profiler));
-
 	// Reset the debug file
 #ifdef ENABLE_OGL_DEBUG
 	m_debug_gl_file = fopen("GS_opengl_debug.txt", "w");

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -249,10 +249,10 @@ private:
 	{
 		std::string vs;
 		GL::Program ps[static_cast<int>(ShaderConvert::Count)]; // program object
-		GLuint ln; // sampler object
-		GLuint pt; // sampler object
-		GSDepthStencilOGL* dss;
-		GSDepthStencilOGL* dss_write;
+		GLuint ln = 0; // sampler object
+		GLuint pt = 0; // sampler object
+		GSDepthStencilOGL* dss = nullptr;
+		GSDepthStencilOGL* dss_write = nullptr;
 	} m_convert;
 
 	struct
@@ -269,8 +269,8 @@ private:
 
 	struct
 	{
-		GSDepthStencilOGL* dss;
-		GSTexture* t;
+		GSDepthStencilOGL* dss = nullptr;
+		GSTexture* t = nullptr;
 	} m_date;
 
 	struct
@@ -280,14 +280,14 @@ private:
 
 	struct
 	{
-		u16 last_query;
-		GLuint timer_query[1 << 16];
+		u16 last_query = 0;
+		GLuint timer_query[1 << 16] = {};
 
 		GLuint timer() { return timer_query[last_query]; }
 	} m_profiler;
 
 	GLuint m_ps_ss[1 << 8];
-	GSDepthStencilOGL* m_om_dss[1 << 5];
+	GSDepthStencilOGL* m_om_dss[1 << 5] = {};
 	std::unordered_map<ProgramSelector, GL::Program, ProgramSelectorHash> m_programs;
 	GL::ShaderCache m_shader_cache;
 


### PR DESCRIPTION
### Description of Changes
Stops memsetting a bunch of C++ classes to zero

Fixes #5226

### Rationale behind Changes
Memsetting C++ objects is not generally a good idea
For most objects, all zeroes is valid and equivalent to default initialization, but sometimes it isn't

In particular, `std::string` on some systems does not like to be memset to zeroes

### Suggested Testing Steps
Run OGL renderer and make sure it doesn't crash