### PR TITLE
GS: HLE double clear with colour for Burnout games (Bloom) WIP

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -261,21 +261,21 @@ const CRC::Game CRC::m_games[] =
 	{0xBC8B3F50, TombRaiderLegend, US, 0},
 	{0x365172A0, TombRaiderLegend, JP, 0},
 	{0x05177ECE, TombRaiderLegend, EU, 0},
-	{0xBEBF8793, BurnoutGames, US, 0}, // BurnoutTakedown
-	{0xBB2E845F, BurnoutGames, JP, 0}, // BurnoutTakedown
-	{0x5F060991, BurnoutGames, KO, 0}, // BurnoutTakedown
-	{0x75BECC18, BurnoutGames, EU, 0}, // BurnoutTakedown
-	{0xCE49B0DE, BurnoutGames, EU, 0}, // BurnoutTakedown
-	{0x381EE9EF, BurnoutGames, EU, 0}, // BurnoutTakedown E3 Demo
-	{0xD224D348, BurnoutGames, US, 0}, // BurnoutRevenge
-	{0x878E7A1D, BurnoutGames, JP, 0}, // BurnoutRevenge
-	{0xEEA60511, BurnoutGames, KO, 0}, // BurnoutRevenge
-	{0x7E83CC5B, BurnoutGames, EU, 0}, // BurnoutRevenge
-	{0x2CAC3DBC, BurnoutGames, EU, 0}, // BurnoutRevenge
-	{0x8C9576A1, BurnoutGames, US, 0}, // BurnoutDominator
-	{0xDDF76A98, BurnoutGames, JP, 0}, // BurnoutDominator
-	{0x8C9576B4, BurnoutGames, EU, 0}, // BurnoutDominator
-	{0x8C9C76B4, BurnoutGames, EU, 0}, // BurnoutDominator
+	{0xBEBF8793, BurnoutGames, US, TextureInsideRt }, // BurnoutTakedown
+	{0xBB2E845F, BurnoutGames, JP, TextureInsideRt }, // BurnoutTakedown
+	{0x5F060991, BurnoutGames, KO, TextureInsideRt }, // BurnoutTakedown
+	{0x75BECC18, BurnoutGames, EU, TextureInsideRt }, // BurnoutTakedown
+	{0xCE49B0DE, BurnoutGames, EU, TextureInsideRt }, // BurnoutTakedown
+	{0x381EE9EF, BurnoutGames, EU, TextureInsideRt }, // BurnoutTakedown E3 Demo
+	{0xD224D348, BurnoutGames, US, TextureInsideRt }, // BurnoutRevenge
+	{0x878E7A1D, BurnoutGames, JP, TextureInsideRt }, // BurnoutRevenge
+	{0xEEA60511, BurnoutGames, KO, TextureInsideRt }, // BurnoutRevenge
+	{0x7E83CC5B, BurnoutGames, EU, TextureInsideRt }, // BurnoutRevenge
+	{0x2CAC3DBC, BurnoutGames, EU, TextureInsideRt }, // BurnoutRevenge
+	{0x8C9576A1, BurnoutGames, US, TextureInsideRt }, // BurnoutDominator
+	{0xDDF76A98, BurnoutGames, JP, TextureInsideRt }, // BurnoutDominator
+	{0x8C9576B4, BurnoutGames, EU, TextureInsideRt }, // BurnoutDominator
+	{0x8C9C76B4, BurnoutGames, EU, TextureInsideRt }, // BurnoutDominator
 	{0x4A0E5B3A, MidnightClub3, US, 0}, // dub
 	{0xEBE1972D, MidnightClub3, EU, 0}, // dub
 	{0x60A42FF5, MidnightClub3, US, 0}, // remix

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -410,22 +410,6 @@ bool GSC_TombRaiderUnderWorld(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_BurnoutGames(const GSFrameInfo& fi, int& skip)
-{
-	if (skip == 0)
-	{
-		if (fi.TME && (fi.FBP == 0x01dc0 || fi.FBP == 0x01c00 || fi.FBP == 0x01f00 || fi.FBP == 0x01d40 || fi.FBP == 0x02200 || fi.FBP == 0x02000) && fi.FPSM == fi.TPSM && (fi.TBP0 == 0x01dc0 || fi.TBP0 == 0x01c00 || fi.TBP0 == 0x01f00 || fi.TBP0 == 0x01d40 || fi.TBP0 == 0x02200 || fi.TBP0 == 0x02000) && fi.TPSM == PSM_PSMCT32)
-		{
-			// 0x01dc0 01c00(MP) ntsc, 0x01f00 0x01d40(MP) ntsc progressive, 0x02200(MP) pal.
-			// Yellow stripes.
-			// Multiplayer tested only on Takedown.
-			skip = s_autoflush ? 2 : 4;
-		}
-	}
-
-	return true;
-}
-
 bool GSC_MidnightClub3(const GSFrameInfo& fi, int& skip)
 {
 	if (skip == 0)
@@ -981,9 +965,6 @@ void GSState::SetupCrcHack()
 		lut[CRC::SkyGunner] = GSC_SkyGunner; // Maybe not a channel effect
 		lut[CRC::Spartan] = GSC_Spartan;
 		lut[CRC::SteambotChronicles] = GSC_SteambotChronicles;
-
-		// Depth Issue
-		lut[CRC::BurnoutGames] = GSC_BurnoutGames;
 
 		// Half Screen bottom issue
 		lut[CRC::Tekken5] = GSC_Tekken5;


### PR DESCRIPTION
### Description of Changes
HLE's the double half clear with non-zero colour effect used by Burnout (Similar to Powerdrome). This removes the CRC hack for Burnout games (Though other fixes for things like the sky are still active)

### Rationale behind Changes
the HW renderer can't handle this scenario, so we had to HLE it.

### Suggested Testing Steps
Test burnout games, make sure they're ok. Best effect in "Native" upscaling requires the "Wild Arms Offset" hack to not look broken. If your CRC isn't in the code you will also require "Tex in Rt", you will also manually require Auto Flush

Fixes somewhat #5602
and Fixes #1415
Before: 
![image](https://user-images.githubusercontent.com/6278726/157956374-61db0bc9-a5a1-4050-b517-586bad4d71ea.png)

After:
![image](https://user-images.githubusercontent.com/6278726/157966644-c23ea5fe-54b5-4418-a520-5021e3ea8b80.png)

