### PR TITLE
GameDB: Major League Baseball 2K5 Hang fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -42840,6 +42840,8 @@ SLUS-21034:
 SLUS-21035:
   name: "Major League Baseball 2K5"
   region: "NTSC-U"
+  clampModes:
+    eeClampMode: 2 # Fixes hang when the baseball hits the ground.
   patches:
     2243ce1d:
       content: |-
@@ -44307,6 +44309,8 @@ SLUS-21323:
 SLUS-21324:
   name: "Major League Baseball 2K5 [World Series Edition]"
   region: "NTSC-U"
+  clampModes:
+    eeClampMode: 2 # Fixes hang when the baseball hits the ground.
   patches:
     D592B291:
       content: |-


### PR DESCRIPTION
### Description of Changes
Adds EE Clamp Extra + Sign to MLB 2K5 and the world series edition.

### Rationale behind Changes
Less crashy more good.

### Suggested Testing Steps
Make sure CI is happy.
