### PR TITLE
GS: Split convert and present shaders

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -91,30 +91,6 @@ PS_OUTPUT ps_filter_transparency(PS_INPUT input)
 	return output;
 }
 
-float4 ps_crt(PS_INPUT input, int i)
-{
-	float4 mask[4] = 
-	{
-		float4(1, 0, 0, 0), 
-		float4(0, 1, 0, 0), 
-		float4(0, 0, 1, 0), 
-		float4(1, 1, 1, 0)
-	};
-	
-	return sample_c(input.t) * saturate(mask[i] + 0.5f);
-}
-
-float4 ps_scanlines(PS_INPUT input, int i)
-{
-	float4 mask[2] =
-	{
-		float4(1, 1, 1, 0),
-		float4(0, 0, 0, 0)
-	};
-
-	return sample_c(input.t) * saturate(mask[i] + 0.5f);
-}
-
 // Need to be careful with precision here, it can break games like Spider-Man 3 and Dogs Life
 uint ps_convert_rgba8_16bits(PS_INPUT input) : SV_Target0
 {
@@ -155,55 +131,6 @@ PS_OUTPUT ps_mod256(PS_INPUT input)
 	float4 fmod2 = fmod(fmod1, 256);
 
 	output.c = fmod2 / 255.0f;
-
-	return output;
-}
-
-PS_OUTPUT ps_filter_scanlines(PS_INPUT input)
-{
-	PS_OUTPUT output;
-	
-	uint4 p = (uint4)input.p;
-
-	output.c = ps_scanlines(input, p.y % 2);
-
-	return output;
-}
-
-PS_OUTPUT ps_filter_diagonal(PS_INPUT input)
-{
-	PS_OUTPUT output;
-
-	uint4 p = (uint4)input.p;
-
-	output.c = ps_crt(input, (p.x + (p.y % 3)) % 3);
-
-	return output;
-}
-
-PS_OUTPUT ps_filter_triangular(PS_INPUT input)
-{
-	PS_OUTPUT output;
-
-	uint4 p = (uint4)input.p;
-
-	// output.c = ps_crt(input, ((p.x + (p.y & 1) * 3) >> 1) % 3); 
-	output.c = ps_crt(input, ((p.x + ((p.y >> 1) & 1) * 3) >> 1) % 3);
-
-	return output;
-}
-
-static const float PI = 3.14159265359f;
-PS_OUTPUT ps_filter_complex(PS_INPUT input) // triangular
-{
-	PS_OUTPUT output;
-
-	float2 texdim, halfpixel; 
-	Texture.GetDimensions(texdim.x, texdim.y); 
-	if (ddy(input.t.y) * input.t.y > 0.5) 
-		output.c = sample_c(input.t); 
-	else
-		output.c = (0.9 - 0.4 * cos(2 * PI * input.t.y * texdim.y)) * sample_c(float2(input.t.x, (floor(input.t.y * texdim.y) + 0.5) / texdim.y));
 
 	return output;
 }

--- a/bin/resources/shaders/dx11/present.fx
+++ b/bin/resources/shaders/dx11/present.fx
@@ -1,0 +1,148 @@
+#ifdef SHADER_MODEL // make safe to include in resource file to enforce dependency
+
+#ifndef PS_SCALE_FACTOR
+#define PS_SCALE_FACTOR 1
+#endif
+
+struct VS_INPUT
+{
+	float4 p : POSITION;
+	float2 t : TEXCOORD0;
+	float4 c : COLOR;
+};
+
+struct VS_OUTPUT
+{
+	float4 p : SV_Position;
+	float2 t : TEXCOORD0;
+	float4 c : COLOR;
+};
+
+cbuffer cb0 : register(b0)
+{
+	float4 u_source_rect;
+	float4 u_target_rect;
+	float2 u_source_size;
+	float2 u_target_size;
+	float2 u_target_resolution;
+	float2 u_rcp_target_resolution; // 1 / u_target_resolution
+	float2 u_source_resolution;
+	float2 u_rcp_source_resolution; // 1 / u_source_resolution
+	float u_time;
+	float3 cb0_pad0;
+};
+
+Texture2D Texture;
+SamplerState TextureSampler;
+
+float4 sample_c(float2 uv)
+{
+	return Texture.Sample(TextureSampler, uv);
+}
+
+struct PS_INPUT
+{
+	float4 p : SV_Position;
+	float2 t : TEXCOORD0;
+	float4 c : COLOR;
+};
+
+struct PS_OUTPUT
+{
+	float4 c : SV_Target0;
+};
+
+VS_OUTPUT vs_main(VS_INPUT input)
+{
+	VS_OUTPUT output;
+
+	output.p = input.p;
+	output.t = input.t;
+	output.c = input.c;
+
+	return output;
+}
+
+PS_OUTPUT ps_copy(PS_INPUT input)
+{
+	PS_OUTPUT output;
+	
+	output.c = sample_c(input.t);
+
+	return output;
+}
+
+float4 ps_crt(PS_INPUT input, int i)
+{
+	float4 mask[4] = 
+	{
+		float4(1, 0, 0, 0), 
+		float4(0, 1, 0, 0), 
+		float4(0, 0, 1, 0), 
+		float4(1, 1, 1, 0)
+	};
+	
+	return sample_c(input.t) * saturate(mask[i] + 0.5f);
+}
+
+float4 ps_scanlines(PS_INPUT input, int i)
+{
+	float4 mask[2] =
+	{
+		float4(1, 1, 1, 0),
+		float4(0, 0, 0, 0)
+	};
+
+	return sample_c(input.t) * saturate(mask[i] + 0.5f);
+}
+
+PS_OUTPUT ps_filter_scanlines(PS_INPUT input)
+{
+	PS_OUTPUT output;
+	
+	uint4 p = (uint4)input.p;
+
+	output.c = ps_scanlines(input, p.y % 2);
+
+	return output;
+}
+
+PS_OUTPUT ps_filter_diagonal(PS_INPUT input)
+{
+	PS_OUTPUT output;
+
+	uint4 p = (uint4)input.p;
+
+	output.c = ps_crt(input, (p.x + (p.y % 3)) % 3);
+
+	return output;
+}
+
+PS_OUTPUT ps_filter_triangular(PS_INPUT input)
+{
+	PS_OUTPUT output;
+
+	uint4 p = (uint4)input.p;
+
+	// output.c = ps_crt(input, ((p.x + (p.y & 1) * 3) >> 1) % 3); 
+	output.c = ps_crt(input, ((p.x + ((p.y >> 1) & 1) * 3) >> 1) % 3);
+
+	return output;
+}
+
+static const float PI = 3.14159265359f;
+PS_OUTPUT ps_filter_complex(PS_INPUT input) // triangular
+{
+	PS_OUTPUT output;
+
+	float2 texdim, halfpixel; 
+	Texture.GetDimensions(texdim.x, texdim.y); 
+	if (ddy(input.t.y) * input.t.y > 0.5) 
+		output.c = sample_c(input.t); 
+	else
+		output.c = (0.9 - 0.4 * cos(2 * PI * input.t.y * texdim.y)) * sample_c(float2(input.t.x, (floor(input.t.y * texdim.y) + 0.5) / texdim.y));
+
+	return output;
+}
+
+#endif

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -47,18 +47,6 @@ vec4 sample_c()
     return texture(TextureSampler, PSin_t);
 }
 
-vec4 ps_crt(uint i)
-{
-    vec4 mask[4] = vec4[4]
-        (
-         vec4(1, 0, 0, 0),
-         vec4(0, 1, 0, 0),
-         vec4(0, 0, 1, 0),
-         vec4(1, 1, 1, 0)
-        );
-    return sample_c() * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
-}
-
 #ifdef ps_copy
 void ps_copy()
 {
@@ -237,70 +225,6 @@ void ps_filter_transparency()
     vec4 c = sample_c();
 
     c.a = dot(c.rgb, vec3(0.299, 0.587, 0.114));
-
-    SV_Target0 = c;
-}
-#endif
-
-#ifdef ps_filter_scanlines
-vec4 ps_scanlines(uint i)
-{
-    vec4 mask[2] =
-    {
-        vec4(1, 1, 1, 0),
-        vec4(0, 0, 0, 0)
-    };
-
-    return sample_c() * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
-}
-
-void ps_filter_scanlines() // scanlines
-{
-    highp uvec4 p = uvec4(gl_FragCoord);
-
-    vec4 c = ps_scanlines(p.y % 2u);
-
-    SV_Target0 = c;
-}
-#endif
-
-#ifdef ps_filter_diagonal
-void ps_filter_diagonal() // diagonal
-{
-    highp uvec4 p = uvec4(gl_FragCoord);
-
-    vec4 c = ps_crt((p.x + (p.y % 3u)) % 3u);
-
-    SV_Target0 = c;
-}
-#endif
-
-#ifdef ps_filter_triangular
-void ps_filter_triangular() // triangular
-{
-    highp uvec4 p = uvec4(gl_FragCoord);
-
-    vec4 c = ps_crt(((p.x + ((p.y >> 1u) & 1u) * 3u) >> 1u) % 3u);
-
-    SV_Target0 = c;
-}
-#endif
-
-#ifdef ps_filter_complex
-void ps_filter_complex()
-{
-
-    const float PI = 3.14159265359f;
-
-    vec2 texdim = vec2(textureSize(TextureSampler, 0));
-
-    vec4 c;
-    if (dFdy(PSin_t.y) * PSin_t.y > 0.5f) {
-        c = sample_c();
-    } else {
-        float factor = (0.9f - 0.4f * cos(2.0f * PI * PSin_t.y * texdim.y));
-        c =  factor * texture(TextureSampler, vec2(PSin_t.x, (floor(PSin_t.y * texdim.y) + 0.5f) / texdim.y));
-    }
 
     SV_Target0 = c;
 }

--- a/bin/resources/shaders/opengl/present.glsl
+++ b/bin/resources/shaders/opengl/present.glsl
@@ -1,0 +1,139 @@
+//#version 420 // Keep it for editor detection
+
+
+#ifdef VERTEX_SHADER
+
+layout(location = 0) in vec2 POSITION;
+layout(location = 1) in vec2 TEXCOORD0;
+layout(location = 7) in vec4 COLOR;
+
+// FIXME set the interpolation (don't know what dx do)
+// flat means that there is no interpolation. The value given to the fragment shader is based on the provoking vertex conventions.
+//
+// noperspective means that there will be linear interpolation in window-space. This is usually not what you want, but it can have its uses.
+//
+// smooth, the default, means to do perspective-correct interpolation.
+//
+// The centroid qualifier only matters when multisampling. If this qualifier is not present, then the value is interpolated to the pixel's center, anywhere in the pixel, or to one of the pixel's samples. This sample may lie outside of the actual primitive being rendered, since a primitive can cover only part of a pixel's area. The centroid qualifier is used to prevent this; the interpolation point must fall within both the pixel's area and the primitive's area.
+out vec4 PSin_p;
+out vec2 PSin_t;
+out vec4 PSin_c;
+
+void vs_main()
+{
+    PSin_p = vec4(POSITION, 0.5f, 1.0f);
+    PSin_t = TEXCOORD0;
+    PSin_c = COLOR;
+    gl_Position = vec4(POSITION, 0.5f, 1.0f); // NOTE I don't know if it is possible to merge POSITION_OUT and gl_Position
+}
+
+#endif
+
+#ifdef FRAGMENT_SHADER
+
+uniform vec4 u_source_rect;
+uniform vec4 u_target_rect;
+uniform vec2 u_source_size;
+uniform vec2 u_target_size;
+uniform vec2 u_target_resolution;
+uniform vec2 u_rcp_target_resolution; // 1 / u_target_resolution
+uniform vec2 u_source_resolution;
+uniform vec2 u_rcp_source_resolution; // 1 / u_source_resolution
+uniform float u_time;
+uniform vec3 cb0_pad0;
+
+in vec4 PSin_p;
+in vec2 PSin_t;
+in vec4 PSin_c;
+
+layout(location = 0) out vec4 SV_Target0;
+
+vec4 sample_c()
+{
+    return texture(TextureSampler, PSin_t);
+}
+
+vec4 ps_crt(uint i)
+{
+    vec4 mask[4] = vec4[4]
+        (
+         vec4(1, 0, 0, 0),
+         vec4(0, 1, 0, 0),
+         vec4(0, 0, 1, 0),
+         vec4(1, 1, 1, 0)
+        );
+    return sample_c() * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
+}
+
+#ifdef ps_copy
+void ps_copy()
+{
+    SV_Target0 = sample_c();
+}
+#endif
+
+#ifdef ps_filter_scanlines
+vec4 ps_scanlines(uint i)
+{
+    vec4 mask[2] =
+    {
+        vec4(1, 1, 1, 0),
+        vec4(0, 0, 0, 0)
+    };
+
+    return sample_c() * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
+}
+
+void ps_filter_scanlines() // scanlines
+{
+    highp uvec4 p = uvec4(gl_FragCoord);
+
+    vec4 c = ps_scanlines(p.y % 2u);
+
+    SV_Target0 = c;
+}
+#endif
+
+#ifdef ps_filter_diagonal
+void ps_filter_diagonal() // diagonal
+{
+    highp uvec4 p = uvec4(gl_FragCoord);
+
+    vec4 c = ps_crt((p.x + (p.y % 3u)) % 3u);
+
+    SV_Target0 = c;
+}
+#endif
+
+#ifdef ps_filter_triangular
+void ps_filter_triangular() // triangular
+{
+    highp uvec4 p = uvec4(gl_FragCoord);
+
+    vec4 c = ps_crt(((p.x + ((p.y >> 1u) & 1u) * 3u) >> 1u) % 3u);
+
+    SV_Target0 = c;
+}
+#endif
+
+#ifdef ps_filter_complex
+void ps_filter_complex()
+{
+
+    const float PI = 3.14159265359f;
+
+    vec2 texdim = vec2(textureSize(TextureSampler, 0));
+
+    vec4 c;
+    if (dFdy(PSin_t.y) * PSin_t.y > 0.5f) {
+        c = sample_c();
+    } else {
+        float factor = (0.9f - 0.4f * cos(2.0f * PI * PSin_t.y * texdim.y));
+        c =  factor * texture(TextureSampler, vec2(PSin_t.x, (floor(PSin_t.y * texdim.y) + 0.5f) / texdim.y));
+    }
+
+    SV_Target0 = c;
+}
+#endif
+
+#endif

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -34,29 +34,6 @@ vec4 sample_c(vec2 uv)
 	return texture(samp0, uv);
 }
 
-vec4 ps_crt(uint i)
-{
-		vec4 mask[4] = vec4[4]
-				(
-				 vec4(1, 0, 0, 0),
-				 vec4(0, 1, 0, 0),
-				 vec4(0, 0, 1, 0),
-				 vec4(1, 1, 1, 0)
-				);
-		return sample_c(v_tex) * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
-}
-
-vec4 ps_scanlines(uint i)
-{
-		vec4 mask[2] =
-		{
-				vec4(1, 1, 1, 0),
-				vec4(0, 0, 0, 0)
-		};
-
-		return sample_c(v_tex) * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
-}
-
 #ifdef ps_copy
 void ps_copy()
 {
@@ -122,45 +99,6 @@ void ps_mod256()
 	vec4 fmod2 = mod(fmod1, 256);
 
 	o_col0 = fmod2 / 255.0f;
-}
-#endif
-
-#ifdef ps_filter_scanlines
-void ps_filter_scanlines() // scanlines
-{
-	uvec4 p = uvec4(gl_FragCoord);
-
-	o_col0 = ps_scanlines(p.y % 2);
-}
-#endif
-
-#ifdef ps_filter_diagonal
-void ps_filter_diagonal() // diagonal
-{
-	uvec4 p = uvec4(gl_FragCoord);
-	o_col0 = ps_crt((p.x + (p.y % 3)) % 3);
-}
-#endif
-
-#ifdef ps_filter_triangular
-void ps_filter_triangular() // triangular
-{
-	uvec4 p = uvec4(gl_FragCoord);
-
-	// output.c = ps_crt(input, ((p.x + (p.y & 1) * 3) >> 1) % 3); 
-	o_col0 = ps_crt(((p.x + ((p.y >> 1) & 1) * 3) >> 1) % 3);
-}
-#endif
-
-#ifdef ps_filter_complex
-void ps_filter_complex() // triangular
-{
-	const float PI = 3.14159265359f;
-	vec2 texdim = vec2(textureSize(samp0, 0));
-	if (dFdy(v_tex.y) * v_tex.y > 0.5) 
-		o_col0 = sample_c(v_tex); 
-	else
-		o_col0 = (0.9 - 0.4 * cos(2 * PI * v_tex.y * texdim.y)) * sample_c(vec2(v_tex.x, (floor(v_tex.y * texdim.y) + 0.5) / texdim.y));
 }
 #endif
 

--- a/bin/resources/shaders/vulkan/present.glsl
+++ b/bin/resources/shaders/vulkan/present.glsl
@@ -1,0 +1,116 @@
+#ifndef PS_SCALE_FACTOR
+#define PS_SCALE_FACTOR 1
+#endif
+
+#ifdef VERTEX_SHADER
+
+layout(location = 0) in vec4 a_pos;
+layout(location = 1) in vec2 a_tex;
+
+layout(location = 0) out vec2 v_tex;
+
+void main()
+{
+	gl_Position = vec4(a_pos.x, -a_pos.y, a_pos.z, a_pos.w);
+	v_tex = a_tex;
+}
+
+#endif
+
+#ifdef FRAGMENT_SHADER
+
+layout(push_constant) uniform cb10
+{
+	vec4 u_source_rect;
+	vec4 u_target_rect;
+	vec2 u_source_size;
+	vec2 u_target_size;
+	vec2 u_target_resolution;
+	vec2 u_rcp_target_resolution; // 1 / u_target_resolution
+	vec2 u_source_resolution;
+	vec2 u_rcp_source_resolution; // 1 / u_source_resolution
+	float u_time;
+	vec3 cb0_pad0;
+};
+
+layout(location = 0) in vec2 v_tex;
+
+layout(location = 0) out vec4 o_col0;
+
+layout(set = 0, binding = 0) uniform sampler2D samp0;
+
+vec4 sample_c(vec2 uv)
+{
+	return texture(samp0, uv);
+}
+
+vec4 ps_crt(uint i)
+{
+		vec4 mask[4] = vec4[4]
+				(
+				 vec4(1, 0, 0, 0),
+				 vec4(0, 1, 0, 0),
+				 vec4(0, 0, 1, 0),
+				 vec4(1, 1, 1, 0)
+				);
+		return sample_c(v_tex) * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
+}
+
+vec4 ps_scanlines(uint i)
+{
+		vec4 mask[2] =
+		{
+				vec4(1, 1, 1, 0),
+				vec4(0, 0, 0, 0)
+		};
+
+		return sample_c(v_tex) * clamp((mask[i] + 0.5f), 0.0f, 1.0f);
+}
+
+#ifdef ps_copy
+void ps_copy()
+{
+	o_col0 = sample_c(v_tex);
+}
+#endif
+
+#ifdef ps_filter_scanlines
+void ps_filter_scanlines() // scanlines
+{
+	uvec4 p = uvec4(gl_FragCoord);
+
+	o_col0 = ps_scanlines(p.y % 2);
+}
+#endif
+
+#ifdef ps_filter_diagonal
+void ps_filter_diagonal() // diagonal
+{
+	uvec4 p = uvec4(gl_FragCoord);
+	o_col0 = ps_crt((p.x + (p.y % 3)) % 3);
+}
+#endif
+
+#ifdef ps_filter_triangular
+void ps_filter_triangular() // triangular
+{
+	uvec4 p = uvec4(gl_FragCoord);
+
+	// output.c = ps_crt(input, ((p.x + (p.y & 1) * 3) >> 1) % 3); 
+	o_col0 = ps_crt(((p.x + ((p.y >> 1) & 1) * 3) >> 1) % 3);
+}
+#endif
+
+#ifdef ps_filter_complex
+void ps_filter_complex() // triangular
+{
+	const float PI = 3.14159265359f;
+	vec2 texdim = vec2(textureSize(samp0, 0));
+	if (dFdy(v_tex.y) * v_tex.y > 0.5) 
+		o_col0 = sample_c(v_tex); 
+	else
+		o_col0 = (0.9 - 0.4 * cos(2 * PI * v_tex.y * texdim.y)) * sample_c(vec2(v_tex.x, (floor(v_tex.y * texdim.y) + 0.5) / texdim.y));
+}
+#endif
+
+#endif

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -798,6 +798,7 @@ endif()
 
 set(pcsx2GSMetalShaders
 	GS/Renderers/Metal/convert.metal
+	GS/Renderers/Metal/present.metal
 	GS/Renderers/Metal/merge.metal
 	GS/Renderers/Metal/interlace.metal
 	GS/Renderers/Metal/tfx.metal

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -22,16 +22,13 @@ const char* shaderName(ShaderConvert value)
 {
 	switch (value)
 	{
+			// clang-format off
 		case ShaderConvert::COPY:                return "ps_copy";
 		case ShaderConvert::RGBA8_TO_16_BITS:    return "ps_convert_rgba8_16bits";
 		case ShaderConvert::DATM_1:              return "ps_datm1";
 		case ShaderConvert::DATM_0:              return "ps_datm0";
 		case ShaderConvert::MOD_256:             return "ps_mod256";
-		case ShaderConvert::SCANLINE:            return "ps_filter_scanlines";
-		case ShaderConvert::DIAGONAL_FILTER:     return "ps_filter_diagonal";
 		case ShaderConvert::TRANSPARENCY_FILTER: return "ps_filter_transparency";
-		case ShaderConvert::TRIANGULAR_FILTER:   return "ps_filter_triangular";
-		case ShaderConvert::COMPLEX_FILTER:      return "ps_filter_complex";
 		case ShaderConvert::FLOAT32_TO_16_BITS:  return "ps_convert_float32_32bits";
 		case ShaderConvert::FLOAT32_TO_32_BITS:  return "ps_convert_float32_32bits";
 		case ShaderConvert::FLOAT32_TO_RGBA8:    return "ps_convert_float32_rgba8";
@@ -43,9 +40,27 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::DEPTH_COPY:          return "ps_depth_copy";
 		case ShaderConvert::RGBA_TO_8I:          return "ps_convert_rgba_8i";
 		case ShaderConvert::YUV:                 return "ps_yuv";
+			// clang-format on
 		default:
 			ASSERT(0);
 			return "ShaderConvertUnknownShader";
+	}
+}
+
+const char* shaderName(PresentShader value)
+{
+	switch (value)
+	{
+			// clang-format off
+		case PresentShader::COPY:              return "ps_copy";
+		case PresentShader::SCANLINE:          return "ps_filter_scanlines";
+		case PresentShader::DIAGONAL_FILTER:   return "ps_filter_diagonal";
+		case PresentShader::TRIANGULAR_FILTER: return "ps_filter_triangular";
+		case PresentShader::COMPLEX_FILTER:    return "ps_filter_complex";
+			// clang-format on
+		default:
+			ASSERT(0);
+			return "DisplayShaderUnknownShader";
 	}
 }
 
@@ -56,18 +71,7 @@ static int MipmapLevelsForSize(int width, int height)
 
 std::unique_ptr<GSDevice> g_gs_device;
 
-GSDevice::GSDevice()
-	: m_merge(NULL)
-	, m_weavebob(NULL)
-	, m_blend(NULL)
-	, m_target_tmp(NULL)
-	, m_current(NULL)
-	, m_frame(0)
-	, m_rbswapped(false)
-{
-	memset(&m_vertex, 0, sizeof(m_vertex));
-	memset(&m_index, 0, sizeof(m_index));
-}
+GSDevice::GSDevice() = default;
 
 GSDevice::~GSDevice()
 {

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -30,6 +30,8 @@ class GSRenderer : public GSState
 private:
 	bool Merge(int field);
 
+	u64 m_shader_time_start = 0;
+
 #ifndef PCSX2_CORE
 	GSCapture m_capture;
 	std::mutex m_snapshot_mutex;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -172,6 +172,14 @@ private:
 
 	struct
 	{
+		wil::com_ptr_nothrow<ID3D11InputLayout> il;
+		wil::com_ptr_nothrow<ID3D11VertexShader> vs;
+		wil::com_ptr_nothrow<ID3D11PixelShader> ps[static_cast<int>(PresentShader::Count)];
+		wil::com_ptr_nothrow<ID3D11Buffer> ps_cb;
+	} m_present;
+
+	struct
+	{
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps[2];
 		wil::com_ptr_nothrow<ID3D11Buffer> cb;
 		wil::com_ptr_nothrow<ID3D11BlendState> bs;
@@ -257,6 +265,7 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, bool linear = true);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, ID3D11BlendState* bs, bool linear = true);
+	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) override;
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vertices, bool datm);
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -48,11 +48,6 @@ static bool IsIntConvertShader(ShaderConvert i)
 
 static bool IsDATMConvertShader(ShaderConvert i) { return (i == ShaderConvert::DATM_0 || i == ShaderConvert::DATM_1); }
 
-static bool IsPresentConvertShader(ShaderConvert i)
-{
-	return (i == ShaderConvert::COPY || (i >= ShaderConvert::SCANLINE && i <= ShaderConvert::COMPLEX_FILTER));
-}
-
 static D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE GetLoadOpForTexture(GSTexture12* tex)
 {
 	if (!tex)
@@ -157,8 +152,9 @@ bool GSDevice12::Create(HostDisplay* display)
 	if (!CreateBuffers())
 		return false;
 
-	if (!CompileConvertPipelines() || !CompileInterlacePipelines() ||
-		!CompileMergePipelines() || !CompilePostProcessingPipelines())
+	if (!CompileConvertPipelines() || !CompilePresentPipelines() ||
+		!CompileInterlacePipelines() || !CompileMergePipelines() ||
+		!CompilePostProcessingPipelines())
 	{
 		Host::ReportErrorAsync("GS", "Failed to compile utility pipelines");
 		return false;
@@ -499,6 +495,20 @@ void GSDevice12::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	const u32 index = (red ? 1 : 0) | (green ? 2 : 0) | (blue ? 4 : 0) | (alpha ? 8 : 0);
 	DoStretchRect(
 		static_cast<GSTexture12*>(sTex), sRect, static_cast<GSTexture12*>(dTex), dRect, m_color_copy[index].get(), false);
+}
+
+void GSDevice12::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
+	PresentShader shader, float shaderTime, bool linear)
+{
+	DisplayConstantBuffer cb;
+	cb.SetSource(sRect, sTex->GetSize());
+	cb.SetTarget(dRect, dTex ? dTex->GetSize() : GSVector2i(m_display->GetWindowWidth(), m_display->GetWindowHeight()));
+	cb.SetTime(shaderTime);
+	SetUtilityRootSignature();
+	SetUtilityPushConstants(&cb, sizeof(cb));
+
+	DoStretchRect(static_cast<GSTexture12*>(sTex), sRect, static_cast<GSTexture12*>(dTex), dRect,
+		m_present[static_cast<int>(shader)].get(), linear);
 }
 
 void GSDevice12::BeginRenderPassForStretchRect(GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc)
@@ -1132,17 +1142,6 @@ bool GSDevice12::CompileConvertPipelines()
 
 		D3D12::SetObjectNameFormatted(m_convert[index].get(), "Convert pipeline %d", i);
 
-		if (/*swapchain && */ IsPresentConvertShader(i))
-		{
-			// TODO: compile a present variant too
-			gpb.SetRenderTarget(0, DXGI_FORMAT_R8G8B8A8_UNORM);
-			m_present[index] = gpb.Create(g_d3d12_context->GetDevice(), m_shader_cache, false);
-			if (!m_present[index])
-				return false;
-
-			D3D12::SetObjectNameFormatted(m_present[index].get(), "Convert pipeline %d (Present)", i);
-		}
-
 		if (i == ShaderConvert::COPY)
 		{
 			// compile the variant for setting up hdr rendering
@@ -1213,6 +1212,50 @@ bool GSDevice12::CompileConvertPipelines()
 
 			D3D12::SetObjectNameFormatted(m_date_image_setup_pipelines[ds][datm].get(), "DATE image clear pipeline (ds=%u, datm=%u)", ds, datm);
 		}
+	}
+
+	return true;
+}
+
+bool GSDevice12::CompilePresentPipelines()
+{
+	std::optional<std::string> shader = Host::ReadResourceFileToString("shaders/dx11/present.fx");
+	if (!shader)
+	{
+		Host::ReportErrorAsync("GS", "Failed to read shaders/dx11/present.fx.");
+		return false;
+	}
+
+	ComPtr<ID3DBlob> m_convert_vs = GetUtilityVertexShader(*shader, "vs_main");
+	if (!m_convert_vs)
+		return false;
+
+	D3D12::GraphicsPipelineBuilder gpb;
+	gpb.SetRootSignature(m_utility_root_signature.get());
+	AddUtilityVertexAttributes(gpb);
+	gpb.SetNoCullRasterizationState();
+	gpb.SetNoBlendingState();
+	gpb.SetVertexShader(m_convert_vs.get());
+	gpb.SetDepthState(false, false, D3D12_COMPARISON_FUNC_ALWAYS);
+	gpb.SetNoStencilState();
+	gpb.SetRenderTarget(0, DXGI_FORMAT_R8G8B8A8_UNORM);
+
+	for (PresentShader i = PresentShader::COPY; static_cast<int>(i) < static_cast<int>(PresentShader::Count);
+		 i = static_cast<PresentShader>(static_cast<int>(i) + 1))
+	{
+		const int index = static_cast<int>(i);
+
+		ComPtr<ID3DBlob> ps(GetUtilityPixelShader(*shader, shaderName(i)));
+		if (!ps)
+			return false;
+
+		gpb.SetPixelShader(ps.get());
+
+		m_present[index] = gpb.Create(g_d3d12_context->GetDevice(), m_shader_cache, false);
+		if (!m_present[index])
+			return false;
+
+		D3D12::SetObjectNameFormatted(m_present[index].get(), "Present pipeline %d", i);
 	}
 
 	return true;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -114,7 +114,7 @@ public:
 		NUM_TFX_SAMPLERS = 2,
 		NUM_UTILITY_TEXTURES = 1,
 		NUM_UTILITY_SAMPLERS = 1,
-		CONVERT_PUSH_CONSTANTS_SIZE = 32,
+		CONVERT_PUSH_CONSTANTS_SIZE = 96,
 
 		VERTEX_BUFFER_SIZE = 32 * 1024 * 1024,
 		INDEX_BUFFER_SIZE = 16 * 1024 * 1024,
@@ -154,7 +154,7 @@ private:
 	std::unordered_map<u32, D3D12::DescriptorHandle> m_samplers;
 
 	std::array<ComPtr<ID3D12PipelineState>, static_cast<int>(ShaderConvert::Count)> m_convert{};
-	std::array<ComPtr<ID3D12PipelineState>, static_cast<int>(ShaderConvert::Count)> m_present{};
+	std::array<ComPtr<ID3D12PipelineState>, static_cast<int>(PresentShader::Count)> m_present{};
 	std::array<ComPtr<ID3D12PipelineState>, 16> m_color_copy{};
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_merge{};
 	std::array<ComPtr<ID3D12PipelineState>, 4> m_interlace{};
@@ -205,6 +205,7 @@ private:
 	bool CreateRootSignatures();
 
 	bool CompileConvertPipelines();
+	bool CompilePresentPipelines();
 	bool CompileInterlacePipelines();
 	bool CompileMergePipelines();
 	bool CompilePostProcessingPipelines();
@@ -254,6 +255,8 @@ public:
 		ShaderConvert shader = ShaderConvert::COPY, bool linear = true) override;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red,
 		bool green, bool blue, bool alpha) override;
+	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
+		PresentShader shader, float shaderTime, bool linear);
 
 	void BeginRenderPassForStretchRect(GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc);
 	void DoStretchRect(GSTexture12* sTex, const GSVector4& sRect, GSTexture12* dTex, const GSVector4& dRect,

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -228,7 +228,7 @@ public:
 
 	// Functions and Pipeline States
 	MRCOwned<id<MTLRenderPipelineState>> m_convert_pipeline[static_cast<int>(ShaderConvert::Count)];
-	MRCOwned<id<MTLRenderPipelineState>> m_present_pipeline[static_cast<int>(ShaderConvert::Count)];
+	MRCOwned<id<MTLRenderPipelineState>> m_present_pipeline[static_cast<int>(PresentShader::Count)];
 	MRCOwned<id<MTLRenderPipelineState>> m_convert_pipeline_copy[2];
 	MRCOwned<id<MTLRenderPipelineState>> m_convert_pipeline_copy_mask[1 << 4];
 	MRCOwned<id<MTLRenderPipelineState>> m_merge_pipeline[4];
@@ -356,6 +356,7 @@ public:
 	void RenderCopy(GSTexture* sTex, id<MTLRenderPipelineState> pipeline, const GSVector4i& rect);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader = ShaderConvert::COPY, bool linear = true) override;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) override;
+	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) override;
 
 	void FlushClears(GSTexture* tex);
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -790,19 +790,11 @@ bool GSDeviceMTL::Create(HostDisplay* display)
 			NSString* name = [NSString stringWithCString:shaderName(conv) encoding:NSUTF8StringEncoding];
 			switch (conv)
 			{
+				case ShaderConvert::COPY:
 				case ShaderConvert::Count:
 				case ShaderConvert::DATM_0:
 				case ShaderConvert::DATM_1:
 				case ShaderConvert::MOD_256:
-					continue;
-				case ShaderConvert::COPY:
-				case ShaderConvert::SCANLINE:
-				case ShaderConvert::DIAGONAL_FILTER:
-				case ShaderConvert::TRIANGULAR_FILTER:
-				case ShaderConvert::COMPLEX_FILTER:
-					pdesc.colorAttachments[0].pixelFormat = layer_px_fmt;
-					pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
-					m_present_pipeline[i] = MakePipeline(pdesc, vs_convert, LoadShader(name), [NSString stringWithFormat:@"present_%s", shaderName(conv) + 3]);
 					continue;
 				case ShaderConvert::FLOAT32_TO_32_BITS:
 					pdesc.colorAttachments[0].pixelFormat = ConvertPixelFormat(GSTexture::Format::UInt32);
@@ -833,6 +825,13 @@ bool GSDeviceMTL::Create(HostDisplay* display)
 			m_convert_pipeline[i] = MakePipeline(pdesc, vs_convert, LoadShader(name), name);
 		}
 		pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
+		for (size_t i = 0; i < std::size(m_present_pipeline); i++)
+		{
+			PresentShader conv = static_cast<PresentShader>(i);
+			NSString* name = [NSString stringWithCString:shaderName(conv) encoding:NSUTF8StringEncoding];
+			pdesc.colorAttachments[0].pixelFormat = layer_px_fmt;
+			m_present_pipeline[i] = MakePipeline(pdesc, vs_convert, LoadShader(name), [NSString stringWithFormat:@"present_%s", shaderName(conv) + 3]);
+		}
 		pdesc.colorAttachments[0].pixelFormat = ConvertPixelFormat(GSTexture::Format::Color);
 		m_convert_pipeline_copy[0] = MakePipeline(pdesc, vs_convert, ps_copy, @"copy_color");
 		pdesc.colorAttachments[0].pixelFormat = ConvertPixelFormat(GSTexture::Format::FloatColor);
@@ -1052,16 +1051,6 @@ void GSDeviceMTL::RenderCopy(GSTexture* sTex, id<MTLRenderPipelineState> pipelin
 
 void GSDeviceMTL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader, bool linear)
 { @autoreleasepool {
-	if (!dTex)
-	{
-		// !dTex → "Present with the current draw encoder"
-		[m_current_render.encoder setRenderPipelineState:m_present_pipeline[static_cast<int>(shader)]];
-		[m_current_render.encoder setFragmentSamplerState:m_sampler_hw[linear ? SamplerSelector::Linear().key : SamplerSelector::Point().key] atIndex:0];
-		[m_current_render.encoder setFragmentTexture:static_cast<GSTextureMTL*>(sTex)->GetTexture() atIndex:0];
-		DrawStretchRect(sRect, dRect, GSVector2i(m_display->GetWindowWidth(), m_display->GetWindowHeight()));
-		return;
-	}
-
 	id<MTLRenderPipelineState> pipeline;
 	if (shader == ShaderConvert::COPY)
 		pipeline = m_convert_pipeline_copy[dTex->GetFormat() == GSTexture::Format::Color ? 0 : 1];
@@ -1085,6 +1074,40 @@ void GSDeviceMTL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	id<MTLRenderPipelineState> pipeline = m_convert_pipeline_copy_mask[sel];
 
 	DoStretchRect(sTex, sRect, dTex, dRect, pipeline, false, sel == 15 ? LoadAction::DontCareIfFull : LoadAction::Load, nullptr, 0);
+}}
+
+static_assert(sizeof(DisplayConstantBuffer) == sizeof(GSMTLPresentPSUniform));
+static_assert(offsetof(DisplayConstantBuffer, SourceRect)          == offsetof(GSMTLPresentPSUniform, source_rect));
+static_assert(offsetof(DisplayConstantBuffer, TargetRect)          == offsetof(GSMTLPresentPSUniform, target_rect));
+static_assert(offsetof(DisplayConstantBuffer, TargetSize)          == offsetof(GSMTLPresentPSUniform, target_size));
+static_assert(offsetof(DisplayConstantBuffer, TargetResolution)    == offsetof(GSMTLPresentPSUniform, target_resolution));
+static_assert(offsetof(DisplayConstantBuffer, RcpTargetResolution) == offsetof(GSMTLPresentPSUniform, rcp_target_resolution));
+static_assert(offsetof(DisplayConstantBuffer, SourceResolution)    == offsetof(GSMTLPresentPSUniform, source_resolution));
+static_assert(offsetof(DisplayConstantBuffer, RcpSourceResolution) == offsetof(GSMTLPresentPSUniform, rcp_source_resolution));
+static_assert(offsetof(DisplayConstantBuffer, TimeAndPad.x)        == offsetof(GSMTLPresentPSUniform, time));
+
+void GSDeviceMTL::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear)
+{ @autoreleasepool {
+	GSVector2i ds = dTex ? dTex->GetSize() : GSVector2i(m_display->GetWindowWidth(), m_display->GetWindowHeight());
+	DisplayConstantBuffer cb;
+	cb.SetSource(sRect, sTex->GetSize());
+	cb.SetTarget(dRect, ds);
+	cb.SetTime(shaderTime);
+	id<MTLRenderPipelineState> pipe = m_present_pipeline[static_cast<int>(shader)];
+
+	if (dTex)
+	{
+		DoStretchRect(sTex, sRect, dTex, dRect, pipe, linear, LoadAction::DontCareIfFull, &cb, sizeof(cb));
+	}
+	else
+	{
+		// !dTex → Use current draw encoder
+		[m_current_render.encoder setRenderPipelineState:pipe];
+		[m_current_render.encoder setFragmentSamplerState:m_sampler_hw[linear ? SamplerSelector::Linear().key : SamplerSelector::Point().key] atIndex:0];
+		[m_current_render.encoder setFragmentTexture:static_cast<GSTextureMTL*>(sTex)->GetTexture() atIndex:0];
+		[m_current_render.encoder setFragmentBytes:&cb length:sizeof(cb) atIndex:GSMTLBufferIndexUniforms];
+		DrawStretchRect(sRect, dRect, ds);
+	}
 }}
 
 void GSDeviceMTL::FlushClears(GSTexture* tex)

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -39,6 +39,19 @@ struct GSMTLConvertPSUniform
 	int emodc;
 };
 
+struct GSMTLPresentPSUniform
+{
+	vector_float4 source_rect;
+	vector_float4 target_rect;
+	vector_float2 source_size;
+	vector_float2 target_size;
+	vector_float2 target_resolution;
+	vector_float2 rcp_target_resolution; ///< 1 / target_resolution
+	vector_float2 source_resolution;
+	vector_float2 rcp_source_resolution; ///< 1 / source_resolution
+	float time;
+};
+
 struct GSMTLInterlacePSUniform
 {
 	vector_float2 ZrH;

--- a/pcsx2/GS/Renderers/Metal/present.metal
+++ b/pcsx2/GS/Renderers/Metal/present.metal
@@ -1,0 +1,80 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GSMTLShaderCommon.h"
+
+using namespace metal;
+
+// use vs_convert from convert.metal
+
+static float4 ps_crt(float4 color, int i)
+{
+	constexpr float4 mask[4] =
+	{
+		float4(1, 0, 0, 0),
+		float4(0, 1, 0, 0),
+		float4(0, 0, 1, 0),
+		float4(1, 1, 1, 0),
+	};
+
+	return color * saturate(mask[i] + 0.5f);
+}
+
+static float4 ps_scanlines(float4 color, int i)
+{
+	constexpr float4 mask[2] =
+	{
+		float4(1, 1, 1, 0),
+		float4(0, 0, 0, 0)
+	};
+
+	return color * saturate(mask[i] + 0.5f);
+}
+
+// use ps_copy from convert.metal
+
+fragment float4 ps_filter_scanlines(ConvertShaderData data [[stage_in]], ConvertPSRes res)
+{
+	return ps_scanlines(res.sample(data.t), uint(data.p.y) % 2);
+}
+
+fragment float4 ps_filter_diagonal(ConvertShaderData data [[stage_in]], ConvertPSRes res)
+{
+	uint4 p = uint4(data.p);
+	return ps_crt(res.sample(data.t), (p.x + (p.y % 3)) % 3);
+}
+
+fragment float4 ps_filter_triangular(ConvertShaderData data [[stage_in]], ConvertPSRes res)
+{
+	uint4 p = uint4(data.p);
+	uint val = ((p.x + ((p.y >> 1) & 1) * 3) >> 1) % 3;
+	return ps_crt(res.sample(data.t), val);
+}
+
+fragment float4 ps_filter_complex(ConvertShaderData data [[stage_in]], ConvertPSRes res)
+{
+	float2 texdim = float2(res.texture.get_width(), res.texture.get_height());
+
+	if (dfdy(data.t.y) * texdim.y > 0.5)
+	{
+		return res.sample(data.t);
+	}
+	else
+	{
+		float factor = (0.9f - 0.4f * cos(2.f * M_PI_F * data.t.y * texdim.y));
+		float ycoord = (floor(data.t.y * texdim.y) + 0.5f) / texdim.y;
+		return factor * res.sample(float2(data.t.x, ycoord));
+	}
+}

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -255,6 +255,8 @@ private:
 		GSDepthStencilOGL* dss_write = nullptr;
 	} m_convert;
 
+	GL::Program m_present[static_cast<int>(PresentShader::Count)];
+
 	struct
 	{
 		GL::Program ps;
@@ -354,6 +356,7 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, bool linear = true);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha) final;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GL::Program& ps, bool alpha_blend, OMColorMaskSelector cms, bool linear = true);
+	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) final;
 
 	void RenderHW(GSHWDrawConfig& config) final;
 	void SendHWDraw(const GSHWDrawConfig& config, bool needs_barrier);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -77,7 +77,7 @@ public:
 		NUM_TFX_TEXTURES = NUM_TFX_SAMPLERS + NUM_TFX_RT_TEXTURES,
 		NUM_CONVERT_TEXTURES = 1,
 		NUM_CONVERT_SAMPLERS = 1,
-		CONVERT_PUSH_CONSTANTS_SIZE = 32,
+		CONVERT_PUSH_CONSTANTS_SIZE = 96,
 
 		VERTEX_BUFFER_SIZE = 32 * 1024 * 1024,
 		INDEX_BUFFER_SIZE = 16 * 1024 * 1024,
@@ -116,7 +116,7 @@ private:
 	std::unordered_map<u32, VkSampler> m_samplers;
 
 	std::array<VkPipeline, static_cast<int>(ShaderConvert::Count)> m_convert{};
-	std::array<VkPipeline, static_cast<int>(ShaderConvert::Count)> m_present{};
+	std::array<VkPipeline, static_cast<int>(PresentShader::Count)> m_present{};
 	std::array<VkPipeline, 16> m_color_copy{};
 	std::array<VkPipeline, 2> m_merge{};
 	std::array<VkPipeline, 4> m_interlace{};
@@ -177,6 +177,7 @@ private:
 	bool CreateRenderPasses();
 
 	bool CompileConvertPipelines();
+	bool CompilePresentPipelines();
 	bool CompileInterlacePipelines();
 	bool CompileMergePipelines();
 	bool CompilePostProcessingPipelines();
@@ -229,6 +230,8 @@ public:
 		ShaderConvert shader = ShaderConvert::COPY, bool linear = true) override;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red,
 		bool green, bool blue, bool alpha) override;
+	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
+		PresentShader shader, float shaderTime, bool linear) override;
 
 	void BeginRenderPassForStretchRect(GSTextureVK* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc);
 	void DoStretchRect(GSTextureVK* sTex, const GSVector4& sRect, GSTextureVK* dTex, const GSVector4& dRect,


### PR DESCRIPTION
### Description of Changes

Splits the presentation shaders (filters) out of the convert shader pack, and adds resolution-related uniforms (needed for CRT shaders).

TODO: Define the uniform buffer in Metal, test Metal.

### Rationale behind Changes

This is just a bit of stop-gap measure to allow other shaders to be added, until I have the time/motivation to integrate reshade into PCSX2.

### Suggested Testing Steps

Test post shaders on all APIs.