### PR TITLE
build: on linux use system wayland libs falling back to appimage ones

### DIFF
--- a/.github/workflows/scripts/linux/app-variables.sh
+++ b/.github/workflows/scripts/linux/app-variables.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 export LD_LIBRARY_PATH="$APPDIR/usr/lib:$LD_LIBRARY_PATH"
+
+# use system wayland if available otherwise use the appimage provided wayland
+if [[ $(ldconfig -p | grep libwayland-client | wc -l) -lt 1 ]]; then
+        export LD_LIBRARY_PATH="$APPDIR/usr/lib/wayland:$LD_LIBRARY_PATH"
+fi
+
 export BINARY_NAME=$(basename "$ARGV0")
 if [[ ! -e "$PWD/$BINARY_NAME.config" ]]; then
         mkdir "$PWD/$BINARY_NAME.config"

--- a/.github/workflows/scripts/linux/appimage.sh
+++ b/.github/workflows/scripts/linux/appimage.sh
@@ -49,8 +49,14 @@ cp --dereference /lib/"$LIBARCH"/libgcc_s.so.1 "$GITHUB_WORKSPACE"/squashfs-root
 chmod +x .github/workflows/scripts/linux/app-variables.sh
 cp .github/workflows/scripts/linux/app-variables.sh "$GITHUB_WORKSPACE"/squashfs-root/apprun-hooks
 export UPD_INFO="gh-releases-zsync|PCSX2|pcsx2|latest|$name.AppImage.zsync"
-export OUTPUT="$name.AppImage"
-/tmp/squashfs-root/AppRun --appdir="$GITHUB_WORKSPACE"/squashfs-root/ --plugin gtk -d "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.desktop -i "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.png --output appimage
+/tmp/squashfs-root/AppRun --appdir="$GITHUB_WORKSPACE"/squashfs-root/ --plugin gtk -d "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.desktop -i "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.png
+# see LD_LIBRARY_PATH in app-variables.sh - the intent is to use system wayland if available but fall back to app-image provided
+# a little bit hacky but should ensure maximum compatibility
+mkdir -p squashfs-root/usr/lib/wayland
+mv squashfs-root/usr/lib/libwayland-* squashfs-root/usr/lib/wayland
+curl -sSfL "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$ARCH.AppImage" -o ./appimagetool-"$ARCH".AppImage
+chmod a+x appimagetool*.AppImage
+./appimagetool-"$ARCH".AppImage "$GITHUB_WORKSPACE"/squashfs-root "$name.AppImage"
 mkdir -p "$GITHUB_WORKSPACE"/ci-artifacts/
 ls -al .
 mv "$name.AppImage" "$GITHUB_WORKSPACE"/ci-artifacts # && mv "$name.AppImage.zsync" "$GITHUB_WORKSPACE"/ci-artifacts


### PR DESCRIPTION
### Description of Changes
Prefer system libwayland-* to the ones provided by the AppImage

### Rationale behind Changes
Currently the AppImage crashes when starting emulation with graphical output on certain stock configured Linux distributions like Fedora or SteamOS. Not sure on the exact internal details but relying on system wayland rather than a bundled one seems to solve this.

Fixes #5904 

### Suggested Testing Steps
- [x] Test a game starts on a Linux distribution that uses wayland 
- [x] Test a game starts on a Linux distribution without wayland

Has been confirmed working on a range of Linux distributions (OpenSuse, Debian, Fedora, Steam Deck/SteamOS) by various people in Discord.
