### PR TITLE
GameDB: Don't search for CRC before the ELF has been loaded

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 
+#include "R5900.h"
 #include "GameDatabase.h"
 #include "Host.h"
 #include "Patch.h"
@@ -750,6 +751,12 @@ void GameDatabase::ensureLoaded()
 const GameDatabaseSchema::GameEntry* GameDatabase::findGame(const std::string_view& serial)
 {
 	GameDatabase::ensureLoaded();
+
+	if ((!g_GameStarted) && (!g_GameLoading))
+	{
+		Console.WriteLn(fmt::format("[GameDB] ELF has not been loaded yet, skipping..."));
+		return nullptr;
+	}
 
 	std::string serialLower = StringUtil::toLower(serial);
 	Console.WriteLn(fmt::format("[GameDB] Searching for '{}' in GameDB", serialLower));


### PR DESCRIPTION
### Description of Changes
Stops GameDB from trying to search for a CRC when it hasn't been loaded yet from the ELF.

### Rationale behind Changes
Cleanliness

### Suggested Testing Steps
Make sure gamefixes and patches still load properly
