### PR TITLE
GameDB: Ridge Racer V upscaling fixes.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2599,6 +2599,9 @@ SCES-50000:
   gsHWFixes:
     cpuFramebufferConversion: 1
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
+    roundSprite: 1 # Fixes ui and hud alignment.
+    texturePreloading: 0 # Disabling for major speedup.
 SCES-50001:
   name: "Tekken Tag Tournament"
   region: "PAL-M5"
@@ -23093,6 +23096,9 @@ SLPM-60109:
   gsHWFixes:
     cpuFramebufferConversion: 1
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
+    roundSprite: 1 # Fixes ui and hud alignment.
+    texturePreloading: 0 # Disabling for major speedup.
 SLPM-60123:
   name: "Gekikuukan Pro Baseball - The End of the Century 1999 [Trial]"
   region: "NTSC-J"
@@ -32804,6 +32810,9 @@ SLPS-20001:
   gsHWFixes:
     cpuFramebufferConversion: 1
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
+    roundSprite: 1 # Fixes ui and hud alignment.
+    texturePreloading: 0 # Disabling for major speedup.
 SLPS-20002:
   name: "Doukyu Billiards"
   region: "NTSC-J"
@@ -37961,6 +37970,9 @@ SLUS-20002:
   gsHWFixes:
     cpuFramebufferConversion: 1
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes title screen and some intro post processing alignment.
+    roundSprite: 1 # Fixes ui and hud alignment.
+    texturePreloading: 0 # Disabling for major speedup.
 SLUS-20003:
   name: "Portal Runner"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Add upscaling fixes for Ridge Racer V. Fixes most hud and ui alignment issues while upscaling. Also removes the grid effect on the intro. The weird color aliasing is still there though.

### Rationale behind Changes
There are multiple hud and ui alignment issues while upscaling. They can be mostly mitigated with upscaling hacks. Lets add them to the db. Examples running at x4 below:

Before:
![gs_20220728180135_Ridge Racer V_SLUS-20002](https://user-images.githubusercontent.com/8155719/181629906-65ee90ec-4a8a-4365-8076-052d0ce43001.png)

After:
![gs_20220728180129_Ridge Racer V_SLUS-20002](https://user-images.githubusercontent.com/8155719/181629942-feac97fa-c92b-471c-b569-184d6c29d094.png)

Before:
![gs_20220728180206_Ridge Racer V_SLUS-20002](https://user-images.githubusercontent.com/8155719/181629977-1f8add41-a586-47a9-ad7a-6504225b0a33.png)

After:
![gs_20220728180211_Ridge Racer V_SLUS-20002](https://user-images.githubusercontent.com/8155719/181630011-0706fc3b-e08f-4c1b-b180-27b035050ede.png)


Before:
![gs_20220728180149_Ridge Racer V_SLUS-20002](https://user-images.githubusercontent.com/8155719/181630420-4a44b08c-fecc-4a76-a3a5-f64458fb5951.png)

After:
![gs_20220728180152_Ridge Racer V_SLUS-20002](https://user-images.githubusercontent.com/8155719/181630453-82ecebc5-d867-4e81-9ba8-3453f31e6f89.png)

### Suggested Testing Steps
Tested against the US version with good results. Probaly needs verification on the PAL and JP releases.
