### PR TITLE
GameDB: Normalize HW fixes for Xenosaga Episode II

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -820,7 +820,7 @@ SCAJ-20086:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
-    texturePreloading: 0
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -835,7 +835,7 @@ SCAJ-20087:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
-    texturePreloading: 0
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -21783,6 +21783,7 @@ SLES-82034:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLES-82034"
     - "SCES-82034"
@@ -21793,6 +21794,7 @@ SLES-82035:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLES-82034"
     - "SCES-82034"
@@ -35948,6 +35950,7 @@ SLPS-25366:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -35962,6 +35965,7 @@ SLPS-25367:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -35976,6 +35980,7 @@ SLPS-25368:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters: # Allows import of Xenosaga I, Xenosaga I Reloaded, and Xenosaga Freaks data.
     - "SLPS-29001"
     - "SLPS-29002"
@@ -35990,6 +35995,7 @@ SLPS-25369:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -38240,6 +38246,7 @@ SLPS-73224:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -38254,6 +38261,7 @@ SLPS-73225:
     autoFlush: 1 # Fixes shadows in cutscenes.
     halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
     roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters:
     - "SLPS-29001"
     - "SLPS-29002"
@@ -42477,7 +42485,10 @@ SLUS-20892:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
+    roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
   memcardFilters: # Allows import of Xenosaga I data.
     - "SLUS-20469"
     - "SLUS-20892"
@@ -43687,9 +43698,11 @@ SLUS-21133:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    autoFlush: 1
-    texturePreloading: 0
-  memcardFilters:
+    autoFlush: 1 # Fixes shadows in cutscenes.
+    halfPixelOffset: 2 # Fixes lighting misalignment and shadows.
+    roundSprite: 2 # Fixes font artifacts.
+    texturePreloading: 0 # Fix slowdown due to large textures.
+  memcardFilters: # Allows import of Xenosaga I data.
     - "SLUS-20469"
     - "SLUS-20892"
 SLUS-21134:


### PR DESCRIPTION
### Description of Changes

Different title format (the hyphen), probably why they got missed.

### Rationale behind Changes

Preloading hurts in these games, because they use huge textures.

### Suggested Testing Steps

Make sure CI runs.
