### PR TITLE
WX: Change default sound module to Cubeb

### DIFF
--- a/pcsx2/SPU2/Windows/Config.cpp
+++ b/pcsx2/SPU2/Windows/Config.cpp
@@ -118,7 +118,7 @@ void ReadSettings()
 	// Let's use xaudio2 until this is sorted (rama).
 
 	//	CfgReadStr(L"OUTPUT", L"Output_Module", omodid, 127, PortaudioOut->GetIdent());
-	CfgReadStr(L"OUTPUT", L"Output_Module", omodid, 127, StringUtil::UTF8StringToWideString(XAudio2Out->GetIdent()).c_str());
+	CfgReadStr(L"OUTPUT", L"Output_Module", omodid, 127, StringUtil::UTF8StringToWideString(CubebOut->GetIdent()).c_str());
 
 	// Find the driver index of this module:
 	OutputModule = FindOutputModuleById(StringUtil::WideStringToUTF8String(omodid).c_str());


### PR DESCRIPTION
### Description of Changes
Changes the default sound module from XAudio2 to Cubeb to prevent USB crashing as well as achieve parity with Qt

### Rationale behind Changes
Less crashy more good.

Fixes #5458 

### Suggested Testing Steps
Make sure the default module is Cubeb on fresh boot and CI passes.
