### PR TITLE
GS: Add slow path for odd width 4bpp host->local transfers

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -815,8 +815,8 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const u8* src, int len, GIFRegB
 	if (TRXREG.RRW == 0)
 		return;
 
-	int l = (int)TRXPOS.DSAX;
-	int r = l + (int)TRXREG.RRW;
+	const int l = (int)TRXPOS.DSAX;
+	const int r = l + (int)TRXREG.RRW;
 
 	// finish the incomplete row first
 
@@ -828,11 +828,31 @@ void GSLocalMemory::WriteImage(int& tx, int& ty, const u8* src, int len, GIFRegB
 		len -= n;
 	}
 
-	int la = (l + (bsx - 1)) & ~(bsx - 1);
-	int ra = r & ~(bsx - 1);
+	const int la = (l + (bsx - 1)) & ~(bsx - 1);
+	const int ra = r & ~(bsx - 1);
 	// Round up to the nearest byte (NFL 2K5 does r = 1, l = 0 bpp =4, causing divide by zero)
-	int srcpitch = (((r - l) * trbpp) + 7) >> 3;
+	const int srcpitch = (((r - l) * trbpp) + 7) >> 3;
 	int h = len / srcpitch;
+
+	// Slow path for odd width 4bpp, the fast path expects everything to be perfectly aligned and great,
+	// but things get hairy with 4bpp pixels and odd widths since the lowest size we can address is 8bits, it goes out of sync.
+	// Although I call this a slow path, it's probably faster than modifying the data alignment every other line.
+	// GT3 demo, Jak 2 Japanese subtitles, and the BG Dark Alliance minimap do this.
+	if (trbpp == 4 && (TRXREG.RRW & 0x1))
+	{
+		int count = 0;
+		const int t = TRXPOS.DSAY;
+		const int b = t + (int)TRXREG.RRH;
+		for (int y = t; y < b; y++)
+		{
+			for (int x = l; x < r; x++)
+			{
+				WritePixel4(x, y, src[count >> 1] >> ((count & 1) << 2), BITBLTBUF.DBP, BITBLTBUF.DBW);
+				count++;
+			}
+		}
+		return;
+	}
 
 	if (ra - la >= bsx && h > 0) // "transfer width" >= "block width" && there is at least one full row
 	{


### PR DESCRIPTION
### Description of Changes
Adds a slow transfer path for 4BPP transfers which are misaligned,

### Rationale behind Changes
The transfer systems in place in PCSX2 are designed to be fast, but work on aligned data. The main problem being, with 4bpp transfers, the smallest we can represent in C++ is 8bits, so each 8bit contains 2 pixels, so when the transfer width is an odd number, that means the end of a line and the start of the next are contained in the same 8bits, and this means the fast path will throw the order out, causing the data to drift.

This PR adds a slow path which does the transfer pixel by pixel, but only when the widths are misaligned, since it's faster the other way, if we can.

### Suggested Testing Steps
If you know any games with weirdly misshapen textures (kinda like a rhombus), then this will probably fix it.

Known to fix the GT3 Demo. Fixes #3228
Fixes Jak 2 Renegate Japanese subtitles. Fixes #6581
Fixes Baldur's Gate: Dark Alliance messed up minimap.