### PR TITLE
GS: Fix zequal handling in CDrawScanline

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -357,18 +357,14 @@ void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSVertex
 
 		if (sel.zb)
 		{
-			VectorF zbase = VectorF::broadcast64(&scan.p.z);
 			if (sel.zequal)
 			{
-#if _M_SSE >= 0x501
-				z0 = GSVector8::cast(GSVector8i::broadcast32(zbase.extract<0>().f64toi32()));
-#else
-				z0 = GSVector4::cast(zbase.f64toi32());
-				z0 = z0.upld(z0);
-#endif
+				u32 z = static_cast<u32>(scan.p.F64[1]);
+				z0 = VectorF::cast(VectorI(z));
 			}
 			else
 			{
+				VectorF zbase = VectorF::broadcast64(&scan.p.z);
 				z0 = zbase.add64(VectorF::f32to64(&local.d[skip].z.F32[0]));
 				z1 = zbase.add64(VectorF::f32to64(&local.d[skip].z.F32[vlen/2]));
 			}

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -109,12 +109,12 @@ union GSScanlineSelector
 			"tfx:%d tcc:%d fst:%d ltf:%d tlu:%d wms:%d wmt:%d mmin:%d lcm:%d tw:%d "
 			"fba:%d cclamp:%d date:%d datm:%d "
 			"prim:%d abe:%d %d%d%d%d fge:%d dthe:%d notest:%d pabe:%d aa1:%d "
-			"fwrite:%d ftest:%d zoverflow:%d zclamp:%d edge:%d",
+			"fwrite:%d ftest:%d zoverflow:%d zequal:%d zclamp:%d edge:%d",
 			fpsm, zpsm, ztst, ztest, atst, afail, iip, rfb, fb, zb, zwrite,
 			tfx, tcc, fst, ltf, tlu, wms, wmt, mmin, lcm, tw,
 			fba, colclamp, date, datm,
 			prim, abe, aba, abb, abc, abd, fge, dthe, notest, pabe, aa1,
-			fwrite, ftest, zoverflow, zclamp, edge);
+			fwrite, ftest, zoverflow, zequal, zclamp, edge);
 		return str;
 	}
 


### PR DESCRIPTION
### Description of Changes
Fix zequal handling in CDrawScanline to match the asm generator

### Rationale behind Changes
I somehow didn't use the same algorithm as the asm version originally.  The C version didn't work properly with zoverflow.

### Suggested Testing Steps
I haven't found any games that hit this case, but if you are going to test, make sure to disable the sw renderer JIT rasterizer or use the `USE_C_DRAW_SCANLINE=` env variable, or there'll definitely be no difference.
(If you're using the `USE_C_DRAW_SCANLINE=` env variable, you can prescan the txt file for draws with a non-3 `prim`, and `zequal:1`.  If you don't find any of those, there's almost guaranteed to be no change.  Probably no change unless there's `zoverflow:1` as well, though if the new code is buggy there could be a change otherwise.)
The closest game I've found to being affected by the buggy algorithm is KOF98, which uses zequal zoverflow sprites (sprites use a different path), and non-zequal zoverflow triangles, but no zequal zoverflow triangles. 
