### PR TITLE
GS-hw: Improve how we handle blending on 24bit with Ad factor in renderer.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -66,6 +66,7 @@
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
+#define SW_BLEND_NEEDS_RT (SW_BLEND && (PS_BLEND_A == 1 || PS_BLEND_B == 1 || PS_BLEND_C == 1 || PS_BLEND_D == 1))
 
 struct VS_INPUT
 {
@@ -762,9 +763,9 @@ void ps_blend(inout float4 Color, inout float As, float2 pos_xy)
 				return;
 		}
 
-		float4 RT = trunc(RtTexture.Load(int3(pos_xy, 0)) * 255.0f + 0.1f);
+		float4 RT = SW_BLEND_NEEDS_RT ? trunc(RtTexture.Load(int3(pos_xy, 0)) * 255.0f + 0.1f) : (float4)0.0f;
 
-		float Ad = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+		float Ad = RT.a / 128.0f;
 
 		float3 Cd = RT.rgb;
 		float3 Cs = Color.rgb;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -709,13 +709,9 @@ void ps_blend(inout vec4 Color, inout float As)
     vec4 RT = trunc(texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0) * 255.0f + 0.1f);
 #endif
 
-#if PS_DFMT == FMT_24
-    float Ad = 1.0f;
-#else
     // FIXME FMT_16 case
     // FIXME Ad or Ad * 2?
     float Ad = RT.a / 128.0f;
-#endif
 
     // Let the compiler do its jobs !
     vec3 Cd = RT.rgb;

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1008,13 +1008,9 @@ void ps_blend(inout vec4 Color, inout float As)
 				vec4 RT = vec4(0.0f);
 		#endif
 
-		#if PS_DFMT == FMT_24
-				float Ad = 1.0f;
-		#else
 				// FIXME FMT_16 case
 				// FIXME Ad or Ad * 2?
 				float Ad = RT.a / 128.0f;
-		#endif
 
 				// Let the compiler do its jobs !
 				vec3 Cd = RT.rgb;

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -823,7 +823,7 @@ struct PSMain
 					return;
 			}
 
-			float Ad = PS_DFMT == FMT_24 ? 1.f : trunc(current_color.a * 255.5f) / 128.f;
+			float Ad = trunc(current_color.a * 255.5f) / 128.f;
 
 			float3 Cd = trunc(current_color.rgb * 255.5f);
 			float3 Cs = Color.rgb;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Improve how we handle blending on 24bit with Ad factor in renderer.

This will allow us to use any previous optimizations we did where we adjust the blend equations, alpha will be 1.0 so it will be easy to hit/reuse those optimizations.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
More brr, but rare to trigger, might be difficult to find such cases.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test blending to very rare to trigger this case.