### PR TITLE
GameDB: Fix and add Japanese game names, apply upscaling fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1024,10 +1024,13 @@ SCAJ-20131:
   name: "namCollection - Namco 50th Anniversary"
   region: "NTSC-Unk"
 SCAJ-20132:
-  name: "Drag-On Dragon 2 - Fuuin no Kurenai"
+  name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting characters.
+    mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
 SCAJ-20133:
   name: "Kagero 2 - Dark Illusion"
   region: "NTSC-Unk"
@@ -22565,10 +22568,13 @@ SLPM-55071:
   name: "Yumemi Hakusho - Second Dream"
   region: "NTSC-J"
 SLPM-55081:
-  name: "Drag-on Dragoon 2 - Fuuin no Kurenai [Ultimate Hits]"
+  name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Ultimate Hits]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting characters.
+    mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
 SLPM-55086:
   name: "Ever17 The Out of Infinity [Renai Game Selection]"
   region: "NTSC-J"
@@ -23108,10 +23114,13 @@ SLPM-61117:
   gameFixes:
     - EETimingHack # Fixes garbled character animation.
 SLPM-61120:
-  name: "Drag-on Dragoon 2 - Fuuin no Kurenai [Trial Version]"
+  name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro [Trial Version]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting characters.
+    mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
 SLPM-61127:
   name: "FlatOut [Trial]"
   region: "NTSC-J"
@@ -23711,7 +23720,7 @@ SLPM-62233:
   name: "Simple 2000 Series Ultimate Vol. 4 - Urawaza Ikasa Mahjong Machi"
   region: "NTSC-J"
 SLPM-62234:
-  name: "Simple2000 Vol.13 The Renai Adv Garasu No Mori"
+  name: "Simple 2000 Series Vol. 13 - Onna no Ko no Tame no - The Renai Adventure - Garasu no Mori"
   region: "NTSC-J"
 SLPM-62235:
   name: "GetBass Battle"
@@ -23841,7 +23850,10 @@ SLPM-62278:
   name: "Hunter x Hunter"
   region: "NTSC-J"
 SLPM-62279:
-  name: "Winning Post 5 - Maximum 2002"
+  name: "GI Jockey 3 [Premium Pack]"
+  region: "NTSC-J"
+SLPM-62280:
+  name: "Winning Post 5 Maximum 2002 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62282:
   name: "Silent Scope 2 - Innocent Sweeper"
@@ -28552,10 +28564,13 @@ SLPM-65998:
   region: "NTSC-J"
   compat: 5
 SLPM-65999:
-  name: "Drag-on Dragoon 2 - Fuuin no Kurenai"
+  name: "Drag-on Dragoon 2 - Fuuin no Aka, Haitoku no Kuro"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Fixes wrong color on some characters and breakable objects.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting characters.
+    mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
 SLPM-66000:
   name: "Conflict Delta II - Gulf War 1991"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes

- Change the name for all releases of Drag-on Dragoon 2 (Japanese name of Drakengard 2). According to [the Japanese Wikipedia page for Drag-on Dragoon 2](https://ja.wikipedia.org/wiki/%E3%83%89%E3%83%A9%E3%83%83%E3%82%B0%E3%82%AA%E3%83%B3%E3%83%89%E3%83%A9%E3%82%B0%E3%83%BC%E3%83%B32_%E5%B0%81%E5%8D%B0%E3%81%AE%E7%B4%85%E3%80%81%E8%83%8C%E5%BE%B3%E3%81%AE%E9%BB%92), redump.org and some other Japanese sources, the correct subtitle is "Fuuin no Aka, Haitoku no Kuro".
The games were also missing two gsHWFixes listed for the US and PAL releases of Drakengard 2.

- Change the name for Simple 2000 Series Vol. 13 to fit the naming of the other games in the series.

- SLPM-62279 was listed as Winning Post 5 - Maximum 2002. This is wrong
SLPM-62279 and SLPM-62280 is a two disc pack.
The correct title for 62279 is GI Jockey 3. Winning Post 5 is actually SLPM-62280. 

### Rationale behind Changes
Improve GameDB
