### PR TITLE
Qt: Frame Rate Control - increase maximum

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSystemSettingsWidget.ui
@@ -146,6 +146,9 @@
         <property name="singleStep">
          <double>0.010000000000000</double>
         </property>
+        <property name="maximum">
+         <double>999.99</double>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -155,6 +158,9 @@
         </property>
         <property name="singleStep">
          <double>0.010000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>999.99</double>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
### Description of Changes
Raise maximum values to 999.99, up from [QDoubleSpinBox default maximum of 99.99](https://doc.qt.io/qt-5/qdoublespinbox.html#maximum-prop).

### Rationale behind Changes
Remove an unintentional (?) limitation, parity with wx (but still prevent input of extremely high values).
Values over 99.99 can be useful for high frame rate patches, and for games which don't break or speed up at high FPS.

### Suggested Testing Steps
Test different frame rate control values.