### PR TITLE
GS: Per-selector switch for whether to use JIT for DrawScanline

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.h
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.h
@@ -66,17 +66,17 @@ public:
 
 	void DrawRect(const GSVector4i& r, const GSVertexSW& v);
 
+	static void CSetupPrim(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan, GSScanlineLocalData& local, const GSScanlineGlobalData& global);
+	static void CDrawScanline(int pixels, int left, int top, const GSVertexSW& scan, GSScanlineLocalData& local, const GSScanlineGlobalData& global);
+
+	template<class T> static bool TestAlpha(T& test, T& fm, T& zm, const T& ga, const GSScanlineGlobalData& global);
+	template<class T> static void WritePixel(const T& src, int addr, int i, u32 psm, const GSScanlineGlobalData& global);
+
 #ifndef ENABLE_JIT_RASTERIZER
 
 	void SetupPrim(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan);
 	void DrawScanline(int pixels, int left, int top, const GSVertexSW& scan);
 	void DrawEdge(int pixels, int left, int top, const GSVertexSW& scan);
-
-	bool IsEdge() const { return m_global.sel.aa1; }
-	bool IsRect() const { return m_global.sel.IsSolidRect(); }
-
-	template<class T> bool TestAlpha(T& test, T& fm, T& zm, const T& ga);
-	template<class T> void WritePixel(const T& src, int addr, int i, u32 psm);
 
 #endif
 

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.cpp
@@ -16,7 +16,68 @@
 #include "PrecompiledHeader.h"
 #include "GSDrawScanlineCodeGenerator.h"
 #include "GSDrawScanlineCodeGenerator.all.h"
+#include "GSDrawScanline.h"
+#include <fstream>
+#include <map>
+#include <mutex>
 
+static std::map<u64, bool> s_use_c_draw_scanline;
+static std::mutex s_use_c_draw_scanline_mutex;
+
+static bool shouldUseCDrawScanline(u64 key)
+{
+	static const char* const fname = getenv("USE_C_DRAW_SCANLINE");
+	if (!fname)
+		return false;
+
+	std::lock_guard<std::mutex> l(s_use_c_draw_scanline_mutex);
+
+	if (s_use_c_draw_scanline.empty())
+	{
+		std::ifstream file(fname);
+		if (file)
+		{
+			for (std::string str; std::getline(file, str);)
+			{
+				u64 key;
+				char yn;
+				if (sscanf(str.c_str(), "%llx %c", &key, &yn) == 2)
+				{
+					if (yn != 'Y' && yn != 'N' && yn != 'y' && yn != 'n')
+						Console.Warning("Failed to parse %s: Not y/n", str.c_str());
+					s_use_c_draw_scanline[key] = (yn == 'Y' || yn == 'y') ? true : false;
+				}
+				else
+				{
+					Console.Warning("Failed to process line %s", str.c_str());
+				}
+			}
+		}
+	}
+
+	auto idx = s_use_c_draw_scanline.find(key);
+	if (idx == s_use_c_draw_scanline.end())
+	{
+		s_use_c_draw_scanline[key] = false;
+		// Rewrite file
+		FILE* file = fopen(fname, "w");
+		if (file)
+		{
+			for (const auto& pair : s_use_c_draw_scanline)
+			{
+				fprintf(file, "%016llX %c %s\n", pair.first, pair.second ? 'Y' : 'N', GSScanlineSelector(pair.first).to_string().c_str());
+			}
+			fclose(file);
+		}
+		else
+		{
+			Console.Warning("Failed to write C draw scanline usage config: %s", strerror(errno));
+		}
+		return false;
+	}
+
+	return idx->second;
+}
 
 GSDrawScanlineCodeGenerator::GSDrawScanlineCodeGenerator(void* param, u64 key, void* code, size_t maxsize)
 	: GSCodeGenerator(code, maxsize)
@@ -27,6 +88,23 @@ GSDrawScanlineCodeGenerator::GSDrawScanlineCodeGenerator(void* param, u64 key, v
 
 	if (m_sel.breakpoint)
 		db(0xCC);
+
+	if (shouldUseCDrawScanline(key))
+	{
+#if defined(_WIN32)
+		mov(r8, reinterpret_cast<size_t>(&m_local));
+		push(ptr[r8 + offsetof(GSScanlineLocalData, gd)]);
+		push(r8);
+		sub(rsp, 32); // CC required shadow space
+		call(reinterpret_cast<void*>(GSDrawScanline::CDrawScanline));
+		ret(48);
+#else
+		mov(r8, reinterpret_cast<size_t>(&m_local));
+		mov(r9, ptr[r8 + offsetof(GSScanlineLocalData, gd)]);
+		jmp(reinterpret_cast<void*>(GSDrawScanline::CDrawScanline));
+#endif
+		return;
+	}
 
 	GSDrawScanlineCodeGenerator2(this, CPUInfo(m_cpu), (void*)&m_local, m_sel.key).Generate();
 }

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -108,11 +108,13 @@ union GSScanlineSelector
 			"fpsm:%d zpsm:%d ztst:%d ztest:%d atst:%d afail:%d iip:%d rfb:%d fb:%d zb:%d zw:%d "
 			"tfx:%d tcc:%d fst:%d ltf:%d tlu:%d wms:%d wmt:%d mmin:%d lcm:%d tw:%d "
 			"fba:%d cclamp:%d date:%d datm:%d "
-			"prim:%d abe:%d %d%d%d%d fge:%d dthe:%d notest:%d",
+			"prim:%d abe:%d %d%d%d%d fge:%d dthe:%d notest:%d pabe:%d aa1:%d "
+			"fwrite:%d ftest:%d zoverflow:%d zclamp:%d edge:%d",
 			fpsm, zpsm, ztst, ztest, atst, afail, iip, rfb, fb, zb, zwrite,
 			tfx, tcc, fst, ltf, tlu, wms, wmt, mmin, lcm, tw,
 			fba, colclamp, date, datm,
-			prim, abe, aba, abb, abc, abd, fge, dthe, notest);
+			prim, abe, aba, abb, abc, abd, fge, dthe, notest, pabe, aa1,
+			fwrite, ftest, zoverflow, zclamp, edge);
 		return str;
 	}
 

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -101,16 +101,24 @@ union GSScanlineSelector
 		return prim == GS_SPRITE_CLASS && iip == 0 && tfx == TFX_NONE && abe == 0 && ztst <= 1 && atst <= 1 && date == 0 && fge == 0;
 	}
 
+	std::string to_string() const
+	{
+		char str[1024];
+		sprintf(str,
+			"fpsm:%d zpsm:%d ztst:%d ztest:%d atst:%d afail:%d iip:%d rfb:%d fb:%d zb:%d zw:%d "
+			"tfx:%d tcc:%d fst:%d ltf:%d tlu:%d wms:%d wmt:%d mmin:%d lcm:%d tw:%d "
+			"fba:%d cclamp:%d date:%d datm:%d "
+			"prim:%d abe:%d %d%d%d%d fge:%d dthe:%d notest:%d",
+			fpsm, zpsm, ztst, ztest, atst, afail, iip, rfb, fb, zb, zwrite,
+			tfx, tcc, fst, ltf, tlu, wms, wmt, mmin, lcm, tw,
+			fba, colclamp, date, datm,
+			prim, abe, aba, abb, abc, abd, fge, dthe, notest);
+		return str;
+	}
+
 	void Print() const
 	{
-		fprintf(stderr, "fpsm:%d zpsm:%d ztst:%d ztest:%d atst:%d afail:%d iip:%d rfb:%d fb:%d zb:%d zw:%d "
-		                "tfx:%d tcc:%d fst:%d ltf:%d tlu:%d wms:%d wmt:%d mmin:%d lcm:%d tw:%d "
-		                "fba:%d cclamp:%d date:%d datm:%d "
-		                "prim:%d abe:%d %d%d%d%d fge:%d dthe:%d notest:%d\n",
-		        fpsm, zpsm, ztst, ztest, atst, afail, iip, rfb, fb, zb, zwrite,
-		        tfx, tcc, fst, ltf, tlu, wms, wmt, mmin, lcm, tw,
-		        fba, colclamp, date, datm,
-		        prim, abe, aba, abb, abc, abd, fge, dthe, notest);
+		fprintf(stderr, "%s\n", to_string().c_str());
 	}
 };
 


### PR DESCRIPTION
### Description of Changes
Adds a per-selector switch for using JIT for DrawScanline

### Rationale behind Changes
Easier to track down JIT bugs

### Suggested Testing Steps
Run with the environment variable `USE_C_DRAW_SCANLINE` set to a file name.  Open that file and edit some of the `N`s to `Y`s.  See if it still works (but slower).

Tested working on macOS x64.  x86 and Windows x64 are not yet tested
