### PR TITLE
Qt: Implement automatic controller mapping

### DIFF
--- a/common/StringUtil.cpp
+++ b/common/StringUtil.cpp
@@ -251,6 +251,30 @@ namespace StringUtil
 		return str.substr(start, end - start + 1);
 	}
 
+	std::vector<std::string_view> SplitString(const std::string_view& str, char delimiter, bool skip_empty /*= true*/)
+	{
+		std::vector<std::string_view> res;
+		std::string_view::size_type last_pos = 0;
+		std::string_view::size_type pos;
+		while (last_pos < str.size() && (pos = str.find(delimiter, last_pos)) != std::string_view::npos)
+		{
+			std::string_view part(StripWhitespace(str.substr(last_pos, pos - last_pos)));
+			if (!skip_empty || !part.empty())
+				res.push_back(std::move(part));
+
+			last_pos = pos + 1;
+		}
+
+		if (last_pos < str.size())
+		{
+			std::string_view part(StripWhitespace(str.substr(last_pos)));
+			if (!skip_empty || !part.empty())
+				res.push_back(std::move(part));
+		}
+
+		return res;
+	}
+
 	std::wstring UTF8StringToWideString(const std::string_view& str)
 	{
 		std::wstring ret;

--- a/common/StringUtil.h
+++ b/common/StringUtil.h
@@ -167,6 +167,9 @@ namespace StringUtil
 	/// Strip whitespace from the start/end of the string.
 	std::string_view StripWhitespace(const std::string_view& str);
 
+	/// Splits a string based on a single character delimiter.
+	std::vector<std::string_view> SplitString(const std::string_view& str, char delimiter, bool skip_empty = true);
+
 	/// Strided memcpy/memcmp.
 	static inline void StrideMemCpy(void* dst, std::size_t dst_stride, const void* src, std::size_t src_stride,
 		std::size_t copy_size, std::size_t count)

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -54,7 +54,6 @@ static bool InitializeConfig();
 static void HookSignals();
 static bool SetCriticalFolders();
 static void SetDefaultConfig();
-static void QueueSettingsSave();
 static void SaveSettings();
 }
 
@@ -175,6 +174,11 @@ void QtHost::SetDefaultConfig()
 
 	EmuFolders::Save(si);
 	PAD::SetDefaultConfig(si);
+}
+
+SettingsInterface* QtHost::GetBaseSettingsInterface()
+{
+	return s_base_settings_interface.get();
 }
 
 std::string QtHost::GetBaseStringSettingValue(const char* section, const char* key, const char* default_value /*= ""*/)

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -38,6 +38,7 @@ namespace QtHost
 	void UpdateLogging();
 
 	/// Thread-safe settings access.
+	SettingsInterface* GetBaseSettingsInterface();
 	std::string GetBaseStringSettingValue(const char* section, const char* key, const char* default_value = "");
 	bool GetBaseBoolSettingValue(const char* section, const char* key, bool default_value = false);
 	int GetBaseIntSettingValue(const char* section, const char* key, int default_value = 0);
@@ -51,4 +52,5 @@ namespace QtHost
 	bool AddBaseValueToStringList(const char* section, const char* key, const char* value);
 	bool RemoveBaseValueFromStringList(const char* section, const char* key, const char* value);
 	void RemoveBaseSettingValue(const char* section, const char* key);
+	void QueueSettingsSave();
 } // namespace QtHost

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.h
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.h
@@ -39,9 +39,11 @@ public:
 
 private Q_SLOTS:
 	void onTypeChanged();
+	void doAutomaticBinding();
 
 private:
 	void populateControllerTypes();
+	void doDeviceAutomaticBinding(const QString& device);
 
 	Ui::ControllerBindingWidget m_ui;
 

--- a/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.cpp
@@ -89,18 +89,29 @@ void ControllerSettingsDialog::onCategoryCurrentRowChanged(int row)
 
 void ControllerSettingsDialog::onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices)
 {
+	m_device_list = devices;
 	for (const QPair<QString, QString>& device : devices)
 		m_global_settings->addDeviceToList(device.first, device.second);
 }
 
 void ControllerSettingsDialog::onInputDeviceConnected(const QString& identifier, const QString& device_name)
 {
+	m_device_list.emplace_back(identifier, device_name);
 	m_global_settings->addDeviceToList(identifier, device_name);
 	g_emu_thread->enumerateVibrationMotors();
 }
 
 void ControllerSettingsDialog::onInputDeviceDisconnected(const QString& identifier)
 {
+	for (auto iter = m_device_list.begin(); iter != m_device_list.end(); ++iter)
+	{
+		if (iter->first == identifier)
+		{
+			m_device_list.erase(iter);
+			break;
+		}
+	}
+
 	m_global_settings->removeDeviceFromList(identifier);
 	g_emu_thread->enumerateVibrationMotors();
 }

--- a/pcsx2-qt/Settings/ControllerSettingsDialog.h
+++ b/pcsx2-qt/Settings/ControllerSettingsDialog.h
@@ -50,6 +50,7 @@ public:
 
 	HotkeySettingsWidget* getHotkeySettingsWidget() const { return m_hotkey_settings; }
 
+	__fi const QList<QPair<QString, QString>>& getDeviceList() const { return m_device_list; }
 	__fi const QStringList& getVibrationMotors() const { return m_vibration_motors; }
 
 public Q_SLOTS:
@@ -70,5 +71,6 @@ private:
 	std::array<ControllerBindingWidget*, MAX_PORTS> m_port_bindings{};
 	HotkeySettingsWidget* m_hotkey_settings = nullptr;
 
+	QList<QPair<QString, QString>> m_device_list;
 	QStringList m_vibration_motors;
 };

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -583,6 +583,18 @@ void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, const ch
 		}
 	}
 
+	for (u32 macro_button_index = 0; macro_button_index < PAD::NUM_MACRO_BUTTONS_PER_CONTROLLER; macro_button_index++)
+	{
+		const std::vector<std::string> bindings(si.GetStringList(section.c_str(),
+			StringUtil::StdStringFromFormat("Macro%u", macro_button_index + 1).c_str()));
+		if (!bindings.empty())
+		{
+			AddBindings(bindings, InputButtonEventHandler{[pad_index, macro_button_index](bool state) {
+				PAD::SetMacroButtonState(pad_index, macro_button_index, state);
+			}});
+		}
+	}
+
 	const PAD::VibrationCapabilities vibcaps = PAD::GetControllerVibrationCapabilities(type);
 	if (vibcaps != PAD::VibrationCapabilities::NoVibration)
 	{

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -935,6 +935,61 @@ std::vector<InputBindingKey> InputManager::EnumerateMotors()
 	return ret;
 }
 
+static void GetKeyboardGenericBindingMapping(std::vector<std::pair<GenericInputBinding, std::string>>* mapping)
+{
+	mapping->emplace_back(GenericInputBinding::DPadUp, "Keyboard/Up");
+	mapping->emplace_back(GenericInputBinding::DPadRight, "Keyboard/Right");
+	mapping->emplace_back(GenericInputBinding::DPadDown, "Keyboard/Down");
+	mapping->emplace_back(GenericInputBinding::DPadLeft, "Keyboard/Left");
+	mapping->emplace_back(GenericInputBinding::LeftStickUp, "Keyboard/W");
+	mapping->emplace_back(GenericInputBinding::LeftStickRight, "Keyboard/D");
+	mapping->emplace_back(GenericInputBinding::LeftStickDown, "Keyboard/S");
+	mapping->emplace_back(GenericInputBinding::LeftStickLeft, "Keyboard/A");
+	mapping->emplace_back(GenericInputBinding::RightStickUp, "Keyboard/T");
+	mapping->emplace_back(GenericInputBinding::RightStickRight, "Keyboard/H");
+	mapping->emplace_back(GenericInputBinding::RightStickDown, "Keyboard/G");
+	mapping->emplace_back(GenericInputBinding::RightStickLeft, "Keyboard/F");
+	mapping->emplace_back(GenericInputBinding::Start, "Keyboard/Return");
+	mapping->emplace_back(GenericInputBinding::Select, "Keyboard/Backspace");
+	mapping->emplace_back(GenericInputBinding::Triangle, "Keyboard/I");
+	mapping->emplace_back(GenericInputBinding::Circle, "Keyboard/L");
+	mapping->emplace_back(GenericInputBinding::Cross, "Keyboard/K");
+	mapping->emplace_back(GenericInputBinding::Square, "Keyboard/J");
+	mapping->emplace_back(GenericInputBinding::L1, "Keyboard/Q");
+	mapping->emplace_back(GenericInputBinding::L2, "Keyboard/1");
+	mapping->emplace_back(GenericInputBinding::L3, "Keyboard/2");
+	mapping->emplace_back(GenericInputBinding::R1, "Keyboard/E");
+	mapping->emplace_back(GenericInputBinding::R2, "Keyboard/2");
+	mapping->emplace_back(GenericInputBinding::R3, "Keyboard/4");
+}
+
+static bool GetInternalGenericBindingMapping(const std::string_view& device, GenericInputBindingMapping* mapping)
+{
+	if (device == "Keyboard")
+	{
+		GetKeyboardGenericBindingMapping(mapping);
+		return true;
+	}
+
+	return false;
+}
+
+GenericInputBindingMapping InputManager::GetGenericBindingMapping(const std::string_view& device)
+{
+	GenericInputBindingMapping mapping;
+
+	if (!GetInternalGenericBindingMapping(device, &mapping))
+	{
+		for (u32 i = FIRST_EXTERNAL_INPUT_SOURCE; i < LAST_EXTERNAL_INPUT_SOURCE; i++)
+		{
+			if (s_input_sources[i] && s_input_sources[i]->GetGenericBindingMapping(device, &mapping))
+				break;
+		}
+	}
+
+	return mapping;
+}
+
 template <typename T>
 static void UpdateInputSourceState(SettingsInterface& si, InputSourceType type, bool default_state)
 {

--- a/pcsx2/Frontend/InputManager.h
+++ b/pcsx2/Frontend/InputManager.h
@@ -125,6 +125,50 @@ DECLARE_HOTKEY_LIST(g_vm_manager_hotkeys);
 DECLARE_HOTKEY_LIST(g_gs_hotkeys);
 DECLARE_HOTKEY_LIST(g_host_hotkeys);
 
+/// Generic input bindings. These roughly match a DualShock 4 or XBox One controller.
+/// They are used for automatic binding to PS2 controller types.
+enum class GenericInputBinding : u8
+{
+	Unknown,
+
+	DPadUp,
+	DPadRight,
+	DPadLeft,
+	DPadDown,
+
+	LeftStickUp,
+	LeftStickRight,
+	LeftStickDown,
+	LeftStickLeft,
+	L3,
+
+	RightStickUp,
+	RightStickRight,
+	RightStickDown,
+	RightStickLeft,
+	R3,
+
+	Triangle, // Y on XBox pads.
+	Circle, // B on XBox pads.
+	Cross, // A on XBox pads.
+	Square, // X on XBox pads.
+
+	Select, // Share on DS4, View on XBox pads.
+	Start, // Options on DS4, Menu on XBox pads.
+	System, // PS button on DS4, Guide button on XBox pads.
+
+	L1, // LB on Xbox pads.
+	L2, // Left trigger on XBox pads.
+	R1, // RB on XBox pads.
+	R2, // Right trigger on Xbox pads.
+
+	SmallMotor, // High frequency vibration.
+	LargeMotor, // Low frequency vibration.
+
+	Count,
+};
+using GenericInputBindingMapping = std::vector<std::pair<GenericInputBinding, std::string>>;
+
 /// External input source class.
 class InputSource;
 
@@ -177,6 +221,9 @@ namespace InputManager
 
 	/// Enumerates available vibration motors at the time of call.
 	std::vector<InputBindingKey> EnumerateMotors();
+
+	/// Retrieves bindings that match the generic bindings for the specified device.
+	GenericInputBindingMapping GetGenericBindingMapping(const std::string_view& device);
 
 	/// Re-parses the config and registers all hotkey and pad bindings.
 	void ReloadBindings(SettingsInterface& si);

--- a/pcsx2/Frontend/InputSource.h
+++ b/pcsx2/Frontend/InputSource.h
@@ -47,6 +47,10 @@ public:
 	/// Enumerates available vibration motors at the time of call.
 	virtual std::vector<InputBindingKey> EnumerateMotors() = 0;
 
+	/// Retrieves bindings that match the generic bindings for the specified device.
+	/// Returns false if it's not one of our devices.
+	virtual bool GetGenericBindingMapping(const std::string_view& device, GenericInputBindingMapping* mapping) = 0;
+
 	/// Informs the source of a new vibration motor state. Changes may not take effect until the next PollEvents() call.
 	virtual void UpdateMotorState(InputBindingKey key, float intensity) = 0;
 

--- a/pcsx2/Frontend/SDLInputSource.h
+++ b/pcsx2/Frontend/SDLInputSource.h
@@ -36,6 +36,7 @@ public:
   void PollEvents() override;
   std::vector<std::pair<std::string, std::string>> EnumerateDevices() override;
   std::vector<InputBindingKey> EnumerateMotors() override;
+  bool GetGenericBindingMapping(const std::string_view& device, GenericInputBindingMapping* mapping) override;
   void UpdateMotorState(InputBindingKey key, float intensity) override;
   void UpdateMotorState(InputBindingKey large_key, InputBindingKey small_key, float large_intensity, float small_intensity) override;
 

--- a/pcsx2/Frontend/XInputSource.h
+++ b/pcsx2/Frontend/XInputSource.h
@@ -36,6 +36,7 @@ public:
   void PollEvents() override;
   std::vector<std::pair<std::string, std::string>> EnumerateDevices() override;
   std::vector<InputBindingKey> EnumerateMotors() override;
+  bool GetGenericBindingMapping(const std::string_view& device, GenericInputBindingMapping* mapping) override;
   void UpdateMotorState(InputBindingKey key, float intensity) override;
   void UpdateMotorState(InputBindingKey large_key, InputBindingKey small_key, float large_intensity, float small_intensity) override;
 

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -31,6 +31,25 @@ const u32 build = 0; // increase that with each version
 
 KeyStatus g_key_status;
 
+namespace PAD
+{
+	struct MacroButton
+	{
+		std::vector<u32> buttons; ///< Buttons to activate.
+		u32 toggle_frequency; ///< Interval at which the buttons will be toggled, if not 0.
+		u32 toggle_counter; ///< When this counter reaches zero, buttons will be toggled.
+		bool toggle_state; ///< Current state for turbo.
+		bool trigger_state; ///< Whether the macro button is active.
+	};
+
+	static const char* GetDefaultPadType(u32 pad);
+	static void LoadMacroButtonConfig(const SettingsInterface& si, u32 pad, const std::string_view& type, const std::string& section);
+	static void ApplyMacroButton(u32 pad, const MacroButton& mb);
+	static void UpdateMacroButtons();
+
+	static std::array<std::array<MacroButton, NUM_MACRO_BUTTONS_PER_CONTROLLER>, GAMEPAD_NUMBER> s_macro_buttons;
+} // namespace PAD
+
 s32 PADinit()
 {
 	Pad::reset_all();
@@ -161,11 +180,13 @@ u8 PADpoll(u8 value)
 
 void PAD::LoadConfig(const SettingsInterface& si)
 {
-	// This is where we would load controller types, if onepad supported them.
+	PAD::s_macro_buttons = {};
 
+	// This is where we would load controller types, if onepad supported them.
 	for (u32 i = 0; i < GAMEPAD_NUMBER; i++)
 	{
 		const std::string section(StringUtil::StdStringFromFormat("Pad%u", i + 1u));
+		const std::string type(si.GetStringValue(section.c_str(), "Type", GetDefaultPadType(i)));
 		const float axis_scale = si.GetFloatValue(section.c_str(), "AxisScale", 1.0f);
 		const float large_motor_scale = si.GetFloatValue(section.c_str(), "LargeMotorScale", 1.0f);
 		const float small_motor_scale = si.GetFloatValue(section.c_str(), "SmallMotorScale", 1.0f);
@@ -173,7 +194,14 @@ void PAD::LoadConfig(const SettingsInterface& si)
 		g_key_status.SetAxisScale(i, axis_scale);
 		g_key_status.SetVibrationScale(i, 0, large_motor_scale);
 		g_key_status.SetVibrationScale(i, 1, small_motor_scale);
+
+		LoadMacroButtonConfig(si, i, type, section);
 	}
+}
+
+const char* PAD::GetDefaultPadType(u32 pad)
+{
+	return (pad == 0) ? "DualShock2" : "None";
 }
 
 void PAD::SetDefaultConfig(SettingsInterface& si)
@@ -184,14 +212,14 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 		si.ClearSection(StringUtil::StdStringFromFormat("Pad%u", i + 1).c_str());
 
 	si.ClearSection("Hotkeys");
-	
+
 	// PCSX2 Controller Settings - Global Settings
 	si.SetBoolValue("InputSources", "SDL", true);
 	si.SetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
 	si.SetBoolValue("InputSources", "XInput", false);
-	
+
 	// PCSX2 Controller Settings - Controller 1 / Controller 2 / ...
-	si.SetStringValue("Pad1", "Type", "DualShock2");
+	si.SetStringValue("Pad1", "Type", GetDefaultPadType(0));
 	si.SetStringValue("Pad1", "Up", "Keyboard/Up");
 	si.SetStringValue("Pad1", "Right", "Keyboard/Right");
 	si.SetStringValue("Pad1", "Down", "Keyboard/Down");
@@ -216,23 +244,23 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 	si.SetStringValue("Pad1", "R3", "Keyboard/4");
 	si.SetStringValue("Pad1", "Start", "Keyboard/Return");
 	si.SetStringValue("Pad1", "Select", "Keyboard/Backspace");
-	
+
 	// PCSX2 Controller Settings - Hotkeys
-	
+
 	// PCSX2 Controller Settings - Hotkeys - General
 	si.SetStringValue("Hotkeys", "Screenshot", "Keyboard/F8");
 	si.SetStringValue("Hotkeys", "ToggleFullscreen", "Keyboard/Alt & Keyboard/Return");
-	
+
 	// PCSX2 Controller Settings - Hotkeys - Graphics
 	si.SetStringValue("Hotkeys", "CycleAspectRatio", "Keyboard/F6");
 	si.SetStringValue("Hotkeys", "CycleMipmapMode", "Keyboard/Insert");
 	si.SetStringValue("Hotkeys", "CycleInterlaceMode", "Keyboard/F5");
-//	si.SetStringValue("Hotkeys", "DecreaseUpscaleMultiplier", "Keyboard"); TBD 
-//	si.SetStringValue("Hotkeys", "IncreaseUpscaleMultiplier", "Keyboard"); TBD 
+	//	si.SetStringValue("Hotkeys", "DecreaseUpscaleMultiplier", "Keyboard"); TBD
+	//	si.SetStringValue("Hotkeys", "IncreaseUpscaleMultiplier", "Keyboard"); TBD
 	si.SetStringValue("Hotkeys", "ToggleSoftwareRendering", "Keyboard/F9");
 	si.SetStringValue("Hotkeys", "ZoomIn", "Keyboard/Control & Keyboard/Plus");
 	si.SetStringValue("Hotkeys", "ZoomOut", "Keyboard/Control & Keyboard/Minus");
-// Missing hotkey for resetting zoom back to 100 with Keyboard/Control & Keyboard/Asterisk
+	// Missing hotkey for resetting zoom back to 100 with Keyboard/Control & Keyboard/Asterisk
 
 	// PCSX2 Controller Settings - Hotkeys - Save States
 	si.SetStringValue("Hotkeys", "LoadStateFromSlot", "Keyboard/F3");
@@ -241,17 +269,18 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 	si.SetStringValue("Hotkeys", "PreviousSaveStateSlot", "Keyboard/Shift & Keyboard/F2");
 
 	// PCSX2 Controller Settings - Hotkeys - System
-//	si.SetStringValue("Hotkeys", "DecreaseSpeed", "Keyboard"); TBD 
-//	si.SetStringValue("Hotkeys", "IncreaseSpeed", "Keyboard"); TBD 
+	//	si.SetStringValue("Hotkeys", "DecreaseSpeed", "Keyboard"); TBD
+	//	si.SetStringValue("Hotkeys", "IncreaseSpeed", "Keyboard"); TBD
 	si.SetStringValue("Hotkeys", "ToggleFrameLimit", "Keyboard/F4");
-	si.SetStringValue("Hotkeys", "TogglePause", "Keyboard/Space");	
-	si.SetStringValue("Hotkeys", "ToggleSlowMotion", "Keyboard/Shift & Keyboard/Backtab");	
+	si.SetStringValue("Hotkeys", "TogglePause", "Keyboard/Space");
+	si.SetStringValue("Hotkeys", "ToggleSlowMotion", "Keyboard/Shift & Keyboard/Backtab");
 	si.SetStringValue("Hotkeys", "ToggleTurbo", "Keyboard/Tab");
 }
 
 void PAD::Update()
 {
 	Pad::rumble_all();
+	UpdateMacroButtons();
 }
 
 std::vector<std::string> PAD::GetControllerTypeNames()
@@ -311,4 +340,89 @@ void PAD::SetControllerState(u32 controller, u32 bind, float value)
 		return;
 
 	g_key_status.Set(controller, bind, value);
+}
+
+void PAD::LoadMacroButtonConfig(const SettingsInterface& si, u32 pad, const std::string_view& type, const std::string& section)
+{
+	// lazily initialized
+	std::vector<std::string> binds;
+
+	for (u32 i = 0; i < NUM_MACRO_BUTTONS_PER_CONTROLLER; i++)
+	{
+		std::string binds_string;
+		if (!si.GetStringValue(section.c_str(), StringUtil::StdStringFromFormat("Macro%uBinds", i + 1).c_str(), &binds_string))
+			continue;
+
+		const u32 frequency = si.GetUIntValue(section.c_str(), StringUtil::StdStringFromFormat("Macro%uFrequency", i + 1).c_str(), 0u);
+		if (binds.empty())
+			binds = GetControllerBinds(type);
+
+		// convert binds
+		std::vector<u32> bind_indices;
+		std::vector<std::string_view> buttons_split(StringUtil::SplitString(binds_string, '&', true));
+		if (buttons_split.empty())
+			continue;
+		for (const std::string_view& button : buttons_split)
+		{
+			auto it = std::find(binds.begin(), binds.end(), button);
+			if (it == binds.end())
+			{
+				Console.Error("Invalid bind '%.*s' in macro button %u for pad %u", static_cast<int>(button.size()), button.data(), pad, i);
+				continue;
+			}
+
+			bind_indices.push_back(static_cast<u32>(std::distance(binds.begin(), it)));
+		}
+		if (bind_indices.empty())
+			continue;
+
+		s_macro_buttons[pad][i].buttons = std::move(bind_indices);
+		s_macro_buttons[pad][i].toggle_frequency = frequency;
+	}
+}
+
+void PAD::SetMacroButtonState(u32 pad, u32 index, bool state)
+{
+	if (pad >= GAMEPAD_NUMBER || index >= NUM_MACRO_BUTTONS_PER_CONTROLLER)
+		return;
+
+	MacroButton& mb = s_macro_buttons[pad][index];
+	if (mb.buttons.empty() || mb.trigger_state == state)
+		return;
+
+	mb.toggle_counter = mb.toggle_frequency;
+	mb.trigger_state = state;
+	if (mb.toggle_state != state)
+	{
+		mb.toggle_state = state;
+		ApplyMacroButton(pad, mb);
+	}
+}
+
+void PAD::ApplyMacroButton(u32 pad, const MacroButton& mb)
+{
+	const float value = mb.toggle_state ? 1.0f : 0.0f;
+	for (const u32 btn : mb.buttons)
+		g_key_status.Set(pad, btn, value);
+}
+
+void PAD::UpdateMacroButtons()
+{
+	for (u32 pad = 0; pad < GAMEPAD_NUMBER; pad++)
+	{
+		for (u32 index = 0; index < NUM_MACRO_BUTTONS_PER_CONTROLLER; index++)
+		{
+			MacroButton& mb = s_macro_buttons[pad][index];
+			if (!mb.trigger_state || mb.toggle_frequency == 0)
+				continue;
+
+			mb.toggle_counter--;
+			if (mb.toggle_counter > 0)
+				continue;
+
+			mb.toggle_counter = mb.toggle_frequency;
+			mb.toggle_state = !mb.toggle_state;
+			ApplyMacroButton(pad, mb);
+		}
+	}
 }

--- a/pcsx2/PAD/Host/PAD.h
+++ b/pcsx2/PAD/Host/PAD.h
@@ -43,6 +43,9 @@ namespace PAD
 		Count
 	};
 
+	/// Number of macro buttons per controller.
+	static constexpr u32 NUM_MACRO_BUTTONS_PER_CONTROLLER = 4;
+
 	/// Reloads configuration.
 	void LoadConfig(const SettingsInterface& si);
 
@@ -63,4 +66,7 @@ namespace PAD
 
 	/// Sets the specified bind on a controller to the specified pressure (normalized to 0..1).
 	void SetControllerState(u32 controller, u32 bind, float value);
+
+	/// Sets the state of the specified macro button.
+	void SetMacroButtonState(u32 pad, u32 index, bool state);
 } // namespace PAD

--- a/pcsx2/PAD/Host/PAD.h
+++ b/pcsx2/PAD/Host/PAD.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "PAD/Host/Global.h"
@@ -23,6 +24,7 @@
 
 class SettingsInterface;
 struct WindowInfo;
+enum class GenericInputBinding : u8;
 
 s32 PADinit();
 void PADshutdown();
@@ -63,6 +65,10 @@ namespace PAD
 
 	/// Returns the vibration configuration for the specified controller type.
 	VibrationCapabilities GetControllerVibrationCapabilities(const std::string_view& type);
+
+	/// Performs automatic controller mapping with the provided list of generic mappings.
+	bool MapController(SettingsInterface& si, u32 controller,
+		const std::vector<std::pair<GenericInputBinding, std::string>>& mapping);
 
 	/// Sets the specified bind on a controller to the specified pressure (normalized to 0..1).
 	void SetControllerState(u32 controller, u32 bind, float value);


### PR DESCRIPTION
### Description of Changes

This PR adds automatic mapping for both controllers and keyboards. It's a nice flexible system that you define:

1) A mapping from device to generic bindings.
2) A mapping from generic bindings to the PS2 controller type.

And it takes care of the rest.

Also includes macro button support in the host PAD implementation. But no way to configure it in the UI yet.

### Rationale behind Changes

Mapping controllers manually sucks.

### Suggested Testing Steps

Qt, yolo.
