### PR TITLE
GS: Improve interlace handling and odd frames

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -264,18 +264,29 @@ bool GSRenderer::Merge(int field)
 
 		if (m_regs->SMODE2.INT && GSConfig.InterlaceMode != GSInterlaceMode::Off)
 		{
+			const bool scanmask = (m_scanmask_used && scanmsk_frame) && GSConfig.InterlaceMode == GSInterlaceMode::Automatic;
+
 			if (GSConfig.InterlaceMode == GSInterlaceMode::Automatic && (m_regs->SMODE2.FFMD)) // Auto interlace enabled / Odd frame interlace setting
 			{
-				int field2 = 0;
-				int mode = 2;
+				constexpr int field2 = 1;
+				constexpr int mode = 2;
 				g_gs_device->Interlace(ds, field ^ field2, mode, tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
 			}
 			else
 			{
-				bool scanmask = (m_scanmask_used && scanmsk_frame) && GSConfig.InterlaceMode == GSInterlaceMode::Automatic;
-				int field2 = 1 - ((static_cast<int>(GSConfig.InterlaceMode) - 1) & 1);
-				int mode = scanmask ? 2 : (static_cast<int>(GSConfig.InterlaceMode) - 1) >> 1;
-				g_gs_device->Interlace(ds, field ^ field2, mode, tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
+				const int field2 = scanmask ? 0 : 1 - ((static_cast<int>(GSConfig.InterlaceMode) - 1) & 1);
+				const int offset = tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y;
+				// -1 = None
+				// 0 = Weave
+				// 1 = Bob
+				// 2 = Blend
+				int mode = scanmask ? 2 : std::clamp((static_cast<int>(GSConfig.InterlaceMode) - 1) >> 1, -1, 2);
+
+				// If we're on auto, prefer no interlacing (bob, kinda), unless there is an offset or scanmsk, then retain blend
+				if (GSConfig.InterlaceMode == GSInterlaceMode::Automatic && !(m_regs->SMODE2.FFMD) && !scanmask && !offset)
+					mode = -1;
+
+				g_gs_device->Interlace(ds, field ^ field2, mode, offset);
 			}
 		}
 
@@ -429,7 +440,7 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 
 	g_gs_device->AgePool();
 
-	const bool blank_frame = !Merge(field ? 1 : 0);
+	const bool blank_frame = !Merge(field);
 	const bool skip_frame = m_frameskip;
 
 	if (blank_frame || skip_frame)

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -441,7 +441,7 @@ void SysMtgsThread::ExecuteTaskInThread()
 							((GSRegSIGBLID&)RingBuffer.Regs[0x1080]) = (GSRegSIGBLID&)remainder[2];
 
 							// CSR & 0x2000; is the pageflip id.
-							GSvsync(((u32&)RingBuffer.Regs[0x1000]) & 0x2000, remainder[4] != 0);
+							GSvsync((((u32&)RingBuffer.Regs[0x1000]) & 0x2000) ? 0 : 1, remainder[4] != 0);
 							gsFrameSkip();
 
 							m_QueuedFrameCount.fetch_sub(1);

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -766,7 +766,7 @@ void Dialogs::GSDumpDialog::ProcessDumpEvent(const GSDumpFile::GSData& event, u8
 		}
 		case GSType::VSync:
 		{
-			GSvsync((*((int*)(regs + 4096)) & 0x2000) > 0 ? (u8)1 : (u8)0, false);
+			GSvsync((*((int*)(regs + 4096)) & 0x2000) > 0 ? (u8)0 : (u8)1, false);
 			g_FrameCount++;
 			break;
 		}


### PR DESCRIPTION
### Description of Changes
Attempt to improve interlace handling on games which were shaking or relying on the interlacing to display the picture (NBA Jam 2004)

### Rationale behind Changes
The frame/interlace handling to try and get the correct FIELD values reported and used.

### Suggested Testing Steps
test games with auto interlacing, make sure they don't shake or have half the picture missing or what have you.

Fixes #5262
