### PR TITLE
iR5900: Elide VU0 micro finish calls when safe

### DIFF
--- a/pcsx2/x86/iCore.h
+++ b/pcsx2/x86/iCore.h
@@ -220,6 +220,7 @@ int _signExtendXMMtoM(uptr to, x86SSERegType from, int candestroy); // returns t
 #define EEINST_COP2_STATUS_FLAG 0x400
 #define EEINST_COP2_MAC_FLAG 0x800
 #define EEINST_COP2_CLIP_FLAG 0x1000
+#define EEINST_COP2_FINISH_VU0_MICRO 0x2000
 
 struct EEINST
 {

--- a/pcsx2/x86/iR5900Analysis.h
+++ b/pcsx2/x86/iR5900Analysis.h
@@ -62,4 +62,13 @@ namespace R5900
 
 		u32 m_cfc2_pc = 0;
 	};
+
+	class COP2MicroFinishPass final : public AnalysisPass
+	{
+	public:
+		COP2MicroFinishPass();
+		~COP2MicroFinishPass();
+
+		void Run(u32 start, u32 end, EEINST* inst_cache) override;
+	};
 } // namespace R5900

--- a/pcsx2/x86/ix86-32/iR5900-32.cpp
+++ b/pcsx2/x86/ix86-32/iR5900-32.cpp
@@ -2190,10 +2190,12 @@ StartRecomp:
 	}
 
 	// eventually we'll want to have a vector of passes or something.
-	if (has_cop2_instructions && EmuConfig.Speedhacks.vuFlagHack)
+	if (has_cop2_instructions)
 	{
-		COP2FlagHackPass fhpass;
-		fhpass.Run(startpc, s_nEndBlock, s_pInstCache + 1);
+		COP2MicroFinishPass().Run(startpc, s_nEndBlock, s_pInstCache + 1);
+
+		if (EmuConfig.Speedhacks.vuFlagHack)
+			COP2FlagHackPass().Run(startpc, s_nEndBlock, s_pInstCache + 1);
 	}
 
 	// analyze instructions //


### PR DESCRIPTION
### Description of Changes

This makes a difference in COP2-heavy games, where a chain of instructions will repeatedly test the VU0 idle bit unnecessarily, as it is impossible for a micro to be started inbetween the instruction chain.

Saves a bit of code size (for register backup/restore), as well as getting rid of branches. Seems to make a 1-2% difference in performance in Ratchet on a 3900X, but if we're lucky, more on slower chips.

### Rationale behind Changes

Brr maybe?

### Suggested Testing Steps

Test VU0 games, make sure nothing broke.