### PR TITLE
GS: Rearrange GS Dump names to be less annoying to navigate

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -762,6 +762,23 @@ void GSRenderer::QueueSnapshot(const std::string& path, u32 gsdump_frames)
 	}
 	else
 	{
+		m_snapshot = "";
+
+		// append the game serial and title
+		if (std::string name(GetDumpName()); !name.empty())
+		{
+			Path::SanitizeFileName(name);
+			if (name.length() > 219)
+				name.resize(219);
+			m_snapshot += name;
+		}
+		if (std::string serial(GetDumpSerial()); !serial.empty())
+		{
+			Path::SanitizeFileName(serial);
+			m_snapshot += '_';
+			m_snapshot += serial;
+		}
+
 		time_t cur_time = time(nullptr);
 		char local_time[16];
 
@@ -774,28 +791,16 @@ void GSRenderer::QueueSnapshot(const std::string& path, u32 gsdump_frames)
 			// the captured image is the 2nd image captured at this specific time.
 			static int n = 2;
 
+			m_snapshot += '_';
+
 			if (cur_time == prev_snap)
-				m_snapshot = fmt::format("gs_{0}_({1})", local_time, n++);
+				m_snapshot += fmt::format("{0}_({1})", local_time, n++);
 			else
 			{
 				n = 2;
-				m_snapshot = fmt::format("gs_{}", local_time);
+				m_snapshot += fmt::format("{}", local_time);
 			}
 			prev_snap = cur_time;
-		}
-
-		// append the game serial and title
-		if (std::string name(GetDumpName()); !name.empty())
-		{
-			Path::SanitizeFileName(name);
-			m_snapshot += '_';
-			m_snapshot += name;
-		}
-		if (std::string serial(GetDumpSerial()); !serial.empty())
-		{
-			Path::SanitizeFileName(serial);
-			m_snapshot += '_';
-			m_snapshot += serial;
 		}
 
 		// prepend snapshots directory


### PR DESCRIPTION
### Description of Changes
Rearranges gs dump names so they are in order by their name and not gs_123453245234234 for everything

### Rationale behind Changes
Previous method (shown above) was a nightmare to find what you want when you have a lot of gsdumps, this makes it suck less, you know the Silent Hill dumps are gonna be at S, etc.

### Suggested Testing Steps
Make some dumps, rest in comfort of the beautiful naming.

![image](https://user-images.githubusercontent.com/6278726/181872608-f99f2bf8-d11e-4c6f-be16-59114c21f247.png)

