### PR TITLE
input-rec: ensure controller logging is disabled by default

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -772,8 +772,8 @@ void QtHost::UpdateLogging()
 	SysConsole.iopConsole.Enabled = any_logging_sinks && QtHost::GetBaseBoolSettingValue("Logging", "EnableIOPConsole", true);
     
 	// Input Recording Logs
-	SysConsole.recordingConsole.Enabled = system_console_enabled && QtHost::GetBaseBoolSettingValue("Logging", "EnableInputRecordingLogs", true);
-	SysConsole.controlInfo.Enabled = system_console_enabled && QtHost::GetBaseBoolSettingValue("Logging", "EnableControllerLogs", true);
+	SysConsole.recordingConsole.Enabled = any_logging_sinks && QtHost::GetBaseBoolSettingValue("Logging", "EnableInputRecordingLogs", true);
+	SysConsole.controlInfo.Enabled = any_logging_sinks && QtHost::GetBaseBoolSettingValue("Logging", "EnableControllerLogs", false);
 
 	SetSystemConsoleEnabled(system_console_enabled);
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Logging sources have two sources of default values, the first is related to the UI, the other related to the settings value.  One of these was missing/incorrect

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

These logs are spammy and should not be included by default

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Launch Qt with default/fresh settings - you should not see any log spam.
