### PR TITLE
GameDB: Remove half-pixel offset from Mercenaries

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -14240,19 +14240,16 @@ SLES-52588:
   region: "PAL-E"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLES-52589:
   name: "Mercenaries"
   region: "PAL-F"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLES-52590:
   name: "Mercenaries"
   region: "PAL-G"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLES-52591:
   name: "Dynasty Warriors 4 - Empires"
   region: "PAL-E"
@@ -15216,7 +15213,6 @@ SLES-53008:
   region: "PAL-I-S"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLES-53009:
   name: "Dance Factory"
   region: "PAL-M5"
@@ -28716,7 +28712,6 @@ SLPM-65942:
   region: "NTSC-J"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-65943:
   name: "Angel's Feather"
   region: "NTSC-J"
@@ -30567,7 +30562,6 @@ SLPM-66465:
   region: "NTSC-J"
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLPM-66467:
   name: "Midway Arcade Treasures - The Game Center of USA"
   region: "NTSC-J"
@@ -42213,7 +42207,6 @@ SLUS-20932:
   compat: 5
   gsHWFixes:
     halfBottomOverride: 1 # Bottom screen has wrong colors.
-    halfPixelOffset: 1 # Fixes bloom misalignment.
 SLUS-20933:
   name: "Smash Court Pro Tournament Tennis 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Remove half-pixel offset normal (vertex) from Mercenaries. 

### Rationale behind Changes
Half-pixel offset normal (vertex) does fix bloom alignment (and loading screen animations), but it also produces colourful flickering and seams in the skybox during gameplay. 
Colourful flickering also affects puddles on wet roads.

[Video of skybox flickering](https://i.imgur.com/HzFDJnd.mp4)

Half-pixel offset normal (vertex):

![Half-pixel offset normal (vertex)](https://user-images.githubusercontent.com/8492684/184506911-c7677b49-22d4-421c-bb4c-50ddf65cd201.png)

Half-pixel offset disabled:

![Half-pixel offset disabled](https://user-images.githubusercontent.com/8492684/184506919-60c8b0b7-94c1-4e36-8573-307b6fa4b8f5.png)

[GS dump](https://github.com/PCSX2/pcsx2/files/9332024/Mercenaries.skybox.zip)

Seams also appear in a grid pattern on water surfaces.

Half-pixel offset normal (vertex):

![Mercenaries_HPO_normal2](https://user-images.githubusercontent.com/8492684/184509096-3c86072e-12e2-419a-8f58-ba654b9c04e0.png)

Half-pixel offset disabled:

![Mercenaries_HPO_off2](https://user-images.githubusercontent.com/8492684/184509107-bbe49a0d-e350-4a6f-8dbf-1787614742da.png)


### Suggested Testing Steps
Check CI, test game.