### PR TITLE
Qt: fix inhibit screensaver on Linux (X11)

### DIFF
--- a/pcsx2/Frontend/CommonHost.cpp
+++ b/pcsx2/Frontend/CommonHost.cpp
@@ -430,8 +430,9 @@ void CommonHost::UpdateInhibitScreensaver(bool inhibit)
 		return;
 
 	WindowInfo wi;
-	if (g_host_display)
-		wi = g_host_display->GetWindowInfo();
+	auto top_level_wi = Host::GetTopLevelWindowInfo();
+	if (top_level_wi.has_value())
+		wi = top_level_wi.value();
 
 	s_screensaver_inhibited = inhibit;
 	if (!WindowInfo::InhibitScreensaver(wi, inhibit) && inhibit)


### PR DESCRIPTION
### Description of Changes
This change fixes https://github.com/PCSX2/pcsx2/issues/7367. `xdg-screensaver` appears to only work properly in all cases if you give it the top level window ID of PCSX2.

As far as I can tell, this change is only relevant to the Qt client on Linux with X11.

### Rationale behind Changes
With this change, inhibit screensaver now works with the Qt client on Linux (X11) when a game is fullscreen as well windowed.

### Suggested Testing Steps
Make sure the screensaver is inhibited while a game is both fullscreen and windowed.
