### PR TITLE
GS: Support local to local transfers that overwrite themselves

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1702,14 +1702,59 @@ void GSState::Move()
 		int _sy = sy, _dy = dy; // Faster with local copied variables, compiler optimizations are dumb
 		if (xinc > 0)
 		{
-			for (int y = 0; y < h; y++, _sy += yinc, _dy += yinc)
+			const int page_width = GSLocalMemory::m_psm[m_env.BITBLTBUF.DPSM].pgs.x;
+			const int page_height = GSLocalMemory::m_psm[m_env.BITBLTBUF.DPSM].pgs.y;
+			const int xpage = sx & ~(page_width - 1);
+			const int ypage = _sy & ~(page_height - 1);
+			// Copying from itself to itself (rotating textures) used in Gitaroo Man stage 8
+			// What probably happens is because the copy is buffered, the source stays just ahead of the destination.
+			if (sbp == dbp && (((_sy < _dy) && ((ypage + page_height) > _dy)) || ((sx < dx) && ((xpage + page_width) > dx))))
 			{
-				auto s = getPAHelper(spo, sx, _sy);
-				auto d = getPAHelper(dpo, dx, _dy);
+				int starty = 0;
+				int endy = h;
+				int y_inc = yinc;
 
-				for (int x = 0; x < w; x++)
+				if (((_sy < _dy) && ((ypage + page_height) > _dy)))
 				{
-					pxCopyFn(d, s, x);
+					_sy += h;
+					_dy += h;
+					starty = h-1;
+					endy = -1;
+					y_inc = -y_inc;
+				}
+			
+				for (int y = starty; y != endy; y+= y_inc, _sy += y_inc, _dy += y_inc)
+				{
+					auto s = getPAHelper(spo, sx, _sy);
+					auto d = getPAHelper(dpo, dx, _dy);
+
+					if (((sx < dx) && ((xpage + page_width) > dx)))
+					{
+						for (int x = w - 1; x >= 0; x--)
+						{
+							pxCopyFn(d, s, x);
+						}
+					}
+					else
+					{
+						for (int x = 0; x < w; x++)
+						{
+							pxCopyFn(d, s, x);
+						}
+					}
+				}
+			}
+			else
+			{
+				for (int y = 0; y < h; y++, _sy += yinc, _dy += yinc)
+				{
+					auto s = getPAHelper(spo, sx, _sy);
+					auto d = getPAHelper(dpo, dx, _dy);
+
+					for (int x = 0; x < w; x++)
+					{
+						pxCopyFn(d, s, x);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Changes
Adds support for local to local GS transfers that use the same source/destination address

### Rationale behind Changes
Some games (In this case Gitarooman will do local to local transfers to the same address but with the source only a few pixels behind the destination, causing the source to get overwritten by the destination (it will repeat the first few pixels), this is an undesired effect, so we need to do the copy backwards. On real hardware the page would likely be buffered when the read starts, so it will have a clean copy before it gets overridden, we don't have that luxury in the current code (also it'd be slower)

### Suggested Testing Steps
Check Gitarooman stage 8, not sure if any other games do this.

Fixes #3118
