### PR TITLE
ImGuiOverlays: Add hardware download mode to settings OSD

### DIFF
--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -280,6 +280,9 @@ void ImGuiManager::DrawSettingsOverlay()
 		if (GSConfig.GPUPaletteConversion)
 			APPEND("PT ");
 
+		if (GSConfig.HWDownloadMode != GSHardwareDownloadMode::Enabled)
+			APPEND("DL={} ", static_cast<unsigned>(GSConfig.HWDownloadMode));
+
 		if (GSConfig.HWMipmap != HWMipmapLevel::Automatic)
 			APPEND("MM={} ", static_cast<unsigned>(GSConfig.HWMipmap));
 


### PR DESCRIPTION
Useful one to have when diagnosing issues, since it can break some games pretty badly.