### PR TITLE
LnxMisc: Use clock_gettime() instead of gettimeofday()

### DIFF
--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -41,14 +41,14 @@ void InitCPUTicks()
 
 u64 GetTickFrequency()
 {
-	return 1000000; // unix measures in microseconds
+	return 1000000000;// unix measures in nanoseconds
 }
 
 u64 GetCPUTicks()
 {
-	struct timeval t;
-	gettimeofday(&t, NULL);
-	return ((u64)t.tv_sec * GetTickFrequency()) + t.tv_usec;
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (static_cast<u64>(ts.tv_sec) * 1000000000ULL) + ts.tv_nsec;
 }
 
 wxString GetOSVersionString()


### PR DESCRIPTION
### Description of Changes

`gettimeofday()` is not monotonically increasing, and can be subject to clock changes. `clock_gettime()` also has nanosecond resolution.

### Rationale behind Changes

Correctness.

### Suggested Testing Steps

Check Linux build still works as intended. Check Mac build, because apparently it's buggy/nonexistant there?
