### PR TITLE
GSState: Remove transfer direction warning

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1505,8 +1505,7 @@ void GSState::GIFRegHandlerTRXDIR(const GIFReg* RESTRICT r)
 		case 2: // local -> local
 			Move();
 			break;
-		default: // 3 prohibited, behavior unknown
-			Console.Warning("Invalid guest transfer direction. Please report: https://github.com/PCSX2/pcsx2/issues");
+		default: // 3 deactivated as stated by manual. Tested on hardware and no transfers happen.
 			break;
 	}
 }


### PR DESCRIPTION
### Description of Changes
After hardware testing, the behaviour of having a TRXDIR of 3 is known. It simply does nothing.

(Please use the software renderer when using these)
[TRXDIR-HardwareTests.zip](https://github.com/PCSX2/pcsx2/files/8458288/TRXDIR-HardwareTests.zip)
Code is here -> https://github.com/F0bes/hwtest/tree/master/trxdir3

TRXDIR3-Download.elf (Enable host filesystem if running on PCSX2)
-> Downloads the framebuffer twice. The first download has a valid TRXDIR, the second has the TRXDIR of 3)
-> This hangs the hardware, as there is no data to be transferred yet we wait, and wait.

TRXDIR3-Upload.elf
-> Uploads an image twice, one at 32,0(TRXDIR 0) and another at 64,0(TRXDIR 3)
-> The uploaded data goes nowhere when TRXDIR is 3

TRXDIR3-Copy.elf
-> Uploads to the framebuffer, copies it 32 pixels to the right
-> Copies it 64 pixels to the right with the TRXDIR of 3
-> The second copy does nothing


### Rationale behind Changes
Reflect on findings, another unnecessary log gone.


