### PR TITLE
GS-SW: Fix framebuffer looping at 2048 height/width.

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -327,7 +327,7 @@ public:
 	GSVector4i GetFrameMagnifiedRect(int i = -1);
 	GSVector2i GetResolutionOffset(int i = -1);
 	GSVector2i GetResolution();
-	GSVector4i GetFrameRect(int i = -1);
+	GSVector4i GetFrameRect(int i = -1, bool ignore_off = false);
 	GSVideoMode GetVideoMode();
 
 	bool IsEnabled(int i);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -275,7 +275,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 	const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
 	const int display_height = offsets.y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
 	const int display_offset = GetResolutionOffset(i).y;
-	int fb_height = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
+	int fb_height = std::min<int>(std::min<int>(GetFramebufferHeight(), display_height) + (int)DISPFB.DBY, 2048);
 	
 	// If there is a negative vertical offset on the picture, we need to read more.
 	if (display_offset < 0)

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -35,6 +35,7 @@ GSRendererSW::GSRendererSW(int threads)
 	m_tc = std::make_unique<GSTextureCacheSW>();
 	m_rl = GSRasterizerList::Create<GSDrawScanline>(threads);
 
+	// Max framebuffer size can be 1024x2048 (it will loop at 2048).
 	m_output = (u8*)_aligned_malloc(1024 * 1024 * sizeof(u32), 32);
 
 	std::fill(std::begin(m_fzb_pages), std::end(m_fzb_pages), 0);
@@ -132,7 +133,7 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 	const int display_offset = GetResolutionOffset(i).y;
 	const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
 	const int display_height = offsets.y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
-	int h = std::min(GetFramebufferHeight(), display_height) + DISPFB.DBY;
+	int h = std::min(GetFramebufferHeight(), display_height);
 
 	// If there is a negative vertical offset on the picture, we need to read more.
 	if (display_offset < 0)
@@ -142,15 +143,54 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 
 	if (g_gs_device->ResizeTarget(&m_texture[i], w, h))
 	{
-		static int pitch = 1024 * 4;
+		constexpr int pitch = 1024 * 4;
+		const int off_x = DISPFB.DBX & 0x7ff;
+		const int off_y = DISPFB.DBY & 0x7ff;
+		bool part2_h = false;
+		bool part2_w = false;
+		GSVector4i r(off_x, off_y, w + off_x, h + off_y);
+		GSVector4i rh(off_x, off_y, w + off_x, (h + off_y) & 0x7FF);
+		GSVector4i rw(off_x, off_y, (w + off_x) & 0x7FF, h + off_y);
+		GSVector4i out_r(0, 0, w, h);
 
-		GSVector4i r(0, 0, w, h);
+		// Need to read it in 2 parts, since you can't do a split rect.
+		if (r.bottom >= 2048)
+		{
+			r.bottom = 2048;
+			rw.bottom = 2048;
+			part2_h = true;
+			rh.top = 0;
+		}
 
+		if (r.right >= 2048)
+		{
+			r.right = 2048;
+			rh.right = 2048;
+			part2_w = true;
+			rw.left = 0;
+			
+		}
 		const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[DISPFB.PSM];
 
 		(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), r.ralign<Align_Outside>(psm.bs), m_output, pitch, m_env.TEXA);
 
-		m_texture[i]->Update(r, m_output, pitch);
+		int top = (part2_h) ? ((r.bottom - r.top) * pitch) : 0;
+		int left = (part2_w) ? (r.right - r.left) * (GSLocalMemory::m_psm[DISPFB.PSM].bpp / 8) : 0;
+
+		if (part2_w)
+			(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), rw.ralign<Align_Outside>(psm.bs), &m_output[left], pitch, m_env.TEXA);
+
+		if (part2_h)
+			(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), rh.ralign<Align_Outside>(psm.bs), &m_output[top], pitch, m_env.TEXA);
+
+		if (part2_h && part2_w)
+		{
+			// needs also rw with the start/end height of rh, fills in the bottom right rect which will be missing if both overflow.
+			const GSVector4i rwh(rw.left, rh.top, rw.right, rh.bottom);
+			(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), rwh.ralign<Align_Outside>(psm.bs), &m_output[top + left], pitch, m_env.TEXA);
+		}
+
+		m_texture[i]->Update(out_r, m_output, pitch);
 
 		if (s_dump)
 		{

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -35,7 +35,6 @@ GSRendererSW::GSRendererSW(int threads)
 	m_tc = std::make_unique<GSTextureCacheSW>();
 	m_rl = GSRasterizerList::Create<GSDrawScanline>(threads);
 
-	// Max framebuffer size can be 1024x2048 (it will loop at 2048).
 	m_output = (u8*)_aligned_malloc(1024 * 1024 * sizeof(u32), 32);
 
 	std::fill(std::begin(m_fzb_pages), std::end(m_fzb_pages), 0);
@@ -146,46 +145,52 @@ GSTexture* GSRendererSW::GetOutput(int i, int& y_offset)
 		constexpr int pitch = 1024 * 4;
 		const int off_x = DISPFB.DBX & 0x7ff;
 		const int off_y = DISPFB.DBY & 0x7ff;
-		bool part2_h = false;
-		bool part2_w = false;
+		const GSVector4i out_r(0, 0, w, h);
 		GSVector4i r(off_x, off_y, w + off_x, h + off_y);
 		GSVector4i rh(off_x, off_y, w + off_x, (h + off_y) & 0x7FF);
 		GSVector4i rw(off_x, off_y, (w + off_x) & 0x7FF, h + off_y);
-		GSVector4i out_r(0, 0, w, h);
+		bool h_wrap = false;
+		bool w_wrap = false;
 
 		// Need to read it in 2 parts, since you can't do a split rect.
 		if (r.bottom >= 2048)
 		{
 			r.bottom = 2048;
 			rw.bottom = 2048;
-			part2_h = true;
 			rh.top = 0;
+			h_wrap = true;
 		}
 
 		if (r.right >= 2048)
 		{
 			r.right = 2048;
 			rh.right = 2048;
-			part2_w = true;
 			rw.left = 0;
-			
+			w_wrap = true;
 		}
+
 		const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[DISPFB.PSM];
 
+		// Top left rect
 		(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), r.ralign<Align_Outside>(psm.bs), m_output, pitch, m_env.TEXA);
 
-		int top = (part2_h) ? ((r.bottom - r.top) * pitch) : 0;
-		int left = (part2_w) ? (r.right - r.left) * (GSLocalMemory::m_psm[DISPFB.PSM].bpp / 8) : 0;
+		int top = (h_wrap) ? ((r.bottom - r.top) * pitch) : 0;
+		int left = (w_wrap) ? (r.right - r.left) * (GSLocalMemory::m_psm[DISPFB.PSM].bpp / 8) : 0;
 
-		if (part2_w)
+		// The following only happen if the DBX/DBY wrap around at 2048.
+
+		// Top right rect
+		if (w_wrap)
 			(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), rw.ralign<Align_Outside>(psm.bs), &m_output[left], pitch, m_env.TEXA);
 
-		if (part2_h)
+		// Bottom left rect
+		if (h_wrap)
 			(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), rh.ralign<Align_Outside>(psm.bs), &m_output[top], pitch, m_env.TEXA);
 
-		if (part2_h && part2_w)
+		// Bottom right rect
+		if (h_wrap && w_wrap)
 		{
-			// needs also rw with the start/end height of rh, fills in the bottom right rect which will be missing if both overflow.
+			// Needs also rw with the start/end height of rh, fills in the bottom right rect which will be missing if both overflow.
 			const GSVector4i rwh(rw.left, rh.top, rw.right, rh.bottom);
 			(m_mem.*psm.rtx)(m_mem.GetOffset(DISPFB.Block(), DISPFB.FBW, DISPFB.PSM), rwh.ralign<Align_Outside>(psm.bs), &m_output[top + left], pitch, m_env.TEXA);
 		}


### PR DESCRIPTION
### Description of Changes
Fixes the vertical and horizontal looping of the framebuffer output in the merge circuit in software mode.

### Rationale behind Changes
Before this would just read off the end, look wrong, and crash, this fixes the looped behaviour which we checked on the PS2.

### Suggested Testing Steps
Test games especially with funny offsets (Devil May Cry, Time Crisis multiplayer, WipEout (with screen offsets) for example) make sure they all work okay in software mode, can check hardware too for bonus points.

Fixes the crash on NASCAR '08 in software mode, no other known games benefit from it.
