### PR TITLE
GS: Unset scanmsk_used after 2 frames

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -42,7 +42,7 @@ GSState::GSState()
 	, m_skip(0)
 	, m_skip_offset(0)
 	, m_q(1.0f)
-	, m_scanmask_used(false)
+	, m_scanmask_used(0)
 	, tex_flushed(true)
 	, m_vt(this, IsFirstProvokingVertex())
 	, m_regs(NULL)
@@ -182,7 +182,7 @@ void GSState::Reset(bool hardware_reset)
 	m_vertex.tail = 0;
 	m_vertex.next = 0;
 	m_index.tail = 0;
-	m_scanmask_used = false;
+	m_scanmask_used = 0;
 	m_dirty_gs_regs = 0;
 	m_backed_up_ctx = -1;
 
@@ -1271,7 +1271,7 @@ void GSState::GIFRegHandlerSCANMSK(const GIFReg* RESTRICT r)
 	m_env.SCANMSK = (GSVector4i)r->SCANMSK;
 
 	if (m_env.SCANMSK.MSK & 2)
-		m_scanmask_used = true;
+		m_scanmask_used = 2;
 
 	if (m_prev_env.SCANMSK.MSK != m_env.SCANMSK.MSK)
 		m_dirty_gs_regs |= (1 << DIRTY_REG_SCANMSK);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -161,7 +161,7 @@ protected:
 	GSVector4i m_scissor;
 	GSVector4i m_ofxy;
 
-	bool m_scanmask_used;
+	u8 m_scanmask_used;
 	bool tex_flushed;
 
 	struct

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -388,7 +388,8 @@ bool GSRenderer::Merge(int field)
 		}
 	}
 
-	m_scanmask_used = false;
+	if (m_scanmask_used)
+		m_scanmask_used--;
 
 	return true;
 }


### PR DESCRIPTION
### Description of Changes
Changes it so m_scanmask_usedonly gets unset after 2 frames have passed

### Rationale behind Changes
Some games (King's Field IV) were only using scanmask every other frame, causing it to constantly flick between using Bob and Blend deinterlacing, which completely broke it visually..

### Suggested Testing Steps
Not really anything to test, already tested it. You could make sure old savestates still work I guess...

Might need to bump the savestate version, especially if linux doesn't store bool's as 8bit values
