### PR TITLE
IOPBios: Make our hostfs HLE safer

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -316,6 +316,7 @@ namespace R3000A
 			ghc::filesystem::directory_iterator dirent(path.c_str(), err);
 			if (err)
 				return -IOP_ENOENT; // Should return ENOTDIR if path is a file?
+                                    // Would love to but err's code is platform dependent
 
 			*dir = new HostDir(dirent);
 			if (!*dir)
@@ -633,8 +634,13 @@ namespace R3000A
 			{
 				const std::string path = full_path.substr(full_path.find(':') + 1);
 				const ghc::filesystem::path file_path{host_path(path)};
-				const bool succeeded = ghc::filesystem::remove(file_path);
-				v0 = succeeded ? 0 : -IOP_EIO;
+				std::error_code err;
+				const bool succeeded = ghc::filesystem::remove(file_path, err);
+
+				if(err)
+					Console.Warning("IOPHLE remove_HLE: '%s'", err.message().c_str());
+
+				v0 = (succeeded && !err) ? 0 : -IOP_EIO;
 				pc = ra;
 			}
 			return 0;
@@ -648,8 +654,13 @@ namespace R3000A
 			{
 				const std::string path = full_path.substr(full_path.find(':') + 1);
 				const ghc::filesystem::path folder_path{host_path(path)};
-				const bool succeeded = ghc::filesystem::create_directory(folder_path);
-				v0 = succeeded ? 0 : -IOP_EIO;
+				std::error_code err;
+				const bool succeeded = ghc::filesystem::create_directory(folder_path, err);
+
+				if (err)
+					Console.Warning("IOPHLE mkdir_HLE: '%s'", err.message().c_str());
+
+				v0 = (succeeded && !err) ? 0 : -IOP_EIO;
 				pc = ra;
 				return 1;
 			}
@@ -687,8 +698,13 @@ namespace R3000A
 			{
 				const std::string path = full_path.substr(full_path.find(':') + 1);
 				const ghc::filesystem::path folder_path{host_path(path)};
-				const bool succeeded = ghc::filesystem::remove(folder_path);
-				v0 = succeeded ? 0 : -IOP_EIO;
+				std::error_code err;
+				const bool succeeded = ghc::filesystem::remove(folder_path, err);
+
+				if (err)
+					Console.Warning("IOPHLE rmdir_HLE: '%s'", err.message().c_str());
+
+				v0 = (succeeded && !err) ? 0 : -IOP_EIO;
 				pc = ra;
 				return 1;
 			}


### PR DESCRIPTION
### Description of Changes
Instead of letting `filesystem` possibly throw exceptions that crash the emulator, use the overloaded functions that instead take an std::error_code by reference. Logging was also added for when this happens as the IOP HLE error code system is currently meh¹ and is wrong anyways. We just pass EIO (Generic Input / Output Error).

Here is a sample of the logging
![image](https://user-images.githubusercontent.com/29295048/176492325-ae802907-fec4-4f0f-b69b-aade82c69b6a.png)

[1] What's the point of standardizing a filesystem API, only to make the error codes platform dependent? Thanks ISOCpp :/

### Rationale behind Changes
If you were to mkdir a path that is taken by an existing _file_, GHC would throw an exception and crash the emulator.

Try it here:
[hostfs.zip](https://github.com/PCSX2/pcsx2/files/9012446/hostfs.zip)

### Suggested Testing Steps
Use something that utilizes hostfs.


Thanks @fjtrujy for pointing this out ^‿^