### PR TITLE
ci: differentiate cmake windows build from the other build configs

### DIFF
--- a/.github/workflows/scripts/common/name-artifacts.sh
+++ b/.github/workflows/scripts/common/name-artifacts.sh
@@ -8,6 +8,7 @@
 
 # Inputs as env-vars
 # OS
+# BUILD_SYSTEM
 # GUI_FRAMEWORK
 # ARCH
 # SIMD
@@ -24,6 +25,14 @@ elif [ "${OS}" == "windows" ]; then
   NAME="PCSX2-${OS}-${GUI_FRAMEWORK}-${ARCH}-${SIMD}"
 else
   NAME="PCSX2-${OS}-${GUI_FRAMEWORK}-${ARCH}"
+fi
+
+# Add cmake if used to differentate it from msbuild builds
+# Else the two artifacts will have the same name and the files will be merged
+if [[ ! -z "${BUILD_SYSTEM}" ]]; then
+  if [ "${BUILD_SYSTEM}" == "cmake" ]; then
+    NAME="${NAME}-${BUILD_SYSTEM}"
+  fi
 fi
 
 # Add PR / Commit Metadata

--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -64,4 +64,5 @@ jobs:
     with:
       jobName: wxWidgets
       configuration: CMake
+      buildSystem: cmake
     secrets: inherit

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: AVX2
+      buildSystem:
+        required: false
+        type: string
+        default: msbuild
       qt_binary_url:
         required: false
         type: string
@@ -51,6 +55,7 @@ jobs:
         shell: bash
         env:
           OS: windows
+          BUILD_SYSTEM: ${{ inputs.buildSystem }}
           GUI_FRAMEWORK: Qt
           ARCH: ${{ inputs.platform }}
           SIMD: ${{ inputs.simd }}

--- a/.github/workflows/windows_build_wx.yml
+++ b/.github/workflows/windows_build_wx.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: AVX2
+      buildSystem:
+        required: false
+        type: string
+        default: msbuild
       configuration:
         required: true
         type: string
@@ -47,6 +51,7 @@ jobs:
         shell: bash
         env:
           OS: windows
+          BUILD_SYSTEM: ${{ inputs.buildSystem }}
           GUI_FRAMEWORK: wxWidgets
           ARCH: ${{ inputs.platform }}
           SIMD: ${{ inputs.simd }}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Append `-cmake` to artifacts that are built with cmake (only currently applicable to windows)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Learned something new about actions artifacts.  If they have the same name the file contents are effectively merged.  Looking at the recent artifacts, wxWidgets AVX2 Windows artifacts have 2 .exe's.  The `pcsx2.exe` is coming from the cmake build.

Differentiating the name solves this inconsistency.

All other windows builds were fine because we only built cmake with avx2 (and only on wx).  Linux and MacOS are _always_ done with cmake so its redundant to append there.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Look at the artifact in question.
