### PR TITLE
GUI: Rename Fast Texture Invalidation

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -723,7 +723,7 @@
          <item row="3" column="0">
           <widget class="QCheckBox" name="fastTextureInvalidation">
            <property name="text">
-            <string>Fast Texture Invalidation</string>
+            <string>Disable Partial Invalidation</string>
            </property>
           </widget>
          </item>

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -345,7 +345,7 @@ HacksTab::HacksTab(wxWindow* parent)
 	m_ui.addCheckBox(rend_hacks_grid, "Memory Wrapping",           "wrap_gs_mem",                          IDC_MEMORY_WRAPPING,   hacks_prereq);
 	m_ui.addCheckBox(rend_hacks_grid, "Disable Safe Features",     "UserHacks_Disable_Safe_Features",      IDC_SAFE_FEATURES,     hacks_prereq);
 	m_ui.addCheckBox(rend_hacks_grid, "Preload Frame Data",        "preload_frame_with_gs_data",           IDC_PRELOAD_GS,        hacks_prereq);
-	m_ui.addCheckBox(rend_hacks_grid, "Fast Texture Invalidation", "UserHacks_DisablePartialInvalidation", IDC_FAST_TC_INV,       hacks_prereq);
+	m_ui.addCheckBox(rend_hacks_grid, "Disable Partial Invalidation", "UserHacks_DisablePartialInvalidation", IDC_FAST_TC_INV,       hacks_prereq);
 	m_ui.addCheckBox(rend_hacks_grid, "Texture Inside RT",         "UserHacks_TextureInsideRt",            IDC_TEX_IN_RT,         hacks_prereq);
 
 	// Upscale


### PR DESCRIPTION
### Description of Changes
Renames Fast Texture Invalidation to Disable Partial Invalidation.

### Rationale behind Changes
Reduces confusion with users selecting it thinking it increases speed when it only generally helps with specific games.

### Suggested Testing Steps
Make sure it builds and the setting still functions correctly.
