### PR TITLE
GameDB: Upscaling changes for Tokyo Xtreme Racer 3

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -40349,6 +40349,8 @@ SLUS-20831:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # Improves visual clarity whilst upscaling.
+    roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLUS-20833:
   name: "Mega Man Anniversary Collection"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds half Round Sprite and Wild Arms Hack to Tokyo Xtreme Racer 3 to improve UI and 3D upscaling clarity.

### Rationale behind Changes
Did a lot of A/B testing and concluded these hacks, when enabled, improve the visual output closer to software mode but also high in clarity.

### Suggested Testing Steps
Others who own the game will need to test on their own installation for unintended side effects that I have not been able to find after playing for around 10 hours.

Disabled:
![off](https://user-images.githubusercontent.com/107822219/174516028-417eea82-9545-4ebd-9d43-c17a951d4c7c.png)

Enabled:
![on](https://user-images.githubusercontent.com/107822219/174516039-304e0724-0353-4256-bd02-6c84c1c64582.png)

