### PR TITLE
HostDisplay: Create swap chain in CreateRenderDevice() for D3D

### DIFF
--- a/pcsx2/Frontend/D3D11HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D11HostDisplay.cpp
@@ -320,14 +320,15 @@ bool D3D11HostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view
 
 	m_window_info = wi;
 	m_vsync_mode = vsync;
+
+	if (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain(nullptr))
+		return false;
+
 	return true;
 }
 
 bool D3D11HostDisplay::InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device)
 {
-	if (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain(nullptr))
-		return false;
-
 	return true;
 }
 

--- a/pcsx2/Frontend/D3D12HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D12HostDisplay.cpp
@@ -191,14 +191,15 @@ bool D3D12HostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view
 	}
 
 	m_window_info = wi;
+
+	if (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain(nullptr))
+		return false;
+
 	return true;
 }
 
 bool D3D12HostDisplay::InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device)
 {
-	if (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain(nullptr))
-		return false;
-
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes

Fixes starting in exclusive fullscreen mode in Qt.

### Rationale behind Changes

Fixes #6222 .

### Suggested Testing Steps

Test starting with exclusive fullscreen, ensure mode switch succeeds.
