### PR TITLE
IPU: Implement start code validation for BDEC/IDEC

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15847,8 +15847,6 @@ SLES-53541:
   region: "PAL-M4"
   clampModes:
     vuClampMode: 3 # Fix black textures on characters.
-  gameFixes:
-    - SkipMPEGHack # Fixes hang after EA intro (IPU).
 SLES-53542:
   name: "Shadow the Hedgehog"
   region: "PAL-M5"
@@ -18979,8 +18977,6 @@ SLES-54867:
   region: "PAL-E-F"
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gameFixes:
-    - SkipMPEGHack # Fixes hang after EA intro.
 SLES-54870:
   name: "FIFA '08"
   region: "PAL-E"
@@ -20825,25 +20821,6 @@ SLES-82038:
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
-  patches:
-    812C5A96:
-      content: |-
-        comment=patched by Kozarrov and ported by Prafull
-        //Improve menus, and other 2D displays handled on IPU
-        // Set IPU_DATA IVF to Intra
-        patch=1,EE,003c3678,word,3C040020
-        // Set IPU_CMD to IDEC, and set QSC to 2
-        // Why 2? Because it seems to work best.
-        patch=1,EE,003c368c,word,3C021002
-        // Old patch by shadow lady (still needed)
-        patch=1,EE,00104170,word,00000000
-        // Disable print - we need that loop!
-        // Without loop ipu break itself.
-        patch=1,EE,0010FDC8,word,34190180
-        patch=1,EE,0010FDCC,word,1720FFFF
-        patch=1,EE,0010FDD0,word,2739FFFF
-        patch=1,EE,0010FDD4,word,03E00008
-        patch=1,EE,0010FDD8,word,00000000
 SLES-82039:
   name: "Onimusha - Dawn of Dreams [Disc2of2]"
   region: "PAL-M5"
@@ -20852,25 +20829,6 @@ SLES-82039:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
   memcardFilters:
     - "SLES-82038"
-  patches:
-    812C5A96:
-      content: |-
-        comment=patched by Kozarrov and ported by Prafull
-        //Improve menus, and other 2D displays handled on IPU
-        // Set IPU_DATA IVF to Intra
-        patch=1,EE,003c3678,word,3C040020
-        // Set IPU_CMD to IDEC, and set QSC to 2
-        // Why 2? Because it seems to work best.
-        patch=1,EE,003c368c,word,3C021002
-        // Old patch by shadow lady (still needed)
-        patch=1,EE,00104170,word,00000000
-        // Disable print - we need that loop!
-        // Without loop ipu break itself.
-        patch=1,EE,0010FDC8,word,34190180
-        patch=1,EE,0010FDCC,word,1720FFFF
-        patch=1,EE,0010FDD0,word,2739FFFF
-        patch=1,EE,0010FDD4,word,03E00008
-        patch=1,EE,0010FDD8,word,00000000
 SLES-82042:
   name: "Metal Gear Solid 3 - Subsistence [Disc1of3]"
   region: "PAL-E-F"
@@ -26252,12 +26210,6 @@ SLPM-65583:
   compat: 4
   gameFixes:
     - XGKickHack
-  patches:
-    C4467D30:
-      content: |-
-        comment=Patch by Nachbrenner
-        // Skip sceIpuSync.
-        patch=1,EE,0027c808,word,03e00008
 SLPM-65585:
   name: "Princess Holiday"
   region: "NTSC-J"
@@ -28269,8 +28221,6 @@ SLPM-66191:
   region: "NTSC-J"
   clampModes:
     vuClampMode: 3 # Fixes black textures on characters.
-  gameFixes:
-    - SkipMPEGHack # Fixes hang after EA intro (IPU).
 SLPM-66192:
   name: "Izumo 2"
   region: "NTSC-J"
@@ -41624,24 +41574,6 @@ SLUS-21180:
   compat: 5
   gameFixes:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
-  patches:
-    FE44479E:
-      content: |-
-        author=kozarovv
-        // Set IPU_DATA IVF to Intra
-        patch=1,EE,003BFDD8,word,3C040020
-        // Set IPU_CMD to IDEC, and set QSC to 2
-        // Why 2? Because it seems to work best.
-        patch=1,EE,003BFDEC,word,3C021002
-        // Old patch by shadow lady (still needed)
-        patch=1,EE,00104170,word,00000000
-        // Disable print - we need that loop!
-        // Without loop ipu break itself.
-        patch=1,EE,0010FDC8,word,34190180
-        patch=1,EE,0010FDCC,word,1720FFFF
-        patch=1,EE,0010FDD0,word,2739FFFF
-        patch=1,EE,0010FDD4,word,03E00008
-        patch=1,EE,0010FDD8,word,00000000
 SLUS-21181:
   name: "D.I.C.E. - DNA Integrated Cybernetic Enterprises"
   region: "NTSC-U"
@@ -42088,8 +42020,6 @@ SLUS-21264:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fix black textures on characters.
-  gameFixes:
-    - SkipMPEGHack # Fixes hang after EA intro (IPU).
 SLUS-21265:
   name: "Sims 2, The"
   region: "NTSC-U"
@@ -43888,8 +43818,6 @@ SLUS-21646:
   compat: 5
   clampModes:
     vuClampMode: 2 # Fix black textures on characters.
-  gameFixes:
-    - SkipMPEGHack # Fixes hang after EA intro.
 SLUS-21647:
   name: "NHL '08"
   region: "NTSC-U"

--- a/pcsx2/IPU/mpeg2lib/Mpeg.cpp
+++ b/pcsx2/IPU/mpeg2lib/Mpeg.cpp
@@ -920,6 +920,7 @@ finish_idec:
 	case 3:
 	{
 		u8 bit8;
+		u32 start_check;
 		if (!getBits8((u8*)&bit8, 0))
 		{
 			ipu_cmd.pos[0] = 3;
@@ -929,7 +930,21 @@ finish_idec:
 		if (bit8 == 0)
 		{
 			g_BP.Align();
-			ipuRegs.ctrl.SCD = 1;
+			do
+			{
+				if (!g_BP.FillBuffer(24)) 
+				{
+					ipu_cmd.pos[0] = 3;
+					return false;
+				}
+				start_check = UBITS(24);
+				if (start_check == 1)
+				{
+					ipuRegs.ctrl.SCD = 1;
+					break;
+				}
+				DUMPBITS(8);
+			} while (start_check != 1);
 		}
 	}
 		[[fallthrough]];
@@ -1196,6 +1211,7 @@ __fi bool mpeg2_slice()
 	case 4:
 	{
 		u8 bit8;
+		u32 start_check;
 		if (!getBits8((u8*)&bit8, 0))
 		{
 			ipu_cmd.pos[0] = 4;
@@ -1205,7 +1221,21 @@ __fi bool mpeg2_slice()
 		if (bit8 == 0)
 		{
 			g_BP.Align();
-			ipuRegs.ctrl.SCD = 1;
+			do
+			{
+				if (!g_BP.FillBuffer(24)) 
+				{
+					ipu_cmd.pos[0] = 4;
+					return false;
+				}
+				start_check = UBITS(24);
+				if (start_check == 1)
+				{
+					ipuRegs.ctrl.SCD = 1;
+					break;
+				}
+				DUMPBITS(8);
+			} while (start_check != 1);
 		}
 	}
 		[[fallthrough]];


### PR DESCRIPTION
### Description of Changes
According to MPEG 1/2 specs when 8 "0" bits are found, we should check for 000001xxh. Recommended way is to discard bits until stream is aligned. Then check 24 bits for 000001h, and if they won't match discard 8 bits and try again until valid code is found, or stream ends.

### Rationale behind Changes
Fixes #1141
Also helps Tiger Woods 06/08 from https://github.com/PCSX2/pcsx2/issues/2132
WRC3 patch removed as a bonus, game work also on master.

### Suggested Testing Steps
Test that other games aren't broken while playing movies. Test that movies aren't corrupted, don't skip, etc.
I tested many random games i own this time, and all of then worked. I wasn't able to test "billboards" in Test Drive game, and i suspect that PR can help it. Games which still have IPU entries in GameDB are still broken, no need to test them really. 


Thx to @raul3d for pointing out Play! commit which fixed Onimusha, that helped a lot.
This implementation is little bit different from what Play! do, I extended code search to BDEC (more precisely to mpeg2_slice). We also don't accept code if there is no data after first 8 bits after alignment. This break many games in non intra mode. But if we return false instead, and wait for data, everything seems to work ok. This was needed for Tiger Woods PGA games. 
