### PR TITLE
WX: Add Disable Hardware Readbacks option

### DIFF
--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -558,6 +558,7 @@ DebugTab::DebugTab(wxWindow* parent)
 		m_ui.addCheckBox(debug_check_box, "Disable Dual-Source Blending", "DisableDualSourceBlend");
 		m_ui.addCheckBox(debug_check_box, "Use Debug Device",             "UseDebugDevice");
 		m_ui.addCheckBox(debug_check_box, "Dump GS data",                 "dump");
+		m_ui.addCheckBox(debug_check_box, "Disable Hardware Readbacks",   "HWDisableReadbacks");
 
 		auto* debug_save_check_box = new wxWrapSizer(wxHORIZONTAL);
 		m_ui.addCheckBox(debug_save_check_box, "Save RT",      "save");


### PR DESCRIPTION
### Description of Changes
Adds the missing disable hardware readback option to WX.

### Rationale behind Changes
The option was already present internally it was just never added to the debug options. Mostly useful for people who play GT4 or the likes who get a fairly decent boost from this option.

### Suggested Testing Steps
Make sure the option works and CI is happy.
