### PR TITLE
GS: Improve CLUT testing, add test for local->local transfers.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -710,8 +710,7 @@ __inline void GSState::CheckFlushes()
 			Flush();
 		}
 	}
-
-	if ((m_context->FRAME.FBMSK & GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk) != GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk)
+	if (m_index.tail > 0 && (m_context->FRAME.FBMSK & GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk) != GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk)
 		m_mem.m_clut.Invalidate(m_context->FRAME.Block());
 }
 
@@ -1952,7 +1951,7 @@ void GSState::Write(const u8* mem, int len)
 			FlushWrite();
 	}
 
-	m_mem.m_clut.Invalidate();
+	m_mem.m_clut.Invalidate(blit.DBP);
 }
 
 void GSState::InitReadFIFO(u8* mem, int len)
@@ -2196,6 +2195,8 @@ void GSState::Move()
 			(m_mem.*dpsm.wpa)(doff, (m_mem.*spsm.rpa)(soff));
 		});
 	}
+
+	m_mem.m_clut.Invalidate(m_env.BITBLTBUF.DBP);
 }
 
 void GSState::SoftReset(u32 mask)


### PR DESCRIPTION
### Description of Changes
Adds CLUT dirty checks to local->local transfers, and adjusts how it's handled elsewhere.

### Rationale behind Changes
We only flush the CLUT when we know the data has changed, for brr reasons, However if it was a local->local transfer we didn't check it. Also it was pointlessly flushing it if no drawing has happened, so stopped that. And make uploads check the block pointers to make sure they match also instead of just invalidating the CLUT always.

### Suggested Testing Steps
Test games known to have CLUT issues, I guess :P the sega games won't be fixed in HW, but make sure SW is ok.

Fixes Sagashi ni Ikouyo which does local->local transfers in to the CLUT so it needs flushing.