### PR TITLE
EE/JIT: Flush Rt on LDR/LDL before write

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -500,17 +500,19 @@ void recLDL()
 		return;
 
 #ifdef REC_LOADS
+
 	if (GPR_IS_CONST1(_Rt_))
 	{
 		_flushConstReg(_Rt_);
 		_eeOnWriteReg(_Rt_, 0);
 	}
+	_deleteEEreg(_Rt_, 1);
 
 	if (GPR_IS_CONST1(_Rs_))
 	{
 		u32 srcadr = g_cpuConstRegs[_Rs_].UL[0] + _Imm_;
 
-		// If _Rs_ is equal to _Rt_ we need to put the shift in to eax since it won't take the CONST path
+		// If _Rs_ is equal to _Rt_ we need to put the shift in to eax since it won't take the CONST path.
 		if (_Rs_ == _Rt_)
 			xMOV(calleeSavedReg1d, srcadr);
 
@@ -552,7 +554,7 @@ void recLDL()
 		xAND(calleeSavedReg1d, 0x7);
 		xCMP(calleeSavedReg1d, 7);
 		xForwardJE8 skip;
-			// Calculate the shift from top bit to lowest
+			// Calculate the shift from top bit to lowest.
 			xADD(calleeSavedReg1d, 1);
 			xMOV(edx, 64);
 			xSHL(calleeSavedReg1d, 3);
@@ -585,12 +587,13 @@ void recLDR()
 		_flushConstReg(_Rt_);
 		_eeOnWriteReg(_Rt_, 0);
 	}
+	_deleteEEreg(_Rt_, 1);
 
 	if (GPR_IS_CONST1(_Rs_))
 	{
 		u32 srcadr = g_cpuConstRegs[_Rs_].UL[0] + _Imm_;
 
-		// If _Rs_ is equal to _Rt_ we need to put the shift in to eax since it won't take the CONST path
+		// If _Rs_ is equal to _Rt_ we need to put the shift in to eax since it won't take the CONST path.
 		if(_Rs_ == _Rt_)
 			xMOV(calleeSavedReg1d, srcadr);
 
@@ -631,7 +634,7 @@ void recLDR()
 
 		xAND(calleeSavedReg1d, 0x7);
 		xForwardJE8 skip;
-			// Calculate the shift from top bit to lowest
+			// Calculate the shift from top bit to lowest.
 			xMOV(edx, 64);
 			xSHL(calleeSavedReg1d, 3);
 			xSUB(edx, calleeSavedReg1d);

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -555,14 +555,11 @@ static void recQMFC2()
 	}
 
 	int rtreg = _allocGPRtoXMMreg(-1, _Rt_, MODE_WRITE);
-	int t0reg = _allocTempXMMreg(XMMT_INT, -1);
 	// Update Refraction 20/09/2021: This is needed because Const Prop is broken
 	// the Flushed flag isn't being cleared when it's not flushed. TODO I guess
 	_eeOnWriteReg(_Rt_, 0); // This is needed because Const Prop is broken
 
-	xMOVAPS(xRegisterSSE(t0reg), ptr128[&vu0Regs.VF[_Rd_]]);
-	xMOVAPS(xRegisterSSE(rtreg), xRegisterSSE(t0reg));
-	_freeXMMreg(t0reg);
+	xMOVAPS(xRegisterSSE(rtreg), ptr128[&vu0Regs.VF[_Rd_]]);
 }
 
 static void recQMTC2()
@@ -596,11 +593,8 @@ static void recQMTC2()
 	}
 
 	int rtreg = _allocGPRtoXMMreg(-1, _Rt_, MODE_READ);
-	int t0reg = _allocTempXMMreg(XMMT_INT, -1);
 
-	xMOVAPS(xRegisterSSE(t0reg), xRegisterSSE(rtreg));
-	xMOVAPS(ptr128[&vu0Regs.VF[_Rd_]], xRegisterSSE(t0reg));
-	_freeXMMreg(t0reg);
+	xMOVAPS(ptr128[&vu0Regs.VF[_Rd_]], xRegisterSSE(rtreg));
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes
Adds a flush for Rt in any XMM's before we write to Rt directly.

### Rationale behind Changes
Having multiple versions of data and regs falsely marked as in use when it's old data is bad :) Was a small oversight in https://github.com/PCSX2/pcsx2/pull/7179

### Suggested Testing Steps
idk, test stuff, mainly Max Payne I guess.

Fixes #7260
