### PR TITLE
ImGuiOverlays: Add Texture in RT

### DIFF
--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -309,6 +309,8 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("CSBW={} ", GSConfig.UserHacks_CPUSpriteRenderBW);
 		if (GSConfig.SkipDrawStart != 0 || GSConfig.SkipDrawEnd != 0)
 			APPEND("SD={}/{} ", GSConfig.SkipDrawStart, GSConfig.SkipDrawEnd);
+		if (GSConfig.UserHacks_TextureInsideRt)
+			APPEND("TexRT ");
 	}
 
 #undef APPEND


### PR DESCRIPTION
### Description of Changes
Adds Texture in RT to the imgui overlay.

### Rationale behind Changes
Missing settings in overlay is bad.

### Suggested Testing Steps
Make sure CI is happy and the setting appears in the overlay.
