### PR TITLE
IPU: Remove some DMA hacks

### DIFF
--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -41,9 +41,10 @@ void IPU_Fifo_Input::clear()
 
 	// Because the FIFO is drained it will request more data immediately
 	IPU1Status.DataRequested = true;
+
 	if (ipu1ch.chcr.STR && cpuRegs.eCycle[4] == 0x9999)
 	{
-		CPU_INT(DMAC_TO_IPU, 32);
+		CPU_INT(DMAC_TO_IPU, 4);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Removes some DMA hacks put in for Test Drive and Bust-a-move: Dance Summit 2001

### Rationale behind Changes
They were wrong, but worked when the IPU was more broken, now they actually break stuff.

### Suggested Testing Steps
Test videos, especially the above mentioned games (but I did test them myself also) 

Fixes Saishuu Densha freeze (the crash can still happen though)