### PR TITLE
GS: Utilize framebuffer fetch for blending/fbmask where available

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -57,6 +57,9 @@
 #define PS_AUTOMATIC_LOD 0
 #define PS_MANUAL_LOD 0
 #define PS_TEX_IS_FB 0
+#define PS_NO_ABLEND 0
+#define PS_ONLY_ALPHA 0
+#define PS_NO_COLOR1 0
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
@@ -100,7 +103,9 @@ struct PS_INPUT
 struct PS_OUTPUT
 {
 	float4 c0 : SV_Target0;
+#if !PS_NO_COLOR1
 	float4 c1 : SV_Target1;
+#endif
 #if PS_ZCLAMP
 	float depth : SV_Depth;
 #endif
@@ -855,7 +860,18 @@ PS_OUTPUT ps_main(PS_INPUT input)
 	ps_fbmask(C, input.p.xy);
 
 	output.c0 = C / 255.0f;
+#if !PS_NO_COLOR1
 	output.c1 = (float4)(alpha_blend);
+#endif
+
+#if PS_NO_ABLEND
+	// write alpha blend factor into col0
+	output.c0.a = alpha_blend;
+#endif
+#if PS_ONLY_ALPHA
+	// rgb isn't used
+	output.c0.rgb = float3(0.0f, 0.0f, 0.0f);
+#endif
 
 #if PS_ZCLAMP
 	output.depth = min(input.p.z, MaxDepthPS);

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -57,9 +57,10 @@
 #define PS_AUTOMATIC_LOD 0
 #define PS_MANUAL_LOD 0
 #define PS_TEX_IS_FB 0
+#define PS_NO_COLOR 0
+#define PS_NO_COLOR1 0
 #define PS_NO_ABLEND 0
 #define PS_ONLY_ALPHA 0
-#define PS_NO_COLOR1 0
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
@@ -102,9 +103,11 @@ struct PS_INPUT
 
 struct PS_OUTPUT
 {
+#if !PS_NO_COLOR
 	float4 c0 : SV_Target0;
 #if !PS_NO_COLOR1
 	float4 c1 : SV_Target1;
+#endif
 #endif
 #if PS_ZCLAMP
 	float depth : SV_Depth;
@@ -859,6 +862,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 
 	ps_fbmask(C, input.p.xy);
 
+#if !PS_NO_COLOR
 	output.c0 = C / 255.0f;
 #if !PS_NO_COLOR1
 	output.c1 = (float4)(alpha_blend);
@@ -871,6 +875,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 #if PS_ONLY_ALPHA
 	// rgb isn't used
 	output.c0.rgb = float3(0.0f, 0.0f, 0.0f);
+#endif
 #endif
 
 #if PS_ZCLAMP

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -50,7 +50,7 @@ in SHADER
   #endif
 #endif
 
-#ifndef DISABLE_DUAL_SOURCE
+#if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
   // Same buffer but 2 colors for dual source blending
   layout(location = 0, index = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
   layout(location = 0, index = 1) out vec4 SV_Target1;
@@ -943,8 +943,17 @@ void ps_main()
     ps_fbmask(C);
 
     SV_Target0 = C / 255.0f;
-#ifndef DISABLE_DUAL_SOURCE
+#if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
     SV_Target1 = vec4(alpha_blend);
+#endif
+
+#if PS_NO_ABLEND
+    // write alpha blend factor into col0
+    SV_Target0.a = alpha_blend;
+#endif
+#if PS_ONLY_ALPHA
+    // rgb isn't used
+    SV_Target0.rgb = vec3(0.0f);
 #endif
 
 #if PS_ZCLAMP

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -50,12 +50,14 @@ in SHADER
   #endif
 #endif
 
+#if !PS_NO_COLOR
 #if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
   // Same buffer but 2 colors for dual source blending
   layout(location = 0, index = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
   layout(location = 0, index = 1) out vec4 SV_Target1;
 #else
   layout(location = 0) TARGET_0_QUALIFIER vec4 SV_Target0;
+#endif
 #endif
 
 layout(binding = 1) uniform sampler2D PaletteSampler;
@@ -942,6 +944,7 @@ void ps_main()
 
     ps_fbmask(C);
 
+#if !PS_NO_COLOR
     SV_Target0 = C / 255.0f;
 #if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
     SV_Target1 = vec4(alpha_blend);
@@ -954,6 +957,7 @@ void ps_main()
 #if PS_ONLY_ALPHA
     // rgb isn't used
     SV_Target0.rgb = vec3(0.0f);
+#endif
 #endif
 
 #if PS_ZCLAMP

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -378,7 +378,7 @@ layout(location = 0) in VSOutput
 	#endif
 } vsIn;
 
-#ifndef DISABLE_DUAL_SOURCE
+#if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
 layout(location = 0, index = 0) out vec4 o_col0;
 layout(location = 0, index = 1) out vec4 o_col1;
 #else
@@ -1202,8 +1202,17 @@ void main()
   ps_fbmask(C);
 
 	o_col0 = C / 255.0f;
-#ifndef DISABLE_DUAL_SOURCE
+#if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
 	o_col1 = vec4(alpha_blend);
+#endif
+
+#if PS_NO_ABLEND
+	// write alpha blend factor into col0
+	o_col0.a = alpha_blend;
+#endif
+#if PS_ONLY_ALPHA
+	// rgb isn't used
+	o_col0.rgb = vec3(0.0f);
 #endif
 
 #if PS_ZCLAMP

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1201,6 +1201,7 @@ void main()
 
   ps_fbmask(C);
 
+#if !PS_NO_COLOR
 	o_col0 = C / 255.0f;
 #if !defined(DISABLE_DUAL_SOURCE) && !PS_NO_COLOR1
 	o_col1 = vec4(alpha_blend);
@@ -1213,6 +1214,7 @@ void main()
 #if PS_ONLY_ALPHA
 	// rgb isn't used
 	o_col0.rgb = vec3(0.0f);
+#endif
 #endif
 
 #if PS_ZCLAMP

--- a/common/Vulkan/Builders.cpp
+++ b/common/Vulkan/Builders.cpp
@@ -352,6 +352,11 @@ namespace Vulkan
 		}
 	}
 
+	void GraphicsPipelineBuilder::AddBlendFlags(u32 flags)
+	{
+		m_blend_state.flags |= flags;
+	}
+
 	void GraphicsPipelineBuilder::ClearBlendAttachments()
 	{
 		m_blend_attachments = {};

--- a/common/Vulkan/Builders.h
+++ b/common/Vulkan/Builders.h
@@ -112,6 +112,7 @@ namespace Vulkan
 			VkBlendOp op, VkBlendFactor alpha_src_factor, VkBlendFactor alpha_dst_factor, VkBlendOp alpha_op,
 			VkColorComponentFlags write_mask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
 											   VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT);
+		void AddBlendFlags(u32 flags);
 		void ClearBlendAttachments();
 
 		void SetBlendConstants(float r, float g, float b, float a);

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -51,6 +51,7 @@ namespace Vulkan
 			bool vk_ext_provoking_vertex : 1;
 			bool vk_ext_memory_budget : 1;
 			bool vk_khr_driver_properties : 1;
+			bool vk_arm_rasterization_order_attachment_access : 1;
 		};
 
 		~Context();

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -182,6 +182,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableFramebufferFetch, "EmuCore/GS", "DisableFramebufferFetch", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableDualSource, "EmuCore/GS", "DisableDualSourceBlend", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// SW Settings

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -181,6 +181,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableFramebufferFetch, "EmuCore/GS", "DisableFramebufferFetch", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// SW Settings

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -179,6 +179,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useBlitSwapChain, "EmuCore/GS", "UseBlitSwapChain", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
 
 	//////////////////////////////////////////////////////////////////////////
 	// SW Settings

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -963,20 +963,76 @@
          <property name="title">
           <string>Debug Options</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_7">
+         <layout class="QFormLayout" name="formLayout_6">
           <item row="0" column="0">
-           <widget class="QCheckBox" name="useBlitSwapChain">
+           <widget class="QLabel" name="label_19">
             <property name="text">
-             <string>Use Blit Swap Chain</string>
+              <string>Override Texture Barriers:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QCheckBox" name="useDebugDevice">
+           <widget class="QComboBox" name="overrideTextureBarriers">
+            <item>
+             <property name="text">
+              <string>Automatic (Default)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Force Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Force Enabled</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_30">
             <property name="text">
-             <string>Use Debug Device</string>
+             <string>Override Geometry Shader:</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="overrideGeometryShader">
+            <item>
+             <property name="text">
+               <string>Automatic (Default)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+               <string>Force Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Force Enabled</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <layout class="QGridLayout" name="gridLayout_7">
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="useBlitSwapChain">
+              <property name="text">
+               <string>Use Blit Swap Chain</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="useDebugDevice">
+              <property name="text">
+               <string>Use Debug Device</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1032,6 +1032,13 @@
               </property>
              </widget>
             </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="disableFramebufferFetch">
+              <property name="text">
+               <string>Disable Framebuffer Fetch</string>
+              </property>
+              </widget>
+            </item>
            </layout>
           </item>
          </layout>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1033,6 +1033,13 @@
              </widget>
             </item>
             <item row="1" column="0">
+             <widget class="QCheckBox" name="disableDualSource">
+              <property name="text">
+               <string>Disable Dual Source Blending</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
              <widget class="QCheckBox" name="disableFramebufferFetch">
               <property name="text">
                <string>Disable Framebuffer Fetch</string>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -423,6 +423,7 @@ struct Pcsx2Config
 					UseDebugDevice : 1,
 					UseBlitSwapChain : 1,
 					DisableShaderCache : 1,
+					DisableDualSourceBlend : 1,
 					DisableFramebufferFetch : 1,
 					ThreadedPresentation : 1,
 					OsdShowMessages : 1,

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -423,6 +423,7 @@ struct Pcsx2Config
 					UseDebugDevice : 1,
 					UseBlitSwapChain : 1,
 					DisableShaderCache : 1,
+					DisableFramebufferFetch : 1,
 					ThreadedPresentation : 1,
 					OsdShowMessages : 1,
 					OsdShowSpeed : 1,

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -521,6 +521,8 @@ struct Pcsx2Config
 		int UserHacks_TCOffsetX{0};
 		int UserHacks_TCOffsetY{0};
 		TriFiltering UserHacks_TriFilter{TriFiltering::Off};
+		int OverrideTextureBarriers{-1};
+		int OverrideGeometryShaders{-1};
 
 		int ShadeBoost_Brightness{50};
 		int ShadeBoost_Contrast{50};

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -14,7 +14,7 @@
 #include "imgui_impl_vulkan.h"
 #include <array>
 
-static constexpr u32 SHADER_CACHE_VERSION = 1;
+static constexpr u32 SHADER_CACHE_VERSION = 2;
 
 class VulkanHostDisplayTexture : public HostDisplayTexture
 {

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -14,7 +14,7 @@
 #include "imgui_impl_vulkan.h"
 #include <array>
 
-static constexpr u32 SHADER_CACHE_VERSION = 2;
+static constexpr u32 SHADER_CACHE_VERSION = 3;
 
 class VulkanHostDisplayTexture : public HostDisplayTexture
 {

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -14,7 +14,7 @@
 #include "imgui_impl_vulkan.h"
 #include <array>
 
-static constexpr u32 SHADER_CACHE_VERSION = 3;
+static constexpr u32 SHADER_CACHE_VERSION = 4;
 
 class VulkanHostDisplayTexture : public HostDisplayTexture
 {

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1340,7 +1340,6 @@ void GSApp::Init()
 	m_default_configuration["OsdShowGSStats"]                             = "0";
 	m_default_configuration["OsdShowIndicators"]                          = "1";
 	m_default_configuration["OsdScale"]                                   = "100";
-	m_default_configuration["override_geometry_shader"]                   = "-1";
 	m_default_configuration["override_GL_ARB_copy_image"]                 = "-1";
 	m_default_configuration["override_GL_ARB_clear_texture"]              = "-1";
 	m_default_configuration["override_GL_ARB_clip_control"]               = "-1";
@@ -1351,6 +1350,8 @@ void GSApp::Init()
 	m_default_configuration["override_GL_ARB_sparse_texture"]             = "-1";
 	m_default_configuration["override_GL_ARB_sparse_texture2"]            = "-1";
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
+	m_default_configuration["OverrideTextureBarriers"]                    = "-1";
+	m_default_configuration["OverrideGeometryShaders"]                    = "-1";
 	m_default_configuration["paltex"]                                     = "0";
 	m_default_configuration["png_compression_level"]                      = std::to_string(Z_BEST_SPEED);
 	m_default_configuration["PointListPalette"]                           = "0";

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1308,6 +1308,7 @@ void GSApp::Init()
 	m_default_configuration["CrcHacksExclusions"]                         = "";
 	m_default_configuration["disable_hw_gl_draw"]                         = "0";
 	m_default_configuration["disable_shader_cache"]                       = "0";
+	m_default_configuration["DisableDualSourceBlend"]                     = "0";
 	m_default_configuration["DisableFramebufferFetch"]                    = "0";
 	m_default_configuration["dithering_ps2"]                              = "2";
 	m_default_configuration["dump"]                                       = "0";

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1308,6 +1308,7 @@ void GSApp::Init()
 	m_default_configuration["CrcHacksExclusions"]                         = "";
 	m_default_configuration["disable_hw_gl_draw"]                         = "0";
 	m_default_configuration["disable_shader_cache"]                       = "0";
+	m_default_configuration["DisableFramebufferFetch"]                    = "0";
 	m_default_configuration["dithering_ps2"]                              = "2";
 	m_default_configuration["dump"]                                       = "0";
 	m_default_configuration["DumpReplaceableTextures"]                    = "0";

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -507,8 +507,6 @@ HWBlend GSDevice::GetBlend(size_t index)
 	return blend;
 }
 
-u16 GSDevice::GetBlendFlags(size_t index) { return m_blendMap[index].flags; }
-
 // clang-format off
 
 std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -498,18 +498,38 @@ GSAdapter::GSAdapter(const DXGI_ADAPTER_DESC1& desc_dxgi)
 // TODO
 #endif
 
-HWBlend GSDevice::GetBlend(size_t index)
+HWBlend GSDevice::GetBlend(size_t index, bool replace_dual_src)
 {
 	HWBlend blend = m_blendMap[index];
 	blend.op  = ConvertBlendEnum(blend.op);
-	blend.src = ConvertBlendEnum(blend.src);
-	blend.dst = ConvertBlendEnum(blend.dst);
+	blend.src = ConvertBlendEnum(replace_dual_src ? m_replaceDualSrcBlendMap[blend.src] : blend.src);
+	blend.dst = ConvertBlendEnum(replace_dual_src ? m_replaceDualSrcBlendMap[blend.dst] : blend.dst);
 	return blend;
 }
 
 // clang-format off
 
-std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
+const std::array<u16, 16> GSDevice::m_replaceDualSrcBlendMap =
+{{
+	SRC_COLOR,        // SRC_COLOR
+	INV_SRC_COLOR,    // INV_SRC_COLOR
+	DST_COLOR,        // DST_COLOR
+	INV_DST_COLOR,    // INV_DST_COLOR
+	SRC_COLOR,        // SRC1_COLOR
+	INV_SRC_COLOR,    // INV_SRC1_COLOR
+	SRC_ALPHA,        // SRC_ALPHA
+	INV_SRC_ALPHA,    // INV_SRC_ALPHA
+	DST_ALPHA,        // DST_ALPHA
+	INV_DST_ALPHA,    // INV_DST_ALPHA
+	SRC_ALPHA,        // SRC1_ALPHA
+	INV_SRC_ALPHA,    // INV_SRC1_ALPHA
+	CONST_COLOR,      // CONST_COLOR
+	INV_CONST_COLOR,  // INV_CONST_COLOR
+	CONST_ONE,        // CONST_ONE
+	CONST_ZERO        // CONST_ZERO
+}};
+
+const std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
 {{
 	{ BLEND_NO_REC               , OP_ADD          , CONST_ONE       , CONST_ZERO}      , // 0000: (Cs - Cs)*As + Cs ==> Cs
 	{ BLEND_CD                   , OP_ADD          , CONST_ZERO      , CONST_ONE}       , // 0001: (Cs - Cs)*As + Cd ==> Cd

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -498,18 +498,9 @@ GSAdapter::GSAdapter(const DXGI_ADAPTER_DESC1& desc_dxgi)
 // TODO
 #endif
 
-HWBlend GSDevice::GetBlend(size_t index, bool replace_dual_src)
-{
-	HWBlend blend = m_blendMap[index];
-	blend.op  = ConvertBlendEnum(blend.op);
-	blend.src = ConvertBlendEnum(replace_dual_src ? m_replaceDualSrcBlendMap[blend.src] : blend.src);
-	blend.dst = ConvertBlendEnum(replace_dual_src ? m_replaceDualSrcBlendMap[blend.dst] : blend.dst);
-	return blend;
-}
-
 // clang-format off
 
-const std::array<u16, 16> GSDevice::m_replaceDualSrcBlendMap =
+const std::array<u8, 16> GSDevice::m_replaceDualSrcBlendMap =
 {{
 	SRC_COLOR,        // SRC_COLOR
 	INV_SRC_COLOR,    // INV_SRC_COLOR
@@ -529,7 +520,7 @@ const std::array<u16, 16> GSDevice::m_replaceDualSrcBlendMap =
 	CONST_ZERO        // CONST_ZERO
 }};
 
-const std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
+const std::array<HWBlend, 3*3*3*3> GSDevice::m_blendMap =
 {{
 	{ BLEND_NO_REC               , OP_ADD          , CONST_ONE       , CONST_ZERO}      , // 0000: (Cs - Cs)*As + Cs ==> Cs
 	{ BLEND_CD                   , OP_ADD          , CONST_ZERO      , CONST_ONE}       , // 0001: (Cs - Cs)*As + Cd ==> Cd
@@ -612,5 +603,4 @@ const std::array<HWBlend, 3*3*3*3 + 1> GSDevice::m_blendMap =
 	{ BLEND_NO_REC               , OP_ADD          , CONST_ONE       , CONST_ZERO}      , // 2220: (0  -  0)*F  + Cs ==> Cs
 	{ BLEND_CD                   , OP_ADD          , CONST_ZERO      , CONST_ONE}       , // 2221: (0  -  0)*F  + Cd ==> Cd
 	{ BLEND_NO_REC               , OP_ADD          , CONST_ZERO      , CONST_ZERO}      , // 2222: (0  -  0)*F  +  0 ==> 0
-	{ 0                          , OP_ADD          , SRC_ALPHA       , INV_SRC_ALPHA}   , // extra for merge operation
 }};

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -544,6 +544,8 @@ public:
 		bool prefer_new_textures  : 1; ///< Allocate textures up to the pool size before reusing them, to avoid render pass restarts.
 		bool dxt_textures         : 1; ///< Supports DXTn texture compression, i.e. S3TC and BC1-3.
 		bool bptc_textures        : 1; ///< Supports BC6/7 texture compression.
+		bool framebuffer_fetch    : 1; ///< Can sample from the framebuffer without texture barriers.
+		bool dual_source_blend    : 1; ///< Can use alpha output as a blend factor.
 		FeatureSupport()
 		{
 			memset(this, 0, sizeof(*this));
@@ -606,6 +608,12 @@ public:
 
 	__fi HostDisplay* GetDisplay() const { return m_display; }
 	__fi unsigned int GetFrameNumber() const { return m_frame; }
+
+	__fi static constexpr bool IsDualSourceBlendFactor(u16 factor)
+	{
+		return (factor == GSDevice::SRC1_ALPHA || factor == GSDevice::INV_SRC1_ALPHA
+			/*|| factor == GSDevice::SRC1_COLOR || factor == GSDevice::INV_SRC1_COLOR*/); // not used
+	}
 
 	void Recycle(GSTexture* t);
 
@@ -700,7 +708,8 @@ public:
 	// Convert the GS blend equations to HW specific blend factors/ops
 	// Index is computed as ((((A * 3 + B) * 3) + C) * 3) + D. A, B, C, D taken from ALPHA register.
 	HWBlend GetBlend(size_t index);
-	u16 GetBlendFlags(size_t index);
+	__fi HWBlend GetUnconvertedBlend(size_t index) { return m_blendMap[index]; }
+	__fi u16 GetBlendFlags(size_t index) const { return m_blendMap[index].flags; }
 };
 
 struct GSAdapter

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -580,6 +580,7 @@ public:
 		bool bptc_textures        : 1; ///< Supports BC6/7 texture compression.
 		bool framebuffer_fetch    : 1; ///< Can sample from the framebuffer without texture barriers.
 		bool dual_source_blend    : 1; ///< Can use alpha output as a blend factor.
+		bool stencil_buffer       : 1; ///< Supports stencil buffer, and can use for DATE.
 		FeatureSupport()
 		{
 			memset(this, 0, sizeof(*this));

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -239,8 +239,9 @@ struct alignas(16) GSHWDrawConfig
 				u32 colclip     : 1;
 				u32 blend_mix   : 1;
 				u32 pabe        : 1;
-				u32 no_ablend   : 1; // output alpha blend in col0 (for no-DSB)
+				u32 no_color    : 1; // disables color output entirely (depth only)
 				u32 no_color1   : 1; // disables second color output (when unnecessary)
+				u32 no_ablend   : 1; // output alpha blend in col0 (for no-DSB)
 				u32 only_alpha  : 1; // don't bother computing RGB
 
 				// Others ways to fetch the texture

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -55,6 +55,7 @@ GSDevice11::GSDevice11()
 	m_features.bptc_textures = false;
 	m_features.framebuffer_fetch = false;
 	m_features.dual_source_blend = true;
+	m_features.stencil_buffer = true;
 }
 
 bool GSDevice11::Create(HostDisplay* display)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -53,6 +53,8 @@ GSDevice11::GSDevice11()
 	m_features.prefer_new_textures = false;
 	m_features.dxt_textures = false;
 	m_features.bptc_textures = false;
+	m_features.framebuffer_fetch = false;
+	m_features.dual_source_blend = true;
 }
 
 bool GSDevice11::Create(HostDisplay* display)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -213,7 +213,7 @@ private:
 	std::unordered_map<u32, GSVertexShader11> m_vs;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_vs_cb;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11GeometryShader>> m_gs;
-	std::unordered_map<u64, wil::com_ptr_nothrow<ID3D11PixelShader>> m_ps;
+	std::unordered_map<PSSelector, wil::com_ptr_nothrow<ID3D11PixelShader>, GSHWDrawConfig::PSSelectorHash> m_ps;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ps_cb;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11SamplerState>> m_ps_ss;
 	wil::com_ptr_nothrow<ID3D11SamplerState> m_palette_ss;
@@ -291,7 +291,7 @@ public:
 	bool CreateTextureFX();
 	void SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer* cb);
 	void SetupGS(GSSelector sel);
-	void SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel);
+	void SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel);
 	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 afix);
 
 	void RenderHW(GSHWDrawConfig& config) final;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -51,10 +51,10 @@ public:
 				u32 wb : 1;
 				u32 wa : 1;
 				// Alpha blending
-				u32 blend_index : 7;
-				u32 abe : 1;
-				u32 accu_blend : 1;
-				u32 blend_mix : 1;
+				u32 blend_enable : 1;
+				u32 blend_op : 2;
+				u32 blend_src_factor : 4;
+				u32 blend_dst_factor : 4;
 			};
 
 			struct
@@ -66,7 +66,7 @@ public:
 			u32 key;
 		};
 
-		operator u32() { return key & 0x3fff; }
+		operator u32() { return key & 0x7fff; }
 
 		OMBlendSelector()
 			: key(0)
@@ -126,8 +126,6 @@ private:
 	void DoFXAA(GSTexture* sTex, GSTexture* dTex) final;
 	void DoShadeBoost(GSTexture* sTex, GSTexture* dTex) final;
 	void DoExternalFX(GSTexture* sTex, GSTexture* dTex) final;
-
-	u16 ConvertBlendEnum(u16 generic) final;
 
 	wil::com_ptr_nothrow<ID3D11Device> m_dev;
 	wil::com_ptr_nothrow<ID3D11DeviceContext> m_ctx;

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -147,9 +147,9 @@ void GSDevice11::SetupGS(GSSelector sel)
 	GSSetShader(gs.get(), m_vs_cb.get());
 }
 
-void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel)
+void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel)
 {
-	auto i = std::as_const(m_ps).find(sel.key);
+	auto i = std::as_const(m_ps).find(sel);
 
 	if (i == m_ps.end())
 	{
@@ -195,9 +195,12 @@ void GSDevice11::SetupPS(PSSelector sel, const GSHWDrawConfig::PSConstantBuffer*
 		sm.AddMacro("PS_AUTOMATIC_LOD", sel.automatic_lod);
 		sm.AddMacro("PS_MANUAL_LOD", sel.manual_lod);
 		sm.AddMacro("PS_TEX_IS_FB", sel.tex_is_fb);
+		sm.AddMacro("PS_NO_ABLEND", sel.no_ablend);
+		sm.AddMacro("PS_ONLY_ALPHA", sel.only_alpha);
+		sm.AddMacro("PS_NO_COLOR1", sel.no_color1);
 
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps = m_shader_cache.GetPixelShader(m_dev.get(), m_tfx_source, sm.GetPtr(), "ps_main");
-		i = m_ps.try_emplace(sel.key, std::move(ps)).first;
+		i = m_ps.try_emplace(sel, std::move(ps)).first;
 	}
 
 	if (cb && m_ps_cb_cache.Update(*cb))
@@ -335,7 +338,7 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 
 
 		if (bsel.abe)
 		{
-			const HWBlend blend = GetBlend(bsel.blend_index);
+			const HWBlend blend = GetBlend(bsel.blend_index, false);
 			bd.RenderTarget[0].BlendEnable = TRUE;
 			bd.RenderTarget[0].BlendOp = (D3D11_BLEND_OP)blend.op;
 			bd.RenderTarget[0].SrcBlend = (D3D11_BLEND)blend.src;

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -195,9 +195,10 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		sm.AddMacro("PS_AUTOMATIC_LOD", sel.automatic_lod);
 		sm.AddMacro("PS_MANUAL_LOD", sel.manual_lod);
 		sm.AddMacro("PS_TEX_IS_FB", sel.tex_is_fb);
+		sm.AddMacro("PS_NO_COLOR", sel.no_color);
+		sm.AddMacro("PS_NO_COLOR1", sel.no_color1);
 		sm.AddMacro("PS_NO_ABLEND", sel.no_ablend);
 		sm.AddMacro("PS_ONLY_ALPHA", sel.only_alpha);
-		sm.AddMacro("PS_NO_COLOR1", sel.no_color1);
 
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps = m_shader_cache.GetPixelShader(m_dev.get(), m_tfx_source, sm.GetPtr(), "ps_main");
 		i = m_ps.try_emplace(sel, std::move(ps)).first;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -867,9 +867,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool&
 		sw_blending = false; // DATE_PRIMID
 
 		// Output is Cd, set rgb write to 0.
-		m_conf.colormask.wr = 0;
-		m_conf.colormask.wg = 0;
-		m_conf.colormask.wb = 0;
+		m_conf.colormask.wrgba &= 0x8;
+		m_conf.ps.no_color = (m_conf.colormask.wrgba == 0);
 	}
 	else if (sw_blending)
 	{
@@ -1521,6 +1520,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	else
 	{
 		m_conf.blend = {}; // No blending please
+		m_conf.ps.no_color = !rt || (m_conf.colormask.wrgba == 0);
 		m_conf.ps.no_color1 = true;
 	}
 
@@ -1784,6 +1784,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			m_conf.alpha_second_pass.colormask.wg = g;
 			m_conf.alpha_second_pass.colormask.wb = b;
 			m_conf.alpha_second_pass.colormask.wa = a;
+			m_conf.alpha_second_pass.ps.no_color |= !(r || g || b || a);
 		}
 		else
 		{

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -183,7 +183,8 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 	// m_texture_shuffle = false;
 
 	bool enable_fbmask_emulation = false;
-	if (g_gs_device->Features().texture_barrier)
+	const GSDevice::FeatureSupport features = g_gs_device->Features();
+	if (features.texture_barrier)
 	{
 		enable_fbmask_emulation = GSConfig.AccurateBlendingUnit != AccBlendLevel::Minimum;
 	}
@@ -224,7 +225,7 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 		// If date is enabled you need to test the green channel instead of the
 		// alpha channel. Only enable this code in DATE mode to reduce the number
 		// of shader.
-		m_conf.ps.write_rg = !write_ba && g_gs_device->Features().texture_barrier && m_context->TEST.DATE;
+		m_conf.ps.write_rg = !write_ba && features.texture_barrier && m_context->TEST.DATE;
 
 		m_conf.ps.read_ba = read_ba;
 
@@ -278,15 +279,15 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 			m_conf.cb_ps.FbMask.a = ba_mask;
 
 			// No blending so hit unsafe path.
-			if (!PRIM->ABE || !g_gs_device->Features().texture_barrier)
+			if (!PRIM->ABE || !features.texture_barrier)
 			{
 				GL_INS("FBMASK Unsafe SW emulated fb_mask:%x on tex shuffle", fbmask);
-				m_conf.require_one_barrier = true;
+				m_conf.require_one_barrier = features.texture_barrier;
 			}
 			else
 			{
 				GL_INS("FBMASK SW emulated fb_mask:%x on tex shuffle", fbmask);
-				m_conf.require_full_barrier = true;
+				m_conf.require_full_barrier = features.texture_barrier;
 			}
 		}
 		else
@@ -339,14 +340,14 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 			{
 				GL_INS("FBMASK Unsafe SW emulated fb_mask:%x on %d bits format", m_context->FRAME.FBMSK,
 					(m_conf.ps.dfmt == 2) ? 16 : 32);
-				m_conf.require_one_barrier = true;
+				m_conf.require_one_barrier = features.texture_barrier;
 			}
 			else
 			{
 				// The safe and accurate path (but slow)
 				GL_INS("FBMASK SW emulated fb_mask:%x on %d bits format", m_context->FRAME.FBMSK,
 					(m_conf.ps.dfmt == 2) ? 16 : 32);
-				m_conf.require_full_barrier = true;
+				m_conf.require_full_barrier = features.texture_barrier;
 			}
 		}
 	}
@@ -492,7 +493,7 @@ void GSRendererNew::EmulateChannelShuffle(const GSTextureCache::Source* tex)
 				// sample from fb instead
 				m_conf.tex = nullptr;
 				m_conf.ps.tex_is_fb = true;
-				m_conf.require_one_barrier = true;
+				m_conf.require_one_barrier = !g_gs_device->Features().framebuffer_fetch;
 			}
 			else if (m_conf.tex == m_conf.ds)
 			{
@@ -539,6 +540,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	}
 
 	// Compute the blending equation to detect special case
+	const GSDevice::FeatureSupport features(g_gs_device->Features());
 	const GIFRegALPHA& ALPHA = m_context->ALPHA;
 
 	// Set blending to shader bits
@@ -627,20 +629,31 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		&& (m_env.COLCLAMP.CLAMP)                                        // Let's add a colclamp check too, hw blend will clamp to 0-1.
 		&& !(m_conf.require_one_barrier || m_conf.require_full_barrier); // Also don't run if there are barriers present.
 
+	bool sw_blending = false;
+	if (!features.dual_source_blend)
+	{
+		const HWBlend unconverted_blend = g_gs_device->GetUnconvertedBlend(blend_index);
+		if (GSDevice::IsDualSourceBlendFactor(unconverted_blend.dst) ||
+			GSDevice::IsDualSourceBlendFactor(unconverted_blend.src))
+		{
+			sw_blending = true;
+		}
+	}
+
 	// Warning no break on purpose
 	// Note: the [[fallthrough]] attribute tell compilers not to complain about not having breaks.
-	bool sw_blending = false;
-	if (g_gs_device->Features().texture_barrier)
+	if (features.texture_barrier)
 	{
 		// Condition 1: Require full sw blend for full barrier.
 		// Condition 2: One barrier is already enabled, prims don't overlap so let's use sw blend instead.
 		const bool prefer_sw_blend = m_conf.require_full_barrier || (m_conf.require_one_barrier && m_prim_overlap == PRIM_OVERLAP_NO);
 
 		// SW Blend is (nearly) free. Let's use it.
+		const bool no_prim_overlap = features.framebuffer_fetch ? (m_vt.m_primclass == GS_SPRITE_CLASS) : (m_prim_overlap == PRIM_OVERLAP_NO);
 		const bool impossible_or_free_blend = (blend_flag & BLEND_A_MAX) // Impossible blending
 			|| blend_non_recursive                 // Free sw blending, doesn't require barriers or reading fb
 			|| accumulation_blend                  // Mix of hw/sw blending
-			|| (m_prim_overlap == PRIM_OVERLAP_NO) // Blend can be done in a single draw
+			|| no_prim_overlap                     // Blend can be done in a single draw
 			|| (m_conf.require_full_barrier);      // Another effect (for example fbmask) already requires a full barrier
 
 		switch (GSConfig.AccurateBlendingUnit)
@@ -731,7 +744,9 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	if (m_env.COLCLAMP.CLAMP == 0)
 	{
 		bool free_colclip = false;
-		if (g_gs_device->Features().texture_barrier)
+		if (features.framebuffer_fetch)
+			free_colclip = true;
+		else if (features.texture_barrier)
 			free_colclip = m_prim_overlap == PRIM_OVERLAP_NO || blend_non_recursive;
 		else
 			free_colclip = blend_non_recursive;
@@ -780,7 +795,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		if (sw_blending)
 		{
 			GL_INS("PABE mode ENABLED");
-			if (g_gs_device->Features().texture_barrier)
+			if (features.texture_barrier)
 			{
 				// Disable hw/sw blend and do pure sw blend with reading the framebuffer.
 				color_dest_blend   = false;
@@ -889,7 +904,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 			const bool blend_non_recursive_one_barrier = blend_non_recursive && blend_ad_alpha_masked;
 			if (blend_non_recursive_one_barrier)
 				m_conf.require_one_barrier |= true;
-			else if (g_gs_device->Features().texture_barrier)
+			else if (features.texture_barrier)
 				m_conf.require_full_barrier |= !blend_non_recursive;
 			else
 				m_conf.require_one_barrier |= !blend_non_recursive;
@@ -1294,6 +1309,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 	const GSVector2i& rtsize = ds ? ds->GetSize()  : rt->GetSize();
 	const GSVector2& rtscale = ds ? ds->GetScale() : rt->GetScale();
+	const GSDevice::FeatureSupport features(g_gs_device->Features());
 
 	const bool DATE = m_context->TEST.DATE && m_context->FRAME.PSM != PSM_PSMCT24;
 	bool DATE_PRIMID = false;
@@ -1324,10 +1340,13 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	// Upscaling hack to avoid various line/grid issues
 	MergeSprite(tex);
 
-	m_prim_overlap = PrimitiveOverlap();
+	if (!features.framebuffer_fetch)
+		m_prim_overlap = PrimitiveOverlap();
+	else
+		m_prim_overlap = PRIM_OVERLAP_UNKNOW;
 
 	// Detect framebuffer read that will need special handling
-	if (g_gs_device->Features().texture_barrier && (m_context->FRAME.Block() == m_context->TEX0.TBP0) && PRIM->TME && GSConfig.AccurateBlendingUnit != AccBlendLevel::Minimum)
+	if (features.texture_barrier && (m_context->FRAME.Block() == m_context->TEX0.TBP0) && PRIM->TME && GSConfig.AccurateBlendingUnit != AccBlendLevel::Minimum)
 	{
 		if ((m_context->FRAME.FBMSK == 0x00FFFFFF) && (m_vt.m_primclass == GS_TRIANGLE_CLASS))
 		{
@@ -1336,7 +1355,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			// Tri-Ace (Star Ocean 3/RadiataStories/VP2) uses a palette to handle the +1/-1
 			GL_DBG("Source and Target are the same! Let's sample the framebuffer");
 			m_conf.ps.tex_is_fb = 1;
-			m_conf.require_full_barrier = true;
+			m_conf.require_full_barrier = !features.framebuffer_fetch;
 		}
 		else if (m_prim_overlap != PRIM_OVERLAP_NO)
 		{
@@ -1353,11 +1372,16 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	{
 		// It is way too complex to emulate texture shuffle with DATE, so use accurate path.
 		// No overlap should be triggered on gl/vk only as they support DATE_BARRIER.
-		const bool no_overlap = (g_gs_device->Features().texture_barrier) && (m_prim_overlap == PRIM_OVERLAP_NO);
-		if (no_overlap || m_texture_shuffle)
+		if (features.framebuffer_fetch)
 		{
-			GL_PERF("DATE: Accurate with %s", no_overlap ? "no overlap" : "texture shuffle");
-			if (g_gs_device->Features().texture_barrier)
+			// Full DATE is "free" with framebuffer fetch. The barrier gets cleared below.
+			DATE_BARRIER = true;
+			m_conf.require_full_barrier = true;
+		}
+		else if ((features.texture_barrier && m_prim_overlap == PRIM_OVERLAP_NO) || m_texture_shuffle)
+		{
+			GL_PERF("DATE: Accurate with %s", (features.texture_barrier && m_prim_overlap == PRIM_OVERLAP_NO) ? "no overlap" : "texture shuffle");
+			if (features.texture_barrier)
 			{
 				m_conf.require_full_barrier = true;
 				DATE_BARRIER = true;
@@ -1445,6 +1469,13 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 		m_conf.blend = {}; // No blending please
 	}
 
+	if (features.framebuffer_fetch)
+	{
+		// barriers aren't needed with fbfetch
+		m_conf.require_one_barrier = false;
+		m_conf.require_full_barrier = false;
+	}
+
 	if (m_conf.ps.scanmsk & 2)
 		DATE_PRIMID = false; // to have discard in the shader work correctly
 
@@ -1508,7 +1539,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 	}
 	else if (DATE_one)
 	{
-		if (g_gs_device->Features().texture_barrier)
+		if (features.texture_barrier)
 		{
 			m_conf.require_one_barrier = true;
 			m_conf.ps.date = 5 + m_context->TEST.DATM;
@@ -1614,7 +1645,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			//
 			// Use an HLE shader to sample depth directly as the alpha channel
 			GL_INS("ICO sample depth as alpha");
-			m_conf.require_full_barrier = true;
+			m_conf.require_full_barrier = !features.framebuffer_fetch;
 			// Extract the depth as palette index
 			m_conf.ps.depth_fmt = 1;
 			m_conf.ps.channel = ChannelFetch_BLUE;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -1444,13 +1444,13 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			// Performance note: check alpha range with GetAlphaMinMax()
 			// Note: all my dump are already above 120fps, but it seems to reduce GPU load
 			// with big upscaling
-			if (m_context->TEST.DATM && GetAlphaMinMax().max < 128)
+			if (m_context->TEST.DATM && GetAlphaMinMax().max < 128 && features.stencil_buffer)
 			{
 				// Only first pixel (write 0) will pass (alpha is 1)
 				GL_PERF("DATE: Fast with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 				DATE_one = true;
 			}
-			else if (!m_context->TEST.DATM && GetAlphaMinMax().min >= 128)
+			else if (!m_context->TEST.DATM && GetAlphaMinMax().min >= 128 && features.stencil_buffer)
 			{
 				// Only first pixel (write 1) will pass (alpha is 0)
 				GL_PERF("DATE: Fast with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
@@ -1461,7 +1461,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 				// texture barrier will split the draw call into n draw call. It is very efficient for
 				// few primitive draws. Otherwise it sucks.
 				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
-				if (g_gs_device->Features().texture_barrier)
+				if (features.texture_barrier)
 				{
 					m_conf.require_full_barrier = true;
 					DATE_BARRIER = true;
@@ -1471,16 +1471,16 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 			{
 				// Note: Fast level (DATE_one) was removed as it's less accurate.
 				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
-				if (g_gs_device->Features().image_load_store)
+				if (features.image_load_store)
 				{
 					DATE_PRIMID = true;
 				}
-				else if (g_gs_device->Features().texture_barrier)
+				else if (features.texture_barrier)
 				{
 					m_conf.require_full_barrier = true;
 					DATE_BARRIER = true;
 				}
-				else
+				else if (features.stencil_buffer)
 				{
 					DATE_one = true;
 				}
@@ -1544,7 +1544,7 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 		m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking;
 	else if (DATE_BARRIER)
 		m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Full;
-	else
+	else if (features.stencil_buffer)
 		m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Stencil;
 
 	m_conf.datm = m_context->TEST.DATM;

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -521,7 +521,7 @@ void GSRendererNew::EmulateChannelShuffle(const GSTextureCache::Source* tex)
 	}
 }
 
-void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
+void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& blending_alpha_pass)
 {
 	// AA1: Don't enable blending on AA1, not yet implemented on hardware mode,
 	// it requires coverage sample so it's safer to turn it off instead.
@@ -536,6 +536,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 	if (FBMASK || PABE || !(PRIM->ABE || AA1))
 	{
 		m_conf.blend = {};
+		m_conf.ps.no_color1 = true;
 		return;
 	}
 
@@ -629,19 +630,9 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		&& (m_env.COLCLAMP.CLAMP)                                        // Let's add a colclamp check too, hw blend will clamp to 0-1.
 		&& !(m_conf.require_one_barrier || m_conf.require_full_barrier); // Also don't run if there are barriers present.
 
-	bool sw_blending = false;
-	if (!features.dual_source_blend)
-	{
-		const HWBlend unconverted_blend = g_gs_device->GetUnconvertedBlend(blend_index);
-		if (GSDevice::IsDualSourceBlendFactor(unconverted_blend.dst) ||
-			GSDevice::IsDualSourceBlendFactor(unconverted_blend.src))
-		{
-			sw_blending = true;
-		}
-	}
-
 	// Warning no break on purpose
 	// Note: the [[fallthrough]] attribute tell compilers not to complain about not having breaks.
+	bool sw_blending = false;
 	if (features.texture_barrier)
 	{
 		// Condition 1: Require full sw blend for full barrier.
@@ -737,6 +728,50 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:
 				break;
+		}
+	}
+
+	bool replace_dual_src = false;
+	if (!features.dual_source_blend)
+	{
+		const HWBlend unconverted_blend = g_gs_device->GetUnconvertedBlend(blend_index);
+		if (GSDevice::IsDualSourceBlendFactor(unconverted_blend.dst) ||
+			GSDevice::IsDualSourceBlendFactor(unconverted_blend.src))
+		{
+			// if we don't have an alpha channel, we don't need a second pass, just output the alpha blend
+			// in the single colour's alpha chnanel, and blend with it
+			if (!m_conf.colormask.wa)
+			{
+				GL_INS("Outputting alpha blend in col0 because of no alpha write");
+				m_conf.ps.no_ablend = true;
+				replace_dual_src = true;
+			}
+			else if (features.framebuffer_fetch || m_conf.require_one_barrier || m_conf.require_full_barrier)
+			{
+				// prefer single pass sw blend (if barrier) or framebuffer fetch over dual pass alpha when supported
+				sw_blending = true;
+				color_dest_blend = false;
+				accumulation_blend &= !features.framebuffer_fetch;
+				blend_mix = false;
+			}
+			else
+			{
+				// split the draw into two
+				blending_alpha_pass = true;
+				replace_dual_src = true;
+			}
+		}
+	}
+	else if (features.framebuffer_fetch)
+	{
+		// If we have fbfetch, use software blending when we need the fb value for anything else.
+		// This saves outputting the second color when it's not needed.
+		if (m_conf.require_one_barrier || m_conf.require_full_barrier)
+		{
+			sw_blending = true;
+			color_dest_blend = false;
+			accumulation_blend = false;
+			blend_mix = false;
 		}
 	}
 
@@ -849,7 +884,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		if (accumulation_blend)
 		{
 			// Keep HW blending to do the addition/subtraction
-			m_conf.blend = {blend_index, 0, false, true, false};
+			m_conf.blend = {blend_index, 0, false, true, false, replace_dual_src};
 			if (m_conf.ps.blend_a == 2)
 			{
 				// The blend unit does a reverse subtraction so it means
@@ -861,12 +896,15 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 			// Remove the addition/substraction from the SW blending
 			m_conf.ps.blend_d = 2;
 
+			// Dual source output not needed (accumulation blend replaces it with ONE).
+			m_conf.ps.no_color1 = true;
+
 			// Only Ad case will require one barrier
 			m_conf.require_one_barrier |= blend_ad_alpha_masked;
 		}
 		else if (blend_mix)
 		{
-			m_conf.blend = {blend_index, ALPHA.FIX, m_conf.ps.blend_c == 2, false, true};
+			m_conf.blend = {blend_index, ALPHA.FIX, m_conf.ps.blend_c == 2, false, true, replace_dual_src};
 			m_conf.ps.blend_mix = 1;
 
 			if (blend_mix1)
@@ -900,6 +938,8 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		{
 			// Disable HW blending
 			m_conf.blend = {};
+			replace_dual_src = false;
+			blending_alpha_pass = false;
 
 			const bool blend_non_recursive_one_barrier = blend_non_recursive && blend_ad_alpha_masked;
 			if (blend_non_recursive_one_barrier)
@@ -966,11 +1006,11 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER)
 		{
 			// 24 bits doesn't have an alpha channel so use 1.0f fix factor as equivalent
 			const u8 hacked_blend_index = blend_index + 3; // +3 <=> +1 on C
-			m_conf.blend = {hacked_blend_index, 128, true, false, false};
+			m_conf.blend = {hacked_blend_index, 128, true, false, false, replace_dual_src};
 		}
 		else
 		{
-			m_conf.blend = {blend_index, ALPHA.FIX, m_conf.ps.blend_c == 2, false, false};
+			m_conf.blend = {blend_index, ALPHA.FIX, m_conf.ps.blend_c == 2, false, false, replace_dual_src};
 		}
 	}
 
@@ -1460,13 +1500,15 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 
 	// Blend
 
+	bool blending_alpha_pass = false;
 	if (!IsOpaque() && rt)
 	{
-		EmulateBlending(DATE_PRIMID, DATE_BARRIER);
+		EmulateBlending(DATE_PRIMID, DATE_BARRIER, blending_alpha_pass);
 	}
 	else
 	{
 		m_conf.blend = {}; // No blending please
+		m_conf.ps.no_color1 = true;
 	}
 
 	if (features.framebuffer_fetch)
@@ -1475,6 +1517,10 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 		m_conf.require_one_barrier = false;
 		m_conf.require_full_barrier = false;
 	}
+
+	// Don't emit the second color output from the pixel shader when it's
+	// not going to be used (no or sw blending).
+	m_conf.ps.no_color1 |= (m_conf.blend.index == 0);
 
 	if (m_conf.ps.scanmsk & 2)
 		DATE_PRIMID = false; // to have discard in the shader work correctly
@@ -1753,6 +1799,46 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 		memcpy(&m_conf.depth,     &m_conf.alpha_second_pass.depth,     sizeof(m_conf.depth));
 		m_conf.cb_ps.FogColor_AREF.a = m_conf.alpha_second_pass.ps_aref;
 		m_conf.alpha_second_pass.enable = false;
+	}
+
+	if (blending_alpha_pass)
+	{
+		// ensure alpha blend output is disabled on both passes
+		m_conf.ps.no_ablend = true;
+
+		// if we're doing RGBA then Z alpha testing, we can't combine Z and A, and we need a third pass :(
+		if (ate_RGBA_then_Z)
+		{
+			// move second pass to third pass, since we want to write A first
+			std::memcpy(&m_conf.alpha_third_pass, &m_conf.alpha_second_pass, sizeof(m_conf.alpha_third_pass));
+			m_conf.alpha_third_pass.ps.no_ablend = true;
+			m_conf.alpha_second_pass.enable = false;
+		}
+
+		if (!m_conf.alpha_second_pass.enable)
+		{
+			m_conf.alpha_second_pass.enable = true;
+			memcpy(&m_conf.alpha_second_pass.ps, &m_conf.ps, sizeof(m_conf.ps));
+			memcpy(&m_conf.alpha_second_pass.colormask, &m_conf.colormask, sizeof(m_conf.colormask));
+			memcpy(&m_conf.alpha_second_pass.depth, &m_conf.depth, sizeof(m_conf.depth));
+
+			// disable alpha writes on first pass
+			m_conf.colormask.wa = false;
+		}
+
+		// only need to compute the alpha component (allow the shader to optimize better)
+		m_conf.alpha_second_pass.ps.no_ablend = false;
+		m_conf.alpha_second_pass.ps.only_alpha = true;
+		m_conf.alpha_second_pass.colormask.wr = m_conf.alpha_second_pass.colormask.wg = m_conf.alpha_second_pass.colormask.wb = false;
+		m_conf.alpha_second_pass.colormask.wa = true;
+
+		// if depth writes are on, we can optimize to an EQUAL test, otherwise we leave the tests alone
+		// since the alpha channel isn't blended, the last fragment wins and this'll be okay
+		if (m_conf.alpha_second_pass.depth.zwe)
+		{
+			m_conf.alpha_second_pass.depth.zwe = false;
+			m_conf.alpha_second_pass.depth.ztst = ZTST_GEQUAL;
+		}
 	}
 
 	if (m_conf.require_full_barrier && m_prim_overlap == PRIM_OVERLAP_NO)

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.h
@@ -28,7 +28,7 @@ private:
 	inline void SetupIA(const float& sx, const float& sy);
 	inline void EmulateTextureShuffleAndFbmask();
 	inline void EmulateChannelShuffle(const GSTextureCache::Source* tex);
-	inline void EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER);
+	inline void EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& blending_alpha_pass);
 	inline void EmulateTextureSampler(const GSTextureCache::Source* tex);
 	inline void EmulateZbuffer();
 	inline void EmulateATST(float& AREF, GSHWDrawConfig::PSSelector& ps, bool pass_2);

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -216,9 +216,10 @@ namespace GLLoader
 		mesa_driver = !vendor_id_nvidia && !vendor_id_amd;
 #endif
 
-		if (theApp.GetConfigI("override_geometry_shader") != -1)
+		if (GSConfig.OverrideGeometryShaders != -1)
 		{
-			found_geometry_shader = theApp.GetConfigB("override_geometry_shader");
+			found_geometry_shader = GSConfig.OverrideGeometryShaders != 0 &&
+									(GLAD_GL_VERSION_3_2 || GL_ARB_geometry_shader4 || GSConfig.OverrideGeometryShaders == 1);
 			GLExtension::Set("GL_ARB_geometry_shader4", found_geometry_shader);
 			fprintf(stderr, "Overriding geometry shaders detection\n");
 		}

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -154,6 +154,8 @@ namespace GLLoader
 	bool mesa_driver = false;
 	bool in_replayer = false;
 
+	bool has_dual_source_blend = false;
+	bool found_framebuffer_fetch = false;
 	bool found_geometry_shader = true; // we require GL3.3 so geometry must be supported by default
 	bool found_GL_ARB_clear_texture = false;
 	// DX11 GPU
@@ -208,6 +210,7 @@ namespace GLLoader
 			vendor_id_amd = true;
 		else if (strstr(vendor, "NVIDIA Corporation"))
 			vendor_id_nvidia = true;
+
 #ifdef _WIN32
 		else if (strstr(vendor, "Intel"))
 			vendor_id_intel = true;
@@ -287,6 +290,13 @@ namespace GLLoader
 			// Mandatory for the advance HW renderer effect. Unfortunately Mesa LLVMPIPE/SWR renderers doesn't support this extension.
 			// Rendering might be corrupted but it could be good enough for test/virtual machine.
 			optional("GL_ARB_texture_barrier");
+
+			found_framebuffer_fetch = GLAD_GL_EXT_shader_framebuffer_fetch || GLAD_GL_ARM_shader_framebuffer_fetch;
+			if (found_framebuffer_fetch && GSConfig.DisableFramebufferFetch)
+			{
+				Console.Warning("Framebuffer fetch was found but is disabled. This will reduce performance.");
+				found_framebuffer_fetch = false;
+			}
 		}
 
 		if (vendor_id_amd)

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -291,6 +291,7 @@ namespace GLLoader
 			// Rendering might be corrupted but it could be good enough for test/virtual machine.
 			optional("GL_ARB_texture_barrier");
 
+			has_dual_source_blend = GLAD_GL_VERSION_3_2 || GLAD_GL_ARB_blend_func_extended;
 			found_framebuffer_fetch = GLAD_GL_EXT_shader_framebuffer_fetch || GLAD_GL_ARM_shader_framebuffer_fetch;
 			if (found_framebuffer_fetch && GSConfig.DisableFramebufferFetch)
 			{

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.h
@@ -39,6 +39,8 @@ namespace GLLoader
 	extern bool in_replayer;
 
 	// GL
+	extern bool has_dual_source_blend;
+	extern bool found_framebuffer_fetch;
 	extern bool found_geometry_shader;
 	extern bool found_GL_ARB_gpu_shader5;
 	extern bool found_GL_ARB_shader_image_load_store;

--- a/pcsx2/GS/Renderers/OpenGL/GLState.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.cpp
@@ -30,7 +30,7 @@ namespace GLState
 	u16 f_sRGB;
 	u16 f_dRGB;
 	u8 bf;
-	u32 wrgba;
+	u8 wrgba;
 
 	bool depth;
 	GLenum depth_func;

--- a/pcsx2/GS/Renderers/OpenGL/GLState.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.h
@@ -32,7 +32,7 @@ namespace GLState
 	extern u16 f_sRGB;
 	extern u16 f_dRGB;
 	extern u8 bf;
-	extern u32 wrgba;
+	extern u8 wrgba;
 
 	extern bool depth;
 	extern GLenum depth_func;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -225,6 +225,7 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 	m_features.prefer_new_textures = false;
 	m_features.framebuffer_fetch = GLLoader::found_framebuffer_fetch;
 	m_features.dual_source_blend = GLLoader::has_dual_source_blend && !GSConfig.DisableDualSourceBlend;
+	m_features.stencil_buffer = true;
 
 	GLint point_range[2] = {};
 	GLint line_range[2] = {};

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -217,7 +217,7 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 	m_features.broken_point_sampler = GLLoader::vendor_id_amd;
 	m_features.geometry_shader = GLLoader::found_geometry_shader;
 	m_features.image_load_store = GLLoader::found_GL_ARB_shader_image_load_store && GLLoader::found_GL_ARB_clear_texture;
-	m_features.texture_barrier = true;
+	m_features.texture_barrier = GSConfig.OverrideTextureBarriers != 0;
 	m_features.provoking_vertex_last = true;
 	m_features.prefer_new_textures = false;
 	m_features.dxt_textures = GL_EXT_texture_compression_s3tc;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1122,8 +1122,9 @@ std::string GSDeviceOGL::GetPSSource(const PSSelector& sel)
 		+ format("#define PS_PABE %d\n", sel.pabe)
 		+ format("#define PS_SCANMSK %d\n", sel.scanmsk)
 		+ format("#define PS_SCALE_FACTOR %d\n", GSConfig.UpscaleMultiplier)
-		+ format("#define PS_NO_ABLEND %d\n", sel.no_ablend)
+		+ format("#define PS_NO_COLOR %d\n", sel.no_color)
 		+ format("#define PS_NO_COLOR1 %d\n", sel.no_color1)
+		+ format("#define PS_NO_ABLEND %d\n", sel.no_ablend)
 		+ format("#define PS_ONLY_ALPHA %d\n", sel.only_alpha)
 	;
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -212,7 +212,7 @@ public:
 
 private:
 	// Increment this constant whenever shaders change, to invalidate user's program binary cache.
-	static constexpr u32 SHADER_VERSION = 1;
+	static constexpr u32 SHADER_VERSION = 2;
 
 	static FILE* m_debug_gl_file;
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -310,8 +310,6 @@ private:
 	void OMAttachDs(GSTextureOGL* ds = NULL);
 	void OMSetFBO(GLuint fbo);
 
-	u16 ConvertBlendEnum(u16 generic) final;
-
 	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
 
 public:
@@ -355,7 +353,7 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader = ShaderConvert::COPY, bool linear = true) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, bool linear = true);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) final;
-	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, int bs, OMColorMaskSelector cms, bool linear = true);
+	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, bool alpha_blend, OMColorMaskSelector cms, bool linear = true);
 
 	void RenderHW(GSHWDrawConfig& config) final;
 	void SendHWDraw(const GSHWDrawConfig& config);
@@ -372,7 +370,7 @@ public:
 	void ClearSamplerCache() final;
 
 	void OMSetDepthStencilState(GSDepthStencilOGL* dss);
-	void OMSetBlendState(u8 blend_index = 0, u8 blend_factor = 0, bool is_blend_constant = false, bool accumulation_blend = false, bool blend_mix = false, bool replace_dual_src = false);
+	void OMSetBlendState(bool enable = false, GLenum src_factor = GL_ONE, GLenum dst_factor = GL_ZERO, GLenum op = GL_FUNC_ADD, bool is_constant = false, u8 constant = 0);
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL);
 	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector());
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -132,22 +132,20 @@ public:
 		{
 			struct
 			{
-				u32 int_fst : 1;
-				u32 iip : 1;
-				u32 point_size : 1;
-				u32 _free : 29;
+				u8 int_fst : 1;
+				u8 iip : 1;
+				u8 point_size : 1;
+				u8 _free : 5;
 			};
 
-			u32 key;
+			u8 key;
 		};
-
-		operator u32() const { return key; }
 
 		VSSelector()
 			: key(0)
 		{
 		}
-		VSSelector(u32 k)
+		VSSelector(u8 k)
 			: key(k)
 		{
 		}
@@ -159,15 +157,15 @@ public:
 		{
 			struct
 			{
-				u32 sprite : 1;
-				u32 point  : 1;
-				u32 line   : 1;
-				u32 iip    : 1;
+				u8 sprite : 1;
+				u8 point  : 1;
+				u8 line   : 1;
+				u8 iip    : 1;
 
-				u32 _free : 28;
+				u8 _free : 4;
 			};
 
-			u32 key;
+			u8 key;
 		};
 
 		operator u32() const { return key; }
@@ -176,7 +174,7 @@ public:
 			: key(0)
 		{
 		}
-		GSSelector(u32 k)
+		GSSelector(u8 k)
 			: key(k)
 		{
 		}
@@ -187,22 +185,24 @@ public:
 	using OMDepthStencilSelector = GSHWDrawConfig::DepthStencilSelector;
 	using OMColorMaskSelector = GSHWDrawConfig::ColorMaskSelector;
 
-	struct ProgramSelector
+	struct alignas(16) ProgramSelector
 	{
+		PSSelector ps;
 		VSSelector vs;
 		GSSelector gs;
-		PSSelector ps;
+		u16 pad;
 
-		__fi bool operator==(const ProgramSelector& p) const { return vs.key == p.vs.key && gs.key == p.gs.key && ps.key == p.ps.key; }
-		__fi bool operator!=(const ProgramSelector& p) const { return vs.key != p.vs.key || gs.key != p.gs.key || ps.key != p.ps.key; }
+		__fi bool operator==(const ProgramSelector& p) const { return (std::memcmp(this, &p, sizeof(*this)) == 0); }
+		__fi bool operator!=(const ProgramSelector& p) const { return (std::memcmp(this, &p, sizeof(*this)) != 0); }
 	};
+	static_assert(sizeof(ProgramSelector) == 16, "Program selector is 16 bytes");
 
 	struct ProgramSelectorHash
 	{
 		__fi std::size_t operator()(const ProgramSelector& p) const noexcept
 		{
 			std::size_t h = 0;
-			HashCombine(h, p.vs.key, p.gs.key, p.ps.key);
+			HashCombine(h, p.vs.key, p.gs.key, p.ps.key_hi, p.ps.key_lo);
 			return h;
 		}
 	};
@@ -212,7 +212,7 @@ public:
 
 private:
 	// Increment this constant whenever shaders change, to invalidate user's program binary cache.
-	static constexpr u32 SHADER_VERSION = 2;
+	static constexpr u32 SHADER_VERSION = 3;
 
 	static FILE* m_debug_gl_file;
 
@@ -372,7 +372,7 @@ public:
 	void ClearSamplerCache() final;
 
 	void OMSetDepthStencilState(GSDepthStencilOGL* dss);
-	void OMSetBlendState(u8 blend_index = 0, u8 blend_factor = 0, bool is_blend_constant = false, bool accumulation_blend = false, bool blend_mix = false);
+	void OMSetBlendState(u8 blend_index = 0, u8 blend_factor = 0, bool is_blend_constant = false, bool accumulation_blend = false, bool blend_mix = false, bool replace_dual_src = false);
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL);
 	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector());
 
@@ -384,7 +384,7 @@ public:
 	std::string GenGlslHeader(const std::string_view& entry, GLenum type, const std::string_view& macro);
 	std::string GetVSSource(VSSelector sel);
 	std::string GetGSSource(GSSelector sel);
-	std::string GetPSSource(PSSelector sel);
+	std::string GetPSSource(const PSSelector& sel);
 	GLuint CreateSampler(PSSamplerSelector sel);
 	GSDepthStencilOGL* CreateDepthStencil(OMDepthStencilSelector dssel);
 

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -234,11 +234,23 @@ GSTextureOGL::GSTextureOGL(Type type, int width, int height, int levels, Format 
 
 		// Depth buffer
 		case Format::DepthStencil:
-			gl_fmt          = GL_DEPTH32F_STENCIL8;
-			m_int_format    = GL_DEPTH_STENCIL;
-			m_int_type      = GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
-			m_int_shift     = 3; // 4 bytes for depth + 4 bytes for stencil by texels
-			break;
+		{
+			if (!GLLoader::found_framebuffer_fetch)
+			{
+				gl_fmt = GL_DEPTH32F_STENCIL8;
+				m_int_format = GL_DEPTH_STENCIL;
+				m_int_type = GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
+				m_int_shift = 3; // 4 bytes for depth + 4 bytes for stencil by texels
+			}
+			else
+			{
+				gl_fmt = GL_DEPTH_COMPONENT32F;
+				m_int_format = GL_DEPTH_COMPONENT;
+				m_int_type = GL_FLOAT;
+				m_int_shift = 2;
+			}
+		}
+		break;
 
 		case Format::BC1:
 			gl_fmt          = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
@@ -622,7 +634,7 @@ bool GSTextureOGL::Save(const std::string& fn)
 	GSPng::Format fmt = GSPng::RGB_PNG;
 #endif
 
-	if (IsDss())
+	if (IsDepth())
 	{
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo_read);
 

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
@@ -71,7 +71,16 @@ public:
 	void Swap(GSTexture* tex) final;
 
 	GSMap Read(const GSVector4i& r, AlignedBuffer<u8, 32>& buffer);
-	bool IsDss() { return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil); }
+	bool IsDss() { return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil) && !GLLoader::found_framebuffer_fetch; }
+	bool IsDepth() { return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil); }
+	bool IsIntegerFormat() const
+	{
+		return (m_int_format == GL_RED_INTEGER || m_int_format == GL_RGBA_INTEGER);
+	}
+	bool IsUnsignedFormat() const
+	{
+		return (m_int_type == GL_UNSIGNED_BYTE || m_int_type == GL_UNSIGNED_SHORT || m_int_type == GL_UNSIGNED_INT);
+	}
 
 	u32 GetID() final { return m_texture_id; }
 	bool HasBeenCleaned() { return m_clean; }

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -243,6 +243,8 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.image_load_store = features.fragmentStoresAndAtomics && m_features.texture_barrier;
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = g_vulkan_context->GetOptionalExtensions().vk_ext_provoking_vertex;
+	m_features.framebuffer_fetch = false;
+	m_features.dual_source_blend = features.dualSrcBlend;
 
 	if (!features.dualSrcBlend)
 		Console.Warning("Vulkan driver is missing dual-source blending. This will have an impact on performance.");

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1816,8 +1816,9 @@ VkShaderModule GSDeviceVK::GetTFXFragmentShader(const GSHWDrawConfig::PSSelector
 	AddMacro(ss, "PS_SCANMSK", sel.scanmsk);
 	AddMacro(ss, "PS_SCALE_FACTOR", GSConfig.UpscaleMultiplier);
 	AddMacro(ss, "PS_TEX_IS_FB", sel.tex_is_fb);
-	AddMacro(ss, "PS_NO_ABLEND", sel.no_ablend);
+	AddMacro(ss, "PS_NO_COLOR", sel.no_color);
 	AddMacro(ss, "PS_NO_COLOR1", sel.no_color1);
+	AddMacro(ss, "PS_NO_ABLEND", sel.no_ablend);
 	AddMacro(ss, "PS_ONLY_ALPHA", sel.only_alpha);
 	ss << m_tfx_source;
 
@@ -2653,10 +2654,12 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	init_pipe.dss.zwe = false;
 	init_pipe.cms.wrgba = 0;
 	init_pipe.bs = {};
-	init_pipe.ps.blend_a = init_pipe.ps.blend_b = init_pipe.ps.blend_c = init_pipe.ps.blend_d = false;
 	init_pipe.feedback_loop = false;
 	init_pipe.rt = true;
+	init_pipe.ps.blend_a = init_pipe.ps.blend_b = init_pipe.ps.blend_c = init_pipe.ps.blend_d = false;
 	init_pipe.ps.date += 10;
+	init_pipe.ps.no_color = false;
+	init_pipe.ps.no_color1 = true;
 	if (BindDrawPipeline(init_pipe))
 		DrawIndexedPrimitive();
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -27,14 +27,9 @@
 class GSDeviceVK final : public GSDevice
 {
 public:
-	struct PipelineSelector
+	struct alignas(8) PipelineSelector
 	{
-		GSHWDrawConfig::VSSelector vs;
-		GSHWDrawConfig::GSSelector gs;
 		GSHWDrawConfig::PSSelector ps;
-		GSHWDrawConfig::DepthStencilSelector dss;
-		GSHWDrawConfig::BlendState bs;
-		GSHWDrawConfig::ColorMaskSelector cms;
 
 		union
 		{
@@ -50,29 +45,25 @@ public:
 			u32 key;
 		};
 
-		__fi bool operator==(const PipelineSelector& p) const
-		{
-			return vs.key == p.vs.key && gs.key == p.gs.key && ps.key == p.ps.key && dss.key == p.dss.key &&
-				   bs.key == p.bs.key && cms.key == p.cms.key && key == p.key;
-		}
-		__fi bool operator!=(const PipelineSelector& p) const
-		{
-			return vs.key != p.vs.key || gs.key != p.gs.key || ps.key != p.ps.key || dss.key != p.dss.key ||
-				   bs.key != p.bs.key || cms.key != p.cms.key || key != p.key;
-		}
+		GSHWDrawConfig::VSSelector vs;
+		GSHWDrawConfig::GSSelector gs;
+		GSHWDrawConfig::DepthStencilSelector dss;
+		GSHWDrawConfig::ColorMaskSelector cms;
+		GSHWDrawConfig::BlendState bs;
 
-		PipelineSelector()
-			: key(0)
-		{
-		}
+		__fi bool operator==(const PipelineSelector& p) const { return (memcmp(this, &p, sizeof(p)) == 0); }
+		__fi bool operator!=(const PipelineSelector& p) const { return (memcmp(this, &p, sizeof(p)) != 0); }
+
+		__fi PipelineSelector() { memset(this, 0, sizeof(*this)); }
 	};
+	static_assert(sizeof(PipelineSelector) == 24, "Pipeline selector is 24 bytes");
 
 	struct PipelineSelectorHash
 	{
 		std::size_t operator()(const PipelineSelector& e) const noexcept
 		{
 			std::size_t hash = 0;
-			HashCombine(hash, e.vs.key, e.gs.key, e.ps.key, e.dss.key, e.cms.key, e.bs.key, e.key);
+			HashCombine(hash, e.vs.key, e.gs.key, e.ps.key_hi, e.ps.key_lo, e.dss.key, e.cms.key, e.bs.key, e.key);
 			return hash;
 		}
 	};
@@ -136,7 +127,7 @@ private:
 
 	std::unordered_map<u32, VkShaderModule> m_tfx_vertex_shaders;
 	std::unordered_map<u32, VkShaderModule> m_tfx_geometry_shaders;
-	std::unordered_map<u64, VkShaderModule> m_tfx_fragment_shaders;
+	std::unordered_map<GSHWDrawConfig::PSSelector, VkShaderModule, GSHWDrawConfig::PSSelectorHash> m_tfx_fragment_shaders;
 	std::unordered_map<PipelineSelector, VkPipeline, PipelineSelectorHash> m_tfx_pipelines;
 
 	VkRenderPass m_utility_color_render_pass_load = VK_NULL_HANDLE;
@@ -168,7 +159,7 @@ private:
 
 	VkShaderModule GetTFXVertexShader(GSHWDrawConfig::VSSelector sel);
 	VkShaderModule GetTFXGeometryShader(GSHWDrawConfig::GSSelector sel);
-	VkShaderModule GetTFXFragmentShader(GSHWDrawConfig::PSSelector sel);
+	VkShaderModule GetTFXFragmentShader(const GSHWDrawConfig::PSSelector& sel);
 	VkPipeline CreateTFXPipeline(const PipelineSelector& p);
 	VkPipeline GetTFXPipeline(const PipelineSelector& p);
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -146,6 +146,8 @@ private:
 
 	std::string m_tfx_source;
 
+	VkFormat LookupNativeFormat(GSTexture::Format format) const;
+
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) override;
 
 	void DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE,

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -152,7 +152,8 @@ private:
 		const GSRegEXTBUF& EXTBUF, const GSVector4& c) final;
 	void DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset = 0) final;
 
-	u16 ConvertBlendEnum(u16 generic) final;
+	static VkBlendFactor ConvertBlendFactor(u8 generic);
+	static VkBlendOp ConvertBlendOp(u8 generic);
 
 	VkSampler GetSampler(GSHWDrawConfig::SamplerSelector ss);
 	void ClearSamplerCache() final;

--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
@@ -59,7 +59,7 @@ GSTextureVK::~GSTextureVK()
 	}
 }
 
-std::unique_ptr<GSTextureVK> GSTextureVK::Create(Type type, u32 width, u32 height, u32 levels, Format format)
+std::unique_ptr<GSTextureVK> GSTextureVK::Create(Type type, u32 width, u32 height, u32 levels, Format format, VkFormat vk_format)
 {
 	switch (type)
 	{
@@ -77,7 +77,7 @@ std::unique_ptr<GSTextureVK> GSTextureVK::Create(Type type, u32 width, u32 heigh
 			}
 
 			Vulkan::Texture texture;
-			if (!texture.Create(width, height, levels, 1, LookupNativeFormat(format), VK_SAMPLE_COUNT_1_BIT,
+			if (!texture.Create(width, height, levels, 1, vk_format, VK_SAMPLE_COUNT_1_BIT,
 					VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, usage, swizzle))
 			{
 				return {};
@@ -93,7 +93,7 @@ std::unique_ptr<GSTextureVK> GSTextureVK::Create(Type type, u32 width, u32 heigh
 			pxAssert(levels == 1);
 
 			Vulkan::Texture texture;
-			if (!texture.Create(width, height, levels, 1, LookupNativeFormat(format), VK_SAMPLE_COUNT_1_BIT,
+			if (!texture.Create(width, height, levels, 1, vk_format, VK_SAMPLE_COUNT_1_BIT,
 					VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
 					VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 						VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
@@ -112,7 +112,7 @@ std::unique_ptr<GSTextureVK> GSTextureVK::Create(Type type, u32 width, u32 heigh
 			pxAssert(levels == 1);
 
 			Vulkan::Texture texture;
-			if (!texture.Create(width, height, levels, 1, LookupNativeFormat(format), VK_SAMPLE_COUNT_1_BIT,
+			if (!texture.Create(width, height, levels, 1, vk_format, VK_SAMPLE_COUNT_1_BIT,
 					VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
 					VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 						VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))
@@ -128,27 +128,6 @@ std::unique_ptr<GSTextureVK> GSTextureVK::Create(Type type, u32 width, u32 heigh
 		default:
 			return {};
 	}
-}
-
-VkFormat GSTextureVK::LookupNativeFormat(Format format)
-{
-	static constexpr std::array<VkFormat, static_cast<int>(GSTexture::Format::BC7) + 1> s_format_mapping = {{
-		VK_FORMAT_UNDEFINED, // Invalid
-		VK_FORMAT_R8G8B8A8_UNORM, // Color
-		VK_FORMAT_R32G32B32A32_SFLOAT, // FloatColor
-		VK_FORMAT_D32_SFLOAT_S8_UINT, // DepthStencil
-		VK_FORMAT_R8_UNORM, // UNorm8
-		VK_FORMAT_R16_UINT, // UInt16
-		VK_FORMAT_R32_UINT, // UInt32
-		VK_FORMAT_R32_SFLOAT, // Int32
-		VK_FORMAT_BC1_RGBA_UNORM_BLOCK, // BC1
-		VK_FORMAT_BC2_UNORM_BLOCK, // BC2
-		VK_FORMAT_BC3_UNORM_BLOCK, // BC3
-		VK_FORMAT_BC7_UNORM_BLOCK, // BC7
-	}};
-
-
-	return s_format_mapping[static_cast<int>(format)];
 }
 
 void* GSTextureVK::GetNativeHandle() const { return const_cast<Vulkan::Texture*>(&m_texture); }

--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
@@ -33,8 +33,7 @@ public:
 	GSTextureVK(Type type, Format format, Vulkan::Texture texture);
 	~GSTextureVK() override;
 
-	static std::unique_ptr<GSTextureVK> Create(Type type, u32 width, u32 height, u32 levels, Format format);
-	static VkFormat LookupNativeFormat(Format format);
+	static std::unique_ptr<GSTextureVK> Create(Type type, u32 width, u32 height, u32 levels, Format format, VkFormat vk_format);
 
 	__fi Vulkan::Texture& GetTexture() { return m_texture; }
 	__fi VkFormat GetNativeFormat() const { return m_texture.GetFormat(); }

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -541,11 +541,12 @@ DebugTab::DebugTab(wxWindow* parent)
 	{
 		PaddedBoxSizer<wxStaticBoxSizer> debug_box(wxVERTICAL, this, "Debug");
 		auto* debug_check_box = new wxWrapSizer(wxHORIZONTAL);
-		m_ui.addCheckBox(debug_check_box, "Use Blit Swap Chain",       "UseBlitSwapChain");
-		m_ui.addCheckBox(debug_check_box, "Disable Shader Cache",      "disable_shader_cache");
-		m_ui.addCheckBox(debug_check_box, "Disable Framebuffer Fetch", "DisableFramebufferFetch");
-		m_ui.addCheckBox(debug_check_box, "Use Debug Device",          "UseDebugDevice");
-		m_ui.addCheckBox(debug_check_box, "Dump GS data",              "dump");
+		m_ui.addCheckBox(debug_check_box, "Use Blit Swap Chain",          "UseBlitSwapChain");
+		m_ui.addCheckBox(debug_check_box, "Disable Shader Cache",         "disable_shader_cache");
+		m_ui.addCheckBox(debug_check_box, "Disable Framebuffer Fetch",    "DisableFramebufferFetch");
+		m_ui.addCheckBox(debug_check_box, "Disable Dual-Source Blending", "DisableDualSourceBlend");
+		m_ui.addCheckBox(debug_check_box, "Use Debug Device",             "UseDebugDevice");
+		m_ui.addCheckBox(debug_check_box, "Dump GS data",                 "dump");
 
 		auto* debug_save_check_box = new wxWrapSizer(wxHORIZONTAL);
 		m_ui.addCheckBox(debug_save_check_box, "Save RT",      "save");

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -541,10 +541,11 @@ DebugTab::DebugTab(wxWindow* parent)
 	{
 		PaddedBoxSizer<wxStaticBoxSizer> debug_box(wxVERTICAL, this, "Debug");
 		auto* debug_check_box = new wxWrapSizer(wxHORIZONTAL);
-		m_ui.addCheckBox(debug_check_box, "Use Blit Swap Chain",  "UseBlitSwapChain");
-		m_ui.addCheckBox(debug_check_box, "Disable Shader Cache", "disable_shader_cache");
-		m_ui.addCheckBox(debug_check_box, "Use Debug Device",     "UseDebugDevice");
-		m_ui.addCheckBox(debug_check_box, "Dump GS data",         "dump");
+		m_ui.addCheckBox(debug_check_box, "Use Blit Swap Chain",       "UseBlitSwapChain");
+		m_ui.addCheckBox(debug_check_box, "Disable Shader Cache",      "disable_shader_cache");
+		m_ui.addCheckBox(debug_check_box, "Disable Framebuffer Fetch", "DisableFramebufferFetch");
+		m_ui.addCheckBox(debug_check_box, "Use Debug Device",          "UseDebugDevice");
+		m_ui.addCheckBox(debug_check_box, "Dump GS data",              "dump");
 
 		auto* debug_save_check_box = new wxWrapSizer(wxHORIZONTAL);
 		m_ui.addCheckBox(debug_save_check_box, "Save RT",      "save");

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -566,9 +566,10 @@ DebugTab::DebugTab(wxWindow* parent)
 		tab_box->Add(debug_box.outer, wxSizerFlags().Expand());
 	}
 
-	PaddedBoxSizer<wxStaticBoxSizer> ogl_box(wxVERTICAL, this, "OpenGL");
+	PaddedBoxSizer<wxStaticBoxSizer> ogl_box(wxVERTICAL, this, "Overrides");
 	auto* ogl_grid = new wxFlexGridSizer(2, space, space);
-	m_ui.addComboBoxAndLabel(ogl_grid, "Geometry Shader:",  "override_geometry_shader",                &theApp.m_gs_generic_list, IDC_GEOMETRY_SHADER_OVERRIDE, ogl_hw_prereq);
+	m_ui.addComboBoxAndLabel(ogl_grid, "Texture Barriers:", "OverrideTextureBarriers",                 &theApp.m_gs_generic_list, -1);
+	m_ui.addComboBoxAndLabel(ogl_grid, "Geometry Shader:",  "OverrideGeometryShaders",                 &theApp.m_gs_generic_list, IDC_GEOMETRY_SHADER_OVERRIDE);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Image Load Store:", "override_GL_ARB_shader_image_load_store", &theApp.m_gs_generic_list, IDC_IMAGE_LOAD_STORE,         ogl_hw_prereq);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Sparse Texture:",   "override_GL_ARB_sparse_texture",          &theApp.m_gs_generic_list, IDC_SPARSE_TEXTURE,           ogl_hw_prereq);
 	ogl_box->Add(ogl_grid);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -396,6 +396,8 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_TCOffsetX) &&
 		OpEqu(UserHacks_TCOffsetY) &&
 		OpEqu(UserHacks_TriFilter) &&
+		OpEqu(OverrideTextureBarriers) &&
+		OpEqu(OverrideGeometryShaders) &&
 
 		OpEqu(ShadeBoost_Brightness) &&
 		OpEqu(ShadeBoost_Contrast) &&
@@ -419,7 +421,9 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(UseDebugDevice) &&
 		   OpEqu(UseBlitSwapChain) &&
 		   OpEqu(DisableShaderCache) &&
-		   OpEqu(ThreadedPresentation);
+		   OpEqu(ThreadedPresentation) &&
+		   OpEqu(OverrideTextureBarriers) &&
+		   OpEqu(OverrideGeometryShaders);
 }
 
 void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
@@ -568,6 +572,8 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingIntEx(UserHacks_TCOffsetX, "UserHacks_TCOffsetX");
 	GSSettingIntEx(UserHacks_TCOffsetY, "UserHacks_TCOffsetY");
 	GSSettingIntEnumEx(UserHacks_TriFilter, "UserHacks_TriFilter");
+	GSSettingIntEx(OverrideTextureBarriers, "OverrideTextureBarriers");
+	GSSettingIntEx(OverrideGeometryShaders, "OverrideGeometryShaders");
 
 	GSSettingInt(ShadeBoost_Brightness);
 	GSSettingInt(ShadeBoost_Contrast);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -422,6 +422,7 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(UseDebugDevice) &&
 		   OpEqu(UseBlitSwapChain) &&
 		   OpEqu(DisableShaderCache) &&
+		   OpEqu(DisableDualSourceBlend) &&
 		   OpEqu(DisableFramebufferFetch) &&
 		   OpEqu(ThreadedPresentation) &&
 		   OpEqu(OverrideTextureBarriers) &&
@@ -503,6 +504,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(UseDebugDevice);
 	GSSettingBool(UseBlitSwapChain);
 	GSSettingBoolEx(DisableShaderCache, "disable_shader_cache");
+	GSSettingBool(DisableDualSourceBlend);
 	GSSettingBool(DisableFramebufferFetch);
 	GSSettingBool(ThreadedPresentation);
 	GSSettingBool(OsdShowMessages);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -295,6 +295,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	UseDebugDevice = false;
 	UseBlitSwapChain = false;
 	DisableShaderCache = false;
+	DisableFramebufferFetch = false;
 	ThreadedPresentation = false;
 	OsdShowMessages = true;
 	OsdShowSpeed = false;
@@ -421,6 +422,7 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(UseDebugDevice) &&
 		   OpEqu(UseBlitSwapChain) &&
 		   OpEqu(DisableShaderCache) &&
+		   OpEqu(DisableFramebufferFetch) &&
 		   OpEqu(ThreadedPresentation) &&
 		   OpEqu(OverrideTextureBarriers) &&
 		   OpEqu(OverrideGeometryShaders);
@@ -501,6 +503,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(UseDebugDevice);
 	GSSettingBool(UseBlitSwapChain);
 	GSSettingBoolEx(DisableShaderCache, "disable_shader_cache");
+	GSSettingBool(DisableFramebufferFetch);
 	GSSettingBool(ThreadedPresentation);
 	GSSettingBool(OsdShowMessages);
 	GSSettingBool(OsdShowSpeed);


### PR DESCRIPTION
### Description of Changes

This PR changes the hardware renderers to use GL_EXT_shader_framebuffer_fetch and VK_ARM_rasterization_order_attachment_access if available. It can result in a massive performance improvement on these drivers.

For now, this only means Intel with OpenGL on Linux. But when/if Mesa supports the Vulkan extension, we'll be ready. It's also potentially applicable for Metal.

Also adds some unrelated changes, like supporting drivers without dual-source blending (probably not many or any left), and Vulkan drivers without D32S8. The latter can be taken advantage of when we use fbfetch, since the stencil buffer isn't needed because DATE goes through the faster fbfetch path instead.

Some quick performance testing at 2x resolution with High blending on a 7700HQ / HD 630 (KabyLake GT2):

 - NFS Carbon Main Menu: fbfetch off **20fps** | fbfetch on **51fps**
 - Monster Hunter: fbfetch off **59fps** | fbfetch on: **265fps**
 - Sly 2: fbfetch off **8fps** | fbfetch on: **78fps**

### Rationale behind Changes

Brr. Too bad more drivers don't support it.

### Suggested Testing Steps

As it touches a fair bit of code, probably need a decent amount of testing, both with and without fbfetch, to make sure there's no performance regressions from the additional paths.
