### PR TITLE
GameDB: Upscaling fixes added for all retail versions of Shutokou Bat…

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8242,7 +8242,12 @@ SLAJ-25016:
   region: "NTSC-Unk"
 SLAJ-25018:
   name: "Shutokou Battle 01"
-  region: "NTSC-Unk"
+  region: "NTSC-HK"
+  compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # Improves visual clarity whilst upscaling.
+    roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLAJ-25023:
   name: "Shin Sangoku Musou 3 - Mushoden"
   region: "NTSC-Unk"
@@ -21409,6 +21414,14 @@ SLKA-25082:
   compat: 5
   clampModes:
     eeClampMode: 3 # Fixes cutscene freezes.
+SLKA-25084:
+  name: "Shutokou Battle 01"
+  region: "NTSC-K"
+  compat: 5
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # Improves visual clarity whilst upscaling.
+    roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLKA-25087:
   name: "FIFA Soccer 2004"
   region: "NTSC-J"
@@ -25768,6 +25781,8 @@ SLPM-65308:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # Improves visual clarity whilst upscaling.
+    roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLPM-65309:
   name: "Splashdown [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -31658,6 +31673,8 @@ SLPM-74204:
   compat: 5
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # Improves visual clarity whilst upscaling.
+    roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLPM-74205:
   name: "Shin Megami Tensei III - Nocturne [PlayStation 2 The Best]"
   region: "NTSC-J"


### PR DESCRIPTION
…tle 01

### Description of Changes
Following on from adding these changes to Tokyo Xtreme Racer 3, the original version of the game is identical in terms of graphics. I have located all versions of Shutokou Battle 01 and added the fixes. I did not add it to Taikenban/Demo version however, as I am unsure with its pre-release state if anything changed rendering wise.

The Korean version of the game has also been added to the database for the first time.

### Rationale behind Changes
Extending the fixes for the translated NTSC-U American version to the game back to the original Japanese and branched Korean and Hong Kong releases.

### Suggested Testing Steps
Owners of these games should report if this causes additional graphics issues such as graphics corruption on the UI that wasn't there before.
