### PR TITLE
GameDB: remove texture inside RT from Xenosaga Episode III

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1266,7 +1266,6 @@ SCAJ-20179:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc1of2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
@@ -1274,7 +1273,6 @@ SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc2of2]"
   region: "NTSC-Unk"
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
@@ -23067,7 +23065,6 @@ SLPM-61147:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Demo]"
   region: "NTSC-J"
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
@@ -35815,7 +35812,6 @@ SLPS-25640:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
@@ -35827,7 +35823,6 @@ SLPS-25641:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows (probably texture cache issue).
     roundSprite: 2 # Fixes font artifacts.
@@ -43814,7 +43809,6 @@ SLUS-21389:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.
@@ -43943,7 +43937,6 @@ SLUS-21417:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    textureInsideRT: 1
     autoFlush: 1
     halfPixelOffset: 1 # Fixes lighting misalignment and reduces ground shadows.
     roundSprite: 2 # Fixes font artifacts.


### PR DESCRIPTION
### Rationale behind Changes
When enabled, it broke the title screen.

![image](https://user-images.githubusercontent.com/79612681/178321474-78a63b84-70b8-44d6-9a30-0d5072392bd0.png)

