### PR TITLE
Acheivements: Make login progress indeterminate

### DIFF
--- a/pcsx2/Frontend/Achievements.cpp
+++ b/pcsx2/Frontend/Achievements.cpp
@@ -948,7 +948,7 @@ bool Achievements::LoginAsync(const char* username, const char* password)
 
 	if (FullscreenUI::IsInitialized())
 	{
-		ImGuiFullscreen::OpenBackgroundProgressDialog("cheevos_async_login", "Logging in to RetroAchievements...", 0, 1, 0);
+		ImGuiFullscreen::OpenBackgroundProgressDialog("cheevos_async_login", "Logging in to RetroAchievements...", 0, 0, 0);
 	}
 
 	SendLogin(username, password, s_http_downloader.get(), LoginASyncCallback);


### PR DESCRIPTION
### Description of Changes

It doesn't have a percentage.

### Rationale behind Changes

Seeing 0% and then immediately closing is confusing.

### Suggested Testing Steps

Test login in big picture. But this is such a simple change it's obvious it works (min == max triggers indeterminate).
