### PR TITLE
GS: Improve read heights with screen offset disabled

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -269,7 +269,14 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 
 	const int videomode = static_cast<int>(GetVideoMode()) - 1;
 	const int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
-	const int fb_height = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
+	const int display_offset = GetResolutionOffset(i).y;
+	int fb_height = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
+	
+	// If there is a negative vertical offset on the picture, we need to read more.
+	if (display_offset < 0)
+	{
+		fb_height += -display_offset;
+	}
 	// TRACE(_T("[%d] GetOutput %d %05x (%d)\n"), (int)m_perfmon.GetFrame(), i, (int)TEX0.TBP0, (int)TEX0.PSM);
 
 	GSTexture* t = NULL;

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -143,10 +143,15 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 	int w = DISPFB.FBW * 64;
 
 	const int videomode = static_cast<int>(GetVideoMode()) - 1;
-	int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
+	const int display_offset = GetResolutionOffset(i).y;
+	const int display_height = VideoModeOffsets[videomode].y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
 	int h = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
 
-	// TODO: round up bottom
+	// If there is a negative vertical offset on the picture, we need to read more.
+	if (display_offset < 0)
+	{
+		h += -display_offset;
+	}
 
 	if (g_gs_device->ResizeTarget(&m_texture[i], w, h))
 	{


### PR DESCRIPTION
### Description of Changes
Account for negative vertical offsets to read more of the frame when screen offsets are disabled.  Now we are limiting by height, the mode without screen offsets doesn't understand if a picture has been negatively offset and would have cut off early, this resolves that.

### Rationale behind Changes
It was causing some corruption when software mode read the frame but didn't get enough height to fill the screen. Also it cut off the picture early in some games which used this negative offset.

### Suggested Testing Steps
Make sure games don't have any stretched/blurry stuff at the bottom with screen offsets on or off.

Fixes #6026
