### PR TITLE
Spin GPU during readbacks

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(common PRIVATE
 	PrecompiledHeader.cpp
 	Perf.cpp
 	ProgressCallback.cpp
+	ReadbackSpinManager.cpp
 	Semaphore.cpp
 	SettingsWrapper.cpp
 	StringUtil.cpp
@@ -86,6 +87,7 @@ target_sources(common PRIVATE
 	PageFaultSource.h
 	PrecompiledHeader.h
 	ProgressCallback.h
+	ReadbackSpinManager.h
 	RedtapeWindows.h
 	SafeArray.h
 	ScopedGuard.h

--- a/common/D3D12/Context.cpp
+++ b/common/D3D12/Context.cpp
@@ -17,6 +17,7 @@
 
 #include "common/D3D12/Context.h"
 #include "common/Assertions.h"
+#include "common/General.h"
 #include "common/ScopedGuard.h"
 #include "common/Console.h"
 #include "D3D12MemAlloc.h"
@@ -382,7 +383,7 @@ void Context::MoveToNextCommandList()
 
 	// We may have to wait if this command list hasn't finished on the GPU.
 	CommandListResources& res = m_command_lists[m_current_command_list];
-	WaitForFence(res.ready_fence_value);
+	WaitForFence(res.ready_fence_value, false);
 	res.ready_fence_value = m_current_fence_value;
 	res.init_command_list_used = false;
 
@@ -445,7 +446,7 @@ ID3D12GraphicsCommandList4* Context::GetInitCommandList()
 	return res.command_lists[0].get();
 }
 
-void Context::ExecuteCommandList(bool wait_for_completion)
+void Context::ExecuteCommandList(WaitType wait_for_completion)
 {
 	CommandListResources& res = m_command_lists[m_current_command_list];
 	HRESULT hr;
@@ -485,8 +486,8 @@ void Context::ExecuteCommandList(bool wait_for_completion)
 	pxAssertRel(SUCCEEDED(hr), "Signal fence");
 
 	MoveToNextCommandList();
-	if (wait_for_completion)
-		WaitForFence(res.ready_fence_value);
+	if (wait_for_completion != WaitType::None)
+		WaitForFence(res.ready_fence_value, wait_for_completion == WaitType::Spin);
 }
 
 void Context::InvalidateSamplerGroups()
@@ -547,7 +548,7 @@ void Context::DestroyPendingResources(CommandListResources& cmdlist)
 
 void Context::DestroyResources()
 {
-	ExecuteCommandList(true);
+	ExecuteCommandList(WaitType::Sleep);
 
 	m_texture_stream_buffer.Destroy(false);
 	m_descriptor_heap_manager.Free(&m_null_srv_descriptor);
@@ -573,20 +574,30 @@ void Context::DestroyResources()
 	m_device.reset();
 }
 
-void Context::WaitForFence(u64 fence)
+void Context::WaitForFence(u64 fence, bool spin)
 {
 	if (m_completed_fence_value >= fence)
 		return;
 
-	// Try non-blocking check.
-	m_completed_fence_value = m_fence->GetCompletedValue();
-	if (m_completed_fence_value < fence)
+	if (spin)
 	{
-		// Fall back to event.
-		HRESULT hr = m_fence->SetEventOnCompletion(fence, m_fence_event);
-		pxAssertRel(SUCCEEDED(hr), "Set fence event on completion");
-		WaitForSingleObject(m_fence_event, INFINITE);
+		u64 value;
+		while ((value = m_fence->GetCompletedValue()) < fence)
+			ShortSpin();
+		m_completed_fence_value = value;
+	}
+	else
+	{
+		// Try non-blocking check.
 		m_completed_fence_value = m_fence->GetCompletedValue();
+		if (m_completed_fence_value < fence)
+		{
+			// Fall back to event.
+			HRESULT hr = m_fence->SetEventOnCompletion(fence, m_fence_event);
+			pxAssertRel(SUCCEEDED(hr), "Set fence event on completion");
+			WaitForSingleObject(m_fence_event, INFINITE);
+			m_completed_fence_value = m_fence->GetCompletedValue();
+		}
 	}
 
 	// Release resources for as many command lists which have completed.
@@ -607,7 +618,7 @@ void Context::WaitForGPUIdle()
 	u32 index = (m_current_command_list + 1) % NUM_COMMAND_LISTS;
 	for (u32 i = 0; i < (NUM_COMMAND_LISTS - 1); i++)
 	{
-		WaitForFence(m_command_lists[index].ready_fence_value);
+		WaitForFence(m_command_lists[index].ready_fence_value, false);
 		index = (index + 1) % NUM_COMMAND_LISTS;
 	}
 }

--- a/common/D3D12/Context.h
+++ b/common/D3D12/Context.h
@@ -122,11 +122,18 @@ namespace D3D12
 		/// Test for support for the specified texture format.
 		bool SupportsTextureFormat(DXGI_FORMAT format);
 
+		enum class WaitType
+		{
+			None,  ///< Don't wait (async)
+			Sleep, ///< Wait normally
+			Spin,  ///< Wait by spinning
+		};
+
 		/// Executes the current command list.
-		void ExecuteCommandList(bool wait_for_completion);
+		void ExecuteCommandList(WaitType wait_for_completion);
 
 		/// Waits for a specific fence.
-		void WaitForFence(u64 fence);
+		void WaitForFence(u64 fence, bool spin);
 
 		/// Waits for any in-flight command buffers to complete.
 		void WaitForGPUIdle();

--- a/common/D3D12/StreamBuffer.cpp
+++ b/common/D3D12/StreamBuffer.cpp
@@ -273,7 +273,7 @@ bool StreamBuffer::WaitForClearSpace(u32 num_bytes)
 		return false;
 
 	// Wait until this fence is signaled. This will fire the callback, updating the GPU position.
-	g_d3d12_context->WaitForFence(iter->first);
+	g_d3d12_context->WaitForFence(iter->first, false);
 	m_tracked_fences.erase(m_tracked_fences.begin(), m_current_offset == iter->second ? m_tracked_fences.end() : ++iter);
 	m_current_offset = new_offset;
 	m_current_space = new_space;

--- a/common/D3D12/Texture.cpp
+++ b/common/D3D12/Texture.cpp
@@ -293,7 +293,7 @@ ID3D12GraphicsCommandList* Texture::BeginStreamUpdate(ID3D12GraphicsCommandList*
 	{
 		DevCon.WriteLn("Executing command buffer while waiting for %u bytes (%ux%u) in upload buffer", upload_size, width,
 			height);
-		g_d3d12_context->ExecuteCommandList(false);
+		g_d3d12_context->ExecuteCommandList(Context::WaitType::None);
 		if (!g_d3d12_context->GetTextureStreamBuffer().ReserveMemory(upload_size, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT))
 		{
 			Console.Error("Failed to reserve %u bytes for %ux%u upload", upload_size, width, height);

--- a/common/ReadbackSpinManager.cpp
+++ b/common/ReadbackSpinManager.cpp
@@ -1,0 +1,230 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ReadbackSpinManager.h"
+
+#include <algorithm>
+
+static bool EventIsReadback(const ReadbackSpinManager::Event& event)
+{
+	return event.size < 0;
+}
+
+static bool EventIsDraw(const ReadbackSpinManager::Event& event)
+{
+	return !EventIsReadback(event);
+}
+
+static bool IsCompleted(const ReadbackSpinManager::Event& event)
+{
+	return event.begin != event.end;
+}
+
+static int Similarity(const std::vector<ReadbackSpinManager::Event>& a, std::vector<ReadbackSpinManager::Event>& b)
+{
+	u32 a_num_readbacks = std::count_if(a.begin(), a.end(), EventIsReadback);
+	u32 b_num_readbacks = std::count_if(b.begin(), b.end(), EventIsReadback);
+
+	int score = 0x10 - abs(static_cast<int>(a.size() - b.size()));
+
+	if (a_num_readbacks == b_num_readbacks)
+		score += 0x10000;
+
+	auto a_idx = a.begin();
+	auto b_idx = b.begin();
+	while (a_idx != a.end() && b_idx != b.end())
+	{
+		if (EventIsReadback(*a_idx) && EventIsReadback(*b_idx))
+		{
+			// Same number of events between readbacks
+			score += 0x1000;
+		}
+		// Try to match up on readbacks
+		else if (EventIsReadback(*a_idx))
+		{
+			b_idx++;
+			continue;
+		}
+		else if (EventIsReadback(*b_idx))
+		{
+			a_idx++;
+			continue;
+		}
+		else if (a_idx->size == b_idx->size)
+		{
+			// Same size
+			score += 0x100;
+		}
+		else if (a_idx->size / 2 <= b_idx->size && b_idx->size / 2 <= a_idx->size)
+		{
+			// Similar size
+			score += 0x10;
+		}
+		a_idx++;
+		b_idx++;
+		continue;
+	}
+	// Both hit the end at the same time
+	if (a_idx == a.end() && b_idx == b.end())
+		score += 0x1000;
+
+	return score;
+}
+
+static u32 PrevFrameNo(u32 frame, size_t total_frames)
+{
+	s32 prev_frame = frame - 1;
+	if (prev_frame < 0)
+		prev_frame = total_frames - 1;
+	return prev_frame;
+}
+
+static u32 NextFrameNo(u32 frame, size_t total_frames)
+{
+	u32 next_frame = frame + 1;
+	if (next_frame >= total_frames)
+		next_frame = 0;
+	return next_frame;
+}
+
+void ReadbackSpinManager::ReadbackRequested()
+{
+	Event ev = {};
+	ev.size = -1;
+	m_frames[m_current_frame].push_back(ev);
+
+	// Advance reference frame idx to the next readback
+	while (m_frames[m_reference_frame].size() > m_reference_frame_idx &&
+	       !EventIsReadback(m_frames[m_reference_frame][m_reference_frame_idx]))
+	{
+		m_reference_frame_idx++;
+	}
+	// ...and past it
+	if (m_frames[m_reference_frame].size() > m_reference_frame_idx)
+		m_reference_frame_idx++;
+}
+
+void ReadbackSpinManager::NextFrame()
+{
+	u32 prev_frame_0 = PrevFrameNo(m_current_frame, std::size(m_frames));
+	u32 prev_frame_1 = PrevFrameNo(prev_frame_0, std::size(m_frames));
+	int similarity_0 = Similarity(m_frames[m_current_frame], m_frames[prev_frame_0]);
+	int similarity_1 = Similarity(m_frames[m_current_frame], m_frames[prev_frame_1]);
+
+	if (similarity_1 > similarity_0)
+		m_reference_frame = prev_frame_0;
+	else
+		m_reference_frame = m_current_frame;
+	m_reference_frame_idx = 0;
+
+	m_current_frame = NextFrameNo(m_current_frame, std::size(m_frames));
+	m_frames[m_current_frame].clear();
+}
+
+ReadbackSpinManager::DrawSubmittedReturn ReadbackSpinManager::DrawSubmitted(u64 size)
+{
+	DrawSubmittedReturn out = {};
+	u32 idx = m_frames[m_current_frame].size();
+	out.id = idx | m_current_frame << 28;
+	Event ev = {};
+	ev.size = size;
+	m_frames[m_current_frame].push_back(ev);
+
+	if (m_reference_frame != m_current_frame &&
+	    m_frames[m_reference_frame].size() > m_reference_frame_idx &&
+	    EventIsDraw(m_frames[m_reference_frame][m_reference_frame_idx]))
+	{
+		auto find_next_draw = [this](u32 frame) -> Event* {
+			auto next = std::find_if(m_frames[frame].begin() + m_reference_frame_idx + 1,
+			                         m_frames[frame].end(),
+			                         EventIsDraw);
+			bool found = next != m_frames[frame].end();
+			if (!found)
+			{
+				u32 next_frame = NextFrameNo(frame, std::size(m_frames));
+				next = std::find_if(m_frames[next_frame].begin(), m_frames[next_frame].end(), EventIsDraw);
+				found = next != m_frames[next_frame].end();
+			}
+			return found ? &*next : nullptr;
+		};
+		Event* cur_draw = &m_frames[m_reference_frame][m_reference_frame_idx];
+		Event* next_draw = find_next_draw(m_reference_frame);
+		const bool is_one_frame_back = m_reference_frame == PrevFrameNo(m_current_frame, std::size(m_frames));
+		if ((!next_draw || !IsCompleted(*cur_draw) || !IsCompleted(*next_draw)) && is_one_frame_back)
+		{
+			// Last frame's timing data hasn't arrived, try the same spot in the frame before
+			u32 two_back = PrevFrameNo(m_reference_frame, std::size(m_frames));
+			if (m_frames[two_back].size() > m_reference_frame_idx &&
+			    EventIsDraw(m_frames[two_back][m_reference_frame_idx]))
+			{
+				cur_draw = &m_frames[two_back][m_reference_frame_idx];
+				next_draw = find_next_draw(two_back);
+			}
+		}
+		if (next_draw && IsCompleted(*cur_draw) && IsCompleted(*next_draw) && m_spins_per_unit_time != 0)
+		{
+			u64 cur_size = cur_draw->size;
+			bool is_similar = cur_size / 2 <= size && size / 2 <= cur_size;
+			if (is_similar) // Only recommend spins if we're somewhat confident in what's going on
+			{
+				s32 current_draw_time = cur_draw->end - cur_draw->begin;
+				s32 gap = next_draw->begin - cur_draw->end;
+				// Give an extra bit of space for the draw to take a bit longer (we'll go with 1/8 longer)
+				s32 fill = gap - (current_draw_time >> 3);
+				if (fill > 0)
+					out.recommended_spin = static_cast<u32>(static_cast<double>(fill) * m_spins_per_unit_time);
+			}
+		}
+
+		m_reference_frame_idx++;
+	}
+
+	if (m_spins_per_unit_time == 0)
+	{
+		// Recommend some spinning so that we can get timing data
+		out.recommended_spin = 128;
+	}
+
+	return out;
+}
+
+void ReadbackSpinManager::DrawCompleted(u32 id, u32 begin_time, u32 end_time)
+{
+	u32 frame_id = id >> 28;
+	u32 frame_off = id & ((1 << 28) - 1);
+	if (frame_id < std::size(m_frames) && frame_off < m_frames[frame_id].size())
+	{
+		Event& ev = m_frames[frame_id][frame_off];
+		ev.begin = begin_time;
+		ev.end = end_time;
+	}
+}
+
+void ReadbackSpinManager::SpinCompleted(u32 cycles, u32 begin_time, u32 end_time)
+{
+	double elapsed = static_cast<double>(end_time - begin_time);
+	constexpr double decay = 15.0 / 16.0;
+
+	// Obviously it'll vary from GPU to GPU, but in my testing,
+	// both a Radeon Pro 5600M and Intel UHD 630 spin at about 100ns/cycle
+
+	// Note: We assume spin time is some constant times the number of cycles
+	// Obviously as the number of cycles gets really low, a constant offset may start being noticeable
+	// But this is not the case as low as 512 cycles (~50µs) on the GPUs listed above
+
+	m_total_spin_cycles = m_total_spin_cycles * decay + cycles;
+	m_total_spin_time = m_total_spin_time * decay + elapsed;
+	m_spins_per_unit_time = m_total_spin_cycles / m_total_spin_time;
+}

--- a/common/ReadbackSpinManager.h
+++ b/common/ReadbackSpinManager.h
@@ -1,0 +1,65 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Pcsx2Defs.h"
+
+#include <vector>
+
+/// A class for calculating optimal spin values to trick OSes into not powering down GPUs while waiting for readbacks
+class ReadbackSpinManager
+{
+public:
+	struct Event
+	{
+		s64 size;
+		u32 begin;
+		u32 end;
+	};
+
+private:
+	double m_spins_per_unit_time = 0;
+	double m_total_spin_time = 0;
+	double m_total_spin_cycles = 0;
+	std::vector<Event> m_frames[3];
+	u32 m_current_frame = 0;
+	u32 m_reference_frame = 0;
+	u32 m_reference_frame_idx = 0;
+
+public:
+	struct DrawSubmittedReturn
+	{
+		u32 id;
+		u32 recommended_spin;
+	};
+
+	/// Call when a readback is requested
+	void ReadbackRequested();
+	/// Call at the end of a frame
+	void NextFrame();
+	/// Call when a command buffer is submitted to the GPU
+	/// `size` is used to attempt to find patterns in submissions, and can be any metric that approximates the amount of work in a submission (draw calls, command encoders, etc)
+	/// Returns an id to be passed to `DrawCompleted`, and the recommended number of spin cycles to perform on the GPU in order to keep it busy
+	DrawSubmittedReturn DrawSubmitted(u64 size);
+	/// Call once a draw has been finished by the GPU and you have begin/end data for it
+	/// `begin_time` and `end_time` can be in any unit as long as it's consistent.  It's okay if they roll over, as long as it happens less than once every few frames.
+	void DrawCompleted(u32 id, u32 begin_time, u32 end_time);
+	/// Call when a spin completes to help the manager figure out how quickly your GPU spins
+	void SpinCompleted(u32 cycles, u32 begin_time, u32 end_time);
+	/// Get the calculated number of spins per unit of time
+	/// Note: May be zero when there's insufficient data
+	double SpinsPerUnitTime() const { return m_spins_per_unit_time; }
+};

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -198,7 +198,14 @@ namespace Vulkan
 			uint32_t present_image_index = 0xFFFFFFFF, bool submit_on_thread = false);
 		void MoveToNextCommandBuffer();
 
-		void ExecuteCommandBuffer(bool wait_for_completion);
+		enum class WaitType
+		{
+			None,
+			Sleep,
+			Spin,
+		};
+
+		void ExecuteCommandBuffer(WaitType wait_for_completion);
 		void WaitForPresentComplete();
 
 		// Was the last present submitted to the queue a failure? If so, we must recreate our swapchain.

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -267,7 +267,9 @@ namespace Vulkan
 		VkRenderPass CreateCachedRenderPass(RenderPassCacheKey key);
 		void DestroyRenderPassCache();
 
+		void CommandBufferCompleted(u32 index);
 		void ActivateCommandBuffer(u32 index);
+		void ScanForCommandBufferCompletion();
 		void WaitForCommandBufferCompletion(u32 index);
 
 		void DoSubmitCommandBuffer(u32 index, VkSemaphore wait_semaphore, VkSemaphore signal_semaphore);

--- a/common/Vulkan/Context.h
+++ b/common/Vulkan/Context.h
@@ -50,6 +50,7 @@ namespace Vulkan
 		{
 			bool vk_ext_provoking_vertex : 1;
 			bool vk_ext_memory_budget : 1;
+			bool vk_ext_calibrated_timestamps : 1;
 			bool vk_khr_driver_properties : 1;
 			bool vk_arm_rasterization_order_attachment_access : 1;
 			bool vk_khr_fragment_shader_barycentric : 1;
@@ -309,6 +310,7 @@ namespace Vulkan
 		float m_accumulated_gpu_time = 0.0f;
 		bool m_gpu_timing_enabled = false;
 		bool m_gpu_timing_supported = false;
+		VkTimeDomainEXT m_calibrated_timestamp_type = VK_TIME_DOMAIN_DEVICE_EXT;
 
 		std::array<FrameResources, NUM_COMMAND_BUFFERS> m_frame_resources;
 		u64 m_next_fence_counter = 1;

--- a/common/Vulkan/EntryPoints.h
+++ b/common/Vulkan/EntryPoints.h
@@ -231,3 +231,7 @@ extern "C" {
 #define vkAcquireFullScreenExclusiveModeEXT pcsx2_vkAcquireFullScreenExclusiveModeEXT
 #define vkReleaseFullScreenExclusiveModeEXT pcsx2_vkReleaseFullScreenExclusiveModeEXT
 #endif
+
+// VK_EXT_calibrated_timestamps
+#define vkGetCalibratedTimestampsEXT pcsx2_vkGetCalibratedTimestampsEXT
+#define vkGetPhysicalDeviceCalibrateableTimeDomainsEXT pcsx2_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT

--- a/common/Vulkan/EntryPoints.inl
+++ b/common/Vulkan/EntryPoints.inl
@@ -104,6 +104,9 @@ VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceFeatures2, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceProperties2, true)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2, true)
 
+// VK_EXT_calibrated_timestamps
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, false)
+
 #endif // VULKAN_INSTANCE_ENTRY_POINT
 
 #ifdef VULKAN_DEVICE_ENTRY_POINT
@@ -244,5 +247,8 @@ VULKAN_DEVICE_ENTRY_POINT(vkBindImageMemory2, true)
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireFullScreenExclusiveModeEXT, false)
 VULKAN_DEVICE_ENTRY_POINT(vkReleaseFullScreenExclusiveModeEXT, false)
 #endif
+
+// VK_EXT_calibrated_timestamps
+VULKAN_DEVICE_ENTRY_POINT(vkGetCalibratedTimestampsEXT, false)
 
 #endif // VULKAN_DEVICE_ENTRY_POINT

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -81,6 +81,7 @@
     <ClCompile Include="MD5Digest.cpp" />
     <ClCompile Include="MemorySettingsInterface.cpp" />
     <ClCompile Include="ProgressCallback.cpp" />
+    <ClCompile Include="ReadbackSpinManager.cpp" />
     <ClCompile Include="StackWalker.cpp" />
     <ClCompile Include="StringUtil.cpp" />
     <ClCompile Include="SettingsWrapper.cpp" />
@@ -177,6 +178,7 @@
     <ClInclude Include="MemcpyFast.h" />
     <ClInclude Include="Path.h" />
     <ClInclude Include="PrecompiledHeader.h" />
+    <ClInclude Include="ReadbackSpinManager.h" />
     <ClInclude Include="RedtapeWindows.h" />
     <ClInclude Include="SafeArray.h" />
     <ClInclude Include="ThreadPool.h" />

--- a/common/common.vcxproj.filters
+++ b/common/common.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="PrecompiledHeader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ReadbackSpinManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Semaphore.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -277,6 +280,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="PrecompiledHeader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ReadbackSpinManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="RedtapeWindows.h">

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -98,6 +98,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.adapter, "EmuCore/GS", "Adapter");
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.vsync, "EmuCore/GS", "VsyncEnable", 0);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableHWFixes, "EmuCore/GS", "UserHacks", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinGPUDuringReadbacks, "EmuCore/GS", "HWSpinGPUForReadbacks", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Game Display Settings
@@ -409,6 +410,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 			tr("Enabling this option gives you the ability to change the renderer and upscaling fixes "
 			   "to your games. However IF you have ENABLED this, you WILL DISABLE AUTOMATIC "
 			   "SETTINGS and you can re-enable automatic settings by unchecking this option."));
+
+		dialog->registerWidgetHelp(m_ui.spinGPUDuringReadbacks, tr("Spin GPU During Readbacks"), tr("Unchecked"),
+			tr("Submits useless work to the GPU during readbacks to prevent it from going into powersave modes. "
+			   "May improve performance but with a significant increase in power usage."));
 
 		// Software
 		dialog->registerWidgetHelp(m_ui.extraSWThreads, tr("Extra Rendering Threads"), tr("2 threads"),

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -99,6 +99,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.vsync, "EmuCore/GS", "VsyncEnable", 0);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableHWFixes, "EmuCore/GS", "UserHacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinGPUDuringReadbacks, "EmuCore/GS", "HWSpinGPUForReadbacks", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinCPUDuringReadbacks, "EmuCore/GS", "HWSpinCPUForReadbacks", false);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Game Display Settings
@@ -413,6 +414,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.spinGPUDuringReadbacks, tr("Spin GPU During Readbacks"), tr("Unchecked"),
 			tr("Submits useless work to the GPU during readbacks to prevent it from going into powersave modes. "
+			   "May improve performance but with a significant increase in power usage."));
+
+		dialog->registerWidgetHelp(m_ui.spinGPUDuringReadbacks, tr("Spin CPU During Readbacks"), tr("Unchecked"),
+			tr("Does useless work on the CPU during readbacks to prevent it from going to into powersave modes. "
 			   "May improve performance but with a significant increase in power usage."));
 
 		// Software

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -643,6 +643,13 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="spinGPUDuringReadbacks">
+           <property name="text">
+            <string>Spin GPU During Readbacks</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
       </layout>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -650,6 +650,13 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="spinCPUDuringReadbacks">
+           <property name="text">
+            <string>Spin CPU During Readbacks</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
       </layout>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -796,6 +796,7 @@ set(pcsx2GSMetalShaders
 	GS/Renderers/Metal/convert.metal
 	GS/Renderers/Metal/present.metal
 	GS/Renderers/Metal/merge.metal
+	GS/Renderers/Metal/misc.metal
 	GS/Renderers/Metal/interlace.metal
 	GS/Renderers/Metal/tfx.metal
 	GS/Renderers/Metal/fxaa.metal

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -497,6 +497,7 @@ struct Pcsx2Config
 
 				bool
 					HWSpinGPUForReadbacks : 1,
+					HWSpinCPUForReadbacks : 1,
 					GPUPaletteConversion : 1,
 					AutoFlushSW : 1,
 					PreloadFrameWithGSData : 1,

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -496,6 +496,7 @@ struct Pcsx2Config
 					OsdShowInputs : 1;
 
 				bool
+					HWSpinGPUForReadbacks : 1,
 					GPUPaletteConversion : 1,
 					AutoFlushSW : 1,
 					PreloadFrameWithGSData : 1,

--- a/pcsx2/Frontend/D3D12HostDisplay.cpp
+++ b/pcsx2/Frontend/D3D12HostDisplay.cpp
@@ -333,7 +333,7 @@ bool D3D12HostDisplay::ChangeWindow(const WindowInfo& new_wi)
 void D3D12HostDisplay::DestroySurface()
 {
 	// For some reason if we don't execute the command list here, the swap chain is in use.. not sure where.
-	g_d3d12_context->ExecuteCommandList(true);
+	g_d3d12_context->ExecuteCommandList(D3D12::Context::WaitType::Sleep);
 
 	if (IsFullscreen())
 		SetFullscreen(false, 0, 0, 0.0f);
@@ -438,7 +438,7 @@ void D3D12HostDisplay::ResizeWindow(s32 new_window_width, s32 new_window_height,
 		return;
 
 	// For some reason if we don't execute the command list here, the swap chain is in use.. not sure where.
-	g_d3d12_context->ExecuteCommandList(true);
+	g_d3d12_context->ExecuteCommandList(D3D12::Context::WaitType::Sleep);
 
 	DestroySwapChainRTVs();
 
@@ -509,7 +509,7 @@ bool D3D12HostDisplay::SetFullscreen(bool fullscreen, u32 width, u32 height, flo
 		return true;
 	}
 
-	g_d3d12_context->ExecuteCommandList(true);
+	g_d3d12_context->ExecuteCommandList(D3D12::Context::WaitType::Sleep);
 	DestroySwapChainRTVs();
 	m_swap_chain.reset();
 
@@ -585,7 +585,7 @@ void D3D12HostDisplay::EndPresent()
 	m_current_swap_chain_buffer = ((m_current_swap_chain_buffer + 1) % static_cast<u32>(m_swap_chain_buffers.size()));
 
 	swap_chain_buf.TransitionToState(g_d3d12_context->GetCommandList(), D3D12_RESOURCE_STATE_PRESENT);
-	g_d3d12_context->ExecuteCommandList(false);
+	g_d3d12_context->ExecuteCommandList(D3D12::Context::WaitType::None);
 
 	const bool vsync = static_cast<UINT>(m_vsync_mode != VsyncMode::Off);
 	if (!vsync && m_using_allow_tearing)

--- a/pcsx2/Frontend/MetalHostDisplay.mm
+++ b/pcsx2/Frontend/MetalHostDisplay.mm
@@ -298,6 +298,7 @@ void MetalHostDisplay::EndPresent()
 			[drawable present];
 		}];
 	dev->FlushEncoders();
+	dev->FrameCompleted();
 	m_current_drawable = nullptr;
 	if (m_capture_start_frame)
 	{

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -86,7 +86,7 @@ bool VulkanHostDisplay::ChangeWindow(const WindowInfo& new_wi)
 
 	if (new_wi.type == WindowInfo::Type::Surfaceless)
 	{
-		g_vulkan_context->ExecuteCommandBuffer(true);
+		g_vulkan_context->ExecuteCommandBuffer(Vulkan::Context::WaitType::Sleep);
 		m_swap_chain.reset();
 		m_window_info = new_wi;
 		return true;
@@ -209,7 +209,7 @@ static bool UploadBufferToTexture(
 	if (!buf.ReserveMemory(upload_size, g_vulkan_context->GetBufferCopyOffsetAlignment()))
 	{
 		Console.WriteLn("Executing command buffer for UploadBufferToTexture()");
-		g_vulkan_context->ExecuteCommandBuffer(false);
+		g_vulkan_context->ExecuteCommandBuffer(Vulkan::Context::WaitType::None);
 		if (!buf.ReserveMemory(upload_size, g_vulkan_context->GetBufferCopyOffsetAlignment()))
 		{
 			Console.WriteLn("Failed to allocate %u bytes in stream buffer for UploadBufferToTexture()", upload_size);
@@ -365,7 +365,7 @@ bool VulkanHostDisplay::BeginPresent(bool frame_skip)
 			if (!m_swap_chain->RecreateSurface(m_window_info))
 			{
 				Console.Error("Failed to recreate surface after loss");
-				g_vulkan_context->ExecuteCommandBuffer(false);
+				g_vulkan_context->ExecuteCommandBuffer(Vulkan::Context::WaitType::None);
 				return false;
 			}
 
@@ -378,7 +378,7 @@ bool VulkanHostDisplay::BeginPresent(bool frame_skip)
 		{
 			// Still submit the command buffer, otherwise we'll end up with several frames waiting.
 			LOG_VULKAN_ERROR(res, "vkAcquireNextImageKHR() failed: ");
-			g_vulkan_context->ExecuteCommandBuffer(false);
+			g_vulkan_context->ExecuteCommandBuffer(Vulkan::Context::WaitType::None);
 			return false;
 		}
 	}

--- a/pcsx2/Frontend/imgui_impl_dx12.cpp
+++ b/pcsx2/Frontend/imgui_impl_dx12.cpp
@@ -165,7 +165,7 @@ void ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data)
     if (!bd->VertexStreamBuffer.ReserveMemory(needed_vb, sizeof(ImDrawVert)) ||
       !bd->IndexStreamBuffer.ReserveMemory(needed_ib, sizeof(ImDrawIdx)))
     {
-        g_d3d12_context->ExecuteCommandList(false);
+        g_d3d12_context->ExecuteCommandList(D3D12::Context::WaitType::None);
         if (!bd->VertexStreamBuffer.ReserveMemory(needed_vb, sizeof(ImDrawVert)) ||
           !bd->IndexStreamBuffer.ReserveMemory(needed_ib, sizeof(ImDrawIdx)))
         {
@@ -230,7 +230,7 @@ void ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data)
                     if (!g_d3d12_context->GetDescriptorAllocator().Allocate(1, &handle))
                     {
                         // ugh.
-                        g_d3d12_context->ExecuteCommandList(false);
+                        g_d3d12_context->ExecuteCommandList(D3D12::Context::WaitType::None);
                         ctx = g_d3d12_context->GetCommandList();
                         ImGui_ImplDX12_SetupRenderState(draw_data, ctx);
                         if (!g_d3d12_context->GetDescriptorAllocator().Allocate(1, &handle))

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1445,6 +1445,7 @@ void GSApp::Init()
 	m_default_configuration["fxaa"]                                       = "0";
 	m_default_configuration["HWDownloadMode"]                             = std::to_string(static_cast<u8>(GSHardwareDownloadMode::Enabled));
 	m_default_configuration["GSDumpCompression"]                          = std::to_string(static_cast<u8>(GSDumpCompressionMethod::LZMA));
+	m_default_configuration["HWSpinGPUForReadbacks"]                      = "0";
 	m_default_configuration["pcrtc_antiblur"]                             = "1";
 	m_default_configuration["disable_interlace_offset"]                   = "0";
 	m_default_configuration["pcrtc_offsets"]                              = "0";

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1446,6 +1446,7 @@ void GSApp::Init()
 	m_default_configuration["HWDownloadMode"]                             = std::to_string(static_cast<u8>(GSHardwareDownloadMode::Enabled));
 	m_default_configuration["GSDumpCompression"]                          = std::to_string(static_cast<u8>(GSDumpCompressionMethod::LZMA));
 	m_default_configuration["HWSpinGPUForReadbacks"]                      = "0";
+	m_default_configuration["HWSpinCPUForReadbacks"]                      = "0";
 	m_default_configuration["pcrtc_antiblur"]                             = "1";
 	m_default_configuration["disable_interlace_offset"]                   = "0";
 	m_default_configuration["pcrtc_offsets"]                              = "0";

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -25,6 +25,7 @@
 
 #include "common/HashCombine.h"
 #include "common/MRCHelpers.h"
+#include "common/ReadbackSpinManager.h"
 #include "GS/GS.h"
 #include "GSMTLDeviceInfo.h"
 #include "GSMTLSharedHeader.h"
@@ -227,6 +228,14 @@ public:
 	u64 m_current_draw = 1;
 	std::atomic<u64> m_last_finished_draw{0};
 
+	// Spinning
+	ReadbackSpinManager m_spin_manager;
+	u32 m_encoders_in_current_cmdbuf;
+	u32 m_spin_timer;
+	MRCOwned<id<MTLComputePipelineState>> m_spin_pipeline;
+	MRCOwned<id<MTLBuffer>> m_spin_buffer;
+	MRCOwned<id<MTLFence>> m_spin_fence;
+
 	// Functions and Pipeline States
 	MRCOwned<id<MTLRenderPipelineState>> m_convert_pipeline[static_cast<int>(ShaderConvert::Count)];
 	MRCOwned<id<MTLRenderPipelineState>> m_present_pipeline[static_cast<int>(PresentShader::Count)];
@@ -332,6 +341,8 @@ public:
 	void EndRenderPass();
 	/// Begin a new render pass (may reuse existing)
 	void BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil = nullptr, MTLLoadAction stencil_load = MTLLoadActionDontCare);
+	/// Call at the end of each frame
+	void FrameCompleted();
 
 	GSTexture* CreateSurface(GSTexture::Type type, int width, int height, int levels, GSTexture::Format format) override;
 

--- a/pcsx2/GS/Renderers/Metal/misc.metal
+++ b/pcsx2/GS/Renderers/Metal/misc.metal
@@ -1,0 +1,24 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021 PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+kernel void waste_time(constant uint& cycles [[buffer(0)]], device uint* spin [[buffer(1)]])
+{
+	uint value = spin[0];
+	// The compiler doesn't know, but spin[0] == 0, so this loop won't actually go anywhere
+	for (uint i = 0; i < cycles; i++)
+		value = spin[value];
+	// Store the result back to the buffer so the compiler can't optimize it away
+	spin[0] = value;
+}

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -109,6 +109,7 @@ private:
 	VkBuffer m_readback_staging_buffer = VK_NULL_HANDLE;
 	void* m_readback_staging_buffer_map = nullptr;
 	u32 m_readback_staging_buffer_size = 0;
+	bool m_warned_slow_spin = false;
 
 	VkSampler m_point_sampler = VK_NULL_HANDLE;
 	VkSampler m_linear_sampler = VK_NULL_HANDLE;

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -164,6 +164,9 @@ const char* dialog_message(int ID, bool* updateText)
 		case IDC_GEOMETRY_SHADER_OVERRIDE:
 			return cvtString("Allows the GPU instead of just the CPU to transform lines into sprites. This reduces CPU load and bandwidth requirement, but it is heavier on the GPU.\n"
 				"Automatic detection is recommended.");
+		case IDC_SPIN_GPU:
+			return cvtString("Submits useless work to the GPU during readbacks to prevent it from going into powersave modes.\n"
+				"May improve performance but with a significant increase in power usage.");
 		case IDC_LINEAR_PRESENT:
 			return cvtString("Use bilinear filtering when Upscaling/Downscaling the image to the screen. Disable it if you want a sharper/pixelated output.");
 		// Exclusive for Hardware Renderer

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -167,6 +167,9 @@ const char* dialog_message(int ID, bool* updateText)
 		case IDC_SPIN_GPU:
 			return cvtString("Submits useless work to the GPU during readbacks to prevent it from going into powersave modes.\n"
 				"May improve performance but with a significant increase in power usage.");
+		case IDC_SPIN_CPU:
+			return cvtString("Does useless work on the CPU during readbacks to prevent it from going to into powersave modes.\n"
+				"May improve performance but with a significant increase in power usage.");
 		case IDC_LINEAR_PRESENT:
 			return cvtString("Use bilinear filtering when Upscaling/Downscaling the image to the screen. Disable it if you want a sharper/pixelated output.");
 		// Exclusive for Hardware Renderer

--- a/pcsx2/GS/Window/GSSetting.h
+++ b/pcsx2/GS/Window/GSSetting.h
@@ -88,6 +88,7 @@ enum
 	// OpenGL Advanced Settings
 	IDC_GEOMETRY_SHADER_OVERRIDE,
 	IDC_SPIN_GPU,
+	IDC_SPIN_CPU,
 	// On-screen Display
 	IDC_OSD_LOG,
 	IDC_OSD_MONITOR,

--- a/pcsx2/GS/Window/GSSetting.h
+++ b/pcsx2/GS/Window/GSSetting.h
@@ -87,6 +87,7 @@ enum
 	IDC_SWTHREADS_EDIT,
 	// OpenGL Advanced Settings
 	IDC_GEOMETRY_SHADER_OVERRIDE,
+	IDC_SPIN_GPU,
 	// On-screen Display
 	IDC_OSD_LOG,
 	IDC_OSD_MONITOR,

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -284,6 +284,7 @@ RendererTab::RendererTab(wxWindow* parent)
 	auto* hw_checks_box = new wxWrapSizer(wxHORIZONTAL);
 
 	auto* paltex_prereq = m_ui.addCheckBox(hw_checks_box, "GPU Palette Conversion", "paltex", IDC_PALTEX, hw_prereq);
+	m_ui.addCheckBox(hw_checks_box, "Spin GPU During Readbacks", "HWSpinGPUForReadbacks", IDC_SPIN_GPU);
 	auto aniso_prereq = [this, paltex_prereq]{ return m_is_hardware && paltex_prereq->GetValue() == false; };
 
 	auto* hw_choice_grid = new wxFlexGridSizer(2, space, space);
@@ -473,10 +474,9 @@ PostTab::PostTab(wxWindow* parent)
 	auto* shader_boost_grid = new wxFlexGridSizer(2, space, space);
 	shader_boost_grid->AddGrowableCol(1);
 
-	auto shader_boost_prereq = [shade_boost_check, this] { return shade_boost_check.box->GetValue(); };
-	m_ui.addSliderAndLabel(shader_boost_grid, "Brightness:", "ShadeBoost_Brightness", 0, 100, 50, -1, shader_boost_prereq);
-	m_ui.addSliderAndLabel(shader_boost_grid, "Contrast:",   "ShadeBoost_Contrast",   0, 100, 50, -1, shader_boost_prereq);
-	m_ui.addSliderAndLabel(shader_boost_grid, "Saturation:", "ShadeBoost_Saturation", 0, 100, 50, -1, shader_boost_prereq);
+	m_ui.addSliderAndLabel(shader_boost_grid, "Brightness:", "ShadeBoost_Brightness", 0, 100, 50, -1, shade_boost_check);
+	m_ui.addSliderAndLabel(shader_boost_grid, "Contrast:",   "ShadeBoost_Contrast",   0, 100, 50, -1, shade_boost_check);
+	m_ui.addSliderAndLabel(shader_boost_grid, "Saturation:", "ShadeBoost_Saturation", 0, 100, 50, -1, shade_boost_check);
 
 	shade_boost_box->Add(shader_boost_grid, wxSizerFlags().Expand());
 	shader_box->Add(shade_boost_box.outer, wxSizerFlags().Expand());

--- a/pcsx2/GS/Window/GSwxDialog.cpp
+++ b/pcsx2/GS/Window/GSwxDialog.cpp
@@ -285,6 +285,7 @@ RendererTab::RendererTab(wxWindow* parent)
 
 	auto* paltex_prereq = m_ui.addCheckBox(hw_checks_box, "GPU Palette Conversion", "paltex", IDC_PALTEX, hw_prereq);
 	m_ui.addCheckBox(hw_checks_box, "Spin GPU During Readbacks", "HWSpinGPUForReadbacks", IDC_SPIN_GPU);
+	m_ui.addCheckBox(hw_checks_box, "Spin CPU During Readbacks", "HWSpinCPUForReadbacks", IDC_SPIN_CPU);
 	auto aniso_prereq = [this, paltex_prereq]{ return m_is_hardware && paltex_prereq->GetValue() == false; };
 
 	auto* hw_choice_grid = new wxFlexGridSizer(2, space, space);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -325,6 +325,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdShowInputs = false;
 
 	HWDownloadMode = GSHardwareDownloadMode::Enabled;
+	HWSpinGPUForReadbacks = false;
 	GPUPaletteConversion = false;
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
@@ -548,6 +549,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(OsdShowSettings);
 	GSSettingBool(OsdShowInputs);
 
+	GSSettingBool(HWSpinGPUForReadbacks);
 	GSSettingBoolEx(GPUPaletteConversion, "paltex");
 	GSSettingBoolEx(AutoFlushSW, "autoflush_sw");
 	GSSettingBoolEx(PreloadFrameWithGSData, "preload_frame_with_gs_data");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -326,6 +326,7 @@ Pcsx2Config::GSOptions::GSOptions()
 
 	HWDownloadMode = GSHardwareDownloadMode::Enabled;
 	HWSpinGPUForReadbacks = false;
+	HWSpinCPUForReadbacks = false;
 	GPUPaletteConversion = false;
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
@@ -550,6 +551,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(OsdShowInputs);
 
 	GSSettingBool(HWSpinGPUForReadbacks);
+	GSSettingBool(HWSpinCPUForReadbacks);
 	GSSettingBoolEx(GPUPaletteConversion, "paltex");
 	GSSettingBoolEx(AutoFlushSW, "autoflush_sw");
 	GSSettingBoolEx(PreloadFrameWithGSData, "preload_frame_with_gs_data");


### PR DESCRIPTION
### Description of Changes
Adds an option to submit pointless work to GPUs while they're waiting for work after a readback completes
(Currently supported on Vulkan and Metal)

The Vulkan implementation optionally uses `VK_EXT_calibrated_timestamps`.  On GPUs that don't support async compute (Intel), this is almost required to not have really bad performance characteristics, but GPUs with async compute should be fairly OK either way.  Regardless, we display a warning on the first readback if `VK_EXT_calibrated_timestamps` isn't supported.  Most drivers support `VK_EXT_calibrated_timestamps`, but notably, MoltenVK does not.  It just so happens that `timestampPeriod` reporting is also broken on MoltenVK+Intel, effectively disabling the feature anyways, so I doubt anyone will experience this slowdown.

Some notes on the Vulkan implementation:
I wasn't sure whether to put the code in `Common::Vulkan::Context` or `GSDeviceVK`.  It requires resources like buffers and pipelines, which were previously only managed in `GSDeviceVK`, but also requires access to timestamp data, which was previously only accessed in `Common::Vulkan::Context`.  In the end I put it in `Common::Vulkan::Context`, but am open to other opinions on where this should go.

I'm also not counting spin time for the GPU usage counter, which means there may be disagreements between Task Manager and PCSX2 on GPU usage.

Finally, I wasn't sure whether to put the checkbox in renderer or advanced settings.  For now it's in the renderer settings.

### Rationale behind Changes
A lot of laptop GPUs go into power saving modes when they're not being fully utilized, and because we don't submit new work immediately after a readback, this often makes the GPU think it can save power when it really shouldn't.
Seeing noticeable improvements on:
- Radeon Pro 5600M on Windows
- Intel UHD 630 on MacOS

<details>
<summary>Comparison Screenshots</summary>

Valkyrie Profile 2 @ 1x, Spin Off, Radeon Pro 5600M (Windows)
![image](https://user-images.githubusercontent.com/3315070/191164813-29bff08a-964d-415b-b64d-c34d4ab3156d.png)
Valkyrie Profile 2 @ 1x, Spin On, Radeon Pro 5600M (Windows)
![image](https://user-images.githubusercontent.com/3315070/191164932-02935599-faf4-40ba-898d-96472d445d28.png)
SSX Tricky Snowdream @ 4x, Spin Off, Radeon Pro 5600M (Windows)
![image](https://user-images.githubusercontent.com/3315070/191164978-cb9593de-abb9-4629-9317-b334a922a000.png)
SSX Tricky Snowdream @ 4x, Spin On, Radeon Pro 5600M (Windows)
![image](https://user-images.githubusercontent.com/3315070/191165004-38698505-e561-4e97-a163-c73342d0f3e4.png)
Valkyrie Profile 2 @ 1x, Spin Off, Intel UHD 630 (macOS Metal)
![image](https://user-images.githubusercontent.com/3315070/191165550-548a2107-7bc8-41ea-84f0-de60a80a9379.png)
Valkyrie Profile 2 @ 1x, Spin On, Intel UHD 630 (macOS Metal)
![image](https://user-images.githubusercontent.com/3315070/191165581-f639da58-f8df-4b6c-bdfa-72761f61dd35.png)

</details>

### Suggested Testing Steps
Test games that use readbacks.  Not GSdumps, they don't have the same performance characteristics.  Some steam deck numbers would be nice, since they've previously had a lot of issues with readbacks.  Also Intel GPUs on Windows or Linux, I've only been able to test async-compute-supporting GPUs on the Vulkan implementation, which are much more forgiving in spin overruns.  Power usage comparisons would be nice too, I expect high power usage but the question is how high.

Any game is fine, monitor the OSD Statistics for `1 RB` (or more than 1).  Some games I know benefit:
- Valkyrie Profile 2, outside right after starting the game (see comparison screenshots above)
- SSX Tricky, Snowdream
- Gran Turismo 4, Night stages