### PR TITLE
PAD: changed freeze data size in Linux for cross-platform compatibility

### DIFF
--- a/pcsx2/PAD/Linux/state_management.h
+++ b/pcsx2/PAD/Linux/state_management.h
@@ -120,6 +120,9 @@ struct PadFullFreezeData
 	u8 slot[2];
 	PadFreezeData padData[2][4];
 	QueryInfo query;
+	// unused padding data, present only so that data size
+	// matches Windows version for cross-platform save/load
+	char padding[8];
 };
 
 extern QueryInfo query;


### PR DESCRIPTION
### Description of Changes
Padding of 8 bytes was added to the Linux's PAD's freeze data structure so the size matches the Windows' PAD's freeze data structure's size.

### Rationale behind Changes
Fixes #6424.

When PAD's freeze (state) data has lower size than expected, the state loading will abort with an error, even though pad data is not essential and the load method checks if data is incompatible and skips loading if it is.

Because of that, states created in Linux were not loadable in Windows. But it was possible the other way around.

Matching the sizes between Linux and Windows prevents aborting and states are properly loaded without PAD data when switching between platforms.

Unfortunately, the states saved in older version of PCSX2 on Linux **will not be loadable after this fix**.

See #6424.

### Suggested Testing Steps
Save state in Linux and load in Windows and vice versa.