### PR TITLE
EE: Implement Instant DMA hack for some cache problematic games

### DIFF
--- a/.github/workflows/scripts/lint/gamedb/lint.py
+++ b/.github/workflows/scripts/lint/gamedb/lint.py
@@ -28,6 +28,7 @@ allowed_game_fixes = [
     "SkipMPEGHack",
     "OPHFlagHack",
     "EETimingHack",
+    "InstantDMAHack",
     "DMABusyHack",
     "GIFFIFOHack",
     "VIFFIFOHack",

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10650,6 +10650,8 @@ SLES-50713:
 SLES-50714:
   name: "Defender"
   region: "PAL-M5"
+  gameFixes:
+    - InstantDMAHack # Fixes bad UI positioning.
 SLES-50715:
   name: "Gravity Games Bike Street - Vertical Dirt"
   region: "PAL-M5"
@@ -25002,6 +25004,8 @@ SLPM-62285:
 SLPM-62287:
   name: "Fire Pro Wrestling Z [Limited Edition]"
   region: "NTSC-J"
+  gameFixes:
+    - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62288:
   name: "pop'n music Best Hits!"
   region: "NTSC-J"
@@ -25144,6 +25148,8 @@ SLPM-62342:
   name: "Fire Pro Wrestling Z"
   region: "NTSC-J"
   compat: 5
+  gameFixes:
+    - InstantDMAHack # Fixes bad ring/UI textures.
 SLPM-62343:
   name: "Simple 2000 Series Vol. 34 - The Renai Horror Adventure - Hyouryuu Shoujo"
   region: "NTSC-J"
@@ -39965,6 +39971,8 @@ SLUS-20191:
   name: "Defender"
   region: "NTSC-U"
   compat: 5
+  gameFixes:
+    - InstantDMAHack # Fixes bad UI positioning.
 SLUS-20194:
   name: "Grandia II"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
@@ -38,6 +38,7 @@ GameFixSettingsWidget::GameFixSettingsWidget(SettingsDialog* dialog, QWidget* pa
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.SkipMPEGHack, "EmuCore/Gamefixes", "SkipMPEGHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.OPHFlagHack, "EmuCore/Gamefixes", "OPHFlagHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.EETimingHack, "EmuCore/Gamefixes", "EETimingHack", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.InstantDMAHack, "EmuCore/Gamefixes", "InstantDMAHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.DMABusyHack, "EmuCore/Gamefixes", "DMABusyHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.GIFFIFOHack, "EmuCore/Gamefixes", "GIFFIFOHack", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.VIFFIFOHack, "EmuCore/Gamefixes", "VIFFIFOHack", false);

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>648</width>
-    <height>481</height>
+    <width>676</width>
+    <height>535</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -68,6 +68,13 @@
        <widget class="QCheckBox" name="EETimingHack">
         <property name="text">
          <string>EE Timing Hack (General Purpose Timing Hack)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="InstantDMAHack">
+        <property name="text">
+         <string>Instant DMA Hack (Good for cache emulation problems)</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -35,6 +35,7 @@ enum GamefixId
 	Fix_SkipMpeg,
 	Fix_OPHFlag,
 	Fix_EETiming,
+	Fix_InstantDMA,
 	Fix_DMABusy,
 	Fix_GIFFIFO,
 	Fix_VIFFIFO,
@@ -836,6 +837,7 @@ struct Pcsx2Config
 			SkipMPEGHack : 1, // Skips MPEG videos (Katamari and other games need this)
 			OPHFlagHack : 1, // Bleach Blade Battlers
 			EETimingHack : 1, // General purpose timing hack.
+			InstantDMAHack : 1, // Instantly complete DMA's if possible, good for cache emulation problems.
 			DMABusyHack : 1, // Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.
 			GIFFIFOHack : 1, // Enabled the GIF FIFO (more correct but slower)
 			VIFFIFOHack : 1, // Pretends to fill the non-existant VIF FIFO Buffer.
@@ -1153,6 +1155,7 @@ namespace EmuFolders
 #define CHECK_FPUNEGDIVHACK (EmuConfig.Gamefixes.FpuNegDivHack) // Special Fix for Gundam games messed up camera-view.
 #define CHECK_XGKICKHACK (EmuConfig.Gamefixes.XgKickHack) // Special Fix for Erementar Gerad, adds more delay to VU XGkick instructions. Corrects the color of some graphics.
 #define CHECK_EETIMINGHACK (EmuConfig.Gamefixes.EETimingHack) // Fix all scheduled events to happen in 1 cycle.
+#define CHECK_INSTANTDMAHACK (EmuConfig.Gamefixes.InstantDMAHack) // Attempt to finish DMA's instantly, useful for games which rely on cache emulation.
 #define CHECK_SKIPMPEGHACK (EmuConfig.Gamefixes.SkipMPEGHack) // Finds sceMpegIsEnd pattern to tell the game the mpeg is finished (Katamari and a lot of games need this)
 #define CHECK_OPHFLAGHACK (EmuConfig.Gamefixes.OPHFlagHack) // Bleach Blade Battlers
 #define CHECK_DMABUSYHACK (EmuConfig.Gamefixes.DMABusyHack) // Denies writes to the DMAC when it's busy. This is correct behaviour but bad timing can cause problems.

--- a/pcsx2/Frontend/FullscreenUI.cpp
+++ b/pcsx2/Frontend/FullscreenUI.cpp
@@ -3844,6 +3844,9 @@ void FullscreenUI::DrawGameFixesSettingsPage()
 	DrawToggleSetting(bsi, "EE Timing Hack",
 		"Known to affect following games: Digital Devil Saga (Fixes FMV and crashes), SSX (Fixes bad graphics and crashes).",
 		"EmuCore/Gamefixes", "EETimingHack", false);
+	DrawToggleSetting(bsi, "Instant DMA Hack",
+		"Known to affect following games: Fire Pro Wrestling Z (Bad ring graphics).",
+		"EmuCore/Gamefixes", "InstantDMAHack", false);
 	DrawToggleSetting(bsi, "Handle DMAC writes when it is busy.",
 		"Known to affect following games: Mana Khemia 1 (Going \"off campus\"), Metal Saga (Intro FMV), Pilot Down Behind Enemy Lines.",
 		"EmuCore/Gamefixes", "DMABusyHack", false);

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -250,6 +250,7 @@ __fi void gifInterrupt()
 			{
 				GifDMAInt(16);
 			}
+			CPU_SET_DMASTALL(DMAC_GIF, gifUnit.Path3Masked() || !gifUnit.CanDoPath3());
 			return;
 		}
 	}
@@ -265,6 +266,7 @@ __fi void gifInterrupt()
 	{
 		GIF_LOG("Path 3 Paused");
 		GifDMAInt(128);
+		CPU_SET_DMASTALL(DMAC_GIF, true);
 		if (gif_fifo.fifoSize == 16)
 			return;
 	}
@@ -282,7 +284,10 @@ __fi void gifInterrupt()
 		// If we just read from the fifo, we want to loop and not read more DMA
 		// If there is no DMA data waiting and the DMA is active, let the DMA progress until there is
 		if ((!CheckPaths() && gif_fifo.fifoSize == 16) || readSize)
+		{
+			CPU_SET_DMASTALL(DMAC_GIF, gifUnit.Path3Masked() || !gifUnit.CanDoPath3());
 			return;
+		}
 	}
 
 	if (!(gifch.chcr.STR))
@@ -295,6 +300,7 @@ __fi void gifInterrupt()
 			Console.Warning("gs dma masked, re-scheduling...");
 			// Re-raise the int shortly in the future
 			GifDMAInt(64);
+			CPU_SET_DMASTALL(DMAC_GIF, true);
 			return;
 		}
 		GIFdma();
@@ -459,6 +465,7 @@ void GIFdma()
 					hwDmacIrq(DMAC_STALL_SIS);
 					GifDMAInt(128);
 					gif.gscycles = 0;
+					CPU_SET_DMASTALL(DMAC_GIF, true);
 					return;
 				}
 			}
@@ -474,6 +481,7 @@ void GIFdma()
 		if (gifch.qwc > 0) // Normal Mode
 		{
 			GIFchain(); // Transfers the data set by the switch
+			CPU_SET_DMASTALL(DMAC_GIF, gifUnit.Path3Masked() || !gifUnit.CanDoPath3());
 			return;
 		}
 	}
@@ -487,7 +495,7 @@ void dmaGIF()
 	// DevCon.Warning("dmaGIFstart chcr = %lx, madr = %lx, qwc  = %lx\n tadr = %lx, asr0 = %lx, asr1 = %lx", gifch.chcr._u32, gifch.madr, gifch.qwc, gifch.tadr, gifch.asr0, gifch.asr1);
 
 	gif.gspath3done = false; // For some reason this doesn't clear? So when the system starts the thread, we will clear it :)
-
+	CPU_SET_DMASTALL(DMAC_GIF, false);
 	if (gifch.chcr.MOD == NORMAL_MODE)
 	{ // Else it really is a normal transfer and we want to quit, else it gets confused with chains
 		gif.gspath3done = true;
@@ -722,6 +730,7 @@ void gifMFIFOInterrupt()
 	{ // GIF not in MFIFO anymore, come out.
 		DevCon.WriteLn("GIF Leaving MFIFO - Report if any errors");
 		gifInterrupt();
+		CPU_SET_DMASTALL(DMAC_GIF, true);
 		return;
 	}
 
@@ -742,6 +751,7 @@ void gifMFIFOInterrupt()
 			{
 				GifDMAInt(16);
 			}
+			CPU_SET_DMASTALL(DMAC_GIF, gifUnit.Path3Masked() || !gifUnit.CanDoPath3());
 			return;
 		}
 	}
@@ -749,6 +759,7 @@ void gifMFIFOInterrupt()
 	if (gifUnit.gsSIGNAL.queued)
 	{
 		GifDMAInt(128);
+		CPU_SET_DMASTALL(DMAC_GIF, true);
 		return;
 	}
 
@@ -765,7 +776,10 @@ void gifMFIFOInterrupt()
 		// If we just read from the fifo, we want to loop and not read more DMA
 		// If there is no DMA data waiting and the DMA is active, let the DMA progress until there is
 		if ((!CheckPaths() && gif_fifo.fifoSize == 16) || readSize)
+		{
+			CPU_SET_DMASTALL(DMAC_GIF, gifUnit.Path3Masked() || !gifUnit.CanDoPath3());
 			return;
+		}
 	}
 
 	if (!gifch.chcr.STR)
@@ -777,12 +791,16 @@ void gifMFIFOInterrupt()
 		FireMFIFOEmpty();
 
 		if (gifch.qwc > 0 || !gif.gspath3done)
+		{
+			CPU_SET_DMASTALL(DMAC_GIF, true);
 			return;
+		}
 	}
 
 	if (gifch.qwc > 0 || !gif.gspath3done)
 	{
 		mfifoGIFtransfer();
+		CPU_SET_DMASTALL(DMAC_GIF, gifUnit.Path3Masked() || !gifUnit.CanDoPath3());
 		return;
 	}
 
@@ -793,7 +811,7 @@ void gifMFIFOInterrupt()
 	gifRegs.stat.FQC = gif_fifo.fifoSize;
 	CalculateFIFOCSR();
 	hwDmacIrq(DMAC_GIF);
-
+	CPU_SET_DMASTALL(DMAC_GIF, false);
 	if (gif_fifo.fifoSize)
 		GifDMAInt(8 * BIAS);
 	DMA_LOG("GIF MFIFO DMA End");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -858,6 +858,7 @@ static const char* const tbl_GamefixNames[] =
 	"SkipMPEG",
 	"OPHFlag",
 	"EETiming",
+	"InstantDMA",
 	"DMABusy",
 	"GIFFIFO",
 	"VIFFIFO",
@@ -897,6 +898,7 @@ void Pcsx2Config::GamefixOptions::Set(GamefixId id, bool enabled)
 		case Fix_FpuNegDiv:           FpuNegDivHack           = enabled; break;
 		case Fix_XGKick:              XgKickHack              = enabled; break;
 		case Fix_EETiming:            EETimingHack            = enabled; break;
+		case Fix_InstantDMA:          InstantDMAHack          = enabled; break;
 		case Fix_SoftwareRendererFMV: SoftwareRendererFMVHack = enabled; break;
 		case Fix_SkipMpeg:            SkipMPEGHack            = enabled; break;
 		case Fix_OPHFlag:             OPHFlagHack             = enabled; break;
@@ -923,6 +925,7 @@ bool Pcsx2Config::GamefixOptions::Get(GamefixId id) const
 		case Fix_FpuNegDiv:           return FpuNegDivHack;
 		case Fix_XGKick:              return XgKickHack;
 		case Fix_EETiming:            return EETimingHack;
+		case Fix_InstantDMA:          return InstantDMAHack;
 		case Fix_SoftwareRendererFMV: return SoftwareRendererFMVHack;
 		case Fix_SkipMpeg:            return SkipMPEGHack;
 		case Fix_OPHFlag:             return OPHFlagHack;
@@ -949,6 +952,7 @@ void Pcsx2Config::GamefixOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(FpuNegDivHack);
 	SettingsWrapBitBool(XgKickHack);
 	SettingsWrapBitBool(EETimingHack);
+	SettingsWrapBitBool(InstantDMAHack);
 	SettingsWrapBitBool(SoftwareRendererFMVHack);
 	SettingsWrapBitBool(SkipMPEGHack);
 	SettingsWrapBitBool(OPHFlagHack);

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -174,6 +174,7 @@ struct cpuRegisters {
 	int branch;
 	int opmode;			// operating mode
 	u32 tempcycles;
+	u32 dmastall;
 };
 
 // used for optimization
@@ -417,6 +418,7 @@ enum EE_EventType
 };
 
 extern void CPU_INT( EE_EventType n, s32 ecycle );
+extern void CPU_SET_DMASTALL(EE_EventType n, bool set);
 extern uint intcInterrupt();
 extern uint dmacInterrupt();
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -33,7 +33,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A2E << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A2F << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/Sif0.cpp
+++ b/pcsx2/Sif0.cpp
@@ -167,7 +167,7 @@ static __fi void EndEE()
 		SIF_LOG("SIF0 EE: cycles = 0");
 		sif0.ee.cycles = 1;
 	}
-
+	CPU_SET_DMASTALL(DMAC_SIF0, false);
 	CPU_INT(DMAC_SIF0, sif0.ee.cycles*BIAS);
 }
 
@@ -377,6 +377,7 @@ __fi void dmaSIF0()
 	// (as it should always be at the beginning of a DMA).  using "if iop is busy" flags breaks Tom Clancy Rainbow Six.
 	// Legend of Legaia doesn't throw a warning either :)
 	sif0.ee.end = false;
+	CPU_SET_DMASTALL(DMAC_SIF0, false);
 	SIF0Dma();
 
 }

--- a/pcsx2/Sif1.cpp
+++ b/pcsx2/Sif1.cpp
@@ -154,7 +154,7 @@ static __fi void EndEE()
 		sif1.ee.cycles = 1;
 	}
 
-
+	CPU_SET_DMASTALL(DMAC_SIF1, false);
 	CPU_INT(DMAC_SIF1, /*std::min((int)(*/sif1.ee.cycles*BIAS/*), 384)*/);
 }
 
@@ -225,6 +225,7 @@ static __fi void HandleEETransfer()
 				{
 					hwDmacIrq(DMAC_STALL_SIS);
 					sif1_dma_stall = true;
+					CPU_SET_DMASTALL(DMAC_SIF1, true);
 					return;
 				}
 			}
@@ -341,7 +342,7 @@ __fi void dmaSIF1()
 	psHu32(SBUS_F240) |= 0x4000;
 	sif1.ee.busy = true;
 
-
+	CPU_SET_DMASTALL(DMAC_SIF1, false);
 	// Okay, this here is needed currently (r3644).
 	// FFX battles in the thunder plains map die otherwise, Phantasy Star 4 as well
 	// These 2 games could be made playable again by increasing the time the EE or the IOP run,

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -139,6 +139,7 @@ __fi void vif0VUFinish()
 	if (VU0.VI[REG_VPU_STAT].UL & 0x5)
 	{
 		CPU_INT(VIF_VU0_FINISH, 128);
+		CPU_SET_DMASTALL(VIF_VU0_FINISH, true);
 		return;
 	}
 
@@ -150,6 +151,7 @@ __fi void vif0VUFinish()
 		_cycles = VU0.cycle - _cycles;
 		//DevCon.Warning("Finishing VU0 %d cycles", _cycles);
 		CPU_INT(VIF_VU0_FINISH, _cycles * BIAS);
+		CPU_SET_DMASTALL(VIF_VU0_FINISH, true);
 		return;
 	}
 	vif0Regs.stat.VEW = false;
@@ -177,6 +179,7 @@ __fi void vif0Interrupt()
 	if(vif0.waitforvu)
 	{
 		CPU_INT(VIF_VU0_FINISH, 16);
+		CPU_SET_DMASTALL(DMAC_VIF0, true);
 		return;
 	}
 	if (vif0Regs.stat.VGW)
@@ -208,6 +211,7 @@ __fi void vif0Interrupt()
 			{
 				vif0Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF0 Stalled");
+				CPU_SET_DMASTALL(DMAC_VIF0, true);
 				return;
 			}
 		}
@@ -266,6 +270,7 @@ __fi void vif0Interrupt()
 	if(vif0.queued_program) vifExecQueue(0);
 	g_vif0Cycles = 0;
 	hwDmacIrq(DMAC_VIF0);
+	CPU_SET_DMASTALL(DMAC_VIF0, false);
 	vif0Regs.stat.FQC = 0;
 	DMA_LOG("VIF0 DMA End");
 }
@@ -278,6 +283,7 @@ void dmaVIF0()
 	        vif0ch.tadr, vif0ch.asr0, vif0ch.asr1);
 
 	g_vif0Cycles = 0;
+	CPU_SET_DMASTALL(DMAC_VIF0, false);
 
 	if (vif0ch.qwc > 0)   // Normal Mode
 	{

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -300,6 +300,7 @@ void vifMFIFOInterrupt()
 		{
 			GUNIT_WARN("vifMFIFOInterrupt() - Waiting for Path 2 to be ready");
 			CPU_INT(DMAC_MFIFO_VIF, 128);
+			CPU_SET_DMASTALL(DMAC_VIF1, true);
 			return;
 		}
 	}
@@ -307,6 +308,7 @@ void vifMFIFOInterrupt()
 	{
 		//DevCon.Warning("Waiting on VU1 MFIFO");
 		CPU_INT(VIF_VU1_FINISH, std::max(16, cpuGetCycles(VU_MTVU_BUSY)));
+		CPU_SET_DMASTALL(DMAC_VIF1, true);
 		return;
 	}
 
@@ -339,6 +341,7 @@ void vifMFIFOInterrupt()
 			{
 				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF1 MFIFO Stalled");
+				CPU_SET_DMASTALL(DMAC_VIF1, true);
 				return;
 			}
 		}
@@ -358,6 +361,7 @@ void vifMFIFOInterrupt()
 	if (vif1.inprogress & 0x10)
 	{
 		FireMFIFOEmpty();
+		CPU_SET_DMASTALL(DMAC_VIF1, true);
 		return;
 	}
 
@@ -408,6 +412,6 @@ void vifMFIFOInterrupt()
 	vif1ch.chcr.STR = false;
 	hwDmacIrq(DMAC_VIF1);
 	DMA_LOG("VIF1 MFIFO DMA End");
-
+	CPU_SET_DMASTALL(DMAC_VIF1, false);
 	vif1Regs.stat.FQC = 0;
 }

--- a/pcsx2/gui/Panels/GameFixesPanel.cpp
+++ b/pcsx2/gui/Panels/GameFixesPanel.cpp
@@ -67,6 +67,11 @@ Panels::GameFixesPanel::GameFixesPanel( wxWindow* parent )
 			)
 		},
 		{
+			_("Instant DMA hack. Try if all else fails."),
+			pxEt(L"Known to affect following games:\n * Fire Pro Wrestling Z (Bad ring graphics)"
+			)
+		},
+		{
 			_("Handle DMAC writes when it is busy."),
 			pxEt( L"Known to affect following games:\n * Mana Khemia 1 (Going \"off campus\"), Metal Saga (Intro FMV), Pilot Down Behind Enemy Lines\n"
 			)


### PR DESCRIPTION
### Description of Changes
Implement Instant DMA hack completely (was previously hacked in for the BIOS only).

### Rationale behind Changes
Some games with cache problems, like Fire Pro Wrestling Z experience graphical issues or crashes due to missing cache emulation, this should avoid it, to an extent.

### Suggested Testing Steps
Test games with the new Game fix if they have bad graphics or crash on boot/randomly, worth a shot.

Fire Pro Wrestling Z:
Before:
![image](https://user-images.githubusercontent.com/6278726/200189433-b6ab8d3d-d9b6-4577-8b90-f22226f30881.png)

After:
![image](https://user-images.githubusercontent.com/6278726/200189453-72f3fa35-460a-4abc-ae4c-d58d26dd714d.png)


Defender:
Before:
![image](https://user-images.githubusercontent.com/6278726/200194426-65f26e07-95a5-4f33-a34b-dec4ff03701e.png)

After:
![image](https://user-images.githubusercontent.com/6278726/200194427-d2a6faf6-08f6-428c-8e00-e71d0b8c5870.png)

