### PR TITLE
GS: Avoid Div by 0 on WriteImage

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -832,7 +832,8 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const u8* src, int len, GIFRegB
 
 	int la = (l + (bsx - 1)) & ~(bsx - 1);
 	int ra = r & ~(bsx - 1);
-	int srcpitch = (r - l) * trbpp >> 3;
+	// Round up to the nearest byte (NFL 2K5 does r = 1, l = 0 bpp =4, causing divide by zero)
+	int srcpitch = (((r - l) * trbpp) + 7) >> 3;
 	int h = len / srcpitch;
 
 	if (ra - la >= bsx && h > 0) // "transfer width" >= "block width" && there is at least one full row


### PR DESCRIPTION
### Description of Changes
Avoids divide by zero on small write

### Rationale behind Changes
Divide by zero's are bad.

### Suggested Testing Steps
Probably not gonna bother, just making sure it compiles
