### PR TITLE
VU-MTVU: Simulate VU times when in MTVU w/o Instant VU.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8760,6 +8760,8 @@ SLED-53083:
 SLED-53109:
   name: "Juiced [Demo]"
   region: "PAL-M5"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Significantly improves game speed.
 SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
@@ -15301,6 +15303,8 @@ SLES-53044:
   name: "Juiced"
   region: "PAL-M4"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Significantly improves game speed.
 SLES-53045:
   name: "Street Racing Syndicate"
   region: "PAL-M5"
@@ -15530,6 +15534,8 @@ SLES-53150:
 SLES-53151:
   name: "Juiced"
   region: "PAL-I"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Significantly improves game speed.
 SLES-53152:
   name: "Mashed Fully Loaded"
   region: "PAL-M5"
@@ -29710,6 +29716,8 @@ SLPM-66276:
 SLPM-66277:
   name: "Juiced"
   region: "NTSC-J"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Significantly improves game speed.
 SLPM-66278:
   name: "Shin Gouketuji Ichizoku - Bonnou Kaihou"
   region: "NTSC-J"
@@ -41641,6 +41649,8 @@ SLUS-20872:
   name: "Juiced"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Significantly improves game speed.
 SLUS-20873:
   name: "Silent Hill 4 - The Room"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/SystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.cpp
@@ -94,17 +94,9 @@ SystemSettingsWidget::SystemSettingsWidget(SettingsDialog* dialog, QWidget* pare
 
 	dialog->registerWidgetHelp(m_ui.fastCDVD, tr("Enable Fast CDVD"), tr("Unchecked"),
 		tr("Fast disc access, less loading times. Check HDLoader compatibility lists for known games that have issues with this."));
-
-	updateVU1InstantState();
-	connect(m_ui.MTVU, &QCheckBox::stateChanged, this, &SystemSettingsWidget::updateVU1InstantState);
 }
 
 SystemSettingsWidget::~SystemSettingsWidget() = default;
-
-void SystemSettingsWidget::updateVU1InstantState()
-{
-	//m_ui.instantVU1->setEnabled(!m_dialog->getEffectiveBoolValue("EmuCore/Speedhacks", "vuThread", false));
-}
 
 int SystemSettingsWidget::getGlobalClampingModeIndex(bool vu) const
 {

--- a/pcsx2-qt/Settings/SystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.cpp
@@ -89,7 +89,7 @@ SystemSettingsWidget::SystemSettingsWidget(SettingsDialog* dialog, QWidget* pare
 		   "Safe for most games, but a few are incompatible and may hang."));
 
 	dialog->registerWidgetHelp(m_ui.instantVU1, tr("Instant VU1"), tr("Checked"),
-		tr("Runs VU1 instantly (when MTVU is disabled). Provides a modest speed improvement. "
+		tr("Runs VU1 instantly. Provides a modest speed improvement in most games. "
 		   "Safe for most games, but a few games may exhibit graphical errors."));
 
 	dialog->registerWidgetHelp(m_ui.fastCDVD, tr("Enable Fast CDVD"), tr("Unchecked"),
@@ -103,7 +103,7 @@ SystemSettingsWidget::~SystemSettingsWidget() = default;
 
 void SystemSettingsWidget::updateVU1InstantState()
 {
-	m_ui.instantVU1->setEnabled(!m_dialog->getEffectiveBoolValue("EmuCore/Speedhacks", "vuThread", false));
+	//m_ui.instantVU1->setEnabled(!m_dialog->getEffectiveBoolValue("EmuCore/Speedhacks", "vuThread", false));
 }
 
 int SystemSettingsWidget::getGlobalClampingModeIndex(bool vu) const

--- a/pcsx2-qt/Settings/SystemSettingsWidget.h
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.h
@@ -29,9 +29,6 @@ public:
 	SystemSettingsWidget(SettingsDialog* dialog, QWidget* parent);
 	~SystemSettingsWidget();
 
-private Q_SLOTS:
-	void updateVU1InstantState();
-
 private:
 	int getGlobalClampingModeIndex(bool vu) const;
 	int getClampingModeIndex(bool vu) const;

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -416,7 +416,8 @@ void VU_Thread::Get_MTVUChanges()
 	{
 		mtvuInterrupts.fetch_and(~InterruptFlagVUEBit, std::memory_order_relaxed);
 		
-		VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
+		if(!INSTANT_VU1)
+			VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
 		//DevCon.Warning("E-Bit registered %x", VU0.VI[REG_VPU_STAT].UL);
 	}
 	if (interrupts & InterruptFlagVUTBit)
@@ -458,10 +459,17 @@ void VU_Thread::ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop, u32 fbrst)
 	CommitWritePos();
 	gifUnit.TransferGSPacketData(GIF_TRANS_MTVU, NULL, 0);
 	KickStart();
-	u32 cycles = std::min(Get_vuCycles(), 3000u);
-	cpuRegs.cycle += cycles * EmuConfig.Speedhacks.EECycleSkip;
-	VU0.cycle += cycles * EmuConfig.Speedhacks.EECycleSkip;
+	u32 cycles = std::max(Get_vuCycles(), 4u);
+	u32 skip_cycles = std::min(cycles, 3000u);
+	cpuRegs.cycle += skip_cycles * EmuConfig.Speedhacks.EECycleSkip;
+	VU0.cycle += skip_cycles * EmuConfig.Speedhacks.EECycleSkip;
 	Get_MTVUChanges();
+
+	if (!INSTANT_VU1)
+	{
+		VU0.VI[REG_VPU_STAT].UL |= 0x100;
+		CPU_INT(VU_MTVU_BUSY, cycles);
+	}
 }
 
 void VU_Thread::VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, u8* data, u32 size)

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -416,7 +416,7 @@ void VU_Thread::Get_MTVUChanges()
 	{
 		mtvuInterrupts.fetch_and(~InterruptFlagVUEBit, std::memory_order_relaxed);
 		
-		if(!INSTANT_VU1)
+		if(INSTANT_VU1)
 			VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
 		//DevCon.Warning("E-Bit registered %x", VU0.VI[REG_VPU_STAT].UL);
 	}

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -246,6 +246,13 @@ __fi void cpuSetNextEventDelta( s32 delta )
 	cpuSetNextEvent( cpuRegs.cycle, delta );
 }
 
+__fi int cpuGetCycles(int interrupt)
+{
+	int cycles = (cpuRegs.sCycle[interrupt] + cpuRegs.eCycle[interrupt]) - cpuRegs.cycle;
+
+	return std::max(1, cycles);
+}
+
 // tests the cpu cycle against the given start and delta values.
 // Returns true if the delta time has passed.
 __fi int cpuTestCycle( u32 startCycle, s32 delta )
@@ -292,7 +299,7 @@ static __fi void _cpuTestInterrupts()
 	}
 	/* These are 'pcsx2 interrupts', they handle asynchronous stuff
 	   that depends on the cycle timings */
-
+	TESTINT(VU_MTVU_BUSY,	MTVUInterrupt);
 	TESTINT(DMAC_VIF1,		vif1Interrupt);
 	TESTINT(DMAC_GIF,		gifInterrupt);
 	TESTINT(DMAC_SIF0,		EEsif0Interrupt);

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -528,7 +528,7 @@ __fi void CPU_INT( EE_EventType n, s32 ecycle)
 	// EE events happen 8 cycles in the future instead of whatever was requested.
 	// This can be used on games with PATH3 masking issues for example, or when
 	// some FMV look bad.
-	if(CHECK_EETIMINGHACK) ecycle = 8;
+	if(CHECK_EETIMINGHACK && n < VIF_VU0_FINISH) ecycle = 8;
 
 	cpuRegs.interrupt|= 1 << n;
 	cpuRegs.sCycle[n] = cpuRegs.cycle;

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -248,9 +248,14 @@ __fi void cpuSetNextEventDelta( s32 delta )
 
 __fi int cpuGetCycles(int interrupt)
 {
-	int cycles = (cpuRegs.sCycle[interrupt] + cpuRegs.eCycle[interrupt]) - cpuRegs.cycle;
-
-	return std::max(1, cycles);
+	if(interrupt == VU_MTVU_BUSY && (!THREAD_VU1 || INSTANT_VU1))
+		return 1;
+	else
+	{
+		const int cycles = (cpuRegs.sCycle[interrupt] + cpuRegs.eCycle[interrupt]) - cpuRegs.cycle;
+		return std::max(1, cycles);
+	}
+		
 }
 
 // tests the cpu cycle against the given start and delta values.

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -415,7 +415,8 @@ enum EE_EventType
 	DMAC_GIF_UNIT,
 	VIF_VU0_FINISH,
 	VIF_VU1_FINISH,
-	IPU_PROCESS
+	IPU_PROCESS,
+	VU_MTVU_BUSY
 };
 
 extern void CPU_INT( EE_EventType n, s32 ecycle );
@@ -435,6 +436,7 @@ extern void cpuSetNextEvent( u32 startCycle, s32 delta );
 extern void cpuSetNextEventDelta( s32 delta );
 extern int  cpuTestCycle( u32 startCycle, s32 delta );
 extern void cpuSetEvent();
+extern int cpuGetCycles(int interrupt);
 
 extern void _cpuEventTest_Shared();		// for internal use by the Dynarecs and Ints inside R5900:
 

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -38,7 +38,10 @@ void vu1ResetRegs()
 void vu1Finish(bool add_cycles) {
 	if (THREAD_VU1) {
 		//if (VU0.VI[REG_VPU_STAT].UL & 0x100) DevCon.Error("MTVU: VU0.VI[REG_VPU_STAT].UL & 0x100");
-		vu1Thread.WaitVU();
+		if (INSTANT_VU1 || add_cycles)
+		{
+			vu1Thread.WaitVU();
+		}
 		vu1Thread.Get_MTVUChanges();
 		return;
 	}

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -70,7 +70,6 @@ void vu1ExecMicro(u32 addr)
 		//	VU0.VI[REG_VPU_STAT].UL |= 0x0100;
 		// }
 		// Update 25/06/2022: Disabled this for now, let games YOLO it, if it breaks MTVU, disable MTVU (it doesn't work properly anyway) - Refraction
-
 		vu1Thread.ExecuteVU(addr, vif1Regs.top, vif1Regs.itop, VU0.VI[REG_FBRST].UL);
 		return;
 	}
@@ -89,4 +88,9 @@ void vu1ExecMicro(u32 addr)
 		CpuVU1->ExecuteBlock(1);
 	else
 		CpuVU1->Execute(vu1RunCycles);
+}
+
+void MTVUInterrupt()
+{
+	VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
 }

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -256,6 +256,7 @@ extern void vu1ResetRegs();
 extern void vu1ExecMicro(u32 addr);
 extern void vu1Exec(VURegs* VU);
 extern void iDumpVU1Registers();
+extern void MTVUInterrupt();
 
 #ifdef VUM_LOG
 

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -228,8 +228,11 @@ __fi void vif1VUFinish()
 	if (VU0.VI[REG_VPU_STAT].UL & 0x500)
 	{
 		vu1Thread.Get_MTVUChanges();
-
-		CPU_INT(VIF_VU1_FINISH, 128);
+		
+		if (THREAD_VU1 && !INSTANT_VU1 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
+			CPU_INT(VIF_VU1_FINISH, cpuGetCycles(VU_MTVU_BUSY));
+		else
+			CPU_INT(VIF_VU1_FINISH, 128);
 		return;
 	}
 	

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -40,7 +40,8 @@ void vif1TransferToMemory()
 	u128* pMem = (u128*)dmaGetAddr(vif1ch.madr, false);
 
 	// VIF from gsMemory
-	if (pMem == NULL) { // Is vif0ptag empty?
+	if (pMem == NULL)
+	{ // Is vif0ptag empty?
 		Console.WriteLn("Vif1 Tag BUSERR");
 		dmacRegs.stat.BEIS = true; // Bus Error
 		vif1Regs.stat.FQC = 0;
@@ -55,10 +56,11 @@ void vif1TransferToMemory()
 	// stuff from the GS.  The *only* way to handle this case safely is to flush the GS
 	// completely and execute the transfer there-after.
 	//Console.Warning("Real QWC %x", vif1ch.qwc);
-	const u32   size = std::min(vif1.GSLastDownloadSize, (u32)vif1ch.qwc);
+	const u32 size = std::min(vif1.GSLastDownloadSize, (u32)vif1ch.qwc);
 	//const u128* pMemEnd  = vif1.GSLastDownloadSize + pMem;
 
-	if (size) {
+	if (size)
+	{
 		// Checking if any crazy game does a partial
 		// gs primitive and then does a gs download...
 		Gif_Path& p1 = gifUnit.gifPath[GIF_PATH_1];
@@ -70,7 +72,7 @@ void vif1TransferToMemory()
 	}
 
 	GetMTGS().InitAndReadFIFO(reinterpret_cast<u8*>(pMem), size);
-//	pMem += size;
+	//	pMem += size;
 
 	//Some games such as Alex Ferguson's Player Manager 2001 reads less than GSLastDownloadSize by VIF then reads the remainder by FIFO
 	//Clearing the memory is clearing memory it shouldn't be and kills it.
@@ -89,25 +91,25 @@ void vif1TransferToMemory()
 
 	g_vif1Cycles += size * 2;
 	vif1ch.madr += size * 16; // mgs3 scene changes
-	if (vif1.GSLastDownloadSize >= vif1ch.qwc) {
+	if (vif1.GSLastDownloadSize >= vif1ch.qwc)
+	{
 		vif1.GSLastDownloadSize -= vif1ch.qwc;
 		vif1Regs.stat.FQC = std::min((u32)16, vif1.GSLastDownloadSize);
 		vif1ch.qwc = 0;
 	}
-	else {
+	else
+	{
 		vif1Regs.stat.FQC = 0;
 		vif1ch.qwc -= vif1.GSLastDownloadSize;
 		vif1.GSLastDownloadSize = 0;
 		//This could be potentially bad and cause hangs. I guess we will find out.
 		DevCon.Warning("QWC left on VIF FIFO Reverse");
 	}
-
-	
 }
 
 bool _VIF1chain()
 {
-	u32 *pMem;
+	u32* pMem;
 
 	if (vif1ch.qwc == 0)
 	{
@@ -135,7 +137,7 @@ bool _VIF1chain()
 	}
 
 	VIF_LOG("VIF1chain size=%d, madr=%lx, tadr=%lx",
-	        vif1ch.qwc, vif1ch.madr, vif1ch.tadr);
+		vif1ch.qwc, vif1ch.madr, vif1ch.tadr);
 
 	if (vif1.irqoffset.enabled)
 		return VIF1transfer(pMem + vif1.irqoffset.value, vif1ch.qwc * 4 - vif1.irqoffset.value, false);
@@ -145,20 +147,21 @@ bool _VIF1chain()
 
 __fi void vif1SetupTransfer()
 {
-    tDMA_TAG *ptag;
-	
+	tDMA_TAG* ptag;
+
 	ptag = dmaGetAddr(vif1ch.tadr, false); //Set memory pointer to TADR
 
-	if (!(vif1ch.transfer("Vif1 Tag", ptag))) return;
+	if (!(vif1ch.transfer("Vif1 Tag", ptag)))
+		return;
 
-	vif1ch.madr = ptag[1]._u32;            //MADR = ADDR field + SPR
+	vif1ch.madr = ptag[1]._u32; //MADR = ADDR field + SPR
 	g_vif1Cycles += 1; // Add 1 g_vifCycles from the QW read for the tag
 	vif1.inprogress &= ~1;
 
 	VIF_LOG("VIF1 Tag %8.8x_%8.8x size=%d, id=%d, madr=%lx, tadr=%lx",
-			ptag[1]._u32, ptag[0]._u32, vif1ch.qwc, ptag->ID, vif1ch.madr, vif1ch.tadr);
+		ptag[1]._u32, ptag[0]._u32, vif1ch.qwc, ptag->ID, vif1ch.madr, vif1ch.tadr);
 
-	if (!vif1.done && ((dmacRegs.ctrl.STD == STD_VIF1) && (ptag->ID == TAG_REFS)))   // STD == VIF1
+	if (!vif1.done && ((dmacRegs.ctrl.STD == STD_VIF1) && (ptag->ID == TAG_REFS))) // STD == VIF1
 	{
 		// there are still bugs, need to also check if gif->madr +16*qwc >= stadr, if not, stall
 		if ((vif1ch.madr + vif1ch.qwc * 16) > dmacRegs.stadr.ADDR)
@@ -177,7 +180,7 @@ __fi void vif1SetupTransfer()
 		bool ret;
 
 		alignas(16) static u128 masked_tag;
-				
+
 		masked_tag._u64[0] = 0;
 		masked_tag._u64[1] = *((u64*)ptag + 1);
 
@@ -185,7 +188,7 @@ __fi void vif1SetupTransfer()
 
 		if (vif1.irqoffset.enabled)
 		{
-			ret = VIF1transfer((u32*)&masked_tag + vif1.irqoffset.value, 4 - vif1.irqoffset.value, true);  //Transfer Tag on stall
+			ret = VIF1transfer((u32*)&masked_tag + vif1.irqoffset.value, 4 - vif1.irqoffset.value, true); //Transfer Tag on stall
 			//ret = VIF1transfer((u32*)ptag + (2 + vif1.irqoffset), 2 - vif1.irqoffset);  //Transfer Tag on stall
 		}
 		else
@@ -194,7 +197,7 @@ __fi void vif1SetupTransfer()
 			// to the VU's, which breaks stuff, this is where the 128bit packet will fail, so we ignore the first 2 words
 			vif1.irqoffset.value = 2;
 			vif1.irqoffset.enabled = true;
-			ret = VIF1transfer((u32*)&masked_tag + 2, 2, true);  //Transfer Tag
+			ret = VIF1transfer((u32*)&masked_tag + 2, 2, true); //Transfer Tag
 			//ret = VIF1transfer((u32*)ptag + 2, 2);  //Transfer Tag
 		}
 
@@ -202,7 +205,7 @@ __fi void vif1SetupTransfer()
 		{
 			vif1.inprogress &= ~1; // Better clear this so it has to do it again (Jak 1)
 			vif1ch.qwc = 0; // Gumball 3000 pauses the DMA when the tag stalls so we need to reset the QWC, it'll be gotten again later
-			return;        // IRQ set by VIFTransfer
+			return; // IRQ set by VIFTransfer
 		}
 	}
 	vif1.irqoffset.value = 0;
@@ -210,14 +213,15 @@ __fi void vif1SetupTransfer()
 
 	vif1.done |= hwDmacSrcChainWithStack(vif1ch, ptag->ID);
 
-	if(vif1ch.qwc > 0) vif1.inprogress |= 1;
+	if (vif1ch.qwc > 0)
+		vif1.inprogress |= 1;
 
 	//Check TIE bit of CHCR and IRQ bit of tag
 	if (vif1ch.chcr.TIE && ptag->IRQ)
 	{
 		VIF_LOG("dmaIrq Set");
 
-        //End Transfer
+		//End Transfer
 		vif1.done = true;
 		return;
 	}
@@ -228,14 +232,14 @@ __fi void vif1VUFinish()
 	if (VU0.VI[REG_VPU_STAT].UL & 0x500)
 	{
 		vu1Thread.Get_MTVUChanges();
-		
+
 		if (THREAD_VU1 && !INSTANT_VU1 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
 			CPU_INT(VIF_VU1_FINISH, cpuGetCycles(VU_MTVU_BUSY));
 		else
 			CPU_INT(VIF_VU1_FINISH, 128);
 		return;
 	}
-	
+
 	if (VU0.VI[REG_VPU_STAT].UL & 0x100)
 	{
 		u32 _cycles = VU1.cycle;
@@ -251,7 +255,7 @@ __fi void vif1VUFinish()
 	vif1Regs.stat.VEW = false;
 	VIF_LOG("VU1 finished");
 
-	if(vif1.waitforvu)
+	if (vif1.waitforvu)
 	{
 		vif1.waitforvu = false;
 		//Check if VIF is already scheduled to interrupt, if it's waiting, kick it :P
@@ -263,7 +267,7 @@ __fi void vif1VUFinish()
 				vif1Interrupt();
 		}
 	}
-	
+
 	//DevCon.Warning("VU1 state cleared");
 }
 
@@ -273,19 +277,22 @@ __fi void vif1Interrupt()
 
 	g_vif1Cycles = 0;
 
-	if( gifRegs.stat.APATH == 2 && gifUnit.gifPath[GIF_PATH_2].isDone())
+	if (gifRegs.stat.APATH == 2 && gifUnit.gifPath[GIF_PATH_2].isDone())
 	{
 		gifRegs.stat.APATH = 0;
 		gifRegs.stat.OPH = 0;
 		vif1Regs.stat.VGW = false; //Let vif continue if it's stuck on a flush
 
-		if(gifUnit.checkPaths(1,0,1)) gifUnit.Execute(false, true);
+		if (gifUnit.checkPaths(1, 0, 1))
+			gifUnit.Execute(false, true);
 	}
 	//Some games (Fahrenheit being one) start vif first, let it loop through blankness while it sets MFIFO mode, so we need to check it here.
-	if (dmacRegs.ctrl.MFD == MFD_VIF1) {
+	if (dmacRegs.ctrl.MFD == MFD_VIF1)
+	{
 		//Console.WriteLn("VIFMFIFO\n");
 		// Test changed because the Final Fantasy 12 opening somehow has the tag in *Undefined* mode, which is not in the documentation that I saw.
-		if (vif1ch.chcr.MOD == NORMAL_MODE) Console.WriteLn("MFIFO mode is normal (which isn't normal here)! %x", vif1ch.chcr._u32);
+		if (vif1ch.chcr.MOD == NORMAL_MODE)
+			Console.WriteLn("MFIFO mode is normal (which isn't normal here)! %x", vif1ch.chcr._u32);
 		vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 		vifMFIFOInterrupt();
 		return;
@@ -293,42 +300,46 @@ __fi void vif1Interrupt()
 
 	// We need to check the direction, if it is downloading
 	// from the GS then we handle that separately (KH2 for testing)
-	if (vif1ch.chcr.DIR) {
-		bool isDirect   = (vif1.cmd & 0x7f) == 0x50;
+	if (vif1ch.chcr.DIR)
+	{
+		bool isDirect = (vif1.cmd & 0x7f) == 0x50;
 		bool isDirectHL = (vif1.cmd & 0x7f) == 0x51;
-		if((isDirect   && !gifUnit.CanDoPath2())
-		|| (isDirectHL && !gifUnit.CanDoPath2HL())) {
+		if ((isDirect && !gifUnit.CanDoPath2()) || (isDirectHL && !gifUnit.CanDoPath2HL()))
+		{
 			GUNIT_WARN("vif1Interrupt() - Waiting for Path 2 to be ready");
 			CPU_INT(DMAC_VIF1, 128);
-			if(gifRegs.stat.APATH == 3) vif1Regs.stat.VGW = 1; //We're waiting for path 3. Gunslinger II
+			if (gifRegs.stat.APATH == 3)
+				vif1Regs.stat.VGW = 1; //We're waiting for path 3. Gunslinger II
 			return;
 		}
 		vif1Regs.stat.VGW = 0; //Path 3 isn't busy so we don't need to wait for it.
 		vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 		//Simulated GS transfer time done, clear the flags
 	}
-	
-	if(vif1.waitforvu)
+
+	if (vif1.waitforvu)
 	{
 		//DevCon.Warning("Waiting on VU1");
 		//CPU_INT(DMAC_VIF1, 16);
-		CPU_INT(VIF_VU1_FINISH, 16);
+		CPU_INT(VIF_VU1_FINISH, std::max(16, cpuGetCycles(VU_MTVU_BUSY)));
 		return;
 	}
-	
+
 	if (vif1Regs.stat.VGW)
 		return;
-		
-	if (!vif1ch.chcr.STR) Console.WriteLn("Vif1 running when CHCR == %x", vif1ch.chcr._u32);
+
+	if (!vif1ch.chcr.STR)
+		Console.WriteLn("Vif1 running when CHCR == %x", vif1ch.chcr._u32);
 
 	if (vif1.irq && vif1.vifstalled.enabled && vif1.vifstalled.value == VIF_IRQ_STALL)
 	{
 		VIF_LOG("VIF IRQ Firing");
 		if (!vif1Regs.stat.ER1)
 			vif1Regs.stat.INT = true;
-		
+
 		//Yakuza watches VIF_STAT so lets do this here.
-		if (((vif1Regs.code >> 24) & 0x7f) != 0x7) {
+		if (((vif1Regs.code >> 24) & 0x7f) != 0x7)
+		{
 			vif1Regs.stat.VIS = true;
 		}
 
@@ -342,7 +353,7 @@ __fi void vif1Interrupt()
 			//NFSHPS stalls when the whole packet has gone across (it stalls in the last 32bit cmd)
 			//In this case VIF will end
 			vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
-			if((vif1ch.qwc > 0 || !vif1.done) && !CHECK_VIF1STALLHACK)	
+			if ((vif1ch.qwc > 0 || !vif1.done) && !CHECK_VIF1STALLHACK)
 			{
 				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF1 Stalled");
@@ -356,40 +367,62 @@ __fi void vif1Interrupt()
 	//Mirroring change to VIF0
 	if (vif1.cmd)
 	{
-		if (vif1.done && (vif1ch.qwc == 0)) vif1Regs.stat.VPS = VPS_WAITING;
+		if (vif1.done && (vif1ch.qwc == 0))
+			vif1Regs.stat.VPS = VPS_WAITING;
 	}
 	else
 	{
 		vif1Regs.stat.VPS = VPS_IDLE;
 	}
-	
+
 	if (vif1.inprogress & 0x1)
-    {
-            _VIF1chain();
-            // VIF_NORMAL_FROM_MEM_MODE is a very slow operation.
-            // Timesplitters 2 depends on this beeing a bit higher than 128.
-            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
-		
-			if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
+	{
+		_VIF1chain();
+		// VIF_NORMAL_FROM_MEM_MODE is a very slow operation.
+		// Timesplitters 2 depends on this beeing a bit higher than 128.
+		if (vif1ch.chcr.DIR)
+			vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
+
+		if (!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
+		{
+			if (vif1.waitforvu)
+			{
+				//if (cpuGetCycles(VU_MTVU_BUSY) > static_cast<int>(g_vif1Cycles))
+				//	DevCon.Warning("Waiting %d instead of %d", cpuGetCycles(VU_MTVU_BUSY), static_cast<int>(g_vif1Cycles));
+				CPU_INT(DMAC_VIF1, std::max(static_cast<int>(g_vif1Cycles), cpuGetCycles(VU_MTVU_BUSY)));
+			}
+			else
 				CPU_INT(DMAC_VIF1, g_vif1Cycles);
-            return;
-    }
+		}
+		return;
+	}
 
-    if (!vif1.done)
-    {
+	if (!vif1.done)
+	{
 
-            if (!(dmacRegs.ctrl.DMAE) || vif1Regs.stat.VSS) //Stopped or DMA Disabled
-            {
-                    //Console.WriteLn("vif1 dma masked");
-                    return;
-            }
+		if (!(dmacRegs.ctrl.DMAE) || vif1Regs.stat.VSS) //Stopped or DMA Disabled
+		{
+			//Console.WriteLn("vif1 dma masked");
+			return;
+		}
 
-            if ((vif1.inprogress & 0x1) == 0) vif1SetupTransfer();
-            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
+		if ((vif1.inprogress & 0x1) == 0)
+			vif1SetupTransfer();
+		if (vif1ch.chcr.DIR)
+			vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 
-			if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
-	            CPU_INT(DMAC_VIF1, g_vif1Cycles);
-            return;
+		if (!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
+		{
+			if (vif1.waitforvu)
+			{
+				//if (cpuGetCycles(VU_MTVU_BUSY) > static_cast<int>(g_vif1Cycles))
+				//	DevCon.Warning("Waiting %d instead of %d", cpuGetCycles(VU_MTVU_BUSY), static_cast<int>(g_vif1Cycles));
+				CPU_INT(DMAC_VIF1, std::max(static_cast<int>(g_vif1Cycles), cpuGetCycles(VU_MTVU_BUSY)));
+			}
+			else
+				CPU_INT(DMAC_VIF1, g_vif1Cycles);
+		}
+		return;
 	}
 
 	if (vif1.vifstalled.enabled && vif1.done)
@@ -399,52 +432,55 @@ __fi void vif1Interrupt()
 		return; //Dont want to end if vif is stalled.
 	}
 #ifdef PCSX2_DEVBUILD
-	if (vif1ch.qwc > 0) DevCon.WriteLn("VIF1 Ending with %x QWC left", vif1ch.qwc);
-	if (vif1.cmd != 0) DevCon.WriteLn("vif1.cmd still set %x tag size %x", vif1.cmd, vif1.tag.size);
+	if (vif1ch.qwc > 0)
+		DevCon.WriteLn("VIF1 Ending with %x QWC left", vif1ch.qwc);
+	if (vif1.cmd != 0)
+		DevCon.WriteLn("vif1.cmd still set %x tag size %x", vif1.cmd, vif1.tag.size);
 #endif
 
-	if((vif1ch.chcr.DIR == VIF_NORMAL_TO_MEM_MODE) && vif1.GSLastDownloadSize <= 16)
+	if ((vif1ch.chcr.DIR == VIF_NORMAL_TO_MEM_MODE) && vif1.GSLastDownloadSize <= 16)
 	{
 		//Reverse fifo has finished and nothing is left, so lets clear the outputting flag
 		gifRegs.stat.OPH = false;
 	}
 
-	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
+	if (vif1ch.chcr.DIR)
+		vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 
 	vif1ch.chcr.STR = false;
 	vif1.vifstalled.enabled = false;
 	vif1.irqoffset.enabled = false;
-	if(vif1.queued_program) vifExecQueue(1);
+	if (vif1.queued_program)
+		vifExecQueue(1);
 	g_vif1Cycles = 0;
 	VIF_LOG("VIF1 DMA End");
 	hwDmacIrq(DMAC_VIF1);
-
 }
 
 void dmaVIF1()
 {
 	VIF_LOG("dmaVIF1 chcr = %lx, madr = %lx, qwc  = %lx\n"
-	        "        tadr = %lx, asr0 = %lx, asr1 = %lx",
-	        vif1ch.chcr._u32, vif1ch.madr, vif1ch.qwc,
-	        vif1ch.tadr, vif1ch.asr0, vif1ch.asr1);
+			"        tadr = %lx, asr0 = %lx, asr1 = %lx",
+		vif1ch.chcr._u32, vif1ch.madr, vif1ch.qwc,
+		vif1ch.tadr, vif1ch.asr0, vif1ch.asr1);
 
 	g_vif1Cycles = 0;
 	vif1.inprogress = 0;
 
-	if (vif1ch.qwc > 0)   // Normal Mode
+	if (vif1ch.qwc > 0) // Normal Mode
 	{
-		
+
 		// ignore tag if it's a GS download (Def Jam Fight for NY)
-		if(vif1ch.chcr.MOD == CHAIN_MODE && vif1ch.chcr.DIR) 
+		if (vif1ch.chcr.MOD == CHAIN_MODE && vif1ch.chcr.DIR)
 		{
 			vif1.dmamode = VIF_CHAIN_MODE;
 			//DevCon.Warning(L"VIF1 QWC on Chain CHCR " + vif1ch.chcr.desc());
-			
+
 			if ((vif1ch.chcr.tag().ID == TAG_REFE) || (vif1ch.chcr.tag().ID == TAG_END) || (vif1ch.chcr.tag().IRQ && vif1ch.chcr.TIE))
 			{
 				vif1.done = true;
 			}
-			else 
+			else
 			{
 				vif1.done = false;
 			}
@@ -454,12 +490,13 @@ void dmaVIF1()
 			if (dmacRegs.ctrl.STD == STD_VIF1)
 				Console.WriteLn("DMA Stall Control on VIF1 normal not implemented - Report which game to PCSX2 Team");
 
-			if (vif1ch.chcr.DIR)  // from Memory
+			if (vif1ch.chcr.DIR) // from Memory
 				vif1.dmamode = VIF_NORMAL_FROM_MEM_MODE;
 			else
 				vif1.dmamode = VIF_NORMAL_TO_MEM_MODE;
 
-			if(vif1.irqoffset.enabled && !vif1.done) DevCon.Warning("Warning! VIF1 starting a Normal transfer with vif offset set (Possible force stop?)");
+			if (vif1.irqoffset.enabled && !vif1.done)
+				DevCon.Warning("Warning! VIF1 starting a Normal transfer with vif offset set (Possible force stop?)");
 			vif1.done = true;
 		}
 
@@ -470,10 +507,10 @@ void dmaVIF1()
 		vif1.inprogress &= ~0x1;
 		vif1.dmamode = VIF_CHAIN_MODE;
 		vif1.done = false;
-		
 	}
 
-	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
+	if (vif1ch.chcr.DIR)
+		vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 
 	// Check VIF isn't stalled before starting the loop.
 	// Batman Vengence does something stupid and instead of cancelling a stall it tries to restart VIF, THEN check the stall

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -238,7 +238,10 @@ __fi void vif1VUFinish()
 		u32 _cycles = VU1.cycle;
 		//DevCon.Warning("Finishing VU1");
 		vu1Finish(false);
-		CPU_INT(VIF_VU1_FINISH, VU1.cycle - _cycles);
+		if (THREAD_VU1 && !INSTANT_VU1 && (VU0.VI[REG_VPU_STAT].UL & 0x100))
+			CPU_INT(VIF_VU1_FINISH, cpuGetCycles(VU_MTVU_BUSY));
+		else
+			CPU_INT(VIF_VU1_FINISH, VU1.cycle - _cycles);
 		return;
 	}
 

--- a/pcsx2/gui/Panels/ConfigurationPanels.h
+++ b/pcsx2/gui/Panels/ConfigurationPanels.h
@@ -341,7 +341,6 @@ namespace Panels
 		void Defaults_Click(wxCommandEvent& evt);
 		void EECycleRate_Scroll(wxScrollEvent& event);
 		void VUCycleRate_Scroll(wxScrollEvent& event);
-		void VUThread_Enable(wxCommandEvent& evt);
 	};
 
 	// --------------------------------------------------------------------------------------

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -167,7 +167,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	m_check_vuThread = new pxCheckBox( vuHacksPanel, _("MTVU (Multi-Threaded microVU1)"),
 		_("Good Speedup and High Compatibility; may cause hanging... [Recommended on 3+ cores]") );
 
-	m_check_vu1Instant = new pxCheckBox(vuHacksPanel, _("Instant VU1 (without MTVU only)"),
+	m_check_vu1Instant = new pxCheckBox(vuHacksPanel, _("Instant VU1"),
 		_("Good Speedup and High Compatibility; may cause some graphical errors"));
 
 	m_check_vuFlagHack->SetToolTip( pxEt( L"Updates Status Flags only on blocks which will read them, instead of all the time. This is safe most of the time."
@@ -176,7 +176,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	m_check_vuThread->SetToolTip( pxEt( L"Runs VU1 on its own thread (microVU1-only). Generally a speedup on CPUs with 3 or more cores. This is safe for most games, but a few games are incompatible and may hang. In the case of GS limited games, it may be a slowdown (especially on dual core CPUs)."
 	) );
 
-	m_check_vu1Instant->SetToolTip(pxEt(L"Runs VU1 instantly (when MTVU is disabled). Provides a modest speed improvement. This is safe for most games, but a few games may exhibit graphical errors."
+	m_check_vu1Instant->SetToolTip(pxEt(L"Runs VU1 instantly. Provides a modest speed improvement in most games. This is safe for most games, but a few games may exhibit graphical errors."
 	));
 
 	// ------------------------------------------------------------------------
@@ -270,7 +270,7 @@ void Panels::SpeedHacksPanel::EnableStuff( AppConfig* configToUse )
 	// Disables the Instant VU1 checkbox when MTVU is checked in the GUI as reflected in the code.
 	// Makes Instant VU1 toggleable when MTVU is unchecked in the GUI.
 	// Some may think that having MTVU + Instant VU1 checked, can have bad side-effects when it doesn't.
-	m_check_vu1Instant->Enable(hacksEnabled && !m_check_vuThread->GetValue());
+	//m_check_vu1Instant->Enable(hacksEnabled && !m_check_vuThread->GetValue());
 
 	// Layout necessary to ensure changed slider text gets re-aligned properly
 	// and to properly gray/ungray pxStaticText stuff (I suspect it causes a

--- a/pcsx2/gui/Panels/SpeedhacksPanel.cpp
+++ b/pcsx2/gui/Panels/SpeedhacksPanel.cpp
@@ -173,7 +173,7 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	m_check_vuFlagHack->SetToolTip( pxEt( L"Updates Status Flags only on blocks which will read them, instead of all the time. This is safe most of the time."
 	) );
 
-	m_check_vuThread->SetToolTip( pxEt( L"Runs VU1 on its own thread (microVU1-only). Generally a speedup on CPUs with 3 or more cores. This is safe for most games, but a few games are incompatible and may hang. In the case of GS limited games, it may be a slowdown (especially on dual core CPUs)."
+	m_check_vuThread->SetToolTip( pxEt( L"Runs VU1 on its own thread. Generally a speedup on CPUs with 3 or more cores. This is safe for most games, but a few games are incompatible and may hang. In the case of GS limited games, it may be a slowdown (especially on dual core CPUs)."
 	) );
 
 	m_check_vu1Instant->SetToolTip(pxEt(L"Runs VU1 instantly. Provides a modest speed improvement in most games. This is safe for most games, but a few games may exhibit graphical errors."
@@ -237,7 +237,6 @@ Panels::SpeedHacksPanel::SpeedHacksPanel( wxWindow* parent )
 	Bind(wxEVT_SCROLL_CHANGED, &SpeedHacksPanel::VUCycleRate_Scroll, this, m_slider_eeSkip->GetId());
 	Bind(wxEVT_CHECKBOX, &SpeedHacksPanel::OnEnable_Toggled, this, m_check_Enable->GetId());
 	Bind(wxEVT_BUTTON, &SpeedHacksPanel::Defaults_Click, this, wxID_DEFAULT);
-	Bind(wxEVT_CHECKBOX, &SpeedHacksPanel::VUThread_Enable, this, m_check_vuThread->GetId());
 }
 
 // Doesn't modify values - only locks(gray out)/unlocks as necessary.
@@ -266,11 +265,6 @@ void Panels::SpeedHacksPanel::EnableStuff( AppConfig* configToUse )
 
 	// Grayout MTVU on safest preset
 	m_check_vuThread->Enable(hacksEnabled && (!hasPreset || configToUse->PresetIndex != 0));
-
-	// Disables the Instant VU1 checkbox when MTVU is checked in the GUI as reflected in the code.
-	// Makes Instant VU1 toggleable when MTVU is unchecked in the GUI.
-	// Some may think that having MTVU + Instant VU1 checked, can have bad side-effects when it doesn't.
-	//m_check_vu1Instant->Enable(hacksEnabled && !m_check_vuThread->GetValue());
 
 	// Layout necessary to ensure changed slider text gets re-aligned properly
 	// and to properly gray/ungray pxStaticText stuff (I suspect it causes a
@@ -369,10 +363,4 @@ void Panels::SpeedHacksPanel::VUCycleRate_Scroll(wxScrollEvent &event)
 	Layout();
 
 	event.Skip();
-}
-
-void Panels::SpeedHacksPanel::VUThread_Enable(wxCommandEvent& evt)
-{
-	m_check_vu1Instant->Enable(!m_check_vuThread->GetValue());
-	Layout();
 }


### PR DESCRIPTION
### Description of Changes
Attempt to averagely simulate VU times with Instant VU disabled if MTVU is enabled.

### Rationale behind Changes
Some games such as Juiced can hammer the VU's to try and get as many frames out as possible, you could somewhat repair this with the Cycle Skipping speedhack, but I never liked that. 

### Suggested Testing Steps
Test games with MTVU enabled and Instant VU on and off, especially games that struggle with the VU thread being maxed.
