### PR TITLE
BUILD: exclude libgmodule-2.0

### DIFF
--- a/.github/workflows/scripts/linux/appimage.sh
+++ b/.github/workflows/scripts/linux/appimage.sh
@@ -54,6 +54,7 @@ export UPD_INFO="gh-releases-zsync|PCSX2|pcsx2|latest|$name.AppImage.zsync"
 # a little bit hacky but should ensure maximum compatibility
 mkdir -p squashfs-root/usr/lib/wayland
 mv squashfs-root/usr/lib/libwayland-* squashfs-root/usr/lib/wayland
+rm squashfs-root/usr/lib/libgmodule-2.0.so.0
 curl -sSfL "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$ARCH.AppImage" -o ./appimagetool-"$ARCH".AppImage
 chmod a+x appimagetool*.AppImage
 ./appimagetool-"$ARCH".AppImage "$GITHUB_WORKSPACE"/squashfs-root "$name.AppImage"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Remove libgmodule-2.0.so.0 from AppImage build.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Fixes https://github.com/PCSX2/pcsx2/issues/5615

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Open Settings menu and press `Ok`