### PR TITLE
Qt: Assorted cleanups/add debug log options

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -49,12 +49,7 @@ DisplayWidget::~DisplayWidget() = default;
 
 qreal DisplayWidget::devicePixelRatioFromScreen() const
 {
-	QScreen* screen_for_ratio;
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-	screen_for_ratio = windowHandle()->screen();
-#else
-	screen_for_ratio = screen();
-#endif
+	const QScreen* screen_for_ratio = screen();
 	if (!screen_for_ratio)
 		screen_for_ratio = QGuiApplication::primaryScreen();
 

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -285,6 +285,9 @@ void EmuThread::executeVM()
 				destroyVM();
 				m_event_loop->processEvents(QEventLoop::AllEvents);
 				return;
+
+			default:
+				continue;
 		}
 	}
 }

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -57,7 +57,7 @@ public Q_SLOTS:
 	void startVM(std::shared_ptr<VMBootParameters> boot_params);
 	void resetVM();
 	void setVMPaused(bool paused);
-	void shutdownVM(bool allow_save_to_state = true, bool blocking = false);
+	bool shutdownVM(bool allow_confirm = true, bool allow_save_to_state = true, bool blocking = false);
 	void loadState(const QString& filename);
 	void loadStateFromSlot(qint32 slot);
 	void saveState(const QString& filename);

--- a/pcsx2-qt/Main.cpp
+++ b/pcsx2-qt/Main.cpp
@@ -17,6 +17,7 @@
 
 #include <QtWidgets/QApplication>
 #include <cstdlib>
+#include <csignal>
 
 #include "MainWindow.h"
 #include "EmuThread.h"
@@ -212,7 +213,6 @@ int main(int argc, char* argv[])
 
 	const int result = app.exec();
 
-	EmuThread::stop();
 	QtHost::Shutdown();
 	return result;
 }

--- a/pcsx2-qt/Main.cpp
+++ b/pcsx2-qt/Main.cpp
@@ -184,13 +184,9 @@ static bool ParseCommandLineOptions(int argc, char* argv[], std::shared_ptr<VMBo
 
 int main(int argc, char* argv[])
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-#endif
-#endif
 
 	QApplication app(argc, argv);
 	std::shared_ptr<VMBootParameters> autoboot;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -241,9 +241,6 @@ void MainWindow::setStyleFromSettings()
 		// Alternative white theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor lighterGray(75, 75, 75);
-		const QColor darkGray(53, 53, 53);
-		const QColor gray(128, 128, 128);
 		const QColor black(25, 25, 25);
 		const QColor teal(0, 128, 128);	
 		const QColor tameTeal(160, 190, 185);
@@ -279,18 +276,12 @@ void MainWindow::setStyleFromSettings()
 		// Alternative light theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor lighterGray(75, 75, 75);
 		const QColor gray(150, 150, 150);
 		const QColor black(25, 25, 25);
-		const QColor darkPink(180, 80, 200);
 		const QColor pink(255, 174, 201);
 		const QColor brightPink(255, 230, 255);
 		const QColor congoPink(255, 127, 121);
-		const QColor yellow(255, 235, 180);
-		const QColor darkGreen(161, 240, 183);
-		const QColor green(221, 239, 226);
 		const QColor blue(221, 225, 239);
-		const QColor darkBlue(100, 95, 250);
 
 		QPalette standardPalette;
 		standardPalette.setColor(QPalette::Window, pink);
@@ -322,13 +313,10 @@ void MainWindow::setStyleFromSettings()
 		// Alternative light theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor lighterGray(75, 75, 75);
-		const QColor gray(128, 128, 128);
 		const QColor black(25, 25, 25);
 		const QColor darkBlue(73, 97, 177);
 		const QColor blue(106, 156, 255);
 		const QColor lightBlue(130, 155, 241);
-		const QColor brightBlue(164, 184, 255);
 
 		QPalette standardPalette;
 		standardPalette.setColor(QPalette::Window, lightBlue);
@@ -394,7 +382,6 @@ void MainWindow::setStyleFromSettings()
 		// adapted from https://gist.github.com/QuantumCD/6245215
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor lighterGray(75, 75, 75);
 		const QColor darkGray(53, 53, 53);
 		const QColor gray(128, 128, 128);
 		const QColor black(25, 25, 25);
@@ -431,9 +418,6 @@ void MainWindow::setStyleFromSettings()
 		// Alternative dark theme.
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		const QColor lighterGray(75, 75, 75);
-		const QColor gray(128, 128, 128);
-		const QColor black(25, 25, 25);
 		const QColor darkRed(80, 45, 69);
 		const QColor purplishRed(120, 45, 69);
 		const QColor brightRed(200, 45, 69);
@@ -692,7 +676,7 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		QAction* action = menu.addAction(tr("Properties..."));
 		action->setEnabled(!entry->serial.empty());
 		if (action->isEnabled())
-			connect(action, &QAction::triggered, [this, entry]() { SettingsDialog::openGamePropertiesDialog(entry, entry->crc); });
+			connect(action, &QAction::triggered, [entry]() { SettingsDialog::openGamePropertiesDialog(entry, entry->crc); });
 
 		action = menu.addAction(tr("Open Containing Directory..."));
 		connect(action, &QAction::triggered, [this, entry]() {
@@ -1461,7 +1445,7 @@ void MainWindow::populateSaveStateMenu(QMenu* menu, const QString& serial, quint
 			timestamp = tr("Empty");
 
 		QString title(tr("Save Slot %1 (%2)").arg(i).arg(timestamp));
-		connect(menu->addAction(title), &QAction::triggered, [this, i]() { g_emu_thread->saveStateToSlot(i); });
+		connect(menu->addAction(title), &QAction::triggered, [i]() { g_emu_thread->saveStateToSlot(i); });
 	}
 }
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -39,6 +39,7 @@
 #include "Settings/ControllerSettingsDialog.h"
 #include "Settings/GameListSettingsWidget.h"
 #include "Settings/InterfaceSettingsWidget.h"
+#include "SettingWidgetBinder.h"
 #include "svnrev.h"
 
 static constexpr char DISC_IMAGE_FILTER[] =
@@ -169,6 +170,21 @@ void MainWindow::connectSignals()
 			m_game_list_widget->gridZoomOut();
 	});
 	connect(m_ui.actionGridViewRefreshCovers, &QAction::triggered, m_game_list_widget, &GameListWidget::refreshGridCovers);
+
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableSystemConsole, "Logging", "EnableSystemConsole", false);
+	connect(m_ui.actionEnableSystemConsole, &QAction::triggered, this, &MainWindow::onLoggingOptionChanged);
+#ifndef PCSX2_DEVBUILD
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableVerboseLogging, "Logging", "EnableVerbose", false);
+	connect(m_ui.actionEnableVerboseLogging, &QAction::triggered, this, &MainWindow::onLoggingOptionChanged);
+#else
+	// Dev builds always have verbose logging.
+	m_ui.actionEnableVerboseLogging->setChecked(true);
+	m_ui.actionEnableVerboseLogging->setEnabled(false);
+#endif
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableEEConsoleLogging, "Logging", "EnableEEConsole", false);
+	connect(m_ui.actionEnableEEConsoleLogging, &QAction::triggered, this, &MainWindow::onLoggingOptionChanged);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", false);
+	connect(m_ui.actionEnableIOPConsoleLogging, &QAction::triggered, this, &MainWindow::onLoggingOptionChanged);
 
 	// These need to be queued connections to stop crashing due to menus opening/closing and switching focus.
 	connect(m_game_list_widget, &GameListWidget::refreshProgress, this, &MainWindow::onGameListRefreshProgress);
@@ -881,6 +897,11 @@ void MainWindow::onThemeChangedFromSettings()
 	// reopen the settings dialog after recreating
 	onThemeChanged();
 	g_main_window->doSettings();
+}
+
+void MainWindow::onLoggingOptionChanged()
+{
+	QtHost::UpdateLogging();
 }
 
 void MainWindow::onVMStarting()

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -92,6 +92,7 @@ private Q_SLOTS:
 	void onToolsOpenDataDirectoryTriggered();
 	void onThemeChanged();
 	void onThemeChangedFromSettings();
+	void onLoggingOptionChanged();
 
 	void onVMStarting();
 	void onVMStarted();

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -104,7 +104,7 @@ private Q_SLOTS:
 	void recreate();
 
 protected:
-	void closeEvent(QCloseEvent* event);
+	void closeEvent(QCloseEvent* event) override;
 
 private:
 	enum : s32

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -54,6 +54,8 @@ public Q_SLOTS:
 	void refreshGameList(bool invalidate_cache);
 	void invalidateSaveStateCache();
 	void reportError(const QString& title, const QString& message);
+	bool confirmShutdown();
+	void requestExit();
 
 private Q_SLOTS:
 	DisplayWidget* createDisplay(bool fullscreen, bool render_to_main);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -45,7 +45,8 @@
       <string>Change Disc</string>
      </property>
      <property name="icon">
-      <iconset theme="dvd-line"/>
+      <iconset theme="dvd-line">
+       <normaloff>.</normaloff>.</iconset>
      </property>
      <actiongroup name="actionGroupChangeDiscSubImages"/>
      <addaction name="actionChangeDiscFromFile"/>
@@ -59,7 +60,8 @@
       <string>Cheats</string>
      </property>
      <property name="icon">
-      <iconset theme="flask-line"/>
+      <iconset theme="flask-line">
+       <normaloff>.</normaloff>.</iconset>
      </property>
     </widget>
     <widget class="QMenu" name="menuLoadState">
@@ -67,7 +69,8 @@
       <string>Load State</string>
      </property>
      <property name="icon">
-      <iconset theme="folder-open-line"/>
+      <iconset theme="folder-open-line">
+       <normaloff>.</normaloff>.</iconset>
      </property>
     </widget>
     <widget class="QMenu" name="menuSaveState">
@@ -75,7 +78,8 @@
       <string>Save State</string>
      </property>
      <property name="icon">
-      <iconset theme="save-3-line"/>
+      <iconset theme="save-3-line">
+       <normaloff>.</normaloff>.</iconset>
      </property>
     </widget>
     <addaction name="actionStartFile"/>
@@ -141,6 +145,11 @@
     <addaction name="menuDebugSwitchRenderer"/>
     <addaction name="separator"/>
     <addaction name="actionReloadPatches"/>
+    <addaction name="separator"/>
+    <addaction name="actionEnableSystemConsole"/>
+    <addaction name="actionEnableVerboseLogging"/>
+    <addaction name="actionEnableEEConsoleLogging"/>
+    <addaction name="actionEnableIOPConsoleLogging"/>
    </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
@@ -151,7 +160,8 @@
       <string>&amp;Window Size</string>
      </property>
      <property name="icon">
-      <iconset theme="window-2-line"/>
+      <iconset theme="window-2-line">
+       <normaloff>.</normaloff>.</iconset>
      </property>
     </widget>
     <addaction name="actionViewToolbar"/>
@@ -185,6 +195,9 @@
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QToolBar" name="toolBar">
+   <property name="visible">
+    <bool>true</bool>
+   </property>
    <property name="windowTitle">
     <string>Toolbar</string>
    </property>
@@ -203,9 +216,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
    <addaction name="actionStartFile"/>
    <addaction name="actionStartDisc"/>
    <addaction name="actionStartBios"/>
@@ -227,142 +237,159 @@
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionStartFile">
+   <property name="icon">
+    <iconset theme="file-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Start &amp;File...</string>
    </property>
-   <property name="icon">
-    <iconset theme="file-line"/>
-   </property>
   </action>
   <action name="actionStartDisc">
+   <property name="icon">
+    <iconset theme="disc-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Start &amp;Disc...</string>
    </property>
-   <property name="icon">
-    <iconset theme="disc-line"/>
-   </property>
   </action>
   <action name="actionStartBios">
+   <property name="icon">
+    <iconset theme="hard-drive-2-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Start &amp;BIOS</string>
    </property>
-   <property name="icon">
-    <iconset theme="hard-drive-2-line"/>
-   </property>
   </action>
   <action name="actionScanForNewGames">
+   <property name="icon">
+    <iconset theme="file-search-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Scan For New Games</string>
    </property>
-   <property name="icon">
-    <iconset theme="file-search-line"/>
-   </property>
   </action>
   <action name="actionRescanAllGames">
+   <property name="icon">
+    <iconset theme="refresh-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Rescan All Games</string>
    </property>
-   <property name="icon">
-    <iconset theme="refresh-line"/>
-   </property>
   </action>
   <action name="actionPowerOff">
+   <property name="icon">
+    <iconset theme="shut-down-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Shut &amp;Down</string>
    </property>
-   <property name="icon">
-    <iconset theme="shut-down-line"/>
-   </property>
   </action>
   <action name="actionReset">
+   <property name="icon">
+    <iconset theme="restart-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Reset</string>
-   </property>
-   <property name="icon">
-    <iconset theme="restart-line"/>
    </property>
   </action>
   <action name="actionPause">
    <property name="checkable">
     <bool>true</bool>
    </property>
+   <property name="icon">
+    <iconset theme="pause-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Pause</string>
    </property>
-   <property name="icon">
-    <iconset theme="pause-line"/>
-   </property>
   </action>
   <action name="actionLoadState">
+   <property name="icon">
+    <iconset theme="folder-open-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Load State</string>
    </property>
-   <property name="icon">
-    <iconset theme="folder-open-line"/>
-   </property>
   </action>
   <action name="actionSaveState">
+   <property name="icon">
+    <iconset theme="save-3-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Save State</string>
    </property>
-   <property name="icon">
-    <iconset theme="save-3-line"/>
-   </property>
   </action>
   <action name="actionExit">
+   <property name="icon">
+    <iconset theme="door-open-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>E&amp;xit</string>
    </property>
-   <property name="icon">
-    <iconset theme="door-open-line"/>
-   </property>
   </action>
   <action name="actionBIOSSettings">
+   <property name="icon">
+    <iconset theme="hard-drive-2-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;BIOS</string>
    </property>
-   <property name="icon">
-    <iconset theme="hard-drive-2-line"/>
-   </property>
   </action>
   <action name="actionSystemSettings">
+   <property name="icon">
+    <iconset theme="artboard-2-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>System</string>
    </property>
-   <property name="icon">
-    <iconset theme="artboard-2-line"/>
-   </property>
   </action>
   <action name="actionEmulationSettings">
+   <property name="icon">
+    <iconset theme="dashboard-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Emulation</string>
    </property>
-   <property name="icon">
-    <iconset theme="dashboard-line"/>
-   </property>
   </action>
   <action name="actionControllerSettings">
+   <property name="icon">
+    <iconset theme="gamepad-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Controllers</string>
    </property>
-   <property name="icon">
-    <iconset theme="gamepad-line"/>
-   </property>
   </action>
   <action name="actionHotkeySettings">
+   <property name="icon">
+    <iconset theme="keyboard-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Hotkeys</string>
    </property>
-   <property name="icon">
-    <iconset theme="keyboard-line"/>
-   </property>
   </action>
   <action name="actionGraphicsSettings">
+   <property name="icon">
+    <iconset theme="brush-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Graphics</string>
-   </property>
-   <property name="icon">
-    <iconset theme="brush-line"/>
    </property>
   </action>
   <action name="actionPostProcessingSettings">
@@ -371,11 +398,12 @@
    </property>
   </action>
   <action name="actionFullscreen">
+   <property name="icon">
+    <iconset theme="fullscreen-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Fullscreen</string>
-   </property>
-   <property name="icon">
-    <iconset theme="fullscreen-line"/>
    </property>
   </action>
   <action name="actionResolution_Scale">
@@ -400,7 +428,8 @@
   </action>
   <action name="actionCheckForUpdates">
    <property name="icon">
-    <iconset theme="download-2-line"/>
+    <iconset theme="download-2-line">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Check for &amp;Updates...</string>
@@ -421,59 +450,66 @@
    </property>
   </action>
   <action name="actionChangeDisc">
+   <property name="icon">
+    <iconset theme="dvd-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Change Disc...</string>
    </property>
-   <property name="icon">
-    <iconset theme="dvd-line"/>
-   </property>
   </action>
   <action name="actionCheats">
+   <property name="icon">
+    <iconset theme="flask-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Cheats...</string>
    </property>
-   <property name="icon">
-    <iconset theme="flask-line"/>
-   </property>
   </action>
   <action name="actionAudioSettings">
+   <property name="icon">
+    <iconset theme="volume-up-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Audio</string>
    </property>
-   <property name="icon">
-    <iconset theme="volume-up-line"/>
-   </property>
   </action>
   <action name="actionGameListSettings">
+   <property name="icon">
+    <iconset theme="folder-settings-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Game List</string>
    </property>
-   <property name="icon">
-    <iconset theme="folder-settings-line"/>
-   </property>
   </action>
   <action name="actionInterfaceSettings">
+   <property name="icon">
+    <iconset theme="settings-3-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Interface</string>
    </property>
-   <property name="icon">
-    <iconset theme="settings-3-line"/>
-   </property>
   </action>
   <action name="actionAddGameDirectory">
+   <property name="icon">
+    <iconset theme="folder-add-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Add Game Directory...</string>
    </property>
-   <property name="icon">
-    <iconset theme="folder-add-line"/>
-   </property>    
   </action>
   <action name="actionSettings">
+   <property name="icon">
+    <iconset theme="settings-3-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Settings...</string>
-   </property>
-   <property name="icon">
-    <iconset theme="settings-3-line"/>
    </property>
   </action>
   <action name="actionChangeDiscFromFile">
@@ -502,19 +538,21 @@
    </property>
   </action>
   <action name="actionScreenshot">
+   <property name="icon">
+    <iconset theme="screenshot-2-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Screenshot</string>
    </property>
-   <property name="icon">
-    <iconset theme="screenshot-2-line"/>
-   </property>
   </action>
   <action name="actionMemoryCardSettings">
+   <property name="icon">
+    <iconset theme="sd-card-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Memory Cards</string>
-   </property>
-   <property name="icon">
-    <iconset theme="sd-card-line"/>
    </property>
   </action>
   <action name="actionViewToolbar">
@@ -551,41 +589,45 @@
    </property>
   </action>
   <action name="actionViewGameList">
+   <property name="icon">
+    <iconset theme="list-check">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Game &amp;List</string>
    </property>
-   <property name="icon">
-    <iconset theme="list-check"/>
-   </property>    
   </action>
   <action name="actionViewSystemDisplay">
    <property name="enabled">
     <bool>false</bool>
    </property>
+   <property name="icon">
+    <iconset theme="tv-2-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>System &amp;Display</string>
-   </property>
-   <property name="icon">
-    <iconset theme="tv-2-line"/>
    </property>
   </action>
   <action name="actionViewGameProperties">
    <property name="enabled">
     <bool>false</bool>
    </property>
+   <property name="icon">
+    <iconset theme="file-settings-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Game &amp;Properties</string>
    </property>
-   <property name="icon">
-    <iconset theme="file-settings-line"/>
-   </property>
   </action>
   <action name="actionViewGameGrid">
+   <property name="icon">
+    <iconset theme="function-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Game &amp;Grid</string>
-   </property>
-   <property name="icon">
-    <iconset theme="function-line"/>
    </property>
   </action>
   <action name="actionGridViewShowTitles">
@@ -638,6 +680,32 @@
   <action name="actionReloadPatches">
    <property name="text">
     <string>Reload Cheats/Patches</string>
+   </property>
+  </action>
+  <action name="actionEnableSystemConsole">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable System Console</string>
+   </property>
+  </action>
+  <action name="actionEnableVerboseLogging">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Verbose Logging</string>
+   </property>
+  </action>
+  <action name="actionEnableEEConsoleLogging">
+   <property name="text">
+    <string>Enable EE Console Logging</string>
+   </property>
+  </action>
+  <action name="actionEnableIOPConsoleLogging">
+   <property name="text">
+    <string>Enable IOP Console Logging</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -438,17 +438,14 @@ static const IConsoleWriter ConsoleWriter_WinQt =
 void QtHost::UpdateLogging()
 {
 	// TODO: Make this an actual option.
-	bool console_logging_enabled = false;
+	const bool system_console_enabled = QtHost::GetBaseBoolSettingValue("Logging", "EnableSystemConsole", false);
 
-#if defined(_DEBUG) || defined(PCSX2_DEVBUILD)
-	console_logging_enabled = true;
-#endif
+	const bool any_logging_sinks = system_console_enabled;
+	DevConWriterEnabled = any_logging_sinks && QtHost::GetBaseBoolSettingValue("Logging", "EnableVerbose", false);
+	SysConsole.eeConsole.Enabled = any_logging_sinks && QtHost::GetBaseBoolSettingValue("Logging", "EnableEEConsole", true);
+	SysConsole.iopConsole.Enabled = any_logging_sinks && QtHost::GetBaseBoolSettingValue("Logging", "EnableIOPConsole", true);
 
-	DevConWriterEnabled = console_logging_enabled;
-	SysConsole.eeConsole.Enabled = console_logging_enabled;
-	SysConsole.iopConsole.Enabled = console_logging_enabled;
-
-	if (console_logging_enabled)
+	if (system_console_enabled)
 	{
 #ifdef _WIN32
 		s_debugger_attached = IsDebuggerPresent();

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -20,11 +20,7 @@
 #include <QtGui/QDesktopServices>
 #include <QtGui/QKeyEvent>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QtGui/QAction>
-#else
-#include <QtWidgets/QAction>
-#endif
 
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QDialog>

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -399,7 +399,7 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setNullableBoolValue(widget, std::nullopt);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key)]() {
 				if (std::optional<bool> new_value = Accessor::getNullableBoolValue(widget); new_value.has_value())
 					sif->SetBoolValue(section.c_str(), key.c_str(), new_value.value());
 				else
@@ -413,7 +413,7 @@ namespace SettingWidgetBinder
 		{
 			Accessor::setBoolValue(widget, value);
 
-			Accessor::connectValueChanged(widget, [widget, section, key]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key)]() {
 				const bool new_value = Accessor::getBoolValue(widget);
 				QtHost::SetBaseBoolSettingValue(section.c_str(), key.c_str(), new_value);
 				g_emu_thread->applySettings();
@@ -439,7 +439,7 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setNullableIntValue(widget, std::nullopt);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key)]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
 					sif->SetIntValue(section.c_str(), key.c_str(), new_value.value());
 				else
@@ -453,7 +453,7 @@ namespace SettingWidgetBinder
 		{
 			Accessor::setIntValue(widget, static_cast<int>(value));
 
-			Accessor::connectValueChanged(widget, [widget, section, key, option_offset]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key), option_offset]() {
 				const int new_value = Accessor::getIntValue(widget);
 				QtHost::SetBaseIntSettingValue(section.c_str(), key.c_str(), new_value + option_offset);
 				g_emu_thread->applySettings();
@@ -478,7 +478,7 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setNullableFloatValue(widget, std::nullopt);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key)]() {
 				if (std::optional<float> new_value = Accessor::getNullableFloatValue(widget); new_value.has_value())
 					sif->SetFloatValue(section.c_str(), key.c_str(), new_value.value());
 				else
@@ -492,7 +492,7 @@ namespace SettingWidgetBinder
 		{
 			Accessor::setFloatValue(widget, value);
 
-			Accessor::connectValueChanged(widget, [widget, section, key]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key)]() {
 				const float new_value = Accessor::getFloatValue(widget);
 				QtHost::SetBaseFloatSettingValue(section.c_str(), key.c_str(), new_value);
 				g_emu_thread->applySettings();
@@ -518,7 +518,7 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setNullableIntValue(widget, std::nullopt);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key, range]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), range]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
 					sif->SetFloatValue(section.c_str(), key.c_str(), static_cast<float>(new_value.value()) / range);
 				else
@@ -532,7 +532,7 @@ namespace SettingWidgetBinder
 		{
 			Accessor::setIntValue(widget, static_cast<int>(value * range));
 
-			Accessor::connectValueChanged(widget, [widget, section, key, range]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key), range]() {
 				const float new_value = (static_cast<float>(Accessor::getIntValue(widget)) / range);
 				QtHost::SetBaseFloatSettingValue(section.c_str(), key.c_str(), new_value);
 				g_emu_thread->applySettings();
@@ -558,7 +558,7 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setNullableStringValue(widget, std::nullopt);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key]() {
+			Accessor::connectValueChanged(widget, [widget, sif, section = std::move(section), key = std::move(key)]() {
 				if (std::optional<QString> new_value = Accessor::getNullableStringValue(widget); new_value.has_value())
 					sif->SetStringValue(section.c_str(), key.c_str(), new_value->toUtf8().constData());
 				else
@@ -572,7 +572,7 @@ namespace SettingWidgetBinder
 		{
 			Accessor::setStringValue(widget, value);
 
-			Accessor::connectValueChanged(widget, [widget, section, key]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key)]() {
 				const QString new_value = Accessor::getStringValue(widget);
 				if (!new_value.isEmpty())
 					QtHost::SetBaseStringSettingValue(section.c_str(), key.c_str(), new_value.toUtf8().constData());
@@ -612,7 +612,7 @@ namespace SettingWidgetBinder
 				Accessor::setNullableIntValue(widget, std::nullopt);
 			}
 
-			Accessor::connectValueChanged(widget, [&]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), to_string_function]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
 				{
 					const char* string_value = to_string_function(static_cast<DataType>(static_cast<UnderlyingType>(new_value.value())));
@@ -634,7 +634,7 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setIntValue(widget, static_cast<int>(static_cast<UnderlyingType>(default_value)));
 
-			Accessor::connectValueChanged(widget, [widget, section, key, to_string_function]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key), to_string_function]() {
 				const DataType value = static_cast<DataType>(static_cast<UnderlyingType>(Accessor::getIntValue(widget)));
 				const char* string_value = to_string_function(value);
 				QtHost::SetBaseStringSettingValue(section.c_str(), key.c_str(), string_value);
@@ -682,7 +682,7 @@ namespace SettingWidgetBinder
 			}
 			Accessor::setNullableIntValue(widget, sif_int_value);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key, enum_names]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), enum_names]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
 					sif->SetStringValue(section.c_str(), key.c_str(), enum_names[new_value.value()]);
 				else
@@ -696,7 +696,7 @@ namespace SettingWidgetBinder
 		{
 			Accessor::setIntValue(widget, static_cast<int>(enum_index));
 
-			Accessor::connectValueChanged(widget, [widget, section, key, enum_names]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key), enum_names]() {
 				const UnderlyingType value = static_cast<UnderlyingType>(Accessor::getIntValue(widget));
 				QtHost::SetBaseStringSettingValue(section.c_str(), key.c_str(), enum_names[value]);
 				g_emu_thread->applySettings();
@@ -744,7 +744,7 @@ namespace SettingWidgetBinder
 			}
 			Accessor::setNullableIntValue(widget, sif_int_value);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section, key, enum_names]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), enum_names]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
 					sif->SetStringValue(section.c_str(), key.c_str(), enum_names[new_value.value()]);
 				else
@@ -759,7 +759,7 @@ namespace SettingWidgetBinder
 			if (enum_index >= 0)
 				Accessor::setIntValue(widget, enum_index);
 
-			Accessor::connectValueChanged(widget, [widget, section, key, enum_values]() {
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), key = std::move(key), enum_values]() {
 				const int value = Accessor::getIntValue(widget);
 				QtHost::SetBaseStringSettingValue(section.c_str(), key.c_str(), enum_values[value]);
 				g_emu_thread->applySettings();

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -14,16 +14,12 @@
  */
 
 #pragma once
-#include <QtCore/QtCore>
+
 #include <optional>
 #include <type_traits>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtCore/QtCore>
 #include <QtGui/QAction>
-#else
-#include <QtWidgets/QAction>
-#endif
-
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QDoubleSpinBox>
@@ -152,13 +148,8 @@ namespace SettingWidgetBinder
 		static QString getStringValue(const QComboBox* widget)
 		{
 			const QVariant currentData(widget->currentData());
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-			if (currentData.type() == QVariant::String)
-				return currentData.toString();
-#else
 			if (currentData.metaType().id() == QMetaType::QString)
 				return currentData.toString();
-#endif
 
 			return widget->currentText();
 		}

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -27,7 +27,7 @@
 AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: QWidget(parent)
 {
-	SettingsInterface* sif = dialog->getSettingsInterface();
+	// SettingsInterface* sif = dialog->getSettingsInterface();
 
 	m_ui.setupUi(this);
 }

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -102,7 +102,7 @@ void GameListSettingsWidget::addPathToTable(const std::string& path, bool recurs
 	m_ui.searchDirectoryList->setCellWidget(row, 1, cb);
 	cb->setChecked(recursive);
 
-	connect(cb, &QCheckBox::stateChanged, [this, item](int state) {
+	connect(cb, &QCheckBox::stateChanged, [item](int state) {
 		const std::string path(item->text().toStdString());
 		if (state == Qt::Checked)
 		{

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -1,5 +1,4 @@
 /*  PCSX2 - PS2 Emulator for PCs
-/*  PCSX2 - PS2 Emulator for PCs
  *  Copyright (C) 2002-2022  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -41,7 +41,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.inhibitScreensaver, "UI", "InhibitScreensaver", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.discordPresence, "UI", "DiscordPresence", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.confirmPowerOff, "UI", "ConfirmPowerOff", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.confirmShutdown, "UI", "ConfirmShutdown", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveStateOnExit, "EmuCore", "AutoStateLoadSave", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnStart, "UI", "StartPaused", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnFocusLoss, "UI", "PauseOnFocusLoss", false);
@@ -84,8 +84,8 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 	}
 
 	dialog->registerWidgetHelp(
-		m_ui.confirmPowerOff, tr("Confirm Power Off"), tr("Checked"),
-		tr("Determines whether a prompt will be displayed to confirm shutting down the emulator/game "
+		m_ui.confirmShutdown, tr("Confirm Shutdown"), tr("Checked"),
+		tr("Determines whether a prompt will be displayed to confirm shutting down the virtual machine "
 		   "when the hotkey is pressed."));
 	dialog->registerWidgetHelp(m_ui.saveStateOnExit, tr("Save State On Exit"), tr("Checked"),
 		tr("Automatically saves the emulator state when powering down or exiting. You can then "

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -61,9 +61,9 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="confirmPowerOff">
+       <widget class="QCheckBox" name="confirmShutdown">
         <property name="text">
-         <string>Confirm Power Off</string>
+         <string>Confirm Shutdown</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -27,7 +27,7 @@
 MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: QWidget(parent)
 {
-	SettingsInterface* sif = dialog->getSettingsInterface();
+	// SettingsInterface* sif = dialog->getSettingsInterface();
 
 	m_ui.setupUi(this);
 }

--- a/pcsx2-qt/Settings/SettingsDialog.h
+++ b/pcsx2-qt/Settings/SettingsDialog.h
@@ -93,7 +93,7 @@ private Q_SLOTS:
 	void onRestoreDefaultsClicked();
 
 protected:
-	void closeEvent(QCloseEvent*);
+	void closeEvent(QCloseEvent*) override;
 
 private:
 	enum : u32

--- a/pcsx2-qt/Settings/SystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.cpp
@@ -37,7 +37,7 @@ SystemSettingsWidget::SystemSettingsWidget(SettingsDialog* dialog, QWidget* pare
 
 	m_ui.setupUi(this);
 
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.eeCycleSkipping, "EmuCore/Speedhacks", "EECycleSkip", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.eeCycleSkipping, "EmuCore/Speedhacks", "EECycleSkip", DEFAULT_EE_CYCLE_SKIP);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.MTVU, "EmuCore/Speedhacks", "vuThread", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.instantVU1, "EmuCore/Speedhacks", "vu1Instant", true);


### PR DESCRIPTION
### Description of Changes

Fixes warnings, gets rid of unnecessary ifdefs since we require Qt6 on all platforms. Also makes the log accessible in release builds.

### Suggested Testing Steps

None needed, I've already tested, and it's mostly cosmetic.
