### PR TITLE
Qt: Initialize COM ourselves on EmuThread

### DIFF
--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -228,7 +228,8 @@ void EmuThread::run()
 	m_event_loop = new QEventLoop();
 	m_started_semaphore.release();
 
-	if (!VMManager::Internal::InitializeMemory())
+	// neither of these should ever fail.
+	if (!VMManager::Internal::InitializeGlobals() || !VMManager::Internal::InitializeMemory())
 		pxFailRel("Failed to allocate memory map");
 
 	// we need input sources ready for binding
@@ -252,6 +253,7 @@ void EmuThread::run()
 	InputManager::CloseSources();
 	VMManager::WaitForSaveStateFlush();
 	VMManager::Internal::ReleaseMemory();
+	VMManager::Internal::ReleaseGlobals();
 	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
 	moveToThread(m_ui_thread);
 	deleteLater();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -86,12 +86,10 @@ bool QtHost::Initialize()
 
 	if (!InitializeConfig())
 	{
-		Console.WriteLn("Failed to initialize config.");
+		// NOTE: No point translating this, because no config means the language won't be loaded anyway.
+		QMessageBox::critical(nullptr, QStringLiteral("Error"), QStringLiteral("Failed to initialize config."));
 		return false;
 	}
-
-	if (!VMManager::Internal::InitializeGlobals())
-		return false;
 
 	HookSignals();
 	return true;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -110,8 +110,16 @@ void SysMtgsThread::ShutdownThread()
 
 void SysMtgsThread::ThreadEntryPoint()
 {
-	m_thread_handle = Threading::ThreadHandle::GetForCallingThread();
 	Threading::SetNameOfCurrentThread("GS");
+
+	if (GSinit() != 0)
+	{
+		Host::ReportErrorAsync("Error", "GSinit() failed.");
+		m_open_or_close_done.Post();
+		return;
+	}
+
+	m_thread_handle = Threading::ThreadHandle::GetForCallingThread();
 
 	for (;;)
 	{
@@ -154,6 +162,8 @@ void SysMtgsThread::ThreadEntryPoint()
 		// we need to reset sem_event here, because MainLoop() kills it.
 		m_sem_event.Reset();
 	}
+
+	GSshutdown();
 }
 
 void SysMtgsThread::ResetGS()

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -647,19 +647,6 @@ bool VMManager::Initialize(const VMBootParameters& boot_params)
 	ScopedGuard close_cdvd = [] { DoCDVDclose(); };
 
 	Console.WriteLn("Opening GS...");
-
-	// TODO: Get rid of thread state nonsense and just make it a "normal" thread.
-	static bool gs_initialized = false;
-	if (!gs_initialized)
-	{
-		if (GSinit() != 0)
-		{
-			Console.WriteLn("Failed to initialize GS.");
-			return false;
-		}
-
-		gs_initialized = true;
-	}
 	if (!GetMTGS().WaitForOpen())
 	{
 		// we assume GS is going to report its own error

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -62,6 +62,10 @@
 #include "common/emitter/x86_intrin.h"
 #endif
 
+#ifdef _WIN32
+#include "common/RedtapeWindows.h"
+#endif
+
 namespace VMManager
 {
 	static void LoadSettings();
@@ -187,6 +191,18 @@ std::string VMManager::GetGameName()
 
 bool VMManager::Internal::InitializeGlobals()
 {
+	// On Win32, we have a bunch of things which use COM (e.g. SDL, XAudio2, etc).
+	// We need to initialize COM first, before anything else does, because otherwise they might
+	// initialize it in single-threaded/apartment mode, which can't be changed to multithreaded.
+#ifdef _WIN32
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+	if (FAILED(hr))
+	{
+		Host::ReportErrorAsync("Error", fmt::format("CoInitializeEx() failed: {:08X}", hr));
+		return false;
+	}
+#endif
+
 	x86caps.Identify();
 	x86caps.CountCores();
 	x86caps.SIMD_EstablishMXCSRmask();
@@ -194,6 +210,13 @@ bool VMManager::Internal::InitializeGlobals()
 	SysLogMachineCaps();
 
 	return true;
+}
+
+void VMManager::Internal::ReleaseGlobals()
+{
+#ifdef _WIN32
+	CoUninitialize();
+#endif
 }
 
 bool VMManager::Internal::InitializeMemory()

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -153,6 +153,9 @@ namespace VMManager
 		/// Performs early global initialization.
 		bool InitializeGlobals();
 
+		/// Releases resources allocated in InitializeGlobals().
+		void ReleaseGlobals();
+
 		/// Reserves memory for the virtual machines.
 		bool InitializeMemory();
 

--- a/pcsx2/gui/SysCoreThread.cpp
+++ b/pcsx2/gui/SysCoreThread.cpp
@@ -112,7 +112,6 @@ void SysCoreThread::OnSuspendInThread()
 
 void SysCoreThread::Start()
 {
-	GSinit();
 	SPU2init();
 	PADinit();
 	DEV9init();


### PR DESCRIPTION
### Description of Changes

If we don't, SDL initializes it first in STA mode, which prevents MT mode from being used, which prevents us from using XAudio2.

### Rationale behind Changes

Fixes #6150.

### Suggested Testing Steps

Test XAudio2 in Qt. Make sure I didn't break GS in wx.