### PR TITLE
GameDB: disable MTVU & instantVU for K1 series games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -17646,6 +17646,9 @@ SLES-53809:
   region: "PAL-E"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
+  speedHacks:
+    MTVUSpeedHack: 0 # Fixes game from crashing.
+    InstantVU1SpeedHack: 0 # Fixes graphical issues.
   patches:
     B6F9C8D3:
       content: |-
@@ -25709,6 +25712,9 @@ SLPM-62581:
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
+  speedHacks:
+    MTVUSpeedHack: 0 # Fixes game from crashing.
+    InstantVU1SpeedHack: 0 # Fixes graphical issues.
   patches:
     0A1042EE:
       content: |-
@@ -27501,6 +27507,8 @@ SLPM-65335:
 SLPM-65336:
   name: "K-1 World Grand Prix - The Beast Attack!"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes upscaling lines.
 SLPM-65337:
   name: "Gegege no Kitaro - Ibun Youkaitan"
   region: "NTSC-J"
@@ -27795,6 +27803,8 @@ SLPM-65432:
 SLPM-65433:
   name: "K-1 World Grand Prix 2003"
   region: "NTSC-J"
+  gsHWFixes:
+    alignSprite: 1 # Fixes upscaling lines.
 SLPM-65434:
   name: "Battle Gear 3"
   region: "NTSC-J"
@@ -34978,6 +34988,9 @@ SLPS-20453:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
+  speedHacks:
+    MTVUSpeedHack: 0 # Fixes game from crashing.
+    InstantVU1SpeedHack: 0 # Fixes graphical issues.
   patches:
     602B7A48:
       content: |-
@@ -37197,6 +37210,9 @@ SLPS-25578:
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
+  speedHacks:
+    MTVUSpeedHack: 0 # Fixes game from crashing.
+    InstantVU1SpeedHack: 0 # Fixes graphical issues.
   patches:
     F8664E20:
       content: |-


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
disable MTVU for K1-Dynamite series games
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
less crashing 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
test games , check CI 