### PR TITLE
GS/HW: Make mipmapping suck less

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1095,6 +1095,8 @@ SCAJ-20138:
   region: "NTSC-Unk"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCAJ-20139:
   name: "Zero - Shisei no Koe" # Fatal Frame - Rei - Irezumi no Sei
   region: "NTSC-Unk"
@@ -1371,6 +1373,8 @@ SCAJ-20195:
   region: "NTSC-Ch"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCAJ-20196:
   name: "Wang Da Yu Ju Xiang [PlayStation 2 The Best]"
   region: "NTSC-Ch"
@@ -1531,7 +1535,8 @@ SCCS-40001:
   name: "Ape Escape 2"
   region: "NTSC-C"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCCS-40002:
   name: "Devil May Cry 2 - Disc 1"
   region: "NTSC-C"
@@ -2908,7 +2913,8 @@ SCES-50885:
   name: "Ape Escape 2"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-50887:
   name: "Alpine Racer 3"
   region: "PAL-M5"
@@ -3010,22 +3016,26 @@ SCES-51102:
   name: "Ape Escape 2"
   region: "PAL-F"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51103:
   name: "Ape Escape 2"
   region: "PAL-I"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51104:
   name: "Ape Escape 2"
   region: "PAL-G"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51105:
   name: "Ape Escape 2"
   region: "PAL-S"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51135:
   name: "Primal"
   region: "PAL-M5"
@@ -3756,6 +3766,8 @@ SCES-53642:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-53663:
   name: "Buzz! The Music Quiz"
   region: "PAL-M3"
@@ -4857,6 +4869,8 @@ SCKA-20062:
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCKA-20063:
   name: "Sly Cooper 3 Honor Among Thieves"
   region: "NTSC-K"
@@ -5931,7 +5945,8 @@ SCPS-19206:
   name: "Ape Escape 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19207:
   name: "Popolocrois Story - Hajime no Bouken [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6200,6 +6215,8 @@ SCPS-19327:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19328:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
@@ -6432,7 +6449,8 @@ SCPS-55035:
   name: "Ape Escape 2"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-55038:
   name: "Pac-Man World 2"
   region: "NTSC-J"
@@ -8039,6 +8057,8 @@ SCUS-97501:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCUS-97502:
   name: "Tourist Trophy"
   region: "NTSC-U"
@@ -8212,6 +8232,8 @@ SCUS-97548:
   region: "NTSC-U"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCUS-97554:
   name: "NBA '07 featuring The Life Vol.2 [Demo]"
   region: "NTSC-U"
@@ -41330,7 +41352,8 @@ SLUS-20685:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SLUS-20686:
   name: "Splashdown - Rides Gone Wild"
   region: "NTSC-U"

--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "GSIntrin.h"
+#include <cstring>
 
 #pragma once
 
@@ -65,12 +66,12 @@ public:
 
 	constexpr bool operator==(const GSVector2T& v) const
 	{
-		return x == v.x && y == v.y;
+		return (std::memcmp(this, &v, sizeof(*this)) == 0);
 	}
 
 	constexpr bool operator!=(const GSVector2T& v) const
 	{
-		return x != v.x || y != v.y;
+		return (std::memcmp(this, &v, sizeof(*this)) != 0);
 	}
 
 	constexpr GSVector2T operator*(const GSVector2T& v) const

--- a/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTextureFX11.cpp
@@ -259,7 +259,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 			sd.AddressV = ssel.tav ? D3D11_TEXTURE_ADDRESS_WRAP : D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
 			sd.MinLOD = 0.0f;
-			sd.MaxLOD = ssel.lodclamp ? 0.0f : FLT_MAX;
+			sd.MaxLOD = (ssel.lodclamp || !ssel.UseMipmapFiltering()) ? 0.25f : FLT_MAX;
 			sd.MaxAnisotropy = std::clamp(anisotropy, 1, 16);
 			sd.ComparisonFunc = D3D11_COMPARISON_NEVER;
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -908,7 +908,7 @@ bool GSDevice12::GetSampler(D3D12::DescriptorHandle* cpu_handle, GSHWDrawConfig:
 	sd.AddressV = ss.tav ? D3D12_TEXTURE_ADDRESS_MODE_WRAP : D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 	sd.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 	sd.MinLOD = 0.0f;
-	sd.MaxLOD = ss.lodclamp ? 0.0f : FLT_MAX;
+	sd.MaxLOD = (ss.lodclamp || !ss.UseMipmapFiltering()) ? 0.25f : FLT_MAX;
 	sd.MaxAnisotropy = std::clamp(GSConfig.MaxAnisotropy, 1, 16);
 	sd.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3031,25 +3031,29 @@ void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Source* tex)
 
 	bool bilinear = m_vt.IsLinear();
 	int trilinear = 0;
-	bool trilinear_auto = false;
+	bool trilinear_auto = false; // Generate mipmaps if needed (basic).
 	switch (GSConfig.UserHacks_TriFilter)
 	{
 		case TriFiltering::Forced:
-			{
-				// force bilinear otherwise we can end up with min/mag nearest and mip linear.
-				bilinear = true;
-				trilinear = static_cast<u8>(GS_MIN_FILTER::Linear_Mipmap_Linear);
-				trilinear_auto = !need_mipmap || GSConfig.HWMipmap != HWMipmapLevel::Full;
-			}
-			break;
+		{
+			// Force bilinear otherwise we can end up with min/mag nearest and mip linear.
+			// We don't need to check for HWMipmapLevel::Off here, because forced trilinear implies forced mipmaps.
+			bilinear = true;
+			trilinear = static_cast<u8>(GS_MIN_FILTER::Linear_Mipmap_Linear);
+			trilinear_auto = !need_mipmap || GSConfig.HWMipmap != HWMipmapLevel::Full;
+		}
+		break;
 
 		case TriFiltering::PS2:
-			if (need_mipmap && GSConfig.HWMipmap != HWMipmapLevel::Full)
+		{
+			// Can only use PS2 trilinear when mipmapping is enabled.
+			if (need_mipmap && GSConfig.HWMipmap != HWMipmapLevel::Off)
 			{
 				trilinear = m_context->TEX1.MMIN;
-				trilinear_auto = true;
+				trilinear_auto = GSConfig.HWMipmap != HWMipmapLevel::Full;
 			}
-			break;
+		}
+		break;
 
 		case TriFiltering::Automatic:
 		case TriFiltering::Off:

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -207,6 +207,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 
 	auto& m = m_src.m_map[TEX0.TBP0 >> 5];
 
+	const GSVector2i compare_lod(lod ? *lod : GSVector2i(0, 0));
 	for (auto i = m.begin(); i != m.end(); ++i)
 	{
 		Source* s = *i;
@@ -226,6 +227,11 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const GIFRegTEX0& TEX0, con
 			// We request a 24/16 bit RGBA texture. Alpha expansion was done by
 			// the CPU.  We need to check that TEXA is identical
 			if (psm_s.pal == 0 && psm_s.fmt > 0 && s->m_TEXA.U64 != TEXA.U64)
+				continue;
+
+			// Same base mip texture, but we need to check that MXL was the same as well.
+			// When mipmapping is off, this will be 0,0 vs 0,0.
+			if (s->m_lod != compare_lod)
 				continue;
 		}
 
@@ -1556,6 +1562,8 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 {
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[TEX0.PSM];
 	Source* src = new Source(TEX0, TEXA, false);
+	if (lod)
+		src->m_lod = *lod;
 
 	int tw = 1 << TEX0.TW;
 	int th = 1 << TEX0.TH;
@@ -2276,6 +2284,7 @@ GSTextureCache::Source::Source(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, b
 	: m_palette_obj(nullptr)
 	, m_palette(nullptr)
 	, m_valid_rect(0, 0)
+	, m_lod(0, 0)
 	, m_target(false)
 	, m_p2t(NULL)
 	, m_from_target(NULL)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -159,6 +159,7 @@ public:
 		std::unique_ptr<u32[]> m_valid;// each u32 bits map to the 32 blocks of that page
 		GSTexture* m_palette;
 		GSVector4i m_valid_rect;
+		GSVector2i m_lod;
 		u8 m_valid_hashes = 0;
 		u8 m_complete_layers = 0;
 		bool m_target;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -883,7 +883,7 @@ GLuint GSDeviceOGL::CreateSampler(PSSamplerSelector sel)
 	}
 
 	glSamplerParameterf(sampler, GL_TEXTURE_MIN_LOD, -1000.0f);
-	glSamplerParameterf(sampler, GL_TEXTURE_MAX_LOD, sel.lodclamp ? 0.0f : 1000.0f);
+	glSamplerParameterf(sampler, GL_TEXTURE_MAX_LOD, sel.lodclamp ? 0.25f : 1000.0f);
 
 	if (sel.tau)
 		glSamplerParameteri(sampler, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1029,7 +1029,7 @@ VkSampler GSDeviceVK::GetSampler(GSHWDrawConfig::SamplerSelector ss)
 		VK_FALSE, // compare enable
 		VK_COMPARE_OP_ALWAYS, // compare op
 		0.0f, // min lod
-		ss.lodclamp ? 0.25f : VK_LOD_CLAMP_NONE, // max lod
+		(ss.lodclamp || !ss.UseMipmapFiltering()) ? 0.25f : VK_LOD_CLAMP_NONE, // max lod
 		VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK, // border
 		VK_FALSE // unnormalized coordinates
 	};


### PR DESCRIPTION
### Description of Changes

Fixes building flicker in Burnout 3 with Full mipmapping, as the first draws don't use mipmapping, but the others do, resulting in the texture having whatever was last left in it before it was recycled.

Also fixes flickering and incorrect mipmap blending in Ape Escape 2 (when using Mipmapping = Full, Trilinear = PS2).

### Rationale behind Changes

Making mipmapping suck less.

Closes https://github.com/PCSX2/pcsx2/issues/6280
Closes https://github.com/PCSX2/pcsx2/issues/5320
Closes https://github.com/PCSX2/pcsx2/issues/869
Closes https://github.com/PCSX2/pcsx2/issues/2124

### Suggested Testing Steps

Test affected games.
