### PR TITLE
Qt: Make status bar less confusing

### DIFF
--- a/pcsx2-qt/EmuThread.h
+++ b/pcsx2-qt/EmuThread.h
@@ -110,9 +110,6 @@ Q_SIGNALS:
 	/// Provided by the host; called when the running executable changes.
 	void onGameChanged(const QString& path, const QString& serial, const QString& name, quint32 crc);
 
-	/// Called when performance metrics are changed, approx. once a second.
-	void onPerformanceMetricsUpdated(const QString& fps_stats, const QString& gs_stats);
-
 	void onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices);
 	void onInputDeviceConnected(const QString& identifier, const QString& device_name);
 	void onInputDeviceDisconnected(const QString& identifier);
@@ -173,6 +170,7 @@ private:
 	float m_last_video_fps = 0.0f;
 	int m_last_internal_width = 0;
 	int m_last_internal_height = 0;
+	GSRendererType m_last_renderer = GSRendererType::Null;
 };
 
 extern EmuThread* g_emu_thread;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -179,15 +179,28 @@ void MainWindow::setupAdditionalUi()
 	m_status_progress_widget->setFixedSize(140, 16);
 	m_status_progress_widget->hide();
 
-	m_status_gs_widget = new QLabel(m_ui.statusBar);
-	m_status_gs_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-	m_status_gs_widget->setFixedHeight(16);
-	m_status_gs_widget->hide();
+	m_status_verbose_widget = new QLabel(m_ui.statusBar);
+	m_status_verbose_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+	m_status_verbose_widget->setFixedHeight(16);
+	m_status_verbose_widget->hide();
+
+	m_status_renderer_widget = new QLabel(m_ui.statusBar);
+	m_status_renderer_widget->setFixedHeight(16);
+	m_status_renderer_widget->setFixedSize(65, 16);
+	m_status_renderer_widget->hide();
+
+	m_status_resolution_widget = new QLabel(m_ui.statusBar);
+	m_status_resolution_widget->setFixedHeight(16);
+	m_status_resolution_widget->setFixedSize(70, 16);
+	m_status_resolution_widget->hide();
 
 	m_status_fps_widget = new QLabel(m_ui.statusBar);
-	m_status_fps_widget->setAlignment(Qt::AlignRight);
-	m_status_fps_widget->setFixedHeight(16);
+	m_status_fps_widget->setFixedSize(85, 16);
 	m_status_fps_widget->hide();
+
+	m_status_vps_widget = new QLabel(m_ui.statusBar);
+	m_status_vps_widget->setFixedSize(125, 16);
+	m_status_vps_widget->hide();
 
 	for (u32 scale = 0; scale <= 10; scale++)
 	{
@@ -319,7 +332,6 @@ void MainWindow::connectVMThreadSignals(EmuThread* thread)
 	connect(thread, &EmuThread::onVMResumed, this, &MainWindow::onVMResumed);
 	connect(thread, &EmuThread::onVMStopped, this, &MainWindow::onVMStopped);
 	connect(thread, &EmuThread::onGameChanged, this, &MainWindow::onGameChanged);
-	connect(thread, &EmuThread::onPerformanceMetricsUpdated, this, &MainWindow::onPerformanceMetricsUpdated);
 
 	connect(m_ui.actionReset, &QAction::triggered, thread, &EmuThread::resetVM);
 	connect(m_ui.actionPause, &QAction::toggled, thread, &EmuThread::setVMPaused);
@@ -721,8 +733,11 @@ void MainWindow::updateStatusBarWidgetVisibility()
 		}
 	};
 
-	Update(m_status_gs_widget, s_vm_valid && !s_vm_paused, 1);
+	Update(m_status_verbose_widget, s_vm_valid, 1);
+	Update(m_status_renderer_widget, s_vm_valid, 0);
+	Update(m_status_resolution_widget, s_vm_valid, 0);
 	Update(m_status_fps_widget, s_vm_valid, 0);
+	Update(m_status_vps_widget, s_vm_valid, 0);
 }
 
 void MainWindow::updateWindowTitle()
@@ -1449,7 +1464,8 @@ void MainWindow::onVMPaused()
 	s_vm_paused = true;
 	updateWindowTitle();
 	updateStatusBarWidgetVisibility();
-	m_status_fps_widget->setText(tr("Paused"));
+	m_last_fps_status = m_status_verbose_widget->text();
+	m_status_verbose_widget->setText(tr("Paused"));
 	if (m_display_widget)
 	{
 		m_display_widget->updateRelativeMode(false);
@@ -1469,7 +1485,8 @@ void MainWindow::onVMResumed()
 	m_was_disc_change_request = false;
 	updateWindowTitle();
 	updateStatusBarWidgetVisibility();
-	m_status_fps_widget->setText(m_last_fps_status);
+	m_status_verbose_widget->setText(m_last_fps_status);
+	m_last_fps_status = QString();
 	if (m_display_widget)
 	{
 		m_display_widget->updateRelativeMode(true);
@@ -1507,13 +1524,6 @@ void MainWindow::onGameChanged(const QString& path, const QString& serial, const
 	m_current_game_crc = crc;
 	updateWindowTitle();
 	updateSaveStateMenus(path, serial, crc);
-}
-
-void MainWindow::onPerformanceMetricsUpdated(const QString& fps_stat, const QString& gs_stat)
-{
-	m_last_fps_status = fps_stat;
-	m_status_fps_widget->setText(m_last_fps_status);
-	m_status_gs_widget->setText(gs_stat);
 }
 
 void MainWindow::showEvent(QShowEvent* event)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -86,6 +86,13 @@ public:
 	/// Locks the VM by pausing it, while a popup dialog is displayed.
 	VMLock pauseAndLockVM();
 
+	/// Accessors for the status bar widgets, updated by the emulation thread.
+	__fi QLabel* getStatusVerboseWidget() const { return m_status_verbose_widget; }
+	__fi QLabel* getStatusRendererWidget() const { return m_status_renderer_widget; }
+	__fi QLabel* getStatusResolutionWidget() const { return m_status_resolution_widget; }
+	__fi QLabel* getStatusFPSWidget() const { return m_status_fps_widget; }
+	__fi QLabel* getStatusVPSWidget() const { return m_status_vps_widget; }
+
 public Q_SLOTS:
 	void checkForUpdates(bool display_message);
 	void refreshGameList(bool invalidate_cache);
@@ -156,7 +163,6 @@ private Q_SLOTS:
 	void onVMStopped();
 
 	void onGameChanged(const QString& path, const QString& serial, const QString& name, quint32 crc);
-	void onPerformanceMetricsUpdated(const QString& fps_stat, const QString& gs_stat);
 
 	void recreate();
 
@@ -234,8 +240,11 @@ private:
 	AutoUpdaterDialog* m_auto_updater_dialog = nullptr;
 
 	QProgressBar* m_status_progress_widget = nullptr;
-	QLabel* m_status_gs_widget = nullptr;
+	QLabel* m_status_verbose_widget = nullptr;
+	QLabel* m_status_renderer_widget = nullptr;
 	QLabel* m_status_fps_widget = nullptr;
+	QLabel* m_status_vps_widget = nullptr;
+	QLabel* m_status_resolution_widget = nullptr;
 
 	QString m_current_disc_path;
 	QString m_current_game_serial;


### PR DESCRIPTION
### Description of Changes

Before:
![image](https://user-images.githubusercontent.com/11288319/177042072-e73f4c42-f6ef-48eb-944d-c8a56ad46c79.png)
After:
![image](https://user-images.githubusercontent.com/11288319/177042077-ec22e99a-b3bf-4d63-9b7e-214085134bee.png)

### Rationale behind Changes

Users get confused what G and V mean.

### Suggested Testing Steps

Check everything shows up as expected.
