### PR TITLE
GS-wx: Rearrange debug checkboxes in advanced tab graphics settings.

### DIFF
--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -551,14 +551,16 @@ DebugTab::DebugTab(wxWindow* parent)
 	if (g_Conf->DevMode || IsDevBuild)
 	{
 		PaddedBoxSizer<wxStaticBoxSizer> debug_box(wxVERTICAL, this, "Debug");
-		auto* debug_check_box = new wxWrapSizer(wxHORIZONTAL);
-		m_ui.addCheckBox(debug_check_box, "Use Blit Swap Chain",          "UseBlitSwapChain");
-		m_ui.addCheckBox(debug_check_box, "Disable Shader Cache",         "disable_shader_cache");
-		m_ui.addCheckBox(debug_check_box, "Disable Framebuffer Fetch",    "DisableFramebufferFetch");
+		auto* debug_check_box = new wxFlexGridSizer(2, space, space);
 		m_ui.addCheckBox(debug_check_box, "Disable Dual-Source Blending", "DisableDualSourceBlend");
-		m_ui.addCheckBox(debug_check_box, "Use Debug Device",             "UseDebugDevice");
-		m_ui.addCheckBox(debug_check_box, "Dump GS data",                 "dump");
+		m_ui.addCheckBox(debug_check_box, "Disable Framebuffer Fetch",    "DisableFramebufferFetch");
 		m_ui.addCheckBox(debug_check_box, "Disable Hardware Readbacks",   "HWDisableReadbacks");
+		m_ui.addCheckBox(debug_check_box, "Disable Shader Cache",         "disable_shader_cache");
+		m_ui.addCheckBox(debug_check_box, "Use Blit Swap Chain",          "UseBlitSwapChain");
+		m_ui.addCheckBox(debug_check_box, "Use Debug Device",             "UseDebugDevice");
+
+		auto* debug_save_check_box_main = new wxFlexGridSizer(1, space, space);
+		m_ui.addCheckBox(debug_save_check_box_main, "Dump GS data", "dump");
 
 		auto* debug_save_check_box = new wxWrapSizer(wxHORIZONTAL);
 		m_ui.addCheckBox(debug_save_check_box, "Save RT",      "save");
@@ -567,6 +569,9 @@ DebugTab::DebugTab(wxWindow* parent)
 		m_ui.addCheckBox(debug_save_check_box, "Save Depth",   "savez");
 
 		debug_box->Add(debug_check_box);
+		debug_box->AddSpacer(space);
+		debug_box->Add(debug_save_check_box_main);
+		debug_box->AddSpacer(space);
 		debug_box->Add(debug_save_check_box);
 
 		auto* dump_grid = new wxFlexGridSizer(2, space, space);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-wx: Rearrange debug checkboxes in advanced tab graphics settings.
Less confusing and easier to debug.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Easier to use when debugging.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Compile debug and use the options.