### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1583,8 +1583,14 @@ endif()
 
 # MacOSX/BSD
 if(UNIX AND NOT Linux)
+	if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
 	target_sources(PCSX2 PRIVATE
-		${pcsx2OSXSources}
+			${pcsx2FreeBSDSources})
+	else()
+		target_sources(PCSX2 PRIVATE
+			${pcsx2OSXSources})
+	endif()
+	target_sources(PCSX2 PRIVATE
 		${pcsx2LinuxHeaders}
 		${pcsx2USBNullSources}
 		${pcsx2USBNullHeaders})
@@ -1601,12 +1607,6 @@ else()
 			${pcsx2USBNullSources}
 			${pcsx2USBNullHeaders})
 	endif()
-endif()
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
-	target_sources(PCSX2 PRIVATE
-		${pcsx2FreeBSDSources}
-		${pcsx2LinuxHeaders})
 endif()
 
 target_link_libraries(PCSX2_FLAGS INTERFACE


### PR DESCRIPTION
### Rationale behind Changes
${pcsx2OSXSources} cannot be built on FreeBSD, so remove them. While here, I've also simplified the logic.