### PR TITLE
GS: improve Haunting Ground hw tc hack.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -779,6 +779,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 						t->m_texture ? t->m_texture->GetID() : 0,
 						t->m_TEX0.TBP0);
 					g_gs_device->ClearRenderTarget(t->m_texture, 0);
+					t->m_dirty.clear();
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Changes
The Haunting Ground game has a specific hack in the GS hw tc to emulate the clearing of a render target when
doing an overlapping rendering with a different BP (we could call this "clear rt in rt" and use the infamous "tex in rt"
code also here, but that's another story and part of a more general discussion about the nature of our overlapping tc).
The hack code did not handle dirty targets properly.
This became evident after #5349 was merged, and reported in #4858.
So now, when clearing the render target, also discard all the dirty rectangles previously marked,
to avoid spurious uploads later.

~~Closes #4858.~~
Improves #4858.

### Rationale behind Changes
The existing code did not handle dirty targets properly.

### Suggested Testing Steps
Test the Haunting Ground game and check that #4858 is ~~fixed~~ improved.
No other game should be affected.
