### PR TITLE
Fix Intel graphics on Metal

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -640,12 +640,14 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool&
 		const bool prefer_sw_blend = m_conf.require_full_barrier || (m_conf.require_one_barrier && m_prim_overlap == PRIM_OVERLAP_NO);
 
 		// SW Blend is (nearly) free. Let's use it.
+		const bool one_barrier = m_conf.require_one_barrier || blend_ad_alpha_masked;
 		const bool no_prim_overlap = features.framebuffer_fetch ? (m_vt.m_primclass == GS_SPRITE_CLASS) : (m_prim_overlap == PRIM_OVERLAP_NO);
 		const bool impossible_or_free_blend = (blend_flag & BLEND_A_MAX) // Impossible blending
 			|| blend_non_recursive                 // Free sw blending, doesn't require barriers or reading fb
 			|| accumulation_blend                  // Mix of hw/sw blending
 			|| no_prim_overlap                     // Blend can be done in a single draw
-			|| (m_conf.require_full_barrier);      // Another effect (for example fbmask) already requires a full barrier
+			|| (m_conf.require_full_barrier)       // Another effect (for example fbmask) already requires a full barrier
+			|| (one_barrier && features.framebuffer_fetch); // On fbfetch, one barrier is like full barrier
 
 		switch (GSConfig.AccurateBlendingUnit)
 		{
@@ -1712,9 +1714,17 @@ void GSRendererNew::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sour
 		}
 	}
 
-	// Barriers aren't needed with fbfetch.
-	m_conf.require_one_barrier &= !features.framebuffer_fetch;
-	m_conf.require_full_barrier &= !features.framebuffer_fetch;
+	if (features.framebuffer_fetch)
+	{
+		// Intel GPUs on Metal lock up if you try to use DSB and framebuffer fetch at once
+		// We should never need to do that (since using framebuffer fetch means you should be able to do all blending in shader), but sometimes it slips through
+		if (m_conf.require_one_barrier || m_conf.require_full_barrier)
+			ASSERT(!m_conf.blend.enable);
+
+		// Barriers aren't needed with fbfetch.
+		m_conf.require_one_barrier = false;
+		m_conf.require_full_barrier = false;
+	}
 
 	// Swap full barrier for one barrier when there's no overlap.
 	if (m_conf.require_full_barrier && m_prim_overlap == PRIM_OVERLAP_NO)

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -338,7 +338,7 @@ struct PSMain
 		c.z = sample_c(uv.xw).a;
 		c.w = sample_c(uv.zw).a;
 
-		uchar4 i = uchar4(c * 255.5f); // Denormalize value
+		uint4 i = uint4(c * 255.5f); // Denormalize value
 
 		if (PS_PAL_FMT == 1)
 			return float4(i & 0xF) / 255.f;
@@ -504,9 +504,9 @@ struct PSMain
 		}
 		else
 		{
-			uchar4 rt = uchar4(fetch_raw_color() * 255.5f);
-			uchar green = (rt.g >> cb.channel_shuffle.green_shift) & cb.channel_shuffle.green_mask;
-			uchar blue  = (rt.b >> cb.channel_shuffle.blue_shift)  & cb.channel_shuffle.blue_mask;
+			uint4 rt = uint4(fetch_raw_color() * 255.5f);
+			uint green = (rt.g >> cb.channel_shuffle.green_shift) & cb.channel_shuffle.green_mask;
+			uint blue  = (rt.b >> cb.channel_shuffle.blue_shift)  & cb.channel_shuffle.blue_mask;
 			return float4(green | blue);
 		}
 	}
@@ -800,8 +800,8 @@ struct PSMain
 
 		if (PS_SHUFFLE)
 		{
-			uchar4 denorm_c = uchar4(C);
-			uchar2 denorm_TA = uchar2(cb.ta * 255.5f);
+			uint4 denorm_c = uint4(C);
+			uint2 denorm_TA = uint2(cb.ta * 255.5f);
 
 			C.rb = PS_READ_BA ? C.bb : C.rr;
 			if (PS_READ_BA)


### PR DESCRIPTION
### Description of Changes
Fixes bugs in Intel Graphics on Metal

### Rationale behind Changes
Having your system lock up because you selected Basic blending isn't great

### Suggested Testing Steps
Test [this GOW trace](https://github.com/PCSX2/pcsx2/files/8478912/GodOfWar.gs.xz.zip) on a computer with fbfetch

