### PR TITLE
GameDB: Fix Kaidou Battle upscaling and add missing games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23255,6 +23255,9 @@ SLPM-55269:
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Vertical and horizontal lines in FMV.
+SLPM-55270:
+  name: "Shinkyoku Soukai Polyphonica - After School"
+  region: "NTSC-J"
 SLPM-55271:
   name: "FIFA 10 - World Class Soccer [Ea -SY! 1980]"
   region: "NTSC-J"
@@ -23281,6 +23284,9 @@ SLPM-55283:
   region: "NTSC-J"
 SLPM-55285:
   name: "Crimson Empire"
+  region: "NTSC-J"
+SLPM-55288:
+  name: "Shin Koihime Musou - Otome Ryouran - Sangokushi Engi"
   region: "NTSC-J"
 SLPM-55292:
   name: "Grand Theft Auto - San Andreas [Rockstar Classics]"
@@ -26572,8 +26578,10 @@ SLPM-65245:
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
 SLPM-65246:
-  name: "Kaidou Battle"
+  name: "Kaidou Battle - Nikko, Haruna, Rokko, Hakone"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 SLPM-65247:
   name: "Sangokushi Senki 2"
   region: "NTSC-J"
@@ -29413,6 +29421,9 @@ SLPM-66109:
   region: "NTSC-J"
 SLPM-66110:
   name: "Fushigi no Umi no Nadia - Inherit the Blue Water [Limited Edition]"
+  region: "NTSC-J"
+SLPM-66111:
+  name: "Fushigi no Umi no Nadia - Dennou Battle - Miss Nautilus Contest"
   region: "NTSC-J"
 SLPM-66112:
   name: "Fushigi no Umi no Nadia - Inherit the Blue Water"


### PR DESCRIPTION
### Description of Changes
Fix **Kaidou Battle - Nikko, Haruna, Rokko, Hakone** (SLPM-65246)

- Add Align Sprite upscaling fix to Kaidou Battle to remove vertical black lines when upscaling with hw renderer.
- Correct name in GameDB: Kaidou Battle -> Kaidou Battle - Nikko, Haruna, Rokko, Hakone


Add three missing games to GameDB:

- **Shinkyoku Soukai Polyphonica - After School** (SLPM-55270)
- **Shin Koihime Musou - Otome Ryouran - Sangokushi Engi** (SLPM-55288)
- **Fushigi no Umi no Nadia - Dennou Battle - Miss Nautilus Contest** (SLPM-66111)


### Rationale behind Changes
Improve GameDB and fix for Kaidou Battle

Kaidou Battle - Nikko, Haruna, Rokko, Hakone without Align Sprite
![Kaidou Battle_SLPM-65246_20220913221102](https://user-images.githubusercontent.com/2962364/190005367-2d546af9-1292-4012-88eb-8a802ddd101e.png)

With Align Sprite
![Kaidou Battle_SLPM-65246_20220913221108](https://user-images.githubusercontent.com/2962364/190005513-7ae0870e-3839-47db-bc14-8d0ddd7cdbaf.png)
