### PR TITLE
GS-hw: Improve how we handle blending when output is Cd.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -773,9 +773,14 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 #endif
 	if (color_dest_blend)
 	{
-		// Blend output will be Cd, no need to set Af.
-		m_conf.blend = {blend_index, 0, ALPHA.C == 2, false, false};
+		// Blend output will be Cd, disable hw/sw blending.
+		m_conf.blend = {};
 		sw_blending = false; // DATE_PRIMID
+
+		// Output is Cd, set rgb write to 0.
+		m_conf.colormask.wr = 0;
+		m_conf.colormask.wg = 0;
+		m_conf.colormask.wb = 0;
 	}
 	else if (sw_blending)
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Improve how we handle blending when output is Cd.
Disable hw blending on Cd output,
Disable rgb write on Cd output.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure blending when output is Cd still works.
![image](https://user-images.githubusercontent.com/18107717/157074800-d0916ddb-126e-44f9-b4e1-71908e9f20c8.png)
