### PR TITLE
QT: Add missing gamefix dialog

### DIFF
--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -113,7 +113,7 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 		if (isPerGameSettings())
 		{
 			addWidget(m_game_fix_settings_widget = new GameFixSettingsWidget(this, m_ui.settingsContainer), tr("Game Fix"),
-				QStringLiteral("close-line"), tr("<strong>Game Fix Settings</strong><hr>"));
+				QStringLiteral("close-line"), tr("<strong>Game Fix Settings</strong><hr>Gamefixes can work around incorrect emulation in some titles<br>however they can also cause problems in games if used incorrectly.<br>It is best to leave them all disabled unless advised otherwise."));
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Adds missing text to the gamefixes description box.

### Rationale behind Changes
Missing text is bad.

### Suggested Testing Steps
Make sure CI is happy.
