### PR TITLE
GS: Less aggressive rounding on convert shaders

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -164,8 +164,8 @@ PS_OUTPUT ps_convert_float16_rgb5a1(PS_INPUT input)
 }
 float ps_convert_rgba8_float32(PS_INPUT input) : SV_Depth
 {
-	// Convert a RRGBA texture into a float depth texture
-	uint4 c = uint4(sample_c(input.t) * 255.0f + 0.5f);
+	// Convert a RGBA texture into a float depth texture
+	uint4 c = uint4(sample_c(input.t) * 255.0f + 0.1f);
 	return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
 }
 
@@ -173,8 +173,8 @@ float ps_convert_rgba8_float24(PS_INPUT input) : SV_Depth
 {
 	// Same as above but without the alpha channel (24 bits Z)
 
-	// Convert a RRGBA texture into a float depth texture
-	uint3 c = uint3(sample_c(input.t).rgb * 255.0f + 0.5f);
+	// Convert a RGBA texture into a float depth texture
+	uint3 c = uint3(sample_c(input.t).rgb * 255.0f + 0.1f);
 	return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
 }
 
@@ -182,15 +182,15 @@ float ps_convert_rgba8_float16(PS_INPUT input) : SV_Depth
 {
 	// Same as above but without the A/B channels (16 bits Z)
 
-	// Convert a RRGBA texture into a float depth texture
-	uint2 c = uint2(sample_c(input.t).rg * 255.0f + 0.5f);
+	// Convert a RGBA texture into a float depth texture
+	uint2 c = uint2(sample_c(input.t).rg * 255.0f + 0.1f);
 	return float(c.r | (c.g << 8)) * exp2(-32.0f);
 }
 
 float ps_convert_rgb5a1_float16(PS_INPUT input) : SV_Depth
 {
 	// Convert a RGB5A1 (saved as RGBA8) color to a 16 bit Z
-	uint4 c = uint4(sample_c(input.t) * 255.0f + 0.5f);
+	uint4 c = uint4(sample_c(input.t) * 255.0f + 0.1f);
 	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 }
 

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -100,8 +100,8 @@ void ps_convert_float16_rgb5a1()
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {
-    // Convert a RRGBA texture into a float depth texture
-    uvec4 c = uvec4(sample_c() * vec4(255.0f) + vec4(0.5f));
+    // Convert a RGBA texture into a float depth texture
+    uvec4 c = uvec4(sample_c() * vec4(255.0f) + vec4(0.1f));
     gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
 }
 #endif
@@ -111,8 +111,8 @@ void ps_convert_rgba8_float24()
 {
     // Same as above but without the alpha channel (24 bits Z)
 
-    // Convert a RRGBA texture into a float depth texture
-    uvec3 c = uvec3(sample_c().rgb * vec3(255.0f) + vec3(0.5f));
+    // Convert a RGBA texture into a float depth texture
+    uvec3 c = uvec3(sample_c().rgb * vec3(255.0f) + vec3(0.1f));
     gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
 }
 #endif
@@ -122,8 +122,8 @@ void ps_convert_rgba8_float16()
 {
     // Same as above but without the A/B channels (16 bits Z)
 
-    // Convert a RRGBA texture into a float depth texture
-    uvec2 c = uvec2(sample_c().rg * vec2(255.0f) + vec2(0.5f));
+    // Convert a RGBA texture into a float depth texture
+    uvec2 c = uvec2(sample_c().rg * vec2(255.0f) + vec2(0.1f));
     gl_FragDepth = float(c.r | (c.g << 8)) * exp2(-32.0f);
 }
 #endif
@@ -132,7 +132,7 @@ void ps_convert_rgba8_float16()
 void ps_convert_rgb5a1_float16()
 {
     // Convert a RGB5A1 (saved as RGBA8) color to a 16 bit Z
-    uvec4 c = uvec4(sample_c() * vec4(255.0f) + vec4(0.5f));
+    uvec4 c = uvec4(sample_c() * vec4(255.0f) + vec4(0.1f));
     gl_FragDepth = float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 }
 #endif

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -131,8 +131,8 @@ void ps_convert_float16_rgb5a1()
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {
-	// Convert a RRGBA texture into a float depth texture
-	uvec4 c = uvec4(sample_c(v_tex) * vec4(255.0f) + vec4(0.5f));
+	// Convert a RGBA texture into a float depth texture
+	uvec4 c = uvec4((sample_c(v_tex) * vec4(255.0f)) + vec4(0.1f));
 	gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
 }
 #endif
@@ -142,8 +142,8 @@ void ps_convert_rgba8_float24()
 {
 	// Same as above but without the alpha channel (24 bits Z)
 
-	// Convert a RRGBA texture into a float depth texture
-	uvec3 c = uvec3(sample_c(v_tex).rgb * vec3(255.0f) + vec3(0.5f));
+	// Convert a RGBA texture into a float depth texture
+	uvec3 c = uvec3(sample_c(v_tex).rgb * vec3(255.0f) + vec3(0.1f));
 	gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
 }
 #endif
@@ -153,8 +153,8 @@ void ps_convert_rgba8_float16()
 {
 	// Same as above but without the A/B channels (16 bits Z)
 
-	// Convert a RRGBA texture into a float depth texture
-	uvec2 c = uvec2(sample_c(v_tex).rg * vec2(255.0f) + vec2(0.5f));
+	// Convert a RGBA texture into a float depth texture
+	uvec2 c = uvec2(sample_c(v_tex).rg * vec2(255.0f) + vec2(0.1f));
 	gl_FragDepth = float(c.r | (c.g << 8)) * exp2(-32.0f);
 }
 #endif
@@ -163,7 +163,7 @@ void ps_convert_rgba8_float16()
 void ps_convert_rgb5a1_float16()
 {
 	// Convert a RGB5A1 (saved as RGBA8) color to a 16 bit Z
-	uvec4 c = uvec4(sample_c(v_tex) * vec4(255.0f) + vec4(0.5f));
+	uvec4 c = uvec4(sample_c(v_tex) * vec4(255.0f) + vec4(0.1f));
 	gl_FragDepth = float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
 }
 #endif

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -152,7 +152,7 @@ fragment DepthOut ps_depth_copy(ConvertShaderData data [[stage_in]], ConvertPSDe
 
 static float pack_rgba8_depth(float4 unorm)
 {
-	return float(as_type<uint>(uchar4(unorm * 255.f + 0.5f))) * 0x1p-32f;
+	return float(as_type<uint>(uchar4(unorm * 255.f + 0.1f))) * 0x1p-32f;
 }
 
 fragment DepthOut ps_convert_rgba8_float32(ConvertShaderData data [[stage_in]], ConvertPSRes res)
@@ -168,12 +168,12 @@ fragment DepthOut ps_convert_rgba8_float24(ConvertShaderData data [[stage_in]], 
 
 fragment DepthOut ps_convert_rgba8_float16(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
-	return float(as_type<ushort>(uchar2(res.sample(data.t).rg * 255.f + 0.5f))) * 0x1p-32;
+	return float(as_type<ushort>(uchar2(res.sample(data.t).rg * 255.f + 0.1f))) * 0x1p-32;
 }
 
 fragment DepthOut ps_convert_rgb5a1_float16(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
-	uint4 cu = uint4(res.sample(data.t) * 255.f + 0.5f);
+	uint4 cu = uint4(res.sample(data.t) * 255.f + 0.1f);
 	uint out = (cu.x >> 3) | ((cu.y << 2) & 0x03e0) | ((cu.z << 7) & 0x7c00) | ((cu.w << 8) & 0x8000);
 	return float(out) * 0x1p-32;
 }


### PR DESCRIPTION
### Description of Changes
Reduces how much rounding is done on the colours when converted to full range.

### Rationale behind Changes
This was causing lines to appear on the floor in several Shin Megami Tensei games when upscaling (SMT3 and DDS we know of)

### Suggested Testing Steps
Try games mentioned when upscaling, but also check games mentioned in #5518
