### PR TITLE
GS: Handle Auto Flush across pages + improve performance

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -156,12 +156,12 @@ protected:
 	int m_skip;
 	int m_skip_offset;
 	bool m_userhacks_auto_flush;
+	bool tex_flushed;
 
 	GSVertex m_v;
 	float m_q;
 	GSVector4i m_scissor;
 	GSVector4i m_ofxy;
-	bool tex_flushed;
 
 	bool m_scanmask_used;
 
@@ -185,7 +185,8 @@ protected:
 	void UpdateVertexKick();
 
 	void GrowVertexBuffer();
-
+	void HandleAutoFlush();
+	
 	template <u32 prim, bool auto_flush, bool index_swap>
 	void VertexKick(u32 skip);
 

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -49,6 +49,9 @@ GSVertexTrace::GSVertexTrace(const GSState* state)
 
 void GSVertexTrace::Update(const void* vertex, const u32* index, int v_count, int i_count, GS_PRIM_CLASS primclass)
 {
+	if (i_count == 0)
+		return;
+
 	m_primclass = primclass;
 
 	u32 iip = m_state->PRIM->IIP;


### PR DESCRIPTION
### Description of Changes
Handles auto flushing across page boundaries to improve accuracy, also improve performance slightly by checking texture+page boundaries.

### Rationale behind Changes
Auto flush was very aggressive and didn't really emulate the behaviour of the PS2 caching 1 page of texture in memory very well. Plus due to the aggressiveness it flushed a lot more frequently than it needed to.

### Suggested Testing Steps
Test games that require auto flush, make sure they work okay, note any performance or graphical improvements. This affects Software and Hardware modes.

Jak 2 in 3x native has increased from 32fps in the below scene to 92fps!  (To get the lighting correct when upscaling you need HPO (Special Texture) )

Jak 3's shadows during the intro are fixed and performance is again about 3 fold. Fixes #168

Beyond Good and Evil water almost looks like water, it might be actually fixed in the game, but it's hard to tell from a GS Dump.

Tomb raider menu is fixed. Fixes #4950

Fixes glitchy shadow in Ratchet & Clank Going Commando. Fixes #5524

And as for the tracking thread for Auto Flush killing performance, it's no longer a huge issue, so Fixes #5081

Performance impact from post effect in Sniper Elite is also brought down to basically nothing so it can be turned permanently on. Fixes #3005

Goodies:

Jak 2:

Master:
![image](https://user-images.githubusercontent.com/6278726/156806964-e2cd45e4-639e-4a49-9619-edecb93f04ff.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/156866516-267aedb4-d110-4e35-a720-0b8cd714582b.png)

Jak 3:

Master:

![image](https://user-images.githubusercontent.com/6278726/156866579-2cc9804c-117b-4f5c-b5ad-00f3b096cd13.png)

PR:

![image](https://user-images.githubusercontent.com/6278726/156866593-df1e09c4-a8a0-4b0e-8b56-12302b39cc02.png)

Beyond Good and Evil:

Master:

![image](https://user-images.githubusercontent.com/6278726/156866535-05d14e0d-c8ed-484c-8e28-701ea739e7e6.png)

PR:

![image](https://user-images.githubusercontent.com/6278726/156866538-e7b9fd03-8e9d-4450-a7b4-1801662c1203.png)

Tomb Raider:

Master:

![image](https://user-images.githubusercontent.com/6278726/156866637-99e7ae66-9af8-4e17-bf2c-022c5c7c9049.png)

PR:

![image](https://user-images.githubusercontent.com/6278726/156866626-52d2d503-9b56-4d16-b7a4-f67fa21c4ae7.png)

