### PR TITLE
Qt: Add interface section to per-game settings

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -969,7 +969,7 @@ void MainWindow::updateWindowState(bool force_visible)
 		return;
 
 	const bool hide_window = !isRenderingToMain() && shouldHideMainWindow();
-	const bool disable_resize = Host::GetBaseBoolSettingValue("UI", "DisableWindowResize", false);
+	const bool disable_resize = Host::GetBoolSettingValue("UI", "DisableWindowResize", false);
 	const bool has_window = s_vm_valid || m_display_widget;
 
 	// Need to test both valid and display widget because of startup (vm invalid while window is created).
@@ -1041,7 +1041,7 @@ bool MainWindow::shouldHideMouseCursor() const
 bool MainWindow::shouldHideMainWindow() const
 {
 	// NOTE: We can't use isRenderingToMain() here, because this happens post-fullscreen-switch.
-	return Host::GetBaseBoolSettingValue("UI", "HideMainWindowWhenRunning", false) ||
+	return Host::GetBoolSettingValue("UI", "HideMainWindowWhenRunning", false) ||
 		   (g_emu_thread->shouldRenderToMain() && isRenderingFullscreen()) ||
 		   QtHost::InNoGUIMode();
 }
@@ -1128,7 +1128,7 @@ bool MainWindow::requestShutdown(bool allow_confirm /* = true */, bool allow_sav
 	bool save_state = allow_save_to_state && default_save_to_state;
 
 	// Only confirm on UI thread because we need to display a msgbox.
-	if (!m_is_closing && allow_confirm && !GSDumpReplayer::IsReplayingDump() && Host::GetBaseBoolSettingValue("UI", "ConfirmShutdown", true))
+	if (!m_is_closing && allow_confirm && !GSDumpReplayer::IsReplayingDump() && Host::GetBoolSettingValue("UI", "ConfirmShutdown", true))
 	{
 		VMLock lock(pauseAndLockVM());
 

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -606,7 +606,7 @@ void Host::CheckForSettingsChanges(const Pcsx2Config& old_config)
 
 bool EmuThread::shouldRenderToMain() const
 {
-	return !Host::GetBaseBoolSettingValue("UI", "RenderToSeparateWindow", false) && !QtHost::InNoGUIMode();
+	return !Host::GetBoolSettingValue("UI", "RenderToSeparateWindow", false) && !QtHost::InNoGUIMode();
 }
 
 void EmuThread::toggleSoftwareRendering()

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -78,7 +78,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 		m_ui.inhibitScreensaver, tr("Inhibit Screensaver"), tr("Checked"),
 		tr("Prevents the screen saver from activating and the host from sleeping while emulation is running."));
 
-	if (AutoUpdaterDialog::isSupported())
+	if (!dialog->isPerGameSettings() && AutoUpdaterDialog::isSupported())
 	{
 		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.autoUpdateEnabled, "AutoUpdater", "CheckAtStartup", true);
 		dialog->registerWidgetHelp(m_ui.autoUpdateEnabled, tr("Enable Automatic Update Check"), tr("Checked"),
@@ -103,6 +103,16 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsDialog* dialog, QWidget
 #else
 	m_ui.discordPresence->setEnabled(false);
 #endif
+
+	if (dialog->isPerGameSettings())
+	{
+		// language/theme doesn't make sense to have in per-game settings
+		m_ui.verticalLayout->removeWidget(m_ui.preferencesGroup);
+		m_ui.preferencesGroup->hide();
+
+		// start paused doesn't make sense, because settings are applied after ELF load.
+		m_ui.pauseOnStart->setEnabled(false);
+	}
 
 	dialog->registerWidgetHelp(
 		m_ui.confirmShutdown, tr("Confirm Shutdown"), tr("Checked"),

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -140,7 +140,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="preferencesGroup">
      <property name="title">
       <string>Preferences</string>
      </property>

--- a/pcsx2-qt/Settings/SettingsDialog.cpp
+++ b/pcsx2-qt/Settings/SettingsDialog.cpp
@@ -77,21 +77,7 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 	m_ui.setupUi(this);
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-	// We don't include interface/game list/bios settings from per-game settings.
-	if (!isPerGameSettings())
-	{
-		addWidget(m_interface_settings = new InterfaceSettingsWidget(this, m_ui.settingsContainer), tr("Interface"),
-			QStringLiteral("settings-3-line"),
-			tr("<strong>Interface Settings</strong><hr>These options control how the software looks and behaves.<br><br>Mouse over an option for "
-			   "additional information."));
-		addWidget(m_game_list_settings = new GameListSettingsWidget(this, m_ui.settingsContainer), tr("Game List"),
-			QStringLiteral("folder-settings-line"),
-			tr("<strong>Game List Settings</strong><hr>The list above shows the directories which will be searched by PCSX2 to populate the game "
-			   "list. Search directories can be added, removed, and switched to recursive/non-recursive."));
-		addWidget(m_bios_settings = new BIOSSettingsWidget(this, m_ui.settingsContainer), tr("BIOS"), QStringLiteral("hard-drive-2-line"),
-			tr("<strong>BIOS Settings</strong><hr>Configure your BIOS here.<br><br>Mouse over an option for additional information."));
-	}
-	else
+	if (isPerGameSettings())
 	{
 		if (game)
 		{
@@ -100,6 +86,22 @@ void SettingsDialog::setupUi(const GameList::Entry* game)
 		}
 
 		m_ui.restoreDefaultsButton->setVisible(false);
+	}
+
+	addWidget(m_interface_settings = new InterfaceSettingsWidget(this, m_ui.settingsContainer), tr("Interface"),
+		QStringLiteral("settings-3-line"),
+		tr("<strong>Interface Settings</strong><hr>These options control how the software looks and behaves.<br><br>Mouse over an option for "
+		   "additional information."));
+
+	// We don't include game list/bios settings in per-game settings.
+	if (!isPerGameSettings())
+	{
+		addWidget(m_game_list_settings = new GameListSettingsWidget(this, m_ui.settingsContainer), tr("Game List"),
+			QStringLiteral("folder-settings-line"),
+			tr("<strong>Game List Settings</strong><hr>The list above shows the directories which will be searched by PCSX2 to populate the game "
+			   "list. Search directories can be added, removed, and switched to recursive/non-recursive."));
+		addWidget(m_bios_settings = new BIOSSettingsWidget(this, m_ui.settingsContainer), tr("BIOS"), QStringLiteral("hard-drive-2-line"),
+			tr("<strong>BIOS Settings</strong><hr>Configure your BIOS here.<br><br>Mouse over an option for additional information."));
 	}
 
 	// Common to both per-game and global settings.


### PR DESCRIPTION
### Description of Changes

See title.

### Rationale behind Changes

You might want to set some of these per-game.

### Suggested Testing Steps

Test setting interface options per-game. I've already tried render to separate window.
