### PR TITLE
GameDB: Corvette game fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13435,6 +13435,11 @@ SLES-52219:
   name: "Corvette"
   region: "PAL-M3"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 1 # Increases FPS drastically.
+    MTVUSpeedHack: 0
+  gsHWFixes:
+    halfPixelOffset: 3 # Reduces ghosting.
 SLES-52230:
   name: "Muppets Party Cruise"
   region: "PAL-E-F"
@@ -41918,9 +41923,14 @@ SLUS-20857:
   region: "NTSC-U"
   compat: 5
 SLUS-20858:
-  name: "Corvette 50th Anniversary"
+  name: "Corvette"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 1 # Increases FPS drastically.
+    MTVUSpeedHack: 0
+  gsHWFixes:
+    halfPixelOffset: 3 # Reduces ghosting.
 SLUS-20859:
   name: "Future Tactics - The Uprising"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds half pixel offset special aggressive and disables MTVU for Corvette.

### Rationale behind Changes
brrr

### Suggested Testing Steps
Make sure CI is happy.
