### PR TITLE
GS: Correctly handle field/deinterlace for progressive/interlaced mode.

### DIFF
--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -96,7 +96,8 @@ struct SyncCounter
 //------------------------------------------------------------------
 #define FRAMERATE_NTSC			29.97 // frames per second
 
-#define SCANLINES_TOTAL_NTSC	525 // total number of scanlines
+#define SCANLINES_TOTAL_NTSC_I	525 // total number of scanlines (Interlaced)
+#define SCANLINES_TOTAL_NTSC_NI	526 // total number of scanlines (Interlaced)
 #define SCANLINES_VSYNC_NTSC	3   // scanlines that are used for syncing every half-frame
 #define SCANLINES_VRENDER_NTSC	240 // scanlines in a half-frame (because of interlacing)
 #define SCANLINES_VBLANK1_NTSC	19  // scanlines used for vblank1 (even interlace)
@@ -107,7 +108,8 @@ struct SyncCounter
 //------------------------------------------------------------------
 #define FRAMERATE_PAL			25.0// frames per second * 100 (25)
 
-#define SCANLINES_TOTAL_PAL		625 // total number of scanlines per frame
+#define SCANLINES_TOTAL_PAL_I	625 // total number of scanlines per frame (Interlaced)
+#define SCANLINES_TOTAL_PAL_NI	628 // total number of scanlines per frame (Not Interlaced)
 #define SCANLINES_VSYNC_PAL		5   // scanlines that are used for syncing every half-frame
 #define SCANLINES_VRENDER_PAL	288 // scanlines in a half-frame (because of interlacing)
 #define SCANLINES_VBLANK1_PAL	19  // scanlines used for vblank1 (even interlace)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -340,6 +340,12 @@ bool GSState::isinterlaced()
 	return !!m_regs->SMODE2.INT;
 }
 
+bool GSState::isReallyInterlaced()
+{
+	// The FIELD register only flips if the CMOD field in SMODE1 is set to anything but 0 and Front Porch bottom bit in SYNCV is set.
+	return (m_regs->SYNCV.VFP & 0x1) && m_regs->SMODE1.CMOD;
+}
+
 GSVideoMode GSState::GetVideoMode()
 {
 	// TODO: Get confirmation of videomode from SYSCALL ? not necessary but would be nice.

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -298,6 +298,7 @@ public:
 
 	bool IsEnabled(int i);
 	bool isinterlaced();
+	bool isReallyInterlaced();
 	bool IsAnalogue();
 
 	float GetTvRefreshRate();

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -327,7 +327,7 @@ bool GSRenderer::Merge(int field)
 		// Offset is not compatible with scanmsk, as scanmsk renders every other line, but at x7 the interlace offset will be 7 lines
 		const int offset = (m_scanmask_used || !m_regs->SMODE2.FFMD) ? 0 : (int)(tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
 
-		if (m_regs->SMODE2.INT && GSConfig.InterlaceMode != GSInterlaceMode::Off)
+		if (isReallyInterlaced() && GSConfig.InterlaceMode != GSInterlaceMode::Off)
 		{
 			const bool scanmask = m_scanmask_used && scanmask_frame && GSConfig.InterlaceMode == GSInterlaceMode::Automatic;
 


### PR DESCRIPTION


### Description of Changes
Use the GS registers to detect if we're really in a progressive mode which ignores the field draw swapping or not, this is goverened by the CMOD field of the SMODE1 register and the lowest bit of VFP (Vertical Front Porch) of the SYNCV register.  This was tested on a PS2.
Also correct the number of scanlines for progressive (double strike) modes and how long the V-Blank period is.

### Rationale behind Changes
While it wasn't really wrong (for games using gsSetCrt) some games make a mess of things and try to do them manually. So this handles it properly.  Example of this: FunSlower demo tries to set a double strike progressive mode, but doesn't set everything, so it's actually interlaced, before it would shake. but now it does not.

### Suggested Testing Steps
test games, especially those with progressive modes, make sure they don't do the bouncy bouncy or look worse in some way.
