### PR TITLE
x86/iR5900: Fix quadword stores on Linux

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -200,9 +200,10 @@ static void recStore(u32 bits)
 	else
 	{
 		_flushEEreg(_Rt_); // flush register to mem
-		int rpreg = _allocTempXMMreg(XMMT_INT, 1);
-		xMOVAPS(xRegisterSSE(rpreg), ptr128[&cpuRegs.GPR.r[_Rt_].UL[0]]);
-		_freeXMMreg(rpreg);
+
+		const xRegisterSSE& dreg = xRegisterSSE::GetArgRegister(1, 0);
+		_freeXMMreg(dreg.GetId());
+		xMOVAPS(dreg, ptr128[&cpuRegs.GPR.r[_Rt_].UL[0]]);
 	}
 
 	// Load ECX with the destination address, or issue a direct optimized write
@@ -981,9 +982,9 @@ void recSQC2()
 	skip.SetTarget();
 	skipvuidle.SetTarget();
 
-	int rpreg = _allocTempXMMreg(XMMT_INT, 1);
-	xMOVAPS(xRegisterSSE(rpreg), ptr128[&VU0.VF[_Ft_].UD[0]]);
-	_freeXMMreg(rpreg);
+	const xRegisterSSE& dreg = xRegisterSSE::GetArgRegister(1, 0);
+	_freeXMMreg(dreg.GetId());
+	xMOVAPS(dreg, ptr128[&VU0.VF[_Ft_].UD[0]]);
 
 	if (GPR_IS_CONST1(_Rs_))
 	{

--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -161,7 +161,7 @@ namespace vtlb_private
 				break;
 
 			case 128:
-				xMOVAPS(ptr[arg1reg], xmm1);
+				xMOVAPS(ptr[arg1reg], xRegisterSSE::GetArgRegister(1, 0));
 				break;
 		}
 	}
@@ -514,7 +514,7 @@ void vtlb_DynGenWrite_Const(u32 bits, u32 addr_const)
 				break;
 
 			case 128:
-				xMOVAPS(ptr128[(void*)ppf], xmm1);
+				xMOVAPS(ptr128[(void*)ppf], xRegisterSSE::GetArgRegister(1, 0));
 				break;
 		}
 	}
@@ -534,7 +534,7 @@ void vtlb_DynGenWrite_Const(u32 bits, u32 addr_const)
 		}
 
 		iFlushCall(FLUSH_FULLVTLB);
-		xFastCall(vmv.assumeHandlerGetRaw(szidx, true), paddr, arg2reg);
+		xFastCall(vmv.assumeHandlerGetRaw(szidx, true), paddr);
 	}
 }
 


### PR DESCRIPTION
### Description of Changes

Linux counts vector and GPR registers separately for which register they get passed in when calling functions.

Windows uses the argument position.

Also gets rid of a warning in the x86emitter when compiling with clang.

### Rationale behind Changes

Fixes #7207.

### Suggested Testing Steps

Test e.g. Burnout 3, SH Origins on Linux (fixed for me).