### PR TITLE
GHActions: Properly label Linux AVX2/SSE4 releases

### DIFF
--- a/.github/workflows/scripts/releases/rename-release-assets.py
+++ b/.github/workflows/scripts/releases/rename-release-assets.py
@@ -15,12 +15,13 @@ for dir_name in os.listdir(scan_dir):
     asset_name += "-linux-AppImage-64bit"
   elif "windows" in dir_name.lower():
     asset_name += "-windows-64bit"
-    if "avx" in dir_name.lower():
-      asset_name += "-AVX2"
-    else:
-      asset_name += "-SSE4"
   else:
     continue;
+
+  if "avx2" in dir_name.lower():
+    asset_name += "-AVX2"
+  elif "sse4" in dir_name.lower():
+    asset_name += "-SSE4"
 
   if "wxwidgets" in dir_name.lower():
     asset_name += "-wxWidgets"


### PR DESCRIPTION
### Description of Changes
Properly labels AVX2 and SSE4 Qt Linux builds

### Rationale behind Changes
They were getting named the same thing and overwriting each other

### Suggested Testing Steps
@xTVaser any way to test this before merging?
