### PR TITLE
Core: Tweaks to FIELD switch timing and INTC Hack

### DIFF
--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -233,9 +233,9 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, double framesPerSecond, u32 sca
 	// Jak II - random speedups
 	// Shadow of Rome - FMV audio issues
 	const u64 HalfFrame = Frame / 2;
-	const u64 Blank = Scanline *((gsVideoMode == GS_VideoMode::NTSC ? 22 : 25) + static_cast<int>(gsIsInterlaced));
+	const u64 Blank = Scanline * ((gsVideoMode == GS_VideoMode::NTSC ? 22 : 25) + static_cast<int>(gsIsInterlaced));
 	const u64 Render = HalfFrame - Blank;
-	const u64 GSBlank = Scanline * 3.5; // GS VBlank/CSR Swap happens roughly 3.5 Scanlines after VBlank Start
+	const u64 GSBlank = Scanline * (gsVideoMode == GS_VideoMode::NTSC ? 3.5 : 3); // GS VBlank/CSR Swap happens roughly 3.5(NTSC) and 3(PAL) Scanlines after VBlank Start
 
 	// Important!  The hRender/hBlank timers should be 50/50 for best results.
 	//  (this appears to be what the real EE's timing crystal does anyway)

--- a/pcsx2/HwRead.cpp
+++ b/pcsx2/HwRead.cpp
@@ -30,7 +30,7 @@ static __fi void IntCHackCheck()
 	// Sanity check: To protect from accidentally "rewinding" the cyclecount
 	// on the few times nextBranchCycle can be behind our current cycle.
 	s32 diff = g_nextEventCycle - cpuRegs.cycle;
-	if( diff > 0 ) cpuRegs.cycle = g_nextEventCycle;
+	if (diff > 0 && (cpuRegs.cycle - g_lastEventCycle) > 8) cpuRegs.cycle = g_nextEventCycle;
 }
 
 template< uint page > RETURNS_R128 _hwRead128(u32 mem);

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -365,14 +365,14 @@ static bool cpuIntsEnabled(int Interrupt)
 
 // if cpuRegs.cycle is greater than this cycle, should check cpuEventTest for updates
 u32 g_nextEventCycle = 0;
-
+u32 g_lastEventCycle = 0;
 // Shared portion of the branch test, called from both the Interpreter
 // and the recompiler.  (moved here to help alleviate redundant code)
 __fi void _cpuEventTest_Shared()
 {
 	eeEventTestIsActive = true;
 	g_nextEventCycle = cpuRegs.cycle + eeWaitCycles;
-
+	g_lastEventCycle = cpuRegs.cycle;
 	// ---- INTC / DMAC (CPU-level Exceptions) -----------------
 	// Done first because exceptions raised during event tests need to be postponed a few
 	// cycles (fixes Grandia II [PAL], which does a spin loop on a vsync and expects to
@@ -387,7 +387,7 @@ __fi void _cpuEventTest_Shared()
 	// escape/suspend hooks, and it's really a good idea to suspend/resume emulation before
 	// doing any actual meaningful branchtest logic.
 
-	if( cpuTestCycle( nextsCounter, nextCounter ) )
+	if ( cpuTestCycle( nextsCounter, nextCounter ) )
 	{
 		rcntUpdate();
 		_cpuTestPERF();

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -260,6 +260,7 @@ alignas(16) extern fpuRegisters fpuRegs;
 alignas(16) extern tlbs tlb[48];
 
 extern u32 g_nextEventCycle;
+extern u32 g_lastEventCycle;
 extern bool eeEventTestIsActive;
 extern u32 s_iLastCOP0Cycle;
 extern u32 s_iLastPERFCycle[2];


### PR DESCRIPTION
### Description of Changes
Adjusts the FIELD switch timing for PAL which is 3 scanlines instead of 3.5 (NTSC), probably won't affect much, if anything.
Adjusted the INTC hack to wait 8 cycles after the last event for INTC reads

### Rationale behind Changes
INTC:  if a game is in a tight loop reading it, else it could errantly skip to the next event which could be thousands of cycles away, this could incorrectly cause the EE to slow down.

Counter/GS: Field flip time was too late on PAL as it was timed for NTSC, now corrected.

### Suggested Testing Steps
Eh probably not worth testing, I guess just make sure nothing explodes.

No known fixes, just an accuracy update.
