### PR TITLE
iR5900: Fix vcalls detection in COP2MicroFinishPass::Run

### DIFF
--- a/pcsx2/x86/iR5900Analysis.cpp
+++ b/pcsx2/x86/iR5900Analysis.cpp
@@ -266,7 +266,7 @@ void COP2MicroFinishPass::Run(u32 start, u32 end, EEINST* inst_cache)
 		}
 
 		// Except for VCALLMS/VCALLMSR, that can start a micro, so the next instruction needs to finish it.
-		if (_Funct_ == 070 || _Funct_ == 071)
+		if (_Funct_ == 056 || _Funct_ == 057)
 			needs_vu0_finish = true;
 
 		return true;


### PR DESCRIPTION
### Description of Changes
Fix VCALLMS/VCALLMSR detection in COP2MicroFinishPass::Run.
### Rationale behind Changes
I can't find any affected game, but previous code wasn't able to detect anything (true condition was unreachable, and wrong). 
### Suggested Testing Steps
Maybe test games that need disabled mvuFlagSpeedHack, just in case Soukou Kihei Armodyne still need GameDB entry. 