### PR TITLE
GS/SW: Fix use-after-free on worker thread shutdown

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -40,9 +40,8 @@ static int compute_best_thread_height(int threads)
 		return 4;
 }
 
-GSRasterizer::GSRasterizer(IDrawScanline* ds, int id, int threads, GSPerfMon* perfmon)
-	: m_perfmon(perfmon)
-	, m_ds(ds)
+GSRasterizer::GSRasterizer(IDrawScanline* ds, int id, int threads)
+	: m_ds(ds)
 	, m_id(id)
 	, m_threads(threads)
 	, m_scanmsk_value(0)
@@ -1181,13 +1180,12 @@ void GSRasterizer::DrawEdge(int pixels, int left, int top, const GSVertexSW& sca
 
 //
 
-GSRasterizerList::GSRasterizerList(int threads, GSPerfMon* perfmon)
-	: m_perfmon(perfmon)
+GSRasterizerList::GSRasterizerList(int threads)
 {
 	m_thread_height = compute_best_thread_height(threads);
 
-	int rows = (2048 >> m_thread_height) + 16;
-	m_scanline = (u8*)_aligned_malloc(rows, 64);
+	const int rows = (2048 >> m_thread_height) + 16;
+	m_scanline = static_cast<u8*>(_aligned_malloc(rows, 64));
 
 	for (int i = 0; i < rows; i++)
 	{
@@ -1237,7 +1235,7 @@ void GSRasterizerList::Sync()
 			m_workers[i]->Wait();
 		}
 
-		m_perfmon->Put(GSPerfMon::SyncPoint, 1);
+		g_perfmon.Put(GSPerfMon::SyncPoint, 1);
 	}
 }
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -1211,7 +1211,6 @@ void GSRasterizerList::OnWorkerStartup(int i)
 
 void GSRasterizerList::OnWorkerShutdown(int i)
 {
-	PerformanceMetrics::SetGSSWThreadTimer(i, Common::ThreadCPUTimer());
 }
 
 void GSRasterizerList::Queue(const GSRingHeap::SharedPtr<GSRasterizerData>& data)

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -197,8 +197,8 @@ protected:
 
 	GSRasterizerList(int threads, GSPerfMon* perfmon);
 
-	void OnWorkerStartup(int i);
-	void OnWorkerShutdown(int i);
+	static void OnWorkerStartup(int i);
+	static void OnWorkerShutdown(int i);
 
 public:
 	virtual ~GSRasterizerList();

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -35,7 +35,7 @@ GSRendererSW::GSRendererSW(int threads)
 
 	memset(m_texture, 0, sizeof(m_texture));
 
-	m_rl = GSRasterizerList::Create<GSDrawScanline>(threads, &g_perfmon);
+	m_rl = GSRasterizerList::Create<GSDrawScanline>(threads);
 
 	m_output = (u8*)_aligned_malloc(1024 * 1024 * sizeof(u32), 32);
 


### PR DESCRIPTION
### Description of Changes

Introduced by my GS software thread CPU OSD thingo, happens when switching renderers or shutting down. Also gets rid of some extra pointers to perfmon, which are unnecessary since it's a global now.

### Rationale behind Changes

Fixing my mistakes.

### Suggested Testing Steps

Make sure sw still works (I've done this).
