### PR TITLE
Qt: Rework display widget swapping

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(pcsx2-qt PRIVATE
 	QtUtils.cpp
 	QtUtils.h
 	SettingWidgetBinder.h
+	GameList/EmptyGameListWidget.ui
 	GameList/GameListModel.cpp
 	GameList/GameListModel.h
 	GameList/GameListRefreshThread.cpp

--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -42,7 +42,6 @@ Q_SIGNALS:
 	void windowFocusEvent();
 	void windowResizedEvent(int width, int height, float scale);
 	void windowRestoredEvent();
-	void windowClosedEvent();
 	void windowKeyEvent(int key_code, bool pressed);
 	void windowMouseMoveEvent(int x, int y);
 	void windowMouseButtonEvent(int button, bool pressed);

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -136,7 +136,7 @@ void EmuThread::setVMPaused(bool paused)
 	}
 
 	// if we were surfaceless (view->game list, system->unpause), get our display widget back
-	if (m_is_surfaceless)
+	if (!paused && m_is_surfaceless)
 		setSurfaceless(false);
 
 	VMManager::SetPaused(paused);
@@ -870,23 +870,6 @@ void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false 
 	QMetaObject::invokeMethod(g_emu_thread, "runOnCPUThread",
 		block ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
 		Q_ARG(const std::function<void()>&, std::move(function)));
-}
-
-ScopedVMPause::ScopedVMPause(bool was_paused, bool was_fullscreen)
-	: m_was_paused(was_paused), m_was_fullscreen(was_fullscreen)
-{
-	if (was_fullscreen)
-		g_emu_thread->setFullscreen(false);
-	if (!m_was_paused)
-		g_emu_thread->setVMPaused(true);
-}
-
-ScopedVMPause::~ScopedVMPause()
-{
-	if (!m_was_paused)
-		g_emu_thread->setVMPaused(false);
-	if (m_was_fullscreen)
-		g_emu_thread->setFullscreen(true);
 }
 
 alignas(16) static SysMtgsThread s_mtgs_thread;

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -167,21 +167,4 @@ private:
 	int m_last_internal_height = 0;
 };
 
-/// <summary>
-/// Helper class to pause/unpause the emulation thread.
-/// </summary>
-class ScopedVMPause
-{
-public:
-	ScopedVMPause(bool was_paused, bool was_fullscreen);
-	~ScopedVMPause();
-
-	__fi bool WasPaused() const { return m_was_paused; }
-	__fi bool WasFullscreen() const { return m_was_fullscreen; }
-
-private:
-	bool m_was_paused;
-	bool m_was_fullscreen;
-};
-
 extern EmuThread* g_emu_thread;

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -66,6 +66,7 @@ public Q_SLOTS:
 	void saveStateToSlot(qint32 slot);
 	void toggleFullscreen();
 	void setFullscreen(bool fullscreen);
+	void setSurfaceless(bool surfaceless);
 	void applySettings();
 	void reloadGameSettings();
 	void toggleSoftwareRendering();
@@ -81,7 +82,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	DisplayWidget* onCreateDisplayRequested(bool fullscreen, bool render_to_main);
-	DisplayWidget* onUpdateDisplayRequested(bool fullscreen, bool render_to_main);
+	DisplayWidget* onUpdateDisplayRequested(bool fullscreen, bool render_to_main, bool surfaceless);
 	void onResizeDisplayRequested(qint32 width, qint32 height);
 	void onDestroyDisplayRequested();
 
@@ -157,6 +158,7 @@ private:
 	bool m_verbose_status = false;
 	bool m_is_rendering_to_main = false;
 	bool m_is_fullscreen = false;
+	bool m_is_surfaceless = false;
 
 	float m_last_speed = 0.0f;
 	float m_last_game_fps = 0.0f;
@@ -171,11 +173,15 @@ private:
 class ScopedVMPause
 {
 public:
-	ScopedVMPause(bool was_paused);
+	ScopedVMPause(bool was_paused, bool was_fullscreen);
 	~ScopedVMPause();
+
+	__fi bool WasPaused() const { return m_was_paused; }
+	__fi bool WasFullscreen() const { return m_was_fullscreen; }
 
 private:
 	bool m_was_paused;
+	bool m_was_fullscreen;
 };
 
 extern EmuThread* g_emu_thread;

--- a/pcsx2-qt/GameList/EmptyGameListWidget.ui
+++ b/pcsx2-qt/GameList/EmptyGameListWidget.ui
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EmptyGameListWidget</class>
+ <widget class="QWidget" name="EmptyGameListWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>687</width>
+    <height>470</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;No games in supported formats were found.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please add a directory with games to begin.&lt;/p&gt;&lt;p&gt;Game dumps in the following formats will be scanned and listed:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="supportedFormats">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="addGameDirectory">
+       <property name="text">
+        <string>Add Game Directory...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="scanForNewGames">
+       <property name="text">
+        <string>Scan For New Games</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -15,6 +15,7 @@
 
 #pragma once
 #include "pcsx2/Frontend/GameList.h"
+#include "ui_EmptyGameListWidget.h"
 #include <QtWidgets/QListView>
 #include <QtWidgets/QStackedWidget>
 #include <QtWidgets/QTableView>
@@ -69,6 +70,8 @@ Q_SIGNALS:
 	void entryActivated();
 	void entryContextMenuRequested(const QPoint& point);
 
+	void addGameDirectoryRequested();
+
 private Q_SLOTS:
 	void onRefreshProgress(const QString& status, int current, int total);
 	void onRefreshComplete();
@@ -106,6 +109,9 @@ private:
 	GameListSortModel* m_sort_model = nullptr;
 	QTableView* m_table_view = nullptr;
 	GameListGridListView* m_list_view = nullptr;
+
+	QWidget* m_empty_widget = nullptr;
+	Ui::EmptyGameListWidget m_empty_ui;
 
 	GameListRefreshThread* m_refresh_thread = nullptr;
 };

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -104,11 +104,10 @@ void MainWindow::setupAdditionalUi()
 	m_ui.actionViewStatusBar->setChecked(status_bar_visible);
 	m_ui.statusBar->setVisible(status_bar_visible);
 
-	m_game_list_widget = new GameListWidget(m_ui.mainContainer);
+	m_game_list_widget = new GameListWidget(this);
 	m_game_list_widget->initialize();
-	m_ui.mainContainer->insertWidget(0, m_game_list_widget);
-	m_ui.mainContainer->setCurrentIndex(0);
 	m_ui.actionGridViewShowTitles->setChecked(m_game_list_widget->getShowGridCoverTitles());
+	setCentralWidget(m_game_list_widget);
 
 	m_status_progress_widget = new QProgressBar(m_ui.statusBar);
 	m_status_progress_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
@@ -578,6 +577,9 @@ void MainWindow::updateEmulationActions(bool starting, bool running)
 	m_ui.actionViewGameProperties->setEnabled(running);
 
 	m_game_list_widget->setDisabled(starting && !running);
+
+	if (!starting && !running)
+		m_ui.actionPause->setChecked(false);
 }
 
 void MainWindow::updateStatusBarWidgetVisibility()
@@ -603,26 +605,28 @@ void MainWindow::updateStatusBarWidgetVisibility()
 
 void MainWindow::updateWindowTitle()
 {
-	QString title;
-	if (!m_vm_valid || m_current_game_name.isEmpty())
-	{
 #if defined(_DEBUG)
-		title = QStringLiteral("PCSX2 [Debug] %1").arg(GIT_REV);
+	QString main_title(QStringLiteral("PCSX2 [Debug] %1").arg(GIT_REV));
+	QString display_title(QStringLiteral("%1 [Debug]").arg(m_current_game_name));
 #else
-		title = QStringLiteral("PCSX2 %1").arg(GIT_REV);
+	QString main_title(QStringLiteral("PCSX2 %1").arg(GIT_REV));
+	QString display_title(m_current_game_name);
 #endif
-	}
-	else
-	{
-#if defined(_DEBUG)
-		title = QStringLiteral("%1 [Debug]").arg(m_current_game_name);
-#else
-		title = m_current_game_name;
-#endif
-	}
 
-	if (windowTitle() != title)
-		setWindowTitle(title);
+	if (!m_vm_valid || m_current_game_name.isEmpty())
+		display_title = main_title;
+	else if (isRenderingToMain())
+		main_title = display_title;
+
+	if (windowTitle() != main_title)
+		setWindowTitle(main_title);
+
+	if (m_display_widget && !isRenderingToMain())
+	{
+		QWidget* container = m_display_container ? static_cast<QWidget*>(m_display_container) : static_cast<QWidget*>(m_display_widget);
+		if (container->windowTitle() != display_title)
+			container->setWindowTitle(display_title);
+	}
 }
 
 void MainWindow::setProgressBar(int current, int total)
@@ -648,38 +652,64 @@ void MainWindow::clearProgressBar()
 
 bool MainWindow::isShowingGameList() const
 {
-	return m_ui.mainContainer->currentIndex() == 0;
+	return (centralWidget() == m_game_list_widget);
+}
+
+bool MainWindow::isRenderingFullscreen() const
+{
+	HostDisplay* display = Host::GetHostDisplay();
+	if (!display || !m_display_widget)
+		return false;
+
+	return (m_display_widget->parent() != this && (m_display_widget->isFullScreen() || display->IsFullscreen()));
+}
+
+bool MainWindow::isRenderingToMain() const
+{
+	return (m_display_widget && m_display_widget->parent() == this);
 }
 
 void MainWindow::switchToGameListView()
 {
-	if ((m_display_widget && !m_display_widget->parent()) || m_ui.mainContainer->currentIndex() == 0)
+	if (centralWidget() == m_game_list_widget)
+	{
+		m_game_list_widget->setFocus();
 		return;
+	}
 
 	if (m_vm_valid)
 	{
-		m_was_focused_on_container_switch = m_vm_paused;
+		m_was_paused_on_surface_loss = m_vm_paused;
 		if (!m_vm_paused)
 			g_emu_thread->setVMPaused(true);
+
+		// switch to surfaceless. we have to wait until the display widget is gone before we swap over.
+		g_emu_thread->setSurfaceless(true);
+		while (m_display_widget)
+			QApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 1);
 	}
 
-	m_ui.mainContainer->setCurrentIndex(0);
+	pxAssertMsg(!centralWidget(), "Should not have a central widget at game list switch time");
+	takeCentralWidget();
+	setCentralWidget(m_game_list_widget);
+	m_game_list_widget->setVisible(true);
 	m_game_list_widget->setFocus();
 }
 
 void MainWindow::switchToEmulationView()
 {
-	if (!m_display_widget || !m_display_widget->parent() || m_ui.mainContainer->currentIndex() == 1)
+	if (!m_vm_valid || (m_display_widget && centralWidget() == m_display_widget))
 		return;
 
-	if (m_vm_valid)
-	{
-		m_ui.mainContainer->setCurrentIndex(1);
-		if (m_vm_paused && !m_was_focused_on_container_switch)
-			g_emu_thread->setVMPaused(false);
-	}
+	// we're no longer surfaceless! this will call back to UpdateDisplay(), which will swap the widget out.
+	g_emu_thread->setSurfaceless(false);
 
-	m_display_widget->setFocus();
+	// resume if we weren't paused at switch time
+	if (m_vm_paused && !m_was_paused_on_surface_loss)
+		g_emu_thread->setVMPaused(false);
+
+	if (m_display_widget)
+		m_display_widget->setFocus();
 }
 
 void MainWindow::refreshGameList(bool invalidate_cache)
@@ -710,8 +740,8 @@ bool MainWindow::requestShutdown(bool allow_confirm /* = true */, bool allow_sav
 	// only confirm on UI thread because we need to display a msgbox
 	if (allow_confirm && !GSDumpReplayer::IsReplayingDump() && QtHost::GetBaseBoolSettingValue("UI", "ConfirmShutdown", true))
 	{
-		ScopedVMPause pauser(m_vm_paused);
-		if (QMessageBox::question(g_main_window, tr("Confirm Shutdown"),
+		ScopedVMPause pauser(m_vm_paused, isRenderingFullscreen());
+		if (QMessageBox::question(m_display_widget, tr("Confirm Shutdown"),
 			tr("Are you sure you want to shut down the virtual machine?\n\nAll unsaved progress will be lost.")) != QMessageBox::Yes)
 		{
 			return false;
@@ -882,7 +912,7 @@ void MainWindow::onStartBIOSActionTriggered()
 
 void MainWindow::onChangeDiscFromFileActionTriggered()
 {
-	ScopedVMPause pauser(m_vm_paused);
+	ScopedVMPause pauser(m_vm_paused, isRenderingFullscreen());
 
 	QString filename = QFileDialog::getOpenFileName(this, tr("Select Disc Image"), QString(), tr(DISC_IMAGE_FILTER), nullptr);
 	if (filename.isEmpty())
@@ -1114,6 +1144,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
 DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 {
+	DevCon.WriteLn("createDisplay(%u, %u)", static_cast<u32>(fullscreen), static_cast<u32>(render_to_main));
+
 	HostDisplay* host_display = Host::GetHostDisplay();
 	if (!host_display)
 		return nullptr;
@@ -1131,12 +1163,15 @@ DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 	}
 	else
 	{
-		m_display_widget = new DisplayWidget((!fullscreen && render_to_main) ? m_ui.mainContainer : nullptr);
+		m_display_widget = new DisplayWidget((!fullscreen && render_to_main) ? this : nullptr);
 		container = m_display_widget;
 	}
 
-	container->setWindowTitle(windowTitle());
-	container->setWindowIcon(windowIcon());
+	if (fullscreen || !render_to_main)
+	{
+		container->setWindowTitle(windowTitle());
+		container->setWindowIcon(windowIcon());
+	}
 
 	if (fullscreen)
 	{
@@ -1152,8 +1187,9 @@ DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 	}
 	else
 	{
-		m_ui.mainContainer->insertWidget(1, container);
-		switchToEmulationView();
+		m_game_list_widget->setVisible(false);
+		takeCentralWidget();
+		setCentralWidget(m_display_widget);
 	}
 
 	// we need the surface visible.. this might be able to be replaced with something else
@@ -1180,26 +1216,32 @@ DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 	if (is_exclusive_fullscreen)
 		setDisplayFullscreen(fullscreen_mode);
 
+	updateWindowTitle();
+	m_display_widget->setFocus();
+
 	host_display->DoneRenderContextCurrent();
 	return m_display_widget;
 }
 
-DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main)
+DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main, bool surfaceless)
 {
+	DevCon.WriteLn("updateDisplay(%u, %u, %u)", static_cast<u32>(fullscreen), static_cast<u32>(render_to_main), static_cast<u32>(surfaceless));
+
 	HostDisplay* host_display = Host::GetHostDisplay();
 	QWidget* container = m_display_container ? static_cast<QWidget*>(m_display_container) : static_cast<QWidget*>(m_display_widget);
-	const bool is_fullscreen = container->isFullScreen();
-	const bool is_rendering_to_main = (!is_fullscreen && container->parent());
+	const bool is_fullscreen = (container && container->isFullScreen());
+	const bool is_rendering_to_main = (!is_fullscreen && container && container->parent());
 	const std::string fullscreen_mode(QtHost::GetBaseStringSettingValue("EmuCore/GS", "FullscreenMode", ""));
 	const bool is_exclusive_fullscreen = (fullscreen && !fullscreen_mode.empty() && host_display->SupportsFullscreen());
-	if (fullscreen == is_fullscreen && is_rendering_to_main == render_to_main)
+	const bool changing_surfaceless = (!m_display_widget != surfaceless);
+	if (fullscreen == is_fullscreen && is_rendering_to_main == render_to_main && !changing_surfaceless)
 		return m_display_widget;
 
 	// Skip recreating the surface if we're just transitioning between fullscreen and windowed with render-to-main off.
 	// .. except on Wayland, where everything tends to break if you don't recreate.
 	const bool has_container = (m_display_container != nullptr);
 	const bool needs_container = DisplayContainer::IsNeeded(fullscreen, render_to_main);
-	if (!is_rendering_to_main && !render_to_main && !is_exclusive_fullscreen && has_container == needs_container && !needs_container)
+	if (!is_rendering_to_main && !render_to_main && !is_exclusive_fullscreen && has_container == needs_container && !needs_container && !changing_surfaceless)
 	{
 		Console.WriteLn("Toggling to %s without recreating surface", (fullscreen ? "fullscreen" : "windowed"));
 		if (host_display->IsFullscreen())
@@ -1223,6 +1265,10 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main)
 
 	destroyDisplayWidget();
 
+	// if we're going to surfaceless, we're done here
+	if (surfaceless)
+		return nullptr;
+
 	if (DisplayContainer::IsNeeded(fullscreen, render_to_main))
 	{
 		m_display_container = new DisplayContainer();
@@ -1232,12 +1278,22 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main)
 	}
 	else
 	{
-		m_display_widget = new DisplayWidget((!fullscreen && render_to_main) ? m_ui.mainContainer : nullptr);
+		m_display_widget = new DisplayWidget((!fullscreen && render_to_main) ? this : nullptr);
 		container = m_display_widget;
 	}
 
-	container->setWindowTitle(windowTitle());
-	container->setWindowIcon(windowIcon());
+	if (fullscreen || !render_to_main)
+	{
+		container->setWindowTitle(windowTitle());
+		container->setWindowIcon(windowIcon());
+
+		// make sure the game list widget is still visible
+		if (centralWidget() != m_game_list_widget && !fullscreen)
+		{
+			setCentralWidget(m_game_list_widget);
+			m_game_list_widget->setVisible(true);
+		}
+	}
 
 	if (fullscreen)
 	{
@@ -1253,8 +1309,10 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main)
 	}
 	else
 	{
-		m_ui.mainContainer->insertWidget(1, container);
-		switchToEmulationView();
+		m_game_list_widget->setVisible(false);
+		takeCentralWidget();
+		setCentralWidget(m_display_widget);
+		m_display_widget->setFocus();
 	}
 
 	// we need the surface visible.. this might be able to be replaced with something else
@@ -1276,6 +1334,7 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main)
 	if (is_exclusive_fullscreen)
 		setDisplayFullscreen(fullscreen_mode);
 
+	updateWindowTitle();
 	m_display_widget->setFocus();
 
 	QSignalBlocker blocker(m_ui.actionFullscreen);
@@ -1308,11 +1367,20 @@ void MainWindow::displayResizeRequested(qint32 width, qint32 height)
 void MainWindow::destroyDisplay()
 {
 	destroyDisplayWidget();
+
+	// switch back to game list view, we're not going back to display, so we can't use switchToGameListView().
+	if (centralWidget() != m_game_list_widget)
+	{
+		takeCentralWidget();
+		setCentralWidget(m_game_list_widget);
+		m_game_list_widget->setVisible(true);
+		m_game_list_widget->setFocus();
+	}	
 }
 
 void MainWindow::focusDisplayWidget()
 {
-	if (m_ui.mainContainer->currentIndex() != 1)
+	if (!m_display_widget || centralWidget() != m_display_widget)
 		return;
 
 	m_display_widget->setFocus();
@@ -1355,18 +1423,20 @@ void MainWindow::destroyDisplayWidget()
 	if (m_display_container)
 		m_display_container->removeDisplayWidget();
 
-	if (m_display_widget->parent())
+	if (m_display_widget == centralWidget())
+		takeCentralWidget();
+
+	if (m_display_widget)
 	{
-		m_ui.mainContainer->removeWidget(m_display_widget);
-		m_ui.mainContainer->setCurrentIndex(0);
-		m_game_list_widget->setFocus();
+		m_display_widget->deleteLater();
+		m_display_widget = nullptr;
 	}
 
-	delete m_display_widget;
-	m_display_widget = nullptr;
-
-	delete m_display_container;
-	m_display_container = nullptr;
+	if (m_display_container)
+	{
+		m_display_container->deleteLater();
+		m_display_container = nullptr;
+	}
 }
 
 void MainWindow::setDisplayFullscreen(const std::string& fullscreen_mode)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -215,6 +215,8 @@ void MainWindow::connectSignals()
 	connect(m_game_list_widget, &GameListWidget::entryActivated, this, &MainWindow::onGameListEntryActivated, Qt::QueuedConnection);
 	connect(
 		m_game_list_widget, &GameListWidget::entryContextMenuRequested, this, &MainWindow::onGameListEntryContextMenuRequested, Qt::QueuedConnection);
+	connect(m_game_list_widget, &GameListWidget::addGameDirectoryRequested, this,
+		[this]() { getSettingsDialog()->getGameListSettingsWidget()->addSearchDirectory(this); });
 }
 
 void MainWindow::connectVMThreadSignals(EmuThread* thread)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -160,6 +160,7 @@ private:
 	void populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc);
 	void populateSaveStateMenu(QMenu* menu, const QString& serial, quint32 crc);
 	void updateSaveStateMenus(const QString& filename, const QString& serial, quint32 crc);
+	void doDiscChange(const QString& path);
 
 	Ui::MainWindow m_ui;
 
@@ -184,6 +185,7 @@ private:
 	bool m_vm_paused = false;
 	bool m_save_states_invalidated = false;
 	bool m_was_paused_on_surface_loss = false;
+	bool m_was_disc_change_request = false;
 
 	QString m_last_fps_status;
 };

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -62,7 +62,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	DisplayWidget* createDisplay(bool fullscreen, bool render_to_main);
-	DisplayWidget* updateDisplay(bool fullscreen, bool render_to_main);
+	DisplayWidget* updateDisplay(bool fullscreen, bool render_to_main, bool surfaceless);
 	void displayResizeRequested(qint32 width, qint32 height);
 	void destroyDisplay();
 	void focusDisplayWidget();
@@ -134,6 +134,8 @@ private:
 	void clearProgressBar();
 
 	bool isShowingGameList() const;
+	bool isRenderingFullscreen() const;
+	bool isRenderingToMain() const;
 	void switchToGameListView();
 	void switchToEmulationView();
 
@@ -181,7 +183,7 @@ private:
 	bool m_vm_valid = false;
 	bool m_vm_paused = false;
 	bool m_save_states_invalidated = false;
-	bool m_was_focused_on_container_switch = false;
+	bool m_was_paused_on_surface_loss = false;
 
 	QString m_last_fps_status;
 };

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -20,13 +20,6 @@
    <iconset resource="resources/resources.qrc">
     <normaloff>:/icons/AppIcon.png</normaloff>:/icons/AppIcon.png</iconset>
   </property>
-  <widget class="QStackedWidget" name="mainContainer">
-   <property name="currentIndex">
-    <number>0</number>
-   </property>
-   <widget class="QWidget" name="page"/>
-   <widget class="QWidget" name="page_2"/>
-  </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">
     <rect>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -262,6 +262,9 @@
     <QtUi Include="MainWindow.ui">
       <FileType>Document</FileType>
     </QtUi>
+    <QtUi Include="GameList\EmptyGameListWidget.ui">
+      <FileType>Document</FileType>
+    </QtUi>
     <QtUi Include="Settings\SettingsDialog.ui">
       <FileType>Document</FileType>
     </QtUi>

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -363,5 +363,8 @@
     <QtUi Include="Settings\DEV9SettingsWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
+    <QtUi Include="GameList\EmptyGameListWidget.ui">
+      <Filter>GameList</Filter>
+    </QtUi>
   </ItemGroup>
 </Project>

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -117,6 +117,7 @@ void GSinitConfig()
 
 void GSshutdown()
 {
+#ifndef PCSX2_CORE
 	if (g_gs_renderer)
 	{
 		g_gs_renderer->Destroy();
@@ -129,6 +130,7 @@ void GSshutdown()
 	}
 
 	Host::ReleaseHostDisplay();
+#endif
 
 #ifdef _WIN32
 	if (SUCCEEDED(s_hr))


### PR DESCRIPTION
### Description of Changes

I really didn't want to have to make things work this way (messing with the central widget), but it seems to be the only way which works with newer version of wayland/gnome-shell/kwin....

Also fixed the long-running issue where fullscreen wouldn't be exited when displaying the "confirm exit" popup, corrected the window title when not using render-to-main, stopped things blowing up when you closed the non-render-to-main window, and added a confirm dialog for swapping discs from the game list (when it wasn't initiated from file->change disc).

### Rationale behind Changes

Reliability.

### Suggested Testing Steps

Check disc changing, fullscreen/render-to-main switching, view->game list, view->system display, etc. I've done a bit and I think I've nailed all the edge cases, but another set of eyes is always good.
