### PR TITLE
Config: Set texture preloading to full by default

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -528,7 +528,7 @@ struct Pcsx2Config
 		AccBlendLevel AccurateBlendingUnit{AccBlendLevel::Basic};
 		CRCHackLevel CRCHack{CRCHackLevel::Automatic};
 		BiFiltering TextureFiltering{BiFiltering::PS2};
-		TexturePreloadingLevel TexturePreloading{TexturePreloadingLevel::Off};
+		TexturePreloadingLevel TexturePreloading{TexturePreloadingLevel::Full};
 		GSDumpCompressionMethod GSDumpCompression{GSDumpCompressionMethod::Uncompressed};
 		int Dithering{2};
 		int MaxAnisotropy{0};


### PR DESCRIPTION
### Description of Changes
Sets texture preloading to Full (Hash Cache) by default.

### Rationale behind Changes
More brrr,

### Suggested Testing Steps
Make sure CI Is happy.
