### PR TITLE
GameDB: SOCOM II: U.S NAVY SEALs NTSC Multi-Patch

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6984,6 +6984,17 @@ SCUS-97275:
   gameFixes:
     - EETimingHack # Get rids of DMA8/9 non-fatal errors.
     - VIF1StallHack # Fixes broken HUD.
+  patches:
+    default:
+      author: "NightFyre"
+      content: |-
+        author=NightFyre
+        // This will only be applied if the game is version r0001
+        patch=1,EE,D033CD90,extended,0000EF64
+        patch=1,EE,2033CD90,extended,00000000
+        // This will only be applied if the game is version r0004
+        patch=1,EE,D035A320,extended,000064C8
+        patch=1,EE,2035A320,extended,00000000
 SCUS-97276:
   name: "NFL GameDay 2004"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
This is a GameDB patch that will apply based on the current running game version. SOCOM 2 has 2 internal patches that will shift the .text segment of data . This change also applies to the single player version of the game as there is no difference in game memory from Single Player to Multi - Player/LAN

### Rationale behind Changes
This fix will bring the game to full speed as well as retain all normal game functions

### Suggested Testing Steps
Launch SOCOM 2 without a memory card and launch the single player campaign. Upon loading into the first mission a cutscene will ensue explaining the objectives for the mission ahead. Its during this brief intermission that we get our first glimpse of frame drops. After the cutscene ends and you gain control of your player, you will feel that the game is playing rather sluggishly even though the FPS counter will say the game is running at full speed.

Upon applying the r0001 render fix the game will immediately start playing at full speed and you will be able to play the mission at a clean 60fps.

The very same can be said for the r0004 version of the game , however to get your hands on the patch you will first need install a memory card. Then connect to the online portion of the game to get the download prompt. Proceed with the original testing steps after the patch has been downloaded


This patch does not lower the overall brightness from the game
[Video Link](https://youtu.be/oY1GTeTYKqM) for a full detailed breakdown on how this patch works compared to [my last pull request](https://github.com/PCSX2/pcsx2/pull/6386)
![image](https://user-images.githubusercontent.com/80198020/173066618-abfef6d8-e970-41cd-808b-c972c2f0882e.png)
