### PR TITLE
GS: Adjust CLUT dirty checks to reduce false positives

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -752,19 +752,68 @@ void GSClut::Expand16(const u16* RESTRICT src, u32* RESTRICT dst, int w, const G
 	}
 }
 
-//
-
 bool GSClut::WriteState::IsDirty(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 {
-	return dirty || !GSVector4i::load<true>(this).eq(GSVector4i::load(&TEX0, &TEXCLUT));
+	constexpr u64 mask = 0x1FFFFFE000000000ull; // CSA CSM CPSM CBP
+
+	bool is_dirty = dirty;
+
+	if ((this->TEX0.U64 ^ TEX0.U64) & mask)
+		is_dirty |= true;
+	else if (TEX0.CSM == 1 && (TEXCLUT.U32[0] ^ this->TEXCLUT.U32[0]))
+		is_dirty |= true;
+
+	if (!is_dirty)
+	{
+		this->TEX0.U64 = TEX0.U64;
+		this->TEXCLUT.U64 = TEXCLUT.U64;
+	}
+
+	return is_dirty;
 }
 
 bool GSClut::ReadState::IsDirty(const GIFRegTEX0& TEX0)
 {
-	return dirty || !GSVector4i::load<true>(this).eq(GSVector4i::load(&TEX0, &this->TEXA));
+	constexpr u64 mask = 0x1FFFFFE000000000ull; // CSA CSM CPSM CBP
+
+	bool is_dirty = dirty;
+
+	if ((this->TEX0.U64 ^ TEX0.U64) & mask)
+		is_dirty |= true;
+
+	if (!is_dirty)
+	{
+		this->TEX0.U64 = TEX0.U64;
+	}
+
+	return is_dirty;
 }
 
 bool GSClut::ReadState::IsDirty(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA)
 {
-	return dirty || !GSVector4i::load<true>(this).eq(GSVector4i::load(&TEX0, &TEXA));
+	constexpr u64 tex0_mask = 0x1FFFFFE000000000ull; // CSA CSM CPSM CBP
+	constexpr u64 texa24_mask = 0x80FFull; // AEM TA0
+	constexpr u64 texa16_mask = 0xFF000080FFull; // TA1 AEM TA0
+
+	bool is_dirty = dirty;
+
+	if ((this->TEX0.U64 ^ TEX0.U64) & tex0_mask)
+		is_dirty |= true;
+	else // Just to optimise the checks.
+	{
+		// Check TA0 and AEM in 24bit mode.
+		if (TEX0.CPSM == PSM_PSMCT24 && ((this->TEXA.U64 ^ TEXA.U64) & texa24_mask))
+			is_dirty |= true;
+		// Check all fields in 16bit mode.
+		else if (TEX0.CPSM >= PSM_PSMCT16 && ((this->TEXA.U64 ^ TEXA.U64) & texa16_mask))
+			is_dirty |= true;
+	}
+
+	if (!is_dirty)
+	{
+		this->TEX0.U64 = TEX0.U64;
+		this->TEXA.U64 = TEXA.U64;
+	}
+
+	return is_dirty;
 }


### PR DESCRIPTION
### Description of Changes
Swaps out the Dirty checks for the CLUT palette to only check the information important to the CLUT reloading.

### Rationale behind Changes
Before it just checked the entire TEX0, TEXCLUT or TEXA etc, but that isn't always relevant to the current format (or relevant at all), which caused false flushes of draws for no reason.

### Suggested Testing Steps
Run games, make sure the colours aren't a mess.

Observed improvements (in number of draw calls):

Disney Golf - 334-358 (was 335-359)
DT Racer - 819  (was 822)
Firefighter FD-19 - 481-540 (was 613-669) (translates to a 4% speed boost)
Gran Turismo 4 - 1976 (was 1982)
Wallace & Gromit Curse of the Were Rabbit - 197-210 (was 199-211)
