### PR TITLE
GS: Be generous with the resolution for no-interlace patches

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -495,7 +495,10 @@ GSVector2i GSState::GetResolution()
 
 	GSVector2i resolution(VideoModeOffsets[videomode].x, VideoModeOffsets[videomode].y);
 
-	if (isinterlaced() && !m_regs->SMODE2.FFMD)
+	// The resolution of the framebuffer is double when in FRAME mode and interlaced.
+	// Also we need a special check because no-interlace patches like to render in the original height, but in non-interlaced mode
+	// which means it would normally go off the bottom of the screen. Advantages of emulation, i guess... Limited to Ignore Offsets + Deinterlacing = Off.
+	if ((isinterlaced() && !m_regs->SMODE2.FFMD) || (GSConfig.InterlaceMode == GSInterlaceMode::Off && !GSConfig.PCRTCOffsets))
 		resolution.y *= 2;
 
 	if (ignore_offset)


### PR DESCRIPTION
### Description of Changes
Allow the full normal height for PS2 games when no-interlacing patches are enabled.

### Rationale behind Changes
No-Interlacing patches are dumb and take advantage of the fact PCSX2 used to allow you to draw any height, resolution be damned. The theoretical height limit of an NTSC game in Progressive 240p mode is 224 pixels, but the games with patches will still try to render in 448, so since we now maintain the proper heights, it would get cut off.

So I have added a condition that if the deinterlace mode is set to Off (which is done automatically when a no-interlace patch is loaded) and Screen Offsets are disabled, it will allow the height to go to the full 448/480.

### Suggested Testing Steps
Test games with no-interlacing patches (if you know ones) make sure they display okay.

Fixes #6338
