### PR TITLE
GS/Vulkan: Fix warning when compiling RGBA8->RGB5A1 shader

### DIFF
--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -90,7 +90,7 @@ void ps_filter_transparency()
 // Need to be careful with precision here, it can break games like Spider-Man 3 and Dogs Life
 void ps_convert_rgba8_16bits()
 {
-	highp uvec4 i = uvec4(sample_c(v_tex) * vec4(255.5f, 255.5f, 255.5f, 255.5f));
+	uvec4 i = uvec4(sample_c(v_tex) * vec4(255.5f, 255.5f, 255.5f, 255.5f));
 
 	o_col0 = ((i.x & 0x00F8u) >> 3) | ((i.y & 0x00F8u) << 2) | ((i.z & 0x00f8u) << 7) | ((i.w & 0x80u) << 8);
 }

--- a/common/Vulkan/ShaderCompiler.cpp
+++ b/common/Vulkan/ShaderCompiler.cpp
@@ -107,13 +107,11 @@ namespace Vulkan::ShaderCompiler
 		glslang::GlslangToSpv(*intermediate, out_code, &logger);
 
 		// Write out messages
-		// Temporary: skip if it contains "Warning, version 450 is not yet complete; most version-specific
-		// features are present, but some are missing."
-		if (std::strlen(shader->getInfoLog()) > 108)
+		if (std::strlen(shader->getInfoLog()) > 0)
 			Console.Warning("Shader info log: %s", shader->getInfoLog());
 		if (std::strlen(shader->getInfoDebugLog()) > 0)
 			Console.Warning("Shader debug info log: %s", shader->getInfoDebugLog());
-		if (std::strlen(program->getInfoLog()) > 25)
+		if (std::strlen(program->getInfoLog()) > 0)
 			Console.Warning("Program info log: %s", program->getInfoLog());
 		if (std::strlen(program->getInfoDebugLog()) > 0)
 			Console.Warning("Program debug info log: %s", program->getInfoDebugLog());


### PR DESCRIPTION
Also gets rid of the program info log length check, since that's been long removed in glslang.
