### PR TITLE
Fix blockdump loading on Mac and Linux

### DIFF
--- a/pcsx2/CDVD/BlockdumpFileReader.cpp
+++ b/pcsx2/CDVD/BlockdumpFileReader.cpp
@@ -36,8 +36,8 @@ bool BlockdumpFileReader::DetectBlockdump(AsyncFileReader* reader)
 	reader->SetBlockSize(1);
 
 	char buf[4] = {0};
-	bool isbd = (reader->ReadSync(buf, 0, sizeof(buf)) == 4 &&
-				 std::memcmp(buf, "BDV2", sizeof(buf)) == 0);
+	bool isbd = (reader->ReadSync(buf, 0, sizeof(buf)) == 4
+	          && std::memcmp(buf, "BDV2", sizeof(buf)) == 0);
 
 	if (!isbd)
 		reader->SetBlockSize(oldbs);
@@ -71,9 +71,9 @@ bool BlockdumpFileReader::Open(std::string fileName)
 	}
 
 	//m_flags = ISOFLAGS_BLOCKDUMP_V2;
-	if (std::fread(&m_blocksize, sizeof(m_blocksize), 1, m_file) != 1 ||
-		std::fread(&m_blocks, sizeof(m_blocks), 1, m_file) != 1 ||
-		std::fread(&m_blockofs, sizeof(m_blockofs), 1, m_file) != 1)
+	if (std::fread(&m_blocksize, sizeof(m_blocksize), 1, m_file) != 1
+	 || std::fread(&m_blocks,    sizeof(m_blocks),    1, m_file) != 1
+	 || std::fread(&m_blockofs,  sizeof(m_blockofs),  1, m_file) != 1)
 	{
 		return false;
 	}

--- a/pcsx2/Darwin/DarwinFlatFileReader.cpp
+++ b/pcsx2/Darwin/DarwinFlatFileReader.cpp
@@ -108,7 +108,7 @@ int FlatFileReader::FinishRead(void)
 
 	while (aio_suspend(aiocb_list, 1, nullptr) == -1 && errno == EINTR)
 		;
-	return aio_return(&m_aiocb) == -1 ? -1 : 1;
+	return aio_return(&m_aiocb);
 }
 
 void FlatFileReader::CancelRead(void)

--- a/pcsx2/Linux/LnxFlatFileReader.cpp
+++ b/pcsx2/Linux/LnxFlatFileReader.cpp
@@ -69,15 +69,13 @@ void FlatFileReader::BeginRead(void* pBuffer, uint sector, uint count)
 
 int FlatFileReader::FinishRead(void)
 {
-	int min_nr = 1;
-	int max_nr = 1;
-	struct io_event events[max_nr];
+	struct io_event event;
 
-	int event = io_getevents(m_aio_context, min_nr, max_nr, events, NULL);
-	if (event < 1)
+	int nevents = io_getevents(m_aio_context, 1, 1, &event, NULL);
+	if (nevents < 1)
 		return -1;
 
-	return 1;
+	return event.res;
 }
 
 void FlatFileReader::CancelRead(void)


### PR DESCRIPTION
### Description of Changes
New blockdump code relies on the return value of FlatFileReader being the number of bytes read and not just -1 or 1

### Rationale behind Changes
It's nice to be able to load block dumps

### Suggested Testing Steps
Linux testing.  The old code was definitely wrong, but aio docs weren't clear enough for me to be sure that the new code is right.  Untested.
