### PR TITLE
Qt: Apply patches on entry point compile

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -67,6 +67,7 @@ static void SaveSettings();
 //////////////////////////////////////////////////////////////////////////
 // Local variable declarations
 //////////////////////////////////////////////////////////////////////////
+const IConsoleWriter* PatchesCon = &Console;
 static std::unique_ptr<QTimer> s_settings_save_timer;
 static std::unique_ptr<INISettingsInterface> s_base_settings_interface;
 static bool s_batch_mode = false;
@@ -487,18 +488,6 @@ void Host::OnInputDeviceDisconnected(const std::string_view& identifier)
 //////////////////////////////////////////////////////////////////////////
 // Interface Stuff
 //////////////////////////////////////////////////////////////////////////
-
-const IConsoleWriter* PatchesCon = &Console;
-
-void LoadAllPatchesAndStuff(const Pcsx2Config& cfg)
-{
-	// FIXME
-}
-
-void PatchesVerboseReset()
-{
-	// FIXME
-}
 
 static void SignalHandler(int signal)
 {

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -164,6 +164,7 @@ namespace VMManager
 
 		const std::string& GetElfOverride();
 		bool IsExecutionInterrupted();
+		void EntryPointCompilingOnCPUThread();
 		void GameStartingOnCPUThread();
 		void VSyncOnCPUThread();
 	}


### PR DESCRIPTION
### Description of Changes

Fixes WRC4's entrypoint patch not being used.

### Rationale behind Changes

Fixes #6164.

### Suggested Testing Steps

Test WRC4 and other games which use on-load patches.
