### PR TITLE
GameDB: Auto GS HW renderer fixes for some NAMCO games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -716,6 +716,8 @@ SCAJ-20125:
   region: "NTSC-Unk"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove
+  gsHWFixes:
+    alignSprite: 1
 SCAJ-20126:
   name: "Tekken 5"
   region: "NTSC-Unk"
@@ -3095,6 +3097,8 @@ SCES-53202:
   compat: 5
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SCES-53247:
   name: "WRC Rally Evolved"
   region: "PAL-M8"
@@ -4110,6 +4114,8 @@ SCKA-20038:
 SCKA-20039:
   name: "Tekken Nina Williams In Death By Degree"
   region: "NTSC-K"
+  gsHWFixes:
+    alignSprite: 1
 SCKA-20040:
   name: "Jak 3"
   region: "NTSC-K"
@@ -4141,6 +4147,8 @@ SCKA-20049:
   region: "NTSC-K"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SCKA-20050:
   name: "Tales of Legendia"
   region: "NTSC-K"
@@ -4261,6 +4269,8 @@ SCKA-20081:
   region: "NTSC-K"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SCKA-20086:
   name: "Shin Onimusha - Dawn of Dreams [Disc1of2]"
   region: "NTSC-K"
@@ -32196,6 +32206,8 @@ SLPS-25510:
   compat: 5
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SLPS-25511:
   name: "Rasetsu Alternative"
   region: "NTSC-J"
@@ -33804,6 +33816,8 @@ SLPS-73223:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SLPS-73224:
   name: "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc1of2]"
   region: "NTSC-J"
@@ -38564,6 +38578,8 @@ SLUS-21059:
   compat: 5
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SLUS-21060:
   name: "WWE SmackDown! vs. RAW"
   region: "NTSC-U"
@@ -38984,6 +39000,8 @@ SLUS-21160:
   region: "NTSC-U"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+  gsHWFixes:
+    alignSprite: 1
 SLUS-21161:
   name: "Fight Night - Round 2"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -721,6 +721,8 @@ SCAJ-20126:
   region: "NTSC-Unk"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove
+  gsHWFixes:
+    alignSprite: 1
 SCAJ-20127:
   name: "EyeToy - Play 2 [with Camera]"
   region: "NTSC-Unk"
@@ -1024,6 +1026,8 @@ SCAJ-20199:
   region: "NTSC-Unk"
   clampModes:
     eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove
+  gsHWFixes:
+    alignSprite: 1
 SCAJ-25002:
   name: "Shinobi"
   region: "NTSC-Unk"
@@ -1193,6 +1197,8 @@ SCCS-60002:
 SCED-50041:
   name: "Tekken Tag Tournament [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    alignSprite: 1
 SCED-50065:
   name: "Official PlayStation 2 Magazine Demo 1"
   region: "PAL-M5"
@@ -2159,6 +2165,8 @@ SCES-50001:
   name: "Tekken Tag Tournament"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SCES-50002:
   name: "FantaVision"
   region: "PAL-M5"
@@ -2430,6 +2438,8 @@ SCES-50878:
   name: "Tekken 4"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SCES-50885:
   name: "Ape Escape 2"
   region: "PAL-E"
@@ -5476,6 +5486,8 @@ SCPS-55017:
   name: "Tekken 4"
   region: "NTSC-J"
   compat: 3
+  gsHWFixes:
+    alignSprite: 1
 SCPS-55018:
   name: "Kingdom of Scribbling"
   region: "NTSC-J"
@@ -5646,6 +5658,8 @@ SCPS-56002:
   name: "Tekken Tag Tournament"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SCPS-56003:
   name: "Jak and Daxter: The Precursor Legacy"
   region: "NTSC-K"
@@ -5659,6 +5673,8 @@ SCPS-56006:
   name: "Tekken 4"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SCPS-56008:
   name: "Fatal Frame"
   region: "NTSC-K"
@@ -29477,6 +29493,8 @@ SLPS-20015:
   name: "Tekken Tag Tournament"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SLPS-20016:
   name: "Dream Audition"
   region: "NTSC-J"
@@ -30854,6 +30872,8 @@ SLPS-25100:
   name: "Tekken 4"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SLPS-25102:
   name: "Project Arms"
   region: "NTSC-J"
@@ -33667,6 +33687,8 @@ SLPS-73103:
 SLPS-73104:
   name: "Tekken Tag Tournament [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1
 SLPS-73105:
   name: "Kinnikuman Generations [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -33732,6 +33754,8 @@ SLPS-73208:
 SLPS-73209:
   name: "Tekken 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1
 SLPS-73210:
   name: "Katamari Damacy [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -34120,6 +34144,8 @@ SLUS-20001:
   name: "Tekken Tag Tournament"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SLUS-20002:
   name: "Ridge Racer V"
   region: "NTSC-U"
@@ -35330,6 +35356,8 @@ SLUS-20328:
   name: "Tekken 4"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SLUS-20329:
   name: "Pro Race Driver"
   region: "NTSC-U"
@@ -42427,6 +42455,8 @@ SLUS-28010:
 SLUS-28012:
   name: "Tekken 4 [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    alignSprite: 1
 SLUS-28013:
   name: "Dual Hearts [Trade Demo]"
   region: "NTSC-U"
@@ -42645,6 +42675,8 @@ SLUS-29033:
 SLUS-29034:
   name: "Tekken 4 [Regular Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    alignSprite: 1
 SLUS-29035:
   name: "Eidos Demo Disc"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes

Just added some auto GS HW renderer fixes to GameDB for a fews NAMCO games:

- Tekken 4
- Tekken 5
- Tekken Tag Tournament

It's the "vertical lines" fix.

### Rationale behind Changes

Based on comments from https://github.com/PCSX2/pcsx2/pull/5593:

> **Description of Changes**
> 
> This PR allows automatic GS hardware fixes (trying to avoid the word hack) to be applied from the game database, which will significantly improve the user experience over time since they won't have to go looking at the wiki for what upscaling fixes to apply.
> 
> I've done a few games (GTA: SA, GoW/GoW2), but there'll be many others. I'll leave that to the rest of the community :)

Just trying to help.

### Suggested Testing Steps

Test games.