### PR TITLE
macOS Dependency Cleanup

### DIFF
--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -118,7 +118,7 @@ if [ "$GUI" == "Qt" ]; then
 	echo "Installing Qt Base..."
 	tar xf "qtbase-everywhere-src-$QT.tar.xz"
 	cd "qtbase-everywhere-src-$QT"
-	cmake -B build -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release -DFEATURE_optimize_size=ON -DFEATURE_dbus=OFF -DFEATURE_framework=OFF -DFEATURE_icu=OFF -DFEATURE_opengl=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF
+	cmake -B build -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release -DFEATURE_optimize_size=ON -DFEATURE_dbus=OFF -DFEATURE_framework=OFF -DFEATURE_icu=OFF -DFEATURE_opengl=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF -DFEATURE_gssapi=OFF
 	make -C build "-j$NPROCS"
 	make -C build install
 	cd ..

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -12,8 +12,6 @@ NPROCS="$(getconf _NPROCESSORS_ONLN)"
 SDL=SDL2-2.24.0
 PNG=1.6.37
 JPG=9e
-SAMPLERATE=libsamplerate-0.1.9
-PORTAUDIO=pa_stable_v190700_20210406
 SOUNDTOUCH=soundtouch-2.3.1
 WXWIDGETS=3.1.6
 QT=6.3.1
@@ -30,8 +28,6 @@ cat > SHASUMS <<EOF
 91e4c34b1768f92d399b078e171448c6af18cafda743987ed2064a28954d6d97  $SDL.tar.gz
 505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca  libpng-$PNG.tar.xz
 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d  jpegsrc.v$JPG.tar.gz
-0a7eb168e2f21353fb6d84da152e4512126f7dc48ccb0be80578c565413444c1  $SAMPLERATE.tar.gz
-47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def  $PORTAUDIO.tgz
 6900996607258496ce126924a19fe9d598af9d892cf3f33d1e4daaa9b42ae0b1  $SOUNDTOUCH.tar.gz
 4980e86c6494adcd527a41fc0a4e436777ba41d1893717d7b7176c59c2061c25  wxWidgets-$WXWIDGETS.tar.bz2
 0a64421d9c2469c2c48490a032ab91d547017c9cc171f3f8070bc31888f24e03  qtbase-everywhere-src-$QT.tar.xz
@@ -44,8 +40,6 @@ curl -L \
 	-O "https://libsdl.org/release/$SDL.tar.gz" \
 	-O "https://downloads.sourceforge.net/project/libpng/libpng16/$PNG/libpng-$PNG.tar.xz" \
 	-O "https://www.ijg.org/files/jpegsrc.v$JPG.tar.gz" \
-	-O "http://www.mega-nerd.com/SRC/$SAMPLERATE.tar.gz" \
-	-O "http://files.portaudio.com/archives/$PORTAUDIO.tgz" \
 	-O "https://www.surina.net/soundtouch/$SOUNDTOUCH.tar.gz" \
 	-O "https://github.com/wxWidgets/wxWidgets/releases/download/v$WXWIDGETS/wxWidgets-$WXWIDGETS.tar.bz2" \
 	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
@@ -75,23 +69,6 @@ echo "Installing libjpeg..."
 tar xf "jpegsrc.v$JPG.tar.gz"
 cd "jpeg-$JPG"
 ./configure --prefix "$INSTALLDIR" --disable-dependency-tracking
-make "-j$NPROCS"
-make install
-cd ..
-
-echo "Installing libsamplerate..."
-tar xf "$SAMPLERATE.tar.gz"
-cd "$SAMPLERATE"
-sed -i "" "s/Carbon.h/Carbon\\/Carbon.h/" examples/audio_out.c
-./configure --prefix "$INSTALLDIR" --disable-dependency-tracking --disable-sndfile
-make "-j$NPROCS"
-make install
-cd ..
-
-echo "Installing portaudio..."
-tar xf "$PORTAUDIO.tgz"
-cd portaudio
-./configure --prefix "$INSTALLDIR" --enable-mac-universal=no
 make "-j$NPROCS"
 make install
 cd ..

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -31,7 +31,12 @@ else()
 		set(OpenGL_GL_PREFERENCE GLVND)
 		find_package(OpenGL REQUIRED)
 	endif()
+	# On macOS, Mono.framework contains an ancient version of libpng.  We don't want that.
+	# Avoid it by telling cmake to avoid finding frameworks while we search for libpng.
+	set(FIND_FRAMEWORK_BACKUP ${CMAKE_FIND_FRAMEWORK})
+	set(CMAKE_FIND_FRAMEWORK NEVER)
 	find_package(PNG REQUIRED)
+	set(CMAKE_FIND_FRAMEWORK ${FIND_FRAMEWORK_BACKUP})
 	find_package(Vtune)
 
 	if(NOT PCSX2_CORE)


### PR DESCRIPTION
### Description of Changes

- Clean up unused macOS dependency
- Fix finding the wrong copy of libpng on macOS CI
- Fix building of Qt dependency on macOS CI

Requires #7151

### Rationale behind Changes
Cleaner CI build scripts
Fixes loading the pause menu / bigpicture stuff on macOS

### Suggested Testing Steps
Try using bigpicture stuff on macOS