### PR TITLE
Turbo (Hold) Hotkey binding

### DIFF
--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -291,6 +291,7 @@ void PAD::SetDefaultConfig(SettingsInterface& si)
 	si.SetStringValue("Hotkeys", "TogglePause", "Keyboard/Space");
 	si.SetStringValue("Hotkeys", "ToggleSlowMotion", "Keyboard/Shift & Keyboard/Backtab");
 	si.SetStringValue("Hotkeys", "ToggleTurbo", "Keyboard/Tab");
+	si.SetStringValue("Hotkeys", "HoldTurbo", "Keyboard/Period");
 }
 
 void PAD::Update()

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -134,6 +134,7 @@ static u32 s_active_no_interlacing_patches = 0;
 static s32 s_current_save_slot = 1;
 static u32 s_frame_advance_count = 0;
 static u32 s_mxcsr_saved;
+static std::optional<LimiterModeType> s_limiter_mode_prior_to_hold_interaction;
 
 bool VMManager::PerformEarlyHardwareChecks(const char** error)
 {
@@ -1005,6 +1006,8 @@ void VMManager::Shutdown(bool save_resume_state)
 	s_active_game_fixes = 0;
 	s_active_widescreen_patches = 0;
 	s_active_no_interlacing_patches = 0;
+	s_limiter_mode_prior_to_hold_interaction.reset();
+
 	UpdateGameSettingsLayer();
 
 	std::string().swap(s_elf_override);
@@ -1044,6 +1047,7 @@ void VMManager::Reset()
 	s_active_game_fixes = 0;
 	s_active_widescreen_patches = 0;
 	s_active_no_interlacing_patches = 0;
+	s_limiter_mode_prior_to_hold_interaction.reset();
 
 	SysClearExecutionCache();
 	memBindConditionalHandlers();
@@ -1690,11 +1694,17 @@ DEFINE_HOTKEY("ToggleFrameLimit", "System", "Toggle Frame Limit", [](bool presse
 	}
 })
 DEFINE_HOTKEY("ToggleTurbo", "System", "Toggle Turbo", [](bool pressed) {
-	if (!pressed)
+	if (pressed && !s_limiter_mode_prior_to_hold_interaction.has_value())
 	{
-		VMManager::SetLimiterMode((EmuConfig.LimiterMode != LimiterModeType::Turbo) ?
+		s_limiter_mode_prior_to_hold_interaction = VMManager::GetLimiterMode();
+		VMManager::SetLimiterMode((s_limiter_mode_prior_to_hold_interaction.value() != LimiterModeType::Turbo) ?
                                       LimiterModeType::Turbo :
                                       LimiterModeType::Nominal);
+	}
+	else if (!pressed && s_limiter_mode_prior_to_hold_interaction.has_value())
+	{
+		VMManager::SetLimiterMode(s_limiter_mode_prior_to_hold_interaction.value());
+		s_limiter_mode_prior_to_hold_interaction.reset();
 	}
 })
 DEFINE_HOTKEY("ToggleSlowMotion", "System", "Toggle Slow Motion", [](bool pressed) {


### PR DESCRIPTION
Fixes #5538
Acts as a temporary flip-flop switch while held that either enables turbo while held or disables turbo while held if you've already toggled turbo.

Default bind is Keyboard/Period but happy to make this unbound if preferred.
