### PR TITLE
GameDB: Fix name of "The Document of Metal Gear Solid 2"

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -39132,7 +39132,7 @@ SLUS-20541:
   clampModes:
     vuClampMode: 2 # Fixes transparency issues.
 SLUS-20543:
-  name: "Metal Gear Solid 2"
+  name: "Document of Metal Gear Solid 2, The"
   region: "NTSC-U"
   compat: 5
 SLUS-20544:


### PR DESCRIPTION
### Description of Changes
SLUS-20543 was incorrectly named **Metal Gear Solid 2** while it's actually **The Document of Metal Gear Solid 2**. I re-used the name of the NTSC-J version for consistency

### Rationale behind Changes
Fix the name so it's not mistaken for the actual game.

### Suggested Testing Steps
Everything should be okay.