### PR TITLE
gitignore: Don't track bad_shader logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Debug.txt
 install_log.txt
 padLog.txt
 GS_opengl_debug.txt
+bad_shader_*
 
 Debug
 Release


### PR DESCRIPTION
### Description of Changes
Adds exception for bad_shader files generated by PCSX2

### Rationale behind Changes
Keep git clean/avoid errors

### Suggested Testing Steps
N/A
