### PR TITLE
Misc: Remove __fastcall, __fc, __concall and friends

### DIFF
--- a/common/AlignedMalloc.cpp
+++ b/common/AlignedMalloc.cpp
@@ -21,7 +21,7 @@
 #include "common/AlignedMalloc.h"
 #include "common/Assertions.h"
 
-void* __fastcall _aligned_malloc(size_t size, size_t align)
+void* _aligned_malloc(size_t size, size_t align)
 {
 	pxAssert(align < 0x10000);
 #if defined(__USE_ISOC11) && !defined(ASAN_WORKAROUND) // not supported yet on gcc 4.9
@@ -33,7 +33,7 @@ void* __fastcall _aligned_malloc(size_t size, size_t align)
 #endif
 }
 
-void* __fastcall pcsx2_aligned_realloc(void* handle, size_t new_size, size_t align, size_t old_size)
+void* pcsx2_aligned_realloc(void* handle, size_t new_size, size_t align, size_t old_size)
 {
 	pxAssert(align < 0x10000);
 

--- a/common/AlignedMalloc.h
+++ b/common/AlignedMalloc.h
@@ -50,8 +50,8 @@
 
 // aligned_malloc: Implement/declare linux equivalents here!
 #if !defined(_MSC_VER)
-extern void* __fastcall _aligned_malloc(size_t size, size_t align);
-extern void* __fastcall pcsx2_aligned_realloc(void* handle, size_t new_size, size_t align, size_t old_size);
+extern void* _aligned_malloc(size_t size, size_t align);
+extern void* pcsx2_aligned_realloc(void* handle, size_t new_size, size_t align, size_t old_size);
 extern void _aligned_free(void* pmem);
 #else
 #define pcsx2_aligned_realloc(handle, new_size, align, old_size) \

--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -90,11 +90,11 @@ void MSW_OutputDebugString(const wxString& text)
 //  ConsoleNull
 // --------------------------------------------------------------------------------------
 
-static void __concall ConsoleNull_SetTitle(const wxString& title) {}
-static void __concall ConsoleNull_DoSetColor(ConsoleColors color) {}
-static void __concall ConsoleNull_Newline() {}
-static void __concall ConsoleNull_DoWrite(const wxString& fmt) {}
-static void __concall ConsoleNull_DoWriteLn(const wxString& fmt) {}
+static void ConsoleNull_SetTitle(const wxString& title) {}
+static void ConsoleNull_DoSetColor(ConsoleColors color) {}
+static void ConsoleNull_Newline() {}
+static void ConsoleNull_DoWrite(const wxString& fmt) {}
+static void ConsoleNull_DoWriteLn(const wxString& fmt) {}
 
 const IConsoleWriter ConsoleWriter_Null =
 	{
@@ -172,23 +172,23 @@ static __fi const char* GetLinuxConsoleColor(ConsoleColors color)
 #endif
 
 // One possible default write action at startup and shutdown is to use the stdout.
-static void __concall ConsoleStdout_DoWrite(const wxString& fmt)
+static void ConsoleStdout_DoWrite(const wxString& fmt)
 {
 	MSW_OutputDebugString(fmt);
 }
 
 // Default write action at startup and shutdown is to use the stdout.
-static void __concall ConsoleStdout_DoWriteLn(const wxString& fmt)
+static void ConsoleStdout_DoWriteLn(const wxString& fmt)
 {
 	MSW_OutputDebugString(fmt + L"\n");
 }
 
-static void __concall ConsoleStdout_Newline()
+static void ConsoleStdout_Newline()
 {
 	MSW_OutputDebugString(L"\n");
 }
 
-static void __concall ConsoleStdout_DoSetColor(ConsoleColors color)
+static void ConsoleStdout_DoSetColor(ConsoleColors color)
 {
 #if defined(__POSIX__)
 	if (!supports_color)
@@ -198,7 +198,7 @@ static void __concall ConsoleStdout_DoSetColor(ConsoleColors color)
 #endif
 }
 
-static void __concall ConsoleStdout_SetTitle(const wxString& title)
+static void ConsoleStdout_SetTitle(const wxString& title)
 {
 #if defined(__POSIX__)
 	if (supports_color)
@@ -225,12 +225,12 @@ const IConsoleWriter ConsoleWriter_Stdout =
 //  ConsoleAssert
 // --------------------------------------------------------------------------------------
 
-static void __concall ConsoleAssert_DoWrite(const wxString& fmt)
+static void ConsoleAssert_DoWrite(const wxString& fmt)
 {
 	pxFail(L"Console class has not been initialized; Message written:\n\t" + fmt);
 }
 
-static void __concall ConsoleAssert_DoWriteLn(const wxString& fmt)
+static void ConsoleAssert_DoWriteLn(const wxString& fmt)
 {
 	pxFail(L"Console class has not been initialized; Message written:\n\t" + fmt);
 }

--- a/common/Console.h
+++ b/common/Console.h
@@ -55,9 +55,6 @@ enum ConsoleColors
 static const ConsoleColors DefaultConsoleColor = Color_Default;
 
 
-// Use fastcall for the console; should be helpful in most cases
-#define __concall __fastcall
-
 // ----------------------------------------------------------------------------------------
 //  IConsoleWriter -- For printing messages to the console.
 // ----------------------------------------------------------------------------------------
@@ -73,22 +70,22 @@ struct IConsoleWriter
 {
 	// A direct console write, without tabbing or newlines.  Useful to devs who want to do quick
 	// logging of various junk; but should *not* be used in production code due.
-	void(__concall* WriteRaw)(const wxString& fmt);
+	void(* WriteRaw)(const wxString& fmt);
 
 	// WriteLn implementation for internal use only.  Bypasses tabbing, prefixing, and other
 	// formatting.
-	void(__concall* DoWriteLn)(const wxString& fmt);
+	void(* DoWriteLn)(const wxString& fmt);
 
 	// SetColor implementation for internal use only.
-	void(__concall* DoSetColor)(ConsoleColors color);
+	void(* DoSetColor)(ConsoleColors color);
 
 	// Special implementation of DoWrite that's pretty much for MSVC use only.
 	// All implementations should map to DoWrite, except Stdio which should map to Null.
 	// (This avoids circular/recursive stdio output)
-	void(__concall* DoWriteFromStdout)(const wxString& fmt);
+	void(* DoWriteFromStdout)(const wxString& fmt);
 
-	void(__concall* Newline)();
-	void(__concall* SetTitle)(const wxString& title);
+	void(* Newline)();
+	void(* SetTitle)(const wxString& title);
 
 	// internal value for indentation of individual lines.  Use the Indent() member to invoke.
 	int _imm_indentation;

--- a/common/Dependencies.h
+++ b/common/Dependencies.h
@@ -226,8 +226,8 @@ static const s64 _4gb = _1gb * 4;
 #define pxE_dev(english) pxExpandMsg((english))
 
 
-extern const wxChar* __fastcall pxExpandMsg(const wxChar* message);
-extern const wxChar* __fastcall pxGetTranslation(const wxChar* message);
+extern const wxChar* pxExpandMsg(const wxChar* message);
+extern const wxChar* pxGetTranslation(const wxChar* message);
 extern bool pxIsEnglish(int id);
 
 extern wxString fromUTF8(const std::string& str);

--- a/common/FastJmp.h
+++ b/common/FastJmp.h
@@ -30,6 +30,6 @@ struct fastjmp_buf
 };
 
 extern "C" {
-int __fastcall fastjmp_set(fastjmp_buf* buf);
-__noreturn void __fastcall fastjmp_jmp(const fastjmp_buf* buf, int ret);
+int fastjmp_set(fastjmp_buf* buf);
+__noreturn void fastjmp_jmp(const fastjmp_buf* buf, int ret);
 }

--- a/common/Pcsx2Defs.h
+++ b/common/Pcsx2Defs.h
@@ -103,16 +103,19 @@ static const int __pagesize = PCSX2_PAGESIZE;
 // --------------------------------------------------------------------------------------
 
 	#define __assume(cond) do { if (!(cond)) __builtin_unreachable(); } while(0)
-	#define CALLBACK __attribute__((stdcall))
+
+	// SysV ABI passes vector parameters through registers unconditionally.
+	#ifndef _WIN32
+		#define __vectorcall
+		#define CALLBACK
+	#else
+		#define CALLBACK __attribute__((stdcall))
+	#endif
 
 	// Inlining note: GCC needs ((unused)) attributes defined on inlined functions to suppress
 	// warnings when a static inlined function isn't used in the scope of a single file (which
 	// happens *by design* like all the friggen time >_<)
 
-	#ifndef __fastcall
-		#define __fastcall
-	#endif
-	#define __vectorcall __fastcall
 	#define _inline __inline__ __attribute__((unused))
 	#ifdef NDEBUG
 		#define __forceinline __attribute__((always_inline, unused))
@@ -148,7 +151,6 @@ static const int __pagesize = PCSX2_PAGESIZE;
 
 #define __ri __releaseinline
 #define __fi __forceinline
-#define __fc __fastcall
 
 // Makes sure that if anyone includes xbyak, it doesn't do anything bad
 #define XBYAK_ENABLE_OMITTED_OPERAND

--- a/common/pxTranslate.cpp
+++ b/common/pxTranslate.cpp
@@ -14,7 +14,6 @@
  */
 
 #include <wx/wx.h>
-#include "common/Pcsx2Defs.h" // __fastcall
 
 bool pxIsEnglish(int id)
 {
@@ -25,12 +24,12 @@ bool pxIsEnglish(int id)
 //  pxExpandMsg  -- an Iconized Text Translator
 //  Was replaced by a standard implementation of wxGetTranslation
 // --------------------------------------------------------------------------------------
-const wxChar* __fastcall pxExpandMsg(const wxChar* message)
+const wxChar* pxExpandMsg(const wxChar* message)
 {
 	return wxGetTranslation(message).wc_str();
 }
 
-const wxChar* __fastcall pxGetTranslation(const wxChar* message)
+const wxChar* pxGetTranslation(const wxChar* message)
 {
 	return wxGetTranslation(message).wc_str();
 }

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -544,12 +544,12 @@ static HANDLE s_old_console_stdin = NULL;
 static HANDLE s_old_console_stdout = NULL;
 static HANDLE s_old_console_stderr = NULL;
 
-static void __concall ConsoleWinQt_SetTitle(const wxString& title)
+static void ConsoleWinQt_SetTitle(const wxString& title)
 {
 	SetConsoleTitleW(title.wc_str());
 }
 
-static void __concall ConsoleWinQt_DoSetColor(ConsoleColors color)
+static void ConsoleWinQt_DoSetColor(ConsoleColors color)
 {
 	if (!s_console_handle)
 		return;
@@ -583,7 +583,7 @@ static void __concall ConsoleWinQt_DoSetColor(ConsoleColors color)
 	WriteConsoleW(s_console_handle, colortext, std::wcslen(colortext), &written, nullptr);
 }
 
-static void __concall ConsoleWinQt_Newline()
+static void ConsoleWinQt_Newline()
 {
 	if (!s_console_handle)
 		return;
@@ -595,7 +595,7 @@ static void __concall ConsoleWinQt_Newline()
 	WriteConsoleW(s_console_handle, L"\n", 1, &written, nullptr);
 }
 
-static void __concall ConsoleWinQt_DoWrite(const wxString& fmt)
+static void ConsoleWinQt_DoWrite(const wxString& fmt)
 {
 	if (!s_console_handle)
 		return;
@@ -607,7 +607,7 @@ static void __concall ConsoleWinQt_DoWrite(const wxString& fmt)
 	WriteConsoleW(s_console_handle, fmt.wc_str(), static_cast<DWORD>(fmt.size()), &written, nullptr);
 }
 
-static void __concall ConsoleWinQt_DoWriteLn(const wxString& fmt)
+static void ConsoleWinQt_DoWriteLn(const wxString& fmt)
 {
 	if (!s_console_handle)
 		return;

--- a/pcsx2/COP0.cpp
+++ b/pcsx2/COP0.cpp
@@ -36,7 +36,7 @@ __ri void cpuUpdateOperationMode() {
 	//}
 }
 
-void __fastcall WriteCP0Status(u32 value) {
+void WriteCP0Status(u32 value) {
 
 	//DMA_LOG("COP0 Status write = 0x%08x", value);
 
@@ -44,7 +44,7 @@ void __fastcall WriteCP0Status(u32 value) {
     cpuSetNextEventDelta(4);
 }
 
-void __fastcall WriteCP0Config(u32 value) {
+void WriteCP0Config(u32 value) {
 	// Protect the read-only ICacheSize (IC) and DataCacheSize (DC) bits
 	cpuRegs.CP0.n.Config = value & ~0xFC0;
 	cpuRegs.CP0.n.Config |= 0x440;

--- a/pcsx2/COP0.h
+++ b/pcsx2/COP0.h
@@ -16,8 +16,8 @@
 #ifndef __COP0_H__
 #define __COP0_H__
 
-extern void __fastcall WriteCP0Status(u32 value);
-extern void __fastcall WriteCP0Config(u32 value);
+extern void WriteCP0Status(u32 value);
+extern void WriteCP0Config(u32 value);
 extern void cpuUpdateOperationMode();
 extern void WriteTLB(int i);
 extern void UnmapTLB(int i);

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -31,7 +31,7 @@ std::vector<MemCheck *> CBreakPoints::cleanupMemChecks_;
 bool CBreakPoints::breakpointTriggered_ = false;
 
 // called from the dynarec
-u32 __fastcall standardizeBreakpointAddress(u32 addr)
+u32 standardizeBreakpointAddress(u32 addr)
 {
 	if (addr >= 0xFFFF8000)
 		return addr;

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -169,4 +169,4 @@ private:
 
 
 // called from the dynarec
-u32 __fastcall standardizeBreakpointAddress(u32 addr);
+u32 standardizeBreakpointAddress(u32 addr);

--- a/pcsx2/FiFo.cpp
+++ b/pcsx2/FiFo.cpp
@@ -39,7 +39,7 @@
 // 0x6000 - 0x7000 : GS    (all registers map to 0x6000)
 // 0x7000 - 0x8000 : IPU   (registers map to 0x7000 and 0x7010, respectively)
 
-void __fastcall ReadFIFO_VIF1(mem128_t* out)
+void ReadFIFO_VIF1(mem128_t* out)
 {
 	if (vif1Regs.stat.test(VIF1_STAT_INT | VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
 		DevCon.Warning("Reading from vif1 fifo when stalled");
@@ -69,7 +69,7 @@ void __fastcall ReadFIFO_VIF1(mem128_t* out)
 //////////////////////////////////////////////////////////////////////////
 // WriteFIFO Pages
 //
-void __fastcall WriteFIFO_VIF0(const mem128_t* value)
+void WriteFIFO_VIF0(const mem128_t* value)
 {
 	VIF_LOG("WriteFIFO/VIF0 <- %ls", WX_STR(value->ToString()));
 
@@ -91,7 +91,7 @@ void __fastcall WriteFIFO_VIF0(const mem128_t* value)
 	pxAssertDev(ret, "vif stall code not implemented");
 }
 
-void __fastcall WriteFIFO_VIF1(const mem128_t* value)
+void WriteFIFO_VIF1(const mem128_t* value)
 {
 	VIF_LOG("WriteFIFO/VIF1 <- %ls", WX_STR(value->ToString()));
 
@@ -131,7 +131,7 @@ void __fastcall WriteFIFO_VIF1(const mem128_t* value)
 	pxAssertDev(ret, "vif stall code not implemented");
 }
 
-void __fastcall WriteFIFO_GIF(const mem128_t* value)
+void WriteFIFO_GIF(const mem128_t* value)
 {
 	GUNIT_LOG("WriteFIFO_GIF()");
 	if ((!gifUnit.CanDoPath3() || gif_fifo.fifoSize > 0))

--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -215,7 +215,7 @@ __fi void gsWrite32(u32 mem, u32 value)
 //////////////////////////////////////////////////////////////////////////
 // GS Write 64 bit
 
-void __fastcall gsWrite64_generic( u32 mem, const mem64_t* value )
+void gsWrite64_generic( u32 mem, const mem64_t* value )
 {
 	const u32* const srcval32 = (u32*)value;
 	GIF_LOG("GS Write64 at %8.8lx with data %8.8x_%8.8x", mem, srcval32[1], srcval32[0]);
@@ -223,14 +223,14 @@ void __fastcall gsWrite64_generic( u32 mem, const mem64_t* value )
 	*(u64*)PS2GS_BASE(mem) = *value;
 }
 
-void __fastcall gsWrite64_page_00( u32 mem, const mem64_t* value )
+void gsWrite64_page_00( u32 mem, const mem64_t* value )
 {
 	s_GSRegistersWritten |= (mem == GS_DISPFB1 || mem == GS_DISPFB2 || mem == GS_PMODE);
 
 	gsWrite64_generic( mem, value );
 }
 
-void __fastcall gsWrite64_page_01( u32 mem, const mem64_t* value )
+void gsWrite64_page_01( u32 mem, const mem64_t* value )
 {
 	GIF_LOG("GS Write64 at %8.8lx with data %8.8x_%8.8x", mem, (u32*)value[1], (u32*)value[0]);
 
@@ -266,12 +266,12 @@ void __fastcall gsWrite64_page_01( u32 mem, const mem64_t* value )
 //////////////////////////////////////////////////////////////////////////
 // GS Write 128 bit
 
-void __fastcall gsWrite128_page_00( u32 mem, const mem128_t* value )
+void gsWrite128_page_00( u32 mem, const mem128_t* value )
 {
 	gsWrite128_generic( mem, value );
 }
 
-void __fastcall gsWrite128_page_01( u32 mem, const mem128_t* value )
+void gsWrite128_page_01( u32 mem, const mem128_t* value )
 {
 	switch( mem )
 	{
@@ -287,7 +287,7 @@ void __fastcall gsWrite128_page_01( u32 mem, const mem128_t* value )
 	gsWrite128_generic( mem, value );
 }
 
-void __fastcall gsWrite128_generic( u32 mem, const mem128_t* value )
+void gsWrite128_generic( u32 mem, const mem128_t* value )
 {
 	const u32* const srcval32 = (u32*)value;
 

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -449,13 +449,13 @@ extern void gsWrite8(u32 mem, u8 value);
 extern void gsWrite16(u32 mem, u16 value);
 extern void gsWrite32(u32 mem, u32 value);
 
-extern void __fastcall gsWrite64_page_00( u32 mem, const mem64_t* value );
-extern void __fastcall gsWrite64_page_01( u32 mem, const mem64_t* value );
-extern void __fastcall gsWrite64_generic( u32 mem, const mem64_t* value );
+extern void gsWrite64_page_00( u32 mem, const mem64_t* value );
+extern void gsWrite64_page_01( u32 mem, const mem64_t* value );
+extern void gsWrite64_generic( u32 mem, const mem64_t* value );
 
-extern void __fastcall gsWrite128_page_00( u32 mem, const mem128_t* value );
-extern void __fastcall gsWrite128_page_01( u32 mem, const mem128_t* value );
-extern void __fastcall gsWrite128_generic( u32 mem, const mem128_t* value );
+extern void gsWrite128_page_00( u32 mem, const mem128_t* value );
+extern void gsWrite128_page_01( u32 mem, const mem128_t* value );
+extern void gsWrite128_generic( u32 mem, const mem128_t* value );
 
 extern u8   gsRead8(u32 mem);
 extern u16  gsRead16(u32 mem);

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -69,7 +69,7 @@ class IDrawScanline : public GSAlignedClass<32>
 {
 public:
 	typedef void (*SetupPrimPtr)(const GSVertexSW* vertex, const u32* index, const GSVertexSW& dscan);
-	typedef void(__fastcall* DrawScanlinePtr)(int pixels, int left, int top, const GSVertexSW& scan);
+	typedef void (*DrawScanlinePtr)(int pixels, int left, int top, const GSVertexSW& scan);
 	typedef void (IDrawScanline::*DrawRectPtr)(const GSVector4i& r, const GSVertexSW& v); // TODO: jit
 
 protected:

--- a/pcsx2/HwRead.cpp
+++ b/pcsx2/HwRead.cpp
@@ -36,7 +36,7 @@ static __fi void IntCHackCheck()
 template< uint page > RETURNS_R128 _hwRead128(u32 mem);
 
 template< uint page, bool intcstathack >
-mem32_t __fastcall _hwRead32(u32 mem)
+mem32_t _hwRead32(u32 mem)
 {
 	pxAssume( (mem & 0x03) == 0 );
 
@@ -204,14 +204,14 @@ mem32_t __fastcall _hwRead32(u32 mem)
 }
 
 template< uint page >
-mem32_t __fastcall hwRead32(u32 mem)
+mem32_t hwRead32(u32 mem)
 {
 	mem32_t retval = _hwRead32<page,false>(mem);
 	eeHwTraceLog( mem, retval, true );
 	return retval;
 }
 
-mem32_t __fastcall hwRead32_page_0F_INTC_HACK(u32 mem)
+mem32_t hwRead32_page_0F_INTC_HACK(u32 mem)
 {
 	mem32_t retval = _hwRead32<0x0f,true>(mem);
 	eeHwTraceLog( mem, retval, true );
@@ -223,14 +223,14 @@ mem32_t __fastcall hwRead32_page_0F_INTC_HACK(u32 mem)
 // --------------------------------------------------------------------------------------
 
 template< uint page >
-mem8_t __fastcall _hwRead8(u32 mem)
+mem8_t _hwRead8(u32 mem)
 {
 	u32 ret32 = _hwRead32<page, false>(mem & ~0x03);
 	return ((u8*)&ret32)[mem & 0x03];
 }
 
 template< uint page >
-mem8_t __fastcall hwRead8(u32 mem)
+mem8_t hwRead8(u32 mem)
 {
 	mem8_t ret8 = _hwRead8<page>(mem);
 	eeHwTraceLog( mem, ret8, true );
@@ -238,7 +238,7 @@ mem8_t __fastcall hwRead8(u32 mem)
 }
 
 template< uint page >
-mem16_t __fastcall _hwRead16(u32 mem)
+mem16_t _hwRead16(u32 mem)
 {
 	pxAssume( (mem & 0x01) == 0 );
 
@@ -247,14 +247,14 @@ mem16_t __fastcall _hwRead16(u32 mem)
 }
 
 template< uint page >
-mem16_t __fastcall hwRead16(u32 mem)
+mem16_t hwRead16(u32 mem)
 {
 	u16 ret16 = _hwRead16<page>(mem);
 	eeHwTraceLog( mem, ret16, true );
 	return ret16;
 }
 
-mem16_t __fastcall hwRead16_page_0F_INTC_HACK(u32 mem)
+mem16_t hwRead16_page_0F_INTC_HACK(u32 mem)
 {
 	pxAssume( (mem & 0x01) == 0 );
 
@@ -393,12 +393,12 @@ RETURNS_R128 hwRead128(u32 mem)
 }
 
 #define InstantizeHwRead(pageidx) \
-	template mem8_t __fastcall hwRead8<pageidx>(u32 mem); \
-	template mem16_t __fastcall hwRead16<pageidx>(u32 mem); \
-	template mem32_t __fastcall hwRead32<pageidx>(u32 mem); \
+	template mem8_t hwRead8<pageidx>(u32 mem); \
+	template mem16_t hwRead16<pageidx>(u32 mem); \
+	template mem32_t hwRead32<pageidx>(u32 mem); \
 	template RETURNS_R64 hwRead64<pageidx>(u32 mem); \
 	template RETURNS_R128 hwRead128<pageidx>(u32 mem); \
-	template mem32_t __fastcall _hwRead32<pageidx, false>(u32 mem);
+	template mem32_t _hwRead32<pageidx, false>(u32 mem);
 
 InstantizeHwRead(0x00);	InstantizeHwRead(0x08);
 InstantizeHwRead(0x01);	InstantizeHwRead(0x09);

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -38,13 +38,13 @@ using namespace R5900;
 #define HELPSWITCH(m) (((m)>>4) & 0xff)
 #define mcase(src) case HELPSWITCH(src)
 
-template< uint page > void __fastcall _hwWrite8(u32 mem, u8 value);
-template< uint page > void __fastcall _hwWrite16(u32 mem, u8 value);
-template< uint page > void __fastcall _hwWrite128(u32 mem, u8 value);
+template< uint page > void _hwWrite8(u32 mem, u8 value);
+template< uint page > void _hwWrite16(u32 mem, u8 value);
+template< uint page > void _hwWrite128(u32 mem, u8 value);
 
 
 template<uint page>
-void __fastcall _hwWrite32( u32 mem, u32 value )
+void _hwWrite32( u32 mem, u32 value )
 {
 	pxAssume( (mem & 0x03) == 0 );
 
@@ -275,7 +275,7 @@ void __fastcall _hwWrite32( u32 mem, u32 value )
 }
 
 template<uint page>
-void __fastcall hwWrite32( u32 mem, u32 value )
+void hwWrite32( u32 mem, u32 value )
 {
 	eeHwTraceLog( mem, value, false );
 	_hwWrite32<page>( mem, value );
@@ -286,7 +286,7 @@ void __fastcall hwWrite32( u32 mem, u32 value )
 // --------------------------------------------------------------------------------------
 
 template< uint page >
-void __fastcall _hwWrite8(u32 mem, u8 value)
+void _hwWrite8(u32 mem, u8 value)
 {
 #if PSX_EXTRALOGS
 	if ((mem & 0x1000ff00) == 0x1000f300) DevCon.Warning("8bit Write to SIF Register %x value %x wibble", mem, value);
@@ -336,14 +336,14 @@ void __fastcall _hwWrite8(u32 mem, u8 value)
 }
 
 template< uint page >
-void __fastcall hwWrite8(u32 mem, u8 value)
+void hwWrite8(u32 mem, u8 value)
 {
 	eeHwTraceLog( mem, value, false );
 	_hwWrite8<page>(mem, value);
 }
 
 template< uint page >
-void __fastcall _hwWrite16(u32 mem, u16 value)
+void _hwWrite16(u32 mem, u16 value)
 {
 	pxAssume( (mem & 0x01) == 0 );
 #if PSX_EXTRALOGS
@@ -367,14 +367,14 @@ void __fastcall _hwWrite16(u32 mem, u16 value)
 }
 
 template< uint page >
-void __fastcall hwWrite16(u32 mem, u16 value)
+void hwWrite16(u32 mem, u16 value)
 {
 	eeHwTraceLog( mem, value, false );
 	_hwWrite16<page>(mem, value);
 }
 
 template<uint page>
-void __fastcall _hwWrite64( u32 mem, const mem64_t* srcval )
+void _hwWrite64( u32 mem, const mem64_t* srcval )
 {
 	pxAssume( (mem & 0x07) == 0 );
 
@@ -413,14 +413,14 @@ void __fastcall _hwWrite64( u32 mem, const mem64_t* srcval )
 }
 
 template<uint page>
-void __fastcall hwWrite64( u32 mem, const mem64_t* srcval )
+void hwWrite64( u32 mem, const mem64_t* srcval )
 {
 	eeHwTraceLog( mem, *srcval, false );
 	_hwWrite64<page>(mem, srcval);
 }
 
 template< uint page >
-void __fastcall _hwWrite128(u32 mem, const mem128_t* srcval)
+void _hwWrite128(u32 mem, const mem128_t* srcval)
 {
 	pxAssume( (mem & 0x0f) == 0 );
 
@@ -477,18 +477,18 @@ void __fastcall _hwWrite128(u32 mem, const mem128_t* srcval)
 }
 
 template< uint page >
-void __fastcall hwWrite128(u32 mem, const mem128_t* srcval)
+void hwWrite128(u32 mem, const mem128_t* srcval)
 {
 	eeHwTraceLog( mem, *srcval, false );
 	_hwWrite128<page>(mem, srcval);
 }
 
 #define InstantizeHwWrite(pageidx) \
-	template void __fastcall hwWrite8<pageidx>(u32 mem, mem8_t value); \
-	template void __fastcall hwWrite16<pageidx>(u32 mem, mem16_t value); \
-	template void __fastcall hwWrite32<pageidx>(u32 mem, mem32_t value); \
-	template void __fastcall hwWrite64<pageidx>(u32 mem, const mem64_t* srcval); \
-	template void __fastcall hwWrite128<pageidx>(u32 mem, const mem128_t* srcval);
+	template void hwWrite8<pageidx>(u32 mem, mem8_t value); \
+	template void hwWrite16<pageidx>(u32 mem, mem16_t value); \
+	template void hwWrite32<pageidx>(u32 mem, mem32_t value); \
+	template void hwWrite64<pageidx>(u32 mem, const mem64_t* srcval); \
+	template void hwWrite128<pageidx>(u32 mem, const mem128_t* srcval);
 
 InstantizeHwWrite(0x00);	InstantizeHwWrite(0x08);
 InstantizeHwWrite(0x01);	InstantizeHwWrite(0x09);

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -159,7 +159,7 @@ void IPU_Fifo_Output::read(void *value, uint size)
 	}
 }
 
-void __fastcall ReadFIFO_IPUout(mem128_t* out)
+void ReadFIFO_IPUout(mem128_t* out)
 {
 	if (!pxAssertDev( ipuRegs.ctrl.OFC > 0, "Attempted read from IPUout's FIFO, but the FIFO is empty!" )) return;
 	ipu_fifo.out.read(out, 1);
@@ -168,7 +168,7 @@ void __fastcall ReadFIFO_IPUout(mem128_t* out)
 	// its either some glitchy game or a bug in pcsx2.
 }
 
-void __fastcall WriteFIFO_IPUin(const mem128_t* value)
+void WriteFIFO_IPUin(const mem128_t* value)
 {
 	IPU_LOG( "WriteFIFO/IPUin <- %ls", WX_STR(value->ToString()) );
 

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -199,7 +199,7 @@ static __fi void _doBranch_shared(u32 tar)
 	}
 }
 
-static void __fastcall doBranch( u32 target )
+static void doBranch( u32 target )
 {
 	_doBranch_shared( target );
 	cpuRegs.cycle += cpuBlockCycles >> 3;
@@ -207,7 +207,7 @@ static void __fastcall doBranch( u32 target )
 	intEventTest();
 }
 
-void __fastcall intDoBranch(u32 target)
+void intDoBranch(u32 target)
 {
 	//Console.WriteLn("Interpreter Branch ");
 	_doBranch_shared( target );

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -994,7 +994,7 @@ namespace R3000A
 			a0, a1, a2, a3);
 	}
 
-	void __fastcall irxImportLog_rec(u32 import_table, u16 index, const char* funcname)
+	void irxImportLog_rec(u32 import_table, u16 index, const char* funcname)
 	{
 		irxImportLog(iopMemReadString(import_table + 12, 8), index, funcname);
 	}

--- a/pcsx2/IopBios.h
+++ b/pcsx2/IopBios.h
@@ -77,7 +77,7 @@ namespace R3000A
 	irxHLE irxImportHLE(const std::string& libnam, u16 index);
 	irxDEBUG irxImportDebug(const std::string& libname, u16 index);
 	void irxImportLog(const std::string& libnameptr, u16 index, const char* funcname);
-	void __fastcall irxImportLog_rec(u32 import_table, u16 index, const char* funcname);
+	void irxImportLog_rec(u32 import_table, u16 index, const char* funcname);
 	int irxImportExec(u32 import_table, u16 index);
 
 	namespace ioman

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -168,7 +168,7 @@ void psxRcntInit()
 	psxNextsCounter = psxRegs.cycle;
 }
 
-static bool __fastcall _rcntFireInterrupt(int i, bool isOverflow)
+static bool _rcntFireInterrupt(int i, bool isOverflow)
 {
 	bool ret;
 
@@ -201,7 +201,7 @@ static bool __fastcall _rcntFireInterrupt(int i, bool isOverflow)
 
 	return ret;
 }
-static void __fastcall _rcntTestTarget(int i)
+static void _rcntTestTarget(int i)
 {
 	if (psxCounters[i].count < psxCounters[i].target)
 		return;

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -31,7 +31,7 @@ using namespace R3000A;
 // Dma8     in PsxSpd.c
 // Dma11/12 in PsxSio2.c
 
-static void __fastcall psxDmaGeneric(u32 madr, u32 bcr, u32 chcr, u32 spuCore)
+static void psxDmaGeneric(u32 madr, u32 bcr, u32 chcr, u32 spuCore)
 {
 	const char dmaNum = spuCore ? 7 : 4;
 

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -124,7 +124,7 @@ void iopMemoryReserve::Decommit()
 }
 
 
-u8 __fastcall iopMemRead8(u32 mem)
+u8 iopMemRead8(u32 mem)
 {
 	mem &= 0x1fffffff;
 	u32 t = mem >> 16;
@@ -162,7 +162,7 @@ u8 __fastcall iopMemRead8(u32 mem)
 	}
 }
 
-u16 __fastcall iopMemRead16(u32 mem)
+u16 iopMemRead16(u32 mem)
 {
 	mem &= 0x1fffffff;
 	u32 t = mem >> 16;
@@ -222,7 +222,7 @@ u16 __fastcall iopMemRead16(u32 mem)
 	}
 }
 
-u32 __fastcall iopMemRead32(u32 mem)
+u32 iopMemRead32(u32 mem)
 {
 	mem &= 0x1fffffff;
 	u32 t = mem >> 16;
@@ -286,7 +286,7 @@ u32 __fastcall iopMemRead32(u32 mem)
 	}
 }
 
-void __fastcall iopMemWrite8(u32 mem, u8 value)
+void iopMemWrite8(u32 mem, u8 value)
 {
 	mem &= 0x1fffffff;
 	u32 t = mem >> 16;
@@ -333,7 +333,7 @@ void __fastcall iopMemWrite8(u32 mem, u8 value)
 	}
 }
 
-void __fastcall iopMemWrite16(u32 mem, u16 value)
+void iopMemWrite16(u32 mem, u16 value)
 {
 	mem &= 0x1fffffff;
 	u32 t = mem >> 16;
@@ -406,7 +406,7 @@ void __fastcall iopMemWrite16(u32 mem, u16 value)
 	}
 }
 
-void __fastcall iopMemWrite32(u32 mem, u32 value)
+void iopMemWrite32(u32 mem, u32 value)
 {
 	mem &= 0x1fffffff;
 	u32 t = mem >> 16;

--- a/pcsx2/IopMem.h
+++ b/pcsx2/IopMem.h
@@ -76,51 +76,51 @@ extern void psxMemAlloc();
 extern void psxMemReset();
 extern void psxMemShutdown();
 
-extern u8   __fastcall iopMemRead8 (u32 mem);
-extern u16  __fastcall iopMemRead16(u32 mem);
-extern u32  __fastcall iopMemRead32(u32 mem);
-extern void __fastcall iopMemWrite8 (u32 mem, u8 value);
-extern void __fastcall iopMemWrite16(u32 mem, u16 value);
-extern void __fastcall iopMemWrite32(u32 mem, u32 value);
+extern u8   iopMemRead8 (u32 mem);
+extern u16  iopMemRead16(u32 mem);
+extern u32  iopMemRead32(u32 mem);
+extern void iopMemWrite8 (u32 mem, u8 value);
+extern void iopMemWrite16(u32 mem, u16 value);
+extern void iopMemWrite32(u32 mem, u32 value);
 
 std::string iopMemReadString(u32 mem, int maxlen = 65536);
 
 namespace IopMemory
 {
 	// Sif functions not made yet (will for future Iop improvements):
-	extern mem8_t __fastcall SifRead8( u32 iopaddr );
-	extern mem16_t __fastcall SifRead16( u32 iopaddr );
-	extern mem32_t __fastcall SifRead32( u32 iopaddr );
+	extern mem8_t SifRead8( u32 iopaddr );
+	extern mem16_t SifRead16( u32 iopaddr );
+	extern mem32_t SifRead32( u32 iopaddr );
 
-	extern void __fastcall SifWrite8( u32 iopaddr, mem8_t data );
-	extern void __fastcall SifWrite16( u32 iopaddr, mem16_t data );
-	extern void __fastcall SifWrite32( u32 iopaddr, mem32_t data );
+	extern void SifWrite8( u32 iopaddr, mem8_t data );
+	extern void SifWrite16( u32 iopaddr, mem16_t data );
+	extern void SifWrite32( u32 iopaddr, mem32_t data );
 
-	extern mem8_t __fastcall iopHwRead8_generic( u32 addr );
-	extern mem16_t __fastcall iopHwRead16_generic( u32 addr );
-	extern mem32_t __fastcall iopHwRead32_generic( u32 addr );
-	extern void __fastcall iopHwWrite8_generic( u32 addr, mem8_t val );
-	extern void __fastcall iopHwWrite16_generic( u32 addr, mem16_t val );
-	extern void __fastcall iopHwWrite32_generic( u32 addr, mem32_t val );
+	extern mem8_t iopHwRead8_generic( u32 addr );
+	extern mem16_t iopHwRead16_generic( u32 addr );
+	extern mem32_t iopHwRead32_generic( u32 addr );
+	extern void iopHwWrite8_generic( u32 addr, mem8_t val );
+	extern void iopHwWrite16_generic( u32 addr, mem16_t val );
+	extern void iopHwWrite32_generic( u32 addr, mem32_t val );
 
 
-	extern mem8_t __fastcall iopHwRead8_Page1( u32 iopaddr );
-	extern mem8_t __fastcall iopHwRead8_Page3( u32 iopaddr );
-	extern mem8_t __fastcall iopHwRead8_Page8( u32 iopaddr );
-	extern mem16_t __fastcall iopHwRead16_Page1( u32 iopaddr );
-	extern mem16_t __fastcall iopHwRead16_Page3( u32 iopaddr );
-	extern mem16_t __fastcall iopHwRead16_Page8( u32 iopaddr );
-	extern mem32_t __fastcall iopHwRead32_Page1( u32 iopaddr );
-	extern mem32_t __fastcall iopHwRead32_Page3( u32 iopaddr );
-	extern mem32_t __fastcall iopHwRead32_Page8( u32 iopaddr );
+	extern mem8_t iopHwRead8_Page1( u32 iopaddr );
+	extern mem8_t iopHwRead8_Page3( u32 iopaddr );
+	extern mem8_t iopHwRead8_Page8( u32 iopaddr );
+	extern mem16_t iopHwRead16_Page1( u32 iopaddr );
+	extern mem16_t iopHwRead16_Page3( u32 iopaddr );
+	extern mem16_t iopHwRead16_Page8( u32 iopaddr );
+	extern mem32_t iopHwRead32_Page1( u32 iopaddr );
+	extern mem32_t iopHwRead32_Page3( u32 iopaddr );
+	extern mem32_t iopHwRead32_Page8( u32 iopaddr );
 
-	extern void __fastcall iopHwWrite8_Page1( u32 iopaddr, mem8_t data );
-	extern void __fastcall iopHwWrite8_Page3( u32 iopaddr, mem8_t data );
-	extern void __fastcall iopHwWrite8_Page8( u32 iopaddr, mem8_t data );
-	extern void __fastcall iopHwWrite16_Page1( u32 iopaddr, mem16_t data );
-	extern void __fastcall iopHwWrite16_Page3( u32 iopaddr, mem16_t data );
-	extern void __fastcall iopHwWrite16_Page8( u32 iopaddr, mem16_t data );
-	extern void __fastcall iopHwWrite32_Page1( u32 iopaddr, mem32_t data );
-	extern void __fastcall iopHwWrite32_Page3( u32 iopaddr, mem32_t data );
-	extern void __fastcall iopHwWrite32_Page8( u32 iopaddr, mem32_t data );
+	extern void iopHwWrite8_Page1( u32 iopaddr, mem8_t data );
+	extern void iopHwWrite8_Page3( u32 iopaddr, mem8_t data );
+	extern void iopHwWrite8_Page8( u32 iopaddr, mem8_t data );
+	extern void iopHwWrite16_Page1( u32 iopaddr, mem16_t data );
+	extern void iopHwWrite16_Page3( u32 iopaddr, mem16_t data );
+	extern void iopHwWrite16_Page8( u32 iopaddr, mem16_t data );
+	extern void iopHwWrite32_Page1( u32 iopaddr, mem32_t data );
+	extern void iopHwWrite32_Page3( u32 iopaddr, mem32_t data );
+	extern void iopHwWrite32_Page8( u32 iopaddr, mem32_t data );
 }

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -212,15 +212,15 @@ void memMapUserMem()
 {
 }
 
-static mem8_t __fastcall nullRead8(u32 mem) {
+static mem8_t nullRead8(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
 	return 0;
 }
-static mem16_t __fastcall nullRead16(u32 mem) {
+static mem16_t nullRead16(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
 	return 0;
 }
-static mem32_t __fastcall nullRead32(u32 mem) {
+static mem32_t nullRead32(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
 	return 0;
 }
@@ -232,29 +232,29 @@ static RETURNS_R128 nullRead128(u32 mem) {
 	MEM_LOG("Read uninstalled memory at address %08x", mem);
 	return r128_zero();
 }
-static void __fastcall nullWrite8(u32 mem, mem8_t value)
+static void nullWrite8(u32 mem, mem8_t value)
 {
 	MEM_LOG("Write uninstalled memory at address %08x", mem);
 }
-static void __fastcall nullWrite16(u32 mem, mem16_t value)
+static void nullWrite16(u32 mem, mem16_t value)
 {
 	MEM_LOG("Write uninstalled memory at address %08x", mem);
 }
-static void __fastcall nullWrite32(u32 mem, mem32_t value)
+static void nullWrite32(u32 mem, mem32_t value)
 {
 	MEM_LOG("Write uninstalled memory at address %08x", mem);
 }
-static void __fastcall nullWrite64(u32 mem, const mem64_t *value)
+static void nullWrite64(u32 mem, const mem64_t *value)
 {
 	MEM_LOG("Write uninstalled memory at address %08x", mem);
 }
-static void __fastcall nullWrite128(u32 mem, const mem128_t *value)
+static void nullWrite128(u32 mem, const mem128_t *value)
 {
 	MEM_LOG("Write uninstalled memory at address %08x", mem);
 }
 
 template<int p>
-static mem8_t __fastcall _ext_memRead8 (u32 mem)
+static mem8_t _ext_memRead8 (u32 mem)
 {
 	switch (p)
 	{
@@ -277,7 +277,7 @@ static mem8_t __fastcall _ext_memRead8 (u32 mem)
 }
 
 template<int p>
-static mem16_t __fastcall _ext_memRead16(u32 mem)
+static mem16_t _ext_memRead16(u32 mem)
 {
 	switch (p)
 	{
@@ -307,7 +307,7 @@ static mem16_t __fastcall _ext_memRead16(u32 mem)
 }
 
 template<int p>
-static mem32_t __fastcall _ext_memRead32(u32 mem)
+static mem32_t _ext_memRead32(u32 mem)
 {
 	switch (p)
 	{
@@ -360,7 +360,7 @@ static RETURNS_R128 _ext_memRead128(u32 mem)
 }
 
 template<int p>
-static void __fastcall _ext_memWrite8 (u32 mem, mem8_t  value)
+static void _ext_memWrite8 (u32 mem, mem8_t  value)
 {
 	switch (p) {
 		case 3: // psh4
@@ -379,7 +379,7 @@ static void __fastcall _ext_memWrite8 (u32 mem, mem8_t  value)
 }
 
 template<int p>
-static void __fastcall _ext_memWrite16(u32 mem, mem16_t value)
+static void _ext_memWrite16(u32 mem, mem16_t value)
 {
 	switch (p) {
 		case 5: // ba0
@@ -400,7 +400,7 @@ static void __fastcall _ext_memWrite16(u32 mem, mem16_t value)
 }
 
 template<int p>
-static void __fastcall _ext_memWrite32(u32 mem, mem32_t value)
+static void _ext_memWrite32(u32 mem, mem32_t value)
 {
 	switch (p) {
 		case 6: // gsm
@@ -416,7 +416,7 @@ static void __fastcall _ext_memWrite32(u32 mem, mem32_t value)
 }
 
 template<int p>
-static void __fastcall _ext_memWrite64(u32 mem, const mem64_t* value)
+static void _ext_memWrite64(u32 mem, const mem64_t* value)
 {
 
 	/*switch (p) {
@@ -432,7 +432,7 @@ static void __fastcall _ext_memWrite64(u32 mem, const mem64_t* value)
 }
 
 template<int p>
-static void __fastcall _ext_memWrite128(u32 mem, const mem128_t *value)
+static void _ext_memWrite128(u32 mem, const mem128_t *value)
 {
 	/*switch (p) {
 		//case 1: // hwm
@@ -451,7 +451,7 @@ static void __fastcall _ext_memWrite128(u32 mem, const mem128_t *value)
 #define vtlb_RegisterHandlerTempl1(nam,t) vtlb_RegisterHandler(nam##Read8<t>,nam##Read16<t>,nam##Read32<t>,nam##Read64<t>,nam##Read128<t>, \
 															   nam##Write8<t>,nam##Write16<t>,nam##Write32<t>,nam##Write64<t>,nam##Write128<t>)
 
-typedef void __fastcall ClearFunc_t( u32 addr, u32 qwc );
+typedef void ClearFunc_t( u32 addr, u32 qwc );
 
 template<int vunum> static __fi void ClearVuFunc(u32 addr, u32 size) {
 	if (vunum) CpuVU1->Clear(addr, size);
@@ -459,21 +459,21 @@ template<int vunum> static __fi void ClearVuFunc(u32 addr, u32 size) {
 }
 
 // VU Micro Memory Reads...
-template<int vunum> static mem8_t __fc vuMicroRead8(u32 addr) {
+template<int vunum> static mem8_t vuMicroRead8(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	return vu->Micro[addr];
 }
-template<int vunum> static mem16_t __fc vuMicroRead16(u32 addr) {
+template<int vunum> static mem16_t vuMicroRead16(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	return *(u16*)&vu->Micro[addr];
 }
-template<int vunum> static mem32_t __fc vuMicroRead32(u32 addr) {
+template<int vunum> static mem32_t vuMicroRead32(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
@@ -497,7 +497,7 @@ template<int vunum> static RETURNS_R128 vuMicroRead128(u32 addr) {
 
 // Profiled VU writes: Happen very infrequently, with exception of BIOS initialization (at most twice per
 //   frame in-game, and usually none at all after BIOS), so cpu clears aren't much of a big deal.
-template<int vunum> static void __fc vuMicroWrite8(u32 addr,mem8_t data) {
+template<int vunum> static void vuMicroWrite8(u32 addr,mem8_t data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
@@ -510,7 +510,7 @@ template<int vunum> static void __fc vuMicroWrite8(u32 addr,mem8_t data) {
 		vu->Micro[addr] =data;
 	}
 }
-template<int vunum> static void __fc vuMicroWrite16(u32 addr, mem16_t data) {
+template<int vunum> static void vuMicroWrite16(u32 addr, mem16_t data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
@@ -523,7 +523,7 @@ template<int vunum> static void __fc vuMicroWrite16(u32 addr, mem16_t data) {
 		*(u16*)&vu->Micro[addr] =data;
 	}
 }
-template<int vunum> static void __fc vuMicroWrite32(u32 addr, mem32_t data) {
+template<int vunum> static void vuMicroWrite32(u32 addr, mem32_t data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	
@@ -536,7 +536,7 @@ template<int vunum> static void __fc vuMicroWrite32(u32 addr, mem32_t data) {
 		*(u32*)&vu->Micro[addr] =data;
 	}
 }
-template<int vunum> static void __fc vuMicroWrite64(u32 addr, const mem64_t* data) {
+template<int vunum> static void vuMicroWrite64(u32 addr, const mem64_t* data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 
@@ -550,7 +550,7 @@ template<int vunum> static void __fc vuMicroWrite64(u32 addr, const mem64_t* dat
 		*(u64*)&vu->Micro[addr] =data[0];
 	}
 }
-template<int vunum> static void __fc vuMicroWrite128(u32 addr, const mem128_t* data) {
+template<int vunum> static void vuMicroWrite128(u32 addr, const mem128_t* data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 
@@ -565,19 +565,19 @@ template<int vunum> static void __fc vuMicroWrite128(u32 addr, const mem128_t* d
 }
 
 // VU Data Memory Reads...
-template<int vunum> static mem8_t __fc vuDataRead8(u32 addr) {
+template<int vunum> static mem8_t vuDataRead8(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	return vu->Mem[addr];
 }
-template<int vunum> static mem16_t __fc vuDataRead16(u32 addr) {
+template<int vunum> static mem16_t vuDataRead16(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
 	return *(u16*)&vu->Mem[addr];
 }
-template<int vunum> static mem32_t __fc vuDataRead32(u32 addr) {
+template<int vunum> static mem32_t vuDataRead32(u32 addr) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) vu1Thread.WaitVU();
@@ -597,7 +597,7 @@ template<int vunum> static RETURNS_R128 vuDataRead128(u32 addr) {
 }
 
 // VU Data Memory Writes...
-template<int vunum> static void __fc vuDataWrite8(u32 addr, mem8_t data) {
+template<int vunum> static void vuDataWrite8(u32 addr, mem8_t data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) {
@@ -606,7 +606,7 @@ template<int vunum> static void __fc vuDataWrite8(u32 addr, mem8_t data) {
 	}
 	vu->Mem[addr] = data;
 }
-template<int vunum> static void __fc vuDataWrite16(u32 addr, mem16_t data) {
+template<int vunum> static void vuDataWrite16(u32 addr, mem16_t data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) {
@@ -615,7 +615,7 @@ template<int vunum> static void __fc vuDataWrite16(u32 addr, mem16_t data) {
 	}
 	*(u16*)&vu->Mem[addr] = data;
 }
-template<int vunum> static void __fc vuDataWrite32(u32 addr, mem32_t data) {
+template<int vunum> static void vuDataWrite32(u32 addr, mem32_t data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) {
@@ -624,7 +624,7 @@ template<int vunum> static void __fc vuDataWrite32(u32 addr, mem32_t data) {
 	}
 	*(u32*)&vu->Mem[addr] = data;
 }
-template<int vunum> static void __fc vuDataWrite64(u32 addr, const mem64_t* data) {
+template<int vunum> static void vuDataWrite64(u32 addr, const mem64_t* data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) {
@@ -633,7 +633,7 @@ template<int vunum> static void __fc vuDataWrite64(u32 addr, const mem64_t* data
 	}
 	*(u64*)&vu->Mem[addr] = data[0];
 }
-template<int vunum> static void __fc vuDataWrite128(u32 addr, const mem128_t* data) {
+template<int vunum> static void vuDataWrite128(u32 addr, const mem128_t* data) {
 	VURegs* vu = vunum ?  &VU1 :  &VU0;
 	addr      &= vunum ? 0x3fff: 0xfff;
 	if (vunum && THREAD_VU1) {

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -82,7 +82,7 @@ void psxShutdown() {
 	//psxCpu->Shutdown();
 }
 
-void __fastcall psxException(u32 code, u32 bd)
+void psxException(u32 code, u32 bd)
 {
 //	PSXCPU_LOG("psxException %x: %x, %x", code, psxHu32(0x1070), psxHu32(0x1074));
 	//Console.WriteLn("!! psxException %x: %x, %x", code, psxHu32(0x1070), psxHu32(0x1074));

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -198,7 +198,7 @@ extern R3000Acpu psxInt;
 extern R3000Acpu psxRec;
 
 extern void psxReset();
-extern void __fastcall psxException(u32 code, u32 step);
+extern void psxException(u32 code, u32 step);
 extern void iopEventTest();
 extern void psxMemReset();
 
@@ -214,6 +214,6 @@ extern void (*psxCP2[64])();
 extern void (*psxCP2BSC[32])();
 
 extern void psxBiosReset();
-extern bool __fastcall psxBiosCall();
+extern bool psxBiosCall();
 
 #endif /* __R3000A_H__ */

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -546,8 +546,8 @@ __fi void CPU_INT( EE_EventType n, s32 ecycle)
 	cpuSetNextEventDelta( cpuRegs.eCycle[n] );
 }
 
-// Called from recompilers; __fastcall define is mandatory.
-void __fastcall eeGameStarting()
+// Called from recompilers; define is mandatory.
+void eeGameStarting()
 {
 	if (!g_GameStarted)
 	{
@@ -616,8 +616,8 @@ int ParseArgumentString(u32 arg_block)
 	return argc;
 }
 
-// Called from recompilers; __fastcall define is mandatory.
-void __fastcall eeloadHook()
+// Called from recompilers; define is mandatory.
+void eeloadHook()
 {
 #ifndef PCSX2_CORE
 	const std::string elf_override(StringUtil::wxStringToUTF8String(GetCoreThread().GetElfOverride()));
@@ -736,9 +736,9 @@ void __fastcall eeloadHook()
 		g_GameLoading = true;
 }
 
-// Called from recompilers; __fastcall define is mandatory.
+// Called from recompilers; define is mandatory.
 // Only called if g_SkipBiosHack is true
-void __fastcall eeloadHook2()
+void eeloadHook2()
 {
 	if (EmuConfig.CurrentGameArgs.empty())
 		return;

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -266,7 +266,7 @@ void intSetBranch();
 
 // This is a special form of the interpreter's doBranch that is run from various
 // parts of the Recs (namely COP0's branch codes and stuff).
-void __fastcall intDoBranch(u32 target);
+void intDoBranch(u32 target);
 
 // modules loaded at hardcoded addresses by the kernel
 const u32 EEKERNEL_START	= 0;
@@ -275,9 +275,9 @@ const u32 EELOAD_START		= 0x82000;
 const u32 EELOAD_SIZE		= 0x20000; // overestimate for searching
 extern u32 g_eeloadMain, g_eeloadExec;
 
-extern void __fastcall eeGameStarting();
-extern void __fastcall eeloadHook();
-extern void __fastcall eeloadHook2();
+extern void eeGameStarting();
+extern void eeloadHook();
+extern void eeloadHook2();
 
 // --------------------------------------------------------------------------------------
 //  R5900cpu
@@ -426,8 +426,8 @@ extern void cpuTlbMissR(u32 addr, u32 bd);
 extern void cpuTlbMissW(u32 addr, u32 bd);
 extern void cpuTestHwInts();
 extern void cpuClearInt(uint n);
-extern void __fastcall GoemonPreloadTlb();
-extern void __fastcall GoemonUnloadTlb(u32 key);
+extern void GoemonPreloadTlb();
+extern void GoemonUnloadTlb(u32 key);
 
 extern void cpuSetNextEvent( u32 startCycle, s32 delta );
 extern void cpuSetNextEventDelta( s32 delta );

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -576,9 +576,9 @@ namespace SPU2Savestate
 {
 	struct DataBlock;
 
-	extern s32 __fastcall FreezeIt(DataBlock& spud);
-	extern s32 __fastcall ThawIt(DataBlock& spud);
-	extern s32 __fastcall SizeIt();
+	extern s32 FreezeIt(DataBlock& spud);
+	extern s32 ThawIt(DataBlock& spud);
+	extern s32 SizeIt();
 } // namespace SPU2Savestate
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/SPU2/spu2freeze.cpp
+++ b/pcsx2/SPU2/spu2freeze.cpp
@@ -48,7 +48,7 @@ struct SPU2Savestate::DataBlock
 	int PlayMode;
 };
 
-s32 __fastcall SPU2Savestate::FreezeIt(DataBlock& spud)
+s32 SPU2Savestate::FreezeIt(DataBlock& spud)
 {
 	spud.spu2id = SAVE_ID;
 	spud.version = SAVE_VERSION;
@@ -77,7 +77,7 @@ s32 __fastcall SPU2Savestate::FreezeIt(DataBlock& spud)
 	return 0;
 }
 
-s32 __fastcall SPU2Savestate::ThawIt(DataBlock& spud)
+s32 SPU2Savestate::ThawIt(DataBlock& spud)
 {
 	if (spud.spu2id != SAVE_ID || spud.version < SAVE_VERSION)
 	{
@@ -145,7 +145,7 @@ s32 __fastcall SPU2Savestate::ThawIt(DataBlock& spud)
 	return 0;
 }
 
-s32 __fastcall SPU2Savestate::SizeIt()
+s32 SPU2Savestate::SizeIt()
 {
 	return sizeof(DataBlock);
 }

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1123,7 +1123,7 @@ static __forceinline u16 GetLoWord(u32& src)
 }
 
 template <int CoreIdx, int VoiceIdx, int param>
-static void __fastcall RegWrite_VoiceParams(u16 value)
+static void RegWrite_VoiceParams(u16 value)
 {
 	const int core = CoreIdx;
 	const int voice = VoiceIdx;
@@ -1193,7 +1193,7 @@ static void __fastcall RegWrite_VoiceParams(u16 value)
 }
 
 template <int CoreIdx, int VoiceIdx, int address>
-static void __fastcall RegWrite_VoiceAddr(u16 value)
+static void RegWrite_VoiceAddr(u16 value)
 {
 	const int core = CoreIdx;
 	const int voice = VoiceIdx;
@@ -1272,7 +1272,7 @@ static void __fastcall RegWrite_VoiceAddr(u16 value)
 }
 
 template <int CoreIdx, int cAddr>
-static void __fastcall RegWrite_Core(u16 value)
+static void RegWrite_Core(u16 value)
 {
 	const int omem = cAddr;
 	const int core = CoreIdx;
@@ -1585,7 +1585,7 @@ static void __fastcall RegWrite_Core(u16 value)
 }
 
 template <int CoreIdx, int addr>
-static void __fastcall RegWrite_CoreExt(u16 value)
+static void RegWrite_CoreExt(u16 value)
 {
 	V_Core& thiscore = Cores[CoreIdx];
 	const int core = CoreIdx;
@@ -1661,7 +1661,7 @@ static void __fastcall RegWrite_CoreExt(u16 value)
 
 
 template <int core, int addr>
-static void __fastcall RegWrite_Reverb(u16 value)
+static void RegWrite_Reverb(u16 value)
 {
 	// Signal to the Reverb code that the effects buffers need to be re-aligned.
 	// This is both simple, efficient, and safe, since we only want to re-align
@@ -1676,19 +1676,19 @@ static void __fastcall RegWrite_Reverb(u16 value)
 }
 
 template <int addr>
-static void __fastcall RegWrite_SPDIF(u16 value)
+static void RegWrite_SPDIF(u16 value)
 {
 	*(regtable[addr >> 1]) = value;
 	UpdateSpdifMode();
 }
 
 template <int addr>
-static void __fastcall RegWrite_Raw(u16 value)
+static void RegWrite_Raw(u16 value)
 {
 	*(regtable[addr >> 1]) = value;
 }
 
-static void __fastcall RegWrite_Null(u16 value)
+static void RegWrite_Null(u16 value)
 {
 }
 
@@ -1727,7 +1727,7 @@ static void __fastcall RegWrite_Null(u16 value)
 //  tbl_reg_writes  - Register Write Function Invocation LUT
 // --------------------------------------------------------------------------------------
 
-typedef void __fastcall RegWriteHandler(u16 value);
+typedef void RegWriteHandler(u16 value);
 static RegWriteHandler* const tbl_reg_writes[0x401] =
 	{
 		VoiceParamsCore(0), // 0x000 -> 0x180

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -49,7 +49,7 @@ static __fi void vu0SetMicroFlags(u32* flags, u32 value)
 #endif
 }
 
-void __fastcall vu0ExecMicro(u32 addr) {
+void vu0ExecMicro(u32 addr) {
 	VUM_LOG("vu0ExecMicro %x", addr);
 
 	if(VU0.VI[REG_VPU_STAT].UL & 0x1) {

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -57,7 +57,7 @@ void vu1Finish(bool add_cycles) {
 	}
 }
 
-void __fastcall vu1ExecMicro(u32 addr)
+void vu1ExecMicro(u32 addr)
 {
 	if (THREAD_VU1) {
 		VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -95,7 +95,7 @@ public:
 	// C++ Calling Conventions are unstable, and some compilers don't even allow us to take the
 	// address of C++ methods.  We need to use a wrapper function to invoke the ExecuteBlock from
 	// recompiled code.
-	static void __fastcall ExecuteBlockJIT( BaseCpuProvider* cpu )
+	static void ExecuteBlockJIT( BaseCpuProvider* cpu )
 	{
 		cpu->Execute(1024);
 	}
@@ -134,7 +134,7 @@ public:
 	// Executes a Block based on EE delta time (see VUmicro.cpp)
 	virtual void ExecuteBlock(bool startUp=0);
 
-	static void __fastcall ExecuteBlockJIT(BaseVUmicroCPU* cpu, bool interlocked);
+	static void ExecuteBlockJIT(BaseVUmicroCPU* cpu, bool interlocked);
 
 	// VU1 sometimes needs to break execution on XGkick Path1 transfers if
 	// there is another gif path 2/3 transfer already taking place.
@@ -242,7 +242,7 @@ extern BaseVUmicroCPU* CpuVU1;
 
 // VU0
 extern void vu0ResetRegs();
-extern void __fastcall vu0ExecMicro(u32 addr);
+extern void vu0ExecMicro(u32 addr);
 extern void vu0Exec(VURegs* VU);
 extern void _vu0FinishMicro();
 extern void vu0Finish();
@@ -251,7 +251,7 @@ extern void iDumpVU0Registers();
 // VU1
 extern void vu1Finish(bool add_cycles);
 extern void vu1ResetRegs();
-extern void __fastcall vu1ExecMicro(u32 addr);
+extern void vu1ExecMicro(u32 addr);
 extern void vu1Exec(VURegs* VU);
 extern void iDumpVU1Registers();
 

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -220,7 +220,7 @@ __fi void _vuTestPipes(VURegs* VU)
 	}
 }
 
-static void __fastcall _vuFMACTestStall(VURegs* VU, u32 reg, u32 xyzw)
+static void _vuFMACTestStall(VURegs* VU, u32 reg, u32 xyzw)
 {
 	u32 i = 0;
 
@@ -335,7 +335,7 @@ __fi void _vuClearFMAC(VURegs* VU)
 	VU->fmaccount++;
 }
 
-static __ri void __fastcall _vuAddFMACStalls(VURegs* VU, _VURegsNum* VUregsn, bool isUpper)
+static __ri void _vuAddFMACStalls(VURegs* VU, _VURegsNum* VUregsn, bool isUpper)
 {
 	int i = VU->fmacwritepos;
 
@@ -362,7 +362,7 @@ static __ri void __fastcall _vuAddFMACStalls(VURegs* VU, _VURegsNum* VUregsn, bo
 }
 
 
-static __ri void __fastcall _vuFDIVAdd(VURegs* VU, int cycles)
+static __ri void _vuFDIVAdd(VURegs* VU, int cycles)
 {
 	VUM_LOG("adding FDIV pipe");
 
@@ -373,7 +373,7 @@ static __ri void __fastcall _vuFDIVAdd(VURegs* VU, int cycles)
 	VU->fdiv.statusflag = VU->statusflag;
 }
 
-static __ri void __fastcall _vuEFUAdd(VURegs* VU, int cycles)
+static __ri void _vuEFUAdd(VURegs* VU, int cycles)
 {
 	VUM_LOG("adding EFU pipe for %d cycles\n", cycles);
 
@@ -383,7 +383,7 @@ static __ri void __fastcall _vuEFUAdd(VURegs* VU, int cycles)
 	VU->efu.reg.F = VU->p.F;
 }
 
-static __ri void __fastcall _vuAddIALUStalls(VURegs* VU, _VURegsNum* VUregsn)
+static __ri void _vuAddIALUStalls(VURegs* VU, _VURegsNum* VUregsn)
 {
 
 	if (VUregsn->cycles == 0)
@@ -450,7 +450,7 @@ __fi void _vuBackupVI(VURegs* VU, u32 reg)
 /*   VU Upper instructions    */
 /******************************/
 #ifndef INT_VUDOUBLEHACK
-static float __fastcall vuDouble(u32 f)
+static float vuDouble(u32 f)
 {
 	switch (f & 0x7f800000)
 	{
@@ -3848,175 +3848,175 @@ static void VU0MI_XTOP() {}
 /*   VU Micromode Upper instructions    */
 /****************************************/
 
-static void __vuRegsCall VU0regsMI_ABS(_VURegsNum* VUregsn) { _vuRegsABS(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADD(_VURegsNum* VUregsn) { _vuRegsADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDi(_VURegsNum* VUregsn) { _vuRegsADDi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDq(_VURegsNum* VUregsn) { _vuRegsADDq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDx(_VURegsNum* VUregsn) { _vuRegsADDx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDy(_VURegsNum* VUregsn) { _vuRegsADDy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDz(_VURegsNum* VUregsn) { _vuRegsADDz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDw(_VURegsNum* VUregsn) { _vuRegsADDw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDA(_VURegsNum* VUregsn) { _vuRegsADDA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAi(_VURegsNum* VUregsn) { _vuRegsADDAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAq(_VURegsNum* VUregsn) { _vuRegsADDAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAx(_VURegsNum* VUregsn) { _vuRegsADDAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAy(_VURegsNum* VUregsn) { _vuRegsADDAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAz(_VURegsNum* VUregsn) { _vuRegsADDAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ADDAw(_VURegsNum* VUregsn) { _vuRegsADDAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUB(_VURegsNum* VUregsn) { _vuRegsSUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBi(_VURegsNum* VUregsn) { _vuRegsSUBi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBq(_VURegsNum* VUregsn) { _vuRegsSUBq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBx(_VURegsNum* VUregsn) { _vuRegsSUBx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBy(_VURegsNum* VUregsn) { _vuRegsSUBy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBz(_VURegsNum* VUregsn) { _vuRegsSUBz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBw(_VURegsNum* VUregsn) { _vuRegsSUBw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBA(_VURegsNum* VUregsn) { _vuRegsSUBA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAi(_VURegsNum* VUregsn) { _vuRegsSUBAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAq(_VURegsNum* VUregsn) { _vuRegsSUBAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAx(_VURegsNum* VUregsn) { _vuRegsSUBAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAy(_VURegsNum* VUregsn) { _vuRegsSUBAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAz(_VURegsNum* VUregsn) { _vuRegsSUBAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SUBAw(_VURegsNum* VUregsn) { _vuRegsSUBAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MUL(_VURegsNum* VUregsn) { _vuRegsMUL(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULi(_VURegsNum* VUregsn) { _vuRegsMULi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULq(_VURegsNum* VUregsn) { _vuRegsMULq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULx(_VURegsNum* VUregsn) { _vuRegsMULx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULy(_VURegsNum* VUregsn) { _vuRegsMULy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULz(_VURegsNum* VUregsn) { _vuRegsMULz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULw(_VURegsNum* VUregsn) { _vuRegsMULw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULA(_VURegsNum* VUregsn) { _vuRegsMULA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAi(_VURegsNum* VUregsn) { _vuRegsMULAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAq(_VURegsNum* VUregsn) { _vuRegsMULAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAx(_VURegsNum* VUregsn) { _vuRegsMULAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAy(_VURegsNum* VUregsn) { _vuRegsMULAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAz(_VURegsNum* VUregsn) { _vuRegsMULAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MULAw(_VURegsNum* VUregsn) { _vuRegsMULAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADD(_VURegsNum* VUregsn) { _vuRegsMADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDi(_VURegsNum* VUregsn) { _vuRegsMADDi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDq(_VURegsNum* VUregsn) { _vuRegsMADDq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDx(_VURegsNum* VUregsn) { _vuRegsMADDx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDy(_VURegsNum* VUregsn) { _vuRegsMADDy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDz(_VURegsNum* VUregsn) { _vuRegsMADDz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDw(_VURegsNum* VUregsn) { _vuRegsMADDw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDA(_VURegsNum* VUregsn) { _vuRegsMADDA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAi(_VURegsNum* VUregsn) { _vuRegsMADDAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAq(_VURegsNum* VUregsn) { _vuRegsMADDAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAx(_VURegsNum* VUregsn) { _vuRegsMADDAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAy(_VURegsNum* VUregsn) { _vuRegsMADDAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAz(_VURegsNum* VUregsn) { _vuRegsMADDAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MADDAw(_VURegsNum* VUregsn) { _vuRegsMADDAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUB(_VURegsNum* VUregsn) { _vuRegsMSUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBi(_VURegsNum* VUregsn) { _vuRegsMSUBi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBq(_VURegsNum* VUregsn) { _vuRegsMSUBq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBx(_VURegsNum* VUregsn) { _vuRegsMSUBx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBy(_VURegsNum* VUregsn) { _vuRegsMSUBy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBz(_VURegsNum* VUregsn) { _vuRegsMSUBz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBw(_VURegsNum* VUregsn) { _vuRegsMSUBw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBA(_VURegsNum* VUregsn) { _vuRegsMSUBA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAi(_VURegsNum* VUregsn) { _vuRegsMSUBAi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAq(_VURegsNum* VUregsn) { _vuRegsMSUBAq(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAx(_VURegsNum* VUregsn) { _vuRegsMSUBAx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAy(_VURegsNum* VUregsn) { _vuRegsMSUBAy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAz(_VURegsNum* VUregsn) { _vuRegsMSUBAz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MSUBAw(_VURegsNum* VUregsn) { _vuRegsMSUBAw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAX(_VURegsNum* VUregsn) { _vuRegsMAX(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXi(_VURegsNum* VUregsn) { _vuRegsMAXi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXx(_VURegsNum* VUregsn) { _vuRegsMAXx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXy(_VURegsNum* VUregsn) { _vuRegsMAXy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXz(_VURegsNum* VUregsn) { _vuRegsMAXz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MAXw(_VURegsNum* VUregsn) { _vuRegsMAXw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINI(_VURegsNum* VUregsn) { _vuRegsMINI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIi(_VURegsNum* VUregsn) { _vuRegsMINIi(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIx(_VURegsNum* VUregsn) { _vuRegsMINIx(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIy(_VURegsNum* VUregsn) { _vuRegsMINIy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIz(_VURegsNum* VUregsn) { _vuRegsMINIz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MINIw(_VURegsNum* VUregsn) { _vuRegsMINIw(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_OPMULA(_VURegsNum* VUregsn) { _vuRegsOPMULA(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_OPMSUB(_VURegsNum* VUregsn) { _vuRegsOPMSUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_NOP(_VURegsNum* VUregsn) { _vuRegsNOP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI0(_VURegsNum* VUregsn) { _vuRegsFTOI0(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI4(_VURegsNum* VUregsn) { _vuRegsFTOI4(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI12(_VURegsNum* VUregsn) { _vuRegsFTOI12(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FTOI15(_VURegsNum* VUregsn) { _vuRegsFTOI15(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF0(_VURegsNum* VUregsn) { _vuRegsITOF0(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF4(_VURegsNum* VUregsn) { _vuRegsITOF4(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF12(_VURegsNum* VUregsn) { _vuRegsITOF12(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ITOF15(_VURegsNum* VUregsn) { _vuRegsITOF15(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_CLIP(_VURegsNum* VUregsn) { _vuRegsCLIP(&VU0, VUregsn); }
+static void VU0regsMI_ABS(_VURegsNum* VUregsn) { _vuRegsABS(&VU0, VUregsn); }
+static void VU0regsMI_ADD(_VURegsNum* VUregsn) { _vuRegsADD(&VU0, VUregsn); }
+static void VU0regsMI_ADDi(_VURegsNum* VUregsn) { _vuRegsADDi(&VU0, VUregsn); }
+static void VU0regsMI_ADDq(_VURegsNum* VUregsn) { _vuRegsADDq(&VU0, VUregsn); }
+static void VU0regsMI_ADDx(_VURegsNum* VUregsn) { _vuRegsADDx(&VU0, VUregsn); }
+static void VU0regsMI_ADDy(_VURegsNum* VUregsn) { _vuRegsADDy(&VU0, VUregsn); }
+static void VU0regsMI_ADDz(_VURegsNum* VUregsn) { _vuRegsADDz(&VU0, VUregsn); }
+static void VU0regsMI_ADDw(_VURegsNum* VUregsn) { _vuRegsADDw(&VU0, VUregsn); }
+static void VU0regsMI_ADDA(_VURegsNum* VUregsn) { _vuRegsADDA(&VU0, VUregsn); }
+static void VU0regsMI_ADDAi(_VURegsNum* VUregsn) { _vuRegsADDAi(&VU0, VUregsn); }
+static void VU0regsMI_ADDAq(_VURegsNum* VUregsn) { _vuRegsADDAq(&VU0, VUregsn); }
+static void VU0regsMI_ADDAx(_VURegsNum* VUregsn) { _vuRegsADDAx(&VU0, VUregsn); }
+static void VU0regsMI_ADDAy(_VURegsNum* VUregsn) { _vuRegsADDAy(&VU0, VUregsn); }
+static void VU0regsMI_ADDAz(_VURegsNum* VUregsn) { _vuRegsADDAz(&VU0, VUregsn); }
+static void VU0regsMI_ADDAw(_VURegsNum* VUregsn) { _vuRegsADDAw(&VU0, VUregsn); }
+static void VU0regsMI_SUB(_VURegsNum* VUregsn) { _vuRegsSUB(&VU0, VUregsn); }
+static void VU0regsMI_SUBi(_VURegsNum* VUregsn) { _vuRegsSUBi(&VU0, VUregsn); }
+static void VU0regsMI_SUBq(_VURegsNum* VUregsn) { _vuRegsSUBq(&VU0, VUregsn); }
+static void VU0regsMI_SUBx(_VURegsNum* VUregsn) { _vuRegsSUBx(&VU0, VUregsn); }
+static void VU0regsMI_SUBy(_VURegsNum* VUregsn) { _vuRegsSUBy(&VU0, VUregsn); }
+static void VU0regsMI_SUBz(_VURegsNum* VUregsn) { _vuRegsSUBz(&VU0, VUregsn); }
+static void VU0regsMI_SUBw(_VURegsNum* VUregsn) { _vuRegsSUBw(&VU0, VUregsn); }
+static void VU0regsMI_SUBA(_VURegsNum* VUregsn) { _vuRegsSUBA(&VU0, VUregsn); }
+static void VU0regsMI_SUBAi(_VURegsNum* VUregsn) { _vuRegsSUBAi(&VU0, VUregsn); }
+static void VU0regsMI_SUBAq(_VURegsNum* VUregsn) { _vuRegsSUBAq(&VU0, VUregsn); }
+static void VU0regsMI_SUBAx(_VURegsNum* VUregsn) { _vuRegsSUBAx(&VU0, VUregsn); }
+static void VU0regsMI_SUBAy(_VURegsNum* VUregsn) { _vuRegsSUBAy(&VU0, VUregsn); }
+static void VU0regsMI_SUBAz(_VURegsNum* VUregsn) { _vuRegsSUBAz(&VU0, VUregsn); }
+static void VU0regsMI_SUBAw(_VURegsNum* VUregsn) { _vuRegsSUBAw(&VU0, VUregsn); }
+static void VU0regsMI_MUL(_VURegsNum* VUregsn) { _vuRegsMUL(&VU0, VUregsn); }
+static void VU0regsMI_MULi(_VURegsNum* VUregsn) { _vuRegsMULi(&VU0, VUregsn); }
+static void VU0regsMI_MULq(_VURegsNum* VUregsn) { _vuRegsMULq(&VU0, VUregsn); }
+static void VU0regsMI_MULx(_VURegsNum* VUregsn) { _vuRegsMULx(&VU0, VUregsn); }
+static void VU0regsMI_MULy(_VURegsNum* VUregsn) { _vuRegsMULy(&VU0, VUregsn); }
+static void VU0regsMI_MULz(_VURegsNum* VUregsn) { _vuRegsMULz(&VU0, VUregsn); }
+static void VU0regsMI_MULw(_VURegsNum* VUregsn) { _vuRegsMULw(&VU0, VUregsn); }
+static void VU0regsMI_MULA(_VURegsNum* VUregsn) { _vuRegsMULA(&VU0, VUregsn); }
+static void VU0regsMI_MULAi(_VURegsNum* VUregsn) { _vuRegsMULAi(&VU0, VUregsn); }
+static void VU0regsMI_MULAq(_VURegsNum* VUregsn) { _vuRegsMULAq(&VU0, VUregsn); }
+static void VU0regsMI_MULAx(_VURegsNum* VUregsn) { _vuRegsMULAx(&VU0, VUregsn); }
+static void VU0regsMI_MULAy(_VURegsNum* VUregsn) { _vuRegsMULAy(&VU0, VUregsn); }
+static void VU0regsMI_MULAz(_VURegsNum* VUregsn) { _vuRegsMULAz(&VU0, VUregsn); }
+static void VU0regsMI_MULAw(_VURegsNum* VUregsn) { _vuRegsMULAw(&VU0, VUregsn); }
+static void VU0regsMI_MADD(_VURegsNum* VUregsn) { _vuRegsMADD(&VU0, VUregsn); }
+static void VU0regsMI_MADDi(_VURegsNum* VUregsn) { _vuRegsMADDi(&VU0, VUregsn); }
+static void VU0regsMI_MADDq(_VURegsNum* VUregsn) { _vuRegsMADDq(&VU0, VUregsn); }
+static void VU0regsMI_MADDx(_VURegsNum* VUregsn) { _vuRegsMADDx(&VU0, VUregsn); }
+static void VU0regsMI_MADDy(_VURegsNum* VUregsn) { _vuRegsMADDy(&VU0, VUregsn); }
+static void VU0regsMI_MADDz(_VURegsNum* VUregsn) { _vuRegsMADDz(&VU0, VUregsn); }
+static void VU0regsMI_MADDw(_VURegsNum* VUregsn) { _vuRegsMADDw(&VU0, VUregsn); }
+static void VU0regsMI_MADDA(_VURegsNum* VUregsn) { _vuRegsMADDA(&VU0, VUregsn); }
+static void VU0regsMI_MADDAi(_VURegsNum* VUregsn) { _vuRegsMADDAi(&VU0, VUregsn); }
+static void VU0regsMI_MADDAq(_VURegsNum* VUregsn) { _vuRegsMADDAq(&VU0, VUregsn); }
+static void VU0regsMI_MADDAx(_VURegsNum* VUregsn) { _vuRegsMADDAx(&VU0, VUregsn); }
+static void VU0regsMI_MADDAy(_VURegsNum* VUregsn) { _vuRegsMADDAy(&VU0, VUregsn); }
+static void VU0regsMI_MADDAz(_VURegsNum* VUregsn) { _vuRegsMADDAz(&VU0, VUregsn); }
+static void VU0regsMI_MADDAw(_VURegsNum* VUregsn) { _vuRegsMADDAw(&VU0, VUregsn); }
+static void VU0regsMI_MSUB(_VURegsNum* VUregsn) { _vuRegsMSUB(&VU0, VUregsn); }
+static void VU0regsMI_MSUBi(_VURegsNum* VUregsn) { _vuRegsMSUBi(&VU0, VUregsn); }
+static void VU0regsMI_MSUBq(_VURegsNum* VUregsn) { _vuRegsMSUBq(&VU0, VUregsn); }
+static void VU0regsMI_MSUBx(_VURegsNum* VUregsn) { _vuRegsMSUBx(&VU0, VUregsn); }
+static void VU0regsMI_MSUBy(_VURegsNum* VUregsn) { _vuRegsMSUBy(&VU0, VUregsn); }
+static void VU0regsMI_MSUBz(_VURegsNum* VUregsn) { _vuRegsMSUBz(&VU0, VUregsn); }
+static void VU0regsMI_MSUBw(_VURegsNum* VUregsn) { _vuRegsMSUBw(&VU0, VUregsn); }
+static void VU0regsMI_MSUBA(_VURegsNum* VUregsn) { _vuRegsMSUBA(&VU0, VUregsn); }
+static void VU0regsMI_MSUBAi(_VURegsNum* VUregsn) { _vuRegsMSUBAi(&VU0, VUregsn); }
+static void VU0regsMI_MSUBAq(_VURegsNum* VUregsn) { _vuRegsMSUBAq(&VU0, VUregsn); }
+static void VU0regsMI_MSUBAx(_VURegsNum* VUregsn) { _vuRegsMSUBAx(&VU0, VUregsn); }
+static void VU0regsMI_MSUBAy(_VURegsNum* VUregsn) { _vuRegsMSUBAy(&VU0, VUregsn); }
+static void VU0regsMI_MSUBAz(_VURegsNum* VUregsn) { _vuRegsMSUBAz(&VU0, VUregsn); }
+static void VU0regsMI_MSUBAw(_VURegsNum* VUregsn) { _vuRegsMSUBAw(&VU0, VUregsn); }
+static void VU0regsMI_MAX(_VURegsNum* VUregsn) { _vuRegsMAX(&VU0, VUregsn); }
+static void VU0regsMI_MAXi(_VURegsNum* VUregsn) { _vuRegsMAXi(&VU0, VUregsn); }
+static void VU0regsMI_MAXx(_VURegsNum* VUregsn) { _vuRegsMAXx(&VU0, VUregsn); }
+static void VU0regsMI_MAXy(_VURegsNum* VUregsn) { _vuRegsMAXy(&VU0, VUregsn); }
+static void VU0regsMI_MAXz(_VURegsNum* VUregsn) { _vuRegsMAXz(&VU0, VUregsn); }
+static void VU0regsMI_MAXw(_VURegsNum* VUregsn) { _vuRegsMAXw(&VU0, VUregsn); }
+static void VU0regsMI_MINI(_VURegsNum* VUregsn) { _vuRegsMINI(&VU0, VUregsn); }
+static void VU0regsMI_MINIi(_VURegsNum* VUregsn) { _vuRegsMINIi(&VU0, VUregsn); }
+static void VU0regsMI_MINIx(_VURegsNum* VUregsn) { _vuRegsMINIx(&VU0, VUregsn); }
+static void VU0regsMI_MINIy(_VURegsNum* VUregsn) { _vuRegsMINIy(&VU0, VUregsn); }
+static void VU0regsMI_MINIz(_VURegsNum* VUregsn) { _vuRegsMINIz(&VU0, VUregsn); }
+static void VU0regsMI_MINIw(_VURegsNum* VUregsn) { _vuRegsMINIw(&VU0, VUregsn); }
+static void VU0regsMI_OPMULA(_VURegsNum* VUregsn) { _vuRegsOPMULA(&VU0, VUregsn); }
+static void VU0regsMI_OPMSUB(_VURegsNum* VUregsn) { _vuRegsOPMSUB(&VU0, VUregsn); }
+static void VU0regsMI_NOP(_VURegsNum* VUregsn) { _vuRegsNOP(&VU0, VUregsn); }
+static void VU0regsMI_FTOI0(_VURegsNum* VUregsn) { _vuRegsFTOI0(&VU0, VUregsn); }
+static void VU0regsMI_FTOI4(_VURegsNum* VUregsn) { _vuRegsFTOI4(&VU0, VUregsn); }
+static void VU0regsMI_FTOI12(_VURegsNum* VUregsn) { _vuRegsFTOI12(&VU0, VUregsn); }
+static void VU0regsMI_FTOI15(_VURegsNum* VUregsn) { _vuRegsFTOI15(&VU0, VUregsn); }
+static void VU0regsMI_ITOF0(_VURegsNum* VUregsn) { _vuRegsITOF0(&VU0, VUregsn); }
+static void VU0regsMI_ITOF4(_VURegsNum* VUregsn) { _vuRegsITOF4(&VU0, VUregsn); }
+static void VU0regsMI_ITOF12(_VURegsNum* VUregsn) { _vuRegsITOF12(&VU0, VUregsn); }
+static void VU0regsMI_ITOF15(_VURegsNum* VUregsn) { _vuRegsITOF15(&VU0, VUregsn); }
+static void VU0regsMI_CLIP(_VURegsNum* VUregsn) { _vuRegsCLIP(&VU0, VUregsn); }
 
 /*****************************************/
 /*   VU Micromode Lower instructions    */
 /*****************************************/
 
-static void __vuRegsCall VU0regsMI_DIV(_VURegsNum* VUregsn) { _vuRegsDIV(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQRT(_VURegsNum* VUregsn) { _vuRegsSQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RSQRT(_VURegsNum* VUregsn) { _vuRegsRSQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IADD(_VURegsNum* VUregsn) { _vuRegsIADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IADDI(_VURegsNum* VUregsn) { _vuRegsIADDI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IADDIU(_VURegsNum* VUregsn) { _vuRegsIADDIU(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IAND(_VURegsNum* VUregsn) { _vuRegsIAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IOR(_VURegsNum* VUregsn) { _vuRegsIOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISUB(_VURegsNum* VUregsn) { _vuRegsISUB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISUBIU(_VURegsNum* VUregsn) { _vuRegsISUBIU(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MOVE(_VURegsNum* VUregsn) { _vuRegsMOVE(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MFIR(_VURegsNum* VUregsn) { _vuRegsMFIR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MTIR(_VURegsNum* VUregsn) { _vuRegsMTIR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MR32(_VURegsNum* VUregsn) { _vuRegsMR32(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_LQ(_VURegsNum* VUregsn) { _vuRegsLQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_LQD(_VURegsNum* VUregsn) { _vuRegsLQD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_LQI(_VURegsNum* VUregsn) { _vuRegsLQI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQ(_VURegsNum* VUregsn) { _vuRegsSQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQD(_VURegsNum* VUregsn) { _vuRegsSQD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_SQI(_VURegsNum* VUregsn) { _vuRegsSQI(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ILW(_VURegsNum* VUregsn) { _vuRegsILW(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISW(_VURegsNum* VUregsn) { _vuRegsISW(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ILWR(_VURegsNum* VUregsn) { _vuRegsILWR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ISWR(_VURegsNum* VUregsn) { _vuRegsISWR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RINIT(_VURegsNum* VUregsn) { _vuRegsRINIT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RGET(_VURegsNum* VUregsn) { _vuRegsRGET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RNEXT(_VURegsNum* VUregsn) { _vuRegsRNEXT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_RXOR(_VURegsNum* VUregsn) { _vuRegsRXOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_WAITQ(_VURegsNum* VUregsn) { _vuRegsWAITQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSAND(_VURegsNum* VUregsn) { _vuRegsFSAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSEQ(_VURegsNum* VUregsn) { _vuRegsFSEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSOR(_VURegsNum* VUregsn) { _vuRegsFSOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FSSET(_VURegsNum* VUregsn) { _vuRegsFSSET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FMAND(_VURegsNum* VUregsn) { _vuRegsFMAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FMEQ(_VURegsNum* VUregsn) { _vuRegsFMEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FMOR(_VURegsNum* VUregsn) { _vuRegsFMOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCAND(_VURegsNum* VUregsn) { _vuRegsFCAND(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCEQ(_VURegsNum* VUregsn) { _vuRegsFCEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCOR(_VURegsNum* VUregsn) { _vuRegsFCOR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCSET(_VURegsNum* VUregsn) { _vuRegsFCSET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_FCGET(_VURegsNum* VUregsn) { _vuRegsFCGET(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBEQ(_VURegsNum* VUregsn) { _vuRegsIBEQ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBGEZ(_VURegsNum* VUregsn) { _vuRegsIBGEZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBGTZ(_VURegsNum* VUregsn) { _vuRegsIBGTZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBLTZ(_VURegsNum* VUregsn) { _vuRegsIBLTZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBLEZ(_VURegsNum* VUregsn) { _vuRegsIBLEZ(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_IBNE(_VURegsNum* VUregsn) { _vuRegsIBNE(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_B(_VURegsNum* VUregsn) { _vuRegsB(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_BAL(_VURegsNum* VUregsn) { _vuRegsBAL(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_JR(_VURegsNum* VUregsn) { _vuRegsJR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_JALR(_VURegsNum* VUregsn) { _vuRegsJALR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_MFP(_VURegsNum* VUregsn) { _vuRegsMFP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_WAITP(_VURegsNum* VUregsn) { _vuRegsWAITP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESADD(_VURegsNum* VUregsn) { _vuRegsESADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERSADD(_VURegsNum* VUregsn) { _vuRegsERSADD(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ELENG(_VURegsNum* VUregsn) { _vuRegsELENG(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERLENG(_VURegsNum* VUregsn) { _vuRegsERLENG(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EATANxy(_VURegsNum* VUregsn) { _vuRegsEATANxy(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EATANxz(_VURegsNum* VUregsn) { _vuRegsEATANxz(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESUM(_VURegsNum* VUregsn) { _vuRegsESUM(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERCPR(_VURegsNum* VUregsn) { _vuRegsERCPR(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESQRT(_VURegsNum* VUregsn) { _vuRegsESQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ERSQRT(_VURegsNum* VUregsn) { _vuRegsERSQRT(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_ESIN(_VURegsNum* VUregsn) { _vuRegsESIN(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EATAN(_VURegsNum* VUregsn) { _vuRegsEATAN(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_EEXP(_VURegsNum* VUregsn) { _vuRegsEEXP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_XITOP(_VURegsNum* VUregsn) { _vuRegsXITOP(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_XGKICK(_VURegsNum* VUregsn) { _vuRegsXGKICK(&VU0, VUregsn); }
-static void __vuRegsCall VU0regsMI_XTOP(_VURegsNum* VUregsn) { _vuRegsXTOP(&VU0, VUregsn); }
+static void VU0regsMI_DIV(_VURegsNum* VUregsn) { _vuRegsDIV(&VU0, VUregsn); }
+static void VU0regsMI_SQRT(_VURegsNum* VUregsn) { _vuRegsSQRT(&VU0, VUregsn); }
+static void VU0regsMI_RSQRT(_VURegsNum* VUregsn) { _vuRegsRSQRT(&VU0, VUregsn); }
+static void VU0regsMI_IADD(_VURegsNum* VUregsn) { _vuRegsIADD(&VU0, VUregsn); }
+static void VU0regsMI_IADDI(_VURegsNum* VUregsn) { _vuRegsIADDI(&VU0, VUregsn); }
+static void VU0regsMI_IADDIU(_VURegsNum* VUregsn) { _vuRegsIADDIU(&VU0, VUregsn); }
+static void VU0regsMI_IAND(_VURegsNum* VUregsn) { _vuRegsIAND(&VU0, VUregsn); }
+static void VU0regsMI_IOR(_VURegsNum* VUregsn) { _vuRegsIOR(&VU0, VUregsn); }
+static void VU0regsMI_ISUB(_VURegsNum* VUregsn) { _vuRegsISUB(&VU0, VUregsn); }
+static void VU0regsMI_ISUBIU(_VURegsNum* VUregsn) { _vuRegsISUBIU(&VU0, VUregsn); }
+static void VU0regsMI_MOVE(_VURegsNum* VUregsn) { _vuRegsMOVE(&VU0, VUregsn); }
+static void VU0regsMI_MFIR(_VURegsNum* VUregsn) { _vuRegsMFIR(&VU0, VUregsn); }
+static void VU0regsMI_MTIR(_VURegsNum* VUregsn) { _vuRegsMTIR(&VU0, VUregsn); }
+static void VU0regsMI_MR32(_VURegsNum* VUregsn) { _vuRegsMR32(&VU0, VUregsn); }
+static void VU0regsMI_LQ(_VURegsNum* VUregsn) { _vuRegsLQ(&VU0, VUregsn); }
+static void VU0regsMI_LQD(_VURegsNum* VUregsn) { _vuRegsLQD(&VU0, VUregsn); }
+static void VU0regsMI_LQI(_VURegsNum* VUregsn) { _vuRegsLQI(&VU0, VUregsn); }
+static void VU0regsMI_SQ(_VURegsNum* VUregsn) { _vuRegsSQ(&VU0, VUregsn); }
+static void VU0regsMI_SQD(_VURegsNum* VUregsn) { _vuRegsSQD(&VU0, VUregsn); }
+static void VU0regsMI_SQI(_VURegsNum* VUregsn) { _vuRegsSQI(&VU0, VUregsn); }
+static void VU0regsMI_ILW(_VURegsNum* VUregsn) { _vuRegsILW(&VU0, VUregsn); }
+static void VU0regsMI_ISW(_VURegsNum* VUregsn) { _vuRegsISW(&VU0, VUregsn); }
+static void VU0regsMI_ILWR(_VURegsNum* VUregsn) { _vuRegsILWR(&VU0, VUregsn); }
+static void VU0regsMI_ISWR(_VURegsNum* VUregsn) { _vuRegsISWR(&VU0, VUregsn); }
+static void VU0regsMI_RINIT(_VURegsNum* VUregsn) { _vuRegsRINIT(&VU0, VUregsn); }
+static void VU0regsMI_RGET(_VURegsNum* VUregsn) { _vuRegsRGET(&VU0, VUregsn); }
+static void VU0regsMI_RNEXT(_VURegsNum* VUregsn) { _vuRegsRNEXT(&VU0, VUregsn); }
+static void VU0regsMI_RXOR(_VURegsNum* VUregsn) { _vuRegsRXOR(&VU0, VUregsn); }
+static void VU0regsMI_WAITQ(_VURegsNum* VUregsn) { _vuRegsWAITQ(&VU0, VUregsn); }
+static void VU0regsMI_FSAND(_VURegsNum* VUregsn) { _vuRegsFSAND(&VU0, VUregsn); }
+static void VU0regsMI_FSEQ(_VURegsNum* VUregsn) { _vuRegsFSEQ(&VU0, VUregsn); }
+static void VU0regsMI_FSOR(_VURegsNum* VUregsn) { _vuRegsFSOR(&VU0, VUregsn); }
+static void VU0regsMI_FSSET(_VURegsNum* VUregsn) { _vuRegsFSSET(&VU0, VUregsn); }
+static void VU0regsMI_FMAND(_VURegsNum* VUregsn) { _vuRegsFMAND(&VU0, VUregsn); }
+static void VU0regsMI_FMEQ(_VURegsNum* VUregsn) { _vuRegsFMEQ(&VU0, VUregsn); }
+static void VU0regsMI_FMOR(_VURegsNum* VUregsn) { _vuRegsFMOR(&VU0, VUregsn); }
+static void VU0regsMI_FCAND(_VURegsNum* VUregsn) { _vuRegsFCAND(&VU0, VUregsn); }
+static void VU0regsMI_FCEQ(_VURegsNum* VUregsn) { _vuRegsFCEQ(&VU0, VUregsn); }
+static void VU0regsMI_FCOR(_VURegsNum* VUregsn) { _vuRegsFCOR(&VU0, VUregsn); }
+static void VU0regsMI_FCSET(_VURegsNum* VUregsn) { _vuRegsFCSET(&VU0, VUregsn); }
+static void VU0regsMI_FCGET(_VURegsNum* VUregsn) { _vuRegsFCGET(&VU0, VUregsn); }
+static void VU0regsMI_IBEQ(_VURegsNum* VUregsn) { _vuRegsIBEQ(&VU0, VUregsn); }
+static void VU0regsMI_IBGEZ(_VURegsNum* VUregsn) { _vuRegsIBGEZ(&VU0, VUregsn); }
+static void VU0regsMI_IBGTZ(_VURegsNum* VUregsn) { _vuRegsIBGTZ(&VU0, VUregsn); }
+static void VU0regsMI_IBLTZ(_VURegsNum* VUregsn) { _vuRegsIBLTZ(&VU0, VUregsn); }
+static void VU0regsMI_IBLEZ(_VURegsNum* VUregsn) { _vuRegsIBLEZ(&VU0, VUregsn); }
+static void VU0regsMI_IBNE(_VURegsNum* VUregsn) { _vuRegsIBNE(&VU0, VUregsn); }
+static void VU0regsMI_B(_VURegsNum* VUregsn) { _vuRegsB(&VU0, VUregsn); }
+static void VU0regsMI_BAL(_VURegsNum* VUregsn) { _vuRegsBAL(&VU0, VUregsn); }
+static void VU0regsMI_JR(_VURegsNum* VUregsn) { _vuRegsJR(&VU0, VUregsn); }
+static void VU0regsMI_JALR(_VURegsNum* VUregsn) { _vuRegsJALR(&VU0, VUregsn); }
+static void VU0regsMI_MFP(_VURegsNum* VUregsn) { _vuRegsMFP(&VU0, VUregsn); }
+static void VU0regsMI_WAITP(_VURegsNum* VUregsn) { _vuRegsWAITP(&VU0, VUregsn); }
+static void VU0regsMI_ESADD(_VURegsNum* VUregsn) { _vuRegsESADD(&VU0, VUregsn); }
+static void VU0regsMI_ERSADD(_VURegsNum* VUregsn) { _vuRegsERSADD(&VU0, VUregsn); }
+static void VU0regsMI_ELENG(_VURegsNum* VUregsn) { _vuRegsELENG(&VU0, VUregsn); }
+static void VU0regsMI_ERLENG(_VURegsNum* VUregsn) { _vuRegsERLENG(&VU0, VUregsn); }
+static void VU0regsMI_EATANxy(_VURegsNum* VUregsn) { _vuRegsEATANxy(&VU0, VUregsn); }
+static void VU0regsMI_EATANxz(_VURegsNum* VUregsn) { _vuRegsEATANxz(&VU0, VUregsn); }
+static void VU0regsMI_ESUM(_VURegsNum* VUregsn) { _vuRegsESUM(&VU0, VUregsn); }
+static void VU0regsMI_ERCPR(_VURegsNum* VUregsn) { _vuRegsERCPR(&VU0, VUregsn); }
+static void VU0regsMI_ESQRT(_VURegsNum* VUregsn) { _vuRegsESQRT(&VU0, VUregsn); }
+static void VU0regsMI_ERSQRT(_VURegsNum* VUregsn) { _vuRegsERSQRT(&VU0, VUregsn); }
+static void VU0regsMI_ESIN(_VURegsNum* VUregsn) { _vuRegsESIN(&VU0, VUregsn); }
+static void VU0regsMI_EATAN(_VURegsNum* VUregsn) { _vuRegsEATAN(&VU0, VUregsn); }
+static void VU0regsMI_EEXP(_VURegsNum* VUregsn) { _vuRegsEEXP(&VU0, VUregsn); }
+static void VU0regsMI_XITOP(_VURegsNum* VUregsn) { _vuRegsXITOP(&VU0, VUregsn); }
+static void VU0regsMI_XGKICK(_VURegsNum* VUregsn) { _vuRegsXGKICK(&VU0, VUregsn); }
+static void VU0regsMI_XTOP(_VURegsNum* VUregsn) { _vuRegsXTOP(&VU0, VUregsn); }
 
 void VU0unknown()
 {
@@ -4024,7 +4024,7 @@ void VU0unknown()
 	CPU_LOG("Unknown VU micromode opcode called");
 }
 
-static void __vuRegsCall VU0regsunknown(_VURegsNum* VUregsn)
+static void VU0regsunknown(_VURegsNum* VUregsn)
 {
 	pxFailDev("Unknown VU micromode opcode called");
 	CPU_LOG("Unknown VU micromode opcode called");
@@ -4214,175 +4214,175 @@ static void VU1MI_XTOP()    { _vuXTOP(&VU1); }
 /*   VU Micromode Upper instructions    */
 /****************************************/
 
-static void __vuRegsCall VU1regsMI_ABS(_VURegsNum* VUregsn) { _vuRegsABS(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADD(_VURegsNum* VUregsn) { _vuRegsADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDi(_VURegsNum* VUregsn) { _vuRegsADDi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDq(_VURegsNum* VUregsn) { _vuRegsADDq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDx(_VURegsNum* VUregsn) { _vuRegsADDx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDy(_VURegsNum* VUregsn) { _vuRegsADDy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDz(_VURegsNum* VUregsn) { _vuRegsADDz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDw(_VURegsNum* VUregsn) { _vuRegsADDw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDA(_VURegsNum* VUregsn) { _vuRegsADDA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAi(_VURegsNum* VUregsn) { _vuRegsADDAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAq(_VURegsNum* VUregsn) { _vuRegsADDAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAx(_VURegsNum* VUregsn) { _vuRegsADDAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAy(_VURegsNum* VUregsn) { _vuRegsADDAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAz(_VURegsNum* VUregsn) { _vuRegsADDAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ADDAw(_VURegsNum* VUregsn) { _vuRegsADDAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUB(_VURegsNum* VUregsn) { _vuRegsSUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBi(_VURegsNum* VUregsn) { _vuRegsSUBi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBq(_VURegsNum* VUregsn) { _vuRegsSUBq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBx(_VURegsNum* VUregsn) { _vuRegsSUBx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBy(_VURegsNum* VUregsn) { _vuRegsSUBy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBz(_VURegsNum* VUregsn) { _vuRegsSUBz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBw(_VURegsNum* VUregsn) { _vuRegsSUBw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBA(_VURegsNum* VUregsn) { _vuRegsSUBA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAi(_VURegsNum* VUregsn) { _vuRegsSUBAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAq(_VURegsNum* VUregsn) { _vuRegsSUBAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAx(_VURegsNum* VUregsn) { _vuRegsSUBAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAy(_VURegsNum* VUregsn) { _vuRegsSUBAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAz(_VURegsNum* VUregsn) { _vuRegsSUBAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SUBAw(_VURegsNum* VUregsn) { _vuRegsSUBAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MUL(_VURegsNum* VUregsn) { _vuRegsMUL(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULi(_VURegsNum* VUregsn) { _vuRegsMULi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULq(_VURegsNum* VUregsn) { _vuRegsMULq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULx(_VURegsNum* VUregsn) { _vuRegsMULx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULy(_VURegsNum* VUregsn) { _vuRegsMULy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULz(_VURegsNum* VUregsn) { _vuRegsMULz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULw(_VURegsNum* VUregsn) { _vuRegsMULw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULA(_VURegsNum* VUregsn) { _vuRegsMULA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAi(_VURegsNum* VUregsn) { _vuRegsMULAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAq(_VURegsNum* VUregsn) { _vuRegsMULAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAx(_VURegsNum* VUregsn) { _vuRegsMULAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAy(_VURegsNum* VUregsn) { _vuRegsMULAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAz(_VURegsNum* VUregsn) { _vuRegsMULAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MULAw(_VURegsNum* VUregsn) { _vuRegsMULAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADD(_VURegsNum* VUregsn) { _vuRegsMADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDi(_VURegsNum* VUregsn) { _vuRegsMADDi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDq(_VURegsNum* VUregsn) { _vuRegsMADDq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDx(_VURegsNum* VUregsn) { _vuRegsMADDx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDy(_VURegsNum* VUregsn) { _vuRegsMADDy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDz(_VURegsNum* VUregsn) { _vuRegsMADDz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDw(_VURegsNum* VUregsn) { _vuRegsMADDw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDA(_VURegsNum* VUregsn) { _vuRegsMADDA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAi(_VURegsNum* VUregsn) { _vuRegsMADDAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAq(_VURegsNum* VUregsn) { _vuRegsMADDAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAx(_VURegsNum* VUregsn) { _vuRegsMADDAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAy(_VURegsNum* VUregsn) { _vuRegsMADDAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAz(_VURegsNum* VUregsn) { _vuRegsMADDAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MADDAw(_VURegsNum* VUregsn) { _vuRegsMADDAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUB(_VURegsNum* VUregsn) { _vuRegsMSUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBi(_VURegsNum* VUregsn) { _vuRegsMSUBi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBq(_VURegsNum* VUregsn) { _vuRegsMSUBq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBx(_VURegsNum* VUregsn) { _vuRegsMSUBx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBy(_VURegsNum* VUregsn) { _vuRegsMSUBy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBz(_VURegsNum* VUregsn) { _vuRegsMSUBz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBw(_VURegsNum* VUregsn) { _vuRegsMSUBw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBA(_VURegsNum* VUregsn) { _vuRegsMSUBA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAi(_VURegsNum* VUregsn) { _vuRegsMSUBAi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAq(_VURegsNum* VUregsn) { _vuRegsMSUBAq(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAx(_VURegsNum* VUregsn) { _vuRegsMSUBAx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAy(_VURegsNum* VUregsn) { _vuRegsMSUBAy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAz(_VURegsNum* VUregsn) { _vuRegsMSUBAz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MSUBAw(_VURegsNum* VUregsn) { _vuRegsMSUBAw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAX(_VURegsNum* VUregsn) { _vuRegsMAX(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXi(_VURegsNum* VUregsn) { _vuRegsMAXi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXx(_VURegsNum* VUregsn) { _vuRegsMAXx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXy(_VURegsNum* VUregsn) { _vuRegsMAXy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXz(_VURegsNum* VUregsn) { _vuRegsMAXz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MAXw(_VURegsNum* VUregsn) { _vuRegsMAXw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINI(_VURegsNum* VUregsn) { _vuRegsMINI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIi(_VURegsNum* VUregsn) { _vuRegsMINIi(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIx(_VURegsNum* VUregsn) { _vuRegsMINIx(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIy(_VURegsNum* VUregsn) { _vuRegsMINIy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIz(_VURegsNum* VUregsn) { _vuRegsMINIz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MINIw(_VURegsNum* VUregsn) { _vuRegsMINIw(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_OPMULA(_VURegsNum* VUregsn) { _vuRegsOPMULA(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_OPMSUB(_VURegsNum* VUregsn) { _vuRegsOPMSUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_NOP(_VURegsNum* VUregsn) { _vuRegsNOP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI0(_VURegsNum* VUregsn) { _vuRegsFTOI0(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI4(_VURegsNum* VUregsn) { _vuRegsFTOI4(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI12(_VURegsNum* VUregsn) { _vuRegsFTOI12(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FTOI15(_VURegsNum* VUregsn) { _vuRegsFTOI15(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF0(_VURegsNum* VUregsn) { _vuRegsITOF0(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF4(_VURegsNum* VUregsn) { _vuRegsITOF4(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF12(_VURegsNum* VUregsn) { _vuRegsITOF12(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ITOF15(_VURegsNum* VUregsn) { _vuRegsITOF15(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_CLIP(_VURegsNum* VUregsn) { _vuRegsCLIP(&VU1, VUregsn); }
+static void VU1regsMI_ABS(_VURegsNum* VUregsn) { _vuRegsABS(&VU1, VUregsn); }
+static void VU1regsMI_ADD(_VURegsNum* VUregsn) { _vuRegsADD(&VU1, VUregsn); }
+static void VU1regsMI_ADDi(_VURegsNum* VUregsn) { _vuRegsADDi(&VU1, VUregsn); }
+static void VU1regsMI_ADDq(_VURegsNum* VUregsn) { _vuRegsADDq(&VU1, VUregsn); }
+static void VU1regsMI_ADDx(_VURegsNum* VUregsn) { _vuRegsADDx(&VU1, VUregsn); }
+static void VU1regsMI_ADDy(_VURegsNum* VUregsn) { _vuRegsADDy(&VU1, VUregsn); }
+static void VU1regsMI_ADDz(_VURegsNum* VUregsn) { _vuRegsADDz(&VU1, VUregsn); }
+static void VU1regsMI_ADDw(_VURegsNum* VUregsn) { _vuRegsADDw(&VU1, VUregsn); }
+static void VU1regsMI_ADDA(_VURegsNum* VUregsn) { _vuRegsADDA(&VU1, VUregsn); }
+static void VU1regsMI_ADDAi(_VURegsNum* VUregsn) { _vuRegsADDAi(&VU1, VUregsn); }
+static void VU1regsMI_ADDAq(_VURegsNum* VUregsn) { _vuRegsADDAq(&VU1, VUregsn); }
+static void VU1regsMI_ADDAx(_VURegsNum* VUregsn) { _vuRegsADDAx(&VU1, VUregsn); }
+static void VU1regsMI_ADDAy(_VURegsNum* VUregsn) { _vuRegsADDAy(&VU1, VUregsn); }
+static void VU1regsMI_ADDAz(_VURegsNum* VUregsn) { _vuRegsADDAz(&VU1, VUregsn); }
+static void VU1regsMI_ADDAw(_VURegsNum* VUregsn) { _vuRegsADDAw(&VU1, VUregsn); }
+static void VU1regsMI_SUB(_VURegsNum* VUregsn) { _vuRegsSUB(&VU1, VUregsn); }
+static void VU1regsMI_SUBi(_VURegsNum* VUregsn) { _vuRegsSUBi(&VU1, VUregsn); }
+static void VU1regsMI_SUBq(_VURegsNum* VUregsn) { _vuRegsSUBq(&VU1, VUregsn); }
+static void VU1regsMI_SUBx(_VURegsNum* VUregsn) { _vuRegsSUBx(&VU1, VUregsn); }
+static void VU1regsMI_SUBy(_VURegsNum* VUregsn) { _vuRegsSUBy(&VU1, VUregsn); }
+static void VU1regsMI_SUBz(_VURegsNum* VUregsn) { _vuRegsSUBz(&VU1, VUregsn); }
+static void VU1regsMI_SUBw(_VURegsNum* VUregsn) { _vuRegsSUBw(&VU1, VUregsn); }
+static void VU1regsMI_SUBA(_VURegsNum* VUregsn) { _vuRegsSUBA(&VU1, VUregsn); }
+static void VU1regsMI_SUBAi(_VURegsNum* VUregsn) { _vuRegsSUBAi(&VU1, VUregsn); }
+static void VU1regsMI_SUBAq(_VURegsNum* VUregsn) { _vuRegsSUBAq(&VU1, VUregsn); }
+static void VU1regsMI_SUBAx(_VURegsNum* VUregsn) { _vuRegsSUBAx(&VU1, VUregsn); }
+static void VU1regsMI_SUBAy(_VURegsNum* VUregsn) { _vuRegsSUBAy(&VU1, VUregsn); }
+static void VU1regsMI_SUBAz(_VURegsNum* VUregsn) { _vuRegsSUBAz(&VU1, VUregsn); }
+static void VU1regsMI_SUBAw(_VURegsNum* VUregsn) { _vuRegsSUBAw(&VU1, VUregsn); }
+static void VU1regsMI_MUL(_VURegsNum* VUregsn) { _vuRegsMUL(&VU1, VUregsn); }
+static void VU1regsMI_MULi(_VURegsNum* VUregsn) { _vuRegsMULi(&VU1, VUregsn); }
+static void VU1regsMI_MULq(_VURegsNum* VUregsn) { _vuRegsMULq(&VU1, VUregsn); }
+static void VU1regsMI_MULx(_VURegsNum* VUregsn) { _vuRegsMULx(&VU1, VUregsn); }
+static void VU1regsMI_MULy(_VURegsNum* VUregsn) { _vuRegsMULy(&VU1, VUregsn); }
+static void VU1regsMI_MULz(_VURegsNum* VUregsn) { _vuRegsMULz(&VU1, VUregsn); }
+static void VU1regsMI_MULw(_VURegsNum* VUregsn) { _vuRegsMULw(&VU1, VUregsn); }
+static void VU1regsMI_MULA(_VURegsNum* VUregsn) { _vuRegsMULA(&VU1, VUregsn); }
+static void VU1regsMI_MULAi(_VURegsNum* VUregsn) { _vuRegsMULAi(&VU1, VUregsn); }
+static void VU1regsMI_MULAq(_VURegsNum* VUregsn) { _vuRegsMULAq(&VU1, VUregsn); }
+static void VU1regsMI_MULAx(_VURegsNum* VUregsn) { _vuRegsMULAx(&VU1, VUregsn); }
+static void VU1regsMI_MULAy(_VURegsNum* VUregsn) { _vuRegsMULAy(&VU1, VUregsn); }
+static void VU1regsMI_MULAz(_VURegsNum* VUregsn) { _vuRegsMULAz(&VU1, VUregsn); }
+static void VU1regsMI_MULAw(_VURegsNum* VUregsn) { _vuRegsMULAw(&VU1, VUregsn); }
+static void VU1regsMI_MADD(_VURegsNum* VUregsn) { _vuRegsMADD(&VU1, VUregsn); }
+static void VU1regsMI_MADDi(_VURegsNum* VUregsn) { _vuRegsMADDi(&VU1, VUregsn); }
+static void VU1regsMI_MADDq(_VURegsNum* VUregsn) { _vuRegsMADDq(&VU1, VUregsn); }
+static void VU1regsMI_MADDx(_VURegsNum* VUregsn) { _vuRegsMADDx(&VU1, VUregsn); }
+static void VU1regsMI_MADDy(_VURegsNum* VUregsn) { _vuRegsMADDy(&VU1, VUregsn); }
+static void VU1regsMI_MADDz(_VURegsNum* VUregsn) { _vuRegsMADDz(&VU1, VUregsn); }
+static void VU1regsMI_MADDw(_VURegsNum* VUregsn) { _vuRegsMADDw(&VU1, VUregsn); }
+static void VU1regsMI_MADDA(_VURegsNum* VUregsn) { _vuRegsMADDA(&VU1, VUregsn); }
+static void VU1regsMI_MADDAi(_VURegsNum* VUregsn) { _vuRegsMADDAi(&VU1, VUregsn); }
+static void VU1regsMI_MADDAq(_VURegsNum* VUregsn) { _vuRegsMADDAq(&VU1, VUregsn); }
+static void VU1regsMI_MADDAx(_VURegsNum* VUregsn) { _vuRegsMADDAx(&VU1, VUregsn); }
+static void VU1regsMI_MADDAy(_VURegsNum* VUregsn) { _vuRegsMADDAy(&VU1, VUregsn); }
+static void VU1regsMI_MADDAz(_VURegsNum* VUregsn) { _vuRegsMADDAz(&VU1, VUregsn); }
+static void VU1regsMI_MADDAw(_VURegsNum* VUregsn) { _vuRegsMADDAw(&VU1, VUregsn); }
+static void VU1regsMI_MSUB(_VURegsNum* VUregsn) { _vuRegsMSUB(&VU1, VUregsn); }
+static void VU1regsMI_MSUBi(_VURegsNum* VUregsn) { _vuRegsMSUBi(&VU1, VUregsn); }
+static void VU1regsMI_MSUBq(_VURegsNum* VUregsn) { _vuRegsMSUBq(&VU1, VUregsn); }
+static void VU1regsMI_MSUBx(_VURegsNum* VUregsn) { _vuRegsMSUBx(&VU1, VUregsn); }
+static void VU1regsMI_MSUBy(_VURegsNum* VUregsn) { _vuRegsMSUBy(&VU1, VUregsn); }
+static void VU1regsMI_MSUBz(_VURegsNum* VUregsn) { _vuRegsMSUBz(&VU1, VUregsn); }
+static void VU1regsMI_MSUBw(_VURegsNum* VUregsn) { _vuRegsMSUBw(&VU1, VUregsn); }
+static void VU1regsMI_MSUBA(_VURegsNum* VUregsn) { _vuRegsMSUBA(&VU1, VUregsn); }
+static void VU1regsMI_MSUBAi(_VURegsNum* VUregsn) { _vuRegsMSUBAi(&VU1, VUregsn); }
+static void VU1regsMI_MSUBAq(_VURegsNum* VUregsn) { _vuRegsMSUBAq(&VU1, VUregsn); }
+static void VU1regsMI_MSUBAx(_VURegsNum* VUregsn) { _vuRegsMSUBAx(&VU1, VUregsn); }
+static void VU1regsMI_MSUBAy(_VURegsNum* VUregsn) { _vuRegsMSUBAy(&VU1, VUregsn); }
+static void VU1regsMI_MSUBAz(_VURegsNum* VUregsn) { _vuRegsMSUBAz(&VU1, VUregsn); }
+static void VU1regsMI_MSUBAw(_VURegsNum* VUregsn) { _vuRegsMSUBAw(&VU1, VUregsn); }
+static void VU1regsMI_MAX(_VURegsNum* VUregsn) { _vuRegsMAX(&VU1, VUregsn); }
+static void VU1regsMI_MAXi(_VURegsNum* VUregsn) { _vuRegsMAXi(&VU1, VUregsn); }
+static void VU1regsMI_MAXx(_VURegsNum* VUregsn) { _vuRegsMAXx(&VU1, VUregsn); }
+static void VU1regsMI_MAXy(_VURegsNum* VUregsn) { _vuRegsMAXy(&VU1, VUregsn); }
+static void VU1regsMI_MAXz(_VURegsNum* VUregsn) { _vuRegsMAXz(&VU1, VUregsn); }
+static void VU1regsMI_MAXw(_VURegsNum* VUregsn) { _vuRegsMAXw(&VU1, VUregsn); }
+static void VU1regsMI_MINI(_VURegsNum* VUregsn) { _vuRegsMINI(&VU1, VUregsn); }
+static void VU1regsMI_MINIi(_VURegsNum* VUregsn) { _vuRegsMINIi(&VU1, VUregsn); }
+static void VU1regsMI_MINIx(_VURegsNum* VUregsn) { _vuRegsMINIx(&VU1, VUregsn); }
+static void VU1regsMI_MINIy(_VURegsNum* VUregsn) { _vuRegsMINIy(&VU1, VUregsn); }
+static void VU1regsMI_MINIz(_VURegsNum* VUregsn) { _vuRegsMINIz(&VU1, VUregsn); }
+static void VU1regsMI_MINIw(_VURegsNum* VUregsn) { _vuRegsMINIw(&VU1, VUregsn); }
+static void VU1regsMI_OPMULA(_VURegsNum* VUregsn) { _vuRegsOPMULA(&VU1, VUregsn); }
+static void VU1regsMI_OPMSUB(_VURegsNum* VUregsn) { _vuRegsOPMSUB(&VU1, VUregsn); }
+static void VU1regsMI_NOP(_VURegsNum* VUregsn) { _vuRegsNOP(&VU1, VUregsn); }
+static void VU1regsMI_FTOI0(_VURegsNum* VUregsn) { _vuRegsFTOI0(&VU1, VUregsn); }
+static void VU1regsMI_FTOI4(_VURegsNum* VUregsn) { _vuRegsFTOI4(&VU1, VUregsn); }
+static void VU1regsMI_FTOI12(_VURegsNum* VUregsn) { _vuRegsFTOI12(&VU1, VUregsn); }
+static void VU1regsMI_FTOI15(_VURegsNum* VUregsn) { _vuRegsFTOI15(&VU1, VUregsn); }
+static void VU1regsMI_ITOF0(_VURegsNum* VUregsn) { _vuRegsITOF0(&VU1, VUregsn); }
+static void VU1regsMI_ITOF4(_VURegsNum* VUregsn) { _vuRegsITOF4(&VU1, VUregsn); }
+static void VU1regsMI_ITOF12(_VURegsNum* VUregsn) { _vuRegsITOF12(&VU1, VUregsn); }
+static void VU1regsMI_ITOF15(_VURegsNum* VUregsn) { _vuRegsITOF15(&VU1, VUregsn); }
+static void VU1regsMI_CLIP(_VURegsNum* VUregsn) { _vuRegsCLIP(&VU1, VUregsn); }
 
 /*****************************************/
 /*   VU Micromode Lower instructions    */
 /*****************************************/
 
-static void __vuRegsCall VU1regsMI_DIV(_VURegsNum* VUregsn) { _vuRegsDIV(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQRT(_VURegsNum* VUregsn) { _vuRegsSQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RSQRT(_VURegsNum* VUregsn) { _vuRegsRSQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IADD(_VURegsNum* VUregsn) { _vuRegsIADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IADDI(_VURegsNum* VUregsn) { _vuRegsIADDI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IADDIU(_VURegsNum* VUregsn) { _vuRegsIADDIU(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IAND(_VURegsNum* VUregsn) { _vuRegsIAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IOR(_VURegsNum* VUregsn) { _vuRegsIOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISUB(_VURegsNum* VUregsn) { _vuRegsISUB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISUBIU(_VURegsNum* VUregsn) { _vuRegsISUBIU(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MOVE(_VURegsNum* VUregsn) { _vuRegsMOVE(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MFIR(_VURegsNum* VUregsn) { _vuRegsMFIR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MTIR(_VURegsNum* VUregsn) { _vuRegsMTIR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MR32(_VURegsNum* VUregsn) { _vuRegsMR32(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_LQ(_VURegsNum* VUregsn) { _vuRegsLQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_LQD(_VURegsNum* VUregsn) { _vuRegsLQD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_LQI(_VURegsNum* VUregsn) { _vuRegsLQI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQ(_VURegsNum* VUregsn) { _vuRegsSQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQD(_VURegsNum* VUregsn) { _vuRegsSQD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_SQI(_VURegsNum* VUregsn) { _vuRegsSQI(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ILW(_VURegsNum* VUregsn) { _vuRegsILW(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISW(_VURegsNum* VUregsn) { _vuRegsISW(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ILWR(_VURegsNum* VUregsn) { _vuRegsILWR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ISWR(_VURegsNum* VUregsn) { _vuRegsISWR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RINIT(_VURegsNum* VUregsn) { _vuRegsRINIT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RGET(_VURegsNum* VUregsn) { _vuRegsRGET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RNEXT(_VURegsNum* VUregsn) { _vuRegsRNEXT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_RXOR(_VURegsNum* VUregsn) { _vuRegsRXOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_WAITQ(_VURegsNum* VUregsn) { _vuRegsWAITQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSAND(_VURegsNum* VUregsn) { _vuRegsFSAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSEQ(_VURegsNum* VUregsn) { _vuRegsFSEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSOR(_VURegsNum* VUregsn) { _vuRegsFSOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FSSET(_VURegsNum* VUregsn) { _vuRegsFSSET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FMAND(_VURegsNum* VUregsn) { _vuRegsFMAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FMEQ(_VURegsNum* VUregsn) { _vuRegsFMEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FMOR(_VURegsNum* VUregsn) { _vuRegsFMOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCAND(_VURegsNum* VUregsn) { _vuRegsFCAND(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCEQ(_VURegsNum* VUregsn) { _vuRegsFCEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCOR(_VURegsNum* VUregsn) { _vuRegsFCOR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCSET(_VURegsNum* VUregsn) { _vuRegsFCSET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_FCGET(_VURegsNum* VUregsn) { _vuRegsFCGET(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBEQ(_VURegsNum* VUregsn) { _vuRegsIBEQ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBGEZ(_VURegsNum* VUregsn) { _vuRegsIBGEZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBGTZ(_VURegsNum* VUregsn) { _vuRegsIBGTZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBLTZ(_VURegsNum* VUregsn) { _vuRegsIBLTZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBLEZ(_VURegsNum* VUregsn) { _vuRegsIBLEZ(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_IBNE(_VURegsNum* VUregsn) { _vuRegsIBNE(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_B(_VURegsNum* VUregsn) { _vuRegsB(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_BAL(_VURegsNum* VUregsn) { _vuRegsBAL(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_JR(_VURegsNum* VUregsn) { _vuRegsJR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_JALR(_VURegsNum* VUregsn) { _vuRegsJALR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_MFP(_VURegsNum* VUregsn) { _vuRegsMFP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_WAITP(_VURegsNum* VUregsn) { _vuRegsWAITP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESADD(_VURegsNum* VUregsn) { _vuRegsESADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERSADD(_VURegsNum* VUregsn) { _vuRegsERSADD(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ELENG(_VURegsNum* VUregsn) { _vuRegsELENG(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERLENG(_VURegsNum* VUregsn) { _vuRegsERLENG(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EATANxy(_VURegsNum* VUregsn) { _vuRegsEATANxy(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EATANxz(_VURegsNum* VUregsn) { _vuRegsEATANxz(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESUM(_VURegsNum* VUregsn) { _vuRegsESUM(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERCPR(_VURegsNum* VUregsn) { _vuRegsERCPR(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESQRT(_VURegsNum* VUregsn) { _vuRegsESQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ERSQRT(_VURegsNum* VUregsn) { _vuRegsERSQRT(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_ESIN(_VURegsNum* VUregsn) { _vuRegsESIN(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EATAN(_VURegsNum* VUregsn) { _vuRegsEATAN(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_EEXP(_VURegsNum* VUregsn) { _vuRegsEEXP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_XITOP(_VURegsNum* VUregsn) { _vuRegsXITOP(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_XGKICK(_VURegsNum* VUregsn) { _vuRegsXGKICK(&VU1, VUregsn); }
-static void __vuRegsCall VU1regsMI_XTOP(_VURegsNum* VUregsn) { _vuRegsXTOP(&VU1, VUregsn); }
+static void VU1regsMI_DIV(_VURegsNum* VUregsn) { _vuRegsDIV(&VU1, VUregsn); }
+static void VU1regsMI_SQRT(_VURegsNum* VUregsn) { _vuRegsSQRT(&VU1, VUregsn); }
+static void VU1regsMI_RSQRT(_VURegsNum* VUregsn) { _vuRegsRSQRT(&VU1, VUregsn); }
+static void VU1regsMI_IADD(_VURegsNum* VUregsn) { _vuRegsIADD(&VU1, VUregsn); }
+static void VU1regsMI_IADDI(_VURegsNum* VUregsn) { _vuRegsIADDI(&VU1, VUregsn); }
+static void VU1regsMI_IADDIU(_VURegsNum* VUregsn) { _vuRegsIADDIU(&VU1, VUregsn); }
+static void VU1regsMI_IAND(_VURegsNum* VUregsn) { _vuRegsIAND(&VU1, VUregsn); }
+static void VU1regsMI_IOR(_VURegsNum* VUregsn) { _vuRegsIOR(&VU1, VUregsn); }
+static void VU1regsMI_ISUB(_VURegsNum* VUregsn) { _vuRegsISUB(&VU1, VUregsn); }
+static void VU1regsMI_ISUBIU(_VURegsNum* VUregsn) { _vuRegsISUBIU(&VU1, VUregsn); }
+static void VU1regsMI_MOVE(_VURegsNum* VUregsn) { _vuRegsMOVE(&VU1, VUregsn); }
+static void VU1regsMI_MFIR(_VURegsNum* VUregsn) { _vuRegsMFIR(&VU1, VUregsn); }
+static void VU1regsMI_MTIR(_VURegsNum* VUregsn) { _vuRegsMTIR(&VU1, VUregsn); }
+static void VU1regsMI_MR32(_VURegsNum* VUregsn) { _vuRegsMR32(&VU1, VUregsn); }
+static void VU1regsMI_LQ(_VURegsNum* VUregsn) { _vuRegsLQ(&VU1, VUregsn); }
+static void VU1regsMI_LQD(_VURegsNum* VUregsn) { _vuRegsLQD(&VU1, VUregsn); }
+static void VU1regsMI_LQI(_VURegsNum* VUregsn) { _vuRegsLQI(&VU1, VUregsn); }
+static void VU1regsMI_SQ(_VURegsNum* VUregsn) { _vuRegsSQ(&VU1, VUregsn); }
+static void VU1regsMI_SQD(_VURegsNum* VUregsn) { _vuRegsSQD(&VU1, VUregsn); }
+static void VU1regsMI_SQI(_VURegsNum* VUregsn) { _vuRegsSQI(&VU1, VUregsn); }
+static void VU1regsMI_ILW(_VURegsNum* VUregsn) { _vuRegsILW(&VU1, VUregsn); }
+static void VU1regsMI_ISW(_VURegsNum* VUregsn) { _vuRegsISW(&VU1, VUregsn); }
+static void VU1regsMI_ILWR(_VURegsNum* VUregsn) { _vuRegsILWR(&VU1, VUregsn); }
+static void VU1regsMI_ISWR(_VURegsNum* VUregsn) { _vuRegsISWR(&VU1, VUregsn); }
+static void VU1regsMI_RINIT(_VURegsNum* VUregsn) { _vuRegsRINIT(&VU1, VUregsn); }
+static void VU1regsMI_RGET(_VURegsNum* VUregsn) { _vuRegsRGET(&VU1, VUregsn); }
+static void VU1regsMI_RNEXT(_VURegsNum* VUregsn) { _vuRegsRNEXT(&VU1, VUregsn); }
+static void VU1regsMI_RXOR(_VURegsNum* VUregsn) { _vuRegsRXOR(&VU1, VUregsn); }
+static void VU1regsMI_WAITQ(_VURegsNum* VUregsn) { _vuRegsWAITQ(&VU1, VUregsn); }
+static void VU1regsMI_FSAND(_VURegsNum* VUregsn) { _vuRegsFSAND(&VU1, VUregsn); }
+static void VU1regsMI_FSEQ(_VURegsNum* VUregsn) { _vuRegsFSEQ(&VU1, VUregsn); }
+static void VU1regsMI_FSOR(_VURegsNum* VUregsn) { _vuRegsFSOR(&VU1, VUregsn); }
+static void VU1regsMI_FSSET(_VURegsNum* VUregsn) { _vuRegsFSSET(&VU1, VUregsn); }
+static void VU1regsMI_FMAND(_VURegsNum* VUregsn) { _vuRegsFMAND(&VU1, VUregsn); }
+static void VU1regsMI_FMEQ(_VURegsNum* VUregsn) { _vuRegsFMEQ(&VU1, VUregsn); }
+static void VU1regsMI_FMOR(_VURegsNum* VUregsn) { _vuRegsFMOR(&VU1, VUregsn); }
+static void VU1regsMI_FCAND(_VURegsNum* VUregsn) { _vuRegsFCAND(&VU1, VUregsn); }
+static void VU1regsMI_FCEQ(_VURegsNum* VUregsn) { _vuRegsFCEQ(&VU1, VUregsn); }
+static void VU1regsMI_FCOR(_VURegsNum* VUregsn) { _vuRegsFCOR(&VU1, VUregsn); }
+static void VU1regsMI_FCSET(_VURegsNum* VUregsn) { _vuRegsFCSET(&VU1, VUregsn); }
+static void VU1regsMI_FCGET(_VURegsNum* VUregsn) { _vuRegsFCGET(&VU1, VUregsn); }
+static void VU1regsMI_IBEQ(_VURegsNum* VUregsn) { _vuRegsIBEQ(&VU1, VUregsn); }
+static void VU1regsMI_IBGEZ(_VURegsNum* VUregsn) { _vuRegsIBGEZ(&VU1, VUregsn); }
+static void VU1regsMI_IBGTZ(_VURegsNum* VUregsn) { _vuRegsIBGTZ(&VU1, VUregsn); }
+static void VU1regsMI_IBLTZ(_VURegsNum* VUregsn) { _vuRegsIBLTZ(&VU1, VUregsn); }
+static void VU1regsMI_IBLEZ(_VURegsNum* VUregsn) { _vuRegsIBLEZ(&VU1, VUregsn); }
+static void VU1regsMI_IBNE(_VURegsNum* VUregsn) { _vuRegsIBNE(&VU1, VUregsn); }
+static void VU1regsMI_B(_VURegsNum* VUregsn) { _vuRegsB(&VU1, VUregsn); }
+static void VU1regsMI_BAL(_VURegsNum* VUregsn) { _vuRegsBAL(&VU1, VUregsn); }
+static void VU1regsMI_JR(_VURegsNum* VUregsn) { _vuRegsJR(&VU1, VUregsn); }
+static void VU1regsMI_JALR(_VURegsNum* VUregsn) { _vuRegsJALR(&VU1, VUregsn); }
+static void VU1regsMI_MFP(_VURegsNum* VUregsn) { _vuRegsMFP(&VU1, VUregsn); }
+static void VU1regsMI_WAITP(_VURegsNum* VUregsn) { _vuRegsWAITP(&VU1, VUregsn); }
+static void VU1regsMI_ESADD(_VURegsNum* VUregsn) { _vuRegsESADD(&VU1, VUregsn); }
+static void VU1regsMI_ERSADD(_VURegsNum* VUregsn) { _vuRegsERSADD(&VU1, VUregsn); }
+static void VU1regsMI_ELENG(_VURegsNum* VUregsn) { _vuRegsELENG(&VU1, VUregsn); }
+static void VU1regsMI_ERLENG(_VURegsNum* VUregsn) { _vuRegsERLENG(&VU1, VUregsn); }
+static void VU1regsMI_EATANxy(_VURegsNum* VUregsn) { _vuRegsEATANxy(&VU1, VUregsn); }
+static void VU1regsMI_EATANxz(_VURegsNum* VUregsn) { _vuRegsEATANxz(&VU1, VUregsn); }
+static void VU1regsMI_ESUM(_VURegsNum* VUregsn) { _vuRegsESUM(&VU1, VUregsn); }
+static void VU1regsMI_ERCPR(_VURegsNum* VUregsn) { _vuRegsERCPR(&VU1, VUregsn); }
+static void VU1regsMI_ESQRT(_VURegsNum* VUregsn) { _vuRegsESQRT(&VU1, VUregsn); }
+static void VU1regsMI_ERSQRT(_VURegsNum* VUregsn) { _vuRegsERSQRT(&VU1, VUregsn); }
+static void VU1regsMI_ESIN(_VURegsNum* VUregsn) { _vuRegsESIN(&VU1, VUregsn); }
+static void VU1regsMI_EATAN(_VURegsNum* VUregsn) { _vuRegsEATAN(&VU1, VUregsn); }
+static void VU1regsMI_EEXP(_VURegsNum* VUregsn) { _vuRegsEEXP(&VU1, VUregsn); }
+static void VU1regsMI_XITOP(_VURegsNum* VUregsn) { _vuRegsXITOP(&VU1, VUregsn); }
+static void VU1regsMI_XGKICK(_VURegsNum* VUregsn) { _vuRegsXGKICK(&VU1, VUregsn); }
+static void VU1regsMI_XTOP(_VURegsNum* VUregsn) { _vuRegsXTOP(&VU1, VUregsn); }
 
 static void VU1unknown()
 {
@@ -4390,7 +4390,7 @@ static void VU1unknown()
 	CPU_LOG("Unknown VU micromode opcode called");
 }
 
-static void __vuRegsCall VU1regsunknown(_VURegsNum* VUregsn)
+static void VU1regsunknown(_VURegsNum* VUregsn)
 {
 	pxFailDev("Unknown VU micromode opcode called");
 	CPU_LOG("Unknown VU micromode opcode called");
@@ -4621,51 +4621,51 @@ alignas(16) const FNTYPE PREFIX##_UPPER_OPCODE[64] = { \
 // --------------------------------------------------------------------------------------
 
 #define _vuRegsTables(VU, PREFIX, FNTYPE) \
- static void __vuRegsCall PREFIX##_UPPER_FD_00(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##_UPPER_FD_01(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##_UPPER_FD_10(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##_UPPER_FD_11(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##LowerOP(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##LowerOP_T3_00(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##LowerOP_T3_01(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##LowerOP_T3_10(_VURegsNum *VUregsn); \
- static void __vuRegsCall PREFIX##LowerOP_T3_11(_VURegsNum *VUregsn); \
+ static void PREFIX##_UPPER_FD_00(_VURegsNum *VUregsn); \
+ static void PREFIX##_UPPER_FD_01(_VURegsNum *VUregsn); \
+ static void PREFIX##_UPPER_FD_10(_VURegsNum *VUregsn); \
+ static void PREFIX##_UPPER_FD_11(_VURegsNum *VUregsn); \
+ static void PREFIX##LowerOP(_VURegsNum *VUregsn); \
+ static void PREFIX##LowerOP_T3_00(_VURegsNum *VUregsn); \
+ static void PREFIX##LowerOP_T3_01(_VURegsNum *VUregsn); \
+ static void PREFIX##LowerOP_T3_10(_VURegsNum *VUregsn); \
+ static void PREFIX##LowerOP_T3_11(_VURegsNum *VUregsn); \
  \
  _vuTablesMess(PREFIX, FNTYPE) \
  \
- static void __vuRegsCall PREFIX##_UPPER_FD_00(_VURegsNum *VUregsn) { \
+ static void PREFIX##_UPPER_FD_00(_VURegsNum *VUregsn) { \
  PREFIX##_UPPER_FD_00_TABLE[(VU.code >> 6) & 0x1f ](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##_UPPER_FD_01(_VURegsNum *VUregsn) { \
+ static void PREFIX##_UPPER_FD_01(_VURegsNum *VUregsn) { \
  PREFIX##_UPPER_FD_01_TABLE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##_UPPER_FD_10(_VURegsNum *VUregsn) { \
+ static void PREFIX##_UPPER_FD_10(_VURegsNum *VUregsn) { \
  PREFIX##_UPPER_FD_10_TABLE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##_UPPER_FD_11(_VURegsNum *VUregsn) { \
+ static void PREFIX##_UPPER_FD_11(_VURegsNum *VUregsn) { \
  PREFIX##_UPPER_FD_11_TABLE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##LowerOP(_VURegsNum *VUregsn) { \
+ static void PREFIX##LowerOP(_VURegsNum *VUregsn) { \
  PREFIX##LowerOP_OPCODE[VU.code & 0x3f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##LowerOP_T3_00(_VURegsNum *VUregsn) { \
+ static void PREFIX##LowerOP_T3_00(_VURegsNum *VUregsn) { \
  PREFIX##LowerOP_T3_00_OPCODE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##LowerOP_T3_01(_VURegsNum *VUregsn) { \
+ static void PREFIX##LowerOP_T3_01(_VURegsNum *VUregsn) { \
  PREFIX##LowerOP_T3_01_OPCODE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##LowerOP_T3_10(_VURegsNum *VUregsn) { \
+ static void PREFIX##LowerOP_T3_10(_VURegsNum *VUregsn) { \
  PREFIX##LowerOP_T3_10_OPCODE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
  \
- static void __vuRegsCall PREFIX##LowerOP_T3_11(_VURegsNum *VUregsn) { \
+ static void PREFIX##LowerOP_T3_11(_VURegsNum *VUregsn) { \
  PREFIX##LowerOP_T3_11_OPCODE[(VU.code >> 6) & 0x1f](VUregsn); \
 } \
 

--- a/pcsx2/VUops.h
+++ b/pcsx2/VUops.h
@@ -38,8 +38,7 @@ struct _VURegsNum {
 	int cycles;
 };
 
-#define __vuRegsCall __fastcall
-typedef void __vuRegsCall FnType_VuRegsN(_VURegsNum *VUregsn);
+typedef void FnType_VuRegsN(_VURegsNum *VUregsn);
 typedef FnType_VuRegsN* Fnptr_VuRegsN;
 
 alignas(16) extern const Fnptr_Void VU0_LOWER_OPCODE[128];

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -22,7 +22,7 @@
 #include "VUmicro.h"
 #include "MTVU.h"
 
-#define vifOp(vifCodeName) _vifT int __fastcall vifCodeName(int pass, const u32* data)
+#define vifOp(vifCodeName) _vifT int vifCodeName(int pass, const u32* data)
 #define pass1 if (pass == 0)
 #define pass2 if (pass == 1)
 #define pass3 if (pass == 2)

--- a/pcsx2/Vif_Dma.h
+++ b/pcsx2/Vif_Dma.h
@@ -109,7 +109,7 @@ extern void vif1Interrupt();
 extern void vif1VUFinish();
 extern void vif1Reset();
 
-typedef int __fastcall FnType_VifCmdHandler(int pass, const u32 *data);
+typedef int FnType_VifCmdHandler(int pass, const u32 *data);
 typedef FnType_VifCmdHandler* Fnptr_VifCmdHandler;
 
 alignas(16) extern const Fnptr_VifCmdHandler vifCmdHandler[2][128];

--- a/pcsx2/Vif_Unpack.cpp
+++ b/pcsx2/Vif_Unpack.cpp
@@ -72,7 +72,7 @@ static __ri void writeXYZW(u32 offnum, u32 &dest, u32 data) {
 #define tParam idx,mode,doMask
 
 template < uint idx, uint mode, bool doMask, class T >
-static void __fastcall UNPACK_S(u32* dest, const T* src)
+static void UNPACK_S(u32* dest, const T* src)
 {
 	u32 data = *src;
 
@@ -86,7 +86,7 @@ static void __fastcall UNPACK_S(u32* dest, const T* src)
 // The PS2 console actually writes v1v0v1v0 for all V2 unpacks -- the second v1v0 pair
 // being officially "indeterminate" but some games very much depend on it.
 template < uint idx, uint mode, bool doMask, class T >
-static void __fastcall UNPACK_V2(u32* dest, const T* src)
+static void UNPACK_V2(u32* dest, const T* src)
 {
 	writeXYZW<tParam>(OFFSET_X, *(dest+0), *(src+0));
 	writeXYZW<tParam>(OFFSET_Y, *(dest+1), *(src+1));
@@ -98,7 +98,7 @@ static void __fastcall UNPACK_V2(u32* dest, const T* src)
 // during V3 unpacking end up being overwritten by the next unpack.  This is confirmed real
 // hardware behavior that games such as Ape Escape 3 depend on.
 template < uint idx, uint mode, bool doMask, class T >
-static void __fastcall UNPACK_V4(u32* dest, const T* src)
+static void UNPACK_V4(u32* dest, const T* src)
 {
 	writeXYZW<tParam>(OFFSET_X, *(dest+0), *(src+0));
 	writeXYZW<tParam>(OFFSET_Y, *(dest+1), *(src+1));
@@ -108,7 +108,7 @@ static void __fastcall UNPACK_V4(u32* dest, const T* src)
 
 // V4_5 unpacks do not support the MODE register, and act as mode==0 always.
 template< uint idx, bool doMask >
-static void __fastcall UNPACK_V4_5(u32 *dest, const u32* src)
+static void UNPACK_V4_5(u32 *dest, const u32* src)
 {
 	u32 data = *src;
 

--- a/pcsx2/Vif_Unpack.h
+++ b/pcsx2/Vif_Unpack.h
@@ -17,10 +17,10 @@
 
 struct vifStruct;
 
-typedef void (__fastcall *UNPACKFUNCTYPE)(void* dest, const void* src);
+typedef void (*UNPACKFUNCTYPE)(void* dest, const void* src);
 
-#define create_unpack_u_type(bits)		typedef void (__fastcall *UNPACKFUNCTYPE_u##bits)(u32* dest, const u##bits* src);
-#define create_unpack_s_type(bits)		typedef void (__fastcall *UNPACKFUNCTYPE_s##bits)(u32* dest, const s##bits* src);
+#define create_unpack_u_type(bits)		typedef void (*UNPACKFUNCTYPE_u##bits)(u32* dest, const u##bits* src);
+#define create_unpack_s_type(bits)		typedef void (*UNPACKFUNCTYPE_s##bits)(u32* dest, const s##bits* src);
 
 #define create_some_unpacks(bits)		\
 		create_unpack_u_type(bits);		\

--- a/pcsx2/gui/ConsoleLogger.cpp
+++ b/pcsx2/gui/ConsoleLogger.cpp
@@ -1069,7 +1069,7 @@ void Pcsx2App::ProgramLog_PostEvent( wxEvent& evt )
 //  ConsoleImpl_ToFile
 // --------------------------------------------------------------------------------------
 
-static void __concall ConsoleToFile_Newline()
+static void ConsoleToFile_Newline()
 {
 #if defined(__POSIX__)
 	if ((g_Conf) && (g_Conf->EmuOptions.ConsoleToStdio)) ConsoleWriter_Stdout.Newline();
@@ -1082,7 +1082,7 @@ static void __concall ConsoleToFile_Newline()
 #endif
 }
 
-static void __concall ConsoleToFile_DoWrite( const wxString& fmt )
+static void ConsoleToFile_DoWrite( const wxString& fmt )
 {
 #if defined(__POSIX__)
 	if ((g_Conf) && (g_Conf->EmuOptions.ConsoleToStdio)) ConsoleWriter_Stdout.WriteRaw(fmt);
@@ -1091,7 +1091,7 @@ static void __concall ConsoleToFile_DoWrite( const wxString& fmt )
 	px_fputs( emuLog, fmt.ToUTF8() );
 }
 
-static void __concall ConsoleToFile_DoWriteLn( const wxString& fmt )
+static void ConsoleToFile_DoWriteLn( const wxString& fmt )
 {
 	ConsoleToFile_DoWrite( fmt );
 	ConsoleToFile_Newline();
@@ -1099,12 +1099,12 @@ static void __concall ConsoleToFile_DoWriteLn( const wxString& fmt )
 	if (emuLog != NULL) fflush( emuLog );
 }
 
-static void __concall ConsoleToFile_SetTitle( const wxString& title )
+static void ConsoleToFile_SetTitle( const wxString& title )
 {
 	ConsoleWriter_Stdout.SetTitle(title);
 }
 
-static void __concall ConsoleToFile_DoSetColor( ConsoleColors color )
+static void ConsoleToFile_DoSetColor( ConsoleColors color )
 {
 	ConsoleWriter_Stdout.DoSetColor(color);
 }
@@ -1132,7 +1132,7 @@ Mutex& Pcsx2App::GetProgramLogLock()
 //  ConsoleToWindow Implementations
 // --------------------------------------------------------------------------------------
 template< const IConsoleWriter& secondary >
-static void __concall ConsoleToWindow_SetTitle( const wxString& title )
+static void ConsoleToWindow_SetTitle( const wxString& title )
 {
 	secondary.SetTitle(title);
 	wxCommandEvent evt( pxEvt_SetTitleText );
@@ -1141,13 +1141,13 @@ static void __concall ConsoleToWindow_SetTitle( const wxString& title )
 }
 
 template< const IConsoleWriter& secondary >
-static void __concall ConsoleToWindow_DoSetColor( ConsoleColors color )
+static void ConsoleToWindow_DoSetColor( ConsoleColors color )
 {
 	secondary.DoSetColor(color);
 }
 
 template< const IConsoleWriter& secondary >
-static void __concall ConsoleToWindow_Newline()
+static void ConsoleToWindow_Newline()
 {
 	secondary.Newline();
 
@@ -1158,7 +1158,7 @@ static void __concall ConsoleToWindow_Newline()
 }
 
 template< const IConsoleWriter& secondary >
-static void __concall ConsoleToWindow_DoWrite( const wxString& fmt )
+static void ConsoleToWindow_DoWrite( const wxString& fmt )
 {
 	if( secondary.WriteRaw != NULL )
 		secondary.WriteRaw( fmt );
@@ -1170,7 +1170,7 @@ static void __concall ConsoleToWindow_DoWrite( const wxString& fmt )
 }
 
 template< const IConsoleWriter& secondary >
-static void __concall ConsoleToWindow_DoWriteLn( const wxString& fmt )
+static void ConsoleToWindow_DoWriteLn( const wxString& fmt )
 {
 	if( secondary.DoWriteLn != NULL )
 		secondary.DoWriteLn( fmt );
@@ -1181,7 +1181,7 @@ static void __concall ConsoleToWindow_DoWriteLn( const wxString& fmt )
 	if( needsSleep ) wxGetApp().Ping();
 }
 
-typedef void __concall DoWriteFn(const wxString&);
+typedef void DoWriteFn(const wxString&);
 
 static const IConsoleWriter	ConsoleWriter_Window =
 {

--- a/pcsx2/ps2/HwInternal.h
+++ b/pcsx2/ps2/HwInternal.h
@@ -38,28 +38,28 @@
 #define iswitch(mem)
 
 // hw read functions
-template< uint page > extern mem8_t  __fastcall hwRead8  (u32 mem);
-template< uint page > extern mem16_t __fastcall hwRead16 (u32 mem);
-template< uint page > extern mem32_t __fastcall hwRead32 (u32 mem);
+template< uint page > extern mem8_t  hwRead8  (u32 mem);
+template< uint page > extern mem16_t hwRead16 (u32 mem);
+template< uint page > extern mem32_t hwRead32 (u32 mem);
 template< uint page > extern RETURNS_R64        hwRead64 (u32 mem);
 template< uint page > extern RETURNS_R128       hwRead128(u32 mem);
 
 // Internal hwRead32 which does not log reads, used by hwWrite8/16 to perform
 // read-modify-write operations.
 template< uint page, bool intcstathack >
-extern mem32_t __fastcall _hwRead32(u32 mem);
+extern mem32_t _hwRead32(u32 mem);
 
-extern mem16_t __fastcall hwRead16_page_0F_INTC_HACK(u32 mem);
-extern mem32_t __fastcall hwRead32_page_0F_INTC_HACK(u32 mem);
+extern mem16_t hwRead16_page_0F_INTC_HACK(u32 mem);
+extern mem32_t hwRead32_page_0F_INTC_HACK(u32 mem);
 
 
 // hw write functions
-template<uint page> extern void __fastcall hwWrite8  (u32 mem, u8  value);
-template<uint page> extern void __fastcall hwWrite16 (u32 mem, u16 value);
+template<uint page> extern void hwWrite8  (u32 mem, u8  value);
+template<uint page> extern void hwWrite16 (u32 mem, u16 value);
 
-template<uint page> extern void __fastcall hwWrite32 (u32 mem, mem32_t value);
-template<uint page> extern void __fastcall hwWrite64 (u32 mem, const mem64_t* srcval);
-template<uint page> extern void __fastcall hwWrite128(u32 mem, const mem128_t* srcval);
+template<uint page> extern void hwWrite32 (u32 mem, mem32_t value);
+template<uint page> extern void hwWrite64 (u32 mem, const mem64_t* srcval);
+template<uint page> extern void hwWrite128(u32 mem, const mem128_t* srcval);
 
 // --------------------------------------------------------------------------------------
 //  Hardware FIFOs (128 bit access only!)
@@ -70,10 +70,10 @@ template<uint page> extern void __fastcall hwWrite128(u32 mem, const mem128_t* s
 // IPUout -- 0x10007000 -- eeHw[0x7000]
 // IPUin  -- 0x10007010 -- eeHw[0x7010]
 
-extern void __fastcall ReadFIFO_VIF1(mem128_t* out);
-extern void __fastcall ReadFIFO_IPUout(mem128_t* out);
+extern void ReadFIFO_VIF1(mem128_t* out);
+extern void ReadFIFO_IPUout(mem128_t* out);
 
-extern void __fastcall WriteFIFO_VIF0(const mem128_t* value);
-extern void __fastcall WriteFIFO_VIF1(const mem128_t* value);
-extern void __fastcall WriteFIFO_GIF(const mem128_t* value);
-extern void __fastcall WriteFIFO_IPUin(const mem128_t* value);
+extern void WriteFIFO_VIF0(const mem128_t* value);
+extern void WriteFIFO_VIF1(const mem128_t* value);
+extern void WriteFIFO_GIF(const mem128_t* value);
+extern void WriteFIFO_IPUin(const mem128_t* value);

--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -36,7 +36,7 @@ using namespace Internal;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem8_t __fastcall iopHwRead8_Page1( u32 addr )
+mem8_t iopHwRead8_Page1( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f801xxx:
 	pxAssume( (addr >> 12) == 0x1f801 );
@@ -93,7 +93,7 @@ mem8_t __fastcall iopHwRead8_Page1( u32 addr )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem8_t __fastcall iopHwRead8_Page3( u32 addr )
+mem8_t iopHwRead8_Page3( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f803xxx:
 	pxAssume( (addr >> 12) == 0x1f803 );
@@ -111,7 +111,7 @@ mem8_t __fastcall iopHwRead8_Page3( u32 addr )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem8_t __fastcall iopHwRead8_Page8( u32 addr )
+mem8_t iopHwRead8_Page8( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssume( (addr >> 12) == 0x1f808 );
@@ -357,14 +357,14 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem16_t __fastcall iopHwRead16_Page1( u32 addr )
+mem16_t iopHwRead16_Page1( u32 addr )
 {
 	return _HwRead_16or32_Page1<mem16_t>( addr );
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem16_t __fastcall iopHwRead16_Page3( u32 addr )
+mem16_t iopHwRead16_Page3( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f803xxx:
 	pxAssume( (addr >> 12) == 0x1f803 );
@@ -376,7 +376,7 @@ mem16_t __fastcall iopHwRead16_Page3( u32 addr )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem16_t __fastcall iopHwRead16_Page8( u32 addr )
+mem16_t iopHwRead16_Page8( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssume( (addr >> 12) == 0x1f808 );
@@ -388,14 +388,14 @@ mem16_t __fastcall iopHwRead16_Page8( u32 addr )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem32_t __fastcall iopHwRead32_Page1( u32 addr )
+mem32_t iopHwRead32_Page1( u32 addr )
 {
 	return _HwRead_16or32_Page1<mem32_t>( addr );
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem32_t __fastcall iopHwRead32_Page3( u32 addr )
+mem32_t iopHwRead32_Page3( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f803xxx:
 	pxAssume( (addr >> 12) == 0x1f803 );
@@ -406,7 +406,7 @@ mem32_t __fastcall iopHwRead32_Page3( u32 addr )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-mem32_t __fastcall iopHwRead32_Page8( u32 addr )
+mem32_t iopHwRead32_Page8( u32 addr )
 {
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssume( (addr >> 12) == 0x1f808 );

--- a/pcsx2/ps2/Iop/IopHwWrite.cpp
+++ b/pcsx2/ps2/Iop/IopHwWrite.cpp
@@ -48,9 +48,9 @@ static __fi void _generic_write( u32 addr, T val )
 	psxHu(addr) = val;
 }
 
-void __fastcall iopHwWrite8_generic( u32 addr, mem8_t val )		{ _generic_write<mem8_t>( addr, val ); }
-void __fastcall iopHwWrite16_generic( u32 addr, mem16_t val )	{ _generic_write<mem16_t>( addr, val ); }
-void __fastcall iopHwWrite32_generic( u32 addr, mem32_t val )	{ _generic_write<mem32_t>( addr, val ); }
+void iopHwWrite8_generic( u32 addr, mem8_t val )		{ _generic_write<mem8_t>( addr, val ); }
+void iopHwWrite16_generic( u32 addr, mem16_t val )	{ _generic_write<mem16_t>( addr, val ); }
+void iopHwWrite32_generic( u32 addr, mem32_t val )	{ _generic_write<mem32_t>( addr, val ); }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -64,14 +64,14 @@ static __fi T _generic_read( u32 addr )
 	return ret;
 }
 
-mem8_t __fastcall iopHwRead8_generic( u32 addr )	{ return _generic_read<mem8_t>( addr ); }
-mem16_t __fastcall iopHwRead16_generic( u32 addr )	{ return _generic_read<mem16_t>( addr ); }
-mem32_t __fastcall iopHwRead32_generic( u32 addr )	{ return _generic_read<mem32_t>( addr ); }
+mem8_t iopHwRead8_generic( u32 addr )	{ return _generic_read<mem8_t>( addr ); }
+mem16_t iopHwRead16_generic( u32 addr )	{ return _generic_read<mem16_t>( addr ); }
+mem32_t iopHwRead32_generic( u32 addr )	{ return _generic_read<mem32_t>( addr ); }
 
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-void __fastcall iopHwWrite8_Page1( u32 addr, mem8_t val )
+void iopHwWrite8_Page1( u32 addr, mem8_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f801xxx:
 	pxAssert( (addr >> 12) == 0x1f801 );
@@ -117,7 +117,7 @@ void __fastcall iopHwWrite8_Page1( u32 addr, mem8_t val )
 	IopHwTraceLog<mem8_t>( addr, val, false );
 }
 
-void __fastcall iopHwWrite8_Page3( u32 addr, mem8_t val )
+void iopHwWrite8_Page3( u32 addr, mem8_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f803xxx:
 	pxAssert( (addr >> 12) == 0x1f803 );
@@ -151,7 +151,7 @@ void __fastcall iopHwWrite8_Page3( u32 addr, mem8_t val )
 	IopHwTraceLog<mem8_t>( addr, val, false );
 }
 
-void __fastcall iopHwWrite8_Page8( u32 addr, mem8_t val )
+void iopHwWrite8_Page8( u32 addr, mem8_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssert( (addr >> 12) == 0x1f808 );
@@ -541,12 +541,12 @@ static __fi void _HwWrite_16or32_Page1( u32 addr, T val )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-void __fastcall iopHwWrite16_Page1( u32 addr, mem16_t val )
+void iopHwWrite16_Page1( u32 addr, mem16_t val )
 {
 	_HwWrite_16or32_Page1<mem16_t>( addr, val );
 }
 
-void __fastcall iopHwWrite16_Page3( u32 addr, mem16_t val )
+void iopHwWrite16_Page3( u32 addr, mem16_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f803xxx:
 	pxAssert( (addr >> 12) == 0x1f803 );
@@ -554,7 +554,7 @@ void __fastcall iopHwWrite16_Page3( u32 addr, mem16_t val )
 	IopHwTraceLog<mem16_t>( addr, val, false );
 }
 
-void __fastcall iopHwWrite16_Page8( u32 addr, mem16_t val )
+void iopHwWrite16_Page8( u32 addr, mem16_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssert( (addr >> 12) == 0x1f808 );
@@ -564,12 +564,12 @@ void __fastcall iopHwWrite16_Page8( u32 addr, mem16_t val )
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-void __fastcall iopHwWrite32_Page1( u32 addr, mem32_t val )
+void iopHwWrite32_Page1( u32 addr, mem32_t val )
 {
 	_HwWrite_16or32_Page1<mem32_t >( addr, val );
 }
 
-void __fastcall iopHwWrite32_Page3( u32 addr, mem32_t val )
+void iopHwWrite32_Page3( u32 addr, mem32_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f803xxx:
 	pxAssert( (addr >> 12) == 0x1f803 );
@@ -577,7 +577,7 @@ void __fastcall iopHwWrite32_Page3( u32 addr, mem32_t val )
 	IopHwTraceLog<mem32_t>( addr, val, false );
 }
 
-void __fastcall iopHwWrite32_Page8( u32 addr, mem32_t val )
+void iopHwWrite32_Page8( u32 addr, mem32_t val )
 {
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssert( (addr >> 12) == 0x1f808 );

--- a/pcsx2/ps2/Iop/PsxBios.cpp
+++ b/pcsx2/ps2/Iop/PsxBios.cpp
@@ -62,7 +62,7 @@ void psxBiosReset()
 
 // Called for PlayStation BIOS calls at 0xA0, 0xB0 and 0xC0 in kernel reserved memory (seemingly by actually calling those addresses)
 // Returns true if we internally process the call, not that we're likely to do any such thing
-bool __fastcall psxBiosCall()
+bool psxBiosCall()
 {
     // TODO: Tracing
     // TODO (maybe, psx is hardly a priority): HLE framework

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -113,7 +113,7 @@ __inline int CheckCache(u32 addr)
 // See recVTLB.cpp for the dynarec versions.
 
 template< typename DataType >
-DataType __fastcall vtlb_memRead(u32 addr)
+DataType vtlb_memRead(u32 addr)
 {
 	static const uint DataSize = sizeof(DataType) * 8;
 	auto vmv = vtlbdata.vmap[addr>>VTLB_PAGE_BITS];
@@ -214,7 +214,7 @@ RETURNS_R128 vtlb_memRead128(u32 mem)
 }
 
 template< typename DataType >
-void __fastcall vtlb_memWrite(u32 addr, DataType data)
+void vtlb_memWrite(u32 addr, DataType data)
 {
 	static const uint DataSize = sizeof(DataType) * 8;
 
@@ -252,7 +252,7 @@ void __fastcall vtlb_memWrite(u32 addr, DataType data)
 	}
 }
 
-void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value)
+void vtlb_memWrite64(u32 mem, const mem64_t* value)
 {
 	auto vmv = vtlbdata.vmap[mem>>VTLB_PAGE_BITS];
 
@@ -279,7 +279,7 @@ void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value)
 	}
 }
 
-void __fastcall vtlb_memWrite128(u32 mem, const mem128_t *value)
+void vtlb_memWrite128(u32 mem, const mem128_t *value)
 {
 	auto vmv = vtlbdata.vmap[mem>>VTLB_PAGE_BITS];
 
@@ -338,7 +338,7 @@ static void GoemonTlbMissDebug()
 	}
 }
 
-void __fastcall GoemonPreloadTlb()
+void GoemonPreloadTlb()
 {
 	// 0x3d5580 is the address of the TLB cache table
 	GoemonTlb* tlb = (GoemonTlb*)&eeMem->Main[0x3d5580];
@@ -362,7 +362,7 @@ void __fastcall GoemonPreloadTlb()
 	}
 }
 
-void __fastcall GoemonUnloadTlb(u32 key)
+void GoemonUnloadTlb(u32 key)
 {
 	// 0x3d5580 is the address of the TLB cache table
 	GoemonTlb* tlb = (GoemonTlb*)&eeMem->Main[0x3d5580];
@@ -434,28 +434,28 @@ static __ri void vtlb_BusError(u32 addr,u32 mode)
 }
 
 template<typename OperandType, u32 saddr>
-OperandType __fastcall vtlbUnmappedVReadSm(u32 addr)                   { vtlb_Miss(addr|saddr,0); return 0; }
+OperandType vtlbUnmappedVReadSm(u32 addr)                   { vtlb_Miss(addr|saddr,0); return 0; }
 
 template<typename OperandType, u32 saddr>
 u_to_r<OperandType> __vectorcall vtlbUnmappedVReadLg(u32 addr)         { vtlb_Miss(addr|saddr,0); return rhelper<OperandType>::zero(); }
 
 template<typename OperandType, u32 saddr>
-void __fastcall vtlbUnmappedVWriteSm(u32 addr,OperandType data)        { vtlb_Miss(addr|saddr,1); }
+void vtlbUnmappedVWriteSm(u32 addr,OperandType data)        { vtlb_Miss(addr|saddr,1); }
 
 template<typename OperandType, u32 saddr>
-void __fastcall vtlbUnmappedVWriteLg(u32 addr,const OperandType* data) { vtlb_Miss(addr|saddr,1); }
+void vtlbUnmappedVWriteLg(u32 addr,const OperandType* data) { vtlb_Miss(addr|saddr,1); }
 
 template<typename OperandType, u32 saddr>
-OperandType __fastcall vtlbUnmappedPReadSm(u32 addr)                   { vtlb_BusError(addr|saddr,0); return 0; }
+OperandType vtlbUnmappedPReadSm(u32 addr)                   { vtlb_BusError(addr|saddr,0); return 0; }
 
 template<typename OperandType, u32 saddr>
 u_to_r<OperandType> __vectorcall vtlbUnmappedPReadLg(u32 addr)         { vtlb_BusError(addr|saddr,0); return rhelper<OperandType>::zero(); }
 
 template<typename OperandType, u32 saddr>
-void __fastcall vtlbUnmappedPWriteSm(u32 addr,OperandType data)        { vtlb_BusError(addr|saddr,1); }
+void vtlbUnmappedPWriteSm(u32 addr,OperandType data)        { vtlb_BusError(addr|saddr,1); }
 
 template<typename OperandType, u32 saddr>
-void __fastcall vtlbUnmappedPWriteLg(u32 addr,const OperandType* data) { vtlb_BusError(addr|saddr,1); }
+void vtlbUnmappedPWriteLg(u32 addr,const OperandType* data) { vtlb_BusError(addr|saddr,1); }
 
 // --------------------------------------------------------------------------------------
 //  VTLB mapping errors
@@ -464,19 +464,19 @@ void __fastcall vtlbUnmappedPWriteLg(u32 addr,const OperandType* data) { vtlb_Bu
 // properly.  All addressable physical memory should be configured as TLBMiss or Bus Error.
 //
 
-static mem8_t __fastcall vtlbDefaultPhyRead8(u32 addr)
+static mem8_t vtlbDefaultPhyRead8(u32 addr)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted read8 from unmapped physical address @ 0x%08X.", addr));
 	return 0;
 }
 
-static mem16_t __fastcall vtlbDefaultPhyRead16(u32 addr)
+static mem16_t vtlbDefaultPhyRead16(u32 addr)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted read16 from unmapped physical address @ 0x%08X.", addr));
 	return 0;
 }
 
-static mem32_t __fastcall vtlbDefaultPhyRead32(u32 addr)
+static mem32_t vtlbDefaultPhyRead32(u32 addr)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted read32 from unmapped physical address @ 0x%08X.", addr));
 	return 0;
@@ -494,27 +494,27 @@ static __m128i __vectorcall vtlbDefaultPhyRead128(u32 addr)
 	return r128_zero();
 }
 
-static void __fastcall vtlbDefaultPhyWrite8(u32 addr, mem8_t data)
+static void vtlbDefaultPhyWrite8(u32 addr, mem8_t data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write8 to unmapped physical address @ 0x%08X.", addr));
 }
 
-static void __fastcall vtlbDefaultPhyWrite16(u32 addr, mem16_t data)
+static void vtlbDefaultPhyWrite16(u32 addr, mem16_t data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write16 to unmapped physical address @ 0x%08X.", addr));
 }
 
-static void __fastcall vtlbDefaultPhyWrite32(u32 addr, mem32_t data)
+static void vtlbDefaultPhyWrite32(u32 addr, mem32_t data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write32 to unmapped physical address @ 0x%08X.", addr));
 }
 
-static void __fastcall vtlbDefaultPhyWrite64(u32 addr,const mem64_t* data)
+static void vtlbDefaultPhyWrite64(u32 addr,const mem64_t* data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write64 to unmapped physical address @ 0x%08X.", addr));
 }
 
-static void __fastcall vtlbDefaultPhyWrite128(u32 addr,const mem128_t* data)
+static void vtlbDefaultPhyWrite128(u32 addr,const mem128_t* data)
 {
 	pxFailDev(pxsFmt("(VTLB) Attempted write128 to unmapped physical address @ 0x%08X.", addr));
 }

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -23,18 +23,18 @@
 static const uptr VTLB_AllocUpperBounds = _1gb * 2;
 
 // Specialized function pointers for each read type
-typedef  mem8_t __fastcall vtlbMemR8FP(u32 addr);
-typedef  mem16_t __fastcall vtlbMemR16FP(u32 addr);
-typedef  mem32_t __fastcall vtlbMemR32FP(u32 addr);
+typedef  mem8_t vtlbMemR8FP(u32 addr);
+typedef  mem16_t vtlbMemR16FP(u32 addr);
+typedef  mem32_t vtlbMemR32FP(u32 addr);
 typedef  RETURNS_R64 vtlbMemR64FP(u32 addr);
 typedef  RETURNS_R128 vtlbMemR128FP(u32 addr);
 
 // Specialized function pointers for each write type
-typedef  void __fastcall vtlbMemW8FP(u32 addr,mem8_t data);
-typedef  void __fastcall vtlbMemW16FP(u32 addr,mem16_t data);
-typedef  void __fastcall vtlbMemW32FP(u32 addr,mem32_t data);
-typedef  void __fastcall vtlbMemW64FP(u32 addr,const mem64_t* data);
-typedef  void __fastcall vtlbMemW128FP(u32 addr,const mem128_t* data);
+typedef  void vtlbMemW8FP(u32 addr,mem8_t data);
+typedef  void vtlbMemW16FP(u32 addr,mem16_t data);
+typedef  void vtlbMemW32FP(u32 addr,mem32_t data);
+typedef  void vtlbMemW64FP(u32 addr,const mem64_t* data);
+typedef  void vtlbMemW128FP(u32 addr,const mem128_t* data);
 
 template <size_t Width, bool Write> struct vtlbMemFP;
 
@@ -87,14 +87,14 @@ extern void vtlb_VMapUnmap(u32 vaddr,u32 sz);
 //Memory functions
 
 template< typename DataType >
-extern DataType __fastcall vtlb_memRead(u32 mem);
+extern DataType vtlb_memRead(u32 mem);
 extern RETURNS_R64 vtlb_memRead64(u32 mem);
 extern RETURNS_R128 vtlb_memRead128(u32 mem);
 
 template< typename DataType >
-extern void __fastcall vtlb_memWrite(u32 mem, DataType value);
-extern void __fastcall vtlb_memWrite64(u32 mem, const mem64_t* value);
-extern void __fastcall vtlb_memWrite128(u32 mem, const mem128_t* value);
+extern void vtlb_memWrite(u32 mem, DataType value);
+extern void vtlb_memWrite64(u32 mem, const mem64_t* value);
+extern void vtlb_memWrite128(u32 mem, const mem128_t* value);
 
 extern void vtlb_DynGenWrite(u32 sz);
 extern void vtlb_DynGenRead32(u32 bits, bool sign);

--- a/pcsx2/x86/iFPU.cpp
+++ b/pcsx2/x86/iFPU.cpp
@@ -504,7 +504,7 @@ void FPU_SUB(int regd, int regt)
 // or SMALLER (by 0x1). (this means that x86's other rounding modes are only less similar to PS2's mul)
 //------------------------------------------------------------------
 
-u32 __fastcall FPU_MUL_HACK(u32 s, u32 t)
+u32 FPU_MUL_HACK(u32 s, u32 t)
 {
 	if ((s == 0x3e800000) && (t == 0x40490fdb))
 		return 0x3f490fda; // needed for Tales of Destiny Remake (only in a very specific room late-game)

--- a/pcsx2/x86/iFPUd.cpp
+++ b/pcsx2/x86/iFPUd.cpp
@@ -63,7 +63,7 @@ namespace Dynarec {
 namespace OpcodeImpl {
 namespace COP1 {
 
-u32 __fastcall FPU_MUL_HACK(u32 s, u32 t);
+u32 FPU_MUL_HACK(u32 s, u32 t);
 
 namespace DOUBLE {
 

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -108,7 +108,7 @@ static u32 psxdump = 0;
 //  Dynamically Compiled Dispatchers - R3000A style
 // =====================================================================================================
 
-static void __fastcall iopRecRecompile(const u32 startpc);
+static void iopRecRecompile(const u32 startpc);
 
 // Recompiled code buffer for EE recompiler dispatchers!
 alignas(__pagesize) static u8 iopRecDispatchers[__pagesize];
@@ -1272,7 +1272,7 @@ void psxRecompileNextInstruction(int delayslot)
 	_clearNeededX86regs();
 }
 
-static void __fastcall PreBlockCheck(u32 blockpc)
+static void PreBlockCheck(u32 blockpc)
 {
 #ifdef PCSX2_DEBUG
 	extern void iDumpPsxRegisters(u32 startpc, u32 temp);
@@ -1298,7 +1298,7 @@ static void __fastcall PreBlockCheck(u32 blockpc)
 #endif
 }
 
-static void __fastcall iopRecRecompile(const u32 startpc)
+static void iopRecRecompile(const u32 startpc)
 {
 	u32 i;
 	u32 willbranch3 = 0;

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -355,9 +355,9 @@ void recCall(void (*func)())
 //  R5900 Dispatchers
 // =====================================================================================================
 
-static void __fastcall recRecompile(const u32 startpc);
-static void __fastcall dyna_block_discard(u32 start, u32 sz);
-static void __fastcall dyna_page_reset(u32 start, u32 sz);
+static void recRecompile(const u32 startpc);
+static void dyna_block_discard(u32 start, u32 sz);
+static void dyna_page_reset(u32 start, u32 sz);
 
 // Recompiled code buffer for EE recompiler dispatchers!
 alignas(__pagesize) static u8 eeRecDispatchers[__pagesize];
@@ -1310,7 +1310,7 @@ void dynarecMemcheck()
 	recExitExecution();
 }
 
-void __fastcall dynarecMemLogcheck(u32 start, bool store)
+void dynarecMemLogcheck(u32 start, bool store)
 {
 	if (store)
 		DevCon.WriteLn("Hit store breakpoint @0x%x", start);
@@ -1640,7 +1640,7 @@ void recompileNextInstruction(int delayslot)
 // (Called from recompiled code)]
 // This function is called from the recompiler prior to starting execution of *every* recompiled block.
 // Calling of this function can be enabled or disabled through the use of EmuConfig.Recompiler.PreBlockChecks
-static void __fastcall PreBlockCheck(u32 blockpc)
+static void PreBlockCheck(u32 blockpc)
 {
 	/*static int lastrec = 0;
 	static int curcount = 0;
@@ -1667,7 +1667,7 @@ static u32 s_recblocks[] = {0};
 // Called when a block under manual protection fails it's pre-execution integrity check.
 // (meaning the actual code area has been modified -- ie dynamic modules being loaded or,
 //  less likely, self-modifying code)
-void __fastcall dyna_block_discard(u32 start, u32 sz)
+void dyna_block_discard(u32 start, u32 sz)
 {
 	eeRecPerfLog.Write(Color_StrongGray, "Clearing Manual Block @ 0x%08X  [size=%d]", start, sz * 4);
 	recClear(start, sz);
@@ -1676,7 +1676,7 @@ void __fastcall dyna_block_discard(u32 start, u32 sz)
 // called when a page under manual protection has been run enough times to be a candidate
 // for being reset under the faster vtlb write protection.  All blocks in the page are cleared
 // and the block is re-assigned for write protection.
-void __fastcall dyna_page_reset(u32 start, u32 sz)
+void dyna_page_reset(u32 start, u32 sz)
 {
 	recClear(start & ~0xfffUL, 0x400);
 	manual_counter[start >> 12]++;
@@ -1805,7 +1805,7 @@ void doPlace0Patches()
 	ApplyLoadedPatches(PPT_ONCE_ON_LOAD);
 }
 
-static void __fastcall recRecompile(const u32 startpc)
+static void recRecompile(const u32 startpc)
 {
 	u32 i = 0;
 	u32 willbranch3 = 0;

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -301,7 +301,7 @@ static void DynGen_IndirectTlbDispatcher(int mode, int bits, bool sign)
 		xSUB(arg1regd, 0x80000000);
 	xSUB(arg1regd, eax);
 
-	// jump to the indirect handler, which is a __fastcall C++ function.
+	// jump to the indirect handler, which is a C++ function.
 	// [ecx is address, edx is data]
 	sptr table = (sptr)vtlbdata.RWFT[bits][mode];
 	if (table == (s32)table)

--- a/pcsx2/x86/microVU.h
+++ b/pcsx2/x86/microVU.h
@@ -266,11 +266,11 @@ int mVUdebugNow = 0;
 extern void mVUclear(mV, u32, u32);
 extern void mVUreset(microVU& mVU, bool resetReserve);
 extern void* mVUblockFetch(microVU& mVU, u32 startPC, uptr pState);
-_mVUt extern void* __fastcall mVUcompileJIT(u32 startPC, uptr ptr);
+_mVUt extern void* mVUcompileJIT(u32 startPC, uptr ptr);
 
 // Prototypes for Linux
-extern void __fastcall mVUcleanUpVU0();
-extern void __fastcall mVUcleanUpVU1();
+extern void mVUcleanUpVU0();
+extern void mVUcleanUpVU1();
 mVUop(mVUopU);
 mVUop(mVUopL);
 
@@ -278,11 +278,11 @@ mVUop(mVUopL);
 extern void mVUcacheProg(microVU& mVU, microProgram& prog);
 extern void mVUdeleteProg(microVU& mVU, microProgram*& prog);
 _mVUt extern void* mVUsearchProg(u32 startPC, uptr pState);
-extern void* __fastcall mVUexecuteVU0(u32 startPC, u32 cycles);
-extern void* __fastcall mVUexecuteVU1(u32 startPC, u32 cycles);
+extern void* mVUexecuteVU0(u32 startPC, u32 cycles);
+extern void* mVUexecuteVU1(u32 startPC, u32 cycles);
 
 // recCall Function Pointer
-typedef void(__fastcall* mVUrecCall)(u32, u32);
+typedef void (*mVUrecCall)(u32, u32);
 typedef void (*mVUrecCallXG)(void);
 
 template <typename T>

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -19,12 +19,12 @@
 // Messages Called at Execution Time...
 //------------------------------------------------------------------
 
-static inline void __fc mVUbadOp0  (u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
-static inline void __fc mVUbadOp1  (u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
-static inline void __fc mVUwarning0(u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
-static inline void __fc mVUwarning1(u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
-static inline void __fc mVUprintPC1(u32 pc) { Console.WriteLn("Block Start PC = 0x%04x", pc); }
-static inline void __fc mVUprintPC2(u32 pc) { Console.WriteLn("Block End PC   = 0x%04x", pc); }
+static inline void mVUbadOp0  (u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
+static inline void mVUbadOp1  (u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting... Block contains an illegal opcode. [%04x] [%03d]", pc, prog); }
+static inline void mVUwarning0(u32 prog, u32 pc) { Console.Error("microVU0 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
+static inline void mVUwarning1(u32 prog, u32 pc) { Console.Error("microVU1 Warning: Exiting from Possible Infinite Loop [%04x] [%03d]", pc, prog); }
+static inline void mVUprintPC1(u32 pc) { Console.WriteLn("Block Start PC = 0x%04x", pc); }
+static inline void mVUprintPC2(u32 pc) { Console.WriteLn("Block End PC   = 0x%04x", pc); }
 
 //------------------------------------------------------------------
 // Program Range Checking and Setting up Ranges
@@ -901,7 +901,7 @@ __fi void* mVUblockFetch(microVU& mVU, u32 startPC, uptr pState)
 }
 
 // mVUcompileJIT() - Called By JR/JALR during execution
-_mVUt void* __fastcall mVUcompileJIT(u32 startPC, uptr ptr)
+_mVUt void* mVUcompileJIT(u32 startPC, uptr ptr)
 {
 	if (doJumpAsSameProgram) // Treat jump as part of same microProgram
 	{

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -27,7 +27,7 @@ void mVUdispatcherAB(mV)
 	{
 		xScopedStackFrame frame(false, true);
 
-		// __fastcall = The caller has already put the needed parameters in ecx/edx:
+		// = The caller has already put the needed parameters in ecx/edx:
 		if (!isVU1) xFastCall((void*)mVUexecuteVU0, arg1reg, arg2reg);
 		else        xFastCall((void*)mVUexecuteVU1, arg1reg, arg2reg);
 
@@ -73,7 +73,7 @@ void mVUdispatcherAB(mV)
 		// Load EE's MXCSR state
 		xLDMXCSR(g_sseMXCSR);
 
-		// __fastcall = The first two DWORD or smaller arguments are passed in ECX and EDX registers;
+		// = The first two DWORD or smaller arguments are passed in ECX and EDX registers;
 		//              all other arguments are passed right to left.
 		if (!isVU1) xFastCall((void*)mVUcleanUpVU0);
 		else        xFastCall((void*)mVUcleanUpVU1);
@@ -128,7 +128,7 @@ void mVUdispatcherCD(mV)
 //------------------------------------------------------------------
 
 // Executes for number of cycles
-_mVUt void* __fastcall mVUexecute(u32 startPC, u32 cycles)
+_mVUt void* mVUexecute(u32 startPC, u32 cycles)
 {
 
 	microVU& mVU = mVUx;
@@ -187,7 +187,7 @@ _mVUt void mVUcleanUp()
 // Caller Functions
 //------------------------------------------------------------------
 
-void* __fastcall mVUexecuteVU0(u32 startPC, u32 cycles) { return mVUexecute<0>(startPC, cycles); }
-void* __fastcall mVUexecuteVU1(u32 startPC, u32 cycles) { return mVUexecute<1>(startPC, cycles); }
-void __fastcall mVUcleanUpVU0() { mVUcleanUp<0>(); }
-void __fastcall mVUcleanUpVU1() { mVUcleanUp<1>(); }
+void* mVUexecuteVU0(u32 startPC, u32 cycles) { return mVUexecute<0>(startPC, cycles); }
+void* mVUexecuteVU1(u32 startPC, u32 cycles) { return mVUexecute<1>(startPC, cycles); }
+void mVUcleanUpVU0() { mVUcleanUp<0>(); }
+void mVUcleanUpVU1() { mVUcleanUp<1>(); }

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -1542,7 +1542,7 @@ mVUop(mVU_XITOP)
 // XGkick
 //------------------------------------------------------------------
 
-void __fastcall mVU_XGKICK_(u32 addr)
+void mVU_XGKICK_(u32 addr)
 {
 	addr = (addr & 0x3ff) * 16;
 	u32 diff = 0x4000 - addr;
@@ -1560,7 +1560,7 @@ void __fastcall mVU_XGKICK_(u32 addr)
 	}
 }
 
-void __fastcall _vuXGKICKTransfermVU(bool flush)
+void _vuXGKICKTransfermVU(bool flush)
 {
 	while (VU1.xgkickenable && (flush || VU1.xgkickcyclecount >= 2))
 	{

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -173,12 +173,12 @@ static const char branchSTR[16][8] = {
 #define mF int recPass
 #define mX mVU, recPass
 
-typedef void __fastcall Fntype_mVUrecInst(microVU& mVU, int recPass);
+typedef void Fntype_mVUrecInst(microVU& mVU, int recPass);
 typedef Fntype_mVUrecInst* Fnptr_mVUrecInst;
 
 // Function/Template Stuff
 #define mVUx (vuIndex ? microVU1 : microVU0)
-#define mVUop(opName) static void __fastcall opName(mP)
+#define mVUop(opName) static void opName(mP)
 #define _mVUt template <int vuIndex>
 
 // Define Passes
@@ -197,7 +197,7 @@ typedef Fntype_mVUrecInst* Fnptr_mVUrecInst;
 // Define mVUquickSearch
 //------------------------------------------------------------------
 alignas(__pagesize) extern u8 mVUsearchXMM[__pagesize];
-typedef u32(__fastcall* mVUCall)(void*, void*);
+typedef u32 (*mVUCall)(void*, void*);
 #define mVUquickSearch(dest, src, size) ((((mVUCall)((void*)mVUsearchXMM))(dest, src)) == 0xf)
 #define mVUemitSearch() \
 	{ \

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -194,7 +194,7 @@ public:
 	}
 };
 
-_mVUt void __fc mVUprintRegs()
+_mVUt void mVUprintRegs()
 {
 	microVU& mVU = mVUx;
 	for (int i = 0; i < mVU.regAlloc->getXmmCount(); i++)
@@ -212,19 +212,19 @@ _mVUt void __fc mVUprintRegs()
 }
 
 // Gets called by mVUaddrFix at execution-time
-static void __fc mVUwarningRegAccess(u32 prog, u32 pc)
+static void mVUwarningRegAccess(u32 prog, u32 pc)
 {
 	Console.Error("microVU0 Warning: Accessing VU1 Regs! [%04x] [%x]", pc, prog);
 }
 
-static void __fc mVUTBit()
+static void mVUTBit()
 {
 	u32 old = vu1Thread.mtvuInterrupts.fetch_or(VU_Thread::InterruptFlagVUTBit, std::memory_order_release);
 	if (old & VU_Thread::InterruptFlagVUTBit)
 		DevCon.Warning("Old TBit not registered");
 }
 
-static void __fc mVUEBit()
+static void mVUEBit()
 {
 	vu1Thread.mtvuInterrupts.fetch_or(VU_Thread::InterruptFlagVUEBit, std::memory_order_release);
 }
@@ -235,7 +235,7 @@ static inline u32 branchAddr(const mV)
 	return ((((iPC + 2) + (_Imm11_ * 2)) & mVU.progMemMask) * 4);
 }
 
-static void __fc mVUwaitMTVU()
+static void mVUwaitMTVU()
 {
 	if (IsDevBuild)
 		DevCon.WriteLn("microVU0: Waiting on VU1 thread to access VU1 regs!");

--- a/pcsx2/x86/newVif.h
+++ b/pcsx2/x86/newVif.h
@@ -24,8 +24,8 @@
 using namespace x86Emitter;
 
 // newVif_HashBucket.h uses this typedef, so it has to be declared first.
-typedef u32 (__fastcall* nVifCall)(void*, const void*);
-typedef void(__fastcall* nVifrecCall)(uptr dest, uptr src);
+typedef u32  (*nVifCall)(void*, const void*);
+typedef void (*nVifrecCall)(uptr dest, uptr src);
 
 #include "newVif_HashBucket.h"
 

--- a/pcsx2/x86/newVif_Unpack.cpp
+++ b/pcsx2/x86/newVif_Unpack.cpp
@@ -57,9 +57,9 @@ alignas(16) const u8 nVifT[16] = {
 
 // ----------------------------------------------------------------------------
 template <int idx, bool doMode, bool isFill>
-__ri void __fastcall _nVifUnpackLoop(const u8* data);
+__ri void _nVifUnpackLoop(const u8* data);
 
-typedef void __fastcall FnType_VifUnpackLoop(const u8* data);
+typedef void FnType_VifUnpackLoop(const u8* data);
 typedef FnType_VifUnpackLoop* Fnptr_VifUnpackLoop;
 
 // Unpacks Until 'Num' is 0
@@ -228,7 +228,7 @@ static void setMasks(const vifStruct& vif, const VIFregisters& v)
 
 // size - size of the packet fragment incoming from DMAC.
 template <int idx, bool doMode, bool isFill>
-__ri void __fastcall _nVifUnpackLoop(const u8* data)
+__ri void _nVifUnpackLoop(const u8* data)
 {
 
 	vifStruct& vif = MTVU_VifX;


### PR DESCRIPTION
### Description of Changes

These have no meaning in x64 (apart from throwing compiler warnings), and we don't do 32-bit anymore. Also saves needing to include `Pcsx2Defs.h` in files which don't otherwise need it.

### Rationale behind Changes

Getting rid of the remnants of 32-bit.

### Suggested Testing Steps

Make sure things like the recompilers aren't broken. They shouldn't be, because the specifier should have no effect.
