### PR TITLE
GS: Set vsync based on host decision

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1828,8 +1828,7 @@ DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 
 	g_emu_thread->connectDisplaySignals(m_display_widget);
 
-	if (!g_host_display->CreateRenderDevice(wi.value(), Host::GetStringSettingValue("EmuCore/GS", "Adapter", ""), EmuConfig.GetEffectiveVsyncMode(),
-			Host::GetBoolSettingValue("EmuCore/GS", "ThreadedPresentation", false), Host::GetBoolSettingValue("EmuCore/GS", "UseDebugDevice", false)))
+	if (!g_host_display->CreateDevice(wi.value()))
 	{
 		QMessageBox::critical(this, tr("Error"), tr("Failed to create host display device context."));
 		destroyDisplayWidget(true);
@@ -1852,7 +1851,7 @@ DisplayWidget* MainWindow::createDisplay(bool fullscreen, bool render_to_main)
 	m_display_widget->updateCursor(s_vm_valid && !s_vm_paused);
 	m_display_widget->setFocus();
 
-	g_host_display->DoneRenderContextCurrent();
+	g_host_display->DoneCurrent();
 	return m_display_widget;
 }
 
@@ -1904,7 +1903,7 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main, b
 		return m_display_widget;
 	}
 
-	g_host_display->DestroyRenderSurface();
+	g_host_display->DestroySurface();
 
 	destroyDisplayWidget(surfaceless);
 
@@ -1924,7 +1923,7 @@ DisplayWidget* MainWindow::updateDisplay(bool fullscreen, bool render_to_main, b
 
 	g_emu_thread->connectDisplaySignals(m_display_widget);
 
-	if (!g_host_display->ChangeRenderWindow(wi.value()))
+	if (!g_host_display->ChangeWindow(wi.value()))
 		pxFailRel("Failed to recreate surface on new widget.");
 
 	if (is_exclusive_fullscreen)

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -70,7 +70,7 @@ public:
 	bool shouldRenderToMain() const;
 
 	/// Called back from the GS thread when the display state changes (e.g. fullscreen, render to main).
-	bool acquireHostDisplay(HostDisplay::RenderAPI api);
+	bool acquireHostDisplay(RenderAPI api);
 	void connectDisplaySignals(DisplayWidget* widget);
 	void releaseHostDisplay();
 	void updateDisplay();

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -241,6 +241,7 @@ set(pcsx2Headers
 	R5900.h
 	R5900OpcodeTables.h
 	SaveState.h
+	ShaderCacheVersion.h
 	Sifcmd.h
 	Sif.h
 	SingleRegisterTypes.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1089,8 +1089,6 @@ struct Pcsx2Config
 
 	bool MultitapEnabled(uint port) const;
 
-	VsyncMode GetEffectiveVsyncMode() const;
-
 	bool operator==(const Pcsx2Config& right) const;
 	bool operator!=(const Pcsx2Config& right) const
 	{

--- a/pcsx2/Frontend/CommonHotkeys.cpp
+++ b/pcsx2/Frontend/CommonHotkeys.cpp
@@ -22,6 +22,7 @@
 #include "Frontend/InputManager.h"
 #include "GS.h"
 #include "Host.h"
+#include "HostDisplay.h"
 #include "IconsFontAwesome5.h"
 #include "Recording/InputRecordingControls.h"
 #include "VMManager.h"
@@ -45,7 +46,7 @@ static void HotkeyAdjustTargetSpeed(double delta)
 	EmuConfig.Framerate.NominalScalar = std::max(min_speed, EmuConfig.GS.LimitScalar + delta);
 	VMManager::SetLimiterMode(LimiterModeType::Nominal);
 	gsUpdateFrequency(EmuConfig);
-	GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
+	GetMTGS().UpdateVSyncMode();
 	Host::AddIconOSDMessage("SpeedChanged", ICON_FA_CLOCK,
 		fmt::format("Target speed set to {:.0f}%.", std::round(EmuConfig.Framerate.NominalScalar * 100.0)), 5.0f);
 }

--- a/pcsx2/Frontend/D3D11HostDisplay.h
+++ b/pcsx2/Frontend/D3D11HostDisplay.h
@@ -36,26 +36,26 @@ public:
 	~D3D11HostDisplay();
 
 	RenderAPI GetRenderAPI() const override;
-	void* GetRenderDevice() const override;
-	void* GetRenderContext() const override;
-	void* GetRenderSurface() const override;
+	void* GetDevice() const override;
+	void* GetContext() const override;
+	void* GetSurface() const override;
 
-	bool HasRenderDevice() const override;
-	bool HasRenderSurface() const override;
+	bool HasDevice() const override;
+	bool HasSurface() const override;
 
-	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
-	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
+	bool CreateDevice(const WindowInfo& wi) override;
+	bool SetupDevice() override;
 
-	bool MakeRenderContextCurrent() override;
-	bool DoneRenderContextCurrent() override;
+	bool MakeCurrent() override;
+	bool DoneCurrent() override;
 
-	bool ChangeRenderWindow(const WindowInfo& new_wi) override;
-	void ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
+	bool ChangeWindow(const WindowInfo& new_wi) override;
+	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsFullscreen() const override;
 	bool IsFullscreen() override;
 	bool SetFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	AdapterAndModeList GetAdapterAndModeList() override;
-	void DestroyRenderSurface() override;
+	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
 	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;

--- a/pcsx2/Frontend/D3D12HostDisplay.h
+++ b/pcsx2/Frontend/D3D12HostDisplay.h
@@ -42,26 +42,26 @@ public:
 	~D3D12HostDisplay();
 
 	RenderAPI GetRenderAPI() const override;
-	void* GetRenderDevice() const override;
-	void* GetRenderContext() const override;
-	void* GetRenderSurface() const override;
+	void* GetDevice() const override;
+	void* GetContext() const override;
+	void* GetSurface() const override;
 
-	bool HasRenderDevice() const override;
-	bool HasRenderSurface() const override;
+	bool HasDevice() const override;
+	bool HasSurface() const override;
 
-	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
-	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
+	bool CreateDevice(const WindowInfo& wi) override;
+	bool SetupDevice() override;
 
-	bool MakeRenderContextCurrent() override;
-	bool DoneRenderContextCurrent() override;
+	bool MakeCurrent() override;
+	bool DoneCurrent() override;
 
-	bool ChangeRenderWindow(const WindowInfo& new_wi) override;
-	void ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
+	bool ChangeWindow(const WindowInfo& new_wi) override;
+	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsFullscreen() const override;
 	bool IsFullscreen() override;
 	bool SetFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	AdapterAndModeList GetAdapterAndModeList() override;
-	void DestroyRenderSurface() override;
+	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
 	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;

--- a/pcsx2/Frontend/MetalHostDisplay.h
+++ b/pcsx2/Frontend/MetalHostDisplay.h
@@ -51,25 +51,25 @@ public:
 	MetalHostDisplay();
 	~MetalHostDisplay();
 	RenderAPI GetRenderAPI() const override;
-	void* GetRenderDevice() const override;
-	void* GetRenderContext() const override;
-	void* GetRenderSurface() const override;
+	void* GetDevice() const override;
+	void* GetContext() const override;
+	void* GetSurface() const override;
 
-	bool HasRenderDevice() const override;
-	bool HasRenderSurface() const override;
-	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
-	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
-	bool MakeRenderContextCurrent() override;
-	bool DoneRenderContextCurrent() override;
-	void DestroyRenderSurface() override;
-	bool ChangeRenderWindow(const WindowInfo& wi) override;
+	bool HasDevice() const override;
+	bool HasSurface() const override;
+	bool CreateDevice(const WindowInfo& wi) override;
+	bool SetupDevice() override;
+	bool MakeCurrent() override;
+	bool DoneCurrent() override;
+	void DestroySurface() override;
+	bool ChangeWindow(const WindowInfo& wi) override;
 	bool SupportsFullscreen() const override;
 	bool IsFullscreen() override;
 	bool SetFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	AdapterAndModeList GetAdapterAndModeList() override;
 	std::string GetDriverInfo() const override;
 
-	void ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
+	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 
 	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;
 	void UpdateTexture(id<MTLTexture> texture, u32 x, u32 y, u32 width, u32 height, const void* data, u32 data_stride);

--- a/pcsx2/Frontend/OpenGLHostDisplay.cpp
+++ b/pcsx2/Frontend/OpenGLHostDisplay.cpp
@@ -60,22 +60,22 @@ OpenGLHostDisplay::~OpenGLHostDisplay()
 	}
 }
 
-HostDisplay::RenderAPI OpenGLHostDisplay::GetRenderAPI() const
+RenderAPI OpenGLHostDisplay::GetRenderAPI() const
 {
 	return m_gl_context->IsGLES() ? RenderAPI::OpenGLES : RenderAPI::OpenGL;
 }
 
-void* OpenGLHostDisplay::GetRenderDevice() const
+void* OpenGLHostDisplay::GetDevice() const
 {
 	return nullptr;
 }
 
-void* OpenGLHostDisplay::GetRenderContext() const
+void* OpenGLHostDisplay::GetContext() const
 {
 	return m_gl_context.get();
 }
 
-void* OpenGLHostDisplay::GetRenderSurface() const
+void* OpenGLHostDisplay::GetSurface() const
 {
 	return nullptr;
 }
@@ -188,17 +188,17 @@ std::string OpenGLHostDisplay::GetGLSLVersionHeader() const
 	return header;
 }
 
-bool OpenGLHostDisplay::HasRenderDevice() const
+bool OpenGLHostDisplay::HasDevice() const
 {
 	return static_cast<bool>(m_gl_context);
 }
 
-bool OpenGLHostDisplay::HasRenderSurface() const
+bool OpenGLHostDisplay::HasSurface() const
 {
 	return m_window_info.type != WindowInfo::Type::Surfaceless;
 }
 
-bool OpenGLHostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device)
+bool OpenGLHostDisplay::CreateDevice(const WindowInfo& wi)
 {
 	m_gl_context = GL::Context::Create(wi);
 	if (!m_gl_context)
@@ -209,11 +209,11 @@ bool OpenGLHostDisplay::CreateRenderDevice(const WindowInfo& wi, std::string_vie
 	}
 
 	m_window_info = m_gl_context->GetWindowInfo();
-	m_vsync_mode = vsync;
+	m_vsync_mode = Host::GetEffectiveVSyncMode();
 	return true;
 }
 
-bool OpenGLHostDisplay::InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device)
+bool OpenGLHostDisplay::SetupDevice()
 {
 	SetSwapInterval();
 	GL::Program::ResetLastProgram();
@@ -226,7 +226,7 @@ void OpenGLHostDisplay::SetSwapInterval()
 	m_gl_context->SetSwapInterval(interval);
 }
 
-bool OpenGLHostDisplay::MakeRenderContextCurrent()
+bool OpenGLHostDisplay::MakeCurrent()
 {
 	if (!m_gl_context->MakeCurrent())
 	{
@@ -238,12 +238,12 @@ bool OpenGLHostDisplay::MakeRenderContextCurrent()
 	return true;
 }
 
-bool OpenGLHostDisplay::DoneRenderContextCurrent()
+bool OpenGLHostDisplay::DoneCurrent()
 {
 	return m_gl_context->DoneCurrent();
 }
 
-bool OpenGLHostDisplay::ChangeRenderWindow(const WindowInfo& new_wi)
+bool OpenGLHostDisplay::ChangeWindow(const WindowInfo& new_wi)
 {
 	pxAssert(m_gl_context);
 
@@ -265,7 +265,7 @@ bool OpenGLHostDisplay::ChangeRenderWindow(const WindowInfo& new_wi)
 	return true;
 }
 
-void OpenGLHostDisplay::ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale)
+void OpenGLHostDisplay::ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale)
 {
 	if (!m_gl_context)
 		return;
@@ -309,7 +309,7 @@ HostDisplay::AdapterAndModeList OpenGLHostDisplay::GetAdapterAndModeList()
 	return aml;
 }
 
-void OpenGLHostDisplay::DestroyRenderSurface()
+void OpenGLHostDisplay::DestroySurface()
 {
 	if (!m_gl_context)
 		return;

--- a/pcsx2/Frontend/OpenGLHostDisplay.h
+++ b/pcsx2/Frontend/OpenGLHostDisplay.h
@@ -31,26 +31,26 @@ public:
 	~OpenGLHostDisplay();
 
 	RenderAPI GetRenderAPI() const override;
-	void* GetRenderDevice() const override;
-	void* GetRenderContext() const override;
-	void* GetRenderSurface() const override;
+	void* GetDevice() const override;
+	void* GetContext() const override;
+	void* GetSurface() const override;
 
-	bool HasRenderDevice() const override;
-	bool HasRenderSurface() const override;
+	bool HasDevice() const override;
+	bool HasSurface() const override;
 
-	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
-	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
+	bool CreateDevice(const WindowInfo& wi) override;
+	bool SetupDevice() override;
 
-	bool MakeRenderContextCurrent() override;
-	bool DoneRenderContextCurrent() override;
+	bool MakeCurrent() override;
+	bool DoneCurrent() override;
 
-	bool ChangeRenderWindow(const WindowInfo& new_wi) override;
-	void ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
+	bool ChangeWindow(const WindowInfo& new_wi) override;
+	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsFullscreen() const override;
 	bool IsFullscreen() override;
 	bool SetFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	AdapterAndModeList GetAdapterAndModeList() override;
-	void DestroyRenderSurface() override;
+	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
 	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic) override;

--- a/pcsx2/Frontend/VulkanHostDisplay.cpp
+++ b/pcsx2/Frontend/VulkanHostDisplay.cpp
@@ -1,6 +1,7 @@
 ﻿#include "PrecompiledHeader.h"
 
 #include "VulkanHostDisplay.h"
+#include "ShaderCacheVersion.h"
 #include "common/Align.h"
 #include "common/Assertions.h"
 #include "common/Console.h"
@@ -14,8 +15,6 @@
 #include "imgui.h"
 #include "imgui_impl_vulkan.h"
 #include <array>
-
-static constexpr u32 SHADER_CACHE_VERSION = 4;
 
 class VulkanHostDisplayTexture : public HostDisplayTexture
 {

--- a/pcsx2/Frontend/VulkanHostDisplay.h
+++ b/pcsx2/Frontend/VulkanHostDisplay.h
@@ -20,26 +20,26 @@ public:
 	~VulkanHostDisplay();
 
 	RenderAPI GetRenderAPI() const override;
-	void* GetRenderDevice() const override;
-	void* GetRenderContext() const override;
-	void* GetRenderSurface() const override;
+	void* GetDevice() const override;
+	void* GetContext() const override;
+	void* GetSurface() const override;
 
-	bool HasRenderDevice() const override;
-	bool HasRenderSurface() const override;
+	bool HasDevice() const override;
+	bool HasSurface() const override;
 
-	bool CreateRenderDevice(const WindowInfo& wi, std::string_view adapter_name, VsyncMode vsync, bool threaded_presentation, bool debug_device) override;
-	bool InitializeRenderDevice(std::string_view shader_cache_directory, bool debug_device) override;
+	bool CreateDevice(const WindowInfo& wi) override;
+	bool SetupDevice() override;
 
-	bool MakeRenderContextCurrent() override;
-	bool DoneRenderContextCurrent() override;
+	bool MakeCurrent() override;
+	bool DoneCurrent() override;
 
-	bool ChangeRenderWindow(const WindowInfo& new_wi) override;
-	void ResizeRenderWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
+	bool ChangeWindow(const WindowInfo& new_wi) override;
+	void ResizeWindow(s32 new_window_width, s32 new_window_height, float new_window_scale) override;
 	bool SupportsFullscreen() const override;
 	bool IsFullscreen() override;
 	bool SetFullscreen(bool fullscreen, u32 width, u32 height, float refresh_rate) override;
 	AdapterAndModeList GetAdapterAndModeList() override;
-	void DestroyRenderSurface() override;
+	void DestroySurface() override;
 	std::string GetDriverInfo() const override;
 
 	std::unique_ptr<HostDisplayTexture> CreateTexture(u32 width, u32 height, const void* data, u32 data_stride, bool dynamic = false) override;

--- a/pcsx2/GS.h
+++ b/pcsx2/GS.h
@@ -413,7 +413,8 @@ public:
 	void ApplySettings();
 	void ResizeDisplayWindow(int width, int height, float scale);
 	void UpdateDisplayWindow();
-	void SetVSync(VsyncMode mode);
+	void SetVSyncMode(VsyncMode mode);
+	void UpdateVSyncMode();
 	void SwitchRenderer(GSRendererType renderer, bool display_message = true);
 	void SetSoftwareRendering(bool software, bool display_message = true);
 	void ToggleSoftwareRendering();

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -76,7 +76,7 @@ static HRESULT s_hr = E_FAIL;
 
 Pcsx2Config::GSOptions GSConfig;
 
-static HostDisplay::RenderAPI s_render_api;
+static RenderAPI s_render_api;
 
 int GSinit()
 {
@@ -164,45 +164,45 @@ void GSclose()
 	Host::ReleaseHostDisplay();
 }
 
-static HostDisplay::RenderAPI GetAPIForRenderer(GSRendererType renderer)
+static RenderAPI GetAPIForRenderer(GSRendererType renderer)
 {
 #if defined(_WIN32)
 	// On Windows, we use DX11 for software, since it's always available.
-	constexpr HostDisplay::RenderAPI default_api = HostDisplay::RenderAPI::D3D11;
+	constexpr RenderAPI default_api = RenderAPI::D3D11;
 #elif defined(__APPLE__)
 	// For Macs, default to Metal.
-	constexpr HostDisplay::RenderAPI default_api = HostDisplay::RenderAPI::Metal;
+	constexpr RenderAPI default_api = RenderAPI::Metal;
 #else
 	// For Linux, default to OpenGL (because of hardware compatibility), if we
 	// have it, otherwise Vulkan (if we have it).
 #if defined(ENABLE_OPENGL)
-	constexpr HostDisplay::RenderAPI default_api = HostDisplay::RenderAPI::OpenGL;
+	constexpr RenderAPI default_api = RenderAPI::OpenGL;
 #elif defined(ENABLE_VULKAN)
-	constexpr HostDisplay::RenderAPI default_api = HostDisplay::RenderAPI::Vulkan;
+	constexpr RenderAPI default_api = RenderAPI::Vulkan;
 #else
-	constexpr HostDisplay::RenderAPI default_api = HostDisplay::RenderAPI::None;
+	constexpr RenderAPI default_api = RenderAPI::None;
 #endif
 #endif
 
 	switch (renderer)
 	{
 		case GSRendererType::OGL:
-			return HostDisplay::RenderAPI::OpenGL;
+			return RenderAPI::OpenGL;
 
 		case GSRendererType::VK:
-			return HostDisplay::RenderAPI::Vulkan;
+			return RenderAPI::Vulkan;
 
 #ifdef _WIN32
 		case GSRendererType::DX11:
-			return HostDisplay::RenderAPI::D3D11;
+			return RenderAPI::D3D11;
 
 		case GSRendererType::DX12:
-			return HostDisplay::RenderAPI::D3D12;
+			return RenderAPI::D3D12;
 #endif
 
 #ifdef __APPLE__
 		case GSRendererType::Metal:
-			return HostDisplay::RenderAPI::Metal;
+			return RenderAPI::Metal;
 #endif
 
 		default:
@@ -217,27 +217,27 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 	switch (g_host_display->GetRenderAPI())
 	{
 #ifdef _WIN32
-		case HostDisplay::RenderAPI::D3D11:
+		case RenderAPI::D3D11:
 			g_gs_device = std::make_unique<GSDevice11>();
 			break;
-		case HostDisplay::RenderAPI::D3D12:
+		case RenderAPI::D3D12:
 			g_gs_device = std::make_unique<GSDevice12>();
 			break;
 #endif
 #ifdef __APPLE__
-		case HostDisplay::RenderAPI::Metal:
+		case RenderAPI::Metal:
 			g_gs_device = std::unique_ptr<GSDevice>(MakeGSDeviceMTL());
 			break;
 #endif
 #ifdef ENABLE_OPENGL
-		case HostDisplay::RenderAPI::OpenGL:
-		case HostDisplay::RenderAPI::OpenGLES:
+		case RenderAPI::OpenGL:
+		case RenderAPI::OpenGLES:
 			g_gs_device = std::make_unique<GSDeviceOGL>();
 			break;
 #endif
 
 #ifdef ENABLE_VULKAN
-		case HostDisplay::RenderAPI::Vulkan:
+		case RenderAPI::Vulkan:
 			g_gs_device = std::make_unique<GSDeviceVK>();
 			break;
 #endif
@@ -279,13 +279,6 @@ static bool DoGSOpen(GSRendererType renderer, u8* basemem)
 		return false;
 	}
 
-#ifdef PCSX2_CORE
-	// Don't override the fullscreen UI's vsync choice.
-	if (!FullscreenUI::IsInitialized())
-		g_host_display->SetVSync(EmuConfig.GetEffectiveVsyncMode());
-#else
-	g_host_display->SetVSync(EmuConfig.GetEffectiveVsyncMode());
-#endif
 	GSConfig.OsdShowGPU = EmuConfig.GS.OsdShowGPU && g_host_display->SetGPUTimingEnabled(true);
 
 	g_gs_renderer->SetRegsMem(basemem);
@@ -774,9 +767,9 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 	// Options which need a full teardown/recreate.
 	if (!GSConfig.RestartOptionsAreEqual(old_config))
 	{
-		HostDisplay::RenderAPI existing_api = g_host_display->GetRenderAPI();
-		if (existing_api == HostDisplay::RenderAPI::OpenGLES)
-			existing_api = HostDisplay::RenderAPI::OpenGL;
+		RenderAPI existing_api = g_host_display->GetRenderAPI();
+		if (existing_api == RenderAPI::OpenGLES)
+			existing_api = RenderAPI::OpenGL;
 
 		const bool do_full_restart = (
 			existing_api != GetAPIForRenderer(GSConfig.Renderer) ||
@@ -877,9 +870,9 @@ void GSSwitchRenderer(GSRendererType new_renderer)
 	if (!g_gs_renderer || GSConfig.Renderer == new_renderer)
 		return;
 
-	HostDisplay::RenderAPI existing_api = g_host_display->GetRenderAPI();
-	if (existing_api == HostDisplay::RenderAPI::OpenGLES)
-		existing_api = HostDisplay::RenderAPI::OpenGL;
+	RenderAPI existing_api = g_host_display->GetRenderAPI();
+	if (existing_api == RenderAPI::OpenGLES)
+		existing_api = RenderAPI::OpenGL;
 
 	const bool is_software_switch = (new_renderer == GSRendererType::SW || GSConfig.Renderer == GSRendererType::SW);
 	const bool recreate_display = (!is_software_switch && existing_api != GetAPIForRenderer(new_renderer));

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -22,6 +22,7 @@
 #include "GS/GSUtil.h"
 #include "Host.h"
 #include "HostDisplay.h"
+#include "ShaderCacheVersion.h"
 #include "common/StringUtil.h"
 #include <fstream>
 #include <sstream>
@@ -91,14 +92,14 @@ bool GSDevice11::Create()
 
 	if (!GSConfig.DisableShaderCache)
 	{
-		if (!m_shader_cache.Open(EmuFolders::Cache, m_dev->GetFeatureLevel(), SHADER_VERSION, GSConfig.UseDebugDevice))
+		if (!m_shader_cache.Open(EmuFolders::Cache, m_dev->GetFeatureLevel(), SHADER_CACHE_VERSION, GSConfig.UseDebugDevice))
 		{
 			Console.Warning("Shader cache failed to open.");
 		}
 	}
 	else
 	{
-		m_shader_cache.Open({}, m_dev->GetFeatureLevel(), SHADER_VERSION, GSConfig.UseDebugDevice);
+		m_shader_cache.Open({}, m_dev->GetFeatureLevel(), SHADER_CACHE_VERSION, GSConfig.UseDebugDevice);
 		Console.WriteLn("Not using shader cache.");
 	}
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -79,14 +79,14 @@ bool GSDevice11::Create()
 
 	D3D_FEATURE_LEVEL level;
 
-	if (g_host_display->GetRenderAPI() != HostDisplay::RenderAPI::D3D11)
+	if (g_host_display->GetRenderAPI() != RenderAPI::D3D11)
 	{
-		fprintf(stderr, "Render API is incompatible with D3D11\n");
+		Console.Error("Render API is incompatible with D3D11");
 		return false;
 	}
 
-	m_dev = static_cast<ID3D11Device*>(g_host_display->GetRenderDevice());
-	m_ctx = static_cast<ID3D11DeviceContext*>(g_host_display->GetRenderContext());
+	m_dev = static_cast<ID3D11Device*>(g_host_display->GetDevice());
+	m_ctx = static_cast<ID3D11DeviceContext*>(g_host_display->GetContext());
 	level = m_dev->GetFeatureLevel();
 
 	if (!GSConfig.DisableShaderCache)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -108,9 +108,6 @@ public:
 	};
 
 private:
-	// Increment this constant whenever shaders change, to invalidate user's shader cache.
-	static constexpr u32 SHADER_VERSION = 1;
-
 	static constexpr u32 MAX_TEXTURES = 4;
 	static constexpr u32 MAX_SAMPLERS = 2;
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -29,6 +29,7 @@
 #include "GS/GSUtil.h"
 #include "Host.h"
 #include "HostDisplay.h"
+#include "ShaderCacheVersion.h"
 #include <sstream>
 #include <limits>
 
@@ -113,14 +114,14 @@ bool GSDevice12::Create()
 
 	if (!GSConfig.DisableShaderCache)
 	{
-		if (!m_shader_cache.Open(EmuFolders::Cache, g_d3d12_context->GetFeatureLevel(), SHADER_VERSION, GSConfig.UseDebugDevice))
+		if (!m_shader_cache.Open(EmuFolders::Cache, g_d3d12_context->GetFeatureLevel(), SHADER_CACHE_VERSION, GSConfig.UseDebugDevice))
 		{
 			Console.Warning("Shader cache failed to open.");
 		}
 	}
 	else
 	{
-		m_shader_cache.Open({}, g_d3d12_context->GetFeatureLevel(), SHADER_VERSION, GSConfig.UseDebugDevice);
+		m_shader_cache.Open({}, g_d3d12_context->GetFeatureLevel(), SHADER_CACHE_VERSION, GSConfig.UseDebugDevice);
 		Console.WriteLn("Not using shader cache.");
 	}
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -133,8 +133,6 @@ public:
 	};
 
 private:
-	static constexpr u32 SHADER_VERSION = 1;
-
 	ComPtr<ID3D12RootSignature> m_tfx_root_signature;
 	ComPtr<ID3D12RootSignature> m_utility_root_signature;
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -581,14 +581,14 @@ bool GSDeviceMTL::Create()
 	if (!GSDevice::Create())
 		return false;
 
-	if (g_host_display->GetRenderAPI() != HostDisplay::RenderAPI::Metal)
+	if (g_host_display->GetRenderAPI() != RenderAPI::Metal)
 		return false;
 
-	if (!g_host_display->HasRenderDevice() || !g_host_display->HasRenderSurface())
+	if (!g_host_display->HasDevice() || !g_host_display->HasSurface())
 		return false;
-	m_dev = *static_cast<const GSMTLDevice*>(g_host_display->GetRenderDevice());
-	m_queue = MRCRetain((__bridge id<MTLCommandQueue>)g_host_display->GetRenderContext());
-	MTLPixelFormat layer_px_fmt = [(__bridge CAMetalLayer*)g_host_display->GetRenderSurface() pixelFormat];
+	m_dev = *static_cast<const GSMTLDevice*>(g_host_display->GetDevice());
+	m_queue = MRCRetain((__bridge id<MTLCommandQueue>)g_host_display->GetContext());
+	MTLPixelFormat layer_px_fmt = [(__bridge CAMetalLayer*)g_host_display->GetSurface() pixelFormat];
 
 	m_features.broken_point_sampler = [[m_dev.dev name] containsString:@"AMD"];
 	m_features.geometry_shader = false;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -196,7 +196,7 @@ bool GSDeviceOGL::Create()
 	if (!GSDevice::Create())
 		return false;
 
-	if (g_host_display->GetRenderAPI() != HostDisplay::RenderAPI::OpenGL)
+	if (g_host_display->GetRenderAPI() != RenderAPI::OpenGL)
 		return false;
 
 	// Check openGL requirement as soon as possible so we can switch to another

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -22,6 +22,7 @@
 #include "GS/GSUtil.h"
 #include "Host.h"
 #include "HostDisplay.h"
+#include "ShaderCacheVersion.h"
 #include <cinttypes>
 #include <fstream>
 #include <sstream>
@@ -206,7 +207,7 @@ bool GSDeviceOGL::Create()
 
 	if (!theApp.GetConfigB("disable_shader_cache"))
 	{
-		if (!m_shader_cache.Open(false, EmuFolders::Cache, SHADER_VERSION))
+		if (!m_shader_cache.Open(false, EmuFolders::Cache, SHADER_CACHE_VERSION))
 			Console.Warning("Shader cache failed to open.");
 	}
 	else

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -211,9 +211,6 @@ public:
 	static int m_shader_reg;
 
 private:
-	// Increment this constant whenever shaders change, to invalidate user's program binary cache.
-	static constexpr u32 SHADER_VERSION = 3;
-
 	static FILE* m_debug_gl_file;
 
 	bool m_disable_hw_gl_draw;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1308,7 +1308,7 @@ bool GSDeviceVK::CreateRenderPasses()
 bool GSDeviceVK::CompileConvertPipelines()
 {
 	// we may not have a swap chain if running in headless mode.
-	Vulkan::SwapChain* swapchain = static_cast<Vulkan::SwapChain*>(g_host_display->GetRenderSurface());
+	Vulkan::SwapChain* swapchain = static_cast<Vulkan::SwapChain*>(g_host_display->GetSurface());
 	if (swapchain)
 	{
 		m_swap_chain_render_pass =
@@ -1506,7 +1506,7 @@ bool GSDeviceVK::CompileConvertPipelines()
 bool GSDeviceVK::CompilePresentPipelines()
 {
 	// we may not have a swap chain if running in headless mode.
-	Vulkan::SwapChain* swapchain = static_cast<Vulkan::SwapChain*>(g_host_display->GetRenderSurface());
+	Vulkan::SwapChain* swapchain = static_cast<Vulkan::SwapChain*>(g_host_display->GetSurface());
 	if (swapchain)
 	{
 		m_swap_chain_render_pass =

--- a/pcsx2/HostDisplay.cpp
+++ b/pcsx2/HostDisplay.cpp
@@ -142,7 +142,7 @@ std::string HostDisplay::GetFullscreenModeString(u32 width, u32 height, float re
 #endif
 #include "GS/Renderers/Metal/GSMetalCPPAccessible.h"
 
-std::unique_ptr<HostDisplay> HostDisplay::CreateDisplayForAPI(RenderAPI api)
+std::unique_ptr<HostDisplay> HostDisplay::CreateForAPI(RenderAPI api)
 {
 	switch (api)
 	{
@@ -153,7 +153,7 @@ std::unique_ptr<HostDisplay> HostDisplay::CreateDisplayForAPI(RenderAPI api)
 			return std::make_unique<D3D12HostDisplay>();
 #endif
 #ifdef __APPLE__
-		case HostDisplay::RenderAPI::Metal:
+		case RenderAPI::Metal:
 			return std::unique_ptr<HostDisplay>(MakeMetalHostDisplay());
 #endif
 

--- a/pcsx2/MTGS.cpp
+++ b/pcsx2/MTGS.cpp
@@ -935,6 +935,7 @@ void SysMtgsThread::ApplySettings()
 
 	RunOnGSThread([opts = EmuConfig.GS]() {
 		GSUpdateConfig(opts);
+		g_host_display->SetVSync(Host::GetEffectiveVSyncMode());
 	});
 
 	// We need to synchronize the thread when changing any settings when the download mode
@@ -964,13 +965,19 @@ void SysMtgsThread::UpdateDisplayWindow()
 	});
 }
 
-void SysMtgsThread::SetVSync(VsyncMode mode)
+void SysMtgsThread::SetVSyncMode(VsyncMode mode)
 {
 	pxAssertRel(IsOpen(), "MTGS is running");
 
 	RunOnGSThread([mode]() {
+		Console.WriteLn("Vsync is %s", mode == VsyncMode::Off ? "OFF" : (mode == VsyncMode::Adaptive ? "ADAPTIVE" : "ON"));
 		g_host_display->SetVSync(mode);
 	});
+}
+
+void SysMtgsThread::UpdateVSyncMode()
+{
+	SetVSyncMode(Host::GetEffectiveVSyncMode());
 }
 
 void SysMtgsThread::SwitchRenderer(GSRendererType renderer, bool display_message /* = true */)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -678,18 +678,6 @@ bool Pcsx2Config::GSOptions::UseHardwareRenderer() const
 	return (Renderer != GSRendererType::Null && Renderer != GSRendererType::SW);
 }
 
-VsyncMode Pcsx2Config::GetEffectiveVsyncMode() const
-{
-	if (GS.LimitScalar != 1.0f)
-	{
-		Console.WriteLn("Vsync is OFF");
-		return VsyncMode::Off;
-	}
-
-	Console.WriteLn("Vsync is %s", GS.VsyncEnable == VsyncMode::Off ? "OFF" : (GS.VsyncEnable == VsyncMode::Adaptive ? "ADAPTIVE" : "ON"));
-	return GS.VsyncEnable;
-}
-
 Pcsx2Config::SPU2Options::SPU2Options()
 {
 	bitset = 0;

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -1,0 +1,18 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// Version number for GS and other shaders. Increment whenever any of the contents of the
+/// shaders change, to invalidate the cache.
+static constexpr u32 SHADER_CACHE_VERSION = 10;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1377,7 +1377,7 @@ void VMManager::SetLimiterMode(LimiterModeType type)
 
 	EmuConfig.LimiterMode = type;
 	gsUpdateFrequency(EmuConfig);
-	GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
+	GetMTGS().UpdateVSyncMode();
 }
 
 void VMManager::FrameAdvance(u32 num_frames /*= 1*/)
@@ -1586,7 +1586,6 @@ void VMManager::CheckForGSConfigChanges(const Pcsx2Config& old_config)
 	UpdateVSyncRate();
 	frameLimitReset();
 	GetMTGS().ApplySettings();
-	GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
 }
 
 void VMManager::CheckForFramerateConfigChanges(const Pcsx2Config& old_config)
@@ -1598,7 +1597,7 @@ void VMManager::CheckForFramerateConfigChanges(const Pcsx2Config& old_config)
 	gsUpdateFrequency(EmuConfig);
 	UpdateVSyncRate();
 	frameLimitReset();
-	GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
+	GetMTGS().UpdateVSyncMode();
 }
 
 void VMManager::CheckForPatchConfigChanges(const Pcsx2Config& old_config)

--- a/pcsx2/gui/SysCoreThread.cpp
+++ b/pcsx2/gui/SysCoreThread.cpp
@@ -196,7 +196,7 @@ void SysCoreThread::ApplySettings(const Pcsx2Config& src)
 	{
 		Console.WriteLn("Applying GS settings...");
 		GetMTGS().ApplySettings();
-		GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
+		GetMTGS().UpdateVSyncMode();
 	}
 }
 
@@ -237,7 +237,7 @@ void SysCoreThread::_reset_stuff_as_needed()
 
 	if (m_resetVsyncTimers)
 	{
-		GetMTGS().SetVSync(EmuConfig.GetEffectiveVsyncMode());
+		GetMTGS().UpdateVSyncMode();
 		UpdateVSyncRate();
 		frameLimitReset();
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -869,6 +869,7 @@
     <ClInclude Include="PAD\Windows\WndProcEater.h" />
     <ClInclude Include="PAD\Windows\XInputEnum.h" />
     <ClInclude Include="PerformanceMetrics.h" />
+    <ClInclude Include="ShaderCacheVersion.h" />
     <ClInclude Include="SPU2\Config.h" />
     <ClInclude Include="SPU2\Global.h" />
     <ClInclude Include="SPU2\interpolate_table.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -2996,6 +2996,9 @@
     <ClInclude Include="Frontend\ImGuiOverlays.h">
       <Filter>Host</Filter>
     </ClInclude>
+    <ClInclude Include="ShaderCacheVersion.h">
+      <Filter>System\Include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="windows\wxResources.rc">

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -566,6 +566,7 @@
     <ClInclude Include="Recording\InputRecordingFile.h" />
     <ClInclude Include="Recording\PadData.h" />
     <ClInclude Include="Recording\Utilities\InputRecordingLogger.h" />
+    <ClInclude Include="ShaderCacheVersion.h" />
     <ClInclude Include="SPU2\Config.h" />
     <ClInclude Include="SPU2\Global.h" />
     <ClInclude Include="SPU2\Host\Config.h" />


### PR DESCRIPTION
### Description of Changes

Fixes bug where after changing settings in the big picture UI, if you didn't have a game running, it would turn off vsync, making GPU go brr.

Also cleans up HostDisplay a bit, removing redundant parameters.

### Rationale behind Changes

Having the GPU heat up when sitting at the menu isn't ideal.

### Suggested Testing Steps

Make sure your GPU doesn't go brr when the menu is open. Briefly test all renderers, make sure they still work.
