### PR TITLE
WX: Make texture dump location configurable

### DIFF
--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -536,8 +536,8 @@ void AppConfig::FolderOptions::Set(FoldersEnum_t folderidx, const wxString& src,
 			break;
 
 		case FolderId_Textures:
-			Cache = src;
-			UseDefaultCache = useDefault;
+			Textures = src;
+			UseDefaultTextures = useDefault;
 			EmuFolders::Textures = GetResolvedFolder(FolderId_Textures);
 			EmuFolders::Textures.Mkdir();
 			break;
@@ -775,6 +775,7 @@ void AppConfig::FolderOptions::LoadSave(IniInterface& ini)
 	IniBitBool(UseDefaultLangs);
 	IniBitBool(UseDefaultCheats);
 	IniBitBool(UseDefaultCheatsWS);
+	IniBitBool(UseDefaultTextures);
 
 	//when saving in portable mode, we save relative paths if possible
 	//  --> on load, these relative paths will be expanded relative to the exe folder.
@@ -789,6 +790,7 @@ void AppConfig::FolderOptions::LoadSave(IniInterface& ini)
 	IniEntryDirFile(Cheats, rel);
 	IniEntryDirFile(CheatsWS, rel);
 	IniEntryDirFile(Cache, rel);
+	IniEntryDirFile(Textures, rel);
 
 	IniEntryDirFile(RunIso, rel);
 	IniEntryDirFile(RunELF, rel);

--- a/pcsx2/gui/Panels/PathsPanel.cpp
+++ b/pcsx2/gui/Panels/PathsPanel.cpp
@@ -60,6 +60,14 @@ Panels::StandardPathsPanel::StandardPathsPanel( wxWindow* parent )
 		)
 	) | SubGroup();
 
+	*this += BetweenFolderSpace;
+	*this += (new DirPickerPanel( this, FolderId_Textures,
+		_("Textures:"),
+		_("Select a folder for textures") ))->
+		SetToolTip( pxEt( L"This folder is where PCSX2 saves texture dumps and replacements."
+		)
+	) | SubGroup();
+
 	/*
 	*this += BetweenFolderSpace;
 	*this += (new DirPickerPanel( this, FolderId_MemoryCards,


### PR DESCRIPTION
### Description of Changes
Makes texture dump location configurable

Closes #5586

### Rationale behind Changes
Texture dumps are big and you might not want them on your main volume

### Suggested Testing Steps
Make sure you can change the texture dump location in settings and have it actually affect where textures are dumped
