### PR TITLE
GUI: Append warning for Manual HW Hacks

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -252,6 +252,11 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	connect(m_ui.enableHWFixes, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::onEnableHardwareFixesChanged);
 	updateRendererDependentOptions();
 
+	dialog->registerWidgetHelp(m_ui.enableHWFixes, tr("Manual Hardware Renderer Fixes"), tr("Unchecked"),
+		tr("Enabling this option gives you the ability to change the renderer and upscaling fixes "
+		   "to your games. However IF you have ENABLED this, you WILL DISABLE AUTOMATIC "
+		   "SETTINGS and you can re-enable automatic settings by unchecking this option."));
+
 	dialog->registerWidgetHelp(m_ui.useBlitSwapChain, tr("Use Blit Swap Chain"), tr("Unchecked"),
 		tr("Uses a blit presentation model instead of flipping when using the Direct3D 11 "
 		   "renderer. This usually results in slower performance, but may be required for some "

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -339,7 +339,7 @@ HacksTab::HacksTab(wxWindow* parent)
 	PaddedBoxSizer<wxBoxSizer> tab_box(wxVERTICAL);
 
 	auto hw_prereq = [this]{ return m_is_hardware; };
-	auto* hacks_check_box = m_ui.addCheckBox(tab_box.inner, "Manual HW Hacks", "UserHacks", -1, hw_prereq);
+	auto* hacks_check_box = m_ui.addCheckBox(tab_box.inner, "Manual HW Hacks (Disables automatic settings if checked)", "UserHacks", -1, hw_prereq);
 	auto hacks_prereq = [this, hacks_check_box]{ return m_is_hardware && hacks_check_box->GetValue(); };
 	auto upscale_hacks_prereq = [this, hacks_check_box]{ return !m_is_native_res && hacks_check_box->GetValue(); };
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Addendum to the Manual HW Hacks checkbox that warns people that enabling this option undoes automatic (renderer and upscaling) fixes.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
WX and Qt both will disable renderer and upscaling fixes if you want to manually handle the renderer and upscaling fixes. For years enabling this option didn't do much harm for users even if you didn't change any other setting, but since 1.7 development series automatised these to a degree it would be nice for users to know why their game looks potentially awful. Quite a lot of users don't know how to correctly handle this tab anyway and shouldn't touch something they don't get and get worse. Though in some cases like texture offsets you do need to override the automatic fixes.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Look if the text is correct.