### PR TITLE
Qt: Fix fullscreen on Mac

### DIFF
--- a/common/Vulkan/SwapChain.cpp
+++ b/common/Vulkan/SwapChain.cpp
@@ -78,6 +78,9 @@ static bool CreateMetalLayer(WindowInfo* wi)
 		return false;
 	}
 
+	// This needs to be retained, otherwise we double release below.
+	msgsend<void, id>(layer, "retain");
+
 	// [view setWantsLayer:YES]
 	msgsend<void, id, BOOL>(view, "setWantsLayer:", YES);
 

--- a/pcsx2/Frontend/MetalHostDisplay.mm
+++ b/pcsx2/Frontend/MetalHostDisplay.mm
@@ -83,6 +83,9 @@ bool MetalHostDisplay::HasRenderSurface()  const { return static_cast<bool>(m_la
 void MetalHostDisplay::AttachSurfaceOnMainThread()
 {
 	ASSERT([NSThread isMainThread]);
+	m_layer = MRCRetain([CAMetalLayer layer]);
+	[m_layer setDrawableSize:CGSizeMake(m_window_info.surface_width, m_window_info.surface_height)];
+	[m_layer setDevice:m_dev.dev];
 	m_view = MRCRetain((__bridge NSView*)m_window_info.window_handle);
 	[m_view setWantsLayer:YES];
 	[m_view setLayer:m_layer];
@@ -94,6 +97,7 @@ void MetalHostDisplay::DetachSurfaceOnMainThread()
 	[m_view setLayer:nullptr];
 	[m_view setWantsLayer:NO];
 	m_view = nullptr;
+	m_layer = nullptr;
 }
 
 bool MetalHostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device)
@@ -137,9 +141,6 @@ bool MetalHostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view
 	{
 		OnMainThread([this]
 		{
-			m_layer = MRCRetain([CAMetalLayer layer]);
-			[m_layer setDrawableSize:CGSizeMake(m_window_info.surface_width, m_window_info.surface_height)];
-			[m_layer setDevice:m_dev.dev];
 			AttachSurfaceOnMainThread();
 		});
 		SetVSync(vsync);


### PR DESCRIPTION
### Description of Changes

Fixes a crash when switching to fullscreen (in Qt) with the Vulkan renderer, and a black screen when using the Metal renderer. Needs #6010 to fix the crash on shutdown.

### Rationale behind Changes

Not having working fullscreen sucks.

### Suggested Testing Steps

We don't even build Qt for Mac at the moment. But it works for me at least.