### PR TITLE
Qt: GS Settings Fixes

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -41,6 +41,7 @@ private Q_SLOTS:
 	void onAdapterChanged(int index);
 	void onEnableHardwareFixesChanged();
 	void onIntegerScalingChanged();
+	void onGpuPaletteConversionChanged(int state);
 	void onFullscreenModeChanged(int index);
 
 private:

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -309,11 +309,6 @@
         <widget class="QComboBox" name="upscaleMultiplier">
          <item>
           <property name="text">
-           <string>Custom</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
            <string>Native (PS2)</string>
           </property>
          </item>
@@ -349,7 +344,7 @@
          </item>
          <item>
           <property name="text">
-           <string>8x Native (~2280p)</string>
+           <string>8x Native (~2880p)</string>
           </property>
          </item>
         </widget>


### PR DESCRIPTION
### Description of Changes
Sets value of Anisotropic off to `0` instead of `1`
Disable the Anisotropic dropdown when GPU palette conversion is on
Fix issues with the renderer dropdown regarding per-game settings
Fix typo with 8x scale
Remove `Custom` Resolution entry

### Rationale behind Changes
Core sets the default Anisotropic to 0 for Off, while the Qt UI sets the default to 1 (also for Off), make this consistent
Anisotropic off appears to be assumed 0 in a few locations (assuming I'm reading the code correctly) such as https://github.com/PCSX2/pcsx2/blob/45682c382f349c39089d27814b23251a9f721c0b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp#L232

Disabling the Anisotropic dropdown when GPU palette conversion is on was requested by LT

Fix bugs & typos

We don't have Custom resolutions

### Suggested Testing Steps
Test the Anisotropic setting behaviour
Test if toggling GPU palette conversion disables/enables the Anisotropic dropdown
Also test the above with per-game settings
Test the render dropdown with per-game settings
Test that the resolution dropdown behaves correctly & selects the correct scaling
