### PR TITLE
GameDB: add The Sims 2 missing fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8679,7 +8679,7 @@ SLED-53770:
   name: "Sims 2, The [Demo]"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned textures
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLED-53845:
   name: "Matrix, The - Path of Neo [Demo]"
   region: "PAL-E"
@@ -16738,7 +16738,7 @@ SLES-53718:
   region: "PAL-M10"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned textures
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLES-53722:
   name: "Call of Duty 2 - Big Red One [Collector's Edition]"
   region: "PAL-E"
@@ -43223,7 +43223,7 @@ SLUS-21265:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned textures
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLUS-21266:
   name: "NASCAR '06 - Total Team Control"
   region: "NTSC-U"
@@ -46992,7 +46992,7 @@ SLUS-29173:
   name: "Sims 2, The [Demo]"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned textures
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLUS-29174:
   name: "Namco Transmission Demo Disc Vol. 3.1"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16732,6 +16732,8 @@ SLES-53718:
   name: "Sims 2, The"
   region: "PAL-M10"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures
 SLES-53722:
   name: "Call of Duty 2 - Big Red One [Collector's Edition]"
   region: "PAL-E"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8675,6 +8675,11 @@ SLED-53732:
 SLED-53745:
   name: "Total Overdose [Demo]"
   region: "PAL-M5"
+SLED-53770:
+  name: "Sims 2, The [Demo]"
+  region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures
 SLED-53845:
   name: "Matrix, The - Path of Neo [Demo]"
   region: "PAL-E"
@@ -43217,6 +43222,8 @@ SLUS-21265:
   name: "Sims 2, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures
 SLUS-21266:
   name: "NASCAR '06 - Total Team Control"
   region: "NTSC-U"
@@ -46984,6 +46991,8 @@ SLUS-29172:
 SLUS-29173:
   name: "Sims 2, The [Demo]"
   region: "NTSC-U"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures
 SLUS-29174:
   name: "Namco Transmission Demo Disc Vol. 3.1"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Set halfPixelOffset to 1 in The Sims 2 (SLES-53718)

### Rationale behind Changes
Removes texture glitches that appear on the UI and the environment

![Untitled](https://user-images.githubusercontent.com/39221755/179276536-846b00fc-96eb-4136-97e7-a12651f8b4ee.jpg)

### Suggested Testing Steps
Enter a random plot and look at the ground.
