### PR TITLE
Qt: Fix bugs relating to per-game settings

### DIFF
--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -435,7 +435,7 @@ namespace SettingWidgetBinder
 
 			int sif_value;
 			if (sif->GetIntValue(section.c_str(), key.c_str(), &sif_value))
-				Accessor::setNullableIntValue(widget, sif_value);
+				Accessor::setNullableIntValue(widget, sif_value - option_offset);
 			else
 				Accessor::setNullableIntValue(widget, std::nullopt);
 
@@ -735,7 +735,7 @@ namespace SettingWidgetBinder
 			{
 				for (int i = 0; enum_values[i] != nullptr; i++)
 				{
-					if (value == enum_values[i])
+					if (sif_value == enum_values[i])
 					{
 						sif_int_value = i;
 						break;
@@ -744,9 +744,9 @@ namespace SettingWidgetBinder
 			}
 			Accessor::setNullableIntValue(widget, sif_int_value);
 
-			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), enum_names]() {
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), key = std::move(key), enum_values]() {
 				if (std::optional<int> new_value = Accessor::getNullableIntValue(widget); new_value.has_value())
-					sif->SetStringValue(section.c_str(), key.c_str(), enum_names[new_value.value()]);
+					sif->SetStringValue(section.c_str(), key.c_str(), enum_values[new_value.value()]);
 				else
 					sif->DeleteValue(section.c_str(), key.c_str());
 

--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -390,7 +390,7 @@ void SettingsDialog::setStringSettingValue(const char* section, const char* key,
 {
 	if (m_sif)
 	{
-		value.has_value() ? m_sif->SetBoolValue(section, key, value.value()) : m_sif->DeleteValue(section, key);
+		value.has_value() ? m_sif->SetStringValue(section, key, value.value()) : m_sif->DeleteValue(section, key);
 		m_sif->Save();
 	}
 	else


### PR DESCRIPTION
### Description of Changes
Fix the following bugs
One of the overloads for BindWidgetToEnumSetting() would select the wrong index if a per-game setting differed from global
setStringSettingValue would try to save the string as a bool when saving as a per-game setting

### Rationale behind Changes
Bug fixes

### Suggested Testing Steps
The DEV9 Qt PR UI has these fixes, and code that makes use of these functions, so you can check if it works there.
Other than that I guess a unit test can be written to test these functions.
