### PR TITLE
GS: Improve autoflush detection.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2863,6 +2863,10 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap()
 
 __forceinline void GSState::HandleAutoFlush()
 {
+	// Kind of a cheat, making the assumption that 2 consecutive fan/strip triangles won't overlap each other (*should* be safe)
+	if ((m_index.tail & 1) && (PRIM->PRIM == GS_TRIANGLESTRIP || PRIM->PRIM == GS_TRIANGLEFAN))
+		return;
+
 	const u32 frame_mask = GSLocalMemory::m_psm[m_context->TEX0.PSM].fmsk;
 	const bool frame_hit = (m_context->FRAME.Block() == m_context->TEX0.TBP0) && !(m_context->TEST.ATE && m_context->TEST.ATST == 0 && m_context->TEST.AFAIL == 2) && ((m_context->FRAME.FBMSK & frame_mask) != frame_mask);
 	// There's a strange behaviour we need to test on a PS2 here, if the FRAME is a Z format, like Powerdrome something swaps over, and it seems Alpha Fail of "FB Only" writes to the Z.. it's odd.

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1879,6 +1879,20 @@ void GSState::FlushPrim()
 
 			m_vertex.tail = unused;
 			m_vertex.next = next > head ? next - head : 0;
+
+			// If it's a Triangle fan the XY buffer needs to be updated to point to the correct head vert
+			// Jak 3 shadows get spikey (with autoflush) if you don't.
+			if (PRIM->PRIM == GS_TRIANGLEFAN)
+			{
+				for (int i = 0; i < unused; i++)
+				{
+					GSVector4i* RESTRICT vert_ptr = (GSVector4i*)&m_vertex.buff[i];
+					GSVector4i v = vert_ptr[1];
+					v = v.xxxx().u16to32().sub32(m_ofxy);
+					GSVector4i::storel(&m_vertex.xy[i & 3], v.blend16<0xf0>(v.sra32(4)).ps32());
+					m_vertex.xy_tail = unused;
+				}
+			}
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
Improves autoflush detection and fixes a bug with splitting Triangle Fan draws.

### Rationale behind Changes
Old method didn't work properly for triangle fans, overall system needed improving to check rect by rect to avoid false hits by games drawing in a L shape.  

Also there was a bug where we save the last few verts if a flush happens, but because triangle fans rely on the first vert to always be there, the xy buffer (used to calculate skips etc) had incorrect information, causing it to falsely skip draws.

### Suggested Testing Steps
Test games, especially those with Autoflush.

Performance is a mixed bag, Jak 2 in a heavy autoflush spot is about 12% slower, Burnout 3 is about 10% faster (in a GS Dump), and some other games vary slightly in terms of number of draw calls.

Edit: Performance loss in Jak 2 has been mitigated (and increased over master) with [GS: Add shortcut for Autoflush on Tri-Strip/Fan](https://github.com/PCSX2/pcsx2/pull/6825/commits/b9ed7b5773a3a53f68d8125db9e1ec84bcf76f8b) .  It *should* be safe enough.