### PR TITLE
Unified CDVD Part 1

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -611,7 +611,8 @@ s32 cdvdReadSubQ(s32 lsn, cdvdSubQ* subq)
 	if (cdvd.subq.trackNum > 0)
 	{
 		memcpy(subq, &cdvd.subq, sizeof(cdvdSubQ));
-		return 0; 
+		Console.WriteLn("subQ READ: %d", subq->trackNum);
+		return 0;
 	}
 	return 0x80;
 }
@@ -2020,8 +2021,6 @@ static void cdvdWrite04(u8 rt)
 			cdvd.ReadTime = cdvdBlockReadTime(MODE_CDROM);
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, MODE_CDROM));
 
-			CDVD->getSubQ(cdvd.SeekToSector, &cdvd.subq);
-
 			// Read-ahead by telling CDVD about the track now.
 			// This helps improve performance on actual from-cd emulation
 			// (ie, not using the hard drive)
@@ -2031,6 +2030,7 @@ static void cdvdWrite04(u8 rt)
 			// take priority in the handler anyway.  If the read is contiguous then
 			// this'll skip the seek delay.
 			cdvd.Reading = 1;
+			CDVD->getSubQ(cdvd.SeekToSector, &cdvd.subq);
 			break;
 		}
 		case N_DVD_READ: // DvdRead

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -608,10 +608,12 @@ s32 cdvdGetToc(void* toc)
 
 s32 cdvdReadSubQ(s32 lsn, cdvdSubQ* subq)
 {
-	s32 ret = CDVD->readSubQ(lsn, subq);
-	if (ret == -1)
-		ret = 0x80;
-	return ret;
+	if (cdvd.subq.trackNum > 0)
+	{
+		memcpy(subq, &cdvd.subq, sizeof(cdvdSubQ));
+		return 0; 
+	}
+	return 0x80;
 }
 
 static void cdvdDetectDisk()
@@ -2017,6 +2019,8 @@ static void cdvdWrite04(u8 rt)
 
 			cdvd.ReadTime = cdvdBlockReadTime(MODE_CDROM);
 			CDVDREAD_INT(cdvdStartSeek(cdvd.SeekToSector, MODE_CDROM));
+
+			CDVD->getSubQ(cdvd.SeekToSector, &cdvd.subq);
 
 			// Read-ahead by telling CDVD about the track now.
 			// This helps improve performance on actual from-cd emulation

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -20,50 +20,6 @@
 #include <string>
 #include <string_view>
 
-#define btoi(b) ((b) / 16 * 10 + (b) % 16) /* BCD to u_char */
-#define itob(i) ((i) / 10 * 16 + (i) % 10) /* u_char to BCD */
-
-static __fi s32 msf_to_lsn(u8* Time)
-{
-	u32 lsn;
-
-	lsn = Time[2];
-	lsn += (Time[1] - 2) * 75;
-	lsn += Time[0] * 75 * 60;
-	return lsn;
-}
-
-static __fi s32 msf_to_lba(u8 m, u8 s, u8 f)
-{
-	u32 lsn;
-	lsn = f;
-	lsn += (s - 2) * 75;
-	lsn += m * 75 * 60;
-	return lsn;
-}
-
-static __fi void lsn_to_msf(u8* Time, s32 lsn)
-{
-	u8 m, s, f;
-
-	lsn += 150;
-	m = lsn / 4500;       // minuten
-	lsn = lsn - m * 4500; // minuten rest
-	s = lsn / 75;         // sekunden
-	f = lsn - (s * 75);   // sekunden rest
-	Time[0] = itob(m);
-	Time[1] = itob(s);
-	Time[2] = itob(f);
-}
-
-static __fi void lba_to_msf(s32 lba, u8* m, u8* s, u8* f)
-{
-	lba += 150;
-	*m = lba / (60 * 75);
-	*s = (lba / 75) % 60;
-	*f = lba % 75;
-}
-
 struct cdvdRTC
 {
 	u8 status;
@@ -124,6 +80,8 @@ struct cdvdStruct
 	// the videomode's vertical frequency, it updates the real time clock.
 	int RTCcount;
 	cdvdRTC RTC;
+
+	cdvdSubQ subq;
 
 	u32 Sector;
 	int nSectors;

--- a/pcsx2/CDVD/CDVDcommon.cpp
+++ b/pcsx2/CDVD/CDVDcommon.cpp
@@ -117,6 +117,7 @@ bool cdvdCacheFetch(u32 lsn, u8* data, cdvdSubQ *subQ)
 		if (subQ != nullptr)
 		{
 			memcpy(subQ, &Cache[entry].subchannelQ, sizeof(cdvdSubQ));
+			Console.WriteLn("TRACK NUMBER: %d", Cache[entry].subchannelQ.trackNum);
 		}
 		if (data != nullptr)
 		{

--- a/pcsx2/CDVD/CDVDcommon.h
+++ b/pcsx2/CDVD/CDVDcommon.h
@@ -31,6 +31,16 @@ typedef struct _cdvdSubQ
 	u8 discF;      // current frame offset from first track (BCD encoded)
 } cdvdSubQ;
 
+typedef struct _cdvdTrack
+{
+	u32 startLba;
+	u8 trackNum;
+	u32 startDisc;
+	u32 startTrack;
+	u8 type;
+
+} cdvdTrack;
+
 typedef struct _cdvdTD
 { // NOT bcd coded
 	u32 lsn;

--- a/pcsx2/CDVD/CDVDdiscReader.cpp
+++ b/pcsx2/CDVD/CDVDdiscReader.cpp
@@ -33,7 +33,7 @@ static std::thread s_keepalive_thread;
 
 u8 strack;
 u8 etrack;
-track tracks[100];
+cdvdTrack tracks[100];
 
 int curDiskType;
 int curTrayStatus;
@@ -65,7 +65,7 @@ inline void lsn_to_msf(u8* minute, u8* second, u8* frame, u32 lsn)
 // TocStuff
 void cdvdParseTOC()
 {
-	tracks[1].start_lba = 0;
+	tracks[1].startLba = 0;
 
 	if (!src->GetSectorCount())
 	{
@@ -93,7 +93,7 @@ void cdvdParseTOC()
 			continue;
 		strack = std::min(strack, entry.track);
 		etrack = std::max(etrack, entry.track);
-		tracks[entry.track].start_lba = entry.lba;
+		tracks[entry.track].startLba = entry.lba;
 		if ((entry.control & 0x0C) == 0x04)
 		{
 			std::array<u8, 2352> buffer;
@@ -284,10 +284,10 @@ s32 CALLBACK DISCreadSubQ(u32 lsn, cdvdSubQ* subq)
 	lsn_to_msf(&subq->discM, &subq->discS, &subq->discF, lsn + 150);
 
 	u8 i = strack;
-	while (i < etrack && lsn >= tracks[i + 1].start_lba)
+	while (i < etrack && lsn >= tracks[i + 1].startLba)
 		++i;
 
-	lsn -= tracks[i].start_lba;
+	lsn -= tracks[i].startLba;
 
 	lsn_to_msf(&subq->trackM, &subq->trackS, &subq->trackF, lsn);
 
@@ -329,7 +329,7 @@ s32 CALLBACK DISCgetTD(u8 Track, cdvdTD* Buffer)
 	if (Track > etrack)
 		return -1;
 
-	Buffer->lsn = tracks[Track].start_lba;
+	Buffer->lsn = tracks[Track].startLba;
 	Buffer->type = tracks[Track].type;
 	return 0;
 }

--- a/pcsx2/CDVD/CDVDdiscReader.h
+++ b/pcsx2/CDVD/CDVDdiscReader.h
@@ -70,6 +70,7 @@ public:
 	const std::vector<toc_entry>& ReadTOC() const;
 	bool ReadSectors2048(u32 sector, u32 count, u8* buffer) const;
 	bool ReadSectors2352(u32 sector, u32 count, u8* buffer) const;
+	bool ReadSubChannelQ(u32 sector, cdvdSubQ* subQ) const;
 	u32 GetLayerBreakAddress() const;
 	s32 GetMediaType() const;
 	void SetSpindleSpeed(bool restore_defaults) const;
@@ -91,6 +92,7 @@ void cdvdStopThread();
 void cdvdRequestSector(u32 sector, s32 mode);
 u8* cdvdGetSector(u32 sector, s32 mode);
 s32 cdvdDirectReadSector(u32 sector, s32 mode, u8* buffer);
+cdvdSubQ *cdvdReadSubQ(u32 sector);
 s32 cdvdGetMediaType();
 s32 cdvdRefreshData();
 void cdvdParseTOC();

--- a/pcsx2/CDVD/CDVDdiscReader.h
+++ b/pcsx2/CDVD/CDVDdiscReader.h
@@ -22,15 +22,11 @@
 #include <mutex>
 #include <array>
 
-struct track
-{
-	u32 start_lba;
-	u8 type;
-};
+#include "CDVDcommon.h"
 
 extern u8 strack;
 extern u8 etrack;
-extern track tracks[100];
+extern cdvdTrack tracks[100];
 
 extern int curDiskType;
 extern int curTrayStatus;

--- a/pcsx2/CDVD/CDVDisoReader.cpp
+++ b/pcsx2/CDVD/CDVDisoReader.cpp
@@ -77,10 +77,12 @@ s32 CALLBACK ISOopen(const char* pTitle)
 	layer1start = -1;
 	layer1searched = false;
 
+	cdvdCacheReset();
+
 	return 0;
 }
 
-s32 CALLBACK ISOreadSubQ(u32 lsn, cdvdSubQ* subq)
+s32 CALLBACK ISOgetSubQ(u32 lsn, cdvdSubQ* subq)
 {
 	// fake it
 	u8 min, sec, frm;
@@ -411,7 +413,7 @@ CDVD_API CDVDapi_Iso =
 		ISOopen,
 		ISOreadTrack,
 		ISOgetBuffer,
-		ISOreadSubQ,
+		ISOgetSubQ,
 		ISOgetTN,
 		ISOgetTD,
 		ISOgetTOC,

--- a/pcsx2/CDVD/Ps1CD.cpp
+++ b/pcsx2/CDVD/Ps1CD.cpp
@@ -216,12 +216,6 @@ static void ReadTrack()
 	cdr.Prev[1] = itob(cdr.SetSector[1]);
 	cdr.Prev[2] = itob(cdr.SetSector[2]);
 
-	cdvdSubQ subQ;
-	if (CDVD->getSubQ(msf_to_lsn(cdr.SetSector), &subQ))
-	{
-		cdr.subQ = subQ;
-	}
-
 	CDVD_LOG("KEY *** %x:%x:%x", cdr.Prev[0], cdr.Prev[1], cdr.Prev[2]);
 	if (EmuConfig.CdvdVerboseReads)
 		DevCon.WriteLn("CD Read Sector %x", msf_to_lsn(cdr.SetSector));
@@ -670,6 +664,7 @@ void cdrReadInterrupt()
 		CDREAD_INT((cdr.Mode & 0x80) ? (cdReadTime / 2) : cdReadTime);
 	}
 
+	CDVD->getSubQ(msf_to_lsn(cdr.SetSector), &cdr.subQ);
 	psxHu32(0x1070) |= 0x4;
 	return;
 }

--- a/pcsx2/CDVD/Ps1CD.h
+++ b/pcsx2/CDVD/Ps1CD.h
@@ -63,6 +63,7 @@ struct cdrStruct
 	u32 Reading;
 
 	cdvdTN ResultTN;
+	cdvdSubQ subQ;
 	u8 ResultTD[4];
 	u8 SetSector[4];
 	u8 SetSectorSeek[4];
@@ -89,6 +90,7 @@ extern cdrStruct cdr;
 void cdrReset();
 void cdrInterrupt();
 void cdrReadInterrupt();
+void UpdateStat(uint stat);
 u8 cdrRead0(void);
 u8 cdrRead1(void);
 u8 cdrRead2(void);

--- a/pcsx2/CDVD/ThreadedFileReader.cpp
+++ b/pcsx2/CDVD/ThreadedFileReader.cpp
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "ThreadedFileReader.h"
+#include "CDVDcommon.h"
 
 #include "common/Threading.h"
 
@@ -259,6 +260,7 @@ bool ThreadedFileReader::TryCachedRead(void*& buffer, u64& offset, u32& size, co
 bool ThreadedFileReader::Open(std::string fileName)
 {
 	CancelAndWaitUntilStopped();
+	cdvdCacheReset();
 	return Open2(std::move(fileName));
 }
 

--- a/pcsx2/CDVD/Windows/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Windows/IOCtlSrc.cpp
@@ -95,6 +95,33 @@ void IOCtlSrc::SetSpindleSpeed(bool restore_defaults) const
 	}
 }
 
+bool IOCtlSrc::ReadSubChannelQ(u32 sector, cdvdSubQ* subQ) const
+{
+	CDROM_SUB_Q_DATA_FORMAT format;
+	SUB_Q_CHANNEL_DATA data;
+
+	format.Format = IOCTL_CDROM_CURRENT_POSITION;
+
+	if (!DeviceIoControl(m_device, IOCTL_CDROM_READ_Q_CHANNEL, &format,
+		sizeof(format), &data, sizeof(SUB_Q_CHANNEL_DATA), NULL, NULL))
+	{
+		Console.Error("SubQ Read Failed");
+		return false;
+	}
+
+	subQ->mode = data.CurrentPosition.ADR;
+	subQ->ctrl = data.CurrentPosition.Control;
+	subQ->trackNum = data.CurrentPosition.TrackNumber;
+	subQ->trackIndex = data.CurrentPosition.IndexNumber;
+	subQ->discM = data.CurrentPosition.AbsoluteAddress[1];
+	subQ->discS = data.CurrentPosition.AbsoluteAddress[2];
+	subQ->discF = data.CurrentPosition.AbsoluteAddress[3];
+	subQ->trackM = data.CurrentPosition.TrackRelativeAddress[1];
+	subQ->trackS = data.CurrentPosition.TrackRelativeAddress[2];
+	subQ->trackF = data.CurrentPosition.TrackRelativeAddress[3];
+	return true;
+}
+
 u32 IOCtlSrc::GetSectorCount() const
 {
 	return m_sectors;

--- a/pcsx2/Darwin/DarwinFlatFileReader.cpp
+++ b/pcsx2/Darwin/DarwinFlatFileReader.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "AsyncFileReader.h"
 #include "common/FileSystem.h"
+#include "CDVD/CDVDcommon.h"
 #include <unistd.h>
 #include <fcntl.h>
 
@@ -45,7 +46,8 @@ bool FlatFileReader::Open(std::string fileName)
 
     m_fd = FileSystem::OpenFDFile(m_filename.c_str(), O_RDONLY, 0);
 
-	return (m_fd != -1);
+    cdvdCacheReset();
+    return (m_fd != -1);
 }
 
 int FlatFileReader::ReadSync(void* pBuffer, uint sector, uint count)

--- a/pcsx2/windows/FlatFileReaderWindows.cpp
+++ b/pcsx2/windows/FlatFileReaderWindows.cpp
@@ -16,6 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "AsyncFileReader.h"
 #include "common/StringUtil.h"
+#include "CDVD/CDVDcommon.h"
 
 FlatFileReader::FlatFileReader(bool shareWrite) : shareWrite(shareWrite)
 {
@@ -35,6 +36,8 @@ bool FlatFileReader::Open(std::string fileName)
 	m_filename = std::move(fileName);
 
 	hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+
+	cdvdCacheReset();
 
 	DWORD shareMode = FILE_SHARE_READ;
 	if (shareWrite)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Makes several core changes to current CDVD functionality breaking the physical disc reader cached sector buffer out to common
Adds SubchannelQ reads from physical disc functionality. Adds subQ struct to sector cache to imitate that data and subQ are separate signals and that subQ will always be filled into mechacon ram.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy and better unification across CDVD reader types. Preparation for image type multitrack support CHD and CUE files
Preparation for CD-DA sound in ps1 mode as well as Dance Factory CD-DA support in image format

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test ps1, ps2 CD games.

Part 2 will affect the ISO reader and run it through the cache 
