### PR TITLE
New semaphore for work processing threads

### DIFF
--- a/common/Darwin/DarwinSemaphore.cpp
+++ b/common/Darwin/DarwinSemaphore.cpp
@@ -57,6 +57,61 @@ static void MACH_CHECK(kern_return_t mach_retval)
 	}
 }
 
+Threading::KernelSemaphore::KernelSemaphore()
+{
+	MACH_CHECK(semaphore_create(mach_task_self(), &m_sema, SYNC_POLICY_FIFO, 0));
+}
+
+Threading::KernelSemaphore::~KernelSemaphore()
+{
+	MACH_CHECK(semaphore_destroy(mach_task_self(), m_sema));
+}
+
+void Threading::KernelSemaphore::Post()
+{
+	MACH_CHECK(semaphore_signal(m_sema));
+}
+
+void Threading::KernelSemaphore::Wait()
+{
+	pxAssertMsg(!wxThread::IsMain(), "Unyielding semaphore wait issued from the main/gui thread.  Use WaitWithYield.");
+	MACH_CHECK(semaphore_wait(m_sema));
+}
+
+/// Wait up to the given time
+/// Returns true if successful, false if timed out
+static bool WaitUpTo(semaphore_t sema, wxTimeSpan wxtime)
+{
+	mach_timespec_t time;
+	u64 ms = wxtime.GetMilliseconds().GetValue();
+	time.tv_sec = ms / 1000;
+	time.tv_nsec = (ms % 1000) * 1000000;
+	kern_return_t res = semaphore_timedwait(sema, time);
+	if (res == KERN_OPERATION_TIMED_OUT)
+		return false;
+	MACH_CHECK(res);
+	return true;
+}
+
+void Threading::KernelSemaphore::WaitWithYield()
+{
+#if wxUSE_GUI
+	if (!wxThread::IsMain() || (wxTheApp == NULL))
+	{
+		Wait();
+	}
+	else
+	{
+		while (!WaitUpTo(m_sema, def_yieldgui_interval))
+		{
+			YieldToMain();
+		}
+	}
+#else
+	WaitWithoutYield();
+#endif
+}
+
 Threading::Semaphore::Semaphore()
 {
 	// other platforms explicitly make a thread-private (unshared) semaphore
@@ -177,7 +232,9 @@ void Threading::Semaphore::Wait()
 	}
 	else
 	{
-		while (!WaitWithoutYield(def_yieldgui_interval))
+		if (__atomic_sub_fetch(&m_counter, 1, __ATOMIC_ACQUIRE) >= 0)
+			return;
+		while (!WaitUpTo(m_sema, def_yieldgui_interval))
 		{
 			YieldToMain();
 		}

--- a/common/PersistentThread.h
+++ b/common/PersistentThread.h
@@ -100,7 +100,7 @@ namespace Threading
 		uptr m_native_id; // typically an id, but implementing platforms can do whatever.
 		uptr m_native_handle; // typically a pointer/handle, but implementing platforms can do whatever.
 
-		Semaphore m_sem_event; // general wait event that's needed by most threads
+		WorkSema m_sem_event; // general wait event that's needed by most threads
 		Semaphore m_sem_startup; // startup sync tool
 		Mutex m_mtx_InThread; // used for canceling and closing threads in a deadlock-safe manner
 		MutexRecursive m_mtx_start; // used to lock the Start() code from starting simultaneous threads accidentally.

--- a/common/Semaphore.cpp
+++ b/common/Semaphore.cpp
@@ -13,8 +13,6 @@
 *  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if !defined(__APPLE__)
-
 #include "common/Threading.h"
 #include "common/wxBaseTools.h"
 #include "common/ThreadingInternal.h"
@@ -22,6 +20,155 @@
 // --------------------------------------------------------------------------------------
 //  Semaphore Implementations
 // --------------------------------------------------------------------------------------
+
+
+void Threading::WorkSema::WaitForWork()
+{
+	// State change:
+	// SLEEPING, SPINNING: This is the worker thread and it's clearly not asleep or spinning, so these states should be impossible
+	// RUNNING_0: Change state to SLEEPING, wake up thread if WAITING_EMPTY
+	// RUNNING_N: Change state to RUNNING_0 (and preserve WAITING_EMPTY flag)
+	s32 value = m_state.load(std::memory_order_relaxed);
+	while (!m_state.compare_exchange_weak(value, NextStateWaitForWork(value), std::memory_order_acq_rel, std::memory_order_relaxed))
+		;
+	if (IsReadyForSleep(value))
+	{
+		if (value & STATE_FLAG_WAITING_EMPTY)
+			m_empty_sema.Post();
+		m_sema.Wait();
+		// Acknowledge any additional work added between wake up request and getting here
+		m_state.fetch_and(STATE_FLAG_WAITING_EMPTY, std::memory_order_acquire);
+	}
+}
+
+void Threading::WorkSema::WaitForWorkWithSpin()
+{
+	s32 value = m_state.load(std::memory_order_relaxed);
+	while (IsReadyForSleep(value))
+	{
+		if (m_state.compare_exchange_weak(value, STATE_SPINNING, std::memory_order_release, std::memory_order_relaxed))
+		{
+			if (value & STATE_FLAG_WAITING_EMPTY)
+				m_empty_sema.Post();
+			value = STATE_SPINNING;
+			break;
+		}
+	}
+	u32 waited = 0;
+	while (value < 0)
+	{
+		if (waited > SPIN_TIME_NS)
+		{
+			if (!m_state.compare_exchange_weak(value, STATE_SLEEPING, std::memory_order_relaxed))
+				continue;
+			m_sema.Wait();
+			break;
+		}
+		waited += ShortSpin();
+		value = m_state.load(std::memory_order_relaxed);
+	}
+	// Clear back to STATE_RUNNING_0 (but preserve waiting empty flag)
+	m_state.fetch_and(STATE_FLAG_WAITING_EMPTY, std::memory_order_acquire);
+}
+
+void Threading::WorkSema::WaitForEmpty()
+{
+	s32 value = m_state.load(std::memory_order_acquire);
+	while (true)
+	{
+		if (value < 0)
+			return; // STATE_SLEEPING or STATE_SPINNING, queue is empty!
+		if (m_state.compare_exchange_weak(value, value | STATE_FLAG_WAITING_EMPTY, std::memory_order_relaxed, std::memory_order_acquire))
+			break;
+	}
+	pxAssertDev(!(value & STATE_FLAG_WAITING_EMPTY), "Multiple threads attempted to wait for empty (not currently supported)");
+	m_empty_sema.WaitWithYield();
+}
+
+void Threading::WorkSema::WaitForEmptyWithSpin()
+{
+	s32 value = m_state.load(std::memory_order_acquire);
+	u32 waited = 0;
+	while (true)
+	{
+		if (value < 0)
+			return; // STATE_SLEEPING or STATE_SPINNING, queue is empty!
+		if (waited > SPIN_TIME_NS && m_state.compare_exchange_weak(value, value | STATE_FLAG_WAITING_EMPTY, std::memory_order_relaxed, std::memory_order_acquire))
+			break;
+		waited += ShortSpin();
+		value = m_state.load(std::memory_order_acquire);
+	}
+	pxAssertDev(!(value & STATE_FLAG_WAITING_EMPTY), "Multiple threads attempted to wait for empty (not currently supported)");
+	m_empty_sema.WaitWithYield();
+}
+
+#if !defined(__APPLE__) // macOS implementations are in DarwinSemaphore
+
+Threading::KernelSemaphore::KernelSemaphore()
+{
+#ifdef _WIN32
+	m_sema = CreateSemaphore(nullptr, 0, LONG_MAX, nullptr);
+#else
+	sem_init(&m_sema, false, 0);
+#endif
+}
+
+Threading::KernelSemaphore::~KernelSemaphore()
+{
+#ifdef _WIN32
+	CloseHandle(m_sema);
+#else
+	sem_destroy(&m_sema);
+#endif
+}
+
+void Threading::KernelSemaphore::Post()
+{
+#ifdef _WIN32
+	ReleaseSemaphore(m_sema, 1, nullptr);
+#else
+	sem_post(&m_sema);
+#endif
+}
+
+void Threading::KernelSemaphore::Wait()
+{
+	pxAssertMsg(!wxThread::IsMain(), "Unyielding semaphore wait issued from the main/gui thread.  Use WaitWithYield.");
+#ifdef _WIN32
+	pthreadCancelableWait(m_sema);
+#else
+	sem_wait(&m_sema);
+#endif
+}
+
+void Threading::KernelSemaphore::WaitWithYield()
+{
+#if wxUSE_GUI
+	if (!wxThread::IsMain() || (wxTheApp == NULL))
+	{
+		Wait();
+	}
+	else
+	{
+#ifdef _WIN32
+		u64 millis = def_yieldgui_interval.GetMilliseconds().GetValue();
+		while (pthreadCancelableTimedWait(m_sema, millis) == WAIT_TIMEOUT)
+			YieldToMain();
+#else
+		while (true)
+		{
+			wxDateTime megafail(wxDateTime::UNow() + def_yieldgui_interval);
+			const timespec fail = {megafail.GetTicks(), megafail.GetMillisecond() * 1000000};
+			if (sem_timedwait(&m_sema, &fail) == 0)
+				break;
+			YieldToMain();
+		}
+#endif
+	}
+#else
+	Wait();
+#endif
+}
 
 Threading::Semaphore::Semaphore()
 {

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -329,15 +329,13 @@ public:
 	std::atomic<unsigned int> m_ReadPos;  // cur pos gs is reading from
 	std::atomic<unsigned int> m_WritePos; // cur pos ee thread is writing to
 
-	std::atomic<bool>	m_RingBufferIsBusy;
 	std::atomic<bool>	m_SignalRingEnable;
 	std::atomic<int>	m_SignalRingPosition;
 
 	std::atomic<int>	m_QueuedFrameCount;
 	std::atomic<bool>	m_VsyncSignalListener;
 
-	Mutex			m_mtx_RingBufferBusy;  // Is obtained while processing ring-buffer data
-	Mutex			m_mtx_RingBufferBusy2; // This one gets released on semaXGkick waiting...
+	Mutex			m_mtx_RingBufferBusy2; // Gets released on semaXGkick waiting...
 	Mutex			m_mtx_WaitGS;
 	Semaphore		m_sem_OnRingReset;
 	Semaphore		m_sem_Vsync;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -400,7 +400,6 @@ void SysMtgsThread::ExecuteTaskInThread()
 				case GS_RINGTYPE_MTVU_GSPACKET:
 				{
 					MTVU_LOG("MTGS - Waiting on semaXGkick!");
-					vu1Thread.KickStart(true);
 					if (!vu1Thread.semaXGkick.TryWait())
 					{
 						busy.PartialRelease();

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <wx/datetime.h>
 
+#include "common/ScopedGuard.h"
 #include "common/StringUtil.h"
 
 #include "GS.h"
@@ -76,7 +77,6 @@ void SysMtgsThread::OnStart()
 
 	m_ReadPos = 0;
 	m_WritePos = 0;
-	m_RingBufferIsBusy = false;
 	m_packet_size = 0;
 	m_packet_writepos = 0;
 
@@ -176,12 +176,6 @@ void SysMtgsThread::PostVsyncStart(bool registers_written)
 	m_VsyncSignalListener.store(true, std::memory_order_release);
 	//Console.WriteLn( Color_Blue, "(EEcore Sleep) Vsync\t\tringpos=0x%06x, writepos=0x%06x", m_ReadPos.load(), m_WritePos.load() );
 
-	// We will wait a vsync event from the MTGS ring. If the ring is already purged, the event will never come !
-	// To avoid this potential deadlock, ring must be wake up after m_VsyncSignalListener
-	// Note: potentially we can also miss the previous wake up if we optimize away the post just before the release of busy signal of the ring
-	// So let's ensure the ring doesn't sleep
-	m_sem_event.Post();
-
 	m_sem_Vsync.WaitNoCancel();
 }
 
@@ -219,46 +213,6 @@ void SysMtgsThread::OpenGS()
 	GSsetGameCRC(ElfCRC, 0);
 }
 
-class RingBufferLock
-{
-	ScopedLock m_lock1;
-	ScopedLock m_lock2;
-	SysMtgsThread& m_mtgs;
-
-public:
-	RingBufferLock(SysMtgsThread& mtgs)
-		: m_lock1(mtgs.m_mtx_RingBufferBusy)
-		, m_lock2(mtgs.m_mtx_RingBufferBusy2)
-		, m_mtgs(mtgs)
-	{
-		m_mtgs.m_RingBufferIsBusy.store(true, std::memory_order_relaxed);
-	}
-	virtual ~RingBufferLock()
-	{
-		m_mtgs.m_RingBufferIsBusy.store(false, std::memory_order_relaxed);
-	}
-	void Acquire()
-	{
-		m_lock1.Acquire();
-		m_lock2.Acquire();
-		m_mtgs.m_RingBufferIsBusy.store(true, std::memory_order_relaxed);
-	}
-	void Release()
-	{
-		m_mtgs.m_RingBufferIsBusy.store(false, std::memory_order_relaxed);
-		m_lock2.Release();
-		m_lock1.Release();
-	}
-	void PartialAcquire()
-	{
-		m_lock2.Acquire();
-	}
-	void PartialRelease()
-	{
-		m_lock2.Release();
-	}
-};
-
 void SysMtgsThread::ExecuteTaskInThread()
 {
 	// Threading info: run in MTGS thread
@@ -268,19 +222,22 @@ void SysMtgsThread::ExecuteTaskInThread()
 	PacketTagType prevCmd;
 #endif
 
-	RingBufferLock busy(*this);
+	ScopedGuard kill_on_exception([this]{ m_sem_event.Kill(); });
+	ScopedLock mtvu_lock(m_mtx_RingBufferBusy2);
 
 	while (true)
 	{
-		busy.Release();
 
 		// Performance note: Both of these perform cancellation tests, but pthread_testcancel
 		// is very optimized (only 1 instruction test in most cases), so no point in trying
 		// to avoid it.
 
-		m_sem_event.Wait();
+		m_mtx_RingBufferBusy2.Release();
+
+		m_sem_event.WaitForWork();
 		StateCheckInThread();
-		busy.Acquire();
+
+		m_mtx_RingBufferBusy2.Acquire();
 
 		// note: m_ReadPos is intentionally not volatile, because it should only
 		// ever be modified by this thread.
@@ -402,10 +359,10 @@ void SysMtgsThread::ExecuteTaskInThread()
 					MTVU_LOG("MTGS - Waiting on semaXGkick!");
 					if (!vu1Thread.semaXGkick.TryWait())
 					{
-						busy.PartialRelease();
+						mtvu_lock.Release();
 						// Wait for MTVU to complete vu1 program
 						vu1Thread.semaXGkick.WaitWithoutYield();
-						busy.PartialAcquire();
+						mtvu_lock.Acquire();
 					}
 					Gif_Path& path = gifUnit.gifPath[GIF_PATH_1];
 					GS_Packet gsPack = path.GetGSPacketMTVU(); // Get vu1 program's xgkick packet(s)
@@ -537,7 +494,7 @@ void SysMtgsThread::ExecuteTaskInThread()
 			}
 		}
 
-		busy.Release();
+		// TODO: With the new race-free WorkSema do we still need these?
 
 		// Safety valve in case standard signals fail for some reason -- this ensures the EEcore
 		// won't sleep the eternity, even if SignalRingPosition didn't reach 0 for some reason.
@@ -605,33 +562,43 @@ void SysMtgsThread::WaitGS(bool syncRegs, bool weakWait, bool isMTVU)
 		return;
 
 	Gif_Path& path = gifUnit.gifPath[GIF_PATH_1];
-	u32 startP1Packs = weakWait ? path.GetPendingGSPackets() : 0;
 
 	// Both m_ReadPos and m_WritePos can be relaxed as we only want to test if the queue is empty but
 	// we don't want to access the content of the queue
 
-	if (isMTVU || m_ReadPos.load(std::memory_order_relaxed) != m_WritePos.load(std::memory_order_relaxed))
+	SetEvent();
+	if (weakWait)
 	{
-		SetEvent();
-		RethrowException();
-		for (;;)
+		// On weakWait we will stop waiting on the MTGS thread if the
+		// MTGS thread has processed a vu1 xgkick packet, or is pending on
+		// its final vu1 xgkick packet (!curP1Packs)...
+		// Note: m_WritePos doesn't seem to have proper atomic write
+		// code, so reading it from the MTVU thread might be dangerous;
+		// hence it has been avoided...
+		u32 startP1Packs = path.GetPendingGSPackets();
+		if (startP1Packs)
 		{
-			if (weakWait)
+			while (true)
+			{
 				m_mtx_RingBufferBusy2.Wait();
-			else
-				m_mtx_RingBufferBusy.Wait();
-			RethrowException();
-			if (!isMTVU && m_ReadPos.load(std::memory_order_relaxed) == m_WritePos.load(std::memory_order_relaxed))
-				break;
-			u32 curP1Packs = weakWait ? path.GetPendingGSPackets() : 0;
-			if (weakWait && ((startP1Packs - curP1Packs) || !curP1Packs))
-				break;
-			// On weakWait we will stop waiting on the MTGS thread if the
-			// MTGS thread has processed a vu1 xgkick packet, or is pending on
-			// its final vu1 xgkick packet (!curP1Packs)...
-			// Note: m_WritePos doesn't seem to have proper atomic write
-			// code, so reading it from the MTVU thread might be dangerous;
-			// hence it has been avoided...
+				RethrowException();
+				if (path.GetPendingGSPackets() != startP1Packs)
+					break;
+			}
+		}
+	}
+	else
+	{
+		if (!m_sem_event.WaitForEmpty())
+		{
+			// There's a small race here as the semaphore is killed before the exception is set
+			// Try a few times to recover the actual exception before throwing something more generic
+			for (int i = 0; i < 5; i++)
+			{
+				std::this_thread::yield();
+				RethrowException();
+			}
+			throw Exception::RuntimeError(std::runtime_error("MTGS Thread Died"));
 		}
 	}
 
@@ -647,9 +614,7 @@ void SysMtgsThread::WaitGS(bool syncRegs, bool weakWait, bool isMTVU)
 // For use in loops that wait on the GS thread to do certain things.
 void SysMtgsThread::SetEvent()
 {
-	if (!m_RingBufferIsBusy.load(std::memory_order_relaxed))
-		m_sem_event.Post();
-
+	m_sem_event.NotifyOfWork();
 	m_CopyDataTally = 0;
 }
 
@@ -677,7 +642,7 @@ void SysMtgsThread::SendDataPacket()
 	{
 		WaitGS();
 	}
-	else if (!m_RingBufferIsBusy.load(std::memory_order_relaxed))
+	else
 	{
 		m_CopyDataTally += m_packet_size;
 		if (m_CopyDataTally > 0x2000)
@@ -840,12 +805,9 @@ void SysMtgsThread::SendSimpleGSPacket(MTGS_RingCommand type, u32 offset, u32 si
 
 	if (!EmuConfig.GS.SynchronousMTGS)
 	{
-		if (!m_RingBufferIsBusy.load(std::memory_order_relaxed))
-		{
-			m_CopyDataTally += size / 16;
-			if (m_CopyDataTally > 0x2000)
-				SetEvent();
-		}
+		m_CopyDataTally += size / 16;
+		if (m_CopyDataTally > 0x2000)
+			SetEvent();
 	}
 }
 

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -31,13 +31,11 @@ class VU_Thread : public pxThread {
 
 	u32 buffer[buffer_size];
 	// Note: keep atomic on separate cache line to avoid CPU conflict
-	alignas(64) std::atomic<bool> isBusy;   // Is thread processing data?
 	alignas(64) std::atomic<int> m_ato_read_pos; // Only modified by VU thread
 	alignas(64) std::atomic<int> m_ato_write_pos;    // Only modified by EE thread
 	alignas(64) int  m_read_pos; // temporary read pos (local to the VU thread)
 	int  m_write_pos; // temporary write pos (local to the EE thread)
-	Mutex     mtxBusy;
-	Semaphore semaEvent;
+	WorkSema semaEvent;
 	BaseVUmicroCPU*& vuCPU;
 	VURegs&          vuRegs;
 
@@ -67,7 +65,7 @@ public:
 	void Reset();
 
 	// Get MTVU to start processing its packets if it isn't already
-	void KickStart(bool forceKick = false);
+	void KickStart();
 
 	// Used for assertions...
 	bool IsDone();

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -316,7 +316,7 @@ void SysCoreThread::DoCpuExecute()
 void SysCoreThread::ExecuteTaskInThread()
 {
 	Threading::EnableHiresScheduler(); // Note that *something* in SPU2 and GS also set the timer resolution to 1ms.
-	m_sem_event.WaitWithoutYield();
+	m_sem_event.WaitForWork();
 
 	m_mxcsr_saved.bitmask = _mm_getcsr();
 

--- a/pcsx2/System/SysThreadBase.cpp
+++ b/pcsx2/System/SysThreadBase.cpp
@@ -39,7 +39,7 @@ void SysThreadBase::Start()
 	pxAssertDev((m_ExecMode == ExecMode_Closing) || (m_ExecMode == ExecMode_Closed),
 				"Unexpected thread status during SysThread startup.");
 
-	m_sem_event.Post();
+	m_sem_event.NotifyOfWork();
 }
 
 
@@ -118,7 +118,7 @@ void SysThreadBase::Suspend(bool isBlocking)
 		}
 
 		pxAssertDev(m_ExecMode == ExecMode_Closing, "ExecMode should be nothing other than Closing...");
-		m_sem_event.Post();
+		m_sem_event.NotifyOfWork();
 	}
 
 	if (isBlocking)
@@ -156,7 +156,7 @@ void SysThreadBase::Pause(SystemsMask systemsToTearDown, bool debug)
 			OnPauseDebug();
 		else
 			OnPause();
-		m_sem_event.Post();
+		m_sem_event.NotifyOfWork();
 	}
 
 	m_RunningLock.Wait();
@@ -174,7 +174,7 @@ void SysThreadBase::PauseSelf()
 			m_ExecMode = ExecMode_Pausing;
 
 		OnPause();
-		m_sem_event.Post();
+		m_sem_event.NotifyOfWork();
 	}
 }
 
@@ -190,7 +190,7 @@ void SysThreadBase::PauseSelfDebug()
 			m_ExecMode = ExecMode_Pausing;
 
 		OnPauseDebug();
-		m_sem_event.Post();
+		m_sem_event.NotifyOfWork();
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Add a new semaphore designed for more easily making work processing threads and switch to it in MTVU, MTGS, and SW Renderer

### Rationale behind Changes
I'm not a huge fan of either of our current systems.

#### Issues with our use of `Threading::Semaphore`:
Normal semaphores have two functions, post and wait.  Wait decrements a counter by one and sleeps if it goes negative, while post increments it and wakes up a thread if it was negative.

Our current use involves posting once per event, and having the processing thread wait, then process the queue of events.  This would work fine, except that if there are 1000 events, we'll post 1000 times but the thread will process those 1000 events in one wait... so then it'll wait another 999 times before actually sleeping.  Someone must have decided this was wasteful, as they added checks to the posting thread to only post if the processing thread wasn't already running.  But checks like this are almost impossible to make race-free, leading to race conditions where the thread goes to sleep with items in queue.  As a result, before waiting on MTVU, threads seem to like restarting it in case it failed to start previously.

You can see this here with MTVU going for "Kick it until it wakes up"...
https://github.com/PCSX2/pcsx2/blob/906480b8e2803ad6df9543ea76d1a198af9a4f0f/pcsx2/MTVU.cpp#L436-L445
And here with MTGS going for "Kick it harder"
https://github.com/PCSX2/pcsx2/blob/906480b8e2803ad6df9543ea76d1a198af9a4f0f/pcsx2/MTGS.cpp#L402-L410

Neither of these should be required, if it weren't for all the races involved with our semaphore usage.  One way to prevent these race conditions is to only modify the "Is busy" flag under a lock, which brings us to our next communication method:

#### Issues with using `std::condition_variable`

Unlike our `Threading::Semaphore` usage, our `std::condition_variable` usage is 100% race condition free, yay!  Here's (one half of) our usage of it:

https://github.com/PCSX2/pcsx2/blob/906480b8e2803ad6df9543ea76d1a198af9a4f0f/pcsx2/GS/GSThread_CXX11.h#L46-L81

Even though it's built to push developers towards using it correctly, you still have to be careful.
- You must check the queue for emptiness with the lock held before actually going to sleep
- You must hold the lock some time between adding work to the queue and waking up any sleeping threads

If you ever forget to do one of those things, you risk the same issue with your thread staying asleep when it has work to do, but at least it's now possible to avoid it.  After implementing this once, I personally wouldn't want to directly use a CV again, as you have to keep those rules in mind whenever you're doing anything near the CV.  If I were to use one in the future, I'd want to package it into a nicer-to-use class.

### Implementation Details

`Threading::WorkSema` guarantees that some time after calling `NotifyOfWork` (like post on a semaphore), the worker thread will leave its `WaitForWork` method at least once.  If it was sleeping, it will be woken up.  If it was running, it will pass through `WaitForWork` once before actually going to sleep, which prevents any race conditions related to adding items between when the worker thread last checked for new work and attempted to go to sleep.  Therefore to not run into problems, the only requirements are:
- The worker thread must process all work that was in the queue it left `WaitForWork` before calling it again
- You must call `NotifyOfWork` *after* adding the work in question to the queue

Conveniently, these are the kind of things you'd probably be doing anyways

`Threading::WorkSema` is implemented with as state machine where the current state is in an atomic variable.  Sleeping is implemented with semaphores, taking advantage of the fact that they will do the right thing no matter which order the waking and sleeping thread call their respective methods.  The binary representations of the different states are (probably unnecessarily) optimized to make the expected most common operation (adding work while the worker thread is already running) as fast as possible in x86, with a `lock add` and jump on condition code.

### Drawbacks

Unlike with `std::condition_variable`, all interactions between threads must be included in the state machine, which means `Threading::WorkSema` must be compatible with all our uses.  This means that in addition to allowing threads to wait for the worker to finish all work (used by everything), it has support for `pthread_cancel`-ing the worker thread (used by MTVU and MTGS), and for the allowing the worker to randomly die (used by MTGS to throw exceptions across).

### Suggested Testing Steps
- @HeroponRikiBestest I think you had an issue with MTGS locking up a while back?  Can you check if it still happens on the latest master and if so, if this fixes it?
- Play games and see if anything locks up
- Check for performance regressions, especially in the SW renderer