### PR TITLE
Qt: Implement more missing features

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -397,22 +397,6 @@ bool DisplayWidget::event(QEvent* event)
 			return true;
 		}
 
-		case QEvent::FocusIn:
-		{
-			QWidget::event(event);
-			emit windowFocusEvent();
-			return true;
-		}
-
-		case QEvent::ActivationChange:
-		{
-			QWidget::event(event);
-			if (isActiveWindow())
-				emit windowFocusEvent();
-
-			return true;
-		}
-
 		default:
 			return QWidget::event(event);
 	}
@@ -474,19 +458,6 @@ bool DisplayContainer::event(QEvent* event)
 		{
 			if (static_cast<QWindowStateChangeEvent*>(event)->oldState() & Qt::WindowMinimized)
 				emit m_display_widget->windowRestoredEvent();
-		}
-		break;
-
-		case QEvent::FocusIn:
-		{
-			emit m_display_widget->windowFocusEvent();
-		}
-		break;
-
-		case QEvent::ActivationChange:
-		{
-			if (isActiveWindow())
-				emit m_display_widget->windowFocusEvent();
 		}
 		break;
 

--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -42,7 +42,6 @@ public:
 	void updateCursor(bool master_enable);
 
 Q_SIGNALS:
-	void windowFocusEvent();
 	void windowResizedEvent(int width, int height, float scale);
 	void windowRestoredEvent();
 

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -497,18 +497,18 @@ void EmuThread::switchRenderer(GSRendererType renderer)
 	GetMTGS().SwitchRenderer(renderer);
 }
 
-void EmuThread::changeDisc(const QString& path)
+void EmuThread::changeDisc(CDVD_SourceType source, const QString& path)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "changeDisc", Qt::QueuedConnection, Q_ARG(const QString&, path));
+		QMetaObject::invokeMethod(this, "changeDisc", Qt::QueuedConnection, Q_ARG(CDVD_SourceType, source), Q_ARG(const QString&, path));
 		return;
 	}
 
 	if (!VMManager::HasValidVM())
 		return;
 
-	VMManager::ChangeDisc(path.toStdString());
+	VMManager::ChangeDisc(source, path.toStdString());
 }
 
 void EmuThread::reloadPatches()

--- a/pcsx2-qt/EmuThread.cpp
+++ b/pcsx2-qt/EmuThread.cpp
@@ -108,7 +108,7 @@ void EmuThread::startVM(std::shared_ptr<VMBootParameters> boot_params)
 
 	// create the display, this may take a while...
 	m_is_fullscreen = boot_params->fullscreen.value_or(Host::GetBaseBoolSettingValue("UI", "StartFullscreen", false));
-	m_is_rendering_to_main = Host::GetBaseBoolSettingValue("UI", "RenderToMainWindow", true);
+	m_is_rendering_to_main = !Host::GetBaseBoolSettingValue("UI", "RenderToSeparateWindow", false);
 	m_is_surfaceless = false;
 	m_save_state_on_shutdown = false;
 	if (!VMManager::Initialize(*boot_params))
@@ -433,7 +433,7 @@ void EmuThread::checkForSettingChanges()
 
 	if (VMManager::HasValidVM())
 	{
-		const bool render_to_main = Host::GetBaseBoolSettingValue("UI", "RenderToMainWindow", true);
+		const bool render_to_main = !Host::GetBaseBoolSettingValue("UI", "RenderToSeparateWindow", false);
 		if (!m_is_fullscreen && m_is_rendering_to_main != render_to_main)
 		{
 			m_is_rendering_to_main = render_to_main;

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -140,12 +140,13 @@ private:
 	void createBackgroundControllerPollTimer();
 	void destroyBackgroundControllerPollTimer();
 	void loadOurSettings();
+	void connectSignals();
 
 private Q_SLOTS:
 	void stopInThread();
 	void doBackgroundControllerPoll();
 	void onDisplayWindowResized(int width, int height, float scale);
-	void onDisplayWindowFocused();
+	void onApplicationStateChanged(Qt::ApplicationState state);
 	void redrawDisplayWindow();
 
 private:
@@ -161,6 +162,9 @@ private:
 	bool m_is_fullscreen = false;
 	bool m_is_surfaceless = false;
 	bool m_save_state_on_shutdown = false;
+	bool m_pause_on_focus_loss = false;
+
+	bool m_was_paused_by_focus_loss = false;
 
 	float m_last_speed = 0.0f;
 	float m_last_game_fps = 0.0f;

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -146,6 +146,7 @@ private Q_SLOTS:
 	void doBackgroundControllerPoll();
 	void onDisplayWindowResized(int width, int height, float scale);
 	void onDisplayWindowFocused();
+	void redrawDisplayWindow();
 
 private:
 	QThread* m_ui_thread;

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -43,6 +43,7 @@ public:
 
 	__fi QEventLoop* getEventLoop() const { return m_event_loop; }
 	__fi bool isFullscreen() const { return m_is_fullscreen; }
+	__fi bool isRenderingToMain() const { return m_is_rendering_to_main; }
 
 	bool isOnEmuThread() const;
 

--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -30,6 +30,8 @@
 class DisplayWidget;
 struct VMBootParameters;
 
+enum class CDVD_SourceType : uint8_t;
+
 class EmuThread : public QThread
 {
 	Q_OBJECT
@@ -74,7 +76,7 @@ public Q_SLOTS:
 	void updateEmuFolders();
 	void toggleSoftwareRendering();
 	void switchRenderer(GSRendererType renderer);
-	void changeDisc(const QString& path);
+	void changeDisc(CDVD_SourceType source, const QString& path);
 	void reloadPatches();
 	void reloadInputSources();
 	void reloadInputBindings();

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -207,6 +207,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionChangeDiscFromFile, &QAction::triggered, this, &MainWindow::onChangeDiscFromFileActionTriggered);
 	connect(m_ui.actionChangeDiscFromDevice, &QAction::triggered, this, &MainWindow::onChangeDiscFromDeviceActionTriggered);
 	connect(m_ui.actionChangeDiscFromGameList, &QAction::triggered, this, &MainWindow::onChangeDiscFromGameListActionTriggered);
+	connect(m_ui.actionRemoveDisc, &QAction::triggered, this, &MainWindow::onRemoveDiscActionTriggered);
 	connect(m_ui.menuChangeDisc, &QMenu::aboutToShow, this, &MainWindow::onChangeDiscMenuAboutToShow);
 	connect(m_ui.menuChangeDisc, &QMenu::aboutToHide, this, &MainWindow::onChangeDiscMenuAboutToHide);
 	connect(m_ui.actionPowerOff, &QAction::triggered, this, [this]() { requestShutdown(true, true); });
@@ -1139,6 +1140,11 @@ void MainWindow::onChangeDiscFromDeviceActionTriggered()
 		return;
 
 	g_emu_thread->changeDisc(CDVD_SourceType::Disc, path);
+}
+
+void MainWindow::onRemoveDiscActionTriggered()
+{
+	g_emu_thread->changeDisc(CDVD_SourceType::NoDisc, QString());
 }
 
 void MainWindow::onChangeDiscMenuAboutToShow()

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -118,6 +118,7 @@ private Q_SLOTS:
 	void onChangeDiscFromFileActionTriggered();
 	void onChangeDiscFromGameListActionTriggered();
 	void onChangeDiscFromDeviceActionTriggered();
+	void onRemoveDiscActionTriggered();
 	void onChangeDiscMenuAboutToShow();
 	void onChangeDiscMenuAboutToHide();
 	void onLoadStateMenuAboutToShow();

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -235,8 +235,7 @@ private:
 	QString m_current_game_serial;
 	QString m_current_game_name;
 	quint32 m_current_game_crc;
-	bool m_vm_valid = false;
-	bool m_vm_paused = false;
+
 	bool m_save_states_invalidated = false;
 	bool m_was_paused_on_surface_loss = false;
 	bool m_was_disc_change_request = false;

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -179,6 +179,7 @@ private:
 	void updateEmulationActions(bool starting, bool running);
 	void updateStatusBarWidgetVisibility();
 	void updateWindowTitle();
+	void updateWindowVisibility();
 	void setProgressBar(int current, int total);
 	void clearProgressBar();
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -39,6 +39,8 @@ namespace GameList
 	struct Entry;
 }
 
+enum class CDVD_SourceType : uint8_t;
+
 class MainWindow final : public QMainWindow
 {
 	Q_OBJECT
@@ -111,6 +113,7 @@ private Q_SLOTS:
 	void onGameListEntryContextMenuRequested(const QPoint& point);
 
 	void onStartFileActionTriggered();
+	void onStartDiscActionTriggered();
 	void onStartBIOSActionTriggered();
 	void onChangeDiscFromFileActionTriggered();
 	void onChangeDiscFromGameListActionTriggered();
@@ -202,6 +205,8 @@ private:
 	ControllerSettingsDialog* getControllerSettingsDialog();
 	void doControllerSettings(ControllerSettingsDialog::Category category = ControllerSettingsDialog::Category::Count);
 
+	QString getDiscDevicePath(const QString& title);
+
 	void startGameListEntry(const GameList::Entry* entry, std::optional<s32> save_slot = std::nullopt,
 		std::optional<bool> fast_boot = std::nullopt);
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
@@ -212,8 +217,8 @@ private:
 	void populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc);
 	void populateSaveStateMenu(QMenu* menu, const QString& serial, quint32 crc);
 	void updateSaveStateMenus(const QString& filename, const QString& serial, quint32 crc);
-	void doStartDisc(const QString& path);
-	void doDiscChange(const QString& path);
+	void doStartFile(std::optional<CDVD_SourceType> source, const QString& path);
+	void doDiscChange(CDVD_SourceType source, const QString& path);
 
 	Ui::MainWindow m_ui;
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -179,7 +179,7 @@ private:
 	void updateEmulationActions(bool starting, bool running);
 	void updateStatusBarWidgetVisibility();
 	void updateWindowTitle();
-	void updateWindowVisibility();
+	void updateWindowState(bool force_visible = false);
 	void setProgressBar(int current, int total);
 	void clearProgressBar();
 

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -85,6 +85,7 @@ bool QtHost::Initialize()
 	qRegisterMetaType<std::shared_ptr<VMBootParameters>>();
 	qRegisterMetaType<GSRendererType>();
 	qRegisterMetaType<InputBindingKey>();
+	qRegisterMetaType<CDVD_SourceType>();
 	qRegisterMetaType<const GameList::Entry*>();
 
 	if (!InitializeConfig())

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -66,4 +66,8 @@ namespace QtHost
 	bool RemoveBaseValueFromStringList(const char* section, const char* key, const char* value);
 	void RemoveBaseSettingValue(const char* section, const char* key);
 	void QueueSettingsSave();
+
+	/// VM state, safe to access on UI thread.
+	bool IsVMValid();
+	bool IsVMPaused();
 } // namespace QtHost

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -29,11 +29,14 @@ class SettingsInterface;
 
 class EmuThread;
 
+enum class CDVD_SourceType : uint8_t;
+
 Q_DECLARE_METATYPE(std::shared_ptr<VMBootParameters>);
 Q_DECLARE_METATYPE(std::optional<bool>);
 Q_DECLARE_METATYPE(std::function<void()>);
 Q_DECLARE_METATYPE(GSRendererType);
 Q_DECLARE_METATYPE(InputBindingKey);
+Q_DECLARE_METATYPE(CDVD_SourceType);
 
 namespace QtHost
 {

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -29,6 +29,7 @@
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QScrollBar>
+#include <QtWidgets/QStatusBar>
 #include <QtWidgets/QStyle>
 #include <QtWidgets/QTableView>
 #include <QtWidgets/QTreeView>
@@ -167,4 +168,39 @@ namespace QtUtils
 		}
 	}
 
+	void SetWindowResizeable(QWidget* widget, bool resizeable)
+	{
+		if (QMainWindow* window = qobject_cast<QMainWindow*>(widget); window)
+		{
+			// update status bar grip if present
+			if (QStatusBar* sb = window->statusBar(); sb)
+				sb->setSizeGripEnabled(resizeable);
+		}
+
+		if ((widget->sizePolicy().horizontalPolicy() == QSizePolicy::Preferred) != resizeable)
+		{
+			if (resizeable)
+			{
+				// Min/max numbers come from uic.
+				widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+				widget->setMinimumSize(1, 1);
+				widget->setMaximumSize(16777215, 16777215);
+			}
+			else
+			{
+				widget->setFixedSize(widget->size());
+				widget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+			}
+		}
+	}
+
+	void ResizePotentiallyFixedSizeWindow(QWidget* widget, int width, int height)
+	{
+		width = std::max(width, 1);
+		height = std::max(height, 1);
+		if (widget->sizePolicy().horizontalPolicy() == QSizePolicy::Fixed)
+			widget->setFixedSize(width, height);
+
+		widget->resize(width, height);
+	}
 } // namespace QtUtils

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -68,4 +68,10 @@ namespace QtUtils
 
 	/// Sets a widget to italics if the setting value is inherited.
 	void SetWidgetFontForInheritedSetting(QWidget* widget, bool inherited);
+
+	/// Changes whether a window is resizable.
+	void SetWindowResizeable(QWidget* widget, bool resizeable);
+
+	/// Adjusts the fixed size for a window if it's not resizeable.
+	void ResizePotentiallyFixedSizeWindow(QWidget* widget, int width, int height);
 } // namespace QtUtils

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -117,7 +117,6 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 		tr("Hides the main window (with the game list) when a game is running, requires Render To Separate Window to be enabled."));
 
 	// Not yet used, disable the options
-	m_ui.pauseOnFocusLoss->setDisabled(true);
 	m_ui.language->setDisabled(true);
 
 	onRenderToSeparateWindowChanged();

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -62,6 +62,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hideMouseCursor, "UI", "HideMouseCursor", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.renderToSeparateWindow, "UI", "RenderToSeparateWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hideMainWindow, "UI", "HideMainWindowWhenRunning", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableWindowResizing, "UI", "DisableWindowResize", false);
 	connect(m_ui.renderToSeparateWindow, &QCheckBox::stateChanged, this, &InterfaceSettingsWidget::onRenderToSeparateWindowChanged);
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.theme, "UI", "Theme", THEME_NAMES, THEME_VALUES,
@@ -118,7 +119,6 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 	// Not yet used, disable the options
 	m_ui.pauseOnStart->setDisabled(true);
 	m_ui.pauseOnFocusLoss->setDisabled(true);
-	m_ui.disableWindowResizing->setDisabled(true);
 	m_ui.language->setDisabled(true);
 
 	onRenderToSeparateWindowChanged();

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -117,7 +117,6 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 		tr("Hides the main window (with the game list) when a game is running, requires Render To Separate Window to be enabled."));
 
 	// Not yet used, disable the options
-	m_ui.pauseOnStart->setDisabled(true);
 	m_ui.pauseOnFocusLoss->setDisabled(true);
 	m_ui.language->setDisabled(true);
 

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -30,8 +30,7 @@ static const char* THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Baby Pastel (Pink) [Light]"),
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "PCSX2 (White/Blue) [Light]"),
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Scarlet Devil (Red/Purple) [Dark]"),
-	nullptr
-};
+	nullptr};
 
 static const char* THEME_VALUES[] = {
 	"",
@@ -42,8 +41,7 @@ static const char* THEME_VALUES[] = {
 	"BabyPastel",
 	"PCSX2Blue",
 	"ScarletDevilRed",
-	nullptr
-};
+	nullptr};
 
 InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: QWidget(parent)
@@ -62,7 +60,9 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.doubleClickTogglesFullscreen, "UI", "DoubleClickTogglesFullscreen",
 		true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hideMouseCursor, "UI", "HideMouseCursor", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.renderToMainWindow, "UI", "RenderToMainWindow", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.renderToSeparateWindow, "UI", "RenderToSeparateWindow", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hideMainWindow, "UI", "HideMainWindowWhenRunning", false);
+	connect(m_ui.renderToSeparateWindow, &QCheckBox::stateChanged, this, &InterfaceSettingsWidget::onRenderToSeparateWindowChanged);
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.theme, "UI", "Theme", THEME_NAMES, THEME_VALUES,
 		MainWindow::DEFAULT_THEME_NAME);
@@ -109,15 +109,24 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 	dialog->registerWidgetHelp(m_ui.hideMouseCursor, tr("Hide Cursor In Fullscreen"), tr("Checked"),
 		tr("Hides the mouse pointer/cursor when the emulator is in fullscreen mode."));
 	dialog->registerWidgetHelp(
-		m_ui.renderToMainWindow, tr("Render To Main Window"), tr("Checked"),
-		tr("Renders the display of the simulated console to the main window of the application, over "
-		   "the game list. If unchecked, the display will render in a separate window."));
-	
+		m_ui.renderToSeparateWindow, tr("Render To Separate Window"), tr("Unchecked"),
+		tr("Renders the game to a separate window, instead of the main window. If unchecked, the game will display over the top of the game list."));
+	dialog->registerWidgetHelp(
+		m_ui.hideMainWindow, tr("Hide Main Window When Running"), tr("Unchecked"),
+		tr("Hides the main window (with the game list) when a game is running, requires Render To Separate Window to be enabled."));
+
 	// Not yet used, disable the options
 	m_ui.pauseOnStart->setDisabled(true);
 	m_ui.pauseOnFocusLoss->setDisabled(true);
 	m_ui.disableWindowResizing->setDisabled(true);
 	m_ui.language->setDisabled(true);
+
+	onRenderToSeparateWindowChanged();
 }
 
 InterfaceSettingsWidget::~InterfaceSettingsWidget() = default;
+
+void InterfaceSettingsWidget::onRenderToSeparateWindowChanged()
+{
+	m_ui.hideMainWindow->setEnabled(m_ui.renderToSeparateWindow->isChecked());
+}

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.h
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.h
@@ -32,6 +32,9 @@ public:
 Q_SIGNALS:
 	void themeChanged();
 
+private Q_SLOTS:
+	void onRenderToSeparateWindowChanged();
+
 private:
 	Ui::InterfaceSettingsWidget m_ui;
 };

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -78,24 +78,17 @@
      <layout class="QFormLayout" name="formLayout_3">
       <item row="0" column="0" colspan="2">
        <layout class="QGridLayout" name="gridLayout_3">
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="disableWindowResizing">
+          <property name="text">
+           <string>Disable Window Resizing</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="startFullscreen">
           <property name="text">
            <string>Start Fullscreen</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="hideMouseCursor">
-          <property name="text">
-           <string>Hide Cursor In Fullscreen</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="renderToMainWindow">
-          <property name="text">
-           <string>Render To Main Window</string>
           </property>
          </widget>
         </item>
@@ -106,10 +99,24 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="disableWindowResizing">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="renderToSeparateWindow">
           <property name="text">
-           <string>Disable Window Resizing</string>
+           <string>Render To Separate Window</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="hideMouseCursor">
+          <property name="text">
+           <string>Hide Cursor In Fullscreen</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="hideMainWindow">
+          <property name="text">
+           <string>Hide Main Window When Running</string>
           </property>
          </widget>
         </item>

--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -24,6 +24,7 @@
 #include "pcsx2/Frontend/INISettingsInterface.h"
 
 #include "EmuThread.h"
+#include "MainWindow.h"
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingsDialog.h"
@@ -55,8 +56,8 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 	setupUi(nullptr);
 }
 
-SettingsDialog::SettingsDialog(std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, u32 game_crc)
-	: QDialog()
+SettingsDialog::SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, u32 game_crc)
+	: QDialog(parent)
 	, m_sif(std::move(sif))
 	, m_game_crc(game_crc)
 {
@@ -446,7 +447,8 @@ void SettingsDialog::openGamePropertiesDialog(const GameList::Entry* game, const
 								   .arg(game ? QtUtils::StringViewToQString(game->title) : QStringLiteral("<UNKNOWN>"))
 								   .arg(QtUtils::StringViewToQString(Path::GetFileName(sif->GetFileName()))));
 
-	SettingsDialog* dialog = new SettingsDialog(std::move(sif), game, crc);
+	SettingsDialog* dialog = new SettingsDialog(g_main_window, std::move(sif), game, crc);
 	dialog->setWindowTitle(window_title);
+	dialog->setModal(false);
 	dialog->show();
 }

--- a/pcsx2-qt/Settings/SettingsDialog.h
+++ b/pcsx2-qt/Settings/SettingsDialog.h
@@ -48,7 +48,7 @@ class SettingsDialog final : public QDialog
 
 public:
 	explicit SettingsDialog(QWidget* parent);
-	SettingsDialog(std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, u32 game_crc);
+	SettingsDialog(QWidget* parent, std::unique_ptr<SettingsInterface> sif, const GameList::Entry* game, u32 game_crc);
 	~SettingsDialog();
 
 	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view& serial, u32 crc);

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -325,7 +325,9 @@
     <QtMoc Include="Tools\InputRecording\NewInputRecordingDlg.h">
       <Filter>Tools\Input Recording</Filter>
     </QtMoc>
-    <QtMoc Include="Settings\FolderSettingsWidget.h" />
+    <QtMoc Include="Settings\FolderSettingsWidget.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
   </ItemGroup>
   <ItemGroup>
     <QtResource Include="resources\resources.qrc">

--- a/pcsx2/Frontend/GameList.h
+++ b/pcsx2/Frontend/GameList.h
@@ -91,6 +91,8 @@ namespace GameList
 		u32 crc = 0;
 
 		CompatibilityRating compatibility_rating = CompatibilityRating::Unknown;
+
+		__fi bool IsDisc() const { return (type == EntryType::PS1Disc || type == EntryType::PS2Disc); }
 	};
 
 	const char* EntryTypeToString(EntryType type);

--- a/pcsx2/Frontend/ImGuiManager.cpp
+++ b/pcsx2/Frontend/ImGuiManager.cpp
@@ -27,6 +27,10 @@
 #include "common/Timer.h"
 #include "imgui.h"
 
+#ifdef PCSX2_CORE
+#include "imgui_internal.h"
+#endif
+
 #include "Config.h"
 #include "Counters.h"
 #include "Frontend/ImGuiManager.h"
@@ -198,6 +202,9 @@ void ImGuiManager::NewFrame()
 	ImGui::NewFrame();
 
 #ifdef PCSX2_CORE
+	// Disable nav input on the implicit (Debug##Default) window. Otherwise we end up requesting keyboard
+	// focus when there's nothing there. We use GetCurrentWindowRead() because otherwise it'll make it visible.
+	ImGui::GetCurrentWindowRead()->Flags |= ImGuiWindowFlags_NoNavInputs;
 	s_imgui_wants_keyboard.store(io.WantCaptureKeyboard, std::memory_order_relaxed);
 	s_imgui_wants_mouse.store(io.WantCaptureMouse, std::memory_order_release);
 #endif

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -285,6 +285,7 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 	GSConfig.OsdShowGPU = EmuConfig.GS.OsdShowGPU && display->SetGPUTimingEnabled(true);
 
 	g_gs_renderer->SetRegsMem(basemem);
+	g_perfmon.Reset();
 	return true;
 }
 

--- a/pcsx2/GS/GSPerfMon.cpp
+++ b/pcsx2/GS/GSPerfMon.cpp
@@ -19,13 +19,15 @@
 
 GSPerfMon g_perfmon;
 
-GSPerfMon::GSPerfMon()
-	: m_frame(0)
-	, m_lastframe(0)
-	, m_count(0)
+GSPerfMon::GSPerfMon() = default;
+
+void GSPerfMon::Reset()
 {
-	memset(m_counters, 0, sizeof(m_counters));
-	memset(m_stats, 0, sizeof(m_stats));
+	m_frame = 0;
+	m_lastframe = 0;
+	m_count = 0;
+	std::memset(m_counters, 0, sizeof(m_counters));
+	std::memset(m_stats, 0, sizeof(m_stats));
 }
 
 void GSPerfMon::EndFrame()

--- a/pcsx2/GS/GSPerfMon.h
+++ b/pcsx2/GS/GSPerfMon.h
@@ -38,15 +38,17 @@ public:
 	};
 
 protected:
-	double m_counters[CounterLast];
-	double m_stats[CounterLast];
-	u64 m_frame;
-	clock_t m_lastframe;
-	int m_count;
-	int m_disp_fb_sprite_blits;
+	double m_counters[CounterLast] = {};
+	double m_stats[CounterLast] = {};
+	u64 m_frame = 0;
+	clock_t m_lastframe = 0;
+	int m_count = 0;
+	int m_disp_fb_sprite_blits = 0;
 
 public:
 	GSPerfMon();
+
+	void Reset();
 
 	void SetFrame(u64 frame) { m_frame = frame; }
 	u64 GetFrame() { return m_frame; }

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1294,15 +1294,15 @@ void VMManager::FrameAdvance(u32 num_frames /*= 1*/)
 	SetState(VMState::Running);
 }
 
-bool VMManager::ChangeDisc(std::string path)
+bool VMManager::ChangeDisc(CDVD_SourceType source, std::string path)
 {
-	std::string old_path(CDVDsys_GetFile(CDVD_SourceType::Iso));
-	CDVD_SourceType old_type = CDVDsys_GetSourceType();
+	const CDVD_SourceType old_type = CDVDsys_GetSourceType();
+	const std::string old_path(CDVDsys_GetFile(old_type));
 
-	const std::string display_name(path.empty() ? std::string() : FileSystem::GetDisplayNameFromPath(path));
-	CDVDsys_ChangeSource(path.empty() ? CDVD_SourceType::NoDisc : CDVD_SourceType::Iso);
+	const std::string display_name((source != CDVD_SourceType::Iso) ? path : FileSystem::GetDisplayNameFromPath(path));
+	CDVDsys_ChangeSource(source);
 	if (!path.empty())
-		CDVDsys_SetFile(CDVD_SourceType::Iso, std::move(path));
+		CDVDsys_SetFile(source, std::move(path));
 
 	const bool result = DoCDVDopen();
 	if (result)

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1307,17 +1307,20 @@ bool VMManager::ChangeDisc(CDVD_SourceType source, std::string path)
 	const bool result = DoCDVDopen();
 	if (result)
 	{
-		Host::AddOSDMessage(fmt::format("Disc changed to '{}'.", display_name), 5.0f);
+		if (source == CDVD_SourceType::NoDisc)
+			Host::AddKeyedOSDMessage("ChangeDisc", "Disc removed.", 5.0f);
+		else
+			Host::AddKeyedOSDMessage("ChangeDisc", fmt::format("Disc changed to '{}'.", display_name), 5.0f);
 	}
 	else
 	{
-		Host::AddOSDMessage(fmt::format("Failed to open new disc image '{}'. Reverting to old image.", display_name), 20.0f);
+		Host::AddKeyedOSDMessage("ChangeDisc", fmt::format("Failed to open new disc image '{}'. Reverting to old image.", display_name), 20.0f);
 		CDVDsys_ChangeSource(old_type);
 		if (!old_path.empty())
 			CDVDsys_SetFile(old_type, std::move(old_path));
 		if (!DoCDVDopen())
 		{
-			Host::AddOSDMessage("Failed to switch back to old disc image. Removing disc.", 20.0f);
+			Host::AddKeyedOSDMessage("ChangeDisc", "Failed to switch back to old disc image. Removing disc.", 20.0f);
 			CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
 			DoCDVDopen();
 		}

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -135,7 +135,7 @@ namespace VMManager
 
 	/// Changes the disc in the virtual CD/DVD drive. Passing an empty will remove any current disc.
 	/// Returns false if the new disc can't be opened.
-	bool ChangeDisc(std::string path);
+	bool ChangeDisc(CDVD_SourceType source, std::string path);
 
 	/// Returns true if the specified path is an ELF.
 	bool IsElfFileName(const std::string_view& path);


### PR DESCRIPTION
### Description of Changes

 - Implement disable window resize option.
 - Implement pause on start option.
 - Implement pause on focus option.
 - Implement start disc (drive selection/auto-default to single drive).
 - Adds the ability to hide the main window when a game is running, aka wx nogui mode.
 - Add global VM validity (useful for other windows).
 - Fixes bug where game properties windows would stay open after closing the main window.

### Rationale behind Changes

Implementing missing features.

Closes #6223.

### Suggested Testing Steps

Test all new features.
