### PR TITLE
GameDB: Disable InstantVU1 for SoTC

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1126,6 +1126,8 @@ SCAJ-20146:
   name: "Wang Da Yu Ju Xiang"
   region: "NTSC-Ch"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -1372,6 +1374,8 @@ SCAJ-20195:
 SCAJ-20196:
   name: "Wang Da Yu Ju Xiang [PlayStation 2 The Best]"
   region: "NTSC-Ch"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -2389,6 +2393,14 @@ SCED-53932:
 SCED-53939:
   name: "Official PlayStation 2 Magazine Demo 67" # Australian
   region: "PAL-E"
+SCED-53962:
+  name: "Shadow of the Colossus [Demo]"
+  region: "PAL-M5"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCED-53978:
   name: "Official PlayStation 2 Magazine Demo 69"
   region: "PAL-M5"
@@ -3660,6 +3672,8 @@ SCES-53326:
   name: "Shadow of the Colossus"
   region: "PAL-E"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -4827,6 +4841,8 @@ SCKA-20061:
   name: "Wanda to Kyozou"
   region: "NTSC-K"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -5663,6 +5679,8 @@ SCPS-15097:
   name: "Wanda to Kyozou"
   region: "NTSC-J"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -6098,6 +6116,8 @@ SCPS-19319:
 SCPS-19320:
   name: "Wanda to Kyozou [PlayStation 2 The Best]"
   region: "NTSC-J"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -6109,6 +6129,14 @@ SCPS-19320:
     - "SCPS-19103"
     - "SCPS-19151"
     - "SCPS-55001"
+SCPS-19335:
+  name: "Wanda to Kyozou [PlayStation 2 The Best Reprint]"
+  region: "NTSC-J"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCPS-19321:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7846,6 +7874,8 @@ SCUS-97472:
   name: "Shadow of the Colossus"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -8024,6 +8054,8 @@ SCUS-97504:
 SCUS-97505:
   name: "Shadow of the Colossus [Demo]"
   region: "NTSC-U"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.


### PR DESCRIPTION
### Description of Changes
Disables InstantVU1 for a moderate increase in FPS due to lower VU % usage.

### Rationale behind Changes
SoTC is very hard to run due to very high usage disabling InstantVU1 decreases load on the VU% considerably though cycle skipping can still be done for even more FPS. 

### Suggested Testing Steps
Make sure CI is happy.
