### PR TITLE
GS: Ignore 24bit on DATE and Handle Reversed Color and Z

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -37410,6 +37410,15 @@ SLUS-20978:
   name: "Power Drome"
   region: "NTSC-U"
   compat: 4
+  patches:
+    42E15DEF:
+      content: |-
+        // Game takes advantage of the VU's extended float range.
+        // This limits it so x86 can handle it.
+        author=refraction and PSI
+        comment=VU float patch
+        patch=1,EE,00373040,word,7e7fffff
+        patch=1,EE,00373048,word,fe7fffff
 SLUS-20979:
   name: "Suikoden IV"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -964,6 +964,15 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 	u32 fm = context->FRAME.FBMSK;
 	u32 zm = context->ZBUF.ZMSK || context->TEST.ZTE == 0 ? 0xffffffff : 0;
 
+	// When the format is 24bit (Z or C), DATE ceases to function.
+	// It was believed that in 24bit mode all pixels pass because alpha doesn't exist
+	// however after testing this on a PS2 it turns out nothing passes, it ignores the draw.
+	if ((m_context->FRAME.PSM & 0xF) == PSM_PSMCT24 && m_context->TEST.DATE)
+	{
+		//DevCon.Warning("DATE on a 24bit format, Frame PSM %x", m_context->FRAME.PSM);
+		return false;
+	}
+
 	if (context->TEST.ZTE && context->TEST.ZTST == ZTST_NEVER)
 	{
 		fm = 0xffffffff;


### PR DESCRIPTION
### Description of Changes
After PS2 tests, it was discovered that draws are ignored if the FRAME format is 24bit (Color or depth).  Also added support for behaviour where setting FRAME to a Z format forces the ZBUF to use color swizzling.  Added HLE clear for Powerdrome and Snoopy Vs the Red Baron

Also clamping Frame buffer width between 1 and 32, as 0 is invalid and treated as 1.  this is incorrect but PCSX2 can't handle FBW 0, there is likely GSOffset/memory handling problems related to this, but clamping it works better than not.

### Rationale behind Changes
These behaviours weren't handled, they are now handled.

### Suggested Testing Steps
Test listed fixed games, make sure nothing else is broken.

Fixes pink players in team selection on Jikkyou Powerful Pro Yakyuu 12 - Fixes #5125
Fixes multicoloured Cow in Barnyard when using Software Mode
Fixes Powerdrome and Snoopy Vs Red Baron "Double half clear", they do the same thing, but one more ridiculous than the other.  Fixes #5240 Fixes #473 Fixes #5570
Fixes the purple ground in Need for Speed Undercover in software Fixes #5078