### PR TITLE
GS-hw: Remove remaining 24bit destination checks for Ad.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -890,7 +890,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 	if (PS_BLEND_C == 1 && PS_CLR_HW > 3)
 	{
 		float4 RT = trunc(RtTexture.Load(int3(input.p.xy, 0)) * 255.0f + 0.1f);
-		alpha_blend = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+		alpha_blend = RT.a / 128.0f;
 	}
 	else
 	{

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -938,7 +938,7 @@ void ps_main()
 #else
     vec4 RT = trunc(texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0) * 255.0f + 0.1f);
 #endif
-    float alpha_blend = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+    float alpha_blend = RT.a / 128.0f;
 #else
     float alpha_blend = C.a / 128.0f;
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1194,7 +1194,7 @@ void main()
 
 #if (PS_BLEND_C == 1 && PS_CLR_HW > 3)
   vec4 RT = trunc(subpassLoad(RtSampler) * 255.0f + 0.1f);
-  float alpha_blend = (PS_DFMT == FMT_24) ? 1.0f : RT.a / 128.0f;
+  float alpha_blend = RT.a / 128.0f;
 #else
   float alpha_blend = C.a / 128.0f;
 #endif

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -941,7 +941,7 @@ struct PSMain
 			C.a = 128.0f;
 		}
 
-		float alpha_blend = SW_AD_TO_HW ? (PS_DFMT == FMT_24 ? 1.f : trunc(current_color.a * 255.5f) / 128.f) : (C.a / 128.f);
+		float alpha_blend = SW_AD_TO_HW ? (trunc(current_color.a * 255.5f) / 128.f) : (C.a / 128.f);
 
 		if (PS_DFMT == FMT_16)
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Remove remaining 24bit destination checks for Ad.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Follow up from https://github.com/PCSX2/pcsx2/pull/6923
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Compiles, no bad shader errors.