### PR TITLE
GS: Properly detect 16bit format on Texture Shuffle + Convert

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -546,7 +546,9 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 			dst = CreateTarget(TEX0, new_size.x, new_size.y, type, clear);
 			dst->m_32_bits_fmt = dst_match->m_32_bits_fmt;
 			ShaderConvert shader;
-			bool fmt_16_bits = (psm_s.bpp == 16 && GSLocalMemory::m_psm[dst_match->m_TEX0.PSM].bpp == 16);
+			// m_32_bits_fmt gets set on a shuffle or if the format isn't 16bit.
+			// In this case it needs to make sure it isn't part of a shuffle, where it needs to be interpreted as 32bits.
+			const bool fmt_16_bits = (psm_s.bpp == 16 && GSLocalMemory::m_psm[dst_match->m_TEX0.PSM].bpp == 16 && !dst->m_32_bits_fmt);
 			if (type == DepthStencil)
 			{
 				GL_CACHE("TC: Lookup Target(Depth) %dx%d, hit Color (0x%x, %s was %s)", new_size.x, new_size.y, bp, psm_str(TEX0.PSM), psm_str(dst_match->m_TEX0.PSM));


### PR DESCRIPTION
### Description of Changes
Fixes the detection of 16bit format on shuffle and format convert

### Rationale behind Changes
It was being misdetected as 16bit instead of 32bit when a shuffle happened due to texture shuffles explicitly forcing the texture to 32bit, causing issues.

### Suggested Testing Steps
Test games, make sure post processing isn't broken.

Fixes #4661 but does need Half screen hw renderer fix also (now in Master)
