### PR TITLE
GS: Add internal FFMD offset to interlace.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -378,9 +378,9 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 	if (mode == 0 || mode == 2) // weave or blend
 	{
 		// weave first
-		const int offset = static_cast<int>(yoffset) * field;
+		const float offset = -yoffset * static_cast<float>(field);
 
-		DoInterlace(m_merge, m_weavebob, field, false, GSConfig.DisableInterlaceOffset ? 0 : offset);
+		DoInterlace(m_merge, m_weavebob, field, false, GSConfig.DisableInterlaceOffset ? 0.0f : offset);
 
 		if (mode == 2)
 		{

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -378,7 +378,7 @@ void GSDevice::Interlace(const GSVector2i& ds, int field, int mode, float yoffse
 	if (mode == 0 || mode == 2) // weave or blend
 	{
 		// weave first
-		const float offset = -yoffset * static_cast<float>(field);
+		const float offset = yoffset * static_cast<float>(field);
 
 		DoInterlace(m_merge, m_weavebob, field, false, GSConfig.DisableInterlaceOffset ? 0.0f : offset);
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -349,9 +349,15 @@ bool GSRenderer::Merge(int field)
 
 		g_gs_device->Merge(tex, src_gs_read, dst, fs, m_regs->PMODE, m_regs->EXTBUF, c);
 
-		// Use offset for bob deinterlacing, for normal deinterlacing we add an extra 1 since it's clearer, with bob that causes extra shake.
+		// Use offset for bob deinterlacing always, extra offset added later for FFMD mode.
 		const bool is_bob = GSConfig.InterlaceMode == GSInterlaceMode::BobTFF || GSConfig.InterlaceMode == GSInterlaceMode::BobBFF;
-		const float offset = (!m_regs->SMODE2.FFMD && !is_bob) ? 0 : ((tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y));
+		float offset = (!m_regs->SMODE2.FFMD && !is_bob) ? 0 : ((tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y));
+
+		// Offset accounts for the upscaling interlace offset difference, but we need to also account for the internal framebuffer movement in Frame mode.
+		if (m_regs->SMODE2.FFMD && !is_bob)
+		{
+			offset += 1.0f;
+		}
 
 		if (isReallyInterlaced() && GSConfig.InterlaceMode != GSInterlaceMode::Off)
 		{

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -308,7 +308,8 @@ bool GSRenderer::Merge(int field)
 
 		if (m_regs->SMODE2.FFMD && !is_bob && !GSConfig.DisableInterlaceOffset)
 		{
-			interlace_offset += (tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y) * static_cast<float>(field ^ field2);
+			// Why 3/4? Mainly to line up the odd scanlines for the interlacing routine.
+			interlace_offset += ((tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y) * 0.75f) * static_cast<float>(field ^ field2);
 			// We're handling the interlacing offset for upscaling in the merge circuit, rather than in the interlacing shader.
 			offset = 0.0f;
 		}


### PR DESCRIPTION
### Description of Changes
Account for the internal offset on the PCRTC circuit when interlacing, not just the interlace offset.

### Rationale behind Changes
We weren't accounting for this before, and it makes stuff look clearer (see below)

### Suggested Testing Steps
Test games, compare to master, make sure they don't look blurrier. Also test games which looked a little blurry still when upscaled.

(Note the cliffs and the clarity of the UI)

![Raging Master](https://user-images.githubusercontent.com/6278726/175446690-1acfad02-66a5-4ed5-964d-cadbb1363766.png)

![Raging PR](https://user-images.githubusercontent.com/6278726/175696489-82a75333-4cd5-4411-88a8-856193d449e4.png)


(Look at the languages, especially the G in English, also the stepping on the letters in "Dark Alliance")

![BG2 Master](https://user-images.githubusercontent.com/6278726/175446713-4f54d8a8-080c-4f08-aefd-d5267ca5fb10.png)

![BG2 PR](https://user-images.githubusercontent.com/6278726/175696500-0cf9eb9c-912f-4e35-b651-6e53fb641ab6.png)

