### PR TITLE
GS-hw/GameDB: Remove Ikki Tousen crc hack and replace it with round sprite half.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -37666,10 +37666,14 @@ SLPS-25796:
 SLPS-25797:
   name: "Ikki Tousen - Shining Dragon [Limited Edition]"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Aligns bloom effect.
 SLPS-25798:
   name: "Ikki Tousen - Shining Dragon"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    roundSprite: 1 # Aligns bloom effect.
 SLPS-25799:
   name: "Ultraman Fighting Evolution 3 [Banpresto Best]"
   region: "NTSC-J"
@@ -37939,6 +37943,8 @@ SLPS-25881:
 SLPS-25882:
   name: "Ikki Tousen - Shining Dragon [Best Collection]"
   region: "NTSC-J"
+  gsHWFixes:
+    roundSprite: 1 # Aligns bloom effect.
 SLPS-25883:
   name: "Katekyoo Hitman Reborn! Nerae! Ring x Vongola Trainers"
   region: "NTSC-J"

--- a/pcsx2/GS/GSCrc.cpp
+++ b/pcsx2/GS/GSCrc.cpp
@@ -162,7 +162,6 @@ const CRC::Game CRC::m_games[] =
 	{0x1F88BECD, Tekken5, EU, 0}, // language selector...
 	{0x652050D2, Tekken5, US, 0},
 	{0xEA64EF39, Tekken5, KO, 0},
-	{0x9E98B8AE, IkkiTousen, JP, 0},
 	{0x95CC86EF, GiTS, US, 0}, // same CRC also reported as EU
 	{0x2C5BF134, GiTS, US, 0}, // Demo
 	{0xA5768F53, GiTS, JP, 0},

--- a/pcsx2/GS/GSCrc.h
+++ b/pcsx2/GS/GSCrc.h
@@ -40,7 +40,6 @@ public:
 		GodHand,
 		HauntingGround,
 		ICO,
-		IkkiTousen,
 		Jak2,
 		Jak3,
 		JakX,

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -202,21 +202,6 @@ bool GSC_Spartan(const GSFrameInfo& fi, int& skip) noexcept
 	return true;
 }
 
-bool GSC_IkkiTousen(const GSFrameInfo& fi, int& skip) noexcept
-{
-	if (skip == 0)
-	{
-		if (!s_nativeres && fi.TME && fi.FBP == 0x00700 && fi.FPSM == PSM_PSMZ24 && fi.TBP0 == 0x01180 && fi.TPSM == PSM_PSMZ24)
-		{
-			// Might not be needed if any of the upscaling hacks fix the issues, needs to be further tested.
-			// Don't enable hack on native res if crc is below aggressive.
-			skip = 11; // Upscaling blur/ghosting
-		}
-	}
-
-	return true;
-}
-
 bool GSC_Oneechanbara2Special(const GSFrameInfo& fi, int& skip) noexcept
 {
 	if (skip == 0)
@@ -856,7 +841,6 @@ void GSState::SetupCrcHack() noexcept
 		// Upscaling hacks
 		lut[CRC::DBZBT3] = GSC_DBZBT3;
 		lut[CRC::FightingBeautyWulong] = GSC_FightingBeautyWulong;
-		lut[CRC::IkkiTousen] = GSC_IkkiTousen;
 		lut[CRC::Oneechanbara2Special] = GSC_Oneechanbara2Special;
 		lut[CRC::UltramanFightingEvolution] = GSC_UltramanFightingEvolution;
 		lut[CRC::YakuzaGames] = GSC_YakuzaGames;

--- a/pcsx2/GS/Window/GSSetting.cpp
+++ b/pcsx2/GS/Window/GSSetting.cpp
@@ -54,7 +54,7 @@ const char* dialog_message(int ID, bool* updateText)
 				"Minimum:\nEnables CRC lookup for special post processing effects.\n\n"
 				"Aggressive:\nUse more aggressive CRC hacks.\n"
 				"Removes effects in some games which make the image appear sharper/clearer.\n"
-				"Affected games: AC4, BleachBB, Bully, DBZBT 2 & 3, DeathByDegrees, Evangelion, FF games, FightingBeautyWulong, GOW 1 & 2, Kunoichi, IkkiTousen, Okami, Oneechanbara2, OnimushaDoD, RDRevolver, Simple2000Vol114, SoTC, SteambotChronicles, Tekken5, Ultraman, XenosagaE3, Yakuza 1 & 2.\n");
+				"Affected games: AC4, DBZBT 2 & 3, DeathByDegrees, Evangelion, FF games, FightingBeautyWulong, Kunoichi, Okami, Oneechanbara2, OnimushaDoD, RDRevolver, Simple2000Vol114, SteambotChronicles, Tekken5, Ultraman, XenosagaE3, Yakuza 1 & 2.\n");
 		case IDC_SKIPDRAWEND:
 		case IDC_SKIPDRAWHACKEDIT:
 		case IDC_SKIPDRAWSTART:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Remove Ikki Tousen crc hack. 
Upscaling hack, upscaling fixes in gamedb will deal with it.

GameDB: Add Round Sprite Half to Ikki Tousen.
Aligns bloom effect.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, get rid of crc hacks.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
[Ikki Tousen - Shining Dragon (NTSC-J)_SLPS-25798_20221019023805.gs.xz.zip](https://github.com/PCSX2/pcsx2/files/9815939/Ikki.Tousen.-.Shining.Dragon.NTSC-J._SLPS-25798_20221019023805.gs.xz.zip)
