### PR TITLE
GameDB: Fix typos in game names

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -22796,7 +22796,7 @@ SLPM-55040:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3"
   region: "NTSC-J"
 SLPM-55042:
-  name: "Suika A.S Eternal Name  - Sweet So Sweet [Best Edition]"
+  name: "Suika A.S+ Eternal Name - Sweet So Sweet [Best Edition]"
   region: "NTSC-J"
 SLPM-55044:
   name: "Heart no Kuni no Alice - Wonderful Wonder World"
@@ -24066,7 +24066,7 @@ SLPM-62244:
   name: "Choro Q - High Grade 3"
   region: "NTSC-J"
 SLPM-62245:
-  name: "Yuusei Kara no Buutai - Episode 2"
+  name: "Yuusei kara no Buttai X - Episode II"
   region: "NTSC-J"
 SLPM-62247:
   name: "Shin Contra"
@@ -27180,7 +27180,7 @@ SLPM-65465:
   gameFixes:
     - EETimingHack
 SLPM-65466:
-  name: "Kousen Gaeri - Refrain"
+  name: "Yomigaeri - Refrain"
   region: "NTSC-J"
 SLPM-65468:
   name: "Roommate Asami - D-Collection"
@@ -31761,7 +31761,7 @@ SLPM-66786:
   name: "Gift - Prism [Broccoli Best Quality]"
   region: "NTSC-J"
 SLPM-66787:
-  name: "Tsuika AS+ Eternal Name"
+  name: "Suika A.S+ Eternal Name"
   region: "NTSC-J"
 SLPM-66788:
   name: "Grand Theft Auto - San Andreas [Best Price]"
@@ -37690,7 +37690,7 @@ SLPS-73203:
     - "SLPS-73202"
     - "SLPS-73203"
 SLPS-73204:
-  name: "Zettai Zetsumi Toshi [PlayStation 2 The Best]"
+  name: "Zettai Zetsumei Toshi [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.


### PR DESCRIPTION
### Description of Changes

- SLPS-73204 Zetsumi -> Zetsumei (like all other editions of the game in GameDB)
- SLPM-62245 Correct name is Yuusei kara no Buttai X - Episode II
Source: [Japanese Wikipedia article for the game](https://ja.wikipedia.org/wiki/%E9%81%8A%E6%98%9F%E3%81%8B%E3%82%89%E3%81%AE%E7%89%A9%E4%BD%93X_episodeII) and [Boxart from Amazon Japan](https://www.amazon.co.jp/PlayStation2-%E3%82%BD%E3%83%95%E3%83%88-%E9%81%8A%E6%98%9F%E3%81%8B%E3%82%89%E3%81%AE%E7%89%A9%E4%BD%93X-%E3%82%A8%E3%83%94%E3%82%BD%E3%83%BC%E3%83%892/dp/B00DOOIRDQ)
- SLPM-55042 and SLPM-66787 Correct name is Suika A.S+ Eternal Name
Source: [Covers from PCSX2 Wiki](https://wiki.pcsx2.net/File:Cover_Suika_A_S%2B_Eternal_Name.jpg) and [Retroplace](https://www.retroplace.com/en/games/82072--suika-a-s-eternal-name)
- SLPM-65466 The Kanji in the title are read Yomi, not Kousen.
Source: Furigana (reading help in Hiragana) visible above the Kanji on [title screenshot and boxart on VGM](https://www.video-games-museum.com/en/game/Yomigaeri-Refrain/80/2/55635). Also, the official page for the game on the Publisher's website has the URL https://www.d3p.co.jp/yomigaeri/

### Rationale behind Changes
Fix typos, make names across multiple editions of the same game more consistent.
