### PR TITLE
GS: Restrict age of targets for GS Download invalidation.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1072,7 +1072,8 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 			// Checking for targets that overlap with the requested memory region
 			// instead of just comparing TBPs should fix that.
 			// For example, this fixes Judgement ring rendering in Shadow Hearts 2.
-			if (t->Overlaps(bp, bw, psm, r) && t->m_TEX0.TBP0 >= bp && GSUtil::HasSharedBits(psm, t->m_TEX0.PSM))
+			// Be wary of old targets being misdetected, set a sensible range of 30 frames (like Display source lookups).
+			if (t->Overlaps(bp, bw, psm, r) && t->m_TEX0.TBP0 >= bp && GSUtil::HasSharedBits(psm, t->m_TEX0.PSM) && t->m_age <= 30)
 			{
 				// Enforce full invalidation if BP's don't match.
 				const GSVector4i targetr = (bp == t->m_TEX0.TBP0) ? r : t->m_valid;


### PR DESCRIPTION
### Description of Changes
Restricts the age of a target for download to 30 frames (probably still too much tbh!)

### Rationale behind Changes
While #7283 improved the detection of render targets that were required for download, it also introduced some misdetection because of old targets hanging around in the texture cache. So like the final display target lookups, we can restrict this one to 30 frames or less.  Armored Core - Last Raven was affected by this (targets were 371 frames old!).

### Suggested Testing Steps
Test games with GS downloads (readbacks, in most cases), make sure nothing is broken.
