### PR TITLE
GameDB : Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27271,6 +27271,8 @@ SLPM-66139:
 SLPM-66140:
   name: "Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 2 # Fixes the sprites on textbox and characters.
 SLPM-66141:
   name: "Matantei Loki Ragnarok Mayoukaku"
   region: "NTSC-J"


### PR DESCRIPTION
Fix misaligned textures.

**Description of Changes**
The game has the textbox textures misaligned, this fixes it.

**Rationale behind Changes**
Before:
![image](https://user-images.githubusercontent.com/17991404/160713717-fe5e3eab-f22c-4923-b4f9-a7f698f2ecb3.png)
After:
![image](https://user-images.githubusercontent.com/17991404/160713763-ca39a899-bd91-4fb7-816d-654c6e475c92.png)


**Suggested Testing Steps**
Just test the game... this only fix the 2x internal resolution or more....
