### PR TITLE
Qt: Scroll GameList by pixels using the scrollwheel

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -27,6 +27,7 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QMenu>
+#include <QtWidgets/QScrollBar>
 
 #include "GameListModel.h"
 #include "GameListRefreshThread.h"
@@ -184,6 +185,7 @@ void GameListWidget::initialize()
 	m_list_view->setFrameStyle(QFrame::NoFrame);
 	m_list_view->setSpacing(m_model->getCoverArtSpacing());
 	m_list_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
+	m_list_view->verticalScrollBar()->setSingleStep(15);
 
 	updateListFont();
 


### PR DESCRIPTION
### Description of Changes
When scrolling the GameList table 1 step was actualy a whole page, now it's scrolling by 15 pixels

### Rationale behind Changes
When scrolling through your Game List you'd get lost on how much you actually scrolled, I propose a different behaviour than how it is currently.
It depends on what you are used to, but I feel like this resembles how you generally scroll content a bit more reasonably
From my testing, now the speed is affected by your OS's mouse settings, so if you change your "Scrolled Lines" settings in Windows, you will notice that you also scroll more here. 

So if you feel like this scrolling speed is too slow you can adjust the OS level

### Suggested Testing Steps
- Test with different mouse drivers that let you set your _scroll distance_
- Test changing the scrolled lines settings in Windows
- Test if behaviour differs on linux

### Note:
I'm not entirely sure if this arbitrary number (15) is the most satisfactory speed but it feels like a good baseline,

<details>
  <summary>Demonstration:</summary>

## Before:
  ![pcsx2-qtx64_agAIXs8CKO](https://user-images.githubusercontent.com/2606522/187743329-2e124c57-9a8e-4c2a-b2af-50026eca493b.gif)

## After:
  ![pcsx2-qtx64_dtJ7BJKDfF](https://user-images.githubusercontent.com/2606522/187743320-49d203ca-f8c7-44c5-9677-cecb89cce9d8.gif)
</details>

Close https://github.com/PCSX2/pcsx2/issues/6822