### PR TITLE
GameDB: Add Auto Flush for 24 - The Game

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3473,6 +3473,8 @@ SCES-53358:
   region: "PAL-M9"
   clampModes:
     vuClampMode: 2 # Fixes minimap HUD.
+  gsHWFixes:
+    autoFlush: 1 # Fixes pause menu backgrounds.
 SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "PAL-M5"
@@ -22640,6 +22642,8 @@ SLPM-62132:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 2 # Fixes minimap HUD.
+  gsHWFixes:
+    autoFlush: 1 # Fixes pause menu backgrounds.
 SLPM-62133:
   name: "Bloody Roar 3 [Konami The Best]"
   region: "NTSC-J"
@@ -42114,6 +42118,8 @@ SLUS-21268:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes minimap HUD.
+  gsHWFixes:
+    autoFlush: 1 # Fixes pause menu backgrounds.
 SLUS-21269:
   name: "Bully"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
GS fix for 24 - The Game.

Auto Flush disabled:
![image](https://user-images.githubusercontent.com/7947461/170866999-4bef97be-dc29-4265-8b1b-9d7d23eb069d.png)

Auto Flush enabled:
![image](https://user-images.githubusercontent.com/7947461/170867010-4ab0ae7b-53f3-435d-b923-9971bf5dce36.png)

Software Mode:
![image](https://user-images.githubusercontent.com/7947461/170867018-263344d2-0812-4c59-a411-4c989793eeaa.png)

### Rationale behind Changes
-

### Suggested Testing Steps
Try 24 - The Game and pause the game.
