### PR TITLE
GUI/Qt: Prioritize serial in cover lookup

### DIFF
--- a/pcsx2/Frontend/GameList.cpp
+++ b/pcsx2/Frontend/GameList.cpp
@@ -683,7 +683,17 @@ std::string GameList::GetCoverImagePath(const std::string& path, const std::stri
 	std::string cover_path;
 	for (const char* extension : extensions)
 	{
-		// use the file title if it differs (e.g. modded games)
+
+		// Prioritize lookup by serial (Most specific)
+		if (!serial.empty())
+		{
+			const std::string cover_filename(serial + extension);
+			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
+			if (FileSystem::FileExists(cover_path.c_str()))
+				return cover_path;
+		}
+
+		// Try file title (for modded games or specific like above)
 		const std::string_view file_title(Path::GetFileTitle(path));
 		if (!file_title.empty() && title != file_title)
 		{
@@ -695,19 +705,10 @@ std::string GameList::GetCoverImagePath(const std::string& path, const std::stri
 				return cover_path;
 		}
 
-		// try the title
+		// Last resort, check the game title
 		if (!title.empty())
 		{
 			const std::string cover_filename(title + extension);
-			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
-			if (FileSystem::FileExists(cover_path.c_str()))
-				return cover_path;
-		}
-
-		// then the code
-		if (!serial.empty())
-		{
-			const std::string cover_filename(serial + extension);
 			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
 			if (FileSystem::FileExists(cover_path.c_str()))
 				return cover_path;


### PR DESCRIPTION
### Description of Changes
Change the cover lookup priority to check serial first.

### Rationale behind Changes
Generic cover names were used first, which is probably a last reset "generic" filename, serial is much more specific and should be loaded if it exists.

### Suggested Testing Steps
If you have 2 versions of the same game (different regions), try one with the generic game name, and another with the serial.

Fixes #6212