### PR TITLE
Achievements: Avoid potential crash when parsing malformed responses

### DIFF
--- a/pcsx2/Frontend/Achievements.cpp
+++ b/pcsx2/Frontend/Achievements.cpp
@@ -287,7 +287,7 @@ namespace Achievements
 			data.push_back(0);
 
 			const int error = ParseFunc(this, reinterpret_cast<const char*>(data.data()));
-			initialized = true;
+			initialized = (error == RC_OK);
 
 			const rc_api_response_t& response = static_cast<T*>(this)->response;
 			if (error != RC_OK)


### PR DESCRIPTION
### Description of Changes

Somehow we got a `succeeded` value of true for login, but it was missing fields, which the rapi parse did return an error for, but we didn't abort the callback.

Maybe a truncated response...

### Rationale behind Changes

Better reliability.

### Suggested Testing Steps

Test achievements functionality, make sure nothing broke.