### PR TITLE
GS/DX11: Fix incorrect format check for compressed textures

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -31,7 +31,7 @@
 static bool SupportsTextureFormat(ID3D11Device* dev, DXGI_FORMAT format)
 {
 	UINT support;
-	if (FAILED(dev->CheckFormatSupport(DXGI_FORMAT_BC1_UNORM, &support)))
+	if (FAILED(dev->CheckFormatSupport(format, &support)))
 		return false;
 
 	return (support & D3D11_FORMAT_SUPPORT_TEXTURE2D) != 0;


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

Silly mistake on my part I noticed.

### Suggested Testing Steps

None really needed, it'll pass on all supported GPUs anyway.
