### PR TITLE
GS/Vulkan: Copy entire target when ds == tex

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -2565,8 +2565,8 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 					config.drawarea.left, config.drawarea.top,
 					config.drawarea.width(), config.drawarea.height());
 
-				copy_ds->SetState(GSTexture::State::Invalidated);
-				CopyRect(config.ds, copy_ds, config.drawarea, config.drawarea.left, config.drawarea.top);
+				pxAssert(copy_ds->GetState() == GSTexture::State::Invalidated);
+				CopyRect(config.ds, copy_ds, GSVector4i(config.ds->GetSize()).zwxy(), 0, 0);
 				PSSetShaderResource(0, copy_ds, true);
 			}
 		}

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3009,7 +3009,8 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 					config.drawarea.left, config.drawarea.top,
 					config.drawarea.width(), config.drawarea.height());
 
-				CopyRect(config.ds, copy_ds, config.drawarea, config.drawarea.left, config.drawarea.top);
+				pxAssert(copy_ds->GetState() == GSTexture::State::Invalidated);
+				CopyRect(config.ds, copy_ds, GSVector4i(config.ds->GetSize()).zwxy(), 0, 0);
 				PSSetShaderResource(0, copy_ds, true);
 			}
 		}


### PR DESCRIPTION
### Description of Changes

Also for DX12. Shadow Hearts 3 does a downsample, and we don't copy enough if we limit to the render area.

Really, the texture cache should be handling this. But since we have the target height more correct now, the perf hit shouldn't be much.

### Rationale behind Changes

Fixes #7303.

### Suggested Testing Steps

Test Shadow Hearts 3. Probably Ico too since it hits the same path, but copying more instead of less shouldn't hurt anything.