### PR TITLE
releases: allow publishing discord announcements to multiple webhooks

### DIFF
--- a/.github/workflows/scripts/releases/announce-release/index.js
+++ b/.github/workflows/scripts/releases/announce-release/index.js
@@ -19,7 +19,12 @@ const embed = new MessageEmbed()
     { name: 'Included Changes', value: releaseInfo.body, inline: false }
   );
 
-const webhookClient = new WebhookClient({ url: process.env.DISCORD_BUILD_WEBHOOK });
-await webhookClient.send({
-  embeds: [embed],
-});
+// Get all webhooks, simple comma-sep string
+const webhookUrls = process.env.DISCORD_BUILD_WEBHOOK.split(",");
+
+for (const url of webhookUrls) {
+  const webhookClient = new WebhookClient({ url: url });
+  await webhookClient.send({
+    embeds: [embed],
+  });
+}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Some other discords we are associated with would like our announcements to be mirrored there, this facilitates that.
