### PR TITLE
GameDB: Add gsHWFixes for GTA LCS/VCS

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16402,9 +16402,13 @@ SLES-54135:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
 SLES-54136:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "PAL-E-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
 SLES-54137:
   name: "Just Cause"
   region: "PAL-M3"
@@ -17527,9 +17531,13 @@ SLES-54622:
   name: "Grand Theft Auto - Vice City Stories"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
 SLES-54623:
   name: "Grand Theft Auto - Vice City Stories"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
 SLES-54624:
   name: "Samurai Warriors 2 - Empires"
   region: "PAL-E"
@@ -28841,6 +28849,8 @@ SLPM-66850:
 SLPM-66851:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
 SLPM-66852:
   name: "Capcom Classics Collection [Best Price]"
   region: "NTSC-J"
@@ -29044,6 +29054,8 @@ SLPM-66916:
 SLPM-66917:
   name: "Grand Theft Auto - Vice City Stories"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
 SLPM-66918:
   name: "Princess Maker 5"
   region: "NTSC-J"
@@ -40652,6 +40664,8 @@ SLUS-21423:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Removes blur due to misaligned fullscreen effect.
 SLUS-21424:
   name: "NBA 2K7"
   region: "NTSC-U"
@@ -41261,6 +41275,8 @@ SLUS-21590:
   name: "Grand Theft Auto - Vice City Stories"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned effect when in-game Trails option is turned on.
 SLUS-21591:
   name: "Ski-Doo Snow X Racing"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds upscaling fixes for Grand Theft Auto: Liberty City Stories and Grand Theft Auto: Vice City Stories

### Rationale behind Changes
LCS uses some fullscreen effect that causes it to be blurry when upscaled.
Before
![image](https://user-images.githubusercontent.com/4414625/158373880-c76044fb-3ba9-44eb-86ee-a4d8ec6b1052.png)
After
![image](https://user-images.githubusercontent.com/4414625/158373923-584a350f-81df-4e41-b617-4de8d31866ea.png)

VCS uses some kind of bloom when in-game Trails option is turned that becomes misaligned when upscaled
Before
![image](https://user-images.githubusercontent.com/4414625/158374202-93f331b0-fd88-4419-a607-22a4dd2db26a.png)
After
![image](https://user-images.githubusercontent.com/4414625/158374240-1d35d33d-b9cc-417f-8361-4b46cc15877a.png)

### Suggested Testing Steps
Test the games if all works fine.