### PR TITLE
GameDB: Add mipmapping and trilinear filtering to Black

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8734,6 +8734,8 @@ SLAJ-25078:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLAJ-25079:
   name: "Shin Sangoku Musou 4 - Empires"
   region: "NTSC-Unk"
@@ -9017,6 +9019,8 @@ SLED-53937:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLED-53951:
   name: "Honda Demo [Demo]"
   region: "PAL-E"
@@ -17663,6 +17667,8 @@ SLES-53886:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   patches:
     ADDFF505:
       content: |-
@@ -17993,6 +17999,8 @@ SLES-54030:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   patches:
     CAA04879:
       content: |-
@@ -30671,6 +30679,8 @@ SLPM-66354:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   patches:
     B3A9F9ED:
       content: |-
@@ -32069,6 +32079,8 @@ SLPM-66731:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-66732:
   name: "Iinazuke [Limited Edition]"
   region: "NTSC-J"
@@ -32817,6 +32829,8 @@ SLPM-66961:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-66962:
   name: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
@@ -45190,6 +45204,8 @@ SLUS-21376:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   patches:
     5C891FF1:
       content: |-
@@ -48432,6 +48448,8 @@ SLUS-29180:
   gsHWFixes:
     autoFlush: 1 # Properly diffuses light instead of strips of light.
     roundSprite: 1 # Fixes lighting misalignment such as the street poles and the sun.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-29183:
   name: "Fight Night - Round 3 [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds Mipmapping Full and Trilinear (PS2) to Black.

### Rationale behind Changes
Less crusty textures and better smoothness.

Without Mipmapping Full:
![image](https://user-images.githubusercontent.com/80843560/197191229-bd5f53e9-ecb3-4681-a011-8c7dc17992df.png)

With:
![image](https://user-images.githubusercontent.com/80843560/197191464-ac2f0428-7a1d-4678-b0bb-6f49b3534990.png)




### Suggested Testing Steps
CI better be happy the ungrateful so and so.
