### PR TITLE
input-rec: fix crash in wxWidgets if input recording is disabled

### DIFF
--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -149,7 +149,7 @@ void InputRecording::ControllerInterrupt(u8& data, u8& port, u16& bufCount, u8 b
 			}
 			// If the VirtualPad updated the PadData, we have to update the buffer
 			// before sending it to the game
-			else if (pads[port].virtualPad->IsShown() && pads[port].virtualPad->UpdateControllerData(bufIndex, pads[port].padData))
+			else if (pads[port].virtualPad && pads[port].virtualPad->IsShown() && pads[port].virtualPad->UpdateControllerData(bufIndex, pads[port].padData))
 				bufVal = pads[port].padData->PollControllerData(bufIndex);
 		}
 	}

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -205,10 +205,13 @@ SIO_WRITE sioWriteController(u8 data)
 
 	default:
 		sio.buf[sio.bufCount] = PADpoll(data);
-		// Only examine controllers 1 / 2
-		if (sio.slot[sio.port] == 0 || sio.slot[sio.port] == 1)
+		if (EmuConfig.EnableRecordingTools)
 		{
-			g_InputRecording.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+			// Only examine controllers 1 / 2
+			if (sio.slot[sio.port] == 0 || sio.slot[sio.port] == 1)
+			{
+				g_InputRecording.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Fixes the aforementioned crash, virtual pads are only initialized if input recording is enabled.  In the PR that merged earlier today, it exposed a potential path where a NULL virtual pad could be accessed.

I've added back the safeguard to only intercept the inputs if recording is enabled (only a wx concern) as well as eliminated the null pointer issue at the source.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Crashes are bad

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Restart the emulator on wx with input recording enabled and disabled.  In Qt, input recording is always enabled, and there is no ability to disable it -- so this should not be an issue.
