### PR TITLE
VMManager: Re-add .mdf as a disc filename

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1375,7 +1375,7 @@ bool VMManager::IsSaveStateFileName(const std::string_view& path)
 
 bool VMManager::IsDiscFileName(const std::string_view& path)
 {
-	static const char* extensions[] = {".iso", ".bin", ".img", ".gz", ".cso", ".chd"};
+	static const char* extensions[] = {".iso", ".bin", ".img", ".mdf", ".gz", ".cso", ".chd"};
 
 	for (const char* test_extension : extensions)
 	{


### PR DESCRIPTION
Fixes them not being scannable.
