### PR TITLE
Qt: Fix newline printed for guest printf on Linux

### DIFF
--- a/pcsx2/Frontend/LogSink.cpp
+++ b/pcsx2/Frontend/LogSink.cpp
@@ -153,7 +153,6 @@ static void ConsoleQt_DoWrite(const char* fmt)
 	}
 #else
 	std::fputs(fmt, stdout);
-	std::fputc('\n', stdout);
 #endif
 
 	if (emuLog)


### PR DESCRIPTION
### Description of Changes

What the title says.

### Rationale behind Changes

WriteLn writes a newline, Write doesn't. Note that it's still not "perfect", if there's other messages printed before the guest sends a newline, then it'll get a bit messed up. But wx was the same there, ideally it should be buffered instead.

### Suggested Testing Steps

Already tested.
