### PR TITLE
GS: Fix interlace offsets for no-interlace patches

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -175,7 +175,7 @@ bool GSRenderer::Merge(int field)
 	const bool is_bob = GSConfig.InterlaceMode == GSInterlaceMode::BobTFF || GSConfig.InterlaceMode == GSInterlaceMode::BobBFF;
 
 	// Use offset for bob deinterlacing always, extra offset added later for FFMD mode.
-	float offset = (tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y);
+	float offset = is_bob ? (tex[1] ? tex[1]->GetScale().y : tex[0]->GetScale().y) : 0.0f;
 
 	int field2 = 0;
 	int mode = 2;


### PR DESCRIPTION
### Description of Changes
Makes it not use an offset when using no-interlace patches

### Rationale behind Changes
It did, it shouldn't

### Suggested Testing Steps
No need, j ust gonna merge when it builds
