### PR TITLE
GameDB: fix Bakusou Dekotora Densetsu in-game graphics with hardware rendering

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -480,8 +480,11 @@ SCAJ-20009:
   name: "Herdy Gerdy"
   region: "NTSC-Unk"
 SCAJ-20010:
-  name: "Bakusou Dekotora Densetsu 3"
+  name: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
   region: "NTSC-Unk"
+  gsHWFixes:
+    skipDrawStart: 2 # Without Skipdraw everything but rearview mirrors renders black.
+    skipDrawEnd: 2 # Without Skipdraw everything but rearview mirrors renders black.
 SCAJ-20011:
   name: "Armored Core 3 - Silent Line"
   region: "NTSC-Unk"
@@ -25524,6 +25527,9 @@ SLPM-65233:
 SLPM-65234:
   name: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman"
   region: "NTSC-J"
+  gsHWFixes:
+    skipDrawStart: 2 # Without Skipdraw everything but rearview mirrors renders black.
+    skipDrawEnd: 2 # Without Skipdraw everything but rearview mirrors renders black.
 SLPM-65235:
   name: "New Roommania - Porori Seishun"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman (SLPM-65234) needs Skipdraw to render most graphics in-game when using hardware rendering.

Rename SCAJ-20010
Bakusou Dekotora Densetsu 3 -> Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman
According to multiple sources this should be the same game (it is the 3rd game in the series).
Also apply the fix to SCAJ-20010 though I can't personally test it since I don't own that version.

### Rationale behind Changes
Without skipdraw, the game only renders the HUD and rearview mirrors in-game, everything else is only rendered a very dark grey.
**Without skipdraw**
![gs_20220619230413_Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman_SLPM-65234](https://user-images.githubusercontent.com/2962364/175123969-be9d8938-da51-44da-84f2-fece6d046f19.png)

With a Skipdraw range from 2 to 2 the view forward and the round mirror in the middle are rendered correctly. The left and right rearview mirrors don't render cars and trucks correctly anymore (they're correct without skipdraw).
Cars and trucks are rendered as semi-transparent ghosts (the silhouette and pink lights of a truck are visible in the right rearview mirror in the example screenshot). The environment is still rendered correctly though.
**With skipdraw**
![gs_20220619231609_Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman_SLPM-65234](https://user-images.githubusercontent.com/2962364/175124758-0f9a8739-f88f-45a6-ad11-714e526e1ab3.png)

The game is not quite as perfect as with software rendering, but it is still much more playable with the suggested fixes applied than without (slightly borked rearview mirrors instead of completely blind).
