### PR TITLE
GS: Redo a bunch of the ignore offset code

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -510,16 +510,6 @@ GSVector2i GSState::GetResolution()
 		total_rect.w = std::min(total_rect.w, resolution.y);
 		resolution.x = total_rect.z;
 		resolution.y = total_rect.w;
-
-		// When we're ignoring offsets we need to account for pictures which are usually offset up off the screen
-		// where more of the bottom would normally be visible, stops some games looking so cut off.
-		const int display_offset = std::min(GetResolutionOffset(0).y, GetResolutionOffset(1).y);
-
-		// If there is a negative vertical offset on the picture, we need to read more.
-		if (display_offset < 0)
-		{
-			resolution.y += -display_offset;
-		}
 	}
 
 	return resolution;
@@ -555,7 +545,10 @@ GSVector4i GSState::GetFrameRect(int i)
 	rectangle.bottom = rectangle.top + h;
 
 	if (isinterlaced() && m_regs->SMODE2.FFMD && h > 1)
+	{
+		rectangle.bottom += 1;
 		rectangle.bottom >>= 1;
+	}
 
 	return rectangle;
 }


### PR DESCRIPTION
Plus clean up a bunch of stuff which isn't needed

### Description of Changes
Removes a bunch of dead code and made the ignore offsets code more reliable.

### Rationale behind Changes
There was a regression initially with Devil May Cry, however I also noticed a regression with Wipeout, so redesigning this code and cleaning up old dead stuff sorted that out.

### Suggested Testing Steps
Test games with strange display heights, make sure everything is OK.