### PR TITLE
GS-HW: Further restrict CLUT heuristics.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3918,7 +3918,8 @@ bool GSRendererHW::PossibleCLUTDraw()
 
 	// Writing to the framebuffer for output. We're not interested. - Note: This stops NFS HP2 Busted screens working, but they're glitchy anyway
 	// what NFS HP2 really needs is a kind of shuffle with mask, 32bit target is interpreted as 16bit and masked.
-	if ((m_regs->DISP[0].DISPFB.Block() == m_context->FRAME.Block()) || (m_regs->DISP[1].DISPFB.Block() == m_context->FRAME.Block()))
+	if ((m_regs->DISP[0].DISPFB.Block() == m_context->FRAME.Block()) || (m_regs->DISP[1].DISPFB.Block() == m_context->FRAME.Block()) ||
+		(PRIM->TME && ((m_regs->DISP[0].DISPFB.Block() == m_context->TEX0.TBP0) || (m_regs->DISP[1].DISPFB.Block() == m_context->TEX0.TBP0)) && !(m_mem.m_clut.IsInvalid() & 2)))
 		return false;
 
 	// Ignore recursive/shuffle effects, but possible it will recursively draw, but make sure it's staying in page width
@@ -3962,7 +3963,7 @@ bool GSRendererHW::PossibleCLUTDraw()
 	const float draw_width = (m_vt.m_max.p.x - m_vt.m_min.p.x);
 	const float draw_height = (m_vt.m_max.p.y - m_vt.m_min.p.y);
 	const bool valid_size = ((draw_width >= min_clut_width || draw_height >= min_clut_height))
-							&& ((m_vt.m_max.p.x <= page_width) && draw_divder_match); // Make sure draw is multiples of 8 wide (AC5 midetection).
+							&& (((draw_width < page_width && draw_height <= page_height) || (draw_width == page_width)) && draw_divder_match); // Make sure draw is multiples of 8 wide (AC5 midetection).
 	
 	// Make sure the draw hits the next CLUT and it's marked as invalid (kind of a sanity check).
 	// We can also allow draws which are of a sensible size within the page, as they could also be CLUT draws (or gradients for the CLUT).


### PR DESCRIPTION
### Description of Changes
Further check the size of draws and make sure it's not using the framebuffer, unless the draw does invalidate the current CLUT.

### Rationale behind Changes
Reduces readbacks in Burnout by like 75% and a bunch of other games no longer do them.

### Suggested Testing Steps
Test clutty games (actually already done it).

This will break Godfather seethrough lights again, that seems to be misdetection as it reads the framebuffer, but doesn't seem to write to a CLUT, at least directly, but the software draw happeened to fix it. We're coming up with another way of tackling that.
