### PR TITLE
GameDB: Add DMABusy fix to Shining Wind

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20636,8 +20636,10 @@ SLKA-25214:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLKA-25215:
-  name: "Shining Wild"
+  name: "Shining Wind"
   region: "NTSC-K"
+  gameFixes:
+    - DMABusyHack
 SLKA-25216:
   name: "Gitaroo-Man [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
@@ -28725,6 +28727,8 @@ SLPM-66670:
 SLPM-66671:
   name: "Shining Wind"
   region: "NTSC-J"
+  gameFixes:
+    - DMABusyHack
 SLPM-66672:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "NTSC-J"
@@ -30146,6 +30150,11 @@ SLPM-74254:
 SLPM-74259:
   name: "Odin Sphere [PlayStation 2 The Best]"
   region: "NTSC-J"
+SLPM-74261:
+  name: "Shining Wind [PlayStation 2 The Best]"
+  region: "NTSC-J"
+  gameFixes:
+    - DMABusyHack
 SLPM-74265:
   name: "Nobunaga no Yabou: Kakushin [PlayStation 2 The Best]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Booting Shining Wind results in a crash with the assert ["Gif Path Buffer Overflow!"](https://github.com/PCSX2/pcsx2/blob/515d9040a103ba928301580c5c81e4c87b95d885/pcsx2/Gif_Unit.h#L323). Either EETimingHack or DMABusyHack seems to fix booting, picked the DMA one to avoid Emotion.

### Rationale behind Changes
![0016](https://user-images.githubusercontent.com/2485237/158803409-4cc2e079-1e72-4c79-847c-2e9057e658e9.jpg)

### Suggested Testing Steps
Run the game with a master build, see if it crashes.
Run it again with manual game fixes, enable Handle DMAC, see if it boots.
