### PR TITLE
Qt: Add missing null terminator in audio settings

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -40,6 +40,7 @@ static const char* s_output_module_entries[] = {
 #ifdef _WIN32
 	QT_TRANSLATE_NOOP("AudioSettingsWidget", "XAudio2"),
 #endif
+  nullptr
 };
 static const char* s_output_module_values[] = {
 	"nullout",
@@ -47,6 +48,7 @@ static const char* s_output_module_values[] = {
 #ifdef _WIN32
 	"xaudio2",
 #endif
+  nullptr
 };
 
 AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent)


### PR DESCRIPTION
Could cause crashes.