### PR TITLE
GameDB: Add SkipDraw Range to 'Tales of the Abyss'

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1081,6 +1081,8 @@ SCAJ-20163:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 355 # Fixes grid effect.
+    skipDrawEnd: 359 # Fixes grid effect.
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
@@ -30723,6 +30725,8 @@ SLPM-66897:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 355 # Fixes grid effect.
+    skipDrawEnd: 359 # Fixes grid effect.
 SLPM-66898:
   name: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
@@ -34663,6 +34667,8 @@ SLPS-25586:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 355 # Fixes grid effect.
+    skipDrawEnd: 359 # Fixes grid effect.
 SLPS-25587:
   name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
@@ -36359,6 +36365,8 @@ SLPS-73252:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 355 # Fixes grid effect.
+    skipDrawEnd: 359 # Fixes grid effect.
 SLPS-73253:
   name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -42766,6 +42774,8 @@ SLUS-21386:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    skipDrawStart: 355 # Fixes grid effect.
+    skipDrawEnd: 359 # Fixes grid effect.
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds the SkipDraw range 355, 359 that fixes the grid effect present in the Title Screen, Engave, Kaitzur Naval Port, Baticul Castle, Keterburg Port and possibly other instances within 'Tales of the Abyss'

### Rationale behind Changes
A recent commit that corrected an issue within Engave eliminated the need for the extreme SkipDraw range (100, 361) called for on the Wiki, but it also broke HPO on the Title Screen resulting in the return of the grid effect it originally corrected. 
This drove me to find a more reasonable range (355, 359) that fixes the same issues, but doesn't come with the flickering, darkening and texture stripping issues that the old range created. It also seems to correct some minor ghosting in the instances that the grid effect would be present in. It does still introduce a visual glitch into the Desert Oasis, but I feel it's an acceptable compromise for what the range corrects - at least until a future commit removes the need for SkipDraw entirely

Before:
![Title Screen 01](https://user-images.githubusercontent.com/983358/170876774-3bb2f688-05ce-48ae-af76-9917b0e4a9be.jpg)
![Baticul Castle 01](https://user-images.githubusercontent.com/983358/170877005-34c221e7-1c3b-4b4c-92aa-e8669ee794f2.jpg)
![Keterburg Bay 01](https://user-images.githubusercontent.com/983358/170877056-45e97377-5b42-4f2d-9975-6ce4acd12952.jpg)

After:
![Title Screen 02](https://user-images.githubusercontent.com/983358/170876778-536e0928-56a4-4e3e-abed-3d881cd4de8d.jpg)
![Baticul Castle 02](https://user-images.githubusercontent.com/983358/170877007-e32c9226-b4a5-4649-a36b-812764a67c54.jpg)
![Keterburg Bay 02](https://user-images.githubusercontent.com/983358/170877055-d31bdc17-78fc-4563-b3ae-7dd3c02d6163.jpg)

Visual bug introduced into Desert Oasis:
![Desert Oasis](https://user-images.githubusercontent.com/983358/170877164-a9a9f97c-6bc8-4bc5-a79e-1d538c7ce762.jpg)

### Suggested Testing Steps
Test the game to see if all possible instances of the grid effect has been corrected