### PR TITLE
Make PS1 Mode a forced toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ oprofile_data/
 /bin/**/*.lib
 /bin/**/*.pdb
 /bin/pcsx2
+/bin/pcsx2-qt
 /bin/PCSX2-linux.sh
 /bin/*ReplayLoader
 /bin/GS*.txt

--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.cpp
@@ -42,6 +42,7 @@ AdvancedSystemSettingsWidget::AdvancedSystemSettingsWidget(SettingsDialog* dialo
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.iopRecompiler, "EmuCore/CPU/Recompiler", "EnableIOP", true);
 
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ps1Mode, "EmuCore", "EnablePS1Mode", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gameFixes, "EmuCore", "EnableGameFixes", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.patches, "EmuCore", "EnablePatches", true);
 

--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
@@ -99,10 +99,17 @@
       <string>I/O Processor (IOP, MIPS-I)</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
+      <item row="2" column="0">
        <widget class="QCheckBox" name="iopRecompiler">
         <property name="text">
          <string>Enable Recompiler</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="ps1Mode">
+        <property name="text">
+         <string>PS1 Mode</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -962,7 +962,9 @@ struct Pcsx2Config
 		MultitapPort1_Enabled : 1,
 
 		ConsoleToStdio : 1,
-		HostFs : 1;
+		HostFs : 1,
+		EnablePS1Mode : 1;
+
 
 	// uses automatic ntfs compression when creating new memory cards (Win32 only)
 #ifdef _WIN32

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1046,6 +1046,7 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnablePatches);
 	SettingsWrapBitBool(EnableCheats);
 	SettingsWrapBitBool(EnablePINE);
+	SettingsWrapBitBool(EnablePS1Mode);
 	SettingsWrapBitBool(EnableWideScreenPatches);
 	SettingsWrapBitBool(EnableNoInterlacingPatches);
 	SettingsWrapBitBool(EnableRecordingTools);
@@ -1199,6 +1200,7 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	EnablePatches = cfg.EnablePatches;
 	EnableCheats = cfg.EnableCheats;
 	EnablePINE = cfg.EnablePINE;
+	EnablePS1Mode = cfg.EnablePS1Mode;
 	EnableWideScreenPatches = cfg.EnableWideScreenPatches;
 	EnableNoInterlacingPatches = cfg.EnableNoInterlacingPatches;
 	EnableRecordingTools = cfg.EnableRecordingTools;

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -175,6 +175,7 @@ namespace Panels
 	protected:
 		pxRadioPanel* m_panel_RecEE;
 		pxRadioPanel* m_panel_RecIOP;
+		pxCheckBox* m_check_IOPPs1Mode;
 		pxCheckBox* m_check_EECacheEnable;
 		AdvancedOptionsFPU* m_advancedOptsFpu;
 		wxButton* m_button_RestoreDefaults;

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -153,6 +153,7 @@ Panels::CpuPanelEE::CpuPanelEE( wxWindow* parent )
 	s_ee	+= m_panel_RecEE	| StdExpand();
 	s_ee    += m_check_EECacheEnable = &(new pxCheckBox( this, _("Enable EE Cache (Slower)") ))->SetToolTip(_("Interpreter only; provided for diagnostic"));
 	s_iop	+= m_panel_RecIOP	| StdExpand();
+	s_iop   += m_check_IOPPs1Mode = &(new pxCheckBox( this, _("Enable PS1 Mode (Experimental)") ))->SetToolTip(_("A highly experimental and otherwise currently broken feature"));
 
 	s_recs	+= s_ee				| SubGroup();
 	s_recs	+= s_iop			| SubGroup();
@@ -230,6 +231,7 @@ void Panels::CpuPanelEE::Apply()
 	recOps.EnableEE		  = !!m_panel_RecEE->GetSelection();
 	recOps.EnableIOP	  = !!m_panel_RecIOP->GetSelection();
 	recOps.EnableEECache  = m_check_EECacheEnable->GetValue();
+	EmuConfig.EnablePS1Mode = m_check_IOPPs1Mode->GetValue();
 }
 
 void Panels::CpuPanelEE::AppStatusEvent_OnSettingsApplied()
@@ -242,6 +244,9 @@ void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
 	const Pcsx2Config::RecompilerOptions& recOps( configToApply.EmuOptions.Cpu.Recompiler );
 	m_panel_RecEE->SetSelection( (int)recOps.EnableEE );
 	m_panel_RecIOP->SetSelection( (int)recOps.EnableIOP );
+
+	m_check_IOPPs1Mode->SetValue( EmuConfig.EnablePS1Mode );
+	m_check_IOPPs1Mode->Enable(!configToApply.EnablePresets && m_panel_RecIOP->GetSelection() == 0);
 
 	m_panel_RecEE->Enable(!configToApply.EnablePresets);
 	m_panel_RecIOP->Enable(!configToApply.EnablePresets);

--- a/pcsx2/gui/Panels/CpuPanel.cpp
+++ b/pcsx2/gui/Panels/CpuPanel.cpp
@@ -153,7 +153,7 @@ Panels::CpuPanelEE::CpuPanelEE( wxWindow* parent )
 	s_ee	+= m_panel_RecEE	| StdExpand();
 	s_ee    += m_check_EECacheEnable = &(new pxCheckBox( this, _("Enable EE Cache (Slower)") ))->SetToolTip(_("Interpreter only; provided for diagnostic"));
 	s_iop	+= m_panel_RecIOP	| StdExpand();
-	s_iop   += m_check_IOPPs1Mode = &(new pxCheckBox( this, _("Enable PS1 Mode (Experimental)") ))->SetToolTip(_("A highly experimental and otherwise currently broken feature"));
+	s_iop   += m_check_IOPPs1Mode = &(new pxCheckBox( this, _("Enable PS1 Mode (Experimental)") ))->SetToolTip(_("A highly experimental and broken feature"));
 
 	s_recs	+= s_ee				| SubGroup();
 	s_recs	+= s_iop			| SubGroup();
@@ -231,7 +231,7 @@ void Panels::CpuPanelEE::Apply()
 	recOps.EnableEE		  = !!m_panel_RecEE->GetSelection();
 	recOps.EnableIOP	  = !!m_panel_RecIOP->GetSelection();
 	recOps.EnableEECache  = m_check_EECacheEnable->GetValue();
-	EmuConfig.EnablePS1Mode = m_check_IOPPs1Mode->GetValue();
+	g_Conf->EmuOptions.EnablePS1Mode = m_check_IOPPs1Mode->GetValue();
 }
 
 void Panels::CpuPanelEE::AppStatusEvent_OnSettingsApplied()
@@ -245,7 +245,7 @@ void Panels::CpuPanelEE::ApplyConfigToGui( AppConfig& configToApply, int flags )
 	m_panel_RecEE->SetSelection( (int)recOps.EnableEE );
 	m_panel_RecIOP->SetSelection( (int)recOps.EnableIOP );
 
-	m_check_IOPPs1Mode->SetValue( EmuConfig.EnablePS1Mode );
+	m_check_IOPPs1Mode->SetValue( g_Conf->EmuOptions.EnablePS1Mode );
 	m_check_IOPPs1Mode->Enable(!configToApply.EnablePresets && m_panel_RecIOP->GetSelection() == 0);
 
 	m_panel_RecEE->Enable(!configToApply.EnablePresets);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Makes PS1 mode a forced toggle for now

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Because PS1 mode Is currently highly experimental and is being slowly worked on but is not at this time a recommended usable feature

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check magic check box works. Check error box and forced failure to boot work