### PR TITLE
x86emitter: Fix x64 8-bit rmw codegen

### DIFF
--- a/common/emitter/groups.cpp
+++ b/common/emitter/groups.cpp
@@ -45,7 +45,7 @@ namespace x86Emitter
 	{
 		if (sibdest.Is8BitOp())
 		{
-			xOpWrite(sibdest.GetPrefix16(), 0x80, InstType, sibdest);
+			xOpWrite(sibdest.GetPrefix16(), 0x80, InstType, sibdest, 1);
 
 			xWrite<s8>(imm);
 		}

--- a/tests/ctest/x86emitter/codegen_tests_main.cpp
+++ b/tests/ctest/x86emitter/codegen_tests_main.cpp
@@ -113,6 +113,7 @@ TEST(CodegenTests, MathTest)
 	CODEGEN_TEST_64(xADD(r8, r9), "4d 01 c8");
 	CODEGEN_TEST_64(xADD(r8, 0x12), "49 83 c0 12");
 	CODEGEN_TEST_64(xADD(rax, 0x1234), "48 05 34 12 00 00");
+	CODEGEN_TEST_64(xADD(ptr8[base], 1), "80 05 f9 ff ff ff 01");
 	CODEGEN_TEST_64(xADD(ptr32[base], -0x60), "83 05 f9 ff ff ff a0");
 	CODEGEN_TEST_64(xADD(ptr32[base], 0x1234), "81 05 f6 ff ff ff 34 12 00 00");
 	CODEGEN_TEST_BOTH(xADD(eax, ebx), "01 d8");


### PR DESCRIPTION
### Description of Changes
Previously was off by one in the memory address it targeted

Should fix JIT breakpoints

### Rationale behind Changes
It's nice when your codegen does what you told it to do

### Suggested Testing Steps
Test JIT breakpoints