### PR TITLE
Qt: Make FastCDVD per game only

### DIFF
--- a/pcsx2-qt/Settings/SystemSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/SystemSettingsWidget.cpp
@@ -48,6 +48,9 @@ SystemSettingsWidget::SystemSettingsWidget(SettingsDialog* dialog, QWidget* pare
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.vuRoundingMode, "EmuCore/CPU", "VU.Roundmode", 3);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fastCDVD, "EmuCore/Speedhacks", "fastCDVD", false);
 
+	// Allow for FastCDVD for per-game settings only 
+	m_ui.fastCDVD->setEnabled(m_dialog->isPerGameSettings());
+
 	if (m_dialog->isPerGameSettings())
 	{
 		m_ui.eeCycleRate->insertItem(


### PR DESCRIPTION
### Description of Changes
Makes FastCDVD per game only to prevent users enabling a destructive setting globally.

### Rationale behind Changes
Destructive settings should be per game only or ideally hidden away so there is less chance of users breaking something unintentionally.

### Suggested Testing Steps
Make sure it works per game and that CI passes.
