### PR TITLE
gitignore: ignore bin/textures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ oprofile_data/
 /bin/plugins
 /bin/snaps
 /bin/sstates
+/bin/textures
 /bin/translations
 /deps
 /ipch


### PR DESCRIPTION
### Description of Changes
Ignore the textures folder

### Rationale behind Changes
![image](https://user-images.githubusercontent.com/29295048/161866905-a292a3d4-e128-430b-999b-1575f6fa8106.png)
This isn't necessary
