### PR TITLE
GS-hw: Don't disable second output on blend mix when using constant factor.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2713,6 +2713,9 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 			// For mixed blend, the source blend is done in the shader (so we use CONST_ONE as a factor).
 			m_conf.blend = {true, GSDevice::CONST_ONE, blend.dst, blend.op, m_conf.ps.blend_c == 2, ALPHA.FIX};
 			m_conf.ps.blend_mix = 1;
+			
+			// Elide DSB colour output if not used by dest.
+			m_conf.ps.no_color1 |= !GSDevice::IsDualSourceBlendFactor(blend.dst);
 
 			if (blend_mix1)
 			{
@@ -2726,6 +2729,8 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 					// clr_hw 1 will disable alpha clamp, we can reuse the old bits.
 					m_conf.ps.clr_hw = 1;
 					//m_conf.ps.blend_mix = 0;
+					// DSB output will always be used.
+					m_conf.ps.no_color1 = false;
 				}
 
 				m_conf.ps.blend_a = 0;
@@ -2752,9 +2757,6 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 				// Swap Ad with As for hw blend
 				m_conf.ps.clr_hw = 6;
 			}
-
-			// Elide DSB colour output if not used by dest.
-			m_conf.ps.no_color1 |= !GSDevice::IsDualSourceBlendFactor(blend.dst);
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Don't disable second output on blend mix when using constant factor.

We don't want to disable second output when using blend mix1 above 1.0f Af.
Reason is we change Af to As and later output it on second output for hw blending.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix from #6784
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
So far only affects Fatal Frame 3.