### PR TITLE
GS: Only allow recently updated frames for display.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6409,8 +6409,6 @@ SCPS-55008:
 SCPS-55010:
   name: "Grandia Xtreme"
   region: "NTSC-J"
-  gameFixes:
-    - SoftwareRendererFMVHack # Flickering in FMV.
 SCPS-55011:
   name: "Dual Hearts"
   region: "NTSC-J"
@@ -20104,18 +20102,21 @@ SLES-54904:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
+    halfPixelOffset: 2 # Corrects misaligned cel shading.
+    roundSprite: 1 # Further corrects misaligned cel shading.
 SLES-54905:
   name: "Simpsons Game, The"
   region: "PAL-F"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
+    halfPixelOffset: 2 # Corrects misaligned cel shading.
+    roundSprite: 1 # Further corrects misaligned cel shading.
 SLES-54906:
   name: "Simpsons Game, The"
   region: "PAL-I-S"
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
+    halfPixelOffset: 2 # Corrects misaligned cel shading.
+    roundSprite: 1 # Further corrects misaligned cel shading.
 SLES-54913:
   name: "Pro Evolution Soccer 2008"
   region: "PAL-E-S"
@@ -20440,7 +20441,8 @@ SLES-55020:
   name: "Die Simpsons - Das Spiel"
   region: "PAL-G"
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
+    halfPixelOffset: 2 # Corrects misaligned cel shading.
+    roundSprite: 1 # Further corrects misaligned cel shading.
 SLES-55021:
   name: "Pro Evolution Soccer 2008"
   region: "PAL-F-G"
@@ -26420,8 +26422,6 @@ SLPM-65080:
 SLPM-65082:
   name: "Grandia Xtreme [Limited Edition]"
   region: "NTSC-J"
-  gameFixes:
-    - SoftwareRendererFMVHack # Flickering in FMV.
 SLPM-65083:
   name: "Houshin Engi 2"
   region: "NTSC-J"
@@ -26449,8 +26449,6 @@ SLPM-65087:
 SLPM-65089:
   name: "Grandia Xtreme"
   region: "NTSC-J"
-  gameFixes:
-    - SoftwareRendererFMVHack # Flickering in FMV.
 SLPM-65090:
   name: "Spy Hunter"
   region: "NTSC-J"
@@ -40421,8 +40419,6 @@ SLUS-20417:
   name: "Grandia Xtreme"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Flickering in FMV.
 SLUS-20418:
   name: "Wakeboarding Unleashed featuring Shaun Murray"
   region: "NTSC-U"
@@ -46502,7 +46498,8 @@ SLUS-21665:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces misaligned cel shading but still an issue compared to native.
+    halfPixelOffset: 2 # Corrects misaligned cel shading.
+    roundSprite: 1 # Further corrects misaligned cel shading.
 SLUS-21666:
   name: "Mountain Bike Adrenaline"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -471,8 +471,14 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 		// Let's try to find a perfect frame that contains valid data
 		for (auto t : list)
 		{
+			// Only checks that the texure starts at the requested bp, size isn't considered.
 			if (bp == t->m_TEX0.TBP0 && t->m_end_block >= bp)
 			{
+				// If the frame is older than 4 frames (to be safe) then it hasn't been updated for ages, so it's probably not a valid output frame.
+				// The rest of the checks will get better equality, so suffer less from misdetection.
+				if (t->m_age > 4)
+					continue;
+
 				dst = t;
 				GL_CACHE("TC: Lookup Frame %dx%d, perfect hit: %d (0x%x -> 0x%x %s)", size.x, size.y, dst->m_texture->GetID(), bp, t->m_end_block, psm_str(TEX0.PSM));
 				if (real_h > 0 || real_w > 0)
@@ -482,7 +488,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(const GIFRegTEX0& TEX0, con
 			}
 		}
 
-		// 2nd try ! Try to find a frame that include the bp
+		// 2nd try ! Try to find a frame at the requested bp -> bp + size is inside of (or equal to)
 		if (!dst)
 		{
 			for (auto t : list)


### PR DESCRIPTION
### Description of Changes
Make sure matched target for output as the display frame isn't too old (likely not been touched for a long time) on initial lookup.

### Rationale behind Changes
Output fames should be updated at least once every 4 frames, and the first lookup on the TC only checks the start address is the same and it ends after that address somewhere, it has no size equality or anything (this is done in later checks), so if something else existed in that space in the texture cache, it can be errantly picked up as a valid texture, causing flashing in some FMV's. This will limit the check to only frames 4 frames old or less. if the frame genuinely hasn't been updated (loading screen etc), it should match on start & end addresses (a later check).

### Suggested Testing Steps
Test movies in games, and make sure things like loading screens do not flicker.

Possibly could fix anything from https://github.com/PCSX2/pcsx2/issues/3805

Fixes FMV's in Grandia Xtreme.

Also slipped in some updates for The Simpsons Game changing the upscaling as HPO normal causes the FMV's to jump around.
Temp logging added for testing.