### PR TITLE
GameDB: Update Burnout games VU Clamp mode

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8550,7 +8550,7 @@ SLAJ-25053:
   name: "Burnout 3 - Takedown"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -8584,7 +8584,7 @@ SLAJ-25066:
   name: "Burnout Revenge - Battle Racing Ignited"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -8691,7 +8691,7 @@ SLAJ-25094:
   name: "Burnout Dominator"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -8838,6 +8838,8 @@ SLED-52488:
 SLED-52597:
   name: "Burnout 3 - Takedown [Demo]"
   region: "PAL-E"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -8879,7 +8881,7 @@ SLED-53512:
   region: "PAL-E"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -14367,7 +14369,7 @@ SLES-52584:
   region: "PAL-M4"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -14377,7 +14379,7 @@ SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -16463,7 +16465,7 @@ SLES-53506:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -16480,7 +16482,7 @@ SLES-53507:
   region: "PAL-M3"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -19219,7 +19221,7 @@ SLES-54627:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -19382,7 +19384,7 @@ SLES-54681:
   name: "Burnout Dominator"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -22443,6 +22445,8 @@ SLKA-25205:
 SLKA-25206:
   name: "Burnout 3 - Takedown"
   region: "NTSC-K"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -22705,7 +22709,7 @@ SLKA-25304:
   name: "Burnout Revenge"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -22978,6 +22982,8 @@ SLPM-20436:
 SLPM-55004:
   name: "Burnout Revenge (EASY 1980)"
   region: "NTSC-J"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -23013,6 +23019,8 @@ SLPM-55033:
 SLPM-55036:
   name: "Burnout Dominator (EASY 1980)"
   region: "NTSC-J"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -23545,7 +23553,7 @@ SLPM-60246:
   name: "Burnout 3 - Takedown [Trial]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -28229,7 +28237,7 @@ SLPM-65719:
   name: "Burnout 3 - Takedown"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -29048,7 +29056,7 @@ SLPM-65958:
   name: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -29563,7 +29571,7 @@ SLPM-66108:
   name: "Burnout Revenge"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -31518,7 +31526,7 @@ SLPM-66652:
   name: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -31880,7 +31888,7 @@ SLPM-66739:
   name: "Burnout Dominator"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -32593,7 +32601,7 @@ SLPM-66962:
   name: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -43188,7 +43196,7 @@ SLUS-21050:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -44126,7 +44134,7 @@ SLUS-21242:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -45844,7 +45852,7 @@ SLUS-21596:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -47917,7 +47925,7 @@ SLUS-29113:
   name: "Burnout 3 [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
@@ -48022,7 +48030,7 @@ SLUS-29153:
   name: "Burnout Revenge [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.


### PR DESCRIPTION
### Description of Changes
Changes the VU Clamp on the Burnout games from none to extra + preserve sign.

### Rationale behind Changes
Has the same effect of fixing the lighting in the garage section and likely fixes the very weird physics behaviour of cars that can happen rarely.

### Suggested Testing Steps
Make sure CI is happy.
