### PR TITLE
GS/Vulkan: Actually store the readback buffer size

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1401,6 +1401,7 @@ bool GSDevice12::CheckStagingBufferSize(u32 required_size)
 		return false;
 	}
 
+	m_readback_staging_buffer_size = required_size;
 	return true;
 }
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1804,6 +1804,7 @@ bool GSDeviceVK::CheckStagingBufferSize(u32 required_size)
 	}
 
 	m_readback_staging_buffer_map = ai.pMappedData;
+	m_readback_staging_buffer_size = required_size;
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes

This being missing was causing the buffer to be reallocated every download.

### Rationale behind Changes

Reduce CPU load. It's probably not much due to VulkanMemoryAllocator, but still.

### Suggested Testing Steps

Make sure downloads/readbacks still work (can test with a screenshot).
