### PR TITLE
GSRunner: Add standalone GS runner/dumper

### DIFF
--- a/PCSX2_qt.sln
+++ b/PCSX2_qt.sln
@@ -57,6 +57,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "updater", "updater\updater.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpuinfo", "3rdparty\cpuinfo\cpuinfo.vcxproj", "{7E183337-A7E9-460C-9D3D-568BC9F9BCC1}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pcsx2-gsrunner", "pcsx2-gsrunner\pcsx2-gsrunner.vcxproj", "{BB98BF81-A132-444A-BB81-96D510F433A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug AVX2|x64 = Debug AVX2|x64
@@ -379,6 +381,12 @@ Global
 		{7E183337-A7E9-460C-9D3D-568BC9F9BCC1}.Release AVX2|x64.Build.0 = Release|x64
 		{7E183337-A7E9-460C-9D3D-568BC9F9BCC1}.Release|x64.ActiveCfg = Release|x64
 		{7E183337-A7E9-460C-9D3D-568BC9F9BCC1}.Release|x64.Build.0 = Release|x64
+		{BB98BF81-A132-444A-BB81-96D510F433A8}.Debug AVX2|x64.ActiveCfg = Debug AVX2|x64
+		{BB98BF81-A132-444A-BB81-96D510F433A8}.Debug|x64.ActiveCfg = Debug|x64
+		{BB98BF81-A132-444A-BB81-96D510F433A8}.Devel AVX2|x64.ActiveCfg = Devel AVX2|x64
+		{BB98BF81-A132-444A-BB81-96D510F433A8}.Devel|x64.ActiveCfg = Devel|x64
+		{BB98BF81-A132-444A-BB81-96D510F433A8}.Release AVX2|x64.ActiveCfg = Release AVX2|x64
+		{BB98BF81-A132-444A-BB81-96D510F433A8}.Release|x64.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pcsx2-gsrunner/CMakeLists.txt
+++ b/pcsx2-gsrunner/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_executable(pcsx2-gsrunnner)
+
+if (PACKAGE_MODE)
+	install(TARGETS pcsx2-gsrunnner DESTINATION ${CMAKE_INSTALL_BINDIR})
+else()
+	install(TARGETS pcsx2-gsrunnner DESTINATION ${CMAKE_SOURCE_DIR}/bin)
+endif()
+
+target_sources(pcsx2-gsrunner PRIVATE
+	Main.cpp
+)
+
+target_include_directories(pcsx2-gsrunner PRIVATE
+	"${CMAKE_BINARY_DIR}/common/include"
+	"${CMAKE_SOURCE_DIR}/pcsx2"
+)
+
+target_link_libraries(pcsx2-gsrunner PRIVATE
+	PCSX2_FLAGS
+	PCSX2
+)

--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -1,0 +1,629 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <csignal>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#ifdef _WIN32
+#include "common/RedtapeWindows.h"
+#endif
+
+#include "fmt/core.h"
+
+#include "common/Assertions.h"
+#include "common/Console.h"
+#include "common/Exceptions.h"
+#include "common/FileSystem.h"
+#include "common/Path.h"
+#include "common/SettingsWrapper.h"
+#include "common/StringUtil.h"
+
+#include "pcsx2/PrecompiledHeader.h"
+
+#include "pcsx2/CDVD/CDVD.h"
+#include "pcsx2/Frontend/InputManager.h"
+#include "pcsx2/Frontend/ImGuiManager.h"
+#include "pcsx2/Frontend/INISettingsInterface.h"
+#include "pcsx2/Frontend/LogSink.h"
+#include "pcsx2/GS.h"
+#include "pcsx2/GS/GS.h"
+#include "pcsx2/GSDumpReplayer.h"
+#include "pcsx2/HostDisplay.h"
+#include "pcsx2/HostSettings.h"
+#include "pcsx2/PerformanceMetrics.h"
+#include "pcsx2/VMManager.h"
+
+#include "svnrev.h"
+
+namespace GSRunner
+{
+	static bool InitializeConfig();
+	static bool SetCriticalFolders();
+
+	static bool CreatePlatformWindow();
+	static void DestroyPlatformWindow();
+	static std::optional<WindowInfo> GetPlatformWindowInfo();
+	static void PumpPlatformMessages();
+} // namespace GSRunner
+
+static constexpr u32 WINDOW_WIDTH = 640;
+static constexpr u32 WINDOW_HEIGHT = 480;
+
+static std::unique_ptr<INISettingsInterface> s_settings_interface;
+static std::unique_ptr<HostDisplay> s_host_display;
+alignas(16) static SysMtgsThread s_mtgs_thread;
+
+static std::string s_output_prefix;
+static s32 s_loop_count = 1;
+
+bool GSRunner::SetCriticalFolders()
+{
+	EmuFolders::AppRoot = Path::Canonicalize(Path::GetDirectory(FileSystem::GetProgramPath()));
+	EmuFolders::Resources = Path::Combine(EmuFolders::AppRoot, "resources");
+	EmuFolders::DataRoot = EmuFolders::AppRoot;
+
+	// allow SetDataDirectory() to change settings directory (if we want to split config later on)
+	if (EmuFolders::Settings.empty())
+		EmuFolders::Settings = Path::Combine(EmuFolders::DataRoot, "inis");
+
+	// the resources directory should exist, bail out if not
+	if (!FileSystem::DirectoryExists(EmuFolders::Resources.c_str()))
+	{
+		Console.Error("Resources directory is missing, your installation is incomplete.");
+		return false;
+	}
+
+	return true;
+}
+
+bool GSRunner::InitializeConfig()
+{
+	if (!SetCriticalFolders())
+		return false;
+
+	// don't provide an ini path, or bother loading. we'll store everything in memory.
+	s_settings_interface = std::make_unique<INISettingsInterface>(std::string());
+	Host::Internal::SetBaseSettingsLayer(s_settings_interface.get());
+
+	// set defaults, we'll override them later
+	EmuConfig = Pcsx2Config();
+	EmuFolders::SetDefaults();
+	EmuFolders::EnsureFoldersExist();
+	{
+		SettingsSaveWrapper wrapper(*s_settings_interface.get());
+		EmuConfig.LoadSave(wrapper);
+	}
+
+	// complete as quickly as possible
+	s_settings_interface->SetBoolValue("EmuCore/GS", "FrameLimitEnable", false);
+	s_settings_interface->SetIntValue("EmuCore/GS", "VsyncEnable", static_cast<int>(VsyncMode::Off));
+
+	// ensure all input sources are disabled, we're not using them
+	s_settings_interface->SetBoolValue("InputSources", "SDL", false);
+	s_settings_interface->SetBoolValue("InputSources", "XInput", false);
+
+	// we don't need any sound output
+	s_settings_interface->SetStringValue("SPU2/Output", "OutputModule", "nullout");
+
+	// force logging
+	s_settings_interface->SetBoolValue("Logging", "EnableSystemConsole", true);
+	s_settings_interface->SetBoolValue("Logging", "EnableTimestamps", true);
+	s_settings_interface->SetBoolValue("Logging", "EnableVerbose", true);
+	Host::UpdateLogging();
+
+	return true;
+}
+
+std::optional<std::vector<u8>> Host::ReadResourceFile(const char* filename)
+{
+	const std::string path(Path::Combine(EmuFolders::Resources, filename));
+	std::optional<std::vector<u8>> ret(FileSystem::ReadBinaryFile(path.c_str()));
+	if (!ret.has_value())
+		Console.Error("Failed to read resource file '%s'", filename);
+	return ret;
+}
+
+std::optional<std::string> Host::ReadResourceFileToString(const char* filename)
+{
+	const std::string path(Path::Combine(EmuFolders::Resources, filename));
+	std::optional<std::string> ret(FileSystem::ReadFileToString(path.c_str()));
+	if (!ret.has_value())
+		Console.Error("Failed to read resource file to string '%s'", filename);
+	return ret;
+}
+
+void Host::ReportErrorAsync(const std::string_view& title, const std::string_view& message)
+{
+	if (!title.empty() && !message.empty())
+	{
+		Console.Error(
+			"ReportErrorAsync: %.*s: %.*s", static_cast<int>(title.size()), title.data(), static_cast<int>(message.size()), message.data());
+	}
+	else if (!message.empty())
+	{
+		Console.Error("ReportErrorAsync: %.*s", static_cast<int>(message.size()), message.data());
+	}
+}
+
+void Host::OnInputDeviceConnected(const std::string_view& identifier, const std::string_view& device_name)
+{
+}
+
+void Host::OnInputDeviceDisconnected(const std::string_view& identifier)
+{
+}
+
+HostDisplay* Host::GetHostDisplay()
+{
+	return s_host_display.get();
+}
+
+HostDisplay* Host::AcquireHostDisplay(HostDisplay::RenderAPI api)
+{
+	const std::optional<WindowInfo> wi(GSRunner::GetPlatformWindowInfo());
+	if (!wi.has_value())
+		return nullptr;
+
+	s_host_display = HostDisplay::CreateDisplayForAPI(api);
+	if (!s_host_display)
+		return nullptr;
+
+	if (!s_host_display->CreateRenderDevice(wi.value(), Host::GetStringSettingValue("EmuCore/GS", "Adapter", ""),
+			EmuConfig.GetEffectiveVsyncMode(), Host::GetBoolSettingValue("EmuCore/GS", "ThreadedPresentation", false),
+			Host::GetBoolSettingValue("EmuCore/GS", "UseDebugDevice", false)) ||
+		!s_host_display->MakeRenderContextCurrent() || !s_host_display->InitializeRenderDevice(EmuFolders::Cache, false) ||
+		!ImGuiManager::Initialize())
+	{
+		ReleaseHostDisplay();
+		return nullptr;
+	}
+
+	Console.WriteLn(Color_StrongGreen, "%s Graphics Driver Info:", HostDisplay::RenderAPIToString(s_host_display->GetRenderAPI()));
+	Console.Indent().WriteLn(s_host_display->GetDriverInfo());
+
+	return s_host_display.get();
+}
+
+void Host::ReleaseHostDisplay()
+{
+	if (!s_host_display)
+		return;
+
+	ImGuiManager::Shutdown();
+
+	s_host_display->DestroyRenderSurface();
+	s_host_display->DestroyRenderDevice();
+	s_host_display.reset();
+}
+
+bool Host::BeginPresentFrame(bool frame_skip)
+{
+	return s_host_display->BeginPresent(frame_skip);
+}
+
+void Host::EndPresentFrame()
+{
+	s_host_display->EndPresent();
+	ImGuiManager::NewFrame();
+}
+
+void Host::ResizeHostDisplay(u32 new_window_width, u32 new_window_height, float new_window_scale)
+{
+}
+
+void Host::UpdateHostDisplay()
+{
+}
+
+void Host::RequestResizeHostDisplay(s32 width, s32 height)
+{
+}
+
+void Host::OnVMStarting()
+{
+}
+
+void Host::OnVMStarted()
+{
+}
+
+void Host::OnVMDestroyed()
+{
+}
+
+void Host::OnVMPaused()
+{
+}
+
+void Host::OnVMResumed()
+{
+}
+
+void Host::OnGameChanged(const std::string& disc_path, const std::string& game_serial, const std::string& game_name, u32 game_crc)
+{
+}
+
+void Host::OnPerformanceMetricsUpdated()
+{
+}
+
+void Host::OnSaveStateLoading(const std::string_view& filename)
+{
+}
+
+void Host::OnSaveStateLoaded(const std::string_view& filename, bool was_successful)
+{
+}
+
+void Host::OnSaveStateSaved(const std::string_view& filename)
+{
+}
+
+void Host::InvalidateSaveStateCache()
+{
+}
+
+void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false */)
+{
+	pxFailRel("Not implemented");
+}
+
+void Host::RefreshGameListAsync(bool invalidate_cache)
+{
+}
+
+void Host::CancelGameListRefresh()
+{
+}
+
+bool Host::IsFullscreen()
+{
+	return false;
+}
+
+void Host::SetFullscreen(bool enabled)
+{
+}
+
+void Host::RequestExit(bool save_state_if_running)
+{
+}
+
+void Host::RequestVMShutdown(bool save_state)
+{
+	VMManager::SetState(VMState::Stopping);
+}
+
+std::optional<u32> InputManager::ConvertHostKeyboardStringToCode(const std::string_view& str)
+{
+	return std::nullopt;
+}
+
+std::optional<std::string> InputManager::ConvertHostKeyboardCodeToString(u32 code)
+{
+	return std::nullopt;
+}
+
+SysMtgsThread& GetMTGS()
+{
+	return s_mtgs_thread;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Interface Stuff
+//////////////////////////////////////////////////////////////////////////
+
+const IConsoleWriter* PatchesCon = &Console;
+BEGIN_HOTKEY_LIST(g_host_hotkeys)
+END_HOTKEY_LIST()
+
+static void PrintCommandLineVersion()
+{
+	std::fprintf(stderr, "PCSX2 GS Runner Version %s\n", GIT_REV);
+	std::fprintf(stderr, "https://pcsx2.net/\n");
+	std::fprintf(stderr, "\n");
+}
+
+static void PrintCommandLineHelp(const char* progname)
+{
+	PrintCommandLineVersion();
+	std::fprintf(stderr, "Usage: %s [parameters] [--] [filename]\n", progname);
+	std::fprintf(stderr, "\n");
+	std::fprintf(stderr, "  -help: Displays this information and exits.\n");
+	std::fprintf(stderr, "  -version: Displays version information and exits.\n");
+	std::fprintf(stderr, "  -dumpdir <dir>: Frame dump directory (will be dumped as filename_frameN.png).\n");
+	std::fprintf(stderr, "  -loop <count>: Loops dump playback N times. Defaults to 1. 0 will loop infinitely.\n");
+	std::fprintf(stderr, "  -renderer <renderer>: Sets the graphics renderer. Defaults to Auto.\n");
+	std::fprintf(stderr, "  --: Signals that no more arguments will follow and the remaining\n"
+						 "    parameters make up the filename. Use when the filename contains\n"
+						 "    spaces or starts with a dash.\n");
+	std::fprintf(stderr, "\n");
+}
+
+static bool ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& params)
+{
+	bool no_more_args = false;
+	for (int i = 1; i < argc; i++)
+	{
+		if (!no_more_args)
+		{
+#define CHECK_ARG(str) !std::strcmp(argv[i], str)
+#define CHECK_ARG_PARAM(str) (!std::strcmp(argv[i], str) && ((i + 1) < argc))
+
+			if (CHECK_ARG("-help"))
+			{
+				PrintCommandLineHelp(argv[0]);
+				return false;
+			}
+			else if (CHECK_ARG("-version"))
+			{
+				PrintCommandLineVersion();
+				return false;
+			}
+			else if (CHECK_ARG_PARAM("-dumpdir"))
+			{
+				s_output_prefix = argv[++i];
+				if (s_output_prefix.empty())
+				{
+					Console.Error("Invalid dump directory specified.");
+					return false;
+				}
+
+				continue;
+			}
+			else if (CHECK_ARG_PARAM("-loop"))
+			{
+				s_loop_count = StringUtil::FromChars<s32>(argv[++i]).value_or(0);
+				Console.WriteLn("Looping dump playback %d times.", s_loop_count);
+				continue;
+			}
+			else if (CHECK_ARG_PARAM("-renderer"))
+			{
+				const char* rname = argv[++i];
+
+				GSRendererType type = GSRendererType::Auto;
+				if (StringUtil::Strcasecmp(rname, "Auto"))
+					type = GSRendererType::Auto;
+#ifdef _WIN32
+				else if (StringUtil::Strcasecmp(rname, "dx11"))
+					type = GSRendererType::DX11;
+				else if (StringUtil::Strcasecmp(rname, "dx12"))
+					type = GSRendererType::DX12;
+#endif
+#ifdef ENABLE_OPENGL
+				else if (StringUtil::Strcasecmp(rname, "gl"))
+					type = GSRendererType::OGL;
+#endif
+#ifdef ENABLE_VULKAN
+				else if (StringUtil::Strcasecmp(rname, "vulkan"))
+					type = GSRendererType::VK;
+#endif
+#ifdef __APPLE__
+				else if (StringUtil::Strcasecmp(rname, "metal"))
+					type = GSRendererType::Metal;
+#endif
+				else if (StringUtil::Strcasecmp(rname, "sw"))
+					type = GSRendererType::SW;
+				else
+				{
+					Console.Error("Unknown renderer '%s'", rname);
+					return false;
+				}
+
+				Console.WriteLn("Using %s renderer.", Pcsx2Config::GSOptions::GetRendererName(type));
+				s_settings_interface->SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(type));
+				continue;
+			}
+			else if (CHECK_ARG("--"))
+			{
+				no_more_args = true;
+				continue;
+			}
+			else if (argv[i][0] == '-')
+			{
+				Console.Error("Unknown parameter: '%s'", argv[i]);
+				return false;
+			}
+
+#undef CHECK_ARG
+#undef CHECK_ARG_PARAM
+		}
+
+		if (!params.filename.empty())
+			params.filename += ' ';
+		params.filename += argv[i];
+	}
+
+	if (params.filename.empty())
+	{
+		Console.Error("No dump filename provided.");
+		return false;
+	}
+
+	if (!VMManager::IsGSDumpFileName(params.filename))
+	{
+		Console.Error("Provided filename is not a GS dump.");
+		return false;
+	}
+
+	// set up the frame dump directory
+	if (!s_output_prefix.empty())
+	{
+		// strip off all extensions
+		std::string_view title(Path::GetFileTitle(params.filename));
+		if (StringUtil::EndsWithNoCase(title, ".gs"))
+			title = Path::GetFileTitle(title);
+
+		s_output_prefix = Path::Combine(s_output_prefix, title);
+		Console.WriteLn(fmt::format("Saving dumps as {}_frameN.png", s_output_prefix));
+	}
+
+	return true;
+}
+
+int main(int argc, char* argv[])
+{
+	Host::InitializeEarlyConsole();
+
+	if (!GSRunner::InitializeConfig())
+	{
+		Console.Error("Failed to initialize config.");
+		return false;
+	}
+
+	VMBootParameters params;
+	if (!ParseCommandLineArgs(argc, argv, params))
+		return false;
+
+	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle::GetForCallingThread());
+	if (!VMManager::Internal::InitializeGlobals() || !VMManager::Internal::InitializeMemory())
+	{
+		Console.Error("Failed to allocate globals/memory.");
+		return false;
+	}
+
+	if (!GSRunner::CreatePlatformWindow())
+	{
+		Console.Error("Failed to create window.");
+		return false;
+	}
+
+	if (VMManager::Initialize(params))
+	{
+		// run until end
+		GSDumpReplayer::SetLoopCount(s_loop_count);
+		VMManager::SetState(VMState::Running);
+		while (VMManager::GetState() == VMState::Running)
+			VMManager::Execute();
+		VMManager::Shutdown(false);
+	}
+
+	InputManager::CloseSources();
+	VMManager::Internal::ReleaseMemory();
+	PerformanceMetrics::SetCPUThread(Threading::ThreadHandle());
+	GSRunner::DestroyPlatformWindow();
+
+	return EXIT_SUCCESS;
+}
+
+void Host::PumpMessagesOnCPUThread()
+{
+	if (!s_output_prefix.empty())
+	{
+		// wait for the previous frame to complete (and thus dump)
+		GetMTGS().WaitGS(false, false, false);
+
+		// queue dumping of this frame
+		std::string dump_path(fmt::format("{}_frame{}.png", s_output_prefix, GSDumpReplayer::GetFrameNumber()));
+		GetMTGS().RunOnGSThread([dump_path = std::move(dump_path)]() { GSQueueSnapshot(dump_path); });
+	}
+
+	// process any window messages (but we shouldn't really have any)
+	GSRunner::PumpPlatformMessages();
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Platform specific code
+//////////////////////////////////////////////////////////////////////////
+
+#ifdef _WIN32
+
+static constexpr LPCWSTR WINDOW_CLASS_NAME = L"PCSX2GSRunner";
+static HWND s_hwnd = NULL;
+
+static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+bool GSRunner::CreatePlatformWindow()
+{
+	WNDCLASSEXW wc = {};
+	wc.cbSize = sizeof(WNDCLASSEXW);
+	wc.style = 0;
+	wc.lpfnWndProc = WndProc;
+	wc.cbClsExtra = 0;
+	wc.cbWndExtra = 0;
+	wc.hInstance = GetModuleHandle(nullptr);
+	wc.hIcon = NULL;
+	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+	wc.lpszMenuName = NULL;
+	wc.lpszClassName = WINDOW_CLASS_NAME;
+	wc.hIconSm = NULL;
+
+	if (!RegisterClassExW(&wc))
+	{
+		Console.Error("Window registration failed.");
+		return false;
+	}
+
+	s_hwnd = CreateWindowExW(WS_EX_CLIENTEDGE, WINDOW_CLASS_NAME, L"PCSX2 GS Runner",
+		WS_OVERLAPPEDWINDOW | WS_CAPTION | WS_MINIMIZEBOX | WS_SYSMENU | WS_SIZEBOX, CW_USEDEFAULT, CW_USEDEFAULT, WINDOW_WIDTH,
+		WINDOW_HEIGHT, nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+	if (!s_hwnd)
+	{
+		Console.Error("CreateWindowEx failed.");
+		return false;
+	}
+
+	ShowWindow(s_hwnd, SW_SHOW);
+	UpdateWindow(s_hwnd);
+
+	// make sure all messages are processed before returning
+	PumpPlatformMessages();
+	return true;
+}
+
+void GSRunner::DestroyPlatformWindow()
+{
+	if (!s_hwnd)
+		return;
+
+	PumpPlatformMessages();
+	DestroyWindow(s_hwnd);
+	s_hwnd = {};
+}
+
+std::optional<WindowInfo> GSRunner::GetPlatformWindowInfo()
+{
+	RECT rc = {};
+	GetWindowRect(s_hwnd, &rc);
+
+	WindowInfo wi;
+	wi.surface_width = static_cast<u32>(rc.right - rc.left);
+	wi.surface_height = static_cast<u32>(rc.bottom - rc.top);
+	wi.surface_scale = 1.0f;
+	wi.type = WindowInfo::Type::Win32;
+	wi.window_handle = s_hwnd;
+	return wi;
+}
+
+void GSRunner::PumpPlatformMessages()
+{
+	MSG msg;
+	while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
+	{
+		TranslateMessage(&msg);
+		DispatchMessageW(&msg);
+	}
+}
+
+LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+#endif // _WIN32

--- a/pcsx2-gsrunner/pcsx2-gsrunner.vcxproj
+++ b/pcsx2-gsrunner/pcsx2-gsrunner.vcxproj
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)common\vsprops\BaseProjectConfig.props" />
+  <Import Project="$(SolutionDir)common\vsprops\ProjectConfigAVX2.props" />
+  <Import Project="$(SolutionDir)common\vsprops\WinSDK.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{BB98BF81-A132-444A-BB81-96D510F433A8}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization Condition="$(Configuration.Contains(Release))">true</WholeProgramOptimization>
+    <UseDebugLibraries Condition="$(Configuration.Contains(Debug))">true</UseDebugLibraries>
+    <UseDebugLibraries Condition="!$(Configuration.Contains(Debug))">false</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)common\vsprops\common.props" />
+    <Import Project="$(SolutionDir)common\vsprops\BaseProperties.props" />
+    <Import Project="$(SolutionDir)common\vsprops\3rdpartyDeps.props" />
+    <Import Condition="$(Configuration.Contains(Debug))" Project="$(SolutionDir)common\vsprops\CodeGen_Debug.props" />
+    <Import Condition="$(Configuration.Contains(Devel))" Project="$(SolutionDir)common\vsprops\CodeGen_Devel.props" />
+    <Import Condition="$(Configuration.Contains(Release))" Project="$(SolutionDir)common\vsprops\CodeGen_Release.props" />
+    <Import Condition="!$(Configuration.Contains(Release))" Project="$(SolutionDir)common\vsprops\IncrementalLinking.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <TargetName>$(EXEString)</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\xbyak;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\freetype\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\xz\xz\src\liblzma\api;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\baseclasses;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\libpng;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\glad\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)3rdparty\simpleini\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)pcsx2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Needed for moc pch -->
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ProjectDir)\Settings;$(ProjectDir)\GameList</AdditionalIncludeDirectories>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_OPENGL;ENABLE_VULKAN;DIRECTINPUT_VERSION=0x0800;PCSX2_CORE;DISABLE_RECORDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(Devel))">PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(Release))">NDEBUG;_SECURE_SCL_=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(CI)'=='true'">PCSX2_CI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="!$(Configuration.Contains(AVX2))">_M_SSE=0x401;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(AVX2))">_M_SSE=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- This flag will throw a warning on x64 as SSE2 is implied-->
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'!='x64'">StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="$(Configuration.Contains(AVX2))">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
+      <!-- SH 2/3 flashlight, explicitly set here don't change -->
+      <!-- https://github.com/PCSX2/pcsx2/commit/16431653e4d92fda4069031897e24fbe4688d36a -->
+      <FloatingPointModel>Precise</FloatingPointModel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalOptions>/Zc:__cplusplus /Zo /utf-8%(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <LargeAddressAware>Yes</LargeAddressAware>
+      <AdditionalDependencies>comctl32.lib;ws2_32.lib;shlwapi.lib;winmm.lib;rpcrt4.lib;iphlpapi.lib;dsound.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;PowrProf.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)3rdparty\baseclasses\baseclasses.vcxproj">
+      <Project>{27f17499-a372-4408-8afa-4f9f4584fbd3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\fmt\fmt.vcxproj">
+      <Project>{449ad25e-424a-4714-babc-68706cdcc33b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\libjpeg\libjpeg.vcxproj">
+      <Project>{bc236261-77e8-4567-8d09-45cd02965eb6}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\libpng\projects\vstudio\libpng\libpng.vcxproj">
+      <Project>{d6973076-9317-4ef2-a0b8-b7a18ac0713e}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\libsamplerate\libsamplerate.vcxproj">
+      <Project>{47afdbef-f15f-4bc0-b436-5be443c3f80f}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\soundtouch\SoundTouch.vcxproj">
+      <Project>{e9b51944-7e6d-4bcd-83f2-7bbd5a46182d}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\xz\liblzma.vcxproj">
+      <Project>{12728250-16ec-4dc6-94d7-e21dd88947f8}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\libchdr\libchdr.vcxproj">
+      <Project>{a0d2b3ad-1f72-4ee3-8b5c-f2c358da35f0}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\zlib\zlib.vcxproj">
+      <Project>{2f6c0388-20cb-4242-9f6c-a6ebb6a83f47}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\jpgd\jpgd.vcxproj">
+      <Project>{ed2f21fd-0a36-4a8f-9b90-e7d92a2acb63}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\imgui\imgui.vcxproj">
+      <Project>{88fb34ec-845e-4f21-a552-f1573b9ed167}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)common\common.vcxproj">
+      <Project>{4639972e-424e-4e13-8b07-ca403c481346}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)pcsx2\pcsx2core.vcxproj">
+      <Project>{6c7986c4-3e4d-4dcc-b3c6-6bb12b238995}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)3rdparty\glad\glad.vcxproj">
+      <Project>{c0293b32-5acf-40f0-aa6c-e6da6f3bf33a}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/pcsx2-gsrunner/pcsx2-gsrunner.vcxproj.filters
+++ b/pcsx2-gsrunner/pcsx2-gsrunner.vcxproj.filters
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+</Project>

--- a/pcsx2-gsrunner/test_check_dumps.py
+++ b/pcsx2-gsrunner/test_check_dumps.py
@@ -1,0 +1,84 @@
+import argparse
+import glob
+import sys
+import os
+import re
+import hashlib
+
+from pathlib import Path
+
+def compare_frames(path1, path2):
+    try:
+        with open(path1, "rb") as f:
+            hash1 = hashlib.md5(f.read()).digest()
+        with open(path2, "rb") as f:
+            hash2 = hashlib.md5(f.read()).digest()
+
+        return hash1 == hash2
+    except:
+        return False
+
+
+def check_regression_test(baselinedir, testdir, name):
+    #print("Checking '%s'..." % name)
+
+    dir1 = os.path.join(baselinedir, name)
+    dir2 = os.path.join(testdir, name)
+    if not os.path.isdir(dir2):
+        #print("*** %s is missing in test set" % name)
+        return False
+
+    images = glob.glob(os.path.join(dir1, "*_frame*.png"))
+    diff_frames = []
+    for imagepath in images:
+        imagename = Path(imagepath).name
+        matches = re.match(".*_frame([0-9]+).png", imagename)
+        if matches is None:
+            continue
+
+        framenum = int(matches[1])
+        
+        path1 = os.path.join(dir1, imagename)
+        path2 = os.path.join(dir2, imagename)
+        if not os.path.isfile(path2):
+            print("--- Frame %u for %s is missing in test set" % (framenum, name))
+            return False
+
+        if not compare_frames(path1, path2):
+            diff_frames.append(framenum)
+
+    if len(diff_frames) > 0:
+        print("*** Difference in frames [%s] for %s" % (",".join(map(str, diff_frames)), name))
+        return False
+
+    return True
+
+
+def check_regression_tests(baselinedir, testdir):
+    gamedirs = glob.glob(baselinedir + "/*", recursive=False)
+    
+    success = 0
+    failure = 0
+
+    for gamedir in gamedirs:
+        name = Path(gamedir).name
+        if check_regression_test(baselinedir, testdir, name):
+            success += 1
+        else:
+            failure += 1
+
+    return (failure == 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check frame dump images for regression tests")
+    parser.add_argument("-baselinedir", action="store", required=True, help="Directory containing baseline frames to check against")
+    parser.add_argument("-testdir", action="store", required=True, help="Directory containing frames to check")
+
+    args = parser.parse_args()
+
+    if not check_regression_tests(os.path.realpath(args.baselinedir), os.path.realpath(args.testdir)):
+        sys.exit(1)
+    else:
+        sys.exit(0)
+

--- a/pcsx2-gsrunner/test_run_dumps.py
+++ b/pcsx2-gsrunner/test_run_dumps.py
@@ -1,0 +1,81 @@
+import argparse
+import glob
+import sys
+import os
+import subprocess
+import multiprocessing
+from pathlib import Path
+from functools import partial
+
+def is_gs_path(path):
+    ppath = Path(path)
+    for extension in [[".gs"], [".gs", ".xz"], [".gs", ".zst"]]:
+        if ppath.suffixes == extension:
+            return True
+
+    return False
+
+
+def run_regression_test(runner, dumpdir, renderer, gspath):
+    args = [runner]
+    gsname = Path(gspath).name
+    while gsname.rfind('.') >= 0:
+        gsname = gsname[:gsname.rfind('.')]
+
+    real_dumpdir = os.path.join(dumpdir, gsname)
+    if not os.path.exists(real_dumpdir):
+        os.mkdir(real_dumpdir)
+
+    if renderer is not None:
+        args.extend(["-renderer", renderer])
+    args.extend(["-dumpdir", real_dumpdir])
+
+    # loop a couple of times for those stubborn merge/interlace dumps that don't render anything
+    # the first time around
+    args.extend(["-loop", "2"])
+
+    args.append("--")
+    args.append(gspath)
+
+    print("Running '%s'" % (" ".join(args)))
+    subprocess.run(args)
+
+
+def run_regression_tests(runner, gsdir, dumpdir, renderer, parallel=1):
+    paths = glob.glob(gsdir + "/*.*", recursive=True)
+    gamepaths = list(filter(is_gs_path, paths))
+
+    if not os.path.isdir(dumpdir):
+        os.mkdir(dumpdir)
+
+    print("Found %u GS dumps" % len(gamepaths))
+
+    if parallel <= 1:
+        for game in gamepaths:
+            run_regression_test(runner, dumpdir, renderer, game)
+    else:
+        print("Processing %u games on %u processors" % (len(gamepaths), parallel))
+        func = partial(run_regression_test, runner, dumpdir, renderer)
+        pool = multiprocessing.Pool(parallel)
+        pool.map(func, gamepaths)
+        pool.close()
+
+
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate frame dump images for regression tests")
+    parser.add_argument("-runner", action="store", required=True, help="Path to PCSX2 GS runner")
+    parser.add_argument("-gsdir", action="store", required=True, help="Directory containing GS dumps")
+    parser.add_argument("-dumpdir", action="store", required=True, help="Base directory to dump frames to")
+    parser.add_argument("-renderer", action="store", required=False, help="Renderer to use")
+    parser.add_argument("-parallel", action="store", type=int, default=1, help="Number of proceeses to run")
+
+    args = parser.parse_args()
+
+    if not run_regression_tests(args.runner, os.path.realpath(args.gsdir), os.path.realpath(args.dumpdir), args.renderer, args.parallel):
+        sys.exit(1)
+    else:
+        sys.exit(0)
+

--- a/pcsx2/Frontend/INISettingsInterface.cpp
+++ b/pcsx2/Frontend/INISettingsInterface.cpp
@@ -36,6 +36,9 @@ INISettingsInterface::~INISettingsInterface()
 
 bool INISettingsInterface::Load()
 {
+	if (m_filename.empty())
+		return false;
+
 	SI_Error err = SI_FAIL;
 	auto fp = FileSystem::OpenManagedCFile(m_filename.c_str(), "rb");
 	if (fp)
@@ -46,6 +49,9 @@ bool INISettingsInterface::Load()
 
 bool INISettingsInterface::Save()
 {
+	if (m_filename.empty())
+		return false;
+
 	SI_Error err = SI_FAIL;
 	std::FILE* fp = FileSystem::OpenCFile(m_filename.c_str(), "wb");
 	if (fp)

--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -56,6 +56,7 @@ static void GSDumpReplayerCpuSetCacheReserve(uint reserveInMegs);
 static std::unique_ptr<GSDumpFile> s_dump_file;
 static u32 s_current_packet = 0;
 static u32 s_dump_frame_number = 0;
+static s32 s_dump_loop_count = 0;
 static bool s_dump_running = false;
 static bool s_needs_state_loaded = false;
 static u64 s_frame_ticks = 0;
@@ -82,6 +83,11 @@ bool GSDumpReplayer::IsReplayingDump()
 	return static_cast<bool>(s_dump_file);
 }
 
+void GSDumpReplayer::SetLoopCount(s32 loop_count)
+{
+	s_dump_loop_count = loop_count - 1;
+}
+
 bool GSDumpReplayer::Initialize(const char* filename)
 {
 	Common::Timer timer;
@@ -102,6 +108,9 @@ bool GSDumpReplayer::Initialize(const char* filename)
 	psxCpu = &psxInt;
 	CpuVU0 = &gsDumpVU0;
 	CpuVU1 = &gsDumpVU1;
+
+	// loop infinitely by default
+	s_dump_loop_count = -1;
 
 	return true;
 }
@@ -146,6 +155,11 @@ std::string GSDumpReplayer::GetDumpSerial()
 u32 GSDumpReplayer::GetDumpCRC()
 {
 	return s_dump_file->GetCRC();
+}
+
+u32 GSDumpReplayer::GetFrameNumber()
+{
+	return s_dump_frame_number;
 }
 
 void GSDumpReplayerCpuReserve()
@@ -230,7 +244,16 @@ void GSDumpReplayerCpuStep()
 	const GSDumpFile::GSData& packet = s_dump_file->GetPackets()[s_current_packet];
 	s_current_packet = (s_current_packet + 1) % static_cast<u32>(s_dump_file->GetPackets().size());
 	if (s_current_packet == 0)
+	{
 		s_dump_frame_number = 0;
+		if (s_dump_loop_count > 0)
+			s_dump_loop_count--;
+		else if (s_dump_loop_count == 0)
+		{
+			Host::RequestVMShutdown(false);
+			s_dump_running = false;
+		}
+	}
 
 	switch (packet.id)
 	{

--- a/pcsx2/GSDumpReplayer.h
+++ b/pcsx2/GSDumpReplayer.h
@@ -23,12 +23,17 @@ namespace GSDumpReplayer
 {
 bool IsReplayingDump();
 
+/// If set, playback will repeat once it reaches the last frame.
+void SetLoopCount(s32 loop_count = 0);
+
 bool Initialize(const char* filename);
 void Reset();
 void Shutdown();
 
 std::string GetDumpSerial();
 u32 GetDumpCRC();
+
+u32 GetFrameNumber();
 
 void RenderUI();
 }


### PR DESCRIPTION
### Description of Changes

This can be used for automated regression testing for GS changes. Very simple frontend, it just runs a GS file, dumps each frame out, and exits.

Also provided some simple driver/comparison scripts.

### Rationale behind Changes

Knowing in advance when things break for GS changes.

### Suggested Testing Steps

Not applicable to testers, this is for development only (and perhaps eventual integration into CI).
