### PR TITLE
GameDB: Add GS HW fixes for Wild Arms Alter Code F

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1134,6 +1134,8 @@ SCAJ-30001:
 SCAJ-30002:
   name: "Wild ARMs - Alter Code F"
   region: "NTSC-J"
+  gsHWFixes:
+    wildArmsHack: 1 #Fixes bugged lines in text in resolutions above native
 SCAJ-30003:
   name: "Siren"
   region: "NTSC-Unk"
@@ -5232,6 +5234,8 @@ SCPS-17001:
 SCPS-17002:
   name: "Wild ARMs - Alter Code F"
   region: "NTSC-J"
+  gsHWFixes:
+    wildArmsHack: 1 #Fixes bugged lines in text in resolutions above native
 SCPS-17008:
   name: "Nike - Gran Turismo [Limited Edition - 8 inch]"
   region: "NTSC-J"
@@ -5363,6 +5367,8 @@ SCPS-19215:
 SCPS-19251:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    wildArmsHack: 1 #Fixes bugged lines in text in resolutions above native
 SCPS-19252:
   name: "Gran Turismo 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5384,6 +5390,8 @@ SCPS-19252:
 SCPS-19253:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
+  gsHWFixes:
+    wildArmsHack: 1 #Fixes bugged lines in text in resolutions above native
 SCPS-19301:
   name: "Minna no Golf 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -38954,6 +38962,8 @@ SLUS-20937:
   name: "Wild ARMs - Alter Code F"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    wildArmsHack: 1 #Fixes bugged lines in text in resolutions above native
 SLUS-20938:
   name: "Dynasty Warriors 4 - Empires"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -31,7 +31,7 @@
 static bool SupportsTextureFormat(ID3D11Device* dev, DXGI_FORMAT format)
 {
 	UINT support;
-	if (FAILED(dev->CheckFormatSupport(DXGI_FORMAT_BC1_UNORM, &support)))
+	if (FAILED(dev->CheckFormatSupport(format, &support)))
 		return false;
 
 	return (support & D3D11_FORMAT_SUPPORT_TEXTURE2D) != 0;


### PR DESCRIPTION
### Description of Changes
It adds a gshack (wildArmsHack: 1) for all releases of Wild Arms Alter Code F (SCAJ-30002, SCPS-17002, SCPS-19251, SCPS-19253, SLUS-20937).

### Rationale behind Changes
The game needs this hack to prevent the appearance of buggy lines around text in resolutions above native.

Without hack, x2 res
![gs_20220319165228_Wild ARMs - Alter Code F _NTSC-U__SLUS-20937](https://user-images.githubusercontent.com/16591467/159128576-476a95bf-d268-4173-a3cd-f5c2a993980f.png)
With hack, x2 res
![gs_20220319165247_Wild ARMs - Alter Code F _NTSC-U__SLUS-20937](https://user-images.githubusercontent.com/16591467/159128578-b811f3c4-5a04-40f0-b9bf-7f8900b7b9ac.png)

### Suggested Testing Steps
Rise the internal resolution and just go to the title screen to check if the text is rendered correctly.
