### PR TITLE
GS: Texture replacement improvements

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -475,6 +475,8 @@ struct Pcsx2Config
 					DumpReplaceableTextures : 1,
 					DumpReplaceableMipmaps : 1,
 					DumpTexturesWithFMVActive : 1,
+					DumpDirectTextures : 1,
+					DumpPaletteTextures : 1,
 					LoadTextureReplacements : 1,
 					LoadTextureReplacementsAsync : 1,
 					PrecacheTextureReplacements : 1;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1649,6 +1649,38 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys){
 		 if (!pressed)
 			 HotkeyAdjustZoom(-1.0);
 	 }},
+	{"ToggleTextureDumping", "Graphics", "Toggle Texture Dumping", [](bool pressed) {
+		 if (!pressed)
+		 {
+			 EmuConfig.GS.DumpReplaceableTextures = !EmuConfig.GS.DumpReplaceableTextures;
+			 Host::AddKeyedOSDMessage("ToggleTextureReplacements", EmuConfig.GS.DumpReplaceableTextures ? "Texture dumping is now enabled." : "Texture dumping is now disabled.", 10.0f);
+			 GetMTGS().ApplySettings();
+		 }
+	 }},
+	{"ToggleTextureReplacements", "Graphics", "Toggle Texture Replacements", [](bool pressed) {
+		 if (!pressed)
+		 {
+			 EmuConfig.GS.LoadTextureReplacements = !EmuConfig.GS.LoadTextureReplacements;
+			 Host::AddKeyedOSDMessage("ToggleTextureReplacements", EmuConfig.GS.LoadTextureReplacements ? "Texture replacements are now enabled." : "Texture replacements are now disabled.", 10.0f);
+			 GetMTGS().ApplySettings();
+		 }
+	 }},
+	{"ReloadTextureReplacements", "Graphics", "Reload Texture Replacements", [](bool pressed) {
+		 if (!pressed)
+		 {
+			 if (!EmuConfig.GS.LoadTextureReplacements)
+			 {
+				 Host::AddKeyedOSDMessage("ReloadTextureReplacements", "Texture replacements are not enabled.", 10.0f);
+			 }
+			 else
+			 {
+				 Host::AddKeyedOSDMessage("ReloadTextureReplacements", "Reloading texture replacements...", 10.0f);
+				 GetMTGS().RunOnGSThread([]() {
+					 GSTextureReplacements::ReloadReplacementMap();
+				 });
+			 }
+		 }
+	 }},
 END_HOTKEY_LIST()
 
 #endif

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1326,6 +1326,8 @@ void GSApp::Init()
 	m_default_configuration["DumpReplaceableTextures"]                    = "0";
 	m_default_configuration["DumpReplaceableMipmaps"]                     = "0";
 	m_default_configuration["DumpTexturesWithFMVActive"]                  = "0";
+	m_default_configuration["DumpDirectTextures"]                         = "1";
+	m_default_configuration["DumpPaletteTextures"]                        = "1";
 	m_default_configuration["extrathreads"]                               = "2";
 	m_default_configuration["extrathreads_height"]                        = "4";
 	m_default_configuration["filter"]                                     = std::to_string(static_cast<s8>(BiFiltering::PS2));

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1543,7 +1543,8 @@ extern bool FMVstarted;
 GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, bool& paltex, const u32* clut, const GSVector2i* lod)
 {
 	// don't bother hashing if we're not dumping or replacing.
-	const bool dump = GSConfig.DumpReplaceableTextures && (!FMVstarted || GSConfig.DumpTexturesWithFMVActive);
+	const bool dump = GSConfig.DumpReplaceableTextures && (!FMVstarted || GSConfig.DumpTexturesWithFMVActive) &&
+					  (clut ? GSConfig.DumpPaletteTextures : GSConfig.DumpDirectTextures);
 	const bool replace = GSConfig.LoadTextureReplacements;
 	const bool can_cache = CanCacheTextureSize(TEX0.TW, TEX0.TH);
 	if (!dump && !replace && !can_cache)

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -674,9 +674,6 @@ void GSTextureReplacements::SyncWorkerThread()
 void GSTextureReplacements::CancelPendingLoadsAndDumps()
 {
 	std::unique_lock<std::mutex> lock(s_worker_thread_mutex);
-	if (!s_worker_thread.joinable())
-		return;
-
 	while (!s_worker_thread_queue.empty())
 		s_worker_thread_queue.pop();
 	s_async_loaded_textures.clear();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -336,6 +336,8 @@ Pcsx2Config::GSOptions::GSOptions()
 	DumpReplaceableTextures = false;
 	DumpReplaceableMipmaps = false;
 	DumpTexturesWithFMVActive = false;
+	DumpDirectTextures = true;
+	DumpPaletteTextures = true;
 	LoadTextureReplacements = false;
 	LoadTextureReplacementsAsync = true;
 	PrecacheTextureReplacements = false;
@@ -551,12 +553,14 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBoolEx(SaveFrame, "savef");
 	GSSettingBoolEx(SaveTexture, "savet");
 	GSSettingBoolEx(SaveDepth, "savez");
-	GSSettingBoolEx(DumpReplaceableTextures, "DumpReplaceableTextures");
-	GSSettingBoolEx(DumpReplaceableMipmaps, "DumpReplaceableMipmaps");
-	GSSettingBoolEx(DumpTexturesWithFMVActive, "DumpTexturesWithFMVActive");
-	GSSettingBoolEx(LoadTextureReplacements, "LoadTextureReplacements");
-	GSSettingBoolEx(LoadTextureReplacementsAsync, "LoadTextureReplacementsAsync");
-	GSSettingBoolEx(PrecacheTextureReplacements, "PrecacheTextureReplacements");
+	GSSettingBool(DumpReplaceableTextures);
+	GSSettingBool(DumpReplaceableMipmaps);
+	GSSettingBool(DumpTexturesWithFMVActive);
+	GSSettingBool(DumpDirectTextures);
+	GSSettingBool(DumpPaletteTextures);
+	GSSettingBool(LoadTextureReplacements);
+	GSSettingBool(LoadTextureReplacementsAsync);
+	GSSettingBool(PrecacheTextureReplacements);
 
 	GSSettingIntEnumEx(InterlaceMode, "deinterlace");
 


### PR DESCRIPTION
### Description of Changes

 - Fix to-dump list not getting purged/cancelled on shutdown (could leak memory).
 - Add option to filter dumps to palette or direct textures (useful for Dark Cloud, probably others).
 - Add hotkeys for toggling dumping, replacement, and reloading replacement textures.

NOTE: The new options are not present in the UI deliberately to prevent clogging it up, as the potential use cases are pretty small, and that section of settings is already very crowded. The ones to set are `DumpDirectTextures` and `DumpPaletteTextures`.

### Rationale behind Changes

QOL.

### Suggested Testing Steps

Test new stuff.
