### PR TITLE
Core: Fix LnxFlatFileReader compile error with Qt

### DIFF
--- a/pcsx2/Linux/LnxFlatFileReader.cpp
+++ b/pcsx2/Linux/LnxFlatFileReader.cpp
@@ -17,6 +17,7 @@
 #include "AsyncFileReader.h"
 #include "common/FileSystem.h"
 
+#include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
### Description of Changes
Fix compile error when building Qt on Linux
Fixes https://github.com/PCSX2/pcsx2/issues/6117

### Rationale behind Changes
The code must build

### Suggested Testing Steps
Try to build Qt on Linux
