### PR TITLE
Qt: Fix crash on clearing controller bindings

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -197,8 +197,10 @@ void ControllerBindingWidget::onClearBindingsClicked()
 
 	if (m_dialog->isEditingGlobalSettings())
 	{
-		auto lock = Host::GetSettingsLock();
-		PAD::ClearPortBindings(*Host::Internal::GetBaseSettingsLayer(), m_port_number);
+		{
+			auto lock = Host::GetSettingsLock();
+			PAD::ClearPortBindings(*Host::Internal::GetBaseSettingsLayer(), m_port_number);
+		}
 		Host::CommitBaseSettingChanges();
 	}
 	else


### PR DESCRIPTION
Because of double-locking.