### PR TITLE
GS-hw: Implement missing st_int shader bit.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -674,7 +674,7 @@ float4 ps_color(PS_INPUT input)
 #if PS_FST == 0 && PS_INVALID_TEX0 == 1
 	// Re-normalize coordinate from invalid GS to corrected texture size
 	float2 st = (input.t.xy * WH.xy) / (input.t.w * WH.zw);
-	// no st_int yet
+	float2 st_int = (input.ti.zw * WH.xy) / (input.t.w * WH.zw);
 #elif PS_FST == 0
 	float2 st = input.t.xy / input.t.w;
 	float2 st_int = input.ti.zw / input.t.w;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -577,7 +577,7 @@ vec4 ps_color()
 #if (PS_FST == 0) && (PS_INVALID_TEX0 == 1)
     // Re-normalize coordinate from invalid GS to corrected texture size
     vec2 st = (PSin.t_float.xy * WH.xy) / (vec2(PSin.t_float.w) * WH.zw);
-    // no st_int yet
+    vec2 st_int = (PSin.t_int.zw * WH.xy) / (vec2(PSin.t_float.w) * WH.zw);
 #elif (PS_FST == 0)
     vec2 st = PSin.t_float.xy / vec2(PSin.t_float.w);
     vec2 st_int = PSin.t_int.zw / vec2(PSin.t_float.w);

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -906,7 +906,7 @@ vec4 ps_color()
 #if PS_FST == 0 && PS_INVALID_TEX0 == 1
 	// Re-normalize coordinate from invalid GS to corrected texture size
 	vec2 st = (vsIn.t.xy * WH.xy) / (vsIn.t.w * WH.zw);
-	// no st_int yet
+	vec2 st_int = (vsIn.ti.zw * WH.xy) / (vsIn.t.w * WH.zw);
 #elif PS_FST == 0
 	vec2 st = vsIn.t.xy / vsIn.t.w;
 	vec2 st_int = vsIn.ti.zw / vsIn.t.w;

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -725,6 +725,7 @@ struct PSMain
 		if (!FST && PS_INVALID_TEX0)
 		{
 			st = (in.t.xy * cb.wh.xy) / (in.t.w * cb.wh.zw);
+			st_int = (in.ti.zw * cb.wh.xy) / (in.t.w * cb.wh.zw);
 		}
 		else if (!FST)
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Implement missing st_int shader bit.
Was causing bad shader errors in GT4.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Was causing bad shader errors on all hw renderers, don't know if this is actually correct so someone needs to check it as I only followed the logic in the other cases.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
https://cdn.discordapp.com/attachments/923900820167225404/1033511970525155368/fence_Gran_Turismo_4_SCUS-97328_20221015201552.7z