### PR TITLE
Gamedb: Add Bumpy Trot Trial serial

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21701,6 +21701,9 @@ SLPM-60262:
 SLPM-60265:
   name: "10th Anniversary PlayStation & PlayStation 2 All-Soft Catalogue Special SaveData Collection [PS2 Disc]"
   region: "NTSC-J"
+SLPM-60266:
+  name: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Trial]"
+  region: "NTSC-J"
 SLPM-60267:
   name: "Garouden Breakblow [Taikenban]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
add missing gamedb serials.

### Rationale behind Changes
a more complete GameDB

### Suggested Testing Steps
look at CI
