### PR TITLE
Vulkan: Enforce 32 byte alignment for uploads

### DIFF
--- a/common/Align.h
+++ b/common/Align.h
@@ -73,4 +73,20 @@ namespace Common
 		value |= (value >> 16);
 		return value - (value >> 1);
 	}
+
+	template<typename T>
+	static constexpr __fi T NextPow2(T value)
+	{
+		if (value == static_cast<T>(0))
+			return 0;
+
+		value--;
+		value |= value >> 1;
+		value |= value >> 2;
+		value |= value >> 4;
+		value |= value >> 8;
+		value |= value >> 16;
+		value++;
+		return value;
+	}
 } // namespace Common

--- a/common/Vulkan/Context.cpp
+++ b/common/Vulkan/Context.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "common/Vulkan/Context.h"
+#include "common/Align.h"
 #include "common/Assertions.h"
 #include "common/Console.h"
 #include "common/StringUtil.h"
@@ -46,15 +47,17 @@ namespace Vulkan
 		vkGetPhysicalDeviceProperties(physical_device, &m_device_properties);
 		vkGetPhysicalDeviceMemoryProperties(physical_device, &m_device_memory_properties);
 
-		// Would any drivers be this silly? I hope not...
+		// We need this to be at least 32 byte aligned for AVX2 stores.
 		m_device_properties.limits.minUniformBufferOffsetAlignment =
-			std::max(m_device_properties.limits.minUniformBufferOffsetAlignment, static_cast<VkDeviceSize>(1));
+			std::max(m_device_properties.limits.minUniformBufferOffsetAlignment, static_cast<VkDeviceSize>(32));
 		m_device_properties.limits.minTexelBufferOffsetAlignment =
-			std::max(m_device_properties.limits.minTexelBufferOffsetAlignment, static_cast<VkDeviceSize>(1));
+			std::max(m_device_properties.limits.minTexelBufferOffsetAlignment, static_cast<VkDeviceSize>(32));
 		m_device_properties.limits.optimalBufferCopyOffsetAlignment =
-			std::max(m_device_properties.limits.optimalBufferCopyOffsetAlignment, static_cast<VkDeviceSize>(1));
+			std::max(m_device_properties.limits.optimalBufferCopyOffsetAlignment, static_cast<VkDeviceSize>(32));
 		m_device_properties.limits.optimalBufferCopyRowPitchAlignment =
-			std::max(m_device_properties.limits.optimalBufferCopyRowPitchAlignment, static_cast<VkDeviceSize>(1));
+			Common::NextPow2(std::max(m_device_properties.limits.optimalBufferCopyRowPitchAlignment, static_cast<VkDeviceSize>(32)));
+		m_device_properties.limits.bufferImageGranularity =
+			std::max(m_device_properties.limits.bufferImageGranularity, static_cast<VkDeviceSize>(32));
 	}
 
 	Context::~Context() = default;

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -99,23 +99,34 @@ namespace Vulkan
 		__fi const OptionalExtensions& GetOptionalExtensions() const { return m_optional_extensions; }
 
 		// Helpers for getting constants
-		__fi VkDeviceSize GetUniformBufferAlignment() const
+		__fi u32 GetUniformBufferAlignment() const
 		{
-			return m_device_properties.limits.minUniformBufferOffsetAlignment;
+			return static_cast<u32>(m_device_properties.limits.minUniformBufferOffsetAlignment);
 		}
-		__fi VkDeviceSize GetTexelBufferAlignment() const
+		__fi u32 GetTexelBufferAlignment() const
 		{
-			return m_device_properties.limits.minTexelBufferOffsetAlignment;
+			return static_cast<u32>(m_device_properties.limits.minTexelBufferOffsetAlignment);
 		}
-		__fi VkDeviceSize GetStorageBufferAlignment() const
+		__fi u32 GetStorageBufferAlignment() const
 		{
-			return m_device_properties.limits.minStorageBufferOffsetAlignment;
+			return static_cast<u32>(m_device_properties.limits.minStorageBufferOffsetAlignment);
 		}
-		__fi VkDeviceSize GetBufferImageGranularity() const
+		__fi u32 GetBufferImageGranularity() const
 		{
-			return m_device_properties.limits.bufferImageGranularity;
+			return static_cast<u32>(m_device_properties.limits.bufferImageGranularity);
 		}
-		__fi VkDeviceSize GetMaxImageDimension2D() const { return m_device_properties.limits.maxImageDimension2D; }
+		__fi u32 GetBufferCopyOffsetAlignment() const
+		{
+			return static_cast<u32>(m_device_properties.limits.optimalBufferCopyOffsetAlignment);
+		}
+		__fi u32 GetBufferCopyRowPitchAlignment() const
+		{
+			return static_cast<u32>(m_device_properties.limits.optimalBufferCopyRowPitchAlignment);
+		}
+		__fi u32 GetMaxImageDimension2D() const
+		{
+			return m_device_properties.limits.maxImageDimension2D;
+		}
 
 		// Creates a simple render pass.
 		__ri VkRenderPass GetRenderPass(VkFormat color_format, VkFormat depth_format,


### PR DESCRIPTION
### Description of Changes

It blows up on AVX2 stores on some drivers if we don't (e.g. AMD Linux).

### Rationale behind Changes

Fixes a possible crash on those drivers if uploads happen in a specific order which ends up with the upload buffer pointer being unaligned. Could also potentially improve performance due to using the drivers' hinted size, but I doubt anything measurable.

### Suggested Testing Steps

Test Vulkan renderer.
