### PR TITLE
Qt: Allow for weird sounds to come out of more speakers

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -27,6 +27,7 @@
 static constexpr s32 DEFAULT_INTERPOLATION_MODE = 5;
 static constexpr s32 DEFAULT_SYNCHRONIZATION_MODE = 0;
 static constexpr s32 DEFAULT_EXPANSION_MODE = 0;
+static constexpr s32 DEFAULT_DPL_DECODING_LEVEL = 0;
 static const char* DEFAULT_OUTPUT_MODULE = "cubeb";
 static constexpr s32 DEFAULT_OUTPUT_LATENCY = 100;
 static constexpr s32 DEFAULT_VOLUME = 100;
@@ -53,6 +54,7 @@ static const char* s_output_module_values[] = {
 
 AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	: QWidget(parent)
+	, m_dialog(dialog)
 {
 	SettingsInterface* sif = dialog->getSettingsInterface();
 
@@ -61,6 +63,9 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interpolation, "SPU2/Mixing", "Interpolation", DEFAULT_INTERPOLATION_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.syncMode, "SPU2/Output", "SynchMode", DEFAULT_SYNCHRONIZATION_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.expansionMode, "SPU2/Output", "SpeakerConfiguration", DEFAULT_EXPANSION_MODE);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dplLevel, "SPU2/Output", "DplDecodingLevel", DEFAULT_DPL_DECODING_LEVEL);
+	connect(m_ui.expansionMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AudioSettingsWidget::expansionModeChanged);
+	expansionModeChanged();
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.outputModule, "SPU2/Output", "OutputModule", s_output_module_entries, s_output_module_values, DEFAULT_OUTPUT_MODULE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.latency, "SPU2/Output", "Latency", DEFAULT_OUTPUT_LATENCY);
@@ -84,6 +89,12 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsDialog* dialog, QWidget* parent
 }
 
 AudioSettingsWidget::~AudioSettingsWidget() = default;
+
+void AudioSettingsWidget::expansionModeChanged()
+{
+	const bool expansion51 = m_dialog->getEffectiveIntValue("SPU2/Output", "SpeakerConfiguration", 0) == 2;
+	m_ui.dplLevel->setDisabled(!expansion51);
+}
 
 void AudioSettingsWidget::updateVolumeLabel()
 {

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -30,6 +30,7 @@ public:
 	~AudioSettingsWidget();
 
 private Q_SLOTS:
+	void expansionModeChanged();
 	void updateVolumeLabel();
 	void updateLatencyLabel();
 	void updateTimestretchSequenceLengthLabel();
@@ -38,5 +39,6 @@ private Q_SLOTS:
 	void resetTimestretchDefaults();
 
 private:
+	SettingsDialog* m_dialog;
 	Ui::AudioSettingsWidget m_ui;
 };

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -130,6 +130,32 @@
         </item>
        </widget>
       </item>
+	  <item row="3" column="0">
+       <widget class="QLabel" name="label_3b">
+        <property name="text">
+         <string>ProLogic Level:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="dplLevel">
+        <item>
+         <property name="text">
+          <string>None (Default)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>ProLogic Decoding (basic)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>ProLogic II Decoding (gigaherz)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -622,6 +622,7 @@ struct Pcsx2Config
 		s32 FinalVolume = 100;
 		s32 Latency{100};
 		s32 SpeakerConfiguration{0};
+		s32 DplDecodingLevel{0};
 
 		double VolumeAdjustC{ 0.0f };
 		double VolumeAdjustFL{ 0.0f };
@@ -648,6 +649,7 @@ struct Pcsx2Config
 				OpEqu(FinalVolume) &&
 				OpEqu(Latency) &&
 				OpEqu(SpeakerConfiguration) &&
+				OpEqu(DplDecodingLevel) &&
 
 				OpEqu(VolumeAdjustC) &&
 				OpEqu(VolumeAdjustFL) &&

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -722,6 +722,7 @@ void Pcsx2Config::SPU2Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapEntry(Latency);
 		SynchMode = static_cast<SynchronizationMode>(wrap.EntryBitfield(CURRENT_SETTINGS_SECTION, "SynchMode", static_cast<int>(SynchMode), static_cast<int>(SynchMode)));
 		SettingsWrapEntry(SpeakerConfiguration);
+		SettingsWrapEntry(DplDecodingLevel);
 	}
 }
 

--- a/pcsx2/SPU2/Host/Config.cpp
+++ b/pcsx2/SPU2/Host/Config.cpp
@@ -102,6 +102,7 @@ void ReadSettings()
 	SndOutLatencyMS = Host::GetIntSettingValue("SPU2/Output", "Latency", 100);
 	SynchMode = Host::GetIntSettingValue("SPU2/Output", "SynchMode", 0);
 	numSpeakers = Host::GetIntSettingValue("SPU2/Output", "SpeakerConfiguration", 0);
+	dplLevel = Host::GetIntSettingValue("SPU2/Output", "DplDecodingLevel", 0);
 
 	SoundtouchCfg::ReadSettings();
 	DebugConfig::ReadSettings();


### PR DESCRIPTION
### Description of Changes

The SPU setting `DplDecodingLevel` seemed to be ignored when using the Qt builds. The setting now loads but also ended up adding it to the UI for easy usage/testing. Since it's only used with the 5.1 output, the widget is disabled unless `Expansion: Surround 5.1` is selected.

### Rationale behind Changes

Boredom.
Here, have some music. [TotallyNotRickRoll](https://www.youtube.com/watch?v=6riDJMI-Y8U), [4Real](https://www.youtube.com/watch?v=nRKJBpFFsuI)

### Suggested Testing Steps

Click the setting thing, see the log that it changes accordingly. [LogCode](https://github.com/PCSX2/pcsx2/blob/ea051c6d5fcc2eddbf749664340f283c88d058e3/pcsx2/SPU2/SndOut_Cubeb.cpp#L222)

#EDIT: Template thing.
