### PR TITLE
GS: Check whole state before flushing draws

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -212,9 +212,9 @@ void GSState::Reset(bool hardware_reset)
 	m_vertex.next = 0;
 	m_index.tail = 0;
 	m_scanmask_used = false;
+	m_dirty_gs_regs = 0;
+	m_backed_up_ctx = -1;
 
-	m_reg_draw_dirty = false;
-	m_reg_texture_dirty = false;
 	memcpy(&m_prev_env, &m_env, sizeof(m_prev_env));
 }
 
@@ -732,11 +732,11 @@ void GSState::DumpVertices(const std::string& filename)
 
 __inline void GSState::CheckFlushes()
 {
-	if (m_index.tail > 0)
+	if (m_dirty_gs_regs && m_index.tail > 0)
 	{
 		if (TestDrawChanged())
 		{
-			Flush(true);
+			Flush();
 		}
 	}
 
@@ -801,7 +801,9 @@ void GSState::GIFPackedRegHandlerUV_Hack(const GIFPackedReg* RESTRICT r)
 template <u32 prim, u32 adc, bool auto_flush, bool index_swap>
 void GSState::GIFPackedRegHandlerXYZF2(const GIFPackedReg* RESTRICT r)
 {
-	CheckFlushes();
+	const bool skip = adc ? 1 : r->XYZ2.Skip();
+	if (!skip)
+		CheckFlushes();
 
 	GSVector4i xy = GSVector4i::loadl(&r->U64[0]);
 	GSVector4i zf = GSVector4i::loadl(&r->U64[1]);
@@ -811,13 +813,15 @@ void GSState::GIFPackedRegHandlerXYZF2(const GIFPackedReg* RESTRICT r)
 
 	m_v.m[1] = xy.upl32(zf);
 
-	VertexKick<prim, auto_flush, index_swap>(adc ? 1 : r->XYZF2.Skip());
+	VertexKick<prim, auto_flush, index_swap>(skip);
 }
 
 template <u32 prim, u32 adc, bool auto_flush, bool index_swap>
 void GSState::GIFPackedRegHandlerXYZ2(const GIFPackedReg* RESTRICT r)
 {
-	CheckFlushes();
+	const bool skip = adc ? 1 : r->XYZ2.Skip();
+	if(!skip)
+		CheckFlushes();
 
 	const GSVector4i xy = GSVector4i::loadl(&r->U64[0]);
 	const GSVector4i z = GSVector4i::loadl(&r->U64[1]);
@@ -825,7 +829,7 @@ void GSState::GIFPackedRegHandlerXYZ2(const GIFPackedReg* RESTRICT r)
 
 	m_v.m[1] = xyz.upl64(GSVector4i::loadl(&m_v.UV));
 
-	VertexKick<prim, auto_flush, index_swap>(adc ? 1 : r->XYZ2.Skip());
+	VertexKick<prim, auto_flush, index_swap>(skip);
 }
 
 void GSState::GIFPackedRegHandlerFOG(const GIFPackedReg* RESTRICT r)
@@ -919,7 +923,6 @@ void GSState::GIFRegHandlerNull(const GIFReg* RESTRICT r)
 
 __forceinline void GSState::ApplyPRIM(u32 prim)
 {
-
 	if (m_env.PRMODECONT.AC == 1)
 	{
 		m_env.PRIM.U32[0] = prim;
@@ -927,11 +930,12 @@ __forceinline void GSState::ApplyPRIM(u32 prim)
 		UpdateContext();
 	}
 	else
-	{
 		m_env.PRIM.PRIM = prim & 0x7;
-	}
 
-	m_reg_draw_dirty = true;
+	if (m_prev_env.PRIM.U32[0] ^ m_env.PRIM.U32[0])
+		m_dirty_gs_regs |= (1 << DIRTY_REG_PRIM);
+	else
+		m_dirty_gs_regs &= ~(1<< DIRTY_REG_PRIM);
 
 	UpdateVertexKick();
 
@@ -1026,9 +1030,6 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 	// extremely broken for the same reasons as MLB Power Pros in that it spams TEX0 with
 	// complete garbage making for a nice 1G heap of GSOffset.
 
-	m_reg_texture_dirty = true;
-	m_reg_draw_dirty = true;
-
 	GL_REG("Apply TEX0_%d = 0x%x_%x", i, TEX0.U32[1], TEX0.U32[0]);
 
 	// even if TEX0 did not change, a new palette may have been uploaded and will overwrite the currently queued for drawing
@@ -1036,10 +1037,8 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 
 	// clut loading already covered with WriteTest, for drawing only have to check CPSM and CSA (MGS3 intro skybox would be drawn piece by piece without this)
 
-	constexpr u64 mask = 0x1f78001fffffffffull; // TBP0 TBW PSM TW TH TCC TFX CPSM CSA
-
-	if (wt && (TEX0.PSM & 0x30))
-		Flush(true);
+	if (wt)
+		Flush();
 
 	TEX0.CPSM &= 0xa; // 1010b
 
@@ -1090,6 +1089,15 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 		}
 
 		m_mem.m_clut.Write(m_env.CTXT[i].TEX0, m_env.TEXCLUT);
+	}
+
+	constexpr u64 mask = 0x1f78001fffffffffull; // TBP0 TBW PSM TW TH TCC TFX CPSM CSA
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if ((m_prev_env.CTXT[i].TEX0.U64 ^ m_env.CTXT[i].TEX0.U64) & mask)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_TEX0);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_TEX0);
 	}
 }
 
@@ -1161,7 +1169,17 @@ void GSState::GIFRegHandlerTEX0(const GIFReg* RESTRICT r)
 	ApplyTEX0<i>(TEX0);
 
 	if (MTBAReloaded)
+	{
 		m_env.CTXT[i].MIPTBP1 = temp_MIPTBP1;
+
+		if (i == m_prev_env.PRIM.CTXT)
+		{
+			if (m_prev_env.CTXT[i].MIPTBP1.U64 ^ m_env.CTXT[i].MIPTBP1.U64)
+				m_dirty_gs_regs |= (1 << DIRTY_REG_MIPTBP1);
+			else
+				m_dirty_gs_regs &= ~(1 << DIRTY_REG_MIPTBP1);
+		}
+	}
 }
 
 template <int i>
@@ -1169,10 +1187,15 @@ void GSState::GIFRegHandlerCLAMP(const GIFReg* RESTRICT r)
 {
 	GL_REG("CLAMP_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	m_reg_texture_dirty = true;
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].CLAMP = (GSVector4i)r->CLAMP;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].CLAMP.U64 ^ m_env.CTXT[i].CLAMP.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_CLAMP);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_CLAMP);
+	}
 }
 
 void GSState::GIFRegHandlerFOG(const GIFReg* RESTRICT r)
@@ -1189,10 +1212,15 @@ void GSState::GIFRegHandlerTEX1(const GIFReg* RESTRICT r)
 {
 	GL_REG("TEX1_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	m_reg_texture_dirty = true;
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].TEX1 = (GSVector4i)r->TEX1;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].TEX1.U64 ^ m_env.CTXT[i].TEX1.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_TEX1);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_TEX1);
+	}
 }
 
 template <int i>
@@ -1222,9 +1250,15 @@ void GSState::GIFRegHandlerXYOFFSET(const GIFReg* RESTRICT r)
 
 	const GSVector4i o = (GSVector4i)r->XYOFFSET & GSVector4i::x0000ffff();
 
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].XYOFFSET = o;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].XYOFFSET.U64 ^ m_env.CTXT[i].XYOFFSET.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_XYOFFSET);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_XYOFFSET);
+	}
 
 	m_env.CTXT[i].UpdateScissor();
 
@@ -1250,7 +1284,10 @@ void GSState::GIFRegHandlerPRMODE(const GIFReg* RESTRICT r)
 	m_env.PRIM = (GSVector4i)r->PRMODE;
 	m_env.PRIM.PRIM = _PRIM;
 
-	m_reg_draw_dirty = true;
+	if (m_prev_env.PRIM.U32[0] ^ m_env.PRIM.U32[0])
+		m_dirty_gs_regs |= (1 << DIRTY_REG_PRIM);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_PRIM);
 
 	UpdateContext();
 }
@@ -1264,11 +1301,15 @@ void GSState::GIFRegHandlerTEXCLUT(const GIFReg* RESTRICT r)
 
 void GSState::GIFRegHandlerSCANMSK(const GIFReg* RESTRICT r)
 {
-	m_reg_draw_dirty = true;
-
 	m_env.SCANMSK = (GSVector4i)r->SCANMSK;
+
 	if (m_env.SCANMSK.MSK & 2)
 		m_scanmask_used = true;
+
+	if (m_prev_env.SCANMSK.MSK != m_env.SCANMSK.MSK)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_SCANMSK);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_SCANMSK);
 }
 
 template <int i>
@@ -1276,10 +1317,15 @@ void GSState::GIFRegHandlerMIPTBP1(const GIFReg* RESTRICT r)
 {
 	GL_REG("MIPTBP1_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	m_reg_texture_dirty = true;
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].MIPTBP1 = (GSVector4i)r->MIPTBP1;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].MIPTBP1.U64 != m_env.CTXT[i].MIPTBP1.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_MIPTBP1);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_MIPTBP1);
+	}
 }
 
 template <int i>
@@ -1287,29 +1333,39 @@ void GSState::GIFRegHandlerMIPTBP2(const GIFReg* RESTRICT r)
 {
 	GL_REG("MIPTBP2_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	m_reg_texture_dirty = true;
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].MIPTBP2 = (GSVector4i)r->MIPTBP2;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].MIPTBP2.U64 != m_env.CTXT[i].MIPTBP2.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_MIPTBP2);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_MIPTBP2);
+	}
 }
 
 void GSState::GIFRegHandlerTEXA(const GIFReg* RESTRICT r)
 {
 	GL_REG("TEXA = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	m_reg_texture_dirty = true;
-	m_reg_draw_dirty = true;
-
 	m_env.TEXA = (GSVector4i)r->TEXA;
+
+	if (m_prev_env.TEXA != m_env.TEXA)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_TEXA);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_TEXA);
 }
 
 void GSState::GIFRegHandlerFOGCOL(const GIFReg* RESTRICT r)
 {
 	GL_REG("FOGCOL = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	m_reg_draw_dirty = true;
-
 	m_env.FOGCOL = (GSVector4i)r->FOGCOL;
+
+	if (m_prev_env.FOGCOL != m_env.FOGCOL)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_FOGCOL);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_FOGCOL);
 }
 
 void GSState::GIFRegHandlerTEXFLUSH(const GIFReg* RESTRICT r)
@@ -1320,14 +1376,21 @@ void GSState::GIFRegHandlerTEXFLUSH(const GIFReg* RESTRICT r)
 	// This won't get picked up by the new autoflush logic (which checks for page crossings for the PS2 Texture Cache flush)
 	// so we need to do it here.
 	if (IsAutoFlushEnabled())
-		Flush(true);
+		Flush();
 }
 
 template <int i>
 void GSState::GIFRegHandlerSCISSOR(const GIFReg* RESTRICT r)
 {
 	m_env.CTXT[i].SCISSOR = (GSVector4i)r->SCISSOR;
-	m_reg_draw_dirty = true;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].SCISSOR.U64 != m_env.CTXT[i].SCISSOR.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_SCISSOR);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_SCISSOR);
+	}
 
 	m_env.CTXT[i].UpdateScissor();
 
@@ -1339,8 +1402,6 @@ void GSState::GIFRegHandlerALPHA(const GIFReg* RESTRICT r)
 {
 	GL_REG("ALPHA = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].ALPHA = (GSVector4i)r->ALPHA;
 
 	// value of 3 is not allowed by the spec
@@ -1349,13 +1410,19 @@ void GSState::GIFRegHandlerALPHA(const GIFReg* RESTRICT r)
 	m_env.CTXT[i].ALPHA.B = std::clamp<u32>(r->ALPHA.B, 0, 2);
 	m_env.CTXT[i].ALPHA.C = std::clamp<u32>(r->ALPHA.C, 0, 2);
 	m_env.CTXT[i].ALPHA.D = std::clamp<u32>(r->ALPHA.D, 0, 2);
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].ALPHA.U64 != m_env.CTXT[i].ALPHA.U64)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_ALPHA);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_ALPHA);
+	}
 }
 
 void GSState::GIFRegHandlerDIMX(const GIFReg* RESTRICT r)
 {
 	bool update = false;
-
-	m_reg_draw_dirty = true;
 
 	if (r->DIMX != m_env.DIMX)
 		update = true;
@@ -1364,51 +1431,76 @@ void GSState::GIFRegHandlerDIMX(const GIFReg* RESTRICT r)
 
 	if (update)
 		m_env.UpdateDIMX();
+
+	if (m_prev_env.DIMX != m_env.DIMX)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_DIMX);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_DIMX);
 }
 
 void GSState::GIFRegHandlerDTHE(const GIFReg* RESTRICT r)
 {
-	m_reg_draw_dirty = true;
-
 	m_env.DTHE = (GSVector4i)r->DTHE;
+
+	if (m_prev_env.DTHE != m_env.DTHE)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_DTHE);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_DTHE);
 }
 
 void GSState::GIFRegHandlerCOLCLAMP(const GIFReg* RESTRICT r)
 {
-	m_reg_draw_dirty = true;
-
 	m_env.COLCLAMP = (GSVector4i)r->COLCLAMP;
+
+	if (m_prev_env.COLCLAMP != m_env.COLCLAMP)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_COLCLAMP);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_COLCLAMP);
 }
 
 template <int i>
 void GSState::GIFRegHandlerTEST(const GIFReg* RESTRICT r)
 {
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].TEST = (GSVector4i)r->TEST;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].TEST != m_env.CTXT[i].TEST)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_TEST);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_TEST);
+	}
 }
 
 void GSState::GIFRegHandlerPABE(const GIFReg* RESTRICT r)
 {
-	m_reg_draw_dirty = true;
 
 	m_env.PABE = (GSVector4i)r->PABE;
+
+	if (m_prev_env.PABE != m_env.PABE)
+		m_dirty_gs_regs |= (1 << DIRTY_REG_PABE);
+	else
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_PABE);
 }
 
 template <int i>
 void GSState::GIFRegHandlerFBA(const GIFReg* RESTRICT r)
 {
-	m_reg_draw_dirty = true;
-
 	m_env.CTXT[i].FBA = (GSVector4i)r->FBA;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].FBA != m_env.CTXT[i].FBA)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_FBA);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_FBA);
+	}
 }
 
 template <int i>
 void GSState::GIFRegHandlerFRAME(const GIFReg* RESTRICT r)
 {
 	GL_REG("FRAME_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
-
-	m_reg_draw_dirty = true;
 
 	GIFRegFRAME NewFrame = r->FRAME;
 	// FBW is clamped between 1 and 32, however this is wrong, FBW of 0 *should* work and does on Dobiestation
@@ -1419,6 +1511,14 @@ void GSState::GIFRegHandlerFRAME(const GIFReg* RESTRICT r)
 		m_env.CTXT[i].ZBUF.PSM &= ~0x30;
 	else
 		m_env.CTXT[i].ZBUF.PSM |= 0x30;
+
+	if ((m_env.CTXT[i].FRAME.U32[0] ^ NewFrame.U32[0]) & 0x3f3f01ff) // FBP FBW PSM
+	{
+		m_env.CTXT[i].offset.fb = m_mem.GetOffset(NewFrame.Block(), NewFrame.FBW, NewFrame.PSM);
+		m_env.CTXT[i].offset.zb = m_mem.GetOffset(m_env.CTXT[i].ZBUF.Block(), NewFrame.FBW, m_env.CTXT[i].ZBUF.PSM);
+		m_env.CTXT[i].offset.fzb = m_mem.GetPixelOffset(NewFrame, m_env.CTXT[i].ZBUF);
+		m_env.CTXT[i].offset.fzb4 = m_mem.GetPixelOffset4(NewFrame, m_env.CTXT[i].ZBUF);
+	}
 
 	m_env.CTXT[i].FRAME = (GSVector4i)NewFrame;
 
@@ -1443,14 +1543,20 @@ void GSState::GIFRegHandlerFRAME(const GIFReg* RESTRICT r)
 		default:
 			break;
 	}
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].FRAME != m_env.CTXT[i].FRAME)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_FRAME);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_FRAME);
+	}
 }
 
 template <int i>
 void GSState::GIFRegHandlerZBUF(const GIFReg* RESTRICT r)
 {
 	GL_REG("ZBUF_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
-
-	m_reg_draw_dirty = true;
 
 	GIFRegZBUF ZBUF = r->ZBUF;
 
@@ -1465,7 +1571,22 @@ void GSState::GIFRegHandlerZBUF(const GIFReg* RESTRICT r)
 	else
 		ZBUF.PSM |= 0x30;
 
+	if ((m_env.CTXT[i].ZBUF.U32[0] ^ ZBUF.U32[0]) & 0x3f0001ff) // ZBP PSM
+	{
+		m_env.CTXT[i].offset.zb = m_mem.GetOffset(ZBUF.Block(), m_env.CTXT[i].FRAME.FBW, ZBUF.PSM);
+		m_env.CTXT[i].offset.fzb = m_mem.GetPixelOffset(m_env.CTXT[i].FRAME, ZBUF);
+		m_env.CTXT[i].offset.fzb4 = m_mem.GetPixelOffset4(m_env.CTXT[i].FRAME, ZBUF);
+	}
+
 	m_env.CTXT[i].ZBUF = (GSVector4i)ZBUF;
+
+	if (i == m_prev_env.PRIM.CTXT)
+	{
+		if (m_prev_env.CTXT[i].ZBUF != m_env.CTXT[i].ZBUF)
+			m_dirty_gs_regs |= (1 << DIRTY_REG_ZBUF);
+		else
+			m_dirty_gs_regs &= ~(1 << DIRTY_REG_ZBUF);
+	}
 }
 
 void GSState::GIFRegHandlerBITBLTBUF(const GIFReg* RESTRICT r)
@@ -1511,7 +1632,7 @@ void GSState::GIFRegHandlerTRXDIR(const GIFReg* RESTRICT r)
 {
 	GL_REG("TRXDIR = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	Flush(true);
+	Flush();
 
 	m_env.TRXDIR = (GSVector4i)r->TRXDIR;
 
@@ -1543,41 +1664,53 @@ void GSState::GIFRegHandlerHWREG(const GIFReg* RESTRICT r)
 	Write(reinterpret_cast<const u8*>(r), 8); // haunting ground
 }
 
-void GSState::Flush(bool forced)
+inline void GSState::CopyEnv(GSDrawingEnvironment* dest, GSDrawingEnvironment* src, int ctx)
+{
+	memcpy(dest, src, 88);
+	memcpy(&dest->CTXT[ctx], &src->CTXT[ctx], 96);
+	dest->CTXT[ctx].m_fixed_tex0 = src->CTXT[ctx].m_fixed_tex0;
+}
+
+void GSState::Flush()
 {
 	FlushWrite();
+
 	if (m_index.tail > 0)
 	{
-		const int ctx = m_prev_env.PRIM.CTXT;
+		if (m_dirty_gs_regs)
+		{
+			const int ctx = m_prev_env.PRIM.CTXT;
+			bool restore_offsets = false;
 
-		memcpy(&m_backup_env, &m_env, 88);
-		memcpy(&m_backup_env.CTXT[ctx], &m_env.CTXT[ctx], 96);
-		m_backup_env.CTXT[ctx].m_fixed_tex0 = m_env.CTXT[ctx].m_fixed_tex0;
+			CopyEnv(&m_backup_env, &m_env, ctx);
+			CopyEnv(&m_env, &m_prev_env, ctx);
 
-		memcpy(&m_env, &m_prev_env, 88);
-		memcpy(&m_env.CTXT[ctx], &m_prev_env.CTXT[ctx], 96);
-		m_env.CTXT[ctx].m_fixed_tex0 = m_prev_env.CTXT[ctx].m_fixed_tex0;
+			m_env.UpdateDIMX();
+			m_env.CTXT[ctx].UpdateScissor();
+			UpdateContext();
 
-		m_env.CTXT[ctx].offset.fb = m_mem.GetOffset(m_env.CTXT[ctx].FRAME.Block(), m_env.CTXT[ctx].FRAME.FBW, m_env.CTXT[ctx].FRAME.PSM);
-		m_env.CTXT[ctx].offset.zb = m_mem.GetOffset(m_env.CTXT[ctx].ZBUF.Block(), m_env.CTXT[ctx].FRAME.FBW, m_env.CTXT[ctx].ZBUF.PSM);
-		m_env.CTXT[ctx].offset.fzb = m_mem.GetPixelOffset(m_env.CTXT[ctx].FRAME, m_env.CTXT[ctx].ZBUF);
-		m_env.CTXT[ctx].offset.fzb4 = m_mem.GetPixelOffset4(m_env.CTXT[ctx].FRAME, m_env.CTXT[ctx].ZBUF);
+			if (((m_backup_env.CTXT[ctx].ZBUF.U32[0] ^ m_env.CTXT[ctx].ZBUF.U32[0]) & 0x3f0001ff) || ((m_backup_env.CTXT[ctx].FRAME.U32[0] ^ m_env.CTXT[ctx].FRAME.U32[0]) & 0x3f3f01ff))
+			{
+				memcpy(&m_backup_env.CTXT[ctx].offset, &m_env.CTXT[ctx].offset, sizeof(m_env.CTXT[ctx].offset));
+				memcpy(&m_env.CTXT[ctx].offset, &m_prev_env.CTXT[ctx].offset, sizeof(m_env.CTXT[ctx].offset));
+				restore_offsets = true;
+			}
 
-		m_env.UpdateDIMX();
-		m_env.CTXT[ctx].UpdateScissor();
-		UpdateContext();
+			FlushPrim();
 
-		FlushPrim(forced);
+			if (restore_offsets)
+				memcpy(&m_env.CTXT[ctx].offset, &m_backup_env.CTXT[ctx].offset, sizeof(m_env.CTXT[ctx].offset));
 
-		memcpy(&m_env, &m_backup_env, 88);
-		memcpy(&m_env.CTXT[ctx], &m_backup_env.CTXT[ctx], 96);
-		m_env.CTXT[ctx].m_fixed_tex0 = m_backup_env.CTXT[ctx].m_fixed_tex0;
-			
-		m_env.CTXT[ctx].UpdateScissor();
-		UpdateContext();
+			CopyEnv(&m_env, &m_backup_env, ctx);
+			m_env.CTXT[ctx].UpdateScissor();
+			m_env.UpdateDIMX();
+			UpdateContext();
+			m_backed_up_ctx = -1;
+		}
+		else
+			FlushPrim();
 
-		m_reg_draw_dirty = false;
-		m_reg_texture_dirty = false;
+		m_dirty_gs_regs = 0;
 	}
 }
 
@@ -1606,92 +1739,71 @@ void GSState::FlushWrite()
 	g_perfmon.Put(GSPerfMon::Swizzle, len);
 }
 
+// This function decides if the context has changed in a way which warrants flushing the draw.
 inline bool GSState::TestDrawChanged()
 {
-	if (!m_reg_draw_dirty)
-		return false;
+	// Check if PRIM has changed we need to check if it's just a different triangle or the context is changing.
+	if (m_dirty_gs_regs & (1 << DIRTY_REG_PRIM))
+	{
+		u32 prim_mask = 0x7ff;
 
-	m_reg_draw_dirty = false;
-	// Check if PRIM has changed (if so then it's defo a different draw)
-	u32 prim_mask = 0x7ff;
+		if (GSUtil::GetPrimClass(m_prev_env.PRIM.PRIM) == GSUtil::GetPrimClass(m_env.PRIM.PRIM))
+			prim_mask &= ~0x7;
+		else
+			return true;
 
-	if (GSUtil::GetPrimClass(m_prev_env.PRIM.PRIM) == GSUtil::GetPrimClass(m_env.PRIM.PRIM))
-		prim_mask &= ~0x7;
+		if (GSConfig.UseHardwareRenderer() && GSUtil::GetPrimClass(m_env.PRIM.PRIM) == GS_TRIANGLE_CLASS)
+			prim_mask &= ~0x80; // Mask out AA1.
 
-	if (GSConfig.UseHardwareRenderer() && (GSUtil::GetPrimClass(m_prev_env.PRIM.PRIM) == GS_TRIANGLE_CLASS && GSUtil::GetPrimClass(m_env.PRIM.PRIM) == GS_TRIANGLE_CLASS))
-		prim_mask &= ~0x80; // Mask out AA1.
+		if ((m_env.PRIM.U32[0] ^ m_prev_env.PRIM.U32[0]) & prim_mask)
+			return true;
 
-	if ((m_env.PRIM.U32[0] & prim_mask) != (m_prev_env.PRIM.U32[0] & prim_mask))
+		m_dirty_gs_regs &= ~(1 << DIRTY_REG_PRIM);
+
+		// Shortcut, a bunch of games just change the prim reg
+		if (!m_dirty_gs_regs)
+			return false;
+	}
+
+	if ((m_dirty_gs_regs & ((1 << DIRTY_REG_TEST) | (1 << DIRTY_REG_SCISSOR) | (1 << DIRTY_REG_XYOFFSET) | (1 << DIRTY_REG_SCANMSK) | (1 << DIRTY_REG_DTHE))) || ((m_dirty_gs_regs & (1 << DIRTY_REG_DIMX)) && m_prev_env.DTHE.DTHE))
+		return true;
+
+	if (m_env.PRIM.ABE && (m_dirty_gs_regs & ((1 << DIRTY_REG_ALPHA) | (1 << DIRTY_REG_PABE))))
+		return true;
+
+	if (m_env.PRIM.FGE && (m_dirty_gs_regs & (1 << DIRTY_REG_FOGCOL)))
 		return true;
 
 	const int context = m_env.PRIM.CTXT;
 
-	if (m_env.CTXT[context].TEST != m_prev_env.CTXT[context].TEST)
-		return true;
-
 	// If the frame is getting updated check the FRAME, otherwise, we can ignore it
-	if (!m_env.CTXT[context].TEST.ATE || (m_env.CTXT[context].TEST.ATST != ATST_NEVER) || (m_env.CTXT[context].TEST.AFAIL & 1) || m_env.CTXT[context].TEST.DATE)
+	if ((m_env.CTXT[context].TEST.ATST != ATST_NEVER) || !m_env.CTXT[context].TEST.ATE || (m_env.CTXT[context].TEST.AFAIL & 1) || m_env.CTXT[context].TEST.DATE)
 	{
-		if (m_env.CTXT[context].FRAME != m_prev_env.CTXT[context].FRAME)
-			return true;
-
-		if (m_env.COLCLAMP != m_prev_env.COLCLAMP)
-			return true;
-
-		if (m_env.CTXT[context].FBA != m_prev_env.CTXT[context].FBA)
+		if ((m_dirty_gs_regs & ((1 << DIRTY_REG_FRAME) | (1 << DIRTY_REG_COLCLAMP) | (1 << DIRTY_REG_FBA))))
 			return true;
 	}
 
-	if (!m_env.CTXT[context].TEST.ATE || (m_env.CTXT[context].TEST.ATST != ATST_NEVER) || m_env.CTXT[context].TEST.AFAIL == AFAIL_ZB_ONLY)
+	if ((m_env.CTXT[context].TEST.ATST != ATST_NEVER) || !m_env.CTXT[context].TEST.ATE || m_env.CTXT[context].TEST.AFAIL == AFAIL_ZB_ONLY)
 	{
-		if (m_env.CTXT[context].ZBUF != m_prev_env.CTXT[context].ZBUF)
+		if (m_dirty_gs_regs & (1 << DIRTY_REG_ZBUF))
 			return true;
 	}
 
-	if (m_env.CTXT[context].SCISSOR != m_prev_env.CTXT[context].SCISSOR)
-		return true;
-
-	if (m_reg_texture_dirty && m_env.PRIM.TME)
+	if (m_env.PRIM.TME)
 	{
-		m_reg_texture_dirty = false;
-
-		if (m_env.CTXT[context].CLAMP != m_prev_env.CTXT[context].CLAMP)
+		if (m_dirty_gs_regs & ((1 << DIRTY_REG_TEX0) | (1 << DIRTY_REG_TEX1) | (1 << DIRTY_REG_CLAMP) | (1 << DIRTY_REG_TEXA)))
 			return true;
 
-		if (memcmp(&m_env.CTXT[context].TEX0, &m_prev_env.CTXT[context].TEX0, 16)) // TEX0 and TEX1
-			return true;
-
-		// Don't need to test TEXA if 32bit colour used.
-		if (m_env.CTXT[context].TEX0.PSM == 0 || m_env.CTXT[context].TEX0.CPSM == 0)
-		{
-			// Do nothing.
-		}
-		else if (m_env.TEXA != m_prev_env.TEXA)
-			return true;
-
-		if(m_env.CTXT[context].TEX1.MXL > 0 && memcmp(&m_env.CTXT[context].MIPTBP1, &m_prev_env.CTXT[context].MIPTBP1, 16)) // MIPTBP1 and MIPTBP2
+		if(m_env.CTXT[context].TEX1.MXL > 0 && (m_dirty_gs_regs & ((1 << DIRTY_REG_MIPTBP1) | (1 << DIRTY_REG_MIPTBP2))))
 			return true;
 	}
 
-	if (m_env.PRIM.ABE && (m_env.CTXT[context].ALPHA != m_prev_env.CTXT[context].ALPHA))
-		return true;
-	else
-		if (m_env.PABE != m_prev_env.PABE)
-			return true;
-
-	if (m_env.PRIM.FGE && (m_env.FOGCOL != m_prev_env.FOGCOL))
-		return true;
-
-	if (m_env.CTXT[context].XYOFFSET != m_prev_env.CTXT[context].XYOFFSET)
-		return true;
-
-	if (m_env.SCANMSK != m_prev_env.SCANMSK)
-		return true;
+	m_dirty_gs_regs = 0;
 
 	return false;
 }
 
-void GSState::FlushPrim(bool forced)
+void GSState::FlushPrim()
 {
 	const u32 new_prim = PRIM->U32[0];
 
@@ -1845,7 +1957,7 @@ void GSState::Write(const u8* mem, int len)
 
 	if ((PRIM->TME && (blit.DBP == m_context->TEX0.TBP0 || blit.DBP == m_context->TEX0.CBP)) ||
 		(m_prev_env.PRIM.TME && (blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.TBP0 || blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.CBP))) // TODO: hmmmm
-		Flush(true);
+		Flush();
 
 	if (m_tr.end == 0 && len >= m_tr.total)
 	{
@@ -2142,7 +2254,7 @@ void GSState::SoftReset(u32 mask)
 
 void GSState::ReadFIFO(u8* mem, int size)
 {
-	Flush(true);
+	Flush();
 
 	size *= 16;
 
@@ -2388,9 +2500,9 @@ int GSState::Freeze(freezeData* fd, bool sizeonly)
 	if (!fd->data || fd->size < m_sssize)
 		return -1;
 
-	Flush(true);
+	Flush();
 
-    u8* data = fd->data;
+	u8* data = fd->data;
 
 	WriteState(data, &m_version);
 	WriteState(data, &m_env.PRIM);
@@ -2475,7 +2587,7 @@ int GSState::Defrost(const freezeData* fd)
 		return -1;
 	}
 
-	Flush(true);
+	Flush();
 
 	Reset(false);
 
@@ -2887,7 +2999,7 @@ __forceinline void GSState::HandleAutoFlush()
 				area_out = area_out.rintersect(GSVector4i(m_context->scissor.in));
 				// Intersect with texture
 				if (!area_out.rintersect(tex_rect).rempty())
-					Flush(true);
+					Flush();
 			}
 			else // Storage of the TEX and FRAME/Z is different, so uhh, just fall back to flushing each page. It's slower, sorry.
 			{
@@ -2908,10 +3020,10 @@ __forceinline void GSState::HandleAutoFlush()
 					area_out.w += GSLocalMemory::m_psm[m_context->TEX0.PSM].pgs.y;
 
 					if (!area_out.rintersect(tex_rect).rempty())
-						Flush(true);
+						Flush();
 				}
 				else // Page width is different, so it's much more difficult to calculate where it's modifying.
-					Flush(true);
+					Flush();
 			}
 		}
 	}
@@ -3071,11 +3183,12 @@ __forceinline void GSState::VertexKick(u32 skip)
 	if (tail >= m_vertex.maxcount)
 		GrowVertexBuffer();
 
-	if (m_index.tail == 0)
+	if (m_index.tail == 0 && ((m_backed_up_ctx != m_env.PRIM.CTXT) || m_dirty_gs_regs))
 	{
-		memcpy(&m_prev_env, &m_env, 88);
-		memcpy(&m_prev_env.CTXT[m_prev_env.PRIM.CTXT], &m_env.CTXT[m_prev_env.PRIM.CTXT], 96);
-		m_prev_env.CTXT[m_prev_env.PRIM.CTXT].m_fixed_tex0 = m_env.CTXT[m_prev_env.PRIM.CTXT].m_fixed_tex0;
+		CopyEnv(&m_prev_env, &m_env, m_env.PRIM.CTXT);
+		memcpy(&m_prev_env.CTXT[m_prev_env.PRIM.CTXT].offset, &m_env.CTXT[m_prev_env.PRIM.CTXT].offset, sizeof(m_env.CTXT[m_prev_env.PRIM.CTXT].offset));
+		m_dirty_gs_regs = 0;
+		m_backed_up_ctx = m_env.PRIM.CTXT;
 	}
 
 	u32* RESTRICT buff = &m_index.buff[m_index.tail];

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -135,8 +135,6 @@ GSState::GSState()
 	PRIM = &m_env.PRIM;
 	//CSR->rREV = 0x20;
 	m_env.PRMODECONT.AC = 1;
-	m_last_prim.U32[0] = PRIM->U32[0];
-
 	Reset(false);
 
 	ResetHandlers();
@@ -214,6 +212,10 @@ void GSState::Reset(bool hardware_reset)
 	m_vertex.next = 0;
 	m_index.tail = 0;
 	m_scanmask_used = false;
+
+	m_reg_draw_dirty = false;
+	m_reg_texture_dirty = false;
+	memcpy(&m_prev_env, &m_env, sizeof(m_prev_env));
 }
 
 template<bool auto_flush, bool index_swap>
@@ -730,8 +732,13 @@ void GSState::DumpVertices(const std::string& filename)
 
 __inline void GSState::CheckFlushes()
 {
-	if (m_primflush)
-		Flush();
+	if (m_index.tail > 0)
+	{
+		if (TestDrawChanged())
+		{
+			Flush(true);
+		}
+	}
 
 	if ((m_context->FRAME.FBMSK & GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk) != GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk)
 		m_mem.m_clut.Invalidate(m_context->FRAME.Block());
@@ -924,29 +931,14 @@ __forceinline void GSState::ApplyPRIM(u32 prim)
 		m_env.PRIM.PRIM = prim & 0x7;
 	}
 
-	m_primflush = false;
-	u32 prim_mask = 0x7ff;
-
-	// Same class of draw so we don't need to flush
-	if (GSUtil::GetPrimClass(m_last_prim.PRIM) == GSUtil::GetPrimClass(m_env.PRIM.PRIM))
-		prim_mask &= ~0x7;
-
-	if (GSConfig.UseHardwareRenderer() && GSUtil::GetPrimClass(prim & 7) == GS_TRIANGLE_CLASS)
-		prim_mask &= ~0x80; // Mask out AA1.
-
-	if ((m_last_prim.U32[0] ^ m_env.PRIM.U32[0]) & prim_mask)
-		m_primflush = true;
+	m_reg_draw_dirty = true;
 
 	UpdateVertexKick();
 
 	ASSERT(m_index.tail == 0 || !g_gs_device->Features().provoking_vertex_last || m_index.buff[m_index.tail - 1] + 1 == m_vertex.next);
 
 	if (m_index.tail == 0)
-	{
 		m_vertex.next = 0;
-		m_primflush = false;
-		m_last_prim.U32[0] = m_env.PRIM.U32[0];
-	}
 
 	m_vertex.head = m_vertex.tail = m_vertex.next; // remove unused vertices from the end of the vertex buffer
 }
@@ -1034,6 +1026,9 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 	// extremely broken for the same reasons as MLB Power Pros in that it spams TEX0 with
 	// complete garbage making for a nice 1G heap of GSOffset.
 
+	m_reg_texture_dirty = true;
+	m_reg_draw_dirty = true;
+
 	GL_REG("Apply TEX0_%d = 0x%x_%x", i, TEX0.U32[1], TEX0.U32[0]);
 
 	// even if TEX0 did not change, a new palette may have been uploaded and will overwrite the currently queued for drawing
@@ -1043,8 +1038,8 @@ void GSState::ApplyTEX0(GIFRegTEX0& TEX0)
 
 	constexpr u64 mask = 0x1f78001fffffffffull; // TBP0 TBW PSM TW TH TCC TFX CPSM CSA
 
-	if (wt || (PRIM->CTXT == i || m_primflush) && ((TEX0.U64 ^ m_env.CTXT[i].TEX0.U64) & mask))
-		Flush();
+	if (wt && (TEX0.PSM & 0x30))
+		Flush(true);
 
 	TEX0.CPSM &= 0xa; // 1010b
 
@@ -1160,9 +1155,6 @@ void GSState::GIFRegHandlerTEX0(const GIFReg* RESTRICT r)
 		temp_MIPTBP1.TBP3 = bp;
 		temp_MIPTBP1.TBW3 = bw;
 
-		if (temp_MIPTBP1 != m_env.CTXT[i].MIPTBP1)
-			Flush();
-
 		MTBAReloaded = true;
 	}
 
@@ -1177,8 +1169,8 @@ void GSState::GIFRegHandlerCLAMP(const GIFReg* RESTRICT r)
 {
 	GL_REG("CLAMP_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	if ((PRIM->CTXT == i || m_primflush) && r->CLAMP != m_env.CTXT[i].CLAMP)
-		Flush();
+	m_reg_texture_dirty = true;
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].CLAMP = (GSVector4i)r->CLAMP;
 }
@@ -1197,8 +1189,8 @@ void GSState::GIFRegHandlerTEX1(const GIFReg* RESTRICT r)
 {
 	GL_REG("TEX1_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	if ((PRIM->CTXT == i || m_primflush) && r->TEX1 != m_env.CTXT[i].TEX1)
-		Flush();
+	m_reg_texture_dirty = true;
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].TEX1 = (GSVector4i)r->TEX1;
 }
@@ -1230,8 +1222,7 @@ void GSState::GIFRegHandlerXYOFFSET(const GIFReg* RESTRICT r)
 
 	const GSVector4i o = (GSVector4i)r->XYOFFSET & GSVector4i::x0000ffff();
 
-	if (!o.eq(m_env.CTXT[i].XYOFFSET))
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].XYOFFSET = o;
 
@@ -1259,24 +1250,7 @@ void GSState::GIFRegHandlerPRMODE(const GIFReg* RESTRICT r)
 	m_env.PRIM = (GSVector4i)r->PRMODE;
 	m_env.PRIM.PRIM = _PRIM;
 
-	u32 prim_mask = 0x7ff;
-	
-	// Same class of draw so we don't need to flush
-	if (GSUtil::GetPrimClass(m_last_prim.PRIM) == GSUtil::GetPrimClass(m_env.PRIM.PRIM))
-		prim_mask &= ~0x7;
-
-	if (GSConfig.UseHardwareRenderer() && GSUtil::GetPrimClass(m_env.PRIM.PRIM) == GS_TRIANGLE_CLASS)
-		prim_mask &= ~0x80; // Mask out AA1.
-
-	m_primflush = false;
-	if ((m_last_prim.U32[0] ^ m_env.PRIM.U32[0]) & prim_mask)
-		m_primflush = true;
-
-	if (m_index.tail == 0)
-	{
-		m_primflush = false;
-		m_last_prim.U32[0] = m_env.PRIM.U32[0];
-	}
+	m_reg_draw_dirty = true;
 
 	UpdateContext();
 }
@@ -1285,16 +1259,12 @@ void GSState::GIFRegHandlerTEXCLUT(const GIFReg* RESTRICT r)
 {
 	GL_REG("TEXCLUT = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	if (r->TEXCLUT != m_env.TEXCLUT)
-		Flush();
-
 	m_env.TEXCLUT = (GSVector4i)r->TEXCLUT;
 }
 
 void GSState::GIFRegHandlerSCANMSK(const GIFReg* RESTRICT r)
 {
-	if (r->SCANMSK != m_env.SCANMSK)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.SCANMSK = (GSVector4i)r->SCANMSK;
 	if (m_env.SCANMSK.MSK & 2)
@@ -1306,8 +1276,8 @@ void GSState::GIFRegHandlerMIPTBP1(const GIFReg* RESTRICT r)
 {
 	GL_REG("MIPTBP1_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	if ((PRIM->CTXT == i || m_primflush) && r->MIPTBP1 != m_env.CTXT[i].MIPTBP1)
-		Flush();
+	m_reg_texture_dirty = true;
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].MIPTBP1 = (GSVector4i)r->MIPTBP1;
 }
@@ -1317,8 +1287,8 @@ void GSState::GIFRegHandlerMIPTBP2(const GIFReg* RESTRICT r)
 {
 	GL_REG("MIPTBP2_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
-	if ((PRIM->CTXT == i || m_primflush) && r->MIPTBP2 != m_env.CTXT[i].MIPTBP2)
-		Flush();
+	m_reg_texture_dirty = true;
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].MIPTBP2 = (GSVector4i)r->MIPTBP2;
 }
@@ -1326,8 +1296,9 @@ void GSState::GIFRegHandlerMIPTBP2(const GIFReg* RESTRICT r)
 void GSState::GIFRegHandlerTEXA(const GIFReg* RESTRICT r)
 {
 	GL_REG("TEXA = 0x%x_%x", r->U32[1], r->U32[0]);
-	if (r->TEXA != m_env.TEXA)
-		Flush();
+
+	m_reg_texture_dirty = true;
+	m_reg_draw_dirty = true;
 
 	m_env.TEXA = (GSVector4i)r->TEXA;
 }
@@ -1336,8 +1307,7 @@ void GSState::GIFRegHandlerFOGCOL(const GIFReg* RESTRICT r)
 {
 	GL_REG("FOGCOL = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	if (r->FOGCOL != m_env.FOGCOL)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.FOGCOL = (GSVector4i)r->FOGCOL;
 }
@@ -1350,16 +1320,14 @@ void GSState::GIFRegHandlerTEXFLUSH(const GIFReg* RESTRICT r)
 	// This won't get picked up by the new autoflush logic (which checks for page crossings for the PS2 Texture Cache flush)
 	// so we need to do it here.
 	if (IsAutoFlushEnabled())
-		Flush();
+		Flush(true);
 }
 
 template <int i>
 void GSState::GIFRegHandlerSCISSOR(const GIFReg* RESTRICT r)
 {
-	if ((PRIM->CTXT == i || m_primflush) && r->SCISSOR != m_env.CTXT[i].SCISSOR)
-		Flush();
-
 	m_env.CTXT[i].SCISSOR = (GSVector4i)r->SCISSOR;
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].UpdateScissor();
 
@@ -1370,8 +1338,8 @@ template <int i>
 void GSState::GIFRegHandlerALPHA(const GIFReg* RESTRICT r)
 {
 	GL_REG("ALPHA = 0x%x_%x", r->U32[1], r->U32[0]);
-	if ((PRIM->CTXT == i || m_primflush) && r->ALPHA != m_env.CTXT[i].ALPHA)
-		Flush();
+
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].ALPHA = (GSVector4i)r->ALPHA;
 
@@ -1387,12 +1355,10 @@ void GSState::GIFRegHandlerDIMX(const GIFReg* RESTRICT r)
 {
 	bool update = false;
 
-	if (r->DIMX != m_env.DIMX)
-	{
-		Flush();
+	m_reg_draw_dirty = true;
 
+	if (r->DIMX != m_env.DIMX)
 		update = true;
-	}
 
 	m_env.DIMX = (GSVector4i)r->DIMX;
 
@@ -1402,16 +1368,14 @@ void GSState::GIFRegHandlerDIMX(const GIFReg* RESTRICT r)
 
 void GSState::GIFRegHandlerDTHE(const GIFReg* RESTRICT r)
 {
-	if (r->DTHE != m_env.DTHE)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.DTHE = (GSVector4i)r->DTHE;
 }
 
 void GSState::GIFRegHandlerCOLCLAMP(const GIFReg* RESTRICT r)
 {
-	if (r->COLCLAMP != m_env.COLCLAMP)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.COLCLAMP = (GSVector4i)r->COLCLAMP;
 }
@@ -1419,16 +1383,14 @@ void GSState::GIFRegHandlerCOLCLAMP(const GIFReg* RESTRICT r)
 template <int i>
 void GSState::GIFRegHandlerTEST(const GIFReg* RESTRICT r)
 {
-	if ((PRIM->CTXT == i || m_primflush) && r->TEST != m_env.CTXT[i].TEST)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].TEST = (GSVector4i)r->TEST;
 }
 
 void GSState::GIFRegHandlerPABE(const GIFReg* RESTRICT r)
 {
-	if (r->PABE != m_env.PABE)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.PABE = (GSVector4i)r->PABE;
 }
@@ -1436,8 +1398,7 @@ void GSState::GIFRegHandlerPABE(const GIFReg* RESTRICT r)
 template <int i>
 void GSState::GIFRegHandlerFBA(const GIFReg* RESTRICT r)
 {
-	if ((PRIM->CTXT == i || m_primflush) && r->FBA != m_env.CTXT[i].FBA)
-		Flush();
+	m_reg_draw_dirty = true;
 
 	m_env.CTXT[i].FBA = (GSVector4i)r->FBA;
 }
@@ -1447,26 +1408,17 @@ void GSState::GIFRegHandlerFRAME(const GIFReg* RESTRICT r)
 {
 	GL_REG("FRAME_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
+	m_reg_draw_dirty = true;
+
 	GIFRegFRAME NewFrame = r->FRAME;
 	// FBW is clamped between 1 and 32, however this is wrong, FBW of 0 *should* work and does on Dobiestation
 	// However there is some issues so even software mode is incorrect on PCSX2, but this works better..
 	NewFrame.FBW = std::clamp(NewFrame.FBW, 1U, 32U);
 
-	if ((PRIM->CTXT == i || m_primflush) && NewFrame != m_env.CTXT[i].FRAME)
-		Flush();
-
 	if ((NewFrame.PSM & 0x30) == 0x30)
 		m_env.CTXT[i].ZBUF.PSM &= ~0x30;
 	else
 		m_env.CTXT[i].ZBUF.PSM |= 0x30;
-
-	if ((m_env.CTXT[i].FRAME.U32[0] ^ NewFrame.U32[0]) & 0x3f3f01ff) // FBP FBW PSM
-	{
-		m_env.CTXT[i].offset.fb = m_mem.GetOffset(NewFrame.Block(), NewFrame.FBW, NewFrame.PSM);
-		m_env.CTXT[i].offset.zb = m_mem.GetOffset(m_env.CTXT[i].ZBUF.Block(), NewFrame.FBW, m_env.CTXT[i].ZBUF.PSM);
-		m_env.CTXT[i].offset.fzb = m_mem.GetPixelOffset(NewFrame, m_env.CTXT[i].ZBUF);
-		m_env.CTXT[i].offset.fzb4 = m_mem.GetPixelOffset4(NewFrame, m_env.CTXT[i].ZBUF);
-	}
 
 	m_env.CTXT[i].FRAME = (GSVector4i)NewFrame;
 
@@ -1498,6 +1450,8 @@ void GSState::GIFRegHandlerZBUF(const GIFReg* RESTRICT r)
 {
 	GL_REG("ZBUF_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
+	m_reg_draw_dirty = true;
+
 	GIFRegZBUF ZBUF = r->ZBUF;
 
 	// We tested this on the PS2 and it seems to be that when the FRAME is a Z format,
@@ -1510,16 +1464,6 @@ void GSState::GIFRegHandlerZBUF(const GIFReg* RESTRICT r)
 		ZBUF.PSM &= ~0x30;
 	else
 		ZBUF.PSM |= 0x30;
-
-	if ((PRIM->CTXT == i || m_primflush) && ZBUF != m_env.CTXT[i].ZBUF)
-		Flush();
-
-	if ((m_env.CTXT[i].ZBUF.U32[0] ^ ZBUF.U32[0]) & 0x3f0001ff) // ZBP PSM
-	{
-		m_env.CTXT[i].offset.zb = m_mem.GetOffset(ZBUF.Block(), m_env.CTXT[i].FRAME.FBW, ZBUF.PSM);
-		m_env.CTXT[i].offset.fzb = m_mem.GetPixelOffset(m_env.CTXT[i].FRAME, ZBUF);
-		m_env.CTXT[i].offset.fzb4 = m_mem.GetPixelOffset4(m_env.CTXT[i].FRAME, ZBUF);
-	}
 
 	m_env.CTXT[i].ZBUF = (GSVector4i)ZBUF;
 }
@@ -1567,7 +1511,7 @@ void GSState::GIFRegHandlerTRXDIR(const GIFReg* RESTRICT r)
 {
 	GL_REG("TRXDIR = 0x%x_%x", r->U32[1], r->U32[0]);
 
-	Flush();
+	Flush(true);
 
 	m_env.TRXDIR = (GSVector4i)r->TRXDIR;
 
@@ -1599,10 +1543,42 @@ void GSState::GIFRegHandlerHWREG(const GIFReg* RESTRICT r)
 	Write(reinterpret_cast<const u8*>(r), 8); // haunting ground
 }
 
-void GSState::Flush()
+void GSState::Flush(bool forced)
 {
 	FlushWrite();
-	FlushPrim();
+	if (m_index.tail > 0)
+	{
+		const int ctx = m_prev_env.PRIM.CTXT;
+
+		memcpy(&m_backup_env, &m_env, 88);
+		memcpy(&m_backup_env.CTXT[ctx], &m_env.CTXT[ctx], 96);
+		m_backup_env.CTXT[ctx].m_fixed_tex0 = m_env.CTXT[ctx].m_fixed_tex0;
+
+		memcpy(&m_env, &m_prev_env, 88);
+		memcpy(&m_env.CTXT[ctx], &m_prev_env.CTXT[ctx], 96);
+		m_env.CTXT[ctx].m_fixed_tex0 = m_prev_env.CTXT[ctx].m_fixed_tex0;
+
+		m_env.CTXT[ctx].offset.fb = m_mem.GetOffset(m_env.CTXT[ctx].FRAME.Block(), m_env.CTXT[ctx].FRAME.FBW, m_env.CTXT[ctx].FRAME.PSM);
+		m_env.CTXT[ctx].offset.zb = m_mem.GetOffset(m_env.CTXT[ctx].ZBUF.Block(), m_env.CTXT[ctx].FRAME.FBW, m_env.CTXT[ctx].ZBUF.PSM);
+		m_env.CTXT[ctx].offset.fzb = m_mem.GetPixelOffset(m_env.CTXT[ctx].FRAME, m_env.CTXT[ctx].ZBUF);
+		m_env.CTXT[ctx].offset.fzb4 = m_mem.GetPixelOffset4(m_env.CTXT[ctx].FRAME, m_env.CTXT[ctx].ZBUF);
+
+		m_env.UpdateDIMX();
+		m_env.CTXT[ctx].UpdateScissor();
+		UpdateContext();
+
+		FlushPrim(forced);
+
+		memcpy(&m_env, &m_backup_env, 88);
+		memcpy(&m_env.CTXT[ctx], &m_backup_env.CTXT[ctx], 96);
+		m_env.CTXT[ctx].m_fixed_tex0 = m_backup_env.CTXT[ctx].m_fixed_tex0;
+			
+		m_env.CTXT[ctx].UpdateScissor();
+		UpdateContext();
+
+		m_reg_draw_dirty = false;
+		m_reg_texture_dirty = false;
+	}
 }
 
 void GSState::FlushWrite()
@@ -1630,16 +1606,94 @@ void GSState::FlushWrite()
 	g_perfmon.Put(GSPerfMon::Swizzle, len);
 }
 
-void GSState::FlushPrim()
+inline bool GSState::TestDrawChanged()
+{
+	if (!m_reg_draw_dirty)
+		return false;
+
+	m_reg_draw_dirty = false;
+	// Check if PRIM has changed (if so then it's defo a different draw)
+	u32 prim_mask = 0x7ff;
+
+	if (GSUtil::GetPrimClass(m_prev_env.PRIM.PRIM) == GSUtil::GetPrimClass(m_env.PRIM.PRIM))
+		prim_mask &= ~0x7;
+
+	if (GSConfig.UseHardwareRenderer() && (GSUtil::GetPrimClass(m_prev_env.PRIM.PRIM) == GS_TRIANGLE_CLASS && GSUtil::GetPrimClass(m_env.PRIM.PRIM) == GS_TRIANGLE_CLASS))
+		prim_mask &= ~0x80; // Mask out AA1.
+
+	if ((m_env.PRIM.U32[0] & prim_mask) != (m_prev_env.PRIM.U32[0] & prim_mask))
+		return true;
+
+	const int context = m_env.PRIM.CTXT;
+
+	if (m_env.CTXT[context].TEST != m_prev_env.CTXT[context].TEST)
+		return true;
+
+	// If the frame is getting updated check the FRAME, otherwise, we can ignore it
+	if (!m_env.CTXT[context].TEST.ATE || (m_env.CTXT[context].TEST.ATST != ATST_NEVER) || (m_env.CTXT[context].TEST.AFAIL & 1) || m_env.CTXT[context].TEST.DATE)
+	{
+		if (m_env.CTXT[context].FRAME != m_prev_env.CTXT[context].FRAME)
+			return true;
+
+		if (m_env.COLCLAMP != m_prev_env.COLCLAMP)
+			return true;
+
+		if (m_env.CTXT[context].FBA != m_prev_env.CTXT[context].FBA)
+			return true;
+	}
+
+	if (!m_env.CTXT[context].TEST.ATE || (m_env.CTXT[context].TEST.ATST != ATST_NEVER) || m_env.CTXT[context].TEST.AFAIL == AFAIL_ZB_ONLY)
+	{
+		if (m_env.CTXT[context].ZBUF != m_prev_env.CTXT[context].ZBUF)
+			return true;
+	}
+
+	if (m_env.CTXT[context].SCISSOR != m_prev_env.CTXT[context].SCISSOR)
+		return true;
+
+	if (m_reg_texture_dirty && m_env.PRIM.TME)
+	{
+		m_reg_texture_dirty = false;
+
+		if (m_env.CTXT[context].CLAMP != m_prev_env.CTXT[context].CLAMP)
+			return true;
+
+		if (memcmp(&m_env.CTXT[context].TEX0, &m_prev_env.CTXT[context].TEX0, 16)) // TEX0 and TEX1
+			return true;
+
+		// Don't need to test TEXA if 32bit colour used.
+		if (m_env.CTXT[context].TEX0.PSM == 0 || m_env.CTXT[context].TEX0.CPSM == 0)
+		{
+			// Do nothing.
+		}
+		else if (m_env.TEXA != m_prev_env.TEXA)
+			return true;
+
+		if(m_env.CTXT[context].TEX1.MXL > 0 && memcmp(&m_env.CTXT[context].MIPTBP1, &m_prev_env.CTXT[context].MIPTBP1, 16)) // MIPTBP1 and MIPTBP2
+			return true;
+	}
+
+	if (m_env.PRIM.ABE && (m_env.CTXT[context].ALPHA != m_prev_env.CTXT[context].ALPHA))
+		return true;
+	else
+		if (m_env.PABE != m_prev_env.PABE)
+			return true;
+
+	if (m_env.PRIM.FGE && (m_env.FOGCOL != m_prev_env.FOGCOL))
+		return true;
+
+	if (m_env.CTXT[context].XYOFFSET != m_prev_env.CTXT[context].XYOFFSET)
+		return true;
+
+	if (m_env.SCANMSK != m_prev_env.SCANMSK)
+		return true;
+
+	return false;
+}
+
+void GSState::FlushPrim(bool forced)
 {
 	const u32 new_prim = PRIM->U32[0];
-
-	if (m_primflush)
-	{
-		// We need to restore the old PRIM and update the Context (in case it changed)
-		m_env.PRIM.U32[0] = m_last_prim.U32[0];
-		UpdateContext();
-	}
 
 	if (m_index.tail > 0)
 	{
@@ -1748,16 +1802,6 @@ void GSState::FlushPrim()
 			m_vertex.next = 0;
 		}
 	}
-
-	if (m_primflush)
-	{
-		// Restore the backup
-		PRIM->U32[0] = new_prim;
-		UpdateContext();
-	}
-
-	m_primflush = false;
-	m_last_prim.U32[0] = new_prim;
 }
 
 void GSState::Write(const u8* mem, int len)
@@ -1799,8 +1843,9 @@ void GSState::Write(const u8* mem, int len)
 			 m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
 			 m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, w, h);
 
-	if ((PRIM->TME || (m_primflush && m_last_prim.TME)) && (blit.DBP == m_context->TEX0.TBP0 || blit.DBP == m_context->TEX0.CBP)) // TODO: hmmmm
-		FlushPrim();
+	if ((PRIM->TME && (blit.DBP == m_context->TEX0.TBP0 || blit.DBP == m_context->TEX0.CBP)) ||
+		(m_prev_env.PRIM.TME && (blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.TBP0 || blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.CBP))) // TODO: hmmmm
+		Flush(true);
 
 	if (m_tr.end == 0 && len >= m_tr.total)
 	{
@@ -2097,7 +2142,7 @@ void GSState::SoftReset(u32 mask)
 
 void GSState::ReadFIFO(u8* mem, int size)
 {
-	Flush();
+	Flush(true);
 
 	size *= 16;
 
@@ -2343,7 +2388,7 @@ int GSState::Freeze(freezeData* fd, bool sizeonly)
 	if (!fd->data || fd->size < m_sssize)
 		return -1;
 
-	Flush();
+	Flush(true);
 
     u8* data = fd->data;
 
@@ -2430,7 +2475,7 @@ int GSState::Defrost(const freezeData* fd)
 		return -1;
 	}
 
-	Flush();
+	Flush(true);
 
 	Reset(false);
 
@@ -2842,7 +2887,7 @@ __forceinline void GSState::HandleAutoFlush()
 				area_out = area_out.rintersect(GSVector4i(m_context->scissor.in));
 				// Intersect with texture
 				if (!area_out.rintersect(tex_rect).rempty())
-					Flush();
+					Flush(true);
 			}
 			else // Storage of the TEX and FRAME/Z is different, so uhh, just fall back to flushing each page. It's slower, sorry.
 			{
@@ -2863,10 +2908,10 @@ __forceinline void GSState::HandleAutoFlush()
 					area_out.w += GSLocalMemory::m_psm[m_context->TEX0.PSM].pgs.y;
 
 					if (!area_out.rintersect(tex_rect).rempty())
-						Flush();
+						Flush(true);
 				}
 				else // Page width is different, so it's much more difficult to calculate where it's modifying.
-					Flush();
+					Flush(true);
 			}
 		}
 	}
@@ -3025,6 +3070,13 @@ __forceinline void GSState::VertexKick(u32 skip)
 
 	if (tail >= m_vertex.maxcount)
 		GrowVertexBuffer();
+
+	if (m_index.tail == 0)
+	{
+		memcpy(&m_prev_env, &m_env, 88);
+		memcpy(&m_prev_env.CTXT[m_prev_env.PRIM.CTXT], &m_env.CTXT[m_prev_env.PRIM.CTXT], 96);
+		m_prev_env.CTXT[m_prev_env.PRIM.CTXT].m_fixed_tex0 = m_env.CTXT[m_prev_env.PRIM.CTXT].m_fixed_tex0;
+	}
 
 	u32* RESTRICT buff = &m_index.buff[m_index.tail];
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -225,6 +225,8 @@ public:
 	GSPrivRegSet* m_regs;
 	GSLocalMemory m_mem;
 	GSDrawingEnvironment m_env;
+	GSDrawingEnvironment m_backup_env;
+	GSDrawingEnvironment m_prev_env;
 	GSDrawingContext* m_context;
 	u32 m_crc;
 	CRC::Game m_game;
@@ -233,8 +235,8 @@ public:
 	int m_frameskip;
 	bool m_nativeres;
 	bool m_mipmap;
-	bool m_primflush;
-	GIFRegPRIM m_last_prim;
+	bool m_reg_texture_dirty;
+	bool m_reg_draw_dirty;
 
 	static int s_n;
 	bool s_dump;
@@ -315,8 +317,9 @@ public:
 	virtual void Reset(bool hardware_reset);
 	virtual void UpdateSettings(const Pcsx2Config::GSOptions& old_config);
 
-	void Flush();
-	void FlushPrim();
+	void Flush(bool forced = false);
+	void FlushPrim(bool forced);
+	bool TestDrawChanged();
 	void FlushWrite();
 	virtual void Draw() = 0;
 	virtual void PurgePool() = 0;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -235,8 +235,8 @@ public:
 	int m_frameskip;
 	bool m_nativeres;
 	bool m_mipmap;
-	bool m_reg_texture_dirty;
-	bool m_reg_draw_dirty;
+	u32 m_dirty_gs_regs;
+	int m_backed_up_ctx;
 
 	static int s_n;
 	bool s_dump;
@@ -249,6 +249,30 @@ public:
 	std::string m_dump_root;
 
 	static constexpr u32 STATE_VERSION = 8;
+
+	enum REG_DIRTY
+	{
+		DIRTY_REG_ALPHA,
+		DIRTY_REG_CLAMP,
+		DIRTY_REG_COLCLAMP,
+		DIRTY_REG_DIMX,
+		DIRTY_REG_DTHE,
+		DIRTY_REG_FBA,
+		DIRTY_REG_FOGCOL,
+		DIRTY_REG_FRAME,
+		DIRTY_REG_MIPTBP1,
+		DIRTY_REG_MIPTBP2,
+		DIRTY_REG_PABE,
+		DIRTY_REG_PRIM,
+		DIRTY_REG_SCANMSK,
+		DIRTY_REG_SCISSOR,
+		DIRTY_REG_TEST,
+		DIRTY_REG_TEX0,
+		DIRTY_REG_TEX1,
+		DIRTY_REG_TEXA,
+		DIRTY_REG_XYOFFSET,
+		DIRTY_REG_ZBUF
+	};
 
 	enum PRIM_OVERLAP
 	{
@@ -317,8 +341,9 @@ public:
 	virtual void Reset(bool hardware_reset);
 	virtual void UpdateSettings(const Pcsx2Config::GSOptions& old_config);
 
-	void Flush(bool forced = false);
-	void FlushPrim(bool forced);
+	void CopyEnv(GSDrawingEnvironment* dest, GSDrawingEnvironment* src, int ctx);
+	void Flush();
+	void FlushPrim();
 	bool TestDrawChanged();
 	void FlushWrite();
 	virtual void Draw() = 0;

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -504,7 +504,7 @@ static GSVector4 CalculateDrawRect(s32 window_width, s32 window_height, s32 text
 
 void GSRenderer::VSync(u32 field, bool registers_written)
 {
-	Flush(true);
+	Flush();
 
 	if (s_dump && s_n >= s_saven)
 	{

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -504,7 +504,7 @@ static GSVector4 CalculateDrawRect(s32 window_width, s32 window_height, s32 text
 
 void GSRenderer::VSync(u32 field, bool registers_written)
 {
-	Flush();
+	Flush(true);
 
 	if (s_dump && s_n >= s_saven)
 	{


### PR DESCRIPTION
### Description of Changes
Changes the GS State to check the entire register state on vertex request before flushing draws.

### Rationale behind Changes
Before we were super paranoid with flushing, but some games trash the register states then put them back as they were, before this would have caused it to flush, which could reduce the framerate and inflate the draw call count (not so good for OGL or weak GPUs)

### Suggested Testing Steps
Just test games, make sure now graphics are broken, record any differences in performance Vs master.


Here's some of my results. NOTE: All my testing was done with GS Dumps at x3 Native in Vulkan on a 2080Ti + Ryzen 5900x, this may not translate completely to playing the game!

D = Draw Calls
TC  = Texture Copies

FPS gains observed:
-------------------------------------------------------------------------------
Driv3r:  35% increase.
Master: 1643D, 137fps, 378TC
PR: 1422D, 185fps, 17TC
(with autoflush)
Master: 1670D, 134fps, 390TC
PR: 1450D, 180fps, 29TC

Genji: 17% increase.
Master: 423D, 790fps
PR: 169D, 930fps

GTA Vice City: 1% increase.
Master: 271D, 955fps
PR: 269D, 963fps

MGS2 Thermal Vision: 10% increase.
Master: 717D, 427fps
PR: 551D, 470fps

Parappa The Rapper 2: (Bonus it fixed a mipmapping bug) 17% increase.
Master: 390-402D, 1296fps
PR: 335-343D, 1518fps
