### PR TITLE
GUI/Qt: Use higher quality icon

### DIFF
--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources/resources.qrc">
-    <normaloff>:/icons/AppIcon.png</normaloff>:/icons/AppIcon.png</iconset>
+    <normaloff>:/icons/AppIconLarge.png</normaloff>:/icons/AppIconLarge.png</iconset>
   </property>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">


### PR DESCRIPTION
### Description of Changes
Uses larger icon by default so it can scale it down

### Rationale behind Changes
tiny 16x16 icon was picked before and it looks blurry as shit

### Suggested Testing Steps
Make sure the icon isn't blurry as shit (especially when showing labels on windows). Check Linux is ok

Fixes #6168
