### PR TITLE
GS: Only TEXFLUSH if it's an Auto Flush draw.

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -184,6 +184,7 @@ protected:
 	void UpdateVertexKick();
 
 	void GrowVertexBuffer();
+	bool IsAutoFlushDraw();
 	void HandleAutoFlush();
 
 	template <u32 prim, bool auto_flush, bool index_swap>


### PR DESCRIPTION
### Description of Changes
Limits TEXFLUSH function to only work if the current draw is an Auto Flush draw.

### Rationale behind Changes
Avoids some unnecessary flushing when Auto Flush is enabled, can improve performance, especially in GS thread limited scenarios. (Jak 2 gains about 5-10fps on dev builds for me).

Other reasons to flush are already handled by context control.

### Suggested Testing Steps
Test games known to use Auto Flush, make sure nothing explodes.
