### PR TITLE
build: Include CrashHandler.cpp in cmake. Fixes #5938.

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(common PRIVATE
 	EventSource.inl
 	SafeArray.inl
 	Console.cpp
+	CrashHandler.cpp
 	EventSource.cpp
 	Exceptions.cpp
 	FastFormatString.cpp
@@ -65,6 +66,7 @@ target_sources(common PRIVATE
 	Assertions.h
 	boost_spsc_queue.hpp
 	Console.h
+	CrashHandler.h
 	Dependencies.h
 	EnumOps.h
 	EventSource.h


### PR DESCRIPTION
### Description of Changes
Add CrashHandler.cpp and CrashHandler.h to CMakeLists.txt.

### Rationale behind Changes
Pcsx2-qt will not compile without this change. Fixes #5938 .

### Suggested Testing Steps
Compile pcsx2-qt in Linux.
