### PR TITLE
iR5900: Skip reloading COP2 flags register when it's not used

### DIFF
--- a/pcsx2/x86/iR5900Analysis.cpp
+++ b/pcsx2/x86/iR5900Analysis.cpp
@@ -151,10 +151,10 @@ void COP2FlagHackPass::Run(u32 start, u32 end, EEINST* inst_cache)
 				m_status_denormalized = true;
 			}
 
-			// If we're still behind the next CFC2 after the sticky bits got cleared, we need to update flags
-			// also do this if we're a vsqrt/vrsqrt/vdiv, these update status unconditionally.
+			// If we're still behind the next CFC2 after the sticky bits got cleared, we need to update flags.
+			// Also do this if we're a vsqrt/vrsqrt/vdiv, these update status unconditionally.
 			const u32 sub_opcode = (cpuRegs.code & 3) | ((cpuRegs.code >> 4) & 0x7c);
-			if (apc < m_cfc2_pc || (_Rs_ >= 020 && sub_opcode >= 070 && sub_opcode <= 072))
+			if (apc < m_cfc2_pc || (_Rs_ >= 020 && _Funct_ >= 074 && sub_opcode >= 070 && sub_opcode <= 072))
 				inst->info |= EEINST_COP2_STATUS_FLAG;
 
 			m_last_status_write = inst;

--- a/pcsx2/x86/iR5900Analysis.cpp
+++ b/pcsx2/x86/iR5900Analysis.cpp
@@ -151,8 +151,10 @@ void COP2FlagHackPass::Run(u32 start, u32 end, EEINST* inst_cache)
 				m_status_denormalized = true;
 			}
 
-			// if we're still behind the next CFC2 after the sticky bits got cleared, we need to update flags
-			if (apc < m_cfc2_pc)
+			// If we're still behind the next CFC2 after the sticky bits got cleared, we need to update flags
+			// also do this if we're a vsqrt/vrsqrt/vdiv, these update status unconditionally.
+			const u32 sub_opcode = (cpuRegs.code & 3) | ((cpuRegs.code >> 4) & 0x7c);
+			if (apc < m_cfc2_pc || (_Rs_ >= 020 && sub_opcode >= 070 && sub_opcode <= 072))
 				inst->info |= EEINST_COP2_STATUS_FLAG;
 
 			m_last_status_write = inst;

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -71,7 +71,7 @@ void setupMacroOp(int mode, const char* opName)
 		microVU0.prog.IRinfo.info[0].mFlag.doFlag      = true;
 		microVU0.prog.IRinfo.info[0].mFlag.write       = 0xff;
 	}
-	if (mode & 0x10)
+	if (mode & 0x10 && (!CHECK_VU_FLAGHACK || g_pCurInstInfo->info & (EEINST_COP2_STATUS_FLAG | EEINST_COP2_DENORMALIZE_STATUS_FLAG)))
 	{
 		_freeX86reg(gprF0);
 
@@ -107,7 +107,7 @@ void endMacroOp(int mode)
 			mVUallocSFLAGc(eax, gprF0, 0);
 			xMOV(ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL], eax);
 		}
-		else
+		else if (g_pCurInstInfo->info & (EEINST_COP2_STATUS_FLAG | EEINST_COP2_DENORMALIZE_STATUS_FLAG))
 		{
 			// backup denormalized flags for the next instruction
 			// this is fine, because we'll normalize them again before this reg is accessed


### PR DESCRIPTION
### Description of Changes

If the instruction isn't writing to the status register, there's no point reloading it/flushing gprF0.

### Rationale behind Changes

Maybe a teensy tiny bit of performance. But I doubt anything measurable.

### Suggested Testing Steps

Test COP2 flag-sensitive games (e.g. Ratchet Deadlocked).
