### PR TITLE
MemoryCardFolder: Add write osd notification.

### DIFF
--- a/pcsx2/MemoryCardFolder.h
+++ b/pcsx2/MemoryCardFolder.h
@@ -363,6 +363,8 @@ public:
 
 	void WriteToFile(const std::string& filename);
 
+	std::string GetFolderName();
+
 protected:
 	struct EnumeratedFileEntry
 	{


### PR DESCRIPTION
### Description of Changes
Adds write osd notifications for folder based memcards.
Moved the logging point to the FolderMemoryCardAggregator class and not in the Save method like the File impl to avoid the recursion and potential message spamming in the folder impl's Save method.

### Rationale behind Changes
This was not implemeted for folder memcard so adding for parity with file based ones.

### Suggested Testing Steps
Might fall over with some kind of funky folder name but shouldn't be any less brittle than file based saves since its all going through the same string handling paths.
