### PR TITLE
GameDB: Correct Big Game Hunter name

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -43300,7 +43300,7 @@ SLUS-21020:
   region: "NTSC-U"
   compat: 5
 SLUS-21021:
-  name: "Cabela's Deer Hunt - 2005 Season"
+  name: "Cabela's Big Game Hunter 2005 Adventures"
   region: "NTSC-U"
 SLUS-21022:
   name: "Prince of Persia - Warrior Within"


### PR DESCRIPTION
### Description of Changes
Corrects the name of SLUS-21021 and SLUS-21011.

### Rationale behind Changes
Name wrong is bad correct name good.

### Suggested Testing Steps
~~Stress is bad for you~~ Make sure CI is happy.
