### PR TITLE
GameDB: Add HPO Normal to Indiana Jones SOK

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21497,6 +21497,8 @@ SLES-55444:
 SLES-55448:
   name: "Indiana Jones and the Staff of Kings"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLES-55451:
   name: "Rock Band 2"
   region: "PAL-M5"
@@ -47768,6 +47770,8 @@ SLUS-21885:
   name: "Indiana Jones and the Staff of Kings"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes ghosting.
 SLUS-21886:
   name: "G.I. Joe - The Rise of Cobra"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds HPO Normal to Indiana Jones Staff of Kings.

### Rationale behind Changes
Indy looked a bit ghostly with that ghosting.

### Suggested Testing Steps
Make sure CI is happy.
