### PR TITLE
GS: Adjust default renderer based on vendor and feature level.

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -194,16 +194,14 @@ GSRendererType GSUtil::GetPreferredRenderer()
 	// Mac: Prefer Metal hardware.
 	return GSRendererType::Metal;
 #elif defined(_WIN32)
+	if (D3D::ShouldPreferRenderer() == D3D::Renderer::Vulkan)
+		return GSRendererType::VK;
 #if defined(ENABLE_OPENGL)
-	// Windows: Prefer GL if available.
-	if (D3D::ShouldPreferD3D())
-		return GSRendererType::DX11;
-	else
+	else if (D3D::ShouldPreferRenderer() == D3D::Renderer::OpenGL)
 		return GSRendererType::OGL;
-#else
-	// DX11 is always available, otherwise.
-	return GSRendererType::DX11;
 #endif
+	else
+		return GSRendererType::DX11;
 #else
 	// Linux: Prefer GL/Vulkan, whatever is available.
 #if defined(ENABLE_OPENGL)

--- a/pcsx2/GS/Renderers/DX11/D3D.h
+++ b/pcsx2/GS/Renderers/DX11/D3D.h
@@ -32,6 +32,23 @@ namespace D3D
 
 	// this is sort of a legacy thing that doesn't have much to do with d3d (just the easiest way)
 	// checks to see if the adapter at 0 is NV and thus we should prefer OpenGL
-	bool IsNvidia(IDXGIAdapter1* adapter);
-	bool ShouldPreferD3D();
+	enum VendorID
+	{
+		Unknown,
+		Nvidia,
+		AMD,
+		Intel
+	};
+
+	enum Renderer
+	{
+		Default,
+		OpenGL,
+		Vulkan,
+		Direct3D11,
+		Direct3D12
+	};
+
+	u8 Vendor();
+	u8 ShouldPreferRenderer();
 };

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -89,17 +89,6 @@ bool GSDevice11::Create(HostDisplay* display)
 	m_ctx = static_cast<ID3D11DeviceContext*>(display->GetRenderContext());
 	level = m_dev->GetFeatureLevel();
 
-	bool amd_vendor = false;
-	{
-		if (auto dxgi_device = m_dev.try_query<IDXGIDevice>())
-		{
-			wil::com_ptr_nothrow<IDXGIAdapter> dxgi_adapter;
-			DXGI_ADAPTER_DESC adapter_desc;
-			if (SUCCEEDED(dxgi_device->GetAdapter(dxgi_adapter.put())) && SUCCEEDED(dxgi_adapter->GetDesc(&adapter_desc)))
-				amd_vendor = ((adapter_desc.VendorId == 0x1002) || (adapter_desc.VendorId == 0x1022));
-		}
-	}
-
 	if (!GSConfig.DisableShaderCache)
 	{
 		if (!m_shader_cache.Open(StringUtil::wxStringToUTF8String(EmuFolders::Cache.ToString()),
@@ -123,7 +112,7 @@ bool GSDevice11::Create(HostDisplay* display)
 	{
 		// HACK: check AMD
 		// Broken point sampler should be enabled only on AMD.
-		m_features.broken_point_sampler = amd_vendor;
+		m_features.broken_point_sampler = (D3D::Vendor() == D3D::VendorID::AMD);
 	}
 
 	SetFeatures();


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Adjust default renderer based on vendor and feature level.
Vulkan default:
Nvidia Maxwell gen2 and higher.
OpenGL default:
From Fermi to Mawell gen1.
Everything else Direct3D11.

GS-d3d11: Get rid of vendor check in device.
Rely on the vendor check we already use for best renderer selection.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Automatically pick the better best renderer for the user.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure Automatic works as described above.