### PR TITLE
Wayland fixes

### DIFF
--- a/pcsx2/PAD/Linux/PAD.cpp
+++ b/pcsx2/PAD/Linux/PAD.cpp
@@ -37,7 +37,7 @@
 #include "wx_dialog/dialog.h"
 
 #ifndef __APPLE__
-Display* GSdsp;
+Display* GSdsp = nullptr;
 Window GSwin;
 #endif
 
@@ -263,7 +263,7 @@ void PADupdate(int pad)
 	// Emulate an user activity
 	static int count = 0;
 	count++;
-	if ((count & 0xFFF) == 0)
+	if (GSdsp && (count & 0xFFF) == 0)
 	{
 		// 1 call every 4096 Vsync is enough
 		XResetScreenSaver(GSdsp);

--- a/pcsx2/PAD/Linux/keyboard.cpp
+++ b/pcsx2/PAD/Linux/keyboard.cpp
@@ -194,7 +194,7 @@ void AnalyzeKeyEvent(HostKeyEvent& evt)
 #ifdef __unix__
 			if (evt.key == XK_Shift_R || evt.key == XK_Shift_L)
 				s_Shift = true;
-			if (evt.key == XK_F12 && s_Shift)
+			if (evt.key == XK_F12 && s_Shift && GSdsp)
 			{
 				if (!s_grab_input)
 				{

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -73,7 +73,7 @@ HWND gsWnd = nullptr;
 #include "gtk.h"
 #include <gdk/gdkx.h>
 #include <X11/X.h>
-Display* g_GSdsp;
+Display* g_GSdsp = nullptr;
 Window g_GSwin;
 #endif
 

--- a/pcsx2/USB/usb-hid/evdev/evdev.cpp
+++ b/pcsx2/USB/usb-hid/evdev/evdev.cpp
@@ -206,7 +206,7 @@ namespace usb_hid
 								if (event.code == KEY_LEFTSHIFT || event.code == KEY_RIGHTSHIFT)
 									shift = (event.value > 0);
 
-								if (event.code == KEY_F12 && (event.value == 1) && shift)
+								if (event.code == KEY_F12 && (event.value == 1) && shift && g_GSdsp)
 								{
 									if (!grabbed)
 									{


### PR DESCRIPTION
### Description of Changes
A number of calls relying on an X11 display were made conditional on the X11 display actually being available.

### Rationale behind Changes
This fixes a few crashes on Wayland.

### Suggested Testing Steps
Run a game for more than 4096 frames on Wayland, observe that it no longer crashes; likewise for pressing Shift+F12.