### PR TITLE
VMManager: Fix disc path when specifying source type

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -530,6 +530,7 @@ bool VMManager::ApplyBootParameters(const VMBootParameters& params)
 		}
 
 		// Use specified source type.
+		s_disc_path = params.filename;
 		CDVDsys_SetFile(params.source_type.value(), params.filename);
 		CDVDsys_ChangeSource(params.source_type.value());
 	}


### PR DESCRIPTION
This caused an empty disc path variable when the source type was specified (i.e. booting from the game list, not from command line).