### PR TITLE
GameDB: MGS2 Document of text fixes for more versions

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -26313,6 +26313,8 @@ SLPM-65183:
 SLPM-65184:
   name: "Document of Metal Gear Solid 2, The"
   region: "NTSC-J"
+  gameFixes:
+    - EETimingHack # Fixes corrupted or missing menu fonts.
 SLPM-65185:
   name: "Ferrari F355 Challenge"
   region: "NTSC-J"
@@ -40536,6 +40538,8 @@ SLUS-20543:
   name: "Document of Metal Gear Solid 2, The"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - EETimingHack # Fixes corrupted or missing menu fonts.
 SLUS-20544:
   name: "Malice"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds EETimingHack to more versions of MGS2 the document of to fix the flickering broken text.

### Rationale behind Changes
Being able to read the text is good.

### Suggested Testing Steps
Make sure CI is happy.
