### PR TITLE
GS: Don't vmalloc inside fifo_alloc to avoid logic confusion.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -969,7 +969,7 @@ void* fifo_alloc(size_t size, size_t repeat)
 	if (repeat >= std::size(s_Next))
 	{
 		fprintf(stderr, "Memory mapping overflow (%zu >= %u)\n", repeat, static_cast<unsigned>(std::size(s_Next)));
-		return vmalloc(size * repeat, false); // Fallback to default vmalloc
+		return nullptr; // Fallback to default vmalloc
 	}
 
 	s_fh = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, size, nullptr);
@@ -977,7 +977,7 @@ void* fifo_alloc(size_t size, size_t repeat)
 	if (s_fh == NULL)
 	{
 		fprintf(stderr, "Failed to reserve memory. WIN API ERROR:%u\n", errorID);
-		return vmalloc(size * repeat, false); // Fallback to default vmalloc
+		return nullptr; // Fallback to default vmalloc
 	}
 
 	int mmap_segment_failed = 0;
@@ -994,7 +994,7 @@ void* fifo_alloc(size_t size, size_t repeat)
 			{
 				fprintf(stderr, "Memory mapping failed after %d attempts, aborting. WIN API ERROR:%u\n", mmap_segment_failed, errorID);
 				fifo_free(fifo, size, repeat);
-				return vmalloc(size * repeat, false); // Fallback to default vmalloc
+				return nullptr; // Fallback to default vmalloc
 			}
 			do
 			{

--- a/pcsx2/x86/iR5900Analysis.cpp
+++ b/pcsx2/x86/iR5900Analysis.cpp
@@ -259,7 +259,7 @@ void COP2MicroFinishPass::Run(u32 start, u32 end, EEINST* inst_cache)
 			inst->info |= EEINST_COP2_FINISH_VU0_MICRO;
 
 			// QMTC2 and CTC2 interlock on M-Bit not just VU end, so VU0 might continue to run, so we need to continue to check.
-			if ((_Rs_ == 005 || _Rs_ == 006) && (cpuRegs.code & 1))
+			if (_Rs_ == 005 || _Rs_ == 006)
 				return true;
 
 			needs_vu0_finish = false;


### PR DESCRIPTION
### Description of Changes
Changes the GS memory "fifo_alloc" code to not use vm_alloc if filemapping fails.
Also remove a pointless check from my previous COP2 fix.

### Rationale behind Changes
This causes a logic error, since `m_use_fifo_alloc` is set before entering this function, and can't get unset because it's expecting the pointer to be null in order to do so, and it wasn't. Two things trying to do the same job.

### Suggested Testing Steps
Windows only: load and shut down PCSX2 a bunch of times, make sure it doesn't crash. Keep an eye out for either `Failed to reserve memory. WIN API ERROR` or `Memory mapping failed after %d attempts, aborting. WIN API ERROR` in the log, it's instrumental to this happening.
