### PR TITLE
Qt: Consistent save state list in big picture

### DIFF
--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3848,7 +3848,7 @@ u32 FullscreenUI::PopulateSaveStateListEntries(const std::string& title, const s
 {
 	ClearSaveStateEntryList();
 
-	for (s32 i = 0; i <= VMManager::NUM_SAVE_STATE_SLOTS; i++)
+	for (s32 i = 1; i <= VMManager::NUM_SAVE_STATE_SLOTS; i++)
 	{
 		SaveStateListEntry li;
 		if (InitializeSaveStateListEntry(&li, title, serial, crc, i) || !s_save_state_selector_loading)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
In the WX days we had savestate 0-9 where 0 was the first. Then Qt came around where savestate 0-10 existed for Big Picture and 1-10 for the main listing this can cause headaches where you cycle through savestates or just save to the current slot 0 and it doesn't show up in the main window.


WX:
![image](https://user-images.githubusercontent.com/24227051/194848640-0b423b96-3a12-4d6d-81a1-77e0b3e54d2f.png)

Qt Main Window:
![image](https://user-images.githubusercontent.com/24227051/194848740-1a3280e9-3a89-48c9-b07b-0a954be36511.png)

Qt Big Picture (old):
![image](https://user-images.githubusercontent.com/24227051/194848852-add12190-dccd-4ffc-85dd-137f1ffdbdc3.png)

Qt Big Picture (new):
![image](https://user-images.githubusercontent.com/24227051/194849001-3f91912f-9eef-4bd6-8554-d0c74bbe238f.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Consistency + easier for users.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check savestates on both the pause/big picture and the main window.