### PR TITLE
GS:SW: zclamp fixup

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -479,6 +479,9 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 					{
 						zs = VectorI(z);
 					}
+
+					if (sel.zclamp)
+						zs = zs.min_u32(VectorI::xffffffff().srl32(sel.zpsm * 8));
 				}
 				else
 				{
@@ -505,14 +508,11 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 					VectorI zso = zs;
 					VectorI zdo = zd;
 
-					if (sel.zoverflow || sel.zpsm == 0)
+					if (sel.zpsm == 0)
 					{
 						zso -= VectorI::x80000000();
 						zdo -= VectorI::x80000000();
 					}
-
-					if (sel.zclamp)
-						zso = zso.min_u32(VectorI::xffffffff().srl32(sel.zpsm * 8));
 
 					switch (sel.ztst)
 					{
@@ -1200,9 +1200,6 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 				{
 					zs = zs.blend8(zd, zm);
 				}
-
-				if (sel.zclamp)
-					zs = zs.min_u32(VectorI::xffffffff().srl32(sel.zpsm * 8));
 
 				bool fast = sel.ztest ? sel.zpsm < 2 : sel.zpsm == 0 && sel.notest;
 

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -498,15 +498,15 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 					zd = GSVector4i::load((u8*)global.vm + za * 2, (u8*)global.vm + za * 2 + 16);
 #endif
 
-					switch (sel.zpsm)
-					{
-						case 1: zd = zd.sll32( 8).srl32( 8); break;
-						case 2: zd = zd.sll32(16).srl32(16); break;
-						default: break;
-					}
-
 					VectorI zso = zs;
 					VectorI zdo = zd;
+
+					switch (sel.zpsm)
+					{
+						case 1: zdo = zdo.sll32( 8).srl32( 8); break;
+						case 2: zdo = zdo.sll32(16).srl32(16); break;
+						default: break;
+					}
 
 					if (sel.zpsm == 0)
 					{

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -516,8 +516,8 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 
 					switch (sel.ztst)
 					{
-					case ZTST_GEQUAL:  test |= zso <  zdo; break;
-					case ZTST_GREATER: test |= zso <= zdo; break;
+						case ZTST_GEQUAL:  test |= zso <  zdo; break;
+						case ZTST_GREATER: test |= zso <= zdo; break;
 					}
 
 					if (test.alltrue())

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
@@ -1089,6 +1089,7 @@ void GSDrawScanlineCodeGenerator2::TestZ(const XYm& temp1, const XYm& temp2)
 			cvttps2dq(xym0, z);
 		}
 
+		// Clamp Z to ZPSM_FMT_MAX
 		if (m_sel.zclamp)
 		{
 			const u8 amt = (u8)((m_sel.zpsm & 0x3) * 8);
@@ -1124,7 +1125,7 @@ void GSDrawScanlineCodeGenerator2::TestZ(const XYm& temp1, const XYm& temp2)
 			psrld(temp2, static_cast<u8>(m_sel.zpsm * 8));
 		}
 
-		if (m_sel.zoverflow || m_sel.zpsm == 0)
+		if (m_sel.zpsm == 0)
 		{
 			// GSVector4i o = GSVector4i::x80000000();
 
@@ -2550,15 +2551,6 @@ void GSDrawScanlineCodeGenerator2::WriteZBuf()
 			movdqa(xym7, _rip_local(temp.zd));
 			blend8(xym1, xym7 /*, xym0 */);
 		}
-	}
-
-	// Clamp Z to ZPSM_FMT_MAX
-	if (m_sel.zclamp)
-	{
-		const u8 amt = (u8)((m_sel.zpsm & 0x3) * 8);
-		pcmpeqd(xym7, xym7);
-		psrld(xym7, amt);
-		pminsd(xym1, xym7);
 	}
 
 	bool fast = m_sel.ztest ? m_sel.zpsm < 2 : m_sel.zpsm == 0 && m_sel.notest;


### PR DESCRIPTION
### Description of Changes
- ~~Reduces the number of times zclamp is run~~ Fixes an issue where zclamp would be run a second time to clamp out the destination z bits that had just been loaded in order to preserve them
- Fixes an issue in the C rasterizer where zclamp was run after setting the top bit in preparation for using an SSE signed compare as an unsigned compare, which messed up the comparison.
- Fixes an issue in the C rasterizer where the unused z bits (e.g. top 8 bits of Z24) would be wiped out by the C rasterizer
- Disables the `zoverflow` check for enabling signed comparison workarounds, since if `zoverflow && zpsm != 0` then zclamp would be enabled and would clamp the z value down to a size where signed comparison doesn't cause any issues.

Note: Requires #5903

### Rationale behind Changes
- It's nice when your reference renderer matches the ASM generator based off it
- ~~Why zclamp twice when you can zclamp once~~ Let's not clamp away the bits we were trying to preserve

### Suggested Testing Steps
- [Test this GSdump with the C rasterizer (tests zclamp top bit issue)](https://github.com/PCSX2/pcsx2/files/8578637/GodOfWar-BrightSun.gs.xz.zip)
- [Test this one too (tests unused z trashing issue)](https://github.com/PCSX2/pcsx2/files/8588500/ArmoredCore2-RadarGarbage.gs.xz.zip)
- Test zclamp dumps to make sure I didn't break any

