### PR TITLE
Revert PR #6792

### DIFF
--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -225,6 +225,9 @@ const CRC::Game CRC::m_games[] =
 	{0xDDF76A98, BurnoutGames, JP, 0}, // BurnoutDominator
 	{0x8C9576B4, BurnoutGames, EU, 0}, // BurnoutDominator
 	{0x8C9C76B4, BurnoutGames, EU, 0}, // BurnoutDominator
+	{0x4A0E5B3A, MidnightClub3, US, 0}, // dub
+	{0xEBE1972D, MidnightClub3, EU, 0}, // dub
+	{0x60A42FF5, MidnightClub3, US, 0}, // remix
 	{0x43AB7214, TalesOfLegendia, US, 0},
 	{0x1F8640E0, TalesOfLegendia, JP, 0},
 	{0xE4F5DA2B, TalesOfLegendia, KO, 0},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -50,6 +50,7 @@ public:
 		Lamune,
 		Manhunt2,
 		MetalSlug6,
+		MidnightClub3,
 		Okami,
 		Oneechanbara2Special,
 		PolyphonyDigitalGames,

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -390,6 +390,22 @@ bool GSC_BurnoutGames(const GSFrameInfo& fi, int& skip)
 	return true;
 }
 
+bool GSC_MidnightClub3(const GSFrameInfo& fi, int& skip)
+{
+	if (skip == 0)
+	{
+		if (fi.TME && (fi.FBP > 0x01d00 && fi.FBP <= 0x02a00) && fi.FPSM == PSM_PSMCT32 && (fi.FBP >= 0x01600 && fi.FBP < 0x03260) && fi.TPSM == PSM_PSMT8H)
+		{
+			// Vram usage.
+			// Tested: tokyo default cruise.
+			// Move around a bit, stop car, wait as vram goes down, start moving again, vram spike.
+			skip = 1;
+		}
+	}
+
+	return true;
+}
+
 bool GSC_TalesOfLegendia(const GSFrameInfo& fi, int& skip)
 {
 	if (skip == 0)
@@ -831,6 +847,7 @@ void GSState::SetupCrcHack()
 		lut[CRC::KnightsOfTheTemple2] = GSC_KnightsOfTheTemple2;
 		lut[CRC::Kunoichi] = GSC_Kunoichi;
 		lut[CRC::Manhunt2] = GSC_Manhunt2;
+		lut[CRC::MidnightClub3] = GSC_MidnightClub3;
 		lut[CRC::SacredBlaze] = GSC_SacredBlaze;
 		lut[CRC::SakuraTaisen] = GSC_SakuraTaisen;
 		lut[CRC::SakuraWarsSoLongMyLove] = GSC_SakuraWarsSoLongMyLove;


### PR DESCRIPTION
### Description of Changes
Reverts the removal of the Midnight Club 3 CRC hack.

### Rationale behind Changes
The memory load can still be a problem for some users and the effect should be properly emulated before this CRC hack is removed.

### Suggested Testing Steps
Make sure CI is happy.
