### PR TITLE
GameDB: GS HW renderer fixes for Tales of the Abyss

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -881,6 +881,8 @@ SCAJ-20162:
 SCAJ-20163:
   name: "Tales of the Abyss"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 2
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
@@ -28706,6 +28708,8 @@ SLPM-66896:
 SLPM-66897:
   name: "Tales of the Abyss"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2
 SLPM-66898:
   name: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
@@ -32428,6 +32432,8 @@ SLPS-25586:
   name: "Tales of the Abyss"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2
 SLPS-25587:
   name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
@@ -33973,6 +33979,8 @@ SLPS-73251:
 SLPS-73252:
   name: "Tales of the Abyss [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2
 SLPS-73253:
   name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -40082,6 +40090,8 @@ SLUS-21386:
   name: "Tales of the Abyss"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Added Half-Pixel Offset: Special (Texture) to fix ghosting when you're upscaling. The wiki mentions black boxes as an issue too and suggests Workarounds (Trilinear + Mipmapping Full). However I can't reproduce the issue when Half-Pixel Offset is set to Special (Texture).

### Rationale behind Changes
Upscaling goodness & helping out the GameDB

### Suggested Testing Steps
Test Abyss. Bad ghosting shouldn't occur.
