### PR TITLE
GS/HW: HLE shuffles (more like copies) done through moves

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -647,8 +647,8 @@ struct alignas(16) GSHWDrawConfig
 	GSTexture* ds;        ///< Depth stencil
 	GSTexture* tex;       ///< Source texture
 	GSTexture* pal;       ///< Palette texture
-	GSVertex* verts;      ///< Vertices to draw
-	u32* indices;         ///< Indices to draw
+	const GSVertex* verts;///< Vertices to draw
+	const u32* indices;   ///< Indices to draw
 	u32 nverts;           ///< Number of vertices
 	u32 nindices;         ///< Number of indices
 	u32 indices_per_prim; ///< Number of indices that make up one primitive

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -349,6 +349,7 @@ public:
 	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool target = true);
 	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r);
 	bool Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u32 DBW, u32 DPSM, int dx, int dy, int w, int h);
+	bool ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx, int dy, int w, int h);
 
 	void IncAge();
 


### PR DESCRIPTION
### Description of Changes

Final Fantasy XII uses moves to copy the contents of the RG channels to the BA channels, by rendering in PSMCT32, and doing a PSMCT16 move with an 8x0 offset on the destination. This effectively reads from the original red/green channels, and writes to the blue/alpha channels. Who knows why they did it this way, when they could've used sprites, but it means that they had to offset the block pointer for each move. Which our texture cache can't track naively. So, we need to use tex-in-rt here to figure out what the offset into the original PSMCT32 texture was, and HLE the move.

The even better part, is it all happens on the GPU, so no readback, and brr :).

![image](https://user-images.githubusercontent.com/11288319/192131652-56941bcf-229c-4c2b-b28e-ba3da8e67e9d.png)
![image](https://user-images.githubusercontent.com/11288319/192131661-15eb0b91-9918-4ef8-af42-f8b0b8187331.png)

![image](https://user-images.githubusercontent.com/11288319/192131662-05d08c8f-248e-4ad8-b61d-0f335337fefc.png)
![image](https://user-images.githubusercontent.com/11288319/192131665-7b329d55-a70a-47d4-bb30-4885ba3f7c2b.png)

In some scenes, the edges of the shadows are messed up when upscaling. This is a separate issue, caused by the line not being drawn on the edge (we'd probably need to snap these to 1x increments for 2D lines).

![image](https://user-images.githubusercontent.com/11288319/192131641-7ebf4b19-ee69-4a6f-9596-4e06fa0c36fe.png)

Maybe something else is affected? I don't know of anything though.

Also pushes non-overlapping moves to the same block pointer down the HW move path, which should be safe (except for depth on DX11/DX12).

### Rationale behind Changes

Fixes broken shadows in the hardware renderer in Final Fantasy XII.

Closes #1650.

### Suggested Testing Steps

Test FF12.
