### PR TITLE
GS-hw: Attempt to improve half screen detection

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -572,9 +572,30 @@ void GSRendererHW::ConvertSpriteTextureShuffle(bool& write_ba, bool& read_ba)
 			//
 			// 32bits emulation means we can do the effect once but double the size.
 			// Test cases: Crash Twinsantiy and DBZ BT3
-			const int height_delta = m_src->m_valid_rect.height() - m_r.height();
 			// Test Case: NFS: HP2 splits the effect h:256 and h:192 so 64
-			half_bottom = abs(height_delta) <= 64;
+			// Other games: Midnight Club 3 headlights, black bar in Xenosaga 3 dialogue,
+			// Firefighter FD18 fire occlusion, PSI Ops half screen green overlay, Lord of the Rings - Two Towers,
+			// Demon Stone , Sonic Unleashed, Lord of the Rings Two Towers,
+			// Superman Shadow of Apokolips, Matrix Path of Neo, Big Mutha Truckers
+
+			int maxvert = 0;
+			int minvert = 4096;
+			for (size_t i = 0; i < count; i ++)
+			{
+				int YCord = 0;
+
+				if (!PRIM->FST)
+					YCord = (int)((1 << m_context->TEX0.TH) * (v[i].ST.T / v[i].RGBAQ.Q));
+				else
+					YCord = (v[i].V >> 4);
+
+				if (maxvert < YCord)
+					maxvert = YCord;
+				if (minvert > YCord)
+					minvert = YCord;
+			}
+			// Check if it's a full screen blit (or at least half screen), ignore small writes.
+			half_bottom = minvert == 0 && m_r.height() <= maxvert && (m_r.height()+1) >= 224;
 			break;
 	}
 


### PR DESCRIPTION
### Description of Changes
Attempts to improve the detection of half screen effects across games, hopefully without breaking anything.

### Rationale behind Changes
The half screen fix is a hack and is a workaround for the TC not detecting the height properly, the previous detection was possibly a little too conservative, or detected the wrong things, this now tries to detect full screen blits which is usually what causes the half screen issues in games which hit this codepath.

### Suggested Testing Steps
Test games with half screen problems (generally missing effects), see if it fixes them (doesn't fix Dropship, tested that :P)

Fixes Midnight Club 3 headlights. Fixes #2327
Fixes the black bar in Xenosaga 3 dialogues.
Fixes half screen requirement for Firefighter FD18
Fixes PSI Ops half screen green automatically. Fixes #1657
Fixes Lord of the Rings - Two Towers half screen issue
Fixes Demon Stone half screen issue
Works for Sonic Unleashed
Works for NFS HP2
Works for Crash Twinsanity
Works for DBZ BT3
Doesn't break Valkyrie Profile 2 :D

Dumps tested and shown to be working by Lightning Terror
![image](https://user-images.githubusercontent.com/6278726/157718802-2cde87eb-d54f-4254-8e3e-99f7885dd346.png)


Possibly related issue but not all the same cause: #1339