### PR TITLE
Qt: Change name of Adjust to Host Refresh Rate

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -65,10 +65,10 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsDialog* dialog, QWidget
 	dialog->registerWidgetHelp(m_ui.speedLimiter, tr("Speed Limiter"), tr("checked"),
 		tr("Limits the emulation to the appropriate framerate for the currently running game."));
 
-	dialog->registerWidgetHelp(m_ui.syncToHostRefreshRate, tr("Sync To Host Refresh Rate"), tr("Unchecked"),
+	dialog->registerWidgetHelp(m_ui.syncToHostRefreshRate, tr("Scale To Host Refresh Rate"), tr("Unchecked"),
 		tr("Adjusts the emulation speed so the console's refresh rate matches the host's refresh rate when both VSync and "
 		   "Audio Resampling settings are enabled. This results in the smoothest animations possible, at the cost of "
-		   "potentially increasing the emulation speed by less than 1%. Sync To Host Refresh Rate will not take effect if "
+		   "potentially increasing the emulation speed by less than 1%. Scale To Host Refresh Rate will not take effect if "
 		   "the console's refresh rate is too far from the host's refresh rate. Users with variable refresh rate displays "
 		   "should disable this option."));
 

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -110,7 +110,7 @@
         <item row="0" column="1">
          <widget class="QCheckBox" name="syncToHostRefreshRate">
           <property name="text">
-           <string>Adjust To Host Refresh Rate</string>
+           <string>Scale To Host Refresh Rate</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
### Description of Changes
Changes the name of Adjust To Host Refresh Rate to Scale to Host Refresh Rate.

### Rationale behind Changes
The name was inconsistent with the internal name and the description box text.

### Suggested Testing Steps
Make sure CI is happy.
