### PR TITLE
Counters: Fix software renderer FMV fix with auto renderer

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -477,10 +477,10 @@ static __fi void DoFMVSwitch()
 			break;
 	}
 
-	if (EmuConfig.Gamefixes.SoftwareRendererFMVHack && EmuConfig.GS.UseHardwareRenderer())
+	if (EmuConfig.Gamefixes.SoftwareRendererFMVHack && GSConfig.UseHardwareRenderer())
 	{
 		// we don't use the sw toggle here, because it'll change back to auto if set to sw
-		GetMTGS().SwitchRenderer(new_fmv_state ? GSRendererType::SW : EmuConfig.GS.Renderer, false);
+		GetMTGS().SwitchRenderer(new_fmv_state ? GSRendererType::SW : GSConfig.Renderer, false);
 	}
 }
 


### PR DESCRIPTION
Fixes the issue where the use-software-renderer-for-FMVs gamefix didn't activate when using the automatic renderer.