### PR TITLE
DEV9: Various Internal DNS and Socket Fixes

### DIFF
--- a/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
+++ b/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
@@ -106,7 +106,7 @@ namespace InternalServers
 				break;
 		}
 
-		AutoDNS(adapter, EmuConfig.DEV9.ModeDNS1 != Pcsx2Config::DEV9Options::DnsMode::Manual, EmuConfig.DEV9.ModeDNS2 != Pcsx2Config::DEV9Options::DnsMode::Manual);
+		AutoDNS(adapter, EmuConfig.DEV9.ModeDNS1 == Pcsx2Config::DEV9Options::DnsMode::Auto, EmuConfig.DEV9.ModeDNS2 == Pcsx2Config::DEV9Options::DnsMode::Auto);
 		AutoBroadcast(ps2IP, netmask);
 	}
 

--- a/pcsx2/DEV9/PacketReader/IP/UDP/DNS/DNS_Packet.cpp
+++ b/pcsx2/DEV9/PacketReader/IP/UDP/DNS/DNS_Packet.cpp
@@ -107,7 +107,7 @@ namespace PacketReader::IP::UDP::DNS
 	}
 	void DNS_Packet::SetRCode(u8 value)
 	{
-		flags2 = (flags2 & ~(0xF << 3)) | ((value & 0xF) << 3);
+		flags2 = (flags2 & ~(0xF)) | ((value & 0xF));
 	}
 
 	DNS_Packet::DNS_Packet(u8* buffer, int bufferSize)

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -79,6 +79,21 @@ namespace Sessions
 #elif defined(__POSIX__)
 				errno);
 #endif
+
+		sockaddr_in endpoint{0};
+		endpoint.sin_family = AF_INET;
+		*(IP_Address*)&endpoint.sin_addr = adapterIP;
+		endpoint.sin_port = htons(parPort);
+
+		ret = bind(client, (const sockaddr*)&endpoint, sizeof(endpoint));
+
+		if (ret == SOCKET_ERROR)
+			Console.Error("DEV9: UDP: Failed to bind socket. Error: %d",
+#ifdef _WIN32
+				WSAGetLastError());
+#elif defined(__POSIX__)
+				errno);
+#endif
 	}
 
 	IP_Payload* UDP_FixedPort::Recv()

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -591,7 +591,7 @@ bool SocketAdapter::SendUDP(ConnectionKey Key, IP_Packet* ipPkt)
 				fKey.ps2Port = udp.sourcePort;
 				fKey.srvPort = 0;
 
-				Console.WriteLn("DEV9: Socket: Creating New UDPFixedPort with port %d", udp.sourcePort);
+				Console.WriteLn("DEV9: Socket: Creating New UDPFixedPort with port %d", udp.destinationPort);
 
 				fPort = new UDP_FixedPort(fKey, adapterIP, udp.sourcePort);
 				fPort->AddConnectionClosedHandler([&](BaseSession* session) { HandleFixedPortClosed(session); });
@@ -603,14 +603,14 @@ bool SocketAdapter::SendUDP(ConnectionKey Key, IP_Packet* ipPkt)
 				fixedUDPPorts.Add(udp.sourcePort, fPort);
 			}
 
-			Console.WriteLn("DEV9: Socket: Creating New UDP Connection from FixedPort %d", udp.sourcePort);
+			Console.WriteLn("DEV9: Socket: Creating New UDP Connection from FixedPort %d", udp.destinationPort);
 			s = fPort->NewClientSession(Key,
 				ipPkt->destinationIP == dhcpServer.broadcastIP || ipPkt->destinationIP == IP_Address{255, 255, 255, 255},
 				(ipPkt->destinationIP.bytes[0] & 0xF0) == 0xE0);
 		}
 		else
 		{
-			Console.WriteLn("DEV9: Socket: Creating New UDP Connection to %d", udp.sourcePort);
+			Console.WriteLn("DEV9: Socket: Creating New UDP Connection to %d", udp.destinationPort);
 			s = new UDP_Session(Key, adapterIP);
 		}
 


### PR DESCRIPTION
### Description of Changes
Fixed Internal DNS mode acting as Auto DNS
Fixed response code not being set correctly in Internal DNS error path
Fixed UDP not logging correct port in sockets
Fixed UDP connections not working when the source and destination ports are the same

### Rationale behind Changes
Fix Bugs

### Suggested Testing Steps
Test if DNS Internal mode, Auto mode and manual mode work correctly
