### PR TITLE
microVU: Fix program dumping

### DIFF
--- a/pcsx2/x86/microVU_Log.inl
+++ b/pcsx2/x86/microVU_Log.inl
@@ -55,7 +55,7 @@ void __mVUdumpProgram(microVU& mVU, microProgram& prog)
 	int bPC     = iPC;
 	mVUbranch   = 0;
 
-	const std::string logname(fmt::format("microVU{} prog - {:02d}.html"), mVU.index, prog.idx);
+	const std::string logname(fmt::format("microVU{} prog - {:02d}.html", mVU.index, prog.idx));
 	mVU.logFile = FileSystem::OpenCFile(Path::Combine(EmuFolders::Logs, logname).c_str(), "w");
 	if (!mVU.logFile)
 		return;


### PR DESCRIPTION
### Description of Changes

Invalid format string which caused a crash at runtime.

### Rationale behind Changes

Crash bad.

### Suggested Testing Steps

You can't really test this since it's a compile-time option, but I have tested locally.
