### PR TITLE
Qt: Add hardware check for SSE4 and AVX2

### DIFF
--- a/common/emitter/cpudetect.cpp
+++ b/common/emitter/cpudetect.cpp
@@ -46,6 +46,11 @@ using namespace x86Emitter;
 
 alignas(16) x86capabilities x86caps;
 
+#ifdef _MSC_VER
+// We disable optimizations for this function, because we need x86capabilities for AVX
+// detection, but if we keep opts on, it'll use AVX instructions for inlining memzero.
+#pragma optimize("", off)
+#endif
 x86capabilities::x86capabilities()
 	: isIdentified(false)
 	, VendorID(x86Vendor_Unknown)
@@ -65,6 +70,9 @@ x86capabilities::x86capabilities()
 	memzero(VendorName);
 	memzero(FamilyName);
 }
+#ifdef _MSC_VER
+#pragma optimize("", on)
+#endif
 
 // Warning!  We've had problems with the MXCSR detection code causing stack corruption in
 // MSVC PGO builds.  The problem was fixed when I moved the MXCSR code to this function, and

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(pcsx2-qt PRIVATE
 	AutoUpdaterDialog.ui
 	DisplayWidget.cpp
 	DisplayWidget.h
+	EarlyHardwareCheck.cpp
 	EmuThread.cpp
 	EmuThread.h
 	Main.cpp

--- a/pcsx2-qt/EarlyHardwareCheck.cpp
+++ b/pcsx2-qt/EarlyHardwareCheck.cpp
@@ -1,0 +1,59 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#if defined(_WIN32) && defined(_MSC_VER)
+
+#include "pcsx2/VMManager.h"
+
+#include "common/RedtapeWindows.h"
+
+// The problem with AVX2 builds on Windows, is that MSVC generates AVX instructions for zeroing memory,
+// which is pretty common in our global object constructors. So, we have to use a special object which
+// gets initialized before all other global objects, that does the hardware check, and terminates the
+// process before main() or any of the other objects are constructed (which would subsequently crash).
+struct EarlyHardwareCheckObject
+{
+#pragma optimize("", off)
+	EarlyHardwareCheckObject()
+	{
+		const char* error;
+		if (VMManager::PerformEarlyHardwareChecks(&error))
+			return;
+
+		// we can't use StringUtil::UTF8StringToWideString because *that* constructor uses AVX..
+		const int error_len = static_cast<int>(std::strlen(error));
+		int wlen = MultiByteToWideChar(CP_UTF8, 0, error, error_len, nullptr, 0);
+		if (wlen > 0)
+		{
+			wchar_t* werror = static_cast<wchar_t*>(HeapAlloc(GetProcessHeap(), 0, sizeof(wchar_t) * (error_len + 1)));
+			if (werror && (wlen = MultiByteToWideChar(CP_UTF8, 0, error, error_len, werror, wlen)) > 0)
+			{
+				werror[wlen] = 0;
+				MessageBoxW(NULL, werror, L"Hardware Check Failed", MB_ICONERROR);
+				HeapFree(GetProcessHeap(), 0, werror);
+			}
+		}
+
+		TerminateProcess(GetCurrentProcess(), 0xFFFFFFFF);
+	}
+#pragma optimize("", on)
+};
+#pragma warning(disable : 4075) // warning C4075: initializers put in unrecognized initialization area
+#pragma init_seg(".CRT$XCT")
+EarlyHardwareCheckObject s_hardware_checker;
+
+#endif

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -134,6 +134,7 @@
     <Manifest Include="..\pcsx2\windows\PCSX2.manifest" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="EarlyHardwareCheck.cpp" />
     <ClCompile Include="Tools\InputRecording\NewInputRecordingDlg.cpp" />
     <ClCompile Include="Settings\BIOSSettingsWidget.cpp" />
     <ClCompile Include="Settings\ControllerBindingWidgets.cpp" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -204,6 +204,7 @@
     <ClCompile Include="Tools\InputRecording\NewInputRecordingDlg.cpp">
       <Filter>Tools\Input Recording</Filter>
     </ClCompile>
+    <ClCompile Include="EarlyHardwareCheck.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="..\pcsx2\windows\PCSX2.manifest">

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -52,6 +52,9 @@ struct VMBootParameters
 
 namespace VMManager
 {
+	/// Makes sure that AVX2 is available if we were compiled with it.
+	bool PerformEarlyHardwareChecks(const char** error);
+
 	/// Returns the current state of the VM.
 	VMState GetState();
 


### PR DESCRIPTION
### Description of Changes

Make sure the user has the required CPU instructions before PCSX2 properly initializes.

### Rationale behind Changes

Stopping people running the wrong build then complaining it crashes.

### Suggested Testing Steps

Difficult to test unless you have an ancient CPU. But the code can be reviewed :)
