### PR TITLE
GameDB: Add Software FMV to Grandia 2 and Xtreme

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5524,14 +5524,18 @@ SCPS-55008:
   name: "Thunderstrike"
   region: "NTSC-J"
 SCPS-55010:
-  name: "Grandia Extreme"
+  name: "Grandia Xtreme"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
 SCPS-55011:
   name: "Dual Hearts"
   region: "NTSC-J"
 SCPS-55012:
-  name: "Grandia 2"
+  name: "Grandia II"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Vertical Lines in FMV.
 SCPS-55013:
   name: "Soul Reaver 2 - Legacy of Kain"
   region: "NTSC-J"
@@ -8932,6 +8936,8 @@ SLES-50498:
   name: "Grandia II"
   region: "PAL-E"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Vertical Lines in FMV.
 SLES-50503:
   name: "Weakest Link"
   region: "PAL-E"
@@ -23230,8 +23236,10 @@ SLPM-65080:
   region: "NTSC-J"
   compat: 5
 SLPM-65082:
-  name: "Grandia Extreme [Limited Edition]"
+  name: "Grandia Xtreme [Limited Edition]"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
 SLPM-65083:
   name: "Houshin Engi 2"
   region: "NTSC-J"
@@ -23257,8 +23265,10 @@ SLPM-65087:
     - "SLPM-65086"
     - "SLPM-65087"
 SLPM-65089:
-  name: "Grandia Extreme"
+  name: "Grandia Xtreme"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
 SLPM-65090:
   name: "Spy Hunter"
   region: "NTSC-J"
@@ -35074,6 +35084,8 @@ SLUS-20194:
   name: "Grandia II"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Vertical Lines in FMV.
 SLUS-20195:
   name: "Dragon Rage"
   region: "NTSC-U"
@@ -36042,6 +36054,8 @@ SLUS-20417:
   name: "Grandia Xtreme"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering in FMV.
 SLUS-20418:
   name: "Wakeboarding Unleashed featuring Shaun Murray"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Grandia Xtreme has severe flickering in FMV's in Hardware mode. Whereas Grandia 2 exhibits Vertical Lines in FMV's when upscaled. Years ago there was an issue with Grandia 3's FMV's too (Random garbage in the black bars IIRC). However I can not reproduce it on current master, so I assume this has been fixed since.

I also adjusted the naming after looking up the game covers.  The Grandia Xtreme Logo was used in Japan too, without the E.

### Rationale behind Changes
Not risking that PCSX2 sends someone to the hospital (Seriously, the Xtreme Flickering is bad). Less tinkering.

### Suggested Testing Steps
Test the games. Also, play them regardless, because they're great. 
