### PR TITLE
GS/Vulkan: Skip first barrier when starting pass

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -260,7 +260,7 @@ public:
 
 	void RenderHW(GSHWDrawConfig& config) override;
 	void UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelector& pipe);
-	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt);
+	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, bool skip_first_barrier);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Vulkan State


### PR DESCRIPTION
### Description of Changes

When we're the first draw in a render pass, we don't need a barrier. For `one` barriers, we can skip it entirely. For full, we can skip the first barrier.

### Rationale behind Changes

Miniscule performance improvement, maybe.

### Suggested Testing Steps

Check a few blending games, make sure nothing broke. Check for a reduction in barriers - but probably won't be many.
