### PR TITLE
Qt: Add crop options

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -116,8 +116,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.internalResolutionScreenshots, "EmuCore/GS", "InternalResolutionScreenshots", false);
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.zoom, "EmuCore/GS", "Zoom", 100.0f);
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.stretchY, "EmuCore/GS", "StretchY", 100.0f);
-	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.offsetX, "EmuCore/GS", "OffsetX", 0.0f);
-	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.offsetY, "EmuCore/GS", "OffsetY", 0.0f);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cropLeft, "EmuCore/GS", "CropLeft", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cropTop, "EmuCore/GS", "CropTop", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cropRight, "EmuCore/GS", "CropRight", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cropBottom, "EmuCore/GS", "CropBottom", 0);
 
 	connect(m_ui.integerScaling, &QCheckBox::stateChanged, this, &GraphicsSettingsWidget::onIntegerScalingChanged);
 	onIntegerScalingChanged();

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -234,14 +234,21 @@
        <item row="6" column="0">
         <widget class="QLabel" name="label_26">
          <property name="text">
-          <string>Offset:</string>
+          <string>Crop:</string>
          </property>
         </widget>
        </item>
        <item row="6" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,1">
+        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1,0,1,0,1,0,1">
          <item>
-          <widget class="QSpinBox" name="offsetX">
+          <widget class="QLabel" name="label_39">
+           <property name="text">
+            <string>Left:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="cropLeft">
            <property name="suffix">
             <string>px</string>
            </property>
@@ -253,12 +260,46 @@
          <item>
           <widget class="QLabel" name="label_25">
            <property name="text">
-            <string>x</string>
+            <string>Top:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="offsetY">
+          <widget class="QSpinBox" name="cropTop">
+           <property name="suffix">
+            <string>px</string>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_40">
+           <property name="text">
+            <string>Right:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="cropRight">
+           <property name="suffix">
+            <string>px</string>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_41">
+           <property name="text">
+            <string>Bottom:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="cropBottom">
            <property name="suffix">
             <string>px</string>
            </property>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -516,8 +516,12 @@ struct Pcsx2Config
 
 		double Zoom{100.0};
 		double StretchY{100.0};
+#ifndef PCSX2_CORE
 		double OffsetX{0.0};
 		double OffsetY{0.0};
+#else
+		int Crop[4]{};
+#endif
 
 		double OsdScale{100.0};
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -385,8 +385,16 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 
 		OpEqu(Zoom) &&
 		OpEqu(StretchY) &&
+#ifndef PCSX2_CORE
 		OpEqu(OffsetX) &&
 		OpEqu(OffsetY) &&
+#else
+		OpEqu(Crop[0]) &&
+		OpEqu(Crop[1]) &&
+		OpEqu(Crop[2]) &&
+		OpEqu(Crop[3]) &&
+#endif
+
 		OpEqu(OsdScale) &&
 
 		OpEqu(Renderer) &&
@@ -469,8 +477,10 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 	SettingsWrapEntry(Zoom);
 	SettingsWrapEntry(StretchY);
-	SettingsWrapEntry(OffsetX);
-	SettingsWrapEntry(OffsetY);
+	SettingsWrapEntryEx(Crop[0], "CropLeft");
+	SettingsWrapEntryEx(Crop[1], "CropTop");
+	SettingsWrapEntryEx(Crop[2], "CropRight");
+	SettingsWrapEntryEx(Crop[3], "CropBottom");
 #endif
 
 #ifndef PCSX2_CORE


### PR DESCRIPTION
### Description of Changes

Add a crop setting with each four sides being independent. Increments are relative to 1x resolution, can be useful for clearing up the edges of images with artifacts caused by upscaling/HPO (e.g. GT4).

IMO it kinda makes the zoom option redundant, but I'll leave removing that for someone else, don't really feel like arguing the case.

### Rationale behind Changes

Better looking images without having to use stretch+zoom.

### Suggested Testing Steps

Test new option.
