### PR TITLE
IOP: Revert a change from #6267

### DIFF
--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -193,7 +193,7 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 
 			case 0x4:
 				ret = psxCounters[cntidx].mode;
-
+				PSXCNT_LOG("IOP Counter[%d] modeRead%d = %lx", cntidx, sizeof(T) * 8, ret);
 				// hmm!  The old code only did the following bitwise math for 16 bit reads.
 				// Logic indicates it should do the math consistently.  Question is,
 				// should it do the logic for both 16 and 32, or not do logic at all?
@@ -203,10 +203,12 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 
 			case 0x8:
 				ret = psxCounters[cntidx].target;
+				PSXCNT_LOG("IOP Counter[%d] targetRead%d = %lx", cntidx, sizeof(T), ret);
 			break;
 
 			case 0xa:
 				ret = psxCounters[cntidx].target >> 16;
+				PSXCNT_LOG("IOP Counter[%d] targetUpperRead%d = %lx", cntidx, sizeof(T), ret);
 			break;
 
 			default:


### PR DESCRIPTION
### Description of Changes
Think this was a misunderstanding of how the interrupts worked (was actually one shot)
Also tidied up some logging.

### Rationale behind Changes
I think the misunderstanding was due to the counter being in "One Shot" mode during our PS2 tests, which broke Virtual Fighter 2 since that uses "Repeat" mode and never clears the interrupt flags.

### Suggested Testing Steps
Probably not any because merge is going to go brrr (once the CI says it's happy)

Fixes #6356
