### PR TITLE
GameDB: Driving Emotion Type-S fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -33066,8 +33066,11 @@ SLPS-20007:
   name: "Driving Emotion Type S"
   region: "NTSC-J"
   compat: 5
+  clampModes:
+    vuClampMode: 3 # Fixes missing geometry.
   gameFixes:
     - EETimingHack # Garbage in FMVs.
+    - VUSyncHack # Fixes missing geometry.
   gsHWFixes:
     textureInsideRT: 1
 SLPS-20009:


### PR DESCRIPTION
### Description of Changes
Adds VUSyncHack and VU Clamp mode Extra + Sign to Driving Emotion Type-S.

### Rationale behind Changes
The game being less broken is good.

Fixes #6873 

### Suggested Testing Steps
Make sure CI is happy.
