### PR TITLE
GameDB: Remove outdated comments

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2330,12 +2330,6 @@ SCES-50006:
   name: "Drakan - The Ancients' Gates"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        // 04F9D87F
-        comment=- This gamedisc supports multiple languages through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SCES-50009:
   name: "Wild Wild Racing"
   region: "PAL-Unk"
@@ -2844,11 +2838,6 @@ SCES-51608:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SCES-51610:
   name: "This is Football 2004 (Red Devils 2004)"
   region: "PAL-F-DU"
@@ -3120,11 +3109,6 @@ SCES-52460:
     textureInsideRT: 1
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SCES-52529:
   name: "Sly Racoon 2 - Band of Thieves"
   region: "PAL-M11"
@@ -3159,13 +3143,7 @@ SCES-52677:
   region: "PAL-M7"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 1  # Fixes not rendering most the screen
-  patches:
-    default:
-      content: |-
-        // D859B1B4
-        comment=- This gamedisc supports widescreen through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
+    InstantVU1SpeedHack: 1  # Fixes not rendered most of the screen.
 SCES-52748:
   name: "EyeToy - Play 2"
   region: "PAL-M12"
@@ -8689,12 +8667,6 @@ SLES-50211:
   name: "Gauntlet - Dark Legacy"
   region: "PAL-M3"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-50212:
   name: "Paris-Dakar Rally"
   region: "PAL-E"
@@ -10765,10 +10737,6 @@ SLES-51227:
     default:
       content: |-
         // 54AD76D7
-        comment=- This gamedisc supports multiple languages and widescreen.
-        comment=- Language & widescreen selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
-        comment=- Full boot is recommended anyway for this gamedisc to avoid text problems.
         author=Prafull
         // Fix ingame SPS by interchanging vclipw.xyz vf5, vf5w with cfc2.
         patch=1,EE,001db3a0,word,48489000
@@ -12545,12 +12513,6 @@ SLES-52149:
   name: "Tom Clancy's Splinter Cell - Pandora Tomorrow"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-52150:
   name: "Legacy of Kain - Defiance"
   region: "PAL-M5"
@@ -14365,12 +14327,6 @@ SLES-53007:
   name: "Tom Clancy's Splinter Cell - Chaos Theory"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-53008:
   name: "Mercenaries"
   region: "PAL-I-S"
@@ -14766,12 +14722,6 @@ SLES-53152:
 SLES-53154:
   name: "Bard's Tale, The"
   region: "PAL-M8"
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-53155:
   name: "Star Wars - Episode III - Revenge of the Sith"
   region: "PAL-M3"
@@ -15891,12 +15841,6 @@ SLES-53667:
   name: "Gauntlet - Seven Sorrows"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-53668:
   name: "Micro Machines V4"
   region: "PAL-M5"
@@ -16318,12 +16262,6 @@ SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
   compat: 5
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-53827:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M3"
@@ -16496,12 +16434,6 @@ SLES-53908:
   compat: 5
   gsHWFixes:
     mipmap: 1 # Fixes distant characters and models but there are still some flickering textures.
-  patches:
-    default:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-53909:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "PAL-G"
@@ -17098,12 +17030,6 @@ SLES-54185:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "PAL-M5"
   compat: 5
-  patches:
-    33F7D21A:
-      content: |-
-        comment=- This gamedisc supports multiple languages.
-        comment=- Language selection is done through the BIOS configuration.
-        comment=- Implementation requires Full boot - 'Boot CDVD (full)'.
 SLES-54186:
   name: "Devil May Cry 3 - Dante's Awakening [Special Edition]"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The gameDB still had some leftover comments that aren't true anymore. In the past before 1.7.2002 / https://github.com/PCSX2/pcsx2/pull/3936 you needed to use full boot to correctly pass your chosen BIOS language to be piped to the game. Basically fast boot defaulted to the first entry in the available language list.
Full boot:
If you want to see BIOS logo - Good
Region check - Bad

Fast boot:
Immediately jump into the game - Good
Skips region check - Good
Now acts like full boot for languages - Good
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Unneeded and outdated is useless.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check the program log / console / emulog contents of the relevant games.