### PR TITLE
GS/TextureCache: Fix incorrect hashing of L/H/small textures

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2966,7 +2966,7 @@ static void HashTextureLevel(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Blo
 	if (tw < bs.x || th < bs.y || psm.fmsk != 0xFFFFFFFFu)
 	{
 		// Expand texture indices. Align to 32 bytes for AVX2.
-		const u32 pitch = Common::AlignUpPow2(static_cast<u32>(block_rect.w), 32);
+		const u32 pitch = Common::AlignUpPow2(static_cast<u32>(block_rect.z), 32);
 		const u32 row_size = static_cast<u32>(tw);
 		const GSLocalMemory::readTexture rtx = psm.rtxP;
 


### PR DESCRIPTION
### Description of Changes

Fixes text getting garbled in Valkyrie Profile 2 with preloading on. Regression from https://github.com/PCSX2/pcsx2/pull/6494, although it just unmasked the bug.

### Rationale behind Changes

Fixes #6580.

### Suggested Testing Steps

Test VP2.
