### PR TITLE
Various Gamefix code changes

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
@@ -42,7 +42,7 @@ AdvancedSystemSettingsWidget::AdvancedSystemSettingsWidget(SettingsDialog* dialo
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.iopRecompiler, "EmuCore/CPU/Recompiler", "EnableIOP", true);
 
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gameFixes, "", "EnableGameFixes", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gameFixes, "EmuCore", "EnableGameFixes", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.patches, "EmuCore", "EnablePatches", true);
 
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.ntscFrameRate, "EmuCore/GS", "FramerateNTSC", 59.94f);

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -929,6 +929,9 @@ struct Pcsx2Config
 #ifndef DISABLE_RECORDING
 		EnableRecordingTools : 1,
 #endif
+#ifdef PCSX2_CORE
+		EnableGameFixes : 1, // enables automatic game fixes
+#endif
 		// when enabled uses BOOT2 injection, skipping sony bios splashes
 		UseBOOT2Injection : 1,
 		BackupSavestate : 1,

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -18,6 +18,7 @@
 #include "GameDatabase.h"
 #include "Host.h"
 #include "Patch.h"
+#include "vtlb.h"
 
 #include "common/FileSystem.h"
 #include "common/Path.h"
@@ -323,6 +324,113 @@ bool GameDatabaseSchema::isUserHackHWFix(GSHWFixId id)
 		default:
 			return true;
 	}
+}
+
+u32 GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool applyAuto) const
+{
+	// Only apply core game fixes if the user has enabled them.
+	if (!applyAuto)
+		Console.Warning("[GameDB] Game Fixes are disabled");
+
+	u32 num_applied_fixes = 0;
+
+	if (eeRoundMode != GameDatabaseSchema::RoundMode::Undefined)
+	{
+		const SSE_RoundMode eeRM = (SSE_RoundMode)enum_cast(eeRoundMode);
+		if (EnumIsValid(eeRM))
+		{
+			if (applyAuto)
+			{
+				PatchesCon->WriteLn("(GameDB) Changing EE/FPU roundmode to %d [%s]", eeRM, EnumToString(eeRM));
+				config.Cpu.sseMXCSR.SetRoundMode(eeRM);
+				num_applied_fixes++;
+			}
+			else
+				PatchesCon->Warning("[GameDB] Skipping changing EE/FPU roundmode to %d [%s]", eeRM, EnumToString(eeRM));
+		}
+	}
+
+	if (vuRoundMode != GameDatabaseSchema::RoundMode::Undefined)
+	{
+		const SSE_RoundMode vuRM = (SSE_RoundMode)enum_cast(vuRoundMode);
+		if (EnumIsValid(vuRM))
+		{
+			if (applyAuto)
+			{
+				PatchesCon->WriteLn("(GameDB) Changing VU0/VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
+				config.Cpu.sseVUMXCSR.SetRoundMode(vuRM);
+				num_applied_fixes++;
+			}
+			else
+				PatchesCon->Warning("[GameDB] Skipping changing VU0/VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
+		}
+	}
+
+	if (eeClampMode != GameDatabaseSchema::ClampMode::Undefined)
+	{
+		const int clampMode = enum_cast(eeClampMode);
+		if (applyAuto)
+		{
+			PatchesCon->WriteLn("(GameDB) Changing EE/FPU clamp mode [mode=%d]", clampMode);
+			config.Cpu.Recompiler.fpuOverflow = (clampMode >= 1);
+			config.Cpu.Recompiler.fpuExtraOverflow = (clampMode >= 2);
+			config.Cpu.Recompiler.fpuFullMode = (clampMode >= 3);
+			num_applied_fixes++;
+		}
+		else
+			PatchesCon->Warning("[GameDB] Skipping changing EE/FPU clamp mode [mode=%d]", clampMode);
+	}
+
+	if (vuClampMode != GameDatabaseSchema::ClampMode::Undefined)
+	{
+		const int clampMode = enum_cast(vuClampMode);
+		if (applyAuto)
+		{
+			PatchesCon->WriteLn("(GameDB) Changing VU0/VU1 clamp mode [mode=%d]", clampMode);
+			config.Cpu.Recompiler.vuOverflow = (clampMode >= 1);
+			config.Cpu.Recompiler.vuExtraOverflow = (clampMode >= 2);
+			config.Cpu.Recompiler.vuSignOverflow = (clampMode >= 3);
+			num_applied_fixes++;
+		}
+		else
+			PatchesCon->Warning("[GameDB] Skipping changing VU0/VU1 clamp mode [mode=%d]", clampMode);
+	}
+
+	// TODO - config - this could be simplified with maps instead of bitfields and enums
+	for (const auto& it : speedHacks)
+	{
+		const bool mode = it.second != 0;
+		if (!applyAuto)
+		{
+			PatchesCon->Warning("[GameDB] Skipping setting Speedhack '%s' to [mode=%d]", EnumToString(it.first), mode);
+			continue;
+		}
+		// Legacy note - speedhacks are setup in the GameDB as integer values, but
+		// are effectively booleans like the gamefixes
+		config.Speedhacks.Set(it.first, mode);
+		PatchesCon->WriteLn("(GameDB) Setting Speedhack '%s' to [mode=%d]", EnumToString(it.first), mode);
+		num_applied_fixes++;
+	}
+
+	// TODO - config - this could be simplified with maps instead of bitfields and enums
+	for (const GamefixId id : gameFixes)
+	{
+		if (!applyAuto)
+		{
+			PatchesCon->Warning("[GameDB] Skipping Gamefix: %s", EnumToString(id));
+			continue;
+		}
+		// if the fix is present, it is said to be enabled
+		config.Gamefixes.Set(id, true);
+		PatchesCon->WriteLn("(GameDB) Enabled Gamefix: %s", EnumToString(id));
+		num_applied_fixes++;
+
+		// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB)
+		if (id == Fix_GoemonTlbMiss && true)
+			vtlb_Alloc_Ppmap();
+	}
+
+	return num_applied_fixes;
 }
 
 u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -107,6 +107,9 @@ namespace GameDatabaseSchema
 		const Patch* findPatch(const std::string_view& crc) const;
 		const char* compatAsString() const;
 
+		/// Applies Core game fixes to an existing config. Returns the number of applied fixes.
+		u32 applyGameFixes(Pcsx2Config& config, bool applyAuto) const;
+
 		/// Applies GS hardware fixes to an existing config. Returns the number of applied fixes.
 		u32 applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const;
 	};

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1061,6 +1061,9 @@ Pcsx2Config::Pcsx2Config()
 	McdEnableEjection = true;
 	McdFolderAutoManage = true;
 	EnablePatches = true;
+#ifdef PCSX2_CORE
+	EnableGameFixes = true;
+#endif
 	BackupSavestate = true;
 
 #ifdef __WXMSW__
@@ -1093,6 +1096,9 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableWideScreenPatches);
 #ifndef DISABLE_RECORDING
 	SettingsWrapBitBool(EnableRecordingTools);
+#endif
+#ifdef PCSX2_CORE
+	SettingsWrapBitBool(EnableGameFixes);
 #endif
 	SettingsWrapBitBool(ConsoleToStdio);
 	SettingsWrapBitBool(HostFs);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -248,72 +248,7 @@ void VMManager::ApplyGameFixes()
 	if (!game)
 		return;
 
-	if (game->eeRoundMode != GameDatabaseSchema::RoundMode::Undefined)
-	{
-		SSE_RoundMode eeRM = (SSE_RoundMode)enum_cast(game->eeRoundMode);
-		if (EnumIsValid(eeRM))
-		{
-			PatchesCon->WriteLn("(GameDB) Changing EE/FPU roundmode to %d [%s]", eeRM, EnumToString(eeRM));
-			EmuConfig.Cpu.sseMXCSR.SetRoundMode(eeRM);
-			s_active_game_fixes++;
-		}
-	}
-
-	if (game->vuRoundMode != GameDatabaseSchema::RoundMode::Undefined)
-	{
-		SSE_RoundMode vuRM = (SSE_RoundMode)enum_cast(game->vuRoundMode);
-		if (EnumIsValid(vuRM))
-		{
-			PatchesCon->WriteLn("(GameDB) Changing VU0/VU1 roundmode to %d [%s]", vuRM, EnumToString(vuRM));
-			EmuConfig.Cpu.sseVUMXCSR.SetRoundMode(vuRM);
-			s_active_game_fixes++;
-		}
-	}
-
-	if (game->eeClampMode != GameDatabaseSchema::ClampMode::Undefined)
-	{
-		int clampMode = enum_cast(game->eeClampMode);
-		PatchesCon->WriteLn("(GameDB) Changing EE/FPU clamp mode [mode=%d]", clampMode);
-		EmuConfig.Cpu.Recompiler.fpuOverflow = (clampMode >= 1);
-		EmuConfig.Cpu.Recompiler.fpuExtraOverflow = (clampMode >= 2);
-		EmuConfig.Cpu.Recompiler.fpuFullMode = (clampMode >= 3);
-		s_active_game_fixes++;
-	}
-
-	if (game->vuClampMode != GameDatabaseSchema::ClampMode::Undefined)
-	{
-		int clampMode = enum_cast(game->vuClampMode);
-		PatchesCon->WriteLn("(GameDB) Changing VU0/VU1 clamp mode [mode=%d]", clampMode);
-		EmuConfig.Cpu.Recompiler.vuOverflow = (clampMode >= 1);
-		EmuConfig.Cpu.Recompiler.vuExtraOverflow = (clampMode >= 2);
-		EmuConfig.Cpu.Recompiler.vuSignOverflow = (clampMode >= 3);
-		s_active_game_fixes++;
-	}
-
-	// TODO - config - this could be simplified with maps instead of bitfields and enums
-	for (const auto& it : game->speedHacks)
-	{
-		// Legacy note - speedhacks are setup in the GameDB as integer values, but
-		// are effectively booleans like the gamefixes
-		const bool mode = it.second != 0;
-		EmuConfig.Speedhacks.Set(it.first, mode);
-		PatchesCon->WriteLn("(GameDB) Setting Speedhack '%s' to [mode=%d]", EnumToString(it.first), mode);
-		s_active_game_fixes++;
-	}
-
-	// TODO - config - this could be simplified with maps instead of bitfields and enums
-	for (const GamefixId id : game->gameFixes)
-	{
-		// if the fix is present, it is said to be enabled
-		EmuConfig.Gamefixes.Set(id, true);
-		PatchesCon->WriteLn("(GameDB) Enabled Gamefix: %s", EnumToString(id));
-		s_active_game_fixes++;
-
-		// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB)
-		if (id == Fix_GoemonTlbMiss && true)
-			vtlb_Alloc_Ppmap();
-	}
-
+	s_active_game_fixes += game->applyGameFixes(EmuConfig, EmuConfig.EnableGameFixes);
 	s_active_game_fixes += game->applyGSHardwareFixes(EmuConfig.GS);
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes saving the `EnableGameFixes` option in Qt
Moves application of Game Fixes into GameEntry (where GS Hardware fixes are currently applied)
Adds logging similar to GS Hardware Fixes for Game Fixes

### Rationale behind Changes
Fix Bugs
Removes code duplication
Centralises code for applying Game/GS fixes into one file

### Suggested Testing Steps
Test if game fixes apply (or don't if disabled) in both Qt and Wx
Check toggling Game Fixes saves in Qt
