### PR TITLE
GameDB: SOCOM II: U.S NAVY SEALs NTSC Multi-Patch

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6977,6 +6977,19 @@ SCUS-97275:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
+  patches:
+    default:
+      Author: "NightFyre"
+      content: |-
+        author=Harry62
+        // r0001 Render Fix
+        // This will only be applied if the game is version r0001
+        patch=1,EE,D033CD68,extended,000000DB
+        patch=1,EE,2033CD68,extended,100000DB
+        // r0004 Render Fix
+        // This will only be applied if the game is version r0004
+        patch=1,EE,D035A2F8,extended,000000DB
+        patch=1,EE,2035A2F8,extended,100000DB
 SCUS-97276:
   name: "NFL GameDay 2004"
   region: "NTSC-U"


### PR DESCRIPTION
This is a GameDB patch that will apply based on the current running game version. SOCOM 2 has 2 internal patches that will shift the .text segment of data . This change also applies to the single player version of the game as there is no difference in game memory from Single Player to Multi - Player/LAN

**DESCRIPTION OF CHANGES**
SOCOM II has an active community that has been successful in reviving the online multiplayer portion of the game.
With that accomplishment brought upon some patches that needed to be applied to improve the games playability.

One of these patches is the "Render Fix" (Originally created by Harry62)

The  Render Fix adjusts the GameWorld brightness by patching an instruction in the PlayerEyeAdjustment Function. Without this patch the game is susceptible to severe slowdowns (as low as 5-10fps) on certain maps, both for the single player campaign as well as the online multiplayer component.

The online team has been successful in supplying a workaround for this by pushing this patch directly to the user by means of memory poke when the client establishes a connection. Unfortunately , they have not been so kind to provide this patch to community members who would like to play the single player campaign (or people who might not even want to play online and are stuck on the base version of the game).

Being that there is now 2 versions of SOCOM 2 out in the wild (r0001 & r0004) and the Render Fix being at a different address in memory per version, its has become increasingly difficult to provide an all official around fix. I originally intended to include the render fix with my last pull request but remembered that it would have potential issues and the last thing I wanted to do was disrupt the online service in any way.

Here is a video highlighting the problems encountered without the render fix being applied:
<p align="center">
 <video src="https://user-images.githubusercontent.com/80198020/172934613-2aae2171-c098-4ece-b33d-b5d7ef542bd1.mp4" alt="VIDEO">
</p>

**RATIONALE BEHIND CHANGES**
While the online portion of the game has received a lot of love, the same can't be said for the single player version of the game. I find this to be of a disservice to the greater PCSX2 community abroad as all of our findings should be shared and applied at a source level, but I'm going to assume they just didn't have a clue about how to provide the patch to everybody in a more efficient and official way. I've spent a long time trying to come up with a solution to this problem so that everybody can play the game , no matter the version and whether they are online or not, whilst engaging in an enjoyable experience.

**SUGGESTED TESTING STEPS**
Launch SOCOM 2 without a memory card and launch the single player campaign. Upon loading into the first mission a cutscene will ensue explaining the objectives for the mission ahead. Its during this brief intermission that we get our first glimpse of frame drops. After the cutscene ends and you gain control of your player, you will feel that the game is playing rather sluggishly even though the FPS counter will say the game is running at full speed. 

Upon applying the r0001 render fix the game will immediately start playing at full speed and you will be able to play the mission at a clean 60fps.

The very same can be said for the r0004 version of the game , however to get your hands on the patch you will first need install a memory card. Then connect to the online portion of the game to get the download prompt. Proceed with the original testing steps after the patch has been downloaded

**FINAL NOTES**
I've done the proper testing and can conclude that this works for both versions of the game WITHOUT applying both patches concurrently
Thanks to Refraction for giving me some solid information on how to go about applying such a patch.

<p align="center">
 <img src="https://user-images.githubusercontent.com/80198020/172933798-53b2a758-5968-4852-9ceb-f76c88050604.png" alt="SeperatePatches">
</p>

Supplied Patches:
//Render Fix r0001
2033CD68 100000DB     [106000DB]default

//Render Fix r0004
2035A2F8 100000DB     [106000DB]default