### PR TITLE
GS: Improvements for Qt

### DIFF
--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -79,6 +79,7 @@ public Q_SLOTS:
 	void enumerateInputDevices();
 	void enumerateVibrationMotors();
 	void runOnCPUThread(const std::function<void()>& func);
+	void queueSnapshot(quint32 gsdump_frames);
 
 Q_SIGNALS:
 	DisplayWidget* onCreateDisplayRequested(bool fullscreen, bool render_to_main);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -45,8 +45,6 @@
 #include "Settings/InterfaceSettingsWidget.h"
 #include "SettingWidgetBinder.h"
 
-extern u32 GSmakeSnapshot(char* path);
-
 static constexpr char DISC_IMAGE_FILTER[] =
 	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.chd *.cso *.gz *.elf *.irx *.m3u *.gs *.gs.xz);;"
 									"Single-Track Raw Images (*.bin *.iso);;"
@@ -211,6 +209,8 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionEnableEEConsoleLogging, &QAction::triggered, this, &MainWindow::onLoggingOptionChanged);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", true);
 	connect(m_ui.actionEnableIOPConsoleLogging, &QAction::triggered, this, &MainWindow::onLoggingOptionChanged);
+
+	connect(m_ui.actionSaveGSDump, &QAction::triggered, this, &MainWindow::onSaveGSDumpActionTriggered);
 
 	// These need to be queued connections to stop crashing due to menus opening/closing and switching focus.
 	connect(m_game_list_widget, &GameListWidget::refreshProgress, this, &MainWindow::onGameListRefreshProgress);
@@ -514,8 +514,12 @@ void MainWindow::setIconThemeFromSettings()
 
 void MainWindow::onScreenshotActionTriggered()
 {
-	Host::AddOSDMessage("Saved Screenshot.", 10.0f);
-	GSmakeSnapshot(EmuFolders::Snapshots.ToString().char_str());
+	g_emu_thread->queueSnapshot(0);
+}
+
+void MainWindow::onSaveGSDumpActionTriggered()
+{
+	g_emu_thread->queueSnapshot(1);
 }
 
 void MainWindow::saveStateToConfig()

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -46,7 +46,7 @@
 #include "SettingWidgetBinder.h"
 
 static constexpr char DISC_IMAGE_FILTER[] =
-	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.chd *.cso *.gz *.elf *.irx *.m3u *.gs *.gs.xz);;"
+	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.chd *.cso *.gz *.elf *.irx *.m3u *.gs *.gs.xz *.gs.zst);;"
 									"Single-Track Raw Images (*.bin *.iso);;"
 									"Cue Sheets (*.cue);;"
 									"MAME CHD Images (*.chd);;"
@@ -55,7 +55,7 @@ static constexpr char DISC_IMAGE_FILTER[] =
 									"ELF Executables (*.elf);;"
 									"IRX Executables (*.irx);;"
 									"Playlists (*.m3u);;"
-									"GS Dumps (*.gs *.gs.xz)");
+									"GS Dumps (*.gs *.gs.xz *.gs.zst)");
 
 const char* MainWindow::DEFAULT_THEME_NAME = "darkfusion";
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -134,6 +134,7 @@ private Q_SLOTS:
 	void onThemeChangedFromSettings();
 	void onLoggingOptionChanged();
 	void onScreenshotActionTriggered();
+	void onSaveGSDumpActionTriggered();
 
 	void onVMStarting();
 	void onVMStarted();

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -136,8 +136,9 @@
      </property>
     </widget>
     <addaction name="separator"/>
-    <addaction name="actionToggleSoftwareRendering"/>
     <addaction name="menuDebugSwitchRenderer"/>
+    <addaction name="actionToggleSoftwareRendering"/>
+    <addaction name="actionSaveGSDump"/>
     <addaction name="separator"/>
     <addaction name="actionReloadPatches"/>
     <addaction name="separator"/>
@@ -561,11 +562,12 @@
    </property>
   </action>
   <action name="actionDEV9Settings">
+   <property name="icon">
+    <iconset theme="dashboard-line">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Network &amp;&amp; HDD</string>
-   </property>
-   <property name="icon">
-    <iconset theme="dashboard-line"/>
    </property>
   </action>
   <action name="actionViewToolbar">
@@ -736,6 +738,11 @@
    </property>
    <property name="text">
     <string>Enable IOP Console Logging</string>
+   </property>
+  </action>
+  <action name="actionSaveGSDump">
+   <property name="text">
+    <string>Save Single Frame GS Dump</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -208,6 +208,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideTextureBarriers, "EmuCore/GS", "OverrideTextureBarriers", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.overrideGeometryShader, "EmuCore/GS", "OverrideGeometryShaders", -1, -1);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.gsDumpCompression, "EmuCore/GS", "GSDumpCompression", static_cast<int>(GSDumpCompressionMethod::Uncompressed));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableFramebufferFetch, "EmuCore/GS", "DisableFramebufferFetch", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableDualSource, "EmuCore/GS", "DisableDualSourceBlend", false);
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -97,7 +97,7 @@
            <string>Auto Standard (4:3/3:2 Progressive)</string>
           </property>
          </item>
-		 <item>
+         <item>
           <property name="text">
            <string>Standard (4:3)</string>
           </property>
@@ -123,7 +123,7 @@
            <string>Off (Default)</string>
           </property>
          </item>
-		 <item>
+         <item>
           <property name="text">
            <string>Auto Standard (4:3/3:2 Progressive)</string>
           </property>
@@ -1146,7 +1146,7 @@
             </item>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
+          <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_7">
             <item row="0" column="0">
              <widget class="QCheckBox" name="useBlitSwapChain">
@@ -1177,6 +1177,27 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_34">
+            <property name="text">
+             <string>GS Dump Compression:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="gsDumpCompression">
+            <item>
+             <property name="text">
+              <string>Uncompressed</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LZMA (XZ)</string>
+             </property>
+            </item>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1194,7 +1194,12 @@
             </item>
             <item>
              <property name="text">
-              <string>LZMA (XZ)</string>
+              <string>LZMA (xz)</string>
+             </property>
+            </item>
+			<item>
+             <property name="text">
+              <string>Zstandard (zst)</string>
              </property>
             </item>
            </widget>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1604,6 +1604,7 @@ target_link_libraries(PCSX2_FLAGS INTERFACE
 	PkgConfig::SAMPLERATE
 	PNG::PNG
 	LibLZMA::LibLZMA
+	Zstd::Zstd
 	${LIBC_LIBRARIES}
 )
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -195,7 +195,8 @@ enum class TexturePreloadingLevel : u8
 enum class GSDumpCompressionMethod : u8
 {
 	Uncompressed,
-	LZMA
+	LZMA,
+	Zstandard,
 };
 
 // Template function for casting enumerations to their underlying type

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -192,6 +192,12 @@ enum class TexturePreloadingLevel : u8
 	Full,
 };
 
+enum class GSDumpCompressionMethod : u8
+{
+	Uncompressed,
+	LZMA
+};
+
 // Template function for casting enumerations to their underlying type
 template <typename Enumeration>
 typename std::underlying_type<Enumeration>::type enum_cast(Enumeration E)
@@ -519,6 +525,7 @@ struct Pcsx2Config
 		CRCHackLevel CRCHack{CRCHackLevel::Automatic};
 		BiFiltering TextureFiltering{BiFiltering::PS2};
 		TexturePreloadingLevel TexturePreloading{TexturePreloadingLevel::Off};
+		GSDumpCompressionMethod GSDumpCompression{GSDumpCompressionMethod::Uncompressed};
 		int Dithering{2};
 		int MaxAnisotropy{0};
 		int SWExtraThreads{2};

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -480,35 +480,6 @@ void GSvsync(u32 field, bool registers_written)
 	}
 }
 
-u32 GSmakeSnapshot(char* path)
-{
-	try
-	{
-		std::string s{path};
-
-		if (!s.empty())
-		{
-			// Allows for providing a complete path
-			std::string extension = s.substr(s.size() - 4, 4);
-#ifdef _WIN32
-			std::transform(extension.begin(), extension.end(), extension.begin(), (char(_cdecl*)(int))tolower);
-#else
-			std::transform(extension.begin(), extension.end(), extension.begin(), tolower);
-#endif
-			if (extension == ".png")
-				return g_gs_renderer->MakeSnapshot(s);
-			else if (s[s.length() - 1] != DIRECTORY_SEPARATOR)
-				s = s + DIRECTORY_SEPARATOR;
-		}
-
-		return g_gs_renderer->MakeSnapshot(s + "gs");
-	}
-	catch (GSRecoverableError)
-	{
-		return false;
-	}
-}
-
 int GSfreeze(FreezeAction mode, freezeData* data)
 {
 	try
@@ -531,6 +502,18 @@ int GSfreeze(FreezeAction mode, freezeData* data)
 	}
 
 	return 0;
+}
+
+void GSQueueSnapshot(const std::string& path, u32 gsdump_frames)
+{
+	if (g_gs_renderer)
+		g_gs_renderer->QueueSnapshot(path, gsdump_frames);
+}
+
+void GSStopGSDump()
+{
+	if (g_gs_renderer)
+		g_gs_renderer->StopGSDump();
 }
 
 #ifndef PCSX2_CORE
@@ -577,9 +560,7 @@ int GStest()
 	return 0;
 }
 
-#endif
-
-void pt(const char* str)
+static void pt(const char* str)
 {
 	struct tm* current;
 	time_t now;
@@ -623,6 +604,7 @@ void GSendRecording()
 	g_gs_renderer->EndCapture();
 	pt(" - Capture ended\n");
 }
+#endif
 
 void GSsetGameCRC(u32 crc, int options)
 {
@@ -1293,6 +1275,9 @@ void GSApp::Init()
 	m_gs_tv_shaders.push_back(GSSetting(3, "Triangular filter", ""));
 	m_gs_tv_shaders.push_back(GSSetting(4, "Wave filter", ""));
 
+	m_gs_dump_compression.push_back(GSSetting(static_cast<u32>(GSDumpCompressionMethod::Uncompressed), "Uncompressed", ""));
+	m_gs_dump_compression.push_back(GSSetting(static_cast<u32>(GSDumpCompressionMethod::LZMA), "LZMA (XZ)", ""));
+
 	// clang-format off
 	// Avoid to clutter the ini file with useless options
 #if defined(ENABLE_VULKAN) || defined(_WIN32)
@@ -1333,6 +1318,7 @@ void GSApp::Init()
 	m_default_configuration["filter"]                                     = std::to_string(static_cast<s8>(BiFiltering::PS2));
 	m_default_configuration["FMVSoftwareRendererSwitch"]                  = "0";
 	m_default_configuration["fxaa"]                                       = "0";
+	m_default_configuration["GSDumpCompression"]                          = "0";
 	m_default_configuration["HWDisableReadbacks"]                         = "0";
 	m_default_configuration["pcrtc_offsets"]                              = "0";
 	m_default_configuration["IntegerScaling"]                             = "0";
@@ -1581,8 +1567,32 @@ static void HotkeyAdjustZoom(double delta)
 	GetMTGS().RunOnGSThread([new_zoom]() { GSConfig.Zoom = new_zoom; });
 }
 
-BEGIN_HOTKEY_LIST(g_gs_hotkeys){
-	"ToggleSoftwareRendering", "Graphics", "Toggle Software Rendering", [](bool pressed) {
+BEGIN_HOTKEY_LIST(g_gs_hotkeys)
+	{"Screenshot", "Graphics", "Save Screenshot", [](bool pressed) {
+		if (!pressed)
+		{
+			GetMTGS().RunOnGSThread([]() {
+				GSQueueSnapshot(std::string(), 0);
+			});
+		}
+	}},
+	{"GSDumpSingleFrame", "Graphics", "Save Single Frame GS Dump", [](bool pressed) {
+		if (!pressed)
+		{
+			GetMTGS().RunOnGSThread([]() {
+				GSQueueSnapshot(std::string(), 1);
+			});
+		}
+	}},
+	{"GSDumpMultiFrame", "Graphics", "Save Multi Frame GS Dump", [](bool pressed) {
+		GetMTGS().RunOnGSThread([pressed]() {
+			if (pressed)
+				GSQueueSnapshot(std::string(), std::numeric_limits<u32>::max());
+			else
+				GSStopGSDump();
+		});
+	}},
+	{"ToggleSoftwareRendering", "Graphics", "Toggle Software Rendering", [](bool pressed) {
 		if (!pressed)
 			GetMTGS().ToggleSoftwareRendering();
 	}},

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1276,7 +1276,8 @@ void GSApp::Init()
 	m_gs_tv_shaders.push_back(GSSetting(4, "Wave filter", ""));
 
 	m_gs_dump_compression.push_back(GSSetting(static_cast<u32>(GSDumpCompressionMethod::Uncompressed), "Uncompressed", ""));
-	m_gs_dump_compression.push_back(GSSetting(static_cast<u32>(GSDumpCompressionMethod::LZMA), "LZMA (XZ)", ""));
+	m_gs_dump_compression.push_back(GSSetting(static_cast<u32>(GSDumpCompressionMethod::LZMA), "LZMA (xz)", ""));
+	m_gs_dump_compression.push_back(GSSetting(static_cast<u32>(GSDumpCompressionMethod::Zstandard), "Zstandard (zst)", ""));
 
 	// clang-format off
 	// Avoid to clutter the ini file with useless options

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1608,10 +1608,9 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys)
 		 if (pressed)
 			 return;
 
-		 GetMTGS().RunOnGSThread([]() {
-			 GSConfig.AspectRatio = static_cast<AspectRatioType>((static_cast<int>(GSConfig.AspectRatio) + 1) % static_cast<int>(AspectRatioType::MaxCount));
-			 Host::AddKeyedFormattedOSDMessage("CycleAspectRatio", 10.0f, "Aspect ratio set to '%s'.", Pcsx2Config::GSOptions::AspectRatioNames[static_cast<int>(GSConfig.AspectRatio)]);
-		 });
+		 // technically this races, but the worst that'll happen is one frame uses the old AR.
+		 EmuConfig.CurrentAspectRatio = static_cast<AspectRatioType>((static_cast<int>(EmuConfig.CurrentAspectRatio) + 1) % static_cast<int>(AspectRatioType::MaxCount));
+		 Host::AddKeyedFormattedOSDMessage("CycleAspectRatio", 10.0f, "Aspect ratio set to '%s'.", Pcsx2Config::GSOptions::AspectRatioNames[static_cast<int>(EmuConfig.CurrentAspectRatio)]);
 	 }},
 	{"CycleMipmapMode", "Graphics", "Cycle Hardware Mipmapping", [](bool pressed) {
 		 if (pressed)

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -66,15 +66,16 @@ void GSgifTransfer1(u8* mem, u32 addr);
 void GSgifTransfer2(u8* mem, u32 size);
 void GSgifTransfer3(u8* mem, u32 size);
 void GSvsync(u32 field, bool registers_written);
-u32 GSmakeSnapshot(char* path);
 int GSfreeze(FreezeAction mode, freezeData* data);
+void GSQueueSnapshot(const std::string& path, u32 gsdump_frames = 0);
+void GSStopGSDump();
 #ifndef PCSX2_CORE
 void GSkeyEvent(const HostKeyEvent& e);
 void GSconfigure();
 int GStest();
-#endif
 bool GSsetupRecording(std::string& filename);
 void GSendRecording();
+#endif
 void GSsetGameCRC(u32 crc, int options);
 void GSsetFrameSkip(int frameskip);
 
@@ -139,6 +140,7 @@ public:
 	std::vector<GSSetting> m_gs_crc_level;
 	std::vector<GSSetting> m_gs_acc_blend_level;
 	std::vector<GSSetting> m_gs_tv_shaders;
+	std::vector<GSSetting> m_gs_dump_compression;
 };
 
 struct GSError

--- a/pcsx2/GS/GSDump.cpp
+++ b/pcsx2/GS/GSDump.cpp
@@ -17,14 +17,17 @@
 #include "GSDump.h"
 #include "GSExtra.h"
 #include "GSState.h"
+#include "common/Console.h"
+#include "common/FileSystem.h"
 
-GSDumpBase::GSDumpBase(const std::string& fn)
-	: m_frames(0)
+GSDumpBase::GSDumpBase(std::string fn)
+	: m_filename(std::move(fn))
+	, m_frames(0)
 	, m_extra_frames(2)
 {
-	m_gs = px_fopen(fn, "wb");
+	m_gs = FileSystem::OpenCFile(m_filename.c_str(), "wb");
 	if (!m_gs)
-		fprintf(stderr, "GSDump: Error failed to open %s\n", fn.c_str());
+		Console.Error("GSDump: Error failed to open %s", m_filename.c_str());
 }
 
 GSDumpBase::~GSDumpBase()

--- a/pcsx2/GS/GSDump.h
+++ b/pcsx2/GS/GSDump.h
@@ -56,9 +56,10 @@ struct GSDumpHeader
 
 class GSDumpBase
 {
+	FILE* m_gs;
+	std::string m_filename;
 	int m_frames;
 	int m_extra_frames;
-	FILE* m_gs;
 
 protected:
 	void AddHeader(const std::string& serial, u32 crc,
@@ -70,8 +71,10 @@ protected:
 	virtual void AppendRawData(u8 c) = 0;
 
 public:
-	GSDumpBase(const std::string& fn);
+	GSDumpBase(std::string fn);
 	virtual ~GSDumpBase();
+
+	__fi const std::string& GetPath() const { return m_filename; }
 
 	void ReadFIFO(u32 size);
 	void Transfer(int index, const u8* mem, size_t size);

--- a/pcsx2/GS/GSDump.h
+++ b/pcsx2/GS/GSDump.h
@@ -19,6 +19,7 @@
 #include "GSRegs.h"
 #include "Renderers/SW/GSVertexSW.h"
 #include <lzma.h>
+#include <zstd.h>
 
 /*
 
@@ -109,4 +110,23 @@ public:
 		u32 screenshot_width, u32 screenshot_height, const u32* screenshot_pixels,
 		const freezeData& fd, const GSPrivRegSet* regs);
 	virtual ~GSDumpXz();
+};
+
+class GSDumpZst final : public GSDumpBase
+{
+	ZSTD_CStream* m_strm;
+
+	std::vector<u8> m_in_buff;
+	std::vector<u8> m_out_buff;
+
+	void MayFlush();
+	void Compress(ZSTD_EndDirective action);
+	void AppendRawData(const void* data, size_t size);
+	void AppendRawData(u8 c);
+
+public:
+	GSDumpZst(const std::string& fn, const std::string& serial, u32 crc,
+		u32 screenshot_width, u32 screenshot_height, const u32* screenshot_pixels,
+		const freezeData& fd, const GSPrivRegSet* regs);
+	virtual ~GSDumpZst();
 };

--- a/pcsx2/GS/GSLzma.h
+++ b/pcsx2/GS/GSLzma.h
@@ -15,10 +15,12 @@
 
 #pragma once
 
-#include <lzma.h>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <lzma.h>
+#include <zstd.h>
 
 #define GEN_REG_ENUM_CLASS_CONTENT(ClassName, EntryName, Value) \
 	EntryName = Value,
@@ -353,6 +355,30 @@ class GSDumpLzma : public GSDumpFile
 public:
 	GSDumpLzma(FILE* file, FILE* repack_file);
 	virtual ~GSDumpLzma();
+
+	bool IsEof() final;
+	size_t Read(void* ptr, size_t size) final;
+};
+
+class GSDumpDecompressZst : public GSDumpFile
+{
+	static constexpr u32 INPUT_BUFFER_SIZE = 512 * _1kb;
+	static constexpr u32 OUTPUT_BUFFER_SIZE = 2 * _1mb;
+
+	ZSTD_DStream* m_strm;
+	ZSTD_inBuffer m_inbuf;
+
+	uint8_t* m_area;
+
+	size_t m_avail;
+	size_t m_start;
+
+	void Decompress();
+	void Initialize();
+
+public:
+	GSDumpDecompressZst(FILE* file, FILE* repack_file);
+	virtual ~GSDumpDecompressZst();
 
 	bool IsEof() final;
 	size_t Read(void* ptr, size_t size) final;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -564,13 +564,21 @@ void GSRenderer::VSync(u32 field, bool registers_written)
 					fd, m_regs));
 				compression_str = "with no compression";
 			}
-			else
+			else if (GSConfig.GSDumpCompression == GSDumpCompressionMethod::LZMA)
 			{
 				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpXz(m_snapshot, GetDumpSerial(), m_crc,
 					DUMP_SCREENSHOT_WIDTH, DUMP_SCREENSHOT_HEIGHT,
 					screenshot_pixels.empty() ? nullptr : screenshot_pixels.data(),
 					fd, m_regs));
 				compression_str = "with LZMA compression";
+			}
+			else
+			{
+				m_dump = std::unique_ptr<GSDumpBase>(new GSDumpZst(m_snapshot, GetDumpSerial(), m_crc,
+					DUMP_SCREENSHOT_WIDTH, DUMP_SCREENSHOT_HEIGHT,
+					screenshot_pixels.empty() ? nullptr : screenshot_pixels.data(),
+					fd, m_regs));
+				compression_str = "with Zstandard compression";
 			}
 
 			delete[] fd.data;
@@ -642,7 +650,7 @@ void GSRenderer::QueueSnapshot(const std::string& path, u32 gsdump_frames)
 		return;
 
 	// Allows for providing a complete path
-	if (path.size() > 4 && StringUtil::compareNoCase(path.substr(path.size() - 4, 4), ".png"))
+	if (path.size() > 4 && StringUtil::EndsWithNoCase(path, ".png"))
 	{
 		m_snapshot = path.substr(0, path.size() - 4);
 	}

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -586,6 +586,7 @@ DebugTab::DebugTab(wxWindow* parent)
 	m_ui.addComboBoxAndLabel(ogl_grid, "Geometry Shader:",  "OverrideGeometryShaders",                 &theApp.m_gs_generic_list, IDC_GEOMETRY_SHADER_OVERRIDE, vk_ogl_hw_prereq);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Image Load Store:", "override_GL_ARB_shader_image_load_store", &theApp.m_gs_generic_list, IDC_IMAGE_LOAD_STORE,         ogl_hw_prereq);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Sparse Texture:",   "override_GL_ARB_sparse_texture",          &theApp.m_gs_generic_list, IDC_SPARSE_TEXTURE,           ogl_hw_prereq);
+	m_ui.addComboBoxAndLabel(ogl_grid, "Dump Compression:", "GSDumpCompression",                       &theApp.m_gs_dump_compression, -1);
 	ogl_box->Add(ogl_grid);
 
 	tab_box->Add(ogl_box.outer, wxSizerFlags().Expand());

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -391,6 +391,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(CRCHack) &&
 		OpEqu(TextureFiltering) &&
 		OpEqu(TexturePreloading) &&
+		OpEqu(GSDumpCompression) &&
 		OpEqu(Dithering) &&
 		OpEqu(MaxAnisotropy) &&
 		OpEqu(SWExtraThreads) &&
@@ -575,6 +576,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingIntEnumEx(CRCHack, "crc_hack_level");
 	GSSettingIntEnumEx(TextureFiltering, "filter");
 	GSSettingIntEnumEx(TexturePreloading, "texture_preloading");
+	GSSettingIntEnumEx(GSDumpCompression, "GSDumpCompression");
 	GSSettingIntEx(Dithering, "dithering_ps2");
 	GSSettingIntEx(MaxAnisotropy, "MaxAnisotropy");
 	GSSettingIntEx(SWExtraThreads, "extrathreads");

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1111,7 +1111,9 @@ bool VMManager::IsElfFileName(const std::string& path)
 
 bool VMManager::IsGSDumpFileName(const std::string& path)
 {
-	return (StringUtil::EndsWithNoCase(path, ".gs") || StringUtil::EndsWithNoCase(path, ".gs.xz"));
+	return (StringUtil::EndsWithNoCase(path, ".gs") ||
+			StringUtil::EndsWithNoCase(path, ".gs.xz") ||
+			StringUtil::EndsWithNoCase(path, ".gs.zst"));
 }
 
 void VMManager::Execute()

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -222,6 +222,8 @@ void Dialogs::GSDumpDialog::GetDumpsList()
 			dumps.push_back(filename.substr(0, filename.length() - 3));
 		else if (filename.EndsWith(".gs.xz"))
 			dumps.push_back(filename.substr(0, filename.length() - 6));
+		else if (filename.EndsWith(".gs.zst"))
+			dumps.push_back(filename.substr(0, filename.length() - 7));
 		cont = snaps.GetNext(&filename);
 	}
 	std::sort(dumps.begin(), dumps.end(), [](const wxString& a, const wxString& b) { return a.CmpNoCase(b) < 0; });
@@ -249,6 +251,8 @@ void Dialogs::GSDumpDialog::SelectedDump(wxListEvent& evt)
 	wxString filename = g_Conf->Folders.Snapshots.ToAscii() + ("/" + evt.GetText()) + ".gs";
 	if (!wxFileExists(filename))
 		filename.append(".xz");
+	if (!wxFileExists(filename))
+		filename = filename.RemoveLast(3).append(".zst");
 	if (wxFileExists(filename_preview))
 	{
 		auto img = wxImage(filename_preview);

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -372,8 +372,7 @@ namespace Implementations
 
 	void Sys_TakeSnapshot()
 	{
-		if (GSmakeSnapshot(g_Conf->Folders.Snapshots.ToUTF8().data()))
-			OSDlog(ConsoleColors::Color_Black, true, "Snapshot taken");
+		GSQueueSnapshot(std::string(), 0);
 	}
 
 	void Sys_RenderToggle()

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -1040,7 +1040,7 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_Click(wxCommandEvent& even
 	{
 		return;
 	}
-	GSmakeSnapshot(g_Conf->Folders.Snapshots.ToString().char_str());
+	GSQueueSnapshot(std::string(), 0);
 }
 
 void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& event)
@@ -1056,7 +1056,7 @@ void MainEmuFrame::Menu_Capture_Screenshot_Screenshot_As_Click(wxCommandEvent& e
 	wxFileDialog fileDialog(this, _("Select a file"), g_Conf->Folders.Snapshots.ToAscii(), wxEmptyString, "PNG files (*.png)|*.png", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
 	if (fileDialog.ShowModal() == wxID_OK)
-		GSmakeSnapshot((char*)fileDialog.GetPath().char_str());
+		GSQueueSnapshot(StringUtil::wxStringToUTF8String(fileDialog.GetPath()), 0);
 
 	// Resume emulation
 	if (!wasPaused)

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -44,6 +44,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\imgui\imgui;$(SolutionDir)3rdparty\imgui\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\libzip;$(SolutionDir)3rdparty\libzip\libzip\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\d3d12memalloc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\zstd\zstd\lib</AdditionalIncludeDirectories>
       <ExceptionHandling>Async</ExceptionHandling>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -47,6 +47,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\sdl2\include;$(SolutionDir)3rdparty\sdl2\SDL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\libzip;$(SolutionDir)3rdparty\libzip\libzip\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\d3d12memalloc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\zstd\zstd\lib</AdditionalIncludeDirectories>
       <ExceptionHandling>Async</ExceptionHandling>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>


### PR DESCRIPTION
### Description of Changes

 - Fix aspect ratio cycle hotkey.
 - Support saving GS dumps (in the debug menu, also can use hotkeys for multi-frame).
 - Make screenshot saving not a race condition.
 - Add support for using zstandard compression for dumps (can compress at ~30fps in devel builds, haven't tried release).

GS dumps are created uncompressed by default, there's now an option in GS settings to set the compression method, rather than relying on keypresses.

### Rationale behind Changes

Brr. Getting rid of races.

### Suggested Testing Steps

Test screenshot/dump creation in both wx and qt, as both are touched.
