### PR TITLE
DX12: Fix large texture uploads and vsync

### DIFF
--- a/common/D3D12/Texture.cpp
+++ b/common/D3D12/Texture.cpp
@@ -352,7 +352,7 @@ static ID3D12Resource* CreateStagingBuffer(u32 height, const void* data, u32 pit
 	const D3D12_RESOURCE_DESC resource_desc = {
 		D3D12_RESOURCE_DIMENSION_BUFFER, 0, upload_size, 1, 1, 1, DXGI_FORMAT_UNKNOWN, {1, 0}, D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
 		D3D12_RESOURCE_FLAG_NONE};
-	HRESULT hr = g_d3d12_context->GetAllocator()->CreateResource(&allocation_desc, &resource_desc, D3D12_RESOURCE_STATE_COPY_SOURCE,
+	HRESULT hr = g_d3d12_context->GetAllocator()->CreateResource(&allocation_desc, &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr, allocation.put(), IID_PPV_ARGS(resource.put()));
 	if (FAILED(hr))
 	{

--- a/pcsx2/Frontend/D3D12HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D12HostDisplay.cpp
@@ -636,11 +636,11 @@ void D3D12HostDisplay::EndPresent()
 	swap_chain_buf.TransitionToState(g_d3d12_context->GetCommandList(), D3D12_RESOURCE_STATE_PRESENT);
 	g_d3d12_context->ExecuteCommandList(false);
 
-	const UINT vsync_rate = static_cast<UINT>(m_vsync_mode != VsyncMode::Off);
-	if (!m_vsync && m_using_allow_tearing)
+	const bool vsync = static_cast<UINT>(m_vsync_mode != VsyncMode::Off);
+	if (!vsync && m_using_allow_tearing)
 		m_swap_chain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
 	else
-		m_swap_chain->Present(vsync_rate, 0);
+		m_swap_chain->Present(static_cast<UINT>(vsync), 0);
 }
 
 void D3D12HostDisplay::SetGPUTimingEnabled(bool enabled)

--- a/pcsx2/Frontend/D3D12HostDisplay.h
+++ b/pcsx2/Frontend/D3D12HostDisplay.h
@@ -98,5 +98,4 @@ protected:
 
 	bool m_allow_tearing_supported = false;
 	bool m_using_allow_tearing = false;
-	bool m_vsync = true;
 };


### PR DESCRIPTION
Probably a bit tricky to test this one, I hit it when running the fullscreen UI at 4K (with the large font atlas), but it's simple enough that you can see the logic and why it works now.