### PR TITLE
GS-metal: Move PABE shader bit to the top of sw blending.

### DIFF
--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -725,6 +725,13 @@ struct PSMain
 	{
 		if (SW_BLEND)
 		{
+			// PABE
+			if (PS_PABE)
+			{
+				// No blending so early exit
+				if (As < 1.0f)
+					return;
+			}
 
 			float Ad = PS_DFMT == FMT_24 ? 1.f : trunc(current_color.a * 255.5f) / 128.f;
 
@@ -743,9 +750,6 @@ struct PSMain
 				Color.rgb = D;
 			else
 				Color.rgb = trunc((A - B) * C + D);
-
-			if (PS_PABE)
-				Color.rgb = (As >= 1.f) ? Color.rgb : Cs;
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-metal: Move PABE shader bit to the top of sw blending.

Early return when there is no sw blending, no need to run the blend code.
Optimization.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Follow up from #5284 , wasn't ported to metal.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
PABE still works, test games that use pabe.