### PR TITLE
GameDB: upscale fixes, adding missing serials, name corrections, etc

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -88,6 +88,12 @@ CPCS-01005:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+CPCS-01020:
+  name: "Monster Hunter 2 [DX Hunters Box]"
+  region: "NTSC-J"
+  compat: 5
+  clampModes:
+    vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
 GUST-00009:
   name: "Mana Khemia - Alchemists of Al-Revis [Premium Box]"
   region: "NTSC-J"
@@ -554,6 +560,9 @@ SCAJ-20035:
 SCAJ-20037:
   name: "Monster Farm 4"
   region: "NTSC-Unk"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Corrects shadow misalignment.
 SCAJ-20038:
   name: "Arc the Lad - Twilight of the Spirits"
   region: "NTSC-Unk"
@@ -784,6 +793,8 @@ SCAJ-20089:
 SCAJ-20090:
   name: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SCAJ-20092:
   name: "Samurai Spirits Zero"
   region: "NTSC-Unk"
@@ -1079,6 +1090,8 @@ SCAJ-20152:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCAJ-20153:
   name: "Code Age Commanders"
   region: "NTSC-J"
@@ -1364,8 +1377,10 @@ SCAJ-30004:
   name: "Waga Ryuu o Miyo - Pride of the Dragon Peace"
   region: "NTSC-Unk"
 SCAJ-30005:
-  name: "Gacha Mecha Stadium Saru Battle"
+  name: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-Unk"
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SCAJ-30006:
   name: "Gran Turismo 4"
   region: "NTSC-Unk"
@@ -1481,6 +1496,8 @@ SCCS-40015:
 SCCS-40016:
   name: "Ape Escape - Pumped & Primed"
   region: "NTSC-C"
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SCCS-40017:
   name: "EyeToy - Play"
   region: "NTSC-C"
@@ -1593,6 +1610,14 @@ SCED-50463:
 SCED-50506:
   name: "Official PlayStation 2 Magazine Demo 12" # German
   region: "PAL-M5"
+SCED-50520:
+  name: "World Rally Championship [Demo]"
+  region: "PAL-E"
+  compat: 5
+  roundModes:
+    eeRoundMode: 0 # Fixes crash when using the Subaru.
+  gameFixes:
+    - EETimingHack # Fix in-game Freeze.
 SCED-50543:
   name: "Official PlayStation 2 Magazine Demo 12" # French
   region: "PAL-M5"
@@ -1952,6 +1977,14 @@ SCED-52092:
 SCED-52120:
   name: "Official PlayStation 2 Magazine Demo 55" # German
   region: "PAL-E-G"
+SCED-52141:
+  name: "WRC 3 [Demo]"
+  region: "NTSC-J"
+  compat: 5
+  gameFixes:
+    - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
 SCED-52160:
   name: "Official PlayStation 2 Magazine Demo 45"
   region: "PAL-M5"
@@ -2252,8 +2285,16 @@ SCED-53514:
 SCED-53515:
   name: "Bonus Demo 10 (Retail)"
   region: "PAL-M5"
+SCED-53622:
+  name: "24 - The Game [Demo]"
+  region: "PAL-M9"
+  clampModes:
+    vuClampMode: 2 # Fixes minimap HUD.
+  gsHWFixes:
+    autoFlush: 1 # Fixes pause menu backgrounds.
+    roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
 SCED-53679:
-  name: "Fire It Up Lads Demo"
+  name: "Fire It Up Lads [Demo]"
   region: "PAL-E"
   patches:
     default:
@@ -3066,6 +3107,8 @@ SCES-51684:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
 SCES-51685:
   name: "Primal"
   region: "PAL-E-R"
@@ -3538,6 +3581,7 @@ SCES-53358:
     vuClampMode: 2 # Fixes minimap HUD.
   gsHWFixes:
     autoFlush: 1 # Fixes pause menu backgrounds.
+    roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
 SCES-53372:
   name: "Tourist Trophy - The Real Riding Simulator"
   region: "PAL-M5"
@@ -3623,6 +3667,8 @@ SCES-53688:
   compat: 5
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCES-53795:
   name: "SingStar '80s"
   region: "PAL-Unk"
@@ -4642,6 +4688,13 @@ SCKA-20064:
   region: "NTSC-K"
   clampModes:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
+SCKA-20065:
+  name: "Urban Reign"
+  region: "NTSC-K"
+  gameFixes:
+    - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SCKA-20069:
   name: "Siren 2"
   region: "NTSC-K"
@@ -5303,6 +5356,8 @@ SCPS-15071:
 SCPS-15072:
   name: "Gacha Mecha Stadium - Saru Battle"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SCPS-15073:
   name: "EyeToy - Groove [with Camera]"
   region: "NTSC-J"
@@ -17155,9 +17210,16 @@ SLES-54002:
   name: "FlatOut 2"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 2 # Corrects most vertical lines.
 SLES-54003:
   name: "FlatOut 2"
   region: "PAL-G"
+  compat: 5
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 2 # Corrects most vertical lines.
 SLES-54004:
   name: "Disney-Pixar's Cars"
   region: "PAL-NL-P"
@@ -19811,6 +19873,8 @@ SLES-55132:
 SLES-55133:
   name: "LEGO Indiana Jones - The Original Adventure"
   region: "PAL-M6"
+  gsHWFixes:
+    halfPixelOffset: 1 # Corrects bloom misalignment.
 SLES-55134:
   name: "Monster Jam"
   region: "PAL-M5"
@@ -21834,6 +21898,13 @@ SLKA-25397:
   name: "Dragon Ball Z Sparking NEO"
   region: "NTSC-K"
   compat: 5
+SLKA-25401:
+  name: "FlatOut 2"
+  region: "NTSC-K"
+  compat: 5
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 2 # Corrects most vertical lines.
 SLKA-25406:
   name: "King of Fighters, The - Maximum Impact - Regulation A"
   region: "NTSC-K"
@@ -22392,6 +22463,13 @@ SLPM-60271:
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes black screen.
+SLPM-60272:
+  name: "Urban Reign [Trial]"
+  region: "NTSC-J"
+  gameFixes:
+    - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPM-60273:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial B]"
   region: "NTSC-J"
@@ -22818,12 +22896,8 @@ SLPM-62131:
   name: "Romance of the Three Kingdoms VIII"
   region: "NTSC-J"
 SLPM-62132:
-  name: "24 - The Game"
+  name: "Internet Othello - Othello World 24"
   region: "NTSC-J"
-  clampModes:
-    vuClampMode: 2 # Fixes minimap HUD.
-  gsHWFixes:
-    autoFlush: 1 # Fixes pause menu backgrounds.
 SLPM-62133:
   name: "Bloody Roar 3 [Konami The Best]"
   region: "NTSC-J"
@@ -26448,9 +26522,11 @@ SLPM-65582:
 SLPM-65583:
   name: "WRC 3"
   region: "NTSC-J"
-  compat: 4
+  compat: 5
   gameFixes:
-    - XGKickHack
+    - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
 SLPM-65585:
   name: "Princess Holiday"
   region: "NTSC-J"
@@ -28151,6 +28227,11 @@ SLPM-66102:
 SLPM-66103:
   name: "WRC 3 [Spike the Best]"
   region: "NTSC-J"
+  compat: 5
+  gameFixes:
+    - XGKickHack # Fixes SPS.
+  gsHWFixes:
+    roundSprite: 2 # Correct misaligned font, better aligns car shadow.
 SLPM-66104:
   name: "Puyo Puyo Fever 2"
   region: "NTSC-J"
@@ -29865,6 +29946,10 @@ SLPM-66590:
 SLPM-66591:
   name: "FlatOut 2 GTR"
   region: "NTSC-J"
+  compat: 5
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 2 # Corrects most vertical lines.
 SLPM-66592:
   name: "Negima! 3-Jikanme [Theater Version]"
   region: "NTSC-J"
@@ -33741,6 +33826,12 @@ SLPS-25262:
   name: "Private Nurse Maria"
   region: "NTSC-J"
   compat: 5
+SLPS-25263:
+  name: "Monster Farm 4"
+  region: "NTSC-J"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Corrects shadow misalignment.
 SLPS-25264:
   name: "RahXephon [Limited Edition]"
   region: "NTSC-J"
@@ -34807,6 +34898,8 @@ SLPS-25557:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPS-25558:
   name: "NeoGeo Battle Coliseum"
   region: "NTSC-J"
@@ -36763,6 +36856,9 @@ SLPS-73422:
 SLPS-73423:
   name: "Monster Farm 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Corrects shadow misalignment.
 SLPS-73424:
   name: "Guilty Gear XX [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -39702,6 +39798,8 @@ SLUS-20702:
   name: "Monster Rancher 4"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Corrects shadow misalignment.
 SLUS-20703:
   name: "Airforce - Delta Strike"
   region: "NTSC-U"
@@ -41538,6 +41636,8 @@ SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects fullscreen bloom misalignment.
 SLUS-21097:
   name: "MX World Tour featuring Jamie Little"
   region: "NTSC-U"
@@ -42079,7 +42179,7 @@ SLUS-21209:
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
   gsHWFixes:
-    alignSprite: 1 # Fixes black lines when upscaling.
+    alignSprite: 1 # Fixes vertical lines.
 SLUS-21212:
   name: "Spartan - Total Warrior"
   region: "NTSC-U"
@@ -42316,6 +42416,9 @@ SLUS-21251:
   name: "FlatOut 2"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 2 # Corrects most vertical lines.
 SLUS-21252:
   name: "SpongeBob SquarePants - Lights, Camera, PANTS!"
   region: "NTSC-U"
@@ -42411,6 +42514,7 @@ SLUS-21268:
     vuClampMode: 2 # Fixes minimap HUD.
   gsHWFixes:
     autoFlush: 1 # Fixes pause menu backgrounds.
+    roundSprite: 1 # Corrects proportions of fonts and pause-screen lines, adjusts display closer to software.
 SLUS-21269:
   name: "Bully"
   region: "NTSC-U"
@@ -44699,6 +44803,8 @@ SLUS-21759:
   name: "LEGO Indiana Jones - The Original Adventures"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Corrects bloom misalignment.
 SLUS-21760:
   name: "Jeep Thrills"
   region: "NTSC-U"


### PR DESCRIPTION
** HARDWARE UPSCALE FIXES **

[gs_20220606151947_Monster Rancher 4_SLUS-20702.gs.zip](https://github.com/PCSX2/pcsx2/files/8844396/gs_20220606151947_Monster.Rancher.4_SLUS-20702.gs.zip)
Monster Rancher 4 / Monster Farm 4: HPO Normal (Vertex) for shadow misalignment.

[gs_20220601223700_Ape_Escape_-_Pumped___Primed_SLUS-21096.zip](https://github.com/PCSX2/pcsx2/files/8844402/gs_20220601223700_Ape_Escape_-_Pumped___Primed_SLUS-21096.zip)
Ape Escape - Pumped & Primed / Gacha Mecha Stadium - Saru Battle: HPO Special (texture) for bloom misalignment. Name fix on Jap entry.

[gs_20220601225125_LEGO_Indiana_Jones_-_The_Original_Adventures_SLUS-21759.zip](https://github.com/PCSX2/pcsx2/files/8844405/gs_20220601225125_LEGO_Indiana_Jones_-_The_Original_Adventures_SLUS-21759.zip)
LEGO Indiana Jones - The Original Adventure: HPO Normal (Vertex) for bloom misalignment.

[gs_20220606131841_Urban Reign_SLUS-21209.gs.zip](https://github.com/PCSX2/pcsx2/files/8844409/gs_20220606131841_Urban.Reign_SLUS-21209.gs.zip)
Urban Reign: Align Sprite added to the rest of the serials, only one had it before.

[gs_20220606154153_24 - The Game_SLUS-21268.gs.zip](https://github.com/PCSX2/pcsx2/files/8844527/gs_20220606154153_24.-.The.Game_SLUS-21268.gs.zip)
24 - The Game: Round Sprite Half for proportion correction in fonts (primarily in HUD), pause-screen lines (less variance of thick/thin lines), display centering (closer to software) and *very very* minor ghosting corrected in DoF structures. 

[gs_20220606163014_FlatOut 2_SLES-54002.gs.zip](https://github.com/PCSX2/pcsx2/files/8846026/gs_20220606163014_FlatOut.2_SLES-54002.gs.zip)
FlatOut 2: Using HPO Special Texture to remove vertical lines on-screen (some from sprite backgrounds might remain) and better align bloom. Enforced Basic mipmap to correct textures on stands. They weren't wrong, but they were superbly noisy at full detail and would "shimmer". Now the textures behave like they should.

[gs_20220606184634_WRC 3_SCES-51684.gs.zip](https://github.com/PCSX2/pcsx2/files/8846058/gs_20220606184634_WRC.3_SCES-51684.gs.zip)
WRC 3: Using Round Sprite Full to correct cut-off text characters (only fixable when upscaling), remove fog line from the ground (half-bottom fog is still absent when facing uphill), remove vertical lines in sprites, and better align car shadow (requires HPO Normal Vertex for best alignment but that causes other issues, test in provided dump).

** DB ADDITIONS **
Monster Farm 4: Added missing SLPS-25263 to DB.
Monster Hunter 2: Added missing CPCS-01020 to DB. 
World Rally Championship: Added missing SCED-50520 to DB. 
Urban Reign: Added missing SCKA-20065 and SLPM-60272 to DB.
WRC 3: Added missing SCED-52141 to DB.
FlatOut 2: Added missing SLKA-25401 to DB.
24 - The Game: Added missing SCED-53622 to DB.


** DB CORRECTIONS **
SLPM-62132 was actually Internet Othello - Othello World 24.
Monster Farm 4: Corrected compat rating on the different serials (missing in some).
FlatOut 2: Corrected compat rating on the different serials (mismatching and missing in some).
WRC 3: Corrected compat rating on the different serials (mismatching, and missing in some).
Gacha Mecha Stadium - Saru Battle: Corrected a name (was lacking its dash).
Fire It Up Lads: Corrected Demo name (noticed from neighboring edit so eh).

I SHOULD HAVE FINALLY GOTTEN IT RIGHT, I HOPE TO DEAR GOD.