### PR TITLE
Qt: 2 New Theme Options

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -622,7 +622,63 @@ void MainWindow::setStyleFromSettings()
 
 		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
 	}
-	else
+	else if (theme == "Ruby")
+	{
+		// Custom pallete by Daisouji, Black as main color andd Red as complimentary.
+		// Alternative dark theme.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor lighterGray(75, 75, 75);
+		const QColor gray(128, 128, 128);
+		const QColor black(25, 25, 25);
+		const QColor slate(18, 18, 18);
+		const QColor rubyish(172,21,31);
+
+
+		QPalette darkPalette;
+		darkPalette.setColor(QPalette::Window, slate);
+		darkPalette.setColor(QPalette::WindowText, Qt::white);
+		darkPalette.setColor(QPalette::Base, slate.lighter());
+		darkPalette.setColor(QPalette::AlternateBase, slate.lighter());
+		darkPalette.setColor(QPalette::ToolTipBase, slate);
+		darkPalette.setColor(QPalette::ToolTipText, Qt::white);
+		darkPalette.setColor(QPalette::Text, Qt::white);
+		darkPalette.setColor(QPalette::Button, slate);
+		darkPalette.setColor(QPalette::ButtonText, Qt::white);
+		darkPalette.setColor(QPalette::Link, Qt::white);
+		darkPalette.setColor(QPalette::Highlight, rubyish);
+		darkPalette.setColor(QPalette::HighlightedText, Qt::white);
+
+		darkPalette.setColor(QPalette::Active, QPalette::Button, slate.lighter());
+		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray);
+		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Text, gray);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Light, slate.lighter());
+
+		qApp->setPalette(darkPalette);
+
+		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+	} 
+	else if (theme == "Custom")
+	{
+		
+		//Additional Theme option than loads .qss from main PCSX2 Directory
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+		
+		QString sheet_content;
+		QFile sheets("./custom.qss");
+		
+		if(sheets.open(QFile::ReadOnly)){
+	        QString sheet_content = QString::fromUtf8(sheets.readAll().data());
+		qApp->setStyleSheet(sheet_content);
+		}
+		else
+		{
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+		}
+	
+	}
+        else 
 	{
 		qApp->setPalette(QApplication::style()->standardPalette());
 		qApp->setStyleSheet(QString());

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -632,7 +632,7 @@ void MainWindow::setStyleFromSettings()
 		const QColor gray(128, 128, 128);
 		const QColor black(25, 25, 25);
 		const QColor slate(18, 18, 18);
-		const QColor rubyish(172,21,31);
+		const QColor rubyish(172, 21, 31);
 
 
 		QPalette darkPalette;
@@ -658,27 +658,27 @@ void MainWindow::setStyleFromSettings()
 		qApp->setPalette(darkPalette);
 
 		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
-	} 
+	}
 	else if (theme == "Custom")
 	{
-		
+
 		//Additional Theme option than loads .qss from main PCSX2 Directory
 		qApp->setStyle(QStyleFactory::create("Fusion"));
-		
+
 		QString sheet_content;
-		QFile sheets("./custom.qss");
-		
-		if(sheets.open(QFile::ReadOnly)){
-	        QString sheet_content = QString::fromUtf8(sheets.readAll().data());
-		qApp->setStyleSheet(sheet_content);
+		QFile sheets(QString::fromStdString(Path::Combine(EmuFolders::DataRoot, "custom.qss")));
+
+		if (sheets.open(QFile::ReadOnly))
+		{
+			QString sheet_content = QString::fromUtf8(sheets.readAll().data());
+			qApp->setStyleSheet(sheet_content);
 		}
 		else
 		{
-		qApp->setStyle(QStyleFactory::create("Fusion"));
+			qApp->setStyle(QStyleFactory::create("Fusion"));
 		}
-	
 	}
-        else 
+	else
 	{
 		qApp->setPalette(QApplication::style()->standardPalette());
 		qApp->setStyleSheet(QString());

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -30,6 +30,8 @@ static const char* THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Baby Pastel (Pink) [Light]"),
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "PCSX2 (White/Blue) [Light]"),
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Scarlet Devil (Red/Purple) [Dark]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Ruby (Black/Red) [Dark]"),
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Custom.qss [Drop in PCSX2 Folder]"),
 	nullptr};
 
 static const char* THEME_VALUES[] = {
@@ -41,6 +43,8 @@ static const char* THEME_VALUES[] = {
 	"BabyPastel",
 	"PCSX2Blue",
 	"ScarletDevilRed",
+	"Ruby",
+	"Custom",
 	nullptr};
 
 InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget* parent)


### PR DESCRIPTION
### Description of Changes
Added 2 New Options,  A Ruby/Dark Theme (Ruby)  and Another allowing usage of .qss (under the main pcsx2 directory)

**Ruby**

<img width="256" alt="C3" src="https://user-images.githubusercontent.com/82060898/179879020-865ed4f1-7584-4d8b-986e-f6e4caa51d14.PNG">
<img width="256" alt="Capture2" src="https://user-images.githubusercontent.com/82060898/179879022-60475ecd-5654-45e7-b523-9ff39bef2f9b.PNG">

**QSS**
<img width="256" alt="C4" src="https://user-images.githubusercontent.com/82060898/179879464-637afb75-06a0-46a2-9c2c-ae26e932ae1a.PNG">
<img width="256" alt="c5" src="https://user-images.githubusercontent.com/82060898/179879466-7bdf2179-c3a7-4c06-8aac-df8a2b1ec34d.PNG">


### Rationale behind Changes
Thought we needed more color options.

### Suggested Testing Steps

