### PR TITLE
GS-d3d11: Purge the NVIDIA hack.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -114,7 +114,6 @@ private:
 	static constexpr u32 MAX_TEXTURES = 3;
 	static constexpr u32 MAX_SAMPLERS = 2;
 
-	float m_hack_topleft_offset;
 	int m_d3d_texsize;
 
 	void SetFeatures();

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -148,9 +148,7 @@ const char* dialog_message(int ID, bool* updateText)
 				"Disables accurate Unscale Point and Line rendering.\n"
 				"It can help Xenosaga games.\n\n"
 				"Disables accurate GS Memory Clearing to be done on the CPU, and let only the GPU handle it.\n"
-				"It can help Kingdom Hearts games.\n\n"
-				"Disables special Nvidia hack.\n"
-				"It can help SOTC, Fatal Frame games and possibly others too.");
+				"It can help Kingdom Hearts games.");
 		case IDC_MEMORY_WRAPPING:
 			return cvtString("Emulates GS memory wrapping accurately. This fixes issues where part of the image is cut-off by block shaped sections such as the FMVs in Wallace & Gromit: The Curse of the Were-Rabbit and Thrillville.\n\n"
 				"Note: This hack can have a small impact on performance.");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-d3d11: Purge the NVIDIA hack.
The driver issue got resolved by nvidia.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
No longer needed.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test SOTC and VP2 fmv intro, make sure it doesn't flicker
Fixes #3358