### PR TITLE
Change lba to lsn

### DIFF
--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -33,7 +33,7 @@ static __fi s32 msf_to_lsn(u8* Time)
 	return lsn;
 }
 
-static __fi s32 msf_to_lba(u8 m, u8 s, u8 f)
+static __fi s32 msf_to_lsn(u8 m, u8 s, u8 f)
 {
 	u32 lsn;
 	lsn = f;
@@ -56,7 +56,7 @@ static __fi void lsn_to_msf(u8* Time, s32 lsn)
 	Time[2] = itob(f);
 }
 
-static __fi void lba_to_msf(s32 lba, u8* m, u8* s, u8* f)
+static __fi void lsn_to_msf(s32 lba, u8* m, u8* s, u8* f)
 {
 	lba += 150;
 	*m = lba / (60 * 75);

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -65,7 +65,7 @@ inline void lsn_to_msf(u8* minute, u8* second, u8* frame, u32 lsn)
 // TocStuff
 void cdvdParseTOC()
 {
-	tracks[1].start_lba = 0;
+	tracks[1].start_lsn = 0;
 
 	if (!src->GetSectorCount())
 	{
@@ -93,7 +93,7 @@ void cdvdParseTOC()
 			continue;
 		strack = std::min(strack, entry.track);
 		etrack = std::max(etrack, entry.track);
-		tracks[entry.track].start_lba = entry.lba;
+		tracks[entry.track].start_lsn = entry.lba;
 		if ((entry.control & 0x0C) == 0x04)
 		{
 			std::array<u8, 2352> buffer;
@@ -284,10 +284,10 @@ s32 CALLBACK DISCreadSubQ(u32 lsn, cdvdSubQ* subq)
 	lsn_to_msf(&subq->discM, &subq->discS, &subq->discF, lsn + 150);
 
 	u8 i = strack;
-	while (i < etrack && lsn >= tracks[i + 1].start_lba)
+	while (i < etrack && lsn >= tracks[i + 1].start_lsn)
 		++i;
 
-	lsn -= tracks[i].start_lba;
+	lsn -= tracks[i].start_lsn;
 
 	lsn_to_msf(&subq->trackM, &subq->trackS, &subq->trackF, lsn);
 
@@ -329,7 +329,7 @@ s32 CALLBACK DISCgetTD(u8 Track, cdvdTD* Buffer)
 	if (Track > etrack)
 		return -1;
 
-	Buffer->lsn = tracks[Track].start_lba;
+	Buffer->lsn = tracks[Track].start_lsn;
 	Buffer->type = tracks[Track].type;
 	return 0;
 }
@@ -442,7 +442,7 @@ s32 CALLBACK DISCgetTOC(void* toc)
 		tocBuff[17] = dec_to_bcd(diskInfo.etrack);
 
 		//DiskLength
-		lba_to_msf(trackInfo.lsn, &min, &sec, &frm);
+		lsn_to_msf(trackInfo.lsn, &min, &sec, &frm);
 		tocBuff[22] = 0xA2;
 		tocBuff[27] = dec_to_bcd(min);
 		tocBuff[28] = dec_to_bcd(sec);
@@ -453,7 +453,7 @@ s32 CALLBACK DISCgetTOC(void* toc)
 		for (i = diskInfo.strack; i <= diskInfo.etrack; i++)
 		{
 			err = DISCgetTD(i, &trackInfo);
-			lba_to_msf(trackInfo.lsn, &min, &sec, &frm);
+			lsn_to_msf(trackInfo.lsn, &min, &sec, &frm);
 			tocBuff[i * 10 + 30] = trackInfo.type;
 			tocBuff[i * 10 + 32] = err == -1 ? 0 : dec_to_bcd(i); //number
 			tocBuff[i * 10 + 37] = dec_to_bcd(min);

--- a/pcsx2/CDVD/CDVDdiscReader.h
+++ b/pcsx2/CDVD/CDVDdiscReader.h
@@ -25,7 +25,7 @@
 
 struct track
 {
-	u32 start_lba;
+	u32 start_lsn;
 	u8 type;
 };
 

--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -89,14 +89,14 @@ s32 CALLBACK ISOreadSubQ(u32 lsn, cdvdSubQ* subq)
 	subq->trackNum = itob(1);
 	subq->trackIndex = itob(1);
 
-	lba_to_msf(lsn, &min, &sec, &frm);
+	lsn_to_msf(lsn, &min, &sec, &frm);
 	subq->trackM = itob(min);
 	subq->trackS = itob(sec);
 	subq->trackF = itob(frm);
 
 	subq->pad = 0;
 
-	lba_to_msf(lsn + (2 * 75), &min, &sec, &frm);
+	lsn_to_msf(lsn + (2 * 75), &min, &sec, &frm);
 	subq->discM = itob(min);
 	subq->discS = itob(sec);
 	subq->discF = itob(frm);
@@ -283,7 +283,7 @@ s32 CALLBACK ISOgetTOC(void* toc)
 		tocBuff[17] = itob(diskInfo.etrack);
 
 		//DiskLength
-		lba_to_msf(trackInfo.lsn, &min, &sec, &frm);
+		lsn_to_msf(trackInfo.lsn, &min, &sec, &frm);
 		tocBuff[22] = 0xA2;
 		tocBuff[27] = itob(min);
 		tocBuff[28] = itob(sec);
@@ -291,7 +291,7 @@ s32 CALLBACK ISOgetTOC(void* toc)
 		for (i = diskInfo.strack; i <= diskInfo.etrack; i++)
 		{
 			err = ISOgetTD(i, &trackInfo);
-			lba_to_msf(trackInfo.lsn, &min, &sec, &frm);
+			lsn_to_msf(trackInfo.lsn, &min, &sec, &frm);
 			tocBuff[i * 10 + 30] = trackInfo.type;
 			tocBuff[i * 10 + 32] = err == -1 ? 0 : itob(i); //number
 			tocBuff[i * 10 + 37] = itob(min);

--- a/pcsx2/CDVD/Linux/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Linux/IOCtlSrc.cpp
@@ -118,7 +118,7 @@ bool IOCtlSrc::ReadSectors2352(u32 sector, u32 count, u8* buffer) const
 	for (u32 n = 0; n < count; ++n)
 	{
 		u32 lba = sector + n;
-		lba_to_msf(lba, &data.msf.cdmsf_min0, &data.msf.cdmsf_sec0, &data.msf.cdmsf_frame0);
+		lsn_to_msf(lba, &data.msf.cdmsf_min0, &data.msf.cdmsf_sec0, &data.msf.cdmsf_frame0);
 		if (ioctl(m_device, CDROMREADRAW, &data) == -1)
 		{
 			fprintf(stderr, " * CDVD CDROMREADRAW sector %u failed: %s\n",


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Changed names of functions referring to CDVD LBA (Logical Block Address) to instead refer to the more correct term LSN (Logical sector number)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Several functions already had lsn in the title where other's did not. This fixes a naming convention that did not match and thus unifies the code base a bit more

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
C if CI goes brrr