### PR TITLE
GS/HW: Clamp draw rect to unscaled, not scaled coordinates

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -186,7 +186,7 @@ public:
 	void MergeSprite(GSTextureCache::Source* tex);
 	GSVector2 GetTextureScaleFactor() override;
 	GSVector2i GetOutputSize(int real_h);
-	GSVector2i GetTargetSize();
+	GSVector2i GetTargetSize(GSVector2i* unscaled_size = nullptr);
 
 	void Reset(bool hardware_reset) override;
 	void UpdateSettings(const Pcsx2Config::GSOptions& old_config) override;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2548,6 +2548,9 @@ void GSTextureCache::Target::UpdateValidity(const GSVector4i& rect)
 		m_valid = m_valid.runion(rect);
 
 	// Block of the bottom right texel of the validity rectangle, last valid block of the texture
+	// TODO: This is not correct when the PSM changes. e.g. a 512x448 target being shuffled will become 512x896 temporarily, and
+	// at the moment, we blow the valid rect out to twice the size. The only thing stopping everything breaking is the fact
+	// that we clamp the draw rect to the target size in GSRendererHW::Draw().
 	m_end_block = GSLocalMemory::m_psm[m_TEX0.PSM].info.bn(m_valid.z - 1, m_valid.w - 1, m_TEX0.TBP0, m_TEX0.TBW); // Valid only for color formats
 
 	// GL_CACHE("UpdateValidity (0x%x->0x%x) from R:%d,%d Valid: %d,%d", m_TEX0.TBP0, m_end_block, rect.z, rect.w, m_valid.z, m_valid.w);


### PR DESCRIPTION
### Description of Changes

Target rect clamping was working in scaled instead of unscaled coordinates, which meant that the shuffle draw got left as 64x896, blowing out the end block, causing the temporary buffers to get cleared in Haunting Ground's crc hack.

Which exposed an underlying issue, quote from the source:
```
	// TODO: This is not correct when the PSM changes. e.g. a 512x448 target being shuffled will become 512x896 temporarily, and
	// at the moment, we blow the valid rect out to twice the size. The only thing stopping everything breaking is the fact
	// that we clamp the draw rect to the target size in GSRendererHW::Draw().
```

### Rationale behind Changes

Fixes broken shuffle effect in Haunting Ground when upscale is set above 1x.

### Suggested Testing Steps

Test Haunting Ground and a few random shuffles to make sure nothing broke. Should be reasonably safe I think, and only affect > 1x.