### PR TITLE
GameDB: Add Ufficiale PlayStation 2 Speciale Platinum 2007 demo

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2583,6 +2583,9 @@ SCED-54605:
 SCED-54642:
   name: "Official PlayStation 2 Magazine Demo 82" # German
   region: "PAL-M5"
+SCED-54682:
+  name: "UPS2 Speciale Platinum 2007"
+  region: "PAL-M5"
 SCED-54692:
   name: "Official PlayStation 2 Magazine Demo 83" # German
   region: "PAL-E-G"


### PR DESCRIPTION
### Description of Changes
Adds missing demo entry.

### Rationale behind Changes
Self explanatory. 

### Suggested Testing Steps
Make sure CI is happy.
