### PR TITLE
Qt: Implement GS dump playback

### DIFF
--- a/common/StringUtil.h
+++ b/common/StringUtil.h
@@ -153,6 +153,17 @@ namespace StringUtil
 		return (str.length() >= suffix_length && str.compare(str.length() - suffix_length, suffix_length, suffix) == 0);
 	}
 
+	/// StartsWith/EndsWith variants which aren't case sensitive.
+	static inline bool StartsWithNoCase(const std::string_view& str, const char* prefix)
+	{
+		return (Strncasecmp(str.data(), prefix, std::strlen(prefix)) == 0);
+	}
+	static inline bool EndsWithNoCase(const std::string_view& str, const char* suffix)
+	{
+		const std::size_t suffix_length = std::strlen(suffix);
+		return (str.length() >= suffix_length && Strncasecmp(str.data() + (str.length() - suffix_length), suffix, suffix_length) == 0);
+	}
+
 	/// Strip whitespace from the start/end of the string.
 	std::string_view StripWhitespace(const std::string_view& str);
 

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -28,6 +28,7 @@
 #include "pcsx2/Frontend/InputManager.h"
 #include "pcsx2/Frontend/ImGuiManager.h"
 #include "pcsx2/GS.h"
+#include "pcsx2/GSDumpReplayer.h"
 #include "pcsx2/HostDisplay.h"
 #include "pcsx2/PAD/Host/PAD.h"
 #include "pcsx2/PerformanceMetrics.h"
@@ -677,6 +678,9 @@ bool Host::BeginPresentFrame(bool frame_skip)
 
 void Host::EndPresentFrame()
 {
+	if (GSDumpReplayer::IsReplayingDump())
+		GSDumpReplayer::RenderUI();
+
 	ImGuiManager::RenderOSD();
 	s_host_display->EndPresent();
 	ImGuiManager::NewFrame();

--- a/pcsx2-qt/Main.cpp
+++ b/pcsx2-qt/Main.cpp
@@ -41,7 +41,9 @@ static void PrintCommandLineHelp(const char* progname)
 	std::fprintf(stderr, "\n");
 	std::fprintf(stderr, "  -help: Displays this information and exits.\n");
 	std::fprintf(stderr, "  -version: Displays version information and exits.\n");
-	std::fprintf(stderr, "  -batch: Enables batch mode (exits after powering off).\n");
+	std::fprintf(stderr, "  -batch: Enables batch mode (exits after shutting down).\n");
+	std::fprintf(stderr, "  -elf <file>: Overrides the boot ELF with the specified filename.\n");
+	std::fprintf(stderr, "  -disc <path>: Uses the specified host DVD drive as a source.\n");
 	std::fprintf(stderr, "  -fastboot: Force fast boot for provided filename.\n");
 	std::fprintf(stderr, "  -slowboot: Force slow boot for provided filename.\n");
 	std::fprintf(stderr, "  -resume: Load resume save state. If a boot filename is provided,\n"
@@ -64,10 +66,8 @@ static void PrintCommandLineHelp(const char* progname)
 static std::shared_ptr<VMBootParameters>& AutoBoot(std::shared_ptr<VMBootParameters>& autoboot)
 {
 	if (!autoboot)
-	{
 		autoboot = std::make_shared<VMBootParameters>();
-		autoboot->source_type = CDVD_SourceType::NoDisc;
-	}
+
 	return autoboot;
 }
 
@@ -134,6 +134,12 @@ static bool ParseCommandLineOptions(int argc, char* argv[], std::shared_ptr<VMBo
 				AutoBoot(autoboot)->elf_override = argv[++i];
 				continue;
 			}
+			else if (CHECK_ARG_PARAM("-disc"))
+			{
+				AutoBoot(autoboot)->source_type = CDVD_SourceType::Disc;
+				AutoBoot(autoboot)->filename = argv[++i];
+				continue;
+			}
 			else if (CHECK_ARG("-fullscreen"))
 			{
 				Console.WriteLn("Going fullscreen after booting.");
@@ -172,12 +178,10 @@ static bool ParseCommandLineOptions(int argc, char* argv[], std::shared_ptr<VMBo
 #undef CHECK_ARG_PARAM
 		}
 
-		if (!AutoBoot(autoboot)->source.empty())
-			AutoBoot(autoboot)->source += ' ';
-		else
-			AutoBoot(autoboot)->source_type = CDVD_SourceType::Iso;
+		if (!AutoBoot(autoboot)->filename.empty())
+			AutoBoot(autoboot)->filename += ' ';
 
-		AutoBoot(autoboot)->source += argv[i];
+		AutoBoot(autoboot)->filename += argv[i];
 	}
 
 	return true;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -44,9 +44,15 @@
 #include "svnrev.h"
 
 static constexpr char DISC_IMAGE_FILTER[] =
-	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.chd *.cso *.elf *.irx *.m3u);;Single-Track Raw Images (*.bin "
-									"*.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;CSO Images (*.cso);;"
-									"ELF Executables (*.elf);;IRX Executables (*.irx);;Playlists (*.m3u)");
+	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.chd *.cso *.elf *.irx *.m3u *.gs *.gs.xz);;"
+									"Single-Track Raw Images (*.bin *.iso);;"
+									"Cue Sheets (*.cue);;"
+									"MAME CHD Images (*.chd);;"
+									"CSO Images (*.cso);;"
+									"ELF Executables (*.elf);;"
+									"IRX Executables (*.irx);;"
+									"Playlists (*.m3u);;"
+									"GS Dumps (*.gs *.gs.xz)");
 
 const char* MainWindow::DEFAULT_THEME_NAME = "darkfusion";
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -608,7 +608,10 @@ void MainWindow::clearProgressBar()
 	m_ui.statusBar->removeWidget(m_status_progress_widget);
 }
 
-bool MainWindow::isShowingGameList() const { return m_ui.mainContainer->currentIndex() == 0; }
+bool MainWindow::isShowingGameList() const
+{
+	return m_ui.mainContainer->currentIndex() == 0;
+}
 
 void MainWindow::switchToGameListView()
 {
@@ -641,11 +644,20 @@ void MainWindow::switchToEmulationView()
 	m_display_widget->setFocus();
 }
 
-void MainWindow::refreshGameList(bool invalidate_cache) { m_game_list_widget->refresh(invalidate_cache); }
+void MainWindow::refreshGameList(bool invalidate_cache)
+{
+	m_game_list_widget->refresh(invalidate_cache);
+}
 
-void MainWindow::invalidateSaveStateCache() { m_save_states_invalidated = true; }
+void MainWindow::invalidateSaveStateCache()
+{
+	m_save_states_invalidated = true;
+}
 
-void MainWindow::reportError(const QString& title, const QString& message) { QMessageBox::critical(this, title, message); }
+void MainWindow::reportError(const QString& title, const QString& message)
+{
+	QMessageBox::critical(this, title, message);
+}
 
 bool MainWindow::confirmShutdown()
 {
@@ -666,7 +678,10 @@ void MainWindow::requestExit()
 	close();
 }
 
-void Host::InvalidateSaveStateCache() { QMetaObject::invokeMethod(g_main_window, &MainWindow::invalidateSaveStateCache, Qt::QueuedConnection); }
+void Host::InvalidateSaveStateCache()
+{
+	QMetaObject::invokeMethod(g_main_window, &MainWindow::invalidateSaveStateCache, Qt::QueuedConnection);
+}
 
 void MainWindow::onGameListRefreshProgress(const QString& status, int current, int total)
 {
@@ -674,7 +689,10 @@ void MainWindow::onGameListRefreshProgress(const QString& status, int current, i
 	setProgressBar(current, total);
 }
 
-void MainWindow::onGameListRefreshComplete() { clearProgressBar(); }
+void MainWindow::onGameListRefreshComplete()
+{
+	clearProgressBar();
+}
 
 void MainWindow::onGameListSelectionChanged()
 {
@@ -785,14 +803,13 @@ void MainWindow::onStartFileActionTriggered()
 		return;
 
 	std::shared_ptr<VMBootParameters> params = std::make_shared<VMBootParameters>();
-	VMManager::SetBootParametersForPath(filename.toStdString(), params.get());
+	params->filename = filename.toStdString();
 	g_emu_thread->startVM(std::move(params));
 }
 
 void MainWindow::onStartBIOSActionTriggered()
 {
 	std::shared_ptr<VMBootParameters> params = std::make_shared<VMBootParameters>();
-	params->source_type = CDVD_SourceType::NoDisc;
 	g_emu_thread->startVM(std::move(params));
 }
 
@@ -807,7 +824,10 @@ void MainWindow::onChangeDiscFromFileActionTriggered()
 	g_emu_thread->changeDisc(filename);
 }
 
-void MainWindow::onChangeDiscFromGameListActionTriggered() { switchToGameListView(); }
+void MainWindow::onChangeDiscFromGameListActionTriggered()
+{
+	switchToGameListView();
+}
 
 void MainWindow::onChangeDiscFromDeviceActionTriggered()
 {
@@ -891,11 +911,20 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 		SettingsDialog::openGamePropertiesDialog(nullptr, m_current_game_crc);
 }
 
-void MainWindow::onGitHubRepositoryActionTriggered() { QtUtils::OpenURL(this, AboutDialog::getGitHubRepositoryUrl()); }
+void MainWindow::onGitHubRepositoryActionTriggered()
+{
+	QtUtils::OpenURL(this, AboutDialog::getGitHubRepositoryUrl());
+}
 
-void MainWindow::onSupportForumsActionTriggered() { QtUtils::OpenURL(this, AboutDialog::getSupportForumsUrl()); }
+void MainWindow::onSupportForumsActionTriggered()
+{
+	QtUtils::OpenURL(this, AboutDialog::getSupportForumsUrl());
+}
 
-void MainWindow::onDiscordServerActionTriggered() { QtUtils::OpenURL(this, AboutDialog::getDiscordServerUrl()); }
+void MainWindow::onDiscordServerActionTriggered()
+{
+	QtUtils::OpenURL(this, AboutDialog::getDiscordServerUrl());
+}
 
 void MainWindow::onAboutActionTriggered()
 {
@@ -1197,7 +1226,10 @@ void MainWindow::displayResizeRequested(qint32 width, qint32 height)
 	resize(QSize(std::max<qint32>(width, 1), std::max<qint32>(height + extra_height, 1)));
 }
 
-void MainWindow::destroyDisplay() { destroyDisplayWidget(); }
+void MainWindow::destroyDisplay()
+{
+	destroyDisplayWidget();
+}
 
 void MainWindow::focusDisplayWidget()
 {
@@ -1404,7 +1436,7 @@ void MainWindow::loadSaveStateFile(const QString& filename, const QString& state
 	else
 	{
 		std::shared_ptr<VMBootParameters> params = std::make_shared<VMBootParameters>();
-		VMManager::SetBootParametersForPath(filename.toStdString(), params.get());
+		params->filename = filename.toStdString();
 		params->save_state = state_filename.toStdString();
 		g_emu_thread->startVM(std::move(params));
 	}

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -983,6 +983,7 @@ if(PCSX2_CORE)
 		Frontend/InputManager.cpp
 		Frontend/InputSource.cpp
 		Frontend/LayeredSettingsInterface.cpp
+		GSDumpReplayer.cpp
 		HostSettings.cpp
 		VMManager.cpp
 	)
@@ -992,6 +993,7 @@ if(PCSX2_CORE)
 		Frontend/InputManager.h
 		Frontend/InputSource.h
 		Frontend/LayeredSettingsInterface.h
+		GSDumpReplayer.h
 		HostSettings.h
 		VMManager.h)
 endif()

--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -123,19 +123,19 @@ void GameList::FillBootParametersForEntry(VMBootParameters* params, const Entry*
 {
 	if (entry->type == GameList::EntryType::PS1Disc || entry->type == GameList::EntryType::PS2Disc)
 	{
-		params->source = entry->path;
+		params->filename = entry->path;
 		params->source_type = CDVD_SourceType::Iso;
 		params->elf_override.clear();
 	}
 	else if (entry->type == GameList::EntryType::ELF)
 	{
-		params->source.clear();
+		params->filename.clear();
 		params->source_type = CDVD_SourceType::NoDisc;
 		params->elf_override = entry->path;
 	}
 	else
 	{
-		params->source.clear();
+		params->filename.clear();
 		params->source_type = CDVD_SourceType::NoDisc;
 		params->elf_override.clear();
 	}

--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -568,6 +568,17 @@ const GameList::Entry* GameList::GetEntryForPath(const char* path)
 	return nullptr;
 }
 
+const GameList::Entry* GameList::GetEntryByCRC(u32 crc)
+{
+	for (const Entry& entry : m_entries)
+	{
+		if (entry.crc == crc)
+			return &entry;
+	}
+
+	return nullptr;
+}
+
 const GameList::Entry* GameList::GetEntryBySerialAndCRC(const std::string_view& serial, u32 crc)
 {
 	for (const Entry& entry : m_entries)

--- a/pcsx2/Frontend/GameList.h
+++ b/pcsx2/Frontend/GameList.h
@@ -80,6 +80,7 @@ namespace GameList
 	std::unique_lock<std::recursive_mutex> GetLock();
 	const Entry* GetEntryByIndex(u32 index);
 	const Entry* GetEntryForPath(const char* path);
+	const Entry* GetEntryByCRC(u32 crc);
 	const Entry* GetEntryBySerialAndCRC(const std::string_view& serial, u32 crc);
 	u32 GetEntryCount();
 

--- a/pcsx2/Frontend/ImGuiManager.cpp
+++ b/pcsx2/Frontend/ImGuiManager.cpp
@@ -630,3 +630,17 @@ void ImGuiManager::RenderOSD()
 	DrawOSDMessages();
 }
 
+float ImGuiManager::GetGlobalScale()
+{
+	return s_global_scale;
+}
+
+ImFont* ImGuiManager::GetStandardFont()
+{
+	return s_standard_font;
+}
+
+ImFont* ImGuiManager::GetFixedFont()
+{
+	return s_fixed_font;
+}

--- a/pcsx2/Frontend/ImGuiManager.h
+++ b/pcsx2/Frontend/ImGuiManager.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+struct ImFont;
+
 namespace ImGuiManager
 {
 	/// Initializes ImGui, creates fonts, etc.
@@ -34,5 +36,14 @@ namespace ImGuiManager
 
 	/// Renders any on-screen display elements.
 	void RenderOSD();
+
+	/// Returns the scale of all on-screen elements.
+	float GetGlobalScale();
+
+	/// Returns the standard font for external drawing.
+	ImFont* GetStandardFont();
+
+	/// Returns the fixed-width font for external drawing.
+	ImFont* GetFixedFont();
 } // namespace ImGuiManager
 

--- a/pcsx2/GS/GSLzma.h
+++ b/pcsx2/GS/GSLzma.h
@@ -13,24 +13,328 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <lzma.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#define GEN_REG_ENUM_CLASS_CONTENT(ClassName, EntryName, Value) \
+	EntryName = Value,
+
+#define GEN_REG_GETNAME_CONTENT(ClassName, EntryName, Value) \
+	case ClassName::EntryName: \
+		return #EntryName;
+
+#define GEN_REG_ENUM_CLASS_AND_GETNAME(Macro, ClassName, Type, DefaultString) \
+	enum class ClassName : Type \
+	{ \
+		Macro(GEN_REG_ENUM_CLASS_CONTENT) \
+	}; \
+	static constexpr const char* GetName(ClassName reg) \
+	{ \
+		switch (reg) \
+		{ \
+			Macro(GEN_REG_GETNAME_CONTENT) default : return DefaultString; \
+		} \
+	}
+
+namespace GSDumpTypes
+{
+	// clang-format off
+#define DEF_GSType(X) \
+	X(GSType, Transfer,  0) \
+	X(GSType, VSync,     1) \
+	X(GSType, ReadFIFO2, 2) \
+	X(GSType, Registers, 3)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GSType, GSType, u8, "UnknownType")
+#undef DEF_GSType
+
+#define DEF_GSTransferPath(X) \
+	X(GSTransferPath, Path1Old, 0) \
+	X(GSTransferPath, Path2,    1) \
+	X(GSTransferPath, Path3,    2) \
+	X(GSTransferPath, Path1New, 3) \
+	X(GSTransferPath, Dummy,    4)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GSTransferPath, GSTransferPath, u8, "UnknownPath")
+#undef DEF_GSTransferPath
+
+#define DEF_GIFFlag(X) \
+	X(GIFFlag, PACKED,  0) \
+	X(GIFFlag, REGLIST, 1) \
+	X(GIFFlag, IMAGE,   2) \
+	X(GIFFlag, IMAGE2,  3)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GIFFlag, GIFFlag, u8, "UnknownFlag")
+#undef DEF_GifFlag
+
+#define DEF_GIFReg(X) \
+	X(GIFReg, PRIM,       0x00) \
+	X(GIFReg, RGBAQ,      0x01) \
+	X(GIFReg, ST,         0x02) \
+	X(GIFReg, UV,         0x03) \
+	X(GIFReg, XYZF2,      0x04) \
+	X(GIFReg, XYZ2,       0x05) \
+	X(GIFReg, TEX0_1,     0x06) \
+	X(GIFReg, TEX0_2,     0x07) \
+	X(GIFReg, CLAMP_1,    0x08) \
+	X(GIFReg, CLAMP_2,    0x09) \
+	X(GIFReg, FOG,        0x0a) \
+	X(GIFReg, XYZF3,      0x0c) \
+	X(GIFReg, XYZ3,       0x0d) \
+	X(GIFReg, AD,         0x0e) \
+	X(GIFReg, NOP,        0x0f) \
+	X(GIFReg, TEX1_1,     0x14) \
+	X(GIFReg, TEX1_2,     0x15) \
+	X(GIFReg, TEX2_1,     0x16) \
+	X(GIFReg, TEX2_2,     0x17) \
+	X(GIFReg, XYOFFSET_1, 0x18) \
+	X(GIFReg, XYOFFSET_2, 0x19) \
+	X(GIFReg, PRMODECONT, 0x1a) \
+	X(GIFReg, PRMODE,     0x1b) \
+	X(GIFReg, TEXCLUT,    0x1c) \
+	X(GIFReg, SCANMSK,    0x22) \
+	X(GIFReg, MIPTBP1_1,  0x34) \
+	X(GIFReg, MIPTBP1_2,  0x35) \
+	X(GIFReg, MIPTBP2_1,  0x36) \
+	X(GIFReg, MIPTBP2_2,  0x37) \
+	X(GIFReg, TEXA,       0x3b) \
+	X(GIFReg, FOGCOL,     0x3d) \
+	X(GIFReg, TEXFLUSH,   0x3f) \
+	X(GIFReg, SCISSOR_1,  0x40) \
+	X(GIFReg, SCISSOR_2,  0x41) \
+	X(GIFReg, ALPHA_1,    0x42) \
+	X(GIFReg, ALPHA_2,    0x43) \
+	X(GIFReg, DIMX,       0x44) \
+	X(GIFReg, DTHE,       0x45) \
+	X(GIFReg, COLCLAMP,   0x46) \
+	X(GIFReg, TEST_1,     0x47) \
+	X(GIFReg, TEST_2,     0x48) \
+	X(GIFReg, PABE,       0x49) \
+	X(GIFReg, FBA_1,      0x4a) \
+	X(GIFReg, FBA_2,      0x4b) \
+	X(GIFReg, FRAME_1,    0x4c) \
+	X(GIFReg, FRAME_2,    0x4d) \
+	X(GIFReg, ZBUF_1,     0x4e) \
+	X(GIFReg, ZBUF_2,     0x4f) \
+	X(GIFReg, BITBLTBUF,  0x50) \
+	X(GIFReg, TRXPOS,     0x51) \
+	X(GIFReg, TRXREG,     0x52) \
+	X(GIFReg, TRXDIR,     0x53) \
+	X(GIFReg, HWREG,      0x54) \
+	X(GIFReg, SIGNAL,     0x60) \
+	X(GIFReg, FINISH,     0x61) \
+	X(GIFReg, LABEL,      0x62)
+		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GIFReg, GIFReg, u8, "UnknownReg")
+#undef DEF_GIFReg
+	// clang-format on
+
+	template <typename Output, typename Input, typename std::enable_if<sizeof(Input) == sizeof(Output), bool>::type = true>
+	static constexpr Output BitCast(Input input)
+	{
+		Output output;
+		memcpy(&output, &input, sizeof(input));
+		return output;
+	}
+	template <typename Output = u32>
+	static constexpr Output GetBits(u64 value, u32 shift, u32 numbits)
+	{
+		return static_cast<Output>((value >> shift) & ((1ull << numbits) - 1));
+	}
+
+	template <typename Output = u32>
+	static constexpr Output GetBits(u128 value, u32 shift, u32 numbits)
+	{
+		u64 outval = 0;
+		if (shift == 0)
+			outval = value.lo;
+		else if (shift < 64)
+			outval = (value.lo >> shift) | (value.hi << (64 - shift));
+		else
+			outval = value.hi >> (shift - 64);
+		return static_cast<Output>(outval & ((1ull << numbits) - 1));
+	}
+	static constexpr const char* GetNameOneBit(u8 value, const char* zero, const char* one)
+	{
+		switch (value)
+		{
+			case 0:
+				return zero;
+			case 1:
+				return one;
+			default:
+				return "UNKNOWN";
+		}
+	}
+	static constexpr const char* GetNameBool(bool value)
+	{
+		return value ? "True" : "False";
+	}
+
+	static constexpr const char* GetNamePRIMPRIM(u8 prim)
+	{
+		switch (prim)
+		{
+			case 0:
+				return "Point";
+			case 1:
+				return "Line";
+			case 2:
+				return "Line Strip";
+			case 3:
+				return "Triangle";
+			case 4:
+				return "Triangle Strip";
+			case 5:
+				return "Triangle Fan";
+			case 6:
+				return "Sprite";
+			case 7:
+				return "Invalid";
+			default:
+				return "UNKNOWN";
+		}
+	}
+	static constexpr const char* GetNamePRIMIIP(u8 iip)
+	{
+		return GetNameOneBit(iip, "Flat Shading", "Gouraud Shading");
+	}
+	static constexpr const char* GetNamePRIMFST(u8 fst)
+	{
+		return GetNameOneBit(fst, "STQ Value", "UV Value");
+	}
+	static constexpr const char* GetNamePRIMCTXT(u8 ctxt)
+	{
+		return GetNameOneBit(ctxt, "Context 1", "Context 2");
+	}
+	static constexpr const char* GetNamePRIMFIX(u8 fix)
+	{
+		return GetNameOneBit(fix, "Unfixed", "Fixed");
+	}
+	static constexpr const char* GetNameTEXTCC(u8 tcc)
+	{
+		return GetNameOneBit(tcc, "RGB", "RGBA");
+	}
+	static constexpr const char* GetNameTEXTFX(u8 tfx)
+	{
+		switch (tfx)
+		{
+			case 0:
+				return "Modulate";
+			case 1:
+				return "Decal";
+			case 2:
+				return "Highlight";
+			case 3:
+				return "Highlight2";
+			default:
+				return "UNKNOWN";
+		}
+	}
+	static constexpr const char* GetNameTEXCSM(u8 csm)
+	{
+		return GetNameOneBit(csm, "CSM1", "CSM2");
+	}
+	static constexpr const char* GetNameTEXPSM(u8 psm)
+	{
+		switch (psm)
+		{
+			case 000:
+				return "PSMCT32";
+			case 001:
+				return "PSMCT24";
+			case 002:
+				return "PSMCT16";
+			case 012:
+				return "PSMCT16S";
+			case 023:
+				return "PSMT8";
+			case 024:
+				return "PSMT4";
+			case 033:
+				return "PSMT8H";
+			case 044:
+				return "PSMT4HL";
+			case 054:
+				return "PSMT4HH";
+			case 060:
+				return "PSMZ32";
+			case 061:
+				return "PSMZ24";
+			case 062:
+				return "PSMZ16";
+			case 072:
+				return "PSMZ16S";
+			default:
+				return "UNKNOWN";
+		}
+	}
+	static constexpr const char* GetNameTEXCPSM(u8 psm)
+	{
+		switch (psm)
+		{
+			case 000:
+				return "PSMCT32";
+			case 002:
+				return "PSMCT16";
+			case 012:
+				return "PSMCT16S";
+			default:
+				return "UNKNOWN";
+		}
+	}
+} // namespace GSDumpTypes
 
 class GSDumpFile
 {
-	FILE* m_repack_fp;
+public:
+	struct GSData
+	{
+		GSDumpTypes::GSType id;
+		std::unique_ptr<u8[]> data;
+		s32 length;
+		GSDumpTypes::GSTransferPath path;
+	};
+
+	using ByteArray = std::vector<u8>;
+	using GSDataArray = std::vector<GSData>;
+
+	virtual ~GSDumpFile();
+
+	static std::unique_ptr<GSDumpFile> OpenGSDump(const char* filename, const char* repack_filename = nullptr);
+	static bool GetPreviewImageFromDump(const char* filename, u32* width, u32* height, std::vector<u32>* pixels);
+
+	__fi const std::string& GetSerial() const { return m_serial; }
+	__fi u32 GetCRC() const { return m_crc; }
+
+	__fi const ByteArray& GetRegsData() const { return m_regs_data; }
+	__fi const ByteArray& GetStateData() const { return m_state_data; }
+	__fi const GSDataArray& GetPackets() const { return m_dump_packets; }
+
+	bool ReadFile();
 
 protected:
-	FILE* m_fp;
+	GSDumpFile(FILE* file, FILE* repack_file);
 
-	void Repack(void* ptr, size_t size);
-
-public:
 	virtual bool IsEof() = 0;
 	virtual bool Read(void* ptr, size_t size) = 0;
 
-	GSDumpFile(char* filename, const char* repack_filename);
-	GSDumpFile(FILE* file, FILE* repack_file);
-	virtual ~GSDumpFile();
+	void Repack(void* ptr, size_t size);
+
+	FILE* m_fp = nullptr;
+
+private:
+	FILE* m_repack_fp = nullptr;
+
+	std::string m_serial;
+	u32 m_crc = 0;
+
+	std::vector<u8> m_regs_data;
+	std::vector<u8> m_state_data;
+
+	// TODO: Allocate a single, large buffer, and store pointers to
+	// each packet instead of a buffer per packet.
+	GSDataArray m_dump_packets;
 };
 
 class GSDumpLzma : public GSDumpFile
@@ -48,7 +352,6 @@ class GSDumpLzma : public GSDumpFile
 	void Initialize();
 
 public:
-	GSDumpLzma(char* filename, const char* repack_filename);
 	GSDumpLzma(FILE* file, FILE* repack_file);
 	virtual ~GSDumpLzma();
 
@@ -59,7 +362,6 @@ public:
 class GSDumpRaw : public GSDumpFile
 {
 public:
-	GSDumpRaw(char* filename, const char* repack_filename);
 	GSDumpRaw(FILE* file, FILE* repack_file);
 	virtual ~GSDumpRaw() = default;
 

--- a/pcsx2/GS/GSLzma.h
+++ b/pcsx2/GS/GSLzma.h
@@ -291,7 +291,7 @@ public:
 	struct GSData
 	{
 		GSDumpTypes::GSType id;
-		std::unique_ptr<u8[]> data;
+		const u8* data;
 		s32 length;
 		GSDumpTypes::GSTransferPath path;
 	};
@@ -317,7 +317,7 @@ protected:
 	GSDumpFile(FILE* file, FILE* repack_file);
 
 	virtual bool IsEof() = 0;
-	virtual bool Read(void* ptr, size_t size) = 0;
+	virtual size_t Read(void* ptr, size_t size) = 0;
 
 	void Repack(void* ptr, size_t size);
 
@@ -331,9 +331,8 @@ private:
 
 	std::vector<u8> m_regs_data;
 	std::vector<u8> m_state_data;
+	std::vector<u8> m_packet_data;
 
-	// TODO: Allocate a single, large buffer, and store pointers to
-	// each packet instead of a buffer per packet.
 	GSDataArray m_dump_packets;
 };
 
@@ -356,7 +355,7 @@ public:
 	virtual ~GSDumpLzma();
 
 	bool IsEof() final;
-	bool Read(void* ptr, size_t size) final;
+	size_t Read(void* ptr, size_t size) final;
 };
 
 class GSDumpRaw : public GSDumpFile
@@ -366,5 +365,5 @@ public:
 	virtual ~GSDumpRaw() = default;
 
 	bool IsEof() final;
-	bool Read(void* ptr, size_t size) final;
+	size_t Read(void* ptr, size_t size) final;
 };

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -1,0 +1,342 @@
+#include "PrecompiledHeader.h"
+
+#include <atomic>
+
+#include "common/FileSystem.h"
+#include "common/StringUtil.h"
+#include "common/Timer.h"
+
+#include "imgui.h"
+
+// Has to come before Gif.h
+#include "MemoryTypes.h"
+
+#include "Frontend/ImGuiManager.h"
+#include "Frontend/GameList.h"
+#include "Gif.h"
+#include "Gif_Unit.h"
+#include "GSDumpReplayer.h"
+#include "GS/GSLzma.h"
+#include "GS.h"
+#include "Host.h"
+#include "R3000A.h"
+#include "R5900.h"
+#include "VMManager.h"
+#include "VUmicro.h"
+
+static void GSDumpReplayerCpuReserve();
+static void GSDumpReplayerCpuShutdown();
+static void GSDumpReplayerCpuReset();
+static void GSDumpReplayerCpuStep();
+static void GSDumpReplayerCpuExecute();
+static void GSDumpReplayerCpuCheckExecutionState();
+static void GSDumpReplayerCpuThrowException(const BaseException& ex);
+static void GSDumpReplayerCpuThrowCpuException(const BaseR5900Exception& ex);
+static void GSDumpReplayerCpuClear(u32 addr, u32 size);
+static uint GSDumpReplayerCpuGetCacheReserve();
+static void GSDumpReplayerCpuSetCacheReserve(uint reserveInMegs);
+
+static std::unique_ptr<GSDumpFile> s_dump_file;
+static u32 s_current_packet = 0;
+static u32 s_dump_frame_number = 0;
+static bool s_dump_running = false;
+static bool s_needs_state_loaded = false;
+static u64 s_frame_ticks = 0;
+static u64 s_next_frame_time = 0;
+
+R5900cpu GSDumpReplayerCpu = {
+	GSDumpReplayerCpuReserve,
+	GSDumpReplayerCpuShutdown,
+	GSDumpReplayerCpuReset,
+	GSDumpReplayerCpuStep,
+	GSDumpReplayerCpuExecute,
+	GSDumpReplayerCpuCheckExecutionState,
+	GSDumpReplayerCpuThrowException,
+	GSDumpReplayerCpuThrowCpuException,
+	GSDumpReplayerCpuClear,
+	GSDumpReplayerCpuGetCacheReserve,
+	GSDumpReplayerCpuSetCacheReserve};
+
+static InterpVU0 gsDumpVU0;
+static InterpVU1 gsDumpVU1;
+
+bool GSDumpReplayer::IsReplayingDump()
+{
+	return static_cast<bool>(s_dump_file);
+}
+
+bool GSDumpReplayer::Initialize(const char* filename)
+{
+	Common::Timer timer;
+	Console.WriteLn("(GSDumpReplayer) Reading file...");
+
+	s_dump_file = GSDumpFile::OpenGSDump(filename);
+	if (!s_dump_file || !s_dump_file->ReadFile())
+	{
+		Host::ReportFormattedErrorAsync("GSDumpReplayer", "Failed to open or read '%s'.", filename);
+		s_dump_file.reset();
+		return false;
+	}
+
+	Console.WriteLn("(GSDumpReplayer) Read file in %.2f ms.", timer.GetTimeMilliseconds());
+
+	// We replace all CPUs.
+	Cpu = &GSDumpReplayerCpu;
+	psxCpu = &psxInt;
+	CpuVU0 = &gsDumpVU0;
+	CpuVU1 = &gsDumpVU1;
+
+	return true;
+}
+
+void GSDumpReplayer::Reset()
+{
+	GSDumpReplayerCpuReset();
+}
+
+void GSDumpReplayer::Shutdown()
+{
+	Console.WriteLn("(GSDumpReplayer) Shutting down.");
+
+	Cpu = nullptr;
+	psxCpu = nullptr;
+	CpuVU0 = nullptr;
+	CpuVU1 = nullptr;
+	s_dump_file.reset();
+}
+
+std::string GSDumpReplayer::GetDumpSerial()
+{
+	std::string ret;
+
+	if (!s_dump_file->GetSerial().empty())
+	{
+		ret = s_dump_file->GetSerial();
+	}
+	else if (s_dump_file->GetCRC() != 0)
+	{
+		// old dump files don't have serials, but we have the crc...
+		// so, let's try searching the game list for a crc match.
+		auto lock = GameList::GetLock();
+		const GameList::Entry* entry = GameList::GetEntryByCRC(s_dump_file->GetCRC());
+		if (entry)
+			ret = entry->serial;
+	}
+
+	return ret;
+}
+
+u32 GSDumpReplayer::GetDumpCRC()
+{
+	return s_dump_file->GetCRC();
+}
+
+void GSDumpReplayerCpuReserve()
+{
+}
+
+void GSDumpReplayerCpuShutdown()
+{
+}
+
+void GSDumpReplayerCpuReset()
+{
+	s_needs_state_loaded = true;
+	s_current_packet = 0;
+	s_dump_frame_number = 0;
+}
+
+static void GSDumpReplayerLoadInitialState()
+{
+	// reset GS registers to initial dump values
+	std::memcpy(PS2MEM_GS, s_dump_file->GetRegsData().data(),
+		std::min(Ps2MemSize::GSregs, static_cast<u32>(s_dump_file->GetRegsData().size())));
+
+	// load GS state
+	freezeData fd = {static_cast<int>(s_dump_file->GetStateData().size()),
+		const_cast<u8*>(s_dump_file->GetStateData().data())};
+	MTGS_FreezeData mfd = {&fd, 0};
+	GetMTGS().Freeze(FreezeAction::Load, mfd);
+	if (mfd.retval != 0)
+		Host::ReportFormattedErrorAsync("GSDumpReplayer", "Failed to load GS state.");
+}
+
+static void GSDumpReplayerSendPacketToMTGS(GIF_PATH path, const u8* data, u32 length)
+{
+	pxAssert((length % 16) == 0);
+
+	Gif_Path& gifPath = gifUnit.gifPath[path];
+	gifPath.CopyGSPacketData(const_cast<u8*>(data), length);
+
+	GS_Packet gsPack;
+	gsPack.offset = gifPath.curOffset;
+	gsPack.size = length;
+	gifPath.curOffset += length;
+	Gif_AddCompletedGSPacket(gsPack, path);
+}
+
+static void GSDumpReplayerUpdateFrameLimit()
+{
+	constexpr u32 default_frame_limit = 60;
+	const u32 frame_limit = static_cast<u32>(default_frame_limit * EmuConfig.GS.LimitScalar);
+
+	if (frame_limit > 0)
+		s_frame_ticks = (GetTickFrequency() + (frame_limit / 2)) / frame_limit;
+	else
+		s_frame_ticks = 0;
+}
+
+static void GSDumpReplayerFrameLimit()
+{
+	if (s_frame_ticks == 0)
+		return;
+
+	// Frame limiter
+	u64 now = GetCPUTicks();
+	const s64 ms = GetTickFrequency() / 1000;
+	const s64 sleep = s_next_frame_time - now - ms;
+	if (sleep > ms)
+		Threading::Sleep(sleep / ms);
+	while ((now = GetCPUTicks()) < s_next_frame_time)
+		ShortSpin();
+	s_next_frame_time = std::max(now, s_next_frame_time + s_frame_ticks);
+}
+
+void GSDumpReplayerCpuStep()
+{
+	if (s_needs_state_loaded)
+	{
+		GSDumpReplayerLoadInitialState();
+		s_needs_state_loaded = false;
+	}
+
+	const GSDumpFile::GSData& packet = s_dump_file->GetPackets()[s_current_packet];
+	s_current_packet = (s_current_packet + 1) % static_cast<u32>(s_dump_file->GetPackets().size());
+	if (s_current_packet == 0)
+		s_dump_frame_number = 0;
+
+	switch (packet.id)
+	{
+		case GSDumpTypes::GSType::Transfer:
+		{
+			switch (packet.path)
+			{
+				case GSDumpTypes::GSTransferPath::Path1Old:
+				{
+					std::unique_ptr<u8[]> data(new u8[16384]);
+					const s32 addr = 16384 - packet.length;
+					std::memcpy(data.get(), packet.data.get() + addr, packet.length);
+					GSDumpReplayerSendPacketToMTGS(GIF_PATH_1, data.get(), packet.length);
+				}
+				break;
+
+				case GSDumpTypes::GSTransferPath::Path1New:
+				case GSDumpTypes::GSTransferPath::Path2:
+				case GSDumpTypes::GSTransferPath::Path3:
+				{
+					GSDumpReplayerSendPacketToMTGS(static_cast<GIF_PATH>(static_cast<u8>(packet.path) - 1),
+						reinterpret_cast<const u8*>(packet.data.get()), packet.length);
+				}
+				break;
+
+				default:
+					break;
+			}
+			break;
+		}
+
+		case GSDumpTypes::GSType::VSync:
+		{
+			s_dump_frame_number++;
+			GSDumpReplayerCpuCheckExecutionState();
+			GSDumpReplayerUpdateFrameLimit();
+			GSDumpReplayerFrameLimit();
+			GetMTGS().PostVsyncStart(false);
+			VMManager::Internal::VSyncOnCPUThread();
+		}
+		break;
+
+		case GSDumpTypes::GSType::ReadFIFO2:
+		{
+			std::unique_ptr<char[]> arr(new char[*((int*)packet.data.get())]);
+			GSreadFIFO2((u8*)arr.get(), *((int*)packet.data.get()));
+		}
+		break;
+
+		case GSDumpTypes::GSType::Registers:
+		{
+			std::memcpy(PS2MEM_GS, packet.data.get(), std::min<s32>(packet.length, Ps2MemSize::GSregs));
+		}
+		break;
+	}
+}
+
+void GSDumpReplayerCpuExecute()
+{
+	s_dump_running = true;
+	s_next_frame_time = GetCPUTicks();
+
+	while (s_dump_running)
+	{
+		GSDumpReplayerCpuStep();
+	}
+}
+
+void GSDumpReplayerCpuCheckExecutionState()
+{
+	if (VMManager::Internal::IsExecutionInterrupted())
+		s_dump_running = false;
+}
+
+void GSDumpReplayerCpuThrowException(const BaseException& ex)
+{
+}
+
+void GSDumpReplayerCpuThrowCpuException(const BaseR5900Exception& ex)
+{
+}
+
+void GSDumpReplayerCpuClear(u32 addr, u32 size)
+{
+}
+
+uint GSDumpReplayerCpuGetCacheReserve()
+{
+	return 0;
+}
+
+void GSDumpReplayerCpuSetCacheReserve(uint reserveInMegs)
+{
+}
+
+void GSDumpReplayer::RenderUI()
+{
+	const float scale = ImGuiManager::GetGlobalScale();
+	const float shadow_offset = std::ceil(1.0f * scale);
+	const float margin = std::ceil(10.0f * scale);
+	const float spacing = std::ceil(5.0f * scale);
+	float position_y = margin;
+
+	ImDrawList* dl = ImGui::GetBackgroundDrawList();
+	ImFont* font = ImGuiManager::GetFixedFont();
+	FastFormatAscii text;
+	ImVec2 text_size;
+
+#define DRAW_LINE(font, text, color) \
+	do \
+	{ \
+		text_size = font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
+		dl->AddText(font, font->FontSize, ImVec2(margin + shadow_offset, position_y + shadow_offset), IM_COL32(0, 0, 0, 100), (text)); \
+		dl->AddText(font, font->FontSize, ImVec2(margin, position_y), color, (text)); \
+		position_y += text_size.y + spacing; \
+	} while (0)
+
+	text.Write("Dump Frame: %u", s_dump_frame_number);
+	DRAW_LINE(font, text.c_str(), IM_COL32(255, 255, 255, 255));
+
+	text.Clear();
+	text.Write("Packet Number: %u/%u", s_current_packet, static_cast<u32>(s_dump_file->GetPackets().size()));
+	DRAW_LINE(font, text.c_str(), IM_COL32(255, 255, 255, 255));
+
+#undef DRAW_LINE
+}

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -225,7 +225,7 @@ void GSDumpReplayerCpuStep()
 				{
 					std::unique_ptr<u8[]> data(new u8[16384]);
 					const s32 addr = 16384 - packet.length;
-					std::memcpy(data.get(), packet.data.get() + addr, packet.length);
+					std::memcpy(data.get(), packet.data + addr, packet.length);
 					GSDumpReplayerSendPacketToMTGS(GIF_PATH_1, data.get(), packet.length);
 				}
 				break;
@@ -235,7 +235,7 @@ void GSDumpReplayerCpuStep()
 				case GSDumpTypes::GSTransferPath::Path3:
 				{
 					GSDumpReplayerSendPacketToMTGS(static_cast<GIF_PATH>(static_cast<u8>(packet.path) - 1),
-						reinterpret_cast<const u8*>(packet.data.get()), packet.length);
+						packet.data, packet.length);
 				}
 				break;
 
@@ -258,14 +258,14 @@ void GSDumpReplayerCpuStep()
 
 		case GSDumpTypes::GSType::ReadFIFO2:
 		{
-			std::unique_ptr<char[]> arr(new char[*((int*)packet.data.get())]);
-			GSreadFIFO2((u8*)arr.get(), *((int*)packet.data.get()));
+			std::unique_ptr<char[]> arr(new char[*((int*)packet.data)]);
+			GSreadFIFO2((u8*)arr.get(), *((int*)packet.data));
 		}
 		break;
 
 		case GSDumpTypes::GSType::Registers:
 		{
-			std::memcpy(PS2MEM_GS, packet.data.get(), std::min<s32>(packet.length, Ps2MemSize::GSregs));
+			std::memcpy(PS2MEM_GS, packet.data, std::min<s32>(packet.length, Ps2MemSize::GSregs));
 		}
 		break;
 	}

--- a/pcsx2/GSDumpReplayer.h
+++ b/pcsx2/GSDumpReplayer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace GSDumpReplayer
+{
+bool IsReplayingDump();
+
+bool Initialize(const char* filename);
+void Reset();
+void Shutdown();
+
+std::string GetDumpSerial();
+u32 GetDumpCRC();
+
+void RenderUI();
+}

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -49,6 +49,10 @@ BIOS
 
 #include "common/PageFaultSource.h"
 
+#ifdef PCSX2_CORE
+#include "GSDumpReplayer.h"
+#endif
+
 #ifdef ENABLECACHE
 #include "Cache.h"
 #endif
@@ -850,7 +854,13 @@ void eeMemoryReserve::Reset()
 	vtlb_VMap(0x00000000,0x00000000,0x20000000);
 	vtlb_VMapUnmap(0x20000000,0x60000000);
 
-	if (!LoadBIOS())
+#ifdef PCSX2_CORE
+	const bool needs_bios = !GSDumpReplayer::IsReplayingDump();
+#else
+	constexpr bool needs_bios = true;
+#endif
+
+	if (needs_bios && !LoadBIOS())
 		pxFailRel("Failed to load BIOS");
 }
 

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -27,6 +27,11 @@
 #include "common/MemsetFast.inl"
 #include "common/Perf.h"
 
+#ifdef PCSX2_CORE
+#include "GSDumpReplayer.h"
+
+extern R5900cpu GSDumpReplayerCpu;
+#endif
 
 // --------------------------------------------------------------------------------------
 //  RecompiledCodeReserve  (implementations)
@@ -576,6 +581,11 @@ void SysCpuProviderPack::ApplyConfig() const
 
 	if( EmuConfig.Cpu.Recompiler.EnableVU1 )
 		CpuVU1 = (BaseVUmicroCPU*)CpuProviders->microVU1;
+
+#ifdef PCSX2_CORE
+	if (GSDumpReplayer::IsReplayingDump())
+		Cpu = &GSDumpReplayerCpu;
+#endif
 }
 
 // Resets all PS2 cpu execution caches, which does not affect that actual PS2 state/condition.

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -75,6 +75,9 @@ namespace VMManager
 	static void CheckForSPU2ConfigChanges(const Pcsx2Config& old_config);
 	static void CheckForDEV9ConfigChanges(const Pcsx2Config& old_config);
 	static void CheckForMemoryCardConfigChanges(const Pcsx2Config& old_config);
+
+	static bool AutoDetectSource(const std::string& filename);
+	static bool ApplyBootParameters(const VMBootParameters& params);
 	static void UpdateRunningGame(bool force);
 
 	static std::string GetCurrentSaveStateFileName(s32 slot);
@@ -519,30 +522,86 @@ static LimiterModeType GetInitialLimiterMode()
 	return EmuConfig.GS.FrameLimitEnable ? LimiterModeType::Nominal : LimiterModeType::Unlimited;
 }
 
-static void ApplyBootParameters(const VMBootParameters& params)
+bool VMManager::AutoDetectSource(const std::string& filename)
+{
+	if (!filename.empty())
+	{
+		if (!FileSystem::FileExists(filename.c_str()))
+		{
+			Host::ReportFormattedErrorAsync("Error", "Requested filename '%s' does not exist.", filename.c_str());
+			return false;
+		}
+
+		const std::string display_name(FileSystem::GetDisplayNameFromPath(filename));
+		if (IsGSDumpFileName(display_name))
+		{
+			CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
+			return GSDumpReplayer::Initialize(filename.c_str());
+		}
+		else if (IsElfFileName(display_name))
+		{
+			// alternative way of booting an elf, change the elf override, and use no disc.
+			CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
+			s_elf_override = filename;
+			return true;
+		}
+		else
+		{
+			// TODO: Maybe we should check if it's a valid iso here...
+			CDVDsys_SetFile(CDVD_SourceType::Iso, filename);
+			CDVDsys_ChangeSource(CDVD_SourceType::Iso);
+			s_disc_path = filename;
+			return true;
+		}
+	}
+	else
+	{
+		// make sure we're not fast booting when we have no filename
+		CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
+		EmuConfig.UseBOOT2Injection = false;
+		return true;
+	}
+}
+
+bool VMManager::ApplyBootParameters(const VMBootParameters& params)
 {
 	const bool default_fast_boot = Host::GetBoolSettingValue("EmuCore", "EnableFastBoot", true);
-	EmuConfig.UseBOOT2Injection =
-		(params.source_type != CDVD_SourceType::NoDisc && params.fast_boot.value_or(default_fast_boot));
+	EmuConfig.UseBOOT2Injection = params.fast_boot.value_or(default_fast_boot);
+	s_elf_override = params.elf_override;
+	s_disc_path.clear();
 
-	CDVDsys_SetFile(CDVD_SourceType::Iso, params.source);
-	CDVDsys_ChangeSource(params.source_type);
-
-	if (!params.elf_override.empty())
+	if (params.source_type.has_value())
 	{
-		Hle_SetElfPath(params.elf_override.c_str());
-		s_elf_override = std::move(params.elf_override);
+		if (params.source_type.value() == CDVD_SourceType::Iso && !FileSystem::FileExists(params.filename.c_str()))
+		{
+			Host::ReportFormattedErrorAsync("Error", "Requested filename '%s' does not exist.", params.filename.c_str());
+			return false;
+		}
+
+		// Use specified source type.
+		CDVDsys_SetFile(params.source_type.value(), params.filename);
+		CDVDsys_ChangeSource(params.source_type.value());
+	}
+	else
+	{
+		// Automatic type detection of boot parameter based on filename.
+		if (!AutoDetectSource(params.filename))
+			return false;
+	}
+
+	if (!s_elf_override.empty())
+	{
+		if (!FileSystem::FileExists(s_elf_override.c_str()))
+		{
+			Host::ReportFormattedErrorAsync("Error", "Requested boot ELF '%s' does not exist.", s_elf_override.c_str());
+			return false;
+		}
+
+		Hle_SetElfPath(s_elf_override.c_str());
 		EmuConfig.UseBOOT2Injection = true;
 	}
-	else
-	{
-		std::string().swap(s_elf_override);
-	}
 
-	if (params.source_type == CDVD_SourceType::Iso)
-		s_disc_path = params.source;
-	else
-		s_disc_path.clear();
+	return true;
 }
 
 bool VMManager::Initialize(const VMBootParameters& boot_params)
@@ -559,16 +618,8 @@ bool VMManager::Initialize(const VMBootParameters& boot_params)
 
 	LoadSettings();
 
-	if (IsGSDumpFileName(boot_params.source))
-	{
-		CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
-		if (!GSDumpReplayer::Initialize(boot_params.source.c_str()))
-			return false;
-	}
-	else
-	{
-		ApplyBootParameters(boot_params);
-	}
+	if (!ApplyBootParameters(boot_params))
+		return false;
 
 	EmuConfig.LimiterMode = GetInitialLimiterMode();
 
@@ -949,39 +1000,12 @@ bool VMManager::ChangeDisc(std::string path)
 
 bool VMManager::IsElfFileName(const std::string& path)
 {
-	const std::string::size_type pos = path.rfind('.');
-	if (pos == std::string::npos)
-		return false;
-
-	return (StringUtil::Strcasecmp(&path[pos], ".elf") == 0);
+	return StringUtil::EndsWithNoCase(path, ".elf");
 }
 
 bool VMManager::IsGSDumpFileName(const std::string& path)
 {
 	return (StringUtil::EndsWithNoCase(path, ".gs") || StringUtil::EndsWithNoCase(path, ".gs.xz"));
-}
-
-void VMManager::SetBootParametersForPath(const std::string& path, VMBootParameters* params)
-{
-	if (IsElfFileName(path))
-	{
-		params->elf_override = path;
-		params->source_type = CDVD_SourceType::NoDisc;
-	}
-	else if (IsGSDumpFileName(path))
-	{
-		params->source_type = CDVD_SourceType::NoDisc;
-		params->source = path;
-	}
-	else if (!path.empty())
-	{
-		params->source_type = CDVD_SourceType::Iso;
-		params->source = path;
-	}
-	else
-	{
-		params->source_type = CDVD_SourceType::NoDisc;
-	}
 }
 
 void VMManager::Execute()

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -135,6 +135,9 @@ namespace VMManager
 	/// Returns true if the specified path is an ELF.
 	bool IsElfFileName(const std::string& path);
 
+	/// Returns true if the specified path is a GS Dump.
+	bool IsGSDumpFileName(const std::string& path);
+
 	/// Updates boot parameters for a given start filename. If it's an elf, it'll set elf_override, otherwise source.
 	void SetBootParametersForPath(const std::string& path, VMBootParameters* params);
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -39,10 +39,11 @@ enum class VMState
 
 struct VMBootParameters
 {
-	std::string source;
-	std::string save_state;
-	CDVD_SourceType source_type;
+	std::string filename;
 	std::string elf_override;
+	std::string save_state;
+	std::optional<CDVD_SourceType> source_type;
+
 	std::optional<bool> fast_boot;
 	std::optional<bool> fullscreen;
 	std::optional<bool> batch_mode;
@@ -137,9 +138,6 @@ namespace VMManager
 
 	/// Returns true if the specified path is a GS Dump.
 	bool IsGSDumpFileName(const std::string& path);
-
-	/// Updates boot parameters for a given start filename. If it's an elf, it'll set elf_override, otherwise source.
-	void SetBootParametersForPath(const std::string& path, VMBootParameters* params);
 
 	/// Returns the path for the game settings ini file for the specified CRC.
 	std::string GetGameSettingsPath(u32 game_crc);

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -433,7 +433,7 @@ void Dialogs::GSDumpDialog::GenPacketInfo(const GSDumpFile::GSData& dump)
 	{
 		case GSType::Transfer:
 		{
-			u8* data = dump.data.get();
+			const u8* data = dump.data;
 			u32 remaining = dump.length;
 			int idx = 0;
 			while (remaining >= 16)
@@ -468,7 +468,7 @@ void Dialogs::GSDumpDialog::GenPacketInfo(const GSDumpFile::GSData& dump)
 	}
 }
 
-void Dialogs::GSDumpDialog::ParseTransfer(wxTreeItemId& trootId, u8* data)
+void Dialogs::GSDumpDialog::ParseTransfer(wxTreeItemId& trootId, const u8* data)
 {
 	u64 tag  = *(u64*)data;
 	u64 regs = *(u64*)(data + 8);
@@ -746,18 +746,18 @@ void Dialogs::GSDumpDialog::ProcessDumpEvent(const GSDumpFile::GSData& event, u8
 				{
 					std::unique_ptr<char[]> data(new char[16384]);
 					int addr = 16384 - event.length;
-					memcpy(data.get(), event.data.get() + addr, event.length);
+					memcpy(data.get(), event.data + addr, event.length);
 					GSgifTransfer1((u8*)data.get(), addr);
 					break;
 				}
 				case GSTransferPath::Path1New:
-					GSgifTransfer((u8*)event.data.get(), event.length / 16);
+					GSgifTransfer((u8*)event.data, event.length / 16);
 					break;
 				case GSTransferPath::Path2:
-					GSgifTransfer2((u8*)event.data.get(), event.length / 16);
+					GSgifTransfer2((u8*)event.data, event.length / 16);
 					break;
 				case GSTransferPath::Path3:
-					GSgifTransfer3((u8*)event.data.get(), event.length / 16);
+					GSgifTransfer3((u8*)event.data, event.length / 16);
 					break;
 				default:
 					break;
@@ -772,12 +772,12 @@ void Dialogs::GSDumpDialog::ProcessDumpEvent(const GSDumpFile::GSData& event, u8
 		}
 		case GSType::ReadFIFO2:
 		{
-			std::unique_ptr<char[]> arr(new char[*((int*)event.data.get())]);
-			GSreadFIFO2((u8*)arr.get(), *((int*)event.data.get()));
+			std::unique_ptr<char[]> arr(new char[*((int*)event.data)]);
+			GSreadFIFO2((u8*)arr.get(), *((int*)event.data));
 			break;
 		}
 		case GSType::Registers:
-			memcpy(regs, event.data.get(), 8192);
+			memcpy(regs, event.data, 8192);
 			break;
 	}
 }

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -25,28 +25,6 @@
 #include <wx/treectrl.h>
 #include <wx/fswatcher.h>
 
-#define GEN_REG_ENUM_CLASS_CONTENT(ClassName, EntryName, Value) \
-	EntryName = Value,
-
-#define GEN_REG_GETNAME_CONTENT(ClassName, EntryName, Value) \
-	case ClassName::EntryName: \
-		return #EntryName;
-
-#define GEN_REG_ENUM_CLASS_AND_GETNAME(Macro, ClassName, Type, DefaultString) \
-	enum class ClassName : Type \
-	{ \
-		Macro(GEN_REG_ENUM_CLASS_CONTENT) \
-	}; \
-	static constexpr const char* GetName(ClassName reg) \
-	{ \
-		switch (reg) \
-		{ \
-			Macro(GEN_REG_GETNAME_CONTENT) \
-			default: \
-				return DefaultString; \
-		} \
-	}
-
 class FirstTimeWizard : public wxWizard
 {
 	typedef wxWizard _parent;
@@ -147,102 +125,6 @@ namespace Dialogs
 			ID_FRAMERATE,
 		};
 
-		// clang-format off
-
-#define DEF_GSType(X) \
-	X(GSType, Transfer,  0) \
-	X(GSType, VSync,     1) \
-	X(GSType, ReadFIFO2, 2) \
-	X(GSType, Registers, 3)
-		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GSType, GSType, u8, "UnknownType")
-#undef DEF_GSType
-
-#define DEF_GSTransferPath(X) \
-	X(GSTransferPath, Path1Old, 0) \
-	X(GSTransferPath, Path2,    1) \
-	X(GSTransferPath, Path3,    2) \
-	X(GSTransferPath, Path1New, 3) \
-	X(GSTransferPath, Dummy,    4)
-		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GSTransferPath, GSTransferPath, u8, "UnknownPath")
-#undef DEF_GSTransferPath
-
-#define DEF_GIFFlag(X) \
-	X(GIFFlag, PACKED,  0) \
-	X(GIFFlag, REGLIST, 1) \
-	X(GIFFlag, IMAGE,   2) \
-	X(GIFFlag, IMAGE2,  3)
-		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GIFFlag, GIFFlag, u8, "UnknownFlag")
-#undef DEF_GifFlag
-
-#define DEF_GIFReg(X) \
-	X(GIFReg, PRIM,       0x00) \
-	X(GIFReg, RGBAQ,      0x01) \
-	X(GIFReg, ST,         0x02) \
-	X(GIFReg, UV,         0x03) \
-	X(GIFReg, XYZF2,      0x04) \
-	X(GIFReg, XYZ2,       0x05) \
-	X(GIFReg, TEX0_1,     0x06) \
-	X(GIFReg, TEX0_2,     0x07) \
-	X(GIFReg, CLAMP_1,    0x08) \
-	X(GIFReg, CLAMP_2,    0x09) \
-	X(GIFReg, FOG,        0x0a) \
-	X(GIFReg, XYZF3,      0x0c) \
-	X(GIFReg, XYZ3,       0x0d) \
-	X(GIFReg, AD,         0x0e) \
-	X(GIFReg, NOP,        0x0f) \
-	X(GIFReg, TEX1_1,     0x14) \
-	X(GIFReg, TEX1_2,     0x15) \
-	X(GIFReg, TEX2_1,     0x16) \
-	X(GIFReg, TEX2_2,     0x17) \
-	X(GIFReg, XYOFFSET_1, 0x18) \
-	X(GIFReg, XYOFFSET_2, 0x19) \
-	X(GIFReg, PRMODECONT, 0x1a) \
-	X(GIFReg, PRMODE,     0x1b) \
-	X(GIFReg, TEXCLUT,    0x1c) \
-	X(GIFReg, SCANMSK,    0x22) \
-	X(GIFReg, MIPTBP1_1,  0x34) \
-	X(GIFReg, MIPTBP1_2,  0x35) \
-	X(GIFReg, MIPTBP2_1,  0x36) \
-	X(GIFReg, MIPTBP2_2,  0x37) \
-	X(GIFReg, TEXA,       0x3b) \
-	X(GIFReg, FOGCOL,     0x3d) \
-	X(GIFReg, TEXFLUSH,   0x3f) \
-	X(GIFReg, SCISSOR_1,  0x40) \
-	X(GIFReg, SCISSOR_2,  0x41) \
-	X(GIFReg, ALPHA_1,    0x42) \
-	X(GIFReg, ALPHA_2,    0x43) \
-	X(GIFReg, DIMX,       0x44) \
-	X(GIFReg, DTHE,       0x45) \
-	X(GIFReg, COLCLAMP,   0x46) \
-	X(GIFReg, TEST_1,     0x47) \
-	X(GIFReg, TEST_2,     0x48) \
-	X(GIFReg, PABE,       0x49) \
-	X(GIFReg, FBA_1,      0x4a) \
-	X(GIFReg, FBA_2,      0x4b) \
-	X(GIFReg, FRAME_1,    0x4c) \
-	X(GIFReg, FRAME_2,    0x4d) \
-	X(GIFReg, ZBUF_1,     0x4e) \
-	X(GIFReg, ZBUF_2,     0x4f) \
-	X(GIFReg, BITBLTBUF,  0x50) \
-	X(GIFReg, TRXPOS,     0x51) \
-	X(GIFReg, TRXREG,     0x52) \
-	X(GIFReg, TRXDIR,     0x53) \
-	X(GIFReg, HWREG,      0x54) \
-	X(GIFReg, SIGNAL,     0x60) \
-	X(GIFReg, FINISH,     0x61) \
-	X(GIFReg, LABEL,      0x62)
-		GEN_REG_ENUM_CLASS_AND_GETNAME(DEF_GIFReg, GIFReg, u8, "UnknownReg")
-#undef DEF_GIFReg
-
-		// clang-format on
-
-		struct GSData
-		{
-			GSType id;
-			std::unique_ptr<u8[]> data;
-			int length;
-			GSTransferPath path;
-		};
 		enum ButtonState
 		{
 			Step,
@@ -256,16 +138,15 @@ namespace Dialogs
 			int index;
 		};
 		std::vector<GSEvent> m_button_events;
-		std::vector<GSData> m_dump_packets;
 		std::vector<wxTreeItemId> m_gif_items;
 
 		float m_stored_q = 1.0;
-		void ProcessDumpEvent(const GSData& event, u8* regs);
+		void ProcessDumpEvent(const GSDumpFile::GSData& event, u8* regs);
 		u32 ReadPacketSize(const void* packet);
 		void GenPacketList();
-		void GenPacketInfo(GSData& dump);
+		void GenPacketInfo(const GSDumpFile::GSData& dump);
 		void ParseTransfer(wxTreeItemId& id, u8* data);
-		void ParseTreeReg(wxTreeItemId& id, GIFReg reg, u128 data, bool packed);
+		void ParseTreeReg(wxTreeItemId& id, GSDumpTypes::GIFReg reg, u128 data, bool packed);
 		void ParseTreePrim(wxTreeItemId& id, u32 prim);
 		void CloseDump(wxCommandEvent& event);
 		class GSThread : public pxThread

--- a/pcsx2/gui/Dialogs/ModalPopups.h
+++ b/pcsx2/gui/Dialogs/ModalPopups.h
@@ -145,7 +145,7 @@ namespace Dialogs
 		u32 ReadPacketSize(const void* packet);
 		void GenPacketList();
 		void GenPacketInfo(const GSDumpFile::GSData& dump);
-		void ParseTransfer(wxTreeItemId& id, u8* data);
+		void ParseTransfer(wxTreeItemId& id, const u8* data);
 		void ParseTreeReg(wxTreeItemId& id, GSDumpTypes::GIFReg reg, u128 data, bool packed);
 		void ParseTreePrim(wxTreeItemId& id, u32 prim);
 		void CloseDump(wxCommandEvent& event);

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="GameDatabase.cpp" />
     <ClCompile Include="Gif_Logger.cpp" />
     <ClCompile Include="Gif_Unit.cpp" />
+    <ClCompile Include="GSDumpReplayer.cpp" />
     <ClCompile Include="GS\Renderers\DX11\D3D.cpp" />
     <ClCompile Include="GS\Renderers\HW\GSTextureReplacementLoaders.cpp" />
     <ClCompile Include="GS\Renderers\HW\GSTextureReplacements.cpp" />
@@ -488,6 +489,7 @@
     <ClInclude Include="Frontend\XInputSource.h" />
     <ClInclude Include="GameDatabase.h" />
     <ClInclude Include="Gif_Unit.h" />
+    <ClInclude Include="GSDumpReplayer.h" />
     <ClInclude Include="GS\Renderers\DX11\D3D.h" />
     <ClInclude Include="GS\Renderers\HW\GSTextureReplacements.h" />
     <ClInclude Include="GS\Window\GSwxDialog.h" />

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -1202,6 +1202,7 @@
     <ClCompile Include="x86\iR5900Analysis.cpp">
       <Filter>System\Ps2\EmotionEngine\EE\Dynarec</Filter>
     </ClCompile>
+    <ClCompile Include="GSDumpReplayer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Patch.h">
@@ -1985,6 +1986,7 @@
     <ClInclude Include="x86\iR5900Analysis.h">
       <Filter>System\Ps2\EmotionEngine\EE\Dynarec</Filter>
     </ClInclude>
+    <ClInclude Include="GSDumpReplayer.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="GS\GS.rc">


### PR DESCRIPTION
### Description of Changes

What the title says. Currently based on the gamedb PR (hopefully can be merged soon).

Also makes the boot filename detection not suck (you can boot an elf from the command line without using `-elf` now).

### Rationale behind Changes

Adding features.

### Suggested Testing Steps

Make sure GS dump playback in wx is unaffected. It shouldn't be (I just moved the functions to the core instead of gui).