### PR TITLE
Qt: Add Host::RunOnCPUThread() and QtHost::RunOnUIThread()

### DIFF
--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -76,6 +76,7 @@ public Q_SLOTS:
 	void requestDisplaySize(float scale);
 	void enumerateInputDevices();
 	void enumerateVibrationMotors();
+	void runOnCPUThread(const std::function<void()>& func);
 
 Q_SIGNALS:
 	DisplayWidget* onCreateDisplayRequested(bool fullscreen, bool render_to_main);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -696,6 +696,11 @@ void MainWindow::reportError(const QString& title, const QString& message)
 	QMessageBox::critical(this, title, message);
 }
 
+void MainWindow::runOnUIThread(const std::function<void()>& func)
+{
+	func();
+}
+
 bool MainWindow::requestShutdown(bool allow_confirm /* = true */, bool allow_save_to_state /* = true */, bool block_until_done /* = false */)
 {
 	if (!VMManager::HasValidVM())

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -17,6 +17,7 @@
 
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QMainWindow>
+#include <functional>
 #include <optional>
 
 #include "Settings/ControllerSettingsDialog.h"
@@ -55,6 +56,7 @@ public Q_SLOTS:
 	void refreshGameList(bool invalidate_cache);
 	void invalidateSaveStateCache();
 	void reportError(const QString& title, const QString& message);
+	void runOnUIThread(const std::function<void()>& func);
 	bool requestShutdown(bool allow_confirm = true, bool allow_save_to_state = true, bool block_until_done = false);
 	void requestExit();
 

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -69,10 +69,12 @@ static std::unique_ptr<INISettingsInterface> s_base_settings_interface;
 
 bool QtHost::Initialize()
 {
+	qRegisterMetaType<std::optional<bool>>();
+	qRegisterMetaType<std::function<void()>>();
 	qRegisterMetaType<std::shared_ptr<VMBootParameters>>();
 	qRegisterMetaType<GSRendererType>();
-	qRegisterMetaType<const GameList::Entry*>();
 	qRegisterMetaType<InputBindingKey>();
+	qRegisterMetaType<const GameList::Entry*>();
 
 	InitializeWxRubbish();
 	if (!InitializeConfig())

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -300,6 +300,14 @@ void QtHost::QueueSettingsSave()
 	s_settings_save_timer->start(SETTINGS_SAVE_DELAY);
 }
 
+void QtHost::RunOnUIThread(const std::function<void()>& func, bool block /*= false*/)
+{
+	// main window always exists, so it's fine to attach it to that.
+	QMetaObject::invokeMethod(g_main_window, "runOnUIThread",
+		block ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
+		Q_ARG(const std::function<void()>&, func));
+}
+
 std::optional<std::vector<u8>> Host::ReadResourceFile(const char* filename)
 {
 	const std::string path(Path::CombineStdString(EmuFolders::Resources, filename));

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -20,13 +20,18 @@
 #include "pcsx2/Frontend/InputManager.h"
 #include "pcsx2/VMManager.h"
 #include <QtCore/QMetaType>
+#include <functional>
+#include <memory>
+#include <optional>
 
 class SettingsInterface;
 
 class EmuThread;
 
-Q_DECLARE_METATYPE(GSRendererType);
 Q_DECLARE_METATYPE(std::shared_ptr<VMBootParameters>);
+Q_DECLARE_METATYPE(std::optional<bool>);
+Q_DECLARE_METATYPE(std::function<void()>);
+Q_DECLARE_METATYPE(GSRendererType);
 Q_DECLARE_METATYPE(InputBindingKey);
 
 namespace QtHost

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -42,6 +42,9 @@ namespace QtHost
 	void UpdateFolders();
 	void UpdateLogging();
 
+	/// Executes a function on the UI thread.
+	void RunOnUIThread(const std::function<void()>& func, bool block = false);
+
 	/// Thread-safe settings access.
 	SettingsInterface* GetBaseSettingsInterface();
 	std::string GetBaseStringSettingValue(const char* section, const char* key, const char* default_value = "");

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -22,9 +22,6 @@
 #include <string_view>
 #include <optional>
 
-Q_DECLARE_METATYPE(std::optional<bool>);
-Q_DECLARE_METATYPE(std::function<void()>);
-
 class ByteStream;
 
 class QAction;


### PR DESCRIPTION
### Description of Changes

Makes things simpler for doing stuff on the appropriate thread in a blocking or non-blocking manner, rather than the deadlock-prone wx way of pausing the core thread, screwing with its state, and resuming.

Just have to be careful with the blocking parameter; there's probably some scenarios where you need it, but in the majority you'll want it to be asynchronous.

### Rationale behind Changes

Making things easier to develop in Qt.

### Suggested Testing Steps

I've already checked it behaves as expected.
