### PR TITLE
releases: simplify discord announcements, and link to the right page

### DIFF
--- a/.github/workflows/scripts/releases/announce-release/index.js
+++ b/.github/workflows/scripts/releases/announce-release/index.js
@@ -8,52 +8,16 @@ if (!releaseInfo.prerelease) {
   process.exit(0);
 }
 
-const assets = releaseInfo.assets;
-let windowsAssetLinks = "";
-let linuxAssetLinks = "";
-
-for (var i = 0; i < assets.length; i++) {
-  let asset = assets[i];
-  if (asset.name.includes("symbols")) {
-    continue;
-  }
-  if (asset.name.includes("windows")) {
-    let friendlyName = asset.name;
-    try {
-      friendlyName = asset.name.split("windows-")[1].split(".7z")[0].replace("-", " ");
-    } catch (e) {
-      console.log(e);
-    }
-    windowsAssetLinks += `- [${friendlyName}](${asset.browser_download_url})\n`
-  } else if (asset.name.includes("linux")) {
-    let friendlyName = asset.name;
-    try {
-      friendlyName = asset.name.split("linux-")[1].split(".AppImage")[0].replace("-", " ");
-    } catch (e) {
-      console.log(e);
-    }
-    linuxAssetLinks += `- [${friendlyName}](${asset.browser_download_url})\n`
-  }
-}
-
 // Publish Webhook
 const embed = new MessageEmbed()
   .setColor('#FF8000')
   .setTitle('New PCSX2 Nightly Build Available!')
+  .setDescription("To download the latest or previous builds, [visit the official downloads page](https://pcsx2.net/downloads/).")
   .addFields(
     { name: 'Version', value: releaseInfo.tag_name, inline: true },
-    { name: 'Release Link', value: `[Github Release](${releaseInfo.html_url})`, inline: true },
     { name: 'Installation Steps', value: '[See Here](https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide)', inline: true },
-    { name: 'Included Changes', value: releaseInfo.body, inline: false },
-    { name: 'Previous Builds', value: "[See Here](https://pcsx2.github.io/downloads.html#nightly-anchor)", inline: false }
+    { name: 'Included Changes', value: releaseInfo.body, inline: false }
   );
-
-if (windowsAssetLinks != "") {
-  embed.addField('Windows Downloads', windowsAssetLinks, false);
-}
-if (linuxAssetLinks != "") {
-  embed.addField('Linux Downloads', linuxAssetLinks, false);
-}
 
 const webhookClient = new WebhookClient({ url: process.env.DISCORD_BUILD_WEBHOOK });
 await webhookClient.send({


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

- Link to the new full website instead of the temporary page.
- Simplify the message, all links are organized on the website

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

- Full site is live, the temporary github.io one needs to stop being linked to so it can be shut down.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
