### PR TITLE
Qt: Show disabled hw fixes in OSD

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -439,8 +439,85 @@ u32 GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool appl
 	return num_applied_fixes;
 }
 
+bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOptions& config, GSHWFixId id, int value) const
+{
+	switch (id)
+	{
+		case GSHWFixId::AutoFlush:
+			return (static_cast<int>(config.UserHacks_AutoFlush) == value);
+
+		case GSHWFixId::ConservativeFramebuffer:
+			return (static_cast<int>(config.ConservativeFramebuffer) == value);
+
+		case GSHWFixId::CPUFramebufferConversion:
+			return (static_cast<int>(config.UserHacks_CPUFBConversion) == value);
+
+		case GSHWFixId::DisableDepthSupport:
+			return (static_cast<int>(config.UserHacks_DisableDepthSupport) == value);
+
+		case GSHWFixId::WrapGSMem:
+			return (static_cast<int>(config.WrapGSMem) == value);
+
+		case GSHWFixId::PreloadFrameData:
+			return (static_cast<int>(config.PreloadFrameWithGSData) == value);
+
+		case GSHWFixId::DisablePartialInvalidation:
+			return (static_cast<int>(config.UserHacks_DisablePartialInvalidation) == value);
+
+		case GSHWFixId::TextureInsideRT:
+			return (static_cast<int>(config.UserHacks_TextureInsideRt) == value);
+
+		case GSHWFixId::AlignSprite:
+			return (config.UpscaleMultiplier == 1 || static_cast<int>(config.UserHacks_AlignSpriteX) == value);
+
+		case GSHWFixId::MergeSprite:
+			return (config.UpscaleMultiplier == 1 || static_cast<int>(config.UserHacks_MergePPSprite) == value);
+
+		case GSHWFixId::WildArmsHack:
+			return (config.UpscaleMultiplier == 1 || static_cast<int>(config.UserHacks_WildHack) == value);
+
+		case GSHWFixId::PointListPalette:
+			return (static_cast<int>(config.PointListPalette) == value);
+
+		case GSHWFixId::Mipmap:
+			return (config.HWMipmap == HWMipmapLevel::Automatic || static_cast<int>(config.HWMipmap) == value);
+
+		case GSHWFixId::TrilinearFiltering:
+			return (config.UserHacks_TriFilter == TriFiltering::Automatic || static_cast<int>(config.UserHacks_TriFilter) == value);
+
+		case GSHWFixId::SkipDrawStart:
+			return (config.SkipDrawStart == value);
+
+		case GSHWFixId::SkipDrawEnd:
+			return (config.SkipDrawEnd == value);
+
+		case GSHWFixId::HalfBottomOverride:
+			return (config.UserHacks_HalfBottomOverride == value);
+
+		case GSHWFixId::HalfPixelOffset:
+			return (config.UpscaleMultiplier == 1 || config.UserHacks_HalfPixelOffset == value);
+
+		case GSHWFixId::RoundSprite:
+			return (config.UpscaleMultiplier == 1 || config.UserHacks_RoundSprite == value);
+
+		case GSHWFixId::TexturePreloading:
+			return (static_cast<int>(config.TexturePreloading) <= value);
+
+		case GSHWFixId::Deinterlace:
+			return (config.InterlaceMode == GSInterlaceMode::Automatic || static_cast<int>(config.InterlaceMode) == value);
+
+		case GSHWFixId::CPUSpriteRenderBW:
+			return (config.UserHacks_CPUSpriteRenderBW == value);
+
+		default:
+			return false;
+	}
+}
+
 u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const
 {
+	std::string disabled_fixes;
+
 	// Only apply GS HW fixes if the user hasn't manually enabled HW fixes.
 	const bool apply_auto_fixes = !config.ManualUserHacks;
 	if (!apply_auto_fixes)
@@ -451,7 +528,11 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 	{
 		if (isUserHackHWFix(id) && !apply_auto_fixes)
 		{
+			if (configMatchesHWFix(config, id, value))
+				continue;
+
 			PatchesCon->Warning("[GameDB] Skipping GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
+			fmt::format_to(std::back_inserter(disabled_fixes), "{} {} = {}", disabled_fixes.empty() ? "  " : "\n  ", getHWFixName(id), value);
 			continue;
 		}
 
@@ -582,6 +663,20 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 
 	// fixup skipdraw range just in case the db has a bad range (but the linter should catch this)
 	config.SkipDrawEnd = std::max(config.SkipDrawStart, config.SkipDrawEnd);
+
+#ifdef PCSX2_CORE
+	if (!disabled_fixes.empty())
+	{
+		Host::AddKeyedOSDMessage("HWFixesWarning",
+			fmt::format("Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:\n{}",
+				disabled_fixes),
+			10.0f);
+	}
+	else
+	{
+		Host::RemoveKeyedOSDMessage("HWFixesWarning");
+	}
+#endif
 
 	return num_applied_fixes;
 }

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -112,6 +112,9 @@ namespace GameDatabaseSchema
 
 		/// Applies GS hardware fixes to an existing config. Returns the number of applied fixes.
 		u32 applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const;
+
+		/// Returns true if the current config value for the specified hw fix id matches the value.
+		bool configMatchesHWFix(const Pcsx2Config::GSOptions& config, GSHWFixId id, int value) const;
 	};
 };
 


### PR DESCRIPTION
### Description of Changes

This will help with user complaints about upscaling/hardware bugs, when the auto fixes have been disabled because they're silly.

The notification is smart, so it'll only display when the custom config **does not** match the gamedb.

### Rationale behind Changes

Reducing support whinging.

### Suggested Testing Steps

Test manual fixes, both mismatching and matching the gamedb.
