### PR TITLE
GameDB: add Panzer Elite Action upscaling fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16137,6 +16137,8 @@ SLES-53444:
   region: "PAL-M5"
   gameFixes:
     - VUSyncHack # Partly fixes SPS still needs EE+3.
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom.
 SLES-53446:
   name: "Arcade USA"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
Adds Half Pixel Offset setting of Normal (Vertex) to Panzer Elite Action - Fields of Glory.

### Rationale behind Changes
HPO 1 fixes misaligned bloom when upscaling the game in hw mode.


Hardware renderer (Vulkan) without HPO
![Panzer Elite Action - Fields of Glory_SLES-53444_20220801111518](https://user-images.githubusercontent.com/2962364/182563245-4eced00d-dff2-45af-84c0-61e0f1ea4cb5.png)

Hardware renderer with HPO applied
![Panzer Elite Action - Fields of Glory_SLES-53444_20220801111540](https://user-images.githubusercontent.com/2962364/182563760-bc5df620-ff69-4e75-8e21-c198cbe64b33.png)

Software renderer for reference
![Panzer Elite Action - Fields of Glory_SLES-53444_20220801111522](https://user-images.githubusercontent.com/2962364/182563459-a3819df1-d47c-40e9-b76d-b3ceab7637d0.png)


This does **not** fix the broken 3d models for the player tank and some of the enemies.
The only known fix for this problem is to manually set EE Cycle Rate to 300%
![Panzer Elite Action - Fields of Glory_SLES-53444_20220801111552](https://user-images.githubusercontent.com/2962364/182564786-293f303c-5c2f-44fd-9039-c7d8eae19f05.png)

