### PR TITLE
EERec: Implement fastmem

### DIFF
--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include "common/Align.h"
 #include "common/PageFaultSource.h"
 
 // Apple uses the MAP_ANON define instead of MAP_ANONYMOUS, but they mean
@@ -28,12 +29,23 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#include <cerrno>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <ucontext.h>
+
 extern void SignalExit(int sig);
 
 static const uptr m_pagemask = getpagesize() - 1;
 
+static struct sigaction s_old_sigsegv_action;
+#if defined(__APPLE__)
+static struct sigaction s_old_sigbus_action;
+#endif
+
 // Linux implementation of SIGSEGV handler.  Bind it using sigaction().
-static void SysPageFaultSignalFilter(int signal, siginfo_t* siginfo, void*)
+static void SysPageFaultSignalFilter(int signal, siginfo_t* siginfo, void* ctx)
 {
 	// [TODO] : Add a thread ID filter to the Linux Signal handler here.
 	// Rationale: On windows, the __try/__except model allows per-thread specific behavior
@@ -51,13 +63,18 @@ static void SysPageFaultSignalFilter(int signal, siginfo_t* siginfo, void*)
 	// Note: Use of stdio functions isn't safe here.  Avoid console logs,
 	// assertions, file logs, or just about anything else useful.
 
+#if defined(__x86_64__)
+	void* const exception_pc = reinterpret_cast<void*>(static_cast<ucontext_t*>(ctx)->uc_mcontext.gregs[REG_RIP]);
+#else
+	void* const exception_pc = nullptr;
+#endif
 
 	// Note: This signal can be accessed by the EE or MTVU thread
 	// Source_PageFault is a global variable with its own state information
 	// so for now we lock this exception code unless someone can fix this better...
 	Threading::ScopedLock lock(PageFault_Mutex);
 
-	Source_PageFault->Dispatch(PageFaultInfo((uptr)siginfo->si_addr & ~m_pagemask));
+	Source_PageFault->Dispatch(PageFaultInfo((uptr)exception_pc, (uptr)siginfo->si_addr & ~m_pagemask));
 
 	// resumes execution right where we left off (re-executes instruction that
 	// caused the SIGSEGV).
@@ -85,11 +102,11 @@ void _platform_InstallSignalHandler()
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = SA_SIGINFO;
 	sa.sa_sigaction = SysPageFaultSignalFilter;
-#ifdef __APPLE__
+#if defined(__APPLE__)
 	// MacOS uses SIGBUS for memory permission violations
-	sigaction(SIGBUS, &sa, NULL);
+	sigaction(SIGBUS, &sa, &s_old_sigbus_action);
 #else
-	sigaction(SIGSEGV, &sa, NULL);
+	sigaction(SIGSEGV, &sa, &s_old_sigsegv_action);
 #endif
 }
 
@@ -106,13 +123,8 @@ static __ri void PageSizeAssertionTest(size_t size)
 													__pagesize, __pagesize, size, size));
 }
 
-// returns FALSE if the mprotect call fails with an ENOMEM.
-// Raises assertions on other types of POSIX errors (since those typically reflect invalid object
-// or memory states).
-static bool _memprotect(void* baseaddr, size_t size, const PageProtectionMode& mode)
+static __ri uint LinuxProt(const PageProtectionMode& mode)
 {
-	PageSizeAssertionTest(size);
-
 	uint lnxmode = 0;
 
 	if (mode.CanWrite())
@@ -121,6 +133,18 @@ static bool _memprotect(void* baseaddr, size_t size, const PageProtectionMode& m
 		lnxmode |= PROT_READ;
 	if (mode.CanExecute())
 		lnxmode |= PROT_EXEC | PROT_READ;
+
+	return lnxmode;
+}
+
+// returns FALSE if the mprotect call fails with an ENOMEM.
+// Raises assertions on other types of POSIX errors (since those typically reflect invalid object
+// or memory states).
+static bool _memprotect(void* baseaddr, size_t size, const PageProtectionMode& mode)
+{
+	PageSizeAssertionTest(size);
+
+	uint lnxmode = LinuxProt(mode);
 
 	const int result = mprotect(baseaddr, size, lnxmode);
 
@@ -227,4 +251,112 @@ void HostSys::MemProtect(void* baseaddr, size_t size, const PageProtectionMode& 
 				baseaddr, (uptr)baseaddr + size, WX_STR(mode.ToString())));
 	}
 }
+
+wxString HostSys::GetFileMappingName(const char* prefix)
+{
+	const unsigned pid = static_cast<unsigned>(getpid());
+
+	FastFormatAscii ret;
+	ret.Write("%s_%u", prefix, pid);
+
+	return ret.GetString();
+}
+
+void* HostSys::CreateSharedMemory(const wxString& name, size_t size)
+{
+	const int fd = shm_open(name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+	if (fd < 0)
+	{
+		std::fprintf(stderr, "shm_open failed: %d\n", errno);
+		return nullptr;
+	}
+
+	// we're not going to be opening this mapping in other processes, so remove the file
+	shm_unlink(name.c_str());
+
+	// ensure it's the correct size
+	if (ftruncate64(fd, static_cast<off64_t>(size)) < 0)
+	{
+		std::fprintf(stderr, "ftruncate64(%zu) failed: %d\n", size, errno);
+		return nullptr;
+	}
+
+	return reinterpret_cast<void*>(static_cast<intptr_t>(fd));
+}
+
+void HostSys::DestroySharedMemory(void* ptr)
+{
+	close(static_cast<int>(reinterpret_cast<intptr_t>(ptr)));
+}
+
+void* HostSys::MapSharedMemory(void* handle, size_t offset, void* baseaddr, size_t size, const PageProtectionMode& mode)
+{
+	uint lnxmode = LinuxProt(mode);
+
+	const int flags = (baseaddr != nullptr) ? (MAP_SHARED | MAP_FIXED) : MAP_SHARED;
+	void* ptr = mmap(baseaddr, size, lnxmode, flags, static_cast<int>(reinterpret_cast<intptr_t>(handle)), static_cast<off_t>(offset));
+	if (!ptr || ptr == reinterpret_cast<void*>(-1))
+		return nullptr;
+
+	return ptr;
+}
+
+void HostSys::UnmapSharedMemory(void* baseaddr, size_t size)
+{
+	if (mmap(baseaddr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == MAP_FAILED)
+		pxFailRel("Failed to unmap shared memory");
+}
+
+SharedMemoryMappingArea::SharedMemoryMappingArea(u8* base_ptr, size_t size, size_t num_pages)
+	: m_base_ptr(base_ptr)
+	, m_size(size)
+	, m_num_pages(num_pages)
+{
+}
+
+SharedMemoryMappingArea::~SharedMemoryMappingArea()
+{
+	pxAssertRel(m_num_mappings == 0, "No mappings left");
+
+	if (munmap(m_base_ptr, m_size) != 0)
+		pxFailRel("Failed to release shared memory area");
+}
+
+
+std::unique_ptr<SharedMemoryMappingArea> SharedMemoryMappingArea::Create(size_t size)
+{
+	pxAssertRel(Common::IsAlignedPow2(size, HOST_PAGE_SIZE), "Size is page aligned");
+
+	void* alloc = mmap(nullptr, size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	if (alloc == MAP_FAILED)
+		return nullptr;
+
+	return std::unique_ptr<SharedMemoryMappingArea>(new SharedMemoryMappingArea(static_cast<u8*>(alloc), size, size / HOST_PAGE_SIZE));
+}
+
+u8* SharedMemoryMappingArea::Map(void* file_handle, size_t file_offset, void* map_base, size_t map_size, const PageProtectionMode& mode)
+{
+	pxAssert(static_cast<u8*>(map_base) >= m_base_ptr && static_cast<u8*>(map_base) < (m_base_ptr + m_size));
+
+	const uint lnxmode = LinuxProt(mode);
+	void* const ptr = mmap(map_base, map_size, lnxmode, MAP_SHARED | MAP_FIXED,
+		static_cast<int>(reinterpret_cast<intptr_t>(file_handle)), static_cast<off_t>(file_offset));
+	if (!ptr || ptr == reinterpret_cast<void*>(-1))
+		return nullptr;
+
+	m_num_mappings++;
+	return static_cast<u8*>(ptr);
+}
+
+bool SharedMemoryMappingArea::Unmap(void* map_base, size_t map_size)
+{
+	pxAssert(static_cast<u8*>(map_base) >= m_base_ptr && static_cast<u8*>(map_base) < (m_base_ptr + m_size));
+
+	if (mmap(map_base, map_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == MAP_FAILED)
+		return false;
+
+	m_num_mappings--;
+	return true;
+}
+
 #endif

--- a/common/PageFaultSource.h
+++ b/common/PageFaultSource.h
@@ -30,10 +30,12 @@
 
 struct PageFaultInfo
 {
+	uptr pc;
 	uptr addr;
 
-	PageFaultInfo(uptr address)
+	PageFaultInfo(uptr pc_, uptr address)
 	{
+		pc = pc_;
 		addr = address;
 	}
 };
@@ -134,6 +136,7 @@ class VirtualMemoryManager
 
 	wxString m_name;
 
+	void* m_file_handle;
 	uptr m_baseptr;
 
 	// An array to track page usage (to trigger asserts if things try to overlap)
@@ -146,10 +149,13 @@ public:
 	// If upper_bounds is nonzero and the OS fails to allocate memory that is below it,
 	// calls to IsOk() will return false and Alloc() will always return null pointers
 	// strict indicates that the allocation should quietly fail if the memory can't be mapped at `base`
-	VirtualMemoryManager(const wxString& name, uptr base, size_t size, uptr upper_bounds = 0, bool strict = false);
+	VirtualMemoryManager(const char* name, const char* file_mapping_name, uptr base, size_t size, uptr upper_bounds = 0, bool strict = false);
 	~VirtualMemoryManager();
 
+	bool IsSharedMemory() const { return (m_file_handle != nullptr); }
+	void* GetFileHandle() const { return m_file_handle; }
 	void* GetBase() const { return (void*)m_baseptr; }
+	void* GetEnd() const { return (void*)(m_baseptr + m_pages_reserved * __pagesize); }
 
 	// Request the use of the memory at offsetLocation bytes from the start of the reserved memory area
 	// offsetLocation must be page-aligned

--- a/common/Windows/WinHostSys.cpp
+++ b/common/Windows/WinHostSys.cpp
@@ -15,19 +15,27 @@
 
 #if defined(_WIN32)
 
+#include "common/Align.h"
 #include "common/RedtapeWindows.h"
 #include "common/PageFaultSource.h"
+#include "common/Console.h"
 
 static long DoSysPageFaultExceptionFilter(EXCEPTION_POINTERS* eps)
 {
 	if (eps->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION)
 		return EXCEPTION_CONTINUE_SEARCH;
 
+#if defined(_M_AMD64)
+	void* const exception_pc = reinterpret_cast<void*>(eps->ContextRecord->Rip);
+#else
+	void* const exception_pc = nullptr;
+#endif
+
 	// Note: This exception can be accessed by the EE or MTVU thread
 	// Source_PageFault is a global variable with its own state information
 	// so for now we lock this exception code unless someone can fix this better...
 	Threading::ScopedLock lock(PageFault_Mutex);
-	Source_PageFault->Dispatch(PageFaultInfo((uptr)eps->ExceptionRecord->ExceptionInformation[1]));
+	Source_PageFault->Dispatch(PageFaultInfo((uptr)exception_pc, (uptr)eps->ExceptionRecord->ExceptionInformation[1]));
 	return Source_PageFault->WasHandled() ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
 }
 
@@ -160,4 +168,257 @@ void HostSys::MemProtect(void* baseaddr, size_t size, const PageProtectionMode& 
 		pxFailDev(apiError.FormatDiagnosticMessage());
 	}
 }
+
+wxString HostSys::GetFileMappingName(const char* prefix)
+{
+	const unsigned pid = GetCurrentProcessId();
+
+	FastFormatAscii ret;
+	ret.Write("%s_%u", prefix, pid);
+	return ret.GetString();
+}
+
+void* HostSys::CreateSharedMemory(const wxString& name, size_t size)
+{
+	return static_cast<void*>(CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
+		static_cast<DWORD>(size >> 32), static_cast<DWORD>(size), name.c_str()));
+}
+
+void HostSys::DestroySharedMemory(void* ptr)
+{
+	CloseHandle(static_cast<HANDLE>(ptr));
+}
+
+void* HostSys::MapSharedMemory(void* handle, size_t offset, void* baseaddr, size_t size, const PageProtectionMode& mode)
+{
+	void* ret = MapViewOfFileEx(static_cast<HANDLE>(handle), FILE_MAP_READ | FILE_MAP_WRITE,
+		static_cast<DWORD>(offset >> 32), static_cast<DWORD>(offset), size, baseaddr);
+	if (!ret)
+		return nullptr;
+
+	const DWORD prot = ConvertToWinApi(mode);
+	if (prot != PAGE_READWRITE)
+	{
+		DWORD old_prot;
+		if (!VirtualProtect(ret, size, prot, &old_prot))
+			pxFail("Failed to protect memory mapping");
+	}
+	return ret;
+}
+
+void HostSys::UnmapSharedMemory(void* baseaddr, size_t size)
+{
+	if (!UnmapViewOfFile(baseaddr))
+		pxFail("Failed to unmap shared memory");
+}
+
+using PFN_VirtualAlloc2 = PVOID(WINAPI*)(HANDLE Process, PVOID BaseAddress, SIZE_T Size, ULONG AllocationType, ULONG PageProtection, MEM_EXTENDED_PARAMETER* ExtendedParameters, ULONG ParameterCount);
+using PFN_MapViewOfFile3 = PVOID(WINAPI*)(HANDLE FileMapping, HANDLE Process, PVOID BaseAddress, ULONG64 Offset, SIZE_T ViewSize, ULONG AllocationType, ULONG PageProtection, MEM_EXTENDED_PARAMETER* ExtendedParameters, ULONG ParameterCount);
+using PFN_UnmapViewOfFile2 = BOOL(WINAPI*)(HANDLE Process, PVOID BaseAddress, ULONG UnmapFlags);
+
+static PFN_VirtualAlloc2 s_VirtualAlloc2;
+static PFN_MapViewOfFile3 s_MapViewOfFile3;
+static PFN_UnmapViewOfFile2 s_UnmapViewOfFile2;
+
+static void InitSharedMemoryMappingAreaFunctions()
+{
+	static bool initialized = false;
+	if (initialized)
+		return;
+
+	s_VirtualAlloc2 = reinterpret_cast<PFN_VirtualAlloc2>(GetProcAddress(GetModuleHandle(_T("kernelbase.dll")), "VirtualAlloc2"));
+	s_MapViewOfFile3 = reinterpret_cast<PFN_MapViewOfFile3>(GetProcAddress(GetModuleHandle(_T("kernelbase.dll")), "MapViewOfFile3"));
+	s_UnmapViewOfFile2 = reinterpret_cast<PFN_UnmapViewOfFile2>(GetProcAddress(GetModuleHandle(_T("kernelbase.dll")), "UnmapViewOfFile2"));
+	if (!s_VirtualAlloc2 || !s_MapViewOfFile3 || !s_UnmapViewOfFile2)
+		pxFailRel("Missing one or more file mapping APIs");
+
+	initialized = true;
+}
+
+SharedMemoryMappingArea::SharedMemoryMappingArea(u8* base_ptr, size_t size, size_t num_pages)
+	: m_base_ptr(base_ptr)
+	, m_size(size)
+	, m_num_pages(num_pages)
+{
+	m_placeholder_ranges.emplace(0, size);
+}
+
+SharedMemoryMappingArea::~SharedMemoryMappingArea()
+{
+	pxAssertRel(m_num_mappings == 0, "No mappings left");
+
+	// hopefully this will be okay, and we don't need to coalesce all the placeholders...
+	if (!VirtualFreeEx(GetCurrentProcess(), m_base_ptr, 0, MEM_RELEASE))
+		pxFailRel("Failed to release shared memory area");
+}
+
+SharedMemoryMappingArea::PlaceholderMap::iterator SharedMemoryMappingArea::FindPlaceholder(size_t offset)
+{
+	if (m_placeholder_ranges.empty())
+		return m_placeholder_ranges.end();
+
+	// this will give us an iterator equal or after page
+	auto it = m_placeholder_ranges.lower_bound(offset);
+	if (it == m_placeholder_ranges.end())
+	{
+		// check the last page
+		it = (++m_placeholder_ranges.rbegin()).base();
+	}
+
+	// it's the one we found?
+	if (offset >= it->first && offset < it->second)
+		return it;
+
+	// otherwise try the one before
+	if (it == m_placeholder_ranges.begin())
+		return m_placeholder_ranges.end();
+
+	--it;
+	if (offset >= it->first && offset < it->second)
+		return it;
+	else
+		return m_placeholder_ranges.end();
+}
+
+std::unique_ptr<SharedMemoryMappingArea> SharedMemoryMappingArea::Create(size_t size)
+{
+	pxAssertRel(Common::IsAlignedPow2(size, HOST_PAGE_SIZE), "Size is page aligned");
+	InitSharedMemoryMappingAreaFunctions();
+
+	void* alloc = s_VirtualAlloc2(GetCurrentProcess(), nullptr, size, MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, nullptr, 0);
+	if (!alloc)
+		return nullptr;
+
+	return std::unique_ptr<SharedMemoryMappingArea>(new SharedMemoryMappingArea(static_cast<u8*>(alloc), size, size / HOST_PAGE_SIZE));
+}
+
+u8* SharedMemoryMappingArea::Map(void* file_handle, size_t file_offset, void* map_base, size_t map_size, const PageProtectionMode& mode)
+{
+	pxAssert(static_cast<u8*>(map_base) >= m_base_ptr && static_cast<u8*>(map_base) < (m_base_ptr + m_size));
+
+	const size_t map_offset = static_cast<u8*>(map_base) - m_base_ptr;
+	pxAssert(Common::IsAlignedPow2(map_offset, HOST_PAGE_SIZE));
+	pxAssert(Common::IsAlignedPow2(map_size, HOST_PAGE_SIZE));
+
+	// should be a placeholder. unless there's some other mapping we didn't free.
+	PlaceholderMap::iterator phit = FindPlaceholder(map_offset);
+	pxAssertMsg(phit != m_placeholder_ranges.end(), "Page we're mapping is a placeholder");
+	pxAssertMsg(map_offset >= phit->first && map_offset < phit->second, "Page is in returned placeholder range");
+	pxAssertMsg((map_offset + map_size) <= phit->second, "Page range is in returned placeholder range");
+
+	// do we need to split to the left? (i.e. is there a placeholder before this range)
+	const size_t old_ph_end = phit->second;
+	if (map_offset != phit->first)
+	{
+		phit->second = map_offset;
+
+		// split it (i.e. left..start and start..end are now separated)
+		if (!VirtualFreeEx(GetCurrentProcess(), OffsetPointer(phit->first),
+				(map_offset - phit->first), MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER))
+		{
+			pxFailRel("Failed to left split placeholder for map");
+		}
+	}
+	else
+	{
+		// start of the placeholder is getting used, we'll split it right below if there's anything left over
+		m_placeholder_ranges.erase(phit);
+	}
+
+	// do we need to split to the right? (i.e. is there a placeholder after this range)
+	if ((map_offset + map_size) != old_ph_end)
+	{
+		// split out end..ph_end
+		m_placeholder_ranges.emplace(map_offset + map_size, old_ph_end);
+
+		if (!VirtualFreeEx(GetCurrentProcess(), OffsetPointer(map_offset), map_size,
+				MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER))
+		{
+			pxFailRel("Failed to right split placeholder for map");
+		}
+	}
+
+	// actually do the mapping, replacing the placeholder on the range
+	if (!s_MapViewOfFile3(static_cast<HANDLE>(file_handle), GetCurrentProcess(),
+			map_base, file_offset, map_size, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0))
+	{
+		Console.Error("(SharedMemoryMappingArea) MapViewOfFile3() failed: %u", GetLastError());
+		return nullptr;
+	}
+
+	const DWORD prot = ConvertToWinApi(mode);
+	if (prot != PAGE_READWRITE)
+	{
+		DWORD old_prot;
+		if (!VirtualProtect(map_base, map_size, prot, &old_prot))
+			pxFail("Failed to protect memory mapping");
+	}
+
+	m_num_mappings++;
+	return static_cast<u8*>(map_base);
+}
+
+bool SharedMemoryMappingArea::Unmap(void* map_base, size_t map_size)
+{
+	pxAssert(static_cast<u8*>(map_base) >= m_base_ptr && static_cast<u8*>(map_base) < (m_base_ptr + m_size));
+
+	const size_t map_offset = static_cast<u8*>(map_base) - m_base_ptr;
+	pxAssert(Common::IsAlignedPow2(map_offset, HOST_PAGE_SIZE));
+	pxAssert(Common::IsAlignedPow2(map_size, HOST_PAGE_SIZE));
+
+	const size_t page = map_offset / HOST_PAGE_SIZE;
+	const size_t num_pages = map_size / HOST_PAGE_SIZE;
+
+	// unmap the specified range
+	if (!s_UnmapViewOfFile2(GetCurrentProcess(), map_base, MEM_PRESERVE_PLACEHOLDER))
+	{
+		Console.Error("(SharedMemoryMappingArea) UnmapViewOfFile2() failed: %u", GetLastError());
+		return false;
+	}
+
+	// store for possible coalescing to the right
+	size_t ph_start = page;
+
+	// can we coalesce to the left?
+	PlaceholderMap::iterator left_it = (map_offset > 0) ? FindPlaceholder(map_offset - 1) : m_placeholder_ranges.end();
+	if (left_it != m_placeholder_ranges.end())
+	{
+		// the left placeholder should end at our start
+		pxAssert(map_offset == left_it->second);
+		left_it->second = map_offset + map_size;
+
+		// combine placeholders before and the range we're unmapping, i.e. to the left
+		if (!VirtualFreeEx(GetCurrentProcess(), OffsetPointer(left_it->first),
+				 left_it->second - left_it->first, MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS))
+		{
+			pxFail("Failed to coalesce placeholders left for unmap");
+		}
+	}
+	else
+	{
+		// this is a new placeholder
+		left_it = m_placeholder_ranges.emplace(map_offset, map_size).first;
+	}
+
+	// can we coalesce to the right?
+	PlaceholderMap::iterator right_it = ((map_offset + map_size) < m_size) ? FindPlaceholder(map_offset + map_size) : m_placeholder_ranges.end();
+	if (right_it != m_placeholder_ranges.end())
+	{
+		// should start at our end
+		pxAssert(right_it->first == (map_offset + map_size));
+		left_it->second = right_it->second;
+		m_placeholder_ranges.erase(right_it);
+		
+		// combine our placeholder and the next, i.e. to the right
+		if (!VirtualFreeEx(GetCurrentProcess(), OffsetPointer(left_it->first),
+				left_it->second - left_it->first, MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS))
+		{
+			pxFail("Failed to coalescae placeholders right for unmap");
+		}
+	}
+
+	m_num_mappings--;
+	return true;
+}
+
 #endif

--- a/common/emitter/x86emitter.cpp
+++ b/common/emitter/x86emitter.cpp
@@ -467,7 +467,7 @@ const xRegister32
 
 	void EmitRex(const xRegisterBase& reg1, const xRegisterBase& reg2)
 	{
-		bool w = reg1.IsWide();
+		bool w = reg1.IsWide() || reg2.IsWide();
 		bool r = reg1.IsExtended();
 		bool x = false;
 		bool b = reg2.IsExtended();

--- a/common/emitter/x86types.h
+++ b/common/emitter/x86types.h
@@ -75,7 +75,7 @@ namespace x86Emitter
 	template <typename T>
 	static __fi bool is_s8(T imm)
 	{
-		return (s8)imm == (s32)imm;
+		return (s8)imm == (s64)imm;
 	}
 
 	template <typename T>

--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
@@ -35,6 +35,7 @@ AdvancedSystemSettingsWidget::AdvancedSystemSettingsWidget(SettingsDialog* dialo
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeCache, "EmuCore/CPU/Recompiler", "EnableEECache", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeINTCSpinDetection, "EmuCore/Speedhacks", "IntcStat", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeWaitLoopDetection, "EmuCore/Speedhacks", "WaitLoop", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.eeFastmem, "EmuCore/CPU/Recompiler", "EnableFastmem", true);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vu0Recompiler, "EmuCore/CPU/Recompiler", "EnableVU0", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vu1Recompiler, "EmuCore/CPU/Recompiler", "EnableVU1", true);

--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
@@ -32,17 +32,24 @@
       <string>EmotionEngine (MIPS-IV)</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="eeRecompiler">
-        <property name="text">
-         <string>Enable Recompiler</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="eeWaitLoopDetection">
         <property name="text">
          <string>Wait Loop Detection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="eeINTCSpinDetection">
+        <property name="text">
+         <string>INTC Spin Detection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="eeRecompiler">
+        <property name="text">
+         <string>Enable Recompiler</string>
         </property>
        </widget>
       </item>
@@ -53,10 +60,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="eeINTCSpinDetection">
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="eeFastmem">
         <property name="text">
-         <string>INTC Spin Detection</string>
+         <string>Enable Fastmem</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -364,6 +364,8 @@ struct Pcsx2Config
 			PreBlockCheckIOP : 1;
 		bool
 			EnableEECache : 1;
+		bool
+			EnableFastmem : 1;
 		BITFIELD_END
 
 		RecompilerOptions();
@@ -1043,6 +1045,7 @@ namespace EmuFolders
 #define CHECK_EEREC (EmuConfig.Cpu.Recompiler.EnableEE)
 #define CHECK_CACHE (EmuConfig.Cpu.Recompiler.EnableEECache)
 #define CHECK_IOPREC (EmuConfig.Cpu.Recompiler.EnableIOP)
+#define CHECK_FASTMEM (EmuConfig.Cpu.Recompiler.EnableEE && EmuConfig.Cpu.Recompiler.EnableFastmem)
 
 //------------ SPECIAL GAME FIXES!!! ---------------
 #define CHECK_VUADDSUBHACK (EmuConfig.Gamefixes.VuAddSubHack) // Special Fix for Tri-ace games, they use an encryption algorithm that requires VU addi opcode to be bit-accurate.

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -19,6 +19,7 @@
 #include "System/SysThreads.h"
 #include "Gif.h"
 #include "GS/GS.h"
+#include "SingleRegisterTypes.h"
 #include <functional>
 
 extern double GetVerticalFrequency();
@@ -445,13 +446,13 @@ extern void gsWrite8(u32 mem, u8 value);
 extern void gsWrite16(u32 mem, u16 value);
 extern void gsWrite32(u32 mem, u32 value);
 
-extern void __fastcall gsWrite64_page_00( u32 mem, const mem64_t* value );
-extern void __fastcall gsWrite64_page_01( u32 mem, const mem64_t* value );
-extern void __fastcall gsWrite64_generic( u32 mem, const mem64_t* value );
+extern void TAKES_R64 gsWrite64_page_00( u32 mem, r64 value );
+extern void TAKES_R64 gsWrite64_page_01( u32 mem, r64 value );
+extern void TAKES_R64 gsWrite64_generic( u32 mem, r64 value );
 
-extern void __fastcall gsWrite128_page_00( u32 mem, const mem128_t* value );
-extern void __fastcall gsWrite128_page_01( u32 mem, const mem128_t* value );
-extern void __fastcall gsWrite128_generic( u32 mem, const mem128_t* value );
+extern void TAKES_R128 gsWrite128_page_00( u32 mem, r128 value );
+extern void TAKES_R128 gsWrite128_page_01( u32 mem, r128 value );
+extern void TAKES_R128 gsWrite128_generic( u32 mem, r128 value );
 
 extern u8   gsRead8(u32 mem);
 extern u16  gsRead16(u32 mem);

--- a/pcsx2/HwRead.cpp
+++ b/pcsx2/HwRead.cpp
@@ -315,7 +315,7 @@ template< uint page >
 RETURNS_R64 hwRead64(u32 mem)
 {
 	r64 res = _hwRead64<page>(mem);
-	eeHwTraceLog(mem, *(u64*)&res, true);
+	eeHwTraceLog(mem, res, true);
 	return res;
 }
 
@@ -388,7 +388,7 @@ template< uint page >
 RETURNS_R128 hwRead128(u32 mem)
 {
 	r128 res = _hwRead128<page>(mem);
-	eeHwTraceLog(mem, *(mem128_t*)&res, true);
+	eeHwTraceLog(mem, res, true);
 	return res;
 }
 

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -317,7 +317,7 @@ __fi void VU_Thread::Write(u32 val)
 	m_write_pos += 1;
 }
 
-__fi void VU_Thread::Write(void* src, u32 size)
+__fi void VU_Thread::Write(const void* src, u32 size)
 {
 	memcpy(GetWritePtr(), src, size);
 	m_write_pos += size_u32(size);
@@ -464,7 +464,7 @@ void VU_Thread::ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop, u32 fbrst)
 	Get_MTVUChanges();
 }
 
-void VU_Thread::VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, u8* data, u32 size)
+void VU_Thread::VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, const u8* data, u32 size)
 {
 	MTVU_LOG("MTVU - VifUnpack!");
 	u32 vif_copy_size = (uptr)&_vif.StructEnd - (uptr)&_vif.tag;
@@ -478,7 +478,7 @@ void VU_Thread::VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, u8* data, u32
 	KickStart();
 }
 
-void VU_Thread::WriteMicroMem(u32 vu_micro_addr, void* data, u32 size)
+void VU_Thread::WriteMicroMem(u32 vu_micro_addr, const void* data, u32 size)
 {
 	MTVU_LOG("MTVU - WriteMicroMem!");
 	ReserveSpace(3 + size_u32(size));
@@ -490,7 +490,7 @@ void VU_Thread::WriteMicroMem(u32 vu_micro_addr, void* data, u32 size)
 	KickStart();
 }
 
-void VU_Thread::WriteDataMem(u32 vu_data_addr, void* data, u32 size)
+void VU_Thread::WriteDataMem(u32 vu_data_addr, const void* data, u32 size)
 {
 	MTVU_LOG("MTVU - WriteDataMem!");
 	ReserveSpace(3 + size_u32(size));

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -79,13 +79,13 @@ public:
 
 	void ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop, u32 fbrst);
 
-	void VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, u8* data, u32 size);
+	void VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, const u8* data, u32 size);
 
 	// Writes to VU's Micro Memory (size in bytes)
-	void WriteMicroMem(u32 vu_micro_addr, void* data, u32 size);
+	void WriteMicroMem(u32 vu_micro_addr, const void* data, u32 size);
 
 	// Writes to VU's Data Memory (size in bytes)
-	void WriteDataMem(u32 vu_data_addr, void* data, u32 size);
+	void WriteDataMem(u32 vu_data_addr, const void* data, u32 size);
 
 	void WriteVIRegs(REG_VI* viRegs);
 
@@ -117,7 +117,7 @@ private:
 	void ReadRegs(VIFregisters* dest);
 
 	void Write(u32 val);
-	void Write(void* src, u32 size);
+	void Write(const void* src, u32 size);
 	void WriteRegs(VIFregisters* src);
 
 	u32 Get_vuCycles();

--- a/pcsx2/Memory.h
+++ b/pcsx2/Memory.h
@@ -136,16 +136,16 @@ extern void mmap_ResetBlockTracking();
 #define memWrite16 vtlb_memWrite<mem16_t>
 #define memWrite32 vtlb_memWrite<mem32_t>
 
-static __fi void memRead64(u32 mem, mem64_t* out)	{ _mm_storel_epi64((__m128i*)out, vtlb_memRead64(mem)); }
+static __fi void memRead64(u32 mem, mem64_t* out)	{ *out = vtlb_memRead64(mem); }
 static __fi void memRead64(u32 mem, mem64_t& out)	{ memRead64(mem, &out); }
 
 static __fi void memRead128(u32 mem, mem128_t* out) { _mm_store_si128((__m128i*)out, vtlb_memRead128(mem)); }
 static __fi void memRead128(u32 mem, mem128_t& out) { memRead128(mem, &out); }
 
-static __fi void memWrite64(u32 mem, const mem64_t* val)	{ vtlb_memWrite64(mem, val); }
-static __fi void memWrite64(u32 mem, const mem64_t& val)	{ vtlb_memWrite64(mem, &val); }
-static __fi void memWrite128(u32 mem, const mem128_t* val)	{ vtlb_memWrite128(mem, val); }
-static __fi void memWrite128(u32 mem, const mem128_t& val)	{ vtlb_memWrite128(mem, &val); }
+static __fi void memWrite64(u32 mem, const mem64_t* val)	{ vtlb_memWrite64(mem, r64_load(val)); }
+static __fi void memWrite64(u32 mem, const mem64_t& val)	{ vtlb_memWrite64(mem, r64_from_u64(val)); }
+static __fi void memWrite128(u32 mem, const mem128_t* val)	{ vtlb_memWrite128(mem, r128_load(val)); }
+static __fi void memWrite128(u32 mem, const mem128_t& val)	{ vtlb_memWrite128(mem, r128_load(&val)); }
 
 
 extern u16 ba0R16(u32 mem);

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -39,50 +39,6 @@ typedef u32 mem32_t;
 typedef u64 mem64_t;
 typedef u128 mem128_t;
 
-
-// --------------------------------------------------------------------------------------
-//  Future-Planned VTLB pagefault scheme!
-// --------------------------------------------------------------------------------------
-// When enabled, the VTLB will use a large-area reserved memory range of 512megs for EE
-// physical ram/rom access.  The base ram will be committed at 0x00000000, and ROMs will be
-// at 0x1fc00000, etc.  All memory ranges in between will be uncommitted memory -- which
-// means that the memory will *not* count against the operating system's physical memory
-// pool.
-//
-// When the VTLB generates memory operations (loads/stores), it will assume that the op
-// is addressing either RAM or ROM, and by assuming that it can generate a completely efficient
-// direct memory access (one AND and one MOV instruction).  If the access is to another area of
-// memory, such as hardware registers or scratchpad, the access will generate a page fault, the
-// compiled block will be cleared and re-compiled using "full" VTLB translation logic.
-//
-// Note that support for this feature may not be doable under x86/32 platforms, due to the
-// 2gb/3gb limit of Windows XP (the 3gb feature will make it slightly more feasible at least).
-//
-#define VTLB_UsePageFaulting 0
-
-#if VTLB_UsePageFaulting
-
-// The order of the components in this struct *matter* -- it has been laid out so that the
-// full breadth of PS2 RAM and ROM mappings are directly supported.
-struct EEVM_MemoryAllocMess
-{
-	u8 (&Main)[Ps2MemSize::MainRam];				// Main memory (hard-wired to 32MB)
-
-	u8 _padding1[0x1e000000-Ps2MemSize::MainRam]
-	u8 (&ROM1)[Ps2MemSize::Rom1];				// DVD player
-
-	u8 _padding2[0x1e040000-(0x1e000000+Ps2MemSize::Rom1)]
-	u8 (&EROM)[Ps2MemSize::ERom];				// DVD player extensions
-
-	u8 _padding3[0x1e400000-(0x1e040000+Ps2MemSize::EROM)]
-	u8 (&ROM2)[Ps2MemSize::Rom2];				// Chinese extensions
-
-	u8 _padding4[0x1fc00000-(0x1e040000+Ps2MemSize::Rom2)];
-	u8 (&ROM)[Ps2MemSize::Rom];				// Boot rom (4MB)
-};
-
-#else
-
 struct EEVM_MemoryAllocMess
 {
 	u8 Main[Ps2MemSize::MainRam];			// Main memory (hard-wired to 32MB)
@@ -100,8 +56,6 @@ struct EEVM_MemoryAllocMess
 	u8 ZeroRead[_1mb];
 	u8 ZeroWrite[_1mb];
 };
-
-#endif
 
 struct IopVM_MemoryAllocMess
 {

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -153,6 +153,7 @@ Pcsx2Config::RecompilerOptions::RecompilerOptions()
 	EnableIOP = true;
 	EnableVU0 = true;
 	EnableVU1 = true;
+	EnableFastmem = true;
 
 	// vu and fpu clamping default to standard overflow.
 	vuOverflow = true;
@@ -209,6 +210,7 @@ void Pcsx2Config::RecompilerOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableEECache);
 	SettingsWrapBitBool(EnableVU0);
 	SettingsWrapBitBool(EnableVU1);
+	SettingsWrapBitBool(EnableFastmem);
 
 	SettingsWrapBitBool(vuOverflow);
 	SettingsWrapBitBool(vuExtraOverflow);

--- a/pcsx2/SingleRegisterTypes.h
+++ b/pcsx2/SingleRegisterTypes.h
@@ -21,47 +21,82 @@
 
 #pragma once
 
+#include <cstring>
 #include <immintrin.h>
+#include <emmintrin.h>
+
 // Can't stick them in structs because it breaks calling convention things, yay
-using r64  = __m128i;
+using r64 = u64;
 using r128 = __m128i;
 
 // Calling convention setting, yay
-#define RETURNS_R64  r64  __vectorcall
+#define RETURNS_R64  r64
 #define RETURNS_R128 r128 __vectorcall
-#define TAKES_R64  __vectorcall
+#define TAKES_R64
 #define TAKES_R128 __vectorcall
 
 // And since we can't stick them in structs, we get lots of static methods, yay!
 
 __forceinline static r64 r64_load(const void* ptr)
 {
-	return _mm_loadl_epi64(reinterpret_cast<const r64*>(ptr));
+	r64 ret;
+	std::memcpy(&ret, ptr, sizeof(ret));
+	return ret;
+}
+
+__forceinline static void r64_store(void* ptr, r64 val)
+{
+	std::memcpy(ptr, &val, sizeof(val));
 }
 
 __forceinline static r64 r64_zero()
 {
-	return _mm_setzero_si128();
+	return 0;
 }
 
 __forceinline static r64 r64_from_u32(u32 val)
 {
-	return _mm_cvtsi32_si128(val);
+	return static_cast<u64>(val);
 }
 
 __forceinline static r64 r64_from_u32x2(u32 lo, u32 hi)
 {
-	return _mm_unpacklo_epi32(_mm_cvtsi32_si128(lo), _mm_cvtsi32_si128(hi));
+	return (static_cast<u64>(hi) << 32) | static_cast<u64>(lo);
 }
 
 __forceinline static r64 r64_from_u64(u64 val)
 {
-	return _mm_cvtsi64_si128(val);
+	return val;
+}
+
+__forceinline static u32 r64_to_u32(r64 val)
+{
+	return static_cast<u32>(val);
+}
+
+__forceinline static u32 r64_to_u32_hi(r64 val)
+{
+	return static_cast<u32>(val >> 32);
+}
+
+__forceinline static u64 r64_to_u64(r64 val)
+{
+	return val;
 }
 
 __forceinline static r128 r128_load(const void* ptr)
 {
 	return _mm_load_si128(reinterpret_cast<const r128*>(ptr));
+}
+
+__forceinline static void r128_store(void* ptr, r128 val)
+{
+	return _mm_store_si128(reinterpret_cast<r128*>(ptr), val);
+}
+
+__forceinline static void r128_store_unaligned(void* ptr, r128 val)
+{
+	return _mm_storeu_si128(reinterpret_cast<r128*>(ptr), val);
 }
 
 __forceinline static r128 r128_zero()
@@ -72,12 +107,34 @@ __forceinline static r128 r128_zero()
 /// Expects that r64 came from r64-handling code, and not from a recompiler or something
 __forceinline static r128 r128_from_r64_clean(r64 val)
 {
-	return val;
+	return _mm_set1_epi64x(val);
 }
 
 __forceinline static r128 r128_from_u32x4(u32 lo0, u32 lo1, u32 hi0, u32 hi1)
 {
 	return _mm_setr_epi32(lo0, lo1, hi0, hi1);
+}
+
+__forceinline static r128 r128_from_u128(const u128& u)
+{
+	return _mm_loadu_si128(reinterpret_cast<const __m128i*>(&u));
+}
+
+__forceinline static u32 r128_to_u32(r128 val)
+{
+	return _mm_cvtsi128_si32(val);
+}
+
+__forceinline static u64 r128_to_u64(r128 val)
+{
+	return _mm_cvtsi128_si64(val);
+}
+
+__forceinline static u128 r128_to_u128(r128 val)
+{
+	alignas(16) u128 ret;
+	_mm_store_si128(reinterpret_cast<r128*>(&ret), val);
+	return ret;
 }
 
 template <typename u>

--- a/pcsx2/System.h
+++ b/pcsx2/System.h
@@ -42,10 +42,10 @@ class RecompiledCodeReserve;
 
 namespace HostMemoryMap
 {
-	static const u32 Size = 0x28000000;
-
-	// The actual addresses may not be equivalent to Base + Offset in the event that allocation at Base failed
-	// Each of these offsets has a debugger-accessible equivalent variable without the Offset suffix that will hold the actual address (not here because we don't want code using it)
+	//////////////////////////////////////////////////////////////////////////
+	// Main
+	//////////////////////////////////////////////////////////////////////////
+	static const u32 MainSize = 0x14000000;
 
 	// PS2 main memory, SPR, and ROMs
 	static const u32 EEmemOffset   = 0x00000000;
@@ -56,27 +56,36 @@ namespace HostMemoryMap
 	// VU0 and VU1 memory.
 	static const u32 VUmemOffset   = 0x08000000;
 
+	// Bump allocator for any other small allocations
+	// size: Difference between it and HostMemoryMap::Size, so nothing should allocate higher than it!
+	static const u32 bumpAllocatorOffset = 0x10000000;
+
+	//////////////////////////////////////////////////////////////////////////
+	// Code
+	//////////////////////////////////////////////////////////////////////////
+	static const u32 CodeSize = 0x14800000;
+
 	// EE recompiler code cache area (64mb)
-	static const u32 EErecOffset   = 0x10000000;
+	static const u32 EErecOffset   = 0x00000000;
 
 	// IOP recompiler code cache area (16 or 32mb)
-	static const u32 IOPrecOffset  = 0x14000000;
+	static const u32 IOPrecOffset  = 0x04000000;
 
 	// newVif0 recompiler code cache area (16mb)
-	static const u32 VIF0recOffset = 0x16000000;
+	static const u32 VIF0recOffset = 0x06000000;
 
 	// newVif1 recompiler code cache area (32mb)
-	static const u32 VIF1recOffset = 0x18000000;
+	static const u32 VIF1recOffset = 0x08000000;
 
 	// microVU1 recompiler code cache area (32 or 64mb)
-	static const u32 mVU0recOffset = 0x1C000000;
+	static const u32 mVU0recOffset = 0x0C000000;
 
 	// microVU0 recompiler code cache area (64mb)
-	static const u32 mVU1recOffset = 0x20000000;
+	static const u32 mVU1recOffset = 0x10000000;
 
 	// Bump allocator for any other small allocations
 	// size: Difference between it and HostMemoryMap::Size, so nothing should allocate higher than it!
-	static const u32 bumpAllocatorOffset = 0x24000000;
+	static const u32 codeBumpAllocatorOffset = 0x14000000;
 }
 
 // --------------------------------------------------------------------------------------
@@ -87,17 +96,24 @@ class SysMainMemory
 {
 protected:
 	const VirtualMemoryManagerPtr m_mainMemory;
-	VirtualMemoryBumpAllocator    m_bumpAllocator;
-	eeMemoryReserve               m_ee;
-	iopMemoryReserve              m_iop;
-	vuMemoryReserve               m_vu;
+	const VirtualMemoryManagerPtr m_codeMemory;
+
+	VirtualMemoryBumpAllocator m_bumpAllocator;
+	VirtualMemoryBumpAllocator m_codeBumpAllocator;
+
+	eeMemoryReserve m_ee;
+	iopMemoryReserve m_iop;
+	vuMemoryReserve m_vu;
 
 public:
 	SysMainMemory();
 	virtual ~SysMainMemory();
 
-	const VirtualMemoryManagerPtr& MainMemory()    { return m_mainMemory; }
-	VirtualMemoryBumpAllocator&    BumpAllocator() { return m_bumpAllocator; }
+	const VirtualMemoryManagerPtr& MainMemory() { return m_mainMemory; }
+	const VirtualMemoryManagerPtr& CodeMemory() { return m_codeMemory; }
+
+	VirtualMemoryBumpAllocator& BumpAllocator() { return m_bumpAllocator; }
+	VirtualMemoryBumpAllocator& CodeBumpAllocator() { return m_codeBumpAllocator; }
 
 	virtual void ReserveAll();
 	virtual void CommitAll();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -983,6 +983,7 @@ void VMManager::Execute()
 		// We need to switch the cpus out, and reset the new ones if so.
 		s_cpu_provider_pack->ApplyConfig();
 		SysClearExecutionCache();
+		vtlb_ResetFastmem();
 	}
 
 	// Execute until we're asked to stop.
@@ -1045,6 +1046,9 @@ void VMManager::CheckForCPUConfigChanges(const Pcsx2Config& old_config)
 	SetCPUState(EmuConfig.Cpu.sseMXCSR, EmuConfig.Cpu.sseVUMXCSR);
 	SysClearExecutionCache();
 	memBindConditionalHandlers();
+
+	if (EmuConfig.Cpu.Recompiler.EnableFastmem != old_config.Cpu.Recompiler.EnableFastmem)
+		vtlb_ResetFastmem();
 
 	// did we toggle recompilers?
 	if (EmuConfig.Cpu.CpusChanged(old_config.Cpu))

--- a/pcsx2/ps2/HwInternal.h
+++ b/pcsx2/ps2/HwInternal.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "Hw.h"
+#include "SingleRegisterTypes.h"
 
 // --------------------------------------------------------------------------------------
 //  IsPageFor() / iswitch() / icase()   [macros!]
@@ -58,8 +59,8 @@ template<uint page> extern void __fastcall hwWrite8  (u32 mem, u8  value);
 template<uint page> extern void __fastcall hwWrite16 (u32 mem, u16 value);
 
 template<uint page> extern void __fastcall hwWrite32 (u32 mem, mem32_t value);
-template<uint page> extern void __fastcall hwWrite64 (u32 mem, const mem64_t* srcval);
-template<uint page> extern void __fastcall hwWrite128(u32 mem, const mem128_t* srcval);
+template<uint page> extern void TAKES_R64 hwWrite64 (u32 mem, r64 srcval);
+template<uint page> extern void TAKES_R128 hwWrite128(u32 mem, r128 srcval);
 
 // --------------------------------------------------------------------------------------
 //  Hardware FIFOs (128 bit access only!)

--- a/pcsx2/ps2/LegacyDmac.cpp
+++ b/pcsx2/ps2/LegacyDmac.cpp
@@ -72,12 +72,12 @@ tDMA_TAG DMACh::dma_tag()
 
 wxString DMACh::cmq_to_str() const
 {
-	return wxsFormat(L"chcr = %lx, madr = %lx, qwc  = %lx", chcr._u32, madr, qwc);
+	return wxsFormat(L"chcr = %x, madr = %x, qwc  = %x", chcr._u32, madr, qwc);
 }
 
 wxString DMACh::cmqt_to_str() const
 {
-	return wxsFormat(L"chcr = %lx, madr = %lx, qwc  = %lx, tadr = %1x", chcr._u32, madr, qwc, tadr);
+	return wxsFormat(L"chcr = %x, madr = %x, qwc  = %x, tadr = %x", chcr._u32, madr, qwc, tadr);
 }
 
 __fi void throwBusError(const char *s)

--- a/pcsx2/ps2/eeHwTraceLog.inl
+++ b/pcsx2/ps2/eeHwTraceLog.inl
@@ -273,14 +273,25 @@ static __ri void eeHwTraceLog( u32 addr, T val, bool mode )
 	FastFormatAscii labelStr;
 	labelStr.Write("Hw%s%u", mode ? "Read" : "Write", sizeof (T) * 8);
 
-	switch( sizeof(T) )
+	if constexpr (sizeof(T) == 1)
 	{
-		case 1: valStr.Write("0x%02x", val); break;
-		case 2: valStr.Write("0x%04x", val); break;
-		case 4: valStr.Write("0x%08x", val); break;
-
-		case 8: valStr.Write("0x%08x.%08x", ((u32*)&val)[1], ((u32*)&val)[0]); break;
-		case 16: ((u128&)val).WriteTo(valStr);
+		valStr.Write("0x%02x", val);
+	}
+	else if constexpr (sizeof(T) == 2)
+	{
+		valStr.Write("0x%04x", val);
+	}
+	else if constexpr (sizeof(T) == 4)
+	{
+		valStr.Write("0x%08x", val);
+	}
+	else if constexpr (sizeof(T) == 8)
+	{
+		valStr.Write("0x%08x.%08x", r64_to_u32_hi(val), r64_to_u32(val));
+	}
+	else if constexpr (sizeof(T) == 16)
+	{
+		r128_to_u128(val).WriteTo(valStr);
 	}
 			
 	static const char* temp = "%-12s @ 0x%08X/%-16s %s %s";

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -35,8 +35,16 @@
 #include "COP0.h"
 #include "Cache.h"
 #include "R5900Exceptions.h"
+#include "IopMem.h"
 
 #include "common/MemsetFast.inl"
+
+#include <map>
+#include <unordered_set>
+#include <unordered_map>
+
+#define FASTMEM_LOG(...)
+//#define FASTMEM_LOG(...) Console.WriteLn(__VA_ARGS__)
 
 using namespace R5900;
 using namespace vtlb_private;
@@ -55,6 +63,36 @@ static vtlbHandler UnmappedVirtHandler0;
 static vtlbHandler UnmappedVirtHandler1;
 static vtlbHandler UnmappedPhyHandler0;
 static vtlbHandler UnmappedPhyHandler1;
+
+struct FastmemVirtualMapping
+{
+	u32 offset;
+	u32 size;
+};
+
+struct LoadstoreBackpatchInfo
+{
+	u32 guest_pc;
+	u32 gpr_bitmask;
+	u32 fpr_bitmask;
+	u8 code_size;
+	u8 address_register;
+	u8 data_register;
+	u8 size_in_bits;
+	bool is_signed;
+	bool is_load;
+	bool is_fpr;
+};
+
+static constexpr size_t FASTMEM_AREA_SIZE = 0x100000000ULL;
+static constexpr u32 FASTMEM_PAGE_COUNT = FASTMEM_AREA_SIZE / VTLB_PAGE_SIZE;
+static constexpr u32 NO_FASTMEM_MAPPING = 0xFFFFFFFFu;
+
+static std::unique_ptr<SharedMemoryMappingArea> s_fastmem_area;
+static std::vector<u32> s_fastmem_virtual_mapping; // maps vaddr -> mainmem offset
+static std::unordered_multimap<u32, u32> s_fastmem_physical_mapping;	// maps mainmem offset -> vaddr
+static std::unordered_map<uptr, LoadstoreBackpatchInfo> s_fastmem_backpatch_info;
+static std::unordered_set<u32> s_fastmem_faulting_pcs;
 
 vtlb_private::VTLBPhysical vtlb_private::VTLBPhysical::fromPointer(sptr ptr) {
 	pxAssertMsg(ptr >= 0, "Address too high");
@@ -252,7 +290,7 @@ void __fastcall vtlb_memWrite(u32 addr, DataType data)
 	}
 }
 
-void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value)
+void TAKES_R64 vtlb_memWrite64(u32 mem, r64 value)
 {
 	auto vmv = vtlbdata.vmap[mem>>VTLB_PAGE_BITS];
 
@@ -262,12 +300,12 @@ void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value)
 		{
 			if(CHECK_CACHE && CheckCache(mem)) 
 			{
-				writeCache64(mem, *value);
+				writeCache64(mem, r64_to_u64(value));
 				return;
 			}
 		}
 
-		*(mem64_t*)vmv.assumePtr(mem) = *value;
+		*(mem64_t*)vmv.assumePtr(mem) = r64_to_u64(value);
 	}
 	else
 	{
@@ -279,7 +317,7 @@ void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value)
 	}
 }
 
-void __fastcall vtlb_memWrite128(u32 mem, const mem128_t *value)
+void TAKES_R128 vtlb_memWrite128(u32 mem, r128 value)
 {
 	auto vmv = vtlbdata.vmap[mem>>VTLB_PAGE_BITS];
 
@@ -289,12 +327,13 @@ void __fastcall vtlb_memWrite128(u32 mem, const mem128_t *value)
 		{
 			if(CHECK_CACHE && CheckCache(mem)) 
 			{
-				writeCache128(mem, value);
+				alignas(16) const u128 r = r128_to_u128(value);
+				writeCache128(mem, &r);
 				return;
 			}
 		}
 
-		CopyQWC((void*)vmv.assumePtr(mem), value);
+		r128_store_unaligned((void*)vmv.assumePtr(mem), value);
 	}
 	else
 	{
@@ -443,7 +482,7 @@ template<typename OperandType, u32 saddr>
 void __fastcall vtlbUnmappedVWriteSm(u32 addr,OperandType data)        { vtlb_Miss(addr|saddr,1); }
 
 template<typename OperandType, u32 saddr>
-void __fastcall vtlbUnmappedVWriteLg(u32 addr,const OperandType* data) { vtlb_Miss(addr|saddr,1); }
+void __vectorcall vtlbUnmappedVWriteLg(u32 addr,u_to_r<OperandType> data)      { vtlb_Miss(addr|saddr,1); }
 
 template<typename OperandType, u32 saddr>
 OperandType __fastcall vtlbUnmappedPReadSm(u32 addr)                   { vtlb_BusError(addr|saddr,0); return 0; }
@@ -455,7 +494,7 @@ template<typename OperandType, u32 saddr>
 void __fastcall vtlbUnmappedPWriteSm(u32 addr,OperandType data)        { vtlb_BusError(addr|saddr,1); }
 
 template<typename OperandType, u32 saddr>
-void __fastcall vtlbUnmappedPWriteLg(u32 addr,const OperandType* data) { vtlb_BusError(addr|saddr,1); }
+void __vectorcall vtlbUnmappedPWriteLg(u32 addr,u_to_r<OperandType> data)      { vtlb_BusError(addr|saddr,1); }
 
 // --------------------------------------------------------------------------------------
 //  VTLB mapping errors
@@ -482,13 +521,13 @@ static mem32_t __fastcall vtlbDefaultPhyRead32(u32 addr)
 	return 0;
 }
 
-static __m128i __vectorcall vtlbDefaultPhyRead64(u32 addr)
+static RETURNS_R64 vtlbDefaultPhyRead64(u32 addr)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted read64 from unmapped physical address @ 0x%08X.", addr));
 	return r64_zero();
 }
 
-static __m128i __vectorcall vtlbDefaultPhyRead128(u32 addr)
+static RETURNS_R128 vtlbDefaultPhyRead128(u32 addr)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted read128 from unmapped physical address @ 0x%08X.", addr));
 	return r128_zero();
@@ -509,12 +548,12 @@ static void __fastcall vtlbDefaultPhyWrite32(u32 addr, mem32_t data)
 	pxFailDev(pxsFmt("(VTLB) Attempted write32 to unmapped physical address @ 0x%08X.", addr));
 }
 
-static void __fastcall vtlbDefaultPhyWrite64(u32 addr,const mem64_t* data)
+static void TAKES_R64 vtlbDefaultPhyWrite64(u32 addr,r64 data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write64 to unmapped physical address @ 0x%08X.", addr));
 }
 
-static void __fastcall vtlbDefaultPhyWrite128(u32 addr,const mem128_t* data)
+static void TAKES_R128 vtlbDefaultPhyWrite128(u32 addr,r128 data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write128 to unmapped physical address @ 0x%08X.", addr));
 }
@@ -658,6 +697,257 @@ __fi u32 vtlb_V2P(u32 vaddr)
 	return paddr;
 }
 
+static bool vtlb_GetMainMemoryOffsetFromPtr(uptr ptr, u32* mainmem_offset, u32* mainmem_size, PageProtectionMode* prot)
+{
+	const uptr page_end = ptr + VTLB_PAGE_SIZE;
+
+	// EE memory and ROMs.
+	if (ptr >= (uptr)eeMem->Main && page_end <= (uptr)eeMem->ZeroRead)
+	{
+		const u32 eemem_offset = static_cast<u32>(ptr - (uptr)eeMem->Main);
+		const bool writeable = ((eemem_offset < Ps2MemSize::MainRam) ? (mmap_GetRamPageInfo(eemem_offset) != ProtMode_Write) : true);
+		*mainmem_offset = (eemem_offset + HostMemoryMap::EEmemOffset);
+		*mainmem_size = (offsetof(EEVM_MemoryAllocMess, ZeroRead) - eemem_offset);
+		*prot = PageProtectionMode().Read().Write(writeable);
+		return true;
+	}
+
+	// IOP memory.
+	if (ptr >= (uptr)iopMem->Main && page_end <= (uptr)iopMem->P)
+	{
+		const u32 iopmem_offset = static_cast<u32>(ptr - (uptr)iopMem->Main);
+		*mainmem_offset = iopmem_offset + HostMemoryMap::IOPmemOffset;
+		*mainmem_size = (offsetof(IopVM_MemoryAllocMess, P) - iopmem_offset);
+		*prot = PageProtectionMode().Read().Write();
+		return true;
+	}
+
+	// We end up with some unknown mappings here; currently the IOP memory, instead of being physically mapped
+	// as 2MB, ends up being mapped as 8MB. But this shouldn't be virtual mapped anyway, so fallback to slowmem
+	// in such cases.
+	return false;
+}
+
+static bool vtlb_GetMainMemoryOffset(u32 paddr, u32* mainmem_offset, u32* mainmem_size, PageProtectionMode* prot)
+{
+	if (paddr >= VTLB_PMAP_SZ)
+		return false;
+
+	// Handlers aren't in our shared memory, obviously.
+	const VTLBPhysical& vm = vtlbdata.pmap[paddr >> VTLB_PAGE_BITS];
+	if (vm.isHandler())
+		return false;
+
+	return vtlb_GetMainMemoryOffsetFromPtr(vm.raw(), mainmem_offset, mainmem_size, prot);
+}
+
+static void vtlb_CreateFastmemMapping(u32 vaddr, u32 mainmem_offset, const PageProtectionMode& mode)
+{
+	FASTMEM_LOG("Create fastmem mapping @ vaddr %08X mainmem %08X", vaddr, mainmem_offset);
+
+	const u32 page = vaddr / VTLB_PAGE_SIZE;
+
+	if (s_fastmem_virtual_mapping[page] == mainmem_offset)
+	{
+		// current mapping is fine
+		return;
+	}
+
+	if (s_fastmem_virtual_mapping[page] != NO_FASTMEM_MAPPING)
+	{
+		// current mapping needs to be removed
+		s_fastmem_virtual_mapping[page] = NO_FASTMEM_MAPPING;
+		if (!s_fastmem_area->Unmap(s_fastmem_area->PagePointer(page), VTLB_PAGE_SIZE))
+			Console.Error("Failed to unmap vaddr %08X", vaddr);
+
+		// remove reverse mapping
+		auto range = s_fastmem_physical_mapping.equal_range(mainmem_offset);
+		for (auto it = range.first; it != range.second; )
+		{
+			auto this_it = it++;
+			if (this_it->second == vaddr)
+				s_fastmem_physical_mapping.erase(this_it);
+		}
+	}
+
+	if (!s_fastmem_area->Map(GetVmMemory().MainMemory()->GetFileHandle(), mainmem_offset,
+			s_fastmem_area->PagePointer(page), VTLB_PAGE_SIZE, mode))
+	{
+		Console.Error("Failed to map vaddr %08X to mainmem offset %08X", vaddr, mainmem_offset);
+		return;
+	}
+
+	s_fastmem_virtual_mapping[page] = mainmem_offset;
+	s_fastmem_physical_mapping.emplace(mainmem_offset, vaddr);
+}
+
+static void vtlb_RemoveFastmemMapping(u32 vaddr)
+{
+	const u32 page = vaddr / VTLB_PAGE_SIZE;
+	if (s_fastmem_virtual_mapping[page] == NO_FASTMEM_MAPPING)
+		return;
+
+	const u32 mainmem_offset = s_fastmem_virtual_mapping[page];
+	FASTMEM_LOG("Remove fastmem mapping @ vaddr %08X mainmem %08X", vaddr, mainmem_offset);
+	s_fastmem_virtual_mapping[page] = NO_FASTMEM_MAPPING;
+
+	if (!s_fastmem_area->Unmap(s_fastmem_area->OffsetPointer(vaddr), VTLB_PAGE_SIZE))
+		Console.Error("Failed to unmap vaddr %08X", vaddr);
+
+	// remove from reverse map
+	auto range = s_fastmem_physical_mapping.equal_range(mainmem_offset);
+	for (auto it = range.first; it != range.second;)
+	{
+		auto this_it = it++;
+		if (this_it->second == vaddr)
+			s_fastmem_physical_mapping.erase(this_it);
+	}
+}
+
+static void vtlb_RemoveFastmemMappings(u32 vaddr, u32 size)
+{
+	pxAssert((vaddr & VTLB_PAGE_MASK) == 0);
+	pxAssert(size > 0 && (size & VTLB_PAGE_MASK) == 0);
+
+	const u32 num_pages = size / VTLB_PAGE_SIZE;
+	for (u32 i = 0; i < num_pages; i++, vaddr += VTLB_PAGE_SIZE)
+		vtlb_RemoveFastmemMapping(vaddr);
+}
+
+static void vtlb_RemoveFastmemMappings()
+{
+	if (s_fastmem_virtual_mapping.empty())
+	{
+		// not initialized yet
+		return;
+	}
+
+	for (u32 page = 0; page < FASTMEM_PAGE_COUNT; page++)
+	{
+		if (s_fastmem_virtual_mapping[page] == NO_FASTMEM_MAPPING)
+			continue;
+
+		s_fastmem_virtual_mapping[page] = NO_FASTMEM_MAPPING;
+		if (!s_fastmem_area->Unmap(s_fastmem_area->PagePointer(page), VTLB_PAGE_SIZE))
+			Console.Error("Failed to unmap vaddr %08X", page * VTLB_PAGE_SIZE);
+	}
+
+	s_fastmem_physical_mapping.clear();
+}
+
+bool vtlb_ResolveFastmemMapping(uptr* addr)
+{
+	uptr uaddr = *addr;
+	uptr fastmem_start = (uptr)vtlbdata.fastmem_base;
+	uptr fastmem_end = fastmem_start + 0xFFFFFFFFu;
+	if (uaddr < fastmem_start || uaddr > fastmem_end)
+		return false;
+
+	const u32 vaddr = static_cast<u32>(uaddr - fastmem_start);
+	FASTMEM_LOG("Trying to resolve %p (vaddr %08X)", (void*)uaddr, vaddr);
+
+	const u32 vpage = vaddr / VTLB_PAGE_SIZE;
+	if (s_fastmem_virtual_mapping[vpage] == NO_FASTMEM_MAPPING)
+	{
+		FASTMEM_LOG("%08X is not virtual mapped", vaddr);
+		return false;
+	}
+
+	const u32 mainmem_offset = s_fastmem_virtual_mapping[vpage] + (vaddr & VTLB_PAGE_MASK);
+	FASTMEM_LOG("Resolved %p (vaddr %08X) to mainmem offset %08X", uaddr, vaddr, mainmem_offset);
+	*addr = ((uptr)GetVmMemory().MainMemory()->GetBase()) + mainmem_offset;
+	return true;
+}
+
+bool vtlb_GetGuestAddress(uptr host_addr, u32* guest_addr)
+{
+	uptr fastmem_start = (uptr)vtlbdata.fastmem_base;
+	uptr fastmem_end = fastmem_start + 0xFFFFFFFFu;
+	if (host_addr < fastmem_start || host_addr > fastmem_end)
+		return false;
+
+	*guest_addr = static_cast<u32>(host_addr - fastmem_start);
+	return true;
+}
+
+void vtlb_UpdateFastmemProtection(u32 paddr, u32 size, const PageProtectionMode& prot)
+{
+	if (!CHECK_FASTMEM)
+		return;
+
+	pxAssert((paddr & VTLB_PAGE_MASK) == 0);
+	pxAssert(size > 0 && (size & VTLB_PAGE_MASK) == 0);
+
+	u32 mainmem_start, mainmem_size;
+	PageProtectionMode old_prot;
+	if (!vtlb_GetMainMemoryOffset(paddr, &mainmem_start, &mainmem_size, &old_prot))
+		return;
+
+	FASTMEM_LOG("UpdateFastmemProtection %08X mmoffset %08X %08X", paddr, mainmem_start, size);
+
+	u32 current_mainmem = mainmem_start;
+	const u32 num_pages = std::min(size, mainmem_size) / VTLB_PAGE_SIZE;
+	for (u32 i = 0; i < num_pages; i++, current_mainmem += VTLB_PAGE_SIZE)
+	{
+		// update virtual mapping mapping
+		auto range = s_fastmem_physical_mapping.equal_range(current_mainmem);
+		for (auto it = range.first; it != range.second; ++it)
+		{
+			FASTMEM_LOG("  valias %08X (size %u)", it->second, VTLB_PAGE_SIZE);
+			HostSys::MemProtect(s_fastmem_area->OffsetPointer(it->second), VTLB_PAGE_SIZE, prot);
+		}
+	}
+}
+
+void vtlb_ClearLoadStoreInfo()
+{
+	s_fastmem_backpatch_info.clear();
+	s_fastmem_faulting_pcs.clear();
+}
+
+void vtlb_AddLoadStoreInfo(uptr code_address, u32 code_size, u32 guest_pc, u32 gpr_bitmask, u32 fpr_bitmask, u8 address_register, u8 data_register, u8 size_in_bits, bool is_signed, bool is_load, bool is_fpr)
+{
+	pxAssert(code_size < std::numeric_limits<u8>::max());
+
+	auto iter = s_fastmem_backpatch_info.find(code_address);
+	if (iter != s_fastmem_backpatch_info.end())
+		s_fastmem_backpatch_info.erase(iter);
+
+	LoadstoreBackpatchInfo info{guest_pc, gpr_bitmask, fpr_bitmask, static_cast<u8>(code_size), address_register, data_register, size_in_bits, is_signed, is_load, is_fpr};
+	s_fastmem_backpatch_info.emplace(code_address, info);
+}
+
+bool vtlb_BackpatchLoadStore(uptr code_address, uptr fault_address)
+{
+	uptr fastmem_start = (uptr)vtlbdata.fastmem_base;
+	uptr fastmem_end = fastmem_start + 0xFFFFFFFFu;
+	if (fault_address < fastmem_start || fault_address > fastmem_end)
+		return false;
+
+	auto iter = s_fastmem_backpatch_info.find(code_address);
+	if (iter == s_fastmem_backpatch_info.end())
+		return false;
+
+	const LoadstoreBackpatchInfo& info = iter->second;
+	const u32 guest_addr = static_cast<u32>(fault_address - fastmem_start);
+	vtlb_DynBackpatchLoadStore(code_address, info.code_size, info.guest_pc, guest_addr,
+		info.gpr_bitmask, info.fpr_bitmask, info.address_register, info.data_register,
+		info.size_in_bits, info.is_signed, info.is_load, info.is_fpr);
+
+	// queue block for recompilation later
+	Cpu->Clear(info.guest_pc, 1);
+
+	// and store the pc in the faulting list, so that we don't emit another fastmem loadstore
+	s_fastmem_faulting_pcs.insert(info.guest_pc);
+	s_fastmem_backpatch_info.erase(iter);
+	return true;
+}
+
+bool vtlb_IsFaultingPC(u32 guest_pc)
+{
+	return (s_fastmem_faulting_pcs.find(guest_pc) != s_fastmem_faulting_pcs.end());
+}
+
 //virtual mappings
 //TODO: Add invalid paddr checks
 void vtlb_VMap(u32 vaddr,u32 paddr,u32 size)
@@ -665,6 +955,23 @@ void vtlb_VMap(u32 vaddr,u32 paddr,u32 size)
 	verify(0==(vaddr&VTLB_PAGE_MASK));
 	verify(0==(paddr&VTLB_PAGE_MASK));
 	verify(0==(size&VTLB_PAGE_MASK) && size>0);
+
+	if (CHECK_FASTMEM)
+	{
+		const u32 num_pages = size / VTLB_PAGE_SIZE;
+		u32 current_vaddr = vaddr;
+		u32 current_paddr = paddr;
+
+		for (u32 i = 0; i < num_pages; i++, current_vaddr += VTLB_PAGE_SIZE, current_paddr += VTLB_PAGE_SIZE)
+		{
+			u32 hoffset, hsize;
+			PageProtectionMode mode;
+			if (vtlb_GetMainMemoryOffset(current_paddr, &hoffset, &hsize, &mode))
+				vtlb_CreateFastmemMapping(current_vaddr, hoffset, mode);
+			else
+				vtlb_RemoveFastmemMapping(current_vaddr);
+		}
+	}
 
 	while (size > 0)
 	{
@@ -695,6 +1002,22 @@ void vtlb_VMapBuffer(u32 vaddr,void* buffer,u32 size)
 	verify(0==(vaddr&VTLB_PAGE_MASK));
 	verify(0==(size&VTLB_PAGE_MASK) && size>0);
 
+	if (CHECK_FASTMEM)
+	{
+		if (buffer == eeMem->Scratch && size == Ps2MemSize::Scratch)
+		{
+			u32 fm_vaddr = vaddr;
+			u32 fm_hostoffset = HostMemoryMap::EEmemOffset + offsetof(EEVM_MemoryAllocMess, Scratch);
+			PageProtectionMode mode = PageProtectionMode().Read().Write();
+			for (u32 i = 0; i < (Ps2MemSize::Scratch / VTLB_PAGE_SIZE); i++, fm_vaddr += VTLB_PAGE_SIZE, fm_hostoffset += VTLB_PAGE_SIZE)
+				vtlb_CreateFastmemMapping(fm_vaddr, fm_hostoffset, mode);
+		}
+		else
+		{
+			vtlb_RemoveFastmemMappings(vaddr, size);
+		}
+	}
+
 	uptr bu8 = (uptr)buffer;
 	while (size > 0)
 	{
@@ -709,6 +1032,8 @@ void vtlb_VMapUnmap(u32 vaddr,u32 size)
 {
 	verify(0==(vaddr&VTLB_PAGE_MASK));
 	verify(0==(size&VTLB_PAGE_MASK) && size>0);
+
+	vtlb_RemoveFastmemMappings(vaddr, size);
 
 	while (size > 0)
 	{
@@ -734,9 +1059,9 @@ void vtlb_Init()
 
 #define VTLB_BuildUnmappedHandler(baseName, highBit) \
 	baseName##ReadSm<mem8_t,0>,		baseName##ReadSm<mem16_t,0>,	baseName##ReadSm<mem32_t,0>, \
-	baseName##ReadLg<mem64_t,0>,	baseName##ReadLg<mem128_t,0>, \
+	baseName##ReadSm<mem64_t,0>,	baseName##ReadLg<mem128_t,0>, \
 	baseName##WriteSm<mem8_t,0>,	baseName##WriteSm<mem16_t,0>,	baseName##WriteSm<mem32_t,0>, \
-	baseName##WriteLg<mem64_t,0>,	baseName##WriteLg<mem128_t,0>
+	baseName##WriteSm<mem64_t,0>,	baseName##WriteLg<mem128_t,0>
 
 	//Register default handlers
 	//Unmapped Virt handlers _MUST_ be registered first.
@@ -774,7 +1099,36 @@ void vtlb_Init()
 // This function should probably be part of the COP0 rather than here in VTLB.
 void vtlb_Reset()
 {
+	vtlb_RemoveFastmemMappings();
 	for(int i=0; i<48; i++) UnmapTLB(i);
+}
+
+void vtlb_ResetFastmem()
+{
+	vtlb_RemoveFastmemMappings();
+	s_fastmem_backpatch_info.clear();
+	s_fastmem_faulting_pcs.clear();
+
+	if (!CHECK_FASTMEM || !CHECK_EEREC || !vtlbdata.vmap)
+		return;
+
+	// we need to go through and look at the vtlb pointers, to remap the host area
+	for (size_t i = 0; i < VTLB_VMAP_ITEMS; i++)
+	{
+		const VTLBVirtual& vm = vtlbdata.vmap[i];
+		const u32 vaddr = static_cast<u32>(i) << VTLB_PAGE_BITS;
+		if (vm.isHandler(vaddr))
+		{
+			// Handlers should be unmapped.
+			continue;
+		}
+
+		// Check if it's a physical mapping to our main memory area.
+		u32 mainmem_offset, mainmem_size;
+		PageProtectionMode prot;
+		if (vtlb_GetMainMemoryOffsetFromPtr(vm.assumePtr(vaddr), &mainmem_offset, &mainmem_size, &prot))
+			vtlb_CreateFastmemMapping(vaddr, mainmem_offset, prot);
+	}
 }
 
 void vtlb_Term()
@@ -796,14 +1150,21 @@ void vtlb_Core_Alloc()
 		vmap = (VTLBVirtual*)GetVmMemory().BumpAllocator().Alloc(VMAP_SIZE);
 	if (!vtlbdata.vmap)
 	{
-		bool okay = HostSys::MmapCommitPtr(vmap, VMAP_SIZE, PageProtectionMode().Read().Write());
-		if (okay) {
-			vtlbdata.vmap = vmap;
-		} else {
-			throw Exception::OutOfMemory( L"VTLB Virtual Address Translation LUT" )
-				.SetDiagMsg(pxsFmt("(%u megs)", VTLB_VMAP_ITEMS * sizeof(*vtlbdata.vmap) / _1mb)
-			);
-		}
+		HostSys::MemProtect(vmap, VMAP_SIZE, PageProtectionMode().Read().Write());
+		vtlbdata.vmap = vmap;
+	}
+
+	if (!vtlbdata.fastmem_base)
+	{
+		pxAssert(!s_fastmem_area);
+		s_fastmem_area = SharedMemoryMappingArea::Create(FASTMEM_AREA_SIZE);
+		if (!s_fastmem_area)
+			pxFailRel("Failed to allocate fastmem area");
+
+		s_fastmem_virtual_mapping.resize(FASTMEM_PAGE_COUNT, NO_FASTMEM_MAPPING);
+		vtlbdata.fastmem_base = (uptr)s_fastmem_area->BasePointer();
+		Console.WriteLn(Color_StrongGreen, "Fastmem area: %p - %p",
+			vtlbdata.fastmem_base, vtlbdata.fastmem_base + (FASTMEM_AREA_SIZE - 1));
 	}
 }
 
@@ -821,12 +1182,8 @@ void vtlb_Alloc_Ppmap()
 	if (!ppmap)
 		ppmap = (u32*)GetVmMemory().BumpAllocator().Alloc(PPMAP_SIZE);
 
-	bool okay = HostSys::MmapCommitPtr(ppmap, PPMAP_SIZE, PageProtectionMode().Read().Write());
-	if (okay)
-		vtlbdata.ppmap = ppmap;
-	else
-		throw Exception::OutOfMemory(L"VTLB PS2 Virtual Address Translation LUT")
-			.SetDiagMsg(pxsFmt("(%u megs)", PPMAP_SIZE / _1mb));
+	HostSys::MemProtect(ppmap, PPMAP_SIZE, PageProtectionMode().Read().Write());
+	vtlbdata.ppmap = ppmap;
 
 	// By default a 1:1 virtual to physical mapping
 	for (u32 i = 0; i < VTLB_VMAP_ITEMS; i++)
@@ -837,14 +1194,22 @@ void vtlb_Core_Free()
 {
 	if (vtlbdata.vmap)
 	{
-		HostSys::MmapResetPtr(vtlbdata.vmap, VMAP_SIZE);
+		HostSys::MemProtect(vtlbdata.vmap, VMAP_SIZE, PageProtectionMode());
 		vtlbdata.vmap = nullptr;
 	}
 	if (vtlbdata.ppmap)
 	{
-		HostSys::MmapResetPtr(vtlbdata.ppmap, PPMAP_SIZE);
+		HostSys::MemProtect(vtlbdata.ppmap, PPMAP_SIZE, PageProtectionMode());
 		vtlbdata.ppmap = nullptr;
 	}
+
+	vtlb_RemoveFastmemMappings();
+	vtlb_ClearLoadStoreInfo();
+
+	vtlbdata.fastmem_base = 0;
+	decltype(s_fastmem_physical_mapping)().swap(s_fastmem_physical_mapping);
+	decltype(s_fastmem_virtual_mapping)().swap(s_fastmem_virtual_mapping);
+	s_fastmem_area.reset();
 }
 
 static wxString GetHostVmErrorMsg()

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -686,7 +686,7 @@ static void recReserveCache()
 
 	while (!recMem->IsOk())
 	{
-		if (recMem->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::IOPrecOffset, m_ConfiguredCacheReserve * _1mb) != NULL)
+		if (recMem->Reserve(GetVmMemory().CodeMemory(), HostMemoryMap::IOPrecOffset, m_ConfiguredCacheReserve * _1mb) != NULL)
 			break;
 
 		// If it failed, then try again (if possible):

--- a/pcsx2/x86/iR5900.h
+++ b/pcsx2/x86/iR5900.h
@@ -22,6 +22,9 @@
 #include "iCore.h"
 #include "R5900_Profiler.h"
 
+// Register containing a pointer to our fastmem (4GB) area
+#define RFASTMEMBASE x86Emitter::rbp
+
 extern u32 maxrecmem;
 extern u32 pc;             // recompiler pc
 extern int g_branch;       // set for branch
@@ -61,6 +64,10 @@ extern bool s_nBlockInterlocked; // Current block has VU0 interlocking
 	}
 
 extern bool g_recompilingDelaySlot;
+
+// Used for generating backpatch thunks for fastmem.
+u8* recBeginThunk();
+u8* recEndThunk();
 
 // used when processing branches
 void SaveBranchState();
@@ -112,6 +119,7 @@ u32* _eeGetConstReg(int reg);
 
 // finds where the GPR is stored and moves lower 32 bits to EAX
 void _eeMoveGPRtoR(const x86Emitter::xRegister32& to, int fromgpr);
+void _eeMoveGPRtoR(const x86Emitter::xRegister64& to, int fromgpr);
 void _eeMoveGPRtoM(uptr to, int fromgpr);
 void _eeMoveGPRtoRm(x86IntRegType to, int fromgpr);
 void _signExtendToMem(void* mem);

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -40,8 +40,8 @@ void mVUreserveCache(microVU& mVU)
 	mVU.cache_reserve->SetProfilerName(pxsFmt("mVU%urec", mVU.index));
 
 	mVU.cache = mVU.index
-		? (u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU1recOffset, mVU.cacheSize * _1mb)
-		: (u8*)mVU.cache_reserve->Reserve(GetVmMemory().MainMemory(), HostMemoryMap::mVU0recOffset, mVU.cacheSize * _1mb);
+		? (u8*)mVU.cache_reserve->Reserve(GetVmMemory().CodeMemory(), HostMemoryMap::mVU1recOffset, mVU.cacheSize * _1mb)
+		: (u8*)mVU.cache_reserve->Reserve(GetVmMemory().CodeMemory(), HostMemoryMap::mVU0recOffset, mVU.cacheSize * _1mb);
 
 	mVU.cache_reserve->ThrowIfNotOk();
 }

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -37,7 +37,7 @@ void dVifReserve(int idx)
 		nVif[idx].recReserve = new RecompiledCodeReserve(pxsFmt(L"VIF%u Unpack Recompiler Cache", idx), _8mb);
 
 	auto offset = idx ? HostMemoryMap::VIF1recOffset : HostMemoryMap::VIF0recOffset;
-	nVif[idx].recReserve->Reserve(GetVmMemory().MainMemory(), offset, 8 * _1mb);
+	nVif[idx].recReserve->Reserve(GetVmMemory().CodeMemory(), offset, 8 * _1mb);
 }
 
 void dVifReset(int idx)

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -346,7 +346,7 @@ void VifUnpackSSE_Init()
 
 	nVifUpkExec = new RecompiledCodeReserve(L"VIF SSE-optimized Unpacking Functions", _64kb);
 	nVifUpkExec->SetProfilerName("iVIF-SSE");
-	nVifUpkExec->Reserve(GetVmMemory().BumpAllocator(), _64kb);
+	nVifUpkExec->Reserve(GetVmMemory().CodeBumpAllocator(), _64kb);
 
 	nVifUpkExec->ThrowIfNotOk();
 

--- a/tests/ctest/x86emitter/codegen_tests_main.cpp
+++ b/tests/ctest/x86emitter/codegen_tests_main.cpp
@@ -166,4 +166,10 @@ TEST(CodegenTests, SSETest)
 	CODEGEN_TEST_BOTH(xBLEND.PS(xmm0, xmm1, 0x55), "66 0f 3a 0c c1 55");
 	CODEGEN_TEST_64(xBLEND.PD(xmm8, xmm9, 0xaa), "66 45 0f 3a 0d c1 aa");
 	CODEGEN_TEST_64(xEXTRACTPS(ptr32[base], xmm1, 2), "66 0f 3a 17 0d f6 ff ff ff 02");
+	CODEGEN_TEST_64(xMOVD(eax, xmm1), "66 0f 7e c8");
+	CODEGEN_TEST_64(xMOVD(eax, xmm10), "66 44 0f 7e d0");
+	CODEGEN_TEST_64(xMOVD(rax, xmm1), "66 48 0f 7e c8");
+	CODEGEN_TEST_64(xMOVD(r10, xmm1), "66 49 0f 7e ca");
+	CODEGEN_TEST_64(xMOVD(rax, xmm10), "66 4c 0f 7e d0");
+	CODEGEN_TEST_64(xMOVD(r10, xmm10), "66 4d 0f 7e d2");
 }


### PR DESCRIPTION
### Description of Changes

Now that 32-bit is gone, we can do fastmem! What is fastmem? It's basically the idea of abusing the host's MMU to do virtual address translation for the guest.

This is still work in progress; I still have to fix up the unaligned loadstore instructions, and fix some edge cases with page remapping on Windows. But it works well enough for some basic testing (use Qt, I didn't even add the options in wx.)

Quoting myself because it's late and I don't feel like rewriting an explanation today:

> fastmem just takes that idea of RAM/MMIO pages a step further, and reserves a 4GB region (reserves, so only the page tables are allocated, no actual memory), and then aliases the EE RAM throughout it based on the TLB state
> so, MMIO pages have no mapping, and will page fault when you try to access them
> so, when you want to access it in the EE JIT, you just yolo access [base + address], if you fault, you backpatch, jump out to a handler which saves regs, calls the C handler, restores and jumps back
> basically, optimizing for 99% of cases, and handling the other 1% when they actually happen 😉
> current VTLB is still reasonably efficient though; it tests the MSB bit of the pointer in the LUT to check if it's a handler/MMIO page. but it's still an extra memory load (for the pointer), and a compare/branch, whereas with fastmem, we abuse the host's address translation
> basically, on x86, it does something like (assuming the address you want to load is in rcx, and data goes into rsi)
```
mov rdx, rcx
shr rdx, 12
mov rax, oops_we_hit_a_hw_address
mov rbx, qword [vtlb_vmap + rdx * 8]  ; lookup page in vtlb
test rbx, rbx ; check if it's a handler page
js C_dispatcher ; jump out to C if it's a handler page
and rcx, 4095 ; get page offset
mov esi, dword [rbx + rcx] ; load RAM
oops_we_hit_a_hw_address: ; jump back location for handlers
```
in contrast, that same load with fastmem would be (assuming address in rcx, data in rsi, fastmem base pointer in rbp)
```
mov esi, dword [rbp + rcx]
```

> with the added benefit that you don't need to flush the regcache prior, since with the current behavior, you don't know if it's going to call to C or not (and with fastmem, you save it in the "slow" thunk)

Performance boost won't be huge yet, it can be 5-10% depending on the game, often <5%. But it enables further optimization with register caching in the future, and it all adds up.

### Rationale behind Changes

Little bit of brr.

### Suggested Testing Steps

I'll update when it's actually ready for testing/use.
