### PR TITLE
Qt: Fix live changing game settings not applying

### DIFF
--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -374,6 +374,22 @@ void EmuThread::applySettings()
 	VMManager::ApplySettings();
 }
 
+void EmuThread::reloadGameSettings()
+{
+	if (!isOnEmuThread())
+	{
+		QMetaObject::invokeMethod(this, &EmuThread::reloadGameSettings, Qt::QueuedConnection);
+		return;
+	}
+
+	// this will skip applying settings when they're not active
+	if (VMManager::ReloadGameSettings())
+	{
+		// none of these settings below are per-game.. for now. but in case they are in the future.
+		checkForSettingChanges();
+	}
+}
+
 void EmuThread::checkForSettingChanges()
 {
 	if (VMManager::HasValidVM())

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -65,6 +65,7 @@ public Q_SLOTS:
 	void toggleFullscreen();
 	void setFullscreen(bool fullscreen);
 	void applySettings();
+	void reloadGameSettings();
 	void toggleSoftwareRendering();
 	void switchRenderer(GSRendererType renderer);
 	void changeDisc(const QString& path);

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -406,7 +406,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -446,7 +446,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -485,7 +485,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -525,7 +525,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -565,7 +565,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -624,7 +624,7 @@ namespace SettingWidgetBinder
 				}
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -689,7 +689,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else
@@ -751,7 +751,7 @@ namespace SettingWidgetBinder
 					sif->DeleteValue(section.c_str(), key.c_str());
 
 				sif->Save();
-				g_emu_thread->applySettings();
+				g_emu_thread->reloadGameSettings();
 			});
 		}
 		else

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -120,7 +120,7 @@ namespace SettingWidgetBinder
 		}
 		static std::optional<int> getNullableIntValue(const QComboBox* widget)
 		{
-			return isNullValue(widget) ? std::nullopt : std::optional<int>(widget->currentIndex() + 1);
+			return isNullValue(widget) ? std::nullopt : std::optional<int>(widget->currentIndex() - 1);
 		}
 		static void setNullableIntValue(QComboBox* widget, std::optional<int> value)
 		{
@@ -439,9 +439,9 @@ namespace SettingWidgetBinder
 			else
 				Accessor::setNullableIntValue(widget, std::nullopt);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key)]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), option_offset]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
-					sif->SetIntValue(section.c_str(), key.c_str(), new_value.value());
+					sif->SetIntValue(section.c_str(), key.c_str(), new_value.value() + option_offset);
 				else
 					sif->DeleteValue(section.c_str(), key.c_str());
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1158,10 +1158,13 @@ void VMManager::ApplySettings()
 	}
 }
 
-void VMManager::ReloadGameSettings()
+bool VMManager::ReloadGameSettings()
 {
-	if (UpdateGameSettingsLayer())
-		ApplySettings();
+	if (!UpdateGameSettingsLayer())
+		return false;
+
+	ApplySettings();
+	return true;
 }
 
 static void HotkeyAdjustTargetSpeed(double delta)

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -96,7 +96,7 @@ namespace VMManager
 	void ApplySettings();
 
 	/// Reloads game specific settings, and applys any changes present.
-	void ReloadGameSettings();
+	bool ReloadGameSettings();
 
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
 	void ReloadPatches(bool verbose);


### PR DESCRIPTION
### Description of Changes

What the title says. Game settings weren't updating after being changed in the UI because it wasn't reloading the VM side ini interface.

Also fixes incorrect values getting written to the ini which don't match the UI for some options (e.g. resolution scale).

### Rationale behind Changes

This was pretty annoying, and a bug from not properly testing on my part.

### Suggested Testing Steps

It's Qt, and I've already tested it.
