### PR TITLE
Qt: Update emuthread settings on blockdump directory/bios change

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -815,6 +815,8 @@ void MainWindow::onBlockDumpActionToggled(bool checked)
 
 	Host::SetBaseStringSettingValue("EmuCore", "BlockDumpSaveDirectory", new_dir.toUtf8().constData());
 	Host::CommitBaseSettingChanges();
+
+	g_emu_thread->applySettings();
 }
 
 void MainWindow::saveStateToConfig()

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -125,6 +125,8 @@ void BIOSSettingsWidget::listItemChanged(const QTreeWidgetItem* current, const Q
 {
 	Host::SetBaseStringSettingValue("Filenames", "BIOS", current->text(0).toUtf8().constData());
 	Host::CommitBaseSettingChanges();
+
+	g_emu_thread->applySettings();
 }
 
 BIOSSettingsWidget::RefreshThread::RefreshThread(BIOSSettingsWidget* parent, const QString& directory)


### PR DESCRIPTION
### Description of Changes
Update the emu thread settings when choosing a new directory for where the blockdump should go.

### Rationale behind Changes
The Apply Settings only happened on the toggle of the option, but not when the new path was chosen, so unless you restarted the emu first, it would use the old path.

### Suggested Testing Steps
Try toggling the blockdump option on and choosing different paths, make sure it makes the file in the right place.
