### PR TITLE
GameDB: Add Wild Arms Hack to Kaido Battle games, and Racing Battle C1GP.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16168,6 +16168,7 @@ SLES-53191:
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLES-53192:
   name: "Nightmare Before Christmas, The - Tim Burton's"
   region: "PAL-M5"
@@ -17958,6 +17959,7 @@ SLES-53900:
   region: "PAL-M3"
   gsHWFixes:
     alignSprite: 1 # Fixes black lines when upscaling.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLES-53901:
   name: "Torino 2006"
   region: "PAL-M5"
@@ -22570,6 +22572,7 @@ SLKA-25063:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLKA-25064:
   name: "Tenchu 3 Wrath of Heaven"
   region: "NTSC-K"
@@ -22800,6 +22803,7 @@ SLKA-25146:
   region: "NTSC-K"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLKA-25149:
   name: "Silent Hill 4 - The Room"
   region: "NTSC-K"
@@ -27333,10 +27337,11 @@ SLPM-65245:
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
 SLPM-65246:
-  name: "Kaidou Battle - Nikko, Haruna, Rokko, Hakone"
+  name: "Kaido Battle - Nikko, Haruna, Rokko, Hakone"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLPM-65247:
   name: "Sangokushi Senki 2"
   region: "NTSC-J"
@@ -28210,6 +28215,7 @@ SLPM-65514:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLPM-65515:
   name: "Sakura Taisen - Mysterious Paris"
   region: "NTSC-J"
@@ -29453,6 +29459,7 @@ SLPM-65897:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes black lines when upscaling.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLPM-65898:
   name: "Castle Fantasia [Deluxe Pack]"
   region: "NTSC-J"
@@ -29905,6 +29912,7 @@ SLPM-66022:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes black lines when upscaling.
+    wildArmsHack: 1 # De-blurs the 3d image.
 SLPM-66023:
   name: "Fushigi Yuugi - ShigiYuugi Kurotake Kaiden Gaiden - Kagami no Fujo [Limited Edition]"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Changed the GameDB to add the Wild Arms Hack upscaling fix to all Kaido Battle games and Racing Battle: C1 Grand Prix. This de-blurs the image when upscaling (examples attached). Genki seems to re-use the same rendering code that requires this ever since Tokyo Extreme Racer 3 / Shutoku Battle 01

I have also corrected the name of Kaido**u** Battle - Nikko, Haruna, Rokko, Hakone to be consistent with the other Kaido games (and to match its actual spelling in Japanese)

### Rationale behind Changes
Improves the image for these games when upscaling.

### Suggested Testing Steps
I don't have Kaido Battle 2: Chain Reaction/Kaido Racer, but if someone does and reports this as broken I can remove WAH from it.

Off: Kaido Battle 3
![kb3nowah](https://user-images.githubusercontent.com/107822219/200216607-6b471fec-746e-4cc3-89c2-657e87b70b38.png)

On
![kb3wah](https://user-images.githubusercontent.com/107822219/200216629-e33cfdb7-e74b-4617-8b68-d74b163201c1.png)

Off: Kaido Battle
![kb1nowah](https://user-images.githubusercontent.com/107822219/200216671-c7f68b57-fadd-4b49-a189-25dba1c9c799.png)

On
![kb1wah](https://user-images.githubusercontent.com/107822219/200216692-579ca644-f9f6-429c-9fff-65797bc76841.png)

Off: Racing Battle: C1 Grand Prix
![c1gpnowah](https://user-images.githubusercontent.com/107822219/200218135-897daa72-f727-4b0b-9f5d-4e0b6cab5c41.png)

On
![c1gpwah](https://user-images.githubusercontent.com/107822219/200218149-f94c181f-1df6-44df-a8ac-d6667fcf8a43.png)

