### PR TITLE
Emitter: Fix s8 problem with displacements

### DIFF
--- a/common/emitter/x86types.h
+++ b/common/emitter/x86types.h
@@ -75,7 +75,7 @@ namespace x86Emitter
 	template <typename T>
 	static __fi bool is_s8(T imm)
 	{
-		return (s8)imm == (s32)imm;
+		return (s8)imm == (typename std::make_signed<T>::type)imm;
 	}
 
 	template <typename T>


### PR DESCRIPTION
### Description of Changes
Fix the check is a number is 8 bit signed or not.

### Rationale behind Changes
The previous version was broken and was error prone (Wipeout Fusion threw an error with it)

### Suggested Testing Steps
Run games, make sure nothing explodes.

Thanks to TellowKrinkle for coming up with this.