### PR TITLE
Qt: Fix firing multiple bindings with chords

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -42,6 +42,7 @@ DisplayWidget::DisplayWidget(QWidget* parent)
 	setAttribute(Qt::WA_NativeWindow, true);
 	setAttribute(Qt::WA_NoSystemBackground, true);
 	setAttribute(Qt::WA_PaintOnScreen, true);
+	setAttribute(Qt::WA_KeyCompression, false);
 	setFocusPolicy(Qt::StrongFocus);
 	setMouseTracking(true);
 }
@@ -142,12 +143,33 @@ bool DisplayWidget::event(QEvent* event)
 		case QEvent::KeyRelease:
 		{
 			const QKeyEvent* key_event = static_cast<QKeyEvent*>(event);
-			if (!key_event->isAutoRepeat())
+			if (key_event->isAutoRepeat())
+				return true;
+
+			// For some reason, Windows sends "fake" key events.
+			// Scenario: Press shift, press F1, release shift, release F1.
+			// Events: Shift=Pressed, F1=Pressed, Shift=Released, **F1=Pressed**, F1=Released.
+			// To work around this, we keep track of keys pressed with modifiers in a list, and
+			// discard the press event when it's been previously activated. It's pretty gross,
+			// but I can't think of a better way of handling it, and there doesn't appear to be
+			// any window flag which changes this behavior that I can see.
+
+			const int key = key_event->key();
+			const bool pressed = (key_event->type() == QEvent::KeyPress);
+			const auto it = std::find(m_keys_pressed_with_modifiers.begin(), m_keys_pressed_with_modifiers.end(), key);
+			if (it != m_keys_pressed_with_modifiers.end())
 			{
-				emit windowKeyEvent(key_event->key(), static_cast<int>(key_event->modifiers()),
-					event->type() == QEvent::KeyPress);
+				if (pressed)
+					return true;
+				else
+					m_keys_pressed_with_modifiers.erase(it);
+			}
+			else if (key_event->modifiers() != Qt::NoModifier && pressed)
+			{
+				m_keys_pressed_with_modifiers.push_back(key);
 			}
 
+			emit windowKeyEvent(key, pressed);
 			return true;
 		}
 

--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -18,6 +18,7 @@
 #include <QtWidgets/QStackedWidget>
 #include <QtWidgets/QWidget>
 #include <optional>
+#include <vector>
 
 class DisplayWidget final : public QWidget
 {
@@ -42,7 +43,7 @@ Q_SIGNALS:
 	void windowResizedEvent(int width, int height, float scale);
 	void windowRestoredEvent();
 	void windowClosedEvent();
-	void windowKeyEvent(int key_code, int mods, bool pressed);
+	void windowKeyEvent(int key_code, bool pressed);
 	void windowMouseMoveEvent(int x, int y);
 	void windowMouseButtonEvent(int button, bool pressed);
 	void windowMouseWheelEvent(const QPoint& angle_delta);
@@ -54,6 +55,7 @@ private:
 	QPoint m_relative_mouse_start_position{};
 	QPoint m_relative_mouse_last_position{};
 	bool m_relative_mouse_enabled = false;
+	std::vector<int> m_keys_pressed_with_modifiers;
 };
 
 class DisplayContainer final : public QStackedWidget

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -568,7 +568,7 @@ void EmuThread::onDisplayWindowMouseButtonEvent(int button, bool pressed)
 
 void EmuThread::onDisplayWindowMouseWheelEvent(const QPoint& delta_angle) {}
 
-void EmuThread::onDisplayWindowKeyEvent(int key, int mods, bool pressed)
+void EmuThread::onDisplayWindowKeyEvent(int key, bool pressed)
 {
 	InputManager::InvokeEvents(InputManager::MakeHostKeyboardKey(key), pressed ? 1.0f : 0.0f);
 }

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -144,7 +144,7 @@ private Q_SLOTS:
 	void onDisplayWindowMouseWheelEvent(const QPoint& delta_angle);
 	void onDisplayWindowResized(int width, int height, float scale);
 	void onDisplayWindowFocused();
-	void onDisplayWindowKeyEvent(int key, int mods, bool pressed);
+	void onDisplayWindowKeyEvent(int key, bool pressed);
 
 private:
 	QThread* m_ui_thread;

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <sstream>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 // ------------------------------------------------------------------------
@@ -45,102 +46,7 @@ enum : u32
 // This class acts as an adapter to convert from normalized values to
 // binary values when the callback is a binary/button handler. That way
 // you don't need to convert float->bool in your callbacks.
-
-class InputEventHandler
-{
-public:
-	InputEventHandler()
-	{
-		new (&u.button) InputButtonEventHandler;
-		is_axis = false;
-	}
-
-	InputEventHandler(InputButtonEventHandler button)
-	{
-		new (&u.button) InputButtonEventHandler(std::move(button));
-		is_axis = false;
-	}
-
-	InputEventHandler(InputAxisEventHandler axis)
-	{
-		new (&u.axis) InputAxisEventHandler(std::move(axis));
-		is_axis = true;
-	}
-
-	InputEventHandler(const InputEventHandler& copy)
-	{
-		if (copy.is_axis)
-			new (&u.axis) InputAxisEventHandler(copy.u.axis);
-		else
-			new (&u.button) InputButtonEventHandler(copy.u.button);
-		is_axis = copy.is_axis;
-	}
-
-	InputEventHandler(InputEventHandler&& move)
-	{
-		if (move.is_axis)
-			new (&u.axis) InputAxisEventHandler(std::move(move.u.axis));
-		else
-			new (&u.button) InputButtonEventHandler(std::move(move.u.button));
-		is_axis = move.is_axis;
-	}
-
-	~InputEventHandler()
-	{
-		// call the right destructor... :D
-		if (is_axis)
-			u.axis.InputAxisEventHandler::~InputAxisEventHandler();
-		else
-			u.button.InputButtonEventHandler::~InputButtonEventHandler();
-	}
-
-	InputEventHandler& operator=(const InputEventHandler& copy)
-	{
-		InputEventHandler::~InputEventHandler();
-
-		if (copy.is_axis)
-			new (&u.axis) InputAxisEventHandler(copy.u.axis);
-		else
-			new (&u.button) InputButtonEventHandler(copy.u.button);
-		is_axis = copy.is_axis;
-		return *this;
-	}
-
-	InputEventHandler& operator=(InputEventHandler&& move)
-	{
-		InputEventHandler::~InputEventHandler();
-
-		if (move.is_axis)
-			new (&u.axis) InputAxisEventHandler(std::move(move.u.axis));
-		else
-			new (&u.button) InputButtonEventHandler(std::move(move.u.button));
-		is_axis = move.is_axis;
-		return *this;
-	}
-
-	__fi bool IsAxis() const { return is_axis; }
-
-	__fi void Invoke(float value) const
-	{
-		if (is_axis)
-			u.axis(value);
-		else
-			u.button(value > 0.0f);
-	}
-
-private:
-	union HandlerUnion
-	{
-		// constructor/destructor needs to be declared
-		HandlerUnion() {}
-		~HandlerUnion() {}
-
-		InputButtonEventHandler button;
-		InputAxisEventHandler axis;
-	} u;
-
-	bool is_axis;
-};
+using InputEventHandler = std::variant<InputAxisEventHandler, InputButtonEventHandler>;
 
 // ------------------------------------------------------------------------
 // Binding Type
@@ -193,6 +99,8 @@ namespace InputManager
 	static bool SplitBinding(const std::string_view& binding, std::string_view* source, std::string_view* sub_binding);
 	static void AddBindings(const std::vector<std::string>& bindings, const InputEventHandler& handler);
 	static bool ParseBindingAndGetSource(const std::string_view& binding, InputBindingKey* key, InputSource** source);
+
+	static bool IsAxisHandler(const InputEventHandler& handler);
 
 	static void AddHotkeyBindings(SettingsInterface& si);
 	static void AddPadBindings(SettingsInterface& si, u32 pad, const char* default_type);
@@ -639,6 +547,11 @@ bool InputManager::HasAnyBindingsForKey(InputBindingKey key)
 	return (s_binding_map.find(key.MaskDirection()) != s_binding_map.end());
 }
 
+bool InputManager::IsAxisHandler(const InputEventHandler& handler)
+{
+	return std::holds_alternative<InputAxisEventHandler>(handler);
+}
+
 bool InputManager::InvokeEvents(InputBindingKey key, float value)
 {
 	if (DoEventHook(key, value))
@@ -658,7 +571,7 @@ bool InputManager::InvokeEvents(InputBindingKey key, float value)
 	for (auto it = range.first; it != range.second; ++it)
 	{
 		InputBinding* binding = it->second.get();
-		if (binding->handler.IsAxis())
+		if (IsAxisHandler(binding->handler))
 			continue;
 
 		// find the key which matches us
@@ -702,7 +615,7 @@ bool InputManager::InvokeEvents(InputBindingKey key, float value)
 
 			// Don't register the key press when we're part of a longer chord. That way,
 			// the state won't change, and it won't get the released event either.
-			if (longest_hotkey_binding && new_state && !binding->handler.IsAxis() &&
+			if (longest_hotkey_binding && new_state && !IsAxisHandler(binding->handler) &&
 				binding->num_keys != longest_hotkey_binding->num_keys)
 			{
 				continue;
@@ -719,11 +632,18 @@ bool InputManager::InvokeEvents(InputBindingKey key, float value)
                                                                                                         0.0f);
 
 			// axes are fired regardless of a state change, unless they're zero
+			// (but going from not-zero to zero will still fire, because of the full state)
 			// for buttons, we can use the state of the last chord key, because it'll be 1 on press,
 			// and 0 on release (when the full state changes).
-			if (prev_full_state != new_full_state || (binding->handler.IsAxis() && value_to_pass > 0.0f))
+			if (IsAxisHandler(binding->handler))
 			{
-				binding->handler.Invoke(value_to_pass);
+				if (prev_full_state != new_full_state || value_to_pass >= 0.0f)
+					std::get<InputAxisEventHandler>(binding->handler)(value_to_pass);
+			}
+			else
+			{
+				if (prev_full_state != new_full_state)
+					std::get<InputButtonEventHandler>(binding->handler)(value_to_pass > 0.0f);
 			}
 
 			// bail out, since we shouldn't have the same key twice in the chord


### PR DESCRIPTION
### Description of Changes

Previously, when you bound say, F1 to load state, and Shift+F1 to save state, pressing shift->f1 would activate both the save and load bindings. This changes the behaviour, so only the longest chord will activate.

Had to add a nasty workaround in the event handler, due to Windows sending additional events when it's modifier keys. Explained in the code.

Also switched from an explicit union to std::variant, because that's basically what it was anyway.

### Rationale behind Changes

Making it so we can actually use modifiers in bindings.

### Suggested Testing Steps

Test modifier bindings (already done), but someone else might find a way to break it.