### PR TITLE
fix build error when recording is disabled.

### DIFF
--- a/pcsx2/SourceLog.cpp
+++ b/pcsx2/SourceLog.cpp
@@ -121,8 +121,10 @@ SysConsoleLogPack::SysConsoleLogPack()
 	, eeConsole(&TLD_eeConsole)
 	, iopConsole(&TLD_iopConsole)
 	, deci2(&TLD_deci2)
+#ifndef DISABLE_RECORDING
 	, recordingConsole(&TLD_recordingConsole)
 	, controlInfo(&TLD_controlInfo)
+#endif
 {
 }
 


### PR DESCRIPTION
### Description of Changes
This makes is so if `DISABLE_RECORDING` is defined, pcsx2/SourceLog.cpp will still build.

### Rationale behind Changes
This change is needed to make PCSX2 to compile when `DISABLE_RECORDING` is defined.

### Suggested Testing Steps
None