### PR TITLE
Interpolate depth properly when converting from RGBA

### DIFF
--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -97,12 +97,35 @@ void ps_convert_float16_rgb5a1()
 }
 #endif
 
+float rgba8_to_depth32(vec4 unorm)
+{
+    uvec4 c = uvec4(unorm * vec4(255.5f));
+    return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
+}
+
+float rgba8_to_depth24(vec4 unorm)
+{
+    uvec3 c = uvec3(unorm.rgb * vec3(255.5f));
+    return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
+}
+
+float rgba8_to_depth16(vec4 unorm)
+{
+    uvec2 c = uvec2(unorm.rg * vec2(255.5f));
+    return float(c.r | (c.g << 8)) * exp2(-32.0f);
+}
+
+float rgb5a1_to_depth16(vec4 unorm)
+{
+    uvec4 c = uvec4(unorm * vec4(255.5f));
+    return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
+}
+
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {
-    // Convert a RRGBA texture into a float depth texture
-    uvec4 c = uvec4(sample_c() * vec4(255.0f) + vec4(0.5f));
-    gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
+    // Convert an RGBA texture into a float depth texture
+    gl_FragDepth = rgba8_to_depth32(sample_c());
 }
 #endif
 
@@ -111,9 +134,8 @@ void ps_convert_rgba8_float24()
 {
     // Same as above but without the alpha channel (24 bits Z)
 
-    // Convert a RRGBA texture into a float depth texture
-    uvec3 c = uvec3(sample_c().rgb * vec3(255.0f) + vec3(0.5f));
-    gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
+    // Convert an RGBA texture into a float depth texture
+    gl_FragDepth = rgba8_to_depth24(sample_c());
 }
 #endif
 
@@ -122,18 +144,64 @@ void ps_convert_rgba8_float16()
 {
     // Same as above but without the A/B channels (16 bits Z)
 
-    // Convert a RRGBA texture into a float depth texture
-    uvec2 c = uvec2(sample_c().rg * vec2(255.0f) + vec2(0.5f));
-    gl_FragDepth = float(c.r | (c.g << 8)) * exp2(-32.0f);
+    // Convert an RGBA texture into a float depth texture
+    gl_FragDepth = rgba8_to_depth16(sample_c());
 }
 #endif
 
 #ifdef ps_convert_rgb5a1_float16
 void ps_convert_rgb5a1_float16()
 {
-    // Convert a RGB5A1 (saved as RGBA8) color to a 16 bit Z
-    uvec4 c = uvec4(sample_c() * vec4(255.0f) + vec4(0.5f));
-    gl_FragDepth = float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
+    // Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
+    gl_FragDepth = rgb5a1_to_depth16(sample_c());
+}
+#endif
+
+#define SAMPLE_RGBA_DEPTH_BILN(CONVERT_FN) \
+    ivec2 dims = textureSize(TextureSampler, 0); \
+    vec2 top_left_f = PSin_t * vec2(dims) - 0.5f; \
+    ivec2 top_left = ivec2(floor(top_left_f)); \
+    ivec4 coords = clamp(ivec4(top_left, top_left + 1), ivec4(0), dims.xyxy - 1); \
+    vec2 mix_vals = fract(top_left_f); \
+    float depthTL = CONVERT_FN(texelFetch(TextureSampler, coords.xy, 0)); \
+    float depthTR = CONVERT_FN(texelFetch(TextureSampler, coords.zy, 0)); \
+    float depthBL = CONVERT_FN(texelFetch(TextureSampler, coords.xw, 0)); \
+    float depthBR = CONVERT_FN(texelFetch(TextureSampler, coords.zw, 0)); \
+    gl_FragDepth = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+
+#ifdef ps_convert_rgba8_float32_biln
+void ps_convert_rgba8_float32_biln()
+{
+    // Convert an RGBA texture into a float depth texture
+    SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth32);
+}
+#endif
+
+#ifdef ps_convert_rgba8_float24_biln
+void ps_convert_rgba8_float24_biln()
+{
+    // Same as above but without the alpha channel (24 bits Z)
+
+    // Convert an RGBA texture into a float depth texture
+    SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth24);
+}
+#endif
+
+#ifdef ps_convert_rgba8_float16_biln
+void ps_convert_rgba8_float16_biln()
+{
+    // Same as above but without the A/B channels (16 bits Z)
+
+    // Convert an RGBA texture into a float depth texture
+    SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth16);
+}
+#endif
+
+#ifdef ps_convert_rgb5a1_float16_biln
+void ps_convert_rgb5a1_float16_biln()
+{
+    // Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
+    SAMPLE_RGBA_DEPTH_BILN(rgb5a1_to_depth16);
 }
 #endif
 

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -128,12 +128,35 @@ void ps_convert_float16_rgb5a1()
 }
 #endif
 
+float rgba8_to_depth32(vec4 unorm)
+{
+	uvec4 c = uvec4(unorm * vec4(255.5f));
+	return float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
+}
+
+float rgba8_to_depth24(vec4 unorm)
+{
+	uvec3 c = uvec3(unorm.rgb * vec3(255.5f));
+	return float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
+}
+
+float rgba8_to_depth16(vec4 unorm)
+{
+	uvec2 c = uvec2(unorm.rg * vec2(255.5f));
+	return float(c.r | (c.g << 8)) * exp2(-32.0f);
+}
+
+float rgb5a1_to_depth16(vec4 unorm)
+{
+	uvec4 c = uvec4(unorm * vec4(255.5f));
+	return float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
+}
+
 #ifdef ps_convert_rgba8_float32
 void ps_convert_rgba8_float32()
 {
-	// Convert a RRGBA texture into a float depth texture
-	uvec4 c = uvec4(sample_c(v_tex) * vec4(255.0f) + vec4(0.5f));
-	gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16) | (c.a << 24)) * exp2(-32.0f);
+	// Convert an RGBA texture into a float depth texture
+	gl_FragDepth = rgba8_to_depth32(sample_c(v_tex));
 }
 #endif
 
@@ -142,9 +165,8 @@ void ps_convert_rgba8_float24()
 {
 	// Same as above but without the alpha channel (24 bits Z)
 
-	// Convert a RRGBA texture into a float depth texture
-	uvec3 c = uvec3(sample_c(v_tex).rgb * vec3(255.0f) + vec3(0.5f));
-	gl_FragDepth = float(c.r | (c.g << 8) | (c.b << 16)) * exp2(-32.0f);
+	// Convert an RGBA texture into a float depth texture
+	gl_FragDepth = rgba8_to_depth24(sample_c(v_tex));
 }
 #endif
 
@@ -153,18 +175,64 @@ void ps_convert_rgba8_float16()
 {
 	// Same as above but without the A/B channels (16 bits Z)
 
-	// Convert a RRGBA texture into a float depth texture
-	uvec2 c = uvec2(sample_c(v_tex).rg * vec2(255.0f) + vec2(0.5f));
-	gl_FragDepth = float(c.r | (c.g << 8)) * exp2(-32.0f);
+	// Convert an RGBA texture into a float depth texture
+	gl_FragDepth = rgba8_to_depth16(sample_c(v_tex));
 }
 #endif
 
 #ifdef ps_convert_rgb5a1_float16
 void ps_convert_rgb5a1_float16()
 {
-	// Convert a RGB5A1 (saved as RGBA8) color to a 16 bit Z
-	uvec4 c = uvec4(sample_c(v_tex) * vec4(255.0f) + vec4(0.5f));
-	gl_FragDepth = float(((c.r & 0xF8u) >> 3) | ((c.g & 0xF8u) << 2) | ((c.b & 0xF8u) << 7) | ((c.a & 0x80u) << 8)) * exp2(-32.0f);
+	// Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
+	gl_FragDepth = rgb5a1_to_depth16(sample_c(v_tex));
+}
+#endif
+
+#define SAMPLE_RGBA_DEPTH_BILN(CONVERT_FN) \
+	ivec2 dims = textureSize(samp0, 0); \
+	vec2 top_left_f = v_tex * vec2(dims) - 0.5f; \
+	ivec2 top_left = ivec2(floor(top_left_f)); \
+	ivec4 coords = clamp(ivec4(top_left, top_left + 1), ivec4(0), dims.xyxy - 1); \
+	vec2 mix_vals = fract(top_left_f); \
+	float depthTL = CONVERT_FN(texelFetch(samp0, coords.xy, 0)); \
+	float depthTR = CONVERT_FN(texelFetch(samp0, coords.zy, 0)); \
+	float depthBL = CONVERT_FN(texelFetch(samp0, coords.xw, 0)); \
+	float depthBR = CONVERT_FN(texelFetch(samp0, coords.zw, 0)); \
+	gl_FragDepth = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+
+#ifdef ps_convert_rgba8_float32_biln
+void ps_convert_rgba8_float32_biln()
+{
+	// Convert an RGBA texture into a float depth texture
+	SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth32);
+}
+#endif
+
+#ifdef ps_convert_rgba8_float24_biln
+void ps_convert_rgba8_float24_biln()
+{
+	// Same as above but without the alpha channel (24 bits Z)
+
+	// Convert an RGBA texture into a float depth texture
+	SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth24);
+}
+#endif
+
+#ifdef ps_convert_rgba8_float16_biln
+void ps_convert_rgba8_float16_biln()
+{
+	// Same as above but without the A/B channels (16 bits Z)
+
+	// Convert an RGBA texture into a float depth texture
+	SAMPLE_RGBA_DEPTH_BILN(rgba8_to_depth16);
+}
+#endif
+
+#ifdef ps_convert_rgb5a1_float16_biln
+void ps_convert_rgb5a1_float16_biln()
+{
+	// Convert an RGB5A1 (saved as RGBA8) color to a 16 bit Z
+	SAMPLE_RGBA_DEPTH_BILN(rgb5a1_to_depth16);
 }
 #endif
 

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -266,21 +266,21 @@ layout(push_constant) uniform cb10
 
 void ps_yuv()
 {
-  vec4 i = sample_c(v_tex);
-  vec4 o;
+	vec4 i = sample_c(v_tex);
+	vec4 o;
 
-  mat3 rgb2yuv;
-  rgb2yuv[0] = vec3(0.587, -0.311, -0.419);
-  rgb2yuv[1] = vec3(0.114, 0.500, -0.081);
-  rgb2yuv[2] = vec3(0.299, -0.169, 0.500);
+	mat3 rgb2yuv;
+	rgb2yuv[0] = vec3(0.587, -0.311, -0.419);
+	rgb2yuv[1] = vec3(0.114, 0.500, -0.081);
+	rgb2yuv[2] = vec3(0.299, -0.169, 0.500);
 
-  vec3 yuv = rgb2yuv * i.gbr;
+	vec3 yuv = rgb2yuv * i.gbr;
 
-  float Y = float(0xDB)/255.0f * yuv.x + float(0x10)/255.0f;
-  float Cr = float(0xE0)/255.0f * yuv.y + float(0x80)/255.0f;
-  float Cb = float(0xE0)/255.0f * yuv.z + float(0x80)/255.0f;
+	float Y = float(0xDB)/255.0f * yuv.x + float(0x10)/255.0f;
+	float Cr = float(0xE0)/255.0f * yuv.y + float(0x80)/255.0f;
+	float Cb = float(0xE0)/255.0f * yuv.z + float(0x80)/255.0f;
 
-  switch(EMODA) {
+	switch(EMODA) {
 		case 0:
 			o.a = i.a;
 			break;
@@ -293,22 +293,22 @@ void ps_yuv()
 		case 3:
 			o.a = 0.0f;
 			break;
-  }
+	}
 
-  switch(EMODC) {
-    case 0:
-      o.rgb = i.rgb;
-      break;
-    case 1:
-      o.rgb = vec3(Y);
-      break;
-    case 2:
-      o.rgb = vec3(Y, Cb, Cr);
-      break;
-    case 3:
-      o.rgb = vec3(i.a);
-      break;
-  }
+	switch(EMODC) {
+		case 0:
+			o.rgb = i.rgb;
+			break;
+		case 1:
+			o.rgb = vec3(Y);
+			break;
+		case 2:
+			o.rgb = vec3(Y, Cb, Cr);
+			break;
+		case 3:
+			o.rgb = vec3(i.a);
+			break;
+	}
 
 	o_col0 = o;
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -23,23 +23,27 @@ const char* shaderName(ShaderConvert value)
 	switch (value)
 	{
 			// clang-format off
-		case ShaderConvert::COPY:                return "ps_copy";
-		case ShaderConvert::RGBA8_TO_16_BITS:    return "ps_convert_rgba8_16bits";
-		case ShaderConvert::DATM_1:              return "ps_datm1";
-		case ShaderConvert::DATM_0:              return "ps_datm0";
-		case ShaderConvert::MOD_256:             return "ps_mod256";
-		case ShaderConvert::TRANSPARENCY_FILTER: return "ps_filter_transparency";
-		case ShaderConvert::FLOAT32_TO_16_BITS:  return "ps_convert_float32_32bits";
-		case ShaderConvert::FLOAT32_TO_32_BITS:  return "ps_convert_float32_32bits";
-		case ShaderConvert::FLOAT32_TO_RGBA8:    return "ps_convert_float32_rgba8";
-		case ShaderConvert::FLOAT16_TO_RGB5A1:   return "ps_convert_float16_rgb5a1";
-		case ShaderConvert::RGBA8_TO_FLOAT32:    return "ps_convert_rgba8_float32";
-		case ShaderConvert::RGBA8_TO_FLOAT24:    return "ps_convert_rgba8_float24";
-		case ShaderConvert::RGBA8_TO_FLOAT16:    return "ps_convert_rgba8_float16";
-		case ShaderConvert::RGB5A1_TO_FLOAT16:   return "ps_convert_rgb5a1_float16";
-		case ShaderConvert::DEPTH_COPY:          return "ps_depth_copy";
-		case ShaderConvert::RGBA_TO_8I:          return "ps_convert_rgba_8i";
-		case ShaderConvert::YUV:                 return "ps_yuv";
+		case ShaderConvert::COPY:                   return "ps_copy";
+		case ShaderConvert::RGBA8_TO_16_BITS:       return "ps_convert_rgba8_16bits";
+		case ShaderConvert::DATM_1:                 return "ps_datm1";
+		case ShaderConvert::DATM_0:                 return "ps_datm0";
+		case ShaderConvert::MOD_256:                return "ps_mod256";
+		case ShaderConvert::TRANSPARENCY_FILTER:    return "ps_filter_transparency";
+		case ShaderConvert::FLOAT32_TO_16_BITS:     return "ps_convert_float32_32bits";
+		case ShaderConvert::FLOAT32_TO_32_BITS:     return "ps_convert_float32_32bits";
+		case ShaderConvert::FLOAT32_TO_RGBA8:       return "ps_convert_float32_rgba8";
+		case ShaderConvert::FLOAT16_TO_RGB5A1:      return "ps_convert_float16_rgb5a1";
+		case ShaderConvert::RGBA8_TO_FLOAT32:       return "ps_convert_rgba8_float32";
+		case ShaderConvert::RGBA8_TO_FLOAT24:       return "ps_convert_rgba8_float24";
+		case ShaderConvert::RGBA8_TO_FLOAT16:       return "ps_convert_rgba8_float16";
+		case ShaderConvert::RGB5A1_TO_FLOAT16:      return "ps_convert_rgb5a1_float16";
+		case ShaderConvert::RGBA8_TO_FLOAT32_BILN:  return "ps_convert_rgba8_float32_biln";
+		case ShaderConvert::RGBA8_TO_FLOAT24_BILN:  return "ps_convert_rgba8_float24_biln";
+		case ShaderConvert::RGBA8_TO_FLOAT16_BILN:  return "ps_convert_rgba8_float16_biln";
+		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN: return "ps_convert_rgb5a1_float16_biln";
+		case ShaderConvert::DEPTH_COPY:             return "ps_depth_copy";
+		case ShaderConvert::RGBA_TO_8I:             return "ps_convert_rgba_8i";
+		case ShaderConvert::YUV:                    return "ps_yuv";
 			// clang-format on
 		default:
 			ASSERT(0);

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -45,11 +45,74 @@ enum class ShaderConvert
 	RGBA8_TO_FLOAT24,
 	RGBA8_TO_FLOAT16,
 	RGB5A1_TO_FLOAT16,
+	RGBA8_TO_FLOAT32_BILN,
+	RGBA8_TO_FLOAT24_BILN,
+	RGBA8_TO_FLOAT16_BILN,
+	RGB5A1_TO_FLOAT16_BILN,
 	DEPTH_COPY,
 	RGBA_TO_8I,
 	YUV,
 	Count
 };
+
+static inline bool HasDepthOutput(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::RGBA8_TO_FLOAT32:
+		case ShaderConvert::RGBA8_TO_FLOAT24:
+		case ShaderConvert::RGBA8_TO_FLOAT16:
+		case ShaderConvert::RGB5A1_TO_FLOAT16:
+		case ShaderConvert::RGBA8_TO_FLOAT32_BILN:
+		case ShaderConvert::RGBA8_TO_FLOAT24_BILN:
+		case ShaderConvert::RGBA8_TO_FLOAT16_BILN:
+		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN:
+		case ShaderConvert::DEPTH_COPY:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static inline bool HasStencilOutput(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::DATM_0:
+		case ShaderConvert::DATM_1:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static inline bool SupportsNearest(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::RGBA8_TO_FLOAT32_BILN:
+		case ShaderConvert::RGBA8_TO_FLOAT24_BILN:
+		case ShaderConvert::RGBA8_TO_FLOAT16_BILN:
+		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN:
+			return false;
+		default:
+			return true;
+	}
+}
+
+static inline bool SupportsBilinear(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::RGBA8_TO_FLOAT32:
+		case ShaderConvert::RGBA8_TO_FLOAT24:
+		case ShaderConvert::RGBA8_TO_FLOAT16:
+		case ShaderConvert::RGB5A1_TO_FLOAT16:
+			return false;
+		default:
+			return true;
+	}
+}
 
 enum class PresentShader
 {

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -577,6 +577,8 @@ void GSDevice11::CloneTexture(GSTexture* src, GSTexture** dest, const GSVector4i
 
 void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader, bool linear)
 {
+	pxAssert(dTex->IsDepthStencil() == HasDepthOutput(shader));
+	pxAssert(linear ? SupportsBilinear(shader) : SupportsNearest(shader));
 	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[static_cast<int>(shader)].get(), nullptr, linear);
 }
 
@@ -608,11 +610,7 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 {
 	ASSERT(sTex);
 
-	const bool draw_in_depth = ps == m_convert.ps[static_cast<int>(ShaderConvert::DEPTH_COPY)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT32)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT24)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT16)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGB5A1_TO_FLOAT16)];
+	const bool draw_in_depth = dTex && dTex->IsDepthStencil();
 
 	BeginScene();
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -32,20 +32,6 @@
 #include <sstream>
 #include <limits>
 
-static bool IsDepthConvertShader(ShaderConvert i)
-{
-	return (i == ShaderConvert::DEPTH_COPY || i == ShaderConvert::RGBA8_TO_FLOAT32 ||
-			i == ShaderConvert::RGBA8_TO_FLOAT24 || i == ShaderConvert::RGBA8_TO_FLOAT16 ||
-			i == ShaderConvert::RGB5A1_TO_FLOAT16 || i == ShaderConvert::DATM_0 ||
-			i == ShaderConvert::DATM_1);
-}
-
-static bool IsIntConvertShader(ShaderConvert i)
-{
-	return (i == ShaderConvert::RGBA8_TO_16_BITS || i == ShaderConvert::FLOAT32_TO_16_BITS ||
-			i == ShaderConvert::FLOAT32_TO_32_BITS);
-}
-
 static bool IsDATMConvertShader(ShaderConvert i) { return (i == ShaderConvert::DATM_0 || i == ShaderConvert::DATM_1); }
 
 static D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE GetLoadOpForTexture(GSTexture12* tex)
@@ -476,7 +462,7 @@ void GSDevice12::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r,
 void GSDevice12::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 	ShaderConvert shader /* = ShaderConvert::COPY */, bool linear /* = true */)
 {
-	pxAssert(IsDepthConvertShader(shader) == (dTex && dTex->GetType() == GSTexture::Type::DepthStencil));
+	pxAssert(HasDepthOutput(shader) == (dTex && dTex->GetType() == GSTexture::Type::DepthStencil));
 
 	GL_INS("StretchRect(%d) {%d,%d} %dx%d -> {%d,%d) %dx%d", shader, int(sRect.left), int(sRect.top),
 		int(sRect.right - sRect.left), int(sRect.bottom - sRect.top), int(dRect.left), int(dRect.top),
@@ -1083,7 +1069,7 @@ bool GSDevice12::CompileConvertPipelines()
 	for (ShaderConvert i = ShaderConvert::COPY; static_cast<int>(i) < static_cast<int>(ShaderConvert::Count);
 		 i = static_cast<ShaderConvert>(static_cast<int>(i) + 1))
 	{
-		const bool depth = IsDepthConvertShader(i);
+		const bool depth = HasDepthOutput(i);
 		const int index = static_cast<int>(i);
 
 		switch (i)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2515,7 +2515,7 @@ void GSTextureCache::Target::Update()
 		GL_INS("ERROR: Update DepthStencil 0x%x", m_TEX0.TBP0);
 
 		// FIXME linear or not?
-		g_gs_device->StretchRect(t, m_texture, GSVector4(r) * GSVector4(m_texture->GetScale()).xyxy(), ShaderConvert::RGBA8_TO_FLOAT32);
+		g_gs_device->StretchRect(t, m_texture, GSVector4(r) * GSVector4(m_texture->GetScale()).xyxy(), ShaderConvert::RGBA8_TO_FLOAT32_BILN);
 	}
 
 	g_gs_device->Recycle(t);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -809,6 +809,10 @@ bool GSDeviceMTL::Create(HostDisplay* display)
 				case ShaderConvert::RGBA8_TO_FLOAT24:
 				case ShaderConvert::RGBA8_TO_FLOAT16:
 				case ShaderConvert::RGB5A1_TO_FLOAT16:
+				case ShaderConvert::RGBA8_TO_FLOAT32_BILN:
+				case ShaderConvert::RGBA8_TO_FLOAT24_BILN:
+				case ShaderConvert::RGBA8_TO_FLOAT16_BILN:
+				case ShaderConvert::RGB5A1_TO_FLOAT16_BILN:
 					pdesc.colorAttachments[0].pixelFormat = MTLPixelFormatInvalid;
 					pdesc.depthAttachmentPixelFormat = ConvertPixelFormat(GSTexture::Format::DepthStencil);
 					break;
@@ -1051,6 +1055,9 @@ void GSDeviceMTL::RenderCopy(GSTexture* sTex, id<MTLRenderPipelineState> pipelin
 void GSDeviceMTL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader, bool linear)
 { @autoreleasepool {
 	id<MTLRenderPipelineState> pipeline;
+
+	pxAssert(linear ? SupportsBilinear(shader) : SupportsNearest(shader));
+
 	if (shader == ShaderConvert::COPY)
 		pipeline = m_convert_pipeline_copy[dTex->GetFormat() == GSTexture::Format::Color ? 0 : 1];
 	else

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1204,6 +1204,8 @@ void GSDeviceOGL::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r
 
 void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader, bool linear)
 {
+	pxAssert(dTex->IsDepthStencil() == HasDepthOutput(shader));
+	pxAssert(linear ? SupportsBilinear(shader) : SupportsNearest(shader));
 	StretchRect(sTex, sRect, dTex, dRect, m_convert.ps[(int)shader], linear);
 }
 
@@ -1228,11 +1230,7 @@ void GSDeviceOGL::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 {
 	ASSERT(sTex);
 
-	const bool draw_in_depth = ps == m_convert.ps[static_cast<int>(ShaderConvert::DEPTH_COPY)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT32)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT24)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGBA8_TO_FLOAT16)]
-	                        || ps == m_convert.ps[static_cast<int>(ShaderConvert::RGB5A1_TO_FLOAT16)];
+	const bool draw_in_depth = dTex->IsDepthStencil();
 
 	// ************************************
 	// Init


### PR DESCRIPTION
### Description of Changes
When converting rgba to depth, run bilinear sampling after the conversion

Fixes lines in shadows in SMT3 Nocturne and SMT Digital Devil Saga

Supersedes #6847

### Rationale behind Changes
When you do bilinear interpolation on the RGBA values, when r overflows into g, the interpolation flips g while r is at 128, resulting in depth values higher than any of the input pixels.
<details>
<summary>Images</summary>

Before:
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/3315070/185071558-5f3a84f6-5535-4bbf-bb51-4187ea82f1b8.png">
After:
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/3315070/185071650-59786ce9-58e4-4a26-a21d-c967c776a513.png">
</details>

Doing interpolation in the shader after converting to depth gets us the best closest image we can get to the original.  Not perfect, since it's been downscaled when the game downloaded it, but there's not much more we can do.

### Suggested Testing Steps
Test these traces:
[SMT3_DepthConversionShadowLines.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9357874/SMT3_DepthConversionShadowLines.gs.xz.zip)
[SMTDDS_DepthConversionShadowLines.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9357876/SMTDDS_DepthConversionShadowLines.gs.xz.zip)

Test general PCSX2 things since I messed with a lot of stuff

~~DX11, DX12, and OGL are completely untested at the moment~~ Tested by ref