### PR TITLE
GameDB: Add VUSyncHack to Twisted Metal Head On ETE

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -8443,6 +8443,8 @@ SCUS-97621:
   name: "Twisted Metal - Head-On [Extra Twisted Edition]"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - VUSyncHack # Fixes black doors on vehicles.
   patches:
     3DC2FE45:
       content: |-


### PR DESCRIPTION
### Description of Changes
Adds VUSyncHack to Twisted Metal Head On to fix the black doors issue.

https://github.com/PCSX2/pcsx2/issues/2226#issuecomment-1289621995

### Rationale behind Changes
Issues bad.

### Suggested Testing Steps
Make sure CI is happy.
