### PR TITLE
GS-TC: Preserve scale when resizing target for display.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -664,6 +664,8 @@ void GSTextureCache::ScaleTargetForDisplay(Target* t, const GIFRegTEX0& dispfb, 
 		// Memory allocation failure, do our best to hobble along.
 		return;
 	}
+	// Keep the scale of the original texture.
+	new_texture->SetScale(old_texture->GetScale());
 
 	GL_CACHE("Expanding target for display output, target height %d @ 0x%X, display %d @ 0x%X offset %d needed %d",
 		t->m_texture->GetHeight(), t->m_TEX0.TBP0, real_h, dispfb.TBP0, y_offset, needed_height);


### PR DESCRIPTION
### Description of Changes
Preserve the scale of the texture when resizing for the display. Regression from #6142

### Rationale behind Changes
It was setting the scale to 1, then expanding again, causing it to double the size, making insane texture sizes.

### Suggested Testing Steps
try games in high resolutions (mainly in vulkan) make sure it doesn't flash and freak out
