### PR TITLE
IopCounters: missing include

### DIFF
--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -19,6 +19,7 @@
 // The EventText function will pick it up.
 
 #include "PrecompiledHeader.h"
+#include "IopCounters.h"
 #include "R3000A.h"
 #include "Common.h"
 #include "SPU2/spu2.h"


### PR DESCRIPTION
IopCounters.cpp wasn't including IopCounters.h.

(I ran into this when rebasing my SPU replacement branch)