### PR TITLE
GS: Don't double res on No-Interlace patch when interlaced

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -482,7 +482,7 @@ GSVector2i GSState::GetResolution()
 	// The resolution of the framebuffer is double when in FRAME mode and interlaced.
 	// Also we need a special check because no-interlace patches like to render in the original height, but in non-interlaced mode
 	// which means it would normally go off the bottom of the screen. Advantages of emulation, i guess... Limited to Ignore Offsets + Deinterlacing = Off.
-	if ((isinterlaced() && !m_regs->SMODE2.FFMD) || (GSConfig.InterlaceMode == GSInterlaceMode::Off && !GSConfig.PCRTCOffsets))
+	if ((isinterlaced() && !m_regs->SMODE2.FFMD) || (GSConfig.InterlaceMode == GSInterlaceMode::Off && !GSConfig.PCRTCOffsets && !isinterlaced()))
 		resolution.y *= 2;
 
 	if (ignore_offset)


### PR DESCRIPTION
### Description of Changes
Fixes no interlace patch annoyingness

### Rationale behind Changes
No interlace patches are annoying and I hate them. But *sometimes* they still leave it interlaced and it didn't like that, we always assumed it was not interlaced.

### Suggested Testing Steps
Test no-interlace patches to make sure they don't half height/double height anymore.

Fixes #6751
Also fixes Rocky Legends menu flickering if you put interlace mode to "none"