### PR TITLE
ContextWGL: Use pbuffers when we don't have a surface

### DIFF
--- a/common/GL/ContextWGL.h
+++ b/common/GL/ContextWGL.h
@@ -24,6 +24,7 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+#include <optional>
 
 namespace GL
 {
@@ -48,12 +49,24 @@ namespace GL
 	private:
 		__fi HWND GetHWND() const { return static_cast<HWND>(m_wi.window_handle); }
 
+		HDC GetDCAndSetPixelFormat(HWND hwnd);
+
 		bool Initialize(const Version* versions_to_try, size_t num_versions_to_try);
 		bool InitializeDC();
+		void ReleaseDC();
+		bool CreatePBuffer();
 		bool CreateAnyContext(HGLRC share_context, bool make_current);
 		bool CreateVersionContext(const Version& version, HGLRC share_context, bool make_current);
 
 		HDC m_dc = {};
 		HGLRC m_rc = {};
+
+		// Can't change pixel format once it's set for a RC.
+		std::optional<int> m_pixel_format;
+
+		// Dummy window for creating a PBuffer off when we're surfaceless.
+		HWND m_dummy_window = {};
+		HDC m_dummy_dc = {};
+		HPBUFFERARB m_pbuffer = {};
 	};
 } // namespace GL

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -688,10 +688,7 @@ void EmuThread::releaseHostDisplay()
 	ImGuiManager::Shutdown();
 
 	if (s_host_display)
-	{
-		s_host_display->DestroyRenderSurface();
 		s_host_display->DestroyRenderDevice();
-	}
 
 	emit onDestroyDisplayRequested();
 

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -687,12 +687,8 @@ void EmuThread::releaseHostDisplay()
 {
 	ImGuiManager::Shutdown();
 
-	if (s_host_display)
-		s_host_display->DestroyRenderDevice();
-
-	emit onDestroyDisplayRequested();
-
 	s_host_display.reset();
+	emit onDestroyDisplayRequested();
 }
 
 HostDisplay* Host::GetHostDisplay()

--- a/pcsx2/Frontend/D3D11HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D11HostDisplay.cpp
@@ -95,8 +95,9 @@ D3D11HostDisplay::D3D11HostDisplay() = default;
 
 D3D11HostDisplay::~D3D11HostDisplay()
 {
-	pxAssertMsg(!m_context, "Context should have been destroyed by now");
-	pxAssertMsg(!m_swap_chain, "Swap chain should have been destroyed by now");
+	D3D11HostDisplay::DestroyRenderSurface();
+	m_context.Reset();
+	m_device.Reset();
 }
 
 HostDisplay::RenderAPI D3D11HostDisplay::GetRenderAPI() const
@@ -330,13 +331,6 @@ bool D3D11HostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view
 bool D3D11HostDisplay::InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device)
 {
 	return true;
-}
-
-void D3D11HostDisplay::DestroyRenderDevice()
-{
-	DestroyRenderSurface();
-	m_context.Reset();
-	m_device.Reset();
 }
 
 bool D3D11HostDisplay::MakeRenderContextCurrent()

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -45,7 +45,6 @@ public:
 
 	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
 	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
-	void DestroyRenderDevice() override;
 
 	bool MakeRenderContextCurrent() override;
 	bool DoneRenderContextCurrent() override;

--- a/pcsx2/Frontend/D3D12HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D12HostDisplay.cpp
@@ -51,8 +51,12 @@ D3D12HostDisplay::D3D12HostDisplay() = default;
 
 D3D12HostDisplay::~D3D12HostDisplay()
 {
-	pxAssertMsg(!g_d3d12_context, "Context should have been destroyed by now");
-	pxAssertMsg(!m_swap_chain, "Swap chain should have been destroyed by now");
+	if (g_d3d12_context)
+	{
+		g_d3d12_context->WaitForGPUIdle();
+		D3D12HostDisplay::DestroyRenderSurface();
+		g_d3d12_context->Destroy();
+	}
 }
 
 HostDisplay::RenderAPI D3D12HostDisplay::GetRenderAPI() const
@@ -202,15 +206,6 @@ bool D3D12HostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view
 bool D3D12HostDisplay::InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device)
 {
 	return true;
-}
-
-void D3D12HostDisplay::DestroyRenderDevice()
-{
-	g_d3d12_context->ExecuteCommandList(true);
-
-	DestroyRenderSurface();
-	if (g_d3d12_context)
-		g_d3d12_context->Destroy();
 }
 
 bool D3D12HostDisplay::MakeRenderContextCurrent()

--- a/pcsx2/Frontend/D3D12HostDisplay.h
+++ b/pcsx2/Frontend/D3D12HostDisplay.h
@@ -51,7 +51,6 @@ public:
 
 	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
 	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
-	void DestroyRenderDevice() override;
 
 	bool MakeRenderContextCurrent() override;
 	bool DoneRenderContextCurrent() override;

--- a/pcsx2/Frontend/MetalHostDisplay.h
+++ b/pcsx2/Frontend/MetalHostDisplay.h
@@ -56,7 +56,6 @@ public:
 	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
 	bool MakeRenderContextCurrent() override;
 	bool DoneRenderContextCurrent() override;
-	void DestroyRenderDevice() override;
 	void DestroyRenderSurface() override;
 	bool ChangeRenderWindow(const WindowInfo& wi) override;
 	bool SupportsFullscreen() const override;

--- a/pcsx2/Frontend/MetalHostDisplay.mm
+++ b/pcsx2/Frontend/MetalHostDisplay.mm
@@ -49,6 +49,9 @@ MetalHostDisplay::MetalHostDisplay()
 
 MetalHostDisplay::~MetalHostDisplay()
 {
+	MetalHostDisplay::DestroyRenderSurface();
+	m_queue = nullptr;
+	m_dev.Reset();
 }
 
 HostDisplay::AdapterAndModeList GetMetalAdapterAndModeList()
@@ -157,13 +160,6 @@ bool MetalHostDisplay::InitializeRenderDevice(std::string_view shader_cache_dire
 
 bool MetalHostDisplay::MakeRenderContextCurrent() { return true; }
 bool MetalHostDisplay::DoneRenderContextCurrent() { return true; }
-
-void MetalHostDisplay::DestroyRenderDevice()
-{
-	DestroyRenderSurface();
-	m_queue = nullptr;
-	m_dev.Reset();
-}
 
 void MetalHostDisplay::DestroyRenderSurface()
 {

--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -53,7 +53,11 @@ OpenGLHostDisplay::OpenGLHostDisplay() = default;
 
 OpenGLHostDisplay::~OpenGLHostDisplay()
 {
-	pxAssertMsg(!m_gl_context, "Context should have been destroyed by now");
+	if (m_gl_context)
+	{
+		m_gl_context->DoneCurrent();
+		m_gl_context.reset();
+	}
 }
 
 HostDisplay::RenderAPI OpenGLHostDisplay::GetRenderAPI() const
@@ -237,15 +241,6 @@ bool OpenGLHostDisplay::MakeRenderContextCurrent()
 bool OpenGLHostDisplay::DoneRenderContextCurrent()
 {
 	return m_gl_context->DoneCurrent();
-}
-
-void OpenGLHostDisplay::DestroyRenderDevice()
-{
-	if (!m_gl_context)
-		return;
-
-	m_gl_context->DoneCurrent();
-	m_gl_context.reset();
 }
 
 bool OpenGLHostDisplay::ChangeRenderWindow(const WindowInfo& new_wi)

--- a/pcsx2/Frontend/OpenGLHostDisplay.h
+++ b/pcsx2/Frontend/OpenGLHostDisplay.h
@@ -40,7 +40,6 @@ public:
 
 	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
 	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
-	void DestroyRenderDevice() override;
 
 	bool MakeRenderContextCurrent() override;
 	bool DoneRenderContextCurrent() override;

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -326,9 +326,9 @@ void VulkanHostDisplay::DestroyRenderDevice()
 		return;
 
 	g_vulkan_context->WaitForGPUIdle();
+	m_swap_chain.reset();
 
 	Vulkan::ShaderCache::Destroy();
-	DestroyRenderSurface();
 	Vulkan::Context::Destroy();
 }
 

--- a/pcsx2/Frontend/VulkanHostDisplay.h
+++ b/pcsx2/Frontend/VulkanHostDisplay.h
@@ -29,7 +29,6 @@ public:
 
 	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
 	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
-	void DestroyRenderDevice() override;
 
 	bool MakeRenderContextCurrent() override;
 	bool DoneRenderContextCurrent() override;

--- a/pcsx2/HostDisplay.h
+++ b/pcsx2/HostDisplay.h
@@ -101,7 +101,6 @@ public:
 	virtual bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) = 0;
 	virtual bool MakeRenderContextCurrent() = 0;
 	virtual bool DoneRenderContextCurrent() = 0;
-	virtual void DestroyRenderDevice() = 0;
 	virtual void DestroyRenderSurface() = 0;
 	virtual bool ChangeRenderWindow(const WindowInfo& wi) = 0;
 	virtual bool SupportsFullscreen() const = 0;

--- a/pcsx2/gui/AppHost.cpp
+++ b/pcsx2/gui/AppHost.cpp
@@ -121,7 +121,6 @@ HostDisplay* Host::AcquireHostDisplay(HostDisplay::RenderAPI api)
 		!s_host_display->InitializeRenderDevice(EmuFolders::Cache, GSConfig.UseDebugDevice) ||
 		!ImGuiManager::Initialize())
 	{
-		s_host_display->DestroyRenderDevice();
 		s_host_display.reset();
 		return nullptr;
 	}
@@ -137,10 +136,7 @@ void Host::ReleaseHostDisplay()
 	ImGuiManager::Shutdown();
 
 	if (s_host_display)
-	{
-		s_host_display->DestroyRenderDevice();
 		s_host_display.reset();
-	}
 
 	sApp.CloseGsPanel();
 }


### PR DESCRIPTION
### Description of Changes

Also cleans up HostDisplay a little, removing a redundant virtual function (using RAII instead).

### Rationale behind Changes

Fixes the assert fail/crash when confirming shutdown while fullscreen.

### Suggested Testing Steps

Test fullscreen transitions, confirming shutdown, starting/shutting down on all renderers.
