### PR TITLE
Qt: Fix main window hiding with EFS bug

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1021,7 +1021,10 @@ bool MainWindow::shouldHideMouseCursor() const
 
 bool MainWindow::shouldHideMainWindow() const
 {
-	return Host::GetBaseBoolSettingValue("UI", "HideMainWindowWhenRunning", false) || isRenderingFullscreen() || QtHost::InNoGUIMode();
+	// NOTE: We can't use isRenderingToMain() here, because this happens post-fullscreen-switch.
+	return Host::GetBaseBoolSettingValue("UI", "HideMainWindowWhenRunning", false) ||
+		   (g_emu_thread->shouldRenderToMain() && isRenderingFullscreen()) ||
+		   QtHost::InNoGUIMode();
 }
 
 void MainWindow::switchToGameListView()
@@ -1896,6 +1899,7 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main, b
 		m_display_widget->setShouldHideCursor(shouldHideMouseCursor());
 		m_display_widget->updateRelativeMode(s_vm_valid && !s_vm_paused);
 		m_display_widget->updateCursor(s_vm_valid && !s_vm_paused);
+		updateWindowState();
 
 		QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
 		return m_display_widget;

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -67,6 +67,7 @@ public:
 	__fi bool isRunningFullscreenUI() const { return m_run_fullscreen_ui; }
 
 	bool isOnEmuThread() const;
+	bool shouldRenderToMain() const;
 
 	/// Called back from the GS thread when the display state changes (e.g. fullscreen, render to main).
 	bool acquireHostDisplay(HostDisplay::RenderAPI api);
@@ -166,7 +167,6 @@ private:
 
 	void destroyVM();
 	void executeVM();
-	bool shouldRenderToMain() const;
 
 	void createBackgroundControllerPollTimer();
 	void destroyBackgroundControllerPollTimer();


### PR DESCRIPTION
### Description of Changes

Fixes the bug where the main window gets hidden when exclusive fullscreen *and* render-to-separate window is used, and you can't get it back until you exit.

### Rationale behind Changes

Fixes #7025.

### Suggested Testing Steps

Test that exclusive (and regular) fullscreen keeps the main window visible when render to separate window is enabled, and hides it when it's not. You'll probably need a second monitor to test exclusive (which I've done).
