### PR TITLE
GS-hw: Set alpha for blend constants to 0.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1156,9 +1156,7 @@ void GSDevice11::OMSetBlendState(ID3D11BlendState* bs, float bf)
 	{
 		m_state.bs = bs;
 		m_state.bf = bf;
-
-		const float BlendFactor[] = {bf, bf, bf, 0};
-
+		const float BlendFactor[4] = {bf, bf, bf, 0};
 		m_ctx->OMSetBlendState(bs, BlendFactor, 0xffffffff);
 	}
 }

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1674,8 +1674,8 @@ void GSDeviceOGL::OMSetBlendState(u8 blend_index, u8 blend_factor, bool is_blend
 		if (is_blend_constant && GLState::bf != blend_factor)
 		{
 			GLState::bf = blend_factor;
-			const float bf = (float)blend_factor / 128.0f;
-			glBlendColor(bf, bf, bf, bf);
+			const float bf = static_cast<float>(blend_factor) / 128.0f;
+			glBlendColor(bf, bf, bf, 0);
 		}
 
 		HWBlend b = GetBlend(blend_index);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2307,8 +2307,9 @@ __ri void GSDeviceVK::ApplyBaseState(u32 flags, VkCommandBuffer cmdbuf)
 
 	if (flags & DIRTY_FLAG_BLEND_CONSTANTS)
 	{
-		const GSVector4 col(static_cast<float>(m_blend_constant_color) / 128.0f);
-		vkCmdSetBlendConstants(cmdbuf, col.v);
+		const float BlendFactor = static_cast<float>(m_blend_constant_color) / 128.0f;
+		const float BlendConstants[4] = {BlendFactor, BlendFactor, BlendFactor, 0};
+		vkCmdSetBlendConstants(cmdbuf, BlendConstants);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Set alpha for blend constants to 0.
Set alpha for blend constants to 0, we use rgb only for blending, no reason to use it.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test blending, minimum mostly as the changes affect hw blending.