### PR TITLE
GS-TC: Don't skip depth lookup on KOF2002 - The King of Fighters 2002

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -149,6 +149,10 @@ const CRC::Game CRC::m_games[] =
 	{0xAC3C1147, SVCChaos, EU, 0}, // SVC Chaos: SNK vs. Capcom
 	{0xB00FF2ED, SVCChaos, JP, 0},
 	{0x94834BD3, SVCChaos, JP, 0},
+	{0xCF1D71EE, KOF2002, EU, 0}, // The King of Fighters 2002
+	{0xABD16263, KOF2002, JP, 0},
+	{0x424A8601, KOF2002, JP, 0},
+	{0x7F74D8D0, KOF2002, US, 0},
 	{0xA32F7CD0, AceCombat4, US, 0}, // Also needed for automatic mipmapping
 	{0x5ED8FB53, AceCombat4, JP, 0},
 	{0x1B9B7563, AceCombat4, EU, 0},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -45,6 +45,7 @@ public:
 		Jak3,
 		JakX,
 		KnightsOfTheTemple2,
+		KOF2002,
 		Kunoichi,
 		Lamune,
 		Manhunt2,

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -162,9 +162,9 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 
 		m_src.m_surfaces.insert(src);
 	}
-	else if (g_gs_renderer->m_game.title == CRC::SVCChaos)
+	else if (g_gs_renderer->m_game.title == CRC::SVCChaos || g_gs_renderer->m_game.title == CRC::KOF2002)
 	{
-		// SVCChaos black screen on main menu, regardless of depth enabled or disabled.
+		// SVCChaos black screen & KOF2002 blue screen on main menu, regardless of depth enabled or disabled.
 		return LookupSource(TEX0, TEXA, r, nullptr);
 	}
 	else


### PR DESCRIPTION
KOF2002 is affected by this exact same [SVCChaos issue](https://github.com/PCSX2/pcsx2/issues/1862).

In HW, the menu isn't showed and only the blue background is displayed. Software displays it perfectly.

HW : 
![gs_20220506120513_King of Fighters 2002_ The _SNK Best Collection_ _NTSC-J__SLPS-25573](https://user-images.githubusercontent.com/47425204/167111754-d82e6f76-56d9-4249-ab2c-add9130e9ff9.png)

SW :
![gs_20220506120518_King of Fighters 2002_ The _SNK Best Collection_ _NTSC-J__SLPS-25573](https://user-images.githubusercontent.com/47425204/167111762-82f9fff5-3e8d-4ae5-bf66-078754449c80.png)

This was solved by [this PR](https://github.com/PCSX2/pcsx2/pull/2382), I just added KOF2002 to the list.


I also attached GS dumps as no issue was opened : [snaps.zip](https://github.com/Immersion95/pcsx2/files/8639202/snaps.zip)