### PR TITLE
Misc: Remove a bunch of dead code

### DIFF
--- a/common/CrashHandler.cpp
+++ b/common/CrashHandler.cpp
@@ -21,7 +21,7 @@
 #include <cstdio>
 #include <ctime>
 
-#if defined(_WIN32) && !defined(_UWP)
+#if defined(_WIN32)
 #include "RedtapeWindows.h"
 
 #include "StackWalker.h"

--- a/common/D3D12/Context.cpp
+++ b/common/D3D12/Context.cpp
@@ -31,8 +31,6 @@ std::unique_ptr<D3D12::Context> g_d3d12_context;
 
 using namespace D3D12;
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-
 // Private D3D12 state
 static HMODULE s_d3d12_library;
 static PFN_D3D12_CREATE_DEVICE s_d3d12_create_device;
@@ -73,21 +71,6 @@ static void UnloadD3D12Library()
 		s_d3d12_library = nullptr;
 	}
 }
-
-#else
-
-static const PFN_D3D12_CREATE_DEVICE s_d3d12_create_device = D3D12CreateDevice;
-static const PFN_D3D12_GET_DEBUG_INTERFACE s_d3d12_get_debug_interface = D3D12GetDebugInterface;
-static const PFN_D3D12_SERIALIZE_ROOT_SIGNATURE s_d3d12_serialize_root_signature = D3D12SerializeRootSignature;
-
-static bool LoadD3D12Library()
-{
-	return true;
-}
-
-static void UnloadD3D12Library() {}
-
-#endif
 
 Context::Context() = default;
 

--- a/common/D3D12/ShaderCache.h
+++ b/common/D3D12/ShaderCache.h
@@ -48,7 +48,6 @@ namespace D3D12
 
 		__fi D3D_FEATURE_LEVEL GetFeatureLevel() const { return m_feature_level; }
 		__fi u32 GetDataVersion() const { return m_data_version; }
-		__fi bool UsingPipelineCache() const { return m_use_pipeline_cache; }
 		__fi bool UsingDebugShaders() const { return m_debug; }
 
 		bool Open(std::string_view base_path, D3D_FEATURE_LEVEL feature_level, u32 version, bool debug);
@@ -146,7 +145,6 @@ namespace D3D12
 
 		D3D_FEATURE_LEVEL m_feature_level = D3D_FEATURE_LEVEL_11_0;
 		u32 m_data_version = 0;
-		bool m_use_pipeline_cache = false;
 		bool m_debug = false;
 	};
 } // namespace D3D12

--- a/common/Exceptions.cpp
+++ b/common/Exceptions.cpp
@@ -47,7 +47,7 @@ static std::mutex s_assertion_failed_mutex;
 
 static inline void FreezeThreads(void** handle)
 {
-#if defined(_WIN32) && !defined(_UWP)
+#if defined(_WIN32)
 	HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
 	if (snapshot != INVALID_HANDLE_VALUE)
 	{
@@ -77,7 +77,7 @@ static inline void FreezeThreads(void** handle)
 
 static inline void ResumeThreads(void* handle)
 {
-#if defined(_WIN32) && !defined(_UWP)
+#if defined(_WIN32)
 	if (handle != INVALID_HANDLE_VALUE)
 	{
 		THREADENTRY32 threadEntry;
@@ -112,7 +112,7 @@ void pxOnAssertFail(const char* file, int line, const char* func, const char* ms
 	char full_msg[512];
 	std::snprintf(full_msg, sizeof(full_msg), "%s:%d: assertion failed in function %s: %s\n", file, line, func, msg);
 
-#if defined(_WIN32) && !defined(_UWP)
+#if defined(_WIN32)
 	HANDLE error_handle = GetStdHandle(STD_ERROR_HANDLE);
 	if (error_handle != INVALID_HANDLE_VALUE)
 		WriteConsoleA(GetStdHandle(STD_ERROR_HANDLE), full_msg, static_cast<DWORD>(std::strlen(full_msg)), NULL, NULL);

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -39,19 +39,6 @@
 #include <winioctl.h>
 #include <share.h>
 #include <shlobj.h>
-
-#if defined(_UWP)
-#include <fcntl.h>
-#include <io.h>
-#include <winrt/Windows.ApplicationModel.h>
-#include <winrt/Windows.Devices.Enumeration.h>
-#include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Storage.FileProperties.h>
-#include <winrt/Windows.Storage.Search.h>
-#include <winrt/Windows.Storage.h>
-#endif
-
 #else
 #include <fcntl.h>
 #include <dirent.h>
@@ -521,7 +508,7 @@ std::vector<std::string> FileSystem::GetRootDirectoryList()
 {
 	std::vector<std::string> results;
 
-#if defined(_WIN32) && !defined(_UWP)
+#if defined(_WIN32)
 	char buf[256];
 	const DWORD size = GetLogicalDriveStringsA(sizeof(buf), buf);
 	if (size != 0 && size < (sizeof(buf) - 1))
@@ -533,28 +520,6 @@ std::vector<std::string> FileSystem::GetRootDirectoryList()
 			results.emplace_back(ptr, len);
 			ptr += len + 1u;
 		}
-	}
-#elif defined(_UWP)
-	if (const auto install_location = winrt::Windows::ApplicationModel::Package::Current().InstalledLocation();
-		install_location)
-	{
-		if (const auto path = install_location.Path(); !path.empty())
-			results.push_back(StringUtil::WideStringToUTF8String(path));
-	}
-
-	if (const auto local_location = winrt::Windows::Storage::ApplicationData::Current().LocalFolder(); local_location)
-	{
-		if (const auto path = local_location.Path(); !path.empty())
-			results.push_back(StringUtil::WideStringToUTF8String(path));
-	}
-
-	const auto devices = winrt::Windows::Storage::KnownFolders::RemovableDevices();
-	const auto folders_task(devices.GetFoldersAsync());
-	for (const auto& storage_folder : folders_task.get())
-	{
-		const auto path = storage_folder.Path();
-		if (!path.empty())
-			results.push_back(StringUtil::WideStringToUTF8String(path));
 	}
 #else
 	const char* home_path = std::getenv("HOME");
@@ -595,127 +560,6 @@ std::string Path::Combine(const std::string_view& base, const std::string_view& 
 	return ret;
 }
 
-#ifdef _UWP
-static std::FILE* OpenCFileUWP(const wchar_t* wfilename, const wchar_t* mode, FileSystem::FileShareMode share_mode)
-{
-	DWORD access = 0;
-	DWORD share = 0;
-	DWORD disposition = 0;
-
-	switch (share_mode)
-	{
-		case FileSystem::FileShareMode::DenyNone:
-			share = FILE_SHARE_READ | FILE_SHARE_WRITE;
-			break;
-		case FileSystem::FileShareMode::DenyRead:
-			share = FILE_SHARE_WRITE;
-			break;
-		case FileSystem::FileShareMode::DenyWrite:
-			share = FILE_SHARE_READ;
-			break;
-		case FileSystem::FileShareMode::DenyReadWrite:
-		default:
-			share = 0;
-			break;
-	}
-
-	int flags = 0;
-	const wchar_t* tmode = mode;
-	while (*tmode)
-	{
-		if (*tmode == L'r' && *(tmode + 1) == L'+')
-		{
-			access = GENERIC_READ | GENERIC_WRITE;
-			disposition = OPEN_EXISTING;
-			flags |= _O_RDWR;
-			tmode += 2;
-		}
-		else if (*tmode == L'w' && *(tmode + 1) == L'+')
-		{
-			access = GENERIC_READ | GENERIC_WRITE;
-			disposition = CREATE_ALWAYS;
-			flags |= _O_RDWR | _O_CREAT | _O_TRUNC;
-			tmode += 2;
-		}
-		else if (*tmode == L'a' && *(tmode + 1) == L'+')
-		{
-			access = GENERIC_READ | GENERIC_WRITE;
-			disposition = CREATE_ALWAYS;
-			flags |= _O_RDWR | _O_APPEND | _O_CREAT | _O_TRUNC;
-			tmode += 2;
-		}
-		else if (*tmode == L'r')
-		{
-			access = GENERIC_READ;
-			disposition = OPEN_EXISTING;
-			flags |= _O_RDONLY;
-			tmode++;
-		}
-		else if (*tmode == L'w')
-		{
-			access = GENERIC_WRITE;
-			disposition = CREATE_ALWAYS;
-			flags |= _O_WRONLY | _O_CREAT | _O_TRUNC;
-			tmode++;
-		}
-		else if (*tmode == L'a')
-		{
-			access = GENERIC_READ | GENERIC_WRITE;
-			disposition = CREATE_ALWAYS;
-			flags |= _O_WRONLY | _O_APPEND | _O_CREAT | _O_TRUNC;
-			tmode++;
-		}
-		else if (*tmode == L'b')
-		{
-			flags |= _O_BINARY;
-			tmode++;
-		}
-		else if (*tmode == L'S')
-		{
-			flags |= _O_SEQUENTIAL;
-			tmode++;
-		}
-		else if (*tmode == L'R')
-		{
-			flags |= _O_RANDOM;
-			tmode++;
-		}
-		else
-		{
-			Console.Error("Unknown mode flags: '%s'", StringUtil::WideStringToUTF8String(mode).c_str());
-			return nullptr;
-		}
-	}
-
-	HANDLE hFile = CreateFileFromAppW(wfilename, access, share, nullptr, disposition, 0, nullptr);
-	if (hFile == INVALID_HANDLE_VALUE)
-		return nullptr;
-
-	if (flags & _O_APPEND && !SetFilePointerEx(hFile, LARGE_INTEGER{}, nullptr, FILE_END))
-	{
-		Console.Error("SetFilePointerEx() failed: %08X", GetLastError());
-		CloseHandle(hFile);
-		return nullptr;
-	}
-
-	int fd = _open_osfhandle(reinterpret_cast<intptr_t>(hFile), flags);
-	if (fd < 0)
-	{
-		CloseHandle(hFile);
-		return nullptr;
-	}
-
-	std::FILE* fp = _wfdopen(fd, mode);
-	if (!fp)
-	{
-		_close(fd);
-		return nullptr;
-	}
-
-	return fp;
-}
-#endif // _UWP
-
 std::FILE* FileSystem::OpenCFile(const char* filename, const char* mode)
 {
 #ifdef _WIN32
@@ -725,13 +569,7 @@ std::FILE* FileSystem::OpenCFile(const char* filename, const char* mode)
 	{
 		std::FILE* fp;
 		if (_wfopen_s(&fp, wfilename.c_str(), wmode.c_str()) != 0)
-		{
-#ifdef _UWP
-			return OpenCFileUWP(wfilename.c_str(), wmode.c_str(), FileShareMode::DenyReadWrite);
-#else
 			return nullptr;
-#endif
-		}
 
 		return fp;
 	}
@@ -751,10 +589,7 @@ int FileSystem::OpenFDFile(const char* filename, int flags, int mode)
 #ifdef _WIN32
 	const std::wstring wfilename(StringUtil::UTF8StringToWideString(filename));
 	if (!wfilename.empty())
-	{
-		// TODO: UWP
 		return _wopen(wfilename.c_str(), flags, mode);
-	}
 
 	return -1;
 #else
@@ -797,11 +632,7 @@ std::FILE* FileSystem::OpenSharedCFile(const char* filename, const char* mode, F
 	if (fp)
 		return fp;
 
-#ifdef _UWP
-	return OpenCFileUWP(wfilename.c_str(), wmode.c_str(), share_mode);
-#else
 	return nullptr;
-#endif
 #else
 	return std::fopen(filename, mode);
 #endif
@@ -1027,19 +858,6 @@ static u32 TranslateWin32Attributes(u32 Win32Attributes)
 	return r;
 }
 
-static DWORD WrapGetFileAttributes(const wchar_t* path)
-{
-#ifndef _UWP
-	return GetFileAttributesW(path);
-#else
-	WIN32_FILE_ATTRIBUTE_DATA fad;
-	if (!GetFileAttributesExFromAppW(path, GetFileExInfoStandard, &fad))
-		return INVALID_FILE_ATTRIBUTES;
-
-	return fad.dwFileAttributes;
-#endif
-}
-
 static u32 RecursiveFindFiles(const char* origin_path, const char* parent_path, const char* path, const char* pattern,
 	u32 flags, FileSystem::FindResultsArray* results)
 {
@@ -1061,13 +879,7 @@ static u32 RecursiveFindFiles(const char* origin_path, const char* parent_path, 
 	std::string utf8_filename;
 	utf8_filename.reserve((sizeof(wfd.cFileName) / sizeof(wfd.cFileName[0])) * 2);
 
-#ifndef _UWP
 	HANDLE hFind = FindFirstFileW(StringUtil::UTF8StringToWideString(tempStr).c_str(), &wfd);
-#else
-	HANDLE hFind = FindFirstFileExFromAppW(StringUtil::UTF8StringToWideString(tempStr).c_str(), FindExInfoBasic, &wfd,
-		FindExSearchNameMatch, nullptr, 0);
-#endif
-
 	if (hFind == INVALID_HANDLE_VALUE)
 		return 0;
 
@@ -1249,7 +1061,6 @@ bool FileSystem::StatFile(const char* path, FILESYSTEM_STAT_DATA* sd)
 	if (wpath.empty())
 		return false;
 
-#ifndef _UWP
 	// determine attributes for the path. if it's a directory, things have to be handled differently..
 	DWORD fileAttributes = GetFileAttributesW(wpath.c_str());
 	if (fileAttributes == INVALID_FILE_ATTRIBUTES)
@@ -1289,17 +1100,6 @@ bool FileSystem::StatFile(const char* path, FILESYSTEM_STAT_DATA* sd)
 	sd->ModificationTime = ConvertFileTimeToUnixTime(bhfi.ftLastWriteTime);
 	sd->Size = static_cast<s64>(((u64)bhfi.nFileSizeHigh) << 32 | (u64)bhfi.nFileSizeLow);
 	return true;
-#else
-	WIN32_FILE_ATTRIBUTE_DATA fad;
-	if (!GetFileAttributesExFromAppW(wpath, GetFileExInfoStandard, &fad))
-		return false;
-
-	sd->Attributes = TranslateWin32Attributes(fad.dwFileAttributes);
-	sd->CreationTime = ConvertFileTimeToUnixTime(fad.ftCreationTime);
-	sd->ModificationTime = ConvertFileTimeToUnixTime(fad.ftLastWriteTime);
-	sd->Size = static_cast<s64>(((u64)fad.nFileSizeHigh) << 32 | (u64)fad.nFileSizeLow);
-	return true;
-#endif
 }
 
 bool FileSystem::StatFile(std::FILE* fp, FILESYSTEM_STAT_DATA* sd)
@@ -1340,7 +1140,7 @@ bool FileSystem::FileExists(const char* path)
 		return false;
 
 	// determine attributes for the path. if it's a directory, things have to be handled differently..
-	DWORD fileAttributes = WrapGetFileAttributes(wpath.c_str());
+	DWORD fileAttributes = GetFileAttributesW(wpath.c_str());
 	if (fileAttributes == INVALID_FILE_ATTRIBUTES)
 		return false;
 
@@ -1362,7 +1162,7 @@ bool FileSystem::DirectoryExists(const char* path)
 		return false;
 
 	// determine attributes for the path. if it's a directory, things have to be handled differently..
-	DWORD fileAttributes = WrapGetFileAttributes(wpath.c_str());
+	DWORD fileAttributes = GetFileAttributesW(wpath.c_str());
 	if (fileAttributes == INVALID_FILE_ATTRIBUTES)
 		return false;
 
@@ -1378,11 +1178,7 @@ bool FileSystem::DirectoryIsEmpty(const char* path)
 	wpath += L"\\*";
 
 	WIN32_FIND_DATAW wfd;
-#ifndef _UWP
 	HANDLE hFind = FindFirstFileW(wpath.c_str(), &wfd);
-#else
-	HANDLE hFind = FindFirstFileExFromAppW(wpath.c_str(), FindExInfoBasic, &wfd, FindExSearchNameMatch, nullptr, 0);
-#endif
 
 	if (hFind == INVALID_HANDLE_VALUE)
 		return true;
@@ -1411,14 +1207,9 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 	if (wpath.empty())
 		return false;
 
-		// try just flat-out, might work if there's no other segments that have to be made
-#ifndef _UWP
+	// try just flat-out, might work if there's no other segments that have to be made
 	if (CreateDirectoryW(wpath.c_str(), nullptr))
 		return true;
-#else
-	if (CreateDirectoryFromAppW(wpath.c_str(), nullptr))
-		return true;
-#endif
 
 	if (!Recursive)
 		return false;
@@ -1428,7 +1219,7 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 	if (lastError == ERROR_ALREADY_EXISTS)
 	{
 		// check the attributes
-		u32 Attributes = WrapGetFileAttributes(wpath.c_str());
+		u32 Attributes = GetFileAttributesW(wpath.c_str());
 		if (Attributes != INVALID_FILE_ATTRIBUTES && Attributes & FILE_ATTRIBUTE_DIRECTORY)
 			return true;
 		else
@@ -1447,11 +1238,7 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 		{
 			if (wpath[i] == L'\\' || wpath[i] == L'/')
 			{
-#ifndef _UWP
 				const BOOL result = CreateDirectoryW(tempPath.c_str(), nullptr);
-#else
-				const BOOL result = CreateDirectoryFromAppW(tempPath.c_str(), nullptr);
-#endif
 				if (!result)
 				{
 					lastError = GetLastError();
@@ -1471,11 +1258,7 @@ bool FileSystem::CreateDirectoryPath(const char* Path, bool Recursive)
 		// re-create the end if it's not a separator, check / as well because windows can interpret them
 		if (wpath[pathLength - 1] != L'\\' && wpath[pathLength - 1] != L'/')
 		{
-#ifndef _UWP
 			const BOOL result = CreateDirectoryW(wpath.c_str(), nullptr);
-#else
-			const BOOL result = CreateDirectoryFromAppW(wpath.c_str(), nullptr);
-#endif
 			if (!result)
 			{
 				lastError = GetLastError();
@@ -1500,15 +1283,11 @@ bool FileSystem::DeleteFilePath(const char* path)
 		return false;
 
 	const std::wstring wpath(StringUtil::UTF8StringToWideString(path));
-	const DWORD fileAttributes = WrapGetFileAttributes(wpath.c_str());
+	const DWORD fileAttributes = GetFileAttributesW(wpath.c_str());
 	if (fileAttributes == INVALID_FILE_ATTRIBUTES || fileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		return false;
 
-#ifndef _UWP
 	return (DeleteFileW(wpath.c_str()) == TRUE);
-#else
-	return (DeleteFileFromAppW(wpath.c_str()) == TRUE);
-#endif
 }
 
 bool FileSystem::RenamePath(const char* old_path, const char* new_path)
@@ -1516,29 +1295,11 @@ bool FileSystem::RenamePath(const char* old_path, const char* new_path)
 	const std::wstring old_wpath(StringUtil::UTF8StringToWideString(old_path));
 	const std::wstring new_wpath(StringUtil::UTF8StringToWideString(new_path));
 
-#ifndef _UWP
 	if (!MoveFileExW(old_wpath.c_str(), new_wpath.c_str(), MOVEFILE_REPLACE_EXISTING))
 	{
 		Console.Error("MoveFileEx('%s', '%s') failed: %08X", old_path, new_path, GetLastError());
 		return false;
 	}
-#else
-	// try moving if it doesn't exist, since ReplaceFile fails on non-existing destinations
-	if (WrapGetFileAttributes(new_wpath.c_str()) != INVALID_FILE_ATTRIBUTES)
-	{
-		if (!DeleteFileFromAppW(new_wpath.c_str()))
-		{
-			Log_ErrorPrintf("DeleteFileFromAppW('%s') failed: %08X", new_wpath.c_str(), GetLastError());
-			return false;
-		}
-	}
-
-	if (!MoveFileFromAppW(old_wpath.c_str(), new_wpath.c_str()))
-	{
-		Log_ErrorPrintf("MoveFileFromAppW('%s', '%s') failed: %08X", old_path, new_path, GetLastError());
-		return false;
-	}
-#endif
 
 	return true;
 }
@@ -1556,10 +1317,8 @@ std::string FileSystem::GetProgramPath()
 
 	// Fall back to the main module if this fails.
 	HMODULE module = nullptr;
-#ifndef _UWP
 	GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
 		reinterpret_cast<LPCWSTR>(&GetProgramPath), &module);
-#endif
 
 	for (;;)
 	{

--- a/common/Vulkan/Loader.cpp
+++ b/common/Vulkan/Loader.cpp
@@ -69,11 +69,7 @@ namespace Vulkan
 			return true;
 		}
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
 		vulkan_module = LoadLibraryA("vulkan-1.dll");
-#else
-		vulkan_module = NULL;
-#endif
 		if (!vulkan_module)
 		{
 			std::fprintf(stderr, "Failed to load vulkan-1.dll\n");

--- a/common/WindowInfo.cpp
+++ b/common/WindowInfo.cpp
@@ -18,7 +18,7 @@
 #include "WindowInfo.h"
 #include "Console.h"
 
-#if defined(_WIN32) && !defined(_UWP)
+#if defined(_WIN32)
 
 #include "RedtapeWindows.h"
 #include <dwmapi.h>

--- a/pcsx2/Frontend/D3D11HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D11HostDisplay.cpp
@@ -217,11 +217,7 @@ bool D3D11HostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view
 		create_flags |= D3D11_CREATE_DEVICE_DEBUG;
 
 	ComPtr<IDXGIFactory> temp_dxgi_factory;
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 	HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(temp_dxgi_factory.GetAddressOf()));
-#else
-	HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(temp_dxgi_factory.GetAddressOf()));
-#endif
 	if (FAILED(hr))
 	{
 		Console.Error("Failed to create DXGI factory: 0x%08X", hr);
@@ -345,9 +341,6 @@ bool D3D11HostDisplay::DoneRenderContextCurrent()
 
 bool D3D11HostDisplay::CreateSwapChain(const DXGI_MODE_DESC* fullscreen_mode)
 {
-	HRESULT hr;
-
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 	if (m_window_info.type != WindowInfo::Type::Win32)
 		return false;
 
@@ -385,7 +378,7 @@ bool D3D11HostDisplay::CreateSwapChain(const DXGI_MODE_DESC* fullscreen_mode)
 		swap_chain_desc.BufferDesc.Height, m_using_flip_model_swap_chain ? "flip-discard" : "discard",
 		swap_chain_desc.Windowed ? "windowed" : "full-screen");
 
-	hr = m_dxgi_factory->CreateSwapChain(m_device.Get(), &swap_chain_desc, m_swap_chain.GetAddressOf());
+	HRESULT hr = m_dxgi_factory->CreateSwapChain(m_device.Get(), &swap_chain_desc, m_swap_chain.GetAddressOf());
 	if (FAILED(hr) && m_using_flip_model_swap_chain)
 	{
 		Console.Warning("Failed to create a flip-discard swap chain, trying discard.");
@@ -410,42 +403,6 @@ bool D3D11HostDisplay::CreateSwapChain(const DXGI_MODE_DESC* fullscreen_mode)
 		if (FAILED(hr))
 			Console.Warning("MakeWindowAssociation() to disable ALT+ENTER failed");
 	}
-#else
-	if (m_window_info.type != WindowInfo::Type::WinRT)
-		return false;
-
-	ComPtr<IDXGIFactory2> factory2;
-	hr = m_dxgi_factory.As(&factory2);
-	if (FAILED(hr))
-	{
-		Console.Error("Failed to get DXGI factory: %08X", hr);
-		return false;
-	}
-
-	DXGI_SWAP_CHAIN_DESC1 swap_chain_desc = {};
-	swap_chain_desc.Width = m_window_info.surface_width;
-	swap_chain_desc.Height = m_window_info.surface_height;
-	swap_chain_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-	swap_chain_desc.SampleDesc.Count = 1;
-	swap_chain_desc.BufferCount = 3;
-	swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-	swap_chain_desc.SwapEffect = m_using_flip_model_swap_chain ? DXGI_SWAP_EFFECT_FLIP_DISCARD : DXGI_SWAP_EFFECT_DISCARD;
-
-	m_using_allow_tearing = (m_allow_tearing_supported && m_using_flip_model_swap_chain && !fullscreen_mode);
-	if (m_using_allow_tearing)
-		swap_chain_desc.Flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
-
-	ComPtr<IDXGISwapChain1> swap_chain1;
-	hr = factory2->CreateSwapChainForCoreWindow(m_device.Get(), static_cast<IUnknown*>(m_window_info.window_handle),
-		&swap_chain_desc, nullptr, swap_chain1.GetAddressOf());
-	if (FAILED(hr))
-	{
-		Console.Error("CreateSwapChainForCoreWindow failed: 0x%08X", hr);
-		return false;
-	}
-
-	m_swap_chain = swap_chain1;
-#endif
 
 	return CreateSwapChainRTV();
 }
@@ -865,11 +822,7 @@ float D3D11HostDisplay::GetAndResetAccumulatedGPUTime()
 HostDisplay::AdapterAndModeList D3D11HostDisplay::StaticGetAdapterAndModeList()
 {
 	ComPtr<IDXGIFactory> dxgi_factory;
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-	HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(dxgi_factory.GetAddressOf()));
-#else
-	HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(dxgi_factory.GetAddressOf()));
-#endif
+	const HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(dxgi_factory.GetAddressOf()));
 	if (FAILED(hr))
 		return {};
 

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -24,13 +24,13 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include <wrl/client.h>
+#include <wil/com.h>
 
 class D3D11HostDisplay final : public HostDisplay
 {
 public:
 	template <typename T>
-	using ComPtr = Microsoft::WRL::ComPtr<T>;
+	using ComPtr = wil::com_ptr_nothrow<T>;
 
 	D3D11HostDisplay();
 	~D3D11HostDisplay();

--- a/pcsx2/Frontend/XInputSource.cpp
+++ b/pcsx2/Frontend/XInputSource.cpp
@@ -96,7 +96,6 @@ XInputSource::~XInputSource() = default;
 
 bool XInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 	// xinput1_3.dll is flawed and obsolete, but it's also commonly used by wrappers.
 	// For this reason, try to load it *only* from the application directory, and not system32.
 	m_xinput_module = LoadLibraryExW(L"xinput1_3", nullptr, LOAD_LIBRARY_SEARCH_APPLICATION_DIR);
@@ -127,12 +126,6 @@ bool XInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex
 	// SCP extension, only exists when the bridge xinput1_3.dll is in use
 	m_xinput_get_extended =
 		reinterpret_cast<decltype(m_xinput_get_extended)>(GetProcAddress(m_xinput_module, "XInputGetExtended"));
-#else
-	m_xinput_get_state = XInputGetState;
-	m_xinput_set_state = XInputSetState;
-	m_xinput_get_capabilities = XInputGetCapabilities;
-	m_xinput_get_extended = nullptr;
-#endif
 	if (!m_xinput_get_state || !m_xinput_set_state || !m_xinput_get_capabilities)
 	{
 		Console.Error("Failed to get XInput function pointers.");
@@ -154,13 +147,11 @@ void XInputSource::Shutdown()
 			HandleControllerDisconnection(i);
 	}
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 	if (m_xinput_module)
 	{
 		FreeLibrary(m_xinput_module);
 		m_xinput_module = nullptr;
 	}
-#endif
 
 	m_xinput_get_state = nullptr;
 	m_xinput_set_state = nullptr;


### PR DESCRIPTION
### Description of Changes

Leftover bits from code I pulled in from duckstation which isn't needed, and I've also removed there.

Also migrates D3D11HostDispaly from wrl to wil, to be consistent with the rest of the application.

### Rationale behind Changes

No point keeping dead code around.

### Suggested Testing Steps

Make sure it compiles and normal use is fine (check DX11).
