### PR TITLE
Qt: Fix error writing config on first launch

### DIFF
--- a/pcsx2/Frontend/CommonHost.cpp
+++ b/pcsx2/Frontend/CommonHost.cpp
@@ -90,7 +90,13 @@ bool CommonHost::InitializeCriticalFolders()
 
 	// allow SetDataDirectory() to change settings directory (if we want to split config later on)
 	if (EmuFolders::Settings.empty())
+	{
 		EmuFolders::Settings = Path::Combine(EmuFolders::DataRoot, "inis");
+
+		// Create settings directory if it doesn't exist. If we're not using portable mode, it won't.
+		if (!FileSystem::DirectoryExists(EmuFolders::Settings.c_str()))
+			FileSystem::CreateDirectoryPath(EmuFolders::Settings.c_str(), false);
+	}
 
 	// Write crash dumps to the data directory, since that'll be accessible for certain.
 	CrashHandler::SetWriteDirectory(EmuFolders::DataRoot);


### PR DESCRIPTION
### Description of Changes

Settings directory doesn't exist yet, so when it tries to save after resetting, it fails.

### Rationale behind Changes

Failing to save config isn't good.

### Suggested Testing Steps

Test running pcsx2 in a new directory.
