### PR TITLE
Qt: Change the word “Save Slot” to “Load Slot” in Load State menu

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2045,7 +2045,7 @@ void MainWindow::populateLoadStateMenu(QMenu* menu, const QString& filename, con
 		if (!FileSystem::StatFile(state_filename.c_str(), &sd))
 			continue;
 
-		action = menu->addAction(tr("Save Slot %1 (%2)").arg(i).arg(formatTimestampForSaveStateMenu(sd.ModificationTime)));
+		action = menu->addAction(tr("Load Slot %1 (%2)").arg(i).arg(formatTimestampForSaveStateMenu(sd.ModificationTime)));
 		connect(action, &QAction::triggered, [this, i]() { loadSaveStateSlot(i); });
 	}
 }


### PR DESCRIPTION
Fixes #6395, partially.

### Description of Changes
Under “Load State” button, “Save Slot #” becomes “Load Slot #”.

### Rationale behind Changes
Because the word “Save Slot” under “Load State” button is a little bit confusing.

![PCSX2LoadState](https://user-images.githubusercontent.com/11696957/173204126-a1b18886-776d-4938-ae65-a6e975f84e0e.png)

### Suggested Testing Steps
I must admit, I **HAVE NOT** compiled the project to see if my change breaks the whole thing or not. I just searched the entire repository for `Save Slot` and renamed the one related to `loadSaveStateSlot`.
