### PR TITLE
DMAC: Test mem against fakestat.

### DIFF
--- a/pcsx2/Dmac.cpp
+++ b/pcsx2/Dmac.cpp
@@ -541,7 +541,7 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 		case (DMAC_FAKESTAT):
 		case (DMAC_STAT):
 		{
-			if (DMAC_FAKESTAT)
+			if (mem == DMAC_FAKESTAT)
 			{
 				HW_LOG("Midways own DMAC_STAT Write 32bit %x", value);
 			}


### PR DESCRIPTION
### Description of Changes
Changed if (DMAC_FAKESTAT) to if (mem == DMAC_FAKESTAT)

### Rationale behind Changes
The first statement is always true. (Bug introduced in a recent commit.)

### Suggested Testing Steps
Run a game that calls this particular case.