### PR TITLE
GameDB: Port the Midnight Club 3 patch to NTSC-U v2.00

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -41263,6 +41263,15 @@ SLUS-21029:
   gsHWFixes:
     wildArmsHack: 1 # Fixes post-processing misalignment.
   patches:
+    0DD3417A:
+      content: |-
+        comment=Patch by Refraction
+        // Patches a CTC2 write to FBRST to not set the T-Bit enable
+        // Fixes slow speed in MTVU due to developers leaving T-Bit enabled and not using it
+        // PCSX2 has to sync more when T-Bit is enabled so the game spends more time waiting
+        // for VU1 to finish, which reduces the advantage of MTVU to basically zero.
+        patch=1,EE,D0525B3C,extended,00000800
+        patch=1,EE,20525B3C,extended,00000000
     4A0E5B3A:
       content: |-
         comment=Patch by Refraction


### PR DESCRIPTION
### Description of Changes
refraction's T-Bit patch for the NTSC-U version of Midnight Club 3 (non-Remix) was made only for v1.04. This PR ports the patch to v2.00.

### Suggested Testing Steps
Verify that Midnight Club 3: DUB Edition NTSC-U v2.00 (SLUS-21029, CRC 0DD3417A) isn't sloww anymore.
