### PR TITLE
DEV9: Merged confg fixes

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -668,7 +668,7 @@ struct Pcsx2Config
 		 * which is 2^32 * 512 byte sectors
 		 * Note that we don't yet support
 		 * 48bit LBA, so our limit is lower */
-		uint HddSizeSectors{0};
+		uint HddSizeSectors{40 * (1024 * 1024 * 1024 / 512)};
 
 		DEV9Options();
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -680,23 +680,27 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapEntry(InterceptDHCP);
 
 		std::string ps2IPStr = "0.0.0.0";
+		std::string maskStr = "0.0.0.0";
 		std::string gatewayStr = "0.0.0.0";
 		std::string dns1Str = "0.0.0.0";
 		std::string dns2Str = "0.0.0.0";
 		if (wrap.IsSaving())
 		{
 			ps2IPStr = SaveIPHelper(PS2IP);
+			maskStr = SaveIPHelper(Mask);
 			gatewayStr = SaveIPHelper(Gateway);
 			dns1Str = SaveIPHelper(DNS1);
 			dns2Str = SaveIPHelper(DNS2);
 		}
 		SettingsWrapEntryEx(ps2IPStr, "PS2IP");
+		SettingsWrapEntryEx(maskStr, "Mask");
 		SettingsWrapEntryEx(gatewayStr, "Gateway");
 		SettingsWrapEntryEx(dns1Str, "DNS1");
 		SettingsWrapEntryEx(dns2Str, "DNS2");
 		if (wrap.IsLoading())
 		{
 			LoadIPHelper(PS2IP, ps2IPStr);
+			LoadIPHelper(Mask, maskStr);
 			LoadIPHelper(Gateway, gatewayStr);
 			LoadIPHelper(DNS1, dns1Str);
 			LoadIPHelper(DNS1, dns1Str);


### PR DESCRIPTION
### Description of Changes
Actually save subnet mask when it is manually specified.
Specify a sane default config value for the HDD size, rather than leaving at zero.

### Rationale behind Changes
Makes manually specifying a subnet mask with DHCP Intercept usable, although most will use the Auto setting
As for the HDD File size setting, a sane default value is used incase HDD support is enabled but the size setting was left unchanged.

### Suggested Testing Steps
Specify a subnet with DHCP Intercept, instead of using Auto subnet, and check the value saves.
On a fresh config, check that the value of `HddSizeSectors` is not zero in the config file.

