### PR TITLE
GS-TC: Reset age on Host->Local dirty textures

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -898,6 +898,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 						t->m_texture ? t->m_texture->GetID() : 0,
 						t->m_TEX0.TBP0, r.x, r.y, r.z, r.w);
 					t->m_TEX0.TBW = bw;
+					t->m_age = 0;
 					t->m_dirty.push_back(GSDirtyRect(r, psm, bw));
 				}
 				else
@@ -974,6 +975,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 								t->m_TEX0.TBP0);
 							// TODO: do not add this rect above too
 							t->m_TEX0.TBW = bw;
+							t->m_age = 0;
 							t->m_dirty.push_back(GSDirtyRect(GSVector4i(r.left, r.top - y, r.right, r.bottom - y), psm, bw));
 							continue;
 						}
@@ -1000,7 +1002,7 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 							t->m_texture ? t->m_texture->GetID() : 0,
 							t->m_TEX0.TBP0, t->m_end_block,
 							r.left, r.top + y, r.right, r.bottom + y, bw);
-
+						t->m_age = 0;
 						t->m_TEX0.TBW = bw;
 						t->m_dirty.push_back(GSDirtyRect(GSVector4i(r.left, r.top + y, r.right, r.bottom + y), psm, bw));
 						continue;
@@ -1010,7 +1012,10 @@ void GSTextureCache::InvalidateVideoMem(const GSOffset& off, const GSVector4i& r
 				{
 					const SurfaceOffset so = ComputeSurfaceOffset(off, r, t);
 					if (so.is_valid)
+					{
+						t->m_age = 0;
 						t->m_dirty.push_back(GSDirtyRect(so.b2a_offset, psm, bw));
+					}
 				}
 #endif
 			}


### PR DESCRIPTION
### Description of Changes
Resets the texture age when it's made dirty by upload.

### Rationale behind Changes
Some FMV's such as Superman Returns stream the picture via Host->Local transfers, but right now we try to make sure it's new targets only (and they don't get updated because no draws happen) it starts missing and bad things happen.  So this PR will reset the age on the texture so it's still a "fresh" texture when it has dirty parts, so it can retrieve it from GS memory.

### Suggested Testing Steps
Test Superman Returns movies
