### PR TITLE
Qt: Implement save-state-on-shutdown

### DIFF
--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -249,6 +249,7 @@ void EmuThread::run()
 	stopBackgroundControllerPollTimer();
 	destroyBackgroundControllerPollTimer();
 	InputManager::CloseSources();
+	VMManager::WaitForSaveStateFlush();
 	VMManager::Internal::ReleaseMemory();
 	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
 	moveToThread(m_ui_thread);

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -59,7 +59,7 @@ public Q_SLOTS:
 	void startVM(std::shared_ptr<VMBootParameters> boot_params);
 	void resetVM();
 	void setVMPaused(bool paused);
-	void shutdownVM(bool allow_save_to_state = true);
+	void shutdownVM(bool save_state = true);
 	void loadState(const QString& filename);
 	void loadStateFromSlot(qint32 slot);
 	void saveState(const QString& filename);
@@ -159,6 +159,7 @@ private:
 	bool m_is_rendering_to_main = false;
 	bool m_is_fullscreen = false;
 	bool m_is_surfaceless = false;
+	bool m_save_state_on_shutdown = false;
 
 	float m_last_speed = 0.0f;
 	float m_last_game_fps = 0.0f;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -835,6 +835,9 @@ void MainWindow::onGameListEntryActivated()
 		return;
 	}
 
+	// we might still be saving a resume state...
+	VMManager::WaitForSaveStateFlush();
+
 	const std::optional<bool> resume = promptForResumeState(
 		QString::fromStdString(VMManager::GetSaveStateFileName(entry->serial.c_str(), entry->crc, -1)));
 	if (!resume.has_value())
@@ -927,6 +930,9 @@ void MainWindow::onStartFileActionTriggered()
 
 	std::shared_ptr<VMBootParameters> params = std::make_shared<VMBootParameters>();
 	params->filename = filename.toStdString();
+
+	// we might still be saving a resume state...
+	VMManager::WaitForSaveStateFlush();
 
 	const std::optional<bool> resume(
 		promptForResumeState(

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -185,6 +185,7 @@ private:
 		std::optional<bool> fast_boot = std::nullopt);
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
 
+	std::optional<bool> promptForResumeState(const QString& save_state_path);
 	void loadSaveStateSlot(s32 slot);
 	void loadSaveStateFile(const QString& filename, const QString& state_filename);
 	void populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -80,6 +80,7 @@
     <addaction name="actionStartBios"/>
     <addaction name="separator"/>
     <addaction name="actionPowerOff"/>
+    <addaction name="actionPowerOffWithoutSaving"/>
     <addaction name="actionReset"/>
     <addaction name="actionPause"/>
     <addaction name="menuChangeDisc"/>
@@ -283,6 +284,15 @@
    </property>
    <property name="text">
     <string>Shut &amp;Down</string>
+   </property>
+  </action>
+  <action name="actionPowerOffWithoutSaving">
+   <property name="icon">
+    <iconset theme="close-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Shut Down &amp;Without Saving</string>
    </property>
   </action>
   <action name="actionReset">

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -42,7 +42,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.inhibitScreensaver, "UI", "InhibitScreensaver", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.discordPresence, "UI", "DiscordPresence", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.confirmShutdown, "UI", "ConfirmShutdown", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveStateOnExit, "EmuCore", "AutoStateLoadSave", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveStateOnShutdown, "EmuCore", "SaveStateOnShutdown", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnStart, "UI", "StartPaused", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnFocusLoss, "UI", "PauseOnFocusLoss", false);
 
@@ -87,7 +87,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 		m_ui.confirmShutdown, tr("Confirm Shutdown"), tr("Checked"),
 		tr("Determines whether a prompt will be displayed to confirm shutting down the virtual machine "
 		   "when the hotkey is pressed."));
-	dialog->registerWidgetHelp(m_ui.saveStateOnExit, tr("Save State On Exit"), tr("Checked"),
+	dialog->registerWidgetHelp(m_ui.saveStateOnShutdown, tr("Save State On Shutdown"), tr("Checked"),
 		tr("Automatically saves the emulator state when powering down or exiting. You can then "
 		   "resume directly from where you left off next time."));
 	dialog->registerWidgetHelp(m_ui.pauseOnStart, tr("Pause On Start"), tr("Unchecked"),

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -68,9 +68,9 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QCheckBox" name="saveStateOnExit">
+       <widget class="QCheckBox" name="saveStateOnShutdown">
         <property name="text">
-         <string>Save Or Load State On Exit / Resume</string>
+         <string>Save State On Shutdown</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -939,6 +939,7 @@ struct Pcsx2Config
 #endif
 #ifdef PCSX2_CORE
 		EnableGameFixes : 1, // enables automatic game fixes
+		SaveStateOnShutdown : 1, // default value for saving state on shutdown
 #endif
 		// when enabled uses BOOT2 injection, skipping sony bios splashes
 		UseBOOT2Injection : 1,

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1062,6 +1062,7 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 #endif
 #ifdef PCSX2_CORE
 	SettingsWrapBitBool(EnableGameFixes);
+	SettingsWrapBitBool(SaveStateOnShutdown);
 #endif
 	SettingsWrapBitBool(ConsoleToStdio);
 	SettingsWrapBitBool(HostFs);

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -783,8 +783,7 @@ static bool SaveState_CompressScreenshot(SaveStateScreenshotData* data, zip_t* z
 // --------------------------------------------------------------------------------------
 //  CompressThread_VmState
 // --------------------------------------------------------------------------------------
-static void ZipStateToDiskOnThread(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot,
-	std::string filename, s32 slot_for_message)
+void SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message)
 {
 #ifndef PCSX2_CORE
 	wxGetApp().StartPendingSave();
@@ -858,9 +857,10 @@ static void ZipStateToDiskOnThread(std::unique_ptr<ArchiveEntryList> srclist, st
 #endif
 }
 
-void SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message)
+
+void SaveState_ZipToDiskOnThread(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message)
 {
-	std::thread threaded_save(ZipStateToDiskOnThread, std::move(srclist), std::move(screenshot), std::move(filename), slot_for_message);
+	std::thread threaded_save(SaveState_ZipToDisk, std::move(srclist), std::move(screenshot), std::move(filename), slot_for_message);
 	threaded_save.detach();
 }
 

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -780,45 +780,109 @@ static bool SaveState_CompressScreenshot(SaveStateScreenshotData* data, zip_t* z
 	return true;
 }
 
+static bool SaveState_ReadScreenshot(zip_t* zf, u32* out_width, u32* out_height, std::vector<u32>* out_pixels)
+{
+	auto zff = zip_fopen_managed(zf, EntryFilename_Screenshot, 0);
+	if (!zff)
+		return false;
+
+	png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	if (!png_ptr)
+		return false;
+
+	png_infop info_ptr = png_create_info_struct(png_ptr);
+	if (!info_ptr)
+	{
+		png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+		return false;
+	}
+
+	ScopedGuard cleanup([&png_ptr, &info_ptr]() {
+		png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+	});
+
+	if (setjmp(png_jmpbuf(png_ptr)))
+		return false;
+
+	png_set_read_fn(png_ptr, zff.get(), [](png_structp png_ptr, png_bytep data_ptr, png_size_t size) {
+		zip_fread(static_cast<zip_file_t*>(png_get_io_ptr(png_ptr)), data_ptr, size);
+	});
+
+	png_read_info(png_ptr, info_ptr);
+
+	png_uint_32 width = 0;
+	png_uint_32 height = 0;
+	int bitDepth = 0;
+	int colorType = -1;
+	if (png_get_IHDR(png_ptr, info_ptr, &width, &height, &bitDepth, &colorType, nullptr, nullptr, nullptr) != 1 ||
+		width == 0 || height == 0)
+	{
+		return false;
+	}
+
+	const png_uint_32 bytesPerRow = png_get_rowbytes(png_ptr, info_ptr);
+	std::vector<u8> rowData(bytesPerRow);
+
+	*out_width = width;
+	*out_height = height;
+	out_pixels->resize(width * height);
+
+	for (u32 y = 0; y < height; y++)
+	{
+		png_read_row(png_ptr, static_cast<png_bytep>(rowData.data()), nullptr);
+
+		const u8* row_ptr = rowData.data();
+		u32* out_ptr = &out_pixels->at(y * width);
+		if (colorType == PNG_COLOR_TYPE_RGB)
+		{
+			for (u32 x = 0; x < width; x++)
+			{
+				u32 pixel = static_cast<u32>(*(row_ptr)++);
+				pixel |= static_cast<u32>(*(row_ptr)++) << 8;
+				pixel |= static_cast<u32>(*(row_ptr)++) << 16;
+				pixel |= static_cast<u32>(*(row_ptr)++) << 24;
+				*(out_ptr++) = pixel | 0xFF000000u; // make opaque
+			}
+		}
+		else if (colorType == PNG_COLOR_TYPE_RGBA)
+		{
+			for (u32 x = 0; x < width; x++)
+			{
+				u32 pixel;
+				std::memcpy(&pixel, row_ptr, sizeof(u32));
+				row_ptr += sizeof(u32);
+				*(out_ptr++) = pixel | 0xFF000000u; // make opaque
+			}
+		}
+	}
+
+	return true;
+}
+
 // --------------------------------------------------------------------------------------
 //  CompressThread_VmState
 // --------------------------------------------------------------------------------------
-void SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message)
+static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateScreenshotData* screenshot)
 {
-#ifndef PCSX2_CORE
-	wxGetApp().StartPendingSave();
-#endif
-
-	zip_error_t ze = {};
-	auto zf = zip_open_managed(filename.c_str(), ZIP_CREATE | ZIP_TRUNCATE, &ze);
-	if (!zf)
-	{
-		Console.Error("Failed to open zip file '%s' for save state: %s", filename.c_str(), zip_error_strerror(&ze));
-		return;
-	}
-
-	// discard zip file if we fail saving something
-	ScopedGuard zip_discarder([&zf]() { zip_discard(zf.release()); });
-
 	// use zstd compression, it can be 10x+ faster for saving.
 	const u32 compression = EmuConfig.SavestateZstdCompression ? ZIP_CM_ZSTD : ZIP_CM_DEFLATE;
 	const u32 compression_level = 0;
 
 	// version indicator
 	{
-		zip_source_t* const zs = zip_source_buffer(zf.get(), &g_SaveVersion, sizeof(g_SaveVersion), 0);
+		zip_source_t* const zs = zip_source_buffer(zf, &g_SaveVersion, sizeof(g_SaveVersion), 0);
 		if (!zs)
-			return;
+			return false;
 
 		// NOTE: Source should not be freed if successful.
-		const s64 fi = zip_file_add(zf.get(), EntryFilename_StateVersion, zs, ZIP_FL_ENC_UTF_8);
+		const s64 fi = zip_file_add(zf, EntryFilename_StateVersion, zs, ZIP_FL_ENC_UTF_8);
 		if (fi < 0)
 		{
 			zip_source_free(zs);
-			return;
+			return false;
 		}
 
-		zip_set_file_compression(zf.get(), fi, ZIP_CM_STORE, 0);
+		zip_set_file_compression(zf, fi, ZIP_CM_STORE, 0);
 	}
 
 	const uint listlen = srclist->GetLength();
@@ -828,40 +892,67 @@ void SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_
 		if (!entry.GetDataSize())
 			continue;
 
-		zip_source_t* const zs = zip_source_buffer(zf.get(), srclist->GetPtr(entry.GetDataIndex()), entry.GetDataSize(), 0);
+		zip_source_t* const zs = zip_source_buffer(zf, srclist->GetPtr(entry.GetDataIndex()), entry.GetDataSize(), 0);
 		if (!zs)
-			return;
+			return false;
 
-		const s64 fi = zip_file_add(zf.get(), entry.GetFilename().c_str(), zs, ZIP_FL_ENC_UTF_8);
+		const s64 fi = zip_file_add(zf, entry.GetFilename().c_str(), zs, ZIP_FL_ENC_UTF_8);
 		if (fi < 0)
 		{
 			zip_source_free(zs);
-			return;
+			return false;
 		}
 
-		zip_set_file_compression(zf.get(), fi, compression, compression_level);
+		zip_set_file_compression(zf, fi, compression, compression_level);
 	}
 
 	if (screenshot)
-		SaveState_CompressScreenshot(screenshot.get(), zf.get());
+	{
+		if (!SaveState_CompressScreenshot(screenshot, zf))
+			return false;
+	}
 
-	// force the zip to close, this is the expensive part with libzip.
-	zf.reset();
-
-#ifdef PCSX2_CORE
-	if (slot_for_message >= 0 && VMManager::HasValidVM())
-		Host::AddKeyedFormattedOSDMessage(StringUtil::StdStringFromFormat("SaveStateSlot%d", slot_for_message), 10.0f, "State saved to slot %d.", slot_for_message);
-#else
-	Console.WriteLn("(gzipThread) Data saved to disk without error.");
-	wxGetApp().ClearPendingSave();
-#endif
+	return true;
 }
 
-
-void SaveState_ZipToDiskOnThread(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message)
+bool SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, const char* filename)
 {
-	std::thread threaded_save(SaveState_ZipToDisk, std::move(srclist), std::move(screenshot), std::move(filename), slot_for_message);
-	threaded_save.detach();
+	zip_error_t ze = {};
+	zip_source_t* zs = zip_source_file_create(filename, 0, 0, &ze);
+	zip_t* zf = nullptr;
+	if (zs && !(zf = zip_open_from_source(zs, ZIP_CREATE | ZIP_TRUNCATE, &ze)))
+	{
+		Console.Error("Failed to open zip file '%s' for save state: %s", filename, zip_error_strerror(&ze));
+
+		// have to clean up source
+		zip_source_free(zs);
+		return false;
+	}
+
+	// discard zip file if we fail saving something
+	if (!SaveState_AddToZip(zf, srclist.get(), screenshot.get()))
+	{
+		Console.Error("Failed to save state to zip file '%s'", filename);
+		zip_discard(zf);
+		return false;
+	}
+
+	// force the zip to close, this is the expensive part with libzip.
+	zip_close(zf);
+	return true;
+}
+
+bool SaveState_ReadScreenshot(const std::string& filename, u32* out_width, u32* out_height, std::vector<u32>* out_pixels)
+{
+	zip_error_t ze = {};
+	auto zf = zip_open_managed(filename.c_str(), ZIP_RDONLY, &ze);
+	if (!zf)
+	{
+		Console.Error("Failed to open zip file '%s' for save state screenshot: %s", filename.c_str(), zip_error_strerror(&ze));
+		return false;
+	}
+
+	return SaveState_ReadScreenshot(zf.get(), out_width, out_height, out_pixels);
 }
 
 static void CheckVersion(const std::string& filename, zip_t* zf)

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -59,6 +59,7 @@ class ArchiveEntryList;
 extern std::unique_ptr<ArchiveEntryList> SaveState_DownloadState();
 extern std::unique_ptr<SaveStateScreenshotData> SaveState_SaveScreenshot();
 extern void SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message);
+extern void SaveState_ZipToDiskOnThread(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message);
 extern void SaveState_UnzipFromDisk(const std::string& filename);
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -58,8 +58,8 @@ class ArchiveEntryList;
 // These functions assume that the caller has paused the core thread.
 extern std::unique_ptr<ArchiveEntryList> SaveState_DownloadState();
 extern std::unique_ptr<SaveStateScreenshotData> SaveState_SaveScreenshot();
-extern void SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message);
-extern void SaveState_ZipToDiskOnThread(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, std::string filename, s32 slot_for_message);
+extern bool SaveState_ZipToDisk(std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot, const char* filename);
+extern bool SaveState_ReadScreenshot(const std::string& filename, u32* out_width, u32* out_height, std::vector<u32>* out_pixels);
 extern void SaveState_UnzipFromDisk(const std::string& filename);
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -76,7 +76,7 @@ namespace VMManager
 	bool Initialize(const VMBootParameters& boot_params);
 
 	/// Destroys all system components.
-	void Shutdown(bool allow_save_resume_state = true);
+	void Shutdown(bool save_resume_state);
 
 	/// Resets all subsystems to a cold boot.
 	void Reset();
@@ -96,11 +96,11 @@ namespace VMManager
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
 	void ReloadPatches(bool verbose);
 
-	/// Returns true if a resume save state should be saved/loaded.
-	bool ShouldSaveResumeState();
-
 	/// Returns the save state filename for the given game serial/crc.
 	std::string GetSaveStateFileName(const char* game_serial, u32 game_crc, s32 slot);
+
+	/// Returns the path to save state for the specified disc/elf.
+	std::string GetSaveStateFileName(const char* filename, s32 slot);
 
 	/// Returns true if there is a save state in the specified slot.
 	bool HasSaveStateInSlot(const char* game_serial, u32 game_crc, s32 slot);
@@ -112,10 +112,10 @@ namespace VMManager
 	bool LoadStateFromSlot(s32 slot);
 
 	/// Saves state to the specified filename.
-	bool SaveState(const char* filename);
+	bool SaveState(const char* filename, bool zip_on_thread = true);
 
 	/// Saves state to the specified slot.
-	bool SaveStateToSlot(s32 slot);
+	bool SaveStateToSlot(s32 slot, bool zip_on_thread = true);
 
 	/// Returns the current limiter mode.
 	LimiterModeType GetLimiterMode();

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -117,6 +117,9 @@ namespace VMManager
 	/// Saves state to the specified slot.
 	bool SaveStateToSlot(s32 slot, bool zip_on_thread = true);
 
+	/// Waits until all compressing save states have finished saving to disk.
+	void WaitForSaveStateFlush();
+
 	/// Returns the current limiter mode.
 	LimiterModeType GetLimiterMode();
 

--- a/pcsx2/gui/SysState.cpp
+++ b/pcsx2/gui/SysState.cpp
@@ -61,7 +61,20 @@ protected:
 		std::unique_ptr<ArchiveEntryList> elist = SaveState_DownloadState();
 		UI_EnableStateActions();
 		paused_core.AllowResume();
-		SaveState_ZipToDiskOnThread(std::move(elist), nullptr, StringUtil::wxStringToUTF8String(m_filename), -1);
+
+		std::thread kickoff(&SysExecEvent_SaveState::ZipThreadProc,
+			std::move(elist), StringUtil::wxStringToUTF8String(m_filename));
+		kickoff.detach();
+	}
+
+	static void ZipThreadProc(std::unique_ptr<ArchiveEntryList> elist, std::string filename)
+	{
+		wxGetApp().StartPendingSave();
+		if (SaveState_ZipToDisk(std::move(elist), nullptr, filename.c_str()))
+			Console.WriteLn("(gzipThread) Data saved to disk without error.");
+		else
+			Console.Error("Failed to zip state to '%s'", filename.c_str());
+		wxGetApp().ClearPendingSave();
 	}
 };
 

--- a/pcsx2/gui/SysState.cpp
+++ b/pcsx2/gui/SysState.cpp
@@ -61,7 +61,7 @@ protected:
 		std::unique_ptr<ArchiveEntryList> elist = SaveState_DownloadState();
 		UI_EnableStateActions();
 		paused_core.AllowResume();
-		SaveState_ZipToDisk(std::move(elist), nullptr, StringUtil::wxStringToUTF8String(m_filename), -1);
+		SaveState_ZipToDiskOnThread(std::move(elist), nullptr, StringUtil::wxStringToUTF8String(m_filename), -1);
 	}
 };
 


### PR DESCRIPTION
### Description of Changes

What the title says. When you shut down, you can optionally save state (default driven by settings), and when you start the game next, it'll prompt you if you want to load. If you disable shutdown confirmation, it'll use the value from settings unconditionally.

### Rationale behind Changes

Features.

### Suggested Testing Steps

As this touches wx saving code with some refactoring, save states should be tested in both.
Test new resume functionality.
