### PR TITLE
GameDB: Add autoflush to Tales of the Abyss. Fixes lighting post

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1247,6 +1247,7 @@ SCAJ-20163:
   region: "NTSC-Unk"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    autoFlush: 1 # Fixes post lighting.
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
@@ -32939,6 +32940,7 @@ SLPM-66897:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    autoFlush: 1 # Fixes post lighting.
 SLPM-66898:
   name: "Spectral Gene [Limited Edition]"
   region: "NTSC-J"
@@ -37227,6 +37229,7 @@ SLPS-25586:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    autoFlush: 1 # Fixes post lighting.
 SLPS-25587:
   name: "Sugar Sugar Rune - Koi mo Oshare mo Pick-Up"
   region: "NTSC-J"
@@ -38944,6 +38947,7 @@ SLPS-73252:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    autoFlush: 1 # Fixes post lighting.
 SLPS-73253:
   name: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -45644,6 +45648,7 @@ SLUS-21386:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
+    autoFlush: 1 # Fixes post lighting.
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds Autoflush to Tales of the Abyss as an auto fix.

### Rationale behind Changes
Fixes post processing effects for lighting (see below)

### Suggested Testing Steps
Make sure CI is happy.

Before:
![image](https://user-images.githubusercontent.com/6278726/199869508-63e5b75c-3fad-4648-8eb2-5b1e549655bf.png)


After:
![image](https://user-images.githubusercontent.com/6278726/199869515-e2ad5722-3e81-4f92-99a1-926f21db80c6.png)

Software:
![image](https://user-images.githubusercontent.com/6278726/199869542-33711764-0e49-42ad-b159-b0cdbb472325.png)
