### PR TITLE
Qt: Implement drag/drop to main window

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1893,7 +1893,9 @@ void MainWindow::loadSaveStateFile(const QString& filename, const QString& state
 {
 	if (m_vm_valid)
 	{
-		g_emu_thread->loadState(filename);
+		if (!filename.isEmpty() && m_current_disc_path != filename)
+			g_emu_thread->changeDisc(m_current_disc_path);
+		g_emu_thread->loadState(state_filename);
 	}
 	else
 	{

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -157,6 +157,8 @@ private Q_SLOTS:
 
 protected:
 	void closeEvent(QCloseEvent* event) override;
+	void dragEnterEvent(QDragEnterEvent* event) override;
+	void dropEvent(QDropEvent* event) override;
 
 private:
 	enum : s32
@@ -206,6 +208,7 @@ private:
 	void populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc);
 	void populateSaveStateMenu(QMenu* menu, const QString& serial, quint32 crc);
 	void updateSaveStateMenus(const QString& filename, const QString& serial, quint32 crc);
+	void doStartDisc(const QString& path);
 	void doDiscChange(const QString& path);
 
 	Ui::MainWindow m_ui;

--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -110,17 +110,13 @@ const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating ratin
 	// clang-format on
 }
 
-bool GameList::IsScannableFilename(const std::string& path)
+bool GameList::IsScannableFilename(const std::string_view& path)
 {
 	static const char* extensions[] = {".iso", ".mdf", ".nrg", ".bin", ".img", ".gz", ".cso", ".chd", ".elf", ".irx"};
 
-	const std::string::size_type pos = path.rfind('.');
-	if (pos == std::string::npos)
-		return false;
-
 	for (const char* test_extension : extensions)
 	{
-		if (StringUtil::Strcasecmp(&path[pos], test_extension) == 0)
+		if (StringUtil::EndsWithNoCase(path, test_extension))
 			return true;
 	}
 

--- a/pcsx2/Frontend/GameList.h
+++ b/pcsx2/Frontend/GameList.h
@@ -72,7 +72,7 @@ namespace GameList
 	const char* RegionToString(Region region);
 	const char* EntryCompatibilityRatingToString(CompatibilityRating rating);
 
-	bool IsScannableFilename(const std::string& path);
+	bool IsScannableFilename(const std::string_view& path);
 
 	/// Fills in boot parameters (iso or elf) based on the game list entry.
 	void FillBootParametersForEntry(VMBootParameters* params, const Entry* entry);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1208,16 +1208,26 @@ bool VMManager::ChangeDisc(std::string path)
 	return result;
 }
 
-bool VMManager::IsElfFileName(const std::string& path)
+bool VMManager::IsElfFileName(const std::string_view& path)
 {
 	return StringUtil::EndsWithNoCase(path, ".elf");
 }
 
-bool VMManager::IsGSDumpFileName(const std::string& path)
+bool VMManager::IsGSDumpFileName(const std::string_view& path)
 {
 	return (StringUtil::EndsWithNoCase(path, ".gs") ||
 			StringUtil::EndsWithNoCase(path, ".gs.xz") ||
 			StringUtil::EndsWithNoCase(path, ".gs.zst"));
+}
+
+bool VMManager::IsSaveStateFileName(const std::string_view& path)
+{
+	return StringUtil::EndsWithNoCase(path, ".p2s");
+}
+
+bool VMManager::IsLoadableFileName(const std::string_view& path)
+{
+	return IsElfFileName(path) || IsGSDumpFileName(path) || GameList::IsScannableFilename(path);
 }
 
 void VMManager::Execute()

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -135,10 +135,16 @@ namespace VMManager
 	bool ChangeDisc(std::string path);
 
 	/// Returns true if the specified path is an ELF.
-	bool IsElfFileName(const std::string& path);
+	bool IsElfFileName(const std::string_view& path);
 
 	/// Returns true if the specified path is a GS Dump.
-	bool IsGSDumpFileName(const std::string& path);
+	bool IsGSDumpFileName(const std::string_view& path);
+
+	/// Returns true if the specified path is a save state.
+	bool IsSaveStateFileName(const std::string_view& path);
+
+	/// Returns true if the specified path is a disc/elf/etc.
+	bool IsLoadableFileName(const std::string_view& path);
 
 	/// Returns the path for the game settings ini file for the specified CRC.
 	std::string GetGameSettingsPath(const std::string_view& game_serial, u32 game_crc);


### PR DESCRIPTION
### Description of Changes

See title. Also fixes System -> Load State -> From File.

You can drag a disc image, as well as a save state onto the window to load it. Obviously be careful with save states, since the disc won't be changed, if you drop a save state from a different game in, bad things are gonna happen.

### Rationale behind Changes

Missing features.

### Suggested Testing Steps

Test dragging and dropping various file types, and system -> load state -> from file (also tested myself).