### PR TITLE
GS: Add SW CPU usage and host GPU usage stats

### DIFF
--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -208,6 +208,9 @@ namespace Vulkan
 
 		void WaitForGPUIdle();
 
+		float GetAndResetAccumulatedGPUTime();
+		void SetEnableGPUTiming(bool enabled);
+
 	private:
 		Context(VkInstance instance, VkPhysicalDevice physical_device);
 
@@ -284,14 +287,19 @@ namespace Vulkan
 		VkDescriptorPool m_global_descriptor_pool = VK_NULL_HANDLE;
 
 		VkQueue m_graphics_queue = VK_NULL_HANDLE;
-		u32 m_graphics_queue_family_index = 0;
 		VkQueue m_present_queue = VK_NULL_HANDLE;
+		u32 m_graphics_queue_family_index = 0;
 		u32 m_present_queue_family_index = 0;
+
+		VkQueryPool m_timestamp_query_pool = VK_NULL_HANDLE;
+		float m_accumulated_gpu_time = 0.0f;
+		bool m_gpu_timing_enabled = false;
+		bool m_gpu_timing_supported = false;
 
 		std::array<FrameResources, NUM_COMMAND_BUFFERS> m_frame_resources;
 		u64 m_next_fence_counter = 1;
 		u64 m_completed_fence_counter = 0;
-		u32 m_current_frame;
+		u32 m_current_frame = 0;
 
 		StreamBuffer m_texture_upload_buffer;
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -104,6 +104,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowSpeed, "EmuCore/GS", "OsdShowSpeed", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowFPS, "EmuCore/GS", "OsdShowFPS", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowCPU, "EmuCore/GS", "OsdShowCPU", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowGPU, "EmuCore/GS", "OsdShowGPU", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowResolution, "EmuCore/GS", "OsdShowResolution", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowGSStats, "EmuCore/GS", "OsdShowGSStats", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowIndicators, "EmuCore/GS", "OsdShowIndicators", true);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -921,13 +921,20 @@
           </widget>
          </item>
          <item row="2" column="1">
+          <widget class="QCheckBox" name="osdShowGPU">
+           <property name="text">
+            <string>Show GPU Usage</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
           <widget class="QCheckBox" name="osdShowGSStats">
            <property name="text">
             <string>Show Statistics</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="3" column="1">
           <widget class="QCheckBox" name="osdShowIndicators">
            <property name="text">
             <string>Show Indicators</string>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -428,6 +428,7 @@ struct Pcsx2Config
 					OsdShowSpeed : 1,
 					OsdShowFPS : 1,
 					OsdShowCPU : 1,
+					OsdShowGPU : 1,
 					OsdShowResolution : 1,
 					OsdShowGSStats : 1,
 					OsdShowIndicators : 1;

--- a/pcsx2/Frontend/D3D11HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D11HostDisplay.cpp
@@ -742,11 +742,122 @@ void D3D11HostDisplay::EndPresent()
 	ImGui::Render();
 	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 
+	if (m_gpu_timing_enabled)
+		PopTimestampQuery();
+
 	const UINT vsync_rate = static_cast<UINT>(m_vsync_mode != VsyncMode::Off);
 	if (vsync_rate == 0 && m_using_allow_tearing)
 		m_swap_chain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
 	else
 		m_swap_chain->Present(vsync_rate, 0);
+
+	if (m_gpu_timing_enabled)
+		KickTimestampQuery();
+}
+
+void D3D11HostDisplay::CreateTimestampQueries()
+{
+	for (u32 i = 0; i < NUM_TIMESTAMP_QUERIES; i++)
+	{
+		for (u32 j = 0; j < 3; j++)
+		{
+			const CD3D11_QUERY_DESC qdesc((j == 0) ? D3D11_QUERY_TIMESTAMP_DISJOINT : D3D11_QUERY_TIMESTAMP);
+			const HRESULT hr = m_device->CreateQuery(&qdesc, m_timestamp_queries[i][j].ReleaseAndGetAddressOf());
+			if (FAILED(hr))
+			{
+				m_timestamp_queries = {};
+				return;
+			}
+		}
+	}
+
+	KickTimestampQuery();
+}
+
+void D3D11HostDisplay::DestroyTimestampQueries()
+{
+	if (!m_timestamp_queries[0][0])
+		return;
+
+	if (m_timestamp_query_started)
+		m_context->End(m_timestamp_queries[m_write_timestamp_query][1].Get());
+
+	m_timestamp_queries = {};
+	m_read_timestamp_query = 0;
+	m_write_timestamp_query = 0;
+	m_waiting_timestamp_queries = 0;
+	m_timestamp_query_started = 0;
+}
+
+void D3D11HostDisplay::PopTimestampQuery()
+{
+	while (m_waiting_timestamp_queries > 0)
+	{
+		D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjoint;
+		const HRESULT disjoint_hr = m_context->GetData(m_timestamp_queries[m_read_timestamp_query][0].Get(), &disjoint, sizeof(disjoint), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+		if (disjoint_hr != S_OK)
+			break;
+
+		if (disjoint.Disjoint)
+		{
+			DevCon.WriteLn("GPU timing disjoint, resetting.");
+			m_read_timestamp_query = 0;
+			m_write_timestamp_query = 0;
+			m_waiting_timestamp_queries = 0;
+			m_timestamp_query_started = 0;
+		}
+		else
+		{
+			u64 start = 0, end = 0;
+			const HRESULT start_hr = m_context->GetData(m_timestamp_queries[m_read_timestamp_query][1].Get(), &start, sizeof(start), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+			const HRESULT end_hr = m_context->GetData(m_timestamp_queries[m_read_timestamp_query][2].Get(), &end, sizeof(end), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+			if (start_hr == S_OK && end_hr == S_OK)
+			{
+				m_accumulated_gpu_time += static_cast<float>(static_cast<double>(end - start) / (static_cast<double>(disjoint.Frequency) / 1000.0));
+				m_read_timestamp_query = (m_read_timestamp_query + 1) % NUM_TIMESTAMP_QUERIES;
+				m_waiting_timestamp_queries--;
+			}
+		}
+	}
+
+	// delay ending the current query until we've read back some
+	if (m_timestamp_query_started && m_waiting_timestamp_queries < (NUM_TIMESTAMP_QUERIES - 1))
+	{
+		m_context->End(m_timestamp_queries[m_write_timestamp_query][2].Get());
+		m_context->End(m_timestamp_queries[m_write_timestamp_query][0].Get());
+		m_write_timestamp_query = (m_write_timestamp_query + 1) % NUM_TIMESTAMP_QUERIES;
+		m_timestamp_query_started = false;
+		m_waiting_timestamp_queries++;
+	}
+}
+
+void D3D11HostDisplay::KickTimestampQuery()
+{
+	if (m_timestamp_query_started)
+		return;
+
+	m_context->Begin(m_timestamp_queries[m_write_timestamp_query][0].Get());
+	m_context->End(m_timestamp_queries[m_write_timestamp_query][1].Get());
+	m_timestamp_query_started = true;
+}
+
+void D3D11HostDisplay::SetGPUTimingEnabled(bool enabled)
+{
+	if (m_gpu_timing_enabled == enabled)
+		return;
+
+	m_gpu_timing_enabled = enabled;
+	if (m_gpu_timing_enabled)
+		CreateTimestampQueries();
+	else
+		DestroyTimestampQueries();
+}
+
+float D3D11HostDisplay::GetAndResetAccumulatedGPUTime()
+{
+	const float value = m_accumulated_gpu_time;
+	m_accumulated_gpu_time = 0.0f;
+	return value;
 }
 
 HostDisplay::AdapterAndModeList D3D11HostDisplay::StaticGetAdapterAndModeList()

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -17,6 +17,7 @@
 #include "HostDisplay.h"
 #include "common/RedtapeWindows.h"
 #include "common/WindowInfo.h"
+#include <array>
 #include <d3d11.h>
 #include <dxgi.h>
 #include <memory>
@@ -68,10 +69,14 @@ public:
 	bool BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
+	void SetGPUTimingEnabled(bool enabled) override;
+	float GetAndResetAccumulatedGPUTime() override;
+
 	static AdapterAndModeList StaticGetAdapterAndModeList();
 
 protected:
 	static constexpr u32 DISPLAY_CONSTANT_BUFFER_SIZE = 16;
+	static constexpr u8 NUM_TIMESTAMP_QUERIES = 3;
 
 	static AdapterAndModeList GetAdapterAndModeList(IDXGIFactory* dxgi_factory);
 
@@ -81,6 +86,11 @@ protected:
 
 	bool CreateSwapChain(const DXGI_MODE_DESC* fullscreen_mode);
 	bool CreateSwapChainRTV();
+
+	void CreateTimestampQueries();
+	void DestroyTimestampQueries();
+	void PopTimestampQuery();
+	void KickTimestampQuery();
 
 	ComPtr<ID3D11Device> m_device;
 	ComPtr<ID3D11DeviceContext> m_context;
@@ -92,5 +102,13 @@ protected:
 	bool m_allow_tearing_supported = false;
 	bool m_using_flip_model_swap_chain = true;
 	bool m_using_allow_tearing = false;
+
+	std::array<std::array<ComPtr<ID3D11Query>, 3>, NUM_TIMESTAMP_QUERIES> m_timestamp_queries = {};
+	u8 m_read_timestamp_query = 0;
+	u8 m_write_timestamp_query = 0;
+	u8 m_waiting_timestamp_queries = 0;
+	bool m_timestamp_query_started = false;
+	float m_accumulated_gpu_time = 0.0f;
+	bool m_gpu_timing_enabled = false;
 };
 

--- a/pcsx2/Frontend/ImGuiManager.cpp
+++ b/pcsx2/Frontend/ImGuiManager.cpp
@@ -610,6 +610,14 @@ static void DrawPerformanceOverlay()
 			}
 		}
 
+		if (GSConfig.OsdShowGPU)
+		{
+			text.Clear();
+			text.Write("GPU: %.1f%% (%.2fms)", PerformanceMetrics::GetGPUUsage(),
+				PerformanceMetrics::GetGPUAverageTime());
+			DRAW_LINE(s_fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
+		}
+
 		if (GSConfig.OsdShowIndicators)
 		{
 			const bool is_normal_speed = (EmuConfig.GS.LimitScalar == EmuConfig.Framerate.NominalScalar);

--- a/pcsx2/Frontend/ImGuiManager.cpp
+++ b/pcsx2/Frontend/ImGuiManager.cpp
@@ -592,6 +592,15 @@ static void DrawPerformanceOverlay()
 				PerformanceMetrics::GetGSThreadAverageTime());
 			DRAW_LINE(s_fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 
+			const u32 gs_sw_threads = PerformanceMetrics::GetGSSWThreadCount();
+			for (u32 i = 0; i < gs_sw_threads; i++)
+			{
+				text.Clear();
+				text.Write("SW-%u: %.1f%% (%.2fms)", i, PerformanceMetrics::GetGSSWThreadUsage(i),
+					PerformanceMetrics::GetGSSWThreadAverageTime(i));
+				DRAW_LINE(s_fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
+			}
+
 			if (THREAD_VU1)
 			{
 				text.Clear();

--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -374,6 +374,128 @@ void OpenGLHostDisplay::EndPresent()
 	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 	GL::Program::ResetLastProgram();
 
+	if (m_gpu_timing_enabled)
+		PopTimestampQuery();
+
 	m_gl_context->SwapBuffers();
+
+	if (m_gpu_timing_enabled)
+		KickTimestampQuery();
+}
+
+void OpenGLHostDisplay::CreateTimestampQueries()
+{
+	const bool gles = m_gl_context->IsGLES();
+	const auto GenQueries = gles ? glGenQueriesEXT : glGenQueries;
+
+	GenQueries(static_cast<u32>(m_timestamp_queries.size()), m_timestamp_queries.data());
+	KickTimestampQuery();
+}
+
+void OpenGLHostDisplay::DestroyTimestampQueries()
+{
+	if (m_timestamp_queries[0] == 0)
+		return;
+
+	const bool gles = m_gl_context->IsGLES();
+	const auto DeleteQueries = gles ? glDeleteQueriesEXT : glDeleteQueries;
+
+	if (m_timestamp_query_started)
+	{
+		const auto EndQuery = gles ? glEndQueryEXT : glEndQuery;
+		EndQuery(m_timestamp_queries[m_write_timestamp_query]);
+	}
+
+	DeleteQueries(static_cast<u32>(m_timestamp_queries.size()), m_timestamp_queries.data());
+	m_timestamp_queries.fill(0);
+	m_read_timestamp_query = 0;
+	m_write_timestamp_query = 0;
+	m_waiting_timestamp_queries = 0;
+	m_timestamp_query_started = false;
+}
+
+void OpenGLHostDisplay::PopTimestampQuery()
+{
+	const bool gles = m_gl_context->IsGLES();
+
+	if (gles)
+	{
+		GLint disjoint = 0;
+		glGetIntegerv(GL_GPU_DISJOINT_EXT, &disjoint);
+		if (disjoint)
+		{
+			DevCon.WriteLn("GPU timing disjoint, resetting.");
+			if (m_timestamp_query_started)
+				glEndQueryEXT(GL_TIME_ELAPSED);
+
+			m_read_timestamp_query = 0;
+			m_write_timestamp_query = 0;
+			m_waiting_timestamp_queries = 0;
+			m_timestamp_query_started = false;
+		}
+	}
+
+	while (m_waiting_timestamp_queries > 0)
+	{
+		const auto GetQueryObjectiv = gles ? glGetQueryObjectivEXT : glGetQueryObjectiv;
+		const auto GetQueryObjectui64v = gles ? glGetQueryObjectui64vEXT : glGetQueryObjectui64v;
+
+		GLint available = 0;
+		GetQueryObjectiv(m_timestamp_queries[m_read_timestamp_query], GL_QUERY_RESULT_AVAILABLE, &available);
+		pxAssert(m_read_timestamp_query != m_write_timestamp_query);
+
+		if (!available)
+			break;
+
+		u64 result = 0;
+		GetQueryObjectui64v(m_timestamp_queries[m_read_timestamp_query], GL_QUERY_RESULT, &result);
+		m_accumulated_gpu_time += static_cast<float>(static_cast<double>(result) / 1000000.0);
+		m_read_timestamp_query = (m_read_timestamp_query + 1) % NUM_TIMESTAMP_QUERIES;
+		m_waiting_timestamp_queries--;
+	}
+
+	// delay ending the current query until we've read back some
+	if (m_timestamp_query_started && m_waiting_timestamp_queries < (NUM_TIMESTAMP_QUERIES - 1))
+	{
+		const auto EndQuery = gles ? glEndQueryEXT : glEndQuery;
+		EndQuery(GL_TIME_ELAPSED);
+
+		m_write_timestamp_query = (m_write_timestamp_query + 1) % NUM_TIMESTAMP_QUERIES;
+		m_timestamp_query_started = false;
+		m_waiting_timestamp_queries++;
+	}
+}
+
+void OpenGLHostDisplay::KickTimestampQuery()
+{
+	if (m_timestamp_query_started)
+		return;
+
+	const bool gles = m_gl_context->IsGLES();
+	const auto BeginQuery = gles ? glBeginQueryEXT : glBeginQuery;
+
+	BeginQuery(GL_TIME_ELAPSED, m_timestamp_queries[m_write_timestamp_query]);
+	m_timestamp_query_started = true;
+}
+
+void OpenGLHostDisplay::SetGPUTimingEnabled(bool enabled)
+{
+	enabled &= (!m_gl_context->IsGLES() || GLAD_GL_EXT_disjoint_timer_query);
+
+	if (m_gpu_timing_enabled == enabled)
+		return;
+
+	m_gpu_timing_enabled = enabled;
+	if (m_gpu_timing_enabled)
+		CreateTimestampQueries();
+	else
+		DestroyTimestampQueries();
+}
+
+float OpenGLHostDisplay::GetAndResetAccumulatedGPUTime()
+{
+	const float value = m_accumulated_gpu_time;
+	m_accumulated_gpu_time = 0.0f;
+	return value;
 }
 

--- a/pcsx2/Frontend/OpenGLHostDisplay.h
+++ b/pcsx2/Frontend/OpenGLHostDisplay.h
@@ -20,6 +20,8 @@
 #include "HostDisplay.h"
 #include "common/GL/Context.h"
 #include "common/WindowInfo.h"
+#include <array>
+#include <bitset>
 #include <memory>
 
 class OpenGLHostDisplay final : public HostDisplay
@@ -60,7 +62,12 @@ public:
 	bool BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
+	void SetGPUTimingEnabled(bool enabled) override;
+	float GetAndResetAccumulatedGPUTime() override;
+
 protected:
+	static constexpr u8 NUM_TIMESTAMP_QUERIES = 3;
+
 	const char* GetGLSLVersionString() const;
 	std::string GetGLSLVersionHeader() const;
 
@@ -70,6 +77,19 @@ protected:
 
 	void SetSwapInterval();
 
+	void CreateTimestampQueries();
+	void DestroyTimestampQueries();
+	void PopTimestampQuery();
+	void KickTimestampQuery();
+
 	std::unique_ptr<GL::Context> m_gl_context;
+
+	std::array<GLuint, NUM_TIMESTAMP_QUERIES> m_timestamp_queries = {};
+	u8 m_read_timestamp_query = 0;
+	u8 m_write_timestamp_query = 0;
+	u8 m_waiting_timestamp_queries = 0;
+	bool m_timestamp_query_started = false;
+	float m_accumulated_gpu_time = 0.0f;
+	bool m_gpu_timing_enabled = false;
 };
 

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -396,6 +396,16 @@ void VulkanHostDisplay::EndPresent()
 	g_vulkan_context->MoveToNextCommandBuffer();
 }
 
+void VulkanHostDisplay::SetGPUTimingEnabled(bool enabled)
+{
+	g_vulkan_context->SetEnableGPUTiming(enabled);
+}
+
+float VulkanHostDisplay::GetAndResetAccumulatedGPUTime()
+{
+	return g_vulkan_context->GetAndResetAccumulatedGPUTime();
+}
+
 HostDisplay::AdapterAndModeList VulkanHostDisplay::StaticGetAdapterAndModeList(const WindowInfo* wi)
 {
 	AdapterAndModeList ret;

--- a/pcsx2/Frontend/VulkanHostDisplay.h
+++ b/pcsx2/Frontend/VulkanHostDisplay.h
@@ -51,6 +51,9 @@ public:
 	bool BeginPresent(bool frame_skip) override;
 	void EndPresent() override;
 
+	void SetGPUTimingEnabled(bool enabled) override;
+	float GetAndResetAccumulatedGPUTime() override;
+
 	static AdapterAndModeList StaticGetAdapterAndModeList(const WindowInfo* wi);
 
 protected:

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -657,21 +657,16 @@ void GSgetStats(std::string& info)
 
 	if (GSConfig.Renderer == GSRendererType::SW)
 	{
-		float sum = 0.0f;
-		for (int i = GSPerfMon::WorkerDraw0; i < GSPerfMon::TimerLast; i++)
-			sum += pm.GetTimer(static_cast<GSPerfMon::timer_t>(i));
-
 		const double fps = GetVerticalFrequency();
 		const double fillrate = pm.Get(GSPerfMon::Fillrate);
-		info = format("%s SW | %d S | %d P | %d D | %.2f U | %.2f D | %.2f mpps | %d%% WCPU",
+		info = format("%s SW | %d S | %d P | %d D | %.2f U | %.2f D | %.2f mpps",
 			api_name,
 			(int)pm.Get(GSPerfMon::SyncPoint),
 			(int)pm.Get(GSPerfMon::Prim),
 			(int)pm.Get(GSPerfMon::Draw),
 			pm.Get(GSPerfMon::Swizzle) / 1024,
 			pm.Get(GSPerfMon::Unswizzle) / 1024,
-			fps * fillrate / (1024 * 1024),
-			static_cast<int>(std::lround(sum)));
+			fps * fillrate / (1024 * 1024));
 	}
 	else if (GSConfig.Renderer == GSRendererType::Null)
 	{

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -147,6 +147,9 @@ void GSclose()
 		g_gs_device.reset();
 	}
 
+	if (HostDisplay* display = Host::GetHostDisplay(); display)
+		display->SetGPUTimingEnabled(false);
+
 	Host::ReleaseHostDisplay();
 }
 
@@ -238,6 +241,7 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 	s_gs->SetRegsMem(basemem);
 
 	display->SetVSync(EmuConfig.GetEffectiveVsyncMode());
+	display->SetGPUTimingEnabled(GSConfig.OsdShowGPU);
 	return true;
 }
 
@@ -820,6 +824,12 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	{
 		s_gs->PurgeTextureCache();
 	}
+
+	if (GSConfig.OsdShowGPU != old_config.OsdShowGPU)
+	{
+		if (HostDisplay* display = Host::GetHostDisplay(); display)
+			display->SetGPUTimingEnabled(GSConfig.OsdShowGPU);
+	}
 }
 
 void GSSwitchRenderer(GSRendererType new_renderer)
@@ -1325,6 +1335,7 @@ void GSApp::Init()
 	m_default_configuration["OsdShowSpeed"]                               = "0";
 	m_default_configuration["OsdShowFPS"]                                 = "0";
 	m_default_configuration["OsdShowCPU"]                                 = "0";
+	m_default_configuration["OsdShowGPU"]                                 = "0";
 	m_default_configuration["OsdShowResolution"]                          = "0";
 	m_default_configuration["OsdShowGSStats"]                             = "0";
 	m_default_configuration["OsdShowIndicators"]                          = "1";

--- a/pcsx2/GS/GSCapture.cpp
+++ b/pcsx2/GS/GSCapture.cpp
@@ -538,7 +538,7 @@ bool GSCapture::BeginCapture(float fps, GSVector2i recommendedResolution, float 
 
 	for (int i = 0; i < m_threads; i++)
 	{
-		m_workers.push_back(std::unique_ptr<GSPng::Worker>(new GSPng::Worker(&GSPng::Process)));
+		m_workers.push_back(std::unique_ptr<GSPng::Worker>(new GSPng::Worker({}, &GSPng::Process, {})));
 	}
 
 	m_capturing = true;

--- a/pcsx2/GS/GSPerfMon.cpp
+++ b/pcsx2/GS/GSPerfMon.cpp
@@ -26,9 +26,6 @@ GSPerfMon::GSPerfMon()
 {
 	memset(m_counters, 0, sizeof(m_counters));
 	memset(m_stats, 0, sizeof(m_stats));
-	memset(m_timer_stats, 0, sizeof(m_timer_stats));
-	memset(m_total, 0, sizeof(m_total));
-	memset(m_begin, 0, sizeof(m_begin));
 }
 
 void GSPerfMon::EndFrame()
@@ -39,7 +36,6 @@ void GSPerfMon::EndFrame()
 
 void GSPerfMon::Update()
 {
-#ifndef DISABLE_PERF_MON
 	if (m_count > 0)
 	{
 		for (size_t i = 0; i < std::size(m_counters); i++)
@@ -48,55 +44,7 @@ void GSPerfMon::Update()
 		}
 
 		m_count = 0;
-
-		// Update CPU usage for SW renderer.
-		if (GSConfig.Renderer == GSRendererType::SW)
-		{
-			const u64 current = __rdtsc();
-
-			for (size_t i = WorkerDraw0; i < TimerLast; i++)
-			{
-				if (m_begin[i] == 0)
-				{
-					m_timer_stats[i] = 0.0f;
-					continue;
-				}
-
-				m_timer_stats[i] =
-					static_cast<float>(static_cast<double>(m_total[i]) / static_cast<double>(current - m_begin[i])
-						* 100.0);
-
-				m_begin[i] = 0;
-				m_start[i] = 0;
-				m_total[i] = 0;
-			}
-		}
-
 	}
 
 	memset(m_counters, 0, sizeof(m_counters));
-#endif
-}
-
-void GSPerfMon::Start(int timer)
-{
-#ifndef DISABLE_PERF_MON
-	m_start[timer] = __rdtsc();
-
-	if (m_begin[timer] == 0)
-	{
-		m_begin[timer] = m_start[timer];
-	}
-#endif
-}
-
-void GSPerfMon::Stop(int timer)
-{
-#ifndef DISABLE_PERF_MON
-	if (m_start[timer] > 0)
-	{
-		m_total[timer] += __rdtsc() - m_start[timer];
-		m_start[timer] = 0;
-	}
-#endif
 }

--- a/pcsx2/GS/GSPerfMon.h
+++ b/pcsx2/GS/GSPerfMon.h
@@ -18,14 +18,6 @@
 class GSPerfMon
 {
 public:
-	enum timer_t
-	{
-		Main,
-		Sync,
-		WorkerDraw0,
-		TimerLast = WorkerDraw0 + 32, // Enough space for 32 GS worker threads
-	};
-
 	enum counter_t
 	{
 		Prim,
@@ -47,14 +39,10 @@ public:
 protected:
 	double m_counters[CounterLast];
 	double m_stats[CounterLast];
-	float m_timer_stats[TimerLast];
-	u64 m_begin[TimerLast], m_total[TimerLast], m_start[TimerLast];
 	u64 m_frame;
 	clock_t m_lastframe;
 	int m_count;
 	int m_disp_fb_sprite_blits;
-
-	friend class GSPerfMonAutoTimer;
 
 public:
 	GSPerfMon();
@@ -65,11 +53,7 @@ public:
 
 	void Put(counter_t c, double val = 0) { m_counters[c] += val; }
 	double Get(counter_t c) { return m_stats[c]; }
-	float GetTimer(timer_t t) { return m_timer_stats[t]; }
 	void Update();
-
-	void Start(int timer = Main);
-	void Stop(int timer = Main);
 
 	__fi void AddDisplayFramebufferSpriteBlit() { m_disp_fb_sprite_blits++; }
 	__fi int GetDisplayFramebufferSpriteBlits()
@@ -78,20 +62,6 @@ public:
 		m_disp_fb_sprite_blits = 0;
 		return blits;
 	}
-};
-
-class GSPerfMonAutoTimer
-{
-	GSPerfMon* m_pm;
-	int m_timer;
-
-public:
-	GSPerfMonAutoTimer(GSPerfMon* pm, int timer = GSPerfMon::Main)
-	{
-		m_timer = timer;
-		(m_pm = pm)->Start(m_timer);
-	}
-	~GSPerfMonAutoTimer() { m_pm->Stop(m_timer); }
 };
 
 extern GSPerfMon g_perfmon;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1965,8 +1965,6 @@ void GSState::SoftReset(u32 mask)
 
 void GSState::ReadFIFO(u8* mem, int size)
 {
-	GSPerfMonAutoTimer pmat(&g_perfmon);
-
 	Flush();
 
 	size *= 16;
@@ -1985,8 +1983,6 @@ template void GSState::Transfer<3>(const u8* mem, u32 size);
 template <int index>
 void GSState::Transfer(const u8* mem, u32 size)
 {
-	GSPerfMonAutoTimer pmat(&g_perfmon);
-
 	const u8* start = mem;
 
 	GIFPath& path = m_path[index];

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -416,8 +416,6 @@ static GSVector4 CalculateDrawRect(s32 window_width, s32 window_height, s32 text
 
 void GSRenderer::VSync(u32 field, bool registers_written)
 {
-	GSPerfMonAutoTimer pmat(&g_perfmon);
-
 	Flush();
 
 	if (s_dump && s_n >= s_saven)

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -463,6 +463,9 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 		}
 
 		Host::EndPresentFrame();
+
+		if (GSConfig.OsdShowGPU)
+			PerformanceMetrics::OnGPUPresent(Host::GetHostDisplay()->GetAndResetAccumulatedGPUTime());
 	}
 	g_gs_device->RestoreAPIState();
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -197,6 +197,9 @@ protected:
 
 	GSRasterizerList(int threads, GSPerfMon* perfmon);
 
+	void OnWorkerStartup(int i);
+	void OnWorkerShutdown(int i);
+
 public:
 	virtual ~GSRasterizerList();
 
@@ -217,7 +220,9 @@ public:
 			rl->m_r.push_back(std::unique_ptr<GSRasterizer>(new GSRasterizer(new DS(), i, threads, perfmon)));
 			auto& r = *rl->m_r[i];
 			rl->m_workers.push_back(std::unique_ptr<GSWorker>(new GSWorker(
-				[&r](GSRingHeap::SharedPtr<GSRasterizerData>& item) { r.Draw(item.get()); })));
+				[rl, i]() { rl->OnWorkerStartup(i); },
+				[&r](GSRingHeap::SharedPtr<GSRasterizerData>& item) { r.Draw(item.get()); },
+				[rl, i]() { rl->OnWorkerShutdown(i); })));
 		}
 
 		return rl;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -582,9 +582,7 @@ void GSRendererSW::Sync(int reason)
 {
 	//printf("sync %d\n", reason);
 
-	GSPerfMonAutoTimer pmat(&g_perfmon, GSPerfMon::Sync);
-
-	u64 t = __rdtsc();
+	u64 t = LOG ? __rdtsc() : 0;
 
 	m_rl->Sync();
 
@@ -607,7 +605,7 @@ void GSRendererSW::Sync(int reason)
 		}
 	}
 
-	t = __rdtsc() - t;
+	t = LOG ? (__rdtsc() - t) : 0;
 
 	int pixels = m_rl->GetPixels();
 

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -517,6 +517,7 @@ OSDTab::OSDTab(wxWindow* parent)
 	m_ui.addCheckBox(log_grid, "Show Speed", "OsdShowSpeed", -1);
 	m_ui.addCheckBox(log_grid, "Show FPS", "OsdShowFPS", -1);
 	m_ui.addCheckBox(log_grid, "Show CPU Usage", "OsdShowCPU", -1);
+	m_ui.addCheckBox(log_grid, "Show GPU Usage", "OsdShowGPU", -1);
 	m_ui.addCheckBox(log_grid, "Show Resolution", "OsdShowResolution", -1);
 	m_ui.addCheckBox(log_grid, "Show Statistics", "OsdShowGSStats", -1);
 	m_ui.addCheckBox(log_grid, "Show Indicators", "OsdShowIndicators", -1);

--- a/pcsx2/HostDisplay.cpp
+++ b/pcsx2/HostDisplay.cpp
@@ -53,6 +53,15 @@ bool HostDisplay::GetHostRefreshRate(float* refresh_rate)
 	return WindowInfo::QueryRefreshRateForWindow(m_window_info, refresh_rate);
 }
 
+void HostDisplay::SetGPUTimingEnabled(bool enabled)
+{
+}
+
+float HostDisplay::GetAndResetAccumulatedGPUTime()
+{
+	return 0.0f;
+}
+
 bool HostDisplay::ParseFullscreenMode(const std::string_view& mode, u32* width, u32* height, float* refresh_rate)
 {
 	if (!mode.empty())

--- a/pcsx2/HostDisplay.h
+++ b/pcsx2/HostDisplay.h
@@ -133,6 +133,12 @@ public:
 	/// Returns the effective refresh rate of this display.
 	virtual bool GetHostRefreshRate(float* refresh_rate);
 
+	/// Enables/disables GPU frame timing.
+	virtual void SetGPUTimingEnabled(bool enabled);
+
+	/// Returns the amount of GPU time utilized since the last time this method was called.
+	virtual float GetAndResetAccumulatedGPUTime();
+
 	/// Returns true if it's an OpenGL-based renderer.
 	bool UsesLowerLeftOrigin() const;
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -300,6 +300,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdShowSpeed = false;
 	OsdShowFPS = false;
 	OsdShowCPU = false;
+	OsdShowGPU = false;
 	OsdShowResolution = false;
 	OsdShowGSStats = false;
 	OsdShowIndicators = true;
@@ -501,6 +502,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(OsdShowSpeed);
 	GSSettingBool(OsdShowFPS);
 	GSSettingBool(OsdShowCPU);
+	GSSettingBool(OsdShowGPU);
 	GSSettingBool(OsdShowResolution);
 	GSSettingBool(OsdShowGSStats);
 	GSSettingBool(OsdShowIndicators);

--- a/pcsx2/PerformanceMetrics.h
+++ b/pcsx2/PerformanceMetrics.h
@@ -28,6 +28,7 @@ namespace PerformanceMetrics
 	void Clear();
 	void Reset();
 	void Update(bool gs_register_write, bool fb_blit);
+	void OnGPUPresent(float gpu_time);
 
 	/// Sets the EE thread for CPU usage calculations.
 	void SetCPUThreadTimer(Common::ThreadCPUTimer timer);
@@ -60,4 +61,7 @@ namespace PerformanceMetrics
 	u32 GetGSSWThreadCount();
 	double GetGSSWThreadUsage(u32 index);
 	double GetGSSWThreadAverageTime(u32 index);
+
+	float GetGPUUsage();
+	float GetGPUAverageTime();
 } // namespace PerformanceMetrics

--- a/pcsx2/PerformanceMetrics.h
+++ b/pcsx2/PerformanceMetrics.h
@@ -32,6 +32,10 @@ namespace PerformanceMetrics
 	/// Sets the EE thread for CPU usage calculations.
 	void SetCPUThreadTimer(Common::ThreadCPUTimer timer);
 
+	/// Sets timers for GS software threads.
+	void SetGSSWThreadCount(u32 count);
+	void SetGSSWThreadTimer(u32 index, Common::ThreadCPUTimer timer);
+
 	/// Sets the vertical frequency, used in speed calculations.
 	void SetVerticalFrequency(float rate);
 
@@ -52,4 +56,8 @@ namespace PerformanceMetrics
 	float GetGSThreadAverageTime();
 	float GetVUThreadUsage();
 	float GetVUThreadAverageTime();
+
+	u32 GetGSSWThreadCount();
+	double GetGSSWThreadUsage(u32 index);
+	double GetGSSWThreadAverageTime(u32 index);
 } // namespace PerformanceMetrics


### PR DESCRIPTION
### Description of Changes

What the title says.

Keep in mind that the GPU usage is a bit difficult to interpret; 100% isn't necessarily 100%, it's 100% at the current clock speed. More load will push the clock speed up. But the same applies logic applies to CPU anyway.

There may be a *tiny* performance impact by enabling GPU usage counters, as there's a query. But it shouldn't block on retrieving the results, so that means the figures are technically a few frames behind, but better than making things slower.

### Rationale behind Changes

Letting users know when their GPU doesn't go brr.

### Suggested Testing Steps

Make sure stats work as expected on a range of systems.
