### PR TITLE
GS/DX12: Fix DATE on non-triangles

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -35,6 +35,9 @@
 static bool IsDATMConvertShader(ShaderConvert i) { return (i == ShaderConvert::DATM_0 || i == ShaderConvert::DATM_1); }
 static bool IsDATEModePrimIDInit(u32 flag) { return flag == 1 || flag == 2; }
 
+static constexpr std::array<D3D12_PRIMITIVE_TOPOLOGY, 3> s_primitive_topology_mapping =
+	{{D3D_PRIMITIVE_TOPOLOGY_POINTLIST, D3D_PRIMITIVE_TOPOLOGY_LINELIST, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST}};
+
 static D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE GetLoadOpForTexture(GSTexture12* tex)
 {
 	if (!tex)
@@ -2399,6 +2402,7 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 		DrawPrimitive();
 
 	// image is now filled with either -1 or INT_MAX, so now we can do the prepass
+	SetPrimitiveTopology(s_primitive_topology_mapping[static_cast<u8>(config.topology)]);
 	IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);
 	IASetIndexBuffer(config.indices, config.nindices);
 
@@ -2429,9 +2433,6 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 
 void GSDevice12::RenderHW(GSHWDrawConfig& config)
 {
-	static constexpr std::array<D3D12_PRIMITIVE_TOPOLOGY, 3> primitive_topologies =
-		{{D3D_PRIMITIVE_TOPOLOGY_POINTLIST, D3D_PRIMITIVE_TOPOLOGY_LINELIST, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST}};
-
 	// Destination Alpha Setup
 	const bool stencil_DATE =
 		(config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
@@ -2592,7 +2593,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// VB/IB upload, if we did DATE setup and it's not HDR this has already been done
-	SetPrimitiveTopology(primitive_topologies[static_cast<u8>(config.topology)]);
+	SetPrimitiveTopology(s_primitive_topology_mapping[static_cast<u8>(config.topology)]);
 	if (!date_image || hdr_rt)
 	{
 		IASetVertexBuffer(config.verts, sizeof(GSVertex), config.nverts);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1189,7 +1189,7 @@ bool GSDevice12::CompileConvertPipelines()
 		gpb.SetPixelShader(ps.get());
 		gpb.SetNoDepthTestState();
 		gpb.SetNoStencilState();
-		gpb.SetBlendState(0, true, D3D12_BLEND_ONE, D3D12_BLEND_ONE, D3D12_BLEND_OP_MIN,
+		gpb.SetBlendState(0, false, D3D12_BLEND_ONE, D3D12_BLEND_ONE, D3D12_BLEND_OP_ADD,
 			D3D12_BLEND_ZERO, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD, D3D12_COLOR_WRITE_ENABLE_RED);
 
 		for (u32 ds = 0; ds < 2; ds++)
@@ -2378,11 +2378,11 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 
 	// if the depth target has been cleared, we need to preserve that clear
 	BeginRenderPass(
-		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
 		GetLoadOpForTexture(static_cast<GSTexture12*>(config.ds)),
 		config.ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-		GSVector4(static_cast<float>(std::numeric_limits<s32>::max()), 0.0f, 0.0f, 0.0f),
+		GSVector4::zero(),
 		static_cast<GSTexture12*>(config.ds)->GetClearDepth());
 
 	// draw the quad to prefill the image

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1482,7 +1482,7 @@ bool GSDeviceVK::CompileConvertPipelines()
 			m_date_image_setup_render_passes[ds][clear] =
 				g_vulkan_context->GetRenderPass(LookupNativeFormat(GSTexture::Format::PrimID),
 					ds ? LookupNativeFormat(GSTexture::Format::DepthStencil) : VK_FORMAT_UNDEFINED,
-					VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE,
+					VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE,
 					ds ? (clear ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD) : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
 					ds ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE);
 		}
@@ -1501,7 +1501,7 @@ bool GSDeviceVK::CompileConvertPipelines()
 		gpb.SetNoDepthTestState();
 		gpb.SetNoStencilState();
 		gpb.ClearBlendAttachments();
-		gpb.SetBlendAttachment(0, true, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_MIN,
+		gpb.SetBlendAttachment(0, false, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD,
 			VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD, VK_COLOR_COMPONENT_R_BIT);
 
 		for (u32 ds = 0; ds < 2; ds++)
@@ -2798,17 +2798,16 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 	const VkAttachmentLoadOp ds_load_op = GetLoadOpForTexture(static_cast<GSTextureVK*>(config.ds));
 	const u32 ds = (config.ds ? 1 : 0);
 
-	VkClearValue cv[2] = {};
-	cv[0].color.float32[0] = static_cast<float>(std::numeric_limits<int>::max());
 	if (ds_load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
 	{
+		VkClearValue cv[2] = {};
 		cv[1].depthStencil.depth = static_cast<GSTextureVK*>(config.ds)->GetClearDepth();
 		cv[1].depthStencil.stencil = 1;
 		BeginClearRenderPass(m_date_image_setup_render_passes[ds][1], GSVector4i(0, 0, rtsize.x, rtsize.y), cv, 2);
 	}
 	else
 	{
-		BeginClearRenderPass(m_date_image_setup_render_passes[ds][0], config.drawarea, cv, 1);
+		BeginRenderPass(m_date_image_setup_render_passes[ds][0], config.drawarea);
 	}
 
 	// draw the quad to prefill the image


### PR DESCRIPTION
### Description of Changes

Follow-up to #6993.

Also a small optimization for both DX12 and Vulkan here - we don't need to clear the texture, since we fill the draw area every time. Will save a bit of memory bandwidth.

### Rationale behind Changes

Broken rendering is bad.

### Suggested Testing Steps

Test affected GS dumps - `Amagami_transparency`, `kimikiss_dstalpha`.
