### PR TITLE
Add MacOS badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Windows Build Status](https://img.shields.io/github/workflow/status/PCSX2/pcsx2/%F0%9F%96%A5%EF%B8%8F%20Windows%20Builds/master?label=Windows%20Builds)
 ![Linux Build Status](https://img.shields.io/github/workflow/status/PCSX2/pcsx2/%F0%9F%90%A7%20Linux%20Builds/master?label=Linux%20Builds)
+![MacOS Build Status](https://img.shields.io/github/workflow/status/PCSX2/pcsx2/%F0%9F%8D%8E%20MacOS%20Builds/master?label=MacOS%20Builds)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1f7c0d75fec74d6daa6adb084e5b4f71)](https://www.codacy.com/gh/PCSX2/pcsx2/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=PCSX2/pcsx2&amp;utm_campaign=Badge_Grade)
 [![Discord Server](https://img.shields.io/discord/309643527816609793?color=%235CA8FA&label=PCSX2%20Discord&logo=discord&logoColor=white)](https://discord.com/invite/TCz3t9k)
 


### PR DESCRIPTION
### Description of Changes
Adds a MacOS badge to the project readme.

### Rationale behind Changes
I was poking around on my fork regarding the readme, and noticed that there's no MacOS badge. Thought that was odd, figured I'd add it.

### Suggested Testing Steps
Feel free to cross-reference the URL with a badge [generated on your own](https://shields.io/category/build) I 'spose.