### PR TITLE
FullscreenUI: Display primed achievement list in pause menu

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -47,6 +47,8 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsDialog* dialog, QWi
 		"UnofficialTestMode", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.soundEffects, "Achievements",
 		"SoundEffects", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.primedIndicators, "Achievements",
+		"PrimedIndicators", true);
 
 	dialog->registerWidgetHelp(m_ui.enable, tr("Enable Achievements"), tr("Unchecked"),
 		tr("When enabled and logged in, PCSX2 will scan for achievements on game load."));
@@ -68,6 +70,9 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsDialog* dialog, QWi
 	dialog->registerWidgetHelp(
 		m_ui.soundEffects, tr("Enable Sound Effects"), tr("Checked"),
 		tr("Plays sound effects for events such as achievement unlocks and leaderboard submissions."));
+	dialog->registerWidgetHelp(
+		m_ui.primedIndicators, tr("Show Challenge Indicators"), tr("Checked"),
+		tr("Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active."));
 
 	connect(m_ui.enable, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);
 	connect(m_ui.challengeMode, &QCheckBox::stateChanged, this, &AchievementSettingsWidget::updateEnableState);

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>648</width>
-    <height>456</height>
+    <height>470</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -60,13 +60,6 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="testMode">
-        <property name="text">
-         <string>Enable Test Mode</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="soundEffects">
         <property name="text">
@@ -78,6 +71,20 @@
        <widget class="QCheckBox" name="unofficialTestMode">
         <property name="text">
          <string>Test Unofficial Achievements</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="testMode">
+        <property name="text">
+         <string>Enable Test Mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="primedIndicators">
+        <property name="text">
+         <string>Show Challenge Indicators</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -955,7 +955,8 @@ struct Pcsx2Config
 			RichPresence : 1,
 			ChallengeMode : 1,
 			Leaderboards : 1,
-			SoundEffects : 1;
+			SoundEffects : 1,
+			PrimedIndicators : 1;
 		BITFIELD_END
 
 		AchievementsOptions();

--- a/pcsx2/Frontend/Achievements.cpp
+++ b/pcsx2/Frontend/Achievements.cpp
@@ -1915,15 +1915,16 @@ std::string Achievements::GetAchievementProgressText(const Achievement& achievem
 	return buf;
 }
 
-const std::string& Achievements::GetAchievementBadgePath(const Achievement& achievement, bool download_if_missing)
+const std::string& Achievements::GetAchievementBadgePath(const Achievement& achievement, bool download_if_missing, bool force_unlocked_icon)
 {
-	std::string& badge_path = achievement.locked ? achievement.locked_badge_path : achievement.unlocked_badge_path;
+	const bool use_locked = (achievement.locked && !force_unlocked_icon);
+	std::string& badge_path = use_locked ? achievement.locked_badge_path : achievement.unlocked_badge_path;
 	if (!badge_path.empty() || achievement.badge_name.empty())
 		return badge_path;
 
 	// well, this comes from the internet.... :)
 	std::string clean_name(Path::SanitizeFileName(achievement.badge_name));
-	badge_path = Path::Combine(s_achievement_icon_cache_directory, fmt::format("{}{}.png", clean_name, achievement.locked ? "_lock" : ""));
+	badge_path = Path::Combine(s_achievement_icon_cache_directory, fmt::format("{}{}.png", clean_name, use_locked ? "_lock" : ""));
 	if (FileSystem::FileExists(badge_path.c_str()))
 		return badge_path;
 
@@ -1932,7 +1933,7 @@ const std::string& Achievements::GetAchievementBadgePath(const Achievement& achi
 	{
 		RAPIRequest<rc_api_fetch_image_request_t, rc_api_init_fetch_image_request> request;
 		request.image_name = achievement.badge_name.c_str();
-		request.image_type = achievement.locked ? RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED : RC_IMAGE_TYPE_ACHIEVEMENT;
+		request.image_type = use_locked ? RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED : RC_IMAGE_TYPE_ACHIEVEMENT;
 		request.DownloadImage(badge_path);
 	}
 

--- a/pcsx2/Frontend/Achievements.h
+++ b/pcsx2/Frontend/Achievements.h
@@ -146,7 +146,8 @@ namespace Achievements
 	const Achievement* GetAchievementByID(u32 id);
 	std::pair<u32, u32> GetAchievementProgress(const Achievement& achievement);
 	std::string GetAchievementProgressText(const Achievement& achievement);
-	const std::string& GetAchievementBadgePath(const Achievement& achievement, bool download_if_missing = true);
+	const std::string& GetAchievementBadgePath(
+		const Achievement& achievement, bool download_if_missing = true, bool force_unlocked_icon = false);
 	std::string GetAchievementBadgeURL(const Achievement& achievement);
 	u32 GetPrimedAchievementCount();
 

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -785,7 +785,7 @@ void FullscreenUI::Render()
 
 #ifdef ENABLE_ACHIEVEMENTS
 	// Primed achievements must come first, because we don't want the pause screen to be behind them.
-	if (Achievements::GetPrimedAchievementCount() > 0)
+	if (EmuConfig.Achievements.PrimedIndicators && Achievements::GetPrimedAchievementCount() > 0)
 		DrawPrimedAchievements();
 #endif
 
@@ -5729,6 +5729,9 @@ void FullscreenUI::DrawAchievementsSettingsPage()
 	DrawToggleSetting(bsi, ICON_FA_HEADPHONES " Sound Effects",
 		"Plays sound effects for events such as achievement unlocks and leaderboard submissions.", "Achievements", "SoundEffects", true,
 		enabled);
+	DrawToggleSetting(bsi, ICON_FA_MAGIC " Show Challenge Indicators",
+		"Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active.", "Achievements",
+		"PrimedIndicators", true, enabled);
 	DrawToggleSetting(bsi, ICON_FA_MEDAL " Test Unofficial Achievements",
 		"When enabled, PCSX2 will list achievements from unofficial sets. These achievements are not tracked by RetroAchievements.",
 		"Achievements", "UnofficialTestMode", false, enabled);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1024,6 +1024,7 @@ Pcsx2Config::AchievementsOptions::AchievementsOptions()
 	ChallengeMode = false;
 	Leaderboards = true;
 	SoundEffects = true;
+	PrimedIndicators = true;
 }
 
 void Pcsx2Config::AchievementsOptions::LoadSave(SettingsWrapper& wrap)
@@ -1037,6 +1038,7 @@ void Pcsx2Config::AchievementsOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(ChallengeMode);
 	SettingsWrapBitBool(Leaderboards);
 	SettingsWrapBitBool(SoundEffects);
+	SettingsWrapBitBool(PrimedIndicators);
 }
 
 #endif


### PR DESCRIPTION
### Description of Changes

Also adds an option to disable showing the icons when ingame.

![image](https://user-images.githubusercontent.com/11288319/194285764-ba1ddd77-b594-4ba0-ad79-31851985b32c.png)

### Rationale behind Changes

Closes #7137.

### Suggested Testing Steps

Test challenge/primed achievements. Apparently MGS2/3 has a bunch. I just forced a few for the above screenshot.
