### PR TITLE
GS: Fix overflow calculation from errantly going off.

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -132,7 +132,6 @@ class GSState : public GSAlignedClass<32>
 	{
 		int x, y;
 		int start, end, total;
-		bool overflow;
 		u8* buff;
 		GIFRegBITBLTBUF m_blit;
 


### PR DESCRIPTION
### Description of Changes
fixes overflow message/warning calculation.

### Rationale behind Changes
It was being set to zero sometimes and going off by accident.

### Suggested Testing Steps
See if the CI builds, then I'm merging.
