### PR TITLE
GS: Use pixel format mask for FBMSK checks

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -212,7 +212,7 @@ protected:
 		u8 uses_boundary;    ///< Whether or not the usage touches the left, top, right, or bottom edge (and therefore needs wrap modes preserved)
 	};
 	TextureMinMaxResult GetTextureMinMax(const GIFRegTEX0& TEX0, const GIFRegCLAMP& CLAMP, bool linear);
-	bool TryAlphaTest(u32& fm, u32& zm);
+	bool TryAlphaTest(u32& fm, const u32 fm_mask, u32& zm);
 	bool IsOpaque();
 	bool IsMipMapDraw();
 	bool IsMipMapActive();


### PR DESCRIPTION
### Description of Changes
Uses the preconfigured pixel format masks for doing FBMSK checks to see if the channel is entirely masked or not.

### Rationale behind Changes
Before it just did a blanket check of the whole 32bits (in some cases) which may not always be the case, this uses the pixel format mask to only check the bits we care about.
More brr in some scenarios?
Bit cleaner than having "this number, or this number, or this number" in places.

### Suggested Testing Steps
Test any games, especially ones with fancy post effects, make sure nothing is broken.
