### PR TITLE
DEV9: Fix double calling freeifaddrs()

### DIFF
--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -232,7 +232,6 @@ SocketAdapter::SocketAdapter()
 		if (!foundAdapter)
 		{
 			Console.Error("DEV9: Socket: Auto Selection Failed, Check You Connection or Manually Specify Adapter");
-			freeifaddrs(buffer);
 			return;
 		}
 	}
@@ -676,9 +675,6 @@ void SocketAdapter::reloadSettings()
 		foundAdapter = GetIfSelectedAdapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
 	else
 		foundAdapter = GetIfAutoAdapter(&adapter, &buffer);
-
-	if (foundAdapter)
-		freeifaddrs(buffer);
 #endif
 
 	const IP_Address ps2IP = {internalIP.bytes[0], internalIP.bytes[1], internalIP.bytes[2], 100};


### PR DESCRIPTION
### Description of Changes
Don't call freeifaddrs() twice on the same buffer

Issue was found during live settings reload, and in an error path.

### Rationale behind Changes
Fixes crashes when settings are reloading during emulation, which some gamefixes(?) trigger 

Should fix https://github.com/PCSX2/pcsx2/issues/6039

### Suggested Testing Steps
Test sockets on Linux, with games such as Ratchet & Clank: Up your arsenal, while having the socket selected in the network settings
