### PR TITLE
System: Purge pxThread from MTGS and MTVU

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -25,6 +25,7 @@
 
 #include "common/FileSystem.h"
 #include "common/StringUtil.h"
+#include "common/Threading.h"
 
 #include "Ps1CD.h"
 #include "CDVD.h"
@@ -372,7 +373,7 @@ s32 cdvdWriteConfig(const u8* config)
 	return 0;
 }
 
-static MutexRecursive Mutex_NewDiskCB;
+static Threading::MutexRecursive Mutex_NewDiskCB;
 
 // Sets ElfCRC to the CRC of the game bound to the CDVD source.
 static __fi ElfObject* loadElf(std::string filename, bool isPSXElf)
@@ -414,7 +415,7 @@ static __fi ElfObject* loadElf(std::string filename, bool isPSXElf)
 static __fi void _reloadElfInfo(std::string elfpath)
 {
 	// Now's a good time to reload the ELF info...
-	ScopedLock locker(Mutex_NewDiskCB);
+	Threading::ScopedLock locker(Mutex_NewDiskCB);
 
 	if (elfpath == LastELF)
 		return;
@@ -911,7 +912,7 @@ void SaveStateBase::cdvdFreeze()
 
 void cdvdNewDiskCB()
 {
-	ScopedTryLock lock(Mutex_NewDiskCB);
+	Threading::ScopedTryLock lock(Mutex_NewDiskCB);
 	if (lock.Failed())
 	{
 		DevCon.WriteLn(Color_Red, L"NewDiskCB Lock Failed");

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -27,6 +27,10 @@
 #include "IopMem.h"
 #include "SymbolMap.h"
 
+#ifndef PCSX2_CORE
+#include "System/SysThreads.h"
+#endif
+
 R5900DebugInterface r5900Debug;
 R3000DebugInterface r3000Debug;
 

--- a/pcsx2/PerformanceMetrics.cpp
+++ b/pcsx2/PerformanceMetrics.cpp
@@ -118,7 +118,7 @@ void PerformanceMetrics::Reset()
 	s_last_frame_time.Reset();
 
 	s_last_cpu_time = s_cpu_thread_handle.GetCPUTime();
-	s_last_gs_time = GetMTGS().GetCpuTime();
+	s_last_gs_time = GetMTGS().GetThreadHandle().GetCPUTime();
 	s_last_vu_time = THREAD_VU1 ? vu1Thread.GetThreadHandle().GetCPUTime() : 0;
 	s_last_ticks = GetCPUTicks();
 
@@ -183,7 +183,7 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
 								(1.0 / static_cast<double>(s_frames_since_last_update));
 
 	const u64 cpu_time = s_cpu_thread_handle.GetCPUTime();
-	const u64 gs_time = GetMTGS().GetCpuTime();
+	const u64 gs_time = GetMTGS().GetThreadHandle().GetCPUTime();
 	const u64 vu_time = THREAD_VU1 ? vu1Thread.GetThreadHandle().GetCPUTime() : 0;
 
 	const u64 cpu_delta = cpu_time - s_last_cpu_time;

--- a/pcsx2/PerformanceMetrics.cpp
+++ b/pcsx2/PerformanceMetrics.cpp
@@ -119,7 +119,7 @@ void PerformanceMetrics::Reset()
 
 	s_last_cpu_time = s_cpu_thread_handle.GetCPUTime();
 	s_last_gs_time = GetMTGS().GetCpuTime();
-	s_last_vu_time = THREAD_VU1 ? vu1Thread.GetCpuTime() : 0;
+	s_last_vu_time = THREAD_VU1 ? vu1Thread.GetThreadHandle().GetCPUTime() : 0;
 	s_last_ticks = GetCPUTicks();
 
 	for (GSSWThreadStats& stat : s_gs_sw_threads)
@@ -184,7 +184,7 @@ void PerformanceMetrics::Update(bool gs_register_write, bool fb_blit)
 
 	const u64 cpu_time = s_cpu_thread_handle.GetCPUTime();
 	const u64 gs_time = GetMTGS().GetCpuTime();
-	const u64 vu_time = THREAD_VU1 ? vu1Thread.GetCpuTime() : 0;
+	const u64 vu_time = THREAD_VU1 ? vu1Thread.GetThreadHandle().GetCPUTime() : 0;
 
 	const u64 cpu_delta = cpu_time - s_last_cpu_time;
 	const u64 gs_delta = gs_time - s_last_gs_time;

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -368,8 +368,7 @@ void SysCoreThread::OnCleanupInThread()
 	m_resetVirtualMachine = true;
 
 	R3000A::ioman::reset();
-	// FIXME: temporary workaround for deadlock on exit, which actually should be a crash
-	vu1Thread.WaitVU();
+	vu1Thread.Close();
 	USBclose();
 	SPU2close();
 	PADclose();

--- a/pcsx2/System/SysCoreThread.cpp
+++ b/pcsx2/System/SysCoreThread.cpp
@@ -212,7 +212,7 @@ void SysCoreThread::ApplySettings(const Pcsx2Config& src)
 // --------------------------------------------------------------------------------------
 bool SysCoreThread::HasPendingStateChangeRequest() const
 {
-	return !m_hasActiveMachine || GetMTGS().HasPendingException() || _parent::HasPendingStateChangeRequest();
+	return !m_hasActiveMachine || _parent::HasPendingStateChangeRequest();
 }
 
 void SysCoreThread::_reset_stuff_as_needed()
@@ -299,7 +299,6 @@ void SysCoreThread::GameStartingInThread()
 
 bool SysCoreThread::StateCheckInThread()
 {
-	GetMTGS().RethrowException();
 	return _parent::StateCheckInThread() && (_reset_stuff_as_needed(), true);
 }
 
@@ -376,12 +375,12 @@ void SysCoreThread::OnCleanupInThread()
 	DoCDVDclose();
 	FWclose();
 	FileMcd_EmuClose();
-	GetMTGS().Suspend();
+	GetMTGS().WaitForClose();
 	USBshutdown();
 	SPU2shutdown();
 	PADshutdown();
 	DEV9shutdown();
-	GetMTGS().Cancel();
+	GetMTGS().ShutdownThread();
 
 	_mm_setcsr(m_mxcsr_saved.bitmask);
 	Threading::DisableHiresScheduler();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -673,7 +673,7 @@ bool VMManager::Initialize(const VMBootParameters& boot_params)
 		return false;
 	}
 
-	ScopedGuard close_gs = []() { GetMTGS().Suspend(); };
+	ScopedGuard close_gs = []() { GetMTGS().WaitForClose(); };
 
 	Console.WriteLn("Opening SPU2...");
 	if (SPU2init() != 0 || SPU2open() != 0)
@@ -827,14 +827,11 @@ void VMManager::Shutdown(bool allow_save_resume_state /* = true */)
 	DoCDVDclose();
 	FWclose();
 	FileMcd_EmuClose();
-	GetMTGS().Suspend();
+	GetMTGS().WaitForClose();
 	USBshutdown();
 	SPU2shutdown();
 	PADshutdown();
 	DEV9shutdown();
-
-	// GS mess here...
-	GetMTGS().Cancel();
 	GSshutdown();
 
 	s_vm_memory->DecommitAll();

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -717,11 +717,6 @@ Pcsx2App::Pcsx2App()
 Pcsx2App::~Pcsx2App()
 {
 	pxDoAssert = pxAssertImpl_LogIt;
-	try
-	{
-		vu1Thread.Cancel();
-	}
-	DESTRUCTOR_CATCHALL
 }
 
 void Pcsx2App::CleanUp()

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -371,7 +371,7 @@ void recMicroVU1::Reserve()
 	if (m_Reserved.exchange(1) == 0)
 	{
 		mVUinit(microVU1, 1);
-		vu1Thread.Start();
+		vu1Thread.Open();
 	}
 }
 


### PR DESCRIPTION
### Description of Changes

This was causing the GS thread to get wedged on shutdown in newer Ubuntu versions for some reason, at least on the Qt build, with base-only-wx. The cleanup handler wasn't firing, and I couldn't be bothered to spend any more time debugging it, so I rewrote it. Was planning on getting rid of this for some time anyway.

### Rationale behind Changes

Getting rid of air's crap.

### Suggested Testing Steps

Ensure the usual workflow functions as normal (suspending, shutting down, renderer switch, etc).
