### PR TITLE
Better PrimID destination alpha support

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -102,7 +102,7 @@ struct PS_INPUT
 #else
 	nointerpolation float4 c : COLOR0;
 #endif
-#if PS_DATE > 10 || PS_DATE == 3
+#if PS_DATE >= 1 && PS_DATE <= 3
 	uint primid : SV_PrimitiveID;
 #endif
 };
@@ -110,7 +110,7 @@ struct PS_INPUT
 struct PS_OUTPUT
 {
 #if !PS_NO_COLOR
-#if PS_DATE > 10
+#if PS_DATE == 1 || PS_DATE == 2
 	float c : SV_Target;
 #else
 	float4 c0 : SV_Target0;
@@ -918,12 +918,12 @@ PS_OUTPUT ps_main(PS_INPUT input)
 #endif
 
 	// Get first primitive that will write a failling alpha value
-#if PS_DATE == 11
+#if PS_DATE == 1
 	// DATM == 0
 	// Pixel with alpha equal to 1 will failed (128-255)
 	output.c = (C.a > 127.5f) ? float(input.primid) : float(0x7FFFFFFF);
 
-#elif PS_DATE == 12
+#elif PS_DATE == 2
 
 	// DATM == 1
 	// Pixel with alpha equal to 0 will failed (0-127)

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -13,6 +13,7 @@
 #ifndef GS_IIP
 #define GS_IIP 0
 #define GS_PRIM 3
+#define GS_FORWARD_PRIMID 0
 #endif
 
 #ifndef PS_FST
@@ -102,7 +103,7 @@ struct PS_INPUT
 #else
 	nointerpolation float4 c : COLOR0;
 #endif
-#if PS_DATE >= 1 && PS_DATE <= 3
+#if (PS_DATE >= 1 && PS_DATE <= 3) || GS_FORWARD_PRIMID
 	uint primid : SV_PrimitiveID;
 #endif
 };
@@ -1026,13 +1027,40 @@ VS_OUTPUT vs_main(VS_INPUT input)
 // Geometry Shader
 //////////////////////////////////////////////////////////////////////
 
+#if GS_FORWARD_PRIMID
+#define PRIMID_IN , uint primid : SV_PrimitiveID
+#define VS2PS(x) vs2ps_impl(x, primid)
+PS_INPUT vs2ps_impl(VS_OUTPUT vs, uint primid)
+{
+	PS_INPUT o;
+	o.p = vs.p;
+	o.t = vs.t;
+	o.ti = vs.ti;
+	o.c = vs.c;
+	o.primid = primid;
+	return o;
+}
+#else
+#define PRIMID_IN
+#define VS2PS(x) vs2ps_impl(x)
+PS_INPUT vs2ps_impl(VS_OUTPUT vs)
+{
+	PS_INPUT o;
+	o.p = vs.p;
+	o.t = vs.t;
+	o.ti = vs.ti;
+	o.c = vs.c;
+	return o;
+}
+#endif
+
 #if GS_PRIM == 0
 
 [maxvertexcount(6)]
-void gs_main(point VS_OUTPUT input[1], inout TriangleStream<VS_OUTPUT> stream)
+void gs_main(point VS_OUTPUT input[1], inout TriangleStream<PS_INPUT> stream PRIMID_IN)
 {
 	// Transform a point to a NxN sprite
-	VS_OUTPUT Point = input[0];
+	PS_INPUT Point = VS2PS(input[0]);
 
 	// Get new position
 	float4 lt_p = input[0].p;
@@ -1066,11 +1094,11 @@ void gs_main(point VS_OUTPUT input[1], inout TriangleStream<VS_OUTPUT> stream)
 #elif GS_PRIM == 1
 
 [maxvertexcount(6)]
-void gs_main(line VS_OUTPUT input[2], inout TriangleStream<VS_OUTPUT> stream)
+void gs_main(line VS_OUTPUT input[2], inout TriangleStream<PS_INPUT> stream PRIMID_IN)
 {
 	// Transform a line to a thick line-sprite
-	VS_OUTPUT left = input[0];
-	VS_OUTPUT right = input[1];
+	PS_INPUT left = VS2PS(input[0]);
+	PS_INPUT right = VS2PS(input[1]);
 	float2 lt_p = input[0].p.xy;
 	float2 rt_p = input[1].p.xy;
 
@@ -1114,10 +1142,10 @@ void gs_main(line VS_OUTPUT input[2], inout TriangleStream<VS_OUTPUT> stream)
 #elif GS_PRIM == 3
 
 [maxvertexcount(4)]
-void gs_main(line VS_OUTPUT input[2], inout TriangleStream<VS_OUTPUT> stream)
+void gs_main(line VS_OUTPUT input[2], inout TriangleStream<PS_INPUT> stream PRIMID_IN)
 {
-	VS_OUTPUT lt = input[0];
-	VS_OUTPUT rb = input[1];
+	PS_INPUT lt = VS2PS(input[0]);
+	PS_INPUT rb = VS2PS(input[1]);
 
 	// flat depth
 	lt.p.z = rb.p.z;
@@ -1128,13 +1156,13 @@ void gs_main(line VS_OUTPUT input[2], inout TriangleStream<VS_OUTPUT> stream)
 	lt.c = rb.c;
 
 	// Swap texture and position coordinate
-	VS_OUTPUT lb = rb;
+	PS_INPUT lb = rb;
 	lb.p.x = lt.p.x;
 	lb.t.x = lt.t.x;
 	lb.ti.x = lt.ti.x;
 	lb.ti.z = lt.ti.z;
 
-	VS_OUTPUT rt = rb;
+	PS_INPUT rt = rb;
 	rt.p.y = lt.p.y;
 	rt.t.y = lt.t.y;
 	rt.ti.y = lt.ti.y;

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -378,4 +378,21 @@ void ps_yuv()
 }
 #endif
 
+#if defined(ps_stencil_image_init_0) || defined(ps_stencil_image_init_1)
+
+void main()
+{
+    SV_Target0 = vec4(0x7FFFFFFF);
+
+    #ifdef ps_stencil_image_init_0
+        if((127.5f / 255.0f) < sample_c().a) // < 0x80 pass (== 0x80 should not pass)
+            SV_Target0 = vec4(-1);
+    #endif
+    #ifdef ps_stencil_image_init_1
+        if(sample_c().a < (127.5f / 255.0f)) // >= 0x80 pass
+            SV_Target0 = vec4(-1);
+    #endif
+}
+#endif
+
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -348,7 +348,7 @@ void main()
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
 #define SW_BLEND_NEEDS_RT (PS_BLEND_A == 1 || PS_BLEND_B == 1 || PS_BLEND_C == 1 || PS_BLEND_D == 1)
 
-#define PS_FEEDBACK_LOOP_IS_NEEDED (PS_TEX_IS_FB == 1 || PS_FBMASK || SW_BLEND_NEEDS_RT || (PS_DATE < 10 && (((PS_DATE & 3) == 1 || (PS_DATE & 3) == 2))))
+#define PS_FEEDBACK_LOOP_IS_NEEDED (PS_TEX_IS_FB == 1 || PS_FBMASK || SW_BLEND_NEEDS_RT || (PS_DATE >= 5))
 
 layout(std140, set = 0, binding = 1) uniform cb1
 {
@@ -1110,10 +1110,6 @@ void ps_blend(inout vec4 Color, inout float As)
 	#endif
 }
 
-#if PS_DATE == 1 || PS_DATE == 2 || PS_DATE == 11 || PS_DATE == 12
-layout(early_fragment_tests) in;
-#endif
-
 void main()
 {
 #if PS_SCANMSK & 2
@@ -1121,7 +1117,7 @@ void main()
  	if ((int(gl_FragCoord.y) & 1) == (PS_SCANMSK & 1))
 		discard;
 #endif
-#if PS_DATE < 10 && (((PS_DATE & 3) == 1 || (PS_DATE & 3) == 2))
+#if PS_DATE >= 5
 
 #if PS_WRITE_RG == 1
   // Pseudo 16 bits access.
@@ -1139,15 +1135,10 @@ void main()
 #endif
 
   if (bad) {
-#if PS_DATE >= 5
     discard;
-#else
-    // imageStore(img_prim_min, ivec2(gl_FragCoord.xy), ivec4(-1));
-    return;
-#endif
   }
 
-#endif		// PS_DATE < 10 && (((PS_DATE & 3) == 1 || (PS_DATE & 3) == 2))
+#endif		// PS_DATE >= 5
 
 #if PS_DATE == 3
   int stencil_ceil = int(texelFetch(PrimMinTexture, ivec2(gl_FragCoord.xy), 0).r);
@@ -1208,13 +1199,13 @@ void main()
 #endif
 
   // Get first primitive that will write a failling alpha value
-#if PS_DATE == 1 || PS_DATE == 11
+#if PS_DATE == 1
 
   // DATM == 0
   // Pixel with alpha equal to 1 will failed (128-255)
 	o_col0 = (C.a > 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
 
-#elif PS_DATE == 2 || PS_DATE == 12
+#elif PS_DATE == 2
 
   // DATM == 1
   // Pixel with alpha equal to 0 will failed (0-127)

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -113,6 +113,9 @@ layout(location = 0) out GSOutput
 
 void WriteVertex(vec4 pos, vec4 t, vec4 ti, vec4 c)
 {
+#if GS_FORWARD_PRIMID
+	gl_PrimitiveID = gl_PrimitiveIDIn;
+#endif
 	gl_Position = pos;
 	gsOut.t = t;
 	gsOut.ti = ti;

--- a/common/Vulkan/Context.cpp
+++ b/common/Vulkan/Context.cpp
@@ -450,6 +450,8 @@ namespace Vulkan
 			SupportsExtension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, false);
 		m_optional_extensions.vk_arm_rasterization_order_attachment_access =
 			SupportsExtension(VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME, false);
+		m_optional_extensions.vk_khr_fragment_shader_barycentric =
+			SupportsExtension(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME, false);
 
 		return true;
 	}

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -52,6 +52,7 @@ namespace Vulkan
 			bool vk_ext_memory_budget : 1;
 			bool vk_khr_driver_properties : 1;
 			bool vk_arm_rasterization_order_attachment_access : 1;
+			bool vk_khr_fragment_shader_barycentric : 1;
 		};
 
 		~Context();

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1477,12 +1477,10 @@ void GSApp::Init()
 	m_default_configuration["OsdShowIndicators"]                          = "1";
 	m_default_configuration["OsdScale"]                                   = "100";
 	m_default_configuration["override_GL_ARB_copy_image"]                 = "-1";
-	m_default_configuration["override_GL_ARB_clear_texture"]              = "-1";
 	m_default_configuration["override_GL_ARB_clip_control"]               = "-1";
 	m_default_configuration["override_GL_ARB_direct_state_access"]        = "-1";
 	m_default_configuration["override_GL_ARB_draw_buffers_blend"]         = "-1";
 	m_default_configuration["override_GL_ARB_gpu_shader5"]                = "-1";
-	m_default_configuration["override_GL_ARB_shader_image_load_store"]    = "-1";
 	m_default_configuration["override_GL_ARB_texture_barrier"]            = "-1";
 	m_default_configuration["OverrideTextureBarriers"]                    = "-1";
 	m_default_configuration["OverrideGeometryShaders"]                    = "-1";

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -263,6 +263,7 @@ struct alignas(16) GSHWDrawConfig
 				GSTopology topology : 2;
 				bool expand : 1;
 				bool iip : 1;
+				bool forward_primid : 1;
 			};
 			u8 key;
 		};

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -699,7 +699,7 @@ public:
 		bool broken_point_sampler : 1; ///< Issue with AMD cards, see tfx shader for details
 		bool geometry_shader      : 1; ///< Supports geometry shader
 		bool vs_expand            : 1; ///< Supports expanding points/lines/sprites in the vertex shader
-		bool image_load_store     : 1; ///< Supports atomic min and max on images (for use with prim tracking destination alpha algorithm)
+		bool primitive_id         : 1; ///< Supports primitive ID for use with prim tracking destination alpha algorithm
 		bool texture_barrier      : 1; ///< Supports sampling rt and hopefully texture barrier
 		bool provoking_vertex_last: 1; ///< Supports using the last vertex in a primitive as the value for flat shading.
 		bool point_expand         : 1; ///< Supports point expansion in hardware without using geometry shaders.

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -312,7 +312,7 @@ struct alignas(16) GSHWDrawConfig
 				// Flat/goround shading
 				u32 iip : 1;
 				// Pixel test
-				u32 date : 4;
+				u32 date : 3;
 				u32 atst : 3;
 				// Color sampling
 				u32 fst : 1; // Investigate to do it on the VS

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -45,7 +45,7 @@ GSDevice11::GSDevice11()
 	m_state.bf = -1;
 
 	m_features.geometry_shader = true;
-	m_features.image_load_store = false;
+	m_features.primitive_id = false;
 	m_features.texture_barrier = false;
 	m_features.provoking_vertex_last = false;
 	m_features.point_expand = false;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -45,7 +45,7 @@ GSDevice11::GSDevice11()
 	m_state.bf = -1;
 
 	m_features.geometry_shader = true;
-	m_features.primitive_id = false;
+	m_features.primitive_id = true;
 	m_features.texture_barrier = false;
 	m_features.provoking_vertex_last = false;
 	m_features.point_expand = false;
@@ -132,11 +132,11 @@ bool GSDevice11::Create(HostDisplay* display)
 
 	ShaderMacro sm_model(m_shader_cache.GetFeatureLevel());
 
-	shader = Host::ReadResourceFileToString("shaders/dx11/convert.fx");
-	if (!shader.has_value())
+	std::optional<std::string> convert_hlsl = Host::ReadResourceFileToString("shaders/dx11/convert.fx");
+	if (!convert_hlsl.has_value())
 		return false;
 	if (!m_shader_cache.GetVertexShaderAndInputLayout(m_dev.get(), m_convert.vs.put(), m_convert.il.put(),
-			il_convert, std::size(il_convert), *shader, sm_model.GetPtr(), "vs_main"))
+			il_convert, std::size(il_convert), *convert_hlsl, sm_model.GetPtr(), "vs_main"))
 	{
 		return false;
 	}
@@ -148,7 +148,7 @@ bool GSDevice11::Create(HostDisplay* display)
 
 	for (size_t i = 0; i < std::size(m_convert.ps); i++)
 	{
-		m_convert.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *shader, sm_convert_ptr, shaderName(static_cast<ShaderConvert>(i)));
+		m_convert.ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, sm_convert_ptr, shaderName(static_cast<ShaderConvert>(i)));
 		if (!m_convert.ps[i])
 			return false;
 	}
@@ -341,6 +341,14 @@ bool GSDevice11::Create(HostDisplay* display)
 
 	m_dev->CreateBlendState(&blend, m_date.bs.put());
 
+	for (size_t i = 0; i < std::size(m_date.primid_init_ps); i++)
+	{
+		const std::string entry_point(StringUtil::StdStringFromFormat("ps_stencil_image_init_%d", i));
+		m_date.primid_init_ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, sm_model.GetPtr(), entry_point.c_str());
+		if (!m_date.primid_init_ps[i])
+			return false;
+	}
+
 	return true;
 }
 
@@ -462,7 +470,7 @@ GSTexture* GSDevice11::CreateSurface(GSTexture::Type type, int width, int height
 		case GSTexture::Format::UNorm8:       dxformat = DXGI_FORMAT_A8_UNORM;           break;
 		case GSTexture::Format::UInt16:       dxformat = DXGI_FORMAT_R16_UINT;           break;
 		case GSTexture::Format::UInt32:       dxformat = DXGI_FORMAT_R32_UINT;           break;
-		case GSTexture::Format::PrimID:       dxformat = DXGI_FORMAT_R32_SINT;           break;
+		case GSTexture::Format::PrimID:       dxformat = DXGI_FORMAT_R32_FLOAT;          break;
 		case GSTexture::Format::BC1:          dxformat = DXGI_FORMAT_BC1_UNORM;          break;
 		case GSTexture::Format::BC2:          dxformat = DXGI_FORMAT_BC2_UNORM;          break;
 		case GSTexture::Format::BC3:          dxformat = DXGI_FORMAT_BC3_UNORM;          break;
@@ -1336,7 +1344,6 @@ static GSDevice11::OMBlendSelector convertSel(GSHWDrawConfig::ColorMaskSelector 
 /// Clears things we don't support that can be quietly disabled
 static void preprocessSel(GSDevice11::PSSelector& sel)
 {
-	ASSERT(sel.date      == 0); // In-shader destination alpha not supported and shouldn't be sent
 	ASSERT(sel.write_rg  == 0); // Not supported, shouldn't be sent
 }
 
@@ -1345,7 +1352,16 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	ASSERT(!config.require_full_barrier); // We always specify no support so it shouldn't request this
 	preprocessSel(config.ps);
 
-	if (config.destination_alpha != GSHWDrawConfig::DestinationAlphaMode::Off)
+	GSVector2i rtsize = (config.rt ? config.rt : config.ds)->GetSize();
+
+	GSTexture* primid_tex = nullptr;
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+	{
+		primid_tex = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::PrimID, false);
+		StretchRect(config.rt, GSVector4(config.drawarea) / GSVector4(rtsize).xyxy(),
+			primid_tex, GSVector4(config.drawarea), m_date.primid_init_ps[config.datm].get(), nullptr, false);
+	}
+	else if (config.destination_alpha != GSHWDrawConfig::DestinationAlphaMode::Off)
 	{
 		const GSVector4 src = GSVector4(config.drawarea) / GSVector4(config.ds->GetSize()).xyxy();
 		const GSVector4 dst = src * 2.0f - 1.0f;
@@ -1364,10 +1380,9 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	GSTexture* hdr_rt = nullptr;
 	if (config.ps.hdr)
 	{
-		const GSVector2i size = config.rt->GetSize();
 		const GSVector4 dRect(config.drawarea);
-		const GSVector4 sRect = dRect / GSVector4(size.x, size.y).xyxy();
-		hdr_rt = CreateRenderTarget(size.x, size.y, GSTexture::Format::FloatColor);
+		const GSVector4 sRect = dRect / GSVector4(rtsize.x, rtsize.y).xyxy();
+		hdr_rt = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::FloatColor);
 		// Warning: StretchRect must be called before BeginScene otherwise
 		// vertices will be overwritten. Trust me you don't want to do that.
 		StretchRect(config.rt, sRect, hdr_rt, dRect, ShaderConvert::COPY, false);
@@ -1390,8 +1405,6 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		case GSHWDrawConfig::Topology::Triangle: topology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST; break;
 	}
 	IASetPrimitiveTopology(topology);
-
-	OMSetRenderTargets(hdr_rt ? hdr_rt : config.rt, config.ds, &config.scissor);
 
 	PSSetShaderResources(config.tex, config.pal);
 
@@ -1422,10 +1435,34 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 			PSSetShaderResource(0, ds_copy);
 	}
 
-	SetupOM(config.depth, convertSel(config.colormask, config.blend), config.blend.constant);
 	SetupVS(config.vs, &config.cb_vs);
 	SetupGS(config.gs);
 	SetupPS(config.ps, &config.cb_ps, config.sampler);
+
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+	{
+		OMDepthStencilSelector dss = config.depth;
+		dss.zwe = 0;
+		OMBlendSelector blend;
+		blend.wrgba = 0;
+		blend.wr = 1;
+		blend.blend_enable = 1;
+		blend.blend_src_factor = CONST_ONE;
+		blend.blend_dst_factor = CONST_ONE;
+		blend.blend_op = 3; // MIN
+		SetupOM(dss, blend, 0);
+		OMSetRenderTargets(primid_tex, config.ds, &config.scissor);
+
+		DrawIndexedPrimitive();
+
+		config.ps.date = 3;
+		config.alpha_second_pass.ps.date = 3;
+		SetupPS(config.ps, nullptr, config.sampler);
+		PSSetShaderResource(3, primid_tex);
+	}
+
+	SetupOM(config.depth, convertSel(config.colormask, config.blend), config.blend.constant);
+	OMSetRenderTargets(hdr_rt ? hdr_rt : config.rt, config.ds, &config.scissor);
 
 	DrawIndexedPrimitive();
 
@@ -1474,6 +1511,8 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		Recycle(rt_copy);
 	if (ds_copy)
 		Recycle(ds_copy);
+	if (primid_tex)
+		Recycle(primid_tex);
 
 	if (hdr_rt)
 	{

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -111,7 +111,7 @@ private:
 	// Increment this constant whenever shaders change, to invalidate user's shader cache.
 	static constexpr u32 SHADER_VERSION = 1;
 
-	static constexpr u32 MAX_TEXTURES = 3;
+	static constexpr u32 MAX_TEXTURES = 4;
 	static constexpr u32 MAX_SAMPLERS = 2;
 
 	int m_d3d_texsize;
@@ -209,6 +209,7 @@ private:
 	{
 		wil::com_ptr_nothrow<ID3D11DepthStencilState> dss;
 		wil::com_ptr_nothrow<ID3D11BlendState> bs;
+		wil::com_ptr_nothrow<ID3D11PixelShader> primid_init_ps[2];
 	} m_date;
 
 	// Shaders...

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -137,6 +137,7 @@ void GSDevice11::SetupGS(GSSelector sel)
 			sm.AddMacro("GS_IIP", sel.iip);
 			sm.AddMacro("GS_PRIM", static_cast<int>(sel.topology));
 			sm.AddMacro("GS_EXPAND", sel.expand);
+			sm.AddMacro("GS_FORWARD_PRIMID", sel.forward_primid);
 
 			gs = m_shader_cache.GetGeometryShader(m_dev.get(), m_tfx_source, sm.GetPtr(), "gs_main");
 

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -164,6 +164,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		sm.AddMacro("PS_AEM", sel.aem);
 		sm.AddMacro("PS_TFX", sel.tfx);
 		sm.AddMacro("PS_TCC", sel.tcc);
+		sm.AddMacro("PS_DATE", sel.date);
 		sm.AddMacro("PS_ATST", sel.atst);
 		sm.AddMacro("PS_FOG", sel.fog);
 		sm.AddMacro("PS_IIP", sel.iip);
@@ -290,8 +291,8 @@ static constexpr std::array<D3D11_BLEND, 16> s_d3d11_blend_factors = { {
 	D3D11_BLEND_DEST_ALPHA, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_SRC1_ALPHA, D3D11_BLEND_INV_SRC1_ALPHA,
 	D3D11_BLEND_BLEND_FACTOR, D3D11_BLEND_INV_BLEND_FACTOR, D3D11_BLEND_ONE, D3D11_BLEND_ZERO
 } };
-static constexpr std::array<D3D11_BLEND_OP, 3> s_d3d11_blend_ops = { {
-	D3D11_BLEND_OP_ADD, D3D11_BLEND_OP_SUBTRACT, D3D11_BLEND_OP_REV_SUBTRACT
+static constexpr std::array<D3D11_BLEND_OP, 4> s_d3d11_blend_ops = { {
+	D3D11_BLEND_OP_ADD, D3D11_BLEND_OP_SUBTRACT, D3D11_BLEND_OP_REV_SUBTRACT, D3D11_BLEND_OP_MIN
 } };
 // clang-format on
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -192,7 +192,7 @@ bool GSDevice12::CheckFeatures()
 	m_features.texture_barrier = false;
 	m_features.broken_point_sampler = isAMD;
 	m_features.geometry_shader = true;
-	m_features.image_load_store = true;
+	m_features.primitive_id = true;
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = false;
 	m_features.point_expand = false;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -33,6 +33,7 @@
 #include <limits>
 
 static bool IsDATMConvertShader(ShaderConvert i) { return (i == ShaderConvert::DATM_0 || i == ShaderConvert::DATM_1); }
+static bool IsDATEModePrimIDInit(u32 flag) { return flag == 1 || flag == 2; }
 
 static D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE GetLoadOpForTexture(GSTexture12* tex)
 {
@@ -1601,8 +1602,9 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 	if (p.rt)
 	{
 		gpb.SetRenderTarget(0,
-			(p.ps.date >= 10) ? DXGI_FORMAT_R32_FLOAT :
-                                (p.ps.hdr ? DXGI_FORMAT_R32G32B32A32_FLOAT : DXGI_FORMAT_R8G8B8A8_UNORM));
+			IsDATEModePrimIDInit(p.ps.date) ? DXGI_FORMAT_R32_FLOAT :
+			p.ps.hdr                        ? DXGI_FORMAT_R32G32B32A32_FLOAT :
+			                                  DXGI_FORMAT_R8G8B8A8_UNORM);
 	}
 	if (p.ds)
 		gpb.SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT_S8X24_UINT);
@@ -1642,7 +1644,7 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 	}
 
 	// Blending
-	if (p.ps.date >= 10)
+	if (IsDATEModePrimIDInit(p.ps.date))
 	{
 		// image DATE prepass
 		gpb.SetBlendState(0, true, D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_MIN, D3D12_BLEND_ONE,
@@ -2406,7 +2408,6 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	init_pipe.bs = {};
 	init_pipe.rt = true;
 	init_pipe.ps.blend_a = init_pipe.ps.blend_b = init_pipe.ps.blend_c = init_pipe.ps.blend_d = false;
-	init_pipe.ps.date += 10;
 	init_pipe.ps.no_color = false;
 	init_pipe.ps.no_color1 = true;
 	if (BindDrawPipeline(init_pipe))

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1506,6 +1506,7 @@ const ID3DBlob* GSDevice12::GetTFXGeometryShader(GSHWDrawConfig::GSSelector sel)
 	sm.AddMacro("GS_IIP", sel.iip);
 	sm.AddMacro("GS_PRIM", static_cast<int>(sel.topology));
 	sm.AddMacro("GS_EXPAND", sel.expand);
+	sm.AddMacro("GS_FORWARD_PRIMID", sel.forward_primid);
 
 	ComPtr<ID3DBlob> gs(m_shader_cache.GetGeometryShader(m_tfx_source, sm.GetPtr(), "gs_main"));
 	it = m_tfx_geometry_shaders.emplace(sel.key, std::move(gs)).first;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3452,16 +3452,13 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 				GL_PERF("DATE: Fast with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 				DATE_one = true;
 			}
-			else if ((m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 50) || (m_index.tail < 100))
+			else if (features.texture_barrier && ((m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 50) || (m_index.tail < 100)))
 			{
 				// texture barrier will split the draw call into n draw call. It is very efficient for
 				// few primitive draws. Otherwise it sucks.
 				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
-				if (features.texture_barrier)
-				{
-					m_conf.require_full_barrier = true;
-					DATE_BARRIER = true;
-				}
+				m_conf.require_full_barrier = true;
+				DATE_BARRIER = true;
 			}
 			else if (GSConfig.AccurateDATE)
 			{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3589,12 +3589,14 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		m_conf.depth.date = 1;
 		m_conf.depth.date_one = 1;
 	}
+	else if (DATE_PRIMID)
+	{
+		m_conf.ps.date = 1 + m_context->TEST.DATM;
+		m_conf.gs.forward_primid = 1;
+	}
 	else if (DATE)
 	{
-		if (DATE_PRIMID)
-			m_conf.ps.date = 1 + m_context->TEST.DATM;
-		else
-			m_conf.depth.date = 1;
+		m_conf.depth.date = 1;
 	}
 
 	m_conf.ps.fba = m_context->FBA.FBA;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3464,7 +3464,7 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 			{
 				// Note: Fast level (DATE_one) was removed as it's less accurate.
 				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
-				if (features.image_load_store)
+				if (features.primitive_id)
 				{
 					DATE_PRIMID = true;
 				}

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -587,7 +587,7 @@ bool GSDeviceMTL::Create(HostDisplay* display)
 	m_features.broken_point_sampler = [[m_dev.dev name] containsString:@"AMD"];
 	m_features.geometry_shader = false;
 	m_features.vs_expand = true;
-	m_features.image_load_store = m_dev.features.primid;
+	m_features.primitive_id = m_dev.features.primid;
 	m_features.texture_barrier = true;
 	m_features.provoking_vertex_last = false;
 	m_features.point_expand = true;

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.cpp
@@ -148,10 +148,8 @@ namespace GLLoader
 	bool has_dual_source_blend = false;
 	bool found_framebuffer_fetch = false;
 	bool found_geometry_shader = true; // we require GL3.3 so geometry must be supported by default
-	bool found_GL_ARB_clear_texture = false;
 	// DX11 GPU
 	bool found_GL_ARB_gpu_shader5 = false;             // Require IvyBridge
-	bool found_GL_ARB_shader_image_load_store = false; // Intel IB. Nvidia/AMD miss Mesa implementation.
 	bool found_GL_ARB_texture_barrier = false;
 
 	static bool mandatory(const std::string& ext)
@@ -266,10 +264,6 @@ namespace GLLoader
 		{
 			// GL4.0
 			found_GL_ARB_gpu_shader5 = optional("GL_ARB_gpu_shader5");
-			// GL4.2
-			found_GL_ARB_shader_image_load_store = optional("GL_ARB_shader_image_load_store");
-			// GL4.4
-			found_GL_ARB_clear_texture = optional("GL_ARB_clear_texture");
 			// GL4.5
 			optional("GL_ARB_direct_state_access");
 			// Mandatory for the advance HW renderer effect. Unfortunately Mesa LLVMPIPE/SWR renderers doesn't support this extension.

--- a/pcsx2/GS/Renderers/OpenGL/GLLoader.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLLoader.h
@@ -43,7 +43,5 @@ namespace GLLoader
 	extern bool found_framebuffer_fetch;
 	extern bool found_geometry_shader;
 	extern bool found_GL_ARB_gpu_shader5;
-	extern bool found_GL_ARB_shader_image_load_store;
-	extern bool found_GL_ARB_clear_texture;
 	extern bool found_GL_ARB_texture_barrier;
 } // namespace GLLoader

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -217,7 +217,7 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 	// optional features based on context
 	m_features.broken_point_sampler = GLLoader::vendor_id_amd;
 	m_features.geometry_shader = GLLoader::found_geometry_shader;
-	m_features.image_load_store = true;
+	m_features.primitive_id = true;
 	if (GSConfig.OverrideTextureBarriers == 0)
 		m_features.texture_barrier = GLLoader::found_framebuffer_fetch; // Force Disabled
 	else if (GSConfig.OverrideTextureBarriers == 1)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -217,7 +217,7 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 	// optional features based on context
 	m_features.broken_point_sampler = GLLoader::vendor_id_amd;
 	m_features.geometry_shader = GLLoader::found_geometry_shader;
-	m_features.image_load_store = GLLoader::found_GL_ARB_shader_image_load_store && GLLoader::found_GL_ARB_clear_texture;
+	m_features.image_load_store = true;
 	if (GSConfig.OverrideTextureBarriers == 0)
 		m_features.texture_barrier = GLLoader::found_framebuffer_fetch; // Force Disabled
 	else if (GSConfig.OverrideTextureBarriers == 1)
@@ -353,21 +353,23 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 		}
 	}
 
+	// these all share the same vertex shader
+	const auto convert_glsl = Host::ReadResourceFileToString("shaders/opengl/convert.glsl");
+	if (!convert_glsl.has_value())
+	{
+		Host::ReportErrorAsync("GS", "Failed to read shaders/opengl/convert.glsl.");
+		return false;
+	}
+
 	// ****************************************************************
 	// convert
 	// ****************************************************************
 	{
 		GL_PUSH("GSDeviceOGL::Convert");
 
-		// these all share the same vertex shader
-		const auto shader = Host::ReadResourceFileToString("shaders/opengl/convert.glsl");
-		if (!shader.has_value())
-		{
-			Host::ReportErrorAsync("GS", "Failed to read shaders/opengl/convert.glsl.");
-			return false;
-		}
 
-		m_convert.vs = GetShaderSource("vs_main", GL_VERTEX_SHADER, m_shader_common_header, *shader, {});
+
+		m_convert.vs = GetShaderSource("vs_main", GL_VERTEX_SHADER, m_shader_common_header, *convert_glsl, {});
 
 		for (size_t i = 0; i < std::size(m_convert.ps); i++)
 		{
@@ -375,7 +377,7 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 			const std::string macro_sel = (static_cast<ShaderConvert>(i) == ShaderConvert::RGBA_TO_8I) ?
                                               StringUtil::StdStringFromFormat("#define PS_SCALE_FACTOR %d\n", GSConfig.UpscaleMultiplier) :
                                               std::string();
-			const std::string ps(GetShaderSource(name, GL_FRAGMENT_SHADER, m_shader_common_header, *shader, macro_sel));
+			const std::string ps(GetShaderSource(name, GL_FRAGMENT_SHADER, m_shader_common_header, *convert_glsl, macro_sel));
 			if (!m_shader_cache.GetProgram(&m_convert.ps[i], m_convert.vs, {}, ps))
 				return false;
 			m_convert.ps[i].SetFormattedName("Convert pipe %s", name);
@@ -527,6 +529,15 @@ bool GSDeviceOGL::Create(HostDisplay* display)
 		m_date.dss = new GSDepthStencilOGL();
 		m_date.dss->EnableStencil();
 		m_date.dss->SetStencil(GL_ALWAYS, GL_REPLACE);
+
+		for (size_t i = 0; i < std::size(m_date.primid_ps); i++)
+		{
+			const std::string ps(GetShaderSource(
+				StringUtil::StdStringFromFormat("ps_stencil_image_init_%d", i),
+				GL_FRAGMENT_SHADER, m_shader_common_header, *convert_glsl, {}));
+			m_shader_cache.GetProgram(&m_date.primid_ps[i], m_convert.vs, {}, ps);
+			m_date.primid_ps[i].SetFormattedName("PrimID Destination Alpha Init %d", i);
+		}
 	}
 
 	// ****************************************************************
@@ -803,41 +814,26 @@ void GSDeviceOGL::ClearDepth(GSTexture* t)
 
 	GL_PUSH("Clear Depth %d", T->GetID());
 
-	if (0 && GLLoader::found_GL_ARB_clear_texture)
-	{
-		// I don't know what the driver does but it creates
-		// some slowdowns on Harry Potter PS
-		// Maybe it triggers some texture relocations, or maybe
-		// it clears also the stencil value (2 times slower)
-		//
-		// Let's disable this code for the moment.
+	OMSetFBO(m_fbo);
+	// RT must be detached, if RT is too small, depth won't be fully cleared
+	// AT tolenico 2 map clip bug
+	OMAttachRt(NULL);
+	OMAttachDs(T);
 
-		// Don't bother with Depth_Stencil insanity
-		T->Clear(NULL);
+	// TODO: check size of scissor before toggling it
+	glDisable(GL_SCISSOR_TEST);
+	const float c = 0.0f;
+	if (GLState::depth_mask)
+	{
+		glClearBufferfv(GL_DEPTH, 0, &c);
 	}
 	else
 	{
-		OMSetFBO(m_fbo);
-		// RT must be detached, if RT is too small, depth won't be fully cleared
-		// AT tolenico 2 map clip bug
-		OMAttachRt(NULL);
-		OMAttachDs(T);
-
-		// TODO: check size of scissor before toggling it
-		glDisable(GL_SCISSOR_TEST);
-		const float c = 0.0f;
-		if (GLState::depth_mask)
-		{
-			glClearBufferfv(GL_DEPTH, 0, &c);
-		}
-		else
-		{
-			glDepthMask(true);
-			glClearBufferfv(GL_DEPTH, 0, &c);
-			glDepthMask(false);
-		}
-		glEnable(GL_SCISSOR_TEST);
+		glDepthMask(true);
+		glClearBufferfv(GL_DEPTH, 0, &c);
+		glDepthMask(false);
 	}
+	glEnable(GL_SCISSOR_TEST);
 }
 
 void GSDeviceOGL::ClearStencil(GSTexture* t, u8 c)
@@ -938,39 +934,15 @@ GSDepthStencilOGL* GSDeviceOGL::CreateDepthStencil(OMDepthStencilSelector dssel)
 	return dss;
 }
 
-void GSDeviceOGL::InitPrimDateTexture(GSTexture* rt, const GSVector4i& area)
+GSTexture* GSDeviceOGL::InitPrimDateTexture(GSTexture* rt, const GSVector4i& area, bool datm)
 {
 	const GSVector2i& rtsize = rt->GetSize();
 
-	// Create a texture to avoid the useless clean@0
-	if (m_date.t == NULL)
-		m_date.t = CreateTexture(rtsize.x, rtsize.y, false, GSTexture::Format::PrimID);
+	GSTexture* tex = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::PrimID, false);
 
-	// Clean with the max signed value
-	const int max_int = 0x7FFFFFFF;
-	static_cast<GSTextureOGL*>(m_date.t)->Clear(&max_int, area);
-
-	glBindImageTexture(3, static_cast<GSTextureOGL*>(m_date.t)->GetID(), 0, false, 0, GL_READ_WRITE, GL_R32I);
-#ifdef ENABLE_OGL_DEBUG
-	// Help to see the texture in apitrace
-	PSSetShaderResource(3, m_date.t);
-#endif
-}
-
-void GSDeviceOGL::RecycleDateTexture()
-{
-	if (m_date.t)
-	{
-		//static_cast<GSTextureOGL*>(m_date.t)->Save(format("/tmp/date_adv_%04ld.csv", GSState::s_n));
-
-		Recycle(m_date.t);
-		m_date.t = NULL;
-	}
-}
-
-void GSDeviceOGL::Barrier(GLbitfield b)
-{
-	glMemoryBarrier(b);
+	GL_PUSH("PrimID Destination Alpha Clear");
+	StretchRect(rt, GSVector4(area) / GSVector4(rtsize).xyxy(), tex, GSVector4(area), m_date.primid_ps[datm], false);
+	return tex;
 }
 
 std::string GSDeviceOGL::GetShaderSource(const std::string_view& entry, GLenum type, const std::string_view& common_header, const std::string_view& glsl_h_code, const std::string_view& macro_sel)
@@ -999,16 +971,6 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view& entry, GLenum typ
 
 	if (GLLoader::found_GL_ARB_gpu_shader5)
 		header += "#extension GL_ARB_gpu_shader5 : enable\n";
-
-	if (GLLoader::found_GL_ARB_shader_image_load_store)
-	{
-		// Need GL version 420
-		header += "#extension GL_ARB_shader_image_load_store: require\n";
-	}
-	else
-	{
-		header += "#define DISABLE_GL42_image\n";
-	}
 
 	if (m_features.framebuffer_fetch)
 		header += "#define HAS_FRAMEBUFFER_FETCH 1\n";
@@ -1856,6 +1818,8 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	GSVector2i rtsize = (config.rt ? config.rt : config.ds)->GetSize();
 
+	GSTexture* primid_texture = nullptr;
+
 	// Destination Alpha Setup
 	switch (config.destination_alpha)
 	{
@@ -1863,7 +1827,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		case GSHWDrawConfig::DestinationAlphaMode::Full:
 			break; // No setup
 		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking:
-			InitPrimDateTexture(config.rt, config.drawarea);
+			primid_texture = InitPrimDateTexture(config.rt, config.drawarea, config.datm);
 			break;
 		case GSHWDrawConfig::DestinationAlphaMode::StencilOne:
 			if (m_features.texture_barrier)
@@ -1933,11 +1897,6 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		PSSetShaderResource(2, config.rt);
 
 	SetupSampler(config.sampler);
-	OMSetBlendState(config.blend.enable, s_gl_blend_factors[config.blend.src_factor],
-		s_gl_blend_factors[config.blend.dst_factor], s_gl_blend_ops[config.blend.op],
-		config.blend.constant_enable, config.blend.constant);
-	OMSetColorMaskState(config.colormask);
-	SetupOM(config.depth);
 
 	if (m_vs_cb_cache.Update(config.cb_vs))
 	{
@@ -1983,35 +1942,32 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
 	{
-		GL_PUSH("Date GL42");
-		// It could be good idea to use stencil in the same time.
-		// Early stencil test will reduce the number of atomic-load operation
+		GL_PUSH("Destination Alpha PrimID Init");
 
-		// Create an r32i image that will contain primitive ID
-		// Note: do it at the beginning because the clean will dirty the FBO state
-		//dev->InitPrimDateTexture(rtsize.x, rtsize.y);
+		OMSetRenderTargets(primid_texture, config.ds, &config.scissor);
+		OMColorMaskSelector mask;
+		mask.wrgba = 0;
+		mask.wr = true;
+		OMSetColorMaskState(mask);
+		OMSetBlendState(true, GL_ONE, GL_ONE, GL_MIN);
+		OMDepthStencilSelector dss = config.depth;
+		dss.zwe = 0; // Don't write depth
+		SetupOM(dss);
 
-		// I don't know how much is it legal to mount rt as Texture/RT. No write is done.
-		// In doubt let's detach RT.
-		OMSetRenderTargets(NULL, config.ds, &config.scissor);
-
-		// Don't write anything on the color buffer
-		// Neither in the depth buffer
-		glDepthMask(false);
 		// Compute primitiveID max that pass the date test (Draw without barrier)
 		DrawIndexedPrimitive();
-
-		// Ask PS to discard shader above the primitiveID max
-		glDepthMask(GLState::depth_mask);
 
 		psel.ps.date = 3;
 		config.alpha_second_pass.ps.date = 3;
 		SetupPipeline(psel);
-
-		// Be sure that first pass is finished !
-		Barrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+		PSSetShaderResource(3, primid_texture);
 	}
 
+	OMSetBlendState(config.blend.enable, s_gl_blend_factors[config.blend.src_factor],
+		s_gl_blend_factors[config.blend.dst_factor], s_gl_blend_ops[config.blend.op],
+		config.blend.constant_enable, config.blend.constant);
+	OMSetColorMaskState(config.colormask);
+	SetupOM(config.depth);
 	OMSetRenderTargets(hdr_rt ? hdr_rt : config.rt, config.ds, &config.scissor);
 
 	SendHWDraw(config, psel.ps.IsFeedbackLoop());
@@ -2063,8 +2019,8 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
-		RecycleDateTexture();
+	if (primid_texture)
+		Recycle(primid_texture);
 	if (draw_rt_clone)
 		Recycle(draw_rt_clone);
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -272,7 +272,7 @@ private:
 	struct
 	{
 		GSDepthStencilOGL* dss = nullptr;
-		GSTexture* t = nullptr;
+		GL::Program primid_ps[2];
 	} m_date;
 
 	struct
@@ -338,8 +338,7 @@ public:
 	void ClearDepth(GSTexture* t) final;
 	void ClearStencil(GSTexture* t, u8 c) final;
 
-	void InitPrimDateTexture(GSTexture* rt, const GSVector4i& area);
-	void RecycleDateTexture();
+	GSTexture* InitPrimDateTexture(GSTexture* rt, const GSVector4i& area, bool datm);
 
 	bool DownloadTexture(GSTexture* src, const GSVector4i& rect, GSTexture::GSMap& out_map) final;
 
@@ -391,6 +390,4 @@ public:
 	void SetupOM(OMDepthStencilSelector dssel);
 	GLuint GetSamplerID(PSSamplerSelector ssel);
 	GLuint GetPaletteSamplerID();
-
-	void Barrier(GLbitfield b);
 };

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -189,8 +189,8 @@ GSTextureOGL::GSTextureOGL(Type type, int width, int height, int levels, Format 
 	{
 		// 1 Channel integer
 		case Format::PrimID:
-			gl_fmt          = GL_R32I;
-			m_int_format    = GL_RED_INTEGER;
+			gl_fmt          = GL_R32F;
+			m_int_format    = GL_RED;
 			m_int_type      = GL_INT;
 			m_int_shift     = 2;
 			break;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1933,6 +1933,7 @@ VkShaderModule GSDeviceVK::GetTFXGeometryShader(GSHWDrawConfig::GSSelector sel)
 	AddMacro(ss, "GS_IIP", sel.iip);
 	AddMacro(ss, "GS_PRIM", static_cast<int>(sel.topology));
 	AddMacro(ss, "GS_EXPAND", sel.expand);
+	AddMacro(ss, "GS_FORWARD_PRIMID", sel.forward_primid);
 	ss << m_tfx_source;
 
 	VkShaderModule mod = g_vulkan_shader_cache->GetGeometryShader(ss.str());

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -230,7 +230,7 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.texture_barrier = GSConfig.OverrideTextureBarriers != 0;
 	m_features.broken_point_sampler = isAMD;
 	m_features.geometry_shader = features.geometryShader && GSConfig.OverrideGeometryShaders != 0;
-	m_features.image_load_store = features.fragmentStoresAndAtomics;
+	m_features.primitive_id = features.fragmentStoresAndAtomics;
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = g_vulkan_context->GetOptionalExtensions().vk_ext_provoking_vertex;
 	m_features.dual_source_blend = features.dualSrcBlend && !GSConfig.DisableDualSourceBlend;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -36,6 +36,7 @@ static u32 s_debug_scope_depth = 0;
 #endif
 
 static bool IsDATMConvertShader(ShaderConvert i) { return (i == ShaderConvert::DATM_0 || i == ShaderConvert::DATM_1); }
+static bool IsDATEModePrimIDInit(u32 flag) { return flag == 1 || flag == 2; }
 
 static VkAttachmentLoadOp GetLoadOpForTexture(GSTextureVK* tex)
 {
@@ -2035,7 +2036,7 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 
 	// Common state
 	gpb.SetPipelineLayout(m_tfx_pipeline_layout);
-	if (p.ps.date >= 10)
+	if (IsDATEModePrimIDInit(p.ps.date))
 	{
 		// DATE image prepass
 		gpb.SetRenderPass(m_date_image_setup_render_passes[p.ds][0], 0);
@@ -2083,7 +2084,7 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 	}
 
 	// Blending
-	if (p.ps.date >= 10)
+	if (IsDATEModePrimIDInit(p.ps.date))
 	{
 		// image DATE prepass
 		gpb.SetBlendAttachment(0, true, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_MIN, VK_BLEND_FACTOR_ONE,
@@ -2837,7 +2838,6 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 	pipe.feedback_loop = false;
 	pipe.rt = true;
 	pipe.ps.blend_a = pipe.ps.blend_b = pipe.ps.blend_c = pipe.ps.blend_d = false;
-	pipe.ps.date += 10;
 	pipe.ps.no_color = false;
 	pipe.ps.no_color1 = true;
 	if (BindDrawPipeline(pipe))

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -168,10 +168,6 @@ const char* dialog_message(int ID, bool* updateText)
 		case IDC_GEOMETRY_SHADER_OVERRIDE:
 			return cvtString("Allows the GPU instead of just the CPU to transform lines into sprites. This reduces CPU load and bandwidth requirement, but it is heavier on the GPU.\n"
 				"Automatic detection is recommended.");
-		case IDC_IMAGE_LOAD_STORE:
-			return cvtString("Allows advanced atomic operations to speed up Accurate DATE.\n"
-				"Only disable this if using Accurate DATE causes (GPU driver) issues.\n\n"
-				"Note: This option is only supported by GPUs which support at least Direct3D 11.");
 		case IDC_LINEAR_PRESENT:
 			return cvtString("Use bilinear filtering when Upscaling/Downscaling the image to the screen. Disable it if you want a sharper/pixelated output.");
 		// Exclusive for Hardware Renderer

--- a/pcsx2/GS/Window/GSSetting.h
+++ b/pcsx2/GS/Window/GSSetting.h
@@ -88,7 +88,6 @@ enum
 	IDC_SWTHREADS_EDIT,
 	// OpenGL Advanced Settings
 	IDC_GEOMETRY_SHADER_OVERRIDE,
-	IDC_IMAGE_LOAD_STORE,
 	// On-screen Display
 	IDC_OSD_LOG,
 	IDC_OSD_MONITOR,

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -548,7 +548,6 @@ DebugTab::DebugTab(wxWindow* parent)
 	const int space = wxSizerFlags().Border().GetBorderInPixels();
 	PaddedBoxSizer<wxBoxSizer> tab_box(wxVERTICAL);
 
-	auto ogl_hw_prereq = [this]{ return m_is_ogl_hw; };
 	auto vk_ogl_hw_prereq = [this] { return m_is_ogl_hw || m_is_vk_hw; };
 
 	if (g_Conf->DevMode || IsDevBuild)
@@ -584,10 +583,9 @@ DebugTab::DebugTab(wxWindow* parent)
 
 	PaddedBoxSizer<wxStaticBoxSizer> ogl_box(wxVERTICAL, this, "Overrides");
 	auto* ogl_grid = new wxFlexGridSizer(2, space, space);
-	m_ui.addComboBoxAndLabel(ogl_grid, "Texture Barriers:", "OverrideTextureBarriers",                 &theApp.m_gs_generic_list, -1,                           vk_ogl_hw_prereq);
-	m_ui.addComboBoxAndLabel(ogl_grid, "Geometry Shader:",  "OverrideGeometryShaders",                 &theApp.m_gs_generic_list, IDC_GEOMETRY_SHADER_OVERRIDE, vk_ogl_hw_prereq);
-	m_ui.addComboBoxAndLabel(ogl_grid, "Image Load Store:", "override_GL_ARB_shader_image_load_store", &theApp.m_gs_generic_list, IDC_IMAGE_LOAD_STORE,         ogl_hw_prereq);
-	m_ui.addComboBoxAndLabel(ogl_grid, "Dump Compression:", "GSDumpCompression",                       &theApp.m_gs_dump_compression, -1);
+	m_ui.addComboBoxAndLabel(ogl_grid, "Texture Barriers:", "OverrideTextureBarriers", &theApp.m_gs_generic_list, -1,                           vk_ogl_hw_prereq);
+	m_ui.addComboBoxAndLabel(ogl_grid, "Geometry Shader:",  "OverrideGeometryShaders", &theApp.m_gs_generic_list, IDC_GEOMETRY_SHADER_OVERRIDE, vk_ogl_hw_prereq);
+	m_ui.addComboBoxAndLabel(ogl_grid, "Dump Compression:", "GSDumpCompression",       &theApp.m_gs_dump_compression, -1);
 	ogl_box->Add(ogl_grid);
 
 	tab_box->Add(ogl_box.outer, wxSizerFlags().Expand());


### PR DESCRIPTION
### Description of Changes
- Fixes an issue where when barriers were unsupported, primid destination alpha would be skipped on draws that would have otherwise gone to barriers if both barriers and primid were supported.
- Adds PrimID destination alpha support to DX11 (finally giving it accurate destination alpha support)
  - Properly fixes #4480
- Switches OpenGL's primid destination alpha algorithm to match other renderers
- Fixes combining primid destination alpha with geometry shaders on Vulkan

Note: DX12's primid destination alpha is still broken, at least on my old AMD-Mac drivers.  Renderdoc was reporting some very weird things and I was very confused (somehow the init and main draws had different geometry, but only if you looked at the visual geometry viewer and not the list of vertex shader output values (geometry shader output values were just weird id numbers)?  Other than that the post-init texture looked like you would expect, aside from the fact that the wireframe view indicated that the main draw wasn't drawing in the same places...).

Note 2: Updates vulkan headers to get access to the barycentric coordinates extension, which we use as a stand-in for a primitive-id support check for MoltenVK.

### Rationale behind Changes
Accurate destination alpha for everyone, even those ancient GPUs that support DX11 feature level 10_0 and don't support enough OGL extensions for our OGL renderer

### Suggested Testing Steps
- Test [kimikiss_dstalpha.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9487511/kimikiss_dstalpha.gs.xz.zip)
  - Test on Vulkan with barriers forced off
  - Test on DX12 (Didn't work for me, but maybe it will for you)
  - Test on DX11
  - Test on OpenGL with barriers forced off
- Test any other heavy destination alpha games you might have
  - Do some performance comparisons for OpenGL?  Maybe it'll be different?

