### PR TITLE
Qt: Fix window reopening after close

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -376,14 +376,10 @@ bool DisplayWidget::event(QEvent* event)
 
 		case QEvent::Close:
 		{
-			if (!g_main_window->requestShutdown())
-			{
-				// abort the window close
-				event->ignore();
-				return true;
-			}
-
-			QWidget::event(event);
+			// Closing the separate widget will either cancel the close, or trigger shutdown.
+			// In the latter case, it's going to destroy us, so don't let Qt do it first.
+			QMetaObject::invokeMethod(g_main_window, "requestShutdown", Q_ARG(bool, true), Q_ARG(bool, false), Q_ARG(bool, false));
+			event->ignore();
 			return true;
 		}
 
@@ -441,9 +437,11 @@ DisplayWidget* DisplayContainer::removeDisplayWidget()
 
 bool DisplayContainer::event(QEvent* event)
 {
-	if (event->type() == QEvent::Close && !g_main_window->requestShutdown())
+	if (event->type() == QEvent::Close)
 	{
-		// abort the window close
+		// Closing the separate widget will either cancel the close, or trigger shutdown.
+		// In the latter case, it's going to destroy us, so don't let Qt do it first.
+		QMetaObject::invokeMethod(g_main_window, "requestShutdown", Q_ARG(bool, true), Q_ARG(bool, false), Q_ARG(bool, false));
 		event->ignore();
 		return true;
 	}

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -245,6 +245,7 @@ private:
 	bool m_save_states_invalidated = false;
 	bool m_was_paused_on_surface_loss = false;
 	bool m_was_disc_change_request = false;
+	bool m_is_closing = false;
 
 	QString m_last_fps_status;
 };

--- a/pcsx2/PAD/Host/Global.h
+++ b/pcsx2/PAD/Host/Global.h
@@ -17,8 +17,6 @@
 
 #include "common/Pcsx2Defs.h"
 
-static const u32 MAX_KEYS = 25;
-
 enum gamePadValues
 {
 	PAD_UP,       // Directional pad ↑
@@ -46,7 +44,8 @@ enum gamePadValues
 	PAD_R_UP,     // Right joystick (Up) ↑
 	PAD_R_RIGHT,  // Right joystick (Right) →
 	PAD_R_DOWN,   // Right joystick (Down) ↓
-	PAD_R_LEFT    // Right joystick (Left) ←
+	PAD_R_LEFT,   // Right joystick (Left) ←
+	MAX_KEYS,
 };
 
 static inline bool IsAnalogKey(int index)

--- a/pcsx2/PAD/Host/PAD.cpp
+++ b/pcsx2/PAD/Host/PAD.cpp
@@ -546,7 +546,7 @@ bool PAD::MapController(SettingsInterface& si, u32 controller,
 
 void PAD::SetControllerState(u32 controller, u32 bind, float value)
 {
-	if (controller >= NUM_CONTROLLER_PORTS || bind >= MAX_KEYS)
+	if (controller >= NUM_CONTROLLER_PORTS || bind > MAX_KEYS)
 		return;
 
 	g_key_status.Set(controller, bind, value);


### PR DESCRIPTION
### Description of Changes

Stops the window reopening after it's been closedl

### Rationale behind Changes

Regression from #6536.

### Suggested Testing Steps

Test closing window with game running.
