### PR TITLE
Qt: Fix crash when autobinding controller

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -225,8 +225,10 @@ void ControllerBindingWidget::doDeviceAutomaticBinding(const QString& device)
 	bool result;
 	if (m_dialog->isEditingGlobalSettings())
 	{
-		auto lock = Host::GetSettingsLock();
-		result = PAD::MapController(*Host::Internal::GetBaseSettingsLayer(), m_port_number, mapping);
+		{
+			auto lock = Host::GetSettingsLock();
+			result = PAD::MapController(*Host::Internal::GetBaseSettingsLayer(), m_port_number, mapping);
+		}
 		if (result)
 			Host::CommitBaseSettingChanges();
 	}


### PR DESCRIPTION
### Description of Changes

Regression from #7016.

### Rationale behind Changes

Crash bad.

### Suggested Testing Steps

I've tested myself, the issue was double-acquiring a non-recursive mutex as seen in the diff.
