### PR TITLE
GS: Texture replacement fixes

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -131,7 +131,7 @@ u32 GSTexture::CalcUploadSize(u32 height, u32 pitch) const
 
 void GSTexture::GenerateMipmapsIfNeeded()
 {
-	if (!m_needs_mipmaps_generated || m_mipmap_levels <= 1)
+	if (!m_needs_mipmaps_generated || m_mipmap_levels <= 1 || IsCompressedFormat())
 		return;
 
 	m_needs_mipmaps_generated = false;

--- a/pcsx2/GS/Renderers/Common/GSTexture.h
+++ b/pcsx2/GS/Renderers/Common/GSTexture.h
@@ -104,7 +104,7 @@ public:
 
 	Type GetType() const { return m_type; }
 	Format GetFormat() const { return m_format; }
-	bool IsCompressedFormat() const { return (m_format >= Format::BC1 && m_format <= Format::BC7); }
+	bool IsCompressedFormat() const { return IsCompressedFormat(m_format); }
 
 	u32 GetCompressedBytesPerBlock() const;
 	u32 GetCompressedBlockSize() const;
@@ -149,4 +149,7 @@ public:
 
 	// Typical size of a RGBA texture
 	virtual u32 GetMemUsage() { return m_size.x * m_size.y * (m_format == Format::UNorm8 ? 1 : 4); }
+
+	// Helper routines for formats/types
+	static bool IsCompressedFormat(Format format) { return (format >= Format::BC1 && format <= Format::BC7); }
 };

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -484,8 +484,8 @@ GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int width, int height
 			desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
 			break;
 		case GSTexture::Type::Texture:
-			desc.BindFlags = (levels > 1) ? (D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE) : D3D11_BIND_SHADER_RESOURCE;
-			desc.MiscFlags = (levels > 1) ? D3D11_RESOURCE_MISC_GENERATE_MIPS : 0;
+			desc.BindFlags = (levels > 1 && !GSTexture::IsCompressedFormat(format)) ? (D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE) : D3D11_BIND_SHADER_RESOURCE;
+			desc.MiscFlags = (levels > 1 && !GSTexture::IsCompressedFormat(format)) ? D3D11_RESOURCE_MISC_GENERATE_MIPS : 0;
 			break;
 		case GSTexture::Type::Offscreen:
 			desc.Usage = D3D11_USAGE_STAGING;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -70,7 +70,8 @@ public:
 	{
 		GSTexture* texture;
 		u32 refcount;
-		u32 age;
+		u16 age;
+		bool is_replacement;
 	};
 
 	class Surface : public GSAlignedClass<32>

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -490,6 +490,20 @@ void GSTextureReplacements::ClearReplacementTextures()
 
 GSTexture* GSTextureReplacements::CreateReplacementTexture(const ReplacementTexture& rtex, const GSVector2& scale, bool mipmap)
 {
+	// can't use generated mipmaps with compressed formats, because they can't be rendered to
+	// in the future I guess we could decompress the dds and generate them... but there's no reason that modders can't generate mips in dds
+	if (mipmap && GSTexture::IsCompressedFormat(rtex.format) && rtex.mips.empty())
+	{
+		static bool log_once = false;
+		if (!log_once)
+		{
+			Console.Warning("Disabling mipmaps on one or more compressed replacement textures.");
+			log_once = true;
+		}
+
+		mipmap = false;
+	}
+
 	GSTexture* tex = g_gs_device->CreateTexture(rtex.width, rtex.height, mipmap, rtex.format);
 	if (!tex)
 		return nullptr;


### PR DESCRIPTION
### Description of Changes

**[GS/TextureReplacements: Disable generated mipmaps on compressed textures]**

This was causing errors in D3D when replacements were loaded, since it was trying to enable/generate mipmaps on compressed formats, which aren't render targets.

**[GS/TextureCache: Don't count replacements in hash cache budget]**

Large replacement textures were causing the hash cache to disable itself. There's plenty of other massive VRAM sinks in PCSX2 that we need to consider before we can say we're managing VRAM well anyway.

### Rationale behind Changes

Fixing my bugs.

### Suggested Testing Steps

Don't really need any, since it's an experimental feature anyway, but I've briefly tested and replacements are still fine.
