### PR TITLE
VU: Run sync ahead on small blocks & Rework VU Kickstart

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -32,7 +32,7 @@ allowed_game_fixes = [
     "VIF1StallHack",
     "GIFFIFOHack",
     "GoemonTlbHack",
-    "VUKickstartHack",
+    "VUSyncHack",
     "IbitHack",
     "VUOverflowHack",
 ]

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -41,13 +41,9 @@ PAPX-90203:
 PAPX-90222:
   name: "Jak x Daxter: Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 PAPX-90223:
   name: "Jak x Daxter: Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 PAPX-90231:
   name: "Kaitou Sly Cooper [Demo, Taikenban]"
   region: "NTSC-J"
@@ -60,8 +56,6 @@ PAPX-90506:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 PAPX-90512:
   name: "Gran Turismo 4 - Toyota Prius [Trial]"
   region: "NTSC-J"
@@ -72,8 +66,6 @@ PAPX-90512:
 PAPX-90516:
   name: "Jak and Daxter II [Trial]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 PBPX-95201:
   name: "Dead or Alive 2"
   region: "NTSC-J"
@@ -114,13 +106,10 @@ PBPX-95509:
 PBPX-95514:
   name: "Playstation 2 - Demo Disc 2002"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS in Ratchet and Clank.
 PBPX-95516:
   name: "Ratchet & Clank - [Trial Edition]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
@@ -186,7 +175,6 @@ PCPX-98017:
   name: "Ratchet & Clank - Giri Giri Ginga no Giga Battle [Demo]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-10001:
   name: "Makai Senki Disgaea"
@@ -232,7 +220,6 @@ SCAJ-20001:
   name: "Ratchet & Clank"
   region: "NTSC-Unk"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-20002:
   name: "Gallop Racer 6 - Revolution"
@@ -474,15 +461,12 @@ SCAJ-20070:
   region: "NTSC-Unk"
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SCAJ-20072:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-Unk"
 SCAJ-20073:
   name: "Jak and Daxter II"
   region: "NTSC-Unk"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCAJ-20074:
   name: "King of Fighters 2002, The"
   region: "NTSC-Unk"
@@ -623,7 +607,6 @@ SCAJ-20109:
   name: "Ratchet & Clank 3 - Up your Arsenal"
   region: "NTSC-Unk"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-20110:
   name: "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi"
@@ -633,7 +616,6 @@ SCAJ-20111:
   region: "NTSC-Unk"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
-    - VUKickstartHack # Fixes loading hang.
 SCAJ-20112:
   name: "Tales of Rebirth"
   region: "NTSC-Unk"
@@ -657,7 +639,6 @@ SCAJ-20118:
   region: "NTSC-J"
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SCAJ-20119:
   name: "Gladiator - Road to Freedom"
   region: "NTSC-Unk"
@@ -830,7 +811,6 @@ SCAJ-20157:
   name: "Ratchet & Clank 4th - GiriGiri Gingano Giga-battle"
   region: "NTSC-Unk"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCAJ-20158:
   name: "Ikusa Gami"
@@ -910,7 +890,6 @@ SCAJ-20177:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SCAJ-20178:
   name: "Ape Escape - Million Monkeys"
   region: "NTSC-Unk"
@@ -978,7 +957,6 @@ SCAJ-20197:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SCAJ-20198:
   name: "Everybody's Tennis [PlayStation 2 The Best]"
   region: "NTSC-Unk"
@@ -1014,8 +992,6 @@ SCAJ-25045:
 SCAJ-25047:
   name: "Dororo"
   region: "NTSC-Unk"
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SCAJ-30001:
   name: "Xenosaga Episode I [PlayStation 2 The Best]"
   region: "NTSC-Unk"
@@ -1248,8 +1224,6 @@ SCED-50610:
 SCED-50614:
   name: "Jak and Daxter: The Precursor Legacy [Demo]"
   region: "PAL-Unk"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCED-50622:
   name: "Official PlayStation 2 Magazine Demo 14" # German
   region: "PAL-E-G"
@@ -1339,7 +1313,6 @@ SCED-51075:
   name: "Ratchet & Clank [Regular Demo]"
   region: "PAL-M5"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
@@ -1493,8 +1466,6 @@ SCED-51657:
 SCED-51700:
   name: "Jak II: Renegade [Demo]"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCED-51922:
   name: "Ghosthunter [Demo]"
   region: "PAL-G"
@@ -1539,8 +1510,6 @@ SCED-52260:
 SCED-52261:
   name: "Jet Li - Rise to Honor [Demo]"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SCED-52068:
   name: "Official PlayStation 2 Magazine Demo 41" # German
   region: "PAL-E-G"
@@ -1707,8 +1676,6 @@ SCED-52938:
 SCED-52952:
   name: "Jak 3 [Demo]"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCED-52970:
   name: "SCEE Hits Demo"
   region: "PAL-M5"
@@ -2147,8 +2114,6 @@ SCES-50034:
   name: "MotoGP"
   region: "PAL-M5"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Crash On Load.
 SCES-50105:
   name: "Sky Odyssey"
   region: "PAL-M5"
@@ -2201,14 +2166,10 @@ SCES-50354:
 SCES-50360:
   name: "Twisted Metal - Black"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCES-50361:
   name: "Jak and Daxter: The Precursor Legacy"
   region: "PAL-M6"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCES-50408:
   name: "PaRappa the Rapper 2"
   region: "PAL-M5"
@@ -2332,8 +2293,6 @@ SCES-50612:
 SCES-50614:
   name: "Jak and Daxter: The Precursor Legacy"
   region: "PAL-Unk"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCES-50759:
   name: "Virtua Fighter 4"
   region: "PAL-M5"
@@ -2391,7 +2350,6 @@ SCES-50916:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCES-50917:
   name: "Sly Racoon"
@@ -2484,8 +2442,6 @@ SCES-51135:
     eeRoundMode: 0 # Fixes textures on the doors.
   clampModes:
     vuClampMode: 0 # Fix other SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes objects disappearing.
 SCES-51159:
   name: "The Getaway"
   region: "PAL-M5"
@@ -2516,8 +2472,6 @@ SCES-51190:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCES-51224:
   name: "War of the Monsters"
   region: "PAL-E"
@@ -2539,13 +2493,9 @@ SCES-51463:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes Missing Graphics.
 SCES-51480:
   name: "Twisted Metal - Black - Online"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCES-51513:
   name: "EyeToy - Play"
   region: "PAL-M11"
@@ -2564,8 +2514,6 @@ SCES-51592:
 SCES-51593:
   name: "Hardware Online Arena [Beta, Promo & Full Release]"
   region: "PAL-M4"
-  gameFixes:
-    - VUKickstartHack # Reduces chance of hanging going ingame.
   patches:
     81797E77:
       content: |-
@@ -2579,7 +2527,6 @@ SCES-51607:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes DMA errors 
   memcardFilters: # Reads Ratchet 1 data.
     - "SCES-51607"
@@ -2588,8 +2535,6 @@ SCES-51608:
   name: "Jak II: Renegade"
   region: "PAL-M7"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
   patches:
     default:
       content: |-
@@ -2624,6 +2569,8 @@ SCES-51648:
 SCES-51677:
   name: "My Street"
   region: "PAL-M5"
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SCES-51684:
   name: "WRC 3"
   region: "PAL-M8"
@@ -2638,8 +2585,6 @@ SCES-51685:
     eeRoundMode: 0 # Fixes textures on the doors.
   clampModes:
     vuClampMode: 0 # Fix other SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes objects disappearing.
 SCES-51706:
   name: "Amplitude"
   region: "PAL-M5"
@@ -2673,7 +2618,6 @@ SCES-51904:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 SCES-51910:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "PAL-M5"
@@ -2685,8 +2629,6 @@ SCES-51920:
 SCES-51971:
   name: "Jet Li - Rise to Honor"
   region: "PAL-E"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SCES-51977:
   name: "Hardware Online Arena"
   region: "PAL-E"
@@ -2732,8 +2674,6 @@ SCES-52156:
   region: "PAL-M3"
   clampModes:
     vuClampMode: 3 # Fixes SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes Missing Graphics.
 SCES-52268:
   name: "SingStar"
   region: "PAL-E"
@@ -2747,7 +2687,6 @@ SCES-52306:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 SCES-52327:
   name: "Forbidden Siren"
   region: "PAL-F"
@@ -2848,7 +2787,6 @@ SCES-52456:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
@@ -2858,8 +2796,6 @@ SCES-52460:
   name: "Jak 3"
   region: "PAL-M7"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
   patches:
     default:
       content: |-
@@ -3013,13 +2949,10 @@ SCES-53285:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCES-53286:
   name: "Jak X - Combat Racing"
   region: "PAL-M7"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
   memcardFilters: # Reads Ratchet Gladiator data.
     - "SCES-53286"
     - "SCES-53285"
@@ -3075,8 +3008,6 @@ SCES-53358:
   region: "PAL-M9"
   clampModes:
     vuClampMode: 2  # Fixes minimap HUD.
-  gameFixes:
-    - VUKickstartHack # Fixes missing geometry.
 SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "PAL-M5"
@@ -3725,8 +3656,6 @@ SCES-55489:
 SCES-55510:
   name: "Jak and Daxter: The Lost Frontier"
   region: "PAL-M12"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCES-55513:
   name: "SingStar Polskie Hity"
   region: "PAL-PL"
@@ -3878,13 +3807,10 @@ SCKA-20009:
 SCKA-20010:
   name: "Jak II"
   region: "NTSC-K"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCKA-20011:
   name: "Ratchet & Clank 2"
   region: "NTSC-K"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCKA-20012:
   name: "Arc the Lad - Jeong Ryeo Hui Hwang Ho"
@@ -3895,8 +3821,6 @@ SCKA-20014:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCKA-20015:
   name: "Time Crisis 3"
   region: "NTSC-K"
@@ -3982,7 +3906,6 @@ SCKA-20037:
   name: "Ratchet & Clank 3"
   region: "NTSC-K"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCKA-20037"
@@ -3996,8 +3919,6 @@ SCKA-20039:
 SCKA-20040:
   name: "Jak 3"
   region: "NTSC-K"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCKA-20043:
   name: "Magna Carta"
   region: "NTSC-K"
@@ -4069,7 +3990,6 @@ SCKA-20060:
   name: "Ratchet - Deadlocked"
   region: "NTSC-K"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCKA-20061:
   name: "Wanda to Kyozou (Shadow of the Colossus)"
@@ -4129,7 +4049,6 @@ SCKA-20079:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SCKA-20081:
   name: "Tekken 5 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
@@ -4425,8 +4344,6 @@ SCPS-15020:
 SCPS-15021:
   name: "Jak x Daxter: Kyuusekai no Isan"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCPS-15022:
   name: "Dual Hearts"
   region: "NTSC-J"
@@ -4469,8 +4386,6 @@ SCPS-15033:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCPS-15034:
   name: "This is Football 2003"
   region: "NTSC-J"
@@ -4484,7 +4399,6 @@ SCPS-15037:
   name: "Ratchet & Clank"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-15038:
   name: "Operator's Side"
@@ -4539,8 +4453,6 @@ SCPS-15052:
     eeRoundMode: 0 # Fixes textures on the doors.
   clampModes:
     vuClampMode: 0 # Fix other SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes objects disappearing.
 SCPS-15053:
   name: "Siren"
   region: "NTSC-J"
@@ -4568,7 +4480,6 @@ SCPS-15056:
   name: "Ratchet & Clank 2"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCPS-15056"
@@ -4576,8 +4487,6 @@ SCPS-15056:
 SCPS-15057:
   name: "Jak and Daxter II"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCPS-15058:
   name: "Arc the Lad - Generation"
   region: "NTSC-J"
@@ -4704,7 +4613,6 @@ SCPS-15084:
   name: "Ratchet & Clank 3"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCPS-15084"
@@ -4792,13 +4700,11 @@ SCPS-15099:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-15100:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-15101:
   name: "Bleach - Hanatareshi Yabou"
@@ -4982,13 +4888,10 @@ SCPS-19209:
 SCPS-19210:
   name: "Jak x Daxter: Kyuusekai no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCPS-19211:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19213:
   name: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
@@ -5001,8 +4904,6 @@ SCPS-19215:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCPS-19251:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5034,7 +4935,6 @@ SCPS-19302:
   name: "Ratchet & Clank 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19303:
   name: "Boku no Natsuyasumi 2 [PlayStation 2 The Best]"
@@ -5064,8 +4964,6 @@ SCPS-19306:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCPS-19307:
   name: "Popolocrois - The First Adventure [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5076,13 +4974,11 @@ SCPS-19309:
   name: "Ratchet & Clank 3 - Up Your Arsenal [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19310:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19311:
   name: "Saru Get You 3 [PlayStation 2 The Best]"
@@ -5111,13 +5007,11 @@ SCPS-19316:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19317:
   name: "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19318:
   name: "Genji - Dawn of the Samurai [PlayStation 2 The Best]"
@@ -5140,7 +5034,6 @@ SCPS-19321:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19322:
   name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
@@ -5188,7 +5081,6 @@ SCPS-19328:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCPS-19329:
   name: "Bleach - Blade Battlers [PlayStation 2 The Best]"
@@ -5259,8 +5151,6 @@ SCPS-55003:
 SCPS-55004:
   name: "Jak x Daxter: Kyuusekai no Isan"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCPS-55005:
   name: "Gran Turismo - Concept 2001 Tokyo"
   region: "NTSC-J"
@@ -5309,7 +5199,6 @@ SCPS-55019:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SCPS-55020:
   name: "Kengo 2"
   region: "NTSC-J"
@@ -5422,8 +5311,6 @@ SCPS-55048:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCPS-55049:
   name: "King of Fighters 2000, The"
   region: "NTSC-J"
@@ -5470,8 +5357,6 @@ SCPS-56002:
 SCPS-56003:
   name: "Jak and Daxter: The Precursor Legacy"
   region: "NTSC-K"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCPS-56005:
   name: "Gran Turismo Concept 2002 Tokyo-Seoul"
   region: "NTSC-K"
@@ -5533,8 +5418,6 @@ SCUS-97101:
   name: "Twisted Metal - Black"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCUS-97102:
   name: "Gran Turismo 3 - A-Spec"
   region: "NTSC-U"
@@ -5607,8 +5490,6 @@ SCUS-97124:
   name: "Jak and Daxter: The Precursor Legacy"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97125:
   name: "Frequency"
   region: "NTSC-U"
@@ -5684,8 +5565,6 @@ SCUS-97142:
     eeRoundMode: 0 # Fixes textures on the doors.
   clampModes:
     vuClampMode: 0 # Fix other SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes objects disappearing.
 SCUS-97144:
   name: "PlayStation Underground 5.1"
   region: "NTSC-U"
@@ -5749,8 +5628,6 @@ SCUS-97163:
 SCUS-97164:
   name: "Twisted Metal Black [Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCUS-97165:
   name: "Official U.S. PlayStation Magazine Demo Disc 051"
   region: "NTSC-U"
@@ -5769,13 +5646,9 @@ SCUS-97169:
 SCUS-97170:
   name: "Jak and Daxter: The Precursor Legacy [Cingular Wireless Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97171:
   name: "Jak and Daxter: The Precursor Legacy [PS Underground Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97172:
   name: "World Tour Soccer 2002"
   region: "NTSC-U"
@@ -5800,8 +5673,6 @@ SCUS-97179:
   name: "Twisted Metal Black"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCUS-97181:
   name: "Official U.S. PlayStation Magazine Demo Disc 055"
   region: "NTSC-U"
@@ -5844,14 +5715,10 @@ SCUS-97194:
 SCUS-97195:
   name: "Twisted Metal Black - Online"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCUS-97196:
   name: "Twisted Metal Black - Online [Demo]"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Car Models.
 SCUS-97197:
   name: "War of the Monsters"
   region: "NTSC-U"
@@ -5865,7 +5732,6 @@ SCUS-97199:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97200:
   name: "Kiosk Demo Disc 2.05"
@@ -5897,7 +5763,6 @@ SCUS-97209:
   name: "Ratchet & Clank [E3 Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97210:
   name: "Sly Cooper and the Thievius Raccoonus [Demo]"
@@ -5910,14 +5775,14 @@ SCUS-97212:
   name: "My Street (Online)"
   region: "NTSC-U"
   compat: 4
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SCUS-97213:
   name: "Dark Cloud 2"
   region: "NTSC-U"
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCUS-97214:
   name: "NCAA GameBreaker 2003"
   region: "NTSC-U"
@@ -5958,8 +5823,6 @@ SCUS-97225:
     eeRoundMode: 0 # Fixes textures on the doors.
   clampModes:
     vuClampMode: 0 # Fix other SPS.
-  gameFixes:
-    - VUKickstartHack # Fixes objects disappearing.
 SCUS-97226:
   name: "NCAA GameBreaker 2003 [Demo]"
   region: "NTSC-U"
@@ -5971,8 +5834,6 @@ SCUS-97229:
   region: "NTSC-U"
   clampModes:
     eeClampMode: 3 # Fixes textbox.
-  gameFixes:
-    - VUKickstartHack # Fixes shadow flickering with synchronized VU1
 SCUS-97230:
   name: "SOCOM - U.S. Navy SEALs (Online)"
   region: "NTSC-U"
@@ -6007,7 +5868,6 @@ SCUS-97240:
   name: "Ratchet & Clank [EB Games Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   roundModes:
     eeRoundMode: 0 # Fixes Hydrodisplacer behaviour.
@@ -6075,6 +5935,8 @@ SCUS-97262:
 SCUS-97263:
   name: "My Street [Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SCUS-97264:
   name: "Syphon Filter - The Omega Strain"
   region: "NTSC-U"
@@ -6092,8 +5954,6 @@ SCUS-97265:
   name: "Jak II"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97266:
   name: "Final Fantasy XI [Disc1of2]"
   region: "NTSC-U"
@@ -6103,7 +5963,6 @@ SCUS-97268:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCUS-97268"
@@ -6124,13 +5983,9 @@ SCUS-97272:
 SCUS-97273:
   name: "Jak II [Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97274:
   name: "Jak II [Video Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97275:
   name: "SOCOM II - U.S. Navy SEALs"
   region: "NTSC-U"
@@ -6138,7 +5993,6 @@ SCUS-97275:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 SCUS-97276:
   name: "NFL GameDay 2004"
   region: "NTSC-U"
@@ -6153,8 +6007,6 @@ SCUS-97279:
   name: "Jet Li - Rise to Honor"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SCUS-97280:
   name: "Jampack Demo Disc - Summer 2003 [T-Rated]"
   region: "NTSC-U"
@@ -6197,13 +6049,11 @@ SCUS-97322:
   name: "Ratchet & Clank 2 - Going Commando [Regular Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97323:
   name: "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97324:
   name: "Kiosk Demo Disc 2.11"
@@ -6238,8 +6088,6 @@ SCUS-97330:
   name: "Jak 3"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
   region: "NTSC-U"
@@ -6291,7 +6139,6 @@ SCUS-97353:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
   memcardFilters:
     - "SCUS-97353"
@@ -6322,7 +6169,6 @@ SCUS-97366:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 SCUS-97367:
   name: "Neopets - The Darkest Faerie"
   region: "NTSC-U"
@@ -6336,7 +6182,6 @@ SCUS-97368:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 SCUS-97369:
   name: "ATV Off-Road Fury 2"
   region: "NTSC-U"
@@ -6344,8 +6189,6 @@ SCUS-97369:
 SCUS-97372:
   name: "Jet Li-Rise to Honor [Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SCUS-97373:
   name: "989 Sports 2004 Demo Disc"
   region: "NTSC-U"
@@ -6353,7 +6196,6 @@ SCUS-97374:
   name: "Ratchet & Clank 2 - Going Commando & Jak II [Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS (for both).
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97377:
   name: "Syphon Filter - The Omega Strain [Regular Demo]"
@@ -6372,7 +6214,6 @@ SCUS-97381:
   name: "Ratchet & Clank 2 - Going Commando [GameStop Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97382:
   name: "NBA Shootout 2004 [Demo]"
@@ -6444,18 +6285,14 @@ SCUS-97411:
   name: "Ratchet & Clank - Up Your Arsenal [Regular Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97414:
   name: "EyeToy - AntiGrav"
@@ -6505,8 +6342,6 @@ SCUS-97429:
   name: "Jak X - Combat Racing"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
   memcardFilters:
     - "SCUS-97429"
     - "SCUS-97465"
@@ -6543,8 +6378,6 @@ SCUS-97438:
 SCUS-97440:
   name: "Jak and Daxter Trilogy [Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97441:
   name: "The Getaway - Black Monday [Demo]"
   region: "NTSC-U"
@@ -6619,7 +6452,6 @@ SCUS-97465:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97466:
   name: "Gretzky NHL '06"
@@ -6708,25 +6540,19 @@ SCUS-97485:
   name: "Ratchet - Deadlocked [Regular Demo]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97486:
   name: "Jak X - Combat Racing [Regular Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97487:
   name: "Ratchet - Deadlocked [Public Beta v.1]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97488:
   name: "Jak X - Combat Racing [Public Beta v.1]"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97489:
   name: "SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]"
   region: "NTSC-U"
@@ -6792,8 +6618,6 @@ SCUS-97507:
 SCUS-97509:
   name: "Jak II [Greatest Hits]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97510:
   name: "ATV Off-Road Fury 2 [Greatest Hits]"
   region: "NTSC-U"
@@ -6804,7 +6628,6 @@ SCUS-97511:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 SCUS-97512:
   name: "Gran Turismo 3 - A-Spec [Greatest Hits]"
   region: "NTSC-U"
@@ -6815,7 +6638,6 @@ SCUS-97513:
   name: "Ratchet & Clank 2 - Going Commando [Greatest Hits]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97514:
   name: "ATV Off-Road Fury 3 [Greatest Hits]"
@@ -6826,8 +6648,6 @@ SCUS-97515:
 SCUS-97516:
   name: "Jak 3 [Greatest Hits]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
   region: "NTSC-U"
@@ -6837,7 +6657,6 @@ SCUS-97518:
   name: "Ratchet & Clank - Up Your Arsenal [Greatest Hits]"
   region: "NTSC-U"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 SCUS-97519:
   name: "Sly 2 - Band of Thieves [Greatest Hits]"
@@ -6914,8 +6733,6 @@ SCUS-97554:
 SCUS-97555:
   name: "Jak and Daxter Complete Trilogy [Demo]"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS (for all 3 games).
 SCUS-97556:
   name: "MLB '07 - The Show"
   region: "NTSC-U"
@@ -6926,8 +6743,6 @@ SCUS-97558:
   name: "Jak and Daxter: The Lost Frontier"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SCUS-97560:
   name: "SOCOM - U.S. Navy SEALs - Combined Assault [Demo]"
   region: "NTSC-U"
@@ -7177,8 +6992,6 @@ SLAJ-25046:
 SLAJ-25047:
   name: "Dororo"
   region: "NTSC-Ch-J"
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SLAJ-25048:
   name: "Sengoku Musou Mushoden"
   region: "NTSC-Unk"
@@ -7430,13 +7243,10 @@ SLED-53719:
 SLED-53723:
   name: "Peter Jackson's King Kong [Demo]"
   region: "PAL-E"
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLED-53732:
   name: "Spartan: Total Warrior [Demo]"
   region: "PAL"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes garbage textures flashing on the character model 
 SLED-53745:
   name: "Total Overdose [Demo]"
@@ -8212,8 +8022,6 @@ SLES-50306:
   name: "Resident Evil - CODE Veronica X"
   region: "PAL-M4"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes lightning effects.
 SLES-50310:
   name: "Freak Out"
   region: "PAL-E"
@@ -8343,6 +8151,8 @@ SLES-50396:
   name: "Mike Tyson Heavyweight Boxing"
   region: "PAL-M5"
   compat: 4
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SLES-50397:
   name: "Prisoner of War"
   region: "PAL-M5"
@@ -8588,8 +8398,6 @@ SLES-50539:
 SLES-50540:
   name: "Simpsons Road Rage"
   region: "PAL-E"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Character Models.
 SLES-50541:
   name: "Capcom vs. SNK 2 - Mark of the Millennium"
   region: "PAL-E"
@@ -8718,8 +8526,6 @@ SLES-50620:
 SLES-50628:
   name: "Simpsons Road Rage"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Character Models.
 SLES-50630:
   name: "Dragon Rage"
   region: "PAL-E"
@@ -9456,14 +9262,10 @@ SLES-50984:
   name: "Gumball 3000"
   region: "PAL-E"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes minor random car SPS.
 SLES-50985:
   name: "Gumball 3000"
   region: "PAL-M5"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes minor random car SPS.
 SLES-50986:
   name: "Twin Caliber"
   region: "PAL-M4"
@@ -9592,8 +9394,6 @@ SLES-51057:
 SLES-51058:
   name: "Maken Shao - Demon Sword"
   region: "PAL-E"
-  gameFixes:
-    - VUKickstartHack  # Fixes SPS.
   speedHacks:
     mvuFlagSpeedHack: 0
 SLES-51060:
@@ -9791,8 +9591,6 @@ SLES-51144:
   name: "Shox - Rally Reinvented"
   region: "PAL-M7"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLES-51145:
   name: "Monopoly Party"
   region: "PAL-M5"
@@ -10004,13 +9802,9 @@ SLES-51250:
   name: "Shox - Rally Reinvented"
   region: "PAL-E"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLES-51251:
   name: "Shox - Rally Reinvented"
   region: "PAL-E"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLES-51252:
   name: "Lord of the Rings, The - The Two Towers"
   region: "PAL-M3"
@@ -10760,14 +10554,11 @@ SLES-51690:
 SLES-51693:
   name: "Suffering, The"
   region: "PAL-E-F-G"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLES-51696:
   name: "Dragon's Lair 3D - Special Edition"
   region: "PAL-M5"
   gameFixes:
     - EETimingHack # Fixes hang before going ingame.
-    - VUKickstartHack # Fixes SPS.
 SLES-51697:
   name: "SSX 3"
   region: "PAL-M5"
@@ -11232,8 +11023,6 @@ SLES-51917:
   region: "PAL-M6"
   roundModes:
     eeRoundMode: 0  # Fixes SPS with water in some places.
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SLES-51918:
   name: "Prince of Persia - The Sands of Time"
   region: "PAL-M5"
@@ -11409,8 +11198,6 @@ SLES-52001:
   name: "Mission Impossible - Operation Surma"
   region: "PAL-M5"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes crashes and broken graphics.
 SLES-52002:
   name: "Rogue Ops"
   region: "PAL-M6"
@@ -12145,8 +11932,6 @@ SLES-52439:
   name: "Suffering, The"
   region: "PAL-E-I-S"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLES-52440:
   name: "Harry Potter and the Prisoner of Azkaban"
   region: "PAL-M7"
@@ -12440,7 +12225,6 @@ SLES-52568:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
-    - VUKickstartHack # Fixes graphical glitches.
 SLES-52569:
   name: "Spyro - A Hero's Tail"
   region: "PAL-M6"
@@ -12862,8 +12646,6 @@ SLES-52754:
 SLES-52755:
   name: "Blood Will Tell"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SLES-52760:
   name: "Pro Evolution Soccer 4"
   region: "PAL-M4"
@@ -14132,13 +13914,11 @@ SLES-53393:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes garbage textures flashing on the character model
 SLES-53396:
   name: "Spartan Total Warrior"
   region: "PAL-M3"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes garbage textures flashing on the character model
 SLES-53398:
   name: "Zombie Zone"
@@ -14338,8 +14118,6 @@ SLES-53491:
 SLES-53492:
   name: "Total Overdose"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLES-53494:
   name: "Spongebob SquarePants - Lights, Camera, PANTS!"
   region: "PAL-E"
@@ -14437,8 +14215,6 @@ SLES-53525:
 SLES-53526:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-E-F"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -14450,8 +14226,6 @@ SLES-53526:
 SLES-53527:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-E-I-S"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -14463,8 +14237,6 @@ SLES-53527:
 SLES-53528:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-G"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -14744,8 +14516,6 @@ SLES-53624:
 SLES-53626:
   name: "Suffering, The - Ties that Bind"
   region: "PAL-E-G"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   memcardFilters:
     - "SLES-53526"
     - "SLES-53527"
@@ -14914,7 +14684,6 @@ SLES-53701:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes texture normals.
-    - VUKickstartHack # Fixes loading hang.
 SLES-53702:
   name: "Resident Evil 4"
   region: "PAL-M5"
@@ -14923,18 +14692,12 @@ SLES-53703:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-M10"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLES-53704:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-R"
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLES-53705:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-PL-E"
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLES-53706:
   name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
   region: "PAL-E"
@@ -15365,8 +15128,6 @@ SLES-53903:
 SLES-53904:
   name: "DT Racer"
   region: "PAL-M5"
-  gameFixes:
-    - VUKickstartHack # Fixes TLB misses and collision bugs.
 SLES-53906:
   name: "50cent - Bulletproof"
   region: "PAL-F"
@@ -15614,7 +15375,6 @@ SLES-54021:
   region: "PAL-M5"
   gameFixes:
     - EETimingHack # Fixes game engine errors when going ingame.
-    - VUKickstartHack # Fixes shadows on some surfaces.
   patches:
     b02c81e5:
       content: |-
@@ -16131,8 +15891,6 @@ SLES-54307:
   name: "Rayman - Raving Rabbids"
   region: "PAL-M6"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLES-54308:
   name: "Phantasy Star Universe"
   region: "PAL-M3"
@@ -16552,8 +16310,6 @@ SLES-54463:
   region: "PAL-A"
   clampModes:
     vuClampMode: 3
-  gameFixes:
-    - VUKickstartHack
   patches:
     DFBAE612:
       content: |-
@@ -16772,8 +16528,6 @@ SLES-54560:
   region: "PAL-M3"
   clampModes:
     vuClampMode: 3 # Fixes SPS.
-  gameFixes:
-    - VUKickstartHack
 SLES-54561:
   name: "Capcom Classics Collection Vol. 2"
   region: "PAL-E"
@@ -16926,33 +16680,28 @@ SLES-54644:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLES-54645:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-F"
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLES-54646:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-G"
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLES-54647:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-I"
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLES-54648:
   name: "Valkyrie Profile 2 - Silmeria"
   region: "PAL-S"
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLES-54653:
   name: "Freak Out - Extreme Freeride"
   region: "PAL-M5"
@@ -17613,6 +17362,8 @@ SLES-54945:
 SLES-54946:
   name: "Sega Superstars Tennis"
   region: "PAL-M5"
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SLES-54947:
   name: "Dogz"
   region: "PAL-M6"
@@ -17724,8 +17475,6 @@ SLES-54994:
   name: "Pippa Funnell - Ranch Rescue"
   region: "PAL-M11"
   compat: 5
-  gameFixes:
-    - VUKickstartHack
 SLES-54995:
   name: "Puzzle Quest - Challenge of the Warlords"
   region: "PAL-M5"
@@ -17795,7 +17544,6 @@ SLES-55013:
   region: "PAL-M5"
   gameFixes:
     - EETimingHack # Fixes game engine errors when going ingame.
-    - VUKickstartHack # Fixes distant shadows.
   patches:
     304497e5:
       content: |-
@@ -17817,8 +17565,6 @@ SLES-55018:
 SLES-55019:
   name: "Ratchet & Clank - Size Matters"
   region: "PAL-M13"
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SLES-55020:
   name: "Die Simpsons - Das Spiel"
   region: "PAL-G"
@@ -19053,14 +18799,12 @@ SLES-82028:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLES-82029:
   name: "Star Ocean 3 - Till the End of Time [Disc2of2]"
   region: "PAL-E"
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
   memcardFilters:
     - "SLES-82028"
 SLES-82030:
@@ -19575,8 +19319,6 @@ SLKA-25225:
   name: "Dororo"
   region: "NTSC-K"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SLKA-25227:
   name: "Neo Contra"
   region: "NTSC-K"
@@ -20170,8 +19912,6 @@ SLPM-60282:
 SLPM-61007:
   name: "Maken Shao [Trial]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   speedHacks:
     mvuFlagSpeedHack: 0
 SLPM-61009:
@@ -20526,8 +20266,6 @@ SLPM-62132:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2  # Fixes minimap HUD.
-  gameFixes:
-    - VUKickstartHack # Fixes missing geometry.
 SLPM-62133:
   name: "Bloody Roar 3 [Konami The Best]"
   region: "NTSC-J"
@@ -22073,8 +21811,6 @@ SLPM-62736:
 SLPM-62737:
   name: "Rally Shox & Freestyle Motorcross [EA Best Hits]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLPM-62739:
   name: "Suro Genjin"
   region: "NTSC-J"
@@ -22667,8 +22403,6 @@ SLPM-65143:
 SLPM-65144:
   name: "Maken Shao"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   speedHacks:
     mvuFlagSpeedHack: 0
 SLPM-65148:
@@ -22826,7 +22560,6 @@ SLPM-65209:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
   patches:
     BEC32D49:
       content: |-
@@ -23558,14 +23291,12 @@ SLPM-65438:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLPM-65439:
   name: "Star Ocean 3 [Director's Cut] [Disc2of2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
   memcardFilters:
     - "SLPM-65438"
 SLPM-65441:
@@ -23820,16 +23551,12 @@ SLPM-65525:
 SLPM-65526:
   name: "Dororo"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SLPM-65527:
   name: "FIFA Total Football"
   region: "NTSC-J"
 SLPM-65529:
   name: "Mission Impossible - Operation Surma"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes crashes and broken graphics.
 SLPM-65530:
   name: "J-League Pro Soccer Club - Tsukuku 2004"
   region: "NTSC-J"
@@ -24356,8 +24083,6 @@ SLPM-65700:
 SLPM-65701:
   name: "Ghost Hunter"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Missing Graphics.
 SLPM-65702:
   name: "Sangokushi Senki [Koei Collection Series]"
   region: "NTSC-J"
@@ -24672,14 +24397,12 @@ SLPM-65800:
   region: "NTSC-J"
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLPM-65801:
   name: "Crash Bandicoot 5"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad geometry.
-    - VUKickstartHack # Fixes loading hang.
 SLPM-65802:
   name: "Def Jam - Vendetta [EA Best Hits]"
   region: "NTSC-J"
@@ -25910,8 +25633,6 @@ SLPM-66206:
 SLPM-66207:
   name: "Dororo [Sega the Best 2800]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SLPM-66208:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]"
   region: "NTSC-J"
@@ -25924,8 +25645,6 @@ SLPM-66210:
 SLPM-66211:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLPM-66212:
   name: "Sega Rally 2006"
   region: "NTSC-J"
@@ -26599,7 +26318,6 @@ SLPM-66419:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLPM-66420:
   name: "Front Mission 4 [Ultimate Hits]"
   region: "NTSC-J"
@@ -26679,7 +26397,6 @@ SLPM-66444:
   name: "Spartan - Total Warrior"
   region: "NTSC-J"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes garbage textures flashing on the character model 
 SLPM-66445:
   name: "Persona 3"
@@ -26817,14 +26534,12 @@ SLPM-66478:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLPM-66479:
   name: "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc2of2]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
   memcardFilters:
     - "SLPM-66478"
 SLPM-66480:
@@ -27826,7 +27541,6 @@ SLPM-66782:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLPM-66783:
   name: "Idol Janshi Suchie-Pai 4 [Limited Edition]"
   region: "NTSC-J"
@@ -28969,8 +28683,6 @@ SLPS-20038:
 SLPS-20040:
   name: "MotoGP"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes Crash On Load
 SLPS-20041:
   name: "Mahjong Goku Taisei"
   region: "NTSC-J"
@@ -30099,15 +29811,11 @@ SLPS-25041:
 SLPS-25042:
   name: "Maken Shao [Limited Edition]"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   speedHacks:
     mvuFlagSpeedHack: 0
 SLPS-25043:
   name: "Maken Shao"
   region: "NTSC-J"
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
   speedHacks:
     mvuFlagSpeedHack: 0
 SLPS-25044:
@@ -33645,8 +33353,6 @@ SLUS-20058:
   name: "MotoGP"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes crash on load.
 SLUS-20062:
   name: "Grand Theft Auto III"
   region: "NTSC-U"
@@ -33886,8 +33592,6 @@ SLUS-20138:
 SLUS-20139:
   name: "Simpsons, The - Road Rage"
   region: "NTSC-U"
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Character Models.
 SLUS-20140:
   name: "NHL Hitz 2002"
   region: "NTSC-U"
@@ -34065,8 +33769,6 @@ SLUS-20184:
   name: "Resident Evil - CODE Veronica X"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes lightning effects.
 SLUS-20186:
   name: "Monster Jam - Maximum Destruction"
   region: "NTSC-U"
@@ -34578,8 +34280,6 @@ SLUS-20305:
   name: "Simpsons, The - Road Rage"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Bad Character Models.
 SLUS-20306:
   name: "Contra - Shattered Soldier"
   region: "NTSC-U"
@@ -34741,6 +34441,8 @@ SLUS-20345:
   name: "Mike Tyson - Heavyweight Boxing"
   region: "NTSC-U"
   compat: 4
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SLUS-20346:
   name: "AirBlade"
   region: "NTSC-U"
@@ -34975,8 +34677,6 @@ SLUS-20400:
   name: "Mission Impossible - Operation Surma"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes crashes and broken graphics.
 SLUS-20402:
   name: "Britney's Dance Beat"
   region: "NTSC-U"
@@ -35369,7 +35069,6 @@ SLUS-20488:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLUS-20489:
   name: "Whirl Tour"
   region: "NTSC-U"
@@ -35549,8 +35248,6 @@ SLUS-20533:
   name: "Shox"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLUS-20534:
   name: "Cabela's Big Game Hunter"
   region: "NTSC-U"
@@ -35990,8 +35687,6 @@ SLUS-20636:
   name: "Suffering, The"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLUS-20637:
   name: "Chessmaster (Online)"
   region: "NTSC-U"
@@ -36524,8 +36219,6 @@ SLUS-20763:
   compat: 5
   roundModes:
     eeRoundMode: 0  # Fixes SPS with water in some places.
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SLUS-20764:
   name: "Bombastic"
   region: "NTSC-U"
@@ -36593,8 +36286,6 @@ SLUS-20782:
   name: "Blood Will Tell"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes main character model SPS.
 SLUS-20784:
   name: "Italian Job, The"
   region: "NTSC-U"
@@ -37012,7 +36703,6 @@ SLUS-20891:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes character SPS.
   memcardFilters:
     - "SLUS-20488"
 SLUS-20892:
@@ -37091,7 +36781,6 @@ SLUS-20909:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad geometry.
-    - VUKickstartHack # Fixes graphical glitches.
 SLUS-20910:
   name: "Test Drive - Eve of Destruction"
   region: "NTSC-U"
@@ -37493,8 +37182,6 @@ SLUS-20993:
   name: "Ghosthunter"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Missing Graphics.
 SLUS-20994:
   name: "Full Metal Alchemist and The Broken Angel"
   region: "NTSC-U"
@@ -37965,8 +37652,6 @@ SLUS-21095:
   name: "DT Racer"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes TLB misses and collision bugs.
 SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
   region: "NTSC-U"
@@ -38478,7 +38163,6 @@ SLUS-21212:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes garbage textures flashing on the character model
 SLUS-21213:
   name: "Madden NFL '06"
@@ -38739,7 +38423,6 @@ SLUS-21262:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLUS-21263:
   name: "Romancing SaGa"
   region: "NTSC-U"
@@ -38774,8 +38457,6 @@ SLUS-21268:
   compat: 5
   clampModes:
     vuClampMode: 2  # Fixes minimap HUD.
-  gameFixes:
-    - VUKickstartHack # Fixes missing geometry.
 SLUS-21269:
   name: "Bully"
   region: "NTSC-U"
@@ -38796,7 +38477,6 @@ SLUS-21272:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes texture normals.
-    - VUKickstartHack # Fixes loading hang.
 SLUS-21273:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-U"
@@ -38839,8 +38519,6 @@ SLUS-21283:
   name: "Total Overdose - A Gunslinger's Tale in Mexico"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLUS-21284:
   name: "Nicktoons Unite!"
   region: "NTSC-U"
@@ -38958,8 +38636,6 @@ SLUS-21311:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLUS-21312:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-U"
@@ -38974,7 +38650,6 @@ SLUS-21314:
   compat: 4
   gameFixes:
     - EETimingHack # Needed to go ingame.
-    - VUKickstartHack # Fixes shadows on some surfaces.
   patches:
     f73488d5:
       content: |-
@@ -39495,8 +39170,6 @@ SLUS-21418:
   compat: 5
   clampModes:
     vuClampMode: 3
-  gameFixes:
-    - VUKickstartHack
   patches:
     A08C4057:
       content: |-
@@ -39665,7 +39338,6 @@ SLUS-21452:
   compat: 5
   gameFixes:
     - VuAddSubHack
-    - VUKickstartHack # Fixes Character SPS.
 SLUS-21453:
   name: "Disney's Meet the Robinsons"
   region: "NTSC-U"
@@ -40075,8 +39747,6 @@ SLUS-21576:
   name: "Rayman - Raving Rabbids"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes bad polygons on characters.
 SLUS-21577:
   name: "Odin Sphere"
   region: "NTSC-U"
@@ -40579,8 +40249,6 @@ SLUS-21689:
         //prafull's patch to fix hang at first loading screen
         //Game also works with ee timing rate +2 or +3
         patch=1,EE,002f6d70,word,00000000
-  gameFixes:
-    - VUKickstartHack # Fixes SPS.
 SLUS-21690:
   name: "Alone in the Dark"
   region: "NTSC-U"
@@ -40609,7 +40277,6 @@ SLUS-21697:
   compat: 3
   gameFixes:
     - EETimingHack # Fixes game engine errors when going ingame.
-    - VUKickstartHack # Fixes distant shadows.
   patches:
     304497e5:
       content: |-
@@ -40774,6 +40441,8 @@ SLUS-21732:
 SLUS-21733:
   name: "Sega Superstars Tennis"
   region: "NTSC-U"
+  gameFixes:
+    - VUSyncHack # Fixes SPS.
 SLUS-21734:
   name: "Falling Stars"
   region: "NTSC-U"
@@ -42010,8 +41679,6 @@ SLUS-29082:
   region: "NTSC-U"
   roundModes:
     eeRoundMode: 0  # Fixes SPS with water in some places.
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 SLUS-29083:
   name: "Maximo vs. The Army of Zin [Demo]"
   region: "NTSC-U"
@@ -42057,7 +41724,6 @@ SLUS-29101:
   region: "NTSC-U"
   gameFixes:
     - XGKickHack # Fixes bad geometry.
-    - VUKickstartHack # Fixes loading hang (only for Crash).
 SLUS-29104:
   name: "Galactic Wrestling - Featuring Ultimate Muscle [Demo]"
   region: "NTSC-U"
@@ -42298,7 +41964,6 @@ TCES-51904:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
-    - VUKickstartHack # Stops you seeing through walls.
 TCES-52004:
   name: "Killzone Beta Trial Code"
   region: "PAL-E"
@@ -42319,7 +41984,6 @@ TCES-52456:
   name: "Ratchet and Clank 3 Beta Trial Code"
   region: "PAL-E"
   gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
     - EETimingHack # Fixes SPR errors while going in-game.
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
@@ -42336,8 +42000,6 @@ TCES-53286:
   name: "Jak X Beta Trial Code"
   region: "PAL-E"
   compat: 5
-  gameFixes:
-    - VUKickstartHack # Fixes Character SPS.
 TCPS-10058:
   name: "Densha de Go! Shinkansen [with Controller]"
   region: "NTSC-J"

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
@@ -44,7 +44,7 @@ GameFixSettingsWidget::GameFixSettingsWidget(SettingsDialog* dialog, QWidget* pa
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.VIF1StallHack, "EmuCore/Gamefixes", "VIF1StallHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.VuAddSubHack, "EmuCore/Gamefixes", "VuAddSubHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.IbitHack, "EmuCore/Gamefixes", "IbitHack", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.VUKickstartHack, "EmuCore/Gamefixes", "VUKickstartHack", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.VUSyncHack, "EmuCore/Gamefixes", "VUSyncHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.VUOverflowHack, "EmuCore/Gamefixes", "VUOverflowHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.XgKickHack, "EmuCore/Gamefixes", "XgKickHack", false);
 }

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.ui
@@ -128,9 +128,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="VUKickstartHack">
+       <widget class="QCheckBox" name="VUSyncHack">
         <property name="text">
-         <string>VU Kickstart Hack (Run Ahead)</string>
+         <string>VU Sync (Run Behind, M-Bit games)</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -42,7 +42,7 @@ enum GamefixId
 	Fix_VIF1Stall,
 	Fix_VuAddSub,
 	Fix_Ibit,
-	Fix_VUKickstart,
+	Fix_VUSync,
 	Fix_VUOverflow,
 	Fix_XGKick,
 
@@ -726,7 +726,7 @@ struct Pcsx2Config
 			VIF1StallHack : 1, // Like above, processes FIFO data before the stall is allowed (to make sure data goes over).
 			VuAddSubHack : 1, // Tri-ace games, they use an encryption algorithm that requires VU ADDI opcode to be bit-accurate.
 			IbitHack : 1, // I bit hack. Needed to stop constant VU recompilation in some games
-			VUKickstartHack : 1, // Gives new VU programs a slight head start and runs VU's ahead of EE to avoid VU register reading/writing issues
+			VUSyncHack : 1, // Makes microVU run behind the EE to avoid VU register reading/writing sync issues. Useful for M-Bit games
 			VUOverflowHack : 1, // Tries to simulate overflow flag checks (not really possible on x86 without soft floats)
 			XgKickHack : 1; // Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics, but breaks Tri-ace games and others.
 		BITFIELD_END

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -38,7 +38,7 @@ SERIAL-12345: # !required! Serial number for the game, this is how games are loo
     - GIFFIFOHack
     - GoemonTlbHack
     - IbitHack
-    - VUKickstartHack
+    - VSyncHack
     - VUOverflowHack
   # The value of the speedhacks is assumed to be an integer,
   # but at the time of writing speedhacks are effectively booleans (0/1)
@@ -169,8 +169,8 @@ These values are case-sensitive so take care.  If you incorrectly specify a Game
 *   `IbitHack`
     *   VU I bit Hack avoid constant recompilation in some games (Scarface The World Is Yours, Crash Tag Team Racing).
 
-*   `VUKickstartHack`
-    *   Let the VU's both run ahead of the EE to fix some timing issues.
+*   `VUSyncHack`
+    *   Make the VU's run behind/in sync with the EE to fix some timing issues.
 
 *   `VUOverflowHack`
     *   VU Overflow hack to check for possible float overflows (Superman Returns).

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -743,7 +743,7 @@ static const char* const tbl_GamefixNames[] =
 		"VIF1Stall",
 		"VuAddSub",
 		"Ibit",
-		"VUKickstart",
+		"VUSync",
 		"VUOverflow",
 		"XGKick"};
 
@@ -835,8 +835,8 @@ void Pcsx2Config::GamefixOptions::Set(GamefixId id, bool enabled)
 		case Fix_Ibit:
 			IbitHack = enabled;
 			break;
-		case Fix_VUKickstart:
-			VUKickstartHack = enabled;
+		case Fix_VUSync:
+			VUSyncHack = enabled;
 			break;
 		case Fix_VUOverflow:
 			VUOverflowHack = enabled;
@@ -878,8 +878,8 @@ bool Pcsx2Config::GamefixOptions::Get(GamefixId id) const
 			return GoemonTlbHack;
 		case Fix_Ibit:
 			return IbitHack;
-		case Fix_VUKickstart:
-			return VUKickstartHack;
+		case Fix_VUSync:
+			return VUSyncHack;
 		case Fix_VUOverflow:
 			return VUOverflowHack;
 			jNO_DEFAULT;
@@ -905,7 +905,7 @@ void Pcsx2Config::GamefixOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(GIFFIFOHack);
 	SettingsWrapBitBool(GoemonTlbHack);
 	SettingsWrapBitBool(IbitHack);
-	SettingsWrapBitBool(VUKickstartHack);
+	SettingsWrapBitBool(VUSyncHack);
 	SettingsWrapBitBool(VUOverflowHack);
 }
 

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -147,7 +147,7 @@ public:
 	// Executes a Block based on EE delta time (see VUmicro.cpp)
 	virtual void ExecuteBlock(bool startUp=0);
 
-	static void __fastcall ExecuteBlockJIT(BaseVUmicroCPU* cpu);
+	static void __fastcall ExecuteBlockJIT(BaseVUmicroCPU* cpu, bool interlocked);
 
 	// VU1 sometimes needs to break execution on XGkick Path1 transfers if
 	// there is another gif path 2/3 transfer already taking place.

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -93,7 +93,7 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			wxEmptyString
 		},
 		{
-			_("VU Kickstart (Run ahead) to avoid sync problems when reading or writing VU registers"),
+			_("VU Sync (Run behind) to avoid sync problems when reading or writing VU registers"),
 			wxEmptyString
 		},
 		{

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -27,6 +27,7 @@ extern u32 pc;             // recompiler pc
 extern int g_branch;       // set for branch
 extern u32 target;         // branch target
 extern u32 s_nBlockCycles; // cycles of current block recompiling
+extern bool s_nBlockInterlocked; // Current block has VU0 interlocking
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -61,7 +61,7 @@ alignas(16) static u32 hwLUT[_64kb];
 static __fi u32 HWADDR(u32 mem) { return hwLUT[mem >> 16] + mem; }
 
 u32 s_nBlockCycles = 0; // cycles of current block recompiling
-
+bool s_nBlockInterlocked = false; // Block is VU0 interlocked
 u32 pc;       // recompiler pc
 int g_branch; // set for branch
 
@@ -1927,6 +1927,7 @@ static void __fastcall recRecompile(const u32 startpc)
 
 	// reset recomp state variables
 	s_nBlockCycles = 0;
+	s_nBlockInterlocked = false;
 	pc = startpc;
 	g_cpuHasConstReg = g_cpuFlushedConstReg = 1;
 	pxAssert(g_cpuConstRegs[0].UD[0] == 0);

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -963,7 +963,8 @@ void recLQC2()
 	xForwardJL32 skip;
 	_cop2BackupRegs();
 	xLoadFarAddr(arg1reg, CpuVU0);
-	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+	xMOV(arg2reg, s_nBlockInterlocked);
+	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 	_cop2RestoreRegs();
 	skip.SetTarget();
 	skipvuidle.SetTarget();
@@ -1012,7 +1013,8 @@ void recSQC2()
 	xForwardJL32 skip;
 	_cop2BackupRegs();
 	xLoadFarAddr(arg1reg, CpuVU0);
-	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+	xMOV(arg2reg, s_nBlockInterlocked);
+	xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 	_cop2RestoreRegs();
 	skip.SetTarget();
 	skipvuidle.SetTarget();

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -959,7 +959,7 @@ void recLQC2()
 	xForwardJZ32 skipvuidle;
 	xSUB(eax, ptr32[&VU0.cycle]);
 	xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-	xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 4 : 0);
+	xCMP(eax, 4);
 	xForwardJL32 skip;
 	_cop2BackupRegs();
 	xLoadFarAddr(arg1reg, CpuVU0);
@@ -1009,7 +1009,7 @@ void recSQC2()
 	xForwardJZ32 skipvuidle;
 	xSUB(eax, ptr32[&VU0.cycle]);
 	xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-	xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 4 : 0);
+	xCMP(eax, 4);
 	xForwardJL32 skip;
 	_cop2BackupRegs();
 	xLoadFarAddr(arg1reg, CpuVU0);

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -469,7 +469,7 @@ void mVUtestCycles(microVU& mVU, microFlagCycles& mFC)
 	iPC = mVUstartPC;
 
 	xMOV(eax, ptr32[&mVU.cycles]);
-	if (!EmuConfig.Gamefixes.VUKickstartHack)
+	if (EmuConfig.Gamefixes.VUSyncHack)
 		xSUB(eax, mVUcycles); // Running behind, make sure we have time to run the block
 	else
 		xSUB(eax, 1); // Running ahead, make sure cycles left are above 0

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -340,7 +340,7 @@ void COP2_Interlock(bool mBitSync)
 		{
 			xSUB(eax, ptr32[&VU0.cycle]);
 			xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-			xCMP(eax, 0);
+			xCMP(eax, 4);
 			xForwardJL32 skip;
 			xLoadFarAddr(arg1reg, CpuVU0);
 			xMOV(arg2reg, s_nBlockInterlocked);
@@ -385,7 +385,7 @@ static void recCFC2()
 		xForwardJZ32 skipvuidle;
 		xSUB(eax, ptr32[&VU0.cycle]);
 		xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-		xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 8 : 0);
+		xCMP(eax, 4);
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
@@ -448,7 +448,7 @@ static void recCTC2()
 		xForwardJZ32 skipvuidle;
 		xSUB(eax, ptr32[&VU0.cycle]);
 		xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-		xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 8 : 0);
+		xCMP(eax, 4);
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
@@ -551,7 +551,7 @@ static void recQMFC2()
 		xForwardJZ32 skipvuidle;
 		xSUB(eax, ptr32[&VU0.cycle]);
 		xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-		xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 8 : 0);
+		xCMP(eax, 4);
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
@@ -592,7 +592,7 @@ static void recQMTC2()
 		xForwardJZ32 skipvuidle;
 		xSUB(eax, ptr32[&VU0.cycle]);
 		xSUB(eax, ptr32[&VU0.nextBlockCycles]);
-		xCMP(eax, EmuConfig.Gamefixes.VUKickstartHack ? 8 : 0);
+		xCMP(eax, 4);
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -327,6 +327,7 @@ void COP2_Interlock(bool mBitSync)
 
 	if (cpuRegs.code & 1)
 	{
+		s_nBlockInterlocked = true;
 		_freeX86reg(eax);
 		xMOV(eax, ptr32[&cpuRegs.cycle]);
 		xADD(eax, scaleblockcycles_clear());
@@ -342,7 +343,8 @@ void COP2_Interlock(bool mBitSync)
 			xCMP(eax, 0);
 			xForwardJL32 skip;
 			xLoadFarAddr(arg1reg, CpuVU0);
-			xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+			xMOV(arg2reg, s_nBlockInterlocked);
+			xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 			skip.SetTarget();
 
 			xFastCall((void*)_vu0WaitMicro);
@@ -387,7 +389,8 @@ static void recCFC2()
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
-		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+		xMOV(arg2reg, s_nBlockInterlocked);
+		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 		_cop2RestoreRegs();
 		skip.SetTarget();
 		skipvuidle.SetTarget();
@@ -449,7 +452,8 @@ static void recCTC2()
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
-		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+		xMOV(arg2reg, s_nBlockInterlocked);
+		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 		_cop2RestoreRegs();
 		skip.SetTarget();
 		skipvuidle.SetTarget();
@@ -551,7 +555,8 @@ static void recQMFC2()
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
-		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+		xMOV(arg2reg, s_nBlockInterlocked);
+		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 		_cop2RestoreRegs();
 		skip.SetTarget();
 		skipvuidle.SetTarget();
@@ -591,7 +596,8 @@ static void recQMTC2()
 		xForwardJL32 skip;
 		_cop2BackupRegs();
 		xLoadFarAddr(arg1reg, CpuVU0);
-		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg);
+		xMOV(arg2reg, s_nBlockInterlocked);
+		xFastCall((void*)BaseVUmicroCPU::ExecuteBlockJIT, arg1reg, arg2reg);
 		_cop2RestoreRegs();
 		skip.SetTarget();
 		skipvuidle.SetTarget();


### PR DESCRIPTION
### Description of Changes
Attempt to run the VU (VU0 mainly) ahead if it's only running a small block, to try and reduce overhead.
VU Kickstart is now always on and is replaced with a VU Sync option as less games need the sync than the run ahead.

### Rationale behind Changes
Running blocks of like 3 cycles is very inefficient when you factor in entering and exiting a recompiler, so this makes sure at least a more reasonable amount of cycles is run.

### Suggested Testing Steps
test games, compare to master.

Some preliminary numbers:
Tekken Tag: 80-82 to 82-84
Ratchet & Clank: 102-105 to 110-113
Mike Tyson Heavyweight Boxing: 100 to 102
Ratchet & Clank 3: 75 to 82
Jak 3: 118 to 120

Mixed with #5571 (which has now been rebased in) Ratchet & Clank has gone from 105fps to 122fps at the beginning of the first level, a nice little boost, so these two PR's bring a combined boost of somewhere between 10-20% in a bunch of games.

NOTE: This will NOT affect all games, you have to be EE thread limited and the game has to be VU0 heavy (which isn't a great deal) for it to have much effect, so in most scenarios you probably won't even notice a difference.