### PR TITLE
Qt: Cancel game list scanning when VM starts 

### DIFF
--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -905,6 +905,41 @@ void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false 
 		Q_ARG(const std::function<void()>&, std::move(function)));
 }
 
+void Host::RefreshGameListAsync(bool invalidate_cache)
+{
+	QMetaObject::invokeMethod(g_main_window, "refreshGameList", Qt::QueuedConnection,
+		Q_ARG(bool, invalidate_cache));
+}
+
+void Host::CancelGameListRefresh()
+{
+	QMetaObject::invokeMethod(g_main_window, "cancelGameListRefresh", Qt::BlockingQueuedConnection);
+}
+
+void Host::RequestExit(bool save_state_if_running)
+{
+	if (VMManager::HasValidVM())
+		g_emu_thread->shutdownVM(save_state_if_running);
+
+	QMetaObject::invokeMethod(g_main_window, "requestExit", Qt::QueuedConnection);
+}
+
+void Host::RequestVMShutdown(bool save_state)
+{
+	if (VMManager::HasValidVM())
+		g_emu_thread->shutdownVM(save_state);
+}
+
+bool Host::IsFullscreen()
+{
+	return g_emu_thread->isFullscreen();
+}
+
+void Host::SetFullscreen(bool enabled)
+{
+	g_emu_thread->setFullscreen(enabled);
+}
+
 alignas(16) static SysMtgsThread s_mtgs_thread;
 
 SysMtgsThread& GetMTGS()

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -42,6 +42,7 @@ public:
 	static void stop();
 
 	__fi QEventLoop* getEventLoop() const { return m_event_loop; }
+	__fi bool isFullscreen() const { return m_is_fullscreen; }
 
 	bool isOnEmuThread() const;
 

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -163,13 +163,7 @@ bool GameListWidget::getShowGridCoverTitles() const
 
 void GameListWidget::refresh(bool invalidate_cache)
 {
-	if (m_refresh_thread)
-	{
-		m_refresh_thread->cancel();
-		m_refresh_thread->wait();
-		QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-		pxAssertRel(!m_refresh_thread, "Game list thread should be unreferenced by now");
-	}
+	cancelRefresh();
 
 	m_refresh_thread = new GameListRefreshThread(invalidate_cache);
 	connect(m_refresh_thread, &GameListRefreshThread::refreshProgress, this, &GameListWidget::onRefreshProgress,
@@ -177,6 +171,17 @@ void GameListWidget::refresh(bool invalidate_cache)
 	connect(m_refresh_thread, &GameListRefreshThread::refreshComplete, this, &GameListWidget::onRefreshComplete,
 		Qt::QueuedConnection);
 	m_refresh_thread->start();
+}
+
+void GameListWidget::cancelRefresh()
+{
+	if (!m_refresh_thread)
+		return;
+
+	m_refresh_thread->cancel();
+	m_refresh_thread->wait();
+	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+	pxAssertRel(!m_refresh_thread, "Game list thread should be unreferenced by now");
 }
 
 void GameListWidget::onRefreshProgress(const QString& status, int current, int total)

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -54,6 +54,7 @@ public:
 	void initialize();
 
 	void refresh(bool invalidate_cache);
+	void cancelRefresh();
 
 	bool isShowingGameList() const;
 	bool isShowingGameGrid() const;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -731,6 +731,11 @@ void MainWindow::refreshGameList(bool invalidate_cache)
 	m_game_list_widget->refresh(invalidate_cache);
 }
 
+void MainWindow::cancelGameListRefresh()
+{
+	m_game_list_widget->cancelRefresh();
+}
+
 void MainWindow::invalidateSaveStateCache()
 {
 	m_save_states_invalidated = true;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -598,6 +598,10 @@ void MainWindow::updateEmulationActions(bool starting, bool running)
 
 	if (!starting && !running)
 		m_ui.actionPause->setChecked(false);
+
+	// scanning needs to be disabled while running
+	m_ui.actionScanForNewGames->setDisabled(starting_or_running);
+	m_ui.actionRescanAllGames->setDisabled(starting_or_running);
 }
 
 void MainWindow::updateStatusBarWidgetVisibility()
@@ -728,6 +732,10 @@ void MainWindow::switchToEmulationView()
 
 void MainWindow::refreshGameList(bool invalidate_cache)
 {
+	// can't do this while the VM is running because of CDVD
+	if (m_vm_valid)
+		return;
+
 	m_game_list_widget->refresh(invalidate_cache);
 }
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -87,6 +87,7 @@ public:
 public Q_SLOTS:
 	void checkForUpdates(bool display_message);
 	void refreshGameList(bool invalidate_cache);
+	void cancelGameListRefresh();
 	void invalidateSaveStateCache();
 	void reportError(const QString& title, const QString& message);
 	void runOnUIThread(const std::function<void()>& func);

--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -86,6 +86,13 @@ const char* GameList::EntryTypeToString(EntryType type)
 	return names[static_cast<int>(type)];
 }
 
+const char* GameList::RegionToString(Region region)
+{
+	static std::array<const char*, static_cast<int>(Region::Count)> names = {
+		{"NTSC-U/C", "NTSC-J", "PAL", "Other"}};
+	return names[static_cast<int>(region)];
+}
+
 const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating rating)
 {
 	// clang-format off
@@ -497,11 +504,11 @@ void GameList::ScanDirectory(const char* path, bool recursive, const std::vector
 
 		{
 			std::unique_lock lock(s_mutex);
-			if (GetEntryForPath(ffd.FileName.c_str()))
+			if (GetEntryForPath(ffd.FileName.c_str()) || AddFileFromCache(ffd.FileName, ffd.ModificationTime))
+			{
+				progress->IncrementProgressValue();
 				continue;
-
-			if (AddFileFromCache(ffd.FileName, ffd.ModificationTime))
-				continue;
+			}
 		}
 
 		// ownership of fp is transferred

--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -494,6 +494,8 @@ void GameList::ScanDirectory(const char* path, bool recursive, const std::vector
 	progress->SetProgressRange(static_cast<u32>(files.size()));
 	progress->SetProgressValue(0);
 
+	u32 cached_files = 0;
+
 	for (FILESYSTEM_FIND_DATA& ffd : files)
 	{
 		if (progress->IsCancelled() || !GameList::IsScannableFilename(ffd.FileName) ||

--- a/pcsx2/Frontend/GameList.h
+++ b/pcsx2/Frontend/GameList.h
@@ -69,6 +69,7 @@ namespace GameList
 	};
 
 	const char* EntryTypeToString(EntryType type);
+	const char* RegionToString(Region region);
 	const char* EntryCompatibilityRatingToString(CompatibilityRating rating);
 
 	bool IsScannableFilename(const std::string& path);

--- a/pcsx2/HostSettings.cpp
+++ b/pcsx2/HostSettings.cpp
@@ -116,6 +116,11 @@ std::vector<std::string> Host::GetStringListSetting(const char* section, const c
 	return s_layered_settings_interface.GetStringList(section, key);
 }
 
+SettingsInterface* Host::Internal::GetBaseSettingsLayer()
+{
+	return s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_BASE);
+}
+
 void Host::Internal::SetBaseSettingsLayer(SettingsInterface* sif)
 {
 	pxAssertRel(s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_BASE) == nullptr, "Base layer has not been set");

--- a/pcsx2/HostSettings.h
+++ b/pcsx2/HostSettings.h
@@ -47,6 +47,9 @@ namespace Host
 
 	namespace Internal
 	{
+		/// Retrieves the base settings layer. Must call with lock held.
+		SettingsInterface* GetBaseSettingsLayer();
+
 		/// Sets the base settings layer. Should be called by the host at initialization time.
 		void SetBaseSettingsLayer(SettingsInterface* sif);
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -606,6 +606,12 @@ bool VMManager::Initialize(const VMBootParameters& boot_params)
 {
 	const Common::Timer init_timer;
 	pxAssertRel(s_state.load() == VMState::Shutdown, "VM is shutdown");
+
+	// cancel any game list scanning, we need to use CDVD!
+	// TODO: we can get rid of this once, we make CDVD not use globals...
+	// (or make it thread-local, but that seems silly.)
+	Host::CancelGameListRefresh();
+
 	s_state.store(VMState::Initializing);
 	Host::OnVMStarting();
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -211,4 +211,23 @@ namespace Host
 
 	/// Safely executes a function on the VM thread.
 	void RunOnCPUThread(std::function<void()> function, bool block = false);
+
+	/// Asynchronously starts refreshing the game list.
+	void RefreshGameListAsync(bool invalidate_cache);
+
+	/// Cancels game list refresh, if there is one in progress.
+	void CancelGameListRefresh();
+
+	/// Requests shut down and exit of the hosting application. This may not actually exit,
+	/// if the user cancels the shutdown confirmation.
+	void RequestExit(bool save_state_if_running);
+
+	/// Requests shut down of the current virtual machine.
+	void RequestVMShutdown(bool save_state);
+
+	/// Returns true if the hosting application is currently fullscreen.
+	bool IsFullscreen();
+
+	/// Alters fullscreen state of hosting application.
+	void SetFullscreen(bool enabled);
 }


### PR DESCRIPTION
### Description of Changes

Because of CDVD global state, and the fact that we hijack CDVD for getting the game details, we have to cancel the scan. Otherwise, the scanner will clash with the game's CDVD access.

### Rationale behind Changes

Don't want users crashing the software.

### Suggested Testing Steps

Already tested the evil scenario of starting a game while scanning :-)