### PR TITLE
ShaderCache: Don't delete cache when running 2 instances (D3D11/VK)

### DIFF
--- a/common/D3D11/ShaderCache.cpp
+++ b/common/D3D11/ShaderCache.cpp
@@ -130,7 +130,17 @@ bool D3D11::ShaderCache::ReadExisting(const std::string& index_filename, const s
 {
 	m_index_file = FileSystem::OpenCFile(index_filename.c_str(), "r+b");
 	if (!m_index_file)
+	{
+		// special case here: when there's a sharing violation (i.e. two instances running),
+		// we don't want to blow away the cache. so just continue without a cache.
+		if (errno == EACCES)
+		{
+			Console.WriteLn("Failed to open shader cache index with EACCES, are you running two instances?");
+			return true;
+		}
+
 		return false;
+	}
 
 	u32 file_version = 0;
 	u32 data_version = 0;

--- a/common/Vulkan/ShaderCache.cpp
+++ b/common/Vulkan/ShaderCache.cpp
@@ -214,7 +214,17 @@ namespace Vulkan
 	{
 		m_index_file = FileSystem::OpenCFile(index_filename.c_str(), "r+b");
 		if (!m_index_file)
+		{
+			// special case here: when there's a sharing violation (i.e. two instances running),
+			// we don't want to blow away the cache. so just continue without a cache.
+			if (errno == EACCES)
+			{
+				Console.WriteLn("Failed to open shader cache index with EACCES, are you running two instances?");
+				return true;
+			}
+
 			return false;
+		}
 
 		u32 file_version = 0;
 		u32 data_version = 0;


### PR DESCRIPTION
### Description of Changes

This was the case for GL, but not VK/D3D. Meant that the cache got blown away unnecessarily if you ran two instances of PCSX2.

### Suggested Testing Steps

Low-risk and already tested.
