### PR TITLE
SPU: Allow up to 200% final volume

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>752</width>
-    <height>430</height>
+    <height>448</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -402,7 +402,7 @@
         <item row="0" column="0">
          <widget class="QSlider" name="volume">
           <property name="maximum">
-           <number>100</number>
+           <number>200</number>
           </property>
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -2843,7 +2843,7 @@ void FullscreenUI::DrawAudioSettingsPage()
 
 	MenuHeading("Runtime Settings");
 	DrawIntRangeSetting(bsi, ICON_FA_VOLUME_UP " Output Volume", "Applies a global volume modifier to all sound produced by the game.",
-		"SPU2/Mixing", "FinalVolume", 100, 0, 100, "%d%%");
+		"SPU2/Mixing", "FinalVolume", 100, 0, 200, "%d%%");
 
 	MenuHeading("Mixing Settings");
 	DrawIntListSetting(bsi, ICON_FA_MUSIC " Interpolation Mode", "Determines how ADPCM samples are interpolated to the target pitch.",

--- a/pcsx2/SPU2/Host/Config.cpp
+++ b/pcsx2/SPU2/Host/Config.cpp
@@ -75,8 +75,8 @@ void ReadSettings()
 {
 	Interpolation = Host::GetIntSettingValue("SPU2/Mixing", "Interpolation", 5);
 	FinalVolume = ((float)Host::GetIntSettingValue("SPU2/Mixing", "FinalVolume", 100)) / 100;
-	if (FinalVolume > 1.0f)
-		FinalVolume = 1.0f;
+	if (FinalVolume > 2.0f)
+		FinalVolume = 2.0f;
 
 	AdvancedVolumeControl = Host::GetBoolSettingValue("SPU2/Mixing", "AdvancedVolumeControl", false);
 	VolumeAdjustCdb = Host::GetFloatSettingValue("SPU2/Mixing", "VolumeAdjustC", 0);

--- a/pcsx2/SPU2/Linux/Config.cpp
+++ b/pcsx2/SPU2/Linux/Config.cpp
@@ -81,8 +81,8 @@ void ReadSettings()
 
 	Interpolation = CfgReadInt(L"MIXING", L"Interpolation", 5);
 	FinalVolume = ((float)CfgReadInt(L"MIXING", L"FinalVolume", 100)) / 100;
-	if (FinalVolume > 1.0f)
-		FinalVolume = 1.0f;
+	if (FinalVolume > 2.0f)
+		FinalVolume = 2.0f;
 
 	AdvancedVolumeControl = CfgReadBool(L"MIXING", L"AdvancedVolumeControl", false);
 	VolumeAdjustCdb = CfgReadFloat(L"MIXING", L"VolumeAdjustC(dB)", 0);

--- a/pcsx2/SPU2/Windows/Config.cpp
+++ b/pcsx2/SPU2/Windows/Config.cpp
@@ -81,8 +81,8 @@ void ReadSettings()
 	Interpolation = CfgReadInt(L"MIXING", L"Interpolation", 5);
 
 	FinalVolume = ((float)CfgReadInt(L"MIXING", L"FinalVolume", 100)) / 100;
-	if (FinalVolume > 1.0f)
-		FinalVolume = 1.0f;
+	if (FinalVolume > 2.0f)
+		FinalVolume = 2.0f;
 
 	AdvancedVolumeControl = CfgReadBool(L"MIXING", L"AdvancedVolumeControl", false);
 	VolumeAdjustCdb = CfgReadFloat(L"MIXING", L"VolumeAdjustC(dB)", 0);
@@ -359,7 +359,7 @@ BOOL CALLBACK ConfigProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			SetWindowText(GetDlgItem(hWnd, IDC_LATENCY_LABEL), temp);
 
 			int configvol = (int)(FinalVolume * 100);
-			INIT_SLIDER(IDC_VOLUME_SLIDER, 0, 100, 10, 5, 1);
+			INIT_SLIDER(IDC_VOLUME_SLIDER, 0, 200, 10, 5, 1);
 
 			SendDialogMsg(hWnd, IDC_VOLUME_SLIDER, TBM_SETPOS, TRUE, configvol);
 			swprintf_s(temp, L"%d%%", configvol);

--- a/pcsx2/SPU2/wx/wxConfig.cpp
+++ b/pcsx2/SPU2/wx/wxConfig.cpp
@@ -60,7 +60,7 @@ MixerTab::MixerTab(wxWindow* parent)
 
 	// Volume Slider
 	m_volume_box = new wxStaticBoxSizer(wxVERTICAL, this, "Volume");
-	m_volume_slider = new wxSlider(this, wxID_ANY, FinalVolume * 100, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
+	m_volume_slider = new wxSlider(this, wxID_ANY, FinalVolume * 100, 0, 200, wxDefaultPosition, wxDefaultSize, wxSL_LABELS);
 	m_volume_box->Add(m_volume_slider, wxSizerFlags().Expand());
 
 	m_audio_box = new wxBoxSizer(wxVERTICAL);


### PR DESCRIPTION
### Description of Changes
Extends the volume range allowed to up to 200%.

### Rationale behind Changes
Some games, such as Legacy of Kain - Soul Reaver 2, have tragically low volume levels (I streamed it from my PS2 hardware and it registers around -20dB, practically inaudible!) making it difficult for some people to hear, or anybody who dares attempt to stream the game will have trouble.

### Suggested Testing Steps
Run a game, fiddle with the volume slider.


Remember with great power becomes great responsibility. If you experience clipping in your game after going above 100% (Burnout 3 would be an example where this would happen), dial it back, that's on you :P