### PR TITLE
Vulkan: Improve resize robustness, make VMA use static imports

### DIFF
--- a/common/Vulkan/EntryPoints.h
+++ b/common/Vulkan/EntryPoints.h
@@ -15,6 +15,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // We abuse the preprocessor here to only need to specify function names once.
 // Function names are prefixed so to not conflict with system symbols at runtime.
 #define VULKAN_MODULE_ENTRY_POINT(name, required) extern PFN_##name pcsx2_##name;
@@ -26,6 +30,10 @@
 #undef VULKAN_DEVICE_ENTRY_POINT
 #undef VULKAN_INSTANCE_ENTRY_POINT
 #undef VULKAN_MODULE_ENTRY_POINT
+
+#ifdef __cplusplus
+}
+#endif
 
 #define vkCreateInstance pcsx2_vkCreateInstance
 #define vkGetInstanceProcAddr pcsx2_vkGetInstanceProcAddr
@@ -42,7 +50,6 @@
 #define vkGetPhysicalDeviceProperties pcsx2_vkGetPhysicalDeviceProperties
 #define vkGetPhysicalDeviceQueueFamilyProperties pcsx2_vkGetPhysicalDeviceQueueFamilyProperties
 #define vkGetPhysicalDeviceMemoryProperties pcsx2_vkGetPhysicalDeviceMemoryProperties
-#define vkGetPhysicalDeviceFeatures2 pcsx2_vkGetPhysicalDeviceFeatures2
 #define vkCreateDevice pcsx2_vkCreateDevice
 #define vkEnumerateDeviceExtensionProperties pcsx2_vkEnumerateDeviceExtensionProperties
 #define vkEnumerateDeviceLayerProperties pcsx2_vkEnumerateDeviceLayerProperties
@@ -74,7 +81,6 @@
 #define vkSetDebugUtilsObjectTagEXT pcsx2_vkSetDebugUtilsObjectTagEXT
 #define vkSubmitDebugUtilsMessageEXT pcsx2_vkSubmitDebugUtilsMessageEXT
 
-#define vkGetPhysicalDeviceProperties2 pcsx2_vkGetPhysicalDeviceProperties2
 #define vkGetPhysicalDeviceSurfaceCapabilities2KHR pcsx2_vkGetPhysicalDeviceSurfaceCapabilities2KHR
 #define vkGetPhysicalDeviceDisplayPropertiesKHR pcsx2_vkGetPhysicalDeviceDisplayPropertiesKHR
 #define vkGetPhysicalDeviceDisplayPlanePropertiesKHR pcsx2_vkGetPhysicalDeviceDisplayPlanePropertiesKHR
@@ -83,6 +89,11 @@
 #define vkCreateDisplayModeKHR pcsx2_vkCreateDisplayModeKHR
 #define vkGetDisplayPlaneCapabilitiesKHR pcsx2_vkGetDisplayPlaneCapabilitiesKHR
 #define vkCreateDisplayPlaneSurfaceKHR pcsx2_vkCreateDisplayPlaneSurfaceKHR
+
+// Vulkan 1.1 functions.
+#define vkGetPhysicalDeviceFeatures2 pcsx2_vkGetPhysicalDeviceFeatures2
+#define vkGetPhysicalDeviceProperties2 pcsx2_vkGetPhysicalDeviceProperties2
+#define vkGetPhysicalDeviceMemoryProperties2 pcsx2_vkGetPhysicalDeviceMemoryProperties2
 
 #define vkDestroyDevice pcsx2_vkDestroyDevice
 #define vkGetDeviceQueue pcsx2_vkGetDeviceQueue
@@ -209,6 +220,12 @@
 #define vkGetSwapchainImagesKHR pcsx2_vkGetSwapchainImagesKHR
 #define vkAcquireNextImageKHR pcsx2_vkAcquireNextImageKHR
 #define vkQueuePresentKHR pcsx2_vkQueuePresentKHR
+
+// Vulkan 1.1 functions.
+#define vkGetBufferMemoryRequirements2 pcsx2_vkGetBufferMemoryRequirements2
+#define vkGetImageMemoryRequirements2 pcsx2_vkGetImageMemoryRequirements2
+#define vkBindBufferMemory2 pcsx2_vkBindBufferMemory2
+#define vkBindImageMemory2 pcsx2_vkBindImageMemory2
 
 #ifdef SUPPORTS_VULKAN_EXCLUSIVE_FULLSCREEN
 #define vkAcquireFullScreenExclusiveModeEXT pcsx2_vkAcquireFullScreenExclusiveModeEXT

--- a/common/Vulkan/EntryPoints.inl
+++ b/common/Vulkan/EntryPoints.inl
@@ -26,13 +26,13 @@ VULKAN_MODULE_ENTRY_POINT(vkGetInstanceProcAddr, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceExtensionProperties, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceLayerProperties, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceVersion, false)
+VULKAN_MODULE_ENTRY_POINT(vkDestroyInstance, true)
 
 #endif // VULKAN_MODULE_ENTRY_POINT
 
 #ifdef VULKAN_INSTANCE_ENTRY_POINT
 
 VULKAN_INSTANCE_ENTRY_POINT(vkGetDeviceProcAddr, true)
-VULKAN_INSTANCE_ENTRY_POINT(vkDestroyInstance, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkEnumeratePhysicalDevices, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceFeatures, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties, true)

--- a/common/Vulkan/EntryPoints.inl
+++ b/common/Vulkan/EntryPoints.inl
@@ -40,7 +40,6 @@ VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceProperties, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties, true)
-VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceFeatures2, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateDevice, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkEnumerateDeviceExtensionProperties, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkEnumerateDeviceLayerProperties, true)
@@ -90,7 +89,6 @@ VULKAN_INSTANCE_ENTRY_POINT(vkSetDebugUtilsObjectNameEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkSetDebugUtilsObjectTagEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkSubmitDebugUtilsMessageEXT, false)
 
-VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceProperties2, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilities2KHR, false)
 
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceDisplayPropertiesKHR, false)
@@ -100,6 +98,11 @@ VULKAN_INSTANCE_ENTRY_POINT(vkGetDisplayModePropertiesKHR, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateDisplayModeKHR, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetDisplayPlaneCapabilitiesKHR, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateDisplayPlaneSurfaceKHR, false)
+
+// Vulkan 1.1 functions.
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceFeatures2, true)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceProperties2, true)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2, true)
 
 #endif // VULKAN_INSTANCE_ENTRY_POINT
 
@@ -230,6 +233,12 @@ VULKAN_DEVICE_ENTRY_POINT(vkDestroySwapchainKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkGetSwapchainImagesKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireNextImageKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkQueuePresentKHR, false)
+
+// Vulkan 1.1 functions.
+VULKAN_DEVICE_ENTRY_POINT(vkGetBufferMemoryRequirements2, true)
+VULKAN_DEVICE_ENTRY_POINT(vkGetImageMemoryRequirements2, true)
+VULKAN_DEVICE_ENTRY_POINT(vkBindBufferMemory2, true)
+VULKAN_DEVICE_ENTRY_POINT(vkBindImageMemory2, true)
 
 #ifdef SUPPORTS_VULKAN_EXCLUSIVE_FULLSCREEN
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireFullScreenExclusiveModeEXT, false)

--- a/common/Vulkan/Loader.cpp
+++ b/common/Vulkan/Loader.cpp
@@ -30,6 +30,8 @@
 #include <mach-o/dyld.h>
 #endif
 
+extern "C" {
+
 #define VULKAN_MODULE_ENTRY_POINT(name, required) PFN_##name pcsx2_##name;
 #define VULKAN_INSTANCE_ENTRY_POINT(name, required) PFN_##name pcsx2_##name;
 #define VULKAN_DEVICE_ENTRY_POINT(name, required) PFN_##name pcsx2_##name;
@@ -37,6 +39,8 @@
 #undef VULKAN_DEVICE_ENTRY_POINT
 #undef VULKAN_INSTANCE_ENTRY_POINT
 #undef VULKAN_MODULE_ENTRY_POINT
+
+}
 
 namespace Vulkan
 {

--- a/common/Vulkan/Loader.h
+++ b/common/Vulkan/Loader.h
@@ -101,6 +101,9 @@
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 #endif
 
+#define VMA_STATIC_VULKAN_FUNCTIONS 1
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#define VMA_STATS_STRING_ENABLED 0
 #include "vk_mem_alloc.h"
 
 #ifdef __clang__

--- a/common/Vulkan/SwapChain.cpp
+++ b/common/Vulkan/SwapChain.cpp
@@ -825,6 +825,7 @@ namespace Vulkan
 		DestroySwapChainImages();
 		DestroySwapChain();
 		DestroySurface();
+		DestroySemaphores();
 
 		// Re-create the surface with the new native handle
 		m_window_info = new_wi;
@@ -849,7 +850,7 @@ namespace Vulkan
 		}
 
 		// Finally re-create the swap chain
-		if (!CreateSwapChain() || !SetupSwapChainImages())
+		if (!CreateSwapChain() || !SetupSwapChainImages() || !CreateSemaphores())
 			return false;
 
 		return true;

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -112,7 +112,11 @@ void VulkanHostDisplay::ResizeRenderWindow(s32 new_window_width, s32 new_window_
 	g_vulkan_context->WaitForGPUIdle();
 
 	if (!m_swap_chain->ResizeSwapChain(new_window_width, new_window_height))
-		pxFailRel("Failed to resize swap chain");
+	{
+		// AcquireNextImage() will fail, and we'll recreate the surface.
+		Console.Error("Failed to resize swap chain. Next present will fail.");
+		return;
+	}
 
 	m_window_info = m_swap_chain->GetWindowInfo();
 }
@@ -341,7 +345,6 @@ bool VulkanHostDisplay::BeginPresent(bool frame_skip)
 			{
 				Console.Error("Failed to recreate surface after loss");
 				g_vulkan_context->ExecuteCommandBuffer(false);
-				m_swap_chain.reset();
 				return false;
 			}
 


### PR DESCRIPTION
### Description of Changes

Just some maintenance work, probably nothing will change, except the very rare case that if the surface gets lost, PCSX2 won't crash anymore.

### Rationale behind Changes

Things I should've done when writing this code in the first place.

### Suggested Testing Steps

Test Vulkan renderer to make sure it still works as expected.
