### PR TITLE
CMake: Throw error when building Qt with PACKAGE_MODE

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_AUTOUIC ON)
 add_executable(pcsx2-qt)
 
 if (PACKAGE_MODE)
-	install(TARGETS pcsx2-qt DESTINATION ${CMAKE_INSTALL_BINDIR})
+	message(FATAL_ERROR "Package mode is not supported for Qt builds.")
 else()
 	install(TARGETS pcsx2-qt DESTINATION ${CMAKE_SOURCE_DIR}/bin)
 endif()


### PR DESCRIPTION
### Description of Changes

We don't support this.

1. It doesn't make sense to put data in /usr/share since it's not shared between applications.
2. Makes the application not self-contained for easily being moved/removed.
3. Means you can't have multiple versions installed.
4. Every other platform is self-contained (Windows, Mac).

### Rationale behind Changes

Less confusion when someone builds with the option, and then gets a resources not found error (e.g. https://github.com/PCSX2/pcsx2/issues/6939).

### Suggested Testing Steps

Make sure CI still builds.
