### PR TITLE
GS: Drop to SW for CLUT draws

### DIFF
--- a/.github/workflows/scripts/lint/gamedb/lint.py
+++ b/.github/workflows/scripts/lint/gamedb/lint.py
@@ -62,6 +62,7 @@ allowed_gs_hw_fixes = [
     "texturePreloading",
     "deinterlace",
     "cpuSpriteRenderBW",
+    "cpuCLUTRender",
     "gpuPaletteConversion",
 ]
 gs_hw_fix_ranges = {
@@ -73,6 +74,7 @@ gs_hw_fix_ranges = {
     "roundSprite": (0, 2),
     "deinterlace": (0, 7),
     "cpuSpriteRenderBW": (1, 10),
+    "cpuCLUTRender": (1, 2),
     "gpuPaletteConversion": (0, 2),
 }
 allowed_speed_hacks = ["mvuFlagSpeedHack", "InstantVU1SpeedHack", "MTVUSpeedHack"]

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -920,6 +920,7 @@ SCAJ-20104:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     texturePreloading: 1 # Performs better than full.
+    cpuCLUTRender: 1 # Fixes sun occlusion.
 SCAJ-20105:
   name: "Armored Core - Nine breaker"
   region: "NTSC-Unk"
@@ -1095,6 +1096,7 @@ SCAJ-20136:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     texturePreloading: 1 # Performs better than full.
+    cpuCLUTRender: 1 # Fixes sun occlusion.
 SCAJ-20137:
   name: "Musashiden II - Blademaster"
   region: "NTSC-Unk"
@@ -1282,6 +1284,8 @@ SCAJ-20170:
 SCAJ-20171:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SCAJ-20172:
   name: "Final Fantasy XII"
   region: "NTSC-Unk"
@@ -2031,6 +2035,7 @@ SCED-52049:
   gsHWFixes:
     preloadFrameData: 1 # Fixes bad textures on Jake.
     halfPixelOffset: 1 # Fixes double image.
+    cpuCLUTRender: 1 # Fixes Jake going black in Smellovision.
 SCED-52051:
   name: "Official PlayStation 2 Magazine Demo 43"
   region: "PAL-M5"
@@ -2756,6 +2761,8 @@ SCES-50354:
     vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SCES-50360:
   name: "Twisted Metal - Black"
   region: "PAL-M5"
@@ -3139,6 +3146,7 @@ SCES-51248:
     roundSprite: 1 # Fix line in the sky.
     preloadFrameData: 1 # Fixes bad textures on Jake.
     halfPixelOffset: 1 # Fixes double image.
+    cpuCLUTRender: 1 # Fixes Jake going black in Smellovision.
 SCES-51426:
   name: "Getaway, The"
   region: "PAL-M5"
@@ -6696,6 +6704,7 @@ SCPS-56012:
   name: "Raw Danger"
   region: "NTSC-K"
   gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
     autoFlush: 1 # Fixes incorrect blur effect.
 SCPS-56013:
   name: "This is Football 2003"
@@ -8663,9 +8672,11 @@ SLAJ-25053:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLAJ-25055:
   name: "Def Jam - Fight for N.Y."
   region: "NTSC-Unk"
@@ -8697,9 +8708,11 @@ SLAJ-25066:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -8729,6 +8742,7 @@ SLAJ-25075:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -8773,6 +8787,8 @@ SLAJ-25079:
 SLAJ-25080:
   name: "Godfather, The"
   region: "NTSC-Unk"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLAJ-25081:
   name: "FIFA World Cup - Germany 2006"
   region: "NTSC-Unk"
@@ -8806,9 +8822,11 @@ SLAJ-25094:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLAJ-25095:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-Unk"
@@ -8942,6 +8960,8 @@ SLED-52476:
 SLED-52485:
   name: "Alias [Demo]"
   region: "PAL-E"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes lights penetrating objects.
 SLED-52488:
   name: "Suffering, The [Demo]"
   region: "PAL-E"
@@ -8954,9 +8974,11 @@ SLED-52597:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLED-52875:
   name: "Sega Superstars [Demo]"
   region: "PAL-E"
@@ -9004,9 +9026,11 @@ SLED-53512:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
@@ -10588,6 +10612,7 @@ SLES-50731:
     vuClampMode: 2 # White textures.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes "Busted" scenes.
 SLES-50735:
   name: "Jade Cocoon 2"
   region: "PAL-E"
@@ -11749,6 +11774,8 @@ SLES-51229:
 SLES-51230:
   name: "Minority Report"
   region: "PAL-E"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light bleed through objects.
 SLES-51232:
   name: "Virtua Tennis 2"
   region: "PAL-M4"
@@ -11966,9 +11993,13 @@ SLES-51316:
 SLES-51317:
   name: "Minority Report"
   region: "PAL-F"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light bleed through objects.
 SLES-51318:
   name: "Minority Report"
   region: "PAL-G"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light bleed through objects.
 SLES-51322:
   name: "Robotech Battlecry"
   region: "PAL-M5"
@@ -12879,9 +12910,13 @@ SLES-51820:
 SLES-51821:
   name: "Alias"
   region: "PAL-M5"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes lights penetrating objects.
 SLES-51822:
   name: "Alias"
   region: "PAL-I"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes lights penetrating objects.
 SLES-51823:
   name: "Hunter - The Reckoning Wayward"
   region: "PAL-M3"
@@ -14514,9 +14549,11 @@ SLES-52584:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
@@ -14524,9 +14561,11 @@ SLES-52585:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLES-52587:
   name: "Army Men - Sarge's War"
   region: "PAL-M5"
@@ -16209,6 +16248,8 @@ SLES-53350:
   compat: 5
   roundModes:
     vuRoundMode: 0 # Prevents only backgrounds from appearing in Sonic R's multiplayer modes.
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colour in Sonic Fighters.
   memcardFilters: # Vectorman unlocks by having a Mega Collection or Heroes save.
     - "SLES-53350"
     - "SLES-52998"
@@ -16620,9 +16661,11 @@ SLES-53506:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -16637,9 +16680,11 @@ SLES-53507:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -16839,12 +16884,14 @@ SLES-53556:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLES-53557:
   name: "Need for Speed - Most Wanted"
   region: "PAL-E"
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters: # Reads Underground 2 save for extra money.
     - "SLES-53557"
     - "SLES-53558"
@@ -16856,6 +16903,7 @@ SLES-53558:
   region: "PAL-M8"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -16867,6 +16915,7 @@ SLES-53559:
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -16992,6 +17041,7 @@ SLES-53616:
     cpuSpriteRenderBW: 1 # Fixes textures.
     preloadFrameData: 1 # Fixes static text screens.
     roundSprite: 1 # Fixes lines in some post-effects.
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLES-53617:
   name: "True Crime - New York City"
   region: "PAL-G"
@@ -17003,6 +17053,7 @@ SLES-53617:
     cpuSpriteRenderBW: 1 # Fixes textures.
     preloadFrameData: 1 # Fixes static text screens.
     roundSprite: 1 # Fixes lines in some post-effects.
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLES-53618:
   name: "True Crime - New York City"
   region: "PAL-S"
@@ -17014,6 +17065,7 @@ SLES-53618:
     cpuSpriteRenderBW: 1 # Fixes textures.
     preloadFrameData: 1 # Fixes static text screens.
     roundSprite: 1 # Fixes lines in some post-effects.
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLES-53621:
   name: "Wallace & Gromit - The Curse of the Were-Rabbit"
   region: "PAL-M5"
@@ -17633,6 +17685,7 @@ SLES-53857:
   region: "PAL-M3"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -17861,6 +17914,8 @@ SLES-53966:
 SLES-53967:
   name: "Godfather, The"
   region: "PAL-M6"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLES-53968:
   name: "Parrain, Le"
   region: "PAL-F"
@@ -18025,6 +18080,7 @@ SLES-54027:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLES-54030:
   name: "Black"
   region: "PAL-E"
@@ -19328,6 +19384,8 @@ SLES-54586:
 SLES-54587:
   name: "Raw Danger"
   region: "PAL-E"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SLES-54588:
   name: "Brunswick Pro Bowling"
   region: "PAL-E"
@@ -19412,9 +19470,11 @@ SLES-54627:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLES-54628:
   name: "Skate Attack [Promo]"
   region: "PAL-E"
@@ -19581,9 +19641,11 @@ SLES-54681:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLES-54683:
   name: "Medal of Honor - Vanguard"
   region: "PAL-M9"
@@ -20377,6 +20439,9 @@ SLES-54991:
 SLES-54992:
   name: "PDC World Championship Darts 2008"
   region: "PAL-M6"
+  gsHWFixes:
+    autoFlush: 1 # Fixes lights not appearing.
+    cpuCLUTRender: 1 # Fixes lights going through darts players.
 SLES-54994:
   name: "Pippa Funnell - Ranch Rescue"
   region: "PAL-M11"
@@ -22677,9 +22742,11 @@ SLKA-25206:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLKA-25207:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild"
   region: "NTSC-K"
@@ -22941,9 +23008,11 @@ SLKA-25304:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLKA-25307:
   name: "Dragon Ball Z Sparking"
   region: "NTSC-K"
@@ -23031,6 +23100,7 @@ SLKA-25334:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLKA-25335:
   name: "Shadow the Hedgehog"
   region: "NTSC-K"
@@ -23043,6 +23113,7 @@ SLKA-25341:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLKA-25342:
   name: "Ryu ga Gotoku"
   region: "NTSC-K"
@@ -23224,9 +23295,11 @@ SLPM-55004:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-55005:
   name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
@@ -23261,9 +23334,11 @@ SLPM-55036:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-55039:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3 [Limited Edition]"
   region: "NTSC-J"
@@ -23754,6 +23829,8 @@ SLPM-60138:
     vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPM-60167:
   name: "Zero [Trial]"
   region: "NTSC-J"
@@ -23803,9 +23880,11 @@ SLPM-60246:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-60251:
   name: "Devil May Cry 3 [Trial Version]"
   region: "NTSC-J"
@@ -23817,6 +23896,8 @@ SLPM-60251:
 SLPM-60254:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial A]"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SLPM-60256:
   name: "Dengeki D73 demo"
   region: "NTSC-J"
@@ -23863,6 +23944,8 @@ SLPM-60272:
 SLPM-60273:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku-tachi [Trial B]"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SLPM-60274:
   name: "Full House Kiss 2 [Trial]"
   region: "NTSC-J"
@@ -23913,6 +23996,8 @@ SLPM-61039:
 SLPM-61046:
   name: "Dennou Senki - Virtual-On Marz [Trial]"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-61051:
   name: "Dengeki PS2 D61"
   region: "NTSC-J"
@@ -25421,6 +25506,8 @@ SLPM-62547:
   name: "Sega Ages 2500 Series Vol.16 - Virtua Fighter 2"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62548:
   name: "Heisei Bakutoden [SuperLite 2000 Series]"
   region: "NTSC-J"
@@ -25601,6 +25688,8 @@ SLPM-62606:
   name: "Sega Ages 2500 Series Vol.19 - Fighting Vipers"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62607:
   name: "Shikigami no Shiro III [Taito The Best]"
   region: "NTSC-J"
@@ -25834,6 +25923,8 @@ SLPM-62686:
 SLPM-62687:
   name: "Sega Ages 2500 Series Vol.24 - Last Bronx"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62689:
   name: "Langrisser III"
   region: "NTSC-J"
@@ -25881,6 +25972,8 @@ SLPM-62703:
   name: "Sega Rally Championship '95"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-62704:
   name: "Oretachi Geasen Zoku Sono Vol.10 - Quarth"
   region: "NTSC-J"
@@ -27188,6 +27281,8 @@ SLPM-65302:
 SLPM-65303:
   name: "Dennou Senki - Virtual-On Marz"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPM-65305:
   name: "Genso Suikoden 3"
   region: "NTSC-J"
@@ -28502,9 +28597,11 @@ SLPM-65719:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-65720:
   name: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
@@ -28934,7 +29031,7 @@ SLPM-65843:
   name: "120 Yen no Haru - 120 Yen Stories"
   region: "NTSC-J"
   gsHWFixes:
-    pointListPalette: 1
+    cpuCLUTRender: 1 # Fixes CLUT generation.
 SLPM-65844:
   name: "Air [Best]"
   region: "NTSC-J"
@@ -29312,9 +29409,11 @@ SLPM-65958:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-65959:
   name: "Standard Daisenryaku - Ushinawareta Shouri"
   region: "NTSC-J"
@@ -29437,6 +29536,7 @@ SLPM-65995:
   gsHWFixes:
     preloadFrameData: 1 # Fixes bad textures on Jake.
     halfPixelOffset: 1 # Fixes double image.
+    cpuCLUTRender: 1 # Fixes Jake going black in Smellovision.
 SLPM-65996:
   name: "Hametsu no Mars [Limited Edition]"
   region: "NTSC-J"
@@ -29702,6 +29802,8 @@ SLPM-66074:
   compat: 5
   roundModes:
     vuRoundMode: 0 # Prevents only backgrounds from appearing in Sonic R's multiplayer modes.
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colour in Sonic Fighters.
   memcardFilters:
     - "SLPM-66074"
     - "SLPM-65758"
@@ -29827,9 +29929,11 @@ SLPM-66108:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -30290,6 +30394,7 @@ SLPM-66232:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -31161,6 +31266,7 @@ SLPM-66473:
     cpuSpriteRenderBW: 1 # Fixes textures.
     preloadFrameData: 1 # Fixes static text screens.
     roundSprite: 1 # Fixes lines in some post-effects.
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLPM-66474:
   name: "Odin Sphere"
   region: "NTSC-J"
@@ -31470,6 +31576,7 @@ SLPM-66562:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -31503,6 +31610,7 @@ SLPM-66567:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLPM-66568:
   name: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
@@ -31802,9 +31910,11 @@ SLPM-66652:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -32053,6 +32163,8 @@ SLPM-66709:
 SLPM-66710:
   name: "Godfather, The"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLPM-66712:
   name: "Rozen Maiden - Geppetto Garden [Limited Edition]"
   region: "NTSC-J"
@@ -32169,9 +32281,11 @@ SLPM-66739:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-66740:
   name: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
@@ -32884,9 +32998,11 @@ SLPM-66962:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLPM-66963:
   name: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
@@ -32900,6 +33016,8 @@ SLPM-66965:
 SLPM-66966:
   name: "Godfather, The [EA-SY! 1980]"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLPM-66967:
   name: "Aria - The Natural - Tooi Yume no Mirage [Alchemist Best Collection]"
   region: "NTSC-J"
@@ -33148,6 +33266,7 @@ SLPM-67527:
     vuClampMode: 2 # White textures.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes "Busted" scenes.
 SLPM-67528:
   name: "Hajime no Ippo - Victorious Boxers [Championship Edition]"
   region: "NTSC-K"
@@ -33438,6 +33557,7 @@ SLPM-74243:
     cpuSpriteRenderBW: 1 # Fixes textures.
     preloadFrameData: 1 # Fixes static text screens.
     roundSprite: 1 # Fixes lines in some post-effects.
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLPM-74244:
   name: "Phantasy Star Universe [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -33587,6 +33707,8 @@ SLPM-74420:
 SLPM-74421:
   name: "Dennou Senki - Virtual-On Marz [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 2 # Fixes CLUT colours.
 SLPS-20001:
   name: "Ridge Racer V"
   region: "NTSC-J"
@@ -35027,6 +35149,8 @@ SLPS-25033:
     vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPS-25034:
   name: "Flower, Sun and Rain"
   region: "NTSC-J"
@@ -36356,6 +36480,7 @@ SLPS-25418:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     texturePreloading: 1 # Performs better than full.
+    cpuCLUTRender: 1 # Fixes sun occlusion.
   patches:
     86089F31:
       content: |-
@@ -37003,6 +37128,8 @@ SLPS-25606:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioutachi"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SLPS-25607:
   name: "Makai Senki Disgaea 2 [Limited Edition]"
   region: "NTSC-J"
@@ -37913,6 +38040,8 @@ SLPS-25850:
 SLPS-25851:
   name: "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi [Irem Collection]"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SLPS-25852:
   name: "Sanyo Pachinko Paradise 13 [Irem Collection]"
   region: "NTSC-J"
@@ -38407,6 +38536,7 @@ SLPS-73218:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     texturePreloading: 1 # Performs better than full.
+    cpuCLUTRender: 1 # Fixes sun occlusion.
 SLPS-73219:
   name: "Tales of Destiny 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -38707,6 +38837,8 @@ SLPS-73404:
     vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPS-73405:
   name: "Zero [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -39324,6 +39456,8 @@ SLUS-20151:
     vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLUS-20152:
   name: "Ace Combat 04 - Shattered Skies"
   region: "NTSC-U"
@@ -40097,6 +40231,8 @@ SLUS-20331:
   name: "Minority Report - Everybody Runs"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light bleed through objects.
 SLUS-20332:
   name: "NCAA March Madness 2002"
   region: "NTSC-U"
@@ -40220,6 +40356,7 @@ SLUS-20362:
     vuClampMode: 2 # White textures.
   gsHWFixes:
     halfPixelOffset: 1 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes "Busted" scenes.
 SLUS-20363:
   name: "Sled Storm"
   region: "NTSC-U"
@@ -41677,6 +41814,8 @@ SLUS-20673:
   name: "Alias"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes lights penetrating objects.
 SLUS-20674:
   name: "Cyber Troopers - Virtual-On Marz"
   region: "NTSC-U"
@@ -42472,6 +42611,7 @@ SLUS-20851:
     alignSprite: 1 # Fixes vertical lines.
     mergeSprite: 1 # Fixes vertical lines.
     texturePreloading: 1 # Performs better than full.
+    cpuCLUTRender: 1 # Fixes sun occlusion.
   patches:
     39B574F0:
       content: |-
@@ -43358,7 +43498,8 @@ SLUS-21018:
     vuClampMode: 3 # Fixes minor SPS on characters.
   gsHWFixes:
     preloadFrameData: 1 # Fixes bad textures on Jake.
-    halfPixelOffset: 1 # Fixes double image.
+    halfPixelOffset: 1 # Fixes double image.gsHWFixes:
+    cpuCLUTRender: 1 # Fixes Jake going black in Smellovision.
 SLUS-21019:
   name: "Technic Beat"
   region: "NTSC-U"
@@ -43528,9 +43669,11 @@ SLUS-21050:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLUS-21051:
   name: "FIFA 2005"
   region: "NTSC-U"
@@ -43783,6 +43926,7 @@ SLUS-21106:
     cpuSpriteRenderBW: 1 # Fixes textures.
     preloadFrameData: 1 # Fixes static text screens.
     roundSprite: 1 # Fixes lines in some post-effects.
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLUS-21107:
   name: "X-Men - The Official Game"
   region: "NTSC-U"
@@ -44478,9 +44622,11 @@ SLUS-21242:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
     - "SLUS-21242"
     - "SLUS-21050"
@@ -44631,6 +44777,7 @@ SLUS-21267:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -44665,6 +44812,7 @@ SLUS-21271:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLUS-21272:
   name: "Super Monkey Ball Adventure"
   region: "NTSC-U"
@@ -45098,6 +45246,7 @@ SLUS-21351:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -45314,6 +45463,8 @@ SLUS-21385:
   name: "Godfather, The"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLUS-21386:
   name: "Tales of the Abyss"
   region: "NTSC-U"
@@ -45391,6 +45542,7 @@ SLUS-21399:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLUS-21400:
   name: "Monster House"
   region: "NTSC-U"
@@ -45422,6 +45574,8 @@ SLUS-21407:
   compat: 5
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes light occlusion.
 SLUS-21408:
   name: "FIFA World Cup Germany '06"
   region: "NTSC-U"
@@ -45934,6 +46088,8 @@ SLUS-21501:
   name: "Raw Danger"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes some shading/shadows.
 SLUS-21503:
   name: "God Hand"
   region: "NTSC-U"
@@ -46214,9 +46370,11 @@ SLUS-21596:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLUS-21597:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-U"
@@ -47064,6 +47222,9 @@ SLUS-21773:
   name: "PDC World Championship Darts 2008"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    autoFlush: 1 # Fixes lights not appearing.
+    cpuCLUTRender: 1 # Fixes lights going through darts players.
 SLUS-21774:
   name: "Dynasty Warriors 6"
   region: "NTSC-U"
@@ -47342,6 +47503,8 @@ SLUS-21843:
   compat: 5
   roundModes:
     vuRoundMode: 0 # Crashes without.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes bad colours during play.
 SLUS-21844:
   name: "Bolt"
   region: "NTSC-U"
@@ -47811,6 +47974,8 @@ SLUS-28004:
     vuClampMode: 2 # Fixes water reflection.
   gameFixes:
     - EETimingHack # Fixes flickering graphics.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLUS-28006:
   name: "Burnout [Trade Demo]"
   region: "NTSC-U"
@@ -48298,9 +48463,11 @@ SLUS-29113:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -48404,9 +48571,11 @@ SLUS-29153:
     vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
-    autoFlush: 1 # Fixes blur.
+    autoFlush: 1 # Fixes blur and obscures sun behind objects.
+    preloadFrameData: 1 # Makes sun appear.
     mipmap: 2 # Fixes over sharpening.
     trilinearFiltering: 1 # Smoothes out mipmapping.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLUS-29154:
   name: "NHL '06 [Demo]"
   region: "NTSC-U"
@@ -48415,6 +48584,7 @@ SLUS-29155:
   region: "NTSC-U"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
+    cpuCLUTRender: 1 # Fixes sun penetrating bridges (along with HPO special).
 SLUS-29156:
   name: "Marvel Nemesis - Rise of the Imperfects [Demo]"
   region: "NTSC-U"
@@ -48511,6 +48681,7 @@ SLUS-29185:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 2 # Fixes some bad textures.
+    cpuCLUTRender: 1 # Fixes the rest of the bad textures.
 SLUS-29188:
   name: "Steambot Chronicles [Regular Demo]"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16837,6 +16837,8 @@ SLES-53556:
   region: "PAL-M3"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLES-53557:
   name: "Need for Speed - Most Wanted"
   region: "PAL-E"
@@ -18021,6 +18023,8 @@ SLES-54027:
   region: "PAL-M3"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLES-54030:
   name: "Black"
   region: "PAL-E"
@@ -23037,6 +23041,8 @@ SLKA-25341:
   region: "NTSC-K"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLKA-25342:
   name: "Ryu ga Gotoku"
   region: "NTSC-K"
@@ -31495,6 +31501,8 @@ SLPM-66567:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLPM-66568:
   name: "Brothers In Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
@@ -44655,6 +44663,8 @@ SLUS-21271:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLUS-21272:
   name: "Super Monkey Ball Adventure"
   region: "NTSC-U"
@@ -45379,6 +45389,8 @@ SLUS-21399:
   region: "NTSC-U"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLUS-21400:
   name: "Monster House"
   region: "NTSC-U"
@@ -48497,6 +48509,8 @@ SLUS-29185:
   region: "NTSC-U"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  gsHWFixes:
+    cpuSpriteRenderBW: 2 # Fixes some bad textures.
 SLUS-29188:
   name: "Steambot Chronicles [Regular Demo]"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -236,6 +236,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.halfScreenFix, "EmuCore/GS", "UserHacks_Half_Bottom_Override", -1, -1);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuSpriteRenderBW, "EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.cpuCLUTRender, "EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawStart, "EmuCore/GS", "UserHacks_SkipDraw_Start", 0);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.skipDrawEnd, "EmuCore/GS", "UserHacks_SkipDraw_End", 0);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hwAutoFlush, "EmuCore/GS", "UserHacks_AutoFlush", false);
@@ -335,6 +336,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsDialog* dialog, QWidget* 
 	{
 		m_ui.upscalingFixesLayout->removeRow(2);
 		m_ui.hardwareFixesLayout->removeRow(2);
+		m_ui.hardwareFixesLayout->removeRow(1);
 		m_ui.skipDrawStart = nullptr;
 		m_ui.skipDrawEnd = nullptr;
 		m_ui.textureOffsetX = nullptr;

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -58,7 +58,7 @@
    <item>
     <widget class="QTabWidget" name="hardwareRendererGroup">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>
@@ -388,7 +388,7 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QComboBox" name="upscaleMultiplier" />
+        <widget class="QComboBox" name="upscaleMultiplier"/>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label_6">
@@ -692,91 +692,6 @@
          </item>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Skipdraw Range:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QSpinBox" name="skipDrawStart">
-           <property name="maximum">
-            <number>10000</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="skipDrawEnd">
-           <property name="maximum">
-            <number>10000</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="hwAutoFlush">
-           <property name="text">
-            <string>Auto Flush</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="frameBufferConversion">
-           <property name="text">
-            <string>Frame Buffer Conversion</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="disableDepthEmulation">
-           <property name="text">
-            <string>Disable Depth Emulation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="memoryWrapping">
-           <property name="text">
-            <string>Memory Wrapping</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="disableSafeFeatures">
-           <property name="text">
-            <string>Disable Safe Features</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="preloadFrameData">
-           <property name="text">
-            <string>Preload Frame Data</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="disablePartialInvalidation">
-           <property name="text">
-            <string>Disable Partial Invalidation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QCheckBox" name="textureInsideRt">
-           <property name="text">
-            <string>Texture Inside RT</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label_36">
          <property name="text">
@@ -841,6 +756,123 @@
            <string>10 (640 Max Width)</string>
           </property>
          </item>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Skipdraw Range:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QSpinBox" name="skipDrawStart">
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="skipDrawEnd">
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="hwAutoFlush">
+           <property name="text">
+            <string>Auto Flush</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="frameBufferConversion">
+           <property name="text">
+            <string>Frame Buffer Conversion</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="disableDepthEmulation">
+           <property name="text">
+            <string>Disable Depth Emulation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="memoryWrapping">
+           <property name="text">
+            <string>Memory Wrapping</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="disableSafeFeatures">
+           <property name="text">
+            <string>Disable Safe Features</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="preloadFrameData">
+           <property name="text">
+            <string>Preload Frame Data</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="disablePartialInvalidation">
+           <property name="text">
+            <string>Disable Partial Invalidation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="textureInsideRt">
+           <property name="text">
+            <string>Texture Inside RT</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="cpuCLUTRender">
+         <property name="currentText">
+          <string extracomment="0 (Disabled)">0 (Disabled)</string>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>0 (Disabled)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>1 (Normal)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>2 (Aggressive)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>Software CLUT Render</string>
+         </property>
         </widget>
        </item>
       </layout>
@@ -1537,6 +1569,13 @@
        <string>Rendering</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_37">
+         <property name="text">
+          <string>Texture Filtering:</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="1">
         <widget class="QComboBox" name="swTextureFiltering">
          <property name="enabled">
@@ -1573,10 +1612,10 @@
          </item>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_37">
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_9">
          <property name="text">
-          <string>Texture Filtering:</string>
+          <string>Extra Rendering Threads:</string>
          </property>
         </widget>
        </item>
@@ -1584,13 +1623,6 @@
         <widget class="QSpinBox" name="extraSWThreads">
          <property name="suffix">
           <string> threads</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="text">
-          <string>Extra Rendering Threads:</string>
          </property>
         </widget>
        </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -585,6 +585,7 @@ struct Pcsx2Config
 		int UserHacks_TCOffsetX{0};
 		int UserHacks_TCOffsetY{0};
 		int UserHacks_CPUSpriteRenderBW{0};
+		int UserHacks_CPUCLUTRender{ 0 };
 		TriFiltering TriFilter{TriFiltering::Automatic};
 		int OverrideTextureBarriers{-1};
 		int OverrideGeometryShaders{-1};

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -2683,6 +2683,7 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 			static constexpr const char* s_cpu_sprite_render_bw_options[] = {"0 (Disabled)", "1 (64 Max Width)", "2 (128 Max Width)",
 				"3 (192 Max Width)", "4 (256 Max Width)", "5 (320 Max Width)", "6 (384 Max Width)", "7 (448 Max Width)",
 				"8 (512 Max Width)", "9 (576 Max Width)", "10 (640 Max Width)"};
+			static constexpr const char* s_cpu_clut_render_options[] = { "0 (Disabled)", "1 (Normal)", "2 (Aggressive)" };
 			static constexpr const char* s_half_pixel_offset_options[] = {
 				"Off (Default)", "Normal (Vertex)", "Special (Texture)", "Special (Texture - Aggressive)"};
 			static constexpr const char* s_round_sprite_options[] = {"Off (Default)", "Half", "Full"};
@@ -2691,6 +2692,8 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 				"UserHacks_Half_Bottom_Override", -1, s_generic_options, std::size(s_generic_options), -1);
 			DrawIntListSetting(bsi, "CPU Sprite Render Size", "Uses sofware renderer to draw texture decompression-like sprites.",
 				"EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0, s_cpu_sprite_render_bw_options, std::size(s_cpu_sprite_render_bw_options));
+			DrawIntListSetting(bsi, "CPU Sprite Render Size", "Uses sofware renderer to draw texture decompression-like sprites.",
+				"EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0, s_cpu_clut_render_options, std::size(s_cpu_clut_render_options));
 			DrawIntRangeSetting(
 				bsi, "Skip Draw Start", "Object range to skip drawing.", "EmuCore/GS", "UserHacks_SkipDraw_Start", 0, 0, 5000);
 			DrawIntRangeSetting(bsi, "Skip Draw End", "Object range to skip drawing.", "EmuCore/GS", "UserHacks_SkipDraw_End", 0, 0, 5000);

--- a/pcsx2/Frontend/ImGuiOverlays.cpp
+++ b/pcsx2/Frontend/ImGuiOverlays.cpp
@@ -309,6 +309,8 @@ void ImGuiManager::DrawSettingsOverlay()
 			APPEND("TCO={}/{} ", GSConfig.UserHacks_TCOffsetX, GSConfig.UserHacks_TCOffsetY);
 		if (GSConfig.UserHacks_CPUSpriteRenderBW != 0)
 			APPEND("CSBW={} ", GSConfig.UserHacks_CPUSpriteRenderBW);
+		if (GSConfig.UserHacks_CPUCLUTRender != 0)
+			APPEND("CCD={} ", GSConfig.UserHacks_CPUCLUTRender);
 		if (GSConfig.SkipDrawStart != 0 || GSConfig.SkipDrawEnd != 0)
 			APPEND("SD={}/{} ", GSConfig.SkipDrawStart, GSConfig.SkipDrawEnd);
 		if (GSConfig.UserHacks_TextureInsideRt)

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -834,7 +834,8 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		GSConfig.UserHacks_DisableDepthSupport != old_config.UserHacks_DisableDepthSupport ||
 		GSConfig.UserHacks_DisablePartialInvalidation != old_config.UserHacks_DisablePartialInvalidation ||
 		GSConfig.UserHacks_TextureInsideRt != old_config.UserHacks_TextureInsideRt ||
-		GSConfig.UserHacks_CPUSpriteRenderBW != old_config.UserHacks_CPUSpriteRenderBW)
+		GSConfig.UserHacks_CPUSpriteRenderBW != old_config.UserHacks_CPUSpriteRenderBW ||
+		GSConfig.UserHacks_CPUSpriteRenderBW != old_config.UserHacks_CPUCLUTRender)
 	{
 		g_gs_renderer->PurgeTextureCache();
 		g_gs_renderer->PurgePool();
@@ -1512,6 +1513,7 @@ void GSApp::Init()
 	m_default_configuration["UserHacks_Disable_Safe_Features"]            = "0";
 	m_default_configuration["UserHacks_DisablePartialInvalidation"]       = "0";
 	m_default_configuration["UserHacks_CPUSpriteRenderBW"]                = "0";
+	m_default_configuration["UserHacks_CPUCLUTRender"]                    = "0";
 	m_default_configuration["UserHacks_CPU_FB_Conversion"]                = "0";
 	m_default_configuration["UserHacks_Half_Bottom_Override"]             = "-1";
 	m_default_configuration["UserHacks_HalfPixelOffset"]                  = "0";

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -28,7 +28,7 @@ GSClut::GSClut(GSLocalMemory* mem)
 	m_clut = (u16*)&p[0];      // 1k + 1k for mirrored area simulating wrapping memory
 	m_buff32 = (u32*)&p[2048]; // 1k
 	m_buff64 = (u64*)&p[4096]; // 2k
-	m_write.dirty = true;
+	m_write.dirty = 1;
 	m_read.dirty = true;
 
 	for (int i = 0; i < 16; i++)
@@ -103,34 +103,35 @@ GSClut::~GSClut()
 	vmfree(m_clut, CLUT_ALLOC_SIZE);
 }
 
-void GSClut::Invalidate()
+u8 GSClut::IsInvalid()
 {
-	m_write.dirty = true;
+	return m_write.dirty;
 }
 
-void GSClut::InvalidateRange(u32 start_block, u32 end_block)
+u32 GSClut::GetCLUTCBP()
 {
-	u32 blocks = 4;
-
-	if (GSLocalMemory::m_psm[m_write.TEX0.CPSM].bpp == 16)
-		blocks >>= 1;
-
-	if (GSLocalMemory::m_psm[m_write.TEX0.PSM].bpp == 4)
-		blocks >>= 1;
-
-	if ((m_write.TEX0.CBP + blocks) >= start_block && m_write.TEX0.CBP <= end_block)
-	{
-		m_write.dirty = true;
-	}
+	return m_write.TEX0.CBP;
 }
 
-// Check the whole page, if the CLUT is slightly offset from a page boundary it could miss it.
-void GSClut::Invalidate(u32 block)
+void GSClut::SetNextCLUTTEX0(u64 TEX0)
 {
-	if (!((block ^ m_write.TEX0.CBP) & ~0x1F))
+	m_write.next_tex0 = TEX0;
+}
+
+bool GSClut::InvalidateRange(u32 start_block, u32 end_block, bool is_draw)
+{
+	if (m_write.dirty)
+		return m_write.dirty;
+
+	GIFRegTEX0 next_cbp;
+	next_cbp.U64 = m_write.next_tex0;
+
+	if ((next_cbp.CBP + 3) >= start_block && end_block >= next_cbp.CBP)
 	{
-		m_write.dirty = true;
+		m_write.dirty |= is_draw ? 2 : 1;
 	}
+
+	return m_write.dirty;
 }
 
 bool GSClut::WriteTest(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
@@ -163,14 +164,14 @@ bool GSClut::WriteTest(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 			m_CBP[1] = TEX0.CBP;
 			break;
 		case 6:
-			return false; // ffx2 menu
+			return false; // ffx2 menu.
 		case 7:
-			return false; // ford mustang racing // Bouken Jidai Katsugeki Goemon
+			return false; // ford mustang racing // Bouken Jidai Katsugeki Goemon.
 		default:
 			__assume(0);
 	}
 
-	// CLUT only reloads if PSM is a valid index type, avoid unnecessary flushes
+	// CLUT only reloads if PSM is a valid index type, avoid unnecessary flushes.
 	return m_write.IsDirty(TEX0, TEXCLUT);
 }
 
@@ -179,7 +180,7 @@ void GSClut::Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT)
 	m_write.TEX0 = TEX0;
 	m_write.TEXCLUT = TEXCLUT;
 	m_read.dirty = true;
-	m_write.dirty = false;
+	m_write.dirty = 0;
 
 	(this->*m_wc[TEX0.CSM][TEX0.CPSM][TEX0.PSM])(TEX0, TEXCLUT);
 }
@@ -775,7 +776,7 @@ bool GSClut::WriteState::IsDirty(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TE
 
 	bool is_dirty = dirty;
 
-	if (((this->TEX0.U64 ^ TEX0.U64) & mask) || (GSLocalMemory::m_psm[this->TEX0.PSM].bpp != GSLocalMemory::m_psm[TEX0.PSM].bpp))
+	if (((this->TEX0.U64 ^ TEX0.U64) & mask) || (GSLocalMemory::m_psm[this->TEX0.PSM].pal != GSLocalMemory::m_psm[TEX0.PSM].pal))
 		is_dirty |= true;
 	else if (TEX0.CSM == 1 && (TEXCLUT.U32[0] ^ this->TEXCLUT.U32[0]))
 		is_dirty |= true;
@@ -795,7 +796,7 @@ bool GSClut::ReadState::IsDirty(const GIFRegTEX0& TEX0)
 
 	bool is_dirty = dirty;
 
-	if (((this->TEX0.U64 ^ TEX0.U64) & mask) || (GSLocalMemory::m_psm[this->TEX0.PSM].bpp != GSLocalMemory::m_psm[TEX0.PSM].bpp))
+	if (((this->TEX0.U64 ^ TEX0.U64) & mask) || (GSLocalMemory::m_psm[this->TEX0.PSM].pal != GSLocalMemory::m_psm[TEX0.PSM].pal))
 		is_dirty |= true;
 
 	if (!is_dirty)
@@ -814,7 +815,7 @@ bool GSClut::ReadState::IsDirty(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA)
 
 	bool is_dirty = dirty;
 
-	if (((this->TEX0.U64 ^ TEX0.U64) & tex0_mask) || (GSLocalMemory::m_psm[this->TEX0.PSM].bpp != GSLocalMemory::m_psm[TEX0.PSM].bpp))
+	if (((this->TEX0.U64 ^ TEX0.U64) & tex0_mask) || (GSLocalMemory::m_psm[this->TEX0.PSM].pal != GSLocalMemory::m_psm[TEX0.PSM].pal))
 		is_dirty |= true;
 	else // Just to optimise the checks.
 	{

--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -39,7 +39,8 @@ class alignas(32) GSClut : public GSAlignedClass<32>
 	{
 		GIFRegTEX0 TEX0;
 		GIFRegTEXCLUT TEXCLUT;
-		bool dirty;
+		u8 dirty;
+		u64 next_tex0;
 		bool IsDirty(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT);
 	} m_write;
 
@@ -100,9 +101,10 @@ public:
 	GSClut(GSLocalMemory* mem);
 	virtual ~GSClut();
 
-	void Invalidate();
-	void Invalidate(u32 block);
-	void InvalidateRange(u32 start_block, u32 end_block);
+	bool InvalidateRange(u32 start_block, u32 end_block, bool is_draw = false);
+	u8 IsInvalid();
+	u32 GetCLUTCBP();
+	void SetNextCLUTTEX0(u64 CBP);
 	bool WriteTest(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT);
 	void Write(const GIFRegTEX0& TEX0, const GIFRegTEXCLUT& TEXCLUT);
 	//void Read(const GIFRegTEX0& TEX0);

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -444,6 +444,7 @@ public:
 	typedef u32 (GSLocalMemory::*readTexel)(int x, int y, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA) const;
 	typedef void (GSLocalMemory::*writePixelAddr)(u32 addr, u32 c);
 	typedef void (GSLocalMemory::*writeFrameAddr)(u32 addr, u32 c);
+	typedef u32(GSLocalMemory::*PixelAddr)(int x, int y, u32 bp, u32 bw) const;
 	typedef u32 (GSLocalMemory::*readPixelAddr)(u32 addr) const;
 	typedef u32 (GSLocalMemory::*readTexelAddr)(u32 addr, const GIFRegTEXA& TEXA) const;
 	typedef void (GSLocalMemory::*writeImage)(int& tx, int& ty, const u8* src, int len, GIFRegBITBLTBUF& BITBLTBUF, GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG);
@@ -530,17 +531,6 @@ public:
 	GSPixelOffset* GetPixelOffset(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
-
-	static u32 GetEndBlock(int bp, int bw, int w, int h, int psm)
-	{
-		const GSLocalMemory::psm_t& dpsm = GSLocalMemory::m_psm[psm];
-		const int page_width = std::max(1, w / dpsm.pgs.x);
-		const int page_height = std::max(1, h / dpsm.pgs.y);
-		const int pitch = (std::max(1, bw) * 64) / dpsm.pgs.x;
-		const u32 end_bp = bp + ((((page_height % dpsm.pgs.y) != 0) ? (page_width << 5) : 0) + ((page_height * pitch) << 5));
-
-		return end_bp;
-	}
 
 	// address
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -186,6 +186,7 @@ protected:
 	void GrowVertexBuffer();
 	bool IsAutoFlushDraw();
 	void HandleAutoFlush();
+	void CLUTAutoFlush();
 
 	template <u32 prim, bool auto_flush, bool index_swap>
 	void VertexKick(u32 skip);
@@ -228,6 +229,7 @@ public:
 	GSDrawingEnvironment m_env;
 	GSDrawingEnvironment m_backup_env;
 	GSDrawingEnvironment m_prev_env;
+	GSVector4i temp_draw_rect;
 	GSDrawingContext* m_context;
 	u32 m_crc;
 	CRC::Game m_game;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -127,6 +127,8 @@ private:
 	void SwSpriteRender();
 	bool CanUseSwSpriteRender();
 
+	bool PossibleCLUTDraw();
+	bool PossibleCLUTDrawAggressive();
 	bool CanUseSwPrimRender(bool no_rt, bool no_ds, bool draw_sprite_tex);
 	bool SwPrimRender();
 

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -290,6 +290,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"texturePreloading",
 	"deinterlace",
 	"cpuSpriteRenderBW",
+	"cpuCLUTRender",
 	"gpuPaletteConversion",
 };
 static_assert(std::size(s_gs_hw_fix_names) == static_cast<u32>(GameDatabaseSchema::GSHWFixId::Count), "HW fix name lookup is correct size");
@@ -499,6 +500,9 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::CPUSpriteRenderBW:
 			return (config.UserHacks_CPUSpriteRenderBW == value);
 
+		case GSHWFixId::CPUCLUTRender:
+			return (config.UserHacks_CPUCLUTRender == value);
+
 		case GSHWFixId::GPUPaletteConversion:
 			return (config.GPUPaletteConversion == ((value > 1) ? (config.TexturePreloading == TexturePreloadingLevel::Full) : (value != 0)));
 
@@ -642,6 +646,9 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 				config.UserHacks_CPUSpriteRenderBW = value;
 				break;
 
+			case GSHWFixId::CPUCLUTRender:
+				config.UserHacks_CPUCLUTRender = value;
+				break;
 
 			case GSHWFixId::GPUPaletteConversion:
 			{

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -82,6 +82,7 @@ namespace GameDatabaseSchema
 		TexturePreloading,
 		Deinterlace,
 		CPUSpriteRenderBW,
+		CPUCLUTRender,
 		GPUPaletteConversion,
 
 		Count

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -423,6 +423,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_TCOffsetX) &&
 		OpEqu(UserHacks_TCOffsetY) &&
 		OpEqu(UserHacks_CPUSpriteRenderBW) &&
+		OpEqu(UserHacks_CPUCLUTRender) &&
 		OpEqu(OverrideTextureBarriers) &&
 		OpEqu(OverrideGeometryShaders) &&
 
@@ -616,6 +617,7 @@ void Pcsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingIntEx(UserHacks_TCOffsetX, "UserHacks_TCOffsetX");
 	GSSettingIntEx(UserHacks_TCOffsetY, "UserHacks_TCOffsetY");
 	GSSettingIntEx(UserHacks_CPUSpriteRenderBW, "UserHacks_CPUSpriteRenderBW");
+	GSSettingIntEx(UserHacks_CPUCLUTRender, "UserHacks_CPUCLUTRender");
 	GSSettingIntEnumEx(TriFilter, "TriFilter");
 	GSSettingIntEx(OverrideTextureBarriers, "OverrideTextureBarriers");
 	GSSettingIntEx(OverrideGeometryShaders, "OverrideGeometryShaders");
@@ -663,6 +665,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;
 	UserHacks_CPUSpriteRenderBW = 0;
+	UserHacks_CPUCLUTRender = 0;
 	SkipDrawStart = 0;
 	SkipDrawEnd = 0;
 }


### PR DESCRIPTION
### Description of Changes
Tidy up some of the code.
Split out CLUT checks for drawing overwrite of the CBP (CLUT source address).
When drawing to the CLUT, use the sw renderer to do the heavy lifting

### Rationale behind Changes
Tidy code is happy code.
Old check for CLUT invalidation on draw wasn't really sufficient, now it checks more thoroughly.
Drawing the CLUT in hardware on the GPU, then invalidating the CLUT in GS memory and downloading it, thousands of times a frame in some cases, is slow and the HW renderer purposefully has a guard against this happening, but it breaks CLUT related stuff in the process, this forces those draws to be done in software so there's no issues arising from upscaling and there's no download required, so there's no huge performance loss.

### Suggested Testing Steps
Test stuff with lights showing through objects, bad colours, completely missing stuff. You will possibly need to change the new "CPU Clut Render" option in the HW fixes screen, but the below games have been added to the DB.

⚠️ NOTE: If you still experience light bleed, first check game fixes are enabled and hw manual fixes are disabled. If it's still broken, try lowering the upscale (though I think I've resolved this)⚠️ 

### Stuff this PR fixes

120-en no Haru: 120 Yen Stories - Broken sprite colours (actually had an alternative gamefix, but has been replaced)
Ace Combat 05 - Sun occlusion
Alias - Light occlusion (See-through lights)
Burnout 3/Dominator/Revenge - Sun occlusion
Cyber Troopers Virtual-On - Missing colours
Dog's Life - Jake going black when in smell-o-vision (maybe misdetection, but I'll take it)
Driver Parallel Lines - Car/People colours
Godfather, The - Light occlusion through walls. still need skipdraw 1 to remove post effect fail.
Guitar Hero Metallica - Bad colours during gameplay
Klonoa 2 - Pipe monster shadow, green platform transition effect, miscoloured enemies/objects
Minority Report - Light occlusion
PDC World Championship Darts 2008 - Light occlusion and overbright issues when Autoflush was enabled
Need For Speed Most Wanted - Sun occlusion
Fighting Vipers - Missing colours
Last Bronx - Missing colours
Sega Rally 95 - Missing colours (menu background requires disable depth)
Sonic Fighters - Missing colours
True Crime New York City - Light occlusion
Virtual Fighter 2 - Missing colours

Fixes #1860 (Ace Combat 05)
Fixes #5409 (Alias)
Fixes #883 (Burnout 3/Revenge/Dominator)
Fixes #451 (Driver - Parallel Lines)
Fixes #6105 (Fighting Vipers and other mentioned Sega Model 2 games)
Fixes #6723 (Klonoa 2 Platform transition)
Fixes #5200 (Klonoa 2 Shadow)
Fixes #6720 (Klonoa 2 Miscoloured enemies/objects)
~~Didn't solve #2942 (Hot Pursuit)~~
Fixes #3993 (NFS Most Wanted)

### Compairson shots

120-en no Haru: 120 Yen Stories:

Master (without CRC hack)
![image](https://user-images.githubusercontent.com/6278726/197365853-72536356-647d-4513-80e9-c94d22c46c78.png)

PR (without CRC hack)
![image](https://user-images.githubusercontent.com/6278726/197365857-a94ac5e4-632a-422d-aa81-39fd6babb1c1.png)

Ace Combat 05:

Master:
![image](https://user-images.githubusercontent.com/6278726/198246296-16517bed-9e5b-4bb7-9bb7-ee2942ec2c18.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/198246327-58ec89d5-06a3-4e62-baa8-4f63d2eda337.png)

Alias:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365864-929c5e71-561e-49ee-b23c-da87ff82e3ae.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197365872-2c9aefa1-8a3d-4f01-ae8c-3918a45f0fac.png)

Burnout 3:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365879-57f0e2de-b7fd-4b5c-9c49-080f70dda7c5.png)
![image](https://user-images.githubusercontent.com/6278726/197365890-fe4e57f0-2b57-4197-99a6-03f88acc672d.png)

PR (Requires Autoflush + Preload frame, possibly)
![image](https://user-images.githubusercontent.com/6278726/197365892-e8b57988-3212-4d1d-a49a-4d0c335f03ff.png)
![image](https://user-images.githubusercontent.com/6278726/197366044-77a889f1-d08f-4371-9699-67516b40ece7.png)

Cyber Troopers Virtual-On:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365972-497d28f3-bd32-4088-84cc-67c591616147.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197365973-99ea0393-282e-4aa1-9c95-92297d1b5e36.png)

Driver - Parallel Lines:

Master:
![image](https://user-images.githubusercontent.com/6278726/197665214-ef775e6b-b53e-47da-8cf6-1c6fbb2e1371.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197665239-aaf95b0a-bce4-47cf-975e-7213e44ae778.png)

Godfather, The:

Master:
![image](https://user-images.githubusercontent.com/6278726/198323404-a9fd4131-f46c-4c59-8e14-882a3f0af2ff.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/198323434-4106d764-9157-49e2-8e91-eca0ee5bc20e.png)

Klonoa 2:

Master:
![image](https://user-images.githubusercontent.com/6278726/198272305-42c0442d-9243-4ec0-96bd-9d2e16d745d7.png)
![image](https://user-images.githubusercontent.com/6278726/198272419-054c92aa-9751-4203-b595-2e67a59ee69c.png)
![image](https://user-images.githubusercontent.com/6278726/198272576-98dd5fcc-24fe-4dbe-a4fc-541a5b27d429.png)


PR:
![image](https://user-images.githubusercontent.com/6278726/198272320-2178fb72-110c-4361-ba56-d264b5f2e4e0.png)
![image](https://user-images.githubusercontent.com/6278726/198272478-0518b631-679f-4b0a-a56d-b667d17f422b.png)
![image](https://user-images.githubusercontent.com/6278726/198272644-713d70bf-d38c-4b13-aacc-3a71c1829587.png)

Minority Report:

Master:
![image](https://user-images.githubusercontent.com/6278726/197665064-c629743c-62f4-4e4a-80a0-501953ce044d.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197665090-454402c8-6ab5-4c3f-bd61-c1af57ffc6d5.png)

Need for Speed Most Wanted:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365913-105513cf-30a4-4d41-94c6-7da6d93c1ad4.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197365919-79fbbf5b-e77a-4513-be3e-a5fc22a56be2.png)

PDC World Championship Darts 2008:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365996-7e805874-45e4-44eb-9edb-3af4f099b7bf.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197660558-a002d00a-5629-4839-a7d9-338e04d81cbb.png)

Sega Rally 95:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365947-504d98ad-7e41-4747-8d05-b62fe3636d3f.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197365951-ee623ad4-fa1c-4039-98ae-ef7480886144.png)

Sonic Fighters:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365960-eb735199-c311-45af-9118-bfb314d0af0c.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197365964-3efb7e2d-19ea-4d1d-bee4-5f3c170ae3e3.png)

True Crime New York City:

Master:
![image](https://user-images.githubusercontent.com/6278726/198262764-31bb9887-c5f1-4f17-aee4-fbd320ed8acf.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/198262842-f0044997-38ff-493c-aaab-005bf3afae4a.png)

Virtual Fighter 2:

Master:
![image](https://user-images.githubusercontent.com/6278726/197365939-c8da6581-d2f0-4552-b2f9-c59d8e4b7576.png)

PR:
![image](https://user-images.githubusercontent.com/6278726/197365940-2c19a0bd-406f-4a6c-9b8f-688114e8c0bd.png)
