### PR TITLE
GameDB: Added Tourist Trophy VU clamp fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -341,6 +341,8 @@ PCPX-96649:
 PCPX-96660:
   name: "Tourist Trophy [Demo]"
   region: "NTSC-J"
+  clampModes:
+    vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
 PCPX-98017:
   name: "Ratchet & Clank - Giri Giri Ginga no Giga Battle [Demo]"
   region: "NTSC-J"
@@ -1156,6 +1158,8 @@ SCAJ-20170:
   name: "Tourist Trophy"
   region: "NTSC-Ch"
   compat: 5
+  clampModes:
+    vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
 SCAJ-20171:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi"
   region: "NTSC-J"
@@ -3523,6 +3527,8 @@ SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "PAL-M5"
   compat: 5
+  clampModes:
+    vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
 SCES-53397:
   name: "SingStar Pop - World Events Code"
   region: "PAL-Unk"
@@ -5442,6 +5448,8 @@ SCPS-15104:
 SCPS-15105:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "NTSC-J"
+  clampModes:
+    vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
 SCPS-15106:
   name: "Siren 2"
   region: "NTSC-J"
@@ -5868,6 +5876,8 @@ SCPS-19323:
 SCPS-19324:
   name: "Tourist Trophy - The Real Riding Simulator [PlayStation 2 The Best]"
   region: "NTSC-J"
+  clampModes:
+    vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
 SCPS-19325:
   name: "Ape Escape - Million Monkeys [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7672,6 +7682,8 @@ SCUS-97502:
   name: "Tourist Trophy"
   region: "NTSC-U"
   compat: 5
+  clampModes:
+    vuClampMode: 2 # Fixes SPS in TT Mode menu caused by the moving tooltips.
 SCUS-97503:
   name: "MLB '06 - The Show [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds **VU clamping = Extra** to **Tourist Trophy**

### Rationale behind Changes
Fixes SPS in the **Tourist Trophy Mode** menu when the tooltips are moving. Same fix is already applied to Gran Turismo 4, but it also fixed text there.

### Suggested Testing Steps
Test Tourist Trophy if the SPS is gone

Before
![image](https://user-images.githubusercontent.com/4414625/171831359-d72ca19e-fa5d-4118-bdc4-0d11f3cd79d6.png)
After
![image](https://user-images.githubusercontent.com/4414625/171830007-a53ffbe5-ef0b-4afe-9be9-5d912e3b251e.png)
