### PR TITLE
GS/TextureCache: Use Inside() for checking display target

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2046,9 +2046,9 @@ void GSState::Write(const u8* mem, int len)
 	const int page_width = std::max(1, ((w + static_cast<int>(m_env.TRXPOS.DSAX)) / psm.pgs.x));
 	const int page_height = std::max(1, ((h + static_cast<int>(m_env.TRXPOS.DSAY)) / psm.pgs.y));
 	const int pitch = (std::max(1U, blit.DBW) * 64) / psm.pgs.x;
-
+	const u32 end_bp = blit.DBP + ((((page_height % psm.pgs.y) != 0) ? (page_width << 5) : 0) + ((page_height * pitch) << 5));
 	// Try to avoid flushing draws if it doesn't cross paths
-	m_mem.m_clut.InvalidateRange(blit.DBP, blit.DBP + ((page_width << 5) + ((page_height * pitch) << 5)));
+	m_mem.m_clut.InvalidateRange(blit.DBP, end_bp);
 }
 
 void GSState::InitReadFIFO(u8* mem, int len)
@@ -2295,9 +2295,9 @@ void GSState::Move()
 	const int page_width = std::max(1, ((w + static_cast<int>(m_env.TRXPOS.DSAX)) / dpsm.pgs.x));
 	const int page_height = std::max(1, ((h + static_cast<int>(m_env.TRXPOS.DSAY)) / dpsm.pgs.y));
 	const int pitch = (std::max(1, dbw) * 64) / dpsm.pgs.x;
-
+	const u32 end_bp = dbp + ((((page_height % dpsm.pgs.y) != 0) ? (page_width << 5) : 0) + ((page_height * pitch) << 5));
 	// Try to avoid flushing draws if it doesn't cross paths
-	m_mem.m_clut.InvalidateRange(dbp, dbp + ((page_width << 5) + ((page_height * pitch) << 5)));
+	m_mem.m_clut.InvalidateRange(dbp, end_bp);
 }
 
 void GSState::SoftReset(u32 mask)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -485,18 +485,13 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		// 2nd try ! Try to find a frame that include the bp
 		if (!dst)
 		{
-			const int page_width = std::max(1, (real_w / psm_s.pgs.x));
-			const int page_height = std::max(1, (real_h / psm_s.pgs.y));
-			const int pitch = (std::max(1U, TEX0.TBW) * 64) / psm_s.pgs.x;
-			const u32 end_bp = bp + ((page_width << 5) + ((page_height * pitch) << 5));
-
 			for (auto t : list)
 			{
 				// Make sure the target is inside the texture
-				if (t->m_TEX0.TBP0 < bp && bp <= t->m_end_block && end_bp > t->m_TEX0.TBP0 && end_bp <= t->m_end_block)
+				if (t->m_TEX0.TBP0 <= bp && bp <= t->m_end_block && t->Inside(bp, TEX0.TBW, TEX0.PSM, GSVector4i(0, 0, real_w, real_h)))
 				{
 					dst = t;
-					GL_CACHE("TC: Lookup Frame %dx%d, inclusive hit: %d (0x%x, took 0x%x -> 0x%x %s endbp 0x%x)", size.x, size.y, t->m_texture->GetID(), bp, t->m_TEX0.TBP0, t->m_end_block, psm_str(TEX0.PSM), end_bp);
+					GL_CACHE("TC: Lookup Frame %dx%d, inclusive hit: %d (0x%x, took 0x%x -> 0x%x %s)", size.x, size.y, t->m_texture->GetID(), bp, t->m_TEX0.TBP0, t->m_end_block, psm_str(TEX0.PSM));
 
 					if (real_h > 0 || real_w > 0)
 						ScaleTargetForDisplay(dst, TEX0, real_w, real_h);


### PR DESCRIPTION
### Description of Changes

The existing code was adding however many pages the framebuffer crossed unconditionally, when practically this last row will only be read when the height isn't page-aligned.

> if we had a 64x32 FB with a FBW of 1, that's 1x1 pages, so we'd compute the end as bp + (1 << 5) + ((1 * 1) << 5), which is two pages
> if it's not paged aligned, then yeah, you'd want to go one more "row" of pages down, but not take the full stride (in case the width mod 64 is not zero)

### Rationale behind Changes

Fixes #6976.

### Suggested Testing Steps

Test sensitive games.
