### PR TITLE
Qt: Fix qt compilation on linux.

### DIFF
--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -33,7 +33,7 @@
 
 #include "EmuThread.h"
 #include "QtHost.h"
-#include "SettingsDialog.h"
+#include "Settings/SettingsDialog.h"
 
 namespace SettingWidgetBinder
 {
@@ -621,7 +621,7 @@ namespace SettingWidgetBinder
 				Accessor::setNullableIntValue(widget, std::nullopt);
 			}
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key]() {
+			Accessor::connectValueChanged(widget, [&]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
 				{
 					const char* string_value = to_string_function(static_cast<DataType>(static_cast<UnderlyingType>(new_value.value())));


### PR DESCRIPTION
### Description of Changes
Changes one include to include the folder name the header is in so cmake finds it.
Expands the scope of a lambda so that it doesn't error out on "to_string_function".

### Rationale behind Changes
Linux is going to eventually use qt, so should be able to compile on it.

### Suggested Testing Steps
Make sure qt still compiles in windows. Compile it in linux.
