### PR TITLE
GSDumpReplayer: Fix ReadFIFO2 packet executing on wrong thread

### DIFF
--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -258,8 +258,13 @@ void GSDumpReplayerCpuStep()
 
 		case GSDumpTypes::GSType::ReadFIFO2:
 		{
-			std::unique_ptr<char[]> arr(new char[*((int*)packet.data)]);
-			GSreadFIFO2((u8*)arr.get(), *((int*)packet.data));
+			u32 size;
+			std::memcpy(&size, packet.data, sizeof(size));
+
+			std::unique_ptr<u8[]> arr(new u8[size]);
+			GetMTGS().WaitGS();
+			GetMTGS().SendPointerPacket(GS_RINGTYPE_INIT_READ_FIFO2, size, arr.get());
+			GetMTGS().WaitGS(false); // wait without reg sync
 		}
 		break;
 


### PR DESCRIPTION
What the title says. I'm a goose and didn't read the code I adapted from the wx player..

Caused the FIFO read to happen on the CPU thread instead of the GS thread, which wreaked havoc in the renderer.
