### PR TITLE
CommonHotkeys: Fix target speed going below zero

### DIFF
--- a/pcsx2/Frontend/CommonHotkeys.cpp
+++ b/pcsx2/Frontend/CommonHotkeys.cpp
@@ -41,7 +41,8 @@ void CommonHost::Internal::ResetVMHotkeyState()
 
 static void HotkeyAdjustTargetSpeed(double delta)
 {
-	EmuConfig.Framerate.NominalScalar = EmuConfig.GS.LimitScalar + delta;
+	const double min_speed = Achievements::ChallengeModeActive() ? 1.0 : 0.1;
+	EmuConfig.Framerate.NominalScalar = std::max(min_speed, EmuConfig.GS.LimitScalar + delta);
 	VMManager::SetLimiterMode(LimiterModeType::Nominal);
 	gsUpdateFrequency(EmuConfig);
 	GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());


### PR DESCRIPTION
### Description of Changes

Also clamps to 100% for challenge mode.

### Rationale behind Changes

Closes #7186.

### Suggested Testing Steps

Test hotkeys.
