### PR TITLE
GS: Account for frame offset in output circuit

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -269,7 +269,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 
 	const int videomode = static_cast<int>(GetVideoMode()) - 1;
 	int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
-	int fb_height = std::min(GetFramebufferHeight(), display_height);
+	int fb_height = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
 	// TRACE(_T("[%d] GetOutput %d %05x (%d)\n"), (int)m_perfmon.GetFrame(), i, (int)TEX0.TBP0, (int)TEX0.PSM);
 
 	GSTexture* t = NULL;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -144,7 +144,7 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 
 	const int videomode = static_cast<int>(GetVideoMode()) - 1;
 	int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
-	int h = std::min(GetFramebufferHeight(), display_height);
+	int h = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
 
 	// TODO: round up bottom
 


### PR DESCRIPTION
### Description of Changes
Account for offset in framebuffer when calculating height

### Rationale behind Changes
If there was a framebuffer offset and the framebuffer size exceeded the height of the screen, it would cut it off too early. Regression from #5981

### Suggested Testing Steps
test stuff to make suire the screen isn't cut off, especially Silent Hill 2

Fixes Silent Hill 2 bug reported here: https://forums.pcsx2.net/Thread-Bug-Report-Silent-Hill-2-NTSC-U
