### PR TITLE
GS-hw: Move the Ad to As equation swap when alpha is masked to Basic blend level and higher on gl/vk.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -544,7 +544,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	// Replace Ad with As, blend flags will be used from As since we are chaging the blend_index value.
 	bool blend_ad_alpha_masked = (ALPHA.C == 1) && (m_context->FRAME.FBMSK & 0xFF000000) == 0xFF000000;
 	u8 ALPHA_C = ALPHA.C;
-	if (g_gs_device->Features().texture_barrier && blend_ad_alpha_masked)
+	if (((GSConfig.AccurateBlendingUnit >= AccBlendLevel::Basic) || (m_env.COLCLAMP.CLAMP == 0))
+		&& g_gs_device->Features().texture_barrier && blend_ad_alpha_masked)
 		ALPHA_C = 0;
 	else if (((GSConfig.AccurateBlendingUnit >= AccBlendLevel::Medium)
 		// Detect barrier aka fbmask on d3d11.


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Move the Ad to As equation swap when alpha is masked to Basic blend level and higher on gl/vk.
Safer this way, otherwise need to take in to account when accumulation, non recursive, and blend mix is enabled, or manually enable them on Minimum level.

Everything that we need is enabled on Basic level.

Change is done for clamp 1 only.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bug fix/optimization? I dunno. 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Blending tests.