### PR TITLE
GameDB: Add COP2 patch for Mobile Suit Gundam Seed Destiny Rengou vs. Z.A.F.T. II Plus

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -36551,6 +36551,12 @@ SLPS-25718:
     eeRoundMode: 1 # Fix camera issue.
   gameFixes:
     - FpuNegDivHack # Fix target loss issue.
+  patches:
+    F616C207:
+      content: |-
+        comment=Swapping COP2 codes around
+        patch=0,EE,00252824,word,48488000
+        patch=0,EE,00252828,word,4B040183
 SLPS-25719:
   name: "Happiness! Deluxe [First Print Limited Edition]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Adds a COP2 patch to the game.

### Rationale behind Changes
Try to prevent issues that may come up from the bad COP2 code.

### Suggested Testing Steps
Make sure CI is happy.
