### PR TITLE
Qt: Amendment for Turbo naming

### DIFF
--- a/pcsx2/Frontend/CommonHotkeys.cpp
+++ b/pcsx2/Frontend/CommonHotkeys.cpp
@@ -150,7 +150,7 @@ DEFINE_HOTKEY("ToggleFrameLimit", "System", "Toggle Frame Limit", [](s32 pressed
 			(EmuConfig.LimiterMode != LimiterModeType::Unlimited) ? LimiterModeType::Unlimited : LimiterModeType::Nominal);
 	}
 })
-DEFINE_HOTKEY("ToggleTurbo", "System", "Toggle Turbo", [](s32 pressed) {
+DEFINE_HOTKEY("ToggleTurbo", "System", "Toggle Turbo / Fast Forward", [](s32 pressed) {
 	if (!pressed && VMManager::HasValidVM())
 	{
 		VMManager::SetLimiterMode((EmuConfig.LimiterMode != LimiterModeType::Turbo) ? LimiterModeType::Turbo : LimiterModeType::Nominal);
@@ -162,7 +162,7 @@ DEFINE_HOTKEY("ToggleSlowMotion", "System", "Toggle Slow Motion", [](s32 pressed
 		VMManager::SetLimiterMode((EmuConfig.LimiterMode != LimiterModeType::Slomo) ? LimiterModeType::Slomo : LimiterModeType::Nominal);
 	}
 })
-DEFINE_HOTKEY("HoldTurbo", "System", "Turbo (Hold)", [](s32 pressed) {
+DEFINE_HOTKEY("HoldTurbo", "System", "Turbo / Fast Forward (Hold)", [](s32 pressed) {
 	if (!VMManager::HasValidVM())
 		return;
 	if (pressed > 0 && !s_limiter_mode_prior_to_hold_interaction.has_value())


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
PCSX2 uses the Fast Forward naming in the hotkeys, but DuckStation uses Turbo for a similar function.
Makes it easier to see what the hotkey is for.

![image](https://user-images.githubusercontent.com/24227051/194742175-8bc0166b-a96e-4023-96d4-4685167cd0c4.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Avoid confusion for users.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Go to the hotkeys tab and check the strings touched.