### PR TITLE
GS/WX: Fix default adapter causing unnecessary GS restarts

### DIFF
--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -736,8 +736,14 @@ void Dialog::Save()
 	m_ui.Save();
 	// only save the adapter when it makes sense to
 	// prevents changing the adapter, switching to another renderer and saving
-	if (m_adapter_select->GetCount() > 1) // First option is system default
-		theApp.SetConfig("Adapter", m_adapter_select->GetStringSelection().c_str());
+	if (m_adapter_select->GetCount() > 1)
+	{
+		// First option is system default
+		if (m_adapter_select->GetSelection() == 0)
+			theApp.SetConfig("Adapter", "");
+		else
+			theApp.SetConfig("Adapter", m_adapter_select->GetStringSelection().c_str());
+	}
 
 	m_hacks_panel->Save();
 	m_renderer_panel->Save();


### PR DESCRIPTION
### Description of Changes

Easy one, leaving the adapter on default would cause the setting to internally toggle between "Default Adapter" and "", leading to unnecessary GS reopens on settings change.

### Rationale behind Changes

Fixes my bug when I changed adapters from ints to strings.

### Suggested Testing Steps

Already tested with D3D/VK.