### PR TITLE
CDVD: Partial revert change from #5142 keep read state when buffering.

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1115,6 +1115,8 @@ __fi void cdvdSectorReady()
 
 	if (cdvd.nextSectorsBuffered < 16)
 		CDVDSECTORREADY_INT(cdvd.ReadTime);
+	else
+		cdvdUpdateStatus(CDVD_STATUS_PAUSE);
 }
 
 // inlined due to being referenced in only one place.
@@ -1238,7 +1240,10 @@ __fi void cdvdReadInterrupt()
 			cdvdSetIrq();
 			cdvdUpdateReady(CDVD_DRIVE_READY);
 
-			cdvdUpdateStatus(CDVD_STATUS_PAUSE);
+			if (cdvd.nextSectorsBuffered < 16)
+				cdvdUpdateStatus(CDVD_STATUS_READ);
+			else
+				cdvdUpdateStatus(CDVD_STATUS_PAUSE);
 			//DevCon.Warning("Scheduling interrupt in %d cycles", cdvd.ReadTime - ((cdvd.BlockSize / 4) * 12));
 			// Timing issues on command end
 			// Star Ocean (1.1 Japan) expects the DMA to end and interrupt at least 128 or more cycles before the CDVD command ends.


### PR DESCRIPTION
### Description of Changes
Partial revert change from #5142 keep read state when buffering. Was setting it to paused, which is not true if buffering.

### Rationale behind Changes
Breaks Castleween, and doesn't make much sense, never noted anything broken by this, not overly sure *why* I changed it..

### Suggested Testing Steps
Test CDVD sensitive games (no SH2 will not be magically better, try others).

Fixes Castleween loading the last boss.
