### PR TITLE
SPU2: Move ADMA clear to ADMA disable.

### DIFF
--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -108,7 +108,7 @@ void V_Core::AutoDMAReadBuffer(int mode) //mode: 0= split stereo; 1 = do not spl
 
 	int size = std::min(InputDataLeft, (u32)0x200);
 	if (!leftbuffer)
-		size = 0x100;
+		size = std::min(size, 0x100);
 	LogAutoDMA(Index ? ADMA7LogFile : ADMA4LogFile);
 	//ConLog("Refilling ADMA buffer at %x OutPos %x with %x\n", spos, OutPos, size);
 	// HACKFIX!! DMAPtr can be invalid after a savestate load, so the savestate just forces it

--- a/pcsx2/SPU2/ReadInput.cpp
+++ b/pcsx2/SPU2/ReadInput.cpp
@@ -116,12 +116,6 @@ StereoOut32 V_Core::ReadInput()
 		retval = StereoOut32(
 			(s32)(*GetMemPtr(0x2000 + (Index << 10) + ReadIndex)),
 			(s32)(*GetMemPtr(0x2200 + (Index << 10) + ReadIndex)));
-
-		// Not accurate behaviour but shouldn't hurt for now, need to run some tests
-		// to see why Prince of Persia Warrior Within buzzes when going in to the map
-		// since it starts an ADMA of music, then kills ADMA, so it loops on a few ms of data.
-		GetMemPtr(0x2000 + (Index << 10) + ReadIndex)[0] = 0;
-		GetMemPtr(0x2200 + (Index << 10) + ReadIndex)[0] = 0;
 	}
 
 #ifdef PCSX2_DEVBUILD

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1559,6 +1559,16 @@ static void RegWrite_Core(u16 value)
 				thiscore.InputDataLeft = 0;
 				thiscore.DMAICounter = 0;
 				thiscore.InputDataTransferred = 0;
+
+				// Not accurate behaviour but shouldn't hurt for now, need to run some tests
+				// to see why Prince of Persia Warrior Within buzzes when going in to the map
+				// since it starts an ADMA of music, then kills ADMA and input DMA
+				// without disabling ADMA read mode or clearing the buffer.
+				for (int i = 0; i < 0x200; i++)
+				{
+					GetMemPtr(0x2000 + (thiscore.Index << 10))[i] = 0;
+					GetMemPtr(0x2200 + (thiscore.Index << 10))[i] = 0;
+				}
 			}
 			break;
 


### PR DESCRIPTION
### Description of Changes

Moved the hackfix that clears the ADMA buffer for Prince of Persia Warrior Within map screen to the ADMA disable function.
Fix bug with errantly setting data input size to transfer, even if there isn't any.

### Rationale behind Changes
Summoner seemed to not like the ADMA clearing itself behind the read pointer, which is fair, it makes more sense to clear it once ADMA is disabled rather than constantly behind the pointer, I guess kinda more performant too? :D

As for the data size bug, that was just stupid, if there was no DMA waiting and the SPU needed more data, and it was transferring the right channel buffer, it would force the size to 256 bytes ready transfer, which doesn't exist.

### Suggested Testing Steps
test ADMA sensitive games, mentioned in #4057 or #4171 and Summoner's main menu music, of course.

Fixes #6737
