### PR TITLE
GS: Fix single frame of old game after reset

### DIFF
--- a/pcsx2/GS.cpp
+++ b/pcsx2/GS.cpp
@@ -38,7 +38,7 @@ void gsSetVideoMode(GS_VideoMode mode)
 // Make sure framelimiter options are in sync with GS capabilities.
 void gsReset()
 {
-	GetMTGS().ResetGS();
+	GetMTGS().ResetGS(true);
 
 	UpdateVSyncRate();
 	memzero(g_RealGSMem);

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -380,7 +380,7 @@ public:
 
 	// Waits for the GS to empty out the entire ring buffer contents.
 	void WaitGS(bool syncRegs=true, bool weakWait=false, bool isMTVU=false);
-	void ResetGS();
+	void ResetGS(bool hardware_reset);
 
 	void PrepDataPacket( MTGS_RingCommand cmd, u32 size );
 	void PrepDataPacket( GIF_PATH pathidx, u32 size );

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -373,11 +373,11 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 	return true;
 }
 
-void GSreset()
+void GSreset(bool hardware_reset)
 {
 	try
 	{
-		g_gs_renderer->Reset();
+		g_gs_renderer->Reset(hardware_reset);
 	}
 	catch (GSRecoverableError)
 	{

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -496,6 +496,10 @@ int GSfreeze(FreezeAction mode, freezeData* data)
 		}
 		else if (mode == FreezeAction::Load)
 		{
+			// Since Defrost doesn't do a hardware reset (since it would be clearing
+			// local memory just before it's overwritten), we have to manually wipe
+			// out the current textures.
+			g_gs_device->ClearCurrent();
 			return g_gs_renderer->Defrost(data);
 		}
 	}

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -57,7 +57,7 @@ void GSinitConfig();
 void GSshutdown();
 bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* basemem);
 bool GSreopen(bool recreate_display);
-void GSreset();
+void GSreset(bool hardware_reset);
 void GSclose();
 void GSgifSoftReset(u32 mask);
 void GSwriteCSR(u32 csr);

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -204,7 +204,7 @@ template <int n>
 void GSClut::WriteCLUT32_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT32);
-	auto pa = off.paMulti(m_mem->m_vm32, TEXCLUT.COU << 4, TEXCLUT.COV);
+	auto pa = off.paMulti(m_mem->vm32(), TEXCLUT.COU << 4, TEXCLUT.COV);
 
 	u16* RESTRICT clut = m_clut + ((TEX0.CSA & 15) << 4);
 
@@ -221,7 +221,7 @@ template <int n>
 void GSClut::WriteCLUT16_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16);
-	auto pa = off.paMulti(m_mem->m_vm16, TEXCLUT.COU << 4, TEXCLUT.COV);
+	auto pa = off.paMulti(m_mem->vm16(), TEXCLUT.COU << 4, TEXCLUT.COV);
 
 	u16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 
@@ -235,7 +235,7 @@ template <int n>
 void GSClut::WriteCLUT16S_CSM2(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
 	GSOffset off = GSOffset::fromKnownPSM(TEX0.CBP, TEXCLUT.CBW, PSM_PSMCT16S);
-	auto pa = off.paMulti(m_mem->m_vm16, TEXCLUT.COU << 4, TEXCLUT.COV);
+	auto pa = off.paMulti(m_mem->vm16(), TEXCLUT.COU << 4, TEXCLUT.COV);
 
 	u16* RESTRICT clut = m_clut + (TEX0.CSA << 4);
 

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -79,9 +79,6 @@ GSLocalMemory::GSLocalMemory()
 		m_use_fifo_alloc = false;
 	}
 
-	m_vm16 = (u16*)m_vm8;
-	m_vm32 = (u32*)m_vm8;
-
 	memset(m_vm8, 0, m_vmsize);
 
 	for (psm_t& psm : m_psm)
@@ -1190,7 +1187,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const u8* src, int len, GIFReg
 	{
 		case PSM_PSMCT32:
 		case PSM_PSMZ32:
-			readWriteHelper(m_vm32, tx, ty, len / 4, 1, sx, w, off.assertSizesMatch(swizzle32), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len / 4, 1, sx, w, off.assertSizesMatch(swizzle32), [&](auto& pa, int x)
 			{
 				*pa.value(x) = *pd;
 				pd++;
@@ -1199,7 +1196,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const u8* src, int len, GIFReg
 
 		case PSM_PSMCT24:
 		case PSM_PSMZ24:
-			readWriteHelper(m_vm32, tx, ty, len / 3, 1, sx, w, off.assertSizesMatch(swizzle32), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len / 3, 1, sx, w, off.assertSizesMatch(swizzle32), [&](auto& pa, int x)
 			{
 				WritePixel24(pa.value(x), *(u32*)pb);
 				pb += 3;
@@ -1210,7 +1207,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const u8* src, int len, GIFReg
 		case PSM_PSMCT16S:
 		case PSM_PSMZ16:
 		case PSM_PSMZ16S:
-			readWriteHelper(m_vm16, tx, ty, len / 2, 1, sx, w, off.assertSizesMatch(swizzle16), [&](auto& pa, int x)
+			readWriteHelper(vm16(), tx, ty, len / 2, 1, sx, w, off.assertSizesMatch(swizzle16), [&](auto& pa, int x)
 			{
 				*pa.value(x) = *pw;
 				pw++;
@@ -1235,7 +1232,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const u8* src, int len, GIFReg
 			break;
 
 		case PSM_PSMT8H:
-			readWriteHelper(m_vm32, tx, ty, len, 1, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT8H), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len, 1, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT8H), [&](auto& pa, int x)
 			{
 				WritePixel8H(pa.value(x), *pb);
 				pb++;
@@ -1243,7 +1240,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const u8* src, int len, GIFReg
 			break;
 
 		case PSM_PSMT4HL:
-			readWriteHelper(m_vm32, tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HL), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HL), [&](auto& pa, int x)
 			{
 				WritePixel4HL(pa.value(x), *pb & 0xf);
 				WritePixel4HL(pa.value(x + 1), *pb >> 4);
@@ -1252,7 +1249,7 @@ void GSLocalMemory::WriteImageX(int& tx, int& ty, const u8* src, int len, GIFReg
 			break;
 
 		case PSM_PSMT4HH:
-			readWriteHelper(m_vm32, tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HH), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HH), [&](auto& pa, int x)
 			{
 				WritePixel4HH(pa.value(x), *pb & 0xf);
 				WritePixel4HH(pa.value(x + 1), *pb >> 4);
@@ -1296,7 +1293,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 
 			len /= 4;
 
-			GSOffset::PAPtrHelper pa = off.assertSizesMatch(swizzle32).paMulti(m_vm32, 0, y);
+			GSOffset::PAPtrHelper pa = off.assertSizesMatch(swizzle32).paMulti(vm32(), 0, y);
 
 			while (len > 0)
 			{
@@ -1327,7 +1324,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 				{
 					y++;
 					x = sx;
-					pa = off.assertSizesMatch(swizzle32).paMulti(m_vm32, 0, y);
+					pa = off.assertSizesMatch(swizzle32).paMulti(vm32(), 0, y);
 				}
 			}
 
@@ -1338,7 +1335,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 
 		case PSM_PSMCT24:
 		case PSM_PSMZ24:
-			readWriteHelper(m_vm32, tx, ty, len / 3, 1, sx, w, off.assertSizesMatch(swizzle32), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len / 3, 1, sx, w, off.assertSizesMatch(swizzle32), [&](auto& pa, int x)
 			{
 				u32 c = *pa.value(x);
 				pb[0] = (u8)(c);
@@ -1352,7 +1349,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 		case PSM_PSMCT16S:
 		case PSM_PSMZ16:
 		case PSM_PSMZ16S:
-			readWriteHelper(m_vm16, tx, ty, len / 2, 1, sx, w, off.assertSizesMatch(swizzle16), [&](auto& pa, int x)
+			readWriteHelper(vm16(), tx, ty, len / 2, 1, sx, w, off.assertSizesMatch(swizzle16), [&](auto& pa, int x)
 			{
 				*pw = *pa.value(x);
 				pw++;
@@ -1377,7 +1374,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 			break;
 
 		case PSM_PSMT8H:
-			readWriteHelper(m_vm32, tx, ty, len, 1, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT8H), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len, 1, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT8H), [&](auto& pa, int x)
 			{
 				*pb = (u8)(*pa.value(x) >> 24);
 				pb++;
@@ -1385,7 +1382,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 			break;
 
 		case PSM_PSMT4HL:
-			readWriteHelper(m_vm32, tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HL), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HL), [&](auto& pa, int x)
 			{
 				u32 c0 = *pa.value(x) >> 24 & 0x0f;
 				u32 c1 = *pa.value(x + 1) >> 20 & 0xf0;
@@ -1395,7 +1392,7 @@ void GSLocalMemory::ReadImageX(int& tx, int& ty, u8* dst, int len, GIFRegBITBLTB
 			break;
 
 		case PSM_PSMT4HH:
-			readWriteHelper(m_vm32, tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HH), [&](auto& pa, int x)
+			readWriteHelper(vm32(), tx, ty, len * 2, 2, sx, w, GSOffset::fromKnownPSM(bp, bw, PSM_PSMT4HH), [&](auto& pa, int x)
 			{
 				u32 c0 = *pa.value(x) >> 28 & 0x0f;
 				u32 c1 = *pa.value(x + 1) >> 24 & 0xf0;

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -476,8 +476,6 @@ public:
 	static const int m_vmsize = 1024 * 1024 * 4;
 
 	u8* m_vm8;
-	u16* m_vm16;
-	u32* m_vm32;
 
 	GSClut m_clut;
 
@@ -521,6 +519,9 @@ protected:
 public:
 	GSLocalMemory();
 	virtual ~GSLocalMemory();
+
+	__forceinline u16* vm16() const { return reinterpret_cast<u16*>(m_vm8); }
+	__forceinline u32* vm32() const { return reinterpret_cast<u32*>(m_vm8); }
 
 	GSOffset GetOffset(u32 bp, u32 bw, u32 psm) const
 	{
@@ -669,17 +670,17 @@ public:
 
 	__forceinline u32 ReadPixel32(u32 addr) const
 	{
-		return m_vm32[addr];
+		return vm32()[addr];
 	}
 
 	__forceinline u32 ReadPixel24(u32 addr) const
 	{
-		return m_vm32[addr] & 0x00ffffff;
+		return vm32()[addr] & 0x00ffffff;
 	}
 
 	__forceinline u32 ReadPixel16(u32 addr) const
 	{
-		return (u32)m_vm16[addr];
+		return (u32)vm16()[addr];
 	}
 
 	__forceinline u32 ReadPixel8(u32 addr) const
@@ -694,27 +695,27 @@ public:
 
 	__forceinline u32 ReadPixel8H(u32 addr) const
 	{
-		return m_vm32[addr] >> 24;
+		return vm32()[addr] >> 24;
 	}
 
 	__forceinline u32 ReadPixel4HL(u32 addr) const
 	{
-		return (m_vm32[addr] >> 24) & 0x0f;
+		return (vm32()[addr] >> 24) & 0x0f;
 	}
 
 	__forceinline u32 ReadPixel4HH(u32 addr) const
 	{
-		return (m_vm32[addr] >> 28) & 0x0f;
+		return (vm32()[addr] >> 28) & 0x0f;
 	}
 
 	__forceinline u32 ReadFrame24(u32 addr) const
 	{
-		return 0x80000000 | (m_vm32[addr] & 0xffffff);
+		return 0x80000000 | (vm32()[addr] & 0xffffff);
 	}
 
 	__forceinline u32 ReadFrame16(u32 addr) const
 	{
-		u32 c = (u32)m_vm16[addr];
+		u32 c = (u32)vm16()[addr];
 
 		return ((c & 0x8000) << 16) | ((c & 0x7c00) << 9) | ((c & 0x03e0) << 6) | ((c & 0x001f) << 3);
 	}
@@ -816,7 +817,7 @@ public:
 
 	__forceinline void WritePixel32(u32 addr, u32 c)
 	{
-		m_vm32[addr] = c;
+		vm32()[addr] = c;
 	}
 
 	__forceinline static void WritePixel24(u32* addr, u32 c)
@@ -826,12 +827,12 @@ public:
 
 	__forceinline void WritePixel24(u32 addr, u32 c)
 	{
-		WritePixel24(m_vm32 + addr, c);
+		WritePixel24(vm32() + addr, c);
 	}
 
 	__forceinline void WritePixel16(u32 addr, u32 c)
 	{
-		m_vm16[addr] = (u16)c;
+		vm16()[addr] = (u16)c;
 	}
 
 	__forceinline void WritePixel8(u32 addr, u32 c)
@@ -854,7 +855,7 @@ public:
 
 	__forceinline void WritePixel8H(u32 addr, u32 c)
 	{
-		WritePixel8H(m_vm32 + addr, c);
+		WritePixel8H(vm32() + addr, c);
 	}
 
 	__forceinline static void WritePixel4HL(u32* addr, u32 c)
@@ -864,7 +865,7 @@ public:
 
 	__forceinline void WritePixel4HL(u32 addr, u32 c)
 	{
-		WritePixel4HL(m_vm32 + addr, c);
+		WritePixel4HL(vm32() + addr, c);
 	}
 
 	__forceinline static void WritePixel4HH(u32* addr, u32 c)
@@ -874,7 +875,7 @@ public:
 
 	__forceinline void WritePixel4HH(u32 addr, u32 c)
 	{
-		WritePixel4HH(m_vm32 + addr, c);
+		WritePixel4HH(vm32() + addr, c);
 	}
 
 	__forceinline void WriteFrame16(u32 addr, u32 c)
@@ -972,12 +973,12 @@ public:
 
 	void WritePixel32(u8* RESTRICT src, u32 pitch, const GSOffset& off, const GSVector4i& r)
 	{
-		off.loopPixels(r, m_vm32, (u32*)src, pitch, [&](u32* dst, u32* src) { *dst = *src; });
+		off.loopPixels(r, vm32(), (u32*)src, pitch, [&](u32* dst, u32* src) { *dst = *src; });
 	}
 
 	void WritePixel24(u8* RESTRICT src, u32 pitch, const GSOffset& off, const GSVector4i& r)
 	{
-		off.loopPixels(r, m_vm32, (u32*)src, pitch,
+		off.loopPixels(r, vm32(), (u32*)src, pitch,
 		[&](u32* dst, u32* src)
 		{
 			*dst = (*dst & 0xff000000) | (*src & 0x00ffffff);
@@ -986,12 +987,12 @@ public:
 
 	void WritePixel16(u8* RESTRICT src, u32 pitch, const GSOffset& off, const GSVector4i& r)
 	{
-		off.loopPixels(r, m_vm16, (u16*)src, pitch, [&](u16* dst, u16* src) { *dst = *src; });
+		off.loopPixels(r, vm16(), (u16*)src, pitch, [&](u16* dst, u16* src) { *dst = *src; });
 	}
 
 	void WriteFrame16(u8* RESTRICT src, u32 pitch, const GSOffset& off, const GSVector4i& r)
 	{
-		off.loopPixels(r, m_vm16, (u32*)src, pitch,
+		off.loopPixels(r, vm16(), (u32*)src, pitch,
 		[&](u16* dst, u32* src)
 		{
 			u32 rb = *src & 0x00f800f8;
@@ -1003,17 +1004,17 @@ public:
 
 	__forceinline u32 ReadTexel32(u32 addr, const GIFRegTEXA& TEXA) const
 	{
-		return m_vm32[addr];
+		return vm32()[addr];
 	}
 
 	__forceinline u32 ReadTexel24(u32 addr, const GIFRegTEXA& TEXA) const
 	{
-		return Expand24To32(m_vm32[addr], TEXA);
+		return Expand24To32(vm32()[addr], TEXA);
 	}
 
 	__forceinline u32 ReadTexel16(u32 addr, const GIFRegTEXA& TEXA) const
 	{
-		return Expand16To32(m_vm16[addr], TEXA);
+		return Expand16To32(vm16()[addr], TEXA);
 	}
 
 	__forceinline u32 ReadTexel8(u32 addr, const GIFRegTEXA& TEXA) const

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -137,7 +137,7 @@ GSState::GSState()
 	m_env.PRMODECONT.AC = 1;
 	m_last_prim.U32[0] = PRIM->U32[0];
 
-	Reset();
+	Reset(false);
 
 	ResetHandlers();
 }
@@ -178,10 +178,11 @@ void GSState::SetFrameSkip(int skip)
 	}
 }
 
-void GSState::Reset()
+void GSState::Reset(bool hardware_reset)
 {
 	// FIXME: bios logo not shown cut in half after reset, missing graphics in GoW after first FMV
-	// memset(m_mem.m_vm8, 0, m_mem.m_vmsize);
+	if (hardware_reset)
+		memset(m_mem.m_vm8, 0, m_mem.m_vmsize);
 	memset(&m_path, 0, sizeof(m_path));
 	memset(&m_v, 0, sizeof(m_v));
 
@@ -2396,7 +2397,7 @@ int GSState::Defrost(const freezeData* fd)
 
 	Flush();
 
-	Reset();
+	Reset(false);
 
 	ReadState(&m_env.PRIM, data);
 

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2016,21 +2016,21 @@ void GSState::Move()
 	{
 		if (spsm.trbpp == 32)
 		{
-			copyFast(m_mem.m_vm32, dpo.assertSizesMatch(GSLocalMemory::swizzle32), spo.assertSizesMatch(GSLocalMemory::swizzle32), [](u32* d, u32* s)
+			copyFast(m_mem.vm32(), dpo.assertSizesMatch(GSLocalMemory::swizzle32), spo.assertSizesMatch(GSLocalMemory::swizzle32), [](u32* d, u32* s)
 			{
 				*d = *s;
 			});
 		}
 		else if (spsm.trbpp == 24)
 		{
-			copyFast(m_mem.m_vm32, dpo.assertSizesMatch(GSLocalMemory::swizzle32), spo.assertSizesMatch(GSLocalMemory::swizzle32), [](u32* d, u32* s)
+			copyFast(m_mem.vm32(), dpo.assertSizesMatch(GSLocalMemory::swizzle32), spo.assertSizesMatch(GSLocalMemory::swizzle32), [](u32* d, u32* s)
 			{
 				*d = (*d & 0xff000000) | (*s & 0x00ffffff);
 			});
 		}
 		else // if(spsm.trbpp == 16)
 		{
-			copyFast(m_mem.m_vm16, dpo.assertSizesMatch(GSLocalMemory::swizzle16), spo.assertSizesMatch(GSLocalMemory::swizzle16), [](u16* d, u16* s)
+			copyFast(m_mem.vm16(), dpo.assertSizesMatch(GSLocalMemory::swizzle16), spo.assertSizesMatch(GSLocalMemory::swizzle16), [](u16* d, u16* s)
 			{
 				*d = *s;
 			});

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -302,7 +302,7 @@ public:
 
 	float GetTvRefreshRate();
 
-	virtual void Reset();
+	virtual void Reset(bool hardware_reset);
 	virtual void UpdateSettings(const Pcsx2Config::GSOptions& old_config);
 
 	void Flush();

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -315,6 +315,21 @@ void GSDevice::StretchRect(GSTexture* sTex, GSTexture* dTex, const GSVector4& dR
 	StretchRect(sTex, GSVector4(0, 0, 1, 1), dTex, dRect, shader, linear);
 }
 
+void GSDevice::ClearCurrent()
+{
+	m_current = nullptr;
+
+	delete m_merge;
+	delete m_weavebob;
+	delete m_blend;
+	delete m_target_tmp;
+
+	m_merge = nullptr;
+	m_weavebob = nullptr;
+	m_blend = nullptr;
+	m_target_tmp = nullptr;
+}
+
 void GSDevice::Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, const GSVector2i& fs, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c)
 {
 	// KH:COM crashes at startup when booting *through the bios* due to m_merge being NULL.

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -727,6 +727,7 @@ public:
 	__fi FeatureSupport Features() const { return m_features; }
 	__fi GSTexture* GetCurrent() const { return m_current; }
 
+	void ClearCurrent();
 	void Merge(GSTexture* sTex[3], GSVector4* sRect, GSVector4* dRect, const GSVector2i& fs, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, const GSVector4& c);
 	void Interlace(const GSVector2i& ds, int field, int mode, float yoffset);
 	void FXAA();

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -60,6 +60,15 @@ GSRenderer::GSRenderer() = default;
 
 GSRenderer::~GSRenderer() = default;
 
+void GSRenderer::Reset(bool hardware_reset)
+{
+	// clear the current display texture
+	if (hardware_reset)
+		g_gs_device->ClearCurrent();
+
+	GSState::Reset(hardware_reset);
+}
+
 void GSRenderer::Destroy()
 {
 }

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -51,6 +51,8 @@ public:
 	GSRenderer();
 	virtual ~GSRenderer();
 
+	virtual void Reset(bool hardware_reset) override;
+
 	virtual void Destroy();
 
 	virtual void VSync(u32 field, bool registers_written);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -943,8 +943,8 @@ void GSRendererHW::SwSpriteRender()
 
 	for (int y = 0; y < h; y++, ++sy, ++dy)
 	{
-		const auto& spa = spo.paMulti(m_mem.m_vm32, sx, sy);
-		const auto& dpa = dpo.paMulti(m_mem.m_vm32, dx, dy);
+		const auto& spa = spo.paMulti(m_mem.vm32(), sx, sy);
+		const auto& dpa = dpo.paMulti(m_mem.vm32(), dx, dy);
 
 		ASSERT(w % 2 == 0);
 
@@ -3831,7 +3831,7 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel32
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				auto pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(m_mem.m_vm32, 0, y);
+				auto pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(m_mem.vm32(), 0, y);
 
 				for (int x = r.left; x < r.right; x++)
 				{
@@ -3844,7 +3844,7 @@ void GSRendererHW::OI_GsMemClear()
 			// Based on WritePixel24
 			for (int y = r.top; y < r.bottom; y++)
 			{
-				auto pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(m_mem.m_vm32, 0, y);
+				auto pa = off.assertSizesMatch(GSLocalMemory::swizzle32).paMulti(m_mem.vm32(), 0, y);
 
 				for (int x = r.left; x < r.right; x++)
 				{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -202,14 +202,14 @@ int GSRendererHW::GetUpscaleMultiplier()
 	return GSConfig.UpscaleMultiplier;
 }
 
-void GSRendererHW::Reset()
+void GSRendererHW::Reset(bool hardware_reset)
 {
 	// TODO: GSreset can come from the main thread too => crash
 	// m_tc->RemoveAll();
 
 	m_reset = true;
 
-	GSRenderer::Reset();
+	GSRenderer::Reset(hardware_reset);
 }
 
 void GSRendererHW::UpdateSettings(const Pcsx2Config::GSOptions& old_config)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -183,7 +183,7 @@ public:
 	GSVector2 GetTextureScaleFactor() override;
 	GSVector2i GetTargetSize();
 
-	void Reset() override;
+	void Reset(bool hardware_reset) override;
 	void UpdateSettings(const Pcsx2Config::GSOptions& old_config) override;
 	void VSync(u32 field, bool registers_written) override;
 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -66,13 +66,13 @@ GSRendererSW::~GSRendererSW()
 	GSRendererSW::Destroy();
 }
 
-void GSRendererSW::Reset()
+void GSRendererSW::Reset(bool hardware_reset)
 {
 	Sync(-1);
 
 	m_tc->RemoveAll();
 
-	GSRenderer::Reset();
+	GSRenderer::Reset(hardware_reset);
 }
 
 void GSRendererSW::Destroy()

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.h
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.h
@@ -78,7 +78,7 @@ protected:
 	std::atomic<u32> m_fzb_pages[512]; // u16 frame/zbuf pages interleaved
 	std::atomic<u16> m_tex_pages[512];
 
-	void Reset() override;
+	void Reset(bool hardware_reset) override;
 	void VSync(u32 field, bool registers_written) override;
 	GSTexture* GetOutput(int i, int& y_offset) override;
 	GSTexture* GetFeedbackOutput() override;

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -166,7 +166,7 @@ void SysMtgsThread::ThreadEntryPoint()
 	GSshutdown();
 }
 
-void SysMtgsThread::ResetGS()
+void SysMtgsThread::ResetGS(bool hardware_reset)
 {
 	pxAssertDev(!IsOpen() || (m_ReadPos == m_WritePos), "Must close or terminate the GS thread prior to gsReset.");
 
@@ -180,7 +180,7 @@ void SysMtgsThread::ResetGS()
 	m_VsyncSignalListener = 0;
 
 	MTGS_LOG("MTGS: Sending Reset...");
-	SendSimplePacket(GS_RINGTYPE_RESET, 0, 0, 0);
+	SendSimplePacket(GS_RINGTYPE_RESET, static_cast<int>(hardware_reset), 0, 0);
 	SendSimplePacket(GS_RINGTYPE_FRAMESKIP, 0, 0, 0);
 	SetEvent();
 }
@@ -495,7 +495,7 @@ void SysMtgsThread::MainLoop()
 
 						case GS_RINGTYPE_RESET:
 							MTGS_LOG("(MTGS Packet Read) ringtype=Reset");
-							GSreset();
+							GSreset(tag.data != 0);
 							break;
 
 						case GS_RINGTYPE_SOFTRESET:

--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -882,7 +882,7 @@ void Dialogs::GSDumpDialog::GSThread::ExecuteTaskInThread()
 	}
 
 	GSvsync(1, false);
-	GSreset();
+	GSreset(false);
 	GSfreeze(FreezeAction::Load, &fd);
 
 	size_t i = 0;


### PR DESCRIPTION
### Description of Changes

Something which has bothered me for a while. Fixes the single frame of the previous game getting displayed after loading state and/or resetting.

Also gets rid of some duplicate VM pointers, and wipes out local memory on hardware reset.

### Rationale behind Changes

Fixing things which annoy me.

### Suggested Testing Steps

Test resetting.
