### PR TITLE
EERec: Reset reliability improvements

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -393,6 +393,8 @@ struct Pcsx2Config
 		void LoadSave(SettingsWrapper& wrap);
 		void ApplySanityCheck();
 
+		bool CpusChanged(const CpuOptions& right) const;
+
 		bool operator==(const CpuOptions& right) const
 		{
 			return OpEqu(sseMXCSR) && OpEqu(sseVUMXCSR) && OpEqu(Recompiler);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -224,6 +224,14 @@ void Pcsx2Config::RecompilerOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(PreBlockCheckIOP);
 }
 
+bool Pcsx2Config::CpuOptions::CpusChanged(const CpuOptions& right) const
+{
+	return (Recompiler.EnableEE != right.Recompiler.EnableEE ||
+			Recompiler.EnableIOP != right.Recompiler.EnableIOP ||
+			Recompiler.EnableVU0 != right.Recompiler.EnableVU0 ||
+			Recompiler.EnableVU1 != right.Recompiler.EnableVU1);
+}
+
 Pcsx2Config::CpuOptions::CpuOptions()
 {
 	sseMXCSR.bitmask = DEFAULT_sseMXCSR;

--- a/pcsx2/System.cpp
+++ b/pcsx2/System.cpp
@@ -592,7 +592,10 @@ void SysCpuProviderPack::ApplyConfig() const
 // Use this method to reset the recs when important global pointers like the MTGS are re-assigned.
 void SysClearExecutionCache()
 {
+	// Done by VMManager in Qt.
+#ifndef PCSX2_CORE
 	GetCpuProviders().ApplyConfig();
+#endif
 
 	Cpu->Reset();
 	psxCpu->Reset();

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -170,25 +170,6 @@ extern wxString SysGetDiscID();
 
 extern SysMainMemory& GetVmMemory();
 
-// --------------------------------------------------------------------------------------
-//  PCSX2_SEH - Defines existence of "built in" Structured Exception Handling support.
-// --------------------------------------------------------------------------------------
-// This should be available on Windows, via Microsoft or Intel compilers (I'm pretty sure Intel
-// supports native SEH model).  GNUC in Windows, or any compiler in a non-windows platform, will
-// need to use setjmp/longjmp instead to exit recompiled code.
-// In addition, we don't currently set up SEH properly on Windows x64 so disable it there too
-//
-
-//#define PCSX2_SEH		0		// use this to force disable SEH on win32, to test setjmp functionality.
-
-#ifndef PCSX2_SEH
-#	if defined(_WIN32) && !defined(__GNUC__) && !defined(_WIN64)
-#		define PCSX2_SEH	1
-#	else
-#		define PCSX2_SEH	0
-#	endif
-#endif
-
 // special macro which disables inlining on functions that require their own function stackframe.
 // This is due to how Win32 handles structured exception handling.  Linux uses signals instead
 // of SEH, and so these functions can be inlined.


### PR DESCRIPTION
### Description of Changes

**iR5900: Exit on NeedsReset not IsReset**

This is an edge case which can be hit in Goemon, but also when changing settings in Qt, as they will be applied at guest vsync time, which is called within the JIT.

Also, do the reset before entering JIT code, rather than when the first block is compiled.

**EERec: Purge PCSX2_SEH define**

No longer needed since we don't have 32-bit.

**VMManager: Make EE rec toggles reliable**

Before, it'd swap out the Cpu while it was executing... This one only affects Qt, but now you can toggle the recompiler on and off while the game is running, and enjoy your framerate tanking.

### Rationale behind Changes

Reliability.

### Suggested Testing Steps

Make sure Goemon still works as intended, test toggling CPU options while the VM is running in Qt.