### PR TITLE
GS:SW: Don't clamp scissor to fbw

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1490,9 +1490,8 @@ void GSState::GIFRegHandlerFRAME(const GIFReg* RESTRICT r)
 	GL_REG("FRAME_%d = 0x%x_%x", i, r->U32[1], r->U32[0]);
 
 	GIFRegFRAME NewFrame = r->FRAME;
-	// FBW is clamped between 1 and 32, however this is wrong, FBW of 0 *should* work and does on Dobiestation
-	// However there is some issues so even software mode is incorrect on PCSX2, but this works better..
-	NewFrame.FBW = std::clamp(NewFrame.FBW, 1U, 32U);
+	// FBW is clamped to 32
+	NewFrame.FBW = std::min(NewFrame.FBW, 32U);
 
 	if ((NewFrame.PSM & 0x30) == 0x30)
 		m_env.CTXT[i].ZBUF.PSM &= ~0x30;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1284,12 +1284,6 @@ void GSRendererHW::Draw()
 	GSDrawingContext* context = m_context;
 	const GSLocalMemory::psm_t& tex_psm = GSLocalMemory::m_psm[m_context->TEX0.PSM];
 
-	if (!context->FRAME.FBW)
-	{
-		GL_CACHE("Skipping draw with FRAME.FBW = 0.");
-		return;
-	}
-
 	// When the format is 24bit (Z or C), DATE ceases to function.
 	// It was believed that in 24bit mode all pixels pass because alpha doesn't exist
 	// however after testing this on a PS2 it turns out nothing passes, it ignores the draw.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3906,8 +3906,6 @@ bool GSRendererHW::SwPrimRender()
 			bbox.w++;
 	}
 
-	scissor.z = std::min<int>(scissor.z, (int)context->FRAME.FBW * 64); // TODO: find a game that overflows and check which one is the right behaviour
-
 	data.scissor = scissor;
 	data.bbox = bbox;
 	data.frame = g_perfmon.GetFrame();

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -368,8 +368,6 @@ void GSRendererSW::Draw()
 
 	GSVector4i r = bbox.rintersect(scissor);
 
-	scissor.z = std::min<int>(scissor.z, (int)context->FRAME.FBW * 64); // TODO: find a game that overflows and check which one is the right behaviour
-
 	sd->scissor = scissor;
 	sd->bbox = bbox;
 	sd->frame = g_perfmon.GetFrame();


### PR DESCRIPTION
### Description of Changes
- Removes clamping of scissor to fbw
- Removes clamping of fbw from 0 to 1

### Rationale behind Changes
PS2 HW tests indicate that this doesn't happen

### Suggested Testing Steps
- Test this GSdump: [NFSMW_SWSquares.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9457506/NFSMW_SWSquares.gs.xz.zip)
- Test these elves: [fbwtest.zip](https://github.com/PCSX2/pcsx2/files/9457562/fbwtest.zip)
- Test stuff from #5569

<details>
<summary>Screenshots</summary>

NFS Most Wanted Before:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/3315070/187571052-6f723d6c-d873-4866-a2b3-513e7952f963.png">

NFS Most Wanted After:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/3315070/187571222-fd36b0dd-0bd5-40ab-a6d1-f74255429d46.png">

FBW0 Before:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/3315070/187571095-a28dde98-e6f4-4c82-9254-00b929430f43.png">

FBW0 After:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/3315070/187571568-8484a5b0-9fd0-4a8f-823c-aebf3b3e009f.png">

FBW1 Before:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/3315070/187571127-c01b56c1-e9fa-4313-b5eb-60de059bec29.png">

FBW1 After:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/3315070/187571273-223e08ca-4e45-4436-a0d8-b2f819d9599f.png">
</details>
