### PR TITLE
DEV9: Sockets: Set Arp Hardware Type

### DIFF
--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -390,6 +390,7 @@ bool SocketAdapter::send(NetPacket* pkt)
 						memcpy(arpRet->senderProtocolAddress.get(), arpPkt.targetProtocolAddress.get(), 4);
 						arpRet->op = 2,
 						arpRet->protocol = arpPkt.protocol;
+						arpRet->hardwareType = arpPkt.hardwareType;
 
 						EthernetFrame* retARP = new EthernetFrame(arpRet);
 						memcpy(retARP->destinationMAC, ps2MAC, 6);


### PR DESCRIPTION
### Description of Changes
Probally initilise the Hardware Type field

### Rationale behind Changes
This was missed in porting the ARP packet code from CLR_DEV9 to PCSX2.
Some games use ARP to find the gateway, instead of remembering the MAC address from the DHCP process.
ARP packets can be ignored if the fields arn't set correctly.

### Suggested Testing Steps
Test Network games with Sockets
