### PR TITLE
GameDB & CRC fixes for The Getaway games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -3156,6 +3156,7 @@ SCES-51159:
   gsHWFixes:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SCES-51164:
   name: "Mark of Kri, The"
   region: "PAL-M5"
@@ -3205,6 +3206,7 @@ SCES-51426:
   gsHWFixes:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SCES-51428:
   name: "Shinobi"
   region: "PAL-M5"
@@ -3619,6 +3621,7 @@ SCES-52758:
   region: "PAL-M6"
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines on screen edges.
 SCES-52762:
   name: "DJ Decks & FX"
   region: "PAL-F"
@@ -3667,6 +3670,7 @@ SCES-52948:
   region: "PAL-M4"
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines on screen edges.
 SCES-53033:
   name: "Formula One 2005"
   region: "PAL-M7"
@@ -4758,6 +4762,7 @@ SCKA-20018:
   gsHWFixes:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SCKA-20019:
   name: "Siren"
   region: "NTSC-K"
@@ -6955,6 +6960,7 @@ SCUS-97133:
   gsHWFixes:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SCUS-97134:
   name: "SOCOM - U.S. Navy SEALs"
   region: "NTSC-U"
@@ -7321,6 +7327,7 @@ SCUS-97232:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SCUS-97233:
   name: "World Tour Soccer 2003"
   region: "NTSC-U"
@@ -7818,6 +7825,7 @@ SCUS-97408:
   compat: 5
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines on screen edges.
 SCUS-97409:
   name: "Gretzky NHL 2005"
   region: "NTSC-U"
@@ -7971,6 +7979,7 @@ SCUS-97441:
   region: "NTSC-U"
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines on screen edges.
 SCUS-97442:
   name: "Official U.S. PlayStation Magazine Demo Disc 090"
   region: "NTSC-U"
@@ -27884,6 +27893,7 @@ SLPM-65410:
   gsHWFixes:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SLPM-65411:
   name: "Onimusha Buraiden"
   region: "NTSC-J"
@@ -30503,6 +30513,7 @@ SLPM-66183:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
+    halfPixelOffset: 2 # Fixes outlines on screen edges.
 SLPM-66184:
   name: "Ikusa Gami"
   region: "NTSC-J"
@@ -49205,6 +49216,7 @@ SLUS-97133:
   gsHWFixes:
     textureInsideRT: 1
     texturePreloading: 1 # Performs much better with partial preload.
+    halfPixelOffset: 2 # Fixes outlines around characters.
 SLUS-97405:
   name: "ATV Offroad Fury 3 [Greatest Hits]"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -708,6 +708,10 @@ void GSTextureCache::InvalidateVideoMemType(int type, u32 bp)
 	if (GSConfig.UserHacks_DisableDepthSupport)
 		return;
 
+	// The Getaway games need this function disabled for player shadows to work correctly.
+	if (g_gs_renderer->m_game.title == CRC::GetawayGames)
+		return;
+
 	auto& list = m_dst[type];
 	for (auto i = list.begin(); i != list.end(); ++i)
 	{


### PR DESCRIPTION
### Description of Changes
Implements a workaround for the issue described in #3986. Please refer to that issue for a detailed explanation and screenshots. Also enables HPO Special to fix the following upscaling issues:
* The Getaway had outlines around characters, as if their depth did not line up.
* Black Monday had a rainbow border on screen edges.

Before (notice a light outline around the character's forehead):
![image](https://user-images.githubusercontent.com/7947461/201060834-33d03e05-0231-4246-9fb8-3cd116606546.png)
![image](https://user-images.githubusercontent.com/7947461/201060714-0c59dbb6-b98c-4946-ad24-ed2e76a15c14.png)

After:
![image](https://user-images.githubusercontent.com/7947461/201060883-8f36bdb5-dd65-4dd6-be6d-fb4bd54076b5.png)
![image](https://user-images.githubusercontent.com/7947461/201060739-65eb9b80-65f8-4549-885c-8850ddf90ea2.png)


### Rationale behind Changes
Hacks are bad, but this one seems to be a low risk one piggybacking on an existing CRC hack. Plus some upscaling goodness.

### Suggested Testing Steps
* Verify that The Getaway and The Getaway: Black Monday display the player shadow fine with no manual fixes enabled.
* Verify that The Getaway and The Getaway: Black Monday upscale without issues.
