### PR TITLE
GS: Invalidate CLUT by page

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -108,9 +108,11 @@ void GSClut::Invalidate()
 	m_write.dirty = true;
 }
 
+// This checks the whole page! Some games (like We Love Katamari) have the CLUT 1 block ahead of the DBP during a transfer.
+// Safer to check if the whole page is being written anyway since it could modify only part of the CLUT.
 void GSClut::Invalidate(u32 block)
 {
-	if (block == m_write.TEX0.CBP)
+	if (!((block ^ m_write.TEX0.CBP) & ~0x1F))
 	{
 		m_write.dirty = true;
 	}

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -710,8 +710,12 @@ __inline void GSState::CheckFlushes()
 			Flush();
 		}
 	}
-	if (m_index.tail > 0 && (m_context->FRAME.FBMSK & GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk) != GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk)
+	if ((m_context->FRAME.FBMSK & GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk) != GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk)
 		m_mem.m_clut.Invalidate(m_context->FRAME.Block());
+
+	// Hey, why not check? I mean devs have done crazier things..
+	if(!m_context->ZBUF.ZMSK)
+		m_mem.m_clut.Invalidate(m_context->ZBUF.Block());
 }
 
 void GSState::GIFPackedRegHandlerNull(const GIFPackedReg* RESTRICT r)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1923,8 +1923,10 @@ void GSState::Write(const u8* mem, int len)
 			 m_env.TRXPOS.DIRX, m_env.TRXPOS.DIRY,
 			 m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, w, h);
 
-	if ((PRIM->TME && (blit.DBP == m_context->TEX0.TBP0 || blit.DBP == m_context->TEX0.CBP)) ||
-		(m_prev_env.PRIM.TME && (blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.TBP0 || blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.CBP))) // TODO: hmmmm
+	// TODO: Not really sufficient if a partial texture update is done outside the block.
+	// No need to check CLUT here, we can invalidate it below, no need to flush it since TEX0 needs to update, then we can flush.
+	if ((PRIM->TME && (blit.DBP == m_context->TEX0.TBP0)) ||
+		(m_prev_env.PRIM.TME && (blit.DBP == m_prev_env.CTXT[m_prev_env.PRIM.CTXT].TEX0.TBP0)))
 		Flush();
 
 	if (m_tr.end == 0 && len >= m_tr.total)


### PR DESCRIPTION
### Description of Changes
Change the CLUT invalidation check to look  by page rather than just by block, since this is really insufficient for CLUT sizes.
Also add check for CLUT invalidation from Z writes, because it *could* happen, weirder things have been done in games.

### Rationale behind Changes
Some games (We Love Katamari) do host->local writes offset inside the CLUT (0x2c00 instead of the CLUT address of 0x2c01), and one block is only 32 colours (in 32bit) anyway, so by block is insufficient.

Write is 32x64 at 0x2c00, each "block contains" 8x8, meaning this spills over in to 0x2c01 and beyond.

### Suggested Testing Steps
Test colours in games, make sure there's no regressions anymore :)
