### PR TITLE
Updater: Making it fancier

### DIFF
--- a/common/ProgressCallback.cpp
+++ b/common/ProgressCallback.cpp
@@ -128,6 +128,7 @@ public:
 	void SetProgressRange(u32 range) override {}
 	void SetProgressValue(u32 value) override {}
 	void IncrementProgressValue() override {}
+	void SetProgressState(ProgressState state) override {}
 
 	void DisplayError(const char* message) override { Console.Error("%s", message); }
 	void DisplayWarning(const char* message) override { Console.Warning("%s", message); }
@@ -147,12 +148,6 @@ static NullProgressCallbacks s_nullProgressCallbacks;
 ProgressCallback* ProgressCallback::NullProgressCallback = &s_nullProgressCallbacks;
 
 BaseProgressCallback::BaseProgressCallback()
-	: m_cancellable(false)
-	, m_cancelled(false)
-	, m_progress_range(1)
-	, m_progress_value(0)
-	, m_base_progress_value(0)
-	, m_saved_state(NULL)
 {
 }
 
@@ -239,10 +234,16 @@ void BaseProgressCallback::SetProgressRange(u32 range)
 
 void BaseProgressCallback::SetProgressValue(u32 value)
 {
+	SetProgressState(ProgressState::Normal);
 	m_progress_value = m_base_progress_value + value;
 }
 
 void BaseProgressCallback::IncrementProgressValue()
 {
 	SetProgressValue((m_progress_value - m_base_progress_value) + 1);
+}
+
+void BaseProgressCallback::SetProgressState(ProgressState state)
+{
+	m_progress_state = state;
 }

--- a/common/ProgressCallback.h
+++ b/common/ProgressCallback.h
@@ -25,6 +25,14 @@
 class ProgressCallback
 {
 public:
+	enum class ProgressState
+	{
+		Normal,
+		Indeterminate,
+		Paused,
+		Error
+	};
+
 	virtual ~ProgressCallback();
 
 	virtual void PushState() = 0;
@@ -40,6 +48,7 @@ public:
 	virtual void SetProgressRange(u32 range) = 0;
 	virtual void SetProgressValue(u32 value) = 0;
 	virtual void IncrementProgressValue() = 0;
+	virtual void SetProgressState(ProgressState state) = 0;
 
 	void SetFormattedStatusText(const char* Format, ...);
 
@@ -81,6 +90,7 @@ public:
 	virtual void SetProgressRange(u32 range) override;
 	virtual void SetProgressValue(u32 value) override;
 	virtual void IncrementProgressValue() override;
+	virtual void SetProgressState(ProgressState state) override;
 
 protected:
 	struct State
@@ -93,13 +103,14 @@ protected:
 		bool cancellable;
 	};
 
-	bool m_cancellable;
-	bool m_cancelled;
+	bool m_cancellable = false;
+	bool m_cancelled = false;
 	std::string m_status_text;
-	u32 m_progress_range;
-	u32 m_progress_value;
+	u32 m_progress_range = 1;
+	u32 m_progress_value = 0;
+	ProgressState m_progress_state = ProgressState::Normal;
 
-	u32 m_base_progress_value;
+	u32 m_base_progress_value = 0;
 
-	State* m_saved_state;
+	State* m_saved_state = nullptr;
 };

--- a/updater/Windows/WindowsUpdater.cpp
+++ b/updater/Windows/WindowsUpdater.cpp
@@ -193,6 +193,7 @@ bool Win32ProgressCallback::Create()
 		wc.hIconSm = LoadIcon(wc.hInstance, MAKEINTRESOURCE(IDI_ICON1));
 		wc.hCursor = LoadCursor(NULL, IDC_WAIT);
 		wc.hbrBackground = (HBRUSH)COLOR_WINDOW;
+		wc.style = CS_NOCLOSE;
 		wc.lpszClassName = CLASS_NAME;
 		if (!RegisterClassExW(&wc))
 		{
@@ -206,7 +207,7 @@ bool Win32ProgressCallback::Create()
 	m_com_initialized = SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED));
 
 	m_window_hwnd =
-		CreateWindowExW(WS_EX_CLIENTEDGE, CLASS_NAME, L"Win32ProgressCallback", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+		CreateWindowExW(WS_EX_CLIENTEDGE, CLASS_NAME, L"Win32ProgressCallback", WS_OVERLAPPEDWINDOW & ~WS_MAXIMIZEBOX, CW_USEDEFAULT,
 			CW_USEDEFAULT, WINDOW_WIDTH, WINDOW_HEIGHT, nullptr, nullptr, wil::GetModuleInstanceHandle(), this);
 	if (!m_window_hwnd)
 	{


### PR DESCRIPTION
**CAUTION: Please review and test this thoroughly, it would suck to break the updater by accident.**

### Description of Changes
This PR gives the Windows updater some love:
* UI has been moved to a thread, so it is properly responsive and long running operations don't make Windows think the window is stuck.
* Taskbar progress bar has been added, indicating update progress on the taskbar icon, much like many modern installers/updaters do.
* Initial indeterminate stages of updating (waiting for `pcsx2.exe` to exit, parsing the ZIP file etc.) now set the progress bar and the taskbar progress bar into a marquee/indeterminate state. This means that a typical _"something is going on, but I can't give you an ETA"_ sliding progress bar is now used in place of a stuck empty bar.
* Maximize and Close buttons have been disabled because they were breaking things and the updater was never adapted for layout changes/aborting.

Indeterminate progress now looks like this:
![image](https://user-images.githubusercontent.com/7947461/170823451-3cef3179-0e9e-4c66-a577-0f887a442617.png)

While PCSX2 could benefit from a taskbar progress bar, it's been removed from Qt6 so it'll likely need a pure WinAPI solution later, much like the one here.

### Rationale behind Changes
1. Because I can.
2. Because with those improvements the updater feels a little more native.

### Suggested Testing Steps
* Nudge the updater a little, verify that it looks and works properly.
* Ensure there are no functional regressions and updating works as expected.

To test the Updater manually:
1. Make a copy of any pcsx2 ZIP from the build bot. The updater will wipe it after a successful update, so make sure you back it up to save yourself some hassle when retesting.
2. Create a temporary directory somewhere, e.g. `pcsx2_tmp` or anything.
3. Launch `updater.exe` manually (e.g. from a batch file or Command Prompt) like: `updater.exe 1 "path\to\pcsx2_tmp" "path\to\pcsx2_update.zip" "path\to\pcsx2_tmp\pcsx2-qtx64-avx2.exe"`.
4. If done correctly, updater will unpack that "fake" update to a temporary directory created earlier and then run this unpacked version.
