### PR TITLE
GS/VertexTrace: Fix min/max when last provoking vertex unsupported

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -48,7 +48,7 @@ protected:
 
 	FindMinMaxPtr m_fmm[2][2][2][2][4];
 
-	template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color>
+	template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color, bool provoking_vertex_first>
 	void FindMinMax(const void* vertex, const u32* index, int count);
 
 public:
@@ -73,7 +73,7 @@ public:
 	GSVector2 m_lod; // x = min, y = max
 
 public:
-	GSVertexTrace(const GSState* state);
+	GSVertexTrace(const GSState* state, bool provoking_vertex_first);
 	virtual ~GSVertexTrace() {}
 
 	void Update(const void* vertex, const u32* index, int v_count, int i_count, GS_PRIM_CLASS primclass);


### PR DESCRIPTION
### Description of Changes
This was causing incorrect min/max alpha values due to the index swap, which caused the sides of text boxes in KH to disappear (because the alpha test optimized to always failing).

Closes #5639.

### Rationale behind Changes
Fixing my regressions :(

### Suggested Testing Steps
Check KH, and any other games sensitive to IIP=0/provoking vertex last (I've quickly checked Tony Hawk's American Wasteland).