### PR TITLE
GS/TextureCache: Partially invalidate overlapping targets with tex-in-rt

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1000,6 +1000,12 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 						continue;
 					}
 				}
+				else if (GSConfig.UserHacks_TextureInsideRt && t->Overlaps(bp, bw, psm, rect) && GSUtil::HasCompatibleBits(psm, t->m_TEX0.PSM))
+				{
+					const SurfaceOffset so = ComputeSurfaceOffset(off, r, t);
+					if (so.is_valid)
+						t->m_dirty.push_back(GSDirtyRect(so.b2a_offset, psm, bw));
+				}
 #endif
 			}
 		}


### PR DESCRIPTION
### Description of Changes

Just copying my discord rambling for future reference
> so there's a target at 6a0
> and it does a 128x384 write to 6a0
> which includes the floor texture
> which kills the 6a0 source 
> but then it gets recreated later on
> I think why it's only breaking close up, is because the further ones are using level 1, which will have a different BP, and won't hit the target

The problem here is the condition for invalidating overlapping targets requires that the target be inside the copy rect, as well as having a BW of >2.. neither of which is the case for Jak.

https://github.com/PCSX2/pcsx2/blob/96071e157aaa9b8162fbb0ae39ffa16df541e5e6/pcsx2/GS/Renderers/HW/GSTextureCache.cpp#L984

So, instead, we'll leverage the tex-in-rt routine to find the overlapping area of these targets, and mark them as dirty. Basically, a lighter/hopefully less regression prone version of #5534.

As an aside, we can probably enable full mips and trilinear for Jak now. Although it's not necessary, so maybe not worth gamedb'ing.

### Rationale behind Changes

Fix corrupted textures in Jak games.
![image](https://user-images.githubusercontent.com/11288319/194742731-26772eb8-cf4b-4861-b677-65f42001c9dc.png) ![image](https://user-images.githubusercontent.com/11288319/194742745-d1947efb-7e26-4831-9531-51edbd063bf4.png)

![image](https://user-images.githubusercontent.com/11288319/194742736-ee3510d4-feee-4d86-81bf-6ae0beff6bd3.png) ![image](https://user-images.githubusercontent.com/11288319/194742753-0d03b80f-719e-42b2-933c-2147ff0f29bb.png)

### Suggested Testing Steps

Test games with tex-in-rt, make sure nothing broke.
