### PR TITLE
GS: Fix CSR.FIELD for progressive mode

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -73,6 +73,11 @@ static bool IsInterlacedVideoMode()
 	return (gsVideoMode == GS_VideoMode::PAL || gsVideoMode == GS_VideoMode::NTSC || gsVideoMode == GS_VideoMode::DVD_NTSC || gsVideoMode == GS_VideoMode::DVD_PAL || gsVideoMode == GS_VideoMode::HDTV_1080I);
 }
 
+static bool IsProgressiveVideoMode()
+{
+	return (gsVideoMode == GS_VideoMode::VESA || gsVideoMode == GS_VideoMode::SDTV_480P || gsVideoMode == GS_VideoMode::SDTV_576P || gsVideoMode == GS_VideoMode::HDTV_720P || gsVideoMode == GS_VideoMode::HDTV_1080P);
+}
+
 void rcntReset(int index) {
 	counters[index].count = 0;
 	counters[index].sCycleT = cpuRegs.cycle;
@@ -604,7 +609,11 @@ static __fi void VSyncStart(u32 sCycle)
 static __fi void GSVSync()
 {
 	// CSR is swapped and GS vBlank IRQ is triggered roughly 3.5 hblanks after VSync Start
-	CSRreg.SwapField();
+
+	if (IsProgressiveVideoMode())
+		CSRreg.SetField();
+	else
+		CSRreg.SwapField();
 
 	if (!CSRreg.VSINT)
 	{

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -28,10 +28,10 @@ alignas(16) extern u8 g_RealGSMem[Ps2MemSize::GSregs];
 
 enum CSR_FifoState
 {
-    CSR_FIFO_NORMAL = 0,	// Somwhere in between (Neither empty or almost full).
-    CSR_FIFO_EMPTY,			// Empty
-    CSR_FIFO_FULL,			// Almost Full
-    CSR_FIFO_RESERVED		// Reserved / Unused.
+	CSR_FIFO_NORMAL = 0, // Somwhere in between (Neither empty or almost full).
+	CSR_FIFO_EMPTY, // Empty
+	CSR_FIFO_FULL, // Almost Full
+	CSR_FIFO_RESERVED // Reserved / Unused.
 };
 
 // --------------------------------------------------------------------------------------
@@ -51,7 +51,7 @@ union tGS_CSR
 		// Read:
 		//   0 - No SIGNAL pending.
 		//   1 - SIGNAL has been generated.
-		u64 SIGNAL	:1;
+		u64 SIGNAL : 1;
 
 		// Write:
 		//   0 - No action;
@@ -59,7 +59,7 @@ union tGS_CSR
 		// Read:
 		//   0 - No FINISH event pending.
 		//   1 - FINISH event has been generated.
-		u64 FINISH	:1;
+		u64 FINISH : 1;
 
 		// Hsync Interrupt Control
 		// Write:
@@ -68,7 +68,7 @@ union tGS_CSR
 		// Read:
 		//   0 - No Hsync interrupt pending.
 		//   1 - Hsync interrupt has been generated.
-		u64 HSINT	:1;
+		u64 HSINT : 1;
 
 		// Vsync Interrupt Control
 		// Write:
@@ -77,7 +77,7 @@ union tGS_CSR
 		// Read:
 		//   0 - No Vsync interrupt pending.
 		//   1 - Vsync interrupt has been generated.
-		u64 VSINT	:1;
+		u64 VSINT : 1;
 
 		// Rect Area Write Termination Control
 		//   0 - No action;
@@ -85,18 +85,18 @@ union tGS_CSR
 		// Read:
 		//   0 - No RAWrite interrupt pending.
 		//   1 - RAWrite interrupt has been generated.
-		u64 EDWINT	:1;
+		u64 EDWINT : 1;
 
-		u64 _zero1	:1;
-		u64 _zero2	:1;
-		u64 pad1	:1;
+		u64 _zero1 : 1;
+		u64 _zero2 : 1;
+		u64 pad1 : 1;
 
 		// FLUSH  (write-only!)
 		// Write:
 		//   0 - Resume drawing if suspended (?)
 		//   1 - Flush the GS FIFO and suspend drawing
 		// Read: Always returns 0. (?)
-		u64 FLUSH	:1;
+		u64 FLUSH : 1;
 
 		// RESET (write-only!)
 		// Write:
@@ -104,18 +104,18 @@ union tGS_CSR
 		//   1 - GS soft system reset.  Clears FIFOs and resets IMR to all 1's.
 		//       (PCSX2 implementation also clears GIFpaths, though that behavior may differ on real HW).
 		// Read: Always returns 0. (?)
-		u64 RESET	:1;
+		u64 RESET : 1;
 
-		u64 _pad2	:2;
+		u64 _pad2 : 2;
 
 		// (I have no idea what this reg is-- air)
 		// Output value is updated by sampling the VSync. (?)
-		u64 NFIELD	:1;
+		u64 NFIELD : 1;
 
 		// Current Field of Display [page flipping] (read-only?)
 		//  0 - EVEN
 		//  1 - ODD
-		u64 FIELD	:1;
+		u64 FIELD : 1;
 
 		// GS FIFO Status (read-only)
 		//  00 - Somewhere in between
@@ -123,22 +123,22 @@ union tGS_CSR
 		//  10 - Almost Full
 		//  11 - Reserved (unused)
 		// Assign values using the CSR_FifoState enum.
-		u64 FIFO	:2;
+		u64 FIFO : 2;
 
 		// Revision number of the GS (fairly arbitrary)
-		u64 REV		:8;
+		u64 REV : 8;
 
 		// ID of the GS (also fairly arbitrary)
-		u64 ID		:8;
+		u64 ID : 8;
 	};
 
-    u64 _u64;
-    
-    struct  
-    {
-		u32	_u32;			// lower 32 bits (all useful content!)
-		u32	_unused32;		// upper 32 bits (unused -- should probably be 0)
-    };
+	u64 _u64;
+
+	struct
+	{
+		u32 _u32; // lower 32 bits (all useful content!)
+		u32 _unused32; // upper 32 bits (unused -- should probably be 0)
+	};
 
 	void SwapField()
 	{
@@ -150,25 +150,25 @@ union tGS_CSR
 		_u32 |= 0x2000;
 	}
 
-    void Reset()
-    {
-        _u64	= 0;
-        FIFO	= CSR_FIFO_EMPTY;
-        REV		= 0x1B; // GS Revision
-        ID		= 0x55; // GS ID
-    }
+	void Reset()
+	{
+		_u64 = 0;
+		FIFO = CSR_FIFO_EMPTY;
+		REV = 0x1B; // GS Revision
+		ID = 0x55; // GS ID
+	}
 
-    bool HasAnyInterrupts() const { return (SIGNAL || FINISH || HSINT || VSINT || EDWINT); }
+	bool HasAnyInterrupts() const { return (SIGNAL || FINISH || HSINT || VSINT || EDWINT); }
 
 	u32 GetInterruptMask() const
 	{
 		return _u32 & 0x1f;
 	}
 
-    void SetAllInterrupts(bool value=true)
-    {
-        SIGNAL = FINISH = HSINT = VSINT = EDWINT = value;
-    }
+	void SetAllInterrupts(bool value = true)
+	{
+		SIGNAL = FINISH = HSINT = VSINT = EDWINT = value;
+	}
 
 	tGS_CSR(u64 val) { _u64 = val; }
 	tGS_CSR(u32 val) { _u32 = val; }
@@ -180,32 +180,32 @@ union tGS_CSR
 // --------------------------------------------------------------------------------------
 union tGS_IMR
 {
-    struct
-    {
-        u32 _reserved1	: 8;
-        u32 SIGMSK		: 1; // Signal evevnt interrupt mask
-        u32 FINISHMSK	: 1; // Finish event interrupt mask
-        u32 HSMSK		: 1; // HSync interrupt mask
-        u32 VSMSK		: 1; // VSync interrupt mask
-        u32 EDWMSK		: 1; // Rectangle write termination interrupt mask
-        u32 _undefined	: 2; // undefined bits should be set to 1.
-        u32 _reserved2	: 17;
-    };
-    u32 _u32;
+	struct
+	{
+		u32 _reserved1 : 8;
+		u32 SIGMSK : 1; // Signal evevnt interrupt mask
+		u32 FINISHMSK : 1; // Finish event interrupt mask
+		u32 HSMSK : 1; // HSync interrupt mask
+		u32 VSMSK : 1; // VSync interrupt mask
+		u32 EDWMSK : 1; // Rectangle write termination interrupt mask
+		u32 _undefined : 2; // undefined bits should be set to 1.
+		u32 _reserved2 : 17;
+	};
+	u32 _u32;
 
-    void reset()
-    {
-        _u32 = 0;
-        SIGMSK = FINISHMSK = HSMSK = VSMSK = EDWMSK = true;
-        _undefined = 0x3;
-    }
-    void set(u32 value)
-    {
-        _u32 = (value & 0x1f00); // Set only the interrupt mask fields.
-        _undefined = 0x3; // These should always be set.
-    }
+	void reset()
+	{
+		_u32 = 0;
+		SIGMSK = FINISHMSK = HSMSK = VSMSK = EDWMSK = true;
+		_undefined = 0x3;
+	}
+	void set(u32 value)
+	{
+		_u32 = (value & 0x1f00); // Set only the interrupt mask fields.
+		_undefined = 0x3; // These should always be set.
+	}
 
-    bool masked() const { return (SIGMSK || FINISHMSK || HSMSK || VSMSK || EDWMSK); }
+	bool masked() const { return (SIGMSK || FINISHMSK || HSMSK || VSMSK || EDWMSK); }
 };
 
 // --------------------------------------------------------------------------------------
@@ -253,14 +253,14 @@ struct GSRegSIGBLID
 	u32 LBLID;
 };
 
-#define PS2MEM_GS		g_RealGSMem
-#define PS2GS_BASE(mem) (PS2MEM_GS+(mem&0x13ff))
+#define PS2MEM_GS g_RealGSMem
+#define PS2GS_BASE(mem) (PS2MEM_GS + (mem & 0x13ff))
 
-#define CSRreg		((tGS_CSR&)*(PS2MEM_GS+0x1000))
+#define CSRreg ((tGS_CSR&)*(PS2MEM_GS + 0x1000))
 
-#define GSCSRr		((u32&)*(PS2MEM_GS+0x1000))
-#define GSIMR		((tGS_IMR&)*(PS2MEM_GS+0x1010))
-#define GSSIGLBLID	((GSRegSIGBLID&)*(PS2MEM_GS+0x1080))
+#define GSCSRr ((u32&)*(PS2MEM_GS + 0x1000))
+#define GSIMR ((tGS_IMR&)*(PS2MEM_GS + 0x1010))
+#define GSSIGLBLID ((GSRegSIGBLID&)*(PS2MEM_GS + 0x1080))
 
 enum class GS_VideoMode : int
 {
@@ -296,8 +296,8 @@ enum MTGS_RingCommand
 	GS_RINGTYPE_VSYNC,
 	GS_RINGTYPE_FRAMESKIP,
 	GS_RINGTYPE_FREEZE,
-	GS_RINGTYPE_RESET,          // issues a GSreset() command.
-	GS_RINGTYPE_SOFTRESET,      // issues a soft reset for the GIF
+	GS_RINGTYPE_RESET, // issues a GSreset() command.
+	GS_RINGTYPE_SOFTRESET, // issues a soft reset for the GIF
 	GS_RINGTYPE_CRC,
 	GS_RINGTYPE_GSPACKET,
 	GS_RINGTYPE_MTVU_GSPACKET,
@@ -308,15 +308,15 @@ enum MTGS_RingCommand
 
 struct MTGS_FreezeData
 {
-	freezeData*	fdata;
-	s32			retval;		// value returned from the call, valid only after an mtgsWaitGS()
+	freezeData* fdata;
+	s32 retval; // value returned from the call, valid only after an mtgsWaitGS()
 };
 
 struct MTGS_MemoryScreenshotData
 {
 	u32 width = 0;
 	u32 height = 0;
-	std::vector<u32> pixels;		// width * height
+	std::vector<u32> pixels; // width * height
 	bool success = false;
 };
 
@@ -330,14 +330,14 @@ public:
 
 	// note: when m_ReadPos == m_WritePos, the fifo is empty
 	// Threading info: m_ReadPos is updated by the MTGS thread. m_WritePos is updated by the EE thread
-	std::atomic<unsigned int> m_ReadPos;  // cur pos gs is reading from
+	std::atomic<unsigned int> m_ReadPos; // cur pos gs is reading from
 	std::atomic<unsigned int> m_WritePos; // cur pos ee thread is writing to
 
-	std::atomic<bool>	m_SignalRingEnable;
-	std::atomic<int>	m_SignalRingPosition;
+	std::atomic<bool> m_SignalRingEnable;
+	std::atomic<int> m_SignalRingPosition;
 
-	std::atomic<int>	m_QueuedFrameCount;
-	std::atomic<bool>	m_VsyncSignalListener;
+	std::atomic<int> m_QueuedFrameCount;
+	std::atomic<bool> m_VsyncSignalListener;
 
 	std::mutex m_mtx_RingBufferBusy2; // Gets released on semaXGkick waiting...
 	std::mutex m_mtx_WaitGS;
@@ -351,14 +351,14 @@ public:
 
 	// Used to delay the sending of events.  Performance is better if the ringbuffer
 	// has more than one command in it when the thread is kicked.
-	int				m_CopyDataTally;
+	int m_CopyDataTally;
 
 	// These vars maintain instance data for sending Data Packets.
 	// Only one data packet can be constructed and uploaded at a time.
 
-	uint			m_packet_startpos;	// size of the packet (data only, ie. not including the 16 byte command!)
-	uint			m_packet_size;		// size of the packet (data only, ie. not including the 16 byte command!)
-	uint			m_packet_writepos;	// index of the data location in the ringbuffer.
+	uint m_packet_startpos; // size of the packet (data only, ie. not including the 16 byte command!)
+	uint m_packet_size; // size of the packet (data only, ie. not including the 16 byte command!)
+	uint m_packet_writepos; // index of the data location in the ringbuffer.
 
 #ifdef RINGBUF_DEBUG_STACK
 	std::mutex m_lock_Stack;
@@ -387,17 +387,17 @@ public:
 	void WaitGS(bool syncRegs=true, bool weakWait=false, bool isMTVU=false);
 	void ResetGS(bool hardware_reset);
 
-	void PrepDataPacket( MTGS_RingCommand cmd, u32 size );
-	void PrepDataPacket( GIF_PATH pathidx, u32 size );
+	void PrepDataPacket(MTGS_RingCommand cmd, u32 size);
+	void PrepDataPacket(GIF_PATH pathidx, u32 size);
 	void SendDataPacket();
-	void SendGameCRC( u32 crc );
+	void SendGameCRC(u32 crc);
 	bool WaitForOpen();
 	void WaitForClose();
-	void Freeze( FreezeAction mode, MTGS_FreezeData& data );
+	void Freeze(FreezeAction mode, MTGS_FreezeData& data);
 
-	void SendSimpleGSPacket( MTGS_RingCommand type, u32 offset, u32 size, GIF_PATH path );
-	void SendSimplePacket( MTGS_RingCommand type, int data0, int data1, int data2 );
-	void SendPointerPacket( MTGS_RingCommand type, u32 data0, void* data1 );
+	void SendSimpleGSPacket(MTGS_RingCommand type, u32 offset, u32 size, GIF_PATH path);
+	void SendSimplePacket(MTGS_RingCommand type, int data0, int data1, int data2);
+	void SendPointerPacket(MTGS_RingCommand type, u32 data0, void* data1);
 
 	u8* GetDataPacketPtr() const;
 	void SetEvent();
@@ -421,7 +421,7 @@ protected:
 	void ThreadEntryPoint();
 	void MainLoop();
 
-	void GenericStall( uint size );
+	void GenericStall(uint size);
 
 	// Used internally by SendSimplePacket type functions
 	void _FinishSimplePacket();
@@ -454,18 +454,18 @@ extern void gsWrite8(u32 mem, u8 value);
 extern void gsWrite16(u32 mem, u16 value);
 extern void gsWrite32(u32 mem, u32 value);
 
-extern void gsWrite64_page_00( u32 mem, const mem64_t* value );
-extern void gsWrite64_page_01( u32 mem, const mem64_t* value );
-extern void gsWrite64_generic( u32 mem, const mem64_t* value );
+extern void gsWrite64_page_00(u32 mem, const mem64_t* value);
+extern void gsWrite64_page_01(u32 mem, const mem64_t* value);
+extern void gsWrite64_generic(u32 mem, const mem64_t* value);
 
-extern void gsWrite128_page_00( u32 mem, const mem128_t* value );
-extern void gsWrite128_page_01( u32 mem, const mem128_t* value );
-extern void gsWrite128_generic( u32 mem, const mem128_t* value );
+extern void gsWrite128_page_00(u32 mem, const mem128_t* value);
+extern void gsWrite128_page_01(u32 mem, const mem128_t* value);
+extern void gsWrite128_generic(u32 mem, const mem128_t* value);
 
-extern u8   gsRead8(u32 mem);
-extern u16  gsRead16(u32 mem);
-extern u32  gsRead32(u32 mem);
-extern u64  gsRead64(u32 mem);
+extern u8 gsRead8(u32 mem);
+extern u16 gsRead16(u32 mem);
+extern u32 gsRead32(u32 mem);
+extern u64 gsRead64(u32 mem);
 extern u128 gsNonMirroredRead(u32 mem);
 
 void gsIrq();
@@ -479,7 +479,7 @@ extern tGS_CSR CSRr;
 static const uint RingBufferSizeFactor = 19;
 
 // size of the ringbuffer in simd128's.
-static const uint RingBufferSize = 1<<RingBufferSizeFactor;
+static const uint RingBufferSize = 1 << RingBufferSizeFactor;
 
 // Mask to apply to ring buffer indices to wrap the pointer from end to
 // start (the wrapping is what makes it a ringbuffer, yo!)
@@ -487,14 +487,14 @@ static const uint RingBufferMask = RingBufferSize - 1;
 
 struct MTGS_BufferedData
 {
-	u128		m_Ring[RingBufferSize];
-	u8			Regs[Ps2MemSize::GSregs];
+	u128 m_Ring[RingBufferSize];
+	u8 Regs[Ps2MemSize::GSregs];
 
 	MTGS_BufferedData() {}
 
-	u128& operator[]( uint idx )
+	u128& operator[](uint idx)
 	{
-		pxAssert( idx < RingBufferSize );
+		pxAssert(idx < RingBufferSize);
 		return m_Ring[idx];
 	}
 };
@@ -503,30 +503,36 @@ alignas(32) extern MTGS_BufferedData RingBuffer;
 
 // FIXME: These belong in common with other memcpy tools.  Will move them there later if no one
 // else beats me to it.  --air
-inline void MemCopy_WrappedDest( const u128* src, u128* destBase, uint& destStart, uint destSize, uint len ) {
+inline void MemCopy_WrappedDest(const u128* src, u128* destBase, uint& destStart, uint destSize, uint len)
+{
 	uint endpos = destStart + len;
-	if ( endpos < destSize ) {
-		memcpy(&destBase[destStart], src, len*16);
+	if (endpos < destSize)
+	{
+		memcpy(&destBase[destStart], src, len * 16);
 		destStart += len;
 	}
-	else {
+	else
+	{
 		uint firstcopylen = destSize - destStart;
-		memcpy(&destBase[destStart], src, firstcopylen*16);
+		memcpy(&destBase[destStart], src, firstcopylen * 16);
 		destStart = endpos % destSize;
-		memcpy(destBase, src+firstcopylen, destStart*16);
+		memcpy(destBase, src + firstcopylen, destStart * 16);
 	}
 }
 
-inline void MemCopy_WrappedSrc( const u128* srcBase, uint& srcStart, uint srcSize, u128* dest, uint len ) {
+inline void MemCopy_WrappedSrc(const u128* srcBase, uint& srcStart, uint srcSize, u128* dest, uint len)
+{
 	uint endpos = srcStart + len;
-	if ( endpos < srcSize ) {
-		memcpy(dest, &srcBase[srcStart], len*16);
+	if (endpos < srcSize)
+	{
+		memcpy(dest, &srcBase[srcStart], len * 16);
 		srcStart += len;
 	}
-	else {
+	else
+	{
 		uint firstcopylen = srcSize - srcStart;
-		memcpy(dest, &srcBase[srcStart], firstcopylen*16);
+		memcpy(dest, &srcBase[srcStart], firstcopylen * 16);
 		srcStart = endpos % srcSize;
-		memcpy(dest+firstcopylen, srcBase, srcStart*16);
+		memcpy(dest + firstcopylen, srcBase, srcStart * 16);
 	}
 }

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -145,6 +145,11 @@ union tGS_CSR
 		_u32 ^= 0x2000;
 	}
 
+	void SetField()
+	{
+		_u32 |= 0x2000;
+	}
+
     void Reset()
     {
         _u64	= 0;


### PR DESCRIPTION
### Description of Changes
Fixes the CSR.FIELD bit to set when in 480 progressive mode (and others)

### Rationale behind Changes
Not fixing this causes games to shake in progressive mode. @F0bes tested this on the real hardware and it is fixed set when in 480p mode.

### Suggested Testing Steps
Test games in progressive, make sure they don't shake.

Fixes #1413