### PR TITLE
GameDB:  ':' to '-' + GS and other fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28,10 +28,10 @@
 # ---------------------------------------------
 
 GUST-00009:
-  name: "Mana Khemia: Alchemists of Al-Revis [Premium Box]"
+  name: "Mana Khemia - Alchemists of Al-Revis [Premium Box]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes jump issue.
+    eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - SoftwareRendererFMVHack # Vertical lines in FMV.
 PAPX-90201:
@@ -44,13 +44,13 @@ PAPX-90203:
   name: "Gran Turismo 2000 [Trial]"
   region: "NTSC-J"
 PAPX-90222:
-  name: "Jak x Daxter: Kyuu Sekai no Isan [Demo, Taikenban]"
+  name: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
     textureInsideRT: 1
 PAPX-90223:
-  name: "Jak x Daxter: Kyuu Sekai no Isan [Demo, Taikenban]"
+  name: "Jak x Daxter - Kyuu Sekai no Isan [Demo, Taikenban]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -73,8 +73,8 @@ PAPX-90512:
   name: "Gran Turismo 4 - Toyota Prius [Trial]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
-  # Comments from old GameIndex.dbf for this Game
+    vuClampMode: 2 # Text in GT mode works.
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 PAPX-90516:
   name: "Jak and Daxter II [Trial]"
@@ -151,7 +151,7 @@ PBPX-95524:
   name: "Gran Turismo 4 - Prologue"
   region: "NTSC-Unk"
   compat: 5
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95601:
@@ -159,7 +159,7 @@ PBPX-95601:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -171,7 +171,7 @@ PBPX-95601:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 PCPX-96311:
   name: "Gran Turismo 3 Trial Disk Volume 1"
@@ -191,7 +191,7 @@ PCPX-96322:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
 PCPX-96554:
-  name: "Games of Our Style: Tokyo Game Show 2003 Disc"
+  name: "Games of Our Style - Tokyo Game Show 2003 Disc"
   region: "NTSC-J"
 PCPX-96616:
   name: "PurePure 2 Volume 2"
@@ -201,8 +201,8 @@ PCPX-96649:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
-  # Comments from old GameIndex.dbf for this Game
+    vuClampMode: 2 # Text in GT mode works.
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 PCPX-96660:
   name: "Tourist Trophy [Demo]"
@@ -307,7 +307,7 @@ SCAJ-20011:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-Unk"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20011"
     - "SCPS-55014"
@@ -325,10 +325,10 @@ SCAJ-20014:
   name: "Time Splitter"
   region: "NTSC-Unk"
 SCAJ-20015:
-  name: "Shin Megami Tensei III: Nocturne"
+  name: "Shin Megami Tensei III - Nocturne"
   region: "NTSC-Unk"
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SCAJ-20016:
   name: "Warrior of Argus"
   region: "NTSC-CH-E"
@@ -354,7 +354,7 @@ SCAJ-20023:
   name: "Soul Calibur II"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 2  # Respawn issues, SPS.
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-20024:
@@ -443,7 +443,7 @@ SCAJ-20055:
   name: "Battle Gear 3"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 3  # Stops car from falling through track.
+    vuClampMode: 3 # Stops car from falling through track.
 SCAJ-20056:
   name: "Bujingai"
   region: "NTSC-Unk"
@@ -494,7 +494,7 @@ SCAJ-20066:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCAJ-20067:
   name: "GunGrave O.D."
@@ -559,9 +559,13 @@ SCAJ-20078:
   name: "Kuon"
   region: "NTSC-Unk"
   roundModes:
-    eeRoundMode: 0  # Fixes Sugoroku mini-game.
+    eeRoundMode: 0 # Fixes Sugoroku mini-game.
+  speedHacks:
+    InstantVU1SpeedHack: 1 # This option enabled brings about 15% more FPS when I tested it, *your experience may differ.
+    MTVUSpeedHack: 0 # For some reason this games halves the internal game FPS with this option.
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
+    preloadFrameData: 1 # Fixes red cracklines on walls.
 SCAJ-20079:
   name: "Katamari Damacy"
   region: "NTSC-Unk"
@@ -636,7 +640,7 @@ SCAJ-20094:
   name: "Minna no Golf 4 [PlayStation 2 The Best]"
   region: "NTSC-Unk"
 SCAJ-20095:
-  name: "Digital Devil Saga: Avatar Tuner"
+  name: "Digital Devil Saga - Avatar Tuner"
   region: "NTSC-Unk"
   gameFixes:
     - EETimingHack
@@ -694,7 +698,8 @@ SCAJ-20109:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
 SCAJ-20110:
   name: "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi"
   region: "NTSC-Unk"
@@ -740,7 +745,7 @@ SCAJ-20119:
     halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
 SCAJ-20120:
-  name: "Digital Devil Saga: Avatar Tuner 2"
+  name: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-Unk"
   gameFixes:
     - EETimingHack
@@ -781,14 +786,14 @@ SCAJ-20125:
   name: "Tekken 5"
   region: "NTSC-Unk"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SCAJ-20126:
   name: "Tekken 5"
   region: "NTSC-Unk"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SCAJ-20127:
@@ -810,7 +815,7 @@ SCAJ-20132:
   name: "Drag-On Dragon 2 - Fuuin no Kurenai (Love Red, Ambivalence Black)"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+    eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
 SCAJ-20133:
   name: "Kagero 2 - Dark Illusion"
   region: "NTSC-Unk"
@@ -845,11 +850,11 @@ SCAJ-20137:
   name: "Musashiden II - Blademaster"
   region: "NTSC-Unk"
   roundModes:
-    vuRoundMode: 0  # Fixes Red SPS while ingame.
-    eeRoundMode: 0  # Partially fixes wrong enemies eye rendering.
+    vuRoundMode: 0 # Fixes Red SPS while ingame.
+    eeRoundMode: 0 # Partially fixes wrong enemies eye rendering.
   clampModes:
-    vuClampMode: 3  # Fixes White SPS while ingame.
-    eeClampMode: 3  # Fixes White SPS while ingame.
+    vuClampMode: 3 # Fixes White SPS while ingame.
+    eeClampMode: 3 # Fixes White SPS while ingame.
   gameFixes:
     - EETimingHack # Fixes garbled character animation.
 SCAJ-20138:
@@ -940,8 +945,8 @@ SCAJ-20157:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCAJ-20158:
   name: "Ikusa Gami"
   region: "NTSC-Unk"
@@ -950,6 +955,8 @@ SCAJ-20159:
   region: "NTSC-Ch-E-J"
   gameFixes:
     - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-20160:
@@ -967,7 +974,7 @@ SCAJ-20162:
     autoFlush: 1 # Fix glow effects from lamps.
     roundSprite: 1 # Fix minimap and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
-    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing. 
+    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCAJ-20163:
   name: "Tales of the Abyss"
   region: "NTSC-Unk"
@@ -1088,7 +1095,6 @@ SCAJ-20190:
   name: "God of War II"
   region: "NTSC-Unk"
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SCAJ-20191:
@@ -1140,7 +1146,7 @@ SCAJ-20199:
   name: "Tekken 5 [PlayStation 2 The Best]"
   region: "NTSC-Unk"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SCAJ-25002:
@@ -1202,7 +1208,7 @@ SCAJ-30006:
   name: "Gran Turismo 4"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1214,21 +1220,21 @@ SCAJ-30006:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCAJ-30007:
   name: "Gran Turismo 4"
   region: "NTSC-Unk"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
-  # Comments from old GameIndex.dbf for this Game
+    vuClampMode: 2 # Text in GT mode works.
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCAJ-30008:
   name: "Gran Turismo 4 [PlayStation 2 The Best]"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1240,7 +1246,7 @@ SCAJ-30008:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCAJ-30010:
   name: "God of War"
@@ -1253,7 +1259,6 @@ SCAJ-30011:
   name: "God of War II"
   region: "NTSC-E"
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SCCS-40001:
@@ -1268,7 +1273,7 @@ SCCS-40003:
   name: "Devil May Cry 2 - Disc 2"
   region: "NTSC-C"
 SCCS-40004:
-  name: "XIGO: Zuihou de Touzi"
+  name: "XIGO - Zuihou de Touzi"
   region: "NTSC-C"
 SCCS-40005:
   name: "ICO"
@@ -1286,7 +1291,7 @@ SCCS-40006:
   name: "Shin Sangoku Musou 2"
   region: "NTSC-C"
 SCCS-40007:
-  name: "Arc the Lad: Seirei no Tasogare"
+  name: "Arc the Lad - Seirei no Tasogare"
   region: "NTSC-C"
 SCCS-40009:
   name: "Dragon Ball Z 2"
@@ -1295,30 +1300,30 @@ SCCS-40010:
   name: "Super Puzzle Bobble 2"
   region: "NTSC-C"
 SCCS-40011:
-  name: "Armored Core 2: Another Age"
+  name: "Armored Core 2 - Another Age"
   region: "NTSC-C"
 SCCS-40014:
-  name: "World Soccer Winning Eleven 7: International"
+  name: "World Soccer Winning Eleven 7 - International"
   region: "NTSC-C"
 SCCS-40015:
-  name: "Viorate no Atelier: Gramnad no Renkinjutsushi 2"
+  name: "Viorate no Atelier - Gramnad no Renkinjutsushi 2"
   region: "NTSC-C"
 SCCS-40016:
-  name: "Ape Escape: Pumped & Primed"
+  name: "Ape Escape - Pumped & Primed"
   region: "NTSC-C"
 SCCS-40017:
-  name: "EyeToy: Play"
+  name: "EyeToy - Play"
   region: "NTSC-C"
   compat: 5
 SCCS-40018:
-  name: "Saru EyeToy: Oosawagi! Ukkiuki Game Tenkomori!!"
+  name: "Saru EyeToy - Oosawagi! Ukkiuki Game Tenkomori!!"
   region: "NTSC-C"
   compat: 5
 SCCS-40019:
   name: "Formula One 04"
   region: "NTSC-C"
 SCCS-40022:
-  name: "World Soccer Winning Eleven 8: Asia Championship"
+  name: "World Soccer Winning Eleven 8 - Asia Championship"
   region: "NTSC-C"
   compat: 5 
 SCCS-60002:
@@ -1387,7 +1392,7 @@ SCED-50154:
   name: "Official PlayStation 2 Magazine Demo 19"
   region: "PAL-M5"
 SCED-50162:
-  name: "Official PS2 Magazine UK Greatest Hits Vol 2: Special Ed: A-Z of PS2"
+  name: "Official PS2 Magazine UK Greatest Hits Vol 2 - Special Ed - A-Z of PS2"
   region: "PAL-M5"
 SCED-50163:
   name: "PlayStation 2 Greatest Hits Vol.3 [Demo]"
@@ -1429,7 +1434,7 @@ SCED-50610:
   name: "Official PlayStation 2 Magazine Demo 14" # Australian
   region: "PAL-M5"
 SCED-50614:
-  name: "Jak and Daxter: The Precursor Legacy [Demo]"
+  name: "Jak and Daxter - The Precursor Legacy [Demo]"
   region: "PAL-Unk"
   gsHWFixes:
     mipmap: 1
@@ -1444,7 +1449,7 @@ SCED-50642:
   name: "Final Fantasy X [Demo] [Final Fantasy VI PS1 - Bonus Disc]"
   region: "PAL-E"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCED-50675:
@@ -1511,7 +1516,7 @@ SCED-50907:
   name: "Final Fantasy X [Bonus Disc - Beyond Final Fantasy]"
   region: "PAL-Unk"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCED-50945:
@@ -1551,7 +1556,7 @@ SCED-51319:
   name: "Official PlayStation 2 Magazine Demo 27" # German
   region: "PAL-E-G"
 SCED-51352:
-  name: "Gran Turismo: Nissan Micra Edition"
+  name: "Gran Turismo - Nissan Micra Edition [Demo]"
   region: "PAL-E"
 SCED-51359:
   name: "Official PlayStation 2 Magazine Demo 27"
@@ -1650,9 +1655,9 @@ SCED-51568:
   name: "Official PlayStation 2 Magazine Demo 33" # German
   region: "PAL-E-G"
   roundModes:
-    vuRoundMode: 0  # Fixes SPS (Primal).
+    vuRoundMode: 0 # Fixes SPS (Primal).
   clampModes:
-    vuClampMode: 2  # Fixes other SPS (Primal).
+    vuClampMode: 2 # Fixes other SPS (Primal).
 SCED-51569:
   name: "Official PlayStation 2 Magazine Demo 34" # German
   region: "PAL-E-G"
@@ -1680,7 +1685,7 @@ SCED-51657:
       content: |-
         comment=Must enable FPU Negative Div Hack gamefix for Dakar 2 Demo
 SCED-51700:
-  name: "Jak II: Renegade [Demo]"
+  name: "Jak II - Renegade [Demo]"
   region: "PAL-M5"
   gsHWFixes:
     mipmap: 1
@@ -1709,7 +1714,7 @@ SCED-52049:
   region: "PAL-M11"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
     preloadFrameData: 1
 SCED-52051:
@@ -1812,7 +1817,7 @@ SCED-52185:
   name: "Official PlayStation 2 Magazine Demo 41"
   region: "PAL-M5"
 SCED-52196:
-  name: "Official PS2 Magazine Demo 22 Special Ed: It's Here" # United Kingdom
+  name: "Official PS2 Magazine Demo 22 Special Ed - It's Here" # United Kingdom
   region: "PAL-E"
 SCED-52270:
   name: "Official PlayStation 2 Magazine Demo 42"
@@ -2349,7 +2354,7 @@ SCES-50139:
   region: "PAL-M7"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes crash when using the Subaru.
+    eeRoundMode: 0 # Fixes crash when using the Subaru.
   gameFixes:
     - EETimingHack # Fix in-game Freeze.
 SCES-50240:
@@ -2389,15 +2394,15 @@ SCES-50354:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Objects appear in wrong places without it.
-    vuClampMode: 2  # Fixes water reflection.
+    eeClampMode: 3 # Objects appear in wrong places without it.
+    vuClampMode: 2 # Fixes water reflection.
   gameFixes:
-    - EETimingHack # Fixes flickering graphics. 
+    - EETimingHack # Fixes flickering graphics.
 SCES-50360:
   name: "Twisted Metal - Black"
   region: "PAL-M5"
 SCES-50361:
-  name: "Jak and Daxter: The Precursor Legacy"
+  name: "Jak and Daxter - The Precursor Legacy"
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
@@ -2408,7 +2413,7 @@ SCES-50408:
   region: "PAL-M5"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes noodles.
+    InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
 SCES-50409:
   name: "MotoGP 2"
@@ -2437,14 +2442,14 @@ SCES-50490:
   region: "PAL-E"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCES-50491:
   name: "Final Fantasy X"
   region: "PAL-F"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCES-50492:
@@ -2452,21 +2457,21 @@ SCES-50492:
   region: "PAL-G"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCES-50493:
   name: "Final Fantasy X"
   region: "PAL-I"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCES-50494:
   name: "Final Fantasy X"
   region: "PAL-S"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SCES-50499:
@@ -2540,7 +2545,7 @@ SCES-50612:
   name: "Space Channel 5 - Part 2"
   region: "PAL-M5"
 SCES-50614:
-  name: "Jak and Daxter: The Precursor Legacy"
+  name: "Jak and Daxter - The Precursor Legacy"
   region: "PAL-Unk"
   gsHWFixes:
     mipmap: 1
@@ -2621,7 +2626,7 @@ SCES-50928:
   name: "SOCOM - U.S. Navy SEALs [Beta & Full Release]"
   region: "PAL-M6"
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCES-50934:
   name: "WRC II Extreme"
   region: "PAL-M7"
@@ -2740,14 +2745,14 @@ SCES-51176:
   name: "Disney's Treasure Planet"
   region: "PAL-M4"
   clampModes:
-    vuClampMode: 3  # Fixes SPS when the solar surfer's engines are inactive.
+    vuClampMode: 3 # Fixes SPS when the solar surfer's engines are inactive.
   gameFixes:
     - EETimingHack # Fixes hang before going ingame.
 SCES-51177:
   name: "Disney's Treasure Planet"
   region: "PAL"
   clampModes:
-    vuClampMode: 3  # Fixes SPS when the solar surfer's engines are inactive.
+    vuClampMode: 3 # Fixes SPS when the solar surfer's engines are inactive.
   gameFixes:
     - EETimingHack # Fixes hang before going ingame.
 SCES-51179:
@@ -2768,7 +2773,7 @@ SCES-51248:
   name: "Dog's Life"
   region: "PAL-M11"
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
     preloadFrameData: 1
 SCES-51426:
@@ -2824,7 +2829,7 @@ SCES-51607:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - EETimingHack # Fixes DMA errors 
+    - EETimingHack # Fixes DMA errors.
   gsHWFixes:
     mipmap: 1
     autoFlush: 1
@@ -2832,7 +2837,7 @@ SCES-51607:
     - "SCES-51607"
     - "SCES-50916"
 SCES-51608:
-  name: "Jak II: Renegade"
+  name: "Jak II - Renegade"
   region: "PAL-M7"
   compat: 5
   gsHWFixes:
@@ -2859,7 +2864,7 @@ SCES-51618:
   name: "SOCOM - U.S. Navy SEALs"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCES-51635:
   name: "Brave - The Search for Spirit Dancer"
   region: "PAL-M5"
@@ -2896,12 +2901,12 @@ SCES-51719:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCES-51719"
     - "SCES-52438"
     - "SCES-50294"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCES-51725:
   name: "Everquest Online Adventures"
@@ -2942,7 +2947,7 @@ SCES-52004:
   region: "PAL-M6"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCES-52033:
@@ -3088,7 +3093,7 @@ SCES-52438:
     - "SCES-51719"
     - "SCES-52438"
     - "SCES-50294"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCES-52456:
   name: "Ratchet & Clank 3"
@@ -3097,7 +3102,8 @@ SCES-52456:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
     - "SCES-51607"
@@ -3145,7 +3151,7 @@ SCES-52677:
   region: "PAL-M7"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 1  # Fixes not rendered most of the screen.
+    InstantVU1SpeedHack: 1 # Fixes not rendered most of the screen.
 SCES-52748:
   name: "EyeToy - Play 2"
   region: "PAL-M12"
@@ -3191,7 +3197,7 @@ SCES-52893:
   name: "Killzone"
   region: "PAL-E-GR-R"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCES-52930:
@@ -3254,7 +3260,7 @@ SCES-53202:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SCES-53247:
@@ -3270,8 +3276,8 @@ SCES-53285:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCES-53286:
   name: "Jak X - Combat Racing"
   region: "PAL-M7"
@@ -3285,7 +3291,7 @@ SCES-53300:
   name: "SOCOM 3 - U.S. Navy SEALs"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 0  # Fixes SPS ingame.
+    vuClampMode: 0 # Fixes SPS ingame.
 SCES-53304:
   name: "Buzz! The Music Quiz"
   region: "PAL-E"
@@ -3306,8 +3312,10 @@ SCES-53312:
   name: "Soul Calibur III"
   region: "PAL-M5"
   compat: 5
-  roundModes:
-    vuRoundMode: 3
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCES-53315:
@@ -3334,10 +3342,10 @@ SCES-53347:
   name: "SpyToy"
   region: "PAL-M11"
 SCES-53358:
-  name: "24: The Game"
+  name: "24 - The Game"
   region: "PAL-M9"
   clampModes:
-    vuClampMode: 2  # Fixes minimap HUD.
+    vuClampMode: 2 # Fixes minimap HUD.
 SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "PAL-M5"
@@ -3350,9 +3358,9 @@ SCES-53409:
   region: "PAL-M11"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
+    vuRoundMode: 0 # Fixes game engine issue with bombs and ladders.
   clampModes:
-    vuClampMode: 2  # Fixes bugged camera.
+    vuClampMode: 2 # Fixes bugged camera.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCES-53422:
@@ -3548,7 +3556,7 @@ SCES-54078:
   name: "SingStar Norsk på Norsk"
   region: "PAL-N"
 SCES-54094:
-  name: "EyeToy: Play Sports"
+  name: "EyeToy - Play Sports"
   region: "PAL-M15"
 SCES-54128:
   name: "Deutsch Rock-Pop"
@@ -3581,7 +3589,6 @@ SCES-54206:
   region: "PAL-M6"
   compat: 5
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SCES-54219:
@@ -3664,9 +3671,9 @@ SCES-54477:
   region: "PAL-M5"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes disappearing characters.
+    vuRoundMode: 0 # Fixes disappearing characters.
   clampModes:
-    vuClampMode: 2  # Fixes SPS ingame.
+    vuClampMode: 2 # Fixes SPS ingame.
 SCES-54496:
   name: "Buzz! The Mega Quiz"
   region: "PAL-E"
@@ -3698,7 +3705,7 @@ SCES-54552:
     autoFlush: 1 # Fix glow effects from lamps.
     roundSprite: 1 # Fix minimap and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
-    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing. 
+    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
   patches:
     CBB4B383:
       content: |-
@@ -3846,7 +3853,7 @@ SCES-55019:
   gsHWFixes:
     mipmap: 1
 SCES-55038:
-  name: "EyeToy Play: Hero"
+  name: "EyeToy Play - Hero"
   region: "PAL-M15"
 SCES-55056:
   name: "SingStar Summer Party"
@@ -3870,7 +3877,7 @@ SCES-55077:
   name: "SingStar Party Hits"
   region: "PAL-E"
 SCES-55083:
-  name: "EyeToy Play: PomPom Party"
+  name: "EyeToy Play - PomPom Party"
   region: "PAL-M15"
 SCES-55093:
   name: "Buzz! The Pop Quiz"
@@ -3993,7 +4000,7 @@ SCES-55455:
   name: "SingStar Queen"
   region: "PAL-S"
 SCES-55464:
-  name: "Hanuman: Boy Warrior"
+  name: "Hanuman - Boy Warrior"
   region: "PAL-E-HI"
   compat: 5
 SCES-55478:
@@ -4006,7 +4013,7 @@ SCES-55489:
   name: "SingStar Mallorca Party"
   region: "PAL-G"
 SCES-55510:
-  name: "Jak and Daxter: The Lost Frontier"
+  name: "Jak and Daxter - The Lost Frontier"
   region: "PAL-M12"
 SCES-55513:
   name: "SingStar Polskie Hity"
@@ -4024,7 +4031,7 @@ SCES-55527:
   name: "SingStar 2009"
   region: "PAL-S"
 SCES-55535:
-  name: "Desi Adda: Games of India"
+  name: "Desi Adda - Games of India"
   region: "PAL-M4"
   compat: 5
 SCES-55538:
@@ -4109,11 +4116,11 @@ SCES-55650:
   name: "SingStar SuomiSuosikit"
   region: "PAL-FI"
 SCES-55661:
-  name: "RA.ONE: The Game"
+  name: "RA.ONE - The Game"
   region: "PAL-E"
   compat: 5
 SCES-55662:
-  name: "Chandragupta: Warrior Prince"
+  name: "Chandragupta - Warrior Prince"
   region: "PAL-IN"
 SCES-55663:
   name: "Street Cricket Champions 2"
@@ -4195,7 +4202,7 @@ SCKA-20016:
   region: "NTSC-K"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Respawn issues, Fixes SPS.
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCKA-20018:
@@ -4216,7 +4223,7 @@ SCKA-20020:
 SCKA-20022:
   name: "Gran Turismo 4 Prologue"
   region: "NTSC-K"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
 SCKA-20023:
@@ -4258,7 +4265,7 @@ SCKA-20029:
   name: "Gran Turismo Concept 2002 Tokyo-Seoul [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
 SCKA-20030:
-  name: "Sly Cooper: Jeonseolui Bibeobseoreul Chajaseo"
+  name: "Sly Cooper - Jeonseolui Bibeobseoreul Chajaseo"
   region: "NTSC-K"
 SCKA-20032:
   name: "Syphon Filter - The Omega Virus"
@@ -4290,7 +4297,8 @@ SCKA-20037:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
   memcardFilters:
     - "SCKA-20037"
     - "SCKA-20011"
@@ -4328,14 +4336,14 @@ SCKA-20048:
   name: "Killzone"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCKA-20049:
   name: "Tekken 5"
   region: "NTSC-K"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SCKA-20050:
@@ -4383,6 +4391,8 @@ SCKA-20059:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCKA-20060:
@@ -4391,8 +4401,8 @@ SCKA-20060:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCKA-20061:
   name: "Wanda to Kyozou (Shadow of the Colossus)"
   region: "NTSC-K"
@@ -4419,7 +4429,7 @@ SCKA-20064:
   name: "SOCOM 3 - U.S. Navy SEALs"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 0  # Fixes SPS ingame.
+    vuClampMode: 0 # Fixes SPS ingame.
 SCKA-20069:
   name: "Siren 2"
   region: "NTSC-K"
@@ -4453,7 +4463,7 @@ SCKA-20078:
   name: "Killzone [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCKA-20079:
@@ -4469,7 +4479,7 @@ SCKA-20081:
   name: "Tekken 5 [PlayStation 2 Big Hit Series]"
   region: "NTSC-K"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SCKA-20086:
@@ -4489,12 +4499,13 @@ SCKA-20090:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
 SCKA-20092:
   name: "K-1 World Grand Prix 2006"
   region: "NTSC-K"
   speedHacks: 
-    InstantVU1SpeedHack: 0  # Fixes random black frames from happening when in a fight session.
+    InstantVU1SpeedHack: 0 # Fixes random black frames from happening when in a fight session.
     MTVUSpeedHack: 0
   gameFixes:
     - XGKickHack # Fixes grey fighters problem.
@@ -4535,20 +4546,20 @@ SCKA-20120:
   gsHWFixes:
     mipmap: 1
 SCKA-20132:
-  name: "Shin Megami Tensei: Persona 4"
+  name: "Shin Megami Tensei - Persona 4"
   region: "NTSC-K"
   compat: 5
 SCKA-24008:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCKA-30001:
   name: "Gran Turismo 4"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
-  # Comments from old GameIndex.dbf for this Game
+    vuClampMode: 2 # Text in GT mode works.
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCKA-30002:
   name: "God of War"
@@ -4563,7 +4574,6 @@ SCKA-30006:
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SCPM-85101:
@@ -4778,7 +4788,7 @@ SCPS-15017:
   name: "PaRappa the Rapper 2"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes noodles.
+    InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
 SCPS-15018:
   name: "Train Simulator Real, The - Yamanote Sen"
@@ -4794,7 +4804,7 @@ SCPS-15020:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
 SCPS-15021:
-  name: "Jak x Daxter: Kyuusekai no Isan"
+  name: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -4886,7 +4896,7 @@ SCPS-15044:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCPS-15045:
   name: "Ka (Mosquito) - Let's Go Hawaiian"
   region: "NTSC-J"
@@ -4937,7 +4947,7 @@ SCPS-15055:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCPS-15056:
   name: "Ratchet & Clank 2"
@@ -5049,7 +5059,7 @@ SCPS-15072:
   name: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-J"
 SCPS-15073:
-  name: "EyeToy - Groov [with Camera]"
+  name: "EyeToy - Groove [with Camera]"
   region: "NTSC-J"
 SCPS-15074:
   name: "Olympic Summer Games - Athens 2004"
@@ -5087,7 +5097,8 @@ SCPS-15084:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
   memcardFilters:
     - "SCPS-15084"
     - "SCPS-15056"
@@ -5096,7 +5107,7 @@ SCPS-15085:
   name: "Kenran Butousai"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 0  # Fixes missing graphics.
+    eeClampMode: 0 # Fixes missing graphics.
 SCPS-15086:
   name: "Bakufuu Slash! Kizna Arashi [Game Only]"
   region: "NTSC-J"
@@ -5185,16 +5196,16 @@ SCPS-15099:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCPS-15100:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCPS-15101:
   name: "Bleach - Hanatareshi Yabou"
   region: "NTSC-J"
@@ -5205,7 +5216,7 @@ SCPS-15102:
     autoFlush: 1 # Fix glow effects from lamps.
     roundSprite: 1 # Fix minimap and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
-    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing. 
+    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCPS-15103:
   name: "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu [Limited Edition]"
   region: "NTSC-J"
@@ -5284,7 +5295,7 @@ SCPS-17001:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -5296,7 +5307,7 @@ SCPS-17001:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCPS-17002:
   name: "Wild ARMs - Alter Code F"
@@ -5358,8 +5369,8 @@ SCPS-19151:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Otherwise freezes in various spots, check full intro.
-    vuClampMode: 1  # Otherwise camera does not focus correctly on main character.
+    eeClampMode: 2 # Otherwise freezes in various spots, check full intro.
+    vuClampMode: 1 # Otherwise camera does not focus correctly on main character.
   gameFixes:
     - SoftwareRendererFMVHack # FMV is cut off to the upper left.
   gsHWFixes:
@@ -5375,7 +5386,7 @@ SCPS-19201:
   name: "PaRappa the Rapper 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes noodles.
+    InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
 SCPS-19202:
   name: "Extermination [PlayStation 2 The Best]"
@@ -5407,7 +5418,7 @@ SCPS-19209:
   name: "Boku no Summer Vacation [PlayStation 2 The Best]"
   region: "NTSC-J"
 SCPS-19210:
-  name: "Jak x Daxter: Kyuusekai no Isan [PlayStation 2 The Best]"
+  name: "Jak x Daxter - Kyuusekai no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -5445,7 +5456,7 @@ SCPS-19252:
   name: "Gran Turismo 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -5457,7 +5468,7 @@ SCPS-19252:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCPS-19253:
   name: "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]"
@@ -5491,7 +5502,7 @@ SCPS-19304:
     - "SCPS-19304"
     - "SCPS-15009"
     - "SCPS-55007"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # vuClampMode = 2  Text in GT mode works.
   # eeClampMode = 3  Text in races works.
 SCPS-19305:
@@ -5516,7 +5527,8 @@ SCPS-19309:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
 SCPS-19310:
   name: "Ratchet & Clank [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5590,8 +5602,8 @@ SCPS-19321:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCPS-19322:
   name: "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]"
   region: "NTSC-J"
@@ -5646,8 +5658,8 @@ SCPS-19328:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCPS-19329:
   name: "Bleach - Blade Battlers [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -5682,7 +5694,7 @@ SCPS-51010:
   name: "Shikigami no Shiro"
   region: "NTSC-J"
 SCPS-51011:
-  name: "Raging Bless: Gouma Mokushiroku"
+  name: "Raging Bless - Gouma Mokushiroku"
   region: "NTSC-J"
 SCPS-51012:
   name: "Gigantic Drive"
@@ -5706,8 +5718,8 @@ SCPS-55001:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Otherwise freezes in various spots, check full intro.
-    vuClampMode: 1  # Otherwise camera does not focus correctly on main character.
+    eeClampMode: 2 # Otherwise freezes in various spots, check full intro.
+    vuClampMode: 1 # Otherwise camera does not focus correctly on main character.
   gameFixes:
     - SoftwareRendererFMVHack # FMV is cut off to the upper left.
   gsHWFixes:
@@ -5720,7 +5732,7 @@ SCPS-55003:
   name: "Vampire Night"
   region: "NTSC-J"
 SCPS-55004:
-  name: "Jak x Daxter: Kyuusekai no Isan"
+  name: "Jak x Daxter - Kyuusekai no Isan"
   region: "NTSC-J"
   gsHWFixes:
     mipmap: 1
@@ -5759,7 +5771,7 @@ SCPS-55014:
   name: "Armored Core 3"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
 SCPS-55015:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
@@ -5799,7 +5811,7 @@ SCPS-55024:
   name: "Armored Core 2 - Another Age"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
   memcardFilters:
     - "SCPS-55024"
     - "SLPS-25007"
@@ -5942,8 +5954,8 @@ SCPS-56001:
   region: "NTSC-K"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Otherwise freezes in various spots, check full intro.
-    vuClampMode: 1  # Otherwise camera does not focus correctly on main character.
+    eeClampMode: 2 # Otherwise freezes in various spots, check full intro.
+    vuClampMode: 1 # Otherwise camera does not focus correctly on main character.
   gameFixes:
     - SoftwareRendererFMVHack # FMV is cut off to the upper left.
   gsHWFixes:
@@ -5956,7 +5968,7 @@ SCPS-56002:
   gsHWFixes:
     alignSprite: 1
 SCPS-56003:
-  name: "Jak and Daxter: The Precursor Legacy"
+  name: "Jak and Daxter - The Precursor Legacy"
   region: "NTSC-K"
   gsHWFixes:
     mipmap: 1
@@ -6004,20 +6016,20 @@ SCUS-21295:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SCUS-21494:
   name: "Need for Speed - Carbon Collector's Edition"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCUS-90174:
   name: "Toy Story 3 (PlayStation 2 Bundle)"
   region: "NTSC-U"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SCUS-94346:
   name: "SingStar Latino"
   region: "NTSC-U"
@@ -6072,8 +6084,8 @@ SCUS-97113:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Otherwise freezes in various spots, check full intro.
-    vuClampMode: 1  # Otherwise camera does not focus correctly on main character.
+    eeClampMode: 2 # Otherwise freezes in various spots, check full intro.
+    vuClampMode: 1 # Otherwise camera does not focus correctly on main character.
   gameFixes:
     - SoftwareRendererFMVHack # FMV is cut off to the upper left.
   gsHWFixes:
@@ -6107,7 +6119,7 @@ SCUS-97123:
   region: "NTSC-U"
   compat: 5
 SCUS-97124:
-  name: "Jak and Daxter: The Precursor Legacy"
+  name: "Jak and Daxter - The Precursor Legacy"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -6156,7 +6168,7 @@ SCUS-97134:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCUS-97136:
   name: "NCAA Final Four 2002"
   region: "NTSC-U"
@@ -6204,7 +6216,7 @@ SCUS-97146:
   name: "Disney's Treasure Planet"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Fixes SPS when the solar surfer's engines are inactive
+    vuClampMode: 3 # Fixes SPS when the solar surfer's engines are inactive.
   gameFixes:
     - EETimingHack # Fixes hang before going ingame.
 SCUS-97147:
@@ -6275,19 +6287,19 @@ SCUS-97167:
   region: "NTSC-U"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes noodles.
+    InstantVU1SpeedHack: 0 # Fixes noodles.
     MTVUSpeedHack: 0
 SCUS-97169:
   name: "Drakan - The Ancients' Gates [Demo]"
   region: "NTSC-U"
 SCUS-97170:
-  name: "Jak and Daxter: The Precursor Legacy [Cingular Wireless Demo]"
+  name: "Jak and Daxter - The Precursor Legacy [Cingular Wireless Demo]"
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
     textureInsideRT: 1
 SCUS-97171:
-  name: "Jak and Daxter: The Precursor Legacy [PS Underground Demo]"
+  name: "Jak and Daxter - The Precursor Legacy [PS Underground Demo]"
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
@@ -6395,7 +6407,7 @@ SCUS-97205:
   name: "SOCOM - U.S. Navy SEALs [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCUS-97206:
   name: "PlayStation Underground Jampack Summer 2002"
   region: "NTSC-U"
@@ -6403,7 +6415,7 @@ SCUS-97208:
   name: "Hot Shots Golf 3 & PaRappa the Rapper 2 [Demo]"
   region: "NTSC-U"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes noodles on Parappa 2.
+    InstantVU1SpeedHack: 0 # Fixes noodles on Parappa 2.
     MTVUSpeedHack: 0
   gsHWFixes:
     mipmap: 1
@@ -6493,7 +6505,7 @@ SCUS-97230:
   name: "SOCOM - U.S. Navy SEALs (Online)"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Fixes bad shadows.
+    vuClampMode: 2 # Fixes bad shadows.
 SCUS-97231:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "NTSC-U"
@@ -6756,14 +6768,14 @@ SCUS-97328:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters: # Allows car imports from GT3 or something.
     - "SCUS-97328"
     - "SCUS-97436"
     - "SCUS-97102"
     - "SCUS-97219"
     - "SCUS-97512"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCUS-97329:
   name: "Downhill Domination [Demo]"
@@ -6830,7 +6842,8 @@ SCUS-97353:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
   memcardFilters:
     - "SCUS-97353"
     - "SCUS-97268"
@@ -6964,7 +6977,7 @@ SCUS-97402:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCUS-97403:
@@ -6990,7 +7003,7 @@ SCUS-97409:
   name: "Gretzky NHL 2005"
   region: "NTSC-U"
   roundModes:
-    eeRoundMode: 2  # Fix ingame hang.
+    eeRoundMode: 2 # Fix ingame hang.
 SCUS-97410:
   name: "Jampack Demo Disc Vol.10 [T-Rated]"
   region: "NTSC-U"
@@ -7000,7 +7013,8 @@ SCUS-97411:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
@@ -7015,7 +7029,8 @@ SCUS-97413:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
 SCUS-97414:
   name: "EyeToy - AntiGrav"
   region: "NTSC-U"
@@ -7085,28 +7100,28 @@ SCUS-97431:
   name: "Killzone Public Beta V1.0"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCUS-97432:
   name: "Killzone [Regular Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SCUS-97436:
   name: "Gran Turismo 4 [Online Public Beta]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
+    vuClampMode: 2 # Text in GT mode works.
   memcardFilters:
     - "SCUS-97328"
     - "SCUS-97436"
     - "SCUS-97102"
     - "SCUS-97219"
     - "SCUS-97512"
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCUS-97437:
   name: "ATV Off-Road Fury 3 [Demo]"
@@ -7130,7 +7145,7 @@ SCUS-97442:
   name: "Official U.S. PlayStation Magazine Demo Disc 090"
   region: "NTSC-U"
 SCUS-97443:
-  name: "Official U.S. PlayStation Magazine Demo Issue 91"
+  name: "Official U.S. PlayStation Magazine Demo Disc 091"
   region: "NTSC-U"
 SCUS-97444:
   name: "Official U.S. PlayStation Magazine Demo Disc 092"
@@ -7191,9 +7206,9 @@ SCUS-97464:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
+    vuRoundMode: 0 # Fixes game engine issue with bombs and ladders.
   clampModes:
-    vuClampMode: 2  # Fixes bugged camera.
+    vuClampMode: 2 # Fixes bugged camera.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97465:
@@ -7203,8 +7218,8 @@ SCUS-97465:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCUS-97466:
   name: "Gretzky NHL '06"
   region: "NTSC-U"
@@ -7245,7 +7260,7 @@ SCUS-97474:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes SPS ingame.
+    vuClampMode: 0 # Fixes SPS ingame.
   patches:
     75ED4282:
       content: |-
@@ -7258,7 +7273,7 @@ SCUS-97475:
   name: "SOCOM 3 - U.S. Navy SEALs [Regular Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Fixes SPS ingame.
+    vuClampMode: 0 # Fixes SPS ingame.
   patches:
     314F0905:
       content: |-
@@ -7279,30 +7294,28 @@ SCUS-97481:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SCUS-97482:
   name: "God of War II - The Colossus Battle [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SCUS-97483:
   name: "Gran Turismo 4 MX-5 Edition [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Text in GT mode works.
-  # Comments from old GameIndex.dbf for this Game
+    vuClampMode: 2 # Text in GT mode works.
+  # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCUS-97484:
   name: "Sly 3 - Honor Among Thieves [E3 Demo]"
   region: "NTSC-U"
   roundModes:
-    vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
+    vuRoundMode: 0 # Fixes game engine issue with bombs and ladders.
   clampModes:
-    vuClampMode: 2  # Fixes bugged camera.
+    vuClampMode: 2 # Fixes bugged camera.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97485:
@@ -7311,8 +7324,8 @@ SCUS-97485:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCUS-97486:
   name: "Jak X - Combat Racing [Regular Demo]"
   region: "NTSC-U"
@@ -7325,8 +7338,8 @@ SCUS-97487:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
-    preloadFrameData: 1
+    mipmap: 1 # Fixes broken textures.
+    disablePartialInvalidation: 1 # Prevents world geometry and some models from vanishing when pausing or opening vendor.
 SCUS-97488:
   name: "Jak X - Combat Racing [Public Beta v.1]"
   region: "NTSC-U"
@@ -7338,7 +7351,7 @@ SCUS-97489:
   name: "SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Fixes SPS ingame.
+    vuClampMode: 0 # Fixes SPS ingame.
 SCUS-97490:
   name: "Rogue Galaxy"
   region: "NTSC-U"
@@ -7347,7 +7360,7 @@ SCUS-97490:
     autoFlush: 1 # Fix glow effects from lamps.
     roundSprite: 1 # Fix minimap and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
-    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing. 
+    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
   patches:
     0643F90C:
       content: |-
@@ -7459,7 +7472,7 @@ SCUS-97517:
   name: "Killzone [Greatest Hits]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness..
 SCUS-97518:
@@ -7468,7 +7481,8 @@ SCUS-97518:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
 SCUS-97519:
   name: "Sly 2 - Band of Thieves [Greatest Hits]"
   region: "NTSC-U"
@@ -7484,9 +7498,9 @@ SCUS-97527:
   name: "Sly 3 - Honor Among Thieves [Regular Demo]"
   region: "NTSC-U"
   roundModes:
-    vuRoundMode: 0  # Fixes game engine issue with bombs and ladders.
+    vuRoundMode: 0 # Fixes game engine issue with bombs and ladders.
   clampModes:
-    vuClampMode: 2  # Fixes bugged camera.
+    vuClampMode: 2 # Fixes bugged camera.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCUS-97528:
@@ -7536,9 +7550,9 @@ SCUS-97545:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes disappearing characters.
+    vuRoundMode: 0 # Fixes disappearing characters.
   clampModes:
-    vuClampMode: 2  # Fixes SPS ingame.
+    vuClampMode: 2 # Fixes SPS ingame.
 SCUS-97548:
   name: "Ape Escape 3 [Demo]"
   region: "NTSC-U"
@@ -7560,16 +7574,16 @@ SCUS-97557:
   name: "Kiosk Demo Disc Q2-Q3 2006"
   region: "NTSC-U"
 SCUS-97558:
-  name: "Jak and Daxter: The Lost Frontier"
+  name: "Jak and Daxter - The Lost Frontier"
   region: "NTSC-U"
   compat: 5
 SCUS-97560:
   name: "SOCOM - U.S. Navy SEALs - Combined Assault [Demo]"
   region: "NTSC-U"
   roundModes:
-    vuRoundMode: 0  # Fixes disappearing characters.
+    vuRoundMode: 0 # Fixes disappearing characters.
   clampModes:
-    vuClampMode: 2  # Fixes SPS ingame.
+    vuClampMode: 2 # Fixes SPS ingame.
 SCUS-97564:
   name: "Jampack Demo Disc Vol.15 [T-Rated]"
   region: "NTSC-U"
@@ -7590,7 +7604,7 @@ SCUS-97572:
     autoFlush: 1 # Fix glow effects from lamps.
     roundSprite: 1 # Fix minimap and field menu.
     preloadFrameData: 1 # Fixes corrupt textures especially on water.
-    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing. 
+    disablePartialInvalidation: 1 # Prevents UI and subtitles from disappearing.
 SCUS-97579:
   name: "ATV Off-Road Fury 4 [Demo]"
   region: "NTSC-U"
@@ -7601,7 +7615,7 @@ SCUS-97583:
   name: "MLB '08 - The Show"
   region: "NTSC-U"
 SCUS-97584:
-  name: "Syphon Filter: Logan's Shadow"
+  name: "Syphon Filter - Logan's Shadow"
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1
@@ -7643,7 +7657,7 @@ SCUS-97610:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 1  # Fixes the display of scores and text ingame.
+    vuRoundMode: 1 # Fixes the display of scores and text ingame.
 SCUS-97611:
   name: "SingStar Amped"
   region: "NTSC-U"
@@ -7721,7 +7735,7 @@ SCUS-97643:
   region: "NTSC-U"
   compat: 3
 SCUS-97644:
-  name: "MLB '09: The Show"
+  name: "MLB '09 - The Show"
   region: "NTSC-U"
 SCUS-97649:
   name: "SingStar Pop Vol. 2"
@@ -7734,7 +7748,7 @@ SCUS-97651:
   region: "NTSC-U"
   compat: 3
 SCUS-97653:
-  name: "MLB '10: The Show"
+  name: "MLB '10 - The Show"
   region: "NTSC-U"
   compat: 5
 SCUS-97654:
@@ -7847,7 +7861,7 @@ SLAJ-25053:
   name: "Burnout 3 - Takedown"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLAJ-25055:
@@ -7878,7 +7892,7 @@ SLAJ-25066:
   name: "Burnout Revenge - Battle Racing Ignited"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
@@ -7940,9 +7954,10 @@ SLAJ-25078:
   name: "Black"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
 SLAJ-25079:
   name: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-Unk"
@@ -7965,7 +7980,7 @@ SLAJ-25091:
   name: "Need for Speed - Carbon"
   region: "NTSC-Unk"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLAJ-25092:
@@ -7978,7 +7993,7 @@ SLAJ-25094:
   name: "Burnout Dominator"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLAJ-25095:
@@ -8006,12 +8021,12 @@ SLED-50117:
   name: "Metal Gear Solid 2 - Sons of Liberty [Demo] [Zone of the Enders Bonus Disc]"
   region: "PAL-E"
   gameFixes:
-    - DMABusyHack # Fixes broken half-bottom artifacts.  
+    - DMABusyHack # Fixes broken half-bottom artifacts.
 SLED-50359:
   name: "Devil May Cry [Demo]"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Fixes out of place polys (COP2).
+    vuClampMode: 3 # Fixes out of place polys (COP2).
 SLED-50478:
   name: "WWF Smackdown! - Just Bring It [Demo]"
   region: "PAL-E"
@@ -8035,7 +8050,7 @@ SLED-51211:
   name: "Burnout 2 - Point of Impact [Demo]"
   region: "PAL-Unk"
   roundModes:
-    vuRoundMode: 1  # Bright lights in cars.
+    vuRoundMode: 1 # Bright lights in cars.
 SLED-51225:
   name: "Rayman 3 [Demo]"
   region: "PAL-E"
@@ -8050,6 +8065,8 @@ SLED-51342:
 SLED-51901:
   name: "Soul Calibur II [Demo]"
   region: "PAL-E"
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLED-52375:
@@ -8086,7 +8103,7 @@ SLED-52488:
   name: "Suffering, The [Demo]"
   region: "PAL-E"
   speedHacks:
-    InstantVU1SpeedHack: 1  # Fixes SPS.
+    InstantVU1SpeedHack: 1 # Fixes SPS.
 SLED-52597:
   name: "Burnout 3 - Takedown [Demo]"
   region: "PAL-E"
@@ -8129,7 +8146,7 @@ SLED-53723:
   name: "Peter Jackson's King Kong [Demo]"
   region: "PAL-E"
 SLED-53732:
-  name: "Spartan: Total Warrior [Demo]"
+  name: "Spartan - Total Warrior [Demo]"
   region: "PAL"
   gameFixes:
     - EETimingHack # Fixes garbage textures flashing on the character model 
@@ -8145,9 +8162,10 @@ SLED-53937:
   name: "Black [Demo]"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
 SLED-53951:
   name: "Honda Demo [Demo]"
   region: "PAL-E"
@@ -8168,7 +8186,7 @@ SLED-54312:
   name: "Need for Speed - Carbon [Demo]"
   region: "PAL-E"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-50003:
@@ -8218,7 +8236,7 @@ SLES-50021:
   name: "Madden NFL 2001"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-50022:
   name: "NBA Live 2001"
   region: "PAL-E"
@@ -8289,7 +8307,7 @@ SLES-50044:
   name: "Rayman Revolution"
   region: "PAL-M5"
   roundModes:
-    eeRoundMode: 0  # Fixes game hanging in the "Clark running away" ingame cutscene.
+    eeRoundMode: 0 # Fixes game hanging in the "Clark running away" ingame cutscene.
 SLES-50045:
   name: "Disney's Jungle Book - Groove Party"
   region: "PAL-M12"
@@ -8313,7 +8331,7 @@ SLES-50051:
   name: "Eternal Ring"
   region: "PAL-E"
   roundModes:
-    eeRoundMode: 0  # Fixes FPU errors causing instant death in Limestone Cave.
+    eeRoundMode: 0 # Fixes FPU errors causing instant death in Limestone Cave.
 SLES-50052:
   name: "Pool Master"
   region: "PAL-M3"
@@ -8407,7 +8425,7 @@ SLES-50079:
   name: "Armored Core 2"
   region: "PAL-E"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
 SLES-50080:
   name: "NBA Hoopz"
   region: "PAL-M3"
@@ -8466,12 +8484,18 @@ SLES-50127:
 SLES-50128:
   name: "Knockout Kings 2001"
   region: "PAL-E"
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes missing arena, fighters and other missing graphics.
 SLES-50129:
   name: "Knockout Kings 2001"
   region: "PAL-F"
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes missing arena, fighters and other missing graphics.
 SLES-50130:
   name: "Knockout Kings 2001"
   region: "PAL-G"
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes missing arena, fighters and other missing graphics.
 SLES-50131:
   name: "Le Mans 24 Hours"
   region: "PAL-M5"
@@ -8504,7 +8528,7 @@ SLES-50155:
   region: "PAL-M3"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLES-50158:
   name: "Gungriffon Blaze"
   region: "PAL-E"
@@ -8623,7 +8647,7 @@ SLES-50201:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes texture mipmapping.
+    eeClampMode: 2 # Fixes texture mipmapping.
 SLES-50202:
   name: "DNA - Dark Native Apostle"
   region: "PAL-M5"
@@ -8692,6 +8716,8 @@ SLES-50224:
   name: "Kuri Kuri Mix"
   region: "PAL-M3"
   compat: 5
+  speedHacks:
+    MTVUSpeedHack: 0 # Prevents broken textures and graphics.
 SLES-50225:
   name: "Escape from Monkey Island"
   region: "PAL-E"
@@ -8883,7 +8909,7 @@ SLES-50280:
   name: "Victorious Boxers"
   region: "PAL-E"
 SLES-50282:
-  name: "Age of Empires II: The Age of Kings"
+  name: "Age of Empires II - The Age of Kings"
   region: "PAL-M5"
   compat: 5
 SLES-50283:
@@ -8929,12 +8955,12 @@ SLES-50325:
   region: "PAL-E"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes crashes.
+    eeClampMode: 3 # Fixes crashes.
 SLES-50326:
   name: "Max Payne"
   region: "PAL-M4"
   clampModes:
-    eeClampMode: 3  # Fixes crashes.
+    eeClampMode: 3 # Fixes crashes.
 SLES-50330:
   name: "Grand Theft Auto III"
   region: "PAL-M5"
@@ -9015,7 +9041,7 @@ SLES-50382:
   region: "PAL-M6"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLES-50383:
   name: "Metal Gear Solid 2 - Sons of Liberty"
@@ -9080,7 +9106,7 @@ SLES-50422:
   name: "Madden NFL 2002"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-50423:
   name: "F1 2001"
   region: "PAL-M4"
@@ -9147,9 +9173,9 @@ SLES-50446:
   region: "PAL-M4"
   compat: 5
   gameFixes:
-    - EETimingHack # Fixes cutscene freezes. 
+    - EETimingHack # Fixes cutscene freezes.
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes SPS.
+    InstantVU1SpeedHack: 0 # Fixes SPS.
     MTVUSpeedHack: 0
 SLES-50447:
   name: "All-Star Baseball 2003"
@@ -9334,6 +9360,8 @@ SLES-50553:
   name: "Project Eden"
   region: "PAL-M5"
   compat: 5
+  gameFixes:
+    - XGKickHack # Fixes corrupted graphics.
 SLES-50554:
   name: "Thunderhawk - Operation Phoenix"
   region: "PAL-M5"
@@ -9409,9 +9437,9 @@ SLES-50608:
   region: "PAL-G"
   compat: 5
   gameFixes:
-    - EETimingHack # Fixes cutscene freezes. 
+    - EETimingHack # Fixes cutscene freezes.
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes SPS.
+    InstantVU1SpeedHack: 0 # Fixes SPS.
     MTVUSpeedHack: 0
 SLES-50613:
   name: "Woody Woodpecker"
@@ -9500,12 +9528,12 @@ SLES-50662:
   region: "PAL-M5"
   compat: 4
   clampModes:
-    eeClampMode: 2  # Fixes texture mipmapping.
+    eeClampMode: 2 # Fixes texture mipmapping.
 SLES-50670:
   name: "ESPN Winter X-Games Snowboarding 2"
   region: "PAL-M3"
 SLES-50672:
-  name: "Baldur's Gate: Dark Alliance"
+  name: "Baldur's Gate - Dark Alliance"
   region: "PAL-M5"
   compat: 5
   gameFixes:
@@ -9515,7 +9543,7 @@ SLES-50677:
   region: "PAL-E"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes invisible characters in various scenes.
+    eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLES-50679:
   name: "Tenchu 3 - Wrath of Heaven"
   region: "PAL-E"
@@ -9527,7 +9555,7 @@ SLES-50683:
   name: "Sled Storm"
   region: "PAL-M3"
   clampModes:
-    vuClampMode: 3  # Missing polygons at the bottom of the screen.
+    vuClampMode: 3 # Missing polygons at the bottom of the screen.
 SLES-50684:
   name: "Medal of Honor - Frontline"
   region: "PAL-M3"
@@ -9637,7 +9665,7 @@ SLES-50731:
   region: "PAL-M6"
   compat: 5
   clampModes:
-    vuClampMode: 2  # White textures.
+    vuClampMode: 2 # White textures.
 SLES-50735:
   name: "Jade Cocoon 2"
   region: "PAL-E"
@@ -9738,7 +9766,7 @@ SLES-50788:
   name: "Frogger - The Great Quest"
   region: "PAL-M5"
 SLES-50789:
-  name: "Men in Black II: Alien Escape"
+  name: "Men in Black II - Alien Escape"
   region: "PAL-M5"
   gameFixes:
     - VIFFIFOHack # Needed to load the main game properly.
@@ -9843,7 +9871,7 @@ SLES-50822:
   name: "Shadow Hearts"
   region: "PAL-M3"
   clampModes:
-    eeClampMode: 3  # Fixes invisible characters in various scenes.
+    eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLES-50826:
   name: "Star Wars - Clone Wars"
   region: "PAL-E"
@@ -9854,10 +9882,10 @@ SLES-50828:
   name: "Star Wars - Clone Wars"
   region: "PAL-G"
 SLES-50829:
-  name: "Star Wars: La Guerra dei Cloni"
+  name: "Star Wars - La Guerra dei Cloni"
   region: "PAL-I"
 SLES-50830:
-  name: "Star Wars: Las Guerras Clon"
+  name: "Star Wars - Las Guerras Clon"
   region: "PAL-S"
 SLES-50831:
   name: "Star Wars - Bounty Hunter"
@@ -9867,7 +9895,7 @@ SLES-50831:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLES-50832:
   name: "Star Wars - Bounty Hunter"
   region: "PAL-F"
@@ -9876,7 +9904,7 @@ SLES-50832:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLES-50833:
   name: "Star Wars - Bounty Hunter"
   region: "PAL-G"
@@ -9885,7 +9913,7 @@ SLES-50833:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLES-50834:
   name: "Star Wars - Bounty Hunter"
   region: "PAL-I"
@@ -9894,7 +9922,7 @@ SLES-50834:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLES-50835:
   name: "Star Wars - Bounty Hunter"
   region: "PAL-S"
@@ -9903,7 +9931,7 @@ SLES-50835:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLES-50836:
   name: "Indiana Jones and The Emperor's Tomb"
   region: "PAL-E"
@@ -9952,7 +9980,7 @@ SLES-50843:
   name: "Crashed"
   region: "PAL-M5"
 SLES-50845:
-  name: "Medal of Honor: En Première Ligne"
+  name: "Medal of Honor - En Première Ligne"
   region: "PAL-F"
 SLES-50846:
   name: "Medal of Honor - Frontline"
@@ -10072,14 +10100,14 @@ SLES-50902:
   name: "Conflict - Desert Storm"
   region: "PAL-M4"
 SLES-50903:
-  name: "MegaRace 3: Nanotech Disaster"
+  name: "MegaRace 3 - Nanotech Disaster"
   region: "PAL-M5"
 SLES-50905:
   name: "Armored Core 2 - Another Age"
   region: "PAL-E"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
-  # Comments from old GameIndex.dbf for this Game
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
+  # Comments from old GameIndex.dbf for this Game.
   #  Save import option was removed from PAL release.
 SLES-50906:
   name: "Master Rally"
@@ -10261,7 +10289,7 @@ SLES-51023:
   region: "PAL-E"
   compat: 5
 SLES-51024:
-  name: "Roger Lemerre: La Sélection des Champions 2003"
+  name: "Roger Lemerre - La Sélection des Champions 2003"
   region: "PAL-F"
 SLES-51025:
   name: "BDFL Manager 2003"
@@ -10292,7 +10320,7 @@ SLES-51044:
   region: "PAL-M5"
   compat: 5
   roundModes:
-    vuRoundMode: 1  # Bright lights in cars.
+    vuRoundMode: 1 # Bright lights in cars.
 SLES-51045:
   name: "Legends of Wrestling II"
   region: "PAL-E"
@@ -10336,13 +10364,13 @@ SLES-51060:
   name: "Butt Ugly Martians"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 0  # Fixes SPS.
+    vuClampMode: 0 # Fixes SPS.
 SLES-51061:
   name: "Grand Theft Auto - Vice City"
   region: "PAL-M5"
   compat: 5
 SLES-51063:
-  name: "Hot Wheels: Velocity X: Maximum Justice"
+  name: "Hot Wheels - Velocity X - Maximum Justice"
   region: "PAL-E"
 SLES-51064:
   name: "Gladius"
@@ -10455,7 +10483,7 @@ SLES-51110:
   name: "Hitman 2 - Silent Assassin"
   region: "PAL-S"
 SLES-51113:
-  name: "Zone of the Enders: The 2nd Runner Special Edition"
+  name: "Zone of the Enders - The 2nd Runner Special Edition"
   region: "PAL-M5"
   compat: 5
   gameFixes:
@@ -10493,17 +10521,17 @@ SLES-51130:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51131:
   name: "Tony Hawk's Pro Skater 4"
   region: "PAL-F"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51132:
   name: "Tony Hawk's Pro Skater 4"
   region: "PAL-G"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51133:
   name: "Red Faction II"
   region: "PAL-M3"
@@ -10513,7 +10541,7 @@ SLES-51134:
   region: "PAL-M4"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes hangs in certain locations like building under construction.
+    eeClampMode: 3 # Fixes hangs in certain locations like building under construction.
 SLES-51141:
   name: "Summoner 2"
   region: "PAL-E"
@@ -10535,7 +10563,7 @@ SLES-51145:
   name: "Monopoly Party"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 0  # Fixes missing game board.
+    vuClampMode: 0 # Fixes missing game board.
 SLES-51150:
   name: "Scrabble Interactive - 2003 Edition"
   region: "PAL-M3"
@@ -10553,13 +10581,13 @@ SLES-51154:
   name: "Madden NFL 2003"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-51156:
   name: "Silent Hill 2 - Director's Cut"
   region: "PAL-M5"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLES-51157:
   name: "Silent Scope 3"
@@ -10635,14 +10663,14 @@ SLES-51197:
   region: "PAL-M7"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
   gsHWFixes:
     mipmap: 1
 SLES-51198:
   name: "NBA Live 2003"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLES-51199:
   name: "4x4 Evolution II"
   region: "PAL-M3"
@@ -10665,7 +10693,7 @@ SLES-51208:
   name: "Rocky"
   region: "PAL-M5"
   clampModes:
-    eeClampMode: 0  # Fixes boxers not appearing/disappearing.
+    eeClampMode: 0 # Fixes boxers not appearing/disappearing.
   gameFixes:
     - VIF1StallHack # Fixes freezes.
 SLES-51209:
@@ -10786,45 +10814,45 @@ SLES-51252:
   region: "PAL-M3"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLES-51253:
   name: "Lord of the Rings, The - The Two Towers (Seigneur des Anneaux - Les Deux Tours)"
   region: "PAL-F"
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLES-51254:
   name: "Lord of the Rings, The - The Two Towers (Der Herr der Ringe - Die Zwei Turme)"
   region: "PAL-G"
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLES-51255:
   name: "Lord of the Rings, The - The Two Towers"
   region: "PAL-I"
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLES-51256:
   name: "Lord of the Rings, The - The Two Towers (El Senor de Los Anillos - Las Dos Torres)"
   region: "PAL-S"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLES-51257:
   name: "Sims, The (Die Sims)"
   region: "PAL-G"
   compat: 3
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-51258:
   name: "James Bond 007 - Nightfire"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Fixes polygon clipping in driving missions.
+    vuClampMode: 2 # Fixes polygon clipping in driving missions.
 SLES-51260:
   name: "James Bond 007 - Nightfire"
   region: "PAL-G-S"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes polygon clipping in driving missions.
+    vuClampMode: 2 # Fixes polygon clipping in driving missions.
 SLES-51265:
   name: "Dynasty Warriors Tactics"
   region: "PAL-E"
@@ -10841,14 +10869,14 @@ SLES-51272:
   name: "Wakeboarding Unleashed"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Fixes water rendering.
+    vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
 SLES-51273:
   name: "Wakeboarding Unleashed"
   region: "PAL-F"
   clampModes:
-    vuClampMode: 3  # Fixes water rendering.
+    vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
 SLES-51275:
@@ -11044,7 +11072,7 @@ SLES-51372:
   region: "PAL-E"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
 SLES-51374:
   name: "RoboCop"
   region: "PAL-M5"
@@ -11094,7 +11122,7 @@ SLES-51390:
   name: "FightBox"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0  # Fixes missing 3D.
+    vuClampMode: 0 # Fixes missing 3D.
 SLES-51391:
   name: "RTL Skispringen 2003"
   region: "PAL-E-G"
@@ -11124,7 +11152,7 @@ SLES-51399:
   name: "Armored Core 3"
   region: "PAL-E"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
 SLES-51400:
   name: "Tenchu - Wrath of Heaven"
   region: "PAL-S"
@@ -11159,7 +11187,9 @@ SLES-51434:
   name: "Silent Hill 3"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+    vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   memcardFilters:
     - "SLES-51434"
     - "SLES-50382"
@@ -11265,7 +11295,7 @@ SLES-51481:
   region: "PAL-E-F"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Missing environment with microVU.
+    vuClampMode: 2 # Missing environment with microVU.
 SLES-51482:
   name: "Downtown Run"
   region: "PAL-M3"
@@ -11284,7 +11314,7 @@ SLES-51495:
   region: "PAL-M4"
   compat: 5
 SLES-51496:
-  name: "Breath of Fire: Dragon Quarter"
+  name: "Breath of Fire - Dragon Quarter"
   region: "PAL-M5"
 SLES-51503:
   name: "Ace Lightning"
@@ -11311,7 +11341,7 @@ SLES-51511:
   name: "Crash Nitro Kart"
   region: "PAL-M6"
 SLES-51522:
-  name: "Return to Castle Wolfenstein: Operation Resurrection"
+  name: "Return to Castle Wolfenstein - Operation Resurrection"
   region: "PAL-S"
 SLES-51523:
   name: "Conflict - Desert Storm II"
@@ -11332,7 +11362,7 @@ SLES-51547:
   name: "Next Generation Tennis 2003"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 3  # Fixes SPS menus.
+    vuClampMode: 3 # Fixes SPS menus.
 SLES-51548:
   name: "This is Football"
   region: "PAL-M3"
@@ -11340,9 +11370,11 @@ SLES-51553:
   name: "Chaos Legion"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Fixes SPS in item menu.
+    vuClampMode: 2 # Fixes SPS in item menu.
   gsHWFixes:
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes rainbow shadow of legions.
+    alignSprite: 1 # Fixes green vertical lines.
+    roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLES-51554:
   name: "Cell Damage Overdrive"
   region: "PAL-M5"
@@ -11359,9 +11391,9 @@ SLES-51579:
   name: "Yu-Gi-Oh! - The Duelists of the Roses"
   region: "PAL-E"
   roundModes:
-    eeRoundMode: 2  # Partially fixes battle animation.
+    eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
-    eeClampMode: 2  # Partially fixes battle animation.
+    eeClampMode: 2 # Partially fixes battle animation.
 SLES-51580:
   name: "London Racer World Challenge"
   region: "PAL-M4"
@@ -11538,27 +11570,27 @@ SLES-51686:
   region: "PAL-E"
   compat: 4
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-51687:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-F"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-51688:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-G"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-51689:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-I"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-51690:
   name: "Pitfall - The Lost Expedition"
   region: "PAL-S"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-51693:
   name: "Suffering, The"
   region: "PAL-E-F-G"
@@ -11672,7 +11704,7 @@ SLES-51752:
   name: "Tony Hawks Underground"
   region: "PAL-Unk"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51753:
   name: "True Crime - Streets of L.A."
   region: "PAL-E"
@@ -11743,7 +11775,7 @@ SLES-51797:
   name: "Madden NFL 2004"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-51798:
   name: "NHL 2004"
   region: "PAL-M5"
@@ -11752,7 +11784,7 @@ SLES-51799:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Respawn issues, Fixes SPS.
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLES-51800:
@@ -11883,7 +11915,7 @@ SLES-51848:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51850:
   name: "Basketball Xciting"
   region: "PAL-E"
@@ -11891,23 +11923,23 @@ SLES-51851:
   name: "Tony Hawk's Underground"
   region: "PAL-F"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51852:
   name: "Tony Hawk's Underground"
   region: "PAL-G"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51853:
   name: "Tony Hawk's Underground"
   region: "PAL-F"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51854:
   name: "Tony Hawk Underground"
   region: "PAL-S"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-51855:
   name: "Tank Elite"
   region: "PAL-E"
@@ -12005,7 +12037,7 @@ SLES-51887:
   name: "Tiger Woods PGA Tour 2004"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 2  # Fixes black textures on characters.
+    vuClampMode: 2 # Fixes black textures on characters.
 SLES-51888:
   name: "RTL Ski Jumping 2004"
   region: "PAL-E-G"
@@ -12074,7 +12106,7 @@ SLES-51917:
   name: "Beyond Good and Evil"
   region: "PAL-M6"
   roundModes:
-    eeRoundMode: 0  # Fixes SPS with water in some places.
+    eeRoundMode: 0 # Fixes SPS with water in some places.
   gsHWFixes:
     textureInsideRT: 1 # Fixes the shape of shadows.
     autoFlush: 1 # Fixes water rendering.
@@ -12144,7 +12176,7 @@ SLES-51953:
   name: "FIFA 2004"
   region: "PAL-M4"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
   gsHWFixes:
     mipmap: 1
 SLES-51954:
@@ -12181,14 +12213,14 @@ SLES-51963:
   name: "FIFA 2004"
   region: "PAL-F-G"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
   gsHWFixes:
     mipmap: 1
 SLES-51964:
   name: "FIFA 2004"
   region: "PAL-P-S"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
   gsHWFixes:
     mipmap: 1
 SLES-51966:
@@ -12233,12 +12265,12 @@ SLES-51981:
   name: "ShellShock - Nam '67"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
 SLES-51982:
   name: "ShellShock - Nam '67"
   region: "PAL-M3"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
 SLES-51986:
   name: "Backyard Wrestling - Don't Try This At Home"
   region: "PAL-M5"
@@ -12247,7 +12279,7 @@ SLES-51989:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
 SLES-51991:
   name: "Dance UK"
   region: "PAL-E"
@@ -12259,7 +12291,7 @@ SLES-51997:
   region: "PAL-M4"
   compat: 5
   clampModes:
-    eeClampMode: 3  # For grey screen ingame.
+    eeClampMode: 3 # For grey screen ingame.
 SLES-51998:
   name: "Kao the Kangaroo - Round 2"
   region: "PAL-M5"
@@ -12281,7 +12313,7 @@ SLES-52008:
   name: "NBA Live 2004"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLES-52011:
   name: "Tak and The Power of Juju"
   region: "PAL-E"
@@ -12317,13 +12349,13 @@ SLES-52025:
   name: "NFL Street"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-52026:
   name: "Wallace & Gromit in Project Zoo"
   region: "PAL-G"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
 SLES-52028:
   name: "Junior Sports Basketball"
   region: "PAL-M5"
@@ -12419,7 +12451,7 @@ SLES-52097:
   region: "PAL-E-G"
   compat: 5
   clampModes:
-    eeClampMode: 3  # For grey screen ingame.
+    eeClampMode: 3 # For grey screen ingame.
 SLES-52100:
   name: "NRL Rugby League"
   region: "PAL-E"
@@ -12468,7 +12500,7 @@ SLES-52118:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes cutscene freezes.
+    eeClampMode: 3 # Fixes cutscene freezes.
 SLES-52122:
   name: "Crime Life - Gang Wars"
   region: "PAL-M5"
@@ -12553,7 +12585,7 @@ SLES-52179:
   region: "PAL-M5"
   compat: 5
 SLES-52187:
-  name: "Baldur's Gate: Dark Alliance II"
+  name: "Baldur's Gate - Dark Alliance II"
   region: "PAL-M3"
   compat: 5
   gameFixes:
@@ -12561,7 +12593,7 @@ SLES-52187:
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
 SLES-52188:
-  name: "Baldur's Gate: Dark Alliance II"
+  name: "Baldur's Gate - Dark Alliance II"
   region: "PAL-M3"
   compat: 5
   gameFixes:
@@ -12768,12 +12800,12 @@ SLES-52289:
   name: "MTX Mototrax"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Fixes glitchy graphics ingame.
+    vuRoundMode: 0 # Fixes glitchy graphics ingame.
 SLES-52290:
   name: "MTX Mototrax"
   region: "PAL-F"
   roundModes:
-    vuRoundMode: 0  # Fixes glitchy graphics ingame.
+    vuRoundMode: 0 # Fixes glitchy graphics ingame.
 SLES-52291:
   name: "Countryside Bears"
   region: "PAL-M3"
@@ -12816,7 +12848,7 @@ SLES-52322:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Characters are visible in-game.
+    eeClampMode: 3 # Characters are visible in-game.
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and textures wrong.
 SLES-52323:
@@ -12968,27 +13000,27 @@ SLES-52394:
   name: "UFEA Euro 2004"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Fixes disappearing ball and black box issues.
+    vuClampMode: 3 # Fixes disappearing ball and black box issues.
 SLES-52395:
   name: "UFEA Euro 2004"
   region: "PAL-F-G"
   clampModes:
-    vuClampMode: 3  # Fixes disappearing ball and black box issues.
+    vuClampMode: 3 # Fixes disappearing ball and black box issues.
 SLES-52396:
   name: "Euro 2004"
   region: "PAL-P-S"
   clampModes:
-    vuClampMode: 3  # Fixes disappearing ball and black box issues.
+    vuClampMode: 3 # Fixes disappearing ball and black box issues.
 SLES-52397:
   name: "Euro 2004"
   region: "PAL-M3"
   clampModes:
-    vuClampMode: 3  # Fixes disappearing ball and black box issues.
+    vuClampMode: 3 # Fixes disappearing ball and black box issues.
 SLES-52398:
   name: "Euro 2004"
   region: "PAL-M3"
   clampModes:
-    vuClampMode: 3  # Fixes disappearing ball and black box issues.
+    vuClampMode: 3 # Fixes disappearing ball and black box issues.
 SLES-52402:
   name: "Perfect Ace 2 - The Championships"
   region: "PAL-M5"
@@ -13041,6 +13073,8 @@ SLES-52445:
   name: "Silent Hill 4 - The Room"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes dark sides.
 SLES-52446:
   name: "Mashed"
   region: "PAL-M5"
@@ -13065,7 +13099,7 @@ SLES-52457:
   name: "Shrek 2"
   region: "PAL-SW"
 SLES-52458:
-  name: "Disgaea: Hour of Darkness"
+  name: "Disgaea - Hour of Darkness"
   region: "PAL-E"
 SLES-52459:
   name: "Autobahn Raser - Das Spiel zum Film"
@@ -13120,9 +13154,9 @@ SLES-52480:
   name: "Yu-Gi-Oh! - The Duelists of the Roses"
   region: "PAL-M4"
   roundModes:
-    eeRoundMode: 2  # Partially fixes battle animation.
+    eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
-    eeClampMode: 2  # Partially fixes battle animation.
+    eeClampMode: 2 # Partially fixes battle animation.
 SLES-52481:
   name: "Hot Wheels - Stunt Track Challenge"
   region: "PAL-E"
@@ -13137,7 +13171,7 @@ SLES-52486:
   name: "Astro Boy"
   region: "PAL-M5"
   roundModes:
-    eeRoundMode: 0  # Fixes character behaviour.
+    eeRoundMode: 0 # Fixes character behaviour.
 SLES-52490:
   name: "Dance UK - Extra Trax"
   region: "PAL-E"
@@ -13164,7 +13198,7 @@ SLES-52509:
   name: "Tiger Woods PGA Tour 2005"
   region: "PAL-M4"
   clampModes:
-    vuClampMode: 2  # Fix black textures on characters.
+    vuClampMode: 2 # Fix black textures on characters.
 SLES-52510:
   name: "Neo Contra"
   region: "PAL-M3"
@@ -13207,7 +13241,7 @@ SLES-52521:
   name: "Adibou & Les Voleurs d'Energie"
   region: "PAL-M6"
 SLES-52523:
-  name: "Cocoto - Platform Jumper: Griffin's Story"
+  name: "Cocoto - Platform Jumper - Griffin's Story"
   region: "PAL-M5"
 SLES-52525:
   name: "Mouse Trophy"
@@ -13222,7 +13256,7 @@ SLES-52531:
   name: "Suffering, The"
   region: "PAL-G"
   speedHacks:
-    InstantVU1SpeedHack: 1  # Fixes SPS.
+    InstantVU1SpeedHack: 1 # Fixes SPS.
 SLES-52532:
   name: "Aces of War"
   region: "PAL-E"
@@ -13241,17 +13275,17 @@ SLES-52536:
   region: "PAL-E"
   compat: 2
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-52537:
   name: "Shark Tale"
   region: "PAL-M3"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-52539:
   name: "Shark Tale"
   region: "PAL-I"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-52541:
   name: "Grand Theft Auto - San Andreas"
   region: "PAL-M5"
@@ -13343,7 +13377,7 @@ SLES-52568:
   region: "PAL-M5"
   compat: 5
   gameFixes:
-    - XGKickHack # Fixes bad Geometry.
+    - XGKickHack # Fixes bad geometry.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLES-52569:
@@ -13365,7 +13399,7 @@ SLES-52573:
   name: "Conflict - Global Storm"
   region: "PAL-M5"
   roundModes:
-    eeRoundMode: 2  # Fixes abnormal character behaviour.
+    eeRoundMode: 2 # Fixes abnormal character behaviour.
 SLES-52576:
   name: "Yu-Gi-Oh! - Capsule Monster Colisee"
   region: "PAL-M5"
@@ -13376,20 +13410,20 @@ SLES-52581:
   name: "Madden NFL 2005"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-52584:
   name: "Burnout 3 - Takedown"
   region: "PAL-M4"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLES-52587:
@@ -13466,12 +13500,12 @@ SLES-52621:
   name: "Tony Hawk's Underground 2"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-52622:
   name: "Tony Hawk's Underground 2"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-52624:
   name: "X-Men Legends"
   region: "PAL-E"
@@ -13482,7 +13516,7 @@ SLES-52628:
   name: "NBA Ballers"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 2  # Fixes transparency issues.
+    vuClampMode: 2 # Fixes transparency issues.
 SLES-52630:
   name: "Conflict - Vietnam"
   region: "PAL-M5"
@@ -13513,19 +13547,19 @@ SLES-52639:
   name: "V8 Supercars 2"
   region: "PAL-M5"
 SLES-52641:
-  name: "Leisure Suit Larry: Magna Cum Laude (Uncut)"
+  name: "Leisure Suit Larry - Magna Cum Laude (Uncut)"
   region: "PAL-E"
 SLES-52642:
-  name: "Leisure Suit Larry: Magna cum Laude"
+  name: "Leisure Suit Larry - Magna cum Laude"
   region: "PAL-F"
 SLES-52643:
-  name: "Leisure Suit Larry: Magna Cum Laude"
+  name: "Leisure Suit Larry - Magna Cum Laude"
   region: "PAL-G"
 SLES-52644:
-  name: "Leisure Suit Larry: Magna Cum Laude"
+  name: "Leisure Suit Larry - Magna Cum Laude"
   region: "PAL-S"
 SLES-52645:
-  name: "Leisure Suit Larry: Magna cum Laude"
+  name: "Leisure Suit Larry - Magna cum Laude"
   region: "PAL-I"
 SLES-52646:
   name: "Tom Clancy's Ghost Recon 2"
@@ -13607,7 +13641,7 @@ SLES-52670:
   region: "PAL-M5"
   compat: 5
 SLES-52671:
-  name: "Ghost Master: The Gravenville Chronicles"
+  name: "Ghost Master - The Gravenville Chronicles"
   region: "PAL-M5"
 SLES-52673:
   name: "NHL 2005"
@@ -13661,9 +13695,13 @@ SLES-52701:
 SLES-52702:
   name: "Psi-Ops - The Mindgate Conspiracy"
   region: "PAL-M5"
+  gsHWFixes:
+    roundSprite: 2 # Removes blurriness and artifacting at sides, esspecialy helps 3D11.
 SLES-52703:
   name: "Psi-Ops - The Mindgate Conspiracy"
   region: "PAL-M5"
+  gsHWFixes:
+    roundSprite: 2 # Removes blurriness and artifacting at sides, esspecialy helps 3D11.
 SLES-52705:
   name: "Mortal Kombat - Deception"
   region: "PAL-M5"
@@ -13870,22 +13908,22 @@ SLES-52807:
   name: "Lemony Snicket's A Series of Unfortunate Events"
   region: "PAL-E"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to collect items.
+    eeClampMode: 3 # Fixes the inability to collect items.
 SLES-52808:
   name: "Lemony Snicket's A Series of Unfortunate Events"
   region: "PAL-F"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to collect items.
+    eeClampMode: 3 # Fixes the inability to collect items.
 SLES-52809:
   name: "Lemony Snicket - Schauriger Schlamassel"
   region: "PAL-G"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to collect items.
+    eeClampMode: 3 # Fixes the inability to collect items.
 SLES-52810:
   name: "Lemony Snicket's Una Serie Disfortunati Eventi"
   region: "PAL-I"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to collect items.
+    eeClampMode: 3 # Fixes the inability to collect items.
 SLES-52811:
   name: "Get on da Mic"
   region: "PAL-M3"
@@ -13926,7 +13964,7 @@ SLES-52825:
   name: "Lemony Snicket's A Series of Unfortunate Events"
   region: "PAL-S"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to collect items.
+    eeClampMode: 3 # Fixes the inability to collect items.
 SLES-52831:
   name: "Syberia 2"
   region: "PAL-M5"
@@ -14001,7 +14039,7 @@ SLES-52872:
   name: "Constantine"
   region: "PAL-M5"
   roundModes:
-    eeRoundMode: 2  # Resolves dumpster not being able to be climbed from front in level 2.
+    eeRoundMode: 2 # Resolves dumpster not being able to be climbed from front in level 2.
 SLES-52874:
   name: "Dark Wind (with Gametrak)"
   region: "PAL-M5"
@@ -14035,8 +14073,10 @@ SLES-52887:
   name: "Power Rangers Dino Thunder"
   region: "PAL-F"
 SLES-52888:
-  name: "Brothers in Arms: Road to Hill 30"
+  name: "Brothers In Arms - Road to Hill 30"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLES-52889:
   name: "Disney's Winnie the Pooh Rumbly Tumbly Adventure"
   region: "PAL-M6"
@@ -14094,7 +14134,7 @@ SLES-52915:
   name: "Shark Tale"
   region: "PAL-SW"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-52917:
   name: "Scaler"
   region: "PAL-E-F"
@@ -14131,7 +14171,7 @@ SLES-52931:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes broken polygons on trees.
+    vuClampMode: 3 # Fixes broken polygons on trees.
 SLES-52934:
   name: "Guilty Gear Isuka [Preview]"
   region: "PAL-E"
@@ -14211,7 +14251,7 @@ SLES-52963:
   name: "Cold Winter"
   region: "PAL-M4"
   clampModes:
-    vuClampMode: 2  # Fixes rainbow graphics.
+    vuClampMode: 2 # Fixes rainbow graphics.
 SLES-52964:
   name: "NanoBreaker"
   region: "PAL-M5"
@@ -14239,7 +14279,7 @@ SLES-52968:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 1  # Bright lights in cars.
+    vuRoundMode: 1 # Bright lights in cars.
 SLES-52973:
   name: "Ski Racing 2005"
   region: "PAL-M5"
@@ -14253,7 +14293,7 @@ SLES-52976:
   name: "GoldenEye - Rogue Agent"
   region: "PAL-G"
 SLES-52977:
-  name: "GoldenEye: Agente Corrupto"
+  name: "GoldenEye - Agente Corrupto"
   region: "PAL-S"
 SLES-52978:
   name: "La Pucelle Tactics"
@@ -14265,7 +14305,7 @@ SLES-52982:
   name: "NFL Street 2"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
   gameFixes:
     - GIFFIFOHack # Fixes garbage graphics.
 SLES-52983:
@@ -14432,27 +14472,27 @@ SLES-53028:
   name: "Hitman - Blood Money"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues.
+    vuClampMode: 0 # Fixes bump mapping issues.
 SLES-53029:
   name: "Hitman - Blood Money"
   region: "PAL-F"
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues.
+    vuClampMode: 0 # Fixes bump mapping issues.
 SLES-53030:
   name: "Hitman - Blood Money"
   region: "PAL-G"
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues.
+    vuClampMode: 0 # Fixes bump mapping issues.
 SLES-53031:
   name: "Hitman - Blood Money"
   region: "PAL-I"
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues.
+    vuClampMode: 0 # Fixes bump mapping issues.
 SLES-53032:
   name: "Hitman - Blood Money"
   region: "PAL-S"
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues.
+    vuClampMode: 0 # Fixes bump mapping issues.
 SLES-53035:
   name: "Masters of the Universe - He-Man - Defender of Greyskull"
   region: "PAL-E"
@@ -14468,7 +14508,7 @@ SLES-53037:
   region: "PAL-M5"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+    eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLES-53038:
   name: "Devil May Cry 3 - Dante's Awakening"
   region: "PAL-M5"
@@ -14503,9 +14543,13 @@ SLES-53046:
 SLES-53047:
   name: "Punisher, The"
   region: "PAL-E-F"
+  gsHWFixes:
+    roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLES-53049:
   name: "Punisher, The"
   region: "PAL-I-S"
+  gsHWFixes:
+    roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLES-53052:
   name: "Robots"
   region: "PAL-M5"
@@ -14537,7 +14581,7 @@ SLES-53065:
   region: "PAL-E"
   compat: 5
 SLES-53073:
-  name: "Michigan: Report from Hell"
+  name: "Michigan - Report from Hell"
   region: "PAL-M4"
   compat: 5
 SLES-53074:
@@ -14592,7 +14636,7 @@ SLES-53093:
   name: "Cold Winter"
   region: "PAL-G"
   clampModes:
-    vuClampMode: 2  # Fixes rainbow graphics.
+    vuClampMode: 2 # Fixes rainbow graphics.
 SLES-53094:
   name: "Rugby 2005"
   region: "PAL-E"
@@ -14638,7 +14682,7 @@ SLES-53114:
   name: "Full Spectrum Warrior"
   region: "PAL-M5"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLES-53119:
   name: "Kessen III"
   region: "PAL-E"
@@ -14678,7 +14722,7 @@ SLES-53131:
   name: "Full Spectrum Warrior"
   region: "PAL-E"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLES-53138:
   name: "Outlaw Volleyball - Remixed"
   region: "PAL-M4"
@@ -14787,6 +14831,8 @@ SLES-53194:
 SLES-53195:
   name: "Punisher, The"
   region: "PAL-E"
+  gsHWFixes:
+    roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLES-53196:
   name: "Destroy All Humans!"
   region: "PAL-M4"
@@ -14811,6 +14857,8 @@ SLES-53201:
 SLES-53203:
   name: "Punisher, The"
   region: "PAL-R"
+  gsHWFixes:
+    roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLES-53218:
   name: "Dancing Stage MAX"
   region: "PAL-M5"
@@ -14818,7 +14866,7 @@ SLES-53219:
   name: "Winx Club"
   region: "PAL-M5"
 SLES-53221:
-  name: "L'Entraineur 5: Saison 04/05"
+  name: "L'Entraineur 5 - Saison 04/05"
   region: "PAL-F"
 SLES-53222:
   name: "Scudetto 5"
@@ -14901,7 +14949,7 @@ SLES-53300:
   name: "SOCOM 3 - U.S. Navy SEALs"
   region: "PAL-Unk"
   clampModes:
-    vuClampMode: 0  # Fixes SPS ingame.
+    vuClampMode: 0 # Fixes SPS ingame.
 SLES-53301:
   name: "Bomberman Hardball"
   region: "PAL-E"
@@ -14996,7 +15044,7 @@ SLES-53350:
   region: "PAL-M5"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Prevents only backgrounds from appearing in Sonic R's multiplayer modes.
+    vuRoundMode: 0 # Prevents only backgrounds from appearing in Sonic R's multiplayer modes.
   memcardFilters: # Vectorman unlocks by having a Mega Collection or Heroes save.
     - "SLES-53350"
     - "SLES-52998"
@@ -15037,11 +15085,11 @@ SLES-53362:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
 SLES-53363:
-  name: "Shin Megami Tensei: Lucifer's Call"
+  name: "Shin Megami Tensei - Lucifer's Call"
   region: "PAL-M3"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes commands not being visible.
+    eeRoundMode: 0 # Fixes commands not being visible.
 SLES-53364:
   name: "7 Sins"
   region: "PAL-G"
@@ -15138,8 +15186,8 @@ SLES-53402:
   region: "PAL-E"
   compat: 5
   roundModes:
-    eeRoundMode: 2  # Positive rounding fixes white models.
-    vuRoundMode: 2  # Positive rounding fixes white models.
+    eeRoundMode: 2 # Positive rounding fixes white models.
+    vuRoundMode: 2 # Positive rounding fixes white models.
 SLES-53403:
   name: "Demolition Girl"
   region: "PAL-E"
@@ -15165,7 +15213,10 @@ SLES-53411:
   name: "Kuon"
   region: "PAL-M3"
   roundModes:
-    eeRoundMode: 0  # Fixes Sugoroku mini-game.
+    eeRoundMode: 0 # Fixes Sugoroku mini-game.
+  speedHacks:
+    InstantVU1SpeedHack: 1 # This option enabled brings about 15% more FPS when I tested it, *your experience may differ.
+    MTVUSpeedHack: 0 # For some reason this games halves the internal game FPS with this option.
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
@@ -15260,7 +15311,7 @@ SLES-53457:
   name: "Evil Dead - Regeneration"
   region: "PAL-E"
 SLES-53458:
-  name: "Shin Megami Tensei: Digital Devil Saga"
+  name: "Shin Megami Tensei - Digital Devil Saga"
   region: "PAL-E"
   compat: 5
 SLES-53459:
@@ -15312,7 +15363,7 @@ SLES-53481:
   region: "PAL-M5"
   compat: 5
 SLES-53483:
-  name: "Magna Carta: Tears of Blood"
+  name: "Magna Carta - Tears of Blood"
   region: "PAL-E"
   compat: 5
 SLES-53484:
@@ -15357,7 +15408,7 @@ SLES-53498:
   name: "Nickelodeon Bob Esponja - ¡Luces, Cámara, Esponja!"
   region: "PAL-S"
 SLES-53499:
-  name: "Nickelodeon SpongeBob SquarePants: Licht uit, Camera aan!"
+  name: "Nickelodeon SpongeBob SquarePants - Licht uit, Camera aan!"
   region: "PAL-DU"
 SLES-53501:
   name: "Star Wars - Battlefront II"
@@ -15386,7 +15437,7 @@ SLES-53506:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -15398,7 +15449,7 @@ SLES-53507:
   region: "PAL-M3"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
@@ -15418,7 +15469,7 @@ SLES-53510:
   name: "Madden NFL 2006"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-53518:
   name: "Castle Shikigami II"
   region: "PAL-E"
@@ -15435,7 +15486,7 @@ SLES-53523:
   name: "Gun"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Fixes textures and crashes.
+    vuRoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom misalignment.
     wildArmsHack: 1 # Fixes bloom misalignment.
@@ -15498,12 +15549,12 @@ SLES-53534:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-53535:
   name: "Tony Hawk's American Wasteland"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-53536:
   name: "London Racer - Police Madness"
   region: "PAL-M3"
@@ -15638,7 +15689,7 @@ SLES-53561:
   name: "Canis Canem Edit"
   region: "PAL-M5"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
+    eeClampMode: 3 # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
   gsHWFixes:
     wildArmsHack: 1 # Reduces depth ghosting.
     roundSprite: 2 # Reduces depth ghosting.
@@ -15738,14 +15789,14 @@ SLES-53616:
   name: "True Crime - New York City"
   region: "PAL-E"
   clampModes:
-    eeClampMode: 2  # Fixes SPS on highway.
+    eeClampMode: 2 # Fixes SPS on highway.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-53618:
   name: "True Crime - New York City"
   region: "PAL-S"
   clampModes:
-    eeClampMode: 2  # Fixes SPS on highway.
+    eeClampMode: 2 # Fixes SPS on highway.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting.
 SLES-53621:
@@ -15816,7 +15867,7 @@ SLES-53647:
   name: "Gun"
   region: "PAL-G"
   roundModes:
-    vuRoundMode: 0  # Fixes textures and crashes.
+    vuRoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom misalignment.
     wildArmsHack: 1 # Fixes bloom misalignment.
@@ -15838,7 +15889,7 @@ SLES-53656:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "PAL-M4"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLES-53657:
   name: "Shrek - Super Slam"
   region: "PAL-E"
@@ -15846,8 +15897,10 @@ SLES-53658:
   name: "Disney-Pixar's The Incredibles - Rise of the Underminer"
   region: "PAL-R"
 SLES-53659:
-  name: "Brothers in Arms: Earned in Blood"
+  name: "Brothers In Arms - Earned in Blood"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLES-53661:
   name: "Capcom Classics Collection"
   region: "PAL-E"
@@ -16117,8 +16170,8 @@ SLES-53755:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes SPS with microVU.
-    eeClampMode: 2  # Fixes missing blade.
+    vuClampMode: 0 # Fixes SPS with microVU.
+    eeClampMode: 2 # Fixes missing blade.
   memcardFilters: # Reads Lament of Innocence save for easter egg.
     - "SLES-53755"
     - "SLES-52118"
@@ -16147,13 +16200,13 @@ SLES-53763:
   name: "Tom Clancy's Ghost Recon - Advanced Warfighter"
   region: "PAL-M5"
 SLES-53764:
-  name: "Atelier Iris: Eternal Mana"
+  name: "Atelier Iris - Eternal Mana"
   region: "PAL-E"
 SLES-53765:
-  name: "Stella Deus: The Gate of Eternity"
+  name: "Stella Deus - The Gate of Eternity"
   region: "PAL-E"
 SLES-53767:
-  name: "Magna Carta: Les Larmes de Sang"
+  name: "Magna Carta - Les Larmes de Sang"
   region: "PAL-F"
 SLES-53768:
   name: "Sword of Etheria, The"
@@ -16197,7 +16250,7 @@ SLES-53794:
   name: "Drakengard 2"
   region: "PAL-M3"
   clampModes:
-    eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+    eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting characters.
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
@@ -16365,7 +16418,7 @@ SLES-53866:
   name: "Over the Hedge"
   region: "PAL-E"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53867:
   name: "Ski Alpin 2006"
   region: "PAL-E-G"
@@ -16403,9 +16456,10 @@ SLES-53886:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
   patches:
     ADDFF505:
       content: |-
@@ -16429,7 +16483,7 @@ SLES-53901:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 2  # For SPS with microVU.
+    vuClampMode: 2 # For SPS with microVU.
 SLES-53902:
   name: "Leaderboard Golf"
   region: "PAL-E"
@@ -16459,7 +16513,7 @@ SLES-53909:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "PAL-G"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLES-53910:
   name: "Agent Hugo"
   region: "PAL-R"
@@ -16516,7 +16570,7 @@ SLES-53948:
   name: "Winter Sports"
   region: "PAL-M5"
 SLES-53949:
-  name: "Magna Carta: Lacrime di Sangue"
+  name: "Magna Carta - Lacrime di Sangue"
   region: "PAL-I"
 SLES-53952:
   name: "Cue Academy, The (Snooker-Pool-Billiards)"
@@ -16611,22 +16665,22 @@ SLES-53986:
   name: "Over the Hedge"
   region: "PAL-I"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53987:
   name: "Over the Hedge"
   region: "PAL-S"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53988:
   name: "Over the Hedge"
   region: "PAL-E-G"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53989:
   name: "Over the Hedge"
   region: "PAL-DU"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-53991:
   name: "Urban Chaos - Riot Response"
   region: "PAL-M5"
@@ -16646,6 +16700,10 @@ SLES-53998:
   name: "OutRun 2006 - Coast 2 Coast"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
+    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLES-53999:
   name: "King of Fighters, The - Neo Wave"
   region: "PAL-E"
@@ -16720,9 +16778,10 @@ SLES-54030:
   region: "PAL-E"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
   patches:
     CAA04879:
       content: |-
@@ -16877,7 +16936,7 @@ SLES-54132:
   region: "PAL-M5"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLES-54135:
   name: "Grand Theft Auto - Liberty City Stories"
   region: "PAL-M5"
@@ -16918,7 +16977,7 @@ SLES-54151:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Makes the game to correctly register left and right Dpad button input.
+    eeClampMode: 3 # Makes the game to correctly register left and right Dpad button input.
   memcardFilters: # Enables import of players from completed career saves.
     - "SLES-54151"
     - "SLES-54153"
@@ -17008,7 +17067,7 @@ SLES-54173:
   name: "Over The Hedge"
   region: "PAL-SW"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLES-54174:
   name: "ZooCube"
   region: "PAL-E"
@@ -17209,7 +17268,7 @@ SLES-54248:
   name: "Madden NFL '07"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-54250:
   name: "NBA Live '07"
   region: "PAL-F"
@@ -17223,7 +17282,7 @@ SLES-54253:
   name: "Tiger Woods PGA Tour 07"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 2  # Fix black textures on characters.
+    vuClampMode: 2 # Fix black textures on characters.
 SLES-54254:
   name: "Evolution GT"
   region: "PAL-PL"
@@ -17293,28 +17352,28 @@ SLES-54321:
   region: "PAL-E"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54322:
   name: "Need for Speed - Carbon"
   region: "PAL-M8"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54323:
   name: "Need for Speed - Carbon"
   region: "PAL-I-S"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54324:
   name: "Need for Speed - Carbon"
   region: "PAL-R"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54326:
@@ -17476,7 +17535,7 @@ SLES-54379:
   name: "NFL Street 3"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
   gameFixes:
     - GIFFIFOHack # Fixes corrupt textures.
 SLES-54380:
@@ -17498,7 +17557,7 @@ SLES-54384:
   gsHWFixes:
     mipmap: 1
 SLES-54385:
-  name: "Atelier Iris 2: The Azoth of Destiny"
+  name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "PAL-E"
 SLES-54388:
   name: "Kim Possible - What's the Switch"
@@ -17508,13 +17567,13 @@ SLES-54389:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54390:
   name: "Tony Hawk's Project 8"
   region: "PAL-M4"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54393:
   name: "Pippa Funnell - Take the Reins"
   region: "PAL-M3"
@@ -17548,7 +17607,7 @@ SLES-54402:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-F"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54420:
@@ -17562,7 +17621,7 @@ SLES-54423:
   name: "Justice League Heroes"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 2  # Fixes ingame SPS for the capes.
+    vuClampMode: 2 # Fixes ingame SPS for the capes.
 SLES-54424:
   name: "Dr. Dolittle"
   region: "PAL-M7"
@@ -17630,7 +17689,7 @@ SLES-54442:
   region: "PAL-M5"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLES-54443:
   name: "Made Man"
   region: "PAL-M5"
@@ -17660,11 +17719,11 @@ SLES-54453:
   name: "Chicken Little - Asso Spaziale!"
   region: "PAL-I"
 SLES-54454:
-  name: "Disgaea 2: Cursed Memories"
+  name: "Disgaea 2 - Cursed Memories"
   region: "PAL-E"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes flickering FMV's.
-  # Comments from old GameIndex.dbf for this Game
+  # Comments from old GameIndex.dbf for this Game.
   #  Voices can be switched between Japanese and English via Options menu.
 SLES-54455:
   name: "Thrillville"
@@ -17725,7 +17784,7 @@ SLES-54464:
     roundSprite: 1 # Fixes HUD artifacts.
     wildArmsHack: 1 # Lessens the bloom misalignment but still an issue.
 SLES-54465:
-  name: "CSI: 3 Dimensions of Murder"
+  name: "CSI - 3 Dimensions of Murder"
   region: "PAL-M5"
 SLES-54466:
   name: "Test Drive Unlimited"
@@ -17791,19 +17850,20 @@ SLES-54490:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
 SLES-54492:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-E"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54493:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-F-G"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-54494:
@@ -17829,14 +17889,14 @@ SLES-54516:
   region: "PAL-F-G"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mergeSprite: 1 # Fixes blurriness but removes bloom.
+    mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
     wrapGSMem: 1 # Fixes FMVs missing video pieces.
 SLES-54517:
   name: "Thrillville"
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mergeSprite: 1 # Fixes blurriness but removes bloom.
+    mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
     wrapGSMem: 1 # Fixes FMVs missing video pieces.
 SLES-54518:
   name: "Clumsy Shumsy"
@@ -17912,7 +17972,7 @@ SLES-54554:
   region: "PAL-M3"
   compat: 5
 SLES-54555:
-  name: "Shin Megami Tensei: Digital Devil Saga 2"
+  name: "Shin Megami Tensei - Digital Devil Saga 2"
   region: "PAL-E"
   memcardFilters: # Reads data from DDS1.
     - "SLES-54555"
@@ -17974,9 +18034,9 @@ SLES-54584:
   name: "Pac-Man Rally"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 3  # Fixes bad geometry.
+    vuClampMode: 3 # Fixes bad geometry.
 SLES-54586:
-  name: "Ar tonelico: Melody of Elemia"
+  name: "Ar tonelico - Melody of Elemia"
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
@@ -18064,7 +18124,7 @@ SLES-54627:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLES-54628:
@@ -18074,7 +18134,7 @@ SLES-54629:
   name: "Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs. the Soulless Army"
   region: "PAL-E"
 SLES-54630:
-  name: "Chi Vuol Essere Milionario: Party Edition"
+  name: "Chi Vuol Essere Milionario - Party Edition"
   region: "PAL-I"
 SLES-54631:
   name: "Harley-Davidson - Race to the Rally"
@@ -18220,7 +18280,7 @@ SLES-54681:
   name: "Burnout Dominator"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLES-54683:
@@ -18268,12 +18328,12 @@ SLES-54714:
   name: "Tony Hawk's Downhill Jam"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54715:
   name: "Tony Hawk's Downhill Jam"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54716:
   name: "Skateboard Madness - Xtreme Edition"
   region: "PAL-E"
@@ -18309,7 +18369,7 @@ SLES-54727:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
 SLES-54728:
   name: "Mountain Bike Adrenaline featuring Salomon"
   region: "PAL-M5"
@@ -18321,30 +18381,30 @@ SLES-54733:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54734:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-F"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54735:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-G"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54736:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-S"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54737:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-R"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54738:
   name: "Thunderbirds"
   region: "PAL-M11"
@@ -18353,25 +18413,25 @@ SLES-54744:
   region: "PAL-P-CR"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54745:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-I"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54746:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-G"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54747:
   name: "Disney-Pixar Ratatouille"
   region: "PAL-P-S"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-54755:
   name: "Transformers - The Game"
   region: "PAL-E"
@@ -18389,26 +18449,26 @@ SLES-54770:
   name: "DreamWorks Shrek the Third"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Fixes black zones.
+    vuRoundMode: 0 # Fixes black zones.
   clampModes:
-    eeClampMode: 3  # Fixes objects spawning.
+    eeClampMode: 3 # Fixes objects spawning.
 SLES-54771:
   name: "DreamWorks Shrek the Third"
   region: "PAL-M5"
   roundModes:
-    vuRoundMode: 0  # Fixes black zones.
+    vuRoundMode: 0 # Fixes black zones.
   clampModes:
-    eeClampMode: 3  # Fixes objects spawning.
+    eeClampMode: 3 # Fixes objects spawning.
 SLES-54772:
   name: "Monster Eggs"
   region: "PAL-E"
 SLES-54774:
   name: "DreamWorks Shrek the Third"
   roundModes:
-    vuRoundMode: 0  # Fixes black zones.
+    vuRoundMode: 0 # Fixes black zones.
   region: "PAL-M5"
   clampModes:
-    eeClampMode: 3  # Fixes objects spawning.
+    eeClampMode: 3 # Fixes objects spawning.
 SLES-54776:
   name: "Fantastic Four - Rise of the Silver Surfer"
   region: "PAL-E-I"
@@ -18498,7 +18558,7 @@ SLES-54812:
   name: "Madden NFL 08"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLES-54813:
   name: "NASCAR 08"
   region: "PAL-A-E"
@@ -18546,7 +18606,7 @@ SLES-54820:
   gameFixes:
     - VIFFIFOHack
 SLES-54822:
-  name: "Atelier Iris 3: Grand Phantasm"
+  name: "Atelier Iris 3 - Grand Phantasm"
   region: "PAL-E"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
@@ -18598,12 +18658,12 @@ SLES-54859:
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLES-54860:
   name: "Guitar Hero - Rocks The 80's"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLES-54861:
   name: "Thomas & Friends - A Day at the Races"
   region: "PAL-M5"
@@ -18654,7 +18714,7 @@ SLES-54878:
   name: "Naruto - Ultimate Ninja 2"
   region: "PAL-M5"
   clampModes:
-    vuClampMode: 0  # Fixes glow effects.
+    vuClampMode: 0 # Fixes glow effects.
 SLES-54879:
   name: "WWE SmackDown vs. Raw 2008"
   region: "PAL-M5"
@@ -18888,20 +18948,20 @@ SLES-54962:
   name: "Guitar Hero III - Legends of Rock"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54963:
   name: "Tony Hawks - Proving Ground"
   region: "PAL-E"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54964:
   name: "Tony Hawk's Proving Ground"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54971:
-  name: "Hot Wheels: Beat That!"
+  name: "Hot Wheels - Beat That!"
   region: "PAL-M4"
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
@@ -18911,13 +18971,13 @@ SLES-54972:
   gsHWFixes:
     roundSprite: 1 # Fixes font sizes.
 SLES-54973:
-  name: "Le Avventure di Lupin III: Lupin la Morte, Zenigata l'Amore"
+  name: "Le Avventure di Lupin III - Lupin la Morte, Zenigata l'Amore"
   region: "PAL-I"
 SLES-54974:
   name: "Guitar Hero III - Legends of Rock"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-54975:
   name: "George Of The Jungle"
   region: "PAL-E"
@@ -19052,7 +19112,7 @@ SLES-55017:
   name: "Yu-Gi-Oh! GX - Tag Force Evolution"
   region: "PAL-M5"
 SLES-55018:
-  name: "Shin Megami Tensei: Persona 3"
+  name: "Shin Megami Tensei - Persona 3"
   region: "PAL-E"
   compat: 5
   gsHWFixes:
@@ -19138,7 +19198,7 @@ SLES-55049:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Stops ball falling through tables.
+    eeClampMode: 3 # Stops ball falling through tables.
 SLES-55050:
   name: "MX vs. ATV - Untamed"
   region: "PAL-E"
@@ -19215,7 +19275,7 @@ SLES-55109:
   name: "Spiderwick Chronicles, The"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Fixes invisible wall collision in bedroom.
+    vuRoundMode: 0 # Fixes invisible wall collision in bedroom.
 SLES-55110:
   name: "Odin Sphere"
   region: "PAL-M5"
@@ -19230,7 +19290,7 @@ SLES-55122:
   name: "Moorhuhn Fun Kart 2008"
   region: "PAL-M4"
   clampModes:
-    eeClampMode: 3  # Fixes falling through ground.
+    eeClampMode: 3 # Fixes falling through ground.
 SLES-55123:
   name: "Legend of Sayuki"
   region: "PAL-M4"
@@ -19245,7 +19305,7 @@ SLES-55126:
     halfPixelOffset: 1 # Fixes lighting misalignment.
     alignSprite: 1 # Fixes almost all vertical lines.
 SLES-55129:
-  name: "Jumper: Griffin's Story"
+  name: "Jumper - Griffin's Story"
   region: "PAL-M5"
 SLES-55131:
   name: "Roller Coaster Funfare"
@@ -19269,20 +19329,24 @@ SLES-55138:
   name: "Nickelodeon El Tigre - The Adventures of Manny Rivera"
   region: "PAL-E"
 SLES-55143:
-  name: "The Chronicles of Narnia: Prince Caspian"
+  name: "The Chronicles of Narnia - Prince Caspian"
   region: "PAL-G-I"
 SLES-55144:
-  name: "The Chronicles of Narnia: Prince Caspian"
+  name: "The Chronicles of Narnia - Prince Caspian"
   region: "PAL-M6"
 SLES-55145:
-  name: "The Chronicles of Narnia: Prince Caspian"
+  name: "The Chronicles of Narnia - Prince Caspian"
   region: "PAL-F-DU"
 SLES-55146:
-  name: "The Chronicles of Narnia: Prince Caspian"
+  name: "The Chronicles of Narnia - Prince Caspian"
   region: "PAL-UK"
 SLES-55147:
   name: "Silent Hill Origins"
   region: "PAL-M5"
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes black textures and flashlight circle not working.
+    halfPixelOffset: 1 # Fixes ghosting.
+    wildArmsHack: 1 # Fixes ghosting.
 SLES-55148:
   name: "SBK 08 - Superbike World Championship"
   region: "PAL-M5"
@@ -19304,7 +19368,7 @@ SLES-55165:
   name: "Mummy, The - Tomb of the Dragon Emperor"
   region: "PAL-M6"
 SLES-55166:
-  name: "Bob O Construtor: Festival do Divertimento"
+  name: "Bob O Construtor - Festival do Divertimento"
   region: "PAL-P"
 SLES-55167:
   name: "Soul Nomad & the World Eaters"
@@ -19330,27 +19394,27 @@ SLES-55184:
   name: "Disney-Pixar WALL-E"
   region: "PAL-A"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55185:
   name: "Disney-Pixar WALL-E"
   region: "PAL-UK"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55186:
   name: "Disney-Pixar WALL-E"
   region: "PAL-S-P"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55187:
   name: "Disney-Pixar WALL-E"
   region: "PAL-F-G"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55188:
   name: "Disney-Pixar WALL-E"
   region: "PAL-G"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55189:
   name: "Nick Jr. Go Diego Go! Safari Rescue"
   region: "PAL-E-F"
@@ -19361,7 +19425,7 @@ SLES-55191:
   name: "Guitar Hero - Aerosmith"
   region: "PAL-E"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-55192:
   name: "Steam Express"
   region: "PAL-M5"
@@ -19369,22 +19433,22 @@ SLES-55193:
   name: "Disney-Pixar WALL-E"
   region: "PAL-R"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55194:
   name: "Disney-Pixar WALL-E"
   region: "PAL-SC"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55195:
   name: "Disney-Pixar WALL-E"
   region: "PAL-GR-I"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55196:
   name: "Disney-Pixar WALL-E"
   region: "PAL-PL-CR"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55197:
   name: "Dancing Stage SuperNOVA 2"
   region: "PAL-M5"
@@ -19400,7 +19464,7 @@ SLES-55200:
   name: "Guitar Hero - Aerosmith"
   region: "PAL-M4"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-55201:
   name: "Riding Star"
   region: "PAL-M4"
@@ -19480,7 +19544,7 @@ SLES-55237:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes invisible QTE button prompts and overbright in some scenes.
+    vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
 SLES-55238:
   name: "Madden NFL 09"
   region: "PAL-E"
@@ -19679,14 +19743,14 @@ SLES-55344:
   name: "Rock Band - Song Back 1"
   region: "PAL-M5"
 SLES-55345:
-  name: "James Bond: Quantum of Solace"
+  name: "James Bond - Quantum of Solace"
   region: "PAL-M5"
   compat: 5
 SLES-55346:
   name: "Rugby League 2 - World Cup Edition"
   region: "PAL-E"
 SLES-55347:
-  name: "Dragon Ball Z: Infinite World"
+  name: "Dragon Ball Z - Infinite World"
   region: "PAL-M5"
   compat: 5
 SLES-55348:
@@ -19729,7 +19793,7 @@ SLES-55353:
     skipDrawStart: 1 # Removes even more blurriness and garbage texture like on top left.
     skipDrawEnd: 1 # Removes even more blurriness and garbage texture like on top left.
 SLES-55354:
-  name: "Shin Megami Tensei: Persona 3 FES"
+  name: "Shin Megami Tensei - Persona 3 FES"
   region: "PAL-E"
   gsHWFixes:
     mipmap: 1
@@ -19776,11 +19840,11 @@ SLES-55371:
   name: "Barbie Horse Adventures - Riding Camp"
   region: "PAL-M6"
 SLES-55372:
-  name: "Spiderman: Web of Shadows"
+  name: "Spiderman - Web of Shadows"
   region: "PAL-M5"
   compat: 5
 SLES-55373:
-  name: "King of Fighters Collection, The: The Orochi Saga"
+  name: "King of Fighters Collection, The - The Orochi Saga"
   region: "PAL-E"
 SLES-55374:
   name: "DreamWorks Madagascar 2 - Escape 2 Africa"
@@ -19799,12 +19863,12 @@ SLES-55378:
   name: "RTL Biathlon 2009"
   region: "PAL-E-G"
   clampModes:
-    vuClampMode: 3 # Fixes SPS in game 
+    vuClampMode: 3 # Fixes SPS in game.
 SLES-55379:
   name: "RTL Biathlon 2009"
   region: "PAL-E-G"
   clampModes:
-    vuClampMode: 3 # Fixes SPS in game 
+    vuClampMode: 3 # Fixes SPS in game.
 SLES-55380:
   name: "Sonic Unleashed"
   region: "PAL-M5"
@@ -19887,7 +19951,7 @@ SLES-55434:
   name: "Disney Sing It"
   region: "PAL-E-R"
 SLES-55440:
-  name: "Ben 10: Alien Force"
+  name: "Ben 10 - Alien Force"
   region: "PAL-M5"
   compat: 5
 SLES-55442:
@@ -19899,15 +19963,15 @@ SLES-55443:
   region: "PAL-E"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes jump issue.
+    eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLES-55444:
-  name: "Ar tonelico II: Melody of Metafalica"
+  name: "Ar tonelico II - Melody of Metafalica"
   region: "PAL-E"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes "Fall through floor" bug when approaching chests.
+    eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLES-55448:
@@ -19923,13 +19987,13 @@ SLES-55453:
   name: "SingStar Queen"
   region: "PAL-Unk"
 SLES-55457:
-  name: "AC/DC LIVE: Rock Band Track Pack"
+  name: "AC/DC LIVE - Rock Band Track Pack"
   region: "PAL-M5"
 SLES-55458:
   name: "Rock Band - Song Pack 2"
   region: "PAL-M5"
 SLES-55459:
-  name: "Jelly Belly: Ballistic Beans"
+  name: "Jelly Belly - Ballistic Beans"
   region: "PAL-M5"
 SLES-55460:
   name: "Trivial Pursuit"
@@ -19941,7 +20005,7 @@ SLES-55462:
   name: "Dance Party Club Hits"
   region: "PAL-M5"
 SLES-55465:
-  name: "Real Madrid: The Game"
+  name: "Real Madrid - The Game"
   region: "PAL-M5"
 SLES-55467:
   name: "Trivial Pursuit"
@@ -19957,12 +20021,12 @@ SLES-55472:
   name: "Guitar Hero - Metalica"
   region: "PAL-M5"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLES-55474:
-  name: "Shin Megami Tensei: Persona 4"
+  name: "Shin Megami Tensei - Persona 4"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 2  # Fix flickering floor during cutscenes in school.
+    vuClampMode: 2 # Fix flickering floor during cutscenes in school.
 SLES-55476:
   name: "Scooby-Doo! First Frights"
   region: "PAL-M5"
@@ -19991,18 +20055,18 @@ SLES-55492:
   name: "SBK 09 - Superbike World Championship"
   region: "PAL-M5"
 SLES-55493:
-  name: "Marvel: Ultimate Alliance 2"
+  name: "Marvel - Ultimate Alliance 2"
   region: "PAL-E"
 SLES-55494:
   name: "X-Men Origins - Wolverine"
   region: "PAL-E-F"
   clampModes:
-    eeClampMode: 3  # Flickering objects, sound loop.
+    eeClampMode: 3 # Flickering objects, sound loop.
 SLES-55495:
   name: "X-Men Origins - Wolverine"
   region: "PAL-M3"
   clampModes:
-    eeClampMode: 3  # Flickering objects, sound loop.
+    eeClampMode: 3 # Flickering objects, sound loop.
 SLES-55496:
   name: "Secret Agent Clank"
   region: "PAL-Unk"
@@ -20091,6 +20155,7 @@ SLES-55569:
   region: "PAL-M5"
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes missing graphics.
+    halfPixelOffset: 2 # Fixes ghosting.
 SLES-55571:
   name: "Ghostbusters"
   region: "PAL-M6"
@@ -20117,7 +20182,7 @@ SLES-55578:
   name: "Band Hero"
   region: "PAL-M5"
 SLES-55579:
-  name: "Bakugan: Battle Brawlers"
+  name: "Bakugan - Battle Brawlers"
   region: "PAL-M7"
   compat: 5
   roundModes:
@@ -20184,12 +20249,12 @@ SLES-55622:
   region: "PAL-M6"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55623:
   name: "Disney-Pixar Toy Story 3"
   region: "PAL-R"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLES-55625:
   name: "Despicable Me - The Game"
   region: "PAL-M9"
@@ -20598,14 +20663,16 @@ SLKA-25026:
   name: "Chaos Legion"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 2  # Fixes SPS in item menu.
+    vuClampMode: 2 # Fixes SPS in item menu.
   gsHWFixes:
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes rainbow shadow of legions.
+    alignSprite: 1 # Fixes green vertical lines.
+    roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLKA-25029:
   name: "MVP Baseball 2003"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 3  # Fixes missing environment.
+    vuClampMode: 3 # Fixes missing environment.
 SLKA-25030:
   name: "WWE SmackDown! Shut Your Mouth"
   region: "NTSC-K"
@@ -20628,7 +20695,7 @@ SLKA-25041:
   name: "Armored Core 3 Silent Line"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SLKA-25041"
     - "SLPM-67524"
@@ -20640,7 +20707,7 @@ SLKA-25043:
   region: "NTSC-K"
   compat: 5
 SLKA-25044:
-  name: "Robotech: Battlecry"
+  name: "Robotech - Battlecry"
   region: "NTSC-K"
 SLKA-25045:
   name: "The King of Fighters 2000"
@@ -20677,7 +20744,7 @@ SLKA-25064:
   region: "NTSC-K"
   compat: 5
 SLKA-25066:
-  name: "Zone of the Enders: The 2nd Runner SE"
+  name: "Zone of the Enders - The 2nd Runner SE"
   region: "NTSC-K"
   compat: 5
 SLKA-25067:
@@ -20705,13 +20772,13 @@ SLKA-25082:
   region: "NTSC-K"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes cutscene freezes.
+    eeClampMode: 3 # Fixes cutscene freezes.
 SLKA-25087:
   name: "FIFA Soccer 2004"
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLKA-25091:
   name: "Hanjuku Hero vs. 3D"
   region: "NTSC-K"
@@ -20763,7 +20830,7 @@ SLKA-25132:
   name: "Mobile Suit Gundam Encounters in Space"
   region: "NTSC-K"
 SLKA-25133:
-  name: "AirForce Delta Strike"
+  name: "AirForce - Delta Strike"
   region: "NTSC-K"
   compat: 5
 SLKA-25134:
@@ -20788,6 +20855,8 @@ SLKA-25149:
   name: "Silent Hill 4 The Room"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes dark sides.
 SLKA-25150:
   name: "Bujingai"
   region: "NTSC-K"
@@ -20801,17 +20870,17 @@ SLKA-25159:
   name: "Astro Boy"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 0  # Fixes character behaviour.
+    eeRoundMode: 0 # Fixes character behaviour.
 SLKA-25160:
-  name: "Shin Megami Tensei III: Nocturne Maniax"
+  name: "Shin Megami Tensei III - Nocturne Maniax"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLKA-25165:
   name: "Mobile Suit Gundam - Seed Destiny - Rengou vs. Z.A.F.T. II Plus"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes camera issue.
+    eeRoundMode: 1 # Fixes camera issue.
   gameFixes:
     - FpuNegDivHack # Fixes target loss issue.
 SLKA-25166:
@@ -20827,6 +20896,14 @@ SLKA-25171:
   name: "Guon"
   region: "NTSC-K"
   compat: 5
+  roundModes:
+    eeRoundMode: 0 # Fixes Sugoroku mini-game.
+  speedHacks:
+    InstantVU1SpeedHack: 1 # This option enabled brings about 15% more FPS when I tested it, *your experience may differ.
+    MTVUSpeedHack: 0 # For some reason this games halves the internal game FPS with this option.
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces ghosting.
+    preloadFrameData: 1 # Fixes red cracklines on walls.
 SLKA-25172:
   name: "Harry Potter and The Prisoner of Azkaban"
   region: "NTSC-K"
@@ -20884,7 +20961,7 @@ SLKA-25205:
   name: "Dragon Ball Z 3"
   region: "NTSC-K"
 SLKA-25206:
-  name: "Burnout 3: Takedown"
+  name: "Burnout 3 - Takedown"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
@@ -20912,7 +20989,7 @@ SLKA-25214:
   name: "Final Fantasy X - International [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLKA-25215:
@@ -20934,7 +21011,7 @@ SLKA-25219:
   region: "NTSC-K"
   compat: 5
 SLKA-25221:
-  name: "Busin Zero: Wizardry Alternative Neo"
+  name: "Busin Zero - Wizardry Alternative Neo"
   region: "NTSC-K"
   compat: 5
 SLKA-25222:
@@ -21018,7 +21095,7 @@ SLKA-25264:
   name: "Full Spectrum Warrior"
   region: "NTSC-K"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLKA-25265:
   name: "Devil May Cry 3"
   region: "NTSC-K"
@@ -21067,7 +21144,7 @@ SLKA-25290:
   name: "Super Monkey Ball Deluxe"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+    eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLKA-25291:
   name: "Chains of Power"
   region: "NTSC-K"
@@ -21090,7 +21167,7 @@ SLKA-25300:
   gameFixes:
     - EETimingHack
 SLKA-25301:
-  name: "Digital Devil Saga: Avatar Tuner 2"
+  name: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-K"
   compat: 5
   gameFixes:
@@ -21112,12 +21189,12 @@ SLKA-25313:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
 SLKA-25314:
-  name: "Kidou Senshi Gundam SEED: Rengou vs. Z.A.F.T."
+  name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes camera issue.
+    eeRoundMode: 1 # Fixes camera issue.
   gameFixes:
     - FpuNegDivHack # Fixes target loss issue.
 SLKA-25317:
@@ -21141,8 +21218,8 @@ SLKA-25328:
   region: "NTSC-K"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes SPS with microVU.
-    eeClampMode: 2  # Fixes missing blade.
+    vuClampMode: 0 # Fixes SPS with microVU.
+    eeClampMode: 2 # Fixes missing blade.
   memcardFilters:
     - "SLKA-25328"
     - "SLKA-25082"
@@ -21228,7 +21305,7 @@ SLKA-25389:
   region: "NTSC-K"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Otherwise freezes in some spot.
+    eeClampMode: 3 # Otherwise freezes in some spot.
 SLKA-25390:
   name: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-K"
@@ -21253,6 +21330,10 @@ SLKA-25422:
   name: "Silent Hill - Origins"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes black textures and flashlight circle not working.
+    halfPixelOffset: 2 # Fixes ghosting.
+    wildArmsHack: 1 # Fixes ghosting.
 SLKA-25424:
   name: "SNK Arcade Classics Vol.1"
   region: "NTSC-K"
@@ -21294,7 +21375,7 @@ SLPM-20436:
   region: "NTSC-J"
   compat: 5
 SLPM-55005:
-  name: "Mana Khemia 2: Ochita Gakuen to Renkinjutsushi Tachi"
+  name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
@@ -21331,7 +21412,7 @@ SLPM-55081:
   name: "Drag-on Dragoon 2 - Fuuin no Kurenai (Ultimate Hits)"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+    eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
 SLPM-55090:
   name: "DanceDanceRevolution X"
   region: "NTSC-J"
@@ -21361,7 +21442,7 @@ SLPM-55110:
   name: "Mercenaries 2 - World in Flames"
   region: "NTSC-J"
 SLPM-55114:
-  name: "Mana Khemia 2: Ochita Gakuen to Renkinjutsushi Tachi"
+  name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes lines in sprites but still some lines left.
@@ -21412,7 +21493,7 @@ SLPM-55146:
   name: "Jikkyou Powerful Pro Yakyuu 2009"
   region: "NTSC-J"
 SLPM-55148:
-  name: "007: Nagusame no Houshuu"
+  name: "007 - Nagusame no Houshuu"
   region: "NTSC-J"
 SLPM-55155:
   name: "Jikkyou Powerful Major League 2009"
@@ -21450,10 +21531,10 @@ SLPM-55222:
   name: "beatmania IIDX 16 EMPRESS + PREMIUM BEST (PREMIUM BEST DISC)"
   region: "NTSC-J"
 SLPM-55226:
-  name: "FIFA 10: World Class Soccer"
+  name: "FIFA 10 - World Class Soccer"
   region: "NTSC-J"
 SLPM-55244:
-  name: "Need for Speed - Undercover [EA:SY! 1980]"
+  name: "Need for Speed - Undercover [Ea-SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
@@ -21472,7 +21553,7 @@ SLPM-55262:
   name: "J.League Winning Eleven 2010 - Club Championship"
   region: "NTSC-J"
 SLPM-55271:
-  name: "FIFA 10: World Class Soccer (EA:SY! 1980)"
+  name: "FIFA 10 - World Class Soccer (Ea -SY! 1980)"
   region: "NTSC-J"
 SLPM-55273:
   name: "Hakuouki - Reimeiroku"
@@ -21523,14 +21604,14 @@ SLPM-60109:
     cpuFramebufferConversion: 1
     textureInsideRT: 1
 SLPM-60123:
-  name: "Gekikuukan Pro Baseball: The End of the Century 1999 [Trial]"
+  name: "Gekikuukan Pro Baseball - The End of the Century 1999 [Trial]"
   region: "NTSC-J"
 SLPM-60138:
   name: "Klonoa 2 - Lunatea's Veil [Trial]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Objects appear in wrong places without it.
-    vuClampMode: 2  # Fixes water reflection.
+    eeClampMode: 3 # Objects appear in wrong places without it.
+    vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
 SLPM-60172:
@@ -21571,7 +21652,7 @@ SLPM-60251:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting but still an issue compared to native.
 SLPM-60254:
-  name: "Zettai Zetsumei Toshi 2: Itetsuita Kioku-tachi [Trial A]"
+  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial A]"
   region: "NTSC-J"
 SLPM-60256:
   name: "Dengeki D73 demo"
@@ -21601,7 +21682,7 @@ SLPM-60271:
   clampModes:
     eeClampMode: 3 # Fixes black screen.
 SLPM-60273:
-  name: "Zettai Zetsumei Toshi 2: Itetsuita Kioku-tachi [Trial B]"
+  name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial B]"
   region: "NTSC-J"
 SLPM-60274:
   name: "Full House Kiss 2 [Trial]"
@@ -21618,7 +21699,7 @@ SLPM-61009:
   name: "Silent Hill 2 (Red Ribbon) [Trial]"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLPM-61010:
   name: "Devil May Cry [Trial Version]"
@@ -21627,7 +21708,7 @@ SLPM-61011:
   name: "Silent Hill 2 (Black Ribbon) [Video Trial]"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLPM-61018:
   name: "Abarenbou Princess [Trial]"
@@ -21639,24 +21720,24 @@ SLPM-61051:
   name: "Dengeki PS2 D61"
   region: "NTSC-J"
 SLPM-61087:
-  name: "Fullmetal Alchemist 2: Curse of the Crimson Elixir [Trial]"
+  name: "Fullmetal Alchemist 2 - Curse of the Crimson Elixir [Trial]"
   region: "NTSC-J"
 SLPM-61117:
   name: "Musashiden II - Blademaster [Trial]"
   region: "NTSC-J"
   roundModes:
-    vuRoundMode: 0  # Fixes Red SPS while ingame.
-    eeRoundMode: 0  # Partially fixes wrong enemies eye rendering.
+    vuRoundMode: 0 # Fixes Red SPS while ingame.
+    eeRoundMode: 0 # Partially fixes wrong enemies eye rendering.
   clampModes:
-    vuClampMode: 3  # Fixes White SPS while ingame.
-    eeClampMode: 3  # Fixes White SPS while ingame.
+    vuClampMode: 3 # Fixes White SPS while ingame.
+    eeClampMode: 3 # Fixes White SPS while ingame.
   gameFixes:
     - EETimingHack # Fixes garbled character animation.
 SLPM-61120:
   name: "Drag-on Dragoon 2 - Fuuin no Kurenai [Trial Version]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+    eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
 SLPM-61127:
   name: "FlatOut [Trial]"
   region: "NTSC-J"
@@ -21665,13 +21746,15 @@ SLPM-61133:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-61135:
   name: "Naruto - Narutimett Hero 3 [Trial Version]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes invisible QTE button prompts and overbright in some scenes.
+    vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
 SLPM-61147:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Demo]"
   region: "NTSC-J"
@@ -21736,7 +21819,7 @@ SLPM-62023:
   name: "Winback"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62025:
   name: "PrintFan"
   region: "NTSC-J"
@@ -21769,7 +21852,7 @@ SLPM-62036:
   name: "Choukousoku Reversi"
   region: "NTSC-J"
 SLPM-62040:
-  name: "Jikkyou World Soccer 2000: Final Edition"
+  name: "Jikkyou World Soccer 2000 - Final Edition"
   region: "NTSC-J"
 SLPM-62041:
   name: "ESPN National Hockey Night"
@@ -21847,7 +21930,7 @@ SLPM-62075:
   name: "Live World Soccer 2001"
   region: "NTSC-J"
 SLPM-62076:
-  name: "Age of Empires II: The Age of Kings"
+  name: "Age of Empires II - The Age of Kings"
   region: "NTSC-J"
 SLPM-62077:
   name: "Maestro Music 2, The"
@@ -21890,7 +21973,7 @@ SLPM-62097:
   name: "Keisusaikan, The - Shinjuku 24 Hours"
   region: "NTSC-J"
 SLPM-62098:
-  name: "Busin Zero: Wizardry Alternative"
+  name: "Busin Zero - Wizardry Alternative"
   region: "NTSC-J"
 SLPM-62100:
   name: "Rez [Special Package]"
@@ -21942,7 +22025,7 @@ SLPM-62121:
   name: "ESPN NBA 2Night 2002"
   region: "NTSC-J"
 SLPM-62122:
-  name: "Hermina to Culus: Lilie no Atelier Mou Hitotsu no Monogatari"
+  name: "Hermina to Culus - Lilie no Atelier Mou Hitotsu no Monogatari"
   region: "NTSC-J"
 SLPM-62123:
   name: "Winning Post 5"
@@ -21971,10 +22054,10 @@ SLPM-62131:
   name: "Romance of the Three Kingdoms VIII"
   region: "NTSC-J"
 SLPM-62132:
-  name: "24: The Game"
+  name: "24 - The Game"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes minimap HUD.
+    vuClampMode: 2 # Fixes minimap HUD.
 SLPM-62133:
   name: "Bloody Roar 3 [Konami The Best]"
   region: "NTSC-J"
@@ -22094,7 +22177,7 @@ SLPM-62201:
   name: "Winback"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62202:
   name: "Winning Post 4 Maximum 2001"
   region: "NTSC-J"
@@ -22354,7 +22437,7 @@ SLPM-62299:
   name: "Winback [Koei The Best]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62300:
   name: "Horse Breaker [Koei The Best]"
   region: "NTSC-J"
@@ -23053,7 +23136,7 @@ SLPM-62567:
   name: "Winback [Koei Best Series]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62568:
   name: "Shin Sangoku Musou [Koei The Best]"
   region: "NTSC-J"
@@ -23649,12 +23732,12 @@ SLPM-64502:
   name: "Winback"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-64504:
   name: "Maximo"
   region: "NTSC-K"
 SLPM-64513:
-  name: "Crash Bandicoot: Return of the Demon King"
+  name: "Crash Bandicoot - Return of the Demon King"
   region: "NTSC-K"
 SLPM-64522:
   name: "La Pucelle"
@@ -23752,10 +23835,10 @@ SLPM-65017:
   name: "Love Songs - Idol is my Classmate"
   region: "NTSC-J"
 SLPM-65018:
-  name: "Z.O.E.: Zone of the Enders [Limited Edition]"
+  name: "Z.O.E. - Zone of the Enders [Limited Edition]"
   region: "NTSC-J"
 SLPM-65019:
-  name: "Z.O.E.: Zone of the Enders"
+  name: "Z.O.E. - Zone of the Enders"
   region: "NTSC-J"
   compat: 5
 SLPM-65020:
@@ -23844,15 +23927,15 @@ SLPM-65050:
   name: "Yu-Gi-Oh! Shin Duel Monsters 2"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 2  # Partially fixes battle animation.
+    eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
-    eeClampMode: 2  # Partially fixes battle animation.
+    eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65051:
   name: "Silent Hill 2"
   region: "NTSC-J"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLPM-65052:
   name: "GUITAR FREAKS 4thMIX & drummania 3rdMIX"
@@ -23967,7 +24050,7 @@ SLPM-65083:
   name: "Houshin Engi 2"
   region: "NTSC-J"
 SLPM-65085:
-  name: "Alone in the Dark: The New Nightmare"
+  name: "Alone in the Dark - The New Nightmare"
   region: "NTSC-J"
 SLPM-65086:
   name: "Ayumi Hamasaki Dome Tour 2001 - A Visual Mix [Disc1of2]"
@@ -24026,7 +24109,7 @@ SLPM-65098:
   region: "NTSC-J"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLPM-65100:
   name: "Onimusha 2"
@@ -24059,11 +24142,11 @@ SLPM-65115:
   name: "Final Fantasy X International"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-65116:
-  name: "Lilie no Atelier Plus: Salburg no Renkinjutsushi 3"
+  name: "Lilie no Atelier Plus - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
 SLPM-65117:
   name: "Kikou Heiden J-Phoenix [Takara The Best]"
@@ -24100,7 +24183,7 @@ SLPM-65130:
   name: "Dramatic Soccer Game - Becoming a National Team Member"
   region: "NTSC-J"
 SLPM-65131:
-  name: "Judie no Atelier: Gramnad no Renkinjutsushi"
+  name: "Judie no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
 SLPM-65132:
   name: "Warriors of Might and Magic"
@@ -24242,14 +24325,14 @@ SLPM-65192:
   name: "NBA Live 2003"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLPM-65193:
   name: "FIFA Soccer 2003"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLPM-65196:
-  name: "Breath of Fire V: Dragon Quarter"
+  name: "Breath of Fire V - Dragon Quarter"
   region: "NTSC-J"
 SLPM-65197:
   name: "Nobunaga's Ambition Online"
@@ -24336,10 +24419,10 @@ SLPM-65210:
   name: "Chou Battle Houshin - Bundle #1"
   region: "NTSC-J"
 SLPM-65212:
-  name: "Lord of the Rings, The: The Two Towers"
+  name: "Lord of the Rings, The - The Two Towers"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes white shiny weapons.
+    vuClampMode: 3 # Fixes white shiny weapons.
 SLPM-65213:
   name: "Evolution Skateboarding"
   region: "NTSC-J"
@@ -24363,9 +24446,9 @@ SLPM-65222:
   name: "Yu-Gi-Oh! 2 [Konami The Best]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 2  # Partially fixes battle animation.
+    eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
-    eeClampMode: 2  # Partially fixes battle animation.
+    eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65223:
   name: "Triangle Again"
   region: "NTSC-J"
@@ -24395,7 +24478,7 @@ SLPM-65228:
   region: "NTSC-J"
   compat: 5
 SLPM-65229:
-  name: "Totsugeki! Army Men: Shijou Saishou no Sakusen"
+  name: "Totsugeki! Army Men - Shijou Saishou no Sakusen"
   region: "NTSC-J"
 SLPM-65230:
   name: "Tokimeki Memorial 3 [Konami The Best]"
@@ -24433,10 +24516,10 @@ SLPM-65235:
   region: "NTSC-J"
   compat: 5
 SLPM-65236:
-  name: "Anubis: Zone of the Enders"
+  name: "Anubis - Zone of the Enders"
   region: "NTSC-J"
 SLPM-65237:
-  name: "Z.O.E.: Zone of the Enders [PlayStation 2 The Best]"
+  name: "Z.O.E. - Zone of the Enders [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-65238:
   name: "Angelic Concert [Limited Edition]"
@@ -24445,15 +24528,15 @@ SLPM-65239:
   name: "Angelic Concert"
   region: "NTSC-J"
 SLPM-65241:
-  name: "Shin Megami Tensei III: Nocturne [Limited Edition]"
+  name: "Shin Megami Tensei III - Nocturne [Limited Edition]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-65242:
-  name: "Shin Megami Tensei III: Nocturne"
+  name: "Shin Megami Tensei III - Nocturne"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-65243:
   name: "Densha de Go! Professional 2"
   region: "NTSC-J"
@@ -24478,9 +24561,11 @@ SLPM-65249:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes SPS in item menu.
+    vuClampMode: 2 # Fixes SPS in item menu.
   gsHWFixes:
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes rainbow shadow of legions.
+    alignSprite: 1 # Fixes green vertical lines.
+    roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLPM-65254:
   name: "Galaxy Angel"
   region: "NTSC-J"
@@ -24495,7 +24580,9 @@ SLPM-65257:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+    vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -24662,7 +24749,7 @@ SLPM-65310:
   name: "Mark of Kri, The"
   region: "NTSC-J"
 SLPM-65311:
-  name: "Violet no Atelier: Gramnad no Renkinjutsushi"
+  name: "Violet no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
 SLPM-65313:
   name: "First Kiss Story 1&2"
@@ -24760,7 +24847,7 @@ SLPM-65341:
   name: "Silent Hill 2 - Saigo No Uta [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLPM-65342:
   name: "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File"
@@ -24806,10 +24893,10 @@ SLPM-65358:
   region: "NTSC-J"
   compat: 5
 SLPM-65359:
-  name: "Judie no Atelier: Gramnad no Renkinjutsushi [Gust Best Price]"
+  name: "Judie no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
 SLPM-65361:
-  name: "Anubis: Zone of the Enders Special Edition [Limited Edition]"
+  name: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-65362:
@@ -24845,7 +24932,7 @@ SLPM-65374:
   name: "Energy Airforce - Aim Strike!"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hanging while going ingame.
+    InstantVU1SpeedHack: 0 # Fixes hanging while going ingame.
     MTVUSpeedHack: 0
 SLPM-65375:
   name: "Shin Sangoku Musou 3 - Mushoden [Premium Pack]"
@@ -24854,7 +24941,7 @@ SLPM-65377:
   name: "Shin Sangoku Musou 3 - Mushoden"
   region: "NTSC-J"
 SLPM-65378:
-  name: "Busin 0: Wizardry Alternative Neo"
+  name: "Busin 0 - Wizardry Alternative Neo"
   region: "NTSC-J"
 SLPM-65379:
   name: "Baseball 2003 - Akikigou"
@@ -24933,7 +25020,7 @@ SLPM-65406:
   name: "Castlevania - Lament of Innocence [Limited Edition]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes cutscene freezes.
+    eeClampMode: 3 # Fixes cutscene freezes.
 SLPM-65407:
   name: "Transformers Tatakai"
   region: "NTSC-J"
@@ -24986,7 +25073,7 @@ SLPM-65419:
   name: "Tony Hawk's Pro Skater 2003"
   region: "NTSC-J"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLPM-65420:
   name: "Dabitsuku 3 - Let's Become a Derby Owner"
   region: "NTSC-J"
@@ -25032,7 +25119,7 @@ SLPM-65434:
   name: "Battle Gear 3"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Stops car from falling through track.
+    vuClampMode: 3 # Stops car from falling through track.
 SLPM-65435:
   name: "Diamond Dust"
   region: "NTSC-J"
@@ -25055,7 +25142,7 @@ SLPM-65439:
   memcardFilters:
     - "SLPM-65438"
 SLPM-65441:
-  name: "Ashita no Joe: Masshiro ni Moetsukuru"
+  name: "Ashita no Joe - Masshiro ni Moetsukuru"
   region: "NTSC-J"
 SLPM-65442:
   name: "Terminator 3, The - Rise of the Machines"
@@ -25073,7 +25160,7 @@ SLPM-65444:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes cutscene freezes.
+    eeClampMode: 3 # Fixes cutscene freezes.
 SLPM-65445:
   name: "Jikkyou Powerful Pro Yakyuu 10 Chou Ketteiban - 2003 Memorial"
   region: "NTSC-J"
@@ -25094,7 +25181,7 @@ SLPM-65449:
     textureInsideRT: 1 # Fixes rainbow effect in the pause menu before a jump.
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65450:
-  name: "Tantei Gakuen Q: Kiokan no Satsui [First Limited Edition]"
+  name: "Tantei Gakuen Q - Kiokan no Satsui [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65451:
   name: "Prince of Tennis - Smash Hit! 2 [First Limited Edition]"
@@ -25119,19 +25206,19 @@ SLPM-65460:
   name: "Conflict Delta - Wangan War 1991"
   region: "NTSC-J"
 SLPM-65461:
-  name: "Tantei Gakuen Q: Kioukan no Satsui"
+  name: "Tantei Gakuen Q - Kioukan no Satsui"
   region: "NTSC-J"
 SLPM-65462:
-  name: "Shin Megami Tensei III: Nocturne Maniax"
+  name: "Shin Megami Tensei III - Nocturne Maniax"
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-65463:
   name: "Rocky"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 0  # Fixes boxers not appearing/disappearing.
+    eeClampMode: 0 # Fixes boxers not appearing/disappearing.
   gameFixes:
     - VIF1StallHack # Fixes freezes.
 SLPM-65464:
@@ -25236,7 +25323,7 @@ SLPM-65499:
   name: "Bloody Roar 4"
   region: "NTSC-J"
 SLPM-65500:
-  name: "Anubis: Zone of the Enders Special Edition"
+  name: "Anubis - Zone of the Enders Special Edition"
   region: "NTSC-J"
 SLPM-65501:
   name: "Frogger - The Great Quest"
@@ -25351,7 +25438,7 @@ SLPM-65538:
   name: "James Bond 007 - Nightfire [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes polygon clipping in driving missions.
+    vuClampMode: 2 # Fixes polygon clipping in driving missions.
 SLPM-65539:
   name: "V-Rally 3"
   region: "NTSC-J"
@@ -25389,7 +25476,7 @@ SLPM-65551:
   name: "Astro Boy Atom"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes character behaviour.
+    eeRoundMode: 0 # Fixes character behaviour.
 SLPM-65552:
   name: "Metal Wolf Rev [Limited Edition]"
   region: "NTSC-J"
@@ -25452,6 +25539,8 @@ SLPM-65574:
   name: "Silent Hill 4 - The Room"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes dark sides.
 SLPM-65575:
   name: "Crimson Tears"
   region: "NTSC-J"
@@ -25511,7 +25600,7 @@ SLPM-65593:
   name: "beatmania IIDX 7th style"
   region: "NTSC-J"
 SLPM-65594:
-  name: "Iris no Atelier: Eternal Mana"
+  name: "Iris no Atelier - Eternal Mana"
   region: "NTSC-J"
 SLPM-65595:
   name: "Shoubushi Gambler Densetsu - Tetsuya 2 [Athena Best]"
@@ -25520,7 +25609,7 @@ SLPM-65596:
   name: "Juuni Kuniki - Kakukaku Taru Ou Michi Beni Midori no Uka"
   region: "NTSC-J"
 SLPM-65597:
-  name: "Digital Devil Saga: Avatar Tuner"
+  name: "Digital Devil Saga - Avatar Tuner"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
@@ -25602,7 +25691,9 @@ SLPM-65622:
   name: "Silent Hill 3 [Konami The Best]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+    vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -25612,13 +25703,13 @@ SLPM-65622:
     - "SLPM-65341"
     - "SLPM-65631"
 SLPM-65623:
-  name: "Tantei Gakuen Q: Kiokan no Satsui [Konami The Best]"
+  name: "Tantei Gakuen Q - Kiokan no Satsui [Konami The Best]"
   region: "NTSC-J"
 SLPM-65624:
   name: "Dear Boys Fast Break! [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65625:
-  name: "Ashita no Joe: Masshiro ni Moetsukuru [Konami The Best]"
+  name: "Ashita no Joe - Masshiro ni Moetsukuru [Konami The Best]"
   region: "NTSC-J"
 SLPM-65626:
   name: "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [Konami The Best]"
@@ -25639,7 +25730,7 @@ SLPM-65631:
   name: "Silent Hill 2 [Konami The Best]"
   region: "NTSC-J"
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLPM-65632:
   name: "Virtua Fighter Cyber Generation - Ambition of the Judgement Six"
@@ -25689,9 +25780,9 @@ SLPM-65647:
   name: "Yu-Gi-Oh! 2 (Konami Dendou Collection)"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 2  # Partially fixes battle animation.
+    eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
-    eeClampMode: 2  # Partially fixes battle animation.
+    eeClampMode: 2 # Partially fixes battle animation.
 SLPM-65648:
   name: "Medal of Honor - Frontline [EA Best Hits]"
   region: "NTSC-J"
@@ -25737,7 +25828,7 @@ SLPM-65666:
   name: "NBA Live 2004 [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLPM-65668:
   name: "Spectral Force - Radical Elements [Limited Edition]"
   region: "NTSC-J"
@@ -25781,7 +25872,7 @@ SLPM-65682:
   name: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
-  name: "Violet no Atelier: Gramnad no Renkinjutsushi [Gust Best Price]"
+  name: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
 SLPM-65684:
   name: "Meine Liebe - Yuubinaru Kioku"
@@ -25904,7 +25995,7 @@ SLPM-65719:
   name: "Burnout 3 - Takedown"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65720:
@@ -25933,7 +26024,7 @@ SLPM-65726:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLPM-65727:
   name: "Lord of the Rings, The - The Return of the King [EA Best Hits]"
   region: "NTSC-J"
@@ -26147,7 +26238,7 @@ SLPM-65794:
   region: "NTSC-J"
   compat: 5
 SLPM-65795:
-  name: "Digital Devil Saga: Avatar Tuner 2"
+  name: "Digital Devil Saga - Avatar Tuner 2"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
@@ -26178,7 +26269,7 @@ SLPM-65798:
   name: "Madden NFL Superbowl 2005"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLPM-65799:
   name: "New Jinsei Game"
   region: "NTSC-J"
@@ -26331,7 +26422,7 @@ SLPM-65844:
   name: "Air [Best]"
   region: "NTSC-J"
 SLPM-65845:
-  name: "Baldur's Gate: Dark Alliance II"
+  name: "Baldur's Gate - Dark Alliance II"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -26421,7 +26512,7 @@ SLPM-65875:
   name: "Growlanser IV - Wayfarer of the Time [Atlus The Best]"
   region: "NTSC-J"
 SLPM-65876:
-  name: "Busin 0: Wizardry Alternative Neo [Atlus Best Collection]"
+  name: "Busin 0 - Wizardry Alternative Neo [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-65878:
   name: "Galaxy Angel - Eternal Lovers"
@@ -26502,7 +26593,7 @@ SLPM-65901:
   name: "Shark Tale"
   region: "NTSC-J"
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLPM-65902:
   name: "Memories Off - After Rain Vol.2 Souen [Special Edition]"
   region: "NTSC-J"
@@ -26525,7 +26616,7 @@ SLPM-65909:
   name: "Super Monkey Ball Deluxe"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 1  # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+    eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLPM-65910:
   name: "Cafe Lindbergh - Summer Season [Sweet Box]"
   region: "NTSC-J"
@@ -26652,8 +26743,8 @@ SLPM-65948:
   name: "Enthusia Professional Racing"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3 # Fixes Freezing at the start of the race
-    vuClampMode: 3 # Fixes Freezing at the start of the race
+    eeClampMode: 3 # Fixes Freezing at the start of the race.
+    vuClampMode: 3 # Fixes Freezing at the start of the race.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-65949:
@@ -26685,7 +26776,7 @@ SLPM-65958:
   name: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-65959:
@@ -26731,7 +26822,7 @@ SLPM-65972:
   name: "Constantine"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 2  # Resolves dumpster not being able to be climbed from front in level 2.
+    eeRoundMode: 2 # Resolves dumpster not being able to be climbed from front in level 2.
 SLPM-65973:
   name: "Mirai Shounen Conan"
   region: "NTSC-J"
@@ -26772,7 +26863,7 @@ SLPM-65984:
   gsHWFixes:
     autoFlush: 1
 SLPM-65985:
-  name: "Iris no Atelier: Eternal Mana 2"
+  name: "Iris no Atelier - Eternal Mana 2"
   region: "NTSC-J"
 SLPM-65986:
   name: "Quartett! The Stage of Love [Limited Edition]"
@@ -26794,7 +26885,7 @@ SLPM-65990:
   clampModes:
     eeClampMode: 2
 SLPM-65991:
-  name: "Anubis: Zone of the Enders Special Edition [Konami Dendou Collection]"
+  name: "Anubis - Zone of the Enders Special Edition [Konami Dendou Collection]"
   region: "NTSC-J"
 SLPM-65994:
   name: "Remember 11 - The Age of Infinity [Superlite 2000 Series]"
@@ -26803,7 +26894,7 @@ SLPM-65995:
   name: "Dog's Life"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
     preloadFrameData: 1
 SLPM-65996:
@@ -26820,7 +26911,7 @@ SLPM-65999:
   name: "Drag-on Dragoon 2 - Fuuin no Kurenai"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+    eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
 SLPM-66000:
   name: "Conflict Delta II - Gulf War 1991"
   region: "NTSC-J"
@@ -26878,7 +26969,9 @@ SLPM-66018:
   name: "Silent Hill 3 [Konami Dendou Collection]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+    vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -26893,6 +26986,8 @@ SLPM-66019:
 SLPM-66020:
   name: "Psi-Ops - The Mindgate Conspiracy"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 2 # Removes blurriness and artifacting at sides, esspecialy helps 3D11.
 SLPM-66021:
   name: "NBA Street V3"
   region: "NTSC-J"
@@ -26933,6 +27028,8 @@ SLPM-66031:
 SLPM-66032:
   name: "Silent Hill 4 [Konami The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes dark sides.
 SLPM-66033:
   name: "Oz"
   region: "NTSC-J"
@@ -26955,8 +27052,10 @@ SLPM-66041:
   name: "Shoujo Yoshitsune Den [WellMADE The Best]"
   region: "NTSC-J"
 SLPM-66042:
-  name: "Brothers in Arms: Road to Hill 30"
+  name: "Brothers In Arms - Road to Hill 30"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLPM-66043:
   name: "Racing Game - Chuui!"
   region: "NTSC-J"
@@ -27056,7 +27155,7 @@ SLPM-66074:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Prevents only backgrounds from appearing in Sonic R's multiplayer modes.
+    vuRoundMode: 0 # Prevents only backgrounds from appearing in Sonic R's multiplayer modes.
   memcardFilters:
     - "SLPM-66074"
     - "SLPM-65758"
@@ -27084,7 +27183,7 @@ SLPM-66080:
   name: "Generation of Chaos 3 [IF Collection]"
   region: "NTSC-J"
 SLPM-66081:
-  name: "Iris no Atelier: Eternal Mana [Gust Best Price]"
+  name: "Iris no Atelier - Eternal Mana [Gust Best Price]"
   region: "NTSC-J"
 SLPM-66082:
   name: "Fire Pro Wrestling Returns"
@@ -27112,7 +27211,7 @@ SLPM-66089:
   name: "3-Nen B-Gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate! [Best]"
   region: "NTSC-J"
 SLPM-66090:
-  name: "Crash Bandicoot: Gacchanko World"
+  name: "Crash Bandicoot - Gacchanko World"
   region: "NTSC-J"
 SLPM-66091:
   name: "Shinobido Imashime"
@@ -27169,7 +27268,7 @@ SLPM-66108:
   name: "Burnout Revenge"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
@@ -27221,7 +27320,7 @@ SLPM-66124:
   name: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66125:
@@ -27269,7 +27368,7 @@ SLPM-66139:
   gsHWFixes:
     pointListPalette: 1
 SLPM-66140:
-  name: "Atelier Marie + Elie: Salburg no Renkinjutsushi 1&2"
+  name: "Atelier Marie + Elie - Salburg no Renkinjutsushi 1&2"
   region: "NTSC-J"
 SLPM-66141:
   name: "Matantei Loki Ragnarok Mayoukaku"
@@ -27314,7 +27413,7 @@ SLPM-66151:
   name: "Killzone"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66152:
@@ -27390,7 +27489,7 @@ SLPM-66175:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes SPS with microVU.
+    vuClampMode: 0 # Fixes SPS with microVU.
   memcardFilters:
     - "SLPM-66175"
     - "SLPM-66668"
@@ -27492,7 +27591,7 @@ SLPM-66204:
   name: "Madden NFL '06"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLPM-66205:
   name: "Front Mission 5 - Scars of the War"
   region: "NTSC-J"
@@ -27707,7 +27806,7 @@ SLPM-66263:
   name: "Full Spectrum Warrior"
   region: "NTSC-J"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLPM-66264:
   name: "Canvas 2 - Niji-iro no Sketch [Deluxe Pack]"
   region: "NTSC-J"
@@ -27896,7 +27995,7 @@ SLPM-66316:
   name: "Pro Soccer Club o Tsukurou! Europe Championship"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Makes the game to correctly register left and right Dpad button input.
+    eeClampMode: 3 # Makes the game to correctly register left and right Dpad button input.
   memcardFilters: # Enables import of players from completed career saves.
     - "SLPM-66316"
     - "SLPM-66324"
@@ -27934,7 +28033,7 @@ SLPM-66325:
   name: "Castlevania - Lament of Innocence [Konami Palace Selection]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes cutscene freezes.
+    eeClampMode: 3 # Fixes cutscene freezes.
 SLPM-66327:
   name: "Wallace and Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-J"
@@ -28017,9 +28116,10 @@ SLPM-66354:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
   patches:
     B3A9F9ED:
       content: |-
@@ -28036,7 +28136,7 @@ SLPM-66358:
   name: "Shinobido Takumi"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3 # Fixes crash after main menu. 
+    eeClampMode: 3 # Fixes crash after main menu.
 SLPM-66359:
   name: "Mutsu-boshi Kirari - Hoshifuru Miyako"
   region: "NTSC-J"
@@ -28047,7 +28147,7 @@ SLPM-66361:
   name: "Konohana 4 - Yami wo Harau Inori [Superlite 2000]"
   region: "NTSC-J"
 SLPM-66363:
-  name: "Dragon Quest: Shoenen Yangus to Fushigi no Dungeon"
+  name: "Dragon Quest - Shoenen Yangus to Fushigi no Dungeon"
   region: "NTSC-J"
 SLPM-66364:
   name: "Pro Yakyuu Spirits 3"
@@ -28056,12 +28156,12 @@ SLPM-66371:
   name: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
   region: "NTSC-J"
 SLPM-66372:
-  name: "Digital Devil Saga: Avatar Tuner [Atlus Best Collection]"
+  name: "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
 SLPM-66373:
-  name: "Digital Devil Saga: Avatar Tuner 2 [Atlus Best Collection]"
+  name: "Digital Devil Saga - Avatar Tuner 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
@@ -28201,7 +28301,7 @@ SLPM-66409:
   region: "NTSC-J"
   compat: 5
 SLPM-66410:
-  name: "Brothers In Arms: Meiyo no Daishou"
+  name: "Brothers In Arms - Meiyo no Daishou"
   region: "NTSC-J"
 SLPM-66412:
   name: "Pizzicato Polka - Suisei Genya [2800 Collection]"
@@ -28258,7 +28358,7 @@ SLPM-66427:
   name: "Full Spectrum Warrior - Ten Hammers"
   region: "NTSC-J"
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLPM-66429:
   name: "Special Forces - Fire for Effect"
   region: "NTSC-J"
@@ -28283,7 +28383,7 @@ SLPM-66435:
   name: "Festa!! Hyper Girls Party"
   region: "NTSC-J"
 SLPM-66436:
-  name: "Iris no Atelier: Grand Fantasm"
+  name: "Iris no Atelier - Grand Fantasm"
   region: "NTSC-J"
   compat: 5
 SLPM-66437:
@@ -28442,7 +28542,7 @@ SLPM-66473:
   name: "True Crime - New York City"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes SPS on highway.
+    eeClampMode: 2 # Fixes SPS on highway.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting.
 SLPM-66474:
@@ -28591,7 +28691,7 @@ SLPM-66510:
   name: "NHL '06"
   region: "NTSC-J"
 SLPM-66511:
-  name: "Kyuuryuu Youma Gakuenki Re:charge"
+  name: "Kyuuryuu Youma Gakuenki Re-charge"
   region: "NTSC-J"
   compat: 5
 SLPM-66512:
@@ -28665,10 +28765,10 @@ SLPM-66535:
   name: "Ryu Koku"
   region: "NTSC-J"
 SLPM-66536:
-  name: "Aria: The Natural ~Tooi Yume no Mirage~"
+  name: "Aria - The Natural ~Tooi Yume no Mirage~"
   region: "NTSC-J"
 SLPM-66537:
-  name: "Iris no Atelier: Eternal Mana 2 [Gust Best Price]"
+  name: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
 SLPM-66538:
   name: "GI Jockey 4 2006"
@@ -28696,7 +28796,8 @@ SLPM-66550:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
 SLPM-66551:
   name: "Appleseed EX"
   region: "NTSC-J"
@@ -28767,8 +28868,10 @@ SLPM-66567:
   name: "Driver - Parallel Lines"
   region: "NTSC-J"
 SLPM-66568:
-  name: "Brothers in Arms: Road to Hill 30 [Ubisoft Best]"
+  name: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLPM-66569:
   name: "Secret of Evangelion"
   region: "NTSC-J"
@@ -28874,7 +28977,7 @@ SLPM-66600:
   name: "Madden NFL '07"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLPM-66601:
   name: "SSX On Tour [EA Best Hits]"
   region: "NTSC-J"
@@ -28935,7 +29038,7 @@ SLPM-66617:
   name: "Need for Speed - Carbon"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66618:
@@ -28969,9 +29072,13 @@ SLPM-66627:
   name: "WWE SmackDown! vs. RAW 2007"
   region: "NTSC-J"
 SLPM-66628:
-  name: "OutRun2 SP [First Print Limited Edition]"
+  name: "OutRun 2 SP [First Print Limited Edition]"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
+    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66629:
   name: "Dirge of Cerberus - Final Fantasy VII International"
   region: "NTSC-J"
@@ -29017,8 +29124,12 @@ SLPM-66642:
   name: "Prince of Tennis, The - Card Hunter [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66643:
-  name: "OutRun2 SP"
+  name: "OutRun 2 SP"
   region: "NTSC-J"
+  gsHWFixes:
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
+    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLPM-66644:
   name: "J-League Pro Soccer Club o Tsukurou 5"
   region: "NTSC-J"
@@ -29041,7 +29152,7 @@ SLPM-66652:
   name: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters:
@@ -29103,7 +29214,7 @@ SLPM-66668:
   name: "Akumajo Dracula - Yami no Juin [Konami the Best]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes SPS with microVU.
+    vuClampMode: 0 # Fixes SPS with microVU.
   memcardFilters:
     - "SLPM-66175"
     - "SLPM-66668"
@@ -29134,7 +29245,7 @@ SLPM-66674:
   name: "Tiger Woods PGA Tour 07"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes black textures on characters.
+    vuClampMode: 2 # Fixes black textures on characters.
 SLPM-66675:
   name: "Kingdom Hearts II - Final Mix +"
   region: "NTSC-J"
@@ -29145,7 +29256,7 @@ SLPM-66675:
     - "SLPM-66675"
     - "SLPM-66676"
 SLPM-66676:
-  name: "Kingdom Hearts Re: Chain of Memories"
+  name: "Kingdom Hearts Re-Chain of Memories"
   region: "NTSC-J"
   compat: 5
   memcardFilters:
@@ -29155,7 +29266,7 @@ SLPM-66677:
   name: "Final Fantasy X - International [Ultimate Hits]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-66678:
@@ -29166,7 +29277,7 @@ SLPM-66678:
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
 SLPM-66679:
-  name: "Devil Summoner: Kuzunoha Raidou tai Abaddon Ou [Plus]"
+  name: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou [Plus]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66679"
@@ -29178,9 +29289,9 @@ SLPM-66681:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-66683:
-  name: "Devil Summoner: Kuzunoha Raidou tai Abaddon Ou"
+  name: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66679"
@@ -29270,8 +29381,10 @@ SLPM-66705:
   region: "NTSC-J"
   compat: 5
 SLPM-66708:
-  name: "Brothers In Arms: Earned In Blood [Ubisoft Best]"
+  name: "Brothers In Arms - Earned In Blood [Ubisoft Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66709:
   name: "Angel Profile"
   region: "NTSC-J"
@@ -29341,9 +29454,10 @@ SLPM-66731:
   name: "Black [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
 SLPM-66732:
   name: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
@@ -29383,7 +29497,7 @@ SLPM-66739:
   name: "Burnout Dominator"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-66740:
@@ -29418,7 +29532,7 @@ SLPM-66748:
   name: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes jump issue.
+    eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - DMABusyHack
     - SoftwareRendererFMVHack # Vertical lines in FMV.
@@ -29602,7 +29716,7 @@ SLPM-66807:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLPM-66808:
   name: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
   region: "NTSC-J"
@@ -29622,7 +29736,7 @@ SLPM-66813:
   name: "Sangokushi IX [Koei Selection]"
   region: "NTSC-J"
 SLPM-66814:
-  name: "Pure x Cure Re:covery"
+  name: "Pure x Cure Re-covery"
   region: "NTSC-J"
 SLPM-66815:
   name: "Baldr Bullet - Equilibrium"
@@ -29682,7 +29796,7 @@ SLPM-66837:
   name: "Madden NFL '08"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLPM-66838:
   name: "Fantastic Fortune 2 - Triple Star [Best Hit Selection]"
   region: "NTSC-J"
@@ -29717,7 +29831,7 @@ SLPM-66848:
   name: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
-  name: "Iris no Atelier: Grand Fantasm [Gust Best Price]"
+  name: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
   region: "NTSC-J"
 SLPM-66850:
   name: "Arcana Heart"
@@ -29780,7 +29894,7 @@ SLPM-66869:
   name: "Need for Speed - Carbon [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66870:
@@ -30055,14 +30169,15 @@ SLPM-66961:
   name: "Black [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
 SLPM-66962:
   name: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLPM-66963:
@@ -30079,7 +30194,7 @@ SLPM-66966:
   name: "Godfather, The [EA-SY! 1980]"
   region: "NTSC-J"
 SLPM-66967:
-  name: "Aria: The Natural ~Tooi Yume no Mirage~ [Alchemist Best Collection]"
+  name: "Aria - The Natural ~Tooi Yume no Mirage~ [Alchemist Best Collection]"
   region: "NTSC-J"
 SLPM-66968:
   name: "Kamiwaza [Acquire the Best]"
@@ -30136,7 +30251,7 @@ SLPM-66994:
   name: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes jump issue.
+    eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - DMABusyHack
     - SoftwareRendererFMVHack # Vertical lines in FMV.
@@ -30173,10 +30288,10 @@ SLPM-67004:
   name: "Medal of Honor - Rising Sun"
   region: "NTSC-J"
 SLPM-67005:
-  name: "Lord of the Rings, The: The Two Towers (EA Best Hits)"
+  name: "Lord of the Rings, The - The Two Towers (EA Best Hits)"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67006:
   name: "Train Simulator - Kyushu Shinkansen"
   region: "NTSC-J"
@@ -30216,7 +30331,6 @@ SLPM-67013:
   name: "God of War II - The End Begins"
   region: "NTSC-J"
   gsHWFixes:
-    alignSprite: 1 # Fixes water vertical lines.
     halfPixelOffset: 2 # Fixes misaligned bloom.
     roundSprite: 1 # Fixes chromatic effect.
 SLPM-67015:
@@ -30246,7 +30360,7 @@ SLPM-67513:
   name: "Final Fantasy X International"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPM-67514:
@@ -30259,12 +30373,12 @@ SLPM-67519:
   name: "Rayman 2 Revolution"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 0  # Fixes game hanging in the "Clark running away" ingame cutscene.
+    eeRoundMode: 0 # Fixes game hanging in the "Clark running away" ingame cutscene.
 SLPM-67524:
   name: "Armored Core 3"
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
 SLPM-67528:
   name: "Hajime no Ippo - Victorious Boxers [Championship Edition]"
   region: "NTSC-K"
@@ -30301,7 +30415,7 @@ SLPM-67546:
   name: "Lord of the Rings - The Two Towers"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLPM-67552:
   name: "Tomak - Save the Earth Again [Complete Edition]"
   region: "NTSC-K"
@@ -30354,7 +30468,7 @@ SLPM-74006:
   name: "Rez [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74007:
-  name: "Busin: Wizardry Alternative [PlayStation 2 The Best]"
+  name: "Busin - Wizardry Alternative [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74044:
   name: "Space Channel 5 - Part 2 [PlayStation 2 The Best]"
@@ -30384,10 +30498,10 @@ SLPM-74204:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPM-74205:
-  name: "Shin Megami Tensei III: Nocturne [PlayStation 2 The Best]"
+  name: "Shin Megami Tensei III - Nocturne [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLPM-74206:
   name: "Onimusha [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -30483,7 +30597,8 @@ SLPM-74241:
   name: "God Hand [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
 SLPM-74242:
   name: "Devil May Cry 3 [Special Edition] [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -30495,7 +30610,7 @@ SLPM-74243:
   name: "True Crime - New York City [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes SPS on highway.
+    eeClampMode: 2 # Fixes SPS on highway.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting.
 SLPM-74244:
@@ -30559,7 +30674,7 @@ SLPM-74261:
   gameFixes:
     - DMABusyHack
 SLPM-74265:
-  name: "Nobunaga no Yabou: Kakushin [PlayStation 2 The Best]"
+  name: "Nobunaga no Yabou - Kakushin [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74276:
   name: "Sangoku Musou 2 [PlayStation 2 The Best]"
@@ -30610,7 +30725,7 @@ SLPM-74409:
   name: "Gun Survivor 2 - Biohazard Code - Veronica [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74410:
-  name: "Breath of Fire V: Dragon Quarter [PlayStation 2 The Best]"
+  name: "Breath of Fire V - Dragon Quarter [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74411:
   name: "Culdcept II - Expansion [PlayStation 2 The Best]"
@@ -30803,7 +30918,7 @@ SLPS-20055:
   region: "NTSC-J"
   compat: 5
 SLPS-20056:
-  name: "Colorio: Hagaki Print"
+  name: "Colorio - Hagaki Print"
   region: "NTSC-J"
 SLPS-20057:
   name: "Dog of Bay"
@@ -30832,7 +30947,7 @@ SLPS-20065:
   name: "Madden NFL 2001"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLPS-20066:
   name: "Rhapsody 3 - Tenshi no Present - The Marl Kingdom Stories"
   region: "NTSC-J"
@@ -30897,6 +31012,8 @@ SLPS-20094:
 SLPS-20095:
   name: "Knockout Kings 2001"
   region: "NTSC-J"
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes missing arena, fighters and other missing graphics.
 SLPS-20097:
   name: "Magical Sports - Koshien"
   region: "NTSC-J"
@@ -31054,7 +31171,7 @@ SLPS-20202:
   name: "Coloball 2002"
   region: "NTSC-J"
 SLPS-20207:
-  name: "Usagi: Yasei no Topai"
+  name: "Usagi - Yasei no Topai"
   region: "NTSC-J"
 SLPS-20208:
   name: "I am Small!"
@@ -31153,10 +31270,10 @@ SLPS-20280:
   name: "Mahou no Pumpkin"
   region: "NTSC-J"
 SLPS-20281:
-  name: "Monopoly: Mezase!! Daifugou Jinsei!!"
+  name: "Monopoly - Mezase!! Daifugou Jinsei!!"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes missing game board.
+    vuClampMode: 0 # Fixes missing game board.
 SLPS-20282:
   name: "Taiko no Tatsujin"
   region: "NTSC-J"
@@ -31224,7 +31341,7 @@ SLPS-20321:
   region: "NTSC-J"
   compat: 5
 SLPS-20322:
-  name: "Netsu Chu! Pro Yakyuu 2003: Aki no Night Matsuri"
+  name: "Netsu Chu! Pro Yakyuu 2003 - Aki no Night Matsuri"
   region: "NTSC-J"
   patches:
     D3DAF7F4:
@@ -31377,7 +31494,7 @@ SLPS-20383:
   name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
   region: "NTSC-J"
 SLPS-20384:
-  name: "Hayarigami: Keishichou Kaii Jiken File"
+  name: "Hayarigami - Keishichou Kaii Jiken File"
   region: "NTSC-J"
 SLPS-20386:
   name: "Value 2000 Series - Igo 4"
@@ -31716,7 +31833,7 @@ SLPS-25001:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes FPU errors causing instant death in Limestone Cave.
+    eeRoundMode: 0 # Fixes FPU errors causing instant death in Limestone Cave.
 SLPS-25002:
   name: "Dead or Alive 2"
   region: "NTSC-J"
@@ -31745,7 +31862,7 @@ SLPS-25003:
   name: "Evergrace"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes hanging before going in-game.
+    eeClampMode: 3 # Fixes hanging before going in-game.
 SLPS-25004:
   name: "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!"
   region: "NTSC-J"
@@ -31761,7 +31878,7 @@ SLPS-25007:
   name: "Armored Core 2"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
 SLPS-25008:
   name: "Sorcerous Stabber Orphen"
   region: "NTSC-J"
@@ -31781,6 +31898,8 @@ SLPS-25012:
 SLPS-25013:
   name: "Kurikuri Mix"
   region: "NTSC-J"
+  speedHacks:
+    MTVUSpeedHack: 0 # Prevents broken textures and graphics.
 SLPS-25014:
   name: "Choro Q - High Grade [Limited Edition]"
   region: "NTSC-J"
@@ -31843,7 +31962,7 @@ SLPS-25029:
   name: "Rayman 2 Revolution"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes game hanging in the "Clark running away" ingame cutscene.
+    eeRoundMode: 0 # Fixes game hanging in the "Clark running away" ingame cutscene.
 SLPS-25030:
   name: "Lunatic Dawn - Tempest"
   region: "NTSC-J"
@@ -31855,10 +31974,10 @@ SLPS-25033:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Objects appear in wrong places without it.
-    vuClampMode: 2  # Fixes water reflection.
+    eeClampMode: 3 # Objects appear in wrong places without it.
+    vuClampMode: 2 # Fixes water reflection.
   gameFixes:
-    - EETimingHack # Fixes flickering graphics. 
+    - EETimingHack # Fixes flickering graphics.
 SLPS-25034:
   name: "Flower, Sun and Rain"
   region: "NTSC-J"
@@ -31866,7 +31985,7 @@ SLPS-25035:
   name: "Monster Farm 3"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes SPS in game 
+    vuClampMode: 3 # Fixes SPS in game.
 SLPS-25036:
   name: "Gallop Racer 5"
   region: "NTSC-J"
@@ -31884,7 +32003,7 @@ SLPS-25040:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
   memcardFilters:
     - "SCPS-55024"
     - "SLPS-25007"
@@ -31895,7 +32014,7 @@ SLPS-25041:
   name: "Shadow Hearts"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes invisible characters in various scenes.
+    eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLPS-25042:
   name: "Maken Shao [Limited Edition]"
   region: "NTSC-J"
@@ -31910,7 +32029,7 @@ SLPS-25044:
   name: "Evergrace 2"
   region: "NTSC-J"
 SLPS-25045:
-  name: "Lilie no Atelier: Salburg no Renkinjutsushi 3"
+  name: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
   region: "NTSC-J"
 SLPS-25046:
   name: "Golf Navigator Vol.1"
@@ -31926,7 +32045,7 @@ SLPS-25050:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPS-25051:
@@ -32028,7 +32147,7 @@ SLPS-25079:
   name: "Madden NFL 2002"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLPS-25080:
   name: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]"
   region: "NTSC-J"
@@ -32048,7 +32167,7 @@ SLPS-25088:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPS-25094:
@@ -32070,7 +32189,7 @@ SLPS-25099:
   name: "World Rally Championship"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes crash when using the Subaru.
+    eeRoundMode: 0 # Fixes crash when using the Subaru.
 SLPS-25100:
   name: "Tekken 4"
   region: "NTSC-J"
@@ -32109,7 +32228,7 @@ SLPS-25112:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
 SLPS-25113:
   name: "Zettai Zetsumei Toshi"
   region: "NTSC-J"
@@ -32185,7 +32304,7 @@ SLPS-25138:
   name: "Ever 17 - The Out of Infinity"
   region: "NTSC-J"
 SLPS-25139:
-  name: "Baldur's Gate: Dark Alliance"
+  name: "Baldur's Gate - Dark Alliance"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -32292,7 +32411,7 @@ SLPS-25169:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20011"
     - "SCPS-55014"
@@ -32323,7 +32442,7 @@ SLPS-25179:
   name: "FIFA 2003"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
   gsHWFixes:
     mipmap: 1
 SLPS-25181:
@@ -32472,7 +32591,7 @@ SLPS-25230:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Respawn issues, Fixes SPS.
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25231:
@@ -32518,7 +32637,7 @@ SLPS-25244:
   name: "Max Payne"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes crashes.
+    eeClampMode: 3 # Fixes crashes.
 SLPS-25245:
   name: "True Love Story - Summer Days and Yet"
   region: "NTSC-J"
@@ -32543,7 +32662,7 @@ SLPS-25251:
   name: "MVP Baseball 2003"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fixes missing environment.
+    vuClampMode: 3 # Fixes missing environment.
 SLPS-25252:
   name: "Star wars - Jango Fett"
   region: "NTSC-J"
@@ -32552,7 +32671,7 @@ SLPS-25252:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLPS-25254:
   name: "Enter the Matrix"
   region: "NTSC-J"
@@ -32639,7 +32758,7 @@ SLPS-25290:
   name: "Time Crisis 3"
   region: "NTSC-J"
 SLPS-25291:
-  name: "Baldur's Gate: Dark Alliance [PCCW The Best]"
+  name: "Baldur's Gate - Dark Alliance [PCCW The Best]"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -32752,7 +32871,10 @@ SLPS-25329:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes Sugoroku mini-game.
+    eeRoundMode: 0 # Fixes Sugoroku mini-game.
+  speedHacks:
+    InstantVU1SpeedHack: 1 # This option enabled brings about 15% more FPS when I tested it, *your experience may differ.
+    MTVUSpeedHack: 0 # For some reason this games halves the internal game FPS with this option.
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
@@ -32838,7 +32960,7 @@ SLPS-25351:
   name: "Burnout 2 - Point of Impact"
   region: "NTSC-J"
   roundModes:
-    vuRoundMode: 1  # Bright lights in cars.
+    vuRoundMode: 1 # Bright lights in cars.
 SLPS-25352:
   name: "Espgaluda"
   region: "NTSC-J"
@@ -33033,7 +33155,7 @@ SLPS-25398:
   name: "Naruto - Narutimett Hero 2"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes glow effects.
+    vuClampMode: 0 # Fixes glow effects.
 SLPS-25399:
   name: "Keroro Gunsou - Mero Mero Battle Royale"
   region: "NTSC-J"
@@ -33141,7 +33263,7 @@ SLPS-25425:
   name: "SD Gundam Force Daikessen!"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Needed for SPS on some characters.
+    eeClampMode: 2 # Needed for SPS on some characters.
 SLPS-25426:
   name: "Detective Conan - Inheritance of Britain"
   region: "NTSC-J"
@@ -33437,7 +33559,7 @@ SLPS-25510:
   region: "NTSC-J"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SLPS-25511:
@@ -33628,7 +33750,7 @@ SLPS-25569:
   name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 1  # Fixes camera issue.
+    eeRoundMode: 1 # Fixes camera issue.
   gameFixes:
     - FpuNegDivHack # Fixes target loss issue.
 SLPS-25570:
@@ -33659,6 +33781,8 @@ SLPS-25577:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25578:
@@ -33706,7 +33830,7 @@ SLPS-25589:
   name: "Naruto Narutimett Hero 3"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes invisible QTE button prompts and overbright in some scenes.
+    vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
 SLPS-25590:
   name: "Namco Museum Arcade Hits"
   region: "NTSC-J"
@@ -33746,7 +33870,7 @@ SLPS-25603:
   name: "Tensei - Swords of Destiny [Best Collection]"
   region: "NTSC-J"
 SLPS-25604:
-  name: "Ar tonelico: Sekai no Owari de Utai Tsuzukeru Shoujo"
+  name: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
@@ -33873,7 +33997,7 @@ SLPS-25635:
   name: "King of Fighters 2003, The [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25636:
-  name: "King of Fighters, The: Maximum Impact - Maniax"
+  name: "King of Fighters, The - Maximum Impact - Maniax"
   region: "NTSC-J"
 SLPS-25638:
   name: "King of Fighters, The - Maximum Impact 2"
@@ -34182,7 +34306,7 @@ SLPS-25710:
   region: "NTSC-J"
   compat: 4
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes random black frames from happening when in a fight session.
+    InstantVU1SpeedHack: 0 # Fixes random black frames from happening when in a fight session.
     MTVUSpeedHack: 0
   gameFixes:
     - XGKickHack # Fixes grey fighters problem.
@@ -34223,7 +34347,7 @@ SLPS-25718:
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fix camera issue.
+    eeRoundMode: 1 # Fix camera issue.
   gameFixes:
     - FpuNegDivHack # Fix target loss issue.
 SLPS-25719:
@@ -34558,11 +34682,11 @@ SLPS-25818:
   name: "Bakumatsu Renka - Karyuu Kenshiden"
   region: "NTSC-J"
 SLPS-25819:
-  name: "Ar tonelico II: Sekai ni Hibiku Shoujo-Tachi no Souzoushi"
+  name: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Souzoushi"
   region: "NTSC-J"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes "Fall through floor" bug when approaching chests.
+    eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-25820:
@@ -34622,13 +34746,13 @@ SLPS-25838:
   name: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
   region: "NTSC-J"
 SLPS-25839:
-  name: "Samurai Spirits: Rokuban Shoubu [NeoGeo Online Collection Vol. 12]"
+  name: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection Vol. 12]"
   region: "NTSC-J"
 SLPS-25840:
   name: "Guitar Hero III - Legends of Rock [with Guitar]"
   region: "NTSC-J"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLPS-25841:
   name: "Tales of Destiny [Director's Cut] [Premium Box]"
   region: "NTSC-J"
@@ -34683,7 +34807,7 @@ SLPS-25854:
   name: "Poison Pink"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 0  # In-game background visible.
+    eeClampMode: 0 # In-game background visible.
 SLPS-25855:
   name: "Battle of Sunrise"
   region: "NTSC-J"
@@ -34732,7 +34856,7 @@ SLPS-25879:
   name: "Bully"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
+    eeClampMode: 3 # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
   gsHWFixes:
     wildArmsHack: 1 # Reduces depth ghosting.
     roundSprite: 2 # Reduces depth ghosting.
@@ -34758,12 +34882,12 @@ SLPS-25889:
   name: "Guitar Hero - Aerosmith"
   region: "NTSC-J"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLPS-25890:
   name: "Guitar Hero III - Legends of Rock [with Guitar]"
   region: "NTSC-J"
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLPS-25892:
   name: "Nogizaka Haruka no Himitsu - Cosplay Hajimemashita"
   region: "NTSC-J"
@@ -34777,14 +34901,14 @@ SLPS-25898:
   name: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony"
   region: "NTSC-J"
 SLPS-25905:
-  name: "Dragon Ball Z: Infinite World"
+  name: "Dragon Ball Z - Infinite World"
   region: "NTSC-J"
 SLPS-25906:
   name: "ADK Tamashii"
   region: "NTSC-J"
   compat: 5
 SLPS-25914:
-  name: "Kidou Senshi Gundam: Giren no Yabou - Axis no Kyoui V"
+  name: "Kidou Senshi Gundam - Giren no Yabou - Axis no Kyoui V"
   region: "NTSC-J"
   gameFixes:
     - FpuNegDivHack
@@ -34819,7 +34943,7 @@ SLPS-25932:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPS-25934:
-  name: "Samurai Spirits: Rokuban Shoubu [NeoGeo Online Collection the Best]"
+  name: "Samurai Spirits - Rokuban Shoubu [NeoGeo Online Collection the Best]"
   region: "NTSC-J"
 SLPS-25935:
   name: "The King of Fighters '98 Ultimate Match (NeoGeo Online Collection the Best)"
@@ -34829,7 +34953,7 @@ SLPS-25944:
   region: "NTSC-J"
   compat: 5
 SLPS-25947:
-  name: "Summon Night Gran-These: Horobi no Ken to Yakusoku no Kishi"
+  name: "Summon Night Gran-These - Horobi no Ken to Yakusoku no Kishi"
   region: "NTSC-J"
 SLPS-25948:
   name: "Zero no Tsukaima - Maigo no Period to Ikusen no Symphony [Best Collection]"
@@ -34838,7 +34962,7 @@ SLPS-25950:
   name: "Bully [Best of Bethesda]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
+    eeClampMode: 3 # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
   gsHWFixes:
     wildArmsHack: 1 # Reduces depth ghosting.
     roundSprite: 2 # Reduces depth ghosting.
@@ -34846,15 +34970,15 @@ SLPS-25956:
   name: "Moe Moe 2-ji Taisen Ryoku 2"
   region: "NTSC-J"
 SLPS-25959:
-  name: "Kidou Senshi Gundam: Giren no Yabou - Axis no Kyoui V"
+  name: "Kidou Senshi Gundam - Giren no Yabou - Axis no Kyoui V"
   region: "NTSC-J"
   gameFixes:
     - FpuNegDivHack
 SLPS-25961:
-  name: "Kidou Senshi Gundam SEED: Rengou vs. Z.A.F.T."
+  name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes camera issue.
+    eeRoundMode: 1 # Fixes camera issue.
   gameFixes:
     - FpuNegDivHack # Fixes target loss issue.
 SLPS-25983:
@@ -34922,13 +35046,13 @@ SLPS-29003:
   name: "Lord of the Rings - The Two Towers [Collector's Box]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29004:
   name: "Lord of the Rings, The - The Two Towers"
   region: "NTSC-J"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLPS-29005:
   name: "Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]"
   region: "NTSC-J"
@@ -34938,7 +35062,7 @@ SLPS-72501:
   name: "Final Fantasy X [Mega Hits]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 1  # Fixes reverse control and boss in some places.
+    eeRoundMode: 1 # Fixes reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLPS-72502:
@@ -35080,7 +35204,7 @@ SLPS-73221:
   name: "Naruto Narutimett Hero 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0  # Fixes glow effects.
+    vuClampMode: 0 # Fixes glow effects.
 SLPS-73222:
   name: "Harvest Moon - A Wonderful Life [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -35088,7 +35212,7 @@ SLPS-73223:
   name: "Tekken 5 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SLPS-73224:
@@ -35265,7 +35389,7 @@ SLPS-73248:
   name: "Kagero 2 - Dark Illusion [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73249:
-  name: "Ar tonelico: Sekai no Owari de Utai Tsuzukeru Shoujo [PlayStation 2 The Best]"
+  name: "Ar tonelico - Sekai no Owari de Utai Tsuzukeru Shoujo [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 1 # Fixes vertical lines in FMVs, character portraits and other sprites.
@@ -35291,7 +35415,7 @@ SLPS-73251:
   name: "Naruto - Narutimett Hero 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2  # Fixes invisible QTE button prompts and overbright in some scenes.
+    vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
 SLPS-73252:
   name: "Tales of the Abyss [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -35320,17 +35444,17 @@ SLPS-73258:
   name: "Kenka Banchou 2 - Full Throttle [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPS-73263:
-  name: "Ar tonelico II: Sekai ni Hibiku Shoujo-Tachi no Metafalica [PlayStation 2 The Best]"
+  name: "Ar tonelico II - Sekai ni Hibiku Shoujo-Tachi no Metafalica [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes "Fall through floor" bug when approaching chests.
+    eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLPS-73269:
-  name: "Kidou Senshi Gundam SEED: Rengou vs. Z.A.F.T."
+  name: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T."
   region: "NTSC-K"
   roundModes:
-    eeRoundMode: 1  # Fixes camera issue.
+    eeRoundMode: 1 # Fixes camera issue.
   gameFixes:
     - FpuNegDivHack # Fixes target loss issue.
 SLPS-73401:
@@ -35344,15 +35468,15 @@ SLPS-73403:
   name: "Armored Core 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
 SLPS-73404:
   name: "Klonoa 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Objects appear in wrong places without it.
-    vuClampMode: 2  # Fixes water reflection.
+    eeClampMode: 3 # Objects appear in wrong places without it.
+    vuClampMode: 2 # Fixes water reflection.
   gameFixes:
-    - EETimingHack # Fixes flickering graphics. 
+    - EETimingHack # Fixes flickering graphics.
 SLPS-73405:
   name: "Zero [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -35376,7 +35500,7 @@ SLPS-73411:
   name: "Armored Core 2 - Another Age [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
   memcardFilters:
     - "SCPS-55024"
     - "SLPS-25007"
@@ -35396,12 +35520,12 @@ SLPS-73417:
   name: "Armored Core 3 [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
 SLPS-73418:
   name: "Shadow Hearts [PlayStation 2 The Best]"
   region: "NTSC-J"
   clampModes:
-    eeClampMode: 3  # Fixes invisible characters in various scenes.
+    eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLPS-73419:
   name: "Lupin III - Majutsu-Ou no Isan [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -35409,7 +35533,7 @@ SLPS-73420:
   name: "Armored Core 3 - Silent Line [PlayStation 2 The Best]"
   region: "NTSC-J"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
   memcardFilters:
     - "SCAJ-20011"
     - "SCPS-55014"
@@ -35508,13 +35632,13 @@ SLUS-20014:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
 SLUS-20015:
   name: "Eternal Ring"
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes FPU errors causing instant death in Limestone Cave.
+    eeRoundMode: 0 # Fixes FPU errors causing instant death in Limestone Cave.
 SLUS-20016:
   name: "Evergrace"
   region: "NTSC-U"
@@ -35552,7 +35676,7 @@ SLUS-20034:
   region: "NTSC-U"
   compat: 5
 SLUS-20035:
-  name: "Baldur's Gate: Dark Alliance"
+  name: "Baldur's Gate - Dark Alliance"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -35757,7 +35881,7 @@ SLUS-20093:
   name: "Madden NFL 2001"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20094:
   name: "X Squad"
   region: "NTSC-U"
@@ -35868,7 +35992,7 @@ SLUS-20138:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes game hanging in the "Clark running away" ingame cutscene.
+    eeRoundMode: 0 # Fixes game hanging in the "Clark running away" ingame cutscene.
 SLUS-20139:
   name: "Simpsons, The - Road Rage"
   region: "NTSC-U"
@@ -35925,15 +36049,17 @@ SLUS-20150:
   name: "Knockout Kings 2001"
   region: "NTSC-U"
   compat: 3
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes missing arena, fighters and other missing graphics.
 SLUS-20151:
   name: "Klonoa 2 - Lunatea's Veil"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Objects appear in wrong places without it.
-    vuClampMode: 2  # Fixes water reflection.
+    eeClampMode: 3 # Objects appear in wrong places without it.
+    vuClampMode: 2 # Fixes water reflection.
   gameFixes:
-    - EETimingHack # Fixes flickering graphics. 
+    - EETimingHack # Fixes flickering graphics.
 SLUS-20152:
   name: "Ace Combat 4 - Shattered Skies"
   region: "NTSC-U"
@@ -35977,7 +36103,7 @@ SLUS-20160:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes missing 3D polygons when going ingame.
+    vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLUS-20162:
   name: "Aqua Aqua"
   region: "NTSC-U"
@@ -35985,6 +36111,8 @@ SLUS-20164:
   name: "Project Eden"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - XGKickHack # Fixes corrupted graphics.
 SLUS-20165:
   name: "Legacy of Kain - Soul Reaver 2"
   region: "NTSC-U"
@@ -36011,6 +36139,8 @@ SLUS-20170:
   name: "Adventures of Cookie & Cream, The"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    MTVUSpeedHack: 0 # Prevents broken textures and graphics.
 SLUS-20171:
   name: "Motor Mayhem - Vehicular Combat League"
   region: "NTSC-U"
@@ -36019,7 +36149,7 @@ SLUS-20172:
   region: "NTSC-U"
   compat: 5
 SLUS-20173:
-  name: "Unison: Rebels of Rhythm & Dance"
+  name: "Unison - Rebels of Rhythm & Dance"
   region: "NTSC-U"
 SLUS-20174:
   name: "Rumble Racing"
@@ -36268,7 +36398,7 @@ SLUS-20228:
   region: "NTSC-U"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes hang on FMV's when CDVD timing is accurate.
+    InstantVU1SpeedHack: 0 # Fixes hang on FMV's when CDVD timing is accurate.
     MTVUSpeedHack: 0
 SLUS-20229:
   name: "Jonny Moseley - Mad Trix"
@@ -36285,7 +36415,7 @@ SLUS-20230:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes crashes.
+    eeClampMode: 3 # Fixes crashes.
 SLUS-20231:
   name: "Herdy Gerdy"
   region: "NTSC-U"
@@ -36322,14 +36452,14 @@ SLUS-20239:
   name: "Driven"
   region: "NTSC-U"
 SLUS-20240:
-  name: "Conflict Zone: Modern War Strategy"
+  name: "Conflict Zone - Modern War Strategy"
   region: "NTSC-U"
   compat: 5
 SLUS-20241:
   name: "NCAA Football 2002"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20242:
   name: "Legends of Wrestling"
   region: "NTSC-U"
@@ -36357,7 +36487,7 @@ SLUS-20249:
   name: "Armored Core 2 - Another Age"
   region: "NTSC-U"
   clampModes:
-    eeClampMode: 2  # Fixes Abnormal AI behavior.
+    eeClampMode: 2 # Fixes Abnormal AI behavior.
   memcardFilters: # Can import data from regular Armored Core 2.
     - "SLUS-20249"
     - "SLUS-20014"
@@ -36399,7 +36529,7 @@ SLUS-20263:
   name: "Madden NFL 2002"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20264:
   name: "F1 2001"
   region: "NTSC-U"
@@ -36408,7 +36538,7 @@ SLUS-20265:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2 # Fixes corrupt textures. 
+    vuClampMode: 2 # Fixes corrupt textures.
 SLUS-20266:
   name: "NASCAR - Thunder 2002"
   region: "NTSC-U"
@@ -36500,7 +36630,7 @@ SLUS-20284:
   region: "NTSC-U"
   compat: 4
   roundModes:
-    vuRoundMode: 1  # Fixes some bad effects.
+    vuRoundMode: 1 # Fixes some bad effects.
   patches:
     9d1ba44d:
       content: |-
@@ -36605,7 +36735,7 @@ SLUS-20312:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fix reverse control and boss in some places.
+    eeRoundMode: 1 # Fix reverse control and boss in some places.
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts.
 SLUS-20313:
@@ -36632,7 +36762,7 @@ SLUS-20316:
   region: "NTSC-U"
   compat: 5
 SLUS-20318:
-  name: "King's Field IV: The Ancient City"
+  name: "King's Field IV - The Ancient City"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -36761,13 +36891,13 @@ SLUS-20347:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes invisible characters in various scenes.
+    eeClampMode: 3 # Fixes invisible characters in various scenes.
 SLUS-20348:
   name: "Monopoly Party"
   region: "NTSC-U"
   compat: 4
   clampModes:
-    vuClampMode: 0  # Fixes missing game board.
+    vuClampMode: 0 # Fixes missing game board.
 SLUS-20349:
   name: "Scooby-Doo! Night of 100 Frights"
   region: "NTSC-U"
@@ -36812,13 +36942,13 @@ SLUS-20362:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # White textures.
+    vuClampMode: 2 # White textures.
 SLUS-20363:
   name: "Sled Storm"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing polygons at the bottom of the screen.
+    vuClampMode: 3 # Missing polygons at the bottom of the screen.
 SLUS-20364:
   name: "Tiger Woods PGA Tour 2002"
   region: "NTSC-U"
@@ -36977,7 +37107,7 @@ SLUS-20394:
         patch=1,EE,201018d8,extended,24040007
         patch=1,EE,201018e4,extended,24040006
 SLUS-20395:
-  name: "Global Touring Challenge: Africa"
+  name: "Global Touring Challenge - Africa"
   region: "NTSC-U"
 SLUS-20397:
   name: "Tenchu 3 - Wrath of Heaven"
@@ -36991,7 +37121,7 @@ SLUS-20399:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes glitchy graphics ingame.
+    vuRoundMode: 0 # Fixes glitchy graphics ingame.
 SLUS-20400:
   name: "Mission Impossible - Operation Surma"
   region: "NTSC-U"
@@ -37026,7 +37156,7 @@ SLUS-20408:
   region: "NTSC-U"
   compat: 4
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLUS-20409:
   name: "Total Immersion Racing"
   region: "NTSC-U"
@@ -37048,9 +37178,9 @@ SLUS-20413:
   region: "NTSC-U"
   compat: 5
   gameFixes:
-    - EETimingHack # Fixes cutscene freezes. 
+    - EETimingHack # Fixes cutscene freezes.
   speedHacks:
-    InstantVU1SpeedHack: 0  # Fixes SPS.
+    InstantVU1SpeedHack: 0 # Fixes SPS.
     MTVUSpeedHack: 0
 SLUS-20414:
   name: "Legaia 2 - Duel Saga"
@@ -37077,16 +37207,16 @@ SLUS-20418:
   region: "NTSC-U"
   compat: 2
   clampModes:
-    vuClampMode: 3  # Fixes water rendering.
+    vuClampMode: 3 # Fixes water rendering.
   gameFixes:
     - XGKickHack # Fixes SPS while ingame.
 SLUS-20419:
   name: "World Rally Championship"
   region: "NTSC-U"
   roundModes:
-    eeRoundMode: 0  # Fixes crash when using the Subaru.
+    eeRoundMode: 0 # Fixes crash when using the Subaru.
   gameFixes:
-    - XGKickHack # Fixes SPS while ingame     
+    - XGKickHack # Fixes SPS while ingame.
 SLUS-20420:
   name: "Star Wars - Bounty Hunter"
   region: "NTSC-U"
@@ -37095,7 +37225,7 @@ SLUS-20420:
     vuRoundMode: 0
   clampModes:
     vuClampMode: 3
-    eeClampMode: 2  # Fixes missing/grey texture or geometry ingame.
+    eeClampMode: 2 # Fixes missing/grey texture or geometry ingame.
 SLUS-20421:
   name: "Battlestar Galactica"
   region: "NTSC-U"
@@ -37151,7 +37281,7 @@ SLUS-20433:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # For grey screen ingame.
+    eeClampMode: 3 # For grey screen ingame.
 SLUS-20434:
   name: "Myst III - Exile"
   region: "NTSC-U"
@@ -37168,7 +37298,7 @@ SLUS-20435:
   name: "Armored Core 3"
   region: "NTSC-U"
   roundModes:
-    eeRoundMode: 0  # Fixes Z-Fighting.
+    eeRoundMode: 0 # Fixes Z-Fighting.
 SLUS-20436:
   name: "Guilty Gear X2"
   region: "NTSC-U"
@@ -37451,12 +37581,12 @@ SLUS-20497:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 1  # Bright lights in cars.
+    vuRoundMode: 1 # Bright lights in cars.
 SLUS-20498:
   name: "Auto Modellista"
   region: "NTSC-U"
 SLUS-20499:
-  name: "Breath of Fire: Dragon Quarter"
+  name: "Breath of Fire - Dragon Quarter"
   region: "NTSC-U"
   compat: 5
 SLUS-20500:
@@ -37474,7 +37604,7 @@ SLUS-20504:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-20505:
   name: "Mace Griffin - Bounty Hunter"
   region: "NTSC-U"
@@ -37521,9 +37651,9 @@ SLUS-20515:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 2  # Partially fixes battle animation.
+    eeRoundMode: 2 # Partially fixes battle animation.
   clampModes:
-    eeClampMode: 2  # Partially fixes battle animation.
+    eeClampMode: 2 # Partially fixes battle animation.
 SLUS-20516:
   name: "Shrek - Super Party"
   region: "NTSC-U"
@@ -37569,7 +37699,7 @@ SLUS-20527:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes SPS.
+    vuClampMode: 0 # Fixes SPS.
 SLUS-20528:
   name: "Zapper - One Wicked Cricket"
   region: "NTSC-U"
@@ -37577,12 +37707,12 @@ SLUS-20529:
   name: "Madden NFL 2003"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20530:
   name: "NCAA Football 2003"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20531:
   name: "NHL 2003"
   region: "NTSC-U"
@@ -37611,7 +37741,7 @@ SLUS-20536:
   name: "NBA Live 2003"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLUS-20537:
   name: "Jimmy Neutron - Boy Genius"
   region: "NTSC-U"
@@ -37631,7 +37761,7 @@ SLUS-20541:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes transparency issues.
+    vuClampMode: 2 # Fixes transparency issues.
 SLUS-20543:
   name: "Metal Gear Solid 2"
   region: "NTSC-U"
@@ -37640,7 +37770,7 @@ SLUS-20544:
   name: "Malice"
   region: "NTSC-U"
 SLUS-20545:
-  name: "Zone of the Enders: The 2nd Runner"
+  name: "Zone of the Enders - The 2nd Runner"
   region: "NTSC-U"
   compat: 5
 SLUS-20546:
@@ -37699,7 +37829,7 @@ SLUS-20559:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 0  # Fixes boxers not appearing/disappearing.
+    eeClampMode: 0 # Fixes boxers not appearing/disappearing.
   gameFixes:
     - VIF1StallHack # Fixes freezes.
 SLUS-20560:
@@ -37783,7 +37913,7 @@ SLUS-20573:
   region: "NTSC-U"
   compat: 4
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLUS-20574:
   name: "NCAA March Madness 2003"
   region: "NTSC-U"
@@ -37807,18 +37937,18 @@ SLUS-20578:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fix white shiny weapons.
+    vuClampMode: 3 # Fix white shiny weapons.
 SLUS-20579:
   name: "James Bond 007 - Nightfire"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes polygon clipping in driving missions.
+    vuClampMode: 2 # Fixes polygon clipping in driving missions.
 SLUS-20580:
   name: "FIFA Soccer 2003"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLUS-20582:
   name: "Street Racing Syndicate"
   region: "NTSC-U"
@@ -37839,7 +37969,7 @@ SLUS-20585:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes hangs in certain locations like building under construction.
+    eeClampMode: 3 # Fixes hangs in certain locations like building under construction.
 SLUS-20586:
   name: "IHRA Drag Racing 2"
   region: "NTSC-U"
@@ -37988,12 +38118,14 @@ SLUS-20622:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+    vuClampMode: 2 # Fixes some lighting/shadow artefacts (most light sources like the Flashlight are unaffected).
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   memcardFilters: # Reads Silent Hill 2 for easter egg.
     - "SLUS-20622"
     - "SLUS-20228"
 SLUS-20623:
-  name: "World Soccer: Winning Eleven 6 International"
+  name: "World Soccer - Winning Eleven 6 International"
   region: "NTSC-U"
 SLUS-20624:
   name: "Simpsons, The - Hit & Run"
@@ -38078,13 +38210,15 @@ SLUS-20643:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Respawn issues, Fixes SPS.
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20643BD:
   name: "Namco Transmission Demo Disc v1.03 [Soul Calibur II Pack-In]"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20644:
@@ -38106,7 +38240,7 @@ SLUS-20647:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
 SLUS-20648:
   name: "NBA Jam 2004"
   region: "NTSC-U"
@@ -38118,13 +38252,13 @@ SLUS-20650:
   name: "MVP Baseball 2003"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Fixes missing environment. 
+    vuClampMode: 3 # Fixes missing environment.
 SLUS-20651:
   name: "NBA Street Vol. 2"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Missing environment with microVU.
+    vuClampMode: 2 # Missing environment with microVU.
 SLUS-20652:
   name: "Tom Clancy's Splinter Cell"
   region: "NTSC-U"
@@ -38134,7 +38268,7 @@ SLUS-20653:
   region: "NTSC-U"
   compat: 5
 SLUS-20655:
-  name: "Hobbit, The: The Prelude to the Lord of the Rings"
+  name: "Hobbit, The - The Prelude to the Lord of the Rings"
   region: "NTSC-U"
   compat: 5
 SLUS-20656:
@@ -38169,7 +38303,7 @@ SLUS-20665:
   name: "Cabela's Deer Hunt - 2004 Season"
   region: "NTSC-U"
 SLUS-20666:
-  name: "Disgaea: Hour of Darkness"
+  name: "Disgaea - Hour of Darkness"
   region: "NTSC-U"
   compat: 5
 SLUS-20668:
@@ -38219,7 +38353,7 @@ SLUS-20674:
   region: "NTSC-U"
   compat: 5
 SLUS-20675:
-  name: "Baldur's Gate: Dark Alliance II"
+  name: "Baldur's Gate - Dark Alliance II"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -38278,6 +38412,8 @@ SLUS-20688:
   name: "Psi-Ops - The Mindgate Conspiracy"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    roundSprite: 2 # Removes blurriness and artifacting at sides, esspecialy helps 3D11.
 SLUS-20689:
   name: "Conflict - Desert Storm 2 - Back to Baghdad"
   region: "NTSC-U"
@@ -38308,9 +38444,11 @@ SLUS-20695:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes SPS in item menu.
+    vuClampMode: 2 # Fixes SPS in item menu.
   gsHWFixes:
-    textureInsideRT: 1
+    textureInsideRT: 1 # Fixes rainbow shadow of legions.
+    alignSprite: 1 # Fixes green vertical lines.
+    roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLUS-20696:
   name: "Jimmy Neutron - Boy Genius - Jet Fusion"
   region: "NTSC-U"
@@ -38323,7 +38461,7 @@ SLUS-20698:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Needed for SPS on some characters.
+    eeClampMode: 2 # Needed for SPS on some characters.
 SLUS-20699:
   name: "Cowboy Bebop"
   region: "NTSC-U"
@@ -38338,7 +38476,7 @@ SLUS-20702:
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
 SLUS-20703:
-  name: "Airforce: Delta Strike"
+  name: "Airforce - Delta Strike"
   region: "NTSC-U"
   compat: 5
 SLUS-20704:
@@ -38381,7 +38519,7 @@ SLUS-20714:
   region: "NTSC-U"
   compat: 5
 SLUS-20715:
-  name: "Combat Elite: WWII Paratroopers"
+  name: "Combat Elite - WWII Paratroopers"
   region: "NTSC-U"
 SLUS-20716:
   name: "Teenage Mutant Ninja Turtles"
@@ -38395,7 +38533,7 @@ SLUS-20719:
   name: "NCAA Football 2004"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20720:
   name: "Romance of the Three Kingdoms VIII"
   region: "NTSC-U"
@@ -38454,13 +38592,13 @@ SLUS-20731:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-20732:
   name: "Drakengard"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Characters are visible in-game.
+    eeClampMode: 3 # Characters are visible in-game.
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and textures wrong.
 SLUS-20733:
@@ -38468,7 +38606,7 @@ SLUS-20733:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes cutscene freezes.
+    eeClampMode: 3 # Fixes cutscene freezes.
 SLUS-20734:
   name: "Frogger's Adventures - The Rescue"
   region: "NTSC-U"
@@ -38533,7 +38671,7 @@ SLUS-20750:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLUS-20751:
   name: "James Bond 007 - Everything or Nothing"
   region: "NTSC-U"
@@ -38542,7 +38680,7 @@ SLUS-20752:
   name: "Madden NFL 2004"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20753:
   name: "Medal of Honor - Rising Sun"
   region: "NTSC-U"
@@ -38554,7 +38692,7 @@ SLUS-20755:
   name: "NBA Live 2004"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLUS-20756:
   name: "NHL 2004"
   region: "NTSC-U"
@@ -38563,7 +38701,7 @@ SLUS-20757:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes black textures on characters.
+    vuClampMode: 2 # Fixes black textures on characters.
 SLUS-20758:
   name: "Growlanser Generations [Disc1of2]"
   region: "NTSC-U"
@@ -38610,7 +38748,7 @@ SLUS-20763:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes SPS with water in some places.
+    eeRoundMode: 0 # Fixes SPS with water in some places.
   gsHWFixes:
     textureInsideRT: 1 # Fixes the shape of shadows.
     autoFlush: 1 # Fixes water rendering.
@@ -38701,7 +38839,7 @@ SLUS-20786:
   gameFixes:
     - EETimingHack # Texture flicker.
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes SPS.
+    mvuFlagSpeedHack: 0 # Fixes SPS.
 SLUS-20787:
   name: "WWE SmackDown! Here Comes the Pain"
   region: "NTSC-U"
@@ -38750,7 +38888,7 @@ SLUS-20798:
   name: "Starcraft - Ghost"
   region: "NTSC-U"
 SLUS-20799:
-  name: "Terminator 3: Rise of the Machines"
+  name: "Terminator 3 - Rise of the Machines"
   region: "NTSC-U"
   compat: 5
 SLUS-20800:
@@ -38833,7 +38971,7 @@ SLUS-20821:
   region: "NTSC-U"
   compat: 5
 SLUS-20822:
-  name: "Galactic Wrestling: Featuring Ultimate Muscle - The Kinnikuman Legacy"
+  name: "Galactic Wrestling - Featuring Ultimate Muscle - The Kinnikuman Legacy"
   region: "NTSC-U"
   compat: 5
 SLUS-20823:
@@ -38857,7 +38995,7 @@ SLUS-20828:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
 SLUS-20830:
   name: "Intellivision Lives!"
   region: "NTSC-U"
@@ -38899,7 +39037,7 @@ SLUS-20841:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20842:
   name: "Sims, The - Bustin' Out"
   region: "NTSC-U"
@@ -38915,7 +39053,7 @@ SLUS-20845:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes rainbow graphics.
+    vuClampMode: 2 # Fixes rainbow graphics.
 SLUS-20846:
   name: "Strike Force Bowling"
   region: "NTSC-U"
@@ -39007,6 +39145,8 @@ SLUS-20864:
   name: "Punisher, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLUS-20865:
   name: "Backyard Baseball"
   region: "NTSC-U"
@@ -39022,7 +39162,7 @@ SLUS-20867:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes character behaviour.
+    eeRoundMode: 0 # Fixes character behaviour.
 SLUS-20868:
   name: "MVP Baseball 2004"
   region: "NTSC-U"
@@ -39048,6 +39188,8 @@ SLUS-20873:
   name: "Silent Hill 4 - The Room"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes dark sides.
 SLUS-20874:
   name: "Dragon Ball Z - Sagas"
   region: "NTSC-U"
@@ -39216,11 +39358,11 @@ SLUS-20910:
   region: "NTSC-U"
   compat: 5
 SLUS-20911:
-  name: "Shin Megami Tensei: Nocturne"
+  name: "Shin Megami Tensei - Nocturne"
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLUS-20912:
   name: "Superbikes TT"
   region: "NTSC-U"
@@ -39249,7 +39391,7 @@ SLUS-20918:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 1  # Fixes object balls never stopping in the Monkey Billiards DX minigame.
+    eeRoundMode: 1 # Fixes object balls never stopping in the Monkey Billiards DX minigame.
 SLUS-20919:
   name: "ESPN - NFL 2K5"
   region: "NTSC-U"
@@ -39302,7 +39444,7 @@ SLUS-20925:
   region: "NTSC-U"
   compat: 2
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLUS-20926:
   name: "Harry Potter and The Prisoner of Azkaban"
   region: "NTSC-U"
@@ -39401,7 +39543,7 @@ SLUS-20946:
   gsHWFixes:
     autoFlush: 1
 SLUS-20947:
-  name: "WinBack 2: Project Poseidon"
+  name: "WinBack 2 - Project Poseidon"
   region: "NTSC-U"
   compat: 5
 SLUS-20948:
@@ -39439,7 +39581,7 @@ SLUS-20955:
   region: "NTSC-U"
   compat: 5
 SLUS-20956:
-  name: "Leisure Suit Larry: Magna Cum Laude"
+  name: "Leisure Suit Larry - Magna Cum Laude"
   region: "NTSC-U"
   compat: 5
 SLUS-20957:
@@ -39482,7 +39624,7 @@ SLUS-20963:
   region: "NTSC-U"
   compat: 5
 SLUS-20964:
-  name: "Devil May Cry 3: Dante's Awakening"
+  name: "Devil May Cry 3 - Dante's Awakening"
   region: "NTSC-U"
   compat: 5
   roundModes:
@@ -39494,7 +39636,7 @@ SLUS-20965:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-20966:
   name: "State of Emergency 2"
   region: "NTSC-U"
@@ -39534,7 +39676,7 @@ SLUS-20973:
     - "SLUS-20973"
     - "SLUS-20565"
 SLUS-20974:
-  name: "Shin Megami Tensei: Digital Devil Saga"
+  name: "Shin Megami Tensei - Digital Devil Saga"
   region: "NTSC-U"
   compat: 5
 SLUS-20975:
@@ -39575,11 +39717,11 @@ SLUS-20980:
   gameFixes:
     - EETimingHack
 SLUS-20981:
-  name: "Teenage Mutant Ninja Turtles 2: Battle Nexus"
+  name: "Teenage Mutant Ninja Turtles 2 - Battle Nexus"
   region: "NTSC-U"
   compat: 5
 SLUS-20982:
-  name: "Bad Boys: Miami Takedown"
+  name: "Bad Boys - Miami Takedown"
   region: "NTSC-U"
   compat: 5
 SLUS-20983:
@@ -39629,7 +39771,7 @@ SLUS-20991:
   name: "NCAA Football 2005"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-20992:
   name: "Catwoman"
   region: "NTSC-U"
@@ -39691,7 +39833,7 @@ SLUS-21000:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21001:
   name: "NHL 2005"
   region: "NTSC-U"
@@ -39700,7 +39842,7 @@ SLUS-21002:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes black textures on characters.
+    vuClampMode: 2 # Fixes black textures on characters.
 SLUS-21003:
   name: "NASCAR 2005 - Chase for the Cup"
   region: "NTSC-U"
@@ -39758,7 +39900,10 @@ SLUS-21007:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes Sugoroku mini-game.
+    eeRoundMode: 0 # Fixes Sugoroku mini-game.
+  speedHacks:
+    InstantVU1SpeedHack: 1 # This option enabled brings about 15% more FPS when I tested it, *your experience may differ.
+    MTVUSpeedHack: 0 # For some reason this games halves the internal game FPS with this option.
   gsHWFixes:
     halfPixelOffset: 2 # Reduces ghosting.
     preloadFrameData: 1 # Fixes red cracklines on walls.
@@ -39813,7 +39958,7 @@ SLUS-21018:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes minor SPS on characters.
+    vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
     preloadFrameData: 1
 SLUS-21019:
@@ -39838,7 +39983,7 @@ SLUS-21025:
   name: "Madden NFL 2005 [Special Collectors Edition]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21026:
   name: "Battlefield 2 - Modern Combat"
   region: "NTSC-U"
@@ -39967,7 +40112,7 @@ SLUS-21050:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLUS-21051:
@@ -39988,7 +40133,7 @@ SLUS-21054:
   name: "Disney's Treasure Planet (Disney Classics)"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Fixes SPS when the solar surfer's engines are inactive.
+    vuClampMode: 3 # Fixes SPS when the solar surfer's engines are inactive.
   gameFixes:
     - EETimingHack # Fixes hang before going ingame.
 SLUS-21056:
@@ -40005,7 +40150,7 @@ SLUS-21059:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SLUS-21060:
@@ -40050,7 +40195,7 @@ SLUS-21069:
   name: "American Chopper"
   region: "NTSC-U"
 SLUS-21070:
-  name: "Final Fantasy XI: Chains of Promathia"
+  name: "Final Fantasy XI - Chains of Promathia"
   region: "NTSC-U"
 SLUS-21071:
   name: "Nightmare of Druaga"
@@ -40085,7 +40230,7 @@ SLUS-21078:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes the inability to collect items.
+    eeClampMode: 3 # Fixes the inability to collect items.
 SLUS-21079:
   name: "Armored Core Nexus [Revolution Disc]"
   region: "NTSC-U"
@@ -40107,7 +40252,7 @@ SLUS-21082:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLUS-21083:
-  name: "LEGO Star Wars: The Video Game"
+  name: "LEGO Star Wars - The Video Game"
   region: "NTSC-U"
   compat: 5
 SLUS-21084:
@@ -40205,7 +40350,7 @@ SLUS-21106:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes SPS on highway.
+    eeClampMode: 2 # Fixes SPS on highway.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting.
 SLUS-21107:
@@ -40217,7 +40362,7 @@ SLUS-21108:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues
+    vuClampMode: 0 # Fixes bump mapping issues
 SLUS-21109:
   name: "Drive to Survive"
   region: "NTSC-U"
@@ -40240,7 +40385,7 @@ SLUS-21112:
   region: "NTSC-U"
   compat: 5
 SLUS-21113:
-  name: "Atelier Iris: Eternal Mana"
+  name: "Atelier Iris - Eternal Mana"
   region: "NTSC-U"
   compat: 5
 SLUS-21114:
@@ -40263,7 +40408,7 @@ SLUS-21118:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
   gameFixes:
     - GIFFIFOHack # Fixes garbage graphics.
 SLUS-21119:
@@ -40318,7 +40463,7 @@ SLUS-21131:
   region: "NTSC-U"
   compat: 5
 SLUS-21132:
-  name: "Stella Deus: The Gate of Eternity"
+  name: "Stella Deus - The Gate of Eternity"
   region: "NTSC-U"
   compat: 5
 SLUS-21133:
@@ -40356,7 +40501,7 @@ SLUS-21139:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes textures and crashes.
+    vuRoundMode: 0 # Fixes textures and crashes.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes bloom misalignment.
     wildArmsHack: 1 # Fixes bloom misalignment.
@@ -40369,7 +40514,7 @@ SLUS-21142:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 2  # Resolves dumpster not being able to be climbed from front in level 2.
+    eeRoundMode: 2 # Resolves dumpster not being able to be climbed from front in level 2.
 SLUS-21143:
   name: "Star Wars - Episode III - Revenge of the Sith"
   region: "NTSC-U"
@@ -40385,7 +40530,7 @@ SLUS-21145:
   region: "NTSC-U"
   compat: 5
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLUS-21146:
   name: "Far East of Eden"
   region: "NTSC-U"
@@ -40418,7 +40563,7 @@ SLUS-21151:
         patch=1,EE,00203dd8,word,484e9000
         patch=1,EE,00203ddc,word,4bdbd9ff
 SLUS-21152:
-  name: "Shin Megami Tensei: Digital Devil Saga 2"
+  name: "Shin Megami Tensei - Digital Devil Saga 2"
   region: "NTSC-U"
   compat: 5
   memcardFilters:
@@ -40455,7 +40600,7 @@ SLUS-21160:
   name: "Tekken 5 [Demo]"
   region: "NTSC-U"
   clampModes:
-    eeClampMode: 2  # Fixes camera and stops constant coin noises on Pirates Cove.
+    eeClampMode: 2 # Fixes camera and stops constant coin noises on Pirates Cove.
   gsHWFixes:
     alignSprite: 1
 SLUS-21161:
@@ -40466,9 +40611,11 @@ SLUS-21162:
   name: "Ford Mustang - The Legend Lives"
   region: "NTSC-U"
 SLUS-21163:
-  name: "Brothers in Arms: Road to Hill 30"
+  name: "Brothers In Arms - Road to Hill 30"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Reduces blurriness, there are still ghosting issues for like lighting poles.
 SLUS-21164:
   name: "Namco Museum - 50th Anniversary"
   region: "NTSC-U"
@@ -40485,8 +40632,8 @@ SLUS-21168:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes SPS with microVU.
-    eeClampMode: 2  # Fixes missing blade.
+    vuClampMode: 0 # Fixes SPS with microVU.
+    eeClampMode: 2 # Fixes missing blade.
   memcardFilters:
     - "SLUS-21168"
     - "SLUS-20733"
@@ -40512,7 +40659,7 @@ SLUS-21172:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 2  # Fixes abnormal character behaviour.
+    eeRoundMode: 2 # Fixes abnormal character behaviour.
 SLUS-21173:
   name: "Dora the Explorer - To the Purple Planet"
   region: "NTSC-U"
@@ -40545,7 +40692,7 @@ SLUS-21179:
     halfPixelOffset: 3 # Fixes bloom misalignment still a bit misaligned.
     roundSprite: 1 # Fixes bloom misalignment still a bit misaligned.
 SLUS-21180:
-  name: "Onimusha: Dawn of Dreams [Disc1of2]"
+  name: "Onimusha - Dawn of Dreams [Disc1of2]"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -40569,7 +40716,7 @@ SLUS-21180:
        patch=1,EE,0010FDD4,word,03E00008
        patch=1,EE,0010FDD8,word,00000000
 SLUS-21181:
-  name: "D.I.C.E.: DNA Integrated Cybernetic Enterprises"
+  name: "D.I.C.E. - DNA Integrated Cybernetic Enterprises"
   region: "NTSC-U"
   compat: 5
 SLUS-21182:
@@ -40604,7 +40751,7 @@ SLUS-21189:
   region: "NTSC-U"
   compat: 5
   speedHacks:
-    InstantVU1SpeedHack: 1  # Fixes SPS.
+    InstantVU1SpeedHack: 1 # Fixes SPS.
   memcardFilters:
     - "SLUS-21189"
     - "SLUS-20636"
@@ -40696,7 +40843,7 @@ SLUS-21208:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-21209:
   name: "Urban Reign"
   region: "NTSC-U"
@@ -40714,12 +40861,12 @@ SLUS-21213:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21214:
   name: "NCAA Football 2006"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21215:
   name: "Warriors, The"
   region: "NTSC-U"
@@ -40730,6 +40877,8 @@ SLUS-21216:
   compat: 5
   gameFixes:
     - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-21217:
@@ -40751,7 +40900,7 @@ SLUS-21220:
   region: "NTSC-U"
   compat: 5
 SLUS-21221:
-  name: "Magna Carta: Tears of Blood"
+  name: "Magna Carta - Tears of Blood"
   region: "NTSC-U"
   compat: 5
 SLUS-21222:
@@ -40767,7 +40916,7 @@ SLUS-21224:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLUS-21225:
   name: "Bratz - Rock Angelz"
   region: "NTSC-U"
@@ -40879,7 +41028,7 @@ SLUS-21242:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
@@ -40919,7 +41068,7 @@ SLUS-21248:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes broken polygons on trees.
+    vuClampMode: 3 # Fixes broken polygons on trees.
 SLUS-21249:
   name: "Yourself! Fitness - Lifestyle"
   region: "NTSC-U"
@@ -40928,7 +41077,7 @@ SLUS-21250:
   region: "NTSC-U"
   compat: 5
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes bad graphics.
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SLUS-21251:
   name: "FlatOut 2"
   region: "NTSC-U"
@@ -41019,17 +41168,17 @@ SLUS-21267:
     - "SLUS-21351"
     - "SLUS-21065"
 SLUS-21268:
-  name: "24: The Game"
+  name: "24 - The Game"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes minimap HUD.
+    vuClampMode: 2 # Fixes minimap HUD.
 SLUS-21269:
   name: "Bully"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
+    eeClampMode: 3 # Fixes the inability to take the bottle in the trophy case in Chapter 2: Hattrick vs Galloway.
   gsHWFixes:
     wildArmsHack: 1 # Reduces depth ghosting.
     roundSprite: 2 # Reduces depth ghosting.
@@ -41054,9 +41203,13 @@ SLUS-21273:
   gsHWFixes:
     halfPixelOffset: 2 # Fix effects upscaling.
 SLUS-21274:
-  name: "OutRun 2006: Coast 2 Coast"
+  name: "OutRun 2006 - Coast 2 Coast"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Reduces post-processing misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment still a bit misaligned.
+    roundSprite: 1 # Fixes bloom misalignment still a bit misaligned + font artifacts.
 SLUS-21275:
   name: "River King - A Wonderful Journey"
   region: "NTSC-U"
@@ -41154,7 +41307,7 @@ SLUS-21295:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
   memcardFilters: # Game saves use the normal edition serial.
     - "SLUS-21208"
 SLUS-21296:
@@ -41177,7 +41330,7 @@ SLUS-21300:
   region: "NTSC-U"
   compat: 5
   speedHacks:
-    MTVUSpeedHack: 0  # Fixes bad graphics due to bad T-Bit handling.
+    MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLUS-21301:
   name: "World Series of Poker"
   region: "NTSC-U"
@@ -41191,9 +41344,9 @@ SLUS-21304:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Ingame capes become SPS mess with lower than extra VU clamp.
+    vuClampMode: 2 # Ingame capes become SPS mess with lower than extra VU clamp.
 SLUS-21305:
-  name: "Arthur and the Invisibles: The Game"
+  name: "Arthur and the Invisibles - The Game"
   region: "NTSC-U"
 SLUS-21306:
   name: "Ghost Rider"
@@ -41216,9 +41369,11 @@ SLUS-21309:
   name: "Let's Ride - Silver Buckle Stables"
   region: "NTSC-U"
 SLUS-21310:
-  name: "Brothers in Arms: Earned in Blood"
+  name: "Brothers In Arms - Earned in Blood"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLUS-21311:
   name: "King Kong, Peter Jackson's - The Official Game of the Movie"
   region: "NTSC-U"
@@ -41309,7 +41464,7 @@ SLUS-21326:
   gsHWFixes:
     roundSprite: 2 # Fixes font artifacts and reduces text box artifacts.
 SLUS-21327:
-  name: "Atelier Iris 2: The Azoth of Destiny"
+  name: "Atelier Iris 2 - The Azoth of Destiny"
   region: "NTSC-U"
   compat: 5
 SLUS-21328:
@@ -41317,7 +41472,7 @@ SLUS-21328:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes bad geometry.
+    vuClampMode: 3 # Fixes bad geometry.
   patches:
     default:
       content: |-
@@ -41364,7 +41519,7 @@ SLUS-21337:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21338:
   name: "Armored Core - Last Raven"
   region: "NTSC-U"
@@ -41574,7 +41729,7 @@ SLUS-21373:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 2  # Fixes wrong color on some characters and breakable objects.
+    eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes ghosting characters.
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
@@ -41587,15 +41742,16 @@ SLUS-21375:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # For SPS with microVU.
+    vuClampMode: 2 # For SPS with microVU.
 SLUS-21376:
   name: "Black"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
   patches:
     5C891FF1:
       content: |-
@@ -41666,7 +41822,7 @@ SLUS-21387:
   region: "NTSC-U"
   compat: 5
 SLUS-21388:
-  name: "Sopranos, The: Road to Respect"
+  name: "Sopranos, The - Road to Respect"
   region: "NTSC-U"
   compat: 5
 SLUS-21389:
@@ -41708,7 +41864,7 @@ SLUS-21396:
   region: "NTSC-U"
   compat: 5
 SLUS-21397:
-  name: "Disgaea 2: Cursed Memories"
+  name: "Disgaea 2 - Cursed Memories"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -41733,7 +41889,7 @@ SLUS-21402:
   region: "NTSC-U"
   compat: 5
 SLUS-21403:
-  name: "Backyard Sports: Baseball 2007"
+  name: "Backyard Sports - Baseball 2007"
   region: "NTSC-U"
 SLUS-21404:
   name: "Final Fantasy XI - Treasures of Aht Urhgan"
@@ -41750,7 +41906,7 @@ SLUS-21407:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21408:
   name: "FIFA World Cup Germany '06"
   region: "NTSC-U"
@@ -41778,10 +41934,10 @@ SLUS-21413:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned bloom effects.
-    mergeSprite: 1 # Fixes blurriness but removes bloom.
+    mergeSprite: 1 # Fixes blurriness but removes bloom + Recommended to use Shadeboost brightness 80.
     wrapGSMem: 1 # Fixes FMVs missing video pieces.
 SLUS-21414:
-  name: "Delta Force: Black Hawk Down - Team Sabre"
+  name: "Delta Force - Black Hawk Down - Team Sabre"
   region: "NTSC-U"
   compat: 5
 SLUS-21415:
@@ -41925,7 +42081,7 @@ SLUS-21439:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes material stretching across screen that appears for a split second.
+    eeClampMode: 3 # Fixes material stretching across screen that appears for a split second.
   gsHWFixes:
     mipmap: 1
 SLUS-21440:
@@ -41952,7 +42108,7 @@ SLUS-21444:
   roundModes:
     vuRoundMode: 0
 SLUS-21445:
-  name: "Ar tonelico: Melody of Elemia"
+  name: "Ar tonelico - Melody of Elemia"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -41966,7 +42122,7 @@ SLUS-21447:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLUS-21448:
   name: "Rule of Rose"
   region: "NTSC-U"
@@ -42000,9 +42156,9 @@ SLUS-21454:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes black zones.
+    vuRoundMode: 0 # Fixes black zones.
   clampModes:
-    eeClampMode: 3  # Fixes objects spawning.
+    eeClampMode: 3 # Fixes objects spawning.
 SLUS-21455:
   name: "Happy Feet"
   region: "NTSC-U"
@@ -42025,7 +42181,7 @@ SLUS-21459:
   name: "NCAA Football '07"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21460:
   name: "NBA Live '07"
   region: "NTSC-U"
@@ -42094,12 +42250,12 @@ SLUS-21476:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21477:
   name: "Madden NFL '07 [Hall of Fame Edition]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21478:
   name: "Pirates - Legend of the Black Buccaneer"
   region: "NTSC-U"
@@ -42131,7 +42287,7 @@ SLUS-21482:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
   gameFixes:
     - GIFFIFOHack # Fixes corrupt textures.
 SLUS-21483:
@@ -42139,7 +42295,7 @@ SLUS-21483:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fix black textures on characters.
+    vuClampMode: 2 # Fix black textures on characters.
 SLUS-21484:
   name: "Flushed Away"
   region: "NTSC-U"
@@ -42208,14 +42364,14 @@ SLUS-21493:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-21494:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "NTSC-U"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-21495:
@@ -42236,7 +42392,7 @@ SLUS-21498:
   gameFixes:
     - OPHFlagHack
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
 SLUS-21499:
   name: "Corvette Evolution GT"
   region: "NTSC-U"
@@ -42253,7 +42409,8 @@ SLUS-21503:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mergeSprite: 1 # Reduces bloom but fixes blurriness around models.
+    mergeSprite: 1 # Reduces bloom but fixes blurriness around models + Recommended to use Shadeboost brightness 80.
+    halfPixelOffset: 2 # Depth of field effect aligned properly if CRC hack is off + Shifts buildings correctly.
 SLUS-21536:
   name: "Sims 2, The - Pets"
   region: "NTSC-U"
@@ -42278,7 +42435,7 @@ SLUS-21541:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLUS-21542:
   name: "Sega Genesis Collection"
   region: "NTSC-U"
@@ -42369,7 +42526,7 @@ SLUS-21563:
   region: "NTSC-U"
   compat: 5
 SLUS-21564:
-  name: "Atelier Iris 3: Grand Phantasm"
+  name: "Atelier Iris 3 - Grand Phantasm"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -42389,7 +42546,7 @@ SLUS-21568:
   name: "Arena Football - Road to Glory"
   region: "NTSC-U"
 SLUS-21569:
-  name: "Shin Megami Tensei: Persona 3"
+  name: "Shin Megami Tensei - Persona 3"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -42421,7 +42578,7 @@ SLUS-21575:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0  # Fixes glow effects.
+    vuClampMode: 0 # Fixes glow effects.
 SLUS-21576:
   name: "Rayman - Raving Rabbids"
   region: "NTSC-U"
@@ -42464,9 +42621,9 @@ SLUS-21586:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes cut-off numbers and restores missing whitespace inside combo meter.
+    vuRoundMode: 2 # Fixes cut-off numbers and restores missing whitespace inside combo meter.
 SLUS-21587:
-  name: "Made Man: Confessions of the Family Blood"
+  name: "Made Man - Confessions of the Family Blood"
   region: "NTSC-U"
   compat: 5
 SLUS-21588:
@@ -42646,9 +42803,9 @@ SLUS-21620:
   name: "NCAA Football '08"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21621:
-  name: "Shin Megami Tensei: Persona 3 FES"
+  name: "Shin Megami Tensei - Persona 3 FES"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -42683,7 +42840,7 @@ SLUS-21627:
   region: "NTSC-U"
   compat: 5
 SLUS-21628:
-  name: "Hot Wheels: Beat That!"
+  name: "Hot Wheels - Beat That!"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -42730,7 +42887,7 @@ SLUS-21636:
   region: "NTSC-U"
   compat: 5
 SLUS-21637:
-  name: "Disney-Pixar's Cars: Mater-National Championship"
+  name: "Disney-Pixar's Cars - Mater-National Championship"
   region: "NTSC-U"
   compat: 5
 SLUS-21638:
@@ -42738,7 +42895,7 @@ SLUS-21638:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21639:
   name: "NASCAR '08"
   region: "NTSC-U"
@@ -42771,7 +42928,7 @@ SLUS-21646:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fix black textures on characters.
+    vuClampMode: 2 # Fix black textures on characters.
   gameFixes:
     - SkipMPEGHack # Fixes hang after EA intro.
 SLUS-21647:
@@ -42803,14 +42960,14 @@ SLUS-21653:
   region: "NTSC-U"
   compat: 5
 SLUS-21654:
-  name: "Kane & Lynch: Dead Men [Sneak Preview]"
+  name: "Kane & Lynch - Dead Men [Sneak Preview]"
   region: "NTSC-U"
 SLUS-21655:
-  name: "CSI: 3 Dimensions of Murder"
+  name: "CSi - 3 Dimensions of Murder"
   region: "NTSC-U"
   compat: 5
 SLUS-21656:
-  name: "Hannspree Ten Kate Honda SBK: World Superbikes '07"
+  name: "Hannspree Ten Kate Honda SBK - World Superbikes '07"
   region: "NTSC-U"
 SLUS-21658:
   name: "Need for Speed - ProStreet"
@@ -42821,7 +42978,7 @@ SLUS-21660:
   region: "NTSC-U"
   compat: 5
 SLUS-21661:
-  name: "Ben 10: Protector of Earth"
+  name: "Ben 10 - Protector of Earth"
   region: "NTSC-U"
   compat: 5
 SLUS-21662:
@@ -42867,7 +43024,7 @@ SLUS-21672:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-21673:
   name: "College Hoops 2K8"
   region: "NTSC-U"
@@ -43070,7 +43227,7 @@ SLUS-21716:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Fixes invisible wall collision in bedroom.
+    vuRoundMode: 0 # Fixes invisible wall collision in bedroom.
 SLUS-21717:
   name: "Dora the Explorer - Dora Saves the Mermaids"
   region: "NTSC-U"
@@ -43112,7 +43269,7 @@ SLUS-21727:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes invisible QTE button prompts and overbright in some scenes.
+    vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
 SLUS-21728:
   name: "Crash - Mind Over Mutant"
   region: "NTSC-U"
@@ -43135,13 +43292,17 @@ SLUS-21729:
         // My theory is on a deep timing issue.
         patch=1,EE,003cc1a0,word,00000000
 SLUS-21730:
-  name: "Jumper: Griffin's Story"
+  name: "Jumper - Griffin's Story"
   region: "NTSC-U"
   compat: 5
 SLUS-21731:
   name: "Silent Hill - Origins"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    disablePartialInvalidation: 1 # Fixes black textures and flashlight circle not working.
+    halfPixelOffset: 2 # Fixes ghosting.
+    wildArmsHack: 1 # Fixes ghosting.
 SLUS-21732:
   name: "El Tigre - The Adventures of Manny Rivera"
   region: "NTSC-U"
@@ -43159,7 +43320,7 @@ SLUS-21735:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes jump issue.
+    eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - SoftwareRendererFMVHack # Vertical lines in FMV.
 SLUS-21736:
@@ -43167,7 +43328,7 @@ SLUS-21736:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLUS-21737:
   name: "Riding Star"
   region: "NTSC-U"
@@ -43185,7 +43346,7 @@ SLUS-21740:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-21741:
   name: "Sea Monsters - A Prehistoric Adventure"
   region: "NTSC-U"
@@ -43213,7 +43374,7 @@ SLUS-21745:
   name: "NBA 2K9"
   region: "NTSC-U"
 SLUS-21746:
-  name: "Call of Duty: World at War - Final Fronts"
+  name: "Call of Duty - World at War - Final Fronts"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -43223,7 +43384,7 @@ SLUS-21748:
   name: "MLB Power Pros 2008"
   region: "NTSC-U"
 SLUS-21749:
-  name: "Garfield: Lasagna World Tour"
+  name: "Garfield - Lasagna World Tour"
   region: "NTSC-U"
 SLUS-21750:
   name: "Hannah Montana - Spotlight World Tour"
@@ -43237,7 +43398,7 @@ SLUS-21752:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21753:
   name: "Monopoly"
   region: "NTSC-U"
@@ -43318,7 +43479,7 @@ SLUS-21770:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21771:
   name: "NHL 2009"
   region: "NTSC-U"
@@ -43328,7 +43489,7 @@ SLUS-21772:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes black textures on characters.
+    vuClampMode: 2 # Fixes black textures on characters.
 SLUS-21773:
   name: "PDC World Championship Darts 2008"
   region: "NTSC-U"
@@ -43353,7 +43514,7 @@ SLUS-21779:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 0  # In-game background visible.
+    eeClampMode: 0 # In-game background visible.
 SLUS-21780:
   name: "Ferrari Challenge"
   region: "NTSC-U"
@@ -43363,11 +43524,11 @@ SLUS-21781:
   region: "NTSC-U"
   compat: 5
 SLUS-21782:
-  name: "Shin Megami Tensei: Persona 4"
+  name: "Shin Megami Tensei - Persona 4"
   region: "NTSC-U"
   compat: 5
 SLUS-21782B:
-  name: "Shin Megami Tensei: Persona 4"
+  name: "Shin Megami Tensei - Persona 4"
   region: "NTSC-U"
   compat: 5
 SLUS-21783:
@@ -43375,11 +43536,11 @@ SLUS-21783:
   region: "NTSC-U"
   compat: 5
 SLUS-21785:
-  name: "LEGO Batman: The Videogame"
+  name: "LEGO Batman - The Videogame"
   region: "NTSC-U"
   compat: 5
 SLUS-21786:
-  name: "Summer Athletics: The Ultimate Challenge"
+  name: "Summer Athletics - The Ultimate Challenge"
   region: "NTSC-U"
 SLUS-21787:
   name: "TNA Impact! Total Nonstop Action Wrestling"
@@ -43388,11 +43549,11 @@ SLUS-21787:
   gameFixes:
     - EETimingHack
 SLUS-21788:
-  name: "Ar tonelico II: Melody Of Metafalica"
+  name: "Ar tonelico Ii - Melody Of Metafalica"
   region: "NTSC-U"
   compat: 5
   roundModes:
-    eeRoundMode: 0  # Fixes "Fall through floor" bug when approaching chests.
+    eeRoundMode: 0 # Fixes "Fall through floor" bug when approaching chests.
   gsHWFixes:
     roundSprite: 1 # Fixes textboxes and character portraits.
 SLUS-21789:
@@ -43404,7 +43565,7 @@ SLUS-21790:
   region: "NTSC-U"
   compat: 5
 SLUS-21791:
-  name: "Bratz: Girlz Really Rock" # Also has french
+  name: "Bratz - Girlz Really Rock" # Also has french
   region: "NTSC-U"
 SLUS-21793:
   name: "DT Carnage"
@@ -43419,7 +43580,7 @@ SLUS-21795:
   gameFixes:
     - VUSyncHack # Partially fixes graphical issues also needs EE+3 to be fully fixed.
 SLUS-21796:
-  name: "Dora the Explorer: Dora Saves the Snow Princess"
+  name: "Dora the Explorer - Dora Saves the Snow Princess"
   region: "NTSC-U"
 SLUS-21797:
   name: "Tak - Guardians Of Gross"
@@ -43432,7 +43593,7 @@ SLUS-21798:
   region: "NTSC-U"
   compat: 5
 SLUS-21799:
-  name: "Kingdom Hearts Re: Chain of Memories"
+  name: "Kingdom Hearts Re-Chain of Memories"
   region: "NTSC-U"
   compat: 5
 SLUS-21800:
@@ -43503,7 +43664,7 @@ SLUS-21814:
   region: "NTSC-U"
   compat: 5
 SLUS-21815:
-  name: "Ben 10: Alien Force"
+  name: "Ben 10 - Alien Force"
   region: "NTSC-U"
   compat: 5
 SLUS-21816:
@@ -43542,7 +43703,7 @@ SLUS-21818:
   region: "NTSC-U"
   compat: 5
 SLUS-21819:
-  name: "High School Musical 3: Senior Year Dance!"
+  name: "High School Musical 3 - Senior Year Dance!"
   region: "NTSC-U"
   compat: 5
 SLUS-21820:
@@ -43559,7 +43720,7 @@ SLUS-21822:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Connect hits, able to summon... etc...
+    eeClampMode: 3 # Connect hits, able to summon... etc...
 SLUS-21825:
   name: "Pro Bull - Riding Out of the Chute"
   region: "NTSC-U"
@@ -43617,13 +43778,13 @@ SLUS-21843:
   region: "NTSC-U"
   compat: 5
   roundModes:
-    vuRoundMode: 0  # Crashes without.
+    vuRoundMode: 0 # Crashes without.
 SLUS-21844:
   name: "Bolt"
   region: "NTSC-U"
   compat: 5
 SLUS-21845:
-  name: "Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon"
+  name: "Shin Megami Tensei - Devil Summoner 2 - Raidou Kuzunoha vs. King Abaddon"
   region: "NTSC-U"
   compat: 5
   memcardFilters: # Allows import of save from Devil Summoner 1.
@@ -43642,13 +43803,13 @@ SLUS-21848:
   region: "NTSC-U"
   compat: 3
 SLUS-21849:
-  name: "Winter Sports 2: The Next Challenge"
+  name: "Winter Sports 2 - The Next Challenge"
   region: "NTSC-U"
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes SPS.
 SLUS-21850:
-  name: "Score International Baja 1000: The Official Game"
+  name: "Score International Baja 1000 - The Official Game"
   region: "NTSC-U"
   compat: 5
 SLUS-21851:
@@ -43671,7 +43832,7 @@ SLUS-21855:
   region: "NTSC-U"
   compat: 5
 SLUS-21857:
-  name: "Short Track Racing: Trading Paint"
+  name: "Short Track Racing - Trading Paint"
   region: "NTSC-U"
 SLUS-21858:
   name: "Tomb Raider Underworld"
@@ -43681,14 +43842,14 @@ SLUS-21860:
   name: "Bigs 2, The"
   region: "NTSC-U"
 SLUS-21861:
-  name: "Disney Sing It! High School Musical 3: Senior Year"
+  name: "Disney Sing It! High School Musical 3 - Senior Year"
   region: "NTSC-U"
 SLUS-21862:
   name: "Naruto Shippuden - Ultimate Ninja 4"
   region: "NTSC-U"
   compat: 5
 SLUS-21863:
-  name: "Suzuki TT Superbikes: Real Road Racing Championship"
+  name: "Suzuki TT Superbikes - Real Road Racing Championship"
   region: "NTSC-U"
 SLUS-21864:
   name: "Disney Pixar - Up"
@@ -43703,11 +43864,11 @@ SLUS-21866:
   region: "NTSC-U"
   compat: 5
 SLUS-21867:
-  name: "Guitar Hero: Van Halen"
+  name: "Guitar Hero - Van Halen"
   region: "NTSC-U"
   compat: 5
 SLUS-21868:
-  name: "Nobunaga's Ambition: Iron Triangle"
+  name: "Nobunaga's Ambition - Iron Triangle"
   region: "NTSC-U"
   compat: 5
 SLUS-21869:
@@ -43734,13 +43895,13 @@ SLUS-21873:
   region: "NTSC-U"
   compat: 5
 SLUS-21874:
-  name: "Jelly Belly: Ballistic Beans"
+  name: "Jelly Belly - Ballistic Beans"
   region: "NTSC-U"
 SLUS-21875:
   name: "M&Ms Adventure"
   region: "NTSC-U"
 SLUS-21876:
-  name: "Rock Band Track Pack: Classic Rock"
+  name: "Rock Band Track Pack - Classic Rock"
   region: "NTSC-U"
   compat: 3
 SLUS-21877:
@@ -43748,7 +43909,7 @@ SLUS-21877:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2  # Fixes black textures on characters.
+    vuClampMode: 2 # Fixes black textures on characters.
 SLUS-21878:
   name: "Ice Age 3 - Dawn of the Dinosaurs"
   region: "NTSC-U"
@@ -43762,9 +43923,9 @@ SLUS-21880:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    eeClampMode: 3  # Flickering objects, sound loop.
+    eeClampMode: 3 # Flickering objects, sound loop.
 SLUS-21881:
-  name: "Transformers: Revenge of the Fallen"
+  name: "Transformers - Revenge of the Fallen"
   region: "NTSC-U"
   compat: 5
 SLUS-21882:
@@ -43782,7 +43943,7 @@ SLUS-21885:
   region: "NTSC-U"
   compat: 5
 SLUS-21886:
-  name: "G.I. Joe: The Rise of Cobra"
+  name: "G.I. Joe - The Rise of Cobra"
   region: "NTSC-U"
   compat: 5
 SLUS-21888:
@@ -43794,7 +43955,7 @@ SLUS-21889:
   region: "NTSC-U"
   compat: 3
 SLUS-21890:
-  name: "Mana Khemia 2: Fall Of Alchemy"
+  name: "Mana Khemia 2 - Fall Of Alchemy"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -43807,18 +43968,18 @@ SLUS-21892:
   name: "NCAA Football 10"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21893:
   name: "Madden NFL 10"
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21895:
-  name: "Astro Boy: The Video Game"
+  name: "Astro Boy - The Video Game"
   region: "NTSC-U"
 SLUS-21896:
-  name: "Secret Saturdays, The: Beasts of the 5th Sun"
+  name: "Secret Saturdays, The - Beasts of the 5th Sun"
   region: "NTSC-U"
   compat: 5
 SLUS-21897:
@@ -43837,6 +43998,7 @@ SLUS-21899:
   compat: 5
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes missing graphics.
+    halfPixelOffset: 2 # Fixes ghosting.
 SLUS-21900:
   name: "Scooby-Doo! First Frights"
   region: "NTSC-U"
@@ -43846,7 +44008,7 @@ SLUS-21901:
   region: "NTSC-U"
   compat: 5
 SLUS-21902:
-  name: "Bakugan: Battle Brawlers"
+  name: "Bakugan - Battle Brawlers"
   region: "NTSC-U"
   compat: 5
   roundModes:
@@ -43854,7 +44016,7 @@ SLUS-21902:
   clampModes:
     vuClampMode: 0
 SLUS-21904:
-  name: "Teenage Mutant Ninja Turtles: Smash-Up"
+  name: "Teenage Mutant Ninja Turtles - Smash-Up"
   region: "NTSC-U"
   compat: 5
 SLUS-21905:
@@ -43879,7 +44041,7 @@ SLUS-21910:
   gameFixes:
     - EETimingHack # Broken textures.
 SLUS-21913:
-  name: "Star Wars: The Clone Wars - Republic Heroes"
+  name: "Star Wars - The Clone Wars - Republic Heroes"
   region: "NTSC-U"
   compat: 5
   patches:
@@ -43904,7 +44066,7 @@ SLUS-21914:
         // Fixes hanging problem.
         patch=1,EE,00431b70,word,00000000
 SLUS-21915:
-  name: "Lord of the Rings, The: Aragorn's Quest"
+  name: "Lord of the Rings, The - Aragorn's Quest"
   region: "NTSC-U"
   compat: 5
 SLUS-21917:
@@ -43918,23 +44080,23 @@ SLUS-21919:
   name: "Backyard Football 2010"
   region: "NTSC-U"
 SLUS-21920:
-  name: "Disney Sing It: Pop Hits"
+  name: "Disney Sing It - Pop Hits"
   region: "NTSC-U"
 SLUS-21921:
-  name: "Ben 10: Alien Force - Vilgax Attacks"
+  name: "Ben 10 - Alien Force - Vilgax Attacks"
   region: "NTSC-U"
   compat: 5
 SLUS-21923:
-  name: "Dora the Explorer: Dora Saves the Crystal Kingdom"
+  name: "Dora the Explorer - Dora Saves the Crystal Kingdom"
   region: "NTSC-U"
 SLUS-21924:
-  name: "Guitar Hero: Van Halen"
+  name: "Guitar Hero - Van Halen"
   region: "NTSC-U"
 SLUS-21926:
-  name: "Ni Hao, Kai-Lan: Super Game Day"
+  name: "Ni Hao, Kai-Lan - Super Game Day"
   region: "NTSC-U"
 SLUS-21927:
-  name: "Sakura Wars: So Long, My Love [English - Disc 1]"
+  name: "Sakura Wars - So Long, My Love [English - Disc 1]"
   region: "NTSC-U"
   compat: 5
 SLUS-21928:
@@ -43950,19 +44112,19 @@ SLUS-21929:
         // Avoid hanging at loading screen.
         patch=1,EE,003cd6d8,word,00000000
 SLUS-21930:
-  name: "Sakura Wars: So Long, My Love [Japanese - Disc 2]"
+  name: "Sakura Wars - So Long, My Love [Japanese - Disc 2]"
   region: "NTSC-U"
   compat: 5
 SLUS-21931:
   name: "Toy Story 3"
   region: "NTSC-U"
   roundModes:
-    vuRoundMode: 2  # Fixes very minor lines appearing at certain points during the game.
+    vuRoundMode: 2 # Fixes very minor lines appearing at certain points during the game.
 SLUS-21932:
   name: "NCAA Football 11"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21933:
   name: "Despicable Me"
   region: "NTSC-U"
@@ -43981,9 +44143,9 @@ SLUS-21937:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Shows the crowd in the back.
+    vuClampMode: 3 # Shows the crowd in the back.
 SLUS-21938:
-  name: "Ben 10 Ultimate Alien: Cosmic Destruction"
+  name: "Ben 10 Ultimate Alien - Cosmic Destruction"
   region: "NTSC-U"
   compat: 5
 SLUS-21939:
@@ -44019,7 +44181,7 @@ SLUS-21946:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-21947:
   name: "FIFA Soccer 12"
   region: "NTSC-U"
@@ -44052,10 +44214,10 @@ SLUS-27029:
   name: "Disney Sing It [Bundle]"
   region: "NTSC-U"
 SLUS-27030:
-  name: "High School Musical 3: Senior Year DANCE! [w/Mat]"
+  name: "High School Musical 3 - Senior Year DANCE! [w/Mat]"
   region: "NTSC-U"
 SLUS-27034:
-  name: "Disney Sing It! High School Musical 3: Senior Year"
+  name: "Disney Sing It! High School Musical 3 - Senior Year"
   region: "NTSC-U"
 SLUS-27093:
   name: "FIFA 14"
@@ -44067,8 +44229,8 @@ SLUS-28004:
   name: "Klonoa 2 - Lunatea's Veil [Trade Demo]"
   region: "NTSC-U"
   clampModes:
-    eeClampMode: 3  # Objects appear in wrong places without it.
-    vuClampMode: 2  # Fixes water reflection.
+    eeClampMode: 3 # Objects appear in wrong places without it.
+    vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
 SLUS-28006:
@@ -44136,7 +44298,7 @@ SLUS-28032:
   name: ".hack//Mutation Part 2 [Trade Demo]"
   region: "NTSC-U"
 SLUS-28034:
-  name: "Disgaea: Hour of Darkness [Trade Demo]"
+  name: "Disgaea - Hour of Darkness [Trade Demo]"
   region: "NTSC-U"
 SLUS-28037:
   name: "Kya - Dark Lineage [Trade Demo]"
@@ -44162,24 +44324,24 @@ SLUS-28044:
   name: "ChoroQ [Trade Demo]"
   region: "NTSC-U"
 SLUS-28045:
-  name: "Shin Megami Tensei: Nocturne [Trade Demo]"
+  name: "Shin Megami Tensei - Nocturne [Trade Demo]"
   region: "NTSC-U"
   roundModes:
-    eeRoundMode: 0  # Ladder glitch in "Assembly of Nihilo B11" level.
+    eeRoundMode: 0 # Ladder glitch in "Assembly of Nihilo B11" level.
 SLUS-28046:
   name: "Guilty Gear Isuka [Trade Demo]"
   region: "NTSC-U"
 SLUS-28049:
-  name: "Shin Megami Tensei: Digital Devil Saga [Trade Demo]"
+  name: "Shin Megami Tensei - Digital Devil Saga [Trade Demo]"
   region: "NTSC-U"
 SLUS-28050:
-  name: "Stella Deus: The Gate of Eternity [Trade Demo]"
+  name: "Stella Deus - The Gate of Eternity [Trade Demo]"
   region: "NTSC-U"
 SLUS-28051:
   name: "Samurai Western [Trade Demo]"
   region: "NTSC-U"
 SLUS-28052:
-  name: "Shin Megami Tensei: Digital Devil Saga 2 [Trade Demo]"
+  name: "Shin Megami Tensei - Digital Devil Saga 2 [Trade Demo]"
   region: "NTSC-U"
 SLUS-28053:
   name: "Magna Carta [Trade Demo]"
@@ -44209,17 +44371,17 @@ SLUS-28065:
   name: "Odin Sphere [Trade Demo]"
   region: "NTSC-U"
 SLUS-28067:
-  name: "Shin Megami Tensei: Persona 3 [Trade Demo]"
+  name: "Shin Megami Tensei - Persona 3 [Trade Demo]"
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
 SLUS-28068:
-  name: "Shin Megami Tensei: Persona 3 FES [Trade Demo]"
+  name: "Shin Megami Tensei - Persona 3 FES [Trade Demo]"
   region: "NTSC-U"
   gsHWFixes:
     mipmap: 1
 SLUS-28069:
-  name: "Shin Megami Tensei: Persona 4 [Trade Demo]"
+  name: "Shin Megami Tensei - Persona 4 [Trade Demo]"
   region: "NTSC-U"
 SLUS-29001:
   name: "ESPN Winter Games Snowboarding [Demo]"
@@ -44377,6 +44539,8 @@ SLUS-29057:
 SLUS-29058:
   name: "Soul Calibur II [Demo]"
   region: "NTSC-U"
+  clampModes:
+    vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-29059:
@@ -44442,12 +44606,12 @@ SLUS-29081:
   gameFixes:
     - EETimingHack # Texture flicker.
   speedHacks:
-    mvuFlagSpeedHack: 0  # Fixes SPS.
+    mvuFlagSpeedHack: 0 # Fixes SPS.
 SLUS-29082:
   name: "Beyond Good and Evil [Demo]"
   region: "NTSC-U"
   roundModes:
-    eeRoundMode: 0  # Fixes SPS with water in some places.
+    eeRoundMode: 0 # Fixes SPS with water in some places.
   gsHWFixes:
     textureInsideRT: 1 # Fixes the shape of shadows.
     autoFlush: 1 # Fixes water rendering.
@@ -44462,9 +44626,9 @@ SLUS-29086:
   name: "FIFA Soccer 2004 [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 2  # Missing geometry with microVU.
+    vuClampMode: 2 # Missing geometry with microVU.
 SLUS-29087:
-  name: "Square Enix Sampler Disc Vol.1: Drakengard Playable Demo"
+  name: "Square Enix Sampler Disc Vol.1 - Drakengard Playable Demo"
   region: "NTSC-U"
   gameFixes:
     - SoftwareRendererFMVHack # Flickering and textures wrong.
@@ -44481,7 +44645,7 @@ SLUS-29093:
   name: "NFL Street [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Missing geometry with microVU.
+    vuClampMode: 3 # Missing geometry with microVU.
 SLUS-29095:
   name: "James Bond 007 - Everything or Nothing [Demo]"
   region: "NTSC-U"
@@ -44489,7 +44653,7 @@ SLUS-29096:
   name: "Final Night 2004 [Demo]"
   region: "NTSC-U"
 SLUS-29098:
-  name: "Square Enix Sampler Disc Vol.2: Front Mission 4 Playable Demo"
+  name: "Square Enix Sampler Disc Vol.2 - Front Mission 4 Playable Demo"
   region: "NTSC-U"
   gameFixes:
     - SoftwareRendererFMVHack # Flickering in FMV.
@@ -44527,7 +44691,7 @@ SLUS-29113:
   name: "Burnout 3 [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLUS-29116:
@@ -44588,6 +44752,8 @@ SLUS-29137:
 SLUS-29138:
   name: "Punisher, The [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLUS-29139:
   name: "Shadow of Rome [Demo]"
   region: "NTSC-U"
@@ -44622,7 +44788,7 @@ SLUS-29153:
   name: "Burnout Revenge [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting on certain objects.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
 SLUS-29154:
@@ -44682,7 +44848,7 @@ SLUS-29171:
   name: "Final Fantasy XII [Demo]"
   region: "NTSC-U"
 SLUS-29172:
-  name: "Battlefield 2: Modern Combat [Demo]"
+  name: "Battlefield 2 - Modern Combat [Demo]"
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 1
@@ -44707,11 +44873,12 @@ SLUS-29180:
   name: "Black [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 3  # Fixes SPS.
+    vuClampMode: 3 # Fixes SPS.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Properly diffuses light instead of strips of light.
+    roundSprite: 2 # Fixes lighting misalignment such as the street poles and the sun.
 SLUS-29183:
-  name: "Fight Night: Round 3 [Demo]"
+  name: "Fight Night - Round 3 [Demo]"
   region: "NTSC-U"
 SLUS-29185:
   name: "Driver - Parallel Lines [Demo]"
@@ -44726,7 +44893,7 @@ SLUS-29191:
   name: "Hitman - Blood Money & Urban Chaos [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0  # Fixes bump mapping issues
+    vuClampMode: 0 # Fixes bump mapping issues
 SLUS-29192:
   name: "Test Drive Unlimited [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -44739,7 +44906,7 @@ SLUS-29193:
   name: "Need for Speed - Carbon [Demo]"
   region: "NTSC-U"
   clampModes:
-    eeClampMode: 3  # Fixes game hang after opening intro.
+    eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-29194:
@@ -44775,7 +44942,7 @@ SLUS-97405:
   name: "ATV Offroad Fury 3 [Greatest Hits]"
   region: "NTSC-U"
 SLUS-97657:
-  name: "MLB 11: The Show"
+  name: "MLB 11 - The Show"
   region: "NTSC-U"
   compat: 5
 TCES-10001:
@@ -44795,11 +44962,11 @@ TCES-52004:
   name: "Killzone Beta Trial Code"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0  # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 TCES-52033:
-  name: "Syphon Filter: The Omega Strain Beta Trial Code"
+  name: "Syphon Filter - The Omega Strain Beta Trial Code"
   region: "PAL-E"
   gameFixes:
     - EETimingHack # Fixes random hangs.
@@ -44815,7 +44982,8 @@ TCES-52456:
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
   gsHWFixes:
-    mipmap: 1
+    mipmap: 1 # Fixes garbage textures in the distance.
+    disablePartialInvalidation: 1 # Prevents the situation that a level (Aquatos) doesn't render characters and geometry.
 TCES-52582:
   name: "Everybody's Golf 4 Beta Trial Code"
   region: "PAL-E"
@@ -44823,7 +44991,7 @@ TCES-53033:
   name: "Formula One 05 Beta Trial Code"
   region: "PAL-E"
 TCES-53247:
-  name: "WRC: Rally Evolved Beta Trial Code"
+  name: "WRC - Rally Evolved Beta Trial Code"
   region: "PAL-E"
   gameFixes:
     - XGKickHack # Fixes SPS.
@@ -44930,7 +45098,7 @@ TCPS-10172:
   name: "Homura [Taito the Best]"
   region: "NTSC-J"
 TLES-52149:
-  name: "Splinter Cell: Pandora Tomorrow Beta Trial Code"
+  name: "Splinter Cell - Pandora Tomorrow Beta Trial Code"
   region: "PAL-E"
 TLES-52339:
   name: "Crash ‘N’ Burn Beta Trial Code"
@@ -44939,7 +45107,7 @@ TLES-52707:
   name: "Monster Hunter Beta Trial Code"
   region: "PAL-E"
 TLES-52781:
-  name: "WWE: Smackdown Vs Raw Beta Trial Code"
+  name: "WWE - Smackdown Vs Raw Beta Trial Code"
   region: "PAL-E"
 TLES-52940:
   name: "S.L.A.I. Phantom Crash Beta Trial Code"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Original PR (comments, comparison photos): https://github.com/PCSX2/pcsx2/pull/5771

GameDB serials with ':' replaced with ' - '
+
Spacing consistent for comments
+
GS HW Fixes and other fixes for:
- Adventures of Cookie & Cream, The
- Brothers in Arms - Earned in Blood / Road to Hill 30
- Black
- Chaos Legion
- God Hand
- Knockout Kings 2001
- Kuon
- Outrun 2006 / 2 SP
- Project Eden
- Psi-Ops - The Mindgate
- Punisher, The
- Ratchet Deadlocked (USA) / Gladiator (Europe) / 3 Up Your Arsenal
- Silent Hills Origins / Shattered Memories / 3 / 4
- SoulCalibur II / III

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Windows doesn't like you to use ':' in folders this caused issues for when CK1 did savestates in folders and now it's also messing with unable to add covers in Qt so better to replace them and also to avoid other issues now and the future.

WX:
https://github.com/PCSX2/pcsx2/pull/4747
Relevant comment:
![image](https://user-images.githubusercontent.com/24227051/160301605-349cae77-9a84-40a2-bf32-16eb50771092.png)


Qt:
![image](https://user-images.githubusercontent.com/24227051/160301664-621bbc31-826f-4b4a-8b8f-5e3afde0ecfd.png)
![image](https://user-images.githubusercontent.com/24227051/160301576-70015469-6e31-48a9-b79a-7ea6809bd36f.png)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games.