### PR TITLE
Allow commandline params to be passed through to the patched apprun file

### DIFF
--- a/.github/workflows/scripts/linux/AppRun
+++ b/.github/workflows/scripts/linux/AppRun
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$APPDIR/AppRun-patched
+$APPDIR/AppRun-patched "$@"


### PR DESCRIPTION
### Description of Changes
Modified AppRun to support passing of command line parameters 
I have (with some difficulty) run the .github/workflows/scripts/linux/appimage.sh script to confirm that the correct file gets modified within the appimage file.

### Rationale behind Changes
Appimage uses a wrapper that doesn't pass the parameters to the AppRun-patched file
See Bug #5558

### Suggested Testing Steps
Download appimage
Execute passing iso to launch.
PCSX2 will open without loading iso
