### PR TITLE
Qt: Add performance metrics to status bar

### DIFF
--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -52,6 +52,7 @@ public:
 
 	void startBackgroundControllerPollTimer();
 	void stopBackgroundControllerPollTimer();
+	void updatePerformanceMetrics(bool force);
 
 public Q_SLOTS:
 	void startVM(std::shared_ptr<VMBootParameters> boot_params);
@@ -100,6 +101,9 @@ Q_SIGNALS:
 	/// Provided by the host; called when the running executable changes.
 	void onGameChanged(const QString& path, const QString& serial, const QString& name, quint32 crc);
 
+	/// Called when performance metrics are changed, approx. once a second.
+	void onPerformanceMetricsUpdated(const QString& fps_stats, const QString& gs_stats);
+
 	void onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices);
 	void onInputDeviceConnected(const QString& identifier, const QString& device_name);
 	void onInputDeviceDisconnected(const QString& identifier);
@@ -129,6 +133,7 @@ private:
 
 	void createBackgroundControllerPollTimer();
 	void destroyBackgroundControllerPollTimer();
+	void loadOurSettings();
 
 private Q_SLOTS:
 	void stopInThread();
@@ -148,8 +153,15 @@ private:
 
 	std::atomic_bool m_shutdown_flag{false};
 
+	bool m_verbose_status = false;
 	bool m_is_rendering_to_main = false;
 	bool m_is_fullscreen = false;
+
+	float m_last_speed = 0.0f;
+	float m_last_game_fps = 0.0f;
+	float m_last_video_fps = 0.0f;
+	int m_last_internal_width = 0;
+	int m_last_internal_height = 0;
 };
 
 /// <summary>

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <QtWidgets/QLabel>
 #include <QtWidgets/QMainWindow>
 #include <optional>
 
@@ -103,6 +104,7 @@ private Q_SLOTS:
 	void onVMStopped();
 
 	void onGameChanged(const QString& path, const QString& serial, const QString& name, quint32 crc);
+	void onPerformanceMetricsUpdated(const QString& fps_stat, const QString& gs_stat);
 
 	void recreate();
 
@@ -124,6 +126,7 @@ private:
 	void restoreStateFromConfig();
 
 	void updateEmulationActions(bool starting, bool running);
+	void updateStatusBarWidgetVisibility();
 	void updateWindowTitle();
 	void setProgressBar(int current, int total);
 	void clearProgressBar();
@@ -166,6 +169,8 @@ private:
 	ControllerSettingsDialog* m_controller_settings_dialog = nullptr;
 
 	QProgressBar* m_status_progress_widget = nullptr;
+	QLabel* m_status_gs_widget = nullptr;
+	QLabel* m_status_fps_widget = nullptr;
 
 	QString m_current_disc_path;
 	QString m_current_game_serial;
@@ -175,6 +180,8 @@ private:
 	bool m_vm_paused = false;
 	bool m_save_states_invalidated = false;
 	bool m_was_focused_on_container_switch = false;
+
+	QString m_last_fps_status;
 };
 
 extern MainWindow* g_main_window;

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -168,6 +168,7 @@
     <addaction name="actionViewToolbar"/>
     <addaction name="actionViewLockToolbar"/>
     <addaction name="actionViewStatusBar"/>
+    <addaction name="actionViewStatusBarVerbose"/>
     <addaction name="separator"/>
     <addaction name="actionViewGameList"/>
     <addaction name="actionViewGameGrid"/>
@@ -595,6 +596,17 @@
    </property>
    <property name="text">
     <string>&amp;Status Bar</string>
+   </property>
+  </action>
+  <action name="actionViewStatusBarVerbose">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Verbose Status</string>
    </property>
   </action>
   <action name="actionViewGameList">

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -36,6 +36,7 @@
 #include "common/Console.h"
 #include "common/StringUtil.h"
 #include "pcsx2/Config.h"
+#include "pcsx2/Counters.h"
 #include "pcsx2/Host.h"
 #include "pcsx2/HostDisplay.h"
 #include "pcsx2/GS.h"
@@ -715,14 +716,20 @@ void GSgetStats(std::string& info)
 
 void GSgetTitleStats(std::string& info)
 {
+	const char* api_name = HostDisplay::RenderAPIToString(s_render_api);
+	const char* hw_sw_name = (GSConfig.Renderer == GSRendererType::Null) ? " Null" : (GSConfig.UseHardwareRenderer() ? " HW" : " SW");
+	const char* deinterlace_mode = theApp.m_gs_interlace[static_cast<int>(GSConfig.InterlaceMode)].name.c_str();
+
+#ifndef PCSX2_CORE
 	int iwidth, iheight;
 	GSgetInternalResolution(&iwidth, &iheight);
 
-	const char* api_name = HostDisplay::RenderAPIToString(s_render_api);
-	const char* hw_sw_name = (GSConfig.Renderer == GSRendererType::Null) ? " Null" : (GSConfig.UseHardwareRenderer() ? " HW" : " SW");
-	const char* interlace_mode = theApp.m_gs_interlace[static_cast<int>(GSConfig.InterlaceMode)].name.c_str();
-
-	info = format("%s%s | %s | %dx%d", api_name, hw_sw_name, interlace_mode,  iwidth, iheight);
+	info = StringUtil::StdStringFromFormat("%s%s | %s | %dx%d", api_name, hw_sw_name, deinterlace_mode,  iwidth, iheight);
+#else
+	const char* interlace_mode = ReportInterlaceMode();
+	const char* video_mode = ReportVideoMode();
+	info = StringUtil::StdStringFromFormat("%s%s | %s | %s | %s", api_name, hw_sw_name, video_mode, interlace_mode, deinterlace_mode);
+#endif
 }
 
 void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)

--- a/pcsx2/PerformanceMetrics.cpp
+++ b/pcsx2/PerformanceMetrics.cpp
@@ -25,6 +25,10 @@
 #include "GS.h"
 #include "MTVU.h"
 
+#ifdef PCSX2_CORE
+#include "VMManager.h"
+#endif
+
 static const float UPDATE_INTERVAL = 0.5f;
 
 static float s_vertical_frequency = 0.0f;
@@ -130,6 +134,7 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
 	if (time < UPDATE_INTERVAL)
 		return;
 
+	s_last_update_time.ResetTo(now_ticks);
 	s_worst_frame_time = s_worst_frame_time_accumulator;
 	s_worst_frame_time_accumulator = 0.0f;
 	s_average_frame_time = s_average_frame_time_accumulator / static_cast<float>(s_frames_since_last_update);
@@ -191,9 +196,12 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
 	s_last_vu_time = vu_time;
 	s_last_ticks = ticks;
 
-	s_last_update_time.ResetTo(now_ticks);
 	s_frames_since_last_update = 0;
 	s_presents_since_last_update = 0;
+
+#ifdef PCSX2_CORE
+	Host::OnPerformanceMetricsUpdated();
+#endif
 }
 
 void PerformanceMetrics::OnGPUPresent(float gpu_time)

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -177,6 +177,9 @@ namespace Host
 	/// Called when the VM is resumed after being paused.
 	void OnVMResumed();
 
+	/// Called when performance metrics are updated, approximately once a second.
+	void OnPerformanceMetricsUpdated();
+
 	/// Called when a save state is loading, before the file is processed.
 	void OnSaveStateLoading(const std::string_view& filename);
 


### PR DESCRIPTION
### Description of Changes

Now it displays the frame rate and resolution in the bottom-right (or `Paused`), and the familiar information from the wx title bar (if you enable verbose in the view menu).

### Rationale behind Changes

Status bar was looking a bit lonely before. 

### Suggested Testing Steps

It's Qt. We could bikeshed what to put in there for hours, but at least there's _something_ now.
