### PR TITLE
GS/TextureCache: remove an unnecessary TBW check

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1072,7 +1072,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 			// Checking for targets that overlap with the requested memory region
 			// instead of just comparing TBPs should fix that.
 			// For example, this fixes Judgement ring rendering in Shadow Hearts 2.
-			if (t->Overlaps(bp, bw, psm, r) && t->m_TEX0.TBP0 >= bp && t->m_TEX0.TBW == bw && GSUtil::HasSharedBits(psm, t->m_TEX0.PSM))
+			if (t->Overlaps(bp, bw, psm, r) && t->m_TEX0.TBP0 >= bp && GSUtil::HasSharedBits(psm, t->m_TEX0.PSM))
 			{
 				// Enforce full invalidation if BP's don't match.
 				const GSVector4i targetr = (bp == t->m_TEX0.TBP0) ? r : t->m_valid;


### PR DESCRIPTION
### Description of Changes
Remove an unnecessary TBW check that I left in #7283 

### Rationale behind Changes
That TBW check broke Ape Escape 3's pause menu. I added it originally to combat issues with Dog's Life, but I wasn't sure whether it actually contributed anything to the fix, since I added it along with checking whether source TBP is more or equal to the target's TBP. Turns out Ape Escape 3 is downloading PSMT4 data in parts, so the TBW for that is different, which resulted in the download not going through.

### Suggested Testing Steps
Test Ape Escape 3 by trying to go to the pause menu. It shouldn't have any glitches present.
