### PR TITLE
Qt: Use vsync when any FSUI window is open

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -933,7 +933,9 @@ void Host::ReleaseHostDisplay()
 VsyncMode Host::GetEffectiveVSyncMode()
 {
 	// Force vsync on when running big picture UI, and paused or no VM.
-	if (g_emu_thread->isRunningFullscreenUI())
+	// We check the "running FSUI" flag here, because that way we set the initial vsync
+	// state when initalizing to on, avoiding an unnecessary switch.
+	if (FullscreenUI::HasActiveWindow() || (!FullscreenUI::IsInitialized() && g_emu_thread->isRunningFullscreenUI()))
 	{
 		const VMState state = VMManager::GetState();
 		if (state == VMState::Shutdown || state == VMState::Paused)


### PR DESCRIPTION
### Description of Changes

Fixes high GPU usage when pause menu is opened. Previously, it was fine if you started from big picture mode, but not if you invoked it by opening the menu.

### Rationale behind Changes

Fixes #7223.

### Suggested Testing Steps

Test opening pause menu, ensure vsync toggles on (logged to console).
