### PR TITLE
GS: Switch to placeholders for VM repeat mapping in Qt

### DIFF
--- a/common/RedtapeWindows.h
+++ b/common/RedtapeWindows.h
@@ -24,8 +24,14 @@
 #define NOMINMAX
 #endif
 
-// Win8.1 is our minimum at the moment.
+// Qt build requires Windows 10+, WX Windows 8.1+.
+#ifndef _WIN32_WINNT
+#ifdef PCSX2_CORE
+#define _WIN32_WINNT 0x0A00 // Windows 10
+#else
 #define _WIN32_WINNT 0x0603 // Windows 8.1
+#endif
+#endif
 
 #include <windows.h>
 #include <VersionHelpers.h>

--- a/common/vsprops/BaseProperties.props
+++ b/common/vsprops/BaseProperties.props
@@ -11,7 +11,7 @@
     <ClCompile>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__WIN32__;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;WINVER=0x0603;_WIN32_WINNT=0x0603;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__WIN32__;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;WINVER=0x0A00;_WIN32_WINNT=0x0A00;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StructMemberAlignment>16Bytes</StructMemberAlignment>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -74,7 +74,7 @@
       <SubSystem>Windows</SubSystem>
       <LargeAddressAware>Yes</LargeAddressAware>
       <AdditionalDependencies>comctl32.lib;ws2_32.lib;shlwapi.lib;winmm.lib;rpcrt4.lib;iphlpapi.lib;dsound.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;PowrProf.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;PowrProf.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;OneCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies>$(QtEntryPointLib);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1649,7 +1649,11 @@ if(WIN32)
 		opengl32.lib
 		comsuppw.lib
 	)
-	if(NOT PCSX2_CORE)
+	if(PCSX2_CORE)
+		target_link_libraries(PCSX2_FLAGS INTERFACE
+			OneCore.lib
+		)
+	else()
 		target_link_libraries(PCSX2_FLAGS INTERFACE
 			pthreads4w
 		)

--- a/pcsx2/SPU2/Windows/SndOut_XAudio2.cpp
+++ b/pcsx2/SPU2/Windows/SndOut_XAudio2.cpp
@@ -20,7 +20,6 @@
 #endif
 #include "common/Console.h"
 
-#include <xaudio2.h>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -29,6 +28,17 @@
 #include <wil/com.h>
 #include <wil/resource.h>
 #include <wil/win32_helpers.h>
+
+// We set _WIN32_WINNT to Win10, which means that xaudio2.h tries to use
+// the Windows 10 version. For wx, we still need to support Win8, so we
+// cheekily redefine _WIN32_WINNT before xaudio2.h is included, so that
+// it uses the older DLL.
+#ifndef PCSX2_CORE
+#undef _WIN32_WINNT
+#define _WIN32_WINNT _WIN32_WINNT_WIN8
+#endif
+
+#include <xaudio2.h>
 
 //#define XAUDIO2_DEBUG
 

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -75,7 +75,7 @@
     <Link>
       <LargeAddressAware>Yes</LargeAddressAware>
       <AdditionalDependencies>comctl32.lib;ws2_32.lib;shlwapi.lib;winmm.lib;rpcrt4.lib;iphlpapi.lib;dsound.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;PowrProf.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;dinput8.lib;hid.lib;PowrProf.lib;d3dcompiler.lib;d3d11.lib;dxgi.lib;strmiids.lib;opengl32.lib;comsuppw.lib;OneCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Changes

An extension of #6532, this fixes the underlying issue that was causing the allocations to fail in the first place.

The software renderer needs a repeat mapping of the GS local memory for more efficient emulation of wrapping. To do this, we create an anonymous/pagefile backed file, and map the same file over 4 times the virtual address space. The problem is, on Windows prior to Win10 1809, you couldn't guarantee that any of that virtual address space was actually free.

So, PCSX2 just yolo'ed it, trying a few times to get a large enough chunk. But because we were only mapping 4MB, but needed 16MB (for the repeats), there's no guarantee that would actually end up in a free 16MB chunk. Hence "randomly" getting allocation errors, and falling back to no wrapping.

That's obviously bad. So we'll do things the modern way, which works similarly to Linux, which can mmap() over the top of existing mappings no dramas. The only downside, is that it requires Win10. But since Qt also requires Win10, and wx is deprecated already, this is fine.

### Rationale behind Changes

Making the software renderer more reliable.

### Suggested Testing Steps

Toggle software renderer a bunch of times and make sure you see no memory allocation errors. I also need to make sure wx still launches on Win8 despite the `_WIN32_WINNT` bump.
