### PR TITLE
GS: Fix scanmask interlace offsetting on even numbers

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -211,10 +211,13 @@ bool GSRenderer::Merge(int field)
 			// When the displays are offset by 1 we need to adjust for upscale to handle it (reduces bounce in MGS2 when upscaling)
 			interlace_offset += (tex[i]->GetScale().y - 1.0f)  / 2;
 
-			if (!ignore_offset)
-				off.y &= ~1;
+			if (interlace_offset >= 1.0f)
+			{
+				if (!ignore_offset)
+					off.y -= 1;
 
-			display_diff.y &= ~1;
+				display_diff.y -= 1;
+			}
 		}
 
 		// Start of Anti-Blur code.


### PR DESCRIPTION
### Description of Changes
Correct the code so if the interlace offset is on an even number, it corrects the offset properly.

### Rationale behind Changes
Before I had it only masking out the lowest bit, which wouldn't have done anything if the offset display had 2 as the lowest nibble.

### Suggested Testing Steps
Test Scanmask games (FFX-2, apparently, MGS3, MGS2, GT4) with and without screen offsets/anti-blur, make sure it's okay. Though I've already checked them :)

Fixes #6608