### PR TITLE
GS: limit merge circuit memory read height

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -267,11 +267,14 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 	TEX0.TBW = DISPFB.FBW;
 	TEX0.PSM = DISPFB.PSM;
 
+	const int videomode = static_cast<int>(GetVideoMode()) - 1;
+	int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
+	int fb_height = std::min(GetFramebufferHeight(), display_height);
 	// TRACE(_T("[%d] GetOutput %d %05x (%d)\n"), (int)m_perfmon.GetFrame(), i, (int)TEX0.TBP0, (int)TEX0.PSM);
 
 	GSTexture* t = NULL;
 
-	if (GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, GetTargetSize(), GetFramebufferHeight()))
+	if (GSTextureCache::Target* rt = m_tc->LookupTarget(TEX0, GetTargetSize(), fb_height))
 	{
 		t = rt->m_texture;
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -141,7 +141,10 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 	const GSRegDISPFB& DISPFB = m_regs->DISP[i].DISPFB;
 
 	int w = DISPFB.FBW * 64;
-	int h = GetFramebufferHeight();
+
+	const int videomode = static_cast<int>(GetVideoMode()) - 1;
+	int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
+	int h = std::min(GetFramebufferHeight(), display_height);
 
 	// TODO: round up bottom
 


### PR DESCRIPTION
### Description of Changes
Limit the height that can be read from memory when getting the Merge Circuit DISPLAY outputs.

### Rationale behind Changes
#5810 kind of uncovered this bug (after hack removal), games which ask for ridiculous heights(which won't be read anyway) )could end up reading bad memory or out of bounds, which caused a crash when trying to use the software renderer on the below mentioned game.

### Suggested Testing Steps
Test games (especially in SW) and make sure that it doesn't crash.

Fixes crash trying to play Zero Shikikan Josentoki Ni in software mode
