### PR TITLE
Qt: Fix nightly builds not showing version in title bar

### DIFF
--- a/pcsx2-qt/AboutDialog.cpp
+++ b/pcsx2-qt/AboutDialog.cpp
@@ -16,8 +16,8 @@
 #include "PrecompiledHeader.h"
 
 #include "AboutDialog.h"
+#include "QtHost.h"
 #include "QtUtils.h"
-#include "svnrev.h"
 #include <QtCore/QString>
 #include <QtWidgets/QDialog>
 
@@ -30,7 +30,7 @@ AboutDialog::AboutDialog(QWidget* parent)
 	setFixedSize(geometry().width(), geometry().height());
 
 	m_ui.scmversion->setTextInteractionFlags(Qt::TextSelectableByMouse);
-	m_ui.scmversion->setText(GIT_REV);
+	m_ui.scmversion->setText(QtHost::GetAppNameAndVersion());
 
 	m_ui.links->setTextInteractionFlags(Qt::TextBrowserInteraction);
 	m_ui.links->setOpenExternalLinks(true);

--- a/pcsx2-qt/Main.cpp
+++ b/pcsx2-qt/Main.cpp
@@ -25,14 +25,13 @@
 
 #include "CDVD/CDVD.h"
 #include "Frontend/GameList.h"
-#include "svnrev.h"
 
 #include "common/CrashHandler.h"
 
 static void PrintCommandLineVersion()
 {
 	QtHost::InitializeEarlyConsole();
-	std::fprintf(stderr, "PCSX2 Version %s\n", GIT_REV);
+	std::fprintf(stderr, "%s\n", (QtHost::GetAppNameAndVersion() + QtHost::GetAppConfigSuffix()).toUtf8().constData());
 	std::fprintf(stderr, "https://pcsx2.net/\n");
 	std::fprintf(stderr, "\n");
 }

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -43,7 +43,6 @@
 #include "Settings/GameListSettingsWidget.h"
 #include "Settings/InterfaceSettingsWidget.h"
 #include "SettingWidgetBinder.h"
-#include "svnrev.h"
 
 static constexpr char DISC_IMAGE_FILTER[] =
 	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.chd *.cso *.gz *.elf *.irx *.m3u *.gs *.gs.xz);;"
@@ -609,13 +608,9 @@ void MainWindow::updateStatusBarWidgetVisibility()
 
 void MainWindow::updateWindowTitle()
 {
-#if defined(_DEBUG)
-	QString main_title(QStringLiteral("PCSX2 [Debug] %1").arg(GIT_REV));
-	QString display_title(QStringLiteral("%1 [Debug]").arg(m_current_game_name));
-#else
-	QString main_title(QStringLiteral("PCSX2 %1").arg(GIT_REV));
-	QString display_title(m_current_game_name);
-#endif
+	QString suffix(QtHost::GetAppConfigSuffix());
+	QString main_title(QtHost::GetAppNameAndVersion() + suffix);
+	QString display_title(m_current_game_name + suffix);
 
 	if (!m_vm_valid || m_current_game_name.isEmpty())
 		display_title = main_title;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -42,6 +42,7 @@
 #include "GameList/GameListWidget.h"
 #include "MainWindow.h"
 #include "QtHost.h"
+#include "svnrev.h"
 
 #include "pcsx2/DebugTools/Debug.h"
 
@@ -399,6 +400,41 @@ void QtHost::RunOnUIThread(const std::function<void()>& func, bool block /*= fal
 	QMetaObject::invokeMethod(g_main_window, "runOnUIThread",
 		block ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
 		Q_ARG(const std::function<void()>&, func));
+}
+
+QString QtHost::GetAppNameAndVersion()
+{
+	QString ret;
+	if constexpr (!PCSX2_isReleaseVersion && GIT_TAGGED_COMMIT)
+	{
+		ret = QStringLiteral("PCSX2 Nightly - " GIT_TAG);
+	}
+	else if constexpr (PCSX2_isReleaseVersion)
+	{
+#define APPNAME_STRINGIZE(x) #x
+		ret = QStringLiteral("PCSX2 "
+			APPNAME_STRINGIZE(PCSX2_VersionHi) "."
+			APPNAME_STRINGIZE(PCSX2_VersionMid) "."
+			APPNAME_STRINGIZE(PCSX2_VersionLo));
+#undef APPNAME_STRINGIZE
+	}
+	else
+	{
+		return QStringLiteral("PCSX2 " GIT_REV);
+	}
+
+	return ret;
+}
+
+QString QtHost::GetAppConfigSuffix()
+{
+#if defined(PCSX2_DEBUG)
+	return QStringLiteral(" [Debug]");
+#elif defined(PCSX2_DEVBUILD)
+	return QStringLiteral(" [Devel]");
+#else
+	return QString();
+#endif
 }
 
 std::optional<std::vector<u8>> Host::ReadResourceFile(const char* filename)

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -20,6 +20,7 @@
 #include "pcsx2/Frontend/InputManager.h"
 #include "pcsx2/VMManager.h"
 #include <QtCore/QMetaType>
+#include <QtCore/QString>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -51,6 +52,12 @@ namespace QtHost
 
 	/// Executes a function on the UI thread.
 	void RunOnUIThread(const std::function<void()>& func, bool block = false);
+
+	/// Returns the application name and version, optionally including debug/devel config indicator.
+	QString GetAppNameAndVersion();
+
+	/// Returns the debug/devel config indicator.
+	QString GetAppConfigSuffix();
 
 	/// Thread-safe settings access.
 	SettingsInterface* GetBaseSettingsInterface();


### PR DESCRIPTION
### Description of Changes

See title. Also reduces the svnrev.h includes by putting it in one file for all use sites.

### Rationale behind Changes

It didn't display the version before.

### Suggested Testing Steps

Already tested, and no point checking the PR, because it won't show up as a tagged commit.
