### PR TITLE
GameDB: Dog Island and COD Final Fronts

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18825,6 +18825,10 @@ SLES-55125:
 SLES-55126:
   name: "Artlist Collection - The Dog Island"
   region: "PAL-M6"
+  gsHWFixes:
+    autoFlush: 1 # Fixes certains font colors.
+    halfPixelOffset: 1 # Fixes lighting misalignment.
+    alignSprite: 1 # Fixes almost all vertical lines.
 SLES-55129:
   name: "Jumper: Griffin's Story"
   region: "PAL-M5"
@@ -19324,9 +19328,15 @@ SLES-55366:
 SLES-55367:
   name: "Call of Duty - World at War - Final Fronts"
   region: "PAL-M4"
+  gsHWFixes:
+    autoFlush: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.
 SLES-55369:
   name: "Call of Duty - World at War - Final Fronts"
   region: "PAL-G"
+  gsHWFixes:
+    autoFlush: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.
 SLES-55371:
   name: "Barbie Horse Adventures - Riding Camp"
   region: "PAL-M6"
@@ -28462,6 +28472,10 @@ SLPM-66661:
 SLPM-66662:
   name: "Dog Island, The - Hitotsu no Hana no Monogatari"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Fixes certains font colors.
+    halfPixelOffset: 1 # Fixes lighting misalignment.
+    alignSprite: 1 # Fixes almost all vertical lines.
 SLPM-66663:
   name: "Phantasy Star Universe - Ambition of the Illuminus"
   region: "NTSC-J"
@@ -41447,6 +41461,10 @@ SLUS-21551:
   name: "Dog Island, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes certains font colors.
+    halfPixelOffset: 1 # Fixes lighting misalignment.
+    alignSprite: 1 # Fixes almost all vertical lines.
 SLUS-21552:
   name: "Spider-Man 3"
   region: "NTSC-U"
@@ -42333,6 +42351,9 @@ SLUS-21746:
   name: "Call of Duty: World at War - Final Fronts"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.
 SLUS-21748:
   name: "MLB Power Pros 2008"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Also added some screenshots for once to see the differences.

Dog Island:
    autoFlush: 1 # Fixes certains font colors.
    halfPixelOffset: 1 # Fixes lighting misalignment.
    alignSprite: 1 # Fixes almost all vertical lines.
    
Upscaled (with no other settings):
![image](https://user-images.githubusercontent.com/24227051/158498226-cda908fc-1539-47a7-a5a4-2a5d103208f9.png)
Align Sprite:
![image](https://user-images.githubusercontent.com/24227051/158498248-5b5de067-402d-4954-83f1-5415fcfbd5b9.png)
![image](https://user-images.githubusercontent.com/24227051/158498388-de1077f5-f81c-43ea-a744-5c452193f4fa.png)

Now added autoflush + Normal vertex along with align sprite:
![image](https://user-images.githubusercontent.com/24227051/158498455-0cfe0f7c-771d-4ef7-b258-d85af579a190.png)

COD Final Fronts:
  gsHWFixes:
    autoFlush: 1 # Fixes bloom misalignment.
    halfPixelOffset: 2 # Fixes lighting misalignment and depth lines.

Upscaled (with no other settings):
![image](https://user-images.githubusercontent.com/24227051/158498531-d1d94339-d15b-4215-860f-50c8ea2c8838.png)
![image](https://user-images.githubusercontent.com/24227051/158498640-7d617587-739d-43bb-8e4c-0da78f585d42.png)


Now with fixes:
![image](https://user-images.githubusercontent.com/24227051/158498599-39fda627-2d89-419d-a17a-c9351d188113.png)
![image](https://user-images.githubusercontent.com/24227051/158498713-38ba6f7f-49c4-4840-8903-f7b6df277b2a.png)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the relevant games.