### PR TITLE
GS/TextureReplacement: Ignore replaced textures in DumpTexture

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -583,9 +583,9 @@ void GSTextureReplacements::ProcessAsyncLoadedTextures()
 
 void GSTextureReplacements::DumpTexture(const GSTextureCache::HashCacheKey& hash, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, GSLocalMemory& mem, u32 level)
 {
-	// check if it's been dumped already
+	// check if it's been dumped or replaced already
 	const TextureName name(CreateTextureName(hash, level));
-	if (s_dumped_textures.find(name) != s_dumped_textures.end())
+	if (s_dumped_textures.find(name) != s_dumped_textures.end() || s_replacement_texture_filenames.find(name) != s_replacement_texture_filenames.end())
 		return;
 
 	s_dumped_textures.insert(name);


### PR DESCRIPTION
### Description of Changes
Added code that returns from DumpTexture function if texture is present in replacement texture cache or if texture exists in replacements folder.
It searches _only_ in cache if texture precaching is enabled and falls back to fs search otherwise.


### Rationale behind Changes
With this change we can dump only textures that need replacements instead of dumping every texture and then removing unneeded textures with scripts or by hand. 

### Suggested Testing Steps
Start dumping any game, edit texture with game logo with image editor, copy texture to replacements folder, delete texture from dumps folder, then start dumping the game again. You should not see game logo dumped for the second time.
