### PR TITLE
GameDB: Transformers Armada: Prelude to Energon

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7538,12 +7538,24 @@ SLED-52375:
 SLED-52441:
   name: "Transformers [Demo]"
   region: "PAL-E"
+  gameFixes:
+    - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLED-52473:
   name: "Transformers - Optimus Prime [Demo]"
   region: "PAL-E"
+  gameFixes:
+    - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLED-52474:
   name: "Transformers - Red Alert [Demo]"
   region: "PAL-E"
+  gameFixes:
+    - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLED-52476:
   name: "UEFA Euro 2004 - Portugal [Demo]"
   region: "PAL-M5"
@@ -12297,6 +12309,8 @@ SLES-52388:
   compat: 5
   gameFixes:
     - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLES-52392:
   name: "Combat Elite - WWII Paratroopers [Preview]"
   region: "PAL-E"
@@ -14195,6 +14209,8 @@ SLES-53309:
   region: "PAL-M5"
   gameFixes:
     - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLES-53311:
   name: "Graffiti Kingdom"
   region: "PAL-M5"
@@ -36512,6 +36528,8 @@ SLUS-20668:
   compat: 5
   gameFixes:
     - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLUS-20669:
   name: "Resident Evil - Dead Aim"
   region: "NTSC-U"
@@ -42173,6 +42191,10 @@ SLUS-28039:
 SLUS-28040:
   name: "Transformers [Trade Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLUS-28043:
   name: "Test Drive - Eve of Destruction [Trade Demo]"
   region: "NTSC-U"
@@ -42503,6 +42525,10 @@ SLUS-29104:
 SLUS-29107:
   name: "Transformers [Regular Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - VIFFIFOHack
+  speedHacks:
+    MTVUSpeedHack: 0
 SLUS-29108:
   name: "Def Jam - Fight For NY [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Adds missing VIFFIFO + force disabling MTVU for not getting black screen
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering, happier users
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Use the correct Transformers game
Fixes https://github.com/PCSX2/pcsx2/issues/1669 (for the most part)