### PR TITLE
PAD Linux: correct conversion of analog stick values.

### DIFF
--- a/pcsx2/PAD/Linux/KeyStatus.cpp
+++ b/pcsx2/PAD/Linux/KeyStatus.cpp
@@ -69,11 +69,11 @@ void KeyStatus::press(u32 pad, u32 index, s32 value)
 		// Force range :			  80 -> 0  -> 7F
 		// Normal mode : expect value 0  -> 80 -> FF
 		// Reverse mode: expect value FF -> 7F -> 0
-		u8 force = (value / 256);
+		u8 force = (value >> 8);
 		if (analog_is_reversed(pad, index))
 			analog_set(pad, index, m_analog_released_val - force);
 		else
-			analog_set(pad, index, m_analog_released_val + force);
+			analog_set(pad, index, m_analog_released_val + force + 1);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes #6408.
Makes feeding the emulator with analog stick values spanning 0x00-0xFF instead of 0x00-0xFE. That fixes assymetry of response to analog stick input in games.

Replacing division with bit shift got rid of rounding negative values up and allowed force to span 0x80 - 0x7F. Before, it spanned 0x81 - 0x7F.  For non-reversed input, 1 is added to the final value. This makes the result span values 0x00-0xFF instead 0x00-0xFE.

### Rationale behind Changes
Before fix, conversion generated values between 0x00 and 0xFE, leaving 0xFF out.
That caused assymetrical response from some games between between up and down or left and right camera/player movement.

### Suggested Testing Steps
Tested in Call of Duty: Finest Hour. In that game a difference between 0xFE and 0xFF in analog stick value is very perceptible for some reason. Might be tested also in other games.