### PR TITLE
GS/Vulkan: Fix incorrect render pass for stencil DATE

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2880,6 +2880,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 
 		case GSHWDrawConfig::DestinationAlphaMode::Stencil:
 			SetupDATE(config.rt, config.ds, config.datm, config.drawarea);
+			DATE_rp = DATE_RENDER_PASS_STENCIL;
 			break;
 	}
 


### PR DESCRIPTION
### Description of Changes

If `Stencil` mode was used, it would setup the stencil buffer correctly, but then use a `DONT_CARE` or invalidate load op, which meant the driver could choose to ignore the stencil data just written.

### Rationale behind Changes

Fixing undefined behavior.

### Suggested Testing Steps

Probably tricky to test this one, since some drivers may have `DONT_CARE` behaving as `LOAD`, but I've verified the correct pass is used myself.
