### PR TITLE
GS: fix display width calculation for frame when offsets off

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -497,7 +497,7 @@ GSVector2i GSState::GetResolution()
 		// Some games (Mortal Kombat Armageddon) render the image at 834 pixels then shrink it to 624 pixels
 		// which does fit, but when we ignore offsets we go on framebuffer size and some other games
 		// such as Johnny Mosleys Mad Trix and Transformers render too much but design it to go off the screen.
-		int magnified_width = VideoModeDividers[(int)videomode - 1].z / GetDisplayHMagnification();
+		int magnified_width = (VideoModeDividers[static_cast<int>(videomode) - 1].z + 1) / GetDisplayHMagnification();
 
 		GSVector4i total_rect = GetDisplayRect(0).runion(GetDisplayRect(1));
 		total_rect.z = total_rect.z - total_rect.x;


### PR DESCRIPTION
### Description of Changes
Fix what appears to be the cause of a "crash" that can occur under certain conditions due to an off-by-one error 

### Rationale behind Changes
I build and use PCSX2 from master and when I built it and went to use it today Jak II was no longer working for me (PCSX2 crashed after the game had been running for a few seconds). As there were only a few commits since my last working build I manually built each commit and identified commit 904345f as the one that appeared to break things for me.

I haven't taken the time to fully understand the code but looking at the GSState::GetResolution method (changed in the specified commit) in isolation, stepping through the code with GDB, and comparing the current values computed vs what they previously would have been before the commit mentioned it looks like there is a sort of off-by-one bug. The provided commit resolves the issue for me and is hopefully a correct fix - happy to close this PR and create an Issue if I'm wrong.

Here is the stack trace I get from a debug build without this commit shortly after launching Jak II:

```
LnxHostSys.cpp(69) : assertion failed:
    Function:  void SysPageFaultSignalFilter(int, siginfo_t*, void*)
    Thread:    MTGS
    Condition: false
    Message:   Unhandled page fault @ 0x00000000

Stacktrace:
[00] pxOnAssert(DiagnosticOrigin const&, wxString const&) /Projects/pcsx2-fork/common/Exceptions.cpp:125
[01] SysPageFaultSignalFilter(int, siginfo_t*, void*) /Projects/pcsx2-fork/common/Linux/LnxHostSys.cpp:69
[02] 0x0x7f6be4674750                            
[03] _mm_store_si128(long long __vector(2)*, long long __vector(2)) /gcc/x86_64-redhat-linux/11/include/emmintrin.h:734
[04] void GSBlock::ReadColumn32<0>(unsigned char const*, unsigned char*, int) /Projects/pcsx2-fork/pcsx2/GS/GSBlock.h:442
[05] GSBlock::ReadBlock32(unsigned char const*, unsigned char*, int) /Projects/pcsx2-fork/pcsx2/GS/GSBlock.h:683
[06] GSLocalMemory::ReadTexture32(GSOffset const&, GSVector4i const&, unsigned char*, int, GIFRegTEXA const&)::{lambda(unsigned char*, unsigned char const*)#1}::operator()(unsigned char*, unsigned char const*) const /Projects/pcsx2-fork/pcsx2/GS/GSLocalMemory.cpp:1416
[07] void foreachBlock<GSLocalMemory::ReadTexture32(GSOffset const&, GSVector4i const&, unsigned char*, int, GIFRegTEXA const&)::{lambda(unsigned char*, unsigned char const*)#1}>(GSOffset const&, GSLocalMemory*, GSVector4i const&, unsigned char*, int, int, GSLocalMemory::ReadTexture32(GSOffset const&, GSVector4i const&, unsigned char*, int, GIFRegTEXA const&)::{lambda(unsigned char*, unsigned char const*)#1}&&) /Projects/pcsx2-fork/pcsx2/GS/GSLocalMemory.cpp:36
[08] GSLocalMemory::ReadTexture32(GSOffset const&, GSVector4i const&, unsigned char*, int, GIFRegTEXA const&) /Projects/pcsx2-fork/pcsx2/GS/GSLocalMemory.cpp:1413
[09] GSLocalMemory::ReadTexture(GSOffset const&, GSVector4i const&, unsigned char*, int, GIFRegTEXA const&) /Projects/pcsx2-fork/pcsx2/GS/GSLocalMemory.cpp:1712
[10] GSTextureCache::Target::Update()             /Projects/pcsx2-fork/pcsx2/GS/Renderers/HW/GSTextureCache.cpp:2129
[11] GSTextureCache::LookupTarget(GIFRegTEX0 const&, GSVector2T<int> const&, int, bool, unsigned int, bool, int) /Projects/pcsx2-fork/pcsx2/GS/Renderers/HW/GSTextureCache.cpp:598
[12] GSTextureCache::LookupTarget(GIFRegTEX0 const&, GSVector2T<int> const&, int) /Projects/pcsx2-fork/pcsx2/GS/Renderers/HW/GSTextureCache.cpp:611
[13] GSRendererHW::GetOutput(int, int&)           /Projects/pcsx2-fork/pcsx2/GS/Renderers/HW/GSRendererHW.cpp:224
[14] GSRenderer::Merge(int)                       /Projects/pcsx2-fork/pcsx2/GS/Renderers/Common/GSRenderer.cpp:183
[15] GSRenderer::VSync(unsigned int, bool)        /Projects/pcsx2-fork/pcsx2/GS/Renderers/Common/GSRenderer.cpp:570
[16] GSRendererHW::VSync(unsigned int, bool)      /Projects/pcsx2-fork/pcsx2/GS/Renderers/HW/GSRendererHW.cpp:192
[17] GSvsync(unsigned int, bool)                  /Projects/pcsx2-fork/pcsx2/GS/GS.cpp:525
[18] SysMtgsThread::ExecuteTaskInThread()         /Projects/pcsx2-fork/pcsx2/MTGS.cpp:401
[19] Threading::pxThread::_try_virtual_invoke(void (Threading::pxThread::*)()) /Projects/pcsx2-fork/common/ThreadTools.cpp:615
[20] Threading::pxThread::_internal_execute()     /Projects/pcsx2-fork/common/ThreadTools.cpp:670
[21] Threading::pxThread::internal_callback_helper(void*) /Projects/pcsx2-fork/common/ThreadTools.cpp:721
[22] Threading::pxThread::_internal_callback(void*) /Projects/pcsx2-fork/common/ThreadTools.cpp:709
```

### Suggested Testing Steps
Validate #5871 is still fixed and similar testing as for #5881 