### PR TITLE
Qt: Add crash handler/dumper

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -175,7 +175,11 @@ if(WIN32)
 	target_sources(common PRIVATE FastJmp.asm)
 	target_link_libraries(common PUBLIC WIL::WIL D3D12MemAlloc pthreads4w Winmm.lib)
 	target_sources(common PRIVATE
+		CrashHandler.cpp
+		CrashHandler.h
 		FastJmp.asm
+		StackWalker.cpp
+		StackWalker.h
 		D3D11/ShaderCache.cpp
 		D3D11/ShaderCache.h
 		D3D11/ShaderCompiler.cpp

--- a/common/CrashHandler.cpp
+++ b/common/CrashHandler.cpp
@@ -1,0 +1,228 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Pcsx2Defs.h"
+#include "CrashHandler.h"
+#include "FileSystem.h"
+#include "StringUtil.h"
+#include <cinttypes>
+#include <cstdio>
+#include <ctime>
+
+#if defined(_WIN32) && !defined(_UWP)
+#include "RedtapeWindows.h"
+
+#include "StackWalker.h"
+#include <DbgHelp.h>
+
+class CrashHandlerStackWalker : public StackWalker
+{
+public:
+	explicit CrashHandlerStackWalker(HANDLE out_file);
+	~CrashHandlerStackWalker();
+
+protected:
+	void OnOutput(LPCSTR szText) override;
+
+private:
+	HANDLE m_out_file;
+};
+
+CrashHandlerStackWalker::CrashHandlerStackWalker(HANDLE out_file)
+	: StackWalker(RetrieveVerbose, nullptr, GetCurrentProcessId(), GetCurrentProcess())
+	, m_out_file(out_file)
+{
+}
+
+CrashHandlerStackWalker::~CrashHandlerStackWalker()
+{
+	if (m_out_file)
+		CloseHandle(m_out_file);
+}
+
+void CrashHandlerStackWalker::OnOutput(LPCSTR szText)
+{
+	if (m_out_file)
+	{
+		DWORD written;
+		WriteFile(m_out_file, szText, static_cast<DWORD>(std::strlen(szText)), &written, nullptr);
+	}
+
+	OutputDebugStringA(szText);
+}
+
+static bool WriteMinidump(HMODULE hDbgHelp, HANDLE hFile, HANDLE hProcess, DWORD process_id, DWORD thread_id,
+	PEXCEPTION_POINTERS exception, MINIDUMP_TYPE type)
+{
+	using PFNMINIDUMPWRITEDUMP =
+		BOOL(WINAPI*)(HANDLE hProcess, DWORD ProcessId, HANDLE hFile, MINIDUMP_TYPE DumpType,
+			PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam, PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
+			PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
+
+	PFNMINIDUMPWRITEDUMP minidump_write_dump = hDbgHelp ?
+												   reinterpret_cast<PFNMINIDUMPWRITEDUMP>(GetProcAddress(hDbgHelp, "MiniDumpWriteDump")) :
+                                                   nullptr;
+	if (!minidump_write_dump)
+		return false;
+
+	MINIDUMP_EXCEPTION_INFORMATION mei;
+	PMINIDUMP_EXCEPTION_INFORMATION mei_ptr = nullptr;
+	if (exception)
+	{
+		mei.ThreadId = thread_id;
+		mei.ExceptionPointers = exception;
+		mei.ClientPointers = FALSE;
+		mei_ptr = &mei;
+	}
+
+	return minidump_write_dump(hProcess, process_id, hFile, type, mei_ptr, nullptr, nullptr);
+}
+
+static std::wstring s_write_directory;
+static HMODULE s_dbghelp_module = nullptr;
+static PVOID s_veh_handle = nullptr;
+static bool s_in_crash_handler = false;
+
+static void GenerateCrashFilename(wchar_t* buf, size_t len, const wchar_t* prefix, const wchar_t* extension)
+{
+	SYSTEMTIME st = {};
+	GetLocalTime(&st);
+
+	_snwprintf_s(buf, len, _TRUNCATE, L"%s%scrash-%04u-%02u-%02u-%02u-%02u-%02u-%03u.%s",
+		prefix ? prefix : L"", prefix ? L"\\" : L"",
+		st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds, extension);
+}
+
+static LONG NTAPI ExceptionHandler(PEXCEPTION_POINTERS exi)
+{
+	if (s_in_crash_handler)
+		return EXCEPTION_CONTINUE_SEARCH;
+
+	switch (exi->ExceptionRecord->ExceptionCode)
+	{
+		case EXCEPTION_ACCESS_VIOLATION:
+		case EXCEPTION_BREAKPOINT:
+		case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+		case EXCEPTION_INT_DIVIDE_BY_ZERO:
+		case EXCEPTION_INT_OVERFLOW:
+		case EXCEPTION_PRIV_INSTRUCTION:
+		case EXCEPTION_ILLEGAL_INSTRUCTION:
+		case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+		case EXCEPTION_STACK_OVERFLOW:
+		case EXCEPTION_GUARD_PAGE:
+			break;
+
+		default:
+			return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	// if the debugger is attached, let it take care of it.
+	if (IsDebuggerPresent())
+		return EXCEPTION_CONTINUE_SEARCH;
+
+	s_in_crash_handler = true;
+
+	wchar_t filename[1024] = {};
+	GenerateCrashFilename(filename, std::size(filename), s_write_directory.empty() ? nullptr : s_write_directory.c_str(), L"txt");
+
+	// might fail
+	HANDLE hFile = CreateFileW(filename, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+	if (hFile != INVALID_HANDLE_VALUE)
+	{
+		char line[1024];
+		DWORD written;
+		std::snprintf(line, std::size(line), "Exception 0x%08X at 0x%p\n", exi->ExceptionRecord->ExceptionCode,
+			exi->ExceptionRecord->ExceptionAddress);
+		WriteFile(hFile, line, static_cast<DWORD>(std::strlen(line)), &written, nullptr);
+	}
+
+	GenerateCrashFilename(filename, std::size(filename), s_write_directory.empty() ? nullptr : s_write_directory.c_str(), L"dmp");
+
+	const MINIDUMP_TYPE minidump_type =
+		static_cast<MINIDUMP_TYPE>(MiniDumpNormal | MiniDumpWithHandleData | MiniDumpWithProcessThreadData |
+								   MiniDumpWithThreadInfo | MiniDumpWithIndirectlyReferencedMemory);
+	const HANDLE hMinidumpFile = CreateFileW(filename, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+	if (hMinidumpFile == INVALID_HANDLE_VALUE ||
+		!WriteMinidump(s_dbghelp_module, hMinidumpFile, GetCurrentProcess(), GetCurrentProcessId(),
+			GetCurrentThreadId(), exi, minidump_type))
+	{
+		static const char error_message[] = "Failed to write minidump file.\n";
+		if (hFile != INVALID_HANDLE_VALUE)
+		{
+			DWORD written;
+			WriteFile(hFile, error_message, sizeof(error_message) - 1, &written, nullptr);
+		}
+	}
+	if (hMinidumpFile != INVALID_HANDLE_VALUE)
+		CloseHandle(hMinidumpFile);
+
+	CrashHandlerStackWalker sw(hFile);
+	sw.ShowCallstack(GetCurrentThread(), exi->ContextRecord);
+
+	if (hFile != INVALID_HANDLE_VALUE)
+		CloseHandle(hFile);
+
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+bool CrashHandler::Install()
+{
+	// load dbghelp at install/startup, that way we're not LoadLibrary()'ing after a crash
+	// .. because that probably wouldn't go down well.
+	s_dbghelp_module = StackWalker::LoadDbgHelpLibrary();
+
+	s_veh_handle = AddVectoredExceptionHandler(0, ExceptionHandler);
+	return (s_veh_handle != nullptr);
+}
+
+void CrashHandler::SetWriteDirectory(const std::string_view& dump_directory)
+{
+	if (!s_veh_handle)
+		return;
+
+	s_write_directory = StringUtil::UTF8StringToWideString(dump_directory);
+}
+
+void CrashHandler::Uninstall()
+{
+	if (s_veh_handle)
+	{
+		RemoveVectoredExceptionHandler(s_veh_handle);
+		s_veh_handle = nullptr;
+	}
+
+	if (s_dbghelp_module)
+	{
+		FreeLibrary(s_dbghelp_module);
+		s_dbghelp_module = nullptr;
+	}
+}
+
+#else
+
+bool CrashHandler::Install()
+{
+	return false;
+}
+
+void CrashHandler::SetWriteDirectory(const std::string_view& dump_directory)
+{
+}
+
+void CrashHandler::Uninstall()
+{
+}
+
+#endif

--- a/common/CrashHandler.h
+++ b/common/CrashHandler.h
@@ -1,0 +1,23 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string_view>
+
+namespace CrashHandler
+{
+	bool Install();
+	void SetWriteDirectory(const std::string_view& dump_directory);
+	void Uninstall();
+} // namespace CrashHandler

--- a/common/StackWalker.cpp
+++ b/common/StackWalker.cpp
@@ -1,0 +1,1222 @@
+/**********************************************************************
+ *
+ * StackWalker.cpp
+ * https://github.com/JochenKalmbach/StackWalker
+ *
+ * Old location: http://stackwalker.codeplex.com/
+ *
+ *
+ * History:
+ *  2005-07-27   v1    - First public release on http://www.codeproject.com/
+ *                       http://www.codeproject.com/threads/StackWalker.asp
+ *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
+ *                       (to simplify the usage)
+ *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
+ *                       (should also be enough)
+ *                     - Changed to compile correctly with the PSDK of VC7.0
+ *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
+ *                        it uses LPSTR instead of LPCSTR as first parameter)
+ *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
+ *                     - Added a 'pUserData' member to the ShowCallstack function and the
+ *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
+ *                       which can be used in the readMemoryFunction-callback)
+ *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
+ *                     - Added example for doing an exception-callstack-walking in main.cpp
+ *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
+ *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
+ *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
+ *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
+ *                       Fixed Bug: Compiling with "/Wall"
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
+ *                       Fixed Bug: Now checking SymUseSymSrv
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
+ *                       Fixed Bug: Support for recursive function calls
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
+ *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
+ *                       Fixed Bug: SymDia is number 7, not 9!
+ *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
+ *                       Thanks to Teajay which reported the bug...
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
+ *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
+ *                       Thanks to Luiz Salamon which reported this "bug"...
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
+ *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
+ *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
+ *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
+ *  2010-04-15   v12     Added support for VS2010 RTM
+ *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
+ *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
+ *                       http://stackwalker.codeplex.com/workitem/10511
+ *
+ *
+ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ *   Copyright (c) 2005-2013, Jochen Kalmbach
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **********************************************************************/
+
+#include "StackWalker.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <tchar.h>
+#include <windows.h>
+#include <dbghelp.h>
+#pragma comment(lib, "version.lib") // for "VerQueryValue"
+
+
+static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
+{
+  strncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
+}
+
+// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
+#define USED_CONTEXT_FLAGS CONTEXT_FULL
+
+HMODULE StackWalker::LoadDbgHelpLibrary()
+{
+  return LoadLibrary(_T("dbghelp.dll"));
+}
+
+class StackWalkerInternal
+{
+public:
+  StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
+    : m_parent(parent), m_hProcess(hProcess)
+  {
+  }
+  ~StackWalkerInternal()
+  {
+    if (pSC != nullptr)
+      pSC(m_hProcess); // SymCleanup
+    if (m_hDbhHelp != nullptr)
+      FreeLibrary(m_hDbhHelp);
+    m_hDbhHelp = nullptr;
+    m_parent = nullptr;
+    if (m_szSymPath != nullptr)
+      free(m_szSymPath);
+    m_szSymPath = nullptr;
+  }
+  StackWalkerInternal(const StackWalkerInternal&) = delete;
+
+  BOOL Init(LPCSTR szSymPath)
+  {
+    if (m_parent == nullptr)
+      return FALSE;
+    
+    m_hDbhHelp = StackWalker::LoadDbgHelpLibrary();
+    if (m_hDbhHelp == nullptr)
+      return FALSE;
+    pSI = (tSI)GetProcAddress(m_hDbhHelp, "SymInitialize");
+    pSC = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
+
+    pSW = (tSW)GetProcAddress(m_hDbhHelp, "StackWalk64");
+    pSGO = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
+    pSSO = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
+
+    pSFTA = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64");
+    pSGLFA = (tSGLFA)GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64");
+    pSGMB = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
+    pSGMI = (tSGMI)GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64");
+    pSGSFA = (tSGSFA)GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64");
+    pUDSN = (tUDSN)GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName");
+    pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
+    pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
+
+    if (pSC == nullptr || pSFTA == nullptr || pSGMB == nullptr || pSGMI == nullptr || pSGO == nullptr ||
+        pSGSFA == nullptr || pSI == nullptr || pSSO == nullptr || pSW == nullptr || pUDSN == nullptr ||
+        pSLM == nullptr)
+    {
+      FreeLibrary(m_hDbhHelp);
+      m_hDbhHelp = nullptr;
+      pSC = nullptr;
+      return FALSE;
+    }
+
+    // SymInitialize
+    if (szSymPath != nullptr)
+      m_szSymPath = _strdup(szSymPath);
+    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
+      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
+
+    DWORD symOptions = this->pSGO(); // SymGetOptions
+    symOptions |= SYMOPT_LOAD_LINES;
+    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
+    //symOptions |= SYMOPT_NO_PROMPTS;
+    // SymSetOptions
+    symOptions = this->pSSO(symOptions);
+
+    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
+    if (this->pSGSP != nullptr)
+    {
+      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
+        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
+    }
+    char  szUserName[1024] = {0};
+    DWORD dwSize = 1024;
+    GetUserNameA(szUserName, &dwSize);
+    this->m_parent->OnSymInit(buf, symOptions, szUserName);
+
+    return TRUE;
+  }
+
+  StackWalker* m_parent;
+
+  HMODULE m_hDbhHelp = nullptr;
+  HANDLE  m_hProcess;
+  LPSTR   m_szSymPath = nullptr;
+
+#pragma pack(push, 8)
+  struct IMAGEHLP_MODULE64_V3
+  {
+    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+    DWORD64  BaseOfImage;          // base load address of module
+    DWORD    ImageSize;            // virtual size of the loaded module
+    DWORD    TimeDateStamp;        // date/time stamp from pe header
+    DWORD    CheckSum;             // checksum from the pe header
+    DWORD    NumSyms;              // number of symbols in the symbol table
+    SYM_TYPE SymType;              // type of symbols loaded
+    CHAR     ModuleName[32];       // module name
+    CHAR     ImageName[256];       // image name
+    CHAR     LoadedImageName[256]; // symbol file name
+    // new elements: 07-Jun-2002
+    CHAR  LoadedPdbName[256];   // pdb file name
+    DWORD CVSig;                // Signature of the CV record in the debug directories
+    CHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
+    DWORD PdbSig;               // Signature of PDB
+    GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
+    DWORD PdbAge;               // DBI age of pdb
+    BOOL  PdbUnmatched;         // loaded an unmatched pdb
+    BOOL  DbgUnmatched;         // loaded an unmatched dbg
+    BOOL  LineNumbers;          // we have line number information
+    BOOL  GlobalSymbols;        // we have internal symbol information
+    BOOL  TypeInfo;             // we have type information
+    // new elements: 17-Dec-2003
+    BOOL SourceIndexed; // pdb supports source server
+    BOOL Publics;       // contains public symbols
+  };
+
+  struct IMAGEHLP_MODULE64_V2
+  {
+    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+    DWORD64  BaseOfImage;          // base load address of module
+    DWORD    ImageSize;            // virtual size of the loaded module
+    DWORD    TimeDateStamp;        // date/time stamp from pe header
+    DWORD    CheckSum;             // checksum from the pe header
+    DWORD    NumSyms;              // number of symbols in the symbol table
+    SYM_TYPE SymType;              // type of symbols loaded
+    CHAR     ModuleName[32];       // module name
+    CHAR     ImageName[256];       // image name
+    CHAR     LoadedImageName[256]; // symbol file name
+  };
+#pragma pack(pop)
+
+  // SymCleanup()
+  typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
+  tSC pSC = nullptr;
+
+  // SymFunctionTableAccess64()
+  typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
+  tSFTA pSFTA = nullptr;
+
+  // SymGetLineFromAddr64()
+  typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
+                                  IN DWORD64 dwAddr,
+                                  OUT PDWORD pdwDisplacement,
+                                  OUT PIMAGEHLP_LINE64 Line);
+  tSGLFA pSGLFA = nullptr;
+
+  // SymGetModuleBase64()
+  typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
+  tSGMB pSGMB = nullptr;
+
+  // SymGetModuleInfo64()
+  typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
+                                 IN DWORD64 dwAddr,
+                                 OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
+  tSGMI pSGMI = nullptr;
+
+  // SymGetOptions()
+  typedef DWORD(__stdcall* tSGO)(VOID);
+  tSGO pSGO = nullptr;
+
+  // SymGetSymFromAddr64()
+  typedef BOOL(__stdcall* tSGSFA)(IN HANDLE hProcess,
+                                  IN DWORD64 dwAddr,
+                                  OUT PDWORD64 pdwDisplacement,
+                                  OUT PIMAGEHLP_SYMBOL64 Symbol);
+  tSGSFA pSGSFA = nullptr;
+
+  // SymInitialize()
+  typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
+  tSI pSI = nullptr;
+
+  // SymLoadModule64()
+  typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
+                                   IN HANDLE hFile,
+                                   IN PSTR ImageName,
+                                   IN PSTR ModuleName,
+                                   IN DWORD64 BaseOfDll,
+                                   IN DWORD SizeOfDll);
+  tSLM pSLM = nullptr;
+
+  // SymSetOptions()
+  typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
+  tSSO pSSO = nullptr;
+
+  // StackWalk64()
+  typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
+                               HANDLE                           hProcess,
+                               HANDLE                           hThread,
+                               LPSTACKFRAME64                   StackFrame,
+                               PVOID                            ContextRecord,
+                               PREAD_PROCESS_MEMORY_ROUTINE64   ReadMemoryRoutine,
+                               PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
+                               PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
+                               PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
+  tSW pSW = nullptr;
+
+  // UnDecorateSymbolName()
+  typedef DWORD(__stdcall WINAPI* tUDSN)(PCSTR DecoratedName,
+                                         PSTR  UnDecoratedName,
+                                         DWORD UndecoratedLength,
+                                         DWORD Flags);
+  tUDSN pUDSN = nullptr;
+
+  typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
+  tSGSP pSGSP = nullptr;
+
+private:
+// **************************************** ToolHelp32 ************************
+#define MAX_MODULE_NAME32 255
+#define TH32CS_SNAPMODULE 0x00000008
+#pragma pack(push, 8)
+  typedef struct tagMODULEENTRY32
+  {
+    DWORD   dwSize;
+    DWORD   th32ModuleID;  // This module
+    DWORD   th32ProcessID; // owning process
+    DWORD   GlblcntUsage;  // Global usage count on the module
+    DWORD   ProccntUsage;  // Module usage count in th32ProcessID's context
+    BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
+    DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
+    HMODULE hModule;       // The hModule of this module in th32ProcessID's context
+    char    szModule[MAX_MODULE_NAME32 + 1];
+    char    szExePath[MAX_PATH];
+  } MODULEENTRY32;
+  typedef MODULEENTRY32* PMODULEENTRY32;
+  typedef MODULEENTRY32* LPMODULEENTRY32;
+#pragma pack(pop)
+
+  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
+  {
+    // CreateToolhelp32Snapshot()
+    typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
+    // Module32First()
+    typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+    // Module32Next()
+    typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+
+    tCT32S       pCT32S = nullptr;
+    tM32F        pM32F = nullptr;
+    tM32N        pM32N = nullptr;
+
+    HANDLE        hSnap;
+    MODULEENTRY32 me;
+    me.dwSize = sizeof(me);
+
+    HMODULE hKernel32 = LoadLibraryW(L"kernel32.dll");
+    if (hKernel32 == nullptr)
+      return FALSE;
+
+    pCT32S = (tCT32S)GetProcAddress(hKernel32, "CreateToolhelp32Snapshot");
+    pM32F = (tM32F)GetProcAddress(hKernel32, "Module32First");
+    pM32N = (tM32N)GetProcAddress(hKernel32, "Module32Next");
+    if (pCT32S == nullptr || pM32F == nullptr || pM32N == nullptr)
+    {
+      FreeLibrary(hKernel32);
+      return FALSE;
+    }
+
+    hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
+    if (hSnap == (HANDLE)-1)
+    {
+      FreeLibrary(hKernel32);
+      return FALSE;
+    }
+
+    BOOL keepGoing = !!pM32F(hSnap, &me);
+    int cnt = 0;
+    while (keepGoing)
+    {
+      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr,
+                       me.modBaseSize);
+      cnt++;
+      keepGoing = !!pM32N(hSnap, &me);
+    }
+    CloseHandle(hSnap);
+    FreeLibrary(hKernel32);
+    if (cnt <= 0)
+      return FALSE;
+    return TRUE;
+  } // GetModuleListTH32
+
+  // **************************************** PSAPI ************************
+  typedef struct _MODULEINFO
+  {
+    LPVOID lpBaseOfDll;
+    DWORD  SizeOfImage;
+    LPVOID EntryPoint;
+  } MODULEINFO, *LPMODULEINFO;
+
+  BOOL GetModuleListPSAPI(HANDLE hProcess)
+  {
+    // EnumProcessModules()
+    typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
+                                   LPDWORD lpcbNeeded);
+    // GetModuleFileNameEx()
+    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
+                                      DWORD nSize);
+    // GetModuleBaseName()
+    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
+                                     DWORD nSize);
+    // GetModuleInformation()
+    typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
+
+    HINSTANCE hPsapi;
+    tEPM      pEPM;
+    tGMFNE    pGMFNE;
+    tGMBN     pGMBN;
+    tGMI      pGMI;
+
+    DWORD i;
+    //ModuleEntry e;
+    DWORD        cbNeeded;
+    MODULEINFO   mi;
+    HMODULE*     hMods = nullptr;
+    char*        tt = nullptr;
+    char*        tt2 = nullptr;
+    const SIZE_T TTBUFLEN = 8096;
+    int          cnt = 0;
+
+    hPsapi = LoadLibrary(_T("psapi.dll"));
+    if (hPsapi == nullptr)
+      return FALSE;
+
+    pEPM = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
+    pGMFNE = (tGMFNE)GetProcAddress(hPsapi, "GetModuleFileNameExA");
+    pGMBN = (tGMFNE)GetProcAddress(hPsapi, "GetModuleBaseNameA");
+    pGMI = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
+    if ((pEPM == nullptr) || (pGMFNE == nullptr) || (pGMBN == nullptr) || (pGMI == nullptr))
+    {
+      // we couldn't find all functions
+      FreeLibrary(hPsapi);
+      return FALSE;
+    }
+
+    hMods = (HMODULE*)malloc(TTBUFLEN);
+    tt = (char*)malloc(sizeof(char) * TTBUFLEN);
+    tt2 = (char*)malloc(sizeof(char) * TTBUFLEN);
+    if ((hMods == nullptr) || (tt == nullptr) || (tt2 == nullptr))
+      goto cleanup;
+
+    if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded))
+    {
+      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
+      goto cleanup;
+    }
+
+    if (cbNeeded > TTBUFLEN)
+    {
+      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
+      goto cleanup;
+    }
+
+    for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
+    {
+      // base address, size
+      pGMI(hProcess, hMods[i], &mi, sizeof(mi));
+      // image file name
+      tt[0] = 0;
+      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
+      // module name
+      tt2[0] = 0;
+      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
+
+      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
+      if (dwRes != ERROR_SUCCESS)
+        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
+      cnt++;
+    }
+
+  cleanup:
+    if (hPsapi != nullptr)
+      FreeLibrary(hPsapi);
+    if (tt2 != nullptr)
+      free(tt2);
+    if (tt != nullptr)
+      free(tt);
+    if (hMods != nullptr)
+      free(hMods);
+
+    return cnt != 0;
+  } // GetModuleListPSAPI
+
+  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
+  {
+    CHAR* szImg = _strdup(img);
+    CHAR* szMod = _strdup(mod);
+    DWORD result = ERROR_SUCCESS;
+    if ((szImg == nullptr) || (szMod == nullptr))
+      result = ERROR_NOT_ENOUGH_MEMORY;
+    else
+    {
+      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
+        result = GetLastError();
+    }
+    ULONGLONG fileVersion = 0;
+    if ((m_parent != nullptr) && (szImg != nullptr))
+    {
+      // try to retrieve the file-version:
+      if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
+      {
+        VS_FIXEDFILEINFO* fInfo = nullptr;
+        DWORD             dwHandle;
+        DWORD             dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
+        if (dwSize > 0)
+        {
+          LPVOID vData = malloc(dwSize);
+          if (vData != nullptr)
+          {
+            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
+            {
+              UINT  len;
+              TCHAR szSubBlock[] = _T("\\");
+              if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
+                fInfo = nullptr;
+              else
+              {
+                fileVersion =
+                    ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
+              }
+            }
+            free(vData);
+          }
+        }
+      }
+
+      // Retrieve some additional-infos about the module
+      IMAGEHLP_MODULE64_V3 Module;
+      const char*          szSymType = "-unknown-";
+      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
+      {
+        switch (Module.SymType)
+        {
+          case SymNone:
+            szSymType = "-nosymbols-";
+            break;
+          case SymCoff: // 1
+            szSymType = "COFF";
+            break;
+          case SymCv: // 2
+            szSymType = "CV";
+            break;
+          case SymPdb: // 3
+            szSymType = "PDB";
+            break;
+          case SymExport: // 4
+            szSymType = "-exported-";
+            break;
+          case SymDeferred: // 5
+            szSymType = "-deferred-";
+            break;
+          case SymSym: // 6
+            szSymType = "SYM";
+            break;
+          case 7: // SymDia:
+            szSymType = "DIA";
+            break;
+          case 8: //SymVirtual:
+            szSymType = "Virtual";
+            break;
+        }
+      }
+      LPCSTR pdbName = Module.LoadedImageName;
+      if (Module.LoadedPdbName[0] != 0)
+        pdbName = Module.LoadedPdbName;
+      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
+                                   fileVersion);
+    }
+    if (szImg != nullptr)
+      free(szImg);
+    if (szMod != nullptr)
+      free(szMod);
+    return result;
+  }
+
+public:
+  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
+  {
+    // first try toolhelp32
+    if (GetModuleListTH32(hProcess, dwProcessId))
+      return true;
+    // then try psapi
+    return GetModuleListPSAPI(hProcess);
+  }
+
+  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
+  {
+    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+    if (this->pSGMI == nullptr)
+    {
+      SetLastError(ERROR_DLL_INIT_FAILED);
+      return FALSE;
+    }
+    // First try to use the larger ModuleInfo-Structure
+    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+    void* pData = malloc(
+        4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+    if (pData == nullptr)
+    {
+      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+      return FALSE;
+    }
+    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
+    static bool s_useV3Version = true;
+    if (s_useV3Version)
+    {
+      if (this->pSGMI(hProcess, baseAddr, static_cast<IMAGEHLP_MODULE64_V3*>(pData)) != FALSE)
+      {
+        // only copy as much memory as is reserved...
+        memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
+        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+        free(pData);
+        return TRUE;
+      }
+      s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
+    }
+
+    // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
+    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+    if (this->pSGMI(hProcess, baseAddr, static_cast<IMAGEHLP_MODULE64_V3*>(pData)) != FALSE)
+    {
+      // only copy as much memory as is reserved...
+      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
+      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+      free(pData);
+      return TRUE;
+    }
+    free(pData);
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+};
+
+// #############################################################
+StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
+{
+  this->m_options = OptionsAll;
+  this->m_modulesLoaded = FALSE;
+  this->m_hProcess = hProcess;
+  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+  this->m_dwProcessId = dwProcessId;
+  this->m_szSymPath = nullptr;
+  this->m_MaxRecursionCount = 1000;
+}
+StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
+{
+  this->m_options = options;
+  this->m_modulesLoaded = FALSE;
+  this->m_hProcess = hProcess;
+  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+  this->m_dwProcessId = dwProcessId;
+  if (szSymPath != nullptr)
+  {
+    this->m_szSymPath = _strdup(szSymPath);
+    this->m_options |= SymBuildPath;
+  }
+  else
+    this->m_szSymPath = nullptr;
+  this->m_MaxRecursionCount = 1000;
+}
+
+StackWalker::~StackWalker()
+{
+  if (m_szSymPath != nullptr)
+    free(m_szSymPath);
+  m_szSymPath = nullptr;
+  if (this->m_sw != nullptr)
+    delete this->m_sw;
+  this->m_sw = nullptr;
+}
+
+BOOL StackWalker::LoadModules()
+{
+  if (this->m_sw == nullptr)
+  {
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+  if (m_modulesLoaded != FALSE)
+    return TRUE;
+
+  // Build the sym-path:
+  char* szSymPath = nullptr;
+  if ((this->m_options & SymBuildPath) != 0)
+  {
+    const size_t nSymPathLen = 4096;
+    szSymPath = (char*)malloc(nSymPathLen);
+    if (szSymPath == nullptr)
+    {
+      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+      return FALSE;
+    }
+    szSymPath[0] = 0;
+    // Now first add the (optional) provided sympath:
+    if (this->m_szSymPath != nullptr)
+    {
+      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+
+    strcat_s(szSymPath, nSymPathLen, ".;");
+
+    const size_t nTempLen = 1024;
+    char         szTemp[nTempLen];
+    // Now add the current directory:
+    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
+    {
+      szTemp[nTempLen - 1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+
+    // Now add the path for the main-module:
+    if (GetModuleFileNameA(nullptr, szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen - 1] = 0;
+      for (char* p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p)
+      {
+        // locate the rightmost path separator
+        if ((*p == '\\') || (*p == '/') || (*p == ':'))
+        {
+          *p = 0;
+          break;
+        }
+      } // for (search for path separator...)
+      if (strlen(szTemp) > 0)
+      {
+        strcat_s(szSymPath, nSymPathLen, szTemp);
+        strcat_s(szSymPath, nSymPathLen, ";");
+      }
+    }
+    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen - 1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen - 1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
+    {
+      szTemp[nTempLen - 1] = 0;
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+      // also add the "system32"-directory:
+      strcat_s(szTemp, nTempLen, "\\system32");
+      strcat_s(szSymPath, nSymPathLen, szTemp);
+      strcat_s(szSymPath, nSymPathLen, ";");
+    }
+
+    if ((this->m_options & SymUseSymSrv) != 0)
+    {
+      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
+      {
+        szTemp[nTempLen - 1] = 0;
+        strcat_s(szSymPath, nSymPathLen, "SRV*");
+        strcat_s(szSymPath, nSymPathLen, szTemp);
+        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
+        strcat_s(szSymPath, nSymPathLen, "*https://msdl.microsoft.com/download/symbols;");
+      }
+      else
+        strcat_s(szSymPath, nSymPathLen,
+                 "SRV*c:\\websymbols*https://msdl.microsoft.com/download/symbols;");
+    }
+  } // if SymBuildPath
+
+  // First Init the whole stuff...
+  BOOL bRet = this->m_sw->Init(szSymPath);
+  if (szSymPath != nullptr)
+    free(szSymPath);
+  szSymPath = nullptr;
+  if (bRet == FALSE)
+  {
+    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+
+  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
+  if (bRet != FALSE)
+    m_modulesLoaded = TRUE;
+  return bRet;
+}
+
+// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
+// This has to be done due to a problem with the "hProcess"-parameter in x64...
+// Because this class is in no case multi-threading-enabled (because of the limitations
+// of dbghelp.dll) it is "safe" to use a static-variable
+static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = nullptr;
+static LPVOID                                 s_readMemoryFunction_UserData = nullptr;
+
+BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+                                const CONTEXT*            context,
+                                PReadProcessMemoryRoutine readMemoryFunction,
+                                LPVOID                    pUserData)
+{
+  CONTEXT                                   c;
+  CallstackEntry                            csEntry;
+  IMAGEHLP_SYMBOL64*                        pSym = nullptr;
+  StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
+  IMAGEHLP_LINE64                           Line;
+  int                                       frameNum;
+  bool                                      bLastEntryCalled = true;
+  int                                       curRecursionCount = 0;
+
+  if (m_modulesLoaded == FALSE)
+    this->LoadModules(); // ignore the result...
+
+  if (this->m_sw->m_hDbhHelp == nullptr)
+  {
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+
+  s_readMemoryFunction = readMemoryFunction;
+  s_readMemoryFunction_UserData = pUserData;
+
+  if (context == nullptr)
+  {
+    // If no context is provided, capture the context
+    // See: https://stackwalker.codeplex.com/discussions/446958
+#if _WIN32_WINNT <= 0x0501
+    // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
+    if (hThread == GetCurrentThread())
+#else
+    if (GetThreadId(hThread) == GetCurrentThreadId())
+#endif
+    {
+      GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
+    }
+    else
+    {
+      SuspendThread(hThread);
+      memset(&c, 0, sizeof(CONTEXT));
+      c.ContextFlags = USED_CONTEXT_FLAGS;
+
+      // TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
+      // This does only work if we are x64 and the target process is x64 or x86;
+      // It cannot work, if this process is x64 and the target process is x64... this is not supported...
+      // See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
+      if (GetThreadContext(hThread, &c) == FALSE)
+      {
+        ResumeThread(hThread);
+        return FALSE;
+      }
+    }
+  }
+  else
+    c = *context;
+
+  // init STACKFRAME for first call
+  STACKFRAME64 s; // in/out stackframe
+  memset(&s, 0, sizeof(s));
+  DWORD imageType;
+#ifdef _M_IX86
+  // normally, call ImageNtHeader() and use machine info from PE header
+  imageType = IMAGE_FILE_MACHINE_I386;
+  s.AddrPC.Offset = c.Eip;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.Ebp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.Esp;
+  s.AddrStack.Mode = AddrModeFlat;
+#elif _M_X64
+  imageType = IMAGE_FILE_MACHINE_AMD64;
+  s.AddrPC.Offset = c.Rip;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.Rsp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.Rsp;
+  s.AddrStack.Mode = AddrModeFlat;
+#elif _M_IA64
+  imageType = IMAGE_FILE_MACHINE_IA64;
+  s.AddrPC.Offset = c.StIIP;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.IntSp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrBStore.Offset = c.RsBSP;
+  s.AddrBStore.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.IntSp;
+  s.AddrStack.Mode = AddrModeFlat;
+#elif _M_ARM64
+  imageType = IMAGE_FILE_MACHINE_ARM64;
+  s.AddrPC.Offset = c.Pc;
+  s.AddrPC.Mode = AddrModeFlat;
+  s.AddrFrame.Offset = c.Fp;
+  s.AddrFrame.Mode = AddrModeFlat;
+  s.AddrStack.Offset = c.Sp;
+  s.AddrStack.Mode = AddrModeFlat;
+#else
+#error "Platform not supported!"
+#endif
+
+  pSym = (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+  if (!pSym)
+    goto cleanup; // not enough memory...
+  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+
+  memset(&Line, 0, sizeof(Line));
+  Line.SizeOfStruct = sizeof(Line);
+
+  memset(&Module, 0, sizeof(Module));
+  Module.SizeOfStruct = sizeof(Module);
+
+  for (frameNum = 0;; ++frameNum)
+  {
+    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
+    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
+    // assume that either you are done, or that the stack is so hosed that the next
+    // deeper frame could not be found.
+    // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+    if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
+                         this->m_sw->pSFTA, this->m_sw->pSGMB, nullptr))
+    {
+      // INFO: "StackWalk64" does not set "GetLastError"...
+      this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
+      break;
+    }
+
+    csEntry.offset = s.AddrPC.Offset;
+    csEntry.name[0] = 0;
+    csEntry.undName[0] = 0;
+    csEntry.undFullName[0] = 0;
+    csEntry.offsetFromSmybol = 0;
+    csEntry.offsetFromLine = 0;
+    csEntry.lineFileName[0] = 0;
+    csEntry.lineNumber = 0;
+    csEntry.loadedImageName[0] = 0;
+    csEntry.moduleName[0] = 0;
+    if (s.AddrPC.Offset == s.AddrReturn.Offset)
+    {
+      if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
+      {
+        this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
+        break;
+      }
+      curRecursionCount++;
+    }
+    else
+      curRecursionCount = 0;
+    if (s.AddrPC.Offset != 0)
+    {
+      // we seem to have a valid PC
+      // show procedure info (SymGetSymFromAddr64())
+      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
+                             pSym) != FALSE)
+      {
+        MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
+        // UnDecorateSymbolName()
+        this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
+        this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
+      }
+      else
+      {
+        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
+      }
+
+      // show line number info, NT5.0-method (SymGetLineFromAddr64())
+      if (this->m_sw->pSGLFA != nullptr)
+      { // yes, we have SymGetLineFromAddr64()
+        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
+                               &Line) != FALSE)
+        {
+          csEntry.lineNumber = Line.LineNumber;
+          MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
+        }
+        else
+        {
+          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
+        }
+      } // yes, we have SymGetLineFromAddr64()
+
+      // show module info (SymGetModuleInfo64())
+      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
+      { // got module info OK
+        switch (Module.SymType)
+        {
+          case SymNone:
+            csEntry.symTypeString = "-nosymbols-";
+            break;
+          case SymCoff:
+            csEntry.symTypeString = "COFF";
+            break;
+          case SymCv:
+            csEntry.symTypeString = "CV";
+            break;
+          case SymPdb:
+            csEntry.symTypeString = "PDB";
+            break;
+          case SymExport:
+            csEntry.symTypeString = "-exported-";
+            break;
+          case SymDeferred:
+            csEntry.symTypeString = "-deferred-";
+            break;
+          case SymSym:
+            csEntry.symTypeString = "SYM";
+            break;
+#if API_VERSION_NUMBER >= 9
+          case SymDia:
+            csEntry.symTypeString = "DIA";
+            break;
+#endif
+          case 8: //SymVirtual:
+            csEntry.symTypeString = "Virtual";
+            break;
+          default:
+            //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
+            csEntry.symTypeString = nullptr;
+            break;
+        }
+
+        MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
+        csEntry.baseOfImage = Module.BaseOfImage;
+        MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
+      } // got module info OK
+      else
+      {
+        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
+      }
+    } // we seem to have a valid PC
+
+    CallstackEntryType et = nextEntry;
+    if (frameNum == 0)
+      et = firstEntry;
+    bLastEntryCalled = false;
+    this->OnCallstackEntry(et, csEntry);
+
+    if (s.AddrReturn.Offset == 0)
+    {
+      bLastEntryCalled = true;
+      this->OnCallstackEntry(lastEntry, csEntry);
+      SetLastError(ERROR_SUCCESS);
+      break;
+    }
+  } // for ( frameNum )
+
+cleanup:
+  if (pSym)
+    free(pSym);
+
+  if (bLastEntryCalled == false)
+    this->OnCallstackEntry(lastEntry, csEntry);
+
+  if (context == nullptr)
+    ResumeThread(hThread);
+
+  return TRUE;
+}
+
+BOOL StackWalker::ShowObject(LPVOID pObject)
+{
+  // Load modules if not done yet
+  if (m_modulesLoaded == FALSE)
+    this->LoadModules(); // ignore the result...
+
+  // Verify that the DebugHelp.dll was actually found
+  if (this->m_sw->m_hDbhHelp == nullptr)
+  {
+    SetLastError(ERROR_DLL_INIT_FAILED);
+    return FALSE;
+  }
+
+  // SymGetSymFromAddr64() is required
+  if (this->m_sw->pSGSFA == nullptr)
+    return FALSE;
+
+  // Show object info (SymGetSymFromAddr64())
+  DWORD64            dwAddress = DWORD64(pObject);
+  DWORD64            dwDisplacement = 0;
+  const SIZE_T       symSize = sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN;
+  IMAGEHLP_SYMBOL64* pSym = (IMAGEHLP_SYMBOL64*) malloc(symSize);
+  if (!pSym)
+    return FALSE;
+  memset(pSym, 0, symSize);
+  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+  if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
+  {
+    this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
+    free(pSym);
+    return FALSE;
+  }
+  // Object name output
+  this->OnOutput(pSym->Name);
+
+  free(pSym);
+  return TRUE;
+};
+
+BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
+                                          DWORD64 qwBaseAddress,
+                                          PVOID   lpBuffer,
+                                          DWORD   nSize,
+                                          LPDWORD lpNumberOfBytesRead)
+{
+  if (s_readMemoryFunction == nullptr)
+  {
+    SIZE_T st;
+    BOOL   bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
+    *lpNumberOfBytesRead = (DWORD)st;
+    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
+    return bRet;
+  }
+  else
+  {
+    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
+                                s_readMemoryFunction_UserData);
+  }
+}
+
+void StackWalker::OnLoadModule(LPCSTR    img,
+                               LPCSTR    mod,
+                               DWORD64   baseAddr,
+                               DWORD     size,
+                               DWORD     result,
+                               LPCSTR    symType,
+                               LPCSTR    pdbName,
+                               ULONGLONG fileVersion)
+{
+  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+  if (fileVersion == 0)
+    _snprintf_s(buffer, _TRUNCATE, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n",
+                img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
+  else
+  {
+    DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
+    DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
+    DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
+    DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
+    _snprintf_s(
+        buffer, _TRUNCATE,
+        "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n",
+        img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
+  }
+  buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is nullptr terminated
+  OnOutput(buffer);
+}
+
+void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
+{
+  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+    if ((eType != lastEntry) && (entry.offset != 0))
+  {
+    if (entry.name[0] == 0)
+      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
+    if (entry.undName[0] != 0)
+      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
+    if (entry.undFullName[0] != 0)
+      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
+    if (entry.lineFileName[0] == 0)
+    {
+      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
+      if (entry.moduleName[0] == 0)
+        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
+      _snprintf_s(buffer, _TRUNCATE, "%p (%s): %s: %s\n", (LPVOID)entry.offset, entry.moduleName,
+                  entry.lineFileName, entry.name);
+    }
+    else
+      _snprintf_s(buffer, _TRUNCATE, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber,
+                  entry.name);
+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+    OnOutput(buffer);
+  }
+}
+
+void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
+{
+  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+  _snprintf_s(buffer, _TRUNCATE, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle,
+              (LPVOID)addr);
+  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+  OnOutput(buffer);
+}
+
+void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
+{
+  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+  _snprintf_s(buffer, _TRUNCATE, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n",
+              szSearchPath, symOptions, szUserName);
+  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+  OnOutput(buffer);
+
+  OSVERSIONINFOEXA ver;
+  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
+  ver.dwOSVersionInfoSize = sizeof(ver);
+#if _MSC_VER >= 1900
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+  if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
+  {
+    _snprintf_s(buffer, _TRUNCATE, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion,
+                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
+                ver.wProductType);
+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+    OnOutput(buffer);
+  }
+#if _MSC_VER >= 1900
+#pragma warning(pop)
+#endif
+}
+
+void StackWalker::OnOutput(LPCSTR buffer)
+{
+  OutputDebugStringA(buffer);
+}

--- a/common/StackWalker.h
+++ b/common/StackWalker.h
@@ -1,0 +1,181 @@
+/**********************************************************************
+ *
+ * StackWalker.h
+ *
+ *
+ *
+ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ *   Copyright (c) 2005-2009, Jochen Kalmbach
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * **********************************************************************/
+#pragma once
+
+#include "RedtapeWindows.h"
+
+class StackWalkerInternal; // forward
+class StackWalker
+{
+public:
+  typedef enum StackWalkOptions
+  {
+    // No addition info will be retrieved
+    // (only the address is available)
+    RetrieveNone = 0,
+
+    // Try to get the symbol-name
+    RetrieveSymbol = 1,
+
+    // Try to get the line for this symbol
+    RetrieveLine = 2,
+
+    // Try to retrieve the module-infos
+    RetrieveModuleInfo = 4,
+
+    // Also retrieve the version for the DLL/EXE
+    RetrieveFileVersion = 8,
+
+    // Contains all the above
+    RetrieveVerbose = 0xF,
+
+    // Generate a "good" symbol-search-path
+    SymBuildPath = 0x10,
+
+    // Also use the public Microsoft-Symbol-Server
+    SymUseSymSrv = 0x20,
+
+    // Contains all the above "Sym"-options
+    SymAll = 0x30,
+
+    // Contains all options (default)
+    OptionsAll = 0x3F
+  } StackWalkOptions;
+
+  StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
+              LPCSTR szSymPath = NULL,
+              DWORD  dwProcessId = GetCurrentProcessId(),
+              HANDLE hProcess = GetCurrentProcess());
+  StackWalker(DWORD dwProcessId, HANDLE hProcess);
+  StackWalker(const StackWalker&) = delete;
+  virtual ~StackWalker();
+
+  static HMODULE LoadDbgHelpLibrary();
+
+  typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(
+      HANDLE  hProcess,
+      DWORD64 qwBaseAddress,
+      PVOID   lpBuffer,
+      DWORD   nSize,
+      LPDWORD lpNumberOfBytesRead,
+      LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
+  );
+
+  BOOL LoadModules();
+
+  BOOL ShowCallstack(
+      HANDLE                    hThread = GetCurrentThread(),
+      const CONTEXT*            context = NULL,
+      PReadProcessMemoryRoutine readMemoryFunction = NULL,
+      LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
+  );
+
+  BOOL ShowObject(LPVOID pObject);
+
+#if _MSC_VER >= 1300
+  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
+  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
+protected:
+#endif
+  enum
+  {
+    STACKWALK_MAX_NAMELEN = 1024
+  }; // max name length for found symbols
+
+protected:
+  // Entry for each Callstack-Entry
+  typedef struct CallstackEntry
+  {
+    DWORD64 offset; // if 0, we have no valid entry
+    CHAR    name[STACKWALK_MAX_NAMELEN];
+    CHAR    undName[STACKWALK_MAX_NAMELEN];
+    CHAR    undFullName[STACKWALK_MAX_NAMELEN];
+    DWORD64 offsetFromSmybol;
+    DWORD   offsetFromLine;
+    DWORD   lineNumber;
+    CHAR    lineFileName[STACKWALK_MAX_NAMELEN];
+    DWORD   symType;
+    LPCSTR  symTypeString;
+    CHAR    moduleName[STACKWALK_MAX_NAMELEN];
+    DWORD64 baseOfImage;
+    CHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
+  } CallstackEntry;
+
+  typedef enum CallstackEntryType
+  {
+    firstEntry,
+    nextEntry,
+    lastEntry
+  } CallstackEntryType;
+
+  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
+  virtual void OnLoadModule(LPCSTR    img,
+                            LPCSTR    mod,
+                            DWORD64   baseAddr,
+                            DWORD     size,
+                            DWORD     result,
+                            LPCSTR    symType,
+                            LPCSTR    pdbName,
+                            ULONGLONG fileVersion);
+  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
+  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
+  virtual void OnOutput(LPCSTR szText);
+
+  StackWalkerInternal* m_sw;
+  HANDLE               m_hProcess;
+  DWORD                m_dwProcessId;
+  BOOL                 m_modulesLoaded;
+  LPSTR                m_szSymPath;
+
+  int m_options;
+  int m_MaxRecursionCount;
+
+  static BOOL __stdcall myReadProcMem(HANDLE  hProcess,
+                                      DWORD64 qwBaseAddress,
+                                      PVOID   lpBuffer,
+                                      DWORD   nSize,
+                                      LPDWORD lpNumberOfBytesRead);
+
+  friend StackWalkerInternal;
+}; // class StackWalker
+
+// The following is defined for x86 (XP and higher), x64 and IA64:
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+  do                                                              \
+  {                                                               \
+    memset(&c, 0, sizeof(CONTEXT));                               \
+    c.ContextFlags = contextFlags;                                \
+    RtlCaptureContext(&c);                                        \
+  } while (0);

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <ClCompile Include="AlignedMalloc.cpp" />
     <ClCompile Include="Console.cpp" />
+    <ClCompile Include="CrashHandler.cpp" />
     <ClCompile Include="D3D11\ShaderCache.cpp" />
     <ClCompile Include="D3D11\ShaderCompiler.cpp" />
     <ClCompile Include="D3D12\Builders.cpp" />
@@ -68,6 +69,7 @@
     <ClCompile Include="MD5Digest.cpp" />
     <ClCompile Include="ProgressCallback.cpp" />
     <ClCompile Include="pxTranslate.cpp" />
+    <ClCompile Include="StackWalker.cpp" />
     <ClCompile Include="StringUtil.cpp" />
     <ClCompile Include="SettingsWrapper.cpp" />
     <ClCompile Include="Timer.cpp" />
@@ -122,6 +124,7 @@
     <ClInclude Include="Align.h" />
     <ClInclude Include="AlignedMalloc.h" />
     <ClInclude Include="BitCast.h" />
+    <ClInclude Include="CrashHandler.h" />
     <ClInclude Include="D3D11\ShaderCache.h" />
     <ClInclude Include="D3D11\ShaderCompiler.h" />
     <ClInclude Include="D3D12\Builders.h" />
@@ -144,6 +147,7 @@
     <ClInclude Include="MD5Digest.h" />
     <ClInclude Include="ProgressCallback.h" />
     <ClInclude Include="ScopedGuard.h" />
+    <ClInclude Include="StackWalker.h" />
     <ClInclude Include="StringUtil.h" />
     <ClInclude Include="SettingsInterface.h" />
     <ClInclude Include="SettingsWrapper.h" />

--- a/common/common.vcxproj.filters
+++ b/common/common.vcxproj.filters
@@ -199,6 +199,12 @@
     <ClCompile Include="D3D12\Builders.cpp">
       <Filter>Source Files\D3D12</Filter>
     </ClCompile>
+    <ClCompile Include="StackWalker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CrashHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AlignedMalloc.h">
@@ -455,6 +461,12 @@
     </ClInclude>
     <ClInclude Include="D3D12\Builders.h">
       <Filter>Header Files\D3D12</Filter>
+    </ClInclude>
+    <ClInclude Include="CrashHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="StackWalker.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/pcsx2-qt/Main.cpp
+++ b/pcsx2-qt/Main.cpp
@@ -27,6 +27,8 @@
 #include "Frontend/GameList.h"
 #include "svnrev.h"
 
+#include "common/CrashHandler.h"
+
 static void PrintCommandLineVersion()
 {
 	std::fprintf(stderr, "PCSX2 Version %s\n", GIT_REV);
@@ -189,6 +191,8 @@ static bool ParseCommandLineOptions(int argc, char* argv[], std::shared_ptr<VMBo
 
 int main(int argc, char* argv[])
 {
+	CrashHandler::Install();
+
 	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -26,6 +26,7 @@
 
 #include "common/Assertions.h"
 #include "common/Console.h"
+#include "common/CrashHandler.h"
 #include "common/FileSystem.h"
 #include "common/SettingsWrapper.h"
 #include "common/StringUtil.h"
@@ -113,6 +114,9 @@ bool QtHost::SetCriticalFolders()
 
 	EmuFolders::Settings = EmuFolders::DataRoot.Combine(wxDirName(L"inis"));
 	EmuFolders::Resources = EmuFolders::AppRoot.Combine(wxDirName(L"resources"));
+
+	// Write crash dumps to the data directory, since that'll be accessible for certain.
+	CrashHandler::SetWriteDirectory(EmuFolders::DataRoot.ToUTF8().data());
 
 	// the resources directory should exist, bail out if not
 	if (!EmuFolders::Resources.Exists())


### PR DESCRIPTION
### Description of Changes

This PR adds a crash handler to PCSX2-Qt on Windows, which creates both a text file containing a backtrace, as well as a minidump file which can be opened in Visual Studio.

The text file might seem a bit redundant, but sometimes things can get into such a screwed up state that creating the minidump fails, so at least you'll get some kind of backtrace when that happens.

If you're running under a debugger, or attached one post-launch, no crash dump will be created, and the exception will be dispatched to the debugger as one would expect.

NOTE: The stack walker class is a bit old-style and clunky design-wise, but it works well, and I don't feel like reinventing the wheel here (or using wx, which we're going to remove eventually). I've fixed up the warnings that Codacity spews about it, and removed the old msvc version branches from it at least.

### Rationale behind Changes

Crash dumps are very useful when investigating issues reported by users, or perhaps more commonly, telling them to uninstall/update their broken controller drivers.

### Suggested Testing Steps

It's Qt, yolo. But I did test deliberately crashing, and it works as expected.
