### PR TITLE
Save/Load States via hotkey in QT

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1696,6 +1696,38 @@ DEFINE_HOTKEY("LoadStateFromSlot", "Save States", "Load State From Selected Slot
 	if (!pressed)
 		VMManager::LoadStateFromSlot(s_current_save_slot);
 })
+
+#define DEFINE_HOTKEY_SAVESTATE_X(slotnum,slotnumstr) DEFINE_HOTKEY("SaveStateToSlot" #slotnum, \
+	"Save States", "Save State To Slot " #slotnumstr, [](bool pressed) { if (!pressed) VMManager::SaveStateToSlot(slotnum); })
+DEFINE_HOTKEY_SAVESTATE_X(1, 01)
+DEFINE_HOTKEY_SAVESTATE_X(2, 02)
+DEFINE_HOTKEY_SAVESTATE_X(3, 03)
+DEFINE_HOTKEY_SAVESTATE_X(4, 04)
+DEFINE_HOTKEY_SAVESTATE_X(5, 05)
+DEFINE_HOTKEY_SAVESTATE_X(6, 06)
+DEFINE_HOTKEY_SAVESTATE_X(7, 07)
+DEFINE_HOTKEY_SAVESTATE_X(8, 08)
+DEFINE_HOTKEY_SAVESTATE_X(9, 09)
+DEFINE_HOTKEY_SAVESTATE_X(10, 10)
+#define DEFINE_HOTKEY_LOADSTATE_X(slotnum, slotnumstr) DEFINE_HOTKEY("LoadStateFromSlot" #slotnum, \
+	"Save States", "Load State From Slot " #slotnumstr , [](bool pressed) { \
+		if (!pressed) \
+			VMManager::LoadStateFromSlot(slotnum); \
+	})
+DEFINE_HOTKEY_LOADSTATE_X(1, 01)
+DEFINE_HOTKEY_LOADSTATE_X(2, 02)
+DEFINE_HOTKEY_LOADSTATE_X(3, 03)
+DEFINE_HOTKEY_LOADSTATE_X(4, 04)
+DEFINE_HOTKEY_LOADSTATE_X(5, 05)
+DEFINE_HOTKEY_LOADSTATE_X(6, 06)
+DEFINE_HOTKEY_LOADSTATE_X(7, 07)
+DEFINE_HOTKEY_LOADSTATE_X(8, 08)
+DEFINE_HOTKEY_LOADSTATE_X(9, 09)
+DEFINE_HOTKEY_LOADSTATE_X(10, 10)
+
+#undef DEFINE_HOTKEY_SAVESTATE_X
+#undef DEFINE_HOTKEY_LOADSTATE_X
+
 END_HOTKEY_LIST()
 
 #ifdef _WIN32


### PR DESCRIPTION
QT: Adds the commands for loading/saving all numbered states via hotkeys, leaving them all unbound by default.

Addressing https://github.com/PCSX2/pcsx2/issues/6268.
