### PR TITLE
GameDB: Fixes for Wrestle Kingdom 1 + 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28383,7 +28383,7 @@ SLPM-66401:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    alignSprite: 1
+    alignSprite: 1 # Fixes vertical lines.
 SLPM-66402:
   name: "Taito Memories Vol.1 [Taito The Best]"
   region: "NTSC-J"
@@ -29514,7 +29514,7 @@ SLPM-66714:
   name: "Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen"
   region: "NTSC-J"
   gsHWFixes:
-    alignSprite: 1
+    alignSprite: 1 # Fixes vertical lines.
     halfPixelOffset: 1 # Fixes misaligned bloom.
 SLPM-66715:
   name: "Shinki Gensou Spectral Souls II [IF Collection]"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28382,6 +28382,8 @@ SLPM-66401:
   name: "Wrestle Kingdom"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    alignSprite: 1
 SLPM-66402:
   name: "Taito Memories Vol.1 [Taito The Best]"
   region: "NTSC-J"
@@ -29511,6 +29513,9 @@ SLPM-66713:
 SLPM-66714:
   name: "Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1
+    halfPixelOffset: 1 # Fixes misaligned bloom.
 SLPM-66715:
   name: "Shinki Gensou Spectral Souls II [IF Collection]"
   region: "NTSC-J"


### PR DESCRIPTION
…Sekai Taisen

### Description of Changes
Added alignSprite fix to both Wrestle Kingdom games (to fix the vertical lines issue), and halfPixelOffset 1 (Normal) to Wrestle Kingdom 2 (to fix misaligned bloom when upscaling).

Wrestle Kingdom (Before/after alignSprite fix):

![gs_20220413180209_Wrestle Kingdom _NTSC-J__SLPM-66401](https://user-images.githubusercontent.com/67637185/163278516-16bc2253-da2c-4428-92aa-93dd75c63ae2.png)

![gs_20220413180853_Wrestle Kingdom _NTSC-J__SLPM-66401](https://user-images.githubusercontent.com/67637185/163278542-40ecc950-6b81-436c-913b-c1dd93d04b69.png)

Wrestle Kingdom 2 (Before/after alignSprite and halfPixelOffset fixes):

![gs_20220413180518_Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen _NTSC-J__SLPM-66714](https://user-images.githubusercontent.com/67637185/163278598-bf78d6b5-d377-46aa-a584-07ad830127b5.png)

![gs_20220413180726_Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen _NTSC-J__SLPM-66714](https://user-images.githubusercontent.com/67637185/163278614-743d3962-12e6-45e6-8216-6c535b0e1f6f.png)


### Rationale behind Changes
Fixes both games.

### Suggested Testing Steps
Simply test the games.
