### PR TITLE
Common/Semaphore: Fix WaitWithYield() returning immediately

### DIFF
--- a/common/Semaphore.cpp
+++ b/common/Semaphore.cpp
@@ -167,7 +167,7 @@ void Threading::KernelSemaphore::WaitWithYield()
 	{
 #ifdef _WIN32
 		u64 millis = def_yieldgui_interval.GetMilliseconds().GetValue();
-		while (pthreadCancelableTimedWait(m_sema, millis) == WAIT_TIMEOUT)
+		while (pthreadCancelableTimedWait(m_sema, millis) == ETIMEDOUT)
 			YieldToMain();
 #else
 		while (true)


### PR DESCRIPTION
This caused the WaitGS() issued from the main thread when applying renderer settings (while the core thread was paused) to return immediately, and a massive race resuming.

Fixes renderer swapping sometimes crashing in wx.