### PR TITLE
GameList: Mark search directory cells as read-only

### DIFF
--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -96,6 +96,7 @@ void GameListSettingsWidget::addPathToTable(const std::string& path, bool recurs
 
 	QTableWidgetItem* item = new QTableWidgetItem();
 	item->setText(QString::fromStdString(path));
+	item->setFlags(item->flags() & ~(Qt::ItemIsEditable));
 	m_ui.searchDirectoryList->setItem(row, 0, item);
 
 	QCheckBox* cb = new QCheckBox(m_ui.searchDirectoryList);

--- a/pcsx2-qt/Settings/GameListSettingsWidget.h
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.h
@@ -21,8 +21,6 @@
 
 class SettingsDialog;
 
-class GameListSearchDirectoriesModel;
-
 class GameListSettingsWidget : public QWidget
 {
 	Q_OBJECT


### PR DESCRIPTION
### Description of Changes
A minor "regression" compared to DuckStation, Search Directory entries were editable manually but those changes did not take effect. Instead, making them would break the search directory removal.
![image](https://user-images.githubusercontent.com/7947461/169716167-18961a73-d718-4753-851d-d63028ffd61e.png)

With this PR, the Search Directory column is marked read-only, like in DuckStation.

### Rationale behind Changes
Better UX.

### Suggested Testing Steps
1. Open Settings -> Game List
2. Double click on any Search Directory entry
3. Observe that the entries are now **not** editable.
