### PR TITLE
Qt: Fix compiling with spaces in path on Windows

### DIFF
--- a/common/vsprops/QtCompile.props
+++ b/common/vsprops/QtCompile.props
@@ -79,7 +79,7 @@
   <PropertyGroup>
     <MocDefines></MocDefines>
     <MocDefines Condition="!$(Configuration.Contains(Debug))">-DQT_NO_DEBUG -DNDEBUG $(MocDefines)</MocDefines>
-    <MocIncludes>"-I$(QtIncludeDir)" "-I$(SolutionDir)pcsx2" "-I$(SolutionDir)" -I.</MocIncludes>
+    <MocIncludes>-I"$(QtIncludeDir)." -I"$(SolutionDir)pcsx2" "-I$(SolutionDir)." -I.</MocIncludes>
   </PropertyGroup>
   <Target Name="QtMoc"
     BeforeTargets="ClCompile"


### PR DESCRIPTION
See title. Dot is necessary because `$(QtIncludeDir)` includes a trailing slash, which gets turned into `\"`, and not treated as a closing quote.