### PR TITLE
Added VSCode Environment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,196 @@
+{
+        // Use IntelliSense to learn about possible attributes.
+        // Hover to view descriptions of existing attributes.
+        // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "PCSX2 - GDB - Build Debug",
+                "type": "cppdbg",
+                "request": "launch",
+                // Resolved by CMake Tools:
+                "program": "${command:cmake.launchTargetPath}",
+                "args": [],
+                "stopAtEntry": false,
+                "cwd": "${workspaceFolder}",
+                "environment": [
+                    {
+                        // add the directory where our target was built to the PATHs
+                        // it gets resolved by CMake Tools:
+                        "name": "PATH",
+                        "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                    }
+                ],
+                "externalConsole": false,
+                "MIMode": "gdb",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Disable halting on SIGSEGV",
+                        "text": "handle SIGSEGV nostop",
+                        "ignoreFailures": true
+                    }
+                ],
+                "preLaunchTask": "Build PCSX2 - Debug GDB"
+            },
+            {
+                "name": "PCSX2 - GDB - Build Devel",
+                "type": "cppdbg",
+                "request": "launch",
+                // Resolved by CMake Tools:
+                "program": "${command:cmake.launchTargetPath}",
+                "args": [],
+                "stopAtEntry": false,
+                "cwd": "${workspaceFolder}",
+                "environment": [
+                    {
+                        // add the directory where our target was built to the PATHs
+                        // it gets resolved by CMake Tools:
+                        "name": "PATH",
+                        "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                    }
+                ],
+                "externalConsole": false,
+                "MIMode": "gdb",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Disable halting on SIGSEGV",
+                        "text": "handle SIGSEGV nostop",
+                        "ignoreFailures": true
+                    }
+                ],
+                "preLaunchTask": "Build PCSX2 - Devel GDB"
+            },
+            {
+                "name": "PCSX2 - GDB - Build Release",
+                "type": "cppdbg",
+                "request": "launch",
+                // Resolved by CMake Tools:
+                "program": "${command:cmake.launchTargetPath}",
+                "args": [],
+                "stopAtEntry": false,
+                "cwd": "${workspaceFolder}",
+                "environment": [
+                    {
+                        // add the directory where our target was built to the PATHs
+                        // it gets resolved by CMake Tools:
+                        "name": "PATH",
+                        "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                    }
+                ],
+                "externalConsole": false,
+                "MIMode": "gdb",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Disable halting on SIGSEGV",
+                        "text": "handle SIGSEGV nostop",
+                        "ignoreFailures": true
+                    }
+                ],
+                "preLaunchTask": "Build PCSX2 - Release GDB"
+            },
+            {
+                "name": "PCSX2 - GDB - No Build",
+                "type": "cppdbg",
+                "request": "launch",
+                // Resolved by CMake Tools:
+                "program": "${command:cmake.launchTargetPath}",
+                "args": [],
+                "stopAtEntry": false,
+                "cwd": "${workspaceFolder}",
+                "environment": [
+                    {
+                        // add the directory where our target was built to the PATHs
+                        // it gets resolved by CMake Tools:
+                        "name": "PATH",
+                        "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                    }
+                ],
+                "externalConsole": false,
+                "MIMode": "gdb",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Disable halting on SIGSEGV",
+                        "text": "handle SIGSEGV nostop",
+                        "ignoreFailures": true
+                    }
+                ]
+            },        
+        {
+            "name": "Build PCSX2 - MSVC Launch Debug",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program":  "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    // add the directory where our target was built to the PATHs
+                    // it gets resolved by CMake Tools:
+                    "name": "PATH",
+                    "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                }
+            ],
+        "console": "externalTerminal",
+            "preLaunchTask": "Build PCSX2 - Debug MSVC"
+        },
+        {
+            "name": "Build PCSX2 - MSVC Launch Devel",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program":  "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    // add the directory where our target was built to the PATHs
+                    // it gets resolved by CMake Tools:
+                    "name": "PATH",
+                    "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                }
+            ],
+        "console": "externalTerminal",
+            "preLaunchTask": "Build PCSX2 - Devel MSVC"
+        },
+        {
+            "name": "Build PCSX2 - MSVC Launch Release",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program":  "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    // add the directory where our target was built to the PATHs
+                    // it gets resolved by CMake Tools:
+                    "name": "PATH",
+                    "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                }
+            ],
+        "console": "externalTerminal",
+            "preLaunchTask": "Build PCSX2 - Release MSVC"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "buildDir": "${workspaceRoot}\\build",
+    "cmake.configureOnOpen": true,
+    "cmake.generator": "Ninja",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,67 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build PCSX2 - Debug GDB",
+            "type": "shell",
+            "command": "cd build && cmake -DEGL_API=TRUE -DCMAKE_BUILD_TYPE=Debug -GNinja -DBUILD_REPLAY_LOADERS=TRUE -DCMAKE_BUILD_PO=FALSE .. && ninja -j 10 && ninja install && cd ..",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+          "label": "Build PCSX2 - Devel GDB",
+          "type": "shell",
+          "command": "cd build && cmake -DEGL_API=TRUE -DCMAKE_BUILD_TYPE=Devel -GNinja -DBUILD_REPLAY_LOADERS=TRUE -DCMAKE_BUILD_PO=FALSE .. && ninja -j 10 && ninja install && cd ..",
+          "problemMatcher": [],
+          "group": {
+              "kind": "build",
+              "isDefault": true
+          }
+      },
+      {
+        "label": "Build PCSX2 - Debug GDB",
+        "type": "shell",
+        "command": "cd build && cmake -DEGL_API=TRUE -DCMAKE_BUILD_TYPE=Release -GNinja -DBUILD_REPLAY_LOADERS=TRUE -DCMAKE_BUILD_PO=FALSE .. && ninja -j 10 && ninja install && cd ..",
+        "problemMatcher": [],
+        "group": {
+            "kind": "build",
+            "isDefault": true
+        }
+    },
+        {
+          "type": "shell",
+          "label": "Build PCSX2 - Debug MSVC",
+          "command": "cd build && cmake -DCMAKE_BUILD_TYPE=Debug -G Ninja -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_CXX_FLAGS=\"/Zi /EHsc\" ..",
+          "problemMatcher": ["$msCompile"],
+          "group": {
+            "kind": "build",
+            "isDefault": true
+          }
+        },
+        {
+          "type": "shell",
+          "label": "Build PCSX2 - Devel MSVC",
+          "command": "cd build && cmake -DCMAKE_BUILD_TYPE=Devel -G Ninja -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_CXX_FLAGS=\"/Zi /EHsc\" ..",
+          "problemMatcher": ["$msCompile"],
+          "group": {
+            "kind": "build",
+            "isDefault": true
+          }
+        },
+        {
+          "type": "shell",
+          "label": "Build PCSX2 - Release MSVC",
+          "command": "cd build && cmake -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_CXX_FLAGS=\"/Zi /EHsc\" ..",
+          "problemMatcher": ["$msCompile"],
+          "group": {
+            "kind": "build",
+            "isDefault": true
+          }
+        }
+    ]
+}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Adds launch.json, tasks.json, and settings.json for compilation and debugging across Linux and Windows platforms with VSCode.
Note. Does require CMake tools extension installed. And does require currently launching vs code from 64-bit dev console in windows.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
To add an easy unified platform for VSCode users to debug and compile with pcsx2.
To provide a graphical debug environment using GDB or MSVC and VSCode in Linux and Windows

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Try opening VSCode
