### PR TITLE
GameDB: WRC Rally Evolved - Fix rare bug causing player to respawn unexpectedly

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3718,6 +3718,8 @@ SCES-53247:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes SPS.
+  clampModes:
+    eeClampMode: 2 # Fixes rare bug causing player to respawn when starting the race or during certain car crashes.
   patches:
     CBBC2E7F:
       content: |-


### PR DESCRIPTION
### Description of Changes
To quote comment in gamedb: `Fixes rare bug causing player to respawn when starting the race or during certain car crashes.`

[The bug was originally described here](https://retroachievements.org/viewtopic.php?t=16717&c=134961#134961), I can confirm I encountered it when developing achievements for this game, but didn't bother figuring out the fix. Eventually it was found out clamping setting does help when testing it on the save state provided in that forum thread.

### Rationale behind Changes
It's rare but gamebreaking bug worth preventing, otherwise player would have to exit and re-enter the race which loses progress.

### Suggested Testing Steps

