### PR TITLE
wxWidgets 3.1.6 Compatibility

### DIFF
--- a/pcsx2/gui/i18n.cpp
+++ b/pcsx2/gui/i18n.cpp
@@ -36,7 +36,9 @@ static wxString i18n_GetBetterLanguageName( const wxLanguageInfo* info )
 	switch (info->Language)
 	{
 		case wxLANGUAGE_CHINESE:             return L"Chinese (Traditional)";
+#if !wxCHECK_VERSION(3, 1, 6)
 		case wxLANGUAGE_CHINESE_TRADITIONAL: return L"Chinese (Traditional)";
+#endif
 		case wxLANGUAGE_CHINESE_TAIWAN:      return L"Chinese (Traditional)";
 		case wxLANGUAGE_CHINESE_HONGKONG:    return L"Chinese (Traditional, Hong Kong)";
 		case wxLANGUAGE_CHINESE_MACAU:       return L"Chinese (Traditional, Macau)";

--- a/pcsx2/gui/i18n.cpp
+++ b/pcsx2/gui/i18n.cpp
@@ -35,11 +35,11 @@ static wxString i18n_GetBetterLanguageName( const wxLanguageInfo* info )
 {
 	switch (info->Language)
 	{
-		case wxLANGUAGE_CHINESE:				return L"Chinese (Traditional)";
-		case wxLANGUAGE_CHINESE_TRADITIONAL:	return L"Chinese (Traditional)";
-		case wxLANGUAGE_CHINESE_TAIWAN:			return L"Chinese (Traditional)";
-		case wxLANGUAGE_CHINESE_HONGKONG:		return L"Chinese (Traditional, Hong Kong)";
-		case wxLANGUAGE_CHINESE_MACAU:			return L"Chinese (Traditional, Macau)";
+		case wxLANGUAGE_CHINESE:             return L"Chinese (Traditional)";
+		case wxLANGUAGE_CHINESE_TRADITIONAL: return L"Chinese (Traditional)";
+		case wxLANGUAGE_CHINESE_TAIWAN:      return L"Chinese (Traditional)";
+		case wxLANGUAGE_CHINESE_HONGKONG:    return L"Chinese (Traditional, Hong Kong)";
+		case wxLANGUAGE_CHINESE_MACAU:       return L"Chinese (Traditional, Macau)";
 	}
 
 	return info->Description;
@@ -346,7 +346,7 @@ bool i18n_SetLanguage( wxLanguage wxLangId, const wxString& langCode )
 			foundone = true;
 	}
 
-	if (!foundone)	
+	if (!foundone)
 	{
 		Console.Warning("SetLanguage: Requested translation is not implemented yet.");
 		return false;


### PR DESCRIPTION
### Description of Changes
Makes PCSX2 compile properly on wxWidgets 3.1.6

### Rationale behind Changes
It's nice when things compile

### Suggested Testing Steps
Try compiling with wxWidgets 3.1.6