### PR TITLE
GS/OpenGL: Fix incorrect detection of DXT/BPTC texture support

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -220,8 +220,8 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 	m_features.image_load_store = GLLoader::found_GL_ARB_shader_image_load_store && GLLoader::found_GL_ARB_clear_texture;
 	m_features.texture_barrier = GSConfig.OverrideTextureBarriers != 0 || GLLoader::found_framebuffer_fetch;
 	m_features.provoking_vertex_last = true;
-	m_features.dxt_textures = GL_EXT_texture_compression_s3tc;
-	m_features.bptc_textures = GL_VERSION_4_2 || GL_ARB_texture_compression_bptc || GL_EXT_texture_compression_bptc;
+	m_features.dxt_textures = GLAD_GL_EXT_texture_compression_s3tc;
+	m_features.bptc_textures = GLAD_GL_VERSION_4_2 || GLAD_GL_ARB_texture_compression_bptc || GLAD_GL_EXT_texture_compression_bptc;
 	m_features.prefer_new_textures = false;
 	m_features.framebuffer_fetch = GLLoader::found_framebuffer_fetch;
 	m_features.dual_source_blend = GLLoader::has_dual_source_blend && !GSConfig.DisableDualSourceBlend;


### PR DESCRIPTION
### Description of Changes

Reading the macro instead of the actual variable indicating support.

### Rationale behind Changes

Not that this'll make any effective difference since all GL4 GPUs support these formats, but still good to be correct.

### Suggested Testing Steps

Make sure it builds.
