### PR TITLE
GS-HW: GetOutput loop on 2048 and restrict height.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -244,7 +244,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 	const int fb_width = std::min<int>(std::min<int>(GetFramebufferWidth(), DISPFB.FBW * 64) + (int)DISPFB.DBX, 2048);
 	const int display_height = offsets.y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);
 	const int display_offset = GetResolutionOffset(i).y;
-	int fb_height = std::min<int>(std::min<int>(GetFramebufferHeight(), display_height) + (int)DISPFB.DBY, 2048);
+	int fb_height = (std::min<int>(GetFramebufferHeight(), display_height) + (int)DISPFB.DBY) % 2048;
 	// If there is a negative vertical offset on the picture, we need to read more.
 	if (display_offset < 0)
 	{


### PR DESCRIPTION
### Description of Changes
Loops any height reads around 2048, ignoring any pixels before the loop.

### Rationale behind Changes
Some EA games use an offset of 2047 to move the picture up 1 pixel for interlacing, and it's really stupid, but the code was clamping to 2048, which isn't really any good either, so this works better and doesn't confuse the TC, no other games known to do this.

### Suggested Testing Steps
Try NASCAR Thunder 2003 or NASCAR 08/09

Fixes #7307
