### PR TITLE
CMake: Set fp-contract=fast

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -39,8 +39,13 @@ if(NOT TOP_CMAKE_WAS_SOURCED)
 	It is advice to delete all wrongly generated cmake stuff => CMakeFiles & CMakeCache.txt")
 endif()
 
-if(NOT MSVC)
+if(MSVC)
+	if (MSVC_VERSION GREATER_EQUAL 1930)
+		target_compile_options(PCSX2_FLAGS INTERFACE /fp:contract)
+	endif()
+else()
 	target_compile_options(PCSX2_FLAGS INTERFACE
+		-ffp-contract=fast
 		-fno-strict-aliasing
 		-Wstrict-aliasing # Allow to track strict aliasing issue.
 		-Wno-parentheses


### PR DESCRIPTION
### Description of Changes
Allows multiplies and adds to be merged into fma instructions

### Rationale behind Changes
Clang defaults to off, gcc defaults to fast.  MSVC supposedly defaulted on until VS2022, and I've seen it do the optimization but not very consistently.
- Gives a microscopic increase in speed to the software renderer
- Reduces the impact of Double Z (#6033) in AVX2 Clang to 1-2%

### Suggested Testing Steps
Watch things build
