### PR TITLE
Qt: Search all the things!

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -80,7 +80,10 @@ public:
 				return false;
 			if (m_filter_region != GameList::Region::Count && entry->region != m_filter_region)
 				return false;
-			if (!m_filter_name.isEmpty() && !QString::fromStdString(entry->title).contains(m_filter_name, Qt::CaseInsensitive))
+			if (!m_filter_name.isEmpty() &&
+				!QString::fromStdString(entry->path).contains(m_filter_name, Qt::CaseInsensitive) &&
+				!QString::fromStdString(entry->serial).contains(m_filter_name, Qt::CaseInsensitive) &&
+				!QString::fromStdString(entry->title).contains(m_filter_name, Qt::CaseInsensitive))
 				return false;
 		}
 


### PR DESCRIPTION
### Description of Changes
Make search include more entry strings. It now includes not only the title, but the path and serial as well.

### Rationale behind Changes
Makes the search functionality more useful for when filenames might differ from the database ones and also allows for quick subdirectory filtering!
[Example](https://i.imgur.com/zaMdCfW.png) (warning: brightness)

### Suggested Testing Steps
Use the search thingy.

**#PS:** More information per entry like developer or publisher could come in handy. For example, when you want to quickly see all your Phoenix games.

**#stenzek:** \*cough* can't make PR \*cough*
https://github.com/KrossX/duckstation/tree/search_more