### PR TITLE
ci: add SSE4 support for tagged Qt builds

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -54,6 +54,8 @@
 #define UPDATE_PLATFORM_STR "Windows"
 #if _M_SSE >= 0x500
 #define UPDATE_ADDITIONAL_TAGS "AVX2"
+#else
+#define UPDATE_ADDITIONAL_TAGS "SSE4"
 #endif
 #endif
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

The Qt autoupdater builds differently on a tagged build, so this wasn't caught on the PR unfortunately.

Tested on a tagged release here - https://github.com/xTVaser/pcsx2-rr/releases/tag/v1.4.4
