### PR TITLE
pad: Expose Analog Mode button.

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget_DualShock2.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_DualShock2.ui
@@ -397,86 +397,6 @@
     <layout class="QVBoxLayout" name="verticalLayout_3">
      <item>
       <layout class="QGridLayout" name="gridLayout_27">
-       <item row="0" column="0" rowspan="2">
-        <widget class="QGroupBox" name="groupBox_21">
-         <property name="title">
-          <string>L2</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_21">
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="InputBindingWidget" name="L2">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>PushButton</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="3" rowspan="2">
-        <widget class="QGroupBox" name="groupBox_24">
-         <property name="title">
-          <string>R1</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_24">
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="InputBindingWidget" name="R1">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>PushButton</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="2" column="0" rowspan="2">
         <widget class="QGroupBox" name="groupBox_22">
          <property name="title">
@@ -497,12 +417,142 @@
           </property>
           <item row="0" column="0">
            <widget class="InputBindingWidget" name="L1">
-            <property name="minimumSize">
+            <property name="maximumSize">
              <size>
               <width>100</width>
-              <height>0</height>
+              <height>16777215</height>
              </size>
             </property>
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="0" rowspan="2">
+        <widget class="QGroupBox" name="groupBox_21">
+         <property name="title">
+          <string>L2</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_21">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="InputBindingWidget" name="L2">
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="5" rowspan="2">
+        <widget class="QGroupBox" name="groupBox_24">
+         <property name="title">
+          <string>R1</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_24">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="InputBindingWidget" name="R1">
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="5" rowspan="2">
+        <widget class="QGroupBox" name="groupBox_23">
+         <property name="title">
+          <string>R2</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_23">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="InputBindingWidget" name="R2">
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QGroupBox" name="groupBox_26">
+         <property name="title">
+          <string>Start</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_26">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="InputBindingWidget" name="Start">
             <property name="maximumSize">
              <size>
               <width>100</width>
@@ -537,12 +587,6 @@
           </property>
           <item row="0" column="0">
            <widget class="InputBindingWidget" name="Select">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
             <property name="maximumSize">
              <size>
               <width>100</width>
@@ -557,32 +601,14 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="3" rowspan="2">
-        <widget class="QGroupBox" name="groupBox_23">
+       <item row="0" column="2" colspan="2">
+        <widget class="QGroupBox" name="groupBox_31">
          <property name="title">
-          <string>R2</string>
+          <string>Analog</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_23">
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
+         <layout class="QGridLayout" name="gridLayout_33">
           <item row="0" column="0">
-           <widget class="InputBindingWidget" name="R2">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
+           <widget class="InputBindingWidget" name="Analog">
             <property name="maximumSize">
              <size>
               <width>100</width>
@@ -597,47 +623,7 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QGroupBox" name="groupBox_26">
-         <property name="title">
-          <string>Start</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_26">
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="InputBindingWidget" name="Start">
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>PushButton</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="1" rowspan="2" colspan="2">
+       <item row="2" column="1" rowspan="2" colspan="4">
         <widget class="QGroupBox" name="groupBox_30">
          <property name="title">
           <string>Axis Scale</string>

--- a/pcsx2/PAD/Host/Global.h
+++ b/pcsx2/PAD/Host/Global.h
@@ -28,7 +28,7 @@
 #include "common/Pcsx2Defs.h"
 
 static const u32 GAMEPAD_NUMBER = 2;
-static const u32 MAX_KEYS = 24;
+static const u32 MAX_KEYS = 25;
 
 enum gamePadValues
 {
@@ -48,6 +48,7 @@ enum gamePadValues
 	PAD_R2,       // R2 button
 	PAD_L3,       // Left joystick button (L3)
 	PAD_R3,       // Right joystick button (R3)
+	PAD_ANALOG,   // Analog mode toggle
 	PAD_L_UP,     // Left joystick (Up) ↑
 	PAD_L_RIGHT,  // Left joystick (Right) →
 	PAD_L_DOWN,   // Left joystick (Down) ↓

--- a/pcsx2/PAD/Host/KeyStatus.cpp
+++ b/pcsx2/PAD/Host/KeyStatus.cpp
@@ -31,7 +31,7 @@ void KeyStatus::Init()
 {
 	for (u32 pad = 0; pad < GAMEPAD_NUMBER; pad++)
 	{
-		m_button[pad] = 0xFFFF;
+		m_button[pad] = 0xFFFFFFFF;
 
 		for (u32 index = 0; index < MAX_KEYS; index++)
 			m_button_pressure[pad][index] = 0;
@@ -107,6 +107,7 @@ void KeyStatus::Set(u32 pad, u32 index, float value)
 			1, // PAD_R2
 			9, // PAD_L3
 			10, // PAD_R3
+			16, // Analog
 			// remainder are analogs and not used here
 		} };
 
@@ -118,7 +119,7 @@ void KeyStatus::Set(u32 pad, u32 index, float value)
 	}
 }
 
-u16 KeyStatus::GetButtons(u32 pad)
+u32 KeyStatus::GetButtons(u32 pad)
 {
 	return m_button[pad];
 }

--- a/pcsx2/PAD/Host/KeyStatus.h
+++ b/pcsx2/PAD/Host/KeyStatus.h
@@ -28,7 +28,7 @@ private:
 		u8 rx, ry;
 	};
 
-	u16 m_button[GAMEPAD_NUMBER];
+	u32 m_button[GAMEPAD_NUMBER];
 	u8 m_button_pressure[GAMEPAD_NUMBER][MAX_KEYS];
 	PADAnalog m_analog[GAMEPAD_NUMBER];
 	float m_axis_scale[GAMEPAD_NUMBER];
@@ -44,7 +44,7 @@ public:
 	__fi float GetVibrationScale(u32 pad, u32 motor) const { return m_vibration_scale[pad][motor]; }
 	__fi void SetVibrationScale(u32 pad, u32 motor, float scale) { m_vibration_scale[pad][motor] = scale; }
 
-	u16 GetButtons(u32 pad);
+	u32 GetButtons(u32 pad);
 	u8 GetPressure(u32 pad, u32 index);
 };
 

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -303,6 +303,7 @@ static const ControllerBindingInfo s_dualshock2_binds[] = {
 	{"R2", GenericInputBinding::R2 },
 	{"L3", GenericInputBinding::L3 },
 	{"R3", GenericInputBinding::R3 },
+	{"Analog", GenericInputBinding::System},
 	{"LUp", GenericInputBinding::LeftStickUp },
 	{"LRight", GenericInputBinding::LeftStickRight },
 	{"LDown", GenericInputBinding::LeftStickDown },

--- a/pcsx2/PAD/Host/StateManagement.cpp
+++ b/pcsx2/PAD/Host/StateManagement.cpp
@@ -241,7 +241,21 @@ u8 pad_poll(u8 value)
 					b1=b1 & 0x1f;
 #endif
 
-				uint16_t buttons = g_key_status.GetButtons(query.port);
+				uint32_t buttons = g_key_status.GetButtons(query.port);
+				if (!test_bit(buttons, PAD_ANALOG) && !pad->modeLock)
+				{
+					switch (pad->mode)
+					{
+						case MODE_ANALOG:
+						case MODE_DS2_NATIVE:
+							pad->set_mode(MODE_DIGITAL);
+							break;
+						case MODE_DIGITAL:
+						default:
+							pad->set_mode(MODE_ANALOG);
+							break;
+					}
+				}
 
 				query.numBytes = 5;
 


### PR DESCRIPTION
### Description of Changes
Exposes a bindable analog mode toggle through the ui and wires button events into pad state.

### Rationale behind Changes
Issue raised in #6185. Brings Qt to parity with wxWidgets which has the button bindable.

### Suggested Testing Steps
Test that button binding is saved and acted upon, also that well behaved games still accept input and will not switch back to digital when pad state is locked.
Currently tested against Ridge Racer V and Grand Turismo 2000 which both fail to enable analog controls by default. PR allows both to toggle between modes.
Also tested against Gran Turismo 3 which does not allow falling back to digital once ds2 mode is enabled.
