### PR TITLE
Common: Add assertion failure message to crashlogs

### DIFF
--- a/common/Exceptions.cpp
+++ b/common/Exceptions.cpp
@@ -138,7 +138,7 @@ void pxOnAssertFail(const char* file, int line, const char* func, const char* ms
 	fputs(full_msg, stderr);
 	fputs("\nAborting application.\n", stderr);
 	fflush(stderr);
-	abort();
+	AbortWithMessage(full_msg);
 #endif
 
 	ResumeThreads(handle);

--- a/common/General.h
+++ b/common/General.h
@@ -160,6 +160,8 @@ extern u64 GetPhysicalMemory();
 extern u32 ShortSpin();
 /// Number of ns to spin for before sleeping a thread
 extern const u32 SPIN_TIME_NS;
+/// Like C abort() but adds the given message to the crashlog
+[[noreturn]] void AbortWithMessage(const char* msg);
 
 extern std::string GetOSVersionString();
 


### PR DESCRIPTION
### Description of Changes
Adds the assertion failure message to crashlogs

### Rationale behind Changes
We generally request crashlogs from the macOS crash reporter when handling a user with a crashing PCSX2, and with the recent change removing the GUI dialog from assertion failure, it would be nice if we still got the messages.

### Suggested Testing Steps
~~Crash PCSX2 with an assertion failure~~Tested
