### PR TITLE
deps: update `rapid-yaml` to `v0.4.1`

### DIFF
--- a/3rdparty/rapidyaml/ryml.vcxproj
+++ b/3rdparty/rapidyaml/ryml.vcxproj
@@ -52,6 +52,7 @@
     <ClInclude Include="rapidyaml\src\ryml_std.hpp" />
     <ClInclude Include="rapidyaml\src\c4\yml\detail\checks.hpp" />
     <ClInclude Include="rapidyaml\src\c4\yml\detail\parser_dbg.hpp" />
+    <ClInclude Include="rapidyaml\src\c4\yml\detail\print.hpp" />
     <ClInclude Include="rapidyaml\src\c4\yml\detail\stack.hpp" />
     <ClInclude Include="rapidyaml\src\c4\yml\common.hpp" />
     <ClCompile Include="rapidyaml\src\c4\yml\common.cpp" />
@@ -72,8 +73,7 @@
     <ClCompile Include="rapidyaml\src\c4\yml\tree.cpp" />
     <ClInclude Include="rapidyaml\src\c4\yml\writer.hpp" />
     <ClInclude Include="rapidyaml\src\c4\yml\yml.hpp" />
-    <Natvis Include="rapidyaml\src\ryml.natvis">
-    </Natvis>
+    <Natvis Include="rapidyaml\src\ryml.natvis"></Natvis>
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\allocator.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\base64.hpp" />
     <ClCompile Include="rapidyaml\ext\c4core\src\c4\base64.cpp" />
@@ -89,6 +89,7 @@
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\config.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\cpu.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\ctor_dtor.hpp" />
+    <ClInclude Include="rapidyaml\ext\c4core\src\c4\dump.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\enum.hpp" />
     <ClCompile Include="rapidyaml\ext\c4core\src\c4\error.cpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\error.hpp" />
@@ -107,35 +108,29 @@
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\restrict.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\span.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\std.hpp" />
+    <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\std_fwd.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\string.hpp" />
+    <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\string_fwd.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\tuple.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\vector.hpp" />
+    <ClInclude Include="rapidyaml\ext\c4core\src\c4\std\vector_fwd.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\substr.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\substr_fwd.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\szconv.hpp" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\time.hpp" />
-    <ClCompile Include="rapidyaml\ext\c4core\src\c4\time.cpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\type_name.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\types.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\unrestrict.hpp" />
+    <ClInclude Include="rapidyaml\ext\c4core\src\c4\utf.hpp" />
+    <ClCompile Include="rapidyaml\ext\c4core\src\c4\utf.cpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\windows.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\windows_pop.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\windows_push.hpp" />
-    <Natvis Include="rapidyaml\ext\c4core\src\c4\c4core.natvis">
-    </Natvis>
+    <Natvis Include="rapidyaml\ext\c4core\src\c4\c4core.natvis"></Natvis>
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\debugbreak\debugbreak.h" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\rng\rng.hpp" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\sg14\inplace_function.h" />
     <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float.hpp" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\ascii_number.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\bigint.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\decimal_to_binary.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\digit_comparison.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\fast_float.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\fast_table.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\float_common.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\parse_number.h" />
-    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float\include\fast_float\simple_decimal_conversion.h" />
+    <ClInclude Include="rapidyaml\ext\c4core\src\c4\ext\fast_float_all.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2324,7 +2324,6 @@ SCES-50295:
   compat: 5
   gsHWFixes:
     mipmap: 1
-  gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
     trilinearFiltering: 2 # Remove blurriness in font and models.
 SCES-50300:
@@ -4665,7 +4664,6 @@ SCPS-15004:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
-  gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
     trilinearFiltering: 2 # Remove blurriness in font and models.
 SCPS-15005:
@@ -5252,7 +5250,7 @@ SCPS-17013:
     roundSprite: 1 # Fix minimap and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
     trilinearFiltering: 2 # Remove blurriness in font and models.
-    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing. 
+    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
   patches:
     CDEE4B19:
       content: |-
@@ -5309,7 +5307,6 @@ SCPS-19203:
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
-  gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
     trilinearFiltering: 2 # Remove blurriness in font and models..
 SCPS-19204:
@@ -5967,7 +5964,6 @@ SCUS-97111:
   compat: 5
   gsHWFixes:
     mipmap: 1
-  gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
     trilinearFiltering: 2 # Remove blurriness in font and models.
 SCUS-97112:
@@ -6126,7 +6122,6 @@ SCUS-97152:
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
-  gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
     trilinearFiltering: 2 # Remove blurriness in font and models.
 SCUS-97153:

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -504,7 +504,7 @@ std::optional<std::vector<u8>> FileSystem::ReadBinaryFile(const char* filename)
 std::optional<std::vector<u8>> FileSystem::ReadBinaryFile(std::FILE* fp)
 {
 	std::fseek(fp, 0, SEEK_END);
-	long size = std::ftell(fp);
+	const long size = std::ftell(fp);
 	std::fseek(fp, 0, SEEK_SET);
 	if (size < 0)
 		return std::nullopt;
@@ -528,13 +528,14 @@ std::optional<std::string> FileSystem::ReadFileToString(const char* filename)
 std::optional<std::string> FileSystem::ReadFileToString(std::FILE* fp)
 {
 	std::fseek(fp, 0, SEEK_END);
-	long size = std::ftell(fp);
+	const long size = std::ftell(fp);
 	std::fseek(fp, 0, SEEK_SET);
 	if (size < 0)
 		return std::nullopt;
 
 	std::string res;
 	res.resize(static_cast<size_t>(size));
+	// NOTE - assumes mode 'rb', for example, this will fail over missing Windows carriage return bytes
 	if (size > 0 && std::fread(res.data(), 1u, static_cast<size_t>(size), fp) != static_cast<size_t>(size))
 		return std::nullopt;
 
@@ -553,7 +554,7 @@ bool FileSystem::WriteBinaryFile(const char* filename, const void* data, size_t 
 	return true;
 }
 
-bool FileSystem::WriteFileToString(const char* filename, const std::string_view& sv)
+bool FileSystem::WriteStringToFile(const char* filename, const std::string_view& sv)
 {
 	ManagedCFilePtr fp = OpenManagedCFile(filename, "wb");
 	if (!fp)

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -142,7 +142,7 @@ namespace FileSystem
 	std::optional<std::string> ReadFileToString(const char* filename);
 	std::optional<std::string> ReadFileToString(std::FILE* fp);
 	bool WriteBinaryFile(const char* filename, const void* data, size_t data_length);
-	bool WriteFileToString(const char* filename, const std::string_view& sv);
+	bool WriteStringToFile(const char* filename, const std::string_view& sv);
 
 	/// creates a directory in the local filesystem
 	/// if the directory already exists, the return value will be true.

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -465,15 +465,14 @@ void GameDatabase::initDatabase()
 	});
 	try
 	{
-		std::optional<std::vector<u8>> buf(Host::ReadResourceFile(GAMEDB_YAML_FILE_NAME));
+		auto buf = Host::ReadResourceFileToString(GAMEDB_YAML_FILE_NAME);
 		if (!buf.has_value())
 		{
 			Console.Error("[GameDB] Unable to open GameDB file, file does not exist.");
 			return;
 		}
 
-		const ryml::substr view = c4::basic_substring<char>(reinterpret_cast<char*>(buf->data()), buf->size());
-		ryml::Tree tree = ryml::parse(view);
+		ryml::Tree tree = ryml::parse_in_arena(c4::to_csubstr(buf.value()));
 		ryml::NodeRef root = tree.rootref();
 
 		for (const ryml::NodeRef& n : root.children())


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

- Latest version of rapidyaml fixes a bug in parsing/emitting that I discovered fixing the folder memory card regression.
- Cleaned up some of the code around the parsing and file handling
- Noticed a method in the FileSystem header that seemed to be named backwards and added a comment to something that caught me
- Noticed some mistakes in the GameDB (duplicate keys), fixed them at the same time.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

- Don't want us to fall victim to that bug again.
- `ryml::parse` is deprecated, this migrates to the preferred `parse_in_arena/place` methods

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Folder memory cards with games like GTA -- im paranoid about touching the folder memory card code after it broke before.
