### PR TITLE
GS-hw: Don't trigger no overlap check for DATE_BARRIER on d3d11.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -1306,8 +1306,9 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	{
 		// It is way too complex to emulate texture shuffle with DATE. So just use
 		// the slow but accurate algo
+		// No overlap should be triggered on gl/vk only as they support DATE_BARRIER.
 		const bool fbmask = (m_context->FRAME.FBMSK & 0x80000000);
-		const bool no_overlap = (m_prim_overlap == PRIM_OVERLAP_NO);
+		const bool no_overlap = (g_gs_device->Features().texture_barrier) && (m_prim_overlap == PRIM_OVERLAP_NO);
 		if (fbmask || no_overlap || m_texture_shuffle)
 		{
 			GL_PERF("DATE: Accurate with %s", m_texture_shuffle ? "texture shuffle" : no_overlap ? "no overlap" : "FBMASK");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Don't trigger no overlap check for DATE_BARRIER on d3d11.
d3d11 doesn't support DATE_BARRIER, it's better to let the Date one cases handle it as it will be more accurate.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, might have caused regressions that we didn't know about.
Needed to be changed when we added overlap check on dx, on dx we only do the overlap check for blending.

On gl/vk we use the no overlap check and do DATE_BARRIER as it is essentially quite fast, dx doesn't support it.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
