### PR TITLE
GS: Purge sparse texture 

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1477,8 +1477,6 @@ void GSApp::Init()
 	m_default_configuration["override_GL_ARB_draw_buffers_blend"]         = "-1";
 	m_default_configuration["override_GL_ARB_gpu_shader5"]                = "-1";
 	m_default_configuration["override_GL_ARB_shader_image_load_store"]    = "-1";
-	m_default_configuration["override_GL_ARB_sparse_texture"]             = "-1";
-	m_default_configuration["override_GL_ARB_sparse_texture2"]            = "-1";
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
 	m_default_configuration["OverrideTextureBarriers"]                    = "-1";
 	m_default_configuration["OverrideGeometryShaders"]                    = "-1";

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -161,12 +161,10 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int width, int height, i
 	}
 
 	t->SetScale(GSVector2(1, 1)); // Things seem to assume that all textures come out of here with scale 1...
-	t->Commit(); // Clear won't be done if the texture isn't committed.
 
 	switch (type)
 	{
 	case GSTexture::Type::RenderTarget:
-	case GSTexture::Type::SparseRenderTarget:
 		{
 			if (clear)
 				ClearRenderTarget(t, 0);
@@ -175,7 +173,6 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Type type, int width, int height, i
 		}
 		break;
 	case GSTexture::Type::DepthStencil:
-	case GSTexture::Type::SparseDepthStencil:
 		{
 			if (clear)
 				ClearDepth(t);
@@ -215,12 +212,6 @@ void GSDevice::Recycle(GSTexture* t)
 {
 	if (t)
 	{
-#ifdef _DEBUG
-		// Uncommit saves memory but it means a futur allocation when we want to reuse the texture.
-		// Which is slow and defeat the purpose of the m_pool cache.
-		// However, it can help to spot part of texture that we forgot to commit
-		t->Uncommit();
-#endif
 		t->last_frame_used = m_frame;
 
 		m_pool.push_front(t);
@@ -259,16 +250,6 @@ void GSDevice::ClearSamplerCache()
 {
 }
 
-GSTexture* GSDevice::CreateSparseRenderTarget(int w, int h, GSTexture::Format format, bool clear)
-{
-	return FetchSurface(HasColorSparse() ? GSTexture::Type::SparseRenderTarget : GSTexture::Type::RenderTarget, w, h, 1, format, clear, true);
-}
-
-GSTexture* GSDevice::CreateSparseDepthStencil(int w, int h, GSTexture::Format format, bool clear)
-{
-	return FetchSurface(HasDepthSparse() ? GSTexture::Type::SparseDepthStencil : GSTexture::Type::DepthStencil, w, h, 1, format, clear, true);
-}
-
 GSTexture* GSDevice::CreateRenderTarget(int w, int h, GSTexture::Format format, bool clear)
 {
 	return FetchSurface(GSTexture::Type::RenderTarget, w, h, 1, format, clear, true);
@@ -292,7 +273,7 @@ GSTexture* GSDevice::CreateOffscreen(int w, int h, GSTexture::Format format)
 
 GSTexture::Format GSDevice::GetDefaultTextureFormat(GSTexture::Type type)
 {
-	if (type == GSTexture::Type::DepthStencil || type == GSTexture::Type::SparseDepthStencil)
+	if (type == GSTexture::Type::DepthStencil)
 		return GSTexture::Format::DepthStencil;
 	else
 		return GSTexture::Format::Color;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -729,9 +729,6 @@ public:
 	virtual void BeginScene() {}
 	virtual void EndScene();
 
-	virtual bool HasDepthSparse() { return false; }
-	virtual bool HasColorSparse() { return false; }
-
 	virtual void ClearRenderTarget(GSTexture* t, const GSVector4& c) {}
 	virtual void ClearRenderTarget(GSTexture* t, u32 c) {}
 	virtual void InvalidateRenderTarget(GSTexture* t) {}
@@ -742,8 +739,6 @@ public:
 	virtual void PopDebugGroup() {}
 	virtual void InsertDebugMessage(DebugMessageCategory category, const char* fmt, ...) {}
 
-	GSTexture* CreateSparseRenderTarget(int w, int h, GSTexture::Format format, bool clear = true);
-	GSTexture* CreateSparseDepthStencil(int w, int h, GSTexture::Format format, bool clear = true);
 	GSTexture* CreateRenderTarget(int w, int h, GSTexture::Format format, bool clear = true);
 	GSTexture* CreateDepthStencil(int w, int h, GSTexture::Format format, bool clear = true);
 	GSTexture* CreateTexture(int w, int h, bool mipmap, GSTexture::Format format, bool prefer_reuse = false);

--- a/pcsx2/GS/Renderers/Common/GSTexture.h
+++ b/pcsx2/GS/Renderers/Common/GSTexture.h
@@ -33,8 +33,6 @@ public:
 		DepthStencil,
 		Texture,
 		Offscreen,
-		SparseRenderTarget,
-		SparseDepthStencil,
 	};
 
 	enum class Format : u8
@@ -63,24 +61,15 @@ public:
 protected:
 	GSVector2 m_scale;
 	GSVector2i m_size;
-	GSVector2i m_committed_size;
-	GSVector2i m_gpu_page_size;
 	int m_mipmap_levels;
 	Type m_type;
 	Format m_format;
 	State m_state;
-	bool m_sparse;
 	bool m_needs_mipmaps_generated;
 
 public:
 	GSTexture();
 	virtual ~GSTexture() {}
-
-	virtual operator bool()
-	{
-		pxAssert(0);
-		return false;
-	}
 
 	// Returns the native handle of a texture.
 	virtual void* GetNativeHandle() const = 0;
@@ -113,16 +102,15 @@ public:
 
 	bool IsRenderTargetOrDepthStencil() const
 	{
-		return (m_type >= Type::RenderTarget && m_type <= Type::DepthStencil) ||
-			(m_type >= Type::SparseRenderTarget && m_type <= Type::SparseDepthStencil);
+		return (m_type >= Type::RenderTarget && m_type <= Type::DepthStencil);
 	}
 	bool IsRenderTarget() const
 	{
-		return (m_type == Type::RenderTarget || m_type == Type::SparseRenderTarget);
+		return (m_type == Type::RenderTarget);
 	}
 	bool IsDepthStencil() const
 	{
-		return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil);
+		return (m_type == Type::DepthStencil);
 	}
 
 	State GetState() const { return m_state; }
@@ -131,14 +119,6 @@ public:
 	void GenerateMipmapsIfNeeded();
 	void ClearMipmapGenerationFlag() { m_needs_mipmaps_generated = false; }
 
-	virtual void CommitPages(const GSVector2i& region, bool commit) {}
-	void CommitRegion(const GSVector2i& region);
-	void Commit();
-	void Uncommit();
-	GSVector2i GetCommittedSize() const { return m_committed_size; }
-	void SetGpuPageSize(const GSVector2i& page_size);
-	GSVector2i RoundUpPage(GSVector2i v);
-
 	// frame number (arbitrary base) the texture was recycled on
 	// different purpose than texture cache ages, do not attempt to merge
 	unsigned last_frame_used;
@@ -146,7 +126,7 @@ public:
 	float OffsetHack_modxy;
 
 	// Typical size of a RGBA texture
-	virtual u32 GetMemUsage() { return m_size.x * m_size.y * (m_format == Format::UNorm8 ? 1 : 4); }
+	u32 GetMemUsage() const { return m_size.x * m_size.y * (m_format == Format::UNorm8 ? 1 : 4); }
 
 	// Helper routines for formats/types
 	static bool IsCompressedFormat(Format format) { return (format >= Format::BC1 && format <= Format::BC7); }

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1370,7 +1370,6 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		const GSVector4 dRect(config.drawarea);
 		const GSVector4 sRect = dRect / GSVector4(size.x, size.y).xyxy();
 		hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::FloatColor);
-		hdr_rt->CommitRegion(GSVector2i(config.drawarea.z, config.drawarea.w));
 		// Warning: StretchRect must be called before BeginScene otherwise
 		// vertices will be overwritten. Trust me you don't want to do that.
 		StretchRect(config.rt, sRect, hdr_rt, dRect, ShaderConvert::COPY, false);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -319,8 +319,7 @@ void GSDevice12::LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_f
 
 GSTexture* GSDevice12::CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format)
 {
-	pxAssert(type != GSTexture::Type::Offscreen && type != GSTexture::Type::SparseRenderTarget &&
-			 type != GSTexture::Type::SparseDepthStencil);
+	pxAssert(type != GSTexture::Type::Offscreen);
 
 	const u32 clamped_width = static_cast<u32>(std::clamp<int>(1, width, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION));
 	const u32 clamped_height = static_cast<u32>(std::clamp<int>(1, height, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION));

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3520,12 +3520,6 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 
 	SetupIA(sx, sy);
 
-	if (rt)
-		rt->CommitRegion(GSVector2i(m_conf.drawarea.z, m_conf.drawarea.w));
-
-	if (ds)
-		ds->CommitRegion(GSVector2i(m_conf.drawarea.z, m_conf.drawarea.w));
-
 	m_conf.alpha_second_pass.enable = ate_second_pass;
 
 	if (ate_second_pass)
@@ -4226,9 +4220,6 @@ void GSRendererHW::OI_DoubleHalfClear(GSTextureCache::Target*& rt, GSTextureCach
 
 		// If both buffers are side by side we can expect a fast clear in on-going
 		const u32 color = v[1].RGBAQ.U32[0];
-		const GSVector4i commitRect = ComputeBoundingBox(rt->m_texture->GetScale(), rt->m_texture->GetSize());
-		rt->m_texture->CommitRegion(GSVector2i(commitRect.z, commitRect.w));
-
 		g_gs_device->ClearRenderTarget(rt->m_texture, color);
 	}
 }
@@ -4513,8 +4504,6 @@ bool GSRendererHW::OI_FFX(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* 
 	{
 		// random battle transition (z buffer written directly, clear it now)
 		GL_INS("OI_FFX ZB clear");
-		if (ds)
-			ds->Commit(); // Don't bother to save few MB for a single game
 		g_gs_device->ClearDepth(ds);
 	}
 
@@ -4566,7 +4555,6 @@ bool GSRendererHW::OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTex
 			if (GSTextureCache::Target* tmp_rt = m_tc->LookupTarget(TEX0, GetTargetSize(), GSTextureCache::RenderTarget, true))
 			{
 				GL_INS("OI_RozenMaidenGebetGarden FB clear");
-				tmp_rt->m_texture->Commit(); // Don't bother to save few MB for a single game
 				g_gs_device->ClearRenderTarget(tmp_rt->m_texture, 0);
 			}
 
@@ -4585,7 +4573,6 @@ bool GSRendererHW::OI_RozenMaidenGebetGarden(GSTexture* rt, GSTexture* ds, GSTex
 			if (GSTextureCache::Target* tmp_ds = m_tc->LookupTarget(TEX0, GetTargetSize(), GSTextureCache::DepthStencil, true))
 			{
 				GL_INS("OI_RozenMaidenGebetGarden ZB clear");
-				tmp_ds->m_texture->Commit(); // Don't bother to save few MB for a single game
 				g_gs_device->ClearDepth(tmp_ds->m_texture);
 			}
 
@@ -4705,8 +4692,6 @@ bool GSRendererHW::OI_SuperManReturns(GSTexture* rt, GSTexture* ds, GSTextureCac
 	ASSERT((v->RGBAQ.A << 24 | v->RGBAQ.B << 16 | v->RGBAQ.G << 8 | v->RGBAQ.R) == (int)v->XYZ.Z);
 
 	// Do a direct write
-	if (rt)
-		rt->Commit(); // Don't bother to save few MB for a single game
 	g_gs_device->ClearRenderTarget(rt, GSVector4(m_vt.m_min.c));
 
 	m_tc->InvalidateVideoMemType(GSTextureCache::DepthStencil, ctx->FRAME.Block());
@@ -4743,8 +4728,6 @@ bool GSRendererHW::OI_ArTonelico2(GSTexture* rt, GSTexture* ds, GSTextureCache::
 	if (m_vertex.next == 2 && !PRIM->TME && m_context->FRAME.FBW == 10 && v->XYZ.Z == 0 && m_context->TEST.ZTST == ZTST_ALWAYS)
 	{
 		GL_INS("OI_ArTonelico2");
-		if (ds)
-			ds->Commit(); // Don't bother to save few MB for a single game
 		g_gs_device->ClearDepth(ds);
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -518,8 +518,8 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		if (new_s != old_s)
 		{
 			calcRescale(dst->m_texture);
-			GSTexture* tex = type == RenderTarget ? g_gs_device->CreateSparseRenderTarget(new_size.x, new_size.y, GSTexture::Format::Color, clear) :
-				g_gs_device->CreateSparseDepthStencil(new_size.x, new_size.y, GSTexture::Format::DepthStencil, clear);
+			GSTexture* tex = type == RenderTarget ? g_gs_device->CreateRenderTarget(new_size.x, new_size.y, GSTexture::Format::Color, clear) :
+				g_gs_device->CreateDepthStencil(new_size.x, new_size.y, GSTexture::Format::DepthStencil, clear);
 			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, (type == RenderTarget) ? ShaderConvert::COPY : ShaderConvert::DEPTH_COPY, false);
 			g_gs_device->Recycle(dst->m_texture);
 			tex->SetScale(new_s);
@@ -1872,13 +1872,13 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(const GIFRegTEX0& TEX0, int
 
 	if (type == RenderTarget)
 	{
-		t->m_texture = g_gs_device->CreateSparseRenderTarget(w, h, GSTexture::Format::Color, clear);
+		t->m_texture = g_gs_device->CreateRenderTarget(w, h, GSTexture::Format::Color, clear);
 
 		t->m_used = true; // FIXME
 	}
 	else if (type == DepthStencil)
 	{
-		t->m_texture = g_gs_device->CreateSparseDepthStencil(w, h, GSTexture::Format::DepthStencil, clear);
+		t->m_texture = g_gs_device->CreateDepthStencil(w, h, GSTexture::Format::DepthStencil, clear);
 	}
 
 	t->m_texture->SetScale(static_cast<GSRendererHW*>(g_gs_renderer.get())->GetTextureScaleFactor());
@@ -2072,8 +2072,8 @@ void GSTextureCache::Surface::ResizeTexture(int new_width, int new_height, GSVec
 
 	const bool clear = (new_width > width || new_height > height);
 	GSTexture* tex = m_texture->IsDepthStencil() ?
-						 g_gs_device->CreateSparseDepthStencil(new_width, new_height, m_texture->GetFormat(), clear) :
-                         g_gs_device->CreateSparseRenderTarget(new_width, new_height, m_texture->GetFormat(), clear);
+						 g_gs_device->CreateDepthStencil(new_width, new_height, m_texture->GetFormat(), clear) :
+                         g_gs_device->CreateRenderTarget(new_width, new_height, m_texture->GetFormat(), clear);
 	if (!tex)
 	{
 		Console.Error("(GSTextureCache::Surface::ResizeTexture) Failed to allocate %dx%d texture", new_width, new_height);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -402,7 +402,6 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Type type, int width, int heigh
 			[desc setUsage:MTLTextureUsageRenderTarget];
 			break;
 		case GSTexture::Type::RenderTarget:
-		case GSTexture::Type::SparseRenderTarget:
 			if (m_dev.features.slow_color_compression)
 				[desc setUsage:MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget | MTLTextureUsagePixelFormatView]; // Force color compression off by including PixelFormatView
 			else

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.h
@@ -45,7 +45,4 @@ namespace GLLoader
 	extern bool found_GL_ARB_gpu_shader5;
 	extern bool found_GL_ARB_shader_image_load_store;
 	extern bool found_GL_ARB_clear_texture;
-
-	extern bool found_compatible_GL_ARB_sparse_texture2;
-	extern bool found_compatible_sparse_depth;
 } // namespace GLLoader

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -774,7 +774,7 @@ void GSDeviceOGL::InvalidateRenderTarget(GSTexture* t)
 	{
 		OMSetFBO(m_fbo);
 
-		if (T->GetType() == GSTexture::Type::DepthStencil || T->GetType() == GSTexture::Type::SparseDepthStencil)
+		if (T->GetType() == GSTexture::Type::DepthStencil)
 		{
 			OMAttachDs(T);
 			const GLenum attachments[] = {GL_DEPTH_STENCIL_ATTACHMENT};
@@ -1192,7 +1192,6 @@ void GSDeviceOGL::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r
 	PSSetShaderResource(6, sTex);
 #endif
 
-	dTex->CommitRegion(GSVector2i(r.z, r.w));
 	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
 	ASSERT(GLExtension::Has("GL_ARB_copy_image") && glCopyImageSubData);
@@ -1242,7 +1241,6 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	BeginScene();
 
 	GL_PUSH("StretchRect from %d to %d", sTex->GetID(), dTex->GetID());
-	dTex->CommitRegion(GSVector2i((int)dRect.z + 1, (int)dRect.w + 1));
 	if (draw_in_depth)
 		OMSetRenderTargets(NULL, dTex);
 	else
@@ -1885,7 +1883,6 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	{
 		GSVector2i size = config.rt->GetSize();
 		hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::FloatColor, false);
-		hdr_rt->CommitRegion(GSVector2i(config.drawarea.z, config.drawarea.w));
 		OMSetRenderTargets(hdr_rt, config.ds, &config.scissor);
 
 		// save blend state, since BlitRect destroys it

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -377,9 +377,6 @@ public:
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = NULL);
 	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector());
 
-	bool HasColorSparse() final { return GLLoader::found_compatible_GL_ARB_sparse_texture2; }
-	bool HasDepthSparse() final { return GLLoader::found_compatible_sparse_depth; }
-
 	bool CreateTextureFX();
 	std::string GetShaderSource(const std::string_view& entry, GLenum type, const std::string_view& common_header, const std::string_view& glsl_h_code, const std::string_view& macro_sel);
 	std::string GenGlslHeader(const std::string_view& entry, GLenum type, const std::string_view& macro);

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
@@ -54,9 +54,6 @@ private:
 	GLenum m_int_type;
 	u32 m_int_shift;
 
-	// Allow to track size of allocated memory
-	u32 m_mem_usage;
-
 public:
 	explicit GSTextureOGL(Type type, int width, int height, int levels, Format format, GLuint fbo_read);
 	virtual ~GSTextureOGL();
@@ -71,7 +68,6 @@ public:
 	void Swap(GSTexture* tex) final;
 
 	GSMap Read(const GSVector4i& r, AlignedBuffer<u8, 32>& buffer);
-	bool IsDepth() { return (m_type == Type::DepthStencil || m_type == Type::SparseDepthStencil); }
 	bool IsIntegerFormat() const
 	{
 		return (m_int_format == GL_RED_INTEGER || m_int_format == GL_RGBA_INTEGER);
@@ -88,8 +84,4 @@ public:
 
 	void Clear(const void* data);
 	void Clear(const void* data, const GSVector4i& area);
-
-	void CommitPages(const GSVector2i& region, bool commit) final;
-
-	u32 GetMemUsage() final;
 };

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -405,8 +405,7 @@ VkFormat GSDeviceVK::LookupNativeFormat(GSTexture::Format format) const
 
 GSTexture* GSDeviceVK::CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format)
 {
-	pxAssert(type != GSTexture::Type::Offscreen && type != GSTexture::Type::SparseRenderTarget &&
-			 type != GSTexture::Type::SparseDepthStencil);
+	pxAssert(type != GSTexture::Type::Offscreen);
 
 	const u32 clamped_width = static_cast<u32>(std::clamp<int>(1, width, g_vulkan_context->GetMaxImageDimension2D()));
 	const u32 clamped_height = static_cast<u32>(std::clamp<int>(1, height, g_vulkan_context->GetMaxImageDimension2D()));

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -172,9 +172,6 @@ const char* dialog_message(int ID, bool* updateText)
 			return cvtString("Allows advanced atomic operations to speed up Accurate DATE.\n"
 				"Only disable this if using Accurate DATE causes (GPU driver) issues.\n\n"
 				"Note: This option is only supported by GPUs which support at least Direct3D 11.");
-		case IDC_SPARSE_TEXTURE:
-			return cvtString("Allows to reduce VRAM usage on the GPU.\n\n"
-				"Note: Feature is currently experimental and works only on Nvidia GPUs.");
 		case IDC_LINEAR_PRESENT:
 			return cvtString("Use bilinear filtering when Upscaling/Downscaling the image to the screen. Disable it if you want a sharper/pixelated output.");
 		// Exclusive for Hardware Renderer

--- a/pcsx2/GS/Window/GSSetting.h
+++ b/pcsx2/GS/Window/GSSetting.h
@@ -89,7 +89,6 @@ enum
 	// OpenGL Advanced Settings
 	IDC_GEOMETRY_SHADER_OVERRIDE,
 	IDC_IMAGE_LOAD_STORE,
-	IDC_SPARSE_TEXTURE,
 	// On-screen Display
 	IDC_OSD_LOG,
 	IDC_OSD_MONITOR,

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -588,7 +588,6 @@ DebugTab::DebugTab(wxWindow* parent)
 	m_ui.addComboBoxAndLabel(ogl_grid, "Texture Barriers:", "OverrideTextureBarriers",                 &theApp.m_gs_generic_list, -1,                           vk_ogl_hw_prereq);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Geometry Shader:",  "OverrideGeometryShaders",                 &theApp.m_gs_generic_list, IDC_GEOMETRY_SHADER_OVERRIDE, vk_ogl_hw_prereq);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Image Load Store:", "override_GL_ARB_shader_image_load_store", &theApp.m_gs_generic_list, IDC_IMAGE_LOAD_STORE,         ogl_hw_prereq);
-	m_ui.addComboBoxAndLabel(ogl_grid, "Sparse Texture:",   "override_GL_ARB_sparse_texture",          &theApp.m_gs_generic_list, IDC_SPARSE_TEXTURE,           ogl_hw_prereq);
 	m_ui.addComboBoxAndLabel(ogl_grid, "Dump Compression:", "GSDumpCompression",                       &theApp.m_gs_dump_compression, -1);
 	ogl_box->Add(ogl_grid);
 


### PR DESCRIPTION
### Description of Changes

Gets rid of the remnants of sparse texture in both common GS code and OpenGL.

Dependent on #6659.

### Rationale behind Changes

Only worked on a limited number of drivers, not reliable, and not necessary now that we're reducing target sizes, which works better anyway.

### Suggested Testing Steps

Make sure all renderers still work.

