### PR TITLE
Qt: Add DInput input source

### DIFF
--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -36,7 +36,6 @@ public:
 
 	int scaledWindowWidth() const;
 	int scaledWindowHeight() const;
-	qreal devicePixelRatioFromScreen() const;
 
 	std::optional<WindowInfo> getWindowInfo();
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1181,6 +1181,11 @@ void MainWindow::checkForSettingChanges()
 	updateWindowState();
 }
 
+std::optional<WindowInfo> MainWindow::getWindowInfo()
+{
+	return QtUtils::GetWindowInfoForWidget(this);
+}
+
 void Host::InvalidateSaveStateCache()
 {
 	QMetaObject::invokeMethod(g_main_window, &MainWindow::invalidateSaveStateCache, Qt::QueuedConnection);

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "common/WindowInfo.h"
+
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QMainWindow>
 #include <functional>
@@ -108,6 +110,7 @@ public Q_SLOTS:
 	bool requestShutdown(bool allow_confirm = true, bool allow_save_to_state = true, bool default_save_to_state = true, bool block_until_done = false);
 	void requestExit();
 	void checkForSettingChanges();
+	std::optional<WindowInfo> getWindowInfo();
 
 private Q_SLOTS:
 	void onUpdateCheckComplete();

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -177,6 +177,10 @@ protected:
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dropEvent(QDropEvent* event) override;
 
+#ifdef _WIN32
+	bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
+#endif
+
 private:
 	static void setStyleFromSettings();
 	static void setIconThemeFromStyle();
@@ -185,6 +189,9 @@ private:
 	void connectSignals();
 	void recreate();
 	void recreateSettings();
+
+	void registerForDeviceNotifications();
+	void unregisterForDeviceNotifications();
 
 	void saveStateToConfig();
 	void restoreStateFromConfig();
@@ -265,6 +272,10 @@ private:
 	bool m_is_closing = false;
 
 	QString m_last_fps_status;
+
+#ifdef _WIN32
+	void* m_device_notification_handle = nullptr;
+#endif
 };
 
 extern MainWindow* g_main_window;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1465,6 +1465,13 @@ void Host::EndTextInput()
 		QMetaObject::invokeMethod(method, "hide", Qt::QueuedConnection);
 }
 
+std::optional<WindowInfo> Host::GetTopLevelWindowInfo()
+{
+	std::optional<WindowInfo> ret;
+	QMetaObject::invokeMethod(g_main_window, &MainWindow::getWindowInfo, Qt::BlockingQueuedConnection, &ret);
+	return ret;
+}
+
 void Host::OnInputDeviceConnected(const std::string_view& identifier, const std::string_view& device_name)
 {
 	emit g_emu_thread->onInputDeviceConnected(
@@ -1737,6 +1744,7 @@ static bool PerformEarlyHardwareChecks()
 static void RegisterTypes()
 {
 	qRegisterMetaType<std::optional<bool>>();
+	qRegisterMetaType<std::optional<WindowInfo>>("std::optional<WindowInfo>()");
 	qRegisterMetaType<std::function<void()>>("std::function<void()>");
 	qRegisterMetaType<std::shared_ptr<VMBootParameters>>();
 	qRegisterMetaType<GSRendererType>();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -701,6 +701,28 @@ void EmuThread::reloadInputBindings()
 	InputManager::ReloadBindings(*si, *bindings_si);
 }
 
+void EmuThread::reloadInputDevices()
+{
+	if (!isOnEmuThread())
+	{
+		QMetaObject::invokeMethod(this, &EmuThread::reloadInputDevices, Qt::QueuedConnection);
+		return;
+	}
+
+	InputManager::ReloadDevices();
+}
+
+void EmuThread::closeInputSources()
+{
+	if (!isOnEmuThread())
+	{
+		QMetaObject::invokeMethod(this, &EmuThread::reloadInputDevices, Qt::BlockingQueuedConnection);
+		return;
+	}
+
+	InputManager::CloseSources();
+}
+
 void EmuThread::requestDisplaySize(float scale)
 {
 	if (!isOnEmuThread())

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -105,6 +105,8 @@ public Q_SLOTS:
 	void reloadPatches();
 	void reloadInputSources();
 	void reloadInputBindings();
+	void reloadInputDevices();
+	void closeInputSources();
 	void requestDisplaySize(float scale);
 	void enumerateInputDevices();
 	void enumerateVibrationMotors();

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -15,13 +15,15 @@
 
 #include "PrecompiledHeader.h"
 
+#include "QtUtils.h"
+
 #include <QtCore/QCoreApplication>
 #include <QtCore/QMetaObject>
+#include <QtGui/QAction>
+#include <QtGui/QGuiApplication>
 #include <QtGui/QDesktopServices>
 #include <QtGui/QKeyEvent>
-
-#include <QtGui/QAction>
-
+#include <QtGui/QScreen>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QHeaderView>
@@ -33,11 +35,16 @@
 #include <QtWidgets/QStyle>
 #include <QtWidgets/QTableView>
 #include <QtWidgets/QTreeView>
+
 #include <algorithm>
 #include <array>
 #include <map>
 
-#include "QtUtils.h"
+#if defined(_WIN32)
+#include "common/RedtapeWindows.h"
+#elif !defined(APPLE)
+#include <qpa/qplatformnativeinterface.h>
+#endif
 
 namespace QtUtils
 {
@@ -203,4 +210,54 @@ namespace QtUtils
 
 		widget->resize(width, height);
 	}
+
+	qreal GetDevicePixelRatioForWidget(const QWidget* widget)
+	{
+		const QScreen* screen_for_ratio = widget->screen();
+		if (!screen_for_ratio)
+			screen_for_ratio = QGuiApplication::primaryScreen();
+
+		return screen_for_ratio ? screen_for_ratio->devicePixelRatio() : static_cast<qreal>(1);
+	}
+
+	std::optional<WindowInfo> GetWindowInfoForWidget(QWidget* widget)
+	{
+		WindowInfo wi;
+
+		// Windows and Apple are easy here since there's no display connection.
+#if defined(_WIN32)
+		wi.type = WindowInfo::Type::Win32;
+		wi.window_handle = reinterpret_cast<void*>(widget->winId());
+#elif defined(__APPLE__)
+		wi.type = WindowInfo::Type::MacOS;
+		wi.window_handle = reinterpret_cast<void*>(widget->winId());
+#else
+		QPlatformNativeInterface* pni = QGuiApplication::platformNativeInterface();
+		const QString platform_name = QGuiApplication::platformName();
+		if (platform_name == QStringLiteral("xcb"))
+		{
+			wi.type = WindowInfo::Type::X11;
+			wi.display_connection = pni->nativeResourceForWindow("display", widget->windowHandle());
+			wi.window_handle = reinterpret_cast<void*>(widget->winId());
+		}
+		else if (platform_name == QStringLiteral("wayland"))
+		{
+			wi.type = WindowInfo::Type::Wayland;
+			wi.display_connection = pni->nativeResourceForWindow("display", widget->windowHandle());
+			wi.window_handle = pni->nativeResourceForWindow("surface", widget->windowHandle());
+		}
+		else
+		{
+			qCritical() << "Unknown PNI platform " << platform_name;
+			return std::nullopt;
+		}
+#endif
+
+		const qreal dpr = GetDevicePixelRatioForWidget(widget);
+		wi.surface_width = static_cast<u32>(static_cast<qreal>(widget->width()) * dpr);
+		wi.surface_height = static_cast<u32>(static_cast<qreal>(widget->height()) * dpr);
+		wi.surface_scale = static_cast<float>(dpr);
+		return wi;
+	}
+
 } // namespace QtUtils

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -14,6 +14,9 @@
  */
 
 #pragma once
+
+#include "common/WindowInfo.h"
+
 #include <QtCore/QByteArray>
 #include <QtCore/QMetaType>
 #include <QtCore/QString>
@@ -77,4 +80,10 @@ namespace QtUtils
 
 	/// Adjusts the fixed size for a window if it's not resizeable.
 	void ResizePotentiallyFixedSizeWindow(QWidget* widget, int width, int height);
+
+	/// Returns the pixel ratio/scaling factor for a widget.
+	qreal GetDevicePixelRatioForWidget(const QWidget* widget);
+
+	/// Returns the common window info structure for a Qt widget.
+	std::optional<WindowInfo> GetWindowInfoForWidget(QWidget* widget);
 } // namespace QtUtils

--- a/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidgets.cpp
@@ -220,7 +220,7 @@ void ControllerBindingWidget::doDeviceAutomaticBinding(const QString& device)
 	if (mapping.empty())
 	{
 		QMessageBox::critical(QtUtils::GetRootWidget(this), tr("Automatic Binding"),
-			tr("No generic bindings were generated for device '%1'").arg(device));
+			tr("No generic bindings were generated for device '%1'. The controller/source may not support automatic mapping.").arg(device));
 		return;
 	}
 

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -32,12 +32,23 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLSource, "InputSources", "SDL", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableSDLEnhancedMode, "InputSources", "SDLControllerEnhancedMode", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableXInputSource, "InputSources", "XInput", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableMouseMapping, "UI", "EnableMouseMapping", false);
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.multitapPort1, "Pad", "MultitapPort1", false);
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.multitapPort2, "Pad", "MultitapPort2", false);
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(sif, m_ui.pointerXScale, "Pad", "PointerXScale", 8.0f);
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(sif, m_ui.pointerYScale, "Pad", "PointerYScale", 8.0f);
+
+#ifdef _WIN32
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableXInputSource, "InputSources", "XInput", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableDInputSource, "InputSources", "DInput", false);
+#else
+	m_ui.mainLayout->removeWidget(m_ui.xinputGroup);
+	m_ui.xinputGroup->deleteLater();
+	m_ui.xinputGroup = nullptr;
+	m_ui.mainLayout->removeWidget(m_ui.dinputGroup);
+	m_ui.dinputGroup->deleteLater();
+	m_ui.dinputGroup = nullptr;
+#endif
 
 	if (dialog->isEditingProfile())
 	{

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -26,33 +26,8 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="1" rowspan="6">
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Detected Devices</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0" colspan="2">
-       <widget class="QListWidget" name="deviceList">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="sdlGroup">
      <property name="title">
       <string>SDL Input Source</string>
      </property>
@@ -85,7 +60,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="xinputGroup">
      <property name="title">
       <string>XInput Source</string>
      </property>
@@ -110,7 +85,33 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="dinputGroup">
+     <property name="title">
+      <string>DInput Source</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>The DInput source provides support for legacy controllers which do not support XInput. Accessing these controllers via SDL instead is recommended, but DirectInput can be used if they are not compatible with SDL.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enableDInputSource">
+        <property name="text">
+         <string>Enable DInput Input Source</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -123,7 +124,7 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QGroupBox" name="profileSettings">
      <property name="title">
       <string>Profile Settings</string>
@@ -149,8 +150,8 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBox_4">
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="multitapGroup">
      <property name="title">
       <string>Controller Multitap</string>
      </property>
@@ -182,8 +183,8 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_5">
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="mouseGroup">
      <property name="title">
       <string>Mouse/Pointer Source</string>
      </property>
@@ -318,6 +319,31 @@
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1" rowspan="7">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Detected Devices</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="2">
+       <widget class="QListWidget" name="deviceList">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/pcsx2/Frontend/DInputSource.cpp
+++ b/pcsx2/Frontend/DInputSource.cpp
@@ -1,0 +1,446 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+
+#define INITGUID
+
+#include "Frontend/DInputSource.h"
+#include "Frontend/InputManager.h"
+#include "common/Assertions.h"
+#include "common/Console.h"
+#include "common/StringUtil.h"
+
+#include "fmt/format.h"
+#include <cmath>
+#include <limits>
+
+using PFNDIRECTINPUT8CREATE = HRESULT(WINAPI*)(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID* ppvOut, LPUNKNOWN punkOuter);
+using PFNGETDFDIJOYSTICK = LPCDIDATAFORMAT(WINAPI*)();
+
+DInputSource::DInputSource() = default;
+
+DInputSource::~DInputSource()
+{
+	m_controllers.clear();
+	m_dinput.Reset();
+	if (m_dinput_module)
+		FreeLibrary(m_dinput_module);
+}
+
+std::array<bool, DInputSource::NUM_HAT_DIRECTIONS> DInputSource::GetHatButtons(DWORD hat)
+{
+	std::array<bool, NUM_HAT_DIRECTIONS> buttons = {};
+
+	const WORD hv = LOWORD(hat);
+	if (hv != 0xFFFF)
+	{
+		if ((hv >= 0 && hv < 9000) || hv >= 31500)
+			buttons[HAT_DIRECTION_UP] = true;
+		if (hv >= 4500 && hv < 18000)
+			buttons[HAT_DIRECTION_RIGHT] = true;
+		if (hv >= 13500 && hv < 27000)
+			buttons[HAT_DIRECTION_DOWN] = true;
+		if (hv >= 22500)
+			buttons[HAT_DIRECTION_LEFT] = true;
+	}
+
+	return buttons;
+}
+
+std::string DInputSource::GetDeviceIdentifier(u32 index)
+{
+	return fmt::format("DInput-{}", index);
+}
+
+static constexpr std::array<const char*, DInputSource::NUM_HAT_DIRECTIONS> s_hat_directions = {{"Up", "Right", "Down", "Left"}};
+
+bool DInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
+{
+	m_dinput_module = LoadLibraryW(L"dinput8");
+	if (!m_dinput_module)
+	{
+		Console.Error("Failed to load DInput module.");
+		return false;
+	}
+
+	PFNDIRECTINPUT8CREATE create = reinterpret_cast<PFNDIRECTINPUT8CREATE>(GetProcAddress(m_dinput_module, "DirectInput8Create"));
+	PFNGETDFDIJOYSTICK get_joystick_data_format = reinterpret_cast<PFNGETDFDIJOYSTICK>(GetProcAddress(m_dinput_module, "GetdfDIJoystick"));
+	if (!create || !get_joystick_data_format)
+	{
+		Console.Error("Failed to get DInput function pointers.");
+		return false;
+	}
+
+	HRESULT hr = create(
+		GetModuleHandleA(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8W, reinterpret_cast<LPVOID*>(m_dinput.GetAddressOf()), nullptr);
+	m_joystick_data_format = get_joystick_data_format();
+	if (FAILED(hr) || !m_joystick_data_format)
+	{
+		Console.Error("DirectInput8Create() failed: %08X", hr);
+		return false;
+	}
+
+	// need to release the lock while we're enumerating, because we call winId().
+	settings_lock.unlock();
+	const std::optional<WindowInfo> toplevel_wi(Host::GetTopLevelWindowInfo());
+	if (toplevel_wi.has_value() && toplevel_wi->type == WindowInfo::Type::Win32)
+		AddDevices(static_cast<HWND>(toplevel_wi->window_handle));
+	else
+		Console.Error("Missing top level window, cannot add DInput devices.");
+	settings_lock.lock();
+
+	return true;
+}
+
+void DInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
+{
+	// noop
+}
+
+void DInputSource::Shutdown()
+{
+	while (!m_controllers.empty())
+	{
+		Host::OnInputDeviceDisconnected(GetDeviceIdentifier(static_cast<u32>(m_controllers.size() - 1)));
+		m_controllers.pop_back();
+	}
+}
+
+static BOOL CALLBACK EnumCallback(LPCDIDEVICEINSTANCEW lpddi, LPVOID pvRef)
+{
+	static_cast<std::vector<DIDEVICEINSTANCEW>*>(pvRef)->push_back(*lpddi);
+	return DIENUM_CONTINUE;
+}
+
+void DInputSource::AddDevices(HWND toplevel_window)
+{
+	std::vector<DIDEVICEINSTANCEW> devices;
+	m_dinput->EnumDevices(DI8DEVCLASS_GAMECTRL, EnumCallback, &devices, DIEDFL_ATTACHEDONLY);
+
+	DevCon.WriteLn("Enumerated %zu devices", devices.size());
+
+	for (DIDEVICEINSTANCEW inst : devices)
+	{
+		ControllerData cd;
+		HRESULT hr = m_dinput->CreateDevice(inst.guidInstance, cd.device.GetAddressOf(), nullptr);
+		if (FAILED(hr))
+		{
+			Console.Warning("Failed to create instance of device [%s, %s]", inst.tszProductName, inst.tszInstanceName);
+			continue;
+		}
+
+		const std::string name(StringUtil::WideStringToUTF8String(inst.tszProductName));
+		if (AddDevice(cd, toplevel_window, name))
+		{
+			const u32 index = static_cast<u32>(m_controllers.size());
+			m_controllers.push_back(std::move(cd));
+			Host::OnInputDeviceConnected(GetDeviceIdentifier(index), name);
+		}
+	}
+}
+
+bool DInputSource::AddDevice(ControllerData& cd, HWND toplevel_window, const std::string& name)
+{
+	HRESULT hr = cd.device->SetCooperativeLevel(toplevel_window, DISCL_BACKGROUND | DISCL_EXCLUSIVE);
+	if (FAILED(hr))
+	{
+		hr = cd.device->SetCooperativeLevel(toplevel_window, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE);
+		if (FAILED(hr))
+		{
+			Console.Error("Failed to set cooperative level for '%s'", name.c_str());
+			return false;
+		}
+
+		Console.Warning("Failed to set exclusive mode for '%s'", name.c_str());
+	}
+
+	hr = cd.device->SetDataFormat(m_joystick_data_format);
+	if (FAILED(hr))
+	{
+		Console.Error("Failed to set data format for '%s'", name.c_str());
+		return false;
+	}
+
+	hr = cd.device->Acquire();
+	if (FAILED(hr))
+	{
+		Console.Error("Failed to acquire device '%s'", name.c_str());
+		return false;
+	}
+
+	DIDEVCAPS caps = {};
+	caps.dwSize = sizeof(caps);
+	hr = cd.device->GetCapabilities(&caps);
+	if (FAILED(hr))
+	{
+		Console.Error("Failed to get capabilities for '%s'", name.c_str());
+		return false;
+	}
+
+	cd.num_buttons = caps.dwButtons;
+
+	static constexpr const u32 axis_offsets[] = {offsetof(DIJOYSTATE, lX), offsetof(DIJOYSTATE, lY), offsetof(DIJOYSTATE, lZ),
+		offsetof(DIJOYSTATE, lRz), offsetof(DIJOYSTATE, lRx), offsetof(DIJOYSTATE, lRy), offsetof(DIJOYSTATE, rglSlider[0]),
+		offsetof(DIJOYSTATE, rglSlider[1])};
+	for (const u32 offset : axis_offsets)
+	{
+		// ask for 16 bits of axis range
+		DIPROPRANGE range = {};
+		range.diph.dwSize = sizeof(range);
+		range.diph.dwHeaderSize = sizeof(range.diph);
+		range.diph.dwHow = DIPH_BYOFFSET;
+		range.diph.dwObj = static_cast<DWORD>(offset);
+		range.lMin = std::numeric_limits<s16>::min();
+		range.lMax = std::numeric_limits<s16>::max();
+		hr = cd.device->SetProperty(DIPROP_RANGE, &range.diph);
+
+		// did it apply?
+		if (SUCCEEDED(cd.device->GetProperty(DIPROP_RANGE, &range.diph)))
+			cd.axis_offsets.push_back(offset);
+	}
+
+	cd.num_hats = caps.dwPOVs;
+
+	hr = cd.device->Poll();
+	if (hr == DI_NOEFFECT)
+		cd.needs_poll = false;
+	else if (hr != DI_OK)
+		Console.Warning("Polling device '%s' failed: %08X", name.c_str(), hr);
+
+	hr = cd.device->GetDeviceState(sizeof(cd.last_state), &cd.last_state);
+	if (hr != DI_OK)
+		Console.Warning("GetDeviceState() for '%s' failed: %08X", name.c_str(), hr);
+
+	Console.WriteLn(
+		"%s has %u buttons, %u axes, %u hats", name.c_str(), cd.num_buttons, static_cast<u32>(cd.axis_offsets.size()), cd.num_hats);
+
+	return (cd.num_buttons > 0 || !cd.axis_offsets.empty() || cd.num_hats > 0);
+}
+
+void DInputSource::PollEvents()
+{
+	for (size_t i = 0; i < m_controllers.size();)
+	{
+		ControllerData& cd = m_controllers[i];
+		if (cd.needs_poll)
+			cd.device->Poll();
+
+		DIJOYSTATE js;
+		HRESULT hr = cd.device->GetDeviceState(sizeof(js), &js);
+		if (hr == DIERR_INPUTLOST || hr == DIERR_NOTACQUIRED)
+		{
+			hr = cd.device->Acquire();
+			if (hr == DI_OK)
+				hr = cd.device->GetDeviceState(sizeof(js), &js);
+
+			if (hr != DI_OK)
+			{
+				Host::OnInputDeviceDisconnected(GetDeviceIdentifier(static_cast<u32>(i)));
+				m_controllers.erase(m_controllers.begin() + i);
+				continue;
+			}
+		}
+		else if (hr != DI_OK)
+		{
+			Console.Warning("GetDeviceState() failed: %08X", hr);
+			i++;
+			continue;
+		}
+
+		CheckForStateChanges(i, js);
+		i++;
+	}
+}
+
+std::vector<std::pair<std::string, std::string>> DInputSource::EnumerateDevices()
+{
+	std::vector<std::pair<std::string, std::string>> ret;
+	for (size_t i = 0; i < m_controllers.size(); i++)
+	{
+		DIDEVICEINSTANCEW dii = {sizeof(DIDEVICEINSTANCEW)};
+		std::string name;
+		if (SUCCEEDED(m_controllers[i].device->GetDeviceInfo(&dii)))
+			name = StringUtil::WideStringToUTF8String(dii.tszProductName);
+
+		if (name.empty())
+			name = "Unknown";
+
+		ret.emplace_back(GetDeviceIdentifier(static_cast<u32>(i)), std::move(name));
+	}
+
+	return ret;
+}
+
+std::vector<InputBindingKey> DInputSource::EnumerateMotors()
+{
+	return {};
+}
+
+bool DInputSource::GetGenericBindingMapping(const std::string_view& device, GenericInputBindingMapping* mapping)
+{
+	return {};
+}
+
+void DInputSource::UpdateMotorState(InputBindingKey key, float intensity)
+{
+	// not supported
+}
+
+void DInputSource::UpdateMotorState(InputBindingKey large_key, InputBindingKey small_key, float large_intensity, float small_intensity)
+{
+	// not supported
+}
+
+std::optional<InputBindingKey> DInputSource::ParseKeyString(const std::string_view& device, const std::string_view& binding)
+{
+	if (!StringUtil::StartsWith(device, "DInput-") || binding.empty())
+		return std::nullopt;
+
+	const std::optional<s32> player_id = StringUtil::FromChars<s32>(device.substr(7));
+	if (!player_id.has_value() || player_id.value() < 0)
+		return std::nullopt;
+
+	InputBindingKey key = {};
+	key.source_type = InputSourceType::DInput;
+	key.source_index = static_cast<u32>(player_id.value());
+
+	if (StringUtil::StartsWith(binding, "+Axis") || StringUtil::StartsWith(binding, "-Axis"))
+	{
+		const std::optional<u32> axis_index = StringUtil::FromChars<u32>(binding.substr(5));
+		if (!axis_index.has_value())
+			return std::nullopt;
+
+		key.source_subtype = InputSubclass::ControllerAxis;
+		key.data = axis_index.value();
+		key.negative = (binding[0] == '-');
+		return key;
+	}
+	else if (StringUtil::StartsWith(binding, "Hat"))
+	{
+		if (binding[3] < '0' || binding[3] > '9' || binding.length() < 5)
+			return std::nullopt;
+
+		const u32 hat_index = binding[3] - '0';
+		const std::string_view hat_dir(binding.substr(4));
+		for (u32 i = 0; i < NUM_HAT_DIRECTIONS; i++)
+		{
+			if (hat_dir == s_hat_directions[i])
+			{
+				key.source_subtype = InputSubclass::ControllerButton;
+				key.data = MAX_NUM_BUTTONS + hat_index * NUM_HAT_DIRECTIONS + i;
+				return key;
+			}
+		}
+
+		// bad direction
+		return std::nullopt;
+	}
+	else if (StringUtil::StartsWith(binding, "Button"))
+	{
+		const std::optional<u32> button_index = StringUtil::FromChars<u32>(binding.substr(6));
+		if (!button_index.has_value())
+			return std::nullopt;
+
+		key.source_subtype = InputSubclass::ControllerButton;
+		key.data = button_index.value();
+		return key;
+	}
+
+	// unknown axis/button
+	return std::nullopt;
+}
+
+std::string DInputSource::ConvertKeyToString(InputBindingKey key)
+{
+	std::string ret;
+
+	if (key.source_type == InputSourceType::DInput)
+	{
+		if (key.source_subtype == InputSubclass::ControllerAxis)
+		{
+			ret = fmt::format("DInput-{}/{}Axis{}", u32(key.source_index), key.negative ? '-' : '+', u32(key.data));
+		}
+		else if (key.source_subtype == InputSubclass::ControllerButton && key.data >= MAX_NUM_BUTTONS)
+		{
+			const u32 hat_num = (key.data - MAX_NUM_BUTTONS) / NUM_HAT_DIRECTIONS;
+			const u32 hat_dir = (key.data - MAX_NUM_BUTTONS) % NUM_HAT_DIRECTIONS;
+			ret = fmt::format("DInput-{}/Hat{}{}", u32(key.source_index), hat_num, s_hat_directions[hat_dir]);
+		}
+		else if (key.source_subtype == InputSubclass::ControllerButton)
+		{
+			ret = fmt::format("DInput-{}/Button{}", u32(key.source_index), u32(key.data));
+		}
+	}
+
+	return ret;
+}
+
+void DInputSource::CheckForStateChanges(size_t index, const DIJOYSTATE& new_state)
+{
+	ControllerData& cd = m_controllers[index];
+	DIJOYSTATE& last_state = cd.last_state;
+
+	for (size_t i = 0; i < cd.axis_offsets.size(); i++)
+	{
+		LONG new_value;
+		LONG old_value;
+		std::memcpy(&old_value, reinterpret_cast<const u8*>(&cd.last_state) + cd.axis_offsets[i], sizeof(old_value));
+		std::memcpy(&new_value, reinterpret_cast<const u8*>(&new_state) + cd.axis_offsets[i], sizeof(new_value));
+		if (old_value != new_value)
+		{
+			std::memcpy(reinterpret_cast<u8*>(&cd.last_state) + cd.axis_offsets[i], &new_value, sizeof(new_value));
+
+			// TODO: Use the range from caps?
+			const float value = static_cast<float>(new_value) / (new_value < 0 ? 32768.0f : 32767.0f);
+			InputManager::InvokeEvents(MakeGenericControllerAxisKey(InputSourceType::DInput, static_cast<u32>(index), static_cast<u32>(i)),
+				value, GenericInputBinding::Unknown);
+		}
+	}
+
+	for (u32 i = 0; i < cd.num_buttons; i++)
+	{
+		if (last_state.rgbButtons[i] != new_state.rgbButtons[i])
+		{
+			last_state.rgbButtons[i] = new_state.rgbButtons[i];
+
+			const float value = (new_state.rgbButtons[i] != 0) ? 1.0f : 0.0f;
+			InputManager::InvokeEvents(
+				MakeGenericControllerButtonKey(InputSourceType::DInput, static_cast<u32>(index), i), value, GenericInputBinding::Unknown);
+		}
+	}
+
+	for (u32 i = 0; i < cd.num_hats; i++)
+	{
+		if (last_state.rgdwPOV[i] != new_state.rgdwPOV[i])
+		{
+			// map hats to the last buttons
+			const std::array<bool, NUM_HAT_DIRECTIONS> old_buttons(GetHatButtons(last_state.rgdwPOV[i]));
+			const std::array<bool, NUM_HAT_DIRECTIONS> new_buttons(GetHatButtons(new_state.rgdwPOV[i]));
+			last_state.rgdwPOV[i] = new_state.rgdwPOV[i];
+
+			for (u32 j = 0; j < NUM_HAT_DIRECTIONS; j++)
+			{
+				if (old_buttons[j] != new_buttons[j])
+				{
+					const float value = (new_buttons[j] ? 1.0f : 0.0f);
+					InputManager::InvokeEvents(MakeGenericControllerButtonKey(InputSourceType::DInput, static_cast<u32>(index),
+												   cd.num_buttons + (i * NUM_HAT_DIRECTIONS) + j),
+						value, GenericInputBinding::Unknown);
+				}
+			}
+		}
+	}
+}

--- a/pcsx2/Frontend/DInputSource.h
+++ b/pcsx2/Frontend/DInputSource.h
@@ -1,0 +1,93 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2022  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#define DIRECTINPUT_VERSION 0x0800
+#include "common/RedtapeWindows.h"
+#include "Frontend/InputSource.h"
+#include <array>
+#include <dinput.h>
+#include <functional>
+#include <mutex>
+#include <vector>
+#include <wrl/client.h>
+
+class DInputSource final : public InputSource
+{
+public:
+	enum HAT_DIRECTION : u32
+	{
+		HAT_DIRECTION_UP = 0,
+		HAT_DIRECTION_DOWN = 1,
+		HAT_DIRECTION_LEFT = 2,
+		HAT_DIRECTION_RIGHT = 3,
+		NUM_HAT_DIRECTIONS = 4,
+	};
+
+	enum : u32
+	{
+		MAX_NUM_BUTTONS = 32,
+	};
+
+	DInputSource();
+	~DInputSource() override;
+
+	bool Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
+	void UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
+	void Shutdown() override;
+
+	void PollEvents() override;
+	std::vector<std::pair<std::string, std::string>> EnumerateDevices() override;
+	std::vector<InputBindingKey> EnumerateMotors() override;
+	bool GetGenericBindingMapping(const std::string_view& device, GenericInputBindingMapping* mapping) override;
+	void UpdateMotorState(InputBindingKey key, float intensity) override;
+	void UpdateMotorState(InputBindingKey large_key, InputBindingKey small_key, float large_intensity, float small_intensity) override;
+
+	std::optional<InputBindingKey> ParseKeyString(const std::string_view& device, const std::string_view& binding) override;
+	std::string ConvertKeyToString(InputBindingKey key) override;
+
+private:
+	template <typename T>
+	using ComPtr = Microsoft::WRL::ComPtr<T>;
+
+	struct ControllerData
+	{
+		ComPtr<IDirectInputDevice8W> device;
+		DIJOYSTATE last_state = {};
+		std::vector<u32> axis_offsets;
+		u32 num_buttons = 0;
+
+		// NOTE: We expose hats as num_buttons + (hat_index * 4) + direction.
+		u32 num_hats = 0;
+
+		bool needs_poll = true;
+	};
+
+	using ControllerDataArray = std::vector<ControllerData>;
+
+	static std::array<bool, NUM_HAT_DIRECTIONS> GetHatButtons(DWORD hat);
+	static std::string GetDeviceIdentifier(u32 index);
+
+	void AddDevices(HWND toplevel_window);
+	bool AddDevice(ControllerData& cd, HWND toplevel_window, const std::string& name);
+
+	void CheckForStateChanges(size_t index, const DIJOYSTATE& new_state);
+
+	ControllerDataArray m_controllers;
+
+	HMODULE m_dinput_module{};
+	LPCDIDATAFORMAT m_joystick_data_format{};
+	ComPtr<IDirectInput8W> m_dinput;
+};

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -392,6 +392,7 @@ static std::array<const char*, static_cast<u32>(InputSourceType::Count)> s_input
 	"Keyboard",
 	"Mouse",
 #ifdef _WIN32
+	"DInput",
 	"XInput",
 #endif
 #ifdef SDL_BUILD
@@ -418,6 +419,9 @@ bool InputManager::GetInputSourceDefaultEnabled(InputSourceType type)
 			return true;
 
 #ifdef _WIN32
+		case InputSourceType::DInput:
+			return false;
+
 		case InputSourceType::XInput:
 			// Disable xinput by default if we have SDL.
 #ifdef SDL_BUILD
@@ -1177,6 +1181,7 @@ static void UpdateInputSourceState(SettingsInterface& si, std::unique_lock<std::
 }
 
 #ifdef _WIN32
+#include "Frontend/DInputSource.h"
 #include "Frontend/XInputSource.h"
 #endif
 
@@ -1187,6 +1192,7 @@ static void UpdateInputSourceState(SettingsInterface& si, std::unique_lock<std::
 void InputManager::ReloadSources(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
 #ifdef _WIN32
+	UpdateInputSourceState<DInputSource>(si, settings_lock, InputSourceType::DInput);
 	UpdateInputSourceState<XInputSource>(si, settings_lock, InputSourceType::XInput);
 #endif
 #ifdef SDL_BUILD

--- a/pcsx2/Frontend/InputManager.cpp
+++ b/pcsx2/Frontend/InputManager.cpp
@@ -1024,6 +1024,19 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 // Source Management
 // ------------------------------------------------------------------------
 
+bool InputManager::ReloadDevices()
+{
+	bool changed = false;
+
+	for (u32 i = FIRST_EXTERNAL_INPUT_SOURCE; i < LAST_EXTERNAL_INPUT_SOURCE; i++)
+	{
+		if (s_input_sources[i])
+			changed |= s_input_sources[i]->ReloadDevices();
+	}
+
+	return changed;
+}
+
 void InputManager::CloseSources()
 {
 	for (u32 i = FIRST_EXTERNAL_INPUT_SOURCE; i < LAST_EXTERNAL_INPUT_SOURCE; i++)

--- a/pcsx2/Frontend/InputManager.h
+++ b/pcsx2/Frontend/InputManager.h
@@ -32,7 +32,7 @@ enum class InputSourceType : u32
 	Keyboard,
 	Pointer,
 #ifdef _WIN32
-	//DInput,
+	DInput,
 	XInput,
 #endif
 #ifdef SDL_BUILD

--- a/pcsx2/Frontend/InputManager.h
+++ b/pcsx2/Frontend/InputManager.h
@@ -24,6 +24,7 @@
 
 #include "common/Pcsx2Types.h"
 #include "common/SettingsInterface.h"
+#include "common/WindowInfo.h"
 
 /// Class, or source of an input event.
 enum class InputSourceType : u32
@@ -303,6 +304,9 @@ namespace InputManager
 
 namespace Host
 {
+	/// Return the current window handle. Needed for DInput.
+	std::optional<WindowInfo> GetTopLevelWindowInfo();
+
 	/// Called when a new input device is connected.
 	void OnInputDeviceConnected(const std::string_view& identifier, const std::string_view& device_name);
 

--- a/pcsx2/Frontend/InputManager.h
+++ b/pcsx2/Frontend/InputManager.h
@@ -256,6 +256,10 @@ namespace InputManager
 	/// Re-parses the sources part of the config and initializes any backends.
 	void ReloadSources(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock);
 
+	/// Called when a device change is triggered by the system (DBT_DEVNODES_CHANGED on Windows).
+	/// Returns true if any device changes are detected.
+	bool ReloadDevices();
+
 	/// Shuts down any enabled input sources.
 	void CloseSources();
 

--- a/pcsx2/Frontend/InputSource.h
+++ b/pcsx2/Frontend/InputSource.h
@@ -33,6 +33,7 @@ public:
 
 	virtual bool Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) = 0;
 	virtual void UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) = 0;
+	virtual bool ReloadDevices() = 0;
 	virtual void Shutdown() = 0;
 
 	virtual void PollEvents() = 0;

--- a/pcsx2/Frontend/SDLInputSource.cpp
+++ b/pcsx2/Frontend/SDLInputSource.cpp
@@ -129,6 +129,13 @@ void SDLInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std:
 	}
 }
 
+bool SDLInputSource::ReloadDevices()
+{
+	// We'll get a GC added/removed event here.
+	PollEvents();
+	return false;
+}
+
 void SDLInputSource::Shutdown()
 {
 	ShutdownSubsystem();

--- a/pcsx2/Frontend/SDLInputSource.h
+++ b/pcsx2/Frontend/SDLInputSource.h
@@ -31,6 +31,7 @@ public:
 
   bool Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
   void UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
+  bool ReloadDevices() override;
   void Shutdown() override;
 
   void PollEvents() override;

--- a/pcsx2/Frontend/XInputSource.cpp
+++ b/pcsx2/Frontend/XInputSource.cpp
@@ -132,11 +132,44 @@ bool XInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex
 		return false;
 	}
 
+	ReloadDevices();
 	return true;
 }
 
 void XInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
+}
+
+bool XInputSource::ReloadDevices()
+{
+	bool changed = false;
+	for (u32 i = 0; i < NUM_CONTROLLERS; i++)
+	{
+		XINPUT_STATE new_state;
+		SCP_EXTN new_state_scp;
+		DWORD result = m_xinput_get_extended ? m_xinput_get_extended(i, &new_state_scp) : ERROR_NOT_SUPPORTED;
+		if (result != ERROR_SUCCESS)
+			result = m_xinput_get_state(i, &new_state);
+
+		if (result == ERROR_SUCCESS)
+		{
+			if (m_controllers[i].connected)
+				continue;
+
+			HandleControllerConnection(i);
+			changed = true;
+		}
+		else if (result == ERROR_DEVICE_NOT_CONNECTED)
+		{
+			if (!m_controllers[i].connected)
+				continue;
+
+			HandleControllerDisconnection(i);
+			changed = true;
+		}
+	}
+
+	return changed;
 }
 
 void XInputSource::Shutdown()
@@ -164,6 +197,8 @@ void XInputSource::PollEvents()
 	for (u32 i = 0; i < NUM_CONTROLLERS; i++)
 	{
 		const bool was_connected = m_controllers[i].connected;
+		if (!was_connected)
+			continue;
 
 		SCP_EXTN new_state_scp;
 		DWORD result = m_xinput_get_extended ? m_xinput_get_extended(i, &new_state_scp) : ERROR_NOT_SUPPORTED;

--- a/pcsx2/Frontend/XInputSource.h
+++ b/pcsx2/Frontend/XInputSource.h
@@ -65,6 +65,7 @@ public:
 
   bool Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
   void UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
+  bool ReloadDevices() override;
   void Shutdown() override;
 
   void PollEvents() override;

--- a/pcsx2/pcsx2core.vcxproj
+++ b/pcsx2/pcsx2core.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="Frontend\CommonHotkeys.cpp" />
     <ClCompile Include="Frontend\D3D11HostDisplay.cpp" />
     <ClCompile Include="Frontend\D3D12HostDisplay.cpp" />
+    <ClCompile Include="Frontend\DInputSource.cpp" />
     <ClCompile Include="Frontend\FullscreenUI.cpp" />
     <ClCompile Include="Frontend\GameList.cpp" />
     <ClCompile Include="Frontend\ImGuiFullscreen.cpp" />
@@ -519,6 +520,7 @@
     <ClInclude Include="Frontend\CommonHost.h" />
     <ClInclude Include="Frontend\D3D11HostDisplay.h" />
     <ClInclude Include="Frontend\D3D12HostDisplay.h" />
+    <ClInclude Include="Frontend\DInputSource.h" />
     <ClInclude Include="Frontend\FullscreenUI.h" />
     <ClInclude Include="Frontend\GameList.h" />
     <ClInclude Include="Frontend\ImGuiFullscreen.h" />

--- a/pcsx2/pcsx2core.vcxproj.filters
+++ b/pcsx2/pcsx2core.vcxproj.filters
@@ -1293,6 +1293,9 @@
     <ClCompile Include="Frontend\ImGuiOverlays.cpp">
       <Filter>Host</Filter>
     </ClCompile>
+    <ClCompile Include="Frontend\DInputSource.cpp">
+      <Filter>Host</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Patch.h">
@@ -2154,6 +2157,9 @@
       <Filter>System\Include</Filter>
     </ClInclude>
     <ClInclude Include="Frontend\ImGuiOverlays.h">
+      <Filter>Host</Filter>
+    </ClInclude>
+    <ClInclude Include="Frontend\DInputSource.h">
       <Filter>Host</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
### Description of Changes

Adds an input source which can use DirectInput directly, instead of going through SDL.

### Rationale behind Changes

Parity with wx. Most of the time you would want to use SDL. But there's some controllers which apparently don't get handled correctly by the game controller API, so you might need to use DInput for them.

### Suggested Testing Steps

Test new input source with a controller.
