### PR TITLE
GameDB: HPO for Destruction Derby Arenas + Super Trucks Racing

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -11118,6 +11118,9 @@ SLES-50897:
   name: "Super Trucks"
   region: "PAL-M6"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Gets rid of fog line.
+    roundSprite: 1 # Fixes lines in FMVs.
 SLES-50898:
   name: "X-Men - The Next Dimension"
   region: "PAL-E"
@@ -24793,6 +24796,9 @@ SLPM-62255:
 SLPM-62256:
   name: "Super Trucks"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 2 # Gets rid of fog line.
+    roundSprite: 1 # Fixes lines in FMVs.
 SLPM-62257:
   name: "Rally Championship"
   region: "NTSC-J"
@@ -42325,6 +42331,9 @@ SLUS-20748:
   name: "Super Trucks Racing"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Gets rid of fog line.
+    roundSprite: 1 # Fixes lines in FMVs.
 SLUS-20749:
   name: "Rugby 2004"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1825,6 +1825,8 @@ SCED-50750:
 SCED-50781:
   name: "Destruction Derby Arenas [Beta]"
   region: "PAL-M5"
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects shadow position.
 SCED-50825:
   name: "Official PlayStation 2 Magazine Demo 18"
   region: "PAL-M5"
@@ -2975,9 +2977,11 @@ SCES-50760:
     mipmap: 1
     halfPixelOffset: 1 # Fixes effect misalignment.
 SCES-50781:
-  name: "Destruction Derby Arena [Beta, Promo, & Full Retail]"
+  name: "Destruction Derby Arenas [Beta, Promo, & Full Retail]"
   region: "PAL-M6"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects shadow position.
 SCES-50791:
   name: "Frequency"
   region: "PAL-M5"
@@ -3362,6 +3366,8 @@ SCES-51977:
 SCES-51979:
   name: "Destruction Derby Arenas"
   region: "PAL-M6"
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects shadow position.
 SCES-52004:
   name: "Killzone"
   region: "PAL-M6"
@@ -42811,6 +42817,8 @@ SLUS-20855:
   name: "Destruction Derby Arenas"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Corrects shadow position.
 SLUS-20856:
   name: "Spy Fiction"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Add HPO Special Texture to DDA, same for Super Trucks + Half Round Sprite for FMV lines.

### Rationale behind Changes
Shadows were misaligned when upscaling in DDA.
Fog lines and lines in FMV's with Super Trucks.

### Suggested Testing Steps
Watch CI
