### PR TITLE
Qt: Changing Cheevos URL color

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -150,7 +150,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#4169e1;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Dark blue URL from Cheevos to lighter blue.

Making it currently a bit lighter blue which should fit all the themes, in the future we could make it follow the link color.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
At the moment it uses a dark blue color which looks fine on light themes but hurts my eyes on the darker themes, reminds me of the old 1.6 console dark mode.

Old (Burn your eyes away):

![image](https://user-images.githubusercontent.com/24227051/194916728-5fb732c4-c051-4847-b491-783befe707a4.png)
![image](https://user-images.githubusercontent.com/24227051/194912493-611c6ab6-9921-43df-9735-3d0cc9749aef.png)
![image](https://user-images.githubusercontent.com/24227051/194912628-23542746-9d8a-456a-ba1e-5331b5914695.png)
![image](https://user-images.githubusercontent.com/24227051/194912646-dd65acf2-2b74-4595-ad80-5d7343047af0.png)
![image](https://user-images.githubusercontent.com/24227051/194912679-540004fe-981c-4ac9-96cb-b8254cbbb336.png)
![image](https://user-images.githubusercontent.com/24227051/194912715-15b13f65-9136-4051-8c98-25cb703bf8f1.png)
![image](https://user-images.githubusercontent.com/24227051/194912756-c7b92007-dbde-45e0-9661-b65d4e41c718.png)

New:

![image](https://user-images.githubusercontent.com/24227051/194916922-56d9a2b1-d81f-4f85-9fd3-d07bc93dc133.png)
![image](https://user-images.githubusercontent.com/24227051/194917003-f8d5873d-9873-4560-bb49-1c6b33202ddb.png)
![image](https://user-images.githubusercontent.com/24227051/194917035-44b143d7-bfe9-489f-8bf1-710797a36931.png)
![image](https://user-images.githubusercontent.com/24227051/194917066-f086c65f-8302-43ba-89e4-62f1a44faa31.png)
![image](https://user-images.githubusercontent.com/24227051/194917096-711f7c60-cbed-4206-bf50-a3d98cf5e8ff.png)
![image](https://user-images.githubusercontent.com/24227051/194917126-f2c1c1a5-3625-4851-b1c0-b06ada14e924.png)
![image](https://user-images.githubusercontent.com/24227051/194917154-c45c730e-e9db-48e6-8d61-635fa5e431a6.png)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Settings > Achievements and check the URL