### PR TITLE
GS:SW: Fix lod in C rasterizer

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -572,8 +572,8 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 						u = u.srav32(lodi);
 						v = v.srav32(lodi);
 
-						uv[0] = u.srav32(lodi);
-						uv[1] = v.srav32(lodi);
+						uv[0] = u;
+						uv[1] = v;
 
 						GSVector8i tmin = GSVector8i::broadcast128(global.t.min);
 						GSVector8i tminu = tmin.upl16().srlv32(lodi);


### PR DESCRIPTION
### Description of Changes
Don't double-shift coordinates for the second lod level

Requires #5903

### Rationale behind Changes
Double-shifting coordinates makes them all wrong

### Suggested Testing Steps
[Test this GSdump on the C rasterizer](https://github.com/PCSX2/pcsx2/files/8596192/die_hard_textures.gs.xz.zip)

