### PR TITLE
Profiling: Fix QT builds where USE_VTUNE is true

### DIFF
--- a/common/Perf.cpp
+++ b/common/Perf.cpp
@@ -20,6 +20,10 @@
 #endif
 #ifdef ENABLE_VTUNE
 #include "jitprofiling.h"
+
+#include <string> // std::string
+#include <cstring> // strncpy
+#include <algorithm> // std::remove_if
 #endif
 
 //#define ProfileWithPerf

--- a/pcsx2/GS/Renderers/Common/GSFunctionMap.h
+++ b/pcsx2/GS/Renderers/Common/GSFunctionMap.h
@@ -219,7 +219,7 @@ public:
 
 			// if(iJIT_IsProfilingActive()) // always > 0
 			{
-				std::string name = format("%s<%016llx>()", m_name.c_str(), (u64)key);
+				std::string name = fmt::format("%s<%016llx>()", m_name.c_str(), (u64)key);
 
 				iJIT_Method_Load ml;
 


### PR DESCRIPTION
### Description of Changes
Some includes were missing when building with profiling

### Rationale behind Changes
It was broken otherwise.

### Suggested Testing Steps
Try compiling with vtune enabled.
