### PR TITLE
GS-qt: Gray out texture barriers and geometry shaders on d3d or sw renderers.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -354,8 +354,10 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 
 #ifdef _WIN32
 	const bool is_dx11 = (type == GSRendererType::DX11 || type == GSRendererType::SW);
+	const bool is_sw_dx = (type == GSRendererType::DX11 || type == GSRendererType::DX12 || type == GSRendererType::SW);
 #else
 	const bool is_dx11 = false;
+	const bool is_sw_dx = false;
 #endif
 
 	const bool is_hardware = (type == GSRendererType::DX11 || type == GSRendererType::DX12 || type == GSRendererType::OGL || type == GSRendererType::VK);
@@ -412,6 +414,9 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 
 		m_software_renderer_visible = is_software;
 	}
+
+	m_ui.overrideTextureBarriers->setDisabled(is_sw_dx);
+	m_ui.overrideGeometryShader->setDisabled(is_sw_dx);
 
 	m_ui.useBlitSwapChain->setEnabled(is_dx11);
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-qt: Gray out texture barriers and geometry shaders on d3d or sw renderers.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Consistency with what the options should do.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure they work as intended.