### PR TITLE
GS: Read local memory without sync when readbacks are disabled

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -257,6 +257,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	connect(m_ui.enableHWFixes, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::onEnableHardwareFixesChanged);
 	updateRendererDependentOptions();
 
+	// only allow disabling readbacks for per-game settings, it's too dangerous
+	m_ui.disableHardwareReadbacks->setEnabled(m_dialog->isPerGameSettings());
+
 	dialog->registerWidgetHelp(m_ui.enableHWFixes, tr("Manual Hardware Renderer Fixes"), tr("Unchecked"),
 		tr("Enabling this option gives you the ability to change the renderer and upscaling fixes "
 		   "to your games. However IF you have ENABLED this, you WILL DISABLE AUTOMATIC "
@@ -271,6 +274,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 		tr("Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still rendered, it just means "
 		   "the GPU has more time to complete it (this is NOT frame skipping). Can smooth our frame time fluctuations when the CPU/GPU are near maximum "
 		   "utilization, but makes frame pacing more inconsistent and can increase input lag."));
+	dialog->registerWidgetHelp(m_ui.disableHardwareReadbacks, tr("Disable Hardware Readbacks"), tr("Unchecked"),
+		tr("Skips synchronizing with the GS thread and host GPU for GS downloads. "
+		   "Can result in a large speed boost on slower systems, at the cost of many broken graphical effects. "
+		   "If games are broken and you have this option enabled, please disable it first."));
 }
 
 GraphicsSettingsWidget::~GraphicsSettingsWidget() = default;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -423,6 +423,11 @@ void GSInitAndReadFIFO(u8* mem, u32 size)
 	}
 }
 
+void GSReadLocalMemoryUnsync(u8* mem, u32 qwc, u64 BITBLITBUF, u64 TRXPOS, u64 TRXREG)
+{
+	g_gs_renderer->ReadLocalMemoryUnsync(mem, qwc, GIFRegBITBLTBUF{BITBLITBUF}, GIFRegTRXPOS{TRXPOS}, GIFRegTRXREG{TRXREG});
+}
+
 void GSgifTransfer(const u8* mem, u32 size)
 {
 	try

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -62,6 +62,7 @@ void GSclose();
 void GSgifSoftReset(u32 mask);
 void GSwriteCSR(u32 csr);
 void GSInitAndReadFIFO(u8* mem, u32 size);
+void GSReadLocalMemoryUnsync(u8* mem, u32 qwc, u64 BITBLITBUF, u64 TRXPOS, u64 TRXREG);
 void GSgifTransfer(const u8* mem, u32 size);
 void GSgifTransfer1(u8* mem, u32 addr);
 void GSgifTransfer2(u8* mem, u32 size);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2090,6 +2090,25 @@ void GSState::ReadFIFO(u8* mem, int size)
 		m_dump->ReadFIFO(size);
 }
 
+void GSState::ReadLocalMemoryUnsync(u8* mem, int qwc, GIFRegBITBLTBUF BITBLTBUF, GIFRegTRXPOS TRXPOS, GIFRegTRXREG TRXREG)
+{
+	const int sx = TRXPOS.SSAX;
+	const int sy = TRXPOS.SSAY;
+	const int w = TRXREG.RRW;
+	const int h = TRXREG.RRH;
+
+	const u16 bpp = GSLocalMemory::m_psm[BITBLTBUF.SPSM].trbpp;
+
+	GSTransferBuffer tb;
+	tb.Init(TRXPOS.SSAX, TRXPOS.SSAY, BITBLTBUF);
+
+	int len = qwc * 16;
+	if (!tb.Update(w, h, bpp, len))
+		return;
+
+	m_mem.ReadImageX(tb.x, tb.y, mem, len, BITBLTBUF, TRXPOS, TRXREG);
+}
+
 template void GSState::Transfer<0>(const u8* mem, u32 size);
 template void GSState::Transfer<1>(const u8* mem, u32 size);
 template void GSState::Transfer<2>(const u8* mem, u32 size);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -322,6 +322,7 @@ public:
 	void SoftReset(u32 mask);
 	void WriteCSR(u32 csr) { m_regs->CSR.U32[1] = csr; }
 	void ReadFIFO(u8* mem, int size);
+	void ReadLocalMemoryUnsync(u8* mem, int qwc, GIFRegBITBLTBUF BITBLTBUF, GIFRegTRXPOS TRXPOS, GIFRegTRXREG TRXREG);
 	template<int index> void Transfer(const u8* mem, u32 size);
 	int Freeze(freezeData* fd, bool sizeonly);
 	int Defrost(const freezeData* fd);

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -244,7 +244,10 @@ void SysMtgsThread::PostVsyncStart(bool registers_written)
 void SysMtgsThread::InitAndReadFIFO(u8* mem, u32 qwc)
 {
 	if (GSConfig.HWDisableReadbacks && GSConfig.UseHardwareRenderer())
+	{
+		GSReadLocalMemoryUnsync(mem, qwc, vif1.BITBLTBUF._u64, vif1.TRXPOS._u64, vif1.TRXREG._u64);
 		return;
+	}
 
 	SendPointerPacket(GS_RINGTYPE_INIT_AND_READ_FIFO, qwc, mem);
 	WaitGS(false, false, false);

--- a/pcsx2/Vif_Dma.h
+++ b/pcsx2/Vif_Dma.h
@@ -44,9 +44,27 @@ union tBITBLTBUF {
 	};
 };
 
-union tTRXREG {
+union tTRXPOS {
 	u64 _u64;
 	struct {
+		u32 SSAX : 11;
+		u32 _PAD1 : 5;
+		u32 SSAY : 11;
+		u32 _PAD2 : 5;
+		u32 DSAX : 11;
+		u32 _PAD3 : 5;
+		u32 DSAY : 11;
+		u32 DIRY : 1;
+		u32 DIRX : 1;
+		u32 _PAD4 : 3;
+	};
+};
+
+union tTRXREG
+{
+	u64 _u64;
+	struct
+	{
 		u32 RRW : 12;
 		u32 _pad12 : 20;
 		u32 RRH : 12;
@@ -83,8 +101,17 @@ struct vifStruct {
 	int unpackcalls;
 	// GS registers used for calculating the size of the last local->host transfer initiated on the GS
 	// Transfer size calculation should be restricted to GS emulation in the future
-	tBITBLTBUF BITBLTBUF;
-	tTRXREG    TRXREG;
+	union
+	{
+		struct
+		{
+			tBITBLTBUF BITBLTBUF;
+			tTRXPOS    TRXPOS;
+			tTRXREG    TRXREG;
+		};
+		u64 transfer_registers[3];
+	};
+
 	u32        GSLastDownloadSize;
 
 	tVIF_CTRL  irqoffset; // 32bit offset where next vif code is


### PR DESCRIPTION
### Description of Changes

Version 2 of this option got rid of the GS sync on download, but as a result broke a ton of games (e.g. FFX).

Version 3 is even more yolo and will just read whatever out of local memory nondeterministically, but it's enough that FFX doesn't lose its textures (I'm guessing they're downloading -> using GS memory -> reuploading), GT4's loading screens aren't complete garbage, etc.

This PR also makes it per-game settable only. It's way too risky of an option to enable globally, so we don't want to encourage users to do it, only enabling it as a last result.

### Rationale behind Changes

Making hack options less breaky, but still brr.

### Suggested Testing Steps

Test readbacks off, see what's no longer broken, and make sure on is still fine.
