### PR TITLE
GS: Implement PCRTC offsets + 3:2 Aspect Ratio + fit to window

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -36521,12 +36521,6 @@ SLUS-20217:
   name: "Arctic Thunder"
   region: "NTSC-U"
   compat: 5
-  patches:
-    2B2E1535:
-      content: |-
-        author=kozarovv
-        // Set proper height for in game videos. Prevent videos being displayed doubled vertically.
-        patch=1,EE,0013345C,word,240701c0
 SLUS-20218:
   name: "Stunt GP"
   region: "NTSC-U"
@@ -36592,12 +36586,6 @@ SLUS-20229:
   name: "Jonny Moseley - Mad Trix"
   region: "NTSC-U"
   compat: 5
-  patches:
-    AE94FAF8:
-      content: |-
-        author=refraction
-        comment=Fixes interlacing for videos
-        patch=1,EE,0024a6f0,word,24030003
 SLUS-20230:
   name: "Max Payne"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -89,7 +89,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	// Game Display Settings
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToEnumSetting(
-		sif, m_ui.aspectRatio, "EmuCore/GS", "AspectRatio", Pcsx2Config::GSOptions::AspectRatioNames, AspectRatioType::R4_3);
+		sif, m_ui.aspectRatio, "EmuCore/GS", "AspectRatio", Pcsx2Config::GSOptions::AspectRatioNames, AspectRatioType::RAuto4_3_3_2);
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.fmvAspectRatio, "EmuCore/GS", "FMVAspectRatioSwitch",
 		Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, FMVAspectRatioSwitchType::Off);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interlacing, "EmuCore/GS", "deinterlace", DEFAULT_INTERLACE_MODE);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -95,6 +95,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interlacing, "EmuCore/GS", "deinterlace", DEFAULT_INTERLACE_MODE);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.bilinearFiltering, "EmuCore/GS", "linear_present", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.integerScaling, "EmuCore/GS", "IntegerScaling", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.PCRTCOffsets, "EmuCore/GS", "pcrtc_offsets", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.internalResolutionScreenshots, "EmuCore/GS", "InternalResolutionScreenshots", false);
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.zoom, "EmuCore/GS", "Zoom", 100.0f);
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.stretchY, "EmuCore/GS", "StretchY", 100.0f);

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>747</width>
+    <width>566</width>
     <height>890</height>
    </rect>
   </property>
@@ -261,31 +261,38 @@
        </item>
        <item row="7" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="2">
-          <widget class="QCheckBox" name="integerScaling">
-           <property name="text">
-            <string>Integer Upscaling</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
+         <item row="0" column="0">
           <widget class="QCheckBox" name="bilinearFiltering">
            <property name="text">
             <string>Bilinear Filtering</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="1" column="0">
           <widget class="QCheckBox" name="vsync">
            <property name="text">
             <string>Sync To Host Refresh (VSync)</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
+         <item row="1" column="1">
           <widget class="QCheckBox" name="internalResolutionScreenshots">
            <property name="text">
             <string>Internal Resolution Screenshots</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="integerScaling">
+           <property name="text">
+            <string>Integer Upscaling</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="PCRTCOffsets">
+           <property name="text">
+            <string>Screen Offsets</string>
            </property>
           </widget>
          </item>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -94,7 +94,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Standard (4:3)</string>
+           <string>Standard (4:3/3:2 Progressive)</string>
           </property>
          </item>
          <item>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -94,7 +94,12 @@
          </item>
          <item>
           <property name="text">
-           <string>Standard (4:3/3:2 Progressive)</string>
+           <string>Auto Standard (4:3/3:2 Progressive)</string>
+          </property>
+         </item>
+		 <item>
+          <property name="text">
+           <string>Standard (4:3)</string>
           </property>
          </item>
          <item>
@@ -116,6 +121,11 @@
          <item>
           <property name="text">
            <string>Off (Default)</string>
+          </property>
+         </item>
+		 <item>
+          <property name="text">
+           <string>Auto Standard (4:3/3:2 Progressive)</string>
           </property>
          </item>
          <item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -422,6 +422,7 @@ struct Pcsx2Config
 			struct
 			{
 				bool
+					PCRTCOffsets : 1,
 					IntegerScaling : 1,
 					LinearPresent : 1,
 					UseDebugDevice : 1,

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -73,6 +73,7 @@ enum class VsyncMode
 enum class AspectRatioType : u8
 {
 	Stretch,
+	RAuto4_3_3_2,
 	R4_3,
 	R16_9,
 	MaxCount
@@ -81,6 +82,7 @@ enum class AspectRatioType : u8
 enum class FMVAspectRatioSwitchType : u8
 {
 	Off,
+	RAuto4_3_3_2,
 	R4_3,
 	R16_9,
 	MaxCount
@@ -495,7 +497,7 @@ struct Pcsx2Config
 		double FramerateNTSC{59.94};
 		double FrameratePAL{50.00};
 
-		AspectRatioType AspectRatio{AspectRatioType::R4_3};
+		AspectRatioType AspectRatio{AspectRatioType::RAuto4_3_3_2};
 		FMVAspectRatioSwitchType FMVAspectRatioSwitch{FMVAspectRatioSwitchType::Off};
 		GSInterlaceMode InterlaceMode{GSInterlaceMode::Automatic};
 
@@ -983,7 +985,7 @@ struct Pcsx2Config
 	std::string CurrentBlockdump;
 	std::string CurrentIRX;
 	std::string CurrentGameArgs;
-	AspectRatioType CurrentAspectRatio = AspectRatioType::R4_3;
+	AspectRatioType CurrentAspectRatio = AspectRatioType::RAuto4_3_3_2;
 	LimiterModeType LimiterMode = LimiterModeType::Nominal;
 
 	Pcsx2Config();

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -464,6 +464,9 @@ static __fi void DoFMVSwitch()
 	{
 		case FMVAspectRatioSwitchType::Off:
 			break;
+		case FMVAspectRatioSwitchType::RAuto4_3_3_2:
+			EmuConfig.CurrentAspectRatio = new_fmv_state ? AspectRatioType::RAuto4_3_3_2 : EmuConfig.GS.AspectRatio;
+			break;
 		case FMVAspectRatioSwitchType::R4_3:
 			EmuConfig.CurrentAspectRatio = new_fmv_state ? AspectRatioType::R4_3 : EmuConfig.GS.AspectRatio;
 			break;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1368,7 +1368,6 @@ void GSApp::Init()
 	m_default_configuration["MaxAnisotropy"]                              = "0";
 	m_default_configuration["mipmap"]                                     = "1";
 	m_default_configuration["mipmap_hw"]                                  = std::to_string(static_cast<int>(HWMipmapLevel::Automatic));
-	m_default_configuration["NTSC_Saturation"]                            = "1";
 	m_default_configuration["OsdShowMessages"]                            = "1";
 	m_default_configuration["OsdShowSpeed"]                               = "0";
 	m_default_configuration["OsdShowFPS"]                                 = "0";

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1359,6 +1359,7 @@ void GSApp::Init()
 	m_default_configuration["FMVSoftwareRendererSwitch"]                  = "0";
 	m_default_configuration["fxaa"]                                       = "0";
 	m_default_configuration["HWDisableReadbacks"]                         = "0";
+	m_default_configuration["pcrtc_offsets"]                              = "0";
 	m_default_configuration["IntegerScaling"]                             = "0";
 	m_default_configuration["deinterlace"]                                = "7";
 	m_default_configuration["conservative_framebuffer"]                   = "1";

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -671,6 +671,13 @@ void GSsetFrameSkip(int frameskip)
 	s_gs->SetFrameSkip(frameskip);
 }
 
+GSVideoMode GSgetDisplayMode()
+{
+	GSRenderer* gs = s_gs.get();
+
+	return gs->GetVideoMode();
+}
+
 void GSgetInternalResolution(int* width, int* height)
 {
 	GSRenderer* gs = s_gs.get();

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -81,6 +81,7 @@ void GSendRecording();
 void GSsetGameCRC(u32 crc, int options);
 void GSsetFrameSkip(int frameskip);
 
+GSVideoMode GSgetDisplayMode();
 void GSgetInternalResolution(int* width, int* height);
 void GSgetStats(std::string& info);
 void GSgetTitleStats(std::string& info);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -52,7 +52,6 @@ GSState::GSState()
 	// Let's keep it disabled to ease debug.
 	m_nativeres = GSConfig.UpscaleMultiplier == 1;
 	m_mipmap = GSConfig.Mipmap;
-	m_NTSC_Saturation = theApp.GetConfigB("NTSC_Saturation");
 
 	s_n = 0;
 	s_dump = theApp.GetConfigB("dump");

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -258,6 +258,29 @@ public:
 	PRIM_OVERLAP m_prim_overlap;
 	std::vector<size_t> m_drawlist;
 
+	// The horizontal offset values (under z) for PAL and NTSC have been tweaked
+	// they should be apparently 632 and 652 respectively, but that causes a thick black line on the left
+	// these values leave a small black line on the right in a bunch of games, but it's not so bad.
+	// The only conclusion I can come to is there is horizontal overscan expected so there would normally
+	// be black borders either side anyway, or both sides slightly covered.
+	const GSVector4i VideoModeOffsets[6] = {
+		GSVector4i(640, 224, 642, 25),
+		GSVector4i(640, 256, 676, 36),
+		GSVector4i(640, 480, 276, 34),
+		GSVector4i(720, 480, 232, 35),
+		GSVector4i(1280, 720, 302, 24),
+		GSVector4i(1920, 540, 238, 40)
+	};
+
+	const GSVector4i VideoModeDividers[6] = {
+		GSVector4i(3, 0, 2559, 239),
+		GSVector4i(3, 0, 2559, 287),
+		GSVector4i(1, 0, 1279, 479),
+		GSVector4i(1, 0, 1439, 479),
+		GSVector4i(0, 0, 1279, 719),
+		GSVector4i(0, 0, 1919, 1079)
+	};
+
 public:
 	GSState();
 	virtual ~GSState();
@@ -265,13 +288,16 @@ public:
 	void ResetHandlers();
 
 	int GetFramebufferHeight();
-	void SaturateOutputSize(GSVector4i& r);
 	GSVector4i GetDisplayRect(int i = -1);
+	GSVector4i GetDisplayRectSize(int i = -1);
+	GSVector2i GetResolutionOffset(int i = -1);
+	GSVector2i GetResolution();
 	GSVector4i GetFrameRect(int i = -1);
 	GSVideoMode GetVideoMode();
 
 	bool IsEnabled(int i);
 	bool isinterlaced();
+	bool IsAnalogue();
 
 	float GetTvRefreshRate();
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -289,9 +289,9 @@ public:
 
 	int GetFramebufferHeight();
 	GSVector4i GetDisplayRect(int i = -1);
-	GSVector4i GetDisplayRectSize(int i = -1);
+	GSVector4i GetDisplayMagnifiedRect(int i = -1);
 	GSVector2i GetResolutionOffset(int i = -1);
-	GSVector2i GetResolution();
+	GSVector2i GetResolution(bool include_interlace = false);
 	GSVector4i GetFrameRect(int i = -1);
 	GSVideoMode GetVideoMode();
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -231,7 +231,6 @@ public:
 	std::unique_ptr<GSDumpBase> m_dump;
 	int m_options;
 	int m_frameskip;
-	bool m_NTSC_Saturation;
 	bool m_nativeres;
 	bool m_mipmap;
 	bool m_primflush;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -289,9 +289,9 @@ public:
 
 	int GetFramebufferHeight();
 	GSVector4i GetDisplayRect(int i = -1);
-	GSVector4i GetDisplayMagnifiedRect(int i = -1);
+	GSVector4i GetFrameMagnifiedRect(int i = -1);
 	GSVector2i GetResolutionOffset(int i = -1);
-	GSVector2i GetResolution(bool include_interlace = false);
+	GSVector2i GetResolution();
 	GSVector4i GetFrameRect(int i = -1);
 	GSVideoMode GetVideoMode();
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -367,7 +367,7 @@ bool GSRenderer::Merge(int field)
 	}
 	if (tex[0] || tex[1])
 	{
-		if (tex[0] == tex[1] && !slbg && (src[0] == src[1] & dst[0] == dst[1]).alltrue() && !feedback_merge)
+		if ((tex[0] == tex[1]) && (src[0] == src[1]).alltrue() && (dst[0] == dst[1]).alltrue() && !feedback_merge && !slbg)
 		{
 			// the two outputs are identical, skip drawing one of them (the one that is alpha blended)
 
@@ -424,8 +424,8 @@ GSVector2i GSRenderer::GetInternalResolution()
 
 static float GetCurrentAspectRatioFloat(bool is_progressive)
 {
-	static constexpr std::array<float, static_cast<size_t>(AspectRatioType::MaxCount) + 1> ars = { {4.0f / 3.0f, 4.0f / 3.0f, 16.0f / 9.0f, 3.0f / 2.0f} };
-	return ars[static_cast<u32>(GSConfig.AspectRatio) + (3u * is_progressive)];
+	static constexpr std::array<float, static_cast<size_t>(AspectRatioType::MaxCount) + 1> ars = { {4.0f / 3.0f, 4.0f / 3.0f, 4.0f / 3.0f, 16.0f / 9.0f, 3.0f / 2.0f} };
+	return ars[static_cast<u32>(GSConfig.AspectRatio) + (3u * (is_progressive && GSConfig.AspectRatio == AspectRatioType::RAuto4_3_3_2))];
 }
 
 static GSVector4 CalculateDrawRect(s32 window_width, s32 window_height, s32 texture_width, s32 texture_height, HostDisplay::Alignment alignment, bool flip_y, bool is_progressive)
@@ -435,12 +435,16 @@ static GSVector4 CalculateDrawRect(s32 window_width, s32 window_height, s32 text
 	const float clientAr = f_width / f_height;
 
 	float targetAr = clientAr;
-	if (EmuConfig.CurrentAspectRatio == AspectRatioType::R4_3)
+	if (EmuConfig.CurrentAspectRatio == AspectRatioType::RAuto4_3_3_2)
 	{
 		if (is_progressive)
 			targetAr = 3.0f / 2.0f;
 		else
 			targetAr = 4.0f / 3.0f;
+	}
+	else if (EmuConfig.CurrentAspectRatio == AspectRatioType::R4_3)
+	{
+		targetAr = 4.0f / 3.0f;
 	}
 	else if (EmuConfig.CurrentAspectRatio == AspectRatioType::R16_9)
 		targetAr = 16.0f / 9.0f;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -340,17 +340,17 @@ bool GSRenderer::Merge(int field)
 			off.y /= 2;
 
 		// src_gs_read is the size which we're really reading from GS memory.
-		src_gs_read[i] = (GSVector4(fr[i]) + GSVector4(0, y_offset[i], 0, y_offset[i])) * scale / GSVector4(tex[i]->GetSize()).xyxy();
+		src_gs_read[i] = ((GSVector4(fr[i]) + GSVector4(0, y_offset[i], 0, y_offset[i])) * scale) / GSVector4(tex[i]->GetSize()).xyxy();
 
 		// src_out_rect is the resized rect for output.
-		src_out_rect[i] = GSVector4(r) * scale / GSVector4(tex[i]->GetSize()).xyxy();
+		src_out_rect[i] = (GSVector4(r) * scale) / GSVector4(tex[i]->GetSize()).xyxy();
 
 		// dst is the final destination rect with offset on the screen.
 		dst[i] = scale * (GSVector4(off).xyxy() + GSVector4(r.rsize()));
 
 		// Restore the single line offset for scanmsk.
 		if (m_scanmask_used && interlace_offset)
-			dst[i] -= GSVector4(0.0f, 1.0f, 0.0f, 1.0f);
+			dst[i] += GSVector4(0.0f, 1.0f, 0.0f, 1.0f);
 	}
 
 	if (feedback_merge && tex[2])

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -715,13 +715,13 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	{
 		// 2nd output is enabled and selected. Copy it to destination so we can blend it with 1st output
 		// Note: value outside of dRect must contains the background color (c)
-		StretchRect(sTex[1], sRect[1], dTex, dRect[1], ShaderConvert::COPY);
+		StretchRect(sTex[1], sRect[1], dTex, PMODE.SLBG ? dRect[2] : dRect[1], ShaderConvert::COPY);
 	}
 
 	// Save 2nd output
 	if (feedback_write_2)
 	{
-		StretchRect(dTex, full_r, sTex[2], dRect[1], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
+		StretchRect(dTex, full_r, sTex[2], dRect[2], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
 			m_merge.cb.get(), nullptr, true);
 	}
 
@@ -737,7 +737,7 @@ void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 	if (feedback_write_1)
 	{
-		StretchRect(dTex, full_r, sTex[2], dRect[0], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
+		StretchRect(sTex[0], full_r, sTex[2], dRect[2], m_convert.ps[static_cast<int>(ShaderConvert::YUV)].get(),
 			m_merge.cb.get(), nullptr, true);
 	}
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -256,7 +256,7 @@ GSTexture* GSRendererHW::GetFeedbackOutput()
 	TEX0.TBW = m_regs->EXTBUF.EXBW;
 	TEX0.PSM = m_regs->DISP[m_regs->EXTBUF.FBIN & 1].DISPFB.PSM;
 
-	GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, GetTargetSize(), /*GetFrameRect(i).bottom*/ 0);
+	GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, GetTargetSize(), /*GetFrameRect(i).bottom*/ m_regs->DISP[m_regs->EXTBUF.FBIN & 1].DISPLAY.DH);
 
 	GSTexture* t = rt->m_texture;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -41,7 +41,7 @@ GSRendererHW::GSRendererHW()
 
 void GSRendererHW::SetScaling()
 {
-	const GSVector2i crtc_size(GetDisplayRect().width(), GetDisplayRect().height());
+	const GSVector2i crtc_size(GetResolution());
 
 	// Details of (potential) perf impact of a big framebuffer
 	// 1/ extra memory

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1325,7 +1325,7 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 	{
 		// 2nd output is enabled and selected. Copy it to destination so we can blend it with 1st output
 		// Note: value outside of dRect must contains the background color (c)
-		StretchRect(sTex[1], sRect[1], dTex, dRect[1], ShaderConvert::COPY);
+		StretchRect(sTex[1], sRect[1], dTex, PMODE.SLBG ? dRect[2] : dRect[1], ShaderConvert::COPY);
 	}
 
 	// Upload constant to select YUV algo
@@ -1337,8 +1337,8 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 	}
 
 	// Save 2nd output
-	if (feedback_write_2) // FIXME I'm not sure dRect[1] is always correct
-		StretchRect(dTex, full_r, sTex[2], dRect[1], ShaderConvert::YUV);
+	if (feedback_write_2)
+		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV);
 
 	// Restore background color to process the normal merge
 	if (feedback_write_2_but_blend_bg)
@@ -1364,8 +1364,8 @@ void GSDeviceOGL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 		}
 	}
 
-	if (feedback_write_1) // FIXME I'm not sure dRect[0] is always correct
-		StretchRect(dTex, full_r, sTex[2], dRect[0], ShaderConvert::YUV);
+	if (feedback_write_1)
+		StretchRect(dTex, full_r, sTex[2], dRect[2], ShaderConvert::YUV);
 }
 
 void GSDeviceOGL::DoInterlace(GSTexture* sTex, GSTexture* dTex, int shader, bool linear, float yoffset)

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.h
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.h
@@ -71,7 +71,7 @@ protected:
 	IRasterizer* m_rl;
 	GSRingHeap m_vertex_heap;
 	GSTextureCacheSW* m_tc;
-	GSTexture* m_texture[2];
+	GSTexture* m_texture[3];
 	u8* m_output;
 	GSPixelOffset4* m_fzb;
 	GSVector4i m_fzb_bbox;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -763,7 +763,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 			SetUtilityTexture(sTex[1], m_linear_sampler);
 			BeginClearRenderPass(m_utility_color_render_pass_clear, darea, c);
 			SetPipeline(m_convert[static_cast<int>(ShaderConvert::COPY)]);
-			DrawStretchRect(sRect[1], dRect[1], dsize);
+			DrawStretchRect(sRect[1], PMODE.SLBG ? dRect[2] : dRect[1], dsize);
 			dTex->SetState(GSTexture::State::Dirty);
 			dcleared = true;
 		}
@@ -772,20 +772,19 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	// Upload constant to select YUV algo
 	const GSVector2i fbsize(sTex[2] ? sTex[2]->GetSize() : GSVector2i(0, 0));
 	const GSVector4i fbarea(0, 0, fbsize.x, fbsize.y);
-	if (feedback_write_2)// FIXME I'm not sure dRect[1] is always correct
+	if (feedback_write_2)
 	{
 		EndRenderPass();
 		OMSetRenderTargets(sTex[2], nullptr, fbarea, false);
 		if (dcleared)
 			SetUtilityTexture(dTex, m_linear_sampler);
-
 		// sTex[2] can be sTex[0], in which case it might be cleared (e.g. Xenosaga).
-		BeginRenderPassForStretchRect(static_cast<GSTextureVK*>(sTex[2]), fbarea, GSVector4i(dRect[1]));
+		BeginRenderPassForStretchRect(static_cast<GSTextureVK*>(sTex[2]), fbarea, GSVector4i(dRect[2]));
 		if (dcleared)
 		{
 			SetPipeline(m_convert[static_cast<int>(ShaderConvert::YUV)]);
 			SetUtilityPushConstants(yuv_constants, sizeof(yuv_constants));
-			DrawStretchRect(full_r, dRect[1], fbsize);
+			DrawStretchRect(full_r, dRect[2], fbsize);
 		}
 		EndRenderPass();
 
@@ -818,7 +817,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		DrawStretchRect(sRect[0], dRect[0], dTex->GetSize());
 	}
 
-	if (feedback_write_1) // FIXME I'm not sure dRect[0] is always correct
+	if (feedback_write_1)
 	{
 		EndRenderPass();
 		SetPipeline(m_convert[static_cast<int>(ShaderConvert::YUV)]);
@@ -826,7 +825,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		SetUtilityPushConstants(yuv_constants, sizeof(yuv_constants));
 		OMSetRenderTargets(sTex[2], nullptr, fbarea, false);
 		BeginRenderPass(m_utility_color_render_pass_load, fbarea);
-		DrawStretchRect(full_r, dRect[0], dsize);
+		DrawStretchRect(full_r, dRect[2], dsize);
 	}
 
 	EndRenderPass();

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -89,6 +89,10 @@ const char* dialog_message(int ID, bool* updateText)
 			return cvtString("Enabled: GPU converts colormap-textures.\n"
 				"Disabled: CPU converts colormap-textures.\n\n"
 				"It is a trade-off between GPU and CPU.");
+		case IDC_PCRTC_OFFSETS:
+			return cvtString("Enable: Takes in to account offsets in the analogue circuits.\n"
+				"This will use the intended aspect ratios and screen offsets, may cause odd black borders.\n"
+				"Used for screen positioning and screen shake in Wipeout Fusion.");
 		case IDC_ACCURATE_DATE:
 			return cvtString("Implement a more accurate algorithm to compute GS destination alpha testing.\n"
 				"It improves shadow and transparency rendering.\n\n"

--- a/pcsx2/GS/Window/GSSetting.h
+++ b/pcsx2/GS/Window/GSSetting.h
@@ -42,6 +42,7 @@ enum
 {
 	// Renderer
 	IDC_FILTER,
+	IDC_PCRTC_OFFSETS,
 	// Hardware Renderer
 	IDC_PRELOAD_TEXTURES,
 	IDC_ACCURATE_DATE,

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -276,6 +276,7 @@ RendererTab::RendererTab(wxWindow* parent)
 	auto upscale_prereq = [this]{ return !m_is_native_res; };
 
 	PaddedBoxSizer<wxBoxSizer> tab_box(wxVERTICAL);
+	PaddedBoxSizer<wxStaticBoxSizer> general_box(wxVERTICAL, this, "General GS Settings");
 	PaddedBoxSizer<wxStaticBoxSizer> hardware_box(wxVERTICAL, this, "Hardware Mode");
 	PaddedBoxSizer<wxStaticBoxSizer> software_box(wxVERTICAL, this, "Software Mode");
 
@@ -315,8 +316,16 @@ RendererTab::RendererTab(wxWindow* parent)
 	m_ui.addSpinAndLabel(thread_box, "Extra Rendering threads:", "extrathreads", 0, 32, 2, IDC_SWTHREADS, sw_prereq);
 	software_box->Add(thread_box, wxSizerFlags().Centre());
 
+	// General GS Settings box
+	auto* pcrtc_checks_box = new wxWrapSizer(wxHORIZONTAL);
+
+	m_ui.addCheckBox(pcrtc_checks_box, "Screen Offsets", "pcrtc_offsets", IDC_PCRTC_OFFSETS);
+
+	general_box->Add(pcrtc_checks_box, wxSizerFlags().Center());
+
 	tab_box->Add(hardware_box.outer, wxSizerFlags().Expand());
 	tab_box->Add(software_box.outer, wxSizerFlags().Expand());
+	tab_box->Add(general_box.outer, wxSizerFlags().Expand());
 
 	SetSizerAndFit(tab_box.outer);
 }

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -292,6 +292,7 @@ Pcsx2Config::GSOptions::GSOptions()
 {
 	bitset = 0;
 
+	PCRTCOffsets = false;
 	IntegerScaling = false;
 	LinearPresent = true;
 	UseDebugDevice = false;
@@ -501,6 +502,8 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 
 	// Unfortunately, because code in the GS still reads the setting by key instead of
 	// using these variables, we need to use the old names. Maybe post 2.0 we can change this.
+
+	GSSettingBoolEx(PCRTCOffsets, "pcrtc_offsets");
 	GSSettingBool(IntegerScaling);
 	GSSettingBoolEx(LinearPresent, "linear_present");
 	GSSettingBool(UseDebugDevice);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -263,13 +263,13 @@ void Pcsx2Config::CpuOptions::LoadSave(SettingsWrapper& wrap)
 
 const char* Pcsx2Config::GSOptions::AspectRatioNames[] = {
 	"Stretch",
-	"4:3",
+	"4:3/3:2 (Progressive)",
 	"16:9",
 	nullptr};
 
 const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[] = {
 	"Off",
-	"4:3",
+	"4:3/3:2 (Progressive)",
 	"16:9",
 	nullptr};
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -263,13 +263,15 @@ void Pcsx2Config::CpuOptions::LoadSave(SettingsWrapper& wrap)
 
 const char* Pcsx2Config::GSOptions::AspectRatioNames[] = {
 	"Stretch",
-	"4:3/3:2 (Progressive)",
+	"Auto 4:3/3:2",
+	"4:3",
 	"16:9",
 	nullptr};
 
 const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[] = {
 	"Off",
-	"4:3/3:2 (Progressive)",
+	"Auto 4:3/3:2",
+	"4:3",
 	"16:9",
 	nullptr};
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -270,16 +270,22 @@ void VMManager::RequestDisplaySize(float scale /*= 0.0f*/)
 	float x_scale;
 	switch (GSConfig.AspectRatio)
 	{
-	case AspectRatioType::R4_3:
-		x_scale = (4.0f / 3.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
-		break;
-	case AspectRatioType::R16_9:
-		x_scale = (16.0f / 9.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
-		break;
-	case AspectRatioType::Stretch:
-	default:
-		x_scale = 1.0f;
-		break;
+		case AspectRatioType::RAuto4_3_3_2:
+			if (GSgetDisplayMode() == GSVideoMode::SDTV_480P)
+				x_scale = (3.0f / 2.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
+			else
+				x_scale = (4.0f / 3.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
+			break;
+		case AspectRatioType::R4_3:
+			x_scale = (4.0f / 3.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
+			break;
+		case AspectRatioType::R16_9:
+			x_scale = (16.0f / 9.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
+			break;
+		case AspectRatioType::Stretch:
+		default:
+			x_scale = 1.0f;
+			break;
 	}
 
 	float width = static_cast<float>(iwidth) * x_scale;

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -874,7 +874,7 @@ void AppConfig::GSWindowOptions::LoadSave(IniInterface& ini)
 	static const wxChar* AspectRatioNames[] =
 		{
 			L"Stretch",
-			L"4:3",
+			L"4:3/3:2 (Progressive)",
 			L"16:9",
 			// WARNING: array must be NULL terminated to compute it size
 			NULL};
@@ -886,7 +886,7 @@ void AppConfig::GSWindowOptions::LoadSave(IniInterface& ini)
 	static const wxChar* FMVAspectRatioSwitchNames[] =
 		{
 			L"Off",
-			L"4:3",
+			L"4:3/3:2 (Progressive)",
 			L"16:9",
 			// WARNING: array must be NULL terminated to compute it size
 			NULL};

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -874,7 +874,8 @@ void AppConfig::GSWindowOptions::LoadSave(IniInterface& ini)
 	static const wxChar* AspectRatioNames[] =
 		{
 			L"Stretch",
-			L"4:3/3:2 (Progressive)",
+			L"Auto 4:3/3:2 (Progressive)",
+			L"4:3",
 			L"16:9",
 			// WARNING: array must be NULL terminated to compute it size
 			NULL};
@@ -886,7 +887,8 @@ void AppConfig::GSWindowOptions::LoadSave(IniInterface& ini)
 	static const wxChar* FMVAspectRatioSwitchNames[] =
 		{
 			L"Off",
-			L"4:3/3:2 (Progressive)",
+			L"Auto 4:3/3:2 (Progressive)",
+			L"4:3",
 			L"16:9",
 			// WARNING: array must be NULL terminated to compute it size
 			NULL};

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -172,6 +172,10 @@ namespace Implementations
 		switch (art)
 		{
 			case AspectRatioType::Stretch:
+				art = AspectRatioType::RAuto4_3_3_2;
+				arts = "Auto 4:3/3:2";
+				break;
+			case AspectRatioType::RAuto4_3_3_2:
 				art = AspectRatioType::R4_3;
 				arts = "4:3";
 				break;

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -32,13 +32,15 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 	const wxString aspect_ratio_labels[] =
 		{
 			_("Fit to Window/Screen"),
-			_("Standard (4:3/3:2 Progressive)"),
+			_("Auto Standard (4:3/3:2 Progressive)"),
+			_("Standard (4:3)"),
 			_("Widescreen (16:9)")};
 
 	const wxString fmv_aspect_ratio_switch_labels[] =
 		{
 			_("Off (Default)"),
-			_("Standard (4:3/3:2 Progressive)"),
+			_("Auto Standard (4:3/3:2 Progressive)"),
+			_("Standard (4:3)"),
 			_("Widescreen (16:9)")};
 
 	// Warning must match the order of the VsyncMode Enum
@@ -74,7 +76,8 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 	m_check_DclickFullscreen = new pxCheckBox(this, _("Double-click toggles fullscreen mode"));
 
 	m_combo_FMVAspectRatioSwitch->SetToolTip(pxEt(L"Off: Disables temporary aspect ratio switch. (It will use the above setting from Aspect Ratio instead of FMV Aspect Ratio Override.)\n\n"
-												  L"4:3: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display an 4:3 FMV. Will use 3:2 is the resolution is 480P\n\n"
+												  L"Auto 4:3/3:2: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display a 4:3 FMV. Will use 3:2 is the resolution is 480P\n\n"
+												  L"4:3: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display a 4:3 FMV. \n\n"
 												  L"16:9: Temporarily switch to a 16:9 aspect ratio while an FMV plays to correctly display a widescreen 16:9 FMV."));
 
 	m_text_Zoom->SetToolTip(pxEt(L"Zoom = 100: Fit the entire image to the window without any cropping.\n"

--- a/pcsx2/gui/Panels/GSWindowPanel.cpp
+++ b/pcsx2/gui/Panels/GSWindowPanel.cpp
@@ -32,13 +32,13 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 	const wxString aspect_ratio_labels[] =
 		{
 			_("Fit to Window/Screen"),
-			_("Standard (4:3)"),
+			_("Standard (4:3/3:2 Progressive)"),
 			_("Widescreen (16:9)")};
 
 	const wxString fmv_aspect_ratio_switch_labels[] =
 		{
 			_("Off (Default)"),
-			_("Standard (4:3)"),
+			_("Standard (4:3/3:2 Progressive)"),
 			_("Widescreen (16:9)")};
 
 	// Warning must match the order of the VsyncMode Enum
@@ -74,7 +74,7 @@ Panels::GSWindowSettingsPanel::GSWindowSettingsPanel(wxWindow* parent)
 	m_check_DclickFullscreen = new pxCheckBox(this, _("Double-click toggles fullscreen mode"));
 
 	m_combo_FMVAspectRatioSwitch->SetToolTip(pxEt(L"Off: Disables temporary aspect ratio switch. (It will use the above setting from Aspect Ratio instead of FMV Aspect Ratio Override.)\n\n"
-												  L"4:3: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display an 4:3 FMV.\n\n"
+												  L"4:3: Temporarily switch to a 4:3 aspect ratio while an FMV plays to correctly display an 4:3 FMV. Will use 3:2 is the resolution is 480P\n\n"
 												  L"16:9: Temporarily switch to a 16:9 aspect ratio while an FMV plays to correctly display a widescreen 16:9 FMV."));
 
 	m_text_Zoom->SetToolTip(pxEt(L"Zoom = 100: Fit the entire image to the window without any cropping.\n"


### PR DESCRIPTION
### Description of Changes
Limits the height to the PCRTC clock rates the output can manage (max lines per vertical sync).
Also implemented PCRTC Offsets (Screen offsets), this will maintain the intended aspect ratio, but will also allow you to change the screen position in games which support it.
This also makes the screen shake in WipEout Fusion work.
Also adds 3:2 Aspect ratio for 480p Progressive mode, this will automaticly selected, providing your aspect ratio is set to Auto Standard.

### Rationale behind Changes
We had some weird "NTSC saturate" thing before, which wasn't really right, not that this is perfect, but I suspect this will be closer by limiting the max height to what can be drawn.

A kind of attempt of this was done in #962 but non-interlaced and PAL was completely ignored.

Anyway, this was all completely wrong, the actual height displayed should be based on the magnification of the picture, but the way we interpreted the DISPLAY registers wasn't exactly correct, but height displayed is limited by the resolution you are in, this PR should resolve that, but also tries to increae the size of the picture to fill the window while maintaining the aspect ratio where possible.

### Suggested Testing Steps
Test games, make sure the picture isn't cut off and isn't doing any funky half screen stuff.

Games which had incorrect height, fixed in this PR:

Alone in the Dark 4 - Fixes #4356
Arctic Thunder FMVs (Was patched)
Capcom Classics Collection Vol.1 - Fixes #3287
Deus Ex (PAL) loading screens
God of War (NTSC) FMV's - Fixes #4485 - Progressive requires Screen Offsets and will put the video in a box.
Iridium Runners (NTSC) FMV's
Johnny Mosely Mad Trix FMVs (was patched)
King of Fighters 2000
Metal Slug 3 (60hz)
Mizuiro (SLPS 25191) insane flickering in FMVs
MTV Music Generator 2 height is better by default but Screen Offsets fixes the position. Fixes #2901
Pool Paradise (Was hacked)
Silent Hill 2 (Was hacked)
Zero Shikikan Josentoki Ni - Fixes #5119

Also closes the Meta on the PCRTC subject as all issues are resolved (as good as the console). Fixes #961

3:2 Aspect Ratio Fixes #5842

Screenshots:

![image](https://user-images.githubusercontent.com/6278726/162750033-7cb6c1c0-f434-46c3-aef6-437bca863c49.png)

![image](https://user-images.githubusercontent.com/6278726/162750090-13dde786-d241-4cb5-ad6a-2a08375712fb.png)

Don't do this, but you can if you really want to :P
![image](https://user-images.githubusercontent.com/6278726/162750338-3a7a8ed4-2a76-4a37-830e-91964654de85.png)
