### PR TITLE
BiosTools: (Experimental) BIOS region patching

### DIFF
--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -34,7 +34,11 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	m_ui.setupUi(this);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fastBoot, "EmuCore", "EnableFastBoot", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.patchRegion, "EmuCore", "PatchBios", false);
+	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.regionComboBox, "EmuCore", "PatchRegion", BiosZoneStrings, BiosZoneBytes, BiosZoneBytes[0]);
 
+	dialog->registerWidgetHelp(m_ui.patchRegion, tr("Patch Region"),tr("Unchecked"),
+		tr("Patches the BIOS region byte in ROM. Not recommended unless you really know what you're doing."));
 	dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Boot"), tr("Unchecked"),
 		tr("Patches the BIOS to skip the console's boot animation."));
 
@@ -56,6 +60,9 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	connect(m_ui.openSearchDirectory, &QPushButton::clicked, this, &BIOSSettingsWidget::openSearchDirectory);
 	connect(m_ui.refresh, &QPushButton::clicked, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.fileList, &QTreeWidget::currentItemChanged, this, &BIOSSettingsWidget::listItemChanged);
+
+	connect(m_ui.patchRegion, &QCheckBox::clicked, this, [&] { m_ui.regionComboBox->setEnabled(m_ui.patchRegion->isChecked()); });
+	m_ui.regionComboBox->setEnabled(m_ui.patchRegion->isChecked());
 }
 
 BIOSSettingsWidget::~BIOSSettingsWidget()

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>618</width>
-    <height>408</height>
+    <height>439</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -134,13 +134,40 @@
      <property name="title">
       <string>Options and Patches</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="patchRegion">
+        <property name="text">
+         <string>Patch Region</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
        <widget class="QCheckBox" name="fastBoot">
         <property name="text">
          <string>Fast Boot</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="regionComboBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -931,6 +931,7 @@ struct Pcsx2Config
 #endif
 		// when enabled uses BOOT2 injection, skipping sony bios splashes
 		UseBOOT2Injection : 1,
+		PatchBios : 1,
 		BackupSavestate : 1,
 		// enables simulated ejection of memory cards when loading savestates
 		McdEnableEjection : 1,
@@ -961,6 +962,8 @@ struct Pcsx2Config
 	TraceLogFilters Trace;
 
 	FilenameOptions BaseFilenames;
+
+	std::string PatchRegion;
 
 	// Memorycard options - first 2 are default slots, last 6 are multitap 1 and 2
 	// slots (3 each)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1096,6 +1096,8 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 #endif
 	SettingsWrapBitBool(ConsoleToStdio);
 	SettingsWrapBitBool(HostFs);
+	SettingsWrapBitBool(PatchBios);
+	SettingsWrapEntry(PatchRegion);
 
 	SettingsWrapBitBool(BackupSavestate);
 	SettingsWrapBitBool(McdEnableEjection);
@@ -1217,6 +1219,7 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	Trace = cfg.Trace;
 	BaseFilenames = cfg.BaseFilenames;
 	Framerate = cfg.Framerate;
+
 	for (u32 i = 0; i < sizeof(Mcd) / sizeof(Mcd[0]); i++)
 	{
 		// Type will be File here, even if it's a folder, so we preserve the old value.
@@ -1238,6 +1241,8 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	EnableRecordingTools = cfg.EnableRecordingTools;
 #endif
 	UseBOOT2Injection = cfg.UseBOOT2Injection;
+	PatchBios = cfg.PatchBios;
+	PatchRegion = cfg.PatchRegion;
 	BackupSavestate = cfg.BackupSavestate;
 	McdEnableEjection = cfg.McdEnableEjection;
 	McdFolderAutoManage = cfg.McdFolderAutoManage;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -573,6 +573,7 @@ bool VMManager::ApplyBootParameters(const VMBootParameters& params)
 {
 	const bool default_fast_boot = Host::GetBoolSettingValue("EmuCore", "EnableFastBoot", true);
 	EmuConfig.UseBOOT2Injection = params.fast_boot.value_or(default_fast_boot);
+
 	s_elf_override = params.elf_override;
 	s_disc_path.clear();
 

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -55,6 +55,7 @@ std::string BiosDescription;
 std::string BiosZone;
 std::string BiosPath;
 BiosDebugInformation CurrentBiosInformation;
+s64 BiosRegionOffset = 0;
 
 static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& description, u32& region, std::string& zone)
 {
@@ -90,19 +91,25 @@ static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& descriptio
 			switch (romver[4])
 			{
 				// clang-format off
-				case 'T': zone = "T10K";   region = 0; break;
-				case 'X': zone = "Test";	 region = 1; break;
-				case 'J': zone = "Japan";	 region = 2; break;
-				case 'A': zone = "USA";		 region = 3; break;
-				case 'E': zone = "Europe"; region = 4; break;
-				case 'H': zone = "HK";     region = 5; break;
-				case 'P': zone = "Free";   region = 6; break;
-				case 'C': zone = "China";  region = 7; break;
-					// clang-format on
-				default:
-					zone.clear();
-					zone += romver[4];
-					break;
+				case 'T': region = 0; break;
+				case 'X': region = 1; break;
+				case 'J': region = 2; break;
+				case 'A': region = 3; break;
+				case 'E': region = 4; break;
+				case 'H': region = 5; break;
+				case 'P': region = 6; break;
+				case 'C': region = 7; break;
+				// clang-format on
+			}
+
+			if (region >= 0 && region <= 7)
+			{
+				zone = BiosZoneStrings[region];
+			}
+			else
+			{
+				zone.clear();
+				zone += romver[4];
 			}
 
 			char vermaj[3] = {romver[0], romver[1], 0};
@@ -119,6 +126,7 @@ static bool LoadBiosVersion(std::FILE* fp, u32& version, std::string& descriptio
 			version = strtol(vermaj, (char**)NULL, 0) << 8;
 			version |= strtol(vermin, (char**)NULL, 0);
 			foundRomVer = true;
+			BiosRegionOffset = fileOffset;
 
 			Console.WriteLn("Bios Found: %s", description.c_str());
 		}
@@ -286,6 +294,13 @@ bool LoadBIOS()
 	BiosChecksum = 0;
 	ChecksumIt(BiosChecksum, eeMem->ROM);
 	BiosPath = std::move(path);
+
+	// Patch the region
+	if (EmuConfig.PatchBios)
+	{
+		eeMem->ROM[BiosRegionOffset + 4] = EmuConfig.PatchRegion[0];
+		Console.WriteLn("Patching ROM with region code %c", EmuConfig.PatchRegion[0]);
+	}
 
 #ifndef PCSX2_CORE
 	Console.SetTitle(StringUtil::UTF8StringToWxString(StringUtil::StdStringFromFormat("Running BIOS (%s v%u.%u)",

--- a/pcsx2/ps2/BiosTools.h
+++ b/pcsx2/ps2/BiosTools.h
@@ -28,6 +28,23 @@ struct BiosDebugInformation
 	u32 threadListAddr;
 };
 
+static const char* BiosZoneStrings[] {
+	"T10K",
+	"Test",
+	"Japan",
+	"USA",
+	"Europe",
+	"HK",
+	"Free",
+	"China",
+	nullptr
+};
+
+static const char* BiosZoneBytes[]
+{
+	"T", "X", "J", "A", "E", "H", "P", "C", nullptr
+};
+
 extern BiosDebugInformation CurrentBiosInformation;
 extern u32 BiosVersion;		// Used by CDVD
 extern u32 BiosRegion;		// Used by CDVD
@@ -41,4 +58,3 @@ extern std::string BiosPath;
 extern bool LoadBIOS();
 extern bool IsBIOS(const char* filename, u32& version, std::string& description, u32& region, std::string& zone);
 extern bool IsBIOSAvailable(const std::string& full_path);
-


### PR DESCRIPTION
# * This has nothing to do with region locking and whatever DRM SCE used*

### Description of Changes

Allows the user to patch their BIOS region by setting the region byte during ROM upload.

These are the results with my BIOS when going to OSDSYS

<table>
<tr>
	<td> T10K
	<td>TLB miss
<tr>
	<td>Test
	<td>TLB miss
<tr>
	<td>Japan
	<td>Works (On some BIOSes OSDSYS will be Japanese, buttons are always switched)
<tr>
	<td>USA
	<td>Works
<tr>
	<td>Europe
	<td>Works
<tr>
	<td>HK
	<td>Works (English text, is this expected?)
<tr>
	<td>Free
	<td>TLB miss
<tr>
	<td>China
	<td>TLB miss. Infinite rebooting on some BIOSes.
</table>

Of course each bios revision is unique and you may get different results.


### Rationale behind Changes
The recommended BIOS dumper ends up patching slim BIOSes as Japan when it's USA for example. 

### Suggested Testing Steps
Anything pertaining to emulation issues while patching aren't a feasible issue to solve.
