### PR TITLE
GS: fix out of bounds access to index buffer.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3099,7 +3099,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 
 	ASSERT(m_vertex.tail < m_vertex.maxcount + 3);
 
-	if (auto_flush && m_index.tail >= 0 && ((m_vertex.tail + 1) - m_vertex.head) >= n)
+	if (auto_flush && m_index.tail > 0 && ((m_vertex.tail + 1) - m_vertex.head) >= n)
 	{
 		HandleAutoFlush();
 	}

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -900,7 +900,7 @@ void GSRendererHW::SwSpriteRender()
 
 	const bool alpha_blending_enabled = PRIM->ABE;
 
-	const GSVertex& v = m_vertex.buff[m_index.buff[m_index.tail - 1]]; // Last vertex.
+	const GSVertex& v = m_index.tail > 0 ? m_vertex.buff[m_index.buff[m_index.tail - 1]] : GSVertex(); // Last vertex if any.
 	const GSVector4i vc = GSVector4i(v.RGBAQ.R, v.RGBAQ.G, v.RGBAQ.B, v.RGBAQ.A) // 0x000000AA000000BB000000GG000000RR
 							  .ps32(); // 0x00AA00BB00GG00RR00AA00BB00GG00RR
 


### PR DESCRIPTION
### Description of Changes
Fixes the GS sw debugger: there it happened that m_index.tail was 0 in `GSState::HandleAutoFlush`
and thus accessing the array at "m_index.tail - 1" was an invalid operation.
For safety applied the same change to the sw sprite renderer function in the hw renderer.

### Rationale behind Changes
The GS debugger crashed on my side when using the sw renderer.
These changes makes it run fine.

### Suggested Testing Steps
Well, test the GS debugger with the sw renderer, but also some games with sw and hw renderer.
This could affect autoflush in particular.
