### PR TITLE
GS: Support upscaled region repeat

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -201,46 +201,31 @@ float4 clamp_wrap_uv(float4 uv)
 	else
 		tex_size = WH.xyxy;
 
-	if(PS_WMS == PS_WMT)
+	if(PS_WMS == 2)
 	{
-		if(PS_WMS == 2)
-		{
-			uv = clamp(uv, MinMax.xyxy, MinMax.zwzw);
-		}
-		else if(PS_WMS == 3)
-		{
-			#if PS_FST == 0
-			// wrap negative uv coords to avoid an off by one error that shifted
-			// textures. Fixes Xenosaga's hair issue.
-			uv = frac(uv);
-			#endif
-			uv = (float4)(((uint4)(uv * tex_size) & MskFix.xyxy) | MskFix.zwzw) / tex_size;
-		}
+		uv.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
 	}
-	else
+	else if(PS_WMS == 3)
 	{
-		if(PS_WMS == 2)
-		{
-			uv.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
-		}
-		else if(PS_WMS == 3)
-		{
-			#if PS_FST == 0
-			uv.xz = frac(uv.xz);
-			#endif
-			uv.xz = (float2)(((uint2)(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
-		}
-		if(PS_WMT == 2)
-		{
-			uv.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
-		}
-		else if(PS_WMT == 3)
-		{
-			#if PS_FST == 0
-			uv.yw = frac(uv.yw);
-			#endif
-			uv.yw = (float2)(((uint2)(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
-		}
+		// wrap negative uv coords to avoid an off by one error that shifted
+		// textures. Fixes Xenosaga's hair issue.
+		#if PS_FST == 0
+		uv.xz = frac(uv.xz);
+		#endif
+		uv.xz = (float2)(((uint2)(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
+	}
+	if(PS_WMT == 2)
+	{
+		uv.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
+	}
+	else if(PS_WMT == 3)
+	{
+		// wrap negative uv coords to avoid an off by one error that shifted
+		// textures. Fixes Xenosaga's hair issue.
+		#if PS_FST == 0
+		uv.yw = frac(uv.yw);
+		#endif
+		uv.yw = (float2)(((uint2)(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
 	}
 
 	return uv;
@@ -329,36 +314,25 @@ float4 fetch_c(int2 uv)
 int2 clamp_wrap_uv_depth(int2 uv)
 {
 	int4 mask = (int4)MskFix << 4;
-	if (PS_WMS == PS_WMT)
+
+	if (PS_WMS == 2)
 	{
-		if (PS_WMS == 2)
-		{
-			uv = clamp(uv, mask.xy, mask.zw);
-		}
-		else if (PS_WMS == 3)
-		{
-			uv = (uv & mask.xy) | mask.zw;
-		}
+		uv.x = clamp(uv.x, mask.x, mask.z);
 	}
-	else
+	else if (PS_WMS == 3)
 	{
-		if (PS_WMS == 2)
-		{
-			uv.x = clamp(uv.x, mask.x, mask.z);
-		}
-		else if (PS_WMS == 3)
-		{
-			uv.x = (uv.x & mask.x) | mask.z;
-		}
-		if (PS_WMT == 2)
-		{
-			uv.y = clamp(uv.y, mask.y, mask.w);
-		}
-		else if (PS_WMT == 3)
-		{
-			uv.y = (uv.y & mask.y) | mask.w;
-		}
+		uv.x = (uv.x & mask.x) | mask.z;
 	}
+
+	if (PS_WMT == 2)
+	{
+		uv.y = clamp(uv.y, mask.y, mask.w);
+	}
+	else if (PS_WMT == 3)
+	{
+		uv.y = (uv.y & mask.y) | mask.w;
+	}
+
 	return uv;
 }
 

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -206,7 +206,13 @@ float2 clamp_wrap_uv_2(uint mode, float2 uv, float tex_size, float2 min_max, uin
 			uv = frac(uv);
 		#endif
 
-		return float2((uint2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+		uv *= tex_size;
+		float2 masked = float2((uint2(uv) & msk_fix.xx) | msk_fix.yy);
+
+		if (msk_fix.x & 1) // For upscaling, let the bottom bit mask everything below
+			masked += frac(uv);
+
+		return masked / tex_size;
 	}
 	return uv;
 }
@@ -313,7 +319,11 @@ int clamp_wrap_uv_depth_1(uint mode, int uv, int2 msk_fix)
 	if (mode == 2)
 		return clamp(uv, mask.x, mask.y);
 	if (mode == 3)
+	{
+		if (msk_fix.x & 1)
+			mask.x |= 0xF;
 		return (uv & mask.x) | mask.y;
+	}
 	return uv;
 }
 

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -317,7 +317,7 @@ int clamp_wrap_uv_depth_1(uint mode, int uv, int2 msk_fix)
 	int2 mask = msk_fix << 4;
 
 	if (mode == 2)
-		return clamp(uv, mask.x, mask.y);
+		return clamp(uv, mask.x, mask.y | 0xF);
 	if (mode == 3)
 	{
 		if (msk_fix.x & 1)

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -192,41 +192,36 @@ float4 sample_p(float u)
 	return Palette.Sample(PaletteSampler, u);
 }
 
+float2 clamp_wrap_uv_2(uint mode, float2 uv, float tex_size, float2 min_max, uint2 msk_fix)
+{
+	if (mode == 2)
+	{
+		return clamp(uv, min_max.xx, min_max.yy);
+	}
+	if (mode == 3)
+	{
+		#if PS_FST == 0
+			// wrap negative uv coords to avoid an off by one error that shifted
+			// textures. Fixes Xenosaga's hair issue.
+			uv = frac(uv);
+		#endif
+
+		return float2((uint2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+	}
+	return uv;
+}
+
 float4 clamp_wrap_uv(float4 uv)
 {
-	float4 tex_size;
+	float2 tex_size;
 
 	if (PS_INVALID_TEX0 == 1)
-		tex_size = WH.zwzw;
+		tex_size = WH.zw;
 	else
-		tex_size = WH.xyxy;
+		tex_size = WH.xy;
 
-	if(PS_WMS == 2)
-	{
-		uv.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
-	}
-	else if(PS_WMS == 3)
-	{
-		// wrap negative uv coords to avoid an off by one error that shifted
-		// textures. Fixes Xenosaga's hair issue.
-		#if PS_FST == 0
-		uv.xz = frac(uv.xz);
-		#endif
-		uv.xz = (float2)(((uint2)(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
-	}
-	if(PS_WMT == 2)
-	{
-		uv.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
-	}
-	else if(PS_WMT == 3)
-	{
-		// wrap negative uv coords to avoid an off by one error that shifted
-		// textures. Fixes Xenosaga's hair issue.
-		#if PS_FST == 0
-		uv.yw = frac(uv.yw);
-		#endif
-		uv.yw = (float2)(((uint2)(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
-	}
+	uv.xz = clamp_wrap_uv_2(PS_WMS, uv.xz, tex_size.x, MinMax.xz, MskFix.xz);
+	uv.yw = clamp_wrap_uv_2(PS_WMT, uv.yw, tex_size.y, MinMax.yw, MskFix.yw);
 
 	return uv;
 }
@@ -311,28 +306,21 @@ float4 fetch_c(int2 uv)
 // Depth sampling
 //////////////////////////////////////////////////////////////////////
 
+int clamp_wrap_uv_depth_1(uint mode, int uv, int2 msk_fix)
+{
+	int2 mask = msk_fix << 4;
+
+	if (mode == 2)
+		return clamp(uv, mask.x, mask.y);
+	if (mode == 3)
+		return (uv & mask.x) | mask.y;
+	return uv;
+}
+
 int2 clamp_wrap_uv_depth(int2 uv)
 {
-	int4 mask = (int4)MskFix << 4;
-
-	if (PS_WMS == 2)
-	{
-		uv.x = clamp(uv.x, mask.x, mask.z);
-	}
-	else if (PS_WMS == 3)
-	{
-		uv.x = (uv.x & mask.x) | mask.z;
-	}
-
-	if (PS_WMT == 2)
-	{
-		uv.y = clamp(uv.y, mask.y, mask.w);
-	}
-	else if (PS_WMT == 3)
-	{
-		uv.y = (uv.y & mask.y) | mask.w;
-	}
-
+	uv.x = clamp_wrap_uv_depth_1(PS_WMS, uv.x, (int2)MskFix.xz);
+	uv.y = clamp_wrap_uv_depth_1(PS_WMT, uv.y, (int2)MskFix.yw);
 	return uv;
 }
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -149,38 +149,36 @@ vec4 sample_p(float idx)
     return texture(PaletteSampler, vec2(idx, 0.0f));
 }
 
+vec2 clamp_wrap_uv_2(uint mode, vec2 uv, float tex_size, vec2 min_max, uvec2 msk_fix)
+{
+    if (mode == 2)
+    {
+        return clamp(uv, min_max.xx, min_max.yy);
+    }
+    if (mode == 3)
+    {
+        #if PS_FST == 0
+            // wrap negative uv coords to avoid an off by one error that shifted
+            // textures. Fixes Xenosaga's hair issue.
+            uv = fract(uv);
+        #endif
+        return vec2((uvec2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+    }
+    return uv;
+}
+
 vec4 clamp_wrap_uv(vec4 uv)
 {
-    vec4 uv_out = uv;
 #if PS_INVALID_TEX0 == 1
-    vec4 tex_size = WH.zwzw;
+    vec2 tex_size = WH.zw;
 #else
-    vec4 tex_size = WH.xyxy;
+    vec2 tex_size = WH.xy;
 #endif
 
-#if PS_WMS == 2
-    uv_out.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
-#elif PS_WMS == 3
-    #if PS_FST == 0
-    // wrap negative uv coords to avoid an off by one error that shifted
-    // textures. Fixes Xenosaga's hair issue.
-    uv.xz = fract(uv.xz);
-    #endif
-    uv_out.xz = vec2((uvec2(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
-#endif
+    uv.xz = clamp_wrap_uv_2(PS_WMS, uv.xz, tex_size.x, MinMax.xz, MskFix.xz);
+    uv.yw = clamp_wrap_uv_2(PS_WMT, uv.yw, tex_size.y, MinMax.yw, MskFix.yw);
 
-#if PS_WMT == 2
-    uv_out.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
-#elif PS_WMT == 3
-    #if PS_FST == 0
-    // wrap negative uv coords to avoid an off by one error that shifted
-    // textures. Fixes Xenosaga's hair issue.
-    uv.yw = fract(uv.yw);
-    #endif
-    uv_out.yw = vec2((uvec2(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
-#endif
-
-    return uv_out;
+    return uv;
 }
 
 mat4 sample_4c(vec4 uv)
@@ -278,27 +276,24 @@ vec4 fetch_c(ivec2 uv)
 //////////////////////////////////////////////////////////////////////
 // Depth sampling
 //////////////////////////////////////////////////////////////////////
-ivec2 clamp_wrap_uv_depth(ivec2 uv)
+int clamp_wrap_uv_depth_1(uint mode, int uv, ivec2 msk_fix)
 {
-    ivec2 uv_out = uv;
-
     // Keep the full precision
     // It allow to multiply the ScalingFactor before the 1/16 coeff
-    ivec4 mask = ivec4(MskFix) << 4;
+    ivec2 mask = msk_fix << 4;
 
-#if PS_WMS == 2
-    uv_out.x = clamp(uv.x, mask.x, mask.z);
-#elif PS_WMS == 3
-    uv_out.x = (uv.x & mask.x) | mask.z;
-#endif
+    if (mode == 2)
+        return clamp(uv, mask.x, mask.y);
+    if (mode == 3)
+        return (uv & mask.x) | mask.y;
+    return uv;
+}
 
-#if PS_WMT == 2
-    uv_out.y = clamp(uv.y, mask.y, mask.w);
-#elif PS_WMT == 3
-    uv_out.y = (uv.y & mask.y) | mask.w;
-#endif
-
-    return uv_out;
+ivec2 clamp_wrap_uv_depth(ivec2 uv)
+{
+    uv.x = clamp_wrap_uv_depth_1(PS_WMS, uv.x, ivec2(MskFix.xz));
+    uv.y = clamp_wrap_uv_depth_1(PS_WMT, uv.y, ivec2(MskFix.yw));
+    return uv;
 }
 
 vec4 sample_depth(vec2 st)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -158,42 +158,26 @@ vec4 clamp_wrap_uv(vec4 uv)
     vec4 tex_size = WH.xyxy;
 #endif
 
-#if PS_WMS == PS_WMT
-
 #if PS_WMS == 2
-    uv_out = clamp(uv, MinMax.xyxy, MinMax.zwzw);
+    uv_out.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
 #elif PS_WMS == 3
     #if PS_FST == 0
     // wrap negative uv coords to avoid an off by one error that shifted
     // textures. Fixes Xenosaga's hair issue.
-    uv = fract(uv);
-    #endif
-    uv_out = vec4((uvec4(uv * tex_size) & MskFix.xyxy) | MskFix.zwzw) / tex_size;
-#endif
-
-#else // PS_WMS != PS_WMT
-
-#if PS_WMS == 2
-    uv_out.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
-
-#elif PS_WMS == 3
-    #if PS_FST == 0
     uv.xz = fract(uv.xz);
     #endif
     uv_out.xz = vec2((uvec2(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
-
 #endif
 
 #if PS_WMT == 2
     uv_out.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
-
 #elif PS_WMT == 3
     #if PS_FST == 0
+    // wrap negative uv coords to avoid an off by one error that shifted
+    // textures. Fixes Xenosaga's hair issue.
     uv.yw = fract(uv.yw);
     #endif
     uv_out.yw = vec2((uvec2(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
-#endif
-
 #endif
 
     return uv_out;
@@ -302,16 +286,6 @@ ivec2 clamp_wrap_uv_depth(ivec2 uv)
     // It allow to multiply the ScalingFactor before the 1/16 coeff
     ivec4 mask = ivec4(MskFix) << 4;
 
-#if PS_WMS == PS_WMT
-
-#if PS_WMS == 2
-    uv_out = clamp(uv, mask.xy, mask.zw);
-#elif PS_WMS == 3
-    uv_out = (uv & mask.xy) | mask.zw;
-#endif
-
-#else // PS_WMS != PS_WMT
-
 #if PS_WMS == 2
     uv_out.x = clamp(uv.x, mask.x, mask.z);
 #elif PS_WMS == 3
@@ -322,8 +296,6 @@ ivec2 clamp_wrap_uv_depth(ivec2 uv)
     uv_out.y = clamp(uv.y, mask.y, mask.w);
 #elif PS_WMT == 3
     uv_out.y = (uv.y & mask.y) | mask.w;
-#endif
-
 #endif
 
     return uv_out;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -290,7 +290,7 @@ int clamp_wrap_uv_depth_1(uint mode, int uv, ivec2 msk_fix)
     ivec2 mask = msk_fix << 4;
 
     if (mode == 2)
-        return clamp(uv, mask.x, mask.y);
+        return clamp(uv, mask.x, mask.y | 0xF);
     if (mode == 3)
     {
         if ((msk_fix.x & 1) != 0)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -162,7 +162,14 @@ vec2 clamp_wrap_uv_2(uint mode, vec2 uv, float tex_size, vec2 min_max, uvec2 msk
             // textures. Fixes Xenosaga's hair issue.
             uv = fract(uv);
         #endif
-        return vec2((uvec2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+
+        uv *= tex_size;
+        vec2 masked = vec2((uvec2(uv) & msk_fix.xx) | msk_fix.yy);
+
+        if ((msk_fix.x & 1) != 0) // For upscaling, let the bottom bit mask everything below
+            masked += fract(uv);
+
+        return masked / tex_size;
     }
     return uv;
 }
@@ -285,7 +292,11 @@ int clamp_wrap_uv_depth_1(uint mode, int uv, ivec2 msk_fix)
     if (mode == 2)
         return clamp(uv, mask.x, mask.y);
     if (mode == 3)
+    {
+        if ((msk_fix.x & 1) != 0)
+            mask.x |= 0xF;
         return (uv & mask.x) | mask.y;
+    }
     return uv;
 }
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -454,49 +454,33 @@ vec4 clamp_wrap_uv(vec4 uv)
 		tex_size = WH.xyxy;
 	#endif
 
-	#if PS_WMS == PS_WMT
+
+	#if PS_WMS == 2
 	{
-		#if PS_WMS == 2
-		{
-			uv = clamp(uv, MinMax.xyxy, MinMax.zwzw);
-		}
-		#elif PS_WMS == 3
-		{
-			#if PS_FST == 0
-			// wrap negative uv coords to avoid an off by one error that shifted
-			// textures. Fixes Xenosaga's hair issue.
-			uv = fract(uv);
-			#endif
-			uv = vec4((uvec4(uv * tex_size) & MskFix.xyxy) | MskFix.zwzw) / tex_size;
-		}
-		#endif
+		uv.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
 	}
-	#else
+	#elif PS_WMS == 3
 	{
-		#if PS_WMS == 2
-		{
-			uv.xz = clamp(uv.xz, MinMax.xx, MinMax.zz);
-		}
-		#elif PS_WMS == 3
-		{
-			#if PS_FST == 0
-			uv.xz = fract(uv.xz);
-			#endif
-			uv.xz = vec2((uvec2(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
-		}
+		#if PS_FST == 0
+		// wrap negative uv coords to avoid an off by one error that shifted
+		// textures. Fixes Xenosaga's hair issue.
+		uv.xz = fract(uv.xz);
 		#endif
-		#if PS_WMT == 2
-		{
-			uv.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
-		}
-		#elif PS_WMT == 3
-		{
-			#if PS_FST == 0
-			uv.yw = fract(uv.yw);
-			#endif
-			uv.yw = vec2((uvec2(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
-		}
+		uv.xz = vec2((uvec2(uv.xz * tex_size.xx) & MskFix.xx) | MskFix.zz) / tex_size.xx;
+	}
+	#endif
+	#if PS_WMT == 2
+	{
+		uv.yw = clamp(uv.yw, MinMax.yy, MinMax.ww);
+	}
+	#elif PS_WMT == 3
+	{
+		#if PS_FST == 0
+		// wrap negative uv coords to avoid an off by one error that shifted
+		// textures. Fixes Xenosaga's hair issue.
+		uv.yw = fract(uv.yw);
 		#endif
+		uv.yw = vec2((uvec2(uv.yw * tex_size.yy) & MskFix.yy) | MskFix.ww) / tex_size.yy;
 	}
 	#endif
 
@@ -583,40 +567,27 @@ vec4 fetch_c(ivec2 uv)
 ivec2 clamp_wrap_uv_depth(ivec2 uv)
 {
 	ivec4 mask = ivec4(MskFix << 4);
-	#if (PS_WMS == PS_WMT)
+
+	#if (PS_WMS == 2)
 	{
-		#if (PS_WMS == 2)
-		{
-			uv = clamp(uv, mask.xy, mask.zw);
-		}
-		#elif (PS_WMS == 3)
-		{
-			uv = (uv & mask.xy) | mask.zw;
-		}
-		#endif
+		uv.x = clamp(uv.x, mask.x, mask.z);
 	}
-	#else
+	#elif (PS_WMS == 3)
 	{
-		#if (PS_WMS == 2)
-		{
-			uv.x = clamp(uv.x, mask.x, mask.z);
-		}
-		#elif (PS_WMS == 3)
-		{
-			uv.x = (uv.x & mask.x) | mask.z;
-		}
-		#endif
-		#if (PS_WMT == 2)
-		{
-			uv.y = clamp(uv.y, mask.y, mask.w);
-		}
-		#elif (PS_WMT == 3)
-		{
-			uv.y = (uv.y & mask.y) | mask.w;
-		}
-		#endif
+		uv.x = (uv.x & mask.x) | mask.z;
 	}
 	#endif
+
+	#if (PS_WMT == 2)
+	{
+		uv.y = clamp(uv.y, mask.y, mask.w);
+	}
+	#elif (PS_WMT == 3)
+	{
+		uv.y = (uv.y & mask.y) | mask.w;
+	}
+	#endif
+
 	return uv;
 }
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -457,7 +457,14 @@ vec2 clamp_wrap_uv_2(uint mode, vec2 uv, float tex_size, vec2 min_max, uvec2 msk
 			// textures. Fixes Xenosaga's hair issue.
 			uv = fract(uv);
 		#endif
-		return vec2((uvec2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+
+		uv *= tex_size;
+		vec2 masked = vec2((uvec2(uv) & msk_fix.xx) | msk_fix.yy);
+
+		if ((msk_fix.x & 1) != 0) // For upscaling, let the bottom bit mask everything below
+			masked += fract(uv);
+
+		return masked / tex_size;
 	}
 	return uv;
 }
@@ -562,7 +569,11 @@ int clamp_wrap_uv_depth_1(uint mode, int uv, ivec2 msk_fix)
 	if (mode == 2)
 		return clamp(uv, mask.x, mask.y);
 	if (mode == 3)
+	{
+		if ((msk_fix.x & 1) != 0)
+			mask.x |= 0xF;
 		return (uv & mask.x) | mask.y;
+	}
 	return uv;
 }
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -567,7 +567,7 @@ int clamp_wrap_uv_depth_1(uint mode, int uv, ivec2 msk_fix)
 	ivec2 mask = msk_fix << 4;
 
 	if (mode == 2)
-		return clamp(uv, mask.x, mask.y);
+		return clamp(uv, mask.x, mask.y | 0xF);
 	if (mode == 3)
 	{
 		if ((msk_fix.x & 1) != 0)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1370,9 +1370,6 @@ void GSRendererHW::Draw()
 		GSVector4i unscaled_size = GSVector4i(GSVector4(m_src->m_texture->GetSize()) / GSVector4(m_src->m_texture->GetScale()));
 		if (m_context->CLAMP.WMS == CLAMP_REPEAT && (tmm.uses_boundary & TextureMinMaxResult::USES_BOUNDARY_U) && unscaled_size.x != tw)
 		{
-			// Our shader-emulated region repeat doesn't upscale :(
-			// Try to avoid it if possible
-			// TODO: Upscale-supporting shader-emulated region repeat
 			if (unscaled_size.x < tw && m_vt.m_min.t.x > -(tw - unscaled_size.x) && m_vt.m_max.t.x < tw)
 			{
 				// Game only extends into data we don't have (but doesn't wrap around back onto good data), clamp seems like the most reasonable solution

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -1222,7 +1222,8 @@ void GSRendererNew::EmulateTextureSampler(const GSTextureCache::Source* tex)
 	if (complex_wms_wmt)
 	{
 		m_conf.cb_ps.MskFix = GSVector4i(m_context->CLAMP.MINU, m_context->CLAMP.MINV, m_context->CLAMP.MAXU, m_context->CLAMP.MAXV);;
-		m_conf.cb_ps.MinMax = GSVector4(m_conf.cb_ps.MskFix) / WH.xyxy();
+		GSVector4 upscale_offset(0.f, 0.f, (15.f / 16.f), (15.f / 16.f)); // Adjust end position to the end of the upscaled pixel
+		m_conf.cb_ps.MinMax = (GSVector4(m_conf.cb_ps.MskFix) + upscale_offset) / WH.xyxy();
 	}
 	else if (trilinear_manual)
 	{

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -268,47 +268,32 @@ struct PSMain
 		float4 uv_out = uv;
 		float4 tex_size = PS_INVALID_TEX0 ? cb.wh.zwzw : cb.wh.xyxy;
 
-		if (PS_WMS == PS_WMT)
+		if (PS_WMS == 2)
 		{
-			if (PS_WMS == 2)
-			{
-				uv_out = clamp(uv, cb.uv_min_max.xyxy, cb.uv_min_max.zwzw);
-			}
-			else if (PS_WMS == 3)
-			{
-				// wrap negative uv coords to avoid an off by one error that shifted
-				// textures. Fixes Xenosaga's hair issue.
-				if (!FST)
-					uv = fract(uv);
-
-				uv_out = float4((ushort4(uv * tex_size) & ushort4(cb.uv_msk_fix.xyxy)) | ushort4(cb.uv_msk_fix.zwzw)) / tex_size;
-			}
+			uv_out.xz = clamp(uv.xz, cb.uv_min_max.xx, cb.uv_min_max.zz);
 		}
-		else
+		else if (PS_WMS == 3)
 		{
-			if (PS_WMS == 2)
-			{
-				uv_out.xz = clamp(uv.xz, cb.uv_min_max.xx, cb.uv_min_max.zz);
-			}
-			else if (PS_WMS == 3)
-			{
-				if (!FST)
-					uv.xz = fract(uv.xz);
+			// wrap negative uv coords to avoid an off by one error that shifted
+			// textures. Fixes Xenosaga's hair issue.
+			if (!FST)
+				uv.xz = fract(uv.xz);
 
-				uv_out.xz = float2((ushort2(uv.xz * tex_size.xx) & ushort2(cb.uv_msk_fix.xx)) | ushort2(cb.uv_msk_fix.zz)) / tex_size.xx;
-			}
+			uv_out.xz = float2((ushort2(uv.xz * tex_size.xx) & ushort2(cb.uv_msk_fix.xx)) | ushort2(cb.uv_msk_fix.zz)) / tex_size.xx;
+		}
 
-			if (PS_WMT == 2)
-			{
-				uv_out.yw = clamp(uv.yw, cb.uv_min_max.yy, cb.uv_min_max.ww);
-			}
-			else if (PS_WMT == 3)
-			{
-				if (!FST)
-					uv.yw = fract(uv.yw);
+		if (PS_WMT == 2)
+		{
+			uv_out.yw = clamp(uv.yw, cb.uv_min_max.yy, cb.uv_min_max.ww);
+		}
+		else if (PS_WMT == 3)
+		{
+			// wrap negative uv coords to avoid an off by one error that shifted
+			// textures. Fixes Xenosaga's hair issue.
+			if (!FST)
+				uv.yw = fract(uv.yw);
 
-				uv_out.yw = float2((ushort2(uv.yw * tex_size.yy) & ushort2(cb.uv_msk_fix.yy)) | ushort2(cb.uv_msk_fix.ww)) / tex_size.yy;
-			}
+			uv_out.yw = float2((ushort2(uv.yw * tex_size.yy) & ushort2(cb.uv_msk_fix.yy)) | ushort2(cb.uv_msk_fix.ww)) / tex_size.yy;
 		}
 
 		return uv_out;
@@ -386,25 +371,15 @@ struct PSMain
 		// It allow to multiply the ScalingFactor before the 1/16 coeff
 		ushort4 mask = ushort4(cb.uv_msk_fix) << 4;
 
-		if (PS_WMS == PS_WMT)
-		{
-			if (PS_WMS == 2)
-				uv_out = clamp(uv, mask.xy, mask.zw);
-			else if (PS_WMS == 3)
-				uv_out = (uv & mask.xy) | mask.zw;
-		}
-		else
-		{
-			if (PS_WMS == 2)
-				uv_out.x = clamp(uv.x, mask.x, mask.z);
-			else if (PS_WMS == 3)
-				uv_out.x = (uv.x & mask.x) | mask.z;
+		if (PS_WMS == 2)
+			uv_out.x = clamp(uv.x, mask.x, mask.z);
+		else if (PS_WMS == 3)
+			uv_out.x = (uv.x & mask.x) | mask.z;
 
-			if (PS_WMT == 2)
-				uv_out.y = clamp(uv.y, mask.y, mask.w);
-			else if (PS_WMT == 3)
-				uv_out.y = (uv.y & mask.y) | mask.w;
-		}
+		if (PS_WMT == 2)
+			uv_out.y = clamp(uv.y, mask.y, mask.w);
+		else if (PS_WMT == 3)
+			uv_out.y = (uv.y & mask.y) | mask.w;
 
 		return uv_out;
 	}

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -369,7 +369,7 @@ struct PSMain
 		uint2 mask = msk_fix << 4;
 
 		if (mode == 2)
-			return clamp(uv, mask.x, mask.y);
+			return clamp(uv, mask.x, mask.y | 0xF);
 		if (mode == 3)
 		{
 			if (msk_fix.x & 1)

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -276,7 +276,13 @@ struct PSMain
 			if (!FST)
 				uv = fract(uv);
 
-			return float2((uint2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+			uv *= tex_size;
+			float2 masked = float2((uint2(uv) & msk_fix.xx) | msk_fix.yy);
+
+			if (msk_fix.x & 1) // For upscaling, let the bottom bit mask everything below
+				masked += fract(uv);
+
+			return masked / tex_size;
 		}
 		return uv;
 	}
@@ -365,7 +371,11 @@ struct PSMain
 		if (mode == 2)
 			return clamp(uv, mask.x, mask.y);
 		if (mode == 3)
+		{
+			if (msk_fix.x & 1)
+				mask.x |= 0xF;
 			return (uv & mask.x) | mask.y;
+		}
 		return uv;
 	}
 

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -263,40 +263,32 @@ struct PSMain
 		return palette.sample(palette_sampler, float2(idx, 0));
 	}
 
+	float2 clamp_wrap_uv_2(uint mode, float2 uv, float tex_size, float2 min_max, uint2 msk_fix)
+	{
+		if (mode == 2)
+		{
+			return clamp(uv, min_max.xx, min_max.yy);
+		}
+		if (mode == 3)
+		{
+			// wrap negative uv coords to avoid an off by one error that shifted
+			// textures. Fixes Xenosaga's hair issue.
+			if (!FST)
+				uv = fract(uv);
+
+			return float2((uint2(uv * tex_size) & msk_fix.xx) | msk_fix.yy) / tex_size;
+		}
+		return uv;
+	}
+
 	float4 clamp_wrap_uv(float4 uv)
 	{
-		float4 uv_out = uv;
-		float4 tex_size = PS_INVALID_TEX0 ? cb.wh.zwzw : cb.wh.xyxy;
+		float2 tex_size = PS_INVALID_TEX0 ? cb.wh.zw : cb.wh.xy;
 
-		if (PS_WMS == 2)
-		{
-			uv_out.xz = clamp(uv.xz, cb.uv_min_max.xx, cb.uv_min_max.zz);
-		}
-		else if (PS_WMS == 3)
-		{
-			// wrap negative uv coords to avoid an off by one error that shifted
-			// textures. Fixes Xenosaga's hair issue.
-			if (!FST)
-				uv.xz = fract(uv.xz);
+		uv.xz = clamp_wrap_uv_2(PS_WMS, uv.xz, tex_size.x, cb.uv_min_max.xz, cb.uv_msk_fix.xz);
+		uv.yw = clamp_wrap_uv_2(PS_WMT, uv.yw, tex_size.y, cb.uv_min_max.yw, cb.uv_msk_fix.yw);
 
-			uv_out.xz = float2((ushort2(uv.xz * tex_size.xx) & ushort2(cb.uv_msk_fix.xx)) | ushort2(cb.uv_msk_fix.zz)) / tex_size.xx;
-		}
-
-		if (PS_WMT == 2)
-		{
-			uv_out.yw = clamp(uv.yw, cb.uv_min_max.yy, cb.uv_min_max.ww);
-		}
-		else if (PS_WMT == 3)
-		{
-			// wrap negative uv coords to avoid an off by one error that shifted
-			// textures. Fixes Xenosaga's hair issue.
-			if (!FST)
-				uv.yw = fract(uv.yw);
-
-			uv_out.yw = float2((ushort2(uv.yw * tex_size.yy) & ushort2(cb.uv_msk_fix.yy)) | ushort2(cb.uv_msk_fix.ww)) / tex_size.yy;
-		}
-
-		return uv_out;
+		return uv;
 	}
 
 	float4x4 sample_4c(float4 uv)
@@ -364,29 +356,29 @@ struct PSMain
 
 	// MARK: Depth sampling
 
-	ushort2 clamp_wrap_uv_depth(ushort2 uv)
+	uint clamp_wrap_uv_depth_1(uint mode, uint uv, uint2 msk_fix)
 	{
-		ushort2 uv_out = uv;
 		// Keep the full precision
 		// It allow to multiply the ScalingFactor before the 1/16 coeff
-		ushort4 mask = ushort4(cb.uv_msk_fix) << 4;
+		uint2 mask = msk_fix << 4;
 
-		if (PS_WMS == 2)
-			uv_out.x = clamp(uv.x, mask.x, mask.z);
-		else if (PS_WMS == 3)
-			uv_out.x = (uv.x & mask.x) | mask.z;
+		if (mode == 2)
+			return clamp(uv, mask.x, mask.y);
+		if (mode == 3)
+			return (uv & mask.x) | mask.y;
+		return uv;
+	}
 
-		if (PS_WMT == 2)
-			uv_out.y = clamp(uv.y, mask.y, mask.w);
-		else if (PS_WMT == 3)
-			uv_out.y = (uv.y & mask.y) | mask.w;
-
-		return uv_out;
+	uint2 clamp_wrap_uv_depth(uint2 uv)
+	{
+		uv.x = clamp_wrap_uv_depth_1(PS_WMS, uv.x, cb.uv_msk_fix.xz);
+		uv.y = clamp_wrap_uv_depth_1(PS_WMT, uv.y, cb.uv_msk_fix.yw);
+		return uv;
 	}
 
 	float4 sample_depth(float2 st)
 	{
-		float2 uv_f = float2(clamp_wrap_uv_depth(ushort2(st))) * (float2(SCALING_FACTOR) * float2(1.f / 16.f));
+		float2 uv_f = float2(clamp_wrap_uv_depth(uint2(st))) * (float2(SCALING_FACTOR) * float2(1.f / 16.f));
 		ushort2 uv = ushort2(uv_f);
 
 		float4 t = float4(0);


### PR DESCRIPTION
### Description of Changes
- Add support for upscaling region repeat
- Adjust region clamp coordinates for upscaling

### Rationale behind Changes
More upscaling is nice

### Suggested Testing Steps
- Make sure my changes to region clamp didn't make things worse.  I don't think they would, but who knows
- Test DX and GL (I only tested Metal and Vk)
- Test upscaled region repeat.  If you don't know of a game to test, comment out GSRendererHW:1373-1378 and GSRendererHW:1387-1391 and [run this trace](https://github.com/PCSX2/pcsx2/files/8468210/transformers_pixelation_pr5387.gs.xz.zip)

