### PR TITLE
GameDB: Upscaling GS Batch 1

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -20,22 +20,22 @@ allowed_game_options = [
 allowed_round_modes = ["eeRoundMode", "vuRoundMode"]
 allowed_clamp_modes = ["eeClampMode", "vuClampMode"]
 allowed_game_fixes = [
-    "VuAddSubHack",
-    "FpuCompareHack",
     "FpuMulHack",
     "FpuNegDivHack",
-    "XGKickHack",
-    "EETimingHack",
+    "GoemonTlbHack",
+    "SoftwareRendererFMVHack",
     "SkipMPEGHack",
     "OPHFlagHack",
+    "EETimingHack",
     "DMABusyHack",
+    "GIFFIFOHack",
     "VIFFIFOHack",
     "VIF1StallHack",
-    "GIFFIFOHack",
-    "GoemonTlbHack",
-    "VUSyncHack",
+    "VuAddSubHack",
     "IbitHack",
+    "VUSyncHack",
     "VUOverflowHack",
+    "XGKickHack",
 ]
 allowed_gs_hw_fixes = [
     "autoFlush",

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -223,6 +223,8 @@ SCAJ-10011:
 SCAJ-10012:
   name: "Taiko Drum Master"
   region: "NTSC-Unk"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCAJ-10013:
   name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
   region: "NTSC-Unk"
@@ -471,6 +473,8 @@ SCAJ-20067:
 SCAJ-20068:
   name: "Final Fantasy X-2 International"
   region: "NTSC-Unk"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SCAJ-20069:
   name: "Gallop Racer - Lucky 7"
   region: "NTSC-Unk"
@@ -520,6 +524,8 @@ SCAJ-20078:
   region: "NTSC-Unk"
   roundModes:
     eeRoundMode: 0  # Fixes Sugoroku mini-game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SCAJ-20079:
   name: "Katamari Damacy"
   region: "NTSC-Unk"
@@ -828,6 +834,8 @@ SCAJ-20148:
 SCAJ-20149:
   name: "Kingdom Hearts - Final Mix [Ultimate Hits]"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCAJ-20150:
   name: "Critical Velocity"
   region: "NTSC-Unk"
@@ -888,6 +896,8 @@ SCAJ-20163:
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCAJ-20165:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-Unk"
@@ -1036,12 +1046,16 @@ SCAJ-25002:
 SCAJ-25004:
   name: "Kingdom Hearts - Final Mix"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCAJ-25008:
   name: "Initial D - Street Stage"
   region: "NTSC-Unk"
 SCAJ-25012:
   name: "Final Fantasy X-2"
   region: "NTSC-Unk"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
@@ -2251,6 +2265,8 @@ SCES-50295:
   compat: 5
   gsHWFixes:
     mipmap: 1
+  gsHWFixes:
+    halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCES-50300:
   name: "Time Crisis 2"
   region: "PAL-M5"
@@ -2482,11 +2498,15 @@ SCES-50934:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes texture misalignment.
 SCES-50935:
   name: "WRC II Extreme"
   region: "PAL-Unk"
   gameFixes:
     - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes texture misalignment.
 SCES-50956:
   name: "Ferrari F355 Challenge"
   region: "PAL-M5"
@@ -2502,21 +2522,31 @@ SCES-50967:
   name: "Kingdom Hearts"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCES-50968:
   name: "Kingdom Hearts"
   region: "PAL-F"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCES-50969:
   name: "Kingdom Hearts"
   region: "PAL-G"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCES-50970:
   name: "Kingdom Hearts"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCES-50971:
   name: "Kingdom Hearts"
   region: "PAL-S"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SCES-50982:
   name: "MotoGP 3"
   region: "PAL-M5"
@@ -4283,6 +4313,8 @@ SCKA-20090:
   name: "God Hand"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
 SCKA-20092:
   name: "K-1 World Grand Prix 2006"
   region: "NTSC-K"
@@ -4521,6 +4553,8 @@ SCPS-15004:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
+  gsHWFixes:
+    halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-15005:
   name: "Phase Paradox"
   region: "NTSC-J"
@@ -4578,6 +4612,8 @@ SCPS-15019:
 SCPS-15020:
   name: "Legaia 2 - Duel Saga"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SCPS-15021:
   name: "Jak x Daxter: Kyuusekai no Isan"
   region: "NTSC-J"
@@ -4645,9 +4681,13 @@ SCPS-15037:
 SCPS-15038:
   name: "Operator's Side"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCPS-15039:
   name: "Operator's Side"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCPS-15040:
   name: "Arc the Lad - Twilight of the Spirits [Limited Edition]"
   region: "NTSC-J"
@@ -5140,6 +5180,8 @@ SCPS-19203:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
+  gsHWFixes:
+    halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCPS-19204:
   name: "Legaia - Duel Saga [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5176,9 +5218,13 @@ SCPS-19211:
 SCPS-19213:
   name: "Operator's Side [PlayStation 2 The Best] [with Microphone]"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCPS-19214:
   name: "Operator's Side [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCPS-19215:
   name: "Dark Chronicle [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5602,6 +5648,8 @@ SCPS-55042:
 SCPS-55043:
   name: "Fatal Frame"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness.
 SCPS-55044:
   name: "Energy Airforce"
   region: "NTSC-J"
@@ -5699,6 +5747,8 @@ SCPS-56008:
         comment=- This can be fixed by having 'Enable HW Hacks' set
         comment=-  in the GSdx configuration dialog, and having 'Align Sprite' set
         comment=-  and 'Sprite' set to Half in 'Advanced Settings and Hacks'.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness.
 SCPS-56011:
   name: "U - Underwater Unit"
   region: "NTSC-J"
@@ -5773,6 +5823,8 @@ SCUS-97111:
   compat: 5
   gsHWFixes:
     mipmap: 1
+  gsHWFixes:
+    halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCUS-97112:
   name: "Extermination"
   region: "NTSC-U"
@@ -5929,6 +5981,8 @@ SCUS-97152:
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
+  gsHWFixes:
+    halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 SCUS-97153:
   name: "Vans Warped Tour '01 [Demo]"
   region: "NTSC-U"
@@ -7402,6 +7456,8 @@ SLAJ-25003:
 SLAJ-25004:
   name: "Kingdom Hearts - Final Mix"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLAJ-25005:
   name: "World Soccer Winning Eleven 7"
   region: "NTSC-Unk"
@@ -7420,6 +7476,8 @@ SLAJ-25011:
 SLAJ-25012:
   name: "Final Fantasy X-2"
   region: "NTSC-Unk"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLAJ-25014:
   name: "Cyber Troopers - Virtual-On Marz"
   region: "NTSC-Unk"
@@ -7488,6 +7546,8 @@ SLAJ-25053:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLAJ-25055:
   name: "Def Jam - Fight for N.Y."
   region: "NTSC-Unk"
@@ -7517,6 +7577,8 @@ SLAJ-25066:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -7607,9 +7669,14 @@ SLAJ-25094:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLAJ-25095:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
+    mergeSprite: 1 # Removes occasional vertical lines.
 SLAJ-25096:
   name: "Musou Orochi"
   region: "NTSC-Unk"
@@ -7709,6 +7776,8 @@ SLED-52488:
 SLED-52597:
   name: "Burnout 3 - Takedown [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLED-52875:
   name: "Sega Superstars [Demo]"
   region: "PAL-E"
@@ -9205,6 +9274,8 @@ SLES-50722:
 SLES-50723:
   name: "TOCA Race Driver"
   region: "PAL-M3"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLES-50725:
   name: "V-Rally 3"
   region: "PAL-M5"
@@ -9439,6 +9510,8 @@ SLES-50821:
         comment=- This can be fixed by having 'Enable HW Hacks' set
         comment=-  in the GSdx configuration dialog, and having 'Align Sprite' set
         comment=-  and 'Sprite' set to Half in 'Advanced Settings and Hacks'.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLES-50822:
   name: "Shadow Hearts"
   region: "PAL-M3"
@@ -9645,6 +9718,8 @@ SLES-50886:
 SLES-50891:
   name: "Legaia 2 - Duel Saga"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SLES-50892:
   name: "Lethal Skies Elite Pilot - Team SW"
   region: "PAL-M5"
@@ -10062,6 +10137,8 @@ SLES-51114:
 SLES-51117:
   name: "Colin McRae Rally 3"
   region: "PAL-M5"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51118:
   name: "Wizardry - Tales of the Forsaken Land"
   region: "PAL-E"
@@ -11266,6 +11343,8 @@ SLES-51754:
 SLES-51755:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-E"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51756:
   name: "Batman 2 - The Rise of Sin Tzu"
   region: "PAL-M5"
@@ -11353,20 +11432,30 @@ SLES-51815:
   name: "Final Fantasy X-2"
   region: "PAL-E"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLES-51816:
   name: "Final Fantasy X-2"
   region: "PAL-F"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLES-51817:
   name: "Final Fantasy X-2"
   region: "PAL-G"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLES-51818:
   name: "Final Fantasy X-2"
   region: "PAL-I"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLES-51819:
   name: "Final Fantasy X-2"
   region: "PAL-S"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLES-51820:
   name: "Sniper Elite"
   region: "PAL-M5"
@@ -11384,6 +11473,8 @@ SLES-51823:
 SLES-51824:
   name: "Colin McRae Rally '04"
   region: "PAL-M5"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51825:
   name: "Pop Idol"
   region: "PAL-E"
@@ -11508,13 +11599,19 @@ SLES-51869:
 SLES-51870:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-FI-S"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51871:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-F-G"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51872:
   name: "Disney-Pixar's Finding Nemo"
   region: "PAL-M3"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-51873:
   name: "Medal of Honor - Rising Sun"
   region: "PAL-M5"
@@ -12347,6 +12444,8 @@ SLES-52322:
   compat: 5
   clampModes:
     eeClampMode: 3  # Characters are visible in-game.
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and textures wrong.
 SLES-52323:
   name: "Richard Burns Rally"
   region: "PAL-M5"
@@ -12872,6 +12971,8 @@ SLES-52568:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLES-52569:
   name: "Spyro - A Hero's Tail"
   region: "PAL-M6"
@@ -12909,11 +13010,15 @@ SLES-52584:
   compat: 5
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLES-52587:
   name: "Army Men - Sarge's War"
   region: "PAL-M5"
@@ -13011,10 +13116,12 @@ SLES-52636:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes incorrect colors.
 SLES-52637:
   name: "TOCA Racer Driver 2"
   region: "PAL-M5"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-52638:
   name: "DTM Race Driver 2"
   region: "PAL-M5"
@@ -13110,6 +13217,8 @@ SLES-52669:
   name: "Forgotten Realms - Demon Stone"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLES-52670:
   name: "Second Sight"
   region: "PAL-M5"
@@ -13316,6 +13425,8 @@ SLES-52767:
 SLES-52768:
   name: "Commandos - Strike Force"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-52773:
   name: "Pool Shark 2"
   region: "PAL-M5"
@@ -13959,6 +14070,8 @@ SLES-53038:
   compat: 5
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLES-53039:
   name: "Champions - Return to Arms" # aka "Champions of Norrath 2"
   region: "PAL-M4"
@@ -14053,6 +14166,8 @@ SLES-53087:
   name: "TOCA Race Driver 3"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLES-53088:
   name: "DTM Race Driver 3"
   region: "PAL-M5"
@@ -14140,6 +14255,8 @@ SLES-53125:
   clampModes:
     eeClampMode: 3
     vuClampMode: 3 
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLES-53127:
   name: "Teenage Mutant Ninja Turtles - Mutant Melee"
   region: "PAL-M5"
@@ -14636,6 +14753,8 @@ SLES-53411:
   region: "PAL-M3"
   roundModes:
     eeRoundMode: 0  # Fixes Sugoroku mini-game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SLES-53413:
   name: "Rebel Raiders - Operation Nighthawk"
   region: "PAL-M5"
@@ -14843,6 +14962,8 @@ SLES-53507:
   compat: 5
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -15169,11 +15290,15 @@ SLES-53616:
   region: "PAL-E"
   clampModes:
     eeClampMode: 2  # Fixes SPS on highway.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLES-53618:
   name: "True Crime - New York City"
   region: "PAL-S"
   clampModes:
     eeClampMode: 2  # Fixes SPS on highway.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLES-53621:
   name: "Wallace & Grommit - The Curse of the Were Rabbit"
   region: "PAL-M5"
@@ -15589,6 +15714,9 @@ SLES-53794:
   region: "PAL-M3"
   clampModes:
     eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting characters.
+    mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
 SLES-53796:
   name: "FIFA Street 2"
   region: "PAL-E"
@@ -16209,6 +16337,8 @@ SLES-54114:
   name: "Kingdom Hearts II"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLES-54115:
   name: "Delta Force - Black Hawk Down - Team Sabre"
   region: "PAL-M5"
@@ -16429,6 +16559,8 @@ SLES-54186:
   region: "PAL-M5"
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLES-54187:
   name: "Real World Golf 2007"
   region: "PAL-M3"
@@ -16530,15 +16662,23 @@ SLES-54231:
 SLES-54232:
   name: "Kingdom Hearts II"
   region: "PAL-F"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLES-54233:
   name: "Kingdom Hearts II"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLES-54234:
   name: "Kingdom Hearts II"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLES-54235:
   name: "Kingdom Hearts II"
   region: "PAL-S"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLES-54237:
   name: "Pirates of the Caribbean - The Legend of Jack Sparrow"
   region: "PAL-M5"
@@ -16768,6 +16908,8 @@ SLES-54359:
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,001849b8,word,00000000
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54360:
   name: "Pro Evolution Soccer 6"
   region: "PAL-F"
@@ -17130,6 +17272,8 @@ SLES-54490:
   name: "God Hand"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
 SLES-54492:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-E"
@@ -17384,6 +17528,8 @@ SLES-54627:
   compat: 5
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLES-54628:
   name: "Skate Attack [Promo]"
   region: "PAL-E"
@@ -17529,9 +17675,14 @@ SLES-54681:
   region: "PAL-E"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLES-54683:
   name: "Medal of Honor - Vanguard"
   region: "PAL-M9"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
+    mergeSprite: 1 # Removes occasional vertical lines.
 SLES-54684:
   name: "Peter Pan"
   region: "PAL-M3"
@@ -17609,6 +17760,8 @@ SLES-54727:
   region: "PAL-M5"
   gameFixes:
     - OPHFlagHack
+  gsHWFixes:
+    mergeSprite: 1 # Fixes blurry bloom.
 SLES-54728:
   name: "Mountain Bike Adrenaline featuring Salomon"
   region: "PAL-M5"
@@ -17808,6 +17961,8 @@ SLES-54815:
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,00173c38,word,00000000
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54816:
   name: "Legend of Spyro, The - The Eternal Night"
   region: "PAL-R"
@@ -17818,6 +17973,8 @@ SLES-54816:
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,00173bb8,word,00000000
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54817:
   name: "Garfield - Lasagna World Tour"
   region: "PAL-M5"
@@ -18203,12 +18360,18 @@ SLES-54984:
 SLES-54986:
   name: "Bratz - The Movie"
   region: "PAL-E-F"
+  gsHWFixes:
+    halfPixelOffset: 3 # Removes ghosting of bloom and shadows.
 SLES-54988:
   name: "Bratz - The Movie"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 3 # Removes ghosting of bloom and shadows.
 SLES-54989:
   name: "Bratz - The Movie"
   region: "PAL-I-S"
+  gsHWFixes:
+    halfPixelOffset: 3 # Removes ghosting of bloom and shadows.
 SLES-54990:
   name: "Nicktoons - Attack of the Toybots"
   region: "PAL-A"
@@ -18544,6 +18707,8 @@ SLES-55152:
 SLES-55163:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "PAL-M6"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLES-55165:
   name: "Mummy, The - Tomb of the Dragon Emperor"
   region: "PAL-M6"
@@ -18695,6 +18860,8 @@ SLES-55220:
 SLES-55227:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLES-55231:
   name: "Fatal Fury - Battle Archives Volume 1"
   region: "PAL-E"
@@ -18755,11 +18922,13 @@ SLES-55248:
   region: "PAL-M6"
   gsHWFixes:
     mipmap: 1
+    halfPixelOffset: 1 # Reduces ghosting and vertical lines.
 SLES-55249:
   name: "Harry Potter and the Half-Blood Prince"
   region: "PAL-M10"
   gsHWFixes:
     mipmap: 1
+    halfPixelOffset: 1 # Reduces ghosting and vertical lines.
 SLES-55250:
   name: "WWE SmackDown vs. Raw 2009"
   region: "PAL-A"
@@ -18792,6 +18961,8 @@ SLES-55264:
 SLES-55265:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "PAL-R-E"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLES-55266:
   name: "MotoGP 08"
   region: "PAL-M5"
@@ -19935,6 +20106,8 @@ SLKA-25144:
   name: "Final Fantasy X-2"
   region: "NTSC-K"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLKA-25149:
   name: "Silent Hill 4 The Room"
   region: "NTSC-K"
@@ -20036,6 +20209,8 @@ SLKA-25205:
 SLKA-25206:
   name: "Burnout 3: Takedown"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLKA-25207:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild"
   region: "NTSC-K"
@@ -20125,6 +20300,8 @@ SLKA-25251:
 SLKA-25252:
   name: "Forgotten Realms - Demon Stone"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLKA-25254:
   name: "Digimon Rumble Arena 2"
   region: "NTSC-K"
@@ -20164,6 +20341,8 @@ SLKA-25265:
   region: "NTSC-K"
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLKA-25266:
   name: "Sangokushi IX [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
@@ -20249,6 +20428,8 @@ SLKA-25313:
   compat: 5
   gameFixes:
     - OPHFlagHack
+  gsHWFixes:
+    mergeSprite: 1 # Fixes blurry bloom.
 SLKA-25314:
   name: "Kidou Senshi Gundam SEED: Rengou vs. Z.A.F.T."
   region: "NTSC-K"
@@ -20654,6 +20835,8 @@ SLPM-60251:
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLPM-60254:
   name: "Zettai Zetsumei Toshi 2: Itetsuita Kioku-tachi [Trial A]"
   region: "NTSC-J"
@@ -24218,6 +24401,8 @@ SLPM-65478:
   name: "Final Fantasy X-2 International"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLPM-65479:
   name: "Sims, The - Bustin' Out"
   region: "NTSC-J"
@@ -24755,6 +24940,8 @@ SLPM-65654:
 SLPM-65655:
   name: "Finding Nemo [Yuke's The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPM-65657:
   name: "World Soccer Winning Eleven 8"
   region: "NTSC-J"
@@ -24938,6 +25125,8 @@ SLPM-65719:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65720:
   name: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
@@ -25457,6 +25646,8 @@ SLPM-65880:
   compat: 5
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLPM-65881:
   name: "SmackDown vs. Raw - Exciting Professional Wrestling 6"
   region: "NTSC-J"
@@ -25603,6 +25794,8 @@ SLPM-65926:
 SLPM-65927:
   name: "Forgotten Realms - Demon Stone"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPM-65928:
   name: "SuperLite 2000 Series - Memories Off Mix"
   region: "NTSC-J"
@@ -25664,6 +25857,8 @@ SLPM-65948:
   clampModes:
     eeClampMode: 3 # Fixes Freezing at the start of the race
     vuClampMode: 3 # Fixes Freezing at the start of the race
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPM-65949:
   name: "Get Ride! AM Driver - The Truth of Xiangke"
   region: "NTSC-J"
@@ -25694,6 +25889,8 @@ SLPM-65958:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65959:
   name: "Standard Daisenryaku - Ushinawareta Shoeri"
   region: "NTSC-J"
@@ -26169,6 +26366,8 @@ SLPM-66108:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -26205,9 +26404,13 @@ SLPM-66117:
 SLPM-66122:
   name: "Kingdom Hearts [Ultimate Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPM-66123:
   name: "Kingdom Hearts - Final Mix [Ultimate Hits]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPM-66124:
   name: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
@@ -26216,6 +26419,8 @@ SLPM-66124:
 SLPM-66125:
   name: "Final Fantasy X-2 [Ultimate Hits]"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLPM-66129:
   name: "Guilty Gear XX #Reload"
   region: "NTSC-J"
@@ -26322,6 +26527,8 @@ SLPM-66160:
   compat: 5
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLPM-66163:
   name: "Fuuraiki 2"
   region: "NTSC-J"
@@ -26569,6 +26776,8 @@ SLPM-66233:
   name: "Kingdom Hearts II"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPM-66234:
   name: "Wizardry X - Zensen no Gakufu [Wonder Price]"
   region: "NTSC-J"
@@ -26638,6 +26847,8 @@ SLPM-66257:
   clampModes:
     eeClampMode: 3
     vuClampMode: 3
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPM-66258:
   name: "Magic Teacher Negima - Honor Version [Konami The Best]"
   region: "NTSC-J"
@@ -27367,6 +27578,8 @@ SLPM-66473:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2  # Fixes SPS on highway.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLPM-66474:
   name: "Odin Sphere"
   region: "NTSC-J"
@@ -27432,6 +27645,8 @@ SLPM-66491:
 SLPM-66492:
   name: "Commandos Strike Force"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLPM-66493:
   name: "Shinten Makai - Generation of Chaos V [IF Collection]"
   region: "NTSC-J"
@@ -27463,6 +27678,8 @@ SLPM-66497:
 SLPM-66498:
   name: "TOCA Race Driver 2 - Ultimate Racing Simulator"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLPM-66499:
   name: "Kamisama Kazoku - Ouen Ganbou"
   region: "NTSC-J"
@@ -27606,6 +27823,8 @@ SLPM-66550:
   name: "God Hand"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
 SLPM-66551:
   name: "Appleseed EX"
   region: "NTSC-J"
@@ -27938,6 +28157,8 @@ SLPM-66652:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -28026,6 +28247,8 @@ SLPM-66675:
   name: "Kingdom Hearts II - Final Mix +"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
   memcardFilters: # Reads Re:Chain data and vice-versa.
     - "SLPM-66675"
     - "SLPM-66676"
@@ -28044,6 +28267,8 @@ SLPM-66677:
 SLPM-66678:
   name: "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLPM-66679:
   name: "Devil Summoner: Kuzunoha Raidou tai Abaddon Ou [Plus]"
   region: "NTSC-J"
@@ -28263,6 +28488,8 @@ SLPM-66739:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLPM-66740:
   name: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
@@ -28309,6 +28536,9 @@ SLPM-66751:
 SLPM-66752:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
+    mergeSprite: 1 # Removes occasional vertical lines.
 SLPM-66753:
   name: "Getsumento Heiki Mina - Futatsu no Project M [Limited Edition]"
   region: "NTSC-J"
@@ -28684,6 +28914,8 @@ SLPM-66880:
 SLPM-66881:
   name: "TOCA Race Driver 3 - Ultimate Racing Simulator"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLPM-66882:
   name: "Hakarena Heart [Limited Edition]"
   region: "NTSC-J"
@@ -28919,6 +29151,8 @@ SLPM-66962:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLPM-66963:
   name: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
@@ -29319,16 +29553,22 @@ SLPM-74240:
 SLPM-74241:
   name: "God Hand [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
 SLPM-74242:
   name: "Devil May Cry 3 [Special Edition] [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLPM-74243:
   name: "True Crime - New York City [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2  # Fixes SPS on highway.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLPM-74244:
   name: "Phantasy Star Universe [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -30275,10 +30515,14 @@ SLPS-20412:
 SLPS-20413:
   name: "Taiko no Tatsujin - Taiko Drum Masters [with Drum Controller]"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPS-20414:
   name: "Taiko no Tatsujin - Taiko Drum Masters"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPS-20416:
   name: "Inyou Taisenki - Byakko Enbu [with EyeToy]"
   region: "NTSC-J"
@@ -30820,6 +31064,8 @@ SLPS-25074:
         comment=- This can be fixed by having 'Enable HW Hacks' set
         comment=-  in the GSdx configuration dialog, and having 'Align Sprite' set
         comment=-  and 'Sprite' set to Half in 'Advanced Settings and Hacks'.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLPS-25075:
   name: "Sidewinder F"
   region: "NTSC-J"
@@ -30898,6 +31144,8 @@ SLPS-25104:
 SLPS-25105:
   name: "Kingdom Hearts"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPS-25106:
   name: "America Oudan Ultra-Quiz"
   region: "NTSC-J"
@@ -31177,10 +31425,14 @@ SLPS-25196:
 SLPS-25197:
   name: "Kingdom Hearts - Final Mix [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPS-25198:
   name: "Kingdom Hearts - Final Mix"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLPS-25199:
   name: "Unlimited Saga"
   region: "NTSC-J"
@@ -31334,6 +31586,8 @@ SLPS-25248:
 SLPS-25250:
   name: "Final Fantasy X-2"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLPS-25251:
   name: "MVP Baseball 2003"
   region: "NTSC-J"
@@ -31493,6 +31747,8 @@ SLPS-25309:
 SLPS-25310:
   name: "Disney-Pixar's Finding Nemo"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPS-25311:
   name: "Spy Fiction"
   region: "NTSC-J"
@@ -31544,6 +31800,8 @@ SLPS-25329:
   compat: 5
   roundModes:
     eeRoundMode: 0  # Fixes Sugoroku mini-game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SLPS-25330:
   name: "Dragon Ball Z - Budokai 2"
   region: "NTSC-J"
@@ -34022,6 +34280,8 @@ SLPS-73254:
 SLPS-73255:
   name: "Fatal Frame [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness.
 SLPS-73256:
   name: "Fatal Frame II - Crimson Butterfly [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
@@ -35530,6 +35790,8 @@ SLUS-20370:
   name: "Kingdom Hearts"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLUS-20371:
   name: "Thing, The"
   region: "NTSC-U"
@@ -35621,6 +35883,8 @@ SLUS-20388:
         comment=- This can be fixed by having 'Enable HW Hacks' set
         comment=-  in the GSdx configuration dialog, and having 'Align Sprite' set
         comment=-  and 'Sprite' set to Half in 'Advanced Settings and Hacks'.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness.
 SLUS-20389:
   name: "Endgame"
   region: "NTSC-U"
@@ -35735,6 +35999,8 @@ SLUS-20414:
   name: "Legaia 2 - Duel Saga"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SLUS-20415:
   name: "BMX XXX"
   region: "NTSC-U"
@@ -36128,6 +36394,8 @@ SLUS-20502:
   name: "Colin McRae Rally 3"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20504:
   name: "Tony Hawk's Pro Skater 4"
   region: "NTSC-U"
@@ -36671,6 +36939,8 @@ SLUS-20627:
 SLUS-20628:
   name: "Disney's Finding Nemo"
   region: "NTSC-U"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20630:
   name: "Grand Prix Challenge"
   region: "NTSC-U"
@@ -36855,6 +37125,8 @@ SLUS-20672:
   name: "Final Fantasy X-2"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes brightness and overlapping subtitles.
 SLUS-20673:
   name: "Alias"
   region: "NTSC-U"
@@ -37097,6 +37369,8 @@ SLUS-20732:
   compat: 5
   clampModes:
     eeClampMode: 3  # Characters are visible in-game.
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and textures wrong.
 SLUS-20733:
   name: "Castlevania - Lament of Innocence"
   region: "NTSC-U"
@@ -37387,6 +37661,8 @@ SLUS-20799:
 SLUS-20800:
   name: "Taiko Drum Master"
   region: "NTSC-U"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20801:
   name: "Midway Arcade Treasures"
   region: "NTSC-U"
@@ -37399,6 +37675,8 @@ SLUS-20804:
   name: "Forgotten Realms - Demon Stone"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLUS-20805:
   name: "Yu Yu Hakusho - Dark Tournament"
   region: "NTSC-U"
@@ -37491,6 +37769,8 @@ SLUS-20831:
   name: "Tokyo Xtreme Racer 3"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20833:
   name: "MegaMan Anniversary Collection"
   region: "NTSC-U"
@@ -37549,6 +37829,8 @@ SLUS-20848:
   name: "Life Line - Voice Action Adventure"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20849:
   name: "Carmen Sandiego - The Secret of The Stolen Drums"
   region: "NTSC-U"
@@ -37819,6 +38101,8 @@ SLUS-20909:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes bad geometry.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-20910:
   name: "Test Drive - Eve of Destruction"
   region: "NTSC-U"
@@ -38086,6 +38370,8 @@ SLUS-20964:
   compat: 5
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLUS-20965:
   name: "Tony Hawk's Underground 2"
   region: "NTSC-U"
@@ -38103,6 +38389,8 @@ SLUS-20967:
   clampModes:
     eeClampMode: 3
     vuClampMode: 3
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-20968:
   name: "Karaoke Revolution Volume 2"
   region: "NTSC-U"
@@ -38305,6 +38593,8 @@ SLUS-21005:
   name: "Kingdom Hearts II"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces ghosting.
 SLUS-21006:
   name: "Ghost in the Shell - Stand Alone Complex"
   region: "NTSC-U"
@@ -38347,6 +38637,8 @@ SLUS-21007:
   compat: 5
   roundModes:
     eeRoundMode: 0  # Fixes Sugoroku mini-game.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
 SLUS-21008:
   name: "Katamari Damacy"
   region: "NTSC-U"
@@ -38496,6 +38788,8 @@ SLUS-21039:
   name: "TOCA Race Driver 2 - The Ultimate Racing Simulator"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLUS-21040:
   name: "Shield, The"
   region: "NTSC-U"
@@ -38544,6 +38838,8 @@ SLUS-21050:
   compat: 5
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-21051:
   name: "FIFA 2005"
   region: "NTSC-U"
@@ -38748,6 +39044,8 @@ SLUS-21103:
   name: "Commandos Strike Force"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLUS-21104:
   name: "MX vs. ATV Unleashed"
   region: "NTSC-U"
@@ -38768,6 +39066,8 @@ SLUS-21106:
   compat: 5
   clampModes:
     eeClampMode: 2  # Fixes SPS on highway.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLUS-21107:
   name: "X-Men - The Official Game"
   region: "NTSC-U"
@@ -39115,6 +39415,8 @@ SLUS-21182:
   name: "TOCA Race Driver 3"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLUS-21183:
   name: "Teen Titans"
   region: "NTSC-U"
@@ -39406,6 +39708,8 @@ SLUS-21242:
   compat: 5
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
     - "SLUS-21242"
     - "SLUS-21050"
@@ -39989,6 +40293,8 @@ SLUS-21361:
   compat: 5
   roundModes:
     eeRoundMode: 0
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLUS-21362:
   name: "Onimusha - Dawn of Dreams [Disc2of2]"
   region: "NTSC-U"
@@ -40045,12 +40351,17 @@ SLUS-21372:
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,001849b8,word,00000000
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLUS-21373:
   name: "Drakengard 2"
   region: "NTSC-U"
   compat: 5
   clampModes:
     eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting characters.
+    mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
 SLUS-21374:
   name: "Marvel - Ultimate Alliance"
   region: "NTSC-U"
@@ -40681,6 +40992,8 @@ SLUS-21498:
   compat: 5
   gameFixes:
     - OPHFlagHack
+  gsHWFixes:
+    mergeSprite: 1 # Fixes blurry bloom.
 SLUS-21499:
   name: "Corvette Evolution GT"
   region: "NTSC-U"
@@ -40696,6 +41009,8 @@ SLUS-21503:
   name: "God Hand"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
 SLUS-21536:
   name: "Sims 2, The - Pets"
   region: "NTSC-U"
@@ -40939,10 +41254,15 @@ SLUS-21596:
   name: "Burnout - Dominator"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-21597:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
+    mergeSprite: 1 # Removes occasional vertical lines.
 SLUS-21598:
   name: "Digimon World - Data Squad"
   region: "NTSC-U"
@@ -41006,6 +41326,8 @@ SLUS-21607:
         comment=Patch by kozarovv and refraction
         // Fixes HUD and menu display.
         patch=1,EE,00173cb8,word,00000000
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLUS-21608:
   name: "Dance Dance Revolution SuperNOVA 2"
   region: "NTSC-U"
@@ -41870,6 +42192,7 @@ SLUS-21808:
   compat: 5
   gsHWFixes:
     mipmap: 1
+    halfPixelOffset: 1 # Reduces ghosting and vertical lines.
 SLUS-21809:
   name: "Backyard Football 2009"
   region: "NTSC-U"
@@ -41941,6 +42264,8 @@ SLUS-21820:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLUS-21821:
   name: "Pro Evolution Soccer 2009"
   region: "NTSC-U"
@@ -42460,6 +42785,8 @@ SLUS-28004:
 SLUS-28006:
   name: "Burnout [Trade Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-28007:
   name: "All-Star Baseball 2003 [Trade Demo]"
   region: "NTSC-U"
@@ -42833,6 +43160,8 @@ SLUS-29086:
 SLUS-29087:
   name: "Square Enix Sampler Disc Vol.1: Drakengard Playable Demo"
   region: "NTSC-U"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and textures wrong.
 SLUS-29088:
   name: "Champions of Norrath - Realms of EverQuest [Demo]"
   region: "NTSC-U"
@@ -42888,6 +43217,8 @@ SLUS-29113:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -42976,6 +43307,8 @@ SLUS-29153:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 0  # Fixes buggy lighting on certain objects.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-29154:
   name: "NHL '06 [Demo]"
   region: "NTSC-U"
@@ -43038,6 +43371,8 @@ SLUS-29175:
 SLUS-29178:
   name: "TOCA Race Driver 3 [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
 SLUS-29179:
   name: "Sonic Riders [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Fixes the lint and adds a bunch of upscaling fixes.

Align Sprite for:

- Colin McRae Rally 3/4
- Enthusia Professional Racing
- Finding Nemo
- Lifeline (Also known as Operator's side)
- Taiko Drum Masters
- Toca Race Driver 1/2/3
- Tokyo Xtreme Racer 3

Merge Sprite for:

- Drakengard 2
- God Hand
- Medal of Honor - Vanguard
- Naruto - Uzumaki Chronicles

Half-pixel offsets for;

1 Normal (Vertex):

- Drakengard 2
- Forgotten Realms - Demon Stone
- Harry Potter and the Half-Blood Prince
- Kingdom Hearts 1/2
- True Crime - New York City
- WRC II

2 Special (Texture):

- Burnout Revenge/Dominator/Takedown
- Commandos - Strike Force
- Crash Twinsanity
- Dark Cloud
- Devil May Cry 3
- Fatal Frame
- Kuon
- Legaia 2 - Duel Saga
- Legend of Spyro, The - A New Beginning
- Legend of Spyro, The - Dawn of the Dragon
- Legend of Spyro, The - The Eternal Night
- Medal of Honor - Vanguard
- Project Zero

3 Special (Texture-Aggressive):

- Bratz - The Movie
	
Software Renderer gamefix:

- Final Fantasy X-2

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games.