### PR TITLE
3rdparty/SDL2: Bump to 2.0.22 release

### DIFF
--- a/3rdparty/sdl2/SDL.vcxproj
+++ b/3rdparty/sdl2/SDL.vcxproj
@@ -195,6 +195,7 @@
     <ClInclude Include="SDL\src\SDL_error_c.h" />
     <ClInclude Include="SDL\src\SDL_hints_c.h" />
     <ClInclude Include="SDL\src\SDL_internal.h" />
+    <ClInclude Include="SDL\src\SDL_list.h" />
     <ClInclude Include="SDL\src\sensor\dummy\SDL_dummysensor.h" />
     <ClInclude Include="SDL\src\sensor\SDL_sensor_c.h" />
     <ClInclude Include="SDL\src\sensor\SDL_syssensor.h" />
@@ -350,6 +351,7 @@
     <ClCompile Include="SDL\src\SDL_dataqueue.c" />
     <ClCompile Include="SDL\src\SDL_error.c" />
     <ClCompile Include="SDL\src\SDL_hints.c" />
+    <ClCompile Include="SDL\src\SDL_list.c" />
     <ClCompile Include="SDL\src\SDL_log.c" />
     <ClCompile Include="SDL\src\sensor\dummy\SDL_dummysensor.c" />
     <ClCompile Include="SDL\src\sensor\SDL_sensor.c" />

--- a/3rdparty/sdl2/SDL.vcxproj.filters
+++ b/3rdparty/sdl2/SDL.vcxproj.filters
@@ -756,6 +756,7 @@
     <ClInclude Include="SDL\src\SDL_hints_c.h" />
     <ClInclude Include="SDL\src\SDL_internal.h" />
     <ClInclude Include="SDL\src\hidapi\SDL_hidapi_c.h" />
+    <ClInclude Include="SDL\src\SDL_list.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SDL\src\audio\wasapi\SDL_wasapi.c" />
@@ -1245,5 +1246,6 @@
     <ClCompile Include="SDL\src\power\windows\SDL_syspower.c">
       <Filter>power\windows</Filter>
     </ClCompile>
+    <ClCompile Include="SDL\src\SDL_list.c" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes

Fixes a crash on shutdown in Windows::Gaming::Input when controllers are connected. Crash manifests as a hang, because it tries to fire our already-torn-down pagefault handler.

### Rationale behind Changes

Making Qt not hang on shutdown.

### Suggested Testing Steps

Already tested, but @JordanTheToaster was the one who noticed this in the first place, so it would be good to get confirmation that the issue is fixed on his setup too.
