### PR TITLE
Qt: Disable/remove unused buttons.

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -594,11 +594,9 @@ void MainWindow::updateEmulationActions(bool starting, bool running)
 	m_ui.actionReset->setEnabled(running);
 	m_ui.actionPause->setEnabled(running);
 	m_ui.actionChangeDisc->setEnabled(running);
-	m_ui.actionCheats->setEnabled(running);
 	m_ui.actionScreenshot->setEnabled(running);
 	m_ui.actionViewSystemDisplay->setEnabled(starting_or_running);
 	m_ui.menuChangeDisc->setEnabled(running);
-	m_ui.menuCheats->setEnabled(running);
 
 	m_ui.actionSaveState->setEnabled(running);
 	m_ui.menuSaveState->setEnabled(running);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -48,15 +48,6 @@
      <addaction name="actionRemoveDisc"/>
      <addaction name="separator"/>
     </widget>
-    <widget class="QMenu" name="menuCheats">
-     <property name="title">
-      <string>Cheats</string>
-     </property>
-     <property name="icon">
-      <iconset theme="flask-line">
-       <normaloff>.</normaloff>.</iconset>
-     </property>
-    </widget>
     <widget class="QMenu" name="menuLoadState">
      <property name="title">
       <string>Load State</string>
@@ -85,7 +76,6 @@
     <addaction name="actionPause"/>
     <addaction name="menuChangeDisc"/>
     <addaction name="separator"/>
-    <addaction name="menuCheats"/>
     <addaction name="actionScreenshot"/>
     <addaction name="separator"/>
     <addaction name="menuLoadState"/>
@@ -235,7 +225,6 @@
    <addaction name="actionReset"/>
    <addaction name="actionPause"/>
    <addaction name="actionChangeDisc"/>
-   <addaction name="actionCheats"/>
    <addaction name="actionScreenshot"/>
    <addaction name="separator"/>
    <addaction name="actionLoadState"/>
@@ -476,15 +465,6 @@
    </property>
    <property name="text">
     <string>Change Disc...</string>
-   </property>
-  </action>
-  <action name="actionCheats">
-   <property name="icon">
-    <iconset theme="flask-line">
-     <normaloff>.</normaloff>.</iconset>
-   </property>
-   <property name="text">
-    <string>Cheats...</string>
    </property>
   </action>
   <action name="actionAudioSettings">

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -100,6 +100,12 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 		m_ui.renderToMainWindow, tr("Render To Main Window"), tr("Checked"),
 		tr("Renders the display of the simulated console to the main window of the application, over "
 		   "the game list. If unchecked, the display will render in a separate window."));
+	
+	// Not yet used, disable the options
+	m_ui.pauseOnStart->setDisabled(true);
+	m_ui.pauseOnFocusLoss->setDisabled(true);
+	m_ui.disableWindowResizing->setDisabled(true);
+	m_ui.hideMouseCursor->setDisabled(true);
 }
 
 InterfaceSettingsWidget::~InterfaceSettingsWidget() = default;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Qt: Disable/remove unused buttons
Not implemented yet.
Disable:
Pause On Start,
Pause On Focus Loss,
Hide Mouse Cursor,
Disable Window Resizing.

Remove:
Cheats menu and toolbar.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Unused/ non functional.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
GUI still works and looks good, compiles.