### PR TITLE
GameDB: Correct incorrect GTA SA fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12172,6 +12172,8 @@ SLES-51526:
 SLES-51541:
   name: "Grand Theft Auto - San Andreas"
   region: "PAL-Unk"
+  clampModes:
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLES-51547:
@@ -14168,7 +14170,7 @@ SLES-52541:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLES-52542:
@@ -15086,7 +15088,7 @@ SLES-52927:
   name: "Grand Theft Auto - San Andreas"
   region: "PAL-G"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLES-52931:
@@ -22991,7 +22993,7 @@ SLPM-55092:
   name: "Grand Theft Auto - San Andreas [Best Price]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-55096:
@@ -23328,7 +23330,7 @@ SLPM-55292:
   name: "Grand Theft Auto - San Andreas [Rockstar Classics]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-55298:
@@ -29015,7 +29017,7 @@ SLPM-65984:
   name: "Grand Theft Auto - San Andreas"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-65985:
@@ -31934,7 +31936,7 @@ SLPM-66788:
   name: "Grand Theft Auto - San Andreas [Best Price]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-66789:
@@ -42502,7 +42504,7 @@ SLUS-20946:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLUS-20947:


### PR DESCRIPTION
### Description of Changes
Fixes a mistake someone made adding ee clamping to GTA SA.

### Rationale behind Changes
Some doughnut added vu clamping not ee clamping so the mission "Reunite the family's" would still crash despite being listed as "fixed".

### Suggested Testing Steps
Make sure CI is happy.
