### PR TITLE
Qt: Reduce max SPU - Change Speed Preset

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -180,7 +180,7 @@
            <number>15</number>
           </property>
           <property name="maximum">
-           <number>3000</number>
+           <number>200</number>
           </property>
           <property name="value">
            <number>100</number>

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -87,7 +87,7 @@ void EmulationSettingsWidget::initializeSpeedCombo(QComboBox* cb, const char* se
 		}
 	}
 
-	static const int speeds[] = {1, 10, 25, 50, 75, 90, 100, 110, 120, 150, 175, 200, 300, 400, 500, 1000};
+	static const int speeds[] = {2, 10, 25, 50, 75, 90, 100, 110, 120, 150, 175, 200, 300, 400, 500, 1000};
 	for (const int speed : speeds)
 	{
 		cb->addItem(tr("%1% [%2 FPS (NTSC) / %3 FPS (PAL)]")


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
SPU2 max latency changed from 3000ms (3 seconds) to 200 ms (0.2 seconds) value.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Qt has a leftover from the old SPU2-X values which is 3000 ms (3 seconds) latency meaning that if an user sets it to the max it will do something like this: Videoframe ~150 / 180 happens and it makes the first sound after 3 seconds for the first videoframe which is far too long. Also changed 1% speed as it messed with the GSdump player and too stuttery to be usable in other usecases. The lower ms the better but Cubeb should handle it fine and ignore the default 100 ms to a very low number even if your computer is weak:

![image](https://user-images.githubusercontent.com/24227051/160268740-d9777d3d-b3e4-4609-9cab-5064fd60a451.png)

So in best case the audio latency is 0.01 seconds and in worst case 0.025 seconds which is neglible.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if the GUI responds normally.