### PR TITLE
GS: Better swapped draw direction detection on scissor opt

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3212,12 +3212,14 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(const GIFRegTEX0& TEX0, c
 				const GSVertex* vert_first = &m_vertex.buff[m_index.buff[0]];
 				const GSVertex* vert_second = &m_vertex.buff[m_index.buff[1]];
 
-				const bool swap_x = vert_first->U > vert_second->U;
-				const bool swap_y = vert_first->V > vert_second->V;
-
 				// we need to check that it's not going to repeat over the non-clipped part
 				if (wms != CLAMP_REGION_REPEAT && (wms != CLAMP_REPEAT || (static_cast<int>(st.x) & ~tw_mask) == (static_cast<int>(st.z) & ~tw_mask)))
 				{
+					// Check if the UV coords are going in a different direction to the verts, if they match direction, no need to swap
+					const bool u_forward = vert_first->U < vert_second->U;
+					const bool x_forward = vert_first->XYZ.X < vert_second->XYZ.X;
+					const bool swap_x = u_forward != x_forward;
+
 					if (int_rc.left < scissored_rc.left)
 					{
 						if(!swap_x)
@@ -3235,6 +3237,11 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(const GIFRegTEX0& TEX0, c
 				}
 				if (wmt != CLAMP_REGION_REPEAT && (wmt != CLAMP_REPEAT || (static_cast<int>(st.y) & ~th_mask) == (static_cast<int>(st.w) & ~th_mask)))
 				{
+					// Check if the UV coords are going in a different direction to the verts, if they match direction, no need to swap
+					const bool v_forward = vert_first->U < vert_second->U;
+					const bool y_forward = vert_first->XYZ.Y < vert_second->XYZ.Y;
+					const bool swap_y = v_forward != y_forward;
+
 					if (int_rc.top < scissored_rc.top)
 					{
 						if (!swap_y)


### PR DESCRIPTION
### Description of Changes
Improves the detection of if the draw direction is swapped around.

### Rationale behind Changes
More bugs from #5930 just a bit of an oversight by me in #6036 where I only accounted for the UV being reversed, not the verticies.

### Suggested Testing Steps
run games in software or with preload textures set to "none" make sure graphics aren't broken.

Fixes #6228
Fixes #6192
