### PR TITLE
GameDB: Add Upscaling Fixes to Onimusha 3

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11721,6 +11721,9 @@ SLES-51914:
   memcardFilters:
     - "SLES-51913"
     - "SLES-51914"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    roundSprite: 2 # Fixes various lines / reduces bars on right edge.
 SLES-51915:
   name: "Pro Evolution Soccer 3"
   region: "PAL-I"
@@ -20077,6 +20080,9 @@ SLKA-25093:
   memcardFilters:
     - "SLKA-25092"
     - "SLKA-25093"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    roundSprite: 2 # Fixes various lines / reduces bars on right edge.
 SLKA-25100:
   name: "Dragon Quest V Dragon Quarter"
   region: "NTSC-K"
@@ -24227,6 +24233,9 @@ SLPM-65413:
   memcardFilters:
     - "SLPM-65411"
     - "SLPM-65413"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    roundSprite: 2 # Fixes various lines / reduces bars on right edge.
 SLPM-65414:
   name: "Simple 2000 Series Vol.45 - The Love and Tears and Memory"
   region: "NTSC-J"
@@ -37242,6 +37251,9 @@ SLUS-20694:
   memcardFilters:
     - "SLUS-20694"
     - "SLUS-20710"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes ghosting.
+    roundSprite: 2 # Fixes various lines / reduces bars on right edge.
 SLUS-20695:
   name: "Chaos Legion"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds Half-Pixel Offset to reduce ghosting when upscaling and added Round Sprite (Full) to fix various lines, for example in the menu. Round Sprite also helps reduce bars that appear on the right side of the screen, sadly I didn't find a way to make them completely disappear. They don't appear in every situation though. Shadows are semi-broken too when upscaling (some are fine, some aren't).

### Rationale behind Changes
Get Upscaling to as good as it gets for Onimusha 3: Demon Siege.

### Suggested Testing Steps
Test the game. If you find additional solutions I'm happy to know.