### PR TITLE
GS: Fix up SW FMV switch behaviour

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -433,6 +433,8 @@ void frameLimitReset()
 extern uint eecount_on_last_vdec;
 extern bool FMVstarted;
 extern bool EnableFMV;
+
+static bool RendererSwitched = false;
 static bool s_last_fmv_state = false;
 
 static __fi void DoFMVSwitch()
@@ -477,11 +479,15 @@ static __fi void DoFMVSwitch()
 			break;
 	}
 
-	if (EmuConfig.Gamefixes.SoftwareRendererFMVHack && GSConfig.UseHardwareRenderer())
+	if (EmuConfig.Gamefixes.SoftwareRendererFMVHack && (GSConfig.UseHardwareRenderer() || (RendererSwitched && GSConfig.Renderer == GSRendererType::SW)))
 	{
+		RendererSwitched = GSConfig.UseHardwareRenderer();
+
 		// we don't use the sw toggle here, because it'll change back to auto if set to sw
-		GetMTGS().SwitchRenderer(new_fmv_state ? GSRendererType::SW : GSConfig.Renderer, false);
+		GetMTGS().SwitchRenderer(new_fmv_state ? GSRendererType::SW : EmuConfig.GS.Renderer, false);
 	}
+	else
+		RendererSwitched = false;
 }
 
 // Convenience function to update UI thread and set patches. 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -653,9 +653,7 @@ void Pcsx2Config::GSOptions::MaskUpscalingHacks()
 
 bool Pcsx2Config::GSOptions::UseHardwareRenderer() const
 {
-	return (Renderer == GSRendererType::DX11 || Renderer == GSRendererType::DX12 ||
-			Renderer == GSRendererType::OGL || Renderer == GSRendererType::VK ||
-			Renderer == GSRendererType::Metal);
+	return (Renderer != GSRendererType::Null && Renderer != GSRendererType::SW);
 }
 
 VsyncMode Pcsx2Config::GetEffectiveVsyncMode() const


### PR DESCRIPTION
### Description of Changes
Fix Software FMV switch, remembering the old renderer and if it was switched.

### Rationale behind Changes
#5993 changed it so the GSConfig got updated on the switch, then it checked the GSConfig at the end of the FMV to see if it was configured to use a HW renderer, so it never came out of Software.

Also added some extra protection in case the renderer is changed during the FMV.

### Suggested Testing Steps
Test different renderers, Auto, Software, Specific API's with the SW FMV gamefix and make sure switching happens properly

Fixes #5998
