### PR TITLE
Qt: Fix fullscreening in Wayland

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -24,6 +24,7 @@
 #include <QtCore/QDebug>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QKeyEvent>
+#include <QtGui/QResizeEvent>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
 #include <QtGui/QWindowStateChangeEvent>
@@ -208,7 +209,12 @@ bool DisplayWidget::event(QEvent* event)
 		{
 			QWidget::event(event);
 
-			emit windowResizedEvent(scaledWindowWidth(), scaledWindowHeight(), devicePixelRatioFromScreen());
+			const qreal dpr = devicePixelRatioFromScreen();
+			const QSize size = static_cast<QResizeEvent*>(event)->size();
+			const int width = static_cast<int>(std::ceil(static_cast<qreal>(size.width()) * devicePixelRatioFromScreen()));
+			const int height = static_cast<int>(std::ceil(static_cast<qreal>(size.height()) * devicePixelRatioFromScreen()));
+
+			emit windowResizedEvent(width, height, dpr);
 			return true;
 		}
 
@@ -262,7 +268,7 @@ bool DisplayContainer::IsNeeded(bool fullscreen, bool render_to_main)
 #if defined(_WIN32) || defined(__APPLE__)
 	return false;
 #else
-	if (fullscreen || render_to_main)
+	if (!fullscreen && render_to_main)
 		return false;
 
 	// We only need this on Wayland because of client-side decorations...

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -603,9 +603,6 @@ void EmuThread::updateDisplay()
 		pxFailRel("Failed to recreate context after updating");
 		return;
 	}
-
-	// this is always a new widget, so reconnect it
-	connectDisplaySignals(widget);
 }
 
 HostDisplay* EmuThread::acquireHostDisplay(HostDisplay::RenderAPI api)

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -47,6 +47,7 @@ public:
 
 	/// Called back from the GS thread when the display state changes (e.g. fullscreen, render to main).
 	HostDisplay* acquireHostDisplay(HostDisplay::RenderAPI api);
+	void connectDisplaySignals(DisplayWidget* widget);
 	void releaseHostDisplay();
 	void updateDisplay();
 
@@ -127,7 +128,6 @@ private:
 	static constexpr u32 BACKGROUND_CONTROLLER_POLLING_INTERVAL =
 		100; /// Interval at which the controllers are polled when the system is not active.
 
-	void connectDisplaySignals(DisplayWidget* widget);
 	void destroyVM();
 	void executeVM();
 	void checkForSettingChanges();


### PR DESCRIPTION
### Description of Changes

What the title says. Render to main is sadly still a bit flaky, and I have no idea why. Perhaps someone more familiar with QtWayland could provide some insight (this isn't my primary platform anyway). Even weirder, is it's fine on Ubuntu 20.04, but broken on 22.04.

### Rationale behind Changes

Before fullscreening in Qt would dump the display in the top-left corner, instead of actually fullscreen. Apparently showing a widget fullscreen doesn't work in Wayland, and it needs a container, but it's fine in every other platform.

### Suggested Testing Steps

Test fullscreen in Qt on a Wayland desktop (I've already done this).
