### PR TITLE
GSTextureCache: Expand target to fit readout height

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -125,7 +125,7 @@ void GSRendererHW::SetScaling()
 	// Until performance issue is properly fixed, let's keep an option to reduce the framebuffer size.
 	//
 	// m_large_framebuffer has been inverted to m_conservative_framebuffer, it isn't an option that benefits being enabled all the time for everyone.
-	int fb_height = 1280;
+	int fb_height = MAX_FRAMEBUFFER_HEIGHT;
 	if (GSConfig.ConservativeFramebuffer)
 	{
 		fb_height = fb_width < 1024 ? std::max(512, crtc_size.y) : 1024;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -22,6 +22,9 @@
 
 class GSRendererHW : public GSRenderer
 {
+public:
+	static constexpr int MAX_FRAMEBUFFER_HEIGHT = 1280;
+
 private:
 	int m_width;
 	int m_height;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -334,6 +334,10 @@ public:
 	SurfaceOffset ComputeSurfaceOffset(const uint32_t bp, const uint32_t bw, const uint32_t psm, const GSVector4i& r, const Target* t);
 	SurfaceOffset ComputeSurfaceOffset(const SurfaceOffsetKey& sok);
 
+	/// Expands a target when the block pointer for a display framebuffer is within another target, but the read offset
+	/// plus the height is larger than the current size of the target.
+	static void ScaleTargetForDisplay(Target* t, const GIFRegTEX0& dispfb, int real_h);
+
 	/// Invalidates a temporary source, a partial copy only created from the current RT/DS for the current draw.
 	void InvalidateTemporarySource();
 


### PR DESCRIPTION
### Description of Changes

This handles a case where you have two images stacked on top of one another (usually FMVs), and the size of the top framebuffer is larger than the height of the image. Usually happens when conservative FB is on, as off it'll create a 1280 high framebuffer.

The game alternates DISPFB between the top image, where the block pointer matches the target, but when it switches to the other buffer, LookupTarget() will score a partial match on the target because e.g. 448 < 512, but the target doesn't actually contain the full image. This usually leads to flickering. Test case: Neo Contra intro FMVs.

So, for these cases, we simply expand the target to include both images, based on the read height. It won't affect normal rendering, since that doesn't go through this path.

### Rationale behind Changes

Flickering is bad.

Possible fix for #6140.

### Suggested Testing Steps

Test games with FMV issues in the hardware renderers.
