### PR TITLE
CdRom: Remove Speed field/add accessor instead

### DIFF
--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -140,7 +140,7 @@ static __fi void StartReading(u32 type)
 {
 	cdr.Reading = type;
 	// Read's retry. If there's a status error clear and try, try again
-	cdr.StatP &~ STATUS_ERROR;
+	cdr.StatP &= ~STATUS_ERROR;
 	cdr.FirstSector = 1;
 	cdr.Readed = 0xff;
 	//DevCon.Warning("ReadN/ReadS delay: %d", sectorSeekReadDelay);

--- a/pcsx2/CDVD/CdRom.cpp
+++ b/pcsx2/CDVD/CdRom.cpp
@@ -131,6 +131,11 @@ uint sectorSeekReadDelay = 0x800;           // for calculated seek delays
 
 static void AddIrqQueue(u8 irq, u32 ecycle);
 
+static __fi int GetCDSpeed()
+{
+	return 1 + ((cdr.Mode >> 7) & 0x1);
+}
+
 static __fi void StartReading(u32 type)
 {
 	cdr.Reading = type;
@@ -862,7 +867,6 @@ void cdrWrite1(u8 rt)
 			cdr.Mode = cdr.Param[0];
 			cdr.Ctrl |= 0x80;
 			cdr.Stat = NoIntr;
-			cdr.Speed = 1 + ((cdr.Mode >> 7) & 0x1);
 			if (cdr.Mode & MODE_CDDA)
 			{
 				StopCdda();

--- a/pcsx2/CDVD/CdRom.h
+++ b/pcsx2/CDVD/CdRom.h
@@ -69,7 +69,6 @@ struct cdrStruct
 	u8 SetSectorSeek[4];
 	u8 Track;
 	int Play;
-	int Speed;
 	int CurTrack;
 	int Mode, File, Channel, Muted;
 	int Reset;


### PR DESCRIPTION
### Description of Changes

Regression from 02dfc5d20dac9a139151bc47d7e922cfad60b143. It's not worth breaking save states for an additional field which can be inferred from the mode register, and isn't currently used. I've added an accessor if the result is needed in the future.

Also fixes a warning introduced in the same commit, I'm guessing this was meant to be a `&= ~`, because `& ~` will have no effect.

### Rationale behind Changes

Less complaints from users about save states not loading.

### Suggested Testing Steps

Check old states load (I've done this).
