### PR TITLE
UI: Rename Ultra Blending to Maximum Blending

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -547,7 +547,7 @@
         <widget class="QComboBox" name="blending">
          <item>
           <property name="text">
-           <string>Minimum (Fastest)</string>
+           <string>Minimum</string>
           </property>
          </item>
          <item>
@@ -567,12 +567,12 @@
          </item>
          <item>
           <property name="text">
-           <string>Full (Very Slow)</string>
+           <string>Full (Slow)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Ultra (Ultra Slow)</string>
+           <string>Maximum (Very Slow)</string>
           </property>
          </item>
         </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -182,7 +182,7 @@ enum class AccBlendLevel : u8
 	Medium,
 	High,
 	Full,
-	Ultra,
+	Maximum,
 };
 
 enum class TexturePreloadingLevel : u8

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1324,12 +1324,12 @@ void GSApp::Init()
 		GSSetting(CRCHackLevel::Aggressive, "Aggressive", ""),
 	};
 
-	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Minimum), "Minimum", "Fastest"));
+	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Minimum), "Minimum", ""));
 	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Basic), "Basic", "Recommended"));
 	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Medium), "Medium", ""));
 	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::High), "High", ""));
-	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Full), "Full", "Very Slow"));
-	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Ultra), "Ultra", "Ultra Slow"));
+	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Full), "Full", "Slow"));
+	m_gs_acc_blend_level.push_back(GSSetting(static_cast<u32>(AccBlendLevel::Maximum), "Maximum", "Very Slow"));
 
 	m_gs_tv_shaders.push_back(GSSetting(0, "None", ""));
 	m_gs_tv_shaders.push_back(GSSetting(1, "Scanline filter", ""));

--- a/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererNew.cpp
@@ -197,7 +197,7 @@ void GSRendererNew::EmulateTextureShuffleAndFbmask()
 		// 3. SW blending isn't implemented yet.
 		switch (GSConfig.AccurateBlendingUnit)
 		{
-			case AccBlendLevel::Ultra:
+			case AccBlendLevel::Maximum:
 			case AccBlendLevel::Full:
 			case AccBlendLevel::High:
 			case AccBlendLevel::Medium:
@@ -649,7 +649,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool&
 
 		switch (GSConfig.AccurateBlendingUnit)
 		{
-			case AccBlendLevel::Ultra:
+			case AccBlendLevel::Maximum:
 				clr_blend1_2 = false;
 				sw_blending |= true;
 				[[fallthrough]];
@@ -692,7 +692,7 @@ void GSRendererNew::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool&
 
 		switch (GSConfig.AccurateBlendingUnit)
 		{
-			case AccBlendLevel::Ultra:
+			case AccBlendLevel::Maximum:
 				if (m_prim_overlap == PRIM_OVERLAP_NO)
 				{
 					clr_blend1_2 = false;

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -100,14 +100,14 @@ const char* dialog_message(int ID, bool* updateText)
 		case IDC_ACCURATE_BLEND_UNIT:
 			return cvtString("Control the accuracy level of the GS blending unit emulation.\n\n"
 				"Minimum:\nFast but introduces various rendering issues.\n"
-				"It is intended for slow computer.\n\n"
+				"It is intended for slow computers.\n\n"
 				"Basic:\nEmulate correctly most of the effects with a limited speed penalty.\n"
 				"This is the recommended setting.\n\n"
 				"Medium:\nExtend it to all sprites. Performance impact remains reasonable in 3D game.\n\n"
 				"High:\nExtend it to destination alpha blending and color wrapping (helps shadow and fog effects).\n"
 				"A good CPU is required.\n\n"
-				"Full:\nExcept few cases, the blending unit will be fully emulated by the shader. It is ultra slow!\n\n"
-				"Ultra:\nThe blending unit will be completely emulated by the shader. It is ultra slow!\n\n"
+				"Full:\nExcept few cases, the blending unit will be fully emulated by the shader. It is slow!\n\n"
+				"Maximum:\nThe blending unit will be completely emulated by the shader. It is very slow!\n\n"
 				"Note: Direct3D11's blending is capped at High and is reduced in capability compared to OpenGL/Vulkan");
 		case IDC_TC_DEPTH:
 			return cvtString("Disable the support of Depth buffer in the texture cache.\n"


### PR DESCRIPTION
### Description of Changes
Renames both Ultra Blending to Maximum Blending and removes "fastest" from Minimum Blending.

### Rationale behind Changes
Reduces confusion and misuse of settings with proper names and implications of using said settings.

### Suggested Testing Steps
Make sure it builds and the settings themselves still function correctly in both WX and Qt.
