### PR TITLE
GameDB: HW fixes for Mega Man/Rockman X7 + Clamping mode fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11860,8 +11860,10 @@ SLES-51883:
   name: "Scooby-Doo! Mystery Mayhem"
   region: "PAL-M3"
 SLES-51885:
-  name: "MegaMan X7"
+  name: "Mega Man X7"
   region: "PAL-M5"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
@@ -20509,6 +20511,11 @@ SLKA-25112:
 SLKA-25115:
   name: "Rockman X7"
   region: "NTSC-K"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
+  compat: 5
+  clampModes:
+    eeClampMode: 3  # For camera issues in some scenes.
 SLKA-25125:
   name: "SNK vs. Capcom - Chaos"
   region: "NTSC-K"
@@ -21275,6 +21282,11 @@ SLPM-60172:
 SLPM-60207:
   name: "Rockman X7"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
+  compat: 5
+  clampModes:
+    eeClampMode: 3  # For camera issues in some scenes.
 SLPM-60243:
   name: "Full House Kiss [Trial]"
   region: "NTSC-J"
@@ -24435,8 +24447,11 @@ SLPM-65330:
   name: "Akudaikan 2"
   region: "NTSC-J"
 SLPM-65331:
-  name: "RockMan X7"
+  name: "Rockman X7"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
+  compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
 SLPM-65332:
@@ -36995,8 +37010,10 @@ SLUS-20486:
   region: "NTSC-U"
   compat: 5
 SLUS-20487:
-  name: "MegaMan X7"
+  name: "Mega Man X7"
   region: "NTSC-U"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11866,7 +11866,7 @@ SLES-51885:
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   clampModes:
-    eeClampMode: 3  # For camera issues in some scenes.
+    eeClampMode: 3 # For camera issues in some scenes.
 SLES-51886:
   name: "Lethal Skies II"
   region: "PAL-E"
@@ -20515,7 +20515,7 @@ SLKA-25115:
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   clampModes:
-    eeClampMode: 3  # For camera issues in some scenes.
+    eeClampMode: 3 # For camera issues in some scenes.
 SLKA-25125:
   name: "SNK vs. Capcom - Chaos"
   region: "NTSC-K"
@@ -21286,7 +21286,7 @@ SLPM-60207:
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   clampModes:
-    eeClampMode: 3  # For camera issues in some scenes.
+    eeClampMode: 3 # For camera issues in some scenes.
 SLPM-60243:
   name: "Full House Kiss [Trial]"
   region: "NTSC-J"
@@ -24453,7 +24453,7 @@ SLPM-65331:
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   clampModes:
-    eeClampMode: 3  # For camera issues in some scenes.
+    eeClampMode: 3 # For camera issues in some scenes.
 SLPM-65332:
   name: "Mahoromatic Automatic Maiden [Limited Edition]"
   region: "NTSC-J"
@@ -37016,7 +37016,7 @@ SLUS-20487:
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   clampModes:
-    eeClampMode: 3  # For camera issues in some scenes.
+    eeClampMode: 3 # For camera issues in some scenes.
 SLUS-20488:
   name: "Star Ocean 3 - Till the End of Time [Disc1of2]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11862,9 +11862,9 @@ SLES-51883:
 SLES-51885:
   name: "Mega Man X7"
   region: "PAL-M5"
+  compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
-  compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
 SLES-51886:
@@ -20511,9 +20511,9 @@ SLKA-25112:
 SLKA-25115:
   name: "Rockman X7"
   region: "NTSC-K"
+  compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
-  compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
 SLKA-25125:
@@ -21282,9 +21282,9 @@ SLPM-60172:
 SLPM-60207:
   name: "Rockman X7"
   region: "NTSC-J"
+  compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
-  compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
 SLPM-60243:
@@ -24449,9 +24449,9 @@ SLPM-65330:
 SLPM-65331:
   name: "Rockman X7"
   region: "NTSC-J"
+  compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
-  compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
 SLPM-65332:
@@ -37012,9 +37012,9 @@ SLUS-20486:
 SLUS-20487:
   name: "Mega Man X7"
   region: "NTSC-U"
+  compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
-  compat: 5
   clampModes:
     eeClampMode: 3  # For camera issues in some scenes.
 SLUS-20488:


### PR DESCRIPTION
-SoftwareRendererFMVHack for all versions of Mega Man/Rockman X7
-Clamping mode fix for camera issues across all versions
-Same compat info across all versions