### PR TITLE
DEV9: Add Per Game Host List Support

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -42,6 +42,7 @@ private Q_SLOTS:
 	void onEthHostDel();
 	void onEthHostExport();
 	void onEthHostImport();
+	void onEthHostPerGame();
 	void onEthHostEdit(QStandardItem* item);
 
 	void onHddEnabledChanged(int state);
@@ -63,7 +64,8 @@ private:
 	void AddAdapter(const AdapterEntry& adapter);
 	void RefreshHostList();
 	int CountHostsConfig();
-	std::vector<HostEntryUi> ListHostsConfig();
+	std::optional<std::vector<HostEntryUi>> ListHostsConfig();
+	std::vector<HostEntryUi> ListBaseHostsConfig();
 	void AddNewHostConfig(const HostEntryUi& host);
 	void DeleteHostConfig(int index);
 

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -207,6 +207,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QPushButton" name="ethHostPerGame">
+              <property name="text">
+               <string>Per game</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Vertical</enum>


### PR DESCRIPTION
### Description of Changes
Adds the ability to use per game settings for the internal DNS host list

### Rationale behind Changes
More per-game settings

### Suggested Testing Steps
Test if the DNS host list works on a per game basis (when overridden)
