### PR TITLE
Qt: Implement screensaver inhibit

### DIFF
--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -24,6 +24,7 @@
 
 #include "common/Pcsx2Types.h"
 #include "common/General.h"
+#include "common/WindowInfo.h"
 
 // Darwin (OSX) is a bit different from Linux when requesting properties of
 // the OS because of its BSD/Mach heritage. Helpfully, most of this code
@@ -96,7 +97,7 @@ std::string GetOSVersionString()
 
 static IOPMAssertionID s_pm_assertion;
 
-void ScreensaverAllow(bool allow)
+bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
 {
 	if (s_pm_assertion)
 	{
@@ -104,7 +105,9 @@ void ScreensaverAllow(bool allow)
 		s_pm_assertion = 0;
 	}
 
-	if (!allow)
+	if (inhibit)
 		IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep, kIOPMAssertionLevelOn, CFSTR("Playing a game"), &s_pm_assertion);
+
+	return true;
 }
 #endif

--- a/common/General.h
+++ b/common/General.h
@@ -165,8 +165,6 @@ extern const u32 SPIN_TIME_NS;
 
 extern std::string GetOSVersionString();
 
-void ScreensaverAllow(bool allow);
-
 namespace Common
 {
 	/// Abstracts platform-specific code for asynchronously playing a sound.

--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -23,6 +23,7 @@
 
 #include "common/Pcsx2Types.h"
 #include "common/General.h"
+#include "common/WindowInfo.h"
 
 // Returns 0 on failure (not supported by the operating system).
 u64 GetPhysicalMemory()
@@ -62,9 +63,10 @@ std::string GetOSVersionString()
 #endif
 }
 
-void ScreensaverAllow(bool allow)
+bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
 {
 	// no-op
+	return false;
 }
 
 bool Common::PlaySoundAsync(const char* path)

--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -17,12 +17,17 @@
 #include <ctype.h>
 #include <time.h>
 #include <unistd.h>
+#include <optional>
 #include <spawn.h>
 #include <sys/time.h>
 #include <sys/wait.h>
+#include <unistd.h>
+
+#include "fmt/core.h"
 
 #include "common/Pcsx2Types.h"
 #include "common/General.h"
+#include "common/StringUtil.h"
 #include "common/WindowInfo.h"
 
 // Returns 0 on failure (not supported by the operating system).
@@ -44,7 +49,7 @@ void InitCPUTicks()
 
 u64 GetTickFrequency()
 {
-	return 1000000000;// unix measures in nanoseconds
+	return 1000000000; // unix measures in nanoseconds
 }
 
 u64 GetCPUTicks()
@@ -63,10 +68,67 @@ std::string GetOSVersionString()
 #endif
 }
 
+#ifdef X11_API
+
+static bool SetScreensaverInhibitX11(const WindowInfo& wi, bool inhibit)
+{
+	const char* command = "xdg-screensaver";
+	const char* operation = inhibit ? "suspend" : "resume";
+	std::string id = fmt::format("0x{:X}", static_cast<u64>(reinterpret_cast<uintptr_t>(wi.window_handle)));
+
+	char* argv[4] = {const_cast<char*>(command), const_cast<char*>(operation), const_cast<char*>(id.c_str()),
+		nullptr};
+
+	// Since we set SA_NOCLDWAIT in Qt, we don't need to wait here.
+	pid_t pid;
+	int res = posix_spawnp(&pid, "xdg-screensaver", nullptr, nullptr, argv, environ);
+	return (res == 0);
+}
+
+#endif
+
+static bool SetScreensaverInhibit(const WindowInfo& wi, bool inhibit)
+{
+	switch (wi.type)
+	{
+#ifdef X11_API
+		case WindowInfo::Type::X11:
+			return SetScreensaverInhibitX11(wi, inhibit);
+#endif
+
+		default:
+			return false;
+	}
+}
+
+static std::optional<WindowInfo> s_inhibit_window_info;
+
 bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
 {
-	// no-op
-	return false;
+	if (s_inhibit_window_info.has_value())
+	{
+		// Bit of extra logic here, because wx spams it and we don't want to
+		// spawn processes unnecessarily.
+		if (s_inhibit_window_info->type == wi.type &&
+			s_inhibit_window_info->window_handle == wi.window_handle &&
+			s_inhibit_window_info->surface_handle == wi.surface_handle)
+		{
+			return true;
+		}
+		// Clear the old.
+		SetScreensaverInhibit(s_inhibit_window_info.value(), false);
+		s_inhibit_window_info.reset();
+	}
+
+	if (!inhibit)
+		return true;
+
+	// New window.
+	if (!SetScreensaverInhibit(wi, true))
+		return false;
+
+	s_inhibit_window_info = wi;
+	return true;
 }
 
 bool Common::PlaySoundAsync(const char* path)

--- a/common/WindowInfo.h
+++ b/common/WindowInfo.h
@@ -54,4 +54,7 @@ struct WindowInfo
 
 	/// Returns the host's refresh rate for the given window, if available.
 	static bool QueryRefreshRateForWindow(const WindowInfo& wi, float* refresh_rate);
+
+	/// Enables or disables the screen saver from starting.
+	static bool InhibitScreensaver(const WindowInfo& wi, bool inhibit);
 };

--- a/common/Windows/WinMisc.cpp
+++ b/common/Windows/WinMisc.cpp
@@ -20,6 +20,7 @@
 #include "common/Exceptions.h"
 #include "common/StringUtil.h"
 #include "common/General.h"
+#include "common/WindowInfo.h"
 
 #include "fmt/core.h"
 
@@ -112,12 +113,13 @@ std::string Exception::WinApiError::FormatDiagnosticMessage() const
 	return m_message_diag + "\n\t" + GetMsgFromWindows();
 }
 
-void ScreensaverAllow(bool allow)
+bool WindowInfo::InhibitScreensaver(const WindowInfo& wi, bool inhibit)
 {
 	EXECUTION_STATE flags = ES_CONTINUOUS;
-	if (!allow)
+	if (inhibit)
 		flags |= ES_DISPLAY_REQUIRED;
 	SetThreadExecutionState(flags);
+	return true;
 }
 
 bool Common::PlaySoundAsync(const char* path)

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -54,7 +54,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 
 	m_ui.setupUi(this);
 
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.inhibitScreensaver, "UI", "InhibitScreensaver", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.inhibitScreensaver, "EmuCore", "InhibitScreensaver", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.confirmShutdown, "UI", "ConfirmShutdown", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveStateOnShutdown, "EmuCore", "SaveStateOnShutdown", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnStart, "UI", "StartPaused", false);

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -991,6 +991,7 @@ struct Pcsx2Config
 		EnableGameFixes : 1, // enables automatic game fixes
 		SaveStateOnShutdown : 1, // default value for saving state on shutdown
 		EnableDiscordPresence : 1, // enables discord rich presence integration
+		InhibitScreensaver : 1,
 #endif
 		// when enabled uses BOOT2 injection, skipping sony bios splashes
 		UseBOOT2Injection : 1,

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -2187,7 +2187,7 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 	MenuHeading("Behaviour");
 
 	DrawToggleSetting(bsi, ICON_FA_MAGIC " Inhibit Screensaver",
-		"Prevents the screen saver from activating and the host from sleeping while emulation is running.", "UI", "InhibitScreensaver",
+		"Prevents the screen saver from activating and the host from sleeping while emulation is running.", "EmuCore", "InhibitScreensaver",
 		true);
 #ifdef WITH_DISCORD_PRESENCE
 	DrawToggleSetting(bsi, "Enable Discord Presence", "Shows the game you are currently playing as part of your profile on Discord.", "UI",

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1051,6 +1051,7 @@ Pcsx2Config::Pcsx2Config()
 	EnableRecordingTools = true;
 #ifdef PCSX2_CORE
 	EnableGameFixes = true;
+	InhibitScreensaver = true;
 #endif
 	BackupSavestate = true;
 	SavestateZstdCompression = true;
@@ -1096,6 +1097,7 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableGameFixes);
 	SettingsWrapBitBool(SaveStateOnShutdown);
 	SettingsWrapBitBool(EnableDiscordPresence);
+	SettingsWrapBitBool(InhibitScreensaver);
 #endif
 	SettingsWrapBitBool(ConsoleToStdio);
 	SettingsWrapBitBool(HostFs);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -137,6 +137,7 @@ static u32 s_active_no_interlacing_patches = 0;
 static u32 s_frame_advance_count = 0;
 static u32 s_mxcsr_saved;
 static bool s_gs_open_on_initialize = false;
+static bool s_screensaver_inhibited = false;
 
 bool VMManager::PerformEarlyHardwareChecks(const char** error)
 {

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -49,6 +49,17 @@
 
 using namespace pxSizerFlags;
 
+static void HookSignals()
+{
+#ifdef __linux__
+	// Ignore SIGCHLD by default on Linux, since we kick off xdg-screensaver asynchronously.
+	struct sigaction sa_chld = {};
+	sigemptyset(&sa_chld.sa_mask);
+	sa_chld.sa_flags = SA_SIGINFO | SA_RESTART | SA_NOCLDSTOP | SA_NOCLDWAIT;
+	sigaction(SIGCHLD, &sa_chld, nullptr);
+#endif
+}
+
 void Pcsx2App::DetectCpuAndUserMode()
 {
 	AffinityAssert_AllowFrom_MainUI();
@@ -383,6 +394,7 @@ typedef void (wxEvtHandler::*pxStuckThreadEventHandler)(pxMessageBoxEvent&);
 
 bool Pcsx2App::OnInit()
 {
+	HookSignals();
 	EnableAllLogging();
 	Console.WriteLn("Interface is initializing.  Entering Pcsx2App::OnInit!");
 

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -527,8 +527,8 @@ void GSPanel::DirectKeyCommand( wxKeyEvent& evt )
 
 void GSPanel::UpdateScreensaver()
 {
-    bool prevent = g_Conf->GSWindow.DisableScreenSaver && m_HasFocus && m_coreRunning;
-	ScreensaverAllow(!prevent);
+	const bool prevent = g_Conf->GSWindow.DisableScreenSaver && m_HasFocus && m_coreRunning;
+	WindowInfo::InhibitScreensaver(g_gs_window_info, prevent);
 }
 
 void GSPanel::OnFocus( wxFocusEvent& evt )


### PR DESCRIPTION
### Description of Changes

Windows, Mac, and Linux (only X11).

### Rationale behind Changes

Missing functionality.

Closes #6786.
Closes #1002.

### Suggested Testing Steps

Test screensaver doesn't activate.
