### PR TITLE
Improved FreeBSD compatibility

### DIFF
--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -156,7 +156,12 @@ void* HostSys::MmapReservePtr(void* base, size_t size)
 	// or anonymous source, with PROT_NONE (no-access) permission.  Since the mapping
 	// is completely inaccessible, the OS will simply reserve it and will not put it
 	// against the commit table.
-	return mmap(base, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	void* result = mmap(base, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+
+	if (result == MAP_FAILED)
+		result = nullptr;
+
+	return result;
 }
 
 bool HostSys::MmapCommitPtr(void* base, size_t size, const PageProtectionMode& mode)


### PR DESCRIPTION
### Description of Changes
- Map the return value of `mmap` to conform to `MmapReservePtr`'s implicit interface

- Add `MAP_FIXED` to the flags argument in `mmap` call.

### Rationale behind Changes
## 1
In `VirtualMemoryManager::VirtualMemoryManager` (common/VirtualMemory.cpp:76), the return value of `HostSys::MmapReserve` (common/Linux/LnxHostSys.cpp:197) is immediately tested for nullness with `!m_baseptr`. However, `mmap` does not return `NULL` if the call fails, according to POSIX it should return `MAP_FAILED` which is not the same as `NULL`. Both Linux and FreeBSD define it as `(void *) -1` so it's not even a pedantic point. Linux documents that calling `mmap` with `addr = 0`  and `flags = MAP_FIXED` does return `NULL` but that is an example of a "successful" mapping. So in reality directly returning the result of the call to `mmap` is not consistent with `HostSys::MmapReserve`'s interface and therefore the case where it returns `MAP_FAILED` needs to be mapped to `nullptr`. 

## 2
The issue described in [issue #6081](https://github.com/PCSX2/pcsx2/issues/6081) seems to be due to a difference between the Linux and FreeBSD kernels with regards to how much they respect the address hint provided by the caller. On Linux, if the address given has no mapping yet it seems like the kernel just complies with the request and creates a mapping at that address. However, on FreeBSD, it really seems to be taken as just a suggestion and that from the caller's POV, getting some other address is not a big deal. However, in this case it is a big deal, vis-a-vis:

```cpp
if (strict && m_baseptr != base)
	fulfillsRequirements = false;
```

In `makeMainMemoryManager`, `VirtualMemoryManager`'s constructor is called with `strict = true` and so if `m_baseptr` (gotten from `HostSys::MmapReserve`) is not equal to the tentative address `base` passed to the constructor then that's a hard failure. But, that's exactly what passing `MAP_FIXED` to `mmap` does! (as an extra bonus, it's one of the few flags that's actually required by POSIX). Not only is that a more direct approach (i.e. let the operating system do this check instead of doing it in the code), but also, in the case of FreeBSD, it has the side effect of forcing the kernel to take the hint seriously, which it does.

So, these changes have no effect on the behavior on Linux systems (the code is completely equivalent so the behavior cannot be different), but it makes main memory allocation succeed on FreeBSD. Big win if you ask me. Just in case, I briefly tested the emulator on Linux and as far as I can tell, everything is exactly the same, unsurprisingly. PCSX2 now seems to run perfectly on FreeBSD; it's possible there are other areas of incompatibility, but I can now run games on FreeBSD and have not yet noticed any issues.

### Suggested Testing Steps
Not sure. This is a simple change which is very easy to reason about. I don't really feel like a more convincing case needs to be made. However, if I made an error or there is something else that must be done I am happy to discuss it.

Fixes [#6081](https://github.com/PCSX2/pcsx2/issues/6081)
