### PR TITLE
CDVD: Load GZip index location direct from ini.

### DIFF
--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -27,6 +27,8 @@
 #include "gui/StringHelpers.h"
 #include "gui/wxDirName.h"
 #include <wx/stdpaths.h>
+#else
+#include "HostSettings.h"
 #endif
 
 #define CLAMP(val, minval, maxval) (std::min(maxval, std::max(minval, val)))
@@ -182,10 +184,11 @@ static std::string iso2indexname(const std::string& isoname)
 #ifndef PCSX2_CORE
 	std::string appRoot = // TODO: have only one of this in PCSX2. Right now have few...
 		StringUtil::wxStringToUTF8String(((wxDirName)(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath())).ToString());
+	return ApplyTemplate("gzip index", appRoot, EmuConfig.GzipIsoIndexTemplate, isoname, false);
 #else
 	const std::string& appRoot = EmuFolders::DataRoot;
+	return ApplyTemplate("gzip index", appRoot, Host::GetBaseStringSettingValue("EmuCore", "GzipIsoIndexTemplate", "$(f).pindex.tmp"), isoname, false);
 #endif
-	return ApplyTemplate("gzip index", appRoot, EmuConfig.GzipIsoIndexTemplate, isoname, false);
 }
 
 


### PR DESCRIPTION
### Description of Changes
Stops the Qt game list from putting indexes in the default location when a custom one is used.

### Rationale behind Changes
Was using the default, this is undesired.

### Suggested Testing Steps
Let Qt index your game list with .gz files in, but have the GzipIsoIndexTemplate entry in your PCSX2.ini set to something like C:\indexfiles\$(f).pindex.tmp
