### PR TITLE
128mb of ram toggle

### DIFF
--- a/common/Dependencies.h
+++ b/common/Dependencies.h
@@ -249,6 +249,7 @@ static const s64 _8mb = _1mb * 8;
 static const s64 _16mb = _1mb * 16;
 static const s64 _32mb = _1mb * 32;
 static const s64 _64mb = _1mb * 64;
+static const s64 _128mb = _1mb * 128;
 static const s64 _256mb = _1mb * 256;
 static const s64 _1gb = _1mb * 1024;
 static const s64 _4gb = _1gb * 4;

--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
@@ -33,6 +33,7 @@ AdvancedSystemSettingsWidget::AdvancedSystemSettingsWidget(SettingsDialog* dialo
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeRecompiler, "EmuCore/CPU/Recompiler", "EnableEE", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeCache, "EmuCore/CPU/Recompiler", "EnableEECache", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ee128mbram, "EmuCore/CPU/Recompiler", "EnableEE128mbRam", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeINTCSpinDetection, "EmuCore/Speedhacks", "IntcStat", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeWaitLoopDetection, "EmuCore/Speedhacks", "WaitLoop", true);
 

--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
@@ -53,6 +53,13 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="2">
+       <widget class="QCheckBox" name="ee128mbram">
+        <property name="text">
+         <string>Enable 128 MB of RAM</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1">
        <widget class="QCheckBox" name="eeINTCSpinDetection">
         <property name="text">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -361,7 +361,8 @@ struct Pcsx2Config
 			PreBlockCheckEE : 1,
 			PreBlockCheckIOP : 1;
 		bool
-			EnableEECache : 1;
+			EnableEECache : 1,
+			EnableEE128mbRam : 1;
 		BITFIELD_END
 
 		RecompilerOptions();
@@ -996,6 +997,7 @@ namespace EmuFolders
 #define INSTANT_VU1 (EmuConfig.Speedhacks.vu1Instant)
 #define CHECK_EEREC (EmuConfig.Cpu.Recompiler.EnableEE)
 #define CHECK_CACHE (EmuConfig.Cpu.Recompiler.EnableEECache)
+#define CHECK_128MBRAM (EmuConfig.Cpu.Recompiler.EnableEE128mbRam)
 #define CHECK_IOPREC (EmuConfig.Cpu.Recompiler.EnableIOP)
 
 //------------ SPECIAL GAME FIXES!!! ---------------

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -617,7 +617,7 @@ bool R5900DebugInterface::isValidAddress(u32 addr)
 			// [ 0000_8000 - 01FF_FFFF ] RAM
 			// [ 2000_8000 - 21FF_FFFF ] RAM MIRROR
 			// [ 3000_8000 - 31FF_FFFF ] RAM MIRROR
-			if (lopart >= 0x80000 && lopart <= 0x1ffFFff)
+			if (lopart >= 0x80000 && lopart <= (CHECK_128MBRAM ? 0x7ffFFff : 0x1ffFFff))
 				return !!vtlb_GetPhyPtr(lopart);
 			break;
 		case 1:

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -19,7 +19,7 @@
 
 namespace Ps2MemSize
 {
-	static const uint MainRam	= _32mb;			// 32 MB main memory!
+	static const uint MainRam	= _128mb;			// 32 MB main memory (extended to 128)!
 	static const uint Rom		= _1mb * 4;			// 4 MB main rom
 	static const uint Rom1		= 0x00040000;		// DVD player
 	static const uint Rom2		= 0x00080000;		// Chinese rom extension (?)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -150,6 +150,7 @@ Pcsx2Config::RecompilerOptions::RecompilerOptions()
 
 	EnableEE = true;
 	EnableEECache = false;
+	EnableEE128mbRam = false;
 	EnableIOP = true;
 	EnableVU0 = true;
 	EnableVU1 = true;
@@ -207,6 +208,7 @@ void Pcsx2Config::RecompilerOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableEE);
 	SettingsWrapBitBool(EnableIOP);
 	SettingsWrapBitBool(EnableEECache);
+	SettingsWrapBitBool(EnableEE128mbRam);
 	SettingsWrapBitBool(EnableVU0);
 	SettingsWrapBitBool(EnableVU1);
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -554,15 +554,16 @@ void __fastcall eeGameStarting()
 		//Console.WriteLn( Color_Green, "(R5900) ELF Entry point! [addr=0x%08X]", ElfEntry );
 		g_GameStarted = true;
 		g_GameLoading = false;
+
+		// we are using a retail BIOS, which will not map the upper memory, so we must do it manually
+		if (CHECK_128MBRAM)
+			vtlb_VMap(0x02000000, 0x02000000, 0x06000000);
+
 #ifndef PCSX2_CORE
 		GetCoreThread().GameStartingInThread();
 #else
 		VMManager::Internal::GameStartingOnCPUThread();
 #endif
-
-		// we are using a retail BIOS, which will not map the upper memory, so we must do it manually
-		if (CHECK_128MBRAM)
-			vtlb_VMap(0x02000000, 0x02000000, 0x06000000);
 
 		// GameStartingInThread may issue a reset of the cpu and/or recompilers.  Check for and
 		// handle such things here:

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -560,6 +560,9 @@ void __fastcall eeGameStarting()
 		VMManager::Internal::GameStartingOnCPUThread();
 #endif
 
+		// we are using a retail BIOS, which will not map the upper memory, so we must do it manually
+		if (CHECK_128MBRAM)
+			vtlb_VMap(0x02000000, 0x02000000, 0x06000000);
 
 		// GameStartingInThread may issue a reset of the cpu and/or recompilers.  Check for and
 		// handle such things here:

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -42,41 +42,43 @@ class RecompiledCodeReserve;
 
 namespace HostMemoryMap
 {
-	static const u32 Size = 0x28000000;
+	static constexpr u32 _128mbOffset = 0x6000000;
+
+	static constexpr u32 Size = 0x28000000 + _128mbOffset; // 160mb(base) + 96MB(extra needed to bring up to 128MB)
 
 	// The actual addresses may not be equivalent to Base + Offset in the event that allocation at Base failed
 	// Each of these offsets has a debugger-accessible equivalent variable without the Offset suffix that will hold the actual address (not here because we don't want code using it)
 
 	// PS2 main memory, SPR, and ROMs
-	static const u32 EEmemOffset   = 0x00000000;
+	static constexpr u32 EEmemOffset   = 0x00000000; // 128mb
 
 	// IOP main memory and ROMs
-	static const u32 IOPmemOffset  = 0x04000000;
+	static constexpr u32 IOPmemOffset  = 0x04000000 + _128mbOffset;
 
 	// VU0 and VU1 memory.
-	static const u32 VUmemOffset   = 0x08000000;
+	static constexpr u32 VUmemOffset   = 0x08000000 + _128mbOffset;
 
 	// EE recompiler code cache area (64mb)
-	static const u32 EErecOffset   = 0x10000000;
+	static constexpr u32 EErecOffset   = 0x10000000 + _128mbOffset;
 
 	// IOP recompiler code cache area (16 or 32mb)
-	static const u32 IOPrecOffset  = 0x14000000;
+	static constexpr u32 IOPrecOffset  = 0x14000000 + _128mbOffset;
 
 	// newVif0 recompiler code cache area (16mb)
-	static const u32 VIF0recOffset = 0x16000000;
+	static constexpr u32 VIF0recOffset = 0x16000000 + _128mbOffset;
 
 	// newVif1 recompiler code cache area (32mb)
-	static const u32 VIF1recOffset = 0x18000000;
+	static constexpr u32 VIF1recOffset = 0x18000000 + _128mbOffset;
 
 	// microVU1 recompiler code cache area (32 or 64mb)
-	static const u32 mVU0recOffset = 0x1C000000;
+	static constexpr u32 mVU0recOffset = 0x1C000000 + _128mbOffset;
 
 	// microVU0 recompiler code cache area (64mb)
-	static const u32 mVU1recOffset = 0x20000000;
+	static constexpr u32 mVU1recOffset = 0x20000000 + _128mbOffset;
 
 	// Bump allocator for any other small allocations
 	// size: Difference between it and HostMemoryMap::Size, so nothing should allocate higher than it!
-	static const u32 bumpAllocatorOffset = 0x24000000;
+	static constexpr u32 bumpAllocatorOffset = 0x24000000 + _128mbOffset;
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -176,6 +176,7 @@ namespace Panels
 		pxRadioPanel* m_panel_RecEE;
 		pxRadioPanel* m_panel_RecIOP;
 		pxCheckBox* m_check_EECacheEnable;
+		pxCheckBox* m_check_EE128mbEnable;
 		AdvancedOptionsFPU* m_advancedOptsFpu;
 		wxButton* m_button_RestoreDefaults;
 

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -152,6 +152,7 @@ Panels::CpuPanelEE::CpuPanelEE( wxWindow* parent )
 
 	s_ee	+= m_panel_RecEE	| StdExpand();
 	s_ee    += m_check_EECacheEnable = &(new pxCheckBox( this, _("Enable EE Cache (Slower)") ))->SetToolTip(_("Interpreter only; provided for diagnostic"));
+	s_ee    += m_check_EE128mbEnable = &(new pxCheckBox( this, _("Enable 128 MB of RAM") ))->SetToolTip(_("Increases the amount of EE Memory"));
 	s_iop	+= m_panel_RecIOP	| StdExpand();
 
 	s_recs	+= s_ee				| SubGroup();
@@ -227,9 +228,10 @@ Panels::CpuPanelVU::CpuPanelVU( wxWindow* parent )
 void Panels::CpuPanelEE::Apply()
 {
 	Pcsx2Config::RecompilerOptions& recOps( g_Conf->EmuOptions.Cpu.Recompiler );
-	recOps.EnableEE		  = !!m_panel_RecEE->GetSelection();
-	recOps.EnableIOP	  = !!m_panel_RecIOP->GetSelection();
-	recOps.EnableEECache  = m_check_EECacheEnable->GetValue();
+	recOps.EnableEE		    = !!m_panel_RecEE->GetSelection();
+	recOps.EnableIOP	    = !!m_panel_RecIOP->GetSelection();
+	recOps.EnableEECache    = m_check_EECacheEnable->GetValue();
+	recOps.EnableEE128mbRam = m_check_EE128mbEnable->GetValue();
 }
 
 void Panels::CpuPanelEE::AppStatusEvent_OnSettingsApplied()
@@ -249,6 +251,10 @@ void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
 	//EECache option is exclusive to the EE Interpreter.
 	m_check_EECacheEnable->SetValue(recOps.EnableEECache);
 	m_check_EECacheEnable->Enable(!configToApply.EnablePresets && m_panel_RecEE->GetSelection() == 0);
+
+	m_check_EE128mbEnable->SetValue(recOps.EnableEE128mbRam);
+	m_check_EE128mbEnable->Enable(!configToApply.EnablePresets);
+
 	m_button_RestoreDefaults->Enable(!configToApply.EnablePresets);
 
 	if( flags & AppConfig::APPLY_FLAG_MANUALLY_PROPAGATE )

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -15,7 +15,6 @@
 
 #include "PrecompiledHeader.h"
 #include "ConfigurationPanels.h"
-#include <pcsx2/R5900.h>
 
 using namespace pxSizerFlags;
 
@@ -254,7 +253,7 @@ void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
 	m_check_EECacheEnable->Enable(!configToApply.EnablePresets && m_panel_RecEE->GetSelection() == 0);
 
 	m_check_EE128mbEnable->SetValue(recOps.EnableEE128mbRam);
-	m_check_EE128mbEnable->Enable(!configToApply.EnablePresets && !g_GameStarted && !g_GameLoading);
+	m_check_EE128mbEnable->Enable(!configToApply.EnablePresets);
 
 	m_button_RestoreDefaults->Enable(!configToApply.EnablePresets);
 

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "ConfigurationPanels.h"
+#include <pcsx2/R5900.h>
 
 using namespace pxSizerFlags;
 
@@ -253,7 +254,7 @@ void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
 	m_check_EECacheEnable->Enable(!configToApply.EnablePresets && m_panel_RecEE->GetSelection() == 0);
 
 	m_check_EE128mbEnable->SetValue(recOps.EnableEE128mbRam);
-	m_check_EE128mbEnable->Enable(!configToApply.EnablePresets);
+	m_check_EE128mbEnable->Enable(!configToApply.EnablePresets && !g_GameStarted && !g_GameLoading);
 
 	m_button_RestoreDefaults->Enable(!configToApply.EnablePresets);
 


### PR DESCRIPTION
### Description of Changes
Bringing an option to have 128mb of EE ram, from pcsx2-rr project (https://github.com/xTVaser/pcsx2-rr/issues/102).
Since memory layout is set up at compile-time, this basically just allocates more memory regardless of what the toggle status is, but I added a check for it in couple of internal functions that will behave accordingly.
![pcsx2x64-dbg_2022-03-25_14-29-52](https://user-images.githubusercontent.com/4904157/160119631-9d3fbcd9-9476-4d10-963d-191a89ae2223.png)
![pcsx2-qtx64-dbg_2022-03-25_17-03-31](https://user-images.githubusercontent.com/4904157/160136677-d4a1dd5a-836c-42cf-b7e0-2bed4b93cd3a.png)


### Rationale behind Changes
More memory can be used to allocate custom code and data in it, which greatly improves possibilities to create mods(including pnach).
With both, toggle enabled and disabled, GetMemorySize syscall returns `0x2000000`, so this does not make the games aware of more memory, and it's not the point of this PR. Also this shouldn't break anything compatibility wise etc.
Tested by manually creating a call to address beyond 32mb limit, the code executes with no issues:
![pcsx2x64-dbg_2022-03-25_15-03-50](https://user-images.githubusercontent.com/4904157/160117721-b2470ab8-2065-4b30-be2e-f155933fc2e9.png)

![pcsx2x64-dbg_2022-03-25_15-04-34](https://user-images.githubusercontent.com/4904157/160117751-e86d4855-0782-41fe-8c25-6825543a177b.png)


### Suggested Testing Steps
You can see more memory being available at address 0x02000000 in the debugger.

Toggle enabled:
![pcsx2x64-dbg_2022-03-25_14-29-14](https://user-images.githubusercontent.com/4904157/160113818-c074f54d-481d-4982-b2ad-9e5a42aac021.png)

Toggle disabled:
![pcsx2x64-dbg_2022-03-25_14-28-52](https://user-images.githubusercontent.com/4904157/160113823-b5801868-8903-40ba-a567-710a735f9703.png)

