### PR TITLE
Patches: Make cheats_ws.zip search case insensitive

### DIFF
--- a/common/ZipHelpers.h
+++ b/common/ZipHelpers.h
@@ -82,13 +82,13 @@ template<typename T>
 static inline std::optional<T> ReadFileInZipToContainer(zip_t* zip, const char* name)
 {
 	std::optional<T> ret;
-	const zip_int64_t file_index = zip_name_locate(zip, name, 0);
+	const zip_int64_t file_index = zip_name_locate(zip, name, ZIP_FL_NOCASE);
 	if (file_index >= 0)
 	{
 		zip_stat_t zst;
-		if (zip_stat_index(zip, file_index, 0, &zst) == 0)
+		if (zip_stat_index(zip, file_index, ZIP_FL_NOCASE, &zst) == 0)
 		{
-			zip_file_t* zf = zip_fopen_index(zip, file_index, 0);
+			zip_file_t* zf = zip_fopen_index(zip, file_index, ZIP_FL_NOCASE);
 			if (zf)
 			{
 				ret = T();


### PR DESCRIPTION
### Description of Changes
Make zip searches case insensitive for files with capital PNACH

### Rationale behind Changes
It was case sensitive, more grumpy

### Suggested Testing Steps
Add upper case files to your cheats_ws.zip or cheats_ni.zip and make sure it still loads.

Fixes #6139
