### PR TITLE
Fix MemoryCard (Folders) crash

### DIFF
--- a/pcsx2/MemoryCardFolder.cpp
+++ b/pcsx2/MemoryCardFolder.cpp
@@ -65,7 +65,6 @@ std::optional<ryml::Tree> loadYamlFile(const wxString& filePath)
 			return std::nullopt;
 		}
 		std::optional<std::string> buffer = FileSystem::ReadFileToString(file.get());
-		std::fclose(file.get());
 		if (!buffer.has_value())
 		{
 			return std::nullopt;


### PR DESCRIPTION
### Description of Changes
Removes erroneous unmanaged cleanup of managed code. Fixes #5818.

### Rationale behind Changes
`loadYamlFile` calls `OpenManagedCFile` which handles closing the file-handle used. Thus, closing the file-handle outside the API call to `OpenManagedCFile` is not necessary. This prevents crashing on systems such as Linux.