### PR TITLE
GS-hw: Cleanup Half pixel offset Normal.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -31,9 +31,7 @@ GSTexture::GSTexture()
 	, m_sparse(false)
 	, m_needs_mipmaps_generated(true)
 	, last_frame_used(0)
-	, LikelyOffset(false)
-	, OffsetHack_modx(0.0f)
-	, OffsetHack_mody(0.0f)
+	, OffsetHack_modxy(0.0f)
 {
 }
 
@@ -83,9 +81,7 @@ void GSTexture::Swap(GSTexture* tex)
 	std::swap(m_sparse, tex->m_sparse);
 	std::swap(m_needs_mipmaps_generated, tex->m_needs_mipmaps_generated);
 	std::swap(last_frame_used, tex->last_frame_used);
-	std::swap(LikelyOffset, tex->LikelyOffset);
-	std::swap(OffsetHack_modx, tex->OffsetHack_modx);
-	std::swap(OffsetHack_mody, tex->OffsetHack_mody);
+	std::swap(OffsetHack_modxy, tex->OffsetHack_modxy);
 }
 
 u32 GSTexture::GetCompressedBytesPerBlock() const

--- a/pcsx2/GS/Renderers/Common/GSTexture.h
+++ b/pcsx2/GS/Renderers/Common/GSTexture.h
@@ -143,9 +143,7 @@ public:
 	// different purpose than texture cache ages, do not attempt to merge
 	unsigned last_frame_used;
 
-	bool LikelyOffset;
-	float OffsetHack_modx;
-	float OffsetHack_mody;
+	float OffsetHack_modxy;
 
 	// Typical size of a RGBA texture
 	virtual u32 GetMemUsage() { return m_size.x * m_size.y * (m_format == Format::UNorm8 ? 1 : 4); }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3335,10 +3335,10 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 	//The resulting shifted output aligns better with common blending / corona / blurring effects,
 	//but introduces a few bad pixels on the edges.
 
-	if (rt && rt->LikelyOffset && GSConfig.UserHacks_HalfPixelOffset == 1)
+	if (rt && rt->OffsetHack_modxy > 1.0f)
 	{
-		ox2 *= rt->OffsetHack_modx;
-		oy2 *= rt->OffsetHack_mody;
+		ox2 *= rt->OffsetHack_modxy;
+		oy2 *= rt->OffsetHack_modxy;
 	}
 
 	m_conf.cb_vs.vertex_scale = GSVector2(sx, sy);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1419,27 +1419,21 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 
 		// Offset hack. Can be enabled via GS options.
 		// The offset will be used in Draw().
-
-		float modx = 0.0f;
-		float mody = 0.0f;
+		float modxy = 0.0f;
 
 		if (GSConfig.UserHacks_HalfPixelOffset == 1 && hack)
 		{
-			switch(g_gs_renderer->GetUpscaleMultiplier())
+			modxy = static_cast<float>(g_gs_renderer->GetUpscaleMultiplier());
+			switch (g_gs_renderer->GetUpscaleMultiplier())
 			{
-				case 2:  modx = 2.2f; mody = 2.2f; dst->m_texture->LikelyOffset = true;  break;
-				case 3:  modx = 3.1f; mody = 3.1f; dst->m_texture->LikelyOffset = true;  break;
-				case 4:  modx = 4.2f; mody = 4.2f; dst->m_texture->LikelyOffset = true;  break;
-				case 5:  modx = 5.3f; mody = 5.3f; dst->m_texture->LikelyOffset = true;  break;
-				case 6:  modx = 6.2f; mody = 6.2f; dst->m_texture->LikelyOffset = true;  break;
-				case 7:  modx = 7.1f; mody = 7.1f; dst->m_texture->LikelyOffset = true;  break;
-				case 8:  modx = 8.2f; mody = 8.2f; dst->m_texture->LikelyOffset = true;  break;
-				default: modx = 0.0f; mody = 0.0f; dst->m_texture->LikelyOffset = false; break;
+				case 2: case 4: case 6: case 8: modxy += 0.2f; break;
+				case 3: case 7:                 modxy += 0.1f; break;
+				case 5:                         modxy += 0.3f; break;
+				default:                        modxy  = 0.0f; break;
 			}
 		}
 
-		dst->m_texture->OffsetHack_modx = modx;
-		dst->m_texture->OffsetHack_mody = mody;
+		dst->m_texture->OffsetHack_modxy = modxy;
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Cleanup Half pixel offset Normal.

Now that custom res is removed, we don't need to split modx and mody.
Also purely rely on the tc to handle the HPO hack.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Cleanup.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure HPO normal still works.