### PR TITLE
GS: Fix ReadTexture on unaligned reads

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -1670,15 +1670,9 @@ void GSLocalMemory::ReadTexture(const GSOffset& off, const GSVector4i& r, u8* ds
 		}
 		else
 		{
-			for (int y = r.top; y < cr.top; y++, dst += dstpitch)
-			{
-				for (int x = r.left, i = 0; x < r.right; x++, i++)
-				{
-					((u32*)dst)[i] = (this->*rt)(x, y, TEX0, TEXA);
-				}
-			}
+			u8* crdst = dst;
 
-			for (int y = cr.bottom; y < r.bottom; y++, dst += dstpitch)
+			for (int y = r.top; y < cr.top; y++, dst += dstpitch)
 			{
 				for (int x = r.left, i = 0; x < r.right; x++, i++)
 				{
@@ -1699,9 +1693,19 @@ void GSLocalMemory::ReadTexture(const GSOffset& off, const GSVector4i& r, u8* ds
 				}
 			}
 
+			for (int y = cr.bottom; y < r.bottom; y++, dst += dstpitch)
+			{
+				for (int x = r.left, i = 0; x < r.right; x++, i++)
+				{
+					((u32*)dst)[i] = (this->*rt)(x, y, TEX0, TEXA);
+				}
+			}
+
 			if (!cr.rempty())
 			{
-				(this->*rtx)(off, cr, dst + (cr.left - r.left) * sizeof(u32), dstpitch, TEXA);
+				crdst += dstpitch * (cr.top - r.top);
+				crdst += sizeof(u32) * (cr.left - r.left);
+				(this->*rtx)(off, cr, crdst, dstpitch, TEXA);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Changes
When it sees an unaligned request, ReadTexture finds the largest aligned interior rectangle it can, and attempts to read the following pieces:
![intended](https://user-images.githubusercontent.com/3315070/165452416-fa335c14-9598-4f4a-8980-07dc5edfef02.svg)

Somehow, it ends up reading this instead:
![actual](https://user-images.githubusercontent.com/3315070/165452481-a0035556-1ca5-4167-88f2-213ba9c19909.svg)

Since this is larger than the image it was asked to read, this ends up writing out of bounds.  Due to the nature of GPU upload buffers, these OOB reads often do nothing, but sometimes they actually write outside of a buffer and crash.  Fun!

This fixes ReadTexture to read into the intended location.

### Rationale behind Changes
Not crashing is good

### Suggested Testing Steps
[This GSdump was crashing in the Metal renderer previously](https://github.com/PCSX2/pcsx2/files/8569256/DragonBallZ-MetalCrash.gs.xz.zip)