### PR TITLE
GameDB: Removes missed french Tak fmv fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12674,8 +12674,6 @@ SLES-52103:
   name: "Tak & Le Pouvoir de Juju"
   region: "PAL-F"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Flickering in FMV.
 SLES-52104:
   name: "Tak and the Power of JuJu"
   region: "PAL-G"


### PR DESCRIPTION
### Description of Changes
Removes version of Tak & the power of Juju missed in recent FMV hack removal.

### Rationale behind Changes
Accurate GameDB

### Suggested Testing Steps
CI be happy.
