### PR TITLE
GS/TextureCache: Handle edge cases of replacements with paltex enabled

### DIFF
--- a/pcsx2/GS/GSExtra.h
+++ b/pcsx2/GS/GSExtra.h
@@ -114,10 +114,11 @@ extern Pcsx2Config::GSOptions GSConfig;
 
 // Maximum texture size to skip preload/hash path.
 // This is the width/height from the registers, i.e. not the power of 2.
+static constexpr u32 MAXIMUM_TEXTURE_HASH_CACHE_SIZE = 10; // 1024
 __fi static bool CanCacheTextureSize(u32 tw, u32 th)
 {
-	static constexpr u32 MAXIMUM_CACHE_SIZE = 10; // 1024
-	return (GSConfig.TexturePreloading == TexturePreloadingLevel::Full && tw <= MAXIMUM_CACHE_SIZE && th <= MAXIMUM_CACHE_SIZE);
+	return (GSConfig.TexturePreloading == TexturePreloadingLevel::Full &&
+			tw <= MAXIMUM_TEXTURE_HASH_CACHE_SIZE && th <= MAXIMUM_TEXTURE_HASH_CACHE_SIZE);
 }
 
 __fi static bool CanPreloadTextureSize(u32 tw, u32 th)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1614,6 +1614,15 @@ GSTextureCache::HashCacheEntry* GSTextureCache::LookupHashCache(const GIFRegTEX0
 			// so that when the replacement comes back, there's something for it to swap with.
 			can_cache = true;
 		}
+		else if (paltex)
+		{
+			// there's an edge case here; when there's multiple textures with the same vram data, but different
+			// palettes, if we don't replace all of them, the first one to get loaded in will prevent any of the
+			// others from getting tested for replacement. so, disable paltex for the textures when any of the
+			// palette variants have replacements.
+			if (GSTextureReplacements::HasReplacementTextureWithOtherPalette(key))
+				paltex = false;
+		}
 	}
 
 	// if this texture isn't cacheable, bail out now since we don't want to waste time preloading it

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -137,6 +137,9 @@ namespace GSTextureReplacements
 	/// Lookup map of texture names to replacements, if they exist.
 	static std::unordered_map<TextureName, std::string> s_replacement_texture_filenames;
 
+	/// Lookup map of texture names without CLUT hash, to know when we need to disable paltex.
+	static std::unordered_set<TextureName> s_replacement_textures_without_clut_hash;
+
 	/// Lookup map of texture names to replacement data which has been cached.
 	static std::unordered_map<TextureName, ReplacementTexture> s_replacement_texture_cache;
 	static std::mutex s_replacement_texture_cache_mutex;
@@ -290,9 +293,11 @@ void GSTextureReplacements::ReloadReplacementMap()
 
 	// clear out the caches
 	{
+		s_replacement_texture_filenames.clear();
+		s_replacement_textures_without_clut_hash.clear();
+
 		std::unique_lock<std::mutex> lock(s_replacement_texture_cache_mutex);
 		s_replacement_texture_cache.clear();
-		s_replacement_texture_filenames.clear();
 		s_pending_async_load_textures.clear();
 		s_async_loaded_textures.clear();
 	}
@@ -321,7 +326,11 @@ void GSTextureReplacements::ReloadReplacementMap()
 			continue;
 
 		DevCon.WriteLn("Found %ux%u replacement '%.*s'", name->Width(), name->Height(), static_cast<int>(filename.size()), filename.data());
-		s_replacement_texture_filenames.emplace(std::move(name.value()), std::move(fd.FileName));
+		s_replacement_texture_filenames.emplace(name.value(), std::move(fd.FileName));
+
+		// zero out the CLUT hash, because we need this for checking if there's any replacements with this hash when using paltex
+		name->CLUTHash = 0;
+		s_replacement_textures_without_clut_hash.insert(name.value());
 	}
 
 	if (GSConfig.PrecacheTextureReplacements)
@@ -367,6 +376,12 @@ void GSTextureReplacements::Shutdown()
 u32 GSTextureReplacements::CalcMipmapLevelsForReplacement(u32 width, u32 height)
 {
 	return static_cast<u32>(std::log2(std::max(width, height))) + 1u;
+}
+
+bool GSTextureReplacements::HasReplacementTextureWithOtherPalette(const GSTextureCache::HashCacheKey& hash)
+{
+	const TextureName name(CreateTextureName(hash.WithRemovedCLUTHash(), 0));
+	return s_replacement_textures_without_clut_hash.find(name) != s_replacement_textures_without_clut_hash.end();
 }
 
 GSTexture* GSTextureReplacements::LookupReplacementTexture(const GSTextureCache::HashCacheKey& hash, bool mipmap, bool* pending)
@@ -482,6 +497,7 @@ void GSTextureReplacements::PrecacheReplacementTextures()
 void GSTextureReplacements::ClearReplacementTextures()
 {
 	s_replacement_texture_filenames.clear();
+	s_replacement_textures_without_clut_hash.clear();
 
 	std::unique_lock<std::mutex> lock(s_replacement_texture_cache_mutex);
 	s_replacement_texture_cache.clear();

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -333,8 +333,18 @@ void GSTextureReplacements::ReloadReplacementMap()
 		s_replacement_textures_without_clut_hash.insert(name.value());
 	}
 
-	if (GSConfig.PrecacheTextureReplacements)
-		PrecacheReplacementTextures();
+	if (!s_replacement_texture_filenames.empty())
+	{
+		if (GSConfig.PrecacheTextureReplacements)
+			PrecacheReplacementTextures();
+
+		// log a warning when paltex is on and preloading is off, since we'll be disabling paltex
+		if (GSConfig.GPUPaletteConversion && GSConfig.TexturePreloading != TexturePreloadingLevel::Full)
+		{
+			Console.Warning("Replacement textures were found, and GPU palette conversion is enabled without full preloading.");
+			Console.Warning("Palette textures will be disabled. Please enable full preloading or disable GPU palette conversion.");
+		}
+	}
 }
 
 void GSTextureReplacements::UpdateConfig(Pcsx2Config::GSOptions& old_config)
@@ -376,6 +386,11 @@ void GSTextureReplacements::Shutdown()
 u32 GSTextureReplacements::CalcMipmapLevelsForReplacement(u32 width, u32 height)
 {
 	return static_cast<u32>(std::log2(std::max(width, height))) + 1u;
+}
+
+bool GSTextureReplacements::HasAnyReplacementTextures()
+{
+	return !s_replacement_texture_filenames.empty();
 }
 
 bool GSTextureReplacements::HasReplacementTextureWithOtherPalette(const GSTextureCache::HashCacheKey& hash)

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
@@ -44,6 +44,7 @@ namespace GSTextureReplacements
 
 	u32 CalcMipmapLevelsForReplacement(u32 width, u32 height);
 
+	bool HasReplacementTextureWithOtherPalette(const GSTextureCache::HashCacheKey& hash);
 	GSTexture* LookupReplacementTexture(const GSTextureCache::HashCacheKey& hash, bool mipmap, bool* pending);
 	GSTexture* CreateReplacementTexture(const ReplacementTexture& rtex, const GSVector2& scale, bool mipmap);
 	void ProcessAsyncLoadedTextures();

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
@@ -44,6 +44,7 @@ namespace GSTextureReplacements
 
 	u32 CalcMipmapLevelsForReplacement(u32 width, u32 height);
 
+	bool HasAnyReplacementTextures();
 	bool HasReplacementTextureWithOtherPalette(const GSTextureCache::HashCacheKey& hash);
 	GSTexture* LookupReplacementTexture(const GSTextureCache::HashCacheKey& hash, bool mipmap, bool* pending);
 	GSTexture* CreateReplacementTexture(const ReplacementTexture& rtex, const GSVector2& scale, bool mipmap);


### PR DESCRIPTION
### Description of Changes

From the source comment:

```
// Using paltex without full preloading is a disaster case here. basically, unless *all* textures are
// replaced, any texture can get populated without the hash cache, which means it'll get partial invalidated,
// and unless it's 100% removed, this partial texture will always take precedence over future hash cache
// lookups, making replacements impossible.
```

also handles

```
// There's an edge case here; when there's multiple textures with the same vram data, but different
// palettes, if we don't replace all of them, the first one to get loaded in will prevent any of the
// others from getting tested for replacement. So, disable paltex for the textures when any of the
// palette variants have replacements.
```

Basically, it's a crappy solution (disabling paltex when full preloading isn't used), but it's better than forcing preloading, as that's problematic in more games.

### Rationale behind Changes

Fixing #6062 again.

### Suggested Testing Steps

Test replacements with paltex on.
