### PR TITLE
SPU: On config change don't reinit sample rate.

### DIFF
--- a/pcsx2/SPU2/Timestretcher.cpp
+++ b/pcsx2/SPU2/Timestretcher.cpp
@@ -23,7 +23,7 @@
 //Uncomment the next line to use the old time stretcher
 //#define SPU2X_USE_OLD_STRETCHER
 
-static soundtouch::SoundTouch* pSoundTouch = nullptr;
+static std::unique_ptr<soundtouch::SoundTouch> pSoundTouch = nullptr;
 
 // data prediction amount, used to "commit" data that hasn't
 // finished timestretch processing.
@@ -518,7 +518,7 @@ void SndBuffer::timeStretchWrite()
 
 void SndBuffer::soundtouchInit()
 {
-	pSoundTouch = new soundtouch::SoundTouch();
+	pSoundTouch = std::make_unique<soundtouch::SoundTouch>();
 	pSoundTouch->setSampleRate(SampleRate);
 	pSoundTouch->setChannels(2);
 
@@ -558,5 +558,5 @@ void SndBuffer::soundtouchClearContents()
 
 void SndBuffer::soundtouchCleanup()
 {
-	safe_delete(pSoundTouch);
+	pSoundTouch.reset();
 }

--- a/pcsx2/SPU2/Wavedump_wav.cpp
+++ b/pcsx2/SPU2/Wavedump_wav.cpp
@@ -26,7 +26,7 @@
 
 static WavOutFile* _new_WavOutFile(const char* destfile)
 {
-	return new WavOutFile(destfile, 48000, 16, 2);
+	return new WavOutFile(destfile, SampleRate, 16, 2);
 }
 
 namespace WaveDump
@@ -121,12 +121,12 @@ bool RecordStart(const std::string* filename)
 		safe_delete(m_wavrecord);
 		if (filename)
 #ifdef _WIN32
-			m_wavrecord = new WavOutFile(_wfopen(StringUtil::UTF8StringToWideString(*filename).c_str(), L"wb"), 48000, 16, 2);
+			m_wavrecord = new WavOutFile(_wfopen(StringUtil::UTF8StringToWideString(*filename).c_str(), L"wb"), SampleRate, 16, 2);
 #else
-			m_wavrecord = new WavOutFile(filename->c_str(), 48000, 16, 2);
+			m_wavrecord = new WavOutFile(filename->c_str(), SampleRate, 16, 2);
 #endif
 		else
-			m_wavrecord = new WavOutFile("audio_recording.wav", 48000, 16, 2);
+			m_wavrecord = new WavOutFile("audio_recording.wav", SampleRate, 16, 2);
 		WavRecordEnabled = true;
 		return true;
 	}

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -192,7 +192,7 @@ void SPU2SetDeviceSampleRateMultiplier(double multiplier)
 	SPU2UpdateSampleRate();
 }
 
-s32 SPU2init()
+s32 SPU2init(bool KeepMode)
 {
 	assert(regtable[0x400] == nullptr);
 
@@ -244,7 +244,7 @@ s32 SPU2init()
 		}
 	}
 
-	SPU2InternalReset(PS2Modes::PS2);
+	SPU2InternalReset((ConsoleSampleRate == 44100 && KeepMode) ? PS2Modes::PSX : PS2Modes::PS2);
 
 	DMALogOpen();
 	InitADSR();

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -27,7 +27,7 @@ enum class PS2Modes
 	PSX,
 };
 
-s32 SPU2init();
+s32 SPU2init(bool KeepMode);
 s32 SPU2reset(PS2Modes isRunningPSXMode);
 s32 SPU2open();
 void SPU2close();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -908,7 +908,7 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 	};
 
 	Console.WriteLn("Opening SPU2...");
-	if (SPU2init() != 0 || SPU2open() != 0)
+	if (SPU2init(false) != 0 || SPU2open() != 0)
 	{
 		Host::ReportErrorAsync("Startup Error", "Failed to initialize SPU2.");
 		SPU2shutdown();
@@ -1636,7 +1636,7 @@ void VMManager::CheckForSPU2ConfigChanges(const Pcsx2Config& old_config)
 
 	SPU2close();
 	SPU2shutdown();
-	if (SPU2init() != 0 || SPU2open() != 0)
+	if (SPU2init(true) != 0 || SPU2open() != 0)
 	{
 		Console.Error("(CheckForSPU2ConfigChanges) Failed to reopen SPU2, we'll probably crash :(");
 		return;

--- a/pcsx2/gui/SysCoreThread.cpp
+++ b/pcsx2/gui/SysCoreThread.cpp
@@ -111,7 +111,7 @@ void SysCoreThread::OnSuspendInThread()
 
 void SysCoreThread::Start()
 {
-	SPU2init();
+	SPU2init(false);
 	PADinit();
 	DEV9init();
 	USBinit();


### PR DESCRIPTION


### Description of Changes
Don't adjust samplerate back to default on config change, use current rate (for PS1 mode). Also fix up some other samplerate related things and turn the soundtouch pointer in to a unique pointer.

### Rationale behind Changes
resetting to 48000hz when in PS1 mode is annoying.

### Suggested Testing Steps
I don't really care.
