### PR TITLE
Qt: Revision default hotkeys v2

### DIFF
--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -227,19 +227,27 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 	// PCSX2 Controller Settings - Hotkeys
 
 	// PCSX2 Controller Settings - Hotkeys - General
-	si.SetStringValue("Hotkeys", "Screenshot", "Keyboard/F8");
 	si.SetStringValue("Hotkeys", "ToggleFullscreen", "Keyboard/Alt & Keyboard/Return");
 
 	// PCSX2 Controller Settings - Hotkeys - Graphics
 	si.SetStringValue("Hotkeys", "CycleAspectRatio", "Keyboard/F6");
-	si.SetStringValue("Hotkeys", "CycleMipmapMode", "Keyboard/Insert");
 	si.SetStringValue("Hotkeys", "CycleInterlaceMode", "Keyboard/F5");
+	si.SetStringValue("Hotkeys", "CycleMipmapMode", "Keyboard/Insert");
 	//	si.SetStringValue("Hotkeys", "DecreaseUpscaleMultiplier", "Keyboard"); TBD
 	//	si.SetStringValue("Hotkeys", "IncreaseUpscaleMultiplier", "Keyboard"); TBD
+	//  si.SetStringValue("Hotkeys", "ReloadTextureReplacements", "Keyboard"); TBD
+	si.SetStringValue("Hotkeys", "GSDumpMultiFrame", "Keyboard/Control & Keyboard/Shift & Keyboard/F8");
+	si.SetStringValue("Hotkeys", "Screenshot", "Keyboard/F8");
+	si.SetStringValue("Hotkeys", "GSDumpSingleFrame", "Keyboard/Shift & Keyboard/F8");
 	si.SetStringValue("Hotkeys", "ToggleSoftwareRendering", "Keyboard/F9");
+	//  si.SetStringValue("Hotkeys", "ToggleTextureDumping", "Keyboard"); TBD
+	//  si.SetStringValue("Hotkeys", "ToggleTextureReplacements", "Keyboard"); TBD
 	si.SetStringValue("Hotkeys", "ZoomIn", "Keyboard/Control & Keyboard/Plus");
 	si.SetStringValue("Hotkeys", "ZoomOut", "Keyboard/Control & Keyboard/Minus");
 	// Missing hotkey for resetting zoom back to 100 with Keyboard/Control & Keyboard/Asterisk
+	
+	// PCSX2 Controller Settings - Hotkeys - Input Recording
+	si.SetStringValue("Hotkeys", "InputRecToggleMode", "Keyboard/Shift & Keyboard/R");
 
 	// PCSX2 Controller Settings - Hotkeys - Save States
 	si.SetStringValue("Hotkeys", "LoadStateFromSlot", "Keyboard/F3");
@@ -249,12 +257,14 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 
 	// PCSX2 Controller Settings - Hotkeys - System
 	//	si.SetStringValue("Hotkeys", "DecreaseSpeed", "Keyboard"); TBD
+	//  si.SetStringValue("Hotkeys", "FrameAdvance", "Keyboard"); TBD
 	//	si.SetStringValue("Hotkeys", "IncreaseSpeed", "Keyboard"); TBD
+	//  si.SetStringValue("Hotkeys", "ResetVM", "Keyboard"); TBD
+	si.SetStringValue("Hotkeys", "ShutdownVM", "Keyboard/Escape");
 	si.SetStringValue("Hotkeys", "ToggleFrameLimit", "Keyboard/F4");
 	si.SetStringValue("Hotkeys", "TogglePause", "Keyboard/Space");
 	si.SetStringValue("Hotkeys", "ToggleSlowMotion", "Keyboard/Shift & Keyboard/Backtab");
 	si.SetStringValue("Hotkeys", "ToggleTurbo", "Keyboard/Tab");
-	si.SetStringValue("Hotkeys", "ShutdownVM", "Keyboard/Escape");
 }
 
 void PAD::Update()


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
There has been a re-order of keybindings, new keybindings and missing Single Frame GS Dump, Multi Frame GS Dump and Input Recording mode.

To be decided for the rest if it needs default hotkeys and which key or key combinations would be best.

![image](https://user-images.githubusercontent.com/24227051/170138323-b50e4953-d2a5-4b71-a1c2-a9b7f99a238e.png)
![image](https://user-images.githubusercontent.com/24227051/170138354-9ea41234-cb88-4e93-8333-5c254d2293ce.png)
![image](https://user-images.githubusercontent.com/24227051/170138371-84141b6a-d91d-4834-8ee6-e2989bf4772c.png)
![image](https://user-images.githubusercontent.com/24227051/170138387-20a33723-8af0-4e8e-8e5f-ae10c0206273.png)
![image](https://user-images.githubusercontent.com/24227051/170138415-add0b7d2-7813-4c0b-a4b6-bc93f5575258.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Consistency with older hotkeys, better code readability which mimics GUI structure.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test hotkeys.