### PR TITLE
GameDB: Add CPU CLUT Normal to Lego Starwars 2

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -18726,6 +18726,8 @@ SLES-54218:
 SLES-54221:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "PAL-M6"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
   memcardFilters: # Allows import of characters from Lego Star Wars 1.
     - "SLES-54221"
     - "SLES-53194"
@@ -31955,6 +31957,8 @@ SLPM-66571:
 SLPM-66572:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
   memcardFilters:
     - "SLPM-66572"
     - "SLPS-20423"
@@ -46007,6 +46011,8 @@ SLUS-21408:
 SLUS-21409:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-U"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes ghosting on objects and people.
   memcardFilters:
     - "SLUS-21409"
     - "SLUS-21083"


### PR DESCRIPTION
### Description of Changes
Adds CPU CLUT normal to Lego Starwars 2 to fix ghosting.

### Rationale behind Changes
Without:
![image](https://user-images.githubusercontent.com/80843560/200815827-bbf34506-bb73-4417-ad32-8fbfb149a126.png)

With:
![image](https://user-images.githubusercontent.com/80843560/200815882-57adbe6a-d205-492e-b1fb-5d1ffcba7ab5.png)


### Suggested Testing Steps
Make sure CI is happy.
