### PR TITLE
Config: Preserve memcard types instead of wiping to defaults

### DIFF
--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1247,6 +1247,11 @@ void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
 	CurrentGameArgs = std::move(cfg.CurrentGameArgs);
 	CurrentAspectRatio = cfg.CurrentAspectRatio;
 	LimiterMode = cfg.LimiterMode;
+
+	for (u32 i = 0; i < sizeof(Mcd) / sizeof(Mcd[0]); i++)
+	{
+		Mcd[i].Type = cfg.Mcd[i].Type;
+	}
 }
 
 void EmuFolders::SetDefaults(SettingsInterface& si)


### PR DESCRIPTION
### Description of Changes
Makes config preserve memcard's "type" attribute instead of reverting to default. Thanks stenzek for the fast diagnosis!

### Rationale behind Changes
Fixes #7062 

### Suggested Testing Steps
Boot a game with a folder memcard inserted. Game should recognize memcard and function normally.