### PR TITLE
GameDB: HW fixes for Rockman X8

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20699,6 +20699,8 @@ SLKA-25221:
 SLKA-25222:
   name: "Rockman X8"
   region: "NTSC-K"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
 SLKA-25224:
   name: "Detective Saburo Jinguji 9 - Kind of Blue"
   region: "NTSC-K"
@@ -25643,8 +25645,10 @@ SLPM-65729:
   name: "True Crime - Streets of L.A."
   region: "NTSC-J"
 SLPM-65730:
-  name: "RockMan X8"
+  name: "Rockman X8"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   memcardFilters:
     - "SLPM-65730"
     - "SLPM-65643"


### PR DESCRIPTION
The NTSC J & K versions were left out from this upscaling fixes batch https://github.com/PCSX2/pcsx2/pull/5664

I also remade the PR since[ my previous one](https://github.com/PCSX2/pcsx2/pull/5688) had a wrong description.