### PR TITLE
FindMinMax fixes

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -27,9 +27,7 @@ GSVertexTrace::GSVertexTrace(const GSState* state, bool provoking_vertex_first)
 	memset(&m_alpha, 0, sizeof(m_alpha));
 
 	#define InitUpdate3(P, IIP, TME, FST, COLOR) \
-	m_fmm[COLOR][FST][TME][IIP][P] = \
-		provoking_vertex_first ? &GSVertexTrace::FindMinMax<P, IIP, TME, FST, COLOR, true> : \
-                                 &GSVertexTrace::FindMinMax<P, IIP, TME, FST, COLOR, false>;
+		m_fmm[COLOR][FST][TME][IIP][P] = GetFMM<P, IIP, TME, FST, COLOR>(provoking_vertex_first);
 
 	#define InitUpdate2(P, IIP, TME) \
 		InitUpdate3(P, IIP, TME, 0, 0) \
@@ -151,6 +149,19 @@ void GSVertexTrace::Update(const void* vertex, const u32* index, int v_count, in
 				break;
 		}
 	}
+}
+
+template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color>
+GSVertexTrace::FindMinMaxPtr GSVertexTrace::GetFMM(bool provoking_vertex_first)
+{
+	constexpr bool real_fst = tme ? fst : false;
+	constexpr bool provoking_vertex_first_class = primclass == GS_LINE_CLASS || primclass == GS_TRIANGLE_CLASS;
+	const bool swap = provoking_vertex_first_class && !iip && provoking_vertex_first;
+
+	if (swap)
+		return &GSVertexTrace::FindMinMax<primclass, iip, tme, real_fst, color, true>;
+	else
+		return &GSVertexTrace::FindMinMax<primclass, iip, tme, real_fst, color, false>;
 }
 
 template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color, bool flat_swapped>

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -211,8 +211,9 @@ void GSVertexTrace::FindMinMax(const void* vertex, const u32* index, int count)
 			{
 				// For even n, we process v1 and v2 of the same prim
 				// (For odd n, we process one vertex from each of two prims)
-				cmin = cmin.min_u8(c1);
-				cmax = cmax.max_u8(c1);
+				GSVector4i c = flat_swapped ? c0 : c1;
+				cmin = cmin.min_u8(c);
+				cmax = cmax.max_u8(c);
 			}
 		}
 
@@ -302,10 +303,20 @@ void GSVertexTrace::FindMinMax(const void* vertex, const u32* index, int count)
 		}
 		if (count & 1)
 		{
-			processVertices(v[index[i + 0]], v[index[i + 1]], flat_swapped);
-			// Compiler optimizations go!
-			// (And if they don't, it's only one vertex out of many)
-			processVertices(v[index[i + 2]], v[index[i + 2]], !flat_swapped);
+			if (flat_swapped)
+			{
+				processVertices(v[index[i + 1]], v[index[i + 2]], false);
+				// Compiler optimizations go!
+				// (And if they don't, it's only one vertex out of many)
+				processVertices(v[index[i + 0]], v[index[i + 0]], true);
+			}
+			else
+			{
+				processVertices(v[index[i + 0]], v[index[i + 1]], false);
+				// Compiler optimizations go!
+				// (And if they don't, it's only one vertex out of many)
+				processVertices(v[index[i + 2]], v[index[i + 2]], true);
+			}
 		}
 	}
 	else

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -154,14 +154,15 @@ void GSVertexTrace::Update(const void* vertex, const u32* index, int v_count, in
 template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color>
 GSVertexTrace::FindMinMaxPtr GSVertexTrace::GetFMM(bool provoking_vertex_first)
 {
+	constexpr bool real_iip = primclass == GS_SPRITE_CLASS ? false : iip;
 	constexpr bool real_fst = tme ? fst : false;
 	constexpr bool provoking_vertex_first_class = primclass == GS_LINE_CLASS || primclass == GS_TRIANGLE_CLASS;
 	const bool swap = provoking_vertex_first_class && !iip && provoking_vertex_first;
 
 	if (swap)
-		return &GSVertexTrace::FindMinMax<primclass, iip, tme, real_fst, color, true>;
+		return &GSVertexTrace::FindMinMax<primclass, real_iip, tme, real_fst, color, true>;
 	else
-		return &GSVertexTrace::FindMinMax<primclass, iip, tme, real_fst, color, false>;
+		return &GSVertexTrace::FindMinMax<primclass, real_iip, tme, real_fst, color, false>;
 }
 
 template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color, bool flat_swapped>
@@ -260,12 +261,12 @@ void GSVertexTrace::FindMinMax(const void* vertex, const u32* index, int count)
 		GSVector4i xyzf1(v1.m[1]);
 
 		GSVector4i xy0 = xyzf0.upl16();
-		GSVector4i z0 = xyzf0.yyyy();
+		GSVector4i zf0 = xyzf0.ywyw();
 		GSVector4i xy1 = xyzf1.upl16();
-		GSVector4i z1 = xyzf1.yyyy();
+		GSVector4i zf1 = xyzf1.ywyw();
 
-		GSVector4i p0 = xy0.blend16<0xf0>(z0.uph32(primclass == GS_SPRITE_CLASS ? xyzf1 : xyzf0));
-		GSVector4i p1 = xy1.blend16<0xf0>(z1.uph32(xyzf1));
+		GSVector4i p0 = xy0.blend32<0xc>(primclass == GS_SPRITE_CLASS ? zf1 : zf0);
+		GSVector4i p1 = xy1.blend32<0xc>(zf1);
 
 		pmin = pmin.min_u32(p0.min_u32(p1));
 		pmax = pmax.max_u32(p0.max_u32(p1));

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -51,6 +51,9 @@ protected:
 	template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color, bool provoking_vertex_first>
 	void FindMinMax(const void* vertex, const u32* index, int count);
 
+	template <GS_PRIM_CLASS primclass, u32 iip, u32 tme, u32 fst, u32 color>
+	FindMinMaxPtr GetFMM(bool provoking_vertex_first);
+
 public:
 	GS_PRIM_CLASS m_primclass;
 


### PR DESCRIPTION
### Description of Changes
- Reduces the number of different FindMinMax instantiations we use by only setting the parameters if it will make a difference
- Fixes handling of lines when `provoking_vertex_first` is set, as well as handling of the final triangle in triangle lists with odd triangle counts
- Fixes handling of FindMinMax sprites' Z and color values

### Rationale behind Changes
- Binary size (saves a whole 32kb, truly amazing)
- Minor correctness things

### Suggested Testing Steps
Make sure nothing broke