### PR TITLE
GS-hw: Adjust how we handle specific blend mix cases.

### DIFF
--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -689,7 +689,7 @@ void ps_color_clamp_wrap(inout vec3 C)
 #endif
 }
 
-void ps_blend(inout vec4 Color, float As)
+void ps_blend(inout vec4 Color, inout float As)
 {
 #if SW_BLEND
 
@@ -754,14 +754,30 @@ void ps_blend(inout vec4 Color, float As)
 #endif
 
     // As/Af clamp alpha for Blend mix
-#if PS_BLEND_MIX
-    C = min(C, float(1.0f));
+    // We shouldn't clamp blend mix with clr1 as we want alpha higher
+#if PS_BLEND_MIX && PS_CLR_HW != 1
+    C = min(C, 1.0f);
 #endif
 
 #if PS_BLEND_A == PS_BLEND_B
     Color.rgb = D;
 #else
     Color.rgb = trunc((A - B) * C + D);
+#endif
+
+#if PS_CLR_HW == 1
+    // Replace Af with As so we can do proper compensation for Alpha.
+#if PS_BLEND_C == 2
+    As = Af;
+#endif
+    // Subtract 1 for alpha to compensate for the changed equation,
+    // if c.rgb > 255.0f then we further need to adjust alpha accordingly,
+    // we pick the lowest overflow from all colors because it's the safest,
+    // we divide by 255 the color because we don't know Cd value,
+    // changed alpha should only be done for hw blend.
+    float min_color = min(min(Color.r, Color.g), Color.b);
+    float alpha_compensate = max(1.0f, min_color / 255.0f);
+    As -= alpha_compensate;
 #endif
 
 #else

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -721,7 +721,7 @@ struct PSMain
 		return selector == 0 ? zero : selector == 1 ? one : two;
 	}
 
-	void ps_blend(thread float4& Color, float As)
+	void ps_blend(thread float4& Color, thread float& As)
 	{
 		if (SW_BLEND)
 		{
@@ -729,7 +729,7 @@ struct PSMain
 			if (PS_PABE)
 			{
 				// No blending so early exit
-				if (As < 1.0f)
+				if (As < 1.f)
 					return;
 			}
 
@@ -743,13 +743,30 @@ struct PSMain
 			float  C = pick(PS_BLEND_C, As, Ad, cb.alpha_fix);
 			float3 D = pick(PS_BLEND_D, Cs, Cd, float3(0.f));
 
-			if (PS_BLEND_MIX)
+			// As/Af clamp alpha for Blend mix
+			// We shouldn't clamp blend mix with clr1 as we want alpha higher
+			if (PS_BLEND_MIX && PS_CLR_HW != 1)
 				C = min(C, 1.f);
 
 			if (PS_BLEND_A == PS_BLEND_B)
 				Color.rgb = D;
 			else
 				Color.rgb = trunc((A - B) * C + D);
+
+			if (PS_CLR_HW == 1)
+			{
+				// Replace Af with As so we can do proper compensation for Alpha.
+				if (PS_BLEND_C == 2)
+					As = cb.alpha_fix;
+				// Subtract 1 for alpha to compensate for the changed equation,
+				// if c.rgb > 255.0f then we further need to adjust alpha accordingly,
+				// we pick the lowest overflow from all colors because it's the safest,
+				// we divide by 255 the color because we don't know Cd value,
+				// changed alpha should only be done for hw blend.
+				float min_color = min(min(Color.r, Color.g), Color.b);
+				float alpha_compensate = max(1.f, min_color / 255.f);
+				As -= alpha_compensate;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
```
GS-hw: Adjust how we handle specific blend mix cases. 
1ec20dd
Replace Cs*As + Cd*(1 - As) with Cs*As - Cd*(As - 1).
Replace Cs*F + Cd*(1 - F) with Cs*F - Cd*(F - 1).
As - 1 or F - 1 subtraction is only done for the dual source output (hw blending part)
since we are changing the equation.
Af will be replaced with As in shader and send it to dual source output.

Also check if A*Alpha in the shader overflows, if it does then adjust the
alpha that is sent for HW blending further to compensate.
```
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better accuracy.
Helps #6755
Fixes #5315
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test various games, you will see logs in the console if the code is triggered.

The method isn't perfect but it's much better than it was before.