### PR TITLE
DEV9: MAC address fetch implementation for MacOS/FreeBSD

### DIFF
--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -31,7 +31,7 @@
 namespace AdapterUtils
 {
 #ifdef _WIN32
-	bool GetWin32Adapter(const std::string& name, PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
+	bool GetWin32Adapter(const char* name, PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
 	bool GetWin32AdapterAuto(PIP_ADAPTER_ADDRESSES adapter, std::unique_ptr<IP_ADAPTER_ADDRESSES[]>* buffer);
 
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(PIP_ADAPTER_ADDRESSES adapter);
@@ -47,4 +47,5 @@ namespace AdapterUtils
 	std::vector<PacketReader::IP::IP_Address> GetGateways(ifaddrs* adapter);
 	std::vector<PacketReader::IP::IP_Address> GetDNS(ifaddrs* adapter);
 #endif
+	bool GetAdapterMAC(u8 (&mac)[6], const char* adapter_name);
 }; // namespace AdapterUtils

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -166,7 +166,7 @@ SocketAdapter::SocketAdapter()
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
 	{
-		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
+		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice.c_str(), &adapter, &buffer);
 
 		if (!foundAdapter)
 		{
@@ -248,18 +248,9 @@ SocketAdapter::SocketAdapter()
 
 #ifdef _WIN32
 	memcpy(hostMAC, adapter.PhysicalAddress, 6);
-#elif defined(__linux__)
-	struct ifreq ifr;
-	int fd = socket(AF_INET, SOCK_DGRAM, 0);
-	strcpy(ifr.ifr_name, adapter.ifa_name);
-	if (0 == ioctl(fd, SIOCGIFHWADDR, &ifr))
-		memcpy(hostMAC, ifr.ifr_hwaddr.sa_data, 6);
-	else
-	{
-		memcpy(hostMAC, ps2MAC, 6);
-		Console.Error("Could not get MAC address for adapter: %s", adapter.ifa_name);
-	}
-	::close(fd);
+#elif defined(__POSIX__)
+	memcpy(hostMAC, ps2MAC, 6); // In case it fails
+	AdapterUtils::GetAdapterMAC(hostMAC, adapter.ifa_name);
 #else
 	memcpy(hostMAC, ps2MAC, 6);
 	Console.Error("Could not get MAC address for adapter, OS not supported");
@@ -436,7 +427,7 @@ void SocketAdapter::reloadSettings()
 	std::unique_ptr<IP_ADAPTER_ADDRESSES[]> buffer;
 
 	if (strcmp(EmuConfig.DEV9.EthDevice.c_str(), "Auto") != 0)
-		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice, &adapter, &buffer);
+		foundAdapter = AdapterUtils::GetWin32Adapter(EmuConfig.DEV9.EthDevice.c_str(), &adapter, &buffer);
 	else
 		foundAdapter = AdapterUtils::GetWin32AdapterAuto(&adapter, &buffer);
 


### PR DESCRIPTION
### Description of Changes
Adds a function to read MAC addresses on macOS

With this, I can successfully ping my emulated PS2 with adapters in bridge mode, but not switched.  Better than nothing at least.

### Rationale behind Changes
Networking on macOS

### Suggested Testing Steps
Test networking things on macOS.  I've only tested pinging the ps2sdk's tcpip-basic sample code.

Note: I was unable to ping from the computer running PCSX2, but other devices on the network worked fine.

Note: You'll need write access to the `/dev/bpf*` system files.  If you have wireshark (or homebrew's `wireshark-chmodbpf` package) installed, that should handle it for you.  Otherwise, chgrp/chmod those so the user you're running PCSX2 as has access.

@kokroo
