### PR TITLE
FullscreenUI: Clean boot if resume picked without state

### DIFF
--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -4541,15 +4541,16 @@ void FullscreenUI::HandleGameListOptions(const GameList::Entry* entry)
 		{ICON_FA_WINDOW_CLOSE " Close Menu", false},
 	};
 
+	const bool has_resume_state = VMManager::HasSaveStateInSlot(entry->serial.c_str(), entry->crc, -1);
 	OpenChoiceDialog(
-		entry->title.c_str(), false, std::move(options), [entry_path = entry->path](s32 index, const std::string& title, bool checked) {
+		entry->title.c_str(), false, std::move(options), [has_resume_state, entry_path = entry->path](s32 index, const std::string& title, bool checked) {
 			switch (index)
 			{
 				case 0: // Open Game Properties
 					SwitchToGameSettings(entry_path);
 					break;
 				case 1: // Resume Game
-					DoStartPath(entry_path, -1);
+					DoStartPath(entry_path, has_resume_state ? std::optional<s32>(-1) : std::optional<s32>());
 					break;
 				case 2: // Load State
 					OpenLoadStateSelectorForGame(entry_path);


### PR DESCRIPTION
### Description of Changes

Stops an error being thrown when you pick Resume Game from the popup menu in the game list, and just boots the game normally instead.

### Rationale behind Changes

Fewer confusing errors.

### Suggested Testing Steps

Test resuming game via menu that doesn't have a save state (right click or triangle on controller).
