### PR TITLE
Misc: Fix incorrect printf of std::string_view

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -313,13 +313,13 @@ void Host::ReportErrorAsync(const std::string_view& title, const std::string_vie
 {
 	if (!title.empty() && !message.empty())
 	{
-		Console.Error("ReportErrorAsync: %*s: %*s",
+		Console.Error("ReportErrorAsync: %.*s: %.*s",
 			static_cast<int>(title.size()), title.data(),
 			static_cast<int>(message.size()), message.data());
 	}
 	else if (!message.empty())
 	{
-		Console.Error("ReportErrorAsync: %*s",
+		Console.Error("ReportErrorAsync: %.*s",
 			static_cast<int>(message.size()), message.data());
 	}
 

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -102,7 +102,7 @@ void ControllerBindingWidget_Base::initBindingWidgets()
 		InputBindingWidget* widget = findChild<InputBindingWidget*>(QString::fromStdString(binding));
 		if (!widget)
 		{
-			Console.Error("(ControllerBindingWidget_Base) No widget found for '%s' (%*s)",
+			Console.Error("(ControllerBindingWidget_Base) No widget found for '%s' (%.*s)",
 				binding.c_str(), static_cast<int>(type.size()), type.data());
 			continue;
 		}

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -264,7 +264,7 @@ bool InputManager::SplitBinding(
 	const std::string_view::size_type slash_pos = binding.find('/');
 	if (slash_pos == std::string_view::npos)
 	{
-		Console.Warning("Malformed binding: '%*s'", static_cast<int>(binding.size()), binding.data());
+		Console.Warning("Malformed binding: '%.*s'", static_cast<int>(binding.size()), binding.data());
 		return false;
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -319,7 +319,7 @@ void GSTextureReplacements::ReloadReplacementMap()
 		if (!name.has_value())
 			continue;
 
-		DevCon.WriteLn("Found %ux%u replacement '%*s'", name->Width(), name->Height(), static_cast<int>(filename.size()), filename.data());
+		DevCon.WriteLn("Found %ux%u replacement '%.*s'", name->Width(), name->Height(), static_cast<int>(filename.size()), filename.data());
 		s_replacement_texture_filenames.emplace(std::move(name.value()), std::move(fd.FileName));
 	}
 
@@ -564,7 +564,7 @@ void GSTextureReplacements::DumpTexture(const GSTextureCache::HashCacheKey& hash
 		return;
 
 	const std::string_view title(FileSystem::GetFileTitleFromPath(filename));
-	DevCon.WriteLn("Dumping %ux%u texture '%*s'.", name.Width(), name.Height(), static_cast<int>(title.size()), title.data());
+	DevCon.WriteLn("Dumping %ux%u texture '%.*s'.", name.Width(), name.Height(), static_cast<int>(title.size()), title.data());
 
 	// compute width/height
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -218,7 +218,7 @@ void GameDatabase::parseAndInsert(const std::string_view& serial, const c4::yml:
 			std::optional<s32> value = n.has_val() ? StringUtil::FromChars<s32>(std::string_view(n.val().data(), n.val().size())) : 1;
 			if (!id.has_value() || !value.has_value())
 			{
-				Console.Error("[GameDB] Invalid GS HW Fix: '%*s' specified for serial '%*s'. Dropping!",
+				Console.Error("[GameDB] Invalid GS HW Fix: '%.*s' specified for serial '%.*s'. Dropping!",
 					static_cast<int>(id_name.size()), id_name.data(),
 					static_cast<int>(serial.size()), serial.data());
 				continue;

--- a/pcsx2/MemoryCardFile.cpp
+++ b/pcsx2/MemoryCardFile.cpp
@@ -929,7 +929,7 @@ bool FileMcd_CreateNewCard(const std::string_view& name, MemoryCardType type, Me
 
 	if (type == MemoryCardType::Folder)
 	{
-		Console.WriteLn("(FileMcd) Creating new PS2 folder memory card: '%*s'", static_cast<int>(name.size()), name.data());
+		Console.WriteLn("(FileMcd) Creating new PS2 folder memory card: '%.*s'", static_cast<int>(name.size()), name.data());
 
 		if (!FileSystem::CreateDirectoryPath(full_path.c_str(), false))
 		{


### PR DESCRIPTION
### Description of Changes

Turns out I'm a doofus and was printf'ing string_views incorrectly.

### Rationale behind Changes

Stops gamedb errors printf'ing half the file.

### Suggested Testing Steps

Make sure gamedb errors get printed correctly (I did this already).
