### PR TITLE
Threading: Make CPU usage measurements less garbage on Windows

### DIFF
--- a/common/Darwin/DarwinThreads.cpp
+++ b/common/Darwin/DarwinThreads.cpp
@@ -94,6 +94,52 @@ u64 Threading::GetThreadCpuTime()
 	return us;
 }
 
+Threading::ThreadHandle::ThreadHandle() = default;
+
+Threading::ThreadHandle::ThreadHandle(const ThreadHandle& handle)
+	: m_native_handle(handle.m_native_handle)
+{
+}
+
+Threading::ThreadHandle::ThreadHandle(ThreadHandle&& handle)
+	: m_native_handle(handle.m_native_handle)
+{
+	handle.m_native_handle = nullptr;
+}
+
+Threading::ThreadHandle::~ThreadHandle() = default;
+
+Threading::ThreadHandle Threading::ThreadHandle::GetForCallingThread()
+{
+	ThreadHandle ret;
+	ret.m_native_handle = pthread_self();
+	return ret;
+}
+
+Threading::ThreadHandle& Threading::ThreadHandle::operator=(ThreadHandle&& handle)
+{
+	m_native_handle = handle.m_native_handle;
+	handle.m_native_handle = nullptr;
+	return *this;
+}
+
+Threading::ThreadHandle& Threading::ThreadHandle::operator=(const ThreadHandle& handle)
+{
+	m_native_handle = handle.m_native_handle;
+	return *this;
+}
+
+u64 Threading::ThreadHandle::GetCPUTime() const
+{
+	return getthreadtime(pthread_mach_thread_np((pthread_t)m_native_handle));
+}
+
+bool Threading::ThreadHandle::SetAffinity(u64 processor_mask) const
+{
+	// Doesn't appear to be possible to set affinity.
+	return false;
+}
+
 u64 Threading::pxThread::GetCpuTime() const
 {
 	// Get the cpu time for the thread belonging to this object.  Use m_native_id and/or

--- a/common/Threading.h
+++ b/common/Threading.h
@@ -90,6 +90,7 @@ class wxTimeSpan;
 
 namespace Threading
 {
+	class ThreadHandle;
 	class pxThread;
 	class RwMutex;
 
@@ -197,6 +198,45 @@ namespace Threading
 		void Wait();
 	};
 #endif
+
+	// --------------------------------------------------------------------------------------
+	//  ThreadHandle
+	// --------------------------------------------------------------------------------------
+	// Abstracts an OS's handle to a thread, closing the handle when necessary. Currently,
+	// only used for getting the CPU time for a thread.
+	//
+	class ThreadHandle
+	{
+	public:
+		ThreadHandle();
+		ThreadHandle(ThreadHandle&& handle);
+		ThreadHandle(const ThreadHandle& handle);
+		~ThreadHandle();
+
+		/// Returns a new handle for the calling thread.
+		static ThreadHandle GetForCallingThread();
+
+		ThreadHandle& operator=(ThreadHandle&& handle);
+		ThreadHandle& operator=(const ThreadHandle& handle);
+
+		operator void*() const { return m_native_handle; }
+		operator bool() const { return (m_native_handle != nullptr); }
+
+		/// Returns the amount of CPU time consumed by the thread, at the GetThreadTicksPerSecond() frequency.
+		u64 GetCPUTime() const;
+
+		/// Sets the affinity for a thread to the specified processors.
+		/// Obviously, only works up to 64 processors.
+		bool SetAffinity(u64 processor_mask) const;
+
+	private:
+		void* m_native_handle = nullptr;
+
+		// We need the thread ID for affinity adjustments on Linux.
+#if defined(__linux__)
+		unsigned int m_native_id = 0;
+#endif
+	};
 
 	// --------------------------------------------------------------------------------------
 	//  NonblockingMutex

--- a/common/Timer.cpp
+++ b/common/Timer.cpp
@@ -21,23 +21,13 @@
 
 #if defined(_WIN32)
 #include "RedtapeWindows.h"
-#include "Threading.h"
-#elif defined(__APPLE__)
-#include <mach/mach_init.h>
-#include <mach/thread_act.h>
-#include <mach/mach_port.h>
 #else
-#include <pthread.h>
-#include <sys/time.h>
 #include <time.h>
-#include <unistd.h>
 #endif
 
 namespace Common
 {
-
 #ifdef _WIN32
-
 	static double s_counter_frequency;
 	static bool s_counter_initialized = false;
 
@@ -86,9 +76,7 @@ namespace Common
 	{
 		return static_cast<Value>(ns * s_counter_frequency);
 	}
-
 #else
-
 	Timer::Value Timer::GetCurrentValue()
 	{
 		struct timespec tv;
@@ -125,7 +113,6 @@ namespace Common
 	{
 		return static_cast<Value>(ns);
 	}
-
 #endif
 
 	Timer::Timer()
@@ -176,184 +163,4 @@ namespace Common
 		m_tvStartValue = value;
 		return ret;
 	}
-
-	ThreadCPUTimer::ThreadCPUTimer() = default;
-
-	ThreadCPUTimer::ThreadCPUTimer(ThreadCPUTimer&& move)
-		: m_thread_handle(move.m_thread_handle)
-	{
-		move.m_thread_handle = nullptr;
-	}
-
-	ThreadCPUTimer::~ThreadCPUTimer()
-	{
-#ifdef _WIN32
-		if (m_thread_handle)
-			CloseHandle(reinterpret_cast<HANDLE>(m_thread_handle));
-#endif
-	}
-
-	ThreadCPUTimer& ThreadCPUTimer::operator=(ThreadCPUTimer&& move)
-	{
-#ifdef _WIN32
-		if (m_thread_handle)
-			CloseHandle(reinterpret_cast<HANDLE>(m_thread_handle));
-#endif
-
-		m_thread_handle = move.m_thread_handle;
-		move.m_thread_handle = nullptr;
-		return *this;
-	}
-
-	void ThreadCPUTimer::Reset()
-	{
-		m_start_value = GetCurrentValue();
-	}
-
-	ThreadCPUTimer::Value ThreadCPUTimer::GetCurrentValue() const
-	{
-#if defined(_WIN32)
-		ULONG64 ret = 0;
-		QueryThreadCycleTime((HANDLE)m_thread_handle, &ret);
-		return ret;
-#elif defined(__APPLE__)
-		thread_basic_info_data_t info;
-		mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
-
-		const kern_return_t kr = thread_info((mach_port_t) reinterpret_cast<uintptr_t>(m_thread_handle), THREAD_BASIC_INFO, (thread_info_t)&info, &count);
-		if (kr != KERN_SUCCESS)
-			return 0;
-
-		Value value = (static_cast<Value>(info.user_time.seconds) * 1000000) + (static_cast<Value>(info.user_time.microseconds));
-		value += (static_cast<Value>(info.system_time.seconds) * 1000000) + (static_cast<Value>(info.system_time.microseconds));
-		return value;
-#else
-		clockid_t cid;
-		if (!m_thread_handle || pthread_getcpuclockid((pthread_t)m_thread_handle, &cid) != 0)
-			return 0;
-
-		struct timespec ts;
-		if (clock_gettime(cid, &ts) != 0)
-			return 0;
-
-		return (static_cast<Value>(ts.tv_nsec) + static_cast<Value>(ts.tv_sec) * 1000000000LL);
-#endif
-	}
-
-	double ThreadCPUTimer::GetTimeSeconds() const
-	{
-		return ConvertValueToSeconds(GetCurrentValue() - m_start_value);
-	}
-
-	double ThreadCPUTimer::GetTimeMilliseconds() const
-	{
-		return ConvertValueToMilliseconds(GetCurrentValue() - m_start_value);
-	}
-
-	double ThreadCPUTimer::GetTimeNanoseconds() const
-	{
-		return ConvertValueToNanoseconds(GetCurrentValue() - m_start_value);
-	}
-
-	void ThreadCPUTimer::GetUsageInSecondsAndReset(Value time_diff, double* usage_time, double* usage_percent)
-	{
-		const Value new_value = GetCurrentValue();
-		const Value diff = new_value - m_start_value;
-		m_start_value = new_value;
-
-		*usage_time = ConvertValueToSeconds(diff);
-		*usage_percent = GetUtilizationPercentage(time_diff, diff);
-	}
-
-	void ThreadCPUTimer::GetUsageInMillisecondsAndReset(Value time_diff, double* usage_time, double* usage_percent)
-	{
-		const Value new_value = GetCurrentValue();
-		const Value diff = new_value - m_start_value;
-		m_start_value = new_value;
-
-		*usage_time = ConvertValueToMilliseconds(diff);
-		*usage_percent = GetUtilizationPercentage(time_diff, diff);
-	}
-
-	void ThreadCPUTimer::GetUsageInNanosecondsAndReset(Value time_diff, double* usage_time, double* usage_percent)
-	{
-		const Value new_value = GetCurrentValue();
-		const Value diff = new_value - m_start_value;
-		m_start_value = new_value;
-
-		*usage_time = ConvertValueToNanoseconds(diff);
-		*usage_percent = GetUtilizationPercentage(time_diff, diff);
-	}
-
-	double ThreadCPUTimer::GetUtilizationPercentage(Timer::Value time_diff, Value cpu_time_diff)
-	{
-#if defined(_WIN32)
-		// we need to convert from the rdtsc domain to the QPC domain (may not necessarily match)
-		static bool ratio_initialized = false;
-		static double ratio = 0.0;
-		if (unlikely(!ratio_initialized))
-		{
-			ratio = (static_cast<double>(Threading::GetThreadTicksPerSecond()) / static_cast<double>(GetTickFrequency())) / 100.0;
-			ratio_initialized = true;
-		}
-
-		return (static_cast<double>(cpu_time_diff) / (static_cast<double>(time_diff) * ratio));
-#elif defined(__APPLE__)
-		// microseconds, but time_tiff is in nanoseconds, so multiply by 1000 * 100
-		return (static_cast<double>(cpu_time_diff) * 100000.0) / static_cast<double>(time_diff);
-#else
-		// nanoseconds
-		return (static_cast<double>(cpu_time_diff) * 100.0) / static_cast<double>(time_diff);
-#endif
-	}
-
-	double ThreadCPUTimer::ConvertValueToSeconds(Value value)
-	{
-#if defined(_WIN32)
-		return (static_cast<double>(value) / Threading::GetThreadTicksPerSecond());
-#elif defined(__APPLE__)
-		// microseconds
-		return (static_cast<double>(value) / 1000000.0);
-#else
-		// nanoseconds
-		return (static_cast<double>(value) / 1000000000.0);
-#endif
-	}
-
-	double ThreadCPUTimer::ConvertValueToMilliseconds(Value value)
-	{
-#if defined(_WIN32)
-		return (static_cast<double>(value) / (Threading::GetThreadTicksPerSecond() / 1000.0));
-#elif defined(__APPLE__)
-		return (static_cast<double>(value) / 1000.0);
-#else
-		return (static_cast<double>(value) / 1000000.0);
-#endif
-	}
-
-	double ThreadCPUTimer::ConvertValueToNanoseconds(Value value)
-	{
-#if defined(_WIN32)
-		return (static_cast<double>(value) / (Threading::GetThreadTicksPerSecond() / 1000000000.0));
-#elif defined(__APPLE__)
-		return (static_cast<double>(value) * 1000.0);
-#else
-		return static_cast<double>(value);
-#endif
-	}
-
-	ThreadCPUTimer ThreadCPUTimer::GetForCallingThread()
-	{
-		ThreadCPUTimer ret;
-#if defined(_WIN32)
-		ret.m_thread_handle = (void*)OpenThread(THREAD_QUERY_INFORMATION, FALSE, GetCurrentThreadId());
-#elif defined(__APPLE__)
-		ret.m_thread_handle = reinterpret_cast<void*>((uintptr_t)mach_thread_self());
-#else
-		ret.m_thread_handle = (void*)pthread_self();
-#endif
-		ret.Reset();
-		return ret;
-	}
-
 } // namespace Common

--- a/common/Timer.h
+++ b/common/Timer.h
@@ -18,7 +18,6 @@
 
 namespace Common
 {
-
 	class Timer
 	{
 	public:
@@ -50,45 +49,4 @@ namespace Common
 	private:
 		Value m_tvStartValue;
 	};
-
-	class ThreadCPUTimer
-	{
-	public:
-		using Value = std::uint64_t;
-
-		ThreadCPUTimer();
-		ThreadCPUTimer(ThreadCPUTimer&& move);
-		ThreadCPUTimer(const ThreadCPUTimer&) = delete;
-		~ThreadCPUTimer();
-
-		void Reset();
-		void ResetTo(Value value) { m_start_value = value; }
-
-		Value GetStartValue() const { return m_start_value; }
-		Value GetCurrentValue() const;
-
-		double GetTimeSeconds() const;
-		double GetTimeMilliseconds() const;
-		double GetTimeNanoseconds() const;
-
-		void GetUsageInSecondsAndReset(Value time_diff, double* usage_time, double* usage_percent);
-		void GetUsageInMillisecondsAndReset(Value time_diff, double* usage_time, double* usage_percent);
-		void GetUsageInNanosecondsAndReset(Value time_diff, double* usage_time, double* usage_percent);
-
-		static double GetUtilizationPercentage(Timer::Value time_diff, Value cpu_time_diff);
-
-		static double ConvertValueToSeconds(Value value);
-		static double ConvertValueToMilliseconds(Value value);
-		static double ConvertValueToNanoseconds(Value value);
-
-		static ThreadCPUTimer GetForCallingThread();
-
-		ThreadCPUTimer& operator=(const ThreadCPUTimer&) = delete;
-		ThreadCPUTimer& operator=(ThreadCPUTimer&& move);
-
-	private:
-		void* m_thread_handle = nullptr;
-		Value m_start_value = 0;
-	};
-
 } // namespace Common

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -217,7 +217,7 @@ void EmuThread::saveStateToSlot(qint32 slot)
 
 void EmuThread::run()
 {
-	PerformanceMetrics::SetCPUThreadTimer(Common::ThreadCPUTimer::GetForCallingThread());
+	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle::GetForCallingThread());
 	m_event_loop = new QEventLoop();
 	m_started_semaphore.release();
 
@@ -244,7 +244,7 @@ void EmuThread::run()
 	destroyBackgroundControllerPollTimer();
 	InputManager::CloseSources();
 	VMManager::Internal::ReleaseMemory();
-	PerformanceMetrics::SetCPUThreadTimer(Common::ThreadCPUTimer());
+	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
 	moveToThread(m_ui_thread);
 	deleteLater();
 }

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -1204,7 +1204,7 @@ GSRasterizerList::~GSRasterizerList()
 void GSRasterizerList::OnWorkerStartup(int i)
 {
 	Threading::SetNameOfCurrentThread(StringUtil::StdStringFromFormat("GS-SW-%d", i).c_str());
-	PerformanceMetrics::SetGSSWThreadTimer(i, Common::ThreadCPUTimer::GetForCallingThread());
+	PerformanceMetrics::SetGSSWThread(i, Threading::ThreadHandle::GetForCallingThread());
 }
 
 void GSRasterizerList::OnWorkerShutdown(int i)

--- a/pcsx2/PerformanceMetrics.cpp
+++ b/pcsx2/PerformanceMetrics.cpp
@@ -18,6 +18,9 @@
 #include <chrono>
 #include <vector>
 
+#include "common/Timer.h"
+#include "common/Threading.h"
+
 #include "PerformanceMetrics.h"
 #include "System.h"
 #include "System/SysThreads.h"
@@ -50,7 +53,8 @@ static PerformanceMetrics::InternalFPSMethod s_internal_fps_method = Performance
 static u32 s_gs_framebuffer_blits_since_last_update = 0;
 static u32 s_gs_privileged_register_writes_since_last_update = 0;
 
-static Common::ThreadCPUTimer s_cpu_thread_timer;
+static Threading::ThreadHandle s_cpu_thread_handle;
+static u64 s_last_cpu_time = 0;
 static u64 s_last_gs_time = 0;
 static u64 s_last_vu_time = 0;
 static u64 s_last_ticks = 0;
@@ -64,7 +68,8 @@ static float s_vu_thread_time = 0.0f;
 
 struct GSSWThreadStats
 {
-	Common::ThreadCPUTimer timer;
+	Threading::ThreadHandle handle;
+	u64 last_cpu_time = 0;
 	double usage = 0.0;
 	double time = 0.0;
 };
@@ -112,10 +117,13 @@ void PerformanceMetrics::Reset()
 	s_last_update_time.Reset();
 	s_last_frame_time.Reset();
 
-	s_cpu_thread_timer.Reset();
+	s_last_cpu_time = s_cpu_thread_handle.GetCPUTime();
 	s_last_gs_time = GetMTGS().GetCpuTime();
 	s_last_vu_time = THREAD_VU1 ? vu1Thread.GetCpuTime() : 0;
 	s_last_ticks = GetCPUTicks();
+
+	for (GSSWThreadStats& stat : s_gs_sw_threads)
+		stat.last_cpu_time = stat.handle.GetCPUTime();
 }
 
 void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
@@ -164,22 +172,9 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
 	s_gs_privileged_register_writes_since_last_update = 0;
 	s_gs_framebuffer_blits_since_last_update = 0;
 
-	s_cpu_thread_timer.GetUsageInMillisecondsAndReset(ticks_diff, &s_cpu_thread_time, &s_cpu_thread_usage);
-	s_cpu_thread_time /= static_cast<double>(s_frames_since_last_update);
-
-	for (GSSWThreadStats& thread : s_gs_sw_threads)
-	{
-		thread.timer.GetUsageInMillisecondsAndReset(ticks_diff, &thread.time, &thread.usage);
-		thread.time /= static_cast<double>(s_frames_since_last_update);
-	}
-
-	const u64 gs_time = GetMTGS().GetCpuTime();
-	const u64 vu_time = THREAD_VU1 ? vu1Thread.GetCpuTime() : 0;
 	const u64 ticks = GetCPUTicks();
-
-	const u64 gs_delta = gs_time - s_last_gs_time;
-	const u64 vu_delta = vu_time - s_last_vu_time;
 	const u64 ticks_delta = ticks - s_last_ticks;
+	s_last_ticks = ticks;
 
 	const double pct_divider =
 		100.0 * (1.0 / ((static_cast<double>(ticks_delta) * static_cast<double>(GetThreadTicksPerSecond())) /
@@ -187,14 +182,32 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
 	const double time_divider = 1000.0 * (1.0 / static_cast<double>(GetThreadTicksPerSecond())) *
 								(1.0 / static_cast<double>(s_frames_since_last_update));
 
+	const u64 cpu_time = s_cpu_thread_handle.GetCPUTime();
+	const u64 gs_time = GetMTGS().GetCpuTime();
+	const u64 vu_time = THREAD_VU1 ? vu1Thread.GetCpuTime() : 0;
+
+	const u64 cpu_delta = cpu_time - s_last_cpu_time;
+	const u64 gs_delta = gs_time - s_last_gs_time;
+	const u64 vu_delta = vu_time - s_last_vu_time;
+	s_last_cpu_time = cpu_time;
+	s_last_gs_time = gs_time;
+	s_last_vu_time = vu_time;
+
+	s_cpu_thread_usage = static_cast<double>(cpu_delta) * pct_divider;
 	s_gs_thread_usage = static_cast<double>(gs_delta) * pct_divider;
 	s_vu_thread_usage = static_cast<double>(vu_delta) * pct_divider;
+	s_cpu_thread_time = static_cast<double>(cpu_delta) * time_divider;
 	s_gs_thread_time = static_cast<double>(gs_delta) * time_divider;
 	s_vu_thread_time = static_cast<double>(vu_delta) * time_divider;
 
-	s_last_gs_time = gs_time;
-	s_last_vu_time = vu_time;
-	s_last_ticks = ticks;
+	for (GSSWThreadStats& thread : s_gs_sw_threads)
+	{
+		const u64 time = thread.handle.GetCPUTime();
+		const u64 delta = time - thread.last_cpu_time;
+		thread.last_cpu_time = time;
+		thread.usage = static_cast<double>(delta) * pct_divider;
+		thread.time = static_cast<double>(delta) * time_divider;
+	}
 
 	s_frames_since_last_update = 0;
 	s_presents_since_last_update = 0;
@@ -210,9 +223,10 @@ void PerformanceMetrics::OnGPUPresent(float gpu_time)
 	s_presents_since_last_update++;
 }
 
-void PerformanceMetrics::SetCPUThreadTimer(Common::ThreadCPUTimer timer)
+void PerformanceMetrics::SetCPUThread(Threading::ThreadHandle thread)
 {
-	s_cpu_thread_timer = std::move(timer);
+	s_last_cpu_time = thread ? thread.GetCPUTime() : 0;
+	s_cpu_thread_handle = std::move(thread);
 }
 
 void PerformanceMetrics::SetGSSWThreadCount(u32 count)
@@ -221,9 +235,10 @@ void PerformanceMetrics::SetGSSWThreadCount(u32 count)
 	s_gs_sw_threads.resize(count);
 }
 
-void PerformanceMetrics::SetGSSWThreadTimer(u32 index, Common::ThreadCPUTimer timer)
+void PerformanceMetrics::SetGSSWThread(u32 index, Threading::ThreadHandle thread)
 {
-	s_gs_sw_threads[index].timer = std::move(timer);
+	s_gs_sw_threads[index].last_cpu_time = thread ? thread.GetCPUTime() : 0;
+	s_gs_sw_threads[index].handle = std::move(thread);
 }
 
 void PerformanceMetrics::SetVerticalFrequency(float rate)

--- a/pcsx2/PerformanceMetrics.h
+++ b/pcsx2/PerformanceMetrics.h
@@ -14,7 +14,7 @@
  */
 
 #pragma once
-#include "common/Timer.h"
+#include "common/Threading.h"
 
 namespace PerformanceMetrics
 {
@@ -31,11 +31,11 @@ namespace PerformanceMetrics
 	void OnGPUPresent(float gpu_time);
 
 	/// Sets the EE thread for CPU usage calculations.
-	void SetCPUThreadTimer(Common::ThreadCPUTimer timer);
+	void SetCPUThread(Threading::ThreadHandle thread);
 
 	/// Sets timers for GS software threads.
 	void SetGSSWThreadCount(u32 count);
-	void SetGSSWThreadTimer(u32 index, Common::ThreadCPUTimer timer);
+	void SetGSSWThread(u32 index, Threading::ThreadHandle thread);
 
 	/// Sets the vertical frequency, used in speed calculations.
 	void SetVerticalFrequency(float rate);

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -341,12 +341,12 @@ void SysCoreThread::TearDownSystems(SystemsMask systemsToTearDown)
 	if (systemsToTearDown & System_SPU2) SPU2close();
 	if (systemsToTearDown & System_MCD) FileMcd_EmuClose();
 
-	PerformanceMetrics::SetCPUThreadTimer(Common::ThreadCPUTimer());
+	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
 }
 
 void SysCoreThread::OnResumeInThread(SystemsMask systemsToReinstate)
 {
-	PerformanceMetrics::SetCPUThreadTimer(Common::ThreadCPUTimer::GetForCallingThread());
+	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle::GetForCallingThread());
 	PerformanceMetrics::Reset();
 
 	GetMTGS().WaitForOpen();


### PR DESCRIPTION
### Description of Changes

Currently, we use `GetThreadTimes()` for measuring CPU usage of our various threads. It's.. not the best function, both in terms of precision, but also the frequency at which it is updated. It's pretty easy for our polling to fall out of phase with when the system updates it, which leads to spurious 0% CPU usage measurements, and/or it bouncing around +/- up to 20%.

I've replaced it with `QueryThreadCycleTime()`, which works **much** better. **Technically**, we shouldn't be relying on the frequency for this function (MSDN says you shouldn't), *but*, I'm guessing that's just because it's using `rdtsc` internally, and that's not guaranteed to be stable on older CPUs (pre-2008ish). Since we don't support anything older than that anyway, it should be fine for us. But probably worth testing on Intel just to be safe.

Further note: While this introduces a new abstraction (`ThreadHandle`), I got rid of the old timer-based class, and eventually merge `ThreadHandle` into `pxThread`. Once we drop the wx crap there, anyhow.

### Rationale behind Changes

Making it so we can actually measure CPU performance improvements on Windows.

### Suggested Testing Steps

Test AMD and Intel processors on Windows to make sure the CPU usage measurements are correct. I've done Windows and Linux on AMD Zen.