### PR TITLE
GS/Vulkan: Fix uploading compressed replacement textures

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
@@ -79,6 +79,8 @@ public:
 
 private:
 	VkCommandBuffer GetCommandBufferForUpdate();
+	void CopyTextureDataForUpload(void* dst, const void* src, u32 pitch, u32 upload_pitch, u32 height) const;
+	VkBuffer AllocateUploadStagingBuffer(const void* data, u32 pitch, u32 upload_pitch, u32 height) const;
 
 	Vulkan::Texture m_texture;
 


### PR DESCRIPTION
### Description of Changes

Regression from https://github.com/PCSX2/pcsx2/commit/394f1f2049be14be49dcdf104ed5f18c55596bc2

### Rationale behind Changes

Crashing is bad.

### Suggested Testing Steps

Test loading replacement and normal textures (done).
