### PR TITLE
GS: Fix some edge cases with fbfetch

### DIFF
--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -43,6 +43,10 @@ in SHADER
 
 // Only enable framebuffer fetch when we actually need it.
 #if HAS_FRAMEBUFFER_FETCH && (PS_TEX_IS_FB == 1 || PS_FBMASK || SW_BLEND_NEEDS_RT || PS_DATE != 0)
+  // We need to force the colour to be defined here, to read from it.
+  // Basically the only scenario where this'll happen is RGBA masked and DATE is active.
+  #undef PS_NO_COLOR
+  #define PS_NO_COLOR 0
   #if defined(GL_EXT_shader_framebuffer_fetch)
     #undef TARGET_0_QUALIFIER
     #define TARGET_0_QUALIFIER inout

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -282,6 +282,22 @@ struct alignas(16) GSHWDrawConfig
 		{
 			return tex_is_fb || fbmask || date > 0 || blend_a == 1 || blend_b == 1 || blend_c == 1 || blend_d == 1;
 		}
+
+		/// Disables color output from the pixel shader, this is done when all channels are masked.
+		__fi void DisableColorOutput()
+		{
+			// remove software blending, since this will cause the color to be declared inout with fbfetch.
+			blend_a = blend_b = blend_c = blend_d = 0;
+
+			// TEX_IS_FB relies on us having a color output to begin with.
+			tex_is_fb = 0;
+
+			// no point having fbmask, since we're not writing. DATE has to stay.
+			fbmask = 0;
+
+			// disable both outputs.
+			no_color = no_color1 = 1;
+		}
 	};
 #pragma pack(pop)
 	struct PSSelectorHash


### PR DESCRIPTION
### Description of Changes

Second alpha pass with A masked, DATE enabled, etc.

Fixes shaders failing to compile when booting Tekken Tag when fbfetch is supported.

### Rationale behind Changes

Things I apparently didn't test properly.

### Suggested Testing Steps

Brief testing already done (TTT is fine now).
