### PR TITLE
GS: Add interlace override to gamedb, revert earlier change

### DIFF
--- a/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
+++ b/.github/workflows/scripts/validation/lint-gamedb/lint-gamedb.py
@@ -58,6 +58,7 @@ allowed_gs_hw_fixes = [
     "halfPixelOffset",
     "roundSprite",
     "texturePreloading",
+    "interlace",
 ]
 gs_hw_fix_ranges = {
     "mipmap": (0, 2),
@@ -66,6 +67,7 @@ gs_hw_fix_ranges = {
     "skipDrawEnd": (0, 100000),
     "halfPixelOffset": (0, 3),
     "roundSprite": (0, 2),
+    "interlace": (0, 7),
 }
 allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack", "MTVUSpeedHack"]
 # Patches are allowed to have a 'default' key or a crc-32 key, followed by

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2744,6 +2744,8 @@ SCES-51159:
 SCES-51164:
   name: "Mark of Kri, The"
   region: "PAL-M5"
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SCES-51176:
   name: "Disney's Treasure Planet"
   region: "PAL-M4"
@@ -6179,6 +6181,8 @@ SCUS-97140:
   name: "Mark of Kri, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
   patches:
     DBD09DD4:
       content: |-
@@ -6399,6 +6403,8 @@ SCUS-97200:
 SCUS-97201:
   name: "Mark of Kri, The"
   region: "NTSC-U"
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SCUS-97203:
   name: "Wild ARMs 3"
   region: "NTSC-U"
@@ -6477,6 +6483,8 @@ SCUS-97220:
 SCUS-97222:
   name: "Mark of Kri [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SCUS-97223:
   name: "NFL GameDay 2003 [Demo]"
   region: "NTSC-U"
@@ -15808,6 +15816,8 @@ SLES-53621:
   name: "Wallace & Grommit - The Curse of the Were Rabbit"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SLES-53623:
   name: "Spongebob SquarePants - Battle for Bikini Bottom"
   region: "PAL-F"
@@ -24763,6 +24773,8 @@ SLPM-65309:
 SLPM-65310:
   name: "Mark of Kri, The"
   region: "NTSC-J"
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SLPM-65311:
   name: "Violet no Atelier - Gramnad no Renkinjutsushi"
   region: "NTSC-J"
@@ -28059,6 +28071,8 @@ SLPM-66325:
 SLPM-66327:
   name: "Wallace and Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-J"
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SLPM-66328:
   name: "Call of Duty 2 - Big Red One"
   region: "NTSC-J"
@@ -41417,6 +41431,8 @@ SLUS-21312:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    interlace: 3 # Game requires bob delinterlacing when auto
 SLUS-21313:
   name: "Friends - The One with all the Trivia"
   region: "NTSC-U"

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -40,6 +40,10 @@ SERIAL-12345: # !required! Serial number for the game, this is how games are loo
     - IbitHack
     - VUSyncHack
     - VUOverflowHack
+  # The value of the GS Fixes is assumed to be an integer
+  gsHWFixes:
+    mipmap: 1
+    preloadFrameData: 1
   # The value of the speedhacks is assumed to be an integer,
   # but at the time of writing speedhacks are effectively booleans (0/1)
   speedHacks:
@@ -139,6 +143,7 @@ The clamp modes are also numerically based.
 
 *   conservativeFramebuffer   [`0` or `1`]            {Off or On}                           Default: On (`1`)
 *   texturePreloading         [`0` or `1` or `2`]     {None, Partial or Full Hash Cache}    Default: None (`0`)
+*   interlace                 [Value between `0` to `7`]   {Off, WeaveTFF, WeaveBFF, BobTFF, BobBFF, BlendTFF, BlendBFF, Automatic}    Default: Automatic (No value, looks up GameDB)
 
 ### GS Hardware Renderer Fixes
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -276,15 +276,7 @@ bool GSRenderer::Merge(int field)
 			{
 				const int field2 = scanmask ? 0 : 1 - ((static_cast<int>(GSConfig.InterlaceMode) - 1) & 1);
 				const int offset = tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y;
-				// -1 = None
-				// 0 = Weave
-				// 1 = Bob
-				// 2 = Blend
-				int mode = scanmask ? 2 : std::clamp((static_cast<int>(GSConfig.InterlaceMode) - 1) >> 1, -1, 2);
-
-				// If we're on auto, prefer no interlacing (bob, kinda), unless there is an offset or scanmsk, then retain blend
-				if (GSConfig.InterlaceMode == GSInterlaceMode::Automatic && !(m_regs->SMODE2.FFMD) && !scanmask && !offset)
-					mode = -1;
+				int mode = scanmask ? 2 : (static_cast<int>(GSConfig.InterlaceMode) - 1) >> 1;
 
 				g_gs_device->Interlace(ds, field ^ field2, mode, offset);
 			}

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -285,6 +285,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"halfPixelOffset",
 	"roundSprite",
 	"texturePreloading",
+	"interlace",
 };
 static_assert(std::size(s_gs_hw_fix_names) == static_cast<u32>(GameDatabaseSchema::GSHWFixId::Count), "HW fix name lookup is correct size");
 
@@ -308,6 +309,7 @@ bool GameDatabaseSchema::isUserHackHWFix(GSHWFixId id)
 {
 	switch (id)
 	{
+		case GSHWFixId::Interlace:
 		case GSHWFixId::Mipmap:
 		case GSHWFixId::TexturePreloading:
 		case GSHWFixId::ConservativeFramebuffer:
@@ -435,6 +437,16 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 				if (value >= 0 && value <= static_cast<int>(TexturePreloadingLevel::Full))
 					config.TexturePreloading = std::min(config.TexturePreloading, static_cast<TexturePreloadingLevel>(value));
 			}
+			break;
+
+			case GSHWFixId::Interlace:
+				if (value >= 0 && value <= static_cast<int>(GSInterlaceMode::Automatic))
+				{
+					if (config.InterlaceMode == GSInterlaceMode::Automatic)
+						config.InterlaceMode = static_cast<GSInterlaceMode>(value);
+					else
+						Console.Warning("[GameDB] Game requires different interlace mode but it has been overridden by user setting.");
+				}
 			break;
 
 			default:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -81,6 +81,7 @@ namespace GameDatabaseSchema
 		HalfPixelOffset,
 		RoundSprite,
 		TexturePreloading,
+		Interlace,
 
 		Count
 	};


### PR DESCRIPTION
### Description of Changes
Added "interlace" as an option to the gamedb for overriding the automatic interlacing mode for some games which don't work so well with the default automatic setting.

### Rationale behind Changes
Previous change made it alway use Blend, which is technically more correct, but we lost the free progressive style deinterlacing we had previously, however some games don't like it, but there's no easy way to detect it.

### Suggested Testing Steps
test games for shakey shakey.  Games with shakey FMV's but the rest of the game is fine, can't really do a lot about that.
