### PR TITLE
Adds the black grid fix patch for 'Tales of the Abyss' to the GameDB

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1194,6 +1194,12 @@ SCAJ-20163:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+  patches:
+    default:
+      content: |-
+        author=sergx12
+        // fixes black grid
+        patch=1,EE,205E570C,extended,00000000
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
@@ -31704,6 +31710,12 @@ SLPM-66897:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+  patches:
+    default:
+      content: |-
+        author=sergx12
+        // fixes black grid
+        patch=1,EE,205E570C,extended,00000000
 SLPM-66898:
   name: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
@@ -35855,6 +35867,12 @@ SLPS-25586:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+  patches:
+    default:
+      content: |-
+        author=sergx12
+        // fixes black grid
+        patch=1,EE,205E570C,extended,00000000
 SLPS-25587:
   name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
@@ -37514,6 +37532,12 @@ SLPS-73252:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+  patches:
+    default:
+      content: |-
+        author=sergx12
+        // fixes black grid
+        patch=1,EE,205E570C,extended,00000000
 SLPS-73253:
   name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -44046,6 +44070,12 @@ SLUS-21386:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+  patches:
+    default:
+      content: |-
+        author=sergx12
+        // fixes black grid
+        patch=1,EE,205E570C,extended,00000000
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"


### PR DESCRIPTION
Adds the patch found at https://forums.pcsx2.net/Thread-PCSX2-Widescreen-Game-Patches?pid=627849#pid627849 for Tales of the Abyss to the GameDB

### Description of Changes
This adds the patch created by sergx12 to the GameDB. It corrects the black grid effect found in the Titlescreen, Opening Cutscenes, Tataroo Valley (Night), Engeve, Kaitzur Naval Port, Baticul Castle, Grand Chokmah, Keterburg and Keterburg Bay as noted with #6497

### Rationale behind Changes
#6497 has been a long standing issue caused by the use of HPO (or any texture offset) in several areas within the game. Previously the way to correct it was by using a Skipdraw range like those found with #6269 and #6074. This had notable downsides like darkened areas, the introduction of a visual glitch to The Desert Oasis and causing a notable shift of the bloom effect on Native. This patch currently corrects the issue in all known areas without the downsides introduced by the use of Skipdraw.

### Suggested Testing Steps
Test the game to see if any visual glitches are introduced by the use of this patch