### PR TITLE
Qt: Change cycle skipping text

### DIFF
--- a/pcsx2-qt/Settings/SystemSettingsWidget.ui
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.ui
@@ -89,7 +89,7 @@
        <widget class="QComboBox" name="eeCycleSkipping">
         <item>
          <property name="text">
-          <string>Normal</string>
+          <string>None</string>
          </property>
         </item>
         <item>


### PR DESCRIPTION
### Description of Changes
Changes the cycle skipping default level text from "Normal" to "None".

### Rationale behind Changes
Hopefully causes less confusion for users who might think cycle skipping is enabled when it's actually disabled.

### Suggested Testing Steps
Make sure CI is happy.
