### PR TITLE
Achievements: Couple of bug fixes

### DIFF
--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -28,7 +28,7 @@ namespace Achievements
 	extern void GameChanged(u32 crc);
 
 	/// Re-enables hardcode mode if it is enabled in the settings.
-	extern void ResetChallengeMode();
+	extern bool ResetChallengeMode();
 
 	/// Forces hardcore mode off until next reset.
 	extern void DisableChallengeMode();
@@ -62,7 +62,10 @@ namespace Achievements
 		return false;
 	}
 
-	static inline void ResetChallengeMode() {}
+	static inline bool ResetChallengeMode()
+	{
+		return false;
+	}
 
 	static inline void DisableChallengeMode() {}
 

--- a/pcsx2/Frontend/FullscreenUI.h
+++ b/pcsx2/Frontend/FullscreenUI.h
@@ -35,8 +35,8 @@ namespace FullscreenUI
 	void OnVMDestroyed();
 	void OnRunningGameChanged(std::string path, std::string serial, std::string title, u32 crc);
 	void OpenPauseMenu();
-	bool OpenAchievementsWindow();
-	bool OpenLeaderboardsWindow();
+	void OpenAchievementsWindow();
+	void OpenLeaderboardsWindow();
 
 	void Shutdown();
 	void Render();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -693,6 +693,12 @@ void VMManager::UpdateRunningGame(bool resetting, bool game_starting)
 	if (s_patches_crc != s_game_crc)
 		ReloadPatches(game_starting, false);
 
+#ifdef ENABLE_ACHIEVEMENTS
+	// Per-game ini enabling of hardcore mode. We need to re-enforce the settings if so.
+	if (game_starting && Achievements::ResetChallengeMode())
+		ApplySettings();
+#endif
+
 	GetMTGS().SendGameCRC(new_crc);
 
 	Host::OnGameChanged(s_disc_path, s_game_serial, s_game_name, s_game_crc);
@@ -1095,17 +1101,8 @@ void VMManager::Shutdown(bool save_resume_state)
 void VMManager::Reset()
 {
 #ifdef ENABLE_ACHIEVEMENTS
-	const bool previous_challenge_mode = Achievements::ChallengeModeActive();
 	if (!Achievements::OnReset())
 		return;
-
-	if (Achievements::ChallengeModeActive() && !previous_challenge_mode)
-	{
-		// Hardcore mode enabled, so reload settings. This only covers the BIOS
-		// portion of the boot, once the game loads we'll reset anyway, but better
-		// to change things like the speed now rather than later.
-		ApplySettings();
-	}
 #endif
 
 	const bool game_was_started = g_GameStarted;


### PR DESCRIPTION
### Description of Changes

Fixes a possible crash/renderer corruption if you try to open achievements/leaderboards when the FSUI isn't initialized.

Fixes HC mode enabling via per-game settings.

### Rationale behind Changes

Closes #7213.

### Suggested Testing Steps

Test HC mode enabling, make sure I haven't introduced a vulnerability.

Note, to simplify things, the HC enforcement is now moved to ELF load time. So, if you had a slow speed set, it will briefly stay slow after resetting, but get clamped/enforced once the game loads.