### PR TITLE
Counters: Present at VSync End

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -485,16 +485,23 @@ static __fi void DoFMVSwitch()
 }
 
 // Convenience function to update UI thread and set patches. 
-static __fi void frameLimitUpdateCore()
+static __fi void VSyncUpdateCore()
 {
 	DoFMVSwitch();
 
 #ifndef PCSX2_CORE
 	GetCoreThread().VsyncInThread();
+#else
+	VMManager::Internal::VSyncOnCPUThread();
+#endif
+}
+
+static __fi void VSyncCheckExit()
+{
+#ifndef PCSX2_CORE
 	if (GetCoreThread().HasPendingStateChangeRequest())
 		Cpu->ExitExecution();
 #else
-	VMManager::Internal::VSyncOnCPUThread();
 	if (VMManager::Internal::IsExecutionInterrupted())
 		Cpu->ExitExecution();
 #endif
@@ -507,10 +514,7 @@ static __fi void frameLimit()
 {
 	// Framelimiter off in settings? Framelimiter go brrr.
 	if (EmuConfig.GS.LimitScalar == 0.0)
-	{
-		frameLimitUpdateCore();
 		return;
-	}
 
 	const u64 uExpectedEnd = m_iStart + m_iTicks;  // Compute when we would expect this frame to end, assuming everything goes perfectly perfect.
 	const u64 iEnd = GetCPUTicks();                // The current tick we actually stopped on.
@@ -521,7 +525,6 @@ static __fi void frameLimit()
 	{
 		// ... Fudge the next frame start over a bit. Prevents fast forward zoomies.
 		m_iStart += (sDeltaTime / m_iTicks) * m_iTicks;
-		frameLimitUpdateCore();
 		return;
 	}
 
@@ -545,7 +548,6 @@ static __fi void frameLimit()
 
 	// Finally, set our next frame start to when this one ends
 	m_iStart = uExpectedEnd;
-	frameLimitUpdateCore();
 }
 
 static __fi void VSyncStart(u32 sCycle)
@@ -563,9 +565,7 @@ static __fi void VSyncStart(u32 sCycle)
 	// Update vibration at the end of a frame.
 	PAD::Update();
 #endif
-
-	frameLimit(); // limit FPS
-	gsPostVsyncStart(); // MUST be after framelimit; doing so before causes funk with frame times!
+	VSyncUpdateCore();
 
 	if(EmuConfig.Trace.Enabled && EmuConfig.Trace.EE.m_EnableAll)
 		SysTrace.EE.Counters.Write( "    ================  EE COUNTER VSYNC START (frame: %d)  ================", g_FrameCount );
@@ -643,6 +643,9 @@ static __fi void VSyncEnd(u32 sCycle)
 	if (!(g_FrameCount % 60))
 		sioNextFrame();
 
+	frameLimit(); // limit FPS
+	gsPostVsyncStart(); // MUST be after framelimit; doing so before causes funk with frame times!
+	VSyncCheckExit();
 	// This doesn't seem to be needed here.  Games only seem to break with regard to the
 	// vsyncstart irq.
 	//cpuRegs.eCycle[30] = 2;


### PR DESCRIPTION
### Description of Changes
Moves the VSync present and framelimiter to VSync End interrupt

### Rationale behind Changes
Previously we were basically presenting the *previous* frame at the beginning of the next vsync start as a result of how things were working previously, we had to, however this will move it to VSync end, so the framebuffer pointers will have changed to the "just rendered" frame, which in theory should potentially reduce input lag by 1 frame. 

### Suggested Testing Steps
I can't remember what 2D fighting game used to have a problem with it this way around, but it's worth testing any you have.
Aside from that, test games for input lag (probably better on Qt) and make sure you don't get any black frame flashing that wasn't there previously.
