### PR TITLE
GameDB: 'Gitaroo Man' patches and fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10296,9 +10296,6 @@ SLES-50631:
 SLES-50632:
   name: "Dragon Rage"
   region: "PAL-I-S"
-SLES-50633:
-  name: "Gitaroo Man"
-  region: "PAL-Unk"
 SLES-50636:
   name: "Centre Court - Hard Hitter"
   region: "PAL-M3"
@@ -10346,6 +10343,16 @@ SLES-50652:
 SLES-50653:
   name: "Gitaroo Man"
   region: "PAL-M3"
+  compat: 5
+  roundModes:
+    eeRoundMode: 1
+    vuRoundMode: 3
+  patches:
+    default:
+      content: |-
+        author=boringhexi
+        // fix stage 4 flashing triangles
+        patch=0,EE,00102dd0,word,00000000
 SLES-50654:
   name: "Dune, Frank Herbert's"
   region: "PAL-M5"
@@ -22589,8 +22596,8 @@ SLKA-25215:
   region: "NTSC-K"
   gameFixes:
     - DMABusyHack
-SLKA-25216:
-  name: "Gitaroo-Man [PlayStation 2 - Big Hit Series]"
+SLKA-25216: #serial used on printed labels only, internal serial is always SLPM-67508
+  name: "Gitaroo-Man [BigHit Series]"
   region: "NTSC-K"
 SLKA-25217:
   name: "Shining Tears"
@@ -26075,6 +26082,15 @@ SLPM-65012:
   roundModes:
     eeRoundMode: 1
     vuRoundMode: 3
+  memcardFilters:
+    - "SLPM-65012"
+    - "SLPM-62062" #Gitaroo Man One bonus save data
+  patches:
+    default:
+      content: |-
+        author=boringhexi
+        // fix stage 4 flashing triangles
+        patch=0,EE,00104140,word,00000000
 SLPM-65013:
   name: "Shadow of Memories"
   region: "NTSC-J"
@@ -26538,8 +26554,8 @@ SLPM-65156:
 SLPM-65158:
   name: "Riding Spirits"
   region: "NTSC-J"
-SLPM-65160:
-  name: "Gitaroo Man [The Best]"
+SLPM-65160: #serial used on printed labels only, internal serial is always SLPM-65012
+  name: "Gitaroo Man [Koei Summer Chance 2002]"
   region: "NTSC-J"
 SLPM-65161:
   name: "Aero Dancing 4"
@@ -32926,6 +32942,12 @@ SLPM-67508:
   roundModes:
     eeRoundMode: 1
     vuRoundMode: 3
+  patches:
+    default:
+      content: |-
+        author=boringhexi
+        // fix stage 4 flashing triangles
+        patch=0,EE,00102d40,word,00000000
 SLPM-67512:
   name: "2002 FIFA World Cup"
   region: "NTSC-K"
@@ -39757,6 +39779,12 @@ SLUS-20294:
   roundModes:
     eeRoundMode: 1
     vuRoundMode: 3
+  patches:
+    default:
+      content: |-
+        author=boringhexi
+        // fix stage 4 flashing triangles
+        patch=0,EE,00102db0,word,00000000
 SLUS-20296:
   name: "Kao the Kangaroo - Round 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Main changes:
- [NTSC-J, NTSC-U, NTSC-K, PAL-M3] patch to fix stage 4 flashing triangles
- [PAL-M3] missing EE/VU round mode added
- [NTSC-J] Gitaroo Man One serial added to memcardFilters to allow loading bonus data

Other changes:
- removed entry "SLES-50633 Gitaroo Man PAL-Unk". According to [redump wiki](http://www.wiki.redump.org/index.php?title=Sony_Playstation_2_PAL_Missing_Dumps#Discs_that_Don.27t_Exist) this is a typo and doesn't really exist
- changed the special edition disc names to better match redump
- added a comment that each special edition disc's' internal serial is identical to the original edition disc (to justify leaving those entries blank, since in those cases PCSX2 will just use the entry for the original disc anyway) 
    - source of this claim: redump & checking my own discs; all special edition discs are byte-for-byte identical to their respective original

### Rationale behind Changes
- Fixing flashing triangles in stage 4 improves playability, and it's better than than the fix listed on the wiki because it doesn't cause flickering in other stages (namely tutorial and stage 5)
- PAL-M3 version EE/VU round mode is also required for stage 4, this fix was already present for all other versions
- Gitaroo Man One save data is meant to be loaded in Gitaroo Man Japanese version, this makes it easier
- I'm hoping my edits with the special edition discs will prevent future confusion ("Why are these entries blank? Why don't these names match my disc?")

### Suggested Testing Steps
I already tested Stage 4 in all versions, and I also tested every stage in the Korean version (except versus stages because I can't figure out how to disable other controllers on Linux).

Here's a complete memory card save for all versions if you skip directly to stage 4 or any other stage: [gman-complete-allregions.ps2.zip](https://github.com/PCSX2/pcsx2/files/9770273/gman-complete-allregions.ps2.zip). Or if you want to test just versus stages, there's one unlocked right at boot (and all versus stages are identical apart from the player characters).
