### PR TITLE
GameDB: Add a bunch of hw fixes and upscaling fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1013,7 +1013,8 @@ SCAJ-20190:
   name: "God of War II"
   region: "NTSC-Unk"
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SCAJ-20191:
   name: "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]"
   region: "NTSC-Unk"
@@ -1168,7 +1169,8 @@ SCAJ-30011:
   name: "God of War II"
   region: "NTSC-E"
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SCCS-40001:
   name: "Ape Escape 2"
   region: "NTSC-C"
@@ -2773,6 +2775,8 @@ SCES-51618:
 SCES-51635:
   name: "Brave - The Search for Spirit Dancer"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes lighting/shadows.
 SCES-51648:
   name: "Everquest - Online Adventures"
   region: "PAL-E-I"
@@ -3259,6 +3263,8 @@ SCES-53409:
     vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
   clampModes:
     vuClampMode: 2  # Fixes bugged camera.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCES-53422:
   name: "Stuart Little 3 - Big Photo Adventure"
   region: "PAL-M9"
@@ -3479,7 +3485,8 @@ SCES-54206:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SCES-54219:
   name: "Buzz! Junior - Jungle Party"
   region: "PAL-M7"
@@ -4434,7 +4441,8 @@ SCKA-30006:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SCPM-85101:
   name: "McDonald's Original Happy Disc"
   region: "NTSC-J"
@@ -6523,6 +6531,8 @@ SCUS-97316:
   name: "Sly 2 - Band of Thieves"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97317:
   name: "NFL GameDay 2004 [Demo]"
   region: "NTSC-U"
@@ -6834,6 +6844,8 @@ SCUS-97414:
 SCUS-97415:
   name: "Sly 2 - Band of Thieves [E3 Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97416:
   name: "Rise of the Kasai"
   region: "NTSC-U"
@@ -6976,6 +6988,8 @@ SCUS-97456:
 SCUS-97457:
   name: "Sly 2 - Band of Thieves [Retail Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97460:
   name: "MLB 2006 [Demo]"
   region: "NTSC-U"
@@ -6994,6 +7008,8 @@ SCUS-97464:
     vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
   clampModes:
     vuClampMode: 2  # Fixes bugged camera.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97465:
   name: "Ratchet - Deadlocked"
   region: "NTSC-U"
@@ -7076,12 +7092,14 @@ SCUS-97481:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SCUS-97482:
   name: "God of War II - The Colossus Battle [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SCUS-97483:
   name: "Gran Turismo 4 MX-5 Edition [Demo]"
   region: "NTSC-U"
@@ -7096,6 +7114,8 @@ SCUS-97484:
     vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
   clampModes:
     vuClampMode: 2  # Fixes bugged camera.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97485:
   name: "Ratchet - Deadlocked [Regular Demo]"
   region: "NTSC-U"
@@ -7253,6 +7273,8 @@ SCUS-97518:
 SCUS-97519:
   name: "Sly 2 - Band of Thieves [Greatest Hits]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97520:
   name: "Syphon Filter - The Omega Strain [Greatest Hits]"
   region: "NTSC-U"
@@ -7266,6 +7288,8 @@ SCUS-97527:
     vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
   clampModes:
     vuClampMode: 2  # Fixes bugged camera.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97528:
   name: "PlayStation Underground Demo Disc - Holiday 2005 [T-Rated]"
   region: "NTSC-U"
@@ -7670,6 +7694,8 @@ SLAJ-25068:
 SLAJ-25072:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLAJ-25073:
   name: "Resident Evil 4"
   region: "NTSC-Unk"
@@ -7900,6 +7926,8 @@ SLED-53745:
 SLED-53845:
   name: "Matrix, The - Path of Neo [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLED-53937:
   name: "Black [Demo]"
   region: "PAL-M5"
@@ -10749,10 +10777,14 @@ SLES-51347:
   name: "Die Hard - Vendetta"
   region: "PAL-M4"
   compat: 5
+  gsHWFixes:
+    mipmap: 1 # Reduces noisey textures.
 SLES-51348:
   name: "Die Hard - Vendetta"
   region: "PAL-E-G"
   compat: 5
+  gsHWFixes:
+    mipmap: 1 # Reduces noisey textures.
 SLES-51349:
   name: "Evolution Skateboarding"
   region: "PAL-M3"
@@ -11002,6 +11034,8 @@ SLES-51473:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes smoke effects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes fog misalignment.
 SLES-51474:
   name: "Blood Rayne"
   region: "PAL-M4"
@@ -13745,6 +13779,9 @@ SLES-52882:
   name: "Stolen"
   region: "PAL-M5"
   compat: 4
+  gsHWFixes:
+    fastTextureInvalidation: 1 # Improves performance.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLES-52884:
   name: "Duel Masters"
   region: "PAL-M5"
@@ -14978,6 +15015,8 @@ SLES-53461:
 SLES-53462:
   name: "Matrix, The - Path of Neo"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLES-53463:
   name: "NHL '06"
   region: "PAL-E"
@@ -15638,30 +15677,46 @@ SLES-53705:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "PAL-PL-E"
 SLES-53706:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-E"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53707:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53708:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53709:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-DU-F"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53710:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-S"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53712:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-M3"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53713:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-PL"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53715:
-  name: "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe"
+  name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "PAL-R"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53716:
   name: "Without Warning"
   region: "PAL-M5"
@@ -15794,6 +15849,8 @@ SLES-53758:
 SLES-53759:
   name: "Matrix, The - Path of Neo"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLES-53760:
   name: "Rugby Challenge 2006"
   region: "PAL-M5"
@@ -15870,6 +15927,8 @@ SLES-53799:
   name: "Matrix, The - Path of Neo"
   region: "PAL-M4"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLES-53800:
   name: "Rampage - Total Destruction"
   region: "PAL-M5"
@@ -15955,6 +16014,8 @@ SLES-53829:
 SLES-53830:
   name: "Psychonauts"
   region: "PAL-M3"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom.
 SLES-53831:
   name: "BloodRayne 2"
   region: "PAL-M5"
@@ -16674,21 +16735,24 @@ SLES-54182:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54183:
   name: "Scarface - The World is Yours"
   region: "PAL-G"
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54184:
   name: "Scarface - The World is Yours"
   region: "PAL-R"
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54185:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "PAL-M5"
@@ -16888,7 +16952,8 @@ SLES-54271:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54305:
   name: "Demon Chaos"
   region: "PAL-M5"
@@ -16927,6 +16992,8 @@ SLES-54317:
   name: "Ghost Rider"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Fixes alignment on fire effects.
 SLES-54319:
   name: "Biker Mice from Mars"
   region: "PAL-M5"
@@ -17307,6 +17374,8 @@ SLES-54454:
 SLES-54455:
   name: "Thrillville"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom effects.
 SLES-54456:
   name: "Beverly Hills Cop"
   region: "PAL-M11"
@@ -17453,9 +17522,13 @@ SLES-54513:
 SLES-54516:
   name: "Thrillville"
   region: "PAL-F-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom effects.
 SLES-54517:
   name: "Thrillville"
   region: "PAL-M3"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom effects.
 SLES-54518:
   name: "Clumsy Shumsy"
   region: "PAL-E"
@@ -17477,7 +17550,8 @@ SLES-54534:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLES-54536:
   name: "Big Idea's VeggieTales - LarryBoy and the Bad Apple"
   region: "PAL-I"
@@ -18094,9 +18168,13 @@ SLES-54805:
 SLES-54806:
   name: "Thrillville - Off the Rails"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLES-54807:
   name: "Thrillville - Off the Rails"
   region: "PAL-F"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLES-54809:
   name: "Charlotte's Web"
   region: "PAL-A"
@@ -18300,6 +18378,8 @@ SLES-54886:
 SLES-54887:
   name: "Thrillville - Verrückte Achterbahn"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLES-54888:
   name: "Pro Biker 2"
   region: "PAL-E"
@@ -18349,13 +18429,19 @@ SLES-54904:
   name: "Simpsons Game, The"
   region: "PAL-M4"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
 SLES-54905:
   name: "Simpsons Game, The"
   region: "PAL-F"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
 SLES-54906:
   name: "Simpsons Game, The"
   region: "PAL-I-S"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
 SLES-54913:
   name: "Pro Evolution Soccer 2008"
   region: "PAL-E-S"
@@ -18613,9 +18699,13 @@ SLES-55008:
 SLES-55010:
   name: "Thrillville - Fuori dai Binari"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLES-55011:
   name: "Thrillville - Fuera de Control"
   region: "PAL-S"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLES-55012:
   name: "Golden Compass, The"
   region: "PAL-M5"
@@ -18652,6 +18742,8 @@ SLES-55019:
 SLES-55020:
   name: "Die Simpsons - Das Spiel"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
 SLES-55021:
   name: "Pro Evolution Soccer 2008"
   region: "PAL-F-G"
@@ -19655,6 +19747,8 @@ SLES-55565:
 SLES-55569:
   name: "Silent Hill - Shattered Memories"
   region: "PAL-M5"
+  gsHWFixes:
+    fastTextureInvalidation: 1 # Fixes missing graphics.
 SLES-55571:
   name: "Ghostbusters"
   region: "PAL-M6"
@@ -26842,6 +26936,8 @@ SLPM-66176:
 SLPM-66177:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLPM-66178:
   name: "pop'n music 7 [Konami The Best]"
   region: "NTSC-J"
@@ -29590,7 +29686,8 @@ SLPM-67013:
   name: "God of War II - The End Begins"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2
+    halfPixelOffset: 2 # Fixes misaligned bloom.
+    roundSprite: 1 # Fixes chromatic effect.
 SLPM-67015:
   name: "School Days LxH"
   region: "NTSC-J"
@@ -33150,6 +33247,8 @@ SLPS-25624:
 SLPS-25626:
   name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLPS-25627:
   name: "Mobile Suit Gundam Climax U.C."
   region: "NTSC-J"
@@ -36466,6 +36565,8 @@ SLUS-20440:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes smoke effects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes fog misalignment.
 SLUS-20441:
   name: "NASCAR - Dirt to Daytona"
   region: "NTSC-U"
@@ -39335,6 +39436,8 @@ SLUS-21082:
   name: "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes lighting misalignment.
 SLUS-21083:
   name: "LEGO Star Wars: The Video Game"
   region: "NTSC-U"
@@ -39395,6 +39498,9 @@ SLUS-21099:
   name: "Stolen"
   region: "NTSC-U"
   compat: 4
+  gsHWFixes:
+    fastTextureInvalidation: 1 # Improves performance.
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLUS-21100:
   name: "NCAA March Madness 2005"
   region: "NTSC-U"
@@ -39458,7 +39564,8 @@ SLUS-21111:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLUS-21112:
   name: "L.A. Rush"
   region: "NTSC-U"
@@ -39498,6 +39605,8 @@ SLUS-21120:
   name: "Psychonauts"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom.
 SLUS-21122:
   name: "Taito Legends"
   region: "NTSC-U"
@@ -39521,6 +39630,8 @@ SLUS-21127:
   name: "Brave - The Search for Spirit Dancer"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes lighting/shadows.
 SLUS-21128:
   name: "Blitz - The League"
   region: "NTSC-U"
@@ -40246,6 +40357,8 @@ SLUS-21273:
   name: "Matrix, The - Path of Neo"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fix effects upscaling.
 SLUS-21274:
   name: "OutRun 2006: Coast 2 Coast"
   region: "NTSC-U"
@@ -40388,6 +40501,8 @@ SLUS-21306:
   name: "Ghost Rider"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mergeSprite: 1 # Fixes alignment on fire effects.
 SLUS-21307:
   name: "Ice Age 2 - The Meltdown"
   region: "NTSC-U"
@@ -40786,6 +40901,8 @@ SLUS-21380:
   compat: 5
   clampModes:
     vuClampMode: 3
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes fog line.
   patches:
     213DCAC9:
       content: |-
@@ -40939,6 +41056,8 @@ SLUS-21413:
   name: "Thrillville"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom effects.
 SLUS-21414:
   name: "Delta Force: Black Hawk Down - Team Sabre"
   region: "NTSC-U"
@@ -41354,7 +41473,8 @@ SLUS-21492:
   gameFixes:
     - IbitHack
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes post processing overlay.
+    roundSprite: 1 # Greatly reduces chromatic effect when upscaling.
 SLUS-21493:
   name: "Need for Speed - Carbon"
   region: "NTSC-U"
@@ -41739,6 +41859,8 @@ SLUS-21611:
   name: "Thrillville - Off the Rails"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes misaligned bloom effects.
 SLUS-21612:
   name: "Legend of the Dragon"
   region: "NTSC-U"
@@ -41981,6 +42103,8 @@ SLUS-21665:
   name: "Simpsons Game, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
 SLUS-21666:
   name: "Mountain Bike Adrenaline"
   region: "NTSC-U"
@@ -42960,6 +43084,8 @@ SLUS-21899:
   name: "Silent Hill - Shattered Memories"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    fastTextureInvalidation: 1 # Fixes missing graphics.
 SLUS-21900:
   name: "Scooby-Doo! First Frights"
   region: "NTSC-U"
@@ -43264,6 +43390,10 @@ SLUS-28034:
 SLUS-28037:
   name: "Kya - Dark Lineage [Trade Demo]"
   region: "NTSC-U"
+  gameFixes:
+    - EETimingHack # Fixes smoke effects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes fog misalignment.
 SLUS-28039:
   name: "Rogue Ops [Trade Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds a bunch of fixes and upscaling fixes for the following games.

Brave - The Search for Spirit Dancer
Chronicals of Narnia, The - The Lion, The Witch and the Wardrobe
Die Hard - Vendetta
Ghost Rider
God of War 2 (Added round sprite to get rid of chromatic effect)
Kya - Dark Lineage
Matrix, The - Path of Neo
Psychonauts
Scarface - The World is Yours (Still not perfect, but much better)
Silent Hill - Shattered Memories
Simpsons The - The Game
Sly 2
Sly 3
Snoopy Vs the Red Baron
Stolen (Upscaling and performance)
Thrillville
Thrillville - Off the Rails

### Rationale behind Changes
Games looked pretty bad when upscaled, still not perfect in some cases like Scarface but much better

### Suggested Testing Steps
None really required.
