### PR TITLE
GameDB: Resident Evil 4 (BioHazard 4) + Umisho

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -81,7 +81,7 @@ ALCH-0004:
   name: "Duel Savior Destiny [Messiah Box]"
   region: "NTSC-J"
 CPCS-01005:
-  name: "Gun Survivor 4 - Biohazard - Heroes Never Die [with GunCon2]"
+  name: "Gun Survivor 4 - BioHazard - Heroes Never Die [with GunCon2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
@@ -5030,6 +5030,15 @@ SCKA-20087:
     halfPixelOffset: 2 # Fixes misalignment and upscaling lines.
   memcardFilters:
     - "SCKA-20086"
+SCKA-20089:
+  name: "BioHazard 4"
+  region: "NTSC-K"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SCKA-20090:
   name: "God Hand"
   region: "NTSC-K"
@@ -8691,9 +8700,11 @@ SLAJ-25072:
     halfPixelOffset: 2 # Fix effects upscaling.
 SLAJ-25073:
   name: "Resident Evil 4"
-  region: "NTSC-Unk"
+  region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLAJ-25075:
@@ -17187,6 +17198,10 @@ SLES-53702:
   name: "Resident Evil 4"
   region: "PAL-M5"
   compat: 5
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-53703:
@@ -17383,6 +17398,10 @@ SLES-53755:
 SLES-53756:
   name: "Resident Evil 4"
   region: "PAL-M5"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-53758:
@@ -22188,7 +22207,7 @@ SLKA-25035:
   name: "Mobile Suit Gundam - Lost War Chronicles"
   region: "NTSC-K"
 SLKA-25038:
-  name: "Gun Survivor 4 - Biohazard - Heroes Never Die"
+  name: "Gun Survivor 4 - BioHazard - Heroes Never Die"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
@@ -23125,6 +23144,15 @@ SLKA-25407:
   name: "Dragon Ball Z - Sparkling! Meteor"
   region: "NTSC-K"
   compat: 5
+SLKA-25410:
+  name: "BioHazard 4"
+  region: "NTSC-K"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLKA-25413:
   name: "SD Gundam G - Generation Spirits"
   region: "NTSC-K"
@@ -23869,7 +23897,7 @@ SLPM-61018:
   name: "Abarenbou Princess [Trial]"
   region: "NTSC-J"
 SLPM-61039:
-  name: "Gun Survivor 4 - Biohazard - Heroes Never Die [Demo]"
+  name: "Gun Survivor 4 - BioHazard - Heroes Never Die [Demo]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes character offset with flashlight and blurriness.
@@ -30171,6 +30199,10 @@ SLPM-66213:
   name: "BioHazard 4"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-66214:
@@ -32534,6 +32566,8 @@ SLPM-66863:
 SLPM-66864:
   name: "Umisho"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Reduces misaligned line distortian when in QTE.
 SLPM-66866:
   name: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken 2"
   region: "NTSC-J"
@@ -33253,7 +33287,7 @@ SLPM-74104:
   name: "Momotarou Densetsu 15 [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74201:
-  name: "Biohazard Outbreak [PlayStation 2 The Best]"
+  name: "BioHazard Outbreak [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74202:
   name: "Fuuun Shinsengumi [PlayStation 2 The Best]"
@@ -33330,6 +33364,10 @@ SLPM-74228:
 SLPM-74229:
   name: "BioHazard 4 [PlayStation 2 The Best]"
   region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLPM-74230:
@@ -33490,6 +33528,15 @@ SLPM-74278:
 SLPM-74286:
   name: "Shin Sangoku Musou 5 Special [PlayStation 2 The Best]"
   region: "NTSC-J"
+SLPM-74288:
+  name: "BioHazard 4"
+  region: "NTSC-J"
+  gameFixes:
+    - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLPM-74301:
   name: "Ryu ga Gotoku 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -33525,7 +33572,7 @@ SLPM-74408:
   name: "Rakugaki Kingdom [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74409:
-  name: "Gun Survivor 2 - Biohazard Code - Veronica [PlayStation 2 The Best]"
+  name: "Gun Survivor 2 - BioHazard Code - Veronica [PlayStation 2 The Best]"
   region: "NTSC-J"
 SLPM-74410:
   name: "Breath of Fire V - Dragon Quarter [PlayStation 2 The Best]"
@@ -43878,6 +43925,8 @@ SLUS-21134:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-21135:
@@ -48419,6 +48468,8 @@ SLUS-29169:
   region: "NTSC-U"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
+  speedHacks:
+    mvuFlagSpeedHack: 0 # Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-29170:


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Resident Evil 4 / BioHazard 4: Fixes invisible wall in front of the door leading to East 3F in the 2nd visit of Apartment world preventing Eileen's Nurse Outfit. Some entries had missing fixes or entirely not in GameDB.

Video by Ryudo:

https://user-images.githubusercontent.com/24227051/199619271-3b909ed2-ab78-4db1-8906-d90f1b4bbf89.mp4


Umisho: Minor upscaling line issue fix for QTE event.

![2022-10-26_01-41](https://user-images.githubusercontent.com/24227051/199618456-f0b1e345-6df9-46c1-a408-d2541813c29a.png)
![2022-10-26_01-42](https://user-images.githubusercontent.com/24227051/199618450-1bc4fe51-f8e4-4eb8-8bf7-04085b5c4b76.png)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less tinkering.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test relevant games.