### PR TITLE
GS: Support compiling without OpenGL renderer

### DIFF
--- a/3rdparty/imgui/CMakeLists.txt
+++ b/3rdparty/imgui/CMakeLists.txt
@@ -10,9 +10,17 @@ add_library(imgui
 	imgui/imstb_rectpack.h
 	imgui/imstb_textedit.h
 	imgui/imstb_truetype.h
-	include/imgui_impl_opengl3.h
-	src/imgui_impl_opengl3.cpp
 )
+
+target_include_directories(imgui PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/imgui" "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+if(USE_OPENGL)
+	target_sources(imgui PRIVATE
+		include/imgui_impl_opengl3.h
+		src/imgui_impl_opengl3.cpp
+	)
+	target_link_libraries(imgui glad)
+endif()
 
 if(WIN32)
 	target_sources(imgui PRIVATE
@@ -20,7 +28,3 @@ if(WIN32)
 		src/imgui_impl_dx11.cpp
 	)
 endif()
-
-target_include_directories(imgui PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/imgui" "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(imgui glad)
-

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -38,6 +38,7 @@ option(USE_VTUNE "Plug VTUNE to profile GS JIT.")
 # Graphical option
 #-------------------------------------------------------------------------------
 option(BUILD_REPLAY_LOADERS "Build GS replayer to ease testing (developer option)")
+option(USE_OPENGL "Enable OpenGL GS renderer" ON)
 option(USE_VULKAN "Enable Vulkan GS renderer" ON)
 
 #-------------------------------------------------------------------------------
@@ -204,6 +205,10 @@ endif()
 
 if(USE_VTUNE)
 	list(APPEND PCSX2_DEFS ENABLE_VTUNE)
+endif()
+
+if(USE_OPENGL)
+	list(APPEND PCSX2_DEFS ENABLE_OPENGL)
 endif()
 
 if(USE_VULKAN)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -29,8 +29,10 @@ else()
 
 	# Using find_package OpenGL without either setting your opengl preference to GLVND or LEGACY
 	# is deprecated as of cmake 3.11.
-	set(OpenGL_GL_PREFERENCE GLVND)
-	find_package(OpenGL REQUIRED)
+	if(USE_OPENGL)
+		set(OpenGL_GL_PREFERENCE GLVND)
+		find_package(OpenGL REQUIRED)
+	endif()
 	find_package(PNG REQUIRED)
 	find_package(Vtune)
 
@@ -115,7 +117,9 @@ else()
 	include(CheckLib)
 
 	if(UNIX AND NOT APPLE)
-		check_lib(EGL EGL EGL/egl.h)
+		if(USE_OPENGL)
+			check_lib(EGL EGL EGL/egl.h)
+		endif()
 		if(X11_API)
 			check_lib(X11_XCB X11-xcb X11/Xlib-xcb.h)
 			check_lib(XCB xcb xcb/xcb.h)
@@ -259,9 +263,12 @@ else()
 	set(BIN2CPPDEP ${CMAKE_SOURCE_DIR}/linux_various/hex2h.pl)
 endif()
 
-add_subdirectory(3rdparty/glad EXCLUDE_FROM_ALL)
 add_subdirectory(3rdparty/simpleini EXCLUDE_FROM_ALL)
 add_subdirectory(3rdparty/imgui EXCLUDE_FROM_ALL)
+
+if(USE_OPENGL)
+	add_subdirectory(3rdparty/glad EXCLUDE_FROM_ALL)
+endif()
 
 if(USE_VULKAN)
 	add_subdirectory(3rdparty/glslang EXCLUDE_FROM_ALL)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -18,10 +18,6 @@ target_sources(common PRIVATE
 	Exceptions.cpp
 	FastFormatString.cpp
 	FastJmp.cpp
-	GL/Context.cpp
-	GL/Program.cpp
-	GL/ShaderCache.cpp
-	GL/StreamBuffer.cpp
 	FileSystem.cpp
 	IniInterface.cpp
 	Mutex.cpp
@@ -78,10 +74,6 @@ target_sources(common PRIVATE
 	FastJmp.h
 	FileSystem.h
 	General.h
-	GL/Context.h
-	GL/Program.h
-	GL/ShaderCache.h
-	GL/StreamBuffer.h
 	HashCombine.h
 	MemcpyFast.h
 	MemsetFast.inl
@@ -134,6 +126,22 @@ target_sources(common PRIVATE
 	emitter/x86types.h
 )
 
+if(USE_OPENGL)
+	target_sources(common PRIVATE
+		GL/Context.cpp
+		GL/Program.cpp
+		GL/ShaderCache.cpp
+		GL/StreamBuffer.cpp
+	)
+	target_sources(common PRIVATE
+		GL/Context.h
+		GL/Program.h
+		GL/ShaderCache.h
+		GL/StreamBuffer.h
+	)
+	target_link_libraries(common PUBLIC glad)
+endif()
+
 if(USE_VULKAN)
 	target_link_libraries(common PUBLIC
 		Vulkan-Headers glslang
@@ -176,46 +184,66 @@ if(WIN32)
 		D3D11/ShaderCache.h
 		D3D11/ShaderCompiler.cpp
 		D3D11/ShaderCompiler.h
-		GL/ContextWGL.cpp
-		GL/ContextWGL.h
 	)
-	target_link_libraries(common PUBLIC pthreads4w Winmm.lib opengl32.lib)
-elseif(APPLE)
-	target_sources(common PRIVATE
-		GL/ContextAGL.mm
-		GL/ContextAGL.h
-	)
-	set_source_files_properties(GL/ContextAGL.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
-	target_compile_options(common PRIVATE -fobjc-arc)
-	target_link_options(common PRIVATE -fobjc-link-runtime)
-else()
-	if(X11_API OR WAYLAND_API)
-		target_sources(common PRIVATE
-			GL/ContextEGL.cpp
-			GL/ContextEGL.h
-		)
-		target_link_libraries(common PRIVATE PkgConfig::EGL)
-	endif()
+endif()
 
-	if(X11_API)
+if(USE_OPENGL)
+	if(WIN32)
 		target_sources(common PRIVATE
-			GL/ContextEGLX11.cpp
-			GL/ContextEGLX11.h
+			GL/ContextWGL.cpp
+			GL/ContextWGL.h
 		)
-		target_compile_definitions(common PUBLIC "VULKAN_USE_X11=1")
-		if(TARGET PkgConfig::XRANDR)
-			target_link_libraries(common PRIVATE PkgConfig::XRANDR)
-			target_compile_definitions(common PRIVATE "HAS_XRANDR=1")
+		target_link_libraries(common PUBLIC opengl32.lib)
+	elseif(APPLE)
+		target_sources(common PRIVATE
+			GL/ContextAGL.mm
+			GL/ContextAGL.h
+		)
+		set_source_files_properties(GL/ContextAGL.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+		target_compile_options(common PRIVATE -fobjc-arc)
+		target_link_options(common PRIVATE -fobjc-link-runtime)
+	else()
+		if(X11_API OR WAYLAND_API)
+			target_sources(common PRIVATE
+				GL/ContextEGL.cpp
+				GL/ContextEGL.h
+			)
+			target_link_libraries(common PRIVATE PkgConfig::EGL)
+		endif()
+
+		if(X11_API)
+			target_sources(common PRIVATE
+				GL/ContextEGLX11.cpp
+				GL/ContextEGLX11.h
+			)
+			if(TARGET PkgConfig::XRANDR)
+				target_link_libraries(common PRIVATE PkgConfig::XRANDR)
+				target_compile_definitions(common PRIVATE "HAS_XRANDR=1")
+			endif()
+		endif()
+
+		if(WAYLAND_API)
+			target_sources(common PRIVATE
+				GL/ContextEGLWayland.cpp
+				GL/ContextEGLWayland.h
+			)
+			target_link_libraries(common PRIVATE ${WAYLAND_EGL_LIBRARIES})
 		endif()
 	endif()
+endif()
 
-	if(WAYLAND_API)
-		target_sources(common PRIVATE
-			GL/ContextEGLWayland.cpp
-			GL/ContextEGLWayland.h
-		)
-		target_link_libraries(common PRIVATE ${WAYLAND_EGL_LIBRARIES})
-		target_compile_definitions(common PUBLIC "VULKAN_USE_WAYLAND=1")
+if(USE_VULKAN)
+	if(APPLE)
+		# Needed for Metal surface creation.
+		target_compile_options(common PRIVATE -fobjc-arc)
+		target_link_options(common PRIVATE -fobjc-link-runtime)
+	elseif(NOT WIN32)
+		if(X11_API)
+			target_compile_definitions(common PUBLIC "VULKAN_USE_X11=1")
+		endif()
+		if(WAYLAND_API)
+			target_compile_definitions(common PUBLIC "VULKAN_USE_WAYLAND=1")
+		endif()
 	endif()
 endif()
 
@@ -224,7 +252,7 @@ if (USE_GCC AND CMAKE_INTERPROCEDURAL_OPTIMIZATION)
 	set_source_files_properties(FastJmp.cpp PROPERTIES COMPILE_FLAGS -fno-lto)
 endif()
 
-target_link_libraries(common PRIVATE ${LIBC_LIBRARIES} PUBLIC wxWidgets::all glad)
+target_link_libraries(common PRIVATE ${LIBC_LIBRARIES} PUBLIC wxWidgets::all)
 target_compile_features(common PUBLIC cxx_std_17)
 target_include_directories(common PUBLIC ../3rdparty/include ../)
 target_compile_definitions(common PUBLIC "${PCSX2_DEFS}")

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -24,7 +24,9 @@
 #include "pcsx2/GS/GS.h"
 #include "pcsx2/GS/GSUtil.h"
 
+#ifdef ENABLE_VULKAN
 #include "Frontend/VulkanHostDisplay.h"
+#endif
 
 #ifdef _WIN32
 #include "Frontend/D3D11HostDisplay.h"
@@ -419,9 +421,11 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 			break;
 #endif
 
+#ifdef ENABLE_VULKAN
 		case GSRendererType::VK:
 			modes = VulkanHostDisplay::StaticGetAdapterAndModeList(nullptr);
 			break;
+#endif
 
 		case GSRendererType::OGL:
 		case GSRendererType::SW:

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -43,10 +43,18 @@ static constexpr RendererInfo s_renderer_info[] = {
 	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Direct3D 11"),
 	GSRendererType::DX11,
 #endif
+#ifdef ENABLE_OPENGL
 	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "OpenGL"),
 	GSRendererType::OGL,
+#endif
+#ifdef ENABLE_VULKAN
 	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Vulkan"),
 	GSRendererType::VK,
+#endif
+#ifdef __APPLE__
+	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Metal"),
+	GSRendererType::Metal,
+#endif
 	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Software"),
 	GSRendererType::SW,
 	QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Null"),

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -50,7 +50,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;SPU2X_PORTAUDIO;DIRECTINPUT_VERSION=0x0800;PCSX2_CORE;DISABLE_RECORDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_OPENGL;ENABLE_VULKAN;DIRECTINPUT_VERSION=0x0800;PCSX2_CORE;DISABLE_RECORDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Devel))">PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Release))">NDEBUG;_SECURE_SCL_=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -699,10 +699,6 @@ set(pcsx2GSSources
 	GS/Renderers/SW/GSSetupPrimCodeGenerator.all.cpp
 	GS/Renderers/SW/GSTextureCacheSW.cpp
 	GS/Renderers/SW/GSTextureSW.cpp
-	GS/Renderers/OpenGL/GLLoader.cpp
-	GS/Renderers/OpenGL/GLState.cpp
-	GS/Renderers/OpenGL/GSDeviceOGL.cpp
-	GS/Renderers/OpenGL/GSTextureOGL.cpp
 	GS/Window/GSSetting.cpp
 	)
 
@@ -767,15 +763,27 @@ set(pcsx2GSHeaders
 	GS/Renderers/SW/GSTextureCacheSW.h
 	GS/Renderers/SW/GSTextureSW.h
 	GS/Renderers/SW/GSVertexSW.h
-	GS/Renderers/OpenGL/GLLoader.h
-	GS/Renderers/OpenGL/GLState.h
-	GS/Renderers/OpenGL/GSDeviceOGL.h
-	GS/Renderers/OpenGL/GSTextureOGL.h
-	GS/Renderers/OpenGL/GSUniformBufferOGL.h
 	GS/Window/GSCaptureDlg.h
 	GS/Window/GSDialog.h
 	GS/Window/GSSetting.h
 	)
+
+if(USE_OPENGL)
+	list(APPEND pcsx2GSSources
+		GS/Renderers/OpenGL/GLLoader.cpp
+		GS/Renderers/OpenGL/GLState.cpp
+		GS/Renderers/OpenGL/GSDeviceOGL.cpp
+		GS/Renderers/OpenGL/GSTextureOGL.cpp
+	)
+	list(APPEND pcsx2GSHeaders
+		GS/Renderers/OpenGL/GLLoader.h
+		GS/Renderers/OpenGL/GLState.h
+		GS/Renderers/OpenGL/GSDeviceOGL.h
+		GS/Renderers/OpenGL/GSTextureOGL.h
+		GS/Renderers/OpenGL/GSUniformBufferOGL.h
+	)
+	target_link_libraries(PCSX2_FLAGS INTERFACE glad)
+endif()
 
 if(USE_VULKAN)
 	list(APPEND pcsx2GSSources
@@ -984,14 +992,21 @@ set(pcsx2DebugToolsHeaders
 # Frontend sources
 set(pcsx2FrontendSources
 	Frontend/ImGuiManager.cpp
-	Frontend/OpenGLHostDisplay.cpp
 )
 
 # Frontend headers
 set(pcsx2FrontendHeaders
 	Frontend/ImGuiManager.h
-	Frontend/OpenGLHostDisplay.h
 )
+
+if(USE_OPENGL)
+	list(APPEND pcsx2FrontendSources
+		Frontend/OpenGLHostDisplay.cpp
+	)
+	list(APPEND pcsx2FrontendHeaders
+		Frontend/OpenGLHostDisplay.h
+	)
+endif()
 
 if(USE_VULKAN)
 	list(APPEND pcsx2FrontendSources
@@ -1579,7 +1594,6 @@ endif()
 
 target_link_libraries(PCSX2_FLAGS INTERFACE
 	common
-	glad
 	imgui
 	fmt::fmt
 	ryml

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -190,14 +190,30 @@ CRCHackLevel GSUtil::GetRecommendedCRCHackLevel(GSRendererType type)
 
 GSRendererType GSUtil::GetPreferredRenderer()
 {
-#ifdef __APPLE__
+#if defined(__APPLE__)
+	// Mac: Prefer Metal hardware.
 	return GSRendererType::Metal;
-#endif
-#ifdef _WIN32
+#elif defined(_WIN32)
+#if defined(ENABLE_OPENGL)
+	// Windows: Prefer GL if available.
 	if (D3D::ShouldPreferD3D())
 		return GSRendererType::DX11;
+	else
+		return GSRendererType::OGL;
+#else
+	// DX11 is always available, otherwise.
+	return GSRendererType::DX11;
 #endif
+#else
+	// Linux: Prefer GL/Vulkan, whatever is available.
+#if defined(ENABLE_OPENGL)
 	return GSRendererType::OGL;
+#elif defined(ENABLE_VULKAN)
+	return GSRendererType::Vulkan;
+#else
+	return GSRendererType::SW;
+#endif
+#endif
 }
 
 #ifdef _WIN32

--- a/pcsx2/HostDisplay.cpp
+++ b/pcsx2/HostDisplay.cpp
@@ -124,7 +124,9 @@ std::string HostDisplay::GetFullscreenModeString(u32 width, u32 height, float re
 	return StringUtil::StdStringFromFormat("%u x %u @ %f hz", width, height, refresh_rate);
 }
 
+#ifdef ENABLE_OPENGL
 #include "Frontend/OpenGLHostDisplay.h"
+#endif
 
 #ifdef ENABLE_VULKAN
 #include "Frontend/VulkanHostDisplay.h"
@@ -148,9 +150,11 @@ std::unique_ptr<HostDisplay> HostDisplay::CreateDisplayForAPI(RenderAPI api)
 			return std::unique_ptr<HostDisplay>(MakeMetalHostDisplay());
 #endif
 
+#ifdef ENABLE_OPENGL
 		case RenderAPI::OpenGL:
 		case RenderAPI::OpenGLES:
 			return std::make_unique<OpenGLHostDisplay>();
+#endif
 
 #ifdef ENABLE_VULKAN
 		case RenderAPI::Vulkan:

--- a/pcsx2/gui/AppHost.cpp
+++ b/pcsx2/gui/AppHost.cpp
@@ -27,10 +27,6 @@
 
 #include "common/Assertions.h"
 #include "Frontend/ImGuiManager.h"
-#include "Frontend/OpenGLHostDisplay.h"
-#ifdef _WIN32
-#include "Frontend/D3D11HostDisplay.h"
-#endif
 
 #include "gui/App.h"
 #include "gui/AppHost.h"

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -48,7 +48,7 @@
       <ForcedIncludeFiles>PrecompiledHeader.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/Zc:externConstexpr %(AdditionalOptions)</AdditionalOptions>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_VULKAN;SPU2X_CUBEB;DIRECTINPUT_VERSION=0x0800;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_OPENGL;ENABLE_VULKAN;SPU2X_CUBEB;DIRECTINPUT_VERSION=0x0800;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Devel))">PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Release))">NDEBUG;_SECURE_SCL_=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -52,7 +52,7 @@
       <ForcedIncludeFiles>PrecompiledHeader.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/Zc:externConstexpr %(AdditionalOptions)</AdditionalOptions>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_VULKAN;SPU2X_CUBEB;SDL_BUILD;PCSX2_CORE;DISABLE_RECORDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_OPENGL;ENABLE_VULKAN;SPU2X_CUBEB;SDL_BUILD;PCSX2_CORE;DISABLE_RECORDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Devel))">PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Release))">NDEBUG;_SECURE_SCL_=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
### Description of Changes

Mainly relevant for Macs, but also if someone ever does a UWP port.

### Rationale behind Changes

Reducing binary size when it's unnecessary.

### Suggested Testing Steps

Try building with `-DUSE_OPENGL=OFF`, and make sure everything works.
