### PR TITLE
MipsAssembler: Support li pseudo instruction

### DIFF
--- a/pcsx2/DebugTools/MipsAssembler.cpp
+++ b/pcsx2/DebugTools/MipsAssembler.cpp
@@ -686,6 +686,19 @@ void CMipsInstruction::encodeNormal()
 {
 	encoding = Opcode.destencoding;
 
+	if (Opcode.flags & MO_PSEUDO)
+	{
+		// Special opcodes that are legal mips instructions
+		// but are actually other instructions
+		switch (Opcode.destencoding)
+		{
+			case MIPS_OP(0x0D):
+				// li RT, IMM -> ori RT, $zero, IMM
+				encoding |= MIPS_RS(0);
+				break;
+		}
+	}
+
 	if (registers.grs.num != -1) encoding |= MIPS_RS(registers.grs.num);	// source reg
 	if (registers.grt.num != -1) encoding |= MIPS_RT(registers.grt.num);	// target reg
 	if (registers.grd.num != -1) encoding |= MIPS_RD(registers.grd.num);	// dest reg

--- a/pcsx2/DebugTools/MipsAssemblerTables.cpp
+++ b/pcsx2/DebugTools/MipsAssemblerTables.cpp
@@ -437,6 +437,10 @@ const tMipsOpcode MipsOpcodes[] = {
 	{ "seh",		"d,t",		MIPS_ALLEGREX0(16),			MA_PSP },
 	{ "seh",		"d,t",		MIPS_ALLEGREX0(24),			MA_PSP },
 
+	// Special PSEUDO instructions
+	// li    -> ori
+	{ "li",			"t,i",			MIPS_OP(0x0D),				MA_MIPS1,	MO_PSEUDO},
+	
 	// END
 	{ NULL,		NULL,		0,			0 }
 };

--- a/pcsx2/DebugTools/MipsAssemblerTables.h
+++ b/pcsx2/DebugTools/MipsAssemblerTables.h
@@ -45,6 +45,7 @@
 #define MO_VFPU			0x00008000	// vfpu type opcode
 #define MO_64BIT		0x00010000	// only available on 64 bit cpus
 #define MO_FPU			0x00020000	// only available with an fpu
+#define MO_PSEUDO		0x00040000	// psuedo op
 
 #define BITFIELD(START,LENGTH,VALUE)	(((VALUE) << (START)))
 #define MIPS_FUNC(VALUE)				BITFIELD(0,6,(VALUE))


### PR DESCRIPTION
### Description of Changes
Support the li pseudo instruction

### Rationale behind Changes
It's valid mips

### Suggested Testing Steps
Try assembling with `li` in the debugger (wx only on master)

https://user-images.githubusercontent.com/29295048/171924953-655c7c93-bd60-4a03-88ac-8ffcfa031280.mp4
