### PR TITLE
EE/JIT: Flush const on LDL/LDR instructions

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -535,6 +535,12 @@ void recLDL()
 #ifdef LOADSTORE_RECOMPILE
 	int t2reg;
 
+	if (GPR_IS_CONST1(_Rt_))
+	{
+		_flushConstReg(_Rt_);
+		_eeOnWriteReg(_Rt_, 0);
+	}
+
 	if (GPR_IS_CONST1(_Rs_))
 	{
 		u32 srcadr = g_cpuConstRegs[_Rs_].UL[0] + _Imm_;
@@ -610,6 +616,12 @@ void recLDR()
 
 #ifdef LOADSTORE_RECOMPILE
 	int t2reg;
+	
+	if (GPR_IS_CONST1(_Rt_))
+	{
+		_flushConstReg(_Rt_);
+		_eeOnWriteReg(_Rt_, 0);
+	}
 
 	if (GPR_IS_CONST1(_Rs_))
 	{


### PR DESCRIPTION
### Description of Changes
Flush constant reg for Rt if it is constant when doing LDR/LDL instructions

### Rationale behind Changes
Our allocator sucks at handling constants properly.

### Suggested Testing Steps
Mainly probably only really affects Mortal Kombat as linked below, but try other games, I guess.

Fixes #5591
