### PR TITLE
gitignore: Remove unused portaudio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,20 +95,6 @@ oprofile_data/
 /ipch
 
 !/3rdparty/libjpeg/change.log
-/3rdparty/portaudio/portaudio-2.0.pc
-/3rdparty/portaudio/bin
-/3rdparty/portaudio/bin-*
-/3rdparty/portaudio/autom4te.cache
-/3rdparty/portaudio/libtool
-/3rdparty/portaudio/config.*
-/3rdparty/portaudio/lib-stamp
-/3rdparty/portaudio/Makefile
-/3rdparty/portaudio/bindings
-/3rdparty/portaudio/test
-/3rdparty/portaudio/testcvs
-/3rdparty/portaudio/src/hostapi/asio/ASIOSDK/common
-/3rdparty/portaudio/src/hostapi/asio/ASIOSDK/host
-/3rdparty/portaudio/src/hostapi/wasapi/mingw-include
 /3rdparty/**/include/wx/setup.h
 /3rdparty/**/wx/msw/rcdefs.h
 /pcsx2/gui/Resources/*.h


### PR DESCRIPTION
Portaudio's been gone for a while, apparently we missed this when removing it.