### PR TITLE
GameDB: SOCOM Combined Assault NTSC Patch

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7657,7 +7657,7 @@ SCUS-97545:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3 # Fixes SPS ingame.
+    vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
   patches:
     D7CFDCCF:
       content: |-

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7657,7 +7657,13 @@ SCUS-97545:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
+    vuClampMode: 3 # Fixes SPS ingame.
+  patches:
+    D7CFDCCF:
+      content: |-
+        author=Prafull
+        //Fix Slowdown when looking at sun (all Patches)
+        patch=1,EE,0019f480,word,00000000
 SCUS-97548:
   name: "Ape Escape 3 [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Included Sun Fix Patch for NTSC version of the game. This patch also works on updated versions of the game so it should not have any negative affects if users are to be on different patches. I cannot confirm however if this works on another region version of the game however

### Rationale behind Changes
Looking at the sun on some maps will cause a serious slowdown and make it impossible to play the game because the framerate will drop to a non playable state.

### Suggested Testing Steps
Launch SOCOM Combined Assault and play on either the "Harvester" or "Backwoods" map to experience the issue

Use the following code to launch the match solo on game v1.0

//Force Start (1.0)
00A96970 FFFFFFFF (default = 00340000)

## VIDEO EXAMPLE
https://user-images.githubusercontent.com/80198020/165189719-eac509a7-6226-40d0-8301-f6aa29d4c3f4.mp4