### PR TITLE
Qt: Force helpText size to avoid overflow at default window size

### DIFF
--- a/pcsx2-qt/Settings/SettingsDialog.ui
+++ b/pcsx2-qt/Settings/SettingsDialog.ui
@@ -66,7 +66,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>100</height>
+       <height>120</height>
       </size>
      </property>
      <property name="maximumSize">


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Increase minimum size of helpText to match max so that "Adjust to Host Refresh Rate" doesn't overflow it's help text and create a scrollbar at minimum settings window height.

Master - Settings window minimum (default) height:
![OG](https://user-images.githubusercontent.com/11966090/183477095-09abe41b-c583-4a19-8c55-9452b383b9c3.jpg)

Master - Required height to avoid scrollbar:
![OG 2](https://user-images.githubusercontent.com/11966090/183476890-d9f73fbe-cf33-40b9-9983-c1d17192798b.jpg)

PR - Settings window minimum (default) height:
![Fixed](https://user-images.githubusercontent.com/11966090/183476913-19532e3e-8b82-4d87-adc2-aa5c1ab5aa7f.jpg)


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Resizing height by 20 pixels is a bit pointless with the amount of unused space at the minimum window size and leads to "Adjust to Host Refresh Rate" having it's help text overflow and create a scrollbar that cannot be interacted with.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Open settings window, make sure it is set to the minimum height and mouse over the "Adjust to Host Refresh Rate" option and observe help text.