### PR TITLE
GS: Improve upload TEX overwrite detection

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28725,15 +28725,6 @@ SLPM-65797:
   name: "Dragon Quest & Final Fantasy in Itadaki Street"
   region: "NTSC-J"
   compat: 5
-  patches:
-    4CE7FB04:
-      content: |-
-        author=refraction
-        // Game seems to have problems with alpha values being zero in some instances
-        // this patches the results from FPU to be an alpha of 2
-        // Fixes missing board
-        patch=1,EE,00143CBC,word,3C030200
-        patch=1,EE,00143CC0,word,00831825
 SLPM-65798:
   name: "Madden NFL Superbowl 2005"
   region: "NTSC-J"

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -110,7 +110,15 @@ void GSClut::Invalidate()
 
 void GSClut::InvalidateRange(u32 start_block, u32 end_block)
 {
-	if (m_write.TEX0.CBP >= start_block && m_write.TEX0.CBP <= end_block)
+	int blocks = 4;
+
+	if (GSLocalMemory::m_psm[m_write.TEX0.CPSM].bpp == 16)
+		blocks >>= 1;
+
+	if (GSLocalMemory::m_psm[m_write.TEX0.PSM].bpp == 4)
+		blocks >>= 1;
+
+	if ((m_write.TEX0.CBP + blocks) >= start_block && m_write.TEX0.CBP <= end_block)
 	{
 		m_write.dirty = true;
 	}

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -531,6 +531,17 @@ public:
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
 
+	static u32 GetEndBlock(int bp, int bw, int w, int h, int psm)
+	{
+		const GSLocalMemory::psm_t& dpsm = GSLocalMemory::m_psm[psm];
+		const int page_width = std::max(1, w / dpsm.pgs.x);
+		const int page_height = std::max(1, h / dpsm.pgs.y);
+		const int pitch = (std::max(1, bw) * 64) / dpsm.pgs.x;
+		const u32 end_bp = bp + ((((page_height % dpsm.pgs.y) != 0) ? (page_width << 5) : 0) + ((page_height * pitch) << 5));
+
+		return end_bp;
+	}
+
 	// address
 
 	static u32 BlockNumber32(int x, int y, u32 bp, u32 bw)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -283,12 +283,13 @@ public:
 		TEXFLUSH = 1 << 4,
 		GSTRANSFER = 1 << 5,
 		UPLOADDIRTYTEX = 1 << 6,
-		DOWNLOADFIFO = 1 << 7,
-		SAVESTATE = 1 << 8,
-		LOADSTATE = 1 << 9,
-		AUTOFLUSH = 1 << 10,
-		VSYNC  = 1 << 11,
-		GSREOPEN = 1 << 12,
+		LOCALTOLOCALMOVE = 1 << 7,
+		DOWNLOADFIFO = 1 << 8,
+		SAVESTATE = 1 << 9,
+		LOADSTATE = 1 << 10,
+		AUTOFLUSH = 1 << 11,
+		VSYNC  = 1 << 12,
+		GSREOPEN = 1 << 13,
 	};
 
 	GSFlushReason m_state_flush_reason;


### PR DESCRIPTION
### Description of Changes
Improves the code which checks if the current upload is going to overwrite the texture in use.

### Rationale behind Changes
Before it checked for start block equality, which isn't always true (as is the case with Tomb Raider - Angel of Darkness)

### Suggested Testing Steps
Test games known to have CLUT problems, and games listed and any which may have software mode problems still (on the offchange it fixes them, already checked mercenaries and Pride FC to no avail).

Fixes Tomb Raider - Angel of Darkness menu (properly)

Master:
![image](https://user-images.githubusercontent.com/6278726/197057040-63fe3c81-2ae7-496e-b6ac-dedf476732f3.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197057107-dd506333-f762-4331-8be5-afcb11fa7b26.png)
