### PR TITLE
gs-hw: fix tales of abyss upscaled rendering.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3696,8 +3696,6 @@ GSRendererHW::Hacks::Hacks()
 	m_oi_list.push_back(HackEntry<OI_Ptr>(CRC::BurnoutGames, CRC::RegionCount, &GSRendererHW::OI_BurnoutGames));
 
 	m_oo_list.push_back(HackEntry<OO_Ptr>(CRC::BurnoutGames, CRC::RegionCount, &GSRendererHW::OO_BurnoutGames));
-
-	m_cu_list.push_back(HackEntry<CU_Ptr>(CRC::TalesOfAbyss, CRC::RegionCount, &GSRendererHW::CU_TalesOfAbyss));
 }
 
 void GSRendererHW::Hacks::SetGameCRC(const CRC::Game& game)
@@ -4388,11 +4386,4 @@ void GSRendererHW::OO_BurnoutGames()
 
 // Can Upscale hacks: disable upscaling for some draw calls
 
-bool GSRendererHW::CU_TalesOfAbyss()
-{
-	// full image blur and brightening
-
-	const u32 FBP = m_context->FRAME.Block();
-
-	return FBP != 0x036e0 && FBP != 0x03560 && FBP != 0x038e0;
-}
+// None required.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1625,6 +1625,12 @@ void GSRendererHW::Draw()
 		}
 	}
 
+	if (m_src && m_src->m_shared_texture && m_src->m_texture != *m_src->m_from_target)
+	{
+		// Target texture changed, update reference.
+		m_src->m_texture = *m_src->m_from_target;
+	}
+
 	if (s_dump)
 	{
 		const u64 frame = g_perfmon.GetFrame();
@@ -2159,7 +2165,7 @@ void GSRendererHW::EmulateChannelShuffle(const GSTextureCache::Source* tex)
 			GL_INS("Gran Turismo RGB Channel");
 			m_conf.ps.channel = ChannelFetch_RGB;
 			m_context->TEX0.TFX = TFX_DECAL;
-			m_conf.rt = tex->m_from_target;
+			m_conf.rt = *tex->m_from_target;
 		}
 		else if (m_game.title == CRC::Tekken5)
 		{
@@ -2172,7 +2178,7 @@ void GSRendererHW::EmulateChannelShuffle(const GSTextureCache::Source* tex)
 				// 12 pages: 2 calls by channel, 3 channels, 1 blit
 				// Minus current draw call
 				m_skip = 12 * (3 + 3 + 1) - 1;
-				m_conf.rt = tex->m_from_target;
+				m_conf.rt = *tex->m_from_target;
 			}
 			else
 			{
@@ -2278,7 +2284,7 @@ void GSRendererHW::EmulateChannelShuffle(const GSTextureCache::Source* tex)
 	// Effect is really a channel shuffle effect so let's cheat a little
 	if (m_channel_shuffle)
 	{
-		m_conf.tex = tex->m_from_target;
+		m_conf.tex = *tex->m_from_target;
 		if (m_conf.tex)
 		{
 			if (m_conf.tex == m_conf.rt)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -54,8 +54,6 @@ private:
 
 	void OO_BurnoutGames();
 
-	bool CU_TalesOfAbyss();
-
 	class Hacks
 	{
 		template <class T>

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -145,7 +145,7 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		src->m_texture = dst->m_texture;
 		src->m_shared_texture = true;
 		src->m_target = true; // So renderer can check if a conversion is required
-		src->m_from_target = dst->m_texture; // avoid complex condition on the renderer
+		src->m_from_target = &dst->m_texture; // avoid complex condition on the renderer
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_32_bits_fmt = dst->m_32_bits_fmt;
 		src->m_valid_rect = dst->m_valid;
@@ -1258,7 +1258,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// Keep a trace of origin of the texture
 		src->m_texture = dTex;
 		src->m_target = true;
-		src->m_from_target = dst->m_texture;
+		src->m_from_target = &dst->m_texture;
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_texture->SetScale(scale);
 		src->m_end_block = dst->m_end_block;
@@ -1287,7 +1287,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		// Keep a trace of origin of the texture
 		src->m_texture = dTex;
 		src->m_target = true;
-		src->m_from_target = dst->m_texture;
+		src->m_from_target = &dst->m_texture;
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_end_block = dst->m_end_block;
 
@@ -1323,7 +1323,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 
 		// Keep a trace of origin of the texture
 		src->m_target = true;
-		src->m_from_target = dst->m_texture;
+		src->m_from_target = &dst->m_texture;
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_valid_rect = dst->m_valid;
 		src->m_end_block = dst->m_end_block;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1290,6 +1290,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 		src->m_from_target = &dst->m_texture;
 		src->m_from_target_TEX0 = dst->m_TEX0;
 		src->m_end_block = dst->m_end_block;
+		src->m_texture->SetScale(dst->m_texture->GetScale());
 
 		// Even if we sample the framebuffer directly we might need the palette
 		// to handle the format conversion on GPU

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -185,6 +185,9 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const GIFRegTEX0& TEX0
 		throw GSRecoverableError();
 	}
 
+	ASSERT(src->m_texture);
+	ASSERT(src->m_texture->GetScale() == (dst ? dst->m_texture->GetScale() : GSVector2(1, 1)));
+
 	return src;
 }
 
@@ -1532,6 +1535,9 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 	}
 
 	ASSERT(src->m_texture);
+	ASSERT(src->m_target == (dst != nullptr));
+	ASSERT(src->m_from_target == (dst ? &dst->m_texture : nullptr));
+	ASSERT(src->m_texture->GetScale() == ((!dst || TEX0.PSM == PSM_PSMT8) ? GSVector2(1, 1) : dst->m_texture->GetScale()));
 
 	m_src.Add(src, TEX0, g_gs_renderer->m_context->offset.tex);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -164,7 +164,7 @@ public:
 		// Keep a trace of the target origin. There is no guarantee that pointer will
 		// still be valid on future. However it ought to be good when the source is created
 		// so it can be used to access un-converted data for the current draw call.
-		GSTexture* m_from_target;
+		GSTexture** m_from_target;
 		GIFRegTEX0 m_from_target_TEX0; // TEX0 of the target texture, if any, else equal to texture TEX0
 		GIFRegTEX0 m_layer_TEX0[7]; // Detect already loaded value
 		HashType m_layer_hash[7];


### PR DESCRIPTION
### Description of Changes
Fixed the upscaled rendering of tales of abyss, closing #6075 and improving it further.
Commits are mostly related to gs hardware texture cache stuff: after adding target rescaling/resizing, it could have happened that the texture reference stored in the source object became invalid before the rendering occurred; This is now fixed, and this prevents the fullscreen blurring in the tales of abyss game when upscaling.

Also, I found out that for the dummy texture case, the scale of the texture stored in the source object was wrong, and this is fixed (but likely does not make a difference).

I added some assertions in the source lookup code to ensure the scale is properly set on the texture and some other source properties are properly set too.

Finally, I removed the can upscale hack of the tales of abyss game which was just introducing ghosting in the upscaled rendering.

### Rationale behind Changes
Less bugs and hacks is better.

### Suggested Testing Steps
Test tales of abyss and verify that #6075 is fixed and that the rendering quality is improved when upscaling.
Test games that were using the dummy textures system (`GSRendererHW::IsDummyTexture` says "Jak series/tri-ace game") and verify that they work properly.
Test some games that use channel shuffling and verify that they work properly.