### PR TITLE
GameDB: Adds SkipDraw ranges to 'Tales of the Abyss'

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1081,6 +1081,8 @@ SCAJ-20163:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 100 # Fixes black line grids in skyboxes and ghosting in some instances
+    skipDrawEnd: 361 # Fixes black line grids in skyboxes and ghosting in some instances
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
@@ -30692,6 +30694,8 @@ SLPM-66897:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 100 # Fixes black line grids in skyboxes and ghosting in some instances
+    skipDrawEnd: 361 # Fixes black line grids in skyboxes and ghosting in some instances
 SLPM-66898:
   name: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
@@ -34608,6 +34612,8 @@ SLPS-25586:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 100 # Fixes black line grids in skyboxes and ghosting in some instances
+    skipDrawEnd: 361 # Fixes black line grids in skyboxes and ghosting in some instances
 SLPS-25587:
   name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
@@ -36291,6 +36297,8 @@ SLPS-73252:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 100 # Fixes black line grids in skyboxes and ghosting in some instances
+    skipDrawEnd: 361 # Fixes black line grids in skyboxes and ghosting in some instances
 SLPS-73253:
   name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -42715,6 +42723,8 @@ SLUS-21386:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 100 # Fixes black line grids in skyboxes and ghosting in some instances
+    skipDrawEnd: 361 # Fixes black line grids in skyboxes and ghosting in some instances
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
GameDB: Adds SkipDraw ranges to 'Tales of the Abyss'

### Rationale behind Changes
This aims to correct the graphical issues introduced by the use of Upscaling and Half-Pixel Special (Texture) in Tataroo Valley, Engave, Keterburg, Keterburg bay, and outside the castle in Baticul (among others). This does introduce a minor graphical glitch in the Desert Oasis, but should be an acceptable compromise for everything else it corrects

### Suggested Testing Steps
Test suggested areas for any graphical issues