### PR TITLE
GS: Only enable scanmsk offset on frames that need it

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -374,6 +374,8 @@ bool GSRenderer::Merge(int field)
 		}
 	}
 
+	m_scanmask_used = false;
+
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes
Only enable DISPLAY merge offset for scan mask for frames which actually use scan mask

### Rationale behind Changes
Some users found it frustrating that once the game used scanmask it made the picture "blurry" and then it never went back again.  Problem is, in the case of Metal Gear Solid 2, the game is *supposed* to have that blur all the time, but we disable it to give people a nicer picture, however scan mask (MGS2 uses for some transparency effects) doesn't work if we do that, so it needs to be offset by 1 pixel, causing the picture to shift down and the picture to become blurrier.  This can be mostly mitigated/made less noticeable by increasing your internal resolution.

### Suggested Testing Steps
Test GT4, MGS2, MGS3, Alpine Racer 3, make sure they all still work okay.

Fixes #6411 as best as possible. (it was either this or always blurry)