### PR TITLE
wx: Fix assert on settings panel

### DIFF
--- a/pcsx2/gui/Panels/VideoPanel.cpp
+++ b/pcsx2/gui/Panels/VideoPanel.cpp
@@ -322,7 +322,7 @@ Panels::VideoPanel::VideoPanel( wxWindow* parent ) :
 	*left		+= m_fpan		| pxExpand;
 	*left		+= 5;
 	
-	*s_vsyncs	+= Label(_("Vsyncs in MTGS Queue:")) | StdExpand();
+	*s_vsyncs	+= left->Label(_("Vsyncs in MTGS Queue:")) | StdExpand();
 	*s_vsyncs	+= m_spinner_VsyncQueue | pxBorder(wxTOP, -2).Right();
 	*left		+= s_vsyncs | StdExpand();
 #ifdef  PCSX2_DEVBUILD 


### PR DESCRIPTION
### Description of Changes
Fix an assert in debug builds in the settings panel when run on newer wx

### Rationale behind Changes
Assert bad

### Suggested Testing Steps
Open settings panel with wx 3.1.6
