### PR TITLE
Qt: Implement mouse wheel binding

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -330,15 +330,12 @@ bool DisplayWidget::event(QEvent* event)
 
 		case QEvent::Wheel:
 		{
-			// wheel delta is 120 as in winapi
 			const QPoint delta_angle(static_cast<QWheelEvent*>(event)->angleDelta());
-			constexpr float DELTA = 120.0f;
-
-			const float dx = std::clamp(static_cast<float>(delta_angle.x()) / DELTA, -1.0f, 1.0f);
+			const float dx = std::clamp(static_cast<float>(delta_angle.x()) / QtUtils::MOUSE_WHEEL_DELTA, -1.0f, 1.0f);
 			if (dx != 0.0f)
 				InputManager::UpdatePointerRelativeDelta(0, InputPointerAxis::WheelX, dx);
 
-			const float dy = std::clamp(static_cast<float>(delta_angle.y()) / DELTA, -1.0f, 1.0f);
+			const float dy = std::clamp(static_cast<float>(delta_angle.y()) / QtUtils::MOUSE_WHEEL_DELTA, -1.0f, 1.0f);
 			if (dy != 0.0f)
 				InputManager::UpdatePointerRelativeDelta(0, InputPointerAxis::WheelY, dy);
 

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -36,6 +36,9 @@ class QUrl;
 
 namespace QtUtils
 {
+	/// Wheel delta is 120 as in winapi.
+	static constexpr float MOUSE_WHEEL_DELTA = 120.0f;
+
 	/// Marks an action as the "default" - i.e. makes the text bold.
 	void MarkActionAsDefault(QAction* action);
 

--- a/pcsx2-qt/Settings/InputBindingDialog.cpp
+++ b/pcsx2-qt/Settings/InputBindingDialog.cpp
@@ -23,6 +23,7 @@
 #include <QtCore/QTimer>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
+#include <QtGui/QWheelEvent>
 
 // _BitScanForward()
 #include "pcsx2/GS/GSIntrin.h"
@@ -75,6 +76,33 @@ bool InputBindingDialog::eventFilter(QObject* watched, QEvent* event)
 		unsigned long button_index;
 		if (_BitScanForward(&button_index, static_cast<u32>(static_cast<const QMouseEvent*>(event)->button())))
 			m_new_bindings.push_back(InputManager::MakePointerButtonKey(0, button_index));
+		return true;
+	}
+	else if (event_type == QEvent::Wheel)
+	{
+		const QPoint delta_angle(static_cast<QWheelEvent*>(event)->angleDelta());
+		const float dx = std::clamp(static_cast<float>(delta_angle.x()) / QtUtils::MOUSE_WHEEL_DELTA, -1.0f, 1.0f);
+		if (dx != 0.0f)
+		{
+			InputBindingKey key(InputManager::MakePointerAxisKey(0, InputPointerAxis::WheelX));
+			key.negative = (dx < 0.0f);
+			m_new_bindings.push_back(key);
+		}
+
+		const float dy = std::clamp(static_cast<float>(delta_angle.y()) / QtUtils::MOUSE_WHEEL_DELTA, -1.0f, 1.0f);
+		if (dy != 0.0f)
+		{
+			InputBindingKey key(InputManager::MakePointerAxisKey(0, InputPointerAxis::WheelY));
+			key.negative = (dy < 0.0f);
+			m_new_bindings.push_back(key);
+		}
+
+		if (dx != 0.0f || dy != 0.0f)
+		{
+			addNewBinding();
+			stopListeningForInput();
+		}
+
 		return true;
 	}
 	else if (event_type == QEvent::MouseMove && m_mouse_mapping_enabled)

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -18,6 +18,7 @@
 #include <QtCore/QTimer>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
+#include <QtGui/QWheelEvent>
 #include <QtWidgets/QInputDialog>
 #include <QtWidgets/QMessageBox>
 #include <cmath>
@@ -129,6 +130,33 @@ bool InputBindingWidget::eventFilter(QObject* watched, QEvent* event)
 		unsigned long button_index;
 		if (_BitScanForward(&button_index, static_cast<u32>(static_cast<const QMouseEvent*>(event)->button())))
 			m_new_bindings.push_back(InputManager::MakePointerButtonKey(0, button_index));
+		return true;
+	}
+	else if (event_type == QEvent::Wheel)
+	{
+		const QPoint delta_angle(static_cast<QWheelEvent*>(event)->angleDelta());
+		const float dx = std::clamp(static_cast<float>(delta_angle.x()) / QtUtils::MOUSE_WHEEL_DELTA, -1.0f, 1.0f);
+		if (dx != 0.0f)
+		{
+			InputBindingKey key(InputManager::MakePointerAxisKey(0, InputPointerAxis::WheelX));
+			key.negative = (dx < 0.0f);
+			m_new_bindings.push_back(key);
+		}
+
+		const float dy = std::clamp(static_cast<float>(delta_angle.y()) / QtUtils::MOUSE_WHEEL_DELTA, -1.0f, 1.0f);
+		if (dy != 0.0f)
+		{
+			InputBindingKey key(InputManager::MakePointerAxisKey(0, InputPointerAxis::WheelY));
+			key.negative = (dy < 0.0f);
+			m_new_bindings.push_back(key);
+		}
+
+		if (dx != 0.0f || dy != 0.0f)
+		{
+			setNewBinding();
+			stopListeningForInput();
+		}
+
 		return true;
 	}
 	else if (event_type == QEvent::MouseMove && m_mouse_mapping_enabled)


### PR DESCRIPTION
### Description of Changes

See title. Support stuff was in place in DisplayWidget and InputManager, just missing in the binding widget.

### Rationale behind Changes

Closes #6541.

### Suggested Testing Steps

Test wheel binding.
