### PR TITLE
VU: YOLO T-Bit on MTVU

### DIFF
--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -65,10 +65,11 @@ void vu1ExecMicro(u32 addr)
 		// Most of the time with MTVU we want to pretend the VU has finished quickly as to gain the benefit from running another thread
 		// however with T-Bit games when the T-Bit is enabled, it needs to wait in case a T-Bit happens, so we need to set "Busy"
 		// We shouldn't do this all the time as it negates the extra thread and causes games like Ratchet & Clank to be no faster.
-		if (VU0.VI[REG_FBRST].UL & 0x800)
-		{
-			VU0.VI[REG_VPU_STAT].UL |= 0x0100;
-		}
+		// if (VU0.VI[REG_FBRST].UL & 0x800)
+		// {
+		//	VU0.VI[REG_VPU_STAT].UL |= 0x0100;
+		// }
+		// Update 25/06/2022: Disabled this for now, let games YOLO it, if it breaks MTVU, disable MTVU (it doesn't work properly anyway) - Refraction
 
 		vu1Thread.ExecuteVU(addr, vif1Regs.top, vif1Regs.itop, VU0.VI[REG_FBRST].UL);
 		return;


### PR DESCRIPTION
Maybe we can re-enable it in the future if some threading genius figures it out.

### Description of Changes
Disables VU1 busy flag on T-Bit handling when MTVU is enabled.

### Rationale behind Changes
More games than I expected just turn T-Bit on but never actually use it, which causes poor performance in MTVU due to threading.  If there is a game that uses it, we can disable MTVU in the GameDB, since it will break the performance of the game, even if we try to handle it correctly.

### Suggested Testing Steps
Test Tak - The Great Juju Challenge
