### PR TITLE
Common/Timer: Fix closing invalid handle on Win32

### DIFF
--- a/common/Timer.cpp
+++ b/common/Timer.cpp
@@ -187,13 +187,20 @@ namespace Common
 	ThreadCPUTimer::~ThreadCPUTimer()
 	{
 #ifdef _WIN32
-		CloseHandle(reinterpret_cast<HANDLE>(m_thread_handle));
+		if (m_thread_handle)
+			CloseHandle(reinterpret_cast<HANDLE>(m_thread_handle));
 #endif
 	}
 
 	ThreadCPUTimer& ThreadCPUTimer::operator=(ThreadCPUTimer&& move)
 	{
-		std::swap(m_thread_handle, move.m_thread_handle);
+#ifdef _WIN32
+		if (m_thread_handle)
+			CloseHandle(reinterpret_cast<HANDLE>(m_thread_handle));
+#endif
+
+		m_thread_handle = move.m_thread_handle;
+		move.m_thread_handle = nullptr;
 		return *this;
 	}
 


### PR DESCRIPTION
Only is an issue if you have a debugger attached and the exception enabled.
