### PR TITLE
VMManager: Fix per-game memory cards getting ejected on boot

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -681,7 +681,12 @@ void VMManager::UpdateRunningGame(bool resetting, bool game_starting)
 	UpdateGameSettingsLayer();
 	ApplySettings();
 
-	// check this here, for two cases: dynarec on, and when enable cheats is set per-game.
+	// Clear the memory card eject notification again when booting for the first time, or starting.
+	// Otherwise, games think the card was removed on boot.
+	if (game_starting || resetting)
+		ClearMcdEjectTimeoutNow();
+
+	// Check this here, for two cases: dynarec on, and when enable cheats is set per-game.
 	if (s_patches_crc != s_game_crc)
 		ReloadPatches(game_starting, false);
 


### PR DESCRIPTION
### Description of Changes

See title. Many games got very confused, as the card stayed in the ejected state for a few seconds after they booted.

### Rationale behind Changes

Making per-game memory cards not buggy.

### Suggested Testing Steps

Probably difficult to test since it's not in the UI (yet), but you can set it via gamesettings/ini, or take my word that I've tested it and it does work :)