### PR TITLE
GameDB: Set texture preloading to Partial for Keihin Keikyu Train Sim

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -5502,6 +5502,8 @@ SCPS-15030:
 SCPS-15031:
   name: "Train Simulator Real, The"
   region: "NTSC-J"
+  gsHWFixes:
+    texturePreloading: 1 # Increases performance due to massive hash cache size.
 SCPS-15032:
   name: "Formula One 2002"
   region: "NTSC-J"
@@ -5520,6 +5522,8 @@ SCPS-15034:
 SCPS-15035:
   name: "Train Simulator Real, The - Keihin Keikyu"
   region: "NTSC-J"
+  gsHWFixes:
+    texturePreloading: 1 # Increases performance due to massive hash cache size.
 SCPS-15036:
   name: "Kaitou Sly Cooper"
   region: "NTSC-J"


### PR DESCRIPTION
### Description of Changes
Set texture preloading to Partial for Keihin Keikyu Train Simulator

### Rationale behind Changes
Turns out the game hates texture preloading and almost halves the framerate with full hash cache.

### Suggested Testing Steps
Make sure CI is happy.
