### PR TITLE
GS:SW: Clamp Z with unsigned clamp

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
@@ -1095,7 +1095,7 @@ void GSDrawScanlineCodeGenerator2::TestZ(const XYm& temp1, const XYm& temp2)
 			const u8 amt = (u8)((m_sel.zpsm & 0x3) * 8);
 			pcmpeqd(temp1, temp1);
 			psrld(temp1, amt);
-			pminsd(xym0, temp1);
+			pminud(xym0, temp1);
 		}
 
 		if (m_sel.zwrite)


### PR DESCRIPTION
### Description of Changes
Z is unsigned, so clamp it unsigned

### Rationale behind Changes
Correctness

### Suggested Testing Steps
Not sure any games hit this with the zequal test in place (which clamps outside of the JITed code), but removing zequal breaks trapt [trapt_zoverflow_zclamp.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/8653065/trapt_zoverflow_zclamp.gs.xz.zip) (see #6033)