### PR TITLE
GS: Get display width for frame when offsets off

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -288,6 +288,7 @@ public:
 	void ResetHandlers();
 
 	int GetFramebufferHeight();
+	int GetDisplayHMagnification();
 	GSVector4i GetDisplayRect(int i = -1);
 	GSVector4i GetFrameMagnifiedRect(int i = -1);
 	GSVector2i GetResolutionOffset(int i = -1);


### PR DESCRIPTION
### Description of Changes
Calculate how much of the screen the picture should take up in real terms when screen offsets are disabled.

### Rationale behind Changes
some games take a large framebuffer such as Mortal Kombat Armageddon, where it renders 841 pixels and fits it in to like, 632 pixels on the screen due to the magnification, but when Screen Offsets are disabled, it doesn't account for this, but it needs to be restricted as some games try to render too much.

### Suggested Testing Steps
Test games with screen offsets disabled, especially known PCRTC problematic ones, make sure everything fits on the screen properly.

Fixes #5871 and situations like it.
