### PR TITLE
GS: Add flush reason to draw call vertex dumps

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -297,7 +297,7 @@ bool GSreopen(bool recreate_display, const Pcsx2Config::GSOptions& old_config)
 {
 	Console.WriteLn("Reopening GS with %s display", recreate_display ? "new" : "existing");
 
-	g_gs_renderer->Flush();
+	g_gs_renderer->Flush(GSState::GSFlushReason::GSREOPEN);
 
 	freezeData fd = {};
 	if (g_gs_renderer->Freeze(&fd, true) != 0)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -273,6 +273,25 @@ public:
 		DIRTY_REG_ZBUF
 	};
 
+	enum GSFlushReason
+	{
+		UNKNOWN = 1 << 0,
+		RESET = 1 << 1,
+		CONTEXTCHANGE = 1 << 2,
+		CLUTCHANGE = 1 << 3,
+		TEXFLUSH = 1 << 4,
+		GSTRANSFER = 1 << 5,
+		UPLOADDIRTYTEX = 1 << 6,
+		DOWNLOADFIFO = 1 << 7,
+		SAVESTATE = 1 << 8,
+		LOADSTATE = 1 << 9,
+		AUTOFLUSH = 1 << 10,
+		VSYNC  = 1 << 11,
+		GSREOPEN = 1 << 12,
+	};
+
+	GSFlushReason m_state_flush_reason;
+
 	enum PRIM_OVERLAP
 	{
 		PRIM_OVERLAP_UNKNOW,
@@ -342,7 +361,7 @@ public:
 	virtual void UpdateSettings(const Pcsx2Config::GSOptions& old_config);
 
 	void CopyEnv(GSDrawingEnvironment* dest, GSDrawingEnvironment* src, int ctx);
-	void Flush();
+	void Flush(GSFlushReason reason);
 	void FlushPrim();
 	bool TestDrawChanged();
 	void FlushWrite();

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -557,7 +557,7 @@ static GSVector4i CalculateDrawSrcRect(const GSTexture* src)
 
 void GSRenderer::VSync(u32 field, bool registers_written)
 {
-	Flush();
+	Flush(GSFlushReason::VSYNC);
 
 	if (s_dump && s_n >= s_saven)
 	{


### PR DESCRIPTION
### Description of Changes
Adds a line to the vertex dump information which says the reason the draw flush occurred.

### Rationale behind Changes
Sometimes it's nice to see why the draw was flushed, could show details for possible optimisations.

### Suggested Testing Steps
Use a WX build,  create a `temp1` and `temp2` folder on the root of your C drive, set up the GS settings to dump GS Data (don't need any textures or anything) with a range of draw calls, run a GS dump or game so it dumps the info. if you can't see these options under the advanced settings, you may need to put `DevMode=enabled` at the top of your pcsx2_ui.ini. Then look at the _#####_vertex.txt files in the `temp1` (software mode) or `temp2` (hardware mode) folders.


