### PR TITLE
FileSystem: Fix splitting UNC paths

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -445,6 +445,11 @@ std::vector<std::string_view> Path::SplitWindowsPath(const std::string_view& pat
 
 	std::string::size_type start = 0;
 	std::string::size_type pos = 0;
+
+	// preserve unc paths
+	if (path.size() > 2 && path[0] == '\\' && path[1] == '\\')
+		pos = 2;
+
 	while (pos < path.size())
 	{
 		if (path[pos] != '/' && path[pos] != '\\')

--- a/pcsx2-qt/Main.cpp
+++ b/pcsx2-qt/Main.cpp
@@ -54,6 +54,7 @@ static void PrintCommandLineHelp(const char* progname)
 	std::fprintf(stderr, "  -statefile <filename>: Loads state from the specified filename.\n");
 	std::fprintf(stderr, "  -fullscreen: Enters fullscreen mode immediately after starting.\n");
 	std::fprintf(stderr, "  -nofullscreen: Prevents fullscreen mode from triggering if enabled.\n");
+	std::fprintf(stderr, "  -earlyconsolelog: Forces logging of early console messages to console.\n");
 	std::fprintf(stderr, "  --: Signals that no more arguments will follow and the remaining\n"
 						 "    parameters make up the filename. Use when the filename contains\n"
 						 "    spaces or starts with a dash.\n");
@@ -138,6 +139,11 @@ static bool ParseCommandLineOptions(int argc, char* argv[], std::shared_ptr<VMBo
 			else if (CHECK_ARG("-nofullscreen"))
 			{
 				AutoBoot(autoboot)->fullscreen = false;
+				continue;
+			}
+			else if (CHECK_ARG("-earlyconsolelog"))
+			{
+				QtHost::InitializeEarlyConsole();
 				continue;
 			}
 			else if (CHECK_ARG("--"))

--- a/tests/ctest/common/path_tests.cpp
+++ b/tests/ctest/common/path_tests.cpp
@@ -30,6 +30,7 @@ TEST(FileSystem, ToNativePath)
 	ASSERT_EQ(Path::ToNativePath("foo\\bar/baz"), "foo\\bar\\baz");
 	ASSERT_EQ(Path::ToNativePath("foo/bar/baz"), "foo\\bar\\baz");
 	ASSERT_EQ(Path::ToNativePath("foo/🙃bar/b🙃az"), "foo\\🙃bar\\b🙃az");
+	ASSERT_EQ(Path::ToNativePath("\\\\foo\\bar\\baz"), "\\\\foo\\bar\\baz");
 #else
 	ASSERT_EQ(Path::ToNativePath("foo"), "foo");
 	ASSERT_EQ(Path::ToNativePath("foo/"), "foo");
@@ -50,6 +51,7 @@ TEST(FileSystem, IsAbsolute)
 	ASSERT_TRUE(Path::IsAbsolute("C:\\foo/bar"));
 	ASSERT_TRUE(Path::IsAbsolute("C://foo\\bar"));
 	ASSERT_FALSE(Path::IsAbsolute("\\foo/bar"));
+	ASSERT_TRUE(Path::IsAbsolute("\\\\foo\\bar\\baz"));
 #else
 	ASSERT_TRUE(Path::IsAbsolute("/foo/bar"));
 #endif
@@ -72,6 +74,7 @@ TEST(FileSystem, Canonicalize)
 	ASSERT_EQ(Path::Canonicalize("C:/foo\\bar\\..\\baz\\.\\foo"), "C:\\foo\\baz\\foo");
 	ASSERT_EQ(Path::Canonicalize("foo\\bar\\..\\baz\\.\\foo"), "foo\\baz\\foo");
 	ASSERT_EQ(Path::Canonicalize("foo\\bar/..\\baz/.\\foo"), "foo\\baz\\foo");
+	ASSERT_EQ(Path::Canonicalize("\\\\foo\\bar\\baz/..\\foo"), "\\\\foo\\bar\\foo");
 #else
 	ASSERT_EQ(Path::Canonicalize("/foo/bar/../baz/./foo"), "/foo/baz/foo");
 #endif
@@ -92,6 +95,7 @@ TEST(FileSystem, Combine)
 	ASSERT_EQ(Path::Combine("foo\\bar", "baz"), "foo\\bar\\baz");
 	ASSERT_EQ(Path::Combine("foo\\bar\\", "baz"), "foo\\bar\\baz");
 	ASSERT_EQ(Path::Combine("foo/bar\\", "\\baz"), "foo\\bar\\baz");
+	ASSERT_EQ(Path::Combine("\\\\foo\\bar", "baz"), "\\\\foo\\bar\\baz");
 #else
 	ASSERT_EQ(Path::Combine("/foo/bar", "baz"), "/foo/bar/baz");
 #endif
@@ -132,6 +136,12 @@ TEST(FileSystem, MakeRelative)
 	ASSERT_EQ(Path::MakeRelative(A "ŻąłóРстуぬねのはen🍪⟑η∏☉ⴤℹ︎∩₲ ₱⟑♰⫳🐱/b🙃ar", A "ŻąłóРстуぬねのはen🍪⟑η∏☉ⴤℹ︎∩₲ ₱⟑♰⫳🐱/b🙃az"), Path::ToNativePath("../b🙃ar"));
 
 #undef A
+
+#ifdef _WIN32
+	ASSERT_EQ(Path::MakeRelative("\\\\foo\\bar\\baz\\foo", "\\\\foo\\bar\\baz"), "foo");
+	ASSERT_EQ(Path::MakeRelative("\\\\foo\\bar\\foo", "\\\\foo\\bar\\baz"), "..\\foo");
+	ASSERT_EQ(Path::MakeRelative("\\\\foo\\bar\\foo", "\\\\other\\bar\\foo"), "\\\\foo\\bar\\foo");
+#endif
 }
 
 TEST(FileSystem, GetExtension)
@@ -201,6 +211,7 @@ TEST(FileSystem, ChangeFileName)
 #ifdef _WIN32
 	ASSERT_EQ(Path::ChangeFileName("foo/bar", "baz"), "foo\\baz");
 	ASSERT_EQ(Path::ChangeFileName("foo//bar\\foo", "baz"), "foo\\bar\\baz");
+	ASSERT_EQ(Path::ChangeFileName("\\\\foo\\bar\\foo", "baz"), "\\\\foo\\bar\\baz");
 #else
 	ASSERT_EQ(Path::ChangeFileName("/foo/bar", "baz"), "/foo/baz");
 #endif


### PR DESCRIPTION
### Description of Changes

Also adds a bit of logging to better diagnose this stuff in the future.

### Rationale behind Changes

Fixes #6258.

### Suggested Testing Steps

Test running emu from UNC paths (I've checked both running the emu off a share, as well as running games off a share).
