### PR TITLE
IPU: Set ECD if start code is not 1xx

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12435,6 +12435,7 @@ SLES-51914:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
+    disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
 SLES-51915:
   name: "Pro Evolution Soccer 3"
   region: "PAL-I"
@@ -21227,6 +21228,7 @@ SLKA-25093:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
+    disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
 SLKA-25100:
   name: "Dragon Quest V Dragon Quarter"
   region: "NTSC-K"
@@ -25827,6 +25829,7 @@ SLPM-65413:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
+    disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
 SLPM-65414:
   name: "Simple 2000 Series Vol. 45 - The Koi to Namida to, Tsuioku to..."
   region: "NTSC-J"
@@ -39509,6 +39512,7 @@ SLUS-20694:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     roundSprite: 2 # Fixes various lines / reduces bars on right edge.
+    disablePartialInvalidation: 1 # Fixes textureless graphics ingame.
 SLUS-20695:
   name: "Chaos Legion"
   region: "NTSC-U"

--- a/pcsx2/IPU/mpeg2lib/Mpeg.cpp
+++ b/pcsx2/IPU/mpeg2lib/Mpeg.cpp
@@ -938,13 +938,20 @@ finish_idec:
 					return false;
 				}
 				start_check = UBITS(24);
-				if (start_check == 1)
+				if (start_check != 0)
 				{
-					ipuRegs.ctrl.SCD = 1;
+					if (start_check == 1)
+					{
+						ipuRegs.ctrl.SCD = 1;
+					}
+					else
+					{
+						ipuRegs.ctrl.ECD = 1;
+					}
 					break;
 				}
 				DUMPBITS(8);
-			} while (start_check != 1);
+			} while (1);
 		}
 	}
 		[[fallthrough]];
@@ -1229,13 +1236,20 @@ __fi bool mpeg2_slice()
 					return false;
 				}
 				start_check = UBITS(24);
-				if (start_check == 1)
+				if (start_check != 0)
 				{
-					ipuRegs.ctrl.SCD = 1;
+					if (start_check == 1)
+					{
+						ipuRegs.ctrl.SCD = 1;
+					}
+					else
+					{
+						ipuRegs.ctrl.ECD = 1;
+					}
 					break;
 				}
 				DUMPBITS(8);
-			} while (start_check != 1);
+			} while (1);
 		}
 	}
 		[[fallthrough]];


### PR DESCRIPTION
### Description of Changes
Onimusha 3 send 0x200 and expect that start code search finish on it.
Setting ECD here helps The Sims Bustin' Out

### Rationale behind Changes
Trying to fix regression after #6270

### Suggested Testing Steps
Test FMVs. Look for artifacts, freezes, skipping, etc. Test Onimusha games, it seems that Capcom decided that every game from series need to have different quirk in IPU decoding..