### PR TITLE
GameDB: Corrected GSHW Fixes for Radiata Stories

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -730,7 +730,8 @@ SCAJ-20118:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes vertical bars, misalignment bloom effects.
+    alignSprite: 1 # Fixes vertical bars.
+    halfPixelOffset: 2 # Fixes misalignment bloom effects.
 SCAJ-20119:
   name: "Gladiator - Road to Freedom"
   region: "NTSC-Unk"
@@ -26188,7 +26189,8 @@ SLPM-65800:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes vertical bars, misalignment bloom effects.
+    alignSprite: 1 # Fixes vertical bars.
+    halfPixelOffset: 2 # Fixes misalignment bloom effects.
 SLPM-65801:
   name: "Crash Bandicoot 5"
   region: "NTSC-J"
@@ -40987,7 +40989,8 @@ SLUS-21262:
   gameFixes:
     - VuAddSubHack
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes vertical bars, misalignment bloom effects.
+    alignSprite: 1 # Fixes vertical bars.
+    halfPixelOffset: 2 # Fixes misalignment bloom effects.
 SLUS-21263:
   name: "Romancing SaGa"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
The previous fix for Radiata Stories in the GameDB resulted in white bars on the side of the screen. Setting the HalfPixelOffset to Special (Texture) instead of Normal (Vertex) in addition to activating **Align Sprite** solves this.

![2022-03-30 (5)](https://user-images.githubusercontent.com/98034944/160890496-458c18b8-3f6a-41e3-b932-d54aa3e83919.png)

### Rationale behind Changes
Better upscaling for Radiata Stories.

Fixes #5786 

### Suggested Testing Steps
-
