### PR TITLE
Fix debugger breakpoints in the IOP JIT

### DIFF
--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1206,7 +1206,8 @@ void psxRecMemcheck(u32 op, u32 bits, bool store)
 		next2.SetTarget();
 	}
 	// get out of here
-	xCMP(ptr8[&iopBreakpoint], 0);
+	xMOVZX(eax, ptr8[&iopBreakpoint]);
+	xCMP(eax, 0);
 	xJNE(iopExitRecompiledCode);
 }
 
@@ -1217,7 +1218,8 @@ void psxEncodeBreakpoint()
 		_psxFlushCall(FLUSH_EVERYTHING | FLUSH_PC);
 		xFastCall((void*)psxDynarecCheckBreakpoint);
 		// get out of here
-		xCMP(ptr8[&iopBreakpoint], 0);
+		xMOVZX(eax, ptr8[&iopBreakpoint]);
+		xCMP(eax, 0);
 		xJNE(iopExitRecompiledCode);
 	}
 }

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1245,20 +1245,17 @@ void psxEncodeMemcheck()
 
 void psxRecompileNextInstruction(int delayslot)
 {
-	// pblock isn't used elsewhere in this function.
-	//BASEBLOCK* pblock = PSX_GETBLOCK(psxpc);
+	if (IsDebugBuild)
+	{
+		xNOP();
+		xMOV(eax, psxpc);
+	}
 
 	// add breakpoint
 	if (!delayslot)
 	{
 		psxEncodeBreakpoint();
 		psxEncodeMemcheck();
-	}
-
-	if (IsDebugBuild)
-	{
-		xNOP();
-		xMOV(eax, psxpc);
 	}
 
 	psxRegs.code = iopMemRead32(psxpc);


### PR DESCRIPTION
### Description of Changes
Switches from comparing directly to loading into a register and comparing

If the previous way was supposed to work I hope someone who understands this stuff can take a look at it.

### Rationale behind Changes
Fixes the debugger.

### Suggested Testing Steps
Make sure breakpoints work.