### PR TITLE
Config: Fix loading of SavestateZstdCompression setting

### DIFF
--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1209,6 +1209,7 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	PatchBios = cfg.PatchBios;
 	PatchRegion = cfg.PatchRegion;
 	BackupSavestate = cfg.BackupSavestate;
+	SavestateZstdCompression = cfg.SavestateZstdCompression;
 	McdEnableEjection = cfg.McdEnableEjection;
 	McdFolderAutoManage = cfg.McdFolderAutoManage;
 	MultitapPort0_Enabled = cfg.MultitapPort0_Enabled;


### PR DESCRIPTION
### Description of Changes
A line has been added to Pcsx2Config::CopyConfig to load the SavestateZstdCompression setting.

### Rationale behind Changes
I ran into an issue where I couldn't get PCSX2 to dump out save states using the deflate algorithm, preventing me from opening them up in my archive viewer so I could debug something. Having had a quick look at the config code, it appeared that the original author of the change introducing zstd compression just forgot add the extra line: https://github.com/PCSX2/pcsx2/commit/6991f819f3f7e292a8f7d714062229420c2f4bc0

### Suggested Testing Steps

**Trying to extract a file in an archive utility (that doesn't support the new compression) from a PCSX2 savestate both with the setting enabled and disabled.**

Old result:

![Screenshot_20220627_182253](https://user-images.githubusercontent.com/43898262/175999439-0c4ec8ca-0eaf-49e8-9298-3523f45e0db5.png)
