### PR TITLE
Revert "BiosTools: Allow BIOS region patching"

### DIFF
--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -36,13 +36,9 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	m_ui.setupUi(this);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fastBoot, "EmuCore", "EnableFastBoot", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.patchRegion, "EmuCore", "PatchBios", false);
-	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.regionComboBox, "EmuCore", "PatchRegion", BiosZoneStrings, BiosZoneBytes, BiosZoneBytes[0]);
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.searchDirectory, m_ui.browseSearchDirectory, m_ui.openSearchDirectory,
 		m_ui.resetSearchDirectory, "Folders", "Bios", Path::Combine(EmuFolders::DataRoot, "bios"));
 
-	dialog->registerWidgetHelp(m_ui.patchRegion, tr("Patch Region"), tr("Unchecked"),
-		tr("Patches the BIOS region byte in ROM. Not recommended unless you really know what you're doing."));
 	dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Boot"), tr("Checked"),
 		tr("Patches the BIOS to skip the console's boot animation."));
 
@@ -51,9 +47,6 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsDialog* dialog, QWidget* parent)
 	connect(m_ui.searchDirectory, &QLineEdit::textChanged, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.refresh, &QPushButton::clicked, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.fileList, &QTreeWidget::currentItemChanged, this, &BIOSSettingsWidget::listItemChanged);
-
-	connect(m_ui.patchRegion, &QCheckBox::clicked, this, [&] { m_ui.regionComboBox->setEnabled(m_ui.patchRegion->isChecked()); });
-	m_ui.regionComboBox->setEnabled(m_ui.patchRegion->isChecked());
 }
 
 BIOSSettingsWidget::~BIOSSettingsWidget()

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>618</width>
-    <height>439</height>
+    <height>408</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -134,40 +134,13 @@
      <property name="title">
       <string>Options and Patches</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="patchRegion">
-        <property name="text">
-         <string>Patch Region</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
        <widget class="QCheckBox" name="fastBoot">
         <property name="text">
          <string>Fast Boot</string>
         </property>
        </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="regionComboBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -959,7 +959,6 @@ struct Pcsx2Config
 #endif
 		// when enabled uses BOOT2 injection, skipping sony bios splashes
 		UseBOOT2Injection : 1,
-		PatchBios : 1,
 		BackupSavestate : 1,
 		SavestateZstdCompression : 1,
 		// enables simulated ejection of memory cards when loading savestates
@@ -993,8 +992,6 @@ struct Pcsx2Config
 	TraceLogFilters Trace;
 
 	FilenameOptions BaseFilenames;
-
-	std::string PatchRegion;
 
 	// Memorycard options - first 2 are default slots, last 6 are multitap 1 and 2
 	// slots (3 each)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1073,8 +1073,6 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 #endif
 	SettingsWrapBitBool(ConsoleToStdio);
 	SettingsWrapBitBool(HostFs);
-	SettingsWrapBitBool(PatchBios);
-	SettingsWrapEntry(PatchRegion);
 
 	SettingsWrapBitBool(BackupSavestate);
 	SettingsWrapBitBool(SavestateZstdCompression);
@@ -1225,8 +1223,6 @@ void Pcsx2Config::CopyConfig(const Pcsx2Config& cfg)
 	EnableNoInterlacingPatches = cfg.EnableNoInterlacingPatches;
 	EnableRecordingTools = cfg.EnableRecordingTools;
 	UseBOOT2Injection = cfg.UseBOOT2Injection;
-	PatchBios = cfg.PatchBios;
-	PatchRegion = cfg.PatchRegion;
 	BackupSavestate = cfg.BackupSavestate;
 	SavestateZstdCompression = cfg.SavestateZstdCompression;
 	McdEnableEjection = cfg.McdEnableEjection;

--- a/pcsx2/ps2/BiosTools.h
+++ b/pcsx2/ps2/BiosTools.h
@@ -28,24 +28,6 @@ struct BiosDebugInformation
 	u32 threadListAddr;
 };
 
-// The following two arrays are used for Qt
-[[maybe_unused]] static const char* BiosZoneStrings[] {
-	"T10K",
-	"Test",
-	"Japan",
-	"USA",
-	"Europe",
-	"HK",
-	"Free",
-	"China",
-	nullptr
-};
-
-[[maybe_unused]] static const char* BiosZoneBytes[]
-{
-	"T", "X", "J", "A", "E", "H", "P", "C", nullptr
-};
-
 extern BiosDebugInformation CurrentBiosInformation;
 extern u32 BiosVersion;		// Used by CDVD
 extern u32 BiosRegion;		// Used by CDVD
@@ -59,3 +41,4 @@ extern std::string BiosPath;
 extern bool LoadBIOS();
 extern bool IsBIOS(const char* filename, u32& version, std::string& description, u32& region, std::string& zone);
 extern bool IsBIOSAvailable(const std::string& full_path);
+


### PR DESCRIPTION
This reverts commit a4dcaa7c149c80442e4087ff497561764d04001a.

### Description of Changes
Originally implemented to combat the issue the old BIOS dumper had, where slims would be dumped with the Japan BIOS region.
Now that we officially support https://github.com/F0bes/biosdrain which doesn't have this issue, there isn't a purpose for this feature.

If you are interested in poking around at the BIOS and seeing how it reacts to different regions, you can use the script I provided in the original pull request(#5778). [F0bes/BiosPatcher.py](https://gist.github.com/F0bes/1224ca17a8e71a0a5f93be9ced23b14b)
### Rationale behind Changes
The use case for this is niche, it's simply another thing a user can mistake for something else. 

### Suggested Testing Steps
Make sure the BIOS selection windows in QT and WX are both functional.
