### PR TITLE
GS:HW: Fix blend_mix + HDR

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2764,7 +2764,7 @@ void GSRendererHW::EmulateBlending(bool& DATE_PRIMID, bool& DATE_BARRIER, bool& 
 			accumulation_blend = false;
 			blend_mix          = false;
 		}
-		else if (accumulation_blend || blend_mix)
+		else if (accumulation_blend)
 		{
 			// A fast algo that requires 2 passes
 			GL_INS("COLCLIP Fast HDR mode ENABLED");
@@ -3738,6 +3738,8 @@ void GSRendererHW::DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Sourc
 		m_conf.require_one_barrier = false;
 		m_conf.require_full_barrier = false;
 	}
+	// Multi-pass algorithms shouldn't be needed with full barrier and backends may not handle this correctly
+	ASSERT(!m_conf.require_full_barrier || !m_conf.ps.hdr);
 
 	// Swap full barrier for one barrier when there's no overlap.
 	if (m_conf.require_full_barrier && m_prim_overlap == PRIM_OVERLAP_NO)


### PR DESCRIPTION
### Description of Changes
Fixes a bug where blend_mix + HDR would end up enabling full barriers

### Rationale behind Changes
None of the render backends expect full barriers and HDR at once, and they mess up in different ways.  Metal and OGL act like there's a single barrier, and Vulkan doesn't properly correct for the newer HDR algorithm's data format, reading full black instead.

Also, blend_mix shouldn't be enabling full barriers

### Suggested Testing Steps
Test [TalesOfDestiny_BlendMixHDR.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9793545/TalesOfDestiny_BlendMixHDR.gs.xz.zip)
