### PR TITLE
Gamedb: Remove VU rounding form 'Hitman - Contracts'

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12403,29 +12403,19 @@ SLES-52125:
 SLES-52132:
   name: "Hitman - Contracts"
   region: "PAL-E"
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLES-52133:
   name: "Hitman - Contracts"
   region: "PAL-F"
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLES-52134:
   name: "Hitman - Contracts"
   region: "PAL-I"
   compat: 4
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLES-52135:
   name: "Hitman - Contracts"
   region: "PAL-G"
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLES-52136:
   name: "Hitman - Contracts"
   region: "PAL-S"
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLES-52143:
   name: "Carmen Sandiego - The Secret of the Stolen Drums"
   region: "PAL-M4"
@@ -20776,8 +20766,6 @@ SLKA-25217:
 SLKA-25218:
   name: "Hitman - Contracts"
   region: "NTSC-K"
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLKA-25219:
   name: "Monster Hunter G"
   region: "NTSC-K"
@@ -32824,8 +32812,6 @@ SLPS-25405:
 SLPS-25406:
   name: "Hitman - Contracts"
   region: "NTSC-J"
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLPS-25407:
   name: "King of Fighters 2003, The"
   region: "NTSC-J"
@@ -38817,8 +38803,6 @@ SLUS-20882:
   name: "Hitman - Contracts"
   region: "NTSC-U"
   compat: 3
-  roundModes:
-    vuRoundMode: 0  # Fixes effects and textures.
 SLUS-20883:
   name: "Tom Clancy's Rainbow Six 3"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Remove VU rounding form 'Hitman - Contracts'
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Having the rounding setting breaks the lighting, not having it makes a curtain invisible and removes some light cones. Removing it is the lesser evil
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
look at CI/test said game 