### PR TITLE
Vulkan/Context: Don't write timestamp on an unreset query

### DIFF
--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -274,6 +274,7 @@ namespace Vulkan
 			u64 fence_counter = 0;
 			bool init_buffer_used = false;
 			bool needs_fence_wait = false;
+			bool timestamp_written = false;
 
 			std::vector<std::function<void()>> cleanup_resources;
 		};


### PR DESCRIPTION
### Description of Changes

See title. This spewed a warning in the validation layer when starting, and/or an error saying query wasn't ready depending on the driver when "Show GPU Usage" was enabled.

### Rationale behind Changes

Fixing my bugs.

### Suggested Testing Steps

Test with GPU usage shown, see if error disappears.
