### PR TITLE
QT: set Texture Offsets & Skipdraw Range per game only

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -290,6 +290,14 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	// only allow disabling readbacks for per-game settings, it's too dangerous
 	m_ui.disableHardwareReadbacks->setEnabled(m_dialog->isPerGameSettings());
 
+	// allow Texture Offset for per-game settings only 
+	m_ui.textureOffsetX->setEnabled(m_dialog->isPerGameSettings());
+	m_ui.textureOffsetY->setEnabled(m_dialog->isPerGameSettings());
+
+	// allow Skipdraw Range for per-game settings only 
+	m_ui.skipDrawStart->setEnabled(m_dialog->isPerGameSettings());
+	m_ui.skipDrawEnd->setEnabled(m_dialog->isPerGameSettings());
+
 	// Display tab
 	{
 


### PR DESCRIPTION

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes #6181

Making Texture Offsets & Skipdraw Range less dangerous 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
make sure QT compiles and make sure Texture Offsets & Skipdraw Range are per game only  and they work 