### PR TITLE
IPU: Reorder DMA timing for IPU_TO and IPU_FROM

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -1,5 +1,5 @@
 /*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
  *
  *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU Lesser General Public License as published by the Free Software Found-
@@ -191,8 +191,6 @@ __fi u32 ipuRead32(u32 mem)
 	pxAssert((mem & ~0xff) == 0x10002000);
 	mem &= 0xff;	// ipu repeats every 0x100
 
-	IPUProcessInterrupt();
-
 	switch (mem)
 	{
 		ipucase(IPU_CMD) : // IPU_CMD
@@ -242,8 +240,6 @@ __fi RETURNS_R64 ipuRead64(u32 mem)
 
 	pxAssert((mem & ~0xff) == 0x10002000);
 	mem &= 0xff;	// ipu repeats every 0x100
-
-	IPUProcessInterrupt();
 
 	switch (mem)
 	{
@@ -318,7 +314,6 @@ __fi bool ipuWrite32(u32 mem, u32 value)
 		ipucase(IPU_CMD): // IPU_CMD
 			IPU_LOG("write32: IPU_CMD=0x%08X", value);
 			IPUCMD_WRITE(value);
-			IPUProcessInterrupt();
 		return false;
 
 		ipucase(IPU_CTRL): // IPU_CTRL
@@ -354,7 +349,6 @@ __fi bool ipuWrite64(u32 mem, u64 value)
 		ipucase(IPU_CMD):
 			IPU_LOG("write64: IPU_CMD=0x%08X", value);
 			IPUCMD_WRITE((u32)value);
-			IPUProcessInterrupt();
 		return false;
 	}
 
@@ -928,7 +922,15 @@ __fi void IPUCMD_WRITE(u32 val)
 
 	ipuRegs.ctrl.BUSY = 1;
 
-	//if(!ipu1ch.chcr.STR) hwIntcIrq(INTC_IPU);
+	// Have a short delay immitating the time it takes to run IDEC/BDEC, other commands are near instant.
+	// Mana Khemia/Metal Saga start IDEC then change IPU0 expecting there to be a delay before IDEC sends data.
+	if (!CommandExecuteQueued && (ipu_cmd.CMD == SCE_IPU_IDEC || ipu_cmd.CMD == SCE_IPU_BDEC))
+	{
+		CommandExecuteQueued = true;
+		CPU_INT(IPU_PROCESS, 64);
+	}
+	else
+		IPUWorker();
 }
 
 __noinline void IPUWorker()

--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -58,7 +58,7 @@ void tIPU_cmd::clear()
 
 __fi void IPUProcessInterrupt()
 {
-	if (ipuRegs.ctrl.BUSY) // && (g_BP.FP || g_BP.IFC || (ipu1ch.chcr.STR && ipu1ch.qwc > 0)))
+	if (ipuRegs.ctrl.BUSY && !CommandExecuteQueued) // && (g_BP.FP || g_BP.IFC || (ipu1ch.chcr.STR && ipu1ch.qwc > 0)))
 		IPUWorker();
 }
 

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -91,6 +91,8 @@ struct alignas(16) tIPU_BP {
 
 	__fi void Advance(uint bits)
 	{
+		FillBuffer(bits);
+
 		BP += bits;
 		pxAssume( BP <= 256 );
 
@@ -112,10 +114,10 @@ struct alignas(16) tIPU_BP {
 				// if FP == 0 then an already-drained buffer is being advanced, and we need to drop a
 				// quadword from the IPU FIFO.
 
-				if (!FP)
-					ipu_fifo.in.read(&internal_qwc[0]);
-
-				FP = 0;
+				if (ipu_fifo.in.read(&internal_qwc[0]))
+					FP = 1;
+				else
+					FP = 0;
 			}
 		}
 	}

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -290,6 +290,7 @@ static IPUregisters& ipuRegs = (IPUregisters&)eeHw[0x2000];
 
 alignas(16) extern tIPU_cmd ipu_cmd;
 extern int coded_block_pattern;
+extern bool CommandExecuteQueued;
 
 extern void ipuReset();
 

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -86,6 +86,9 @@ int IPU_Fifo_Input::write(u32* pMem, int size)
 		pMem += 4;
 	}
 
+	if (g_BP.IFC == 8)
+		IPU1Status.DataRequested = false;
+
 	return firsttrans;
 }
 
@@ -99,7 +102,7 @@ int IPU_Fifo_Input::read(void *value)
 
 		if(ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
 		{
-			CPU_INT( DMAC_TO_IPU, 32 );
+			CPU_INT( DMAC_TO_IPU, 4);
 		}
 
 		if (g_BP.IFC == 0) return 0;
@@ -135,7 +138,7 @@ int IPU_Fifo_Output::write(const u32 *value, uint size)
 		}
 	/*} while(true);*/
 	if(ipu0ch.chcr.STR)
-		IPU_INT_FROM(64);
+		IPU_INT_FROM(ipuRegs.ctrl.OFC * BIAS);
 	return origsize - size;
 }
 

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -178,6 +178,7 @@ void WriteFIFO_IPUin(const mem128_t* value)
 	//committing every 16 bytes
 	if( ipu_fifo.in.write((u32*)value, 1) == 0 )
 	{
-		IPUProcessInterrupt();
+		CommandExecuteQueued = true;
+		CPU_INT(IPU_PROCESS, 1 * BIAS);
 	}
 }

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -188,7 +188,7 @@ void IPU0dma()
 
 	IPU_INT_FROM( readsize * BIAS );
 
-	if (ipu0ch.qwc > 0)
+	if (ipu0ch.qwc > 0 && !CommandExecuteQueued)
 	{
 		CommandExecuteQueued = true;
 		CPU_INT(IPU_PROCESS, 4);

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -121,7 +121,7 @@ void IPU1dma()
 	if(totalqwc == 0 || (IPU1Status.DMAFinished && !IPU1Status.InProgress))
 	{
 		totalqwc = std::max(4, totalqwc);
-		IPU_INT_TO(totalqwc);
+		IPU_INT_TO(totalqwc * BIAS);
 	}
 	else
 	{
@@ -133,18 +133,18 @@ void IPU1dma()
 		}
 		else
 		{
-			IPU_INT_TO(totalqwc*BIAS);
+			IPU_INT_TO(totalqwc * BIAS);
 		}
 	}
 
-	IPUProcessInterrupt();
+	CPU_INT(IPU_PROCESS, totalqwc * BIAS);
 
 	IPU_LOG("Completed Call IPU1 DMA QWC Remaining %x Finished %d In Progress %d tadr %x", ipu1ch.qwc, IPU1Status.DMAFinished, IPU1Status.InProgress, ipu1ch.tadr);
 }
 
 void IPU0dma()
 {
-	if(!ipuRegs.ctrl.OFC) 
+	if(!ipuRegs.ctrl.OFC)
 	{
 		IPUProcessInterrupt();
 		return;
@@ -181,6 +181,9 @@ void IPU0dma()
 	}
 
 	IPU_INT_FROM( readsize * BIAS );
+
+	if (ipu0ch.qwc > 0)
+		CPU_INT(IPU_PROCESS, 4);
 }
 
 __fi void dmaIPU0() // fromIPU
@@ -254,6 +257,11 @@ __fi void dmaIPU1() // toIPU
 			else
 				cpuRegs.eCycle[4] = 0x9999;
 	}
+}
+
+void ipuCMDProcess()
+{
+	IPUProcessInterrupt();
 }
 
 void ipu0Interrupt()

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -33,6 +33,7 @@ void SaveStateBase::ipuDmaFreeze()
 {
 	FreezeTag( "IPUdma" );
 	Freeze(IPU1Status);
+	Freeze(CommandExecuteQueued);
 }
 
 static __fi int IPU1chain() {

--- a/pcsx2/IPU/IPUdma.h
+++ b/pcsx2/IPU/IPUdma.h
@@ -23,6 +23,7 @@ struct IPUStatus {
 	bool DataRequested;
 };
 
+extern void ipuCMDProcess();
 extern void ipu0Interrupt();
 extern void ipu1Interrupt();
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -293,23 +293,23 @@ static __fi void _cpuTestInterrupts()
 	/* These are 'pcsx2 interrupts', they handle asynchronous stuff
 	   that depends on the cycle timings */
 
-	TESTINT(DMAC_VIF1,		vif1Interrupt);	
+	TESTINT(DMAC_VIF1,		vif1Interrupt);
 	TESTINT(DMAC_GIF,		gifInterrupt);
 	TESTINT(DMAC_SIF0,		EEsif0Interrupt);
 	TESTINT(DMAC_SIF1,		EEsif1Interrupt);
-	TESTINT(IPU_PROCESS,		ipuCMDProcess);
 	// Profile-guided Optimization (sorta)
 	// The following ints are rarely called.  Encasing them in a conditional
 	// as follows helps speed up most games.
 
 	if (cpuRegs.interrupt & ((1 << DMAC_VIF0) | (1 << DMAC_FROM_IPU) | (1 << DMAC_TO_IPU)
 		| (1 << DMAC_FROM_SPR) | (1 << DMAC_TO_SPR) | (1 << DMAC_MFIFO_VIF) | (1 << DMAC_MFIFO_GIF)
-		| (1 << VIF_VU0_FINISH) | (1 << VIF_VU1_FINISH)))
+		| (1 << VIF_VU0_FINISH) | (1 << VIF_VU1_FINISH) | (1 << IPU_PROCESS)))
 	{
 		TESTINT(DMAC_VIF0,		vif0Interrupt);
 
 		TESTINT(DMAC_FROM_IPU,	ipu0Interrupt);
 		TESTINT(DMAC_TO_IPU,	ipu1Interrupt);
+		TESTINT(IPU_PROCESS,	ipuCMDProcess);
 
 		TESTINT(DMAC_FROM_SPR,	SPRFROMinterrupt);
 		TESTINT(DMAC_TO_SPR,	SPRTOinterrupt);

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -297,7 +297,7 @@ static __fi void _cpuTestInterrupts()
 	TESTINT(DMAC_GIF,		gifInterrupt);
 	TESTINT(DMAC_SIF0,		EEsif0Interrupt);
 	TESTINT(DMAC_SIF1,		EEsif1Interrupt);
-	
+	TESTINT(IPU_PROCESS,		ipuCMDProcess);
 	// Profile-guided Optimization (sorta)
 	// The following ints are rarely called.  Encasing them in a conditional
 	// as follows helps speed up most games.

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -413,7 +413,8 @@ enum EE_EventType
 	
 	DMAC_GIF_UNIT,
 	VIF_VU0_FINISH,
-	VIF_VU1_FINISH
+	VIF_VU1_FINISH,
+	IPU_PROCESS
 };
 
 extern void CPU_INT( EE_EventType n, s32 ecycle );

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -33,7 +33,7 @@ enum class FreezeAction
 //  the lower 16 bit value.  IF the change is breaking of all compatibility with old
 //  states, increment the upper 16 bit value, and clear the lower 16 bits to 0.
 
-static const u32 g_SaveVersion = (0x9A2C << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A2D << 16) | 0x0000;
 
 // the freezing data between submodules and core
 // an interesting thing to note is that this dates back from before plugin


### PR DESCRIPTION
### Description of Changes
Reorders how the delays for IPU DMA's happen and how quickly the IPU command continues.
Bumps savestate version. Sorry not sorry.

### Rationale behind Changes
These timings were a mess and IPU was being triggered way too early, causing timing errors in games such as Tales of Rebirth

### Suggested Testing Steps
Make sure no videos are busted, else I may cry.

Fixes regression on Tales of Rebirth from #6270
Fixes #6290 Guilty Gear XX regression