### PR TITLE
Qt: Fix hide mouse cursor not working with render-to-main off

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1635,6 +1635,11 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main, b
 			container->showNormal();
 		}
 
+		m_display_widget->setFocus();
+		m_display_widget->setShouldHideCursor(shouldHideMouseCursor());
+		m_display_widget->updateRelativeMode(m_vm_valid && !m_vm_paused);
+		m_display_widget->updateCursor(m_vm_valid && !m_vm_paused);
+
 		QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
 		return m_display_widget;
 	}


### PR DESCRIPTION
### Description of Changes

See title.

### Rationale behind Changes

Fixes #6470.

### Suggested Testing Steps

Test fs switch with render-to-main off (already done). Was just missing the update call.
