### PR TITLE
VMManager: Remove unused variable

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -137,7 +137,6 @@ static u32 s_active_no_interlacing_patches = 0;
 static u32 s_frame_advance_count = 0;
 static u32 s_mxcsr_saved;
 static bool s_gs_open_on_initialize = false;
-static bool s_screensaver_inhibited = false;
 
 bool VMManager::PerformEarlyHardwareChecks(const char** error)
 {


### PR DESCRIPTION
### Description of Changes

Accidentally left this in when I was originally going to put inhibit in VMManager instead of CommonHost...

### Rationale behind Changes

Warnings

### Suggested Testing Steps

Make sure it builds
