### PR TITLE
Qt: Avoid spamming resize events on paint

### DIFF
--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -34,7 +34,7 @@ public:
 	int scaledWindowHeight() const;
 	qreal devicePixelRatioFromScreen() const;
 
-	std::optional<WindowInfo> getWindowInfo() const;
+	std::optional<WindowInfo> getWindowInfo();
 
 	void setRelativeMode(bool enabled);
 
@@ -55,6 +55,10 @@ private:
 	QPoint m_relative_mouse_last_position{};
 	bool m_relative_mouse_enabled = false;
 	std::vector<int> m_keys_pressed_with_modifiers;
+
+	u32 m_last_window_width = 0;
+	u32 m_last_window_height = 0;
+	float m_last_window_scale = 1.0f;
 };
 
 class DisplayContainer final : public QStackedWidget


### PR DESCRIPTION
### Description of Changes

This caused long freezes on Windows when you dragged the window around, because it was sending a paint event for every movement, as it would repeatedly resize the swap chain.

### Rationale behind Changes

Regression from the Mac Qt PR, in particular the DPI change handling.

### Suggested Testing Steps

Test dragging a window around with Vulkan, make sure it doesn't lag (checked myself). Check resizing works as expected.
