### PR TITLE
GS: Don't add overscan to offsets when looking up output texture.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -239,7 +239,7 @@ GSTexture* GSRendererHW::GetOutput(int i, int& y_offset)
 	TEX0.PSM = DISPFB.PSM;
 
 	const int videomode = static_cast<int>(GetVideoMode()) - 1;
-	const GSVector4i offsets = !GSConfig.PCRTCOverscan ? VideoModeOffsets[videomode] : VideoModeOffsetsOverscan[videomode];
+	const GSVector4i offsets = VideoModeOffsets[videomode];
 
 	const int fb_width = std::min<int>(std::min<int>(GetFramebufferWidth(), DISPFB.FBW * 64) + (int)DISPFB.DBX, 2048);
 	const int display_height = offsets.y * ((isinterlaced() && !m_regs->SMODE2.FFMD) ? 2 : 1);


### PR DESCRIPTION
### Description of Changes
Removes the increased offset in the lookup for hardware mode when overscan is enabled. 

### Rationale behind Changes
This can cause mis-detection when Show Overscan is enabled, making it miss the target.  This is still needed for software however, else you get some pretty ugly stretching.

### Suggested Testing Steps
test Silent Hill 2, Crash Nitro Kart, I guess some other rando games.
