### PR TITLE
GS/TextureCache: Fix target not getting invalidated in some cases

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -754,6 +754,10 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 
 				if (!s->m_target)
 				{
+					found |= b;
+
+					// No point keeping invalidated sources around when the hash cache is active,
+					// we can just re-hash and create a new source from the cached texture.
 					if (s->m_from_hash_cache || (m_disable_partial_invalidation && s->m_repeating))
 					{
 						m_src.RemoveAt(s);
@@ -780,8 +784,6 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 						}
 
 						s->m_complete_layers = 0;
-
-						found |= b;
 					}
 				}
 				else


### PR DESCRIPTION
### Description of Changes

This would happen when there was a source from local memory with the same pointer as the target.

Fixes sky getting messed up in the Jak 3 menu when the hash cache is enabled.

### Rationale behind Changes

Bug fixes.

### Suggested Testing Steps

Make sure snowblind games aren't affected in a negative way when using the fast texture invalidation hack.
