### PR TITLE
GS/TextureCache: Don't let hash cache memusage go negative

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1138,7 +1138,9 @@ void GSTextureCache::IncAge()
 		HashCacheEntry& e = it->second;
 		if (e.refcount == 0 && ++e.age > max_hash_cache_age)
 		{
-			m_hash_cache_memory_usage -= e.texture->GetMemUsage();
+			if (!e.is_replacement)
+				m_hash_cache_memory_usage -= e.texture->GetMemUsage();
+
 			g_gs_device->Recycle(e.texture);
 			m_hash_cache.erase(it++);
 		}


### PR DESCRIPTION
Regression fix for https://github.com/PCSX2/pcsx2/commit/ba27a46ac617bb170eb5524f2f58cc018e720a86.

Should fix #5578, but I have now way of testing it with larger packs and don't feel like creating one.
