### PR TITLE
GS-hw: Use GSVector for rb ga masks in texture shuffle.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2186,13 +2186,12 @@ void GSRendererHW::EmulateTextureShuffleAndFbmask()
 		// fbmask is converted to a 16bit version to represent the 2 32bit channels it's writing to.
 		// The lower 8 bits represents the Red/Blue channels, the top 8 bits is Green/Alpha, depending on write_ba.
 		const u32 fbmask = ((m >> 3) & 0x1F) | ((m >> 6) & 0x3E0) | ((m >> 9) & 0x7C00) | ((m >> 16) & 0x8000);
-		// FIXME GSVector will be nice here
-		const u8 rb_mask = fbmask & 0xFF;
-		const u8 ga_mask = (fbmask >> 8) & 0xFF;
+		// r = rb mask, g = ga mask 
+		const GSVector2i rb_ga_mask = GSVector2i(fbmask & 0xFF, (fbmask >> 8) & 0xFF);
 		m_conf.colormask.wrgba = 0;
 
-		// 2 Select the new mask (Please someone put SSE here)
-		if (rb_mask != 0xFF)
+		// 2 Select the new mask
+		if (rb_ga_mask.r != 0xFF)
 		{
 			if (write_ba)
 			{
@@ -2204,11 +2203,11 @@ void GSRendererHW::EmulateTextureShuffleAndFbmask()
 				GL_INS("Color shuffle %s => R", read_ba ? "B" : "R");
 				m_conf.colormask.wr = 1;
 			}
-			if (rb_mask)
+			if (rb_ga_mask.r)
 				m_conf.ps.fbmask = 1;
 		}
 
-		if (ga_mask != 0xFF)
+		if (rb_ga_mask.g != 0xFF)
 		{
 			if (write_ba)
 			{
@@ -2220,16 +2219,16 @@ void GSRendererHW::EmulateTextureShuffleAndFbmask()
 				GL_INS("Color shuffle %s => G", read_ba ? "A" : "G");
 				m_conf.colormask.wg = 1;
 			}
-			if (ga_mask)
+			if (rb_ga_mask.g)
 				m_conf.ps.fbmask = 1;
 		}
 
 		if (m_conf.ps.fbmask && enable_fbmask_emulation)
 		{
-			m_conf.cb_ps.FbMask.r = rb_mask;
-			m_conf.cb_ps.FbMask.g = ga_mask;
-			m_conf.cb_ps.FbMask.b = rb_mask;
-			m_conf.cb_ps.FbMask.a = ga_mask;
+			m_conf.cb_ps.FbMask.r = rb_ga_mask.r;
+			m_conf.cb_ps.FbMask.g = rb_ga_mask.g;
+			m_conf.cb_ps.FbMask.b = rb_ga_mask.r;
+			m_conf.cb_ps.FbMask.a = rb_ga_mask.g;
 
 			// No blending so hit unsafe path.
 			if (!PRIM->ABE || !features.texture_barrier)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS-hw: Use GSVector for rb ga masks in texture shuffle.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Get rid of a fixme.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Texture shuffling still works.