### PR TITLE
GameDB: Fix flag + add missing US serial

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11822,7 +11822,7 @@ SLES-51615:
   region: "PAL-M5"
 SLES-51616:
   name: "Virtua Fighter 4 Evolution"
-  region: "PAL-UM5"
+  region: "PAL-M5"
   compat: 5
 SLES-51617:
   name: "Starsky & Hutch"
@@ -44810,6 +44810,9 @@ SLUS-21776:
   name: "FIFA 2009"
   region: "NTSC-U"
   compat: 5
+SLUS-21777:
+  name: "NBA Live '09"
+  region: "NTSC-U"
 SLUS-21778:
   name: "Dokapon Kingdom"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Someone in the Discord said that they had the question mark flags for these 2 serials, 1 is Virtua Fighter 4 Evolution PAL which had a typo and another is NBA Live '09 NTSC version. Quite surprising to see a missing American release in the GameDB still.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
People don't like 
![image](https://user-images.githubusercontent.com/24227051/172639882-8b840228-45c5-4aff-b26a-d14ee3100d37.png)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games.