### PR TITLE
GUI: Log graphics driver info on startup

### DIFF
--- a/common/GL/Context.cpp
+++ b/common/GL/Context.cpp
@@ -149,10 +149,10 @@ namespace GL
 		const char* gl_renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
 		const char* gl_version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
 		const char* gl_shading_language_version = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
-		Console.WriteLn(Color_Magenta, "GL_VENDOR: %s", gl_vendor);
-		Console.WriteLn(Color_Magenta, "GL_RENDERER: %s", gl_renderer);
-		Console.WriteLn(Color_Magenta, "GL_VERSION: %s", gl_version);
-		Console.WriteLn(Color_Magenta, "GL_SHADING_LANGUAGE_VERSION: %s", gl_shading_language_version);
+		DevCon.WriteLn(Color_Magenta, "GL_VENDOR: %s", gl_vendor);
+		DevCon.WriteLn(Color_Magenta, "GL_RENDERER: %s", gl_renderer);
+		DevCon.WriteLn(Color_Magenta, "GL_VERSION: %s", gl_version);
+		DevCon.WriteLn(Color_Magenta, "GL_SHADING_LANGUAGE_VERSION: %s", gl_shading_language_version);
 
 		DisableBrokenExtensions(gl_vendor, gl_renderer);
 

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -55,9 +55,6 @@ namespace Vulkan
 
 		~Context();
 
-		// Determines if the Vulkan validation layer is available on the system.
-		static bool CheckValidationLayerAvailablility();
-
 		// Helper method to create a Vulkan instance.
 		static VkInstance CreateVulkanInstance(
 			const WindowInfo* wi, bool enable_debug_utils, bool enable_validation_layer);

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -616,6 +616,9 @@ HostDisplay* EmuThread::acquireHostDisplay(HostDisplay::RenderAPI api)
 
 	g_gs_window_info = s_host_display->GetWindowInfo();
 
+	Console.WriteLn(Color_StrongGreen, "%s Graphics Driver Info:", HostDisplay::RenderAPIToString(s_host_display->GetRenderAPI()));
+	Console.Indent().WriteLn(s_host_display->GetDriverInfo());
+
 	return s_host_display.get();
 }
 

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -138,13 +138,15 @@ void VulkanHostDisplay::DestroyRenderSurface()
 std::string VulkanHostDisplay::GetDriverInfo() const
 {
 	std::string ret;
-	const u32 version = g_vulkan_context->GetDeviceProperties().apiVersion;
+	const u32 api_version = g_vulkan_context->GetDeviceProperties().apiVersion;
+	const u32 driver_version = g_vulkan_context->GetDeviceProperties().driverVersion;
 	if (g_vulkan_context->GetOptionalExtensions().vk_khr_driver_properties)
 	{
 		const VkPhysicalDeviceDriverProperties& props = g_vulkan_context->GetDeviceDriverProperties();
 		ret = StringUtil::StdStringFromFormat(
-			"Vulkan %u.%u.%u\nConformance Version %u.%u.%u.%u\n%s\n%s\n%s",
-			VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version), VK_API_VERSION_PATCH(version),
+			"Driver %u.%u.%u\nVulkan %u.%u.%u\nConformance Version %u.%u.%u.%u\n%s\n%s\n%s",
+			VK_VERSION_MAJOR(driver_version), VK_VERSION_MINOR(driver_version), VK_VERSION_PATCH(driver_version),
+			VK_API_VERSION_MAJOR(api_version), VK_API_VERSION_MINOR(api_version), VK_API_VERSION_PATCH(api_version),
 			props.conformanceVersion.major, props.conformanceVersion.minor, props.conformanceVersion.subminor, props.conformanceVersion.patch,
 			props.driverInfo, props.driverName,
 			g_vulkan_context->GetDeviceProperties().deviceName);
@@ -152,8 +154,9 @@ std::string VulkanHostDisplay::GetDriverInfo() const
 	else
 	{
 		ret = StringUtil::StdStringFromFormat(
-			"Vulkan %u.%u.%u\n%s",
-			VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version), VK_API_VERSION_PATCH(version),
+			"Driver %u.%u.%u\nVulkan %u.%u.%u\n%s",
+			VK_VERSION_MAJOR(driver_version), VK_VERSION_MINOR(driver_version), VK_VERSION_PATCH(driver_version),
+			VK_API_VERSION_MAJOR(api_version), VK_API_VERSION_MINOR(api_version), VK_API_VERSION_PATCH(api_version),
 			g_vulkan_context->GetDeviceProperties().deviceName);
 	}
 

--- a/pcsx2/gui/AppHost.cpp
+++ b/pcsx2/gui/AppHost.cpp
@@ -130,6 +130,9 @@ HostDisplay* Host::AcquireHostDisplay(HostDisplay::RenderAPI api)
 		return nullptr;
 	}
 
+	Console.WriteLn(Color_StrongGreen, "%s Graphics Driver Info:", HostDisplay::RenderAPIToString(s_host_display->GetRenderAPI()));
+	Console.Indent().WriteLn(s_host_display->GetDriverInfo());
+
 	return s_host_display.get();
 }
 


### PR DESCRIPTION
### Description of Changes

Logs graphics driver info to the console when starting up for the first time. Also stops the Vulkan renderer preventing initialization when the debug layers are unavailable but the option is enabled.

### Rationale behind Changes

Useful when dealing with people with driver bugs.

### Suggested Testing Steps

None needed, it's just logging.
