### PR TITLE
GS: Fix wx replayer readbacks

### DIFF
--- a/pcsx2/gui/Dialogs/GSDumpDialog.cpp
+++ b/pcsx2/gui/Dialogs/GSDumpDialog.cpp
@@ -787,7 +787,7 @@ void Dialogs::GSDumpDialog::ProcessDumpEvent(const GSDumpFile::GSData& event, u8
 		case GSType::ReadFIFO2:
 		{
 			std::unique_ptr<u8[]> arr(new u8[*((int*)event.data) * 16]);
-			GetMTGS().InitAndReadFIFO(arr.get(), *((int*)event.data));
+			GSInitAndReadFIFO(arr.get(), *((int*)event.data));
 			break;
 		}
 		case GSType::Registers:


### PR DESCRIPTION
### Description of Changes
Makes wx replayer not fail assertions when running dumps with readbacks

### Rationale behind Changes
It's nice when things don't crash with an assertion failure

### Suggested Testing Steps
Verify that this dump doesn't cause any assertion failures [SMT3_DepthConvertIssue.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9354261/SMT3_DepthConvertIssue.gs.xz.zip)
