### PR TITLE
GS/TextureCache: Remove redundant CLUT read

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -200,10 +200,6 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 	const GSLocalMemory::psm_t& psm_s = GSLocalMemory::m_psm[TEX0.PSM];
 	//const GSLocalMemory::psm_t& cpsm = psm.pal > 0 ? GSLocalMemory::m_psm[TEX0.CPSM] : psm;
 
-	// Until DX is fixed
-	if (psm_s.pal > 0)
-		g_gs_renderer->m_mem.m_clut.Read32(TEX0, TEXA);
-
 	const u32* clut = g_gs_renderer->m_mem.m_clut;
 
 	Source* src = NULL;


### PR DESCRIPTION
### Description of Changes

Unfortunately won't make any performance difference, because the dirty check won't pass.

### Rationale behind Changes

But not having redundant calls is good.

### Suggested Testing Steps

Test clut-senstiive games, mip games (e.g. ratchet) seem fine.
