### PR TITLE
VMManager: Fix no ws/ni patches message showing up on reset

### DIFF
--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -487,7 +487,7 @@ void EmuThread::reloadPatches()
 	if (!VMManager::HasValidVM())
 		return;
 
-	VMManager::ReloadPatches(true);
+	VMManager::ReloadPatches(true, true);
 }
 
 void EmuThread::reloadInputSources()

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -569,9 +569,13 @@ void VMManager::UpdateRunningGame(bool resetting, bool game_starting)
 
 	Host::OnGameChanged(s_disc_path, s_game_serial, s_game_name, s_game_crc);
 
+#if 0
+	// TODO: Enable this when the debugger is added to Qt, and it's active. Otherwise, this is just a waste of time.
+	// In other words, it should be lazily initialized.
 	MIPSAnalyst::ScanForFunctions(R5900SymbolMap, ElfTextRange.first, ElfTextRange.first + ElfTextRange.second, true);
 	R5900SymbolMap.UpdateActiveSymbols();
 	R3000SymbolMap.UpdateActiveSymbols();
+#endif
 }
 
 void VMManager::ReloadPatches(bool verbose, bool show_messages_when_disabled)

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -95,7 +95,7 @@ namespace VMManager
 	bool ReloadGameSettings();
 
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
-	void ReloadPatches(bool verbose);
+	void ReloadPatches(bool verbose, bool show_messages_when_disabled);
 
 	/// Returns the save state filename for the given game serial/crc.
 	std::string GetSaveStateFileName(const char* game_serial, u32 game_crc, s32 slot);


### PR DESCRIPTION
### Description of Changes

See title.

### Rationale behind Changes

Regression from https://github.com/PCSX2/pcsx2/commit/e0194b2b954908ea993f54e83e0b4a33a41e80e9.

### Suggested Testing Steps

Test ws patches and reset behaviour (also tested myself).