### PR TITLE
GameDB: Sniper Elite + Naruto Shippuuden Ninja 3-5 + GT4

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -135,6 +135,8 @@ PAPX-90512:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 PAPX-90516:
@@ -225,6 +227,8 @@ PBPX-95524:
   name: "Gran Turismo 4 - Prologue"
   region: "NTSC-Unk"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
@@ -234,6 +238,8 @@ PBPX-95601:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -281,6 +287,8 @@ PCPX-96649:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 PCPX-96660:
@@ -569,6 +577,8 @@ SCAJ-20066:
   name: "Gran Turismo 4 - Prologue"
   region: "NTSC-Unk"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters: #vuClampMode = 2  Text in GT mode works.
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1298,6 +1308,8 @@ SCAJ-30006:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1317,6 +1329,8 @@ SCAJ-30007:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCAJ-30008:
@@ -1324,6 +1338,8 @@ SCAJ-30008:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -1420,6 +1436,8 @@ SCCS-40022:
 SCCS-60002:
   name: "Gran Turismo 4 [Review Copy]"
   region: "NTSC-C"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
 SCED-50041:
   name: "Tekken Tag Tournament [Demo]"
   region: "PAL-E"
@@ -1956,12 +1974,16 @@ SCED-52549:
 SCED-52578:
   name: "Gran Turismo 4 BMW 1 Series Virtual Drive Dealership [Demo]"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
 SCED-52619:
   name: "Official PlayStation 2 Magazine Demo 48"
   region: "PAL-M5"
 SCED-52681:
   name: "Gran Turismo 4 BMW 1 Series Virtual Drive [Demo]"
   region: "PAL-M11"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
 SCED-52687:
   name: "Formula One 04 [Demo]"
   region: "PAL-M11"
@@ -2998,6 +3020,8 @@ SCES-51719:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCES-51719"
     - "SCES-52438"
@@ -3185,6 +3209,8 @@ SCES-52438:
   name: "Gran Turismo 4 - Prologue"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters: #vuClampMode = 2  Text in GT mode works.
     - "SCES-51719"
     - "SCES-52438"
@@ -4320,6 +4346,8 @@ SCKA-20020:
 SCKA-20022:
   name: "Gran Turismo 4 Prologue"
   region: "NTSC-K"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
   # vuClampMode = 2  Text in GT mode works.
@@ -4657,6 +4685,8 @@ SCKA-30001:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCKA-30002:
@@ -5038,6 +5068,8 @@ SCPS-15054:
 SCPS-15055:
   name: "Gran Turismo 4 - Prologue"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters: #vuClampMode = 2  Text in GT mode works.
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -5400,6 +5432,8 @@ SCPS-17001:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -5563,6 +5597,8 @@ SCPS-19252:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -5597,6 +5633,8 @@ SCPS-19303:
 SCPS-19304:
   name: "Gran Turismo 4 - Prologue [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters: 
     - "SCAJ-20066"
     - "SCAJ-30006"
@@ -6884,6 +6922,8 @@ SCUS-97328:
   compat: 5
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters: # Allows car imports from GT3 or something.
     - "SCUS-97328"
     - "SCUS-97436"
@@ -7231,6 +7271,8 @@ SCUS-97436:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   memcardFilters:
     - "SCUS-97328"
     - "SCUS-97436"
@@ -7426,6 +7468,8 @@ SCUS-97483:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Text in GT mode works.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
   # Comments from old GameIndex.dbf for this Game.
   # eeClampMode = 3  Text in races works.
 SCUS-97484:
@@ -11992,8 +12036,11 @@ SLES-51819:
 SLES-51820:
   name: "Sniper Elite"
   region: "PAL-M5"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment.
 SLES-51821:
   name: "Alias"
   region: "PAL-M5"
@@ -16337,8 +16384,11 @@ SLES-53756:
 SLES-53758:
   name: "Sniper Elite [Pre-Production]"
   region: "PAL-E"
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment.
 SLES-53759:
   name: "Matrix, The - Path of Neo"
   region: "PAL-M5"
@@ -19739,6 +19789,8 @@ SLES-55237:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLES-55238:
   name: "Madden NFL 09"
   region: "PAL-E"
@@ -20233,9 +20285,13 @@ SLES-55480:
 SLES-55481:
   name: "Naruto Shippuden - Ultimate Ninja 4"
   region: "PAL-E-F"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLES-55482:
   name: "Naruto Shippuden - Ultimate Ninja 4"
   region: "PAL-G-I-S"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLES-55483:
   name: "Guilty Gear XX Accent Core Plus"
   region: "PAL-E"
@@ -20436,6 +20492,8 @@ SLES-55605:
   name: "Naruto Shippuuden - Ultimate Ninja 5"
   region: "PAL-M5"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLES-55609:
   name: "Scooby-Doo! and the Spooky Swamp"
   region: "PAL-M5"
@@ -22159,6 +22217,8 @@ SLPM-61135:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPM-61147:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Demo]"
   region: "NTSC-J"
@@ -22167,6 +22227,11 @@ SLPM-61147:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
+SLPM-61157:
+  name: "Naruto Shippuuden: Narutimate Accel [Trial]"
+  region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPM-62001:
   name: "Drum Mania"
   region: "NTSC-J"
@@ -30990,6 +31055,11 @@ SLPM-68005:
 SLPM-68018:
   name: "Virtua Fighter - 10th Anniversary Edition"
   region: "NTSC-J"
+SLPM-68019:
+  name: "Naruto Shippuuden - Narutimate Accel 2"
+  region: "NTSC-J" 
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPM-68503:
   name: "Metal Gear Solid 2 - Sons of Liberty [Shareholder Edition]"
   region: "NTSC-J"
@@ -34404,6 +34474,8 @@ SLPS-25589:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-25590:
   name: "Namco Museum Arcade Hits"
   region: "NTSC-J"
@@ -35083,6 +35155,8 @@ SLPS-25767:
 SLPS-25768:
   name: "Naruto Shippuuden Narutimate Accel"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-25769:
   name: "Netsu Chu! Pro Baseball 2007"
   region: "NTSC-J"
@@ -35319,6 +35393,8 @@ SLPS-25836:
 SLPS-25837:
   name: "Naruto Shippuuden - Narutimate Accel 2"
   region: "NTSC-J"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-25838:
   name: "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugeki su"
   region: "NTSC-J"
@@ -36055,6 +36131,8 @@ SLPS-73251:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLPS-73252:
   name: "Tales of the Abyss [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -41603,8 +41681,11 @@ SLUS-21231:
   name: "Sniper Elite"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Flickering and wrong textures in FMV.
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes bloom misalignment.
+    halfPixelOffset: 2 # Fixes bloom misalignment.
 SLUS-21232:
   name: "College Hoops 2K6"
   region: "NTSC-U"
@@ -43932,6 +44013,8 @@ SLUS-21727:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes invisible QTE button prompts and overbright in some scenes.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLUS-21728:
   name: "Crash - Mind Over Mutant"
   region: "NTSC-U"
@@ -44511,6 +44594,8 @@ SLUS-21862:
   name: "Naruto Shippuden - Ultimate Ninja 4"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
 SLUS-21863:
   name: "Suzuki TT Superbikes - Real Road Racing Championship"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Adds FMV switch for both and adds special texture half pixeloffset for Sniper Elite.

Sniper Elite;
Before:
![2022-05-01_18-36](https://user-images.githubusercontent.com/24227051/166155488-63e7e2ec-cba3-44f0-b98a-348e694ba1c0.png)


After:
![2022-05-01_18-36_1](https://user-images.githubusercontent.com/24227051/166155492-f87fcacf-df17-4a89-8ec1-c8547dffd918.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games.