### PR TITLE
GameDB: Mana Khemia

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -95,6 +95,8 @@ GUST-00009:
     eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - SoftwareRendererFMVHack # Vertical lines in FMV.
+  gsHWFixes:
+    roundSprite: 1 # Fixes misalignment of textures in the Pause Menu.
 PAPX-90201:
   name: "Fantavision [Taikenban]"
   region: "NTSC-J"
@@ -20405,6 +20407,8 @@ SLES-55443:
     eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - SoftwareRendererFMVHack # Fixes vertical lines in FMVs.
+  gsHWFixes:
+    roundSprite: 1 # Fixes misalignment of textures in the Pause Menu.
 SLES-55444:
   name: "Ar tonelico II - Melody of Metafalica"
   region: "PAL-E"
@@ -44411,6 +44415,8 @@ SLUS-21735:
     eeRoundMode: 0 # Fixes jump issue.
   gameFixes:
     - SoftwareRendererFMVHack # Vertical lines in FMV.
+  gsHWFixes:
+    roundSprite: 1 # Fixes misalignment of textures in the Pause Menu.
 SLUS-21736:
   name: "Wall-E"
   region: "NTSC-U"


### PR DESCRIPTION
fixes misalignment of textures in the pause menu.

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
![trash2](https://user-images.githubusercontent.com/17991404/171983262-eb4c59b6-1c7d-48b9-9b44-622d06112635.png)
![trash1](https://user-images.githubusercontent.com/17991404/171983263-3c4a8d25-d24c-406d-8da4-cd86f44f26fa.png)


### Rationale behind Changes
Fixes misalignment of textures in the pause menu.

![notrash2](https://user-images.githubusercontent.com/17991404/171983326-559e3894-fa03-48c8-a1fe-9c385dc95004.png)
![notrash1](https://user-images.githubusercontent.com/17991404/171983329-6ba0c504-3e46-44f6-99a7-421a18b81b62.png)


### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Just try the pause menu in Upscaled resolution,.