### PR TITLE
GS: Allow same src for DISPFB when using 32bit + 24bit

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -135,7 +135,7 @@ bool GSRenderer::Merge(int field)
 		en[0] && en[1] &&
 		m_regs->DISP[0].DISPFB.FBP == m_regs->DISP[1].DISPFB.FBP &&
 		m_regs->DISP[0].DISPFB.FBW == m_regs->DISP[1].DISPFB.FBW &&
-		m_regs->DISP[0].DISPFB.PSM == m_regs->DISP[1].DISPFB.PSM;
+		GSUtil::HasCompatibleBits(m_regs->DISP[0].DISPFB.PSM, m_regs->DISP[1].DISPFB.PSM);
 
 	GSVector2i fs(0, 0);
 	GSVector2i ds(0, 0);


### PR DESCRIPTION
### Description of Changes
Allow the PCRTC to register both displays as the same format if one is 32bit and the other is 24bit (same memory layout, PCRTC doesn't really care about alpha)

### Rationale behind Changes
Tenchu Fatal Shadows used the same display but in different (compatible) formats, offset slightly to blur the picture, this removes the blur.

### Suggested Testing Steps
Test games, make sure nothing is missing.
