### PR TITLE
Qt: Force game list column resize on window show

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -52,6 +52,7 @@ public:
 	__fi GameListModel* getModel() const { return m_model; }
 
 	void initialize();
+	void resizeTableViewColumnsToFit();
 
 	void refresh(bool invalidate_cache);
 	void cancelRefresh();
@@ -97,7 +98,6 @@ protected:
 	void resizeEvent(QResizeEvent* event);
 
 private:
-	void resizeTableViewColumnsToFit();
 	void loadTableViewColumnVisibilitySettings();
 	void saveTableViewColumnVisibilitySettings();
 	void saveTableViewColumnVisibilitySettings(int column);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1400,6 +1400,17 @@ void MainWindow::onPerformanceMetricsUpdated(const QString& fps_stat, const QStr
 	m_status_gs_widget->setText(gs_stat);
 }
 
+void MainWindow::showEvent(QShowEvent* event)
+{
+	QMainWindow::showEvent(event);
+
+	// This is a bit silly, but for some reason resizing *before* the window is shown
+	// gives the incorrect sizes for columns, if you set the style before setting up
+	// the rest of the window... so, instead, let's just force it to be resized on show.
+	if (isShowingGameList())
+		m_game_list_widget->resizeTableViewColumnsToFit();
+}
+
 void MainWindow::closeEvent(QCloseEvent* event)
 {
 	if (!requestShutdown(true, true, true))

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -156,6 +156,7 @@ private Q_SLOTS:
 	void recreate();
 
 protected:
+	void showEvent(QShowEvent* event) override;
 	void closeEvent(QCloseEvent* event) override;
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dropEvent(QDropEvent* event) override;


### PR DESCRIPTION
### Description of Changes

Fixes a regression from dbfb93a50f0ea1008acff2d1522e6a470a23a03c where the game list columns would always be too short on open.

### Suggested Testing Steps

Test opening window, ensure columns are correct size.
