### PR TITLE
Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2 Fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27272,7 +27272,7 @@ SLPM-66140:
   name: "Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 2 # Fixes splitted textbox.
+    roundSprite: 2 # Fixes the sprites on textbox and characters.
 SLPM-66141:
   name: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27271,6 +27271,8 @@ SLPM-66139:
 SLPM-66140:
   name: "Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Fixes splitted textbox.
 SLPM-66141:
   name: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27272,7 +27272,7 @@ SLPM-66140:
   name: "Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2"
   region: "NTSC-J"
   gsHWFixes:
-    roundSprite: 1 # Fixes splitted textbox.
+    roundSprite: 2 # Fixes splitted textbox.
 SLPM-66141:
   name: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"


### PR DESCRIPTION
Fix misaligned textures.

### Description of Changes
The game has the textbox textures misaligned, this fixes it.

### Rationale behind Changes
Before:
![image](https://user-images.githubusercontent.com/17991404/160706322-48d1fad2-d156-44de-bc53-d26164b63025.png)
After:
![image](https://user-images.githubusercontent.com/17991404/160706429-c21f1f1d-9c91-4000-8b81-d3aafb2015a9.png)


### Suggested Testing Steps
Just test the game... this only fix the 2x internal resolution or more....
