### PR TITLE
GameDB: Fix missing splash logos in Krome games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11619,9 +11619,11 @@ SLES-51219:
     mipmap: 1
     cpuFramebufferConversion: 1 # Fixes right side of the screen from garbage textures.
 SLES-51220:
-  name: "Ty - The Tazmanian Tiger"
+  name: "TY the Tasmanian Tiger"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-51222:
   name: "Rayman 3 - Hoodlum Havoc"
   region: "PAL-M5"
@@ -13076,8 +13078,10 @@ SLES-51931:
   region: "PAL-M5"
   compat: 5
 SLES-51932:
-  name: "Jimmy Neutron - Jet Fusion"
+  name: "Adventures of Jimmy Neutron, The - Boy Genius - Jet Fusion"
   region: "PAL-E"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-51933:
   name: "Gregory Horror Show"
   region: "PAL-M3"
@@ -14693,7 +14697,7 @@ SLES-52697:
   name: "Manager de la Liga 2005"
   region: "PAL-S"
 SLES-52700:
-  name: "Jimmy Neutron - Attack of the Twonkies"
+  name: "Adventures of Jimmy Neutron, The - Boy Genius - Attack of the Twonkies"
   region: "PAL-E"
 SLES-52701:
   name: "Future Tactics - The Uprising"
@@ -14722,8 +14726,12 @@ SLES-52707:
   clampModes:
     vuClampMode: 3 # Fixes lighting on character models as caves and other locations don't turn mobs into glow-in-the-dark creatures by themselves.
 SLES-52709:
-  name: "Ty the Tazmanian Tiger 2 - Bush Rescue"
+  name: "TY the Tasmanian Tiger 2 - Bush Rescue"
   region: "PAL-M7"
+  compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
+    halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLES-52710:
   name: "McFarlane's Evil Prophecy"
   region: "PAL-M5"
@@ -15050,6 +15058,9 @@ SLES-52859:
 SLES-52861:
   name: "King Arthur"
   region: "PAL-M5"
+  compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-52863:
   name: "Pinball Hall of Fame"
   region: "PAL-M6"
@@ -16941,8 +16952,12 @@ SLES-53635:
 SLES-53636:
   name: "TY the Tasmanian Tiger 3 - Night of the Quinkan"
   region: "PAL-A"
+  compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes story mission to make it completable.
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
+    halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLES-53638:
   name: "Ski Racing 2006"
   region: "PAL-M5"
@@ -18625,6 +18640,7 @@ SLES-54358:
 SLES-54359:
   name: "Legend of Spyro, The - A New Beginning"
   region: "PAL-M6"
+  compat: 5
   patches:
     0EE5646B:
       content: |-
@@ -18632,6 +18648,7 @@ SLES-54359:
         // Fixes HUD and menu display.
         patch=1,EE,001849b8,word,00000000
   gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54360:
   name: "Pro Evolution Soccer 6"
@@ -19363,6 +19380,7 @@ SLES-54657:
 SLES-54658:
   name: "Star Wars - The Force Unleashed"
   region: "PAL-M5"
+  compat: 5
   patches:
     87109051:
       content: |-
@@ -19371,9 +19389,12 @@ SLES-54658:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017cb84,word,3464fff0
         patch=1,EE,0017cb90,word,3463fffc
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-54659:
   name: "Star Wars - The Force Unleashed"
   region: "PAL-M4"
+  compat: 5
   patches:
     DAF2145C:
       content: |-
@@ -19382,6 +19403,8 @@ SLES-54659:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017cb84,word,3464fff0
         patch=1,EE,0017cb90,word,3463fffc
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-54663:
   name: "Jackass - The Game"
   region: "PAL-M5"
@@ -19780,6 +19803,7 @@ SLES-54815:
         // Fixes HUD and menu display.
         patch=1,EE,00173c38,word,00000000
   gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54816:
   name: "Legend of Spyro, The - The Eternal Night"
@@ -19792,6 +19816,7 @@ SLES-54816:
         // Fixes HUD and menu display.
         patch=1,EE,00173bb8,word,00000000
   gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLES-54817:
   name: "Garfield - Lasagna World Tour"
@@ -20619,6 +20644,7 @@ SLES-55152:
 SLES-55163:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "PAL-M6"
+  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLES-55165:
@@ -20776,6 +20802,7 @@ SLES-55220:
 SLES-55227:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "PAL-M5"
+  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLES-55231:
@@ -20893,6 +20920,7 @@ SLES-55264:
 SLES-55265:
   name: "Legend of Spyro, The - Dawn of the Dragon"
   region: "PAL-R-E"
+  compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting and bloom misalignment.
 SLES-55266:
@@ -21370,8 +21398,10 @@ SLES-55518:
 SLES-55520:
   name: "Transformers - Revenge of the Fallen"
   region: "PAL-M5"
+  compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLES-55522:
   name: "Disney-Pixar Up"
   region: "PAL-E"
@@ -23010,6 +23040,13 @@ SLKA-25443:
   name: "Musou Orochi Maou Sairin"
   region: "NTSC-K"
   compat: 5
+SLKA-25459:
+  name: "Transformers - Revenge of the Fallen"
+  region: "NTSC-K"
+  compat: 5
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes textures.
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLKA-25477:
   name: "World Soccer Winning Eleven 2011"
   region: "NTSC-K"
@@ -37788,6 +37825,7 @@ SLPS-25887:
 SLPS-25888:
   name: "Star Wars - The Force Unleashed"
   region: "NTSC-J"
+  compat: 5
   patches:
     CC9BFDE3:
       content: |-
@@ -37796,6 +37834,8 @@ SLPS-25888:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017d454,word,3464fff0
         patch=1,EE,0017d460,word,3463fffc
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLPS-25889:
   name: "Guitar Hero - Aerosmith"
   region: "NTSC-J"
@@ -40954,9 +40994,11 @@ SLUS-20570:
   region: "NTSC-U"
   compat: 5
 SLUS-20571:
-  name: "Ty the Tasmanian Tiger"
+  name: "TY the Tasmanian Tiger"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-20572:
   name: "Tiger Woods PGA Tour 2003"
   region: "NTSC-U"
@@ -41533,8 +41575,10 @@ SLUS-20695:
     alignSprite: 1 # Fixes green vertical lines.
     roundSprite: 2 # Fixes vertical lines and some font artifacts but not completely fixed.
 SLUS-20696:
-  name: "Jimmy Neutron - Boy Genius - Jet Fusion"
+  name: "Adventures of Jimmy Neutron, The - Boy Genius - Jet Fusion"
   region: "NTSC-U"
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-20697:
   name: "Cy Girls [Disc1of2]"
   region: "NTSC-U"
@@ -42398,7 +42442,7 @@ SLUS-20886:
   name: "Sitting Ducks"
   region: "NTSC-U"
 SLUS-20887:
-  name: "Adventures of Jimmy Neutron, The - Attack of the Twonkies"
+  name: "Adventures of Jimmy Neutron, The - Boy Genius - Attack of the Twonkies"
   region: "NTSC-U"
 SLUS-20888:
   name: "Front Mission 4"
@@ -43248,6 +43292,8 @@ SLUS-21046:
   name: "King Arthur"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-21047:
   name: "Cold Fear"
   region: "NTSC-U"
@@ -43296,8 +43342,12 @@ SLUS-21056:
   name: "Cabal, The ~~CANCELLED~~"
   region: "NTSC-U"
 SLUS-21057:
-  name: "Ty the Tasmanian Tiger 2 - Bush Rescue"
+  name: "TY the Tasmanian Tiger 2 - Bush Rescue"
   region: "NTSC-U"
+  compat: 5
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
+    halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLUS-21058:
   name: "NBA Live 2005"
   region: "NTSC-U"
@@ -44272,11 +44322,14 @@ SLUS-21252:
   region: "NTSC-U"
   compat: 4
 SLUS-21253:
-  name: "Ty the Tasmanian Tiger 3"
+  name: "TY the Tasmanian Tiger 3 - Night of the Quinkan"
   region: "NTSC-U"
   compat: 5
   roundModes:
     eeRoundMode: 0 # Fixes story mission to make it completable.
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
+    halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLUS-21254:
   name: "Zatch Bell! Mamodo Battles"
   region: "NTSC-U"
@@ -44945,6 +44998,7 @@ SLUS-21372:
         // Fixes HUD and menu display.
         patch=1,EE,001849b8,word,00000000
   gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLUS-21373:
   name: "Drakengard 2"
@@ -46007,6 +46061,7 @@ SLUS-21607:
         // Fixes HUD and menu display.
         patch=1,EE,00173cb8,word,00000000
   gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
     halfPixelOffset: 2 # Fixes lighting on mushrooms + others.
 SLUS-21608:
   name: "Dance Dance Revolution SuperNOVA 2"
@@ -46034,7 +46089,7 @@ SLUS-21613:
 SLUS-21614:
   name: "Star Wars - The Force Unleashed"
   region: "NTSC-U"
-  compat: 4
+  compat: 5
   patches:
     879CDA5E:
       content: |-
@@ -46043,6 +46098,8 @@ SLUS-21614:
         // Patch replace values passed to FPU to workaround x86 rounding issues.
         patch=1,EE,0017cf24,word,3464fff0
         patch=1,EE,0017cf30,word,3463fffc
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-21615:
   name: "Wild ARMs 5"
   region: "NTSC-U"
@@ -47207,6 +47264,7 @@ SLUS-21881:
   compat: 5
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes textures.
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
   patches:
     137C792E:
       content: |-
@@ -47340,6 +47398,8 @@ SLUS-21913:
         // This can be fixed on the GS side but the software renderer is impossible to fix.
         // So this patch corrects the issue on the EE side.
         patch=1,EE,00173328,word,3464fffd
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes missing splash logo at boot.
 SLUS-21914:
   name: "NHL 2K10"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds PreloadFrameData to every Krome Studios game (except Sunny Garcia Surfing). Also adds HalfPixelOffset to TY 2 & 3.
A few title fixes were also made, including a missing game entry (SLKA-25459).

### Rationale behind Changes
Fixes the missing splash logos that appear when booting up any game made by Krome Studios. The HalfPixelOffset fixes some visible lines when swimming/walking on water in TY 2 & 3.

### Suggested Testing Steps
Boot up any Krome Studios game, if you don't see a splash logo like this with PreloadFrameData disabled, then that means it's missing/broken:
![Ty the Tasmanian Tiger 2 - Bush Rescue_SLUS-21057_20221007210200](https://user-images.githubusercontent.com/28464642/194686521-34717d2c-999b-4c95-8116-a1338d54554e.png)