### PR TITLE
Common/FileSystem: Don't recompress already compressed files

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1190,6 +1190,13 @@ bool FileSystem::SetPathCompression(const char* path, bool enable)
 	if (attrs == INVALID_FILE_ATTRIBUTES)
 		return false;
 
+	const bool isCompressed = (attrs & FILE_ATTRIBUTE_COMPRESSED) != 0;
+	if (enable == isCompressed)
+	{
+		// already compressed/not compressed
+		return true;
+	}
+
 	const bool isFile = !(attrs & FILE_ATTRIBUTE_DIRECTORY);
 	const DWORD flags = isFile ? FILE_ATTRIBUTE_NORMAL : (FILE_FLAG_BACKUP_SEMANTICS | FILE_ATTRIBUTE_DIRECTORY);
 


### PR DESCRIPTION
### Description of Changes

When we do, it can cause a couple of seconds delay on slow media (e.g. SD Cards).

### Rationale behind Changes

Fewer stalls on startup.

### Suggested Testing Steps

Test NTFS compression still applies as expected.