### PR TITLE
Qt: Allow changing theme without recreating window

### DIFF
--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -146,6 +146,12 @@ void GameListModel::refreshCovers()
 	refresh();
 }
 
+void GameListModel::refreshImages()
+{
+	loadCommonImages();
+	refresh();
+}
+
 int GameListModel::getCoverArtWidth() const
 {
 	return std::max(static_cast<int>(static_cast<float>(COVER_ART_WIDTH) * m_cover_scale), 1);

--- a/pcsx2-qt/GameList/GameListModel.h
+++ b/pcsx2-qt/GameList/GameListModel.h
@@ -73,6 +73,7 @@ public:
 	int getCoverArtHeight() const;
 	int getCoverArtSpacing() const;
 	void refreshCovers();
+	void refreshImages();
 
 private:
 	void loadCommonImages();

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -249,6 +249,11 @@ void GameListWidget::cancelRefresh()
 	pxAssertRel(!m_refresh_thread, "Game list thread should be unreferenced by now");
 }
 
+void GameListWidget::refreshImages()
+{
+	m_model->refreshImages();
+}
+
 void GameListWidget::onRefreshProgress(const QString& status, int current, int total)
 {
 	// switch away from the placeholder while we scan, in case we find anything

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -56,6 +56,7 @@ public:
 
 	void refresh(bool invalidate_cache);
 	void cancelRefresh();
+	void refreshImages();
 
 	bool isShowingGameList() const;
 	bool isShowingGameGrid() const;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -84,6 +84,8 @@ const char* MainWindow::DEFAULT_THEME_NAME = "darkfusion";
 #endif
 
 MainWindow* g_main_window = nullptr;
+static QString s_unthemed_style_name;
+static bool s_unthemed_style_name_set;
 
 #if defined(_WIN32) || defined(__APPLE__)
 static const bool s_use_central_widget = false;
@@ -122,15 +124,12 @@ MainWindow::~MainWindow()
 
 void MainWindow::initialize()
 {
-	setStyleFromSettings();
-	setIconThemeFromStyle();
 #ifdef __APPLE__
 	CocoaTools::AddThemeChangeHandler(this, [](void* ctx) {
 		// This handler is called *before* the style change has propagated far enough for Qt to see it
 		// Use RunOnUIThread to delay until it has
-		QtHost::RunOnUIThread([ctx = static_cast<MainWindow*>(ctx)] {
-			ctx->setStyleFromSettings(); // Qt won't notice the style change without us touching the palette in some way
-			ctx->setIconThemeFromStyle();
+		QtHost::RunOnUIThread([ctx = static_cast<MainWindow*>(ctx)]{
+			ctx->updateTheme();// Qt won't notice the style change without us touching the palette in some way
 		});
 	});
 #endif
@@ -397,6 +396,18 @@ void MainWindow::recreate()
 	new_main_window->refreshGameList(false);
 	new_main_window->show();
 	deleteLater();
+}
+
+void MainWindow::updateApplicationTheme()
+{
+	if (!s_unthemed_style_name_set)
+	{
+		s_unthemed_style_name_set = true;
+		s_unthemed_style_name = QApplication::style()->objectName();
+	}
+
+	setStyleFromSettings();
+	setIconThemeFromStyle();
 }
 
 void MainWindow::setStyleFromSettings()
@@ -682,7 +693,7 @@ void MainWindow::setStyleFromSettings()
 	{
 		qApp->setPalette(QApplication::style()->standardPalette());
 		qApp->setStyleSheet(QString());
-		qApp->setStyle(m_unthemed_style_name);
+		qApp->setStyle(s_unthemed_style_name);
 	}
 }
 
@@ -1433,18 +1444,10 @@ void MainWindow::onToolsOpenDataDirectoryTriggered()
 	QtUtils::OpenURL(this, QUrl::fromLocalFile(path));
 }
 
-void MainWindow::onThemeChanged()
+void MainWindow::updateTheme()
 {
-	setStyleFromSettings();
-	setIconThemeFromStyle();
-	recreate();
-}
-
-void MainWindow::onThemeChangedFromSettings()
-{
-	// reopen the settings dialog after recreating
-	onThemeChanged();
-	g_main_window->doSettings();
+	updateApplicationTheme();
+	m_game_list_widget->refreshImages();
 }
 
 void MainWindow::onLoggingOptionChanged()
@@ -2054,7 +2057,7 @@ SettingsDialog* MainWindow::getSettingsDialog()
 	{
 		m_settings_dialog = new SettingsDialog(this);
 		connect(
-			m_settings_dialog->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::onThemeChangedFromSettings);
+			m_settings_dialog->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::updateTheme);
 	}
 
 	return m_settings_dialog;

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -79,6 +79,9 @@ public:
 	explicit MainWindow(const QString& unthemed_style_name);
 	~MainWindow();
 
+	/// Sets application theme according to settings.
+	static void updateApplicationTheme();
+
 	void initialize();
 	void connectVMThreadSignals(EmuThread* thread);
 	void startupUpdateCheck();
@@ -143,8 +146,7 @@ private Q_SLOTS:
 	void onAboutActionTriggered();
 	void onCheckForUpdatesActionTriggered();
 	void onToolsOpenDataDirectoryTriggered();
-	void onThemeChanged();
-	void onThemeChangedFromSettings();
+	void updateTheme();
 	void onLoggingOptionChanged();
 	void onScreenshotActionTriggered();
 	void onSaveGSDumpActionTriggered();
@@ -178,10 +180,11 @@ private:
 		NUM_SAVE_STATE_SLOTS = 10,
 	};
 
+	static void setStyleFromSettings();
+	static void setIconThemeFromStyle();
+
 	void setupAdditionalUi();
 	void connectSignals();
-	void setStyleFromSettings();
-	void setIconThemeFromStyle();
 
 	void saveStateToConfig();
 	void restoreStateFromConfig();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -703,8 +703,11 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	// Start up the CPU thread.
+	// Set theme before creating any windows.
+	MainWindow::updateApplicationTheme();
 	MainWindow* main_window = new MainWindow(QApplication::style()->objectName());
+
+	// Start up the CPU thread.
 	QtHost::HookSignals();
 	EmuThread::start();
 


### PR DESCRIPTION
### Description of Changes

Recreating the window here always seemed pretty jank.

Unfortunately we still need to do it for language changes.

### Rationale behind Changes

You can change theme without shutting down the game.

### Suggested Testing Steps

Test changing themes.
