### PR TITLE
ci: fix windows release asset structure

### DIFF
--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -96,7 +96,7 @@ jobs:
       # Prepare artifacts, they are all zips from github!
       - name: Prepare Artifacts
         working-directory: ./ci-artifacts/
-        run: for d in *windows*/; do 7z a "${d}asset.7z" $d; done
+        run: for d in *windows*/; do 7z a "${d}asset.7z" ./$d/*; done
 
       # Artifact Naming:
       # MacOS: PCSX2-<tag>-macOS-[additional hyphen seperated tags]


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Ensures all files in windows release assets are in the top level of the `7z` file (not within a sub folder)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

The auto-updater requires the release to be structured a certain way, this was a mistake that wasn't caught before the CI cleanup merge.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

- Tested here, check that the assets look as expected https://github.com/xTVaser/pcsx2-rr/releases/tag/v1.4.5
