### PR TITLE
GS/HW: Fix fbmask not inserting barriers

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1653,14 +1653,9 @@ void GSDeviceOGL::OMAttachDs(GSTextureOGL* ds)
 	if (GLState::ds != id)
 	{
 		GLState::ds = id;
-		if (ds && ds->IsDss())
-		{
-			glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, id, 0);
-		}
-		else
-		{
-			glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, id, 0);
-		}
+
+		const GLenum target = GLLoader::found_framebuffer_fetch ? GL_DEPTH_ATTACHMENT : GL_DEPTH_STENCIL_ATTACHMENT;
+		glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, target, GL_TEXTURE_2D, id, 0);
 	}
 }
 

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
@@ -71,7 +71,6 @@ public:
 	void Swap(GSTexture* tex) final;
 
 	GSMap Read(const GSVector4i& r, AlignedBuffer<u8, 32>& buffer);
-	bool IsDss() { return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil) && !GLLoader::found_framebuffer_fetch; }
 	bool IsDepth() { return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil); }
 	bool IsIntegerFormat() const
 	{


### PR DESCRIPTION
### Description of Changes

Or, missing the fb copy for D3D/barriers off.

Regression from fbfetch PR.

### Rationale behind Changes

Fixing regressions.

### Suggested Testing Steps

Check fifa street gsdump.
