### PR TITLE
GHActions: Migrate to new variable output system

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -73,10 +73,7 @@ jobs:
       # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date -u "+%Y-%m-%d-%H;%M;%S")" >> $GITHUB_OUTPUT
 
       - name: ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/linux_build_wx.yml
+++ b/.github/workflows/linux_build_wx.yml
@@ -71,10 +71,7 @@ jobs:
       # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date -u "+%Y-%m-%d-%H;%M;%S")" >> $GITHUB_OUTPUT
 
       - name: ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -91,10 +91,7 @@ jobs:
       # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date -u "+%Y-%m-%d-%H;%M;%S")" >> $GITHUB_OUTPUT
 
       - name: Cache ccache cache
         uses: actions/cache@v3

--- a/.github/workflows/scripts/common/name-artifacts.sh
+++ b/.github/workflows/scripts/common/name-artifacts.sh
@@ -54,4 +54,4 @@ fi
 # Trim the Name
 NAME=$(printf "%.199s]" "$NAME")
 echo "${NAME}"
-echo "##[set-output name=artifact-name;]${NAME}"
+echo "artifact-name=${NAME}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/windows_build_wx.yml
+++ b/.github/workflows/windows_build_wx.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           if "${{ inputs.platform }}"=="Win32" (SET vcvars=vcvarsamd64_x86.bat) else (SET vcvars=vcvars64.bat)
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\%vcvars%"
-          echo ::set-output name=vcvars::%vcvars%
+          echo vcvars=%vcvars%>> %GITHUB_OUTPUT%
           cmake . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -G Ninja
 
       - name: Build PCSX2


### PR DESCRIPTION
### Description of Changes
Moves to GitHub Actions' new preferred way of setting variables

### Rationale behind Changes
[GitHub is deprecating the old system](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

### Suggested Testing Steps
Make sure everything still gets named correctly
