### PR TITLE
GS: Handle higher TH/TW for STQ calculation

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1099,7 +1099,9 @@ void GSState::GIFRegHandlerTEX0(const GIFReg* RESTRICT r)
 	// Max allowed MTBA size for 32bit swizzled textures (including 8H 4HL etc) is 512, 16bit and normal 8/4bit formats can be 1024
 	const u32 maxTex = (GSLocalMemory::m_psm[TEX0.PSM].bpp < 32) ? 10 : 9;
 
-	// Spec max is 10
+	// Spec max is 10, but bitfield allows for up to 15
+	// However STQ calculations expect the written size to be used for denormalization (Simple 2000 Series Vol 105 The Maid)
+	// This is clamped to 10 in the FixedTEX0 functions so texture sizes don't exceed 1024x1024, but STQ can calculate properly (with invalid_tex0)
 	//
 	// Yakuza (minimap)
 	// Sets TW/TH to 0
@@ -1110,8 +1112,8 @@ void GSState::GIFRegHandlerTEX0(const GIFReg* RESTRICT r)
 	// Sets TW/TH to 0
 	// there used to be a case to force this to 10
 	// but GetSizeFixedTEX0 sorts this now
-	TEX0.TW = std::clamp<u32>(TEX0.TW, 0, 10);
-	TEX0.TH = std::clamp<u32>(TEX0.TH, 0, 10);
+	TEX0.TW = std::clamp<u32>(TEX0.TW, 0, 15);
+	TEX0.TH = std::clamp<u32>(TEX0.TH, 0, 15);
 
 	// MTBA loads are triggered by writes to TEX0 (but not TEX2!)
 	// Textures MUST be a minimum width of 32 pixels

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4074,59 +4074,69 @@ bool GSRendererHW::SwPrimRender()
 				}
 			}
 
-			const u16 tw = 1u << TEX0.TW;
-			const u16 th = 1u << TEX0.TH;
+			u16 tw = 1u << TEX0.TW;
+			u16 th = 1u << TEX0.TH;
+
+			if (tw > 1024)
+				tw = 1;
+
+			if (th > 1024)
+				th = 1;
 
 			switch (context->CLAMP.WMS)
 			{
-			case CLAMP_REPEAT:
-				gd.t.min.U16[0] = gd.t.minmax.U16[0] = tw - 1;
-				gd.t.max.U16[0] = gd.t.minmax.U16[2] = 0;
-				gd.t.mask.U32[0] = 0xffffffff;
-				break;
-			case CLAMP_CLAMP:
-				gd.t.min.U16[0] = gd.t.minmax.U16[0] = 0;
-				gd.t.max.U16[0] = gd.t.minmax.U16[2] = tw - 1;
-				gd.t.mask.U32[0] = 0;
-				break;
-			case CLAMP_REGION_CLAMP:
-				gd.t.min.U16[0] = gd.t.minmax.U16[0] = std::min<u16>(context->CLAMP.MINU, tw - 1);
-				gd.t.max.U16[0] = gd.t.minmax.U16[2] = std::min<u16>(context->CLAMP.MAXU, tw - 1);
-				gd.t.mask.U32[0] = 0;
-				break;
-			case CLAMP_REGION_REPEAT:
-				gd.t.min.U16[0] = gd.t.minmax.U16[0] = context->CLAMP.MINU & (tw - 1);
-				gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU & (tw - 1);
-				gd.t.mask.U32[0] = 0xffffffff;
-				break;
-			default:
-				__assume(0);
+				case CLAMP_REPEAT:
+					gd.t.min.U16[0] = gd.t.minmax.U16[0] = tw - 1;
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = 0;
+					gd.t.mask.U32[0] = 0xffffffff;
+					break;
+				case CLAMP_CLAMP:
+					gd.t.min.U16[0] = gd.t.minmax.U16[0] = 0;
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = tw - 1;
+					gd.t.mask.U32[0] = 0;
+					break;
+				case CLAMP_REGION_CLAMP:
+					// REGION_CLAMP ignores the actual texture size
+					gd.t.min.U16[0] = gd.t.minmax.U16[0] = context->CLAMP.MINU;
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU;
+					gd.t.mask.U32[0] = 0;
+					break;
+				case CLAMP_REGION_REPEAT:
+					// MINU is restricted to MINU or texture size, whichever is smaller, MAXU is an offset in the texture.
+					gd.t.min.U16[0] = gd.t.minmax.U16[0] = context->CLAMP.MINU & (tw - 1);
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU;
+					gd.t.mask.U32[0] = 0xffffffff;
+					break;
+				default:
+					__assume(0);
 			}
 
 			switch (context->CLAMP.WMT)
 			{
-			case CLAMP_REPEAT:
-				gd.t.min.U16[4] = gd.t.minmax.U16[1] = th - 1;
-				gd.t.max.U16[4] = gd.t.minmax.U16[3] = 0;
-				gd.t.mask.U32[2] = 0xffffffff;
-				break;
-			case CLAMP_CLAMP:
-				gd.t.min.U16[4] = gd.t.minmax.U16[1] = 0;
-				gd.t.max.U16[4] = gd.t.minmax.U16[3] = th - 1;
-				gd.t.mask.U32[2] = 0;
-				break;
-			case CLAMP_REGION_CLAMP:
-				gd.t.min.U16[4] = gd.t.minmax.U16[1] = std::min<u16>(context->CLAMP.MINV, th - 1);
-				gd.t.max.U16[4] = gd.t.minmax.U16[3] = std::min<u16>(context->CLAMP.MAXV, th - 1); // ffx anima summon scene, when the anchor appears (th = 256, maxv > 256)
-				gd.t.mask.U32[2] = 0;
-				break;
-			case CLAMP_REGION_REPEAT:
-				gd.t.min.U16[4] = gd.t.minmax.U16[1] = context->CLAMP.MINV & (th - 1); // skygunner main menu water texture 64x64, MINV = 127
-				gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV & (th - 1);
-				gd.t.mask.U32[2] = 0xffffffff;
-				break;
-			default:
-				__assume(0);
+				case CLAMP_REPEAT:
+					gd.t.min.U16[4] = gd.t.minmax.U16[1] = th - 1;
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = 0;
+					gd.t.mask.U32[2] = 0xffffffff;
+					break;
+				case CLAMP_CLAMP:
+					gd.t.min.U16[4] = gd.t.minmax.U16[1] = 0;
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = th - 1;
+					gd.t.mask.U32[2] = 0;
+					break;
+				case CLAMP_REGION_CLAMP:
+					// REGION_CLAMP ignores the actual texture size
+					gd.t.min.U16[4] = gd.t.minmax.U16[1] = context->CLAMP.MINV;
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV; // ffx anima summon scene, when the anchor appears (th = 256, maxv > 256)
+					gd.t.mask.U32[2] = 0;
+					break;
+				case CLAMP_REGION_REPEAT:
+					// MINV is restricted to MINV or texture size, whichever is smaller, MAXV is an offset in the texture.
+					gd.t.min.U16[4] = gd.t.minmax.U16[1] = context->CLAMP.MINV & (th - 1); // skygunner main menu water texture 64x64, MINV = 127
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV;
+					gd.t.mask.U32[2] = 0xffffffff;
+					break;
+				default:
+					__assume(0);
 			}
 
 			gd.t.min = gd.t.min.xxxxlh();

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -1211,6 +1211,11 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 			u16 tw = 1u << TEX0.TW;
 			u16 th = 1u << TEX0.TH;
 
+			if (tw > 1024)
+				tw = 1;
+			if (th > 1024)
+				th = 1;
+
 			switch (context->CLAMP.WMS)
 			{
 				case CLAMP_REPEAT:
@@ -1224,13 +1229,15 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 					gd.t.mask.U32[0] = 0;
 					break;
 				case CLAMP_REGION_CLAMP:
-					gd.t.min.U16[0] = gd.t.minmax.U16[0] = std::min<u16>(context->CLAMP.MINU, tw - 1);
-					gd.t.max.U16[0] = gd.t.minmax.U16[2] = std::min<u16>(context->CLAMP.MAXU, tw - 1);
+					// REGION_CLAMP ignores the actual texture size
+					gd.t.min.U16[0] = gd.t.minmax.U16[0] = context->CLAMP.MINU;
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU;
 					gd.t.mask.U32[0] = 0;
 					break;
 				case CLAMP_REGION_REPEAT:
+					// MINU is restricted to MINU or texture size, whichever is smaller, MAXU is an offset in the texture (Can be bigger than the texture).
 					gd.t.min.U16[0] = gd.t.minmax.U16[0] = context->CLAMP.MINU & (tw - 1);
-					gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU & (tw - 1);
+					gd.t.max.U16[0] = gd.t.minmax.U16[2] = context->CLAMP.MAXU;
 					gd.t.mask.U32[0] = 0xffffffff;
 					break;
 				default:
@@ -1250,13 +1257,15 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 					gd.t.mask.U32[2] = 0;
 					break;
 				case CLAMP_REGION_CLAMP:
-					gd.t.min.U16[4] = gd.t.minmax.U16[1] = std::min<u16>(context->CLAMP.MINV, th - 1);
-					gd.t.max.U16[4] = gd.t.minmax.U16[3] = std::min<u16>(context->CLAMP.MAXV, th - 1); // ffx anima summon scene, when the anchor appears (th = 256, maxv > 256)
+					// REGION_CLAMP ignores the actual texture size
+					gd.t.min.U16[4] = gd.t.minmax.U16[1] = context->CLAMP.MINV;
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV; // ffx anima summon scene, when the anchor appears (th = 256, maxv > 256)
 					gd.t.mask.U32[2] = 0;
 					break;
 				case CLAMP_REGION_REPEAT:
+					// MINV is restricted to MINV or texture size, whichever is smaller, MAXV is an offset in the texture (Can be bigger than the texture).
 					gd.t.min.U16[4] = gd.t.minmax.U16[1] = context->CLAMP.MINV & (th - 1); // skygunner main menu water texture 64x64, MINV = 127
-					gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV & (th - 1);
+					gd.t.max.U16[4] = gd.t.minmax.U16[3] = context->CLAMP.MAXV;
 					gd.t.mask.U32[2] = 0xffffffff;
 					break;
 				default:


### PR DESCRIPTION
### Description of Changes
Modify the clamps/FixedTEX0 calculations to allow TEX0 to set values higher than 10 (max texture size on the GS)

### Rationale behind Changes
When using STQ, the calculations are done with the TH and TW sizes in mind that were written to the TEX0 register, clamping them to 10 causes the calculation result to be incorrect.

### Suggested Testing Steps
test games (Especially those where textures looked accidentally blown up), make sure nothing is busted. Affects both SW and HW.

TODO: Need to do a hardware test to confirm the clamp behaviour, I suspect it will clamp/wrap at 1024, but we will need to do a hardware test to confirm this.

Fixes the text size in `Simple 2000 Series Vol. 105 - The Maid Fuku to Kikanjuu`, ~~there is a further issue where the 4bit pixels are in the wrong order, however the PS2 also shows this error, so it could be another GS problem with an upload that only happens once, or it's a core problem.~~


Before:
![image](https://user-images.githubusercontent.com/6278726/193092158-e9651387-754c-4d0d-b383-7274940428bb.png)
![image](https://user-images.githubusercontent.com/6278726/193092310-6f75fee4-15b9-4986-9f3c-84562216d3e5.png)

After:
![image](https://user-images.githubusercontent.com/6278726/193092247-b6a5b212-5f77-4622-bb1f-2dca4afafedc.png)
![image](https://user-images.githubusercontent.com/6278726/193092364-fce77d62-1c4b-4110-91f6-275965e7b60d.png)
