### PR TITLE
GameDB: Add missing serial

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4148,6 +4148,9 @@ SCES-55485:
 SCES-55489:
   name: "SingStar Mallorca Party"
   region: "PAL-G"
+SCES-55496:
+  name: "Secret Agent Clank"
+  region: "PAL-M12"
 SCES-55510:
   name: "Jak and Daxter - The Lost Frontier"
   region: "PAL-M12"


### PR DESCRIPTION
### Description of Changes
Add missing serial to GameDB: Secret Agent Clank (PAL-M12) [SCES-55496]

### Rationale behind Changes
More complete GameDB.

### Suggested Testing Steps
Make sure CI passes.
