### PR TITLE
GS: Only flush on PRIM if a new draw is requested

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -51,6 +51,8 @@ class GSState : public GSAlignedClass<32>
 	GIFPackedRegHandler m_fpGIFPackedRegHandlers[16];
 	GIFPackedRegHandler m_fpGIFPackedRegHandlerXYZ[8][4];
 
+	void CheckFlushes();
+
 	void GIFPackedRegHandlerNull(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerRGBA(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerSTQ(const GIFPackedReg* RESTRICT r);
@@ -232,6 +234,8 @@ public:
 	bool m_NTSC_Saturation;
 	bool m_nativeres;
 	bool m_mipmap;
+	bool m_primflush;
+	GIFRegPRIM m_last_prim;
 
 	static int s_n;
 	bool s_dump;


### PR DESCRIPTION
### Description of Changes
Delay/Omit flushes on PRIM change until more draws are requested and a change in PRIM is guaranteed.

### Rationale behind Changes
A bunch of games trash the PRIM register or update it in 2 parts in some cases (PRMODE), causing premature flushes. Especially if copies are required this can increase the numbers of draws and copies it needs to do for no reason.

Less draws, less copies, more brr (sometimes?), might be more apparent on lower end hardware or higher resolutions.

### Suggested Testing Steps
Test games, make sure nothing is broken, note any performance increases over master.


Results from running GS Dumps in HW mode 3x Native

Sly 2: 
Master: 155fps
PR: 165fps  (6% increase)  (after upgrading my 3900x to a 5900x and possibly some other tweaks, it's now 16%)

Midnight Club 2: 
Master: 525fps
PR: 535fps (~2% increase)

Barnyard:
Master: 240fps
PR: 270fps (12.5% increase)

Crime Life:
Master: 785fps
PR: 835fps (6% increase)

One at native (because this game sucks)

Stolen: (Disable Partial invalidation + Partial Texture Preloading)

Master: 75fps
PR: 88fps (17% increase)