### PR TITLE
GS-hw: Purge tri ace crc hacks.

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -174,18 +174,6 @@ const CRC::Game CRC::m_games[] =
 	{0xAA5EC3A3, TalesOfAbyss, JP, 0},
 	{0xFB236A46, SonicUnleashed, US, 0},
 	{0x8C913264, SonicUnleashed, EU, 0},
-	{0xE04EA200, TriAceGames, EU, 0}, // StarOcean3
-	{0x23A97857, TriAceGames, US, 0}, // StarOcean3
-	{0xBEC32D49, TriAceGames, JP, 0}, // StarOcean3
-	{0x8192A241, TriAceGames, JP, 0}, // StarOcean3 directors cut
-	{0xCC96CE93, TriAceGames, US, 0}, // ValkyrieProfile2
-	{0x774DE8E2, TriAceGames, JP, 0}, // ValkyrieProfile2
-	{0x04CCB600, TriAceGames, EU, 0}, // ValkyrieProfile2
-	{0xB65E141B, TriAceGames, DE, 0}, // ValkyrieProfile2
-	{0x8510854E, TriAceGames, FR, 0}, // ValkyrieProfile2
-	{0xC70FC973, TriAceGames, IT, 0}, // ValkyrieProfile2
-	{0x47B9B2FD, TriAceGames, US, 0}, // RadiataStories
-	{0xAC73005E, TriAceGames, JP, 0}, // RadiataStories
 	{0xE8FCF8EC, SMTNocturne, US, 0},
 	{0xF0A31EE3, SMTNocturne, EU, 0}, // SMTNocturne (Lucifers Call in EU)
 	{0xAE0DE7B7, SMTNocturne, EU, 0}, // SMTNocturne (Lucifers Call in EU)

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -77,7 +77,6 @@ public:
 		TombRaiderAnniversary,
 		TombRaiderLegend,
 		TombRaiderUnderworld,
-		TriAceGames,
 		UltramanFightingEvolution,
 		UrbanReign,
 		XenosagaE3,

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -710,41 +710,6 @@ bool GSC_GetawayGames(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
-bool GSC_TriAceGames(const GSFrameInfo& fi, int& skip)
-{
-	// Tri Ace Games: ValkyrieProfile2, RadiataStories, StarOcean3
-	//
-	// The games emulate a stencil buffer with the alpha channel of the RT
-	// The operation of the stencil is selected with the palette
-	// For example -1 wrap will be [240, 16, 32, 48 ....]
-	// i.e. p[A>>4] = (A - 16) % 256
-	//
-	// The fastest and accurate solution will be to replace this pseudo stencil
-	// by a dedicated GPU draw call
-	// 1/ Use future GPU capabilities to do a "kind" of SW blending
-	// 2/ Use a real stencil/atomic image, and then compute the RT alpha value
-	//
-	// Both of those solutions will increase code complexity (and only avoid upscaling
-	// glitches)
-
-	if (skip == 0)
-	{
-		if (fi.TME && fi.FBP == fi.TBP0 && fi.FPSM == PSM_PSMCT32 && fi.TPSM == PSM_PSMT4HH)
-		{
-			skip = 1000;
-		}
-	}
-	else
-	{
-		if (!(fi.TME && fi.FBP == fi.TBP0 && fi.FPSM == PSM_PSMCT32 && fi.TPSM == PSM_PSMT4HH))
-		{
-			skip = 0;
-		}
-	}
-
-	return true;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Aggressive only hack
 ////////////////////////////////////////////////////////////////////////////////
@@ -941,11 +906,6 @@ void GSState::SetupCrcHack()
 	{
 		// Accurate Blending
 		lut[CRC::GetawayGames] = GSC_GetawayGames; // Blending High
-
-		// These games emulate a stencil buffer with the alpha channel of the RT (too slow to move to CRC_Aggressive)
-		// Needs at least Basic Blending,
-		// see https://github.com/PCSX2/pcsx2/pull/2921
-		lut[CRC::TriAceGames] = GSC_TriAceGames;
 	}
 
 	if (CRC_Aggressive)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Purge tri ace crc hacks.

Star Ocean 3, Valkyrie Profile 2, Radiata Stories.

The crc hacks aren't that needed anymore since right now D3D is much faster than it used to be.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Not as needed anymore on dx, rendering has been improved that it's much faster now.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the mentioned games.


Note: Slight issue with Star Ocean 3, shadows don't upscale as good, maybe it can be improved.