### PR TITLE
GS/HW: Fix typos in wave filter shader

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -200,7 +200,7 @@ PS_OUTPUT ps_filter_complex(PS_INPUT input) // triangular
 
 	float2 texdim, halfpixel; 
 	Texture.GetDimensions(texdim.x, texdim.y); 
-	if (ddy(input.t.y) * texdim.y > 0.5) 
+	if (ddy(input.t.y) * input.t.y > 0.5) 
 		output.c = sample_c(input.t); 
 	else
 		output.c = (0.9 - 0.4 * cos(2 * PI * input.t.y * texdim.y)) * sample_c(float2(input.t.x, (floor(input.t.y * texdim.y) + 0.5) / texdim.y));

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -157,7 +157,7 @@ void ps_filter_complex() // triangular
 {
 	const float PI = 3.14159265359f;
 	vec2 texdim = vec2(textureSize(samp0, 0));
-	if (dFdy(v_tex.y) * texdim.y > 0.5) 
+	if (dFdy(v_tex.y) * v_tex.y > 0.5) 
 		o_col0 = sample_c(v_tex); 
 	else
 		o_col0 = (0.9 - 0.4 * cos(2 * PI * v_tex.y * texdim.y)) * sample_c(vec2(v_tex.x, (floor(v_tex.y * texdim.y) + 0.5) / texdim.y));


### PR DESCRIPTION
### Description of Changes
There is a small short circuiting typo in the vk and dx shader files ps_filter_complex functions. This brings both shaders in line with the correctly functioning OpenGL implementation.

### Rationale behind Changes
Fix broken wave filter on DirectX 11/12 and Vulkan backends.

### Suggested Testing Steps
Local testing shows idenitical output in DirectX 11/12 and Vulkan compared to OpenGL on nvidia hardware. Checking against other gpu vendors is advisable.
