### PR TITLE
GameDB: Kikou Souhei Armodyne graphics fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5750,6 +5750,8 @@ SCPS-15113:
 SCPS-15114:
   name: "Soukou Kihei Armodyne"
   region: "NTSC-J"
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes bad graphics.
 SCPS-15115:
   name: "Saru Get You - Million Monkeys"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Disables mVU flag speedhack to fix broken graphics.

### Rationale behind Changes
Buildings going Danny Phantom isn't ideal for users.

Closes #6998 

### Suggested Testing Steps
Make sure CI is happy.
