### PR TITLE
GS:HW: Properly handle fbmask of negative values

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -715,7 +715,7 @@ void ps_fbmask(inout float4 C, float2 pos_xy)
 	if (PS_FBMASK)
 	{
 		float4 RT = trunc(RtTexture.Load(int3(pos_xy, 0)) * 255.0f + 0.1f);
-		C = (float4)(((uint4)C & ~FbMask) | ((uint4)RT & FbMask));
+		C = (float4)(((uint4)(int4)C & (FbMask ^ 0xFF) | ((uint4)RT & FbMask));
 	}
 }
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -620,7 +620,7 @@ void ps_fbmask(inout vec4 C)
     // FIXME do I need special case for 16 bits
 #if PS_FBMASK
     vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
-    C = vec4((uvec4(C) & ~FbMask) | (uvec4(RT) & FbMask));
+    C = vec4((uvec4(ivec4(C)) & (FbMask ^ 0xFFu)) | (uvec4(RT) & FbMask));
 #endif
 }
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -946,7 +946,7 @@ void ps_fbmask(inout vec4 C)
 {
 	#if PS_FBMASK
 		vec4 RT = trunc(sample_from_rt() * 255.0f + 0.1f);
-		C = vec4((uvec4(C) & ~FbMask) | (uvec4(RT) & FbMask));
+		C = vec4((uvec4(ivec4(C)) & (FbMask ^ 0xFFu)) | (uvec4(RT) & FbMask));
 	#endif
 }
 

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -767,7 +767,7 @@ struct PSMain
 	void ps_fbmask(thread float4& C)
 	{
 		if (PS_FBMASK)
-			C = float4((uint4(C) & ~cb.fbmask) | (uint4(current_color * 255.5) & cb.fbmask));
+			C = float4((uint4(int4(C)) & (cb.fbmask ^ 0xff)) | (uint4(current_color * 255.5) & cb.fbmask));
 	}
 
 	void ps_dither(thread float4& C)


### PR DESCRIPTION
### Description of Changes
Previously was possible with blending and colclip, but now more common with the new hdr algorithm

Possible alternative: Make `ps_color_clamp_wrap` always do either a clamp or wrap (currently it does neither if `PS_HDR`)

### Rationale behind Changes
fbmask should be able to mask negative values, since blending can output them

### Suggested Testing Steps
Test [Narnia_blackFire.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9740634/Narnia_blackFire.gs.xz.zip) (look at shadows)