### PR TITLE
Qt: Add automatic updater for Linux

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -180,6 +180,7 @@ declare -a QTPLUGINS=(
 	"plugins/imageformats"
 	"plugins/platforms"
 	#"plugins/platformthemes" # Enable this if we want to ship GTK+ themes at any point.
+	"plugins/tls"
 	"plugins/wayland-decoration-client"
 	"plugins/wayland-graphics-integration-client"
 	"plugins/wayland-graphics-integration-server"

--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -47,7 +47,7 @@ tar xf "qtbase-everywhere-src-$QT.tar.xz"
 cd "qtbase-everywhere-src-$QT"
 mkdir build
 cd build
-../configure -prefix "$INSTALLDIR" -release -no-dbus -gui -widgets -fontconfig -qt-doubleconversion -openssl-runtime -opengl desktop -qpa xcb,wayland -xkbcommon -- -DFEATURE_dbus=OFF -DFEATURE_icu=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF
+../configure -prefix "$INSTALLDIR" -release -no-dbus -gui -widgets -fontconfig -qt-doubleconversion -ssl -openssl-runtime -opengl desktop -qpa xcb,wayland -xkbcommon -- -DFEATURE_dbus=OFF -DFEATURE_icu=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF
 cmake --build . --parallel
 cmake --install .
 cd ../../

--- a/pcsx2-qt/AutoUpdaterDialog.h
+++ b/pcsx2-qt/AutoUpdaterDialog.h
@@ -58,9 +58,11 @@ private:
 	void checkIfUpdateNeeded();
 	QString getCurrentUpdateTag() const;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	bool processUpdate(const QByteArray& update_data);
 	bool doUpdate(const QString& zip_path, const QString& updater_path, const QString& destination_path);
+#elif defined(__linux__)
+	bool processUpdate(const QByteArray& update_data);
 #else
 	bool processUpdate(const QByteArray& update_data);
 #endif


### PR DESCRIPTION
### Description of Changes

Adds automatic updater support to the AppImage. It'll replace the current appimage file with the new one, preserving the filename (and thus any shortcuts). The existing AppImage will be renamed/backed up.

I'm not going to have a debate with people saying it should put the version number in the file name. Preserving shortcuts is more important. If you have an issue with it, rename the appimage you downloaded to `PCSX2.AppImage` (which tbh you probably should do anyway).

### Rationale behind Changes

Closes #7037.

### Suggested Testing Steps

Kinda difficult to test this, since the PR isn't a tagged commit, so the updater won't show up.

But I've given it dry runs on my own tree and it's working fine (or, rather, it updates to a non-updatable version/current master).
