### PR TITLE
VMManager: Fix brief unpause before shutdown

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -116,7 +116,7 @@ void VMManager::SetState(VMState state)
 	SetTimerResolutionIncreased(state == VMState::Running);
 	s_state.store(state);
 
-	if (state == VMState::Paused || old_state == VMState::Paused)
+	if (state != VMState::Stopping && (state == VMState::Paused || old_state == VMState::Paused))
 	{
 		if (state == VMState::Paused)
 		{


### PR DESCRIPTION
### Description of Changes

Stops the audio backend from briefly playing buffered audio when shutting down, if the VM was paused.

### Rationale behind Changes

It was annoying.

### Suggested Testing Steps

None needed, it's Qt and I've been running this patch locally for ages.
