### PR TITLE
GameDB: Game fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25313,6 +25313,8 @@ SLPM-65407:
   name: "Transformers Tatakai"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes flickering FMVs.
 SLPM-65408:
   name: "Growlanser IV - Wayfarer of the Time"
   region: "NTSC-J"
@@ -39493,6 +39495,8 @@ SLUS-20852:
   name: "Terminator 3, The - The Redemption"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes environment lights visible through player model.
 SLUS-20853:
   name: "Looney Tunes - Back in Action"
   region: "NTSC-U"
@@ -41251,6 +41255,8 @@ SLUS-21209:
   compat: 5
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
+  gsHWFixes:
+    alignSprite: 1 # Fixes black lines when upscaling.
 SLUS-21212:
   name: "Spartan - Total Warrior"
   region: "NTSC-U"


### PR DESCRIPTION
GameDB fixes for a few games.

### Description of Changes
Transformers Tatakai: Fixes flickering FMVs.

Terminator 3: The Redemption: Fixes environment lights visible through player model.

Before:
![gs_20220416121158_Terminator 3_ The - The Redemption _NTSC-U__SLUS-20852](https://user-images.githubusercontent.com/67637185/163684930-0e67bde7-7a81-407c-aab8-bbc26266fc08.png)

After:
![gs_20220416121213_Terminator 3_ The - The Redemption _NTSC-U__SLUS-20852](https://user-images.githubusercontent.com/67637185/163684935-085a7792-366a-4b4f-bbbf-122c58e045ba.png)

Urban Reign: Fixes black lines when upscaling.

Before:
![gs_20220416123107_Urban Reign _NTSC-U__SLUS-21209](https://user-images.githubusercontent.com/67637185/163684946-d4666187-7c03-4e33-96c6-261afbab6b62.png)

After:
![gs_20220416123134_Urban Reign _NTSC-U__SLUS-21209](https://user-images.githubusercontent.com/67637185/163684958-30e90644-f1fb-415a-b972-d8c8ae8b2294.png)


### Rationale behind Changes
Improve game experience.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test affected games.