### PR TITLE
PAD: Fix dualshock lights for more than one controller attached

### DIFF
--- a/pcsx2/PAD/Windows/DualShock3.cpp
+++ b/pcsx2/PAD/Windows/DualShock3.cpp
@@ -281,7 +281,7 @@ public:
 		memset(&writeop, 0, sizeof(writeop));
 		memset(&sendState, 0, sizeof(sendState));
 		sendState.id = 1;
-		int temp = (index & 4);
+		int temp = (index | 4);
 		sendState.lightFlags = (1 << (temp + 1));
 		sendState.lights[3 - temp].duration = 0xFF;
 		sendState.lights[3 - temp].dunno[0] = 1;


### PR DESCRIPTION
Codacy warnings fixed

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Currently only first controller correctly handles lights, this pr fixes it

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
